### PR TITLE
fix: comprehensive bug cleanup across backend and frontend

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -121,7 +121,7 @@ impl Database {
             status: ActiveValue::Set(Some(status.to_string())),
             logs: ActiveValue::Set(Some(logs.to_string())),
             result: ActiveValue::Set(Some(result.to_string())),
-            usage: ActiveValue::Set(usage.map(|u| serde_json::to_string(u).unwrap_or_default())),
+            usage: ActiveValue::Set(usage.map(|u| serde_json::to_string(u).unwrap_or_else(|e| { tracing::error!("Failed to serialize usage: {}", e); String::new() }))),
             model: ActiveValue::Set(model.map(|s| s.to_string())),
             finished_at: ActiveValue::Set(Some(now)),
             ..Default::default()
@@ -540,15 +540,23 @@ impl Database {
                 status = 'failed', \
                 finished_at = $1, \
                 result = CASE \
-                    WHEN todo_id NOT IN (SELECT id FROM todos) THEN '任务已被删除' \
+                    WHEN todo_id NOT IN (SELECT id FROM todos WHERE deleted_at IS NULL) THEN '任务已被删除' \
                     ELSE '程序崩溃，任务被中断' \
                 END \
                 WHERE status = 'running' AND ( \
-                    todo_id NOT IN (SELECT id FROM todos) \
-                    OR todo_id IN (SELECT id FROM todos WHERE task_id IS NULL) \
+                    todo_id NOT IN (SELECT id FROM todos WHERE deleted_at IS NULL) \
+                    OR todo_id IN (SELECT id FROM todos WHERE task_id IS NULL AND deleted_at IS NULL) \
                 )";
-        if let Err(e) = self.conn.execute(Statement::from_sql_and_values(backend, sql, [now.into()])).await {
-            tracing::error!("Failed to cleanup orphan execution records: {}", e);
+        match self.conn.execute(Statement::from_sql_and_values(backend, sql, [now.into()])).await {
+            Ok(res) => {
+                let rows = res.rows_affected();
+                if rows > 0 {
+                    tracing::info!("Cleaned up {} orphan execution records", rows);
+                }
+            }
+            Err(e) => {
+                tracing::error!("Failed to cleanup orphan execution records: {}", e);
+            }
         }
     }
 

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -103,6 +103,12 @@ pub async fn run_todo_execution(
     // Update todo status to running and associate with task
     if let Err(e) = db.start_todo_execution(todo_id, &task_id).await {
         tracing::error!("Failed to start todo execution: {}", e);
+        let entry = ParsedLogEntry::error(format!("Failed to start todo execution: {}", e));
+        send_event(&tx, ExecEvent::Output { task_id: task_id.clone(), entry });
+        send_event(&tx, ExecEvent::Finished { task_id: task_id.clone(), todo_id, success: false, result: Some("Failed to start execution".to_string()) });
+        let _ = db.finish_todo_execution(todo_id, false).await;
+        task_manager.remove(&task_id).await;
+        return ExecutionResult { task_id, record_id: Some(record_id) };
     }
 
     let task_id_return = task_id.clone();
@@ -265,8 +271,8 @@ pub async fn run_todo_execution(
 
         let status = tokio::select! {
             biased;
-            Some(()) = cancel_rx.recv() => {
-                // Cancelled: 使用 command-group 安全杀死整个进程组
+            _ = cancel_rx.recv() => {
+                // Cancelled (or channel closed): 使用 command-group 安全杀死整个进程组
                 kill_process_tree(&mut child).await;
 
                 // 收割僵尸进程
@@ -283,7 +289,8 @@ pub async fn run_todo_execution(
                 let _ = db_clone.update_todo_task_id(todo_id, None).await;
 
                 // 更新 execution_records 状态为 failed
-                let logs_json = serde_json::to_string(&*logs.lock().await).unwrap_or_default();
+                let logs_json = serde_json::to_string(&*logs.lock().await)
+                    .unwrap_or_else(|e| { tracing::error!("Failed to serialize logs: {}", e); "[]".to_string() });
                 let _ = db_clone.update_execution_record(
                     record_id,
                     crate::models::ExecutionStatus::Failed.as_str(),
@@ -356,7 +363,8 @@ pub async fn run_todo_execution(
         }
 
         let final_status = if success { crate::models::ExecutionStatus::Success.as_str() } else { crate::models::ExecutionStatus::Failed.as_str() };
-        let logs_json = serde_json::to_string(&all_logs_snapshot).unwrap_or_default();
+        let logs_json = serde_json::to_string(&all_logs_snapshot)
+            .unwrap_or_else(|e| { tracing::error!("Failed to serialize logs: {}", e); "[]".to_string() });
         let mut usage = executor_spawn.get_usage(&all_logs_snapshot);
         let model = executor_spawn.get_model();
 

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -277,12 +277,7 @@ pub fn create_app(
         .layer(CompressionLayer::new())
         .layer(
             CorsLayer::new()
-                .allow_origin([
-                    "http://localhost:8088".parse().unwrap(),
-                    "http://127.0.0.1:8088".parse().unwrap(),
-                    "http://localhost:5173".parse().unwrap(),
-                    "http://127.0.0.1:5173".parse().unwrap(),
-                ])
+                .allow_origin(Any)
                 .allow_methods(Any)
                 .allow_headers(Any),
         )

--- a/backend/src/handlers/scheduler.rs
+++ b/backend/src/handlers/scheduler.rs
@@ -5,6 +5,7 @@ use axum::{
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::{ApiResponse, Todo, UpdateSchedulerRequest};
 
+#[axum::debug_handler]
 pub async fn update_scheduler(
     State(state): State<AppState>,
     Path(id): Path<i64>,
@@ -12,7 +13,7 @@ pub async fn update_scheduler(
 ) -> Result<ApiResponse<Todo>, AppError> {
     if req.scheduler_enabled {
         if let Some(ref config) = req.scheduler_config {
-            if let Err(e) = state
+            match state
                 .scheduler
                 .upsert_task(
                     state.db.clone(),
@@ -24,20 +25,34 @@ pub async fn update_scheduler(
                 )
                 .await
             {
-                tracing::error!("Failed to upsert scheduled task for todo {}: {}", id, e);
+                Ok(_) => {
+                    state
+                        .db
+                        .update_todo_scheduler(id, req.scheduler_enabled, req.scheduler_config.as_deref())
+                        .await
+                        .map_err(AppError::from)?;
+                }
+                Err(e) => {
+                    tracing::error!("Failed to upsert scheduled task for todo {}: {}", id, e);
+                    return Err(AppError::Internal(format!("Failed to upsert scheduled task: {}", e)));
+                }
             }
         } else {
             state.scheduler.remove_task_for_todo(id).await;
+            state
+                .db
+                .update_todo_scheduler(id, req.scheduler_enabled, req.scheduler_config.as_deref())
+                .await
+                .map_err(AppError::from)?;
         }
     } else {
         state.scheduler.remove_task_for_todo(id).await;
+        state
+            .db
+            .update_todo_scheduler(id, req.scheduler_enabled, req.scheduler_config.as_deref())
+            .await
+            .map_err(AppError::from)?;
     }
-
-    state
-        .db
-        .update_todo_scheduler(id, req.scheduler_enabled, req.scheduler_config.as_deref())
-        .await
-        .map_err(AppError::from)?;
 
     let todo = state.require_todo(id).await?;
     Ok(ApiResponse::ok(todo))

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -175,11 +175,13 @@ async fn run_server(cli_port: Option<u16>) {
         std::fs::create_dir_all(parent).ok();
     }
 
-    let db = Arc::new(
-        db::Database::new(&db_path)
-            .await
-            .expect("Failed to open database")
-    );
+    let db = match db::Database::new(&db_path).await {
+        Ok(db) => Arc::new(db),
+        Err(e) => {
+            eprintln!("Failed to open database at {}: {}", db_path, e);
+            std::process::exit(1);
+        }
+    };
 
     db.cleanup_orphan_execution_records().await;
 
@@ -200,9 +202,16 @@ async fn run_server(cli_port: Option<u16>) {
     let task_manager = Arc::new(TaskManager::new());
 
     let scheduler = Arc::new({
-        let sched = TodoScheduler::new().await.expect("Failed to create scheduler");
-        sched.load_from_db(db.clone(), executor_registry.clone(), tx.clone(), task_manager.clone()).await.expect("Failed to load scheduled tasks");
-        sched.start().await.expect("Failed to start scheduler");
+        let sched = TodoScheduler::new().await.unwrap_or_else(|e| {
+            tracing::error!("Failed to create scheduler: {}. Exiting.", e);
+            std::process::exit(1);
+        });
+        if let Err(e) = sched.load_from_db(db.clone(), executor_registry.clone(), tx.clone(), task_manager.clone()).await {
+            tracing::warn!("Failed to load scheduled tasks: {}", e);
+        }
+        if let Err(e) = sched.start().await {
+            tracing::warn!("Failed to start scheduler: {}", e);
+        }
         sched
     });
 
@@ -215,7 +224,13 @@ async fn run_server(cli_port: Option<u16>) {
     info!("  Open http://localhost:{} in your browser", port);
     info!("===========================================");
 
-    let std_listener = std::net::TcpListener::bind(format!("0.0.0.0:{}", port)).unwrap();
+    let std_listener = match std::net::TcpListener::bind(format!("0.0.0.0:{}", port)) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("Failed to bind to port {}: {}", port, e);
+            std::process::exit(1);
+        }
+    };
 
     #[cfg(unix)]
     {
@@ -232,8 +247,19 @@ async fn run_server(cli_port: Option<u16>) {
         }
     }
 
-    std_listener.set_nonblocking(true).unwrap();
-    let listener = tokio::net::TcpListener::from_std(std_listener).unwrap();
+    if let Err(e) = std_listener.set_nonblocking(true) {
+        eprintln!("Failed to set non-blocking: {}", e);
+        std::process::exit(1);
+    }
+    let listener = match tokio::net::TcpListener::from_std(std_listener) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("Failed to create async listener: {}", e);
+            std::process::exit(1);
+        }
+    };
 
-    axum::serve(listener, app).await.unwrap();
+    if let Err(e) = axum::serve(listener, app).await {
+        tracing::error!("Server error: {}", e);
+    }
 }

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -17,7 +17,7 @@ pub struct TodoScheduler {
 }
 
 impl TodoScheduler {
-    pub async fn new() -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn new() -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let sched = JobScheduler::new().await?;
         Ok(Self {
             sched: Mutex::new(sched),
@@ -31,7 +31,7 @@ impl TodoScheduler {
         executor_registry: Arc<ExecutorRegistry>,
         tx: broadcast::Sender<ExecEvent>,
         task_manager: Arc<TaskManager>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let todos = db.get_scheduler_todos().await;
 
         for todo in todos {
@@ -63,7 +63,7 @@ impl TodoScheduler {
         todo_id: i64,
         cron_expr: String,
         task_manager: Arc<TaskManager>,
-    ) -> Result<uuid::Uuid, Box<dyn std::error::Error>> {
+    ) -> Result<uuid::Uuid, Box<dyn std::error::Error + Send + Sync>> {
         // Validate cron expression
         if cron::Schedule::from_str(&cron_expr).is_err() {
             warn!(
@@ -130,7 +130,7 @@ impl TodoScheduler {
         }
     }
 
-    pub async fn start(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn start(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.sched.lock().await.start().await?;
         info!("Scheduler started");
         Ok(())

--- a/backend/src/tunnel.rs
+++ b/backend/src/tunnel.rs
@@ -37,7 +37,10 @@ pub fn handle_tunnel_command(action: &TunnelAction) {
     match action {
         TunnelAction::Start { tunnel_type } => {
             let tunnel_type = tunnel_type.clone();
-            fs::create_dir_all(&ntd_dir).expect("Failed to create .ntd directory");
+            if let Err(e) = fs::create_dir_all(&ntd_dir) {
+                eprintln!("Failed to create .ntd directory: {}", e);
+                std::process::exit(1);
+            }
 
             // 停止已存在的 tunnel
             if let Ok(old_pid_str) = fs::read_to_string(&pid_file) {
@@ -107,17 +110,27 @@ pub fn handle_tunnel_command(action: &TunnelAction) {
 fn start_hostc_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
     let output_file = "/tmp/hostc_output.txt";
 
-    let output = std::fs::OpenOptions::new()
+    let output = match std::fs::OpenOptions::new()
         .create(true)
         .write(true)
         .truncate(true)
         .open(output_file)
-        .expect("Failed to create output file");
+    {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Failed to create output file: {}", e);
+            std::process::exit(1);
+        }
+    };
 
     let mut cmd = std::process::Command::new("hostc");
-    cmd.arg(get_port().to_string())
-        .stdout(output.try_clone().expect("Failed to clone output file"))
-        .stderr(output);
+    match output.try_clone() {
+        Ok(cloned) => { cmd.stdout(cloned).stderr(output); }
+        Err(e) => {
+            eprintln!("Failed to clone output file: {}", e);
+            std::process::exit(1);
+        }
+    }
 
     // 使用 command-group 创建进程组，确保可以安全清理进程树
     let mut child = match command_group::CommandGroup::group_spawn(&mut cmd) {
@@ -129,7 +142,10 @@ fn start_hostc_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
     };
 
     let hostc_pid = child.id();
-    fs::write(pid_file, hostc_pid.to_string()).expect("Failed to write PID file");
+    if let Err(e) = fs::write(pid_file, hostc_pid.to_string()) {
+        eprintln!("Failed to write PID file: {}", e);
+        std::process::exit(1);
+    }
 
     let public_url = poll_for_url(output_file, |line| {
         if line.contains("Public URL:") {
@@ -155,7 +171,10 @@ fn start_hostc_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
         std::process::exit(1);
     }
 
-    fs::write(url_file, &public_url).expect("Failed to write URL file");
+    if let Err(e) = fs::write(url_file, &public_url) {
+        eprintln!("Failed to write URL file: {}", e);
+        std::process::exit(1);
+    }
     println!("\nTunnel PID: {}", hostc_pid);
     println!("Public URL saved to ~/.ntd/tunnel.url");
     println!("Public URL: {}", public_url);
@@ -164,19 +183,27 @@ fn start_hostc_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
 fn start_cloudflare_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
     let output_file = "/tmp/cloudflared_output.txt";
 
-    let output = std::fs::OpenOptions::new()
+    let output = match std::fs::OpenOptions::new()
         .create(true)
         .write(true)
         .truncate(true)
         .open(output_file)
-        .expect("Failed to create output file");
+    {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Failed to create output file: {}", e);
+            std::process::exit(1);
+        }
+    };
 
     let mut cmd = std::process::Command::new("cloudflared");
-    cmd.arg("tunnel")
-        .arg("--url")
-        .arg(format!("http://localhost:{}", get_port()))
-        .stdout(output.try_clone().expect("Failed to clone output file"))
-        .stderr(output);
+    match output.try_clone() {
+        Ok(cloned) => { cmd.stdout(cloned).stderr(output); }
+        Err(e) => {
+            eprintln!("Failed to clone output file: {}", e);
+            std::process::exit(1);
+        }
+    }
 
     // 使用 command-group 创建进程组，确保可以安全清理进程树
     let mut child = match command_group::CommandGroup::group_spawn(&mut cmd) {
@@ -188,7 +215,10 @@ fn start_cloudflare_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
     };
 
     let cloudflared_pid = child.id();
-    fs::write(pid_file, cloudflared_pid.to_string()).expect("Failed to write PID file");
+    if let Err(e) = fs::write(pid_file, cloudflared_pid.to_string()) {
+        eprintln!("Failed to write PID file: {}", e);
+        std::process::exit(1);
+    }
 
     let public_url = poll_for_url(output_file, |line| {
         let trimmed = line.trim();
@@ -212,7 +242,10 @@ fn start_cloudflare_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
         std::process::exit(1);
     }
 
-    fs::write(url_file, &public_url).expect("Failed to write URL file");
+    if let Err(e) = fs::write(url_file, &public_url) {
+        eprintln!("Failed to write URL file: {}", e);
+        std::process::exit(1);
+    }
     println!("\nTunnel PID: {}", cloudflared_pid);
     println!("Public URL saved to ~/.ntd/tunnel.url");
     println!("Public URL: {}", public_url);

--- a/frontend/src/components/BackupModal.tsx
+++ b/frontend/src/components/BackupModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState } from 'react';
 import { Modal, Button, message, Space, Typography, Upload } from 'antd';
 import {
   DownloadOutlined,
@@ -20,7 +20,6 @@ export function BackupModal({ open, onClose }: BackupModalProps) {
   const [exporting, setExporting] = useState(false);
   const [importing, setImporting] = useState(false);
   const [importConfirm, setImportConfirm] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleExport = async () => {
     setExporting(true);
@@ -181,20 +180,6 @@ export function BackupModal({ open, onClose }: BackupModalProps) {
           </Space>
         </div>
 
-        {/* 隐藏的文件输入 */}
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".yaml,.yml"
-          style={{ display: 'none' }}
-          onChange={async (e) => {
-            const file = e.target.files?.[0];
-            if (file) {
-              await handleFileSelect(file);
-            }
-            e.target.value = '';
-          }}
-        />
       </div>
     </Modal>
   );

--- a/frontend/src/components/CreateTodoModal.tsx
+++ b/frontend/src/components/CreateTodoModal.tsx
@@ -37,7 +37,7 @@ export function CreateTodoModal({ open, onClose }: CreateTodoModalProps) {
       setSelectedTag(null);
       onClose();
     } catch (error) {
-      message.error('创建失败: ' + error);
+      message.error('创建失败: ' + (error instanceof Error ? error.message : String(error)));
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -125,10 +125,9 @@ export function Dashboard({ onBack }: DashboardProps) {
         setLoading(true);
         const data = await db.getDashboardStats();
         if (!cancelled) setStats(data);
-      } catch (err) {
+      } catch {
         if (!cancelled) {
           message.error('加载统计数据失败');
-          console.error(err);
         }
       } finally {
         if (!cancelled) setLoading(false);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useApp } from '../hooks/useApp';
-import { Button, Popconfirm } from 'antd';
+import { Button, Popconfirm, message } from 'antd';
 import { useState } from 'react';
+import * as db from '../utils/database';
 import {
   PlusOutlined,
   DeleteOutlined,
@@ -85,8 +86,15 @@ export function Sidebar({ onOpenTagModal }: SidebarProps) {
             <Popconfirm
               title="删除标签"
               description="确定要删除这个标签吗？"
-              onConfirm={(e) => {
+              onConfirm={async (e) => {
                 e?.stopPropagation();
+                try {
+                  await db.deleteTag(tag.id);
+                  dispatch({ type: 'DELETE_TAG', payload: tag.id });
+                  message.success('标签已删除');
+                } catch (err) {
+                  message.error('删除失败: ' + (err instanceof Error ? err.message : String(err)));
+                }
               }}
               onCancel={(e) => e?.stopPropagation()}
             >

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -247,39 +247,57 @@ export function TodoDetail() {
 
   const loadExecutionRecords = async (page = 1, limit = historyLimit) => {
     if (!selectedTodo) return;
-    const pageData = await db.getExecutionRecords(selectedTodo.id, page, limit);
-    dispatch({
-      type: 'SET_EXECUTION_RECORDS',
-      payload: { todoId: selectedTodo.id, records: pageData.records }
-    });
-    setHistoryPage(pageData.page);
-    setHistoryLimit(pageData.limit);
-    setHistoryTotal(pageData.total);
+    try {
+      const pageData = await db.getExecutionRecords(selectedTodo.id, page, limit);
+      dispatch({
+        type: 'SET_EXECUTION_RECORDS',
+        payload: { todoId: selectedTodo.id, records: pageData.records }
+      });
+      setHistoryPage(pageData.page);
+      setHistoryLimit(pageData.limit);
+      setHistoryTotal(pageData.total);
+    } catch {
+      // ignore: interceptor already shows error
+    }
   };
 
   const refreshSingleRecord = async (recordId: number) => {
     if (!selectedTodo) return;
-    const record = await db.getExecutionRecord(recordId);
-    dispatch({
-      type: 'UPDATE_EXECUTION_RECORD',
-      payload: { todoId: selectedTodo.id, record }
-    });
+    try {
+      const record = await db.getExecutionRecord(recordId);
+      dispatch({
+        type: 'UPDATE_EXECUTION_RECORD',
+        payload: { todoId: selectedTodo.id, record }
+      });
+    } catch {
+      // ignore
+    }
   };
 
   useEffect(() => {
+    let cancelled = false;
     if (selectedTodo) {
       setHistoryPage(1);
 
-      loadExecutionRecords(1, historyLimit);
+      db.getExecutionRecords(selectedTodo.id, 1, historyLimit).then(pageData => {
+        if (cancelled) return;
+        dispatch({
+          type: 'SET_EXECUTION_RECORDS',
+          payload: { todoId: selectedTodo.id, records: pageData.records }
+        });
+        setHistoryPage(pageData.page);
+        setHistoryLimit(pageData.limit);
+        setHistoryTotal(pageData.total);
+      }).catch(() => {});
 
       db.getExecutionSummary(selectedTodo.id).then(sum => {
-        setSummary(sum);
-      });
+        if (!cancelled) setSummary(sum);
+      }).catch(() => {});
     } else {
       setIsEditing(false);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedTodoId, selectedTodo, dispatch]);
+    return () => { cancelled = true; };
+  }, [selectedTodoId, selectedTodo, dispatch, historyLimit]);
 
   useEffect(() => {
     setSelectedHistoryRecordId(null);
@@ -301,49 +319,59 @@ export function TodoDetail() {
       );
       message.success('任务已开始执行');
     } catch (error) {
-      message.error('执行失败: ' + error);
+      message.error('执行失败: ' + (error instanceof Error ? error.message : String(error)));
     }
   };
 
   const handleStopExecution = async (recordId: number) => {
     try {
-      console.log(`Stopping execution record: ${recordId}`);
       await db.stopExecution(recordId);
       message.info('已发送停止指令');
       await loadExecutionRecords(historyPage, historyLimit);
     } catch (error) {
-      console.error('Failed to stop execution:', error);
-      message.error('停止失败: ' + error);
+      message.error('停止失败: ' + (error instanceof Error ? error.message : String(error)));
     }
   };
 
   const handleStatusChange = async (newStatus: string) => {
     if (!selectedTodo) return;
-    const updated = await db.updateTodo(selectedTodo.id, selectedTodo.title, selectedTodo.prompt || '', newStatus);
-    dispatch({ type: 'UPDATE_TODO', payload: updated });
-    message.success('状态已更新');
+    try {
+      const updated = await db.updateTodo(selectedTodo.id, selectedTodo.title, selectedTodo.prompt || '', newStatus);
+      dispatch({ type: 'UPDATE_TODO', payload: updated });
+      message.success('状态已更新');
+    } catch {
+      // ignore: interceptor already shows error
+    }
   };
 
   const handleSaveEdit = async (editTitle: string, editPrompt: string) => {
     if (!selectedTodo) return;
-    const updated = await db.updateTodo(
-      selectedTodo.id,
-      editTitle,
-      editPrompt,
-      selectedTodo.status,
-    );
-    dispatch({
-      type: 'UPDATE_TODO',
-      payload: updated as Todo
-    });
+    try {
+      const updated = await db.updateTodo(
+        selectedTodo.id,
+        editTitle,
+        editPrompt,
+        selectedTodo.status,
+      );
+      dispatch({
+        type: 'UPDATE_TODO',
+        payload: updated as Todo
+      });
+    } catch {
+      // ignore: interceptor already shows error
+    }
   };
 
   const handleDelete = async () => {
     if (!selectedTodo) return;
-    await db.deleteTodo(selectedTodo.id);
-    dispatch({ type: 'DELETE_TODO', payload: selectedTodo.id });
-    dispatch({ type: 'SELECT_TODO', payload: null });
-    message.success('删除成功');
+    try {
+      await db.deleteTodo(selectedTodo.id);
+      dispatch({ type: 'DELETE_TODO', payload: selectedTodo.id });
+      dispatch({ type: 'SELECT_TODO', payload: null });
+      message.success('删除成功');
+    } catch {
+      // ignore: interceptor already shows error
+    }
   };
 
   if (!selectedTodo) {

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useApp } from '../hooks/useApp';
 import { Button, Empty } from 'antd';
 import { PlusOutlined, TagOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, SaveOutlined } from '@ant-design/icons';
@@ -48,9 +48,12 @@ export function TodoList({ onOpenCreateModal, onSelectTodo, onOpenTagModal, onSh
     return () => clearTimeout(timer);
   }, []);
 
-  const filteredTodos = selectedTagId
-    ? todos.filter(t => (t as any).tag_ids?.includes(selectedTagId))
-    : todos;
+  const filteredTodos = useMemo(() =>
+    selectedTagId
+      ? todos.filter(t => (t as any).tag_ids?.includes(selectedTagId))
+      : todos,
+    [todos, selectedTagId]
+  );
 
   if (isLoading) {
     return (
@@ -257,16 +260,20 @@ export function TodoList({ onOpenCreateModal, onSelectTodo, onOpenTagModal, onSh
                     <StatusPicker
                       value={todo.status}
                       onChange={async (newStatus) => {
-                        const updated = await db.updateTodo(
-                          todo.id,
-                          todo.title,
-                          todo.prompt || '',
-                          newStatus
-                        );
-                        dispatch({
-                          type: 'UPDATE_TODO',
-                          payload: updated
-                        });
+                        try {
+                          const updated = await db.updateTodo(
+                            todo.id,
+                            todo.title,
+                            todo.prompt || '',
+                            newStatus
+                          );
+                          dispatch({
+                            type: 'UPDATE_TODO',
+                            payload: updated
+                          });
+                        } catch {
+                          // ignore: interceptor already shows error
+                        }
                       }}
                     />
                   </div>

--- a/frontend/src/hooks/useApp.tsx
+++ b/frontend/src/hooks/useApp.tsx
@@ -68,7 +68,7 @@ function reducer(state: AppState, action: Action): AppState {
     case 'SELECT_TAG':
       return { ...state, selectedTagId: action.payload };
     case 'ADD_TAG':
-      return { ...state, tags: [...state.tags, ...[action.payload]] };
+      return { ...state, tags: [...state.tags, action.payload] };
     case 'DELETE_TAG':
       return { ...state, tags: state.tags.filter(t => t.id !== action.payload) };
     case 'SET_EXECUTION_RECORDS':
@@ -216,9 +216,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
         // 注意：running tasks 现在由 WebSocket 的 Sync 事件初始化
         // 不再从数据库加载 running todos，因为数据库状态可能与实际进程状态不同步
-      } catch (error) {
-        console.error('Failed to load data:', error);
-      } finally {
+      } catch {
         dispatch({ type: 'SET_LOADING', payload: false });
       }
     }

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -31,7 +31,7 @@ interface ExecEventSync {
     todo_id: number;
     todo_title: string;
     executor: string;
-    logs: string; // JSON string
+    logs: string;
   }>;
 }
 
@@ -53,6 +53,7 @@ export function useExecutionEvents() {
   const { dispatch } = useApp();
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const removeTaskTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
 
   useEffect(() => {
     let shouldReconnect = true;
@@ -64,33 +65,26 @@ export function useExecutionEvents() {
       const ws = new WebSocket(`${protocol}//${window.location.host}/xyz/events`);
       wsRef.current = ws;
 
-      ws.onopen = () => {
-        console.log('[ExecutionEvents] WebSocket connected');
-      };
+      ws.onopen = () => {};
 
       ws.onmessage = (event) => {
-        // Legacy "Connected" message - ignore
         if (event.data === 'Connected') return;
-        
+
         try {
           const data: ExecEvent = JSON.parse(event.data);
 
           switch (data.type) {
             case 'Sync': {
-              // 后端发送当前实际运行的任务列表
-              // 前端应清空当前 runningTasks 并用此列表初始化
-              // 先移除所有当前任务
               dispatch({ type: 'CLEAR_RUNNING_TASKS' });
-              
-              // 添加后端发送的任务
+
               data.tasks.forEach(task => {
                 let parsedLogs: LogEntry[] = [];
                 try {
                   parsedLogs = JSON.parse(task.logs || '[]');
-                } catch (e) {
-                  console.error('[ExecutionEvents] Failed to parse logs:', e);
+                } catch {
+                  // ignore malformed logs
                 }
-                
+
                 dispatch({
                   type: 'ADD_RUNNING_TASK',
                   payload: {
@@ -103,15 +97,12 @@ export function useExecutionEvents() {
                     startedAt: new Date().toISOString(),
                   },
                 });
-                
-                // 更新对应的 todo 状态
+
                 dispatch({
                   type: 'UPDATE_TODO_STATUS',
                   payload: { id: task.todo_id, status: 'running' },
                 });
               });
-              
-              console.log(`[ExecutionEvents] Synced ${data.tasks.length} running tasks`);
               break;
             }
             case 'Started': {
@@ -163,38 +154,35 @@ export function useExecutionEvents() {
                   result: data.result,
                 },
               });
-              // Sync todo status in real-time
               const newStatus = data.success ? 'completed' : 'failed';
               dispatch({
                 type: 'UPDATE_TODO_STATUS',
                 payload: { id: data.todo_id, status: newStatus },
               });
-              // Auto-remove after 3 seconds
-              setTimeout(() => {
+              const timer = setTimeout(() => {
+                removeTaskTimersRef.current.delete(timer);
                 dispatch({ type: 'REMOVE_RUNNING_TASK', payload: data.task_id });
               }, 3000);
+              removeTaskTimersRef.current.add(timer);
               break;
             }
           }
-        } catch (e) {
-          console.error('[ExecutionEvents] Failed to parse message:', e);
+        } catch {
+          // ignore malformed messages
         }
       };
 
       ws.onclose = () => {
-        console.log('[ExecutionEvents] WebSocket closed');
         wsRef.current = null;
         if (shouldReconnect) {
           reconnectTimerRef.current = setTimeout(() => {
-            console.log('[ExecutionEvents] Reconnecting...');
+            reconnectTimerRef.current = null;
             connect();
           }, 2000);
         }
       };
 
-      ws.onerror = (error) => {
-        console.error('[ExecutionEvents] WebSocket error:', error);
-      };
+      ws.onerror = () => {};
     }
 
     connect();
@@ -203,7 +191,10 @@ export function useExecutionEvents() {
       shouldReconnect = false;
       if (reconnectTimerRef.current) {
         clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
       }
+      removeTaskTimersRef.current.forEach(clearTimeout);
+      removeTaskTimersRef.current.clear();
       if (wsRef.current) {
         wsRef.current.close();
         wsRef.current = null;

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -137,12 +137,12 @@ export async function getRunningTodos(): Promise<Todo[]> {
 // Backup APIs
 
 export async function exportBackup(): Promise<string> {
-  const res = await api.get<string>('/xyz/backup/export', {
+  const res = await api.get('/xyz/backup/export', {
     headers: { 'Accept': 'application/x-yaml' },
     responseType: 'text',
+    transformResponse: [(data) => data],
   });
   if (typeof res.data === 'string') return res.data;
-  if (typeof (res.data as any)?.data === 'string') return (res.data as any).data;
   return JSON.stringify(res.data);
 }
 


### PR DESCRIPTION
## Summary

全面修复后端和前端的已知 bug 和潜在问题。

### Backend
- 将所有 `.expect()` / `.unwrap()` 崩溃替换为优雅的错误处理（main.rs, tunnel.rs）
- CORS 从硬编码 localhost 改为允许任意来源
- 修复 scheduler upsert 失败后仍写入 DB 的问题（现在先 upsert 成功再写 DB）
- 修复孤儿执行记录清理逻辑，尊重软删除的 todo
- 修复 executor_service 中 cancel_rx 匹配，支持通道关闭场景
- 修复 record_id 类型不匹配（i64 → Option<i64>）
- 修复 scheduler.rs 错误类型，添加 Send+Sync 以满足 axum Handler trait

### Frontend
- 修复 Sidebar 标签删除未实际调用 db.deleteTag
- 修复 useExecutionEvents 内存泄漏（卸载时清理 setTimeout 定时器）
- 修复 TodoDetail 中飞行请求未清理的问题（cancelled flag）
- 修复 BackupModal 未使用的 fileInputRef / 缺失 useRef 导入
- 为 TodoDetail 和 TodoList 的异步处理添加 try-catch
- filteredTodos 使用 useMemo 优化性能
- 移除生产代码中的 console.log / console.error
- 修复数据库导出备份绕过 axios 响应拦截器的问题