### PR TITLE
feat: 执行历史对话链缩进显示

### DIFF
--- a/backend/src/db/entity/execution_records.rs
+++ b/backend/src/db/entity/execution_records.rs
@@ -24,6 +24,7 @@ pub struct Model {
     pub session_id: Option<String>,
     pub todo_progress: Option<String>,
     pub execution_stats: Option<String>,
+    pub resume_message: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -30,6 +30,7 @@ impl From<execution_records::Model> for ExecutionRecord {
             session_id: m.session_id,
             todo_progress: m.todo_progress,
             execution_stats,
+            resume_message: m.resume_message,
         }
     }
 }
@@ -92,6 +93,7 @@ impl Database {
         trigger_type: &str,
         task_id: &str,
         session_id: Option<&str>,
+        resume_message: Option<&str>,
     ) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let am = execution_records::ActiveModel {
@@ -103,6 +105,7 @@ impl Database {
             started_at: ActiveValue::Set(Some(now)),
             task_id: ActiveValue::Set(Some(task_id.to_string())),
             session_id: ActiveValue::Set(session_id.map(|s| s.to_string())),
+            resume_message: ActiveValue::Set(resume_message.map(|s| s.to_string())),
             ..Default::default()
         };
         let inserted = am.insert(&self.conn).await?;

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -184,6 +184,19 @@ impl Database {
             .unwrap_or_default()
     }
 
+    /// 根据 session_id 获取所有执行记录（按 started_at 排序）
+    pub async fn get_execution_records_by_session(&self, session_id: &str) -> Vec<ExecutionRecord> {
+        execution_records::Entity::find()
+            .filter(execution_records::Column::SessionId.eq(session_id))
+            .order_by_asc(execution_records::Column::StartedAt)
+            .all(&self.conn)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(Into::into)
+            .collect()
+    }
+
     /// 根据 pid 停止执行记录
     pub async fn stop_execution_by_pid(&self, pid: i32) -> Result<bool, sea_orm::DbErr> {
         if let Some(record) = self.get_execution_record_by_pid(pid).await {

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -166,6 +166,12 @@ impl Database {
         )
         .await.ok(); // 忽略错误，因为字段可能已存在
 
+        // 添加 resume_message 字段的迁移（向后兼容）
+        self.exec(
+            "ALTER TABLE execution_records ADD COLUMN resume_message TEXT"
+        )
+        .await.ok(); // 忽略错误，因为字段可能已存在
+
         // Trigger: fill created_at with UTC time on INSERT if not set
         self.exec(
             "CREATE TRIGGER IF NOT EXISTS set_todos_created_at_utc AFTER INSERT ON todos
@@ -300,7 +306,7 @@ mod tests {
         let todo_id = db.create_todo("Test", "Desc").await.unwrap();
         let before = truncate_seconds(Utc::now());
         let record_id = db
-            .create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id", None)
+            .create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id", None, None)
             .await
             .unwrap();
         let after = truncate_seconds(Utc::now());
@@ -319,7 +325,7 @@ mod tests {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Desc").await.unwrap();
         let record_id = db
-            .create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id", None)
+            .create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id", None, None)
             .await
             .unwrap();
 
@@ -600,7 +606,7 @@ mod tests {
     async fn test_create_execution_record() {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
-        let record_id = db.create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id", None).await.unwrap();
+        let record_id = db.create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id", None, None).await.unwrap();
         let (records, total) = db.get_execution_records(todo_id, 100, 0).await;
         assert_eq!(total, 1);
         let record = records.iter().find(|r| r.id == record_id).unwrap();
@@ -616,7 +622,7 @@ mod tests {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         for i in 0..5 {
-            db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id", None).await.unwrap();
+            db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id", None, None).await.unwrap();
         }
         let (records, total) = db.get_execution_records(todo_id, 2, 0).await;
         assert_eq!(total, 5);
@@ -628,7 +634,7 @@ mod tests {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         for i in 0..3 {
-            db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id", None).await.unwrap();
+            db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id", None, None).await.unwrap();
         }
         let (records, total) = db.get_execution_records(todo_id, 10, 2).await;
         assert_eq!(total, 3);
@@ -639,7 +645,7 @@ mod tests {
     async fn test_update_execution_record() {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
-        let record_id = db.create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id", None).await.unwrap();
+        let record_id = db.create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id", None, None).await.unwrap();
         let usage = crate::models::ExecutionUsage {
             input_tokens: 100,
             output_tokens: 50,
@@ -678,11 +684,11 @@ mod tests {
     async fn test_get_execution_summary_counts() {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
-        let r1 = db.create_execution_record(todo_id, "cmd1", "claudecode", "manual", "test-task-id", None).await.unwrap();
+        let r1 = db.create_execution_record(todo_id, "cmd1", "claudecode", "manual", "test-task-id", None, None).await.unwrap();
         db.update_execution_record(r1, "success", "[]", "", None, None).await.unwrap();
-        let r2 = db.create_execution_record(todo_id, "cmd2", "claudecode", "manual", "test-task-id", None).await.unwrap();
+        let r2 = db.create_execution_record(todo_id, "cmd2", "claudecode", "manual", "test-task-id", None, None).await.unwrap();
         db.update_execution_record(r2, "failed", "[]", "", None, None).await.unwrap();
-        let _r3 = db.create_execution_record(todo_id, "cmd3", "claudecode", "manual", "test-task-id", None).await.unwrap();
+        let _r3 = db.create_execution_record(todo_id, "cmd3", "claudecode", "manual", "test-task-id", None, None).await.unwrap();
         // r3 stays "running"
         let summary = db.get_execution_summary(todo_id).await;
         assert_eq!(summary.total_executions, 3);
@@ -695,7 +701,7 @@ mod tests {
     async fn test_get_execution_summary_tokens_and_cost() {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
-        let r1 = db.create_execution_record(todo_id, "cmd1", "claudecode", "manual", "test-task-id", None).await.unwrap();
+        let r1 = db.create_execution_record(todo_id, "cmd1", "claudecode", "manual", "test-task-id", None, None).await.unwrap();
         let usage1 = crate::models::ExecutionUsage {
             input_tokens: 100,
             output_tokens: 50,
@@ -705,7 +711,7 @@ mod tests {
             duration_ms: Some(1000),
         };
         db.update_execution_record(r1, "success", "[]", "", Some(&usage1), None).await.unwrap();
-        let r2 = db.create_execution_record(todo_id, "cmd2", "claudecode", "manual", "test-task-id", None).await.unwrap();
+        let r2 = db.create_execution_record(todo_id, "cmd2", "claudecode", "manual", "test-task-id", None, None).await.unwrap();
         let usage2 = crate::models::ExecutionUsage {
             input_tokens: 200,
             output_tokens: 100,

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -40,6 +40,7 @@ pub async fn run_todo_execution(
     trigger_type: &str,
     task_manager: Arc<TaskManager>,
     resume_session_id: Option<String>,
+    resume_message: Option<String>,
 ) -> ExecutionResult {
     let task_id = Uuid::new_v4().to_string();
     let mut cancel_rx = task_manager.register(task_id.clone()).await;
@@ -93,7 +94,7 @@ pub async fn run_todo_execution(
 
     // Create execution record
     let command = format!("{} {}", executable_path, command_args.join(" "));
-    let record_id = match db.create_execution_record(todo_id, &command, &executor_str, trigger_type, &task_id, Some(session_id_for_executor)).await {
+    let record_id = match db.create_execution_record(todo_id, &command, &executor_str, trigger_type, &task_id, Some(session_id_for_executor), resume_message.as_deref()).await {
         Ok(id) => id,
         Err(e) => {
             tracing::error!("Failed to create execution record: {}", e);

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -41,6 +41,17 @@ pub async fn get_execution_record(
     Ok(ApiResponse::ok(record))
 }
 
+pub async fn get_execution_records_by_session(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Result<ApiResponse<Vec<crate::models::ExecutionRecord>>, AppError> {
+    let records = state
+        .db
+        .get_execution_records_by_session(&session_id)
+        .await;
+    Ok(ApiResponse::ok(records))
+}
+
 pub async fn execute_handler(
     State(state): State<AppState>,
     ApiJson(req): ApiJson<ExecuteRequest>,

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -67,6 +67,7 @@ pub async fn execute_handler(
         "manual",
         state.task_manager.clone(),
         None,
+        None,
     )
     .await;
 
@@ -157,6 +158,12 @@ pub async fn resume_execution_handler(
         .map(|m| m.to_string())
         .unwrap_or_else(|| todo.prompt.clone());
 
+    let resume_message = req.message
+        .as_ref()
+        .map(|m| m.trim())
+        .filter(|m| !m.is_empty())
+        .map(|m| m.to_string());
+
     let resume_session_id = record.session_id
         .or(record.task_id)
         .ok_or_else(|| AppError::BadRequest("No session_id found for this execution record".to_string()))?;
@@ -171,6 +178,7 @@ pub async fn resume_execution_handler(
         "manual",
         state.task_manager.clone(),
         Some(resume_session_id),
+        resume_message,
     )
     .await;
 

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -265,6 +265,7 @@ pub fn create_app(
         .route("/xyz/tags/{id}", delete(tag::delete_tag))
         .route("/xyz/execution-records", get(execution::get_execution_records))
         .route("/xyz/execution-records/{id}", get(execution::get_execution_record))
+        .route("/xyz/execution-records/session/{session_id}", get(execution::get_execution_records_by_session))
         .route("/xyz/execution-records/{id}/resume", post(execution::resume_execution_handler))
         .route("/xyz/dashboard-stats", get(execution::get_dashboard_stats))
         .route("/xyz/execute", post(execution::execute_handler))

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -130,6 +130,8 @@ pub struct ExecutionRecord {
     pub todo_progress: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_stats: Option<ExecutionStats>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resume_message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -97,7 +97,7 @@ impl TodoScheduler {
                     let message = if todo.prompt.is_empty() { todo.title.clone() } else { todo.prompt.clone() };
                     let executor = todo.executor.clone();
                     info!("Scheduled execution triggered for todo {}", todo_id);
-                    run_todo_execution(db, registry, tx, todo_id, message, executor, "cron", tm, None).await;
+                    run_todo_execution(db, registry, tx, todo_id, message, executor, "cron", tm, None, None).await;
                 }
             })
         })?;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,7 @@
         "react": "^19.1.0",
         "react-countup": "^6.5.3",
         "react-dom": "^19.1.0",
-        "react-icons": "^5.3.0",
+        "react-icons": "^5.6.0",
         "react-js-cron": "^6.0.2",
         "react-mde": "^11.5.0"
       },
@@ -7866,7 +7866,7 @@
     },
     "node_modules/react-icons": {
       "version": "5.6.0",
-      "resolved": "https://registry.npmmirror.com/react-icons/-/react-icons-5.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
       "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
       "license": "MIT",
       "peerDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "clsx": "^2.1.1",
         "cron-parser": "^5.5.0",
         "dompurify": "^3.4.2",
+        "framer-motion": "^12.38.0",
         "js-yaml": "^4.1.1",
         "marked": "^18.0.3",
         "rc-field-form": "^2.7.1",
@@ -5562,6 +5563,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -7423,6 +7451,21 @@
         "pkg-types": "^1.3.1",
         "ufo": "^1.6.3"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "react": "^19.1.0",
     "react-countup": "^6.5.3",
     "react-dom": "^19.1.0",
-    "react-icons": "^5.3.0",
+    "react-icons": "^5.6.0",
     "react-js-cron": "^6.0.2",
     "react-mde": "^11.5.0"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.1",
     "cron-parser": "^5.5.0",
     "dompurify": "^3.4.2",
+    "framer-motion": "^12.38.0",
     "js-yaml": "^4.1.1",
     "marked": "^18.0.3",
     "rc-field-form": "^2.7.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -132,7 +132,7 @@ function AppContent() {
             }}
           >
             {state.selectedTodoId ? (
-              <TodoDetail />
+              <TodoDetail onBack={isMobile ? handleBackToList : undefined} />
             ) : activeView === 'settings' ? (
               <SettingsPage onBack={isMobile ? handleBackToList : undefined} />
             ) : (

--- a/frontend/src/components/TimelineFlow/index.tsx
+++ b/frontend/src/components/TimelineFlow/index.tsx
@@ -1,0 +1,171 @@
+import React, { useMemo } from 'react';
+import { Tooltip } from 'antd';
+import { motion, AnimatePresence } from 'framer-motion';
+
+export interface TimelineRecord {
+  id: string;
+  role?: string;
+  content?: string;
+  timestamp?: number;
+  event_type?: string;
+  total_tokens?: number;
+  [key: string]: unknown;
+}
+
+export interface TimelineFlowProps {
+  records: TimelineRecord[];
+  height?: number | string;
+  colorMap?: Record<string, string>;
+  labelMap?: Record<string, string>;
+  disabled?: boolean;
+  staggerDelay?: number;
+  containerStyle?: React.CSSProperties;
+  renderTooltip?: (record: TimelineRecord) => React.ReactNode;
+}
+
+const DEFAULT_COLOR_MAP: Record<string, string> = {
+  user: 'var(--color-info)',
+  assistant: 'var(--color-success)',
+  system: 'var(--color-primary-bg)',
+  tool: 'var(--color-warning)',
+  tool_result: 'var(--color-primary)',
+  text: 'var(--color-success)',
+  thinking: 'var(--color-warning)',
+  step_start: 'var(--color-primary-bg)',
+  step_finish: 'var(--color-success-bg)',
+  error: 'var(--color-error)',
+  info: 'var(--color-primary)',
+  stdout: 'var(--color-text-tertiary)',
+  stderr: 'var(--color-text-tertiary)',
+};
+
+const DEFAULT_LABEL_MAP: Record<string, string> = {
+  user: '用户',
+  assistant: '助手',
+  system: '系统',
+  tool: '工具',
+  tool_result: '结果',
+  tool_call: '工具',
+  tool_use: '工具',
+  text: '输出',
+  thinking: '思考',
+  step_start: '开始',
+  step_finish: '结束',
+  error: '错误',
+  info: '信息',
+  stdout: '输出',
+  stderr: '日志',
+  result: '结果',
+  tokens: '统计',
+};
+
+function formatTooltipContent(record: TimelineRecord, labelMap: Record<string, string>): React.ReactNode {
+  const role = (record.role || '').toLowerCase();
+  const label = labelMap[role] || role || '未知';
+  return (
+    <div>
+      <div><strong>{label}</strong></div>
+      {record.event_type && <div>类型: {record.event_type}</div>}
+      {record.total_tokens != null && record.total_tokens > 0 && <div>Tokens: {record.total_tokens}</div>}
+      {record.content && (
+        <div style={{
+          maxWidth: 300, overflow: 'hidden', textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap', marginTop: 4, opacity: 0.8, fontSize: 12,
+        }}>
+          {record.content}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const TimelineFlow: React.FC<TimelineFlowProps> = ({
+  records,
+  height = 24,
+  colorMap = {},
+  labelMap = {},
+  disabled = false,
+  staggerDelay = 0.08,
+  containerStyle,
+  renderTooltip,
+}) => {
+  const sortedRecords = useMemo(() => {
+    return [...records].sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
+  }, [records]);
+
+  const mergedColorMap = { ...DEFAULT_COLOR_MAP, ...colorMap };
+  const mergedLabelMap = { ...DEFAULT_LABEL_MAP, ...labelMap };
+
+  const displayRecords = sortedRecords;
+
+  if (sortedRecords.length === 0) {
+    return (
+      <div style={{
+        height, width: '100%',
+        background: 'var(--color-border-light)',
+        borderRadius: 4,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: 'var(--color-text-quaternary, var(--color-text-tertiary))',
+        fontSize: 11,
+        ...containerStyle,
+      }}>
+        暂无对话记录
+      </div>
+    );
+  }
+
+  const itemWidthPercent = 100 / displayRecords.length;
+
+  return (
+    <div style={{
+      width: '100%', height,
+      display: 'flex', flexDirection: 'row',
+      borderRadius: 4, overflow: 'hidden',
+      background: 'var(--color-border-light)',
+      position: 'relative',
+      ...containerStyle,
+    }}>
+      <AnimatePresence mode="popLayout">
+        {displayRecords.map((record, index) => {
+          const role = (record.role || '').toLowerCase();
+          const color = mergedColorMap[role] || 'var(--color-text-quaternary, #bfbfbf)';
+
+          const motionProps = disabled
+            ? { initial: { x: 0, opacity: 1 }, animate: { x: 0, opacity: 1 }, exit: { opacity: 1, scale: 1 } }
+            : {
+                initial: { x: 300, opacity: 0 },
+                animate: { x: 0, opacity: 1 },
+                exit: { opacity: 0, scale: 0 },
+              };
+
+          const content = (
+            <motion.div
+              key={record.id}
+              {...motionProps}
+              transition={{
+                type: 'spring', stiffness: 250, damping: 25,
+                delay: disabled ? 0 : index * staggerDelay,
+              }}
+              style={{
+                height: '100%',
+                width: `${itemWidthPercent}%`,
+                background: color,
+                borderRight: index < displayRecords.length - 1 ? '1px solid var(--color-bg-elevated)' : 'none',
+                cursor: 'pointer',
+                minWidth: 3,
+              }}
+            />
+          );
+
+          return renderTooltip ? (
+            <Tooltip key={record.id} title={renderTooltip(record)}>{content}</Tooltip>
+          ) : (
+            <Tooltip key={record.id} title={formatTooltipContent(record, mergedLabelMap)}>{content}</Tooltip>
+          );
+        })}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default TimelineFlow;

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1075,6 +1075,9 @@ export function TodoDetail() {
                   onExport={handleExportMarkdown}
                   onStop={handleStopExecution}
                   messageApi={message}
+                  viewMode={viewMode}
+                  parseLogs={parseRecordLogs}
+                  onRefresh={refreshSingleRecord}
                 />
               );
             })}
@@ -1251,12 +1254,15 @@ function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, o
 }
 
 /** Narrow mode: chain group card — main record with indented continuations */
-function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi }: {
+function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, viewMode, parseLogs, onRefresh }: {
   group: SessionGroup;
   onOpenResume: (r: ExecutionRecord) => void;
   onExport: (r: ExecutionRecord) => void;
   onStop: (id: number) => Promise<void>;
   messageApi: any;
+  viewMode: 'log' | 'chat';
+  parseLogs: (r: ExecutionRecord) => LogEntry[];
+  onRefresh: (id: number) => Promise<void>;
 }) {
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const mainRecord = group.records[0];
@@ -1384,6 +1390,50 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi }: {
                     </Popconfirm>
                   )}
                 </div>
+                {(() => {
+                  const logs = parseLogs(record);
+                  const isRunning = record.status === 'running';
+                  if (!isRunning && logs.length === 0) return null;
+                  if (viewMode === 'chat') {
+                    return (
+                      <div style={{ marginTop: 6 }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+                          <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>对话 ({logs.length})</span>
+                          <ReloadOutlined style={{ fontSize: 10, cursor: 'pointer' }} onClick={(e) => { e.stopPropagation(); onRefresh(record.id); }} />
+                        </div>
+                        <div style={{ maxHeight: 300, overflow: 'auto' }}>
+                          <ChatView logs={logs as LogEntry[]} isRunning={isRunning} />
+                        </div>
+                      </div>
+                    );
+                  }
+                  return (
+                    <details style={{ marginTop: 6 }} open={isRunning}>
+                      <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 10, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6 }}>
+                        <span>日志 ({logs.length})</span>
+                        <ReloadOutlined style={{ fontSize: 9 }} onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
+                      </summary>
+                      <div style={{
+                        background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
+                        fontFamily: 'var(--font-mono)', fontSize: 10, marginTop: 4, maxHeight: 200, overflow: 'auto',
+                      }}>
+                        {logs.length === 0 ? (
+                          <div style={{ color: 'var(--log-text-muted)' }}>等待输出...</div>
+                        ) : (
+                          logs.map((log, i) => (
+                            <div key={i} style={{ marginBottom: 3, display: 'flex', gap: 6 }}>
+                              <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
+                              <span style={{ color: logTypeColors[log.type || ''] || 'var(--log-text)' }}>
+                                [{logTypeLabels[log.type || ''] || log.type}]
+                              </span>
+                              <span>{log.content}</span>
+                            </div>
+                          ))
+                        )}
+                      </div>
+                    </details>
+                  );
+                })()}
               </div>
             )}
             {/* Continue button on last continuation */}

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useApp } from '../hooks/useApp';
-import { Button, Empty, App, Popconfirm, Tag, Badge, Pagination, Segmented, Modal, Input } from 'antd';
-import { PlayCircleOutlined, EditOutlined, DeleteOutlined, SettingOutlined, CheckCircleOutlined, ReloadOutlined, CopyOutlined, ArrowLeftOutlined, StopOutlined, DownOutlined, UpOutlined, UnorderedListOutlined, MessageOutlined, FileTextOutlined } from '@ant-design/icons';
+import { Button, Empty, App, Popconfirm, Tag, Badge, Pagination, Segmented, Modal, Input, Switch } from 'antd';
+import { PlayCircleOutlined, EditOutlined, DeleteOutlined, SettingOutlined, CheckCircleOutlined, ReloadOutlined, CopyOutlined, ArrowLeftOutlined, StopOutlined, DownOutlined, UpOutlined, UnorderedListOutlined, MessageOutlined, FileTextOutlined, SwapOutlined } from '@ant-design/icons';
 import { StatusPicker } from './StatusPicker';
 import { PieChart } from './PieChart';
 import { TodoSettingsDrawer } from './TodoSettingsDrawer';
@@ -15,7 +15,35 @@ import { AnimatedNumber } from './AnimatedNumber';
 import { getExecutorOption, supportsResume } from '../types';
 import { ExecutorBadge } from './ExecutorBadge';
 import XMarkdown from '@ant-design/x-markdown';
-import type { ExecutionSummary, Todo, TodoItem, ExecutionRecord, LogEntry } from '../types';
+import type { ExecutionSummary, Todo, TodoItem, ExecutionRecord, ExecutionStats, LogEntry } from '../types';
+
+/** 按 session_id 分组执行记录，同一 session 的记录按时间排序形成链 */
+interface SessionGroup {
+  sessionId: string;
+  records: ExecutionRecord[];
+}
+
+function groupBySession(records: ExecutionRecord[]): SessionGroup[] {
+  const map = new Map<string, ExecutionRecord[]>();
+  // 无 session_id 的记录用自身 id 作为 key（各自独立）
+  for (const r of records) {
+    const key = r.session_id || `__single_${r.id}`;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(r);
+  }
+  const groups: SessionGroup[] = [];
+  for (const [sessionId, recs] of map) {
+    recs.sort((a, b) => (a.started_at || '').localeCompare(b.started_at || ''));
+    groups.push({ sessionId, records: recs });
+  }
+  // 组间按组内最新记录的 started_at DESC 排序
+  groups.sort((a, b) => {
+    const aLatest = a.records[a.records.length - 1].started_at || '';
+    const bLatest = b.records[b.records.length - 1].started_at || '';
+    return bLatest.localeCompare(aLatest);
+  });
+  return groups;
+}
 
 /** 可展开的 Prompt 内容展示组件 */
 function PromptDisplay({ content }: { content: string }) {
@@ -210,6 +238,70 @@ function ProgressWidget({ items }: { items: TodoItem[] }) {
   );
 }
 
+/** 紧凑历史列表项的内容（不含外层容器样式） */
+function CompactHistoryItem({ record, onOpenResume, onExport }: {
+  record: ExecutionRecord;
+  onOpenResume: (r: ExecutionRecord) => void;
+  onExport: (r: ExecutionRecord) => void;
+}) {
+  return (
+    <>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
+        <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+          {formatLocalDateTime(record.started_at)}
+        </span>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          {record.status !== 'running' && supportsResume(record) && (
+            <MessageOutlined
+              style={{ fontSize: 12, color: 'var(--color-primary)', cursor: 'pointer' }}
+              title="继续对话"
+              onClick={(e) => { e.stopPropagation(); onOpenResume(record); }}
+            />
+          )}
+          {hasLogsStatic(record) && (
+            <FileTextOutlined
+              style={{ fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer' }}
+              title="导出为YAML"
+              onClick={(e) => { e.stopPropagation(); onExport(record); }}
+            />
+          )}
+          <span style={{
+            fontSize: 10,
+            padding: '2px 8px',
+            borderRadius: 10,
+            backgroundColor: record.status === 'success' ? 'var(--color-success)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
+            color: '#fff',
+            fontWeight: 600,
+          }}>
+            {record.status === 'success' ? '成功' : record.status === 'failed' ? '失败' : '进行中'}
+          </span>
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+        {record.executor && <ExecutorBadge executor={record.executor} />}
+        {record.model && <Tag color="#3b82f6" style={{ fontSize: 10, padding: '0 6px', lineHeight: '18px' }}>{record.model}</Tag>}
+        <Tag color={record.trigger_type === 'cron' ? '#8b5cf6' : '#6b7280'} style={{ fontSize: 10, padding: '0 6px', lineHeight: '18px' }}>
+          {record.trigger_type === 'cron' ? 'Cron' : '手动'}
+        </Tag>
+        {record.usage?.duration_ms && (
+          <span style={{ fontSize: 10, color: 'var(--color-success)', fontWeight: 600 }}>
+            {(record.usage.duration_ms / 1000).toFixed(2)}s
+          </span>
+        )}
+        {record.execution_stats && (
+          <span style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }}>
+            🔧{record.execution_stats.tool_calls} 💬{record.execution_stats.conversation_turns}
+          </span>
+        )}
+      </div>
+    </>
+  );
+}
+
+function hasLogsStatic(record: ExecutionRecord): boolean {
+  return !!record.logs && record.logs !== '[]';
+}
+
 /** 任务详情面板，包含执行、编辑、历史记录等功能 */
 export function TodoDetail() {
   const { state, dispatch } = useApp();
@@ -365,6 +457,10 @@ export function TodoDetail() {
   const [resumeRecordId, setResumeRecordId] = useState<number | null>(null);
   const [resumeMessage, setResumeMessage] = useState('');
   const [resumeLoading, setResumeLoading] = useState(false);
+
+  // Chain mode: group execution records by session_id
+  const [chainMode, setChainMode] = useState(false);
+  const sessionGroups = useMemo(() => chainMode ? groupBySession(records) : [], [chainMode, records]);
 
   const handleOpenResume = (record: ExecutionRecord) => {
     setResumeRecordId(record.id);
@@ -608,6 +704,11 @@ export function TodoDetail() {
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12, ...(isWide ? { flexShrink: 0 } : {}) }}>
           <h4 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: 'var(--color-text)' }}>执行历史</h4>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', display: 'flex', alignItems: 'center', gap: 4 }}>
+              <SwapOutlined style={{ fontSize: 12 }} />
+              <span>合并</span>
+              <Switch size="small" checked={chainMode} onChange={setChainMode} />
+            </span>
             <Segmented
               size="small"
               value={viewMode}
@@ -635,65 +736,148 @@ export function TodoDetail() {
             {/* Left: History List */}
             <div style={{ width: 320, flexShrink: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
               <div className="history-list-column">
-                {records.map(record => {
-                  const isSelected = selectedHistoryRecordId === record.id;
-                  return (
-                    <div
-                      key={record.id}
-                      className={`history-item-compact${isSelected ? ' selected' : ''}${record.status === 'failed' ? ' failed' : record.status === 'running' ? ' running' : ''}`}
-                      onClick={() => setSelectedHistoryRecordId(record.id)}
-                    >
-                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
-                        <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
-                          {formatLocalDateTime(record.started_at)}
-                        </span>
-                        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
-                          {record.status !== 'running' && supportsResume(record) && (
-                            <MessageOutlined
-                              style={{ fontSize: 12, color: 'var(--color-primary)', cursor: 'pointer' }}
-                              title="继续对话"
-                              onClick={(e) => { e.stopPropagation(); handleOpenResume(record); }}
-                            />
-                          )}
-                          {hasLogs(record) && (
-                            <FileTextOutlined
-                              style={{ fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer' }}
-                              title="导出为YAML"
-                              onClick={(e) => { e.stopPropagation(); handleExportMarkdown(record); }}
-                            />
-                          )}
-                          <span style={{
-                            fontSize: 10,
-                            padding: '2px 8px',
-                            borderRadius: 10,
-                            backgroundColor: record.status === 'success' ? 'var(--color-success)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
-                            color: '#fff',
-                            fontWeight: 600,
+                {chainMode ? (
+                  // Grouped by session_id
+                  sessionGroups.map(group => {
+                    const isSingle = group.records.length === 1 || !group.records[0].session_id;
+                    const groupSelected = group.records.some(r => r.id === selectedHistoryRecordId);
+                    return (
+                      <div key={group.sessionId} style={{ marginBottom: 4 }}>
+                        {isSingle ? (
+                          // Single record — render normally
+                          group.records.map(record => {
+                            const isSelected = selectedHistoryRecordId === record.id;
+                            return (
+                              <div
+                                key={record.id}
+                                className={`history-item-compact${isSelected ? ' selected' : ''}${record.status === 'failed' ? ' failed' : record.status === 'running' ? ' running' : ''}`}
+                                onClick={() => setSelectedHistoryRecordId(record.id)}
+                              >
+                                <CompactHistoryItem record={record} onOpenResume={handleOpenResume} onExport={handleExportMarkdown} />
+                              </div>
+                            );
+                          })
+                        ) : (
+                          // Chain group — header + timeline items
+                          <div style={{
+                            border: groupSelected ? '1px solid var(--color-primary)' : '1px solid var(--color-border-light)',
+                            borderRadius: 'var(--radius-sm)',
+                            overflow: 'hidden',
+                            background: groupSelected ? 'var(--color-primary-bg)' : 'transparent',
                           }}>
-                            {record.status === 'success' ? '成功' : record.status === 'failed' ? '失败' : '进行中'}
-                          </span>
-                        </div>
-                      </div>
-                      <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
-                        {record.executor && <ExecutorBadge executor={record.executor} />}
-                        {record.model && <Tag color="#3b82f6" style={{ fontSize: 10, padding: '0 6px', lineHeight: '18px' }}>{record.model}</Tag>}
-                        <Tag color={record.trigger_type === 'cron' ? '#8b5cf6' : '#6b7280'} style={{ fontSize: 10, padding: '0 6px', lineHeight: '18px' }}>
-                          {record.trigger_type === 'cron' ? 'Cron' : '手动'}
-                        </Tag>
-                        {record.usage?.duration_ms && (
-                          <span style={{ fontSize: 10, color: 'var(--color-success)', fontWeight: 600 }}>
-                            {(record.usage.duration_ms / 1000).toFixed(2)}s
-                          </span>
+                            {/* Group header */}
+                            <div style={{
+                              display: 'flex',
+                              justifyContent: 'space-between',
+                              alignItems: 'center',
+                              padding: '6px 10px',
+                              background: 'var(--color-bg-elevated)',
+                              borderBottom: '1px solid var(--color-border-light)',
+                              fontSize: 10,
+                              color: 'var(--color-text-tertiary)',
+                            }}>
+                              <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                                <MessageOutlined style={{ fontSize: 10, color: 'var(--color-primary)' }} />
+                                对话链 · {group.records.length}轮
+                              </span>
+                              <span>
+                                累计 {(group.records.reduce((s, r) => s + (r.usage?.duration_ms || 0), 0) / 1000).toFixed(1)}s
+                              </span>
+                            </div>
+                            {/* Timeline items */}
+                            {group.records.map((record, idx) => {
+                              const isSelected = selectedHistoryRecordId === record.id;
+                              const isFirst = idx === 0;
+                              const isLast = idx === group.records.length - 1;
+                              return (
+                                <div
+                                  key={record.id}
+                                  onClick={() => setSelectedHistoryRecordId(record.id)}
+                                  style={{
+                                    display: 'flex',
+                                    cursor: 'pointer',
+                                    background: isSelected ? 'var(--color-primary-bg)' : 'transparent',
+                                    transition: 'background 0.2s',
+                                  }}
+                                >
+                                  {/* Timeline rail */}
+                                  <div style={{
+                                    width: 24,
+                                    flexShrink: 0,
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    alignItems: 'center',
+                                    paddingTop: 8,
+                                  }}>
+                                    <div style={{
+                                      width: 8,
+                                      height: 8,
+                                      borderRadius: '50%',
+                                      border: '2px solid',
+                                      borderColor: record.status === 'running' ? 'var(--color-info)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-success)',
+                                      background: isFirst ? (record.status === 'running' ? 'var(--color-info)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-success)') : 'var(--color-bg-elevated)',
+                                      flexShrink: 0,
+                                    }} />
+                                    {!isLast && (
+                                      <div style={{ width: 1.5, flex: 1, background: 'var(--color-border-light)', minHeight: 20 }} />
+                                    )}
+                                  </div>
+                                  {/* Content */}
+                                  <div style={{ flex: 1, padding: '6px 8px 6px 0', minWidth: 0 }}>
+                                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 2 }}>
+                                      <span style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }}>
+                                        {isFirst ? '发起' : `第${idx + 1}轮`} {formatLocalDateTime(record.started_at).split(' ')[1] || formatLocalDateTime(record.started_at)}
+                                      </span>
+                                      <span style={{
+                                        fontSize: 9,
+                                        padding: '1px 6px',
+                                        borderRadius: 8,
+                                        backgroundColor: record.status === 'success' ? 'var(--color-success)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
+                                        color: '#fff',
+                                        fontWeight: 600,
+                                      }}>
+                                        {record.status === 'success' ? '✓' : record.status === 'failed' ? '✗' : '...'}
+                                      </span>
+                                    </div>
+                                    <div style={{ display: 'flex', gap: 4, alignItems: 'center', flexWrap: 'wrap' }}>
+                                      {record.executor && <ExecutorBadge executor={record.executor} />}
+                                      {record.usage?.duration_ms && (
+                                        <span style={{ fontSize: 9, color: 'var(--color-success)', fontWeight: 600 }}>
+                                          {(record.usage.duration_ms / 1000).toFixed(1)}s
+                                        </span>
+                                      )}
+                                    </div>
+                                    {isLast && record.status !== 'running' && supportsResume(record) && (
+                                      <MessageOutlined
+                                        style={{ fontSize: 11, color: 'var(--color-primary)', cursor: 'pointer', marginTop: 4 }}
+                                        title="继续对话"
+                                        onClick={(e) => { e.stopPropagation(); handleOpenResume(record); }}
+                                      />
+                                    )}
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
                         )}
-                        {record.execution_stats && (
-                          <span style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }}>
-                            🔧{record.execution_stats.tool_calls} 💬{record.execution_stats.conversation_turns}
-                          </span>
-                        )}
                       </div>
-                    </div>
-                  );
-                })}
+                    );
+                  })
+                ) : (
+                  // Original flat list
+                  records.map(record => {
+                    const isSelected = selectedHistoryRecordId === record.id;
+                    return (
+                      <div
+                        key={record.id}
+                        className={`history-item-compact${isSelected ? ' selected' : ''}${record.status === 'failed' ? ' failed' : record.status === 'running' ? ' running' : ''}`}
+                        onClick={() => setSelectedHistoryRecordId(record.id)}
+                      >
+                        <CompactHistoryItem record={record} onOpenResume={handleOpenResume} onExport={handleExportMarkdown} />
+                      </div>
+                    );
+                  })
+                )}
               </div>
               {historyTotal > historyLimit && (
                 <div style={{ flexShrink: 0, display: 'flex', justifyContent: 'center', padding: '8px 0 0', borderTop: '1px solid var(--color-border-light)' }}>
@@ -728,6 +912,48 @@ export function TodoDetail() {
                 const displayLogs = liveLogs && liveLogs.length > 0 ? liveLogs : restLogs;
                 return (
                   <>
+                    {/* Chain breadcrumb — only in chain mode */}
+                    {chainMode && (() => {
+                      const group = sessionGroups.find(g => g.records.some(r => r.id === record.id));
+                      if (!group || group.records.length <= 1 || !group.records[0].session_id) return null;
+                      const idx = group.records.findIndex(r => r.id === record.id);
+                      return (
+                        <div style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 4,
+                          marginBottom: 10,
+                          padding: '4px 8px',
+                          borderRadius: 6,
+                          background: 'var(--color-bg-elevated)',
+                          border: '1px solid var(--color-border-light)',
+                          fontSize: 11,
+                          color: 'var(--color-text-tertiary)',
+                          flexWrap: 'wrap',
+                        }}>
+                          {group.records.map((r, i) => (
+                            <span key={r.id} style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+                              {i > 0 && <span style={{ color: 'var(--color-border)', margin: '0 2px' }}>→</span>}
+                              <span
+                                onClick={() => setSelectedHistoryRecordId(r.id)}
+                                style={{
+                                  cursor: 'pointer',
+                                  padding: '1px 6px',
+                                  borderRadius: 4,
+                                  background: i === idx ? 'var(--color-primary)' : 'transparent',
+                                  color: i === idx ? '#fff' : 'var(--color-text-tertiary)',
+                                  fontWeight: i === idx ? 600 : 400,
+                                  transition: 'all 0.15s',
+                                }}
+                              >
+                                {i === 0 ? '发起' : `第${i + 1}轮`}
+                              </span>
+                            </span>
+                          ))}
+                          <span style={{ marginLeft: 4, color: 'var(--color-text-quaternary)' }}>共{group.records.length}轮</span>
+                        </div>
+                      );
+                    })()}
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12, flexWrap: 'wrap', gap: 8 }}>
                       <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
                         {record.executor && <ExecutorBadge executor={record.executor} />}
@@ -884,200 +1110,56 @@ export function TodoDetail() {
           </div>
         ) : (
           <>
-            {records.map(record => (
-              <div
-                key={record.id}
-                className={`history-card history-card-${record.status}`}
-              >
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8, flexWrap: 'wrap', gap: 8 }}>
-                  <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-                    <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
-                      {formatLocalDateTime(record.started_at)}
-                    </span>
-                    {record.executor && <ExecutorBadge executor={record.executor} />}
-                    {record.model && <Tag color="#3b82f6">{record.model}</Tag>}
-                    <Tag color={record.trigger_type === 'cron' ? '#8b5cf6' : '#6b7280'} style={{ fontSize: 10 }}>
-                      {record.trigger_type === 'cron' ? 'Cron' : '手动'}
-                    </Tag>
-                    {record.usage?.duration_ms && (
-                      <span style={{ fontSize: 11, color: 'var(--color-success)', fontWeight: 600 }}>
-                        {(record.usage.duration_ms / 1000).toFixed(2)}s
-                      </span>
-                    )}
-                  </div>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                    <span style={{
-                      fontSize: 11,
-                      padding: '3px 12px',
-                      borderRadius: 12,
-                      backgroundColor: record.status === 'success' ? 'var(--color-success)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
-                      color: '#fff',
-                      fontWeight: 600,
-                    }}>
-                      {record.status === 'success' ? '成功' : record.status === 'failed' ? '失败' : '进行中'}
-                    </span>
-                    {record.status !== 'running' && supportsResume(record) && (
-                      <Button
-                        type="primary"
-                        size="small"
-                        icon={<MessageOutlined />}
-                        onClick={() => handleOpenResume(record)}
-                      >
-                        继续对话
-                      </Button>
-                    )}
-                    {hasLogs(record) && (
-                      <Button size="small" icon={<FileTextOutlined />} onClick={() => handleExportMarkdown(record)}>导出YAML</Button>
-                    )}
-                    {record.status === 'running' && (() => {
-                      return (
-                        <Popconfirm
-                          title="确定强制停止该任务？"
-                          okText="停止"
-                          cancelText="取消"
-                          onConfirm={async () => {
-                            await handleStopExecution(record.id);
-                          }}
-                        >
-                          <Button
-                            type="primary"
-                            danger
-                            size="middle"
-                            icon={<StopOutlined />}
-                            style={{
-                              fontSize: 14,
-                              fontWeight: 600,
-                              height: '32px',
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: '6px',
-                            }}
-                          >
-                            停止任务
-                          </Button>
-                        </Popconfirm>
-                      );
-                    })()}
-                  </div>
-                </div>
-                {record.command && (
-                  <div style={{ fontSize: 11, color: 'var(--color-text-quaternary)', marginBottom: 8, fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                    {record.command}
-                  </div>
-                )}
-
-                {record.result !== null && record.result !== '' && (
-                  <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`}>
-                    <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
-                      <Button
-                        type="text"
-                        size="small"
-                        icon={<CopyOutlined />}
-                        onClick={async () => {
-                          try {
-                            await navigator.clipboard.writeText(record.result || '');
-                            message.success('已复制到剪贴板');
-                          } catch {
-                            message.error('复制失败');
-                          }
-                        }}
-                      />
-                    </div>
-                    <XMarkdown content={record.result} />
-                  </div>
-                )}
-
-                {record.usage && (
-                  <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 8, display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-                    <span>Input: {record.usage.input_tokens.toLocaleString()}</span>
-                    <span>Output: {record.usage.output_tokens.toLocaleString()}</span>
-                    {record.usage.total_cost_usd !== null && (
-                      <span style={{ color: 'var(--color-warning)', fontWeight: 600 }}>${record.usage.total_cost_usd.toFixed(6)}</span>
-                    )}
-                  </div>
-                )}
-                {(() => {
-                  const isRunning = record.status === 'running';
-                  const stats = resolveExecutionStats(record, isRunning);
-                  if (!stats) return null;
-                  return (
-                    <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 8, display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-                      <span>工具调用: <b style={{ color: 'var(--color-primary)' }}>{stats.tool_calls}</b></span>
-                      <span>对话轮次: <b style={{ color: 'var(--color-primary)' }}>{stats.conversation_turns}</b></span>
-                      {stats.thinking_count > 0 && (
-                        <span>思考次数: <b style={{ color: 'var(--color-primary)' }}>{stats.thinking_count}</b></span>
-                      )}
-                    </div>
-                  );
-                })()}
-
-                {(() => {
-                  const isRunning = record.status === 'running';
-                  const runningTask = isRunning ? getRunningTaskForRecord(record) : null;
-                const liveLogs = runningTask ? runningTask.logs : null;
-                  const restLogs = parseRecordLogs(record);
-                  const displayLogs = liveLogs && liveLogs.length > 0 ? liveLogs : restLogs;
-
-                  if (!isRunning && displayLogs.length === 0) return null;
-
-                  if (viewMode === 'chat') {
-                    return (
-                      <div style={{ marginTop: 8 }}>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-                          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-primary)' }}>
-                            对话视图 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}
-                          </span>
-                          <ReloadOutlined
-                            style={{ fontSize: 11 }}
-                            onClick={(e) => { e.preventDefault(); e.stopPropagation(); refreshSingleRecord(record.id); }}
-                          />
-                        </div>
-                        <div style={{ maxHeight: 400, overflow: 'auto' }}>
-                          <ChatView logs={displayLogs as LogEntry[]} isRunning={isRunning} />
-                        </div>
-                      </div>
-                    );
-                  }
-
-                  return (
-                    <details style={{ marginTop: 8 }} open={isRunning}>
-                      <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 12, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <span>查看日志 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}</span>
-                        <ReloadOutlined
-                          style={{ fontSize: 11 }}
-                          onClick={(e) => { e.preventDefault(); e.stopPropagation(); refreshSingleRecord(record.id); }}
-                        />
-                      </summary>
-                      <div style={{
-                        background: 'var(--log-bg)',
-                        color: 'var(--log-text)',
-                        padding: 8,
-                        borderRadius: 8,
-                        fontFamily: 'var(--font-mono)',
-                        fontSize: 11,
-                        marginTop: 8,
-                        maxHeight: 250,
-                        overflow: 'auto',
-                      }}>
-                        {displayLogs.length === 0 ? (
-                          <div style={{ color: 'var(--log-text-muted)' }}>等待输出...</div>
-                        ) : (
-                          displayLogs.map((log, idx) => (
-                            <div key={idx} style={{ marginBottom: 4, display: 'flex', gap: 8 }}>
-                              <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
-                              <span style={{ color: logTypeColors[log.type || ''] || 'var(--log-text)' }}>
-                                [{logTypeLabels[log.type || ''] || log.type}]
-                              </span>
-                              <span>{log.content}</span>
-                            </div>
-                          ))
-                        )}
-                      </div>
-                    </details>
-                  );
-                })()}
-              </div>
-            ))}
+            {chainMode ? (
+              // Narrow mode — grouped by session
+              sessionGroups.map(group => {
+                const isSingle = group.records.length === 1 || !group.records[0].session_id;
+                if (isSingle) {
+                  return group.records.map(record => (
+                    <NarrowHistoryCard
+                      key={record.id}
+                      record={record}
+                      viewMode={viewMode}
+                      onOpenResume={handleOpenResume}
+                      onExport={handleExportMarkdown}
+                      onStop={handleStopExecution}
+                      onRefresh={refreshSingleRecord}
+                      getRunningTask={getRunningTaskForRecord}
+                      resolveStats={resolveExecutionStats}
+                      parseLogs={parseRecordLogs}
+                      messageApi={message}
+                    />
+                  ));
+                }
+                return (
+                  <ChainGroupCard
+                    key={group.sessionId}
+                    group={group}
+                    onOpenResume={handleOpenResume}
+                    onExport={handleExportMarkdown}
+                    onStop={handleStopExecution}
+                    resolveStats={resolveExecutionStats}
+                    messageApi={message}
+                  />
+                );
+              })
+            ) : (
+              records.map(record => (
+                <NarrowHistoryCard
+                  key={record.id}
+                  record={record}
+                  viewMode={viewMode}
+                  onOpenResume={handleOpenResume}
+                  onExport={handleExportMarkdown}
+                  onStop={handleStopExecution}
+                  onRefresh={refreshSingleRecord}
+                  getRunningTask={getRunningTaskForRecord}
+                  resolveStats={resolveExecutionStats}
+                  parseLogs={parseRecordLogs}
+                  messageApi={message}
+                />
+              ))
+            )}
             {historyTotal > historyLimit && (
               <div style={{ display: 'flex', justifyContent: 'center', marginTop: 16 }}>
                 <Pagination
@@ -1146,6 +1228,311 @@ export function TodoDetail() {
         />
       </Modal>
     </div>
+  );
+}
+
+/** Narrow mode: single history card */
+function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, onRefresh, getRunningTask, resolveStats, parseLogs, messageApi }: {
+  record: ExecutionRecord;
+  viewMode: 'log' | 'chat';
+  onOpenResume: (r: ExecutionRecord) => void;
+  onExport: (r: ExecutionRecord) => void;
+  onStop: (id: number) => Promise<void>;
+  onRefresh: (id: number) => Promise<void>;
+  getRunningTask: (r: ExecutionRecord) => any;
+  resolveStats: (r: ExecutionRecord, running: boolean) => ExecutionStats | null | undefined;
+  parseLogs: (r: ExecutionRecord) => LogEntry[];
+  messageApi: any;
+}) {
+  const isRunning = record.status === 'running';
+  const runningTask = isRunning ? getRunningTask(record) : null;
+  const liveLogs = runningTask ? runningTask.logs : null;
+  const restLogs = parseLogs(record);
+  const displayLogs = liveLogs && liveLogs.length > 0 ? liveLogs : restLogs;
+
+  return (
+    <div className={`history-card history-card-${record.status}`}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8, flexWrap: 'wrap', gap: 8 }}>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+            {formatLocalDateTime(record.started_at)}
+          </span>
+          {record.executor && <ExecutorBadge executor={record.executor} />}
+          {record.model && <Tag color="#3b82f6">{record.model}</Tag>}
+          <Tag color={record.trigger_type === 'cron' ? '#8b5cf6' : '#6b7280'} style={{ fontSize: 10 }}>
+            {record.trigger_type === 'cron' ? 'Cron' : '手动'}
+          </Tag>
+          {record.usage?.duration_ms && (
+            <span style={{ fontSize: 11, color: 'var(--color-success)', fontWeight: 600 }}>
+              {(record.usage.duration_ms / 1000).toFixed(2)}s
+            </span>
+          )}
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span style={{
+            fontSize: 11, padding: '3px 12px', borderRadius: 12,
+            backgroundColor: record.status === 'success' ? 'var(--color-success)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
+            color: '#fff', fontWeight: 600,
+          }}>
+            {record.status === 'success' ? '成功' : record.status === 'failed' ? '失败' : '进行中'}
+          </span>
+          {!isRunning && supportsResume(record) && (
+            <Button type="primary" size="small" icon={<MessageOutlined />} onClick={() => onOpenResume(record)}>继续对话</Button>
+          )}
+          {hasLogsStatic(record) && (
+            <Button size="small" icon={<FileTextOutlined />} onClick={() => onExport(record)}>导出YAML</Button>
+          )}
+          {isRunning && (
+            <Popconfirm title="确定强制停止该任务？" okText="停止" cancelText="取消" onConfirm={() => onStop(record.id)}>
+              <Button type="primary" danger size="middle" icon={<StopOutlined />} style={{ fontSize: 14, fontWeight: 600, height: '32px', display: 'flex', alignItems: 'center', gap: '6px' }}>停止任务</Button>
+            </Popconfirm>
+          )}
+        </div>
+      </div>
+      {record.command && (
+        <div style={{ fontSize: 11, color: 'var(--color-text-quaternary)', marginBottom: 8, fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {record.command}
+        </div>
+      )}
+      {record.result !== null && record.result !== '' && (
+        <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`}>
+          <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
+            <Button type="text" size="small" icon={<CopyOutlined />} onClick={async () => {
+              try { await navigator.clipboard.writeText(record.result || ''); messageApi.success('已复制到剪贴板'); }
+              catch { messageApi.error('复制失败'); }
+            }} />
+          </div>
+          <XMarkdown content={record.result} />
+        </div>
+      )}
+      {record.usage && (
+        <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 8, display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+          <span>Input: {record.usage.input_tokens.toLocaleString()}</span>
+          <span>Output: {record.usage.output_tokens.toLocaleString()}</span>
+          {record.usage.total_cost_usd !== null && (
+            <span style={{ color: 'var(--color-warning)', fontWeight: 600 }}>${record.usage.total_cost_usd.toFixed(6)}</span>
+          )}
+        </div>
+      )}
+      {(() => {
+        const stats = resolveStats(record, isRunning);
+        if (!stats) return null;
+        return (
+          <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 8, display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+            <span>工具调用: <b style={{ color: 'var(--color-primary)' }}>{stats.tool_calls}</b></span>
+            <span>对话轮次: <b style={{ color: 'var(--color-primary)' }}>{stats.conversation_turns}</b></span>
+            {stats.thinking_count > 0 && (
+              <span>思考次数: <b style={{ color: 'var(--color-primary)' }}>{stats.thinking_count}</b></span>
+            )}
+          </div>
+        );
+      })()}
+      {renderNarrowLogs(record, isRunning, displayLogs, liveLogs, viewMode, onRefresh)}
+    </div>
+  );
+}
+
+/** Narrow mode: chain group card */
+function ChainGroupCard({ group, onOpenResume, onExport, onStop, resolveStats, messageApi }: {
+  group: SessionGroup;
+  onOpenResume: (r: ExecutionRecord) => void;
+  onExport: (r: ExecutionRecord) => void;
+  onStop: (id: number) => Promise<void>;
+  resolveStats: (r: ExecutionRecord, running: boolean) => ExecutionStats | null | undefined;
+  messageApi: any;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [expandedRecordId, setExpandedRecordId] = useState<number | null>(null);
+  const lastRecord = group.records[group.records.length - 1];
+  const totalDuration = group.records.reduce((s, r) => s + (r.usage?.duration_ms || 0), 0);
+  const totalToolCalls = group.records.reduce((s, r) => s + (r.execution_stats?.tool_calls || 0), 0);
+  const totalTurns = group.records.reduce((s, r) => s + (r.execution_stats?.conversation_turns || 0), 0);
+
+  return (
+    <div style={{
+      background: 'var(--color-bg-elevated)',
+      border: '1px solid var(--color-border-light)',
+      borderRadius: 'var(--radius-md)',
+      overflow: 'hidden',
+    }}>
+      {/* Group header */}
+      <div
+        onClick={() => {
+          setExpanded(!expanded);
+          if (!expanded && !expandedRecordId) setExpandedRecordId(lastRecord.id);
+        }}
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '10px 14px',
+          cursor: 'pointer',
+          userSelect: 'none',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <MessageOutlined style={{ color: 'var(--color-primary)' }} />
+          <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-text)' }}>对话链</span>
+          <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>{group.records.length}轮</span>
+          {lastRecord.executor && <ExecutorBadge executor={lastRecord.executor} />}
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>
+            累计 {(totalDuration / 1000).toFixed(1)}s · 🔧{totalToolCalls} · 💬{totalTurns}
+          </span>
+          {expanded ? <UpOutlined style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }} /> : <DownOutlined style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }} />}
+        </div>
+      </div>
+
+      {/* Timeline — visible when expanded */}
+      {expanded && (
+        <div style={{ padding: '0 14px 10px' }}>
+          {/* Timeline items */}
+          {group.records.map((record, idx) => {
+            const isFirst = idx === 0;
+            const isLast = idx === group.records.length - 1;
+            const isRecordExpanded = expandedRecordId === record.id;
+            return (
+              <div key={record.id}>
+                <div style={{ display: 'flex', cursor: 'pointer' }} onClick={() => setExpandedRecordId(isRecordExpanded ? null : record.id)}>
+                  {/* Timeline rail */}
+                  <div style={{ width: 20, flexShrink: 0, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                    <div style={{
+                      width: 8, height: 8, borderRadius: '50%', flexShrink: 0, marginTop: 6,
+                      border: '2px solid',
+                      borderColor: record.status === 'running' ? 'var(--color-info)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-success)',
+                      background: isFirst ? (record.status === 'running' ? 'var(--color-info)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-success)') : 'var(--color-bg-elevated)',
+                    }} />
+                    {!isLast && <div style={{ width: 1.5, flex: 1, background: 'var(--color-border-light)', minHeight: 20 }} />}
+                  </div>
+                  {/* Item content */}
+                  <div style={{ flex: 1, padding: '4px 0 8px 6px', minWidth: 0 }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 2 }}>
+                      <span style={{ fontSize: 11, color: 'var(--color-text-secondary)', fontWeight: 500 }}>
+                        {isFirst ? '发起对话' : `继续第${idx + 1}轮`} · {formatLocalDateTime(record.started_at)}
+                      </span>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                        {record.usage?.duration_ms && (
+                          <span style={{ fontSize: 10, color: 'var(--color-success)', fontWeight: 600 }}>
+                            {(record.usage.duration_ms / 1000).toFixed(1)}s
+                          </span>
+                        )}
+                        <span style={{
+                          fontSize: 9, padding: '1px 6px', borderRadius: 8,
+                          backgroundColor: record.status === 'success' ? 'var(--color-success)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
+                          color: '#fff', fontWeight: 600,
+                        }}>
+                          {record.status === 'success' ? '✓' : record.status === 'failed' ? '✗' : '...'}
+                        </span>
+                      </div>
+                    </div>
+                    {/* Expanded record detail */}
+                    {isRecordExpanded && (
+                      <div style={{ marginTop: 6, padding: '8px 10px', background: 'var(--color-bg-container)', borderRadius: 6, border: '1px solid var(--color-border-light)' }}>
+                        {record.result && (
+                          <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`} style={{ marginBottom: 6 }}>
+                            <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
+                              <Button type="text" size="small" icon={<CopyOutlined />} onClick={async (e) => {
+                                e.stopPropagation();
+                                try { await navigator.clipboard.writeText(record.result || ''); messageApi.success('已复制'); }
+                                catch { messageApi.error('复制失败'); }
+                              }} />
+                            </div>
+                            <XMarkdown content={record.result} />
+                          </div>
+                        )}
+                        {record.usage && (
+                          <div style={{ fontSize: 10, color: 'var(--color-text-tertiary)', marginBottom: 4, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                            <span>In: {record.usage.input_tokens.toLocaleString()}</span>
+                            <span>Out: {record.usage.output_tokens.toLocaleString()}</span>
+                            {record.usage.total_cost_usd !== null && (
+                              <span style={{ color: 'var(--color-warning)', fontWeight: 600 }}>${record.usage.total_cost_usd.toFixed(6)}</span>
+                            )}
+                          </div>
+                        )}
+                        {(() => {
+                          const stats = resolveStats(record, record.status === 'running');
+                          if (!stats) return null;
+                          return (
+                            <div style={{ fontSize: 10, color: 'var(--color-text-tertiary)', marginBottom: 4, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                              <span>🔧{stats.tool_calls}</span>
+                              <span>💬{stats.conversation_turns}</span>
+                              {stats.thinking_count > 0 && <span>🧠{stats.thinking_count}</span>}
+                            </div>
+                          );
+                        })()}
+                        <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                          {hasLogsStatic(record) && (
+                            <Button size="small" icon={<FileTextOutlined />} onClick={(e) => { e.stopPropagation(); onExport(record); }}>导出</Button>
+                          )}
+                          {record.status === 'running' && (
+                            <Popconfirm title="确定停止？" okText="停止" cancelText="取消" onConfirm={() => onStop(record.id)}>
+                              <Button type="primary" danger size="small" icon={<StopOutlined />}>停止</Button>
+                            </Popconfirm>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+          {/* Footer actions */}
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 8, paddingTop: 8, borderTop: '1px solid var(--color-border-light)' }}>
+            {lastRecord.status !== 'running' && supportsResume(lastRecord) && (
+              <Button type="primary" size="small" icon={<MessageOutlined />} onClick={() => onOpenResume(lastRecord)}>继续对话</Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Shared log rendering for narrow mode cards */
+function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLogs: LogEntry[], liveLogs: LogEntry[] | null, viewMode: 'log' | 'chat', onRefresh: (id: number) => Promise<void>) {
+  if (!isRunning && displayLogs.length === 0) return null;
+  if (viewMode === 'chat') {
+    return (
+      <div style={{ marginTop: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-primary)' }}>
+            对话视图 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}
+          </span>
+          <ReloadOutlined style={{ fontSize: 11 }} onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
+        </div>
+        <div style={{ maxHeight: 400, overflow: 'auto' }}>
+          <ChatView logs={displayLogs as LogEntry[]} isRunning={isRunning} />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <details style={{ marginTop: 8 }} open={isRunning}>
+      <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 12, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span>查看日志 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}</span>
+        <ReloadOutlined style={{ fontSize: 11 }} onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
+      </summary>
+      <div style={{
+        background: 'var(--log-bg)', color: 'var(--log-text)', padding: 8, borderRadius: 8,
+        fontFamily: 'var(--font-mono)', fontSize: 11, marginTop: 8, maxHeight: 250, overflow: 'auto',
+      }}>
+        {displayLogs.length === 0 ? (
+          <div style={{ color: 'var(--log-text-muted)' }}>等待输出...</div>
+        ) : (
+          displayLogs.map((log, idx) => (
+            <div key={idx} style={{ marginBottom: 4, display: 'flex', gap: 8 }}>
+              <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
+              <span style={{ color: logTypeColors[log.type || ''] || 'var(--log-text)' }}>
+                [{logTypeLabels[log.type || ''] || log.type}]
+              </span>
+              <span>{log.content}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </details>
   );
 }
 

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -8,6 +8,8 @@ import { TodoSettingsDrawer } from './TodoSettingsDrawer';
 import { TodoEditDrawer } from './TodoEditDrawer';
 import { ChatView } from './ChatView';
 import { parseLogsToMessages } from './ChatView';
+import { TimelineFlow } from './TimelineFlow';
+import type { TimelineRecord } from './TimelineFlow';
 import * as db from '../utils/database';
 import { formatLocalDateTime } from '../utils/datetime';
 import { conversationToYaml } from '../utils/markdown';
@@ -302,8 +304,23 @@ function hasLogsStatic(record: ExecutionRecord): boolean {
   return !!record.logs && record.logs !== '[]';
 }
 
+/** 将 execution record 的 logs 转换为 TimelineFlow 需要的格式 */
+function logsToTimelineRecords(record: ExecutionRecord): TimelineRecord[] {
+  try {
+    const logs: LogEntry[] = record.logs && record.logs !== '[]' ? JSON.parse(record.logs) : [];
+    return logs.map((log, i) => ({
+      id: `${record.id}-log-${i}`,
+      role: log.type || 'info',
+      content: log.content?.substring(0, 100),
+      timestamp: log.timestamp ? new Date(log.timestamp).getTime() : i,
+    }));
+  } catch {
+    return [];
+  }
+}
+
 /** 任务详情面板，包含执行、编辑、历史记录等功能 */
-export function TodoDetail() {
+export function TodoDetail({ onBack }: { onBack?: () => void }) {
   const { state, dispatch } = useApp();
   const { message } = App.useApp();
   const { todos, selectedTodoId, executionRecords, runningTasks } = state;
@@ -609,7 +626,11 @@ export function TodoDetail() {
           type="text"
           icon={<ArrowLeftOutlined />}
           onClick={() => {
-            dispatch({ type: 'SELECT_TODO', payload: null });
+            if (onBack) {
+              onBack();
+            } else {
+              dispatch({ type: 'SELECT_TODO', payload: null });
+            }
           }}
           style={{ marginBottom: 8, marginLeft: -4 }}
         >
@@ -939,6 +960,11 @@ export function TodoDetail() {
                         {record.command}
                       </div>
                     )}
+                    {(() => {
+                      const tl = logsToTimelineRecords(record);
+                      if (tl.length === 0) return null;
+                      return <TimelineFlow records={tl} height={20} containerStyle={{ marginBottom: 12 }} />;
+                    })()}
                     {record.result !== null && record.result !== '' && (
                       <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`} style={{ marginBottom: 12 }}>
                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
@@ -1215,6 +1241,11 @@ function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, o
           {record.command}
         </div>
       )}
+      {(() => {
+        const tl = logsToTimelineRecords(record);
+        if (tl.length === 0) return null;
+        return <TimelineFlow records={tl} height={16} containerStyle={{ marginBottom: 8 }} />;
+      })()}
       {record.result !== null && record.result !== '' && (
         <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`}>
           <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useApp } from '../hooks/useApp';
-import { Button, Empty, App, Popconfirm, Tag, Badge, Pagination, Segmented, Modal, Input, Switch } from 'antd';
-import { PlayCircleOutlined, EditOutlined, DeleteOutlined, SettingOutlined, CheckCircleOutlined, ReloadOutlined, CopyOutlined, ArrowLeftOutlined, StopOutlined, DownOutlined, UpOutlined, UnorderedListOutlined, MessageOutlined, FileTextOutlined, SwapOutlined } from '@ant-design/icons';
+import { Button, Empty, App, Popconfirm, Tag, Badge, Pagination, Segmented, Modal, Input } from 'antd';
+import { PlayCircleOutlined, EditOutlined, DeleteOutlined, SettingOutlined, CheckCircleOutlined, ReloadOutlined, CopyOutlined, ArrowLeftOutlined, StopOutlined, DownOutlined, UpOutlined, UnorderedListOutlined, MessageOutlined, FileTextOutlined, LinkOutlined } from '@ant-design/icons';
 import { StatusPicker } from './StatusPicker';
 import { PieChart } from './PieChart';
 import { TodoSettingsDrawer } from './TodoSettingsDrawer';
@@ -458,9 +458,8 @@ export function TodoDetail() {
   const [resumeMessage, setResumeMessage] = useState('');
   const [resumeLoading, setResumeLoading] = useState(false);
 
-  // Chain mode: group execution records by session_id
-  const [chainMode, setChainMode] = useState(false);
-  const sessionGroups = useMemo(() => chainMode ? groupBySession(records) : [], [chainMode, records]);
+  // Always group execution records by session_id
+  const sessionGroups = useMemo(() => groupBySession(records), [records]);
 
   const handleOpenResume = (record: ExecutionRecord) => {
     setResumeRecordId(record.id);
@@ -704,11 +703,6 @@ export function TodoDetail() {
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12, ...(isWide ? { flexShrink: 0 } : {}) }}>
           <h4 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: 'var(--color-text)' }}>执行历史</h4>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', display: 'flex', alignItems: 'center', gap: 4 }}>
-              <SwapOutlined style={{ fontSize: 12 }} />
-              <span>合并</span>
-              <Switch size="small" checked={chainMode} onChange={setChainMode} />
-            </span>
             <Segmented
               size="small"
               value={viewMode}
@@ -736,148 +730,99 @@ export function TodoDetail() {
             {/* Left: History List */}
             <div style={{ width: 320, flexShrink: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
               <div className="history-list-column">
-                {chainMode ? (
-                  // Grouped by session_id
-                  sessionGroups.map(group => {
-                    const isSingle = group.records.length === 1 || !group.records[0].session_id;
-                    const groupSelected = group.records.some(r => r.id === selectedHistoryRecordId);
-                    return (
-                      <div key={group.sessionId} style={{ marginBottom: 4 }}>
-                        {isSingle ? (
-                          // Single record — render normally
-                          group.records.map(record => {
-                            const isSelected = selectedHistoryRecordId === record.id;
-                            return (
-                              <div
-                                key={record.id}
-                                className={`history-item-compact${isSelected ? ' selected' : ''}${record.status === 'failed' ? ' failed' : record.status === 'running' ? ' running' : ''}`}
-                                onClick={() => setSelectedHistoryRecordId(record.id)}
-                              >
-                                <CompactHistoryItem record={record} onOpenResume={handleOpenResume} onExport={handleExportMarkdown} />
-                              </div>
-                            );
-                          })
-                        ) : (
-                          // Chain group — header + timeline items
-                          <div style={{
-                            border: groupSelected ? '1px solid var(--color-primary)' : '1px solid var(--color-border-light)',
-                            borderRadius: 'var(--radius-sm)',
-                            overflow: 'hidden',
-                            background: groupSelected ? 'var(--color-primary-bg)' : 'transparent',
-                          }}>
-                            {/* Group header */}
-                            <div style={{
-                              display: 'flex',
-                              justifyContent: 'space-between',
-                              alignItems: 'center',
-                              padding: '6px 10px',
-                              background: 'var(--color-bg-elevated)',
+                {sessionGroups.map(group => {
+                  const isSingle = group.records.length === 1 || !group.records[0].session_id;
+                  if (isSingle) {
+                    return group.records.map(record => {
+                      const isSelected = selectedHistoryRecordId === record.id;
+                      return (
+                        <div
+                          key={record.id}
+                          className={`history-item-compact${isSelected ? ' selected' : ''}${record.status === 'failed' ? ' failed' : record.status === 'running' ? ' running' : ''}`}
+                          onClick={() => setSelectedHistoryRecordId(record.id)}
+                        >
+                          <CompactHistoryItem record={record} onOpenResume={handleOpenResume} onExport={handleExportMarkdown} />
+                        </div>
+                      );
+                    });
+                  }
+                  // Chain group: main record + indented continuations
+                  const mainRecord = group.records[0];
+                  const continuations = group.records.slice(1);
+                  const mainSelected = selectedHistoryRecordId === mainRecord.id;
+                  return (
+                    <div key={group.sessionId} style={{ marginBottom: 6 }}>
+                      {/* Main record */}
+                      <div
+                        className={`history-item-compact${mainSelected ? ' selected' : ''}`}
+                        onClick={() => setSelectedHistoryRecordId(mainRecord.id)}
+                      >
+                        <CompactHistoryItem record={mainRecord} onOpenResume={handleOpenResume} onExport={handleExportMarkdown} />
+                      </div>
+                      {/* Indented continuations */}
+                      {continuations.map((record, idx) => {
+                        const isSelected = selectedHistoryRecordId === record.id;
+                        const isLast = idx === continuations.length - 1;
+                        return (
+                          <div
+                            key={record.id}
+                            onClick={() => setSelectedHistoryRecordId(record.id)}
+                            style={{
+                              marginLeft: 12,
+                              padding: '6px 8px',
+                              borderLeft: '2px solid var(--color-primary)',
                               borderBottom: '1px solid var(--color-border-light)',
-                              fontSize: 10,
-                              color: 'var(--color-text-tertiary)',
-                            }}>
-                              <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                                <MessageOutlined style={{ fontSize: 10, color: 'var(--color-primary)' }} />
-                                对话链 · {group.records.length}轮
+                              cursor: 'pointer',
+                              background: isSelected ? 'var(--color-primary-bg)' : 'var(--color-bg-elevated)',
+                              transition: 'background 0.15s',
+                              marginBottom: 1,
+                            }}
+                          >
+                            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 2 }}>
+                              <span style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 10, color: 'var(--color-primary)', fontWeight: 500 }}>
+                                <LinkOutlined style={{ fontSize: 10 }} />
+                                {record.resume_message ? (
+                                  <span style={{ color: 'var(--color-text-secondary)', fontWeight: 400 }}>{record.resume_message.length > 30 ? record.resume_message.substring(0, 30) + '...' : record.resume_message}</span>
+                                ) : (
+                                  <span>继续对话</span>
+                                )}
                               </span>
-                              <span>
-                                累计 {(group.records.reduce((s, r) => s + (r.usage?.duration_ms || 0), 0) / 1000).toFixed(1)}s
+                              <span style={{
+                                fontSize: 9, padding: '1px 6px', borderRadius: 8,
+                                backgroundColor: record.status === 'success' ? 'var(--color-success)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
+                                color: '#fff', fontWeight: 600,
+                              }}>
+                                {record.status === 'success' ? '✓' : record.status === 'failed' ? '✗' : '...'}
                               </span>
                             </div>
-                            {/* Timeline items */}
-                            {group.records.map((record, idx) => {
-                              const isSelected = selectedHistoryRecordId === record.id;
-                              const isFirst = idx === 0;
-                              const isLast = idx === group.records.length - 1;
-                              return (
-                                <div
-                                  key={record.id}
-                                  onClick={() => setSelectedHistoryRecordId(record.id)}
-                                  style={{
-                                    display: 'flex',
-                                    cursor: 'pointer',
-                                    background: isSelected ? 'var(--color-primary-bg)' : 'transparent',
-                                    transition: 'background 0.2s',
-                                  }}
-                                >
-                                  {/* Timeline rail */}
-                                  <div style={{
-                                    width: 24,
-                                    flexShrink: 0,
-                                    display: 'flex',
-                                    flexDirection: 'column',
-                                    alignItems: 'center',
-                                    paddingTop: 8,
-                                  }}>
-                                    <div style={{
-                                      width: 8,
-                                      height: 8,
-                                      borderRadius: '50%',
-                                      border: '2px solid',
-                                      borderColor: record.status === 'running' ? 'var(--color-info)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-success)',
-                                      background: isFirst ? (record.status === 'running' ? 'var(--color-info)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-success)') : 'var(--color-bg-elevated)',
-                                      flexShrink: 0,
-                                    }} />
-                                    {!isLast && (
-                                      <div style={{ width: 1.5, flex: 1, background: 'var(--color-border-light)', minHeight: 20 }} />
-                                    )}
-                                  </div>
-                                  {/* Content */}
-                                  <div style={{ flex: 1, padding: '6px 8px 6px 0', minWidth: 0 }}>
-                                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 2 }}>
-                                      <span style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }}>
-                                        {isFirst ? '发起' : `第${idx + 1}轮`} {formatLocalDateTime(record.started_at).split(' ')[1] || formatLocalDateTime(record.started_at)}
-                                      </span>
-                                      <span style={{
-                                        fontSize: 9,
-                                        padding: '1px 6px',
-                                        borderRadius: 8,
-                                        backgroundColor: record.status === 'success' ? 'var(--color-success)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
-                                        color: '#fff',
-                                        fontWeight: 600,
-                                      }}>
-                                        {record.status === 'success' ? '✓' : record.status === 'failed' ? '✗' : '...'}
-                                      </span>
-                                    </div>
-                                    <div style={{ display: 'flex', gap: 4, alignItems: 'center', flexWrap: 'wrap' }}>
-                                      {record.executor && <ExecutorBadge executor={record.executor} />}
-                                      {record.usage?.duration_ms && (
-                                        <span style={{ fontSize: 9, color: 'var(--color-success)', fontWeight: 600 }}>
-                                          {(record.usage.duration_ms / 1000).toFixed(1)}s
-                                        </span>
-                                      )}
-                                    </div>
-                                    {isLast && record.status !== 'running' && supportsResume(record) && (
-                                      <MessageOutlined
-                                        style={{ fontSize: 11, color: 'var(--color-primary)', cursor: 'pointer', marginTop: 4 }}
-                                        title="继续对话"
-                                        onClick={(e) => { e.stopPropagation(); handleOpenResume(record); }}
-                                      />
-                                    )}
-                                  </div>
-                                </div>
-                              );
-                            })}
+                            <div style={{ display: 'flex', gap: 4, alignItems: 'center', flexWrap: 'wrap' }}>
+                              <span style={{ fontSize: 9, color: 'var(--color-text-tertiary)' }}>
+                                {formatLocalDateTime(record.started_at)}
+                              </span>
+                              {record.usage?.duration_ms && (
+                                <span style={{ fontSize: 9, color: 'var(--color-success)', fontWeight: 600 }}>
+                                  {(record.usage.duration_ms / 1000).toFixed(1)}s
+                                </span>
+                              )}
+                              {record.execution_stats && (
+                                <span style={{ fontSize: 9, color: 'var(--color-text-tertiary)' }}>
+                                  🔧{record.execution_stats.tool_calls}
+                                </span>
+                              )}
+                            </div>
+                            {isLast && record.status !== 'running' && supportsResume(record) && (
+                              <MessageOutlined
+                                style={{ fontSize: 11, color: 'var(--color-primary)', cursor: 'pointer', marginTop: 3 }}
+                                title="继续对话"
+                                onClick={(e) => { e.stopPropagation(); handleOpenResume(record); }}
+                              />
+                            )}
                           </div>
-                        )}
-                      </div>
-                    );
-                  })
-                ) : (
-                  // Original flat list
-                  records.map(record => {
-                    const isSelected = selectedHistoryRecordId === record.id;
-                    return (
-                      <div
-                        key={record.id}
-                        className={`history-item-compact${isSelected ? ' selected' : ''}${record.status === 'failed' ? ' failed' : record.status === 'running' ? ' running' : ''}`}
-                        onClick={() => setSelectedHistoryRecordId(record.id)}
-                      >
-                        <CompactHistoryItem record={record} onOpenResume={handleOpenResume} onExport={handleExportMarkdown} />
-                      </div>
-                    );
-                  })
-                )}
+                        );
+                      })}
+                    </div>
+                  );
+                })}
               </div>
               {historyTotal > historyLimit && (
                 <div style={{ flexShrink: 0, display: 'flex', justifyContent: 'center', padding: '8px 0 0', borderTop: '1px solid var(--color-border-light)' }}>
@@ -912,45 +857,38 @@ export function TodoDetail() {
                 const displayLogs = liveLogs && liveLogs.length > 0 ? liveLogs : restLogs;
                 return (
                   <>
-                    {/* Chain breadcrumb — only in chain mode */}
-                    {chainMode && (() => {
+                    {/* Chain breadcrumb — when viewing a continuation record */}
+                    {(() => {
                       const group = sessionGroups.find(g => g.records.some(r => r.id === record.id));
                       if (!group || group.records.length <= 1 || !group.records[0].session_id) return null;
                       const idx = group.records.findIndex(r => r.id === record.id);
+                      if (idx <= 0) return null;
                       return (
                         <div style={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 4,
-                          marginBottom: 10,
-                          padding: '4px 8px',
-                          borderRadius: 6,
-                          background: 'var(--color-bg-elevated)',
-                          border: '1px solid var(--color-border-light)',
-                          fontSize: 11,
-                          color: 'var(--color-text-tertiary)',
-                          flexWrap: 'wrap',
+                          display: 'flex', alignItems: 'center', gap: 6,
+                          marginBottom: 10, padding: '4px 10px', borderRadius: 6,
+                          background: 'var(--color-bg-elevated)', border: '1px solid var(--color-border-light)',
+                          fontSize: 11, color: 'var(--color-text-tertiary)',
                         }}>
-                          {group.records.map((r, i) => (
-                            <span key={r.id} style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
-                              {i > 0 && <span style={{ color: 'var(--color-border)', margin: '0 2px' }}>→</span>}
-                              <span
-                                onClick={() => setSelectedHistoryRecordId(r.id)}
-                                style={{
-                                  cursor: 'pointer',
-                                  padding: '1px 6px',
-                                  borderRadius: 4,
-                                  background: i === idx ? 'var(--color-primary)' : 'transparent',
-                                  color: i === idx ? '#fff' : 'var(--color-text-tertiary)',
-                                  fontWeight: i === idx ? 600 : 400,
-                                  transition: 'all 0.15s',
-                                }}
-                              >
-                                {i === 0 ? '发起' : `第${i + 1}轮`}
+                          <LinkOutlined style={{ color: 'var(--color-primary)', fontSize: 11 }} />
+                          <span>继续自</span>
+                          <span
+                            onClick={() => setSelectedHistoryRecordId(group.records[0].id)}
+                            style={{ cursor: 'pointer', color: 'var(--color-primary)', fontWeight: 500 }}
+                          >
+                            {formatLocalDateTime(group.records[0].started_at)}
+                          </span>
+                          {record.resume_message && (
+                            <>
+                              <span style={{ color: 'var(--color-border)' }}>·</span>
+                              <span style={{ color: 'var(--color-text-secondary)', fontStyle: 'italic' }}>
+                                "{record.resume_message.length > 40 ? record.resume_message.substring(0, 40) + '...' : record.resume_message}"
                               </span>
-                            </span>
-                          ))}
-                          <span style={{ marginLeft: 4, color: 'var(--color-text-quaternary)' }}>共{group.records.length}轮</span>
+                            </>
+                          )}
+                          <span style={{ marginLeft: 'auto', color: 'var(--color-text-quaternary)' }}>
+                            第{idx + 1}轮 / 共{group.records.length}轮
+                          </span>
                         </div>
                       );
                     })()}
@@ -1110,56 +1048,36 @@ export function TodoDetail() {
           </div>
         ) : (
           <>
-            {chainMode ? (
-              // Narrow mode — grouped by session
-              sessionGroups.map(group => {
-                const isSingle = group.records.length === 1 || !group.records[0].session_id;
-                if (isSingle) {
-                  return group.records.map(record => (
-                    <NarrowHistoryCard
-                      key={record.id}
-                      record={record}
-                      viewMode={viewMode}
-                      onOpenResume={handleOpenResume}
-                      onExport={handleExportMarkdown}
-                      onStop={handleStopExecution}
-                      onRefresh={refreshSingleRecord}
-                      getRunningTask={getRunningTaskForRecord}
-                      resolveStats={resolveExecutionStats}
-                      parseLogs={parseRecordLogs}
-                      messageApi={message}
-                    />
-                  ));
-                }
-                return (
-                  <ChainGroupCard
-                    key={group.sessionId}
-                    group={group}
+            {sessionGroups.map(group => {
+              const isSingle = group.records.length === 1 || !group.records[0].session_id;
+              if (isSingle) {
+                return group.records.map(record => (
+                  <NarrowHistoryCard
+                    key={record.id}
+                    record={record}
+                    viewMode={viewMode}
                     onOpenResume={handleOpenResume}
                     onExport={handleExportMarkdown}
                     onStop={handleStopExecution}
+                    onRefresh={refreshSingleRecord}
+                    getRunningTask={getRunningTaskForRecord}
                     resolveStats={resolveExecutionStats}
+                    parseLogs={parseRecordLogs}
                     messageApi={message}
                   />
-                );
-              })
-            ) : (
-              records.map(record => (
-                <NarrowHistoryCard
-                  key={record.id}
-                  record={record}
-                  viewMode={viewMode}
+                ));
+              }
+              return (
+                <ChainGroupCard
+                  key={group.sessionId}
+                  group={group}
                   onOpenResume={handleOpenResume}
                   onExport={handleExportMarkdown}
                   onStop={handleStopExecution}
-                  onRefresh={refreshSingleRecord}
-                  getRunningTask={getRunningTaskForRecord}
-                  resolveStats={resolveExecutionStats}
-                  parseLogs={parseRecordLogs}
                   messageApi={message}
                 />
-              ))
-            )}
+              );
+            })}
             {historyTotal > historyLimit && (
               <div style={{ display: 'flex', justifyContent: 'center', marginTop: 16 }}>
                 <Pagination
@@ -1332,160 +1250,151 @@ function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, o
   );
 }
 
-/** Narrow mode: chain group card */
-function ChainGroupCard({ group, onOpenResume, onExport, onStop, resolveStats, messageApi }: {
+/** Narrow mode: chain group card — main record with indented continuations */
+function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi }: {
   group: SessionGroup;
   onOpenResume: (r: ExecutionRecord) => void;
   onExport: (r: ExecutionRecord) => void;
   onStop: (id: number) => Promise<void>;
-  resolveStats: (r: ExecutionRecord, running: boolean) => ExecutionStats | null | undefined;
   messageApi: any;
 }) {
-  const [expanded, setExpanded] = useState(false);
-  const [expandedRecordId, setExpandedRecordId] = useState<number | null>(null);
-  const lastRecord = group.records[group.records.length - 1];
-  const totalDuration = group.records.reduce((s, r) => s + (r.usage?.duration_ms || 0), 0);
-  const totalToolCalls = group.records.reduce((s, r) => s + (r.execution_stats?.tool_calls || 0), 0);
-  const totalTurns = group.records.reduce((s, r) => s + (r.execution_stats?.conversation_turns || 0), 0);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const mainRecord = group.records[0];
+  const continuations = group.records.slice(1);
 
   return (
-    <div style={{
-      background: 'var(--color-bg-elevated)',
-      border: '1px solid var(--color-border-light)',
-      borderRadius: 'var(--radius-md)',
-      overflow: 'hidden',
-    }}>
-      {/* Group header */}
-      <div
-        onClick={() => {
-          setExpanded(!expanded);
-          if (!expanded && !expandedRecordId) setExpandedRecordId(lastRecord.id);
-        }}
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          padding: '10px 14px',
-          cursor: 'pointer',
-          userSelect: 'none',
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <MessageOutlined style={{ color: 'var(--color-primary)' }} />
-          <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-text)' }}>对话链</span>
-          <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>{group.records.length}轮</span>
-          {lastRecord.executor && <ExecutorBadge executor={lastRecord.executor} />}
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>
-            累计 {(totalDuration / 1000).toFixed(1)}s · 🔧{totalToolCalls} · 💬{totalTurns}
-          </span>
-          {expanded ? <UpOutlined style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }} /> : <DownOutlined style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }} />}
-        </div>
-      </div>
-
-      {/* Timeline — visible when expanded */}
-      {expanded && (
-        <div style={{ padding: '0 14px 10px' }}>
-          {/* Timeline items */}
-          {group.records.map((record, idx) => {
-            const isFirst = idx === 0;
-            const isLast = idx === group.records.length - 1;
-            const isRecordExpanded = expandedRecordId === record.id;
-            return (
-              <div key={record.id}>
-                <div style={{ display: 'flex', cursor: 'pointer' }} onClick={() => setExpandedRecordId(isRecordExpanded ? null : record.id)}>
-                  {/* Timeline rail */}
-                  <div style={{ width: 20, flexShrink: 0, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-                    <div style={{
-                      width: 8, height: 8, borderRadius: '50%', flexShrink: 0, marginTop: 6,
-                      border: '2px solid',
-                      borderColor: record.status === 'running' ? 'var(--color-info)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-success)',
-                      background: isFirst ? (record.status === 'running' ? 'var(--color-info)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-success)') : 'var(--color-bg-elevated)',
-                    }} />
-                    {!isLast && <div style={{ width: 1.5, flex: 1, background: 'var(--color-border-light)', minHeight: 20 }} />}
-                  </div>
-                  {/* Item content */}
-                  <div style={{ flex: 1, padding: '4px 0 8px 6px', minWidth: 0 }}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 2 }}>
-                      <span style={{ fontSize: 11, color: 'var(--color-text-secondary)', fontWeight: 500 }}>
-                        {isFirst ? '发起对话' : `继续第${idx + 1}轮`} · {formatLocalDateTime(record.started_at)}
-                      </span>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                        {record.usage?.duration_ms && (
-                          <span style={{ fontSize: 10, color: 'var(--color-success)', fontWeight: 600 }}>
-                            {(record.usage.duration_ms / 1000).toFixed(1)}s
-                          </span>
-                        )}
-                        <span style={{
-                          fontSize: 9, padding: '1px 6px', borderRadius: 8,
-                          backgroundColor: record.status === 'success' ? 'var(--color-success)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
-                          color: '#fff', fontWeight: 600,
-                        }}>
-                          {record.status === 'success' ? '✓' : record.status === 'failed' ? '✗' : '...'}
-                        </span>
-                      </div>
-                    </div>
-                    {/* Expanded record detail */}
-                    {isRecordExpanded && (
-                      <div style={{ marginTop: 6, padding: '8px 10px', background: 'var(--color-bg-container)', borderRadius: 6, border: '1px solid var(--color-border-light)' }}>
-                        {record.result && (
-                          <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`} style={{ marginBottom: 6 }}>
-                            <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
-                              <Button type="text" size="small" icon={<CopyOutlined />} onClick={async (e) => {
-                                e.stopPropagation();
-                                try { await navigator.clipboard.writeText(record.result || ''); messageApi.success('已复制'); }
-                                catch { messageApi.error('复制失败'); }
-                              }} />
-                            </div>
-                            <XMarkdown content={record.result} />
-                          </div>
-                        )}
-                        {record.usage && (
-                          <div style={{ fontSize: 10, color: 'var(--color-text-tertiary)', marginBottom: 4, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                            <span>In: {record.usage.input_tokens.toLocaleString()}</span>
-                            <span>Out: {record.usage.output_tokens.toLocaleString()}</span>
-                            {record.usage.total_cost_usd !== null && (
-                              <span style={{ color: 'var(--color-warning)', fontWeight: 600 }}>${record.usage.total_cost_usd.toFixed(6)}</span>
-                            )}
-                          </div>
-                        )}
-                        {(() => {
-                          const stats = resolveStats(record, record.status === 'running');
-                          if (!stats) return null;
-                          return (
-                            <div style={{ fontSize: 10, color: 'var(--color-text-tertiary)', marginBottom: 4, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-                              <span>🔧{stats.tool_calls}</span>
-                              <span>💬{stats.conversation_turns}</span>
-                              {stats.thinking_count > 0 && <span>🧠{stats.thinking_count}</span>}
-                            </div>
-                          );
-                        })()}
-                        <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
-                          {hasLogsStatic(record) && (
-                            <Button size="small" icon={<FileTextOutlined />} onClick={(e) => { e.stopPropagation(); onExport(record); }}>导出</Button>
-                          )}
-                          {record.status === 'running' && (
-                            <Popconfirm title="确定停止？" okText="停止" cancelText="取消" onConfirm={() => onStop(record.id)}>
-                              <Button type="primary" danger size="small" icon={<StopOutlined />}>停止</Button>
-                            </Popconfirm>
-                          )}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            );
-          })}
-          {/* Footer actions */}
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 8, paddingTop: 8, borderTop: '1px solid var(--color-border-light)' }}>
-            {lastRecord.status !== 'running' && supportsResume(lastRecord) && (
-              <Button type="primary" size="small" icon={<MessageOutlined />} onClick={() => onOpenResume(lastRecord)}>继续对话</Button>
+    <div>
+      {/* Main record card */}
+      <div className={`history-card history-card-${mainRecord.status}`}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8, flexWrap: 'wrap', gap: 8 }}>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+            <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+              {formatLocalDateTime(mainRecord.started_at)}
+            </span>
+            {mainRecord.executor && <ExecutorBadge executor={mainRecord.executor} />}
+            {mainRecord.model && <Tag color="#3b82f6">{mainRecord.model}</Tag>}
+            {mainRecord.usage?.duration_ms && (
+              <span style={{ fontSize: 11, color: 'var(--color-success)', fontWeight: 600 }}>
+                {(mainRecord.usage.duration_ms / 1000).toFixed(2)}s
+              </span>
             )}
           </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{
+              fontSize: 11, padding: '3px 12px', borderRadius: 12,
+              backgroundColor: mainRecord.status === 'success' ? 'var(--color-success)' : mainRecord.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
+              color: '#fff', fontWeight: 600,
+            }}>
+              {mainRecord.status === 'success' ? '成功' : mainRecord.status === 'failed' ? '失败' : '进行中'}
+            </span>
+          </div>
         </div>
-      )}
+        {mainRecord.result && (
+          <div className={`history-result ${mainRecord.status === 'success' ? 'history-result-success' : 'history-result-failed'}`}>
+            <XMarkdown content={mainRecord.result} />
+          </div>
+        )}
+      </div>
+
+      {/* Indented continuation entries */}
+      {continuations.map((record, idx) => {
+        const isLast = idx === continuations.length - 1;
+        const isExpanded = expandedId === record.id;
+        return (
+          <div key={record.id} style={{
+            marginLeft: 14,
+            borderLeft: '2px solid var(--color-primary)',
+            paddingLeft: 10,
+            marginTop: 4,
+          }}>
+            {/* Continuation header — clickable to expand */}
+            <div
+              onClick={() => setExpandedId(isExpanded ? null : record.id)}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                padding: '6px 8px',
+                borderRadius: 6,
+                background: isExpanded ? 'var(--color-primary-bg)' : 'var(--color-bg-elevated)',
+                cursor: 'pointer',
+                border: '1px solid var(--color-border-light)',
+                transition: 'background 0.15s',
+              }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+                <LinkOutlined style={{ fontSize: 11, color: 'var(--color-primary)', flexShrink: 0 }} />
+                <span style={{ fontSize: 11, color: 'var(--color-text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {record.resume_message || '继续对话'}
+                </span>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+                <span style={{ fontSize: 9, color: 'var(--color-text-tertiary)' }}>
+                  {formatLocalDateTime(record.started_at).split(' ')[1] || formatLocalDateTime(record.started_at)}
+                </span>
+                {record.usage?.duration_ms && (
+                  <span style={{ fontSize: 9, color: 'var(--color-success)', fontWeight: 600 }}>
+                    {(record.usage.duration_ms / 1000).toFixed(1)}s
+                  </span>
+                )}
+                <span style={{
+                  fontSize: 9, padding: '1px 6px', borderRadius: 8,
+                  backgroundColor: record.status === 'success' ? 'var(--color-success)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
+                  color: '#fff', fontWeight: 600,
+                }}>
+                  {record.status === 'success' ? '✓' : record.status === 'failed' ? '✗' : '...'}
+                </span>
+                {isExpanded ? <UpOutlined style={{ fontSize: 9, color: 'var(--color-text-tertiary)' }} /> : <DownOutlined style={{ fontSize: 9, color: 'var(--color-text-tertiary)' }} />}
+              </div>
+            </div>
+            {/* Expanded detail */}
+            {isExpanded && (
+              <div style={{
+                marginTop: 4, padding: '8px 10px',
+                background: 'var(--color-bg-elevated)', borderRadius: 6,
+                border: '1px solid var(--color-border-light)',
+              }}>
+                {record.result && (
+                  <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`} style={{ marginBottom: 6 }}>
+                    <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
+                      <Button type="text" size="small" icon={<CopyOutlined />} onClick={async () => {
+                        try { await navigator.clipboard.writeText(record.result || ''); messageApi.success('已复制'); }
+                        catch { messageApi.error('复制失败'); }
+                      }} />
+                    </div>
+                    <XMarkdown content={record.result} />
+                  </div>
+                )}
+                {record.usage && (
+                  <div style={{ fontSize: 10, color: 'var(--color-text-tertiary)', marginBottom: 4, display: 'flex', gap: 8 }}>
+                    <span>In: {record.usage.input_tokens.toLocaleString()}</span>
+                    <span>Out: {record.usage.output_tokens.toLocaleString()}</span>
+                    {record.usage.total_cost_usd !== null && (
+                      <span style={{ color: 'var(--color-warning)', fontWeight: 600 }}>${record.usage.total_cost_usd.toFixed(6)}</span>
+                    )}
+                  </div>
+                )}
+                <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                  {hasLogsStatic(record) && (
+                    <Button size="small" icon={<FileTextOutlined />} onClick={() => onExport(record)}>导出</Button>
+                  )}
+                  {record.status === 'running' && (
+                    <Popconfirm title="确定停止？" okText="停止" cancelText="取消" onConfirm={() => onStop(record.id)}>
+                      <Button type="primary" danger size="small" icon={<StopOutlined />}>停止</Button>
+                    </Popconfirm>
+                  )}
+                </div>
+              </div>
+            )}
+            {/* Continue button on last continuation */}
+            {isLast && record.status !== 'running' && supportsResume(record) && (
+              <div style={{ marginTop: 6, display: 'flex', justifyContent: 'flex-end' }}>
+                <Button type="primary" size="small" icon={<MessageOutlined />} onClick={() => onOpenResume(record)}>继续对话</Button>
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -385,9 +385,29 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
     if (!selectedTodo) return;
     try {
       const pageData = await db.getExecutionRecords(selectedTodo.id, page, limit);
+
+      // Fetch complete session chains to avoid splitting sessions across pages
+      const sessionIds = [...new Set(
+        pageData.records
+          .filter(r => r.session_id)
+          .map(r => r.session_id!)
+      )];
+
+      let completeRecords = pageData.records;
+      if (sessionIds.length > 0) {
+        const sessionRecordsArrays = await Promise.all(
+          sessionIds.map(sid => db.getExecutionRecordsBySession(sid))
+        );
+        const sessionRecords = sessionRecordsArrays.flat();
+        // Merge: page records + additional session records not already in page
+        const pageIds = new Set(pageData.records.map(r => r.id));
+        const additional = sessionRecords.filter(r => !pageIds.has(r.id));
+        completeRecords = [...pageData.records, ...additional];
+      }
+
       dispatch({
         type: 'SET_EXECUTION_RECORDS',
-        payload: { todoId: selectedTodo.id, records: pageData.records }
+        payload: { todoId: selectedTodo.id, records: completeRecords }
       });
       setHistoryPage(pageData.page);
       setHistoryLimit(pageData.limit);
@@ -1104,6 +1124,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                   viewMode={viewMode}
                   parseLogs={parseRecordLogs}
                   onRefresh={refreshSingleRecord}
+                  resolveStats={resolveExecutionStats}
                 />
               );
             })}
@@ -1285,7 +1306,7 @@ function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, o
 }
 
 /** Narrow mode: chain group card — main record with indented continuations */
-function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, viewMode, parseLogs, onRefresh }: {
+function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, viewMode, parseLogs, onRefresh, resolveStats }: {
   group: SessionGroup;
   onOpenResume: (r: ExecutionRecord) => void;
   onExport: (r: ExecutionRecord) => void;
@@ -1294,6 +1315,7 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
   viewMode: 'log' | 'chat';
   parseLogs: (r: ExecutionRecord) => LogEntry[];
   onRefresh: (id: number) => Promise<void>;
+  resolveStats: (r: ExecutionRecord, running: boolean) => ExecutionStats | null | undefined;
 }) {
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const mainRecord = group.records[0];
@@ -1310,6 +1332,9 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
             </span>
             {mainRecord.executor && <ExecutorBadge executor={mainRecord.executor} />}
             {mainRecord.model && <Tag color="#3b82f6">{mainRecord.model}</Tag>}
+            <Tag color={mainRecord.trigger_type === 'cron' ? '#8b5cf6' : '#6b7280'} style={{ fontSize: 10 }}>
+              {mainRecord.trigger_type === 'cron' ? 'Cron' : '手动'}
+            </Tag>
             {mainRecord.usage?.duration_ms && (
               <span style={{ fontSize: 11, color: 'var(--color-success)', fontWeight: 600 }}>
                 {(mainRecord.usage.duration_ms / 1000).toFixed(2)}s
@@ -1324,13 +1349,54 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
             }}>
               {mainRecord.status === 'success' ? '成功' : mainRecord.status === 'failed' ? '失败' : '进行中'}
             </span>
+            {mainRecord.status !== 'running' && supportsResume(mainRecord) && (
+              <Button type="primary" size="small" icon={<MessageOutlined />} onClick={() => onOpenResume(mainRecord)}>继续对话</Button>
+            )}
+            {hasLogsStatic(mainRecord) && (
+              <Button size="small" icon={<FileTextOutlined />} onClick={() => onExport(mainRecord)}>导出YAML</Button>
+            )}
+            {mainRecord.status === 'running' && (
+              <Popconfirm title="确定强制停止该任务？" okText="停止" cancelText="取消" onConfirm={() => onStop(mainRecord.id)}>
+                <Button type="primary" danger size="small" icon={<StopOutlined />}>停止</Button>
+              </Popconfirm>
+            )}
           </div>
         </div>
+        {mainRecord.command && (
+          <div style={{ fontSize: 11, color: 'var(--color-text-quaternary)', marginBottom: 8, fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {mainRecord.command}
+          </div>
+        )}
+        {(() => {
+          const tl = logsToTimelineRecords(mainRecord);
+          if (tl.length === 0) return null;
+          return <TimelineFlow records={tl} height={16} containerStyle={{ marginBottom: 8 }} />;
+        })()}
         {mainRecord.result && (
           <div className={`history-result ${mainRecord.status === 'success' ? 'history-result-success' : 'history-result-failed'}`}>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
+              <Button type="text" size="small" icon={<CopyOutlined />} onClick={async () => {
+                try { await navigator.clipboard.writeText(mainRecord.result || ''); messageApi.success('已复制到剪贴板'); }
+                catch { messageApi.error('复制失败'); }
+              }} />
+            </div>
             <XMarkdown content={mainRecord.result} />
           </div>
         )}
+        {(() => {
+          const stats = resolveStats(mainRecord, mainRecord.status === 'running');
+          if (!stats) return null;
+          return (
+            <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 8, display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+              <span>工具调用: <b style={{ color: 'var(--color-primary)' }}>{stats.tool_calls}</b></span>
+              <span>对话轮次: <b style={{ color: 'var(--color-primary)' }}>{stats.conversation_turns}</b></span>
+              {stats.thinking_count > 0 && (
+                <span>思考次数: <b style={{ color: 'var(--color-primary)' }}>{stats.thinking_count}</b></span>
+              )}
+            </div>
+          );
+        })()}
+        {renderNarrowLogs(mainRecord, mainRecord.status === 'running', parseLogs(mainRecord), null, viewMode, onRefresh)}
       </div>
 
       {/* Indented continuation entries */}

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+
+export function useIsMobile(threshold = 768): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < threshold);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, [threshold]);
+  return isMobile;
+}

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -72,6 +72,7 @@ export interface ExecutionRecord {
   session_id?: string | null;
   todo_progress?: string | null;
   execution_stats?: ExecutionStats | null;
+  resume_message?: string | null;
 }
 
 export interface ExecutionUsage {

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -100,6 +100,10 @@ export async function getExecutionRecord(recordId: number): Promise<ExecutionRec
   return unwrap(await api.get<ApiResp<ExecutionRecord>>(`/xyz/execution-records/${recordId}`));
 }
 
+export async function getExecutionRecordsBySession(sessionId: string): Promise<ExecutionRecord[]> {
+  return unwrap(await api.get<ApiResp<ExecutionRecord[]>>(`/xyz/execution-records/session/${encodeURIComponent(sessionId)}`));
+}
+
 export async function executeTodo(todoId: number, message: string, executor?: string): Promise<{ task_id: string }> {
   return unwrap(await api.post<ApiResp<{ task_id: string }>>('/xyz/execute', { todo_id: todoId, message, executor }));
 }


### PR DESCRIPTION
## Summary
- 同一 session_id 的执行记录以缩进形式显示，形成自然的对话接续感
- 后端新增 `resume_message` 字段，继续对话时保存用户输入的消息
- 宽屏：主记录下方缩进显示接续条目（🔗 + resume_message），右侧详情面板显示"继续自"导航
- 窄屏：主卡片下方缩进显示可展开的接续条目，支持日志/对话视图
- 移除合并开关，同 session_id 记录始终以缩进形式显示

## Test plan
- [ ] 打开有执行记录的 Todo，确认独立记录正常显示
- [ ] 点击"继续对话"，确认新记录以缩进形式挂在原记录下方
- [ ] 确认接续条目显示用户输入的 resume_message
- [ ] 宽屏：点击接续条目，右侧详情面板顶部显示"继续自"导航
- [ ] 窄屏：点击接续条目展开，确认可查看日志/对话视图