### PR TITLE
fix: 修复选择性导出无法弹出下载框

### DIFF
--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -311,7 +311,15 @@ export function SettingsPage() {
     }
     setExportingSelected(true);
     try {
-      const yamlText = await db.exportSelectedBackup(exportTodoKeys);
+      const response = await fetch('/xyz/backup/export-selected', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/x-yaml' },
+        body: JSON.stringify({ todo_ids: exportTodoKeys }),
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      const yamlText = await response.text();
       const blob = new Blob([yamlText], { type: 'application/x-yaml' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- 修复选择性导出无法弹出下载框的问题
- 原因：`db.exportSelectedBackup` 使用 axios，会被响应拦截器误处理后端返回的纯 YAML，导致解析失败
- 改用原生 `fetch` 与全部导出保持一致的处理方式

## Test plan
- [ ] 点击全部导出，确认弹出下载框
- [ ] 选择性导出勾选若干项，点击导出，确认弹出下载框