### PR TITLE
fix: SQLite 连接添加 busy_timeout

### DIFF
--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -36,7 +36,7 @@ impl Database {
         let url = if path == ":memory:" {
             "sqlite::memory:".to_string()
         } else {
-            format!("sqlite://{}?mode=rwc", path)
+            format!("sqlite://{}?mode=rwc&busy_timeout=5000", path)
         };
 
         let mut opt = ConnectOptions::new(url);


### PR DESCRIPTION
## Summary
- Add `busy_timeout=5000` to SQLite connection URL in `backend/src/db/mod.rs` to prevent `SQLITE_BUSY` errors under concurrent writes.

Closes #96