### PR TITLE
feat: 执行历史命令行点击复制

### DIFF
--- a/backend/src/adapters/joinai.rs
+++ b/backend/src/adapters/joinai.rs
@@ -69,11 +69,8 @@ impl CodeExecutor for JoinaiExecutor {
         let event: AgentEvent = serde_json::from_str(line).ok()?;
 
         let timestamp = event.timestamp
-            .map(|ts| {
-                let secs = ts / 1000;
-                let millis = ts % 1000;
-                format!("{}.{:03}", secs, millis)
-            })
+            .and_then(|ts| chrono::DateTime::from_timestamp_millis(ts as i64))
+            .map(|dt| dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
             .unwrap_or_else(utc_timestamp);
 
         match event.event_type.as_str() {

--- a/frontend/src/components/TimelineFlow/index.tsx
+++ b/frontend/src/components/TimelineFlow/index.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Tooltip } from 'antd';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 
 export interface TimelineRecord {
   id: string;
@@ -89,9 +89,22 @@ export const TimelineFlow: React.FC<TimelineFlowProps> = ({
   containerStyle,
   renderTooltip,
 }) => {
+  // 用 JSON 序列化做内容比较，避免因引用不同而误触发重绘
+  const recordsKey = useMemo(() => {
+    return records.map(r => r.id).join(',');
+  }, [records]);
+
   const sortedRecords = useMemo(() => {
     return [...records].sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
   }, [records]);
+
+  // 只在 records 的 id 列表真正变化时递增 animKey
+  const [animKey, setAnimKey] = useState(0);
+  const [prevKey, setPrevKey] = useState(recordsKey);
+  if (recordsKey !== prevKey) {
+    setPrevKey(recordsKey);
+    setAnimKey(k => k + 1);
+  }
 
   const mergedColorMap = { ...DEFAULT_COLOR_MAP, ...colorMap };
   const mergedLabelMap = { ...DEFAULT_LABEL_MAP, ...labelMap };
@@ -125,22 +138,20 @@ export const TimelineFlow: React.FC<TimelineFlowProps> = ({
       position: 'relative',
       ...containerStyle,
     }}>
-      <AnimatePresence mode="popLayout">
         {displayRecords.map((record, index) => {
           const role = (record.role || '').toLowerCase();
           const color = mergedColorMap[role] || 'var(--color-text-quaternary, #bfbfbf)';
 
           const motionProps = disabled
-            ? { initial: { x: 0, opacity: 1 }, animate: { x: 0, opacity: 1 }, exit: { opacity: 1, scale: 1 } }
+            ? { initial: { x: 0, opacity: 1 }, animate: { x: 0, opacity: 1 } }
             : {
                 initial: { x: 300, opacity: 0 },
                 animate: { x: 0, opacity: 1 },
-                exit: { opacity: 0, scale: 0 },
               };
 
           const content = (
             <motion.div
-              key={record.id}
+              key={`${animKey}-${record.id}`}
               {...motionProps}
               transition={{
                 type: 'spring', stiffness: 250, damping: 25,
@@ -158,12 +169,11 @@ export const TimelineFlow: React.FC<TimelineFlowProps> = ({
           );
 
           return renderTooltip ? (
-            <Tooltip key={record.id} title={renderTooltip(record)}>{content}</Tooltip>
+            <Tooltip key={`${animKey}-${record.id}`} title={renderTooltip(record)}>{content}</Tooltip>
           ) : (
-            <Tooltip key={record.id} title={formatTooltipContent(record, mergedLabelMap)}>{content}</Tooltip>
+            <Tooltip key={`${animKey}-${record.id}`} title={formatTooltipContent(record, mergedLabelMap)}>{content}</Tooltip>
           );
         })}
-      </AnimatePresence>
     </div>
   );
 };

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useApp } from '../hooks/useApp';
-import { Button, Empty, App, Popconfirm, Tag, Badge, Pagination, Segmented, Modal, Input } from 'antd';
+import { Button, Empty, App, Popconfirm, Tag, Badge, Pagination, Segmented, Modal, Input, Tooltip } from 'antd';
 import { PlayCircleOutlined, EditOutlined, DeleteOutlined, SettingOutlined, CheckCircleOutlined, ReloadOutlined, CopyOutlined, ArrowLeftOutlined, StopOutlined, DownOutlined, UpOutlined, UnorderedListOutlined, MessageOutlined, FileTextOutlined, LinkOutlined } from '@ant-design/icons';
 import { StatusPicker } from './StatusPicker';
 import { PieChart } from './PieChart';
@@ -976,9 +976,14 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                       </div>
                     </div>
                     {record.command && (
-                      <div style={{ fontSize: 11, color: 'var(--color-text-quaternary)', marginBottom: 12, fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                        {record.command}
-                      </div>
+                      <Tooltip title="点击复制命令">
+                        <div
+                          onClick={() => { navigator.clipboard.writeText(record.command || '').then(() => message.success('已复制')); }}
+                          style={{ fontSize: 11, color: 'var(--color-text-quaternary)', marginBottom: 12, fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', cursor: 'pointer' }}
+                        >
+                          {record.command}
+                        </div>
+                      </Tooltip>
                     )}
                     {(() => {
                       const tl = logsToTimelineRecords(record);
@@ -1258,9 +1263,14 @@ function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, o
         </div>
       </div>
       {record.command && (
-        <div style={{ fontSize: 11, color: 'var(--color-text-quaternary)', marginBottom: 8, fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-          {record.command}
-        </div>
+        <Tooltip title="点击复制命令">
+          <div
+            onClick={() => { navigator.clipboard.writeText(record.command || '').then(() => messageApi.success('已复制')); }}
+            style={{ fontSize: 11, color: 'var(--color-text-quaternary)', marginBottom: 8, fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', cursor: 'pointer' }}
+          >
+            {record.command}
+          </div>
+        </Tooltip>
       )}
       {(() => {
         const tl = logsToTimelineRecords(record);
@@ -1363,9 +1373,14 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
           </div>
         </div>
         {mainRecord.command && (
-          <div style={{ fontSize: 11, color: 'var(--color-text-quaternary)', marginBottom: 8, fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-            {mainRecord.command}
-          </div>
+          <Tooltip title="点击复制命令">
+            <div
+              onClick={() => { navigator.clipboard.writeText(mainRecord.command || '').then(() => messageApi.success('已复制')); }}
+              style={{ fontSize: 11, color: 'var(--color-text-quaternary)', marginBottom: 8, fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', cursor: 'pointer' }}
+            >
+              {mainRecord.command}
+            </div>
+          </Tooltip>
         )}
         {(() => {
           const tl = logsToTimelineRecords(mainRecord);


### PR DESCRIPTION
## Summary
- 执行历史详情页中的命令行增加点击复制功能，点击后复制完整命令并提示"已复制"
- 覆盖三处命令行显示：TodoDetail 主卡片、NarrowHistoryCard、ChainGroupCard

## Test plan
- [ ] 打开任意执行历史详情，点击命令行文字，确认复制了完整命令
- [ ] 确认点击后出现"已复制"提示