### PR TITLE
fix: replace .expect() with ? for error propagation

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -94,7 +94,7 @@ impl Database {
         executor: &str,
         trigger_type: &str,
         task_id: &str,
-    ) -> i64 {
+    ) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let am = execution_records::ActiveModel {
             todo_id: ActiveValue::Set(Some(todo_id)),
@@ -106,11 +106,8 @@ impl Database {
             task_id: ActiveValue::Set(Some(task_id.to_string())),
             ..Default::default()
         };
-        let inserted = am
-            .insert(&self.conn)
-            .await
-            .expect("insert execution record failed");
-        inserted.id
+        let inserted = am.insert(&self.conn).await?;
+        Ok(inserted.id)
     }
 
     pub async fn update_execution_record(

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -204,7 +204,7 @@ mod tests {
     async fn test_todo_created_at_is_utc() {
         let db = setup_db().await;
         let before = truncate_seconds(Utc::now());
-        let id = db.create_todo("Test", "Desc").await;
+        let id = db.create_todo("Test", "Desc").await.unwrap();
         let after = truncate_seconds(Utc::now());
 
         let todo = db.get_todo(id).await.unwrap();
@@ -218,7 +218,7 @@ mod tests {
     #[tokio::test]
     async fn test_todo_updated_at_changes_on_update() {
         let db = setup_db().await;
-        let id = db.create_todo("Test", "Desc").await;
+        let id = db.create_todo("Test", "Desc").await.unwrap();
         let original = db.get_todo(id).await.unwrap().updated_at;
 
         tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
@@ -243,7 +243,7 @@ mod tests {
     #[tokio::test]
     async fn test_todo_deleted_at_is_utc() {
         let db = setup_db().await;
-        let id = db.create_todo("Test", "Desc").await;
+        let id = db.create_todo("Test", "Desc").await.unwrap();
         let before = truncate_seconds(Utc::now());
         db.delete_todo(id).await.unwrap();
         let after = truncate_seconds(Utc::now());
@@ -264,7 +264,7 @@ mod tests {
     async fn test_tag_created_at_is_utc() {
         let db = setup_db().await;
         let before = truncate_seconds(Utc::now());
-        let id = db.create_tag("urgent", "#ff0000").await;
+        let id = db.create_tag("urgent", "#ff0000").await.unwrap();
         let after = truncate_seconds(Utc::now());
 
         let tag = db.get_tags().await.into_iter().find(|t| t.id == id).unwrap();
@@ -278,11 +278,12 @@ mod tests {
     #[tokio::test]
     async fn test_execution_record_started_at_is_utc() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Desc").await;
+        let todo_id = db.create_todo("Test", "Desc").await.unwrap();
         let before = truncate_seconds(Utc::now());
         let record_id = db
             .create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id")
-            .await;
+            .await
+            .unwrap();
         let after = truncate_seconds(Utc::now());
 
         let (records, _) = db.get_execution_records(todo_id, 100, 0).await;
@@ -297,10 +298,11 @@ mod tests {
     #[tokio::test]
     async fn test_execution_record_finished_at_is_utc() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Desc").await;
+        let todo_id = db.create_todo("Test", "Desc").await.unwrap();
         let record_id = db
             .create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id")
-            .await;
+            .await
+            .unwrap();
 
         let before = truncate_seconds(Utc::now());
         db.update_execution_record(record_id, crate::models::ExecutionStatus::Success.as_str(), "[]", "done", None, None)
@@ -323,7 +325,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_and_get_todo() {
         let db = setup_db().await;
-        let id = db.create_todo("Title", "Prompt").await;
+        let id = db.create_todo("Title", "Prompt").await.unwrap();
         let todo = db.get_todo(id).await.unwrap();
         assert_eq!(todo.title, "Title");
         assert_eq!(todo.prompt, "Prompt");
@@ -334,7 +336,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_todos_excludes_deleted() {
         let db = setup_db().await;
-        let id = db.create_todo("Active", "Prompt").await;
+        let id = db.create_todo("Active", "Prompt").await.unwrap();
         db.delete_todo(id).await.unwrap();
         let todos = db.get_todos().await;
         assert!(todos.iter().all(|t| t.id != id));
@@ -343,9 +345,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_todos_ordering() {
         let db = setup_db().await;
-        let id1 = db.create_todo("First", "Prompt").await;
+        let id1 = db.create_todo("First", "Prompt").await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        let id2 = db.create_todo("Second", "Prompt").await;
+        let id2 = db.create_todo("Second", "Prompt").await.unwrap();
         let todos = db.get_todos().await;
         assert_eq!(todos[0].id, id2);
         assert_eq!(todos[1].id, id1);
@@ -354,7 +356,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_todo_full() {
         let db = setup_db().await;
-        let id = db.create_todo("Old", "Old prompt").await;
+        let id = db.create_todo("Old", "Old prompt").await.unwrap();
         db.update_todo_full(
             id,
             "New",
@@ -380,7 +382,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_todo_executor() {
         let db = setup_db().await;
-        let id = db.create_todo("Test", "Prompt").await;
+        let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.update_todo_executor(id, "joinai").await.unwrap();
         let todo = db.get_todo(id).await.unwrap();
         assert_eq!(todo.executor, Some("joinai".to_string()));
@@ -389,7 +391,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_todo_task_id() {
         let db = setup_db().await;
-        let id = db.create_todo("Test", "Prompt").await;
+        let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.update_todo_task_id(id, Some("task-123")).await.unwrap();
         let todo = db.get_todo(id).await.unwrap();
         assert_eq!(todo.task_id, Some("task-123".to_string()));
@@ -401,7 +403,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_todo_scheduler() {
         let db = setup_db().await;
-        let id = db.create_todo("Test", "Prompt").await;
+        let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.update_todo_scheduler(id, true, Some("0 0 * * *")).await.unwrap();
         let todo = db.get_todo(id).await.unwrap();
         assert!(todo.scheduler_enabled);
@@ -411,7 +413,7 @@ mod tests {
     #[tokio::test]
     async fn test_force_update_todo_status() {
         let db = setup_db().await;
-        let id = db.create_todo("Test", "Prompt").await;
+        let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.force_update_todo_status(id, crate::models::TodoStatus::Failed).await.unwrap();
         let todo = db.get_todo(id).await.unwrap();
         assert_eq!(todo.status, crate::models::TodoStatus::Failed);
@@ -420,7 +422,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_todo_soft_delete() {
         let db = setup_db().await;
-        let id = db.create_todo("Test", "Prompt").await;
+        let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.delete_todo(id).await.unwrap();
         assert!(db.get_todo(id).await.is_none());
         let todos = db.get_todos().await;
@@ -430,7 +432,7 @@ mod tests {
     #[tokio::test]
     async fn test_start_todo_execution() {
         let db = setup_db().await;
-        let id = db.create_todo("Test", "Prompt").await;
+        let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.start_todo_execution(id, "task-1").await.unwrap();
         let todo = db.get_todo(id).await.unwrap();
         assert_eq!(todo.status, crate::models::TodoStatus::Running);
@@ -440,7 +442,7 @@ mod tests {
     #[tokio::test]
     async fn test_finish_todo_execution_success() {
         let db = setup_db().await;
-        let id = db.create_todo("Test", "Prompt").await;
+        let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.start_todo_execution(id, "task-1").await.unwrap();
         db.finish_todo_execution(id, true).await.unwrap();
         let todo = db.get_todo(id).await.unwrap();
@@ -451,7 +453,7 @@ mod tests {
     #[tokio::test]
     async fn test_finish_todo_execution_failure() {
         let db = setup_db().await;
-        let id = db.create_todo("Test", "Prompt").await;
+        let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.start_todo_execution(id, "task-1").await.unwrap();
         db.finish_todo_execution(id, false).await.unwrap();
         let todo = db.get_todo(id).await.unwrap();
@@ -461,9 +463,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_scheduler_todos() {
         let db = setup_db().await;
-        let id1 = db.create_todo("Scheduled", "Prompt").await;
+        let id1 = db.create_todo("Scheduled", "Prompt").await.unwrap();
         db.update_todo_scheduler(id1, true, Some("0 0 * * *")).await.unwrap();
-        let id2 = db.create_todo("Normal", "Prompt").await;
+        let id2 = db.create_todo("Normal", "Prompt").await.unwrap();
         let scheduled = db.get_scheduler_todos().await;
         assert_eq!(scheduled.len(), 1);
         assert_eq!(scheduled[0].id, id1);
@@ -473,8 +475,8 @@ mod tests {
     #[tokio::test]
     async fn test_todo_with_tag_ids() {
         let db = setup_db().await;
-        let tag_id = db.create_tag("urgent", "#ff0000").await;
-        let todo_id = db.create_todo("Test", "Prompt").await;
+        let tag_id = db.create_tag("urgent", "#ff0000").await.unwrap();
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         db.add_todo_tag(todo_id, tag_id).await;
         let todo = db.get_todo(todo_id).await.unwrap();
         assert_eq!(todo.tag_ids, vec![tag_id]);
@@ -485,7 +487,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_and_get_tag() {
         let db = setup_db().await;
-        let id = db.create_tag("urgent", "#ff0000").await;
+        let id = db.create_tag("urgent", "#ff0000").await.unwrap();
         let tags = db.get_tags().await;
         let tag = tags.iter().find(|t| t.id == id).unwrap();
         assert_eq!(tag.name, "urgent");
@@ -495,9 +497,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_tags_ordered_by_name() {
         let db = setup_db().await;
-        db.create_tag("zebra", "#000").await;
-        db.create_tag("apple", "#fff").await;
-        db.create_tag("mango", "#aaa").await;
+        db.create_tag("zebra", "#000").await.unwrap();
+        db.create_tag("apple", "#fff").await.unwrap();
+        db.create_tag("mango", "#aaa").await.unwrap();
         let tags = db.get_tags().await;
         assert_eq!(tags[0].name, "apple");
         assert_eq!(tags[1].name, "mango");
@@ -507,7 +509,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_tag() {
         let db = setup_db().await;
-        let id = db.create_tag("temp", "#000").await;
+        let id = db.create_tag("temp", "#000").await.unwrap();
         db.delete_tag(id).await;
         let tags = db.get_tags().await;
         assert!(tags.iter().all(|t| t.id != id));
@@ -516,8 +518,8 @@ mod tests {
     #[tokio::test]
     async fn test_add_todo_tag() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Prompt").await;
-        let tag_id = db.create_tag("urgent", "#ff0000").await;
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
+        let tag_id = db.create_tag("urgent", "#ff0000").await.unwrap();
         db.add_todo_tag(todo_id, tag_id).await;
         let todo = db.get_todo(todo_id).await.unwrap();
         assert_eq!(todo.tag_ids, vec![tag_id]);
@@ -526,8 +528,8 @@ mod tests {
     #[tokio::test]
     async fn test_add_todo_tag_duplicate_ignored() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Prompt").await;
-        let tag_id = db.create_tag("urgent", "#ff0000").await;
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
+        let tag_id = db.create_tag("urgent", "#ff0000").await.unwrap();
         db.add_todo_tag(todo_id, tag_id).await;
         db.add_todo_tag(todo_id, tag_id).await; // should not panic
         let todo = db.get_todo(todo_id).await.unwrap();
@@ -537,10 +539,10 @@ mod tests {
     #[tokio::test]
     async fn test_set_todo_tags_replace_all() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Prompt").await;
-        let tag1 = db.create_tag("a", "#000").await;
-        let tag2 = db.create_tag("b", "#fff").await;
-        let tag3 = db.create_tag("c", "#aaa").await;
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
+        let tag1 = db.create_tag("a", "#000").await.unwrap();
+        let tag2 = db.create_tag("b", "#fff").await.unwrap();
+        let tag3 = db.create_tag("c", "#aaa").await.unwrap();
         db.add_todo_tag(todo_id, tag1).await;
         db.set_todo_tags(todo_id, &[tag2, tag3]).await;
         let todo = db.get_todo(todo_id).await.unwrap();
@@ -553,8 +555,8 @@ mod tests {
     #[tokio::test]
     async fn test_set_todo_tags_empty_clears_all() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Prompt").await;
-        let tag_id = db.create_tag("urgent", "#ff0000").await;
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
+        let tag_id = db.create_tag("urgent", "#ff0000").await.unwrap();
         db.add_todo_tag(todo_id, tag_id).await;
         db.set_todo_tags(todo_id, &[]).await;
         let todo = db.get_todo(todo_id).await.unwrap();
@@ -564,8 +566,8 @@ mod tests {
     #[tokio::test]
     async fn test_delete_todo_cascades_tags() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Prompt").await;
-        let tag_id = db.create_tag("urgent", "#ff0000").await;
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
+        let tag_id = db.create_tag("urgent", "#ff0000").await.unwrap();
         db.add_todo_tag(todo_id, tag_id).await;
         db.delete_todo(todo_id).await.unwrap();
         // tag should still exist but association should be gone
@@ -578,8 +580,8 @@ mod tests {
     #[tokio::test]
     async fn test_create_execution_record() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Prompt").await;
-        let record_id = db.create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id").await;
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
+        let record_id = db.create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id").await.unwrap();
         let (records, total) = db.get_execution_records(todo_id, 100, 0).await;
         assert_eq!(total, 1);
         let record = records.iter().find(|r| r.id == record_id).unwrap();
@@ -593,9 +595,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_execution_records_pagination() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Prompt").await;
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         for i in 0..5 {
-            db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id").await;
+            db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id").await.unwrap();
         }
         let (records, total) = db.get_execution_records(todo_id, 2, 0).await;
         assert_eq!(total, 5);
@@ -605,9 +607,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_execution_records_offset() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Prompt").await;
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         for i in 0..3 {
-            db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id").await;
+            db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id").await.unwrap();
         }
         let (records, total) = db.get_execution_records(todo_id, 10, 2).await;
         assert_eq!(total, 3);
@@ -617,8 +619,8 @@ mod tests {
     #[tokio::test]
     async fn test_update_execution_record() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Prompt").await;
-        let record_id = db.create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id").await;
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
+        let record_id = db.create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id").await.unwrap();
         let usage = crate::models::ExecutionUsage {
             input_tokens: 100,
             output_tokens: 50,
@@ -643,7 +645,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_execution_summary_empty() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Prompt").await;
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         let summary = db.get_execution_summary(todo_id).await;
         assert_eq!(summary.todo_id, todo_id);
         assert_eq!(summary.total_executions, 0);
@@ -656,12 +658,12 @@ mod tests {
     #[tokio::test]
     async fn test_get_execution_summary_counts() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Prompt").await;
-        let r1 = db.create_execution_record(todo_id, "cmd1", "claudecode", "manual", "test-task-id").await;
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
+        let r1 = db.create_execution_record(todo_id, "cmd1", "claudecode", "manual", "test-task-id").await.unwrap();
         db.update_execution_record(r1, "success", "[]", "", None, None).await.unwrap();
-        let r2 = db.create_execution_record(todo_id, "cmd2", "claudecode", "manual", "test-task-id").await;
+        let r2 = db.create_execution_record(todo_id, "cmd2", "claudecode", "manual", "test-task-id").await.unwrap();
         db.update_execution_record(r2, "failed", "[]", "", None, None).await.unwrap();
-        let _r3 = db.create_execution_record(todo_id, "cmd3", "claudecode", "manual", "test-task-id").await;
+        let _r3 = db.create_execution_record(todo_id, "cmd3", "claudecode", "manual", "test-task-id").await.unwrap();
         // r3 stays "running"
         let summary = db.get_execution_summary(todo_id).await;
         assert_eq!(summary.total_executions, 3);
@@ -673,8 +675,8 @@ mod tests {
     #[tokio::test]
     async fn test_get_execution_summary_tokens_and_cost() {
         let db = setup_db().await;
-        let todo_id = db.create_todo("Test", "Prompt").await;
-        let r1 = db.create_execution_record(todo_id, "cmd1", "claudecode", "manual", "test-task-id").await;
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
+        let r1 = db.create_execution_record(todo_id, "cmd1", "claudecode", "manual", "test-task-id").await.unwrap();
         let usage1 = crate::models::ExecutionUsage {
             input_tokens: 100,
             output_tokens: 50,
@@ -684,7 +686,7 @@ mod tests {
             duration_ms: Some(1000),
         };
         db.update_execution_record(r1, "success", "[]", "", Some(&usage1), None).await.unwrap();
-        let r2 = db.create_execution_record(todo_id, "cmd2", "claudecode", "manual", "test-task-id").await;
+        let r2 = db.create_execution_record(todo_id, "cmd2", "claudecode", "manual", "test-task-id").await.unwrap();
         let usage2 = crate::models::ExecutionUsage {
             input_tokens: 200,
             output_tokens: 100,

--- a/backend/src/db/tag.rs
+++ b/backend/src/db/tag.rs
@@ -25,7 +25,7 @@ impl Database {
             .collect()
     }
 
-    pub async fn create_tag(&self, name: &str, color: &str) -> i64 {
+    pub async fn create_tag(&self, name: &str, color: &str) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let am = tags::ActiveModel {
             name: ActiveValue::Set(name.to_string()),
@@ -33,8 +33,8 @@ impl Database {
             created_at: ActiveValue::Set(Some(now)),
             ..Default::default()
         };
-        let inserted = am.insert(&self.conn).await.expect("insert tag failed");
-        inserted.id
+        let inserted = am.insert(&self.conn).await?;
+        Ok(inserted.id)
     }
 
     pub async fn delete_tag(&self, id: i64) {

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -69,7 +69,7 @@ impl Database {
             .collect()
     }
 
-    pub async fn create_todo(&self, title: &str, prompt: &str) -> i64 {
+    pub async fn create_todo(&self, title: &str, prompt: &str) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let am = todos::ActiveModel {
             title: ActiveValue::Set(title.to_string()),
@@ -80,8 +80,8 @@ impl Database {
             executor: ActiveValue::Set(Some("claudecode".to_string())),
             ..Default::default()
         };
-        let inserted = am.insert(&self.conn).await.expect("insert todo failed");
-        inserted.id
+        let inserted = am.insert(&self.conn).await?;
+        Ok(inserted.id)
     }
 
     pub async fn update_todo_full(

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -96,7 +96,15 @@ pub async fn run_todo_execution(
 
     // Create execution record
     let command = format!("{} {}", executable_path, command_args.join(" "));
-    let record_id = db.create_execution_record(todo_id, &command, &executor_str, trigger_type, &task_id).await;
+    let record_id = match db.create_execution_record(todo_id, &command, &executor_str, trigger_type, &task_id).await {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::error!("Failed to create execution record: {}", e);
+            let _ = db.finish_todo_execution(todo_id, false).await;
+            task_manager.remove(&task_id).await;
+            return task_id;
+        }
+    };
 
     // Update todo status to running and associate with task
     if let Err(e) = db.start_todo_execution(todo_id, &task_id).await {

--- a/backend/src/handlers/tag.rs
+++ b/backend/src/handlers/tag.rs
@@ -20,7 +20,7 @@ pub async fn create_tag(
         return Err(AppError::BadRequest("Tag name is required".to_string()));
     }
     let now = utc_timestamp();
-    let id = state.db.create_tag(name, &req.color).await;
+    let id = state.db.create_tag(name, &req.color).await?;
     Ok(ApiResponse::ok(Tag {
         id,
         name: name.to_string(),

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -25,7 +25,7 @@ pub async fn create_todo(
     } else {
         req.prompt.trim().to_string()
     };
-    let id = state.db.create_todo(title, &prompt).await;
+    let id = state.db.create_todo(title, &prompt).await?;
 
     for tag_id in &req.tag_ids {
         state.db.add_todo_tag(id, *tag_id).await;


### PR DESCRIPTION
## Summary
- `create_todo`, `create_tag`, `create_execution_record` now return `Result<i64, DbErr>` instead of panicking
- Handlers propagate errors with `?` instead of crashing
- `executor_service` handles `create_execution_record` failure gracefully with logging
- Test calls updated to use `.unwrap()`

Replaces PR #25 which had excessive merge conflicts.