### PR TITLE
refactor: P0/P1 代码质量修复

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -774,26 +774,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,15 +1117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if 1.0.4",
-]
-
-[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,21 +1252,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1463,8 +1419,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1474,9 +1432,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1509,25 +1469,6 @@ dependencies = [
  "fnv",
  "log",
  "regex",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1691,7 +1632,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1716,22 +1656,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1752,11 +1677,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2101,6 +2024,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac-notification-sys"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,23 +2158,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "net2"
 version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,6 +2258,7 @@ dependencies = [
  "dirs 5.0.1",
  "libc",
  "libsqlite3-sys",
+ "parking_lot",
  "regex",
  "reqwest",
  "rust-embed",
@@ -2505,50 +2418,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openssl"
-version = "0.10.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if 1.0.4",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -2879,6 +2748,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.39",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.39",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3039,29 +2963,26 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.39",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3069,6 +2990,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3186,6 +3108,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3229,6 +3157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "subtle",
@@ -3250,6 +3179,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3293,15 +3223,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3413,29 +3334,6 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -3726,7 +3624,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -3994,27 +3892,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4224,16 +4101,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -4806,10 +4673,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"
@@ -4977,17 +4863,6 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -25,6 +25,7 @@ cron = "0.15"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout", "compression-gzip"] }
+parking_lot = "0.12"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/backend/src/adapters/agent_event.rs
+++ b/backend/src/adapters/agent_event.rs
@@ -1,0 +1,76 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    #[serde(default)]
+    pub timestamp: Option<u64>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub part: Option<AgentPart>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentPart {
+    #[serde(rename = "type")]
+    pub part_type: Option<String>,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub tool: Option<String>,
+    #[serde(default)]
+    pub call_id: Option<String>,
+    #[serde(default)]
+    pub state: Option<AgentToolState>,
+    #[serde(default)]
+    pub message_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub tokens: Option<AgentTokens>,
+    #[serde(default)]
+    pub cost: Option<f64>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentToolState {
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub input: Option<AgentToolInput>,
+    #[serde(default)]
+    pub output: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentToolInput {
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentTokens {
+    pub total: u64,
+    pub input: u64,
+    pub output: u64,
+    #[serde(default)]
+    pub reasoning: u64,
+    #[serde(default)]
+    pub cache: AgentCacheTokens,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct AgentCacheTokens {
+    #[serde(default)]
+    pub read: u64,
+    #[serde(default)]
+    pub write: u64,
+}

--- a/backend/src/adapters/atomcode.rs
+++ b/backend/src/adapters/atomcode.rs
@@ -1,4 +1,5 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use parking_lot::Mutex;
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
 use crate::models::utc_timestamp;
@@ -81,7 +82,7 @@ impl CodeExecutor for AtomcodeExecutor {
                 }
             }
 
-            let mut usage_guard = self.usage.lock().unwrap();
+            let mut usage_guard = self.usage.lock();
             if let Some(ref mut usage) = *usage_guard {
                 usage.input_tokens = prompt_tokens;
                 usage.output_tokens = completion_tokens;
@@ -106,7 +107,7 @@ impl CodeExecutor for AtomcodeExecutor {
 
         // [done] 4.6s tokens=0 turns=1 tool_calls=0 [stopped=turn_limit]
         if trimmed.starts_with("[done]") {
-            *self.has_done.lock().unwrap() = true;
+            *self.has_done.lock() = true;
 
             let mut total_tokens = 0u64;
             let mut turns = 0u64;
@@ -130,7 +131,7 @@ impl CodeExecutor for AtomcodeExecutor {
                 }
             }
 
-            let mut usage_guard = self.usage.lock().unwrap();
+            let mut usage_guard = self.usage.lock();
             if let Some(ref mut usage) = *usage_guard {
                 usage.duration_ms = duration_ms;
             } else if total_tokens > 0 {
@@ -190,7 +191,7 @@ impl CodeExecutor for AtomcodeExecutor {
     }
 
     fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
-        self.usage.lock().unwrap().clone()
+        self.usage.lock().clone()
     }
 
     fn get_model(&self) -> Option<String> {

--- a/backend/src/adapters/claude_code.rs
+++ b/backend/src/adapters/claude_code.rs
@@ -1,7 +1,8 @@
-use std::sync::{Arc, Mutex};
-use serde::Deserialize;
+use std::sync::Arc;
+use parking_lot::Mutex;
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
+use super::claude_protocol::{ClaudeMessage, ClaudeContentBlock};
 use crate::models::utc_timestamp;
 
 pub struct ClaudeCodeExecutor {
@@ -19,85 +20,6 @@ impl Clone for ClaudeCodeExecutor {
     fn clone(&self) -> Self {
         Self { path: self.path.clone(), model: self.model.clone() }
     }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type")]
-enum ClaudeMessage {
-    #[serde(rename = "system")]
-    System {
-        subtype: Option<String>,
-        session_id: Option<String>,
-        model: Option<String>,
-    },
-    #[serde(rename = "assistant")]
-    Assistant {
-        message: ClaudeMessageContent,
-        #[serde(default)]
-        parent_tool_use_id: Option<String>,
-        session_id: Option<String>,
-        uuid: Option<String>,
-    },
-    #[serde(rename = "user")]
-    User {
-        message: ClaudeMessageContent,
-        #[serde(default)]
-        parent_tool_use_id: Option<String>,
-        session_id: Option<String>,
-        uuid: Option<String>,
-    },
-    #[serde(rename = "result")]
-    Result {
-        subtype: Option<String>,
-        is_error: bool,
-        duration_ms: Option<u64>,
-        result: Option<String>,
-        total_cost_usd: Option<f64>,
-        #[serde(default)]
-        usage: Option<ClaudeUsage>,
-        session_id: Option<String>,
-    },
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct ClaudeMessageContent {
-    id: Option<String>,
-    #[serde(rename = "type")]
-    content_type: Option<String>,
-    role: Option<String>,
-    #[serde(default)]
-    content: Vec<ClaudeContentBlock>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type")]
-enum ClaudeContentBlock {
-    #[serde(rename = "thinking")]
-    Thinking { thinking: Option<String> },
-    #[serde(rename = "text")]
-    Text { text: Option<String> },
-    #[serde(rename = "tool_use")]
-    ToolUse {
-        id: Option<String>,
-        name: Option<String>,
-        input: serde_json::Value,
-    },
-    #[serde(rename = "tool_result")]
-    ToolResult {
-        tool_use_id: Option<String>,
-        content: Option<String>,
-        is_error: Option<bool>,
-    },
-    #[serde(rename = "redacted")]
-    Redacted { redacted: Option<String> },
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct ClaudeUsage {
-    input_tokens: u64,
-    output_tokens: u64,
-    cache_read_input_tokens: Option<u64>,
-    cache_creation_input_tokens: Option<u64>,
 }
 
 impl CodeExecutor for ClaudeCodeExecutor {
@@ -147,7 +69,7 @@ impl CodeExecutor for ClaudeCodeExecutor {
                 ClaudeMessage::System { subtype, session_id, model } => {
                     // Store model if found
                     if let Some(m) = model {
-                        *self.model.lock().unwrap() = Some(m.clone());
+                        *self.model.lock() = Some(m.clone());
                     }
                     Some(ParsedLogEntry {
                         timestamp: utc_timestamp(),
@@ -282,7 +204,7 @@ impl CodeExecutor for ClaudeCodeExecutor {
     }
 
     fn get_model(&self) -> Option<String> {
-        self.model.lock().unwrap().clone()
+        self.model.lock().clone()
     }
 }
 

--- a/backend/src/adapters/claude_protocol.rs
+++ b/backend/src/adapters/claude_protocol.rs
@@ -1,0 +1,80 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum ClaudeMessage {
+    #[serde(rename = "system")]
+    System {
+        subtype: Option<String>,
+        session_id: Option<String>,
+        model: Option<String>,
+    },
+    #[serde(rename = "assistant")]
+    Assistant {
+        message: ClaudeMessageContent,
+        #[serde(default)]
+        parent_tool_use_id: Option<String>,
+        session_id: Option<String>,
+        uuid: Option<String>,
+    },
+    #[serde(rename = "user")]
+    User {
+        message: ClaudeMessageContent,
+        #[serde(default)]
+        parent_tool_use_id: Option<String>,
+        session_id: Option<String>,
+        uuid: Option<String>,
+    },
+    #[serde(rename = "result")]
+    Result {
+        subtype: Option<String>,
+        is_error: bool,
+        duration_ms: Option<u64>,
+        result: Option<String>,
+        total_cost_usd: Option<f64>,
+        #[serde(default)]
+        usage: Option<ClaudeUsage>,
+        session_id: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ClaudeMessageContent {
+    pub id: Option<String>,
+    #[serde(rename = "type")]
+    pub content_type: Option<String>,
+    pub role: Option<String>,
+    #[serde(default)]
+    pub content: Vec<ClaudeContentBlock>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum ClaudeContentBlock {
+    #[serde(rename = "thinking")]
+    Thinking { thinking: Option<String> },
+    #[serde(rename = "text")]
+    Text { text: Option<String> },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: Option<String>,
+        name: Option<String>,
+        input: serde_json::Value,
+    },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: Option<String>,
+        content: Option<String>,
+        is_error: Option<bool>,
+    },
+    #[serde(rename = "redacted")]
+    Redacted { redacted: Option<String> },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ClaudeUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_input_tokens: Option<u64>,
+    pub cache_creation_input_tokens: Option<u64>,
+}

--- a/backend/src/adapters/codebuddy.rs
+++ b/backend/src/adapters/codebuddy.rs
@@ -1,7 +1,8 @@
-use std::sync::{Arc, Mutex};
-use serde::Deserialize;
+use std::sync::Arc;
+use parking_lot::Mutex;
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
+use super::claude_protocol::{ClaudeMessage, ClaudeContentBlock};
 use crate::models::utc_timestamp;
 
 pub struct CodebuddyExecutor {
@@ -19,85 +20,6 @@ impl Clone for CodebuddyExecutor {
     fn clone(&self) -> Self {
         Self { path: self.path.clone(), model: self.model.clone() }
     }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type")]
-enum CodebuddyMessage {
-    #[serde(rename = "system")]
-    System {
-        subtype: Option<String>,
-        session_id: Option<String>,
-        model: Option<String>,
-    },
-    #[serde(rename = "assistant")]
-    Assistant {
-        message: CodebuddyMessageContent,
-        #[serde(default)]
-        parent_tool_use_id: Option<String>,
-        session_id: Option<String>,
-        uuid: Option<String>,
-    },
-    #[serde(rename = "user")]
-    User {
-        message: CodebuddyMessageContent,
-        #[serde(default)]
-        parent_tool_use_id: Option<String>,
-        session_id: Option<String>,
-        uuid: Option<String>,
-    },
-    #[serde(rename = "result")]
-    Result {
-        subtype: Option<String>,
-        is_error: bool,
-        duration_ms: Option<u64>,
-        result: Option<String>,
-        total_cost_usd: Option<f64>,
-        #[serde(default)]
-        usage: Option<CodebuddyUsage>,
-        session_id: Option<String>,
-    },
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct CodebuddyMessageContent {
-    id: Option<String>,
-    #[serde(rename = "type")]
-    content_type: Option<String>,
-    role: Option<String>,
-    #[serde(default)]
-    content: Vec<CodebuddyContentBlock>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type")]
-enum CodebuddyContentBlock {
-    #[serde(rename = "thinking")]
-    Thinking { thinking: Option<String> },
-    #[serde(rename = "text")]
-    Text { text: Option<String> },
-    #[serde(rename = "tool_use")]
-    ToolUse {
-        id: Option<String>,
-        name: Option<String>,
-        input: serde_json::Value,
-    },
-    #[serde(rename = "tool_result")]
-    ToolResult {
-        tool_use_id: Option<String>,
-        content: Option<String>,
-        is_error: Option<bool>,
-    },
-    #[serde(rename = "redacted")]
-    Redacted { redacted: Option<String> },
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct CodebuddyUsage {
-    input_tokens: u64,
-    output_tokens: u64,
-    cache_read_input_tokens: Option<u64>,
-    cache_creation_input_tokens: Option<u64>,
 }
 
 impl CodeExecutor for CodebuddyExecutor {
@@ -124,11 +46,11 @@ impl CodeExecutor for CodebuddyExecutor {
             return None;
         }
 
-        if let Ok(msg) = serde_json::from_str::<CodebuddyMessage>(line) {
+        if let Ok(msg) = serde_json::from_str::<ClaudeMessage>(line) {
             return match msg {
-                CodebuddyMessage::System { subtype, session_id, model } => {
+                ClaudeMessage::System { subtype, session_id, model } => {
                     if let Some(m) = model {
-                        *self.model.lock().unwrap() = Some(m.clone());
+                        *self.model.lock() = Some(m.clone());
                     }
                     Some(ParsedLogEntry {
                         timestamp: utc_timestamp(),
@@ -137,29 +59,29 @@ impl CodeExecutor for CodebuddyExecutor {
                         usage: None,
                     })
                 }
-                CodebuddyMessage::Assistant { message, .. } => {
+                ClaudeMessage::Assistant { message, .. } => {
                     let mut parts = Vec::new();
                     for block in message.content {
                         match block {
-                            CodebuddyContentBlock::Thinking { thinking } => {
+                            ClaudeContentBlock::Thinking { thinking } => {
                                 if let Some(t) = thinking {
                                     parts.push(format!("[thinking] {}", t.chars().take(200).collect::<String>()));
                                 }
                             }
-                            CodebuddyContentBlock::Text { text } => {
+                            ClaudeContentBlock::Text { text } => {
                                 if let Some(t) = text {
                                     parts.push(t);
                                 }
                             }
-                            CodebuddyContentBlock::ToolUse { name, input, .. } => {
+                            ClaudeContentBlock::ToolUse { name, input, .. } => {
                                 let input_str = serde_json::to_string(&input).unwrap_or_default();
                                 parts.push(format!("[tool] {}: {}", name.unwrap_or_default(), input_str.chars().take(100).collect::<String>()));
                             }
-                            CodebuddyContentBlock::ToolResult { content, is_error, .. } => {
+                            ClaudeContentBlock::ToolResult { content, is_error, .. } => {
                                 let err_str = if is_error.unwrap_or(false) { "[error] " } else { "" };
                                 parts.push(format!("{}{}", err_str, content.unwrap_or_default().chars().take(100).collect::<String>()));
                             }
-                            CodebuddyContentBlock::Redacted { redacted } => {
+                            ClaudeContentBlock::Redacted { redacted } => {
                                 parts.push(format!("[redacted] {}", redacted.unwrap_or_default()));
                             }
                         }
@@ -175,10 +97,10 @@ impl CodeExecutor for CodebuddyExecutor {
                         })
                     }
                 }
-                CodebuddyMessage::User { message, .. } => {
+                ClaudeMessage::User { message, .. } => {
                     let mut parts = Vec::new();
                     for block in message.content {
-                        if let CodebuddyContentBlock::ToolResult { content, is_error, .. } = block {
+                        if let ClaudeContentBlock::ToolResult { content, is_error, .. } = block {
                             let err_str = if is_error.unwrap_or(false) { "[error] " } else { "" };
                             parts.push(format!("{}{}", err_str, content.unwrap_or_default()));
                         }
@@ -194,7 +116,7 @@ impl CodeExecutor for CodebuddyExecutor {
                         })
                     }
                 }
-                CodebuddyMessage::Result { result, is_error, duration_ms, total_cost_usd, usage, .. } => {
+                ClaudeMessage::Result { result, is_error, duration_ms, total_cost_usd, usage, .. } => {
                     let err_str = if is_error { "[error] " } else { "" };
                     let result_str = result.unwrap_or_default();
 
@@ -230,7 +152,7 @@ impl CodeExecutor for CodebuddyExecutor {
     }
 
     fn get_model(&self) -> Option<String> {
-        self.model.lock().unwrap().clone()
+        self.model.lock().clone()
     }
 }
 

--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -1,4 +1,5 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use parking_lot::Mutex;
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
 use crate::models::utc_timestamp;
@@ -113,7 +114,7 @@ impl CodeExecutor for HermesExecutor {
     }
 
     fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
-        self.usage.lock().unwrap().clone()
+        self.usage.lock().clone()
     }
 
     fn get_model(&self) -> Option<String> {

--- a/backend/src/adapters/joinai.rs
+++ b/backend/src/adapters/joinai.rs
@@ -1,7 +1,8 @@
-use serde::Deserialize;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use parking_lot::Mutex;
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
+use super::agent_event::{AgentEvent, AgentPart, AgentToolState, AgentTokens};
 use crate::models::utc_timestamp;
 
 pub struct JoinaiExecutor {
@@ -19,74 +20,6 @@ impl Clone for JoinaiExecutor {
     fn clone(&self) -> Self {
         Self { path: self.path.clone(), usage: self.usage.clone() }
     }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct JoinaiEvent {
-    #[serde(rename = "type")]
-    event_type: String,
-    #[serde(default)]
-    part: Option<JoinaiPart>,
-    timestamp: Option<u64>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct JoinaiPart {
-    #[serde(rename = "type")]
-    part_type: String,
-    #[serde(default)]
-    text: Option<String>,
-    #[serde(default)]
-    tool: Option<String>,
-    #[serde(default)]
-    call_id: Option<String>,
-    #[serde(default)]
-    state: Option<JoinaiToolState>,
-    message_id: Option<String>,
-    session_id: Option<String>,
-    #[serde(default)]
-    tokens: Option<JoinaiTokens>,
-    #[serde(default)]
-    cost: Option<f64>,
-    #[serde(default)]
-    reason: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct JoinaiToolState {
-    #[serde(default)]
-    status: Option<String>,
-    #[serde(default)]
-    input: Option<JoinaiToolInput>,
-    #[serde(default)]
-    output: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct JoinaiToolInput {
-    #[serde(default)]
-    command: Option<String>,
-    #[serde(default)]
-    description: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct JoinaiTokens {
-    total: u64,
-    input: u64,
-    output: u64,
-    #[serde(default)]
-    reasoning: u64,
-    #[serde(default)]
-    cache: JoinaiCacheTokens,
-}
-
-#[derive(Debug, Clone, Deserialize, Default)]
-struct JoinaiCacheTokens {
-    #[serde(default)]
-    read: u64,
-    #[serde(default)]
-    write: u64,
 }
 
 impl CodeExecutor for JoinaiExecutor {
@@ -108,7 +41,7 @@ impl CodeExecutor for JoinaiExecutor {
     }
 
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
-        let event: JoinaiEvent = serde_json::from_str(line).ok()?;
+        let event: AgentEvent = serde_json::from_str(line).ok()?;
 
         let timestamp = event.timestamp
             .map(|ts| {
@@ -174,7 +107,7 @@ impl CodeExecutor for JoinaiExecutor {
                             total_cost_usd: part.cost,
                             duration_ms: None,
                         };
-                        *self.usage.lock().unwrap() = Some(usage);
+                        *self.usage.lock() = Some(usage);
                     }
                 }
                 Some(ParsedLogEntry {
@@ -193,7 +126,7 @@ impl CodeExecutor for JoinaiExecutor {
     }
 
     fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
-        self.usage.lock().unwrap().clone()
+        self.usage.lock().clone()
     }
 
     fn get_model(&self) -> Option<String> {

--- a/backend/src/adapters/joinai.rs
+++ b/backend/src/adapters/joinai.rs
@@ -53,6 +53,7 @@ impl CodeExecutor for JoinaiExecutor {
 
         match event.event_type.as_str() {
             "step_start" => {
+                *self.usage.lock() = None;
                 Some(ParsedLogEntry {
                     timestamp,
                     log_type: "step_start".to_string(),

--- a/backend/src/adapters/kimi.rs
+++ b/backend/src/adapters/kimi.rs
@@ -1,4 +1,5 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use parking_lot::Mutex;
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
 use crate::models::utc_timestamp;
@@ -186,7 +187,7 @@ impl CodeExecutor for KimiExecutor {
     }
 
     fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
-        self.usage.lock().unwrap().clone()
+        self.usage.lock().clone()
     }
 
     fn get_model(&self) -> Option<String> {

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -51,6 +51,8 @@ pub fn get_usage_from_logs(logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
 }
 
 pub mod joinai;
+pub mod claude_protocol;
+pub mod agent_event;
 pub mod claude_code;
 pub mod codebuddy;
 pub mod opencode;

--- a/backend/src/adapters/opencode.rs
+++ b/backend/src/adapters/opencode.rs
@@ -1,7 +1,8 @@
-use serde::Deserialize;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use parking_lot::Mutex;
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
+use super::agent_event::{AgentEvent, AgentPart, AgentToolState, AgentTokens};
 use crate::models::utc_timestamp;
 
 pub struct OpencodeExecutor {
@@ -31,81 +32,6 @@ impl Clone for OpencodeExecutor {
             has_successful_finish: self.has_successful_finish.clone(),
         }
     }
-}
-
-
-#[derive(Debug, Clone, Deserialize)]
-struct OpencodeEvent {
-    #[serde(rename = "type")]
-    event_type: String,
-    timestamp: u64,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    part: Option<OpencodePart>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct OpencodePart {
-    #[serde(rename = "type")]
-    part_type: Option<String>,
-    #[serde(default)]
-    id: Option<String>,
-    #[serde(default)]
-    message_id: Option<String>,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    text: Option<String>,
-    #[serde(default)]
-    tool: Option<String>,
-    #[serde(default)]
-    call_id: Option<String>,
-    #[serde(default)]
-    state: Option<OpencodeToolState>,
-    #[serde(default)]
-    reason: Option<String>,
-    #[serde(default)]
-    tokens: Option<OpencodeTokens>,
-    #[serde(default)]
-    cost: Option<f64>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct OpencodeToolState {
-    #[serde(default)]
-    status: Option<String>,
-    #[serde(default)]
-    input: Option<OpencodeToolInput>,
-    #[serde(default)]
-    output: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct OpencodeToolInput {
-    #[serde(default)]
-    command: Option<String>,
-    #[serde(default)]
-    description: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct OpencodeTokens {
-    total: u64,
-    input: u64,
-    output: u64,
-    #[serde(default)]
-    reasoning: u64,
-    #[serde(default)]
-    cache: OpencodeCacheTokens,
-}
-
-#[derive(Debug, Clone, Deserialize, Default)]
-struct OpencodeCacheTokens {
-    #[serde(default)]
-    read: u64,
-    #[serde(default)]
-    write: u64,
 }
 
 impl CodeExecutor for OpencodeExecutor {
@@ -143,9 +69,10 @@ impl CodeExecutor for OpencodeExecutor {
     }
 
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
-        let event: OpencodeEvent = serde_json::from_str(line).ok()?;
+        let event: AgentEvent = serde_json::from_str(line).ok()?;
 
-        let timestamp = chrono::DateTime::from_timestamp_millis(event.timestamp as i64)
+        let timestamp = event.timestamp
+            .and_then(|ts| chrono::DateTime::from_timestamp_millis(ts as i64))
             .map(|dt| dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
             .unwrap_or_else(utc_timestamp);
 
@@ -197,7 +124,7 @@ impl CodeExecutor for OpencodeExecutor {
             "step_finish" => {
                 // Mark as successfully finished — opencode returns non-zero exit code
                 // even on successful execution, so we track success via the event stream.
-                *self.has_successful_finish.lock().unwrap() = true;
+                *self.has_successful_finish.lock() = true;
 
                 // Store usage info if available
                 if let Some(part) = &event.part {
@@ -210,7 +137,7 @@ impl CodeExecutor for OpencodeExecutor {
                             total_cost_usd: part.cost,
                             duration_ms: None,
                         };
-                        *self.usage.lock().unwrap() = Some(usage);
+                        *self.usage.lock() = Some(usage);
                     }
                 }
                 Some(ParsedLogEntry {
@@ -229,11 +156,11 @@ impl CodeExecutor for OpencodeExecutor {
     }
 
     fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
-        self.usage.lock().unwrap().clone()
+        self.usage.lock().clone()
     }
 
     fn get_model(&self) -> Option<String> {
-        self.model.lock().unwrap().clone()
+        self.model.lock().clone()
     }
 
     fn check_success(&self, exit_code: i32) -> bool {
@@ -242,7 +169,7 @@ impl CodeExecutor for OpencodeExecutor {
         }
         // opencode returns non-zero exit codes (e.g. 144) even on successful execution.
         // Trust the presence of a step_finish event in the output stream.
-        *self.has_successful_finish.lock().unwrap()
+        *self.has_successful_finish.lock()
     }
 }
 

--- a/backend/src/adapters/opencode.rs
+++ b/backend/src/adapters/opencode.rs
@@ -78,6 +78,8 @@ impl CodeExecutor for OpencodeExecutor {
 
         match event.event_type.as_str() {
             "step_start" => {
+                *self.has_successful_finish.lock() = false;
+                *self.usage.lock() = None;
                 Some(ParsedLogEntry {
                     timestamp,
                     log_type: "step_start".to_string(),

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -6,6 +6,30 @@ use crate::db::Database;
 use crate::db::entity::execution_records;
 use crate::models::{ExecutionRecord, ExecutionSummary, ExecutionUsage};
 
+impl From<execution_records::Model> for ExecutionRecord {
+    fn from(m: execution_records::Model) -> Self {
+        let usage = m.usage.as_deref().and_then(|u| serde_json::from_str(u).ok());
+        ExecutionRecord {
+            id: m.id,
+            todo_id: m.todo_id.unwrap_or(0),
+            status: m.status.unwrap_or_default(),
+            command: m.command.unwrap_or_default(),
+            stdout: m.stdout.unwrap_or_default(),
+            stderr: m.stderr.unwrap_or_default(),
+            logs: m.logs.unwrap_or_default(),
+            result: m.result,
+            started_at: m.started_at.unwrap_or_default(),
+            finished_at: m.finished_at,
+            usage,
+            executor: m.executor,
+            model: m.model,
+            trigger_type: m.trigger_type.unwrap_or_else(|| "manual".to_string()),
+            pid: m.pid,
+            task_id: m.task_id,
+        }
+    }
+}
+
 impl Database {
     pub async fn get_execution_records(
         &self,
@@ -31,30 +55,7 @@ impl Database {
             .await
             .unwrap_or_default()
             .into_iter()
-            .map(|m| {
-                let usage = m
-                    .usage
-                    .as_deref()
-                    .and_then(|u| serde_json::from_str(u).ok());
-                ExecutionRecord {
-                    id: m.id,
-                    todo_id: m.todo_id.unwrap_or(0),
-                    status: m.status.unwrap_or_default(),
-                    command: m.command.unwrap_or_default(),
-                    stdout: m.stdout.unwrap_or_default(),
-                    stderr: m.stderr.unwrap_or_default(),
-                    logs: m.logs.unwrap_or_default(),
-                    result: m.result,
-                    started_at: m.started_at.unwrap_or_default(),
-                    finished_at: m.finished_at,
-                    usage,
-                    executor: m.executor,
-                    model: m.model,
-                    trigger_type: m.trigger_type.unwrap_or_else(|| "manual".to_string()),
-                    pid: m.pid,
-                    task_id: m.task_id,
-                }
-            })
+            .map(Into::into)
             .collect();
 
         (records, total)
@@ -66,25 +67,7 @@ impl Database {
             .one(&self.conn)
             .await
             .ok()??;
-        let usage = m.usage.as_deref().and_then(|u| serde_json::from_str(u).ok());
-        Some(ExecutionRecord {
-            id: m.id,
-            todo_id: m.todo_id.unwrap_or(0),
-            status: m.status.unwrap_or_default(),
-            command: m.command.unwrap_or_default(),
-            stdout: m.stdout.unwrap_or_default(),
-            stderr: m.stderr.unwrap_or_default(),
-            logs: m.logs.unwrap_or_default(),
-            result: m.result,
-            started_at: m.started_at.unwrap_or_default(),
-            finished_at: m.finished_at,
-            usage,
-            executor: m.executor,
-            model: m.model,
-            trigger_type: m.trigger_type.unwrap_or_else(|| "manual".to_string()),
-            pid: m.pid,
-            task_id: m.task_id,
-        })
+        Some(m.into())
     }
 
     /// 根据 task_id 获取执行记录
@@ -94,25 +77,7 @@ impl Database {
             .one(&self.conn)
             .await
             .ok()??;
-        let usage = m.usage.as_deref().and_then(|u| serde_json::from_str(u).ok());
-        Some(ExecutionRecord {
-            id: m.id,
-            todo_id: m.todo_id.unwrap_or(0),
-            status: m.status.unwrap_or_default(),
-            command: m.command.unwrap_or_default(),
-            stdout: m.stdout.unwrap_or_default(),
-            stderr: m.stderr.unwrap_or_default(),
-            logs: m.logs.unwrap_or_default(),
-            result: m.result,
-            started_at: m.started_at.unwrap_or_default(),
-            finished_at: m.finished_at,
-            usage,
-            executor: m.executor,
-            model: m.model,
-            trigger_type: m.trigger_type.unwrap_or_else(|| "manual".to_string()),
-            pid: m.pid,
-            task_id: m.task_id,
-        })
+        Some(m.into())
     }
 
     pub async fn create_execution_record(
@@ -461,27 +426,7 @@ impl Database {
             .unwrap_or_default();
 
         let recent_executions: Vec<crate::models::ExecutionRecord> = recent_records.into_iter()
-            .map(|m| {
-                let usage = m.usage.as_deref().and_then(|u| serde_json::from_str(u).ok());
-                crate::models::ExecutionRecord {
-                    id: m.id,
-                    todo_id: m.todo_id.unwrap_or(0),
-                    status: m.status.unwrap_or_default(),
-                    command: m.command.unwrap_or_default(),
-                    stdout: m.stdout.unwrap_or_default(),
-                    stderr: m.stderr.unwrap_or_default(),
-                    logs: m.logs.unwrap_or_default(),
-                    result: m.result,
-                    started_at: m.started_at.unwrap_or_default(),
-                    finished_at: m.finished_at,
-                    usage,
-                    executor: m.executor,
-                    model: m.model,
-                    trigger_type: m.trigger_type.unwrap_or_else(|| "manual".to_string()),
-                    pid: m.pid,
-                    task_id: m.task_id,
-                }
-            })
+            .map(Into::into)
             .collect();
 
         crate::models::DashboardStats {
@@ -512,8 +457,7 @@ impl Database {
 
     pub async fn get_execution_summary(&self, todo_id: i64) -> ExecutionSummary {
         let backend = self.conn.get_database_backend();
-        let sql = format!(
-            "SELECT \
+        let sql = "SELECT \
                 COUNT(*) as total, \
                 COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
                 COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count, \
@@ -523,11 +467,9 @@ impl Database {
                 COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read, \
                 COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
                 COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as total_cost \
-                FROM execution_records WHERE todo_id = {}",
-            todo_id
-        );
+                FROM execution_records WHERE todo_id = $1";
 
-        if let Ok(Some(row)) = self.conn.query_one(Statement::from_string(backend, sql)).await {
+        if let Ok(Some(row)) = self.conn.query_one(Statement::from_sql_and_values(backend, sql, [todo_id.into()])).await {
             let total_executions: i64 = row.try_get_by("total").unwrap_or(0);
             let success_count: i64 = row.try_get_by("success_count").unwrap_or(0);
             let failed_count: i64 = row.try_get_by("failed_count").unwrap_or(0);
@@ -571,11 +513,9 @@ impl Database {
     pub async fn cleanup_orphan_execution_records(&self) {
         let now = crate::models::utc_timestamp();
         let backend = self.conn.get_database_backend();
-        // Single UPDATE: mark running records as failed where todo is missing or has no task_id
-        let sql = format!(
-            "UPDATE execution_records SET \
+        let sql = "UPDATE execution_records SET \
                 status = 'failed', \
-                finished_at = '{}', \
+                finished_at = $1, \
                 result = CASE \
                     WHEN todo_id NOT IN (SELECT id FROM todos) THEN '任务已被删除' \
                     ELSE '程序崩溃，任务被中断' \
@@ -583,10 +523,8 @@ impl Database {
                 WHERE status = 'running' AND ( \
                     todo_id NOT IN (SELECT id FROM todos) \
                     OR todo_id IN (SELECT id FROM todos WHERE task_id IS NULL) \
-                )",
-            now
-        );
-        if let Err(e) = self.conn.execute(Statement::from_string(backend, sql)).await {
+                )";
+        if let Err(e) = self.conn.execute(Statement::from_sql_and_values(backend, sql, [now.into()])).await {
             tracing::error!("Failed to cleanup orphan execution records: {}", e);
         }
     }
@@ -595,15 +533,12 @@ impl Database {
     pub async fn mark_execution_records_as_failed(&self, todo_id: i64) {
         let now = crate::models::utc_timestamp();
         let backend = self.conn.get_database_backend();
-        let sql = format!(
-            "UPDATE execution_records SET \
+        let sql = "UPDATE execution_records SET \
                 status = 'failed', \
-                finished_at = '{}', \
+                finished_at = $1, \
                 result = '任务已被手动停止' \
-                WHERE todo_id = {} AND status = 'running'",
-            now, todo_id
-        );
-        let result = self.conn.execute(Statement::from_string(backend, sql)).await;
+                WHERE todo_id = $2 AND status = 'running'";
+        let result = self.conn.execute(Statement::from_sql_and_values(backend, sql, [now.into(), todo_id.into()])).await;
         match result {
             Ok(res) => {
                 let rows = res.rows_affected();

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -88,6 +88,7 @@ pub async fn run_todo_execution(
         None => {
             tracing::error!("No executor available for type {:?} and no default registered", executor_type);
             let _ = db.finish_todo_execution(todo_id, false).await;
+            send_event(&tx, ExecEvent::Finished { task_id: task_id.clone(), todo_id, success: false, result: Some("No executor available".to_string()) });
             task_manager.remove(&task_id).await;
             return task_id;
         }

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -82,8 +82,16 @@ pub async fn run_todo_execution(
         })
         .unwrap_or_default();
 
-    let executor = executor_registry.get(executor_type)
-        .unwrap_or_else(|| executor_registry.get_default().unwrap());
+    let executor = match executor_registry.get(executor_type)
+        .or_else(|| executor_registry.get_default()) {
+        Some(exec) => exec,
+        None => {
+            tracing::error!("No executor available for type {:?} and no default registered", executor_type);
+            let _ = db.finish_todo_execution(todo_id, false).await;
+            task_manager.remove(&task_id).await;
+            return task_id;
+        }
+    };
 
     let executable_path = executor.executable_path().to_string();
     let command_args = executor.command_args_with_session(&message, Some(&task_id));
@@ -187,8 +195,6 @@ pub async fn run_todo_execution(
         let stdout_task = if let Some(stdout_reader) = stdout_handle {
             let tx_clone = tx.clone();
             let tid = task_id.clone();
-            let db_clone2 = db_clone.clone();
-            let rid = record_id;
             let executor_clone = executor_for_parse.clone();
             let logs_for_db = logs_for_db.clone();
 
@@ -198,9 +204,6 @@ pub async fn run_todo_execution(
                     if let Some(parsed) = executor_clone.parse_output_line(&line) {
                         logs_for_db.lock().await.push(parsed.clone());
                         send_event(&tx_clone, ExecEvent::Output { task_id: tid.clone(), entry: parsed });
-
-                        let logs_json = serde_json::to_string(&*logs_for_db.lock().await).unwrap_or_default();
-                        let _ = db_clone2.update_execution_record(rid, crate::models::ExecutionStatus::Running.as_str(), &logs_json, "", None, None).await;
                     }
                 }
             }))


### PR DESCRIPTION
## Summary

- **P0 SQL 注入风险**: `db/execution.rs` 3处 `format!` 拼接 SQL 改为 `Statement::from_sql_and_values` 参数化查询
- **P0 生产环境 panic**: `executor_service.rs` 的 `get_default().unwrap()` 改为优雅错误处理，返回 early 而非崩溃
- **P0 重复映射代码**: 新增 `From<execution_records::Model>` 实现，4处 18 字段映射合并为 `.map(Into::into)`
- **P1 O(n²) 性能**: 移除 executor_service 每行日志的 DB 写入，保留最终写入即可
- **P1 claude_code/codebuddy 重复**: 提取 `claude_protocol.rs` 共享类型（ClaudeMessage、ClaudeContentBlock 等）
- **P1 joinai/opencode 重复**: 提取 `agent_event.rs` 共享类型（AgentEvent、AgentPart 等）
- **P1 Mutex 中毒风险**: 7个 adapter 的 `std::sync::Mutex` 替换为 `parking_lot::Mutex`（无中毒、无 unwrap）

## Changes

| 文件 | 变更 |
|------|------|
| `db/execution.rs` | 参数化查询 + From impl，-143 行 |
| `executor_service.rs` | 移除 unwrap + 移除逐行 DB 写入 |
| `adapters/claude_protocol.rs` | 新增 - 共享 Claude 协议类型 |
| `adapters/agent_event.rs` | 新增 - 共享 Agent 事件类型 |
| `adapters/*.rs` | 7个文件改用 parking_lot::Mutex，移除重复类型定义 |
| `Cargo.toml` | 新增 parking_lot 依赖 |

净减 **321 行**代码。

## Test plan

- [x] `cargo check` 通过
- [x] `cargo test --lib` 全部 166 个测试通过