### PR TITLE
feat: Dashboard 新增推理统计卡片和 Cron 预设选择功能

### DIFF
--- a/frontend/src/components/CronPresetSelect.tsx
+++ b/frontend/src/components/CronPresetSelect.tsx
@@ -57,7 +57,9 @@ export function CronPresetSelect({ value, onChange, disabled }: CronPresetSelect
       </div>
       <Select
         value={value}
-        onChange={onChange}
+        onChange={(val: string | undefined) => {
+          if (val !== undefined) onChange(val);
+        }}
         disabled={disabled}
         style={{ width: '100%' }}
         placeholder="选择常用时间或自定义设置"

--- a/frontend/src/components/CronPresetSelect.tsx
+++ b/frontend/src/components/CronPresetSelect.tsx
@@ -1,0 +1,75 @@
+import { Select, Typography } from 'antd';
+import { ClockCircleOutlined } from '@ant-design/icons';
+
+const { Text } = Typography;
+
+export interface CronPreset {
+  label: string;
+  value: string;
+  category: string;
+}
+
+export const CRON_PRESETS: CronPreset[] = [
+  // 常用
+  { label: '每10分钟', value: '0 */10 * * * *', category: '常用' },
+  { label: '每30分钟', value: '0 */30 * * * *', category: '常用' },
+  { label: '每1小时', value: '0 0 * * * *', category: '常用' },
+  { label: '每2小时', value: '0 0 */2 * * *', category: '常用' },
+  { label: '每6小时', value: '0 0 */6 * * *', category: '常用' },
+  // 定时
+  { label: '每天0点', value: '0 0 0 * * *', category: '定时' },
+  { label: '每天8:00', value: '0 0 8 * * *', category: '定时' },
+  { label: '每天9:00', value: '0 0 9 * * *', category: '定时' },
+  { label: '每天12:00', value: '0 0 12 * * *', category: '定时' },
+  { label: '每天18:00', value: '0 0 18 * * *', category: '定时' },
+  { label: '每天20:00', value: '0 0 20 * * *', category: '定时' },
+  // 工作时间
+  { label: '工作日8:00', value: '0 0 8 * * 1-5', category: '工作时间' },
+  { label: '工作日9:00', value: '0 0 9 * * 1-5', category: '工作时间' },
+  { label: '工作日10:00', value: '0 0 10 * * 1-5', category: '工作时间' },
+  { label: '工作日14:00', value: '0 0 14 * * 1-5', category: '工作时间' },
+  { label: '工作日8-18点每2小时', value: '0 0 8-18/2 * * 1-5', category: '工作时间' },
+  { label: '工作日9-18点每小时', value: '0 0 9-18 * * 1-5', category: '工作时间' },
+  // 下班时间
+  { label: '下班后每30分钟', value: '0 */30 19-23 * * *', category: '下班时间' },
+  { label: '22:00-08:00每45分钟', value: '0 */45 22-23,0-8 * * *', category: '下班时间' },
+  { label: '22:00-08:00每小时', value: '0 0 22-23,0-8 * * *', category: '下班时间' },
+  // 凌晨
+  { label: '每天凌晨2点', value: '0 0 2 * * *', category: '凌晨' },
+  { label: '每天凌晨3点', value: '0 0 3 * * *', category: '凌晨' },
+  { label: '每天凌晨4点', value: '0 0 4 * * *', category: '凌晨' },
+];
+
+interface CronPresetSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+export function CronPresetSelect({ value, onChange, disabled }: CronPresetSelectProps) {
+  const categories = [...new Set(CRON_PRESETS.map(p => p.category))];
+
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+        <ClockCircleOutlined style={{ color: 'var(--color-primary)', fontSize: 12 }} />
+        <Text type="secondary" style={{ fontSize: 12 }}>快速选择</Text>
+      </div>
+      <Select
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        style={{ width: '100%' }}
+        placeholder="选择常用时间或自定义设置"
+        allowClear
+        options={categories.map(category => ({
+          label: category,
+          options: CRON_PRESETS.filter(p => p.category === category).map(p => ({
+            label: p.label,
+            value: p.value,
+          })),
+        }))}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -685,8 +685,8 @@ export function Dashboard({ onBack }: DashboardProps) {
               <div style={{ fontSize: 20, fontWeight: 700, color: '#f59e0b' }}>
                 {loading ? <Spin size="small" /> : (
                   <>
-                    {totalCost < 10000 ? totalCost.toFixed(2) : (totalCost / 10000).toFixed(2)}
-                    <span style={{ fontSize: 12, fontWeight: 500, marginLeft: 2 }}>{totalCost < 10000 ? '元' : '万'}</span>
+                    ${totalCost < 10000 ? totalCost.toFixed(2) : (totalCost / 10000).toFixed(2)}
+                    {totalCost >= 10000 && <span style={{ fontSize: 12, fontWeight: 500, marginLeft: 2 }}>万</span>}
                   </>
                 )}
               </div>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -474,7 +474,6 @@ export function Dashboard({ onBack }: DashboardProps) {
   const modelData = stats?.model_distribution ?? [];
   const modelCountMax = Math.max(...modelData.map((m) => m.count), 1);
   const modelTokenMax = Math.max(...modelData.map((m) => m.total_input_tokens + m.total_output_tokens), 1);
-  const modelCostMax = Math.max(...modelData.map((m) => m.total_cost_usd), 0.01);
 
   const MODEL_COLORS = ['#8b5cf6', '#3b82f6', '#22c55e', '#f59e0b', '#ef4444', '#0891b2', '#ec4899', '#6366f1'];
 
@@ -517,59 +516,28 @@ export function Dashboard({ onBack }: DashboardProps) {
     key: 'model-token-chart',
     render: () => (
       <Card
-        title={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><ThunderboltOutlined /><span>模型 Token 消耗</span></div>}
+        title={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><ThunderboltOutlined /><span>模型推理统计</span></div>}
         className="dashboard-card" style={{ borderRadius: 12 }}
         bodyStyle={{ padding: '8px 16px' }}
       >
         {modelData.length > 0 ? (
           modelData.map((m, i) => {
-            const total = m.total_input_tokens + m.total_output_tokens;
+            const outputRate = m.total_input_tokens > 0 ? (m.total_output_tokens / m.total_input_tokens) * 100 : 0;
+            const costDisplay = m.total_cost_usd < 10000 ? `$${m.total_cost_usd.toFixed(2)}` : `$${(m.total_cost_usd / 10000).toFixed(2)}万`;
             return (
               <CompactRow
                 key={m.model}
                 name={m.model}
-                value={<span style={{ fontSize: 18, fontWeight: 700, color: MODEL_COLORS[i % MODEL_COLORS.length] }}>{formatTokens(total)}</span>}
+                value={<span style={{ fontSize: 16, fontWeight: 700, color: MODEL_COLORS[i % MODEL_COLORS.length] }}>{(m.total_input_tokens / 10000).toFixed(1)}万</span>}
                 color={MODEL_COLORS[i % MODEL_COLORS.length]}
-                barPct={(total / modelTokenMax) * 100}
+                barPct={(m.total_input_tokens / modelTokenMax) * 100}
                 sub={
                   <span>
-                    输入 <strong style={{ color: '#3b82f6' }}>{formatTokens(m.total_input_tokens)}</strong>
-                    <span style={{ margin: '0 6px' }}>·</span>
-                    输出 <strong style={{ color: '#22c55e' }}>{formatTokens(m.total_output_tokens)}</strong>
-                  </span>
-                }
-              />
-            );
-          })
-        ) : (
-          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无模型数据" />
-        )}
-      </Card>
-    ),
-  });
-
-  panels.push({
-    key: 'model-cost-chart',
-    render: () => (
-      <Card
-        title={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><DollarOutlined /><span>模型花费</span></div>}
-        className="dashboard-card" style={{ borderRadius: 12 }}
-        bodyStyle={{ padding: '8px 16px' }}
-      >
-        {modelData.length > 0 ? (
-          modelData.map((m) => {
-            const costInt = Math.round(m.total_cost_usd);
-            const avgCost = m.execution_count > 0 ? Math.round((m.total_cost_usd / m.execution_count) * 100) / 100 : 0;
-            return (
-              <CompactRow
-                key={m.model}
-                name={m.model}
-                value={<span style={{ fontSize: 18, fontWeight: 700, color: '#f59e0b' }}>${costInt}</span>}
-                color="#f59e0b"
-                barPct={(m.total_cost_usd / modelCostMax) * 100}
-                sub={
-                  <span>
-                    均次 <strong style={{ color: 'var(--color-text)' }}>${avgCost}</strong>
+                    推理输入 <strong style={{ color: '#3b82f6' }}>{(m.total_input_tokens / 10000).toFixed(1)}万</strong>
+                    <span style={{ margin: '0 4px' }}>·</span>
+                    成本 <strong style={{ color: '#f59e0b' }}>{costDisplay}</strong>
+                    <span style={{ margin: '0 4px' }}>·</span>
+                    输出率 <strong style={{ color: '#22c55e' }}>{outputRate.toFixed(1)}%</strong>
                   </span>
                 }
               />
@@ -681,6 +649,60 @@ export function Dashboard({ onBack }: DashboardProps) {
           ) : (
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无 Token 趋势数据" />
           )}
+        </Card>
+      );
+    },
+  });
+
+  panels.push({
+    key: 'inference-stats',
+    render: () => {
+      const totalInput = stats?.total_input_tokens ?? 0;
+      const totalOutput = stats?.total_output_tokens ?? 0;
+      const totalCost = stats?.total_cost_usd ?? 0;
+      const outputRate = totalInput > 0 ? (totalOutput / totalInput) * 100 : 0;
+
+      return (
+        <Card
+          title={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><ThunderboltOutlined /><span>推理统计</span></div>}
+          className="dashboard-card" style={{ borderRadius: 12 }}
+          bodyStyle={{ padding: '16px 20px' }}
+        >
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12 }}>
+            <div style={{ padding: '12px 14px', borderRadius: 10, background: '#3b82f610', textAlign: 'center' }}>
+              <div style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginBottom: 4 }}>推理输入</div>
+              <div style={{ fontSize: 20, fontWeight: 700, color: '#3b82f6' }}>
+                {loading ? <Spin size="small" /> : (
+                  <>
+                    {(totalInput / 10000).toFixed(2)}
+                    <span style={{ fontSize: 12, fontWeight: 500, marginLeft: 2 }}>万</span>
+                  </>
+                )}
+              </div>
+            </div>
+            <div style={{ padding: '12px 14px', borderRadius: 10, background: '#f59e0b10', textAlign: 'center' }}>
+              <div style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginBottom: 4 }}>成本</div>
+              <div style={{ fontSize: 20, fontWeight: 700, color: '#f59e0b' }}>
+                {loading ? <Spin size="small" /> : (
+                  <>
+                    {totalCost < 10000 ? totalCost.toFixed(2) : (totalCost / 10000).toFixed(2)}
+                    <span style={{ fontSize: 12, fontWeight: 500, marginLeft: 2 }}>{totalCost < 10000 ? '元' : '万'}</span>
+                  </>
+                )}
+              </div>
+            </div>
+            <div style={{ padding: '12px 14px', borderRadius: 10, background: '#22c55e10', textAlign: 'center' }}>
+              <div style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginBottom: 4 }}>输出率</div>
+              <div style={{ fontSize: 20, fontWeight: 700, color: '#22c55e' }}>
+                {loading ? <Spin size="small" /> : (
+                  <>
+                    {outputRate.toFixed(1)}
+                    <span style={{ fontSize: 12, fontWeight: 500, marginLeft: 2 }}>%</span>
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
         </Card>
       );
     },

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -39,6 +39,7 @@ import * as db from '../utils/database';
 import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '../utils/cron';
 import type { Config, ExecutorPaths } from '../types';
 import yaml from 'js-yaml';
+import { CronPresetSelect } from './CronPresetSelect';
 
 const { Paragraph } = Typography;
 const { Dragger } = Upload;
@@ -671,6 +672,12 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                   <span style={{ fontWeight: 600 }}><ClockCircleOutlined style={{ marginRight: 6 }} />自动备份</span>
                   <Switch checked={autoBackupEnabled} onChange={setAutoBackupEnabled} />
                 </div>
+                {autoBackupEnabled && (
+                  <CronPresetSelect
+                    value={autoBackupCron}
+                    onChange={(val) => setAutoBackupCron(val)}
+                  />
+                )}
                 {autoBackupEnabled && (
                   <Cron
                     value={cronTo5(autoBackupCron)}

--- a/frontend/src/components/TodoSettingsDrawer.tsx
+++ b/frontend/src/components/TodoSettingsDrawer.tsx
@@ -8,6 +8,7 @@ import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '../utils/cron';
 import { EXECUTORS } from '../types';
 import type { Todo } from '../types';
 import { TagCheckCardGroup } from './TagCheckCard';
+import { CronPresetSelect } from './CronPresetSelect';
 
 interface TodoSettingsDrawerProps {
   open: boolean;
@@ -204,6 +205,10 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
 
         {schedulerEnabled && (
           <div style={{ marginTop: 12 }}>
+            <CronPresetSelect
+              value={schedulerConfig || DEFAULT_CRON}
+              onChange={(val) => setSchedulerConfig(val)}
+            />
             <Cron
               value={cronTo5(schedulerConfig || DEFAULT_CRON)}
               setValue={(val: string) => setSchedulerConfig(cronTo6(val))}


### PR DESCRIPTION
## Summary
- 新增"推理统计"卡片，显示总推理输入、成本和输出率
- 模型推理统计卡片新增各模型的输入/成本/输出率展示
- 新增 CronPresetSelect 组件，恢复常用 cron 预设快速选择功能
- 集成到任务设置和自动备份的 Cron 编辑器

## Test plan
- [ ] 验证 Dashboard 上的推理统计卡片数据展示正确
- [ ] 验证任务设置的 Cron 预设下拉选择正常工作
- [ ] 验证自动备份的 Cron 预设下拉选择正常工作