### PR TITLE
fix: JoinAI 时间戳 Invalid Date 及时间线动画重复

### DIFF
--- a/backend/src/adapters/joinai.rs
+++ b/backend/src/adapters/joinai.rs
@@ -69,11 +69,8 @@ impl CodeExecutor for JoinaiExecutor {
         let event: AgentEvent = serde_json::from_str(line).ok()?;
 
         let timestamp = event.timestamp
-            .map(|ts| {
-                let secs = ts / 1000;
-                let millis = ts % 1000;
-                format!("{}.{:03}", secs, millis)
-            })
+            .and_then(|ts| chrono::DateTime::from_timestamp_millis(ts as i64))
+            .map(|dt| dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
             .unwrap_or_else(utc_timestamp);
 
         match event.event_type.as_str() {

--- a/frontend/src/components/TimelineFlow/index.tsx
+++ b/frontend/src/components/TimelineFlow/index.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Tooltip } from 'antd';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 
 export interface TimelineRecord {
   id: string;
@@ -89,9 +89,22 @@ export const TimelineFlow: React.FC<TimelineFlowProps> = ({
   containerStyle,
   renderTooltip,
 }) => {
+  // 用 JSON 序列化做内容比较，避免因引用不同而误触发重绘
+  const recordsKey = useMemo(() => {
+    return records.map(r => r.id).join(',');
+  }, [records]);
+
   const sortedRecords = useMemo(() => {
     return [...records].sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
   }, [records]);
+
+  // 只在 records 的 id 列表真正变化时递增 animKey
+  const [animKey, setAnimKey] = useState(0);
+  const [prevKey, setPrevKey] = useState(recordsKey);
+  if (recordsKey !== prevKey) {
+    setPrevKey(recordsKey);
+    setAnimKey(k => k + 1);
+  }
 
   const mergedColorMap = { ...DEFAULT_COLOR_MAP, ...colorMap };
   const mergedLabelMap = { ...DEFAULT_LABEL_MAP, ...labelMap };
@@ -125,22 +138,20 @@ export const TimelineFlow: React.FC<TimelineFlowProps> = ({
       position: 'relative',
       ...containerStyle,
     }}>
-      <AnimatePresence mode="popLayout">
         {displayRecords.map((record, index) => {
           const role = (record.role || '').toLowerCase();
           const color = mergedColorMap[role] || 'var(--color-text-quaternary, #bfbfbf)';
 
           const motionProps = disabled
-            ? { initial: { x: 0, opacity: 1 }, animate: { x: 0, opacity: 1 }, exit: { opacity: 1, scale: 1 } }
+            ? { initial: { x: 0, opacity: 1 }, animate: { x: 0, opacity: 1 } }
             : {
                 initial: { x: 300, opacity: 0 },
                 animate: { x: 0, opacity: 1 },
-                exit: { opacity: 0, scale: 0 },
               };
 
           const content = (
             <motion.div
-              key={record.id}
+              key={`${animKey}-${record.id}`}
               {...motionProps}
               transition={{
                 type: 'spring', stiffness: 250, damping: 25,
@@ -158,12 +169,11 @@ export const TimelineFlow: React.FC<TimelineFlowProps> = ({
           );
 
           return renderTooltip ? (
-            <Tooltip key={record.id} title={renderTooltip(record)}>{content}</Tooltip>
+            <Tooltip key={`${animKey}-${record.id}`} title={renderTooltip(record)}>{content}</Tooltip>
           ) : (
-            <Tooltip key={record.id} title={formatTooltipContent(record, mergedLabelMap)}>{content}</Tooltip>
+            <Tooltip key={`${animKey}-${record.id}`} title={formatTooltipContent(record, mergedLabelMap)}>{content}</Tooltip>
           );
         })}
-      </AnimatePresence>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- JoinAI 执行器时间戳转换改用 `chrono::DateTime::from_timestamp_millis`，输出 ISO 8601 格式（如 `2026-05-04T12:05:59.656Z`），修复前端显示 Invalid Date
- 移除 TimelineFlow 的 `AnimatePresence` 退出动画，切换执行历史时直接绘制新时间线
- 用 records id 列表做内容比较，只在记录真正变化时才触发动画重播，避免父组件重渲染导致误重绘

## Test plan
- [ ] 新建 JoinAI 执行任务，验证执行历史中时间显示正确（非 Invalid Date）
- [ ] 在不同执行历史间切换，确认时间线直接绘制、无退出动画
- [ ] 观察执行中任务，确认日志更新不会导致时间线动画重复播放