### PR TITLE
fix(security): add 10MB body size limit

### DIFF
--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -7,6 +7,7 @@ use axum::{
 };
 use std::time::Duration;
 use tower_http::compression::CompressionLayer;
+use axum::extract::DefaultBodyLimit;
 use tower_http::cors::CorsLayer;
 use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
@@ -239,6 +240,7 @@ pub fn create_app(
         .route("/xyz/backup/export", get(backup::export_backup))
         .route("/xyz/backup/import", post(backup::import_backup))
         .route("/assets/{*path}", get(static_handler))
+        .layer(DefaultBodyLimit::max(10 * 1024 * 1024)) // 10MB max body size
         .layer(CompressionLayer::new())
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())


### PR DESCRIPTION
## Summary
- Add `DefaultBodyLimit::max(10MB)` to the router to prevent oversized request bodies
- Protects the backup import endpoint from consuming excessive memory with large payloads
- Returns 413 Payload Too Large when limit is exceeded

## Test plan
- [x] `cargo check` passes
- [x] All 160 unit tests pass
- [x] All 27 integration tests pass

Closes #19