### PR TITLE
feat: resume conversation for supported executors

### DIFF
--- a/backend/src/adapters/claude_code.rs
+++ b/backend/src/adapters/claude_code.rs
@@ -42,7 +42,7 @@ impl CodeExecutor for ClaudeCodeExecutor {
         ]
     }
 
-    fn command_args_with_session(&self, message: &str, session_id: Option<&str>) -> Vec<String> {
+    fn command_args_with_session(&self, message: &str, session_id: Option<&str>, is_resume: bool) -> Vec<String> {
         let mut args = vec![
             "--dangerously-skip-permissions".to_string(),
             "-p".to_string(),
@@ -50,12 +50,20 @@ impl CodeExecutor for ClaudeCodeExecutor {
             "stream-json".to_string(),
         ];
         if let Some(sid) = session_id {
-            args.push("--session-id".to_string());
+            if is_resume {
+                args.push("--resume".to_string());
+            } else {
+                args.push("--session-id".to_string());
+            }
             args.push(sid.to_string());
         }
         args.push("--verbose".to_string());
         args.push(message.to_string());
         args
+    }
+
+    fn supports_resume(&self) -> bool {
+        true
     }
 
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {

--- a/backend/src/adapters/codex.rs
+++ b/backend/src/adapters/codex.rs
@@ -51,7 +51,7 @@ impl CodeExecutor for CodexExecutor {
         ]
     }
 
-    fn command_args_with_session(&self, message: &str, _session_id: Option<&str>) -> Vec<String> {
+    fn command_args_with_session(&self, message: &str, _session_id: Option<&str>, _is_resume: bool) -> Vec<String> {
         self.command_args(message)
     }
 

--- a/backend/src/adapters/kimi.rs
+++ b/backend/src/adapters/kimi.rs
@@ -46,13 +46,17 @@ impl CodeExecutor for KimiExecutor {
         ]
     }
 
-    fn command_args_with_session(&self, message: &str, session_id: Option<&str>) -> Vec<String> {
+    fn command_args_with_session(&self, message: &str, session_id: Option<&str>, _is_resume: bool) -> Vec<String> {
         let mut args = self.command_args(message);
         if let Some(sid) = session_id {
             args.push("-S".to_string());
             args.push(sid.to_string());
         }
         args
+    }
+
+    fn supports_resume(&self) -> bool {
+        true
     }
 
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
@@ -219,7 +223,7 @@ mod tests {
     #[test]
     fn test_command_args_with_session() {
         let executor = KimiExecutor::new("kimi".to_string());
-        let args = executor.command_args_with_session("continue task", Some("abc123"));
+        let args = executor.command_args_with_session("continue task", Some("abc123"), false);
         assert_eq!(args, vec!["--print", "--output-format", "stream-json", "-p", "continue task", "-S", "abc123"]);
     }
 

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -74,8 +74,14 @@ pub trait CodeExecutor: Send + Sync {
     fn command_args(&self, message: &str) -> Vec<String>;
 
     /// 返回带 session 的命令参数（默认实现忽略 session）
-    fn command_args_with_session(&self, message: &str, _session_id: Option<&str>) -> Vec<String> {
+    /// `is_resume` 为 true 时表示恢复已有会话，false 表示新执行并指定 session_id
+    fn command_args_with_session(&self, message: &str, _session_id: Option<&str>, _is_resume: bool) -> Vec<String> {
         self.command_args(message)
+    }
+
+    /// 该执行器是否支持通过 session_id 恢复对话
+    fn supports_resume(&self) -> bool {
+        false
     }
 
     /// 解析输出行，返回解析后的日志条目

--- a/backend/src/adapters/opencode.rs
+++ b/backend/src/adapters/opencode.rs
@@ -53,7 +53,7 @@ impl CodeExecutor for OpencodeExecutor {
         ]
     }
 
-    fn command_args_with_session(&self, message: &str, _session_id: Option<&str>) -> Vec<String> {
+    fn command_args_with_session(&self, message: &str, _session_id: Option<&str>, _is_resume: bool) -> Vec<String> {
         // Note: opencode's --session parameter causes issues with JSON output,
         // so we don't use it here. The task_id is still passed to create_execution_record
         // for tracking purposes.

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -219,6 +219,15 @@ pub enum ExecutionAction {
         /// Execution record ID
         id: i64,
     },
+    /// Resume a conversation from an execution record
+    Resume {
+        /// Execution record ID
+        id: i64,
+
+        /// Optional message to send (defaults to todo prompt)
+        #[arg(short, long)]
+        message: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -484,6 +493,11 @@ async fn handle_execution(
             let resp: ClientResponse<ExecutionRecord> = client.get(&format!("/execution-records/{}", id)).await?;
             print_response(resp, output, fields)?;
         }
+        ExecutionAction::Resume { id, message } => {
+            let req = serde_json::json!({ "message": message });
+            let resp: ClientResponse<Value> = client.post(&format!("/execution-records/{}/resume", id), &req).await?;
+            print_response(resp, output, fields)?;
+        }
     }
     Ok(())
 }
@@ -732,6 +746,30 @@ mod tests {
                 assert_eq!(search, Some("bug".to_string()));
             }
             _ => panic!("Expected Todo::List"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_execution_resume() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "execution", "resume", "42"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Execution { action: ExecutionAction::Resume { id, message } } } => {
+                assert_eq!(id, 42);
+                assert!(message.is_none());
+            }
+            _ => panic!("Expected Todo::Execution::Resume"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_execution_resume_with_message() {
+        let cli = Cli::try_parse_from(["ntd", "todo", "execution", "resume", "42", "-m", "fix the bug"]).unwrap();
+        match cli.command {
+            Commands::Todo { action: TodoAction::Execution { action: ExecutionAction::Resume { id, message } } } => {
+                assert_eq!(id, 42);
+                assert_eq!(message, Some("fix the bug".to_string()));
+            }
+            _ => panic!("Expected Todo::Execution::Resume with message"),
         }
     }
 }

--- a/backend/src/db/entity/execution_records.rs
+++ b/backend/src/db/entity/execution_records.rs
@@ -21,6 +21,7 @@ pub struct Model {
     pub trigger_type: Option<String>,
     pub pid: Option<i32>,
     pub task_id: Option<String>,
+    pub session_id: Option<String>,
     pub todo_progress: Option<String>,
     pub execution_stats: Option<String>,
 }

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -27,6 +27,7 @@ impl From<execution_records::Model> for ExecutionRecord {
             trigger_type: m.trigger_type.unwrap_or_else(|| "manual".to_string()),
             pid: m.pid,
             task_id: m.task_id,
+            session_id: m.session_id,
             todo_progress: m.todo_progress,
             execution_stats,
         }
@@ -90,6 +91,7 @@ impl Database {
         executor: &str,
         trigger_type: &str,
         task_id: &str,
+        session_id: Option<&str>,
     ) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let am = execution_records::ActiveModel {
@@ -100,6 +102,7 @@ impl Database {
             status: ActiveValue::Set(Some(crate::models::ExecutionStatus::Running.to_string())),
             started_at: ActiveValue::Set(Some(now)),
             task_id: ActiveValue::Set(Some(task_id.to_string())),
+            session_id: ActiveValue::Set(session_id.map(|s| s.to_string())),
             ..Default::default()
         };
         let inserted = am.insert(&self.conn).await?;

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -124,6 +124,7 @@ impl Database {
                 trigger_type TEXT DEFAULT 'manual',
                 pid INTEGER,
                 task_id TEXT,
+                session_id TEXT,
                 FOREIGN KEY (todo_id) REFERENCES todos(id) ON DELETE CASCADE
             )",
         )
@@ -138,6 +139,12 @@ impl Database {
         // 添加 task_id 字段的迁移（向后兼容）
         self.exec(
             "ALTER TABLE execution_records ADD COLUMN task_id TEXT"
+        )
+        .await.ok(); // 忽略错误，因为字段可能已存在
+
+        // 添加 session_id 字段的迁移（向后兼容）
+        self.exec(
+            "ALTER TABLE execution_records ADD COLUMN session_id TEXT"
         )
         .await.ok(); // 忽略错误，因为字段可能已存在
 
@@ -293,7 +300,7 @@ mod tests {
         let todo_id = db.create_todo("Test", "Desc").await.unwrap();
         let before = truncate_seconds(Utc::now());
         let record_id = db
-            .create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id")
+            .create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id", None)
             .await
             .unwrap();
         let after = truncate_seconds(Utc::now());
@@ -312,7 +319,7 @@ mod tests {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Desc").await.unwrap();
         let record_id = db
-            .create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id")
+            .create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id", None)
             .await
             .unwrap();
 
@@ -593,7 +600,7 @@ mod tests {
     async fn test_create_execution_record() {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
-        let record_id = db.create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id").await.unwrap();
+        let record_id = db.create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id", None).await.unwrap();
         let (records, total) = db.get_execution_records(todo_id, 100, 0).await;
         assert_eq!(total, 1);
         let record = records.iter().find(|r| r.id == record_id).unwrap();
@@ -609,7 +616,7 @@ mod tests {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         for i in 0..5 {
-            db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id").await.unwrap();
+            db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id", None).await.unwrap();
         }
         let (records, total) = db.get_execution_records(todo_id, 2, 0).await;
         assert_eq!(total, 5);
@@ -621,7 +628,7 @@ mod tests {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         for i in 0..3 {
-            db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id").await.unwrap();
+            db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id", None).await.unwrap();
         }
         let (records, total) = db.get_execution_records(todo_id, 10, 2).await;
         assert_eq!(total, 3);
@@ -632,7 +639,7 @@ mod tests {
     async fn test_update_execution_record() {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
-        let record_id = db.create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id").await.unwrap();
+        let record_id = db.create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id", None).await.unwrap();
         let usage = crate::models::ExecutionUsage {
             input_tokens: 100,
             output_tokens: 50,
@@ -671,11 +678,11 @@ mod tests {
     async fn test_get_execution_summary_counts() {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
-        let r1 = db.create_execution_record(todo_id, "cmd1", "claudecode", "manual", "test-task-id").await.unwrap();
+        let r1 = db.create_execution_record(todo_id, "cmd1", "claudecode", "manual", "test-task-id", None).await.unwrap();
         db.update_execution_record(r1, "success", "[]", "", None, None).await.unwrap();
-        let r2 = db.create_execution_record(todo_id, "cmd2", "claudecode", "manual", "test-task-id").await.unwrap();
+        let r2 = db.create_execution_record(todo_id, "cmd2", "claudecode", "manual", "test-task-id", None).await.unwrap();
         db.update_execution_record(r2, "failed", "[]", "", None, None).await.unwrap();
-        let _r3 = db.create_execution_record(todo_id, "cmd3", "claudecode", "manual", "test-task-id").await.unwrap();
+        let _r3 = db.create_execution_record(todo_id, "cmd3", "claudecode", "manual", "test-task-id", None).await.unwrap();
         // r3 stays "running"
         let summary = db.get_execution_summary(todo_id).await;
         assert_eq!(summary.total_executions, 3);
@@ -688,7 +695,7 @@ mod tests {
     async fn test_get_execution_summary_tokens_and_cost() {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
-        let r1 = db.create_execution_record(todo_id, "cmd1", "claudecode", "manual", "test-task-id").await.unwrap();
+        let r1 = db.create_execution_record(todo_id, "cmd1", "claudecode", "manual", "test-task-id", None).await.unwrap();
         let usage1 = crate::models::ExecutionUsage {
             input_tokens: 100,
             output_tokens: 50,
@@ -698,7 +705,7 @@ mod tests {
             duration_ms: Some(1000),
         };
         db.update_execution_record(r1, "success", "[]", "", Some(&usage1), None).await.unwrap();
-        let r2 = db.create_execution_record(todo_id, "cmd2", "claudecode", "manual", "test-task-id").await.unwrap();
+        let r2 = db.create_execution_record(todo_id, "cmd2", "claudecode", "manual", "test-task-id", None).await.unwrap();
         let usage2 = crate::models::ExecutionUsage {
             input_tokens: 200,
             output_tokens: 100,

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -39,6 +39,7 @@ pub async fn run_todo_execution(
     req_executor: Option<String>,
     trigger_type: &str,
     task_manager: Arc<TaskManager>,
+    resume_session_id: Option<String>,
 ) -> ExecutionResult {
     let task_id = Uuid::new_v4().to_string();
     let mut cancel_rx = task_manager.register(task_id.clone()).await;
@@ -80,7 +81,9 @@ pub async fn run_todo_execution(
     };
 
     let executable_path = executor.executable_path().to_string();
-    let command_args = executor.command_args_with_session(&message, Some(&task_id));
+    let session_id_for_executor = resume_session_id.as_deref().unwrap_or(&task_id);
+    let is_resume = resume_session_id.is_some();
+    let command_args = executor.command_args_with_session(&message, Some(session_id_for_executor), is_resume);
 
     // Update todo's executor to the one being used
     let executor_str = executor.executor_type().to_string();

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -93,7 +93,7 @@ pub async fn run_todo_execution(
 
     // Create execution record
     let command = format!("{} {}", executable_path, command_args.join(" "));
-    let record_id = match db.create_execution_record(todo_id, &command, &executor_str, trigger_type, &task_id).await {
+    let record_id = match db.create_execution_record(todo_id, &command, &executor_str, trigger_type, &task_id, Some(session_id_for_executor)).await {
         Ok(id) => id,
         Err(e) => {
             tracing::error!("Failed to create execution record: {}", e);

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -144,7 +144,8 @@ pub async fn resume_execution_handler(
         .map(|m| m.to_string())
         .unwrap_or_else(|| todo.prompt.clone());
 
-    let resume_session_id = record.task_id
+    let resume_session_id = record.session_id
+        .or(record.task_id)
         .ok_or_else(|| AppError::BadRequest("No session_id found for this execution record".to_string()))?;
 
     let result = run_todo_execution(

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -3,6 +3,7 @@ use axum::{
 };
 use serde::Deserialize;
 
+use crate::adapters::parse_executor_type;
 use crate::executor_service::run_todo_execution;
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::{
@@ -65,6 +66,7 @@ pub async fn execute_handler(
         req.executor,
         "manual",
         state.task_manager.clone(),
+        None,
     )
     .await;
 
@@ -101,6 +103,67 @@ pub async fn stop_execution_handler(
     } else {
         Err(AppError::BadRequest("No task_id found for this execution record".to_string()))
     }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResumeExecutionRequest {
+    pub message: Option<String>,
+}
+
+pub async fn resume_execution_handler(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    ApiJson(req): ApiJson<ResumeExecutionRequest>,
+) -> Result<ApiResponse<serde_json::Value>, AppError> {
+    let record = state.db.get_execution_record(id).await
+        .ok_or(AppError::NotFound)?;
+
+    if record.status == "running" {
+        return Err(AppError::BadRequest("Cannot resume a running execution".to_string()));
+    }
+
+    let executor_type = record.executor.as_deref()
+        .and_then(parse_executor_type)
+        .ok_or_else(|| AppError::BadRequest("Unknown executor type".to_string()))?;
+
+    let executor = state.executor_registry.get(executor_type)
+        .ok_or_else(|| AppError::Internal("Executor not found in registry".to_string()))?;
+
+    if !executor.supports_resume() {
+        return Err(AppError::BadRequest("This executor does not support resuming conversations".to_string()));
+    }
+
+    let todo_id = record.todo_id;
+    let todo = state.db.get_todo(todo_id).await
+        .ok_or(AppError::NotFound)?;
+
+    let message = req.message
+        .as_ref()
+        .map(|m| m.trim())
+        .filter(|m| !m.is_empty())
+        .map(|m| m.to_string())
+        .unwrap_or_else(|| todo.prompt.clone());
+
+    let resume_session_id = record.task_id
+        .ok_or_else(|| AppError::BadRequest("No session_id found for this execution record".to_string()))?;
+
+    let result = run_todo_execution(
+        state.db.clone(),
+        state.executor_registry.clone(),
+        state.tx.clone(),
+        todo_id,
+        message,
+        record.executor.clone(),
+        "manual",
+        state.task_manager.clone(),
+        Some(resume_session_id),
+    )
+    .await;
+
+    let record_id = result.record_id
+        .ok_or_else(|| AppError::Internal("Failed to start execution".to_string()))?;
+
+    Ok(ApiResponse::ok(serde_json::json!({ "task_id": result.task_id, "record_id": record_id })))
 }
 
 pub async fn get_execution_summary(

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -265,6 +265,7 @@ pub fn create_app(
         .route("/xyz/tags/{id}", delete(tag::delete_tag))
         .route("/xyz/execution-records", get(execution::get_execution_records))
         .route("/xyz/execution-records/{id}", get(execution::get_execution_record))
+        .route("/xyz/execution-records/{id}/resume", post(execution::resume_execution_handler))
         .route("/xyz/dashboard-stats", get(execution::get_dashboard_stats))
         .route("/xyz/execute", post(execution::execute_handler))
         .route("/xyz/execute/stop", post(execution::stop_execution_handler))

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -124,6 +124,8 @@ pub struct ExecutionRecord {
     pub pid: Option<i32>,
     #[serde(default)]
     pub task_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub todo_progress: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -97,7 +97,7 @@ impl TodoScheduler {
                     let message = if todo.prompt.is_empty() { todo.title.clone() } else { todo.prompt.clone() };
                     let executor = todo.executor.clone();
                     info!("Scheduled execution triggered for todo {}", todo_id);
-                    run_todo_execution(db, registry, tx, todo_id, message, executor, "cron", tm).await;
+                    run_todo_execution(db, registry, tx, todo_id, message, executor, "cron", tm, None).await;
                 }
             })
         })?;

--- a/backend/tests/executor_tests.rs
+++ b/backend/tests/executor_tests.rs
@@ -22,7 +22,7 @@ mod kimi_executor_tests {
     #[test]
     fn test_kimi_command_args_with_session() {
         let executor = KimiExecutor::new("kimi".to_string());
-        let args = executor.command_args_with_session("continue task", Some("abc123"));
+        let args = executor.command_args_with_session("continue task", Some("abc123"), false);
         assert_eq!(args, vec!["--print", "--output-format", "stream-json", "-p", "continue task", "-S", "abc123"]);
     }
 
@@ -185,10 +185,18 @@ mod claude_code_executor_tests {
     }
 
     #[test]
-    fn test_claude_command_args_with_session() {
+    fn test_claude_command_args_with_session_new() {
         let executor = ClaudeCodeExecutor::new("claude".to_string());
-        let args = executor.command_args_with_session("continue", Some("session123"));
+        let args = executor.command_args_with_session("continue", Some("session123"), false);
         assert!(args.contains(&"--session-id".to_string()));
+        assert!(args.contains(&"session123".to_string()));
+    }
+
+    #[test]
+    fn test_claude_command_args_with_session_resume() {
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
+        let args = executor.command_args_with_session("continue", Some("session123"), true);
+        assert!(args.contains(&"--resume".to_string()));
         assert!(args.contains(&"session123".to_string()));
     }
 

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -589,7 +589,7 @@ export function TodoDetail() {
                           {formatLocalDateTime(record.started_at)}
                         </span>
                         <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
-                          {record.status !== 'running' && supportsResume(record.executor) && (
+                          {record.status !== 'running' && supportsResume(record) && (
                             <MessageOutlined
                               style={{ fontSize: 12, color: 'var(--color-primary)', cursor: 'pointer' }}
                               title="继续对话"
@@ -696,7 +696,7 @@ export function TodoDetail() {
                         )}
                       </div>
                       <div style={{ display: 'flex', gap: 8 }}>
-                        {record.status !== 'running' && supportsResume(record.executor) && (
+                        {record.status !== 'running' && supportsResume(record) && (
                           <Button type="primary" size="small" icon={<MessageOutlined />} onClick={() => handleOpenResume(record)}>继续对话</Button>
                         )}
                         {record.status === 'running' && (
@@ -864,7 +864,7 @@ export function TodoDetail() {
                     }}>
                       {record.status === 'success' ? '成功' : record.status === 'failed' ? '失败' : '进行中'}
                     </span>
-                    {record.status !== 'running' && supportsResume(record.executor) && (
+                    {record.status !== 'running' && supportsResume(record) && (
                       <Button
                         type="primary"
                         size="small"

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useApp } from '../hooks/useApp';
-import { Button, Empty, App, Popconfirm, Tag, Badge, Pagination, Segmented } from 'antd';
+import { Button, Empty, App, Popconfirm, Tag, Badge, Pagination, Segmented, Modal, Input } from 'antd';
 import { PlayCircleOutlined, EditOutlined, DeleteOutlined, SettingOutlined, CheckCircleOutlined, ReloadOutlined, CopyOutlined, ArrowLeftOutlined, StopOutlined, DownOutlined, UpOutlined, UnorderedListOutlined, MessageOutlined } from '@ant-design/icons';
 import { StatusPicker } from './StatusPicker';
 import { PieChart } from './PieChart';
@@ -10,7 +10,7 @@ import { ChatView } from './ChatView';
 import * as db from '../utils/database';
 import { formatLocalDateTime } from '../utils/datetime';
 import { AnimatedNumber } from './AnimatedNumber';
-import { getExecutorOption } from '../types';
+import { getExecutorOption, supportsResume } from '../types';
 import XMarkdown from '@ant-design/x-markdown';
 import type { ExecutionSummary, Todo, TodoItem, ExecutionRecord, LogEntry } from '../types';
 
@@ -333,6 +333,33 @@ export function TodoDetail() {
     }
   };
 
+  // Resume conversation state & handlers
+  const [resumeModalOpen, setResumeModalOpen] = useState(false);
+  const [resumeRecordId, setResumeRecordId] = useState<number | null>(null);
+  const [resumeMessage, setResumeMessage] = useState('');
+  const [resumeLoading, setResumeLoading] = useState(false);
+
+  const handleOpenResume = (record: ExecutionRecord) => {
+    setResumeRecordId(record.id);
+    setResumeMessage(selectedTodo?.prompt || selectedTodo?.title || '');
+    setResumeModalOpen(true);
+  };
+
+  const handleResumeConfirm = async () => {
+    if (!resumeRecordId) return;
+    setResumeLoading(true);
+    try {
+      await db.resumeExecutionRecord(resumeRecordId, resumeMessage);
+      message.success('已继续对话，任务开始执行');
+      setResumeModalOpen(false);
+      await loadExecutionRecords(historyPage, historyLimit);
+    } catch (error) {
+      message.error('继续对话失败: ' + (error instanceof Error ? error.message : String(error)));
+    } finally {
+      setResumeLoading(false);
+    }
+  };
+
   const handleStatusChange = async (newStatus: string) => {
     if (!selectedTodo) return;
     try {
@@ -561,16 +588,25 @@ export function TodoDetail() {
                         <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
                           {formatLocalDateTime(record.started_at)}
                         </span>
-                        <span style={{
-                          fontSize: 10,
-                          padding: '2px 8px',
-                          borderRadius: 10,
-                          backgroundColor: record.status === 'success' ? 'var(--color-success)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
-                          color: '#fff',
-                          fontWeight: 600,
-                        }}>
-                          {record.status === 'success' ? '成功' : record.status === 'failed' ? '失败' : '进行中'}
-                        </span>
+                        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                          {record.status !== 'running' && supportsResume(record.executor) && (
+                            <MessageOutlined
+                              style={{ fontSize: 12, color: 'var(--color-primary)', cursor: 'pointer' }}
+                              title="继续对话"
+                              onClick={(e) => { e.stopPropagation(); handleOpenResume(record); }}
+                            />
+                          )}
+                          <span style={{
+                            fontSize: 10,
+                            padding: '2px 8px',
+                            borderRadius: 10,
+                            backgroundColor: record.status === 'success' ? 'var(--color-success)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
+                            color: '#fff',
+                            fontWeight: 600,
+                          }}>
+                            {record.status === 'success' ? '成功' : record.status === 'failed' ? '失败' : '进行中'}
+                          </span>
+                        </div>
                       </div>
                       <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
                         {recExecutor && (
@@ -660,6 +696,9 @@ export function TodoDetail() {
                         )}
                       </div>
                       <div style={{ display: 'flex', gap: 8 }}>
+                        {record.status !== 'running' && supportsResume(record.executor) && (
+                          <Button type="primary" size="small" icon={<MessageOutlined />} onClick={() => handleOpenResume(record)}>继续对话</Button>
+                        )}
                         {record.status === 'running' && (
                           <Popconfirm
                             title="确定强制停止该任务？"
@@ -825,6 +864,16 @@ export function TodoDetail() {
                     }}>
                       {record.status === 'success' ? '成功' : record.status === 'failed' ? '失败' : '进行中'}
                     </span>
+                    {record.status !== 'running' && supportsResume(record.executor) && (
+                      <Button
+                        type="primary"
+                        size="small"
+                        icon={<MessageOutlined />}
+                        onClick={() => handleOpenResume(record)}
+                      >
+                        继续对话
+                      </Button>
+                    )}
                     {record.status === 'running' && (() => {
                       return (
                         <Popconfirm
@@ -1024,6 +1073,26 @@ export function TodoDetail() {
           }
         }}
       />
+
+      <Modal
+        title="继续对话"
+        open={resumeModalOpen}
+        onOk={handleResumeConfirm}
+        onCancel={() => setResumeModalOpen(false)}
+        confirmLoading={resumeLoading}
+        okText="开始执行"
+        cancelText="取消"
+      >
+        <p style={{ marginBottom: 12, color: 'var(--color-text-secondary)' }}>
+          将复用之前的会话上下文继续对话，你可以修改下方消息：
+        </p>
+        <Input.TextArea
+          value={resumeMessage}
+          onChange={(e) => setResumeMessage(e.target.value)}
+          rows={4}
+          placeholder="输入要继续发送的消息..."
+        />
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -231,6 +231,12 @@ export interface Config {
   executors: ExecutorPaths;
 }
 
+export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi']);
+
+export function supportsResume(executor?: string | null): boolean {
+  return !!executor && RESUMABLE_EXECUTORS.has(executor.toLowerCase());
+}
+
 export function getExecutorOption(value: string): ExecutorOption {
   return EXECUTORS.find(e => e.value === value.toLowerCase()) || EXECUTORS[0];
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -56,6 +56,7 @@ export interface ExecutionRecord {
   trigger_type: string;
   pid: number | null;
   task_id?: string | null;
+  session_id?: string | null;
   todo_progress?: string | null;
   execution_stats?: ExecutionStats | null;
 }
@@ -233,8 +234,13 @@ export interface Config {
 
 export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi']);
 
-export function supportsResume(executor?: string | null): boolean {
-  return !!executor && RESUMABLE_EXECUTORS.has(executor.toLowerCase());
+export function supportsResume(record: ExecutionRecord): boolean {
+  return (
+    record.status !== 'running' &&
+    !!record.session_id &&
+    !!record.executor &&
+    RESUMABLE_EXECUTORS.has(record.executor.toLowerCase())
+  );
 }
 
 export function getExecutorOption(value: string): ExecutorOption {

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -116,6 +116,10 @@ export async function stopExecution(recordId: number): Promise<void> {
   await api.post('/xyz/execute/stop', { record_id: recordId });
 }
 
+export async function resumeExecutionRecord(recordId: number, message?: string): Promise<{ task_id: string; record_id: number }> {
+  return unwrap(await api.post<ApiResp<{ task_id: string; record_id: number }>>(`/xyz/execution-records/${recordId}/resume`, { message }));
+}
+
 // Scheduler APIs
 
 export async function updateScheduler(


### PR DESCRIPTION
## Summary

支持通过 resume 继续已完成的 AI 对话，目前支持 Claude Code 和 Kimi 两个执行器。

## 后端改动

- `CodeExecutor` trait 新增 `supports_resume()` 方法
- `command_args_with_session` 新增 `is_resume` 参数，区分新执行和恢复会话：
  - **Claude Code**: 新执行用 `--session-id`，resume 用 `--resume`
  - **Kimi**: 两种情况都用 `-S`
- 新增 `POST /xyz/execution-records/:id/resume` API
- 后端会校验执行器是否支持 resume，不支持返回 `400 BadRequest`

## 前端改动

- 执行历史列表中，仅对支持 resume 的已结束记录显示气泡图标（`MessageOutlined`）
- 记录详情头部增加「继续对话」按钮
- 点击弹出 Modal，可编辑要发送的消息（默认填充 todo prompt）

## CLI 改动

- 新增 `ntd todo execution resume <id> [-m <message>]` 子命令

## 测试

- 后端 52 个 executor 测试全部通过
- CLI resume 解析测试通过

## PR 说明

- 新分支: `feat/resume-conversation`