### PR TITLE
feat: add Hermes executor support

### DIFF
--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -50,7 +50,6 @@ impl CodeExecutor for HermesExecutor {
     fn command_args(&self, message: &str) -> Vec<String> {
         vec![
             "chat".to_string(),
-            "-q".to_string(),
             "-Q".to_string(),
             "--yolo".to_string(),
             message.to_string(),
@@ -187,7 +186,7 @@ mod tests {
     fn test_command_args() {
         let executor = HermesExecutor::new();
         let args = executor.command_args("do something");
-        assert_eq!(args, vec!["chat", "-q", "-Q", "--yolo", "do something"]);
+        assert_eq!(args, vec!["chat", "-Q", "--yolo", "do something"]);
     }
 
     #[test]

--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -50,10 +50,10 @@ impl CodeExecutor for HermesExecutor {
     fn command_args(&self, message: &str) -> Vec<String> {
         vec![
             "chat".to_string(),
-            "-q".to_string(),
-            message.to_string(),
             "-Q".to_string(),
             "--yolo".to_string(),
+            "-q".to_string(),
+            message.to_string(),
         ]
     }
 
@@ -187,7 +187,7 @@ mod tests {
     fn test_command_args() {
         let executor = HermesExecutor::new();
         let args = executor.command_args("do something");
-        assert_eq!(args, vec!["chat", "-q", "do something", "-Q", "--yolo"]);
+        assert_eq!(args, vec!["chat", "-Q", "--yolo", "-q", "do something"]);
     }
 
     #[test]

--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -50,9 +50,10 @@ impl CodeExecutor for HermesExecutor {
     fn command_args(&self, message: &str) -> Vec<String> {
         vec![
             "chat".to_string(),
+            "-q".to_string(),
+            message.to_string(),
             "-Q".to_string(),
             "--yolo".to_string(),
-            message.to_string(),
         ]
     }
 
@@ -186,7 +187,7 @@ mod tests {
     fn test_command_args() {
         let executor = HermesExecutor::new();
         let args = executor.command_args("do something");
-        assert_eq!(args, vec!["chat", "-Q", "--yolo", "do something"]);
+        assert_eq!(args, vec!["chat", "-q", "do something", "-Q", "--yolo"]);
     }
 
     #[test]

--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -51,9 +51,9 @@ impl CodeExecutor for HermesExecutor {
         vec![
             "chat".to_string(),
             "-q".to_string(),
-            message.to_string(),
             "-Q".to_string(),
             "--yolo".to_string(),
+            message.to_string(),
         ]
     }
 
@@ -187,7 +187,7 @@ mod tests {
     fn test_command_args() {
         let executor = HermesExecutor::new();
         let args = executor.command_args("do something");
-        assert_eq!(args, vec!["chat", "-q", "do something", "-Q", "--yolo"]);
+        assert_eq!(args, vec!["chat", "-q", "-Q", "--yolo", "do something"]);
     }
 
     #[test]

--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -1,0 +1,198 @@
+use std::env;
+use std::sync::{Arc, Mutex};
+
+use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
+use crate::models::utc_timestamp;
+
+pub struct HermesExecutor {
+    path: String,
+    usage: Arc<Mutex<Option<ExecutionUsage>>>,
+    has_done: Arc<Mutex<bool>>,
+}
+
+impl HermesExecutor {
+    pub fn new() -> Self {
+        let path = env::var("HERMES_PATH")
+            .unwrap_or_else(|_| "hermes".to_string());
+        Self {
+            path,
+            usage: Arc::new(Mutex::new(None)),
+            has_done: Arc::new(Mutex::new(false)),
+        }
+    }
+}
+
+impl Clone for HermesExecutor {
+    fn clone(&self) -> Self {
+        Self {
+            path: self.path.clone(),
+            usage: self.usage.clone(),
+            has_done: self.has_done.clone(),
+        }
+    }
+}
+
+impl Default for HermesExecutor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodeExecutor for HermesExecutor {
+    fn executor_type(&self) -> ExecutorType {
+        ExecutorType::Hermes
+    }
+
+    fn executable_path(&self) -> &str {
+        &self.path
+    }
+
+    fn command_args(&self, message: &str) -> Vec<String> {
+        vec![
+            "chat".to_string(),
+            "-q".to_string(),
+            message.to_string(),
+            "-Q".to_string(),
+            "--yolo".to_string(),
+        ]
+    }
+
+    fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        // Skip banner lines and special formatting
+        if trimmed.starts_with("╭") || trimmed.starts_with("│") || trimmed.starts_with("╰") {
+            return None;
+        }
+
+        // Parse session_id from output: "session_id: <id>"
+        if trimmed.starts_with("session_id:") {
+            return Some(ParsedLogEntry {
+                timestamp: utc_timestamp(),
+                log_type: "info".to_string(),
+                content: trimmed.to_string(),
+                usage: None,
+            });
+        }
+
+        // Skip status indicators
+        if trimmed.starts_with("┊") {
+            return None;
+        }
+
+        // Skip empty box characters
+        if trimmed.chars().all(|c| c == ' ' || c == '━' || c == '│' || c == '╰' || c == '╭') {
+            return None;
+        }
+
+        Some(ParsedLogEntry {
+            timestamp: utc_timestamp(),
+            log_type: "text".to_string(),
+            content: trimmed.to_string(),
+            usage: None,
+        })
+    }
+
+    fn parse_stderr_line(&self, line: &str) -> Option<ParsedLogEntry> {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        // Hermes outputs some info to stderr
+        Some(ParsedLogEntry {
+            timestamp: utc_timestamp(),
+            log_type: "stderr".to_string(),
+            content: trimmed.to_string(),
+            usage: None,
+        })
+    }
+
+    fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
+        let text_result = logs.iter()
+            .rev()
+            .find(|l| l.log_type == "text")
+            .map(|l| super::strip_think_tags(&l.content));
+
+        let fallback = logs.iter()
+            .rev()
+            .find(|l| l.log_type == "stderr")
+            .map(|l| l.content.clone());
+
+        text_result.or(fallback)
+    }
+
+    fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
+        self.usage.lock().unwrap().clone()
+    }
+
+    fn get_model(&self) -> Option<String> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_output_line_text() {
+        let executor = HermesExecutor::new();
+        let entry = executor.parse_output_line("Hello world").unwrap();
+        assert_eq!(entry.log_type, "text");
+        assert_eq!(entry.content, "Hello world");
+    }
+
+    #[test]
+    fn test_parse_output_line_empty() {
+        let executor = HermesExecutor::new();
+        assert!(executor.parse_output_line("").is_none());
+        assert!(executor.parse_output_line("   ").is_none());
+    }
+
+    #[test]
+    fn test_parse_output_line_session_id() {
+        let executor = HermesExecutor::new();
+        let entry = executor.parse_output_line("session_id: abc123").unwrap();
+        assert_eq!(entry.log_type, "info");
+        assert!(entry.content.contains("session_id"));
+    }
+
+    #[test]
+    fn test_parse_output_line_banner() {
+        let executor = HermesExecutor::new();
+        assert!(executor.parse_output_line("╭─ Hermes ─────────────────────────────────").is_none());
+        assert!(executor.parse_output_line("│ some text").is_none());
+    }
+
+    #[test]
+    fn test_get_final_result_with_text() {
+        let executor = HermesExecutor::new();
+        let logs = vec![
+            ParsedLogEntry::new("text", "  hello world  "),
+        ];
+        assert_eq!(executor.get_final_result(&logs), Some("hello world".to_string()));
+    }
+
+    #[test]
+    fn test_get_usage_before_tokens() {
+        let executor = HermesExecutor::new();
+        assert!(executor.get_usage(&[]).is_none());
+    }
+
+    #[test]
+    fn test_command_args() {
+        let executor = HermesExecutor::new();
+        let args = executor.command_args("do something");
+        assert_eq!(args, vec!["chat", "-q", "do something", "-Q", "--yolo"]);
+    }
+
+    #[test]
+    fn test_executor_type() {
+        let executor = HermesExecutor::new();
+        assert_eq!(executor.executor_type(), ExecutorType::Hermes);
+    }
+}

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -11,6 +11,7 @@ pub fn parse_executor_type(executor: &str) -> ExecutorType {
         "codebuddy" | "cbc" => ExecutorType::Codebuddy,
         "opencode" => ExecutorType::Opencode,
         "atomcode" | "atom" => ExecutorType::Atomcode,
+        "hermes" => ExecutorType::Hermes,
         _ => ExecutorType::Joinai,
     }
 }
@@ -27,6 +28,7 @@ pub mod claude_code;
 pub mod codebuddy;
 pub mod opencode;
 pub mod atomcode;
+pub mod hermes;
 
 #[async_trait]
 pub trait CodeExecutor: Send + Sync {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -94,6 +94,7 @@ async fn run_server() {
     executor_registry.register(adapters::codebuddy::CodebuddyExecutor::new());
     executor_registry.register(adapters::opencode::OpencodeExecutor::new());
     executor_registry.register(adapters::atomcode::AtomcodeExecutor::new());
+    executor_registry.register(adapters::hermes::HermesExecutor::new());
 
     // List available executors
     let executors = executor_registry.list_executors();

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -345,6 +345,7 @@ pub enum ExecutorType {
     Codebuddy,
     Opencode,
     Atomcode,
+    Hermes,
 }
 
 impl Default for ExecutorType {
@@ -361,6 +362,7 @@ impl ExecutorType {
             ExecutorType::Codebuddy => "codebuddy",
             ExecutorType::Opencode => "opencode",
             ExecutorType::Atomcode => "atomcode",
+            ExecutorType::Hermes => "hermes",
         }
     }
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -190,7 +190,7 @@ export const EXECUTORS: ExecutorOption[] = [
   { value: 'opencode',   label: 'Opencode',   color: '#f59e0b', icon: '🟡' },
   { value: 'joinai',     label: 'JoinAI',     color: '#0d9488', icon: '🟢' },
   { value: 'atomcode',   label: 'AtomCode',   color: '#dc2626', icon: '🔴' },
-  { value: 'hermes',     label: 'Hermes',    color: '#9333ea', icon: '🟣' },
+  { value: 'hermes',     label: 'Hermes',    color: '#ea580c', icon: '🟠' },
 ];
 
 export function getExecutorOption(value: string): ExecutorOption {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -190,6 +190,7 @@ export const EXECUTORS: ExecutorOption[] = [
   { value: 'opencode',   label: 'Opencode',   color: '#f59e0b', icon: '🟡' },
   { value: 'joinai',     label: 'JoinAI',     color: '#0d9488', icon: '🟢' },
   { value: 'atomcode',   label: 'AtomCode',   color: '#dc2626', icon: '🔴' },
+  { value: 'hermes',     label: 'Hermes',    color: '#9333ea', icon: '🟣' },
 ];
 
 export function getExecutorOption(value: string): ExecutorOption {


### PR DESCRIPTION
## Summary
- Add HermesExecutor implementation for CodeExecutor trait
- Hermes executor uses `hermes chat -q <message> -Q --yolo` command format
- Support workspace settings (via current_dir at spawn time)
- Registered Hermes in ExecutorRegistry and ExecutorType enum
- Added Hermes to frontend EXECUTORS list

## Test plan
- [x] Backend compiles successfully
- [x] All Hermes unit tests pass (8 tests)
- [x] Frontend builds successfully