### PR TITLE
fix: 执行日志 flush 后清空已写入条目

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -121,11 +121,27 @@ impl Database {
         usage: Option<&ExecutionUsage>,
         model: Option<&str>,
     ) -> Result<(), sea_orm::DbErr> {
+        // Merge new logs with existing logs in DB (since periodic flush may have drained in-memory vec)
+        let existing: Option<String> = execution_records::Entity::find_by_id(id)
+            .one(&self.conn)
+            .await?
+            .and_then(|r| r.logs);
+
+        let merged_logs = match existing {
+            Some(ref json) if !json.is_empty() && json != "[]" => {
+                let mut base: Vec<serde_json::Value> = serde_json::from_str(json).unwrap_or_default();
+                let append: Vec<serde_json::Value> = serde_json::from_str(logs).unwrap_or_default();
+                base.extend(append);
+                serde_json::to_string(&base).unwrap_or_else(|_| logs.to_string())
+            }
+            _ => logs.to_string(),
+        };
+
         let now = crate::models::utc_timestamp();
         let am = execution_records::ActiveModel {
             id: ActiveValue::Unchanged(id),
             status: ActiveValue::Set(Some(status.to_string())),
-            logs: ActiveValue::Set(Some(logs.to_string())),
+            logs: ActiveValue::Set(Some(merged_logs)),
             result: ActiveValue::Set(Some(result.to_string())),
             usage: ActiveValue::Set(usage.map(|u| serde_json::to_string(u).unwrap_or_else(|e| { tracing::error!("Failed to serialize usage: {}", e); String::new() }))),
             model: ActiveValue::Set(model.map(|s| s.to_string())),
@@ -175,11 +191,26 @@ impl Database {
         self.exec_update(am).await
     }
 
-    /// 更新执行记录的 logs 字段（定时批量写入，防止崩溃丢失）
-    pub async fn update_execution_record_logs(&self, id: i64, logs_json: &str) -> Result<(), sea_orm::DbErr> {
+    /// 追加日志条目到执行记录（读取已有日志 + 合并新条目 + 写回，防止覆盖）
+    pub async fn append_execution_record_logs(&self, id: i64, new_logs_json: &str) -> Result<(), sea_orm::DbErr> {
+        let existing: Option<String> = execution_records::Entity::find_by_id(id)
+            .one(&self.conn)
+            .await?
+            .and_then(|r| r.logs);
+
+        let merged = match existing {
+            Some(ref json) if !json.is_empty() && json != "[]" => {
+                let mut base: Vec<serde_json::Value> = serde_json::from_str(json).unwrap_or_default();
+                let append: Vec<serde_json::Value> = serde_json::from_str(new_logs_json).unwrap_or_default();
+                base.extend(append);
+                serde_json::to_string(&base).unwrap_or_else(|_| new_logs_json.to_string())
+            }
+            _ => new_logs_json.to_string(),
+        };
+
         let am = execution_records::ActiveModel {
             id: ActiveValue::Unchanged(id),
-            logs: ActiveValue::Set(Some(logs_json.to_string())),
+            logs: ActiveValue::Set(Some(merged)),
             ..Default::default()
         };
         self.exec_update(am).await

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -200,8 +200,20 @@ impl Database {
 
         let merged = match existing {
             Some(ref json) if !json.is_empty() && json != "[]" => {
-                let mut base: Vec<serde_json::Value> = serde_json::from_str(json).unwrap_or_default();
-                let append: Vec<serde_json::Value> = serde_json::from_str(new_logs_json).unwrap_or_default();
+                let mut base: Vec<serde_json::Value> = match serde_json::from_str(json) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::warn!("Failed to parse existing logs JSON for record {}: {}", id, e);
+                        Vec::new()
+                    }
+                };
+                let append: Vec<serde_json::Value> = match serde_json::from_str(new_logs_json) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        tracing::warn!("Failed to parse new logs JSON for record {}: {}", id, e);
+                        Vec::new()
+                    }
+                };
                 base.extend(append);
                 serde_json::to_string(&base).unwrap_or_else(|_| new_logs_json.to_string())
             }

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -261,13 +261,13 @@ pub async fn run_todo_execution(
                         let prev = unflushed_for_stdout.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         if prev + 1 >= FLUSH_COUNT_THRESHOLD && !flush_pending_for_stdout.swap(true, std::sync::atomic::Ordering::Relaxed) {
                             unflushed_for_stdout.store(0, std::sync::atomic::Ordering::Relaxed);
-                            let snapshot = logs_for_db.lock().await.clone();
+                            let snapshot = std::mem::take(&mut *logs_for_db.lock().await);
                             let db_flush = db_for_todo.clone();
                             let rid_flush = rid;
                             let fp = flush_pending_for_stdout.clone();
                             let h = tokio::spawn(async move {
                                 if let Ok(json) = serde_json::to_string(&snapshot) {
-                                    let _ = db_flush.update_execution_record_logs(rid_flush, &json).await;
+                                    let _ = db_flush.append_execution_record_logs(rid_flush, &json).await;
                                 }
                                 fp.store(false, std::sync::atomic::Ordering::Relaxed);
                             });
@@ -304,13 +304,13 @@ pub async fn run_todo_execution(
                     let prev = unflushed_for_stderr.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     if prev + 1 >= FLUSH_COUNT_THRESHOLD && !flush_for_stderr.swap(true, std::sync::atomic::Ordering::Relaxed) {
                         unflushed_for_stderr.store(0, std::sync::atomic::Ordering::Relaxed);
-                        let snapshot = logs_for_stderr.lock().await.clone();
+                        let snapshot = std::mem::take(&mut *logs_for_stderr.lock().await);
                         let db_flush = db_for_stderr.clone();
                         let rid_flush = rid_for_stderr;
                         let fp = flush_for_stderr.clone();
                         let h = tokio::spawn(async move {
                             if let Ok(json) = serde_json::to_string(&snapshot) {
-                                let _ = db_flush.update_execution_record_logs(rid_flush, &json).await;
+                                let _ = db_flush.append_execution_record_logs(rid_flush, &json).await;
                             }
                             fp.store(false, std::sync::atomic::Ordering::Relaxed);
                         });
@@ -338,13 +338,13 @@ pub async fn run_todo_execution(
                 }
                 let n = timer_uc.swap(0, std::sync::atomic::Ordering::Relaxed);
                 if n > 0 && !timer_fp.swap(true, std::sync::atomic::Ordering::Relaxed) {
-                    let snapshot = timer_logs.lock().await.clone();
+                    let snapshot = std::mem::take(&mut *timer_logs.lock().await);
                     let db_f = timer_db.clone();
                     let rid_f = record_id;
                     let fp = timer_fp.clone();
                     let h = tokio::spawn(async move {
                         if let Ok(json) = serde_json::to_string(&snapshot) {
-                            let _ = db_f.update_execution_record_logs(rid_f, &json).await;
+                            let _ = db_f.append_execution_record_logs(rid_f, &json).await;
                         }
                         fp.store(false, std::sync::atomic::Ordering::Relaxed);
                     });
@@ -427,13 +427,22 @@ pub async fn run_todo_execution(
             }
         }
 
-        let all_logs_snapshot = logs_for_result.lock().await.clone();
-        let result_str = executor_spawn.get_final_result(&all_logs_snapshot).unwrap_or_default();
-
         // 等待所有进行中的 flush 任务完成，防止旧快照覆盖最终写入
         for h in flush_handles.lock().await.drain(..) {
             let _ = h.await;
         }
+
+        // 从数据库读取完整的日志集（因为定期 flush 会 drain 内存中的 vec）
+        let remaining = std::mem::take(&mut *logs_for_result.lock().await);
+        let all_logs_snapshot = match db_clone.get_execution_record(record_id).await {
+            Some(record) if !record.logs.is_empty() && record.logs != "[]" => {
+                let mut base: Vec<ParsedLogEntry> = serde_json::from_str(&record.logs).unwrap_or_default();
+                base.extend(remaining);
+                base
+            }
+            _ => remaining,
+        };
+        let result_str = executor_spawn.get_final_result(&all_logs_snapshot).unwrap_or_default();
 
         // Extract execution stats from logs
         // tool_calls: tool_use (claudecode), tool_call (kimi), tool (atomcode, opencode)

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -436,7 +436,13 @@ pub async fn run_todo_execution(
         let remaining = std::mem::take(&mut *logs_for_result.lock().await);
         let all_logs_snapshot = match db_clone.get_execution_record(record_id).await {
             Some(record) if !record.logs.is_empty() && record.logs != "[]" => {
-                let mut base: Vec<ParsedLogEntry> = serde_json::from_str(&record.logs).unwrap_or_default();
+                let mut base: Vec<ParsedLogEntry> = match serde_json::from_str(&record.logs) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::warn!("Failed to parse execution logs JSON, record_id={}: {}", record_id, e);
+                        Vec::new()
+                    }
+                };
                 base.extend(remaining);
                 base
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "aitodo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "framer-motion": "^12.38.0"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "framer-motion": "^12.38.0"
+  }
+}


### PR DESCRIPTION
Closes #93

## Summary
- 将三个 flush 点的 `clone()` 改为 `std::mem::take`，flush 后内存中的 Vec 被清空，避免长任务期间内存无限增长
- 新增 `append_execution_record_logs` 方法，每次 flush 时先读取 DB 已有日志，追加新条目后写回，防止覆盖
- `update_execution_record` 也改为合并模式，确保最终写入包含完整日志
- 最终结果阶段先等所有 flush 完成，再从 DB 读取完整日志集合并内存中剩余条目

## Test plan
- [ ] 启动长任务执行，观察内存使用是否趋于稳定而非持续增长
- [ ] 执行完成后检查 DB 中日志记录是否完整
- [ ] 手动取消任务后检查日志是否完整保存