### PR TITLE
fix: Skills markdown渲染与移动端按钮修复

### DIFF
--- a/frontend/src/components/SkillsPanel.tsx
+++ b/frontend/src/components/SkillsPanel.tsx
@@ -212,6 +212,7 @@ function SkillDetailDrawer({ skill, executor, executorLabel, open, onClose }: Sk
           <h3 style={{ margin: '16px 0 8px', color: '#595959' }}>内容预览</h3>
           <XMarkdown
             content={content}
+            escapeRawHtml={true}
             style={{
               fontFamily: 'Fira Code, monospace',
               fontSize: 13,
@@ -654,12 +655,14 @@ function SkillTree({ data, onSkillClick, onImport, onExport, searchText, showCat
                   type="text"
                   size="small"
                   icon={<UploadOutlined />}
+                  aria-label="导入 Skills"
                   onClick={() => onImport(executorData.executor)}
                 />
                 <Button
                   type="text"
                   size="small"
                   icon={<DownloadOutlined />}
+                  aria-label="导出 Skills"
                   onClick={() => onExport(executorData.executor, false)}
                 />
               </Space>

--- a/frontend/src/components/SkillsPanel.tsx
+++ b/frontend/src/components/SkillsPanel.tsx
@@ -48,12 +48,12 @@ import {
   FileTextOutlined,
   SaveOutlined,
 } from '@ant-design/icons';
+import XMarkdown from '@ant-design/x-markdown';
 import * as db from '../utils/database';
 import type { ExecutorSkills, SkillComparison, SkillInvocation, SkillMeta } from '../types';
 import { EXECUTORS } from '../types';
 
 const { Text, Paragraph } = Typography;
-const { TextArea } = Input;
 
 // ── 工具函数 ────────────────────────────────────────────────
 
@@ -210,15 +210,15 @@ function SkillDetailDrawer({ skill, executor, executorLabel, open, onClose }: Sk
           </Descriptions>
 
           <h3 style={{ margin: '16px 0 8px', color: '#595959' }}>内容预览</h3>
-          <TextArea
-            value={content}
-            autoSize={{ minRows: 10, maxRows: 30 }}
-            readOnly
+          <XMarkdown
+            content={content}
             style={{
               fontFamily: 'Fira Code, monospace',
               fontSize: 13,
               background: '#1e1e1e',
               color: '#d4d4d4',
+              padding: '12px',
+              borderRadius: '8px',
             }}
           />
         </div>
@@ -650,27 +650,18 @@ function SkillTree({ data, onSkillClick, onImport, onExport, searchText, showCat
             }
             extra={
               <Space size="small">
-                <Tooltip title="导入">
-                  <Button
-                    type="text"
-                    size="small"
-                    icon={<UploadOutlined />}
-                    onClick={() => onImport(executorData.executor)}
-                  />
-                </Tooltip>
-                <Dropdown
-                  menu={{
-                    items: [
-                      { key: 'export-selected', icon: <ExportOutlined />, label: '导出选中', onClick: () => onExport(executorData.executor, false) },
-                      { key: 'export-all', icon: <DownloadOutlined />, label: '导出全部', onClick: () => onExport(executorData.executor, true) },
-                    ]
-                  }}
-                  trigger={['click']}
-                >
-                  <Tooltip title="导出">
-                    <Button type="text" size="small" icon={<DownloadOutlined />} />
-                  </Tooltip>
-                </Dropdown>
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<UploadOutlined />}
+                  onClick={() => onImport(executorData.executor)}
+                />
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<DownloadOutlined />}
+                  onClick={() => onExport(executorData.executor, false)}
+                />
               </Space>
             }
             style={{ marginBottom: 12 }}

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -14,8 +14,8 @@ const api = axios.create({
 
 api.interceptors.response.use(
   (res) => {
-    // Skip code check for blob responses (e.g., skill export)
-    if (res.data instanceof Blob) {
+    // Skip code check for non-object responses (blob, text, arraybuffer, etc.)
+    if (typeof res.data !== 'object' || res.data === null || res.data instanceof Blob) {
       return res;
     }
     const body = res.data as ApiResp<unknown>;

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -14,6 +14,10 @@ const api = axios.create({
 
 api.interceptors.response.use(
   (res) => {
+    // Skip code check for blob responses (e.g., skill export)
+    if (res.data instanceof Blob) {
+      return res;
+    }
     const body = res.data as ApiResp<unknown>;
     if (body && body.code !== 0) {
       return Promise.reject(new Error(body.message || `Error ${body.code}`));


### PR DESCRIPTION
## Summary

- **Markdown 渲染**: Skill 详情抽屉内容预览改为 XMarkdown 组件
- **移动端按钮**: 移除 Tooltip/Dropdown 嵌套，修复点击无反应问题  
- **导出失败**: axios 拦截器对 blob 响应跳过 code 检查

## Test plan

- [ ] 验证 Skill 详情中 markdown 正确渲染
- [ ] 验证桌面端导入/导出功能正常
- [ ] 验证移动端导入/导出按钮可点击