### PR TITLE
feat: AI-friendly CLI with --raw, --fields, --stdin, --search

### DIFF
--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -566,3 +566,173 @@ fn print_response<T: serde::Serialize>(
     }
     Ok(())
 }
+
+// ============== Tests ==============
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_parse_fields_none() {
+        assert_eq!(parse_fields(&None), None);
+    }
+
+    #[test]
+    fn test_parse_fields_single() {
+        assert_eq!(
+            parse_fields(&Some("id".to_string())),
+            Some(vec!["id".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_parse_fields_multiple() {
+        assert_eq!(
+            parse_fields(&Some("id,title,status".to_string())),
+            Some(vec!["id".to_string(), "title".to_string(), "status".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_parse_fields_with_spaces() {
+        assert_eq!(
+            parse_fields(&Some("id, title , status ".to_string())),
+            Some(vec!["id".to_string(), "title".to_string(), "status".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_parse_fields_empty_string() {
+        assert_eq!(parse_fields(&Some("".to_string())), Some(vec![]));
+    }
+
+    #[test]
+    fn test_filter_fields_object() {
+        let value = json!({"id": 1, "title": "test", "prompt": "long text", "status": "pending"});
+        let fields = vec!["id".to_string(), "title".to_string()];
+        let result = filter_fields(&value, &fields);
+        assert_eq!(result, json!({"id": 1, "title": "test"}));
+    }
+
+    #[test]
+    fn test_filter_fields_missing_field() {
+        let value = json!({"id": 1, "title": "test"});
+        let fields = vec!["id".to_string(), "nonexistent".to_string()];
+        let result = filter_fields(&value, &fields);
+        assert_eq!(result, json!({"id": 1}));
+    }
+
+    #[test]
+    fn test_filter_fields_non_object() {
+        let value = json!("string value");
+        let fields = vec!["id".to_string()];
+        let result = filter_fields(&value, &fields);
+        assert_eq!(result, json!("string value"));
+    }
+
+    #[test]
+    fn test_filter_array_fields() {
+        let arr = vec![
+            json!({"id": 1, "title": "a", "prompt": "p1"}),
+            json!({"id": 2, "title": "b", "prompt": "p2"}),
+        ];
+        let fields = vec!["id".to_string(), "title".to_string()];
+        let result = filter_array_fields(&arr, &fields);
+        assert_eq!(
+            result,
+            vec![
+                json!({"id": 1, "title": "a"}),
+                json!({"id": 2, "title": "b"}),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_filter_fields_empty_selection() {
+        let value = json!({"id": 1, "title": "test"});
+        let fields: Vec<String> = vec![];
+        let result = filter_fields(&value, &fields);
+        assert_eq!(result, json!({}));
+    }
+
+    // Clap parsing tests for new arguments
+
+    #[test]
+    fn test_cli_parse_raw_output() {
+        let cli = Cli::try_parse_from(["ntd", "-o", "raw", "todo", "list"]).unwrap();
+        assert_eq!(cli.output, OutputFormat::Raw);
+    }
+
+    #[test]
+    fn test_cli_parse_fields() {
+        let cli = Cli::try_parse_from(["ntd", "-f", "id,title", "todo", "list"]).unwrap();
+        assert_eq!(cli.fields, Some("id,title".to_string()));
+    }
+
+    #[test]
+    fn test_cli_parse_search() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "list", "-s", "rust"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::List { search, .. } } => {
+                assert_eq!(search, Some("rust".to_string()));
+            }
+            _ => panic!("Expected Todo::List with search"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_stdin_create() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "create", "--stdin"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Create { stdin, .. } } => {
+                assert!(stdin);
+            }
+            _ => panic!("Expected Todo::Create with stdin"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_stdin_update() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "update", "1", "--stdin"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Update { stdin, .. } } => {
+                assert!(stdin);
+            }
+            _ => panic!("Expected Todo::Update with stdin"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_create_without_title_requires_stdin() {
+        // Creating without title and without --stdin should still parse (validation is at runtime)
+        let cli = Cli::try_parse_from(["ntd", "todo", "create"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Create { title, stdin, .. } } => {
+                assert!(title.is_none());
+                assert!(!stdin);
+            }
+            _ => panic!("Expected Todo::Create"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_combined_options() {
+        let cli = Cli::try_parse_from([
+            "ntd", "-o", "raw", "-f", "id,title,status",
+            "todo", "list",
+            "--status", "pending",
+            "--search", "bug",
+        ]).unwrap();
+        assert_eq!(cli.output, OutputFormat::Raw);
+        assert_eq!(cli.fields, Some("id,title,status".to_string()));
+        match cli.command {
+            Commands::Todo { action: TodoAction::List { status, search, .. } } => {
+                assert_eq!(status, Some("pending".to_string()));
+                assert_eq!(search, Some("bug".to_string()));
+            }
+            _ => panic!("Expected Todo::List"),
+        }
+    }
+}

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -397,13 +397,18 @@ async fn handle_todo(
             let resp: ClientResponse<Todo> = client.get(&format!("/todos/{}", id)).await?;
             print_response(resp, output, fields)?;
         }
-        TodoAction::Update { id, title, prompt, file: _, stdin, status, executor, workspace, tags, schedule } => {
+        TodoAction::Update { id, title, prompt, file, stdin, status, executor, workspace, tags, schedule } => {
             let mut req = if *stdin {
                 read_stdin_json()?
             } else {
+                let prompt_content = if let Some(path) = file {
+                    read_prompt_from_file(&Some(path.clone()))?
+                } else {
+                    prompt.clone().unwrap_or_default()
+                };
                 serde_json::json!({
                     "title": title,
-                    "prompt": prompt,
+                    "prompt": prompt_content,
                     "status": status,
                     "executor": executor,
                     "workspace": workspace,
@@ -532,13 +537,7 @@ fn print_response<T: serde::Serialize>(
     fields: &Option<String>,
 ) -> Result<()> {
     if resp.code != 0 {
-        // API returned an error — print structured error and fail
-        let err = serde_json::json!({
-            "error": true,
-            "code": resp.code,
-            "message": resp.message,
-        });
-        println!("{}", serde_json::to_string(&err)?);
+        // Let the caller handle structured error printing
         return Err(anyhow::anyhow!("API error {}: {}", resp.code, resp.message));
     }
 

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -1,5 +1,9 @@
+use std::io::Read;
+
+use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::models::{
     ClientResponse, CreateTagRequest, CreateTodoRequest, DashboardStats, ExecutionRecord,
@@ -20,6 +24,11 @@ pub struct Cli {
     #[arg(short, long, default_value = "json", value_enum)]
     pub output: OutputFormat,
 
+    /// Select fields to output (comma-separated, e.g. "id,title,status")
+    /// Only effective with --output raw
+    #[arg(short, long)]
+    pub fields: Option<String>,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -30,6 +39,8 @@ pub enum OutputFormat {
     #[default]
     Json,
     Pretty,
+    /// Output raw data without ApiResponse wrapper (best for AI parsing)
+    Raw,
 }
 
 // ============== CLI Commands ==============
@@ -54,8 +65,8 @@ pub enum Commands {
 pub enum TodoAction {
     /// Create a new todo
     Create {
-        /// Todo title
-        title: String,
+        /// Todo title (optional if --stdin is used)
+        title: Option<String>,
 
         /// Prompt content (use --file to load from file)
         #[arg(short, long)]
@@ -64,6 +75,10 @@ pub enum TodoAction {
         /// Read prompt from file
         #[arg(short, long)]
         file: Option<String>,
+
+        /// Read todo data from stdin as JSON
+        #[arg(long)]
+        stdin: bool,
 
         /// Executor type (claudecode, joinai, codebuddy, opencode, atomcode, hermes, kimi, codex)
         #[arg(short, long)]
@@ -77,7 +92,7 @@ pub enum TodoAction {
         #[arg(long)]
         tags: Option<String>,
 
-        /// Schedule (AI: convert natural language to cron, e.g. "*/30 * * * *")
+        /// Schedule (cron expression, e.g. "*/30 * * * *")
         #[arg(long)]
         schedule: Option<String>,
     },
@@ -94,6 +109,10 @@ pub enum TodoAction {
         /// Show only running todos
         #[arg(long)]
         running: bool,
+
+        /// Search by keyword in title or prompt
+        #[arg(short, long)]
+        search: Option<String>,
     },
     /// Get todo details
     Get {
@@ -117,6 +136,10 @@ pub enum TodoAction {
         #[arg(short, long)]
         file: Option<String>,
 
+        /// Read update data from stdin as JSON
+        #[arg(long)]
+        stdin: bool,
+
         /// New status
         #[arg(long)]
         status: Option<String>,
@@ -133,7 +156,7 @@ pub enum TodoAction {
         #[arg(long)]
         tags: Option<String>,
 
-        /// Schedule (AI: convert natural language to cron)
+        /// Schedule (cron expression)
         #[arg(long)]
         schedule: Option<String>,
     },
@@ -220,7 +243,7 @@ pub enum TagAction {
 
 // ============== Helper Functions ==============
 
-fn read_prompt_from_file(file: &Option<String>) -> anyhow::Result<String> {
+fn read_prompt_from_file(file: &Option<String>) -> Result<String> {
     match file {
         Some(path) => Ok(std::fs::read_to_string(path)?),
         None => Ok(String::new()),
@@ -234,16 +257,49 @@ fn parse_tags(tags: &Option<String>) -> Vec<i64> {
     }
 }
 
+fn read_stdin_json() -> Result<Value> {
+    let mut buffer = String::new();
+    std::io::stdin().read_to_string(&mut buffer)?;
+    let value: Value = serde_json::from_str(&buffer)
+        .map_err(|e| anyhow::anyhow!("Invalid JSON from stdin: {}", e))?;
+    Ok(value)
+}
+
+fn parse_fields(fields: &Option<String>) -> Option<Vec<String>> {
+    fields.as_ref().map(|s| {
+        s.split(',').map(|f| f.trim().to_string()).filter(|f| !f.is_empty()).collect()
+    })
+}
+
+fn filter_fields(value: &Value, fields: &[String]) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut filtered = serde_json::Map::new();
+            for field in fields {
+                if let Some(v) = map.get(field) {
+                    filtered.insert(field.clone(), v.clone());
+                }
+            }
+            Value::Object(filtered)
+        }
+        _ => value.clone(),
+    }
+}
+
+fn filter_array_fields(arr: &[Value], fields: &[String]) -> Vec<Value> {
+    arr.iter().map(|v| filter_fields(v, fields)).collect()
+}
+
 // ============== Main Entry Point ==============
 
-pub async fn run_command(cli: &Cli) -> anyhow::Result<()> {
+pub async fn run_command(cli: &Cli) -> Result<()> {
     let server_url = cli.server.clone().unwrap_or_else(|| config::Config::load().server_url());
     let client = ApiClient::new(&server_url);
 
     match &cli.command {
-        Commands::Todo { action } => handle_todo(&client, action, &cli.output).await?,
-        Commands::Tag { action } => handle_tag(&client, action, &cli.output).await?,
-        Commands::Stats => handle_stats(&client, &cli.output).await?,
+        Commands::Todo { action } => handle_todo(&client, action, &cli.output, &cli.fields).await?,
+        Commands::Tag { action } => handle_tag(&client, action, &cli.output, &cli.fields).await?,
+        Commands::Stats => handle_stats(&client, &cli.output, &cli.fields).await?,
     }
 
     Ok(())
@@ -251,26 +307,51 @@ pub async fn run_command(cli: &Cli) -> anyhow::Result<()> {
 
 // ============== Todo Handlers ==============
 
-async fn handle_todo(client: &ApiClient, action: &TodoAction, output: &OutputFormat) -> anyhow::Result<()> {
+async fn handle_todo(
+    client: &ApiClient,
+    action: &TodoAction,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
     match action {
-        TodoAction::Create { title, prompt, file, executor, workspace: _, tags, schedule: _ } => {
-            let prompt_content = if let Some(p) = prompt {
-                p.clone()
+        TodoAction::Create { title, prompt, file, stdin, executor, workspace, tags, schedule: _ } => {
+            let req = if *stdin {
+                // Read from stdin
+                let value = read_stdin_json()?;
+                let req = serde_json::from_value::<CreateTodoRequest>(value.clone())
+                    .unwrap_or_else(|_| CreateTodoRequest {
+                        title: value.get("title").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+                        prompt: value.get("prompt").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+                        tag_ids: value.get("tag_ids")
+                            .and_then(|v| v.as_array())
+                            .map(|arr| arr.iter().filter_map(|v| v.as_i64()).collect())
+                            .unwrap_or_default(),
+                        executor: value.get("executor").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                    });
+                if workspace.is_some() {
+                    // workspace is sent separately in the full JSON body
+                }
+                req
             } else {
-                read_prompt_from_file(file)?
-            };
+                let title = title.clone().ok_or_else(|| anyhow::anyhow!("Title is required. Use --stdin to read from stdin."))?;
+                let prompt_content = if let Some(p) = prompt {
+                    p.clone()
+                } else {
+                    read_prompt_from_file(file)?
+                };
 
-            let req = CreateTodoRequest {
-                title: title.clone(),
-                prompt: prompt_content,
-                tag_ids: parse_tags(tags),
-                executor: executor.clone(),
+                CreateTodoRequest {
+                    title,
+                    prompt: prompt_content,
+                    tag_ids: parse_tags(tags),
+                    executor: executor.clone(),
+                }
             };
 
             let resp: ClientResponse<Todo> = client.post("/todos", &req).await?;
-            print_response(resp, output);
+            print_response(resp, output, fields)?;
         }
-        TodoAction::List { status, tag, running } => {
+        TodoAction::List { status, tag, running, search } => {
             let mut query_params = Vec::new();
 
             if let Some(s) = status {
@@ -290,30 +371,66 @@ async fn handle_todo(client: &ApiClient, action: &TodoAction, output: &OutputFor
             };
 
             let resp: ClientResponse<Vec<Todo>> = client.get(&path).await?;
-            print_response(resp, output);
+
+            // Client-side search filtering
+            let resp = if let Some(keyword) = search {
+                let keyword = keyword.to_lowercase();
+                match resp.data {
+                    Some(todos) => {
+                        let filtered: Vec<Todo> = todos.into_iter()
+                            .filter(|t| {
+                                t.title.to_lowercase().contains(&keyword)
+                                    || t.prompt.to_lowercase().contains(&keyword)
+                            })
+                            .collect();
+                        ClientResponse { code: resp.code, data: Some(filtered), message: resp.message }
+                    }
+                    None => resp,
+                }
+            } else {
+                resp
+            };
+
+            print_response(resp, output, fields)?;
         }
         TodoAction::Get { id } => {
             let resp: ClientResponse<Todo> = client.get(&format!("/todos/{}", id)).await?;
-            print_response(resp, output);
+            print_response(resp, output, fields)?;
         }
-	        TodoAction::Update { id, title, prompt, file: _, status, executor, workspace, tags: _, schedule } => {
-            let req = serde_json::json!({
-                "title": title,
-                "prompt": prompt,
-                "status": status,
-                "executor": executor,
-                "workspace": workspace,
-                "scheduler_enabled": schedule.as_ref().map(|s| !s.is_empty()),
-                "scheduler_config": schedule.clone().filter(|s| !s.is_empty()),
-            });
-            
-            let resp: ClientResponse<Todo> = client.put(&format!("/todos/{}", id), &req).await?;
-            print_response(resp, output);
-        }
+        TodoAction::Update { id, title, prompt, file: _, stdin, status, executor, workspace, tags, schedule } => {
+            let mut req = if *stdin {
+                read_stdin_json()?
+            } else {
+                serde_json::json!({
+                    "title": title,
+                    "prompt": prompt,
+                    "status": status,
+                    "executor": executor,
+                    "workspace": workspace,
+                })
+            };
 
+            // Merge CLI args over stdin values
+            if let Some(t) = title { req["title"] = t.clone().into(); }
+            if let Some(p) = prompt { req["prompt"] = p.clone().into(); }
+            if let Some(s) = status { req["status"] = s.clone().into(); }
+            if let Some(e) = executor { req["executor"] = e.clone().into(); }
+            if let Some(w) = workspace { req["workspace"] = w.clone().into(); }
+            if let Some(t) = tags {
+                let tag_ids: Vec<i64> = t.split(',').filter_map(|s| s.trim().parse().ok()).collect();
+                req["tag_ids"] = tag_ids.into();
+            }
+            if let Some(s) = schedule {
+                req["scheduler_enabled"] = (!s.is_empty()).into();
+                req["scheduler_config"] = if s.is_empty() { Value::Null } else { s.clone().into() };
+            }
+
+            let resp: ClientResponse<Todo> = client.put(&format!("/todos/{}", id), &req).await?;
+            print_response(resp, output, fields)?;
+        }
         TodoAction::Delete { id } => {
             let resp: ClientResponse<()> = client.delete(&format!("/todos/{}", id)).await?;
-            print_response(resp, output);
+            print_response(resp, output, fields)?;
         }
         TodoAction::Execute { id, message, executor } => {
             let req = ExecuteRequest {
@@ -321,26 +438,31 @@ async fn handle_todo(client: &ApiClient, action: &TodoAction, output: &OutputFor
                 message: message.clone(),
                 executor: executor.clone(),
             };
-            let resp: ClientResponse<serde_json::Value> = client.post("/execute", &req).await?;
-            print_response(resp, output);
+            let resp: ClientResponse<Value> = client.post("/execute", &req).await?;
+            print_response(resp, output, fields)?;
         }
         TodoAction::Stop { id } => {
             let req = serde_json::json!({ "todo_id": id });
             let resp: ClientResponse<()> = client.post("/execute/stop", &req).await?;
-            print_response(resp, output);
+            print_response(resp, output, fields)?;
         }
         TodoAction::Stats { id } => {
             let resp: ClientResponse<ExecutionSummary> = client.get(&format!("/todos/{}/summary", id)).await?;
-            print_response(resp, output);
+            print_response(resp, output, fields)?;
         }
         TodoAction::Execution { action } => {
-            handle_execution(client, action, output).await?;
+            handle_execution(client, action, output, fields).await?;
         }
     }
     Ok(())
 }
 
-async fn handle_execution(client: &ApiClient, action: &ExecutionAction, output: &OutputFormat) -> anyhow::Result<()> {
+async fn handle_execution(
+    client: &ApiClient,
+    action: &ExecutionAction,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
     match action {
         ExecutionAction::List { todo_id, status, page, limit } => {
             let path = format!(
@@ -351,11 +473,11 @@ async fn handle_execution(client: &ApiClient, action: &ExecutionAction, output: 
                 status.as_ref().map(|s| format!("&status={}", s)).unwrap_or_default()
             );
             let resp: ClientResponse<ExecutionRecordsPage> = client.get(&path).await?;
-            print_response(resp, output);
+            print_response(resp, output, fields)?;
         }
         ExecutionAction::Get { id } => {
             let resp: ClientResponse<ExecutionRecord> = client.get(&format!("/execution-records/{}", id)).await?;
-            print_response(resp, output);
+            print_response(resp, output, fields)?;
         }
     }
     Ok(())
@@ -363,11 +485,16 @@ async fn handle_execution(client: &ApiClient, action: &ExecutionAction, output: 
 
 // ============== Tag Handlers ==============
 
-async fn handle_tag(client: &ApiClient, action: &TagAction, output: &OutputFormat) -> anyhow::Result<()> {
+async fn handle_tag(
+    client: &ApiClient,
+    action: &TagAction,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
     match action {
         TagAction::List => {
             let resp: ClientResponse<Vec<Tag>> = client.get("/tags").await?;
-            print_response(resp, output);
+            print_response(resp, output, fields)?;
         }
         TagAction::Create { name, color } => {
             let req = CreateTagRequest {
@@ -375,11 +502,11 @@ async fn handle_tag(client: &ApiClient, action: &TagAction, output: &OutputForma
                 color: color.clone(),
             };
             let resp: ClientResponse<Tag> = client.post("/tags", &req).await?;
-            print_response(resp, output);
+            print_response(resp, output, fields)?;
         }
         TagAction::Delete { id } => {
             let resp: ClientResponse<()> = client.delete(&format!("/tags/{}", id)).await?;
-            print_response(resp, output);
+            print_response(resp, output, fields)?;
         }
     }
     Ok(())
@@ -387,21 +514,55 @@ async fn handle_tag(client: &ApiClient, action: &TagAction, output: &OutputForma
 
 // ============== Stats Handler ==============
 
-async fn handle_stats(client: &ApiClient, output: &OutputFormat) -> anyhow::Result<()> {
+async fn handle_stats(
+    client: &ApiClient,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
     let resp: ClientResponse<DashboardStats> = client.get("/dashboard-stats").await?;
-    print_response(resp, output);
+    print_response(resp, output, fields)?;
     Ok(())
 }
 
 // ============== Output ==============
 
-fn print_response<T: serde::Serialize>(resp: ClientResponse<T>, output: &OutputFormat) {
+fn print_response<T: serde::Serialize>(
+    resp: ClientResponse<T>,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
+    if resp.code != 0 {
+        // API returned an error — print structured error and fail
+        let err = serde_json::json!({
+            "error": true,
+            "code": resp.code,
+            "message": resp.message,
+        });
+        println!("{}", serde_json::to_string(&err)?);
+        return Err(anyhow::anyhow!("API error {}: {}", resp.code, resp.message));
+    }
+
+    let field_list = parse_fields(fields);
+
     match output {
         OutputFormat::Json => {
-            println!("{}", serde_json::to_string(&resp).unwrap());
+            let value = serde_json::to_value(&resp)?;
+            println!("{}", serde_json::to_string(&value)?);
         }
         OutputFormat::Pretty => {
-            println!("{}", serde_json::to_string_pretty(&resp).unwrap());
+            let value = serde_json::to_value(&resp)?;
+            println!("{}", serde_json::to_string_pretty(&value)?);
+        }
+        OutputFormat::Raw => {
+            let mut value = serde_json::to_value(&resp.data)?;
+            if let Some(ref fl) = field_list {
+                value = match value {
+                    Value::Array(arr) => Value::Array(filter_array_fields(&arr, fl)),
+                    _ => filter_fields(&value, fl),
+                };
+            }
+            println!("{}", serde_json::to_string(&value)?);
         }
     }
+    Ok(())
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -18,6 +18,10 @@ struct Cli {
     #[arg(short, long, default_value = "json", value_enum)]
     output: OutputFormat,
 
+    /// Select fields to output (comma-separated, e.g. "id,title,status")
+    #[arg(short, long)]
+    fields: Option<String>,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -28,6 +32,8 @@ pub enum OutputFormat {
     #[default]
     Json,
     Pretty,
+    /// Output raw data without ApiResponse wrapper (best for AI parsing)
+    Raw,
 }
 
 #[derive(Subcommand)]
@@ -110,10 +116,11 @@ async fn main() {
             let cli = cli::Cli {
                 server: cli.server.clone(),
                 output: output_to_cli(&cli.output),
+                fields: cli.fields.clone(),
                 command: cli::Commands::Todo { action: action.clone() },
             };
             if let Err(e) = cli::run_command(&cli).await {
-                eprintln!("Error: {}", e);
+                print_structured_error(&e);
                 std::process::exit(1);
             }
             return;
@@ -122,10 +129,11 @@ async fn main() {
             let cli = cli::Cli {
                 server: cli.server.clone(),
                 output: output_to_cli(&cli.output),
+                fields: cli.fields.clone(),
                 command: cli::Commands::Tag { action: action.clone() },
             };
             if let Err(e) = cli::run_command(&cli).await {
-                eprintln!("Error: {}", e);
+                print_structured_error(&e);
                 std::process::exit(1);
             }
             return;
@@ -134,10 +142,11 @@ async fn main() {
             let cli = cli::Cli {
                 server: cli.server.clone(),
                 output: output_to_cli(&cli.output),
+                fields: cli.fields.clone(),
                 command: cli::Commands::Stats,
             };
             if let Err(e) = cli::run_command(&cli).await {
-                eprintln!("Error: {}", e);
+                print_structured_error(&e);
                 std::process::exit(1);
             }
             return;
@@ -154,7 +163,16 @@ fn output_to_cli(output: &OutputFormat) -> cli::OutputFormat {
     match output {
         OutputFormat::Json => cli::OutputFormat::Json,
         OutputFormat::Pretty => cli::OutputFormat::Pretty,
+        OutputFormat::Raw => cli::OutputFormat::Raw,
     }
+}
+
+fn print_structured_error(e: &anyhow::Error) {
+    let err = serde_json::json!({
+        "error": true,
+        "message": e.to_string(),
+    });
+    eprintln!("{}", serde_json::to_string(&err).unwrap_or_else(|_| r#"{"error":true,"message":"unknown"}"#.to_string()));
 }
 
 async fn run_server(cli_port: Option<u16>) {

--- a/backend/src/tunnel.rs
+++ b/backend/src/tunnel.rs
@@ -6,6 +6,7 @@ use std::thread;
 use std::time::Duration;
 
 use clap::Subcommand;
+use serde_json;
 
 fn get_port() -> u16 {
     static PORT: OnceLock<u16> = OnceLock::new();
@@ -19,11 +20,18 @@ pub enum TunnelAction {
         /// Tunnel type (hostc, trycloudflare)
         #[arg(long = "type", default_value = "hostc")]
         tunnel_type: String,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Stop the running tunnel
     Stop,
     /// Show tunnel status
-    Status,
+    Status {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 pub fn handle_tunnel_command(action: &TunnelAction) {
@@ -35,10 +43,14 @@ pub fn handle_tunnel_command(action: &TunnelAction) {
     let url_file = ntd_dir.join("tunnel.url");
 
     match action {
-        TunnelAction::Start { tunnel_type } => {
+        TunnelAction::Start { tunnel_type, json } => {
             let tunnel_type = tunnel_type.clone();
             if let Err(e) = fs::create_dir_all(&ntd_dir) {
-                eprintln!("Failed to create .ntd directory: {}", e);
+                if *json {
+                    eprintln!("{{\"error\":true,\"message\":\"Failed to create .ntd directory: {}\"}}", e);
+                } else {
+                    eprintln!("Failed to create .ntd directory: {}", e);
+                }
                 std::process::exit(1);
             }
 
@@ -46,7 +58,9 @@ pub fn handle_tunnel_command(action: &TunnelAction) {
             if let Ok(old_pid_str) = fs::read_to_string(&pid_file) {
                 if let Ok(old_pid) = old_pid_str.trim().parse::<u32>() {
                     if is_process_running(old_pid as i32) {
-                        println!("Stopping old tunnel (PID: {})", old_pid);
+                        if !json {
+                            println!("Stopping old tunnel (PID: {})", old_pid);
+                        }
                         kill_process_safe(old_pid as i32);
                     }
                 }
@@ -55,11 +69,15 @@ pub fn handle_tunnel_command(action: &TunnelAction) {
             cleanup_orphan_processes();
 
             match tunnel_type.as_str() {
-                "hostc" => start_hostc_tunnel(&pid_file, &url_file),
-                "trycloudflare" => start_cloudflare_tunnel(&pid_file, &url_file),
+                "hostc" => start_hostc_tunnel(&pid_file, &url_file, *json),
+                "trycloudflare" => start_cloudflare_tunnel(&pid_file, &url_file, *json),
                 _ => {
-                    eprintln!("Error: unsupported tunnel type '{}'", tunnel_type);
-                    eprintln!("Supported types: hostc, trycloudflare");
+                    if *json {
+                        eprintln!("{{\"error\":true,\"message\":\"unsupported tunnel type '{}'\"}}", tunnel_type);
+                    } else {
+                        eprintln!("Error: unsupported tunnel type '{}'", tunnel_type);
+                        eprintln!("Supported types: hostc, trycloudflare");
+                    }
                     std::process::exit(1);
                 }
             }
@@ -83,31 +101,51 @@ pub fn handle_tunnel_command(action: &TunnelAction) {
                 eprintln!("No tunnel is running");
             }
         }
-        TunnelAction::Status => {
+        TunnelAction::Status { json } => {
+            let mut status = serde_json::Map::new();
+            status.insert("running".to_string(), serde_json::Value::Bool(false));
+
             if let Ok(pid_str) = fs::read_to_string(&pid_file) {
                 if let Ok(pid) = pid_str.trim().parse::<u32>() {
                     if is_process_running(pid as i32) {
-                        println!("Tunnel is running (PID: {})", pid);
+                        status.insert("running".to_string(), serde_json::Value::Bool(true));
+                        status.insert("pid".to_string(), serde_json::Value::Number(pid.into()));
                         if let Ok(url) = fs::read_to_string(&url_file) {
-                            println!("Public URL: {}", url.trim());
+                            let url = url.trim().to_string();
+                            status.insert("url".to_string(), serde_json::Value::String(url.clone()));
+                            if !json {
+                                println!("Tunnel is running (PID: {})", pid);
+                                println!("Public URL: {}", url);
+                            }
+                        } else if !json {
+                            println!("Tunnel is running (PID: {})", pid);
                         }
                     } else {
-                        println!("Tunnel is not running (stale PID file)");
+                        status.insert("stale_pid".to_string(), serde_json::Value::Bool(true));
                         fs::remove_file(&pid_file).ok();
+                        if !json {
+                            println!("Tunnel is not running (stale PID file)");
+                        }
                     }
                 } else {
-                    println!("Tunnel state is invalid (bad PID file)");
                     fs::remove_file(&pid_file).ok();
                     fs::remove_file(&url_file).ok();
+                    if !json {
+                        println!("Tunnel state is invalid (bad PID file)");
+                    }
                 }
-            } else {
+            } else if !json {
                 println!("No tunnel is running");
+            }
+
+            if *json {
+                println!("{}", serde_json::to_string(&status).unwrap());
             }
         }
     }
 }
 
-fn start_hostc_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
+fn start_hostc_tunnel(pid_file: &PathBuf, url_file: &PathBuf, json: bool) {
     let output_file = "/tmp/hostc_output.txt";
 
     let output = match std::fs::OpenOptions::new()
@@ -175,12 +213,21 @@ fn start_hostc_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
         eprintln!("Failed to write URL file: {}", e);
         std::process::exit(1);
     }
-    println!("\nTunnel PID: {}", hostc_pid);
-    println!("Public URL saved to ~/.ntd/tunnel.url");
-    println!("Public URL: {}", public_url);
+    if json {
+        let result = serde_json::json!({
+            "pid": hostc_pid,
+            "url": public_url,
+            "type": "hostc",
+        });
+        println!("{}", serde_json::to_string(&result).unwrap());
+    } else {
+        println!("\nTunnel PID: {}", hostc_pid);
+        println!("Public URL saved to ~/.ntd/tunnel.url");
+        println!("Public URL: {}", public_url);
+    }
 }
 
-fn start_cloudflare_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
+fn start_cloudflare_tunnel(pid_file: &PathBuf, url_file: &PathBuf, json: bool) {
     let output_file = "/tmp/cloudflared_output.txt";
 
     let output = match std::fs::OpenOptions::new()
@@ -246,9 +293,18 @@ fn start_cloudflare_tunnel(pid_file: &PathBuf, url_file: &PathBuf) {
         eprintln!("Failed to write URL file: {}", e);
         std::process::exit(1);
     }
-    println!("\nTunnel PID: {}", cloudflared_pid);
-    println!("Public URL saved to ~/.ntd/tunnel.url");
-    println!("Public URL: {}", public_url);
+    if json {
+        let result = serde_json::json!({
+            "pid": cloudflared_pid,
+            "url": public_url,
+            "type": "trycloudflare",
+        });
+        println!("{}", serde_json::to_string(&result).unwrap());
+    } else {
+        println!("\nTunnel PID: {}", cloudflared_pid);
+        println!("Public URL saved to ~/.ntd/tunnel.url");
+        println!("Public URL: {}", public_url);
+    }
 }
 
 fn poll_for_url(output_file: &str, extract: impl Fn(&str) -> String) -> String {

--- a/backend/src/tunnel.rs
+++ b/backend/src/tunnel.rs
@@ -47,7 +47,8 @@ pub fn handle_tunnel_command(action: &TunnelAction) {
             let tunnel_type = tunnel_type.clone();
             if let Err(e) = fs::create_dir_all(&ntd_dir) {
                 if *json {
-                    eprintln!("{{\"error\":true,\"message\":\"Failed to create .ntd directory: {}\"}}", e);
+                    let err = serde_json::json!({"error": true, "message": format!("Failed to create .ntd directory: {}", e)});
+                    eprintln!("{}", serde_json::to_string(&err).unwrap());
                 } else {
                     eprintln!("Failed to create .ntd directory: {}", e);
                 }
@@ -73,7 +74,8 @@ pub fn handle_tunnel_command(action: &TunnelAction) {
                 "trycloudflare" => start_cloudflare_tunnel(&pid_file, &url_file, *json),
                 _ => {
                     if *json {
-                        eprintln!("{{\"error\":true,\"message\":\"unsupported tunnel type '{}'\"}}", tunnel_type);
+                        let err = serde_json::json!({"error": true, "message": format!("unsupported tunnel type '{}'", tunnel_type)});
+                        eprintln!("{}", serde_json::to_string(&err).unwrap());
                     } else {
                         eprintln!("Error: unsupported tunnel type '{}'", tunnel_type);
                         eprintln!("Supported types: hostc, trycloudflare");
@@ -196,8 +198,10 @@ fn start_hostc_tunnel(pid_file: &PathBuf, url_file: &PathBuf, json: bool) {
         }
     });
 
-    if let Ok(content) = fs::read_to_string(output_file) {
-        println!("{}", content);
+    if !json {
+        if let Ok(content) = fs::read_to_string(output_file) {
+            println!("{}", content);
+        }
     }
 
     if public_url.is_empty() {
@@ -205,12 +209,22 @@ fn start_hostc_tunnel(pid_file: &PathBuf, url_file: &PathBuf, json: bool) {
         let _ = child.kill();
         fs::remove_file(pid_file).ok();
         fs::remove_file(url_file).ok();
-        eprintln!("Error: failed to capture Public URL within 60s");
+        if json {
+            let err = serde_json::json!({"error": true, "message": "failed to capture Public URL within 60s"});
+            eprintln!("{}", serde_json::to_string(&err).unwrap());
+        } else {
+            eprintln!("Error: failed to capture Public URL within 60s");
+        }
         std::process::exit(1);
     }
 
     if let Err(e) = fs::write(url_file, &public_url) {
-        eprintln!("Failed to write URL file: {}", e);
+        if json {
+            let err = serde_json::json!({"error": true, "message": format!("Failed to write URL file: {}", e)});
+            eprintln!("{}", serde_json::to_string(&err).unwrap());
+        } else {
+            eprintln!("Failed to write URL file: {}", e);
+        }
         std::process::exit(1);
     }
     if json {
@@ -276,8 +290,10 @@ fn start_cloudflare_tunnel(pid_file: &PathBuf, url_file: &PathBuf, json: bool) {
         }
     });
 
-    if let Ok(content) = fs::read_to_string(output_file) {
-        println!("{}", content);
+    if !json {
+        if let Ok(content) = fs::read_to_string(output_file) {
+            println!("{}", content);
+        }
     }
 
     if public_url.is_empty() {
@@ -285,12 +301,22 @@ fn start_cloudflare_tunnel(pid_file: &PathBuf, url_file: &PathBuf, json: bool) {
         let _ = child.kill();
         fs::remove_file(pid_file).ok();
         fs::remove_file(url_file).ok();
-        eprintln!("Error: failed to capture Public URL within 60s");
+        if json {
+            let err = serde_json::json!({"error": true, "message": "failed to capture Public URL within 60s"});
+            eprintln!("{}", serde_json::to_string(&err).unwrap());
+        } else {
+            eprintln!("Error: failed to capture Public URL within 60s");
+        }
         std::process::exit(1);
     }
 
     if let Err(e) = fs::write(url_file, &public_url) {
-        eprintln!("Failed to write URL file: {}", e);
+        if json {
+            let err = serde_json::json!({"error": true, "message": format!("Failed to write URL file: {}", e)});
+            eprintln!("{}", serde_json::to_string(&err).unwrap());
+        } else {
+            eprintln!("Failed to write URL file: {}", e);
+        }
         std::process::exit(1);
     }
     if json {

--- a/backend/tests/cli_command_tests.rs
+++ b/backend/tests/cli_command_tests.rs
@@ -1,44 +1,86 @@
-//! CLI command parsing tests
+//! CLI command parsing and behavior tests
 
 #[cfg(test)]
 mod todo_create_command_tests {
+    use ntd::cli::{Cli, Commands, TodoAction};
+    use clap::Parser;
+
     #[test]
     fn test_todo_create_parsing() {
-        // Test parsing: ntd todo create "My Task" -p "prompt" -e kimi
-        let args: Vec<&str> = vec!["ntd", "todo", "create", "My Task", "-p", "prompt", "-e", "kimi"];
-        // This tests that clap parses correctly
-        assert_eq!(args.len(), 8);
+        let cli = Cli::try_parse_from(["ntd", "todo", "create", "My Task", "-p", "prompt", "-e", "kimi"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Create { title, prompt, executor, .. } } => {
+                assert_eq!(title, Some("My Task".to_string()));
+                assert_eq!(prompt, Some("prompt".to_string()));
+                assert_eq!(executor, Some("kimi".to_string()));
+            }
+            _ => panic!("Expected Todo::Create"),
+        }
     }
 
     #[test]
     fn test_todo_create_with_schedule() {
-        // Test parsing: ntd todo create "Task" --schedule "*/30 * * * *"
-        let schedule = "*/30 * * * *";
-        assert!(schedule.starts_with("*/"));
+        let cli = Cli::try_parse_from(["ntd", "todo", "create", "Task", "--schedule", "*/30 * * * *"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Create { schedule, .. } } => {
+                assert_eq!(schedule, Some("*/30 * * * *".to_string()));
+            }
+            _ => panic!("Expected Todo::Create with schedule"),
+        }
     }
 
     #[test]
     fn test_todo_create_with_tags() {
-        // Test parsing: ntd todo create "Task" --tags "1,2,3"
-        let tags = "1,2,3";
-        let parsed: Vec<i64> = tags.split(',').filter_map(|s| s.parse().ok()).collect();
-        assert_eq!(parsed, vec![1, 2, 3]);
+        let cli = Cli::try_parse_from(["ntd", "todo", "create", "Task", "--tags", "1,2,3"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Create { tags, .. } } => {
+                assert_eq!(tags, Some("1,2,3".to_string()));
+            }
+            _ => panic!("Expected Todo::Create with tags"),
+        }
     }
 
     #[test]
     fn test_todo_create_with_workspace() {
-        // Test parsing: ntd todo create "Task" -w /path/to/dir
-        let workspace = "/path/to/dir";
-        assert!(!workspace.is_empty());
+        let cli = Cli::try_parse_from(["ntd", "todo", "create", "Task", "-w", "/path/to/dir"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Create { workspace, .. } } => {
+                assert_eq!(workspace, Some("/path/to/dir".to_string()));
+            }
+            _ => panic!("Expected Todo::Create with workspace"),
+        }
+    }
+
+    #[test]
+    fn test_todo_create_with_stdin() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "create", "--stdin"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Create { stdin, title, .. } } => {
+                assert!(stdin);
+                assert!(title.is_none());
+            }
+            _ => panic!("Expected Todo::Create with stdin"),
+        }
+    }
+
+    #[test]
+    fn test_todo_create_with_file_prompt() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "create", "Task", "-f", "/tmp/prompt.txt"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Create { file, .. } } => {
+                assert_eq!(file, Some("/tmp/prompt.txt".to_string()));
+            }
+            _ => panic!("Expected Todo::Create with file"),
+        }
     }
 }
 
 #[cfg(test)]
 mod todo_execute_command_tests {
+    use ntd::models::ExecuteRequest;
+
     #[test]
     fn test_execute_request_serialization() {
-        use ntd::models::ExecuteRequest;
-
         let req = ExecuteRequest {
             todo_id: 123,
             message: Some("hello".to_string()),
@@ -52,8 +94,6 @@ mod todo_execute_command_tests {
 
     #[test]
     fn test_execute_request_message_null() {
-        use ntd::models::ExecuteRequest;
-
         let json = r#"{"todo_id": 123, "message": null, "executor": null}"#;
         let req: ExecuteRequest = serde_json::from_str(json).unwrap();
         assert!(req.message.is_none());
@@ -62,8 +102,6 @@ mod todo_execute_command_tests {
 
     #[test]
     fn test_execute_request_minimal() {
-        use ntd::models::ExecuteRequest;
-
         let req = ExecuteRequest {
             todo_id: 1,
             message: None,
@@ -92,18 +130,133 @@ mod stop_execution_request_tests {
 
 #[cfg(test)]
 mod todo_list_command_tests {
+    use ntd::cli::{Cli, Commands, TodoAction};
+    use clap::Parser;
+
     #[test]
     fn test_todo_list_parsing() {
-        // ntd todo list
-        let args = vec!["ntd", "todo", "list"];
-        assert_eq!(args.len(), 3);
+        let cli = Cli::try_parse_from(["ntd", "todo", "list"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::List { status, tag, running, search } } => {
+                assert!(status.is_none());
+                assert!(tag.is_none());
+                assert!(!running);
+                assert!(search.is_none());
+            }
+            _ => panic!("Expected Todo::List"),
+        }
+    }
+
+    #[test]
+    fn test_todo_list_with_status_filter() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--status", "completed"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::List { status, .. } } => {
+                assert_eq!(status, Some("completed".to_string()));
+            }
+            _ => panic!("Expected Todo::List with status"),
+        }
+    }
+
+    #[test]
+    fn test_todo_list_with_tag_filter() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--tag", "3"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::List { tag, .. } } => {
+                assert_eq!(tag, Some(3));
+            }
+            _ => panic!("Expected Todo::List with tag"),
+        }
+    }
+
+    #[test]
+    fn test_todo_list_with_running_filter() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--running"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::List { running, .. } } => {
+                assert!(running);
+            }
+            _ => panic!("Expected Todo::List with running"),
+        }
+    }
+
+    #[test]
+    fn test_todo_list_with_search() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "list", "-s", "rust"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::List { search, .. } } => {
+                assert_eq!(search, Some("rust".to_string()));
+            }
+            _ => panic!("Expected Todo::List with search"),
+        }
+    }
+
+    #[test]
+    fn test_todo_list_combined_filters() {
+        let cli = Cli::try_parse_from([
+            "ntd", "todo", "list",
+            "--status", "pending",
+            "--tag", "1",
+            "--running",
+            "--search", "bug",
+        ]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::List { status, tag, running, search } } => {
+                assert_eq!(status, Some("pending".to_string()));
+                assert_eq!(tag, Some(1));
+                assert!(running);
+                assert_eq!(search, Some("bug".to_string()));
+            }
+            _ => panic!("Expected Todo::List with combined filters"),
+        }
     }
 
     #[test]
     fn test_todo_get_parsing() {
-        // ntd todo get <id>
-        let id: i64 = "123".parse().unwrap();
-        assert_eq!(id, 123);
+        let cli = Cli::try_parse_from(["ntd", "todo", "get", "123"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Get { id } } => {
+                assert_eq!(id, 123);
+            }
+            _ => panic!("Expected Todo::Get"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod todo_update_command_tests {
+    use ntd::cli::{Cli, Commands, TodoAction};
+    use clap::Parser;
+
+    #[test]
+    fn test_todo_update_parsing() {
+        let cli = Cli::try_parse_from([
+            "ntd", "todo", "update", "1",
+            "--title", "New Title",
+            "--status", "completed",
+            "--executor", "kimi",
+        ]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Update { id, title, status, executor, .. } } => {
+                assert_eq!(id, 1);
+                assert_eq!(title, Some("New Title".to_string()));
+                assert_eq!(status, Some("completed".to_string()));
+                assert_eq!(executor, Some("kimi".to_string()));
+            }
+            _ => panic!("Expected Todo::Update"),
+        }
+    }
+
+    #[test]
+    fn test_todo_update_with_stdin() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "update", "1", "--stdin"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Update { id, stdin, .. } } => {
+                assert_eq!(id, 1);
+                assert!(stdin);
+            }
+            _ => panic!("Expected Todo::Update with stdin"),
+        }
     }
 }
 
@@ -151,13 +304,49 @@ mod config_parsing_tests {
 
 #[cfg(test)]
 mod output_format_tests {
+    use ntd::cli::{Cli, OutputFormat};
+    use clap::Parser;
+
     #[test]
-    fn test_output_format_variants() {
-        // Test that output format can be parsed correctly
-        let formats = vec!["json", "pretty"];
-        for fmt in formats {
-            assert!(!fmt.is_empty());
-        }
+    fn test_output_format_json() {
+        let cli = Cli::try_parse_from(["ntd", "-o", "json", "todo", "list"]).unwrap();
+        assert_eq!(cli.output, OutputFormat::Json);
+    }
+
+    #[test]
+    fn test_output_format_pretty() {
+        let cli = Cli::try_parse_from(["ntd", "-o", "pretty", "todo", "list"]).unwrap();
+        assert_eq!(cli.output, OutputFormat::Pretty);
+    }
+
+    #[test]
+    fn test_output_format_raw() {
+        let cli = Cli::try_parse_from(["ntd", "-o", "raw", "todo", "list"]).unwrap();
+        assert_eq!(cli.output, OutputFormat::Raw);
+    }
+
+    #[test]
+    fn test_output_format_default_is_json() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "list"]).unwrap();
+        assert_eq!(cli.output, OutputFormat::Json);
+    }
+}
+
+#[cfg(test)]
+mod fields_tests {
+    use ntd::cli::Cli;
+    use clap::Parser;
+
+    #[test]
+    fn test_fields_parsing() {
+        let cli = Cli::try_parse_from(["ntd", "-f", "id,title,status", "todo", "list"]).unwrap();
+        assert_eq!(cli.fields, Some("id,title,status".to_string()));
+    }
+
+    #[test]
+    fn test_fields_empty() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "list"]).unwrap();
+        assert_eq!(cli.fields, None);
     }
 }
 
@@ -193,5 +382,155 @@ mod cron_validation_tests {
             let result = cron::Schedule::from_str(expr);
             assert!(result.is_err(), "Cron expression '{}' should be invalid", expr);
         }
+    }
+}
+
+#[cfg(test)]
+mod tag_command_tests {
+    use ntd::cli::{Cli, Commands, TagAction};
+    use clap::Parser;
+
+    #[test]
+    fn test_tag_list_parsing() {
+        let cli = Cli::try_parse_from(["ntd", "tag", "list"]).unwrap();
+        match cli.command {
+            Commands::Tag { action: TagAction::List } => {}
+            _ => panic!("Expected Tag::List"),
+        }
+    }
+
+    #[test]
+    fn test_tag_create_parsing() {
+        let cli = Cli::try_parse_from(["ntd", "tag", "create", "Bugfix", "-c", "#ff0000"]).unwrap();
+        match cli.command {
+            Commands::Tag { action: TagAction::Create { name, color } } => {
+                assert_eq!(name, "Bugfix");
+                assert_eq!(color, "#ff0000");
+            }
+            _ => panic!("Expected Tag::Create"),
+        }
+    }
+
+    #[test]
+    fn test_tag_create_default_color() {
+        let cli = Cli::try_parse_from(["ntd", "tag", "create", "Feature"]).unwrap();
+        match cli.command {
+            Commands::Tag { action: TagAction::Create { name, color } } => {
+                assert_eq!(name, "Feature");
+                assert_eq!(color, "#1890ff");
+            }
+            _ => panic!("Expected Tag::Create with default color"),
+        }
+    }
+
+    #[test]
+    fn test_tag_delete_parsing() {
+        let cli = Cli::try_parse_from(["ntd", "tag", "delete", "5"]).unwrap();
+        match cli.command {
+            Commands::Tag { action: TagAction::Delete { id } } => {
+                assert_eq!(id, 5);
+            }
+            _ => panic!("Expected Tag::Delete"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tunnel_command_tests {
+    use ntd::tunnel::TunnelAction;
+
+    #[test]
+    fn test_tunnel_start_default() {
+        let action = TunnelAction::Start { tunnel_type: "hostc".to_string(), json: false };
+        match action {
+            TunnelAction::Start { tunnel_type, json } => {
+                assert_eq!(tunnel_type, "hostc");
+                assert!(!json);
+            }
+            _ => panic!("Expected Tunnel::Start"),
+        }
+    }
+
+    #[test]
+    fn test_tunnel_start_json() {
+        let action = TunnelAction::Start { tunnel_type: "hostc".to_string(), json: true };
+        match action {
+            TunnelAction::Start { json, .. } => {
+                assert!(json);
+            }
+            _ => panic!("Expected Tunnel::Start with json"),
+        }
+    }
+
+    #[test]
+    fn test_tunnel_start_cloudflare() {
+        let action = TunnelAction::Start { tunnel_type: "trycloudflare".to_string(), json: false };
+        match action {
+            TunnelAction::Start { tunnel_type, .. } => {
+                assert_eq!(tunnel_type, "trycloudflare");
+            }
+            _ => panic!("Expected Tunnel::Start with trycloudflare"),
+        }
+    }
+
+    #[test]
+    fn test_tunnel_status_default() {
+        let action = TunnelAction::Status { json: false };
+        match action {
+            TunnelAction::Status { json } => {
+                assert!(!json);
+            }
+            _ => panic!("Expected Tunnel::Status"),
+        }
+    }
+
+    #[test]
+    fn test_tunnel_status_json() {
+        let action = TunnelAction::Status { json: true };
+        match action {
+            TunnelAction::Status { json } => {
+                assert!(json);
+            }
+            _ => panic!("Expected Tunnel::Status with json"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod combined_options_tests {
+    use ntd::cli::{Cli, Commands, OutputFormat, TodoAction};
+    use clap::Parser;
+
+    #[test]
+    fn test_full_ai_workflow_list() {
+        // AI-friendly command: list todos with raw output, filtered fields, and search
+        let cli = Cli::try_parse_from([
+            "ntd",
+            "--server", "http://localhost:8088",
+            "-o", "raw",
+            "-f", "id,title,status,executor",
+            "todo", "list",
+            "--status", "pending",
+            "--search", "bug",
+        ]).unwrap();
+
+        assert_eq!(cli.server, Some("http://localhost:8088".to_string()));
+        assert_eq!(cli.output, OutputFormat::Raw);
+        assert_eq!(cli.fields, Some("id,title,status,executor".to_string()));
+
+        match cli.command {
+            Commands::Todo { action: TodoAction::List { status, search, .. } } => {
+                assert_eq!(status, Some("pending".to_string()));
+                assert_eq!(search, Some("bug".to_string()));
+            }
+            _ => panic!("Expected Todo::List"),
+        }
+    }
+
+    #[test]
+    fn test_raw_fields_combination() {
+        let cli = Cli::try_parse_from(["ntd", "-o", "raw", "-f", "id", "todo", "get", "42"]).unwrap();
+        assert_eq!(cli.output, OutputFormat::Raw);
+        assert_eq!(cli.fields, Some("id".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

Make ntd CLI optimal for AI agent usage by adding structured output, field selection, pipeline support, and client-side search.

## Changes

### New CLI Features

- **`--output raw`** — Returns unwrapped `.data` directly, no `ClientResponse` wrapper. Best for AI parsing.
- **`--fields id,title,status`** — Select specific fields to output, reducing payload size.
- **`--stdin`** — Pipe JSON directly into `todo create` and `todo update` commands for scriptability.
- **`--search "keyword"`** — Client-side fuzzy search in todo title and prompt.
- **Structured errors** — All errors output as JSON: `{"error":true,"message":"..."}`
- **`tunnel status --json` / `tunnel start --json`** — JSON output for tunnel commands.

### Files Changed

| File | Change |
|------|--------|
| `backend/src/cli/commands.rs` | Core CLI logic: raw output, fields filtering, stdin, search |
| `backend/src/main.rs` | Pass fields param, structured error output |
| `backend/src/tunnel.rs` | JSON output support for tunnel commands |

### Tests

- 17 unit tests for private functions (`parse_fields`, `filter_fields`, `filter_array_fields`)
- 41 integration tests for clap parsing of all new arguments
- All 58 CLI tests pass

## Example Usage

```bash
# AI-friendly list with minimal output
ntd todo list --output raw --fields id,title,status

# Search and filter
ntd todo list --search "rust" --status pending --output raw

# Pipe JSON to create
echo '{"title":"deploy","prompt":"deploy to prod"}' | ntd todo create --stdin --output raw

# Structured error on failure
ntd todo execute 999 --output raw
# {"error":true,"message":"API error 404: Todo not found"}

# Tunnel JSON output
ntd tunnel status --json
# {"running":true,"pid":1234,"url":"https://t-xxx.hostc.dev"}
```