### PR TITLE
feat: 多主题切换支持（亮色/暗色）

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -72,6 +72,30 @@
   --z-toast: 60;
 }
 
+/* ---------- Dark Theme Variables ---------- */
+[data-theme="dark"] {
+  --color-primary-light: #0c4a5e;
+  --color-primary-bg: #0a2e3d;
+  --color-success-bg: #052e16;
+  --color-warning-bg: #422006;
+  --color-error-bg: #450a0a;
+  --color-info-bg: #172554;
+
+  --color-bg: #11111b;
+  --color-bg-elevated: #1e1e2e;
+  --color-border: #313244;
+  --color-border-light: #262637;
+
+  --color-text: #cdd6f4;
+  --color-text-secondary: #a6adc8;
+  --color-text-tertiary: #6c7086;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.2);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.4);
+  --shadow-primary: 0 4px 14px rgba(8, 145, 178, 0.35);
+}
+
 /* Basic Reset */
 *, *::before, *::after {
   box-sizing: border-box;
@@ -254,7 +278,7 @@ body {
 
 .todo-item.selected {
   border-color: var(--color-primary);
-  background: linear-gradient(135deg, var(--color-primary-bg) 0%, #fff 100%);
+  background: linear-gradient(135deg, var(--color-primary-bg) 0%, var(--color-bg-elevated) 100%);
   box-shadow: var(--shadow-primary);
 }
 
@@ -321,7 +345,7 @@ body {
 }
 
 .todo-item-status:hover {
-  background: rgba(0, 0, 0, 0.05);
+  background: var(--color-border-light);
 }
 
 /* ---------- Detail Panel ---------- */
@@ -335,7 +359,7 @@ body {
 }
 
 .detail-card {
-  background: #ffffff;
+  background: var(--color-bg-elevated);
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border-light);
   box-shadow: var(--shadow-sm);
@@ -459,7 +483,7 @@ body {
 
 /* ---------- History Cards ---------- */
 .history-card {
-  background: #ffffff;
+  background: var(--color-bg-elevated);
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border-light);
   box-shadow: var(--shadow-sm);
@@ -591,7 +615,7 @@ body {
 }
 
 .chat-bubble-content pre {
-  background: rgba(0, 0, 0, 0.06);
+  background: var(--color-border-light);
   border-radius: 6px;
   padding: 8px 12px;
   overflow-x: auto;
@@ -733,7 +757,7 @@ body {
 }
 
 .chat-tool-code {
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--color-border-light);
   border-radius: 6px;
   padding: 8px 12px;
   font-family: var(--font-mono);
@@ -1018,7 +1042,8 @@ body {
 }
 
 .glass-effect {
-  background: rgba(255, 255, 255, 0.85);
+  background: var(--color-bg-elevated);
+  opacity: 0.85;
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
 }
@@ -1130,7 +1155,7 @@ body {
 
 /* Tag Check Card Styles */
 .tag-check-card {
-  background: #ffffff;
+  background: var(--color-bg-elevated);
   border: 1px solid var(--color-border-light);
   border-radius: var(--radius-sm);
   padding: 12px 16px;
@@ -1223,7 +1248,7 @@ code {
   z-index: 100;
   background: var(--color-bg-elevated);
   border-top: 1px solid var(--color-border);
-  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
   display: flex;
   flex-direction: column;
   transition: height 0.3s ease;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -70,6 +70,9 @@
   --z-modal: 30;
   --z-fab: 50;
   --z-toast: 60;
+
+  /* Alpha-enabled colors for glass effect */
+  --color-bg-elevated-alpha: rgba(255, 255, 255, 0.85);
 }
 
 /* ---------- Dark Theme Variables ---------- */
@@ -83,6 +86,7 @@
 
   --color-bg: #11111b;
   --color-bg-elevated: #1e1e2e;
+  --color-bg-elevated-alpha: rgba(30, 30, 46, 0.85);
   --color-border: #313244;
   --color-border-light: #262637;
 
@@ -1042,8 +1046,7 @@ body {
 }
 
 .glass-effect {
-  background: var(--color-bg-elevated);
-  opacity: 0.85;
+  background: var(--color-bg-elevated-alpha);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { ConfigProvider, Layout, Spin, App as AntApp } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import { AppProvider, useApp } from './hooks/useApp';
 import { useExecutionEvents } from './hooks/useExecutionEvents';
+import { ThemeProvider, useTheme } from './hooks/useTheme';
 import { TodoList } from './components/TodoList';
 import { TodoDetail } from './components/TodoDetail';
 import { Dashboard } from './components/Dashboard';
@@ -156,64 +157,13 @@ function AppContent() {
   );
 }
 
-const customTheme = {
-  token: {
-    colorPrimary: '#0891b2',
-    colorSuccess: '#22c55e',
-    colorWarning: '#f59e0b',
-    colorError: '#ef4444',
-    colorInfo: '#3b82f6',
-    borderRadius: 12,
-    borderRadiusLG: 16,
-    borderRadiusSM: 8,
-    fontFamily: "'JetBrains Mono', 'SF Mono', 'Cascadia Code', monospace",
-    fontSize: 14,
-    controlHeight: 40,
-    lineHeight: 1.5,
-    colorBgContainer: '#ffffff',
-    colorBgLayout: '#f8fafc',
-    colorText: '#0f172a',
-    colorTextSecondary: '#475569',
-    colorBorder: '#e2e8f0',
-    colorBorderSecondary: '#f1f5f9',
-    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.08)',
-    boxShadowSecondary: '0 8px 24px rgba(0, 0, 0, 0.12)',
-  },
-  components: {
-    Button: {
-      borderRadius: 10,
-      controlHeight: 40,
-      paddingInline: 20,
-    },
-    Card: {
-      borderRadius: 16,
-      paddingLG: 24,
-    },
-    Modal: {
-      borderRadiusLG: 16,
-      paddingContentHorizontalLG: 24,
-    },
-    Input: {
-      borderRadius: 10,
-      paddingInline: 14,
-    },
-    Select: {
-      borderRadius: 10,
-    },
-    Tag: {
-      borderRadius: 6,
-    },
-    Switch: {
-      colorPrimary: '#0891b2',
-    },
-  },
-};
+function ThemedApp() {
+  const { themeConfig } = useTheme();
 
-function App() {
   return (
     <ConfigProvider
       locale={zhCN}
-      theme={customTheme}
+      theme={themeConfig}
     >
       <AntApp>
         <AppProvider>
@@ -221,6 +171,14 @@ function App() {
         </AppProvider>
       </AntApp>
     </ConfigProvider>
+  );
+}
+
+function App() {
+  return (
+    <ThemeProvider>
+      <ThemedApp />
+    </ThemeProvider>
   );
 }
 

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useApp } from '../hooks/useApp';
-import { Button, Empty } from 'antd';
-import { PlusOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, SettingOutlined } from '@ant-design/icons';
+import { Button, Empty, Tooltip } from 'antd';
+import { PlusOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, SettingOutlined, SunOutlined, MoonOutlined } from '@ant-design/icons';
+import { useTheme } from '../hooks/useTheme';
 import { StatusPicker } from './StatusPicker';
 import * as db from '../utils/database';
 import { getExecutorOption } from '../types';
@@ -30,6 +31,7 @@ function SkeletonList() {
 
 export function TodoList({ onOpenCreateModal, onSelectTodo, onShowDashboard, onShowSettings }: TodoListProps) {
   const { state, dispatch } = useApp();
+  const { themeMode, toggleTheme } = useTheme();
   const { todos, selectedTodoId, selectedTagId, tags } = state;
   const [isMobile, setIsMobile] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -83,6 +85,16 @@ export function TodoList({ onOpenCreateModal, onSelectTodo, onShowDashboard, onS
             className="tag-btn"
             aria-label="查看仪表盘"
           />
+          <Tooltip title={themeMode === 'light' ? '切换暗色主题' : '切换亮色主题'}>
+            <Button
+              type="text"
+              size="small"
+              icon={themeMode === 'light' ? <MoonOutlined /> : <SunOutlined />}
+              onClick={toggleTheme}
+              className="tag-btn"
+              aria-label="切换主题"
+            />
+          </Tooltip>
           <Button
             type="text"
             size="small"

--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
+import { createContext, useContext, useState, useLayoutEffect, type ReactNode } from 'react';
 import type { ThemeConfig } from 'antd';
 import type { ThemeMode } from '../themes';
 import { themeMap } from '../themes';
@@ -24,8 +24,11 @@ function getInitialTheme(): ThemeMode {
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [themeMode, setThemeMode] = useState<ThemeMode>(getInitialTheme);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     document.documentElement.setAttribute('data-theme', themeMode);
+  }, [themeMode]);
+
+  useLayoutEffect(() => {
     try {
       localStorage.setItem(STORAGE_KEY, themeMode);
     } catch {}

--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
+import type { ThemeConfig } from 'antd';
+import type { ThemeMode } from '../themes';
+import { themeMap } from '../themes';
+
+interface ThemeContextValue {
+  themeMode: ThemeMode;
+  themeConfig: ThemeConfig;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const STORAGE_KEY = 'app_theme';
+
+function getInitialTheme(): ThemeMode {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === 'dark' || saved === 'light') return saved;
+  } catch {}
+  return 'light';
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [themeMode, setThemeMode] = useState<ThemeMode>(getInitialTheme);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', themeMode);
+    try {
+      localStorage.setItem(STORAGE_KEY, themeMode);
+    } catch {}
+  }, [themeMode]);
+
+  const toggleTheme = () => {
+    setThemeMode(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  const themeConfig = themeMap[themeMode];
+
+  return (
+    <ThemeContext.Provider value={{ themeMode, themeConfig, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}

--- a/frontend/src/themes/index.ts
+++ b/frontend/src/themes/index.ts
@@ -1,0 +1,85 @@
+import type { ThemeConfig } from 'antd';
+import { theme } from 'antd';
+
+const sharedToken = {
+  colorPrimary: '#0891b2',
+  colorSuccess: '#22c55e',
+  colorWarning: '#f59e0b',
+  colorError: '#ef4444',
+  colorInfo: '#3b82f6',
+  borderRadius: 12,
+  borderRadiusLG: 16,
+  borderRadiusSM: 8,
+  fontFamily: "'JetBrains Mono', 'SF Mono', 'Cascadia Code', monospace",
+  fontSize: 14,
+  controlHeight: 40,
+  lineHeight: 1.5,
+};
+
+const sharedComponents = {
+  Button: {
+    borderRadius: 10,
+    controlHeight: 40,
+    paddingInline: 20,
+  },
+  Card: {
+    borderRadius: 16,
+    paddingLG: 24,
+  },
+  Modal: {
+    borderRadiusLG: 16,
+    paddingContentHorizontalLG: 24,
+  },
+  Input: {
+    borderRadius: 10,
+    paddingInline: 14,
+  },
+  Select: {
+    borderRadius: 10,
+  },
+  Tag: {
+    borderRadius: 6,
+  },
+  Switch: {
+    colorPrimary: '#0891b2',
+  },
+};
+
+export const lightTheme: ThemeConfig = {
+  algorithm: theme.defaultAlgorithm,
+  token: {
+    ...sharedToken,
+    colorBgContainer: '#ffffff',
+    colorBgLayout: '#f8fafc',
+    colorText: '#0f172a',
+    colorTextSecondary: '#475569',
+    colorBorder: '#e2e8f0',
+    colorBorderSecondary: '#f1f5f9',
+    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.08)',
+    boxShadowSecondary: '0 8px 24px rgba(0, 0, 0, 0.12)',
+  },
+  components: sharedComponents,
+};
+
+export const darkTheme: ThemeConfig = {
+  algorithm: theme.darkAlgorithm,
+  token: {
+    ...sharedToken,
+    colorBgContainer: '#1e1e2e',
+    colorBgLayout: '#11111b',
+    colorText: '#cdd6f4',
+    colorTextSecondary: '#a6adc8',
+    colorBorder: '#313244',
+    colorBorderSecondary: '#262637',
+    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
+    boxShadowSecondary: '0 8px 24px rgba(0, 0, 0, 0.4)',
+  },
+  components: sharedComponents,
+};
+
+export type ThemeMode = 'light' | 'dark';
+
+export const themeMap: Record<ThemeMode, ThemeConfig> = {
+  light: lightTheme,
+  dark: darkTheme,
+};


### PR DESCRIPTION
## Summary
- 新增多主题切换功能，支持亮色和暗色主题
- 利用 antd v6 的 `algorithm` 机制实现主题切换
- CSS 变量同步跟随主题变化
- 主题偏好通过 localStorage 持久化，刷新页面后保持

## 新增文件
- `frontend/src/themes/index.ts` — 主题配置（lightTheme / darkTheme）
- `frontend/src/hooks/useTheme.tsx` — ThemeProvider + useTheme hook

## 修改内容
- `frontend/src/App.tsx` — 集成 ThemeProvider，ConfigProvider 使用动态主题配置
- `frontend/src/App.css` — 新增 `[data-theme="dark"]` 变量块，替换硬编码颜色
- `frontend/src/components/TodoList.tsx` — 头部添加主题切换按钮（太阳/月亮图标）

## Test plan
- [ ] `make dev` 启动开发服务器
- [ ] 点击 TodoList 顶部的月亮/太阳图标切换主题
- [ ] 确认 antd 组件（Button、Card、Modal、Input 等）正确切换明暗主题
- [ ] 确认自定义 CSS 样式同步变化
- [ ] 刷新页面后主题保持不变