### PR TITLE
feat: 添加对话视图模式

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -578,7 +578,8 @@ body {
 .chat-bubble-content {
   font-size: 14px;
   line-height: 1.6;
-  word-break: break-word;
+  overflow-wrap: anywhere;
+  word-break: normal;
 }
 
 .chat-bubble-content p {
@@ -804,7 +805,7 @@ body {
   height: 8px;
   border-radius: 50%;
   background: var(--color-text-tertiary);
-  animation: typingBounce 1.4s infinite ease-in-out;
+  animation: typing-bounce 1.4s infinite ease-in-out;
 }
 
 .chat-typing-dot:nth-child(1) {
@@ -819,7 +820,7 @@ body {
   animation-delay: 0.4s;
 }
 
-@keyframes typingBounce {
+@keyframes typing-bounce {
   0%, 80%, 100% {
     transform: scale(0.6);
     opacity: 0.4;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -685,6 +685,16 @@ body {
   font-weight: 600;
 }
 
+.chat-tool-preview {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .chat-tool-toggle {
   margin-left: auto;
   font-size: 12px;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -19,6 +19,7 @@
   --color-error: #ef4444;
   --color-error-bg: #fef2f2;
   --color-info: #3b82f6;
+  --color-info-bg: #eff6ff;
 
   /* Neutrals */
   --color-bg: #f8fafc;
@@ -632,6 +633,10 @@ body {
   font-weight: 500;
   color: var(--color-text-secondary);
   user-select: none;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
 }
 
 .chat-thinking-header:hover {
@@ -673,6 +678,10 @@ body {
   font-weight: 500;
   color: var(--color-text-secondary);
   user-select: none;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
 }
 
 .chat-tool-header:hover {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -493,6 +493,368 @@ body {
   color: var(--color-error);
 }
 
+/* ---------- Chat View ---------- */
+.chat-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-md);
+  background: var(--color-bg);
+  border-radius: var(--radius-md);
+  min-height: 200px;
+}
+
+.chat-container::-webkit-scrollbar {
+  width: 6px;
+}
+
+.chat-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.chat-container::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: 3px;
+}
+
+.chat-messages {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+/* Chat Bubble */
+.chat-bubble-row {
+  display: flex;
+  gap: var(--space-sm);
+  max-width: 85%;
+}
+
+.chat-bubble-user {
+  align-self: flex-end;
+  flex-direction: row-reverse;
+}
+
+.chat-bubble-assistant {
+  align-self: flex-start;
+}
+
+.chat-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 14px;
+}
+
+.chat-bubble-user .chat-avatar {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.chat-bubble-assistant .chat-avatar {
+  background: var(--color-bg-elevated);
+  color: var(--color-primary);
+  border: 1px solid var(--color-border);
+}
+
+.chat-bubble {
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  box-shadow: var(--shadow-sm);
+  border: 1px solid var(--color-border-light);
+}
+
+.chat-bubble-user .chat-bubble {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
+}
+
+.chat-bubble-content {
+  font-size: 14px;
+  line-height: 1.6;
+  word-break: break-word;
+}
+
+.chat-bubble-content p {
+  margin: 0 0 8px;
+}
+
+.chat-bubble-content p:last-child {
+  margin-bottom: 0;
+}
+
+.chat-bubble-content pre {
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 6px;
+  padding: 8px 12px;
+  overflow-x: auto;
+  font-size: 12px;
+  margin: 8px 0;
+}
+
+.chat-bubble-user .chat-bubble-content pre {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.chat-bubble-time {
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  margin-top: var(--space-xs);
+  text-align: right;
+}
+
+.chat-bubble-user .chat-bubble-time {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+/* Thinking Block */
+.chat-thinking-block {
+  background: var(--color-warning-bg);
+  border: 1px solid rgba(245, 158, 11, 0.2);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  max-width: 85%;
+  align-self: flex-start;
+}
+
+.chat-thinking-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  user-select: none;
+}
+
+.chat-thinking-header:hover {
+  background: rgba(245, 158, 11, 0.05);
+}
+
+.chat-thinking-toggle {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--color-primary);
+}
+
+.chat-thinking-content {
+  padding: var(--space-sm) var(--space-md);
+  border-top: 1px solid rgba(245, 158, 11, 0.15);
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+/* Tool Block */
+.chat-tool-block {
+  background: var(--color-info-bg);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  max-width: 85%;
+  align-self: flex-start;
+}
+
+.chat-tool-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  user-select: none;
+}
+
+.chat-tool-header:hover {
+  background: rgba(59, 130, 246, 0.05);
+}
+
+.chat-tool-name {
+  font-family: var(--font-mono);
+  color: var(--color-info);
+  font-weight: 600;
+}
+
+.chat-tool-toggle {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--color-primary);
+}
+
+.chat-tool-content {
+  padding: var(--space-sm) var(--space-md);
+  border-top: 1px solid rgba(59, 130, 246, 0.15);
+}
+
+.chat-tool-section {
+  margin-bottom: var(--space-sm);
+}
+
+.chat-tool-section:last-child {
+  margin-bottom: 0;
+}
+
+.chat-tool-section-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  margin-bottom: var(--space-xs);
+  text-transform: uppercase;
+}
+
+.chat-tool-code {
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  overflow-x: auto;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* System Message */
+.chat-system-message {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-xs) var(--space-md);
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  align-self: center;
+  max-width: 90%;
+}
+
+.chat-time {
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  margin-left: auto;
+}
+
+/* Result Block */
+.chat-result-block {
+  background: var(--color-success-bg);
+  border: 1px solid rgba(34, 197, 94, 0.2);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  max-width: 90%;
+  align-self: flex-start;
+}
+
+.chat-result-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-success);
+}
+
+.chat-result-content {
+  padding: var(--space-sm) var(--space-md);
+  border-top: 1px solid rgba(34, 197, 94, 0.15);
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+/* Typing Indicator */
+.chat-typing-indicator {
+  display: flex;
+  gap: 4px;
+  padding: var(--space-sm) var(--space-md);
+  align-self: flex-start;
+}
+
+.chat-typing-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-text-tertiary);
+  animation: typingBounce 1.4s infinite ease-in-out;
+}
+
+.chat-typing-dot:nth-child(1) {
+  animation-delay: 0s;
+}
+
+.chat-typing-dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.chat-typing-dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes typingBounce {
+  0%, 80%, 100% {
+    transform: scale(0.6);
+    opacity: 0.4;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+/* Empty State */
+.chat-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  color: var(--color-text-tertiary);
+  font-size: 14px;
+}
+
+.chat-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+/* Mobile Responsive */
+@media (max-width: 767px) {
+  .chat-bubble-row {
+    max-width: 90%;
+  }
+
+  .chat-thinking-block,
+  .chat-tool-block,
+  .chat-result-block {
+    max-width: 90%;
+  }
+
+  .chat-avatar {
+    width: 28px;
+    height: 28px;
+    font-size: 12px;
+  }
+
+  .chat-bubble {
+    padding: var(--space-sm);
+  }
+
+  .chat-bubble-content {
+    font-size: 13px;
+  }
+}
+
 /* ---------- Input Styles ---------- */
 .card-input {
   border-radius: var(--radius-sm);

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -1,0 +1,266 @@
+import { useState, useRef, useEffect } from 'react';
+import { RobotOutlined, UserOutlined, ToolOutlined, BulbOutlined, CheckCircleOutlined, InfoCircleOutlined, LoadingOutlined } from '@ant-design/icons';
+import XMarkdown from '@ant-design/x-markdown';
+import type { LogEntry } from '../types';
+
+interface ChatViewProps {
+  logs: LogEntry[];
+  isRunning?: boolean;
+}
+
+interface ChatMessage {
+  role: 'user' | 'assistant' | 'system' | 'tool' | 'thinking' | 'result';
+  content: string;
+  timestamp?: string;
+  toolName?: string;
+  toolInput?: string;
+  toolResult?: string;
+  isCollapsed?: boolean;
+}
+
+function parseLogsToMessages(logs: LogEntry[]): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+  let currentThinking = '';
+  let currentToolName = '';
+  let currentToolInput = '';
+  let isCollectingTool = false;
+
+  for (const log of logs) {
+    switch (log.type) {
+      case 'user':
+        messages.push({ role: 'user', content: log.content, timestamp: log.timestamp });
+        break;
+      case 'assistant':
+        if (currentThinking) {
+          messages.push({ role: 'thinking', content: currentThinking, timestamp: log.timestamp, isCollapsed: true });
+          currentThinking = '';
+        }
+        if (isCollectingTool && currentToolName) {
+          messages.push({ role: 'tool', content: '', timestamp: log.timestamp, toolName: currentToolName, toolInput: currentToolInput, isCollapsed: true });
+          currentToolName = '';
+          currentToolInput = '';
+          isCollectingTool = false;
+        }
+        messages.push({ role: 'assistant', content: log.content, timestamp: log.timestamp });
+        break;
+      case 'thinking':
+        currentThinking += log.content + '\n';
+        break;
+      case 'tool':
+      case 'tool_use':
+      case 'tool_call':
+        if (currentThinking) {
+          messages.push({ role: 'thinking', content: currentThinking, timestamp: log.timestamp, isCollapsed: true });
+          currentThinking = '';
+        }
+        try {
+          const toolData = JSON.parse(log.content);
+          currentToolName = toolData.name || toolData.tool || '';
+          currentToolInput = toolData.input ? JSON.stringify(toolData.input, null, 2) : log.content;
+          isCollectingTool = true;
+        } catch {
+          currentToolName = log.content;
+          currentToolInput = '';
+          isCollectingTool = true;
+        }
+        break;
+      case 'tool_result':
+        if (isCollectingTool && currentToolName) {
+          messages.push({ role: 'tool', content: '', timestamp: log.timestamp, toolName: currentToolName, toolInput: currentToolInput, toolResult: log.content, isCollapsed: true });
+          currentToolName = '';
+          currentToolInput = '';
+          isCollectingTool = false;
+        } else {
+          messages.push({ role: 'tool', content: log.content, timestamp: log.timestamp, isCollapsed: true });
+        }
+        break;
+      case 'result':
+        if (currentThinking) {
+          messages.push({ role: 'thinking', content: currentThinking, timestamp: log.timestamp, isCollapsed: true });
+          currentThinking = '';
+        }
+        if (isCollectingTool && currentToolName) {
+          messages.push({ role: 'tool', content: '', timestamp: log.timestamp, toolName: currentToolName, toolInput: currentToolInput, isCollapsed: true });
+          currentToolName = '';
+          currentToolInput = '';
+          isCollectingTool = false;
+        }
+        messages.push({ role: 'result', content: log.content, timestamp: log.timestamp });
+        break;
+      case 'info':
+      case 'system':
+      case 'stdout':
+      case 'stderr':
+      case 'error':
+      case 'text':
+      case 'step_start':
+      case 'step_finish':
+      case 'tokens':
+        messages.push({ role: 'system', content: log.content, timestamp: log.timestamp });
+        break;
+    }
+  }
+
+  // Flush remaining
+  if (currentThinking) {
+    messages.push({ role: 'thinking', content: currentThinking });
+  }
+  if (isCollectingTool && currentToolName) {
+    messages.push({ role: 'tool', content: '', toolName: currentToolName, toolInput: currentToolInput });
+  }
+
+  return messages;
+}
+
+function formatTime(iso?: string): string {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
+  } catch {
+    return '';
+  }
+}
+
+function ThinkingBlock({ content, timestamp }: { content: string; timestamp?: string }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="chat-thinking-block">
+      <div className="chat-thinking-header" onClick={() => setExpanded(!expanded)}>
+        <BulbOutlined style={{ color: '#f59e0b' }} />
+        <span>思考过程</span>
+        <span className="chat-thinking-toggle">{expanded ? '收起' : '展开'}</span>
+        {timestamp && <span className="chat-time">{formatTime(timestamp)}</span>}
+      </div>
+      {expanded && (
+        <div className="chat-thinking-content">
+          <XMarkdown content={content} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ToolBlock({ toolName, toolInput, toolResult, timestamp }: { toolName?: string; toolInput?: string; toolResult?: string; timestamp?: string }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="chat-tool-block">
+      <div className="chat-tool-header" onClick={() => setExpanded(!expanded)}>
+        <ToolOutlined style={{ color: '#3b82f6' }} />
+        <span className="chat-tool-name">{toolName || '工具调用'}</span>
+        <span className="chat-tool-toggle">{expanded ? '收起' : '展开'}</span>
+        {timestamp && <span className="chat-time">{formatTime(timestamp)}</span>}
+      </div>
+      {expanded && (
+        <div className="chat-tool-content">
+          {toolInput && (
+            <div className="chat-tool-section">
+              <div className="chat-tool-section-label">输入参数</div>
+              <pre className="chat-tool-code">{toolInput}</pre>
+            </div>
+          )}
+          {toolResult && (
+            <div className="chat-tool-section">
+              <div className="chat-tool-section-label">执行结果</div>
+              <pre className="chat-tool-code">{toolResult}</pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChatBubble({ message }: { message: ChatMessage }) {
+  const { role, content, timestamp, toolName, toolInput, toolResult } = message;
+
+  if (role === 'thinking') {
+    return <ThinkingBlock content={content} timestamp={timestamp} />;
+  }
+
+  if (role === 'tool') {
+    return <ToolBlock toolName={toolName} toolInput={toolInput} toolResult={toolResult} timestamp={timestamp} />;
+  }
+
+  if (role === 'system') {
+    return (
+      <div className="chat-system-message">
+        <InfoCircleOutlined style={{ color: '#94a3b8', fontSize: 12 }} />
+        <span>{content}</span>
+        {timestamp && <span className="chat-time">{formatTime(timestamp)}</span>}
+      </div>
+    );
+  }
+
+  if (role === 'result') {
+    return (
+      <div className="chat-result-block">
+        <div className="chat-result-header">
+          <CheckCircleOutlined style={{ color: '#22c55e' }} />
+          <span>执行结果</span>
+          {timestamp && <span className="chat-time">{formatTime(timestamp)}</span>}
+        </div>
+        <div className="chat-result-content">
+          <XMarkdown content={content} />
+        </div>
+      </div>
+    );
+  }
+
+  const isUser = role === 'user';
+  return (
+    <div className={`chat-bubble-row ${isUser ? 'chat-bubble-user' : 'chat-bubble-assistant'}`}>
+      <div className="chat-avatar">
+        {isUser ? <UserOutlined /> : <RobotOutlined />}
+      </div>
+      <div className="chat-bubble">
+        <div className="chat-bubble-content">
+          <XMarkdown content={content} />
+        </div>
+        {timestamp && <div className="chat-bubble-time">{formatTime(timestamp)}</div>}
+      </div>
+    </div>
+  );
+}
+
+export function ChatView({ logs, isRunning }: ChatViewProps) {
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messages = parseLogsToMessages(logs);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages.length]);
+
+  if (messages.length === 0) {
+    return (
+      <div className="chat-empty">
+        {isRunning ? (
+          <div className="chat-loading">
+            <LoadingOutlined style={{ fontSize: 24, color: 'var(--color-primary)' }} />
+            <span>等待AI响应...</span>
+          </div>
+        ) : (
+          <span>暂无对话记录</span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="chat-container">
+      <div className="chat-messages">
+        {messages.map((msg, idx) => (
+          <ChatBubble key={idx} message={msg} />
+        ))}
+        {isRunning && (
+          <div className="chat-typing-indicator">
+            <div className="chat-typing-dot" />
+            <div className="chat-typing-dot" />
+            <div className="chat-typing-dot" />
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -49,8 +49,8 @@ function parseLogsToMessages(logs: LogEntry[]): ChatMessage[] {
       case 'tool':
       case 'tool_use':
       case 'tool_call':
-        if (isCollectingTool && currentToolName) {
-          messages.push({ role: 'tool', content: '', timestamp: log.timestamp, toolName: currentToolName, toolInput: currentToolInput, isCollapsed: true });
+        if (isCollectingTool && (currentToolName || currentToolInput)) {
+          messages.push({ role: 'tool', content: '', timestamp: log.timestamp, toolName: currentToolName || '工具调用', toolInput: currentToolInput, isCollapsed: true });
           currentToolName = '';
           currentToolInput = '';
           isCollectingTool = false;
@@ -61,23 +61,23 @@ function parseLogsToMessages(logs: LogEntry[]): ChatMessage[] {
         }
         try {
           const toolData = JSON.parse(log.content);
-          currentToolName = toolData.name || toolData.tool || '';
+          currentToolName = toolData.name || toolData.tool || '工具调用';
           currentToolInput = toolData.input ? JSON.stringify(toolData.input, null, 2) : log.content;
           isCollectingTool = true;
         } catch {
-          currentToolName = log.content;
-          currentToolInput = '';
+          currentToolName = '工具调用';
+          currentToolInput = log.content;
           isCollectingTool = true;
         }
         break;
       case 'tool_result':
-        if (isCollectingTool && currentToolName) {
-          messages.push({ role: 'tool', content: '', timestamp: log.timestamp, toolName: currentToolName, toolInput: currentToolInput, toolResult: log.content, isCollapsed: true });
+        if (isCollectingTool && (currentToolName || currentToolInput)) {
+          messages.push({ role: 'tool', content: '', timestamp: log.timestamp, toolName: currentToolName || '工具调用', toolInput: currentToolInput, toolResult: log.content, isCollapsed: true });
           currentToolName = '';
           currentToolInput = '';
           isCollectingTool = false;
         } else {
-          messages.push({ role: 'tool', content: log.content, timestamp: log.timestamp, isCollapsed: true });
+          messages.push({ role: 'tool', content: '', timestamp: log.timestamp, toolName: '工具调用', toolResult: log.content, isCollapsed: true });
         }
         break;
       case 'result':
@@ -85,8 +85,8 @@ function parseLogsToMessages(logs: LogEntry[]): ChatMessage[] {
           messages.push({ role: 'thinking', content: currentThinking, timestamp: log.timestamp, isCollapsed: true });
           currentThinking = '';
         }
-        if (isCollectingTool && currentToolName) {
-          messages.push({ role: 'tool', content: '', timestamp: log.timestamp, toolName: currentToolName, toolInput: currentToolInput, isCollapsed: true });
+        if (isCollectingTool && (currentToolName || currentToolInput)) {
+          messages.push({ role: 'tool', content: '', timestamp: log.timestamp, toolName: currentToolName || '工具调用', toolInput: currentToolInput, isCollapsed: true });
           currentToolName = '';
           currentToolInput = '';
           isCollectingTool = false;
@@ -111,8 +111,8 @@ function parseLogsToMessages(logs: LogEntry[]): ChatMessage[] {
   if (currentThinking) {
     messages.push({ role: 'thinking', content: currentThinking });
   }
-  if (isCollectingTool && currentToolName) {
-    messages.push({ role: 'tool', content: '', toolName: currentToolName, toolInput: currentToolInput });
+  if (isCollectingTool && (currentToolName || currentToolInput)) {
+    messages.push({ role: 'tool', content: '', toolName: currentToolName || '工具调用', toolInput: currentToolInput });
   }
 
   return messages;
@@ -122,6 +122,7 @@ function formatTime(iso?: string): string {
   if (!iso) return '';
   try {
     const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
     return d.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
   } catch {
     return '';

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState } from 'react';
 import { RobotOutlined, UserOutlined, ToolOutlined, BulbOutlined, CheckCircleOutlined, InfoCircleOutlined, LoadingOutlined } from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
 import type { LogEntry } from '../types';
@@ -258,21 +258,7 @@ function ChatBubble({ message }: { message: ChatMessage }) {
 }
 
 export function ChatView({ logs, isRunning }: ChatViewProps) {
-  const messagesEndRef = useRef<HTMLDivElement>(null);
   const messages = parseLogsToMessages(logs);
-  const isInitialMount = useRef(true);
-
-  useEffect(() => {
-    // 跳过初始挂载时的自动滚动
-    if (isInitialMount.current) {
-      isInitialMount.current = false;
-      return;
-    }
-    // 只在有新消息时才滚动到底部
-    if (messages.length > 0) {
-      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [messages.length]);
 
   if (messages.length === 0) {
     return (
@@ -302,7 +288,6 @@ export function ChatView({ logs, isRunning }: ChatViewProps) {
             <div className="chat-typing-dot" />
           </div>
         )}
-        <div ref={messagesEndRef} />
       </div>
     </div>
   );

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -143,11 +143,29 @@ function ThinkingBlock({ content, timestamp }: { content: string; timestamp?: st
 
 function ToolBlock({ toolName, toolInput, toolResult, timestamp }: { toolName?: string; toolInput?: string; toolResult?: string; timestamp?: string }) {
   const [expanded, setExpanded] = useState(false);
+
+  // 生成参数预览（截取前50个字符）
+  const getInputPreview = () => {
+    if (!toolInput) return '';
+    try {
+      const parsed = JSON.parse(toolInput);
+      const keys = Object.keys(parsed);
+      if (keys.length === 0) return '{}';
+      const preview = keys.map(k => `${k}: ${typeof parsed[k] === 'string' ? `"${parsed[k].substring(0, 20)}${parsed[k].length > 20 ? '...' : ''}"` : parsed[k]}`).join(', ');
+      return preview.length > 60 ? preview.substring(0, 60) + '...' : preview;
+    } catch {
+      return toolInput.length > 50 ? toolInput.substring(0, 50) + '...' : toolInput;
+    }
+  };
+
   return (
     <div className="chat-tool-block">
       <div className="chat-tool-header" onClick={() => setExpanded(!expanded)}>
         <ToolOutlined style={{ color: '#3b82f6' }} />
         <span className="chat-tool-name">{toolName || '工具调用'}</span>
+        {!expanded && toolInput && (
+          <span className="chat-tool-preview">{getInputPreview()}</span>
+        )}
         <span className="chat-tool-toggle">{expanded ? '收起' : '展开'}</span>
         {timestamp && <span className="chat-time">{formatTime(timestamp)}</span>}
       </div>

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -49,6 +49,12 @@ function parseLogsToMessages(logs: LogEntry[]): ChatMessage[] {
       case 'tool':
       case 'tool_use':
       case 'tool_call':
+        if (isCollectingTool && currentToolName) {
+          messages.push({ role: 'tool', content: '', timestamp: log.timestamp, toolName: currentToolName, toolInput: currentToolInput, isCollapsed: true });
+          currentToolName = '';
+          currentToolInput = '';
+          isCollectingTool = false;
+        }
         if (currentThinking) {
           messages.push({ role: 'thinking', content: currentThinking, timestamp: log.timestamp, isCollapsed: true });
           currentThinking = '';
@@ -126,12 +132,17 @@ function ThinkingBlock({ content, timestamp }: { content: string; timestamp?: st
   const [expanded, setExpanded] = useState(false);
   return (
     <div className="chat-thinking-block">
-      <div className="chat-thinking-header" onClick={() => setExpanded(!expanded)}>
+      <button
+        type="button"
+        className="chat-thinking-header"
+        aria-expanded={expanded}
+        onClick={() => setExpanded(!expanded)}
+      >
         <BulbOutlined style={{ color: '#f59e0b' }} />
         <span>思考过程</span>
         <span className="chat-thinking-toggle">{expanded ? '收起' : '展开'}</span>
         {timestamp && <span className="chat-time">{formatTime(timestamp)}</span>}
-      </div>
+      </button>
       {expanded && (
         <div className="chat-thinking-content">
           <XMarkdown content={content} />
@@ -160,7 +171,12 @@ function ToolBlock({ toolName, toolInput, toolResult, timestamp }: { toolName?: 
 
   return (
     <div className="chat-tool-block">
-      <div className="chat-tool-header" onClick={() => setExpanded(!expanded)}>
+      <button
+        type="button"
+        className="chat-tool-header"
+        aria-expanded={expanded}
+        onClick={() => setExpanded(!expanded)}
+      >
         <ToolOutlined style={{ color: '#3b82f6' }} />
         <span className="chat-tool-name">{toolName || '工具调用'}</span>
         {!expanded && toolInput && (
@@ -168,7 +184,7 @@ function ToolBlock({ toolName, toolInput, toolResult, timestamp }: { toolName?: 
         )}
         <span className="chat-tool-toggle">{expanded ? '收起' : '展开'}</span>
         {timestamp && <span className="chat-time">{formatTime(timestamp)}</span>}
-      </div>
+      </button>
       {expanded && (
         <div className="chat-tool-content">
           {toolInput && (

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -260,9 +260,18 @@ function ChatBubble({ message }: { message: ChatMessage }) {
 export function ChatView({ logs, isRunning }: ChatViewProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messages = parseLogsToMessages(logs);
+  const isInitialMount = useRef(true);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    // 跳过初始挂载时的自动滚动
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+    // 只在有新消息时才滚动到底部
+    if (messages.length > 0) {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
   }, [messages.length]);
 
   if (messages.length === 0) {

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1,17 +1,18 @@
 import { useEffect, useState } from 'react';
 import { useApp } from '../hooks/useApp';
-import { Button, Empty, App, Popconfirm, Tag, Badge, Pagination } from 'antd';
-import { PlayCircleOutlined, EditOutlined, DeleteOutlined, SettingOutlined, CheckCircleOutlined, ReloadOutlined, CopyOutlined, ArrowLeftOutlined, StopOutlined, DownOutlined, UpOutlined } from '@ant-design/icons';
+import { Button, Empty, App, Popconfirm, Tag, Badge, Pagination, Segmented } from 'antd';
+import { PlayCircleOutlined, EditOutlined, DeleteOutlined, SettingOutlined, CheckCircleOutlined, ReloadOutlined, CopyOutlined, ArrowLeftOutlined, StopOutlined, DownOutlined, UpOutlined, UnorderedListOutlined, MessageOutlined } from '@ant-design/icons';
 import { StatusPicker } from './StatusPicker';
 import { PieChart } from './PieChart';
 import { TodoSettingsDrawer } from './TodoSettingsDrawer';
 import { TodoEditDrawer } from './TodoEditDrawer';
+import { ChatView } from './ChatView';
 import * as db from '../utils/database';
 import { formatLocalDateTime } from '../utils/datetime';
 import { AnimatedNumber } from './AnimatedNumber';
 import { getExecutorOption } from '../types';
 import XMarkdown from '@ant-design/x-markdown';
-import type { ExecutionSummary, Todo, TodoItem, ExecutionRecord } from '../types';
+import type { ExecutionSummary, Todo, TodoItem, ExecutionRecord, LogEntry } from '../types';
 
 function PromptDisplay({ content }: { content: string }) {
   const [expanded, setExpanded] = useState(false);
@@ -190,6 +191,7 @@ export function TodoDetail() {
   const [isMobile, setIsMobile] = useState(false);
   const [isWide, setIsWide] = useState(false);
   const [selectedHistoryRecordId, setSelectedHistoryRecordId] = useState<number | null>(null);
+  const [viewMode, setViewMode] = useState<'log' | 'chat'>('log');
   const selectedTodo = todos.find(t => t.id === selectedTodoId);
 
   useEffect(() => {
@@ -490,15 +492,26 @@ export function TodoDetail() {
       >
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12, ...(isWide ? { flexShrink: 0 } : {}) }}>
           <h4 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: 'var(--color-text)' }}>执行历史</h4>
-          <Button
-            type="text"
-            size="small"
-            icon={<ReloadOutlined />}
-            onClick={() => loadExecutionRecords(historyPage, historyLimit)}
-            loading={isExecuting}
-          >
-            刷新
-          </Button>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <Segmented
+              size="small"
+              value={viewMode}
+              onChange={(value) => setViewMode(value as 'log' | 'chat')}
+              options={[
+                { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
+                { value: 'chat', icon: <MessageOutlined />, label: '对话' },
+              ]}
+            />
+            <Button
+              type="text"
+              size="small"
+              icon={<ReloadOutlined />}
+              onClick={() => loadExecutionRecords(historyPage, historyLimit)}
+              loading={isExecuting}
+            >
+              刷新
+            </Button>
+          </div>
         </div>
         {records.length === 0 ? (
           <Empty description="暂无执行记录" image={Empty.PRESENTED_IMAGE_SIMPLE} />
@@ -676,6 +689,22 @@ export function TodoDetail() {
                     })()}
                     {(() => {
                       if (!isRunning && displayLogs.length === 0) return null;
+                      if (viewMode === 'chat') {
+                        return (
+                          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8, flexShrink: 0 }}>
+                              <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-primary)' }}>
+                                对话视图 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}
+                              </span>
+                              <ReloadOutlined
+                                style={{ fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer' }}
+                                onClick={() => refreshSingleRecord(record.id)}
+                              />
+                            </div>
+                            <ChatView logs={displayLogs as LogEntry[]} isRunning={isRunning} />
+                          </div>
+                        );
+                      }
                       return (
                         <div>
                           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
@@ -856,6 +885,25 @@ export function TodoDetail() {
                   const displayLogs = liveLogs && liveLogs.length > 0 ? liveLogs : restLogs;
 
                   if (!isRunning && displayLogs.length === 0) return null;
+
+                  if (viewMode === 'chat') {
+                    return (
+                      <div style={{ marginTop: 8 }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+                          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-primary)' }}>
+                            对话视图 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}
+                          </span>
+                          <ReloadOutlined
+                            style={{ fontSize: 11 }}
+                            onClick={(e) => { e.preventDefault(); e.stopPropagation(); refreshSingleRecord(record.id); }}
+                          />
+                        </div>
+                        <div style={{ maxHeight: 400, overflow: 'auto' }}>
+                          <ChatView logs={displayLogs as LogEntry[]} isRunning={isRunning} />
+                        </div>
+                      </div>
+                    );
+                  }
 
                   return (
                     <details style={{ marginTop: 8 }} open={isRunning}>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -29,7 +29,7 @@ export interface TodoTag {
 
 export interface LogEntry {
   timestamp: string;
-  type: 'info' | 'stdout' | 'stderr' | 'error' | 'text' | 'tool' | 'step_start' | 'step_finish' | 'result' | 'assistant' | 'user' | 'system' | 'thinking';
+  type: 'info' | 'stdout' | 'stderr' | 'error' | 'text' | 'tool' | 'tool_use' | 'tool_call' | 'tool_result' | 'step_start' | 'step_finish' | 'result' | 'assistant' | 'user' | 'system' | 'thinking' | 'tokens';
   content: string;
 }
 


### PR DESCRIPTION
## Summary
- 创建 ChatView 组件，以对话形式展示 AI 执行日志
- 支持展示用户消息、AI 回复、思考过程、工具调用、执行结果
- 在执行历史详情区域添加日志/对话视图切换按钮
- 适配手机端、小屏、大屏等不同尺寸

## Test plan
- [ ] 在宽屏模式下测试日志/对话视图切换
- [ ] 在窄屏模式下测试日志/对话视图切换
- [ ] 在手机端测试对话视图的响应式布局
- [ ] 测试实时执行任务的对话视图更新
- [ ] 测试思考过程、工具调用的折叠/展开功能