### PR TITLE
feat: add Kimi executor support

### DIFF
--- a/backend/src/adapters/kimi.rs
+++ b/backend/src/adapters/kimi.rs
@@ -69,55 +69,55 @@ impl CodeExecutor for KimiExecutor {
             return None;
         }
 
-        // Parse JSON line
-        if let Ok(json) = serde_json::from_str::<serde_json::Value>(trimmed) {
-            // Extract text content from assistant message
-            if json.get("role").and_then(|v| v.as_str()) == Some("assistant") {
-                if let Some(content) = json.get("content") {
-                    if let Some(arr) = content.as_array() {
-                        for item in arr {
-                            if item.get("type").and_then(|v| v.as_str()) == Some("text") {
-                                if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
-                                    return Some(ParsedLogEntry {
-                                        timestamp: utc_timestamp(),
-                                        log_type: "text".to_string(),
-                                        content: text.to_string(),
-                                        usage: None,
-                                    });
-                                }
-                            }
-                            // Handle think content
-                            if item.get("type").and_then(|v| v.as_str()) == Some("think") {
-                                if let Some(think) = item.get("think").and_then(|v| v.as_str()) {
-                                    return Some(ParsedLogEntry {
-                                        timestamp: utc_timestamp(),
-                                        log_type: "thinking".to_string(),
-                                        content: think.to_string(),
-                                        usage: None,
-                                    });
-                                }
-                            }
+        // Skip non-JSON lines
+        if !trimmed.starts_with('{') {
+            return None;
+        }
+
+        let json = match serde_json::from_str::<serde_json::Value>(trimmed) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+
+        let role = json.get("role").and_then(|v| v.as_str())?;
+
+        // Skip assistant messages with tool_calls (tool call requests, not results)
+        if role == "assistant" {
+            if json.get("tool_calls").is_some() {
+                return None;
+            }
+            // Final assistant message with text content
+            if let Some(content) = json.get("content").and_then(|v| v.as_array()) {
+                for item in content {
+                    if item.get("type").and_then(|v| v.as_str()) == Some("text") {
+                        if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
+                            return Some(ParsedLogEntry {
+                                timestamp: utc_timestamp(),
+                                log_type: "text".to_string(),
+                                content: text.to_string(),
+                                usage: None,
+                            });
                         }
                     }
                 }
             }
+            return None;
+        }
 
-            // Extract tool call result
-            if json.get("role").and_then(|v| v.as_str()) == Some("tool") {
-                if let Some(content) = json.get("content") {
-                    if let Some(arr) = content.as_array() {
-                        let mut combined = String::new();
-                        for item in arr {
-                            if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
-                                combined.push_str(text);
-                                combined.push('\n');
+        // Tool result: extract the actual result (skip <system> messages)
+        if role == "tool" {
+            if let Some(content) = json.get("content").and_then(|v| v.as_array()) {
+                for item in content {
+                    if item.get("type").and_then(|v| v.as_str()) == Some("text") {
+                        if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
+                            // Skip <system> messages, keep actual results
+                            if text.starts_with("<system>") {
+                                continue;
                             }
-                        }
-                        if !combined.is_empty() {
                             return Some(ParsedLogEntry {
                                 timestamp: utc_timestamp(),
                                 log_type: "tool".to_string(),
-                                content: combined.trim().to_string(),
+                                content: text.to_string(),
                                 usage: None,
                             });
                         }
@@ -126,17 +126,7 @@ impl CodeExecutor for KimiExecutor {
             }
         }
 
-        // Skip session resume hint
-        if trimmed.starts_with("To resume this session:") {
-            return None;
-        }
-
-        Some(ParsedLogEntry {
-            timestamp: utc_timestamp(),
-            log_type: "text".to_string(),
-            content: trimmed.to_string(),
-            usage: None,
-        })
+        None
     }
 
     fn parse_stderr_line(&self, line: &str) -> Option<ParsedLogEntry> {
@@ -155,7 +145,7 @@ impl CodeExecutor for KimiExecutor {
     fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
         logs.iter()
             .rev()
-            .find(|l| l.log_type == "text" && !l.content.starts_with("To resume"))
+            .find(|l| l.log_type == "text")
             .map(|l| l.content.clone())
     }
 
@@ -204,10 +194,17 @@ mod tests {
     #[test]
     fn test_parse_output_line_tool_result() {
         let executor = KimiExecutor::new();
-        let json = r#"{"role":"tool","content":[{"type":"text","text":"date result"}]}"#;
+        let json = r#"{"role":"tool","content":[{"type":"text","text":"Tue Apr 28 07:59:16 PDT 2026"}]}"#;
         let entry = executor.parse_output_line(json).unwrap();
         assert_eq!(entry.log_type, "tool");
-        assert_eq!(entry.content, "date result");
+        assert_eq!(entry.content, "Tue Apr 28 07:59:16 PDT 2026");
+    }
+
+    #[test]
+    fn test_parse_output_line_skip_tool_call_request() {
+        let executor = KimiExecutor::new();
+        let json = r#"{"role":"assistant","content":[{"type":"think","think":"..."}],"tool_calls":[{"type":"function","id":"call_1","function":{"name":"Shell","arguments":"{}"}}]}"#;
+        assert!(executor.parse_output_line(json).is_none());
     }
 
     #[test]
@@ -215,5 +212,14 @@ mod tests {
         let executor = KimiExecutor::new();
         let line = "To resume this session: kimi -r abc123";
         assert!(executor.parse_output_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_output_line_skip_system_message() {
+        let executor = KimiExecutor::new();
+        let json = r#"{"role":"tool","content":[{"type":"text","text":"<system>Command executed successfully.</system>"},{"type":"text","text":"Tue Apr 28"}]}"#;
+        let entry = executor.parse_output_line(json).unwrap();
+        assert_eq!(entry.log_type, "tool");
+        assert_eq!(entry.content, "Tue Apr 28");
     }
 }

--- a/backend/src/adapters/kimi.rs
+++ b/backend/src/adapters/kimi.rs
@@ -98,32 +98,45 @@ impl CodeExecutor for KimiExecutor {
                     }
                 }
             }
-            // Text content
+
+            // Collect all content items and return as separate log entries
             if let Some(content) = json.get("content").and_then(|v| v.as_array()) {
+                let mut text_result: Option<String> = None;
+                let mut think_result: Option<String> = None;
+
                 for item in content {
                     match item.get("type").and_then(|v| v.as_str()) {
                         Some("text") => {
                             if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
-                                return Some(ParsedLogEntry {
-                                    timestamp: utc_timestamp(),
-                                    log_type: "text".to_string(),
-                                    content: text.to_string(),
-                                    usage: None,
-                                });
+                                text_result = Some(text.to_string());
                             }
                         }
                         Some("think") => {
                             if let Some(think) = item.get("think").and_then(|v| v.as_str()) {
-                                return Some(ParsedLogEntry {
-                                    timestamp: utc_timestamp(),
-                                    log_type: "thinking".to_string(),
-                                    content: think.to_string(),
-                                    usage: None,
-                                });
+                                think_result = Some(think.to_string());
                             }
                         }
                         _ => {}
                     }
+                }
+
+                // Return text first if present (it's the final answer)
+                if let Some(text) = text_result {
+                    return Some(ParsedLogEntry {
+                        timestamp: utc_timestamp(),
+                        log_type: "text".to_string(),
+                        content: text,
+                        usage: None,
+                    });
+                }
+                // Fall back to thinking
+                if let Some(think) = think_result {
+                    return Some(ParsedLogEntry {
+                        timestamp: utc_timestamp(),
+                        log_type: "thinking".to_string(),
+                        content: think,
+                        usage: None,
+                    });
                 }
             }
             return None;

--- a/backend/src/adapters/kimi.rs
+++ b/backend/src/adapters/kimi.rs
@@ -1,0 +1,219 @@
+use std::env;
+use std::sync::{Arc, Mutex};
+
+use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
+use crate::models::utc_timestamp;
+
+pub struct KimiExecutor {
+    path: String,
+    usage: Arc<Mutex<Option<ExecutionUsage>>>,
+}
+
+impl KimiExecutor {
+    pub fn new() -> Self {
+        let path = env::var("KIMI_PATH")
+            .unwrap_or_else(|_| "kimi".to_string());
+        Self {
+            path,
+            usage: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl Clone for KimiExecutor {
+    fn clone(&self) -> Self {
+        Self {
+            path: self.path.clone(),
+            usage: self.usage.clone(),
+        }
+    }
+}
+
+impl Default for KimiExecutor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodeExecutor for KimiExecutor {
+    fn executor_type(&self) -> ExecutorType {
+        ExecutorType::Kimi
+    }
+
+    fn executable_path(&self) -> &str {
+        &self.path
+    }
+
+    fn command_args(&self, message: &str) -> Vec<String> {
+        vec![
+            "--print".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+            "-p".to_string(),
+            message.to_string(),
+        ]
+    }
+
+    fn command_args_with_session(&self, message: &str, session_id: Option<&str>) -> Vec<String> {
+        let mut args = self.command_args(message);
+        if let Some(sid) = session_id {
+            args.push("-S".to_string());
+            args.push(sid.to_string());
+        }
+        args
+    }
+
+    fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        // Parse JSON line
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(trimmed) {
+            // Extract text content from assistant message
+            if json.get("role").and_then(|v| v.as_str()) == Some("assistant") {
+                if let Some(content) = json.get("content") {
+                    if let Some(arr) = content.as_array() {
+                        for item in arr {
+                            if item.get("type").and_then(|v| v.as_str()) == Some("text") {
+                                if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
+                                    return Some(ParsedLogEntry {
+                                        timestamp: utc_timestamp(),
+                                        log_type: "text".to_string(),
+                                        content: text.to_string(),
+                                        usage: None,
+                                    });
+                                }
+                            }
+                            // Handle think content
+                            if item.get("type").and_then(|v| v.as_str()) == Some("think") {
+                                if let Some(think) = item.get("think").and_then(|v| v.as_str()) {
+                                    return Some(ParsedLogEntry {
+                                        timestamp: utc_timestamp(),
+                                        log_type: "thinking".to_string(),
+                                        content: think.to_string(),
+                                        usage: None,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Extract tool call result
+            if json.get("role").and_then(|v| v.as_str()) == Some("tool") {
+                if let Some(content) = json.get("content") {
+                    if let Some(arr) = content.as_array() {
+                        let mut combined = String::new();
+                        for item in arr {
+                            if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
+                                combined.push_str(text);
+                                combined.push('\n');
+                            }
+                        }
+                        if !combined.is_empty() {
+                            return Some(ParsedLogEntry {
+                                timestamp: utc_timestamp(),
+                                log_type: "tool".to_string(),
+                                content: combined.trim().to_string(),
+                                usage: None,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // Skip session resume hint
+        if trimmed.starts_with("To resume this session:") {
+            return None;
+        }
+
+        Some(ParsedLogEntry {
+            timestamp: utc_timestamp(),
+            log_type: "text".to_string(),
+            content: trimmed.to_string(),
+            usage: None,
+        })
+    }
+
+    fn parse_stderr_line(&self, line: &str) -> Option<ParsedLogEntry> {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("To resume this session:") {
+            return None;
+        }
+        Some(ParsedLogEntry {
+            timestamp: utc_timestamp(),
+            log_type: "stderr".to_string(),
+            content: trimmed.to_string(),
+            usage: None,
+        })
+    }
+
+    fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
+        logs.iter()
+            .rev()
+            .find(|l| l.log_type == "text" && !l.content.starts_with("To resume"))
+            .map(|l| l.content.clone())
+    }
+
+    fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
+        self.usage.lock().unwrap().clone()
+    }
+
+    fn get_model(&self) -> Option<String> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_args() {
+        let executor = KimiExecutor::new();
+        let args = executor.command_args("do something");
+        assert_eq!(args, vec!["--print", "--output-format", "stream-json", "-p", "do something"]);
+    }
+
+    #[test]
+    fn test_command_args_with_session() {
+        let executor = KimiExecutor::new();
+        let args = executor.command_args_with_session("continue task", Some("abc123"));
+        assert_eq!(args, vec!["--print", "--output-format", "stream-json", "-p", "continue task", "-S", "abc123"]);
+    }
+
+    #[test]
+    fn test_executor_type() {
+        let executor = KimiExecutor::new();
+        assert_eq!(executor.executor_type(), ExecutorType::Kimi);
+    }
+
+    #[test]
+    fn test_parse_output_line_assistant_text() {
+        let executor = KimiExecutor::new();
+        let json = r#"{"role":"assistant","content":[{"type":"text","text":"Hello world"}]}"#;
+        let entry = executor.parse_output_line(json).unwrap();
+        assert_eq!(entry.log_type, "text");
+        assert_eq!(entry.content, "Hello world");
+    }
+
+    #[test]
+    fn test_parse_output_line_tool_result() {
+        let executor = KimiExecutor::new();
+        let json = r#"{"role":"tool","content":[{"type":"text","text":"date result"}]}"#;
+        let entry = executor.parse_output_line(json).unwrap();
+        assert_eq!(entry.log_type, "tool");
+        assert_eq!(entry.content, "date result");
+    }
+
+    #[test]
+    fn test_parse_output_line_skip_resume() {
+        let executor = KimiExecutor::new();
+        let line = "To resume this session: kimi -r abc123";
+        assert!(executor.parse_output_line(line).is_none());
+    }
+}

--- a/backend/src/adapters/kimi.rs
+++ b/backend/src/adapters/kimi.rs
@@ -81,42 +81,63 @@ impl CodeExecutor for KimiExecutor {
 
         let role = json.get("role").and_then(|v| v.as_str())?;
 
-        // Skip assistant messages with tool_calls (tool call requests, not results)
+        // Assistant message: could have tool_calls or text content
         if role == "assistant" {
-            if json.get("tool_calls").is_some() {
-                return None;
+            // Has tool_calls - this is a tool call request
+            if let Some(tool_calls) = json.get("tool_calls").and_then(|v| v.as_array()) {
+                for call in tool_calls {
+                    if let Some(func) = call.get("function") {
+                        let name = func.get("name").and_then(|v| v.as_str()).unwrap_or("unknown");
+                        let args = func.get("arguments").and_then(|v| v.as_str()).unwrap_or("{}");
+                        return Some(ParsedLogEntry {
+                            timestamp: utc_timestamp(),
+                            log_type: "tool_call".to_string(),
+                            content: format!("Calling tool: {} with args: {}", name, args),
+                            usage: None,
+                        });
+                    }
+                }
             }
-            // Final assistant message with text content
+            // Text content
             if let Some(content) = json.get("content").and_then(|v| v.as_array()) {
                 for item in content {
-                    if item.get("type").and_then(|v| v.as_str()) == Some("text") {
-                        if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
-                            return Some(ParsedLogEntry {
-                                timestamp: utc_timestamp(),
-                                log_type: "text".to_string(),
-                                content: text.to_string(),
-                                usage: None,
-                            });
+                    match item.get("type").and_then(|v| v.as_str()) {
+                        Some("text") => {
+                            if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
+                                return Some(ParsedLogEntry {
+                                    timestamp: utc_timestamp(),
+                                    log_type: "text".to_string(),
+                                    content: text.to_string(),
+                                    usage: None,
+                                });
+                            }
                         }
+                        Some("think") => {
+                            if let Some(think) = item.get("think").and_then(|v| v.as_str()) {
+                                return Some(ParsedLogEntry {
+                                    timestamp: utc_timestamp(),
+                                    log_type: "thinking".to_string(),
+                                    content: think.to_string(),
+                                    usage: None,
+                                });
+                            }
+                        }
+                        _ => {}
                     }
                 }
             }
             return None;
         }
 
-        // Tool result: extract the actual result (skip <system> messages)
+        // Tool result
         if role == "tool" {
             if let Some(content) = json.get("content").and_then(|v| v.as_array()) {
                 for item in content {
                     if item.get("type").and_then(|v| v.as_str()) == Some("text") {
                         if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
-                            // Skip <system> messages, keep actual results
-                            if text.starts_with("<system>") {
-                                continue;
-                            }
                             return Some(ParsedLogEntry {
                                 timestamp: utc_timestamp(),
-                                log_type: "tool".to_string(),
+                                log_type: "tool_result".to_string(),
                                 content: text.to_string(),
                                 usage: None,
                             });
@@ -143,6 +164,7 @@ impl CodeExecutor for KimiExecutor {
     }
 
     fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
+        // Get the last text response as final result
         logs.iter()
             .rev()
             .find(|l| l.log_type == "text")
@@ -192,19 +214,21 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_output_line_tool_call_request() {
+        let executor = KimiExecutor::new();
+        let json = r#"{"role":"assistant","content":[],"tool_calls":[{"type":"function","id":"call_1","function":{"name":"Shell","arguments":"{\"command\":\"date\"}"}}]}"#;
+        let entry = executor.parse_output_line(json).unwrap();
+        assert_eq!(entry.log_type, "tool_call");
+        assert!(entry.content.contains("Shell"));
+    }
+
+    #[test]
     fn test_parse_output_line_tool_result() {
         let executor = KimiExecutor::new();
         let json = r#"{"role":"tool","content":[{"type":"text","text":"Tue Apr 28 07:59:16 PDT 2026"}]}"#;
         let entry = executor.parse_output_line(json).unwrap();
-        assert_eq!(entry.log_type, "tool");
+        assert_eq!(entry.log_type, "tool_result");
         assert_eq!(entry.content, "Tue Apr 28 07:59:16 PDT 2026");
-    }
-
-    #[test]
-    fn test_parse_output_line_skip_tool_call_request() {
-        let executor = KimiExecutor::new();
-        let json = r#"{"role":"assistant","content":[{"type":"think","think":"..."}],"tool_calls":[{"type":"function","id":"call_1","function":{"name":"Shell","arguments":"{}"}}]}"#;
-        assert!(executor.parse_output_line(json).is_none());
     }
 
     #[test]
@@ -212,14 +236,5 @@ mod tests {
         let executor = KimiExecutor::new();
         let line = "To resume this session: kimi -r abc123";
         assert!(executor.parse_output_line(line).is_none());
-    }
-
-    #[test]
-    fn test_parse_output_line_skip_system_message() {
-        let executor = KimiExecutor::new();
-        let json = r#"{"role":"tool","content":[{"type":"text","text":"<system>Command executed successfully.</system>"},{"type":"text","text":"Tue Apr 28"}]}"#;
-        let entry = executor.parse_output_line(json).unwrap();
-        assert_eq!(entry.log_type, "tool");
-        assert_eq!(entry.content, "Tue Apr 28");
     }
 }

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -12,6 +12,7 @@ pub fn parse_executor_type(executor: &str) -> ExecutorType {
         "opencode" => ExecutorType::Opencode,
         "atomcode" | "atom" => ExecutorType::Atomcode,
         "hermes" => ExecutorType::Hermes,
+        "kimi" => ExecutorType::Kimi,
         _ => ExecutorType::Joinai,
     }
 }
@@ -29,6 +30,7 @@ pub mod codebuddy;
 pub mod opencode;
 pub mod atomcode;
 pub mod hermes;
+pub mod kimi;
 
 #[async_trait]
 pub trait CodeExecutor: Send + Sync {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -95,6 +95,7 @@ async fn run_server() {
     executor_registry.register(adapters::opencode::OpencodeExecutor::new());
     executor_registry.register(adapters::atomcode::AtomcodeExecutor::new());
     executor_registry.register(adapters::hermes::HermesExecutor::new());
+    executor_registry.register(adapters::kimi::KimiExecutor::new());
 
     // List available executors
     let executors = executor_registry.list_executors();

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -346,6 +346,7 @@ pub enum ExecutorType {
     Opencode,
     Atomcode,
     Hermes,
+    Kimi,
 }
 
 impl Default for ExecutorType {
@@ -363,6 +364,7 @@ impl ExecutorType {
             ExecutorType::Opencode => "opencode",
             ExecutorType::Atomcode => "atomcode",
             ExecutorType::Hermes => "hermes",
+            ExecutorType::Kimi => "kimi",
         }
     }
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -191,6 +191,7 @@ export const EXECUTORS: ExecutorOption[] = [
   { value: 'joinai',     label: 'JoinAI',     color: '#0d9488', icon: '🟢' },
   { value: 'atomcode',   label: 'AtomCode',   color: '#dc2626', icon: '🔴' },
   { value: 'hermes',     label: 'Hermes',    color: '#ea580c', icon: '🟠' },
+  { value: 'kimi',      label: 'Kimi',      color: '#6366f1', icon: '🟪' },
 ];
 
 export function getExecutorOption(value: string): ExecutorOption {


### PR DESCRIPTION
## Summary
Add Kimi executor support with the following features:
- Stream-json output parsing for structured logs
- Session resume support via `-S` flag
- Detailed logging: tool_call, tool_result, text, thinking
- Final result extraction from assistant text responses

## Test plan
- [x] Backend compiles successfully
- [x] All unit tests pass
- [x] Verified kimi execution returns correct final result
- [x] Session resume works with `-S session_id`