### PR TITLE
fix: Config 缓存到 AppState 内存

### DIFF
--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -4,16 +4,16 @@ use crate::config::Config;
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::{ApiResponse, UpdateConfigRequest};
 
-pub async fn get_config(State(_state): State<AppState>) -> Result<ApiResponse<Config>, AppError> {
-    let cfg = Config::load();
+pub async fn get_config(State(state): State<AppState>) -> Result<ApiResponse<Config>, AppError> {
+    let cfg = state.config.read().await.clone();
     Ok(ApiResponse::ok(cfg))
 }
 
 pub async fn update_config(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     ApiJson(req): ApiJson<UpdateConfigRequest>,
 ) -> Result<ApiResponse<Config>, AppError> {
-    let mut cfg = Config::load();
+    let mut cfg = state.config.write().await;
 
     cfg.port = req.port;
     cfg.host = req.host;
@@ -27,5 +27,5 @@ pub async fn update_config(
         return Err(AppError::Internal(format!("Failed to save config: {}", e)));
     }
 
-    Ok(ApiResponse::ok(cfg))
+    Ok(ApiResponse::ok(cfg.clone()))
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -17,6 +17,7 @@ use tokio::sync::broadcast;
 
 use crate::adapters::ExecutorRegistry;
 use crate::Assets;
+use crate::config::Config;
 use crate::db::Database;
 use crate::models::ParsedLogEntry;
 use crate::scheduler::TodoScheduler;
@@ -29,6 +30,7 @@ pub struct AppState {
     pub tx: broadcast::Sender<ExecEvent>,
     pub scheduler: Arc<TodoScheduler>,
     pub task_manager: Arc<TaskManager>,
+    pub config: Arc<tokio::sync::RwLock<Config>>,
 }
 
 impl AppState {
@@ -244,6 +246,7 @@ pub fn create_app(
     tx: broadcast::Sender<ExecEvent>,
     scheduler: Arc<TodoScheduler>,
     task_manager: Arc<TaskManager>,
+    config: Arc<tokio::sync::RwLock<Config>>,
 ) -> Router {
     let state = AppState {
         db,
@@ -251,6 +254,7 @@ pub fn create_app(
         tx,
         scheduler,
         task_manager,
+        config,
     };
 
     Router::new()

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -242,7 +242,8 @@ async fn run_server(cli_port: Option<u16>) {
         sched
     });
 
-    let app = handlers::create_app(db, executor_registry, tx, scheduler, task_manager);
+    let config = Arc::new(tokio::sync::RwLock::new(cfg.clone()));
+    let app = handlers::create_app(db, executor_registry, tx, scheduler, task_manager, config);
 
     let port = cli_port.unwrap_or(cfg.port);
 


### PR DESCRIPTION
## Summary
- Add `Arc<tokio::sync::RwLock<Config>>` field to `AppState` so config is kept in memory
- `get_config` and `update_config` handlers now read/write from the in-memory cache instead of calling `Config::load()` on every request
- `update_config` still persists to disk via `cfg.save()`, keeping the in-memory copy in sync

Closes #88