### PR TITLE
feat: 飞书实时推送功能

### DIFF
--- a/backend/src/db/entity/feishu_push_targets.rs
+++ b/backend/src/db/entity/feishu_push_targets.rs
@@ -1,0 +1,22 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "feishu_push_targets")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub bot_id: i64,
+    pub chat_id: Option<String>,
+    pub receive_id: String,
+    pub receive_id_type: String,
+    /// Push level: "disabled", "result_only", or "all"
+    pub push_level: String,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/entity/mod.rs
+++ b/backend/src/db/entity/mod.rs
@@ -2,6 +2,7 @@ pub mod agent_bots;
 pub mod execution_records;
 pub mod feishu_homes;
 pub mod feishu_messages;
+pub mod feishu_push_targets;
 pub mod tags;
 pub mod todo_tags;
 pub mod todos;
@@ -11,6 +12,7 @@ pub mod prelude {
     pub use super::execution_records::Entity as ExecutionRecords;
     pub use super::feishu_homes::Entity as FeishuHomes;
     pub use super::feishu_messages::Entity as FeishuMessages;
+    pub use super::feishu_push_targets::Entity as FeishuPushTargets;
     pub use super::tags::Entity as Tags;
     pub use super::todo_tags::Entity as TodoTags;
     pub use super::todos::Entity as Todos;

--- a/backend/src/db/feishu_push_target.rs
+++ b/backend/src/db/feishu_push_target.rs
@@ -1,0 +1,98 @@
+use sea_orm::{ActiveModelTrait, ActiveValue, EntityTrait};
+use crate::db::Database;
+use crate::db::entity::feishu_push_targets;
+
+impl Database {
+    /// Set or update the push target for a bot.
+    /// push_level: "disabled", "result_only", or "all". Defaults to "result_only" for new targets.
+    pub async fn set_feishu_push_target(
+        &self,
+        bot_id: i64,
+        chat_id: Option<&str>,
+        receive_id: &str,
+        receive_id_type: &str,
+        push_level: &str,
+    ) -> Result<(), sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+
+        let existing = feishu_push_targets::Entity::find()
+            .all(&self.conn)
+            .await?
+            .into_iter()
+            .find(|t| t.bot_id == bot_id);
+
+        if let Some(t) = existing {
+            let mut am: feishu_push_targets::ActiveModel = t.into();
+            am.chat_id = ActiveValue::Set(chat_id.map(String::from));
+            am.receive_id = ActiveValue::Set(receive_id.to_string());
+            am.receive_id_type = ActiveValue::Set(receive_id_type.to_string());
+            am.push_level = ActiveValue::Set(push_level.to_string());
+            am.updated_at = ActiveValue::Set(Some(now));
+            am.update(&self.conn).await?;
+        } else {
+            let am = feishu_push_targets::ActiveModel {
+                bot_id: ActiveValue::Set(bot_id),
+                chat_id: ActiveValue::Set(chat_id.map(String::from)),
+                receive_id: ActiveValue::Set(receive_id.to_string()),
+                receive_id_type: ActiveValue::Set(receive_id_type.to_string()),
+                push_level: ActiveValue::Set(push_level.to_string()),
+                created_at: ActiveValue::Set(Some(now.clone())),
+                updated_at: ActiveValue::Set(Some(now)),
+                ..Default::default()
+            };
+            am.insert(&self.conn).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Get the push target for a bot.
+    pub async fn get_feishu_push_target(
+        &self,
+        bot_id: i64,
+    ) -> Result<Option<feishu_push_targets::Model>, sea_orm::DbErr> {
+        let targets = feishu_push_targets::Entity::find()
+            .all(&self.conn)
+            .await?;
+        Ok(targets.into_iter().find(|t| t.bot_id == bot_id))
+    }
+
+    /// Get all bots with push enabled (push_level != "disabled").
+    pub async fn get_enabled_feishu_push_targets(
+        &self,
+    ) -> Result<Vec<feishu_push_targets::Model>, sea_orm::DbErr> {
+        let targets = feishu_push_targets::Entity::find()
+            .all(&self.conn)
+            .await?;
+        Ok(targets
+            .into_iter()
+            .filter(|t| t.push_level != "disabled")
+            .collect())
+    }
+
+    /// Update push level for a bot.
+    pub async fn update_feishu_push_level(
+        &self,
+        bot_id: i64,
+        push_level: &str,
+    ) -> Result<(), sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+
+        let existing = feishu_push_targets::Entity::find()
+            .all(&self.conn)
+            .await?
+            .into_iter()
+            .find(|t| t.bot_id == bot_id);
+
+        match existing {
+            Some(t) => {
+                let mut am: feishu_push_targets::ActiveModel = t.into();
+                am.push_level = ActiveValue::Set(push_level.to_string());
+                am.updated_at = ActiveValue::Set(Some(now));
+                am.update(&self.conn).await?;
+            }
+            None => {}
+        }
+        Ok(())
+    }
+}

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -304,6 +304,22 @@ impl Database {
         )
         .await?;
 
+        // Feishu Push Targets table
+        self.exec(
+            "CREATE TABLE IF NOT EXISTS feishu_push_targets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                bot_id INTEGER NOT NULL UNIQUE,
+                chat_id TEXT,
+                receive_id TEXT NOT NULL,
+                receive_id_type TEXT NOT NULL,
+                push_enabled INTEGER DEFAULT 1,
+                created_at TEXT,
+                updated_at TEXT,
+                FOREIGN KEY (bot_id) REFERENCES agent_bots(id)
+            )",
+        )
+        .await?;
+
         Ok(())
     }
 }
@@ -315,6 +331,7 @@ mod skills;
 mod agent_bot;
 mod feishu_home;
 mod feishu_message;
+mod feishu_push_target;
 
 #[cfg(test)]
 mod tests {

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -75,7 +75,7 @@ pub async fn run_todo_execution(
         None => {
             tracing::error!("No executor available for type {:?} and no default registered", executor_type);
             let _ = db.finish_todo_execution(todo_id, false).await;
-            send_event(&tx, ExecEvent::Finished { task_id: task_id.clone(), todo_id, success: false, result: Some("No executor available".to_string()) });
+            send_event(&tx, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo.as_ref().map(|t| t.title.clone()).unwrap_or_default(), executor: executor_type.to_string(), success: false, result: Some("No executor available".to_string()) });
             task_manager.remove(&task_id).await;
             return ExecutionResult { task_id, record_id: None };
         }
@@ -109,7 +109,7 @@ pub async fn run_todo_execution(
         tracing::error!("Failed to start todo execution: {}", e);
         let entry = ParsedLogEntry::error(format!("Failed to start todo execution: {}", e));
         send_event(&tx, ExecEvent::Output { task_id: task_id.clone(), entry });
-        send_event(&tx, ExecEvent::Finished { task_id: task_id.clone(), todo_id, success: false, result: Some("Failed to start execution".to_string()) });
+        send_event(&tx, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo.as_ref().map(|t| t.title.clone()).unwrap_or_default(), executor: executor_str.clone(), success: false, result: Some("Failed to start execution".to_string()) });
         let _ = db.finish_todo_execution(todo_id, false).await;
         task_manager.remove(&task_id).await;
         return ExecutionResult { task_id, record_id: Some(record_id) };
@@ -165,7 +165,7 @@ pub async fn run_todo_execution(
             Err(e) => {
                 let entry = ParsedLogEntry::error(format!("Failed to spawn executor: {}", e));
                 send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
-                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, success: false, result: None });
+                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: None });
                 let _ = db_clone.finish_todo_execution(todo_id, false).await;
                 task_manager_spawn.remove(&task_id).await;
                 return;
@@ -394,7 +394,7 @@ pub async fn run_todo_execution(
 
                 let entry = ParsedLogEntry::error("Execution cancelled by user");
                 send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
-                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, success: false, result: None });
+                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: None });
                 task_manager_spawn.remove(&task_id).await;
                 return;
             }
@@ -511,7 +511,7 @@ pub async fn run_todo_execution(
         );
         send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
 
-        send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, success, result: Some(result_str) });
+        send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success, result: Some(result_str) });
         task_manager_spawn.remove(&task_id).await;
     });
 

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -163,9 +163,10 @@ pub async fn run_todo_execution(
         let mut child = match cmd.group_spawn() {
             Ok(c) => c,
             Err(e) => {
-                let entry = ParsedLogEntry::error(format!("Failed to spawn executor: {}", e));
+                let error_msg = format!("Failed to spawn executor: {}", e);
+                let entry = ParsedLogEntry::error(error_msg.clone());
                 send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
-                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: None });
+                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: Some(error_msg) });
                 let _ = db_clone.finish_todo_execution(todo_id, false).await;
                 task_manager_spawn.remove(&task_id).await;
                 return;
@@ -394,7 +395,7 @@ pub async fn run_todo_execution(
 
                 let entry = ParsedLogEntry::error("Execution cancelled by user");
                 send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
-                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: None });
+                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: Some("Task was cancelled by user".to_string()) });
                 task_manager_spawn.remove(&task_id).await;
                 return;
             }

--- a/backend/src/handlers/agent_bot.rs
+++ b/backend/src/handlers/agent_bot.rs
@@ -87,8 +87,8 @@ pub async fn feishu_begin() -> Result<impl IntoResponse, AppError> {
         .ok_or_else(|| AppError::Internal("Missing verification_uri_complete".to_string()))?
         .to_string();
 
-    if !qr_url.starts_with("https://accounts.feishu.cn/") {
-        return Err(AppError::Internal("Invalid verification URI domain".to_string()));
+    if !qr_url.starts_with("https://accounts.feishu.cn/") && !qr_url.starts_with("https://accounts.larksuite.com/") && !qr_url.starts_with("https://open.feishu.cn/") && !qr_url.starts_with("https://open.larksuite.com/") {
+        return Err(AppError::Internal(format!("Invalid verification URI domain: {}", qr_url)));
     }
 
     let user_code = body

--- a/backend/src/handlers/agent_bot.rs
+++ b/backend/src/handlers/agent_bot.rs
@@ -357,3 +357,67 @@ pub async fn update_agent_bot_config(
 
     Ok(ApiResponse::ok(serde_json::json!({"success": true})))
 }
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FeishuPushStatus {
+    pub bot_id: i64,
+    pub push_level: String,
+    pub chat_id: Option<String>,
+    pub receive_id: String,
+    pub receive_id_type: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UpdateFeishuPushRequest {
+    pub bot_id: i64,
+    pub push_level: String,
+}
+
+pub async fn get_feishu_push(
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, AppError> {
+    let bots = state.db.get_agent_bots().await.map_err(|e| AppError::Internal(e.to_string()))?;
+    let mut statuses = Vec::new();
+
+    for bot in bots.into_iter().filter(|b| b.bot_type == "feishu") {
+        let target = state.db.get_feishu_push_target(bot.id).await.ok().flatten();
+        statuses.push(FeishuPushStatus {
+            bot_id: bot.id,
+            push_level: target.as_ref().map(|t| t.push_level.clone()).unwrap_or_else(|| "disabled".to_string()),
+            chat_id: target.as_ref().and_then(|t| t.chat_id.clone()),
+            receive_id: target.as_ref().map(|t| t.receive_id.clone()).unwrap_or_default(),
+            receive_id_type: target.as_ref().map(|t| t.receive_id_type.clone()).unwrap_or_default(),
+        });
+    }
+
+    Ok(ApiResponse::ok(statuses))
+}
+
+pub async fn update_feishu_push(
+    State(state): State<AppState>,
+    Json(req): Json<UpdateFeishuPushRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let target = state
+        .db
+        .get_feishu_push_target(req.bot_id)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or(AppError::NotFound)?;
+
+    state
+        .db
+        .update_feishu_push_level(req.bot_id, &req.push_level)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    // Refresh push service cache
+    let _ = state.feishu_push_mutator.send(crate::services::feishu_push::PushConfigUpdate::Refresh);
+
+    Ok(ApiResponse::ok(FeishuPushStatus {
+        bot_id: req.bot_id,
+        push_level: req.push_level,
+        chat_id: target.chat_id,
+        receive_id: target.receive_id,
+        receive_id_type: target.receive_id_type,
+    }))
+}

--- a/backend/src/handlers/agent_bot.rs
+++ b/backend/src/handlers/agent_bot.rs
@@ -370,7 +370,10 @@ pub struct FeishuPushStatus {
 #[derive(Debug, Clone, Deserialize)]
 pub struct UpdateFeishuPushRequest {
     pub bot_id: i64,
-    pub push_level: String,
+    pub push_level: Option<String>,
+    pub receive_id: Option<String>,
+    pub receive_id_type: Option<String>,
+    pub chat_id: Option<String>,
 }
 
 pub async fn get_feishu_push(
@@ -404,20 +407,45 @@ pub async fn update_feishu_push(
         .map_err(|e| AppError::Internal(e.to_string()))?
         .ok_or(AppError::NotFound)?;
 
-    state
-        .db
-        .update_feishu_push_level(req.bot_id, &req.push_level)
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?;
+    // Update push_level if provided
+    if let Some(level) = &req.push_level {
+        state
+            .db
+            .update_feishu_push_level(req.bot_id, level)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+    }
+
+    // Update receive fields if provided
+    if req.receive_id.is_some() || req.receive_id_type.is_some() || req.chat_id.is_some() {
+        state
+            .db
+            .set_feishu_push_target(
+                req.bot_id,
+                req.chat_id.as_deref(),
+                req.receive_id.as_deref().unwrap_or(&target.receive_id),
+                req.receive_id_type.as_deref().unwrap_or(&target.receive_id_type),
+                target.push_level.as_str(),
+            )
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+    }
 
     // Refresh push service cache
     let _ = state.feishu_push_mutator.send(crate::services::feishu_push::PushConfigUpdate::Refresh);
 
+    // Fetch updated target
+    let updated = state
+        .db
+        .get_feishu_push_target(req.bot_id)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
     Ok(ApiResponse::ok(FeishuPushStatus {
         bot_id: req.bot_id,
-        push_level: req.push_level,
-        chat_id: target.chat_id,
-        receive_id: target.receive_id,
-        receive_id_type: target.receive_id_type,
+        push_level: updated.as_ref().map(|t| t.push_level.clone()).unwrap_or_default(),
+        chat_id: updated.as_ref().and_then(|t| t.chat_id.clone()),
+        receive_id: updated.as_ref().map(|t| t.receive_id.clone()).unwrap_or_default(),
+        receive_id_type: updated.as_ref().map(|t| t.receive_id_type.clone()).unwrap_or_default(),
     }))
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -57,6 +57,8 @@ pub enum ExecEvent {
     Finished {
         task_id: String,
         todo_id: i64,
+        todo_title: String,
+        executor: String,
         success: bool,
         result: Option<String>,
     },

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -31,6 +31,7 @@ pub struct AppState {
     pub task_manager: Arc<TaskManager>,
     pub config: Arc<tokio::sync::RwLock<Config>>,
     pub feishu_listener: Arc<FeishuListener>,
+    pub feishu_push_mutator: broadcast::Sender<crate::services::feishu_push::PushConfigUpdate>,
 }
 
 impl AppState {
@@ -304,14 +305,20 @@ pub fn create_app(
         }
     });
 
+    // Create and start Feishu push service before AppState
+    use crate::services::feishu_push::FeishuPushService;
+    let (push_service, push_mutator) = FeishuPushService::new(db.clone(), feishu_listener.clone());
+    push_service.start(tx.subscribe());
+
     let state = AppState {
         db,
         executor_registry,
-        tx,
+        tx: tx.clone(),
         scheduler,
         task_manager,
         config,
-        feishu_listener,
+        feishu_listener: feishu_listener.clone(),
+        feishu_push_mutator: push_mutator,
     };
 
     Router::new()
@@ -355,6 +362,7 @@ pub fn create_app(
         .route("/xyz/agent-bots/feishu/init", post(agent_bot::feishu_init))
         .route("/xyz/agent-bots/feishu/begin", post(agent_bot::feishu_begin))
         .route("/xyz/agent-bots/feishu/poll", post(agent_bot::feishu_poll))
+        .route("/xyz/agent-bots/feishu/push", get(agent_bot::get_feishu_push).put(agent_bot::update_feishu_push))
         .route("/xyz/agent-bots/{id}", delete(agent_bot::delete_agent_bot))
         .route("/xyz/agent-bots/{id}/config", put(agent_bot::update_agent_bot_config))
         .route("/assets/{*path}", get(static_handler))

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -148,6 +148,12 @@ impl FeishuListener {
             return;
         }
 
+        // /feishupush command (toggle push)
+        if content == "/feishupush" {
+            Self::handle_feishupush(db, credentials, bot_id, chat_type, &msg.sender, &msg.channel, &msg.id, reaction_id.as_deref()).await;
+            return;
+        }
+
         // DM: check dm_enabled
         if chat_type == "p2p" {
             if !bot_config.dm_enabled {
@@ -197,7 +203,7 @@ impl FeishuListener {
     ) {
         let (receive_id, receive_id_type, chat_id) = match chat_type {
             "p2p" => (sender.to_string(), "open_id", None),
-            _ => (channel.to_string(), "chat", Some(channel.to_string())),
+            _ => (channel.to_string(), "chat_id", Some(channel.to_string())),
         };
 
         match db
@@ -215,8 +221,115 @@ impl FeishuListener {
             }
         }
 
+        // Also store as push target (default to result_only)
+        if let Err(e) = db
+            .set_feishu_push_target(bot_id, chat_id.as_deref(), &receive_id, receive_id_type, "result_only")
+            .await
+        {
+            tracing::error!("[feishu:{}] set push target failed: {e}", bot_id);
+        }
+
+        // Send confirmation
+        let chat_type_label = if chat_type == "p2p" { "私聊" } else { "群聊" };
+        let target_desc = if chat_type == "p2p" { "此私聊" } else { channel };
+        let confirm = format!("✅ 已设置推送目标为此 {chat_type_label} ({target_desc})，执行过程将实时推送。\n\n如需关闭推送，请发送 /feishupush");
+        Self::send_text(credentials, bot_id, &receive_id, &receive_id_type, &confirm).await;
+
         if let Some(rid) = reaction_id {
             Self::delete_reaction(credentials, bot_id, message_id, rid).await;
+        }
+    }
+
+    /// Handle /feishupush - cycle push level: disabled -> result_only -> all -> disabled.
+    async fn handle_feishupush(
+        db: &Database,
+        credentials: &DashMap<i64, (String, String, String)>,
+        bot_id: i64,
+        chat_type: &str,
+        sender: &str,
+        channel: &str,
+        message_id: &str,
+        reaction_id: Option<&str>,
+    ) {
+        let (receive_id, receive_id_type) = match chat_type {
+            "p2p" => (sender.to_string(), "open_id"),
+            _ => (channel.to_string(), "chat_id"),
+        };
+
+        let target = db.get_feishu_push_target(bot_id).await.ok().flatten();
+        let current_level = target.as_ref().map(|t| t.push_level.as_str()).unwrap_or("disabled");
+        let new_level = match current_level {
+            "disabled" => "result_only",
+            "result_only" => "all",
+            "all" => "disabled",
+            _ => "disabled",
+        };
+
+        if let Err(e) = db.update_feishu_push_level(bot_id, new_level).await {
+            tracing::error!("[feishu:{}] /feishupush update failed: {e}", bot_id);
+            let msg = "⚠️ 操作失败，请稍后重试";
+            Self::send_text(credentials, bot_id, &receive_id, &receive_id_type, msg).await;
+        } else {
+            let (status_text, status_emoji) = match new_level {
+                "disabled" => ("关闭", "ℹ️"),
+                "result_only" => ("已切换为仅结论", "✅"),
+                "all" => ("已切换为全部", "✅"),
+                _ => ("未知", "⚠️"),
+            };
+            let msg = format!("{} 推送{}。", status_emoji, status_text);
+            Self::send_text(credentials, bot_id, &receive_id, &receive_id_type, &msg).await;
+            tracing::info!("[feishu:{}] /feishupush: push level changed to {} for bot_id={}", bot_id, new_level, bot_id);
+        }
+
+        if let Some(rid) = reaction_id {
+            Self::delete_reaction(credentials, bot_id, message_id, rid).await;
+        }
+    }
+
+    /// Send a plain text message to a Feishu recipient.
+    async fn send_text(
+        credentials: &DashMap<i64, (String, String, String)>,
+        bot_id: i64,
+        receive_id: &str,
+        receive_id_type: &str,
+        text: &str,
+    ) {
+        let base_url = match Self::base_url(credentials, bot_id) {
+            Some(u) => u,
+            None => return,
+        };
+        let token = match Self::get_tenant_token(credentials, bot_id).await {
+            Some(t) => t,
+            None => return,
+        };
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/open-apis/im/v1/messages?receive_id_type={}", base_url, receive_id_type);
+        let body = serde_json::json!({
+            "receive_id": receive_id,
+            "msg_type": "text",
+            "content": serde_json::to_string(&serde_json::json!({ "text": text })).unwrap_or_default()
+        });
+
+        match client
+            .post(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+        {
+            Ok(res) => {
+                let status = res.status();
+                if !status.is_success() {
+                    tracing::error!("[feishu:{}] send_text failed: status={}", bot_id, status);
+                } else {
+                    tracing::debug!("[feishu:{}] send_text ok to {} ({})", bot_id, receive_id, receive_id_type);
+                }
+            }
+            Err(e) => {
+                tracing::error!("[feishu:{}] send_text request failed: {e}", bot_id);
+            }
         }
     }
 
@@ -228,6 +341,45 @@ impl FeishuListener {
         } else {
             anyhow::bail!("bot {} not running", bot_id)
         }
+    }
+
+    /// Send a raw text message using a specific receive_id_type.
+    pub async fn send_raw(
+        &self,
+        bot_id: i64,
+        receive_id: &str,
+        receive_id_type: &str,
+        text: &str,
+    ) -> anyhow::Result<()> {
+        let base_url = Self::base_url(&self.bot_credentials, bot_id)
+            .ok_or_else(|| anyhow::anyhow!("no credentials for bot {}", bot_id))?;
+        let token = Self::get_tenant_token(&self.bot_credentials, bot_id)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("no token for bot {}", bot_id))?;
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/open-apis/im/v1/messages?receive_id_type={}", base_url, receive_id_type);
+        let body = serde_json::json!({
+            "receive_id": receive_id,
+            "msg_type": "text",
+            "content": serde_json::to_string(&serde_json::json!({ "text": text })).unwrap_or_default()
+        });
+
+        let res = client
+            .post(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
+
+        let status = res.status();
+        if !status.is_success() {
+            let body: serde_json::Value = res.json().await.unwrap_or_default();
+            return Err(anyhow::anyhow!("send_raw failed: {} {:?}", status, body));
+        }
+
+        Ok(())
     }
 
     // --- Feishu API helpers ---

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -1,0 +1,194 @@
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::broadcast;
+use tracing::{debug, error, info, warn};
+
+use crate::db::Database;
+use crate::handlers::ExecEvent;
+use crate::services::feishu_listener::FeishuListener;
+
+/// Subscribe to ExecEvent broadcast and push formatted messages to Feishu.
+pub struct FeishuPushService {
+    db: Arc<Database>,
+    feishu_listener: Arc<FeishuListener>,
+    mutator: broadcast::Sender<PushConfigUpdate>,
+}
+
+#[derive(Clone, Debug)]
+pub enum PushConfigUpdate {
+    Refresh,
+}
+
+impl FeishuPushService {
+    pub fn new(
+        db: Arc<Database>,
+        feishu_listener: Arc<FeishuListener>,
+    ) -> (Self, broadcast::Sender<PushConfigUpdate>) {
+        let (mutator, _) = broadcast::channel(4);
+        let service = Self {
+            db,
+            feishu_listener,
+            mutator: mutator.clone(),
+        };
+        (service, mutator)
+    }
+
+    /// Start the push loop. Call this once after construction.
+    pub fn start(&self, mut rx: broadcast::Receiver<ExecEvent>) {
+        let db = self.db.clone();
+        let feishu_listener = self.feishu_listener.clone();
+        let mut config_rx = self.mutator.subscribe();
+        let mut targets_cache: Vec<(i64, String, String, String)> = Vec::new();
+        let mut last_refresh = Instant::now();
+
+        tokio::spawn(async move {
+            // Initial load
+            Self::refresh_targets(&db, &mut targets_cache).await;
+
+            loop {
+                tokio::select! {
+                    event = rx.recv() => {
+                        match event {
+                            Ok(ev) => {
+                                // Refresh targets every 60 seconds
+                                if last_refresh.elapsed().as_secs() > 60 {
+                                    Self::refresh_targets(&db, &mut targets_cache).await;
+                                    last_refresh = Instant::now();
+                                }
+
+                                if targets_cache.is_empty() {
+                                    continue;
+                                }
+
+                                let Some(text) = Self::format_event(&ev) else {
+                                    continue;
+                                };
+
+                                for (bot_id, receive_id, receive_id_type, push_level) in targets_cache.iter() {
+                                    if !Self::should_send(push_level, &ev) {
+                                        continue;
+                                    }
+                                    if let Err(e) = feishu_listener.send_raw(*bot_id, receive_id, receive_id_type, &text).await {
+                                        warn!("[feishu-push] send failed for bot {}: {}", bot_id, e);
+                                    } else {
+                                        debug!("[feishu-push] sent to bot {}: {}", bot_id, &text[..text.len().min(60)]);
+                                    }
+                                }
+                            }
+                            Err(broadcast::error::RecvError::Lagged(n)) => {
+                                warn!("[feishu-push] lagged {} events, skipping", n);
+                            }
+                            Err(broadcast::error::RecvError::Closed) => {
+                                info!("[feishu-push] channel closed, stopping");
+                                break;
+                            }
+                        }
+                    }
+                    update = config_rx.recv() => {
+                        if update.is_ok() {
+                            Self::refresh_targets(&db, &mut targets_cache).await;
+                            last_refresh = Instant::now();
+                            debug!("[feishu-push] targets refreshed");
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    pub fn mutator(&self) -> broadcast::Sender<PushConfigUpdate> {
+        self.mutator.clone()
+    }
+
+    /// Check if an event should be sent based on push_level.
+    /// - "disabled": never send
+    /// - "result_only": only send Finished events
+    /// - "all": send all events
+    fn should_send(push_level: &str, event: &ExecEvent) -> bool {
+        match push_level {
+            "disabled" => false,
+            "result_only" => matches!(event, ExecEvent::Finished { .. }),
+            "all" => true,
+            _ => false,
+        }
+    }
+
+    async fn refresh_targets(db: &Database, targets: &mut Vec<(i64, String, String, String)>) {
+        targets.clear();
+        match db.get_enabled_feishu_push_targets().await {
+            Ok(targets_list) => {
+                for t in targets_list {
+                    targets.push((t.bot_id, t.receive_id, t.receive_id_type, t.push_level));
+                }
+            }
+            Err(e) => {
+                error!("[feishu-push] failed to load push targets: {}", e);
+            }
+        }
+    }
+
+    /// Format an ExecEvent into a text message (if not a sync event).
+    fn format_event(event: &ExecEvent) -> Option<String> {
+        match event {
+            ExecEvent::Started { task_id, todo_title, executor, .. } => {
+                Some(format!(
+                    "🟢 [开始执行]\n📋 {}\n⚡ 执行器: {}\n🆔 TaskID: {}",
+                    todo_title, executor, task_id
+                ))
+            }
+            ExecEvent::Output { task_id, entry } => {
+                let prefix = match entry.log_type.as_str() {
+                    "error" | "stderr" => "🔴",
+                    "warning" => "⚠️",
+                    "success" => "✅",
+                    "user" | "input" => "👤",
+                    _ => "📝",
+                };
+                let content = entry.content.trim();
+                if content.is_empty() {
+                    None
+                } else {
+                    let preview = if content.chars().count() > 200 {
+                        content.chars().take(200).collect::<String>() + "..."
+                    } else {
+                        content.to_string()
+                    };
+                    Some(format!("{} {}\n🆔 {}", prefix, preview, task_id))
+                }
+            }
+            ExecEvent::Finished { success, result, .. } => {
+                let status = if *success { "✅ 成功" } else { "❌ 失败" };
+                let result_preview = result.as_ref()
+                    .map(|r| format!("\n📤 结果: {}", if r.chars().count() > 100 { r.chars().take(100).collect::<String>() + "..." } else { r.clone() }))
+                    .unwrap_or_default();
+                Some(format!(
+                    "{} [执行完成] {}{}",
+                    if *success { "✅" } else { "❌" },
+                    status,
+                    result_preview
+                ))
+            }
+            ExecEvent::TodoProgress { task_id, progress } => {
+                if progress.is_empty() {
+                    None
+                } else {
+                    let items: Vec<String> = progress.iter().take(5).map(|t| {
+                        format!("• {} [{}]", t.content, t.status)
+                    }).collect();
+                    Some(format!(
+                        "📋 [进度更新] TaskID: {}\n{}",
+                        task_id,
+                        items.join("\n")
+                    ))
+                }
+            }
+            ExecEvent::ExecutionStats { task_id, stats } => {
+                Some(format!(
+                    "📊 [执行统计] TaskID: {}\n🔧 工具调用: {}\n💬 对话轮次: {}",
+                    task_id, stats.tool_calls, stats.conversation_turns
+                ))
+            }
+            ExecEvent::Sync { .. } => None,
+        }
+    }
+}

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -156,15 +156,15 @@ impl FeishuPushService {
                     Some(format!("{} {}\n🆔 {}", prefix, preview, task_id))
                 }
             }
-            ExecEvent::Finished { success, result, .. } => {
-                let status = if *success { "✅ 成功" } else { "❌ 失败" };
+            ExecEvent::Finished { success, result, todo_title, executor, .. } => {
                 let result_preview = result.as_ref()
-                    .map(|r| format!("\n📤 结果: {}", if r.chars().count() > 100 { r.chars().take(100).collect::<String>() + "..." } else { r.clone() }))
+                    .map(|r| format!("\n\n📤 结果: {}", if r.chars().count() > 100 { r.chars().take(100).collect::<String>() + "..." } else { r.clone() }))
                     .unwrap_or_default();
                 Some(format!(
-                    "{} [执行完成] {}{}",
-                    if *success { "✅" } else { "❌" },
-                    status,
+                    "📋 {}\n⚡ 执行器: {}\n{}{}",
+                    todo_title,
+                    executor,
+                    if *success { "✅ 成功" } else { "❌ 失败" },
                     result_preview
                 ))
             }

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,1 +1,2 @@
 pub mod feishu_listener;
+pub mod feishu_push;

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -41,6 +41,7 @@ import QRCode from 'qrcode';
 import 'react-js-cron/dist/styles.css';
 import { useApp } from '../hooks/useApp';
 import * as db from '../utils/database';
+import type { FeishuPushStatus } from '../utils/database';
 import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '../utils/cron';
 import type { Config, ExecutorPaths } from '../types';
 import yaml from 'js-yaml';
@@ -127,6 +128,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
   // Agent Bots state
   const [agentBots, setAgentBots] = useState<db.AgentBot[]>([]);
   const [botsLoading, setBotsLoading] = useState(false);
+  const [feishuPushStatus, setFeishuPushStatus] = useState<FeishuPushStatus[]>([]);
   const [binding, setBinding] = useState(false);
   const [bindModalOpen, setBindModalOpen] = useState(false);
   const [qrCodeUrl, setQrCodeUrl] = useState('');
@@ -213,8 +215,15 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       .finally(() => setBotsLoading(false));
   };
 
+  const loadFeishuPush = () => {
+    db.getFeishuPush()
+      .then((status) => setFeishuPushStatus(status))
+      .catch(() => {});
+  };
+
   useEffect(() => {
     loadAgentBots();
+    loadFeishuPush();
   }, []);
 
   // 飞书绑定 — 后端轮询模式，前端只需一次调用
@@ -248,6 +257,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
         setBindSuccess(true);
         message.success(`绑定成功！Bot: ${pollRes.bot_name || 'Feishu Bot'}`);
         loadAgentBots();
+        loadFeishuPush();
         setTimeout(() => {
           setBindModalOpen(false);
           setQrCodeUrl('');
@@ -887,6 +897,17 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                       }
                     };
 
+                    const botPushStatus = feishuPushStatus.find(p => p.bot_id === bot.id);
+                    const hasPushTarget = !!botPushStatus && (botPushStatus.receive_id || botPushStatus.chat_id);
+                    const handlePushLevelChange = async (level: db.FeishuPushLevel) => {
+                      try {
+                        await db.updateFeishuPush(bot.id, level);
+                        loadFeishuPush();
+                      } catch (e: any) {
+                        message.error('设置推送失败: ' + (e.message || '未知错误'));
+                      }
+                    };
+
                     return (
                       <div
                         key={bot.id}
@@ -967,6 +988,22 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                                 Echo 回复
                               </span>
                             </div>
+                            {hasPushTarget && (
+                              <div style={{ marginTop: 8 }}>
+                                <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 6 }}>实时推送 {botPushStatus.receive_id_type === 'open_id' ? '(私聊)' : '(群聊)'}</div>
+                                <Select
+                                  size="small"
+                                  value={botPushStatus.push_level}
+                                  onChange={handlePushLevelChange}
+                                  style={{ width: 120 }}
+                                  options={[
+                                    { value: 'disabled', label: '关闭' },
+                                    { value: 'result_only', label: '仅结论' },
+                                    { value: 'all', label: '全部' },
+                                  ]}
+                                />
+                              </div>
+                            )}
                           </div>
                         )}
                       </div>

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -35,6 +35,7 @@ import {
   InfoCircleOutlined,
   MessageOutlined,
   QrcodeOutlined,
+  CopyOutlined,
 } from '@ant-design/icons';
 import { Cron } from 'react-js-cron';
 import QRCode from 'qrcode';
@@ -901,11 +902,26 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                     const hasPushTarget = !!botPushStatus && (botPushStatus.receive_id || botPushStatus.chat_id);
                     const handlePushLevelChange = async (level: db.FeishuPushLevel) => {
                       try {
-                        await db.updateFeishuPush(bot.id, level);
+                        await db.updateFeishuPush({ botId: bot.id, pushLevel: level });
                         loadFeishuPush();
                       } catch (e: any) {
                         message.error('设置推送失败: ' + (e.message || '未知错误'));
                       }
+                    };
+                    const handlePushTargetUpdate = async (field: 'receive_id' | 'receive_id_type' | 'chat_id', value: string) => {
+                      try {
+                        await db.updateFeishuPush({ botId: bot.id, [field]: value });
+                        loadFeishuPush();
+                      } catch (e: any) {
+                        message.error('更新推送目标失败: ' + (e.message || '未知错误'));
+                      }
+                    };
+                    const copyToClipboard = (text: string, label: string) => {
+                      navigator.clipboard.writeText(text).then(() => {
+                        message.success(`${label} 已复制`);
+                      }).catch(() => {
+                        message.error('复制失败');
+                      });
                     };
 
                     return (
@@ -991,17 +1007,56 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                             {hasPushTarget && (
                               <div style={{ marginTop: 8 }}>
                                 <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 6 }}>实时推送 {botPushStatus.receive_id_type === 'open_id' ? '(私聊)' : '(群聊)'}</div>
-                                <Select
-                                  size="small"
-                                  value={botPushStatus.push_level}
-                                  onChange={handlePushLevelChange}
-                                  style={{ width: 120 }}
-                                  options={[
-                                    { value: 'disabled', label: '关闭' },
-                                    { value: 'result_only', label: '仅结论' },
-                                    { value: 'all', label: '全部' },
-                                  ]}
-                                />
+                                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center', marginBottom: 6 }}>
+                                  <Select
+                                    size="small"
+                                    value={botPushStatus.push_level}
+                                    onChange={handlePushLevelChange}
+                                    style={{ width: 100 }}
+                                    options={[
+                                      { value: 'disabled', label: '关闭' },
+                                      { value: 'result_only', label: '仅结论' },
+                                      { value: 'all', label: '全部' },
+                                    ]}
+                                  />
+                                </div>
+                                <div style={{ fontSize: 11, color: 'var(--color-text-secondary)', marginBottom: 4 }}>推送目标信息（可编辑）</div>
+                                <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                                  <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                                    <span style={{ fontSize: 11, width: 80, color: 'var(--color-text-tertiary)' }}>接收ID:</span>
+                                    <Input
+                                      size="small"
+                                      value={botPushStatus.receive_id}
+                                      onChange={(e) => handlePushTargetUpdate('receive_id', e.target.value)}
+                                      style={{ flex: 1, fontSize: 11 }}
+                                    />
+                                    <Button size="small" icon={<CopyOutlined />} onClick={() => copyToClipboard(botPushStatus.receive_id, 'receive_id')} />
+                                  </div>
+                                  <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                                    <span style={{ fontSize: 11, width: 80, color: 'var(--color-text-tertiary)' }}>群ID:</span>
+                                    <Input
+                                      size="small"
+                                      value={botPushStatus.chat_id || ''}
+                                      onChange={(e) => handlePushTargetUpdate('chat_id', e.target.value)}
+                                      style={{ flex: 1, fontSize: 11 }}
+                                    />
+                                    <Button size="small" icon={<CopyOutlined />} onClick={() => copyToClipboard(botPushStatus.chat_id || '', 'chat_id')} />
+                                  </div>
+                                  <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                                    <span style={{ fontSize: 11, width: 80, color: 'var(--color-text-tertiary)' }}>推送类型:</span>
+                                    <Select
+                                      size="small"
+                                      value={botPushStatus.receive_id_type}
+                                      onChange={(v) => handlePushTargetUpdate('receive_id_type', v)}
+                                      style={{ width: 100 }}
+                                      options={[
+                                        { value: 'open_id', label: '私聊' },
+                                        { value: 'chat_id', label: '群聊' },
+                                      ]}
+                                    />
+                                    <Button size="small" icon={<CopyOutlined />} onClick={() => copyToClipboard(botPushStatus.receive_id_type, 'receive_id_type')} />
+                                  </div>
+                                </div>
                               </div>
                             )}
                           </div>

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -358,3 +358,24 @@ export async function feishuPoll(device_code: string, interval?: number, expire_
     expire_in,
   }));
 }
+
+export type FeishuPushLevel = 'disabled' | 'result_only' | 'all';
+
+export interface FeishuPushStatus {
+  bot_id: number;
+  push_level: FeishuPushLevel;
+  chat_id?: string;
+  receive_id: string;
+  receive_id_type: string;
+}
+
+export async function getFeishuPush(): Promise<FeishuPushStatus[]> {
+  return unwrap(await api.get<ApiResp<FeishuPushStatus[]>>('/xyz/agent-bots/feishu/push'));
+}
+
+export async function updateFeishuPush(botId: number, pushLevel: FeishuPushLevel): Promise<FeishuPushStatus> {
+  return unwrap(await api.put<ApiResp<FeishuPushStatus>>('/xyz/agent-bots/feishu/push', {
+    bot_id: botId,
+    push_level: pushLevel,
+  }));
+}

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -373,9 +373,20 @@ export async function getFeishuPush(): Promise<FeishuPushStatus[]> {
   return unwrap(await api.get<ApiResp<FeishuPushStatus[]>>('/xyz/agent-bots/feishu/push'));
 }
 
-export async function updateFeishuPush(botId: number, pushLevel: FeishuPushLevel): Promise<FeishuPushStatus> {
+export interface UpdateFeishuPushParams {
+  botId: number;
+  pushLevel?: FeishuPushLevel;
+  receiveId?: string;
+  receiveIdType?: string;
+  chatId?: string;
+}
+
+export async function updateFeishuPush(params: UpdateFeishuPushParams): Promise<FeishuPushStatus> {
   return unwrap(await api.put<ApiResp<FeishuPushStatus>>('/xyz/agent-bots/feishu/push', {
-    bot_id: botId,
-    push_level: pushLevel,
+    bot_id: params.botId,
+    push_level: params.pushLevel,
+    receive_id: params.receiveId,
+    receive_id_type: params.receiveIdType,
+    chat_id: params.chatId,
   }));
 }


### PR DESCRIPTION
## Summary
- 添加 `/sethome` 命令设置推送目标（私聊/群聊），默认启用"仅结论"推送
- 添加 `/feishupush` 命令在三个推送级别间循环切换：关闭 → 仅结论 → 全部 → 关闭
- 添加 `FeishuPushService` 订阅 `ExecEvent` 广播，实时推送执行过程/结果到飞书
- 前端设置页面「消息」标签支持三档切换：关闭 / 仅结论 / 全部

## 推送级别说明
- **关闭**：不推送任何消息
- **仅结论**：仅在任务执行完成时推送结果
- **全部**：推送执行过程中的所有事件（开始、输出、完成等）

## Test plan
- [ ] 在飞书私聊 Bot，发送 `/sethome` 设置推送目标
- [ ] 在飞书群聊发送 `/sethome` 设置群推送
- [ ] 执行任务，验证"仅结论"收到完成消息
- [ ] 执行任务，验证"全部"收到所有过程消息
- [ ] 前端设置页面切换推送级别