### PR TITLE
fix: 修复 JoinAI 执行历史时间戳显示为 Invalid Date 的问题

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,6 +91,8 @@ jobs:
         env:
           # Mount frontend/dist for rust-embed + .git for vergen
           CROSS_CONTAINER_OPTS: "-v ${{ github.workspace }}/frontend/dist:/frontend/dist:ro -v ${{ github.workspace }}/.git:/project/.git:ro"
+          # Point GIT_DIR to where .git is mounted inside the container
+          GIT_DIR: /project/.git
         run: cd backend && cross build --release --target ${{ matrix.target }}
 
       - name: Build (native)

--- a/backend/build.rs
+++ b/backend/build.rs
@@ -10,6 +10,9 @@ fn main() {
         println!("cargo:rerun-if-changed={}", dist_path.display());
     }
 
+    // Note: GIT_DIR environment variable is automatically picked up by vergen
+    // when the .git directory is in a non-standard location (e.g., when using
+    // cross for Docker-based builds)
     let gitcl = GitclBuilder::default()
         .sha(true)
         .describe(true, true, None)

--- a/backend/src/adapters/agent_event.rs
+++ b/backend/src/adapters/agent_event.rs
@@ -5,12 +5,29 @@ use serde::Deserialize;
 pub struct AgentEvent {
     #[serde(rename = "type")]
     pub event_type: String,
-    #[serde(default)]
-    pub timestamp: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_timestamp")]
+    pub timestamp: Option<f64>,
     #[serde(default, rename = "sessionID")]
     pub session_id: Option<String>,
     #[serde(default)]
     pub part: Option<AgentPart>,
+}
+
+// Custom deserializer that accepts both string and number formats for timestamp
+fn deserialize_timestamp<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt = Option::<serde_json::Value>::deserialize(deserializer)?;
+    match opt {
+        Some(serde_json::Value::Number(n)) => {
+            Ok(Some(n.as_f64().unwrap_or(0.0)))
+        }
+        Some(serde_json::Value::String(s)) => {
+            Ok(s.parse::<f64>().ok())
+        }
+        _ => Ok(None),
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/backend/src/adapters/joinai.rs
+++ b/backend/src/adapters/joinai.rs
@@ -69,7 +69,14 @@ impl CodeExecutor for JoinaiExecutor {
         let event: AgentEvent = serde_json::from_str(line).ok()?;
 
         let timestamp = event.timestamp
-            .and_then(|ts| chrono::DateTime::from_timestamp_millis(ts as i64))
+            .and_then(|ts| {
+                // JoinAI may send timestamps as either:
+                // - Milliseconds (13+ digits, e.g., 1700000000000)
+                // - Seconds with decimal (10 digits, e.g., 1778032233.261)
+                // Use magnitude to determine: > 1e12 means milliseconds, < 1e12 means seconds
+                let ts_ms = if ts > 1e12 { ts as i64 } else { (ts * 1000.0) as i64 };
+                chrono::DateTime::from_timestamp_millis(ts_ms)
+            })
             .map(|dt| dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
             .unwrap_or_else(utc_timestamp);
 
@@ -281,6 +288,28 @@ mod tests {
     fn test_get_model_always_none() {
         let executor = JoinaiExecutor::new("joinai".to_string());
         assert!(executor.get_model().is_none());
+    }
+
+    #[test]
+    fn test_parse_output_line_with_string_timestamp_seconds() {
+        // JoinAI may send timestamps as strings in seconds format (e.g., "1778032233.261")
+        let executor = JoinaiExecutor::new("joinai".to_string());
+        let line = r#"{"type":"step_start","timestamp":"1778032233.261","content":"Step started"}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_start");
+        assert_eq!(entry.content, "Step started");
+        // The timestamp should be parsed and formatted as ISO 8601
+        assert!(entry.timestamp.starts_with("2026-"));
+    }
+
+    #[test]
+    fn test_parse_output_line_with_number_timestamp_milliseconds() {
+        // Milliseconds format (13+ digits) should still work
+        let executor = JoinaiExecutor::new("joinai".to_string());
+        let line = r#"{"type":"step_start","timestamp":1700000000000,"content":"Step started"}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_start");
+        assert!(entry.timestamp.starts_with("2023-"));
     }
 }
 


### PR DESCRIPTION
## 问题描述

JoinAI 执行器的执行历史中，时间显示为 "Invalid Date"。

## 原因分析

JoinAI 发送的时间戳是字符串格式的 Unix 时间戳（秒），例如 `"1778032233.261"`，但 `AgentEvent.timestamp` 定义为 `Option<u64>`，无法解析字符串格式。这导致解析失败后回退到使用当前时间。

## 修复内容

1. **agent_event.rs**: 添加自定义反序列化器 `deserialize_timestamp`，同时接受字符串和数字格式的时间戳
2. **joinai.rs**: 通过数值大小判断时间戳格式（>1e12 为毫秒，<1e12 为秒），并正确转换后再解析
3. 新增单元测试验证两种格式都能正确解析

## 测试

- `test_parse_output_line_with_string_timestamp_seconds`: 验证字符串格式（秒）时间戳
- `test_parse_output_line_with_number_timestamp_milliseconds`: 验证数字格式（毫秒）时间戳