### PR TITLE
fix(scheduler): remove prompt content from scheduled execution log

### DIFF
--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -79,7 +79,7 @@ impl TodoScheduler {
                 if let Some(todo) = db.get_todo(todo_id).await {
                     let message = if todo.prompt.is_empty() { todo.title.clone() } else { todo.prompt.clone() };
                     let executor = todo.executor.clone();
-                    info!("Scheduled execution triggered for todo {}: {}", todo_id, message);
+                    info!("Scheduled execution triggered for todo {}", todo_id);
                     run_todo_execution(db, registry, tx, todo_id, message, executor, "cron", tm).await;
                 }
             })


### PR DESCRIPTION
## Summary
- Remove prompt text from scheduler execution log to reduce noise
- Previously logged the full prompt on every cron trigger, which is not useful and clutters logs
- Now only logs the todo ID