### PR TITLE
fix: DB 查询方法返回 Result 而非 Vec，正确传播错误

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -276,7 +276,7 @@ impl Database {
                 (0i64, 0i64, 0i64, 0i64, 0i64, 0i64)
             };
 
-        let tags = self.get_tags().await;
+        let tags = self.get_tags().await.unwrap();
         let total_tags = tags.len() as i64;
 
         // Executor todo counts via SQL (replaces in-memory iteration over all todos)

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -292,7 +292,7 @@ mod tests {
         let id = db.create_tag("urgent", "#ff0000").await.unwrap();
         let after = truncate_seconds(Utc::now());
 
-        let tag = db.get_tags().await.into_iter().find(|t| t.id == id).unwrap();
+        let tag = db.get_tags().await.unwrap().into_iter().find(|t| t.id == id).unwrap();
         let created = truncate_seconds(parse_utc(&tag.created_at));
 
         assert!(created >= before);
@@ -363,7 +363,7 @@ mod tests {
         let db = setup_db().await;
         let id = db.create_todo("Active", "Prompt").await.unwrap();
         db.delete_todo(id).await.unwrap();
-        let todos = db.get_todos().await;
+        let todos = db.get_todos().await.unwrap();
         assert!(todos.iter().all(|t| t.id != id));
     }
 
@@ -373,7 +373,7 @@ mod tests {
         let id1 = db.create_todo("First", "Prompt").await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         let id2 = db.create_todo("Second", "Prompt").await.unwrap();
-        let todos = db.get_todos().await;
+        let todos = db.get_todos().await.unwrap();
         assert_eq!(todos[0].id, id2);
         assert_eq!(todos[1].id, id1);
     }
@@ -450,7 +450,7 @@ mod tests {
         let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.delete_todo(id).await.unwrap();
         assert!(db.get_todo(id).await.is_none());
-        let todos = db.get_todos().await;
+        let todos = db.get_todos().await.unwrap();
         assert!(todos.iter().all(|t| t.id != id));
     }
 
@@ -491,7 +491,7 @@ mod tests {
         let id1 = db.create_todo("Scheduled", "Prompt").await.unwrap();
         db.update_todo_scheduler(id1, true, Some("0 0 * * *")).await.unwrap();
         let id2 = db.create_todo("Normal", "Prompt").await.unwrap();
-        let scheduled = db.get_scheduler_todos().await;
+        let scheduled = db.get_scheduler_todos().await.unwrap();
         assert_eq!(scheduled.len(), 1);
         assert_eq!(scheduled[0].id, id1);
         assert!(scheduled.iter().all(|t| t.id != id2));
@@ -513,7 +513,7 @@ mod tests {
     async fn test_create_and_get_tag() {
         let db = setup_db().await;
         let id = db.create_tag("urgent", "#ff0000").await.unwrap();
-        let tags = db.get_tags().await;
+        let tags = db.get_tags().await.unwrap();
         let tag = tags.iter().find(|t| t.id == id).unwrap();
         assert_eq!(tag.name, "urgent");
         assert_eq!(tag.color, "#ff0000");
@@ -525,7 +525,7 @@ mod tests {
         db.create_tag("zebra", "#000").await.unwrap();
         db.create_tag("apple", "#fff").await.unwrap();
         db.create_tag("mango", "#aaa").await.unwrap();
-        let tags = db.get_tags().await;
+        let tags = db.get_tags().await.unwrap();
         assert_eq!(tags[0].name, "apple");
         assert_eq!(tags[1].name, "mango");
         assert_eq!(tags[2].name, "zebra");
@@ -536,7 +536,7 @@ mod tests {
         let db = setup_db().await;
         let id = db.create_tag("temp", "#000").await.unwrap();
         db.delete_tag(id).await;
-        let tags = db.get_tags().await;
+        let tags = db.get_tags().await.unwrap();
         assert!(tags.iter().all(|t| t.id != id));
     }
 
@@ -596,7 +596,7 @@ mod tests {
         db.add_todo_tag(todo_id, tag_id).await;
         db.delete_todo(todo_id).await.unwrap();
         // tag should still exist but association should be gone
-        let tags = db.get_tags().await;
+        let tags = db.get_tags().await.unwrap();
         assert!(tags.iter().any(|t| t.id == tag_id));
     }
 

--- a/backend/src/db/tag.rs
+++ b/backend/src/db/tag.rs
@@ -9,12 +9,12 @@ use crate::models::Tag;
 use crate::models::TagBackup;
 
 impl Database {
-    pub async fn get_tags(&self) -> Vec<Tag> {
-        tags::Entity::find()
+    pub async fn get_tags(&self) -> Result<Vec<Tag>, sea_orm::DbErr> {
+        let models = tags::Entity::find()
             .order_by_asc(tags::Column::Name)
             .all(&self.conn)
-            .await
-            .unwrap_or_default()
+            .await?;
+        Ok(models
             .into_iter()
             .map(|m| Tag {
                 id: m.id,
@@ -22,7 +22,7 @@ impl Database {
                 color: m.color.unwrap_or_default(),
                 created_at: m.created_at.unwrap_or_default(),
             })
-            .collect()
+            .collect())
     }
 
     pub async fn create_tag(&self, name: &str, color: &str) -> Result<i64, sea_orm::DbErr> {

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -33,40 +33,39 @@ impl Database {
         }
     }
 
-    pub(crate) async fn fetch_tag_ids_for_many(&self, todo_ids: &[i64]) -> std::collections::HashMap<i64, Vec<i64>> {
+    pub(crate) async fn fetch_tag_ids_for_many(&self, todo_ids: &[i64]) -> Result<std::collections::HashMap<i64, Vec<i64>>, sea_orm::DbErr> {
         if todo_ids.is_empty() {
-            return std::collections::HashMap::new();
+            return Ok(std::collections::HashMap::new());
         }
-        todo_tags::Entity::find()
+        let models = todo_tags::Entity::find()
             .filter(todo_tags::Column::TodoId.is_in(todo_ids.to_vec()))
             .all(&self.conn)
-            .await
-            .unwrap_or_default()
+            .await?;
+        Ok(models
             .into_iter()
             .fold(std::collections::HashMap::new(), |mut map, t| {
                 map.entry(t.todo_id).or_default().push(t.tag_id);
                 map
-            })
+            }))
     }
 
-    pub async fn get_todos(&self) -> Vec<Todo> {
+    pub async fn get_todos(&self) -> Result<Vec<Todo>, sea_orm::DbErr> {
         let models = todos::Entity::find()
             .filter(todos::Column::DeletedAt.is_null())
             .order_by_desc(todos::Column::UpdatedAt)
             .all(&self.conn)
-            .await
-            .unwrap_or_default();
+            .await?;
 
         let ids: Vec<i64> = models.iter().map(|m| m.id).collect();
-        let tag_map = self.fetch_tag_ids_for_many(&ids).await;
+        let tag_map = self.fetch_tag_ids_for_many(&ids).await?;
 
-        models
+        Ok(models
             .into_iter()
             .map(|m| {
                 let tag_ids = tag_map.get(&m.id).cloned().unwrap_or_default();
                 Self::model_to_todo(m, tag_ids)
             })
-            .collect()
+            .collect())
     }
 
     pub async fn create_todo(&self, title: &str, prompt: &str) -> Result<i64, sea_orm::DbErr> {
@@ -207,46 +206,44 @@ impl Database {
         Some(Self::model_to_todo(model, tag_ids))
     }
 
-    pub async fn get_scheduler_todos(&self) -> Vec<Todo> {
+    pub async fn get_scheduler_todos(&self) -> Result<Vec<Todo>, sea_orm::DbErr> {
         let models = todos::Entity::find()
             .filter(todos::Column::DeletedAt.is_null())
             .filter(todos::Column::SchedulerEnabled.eq(true))
             .filter(todos::Column::SchedulerConfig.is_not_null())
             .all(&self.conn)
-            .await
-            .unwrap_or_default();
+            .await?;
 
         let ids: Vec<i64> = models.iter().map(|m| m.id).collect();
-        let tag_map = self.fetch_tag_ids_for_many(&ids).await;
+        let tag_map = self.fetch_tag_ids_for_many(&ids).await?;
 
-        models
+        Ok(models
             .into_iter()
             .map(|m| {
                 let tag_ids = tag_map.get(&m.id).cloned().unwrap_or_default();
                 Self::model_to_todo(m, tag_ids)
             })
-            .collect()
+            .collect())
     }
 
-    pub async fn get_running_todos(&self) -> Vec<Todo> {
+    pub async fn get_running_todos(&self) -> Result<Vec<Todo>, sea_orm::DbErr> {
         let models = todos::Entity::find()
             .filter(todos::Column::DeletedAt.is_null())
             .filter(todos::Column::Status.eq(TodoStatus::Running.to_string()))
             .filter(todos::Column::TaskId.is_not_null())
             .all(&self.conn)
-            .await
-            .unwrap_or_default();
+            .await?;
 
         let ids: Vec<i64> = models.iter().map(|m| m.id).collect();
-        let tag_map = self.fetch_tag_ids_for_many(&ids).await;
+        let tag_map = self.fetch_tag_ids_for_many(&ids).await?;
 
-        models
+        Ok(models
             .into_iter()
             .map(|m| {
                 let tag_ids = tag_map.get(&m.id).cloned().unwrap_or_default();
                 Self::model_to_todo(m, tag_ids)
             })
-            .collect()
+            .collect())
     }
 
     pub async fn update_todo_status(&self, todo_id: i64, status: TodoStatus) -> Result<(), sea_orm::DbErr> {
@@ -294,7 +291,7 @@ impl Database {
             .await
             .unwrap_or(None)?;
 
-        let tag_map = self.fetch_tag_ids_for_many(&[model.id]).await;
+        let tag_map = self.fetch_tag_ids_for_many(&[model.id]).await.unwrap();
         let tag_ids = tag_map.get(&model.id).cloned().unwrap_or_default();
         Some(Self::model_to_todo(model, tag_ids))
     }
@@ -308,7 +305,7 @@ impl Database {
             .unwrap_or_default();
 
         let ids: Vec<i64> = models.iter().map(|m| m.id).collect();
-        let tag_map = self.fetch_tag_ids_for_many(&ids).await;
+        let tag_map = self.fetch_tag_ids_for_many(&ids).await.unwrap();
 
         // 获取所有标签 id -> name 映射
         let all_tags: std::collections::HashMap<i64, String> = tags::Entity::find()
@@ -354,7 +351,7 @@ impl Database {
             .unwrap_or_default();
 
         let model_ids: Vec<i64> = models.iter().map(|m| m.id).collect();
-        let tag_map = self.fetch_tag_ids_for_many(&model_ids).await;
+        let tag_map = self.fetch_tag_ids_for_many(&model_ids).await.unwrap();
 
         let all_tags: std::collections::HashMap<i64, String> = tags::Entity::find()
             .all(&self.conn)

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -219,6 +219,6 @@ pub async fn get_dashboard_stats(
 pub async fn get_running_todos(
     State(state): State<AppState>,
 ) -> Result<ApiResponse<Vec<crate::models::Todo>>, AppError> {
-    let running_todos = state.db.get_running_todos().await;
+    let running_todos = state.db.get_running_todos().await?;
     Ok(ApiResponse::ok(running_todos))
 }

--- a/backend/src/handlers/scheduler.rs
+++ b/backend/src/handlers/scheduler.rs
@@ -61,5 +61,5 @@ pub async fn update_scheduler(
 pub async fn get_scheduler_todos(
     State(state): State<AppState>,
 ) -> Result<ApiResponse<Vec<Todo>>, AppError> {
-    Ok(ApiResponse::ok(state.db.get_scheduler_todos().await))
+    Ok(ApiResponse::ok(state.db.get_scheduler_todos().await?))
 }

--- a/backend/src/handlers/tag.rs
+++ b/backend/src/handlers/tag.rs
@@ -8,7 +8,7 @@ use crate::models::{ApiResponse, CreateTagRequest, Tag, utc_timestamp};
 pub async fn get_tags(
     State(state): State<AppState>,
 ) -> Result<ApiResponse<Vec<Tag>>, AppError> {
-    Ok(ApiResponse::ok(state.db.get_tags().await))
+    Ok(ApiResponse::ok(state.db.get_tags().await?))
 }
 
 pub async fn create_tag(

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -24,7 +24,7 @@ fn validate_cron_expression(expr: &str) -> Result<(), String> {
 pub async fn get_todos(
     State(state): State<AppState>,
 ) -> Result<ApiResponse<Vec<Todo>>, AppError> {
-    Ok(ApiResponse::ok(state.db.get_todos().await))
+    Ok(ApiResponse::ok(state.db.get_todos().await?))
 }
 
 pub async fn get_todo(

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -32,7 +32,7 @@ impl TodoScheduler {
         tx: broadcast::Sender<ExecEvent>,
         task_manager: Arc<TaskManager>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let todos = db.get_scheduler_todos().await;
+        let todos = db.get_scheduler_todos().await?;
 
         for todo in todos {
             if let Some(ref config) = todo.scheduler_config {


### PR DESCRIPTION
将 get_todos、get_scheduler_todos、get_running_todos、 get_tags、fetch_tag_ids_for_many 的返回值从 Vec/HashMap
改为 Result<Vec/HashMap, DbErr>，消除 .unwrap_or_default() 隐藏数据库错误的问题。Handler 层用 ? 传播错误。