### PR TITLE
fix: ExecutionRecord.status 从 String 改为 ExecutionStatus 枚举

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -4,16 +4,19 @@ use sea_orm::{
 
 use crate::db::Database;
 use crate::db::entity::execution_records;
-use crate::models::{ExecutionRecord, ExecutionSummary, ExecutionUsage};
+use crate::models::{ExecutionRecord, ExecutionStatus, ExecutionSummary, ExecutionUsage};
 
 impl From<execution_records::Model> for ExecutionRecord {
     fn from(m: execution_records::Model) -> Self {
         let usage = m.usage.as_deref().and_then(|u| serde_json::from_str(u).ok());
         let execution_stats = m.execution_stats.as_deref().and_then(|s| serde_json::from_str(s).ok());
+        let status = m.status.as_deref()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(ExecutionStatus::Running);
         ExecutionRecord {
             id: m.id,
             todo_id: m.todo_id.unwrap_or(0),
-            status: m.status.unwrap_or_default(),
+            status,
             command: m.command.unwrap_or_default(),
             stdout: m.stdout.unwrap_or_default(),
             stderr: m.stderr.unwrap_or_default(),

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -12,7 +12,10 @@ impl From<execution_records::Model> for ExecutionRecord {
         let execution_stats = m.execution_stats.as_deref().and_then(|s| serde_json::from_str(s).ok());
         let status = m.status.as_deref()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(ExecutionStatus::Running);
+            .unwrap_or_else(|| {
+                tracing::warn!("Failed to parse execution status, defaulting to Running: {:?}", m.status);
+                ExecutionStatus::Running
+            });
         ExecutionRecord {
             id: m.id,
             todo_id: m.todo_id.unwrap_or(0),

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -610,7 +610,7 @@ mod tests {
         let (records, total) = db.get_execution_records(todo_id, 100, 0).await;
         assert_eq!(total, 1);
         let record = records.iter().find(|r| r.id == record_id).unwrap();
-        assert_eq!(record.status, "running");
+        assert_eq!(record.status, crate::models::ExecutionStatus::Running);
         assert_eq!(record.command, "echo hi");
         assert_eq!(record.executor, Some("claudecode".to_string()));
         assert_eq!(record.trigger_type, "manual");
@@ -657,7 +657,7 @@ mod tests {
         db.update_execution_record(record_id, "success", "[{\"type\":\"info\"}]", "done", Some(&usage), Some("claude-3")).await.unwrap();
         let (records, _) = db.get_execution_records(todo_id, 100, 0).await;
         let record = records.iter().find(|r| r.id == record_id).unwrap();
-        assert_eq!(record.status, "success");
+        assert_eq!(record.status, crate::models::ExecutionStatus::Success);
         assert_eq!(record.logs, "[{\"type\":\"info\"}]");
         assert_eq!(record.result, Some("done".to_string()));
         assert_eq!(record.model, Some("claude-3".to_string()));

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -7,7 +7,7 @@ use crate::adapters::parse_executor_type;
 use crate::executor_service::run_todo_execution;
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::{
-    ApiResponse, DashboardStats, ExecuteRequest, ExecutionRecordsPage, ExecutionSummary, TodoIdQuery,
+    ApiResponse, DashboardStats, ExecuteRequest, ExecutionRecordsPage, ExecutionStatus, ExecutionSummary, TodoIdQuery,
 };
 
 pub async fn get_execution_records(
@@ -103,7 +103,7 @@ pub async fn stop_execution_handler(
     let record = state.db.get_execution_record(req.record_id).await
         .ok_or(AppError::BadRequest("Execution record not found".to_string()))?;
 
-    if record.status != "running" {
+    if record.status != ExecutionStatus::Running {
         return Err(AppError::BadRequest("Execution record is not running".to_string()));
     }
 
@@ -143,7 +143,7 @@ pub async fn resume_execution_handler(
     let record = state.db.get_execution_record(id).await
         .ok_or(AppError::NotFound)?;
 
-    if record.status == "running" {
+    if record.status == ExecutionStatus::Running {
         return Err(AppError::BadRequest("Cannot resume a running execution".to_string()));
     }
 

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -69,6 +70,18 @@ impl std::fmt::Display for ExecutionStatus {
     }
 }
 
+impl std::str::FromStr for ExecutionStatus {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "running" => Ok(Self::Running),
+            "success" => Ok(Self::Success),
+            "failed" => Ok(Self::Failed),
+            _ => Err(format!("unknown execution status: {}", s)),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Todo {
     pub id: i64,
@@ -107,7 +120,7 @@ fn default_trigger_type() -> String { "manual".to_string() }
 pub struct ExecutionRecord {
     pub id: i64,
     pub todo_id: i64,
-    pub status: String,
+    pub status: ExecutionStatus,
     pub command: String,
     pub stdout: String,
     pub stderr: String,

--- a/backend/tests/business_logic_tests.rs
+++ b/backend/tests/business_logic_tests.rs
@@ -263,7 +263,7 @@ mod execution_record_tests {
         let record: ExecutionRecord = serde_json::from_str(json).unwrap();
         assert_eq!(record.id, 1);
         assert_eq!(record.todo_id, 10);
-        assert_eq!(record.status, "success");
+        assert_eq!(record.status, ntd::models::ExecutionStatus::Success);
         assert_eq!(record.executor, Some("kimi".to_string()));
         assert!(record.usage.is_some());
         let usage = record.usage.unwrap();
@@ -297,7 +297,7 @@ mod execution_record_tests {
 
         let record: ExecutionRecord = serde_json::from_str(json).unwrap();
         assert_eq!(record.id, 1);
-        assert_eq!(record.status, "running");
+        assert_eq!(record.status, ntd::models::ExecutionStatus::Running);
         assert!(record.usage.is_none());
         assert!(record.pid.is_none());
     }


### PR DESCRIPTION
## Summary
- 为 `ExecutionStatus` 枚举添加 `FromStr` 实现
- `ExecutionRecord.status` 字段从 `String` 改为 `ExecutionStatus`
- 更新 `From<execution_records::Model>` 实现，正确解析数据库字符串到枚举
- 将 handler 中的字符串比较（`status == "running"`）改为枚举比较

Closes #85