### PR TITLE
fix: improve skills import/export functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ step6-same-again.png
 .atomcode
 datalog
 .cc-connect
+frontend/test-results/.last-run.json

--- a/backend/src/db/skills.rs
+++ b/backend/src/db/skills.rs
@@ -1,4 +1,4 @@
-use sea_orm::{ConnectionTrait, Statement, DbBackend, Value};
+use sea_orm::{ConnectionTrait, Statement, Value};
 
 use crate::db::Database;
 use crate::handlers::skills::SkillInvocation;

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -7,7 +7,6 @@ use axum::extract::{Query, State};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::io::Write;
 use zip::write::FileOptions;
 use zip::ZipArchive;
 
@@ -498,6 +497,9 @@ pub async fn import_skill(
 
     let target_dir = skills_dir.join(&skill_name);
 
+    std::fs::create_dir_all(&target_dir)
+        .map_err(|e| AppError::Internal(format!("Failed to create target dir: {}", e)))?;
+
     // Canonicalize target_dir to verify it's under skills_dir
     let target_dir = target_dir.canonicalize()
         .map_err(|e| AppError::Internal(format!("Failed to resolve target dir: {}", e)))?;
@@ -508,9 +510,6 @@ pub async fn import_skill(
     if !target_dir.starts_with(&skills_dir_canonical) {
         return Err(AppError::BadRequest("Invalid skill name: would escape skills directory".to_string()));
     }
-
-    std::fs::create_dir_all(&target_dir)
-        .map_err(|e| AppError::Internal(format!("Failed to create target dir: {}", e)))?;
 
     let mut imported_files = 0i32;
     for i in 0..archive.len() {

--- a/frontend/src/components/SkillsPanel.tsx
+++ b/frontend/src/components/SkillsPanel.tsx
@@ -239,12 +239,12 @@ interface ImportExportModalProps {
   mode: 'import' | 'export';
   executor: string;
   data: ExecutorSkills[];
-  exportAll?: boolean;
+  initialSelectedSkills?: string[];
   onClose: () => void;
 }
 
-function ImportExportModal({ open, mode, executor, data, exportAll, onClose }: ImportExportModalProps) {
-  const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
+function ImportExportModal({ open, mode, executor, data, initialSelectedSkills, onClose }: ImportExportModalProps) {
+  const [selectedSkills, setSelectedSkills] = useState<string[]>(initialSelectedSkills || []);
   const [exporting, setExporting] = useState(false);
   const [tasks, setTasks] = useState<ExportTask[]>([]);
   const [importFile, setImportFile] = useState<File | null>(null);
@@ -267,14 +267,13 @@ function ImportExportModal({ open, mode, executor, data, exportAll, onClose }: I
   }, [data, executor]);
   const skills = executorData?.skills || [];
 
-  // 每次模态框打开、executor 变化或 exportAll 变化时，重置选中状态
+  // 每次模态框打开时，重置选中状态
   useEffect(() => {
     if (open) {
-      setSelectedSkills(exportAll ? skills.map(s => s.name) : []);
+      setSelectedSkills(initialSelectedSkills || []);
       setTasks([]);
     }
-  }, [open, executor, exportAll, skills]);
-
+  }, [open, initialSelectedSkills]);
   const handleExport = async () => {
     if (selectedSkills.length === 0) {
       message.warning('请选择要导出的 Skills');
@@ -702,7 +701,7 @@ function SkillsOverview() {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [exportModalOpen, setExportModalOpen] = useState(false);
   const [exportMode, setExportMode] = useState<'import' | 'export'>('export');
-  const [exportAll, setExportAll] = useState(false);
+  const [initialSelectedSkills, setInitialSelectedSkills] = useState<string[] | undefined>(undefined);
 
   useEffect(() => {
     setLoading(true);
@@ -739,10 +738,17 @@ function SkillsOverview() {
   const handleExportMenuClick: MenuProps['onClick'] = ({ key }) => {
     if (key === 'import') {
       setExportMode('import');
-      setExportAll(false);
+      setInitialSelectedSkills(undefined);
     } else {
       setExportMode('export');
-      setExportAll(key === 'export-all');
+      if (key === 'export-all') {
+        const executorData = data.find(e => e.executor === selectedExecutor);
+        if (executorData) {
+          setInitialSelectedSkills(executorData.skills.map(s => s.name));
+        }
+      } else {
+        setInitialSelectedSkills(undefined);
+      }
     }
     setExportModalOpen(true);
   };
@@ -750,14 +756,21 @@ function SkillsOverview() {
   const handleImport = (executor: string) => {
     setSelectedExecutor(executor);
     setExportMode('import');
-    setExportAll(false);
+    setInitialSelectedSkills(undefined);
     setExportModalOpen(true);
   };
 
   const handleExport = (executor: string, selectAll?: boolean) => {
     setSelectedExecutor(executor);
     setExportMode('export');
-    setExportAll(selectAll || false);
+    if (selectAll) {
+      const executorData = data.find(e => e.executor === executor);
+      if (executorData) {
+        setInitialSelectedSkills(executorData.skills.map(s => s.name));
+      }
+    } else {
+      setInitialSelectedSkills(undefined);
+    }
     setExportModalOpen(true);
   };
 
@@ -856,8 +869,11 @@ function SkillsOverview() {
         mode={exportMode}
         executor={selectedExecutor}
         data={data}
-        exportAll={exportAll}
-        onClose={() => setExportModalOpen(false)}
+        initialSelectedSkills={initialSelectedSkills}
+        onClose={() => {
+          setExportModalOpen(false);
+          setInitialSelectedSkills(undefined);
+        }}
       />
     </div>
   );

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -273,14 +273,13 @@ export interface ImportResult {
 }
 
 export async function importSkill(executor: string, file: File, skillName?: string, flatten?: boolean): Promise<ImportResult> {
-  const formData = new FormData();
-  formData.append('file', file);
-  if (skillName) formData.append('skill_name', skillName);
-  if (flatten !== undefined) formData.append('flatten', String(flatten));
+  const params: Record<string, string> = { executor };
+  if (skillName) params.skill_name = skillName;
+  if (flatten !== undefined) params.flatten = String(flatten);
 
-  const response = await api.post<ApiResp<ImportResult>>('/xyz/skills/import', formData, {
-    headers: { 'Content-Type': 'multipart/form-data' },
-    params: { executor, skill_name: skillName, flatten },
+  const response = await api.post<ApiResp<ImportResult>>('/xyz/skills/import', await file.arrayBuffer(), {
+    params,
+    headers: { 'Content-Type': 'application/zip' },
   });
   return response.data.data as ImportResult;
 }


### PR DESCRIPTION
## Summary

- SkillsPanel.tsx: improve import/export UI and functionality
- database.ts: enhance skills database operations
- handlers/skills.rs: fix directory creation order for skill import (move create_dir_all before canonicalize)
- db/skills.rs: clean up unused imports with cargo fix
- Add test-results to gitignore

## Test plan

- [ ] Import a skill and verify files are extracted correctly
- [ ] Export a skill and verify archive is created
- [ ] Verify dashboard shows "定时" label correctly