### PR TITLE
feat: Token 统计详情使用 AnimatedNumber 展示

### DIFF
--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -101,7 +101,7 @@ function InlineTokenStats({ input, output, cacheRead, cacheCreate, totalTokens, 
             {tokenSegments.filter(s => s.value > 0).map(s => (
               <span key={s.label} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                 <span style={{ width: 8, height: 8, borderRadius: '50%', background: s.color }} />
-                {s.label}: {s.value.toLocaleString()}
+                {s.label}: <AnimatedNumber value={s.value} duration={1.2} chineseFormat />
               </span>
             ))}
           </div>
@@ -109,7 +109,7 @@ function InlineTokenStats({ input, output, cacheRead, cacheCreate, totalTokens, 
             {extraSegments.map(s => (
               <span key={s.label} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                 <span style={{ width: 8, height: 8, borderRadius: '50%', background: s.color }} />
-                {s.label}: {s.isPercent ? s.value.toFixed(1) + '%' : s.value.toLocaleString()}
+                {s.label}: {s.isPercent ? s.value.toFixed(1) + '%' : <AnimatedNumber value={s.value} duration={1.2} chineseFormat />}
               </span>
             ))}
           </div>

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -14,6 +14,7 @@ import { getExecutorOption, supportsResume } from '../types';
 import XMarkdown from '@ant-design/x-markdown';
 import type { ExecutionSummary, Todo, TodoItem, ExecutionRecord, LogEntry } from '../types';
 
+/** 可展开的 Prompt 内容展示组件 */
 function PromptDisplay({ content }: { content: string }) {
   const [expanded, setExpanded] = useState(false);
   return (
@@ -52,6 +53,7 @@ function PromptDisplay({ content }: { content: string }) {
   );
 }
 
+/** 内联 Token 统计摘要，支持展开查看详细分项 */
 function InlineTokenStats({ input, output, cacheRead, cacheCreate, totalTokens, summary }: {
   input: number; output: number; cacheRead: number; cacheCreate: number; totalTokens: number; summary: ExecutionSummary;
 }) {
@@ -119,6 +121,7 @@ function InlineTokenStats({ input, output, cacheRead, cacheCreate, totalTokens, 
   );
 }
 
+/** 任务进度展示组件，显示子项完成情况 */
 function ProgressWidget({ items }: { items: TodoItem[] }) {
   const [expanded, setExpanded] = useState(false);
   const total = items.length;
@@ -204,6 +207,7 @@ function ProgressWidget({ items }: { items: TodoItem[] }) {
   );
 }
 
+/** 任务详情面板，包含执行、编辑、历史记录等功能 */
 export function TodoDetail() {
   const { state, dispatch } = useApp();
   const { message } = App.useApp();


### PR DESCRIPTION
## Summary
- 将 Token 统计展开详情中的 `toLocaleString()` 数字显示替换为 `<AnimatedNumber>` 组件，支持中文数字格式和动画效果

## Test plan
- [ ] 打开 Todo 详情，点击 Token 统计摘要展开详情
- [ ] 确认输入、输出、缓存读、缓存写、推理输入、成本输入均以动画方式展示中文格式数字
- [ ] 输出率仍以百分比显示，不受影响