### PR TITLE
feat: 执行日志实时持久化

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -175,6 +175,16 @@ impl Database {
         self.exec_update(am).await
     }
 
+    /// 更新执行记录的 logs 字段（定时批量写入，防止崩溃丢失）
+    pub async fn update_execution_record_logs(&self, id: i64, logs_json: &str) -> Result<(), sea_orm::DbErr> {
+        let am = execution_records::ActiveModel {
+            id: ActiveValue::Unchanged(id),
+            logs: ActiveValue::Set(Some(logs_json.to_string())),
+            ..Default::default()
+        };
+        self.exec_update(am).await
+    }
+
     /// 根据 pid 获取执行记录
     pub async fn get_execution_record_by_pid(&self, pid: i32) -> Option<execution_records::Model> {
         execution_records::Entity::find()

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -189,6 +189,7 @@ pub async fn run_todo_execution(
         let logs = Arc::new(Mutex::new(Vec::<ParsedLogEntry>::new()));
         let logs_for_db = logs.clone();
         let logs_for_result = logs.clone();
+        let flush_pending = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         let executor_for_parse = executor_spawn.clone();
 
@@ -200,6 +201,7 @@ pub async fn run_todo_execution(
             let logs_for_db = logs_for_db.clone();
             let db_for_todo = db_clone.clone();
             let rid = record_id;
+            let flush_pending_for_stdout = flush_pending.clone();
 
             Some(tokio::spawn(async move {
                 let mut reader = BufReader::new(stdout_reader).lines();
@@ -251,6 +253,18 @@ pub async fn run_todo_execution(
                         }
 
                         logs_for_db.lock().await.push(parsed.clone());
+                        if !flush_pending_for_stdout.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                            let snapshot = logs_for_db.lock().await.clone();
+                            let db_flush = db_for_todo.clone();
+                            let rid_flush = rid;
+                            let fp = flush_pending_for_stdout.clone();
+                            tokio::spawn(async move {
+                                if let Ok(json) = serde_json::to_string(&snapshot) {
+                                    let _ = db_flush.update_execution_record_logs(rid_flush, &json).await;
+                                }
+                                fp.store(false, std::sync::atomic::Ordering::Relaxed);
+                            });
+                        }
                         send_event(&tx_clone, ExecEvent::Output { task_id: tid.clone(), entry: parsed });
                     }
                 }
@@ -264,6 +278,9 @@ pub async fn run_todo_execution(
         let stderr_tid = task_id.clone();
         let logs_for_stderr = logs.clone();
         let executor_for_stderr = executor_spawn.clone();
+        let db_for_stderr = db_clone.clone();
+        let rid_for_stderr = record_id;
+        let flush_for_stderr = flush_pending.clone();
         let stderr_task = if let Some(stderr_reader) = stderr_handle {
             Some(tokio::spawn(async move {
                 let mut reader = BufReader::new(stderr_reader).lines();
@@ -274,6 +291,18 @@ pub async fn run_todo_execution(
                         ParsedLogEntry::stderr(line.clone())
                     };
                     logs_for_stderr.lock().await.push(entry.clone());
+                    if !flush_for_stderr.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                        let snapshot = logs_for_stderr.lock().await.clone();
+                        let db_flush = db_for_stderr.clone();
+                        let rid_flush = rid_for_stderr;
+                        let fp = flush_for_stderr.clone();
+                        tokio::spawn(async move {
+                            if let Ok(json) = serde_json::to_string(&snapshot) {
+                                let _ = db_flush.update_execution_record_logs(rid_flush, &json).await;
+                            }
+                            fp.store(false, std::sync::atomic::Ordering::Relaxed);
+                        });
+                    }
                     send_event(&stderr_tx, ExecEvent::Output { task_id: stderr_tid.clone(), entry });
                 }
             }))

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -190,6 +190,8 @@ pub async fn run_todo_execution(
         let logs_for_db = logs.clone();
         let logs_for_result = logs.clone();
         let flush_pending = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let unflushed_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        const FLUSH_COUNT_THRESHOLD: u64 = 5;
 
         let executor_for_parse = executor_spawn.clone();
 
@@ -202,6 +204,7 @@ pub async fn run_todo_execution(
             let db_for_todo = db_clone.clone();
             let rid = record_id;
             let flush_pending_for_stdout = flush_pending.clone();
+            let unflushed_for_stdout = unflushed_count.clone();
 
             Some(tokio::spawn(async move {
                 let mut reader = BufReader::new(stdout_reader).lines();
@@ -253,7 +256,9 @@ pub async fn run_todo_execution(
                         }
 
                         logs_for_db.lock().await.push(parsed.clone());
-                        if !flush_pending_for_stdout.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                        let prev = unflushed_for_stdout.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if prev + 1 >= FLUSH_COUNT_THRESHOLD && !flush_pending_for_stdout.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                            unflushed_for_stdout.store(0, std::sync::atomic::Ordering::Relaxed);
                             let snapshot = logs_for_db.lock().await.clone();
                             let db_flush = db_for_todo.clone();
                             let rid_flush = rid;
@@ -281,6 +286,7 @@ pub async fn run_todo_execution(
         let db_for_stderr = db_clone.clone();
         let rid_for_stderr = record_id;
         let flush_for_stderr = flush_pending.clone();
+        let unflushed_for_stderr = unflushed_count.clone();
         let stderr_task = if let Some(stderr_reader) = stderr_handle {
             Some(tokio::spawn(async move {
                 let mut reader = BufReader::new(stderr_reader).lines();
@@ -291,7 +297,9 @@ pub async fn run_todo_execution(
                         ParsedLogEntry::stderr(line.clone())
                     };
                     logs_for_stderr.lock().await.push(entry.clone());
-                    if !flush_for_stderr.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                    let prev = unflushed_for_stderr.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    if prev + 1 >= FLUSH_COUNT_THRESHOLD && !flush_for_stderr.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                        unflushed_for_stderr.store(0, std::sync::atomic::Ordering::Relaxed);
                         let snapshot = logs_for_stderr.lock().await.clone();
                         let db_flush = db_for_stderr.clone();
                         let rid_flush = rid_for_stderr;
@@ -310,11 +318,37 @@ pub async fn run_todo_execution(
             None
         };
 
+        // 定时兜底 flush：每 3 秒检查未刷新条目，有则写库
+        let timer_db = db_clone.clone();
+        let timer_logs = logs.clone();
+        let timer_fp = flush_pending.clone();
+        let timer_uc = unflushed_count.clone();
+        let flush_timer = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(3));
+            loop {
+                interval.tick().await;
+                let n = timer_uc.swap(0, std::sync::atomic::Ordering::Relaxed);
+                if n > 0 && !timer_fp.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                    let snapshot = timer_logs.lock().await.clone();
+                    let db_f = timer_db.clone();
+                    let rid_f = record_id;
+                    let fp = timer_fp.clone();
+                    tokio::spawn(async move {
+                        if let Ok(json) = serde_json::to_string(&snapshot) {
+                            let _ = db_f.update_execution_record_logs(rid_f, &json).await;
+                        }
+                        fp.store(false, std::sync::atomic::Ordering::Relaxed);
+                    });
+                }
+            }
+        });
+
         let status = tokio::select! {
             biased;
             _ = cancel_rx.recv() => {
                 // Cancelled (or channel closed): 使用 command-group 安全杀死整个进程组
                 kill_process_tree(&mut child).await;
+                flush_timer.abort();
 
                 // 收割僵尸进程
                 let _status = child.wait().await;
@@ -349,6 +383,7 @@ pub async fn run_todo_execution(
             }
             status = child.wait() => {
                 // 子进程已自然退出，command-group 的进程组已自动清理
+                flush_timer.abort();
 
                 if let Some(handle) = stdout_task {
                     let _ = handle.await;

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -191,6 +191,7 @@ pub async fn run_todo_execution(
         let logs_for_result = logs.clone();
         let flush_pending = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let unflushed_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let flush_handles: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>> = Arc::new(Mutex::new(Vec::new()));
         const FLUSH_COUNT_THRESHOLD: u64 = 5;
 
         let executor_for_parse = executor_spawn.clone();
@@ -205,6 +206,7 @@ pub async fn run_todo_execution(
             let rid = record_id;
             let flush_pending_for_stdout = flush_pending.clone();
             let unflushed_for_stdout = unflushed_count.clone();
+            let flush_handles_stdout = flush_handles.clone();
 
             Some(tokio::spawn(async move {
                 let mut reader = BufReader::new(stdout_reader).lines();
@@ -263,12 +265,13 @@ pub async fn run_todo_execution(
                             let db_flush = db_for_todo.clone();
                             let rid_flush = rid;
                             let fp = flush_pending_for_stdout.clone();
-                            tokio::spawn(async move {
+                            let h = tokio::spawn(async move {
                                 if let Ok(json) = serde_json::to_string(&snapshot) {
                                     let _ = db_flush.update_execution_record_logs(rid_flush, &json).await;
                                 }
                                 fp.store(false, std::sync::atomic::Ordering::Relaxed);
                             });
+                            flush_handles_stdout.lock().await.push(h);
                         }
                         send_event(&tx_clone, ExecEvent::Output { task_id: tid.clone(), entry: parsed });
                     }
@@ -287,6 +290,7 @@ pub async fn run_todo_execution(
         let rid_for_stderr = record_id;
         let flush_for_stderr = flush_pending.clone();
         let unflushed_for_stderr = unflushed_count.clone();
+        let flush_handles_stderr = flush_handles.clone();
         let stderr_task = if let Some(stderr_reader) = stderr_handle {
             Some(tokio::spawn(async move {
                 let mut reader = BufReader::new(stderr_reader).lines();
@@ -304,12 +308,13 @@ pub async fn run_todo_execution(
                         let db_flush = db_for_stderr.clone();
                         let rid_flush = rid_for_stderr;
                         let fp = flush_for_stderr.clone();
-                        tokio::spawn(async move {
+                        let h = tokio::spawn(async move {
                             if let Ok(json) = serde_json::to_string(&snapshot) {
                                 let _ = db_flush.update_execution_record_logs(rid_flush, &json).await;
                             }
                             fp.store(false, std::sync::atomic::Ordering::Relaxed);
                         });
+                        flush_handles_stderr.lock().await.push(h);
                     }
                     send_event(&stderr_tx, ExecEvent::Output { task_id: stderr_tid.clone(), entry });
                 }
@@ -323,22 +328,29 @@ pub async fn run_todo_execution(
         let timer_logs = logs.clone();
         let timer_fp = flush_pending.clone();
         let timer_uc = unflushed_count.clone();
+        let timer_handles = flush_handles.clone();
         let flush_timer = tokio::spawn(async move {
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(3));
             loop {
                 interval.tick().await;
+                if timer_fp.load(std::sync::atomic::Ordering::Relaxed) {
+                    continue;
+                }
                 let n = timer_uc.swap(0, std::sync::atomic::Ordering::Relaxed);
                 if n > 0 && !timer_fp.swap(true, std::sync::atomic::Ordering::Relaxed) {
                     let snapshot = timer_logs.lock().await.clone();
                     let db_f = timer_db.clone();
                     let rid_f = record_id;
                     let fp = timer_fp.clone();
-                    tokio::spawn(async move {
+                    let h = tokio::spawn(async move {
                         if let Ok(json) = serde_json::to_string(&snapshot) {
                             let _ = db_f.update_execution_record_logs(rid_f, &json).await;
                         }
                         fp.store(false, std::sync::atomic::Ordering::Relaxed);
                     });
+                    timer_handles.lock().await.push(h);
+                } else if n > 0 {
+                    timer_uc.fetch_add(n, std::sync::atomic::Ordering::Relaxed);
                 }
             }
         });
@@ -358,6 +370,11 @@ pub async fn run_todo_execution(
                 }
                 if let Some(handle) = stderr_task {
                     let _ = handle.await;
+                }
+
+                // 等待所有进行中的 flush 任务完成，防止旧快照覆盖
+                for h in flush_handles.lock().await.drain(..) {
+                    let _ = h.await;
                 }
 
                 let _ = db_clone.update_todo_status(todo_id, crate::models::TodoStatus::Cancelled).await;
@@ -412,6 +429,11 @@ pub async fn run_todo_execution(
 
         let all_logs_snapshot = logs_for_result.lock().await.clone();
         let result_str = executor_spawn.get_final_result(&all_logs_snapshot).unwrap_or_default();
+
+        // 等待所有进行中的 flush 任务完成，防止旧快照覆盖最终写入
+        for h in flush_handles.lock().await.drain(..) {
+            let _ = h.await;
+        }
 
         // Extract execution stats from logs
         // tool_calls: tool_use (claudecode), tool_call (kimi), tool (atomcode, opencode)

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -113,8 +113,8 @@ pub async fn stop_execution_handler(
         if !cancelled {
             tracing::warn!("Task {} was not found in task manager (may have already finished)", task_id);
         }
-        // 更新数据库状态为失败
-        let logs_json = serde_json::to_string::<Vec<crate::models::ParsedLogEntry>>(&vec![]).unwrap_or_default();
+        // 更新数据库状态为失败，保留定时刷新已写入的日志
+        let logs_json = record.logs.clone();
         let _ = state.db.update_execution_record(
             req.record_id,
             crate::models::ExecutionStatus::Failed.as_str(),


### PR DESCRIPTION
## Summary
- 将执行日志从进程结束时一次性写库改为每条日志事件实时触发异步写库
- 使用 AtomicBool 节流，确保同一时间只有一个 flush 任务运行
- 修复 stop handler 覆盖已有日志为空的问题

## 改动
- `db/execution.rs`: 新增 `update_execution_record_logs` 单字段更新方法
- `executor_service.rs`: 移除 10 秒定时器，stdout/stderr 每条日志后通过 AtomicBool 触发异步 flush
- `handlers/execution.rs`: stop handler 保留已有日志而非写入空数组

## Test plan
- [ ] 启动一个长时间执行的任务，确认日志实时写入数据库
- [ ] 手动停止任务，确认日志被保留
- [ ] 强制 kill 服务进程，重启后检查日志是否保留了崩溃前已处理的日志