### PR TITLE
fix: 优化日志显示格式

### DIFF
--- a/backend/src/adapters/claude_code.rs
+++ b/backend/src/adapters/claude_code.rs
@@ -166,61 +166,92 @@ impl CodeExecutor for ClaudeCodeExecutor {
                     })
                 }
                 ClaudeMessage::Assistant { message, .. } => {
-                    let mut parts = Vec::new();
-                    for block in message.content {
-                        match block {
-                            ClaudeContentBlock::Thinking { thinking } => {
-                                if let Some(t) = thinking {
-                                    parts.push(format!("[thinking] {}", t.chars().take(200).collect::<String>()));
-                                }
-                            }
-                            ClaudeContentBlock::Text { text } => {
-                                if let Some(t) = text {
-                                    parts.push(t);
-                                }
-                            }
-                            ClaudeContentBlock::ToolUse { name, input, .. } => {
-                                let input_str = serde_json::to_string(&input).unwrap_or_default();
-                                parts.push(format!("[tool] {}: {}", name.unwrap_or_default(), input_str.chars().take(100).collect::<String>()));
-                            }
-                            ClaudeContentBlock::ToolResult { content, is_error, .. } => {
-                                let err_str = if is_error.unwrap_or(false) { "[error] " } else { "" };
-                                parts.push(format!("{}{}", err_str, content.unwrap_or_default().chars().take(100).collect::<String>()));
-                            }
-                            ClaudeContentBlock::Redacted { redacted } => {
-                                parts.push(format!("[redacted] {}", redacted.unwrap_or_default()));
+                    // Check for tool_use first (for tool execution display)
+                    for block in &message.content {
+                        if let ClaudeContentBlock::ToolUse { name, input, .. } = block {
+                            let input_str = serde_json::to_string(input).unwrap_or_default();
+                            return Some(ParsedLogEntry {
+                                timestamp: utc_timestamp(),
+                                log_type: "tool_use".to_string(),
+                                content: format!("调用工具: {} - {}", name.as_ref().unwrap_or(&"unknown".to_string()), input_str.chars().take(300).collect::<String>()),
+                                usage: None,
+                            });
+                        }
+                    }
+
+                    // Check for thinking (for AI thinking display)
+                    for block in &message.content {
+                        if let ClaudeContentBlock::Thinking { thinking } = block {
+                            if let Some(t) = thinking {
+                                return Some(ParsedLogEntry {
+                                    timestamp: utc_timestamp(),
+                                    log_type: "thinking".to_string(),
+                                    content: t.chars().take(500).collect::<String>(),
+                                    usage: None,
+                                });
                             }
                         }
                     }
-                    if parts.is_empty() {
-                        None
-                    } else {
-                        Some(ParsedLogEntry {
+
+                    // Check for tool_result (from user message)
+                    for block in &message.content {
+                        if let ClaudeContentBlock::ToolResult { content, is_error, .. } = block {
+                            let err_str = if is_error.unwrap_or(false) { "[错误] " } else { "" };
+                            return Some(ParsedLogEntry {
+                                timestamp: utc_timestamp(),
+                                log_type: "tool_result".to_string(),
+                                content: format!("{}{}", err_str, content.as_ref().unwrap_or(&String::new()).chars().take(300).collect::<String>()),
+                                usage: None,
+                            });
+                        }
+                    }
+
+                    // Check for text content
+                    let mut text_parts = Vec::new();
+                    for block in &message.content {
+                        if let ClaudeContentBlock::Text { text } = block {
+                            if let Some(t) = text {
+                                text_parts.push(t.clone());
+                            }
+                        }
+                    }
+                    if !text_parts.is_empty() {
+                        return Some(ParsedLogEntry {
                             timestamp: utc_timestamp(),
                             log_type: "assistant".to_string(),
-                            content: parts.join("\n"),
+                            content: text_parts.join("\n"),
                             usage: None,
-                        })
+                        });
                     }
-                }
-                ClaudeMessage::User { message, .. } => {
-                    let mut parts = Vec::new();
-                    for block in message.content {
-                        if let ClaudeContentBlock::ToolResult { content, is_error, .. } = block {
-                            let err_str = if is_error.unwrap_or(false) { "[error] " } else { "" };
-                            parts.push(format!("{}{}", err_str, content.unwrap_or_default()));
+
+                    // Check for redacted content
+                    for block in &message.content {
+                        if let ClaudeContentBlock::Redacted { redacted } = block {
+                            return Some(ParsedLogEntry {
+                                timestamp: utc_timestamp(),
+                                log_type: "assistant".to_string(),
+                                content: format!("[redacted] {}", redacted.as_ref().unwrap_or(&String::new())),
+                                usage: None,
+                            });
                         }
                     }
-                    if parts.is_empty() {
-                        None
-                    } else {
-                        Some(ParsedLogEntry {
-                            timestamp: utc_timestamp(),
-                            log_type: "user".to_string(),
-                            content: parts.join("\n"),
-                            usage: None,
-                        })
+
+                    None
+                }
+                ClaudeMessage::User { message, .. } => {
+                    // Check for tool_result in user message
+                    for block in &message.content {
+                        if let ClaudeContentBlock::ToolResult { content, is_error, .. } = block {
+                            let err_str = if is_error.unwrap_or(false) { "[错误] " } else { "" };
+                            return Some(ParsedLogEntry {
+                                timestamp: utc_timestamp(),
+                                log_type: "tool_result".to_string(),
+                                content: format!("{}{}", err_str, content.as_ref().unwrap_or(&String::new()).chars().take(300).collect::<String>()),
+                                usage: None,
+                            });
+                        }
                     }
+                    None
                 }
                 ClaudeMessage::Result { result, is_error, duration_ms, total_cost_usd, usage, .. } => {
                     let err_str = if is_error { "[error] " } else { "" };
@@ -293,9 +324,8 @@ mod tests {
         let executor = ClaudeCodeExecutor::new();
         let line = r#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"thinking..."}]}}"#;
         let entry = executor.parse_output_line(line).unwrap();
-        assert_eq!(entry.log_type, "assistant");
-        assert!(entry.content.starts_with("[thinking]"));
-        assert!(entry.content.contains("thinking..."));
+        assert_eq!(entry.log_type, "thinking");
+        assert_eq!(entry.content, "thinking...");
     }
 
     #[test]
@@ -303,7 +333,7 @@ mod tests {
         let executor = ClaudeCodeExecutor::new();
         let line = r#"{"type":"user","message":{"content":[{"type":"tool_result","content":"result","is_error":false}]}}"#;
         let entry = executor.parse_output_line(line).unwrap();
-        assert_eq!(entry.log_type, "user");
+        assert_eq!(entry.log_type, "tool_result");
         assert_eq!(entry.content, "result");
     }
 

--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -102,10 +102,16 @@ impl CodeExecutor for HermesExecutor {
             return None;
         }
 
-        // Hermes outputs some info to stderr
+        // Classify stderr content by its nature - Hermes often outputs info to stderr
+        let log_type = if trimmed.contains("error") || trimmed.contains("Error") || trimmed.contains("ERROR") || trimmed.contains("failed") || trimmed.contains("Failed") {
+            "stderr".to_string()
+        } else {
+            "info".to_string()
+        };
+
         Some(ParsedLogEntry {
             timestamp: utc_timestamp(),
-            log_type: "stderr".to_string(),
+            log_type,
             content: trimmed.to_string(),
             usage: None,
         })

--- a/backend/src/adapters/kimi.rs
+++ b/backend/src/adapters/kimi.rs
@@ -168,9 +168,19 @@ impl CodeExecutor for KimiExecutor {
         if trimmed.is_empty() || trimmed.starts_with("To resume this session:") {
             return None;
         }
+
+        // Classify stderr content by its nature
+        let log_type = if trimmed.starts_with("[tool-streaming") {
+            "tool".to_string()
+        } else if trimmed.contains("error") || trimmed.contains("Error") || trimmed.contains("ERROR") || trimmed.contains("failed") || trimmed.contains("Failed") {
+            "stderr".to_string()
+        } else {
+            "info".to_string()
+        };
+
         Some(ParsedLogEntry {
             timestamp: utc_timestamp(),
-            log_type: "stderr".to_string(),
+            log_type,
             content: trimmed.to_string(),
             usage: None,
         })

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -630,7 +630,7 @@ export function TodoDetail() {
                             ) : (
                               displayLogs.map((log, idx) => (
                                 <div key={idx} style={{ marginBottom: 4, display: 'flex', gap: 8 }}>
-                                  <span style={{ color: '#64748b', flexShrink: 0 }}>{log.timestamp}</span>
+                                  <span style={{ color: '#64748b', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
                                   <span style={{ color: logTypeColors[log.type || ''] || '#cbd5e1' }}>
                                     [{logTypeLabels[log.type || ''] || log.type}]
                                   </span>
@@ -796,7 +796,7 @@ export function TodoDetail() {
                         ) : (
                           displayLogs.map((log, idx) => (
                             <div key={idx} style={{ marginBottom: 4, display: 'flex', gap: 8 }}>
-                              <span style={{ color: '#64748b', flexShrink: 0 }}>{log.timestamp}</span>
+                              <span style={{ color: '#64748b', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
                               <span style={{ color: logTypeColors[log.type || ''] || '#cbd5e1' }}>
                                 [{logTypeLabels[log.type || ''] || log.type}]
                               </span>
@@ -865,30 +865,55 @@ const logTypeColors: Record<string, string> = {
   info: '#60a5fa',
   text: '#4ade80',
   tool: '#fbbf24',
+  tool_use: '#fbbf24',
+  tool_call: '#fbbf24',
+  tool_result: '#fbbf24',
   step_start: '#c084fc',
   step_finish: '#2dd4bf',
   stdout: '#cbd5e1',
-  stderr: '#f87171',
+  stderr: '#94a3b8',
   error: '#ef4444',
   system: '#94a3b8',
   assistant: '#a78bfa',
   user: '#22d3ee',
   result: '#4ade80',
   thinking: '#fb923c',
+  tokens: '#94a3b8',
 };
 
 const logTypeLabels: Record<string, string> = {
   info: 'INFO',
   text: 'TEXT',
   tool: 'TOOL',
+  tool_use: 'TOOL',
+  tool_call: 'TOOL',
+  tool_result: 'RESULT',
   step_start: 'START',
   step_finish: 'END',
   stdout: 'OUT',
-  stderr: 'ERR',
+  stderr: 'LOG',
   error: 'ERROR',
   system: 'SYS',
   assistant: 'ASST',
   user: 'USER',
   result: 'RESULT',
   thinking: 'THINK',
+  tokens: 'INFO',
 };
+
+/**
+ * 格式化时间戳为短时间格式 (HH:mm:ss)
+ */
+function formatLogTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString('zh-CN', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+  } catch {
+    return iso;
+  }
+}


### PR DESCRIPTION
## 改动

### 前端
- 修复时间戳格式化为 HH:mm:ss 本地时间
- stderr 类型改为 LOG 显示（灰色），不再误标为 ERR
- 添加 tool_call, tool_use, tool_result, tokens 日志类型支持

### 后端
- claude_code: 工具调用/结果/思考分离为独立日志条目
- kimi: [tool-streaming← xxx] 标记为 tool 类型
- hermes/kimi: 非错误 stderr 改为 info 类型