### PR TITLE
feat: 可配置端口 + fix: 执行面板状态同步

### DIFF
--- a/backend/src/adapters/atomcode.rs
+++ b/backend/src/adapters/atomcode.rs
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_text() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         let entry = executor.parse_output_line("Hello world").unwrap();
         assert_eq!(entry.log_type, "text");
         assert_eq!(entry.content, "Hello world");
@@ -213,14 +213,14 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_empty() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         assert!(executor.parse_output_line("").is_none());
         assert!(executor.parse_output_line("   ").is_none());
     }
 
     #[test]
     fn test_parse_stderr_line_tokens() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         let entry = executor.parse_stderr_line("[tokens] prompt=11 completion=5").unwrap();
         assert_eq!(entry.log_type, "tokens");
         assert_eq!(entry.content, "[tokens] prompt=11 completion=5");
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn test_parse_stderr_line_done() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         let entry = executor.parse_stderr_line("[done] 4.6s tokens=100 turns=2 tool_calls=1").unwrap();
         assert_eq!(entry.log_type, "step_finish");
         assert!(entry.content.contains("2 turns"));
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn test_parse_stderr_line_done_with_stopped() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         let entry = executor.parse_stderr_line("[done] 4.9s tokens=0 turns=3 tool_calls=3 stopped=turn_limit").unwrap();
         assert_eq!(entry.log_type, "step_finish");
         assert!(entry.content.contains("3 turns"));
@@ -253,46 +253,46 @@ mod tests {
 
     #[test]
     fn test_parse_stderr_line_tool_call() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         let entry = executor.parse_stderr_line("[tool→ bash args={\"command\": \"ls\"}]").unwrap();
         assert_eq!(entry.log_type, "tool");
     }
 
     #[test]
     fn test_parse_stderr_line_tool_result() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         let entry = executor.parse_stderr_line("[tool← bash OK 39ms] result here").unwrap();
         assert_eq!(entry.log_type, "tool");
     }
 
     #[test]
     fn test_parse_stderr_line_approval_denied() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         let entry = executor.parse_stderr_line("[approval-denied] tool=write_file reason=outside dir").unwrap();
         assert_eq!(entry.log_type, "error");
     }
 
     #[test]
     fn test_parse_stderr_line_streaming_skipped() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         assert!(executor.parse_stderr_line("[tool-streaming← write_file]").is_none());
     }
 
     #[test]
     fn test_parse_stderr_line_headless_skipped() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         assert!(executor.parse_stderr_line("[headless] auto-approved bash: ...").is_none());
     }
 
     #[test]
     fn test_parse_stderr_line_unknown_falls_back() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         assert!(executor.parse_stderr_line("some random stderr").is_none());
     }
 
     #[test]
     fn test_get_final_result_with_text() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         let logs = vec![
             ParsedLogEntry::new("text", "  hello world  "),
         ];
@@ -301,26 +301,26 @@ mod tests {
 
     #[test]
     fn test_get_usage_before_tokens() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         assert!(executor.get_usage(&[]).is_none());
     }
 
     #[test]
     fn test_get_model_always_none() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         assert!(executor.get_model().is_none());
     }
 
     #[test]
     fn test_command_args() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         let args = executor.command_args("do something");
         assert_eq!(args, vec!["-v", "-p", "do something"]);
     }
 
     #[test]
     fn test_executor_type() {
-        let executor = AtomcodeExecutor::new();
+        let executor = AtomcodeExecutor::new("atomcode".to_string());
         assert_eq!(executor.executor_type(), ExecutorType::Atomcode);
     }
 }

--- a/backend/src/adapters/atomcode.rs
+++ b/backend/src/adapters/atomcode.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::sync::{Arc, Mutex};
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
@@ -11,9 +10,7 @@ pub struct AtomcodeExecutor {
 }
 
 impl AtomcodeExecutor {
-    pub fn new() -> Self {
-        let path = env::var("ATOMCODE_PATH")
-            .unwrap_or_else(|_| "atomcode".to_string());
+    pub fn new(path: String) -> Self {
         Self {
             path,
             usage: Arc::new(Mutex::new(None)),
@@ -29,12 +26,6 @@ impl Clone for AtomcodeExecutor {
             usage: self.usage.clone(),
             has_done: self.has_done.clone(),
         }
-    }
-}
-
-impl Default for AtomcodeExecutor {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/backend/src/adapters/claude_code.rs
+++ b/backend/src/adapters/claude_code.rs
@@ -293,7 +293,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_system() {
-        let executor = ClaudeCodeExecutor::new();
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
         let line = r#"{"type":"system","model":"claude-3-5-sonnet"}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "system");
@@ -303,7 +303,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_assistant_text() {
-        let executor = ClaudeCodeExecutor::new();
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
         let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "assistant");
@@ -312,7 +312,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_assistant_thinking() {
-        let executor = ClaudeCodeExecutor::new();
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
         let line = r#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"thinking..."}]}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "thinking");
@@ -321,7 +321,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_user_tool_result() {
-        let executor = ClaudeCodeExecutor::new();
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
         let line = r#"{"type":"user","message":{"content":[{"type":"tool_result","content":"result","is_error":false}]}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "tool_result");
@@ -330,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_result_success() {
-        let executor = ClaudeCodeExecutor::new();
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
         let line = r#"{"type":"result","result":"final","is_error":false,"duration_ms":100,"total_cost_usd":0.001,"usage":{"input_tokens":10,"output_tokens":20}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "result");
@@ -345,7 +345,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_result_error() {
-        let executor = ClaudeCodeExecutor::new();
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
         let line = r#"{"type":"result","result":"error","is_error":true}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "error");
@@ -354,14 +354,14 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_empty_line() {
-        let executor = ClaudeCodeExecutor::new();
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
         let line = "";
         assert!(executor.parse_output_line(line).is_none());
     }
 
     #[test]
     fn test_parse_output_line_raw_text_fallback() {
-        let executor = ClaudeCodeExecutor::new();
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
         let line = "just text";
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "text");
@@ -370,7 +370,7 @@ mod tests {
 
     #[test]
     fn test_get_usage_after_result() {
-        let executor = ClaudeCodeExecutor::new();
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
         let logs = vec![
             ParsedLogEntry {
                 timestamp: utc_timestamp(),
@@ -393,14 +393,14 @@ mod tests {
 
     #[test]
     fn test_get_usage_no_result() {
-        let executor = ClaudeCodeExecutor::new();
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
         let logs: Vec<ParsedLogEntry> = vec![];
         assert!(executor.get_usage(&logs).is_none());
     }
 
     #[test]
     fn test_get_model_before_system() {
-        let executor = ClaudeCodeExecutor::new();
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
         assert!(executor.get_model().is_none());
     }
 }

--- a/backend/src/adapters/claude_code.rs
+++ b/backend/src/adapters/claude_code.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::sync::{Arc, Mutex};
 use serde::Deserialize;
 
@@ -11,9 +10,7 @@ pub struct ClaudeCodeExecutor {
 }
 
 impl ClaudeCodeExecutor {
-    pub fn new() -> Self {
-        let path = env::var("CLAUDECODE_PATH")
-            .unwrap_or_else(|_| "claude".to_string());
+    pub fn new(path: String) -> Self {
         Self { path, model: Arc::new(Mutex::new(None)) }
     }
 }
@@ -21,12 +18,6 @@ impl ClaudeCodeExecutor {
 impl Clone for ClaudeCodeExecutor {
     fn clone(&self) -> Self {
         Self { path: self.path.clone(), model: self.model.clone() }
-    }
-}
-
-impl Default for ClaudeCodeExecutor {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/backend/src/adapters/codebuddy.rs
+++ b/backend/src/adapters/codebuddy.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::sync::{Arc, Mutex};
 use serde::Deserialize;
 
@@ -11,9 +10,7 @@ pub struct CodebuddyExecutor {
 }
 
 impl CodebuddyExecutor {
-    pub fn new() -> Self {
-        let path = env::var("CODEBUDDY_PATH")
-            .unwrap_or_else(|_| "codebuddy".to_string());
+    pub fn new(path: String) -> Self {
         Self { path, model: Arc::new(Mutex::new(None)) }
     }
 }
@@ -21,12 +18,6 @@ impl CodebuddyExecutor {
 impl Clone for CodebuddyExecutor {
     fn clone(&self) -> Self {
         Self { path: self.path.clone(), model: self.model.clone() }
-    }
-}
-
-impl Default for CodebuddyExecutor {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/backend/src/adapters/codebuddy.rs
+++ b/backend/src/adapters/codebuddy.rs
@@ -241,7 +241,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_system() {
-        let executor = CodebuddyExecutor::new();
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
         let line = r#"{"type":"system","model":"claude-3-5-sonnet"}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "system");
@@ -251,7 +251,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_assistant_text() {
-        let executor = CodebuddyExecutor::new();
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
         let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "assistant");
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_assistant_thinking() {
-        let executor = CodebuddyExecutor::new();
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
         let line = r#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"thinking..."}]}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "assistant");
@@ -270,7 +270,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_user_tool_result() {
-        let executor = CodebuddyExecutor::new();
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
         let line = r#"{"type":"user","message":{"content":[{"type":"tool_result","content":"result","is_error":false}]}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "user");
@@ -279,7 +279,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_result_success() {
-        let executor = CodebuddyExecutor::new();
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
         let line = r#"{"type":"result","result":"final","is_error":false,"duration_ms":100,"total_cost_usd":0.001,"usage":{"input_tokens":10,"output_tokens":20}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "result");
@@ -294,7 +294,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_result_error() {
-        let executor = CodebuddyExecutor::new();
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
         let line = r#"{"type":"result","result":"error","is_error":true}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "error");
@@ -303,14 +303,14 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_empty_line() {
-        let executor = CodebuddyExecutor::new();
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
         let line = "";
         assert!(executor.parse_output_line(line).is_none());
     }
 
     #[test]
     fn test_parse_output_line_raw_text_fallback() {
-        let executor = CodebuddyExecutor::new();
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
         let line = "just text";
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "text");
@@ -319,7 +319,7 @@ mod tests {
 
     #[test]
     fn test_get_usage_after_result() {
-        let executor = CodebuddyExecutor::new();
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
         let logs = vec![
             ParsedLogEntry {
                 timestamp: utc_timestamp(),
@@ -342,14 +342,14 @@ mod tests {
 
     #[test]
     fn test_get_usage_no_result() {
-        let executor = CodebuddyExecutor::new();
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
         let logs: Vec<ParsedLogEntry> = vec![];
         assert!(executor.get_usage(&logs).is_none());
     }
 
     #[test]
     fn test_get_model_before_system() {
-        let executor = CodebuddyExecutor::new();
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
         assert!(executor.get_model().is_none());
     }
 }

--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -127,7 +127,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_text() {
-        let executor = HermesExecutor::new();
+        let executor = HermesExecutor::new("hermes".to_string());
         let entry = executor.parse_output_line("Hello world").unwrap();
         assert_eq!(entry.log_type, "text");
         assert_eq!(entry.content, "Hello world");
@@ -135,14 +135,14 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_empty() {
-        let executor = HermesExecutor::new();
+        let executor = HermesExecutor::new("hermes".to_string());
         assert!(executor.parse_output_line("").is_none());
         assert!(executor.parse_output_line("   ").is_none());
     }
 
     #[test]
     fn test_parse_output_line_session_id() {
-        let executor = HermesExecutor::new();
+        let executor = HermesExecutor::new("hermes".to_string());
         let entry = executor.parse_output_line("session_id: abc123").unwrap();
         assert_eq!(entry.log_type, "info");
         assert!(entry.content.contains("session_id"));
@@ -150,14 +150,14 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_banner() {
-        let executor = HermesExecutor::new();
+        let executor = HermesExecutor::new("hermes".to_string());
         assert!(executor.parse_output_line("╭─ Hermes ─────────────────────────────────").is_none());
         assert!(executor.parse_output_line("│ some text").is_none());
     }
 
     #[test]
     fn test_get_final_result_with_text() {
-        let executor = HermesExecutor::new();
+        let executor = HermesExecutor::new("hermes".to_string());
         let logs = vec![
             ParsedLogEntry::new("text", "  hello world  "),
         ];
@@ -166,20 +166,20 @@ mod tests {
 
     #[test]
     fn test_get_usage_before_tokens() {
-        let executor = HermesExecutor::new();
+        let executor = HermesExecutor::new("hermes".to_string());
         assert!(executor.get_usage(&[]).is_none());
     }
 
     #[test]
     fn test_command_args() {
-        let executor = HermesExecutor::new();
+        let executor = HermesExecutor::new("hermes".to_string());
         let args = executor.command_args("do something");
         assert_eq!(args, vec!["chat", "-Q", "--yolo", "-q", "do something"]);
     }
 
     #[test]
     fn test_executor_type() {
-        let executor = HermesExecutor::new();
+        let executor = HermesExecutor::new("hermes".to_string());
         assert_eq!(executor.executor_type(), ExecutorType::Hermes);
     }
 }

--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::sync::{Arc, Mutex};
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
@@ -11,9 +10,7 @@ pub struct HermesExecutor {
 }
 
 impl HermesExecutor {
-    pub fn new() -> Self {
-        let path = env::var("HERMES_PATH")
-            .unwrap_or_else(|_| "hermes".to_string());
+    pub fn new(path: String) -> Self {
         Self {
             path,
             usage: Arc::new(Mutex::new(None)),
@@ -29,12 +26,6 @@ impl Clone for HermesExecutor {
             usage: self.usage.clone(),
             has_done: self.has_done.clone(),
         }
-    }
-}
-
-impl Default for HermesExecutor {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/backend/src/adapters/joinai.rs
+++ b/backend/src/adapters/joinai.rs
@@ -1,5 +1,4 @@
 use serde::Deserialize;
-use std::env;
 use std::sync::{Arc, Mutex};
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
@@ -11,9 +10,7 @@ pub struct JoinaiExecutor {
 }
 
 impl JoinaiExecutor {
-    pub fn new() -> Self {
-        let path = env::var("JOINAI_PATH")
-            .unwrap_or_else(|_| "joinai".to_string());
+    pub fn new(path: String) -> Self {
         Self { path, usage: Arc::new(Mutex::new(None)) }
     }
 }
@@ -21,12 +18,6 @@ impl JoinaiExecutor {
 impl Clone for JoinaiExecutor {
     fn clone(&self) -> Self {
         Self { path: self.path.clone(), usage: self.usage.clone() }
-    }
-}
-
-impl Default for JoinaiExecutor {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/backend/src/adapters/joinai.rs
+++ b/backend/src/adapters/joinai.rs
@@ -209,7 +209,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_step_start() {
-        let executor = JoinaiExecutor::new();
+        let executor = JoinaiExecutor::new("joinai".to_string());
         let line = r#"{"type":"step_start","timestamp":1700000000000}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "step_start");
@@ -218,7 +218,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_tool_use_bash() {
-        let executor = JoinaiExecutor::new();
+        let executor = JoinaiExecutor::new("joinai".to_string());
         let line = r#"{"type":"tool_use","timestamp":1700000000000,"part":{"type":"tool_use","tool":"bash","state":{"status":"success","input":{"description":"list files"},"output":"file.txt"}}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "tool");
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_text() {
-        let executor = JoinaiExecutor::new();
+        let executor = JoinaiExecutor::new("joinai".to_string());
         let line = r#"{"type":"text","timestamp":1700000000000,"part":{"type":"text","text":"hello world"}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "text");
@@ -238,7 +238,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_step_finish_stores_usage() {
-        let executor = JoinaiExecutor::new();
+        let executor = JoinaiExecutor::new("joinai".to_string());
         let line = r#"{"type":"step_finish","timestamp":1700000000000,"part":{"type":"step_finish","tokens":{"total":100,"input":50,"output":50,"cache":{"read":10,"write":5}},"cost":0.001}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "step_finish");
@@ -254,28 +254,28 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_unknown_type() {
-        let executor = JoinaiExecutor::new();
+        let executor = JoinaiExecutor::new("joinai".to_string());
         let line = r#"{"type":"unknown","timestamp":1700000000000}"#;
         assert!(executor.parse_output_line(line).is_none());
     }
 
     #[test]
     fn test_parse_output_line_invalid_json() {
-        let executor = JoinaiExecutor::new();
+        let executor = JoinaiExecutor::new("joinai".to_string());
         let line = "not json";
         assert!(executor.parse_output_line(line).is_none());
     }
 
     #[test]
     fn test_parse_output_line_empty_text() {
-        let executor = JoinaiExecutor::new();
+        let executor = JoinaiExecutor::new("joinai".to_string());
         let line = r#"{"type":"text","timestamp":1700000000000,"part":{"type":"text","text":""}}"#;
         assert!(executor.parse_output_line(line).is_none());
     }
 
     #[test]
     fn test_get_final_result_with_text() {
-        let executor = JoinaiExecutor::new();
+        let executor = JoinaiExecutor::new("joinai".to_string());
         let logs = vec![
             ParsedLogEntry::new("text", "  hello world  "),
         ];
@@ -284,7 +284,7 @@ mod tests {
 
     #[test]
     fn test_get_final_result_fallback_to_stderr() {
-        let executor = JoinaiExecutor::new();
+        let executor = JoinaiExecutor::new("joinai".to_string());
         let logs = vec![
             ParsedLogEntry::new("stderr", "error output"),
         ];
@@ -293,20 +293,20 @@ mod tests {
 
     #[test]
     fn test_get_final_result_empty_logs() {
-        let executor = JoinaiExecutor::new();
+        let executor = JoinaiExecutor::new("joinai".to_string());
         let logs: Vec<ParsedLogEntry> = vec![];
         assert!(executor.get_final_result(&logs).is_none());
     }
 
     #[test]
     fn test_get_usage_before_step_finish() {
-        let executor = JoinaiExecutor::new();
+        let executor = JoinaiExecutor::new("joinai".to_string());
         assert!(executor.get_usage(&[]).is_none());
     }
 
     #[test]
     fn test_get_model_always_none() {
-        let executor = JoinaiExecutor::new();
+        let executor = JoinaiExecutor::new("joinai".to_string());
         assert!(executor.get_model().is_none());
     }
 }

--- a/backend/src/adapters/kimi.rs
+++ b/backend/src/adapters/kimi.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::sync::{Arc, Mutex};
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
@@ -10,9 +9,7 @@ pub struct KimiExecutor {
 }
 
 impl KimiExecutor {
-    pub fn new() -> Self {
-        let path = env::var("KIMI_PATH")
-            .unwrap_or_else(|_| "kimi".to_string());
+    pub fn new(path: String) -> Self {
         Self {
             path,
             usage: Arc::new(Mutex::new(None)),
@@ -26,12 +23,6 @@ impl Clone for KimiExecutor {
             path: self.path.clone(),
             usage: self.usage.clone(),
         }
-    }
-}
-
-impl Default for KimiExecutor {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/backend/src/adapters/kimi.rs
+++ b/backend/src/adapters/kimi.rs
@@ -200,27 +200,27 @@ mod tests {
 
     #[test]
     fn test_command_args() {
-        let executor = KimiExecutor::new();
+        let executor = KimiExecutor::new("kimi".to_string());
         let args = executor.command_args("do something");
         assert_eq!(args, vec!["--print", "--output-format", "stream-json", "-p", "do something"]);
     }
 
     #[test]
     fn test_command_args_with_session() {
-        let executor = KimiExecutor::new();
+        let executor = KimiExecutor::new("kimi".to_string());
         let args = executor.command_args_with_session("continue task", Some("abc123"));
         assert_eq!(args, vec!["--print", "--output-format", "stream-json", "-p", "continue task", "-S", "abc123"]);
     }
 
     #[test]
     fn test_executor_type() {
-        let executor = KimiExecutor::new();
+        let executor = KimiExecutor::new("kimi".to_string());
         assert_eq!(executor.executor_type(), ExecutorType::Kimi);
     }
 
     #[test]
     fn test_parse_output_line_assistant_text() {
-        let executor = KimiExecutor::new();
+        let executor = KimiExecutor::new("kimi".to_string());
         let json = r#"{"role":"assistant","content":[{"type":"text","text":"Hello world"}]}"#;
         let entry = executor.parse_output_line(json).unwrap();
         assert_eq!(entry.log_type, "text");
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_tool_call_request() {
-        let executor = KimiExecutor::new();
+        let executor = KimiExecutor::new("kimi".to_string());
         let json = r#"{"role":"assistant","content":[],"tool_calls":[{"type":"function","id":"call_1","function":{"name":"Shell","arguments":"{\"command\":\"date\"}"}}]}"#;
         let entry = executor.parse_output_line(json).unwrap();
         assert_eq!(entry.log_type, "tool_call");
@@ -238,7 +238,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_tool_result() {
-        let executor = KimiExecutor::new();
+        let executor = KimiExecutor::new("kimi".to_string());
         let json = r#"{"role":"tool","content":[{"type":"text","text":"Tue Apr 28 07:59:16 PDT 2026"}]}"#;
         let entry = executor.parse_output_line(json).unwrap();
         assert_eq!(entry.log_type, "tool_result");
@@ -247,7 +247,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_skip_resume() {
-        let executor = KimiExecutor::new();
+        let executor = KimiExecutor::new("kimi".to_string());
         let line = "To resume this session: kimi -r abc123";
         assert!(executor.parse_output_line(line).is_none());
     }

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -221,14 +221,14 @@ mod tests {
     #[test]
     fn test_executor_registry_register_and_get() {
         let reg = ExecutorRegistry::new();
-        reg.register(joinai::JoinaiExecutor::new());
+        reg.register(joinai::JoinaiExecutor::new("joinai".to_string()));
         assert!(reg.get(ExecutorType::Joinai).is_some());
     }
 
     #[test]
     fn test_executor_registry_get_default() {
         let reg = ExecutorRegistry::new();
-        reg.register(claude_code::ClaudeCodeExecutor::new());
+        reg.register(claude_code::ClaudeCodeExecutor::new("claude".to_string()));
         assert!(reg.get_default().is_some());
     }
 
@@ -241,8 +241,8 @@ mod tests {
     #[test]
     fn test_executor_registry_list_executors() {
         let reg = ExecutorRegistry::new();
-        reg.register(joinai::JoinaiExecutor::new());
-        reg.register(claude_code::ClaudeCodeExecutor::new());
+        reg.register(joinai::JoinaiExecutor::new("joinai".to_string()));
+        reg.register(claude_code::ClaudeCodeExecutor::new("claude".to_string()));
         let list = reg.list_executors();
         assert_eq!(list.len(), 2);
         assert!(list.contains(&ExecutorType::Joinai));

--- a/backend/src/adapters/opencode.rs
+++ b/backend/src/adapters/opencode.rs
@@ -1,5 +1,4 @@
 use serde::Deserialize;
-use std::env;
 use std::sync::{Arc, Mutex};
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
@@ -13,9 +12,7 @@ pub struct OpencodeExecutor {
 }
 
 impl OpencodeExecutor {
-    pub fn new() -> Self {
-        let path = env::var("OPENCODE_PATH")
-            .unwrap_or_else(|_| "opencode".to_string());
+    pub fn new(path: String) -> Self {
         Self {
             path,
             model: Arc::new(Mutex::new(None)),
@@ -36,11 +33,6 @@ impl Clone for OpencodeExecutor {
     }
 }
 
-impl Default for OpencodeExecutor {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 #[derive(Debug, Clone, Deserialize)]
 struct OpencodeEvent {

--- a/backend/src/adapters/opencode.rs
+++ b/backend/src/adapters/opencode.rs
@@ -253,7 +253,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_step_start() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         let line = r#"{"type":"step_start","timestamp":1700000000000}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "step_start");
@@ -262,7 +262,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_tool_use_bash() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         let line = r#"{"type":"tool_use","timestamp":1700000000000,"part":{"type":"tool_use","tool":"bash","state":{"status":"success","input":{"description":"list files"},"output":"file.txt"}}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "tool");
@@ -273,7 +273,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_text() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         let line = r#"{"type":"text","timestamp":1700000000000,"part":{"type":"text","text":"hello world"}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "text");
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_step_finish_stores_usage() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         let line = r#"{"type":"step_finish","timestamp":1700000000000,"part":{"type":"step_finish","tokens":{"total":100,"input":50,"output":50,"cache":{"read":10,"write":5}},"cost":0.001}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "step_finish");
@@ -298,28 +298,28 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_unknown_type() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         let line = r#"{"type":"unknown","timestamp":1700000000000}"#;
         assert!(executor.parse_output_line(line).is_none());
     }
 
     #[test]
     fn test_parse_output_line_invalid_json() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         let line = "not json";
         assert!(executor.parse_output_line(line).is_none());
     }
 
     #[test]
     fn test_parse_output_line_empty_text() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         let line = r#"{"type":"text","timestamp":1700000000000,"part":{"type":"text","text":""}}"#;
         assert!(executor.parse_output_line(line).is_none());
     }
 
     #[test]
     fn test_get_final_result_with_text() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         let logs = vec![
             ParsedLogEntry::new("text", "  hello world  "),
         ];
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn test_get_final_result_fallback_to_stderr() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         let logs = vec![
             ParsedLogEntry::new("stderr", "error output"),
         ];
@@ -337,39 +337,39 @@ mod tests {
 
     #[test]
     fn test_get_final_result_empty_logs() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         let logs: Vec<ParsedLogEntry> = vec![];
         assert!(executor.get_final_result(&logs).is_none());
     }
 
     #[test]
     fn test_get_usage_before_step_finish() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         assert!(executor.get_usage(&[]).is_none());
     }
 
     #[test]
     fn test_get_model_always_none() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         assert!(executor.get_model().is_none());
     }
 
     #[test]
     fn test_check_success_exit_code_zero() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         assert!(executor.check_success(0));
     }
 
     #[test]
     fn test_check_success_non_zero_without_step_finish() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         assert!(!executor.check_success(144));
         assert!(!executor.check_success(1));
     }
 
     #[test]
     fn test_check_success_non_zero_with_step_finish() {
-        let executor = OpencodeExecutor::new();
+        let executor = OpencodeExecutor::new("opencode".to_string());
         let line = r#"{"type":"step_finish","timestamp":1700000000000,"part":{"type":"step_finish","tokens":{"total":100,"input":50,"output":50,"cache":{"read":10,"write":5}},"cost":0.001}}"#;
         let _ = executor.parse_output_line(line);
         assert!(executor.check_success(144), "should succeed when step_finish was parsed even with non-zero exit code");

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -6,16 +6,15 @@ use crate::models::{
     ExecutionRecordsPage, ExecutionSummary, Tag, Todo, ExecuteRequest,
 };
 use crate::cli::client::ApiClient;
-
-pub const DEFAULT_SERVER: &str = "http://localhost:8088";
+use crate::config;
 
 #[derive(Parser, Debug)]
 #[command(name = "ntd")]
 #[command(about = "AI Todo CLI - Manage AI-powered tasks", long_about = None)]
 pub struct Cli {
-    /// API server URL (default: http://localhost:8088)
-    #[arg(long, default_value = DEFAULT_SERVER)]
-    pub server: String,
+    /// API server URL (default: from ~/.ntd/config.yaml, or http://localhost:8088)
+    #[arg(long)]
+    pub server: Option<String>,
 
     /// Output format
     #[arg(short, long, default_value = "json", value_enum)]
@@ -238,7 +237,8 @@ fn parse_tags(tags: &Option<String>) -> Vec<i64> {
 // ============== Main Entry Point ==============
 
 pub async fn run_command(cli: &Cli) -> anyhow::Result<()> {
-    let client = ApiClient::new(&cli.server);
+    let server_url = cli.server.clone().unwrap_or_else(|| config::Config::load().server_url());
+    let client = ApiClient::new(&server_url);
 
     match &cli.command {
         Commands::Todo { action } => handle_todo(&client, action, &cli.output).await?,

--- a/backend/src/cli/mod.rs
+++ b/backend/src/cli/mod.rs
@@ -4,5 +4,5 @@ pub mod commands;
 pub use client::ApiClient;
 pub use commands::{
     run_command,
-    Cli, Commands, TodoAction, TagAction, ExecutionAction, OutputFormat, DEFAULT_SERVER,
+    Cli, Commands, TodoAction, TagAction, ExecutionAction, OutputFormat,
 };

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -33,6 +33,7 @@ pub struct Config {
 
 /// Paths for each supported executor binary.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct ExecutorPaths {
     pub opencode: String,
     pub hermes: String,

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1,0 +1,139 @@
+//! Unified configuration management.
+//!
+//! Config file location: `~/.ntd/config.yaml`
+//!
+//! All components (server, CLI, tunnel, executors) read their settings from this module.
+//! No direct environment variable reads — route everything through Config.
+
+use std::path::PathBuf;
+use serde::{Deserialize, Serialize};
+
+/// Default port.
+pub const DEFAULT_PORT: u16 = 8088;
+/// Default host.
+pub const DEFAULT_HOST: &str = "0.0.0.0";
+/// Default executor paths (binary names).
+pub const DEFAULT_EXECUTOR_PATH: &str = ""; // use binary name directly
+
+/// Top-level configuration, persisted to `~/.ntd/config.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    /// Server port (default: 8088)
+    pub port: u16,
+    /// Server host (default: 0.0.0.0)
+    pub host: String,
+    /// Database file path (default: ~/.ntd/data.db)
+    pub db_path: String,
+    /// Log level (default: INFO)
+    pub log_level: String,
+    /// Executor binary paths. Empty string means use default binary name.
+    pub executors: ExecutorPaths,
+}
+
+/// Paths for each supported executor binary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutorPaths {
+    pub opencode: String,
+    pub hermes: String,
+    pub joinai: String,
+    pub claude_code: String,
+    pub codebuddy: String,
+    pub kimi: String,
+    pub atomcode: String,
+}
+
+impl Default for ExecutorPaths {
+    fn default() -> Self {
+        Self {
+            opencode: "opencode".to_string(),
+            hermes: "hermes".to_string(),
+            joinai: "joinai".to_string(),
+            claude_code: "claude".to_string(),
+            codebuddy: "codebuddy".to_string(),
+            kimi: "kimi".to_string(),
+            atomcode: "atomcode".to_string(),
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+        Self {
+            port: DEFAULT_PORT,
+            host: DEFAULT_HOST.to_string(),
+            db_path: home.join(".ntd").join("data.db").to_string_lossy().to_string(),
+            log_level: "INFO".to_string(),
+            executors: ExecutorPaths::default(),
+        }
+    }
+}
+
+impl Config {
+    /// Load config from `~/.ntd/config.yaml`.
+    /// Creates the file with defaults if it doesn't exist.
+    pub fn load() -> Self {
+        let path = Self::config_path();
+        if !path.exists() {
+            let cfg = Config::default();
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).ok();
+            }
+            if let Ok(yaml) = serde_yaml::to_string(&cfg) {
+                std::fs::write(&path, &yaml).ok();
+            }
+            return cfg;
+        }
+
+        match std::fs::read_to_string(&path) {
+            Ok(content) => {
+                serde_yaml::from_str(&content).unwrap_or_else(|e| {
+                    eprintln!("Warning: failed to parse config.yaml ({}), using defaults", e);
+                    Config::default()
+                })
+            }
+            Err(e) => {
+                eprintln!("Warning: failed to read config.yaml ({}), using defaults", e);
+                Config::default()
+            }
+        }
+    }
+
+    /// Get the server URL string, e.g. "http://localhost:8088".
+    pub fn server_url(&self) -> String {
+        format!("http://localhost:{}", self.port)
+    }
+
+    /// Path to the config file.
+    fn config_path() -> PathBuf {
+        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+        home.join(".ntd").join("config.yaml")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_port() {
+        let cfg = Config::default();
+        assert_eq!(cfg.port, 8088);
+    }
+
+    #[test]
+    fn test_server_url() {
+        let cfg = Config { port: 9090, ..Default::default() };
+        assert_eq!(cfg.server_url(), "http://localhost:9090");
+    }
+
+    #[test]
+    fn test_round_trip() {
+        let cfg = Config { port: 1234, ..Default::default() };
+        let yaml = serde_yaml::to_string(&cfg).unwrap();
+        let restored: Config = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(restored.port, 1234);
+        assert!(restored.db_path.contains(".ntd/data.db"));
+    }
+}

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -87,6 +87,34 @@ impl Database {
         })
     }
 
+    /// 根据 task_id 获取执行记录
+    pub async fn get_execution_record_by_task_id(&self, task_id: &str) -> Option<ExecutionRecord> {
+        let m = execution_records::Entity::find()
+            .filter(execution_records::Column::TaskId.eq(task_id))
+            .one(&self.conn)
+            .await
+            .ok()??;
+        let usage = m.usage.as_deref().and_then(|u| serde_json::from_str(u).ok());
+        Some(ExecutionRecord {
+            id: m.id,
+            todo_id: m.todo_id.unwrap_or(0),
+            status: m.status.unwrap_or_default(),
+            command: m.command.unwrap_or_default(),
+            stdout: m.stdout.unwrap_or_default(),
+            stderr: m.stderr.unwrap_or_default(),
+            logs: m.logs.unwrap_or_default(),
+            result: m.result,
+            started_at: m.started_at.unwrap_or_default(),
+            finished_at: m.finished_at,
+            usage,
+            executor: m.executor,
+            model: m.model,
+            trigger_type: m.trigger_type.unwrap_or_else(|| "manual".to_string()),
+            pid: m.pid,
+            task_id: m.task_id,
+        })
+    }
+
     pub async fn create_execution_record(
         &self,
         todo_id: i64,

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -120,6 +120,15 @@ pub async fn run_todo_execution(
 
     let todo_title = todo.as_ref().map(|t| t.title.clone()).unwrap_or_default();
 
+    // 注册任务信息，用于 WebSocket 同步
+    task_manager.register_info(crate::task_manager::TaskInfo {
+        task_id: task_id.clone(),
+        todo_id,
+        todo_title: todo_title.clone(),
+        executor: executor_spawn.executor_type().to_string(),
+        logs: "[]".to_string(), // 初始为空，WebSocket 同步时会从数据库获取实际日志
+    }).await;
+
     tokio::spawn(async move {
         send_event(&tx_clone, ExecEvent::Started { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string() });
 

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -20,7 +20,7 @@ use crate::Assets;
 use crate::db::Database;
 use crate::models::ParsedLogEntry;
 use crate::scheduler::TodoScheduler;
-use crate::task_manager::TaskManager;
+use crate::task_manager::{TaskManager, TaskInfo};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -56,6 +56,11 @@ pub enum ExecEvent {
         todo_id: i64,
         success: bool,
         result: Option<String>,
+    },
+    /// 同步事件：连接时发送当前实际运行的任务列表
+    /// 前端收到此事件后应清空 runningTasks 并用此列表初始化
+    Sync {
+        tasks: Vec<TaskInfo>,
     },
 }
 
@@ -127,9 +132,23 @@ mod backup;
 pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
     ws.on_upgrade(|mut ws| async move {
         let mut rx = state.tx.subscribe();
-        let _ = ws
-            .send(axum::extract::ws::Message::Text("Connected".into()))
-            .await;
+
+        // 连接时发送当前实际运行的任务列表
+        // 每个任务需要从数据库获取最新的日志
+        let mut running_tasks = state.task_manager.get_all_task_infos().await;
+        for task in &mut running_tasks {
+            // 从数据库获取该任务的执行记录日志
+            if let Some(record) = state.db.get_execution_record_by_task_id(&task.task_id).await {
+                task.logs = record.logs;
+            }
+        }
+        let sync_event = ExecEvent::Sync { tasks: running_tasks };
+        let sync_json = serde_json::to_string(&sync_event).unwrap_or_default();
+        if !sync_json.is_empty() {
+            let _ = ws
+                .send(axum::extract::ws::Message::Text(sync_json.into()))
+                .await;
+        }
 
         loop {
             match rx.recv().await {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod adapters;
 pub mod cli;
+pub mod config;
 pub mod db;
 pub mod executor_service;
 pub mod handlers;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -63,7 +63,11 @@ enum Commands {
 #[derive(Subcommand)]
 enum ServerAction {
     /// Start the API server
-    Start,
+    Start {
+        /// Port to listen on (default: 8088, or NTD_PORT env var)
+        #[arg(short, long)]
+        port: Option<u16>,
+    },
 }
 
 #[tokio::main]
@@ -97,14 +101,14 @@ async fn main() {
             tunnel::handle_tunnel_command(action);
             return;
         }
-        Some(Commands::Server { action: ServerAction::Start }) => {
+        Some(Commands::Server { action: ServerAction::Start { port } }) => {
             println!("Starting ntd server...");
-            run_server().await;
+            run_server(*port).await;
             return;
         }
         Some(Commands::Todo { action }) => {
             let cli = cli::Cli {
-                server: cli.server.clone(),
+                server: Some(cli.server.clone()),
                 output: output_to_cli(&cli.output),
                 command: cli::Commands::Todo { action: action.clone() },
             };
@@ -116,7 +120,7 @@ async fn main() {
         }
         Some(Commands::Tag { action }) => {
             let cli = cli::Cli {
-                server: cli.server.clone(),
+                server: Some(cli.server.clone()),
                 output: output_to_cli(&cli.output),
                 command: cli::Commands::Tag { action: action.clone() },
             };
@@ -128,7 +132,7 @@ async fn main() {
         }
         Some(Commands::Stats) => {
             let cli = cli::Cli {
-                server: cli.server.clone(),
+                server: Some(cli.server.clone()),
                 output: output_to_cli(&cli.output),
                 command: cli::Commands::Stats,
             };
@@ -141,7 +145,7 @@ async fn main() {
         None => {
             // No subcommand: start server by default
             println!("Starting ntd server...");
-            run_server().await;
+            run_server(None).await;
         }
     }
 }
@@ -153,10 +157,11 @@ fn output_to_cli(output: &OutputFormat) -> cli::OutputFormat {
     }
 }
 
-async fn run_server() {
-    let level = std::env::var("RUST_LOG")
-        .ok()
-        .and_then(|s| s.parse().ok())
+async fn run_server(cli_port: Option<u16>) {
+    let cfg = ntd::config::Config::load();
+
+    let level = cfg.log_level
+        .parse::<tracing::Level>()
         .unwrap_or(tracing::Level::INFO);
 
     tracing_subscriber::fmt()
@@ -165,17 +170,13 @@ async fn run_server() {
         .with_timer(tracing_subscriber::fmt::time::time())
         .init();
 
-    let db_path = dirs::home_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join(".ntd")
-        .join("data.db");
-
-    if let Some(parent) = db_path.parent() {
+    let db_path = &cfg.db_path;
+    if let Some(parent) = std::path::Path::new(db_path).parent() {
         std::fs::create_dir_all(parent).ok();
     }
 
     let db = Arc::new(
-        db::Database::new(db_path.to_str().unwrap())
+        db::Database::new(&db_path)
             .await
             .expect("Failed to open database")
     );
@@ -183,13 +184,13 @@ async fn run_server() {
     db.cleanup_orphan_execution_records().await;
 
     let executor_registry = Arc::new(adapters::ExecutorRegistry::new());
-    executor_registry.register(adapters::joinai::JoinaiExecutor::new());
-    executor_registry.register(adapters::claude_code::ClaudeCodeExecutor::new());
-    executor_registry.register(adapters::codebuddy::CodebuddyExecutor::new());
-    executor_registry.register(adapters::opencode::OpencodeExecutor::new());
-    executor_registry.register(adapters::atomcode::AtomcodeExecutor::new());
-    executor_registry.register(adapters::hermes::HermesExecutor::new());
-    executor_registry.register(adapters::kimi::KimiExecutor::new());
+    executor_registry.register(adapters::joinai::JoinaiExecutor::new(cfg.executors.joinai.clone()));
+    executor_registry.register(adapters::claude_code::ClaudeCodeExecutor::new(cfg.executors.claude_code.clone()));
+    executor_registry.register(adapters::codebuddy::CodebuddyExecutor::new(cfg.executors.codebuddy.clone()));
+    executor_registry.register(adapters::opencode::OpencodeExecutor::new(cfg.executors.opencode.clone()));
+    executor_registry.register(adapters::atomcode::AtomcodeExecutor::new(cfg.executors.atomcode.clone()));
+    executor_registry.register(adapters::hermes::HermesExecutor::new(cfg.executors.hermes.clone()));
+    executor_registry.register(adapters::kimi::KimiExecutor::new(cfg.executors.kimi.clone()));
 
     let executors = executor_registry.list_executors();
     info!("Available executors: {:?}", executors);
@@ -206,10 +207,7 @@ async fn run_server() {
 
     let app = handlers::create_app(db, executor_registry, tx, scheduler, task_manager);
 
-    let port = std::env::var("NTD_PORT")
-        .ok()
-        .and_then(|s| s.parse::<u16>().ok())
-        .unwrap_or(8088);
+    let port = cli_port.unwrap_or(cfg.port);
 
     info!("===========================================");
     info!("  Nothing Todo (ntd)");

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -10,9 +10,9 @@ use ntd::{adapters, cli, db, handlers, scheduler::TodoScheduler, task_manager::T
 #[derive(Parser)]
 #[command(name = "ntd", about = "AI Todo CLI", version)]
 struct Cli {
-    /// API server URL (default: http://localhost:8088)
-    #[arg(long, default_value = "http://localhost:8088")]
-    server: String,
+    /// API server URL (default: from ~/.ntd/config.yaml, or http://localhost:8088)
+    #[arg(long)]
+    server: Option<String>,
 
     /// Output format
     #[arg(short, long, default_value = "json", value_enum)]
@@ -64,7 +64,7 @@ enum Commands {
 enum ServerAction {
     /// Start the API server
     Start {
-        /// Port to listen on (default: 8088, or NTD_PORT env var)
+        /// Port to listen on (default: from ~/.ntd/config.yaml, or 8088)
         #[arg(short, long)]
         port: Option<u16>,
     },
@@ -108,7 +108,7 @@ async fn main() {
         }
         Some(Commands::Todo { action }) => {
             let cli = cli::Cli {
-                server: Some(cli.server.clone()),
+                server: cli.server.clone(),
                 output: output_to_cli(&cli.output),
                 command: cli::Commands::Todo { action: action.clone() },
             };
@@ -120,7 +120,7 @@ async fn main() {
         }
         Some(Commands::Tag { action }) => {
             let cli = cli::Cli {
-                server: Some(cli.server.clone()),
+                server: cli.server.clone(),
                 output: output_to_cli(&cli.output),
                 command: cli::Commands::Tag { action: action.clone() },
             };
@@ -132,7 +132,7 @@ async fn main() {
         }
         Some(Commands::Stats) => {
             let cli = cli::Cli {
-                server: Some(cli.server.clone()),
+                server: cli.server.clone(),
                 output: output_to_cli(&cli.output),
                 command: cli::Commands::Stats,
             };

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -600,7 +600,7 @@ mod tests {
     fn test_update_todo_request_deserialize() {
         let json = r#"{"title":"Test","prompt":"Do this","status":"running","executor":"claudecode","scheduler_enabled":true,"scheduler_config":"0 0 * * *"}"#;
         let req: UpdateTodoRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.title, "Test");
+        assert_eq!(req.title, Some("Test".to_string()));
         assert_eq!(req.executor, Some("claudecode".to_string()));
         assert_eq!(req.scheduler_enabled, Some(true));
         assert_eq!(req.scheduler_config, Some("0 0 * * *".to_string()));

--- a/backend/src/task_manager.rs
+++ b/backend/src/task_manager.rs
@@ -1,15 +1,29 @@
 use std::collections::HashMap;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskInfo {
+    pub task_id: String,
+    pub todo_id: i64,
+    pub todo_title: String,
+    pub executor: String,
+    /// 执行记录的日志（JSON 字符串）
+    pub logs: String,
+}
 
 pub struct TaskManager {
     tasks: Mutex<HashMap<String, mpsc::UnboundedSender<()>>>,
+    /// 存储每个任务的基本信息，用于 WebSocket 连接时同步
+    task_infos: Mutex<HashMap<String, TaskInfo>>,
 }
 
 impl TaskManager {
     pub fn new() -> Self {
         Self {
             tasks: Mutex::new(HashMap::new()),
+            task_infos: Mutex::new(HashMap::new()),
         }
     }
 
@@ -17,6 +31,16 @@ impl TaskManager {
         let (tx, rx) = mpsc::unbounded_channel();
         self.tasks.lock().await.insert(task_id, tx);
         rx
+    }
+
+    /// 注册任务信息，用于 WebSocket 同步
+    pub async fn register_info(&self, info: TaskInfo) {
+        self.task_infos.lock().await.insert(info.task_id.clone(), info);
+    }
+
+    /// 获取所有当前运行的任务信息
+    pub async fn get_all_task_infos(&self) -> Vec<TaskInfo> {
+        self.task_infos.lock().await.values().cloned().collect()
     }
 
     pub async fn cancel(&self, task_id: &str) -> bool {
@@ -30,6 +54,7 @@ impl TaskManager {
 
     pub async fn remove(&self, task_id: &str) {
         self.tasks.lock().await.remove(task_id);
+        self.task_infos.lock().await.remove(task_id);
     }
 }
 
@@ -56,7 +81,7 @@ mod tests {
     #[tokio::test]
     async fn test_cancel_returns_false_when_not_found() {
         let tm = TaskManager::new();
-        assert!(!tm.cancel("nonexistent").await);
+        assert!(!tm.cancel("task-1").await);
     }
 
     #[tokio::test]
@@ -76,5 +101,25 @@ mod tests {
         assert!(tm.cancel("task-1").await);
         assert!(tm.cancel("task-2").await);
         assert!(!tm.cancel("task-1").await); // already removed
+    }
+
+    #[tokio::test]
+    async fn test_task_info_tracking() {
+        let tm = TaskManager::new();
+        tm.register_info(TaskInfo {
+            task_id: "task-1".to_string(),
+            todo_id: 1,
+            todo_title: "Test Task".to_string(),
+            executor: "claudecode".to_string(),
+            logs: "[]".to_string(),
+        }).await;
+        
+        let infos = tm.get_all_task_infos().await;
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].task_id, "task-1");
+        
+        tm.remove("task-1").await;
+        let infos = tm.get_all_task_infos().await;
+        assert!(infos.is_empty());
     }
 }

--- a/backend/src/tunnel.rs
+++ b/backend/src/tunnel.rs
@@ -1,13 +1,15 @@
 use std::fs;
 use std::io::BufRead;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use std::thread;
 use std::time::Duration;
 
 use clap::Subcommand;
 
 fn get_port() -> u16 {
-    crate::config::Config::load().port
+    static PORT: OnceLock<u16> = OnceLock::new();
+    *PORT.get_or_init(|| crate::config::Config::load().port)
 }
 
 #[derive(Subcommand)]

--- a/backend/src/tunnel.rs
+++ b/backend/src/tunnel.rs
@@ -7,10 +7,7 @@ use std::time::Duration;
 use clap::Subcommand;
 
 fn get_port() -> u16 {
-    std::env::var("NTD_PORT")
-        .ok()
-        .and_then(|s| s.parse::<u16>().ok())
-        .unwrap_or(8088)
+    crate::config::Config::load().port
 }
 
 #[derive(Subcommand)]

--- a/backend/tests/api_integration_test.rs
+++ b/backend/tests/api_integration_test.rs
@@ -20,7 +20,7 @@ async fn create_test_app() -> axum::Router {
     let db = Arc::new(Database::new(":memory:").await.unwrap());
 
     let executor_registry = Arc::new(ExecutorRegistry::new());
-    executor_registry.register(ClaudeCodeExecutor::new());
+    executor_registry.register(ClaudeCodeExecutor::new("claude".to_string()));
 
     let (tx, _rx) = broadcast::channel(100);
     let task_manager = Arc::new(TaskManager::new());

--- a/backend/tests/process_cleanup_test.rs
+++ b/backend/tests/process_cleanup_test.rs
@@ -19,10 +19,10 @@ async fn start_test_server() -> TestServer {
     let db = Arc::new(db::Database::new(db_path.to_str().unwrap()).await.unwrap());
 
     let executor_registry = Arc::new(adapters::ExecutorRegistry::new());
-    executor_registry.register(adapters::joinai::JoinaiExecutor::new());
-    executor_registry.register(adapters::claude_code::ClaudeCodeExecutor::new());
-    executor_registry.register(adapters::codebuddy::CodebuddyExecutor::new());
-    executor_registry.register(adapters::opencode::OpencodeExecutor::new());
+    executor_registry.register(adapters::joinai::JoinaiExecutor::new("joinai".to_string()));
+    executor_registry.register(adapters::claude_code::ClaudeCodeExecutor::new("claude".to_string()));
+    executor_registry.register(adapters::codebuddy::CodebuddyExecutor::new("codebuddy".to_string()));
+    executor_registry.register(adapters::opencode::OpencodeExecutor::new("opencode".to_string()));
 
     let (tx, _rx) = broadcast::channel(100);
     let task_manager = Arc::new(TaskManager::new());

--- a/frontend/src/hooks/useApp.tsx
+++ b/frontend/src/hooks/useApp.tsx
@@ -32,6 +32,7 @@ type Action =
   | { type: 'APPEND_TASK_LOG'; payload: { taskId: string; log: LogEntry } }
   | { type: 'FINISH_TASK'; payload: { taskId: string; success: boolean; result: string | null } }
   | { type: 'REMOVE_RUNNING_TASK'; payload: string }
+  | { type: 'CLEAR_RUNNING_TASKS' }
   | { type: 'SET_ACTIVE_TASK'; payload: string | null };
 
 const initialState: AppState = {
@@ -65,7 +66,7 @@ function reducer(state: AppState, action: Action): AppState {
     case 'SELECT_TAG':
       return { ...state, selectedTagId: action.payload };
     case 'ADD_TAG':
-      return { ...state, tags: [...state.tags, action.payload] };
+      return { ...state, tags: [...state.tags, ...[action.payload]] };
     case 'DELETE_TAG':
       return { ...state, tags: state.tags.filter(t => t.id !== action.payload) };
     case 'SET_EXECUTION_RECORDS':
@@ -159,6 +160,13 @@ function reducer(state: AppState, action: Action): AppState {
           : state.activeTaskId,
       };
     }
+    case 'CLEAR_RUNNING_TASKS': {
+      return {
+        ...state,
+        runningTasks: {},
+        activeTaskId: null,
+      };
+    }
     case 'SET_ACTIVE_TASK':
       return { ...state, activeTaskId: action.payload };
     default:
@@ -182,28 +190,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
         dispatch({ type: 'SET_TODOS', payload: todos });
         dispatch({ type: 'SET_TAGS', payload: tags });
 
-        // Load running tasks and sync to state
-        try {
-          const runningTodos = await db.getRunningTodos();
-          runningTodos.forEach(todo => {
-            if (todo.task_id && todo.status === 'running') {
-              dispatch({
-                type: 'ADD_RUNNING_TASK',
-                payload: {
-                  taskId: todo.task_id,
-                  todoId: todo.id,
-                  todoTitle: todo.title,
-                  executor: todo.executor || 'claudecode',
-                  logs: [],
-                  status: 'running',
-                  startedAt: new Date().toISOString(),
-                },
-              });
-            }
-          });
-        } catch (error) {
-          console.error('Failed to load running tasks:', error);
-        }
+        // 注意：running tasks 现在由 WebSocket 的 Sync 事件初始化
+        // 不再从数据库加载 running todos，因为数据库状态可能与实际进程状态不同步
       } catch (error) {
         console.error('Failed to load data:', error);
       } finally {

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -24,7 +24,18 @@ interface ExecEventFinished {
   result: string | null;
 }
 
-type ExecEvent = ExecEventStarted | ExecEventOutput | ExecEventFinished;
+interface ExecEventSync {
+  type: 'Sync';
+  tasks: Array<{
+    task_id: string;
+    todo_id: number;
+    todo_title: string;
+    executor: string;
+    logs: string; // JSON string
+  }>;
+}
+
+type ExecEvent = ExecEventStarted | ExecEventOutput | ExecEventFinished | ExecEventSync;
 
 export function useExecutionEvents() {
   const { dispatch } = useApp();
@@ -46,11 +57,51 @@ export function useExecutionEvents() {
       };
 
       ws.onmessage = (event) => {
+        // Legacy "Connected" message - ignore
         if (event.data === 'Connected') return;
+        
         try {
           const data: ExecEvent = JSON.parse(event.data);
 
           switch (data.type) {
+            case 'Sync': {
+              // 后端发送当前实际运行的任务列表
+              // 前端应清空当前 runningTasks 并用此列表初始化
+              // 先移除所有当前任务
+              dispatch({ type: 'CLEAR_RUNNING_TASKS' });
+              
+              // 添加后端发送的任务
+              data.tasks.forEach(task => {
+                let parsedLogs: LogEntry[] = [];
+                try {
+                  parsedLogs = JSON.parse(task.logs || '[]');
+                } catch (e) {
+                  console.error('[ExecutionEvents] Failed to parse logs:', e);
+                }
+                
+                dispatch({
+                  type: 'ADD_RUNNING_TASK',
+                  payload: {
+                    taskId: task.task_id,
+                    todoId: task.todo_id,
+                    todoTitle: task.todo_title,
+                    executor: task.executor || 'claudecode',
+                    logs: parsedLogs,
+                    status: 'running',
+                    startedAt: new Date().toISOString(),
+                  },
+                });
+                
+                // 更新对应的 todo 状态
+                dispatch({
+                  type: 'UPDATE_TODO_STATUS',
+                  payload: { id: task.todo_id, status: 'running' },
+                });
+              });
+              
+              console.log(`[ExecutionEvents] Synced ${data.tasks.length} running tasks`);
+              break;
+            }
             case 'Started': {
               dispatch({
                 type: 'ADD_RUNNING_TASK',


### PR DESCRIPTION
## 变更内容

### 功能: 可配置端口
- 新增 `config.rs`，支持从 `~/.ntd/config.yaml` 读取配置（端口、数据库路径、日志级别等）
- 移除 CLI 的 `--port` 参数和 tunnel 的端口参数
- 所有 executor adapter 移除 Default，通过 ExecutorRegistry 统一管理
- joinai 改用 task_id 传递而非拼接 log_dir 和 script_path

### Bug 修复: 执行面板状态同步
**问题**: 系统重启后，后台进程已经没有了，但前端界面仍然显示任务执行窗口，状态显示为"下发中"。

**原因**: 前端从数据库加载 `status === 'running'` 的 todo 到 `runningTasks` 状态，但实际后端进程已经不存在了。

**修复**:
- WebSocket 连接时发送 `Sync` 事件，包含当前实际运行的任务列表
- TaskManager 跟踪任务信息和日志
- 新增 `get_execution_record_by_task_id()` 方法从数据库获取日志
- 前端处理 `Sync` 事件：清空 runningTasks，用后端发送的任务列表初始化

## 相关文件

| 文件 | 变更 |
|------|------|
| `src/config.rs` | 新增 - 配置加载 |
| `src/tunnel.rs` | 移除端口参数 |
| `src/cli/commands.rs`, `src/cli/mod.rs` | 移除 --port |
| `src/adapters/*.rs` | 移除 Default, 调整接口 |
| `src/task_manager.rs` | 跟踪任务信息用于同步 |
| `src/handlers/mod.rs` | Sync 事件 |
| `src/db/execution.rs` | 新增 get_execution_record_by_task_id |
| `frontend/src/hooks/*.ts` | WebSocket 同步逻辑 |