### PR TITLE
fix: execution panel info popover z-index and overflow

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1296,13 +1296,15 @@ code {
 
 .execution-panel-tabs {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   border-bottom: 1px solid var(--color-border-light);
   background: var(--color-bg);
   flex-shrink: 0;
-  height: 40px;
+  min-height: 40px;
   padding: 0 8px;
   gap: 4px;
+  position: relative;
+  z-index: 10;
 }
 
 .execution-panel-tabs-scroll {

--- a/frontend/src/components/ExecutionPanel.tsx
+++ b/frontend/src/components/ExecutionPanel.tsx
@@ -221,7 +221,7 @@ export function ExecutionPanel({ collapsed, onToggleCollapse }: ExecutionPanelPr
                       position: 'absolute',
                       top: '100%',
                       left: 0,
-                      zIndex: 100,
+                      zIndex: 1000,
                       background: 'var(--color-bg-elevated)',
                       border: '1px solid var(--color-border-light)',
                       borderRadius: 8,

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1211,7 +1211,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                     }
                   >
                     <Paragraph type="secondary" style={{ marginBottom: 16, fontSize: 13 }}>
-                      {'配置全局斜杠命令，将飞书消息中的命令路由到指定 Todo。命中后会把命令后的正文作为参数传入 Todo Prompt，支持使用 `{{content}}`、`{{message}}`、`{{raw_message}}`、`{{slash_command}}`。'}
+                      配置全局斜杠命令，将飞书消息中的命令路由到指定 Todo。命中后会把命令后的正文作为参数传入 Todo Prompt，支持使用 {'{{'}content{'}}'}、{'{{'}message{'}}'}、{'{{'}raw_message{'}}'}、{'{{'}slash_command{'}}'}。
                     </Paragraph>
                     <Form form={configForm} layout="vertical">
                       <Form.List name="slash_command_rules">


### PR DESCRIPTION
## Summary
- 修复执行面板 info 按钮弹出的内容被其他控件遮挡的问题
- `.execution-panel-tabs` 改为 `min-height` 并设置 `z-index`
- popover `z-index` 从 100 提升到 1000

## Changes
- `frontend/src/App.css`: tabs 容器样式调整
- `frontend/src/components/ExecutionPanel.tsx`: popover z-index 提升
- `frontend/src/components/SettingsPage.tsx`: 修复 JSX 中 `{{}}` 转义