### PR TITLE
fix(executor): 添加执行超时机制和修复运行时间统计

### DIFF
--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -175,6 +175,10 @@ pub async fn run_todo_execution(
 
         let child_id = child.id().unwrap_or(0);
 
+        // Close stdin immediately so child processes get EOF when they try to read it.
+        // Without this, processes that read stdin after finishing work will hang forever.
+        drop(child.stdin.take());
+
         #[cfg(unix)]
         {
             // 在 spawn 后立即设置进程组

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -317,18 +317,17 @@ pub async fn run_todo_execution(
                 return;
             }
             status = child.wait() => {
+                // Kill process group first to close any pipes held by grandchild processes,
+                // otherwise reader tasks may hang forever on BufReader::lines()
+                kill_process_group(child_id);
+                kill_processes_by_message(&message_clone);
+
                 if let Some(handle) = stdout_task {
                     let _ = handle.await;
                 }
                 if let Some(handle) = stderr_task {
                     let _ = handle.await;
                 }
-
-                // Clean up the process group to ensure no grandchild processes are left behind
-                kill_process_group(child_id);
-
-                // Also kill any orphaned child processes spawned by the executor
-                kill_processes_by_message(&message_clone);
 
                 status
             }

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -1,12 +1,8 @@
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::{broadcast, Mutex};
 use uuid::Uuid;
-
-/// Maximum execution time: 30 minutes
-const MAX_EXECUTION_DURATION: Duration = Duration::from_secs(30 * 60);
 
 use crate::adapters::{ExecutorRegistry, parse_executor_type};
 use crate::db::Database;
@@ -320,65 +316,21 @@ pub async fn run_todo_execution(
                 task_manager_spawn.remove(&task_id).await;
                 return;
             }
-            result = tokio::time::timeout(MAX_EXECUTION_DURATION, child.wait()) => {
-                match result {
-                    Ok(status) => {
-                        // Process completed within timeout
-                        if let Some(handle) = stdout_task {
-                            let _ = handle.await;
-                        }
-                        if let Some(handle) = stderr_task {
-                            let _ = handle.await;
-                        }
-
-                        // Clean up the process group to ensure no grandchild processes are left behind
-                        kill_process_group(child_id);
-
-                        // Also kill any orphaned child processes spawned by the executor
-                        kill_processes_by_message(&message_clone);
-
-                        status
-                    }
-                    Err(_) => {
-                        // Timeout: process exceeded maximum execution time
-                        tracing::warn!("Execution timed out after {:?} for todo {}, killing process", MAX_EXECUTION_DURATION, todo_id);
-
-                        // Kill the process group
-                        kill_process_group(child_id);
-                        let _ = child.kill().await;
-                        let _status = child.wait().await;
-
-                        if let Some(handle) = stdout_task {
-                            let _ = handle.await;
-                        }
-                        if let Some(handle) = stderr_task {
-                            let _ = handle.await;
-                        }
-
-                        // Also kill any orphaned child processes spawned by the executor
-                        kill_processes_by_message(&message_clone);
-
-                        // Mark as failed due to timeout
-                        let _ = db_clone.update_todo_status(todo_id, crate::models::TodoStatus::Failed).await;
-                        let _ = db_clone.update_todo_task_id(todo_id, None).await;
-
-                        let logs_json = serde_json::to_string(&*logs.lock().await).unwrap_or_default();
-                        let _ = db_clone.update_execution_record(
-                            record_id,
-                            crate::models::ExecutionStatus::Failed.as_str(),
-                            &logs_json,
-                            &format!("执行超时，已超过最大执行时间 {:?}", MAX_EXECUTION_DURATION),
-                            None,
-                            None,
-                        ).await;
-
-                        let entry = ParsedLogEntry::error(format!("Execution timed out after {:?}", MAX_EXECUTION_DURATION));
-                        send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
-                        send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, success: false, result: Some(format!("执行超时，已超过最大执行时间 {:?}", MAX_EXECUTION_DURATION)) });
-                        task_manager_spawn.remove(&task_id).await;
-                        return;
-                    }
+            status = child.wait() => {
+                if let Some(handle) = stdout_task {
+                    let _ = handle.await;
                 }
+                if let Some(handle) = stderr_task {
+                    let _ = handle.await;
+                }
+
+                // Clean up the process group to ensure no grandchild processes are left behind
+                kill_process_group(child_id);
+
+                // Also kill any orphaned child processes spawned by the executor
+                kill_processes_by_message(&message_clone);
+
+                status
             }
         };
 

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -1,13 +1,17 @@
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::{broadcast, Mutex};
 use uuid::Uuid;
 
+/// Maximum execution time: 30 minutes
+const MAX_EXECUTION_DURATION: Duration = Duration::from_secs(30 * 60);
+
 use crate::adapters::{ExecutorRegistry, parse_executor_type};
 use crate::db::Database;
 use crate::handlers::ExecEvent;
-use crate::models::{ParsedLogEntry, ExecutorType};
+use crate::models::ParsedLogEntry;
 use crate::task_manager::TaskManager;
 
 fn send_event(tx: &broadcast::Sender<ExecEvent>, event: ExecEvent) {
@@ -139,6 +143,8 @@ pub async fn run_todo_execution(
     }).await;
 
     tokio::spawn(async move {
+        let execution_start = std::time::Instant::now();
+
         send_event(&tx_clone, ExecEvent::Started { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string() });
 
         let entry = ParsedLogEntry::info(format!("Starting {}", executor_spawn.executor_type()));
@@ -310,21 +316,65 @@ pub async fn run_todo_execution(
                 task_manager_spawn.remove(&task_id).await;
                 return;
             }
-            status = child.wait() => {
-                if let Some(handle) = stdout_task {
-                    let _ = handle.await;
+            result = tokio::time::timeout(MAX_EXECUTION_DURATION, child.wait()) => {
+                match result {
+                    Ok(status) => {
+                        // Process completed within timeout
+                        if let Some(handle) = stdout_task {
+                            let _ = handle.await;
+                        }
+                        if let Some(handle) = stderr_task {
+                            let _ = handle.await;
+                        }
+
+                        // Clean up the process group to ensure no grandchild processes are left behind
+                        kill_process_group(child_id);
+
+                        // Also kill any orphaned child processes spawned by the executor
+                        kill_processes_by_message(&message_clone);
+
+                        status
+                    }
+                    Err(_) => {
+                        // Timeout: process exceeded maximum execution time
+                        tracing::warn!("Execution timed out after {:?} for todo {}, killing process", MAX_EXECUTION_DURATION, todo_id);
+
+                        // Kill the process group
+                        kill_process_group(child_id);
+                        let _ = child.kill().await;
+                        let _status = child.wait().await;
+
+                        if let Some(handle) = stdout_task {
+                            let _ = handle.await;
+                        }
+                        if let Some(handle) = stderr_task {
+                            let _ = handle.await;
+                        }
+
+                        // Also kill any orphaned child processes spawned by the executor
+                        kill_processes_by_message(&message_clone);
+
+                        // Mark as failed due to timeout
+                        let _ = db_clone.update_todo_status(todo_id, crate::models::TodoStatus::Failed).await;
+                        let _ = db_clone.update_todo_task_id(todo_id, None).await;
+
+                        let logs_json = serde_json::to_string(&*logs.lock().await).unwrap_or_default();
+                        let _ = db_clone.update_execution_record(
+                            record_id,
+                            crate::models::ExecutionStatus::Failed.as_str(),
+                            &logs_json,
+                            &format!("执行超时，已超过最大执行时间 {:?}", MAX_EXECUTION_DURATION),
+                            None,
+                            None,
+                        ).await;
+
+                        let entry = ParsedLogEntry::error(format!("Execution timed out after {:?}", MAX_EXECUTION_DURATION));
+                        send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
+                        send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, success: false, result: Some(format!("执行超时，已超过最大执行时间 {:?}", MAX_EXECUTION_DURATION)) });
+                        task_manager_spawn.remove(&task_id).await;
+                        return;
+                    }
                 }
-                if let Some(handle) = stderr_task {
-                    let _ = handle.await;
-                }
-
-                // Clean up the process group to ensure no grandchild processes are left behind
-                kill_process_group(child_id);
-
-                // Also kill any orphaned child processes spawned by the executor
-                kill_processes_by_message(&message_clone);
-
-                status
             }
         };
 
@@ -372,8 +422,29 @@ pub async fn run_todo_execution(
 
         let final_status = if success { crate::models::ExecutionStatus::Success.as_str() } else { crate::models::ExecutionStatus::Failed.as_str() };
         let logs_json = serde_json::to_string(&all_logs_snapshot).unwrap_or_default();
-        let usage = executor_spawn.get_usage(&all_logs_snapshot);
+        let mut usage = executor_spawn.get_usage(&all_logs_snapshot);
         let model = executor_spawn.get_model();
+
+        // Always use wall-clock duration (start to end of execution)
+        // This ensures duration is always available, regardless of executor support
+        let wall_clock_duration_ms = execution_start.elapsed().as_millis() as u64;
+        match usage.as_mut() {
+            Some(u) => {
+                // Override executor-reported duration with actual wall-clock time
+                u.duration_ms = Some(wall_clock_duration_ms);
+            }
+            None => {
+                usage = Some(crate::models::ExecutionUsage {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    cache_read_input_tokens: None,
+                    cache_creation_input_tokens: None,
+                    total_cost_usd: None,
+                    duration_ms: Some(wall_clock_duration_ms),
+                });
+            }
+        }
+
         let _ = db_clone.update_execution_record(record_id, final_status, &logs_json, &result_str, usage.as_ref(), model.as_deref()).await;
 
         let _ = db_clone.finish_todo_execution(todo_id, success).await;


### PR DESCRIPTION
## Summary
- 添加30分钟执行超时机制，防止进程无限期卡在"处理中"状态
- 使用实际墙钟时间（start → end）作为运行时间，确保所有执行记录都有时间统计

## 问题描述
1. 长时间运行的进程有时会卡在"处理中"状态，即使内容已经完成（如看到RESULT输出）
2. 部分执行记录没有运行时间，因为依赖执行器自身报告的duration_ms，有些执行器不提供

## 修复方案
1. **超时机制**: 在`tokio::select!`中用`tokio::time::timeout`包装`child.wait()`，30分钟后自动终止进程并标记失败
2. **运行时间**: 在spawned task开始时记录`Instant::now()`，执行完成后计算wall-clock时间，覆盖`usage.duration_ms`

## 改动文件
- `backend/src/executor_service.rs`: 添加超时逻辑和wall-clock时间计算