### PR TITLE
fix: switch reqwest from native-tls to rustls-tls

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -14,7 +14,7 @@ sea-orm = { version = "0.12", features = ["sqlx-sqlite", "runtime-tokio-rustls",
 libsqlite3-sys = { version = "0.27", features = ["bundled"] }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 async-trait = "0.1"
@@ -31,7 +31,7 @@ libc = "0.2"
 
 [dev-dependencies]
 cargo-watch = "8"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
 


### PR DESCRIPTION
## Summary
- 切换 reqwest 从 native-tls 到 rustls-tls
- 避免交叉编译时的 OpenSSL 依赖问题

## Changes
- `backend/Cargo.toml`: 为 reqwest 添加 `rustls-tls` 特性，禁用默认特性

## Test plan
- [ ] 验证项目可以正常编译
- [ ] 验证 HTTP 请求功能正常