### PR TITLE
feat: 选择性导出 + 数据库备份

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -29,6 +29,10 @@ pub struct Config {
     pub log_level: String,
     /// Executor binary paths. Empty string means use default binary name.
     pub executors: ExecutorPaths,
+    /// 是否开启自动数据库备份
+    pub auto_backup_enabled: bool,
+    /// 自动备份 cron 表达式（6 字段，含秒）
+    pub auto_backup_cron: String,
 }
 
 /// Paths for each supported executor binary.
@@ -68,6 +72,8 @@ impl Default for Config {
             db_path: "~/.ntd/data.db".to_string(),
             log_level: "INFO".to_string(),
             executors: ExecutorPaths::default(),
+            auto_backup_enabled: false,
+            auto_backup_cron: "0 0 3 * * *".to_string(),
         }
     }
 }

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -386,6 +386,24 @@ impl Database {
             .collect()
     }
 
+    /// 按 tag name 列表查询 tag 备份数据
+    pub async fn get_tag_backups_by_names(&self, names: &[&str]) -> Vec<crate::models::TagBackup> {
+        if names.is_empty() {
+            return Vec::new();
+        }
+        tags::Entity::find()
+            .filter(tags::Column::Name.is_in(names.iter().map(|s| s.to_string()).collect::<Vec<_>>()))
+            .all(&self.conn)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|t| crate::models::TagBackup {
+                name: t.name,
+                color: t.color.unwrap_or_default(),
+            })
+            .collect()
+    }
+
     /// 获取指定 todo 列表中涉及的所有 tag 备份数据
     pub async fn get_tag_backups_for_todos(&self, ids: &[i64]) -> Vec<crate::models::TagBackup> {
         if ids.is_empty() {

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -341,6 +341,74 @@ impl Database {
             .collect()
     }
 
+    /// 按 ID 列表获取 todo 的备份数据
+    pub async fn get_todo_backups_by_ids(&self, ids: &[i64]) -> Vec<TodoBackup> {
+        if ids.is_empty() {
+            return Vec::new();
+        }
+        let models = todos::Entity::find()
+            .filter(todos::Column::Id.is_in(ids.to_vec()))
+            .filter(todos::Column::DeletedAt.is_null())
+            .all(&self.conn)
+            .await
+            .unwrap_or_default();
+
+        let model_ids: Vec<i64> = models.iter().map(|m| m.id).collect();
+        let tag_map = self.fetch_tag_ids_for_many(&model_ids).await;
+
+        let all_tags: std::collections::HashMap<i64, String> = tags::Entity::find()
+            .all(&self.conn)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|t| (t.id, t.name))
+            .collect();
+
+        models
+            .into_iter()
+            .map(|m| {
+                let tag_ids = tag_map.get(&m.id).cloned().unwrap_or_default();
+                let tag_names: Vec<String> = tag_ids
+                    .iter()
+                    .filter_map(|tid| all_tags.get(tid).cloned())
+                    .collect();
+                TodoBackup {
+                    title: m.title,
+                    prompt: m.prompt.unwrap_or_default(),
+                    status: m.status.as_deref().and_then(|s| s.parse().ok()).unwrap_or(TodoStatus::Pending),
+                    executor: m.executor,
+                    scheduler_enabled: m.scheduler_enabled.unwrap_or(false),
+                    scheduler_config: m.scheduler_config,
+                    tag_names,
+                    workspace: m.workspace,
+                }
+            })
+            .collect()
+    }
+
+    /// 获取指定 todo 列表中涉及的所有 tag 备份数据
+    pub async fn get_tag_backups_for_todos(&self, ids: &[i64]) -> Vec<crate::models::TagBackup> {
+        if ids.is_empty() {
+            return Vec::new();
+        }
+        let tag_map = self.fetch_tag_ids_for_many(ids).await;
+        let tag_ids: std::collections::HashSet<i64> = tag_map.values().flat_map(|v| v.iter()).copied().collect();
+        if tag_ids.is_empty() {
+            return Vec::new();
+        }
+        tags::Entity::find()
+            .filter(tags::Column::Id.is_in(tag_ids.into_iter().collect::<Vec<_>>()))
+            .all(&self.conn)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|t| crate::models::TagBackup {
+                name: t.name,
+                color: t.color.unwrap_or_default(),
+            })
+            .collect()
+    }
+
     /// 从备份数据导入 todo（清空现有数据后导入，失败时自动回滚）
     pub async fn import_backup(&self, tags_in: &[crate::models::TagBackup], todos_in: &[TodoBackup]) -> Result<(), sea_orm::DbErr> {
         use sea_orm::TransactionTrait;

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -4,7 +4,9 @@ use axum::{
     response::IntoResponse,
     http::header,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::str::FromStr;
 
 use crate::handlers::{AppError, AppState};
 use crate::models::{ApiResponse, BackupData, TagBackup, TodoBackup, utc_timestamp};
@@ -15,6 +17,37 @@ pub async fn export_backup(
 ) -> Result<impl IntoResponse, AppError> {
     let tags = state.db.get_tag_backups().await;
     let todos = state.db.get_todo_backups().await;
+    let data = BackupData {
+        version: "1.0".to_string(),
+        created_at: utc_timestamp(),
+        tags,
+        todos,
+    };
+    let yaml = serde_yaml::to_string(&data).map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok((
+        [(header::CONTENT_TYPE, "application/x-yaml; charset=utf-8")],
+        yaml,
+    ))
+}
+
+/// 选择性导出（按 todo ID 列表导出）
+#[derive(Deserialize)]
+pub struct ExportSelectedRequest {
+    pub todo_ids: Vec<i64>,
+}
+
+pub async fn export_selected(
+    State(state): State<AppState>,
+    axum::Json(req): axum::Json<ExportSelectedRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if req.todo_ids.is_empty() {
+        return Err(AppError::BadRequest("No todo IDs provided".to_string()));
+    }
+    let tags = state.db.get_tag_backups_for_todos(&req.todo_ids).await;
+    let todos = state.db.get_todo_backups_by_ids(&req.todo_ids).await;
+    if todos.is_empty() {
+        return Err(AppError::BadRequest("No todos found for given IDs".to_string()));
+    }
     let data = BackupData {
         version: "1.0".to_string(),
         created_at: utc_timestamp(),
@@ -67,4 +100,254 @@ pub async fn merge_backup(
         .map_err(|e| AppError::Internal(format!("Merge failed: {}", e)))?;
 
     Ok(ApiResponse::ok(format!("新建 {} 项，覆盖 {} 项", created, updated)))
+}
+
+// ============ 数据库备份 ============
+
+fn backup_dir() -> PathBuf {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    home.join(".ntd").join("backups")
+}
+
+/// 手动下载数据库文件
+pub async fn download_database(
+    State(_state): State<AppState>,
+) -> Result<impl IntoResponse, AppError> {
+    let cfg = crate::config::Config::load();
+    let db_path = PathBuf::from(&cfg.db_path);
+
+    if !db_path.exists() {
+        return Err(AppError::Internal("Database file not found".to_string()));
+    }
+
+    let bytes = std::fs::read(&db_path)
+        .map_err(|e| AppError::Internal(format!("Failed to read database: {}", e)))?;
+
+    let filename = format!("ntd-database-{}.db",
+        chrono::Utc::now().format("%Y%m%d-%H%M%S"));
+
+    let disposition = format!("attachment; filename=\"{}\"", filename);
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/octet-stream".to_string()),
+            (header::CONTENT_DISPOSITION, disposition),
+        ],
+        bytes,
+    ))
+}
+
+/// 将数据库复制到备份目录
+pub async fn trigger_local_backup() -> Result<ApiResponse<String>, AppError> {
+    let cfg = crate::config::Config::load();
+    let db_path = PathBuf::from(&cfg.db_path);
+
+    if !db_path.exists() {
+        return Err(AppError::Internal("Database file not found".to_string()));
+    }
+
+    let dir = backup_dir();
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| AppError::Internal(format!("Failed to create backup dir: {}", e)))?;
+
+    let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S");
+    let backup_path = dir.join(format!("ntd-backup-{}.db", timestamp));
+
+    std::fs::copy(&db_path, &backup_path)
+        .map_err(|e| AppError::Internal(format!("Failed to copy database: {}", e)))?;
+
+    // 清理旧备份，保留最近 30 个
+    cleanup_old_backups(30);
+
+    Ok(ApiResponse::ok(format!("备份成功: {}", backup_path.display())))
+}
+
+#[derive(Serialize)]
+pub struct BackupFile {
+    pub name: String,
+    pub size: u64,
+    pub created_at: String,
+}
+
+#[derive(Serialize)]
+pub struct BackupStatus {
+    pub auto_backup_enabled: bool,
+    pub auto_backup_cron: String,
+    pub last_backup: Option<String>,
+    pub files: Vec<BackupFile>,
+}
+
+/// 获取数据库备份状态
+pub async fn get_database_backup_status() -> Result<ApiResponse<BackupStatus>, AppError> {
+    let cfg = crate::config::Config::load();
+    let dir = backup_dir();
+
+    let mut files = Vec::new();
+    if dir.exists() {
+        if let Ok(entries) = std::fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().is_some_and(|ext| ext == "db") {
+                    let meta = entry.metadata().ok();
+                    let created = meta.as_ref()
+                        .and_then(|m| m.created().ok())
+                        .map(|t| {
+                            let dt: chrono::DateTime<chrono::Local> = t.into();
+                            dt.format("%Y-%m-%d %H:%M:%S").to_string()
+                        })
+                        .unwrap_or_default();
+                    files.push(BackupFile {
+                        name: path.file_name().unwrap_or_default().to_string_lossy().to_string(),
+                        size: meta.map(|m| m.len()).unwrap_or(0),
+                        created_at: created,
+                    });
+                }
+            }
+        }
+    }
+    files.sort_by(|a, b| b.name.cmp(&a.name));
+
+    let last_backup = files.first().map(|f| f.created_at.clone());
+
+    Ok(ApiResponse::ok(BackupStatus {
+        auto_backup_enabled: cfg.auto_backup_enabled,
+        auto_backup_cron: cfg.auto_backup_cron,
+        last_backup,
+        files,
+    }))
+}
+
+/// 更新自动备份配置
+#[derive(Deserialize)]
+pub struct UpdateAutoBackupRequest {
+    pub enabled: bool,
+    pub cron: String,
+}
+
+pub async fn update_auto_backup(
+    axum::Json(req): axum::Json<UpdateAutoBackupRequest>,
+) -> Result<ApiResponse<String>, AppError> {
+    // 验证 cron 表达式
+    if req.enabled {
+        let schedule = cron::Schedule::from_str(&req.cron)
+            .map_err(|e| AppError::BadRequest(format!("Invalid cron expression: {}", e)))?;
+        // 验证能产生下一次执行时间
+        schedule.upcoming(chrono::Utc).next()
+            .ok_or_else(|| AppError::BadRequest("Cron expression has no future executions".to_string()))?;
+    }
+
+    let mut cfg = crate::config::Config::load();
+    cfg.auto_backup_enabled = req.enabled;
+    cfg.auto_backup_cron = req.cron;
+    cfg.save().map_err(|e| AppError::Internal(e))?;
+
+    Ok(ApiResponse::ok("自动备份配置已更新".to_string()))
+}
+
+/// 删除备份文件
+#[derive(Deserialize)]
+pub struct DeleteBackupRequest {
+    pub filename: String,
+}
+
+pub async fn delete_backup_file(
+    axum::Json(req): axum::Json<DeleteBackupRequest>,
+) -> Result<ApiResponse<String>, AppError> {
+    // 安全检查：文件名不能包含路径分隔符
+    if req.filename.contains('/') || req.filename.contains('\\') || req.filename.contains("..") {
+        return Err(AppError::BadRequest("Invalid filename".to_string()));
+    }
+    let path = backup_dir().join(&req.filename);
+    if !path.exists() {
+        return Err(AppError::NotFound);
+    }
+    std::fs::remove_file(&path)
+        .map_err(|e| AppError::Internal(format!("Failed to delete: {}", e)))?;
+    Ok(ApiResponse::ok("已删除".to_string()))
+}
+
+/// 执行数据库文件备份（供定时任务调用）
+pub fn perform_database_backup() -> Result<String, String> {
+    let cfg = crate::config::Config::load();
+    let db_path = PathBuf::from(&cfg.db_path);
+
+    if !db_path.exists() {
+        return Err("Database file not found".to_string());
+    }
+
+    let dir = backup_dir();
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("Failed to create backup dir: {}", e))?;
+
+    let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S");
+    let backup_path = dir.join(format!("ntd-backup-{}.db", timestamp));
+
+    std::fs::copy(&db_path, &backup_path)
+        .map_err(|e| format!("Failed to copy database: {}", e))?;
+
+    cleanup_old_backups(30);
+
+    Ok(format!("Auto backup: {}", backup_path.display()))
+}
+
+fn cleanup_old_backups(keep: usize) {
+    let dir = backup_dir();
+    if !dir.exists() {
+        return;
+    }
+    let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .ok()
+        .map(|entries| {
+            entries
+                .flatten()
+                .map(|e| e.path())
+                .filter(|p| p.extension().is_some_and(|ext| ext == "db"))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if files.len() <= keep {
+        return;
+    }
+
+    files.sort_by(|a, b| {
+        let a_time = std::fs::metadata(a).and_then(|m| m.created()).ok();
+        let b_time = std::fs::metadata(b).and_then(|m| m.created()).ok();
+        b_time.cmp(&a_time)
+    });
+
+    for old_file in files.iter().skip(keep) {
+        std::fs::remove_file(old_file).ok();
+    }
+}
+
+/// 启动自动备份定时任务
+pub fn start_auto_backup(cron_expr: &str) -> Result<(), String> {
+    let schedule = cron::Schedule::from_str(cron_expr)
+        .map_err(|e| format!("Invalid cron: {}", e))?;
+
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async move {
+            loop {
+                let next = schedule.upcoming(chrono::Utc).next();
+                let delay = match next {
+                    Some(dt) => {
+                        let now = chrono::Utc::now();
+                        (dt - now).to_std().unwrap_or(std::time::Duration::from_secs(60))
+                    }
+                    None => std::time::Duration::from_secs(3600),
+                };
+                tokio::time::sleep(delay).await;
+                match perform_database_backup() {
+                    Ok(msg) => tracing::info!("{}", msg),
+                    Err(e) => tracing::error!("Auto backup failed: {}", e),
+                }
+            }
+        });
+    });
+
+    Ok(())
 }

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -43,11 +43,15 @@ pub async fn export_selected(
     if req.todo_ids.is_empty() {
         return Err(AppError::BadRequest("No todo IDs provided".to_string()));
     }
-    let tags = state.db.get_tag_backups_for_todos(&req.todo_ids).await;
     let todos = state.db.get_todo_backups_by_ids(&req.todo_ids).await;
     if todos.is_empty() {
         return Err(AppError::BadRequest("No todos found for given IDs".to_string()));
     }
+    // Collect unique tag names from valid todos and query tags by name
+    let tag_names: std::collections::HashSet<&str> = todos.iter()
+        .flat_map(|t| t.tag_names.iter().map(|s| s.as_str()))
+        .collect();
+    let tags = state.db.get_tag_backups_by_names(&tag_names.into_iter().collect::<Vec<_>>()).await;
     let data = BackupData {
         version: "1.0".to_string(),
         created_at: utc_timestamp(),

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -134,7 +134,7 @@ mod todo;
 mod tag;
 mod execution;
 mod scheduler;
-mod backup;
+pub mod backup;
 mod config;
 
 // WebSocket handler
@@ -273,8 +273,14 @@ pub fn create_app(
         .route("/xyz/events", get(events_handler))
         .route("/xyz/scheduler/todos", get(scheduler::get_scheduler_todos))
         .route("/xyz/backup/export", get(backup::export_backup))
+        .route("/xyz/backup/export-selected", post(backup::export_selected))
         .route("/xyz/backup/import", post(backup::import_backup))
         .route("/xyz/backup/merge", post(backup::merge_backup))
+        .route("/xyz/backup/database/download", get(backup::download_database))
+        .route("/xyz/backup/database/status", get(backup::get_database_backup_status))
+        .route("/xyz/backup/database/trigger", post(backup::trigger_local_backup))
+        .route("/xyz/backup/database/auto", put(backup::update_auto_backup))
+        .route("/xyz/backup/database/file", delete(backup::delete_backup_file))
         .route("/xyz/config", get(config::get_config).put(config::update_config))
         .route("/assets/{*path}", get(static_handler))
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024)) // 10MB

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -230,6 +230,15 @@ async fn run_server(cli_port: Option<u16>) {
         if let Err(e) = sched.start().await {
             tracing::warn!("Failed to start scheduler: {}", e);
         }
+
+        // 注册自动数据库备份定时任务
+        if cfg.auto_backup_enabled {
+            match handlers::backup::start_auto_backup(&cfg.auto_backup_cron) {
+                Ok(()) => info!("Auto database backup enabled, cron: {}", cfg.auto_backup_cron),
+                Err(e) => tracing::warn!("Failed to start auto backup: {}", e),
+            }
+        }
+
         sched
     });
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "react": "^19.1.0",
         "react-countup": "^6.5.3",
         "react-dom": "^19.1.0",
+        "react-js-cron": "^6.0.2",
         "react-mde": "^11.5.0"
       },
       "devDependencies": {
@@ -7519,6 +7520,20 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/react-js-cron": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-js-cron/-/react-js-cron-6.0.2.tgz",
+      "integrity": "sha512-JLrOujYZhfQqnIZk5KGkkzUdK+QuSJBdGS9xRnifdWg8FMgRLod1INnU4vsQxcdjYCylEF6oVfh5WnRDhZ58+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "antd": ">=6.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "react": "^19.1.0",
     "react-countup": "^6.5.3",
     "react-dom": "^19.1.0",
+    "react-js-cron": "^6.0.2",
     "react-mde": "^11.5.0"
   },
   "devDependencies": {

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -20,7 +20,6 @@ import {
   Table,
   Tag as AntTag,
   Switch,
-  Input as AntInput,
 } from 'antd';
 import {
   SettingOutlined,
@@ -33,8 +32,11 @@ import {
   DatabaseOutlined,
   ClockCircleOutlined,
 } from '@ant-design/icons';
+import { Cron } from 'react-js-cron';
+import 'react-js-cron/dist/styles.css';
 import { useApp } from '../hooks/useApp';
 import * as db from '../utils/database';
+import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '../utils/cron';
 import type { Config, ExecutorPaths } from '../types';
 import yaml from 'js-yaml';
 
@@ -658,22 +660,24 @@ export function SettingsPage() {
                   <Switch checked={autoBackupEnabled} onChange={setAutoBackupEnabled} />
                 </div>
                 {autoBackupEnabled && (
-                  <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                    <AntInput
-                      value={autoBackupCron}
-                      onChange={(e) => setAutoBackupCron(e.target.value)}
-                      placeholder="0 0 3 * * *"
-                      style={{ flex: 1 }}
-                      size="small"
+                  <>
+                    <Cron
+                      value={cronTo5(autoBackupCron)}
+                      setValue={(val: string) => {
+                        setAutoBackupCron(cronTo6(val));
+                      }}
+                      locale={CRON_ZH_LOCALE}
+                      defaultPeriod="day"
+                      humanizeLabels
+                      allowClear={false}
                     />
-                    <Button size="small" type="primary" onClick={handleSaveAutoBackup} loading={backupLoading}>
-                      保存
-                    </Button>
-                  </div>
+                    <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 8 }}>
+                      <Button size="small" type="primary" onClick={handleSaveAutoBackup} loading={backupLoading}>
+                        保存
+                      </Button>
+                    </div>
+                  </>
                 )}
-                <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 4 }}>
-                  Cron 表达式（6 字段，含秒），如 "0 0 3 * * *" = 每天凌晨 3 点
-                </div>
               </div>
 
               {backupStatus && backupStatus.files.length > 0 && (

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -19,6 +19,8 @@ import {
   Modal,
   Table,
   Tag as AntTag,
+  Switch,
+  Input as AntInput,
 } from 'antd';
 import {
   SettingOutlined,
@@ -28,6 +30,8 @@ import {
   DownloadOutlined,
   DeleteOutlined,
   InboxOutlined,
+  DatabaseOutlined,
+  ClockCircleOutlined,
 } from '@ant-design/icons';
 import { useApp } from '../hooks/useApp';
 import * as db from '../utils/database';
@@ -87,6 +91,22 @@ export function SettingsPage() {
 
   const [importing, setImporting] = useState(false);
 
+  // Selective export state
+  const [exportModalOpen, setExportModalOpen] = useState(false);
+  const [exportTodoKeys, setExportTodoKeys] = useState<number[]>([]);
+  const [exportingSelected, setExportingSelected] = useState(false);
+
+  // Database backup state
+  const [backupStatus, setBackupStatus] = useState<{
+    auto_backup_enabled: boolean;
+    auto_backup_cron: string;
+    last_backup: string | null;
+    files: { name: string; size: number; created_at: string }[];
+  } | null>(null);
+  const [autoBackupEnabled, setAutoBackupEnabled] = useState(false);
+  const [autoBackupCron, setAutoBackupCron] = useState('0 0 3 * * *');
+  const [backupLoading, setBackupLoading] = useState(false);
+
   // Import wizard state
   const [wizardOpen, setWizardOpen] = useState(false);
   const [wizardItems, setWizardItems] = useState<ImportItem[]>([]);
@@ -135,6 +155,17 @@ export function SettingsPage() {
       })
       .finally(() => setConfigLoading(false));
   }, [configForm]);
+
+  // Load database backup status
+  useEffect(() => {
+    db.getDatabaseBackupStatus()
+      .then((status) => {
+        setBackupStatus(status);
+        setAutoBackupEnabled(status.auto_backup_enabled);
+        setAutoBackupCron(status.auto_backup_cron);
+      })
+      .catch(() => {});
+  }, []);
 
   const handleSaveConfig = async () => {
     try {
@@ -267,6 +298,92 @@ export function SettingsPage() {
       message.error(err?.message || '导入失败');
     } finally {
       setImporting(false);
+    }
+  };
+
+  // Selective export
+  const handleExportSelected = async () => {
+    if (exportTodoKeys.length === 0) {
+      message.warning('请至少选择一项');
+      return;
+    }
+    setExportingSelected(true);
+    try {
+      const yamlText = await db.exportSelectedBackup(exportTodoKeys);
+      const blob = new Blob([yamlText], { type: 'application/x-yaml' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+      a.download = `aietodo-backup-selected-${timestamp}.yaml`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      message.success(`已导出 ${exportTodoKeys.length} 项`);
+      setExportModalOpen(false);
+    } catch (err: any) {
+      message.error(err?.message || '导出失败');
+    } finally {
+      setExportingSelected(false);
+    }
+  };
+
+  // Database backup handlers
+  const handleTriggerBackup = async () => {
+    setBackupLoading(true);
+    try {
+      const msg = await db.triggerLocalBackup();
+      message.success(msg);
+      const status = await db.getDatabaseBackupStatus();
+      setBackupStatus(status);
+    } catch (err: any) {
+      message.error(err?.message || '备份失败');
+    } finally {
+      setBackupLoading(false);
+    }
+  };
+
+  const handleDownloadDatabase = async () => {
+    try {
+      const response = await fetch('/xyz/backup/database/download');
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+      a.download = `ntd-database-${timestamp}.db`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      message.success('数据库下载成功');
+    } catch (err: any) {
+      message.error(err?.message || '下载失败');
+    }
+  };
+
+  const handleSaveAutoBackup = async () => {
+    setBackupLoading(true);
+    try {
+      await db.updateAutoBackup(autoBackupEnabled, autoBackupCron);
+      message.success('自动备份配置已保存');
+    } catch (err: any) {
+      message.error(err?.message || '保存失败');
+    } finally {
+      setBackupLoading(false);
+    }
+  };
+
+  const handleDeleteBackup = async (filename: string) => {
+    try {
+      await db.deleteBackupFile(filename);
+      message.success('已删除');
+      const status = await db.getDatabaseBackupStatus();
+      setBackupStatus(status);
+    } catch (err: any) {
+      message.error(err?.message || '删除失败');
     }
   };
 
@@ -471,20 +588,29 @@ export function SettingsPage() {
           <Card title="导出备份" size="small" style={{ marginBottom: 24 }}>
             <Space direction="vertical" style={{ width: '100%' }}>
               <Paragraph type="secondary">
-                将所有 Todo 和标签导出为 YAML 文件，方便迁移和存档
+                将 Todo 和标签导出为 YAML 文件，方便迁移和存档
               </Paragraph>
-              <Button
-                type="primary"
-                icon={<DownloadOutlined />}
-                onClick={handleExportBackup}
-                block
-              >
-                导出为 YAML 文件
-              </Button>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <Button
+                  type="primary"
+                  icon={<DownloadOutlined />}
+                  onClick={handleExportBackup}
+                  style={{ flex: 1 }}
+                >
+                  导出全部
+                </Button>
+                <Button
+                  icon={<DownloadOutlined />}
+                  onClick={() => setExportModalOpen(true)}
+                  style={{ flex: 1 }}
+                >
+                  选择性导出
+                </Button>
+              </div>
             </Space>
           </Card>
 
-          <Card title="导入备份" size="small">
+          <Card title="导入备份" size="small" style={{ marginBottom: 24 }}>
             <Space direction="vertical" style={{ width: '100%' }}>
               <Paragraph type="secondary">
                 从 YAML 文件恢复数据，支持预览和选择性导入
@@ -502,6 +628,78 @@ export function SettingsPage() {
                 <p className="ant-upload-text">点击或拖拽 YAML 文件到此处</p>
                 <p className="ant-upload-hint">将解析文件并展示预览，可选择性导入</p>
               </Dragger>
+            </Space>
+          </Card>
+
+          <Card title="数据库备份" size="small">
+            <Space direction="vertical" style={{ width: '100%' }} size="middle">
+              <Paragraph type="secondary">
+                直接备份 SQLite 数据库文件，包含所有数据（含执行记录）
+              </Paragraph>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <Button
+                  icon={<DownloadOutlined />}
+                  onClick={handleDownloadDatabase}
+                >
+                  下载数据库
+                </Button>
+                <Button
+                  icon={<DatabaseOutlined />}
+                  onClick={handleTriggerBackup}
+                  loading={backupLoading}
+                >
+                  备份到服务器
+                </Button>
+              </div>
+
+              <div style={{ borderTop: '1px solid var(--color-border-light)', paddingTop: 12, marginTop: 4 }}>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+                  <span style={{ fontWeight: 600 }}><ClockCircleOutlined style={{ marginRight: 6 }} />自动备份</span>
+                  <Switch checked={autoBackupEnabled} onChange={setAutoBackupEnabled} />
+                </div>
+                {autoBackupEnabled && (
+                  <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                    <AntInput
+                      value={autoBackupCron}
+                      onChange={(e) => setAutoBackupCron(e.target.value)}
+                      placeholder="0 0 3 * * *"
+                      style={{ flex: 1 }}
+                      size="small"
+                    />
+                    <Button size="small" type="primary" onClick={handleSaveAutoBackup} loading={backupLoading}>
+                      保存
+                    </Button>
+                  </div>
+                )}
+                <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 4 }}>
+                  Cron 表达式（6 字段，含秒），如 "0 0 3 * * *" = 每天凌晨 3 点
+                </div>
+              </div>
+
+              {backupStatus && backupStatus.files.length > 0 && (
+                <div style={{ borderTop: '1px solid var(--color-border-light)', paddingTop: 12 }}>
+                  <div style={{ fontWeight: 600, marginBottom: 8 }}>备份文件 ({backupStatus.files.length})</div>
+                  <List
+                    size="small"
+                    dataSource={backupStatus.files.slice(0, 10)}
+                    renderItem={(file) => (
+                      <List.Item
+                        style={{ padding: '6px 0', fontSize: 12 }}
+                      >
+                        <div>
+                          <div style={{ fontWeight: 500 }}>{file.name}</div>
+                          <div style={{ color: 'var(--color-text-tertiary)', fontSize: 11 }}>
+                            {(file.size / 1024).toFixed(1)} KB · {file.created_at}
+                          </div>
+                        </div>
+                        <Popconfirm title="确定删除此备份？" onConfirm={() => handleDeleteBackup(file.name)}>
+                          <Button type="text" danger icon={<DeleteOutlined />} size="small" />
+                        </Popconfirm>
+                      </List.Item>
+                    )}
+                  />
+                </div>
+              )}
             </Space>
           </Card>
         </div>
@@ -588,6 +786,58 @@ export function SettingsPage() {
               dataIndex: 'prompt',
               ellipsis: true,
               render: (v: string) => v ? v.slice(0, 60) + (v.length > 60 ? '...' : '') : '-',
+            },
+          ]}
+        />
+      </Modal>
+
+      <Modal
+        title="选择性导出"
+        open={exportModalOpen}
+        onCancel={() => setExportModalOpen(false)}
+        onOk={handleExportSelected}
+        okText={`导出 ${exportTodoKeys.length} 项`}
+        cancelText="取消"
+        confirmLoading={exportingSelected}
+        width={700}
+        okButtonProps={{ disabled: exportTodoKeys.length === 0 }}
+      >
+        <Table
+          dataSource={state.todos}
+          rowKey="id"
+          size="small"
+          pagination={{ pageSize: 50 }}
+          scroll={{ y: 400 }}
+          rowSelection={{
+            selectedRowKeys: exportTodoKeys,
+            onChange: (keys) => setExportTodoKeys(keys as number[]),
+          }}
+          columns={[
+            {
+              title: '标题',
+              dataIndex: 'title',
+              ellipsis: true,
+            },
+            {
+              title: '执行器',
+              dataIndex: 'executor',
+              width: 100,
+              render: (v: string | undefined) => v || '-',
+            },
+            {
+              title: '状态',
+              dataIndex: 'status',
+              width: 80,
+              render: (v: string) => {
+                const map: Record<string, { color: string; label: string }> = {
+                  pending: { color: 'default', label: '待办' },
+                  running: { color: 'processing', label: '进行中' },
+                  completed: { color: 'success', label: '完成' },
+                  failed: { color: 'error', label: '失败' },
+                };
+                const s = map[v] || { color: 'default', label: v };
+                return <AntTag color={s.color}>{s.label}</AntTag>;
+              },
             },
           ]}
         />

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -660,24 +660,22 @@ export function SettingsPage() {
                   <Switch checked={autoBackupEnabled} onChange={setAutoBackupEnabled} />
                 </div>
                 {autoBackupEnabled && (
-                  <>
-                    <Cron
-                      value={cronTo5(autoBackupCron)}
-                      setValue={(val: string) => {
-                        setAutoBackupCron(cronTo6(val));
-                      }}
-                      locale={CRON_ZH_LOCALE}
-                      defaultPeriod="day"
-                      humanizeLabels
-                      allowClear={false}
-                    />
-                    <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 8 }}>
-                      <Button size="small" type="primary" onClick={handleSaveAutoBackup} loading={backupLoading}>
-                        保存
-                      </Button>
-                    </div>
-                  </>
+                  <Cron
+                    value={cronTo5(autoBackupCron)}
+                    setValue={(val: string) => {
+                      setAutoBackupCron(cronTo6(val));
+                    }}
+                    locale={CRON_ZH_LOCALE}
+                    defaultPeriod="day"
+                    humanizeLabels
+                    allowClear={false}
+                  />
                 )}
+                <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 8 }}>
+                  <Button size="small" type="primary" onClick={handleSaveAutoBackup} loading={backupLoading}>
+                    保存
+                  </Button>
+                </div>
               </div>
 
               {backupStatus && backupStatus.files.length > 0 && (
@@ -685,7 +683,7 @@ export function SettingsPage() {
                   <div style={{ fontWeight: 600, marginBottom: 8 }}>备份文件 ({backupStatus.files.length})</div>
                   <List
                     size="small"
-                    dataSource={backupStatus.files.slice(0, 10)}
+                    dataSource={backupStatus.files}
                     renderItem={(file) => (
                       <List.Item
                         style={{ padding: '6px 0', fontSize: 12 }}

--- a/frontend/src/components/TodoSettingsDrawer.tsx
+++ b/frontend/src/components/TodoSettingsDrawer.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from 'react';
-import { Drawer, Input, Button, Switch, Divider, App, Space, Tag } from 'antd';
+import { Drawer, Input, Button, Switch, Divider, App } from 'antd';
 import { ClockCircleOutlined, CheckOutlined, FolderOutlined } from '@ant-design/icons';
+import { Cron } from 'react-js-cron';
+import 'react-js-cron/dist/styles.css';
 import * as db from '../utils/database';
+import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '../utils/cron';
 import { EXECUTORS } from '../types';
 import type { Todo } from '../types';
 import { TagCheckCardGroup } from './TagCheckCard';
-import parseExpression from 'cron-parser';
 
 interface TodoSettingsDrawerProps {
   open: boolean;
@@ -15,21 +17,7 @@ interface TodoSettingsDrawerProps {
   onUpdated: () => void;
 }
 
-const CRON_PRESETS = [
-  { label: '每10分钟', value: '0 */10 * * * *', category: '常用' },
-  { label: '每30分钟', value: '0 */30 * * * *', category: '常用' },
-  { label: '每1小时', value: '0 0 * * * *', category: '常用' },
-  { label: '每2小时', value: '0 0 */2 * * *', category: '常用' },
-  { label: '每6小时', value: '0 0 */6 * * *', category: '常用' },
-  { label: '每天0点', value: '0 0 0 * * *', category: '定时' },
-  { label: '每天9:00', value: '0 0 9 * * *', category: '定时' },
-  { label: '每天18:00', value: '0 0 18 * * *', category: '定时' },
-  { label: '工作日9-18点每小时', value: '0 0 9-18 * * 1-5', category: '工作时间' },
-  { label: '工作日10:00', value: '0 0 10 * * 1-5', category: '工作时间' },
-  { label: '工作日14:00', value: '0 0 14 * * 1-5', category: '工作时间' },
-  { label: '22:00-08:00每45分钟', value: '0 */45 22-23,0-8 * * *', category: '下班时间' },
-  { label: '22:00-08:00每小时', value: '0 0 22-23,0-8 * * *', category: '下班时间' },
-];
+const DEFAULT_CRON = '0 */10 * * * *';
 
 export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: TodoSettingsDrawerProps) {
   const { message } = App.useApp();
@@ -38,44 +26,7 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
   const [schedulerConfig, setSchedulerConfig] = useState<string>('');
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [workspace, setWorkspace] = useState<string>('');
-
-  const [cronSecond, setCronSecond] = useState<string>('');
-  const [cronMinute, setCronMinute] = useState<string>('');
-  const [cronHour, setCronHour] = useState<string>('');
-  const [cronDay, setCronDay] = useState<string>('');
-  const [cronMonth, setCronMonth] = useState<string>('');
-  const [cronWeekday, setCronWeekday] = useState<string>('');
-
   const [loading, setLoading] = useState(false);
-
-  const setCronFields = (config: string) => {
-    const parts = config.split(' ');
-    if (parts.length >= 6) {
-      setCronSecond(parts[0]);
-      setCronMinute(parts[1]);
-      setCronHour(parts[2]);
-      setCronDay(parts[3]);
-      setCronMonth(parts[4]);
-      setCronWeekday(parts[5]);
-    }
-  };
-
-  const handlePresetSelect = (presetValue: string) => {
-    setSchedulerConfig(presetValue);
-    setCronFields(presetValue);
-  };
-
-  const validateCronExpression = (expr: string): { valid: boolean; error?: string } => {
-    if (!expr) return { valid: false, error: 'Cron 表达式不能为空' };
-    const parts = expr.split(' ');
-    if (parts.length !== 6) return { valid: false, error: 'Cron 表达式必须包含6个字段（秒 分 时 日 月 星期）' };
-    try {
-      parseExpression.parse(expr);
-      return { valid: true };
-    } catch (error: any) {
-      return { valid: false, error: `无效的 Cron 表达式: ${error.message}` };
-    }
-  };
 
   useEffect(() => {
     if (todo) {
@@ -84,24 +35,11 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
       setSchedulerConfig(todo.scheduler_config || '');
       setSelectedTags((todo as any).tag_ids || []);
       setWorkspace(todo.workspace || '');
-      if (todo.scheduler_config) {
-        setCronFields(todo.scheduler_config);
-      } else {
-        setCronFields('* * * * * *');
-      }
     }
   }, [todo, open]);
 
   const handleSave = async () => {
     if (!todo) return;
-
-    if (schedulerEnabled) {
-      const validation = validateCronExpression(schedulerConfig);
-      if (!validation.valid) {
-        message.error(validation.error);
-        return;
-      }
-    }
 
     setLoading(true);
     try {
@@ -258,9 +196,7 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
             onChange={(checked) => {
               setSchedulerEnabled(checked);
               if (checked && !schedulerConfig) {
-                const defaultCron = '0 */10 * * * *';
-                setSchedulerConfig(defaultCron);
-                setCronFields(defaultCron);
+                setSchedulerConfig(DEFAULT_CRON);
               }
             }}
           />
@@ -268,98 +204,14 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
 
         {schedulerEnabled && (
           <div style={{ marginTop: 12 }}>
-            <div style={{ marginBottom: 8 }}>
-              <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 6, fontWeight: 500 }}>
-                快捷选择
-              </div>
-              <Space direction="vertical" style={{ width: '100%' }} size={8}>
-                {['常用', '定时', '工作时间', '下班时间'].map(category => {
-                  const presets = CRON_PRESETS.filter(p => p.category === category);
-                  return (
-                    <div key={category}>
-                      <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginBottom: 4 }}>
-                        {category}
-                      </div>
-                      <Space wrap size={6}>
-                        {presets.map(preset => (
-                          <Tag
-                            key={preset.value}
-                            color={schedulerConfig === preset.value ? 'blue' : 'default'}
-                            style={{
-                              cursor: 'pointer',
-                              padding: '4px 10px',
-                              fontSize: 12,
-                              borderRadius: 4,
-                              border: schedulerConfig === preset.value ? '2px solid #1677ff' : '1px solid var(--color-border)',
-                              fontWeight: schedulerConfig === preset.value ? 600 : 400,
-                            }}
-                            onClick={() => handlePresetSelect(preset.value)}
-                          >
-                            {preset.label}
-                          </Tag>
-                        ))}
-                      </Space>
-                    </div>
-                  );
-                })}
-              </Space>
-            </div>
-
-            <div>
-              <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 6, fontWeight: 500 }}>
-                Cron 表达式配置
-              </div>
-              <div style={{
-                display: 'grid',
-                gridTemplateColumns: 'repeat(auto-fit, minmax(80px, 1fr))',
-                gap: '8px 12px',
-                background: 'var(--color-fill-quaternary)',
-                padding: '12px',
-                borderRadius: '8px',
-                border: '1px solid var(--color-border-secondary)',
-              }}>
-                {[
-                  { label: '秒', value: cronSecond, onChange: setCronSecond, placeholder: '0-59' },
-                  { label: '分', value: cronMinute, onChange: setCronMinute, placeholder: '0-59' },
-                  { label: '时', value: cronHour, onChange: setCronHour, placeholder: '0-23' },
-                  { label: '日', value: cronDay, onChange: setCronDay, placeholder: '1-31' },
-                  { label: '月', value: cronMonth, onChange: setCronMonth, placeholder: '1-12' },
-                  { label: '星期', value: cronWeekday, onChange: setCronWeekday, placeholder: '0-6' },
-                ].map((field, index) => (
-                  <div key={field.label}>
-                    <div style={{
-                      fontSize: 11,
-                      color: 'var(--color-text-tertiary)',
-                      marginBottom: 4,
-                      textAlign: 'center',
-                      fontWeight: 500,
-                    }}>
-                      {field.label}
-                    </div>
-                    <Input
-                      value={field.value}
-                      onChange={(e) => {
-                        const newVal = e.target.value;
-                        field.onChange(newVal);
-                        const parts = [cronSecond, cronMinute, cronHour, cronDay, cronMonth, cronWeekday];
-                        parts[index] = newVal;
-                        setSchedulerConfig(parts.join(' '));
-                      }}
-                      placeholder={field.placeholder}
-                      style={{
-                        fontSize: 12,
-                        textAlign: 'center',
-                        fontFamily: 'monospace',
-                        borderColor: index < 5 ? undefined : '#1677ff',
-                      }}
-                    />
-                  </div>
-                ))}
-              </div>
-              <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 6 }}>
-                提示: * (任意) */n (每n) n-m (范围) n,m,n (多个值，如 1,3,5 表示第1、3、5)
-              </div>
-            </div>
+            <Cron
+              value={cronTo5(schedulerConfig || DEFAULT_CRON)}
+              setValue={(val: string) => setSchedulerConfig(cronTo6(val))}
+              locale={CRON_ZH_LOCALE}
+              defaultPeriod="hour"
+              humanizeLabels
+              allowClear={false}
+            />
           </div>
         )}
 

--- a/frontend/src/utils/cron.ts
+++ b/frontend/src/utils/cron.ts
@@ -1,0 +1,47 @@
+import type { Locale } from 'react-js-cron';
+
+/** Chinese locale for react-js-cron */
+export const CRON_ZH_LOCALE: Locale = {
+  everyText: '每',
+  emptyMonths: '每月',
+  emptyMonthDays: '每日',
+  emptyMonthDaysShort: '每日',
+  emptyWeekDays: '每周几',
+  emptyWeekDaysShort: '每天',
+  emptyHours: '每小时',
+  emptyMinutes: '每分钟',
+  emptyMinutesForHourPeriod: '每分钟',
+  yearOption: '年',
+  monthOption: '月',
+  weekOption: '周',
+  dayOption: '天',
+  hourOption: '小时',
+  minuteOption: '分钟',
+  rebootOption: '重启',
+  prefixPeriod: '每',
+  prefixMonths: '的',
+  prefixMonthDays: '的',
+  prefixWeekDays: '的',
+  prefixWeekDaysForMonthAndYearPeriod: '和',
+  prefixHours: '的',
+  prefixMinutes: '的',
+  prefixMinutesForHourPeriod: '的',
+  suffixMinutesForHourPeriod: '',
+  errorInvalidCron: '无效的 Cron 表达式',
+  clearButtonText: '清空',
+  weekDays: ['周日', '周一', '周二', '周三', '周四', '周五', '周六'],
+  months: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'],
+  altWeekDays: ['日', '一', '二', '三', '四', '五', '六'],
+  altMonths: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+};
+
+/** 6-field cron (with seconds) → 5-field (drop seconds) */
+export function cronTo5(value: string): string {
+  const parts = value.trim().split(/\s+/);
+  return parts.length >= 6 ? parts.slice(1).join(' ') : value;
+}
+
+/** 5-field cron → 6-field (prepend seconds=0) */
+export function cronTo6(value: string): string {
+  return `0 ${value}`;
+}

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -160,6 +160,42 @@ export async function mergeBackup(tags: { name: string; color: string }[], todos
   return unwrap(await api.post<ApiResp<string>>('/xyz/backup/merge', { tags, todos }));
 }
 
+export async function exportSelectedBackup(todoIds: number[]): Promise<string> {
+  const res = await api.post('/xyz/backup/export-selected', { todo_ids: todoIds }, {
+    headers: { 'Accept': 'application/x-yaml' },
+    responseType: 'text',
+    transformResponse: [(data: unknown) => data],
+  });
+  if (typeof res.data === 'string') return res.data;
+  return JSON.stringify(res.data);
+}
+
+export async function triggerLocalBackup(): Promise<string> {
+  return unwrap(await api.post<ApiResp<string>>('/xyz/backup/database/trigger'));
+}
+
+export async function getDatabaseBackupStatus(): Promise<{
+  auto_backup_enabled: boolean;
+  auto_backup_cron: string;
+  last_backup: string | null;
+  files: { name: string; size: number; created_at: string }[];
+}> {
+  return unwrap(await api.get<ApiResp<{
+    auto_backup_enabled: boolean;
+    auto_backup_cron: string;
+    last_backup: string | null;
+    files: { name: string; size: number; created_at: string }[];
+  }>>('/xyz/backup/database/status'));
+}
+
+export async function updateAutoBackup(enabled: boolean, cron: string): Promise<string> {
+  return unwrap(await api.put<ApiResp<string>>('/xyz/backup/database/auto', { enabled, cron }));
+}
+
+export async function deleteBackupFile(filename: string): Promise<string> {
+  return unwrap(await api.delete<ApiResp<string>>('/xyz/backup/database/file', { data: { filename } }));
+}
+
 // Config APIs
 
 export async function getConfig(): Promise<import('../types').Config> {


### PR DESCRIPTION
## Summary
- 新增选择性导出功能：弹窗展示所有 todo 列表，支持 Checkbox 多选，仅导出选中项为 YAML
- 新增数据库备份功能：手动下载 .db 文件、触发服务器端备份到 ~/.ntd/backups/
- 新增自动定时备份：支持 cron 表达式配置，自动保留最近 30 个备份文件
- 备份文件列表展示与删除管理

## 修改文件
| 文件 | 变更 |
|------|------|
| `backend/src/handlers/backup.rs` | 新增 6 个 handler（选择性导出、数据库下载/触发/状态/自动配置/删除） |
| `backend/src/handlers/mod.rs` | 注册 6 条新路由 |
| `backend/src/db/todo.rs` | 新增 `get_todo_backups_by_ids`、`get_tag_backups_for_todos` |
| `backend/src/config.rs` | Config 增加 auto_backup 字段 |
| `backend/src/main.rs` | 启动时注册自动备份 cron |
| `frontend/src/utils/database.ts` | 新增 6 个 API 函数 |
| `frontend/src/components/SettingsPage.tsx` | 选择性导出 Modal + 数据库备份 UI |

## Test plan
- [ ] 设置页导出按钮弹窗，勾选 todo 后点击导出，下载的 YAML 仅包含选中项
- [ ] 手动下载数据库 — 点击按钮下载 .db 文件
- [ ] 备份到本地 — 触发后在 ~/.ntd/backups/ 目录看到备份文件
- [ ] 开启自动备份 — 设定 cron 表达式，保存后重启服务验证定时任务启动
- [ ] 备份文件列表 — 展示已有备份，可删除