### PR TITLE
feat: 任务执行面板支持全屏模式

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -832,6 +832,28 @@ code {
   height: 40px;
 }
 
+.execution-panel.fullscreen {
+  height: 100vh;
+  top: 0;
+  z-index: 1000;
+}
+
+.execution-panel.fullscreen .execution-panel-logs {
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 8px 16px;
+}
+
+.execution-panel.fullscreen .log-timestamp {
+  width: 64px;
+  font-size: 11px;
+}
+
+.execution-panel.fullscreen .log-type-badge {
+  font-size: 10px;
+  padding: 1px 4px;
+}
+
 .execution-panel-tabs {
   display: flex;
   align-items: center;

--- a/frontend/src/components/ExecutionPanel.tsx
+++ b/frontend/src/components/ExecutionPanel.tsx
@@ -1,4 +1,5 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
+import { ExpandOutlined, CompressOutlined } from '@ant-design/icons';
 import { useApp } from '../hooks/useApp';
 import { getExecutorOption } from '../types';
 
@@ -57,6 +58,7 @@ export function ExecutionPanel({ collapsed, onToggleCollapse }: ExecutionPanelPr
   const { state, dispatch } = useApp();
   const { runningTasks, activeTaskId } = state;
   const logsEndRef = useRef<HTMLDivElement>(null);
+  const [fullscreen, setFullscreen] = useState(false);
 
   const taskIds = Object.keys(runningTasks);
   const activeTask = activeTaskId ? runningTasks[activeTaskId] : null;
@@ -85,7 +87,7 @@ export function ExecutionPanel({ collapsed, onToggleCollapse }: ExecutionPanelPr
   if (taskIds.length === 0) return null;
 
   return (
-    <div className={`execution-panel ${collapsed ? 'collapsed' : ''}`}>
+    <div className={`execution-panel ${collapsed ? 'collapsed' : ''} ${fullscreen ? 'fullscreen' : ''}`}>
       {/* Tab Bar */}
       <div className="execution-panel-tabs">
         <div className="execution-panel-tabs-scroll">
@@ -123,7 +125,25 @@ export function ExecutionPanel({ collapsed, onToggleCollapse }: ExecutionPanelPr
           <span className="task-count">{taskIds.length} 个任务</span>
           <button
             className="panel-toggle-btn"
-            onClick={onToggleCollapse}
+            onClick={() => {
+              if (fullscreen) {
+                setFullscreen(false);
+              } else {
+                setFullscreen(true);
+                if (collapsed) onToggleCollapse();
+              }
+            }}
+            aria-label={fullscreen ? '退出全屏' : '全屏'}
+            title={fullscreen ? '退出全屏' : '全屏'}
+          >
+            {fullscreen ? <CompressOutlined /> : <ExpandOutlined />}
+          </button>
+          <button
+            className="panel-toggle-btn"
+            onClick={() => {
+              if (fullscreen) setFullscreen(false);
+              onToggleCollapse();
+            }}
             aria-label={collapsed ? '展开' : '收起'}
           >
             {collapsed ? '▲' : '▼'}


### PR DESCRIPTION
## Summary
- 在执行面板右上角新增全屏按钮（展开/收起图标），点击后面板覆盖整个浏览器窗口
- 全屏模式下日志区域字体和行距适当增大，提升可读性
- 支持全屏与收起/展开状态的独立切换

## Test plan
- [ ] 有运行中任务时，执行面板右上角出现全屏按钮
- [ ] 点击全屏按钮后面板覆盖整个浏览器窗口
- [ ] 全屏模式下点击退出全屏按钮恢复正常底部面板
- [ ] 全屏模式下点击收起按钮自动退出全屏并收起面板