### PR TITLE
fix: 清理未使用的死代码

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -185,15 +185,6 @@ impl Database {
         self.exec_update(am).await
     }
 
-    /// 根据 pid 获取执行记录
-    pub async fn get_execution_record_by_pid(&self, pid: i32) -> Option<execution_records::Model> {
-        execution_records::Entity::find()
-            .filter(execution_records::Column::Pid.eq(pid))
-            .one(&self.conn)
-            .await
-            .unwrap_or_default()
-    }
-
     /// 根据 session_id 获取所有执行记录（按 started_at 排序）
     pub async fn get_execution_records_by_session(&self, session_id: &str) -> Vec<ExecutionRecord> {
         execution_records::Entity::find()
@@ -205,27 +196,6 @@ impl Database {
             .into_iter()
             .map(Into::into)
             .collect()
-    }
-
-    /// 根据 pid 停止执行记录
-    pub async fn stop_execution_by_pid(&self, pid: i32) -> Result<bool, sea_orm::DbErr> {
-        if let Some(record) = self.get_execution_record_by_pid(pid).await {
-            // 只更新这一条执行记录，不影响 todo 的状态
-            let now = crate::models::utc_timestamp();
-            let am = execution_records::ActiveModel {
-                id: ActiveValue::Unchanged(record.id),
-                status: ActiveValue::Set(Some(crate::models::ExecutionStatus::Failed.as_str().to_string())),
-                finished_at: ActiveValue::Set(Some(now)),
-                result: ActiveValue::Set(Some("任务已被手动停止".to_string())),
-                pid: ActiveValue::Set(None),
-                ..Default::default()
-            };
-            self.exec_update(am).await?;
-
-            tracing::info!("Stopped execution record {} with pid {}", record.id, pid);
-            return Ok(true);
-        }
-        Ok(false)
     }
 
     pub async fn get_dashboard_stats(&self) -> crate::models::DashboardStats {
@@ -599,30 +569,4 @@ impl Database {
         }
     }
 
-    /// 标记指定todo的所有running状态执行记录为failed
-    pub async fn mark_execution_records_as_failed(&self, todo_id: i64) {
-        let now = crate::models::utc_timestamp();
-        let backend = self.conn.get_database_backend();
-        let sql = "UPDATE execution_records SET \
-                status = 'failed', \
-                finished_at = $1, \
-                result = '任务已被手动停止' \
-                WHERE todo_id = $2 AND status = 'running'";
-        let result = self.conn.execute(Statement::from_sql_and_values(backend, sql, [now.into(), todo_id.into()])).await;
-        match result {
-            Ok(res) => {
-                let rows = res.rows_affected();
-                if rows > 0 {
-                    tracing::warn!(
-                        "Marked {} running execution records as failed for todo {}",
-                        rows,
-                        todo_id
-                    );
-                }
-            }
-            Err(e) => {
-                tracing::error!("Failed to mark execution records as failed for todo {}: {}", todo_id, e);
-            }
-        }
-    }
 }

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -404,29 +404,6 @@ impl Database {
             .collect()
     }
 
-    /// 获取指定 todo 列表中涉及的所有 tag 备份数据
-    pub async fn get_tag_backups_for_todos(&self, ids: &[i64]) -> Vec<crate::models::TagBackup> {
-        if ids.is_empty() {
-            return Vec::new();
-        }
-        let tag_map = self.fetch_tag_ids_for_many(ids).await;
-        let tag_ids: std::collections::HashSet<i64> = tag_map.values().flat_map(|v| v.iter()).copied().collect();
-        if tag_ids.is_empty() {
-            return Vec::new();
-        }
-        tags::Entity::find()
-            .filter(tags::Column::Id.is_in(tag_ids.into_iter().collect::<Vec<_>>()))
-            .all(&self.conn)
-            .await
-            .unwrap_or_default()
-            .into_iter()
-            .map(|t| crate::models::TagBackup {
-                name: t.name,
-                color: t.color.unwrap_or_default(),
-            })
-            .collect()
-    }
-
     /// 从备份数据导入 todo（清空现有数据后导入，失败时自动回滚）
     pub async fn import_backup(&self, tags_in: &[crate::models::TagBackup], todos_in: &[TodoBackup]) -> Result<(), sea_orm::DbErr> {
         use sea_orm::TransactionTrait;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
-use clap::{Parser, Subcommand, ValueEnum};
-use serde::{Deserialize, Serialize};
+use clap::{Parser, Subcommand};
 use tokio::sync::broadcast;
 use tracing::info;
 
@@ -16,7 +15,7 @@ struct Cli {
 
     /// Output format
     #[arg(short, long, default_value = "json", value_enum)]
-    output: OutputFormat,
+    output: cli::OutputFormat,
 
     /// Select fields to output (comma-separated, e.g. "id,title,status")
     #[arg(short, long)]
@@ -24,16 +23,6 @@ struct Cli {
 
     #[command(subcommand)]
     command: Option<Commands>,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum OutputFormat {
-    #[default]
-    Json,
-    Pretty,
-    /// Output raw data without ApiResponse wrapper (best for AI parsing)
-    Raw,
 }
 
 #[derive(Subcommand)]
@@ -115,7 +104,7 @@ async fn main() {
         Some(Commands::Todo { action }) => {
             let cli = cli::Cli {
                 server: cli.server.clone(),
-                output: output_to_cli(&cli.output),
+                output: cli.output,
                 fields: cli.fields.clone(),
                 command: cli::Commands::Todo { action: action.clone() },
             };
@@ -128,7 +117,7 @@ async fn main() {
         Some(Commands::Tag { action }) => {
             let cli = cli::Cli {
                 server: cli.server.clone(),
-                output: output_to_cli(&cli.output),
+                output: cli.output,
                 fields: cli.fields.clone(),
                 command: cli::Commands::Tag { action: action.clone() },
             };
@@ -141,7 +130,7 @@ async fn main() {
         Some(Commands::Stats) => {
             let cli = cli::Cli {
                 server: cli.server.clone(),
-                output: output_to_cli(&cli.output),
+                output: cli.output,
                 fields: cli.fields.clone(),
                 command: cli::Commands::Stats,
             };
@@ -156,14 +145,6 @@ async fn main() {
             println!("Starting ntd server...");
             run_server(None).await;
         }
-    }
-}
-
-fn output_to_cli(output: &OutputFormat) -> cli::OutputFormat {
-    match output {
-        OutputFormat::Json => cli::OutputFormat::Json,
-        OutputFormat::Pretty => cli::OutputFormat::Pretty,
-        OutputFormat::Raw => cli::OutputFormat::Raw,
     }
 }
 


### PR DESCRIPTION
## Summary
- 移除未使用的函数 `get_tag_backups_for_todos` (db/todo.rs)
- 移除未使用的函数 `get_execution_record_by_pid`、`stop_execution_by_pid`、`mark_execution_records_as_failed` (db/execution.rs)
- 移除 main.rs 中重复的 `OutputFormat` 枚举，统一使用 `cli::commands` 中的定义，消除冗余的 `output_to_cli` 转换函数

Closes #89