### PR TITLE
fix: 修复多个执行记录同时运行时实时日志串台

### DIFF
--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -89,16 +89,25 @@ export function TodoDetail() {
     ? records.find(r => r.id === selectedHistoryRecordId) || null
     : null;
 
-  // Check if current todo is running in the global panel
-  const currentRunningTask = Object.values(runningTasks).find(
-    t => t.todoId === selectedTodoId
+  // Check if current todo is executing (has any running task)
+  const isExecuting = Object.values(runningTasks).some(
+    t => t.todoId === selectedTodoId && t.status === 'running'
   );
-  const isExecuting = !!currentRunningTask && currentRunningTask.status === 'running';
+
+  // Find the running task that matches a specific execution record by task_id
+  const getRunningTaskForRecord = (record: ExecutionRecord) => {
+    if (record.task_id) {
+      return runningTasks[record.task_id] || null;
+    }
+    // Fallback: match by todoId for records without task_id
+    return Object.values(runningTasks).find(t => t.todoId === record.todo_id) || null;
+  };
 
   // Helper to resolve todo progress from record or running task
   const resolveTodoProgress = (record: ExecutionRecord, isRunning: boolean): TodoItem[] | null => {
-    if (isRunning && currentRunningTask?.todoProgress?.length) {
-      return currentRunningTask.todoProgress;
+    if (isRunning) {
+      const task = getRunningTaskForRecord(record);
+      if (task?.todoProgress?.length) return task.todoProgress;
     }
     if (record.todo_progress) {
       try {
@@ -113,8 +122,9 @@ export function TodoDetail() {
 
   // Helper to resolve execution stats from record or running task
   const resolveExecutionStats = (record: ExecutionRecord, isRunning: boolean) => {
-    if (isRunning && currentRunningTask?.executionStats) {
-      return currentRunningTask.executionStats;
+    if (isRunning) {
+      const task = getRunningTaskForRecord(record);
+      if (task?.executionStats) return task.executionStats;
     }
     return record.execution_stats;
   };
@@ -556,7 +566,8 @@ export function TodoDetail() {
               {selectedHistoryRecord ? (() => {
                 const record = selectedHistoryRecord;
                 const isRunning = record.status === 'running';
-                const liveLogs = isRunning && currentRunningTask ? currentRunningTask.logs : null;
+                const runningTask = isRunning ? getRunningTaskForRecord(record) : null;
+                const liveLogs = runningTask ? runningTask.logs : null;
                 const restLogs: Array<{ timestamp?: string; type?: string; content?: string }> = (() => {
                   try { return record.logs && record.logs !== '[]' ? JSON.parse(record.logs) : []; }
                   catch { return []; }
@@ -830,7 +841,8 @@ export function TodoDetail() {
 
                 {(() => {
                   const isRunning = record.status === 'running';
-                  const liveLogs = isRunning && currentRunningTask ? currentRunningTask.logs : null;
+                  const runningTask = isRunning ? getRunningTaskForRecord(record) : null;
+                const liveLogs = runningTask ? runningTask.logs : null;
                   const restLogs: Array<{ timestamp?: string; type?: string; content?: string }> = (() => {
                     try { return record.logs && record.logs !== '[]' ? JSON.parse(record.logs) : []; }
                     catch { return []; }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -55,6 +55,7 @@ export interface ExecutionRecord {
   model: string | null;
   trigger_type: string;
   pid: number | null;
+  task_id?: string | null;
   todo_progress?: string | null;
   execution_stats?: ExecutionStats | null;
 }


### PR DESCRIPTION
## Summary
- 修复多个执行记录同时处于 running 状态时，点击切换执行记录，右侧实时日志始终显示同一个任务的问题
- 根因：`TodoDetail` 通过 `todoId` 匹配 running task，多个并发执行只能匹配到第一个
- 修复：利用 execution record 的 `task_id` 精确关联对应的 running task，每条记录独立查找

## Changes
- `frontend/src/types/index.ts` — `ExecutionRecord` 增加 `task_id` 字段
- `frontend/src/components/TodoDetail.tsx` — 用 `getRunningTaskForRecord(record)` 按 `task_id` 精确匹配，替代全局 `currentRunningTask`

## Test plan
- [ ] 同时执行多个任务，在执行历史中点击切换不同 running 记录，验证实时日志不串台
- [ ] 执行完成后点击历史记录，验证日志显示正确