### PR TITLE
fix: 宽屏布局下执行记录缺少命令显示

### DIFF
--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -644,6 +644,11 @@ export function TodoDetail() {
                         )}
                       </div>
                     </div>
+                    {record.command && (
+                      <div style={{ fontSize: 11, color: 'var(--color-text-quaternary)', marginBottom: 12, fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {record.command}
+                      </div>
+                    )}
                     {record.result !== null && record.result !== '' && (
                       <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`} style={{ marginBottom: 12 }}>
                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>


### PR DESCRIPTION
## Summary
- 宽屏(>=1440px)详情面板中遗漏了 `record.command` 的渲染，导致执行命令只在中等屏幕下显示，宽屏下不显示

## Test plan
- [ ] 在宽屏(>=1440px)下打开含执行记录的 Todo，确认命令行可见
- [ ] 在中等屏幕(768-1439px)下确认显示无变化
- [ ] command 为空的记录不显示多余元素