### PR TITLE
fix: 修复飞书 reaction 事件处理和 push_level 字段迁移

### DIFF
--- a/backend/src/daemon.rs
+++ b/backend/src/daemon.rs
@@ -1,13 +1,13 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 
 use clap::Subcommand;
 
-const SERVICE_NAME: &str = "ntd";
-const SERVICE_DESCRIPTION: &str = "Nothing Todo (ntd) - AI Todo Service";
+#[allow(unused)] const SERVICE_NAME: &str = "ntd";
+#[allow(unused)] const SERVICE_DESCRIPTION: &str = "Nothing Todo (ntd) - AI Todo Service";
 const LAUNCHD_LABEL: &str = "com.nothing-todo.ntd";
-const TASK_NAME: &str = "ntd";
+#[allow(unused)] const TASK_NAME: &str = "ntd";
 
 #[derive(Subcommand)]
 pub enum DaemonAction {
@@ -94,6 +94,7 @@ fn get_ntd_dir() -> PathBuf {
 }
 
 /// Get the directory containing the ntd binary (for PATH in service definition)
+#[allow(unused)]
 fn get_ntd_bin_dir() -> PathBuf {
     get_ntd_binary_path()
         .parent()

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -320,6 +320,12 @@ impl Database {
         )
         .await?;
 
+        // 添加 push_level 字段的迁移（向后兼容）
+        self.exec(
+            "ALTER TABLE feishu_push_targets ADD COLUMN push_level TEXT DEFAULT 'all'"
+        )
+        .await.ok(); // 忽略错误，因为字段可能已存在
+
         Ok(())
     }
 }

--- a/backend/src/feishu/channel.rs
+++ b/backend/src/feishu/channel.rs
@@ -148,6 +148,24 @@ impl FeishuChannelService {
                                 error!("Failed to forward message to channel bus: {e}");
                             }
                         })
+                        .and_then(|builder| {
+                            builder.register_p2_im_message_reaction_deleted_v1(|event| {
+                                tracing::debug!(
+                                    "WebSocket: reaction deleted on message {} in chat {:?}",
+                                    event.event.message_id,
+                                    event.event.chat_id
+                                );
+                            })
+                        })
+                        .and_then(|builder| {
+                            builder.register_p2_im_message_reaction_created_v1(|event| {
+                                tracing::debug!(
+                                    "WebSocket: reaction created on message {} in chat {:?}",
+                                    event.event.message_id,
+                                    event.event.chat_id
+                                );
+                            })
+                        })
                         .expect("Failed to register event handler")
                         .build();
 

--- a/backend/src/feishu/sdk/event.rs
+++ b/backend/src/feishu/sdk/event.rs
@@ -82,6 +82,50 @@ pub struct MentionEvent {
     pub tenant_key: String,
 }
 
+// --- P2ImMessageReactionDeletedV1 ---
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct P2ImMessageReactionDeletedV1 {
+    pub schema: String,
+    pub header: EventHeader,
+    pub event: P2ImMessageReactionDeletedV1Data,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct P2ImMessageReactionDeletedV1Data {
+    #[serde(default)]
+    pub sender: Option<EventSender>,
+    pub message_id: String,
+    #[serde(default)]
+    pub chat_id: Option<String>,
+    #[serde(default)]
+    pub reaction_type: serde_json::Value,
+    #[serde(default)]
+    pub create_time: Option<String>,
+}
+
+// --- P2ImMessageReactionCreatedV1 ---
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct P2ImMessageReactionCreatedV1 {
+    pub schema: String,
+    pub header: EventHeader,
+    pub event: P2ImMessageReactionCreatedV1Data,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct P2ImMessageReactionCreatedV1Data {
+    #[serde(default)]
+    pub sender: Option<EventSender>,
+    pub message_id: String,
+    #[serde(default)]
+    pub chat_id: Option<String>,
+    #[serde(default)]
+    pub reaction_type: serde_json::Value,
+    #[serde(default)]
+    pub create_time: Option<String>,
+}
+
 // --- Event dispatcher ---
 
 pub trait EventHandler {
@@ -102,6 +146,42 @@ where
     fn handle(&self, payload: &[u8]) -> anyhow::Result<()> {
         let message: P2ImMessageReceiveV1 = serde_json::from_slice(payload)?;
         (self.f)(message);
+        Ok(())
+    }
+}
+
+struct P2ImMessageReactionDeletedV1Handler<F>
+where
+    F: Fn(P2ImMessageReactionDeletedV1) + 'static,
+{
+    f: F,
+}
+
+impl<F> EventHandler for P2ImMessageReactionDeletedV1Handler<F>
+where
+    F: Fn(P2ImMessageReactionDeletedV1) + 'static + Sync + Send,
+{
+    fn handle(&self, payload: &[u8]) -> anyhow::Result<()> {
+        let event: P2ImMessageReactionDeletedV1 = serde_json::from_slice(payload)?;
+        (self.f)(event);
+        Ok(())
+    }
+}
+
+struct P2ImMessageReactionCreatedV1Handler<F>
+where
+    F: Fn(P2ImMessageReactionCreatedV1) + 'static,
+{
+    f: F,
+}
+
+impl<F> EventHandler for P2ImMessageReactionCreatedV1Handler<F>
+where
+    F: Fn(P2ImMessageReactionCreatedV1) + 'static + Sync + Send,
+{
+    fn handle(&self, payload: &[u8]) -> anyhow::Result<()> {
+        let event: P2ImMessageReactionCreatedV1 = serde_json::from_slice(payload)?;
+        (self.f)(event);
         Ok(())
     }
 }
@@ -164,6 +244,32 @@ impl EventDispatcherHandlerBuilder {
             return Err(format!("processor already registered, type: {key}"));
         }
         let processor = P2ImMessageReceiveV1Handler { f };
+        self.processor_map.insert(key, Box::new(processor));
+        Ok(self)
+    }
+
+    pub fn register_p2_im_message_reaction_deleted_v1<F>(mut self, f: F) -> Result<Self, String>
+    where
+        F: Fn(P2ImMessageReactionDeletedV1) + 'static + Sync + Send,
+    {
+        let key = "p2.im.message.reaction.deleted_v1".to_string();
+        if self.processor_map.contains_key(&key) {
+            return Err(format!("processor already registered, type: {key}"));
+        }
+        let processor = P2ImMessageReactionDeletedV1Handler { f };
+        self.processor_map.insert(key, Box::new(processor));
+        Ok(self)
+    }
+
+    pub fn register_p2_im_message_reaction_created_v1<F>(mut self, f: F) -> Result<Self, String>
+    where
+        F: Fn(P2ImMessageReactionCreatedV1) + 'static + Sync + Send,
+    {
+        let key = "p2.im.message.reaction.created_v1".to_string();
+        if self.processor_map.contains_key(&key) {
+            return Err(format!("processor already registered, type: {key}"));
+        }
+        let processor = P2ImMessageReactionCreatedV1Handler { f };
         self.processor_map.insert(key, Box::new(processor));
         Ok(self)
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2815,6 +2815,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"


### PR DESCRIPTION
## Summary

- 添加 `p2.im.message.reaction.created_v1` 和 `deleted_v1` 事件处理器，解决事件处理器不存在错误
- 将 reaction 事件数据结构的可选字段（`sender`、`chat_id`、`create_time`）改为 `Option` 类型以兼容飞书不同版本的 API
- 添加 `feishu_push_targets` 表 `push_level` 列的 `ALTER TABLE` 迁移，解决 `no such column` 错误
- 清除 `daemon.rs` 中因 `#[cfg]` 条件编译导致的未使用变量警告（`SERVICE_NAME`、`SERVICE_DESCRIPTION`、`TASK_NAME`、`get_ntd_bin_dir`）

## Test plan

- [x] 重启服务后飞书 reaction 事件不再报错
- [x] `push_level` 字段迁移正常执行
- [x] 编译无警告