### PR TITLE
refactor(adapters): extract shared helper functions to reduce duplication

### DIFF
--- a/backend/src/adapters/atomcode.rs
+++ b/backend/src/adapters/atomcode.rs
@@ -195,17 +195,7 @@ impl CodeExecutor for AtomcodeExecutor {
     }
 
     fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
-        let text_result = logs.iter()
-            .rev()
-            .find(|l| l.log_type == "text")
-            .map(|l| super::strip_think_tags(&l.content));
-
-        let fallback = logs.iter()
-            .rev()
-            .find(|l| l.log_type == "stderr")
-            .map(|l| l.content.clone());
-
-        text_result.or(fallback)
+        super::default_final_result_with_think_stripping(logs)
     }
 
     fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {

--- a/backend/src/adapters/claude_code.rs
+++ b/backend/src/adapters/claude_code.rs
@@ -256,8 +256,7 @@ impl CodeExecutor for ClaudeCodeExecutor {
     }
 
     fn get_usage(&self, logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
-        // Usage is now captured directly in the ParsedLogEntry.usage field
-        logs.iter().rev().find(|l| l.log_type == "result")?.usage.clone()
+        super::get_usage_from_logs(logs)
     }
 
     fn get_model(&self) -> Option<String> {

--- a/backend/src/adapters/codebuddy.rs
+++ b/backend/src/adapters/codebuddy.rs
@@ -235,7 +235,7 @@ impl CodeExecutor for CodebuddyExecutor {
     }
 
     fn get_usage(&self, logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
-        logs.iter().rev().find(|l| l.log_type == "result")?.usage.clone()
+        super::get_usage_from_logs(logs)
     }
 
     fn get_model(&self) -> Option<String> {

--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -112,17 +112,7 @@ impl CodeExecutor for HermesExecutor {
     }
 
     fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
-        let text_result = logs.iter()
-            .rev()
-            .find(|l| l.log_type == "text")
-            .map(|l| super::strip_think_tags(&l.content));
-
-        let fallback = logs.iter()
-            .rev()
-            .find(|l| l.log_type == "stderr")
-            .map(|l| l.content.clone());
-
-        text_result.or(fallback)
+        super::default_final_result_with_think_stripping(logs)
     }
 
     fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {

--- a/backend/src/adapters/joinai.rs
+++ b/backend/src/adapters/joinai.rs
@@ -198,19 +198,7 @@ impl CodeExecutor for JoinaiExecutor {
     }
 
     fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
-        // 查找最后的 text 类型日志作为结果
-        let text_result = logs.iter()
-            .rev()
-            .find(|l| l.log_type == "text")
-            .map(|l| super::strip_think_tags(&l.content));
-
-        // 如果没有 text，尝试 stderr
-        let fallback = logs.iter()
-            .rev()
-            .find(|l| l.log_type == "stderr")
-            .map(|l| l.content.clone());
-
-        text_result.or(fallback)
+        super::default_final_result_with_think_stripping(logs)
     }
 
     fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -24,6 +24,27 @@ pub fn strip_think_tags(content: &str) -> String {
     re.replace_all(content, "").trim().to_string()
 }
 
+/// Default `get_final_result` for executors that use text+stderr logs with think-tag stripping.
+/// Returns the last "text" log (with think tags stripped), falling back to last "stderr" log.
+pub fn default_final_result_with_think_stripping(logs: &[ParsedLogEntry]) -> Option<String> {
+    let text_result = logs.iter()
+        .rev()
+        .find(|l| l.log_type == "text")
+        .map(|l| strip_think_tags(&l.content));
+
+    let fallback = logs.iter()
+        .rev()
+        .find(|l| l.log_type == "stderr")
+        .map(|l| l.content.clone());
+
+    text_result.or(fallback)
+}
+
+/// Extract usage from the last "result" log entry (used by claude_code, codebuddy).
+pub fn get_usage_from_logs(logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
+    logs.iter().rev().find(|l| l.log_type == "result")?.usage.clone()
+}
+
 pub mod joinai;
 pub mod claude_code;
 pub mod codebuddy;

--- a/backend/src/adapters/opencode.rs
+++ b/backend/src/adapters/opencode.rs
@@ -233,19 +233,7 @@ impl CodeExecutor for OpencodeExecutor {
     }
 
     fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
-        // 查找最后的 text 类型日志作为结果
-        let text_result = logs.iter()
-            .rev()
-            .find(|l| l.log_type == "text")
-            .map(|l| super::strip_think_tags(&l.content));
-
-        // 如果没有 text，尝试 stderr
-        let fallback = logs.iter()
-            .rev()
-            .find(|l| l.log_type == "stderr")
-            .map(|l| l.content.clone());
-
-        text_result.or(fallback)
+        super::default_final_result_with_think_stripping(logs)
     }
 
     fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {


### PR DESCRIPTION
## Summary
- Add `default_final_result_with_think_stripping()` to `adapters/mod.rs`, replacing 4 identical `get_final_result` implementations (opencode, joinai, atomcode, hermes)
- Add `get_usage_from_logs()` to `adapters/mod.rs`, replacing 2 identical `get_usage` implementations (claude_code, codebuddy)

## Test plan
- [x] `cargo check` passes
- [x] All 160 unit tests pass
- [x] All 27 integration tests pass

Closes #14