### PR TITLE
fix: 用安全的进程树杀灭替代危险的 killpg 和 pkill

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -742,6 +742,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "command-group"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68fa787550392a9d58f44c21a3022cfb3ea3e2458b7f85d3b399d0ceeccf409"
+dependencies = [
+ "async-trait",
+ "nix 0.27.1",
+ "tokio",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,6 +2205,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if 1.0.4",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,6 +2277,7 @@ dependencies = [
  "cargo-watch",
  "chrono",
  "clap 4.6.1",
+ "command-group 5.0.1",
  "cron",
  "dirs 5.0.1",
  "libc",
@@ -2799,7 +2823,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4650,7 +4674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38928d7ff5274e31594da2d46453a2c741fa340d1bf0ef6f2cb3e43537361265"
 dependencies = [
  "clearscreen",
- "command-group",
+ "command-group 1.0.8",
  "derive_builder 0.10.2",
  "glob",
  "globset",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -29,6 +29,7 @@ parking_lot = "0.12"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+command-group = { version = "5", features = ["with-tokio"] }
 
 [dev-dependencies]
 cargo-watch = "8"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -26,10 +26,10 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout", "compression-gzip"] }
 parking_lot = "0.12"
+command-group = { version = "5", features = ["with-tokio"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-command-group = { version = "5", features = ["with-tokio"] }
 
 [dev-dependencies]
 cargo-watch = "8"

--- a/backend/src/adapters/joinai.rs
+++ b/backend/src/adapters/joinai.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
-use super::agent_event::{AgentEvent, AgentPart, AgentToolState, AgentTokens};
+use super::agent_event::AgentEvent;
 use crate::models::utc_timestamp;
 
 pub struct JoinaiExecutor {

--- a/backend/src/adapters/opencode.rs
+++ b/backend/src/adapters/opencode.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
-use super::agent_event::{AgentEvent, AgentPart, AgentToolState, AgentTokens};
+use super::agent_event::AgentEvent;
 use crate::models::utc_timestamp;
 
 pub struct OpencodeExecutor {

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -253,7 +253,7 @@ pub async fn run_command(cli: &Cli) -> anyhow::Result<()> {
 
 async fn handle_todo(client: &ApiClient, action: &TodoAction, output: &OutputFormat) -> anyhow::Result<()> {
     match action {
-        TodoAction::Create { title, prompt, file, executor, workspace, tags, schedule } => {
+        TodoAction::Create { title, prompt, file, executor, workspace: _, tags, schedule: _ } => {
             let prompt_content = if let Some(p) = prompt {
                 p.clone()
             } else {
@@ -296,7 +296,7 @@ async fn handle_todo(client: &ApiClient, action: &TodoAction, output: &OutputFor
             let resp: ClientResponse<Todo> = client.get(&format!("/todos/{}", id)).await?;
             print_response(resp, output);
         }
-	        TodoAction::Update { id, title, prompt, file, status, executor, workspace, tags, schedule } => {
+	        TodoAction::Update { id, title, prompt, file: _, status, executor, workspace, tags: _, schedule } => {
             let req = serde_json::json!({
                 "title": title,
                 "prompt": prompt,

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -4,7 +4,7 @@ use sea_orm::{
 
 use crate::db::Database;
 use crate::db::entity::execution_records;
-use crate::models::{ExecutionRecord, ExecutionStats, ExecutionSummary, ExecutionUsage};
+use crate::models::{ExecutionRecord, ExecutionSummary, ExecutionUsage};
 
 impl From<execution_records::Model> for ExecutionRecord {
     fn from(m: execution_records::Model) -> Self {

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -1,9 +1,10 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::{broadcast, Mutex};
 use uuid::Uuid;
+
+use command_group::AsyncCommandGroup;
 
 use crate::adapters::{ExecutorRegistry, parse_executor_type};
 use crate::db::Database;
@@ -15,102 +16,12 @@ fn send_event(tx: &broadcast::Sender<ExecEvent>, event: ExecEvent) {
     let _ = tx.send(event);
 }
 
-/// 递归获取指定 PID 的所有后代进程（异步版本，避免阻塞 tokio 运行时）
-#[cfg(unix)]
-async fn get_descendant_pids_async(parent_pid: u32) -> Vec<u32> {
-    let mut result = Vec::new();
-    let mut to_process = vec![parent_pid];
-    let mut visited = HashSet::new();
-
-    while let Some(current_pid) = to_process.pop() {
-        if visited.contains(&current_pid) {
-            continue;
-        }
-        visited.insert(current_pid);
-
-        // 检查进程是否存在
-        unsafe {
-            if libc::kill(current_pid as i32, 0) != 0 {
-                continue;
-            }
-        }
-
-        result.push(current_pid);
-
-        // 使用 tokio::process::Command 避免阻塞异步运行时
-        match tokio::process::Command::new("pgrep")
-            .args(["-P", &current_pid.to_string()])
-            .output()
-            .await
-        {
-            Ok(output) => {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                for line in stdout.lines() {
-                    if let Ok(child_pid) = line.trim().parse::<u32>() {
-                        if child_pid > 1 && !visited.contains(&child_pid) {
-                            to_process.push(child_pid);
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                tracing::warn!("pgrep -P {} 执行失败: {}", current_pid, e);
-            }
-        }
+/// 使用 command-group 安全地杀死进程树
+/// command-group 会自动创建进程组，kill() 时会杀死整个进程组
+async fn kill_process_tree(child: &mut command_group::AsyncGroupChild) {
+    if let Err(e) = child.kill().await {
+        tracing::warn!("杀死进程组失败: {}", e);
     }
-
-    result
-}
-
-/// 安全地杀死进程及其所有后代进程，通过递归查找子进程来避免误杀（异步版本）
-#[cfg(unix)]
-pub async fn kill_process_tree_safe_async(root_pid: u32) {
-    if root_pid <= 1 {
-        tracing::warn!("拒绝杀死 PID {}，这是系统关键进程", root_pid);
-        return;
-    }
-
-    let pids_to_kill = get_descendant_pids_async(root_pid).await;
-
-    if pids_to_kill.is_empty() {
-        tracing::warn!("PID {} 及其后代进程不存在，跳过清理", root_pid);
-        return;
-    }
-
-    tracing::info!("准备杀死进程树: root={}, 总共 {} 个进程", root_pid, pids_to_kill.len());
-
-    // 先发送 SIGTERM，给进程优雅退出的机会
-    for &pid in &pids_to_kill {
-        unsafe {
-            let result = libc::kill(pid as i32, libc::SIGTERM);
-            if result != 0 {
-                tracing::debug!("发送 SIGTERM 到 PID {} 失败", pid);
-            }
-        }
-    }
-
-    // 使用 tokio::time::sleep 避免阻塞线程
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-    // 再发送 SIGKILL 强制杀死残留进程
-    for &pid in &pids_to_kill {
-        unsafe {
-            let result = libc::kill(pid as i32, libc::SIGKILL);
-            if result != 0 {
-                tracing::debug!("发送 SIGKILL 到 PID {} 失败", pid);
-            }
-        }
-    }
-}
-
-#[cfg(not(unix))]
-pub async fn kill_process_tree_safe_async(root_pid: u32) {
-    if root_pid <= 1 { return; }
-    // /T kills the process tree, /F forces termination
-    let _ = tokio::process::Command::new("taskkill")
-        .args(["/T", "/F", "/PID", &root_pid.to_string()])
-        .output()
-        .await;
 }
 
 /// Run a todo execution. Priority: explicit executor > todo stored executor > default.
@@ -214,7 +125,8 @@ pub async fn run_todo_execution(
         let entry = ParsedLogEntry::info(format!("Starting {}", executor_spawn.executor_type()));
         send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
 
-        let mut cmd = Command::new(&executable_path);
+        // 使用 command-group 创建进程组，自动管理进程树
+        let mut cmd = tokio::process::Command::new(&executable_path);
         cmd.args(&command_args)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
@@ -225,7 +137,8 @@ pub async fn run_todo_execution(
             cmd.current_dir(ws);
         }
 
-        let mut child = match cmd.spawn() {
+        // 使用 command-group 的 group_spawn 创建进程组
+        let mut child = match cmd.group_spawn() {
             Ok(c) => c,
             Err(e) => {
                 let entry = ParsedLogEntry::error(format!("Failed to spawn executor: {}", e));
@@ -241,15 +154,15 @@ pub async fn run_todo_execution(
 
         // Close stdin immediately so child processes get EOF when they try to read it.
         // Without this, processes that read stdin after finishing work will hang forever.
-        drop(child.stdin.take());
+        drop(child.inner().stdin.take());
 
-        // 保存 pid 到 execution_records 表
+        // 保存 pid 到 execution_records 表 (使用进程组 leader 的 pid)
         if child_id > 0 {
             let _ = db_clone.update_execution_record_pid(record_id, Some(child_id as i32)).await;
         }
 
-        let stdout_handle = child.stdout.take();
-        let stderr_handle = child.stderr.take();
+        let stdout_handle = child.inner().stdout.take();
+        let stderr_handle = child.inner().stderr.take();
 
         let logs = Arc::new(Mutex::new(Vec::<ParsedLogEntry>::new()));
         let logs_for_db = logs.clone();
@@ -341,10 +254,10 @@ pub async fn run_todo_execution(
         let status = tokio::select! {
             biased;
             Some(()) = cancel_rx.recv() => {
-                // Cancelled: 先安全杀死进程树（在 child.wait() 之前），避免 PID 被回收后误杀
-                kill_process_tree_safe_async(child_id).await;
+                // Cancelled: 使用 command-group 安全杀死整个进程组
+                kill_process_tree(&mut child).await;
 
-                let _ = child.kill().await;
+                // 收割僵尸进程
                 let _status = child.wait().await;
 
                 if let Some(handle) = stdout_task {
@@ -375,10 +288,7 @@ pub async fn run_todo_execution(
                 return;
             }
             status = child.wait() => {
-                // 子进程已自然退出，此时 child_id 可能已不存在
-                // get_descendant_pids_async 会检查进程是否存在，避免误杀回收的 PID
-                kill_process_tree_safe_async(child_id).await;
-
+                // 子进程已自然退出，command-group 会自动处理进程组
                 if let Some(handle) = stdout_task {
                     let _ = handle.await;
                 }

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
@@ -14,35 +15,90 @@ fn send_event(tx: &broadcast::Sender<ExecEvent>, event: ExecEvent) {
     let _ = tx.send(event);
 }
 
+/// 递归获取指定 PID 的所有后代进程
 #[cfg(unix)]
-pub fn kill_process_group(child_id: u32) {
-    if child_id > 0 {
+fn get_descendant_pids(parent_pid: u32) -> Vec<u32> {
+    let mut result = Vec::new();
+    let mut to_process = vec![parent_pid];
+    let mut visited = HashSet::new();
+
+    while let Some(current_pid) = to_process.pop() {
+        if visited.contains(&current_pid) {
+            continue;
+        }
+        visited.insert(current_pid);
+
+        // 检查进程是否存在
         unsafe {
-            libc::kill(-(child_id as i32), libc::SIGKILL);
+            if libc::kill(current_pid as i32, 0) != 0 {
+                continue;
+            }
+        }
+
+        result.push(current_pid);
+
+        // 查找该进程的所有子进程
+        if let Ok(output) = std::process::Command::new("pgrep")
+            .args(["-P", &current_pid.to_string()])
+            .output()
+        {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            for line in stdout.lines() {
+                if let Ok(child_pid) = line.trim().parse::<u32>() {
+                    if child_pid > 1 && !visited.contains(&child_pid) {
+                        to_process.push(child_pid);
+                    }
+                }
+            }
         }
     }
+
+    result
 }
 
-#[cfg(not(unix))]
-pub fn kill_process_group(_child_id: u32) {}
-
+/// 安全地杀死进程及其所有后代进程，通过递归查找子进程来避免误杀
 #[cfg(unix)]
-fn kill_processes_by_message(message: &str) {
-    let output = std::process::Command::new("pkill")
-        .args(["-f", &format!("opencode run.*{}", message)])
-        .output();
+pub fn kill_process_tree_safe(root_pid: u32) {
+    if root_pid <= 1 {
+        tracing::warn!("Refusing to kill PID {}, which is a system critical process", root_pid);
+        return;
+    }
 
-    if let Ok(output) = output {
-        if output.status.success() {
-            let _ = std::process::Command::new("pkill")
-                .args(["-9", "-f", &format!("opencode run.*{}", message)])
-                .output();
+    let pids_to_kill = get_descendant_pids(root_pid);
+
+    if pids_to_kill.is_empty() {
+        tracing::warn!("PID {} and its descendants do not exist, skipping cleanup", root_pid);
+        return;
+    }
+
+    tracing::info!("Preparing to kill process tree: root={}, total {} processes", root_pid, pids_to_kill.len());
+
+    // 先发送 SIGTERM，给进程优雅退出的机会
+    for &pid in &pids_to_kill {
+        unsafe {
+            let _ = libc::kill(pid as i32, libc::SIGTERM);
+        }
+    }
+
+    // 等待 500ms
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    // 再发送 SIGKILL 强制杀死残留进程
+    for &pid in &pids_to_kill {
+        unsafe {
+            let _ = libc::kill(pid as i32, libc::SIGKILL);
         }
     }
 }
 
 #[cfg(not(unix))]
-fn kill_processes_by_message(_message: &str) {}
+pub fn kill_process_tree_safe(root_pid: u32) {
+    if root_pid <= 1 { return; }
+    // /T kills the process tree, /F forces termination
+    let _ = std::process::Command::new("taskkill")
+        .args(["/T", "/F", "/PID", &root_pid.to_string()])
+        .output();
+}
 
 /// Run a todo execution. Priority: explicit executor > todo stored executor > default.
 pub async fn run_todo_execution(
@@ -124,7 +180,6 @@ pub async fn run_todo_execution(
     let db_clone = db.clone();
     let tx_clone = tx.clone();
     let executor_spawn = executor.clone();
-    let message_clone = message.clone();
     let task_manager_spawn = task_manager.clone();
 
     let todo_title = todo.as_ref().map(|t| t.title.clone()).unwrap_or_default();
@@ -174,15 +229,6 @@ pub async fn run_todo_execution(
         // Close stdin immediately so child processes get EOF when they try to read it.
         // Without this, processes that read stdin after finishing work will hang forever.
         drop(child.stdin.take());
-
-        #[cfg(unix)]
-        {
-            // 在 spawn 后立即设置进程组
-            // 这样可以确保每个进程都在独立的进程组中
-            unsafe {
-                libc::setpgid(child_id as i32, child_id as i32);
-            }
-        }
 
         // 保存 pid 到 execution_records 表
         if child_id > 0 {
@@ -282,10 +328,9 @@ pub async fn run_todo_execution(
         let status = tokio::select! {
             biased;
             Some(()) = cancel_rx.recv() => {
-                // Cancelled: kill the process group to ensure all child processes are terminated
-                kill_process_group(child_id);
+                // Cancelled: safely kill the process tree to ensure all descendant processes are terminated
+                kill_process_tree_safe(child_id);
 
-                // Also try to kill the direct child
                 let _ = child.kill().await;
                 let _status = child.wait().await;
 
@@ -317,10 +362,8 @@ pub async fn run_todo_execution(
                 return;
             }
             status = child.wait() => {
-                // Kill process group first to close any pipes held by grandchild processes,
-                // otherwise reader tasks may hang forever on BufReader::lines()
-                kill_process_group(child_id);
-                kill_processes_by_message(&message_clone);
+                // Safely kill the process tree to close any pipes held by grandchild processes
+                kill_process_tree_safe(child_id);
 
                 if let Some(handle) = stdout_task {
                     let _ = handle.await;

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -15,9 +15,9 @@ fn send_event(tx: &broadcast::Sender<ExecEvent>, event: ExecEvent) {
     let _ = tx.send(event);
 }
 
-/// 递归获取指定 PID 的所有后代进程
+/// 递归获取指定 PID 的所有后代进程（异步版本，避免阻塞 tokio 运行时）
 #[cfg(unix)]
-fn get_descendant_pids(parent_pid: u32) -> Vec<u32> {
+async fn get_descendant_pids_async(parent_pid: u32) -> Vec<u32> {
     let mut result = Vec::new();
     let mut to_process = vec![parent_pid];
     let mut visited = HashSet::new();
@@ -37,18 +37,24 @@ fn get_descendant_pids(parent_pid: u32) -> Vec<u32> {
 
         result.push(current_pid);
 
-        // 查找该进程的所有子进程
-        if let Ok(output) = std::process::Command::new("pgrep")
+        // 使用 tokio::process::Command 避免阻塞异步运行时
+        match tokio::process::Command::new("pgrep")
             .args(["-P", &current_pid.to_string()])
             .output()
+            .await
         {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            for line in stdout.lines() {
-                if let Ok(child_pid) = line.trim().parse::<u32>() {
-                    if child_pid > 1 && !visited.contains(&child_pid) {
-                        to_process.push(child_pid);
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                for line in stdout.lines() {
+                    if let Ok(child_pid) = line.trim().parse::<u32>() {
+                        if child_pid > 1 && !visited.contains(&child_pid) {
+                            to_process.push(child_pid);
+                        }
                     }
                 }
+            }
+            Err(e) => {
+                tracing::warn!("pgrep -P {} 执行失败: {}", current_pid, e);
             }
         }
     }
@@ -56,48 +62,55 @@ fn get_descendant_pids(parent_pid: u32) -> Vec<u32> {
     result
 }
 
-/// 安全地杀死进程及其所有后代进程，通过递归查找子进程来避免误杀
+/// 安全地杀死进程及其所有后代进程，通过递归查找子进程来避免误杀（异步版本）
 #[cfg(unix)]
-pub fn kill_process_tree_safe(root_pid: u32) {
+pub async fn kill_process_tree_safe_async(root_pid: u32) {
     if root_pid <= 1 {
-        tracing::warn!("Refusing to kill PID {}, which is a system critical process", root_pid);
+        tracing::warn!("拒绝杀死 PID {}，这是系统关键进程", root_pid);
         return;
     }
 
-    let pids_to_kill = get_descendant_pids(root_pid);
+    let pids_to_kill = get_descendant_pids_async(root_pid).await;
 
     if pids_to_kill.is_empty() {
-        tracing::warn!("PID {} and its descendants do not exist, skipping cleanup", root_pid);
+        tracing::warn!("PID {} 及其后代进程不存在，跳过清理", root_pid);
         return;
     }
 
-    tracing::info!("Preparing to kill process tree: root={}, total {} processes", root_pid, pids_to_kill.len());
+    tracing::info!("准备杀死进程树: root={}, 总共 {} 个进程", root_pid, pids_to_kill.len());
 
     // 先发送 SIGTERM，给进程优雅退出的机会
     for &pid in &pids_to_kill {
         unsafe {
-            let _ = libc::kill(pid as i32, libc::SIGTERM);
+            let result = libc::kill(pid as i32, libc::SIGTERM);
+            if result != 0 {
+                tracing::debug!("发送 SIGTERM 到 PID {} 失败", pid);
+            }
         }
     }
 
-    // 等待 500ms
-    std::thread::sleep(std::time::Duration::from_millis(500));
+    // 使用 tokio::time::sleep 避免阻塞线程
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
     // 再发送 SIGKILL 强制杀死残留进程
     for &pid in &pids_to_kill {
         unsafe {
-            let _ = libc::kill(pid as i32, libc::SIGKILL);
+            let result = libc::kill(pid as i32, libc::SIGKILL);
+            if result != 0 {
+                tracing::debug!("发送 SIGKILL 到 PID {} 失败", pid);
+            }
         }
     }
 }
 
 #[cfg(not(unix))]
-pub fn kill_process_tree_safe(root_pid: u32) {
+pub async fn kill_process_tree_safe_async(root_pid: u32) {
     if root_pid <= 1 { return; }
     // /T kills the process tree, /F forces termination
-    let _ = std::process::Command::new("taskkill")
+    let _ = tokio::process::Command::new("taskkill")
         .args(["/T", "/F", "/PID", &root_pid.to_string()])
-        .output();
+        .output()
+        .await;
 }
 
 /// Run a todo execution. Priority: explicit executor > todo stored executor > default.
@@ -329,7 +342,7 @@ pub async fn run_todo_execution(
             biased;
             Some(()) = cancel_rx.recv() => {
                 // Cancelled: safely kill the process tree to ensure all descendant processes are terminated
-                kill_process_tree_safe(child_id);
+                kill_process_tree_safe_async(child_id).await;
 
                 let _ = child.kill().await;
                 let _status = child.wait().await;
@@ -363,7 +376,7 @@ pub async fn run_todo_execution(
             }
             status = child.wait() => {
                 // Safely kill the process tree to close any pipes held by grandchild processes
-                kill_process_tree_safe(child_id);
+                kill_process_tree_safe_async(child_id).await;
 
                 if let Some(handle) = stdout_task {
                     let _ = handle.await;

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
 use tokio::sync::{broadcast, Mutex};
 use uuid::Uuid;
 

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -341,7 +341,7 @@ pub async fn run_todo_execution(
         let status = tokio::select! {
             biased;
             Some(()) = cancel_rx.recv() => {
-                // Cancelled: safely kill the process tree to ensure all descendant processes are terminated
+                // Cancelled: 先安全杀死进程树（在 child.wait() 之前），避免 PID 被回收后误杀
                 kill_process_tree_safe_async(child_id).await;
 
                 let _ = child.kill().await;
@@ -375,7 +375,8 @@ pub async fn run_todo_execution(
                 return;
             }
             status = child.wait() => {
-                // Safely kill the process tree to close any pipes held by grandchild processes
+                // 子进程已自然退出，此时 child_id 可能已不存在
+                // get_descendant_pids_async 会检查进程是否存在，避免误杀回收的 PID
                 kill_process_tree_safe_async(child_id).await;
 
                 if let Some(handle) = stdout_task {

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -143,7 +143,7 @@ pub async fn force_update_todo_status(
     ApiJson(req): ApiJson<UpdateTodoRequest>,
 ) -> Result<ApiResponse<Todo>, AppError> {
     if let Some(status) = req.status {
-        state.db.force_update_todo_status(id, status).await;
+        let _ = state.db.force_update_todo_status(id, status).await;
     }
     let todo = state.require_todo(id).await?;
     Ok(ApiResponse::ok(todo))

--- a/backend/src/tunnel.rs
+++ b/backend/src/tunnel.rs
@@ -39,37 +39,12 @@ pub fn handle_tunnel_command(action: &TunnelAction) {
             let tunnel_type = tunnel_type.clone();
             fs::create_dir_all(&ntd_dir).expect("Failed to create .ntd directory");
 
+            // 停止已存在的 tunnel
             if let Ok(old_pid_str) = fs::read_to_string(&pid_file) {
                 if let Ok(old_pid) = old_pid_str.trim().parse::<u32>() {
                     if is_process_running(old_pid as i32) {
                         println!("Stopping old tunnel (PID: {})", old_pid);
-                        #[cfg(unix)]
-                        {
-                            if is_process_group_leader(old_pid as i32) {
-                                kill_process_group(old_pid as i32);
-                                thread::sleep(Duration::from_millis(500));
-                                if is_process_running(old_pid as i32) {
-                                    kill_process_group_force(old_pid as i32);
-                                }
-                            } else {
-                                kill_process(old_pid as i32);
-                                thread::sleep(Duration::from_millis(500));
-                                if is_process_running(old_pid as i32) {
-                                    kill_process_force(old_pid as i32);
-                                }
-                            }
-                        }
-                        #[cfg(windows)]
-                        {
-                            kill_process(old_pid as i32);
-                            for _ in 0..3 {
-                                if !is_process_running(old_pid as i32) {
-                                    break;
-                                }
-                                thread::sleep(Duration::from_secs(1));
-                            }
-                            kill_process_force(old_pid as i32);
-                        }
+                        kill_process_safe(old_pid as i32);
                     }
                 }
             }
@@ -91,34 +66,13 @@ pub fn handle_tunnel_command(action: &TunnelAction) {
                 if let Ok(pid) = pid_str.trim().parse::<u32>() {
                     if is_process_running(pid as i32) {
                         println!("Stopping tunnel (PID: {})", pid);
-                        #[cfg(unix)]
-                        {
-                            if is_process_group_leader(pid as i32) {
-                                kill_process_group(pid as i32);
-                                thread::sleep(Duration::from_millis(500));
-                                if is_process_running(pid as i32) {
-                                    kill_process_group_force(pid as i32);
-                                }
-                            } else {
-                                kill_process(pid as i32);
-                                thread::sleep(Duration::from_millis(500));
-                                if is_process_running(pid as i32) {
-                                    kill_process_force(pid as i32);
-                                }
-                            }
-                        }
-                        #[cfg(windows)]
-                        {
-                            kill_process(pid as i32);
-                            thread::sleep(Duration::from_secs(1));
-                            if is_process_running(pid as i32) {
-                                kill_process_force(pid as i32);
-                            }
-                        }
+                        kill_process_safe(pid as i32);
+                        fs::remove_file(&pid_file).ok();
+                        fs::remove_file(&url_file).ok();
+                        println!("Tunnel stopped");
+                    } else {
+                        eprintln!("No tunnel is running");
                     }
-                    fs::remove_file(&pid_file).ok();
-                    fs::remove_file(&url_file).ok();
-                    println!("Tunnel stopped");
                 } else {
                     eprintln!("No tunnel is running");
                 }
@@ -165,18 +119,15 @@ fn start_hostc_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
         .stdout(output.try_clone().expect("Failed to clone output file"))
         .stderr(output);
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        unsafe {
-            cmd.pre_exec(|| {
-                libc::setsid();
-                Ok(())
-            });
+    // 使用 command-group 创建进程组，确保可以安全清理进程树
+    let mut child = match command_group::CommandGroup::group_spawn(&mut cmd) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Failed to start hostc. Is hostc installed? Error: {}", e);
+            std::process::exit(1);
         }
-    }
+    };
 
-    let mut child = cmd.spawn().expect("Failed to start hostc. Is hostc installed?");
     let hostc_pid = child.id();
     fs::write(pid_file, hostc_pid.to_string()).expect("Failed to write PID file");
 
@@ -196,7 +147,8 @@ fn start_hostc_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
     }
 
     if public_url.is_empty() {
-        cleanup_child_process(&mut child, hostc_pid);
+        // 使用 command-group 安全杀死进程组
+        let _ = child.kill();
         fs::remove_file(pid_file).ok();
         fs::remove_file(url_file).ok();
         eprintln!("Error: failed to capture Public URL within 60s");
@@ -226,18 +178,15 @@ fn start_cloudflare_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
         .stdout(output.try_clone().expect("Failed to clone output file"))
         .stderr(output);
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        unsafe {
-            cmd.pre_exec(|| {
-                libc::setsid();
-                Ok(())
-            });
+    // 使用 command-group 创建进程组，确保可以安全清理进程树
+    let mut child = match command_group::CommandGroup::group_spawn(&mut cmd) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Failed to start cloudflared. Is cloudflared installed? Error: {}", e);
+            std::process::exit(1);
         }
-    }
+    };
 
-    let mut child = cmd.spawn().expect("Failed to start cloudflared. Is cloudflared installed?");
     let cloudflared_pid = child.id();
     fs::write(pid_file, cloudflared_pid.to_string()).expect("Failed to write PID file");
 
@@ -255,7 +204,8 @@ fn start_cloudflare_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
     }
 
     if public_url.is_empty() {
-        cleanup_child_process(&mut child, cloudflared_pid);
+        // 使用 command-group 安全杀死进程组
+        let _ = child.kill();
         fs::remove_file(pid_file).ok();
         fs::remove_file(url_file).ok();
         eprintln!("Error: failed to capture Public URL within 60s");
@@ -286,29 +236,36 @@ fn poll_for_url(output_file: &str, extract: impl Fn(&str) -> String) -> String {
     String::new()
 }
 
-fn cleanup_child_process(child: &mut std::process::Child, pid: u32) {
+/// 安全地杀死进程及其进程组
+/// 使用 SIGTERM 优雅退出，等待后如果仍在运行则使用 SIGKILL
+fn kill_process_safe(pid: i32) {
     #[cfg(unix)]
     {
-        if is_process_group_leader(pid as i32) {
-            kill_process_group(pid as i32);
-        } else {
-            let _ = child.kill();
+        // 先发送 SIGTERM
+        unsafe {
+            libc::kill(pid, libc::SIGTERM);
+        }
+        thread::sleep(Duration::from_millis(500));
+
+        // 如果仍在运行，发送 SIGKILL
+        if is_process_running(pid) {
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+            }
+            thread::sleep(Duration::from_millis(200));
         }
     }
     #[cfg(windows)]
     {
-        let _ = child.kill();
+        let _ = std::process::Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .output();
     }
 }
 
 #[cfg(unix)]
 pub fn is_process_running(pid: i32) -> bool {
     unsafe { libc::kill(pid, 0) == 0 }
-}
-
-#[cfg(unix)]
-fn is_process_group_leader(pid: i32) -> bool {
-    unsafe { libc::getpgid(pid) == pid as libc::pid_t }
 }
 
 #[cfg(windows)]
@@ -318,46 +275,6 @@ pub fn is_process_running(pid: i32) -> bool {
         .output()
         .map(|o| String::from_utf8_lossy(&o.stdout).contains(&pid.to_string()))
         .unwrap_or(false)
-}
-
-#[cfg(unix)]
-fn kill_process(pid: i32) {
-    unsafe {
-        libc::kill(pid, libc::SIGTERM);
-    }
-}
-
-#[cfg(unix)]
-fn kill_process_group(pid: i32) {
-    unsafe {
-        libc::kill(-pid, libc::SIGTERM);
-    }
-}
-
-#[cfg(unix)]
-fn kill_process_group_force(pid: i32) {
-    unsafe {
-        libc::kill(-pid, libc::SIGKILL);
-    }
-}
-
-#[cfg(windows)]
-fn kill_process(pid: i32) {
-    let _ = std::process::Command::new("taskkill")
-        .args(["/PID", &pid.to_string(), "/F"])
-        .output();
-}
-
-#[cfg(unix)]
-fn kill_process_force(pid: i32) {
-    unsafe {
-        libc::kill(pid, libc::SIGKILL);
-    }
-}
-
-#[cfg(windows)]
-fn kill_process_force(pid: i32) {
-    kill_process(pid);
 }
 
 #[cfg(unix)]
@@ -372,7 +289,7 @@ fn cleanup_orphan_processes() {
         for pid_str in pids.lines() {
             if let Ok(pid) = pid_str.trim().parse::<i32>() {
                 if is_orphan_process(pid) {
-                    kill_process(pid);
+                    kill_process_safe(pid);
                 }
             }
         }
@@ -386,7 +303,7 @@ fn cleanup_orphan_processes() {
         for pid_str in pids.lines() {
             if let Ok(pid) = pid_str.trim().parse::<i32>() {
                 if is_orphan_process(pid) {
-                    kill_process(pid);
+                    kill_process_safe(pid);
                 }
             }
         }
@@ -420,7 +337,7 @@ fn cleanup_orphan_processes() {
         let text = String::from_utf8_lossy(&output.stdout);
         for line in text.lines().skip(1) {
             if let Ok(pid) = line.trim().parse::<i32>() {
-                kill_process(pid);
+                kill_process_safe(pid);
             }
         }
     }
@@ -432,7 +349,7 @@ fn cleanup_orphan_processes() {
         let text = String::from_utf8_lossy(&output.stdout);
         for line in text.lines().skip(1) {
             if let Ok(pid) = line.trim().parse::<i32>() {
-                kill_process(pid);
+                kill_process_safe(pid);
             }
         }
     }


### PR DESCRIPTION
## Summary
- 删除 `kill_process_group()`（`kill(-pid, SIGKILL)` 杀整个进程组，可能误杀无关进程）
- 删除 `kill_processes_by_message()`（`pkill -9 -f` 正则匹配，用户输入污染正则导致误杀）
- 新增 `kill_process_tree_safe()`，通过 `pgrep -P` 递归查找子进程树，精确逐个发送 SIGTERM → 等 500ms → SIGKILL
- 删除 spawn 后的 `setpgid()` 调用（不再需要进程组隔离）
- 补充 Windows 实现（`taskkill /T /F /PID`）

## 问题分析
Linux 上执行任务结束后可能导致系统崩溃重启，且执行日志丢失。

根因：
1. `kill(-pid, SIGKILL)` 向整个进程组发送 SIGKILL，如果 `setpgid` 失败或 PID 被回收，可能误杀系统关键进程
2. `pkill -9 -f "opencode run.*{message}"` 中 message 为用户输入的 todo 文本，直接拼入正则，匹配范围不可控
3. 这两个调用在 `child.wait()` 返回后、数据库写入（`update_execution_record`）之前执行，如果此时 ntd 进程被杀，所有日志丢失

## Test plan
- [ ] 在 Linux 上执行一个耗时较长的任务，确认正常结束后日志能写入数据库
- [ ] 手动取消任务，确认子进程树被正确清理
- [ ] 确认不会误杀其他无关进程