### PR TITLE
fix: 添加缺失的数据库索引

### DIFF
--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -172,6 +172,17 @@ impl Database {
         )
         .await.ok(); // 忽略错误，因为字段可能已存在
 
+        // --- Indexes for frequently-filtered columns ---
+        self.exec("CREATE INDEX IF NOT EXISTS idx_todos_deleted_at ON todos(deleted_at)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_todos_status ON todos(status)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_todos_task_id ON todos(task_id)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_execution_records_todo_id ON execution_records(todo_id)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_execution_records_task_id ON execution_records(task_id)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_execution_records_pid ON execution_records(pid)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_execution_records_session_id ON execution_records(session_id)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_execution_records_status ON execution_records(status)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_todo_tags_todo_id ON todo_tags(todo_id)").await?;
+
         // Trigger: fill created_at with UTC time on INSERT if not set
         self.exec(
             "CREATE TRIGGER IF NOT EXISTS set_todos_created_at_utc AFTER INSERT ON todos


### PR DESCRIPTION
## Summary
- 在 `init_tables` 中为频繁过滤的数据库列添加 9 个 `CREATE INDEX IF NOT EXISTS` 语句
- 覆盖 `todos(deleted_at, status, task_id)`、`execution_records(todo_id, task_id, pid, session_id, status)` 和 `todo_tags(todo_id)` 上的索引
- 使用与现有 CREATE TABLE 语句相同的 `self.exec()` 模式

Closes #90