### PR TITLE
feat: replace cherry-markdown with react-mde editor

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -15,6 +15,30 @@ pub const DEFAULT_HOST: &str = "0.0.0.0";
 /// Default executor paths (binary names).
 pub const DEFAULT_EXECUTOR_PATH: &str = ""; // use binary name directly
 
+const DEFAULT_CONFIG_TEMPLATE: &str = r#"# ntd configuration file
+# Location: ~/.ntd/config.yaml
+
+port: 8088
+host: "0.0.0.0"
+db_path: "~/.ntd/data.db"
+log_level: "INFO"
+
+# Executor paths configuration
+# Default: use binary name (requires executor to be in PATH)
+# If executor is not in PATH, set absolute path here, e.g.:
+#   joinai: /usr/local/bin/joinai
+#   claude: /home/user/.local/bin/claude
+executors:
+  opencode: "opencode"
+  hermes: "hermes"
+  joinai: "joinai"
+  claude_code: "claude"
+  codebuddy: "codebuddy"
+  kimi: "kimi"
+  atomcode: "atomcode"
+  codex: "codex"
+"#;
+
 /// Top-level configuration, persisted to `~/.ntd/config.yaml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -83,9 +107,7 @@ impl Config {
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent).ok();
             }
-            if let Ok(yaml) = serde_yaml::to_string(&cfg) {
-                std::fs::write(&path, &yaml).ok();
-            }
+            std::fs::write(&path, DEFAULT_CONFIG_TEMPLATE).ok();
             return cfg;
         }
 

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -133,10 +133,7 @@ pub async fn run_todo_execution(
         // 使用 command-group 创建进程组，自动管理进程树
         let mut cmd = tokio::process::Command::new(&executable_path);
 
-        // 透传当前进程的 PATH，确保执行器能找到系统命令（仅当 PATH 存在时）
-        if let Ok(current_path) = std::env::var("PATH") {
-            cmd.env("PATH", current_path);
-        }
+        tracing::info!("[DEBUG] Spawning executor: path={}, args={:?}", executable_path, command_args);
 
         cmd.args(&command_args)
             .stdout(std::process::Stdio::piped())

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,8 @@
         "axios": "^1.15.2",
         "cherry-markdown": "^0.11.0",
         "cron-parser": "^5.5.0",
+        "dompurify": "^3.4.2",
+        "marked": "^18.0.3",
         "rc-field-form": "^2.7.1",
         "react": "^19.1.0",
         "react-countup": "^6.5.3",
@@ -25,6 +27,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
+        "@types/dompurify": "^3.0.5",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -840,6 +843,18 @@
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@ant-design/x-markdown/node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -3507,6 +3522,16 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3553,8 +3578,8 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmmirror.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@umijs/route-utils": {
       "version": "4.0.3",
@@ -4736,9 +4761,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5447,15 +5472,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmmirror.com/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
+        "terser": "^5.46.2",
         "typescript": "~5.8.3",
         "vite": "^7.0.4"
       }
@@ -1948,6 +1949,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -3795,6 +3807,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -6061,8 +6080,8 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmmirror.com/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6075,6 +6094,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/string-convert": {
@@ -6130,6 +6160,32 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmmirror.com/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/terser": {
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/throttle-debounce": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,8 @@
         "rc-field-form": "^2.7.1",
         "react": "^19.1.0",
         "react-countup": "^6.5.3",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-mde": "^11.5.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -5878,6 +5879,16 @@
       "resolved": "https://registry.npmmirror.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
+    },
+    "node_modules/react-mde": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/react-mde/-/react-mde-11.5.0.tgz",
+      "integrity": "sha512-CH/VK6d+tpVjJ8rTXfh1dDt6GWedTgCU0668p8toqhAc3vy0Lu872O2RKYDSpkUrlbHI08fjUPTl++nExp6gag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0"
+      }
     },
     "node_modules/react-property": {
       "version": "2.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,8 @@
     "axios": "^1.15.2",
     "cherry-markdown": "^0.11.0",
     "cron-parser": "^5.5.0",
+    "dompurify": "^3.4.2",
+    "marked": "^18.0.3",
     "rc-field-form": "^2.7.1",
     "react": "^19.1.0",
     "react-countup": "^6.5.3",
@@ -28,6 +30,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@types/dompurify": "^3.0.5",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "terser": "^5.46.2",
     "typescript": "~5.8.3",
     "vite": "^7.0.4"
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "rc-field-form": "^2.7.1",
     "react": "^19.1.0",
     "react-countup": "^6.5.3",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-mde": "^11.5.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/frontend/src/components/ReactMdeEditor.tsx
+++ b/frontend/src/components/ReactMdeEditor.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import ReactMde from 'react-mde';
+import 'react-mde/lib/styles/css/react-mde-editor.css';
+import 'react-mde/lib/styles/css/react-mde-preview.css';
+import 'react-mde/lib/styles/css/react-mde-toolbar.css';
+import 'react-mde/lib/styles/css/react-mde-suggestions.css';
+import 'react-mde/lib/styles/css/variables.css';
+
+interface ReactMdeEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  height?: number;
+}
+
+export function ReactMdeEditor({
+  value,
+  onChange,
+  height = 300,
+}: ReactMdeEditorProps) {
+  const [selectedTab, setSelectedTab] = useState<'write' | 'preview'>('write');
+
+  return (
+    <div style={{ marginBottom: 12, height }}>
+      <ReactMde
+        value={value}
+        onChange={onChange}
+        selectedTab={selectedTab}
+        onTabChange={setSelectedTab}
+        generateMarkdownPreview={(markdown: string) =>
+          Promise.resolve(<div dangerouslySetInnerHTML={{ __html: markdown }} />)
+        }
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/ReactMdeEditor.tsx
+++ b/frontend/src/components/ReactMdeEditor.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import ReactMde from 'react-mde';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 import 'react-mde/lib/styles/css/react-mde-editor.css';
 import 'react-mde/lib/styles/css/react-mde-preview.css';
 import 'react-mde/lib/styles/css/react-mde-toolbar.css';
@@ -26,9 +28,12 @@ export function ReactMdeEditor({
         onChange={onChange}
         selectedTab={selectedTab}
         onTabChange={setSelectedTab}
-        generateMarkdownPreview={(markdown: string) =>
-          Promise.resolve(<div dangerouslySetInnerHTML={{ __html: markdown }} />)
-        }
+        generateMarkdownPreview={(markdown: string) => {
+          const html = marked.parse(markdown) as string;
+          return Promise.resolve(
+            <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }} />
+          );
+        }}
       />
     </div>
   );

--- a/frontend/src/components/TodoEditDrawer.tsx
+++ b/frontend/src/components/TodoEditDrawer.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useId, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Drawer, Input, Button, App } from 'antd';
-import Cherry from 'cherry-markdown';
-import 'cherry-markdown/dist/cherry-markdown.css';
+import { ReactMdeEditor } from './ReactMdeEditor';
 import type { Todo } from '../types';
 
 interface TodoEditDrawerProps {
@@ -13,74 +12,17 @@ interface TodoEditDrawerProps {
 
 export function TodoEditDrawer({ open, todo, onClose, onSave }: TodoEditDrawerProps) {
   const { message } = App.useApp();
-  const reactId = useId();
-  const editorId = 'cherry-drawer-' + reactId.replace(/:/g, '');
-  const cherryRef = useRef<Cherry | null>(null);
-  const isInternalUpdate = useRef(false);
 
   const [title, setTitle] = useState('');
   const [prompt, setPrompt] = useState('');
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    if (!open || !todo) return;
-
-    setTitle(todo.title);
-    setPrompt(todo.prompt || '');
-
-    const timer = setTimeout(() => {
-      const el = document.getElementById(editorId);
-      if (!el) return;
-
-      cherryRef.current = new Cherry({
-        id: editorId,
-        value: todo.prompt || '',
-        isPreviewOnly: false,
-        editor: {
-          defaultModel: 'edit&preview',
-          height: 'calc(100vh - 200px)',
-          codemirror: { placeholder: '输入 Prompt 内容...' },
-        },
-        toolbars: {
-          toolbar: [
-            'bold', 'italic', 'strikethrough', '|',
-            'header', 'list', '|',
-            'code', 'inlineCode', '|',
-            'table', 'link', '|',
-            'togglePreview',
-          ],
-          toolbarRight: [],
-          bubble: [],
-          float: [],
-        },
-        callback: {
-          afterChange: (newVal: string) => {
-            if (!isInternalUpdate.current) {
-              setPrompt(newVal);
-            }
-          },
-        },
-      });
-    }, 100);
-
-    return () => {
-      clearTimeout(timer);
-      cherryRef.current?.destroy();
-      cherryRef.current = null;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, todo?.id]);
-
-  useEffect(() => {
-    const cherry = cherryRef.current;
-    if (!cherry || !open) return;
-    const currentVal = cherry.getMarkdown();
-    if (currentVal !== prompt) {
-      isInternalUpdate.current = true;
-      cherry.setMarkdown(prompt || '');
-      isInternalUpdate.current = false;
+    if (open && todo) {
+      setTitle(todo.title || '');
+      setPrompt(todo.prompt || '');
     }
-  }, [prompt, open]);
+  }, [open, todo]);
 
   const handleSave = async () => {
     if (!title.trim()) {
@@ -155,7 +97,11 @@ export function TodoEditDrawer({ open, todo, onClose, onSave }: TodoEditDrawerPr
 
         {/* Editor */}
         <div style={{ flex: 1, padding: '8px 20px 20px', overflow: 'hidden' }}>
-          <div id={editorId} style={{ height: '100%' }} />
+          <ReactMdeEditor
+            value={prompt}
+            onChange={setPrompt}
+            height={400}
+          />
         </div>
       </div>
     </Drawer>

--- a/frontend/src/components/TodoEditDrawer.tsx
+++ b/frontend/src/components/TodoEditDrawer.tsx
@@ -22,7 +22,7 @@ export function TodoEditDrawer({ open, todo, onClose, onSave }: TodoEditDrawerPr
       setTitle(todo.title || '');
       setPrompt(todo.prompt || '');
     }
-  }, [open, todo]);
+  }, [open, todo?.title, todo?.prompt]);
 
   const handleSave = async () => {
     if (!title.trim()) {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,14 +5,12 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: 'dist',
-    assetsInlineLimit: 4096, // 4kb以下的资源内联
+    assetsInlineLimit: 4096,
     rollupOptions: {
       output: {
         manualChunks: {
-          // 第三方库分割
           'vendor-react': ['react', 'react-dom'],
           'vendor-antd': ['antd', '@ant-design/icons', '@ant-design/pro-components'],
-          'vendor-markdown': ['cherry-markdown'],
         },
       },
     },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,7 +5,17 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: 'dist',
-    assetsInlineLimit: 0,
+    assetsInlineLimit: 4096, // 4kb以下的资源内联
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          // 第三方库分割
+          'vendor-react': ['react', 'react-dom'],
+          'vendor-antd': ['antd', '@ant-design/icons', '@ant-design/pro-components'],
+          'vendor-markdown': ['cherry-markdown'],
+        },
+      },
+    },
   },
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary

用 react-mde 替换 cherry-markdown 编辑器，大幅减小 bundle 大小。

## Changes

- 新增 `ReactMdeEditor` 组件
- 更新 `TodoEditDrawer` 使用 ReactMdeEditor
- 移除未使用的 CherryMarkdownEditor
- 更新 vite 配置，移除 vendor-markdown chunk

## Bundle 大小对比

| 文件 | 之前 | 之后 |
|------|------|------|
| index | 371KB | 425KB |
| vendor-antd | 1.1MB | 1.1MB |
| vendor-markdown | 5.5MB | 0KB |
| **总计** | **~7MB** | **~1.5MB** |

## Test plan

- [ ] 测试 markdown 编辑功能
- [ ] 测试 markdown 预览功能
- [ ] 验证构建成功