### PR TITLE
fix: correct path normalization bugs in config

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -130,7 +130,8 @@ impl Config {
             && path.contains(std::path::MAIN_SEPARATOR)
         {
             if let Some(home) = dirs::home_dir() {
-                return home.join(path).to_string_lossy().to_string();
+                let stripped = path.trim_start_matches("./");
+                return home.join(stripped).to_string_lossy().to_string();
             }
         }
         path.to_string()
@@ -177,7 +178,7 @@ mod tests {
     fn test_normalize_single_path_tilde_expansion() {
         let home = dirs::home_dir().expect("need home dir for test");
         let result = Config::normalize_single_path("~/bin/joinai");
-        let expected = format!("{}/bin/joinai", home.display());
+        let expected = home.join("bin").join("joinai").to_string_lossy().to_string();
         assert_eq!(result, expected, "~ should expand to home directory");
     }
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -122,10 +122,13 @@ impl Config {
     fn normalize_single_path(path: &str) -> String {
         if path.starts_with('~') {
             if let Some(home) = dirs::home_dir() {
-                let relative = path.trim_start_matches('~');
+                let relative = path.trim_start_matches('~').trim_start_matches(std::path::MAIN_SEPARATOR);
                 return home.join(relative).to_string_lossy().to_string();
             }
-        } else if !path.is_empty() && !PathBuf::from(path).is_absolute() {
+        } else if !path.is_empty()
+            && !PathBuf::from(path).is_absolute()
+            && path.contains(std::path::MAIN_SEPARATOR)
+        {
             if let Some(home) = dirs::home_dir() {
                 return home.join(path).to_string_lossy().to_string();
             }
@@ -168,5 +171,45 @@ mod tests {
         let restored: Config = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(restored.port, 1234);
         assert!(restored.db_path.contains(".ntd/data.db"));
+    }
+
+    #[test]
+    fn test_normalize_single_path_tilde_expansion() {
+        let home = dirs::home_dir().expect("need home dir for test");
+        let result = Config::normalize_single_path("~/bin/joinai");
+        let expected = format!("{}/bin/joinai", home.display());
+        assert_eq!(result, expected, "~ should expand to home directory");
+    }
+
+    #[test]
+    fn test_normalize_single_path_relative() {
+        let home = dirs::home_dir().expect("need home dir for test");
+        let result = Config::normalize_single_path("./local/claude");
+        assert!(
+            result.starts_with(&format!("{}", home.display())),
+            "relative path should be resolved to absolute under home"
+        );
+        assert_ne!(result, "./local/claude", "relative path should be changed");
+    }
+
+    #[test]
+    fn test_normalize_single_path_bare_command() {
+        let result = Config::normalize_single_path("opencode");
+        assert_eq!(result, "opencode", "bare command name should be left untouched for PATH lookup");
+
+        let result = Config::normalize_single_path("joinai");
+        assert_eq!(result, "joinai", "bare command name should be left untouched for PATH lookup");
+    }
+
+    #[test]
+    fn test_normalize_single_path_empty() {
+        let result = Config::normalize_single_path("");
+        assert_eq!(result, "", "empty path should remain empty");
+    }
+
+    #[test]
+    fn test_normalize_single_path_already_absolute() {
+        let result = Config::normalize_single_path("/usr/bin/claude");
+        assert_eq!(result, "/usr/bin/claude", "absolute path should not be modified");
     }
 }


### PR DESCRIPTION
## Summary

修复 PR #60 中 CodeRabbit 审查指出的两个关键 bug：

### Bug 1: `~` 扩展时丢弃 home 目录
路径如 `~/bin/joinai`，`trim_start_matches('~')` 后得到 `/bin/joinai`，`PathBuf::join` 遇到绝对路径会丢弃前缀，最终变成 `/bin/joinai` 而非 `<home>/bin/joinai`。

**修复**: 在 `trim_start_matches('~')` 后再加上 `trim_start_matches(MAIN_SEPARATOR)`，确保相对部分正确拼接。

### Bug 2: 裸命令名被错误当作相对路径
配置中默认值如 `opencode`、`joinai` 等纯命令名，由于 `!PathBuf::from(path).is_absolute()` 为 true，被错误前缀为 `<home>/opencode`，导致 PATH 查找失效。

**修复**: 增加 `path.contains(MAIN_SEPARATOR)` 条件，只有包含路径分隔符的路径才被当作相对路径处理，裸命令名保持不变。

### 测试
新增 5 个单元测试覆盖关键场景：
- `~/bin/joinai` → home 目录展开
- `./local/claude` → 解析为绝对路径
- `opencode` → 保持不变（PATH 查找）
- `""` → 保持空
- `/usr/bin/claude` → 绝对路径不变