### PR TITLE
feat: OpenCode 支持继续对话功能

### DIFF
--- a/backend/src/adapters/joinai.rs
+++ b/backend/src/adapters/joinai.rs
@@ -40,6 +40,31 @@ impl CodeExecutor for JoinaiExecutor {
         ]
     }
 
+    fn command_args_with_session(&self, message: &str, session_id: Option<&str>, is_resume: bool) -> Vec<String> {
+        let mut args = vec![
+            "run".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+        ];
+        if is_resume {
+            if let Some(sid) = session_id {
+                args.push("-s".to_string());
+                args.push(sid.to_string());
+            }
+        }
+        args.push(message.to_string());
+        args
+    }
+
+    fn supports_resume(&self) -> bool {
+        true
+    }
+
+    fn extract_session_id(&self, line: &str) -> Option<String> {
+        let event: AgentEvent = serde_json::from_str(line).ok()?;
+        event.session_id.or_else(|| event.part.as_ref()?.session_id.clone())
+    }
+
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
         let event: AgentEvent = serde_json::from_str(line).ok()?;
 

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -84,6 +84,11 @@ pub trait CodeExecutor: Send + Sync {
         false
     }
 
+    /// 从输出行中提取 session_id（用于执行过程中实时更新数据库）
+    fn extract_session_id(&self, _line: &str) -> Option<String> {
+        None
+    }
+
     /// 解析输出行，返回解析后的日志条目
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry>;
 

--- a/backend/src/adapters/opencode.rs
+++ b/backend/src/adapters/opencode.rs
@@ -53,17 +53,31 @@ impl CodeExecutor for OpencodeExecutor {
         ]
     }
 
-    fn command_args_with_session(&self, message: &str, _session_id: Option<&str>, _is_resume: bool) -> Vec<String> {
-        // Note: opencode's --session parameter causes issues with JSON output,
-        // so we don't use it here. The task_id is still passed to create_execution_record
-        // for tracking purposes.
-        vec![
+    fn command_args_with_session(&self, message: &str, session_id: Option<&str>, is_resume: bool) -> Vec<String> {
+        let mut args = vec![
             "run".to_string(),
             "--format".to_string(),
             "json".to_string(),
-            "--dangerously-skip-permissions".to_string(),
-            message.to_string(),
-        ]
+        ];
+        // Resume mode: use -s to specify existing session
+        if is_resume {
+            if let Some(sid) = session_id {
+                args.push("-s".to_string());
+                args.push(sid.to_string());
+            }
+        }
+        args.push("--dangerously-skip-permissions".to_string());
+        args.push(message.to_string());
+        args
+    }
+
+    fn supports_resume(&self) -> bool {
+        true
+    }
+
+    fn extract_session_id(&self, line: &str) -> Option<String> {
+        let event: AgentEvent = serde_json::from_str(line).ok()?;
+        event.session_id.or_else(|| event.part.as_ref()?.session_id.clone())
     }
 
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -142,6 +142,16 @@ impl Database {
         self.exec_update(am).await
     }
 
+    /// 更新执行记录的 session_id
+    pub async fn update_execution_record_session_id(&self, id: i64, session_id: &str) -> Result<(), sea_orm::DbErr> {
+        let am = execution_records::ActiveModel {
+            id: ActiveValue::Unchanged(id),
+            session_id: ActiveValue::Set(Some(session_id.to_string())),
+            ..Default::default()
+        };
+        self.exec_update(am).await
+    }
+
     /// 更新执行记录的 todo_progress
     pub async fn update_execution_record_todo_progress(&self, id: i64, todo_progress_json: &str) -> Result<(), sea_orm::DbErr> {
         let am = execution_records::ActiveModel {

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -203,7 +203,15 @@ pub async fn run_todo_execution(
             Some(tokio::spawn(async move {
                 let mut reader = BufReader::new(stdout_reader).lines();
                 let mut log_count = 0u64;
+                let mut session_id_updated = false;
                 while let Ok(Some(line)) = reader.next_line().await {
+                    // Extract and update session_id if present
+                    if !session_id_updated {
+                        if let Some(sid) = executor_clone.extract_session_id(&line) {
+                            let _ = db_for_todo.update_execution_record_session_id(rid, &sid).await;
+                            session_id_updated = true;
+                        }
+                    }
                     if let Some(parsed) = executor_clone.parse_output_line(&line) {
                         // Detect todo progress updates
                         if let Some(progress) = crate::todo_progress::try_extract_todo_progress(&parsed) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -232,7 +232,7 @@ export interface Config {
   executors: ExecutorPaths;
 }
 
-export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi']);
+export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode']);
 
 export function supportsResume(record: ExecutionRecord): boolean {
   return (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -232,7 +232,7 @@ export interface Config {
   executors: ExecutorPaths;
 }
 
-export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode']);
+export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'joinai']);
 
 export function supportsResume(record: ExecutionRecord): boolean {
   return (


### PR DESCRIPTION
## Summary
- 后端新增 `extract_session_id` trait 方法，从输出行提取 session_id
- executor_service 在解析日志时实时更新 execution_records 的 session_id
- OpenCode 实现 `supports_resume()` 返回 true
- OpenCode 实现 `extract_session_id()` 解析 step_start/step-start 事件中的 sessionID
- OpenCode `command_args_with_session` 支持 -s 参数恢复会话
- 前端 RESUMABLE_EXECUTORS 添加 opencode

## Test plan
- [ ] 使用 OpenCode 执行一个任务
- [ ] 检查数据库 execution_records 表的 session_id 字段是否有值
- [ ] 点击继续对话按钮，验证是否能恢复会话