### PR TITLE
feat: 优化 ChatView 对话显示样式

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -642,128 +642,125 @@ body {
   color: rgba(255, 255, 255, 0.7);
 }
 
-/* Thinking Block */
-.chat-thinking-block {
-  background: var(--color-warning-bg);
-  border: 1px solid rgba(245, 158, 11, 0.2);
+/* ---------- Collapsible Card Styles (Trae-like) ---------- */
+.chat-collapsible-card {
   border-radius: var(--radius-md);
+  border: 1px solid;
   overflow: hidden;
-  max-width: 85%;
+  max-width: 90%;
   align-self: flex-start;
+  transition: box-shadow var(--transition-fast);
 }
 
-.chat-thinking-header {
+.chat-collapsible-card:hover {
+  box-shadow: var(--shadow-sm);
+}
+
+.chat-card-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--space-sm);
   padding: var(--space-sm) var(--space-md);
   cursor: pointer;
   font-size: 13px;
   font-weight: 500;
-  color: var(--color-text-secondary);
   user-select: none;
-  background: none;
+  background: transparent;
   border: none;
   width: 100%;
   text-align: left;
+  transition: background var(--transition-fast);
 }
 
-.chat-thinking-header:hover {
-  background: rgba(245, 158, 11, 0.05);
+.chat-card-header:hover {
+  background: rgba(0, 0, 0, 0.03);
 }
 
-.chat-thinking-toggle {
-  margin-left: auto;
+[data-theme="dark"] .chat-card-header:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.chat-card-header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-width: 0;
+  flex: 1;
+}
+
+.chat-card-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.chat-card-label {
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.chat-card-preview {
   font-size: 12px;
-  color: var(--color-primary);
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
 }
 
-.chat-thinking-content {
+.chat-card-header-right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-shrink: 0;
+}
+
+.chat-card-time {
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-card-toggle {
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  transition: transform var(--transition-fast);
+}
+
+.chat-card-content {
   padding: var(--space-sm) var(--space-md);
-  border-top: 1px solid rgba(245, 158, 11, 0.15);
+  border-top: 1px solid var(--color-border-light);
   font-size: 13px;
   color: var(--color-text-secondary);
-  max-height: 200px;
+  max-height: 400px;
   overflow-y: auto;
 }
 
-/* Tool Block */
-.chat-tool-block {
-  background: var(--color-info-bg);
-  border: 1px solid rgba(59, 130, 246, 0.2);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  max-width: 85%;
-  align-self: flex-start;
+.chat-card-section {
+  margin-bottom: var(--space-md);
 }
 
-.chat-tool-header {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  padding: var(--space-sm) var(--space-md);
-  cursor: pointer;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--color-text-secondary);
-  user-select: none;
-  background: none;
-  border: none;
-  width: 100%;
-  text-align: left;
-}
-
-.chat-tool-header:hover {
-  background: rgba(59, 130, 246, 0.05);
-}
-
-.chat-tool-name {
-  font-family: var(--font-mono);
-  color: var(--color-info);
-  font-weight: 600;
-}
-
-.chat-tool-preview {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--color-text-tertiary);
-  max-width: 200px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.chat-tool-toggle {
-  margin-left: auto;
-  font-size: 12px;
-  color: var(--color-primary);
-}
-
-.chat-tool-content {
-  padding: var(--space-sm) var(--space-md);
-  border-top: 1px solid rgba(59, 130, 246, 0.15);
-}
-
-.chat-tool-section {
-  margin-bottom: var(--space-sm);
-}
-
-.chat-tool-section:last-child {
+.chat-card-section:last-child {
   margin-bottom: 0;
 }
 
-.chat-tool-section-label {
+.chat-card-section-label {
   font-size: 11px;
   font-weight: 600;
   color: var(--color-text-tertiary);
   margin-bottom: var(--space-xs);
   text-transform: uppercase;
+  letter-spacing: 0.5px;
 }
 
-.chat-tool-code {
+.chat-card-code {
   background: var(--color-border-light);
-  border-radius: 6px;
-  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
   font-family: var(--font-mono);
   font-size: 12px;
   color: var(--color-text-secondary);
@@ -773,51 +770,28 @@ body {
   word-break: break-all;
 }
 
-/* System Message */
+/* Mobile adjustments for collapsible cards */
+@media (max-width: 767px) {
+  .chat-collapsible-card {
+    max-width: 100%;
+  }
+
+  .chat-card-preview {
+    display: none;
+  }
+}
+
+/* System Message - displayed inline */
 .chat-system-message {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: var(--space-sm);
   padding: var(--space-xs) var(--space-md);
   font-size: 12px;
   color: var(--color-text-tertiary);
-  align-self: center;
-  max-width: 90%;
-}
-
-.chat-time {
-  font-size: 11px;
-  color: var(--color-text-tertiary);
-  margin-left: auto;
-}
-
-/* Result Block */
-.chat-result-block {
-  background: var(--color-success-bg);
-  border: 1px solid rgba(34, 197, 94, 0.2);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  max-width: 90%;
   align-self: flex-start;
-}
-
-.chat-result-header {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  padding: var(--space-sm) var(--space-md);
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--color-success);
-}
-
-.chat-result-content {
-  padding: var(--space-sm) var(--space-md);
-  border-top: 1px solid rgba(34, 197, 94, 0.15);
-  font-size: 14px;
-  color: var(--color-text-secondary);
-  max-height: 300px;
-  overflow-y: auto;
+  max-width: 90%;
+  margin-left: var(--space-md);
 }
 
 /* Typing Indicator */
@@ -879,12 +853,6 @@ body {
 /* Mobile Responsive */
 @media (max-width: 767px) {
   .chat-bubble-row {
-    max-width: 90%;
-  }
-
-  .chat-thinking-block,
-  .chat-tool-block,
-  .chat-result-block {
     max-width: 90%;
   }
 

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -1,5 +1,15 @@
 import { useState } from 'react';
-import { RobotOutlined, UserOutlined, ToolOutlined, BulbOutlined, CheckCircleOutlined, InfoCircleOutlined, LoadingOutlined } from '@ant-design/icons';
+import {
+  RobotOutlined,
+  UserOutlined,
+  ToolOutlined,
+  BulbOutlined,
+  InfoCircleOutlined,
+  LoadingOutlined,
+  DownOutlined,
+  RightOutlined,
+  MessageOutlined,
+} from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
 import type { LogEntry, ChatMessage } from '../types';
 
@@ -99,7 +109,6 @@ export function parseLogsToMessages(logs: LogEntry[]): ChatMessage[] {
     }
   }
 
-  // Flush remaining
   if (currentThinking) {
     messages.push({ role: 'thinking', content: currentThinking });
   }
@@ -121,83 +130,170 @@ function formatTime(iso?: string): string {
   }
 }
 
-function ThinkingBlock({ content, timestamp }: { content: string; timestamp?: string }) {
+// 卡片类型配置
+const CARD_CONFIG = {
+  thinking: {
+    icon: BulbOutlined,
+    label: '思考',
+    color: '#f59e0b',
+    bgColor: 'rgba(245, 158, 11, 0.1)',
+    borderColor: 'rgba(245, 158, 11, 0.3)',
+  },
+  tool: {
+    icon: ToolOutlined,
+    label: '工具',
+    color: '#8b5cf6',
+    bgColor: 'rgba(139, 92, 246, 0.1)',
+    borderColor: 'rgba(139, 92, 246, 0.3)',
+  },
+  output: {
+    icon: MessageOutlined,
+    label: '输出',
+    color: '#3b82f6',
+    bgColor: 'rgba(59, 130, 246, 0.1)',
+    borderColor: 'rgba(59, 130, 246, 0.3)',
+  },
+  system: {
+    icon: InfoCircleOutlined,
+    label: '系统',
+    color: '#94a3b8',
+    bgColor: 'rgba(148, 163, 184, 0.1)',
+    borderColor: 'rgba(148, 163, 184, 0.3)',
+  },
+} as const;
+
+// 通用的可折叠卡片组件
+function CollapsibleCard({
+  type,
+  preview,
+  children,
+  timestamp,
+}: {
+  type: 'thinking' | 'tool' | 'output' | 'system';
+  preview?: string;
+  children: React.ReactNode;
+  timestamp?: string;
+}) {
   const [expanded, setExpanded] = useState(false);
+  const config = CARD_CONFIG[type];
+  const Icon = config.icon;
+
   return (
-    <div className="chat-thinking-block">
+    <div
+      className="chat-collapsible-card"
+      style={{
+        borderLeft: `3px solid ${config.color}`,
+        background: config.bgColor,
+        borderColor: config.borderColor,
+      }}
+    >
       <button
         type="button"
-        className="chat-thinking-header"
-        aria-expanded={expanded}
+        className="chat-card-header"
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
       >
-        <BulbOutlined style={{ color: '#f59e0b' }} />
-        <span>思考过程</span>
-        <span className="chat-thinking-toggle">{expanded ? '收起' : '展开'}</span>
-        {timestamp && <span className="chat-time">{formatTime(timestamp)}</span>}
-      </button>
-      {expanded && (
-        <div className="chat-thinking-content">
-          <XMarkdown content={content} />
+        <div className="chat-card-header-left">
+          <span className="chat-card-icon" style={{ color: config.color }}>
+            <Icon />
+          </span>
+          <span className="chat-card-label" style={{ color: config.color }}>
+            {config.label}
+          </span>
+          {preview && !expanded && (
+            <span className="chat-card-preview">{preview}</span>
+          )}
         </div>
-      )}
+        <div className="chat-card-header-right">
+          {timestamp && <span className="chat-card-time">{formatTime(timestamp)}</span>}
+          <span className="chat-card-toggle" style={{ color: config.color }}>
+            {expanded ? <DownOutlined /> : <RightOutlined />}
+          </span>
+        </div>
+      </button>
+      {expanded && <div className="chat-card-content">{children}</div>}
     </div>
   );
 }
 
-function ToolBlock({ toolName, toolInput, toolResult, timestamp }: { toolName?: string; toolInput?: string; toolResult?: string; timestamp?: string }) {
-  const [expanded, setExpanded] = useState(false);
+// 思考块
+function ThinkingBlock({ content, timestamp }: { content: string; timestamp?: string }) {
+  return (
+    <CollapsibleCard type="thinking" timestamp={timestamp}>
+      <XMarkdown content={content} />
+    </CollapsibleCard>
+  );
+}
 
-  // 生成参数预览（截取前50个字符）
+// 工具块
+function ToolBlock({
+  toolName,
+  toolInput,
+  toolResult,
+  timestamp,
+}: {
+  toolName?: string;
+  toolInput?: string;
+  toolResult?: string;
+  timestamp?: string;
+}) {
+  // 生成参数预览
   const getInputPreview = () => {
     if (!toolInput) return '';
     try {
       const parsed = JSON.parse(toolInput);
       const keys = Object.keys(parsed);
       if (keys.length === 0) return '{}';
-      const preview = keys.map(k => `${k}: ${typeof parsed[k] === 'string' ? `"${parsed[k].substring(0, 20)}${parsed[k].length > 20 ? '...' : ''}"` : parsed[k]}`).join(', ');
-      return preview.length > 60 ? preview.substring(0, 60) + '...' : preview;
+      const preview = keys
+        .map((k) => {
+          const val = parsed[k];
+          const strVal = typeof val === 'string' ? `"${val.substring(0, 15)}${val.length > 15 ? '...' : ''}"` : String(val);
+          return `${k}: ${strVal}`;
+        })
+        .join(', ');
+      return preview.length > 50 ? preview.substring(0, 50) + '...' : preview;
     } catch {
       return toolInput.length > 50 ? toolInput.substring(0, 50) + '...' : toolInput;
     }
   };
 
   return (
-    <div className="chat-tool-block">
-      <button
-        type="button"
-        className="chat-tool-header"
-        aria-expanded={expanded}
-        onClick={() => setExpanded(!expanded)}
-      >
-        <ToolOutlined style={{ color: '#3b82f6' }} />
-        <span className="chat-tool-name">{toolName || '工具调用'}</span>
-        {!expanded && toolInput && (
-          <span className="chat-tool-preview">{getInputPreview()}</span>
-        )}
-        <span className="chat-tool-toggle">{expanded ? '收起' : '展开'}</span>
-        {timestamp && <span className="chat-time">{formatTime(timestamp)}</span>}
-      </button>
-      {expanded && (
-        <div className="chat-tool-content">
-          {toolInput && (
-            <div className="chat-tool-section">
-              <div className="chat-tool-section-label">输入参数</div>
-              <pre className="chat-tool-code">{toolInput}</pre>
-            </div>
-          )}
-          {toolResult && (
-            <div className="chat-tool-section">
-              <div className="chat-tool-section-label">执行结果</div>
-              <pre className="chat-tool-code">{toolResult}</pre>
-            </div>
-          )}
+    <CollapsibleCard type="tool" preview={`${toolName || '工具调用'} ${getInputPreview()}`} timestamp={timestamp}>
+      {toolInput && (
+        <div className="chat-card-section">
+          <div className="chat-card-section-label">输入参数</div>
+          <pre className="chat-card-code">{toolInput}</pre>
         </div>
       )}
-    </div>
+      {toolResult && (
+        <div className="chat-card-section">
+          <div className="chat-card-section-label">执行结果</div>
+          <pre className="chat-card-code">{toolResult}</pre>
+        </div>
+      )}
+    </CollapsibleCard>
   );
 }
 
+// 结果块
+function ResultBlock({ content, timestamp }: { content: string; timestamp?: string }) {
+  return (
+    <CollapsibleCard type="output" timestamp={timestamp}>
+      <XMarkdown content={content} />
+    </CollapsibleCard>
+  );
+}
+
+// 系统消息块
+function SystemBlock({ content, timestamp }: { content: string; timestamp?: string }) {
+  return (
+    <CollapsibleCard type="system" timestamp={timestamp}>
+      <span>{content}</span>
+    </CollapsibleCard>
+  );
+}
+
+// 消息气泡
 function ChatBubble({ message }: { message: ChatMessage }) {
   const { role, content, timestamp, toolName, toolInput, toolResult } = message;
 
@@ -210,28 +306,11 @@ function ChatBubble({ message }: { message: ChatMessage }) {
   }
 
   if (role === 'system') {
-    return (
-      <div className="chat-system-message">
-        <InfoCircleOutlined style={{ color: '#94a3b8', fontSize: 12 }} />
-        <span>{content}</span>
-        {timestamp && <span className="chat-time">{formatTime(timestamp)}</span>}
-      </div>
-    );
+    return <SystemBlock content={content} timestamp={timestamp} />;
   }
 
   if (role === 'result') {
-    return (
-      <div className="chat-result-block">
-        <div className="chat-result-header">
-          <CheckCircleOutlined style={{ color: '#22c55e' }} />
-          <span>执行结果</span>
-          {timestamp && <span className="chat-time">{formatTime(timestamp)}</span>}
-        </div>
-        <div className="chat-result-content">
-          <XMarkdown content={content} />
-        </div>
-      </div>
-    );
+    return <ResultBlock content={content} timestamp={timestamp} />;
   }
 
   const isUser = role === 'user';


### PR DESCRIPTION
## Summary
- 重构为 Trae 风格的可折叠卡片设计
- 不同类型使用不同颜色图标区分：思考(琥珀)、工具(紫色)、输出(蓝色)
- 卡片默认收起，点击展开显示详细内容
- 优化移动端适配

## Test plan
- [ ] 执行任务查看对话历史
- [ ] 确认不同类型的消息有不同的颜色和图标
- [ ] 点击卡片可以展开/收起
- [ ] 移动端显示正常