### PR TITLE
fix: 数据库操作错误不再静默吞掉

### DIFF
--- a/backend/src/db/tag.rs
+++ b/backend/src/db/tag.rs
@@ -48,7 +48,7 @@ impl Database {
             todo_id: ActiveValue::Set(todo_id),
             tag_id: ActiveValue::Set(tag_id),
         };
-        let _ = todo_tags::Entity::insert(am)
+        if let Err(e) = todo_tags::Entity::insert(am)
             .on_conflict(
                 sea_orm::sea_query::OnConflict::columns([
                     todo_tags::Column::TodoId,
@@ -58,12 +58,15 @@ impl Database {
                 .to_owned(),
             )
             .exec(&self.conn)
-            .await;
+            .await
+        {
+            tracing::warn!("Failed to add tag {} to todo {}: {}", tag_id, todo_id, e);
+        }
     }
 
     pub async fn set_todo_tags(&self, todo_id: i64, tag_ids: &[i64]) {
         let tag_ids = tag_ids.to_vec();
-        let _ = self
+        if let Err(e) = self
             .conn
             .transaction::<_, (), sea_orm::DbErr>(|txn| {
                 Box::pin(async move {
@@ -99,7 +102,10 @@ impl Database {
                     Ok(())
                 })
             })
-            .await;
+            .await
+        {
+            tracing::warn!("Failed to set tags for todo {}: {}", todo_id, e);
+        }
     }
 
     pub async fn get_tag_backups(&self) -> Vec<TagBackup> {

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -54,7 +54,9 @@ pub async fn create_todo(
 
     // Update executor if specified
     if let Some(ref exec) = req.executor {
-        state.db.update_todo_executor(id, exec).await.ok();
+        if let Err(e) = state.db.update_todo_executor(id, exec).await {
+            tracing::warn!("Failed to update executor for todo {}: {}", id, e);
+        }
     }
 
     for tag_id in &req.tag_ids {
@@ -140,7 +142,7 @@ pub async fn delete_todo(
     State(state): State<AppState>,
     Path(id): Path<i64>,
 ) -> Result<ApiResponse<()>, AppError> {
-    let _ = state.db.delete_todo(id).await;
+    state.db.delete_todo(id).await.map_err(AppError::from)?;
     Ok(ApiResponse::ok(()))
 }
 
@@ -150,7 +152,7 @@ pub async fn force_update_todo_status(
     ApiJson(req): ApiJson<UpdateTodoRequest>,
 ) -> Result<ApiResponse<Todo>, AppError> {
     if let Some(status) = req.status {
-        let _ = state.db.force_update_todo_status(id, status).await;
+        state.db.force_update_todo_status(id, status).await.map_err(AppError::from)?;
     }
     let todo = state.require_todo(id).await?;
     Ok(ApiResponse::ok(todo))


### PR DESCRIPTION
## Summary
- Replace `let _ =` silent error swallowing with proper error handling
- `db/tag.rs`: `add_todo_tag` and `set_todo_tags` now log errors via `tracing::warn!`
- `handlers/todo.rs`: `delete_todo` and `force_update_todo_status` now propagate errors to the caller; `update_todo_executor` logs failures

Closes #84

## Test plan
- [x] `cargo check` passes
- [ ] Manual testing: delete a todo, verify errors are returned instead of silently ignored
- [ ] Manual testing: add tags to a todo, verify warning logs on failure