### PR TITLE
feat: group chat whitelist for message response

### DIFF
--- a/backend/src/db/entity/feishu_group_whitelist.rs
+++ b/backend/src/db/entity/feishu_group_whitelist.rs
@@ -1,0 +1,18 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "feishu_group_whitelist")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub bot_id: i64,
+    pub sender_open_id: String,
+    pub sender_name: Option<String>,
+    pub created_at: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/entity/mod.rs
+++ b/backend/src/db/entity/mod.rs
@@ -5,6 +5,7 @@ pub mod feishu_history_chats;
 pub mod feishu_messages;
 pub mod feishu_push_targets;
 pub mod feishu_response_config;
+pub mod feishu_group_whitelist;
 pub mod tags;
 pub mod todo_tags;
 pub mod todos;
@@ -17,6 +18,7 @@ pub mod prelude {
     pub use super::feishu_messages::Entity as FeishuMessages;
     pub use super::feishu_push_targets::Entity as FeishuPushTargets;
     pub use super::feishu_response_config::Entity as FeishuResponseConfig;
+    pub use super::feishu_group_whitelist::Entity as FeishuGroupWhitelist;
     pub use super::tags::Entity as Tags;
     pub use super::todo_tags::Entity as TodoTags;
     pub use super::todos::Entity as Todos;

--- a/backend/src/db/feishu_group_whitelist.rs
+++ b/backend/src/db/feishu_group_whitelist.rs
@@ -1,0 +1,65 @@
+use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter};
+use crate::db::Database;
+use crate::db::entity::feishu_group_whitelist;
+
+impl Database {
+    /// Check if a sender is in the whitelist for a bot.
+    /// Returns true if whitelist is empty (no restriction) or sender is in the list.
+    pub async fn is_sender_in_whitelist(
+        &self,
+        bot_id: i64,
+        sender_open_id: &str,
+    ) -> Result<bool, sea_orm::DbErr> {
+        let list = feishu_group_whitelist::Entity::find()
+            .filter(feishu_group_whitelist::Column::BotId.eq(bot_id))
+            .all(&self.conn)
+            .await?;
+
+        // Empty whitelist means no restriction
+        if list.is_empty() {
+            return Ok(true);
+        }
+
+        Ok(list.iter().any(|w| w.sender_open_id == sender_open_id))
+    }
+
+    /// Get all whitelist entries for a bot.
+    pub async fn get_group_whitelist(
+        &self,
+        bot_id: i64,
+    ) -> Result<Vec<feishu_group_whitelist::Model>, sea_orm::DbErr> {
+        feishu_group_whitelist::Entity::find()
+            .filter(feishu_group_whitelist::Column::BotId.eq(bot_id))
+            .all(&self.conn)
+            .await
+    }
+
+    /// Add a sender to the whitelist.
+    pub async fn add_group_whitelist(
+        &self,
+        bot_id: i64,
+        sender_open_id: &str,
+        sender_name: Option<&str>,
+    ) -> Result<feishu_group_whitelist::Model, sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+        let am = feishu_group_whitelist::ActiveModel {
+            bot_id: ActiveValue::Set(bot_id),
+            sender_open_id: ActiveValue::Set(sender_open_id.to_string()),
+            sender_name: ActiveValue::Set(sender_name.map(String::from)),
+            created_at: ActiveValue::Set(Some(now)),
+            ..Default::default()
+        };
+        am.insert(&self.conn).await
+    }
+
+    /// Remove a sender from the whitelist.
+    pub async fn remove_group_whitelist(
+        &self,
+        id: i64,
+    ) -> Result<(), sea_orm::DbErr> {
+        feishu_group_whitelist::Entity::delete_by_id(id)
+            .exec(&self.conn)
+            .await?;
+        Ok(())
+    }
+}

--- a/backend/src/db/feishu_group_whitelist.rs
+++ b/backend/src/db/feishu_group_whitelist.rs
@@ -34,13 +34,23 @@ impl Database {
             .await
     }
 
-    /// Add a sender to the whitelist.
+    /// Add a sender to the whitelist. Returns existing entry if duplicate.
     pub async fn add_group_whitelist(
         &self,
         bot_id: i64,
         sender_open_id: &str,
         sender_name: Option<&str>,
     ) -> Result<feishu_group_whitelist::Model, sea_orm::DbErr> {
+        // Check if already exists
+        if let Some(existing) = feishu_group_whitelist::Entity::find()
+            .filter(feishu_group_whitelist::Column::BotId.eq(bot_id))
+            .filter(feishu_group_whitelist::Column::SenderOpenId.eq(sender_open_id))
+            .one(&self.conn)
+            .await?
+        {
+            return Ok(existing);
+        }
+
         let now = crate::models::utc_timestamp();
         let am = feishu_group_whitelist::ActiveModel {
             bot_id: ActiveValue::Set(bot_id),

--- a/backend/src/db/feishu_message.rs
+++ b/backend/src/db/feishu_message.rs
@@ -32,6 +32,7 @@ impl Database {
         chat_id: &str,
         chat_type: &str,
         sender_open_id: &str,
+        sender_type: Option<&str>,
         content: Option<&str>,
         msg_type: &str,
         is_mention: bool,
@@ -44,6 +45,7 @@ impl Database {
             chat_type: ActiveValue::Set(chat_type.to_string()),
             sender_open_id: ActiveValue::Set(sender_open_id.to_string()),
             sender_nickname: ActiveValue::Set(None),
+            sender_type: ActiveValue::Set(sender_type.map(String::from)),
             content: ActiveValue::Set(content.map(String::from)),
             msg_type: ActiveValue::Set(msg_type.to_string()),
             is_mention: ActiveValue::Set(Some(is_mention)),
@@ -208,6 +210,13 @@ impl Database {
                 model.sender_nickname.clone(),
                 0,
             ));
+            // Prefer non-null nickname and sender_type
+            if model.sender_nickname.is_some() {
+                entry.1 = model.sender_nickname.clone();
+            }
+            if model.sender_type.is_some() {
+                entry.0 = model.sender_type.clone();
+            }
             entry.2 += 1;
         }
 

--- a/backend/src/db/feishu_message.rs
+++ b/backend/src/db/feishu_message.rs
@@ -210,11 +210,11 @@ impl Database {
                 model.sender_nickname.clone(),
                 0,
             ));
-            // Prefer non-null nickname and sender_type
-            if model.sender_nickname.is_some() {
+            // Fill non-null nickname and sender_type only when missing
+            if entry.1.is_none() && model.sender_nickname.is_some() {
                 entry.1 = model.sender_nickname.clone();
             }
-            if model.sender_type.is_some() {
+            if entry.0.is_none() && model.sender_type.is_some() {
                 entry.0 = model.sender_type.clone();
             }
             entry.2 += 1;

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -394,6 +394,20 @@ impl Database {
         )
         .await?;
 
+        // feishu_group_whitelist 表（群聊响应白名单）
+        self.exec("DROP TABLE IF EXISTS feishu_group_whitelist").await?;
+        self.exec(
+            "CREATE TABLE feishu_group_whitelist (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                bot_id INTEGER NOT NULL,
+                sender_open_id TEXT NOT NULL,
+                sender_name TEXT,
+                created_at TEXT,
+                UNIQUE(bot_id, sender_open_id)
+            )",
+        )
+        .await?;
+
         Ok(())
     }
 }
@@ -408,6 +422,7 @@ mod feishu_message;
 mod feishu_push_target;
 mod feishu_history_chat;
 mod feishu_response_config;
+mod feishu_group_whitelist;
 
 #[cfg(test)]
 mod tests {

--- a/backend/src/feishu/channel.rs
+++ b/backend/src/feishu/channel.rs
@@ -137,6 +137,7 @@ impl FeishuChannelService {
                             let channel_msg = ChannelMessage {
                                 id: message_id,
                                 sender: sender_open_id,
+                                sender_type: msg.sender.sender_type.clone(),
                                 content,
                                 channel: msg.message.chat_id.clone(),
                                 timestamp,

--- a/backend/src/feishu/message.rs
+++ b/backend/src/feishu/message.rs
@@ -3,6 +3,7 @@
 pub struct ChannelMessage {
     pub id: String,
     pub sender: String,
+    pub sender_type: Option<String>,
     pub content: String,
     pub channel: String,
     pub timestamp: u64,

--- a/backend/src/handlers/agent_bot.rs
+++ b/backend/src/handlers/agent_bot.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -444,4 +445,70 @@ pub async fn update_feishu_push(
         p2p_response_enabled: p2p_enabled,
         group_response_enabled: group_enabled,
     }))
+}
+
+// Group Whitelist APIs
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WhitelistEntry {
+    pub id: i64,
+    pub bot_id: i64,
+    pub sender_open_id: String,
+    pub sender_name: Option<String>,
+    pub created_at: Option<String>,
+}
+
+pub async fn get_group_whitelist(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+) -> Result<impl IntoResponse, AppError> {
+    let bot_id: i64 = params.get("bot_id")
+        .ok_or(AppError::BadRequest("bot_id required".into()))?
+        .parse()
+        .map_err(|_| AppError::BadRequest("invalid bot_id".into()))?;
+
+    let list = state.db.get_group_whitelist(bot_id).await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let entries: Vec<WhitelistEntry> = list.into_iter().map(|w| WhitelistEntry {
+        id: w.id,
+        bot_id: w.bot_id,
+        sender_open_id: w.sender_open_id,
+        sender_name: w.sender_name,
+        created_at: w.created_at,
+    }).collect();
+
+    Ok(ApiResponse::ok(entries))
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AddWhitelistRequest {
+    pub bot_id: i64,
+    pub sender_open_id: String,
+    pub sender_name: Option<String>,
+}
+
+pub async fn add_group_whitelist(
+    State(state): State<AppState>,
+    Json(req): Json<AddWhitelistRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let entry = state.db.add_group_whitelist(req.bot_id, &req.sender_open_id, req.sender_name.as_deref()).await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(ApiResponse::ok(WhitelistEntry {
+        id: entry.id,
+        bot_id: entry.bot_id,
+        sender_open_id: entry.sender_open_id,
+        sender_name: entry.sender_name,
+        created_at: entry.created_at,
+    }))
+}
+
+pub async fn delete_group_whitelist(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<impl IntoResponse, AppError> {
+    state.db.remove_group_whitelist(id).await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok(ApiResponse::ok(serde_json::json!({"success": true})))
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -404,6 +404,8 @@ pub fn create_app(
         .route("/xyz/agent-bots/feishu/begin", post(agent_bot::feishu_begin))
         .route("/xyz/agent-bots/feishu/poll", post(agent_bot::feishu_poll))
         .route("/xyz/agent-bots/feishu/push", get(agent_bot::get_feishu_push).put(agent_bot::update_feishu_push))
+        .route("/xyz/agent-bots/feishu/group-whitelist", get(agent_bot::get_group_whitelist).post(agent_bot::add_group_whitelist))
+        .route("/xyz/agent-bots/feishu/group-whitelist/{id}", delete(agent_bot::delete_group_whitelist))
         .route("/xyz/feishu/history-messages", get(feishu_history::get_history_messages))
         .route("/xyz/feishu/senders", get(feishu_history::get_distinct_senders))
         .route("/xyz/feishu/history-chats", get(feishu_history::get_history_chats).post(feishu_history::create_history_chat))

--- a/backend/src/services/feishu_history_fetcher.rs
+++ b/backend/src/services/feishu_history_fetcher.rs
@@ -382,6 +382,16 @@ impl FeishuHistoryFetcher {
 
                         // Process the message through slash command / default response pipeline
                         if let Some(ref msg_content) = content {
+                            // Check group whitelist
+                            let in_whitelist = db.is_sender_in_whitelist(bot_id, sender_open_id).await.unwrap_or(true);
+                            if !in_whitelist {
+                                tracing::debug!(
+                                    "[feishu-history-fetcher] sender {} not in group whitelist, skipping",
+                                    sender_open_id
+                                );
+                                continue;
+                            }
+
                             if let Some((todo_id, execution_record_id)) = Self::process_message(
                                 db,
                                 executor_registry,

--- a/backend/src/services/feishu_history_fetcher.rs
+++ b/backend/src/services/feishu_history_fetcher.rs
@@ -383,7 +383,13 @@ impl FeishuHistoryFetcher {
                         // Process the message through slash command / default response pipeline
                         if let Some(ref msg_content) = content {
                             // Check group whitelist
-                            let in_whitelist = db.is_sender_in_whitelist(bot_id, sender_open_id).await.unwrap_or(true);
+                            let in_whitelist = match db.is_sender_in_whitelist(bot_id, sender_open_id).await {
+                                Ok(allowed) => allowed,
+                                Err(e) => {
+                                    tracing::warn!("[feishu-history-fetcher] whitelist check failed for sender {}, denying: {}", sender_open_id, e);
+                                    false
+                                }
+                            };
                             if !in_whitelist {
                                 tracing::debug!(
                                     "[feishu-history-fetcher] sender {} not in group whitelist, skipping",

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -224,7 +224,13 @@ impl FeishuListener {
 
         // Check group whitelist for group chats
         if chat_type == "group" {
-            let in_whitelist = db.is_sender_in_whitelist(bot_id, &msg.sender).await.unwrap_or(true);
+            let in_whitelist = match db.is_sender_in_whitelist(bot_id, &msg.sender).await {
+                Ok(allowed) => allowed,
+                Err(e) => {
+                    tracing::warn!("[feishu:{}] whitelist check failed for sender {}, defaulting to allow: {}", bot_id, msg.sender, e);
+                    true
+                }
+            };
             if !in_whitelist {
                 tracing::info!("[feishu:{}] sender {} not in group whitelist, skipping", bot_id, msg.sender);
                 if let Some(rid) = &reaction_id {

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -221,6 +221,18 @@ impl FeishuListener {
             return;
         }
 
+        // Check group whitelist for group chats
+        if chat_type == "group" {
+            let in_whitelist = db.is_sender_in_whitelist(bot_id, &msg.sender).await.unwrap_or(true);
+            if !in_whitelist {
+                tracing::info!("[feishu:{}] sender {} not in group whitelist, skipping", bot_id, msg.sender);
+                if let Some(rid) = &reaction_id {
+                    Self::delete_reaction(credentials, token_manager, bot_id, &msg.id, rid).await;
+                }
+                return;
+            }
+        }
+
         if let Some(command_ctx) = Self::parse_slash_command(content) {
             let triggered = Self::handle_custom_slash_command(
                 db,

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -179,6 +179,7 @@ impl FeishuListener {
             &msg.channel,
             chat_type,
             &msg.sender,
+            msg.sender_type.as_deref(),
             Some(&msg.content),
             "text",
             is_mention,

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -5,6 +5,7 @@ import {
   Input,
   InputNumber,
   Select,
+  AutoComplete,
   Button,
   message,
   List,
@@ -158,6 +159,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
   const [historySelectedChatId, setHistorySelectedChatId] = useState<string | undefined>(undefined);
   const [historyIsHistory, setHistoryIsHistory] = useState<boolean | undefined>(undefined);
   const [historySelectedSenderId, setHistorySelectedSenderId] = useState<string | undefined>(undefined);
+  const [historyViewMsg, setHistoryViewMsg] = useState<string | null>(null);
   const [historyAddModalOpen, setHistoryAddModalOpen] = useState(false);
   const [historyForm] = Form.useForm();
 
@@ -1263,33 +1265,32 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                                           </Tooltip>
                                         </div>
                                         <div style={{ display: 'flex', gap: 4, marginBottom: 4 }}>
-                                          <Select
+                                          <AutoComplete
                                             size="small"
-                                            showSearch
-                                            placeholder="搜索选择用户 Open ID"
+                                            placeholder="搜索或粘贴 Open ID"
                                             value={whitelistBotId === botPushStatus.bot_id ? whitelistOpenId : undefined}
                                             onChange={(v) => { setWhitelistBotId(botPushStatus.bot_id); setWhitelistOpenId(v); }}
                                             onFocus={() => { if (whitelistBotId !== botPushStatus.bot_id) { loadGroupWhitelist(botPushStatus.bot_id); loadHistorySenders(); } }}
-                                            onSearch={() => { if (historySenders.length === 0) loadHistorySenders(); }}
                                             filterOption={(input, option) => {
-                                              const sender = historySenders.find(s => s.sender_open_id === option?.value);
-                                              if (!sender) return (option?.value as string)?.toLowerCase().includes(input.toLowerCase());
-                                              const name = sender.sender_nickname?.toLowerCase() || '';
-                                              const id = sender.sender_open_id.toLowerCase();
+                                              if (!option?.value) return false;
+                                              const val = (option.value as string).toLowerCase();
+                                              const label = (option.label as string)?.toLowerCase() || '';
                                               const q = input.toLowerCase();
-                                              return name.includes(q) || id.includes(q);
+                                              return val.includes(q) || label.includes(q);
                                             }}
                                             style={{ flex: 1, fontSize: 11 }}
-                                          >
-                                            {historySenders
-                                              .filter(s => s.sender_type !== 'app')
-                                              .map((s) => (
-                                                <Select.Option key={s.sender_open_id} value={s.sender_open_id}>
-                                                  {s.sender_nickname || s.sender_open_id.slice(0, 16)} ({s.count}条)
-                                                </Select.Option>
-                                              ))
+                                            options={historySenders
+                                              .filter(s => s.sender_open_id)
+                                              .map((s) => {
+                                                const typeTag = s.sender_type === 'app' ? '[Bot] ' : '';
+                                                const label = s.sender_nickname || s.sender_open_id;
+                                                return {
+                                                  value: s.sender_open_id,
+                                                  label: `${typeTag}${label} (${s.count}条)`,
+                                                };
+                                              })
                                             }
-                                          </Select>
+                                          />
                                           <Input
                                             size="small"
                                             placeholder="备注名"
@@ -1322,6 +1323,18 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                       )}
                     </Spin>
                   </Card>
+
+                  <Modal
+                    open={!!historyViewMsg}
+                    onCancel={() => setHistoryViewMsg(null)}
+                    footer={null}
+                    width={560}
+                    title="消息详情"
+                  >
+                    <div style={{ fontSize: 13, lineHeight: 1.8, whiteSpace: 'pre-wrap', wordBreak: 'break-all', maxHeight: 400, overflowY: 'auto' }}>
+                      {historyViewMsg}
+                    </div>
+                  </Modal>
 
                   <Card
                     title="斜杠命令规则"
@@ -1707,17 +1720,29 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                         title: '内容',
                         dataIndex: 'content',
                         key: 'content',
-                        ellipsis: true,
+                        width: 200,
                         render: (content: string, record) => {
+                          let text: string;
                           if (record.msg_type === 'text') {
                             try {
                               const parsed = JSON.parse(content);
-                              return parsed.text || content;
+                              text = parsed.text || content;
                             } catch {
-                              return content;
+                              text = content;
                             }
+                          } else {
+                            return <AntTag>{record.msg_type}</AntTag>;
                           }
-                          return <AntTag>{record.msg_type}</AntTag>;
+                          const MAX = 40;
+                          const truncated = text.length > MAX ? text.slice(0, MAX) + '...' : text;
+                          return (
+                            <span
+                              style={{ cursor: 'pointer', fontSize: 12 }}
+                              onClick={() => setHistoryViewMsg(text)}
+                            >
+                              {truncated}
+                            </span>
+                          );
                         },
                       },
                       {

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1263,14 +1263,33 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                                           </Tooltip>
                                         </div>
                                         <div style={{ display: 'flex', gap: 4, marginBottom: 4 }}>
-                                          <Input
+                                          <Select
                                             size="small"
-                                            placeholder="Open ID"
-                                            value={whitelistBotId === botPushStatus.bot_id ? whitelistOpenId : ''}
-                                            onChange={(e) => { setWhitelistBotId(botPushStatus.bot_id); setWhitelistOpenId(e.target.value); }}
-                                            onFocus={() => { if (whitelistBotId !== botPushStatus.bot_id) loadGroupWhitelist(botPushStatus.bot_id); }}
+                                            showSearch
+                                            placeholder="搜索选择用户 Open ID"
+                                            value={whitelistBotId === botPushStatus.bot_id ? whitelistOpenId : undefined}
+                                            onChange={(v) => { setWhitelistBotId(botPushStatus.bot_id); setWhitelistOpenId(v); }}
+                                            onFocus={() => { if (whitelistBotId !== botPushStatus.bot_id) { loadGroupWhitelist(botPushStatus.bot_id); loadHistorySenders(); } }}
+                                            onSearch={() => { if (historySenders.length === 0) loadHistorySenders(); }}
+                                            filterOption={(input, option) => {
+                                              const sender = historySenders.find(s => s.sender_open_id === option?.value);
+                                              if (!sender) return (option?.value as string)?.toLowerCase().includes(input.toLowerCase());
+                                              const name = sender.sender_nickname?.toLowerCase() || '';
+                                              const id = sender.sender_open_id.toLowerCase();
+                                              const q = input.toLowerCase();
+                                              return name.includes(q) || id.includes(q);
+                                            }}
                                             style={{ flex: 1, fontSize: 11 }}
-                                          />
+                                          >
+                                            {historySenders
+                                              .filter(s => s.sender_type !== 'app')
+                                              .map((s) => (
+                                                <Select.Option key={s.sender_open_id} value={s.sender_open_id}>
+                                                  {s.sender_nickname || s.sender_open_id.slice(0, 16)} ({s.count}条)
+                                                </Select.Option>
+                                              ))
+                                            }
+                                          </Select>
                                           <Input
                                             size="small"
                                             placeholder="备注名"
@@ -1657,17 +1676,29 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                       {
                         title: '发送者',
                         key: 'sender',
-                        width: 120,
+                        width: 160,
                         render: (_, record) => {
                           const isBot = record.sender_type === 'app';
                           return (
-                            <Space>
+                            <Space size={2}>
                               <AntTag color={isBot ? 'blue' : 'green'}>
                                 {isBot ? '智能体' : '用户'}
                               </AntTag>
                               <Typography.Text type="secondary" style={{ fontSize: 12 }}>
                                 {record.sender_nickname || record.sender_open_id?.slice(0, 8) || '-'}
                               </Typography.Text>
+                              {record.sender_open_id && (
+                                <Button
+                                  size="small"
+                                  type="link"
+                                  icon={<CopyOutlined />}
+                                  style={{ fontSize: 10, padding: 0 }}
+                                  onClick={() => {
+                                    navigator.clipboard.writeText(record.sender_open_id);
+                                    message.success('已复制 Open ID');
+                                  }}
+                                />
+                              )}
                             </Space>
                           );
                         },

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -49,7 +49,7 @@ import QRCode from 'qrcode';
 import 'react-js-cron/dist/styles.css';
 import { useApp } from '../hooks/useApp';
 import * as db from '../utils/database';
-import type { FeishuPushStatus } from '../utils/database';
+import type { FeishuPushStatus, WhitelistEntry } from '../utils/database';
 import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '../utils/cron';
 import type { Config, ExecutorPaths, FeishuHistoryMessage, FeishuHistoryChat, SlashCommandRule } from '../types';
 import yaml from 'js-yaml';
@@ -137,6 +137,10 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
   const [agentBots, setAgentBots] = useState<db.AgentBot[]>([]);
   const [botsLoading, setBotsLoading] = useState(false);
   const [feishuPushStatus, setFeishuPushStatus] = useState<FeishuPushStatus[]>([]);
+  const [groupWhitelist, setGroupWhitelist] = useState<WhitelistEntry[]>([]);
+  const [whitelistOpenId, setWhitelistOpenId] = useState('');
+  const [whitelistName, setWhitelistName] = useState('');
+  const [whitelistBotId, setWhitelistBotId] = useState<number | null>(null);
   const [binding, setBinding] = useState(false);
   const [bindModalOpen, setBindModalOpen] = useState(false);
   const [qrCodeUrl, setQrCodeUrl] = useState('');
@@ -244,6 +248,35 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
     db.getFeishuPush()
       .then((status) => setFeishuPushStatus(status))
       .catch(() => {});
+  };
+
+  const loadGroupWhitelist = (botId: number) => {
+    setWhitelistBotId(botId);
+    db.getGroupWhitelist(botId)
+      .then(setGroupWhitelist)
+      .catch(() => setGroupWhitelist([]));
+  };
+
+  const handleAddWhitelist = async () => {
+    if (!whitelistBotId || !whitelistOpenId.trim()) return;
+    try {
+      await db.addGroupWhitelist(whitelistBotId, whitelistOpenId.trim(), whitelistName.trim() || undefined);
+      loadGroupWhitelist(whitelistBotId);
+      setWhitelistOpenId('');
+      setWhitelistName('');
+    } catch (e: any) {
+      message.error('添加白名单失败: ' + (e.message || '未知错误'));
+    }
+  };
+
+  const handleDeleteWhitelist = async (id: number) => {
+    if (!whitelistBotId) return;
+    try {
+      await db.deleteGroupWhitelist(id);
+      loadGroupWhitelist(whitelistBotId);
+    } catch (e: any) {
+      message.error('删除白名单失败: ' + (e.message || '未知错误'));
+    }
   };
 
   const loadHistoryMessages = async () => {
@@ -1219,6 +1252,46 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                                             />
                                           </div>
                                         </div>
+                                      </div>
+                                    )}
+                                    {hasPushTarget && (
+                                      <div style={{ marginTop: 10 }}>
+                                        <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 4 }}>
+                                          群聊响应白名单
+                                          <Tooltip title="白名单为空时不限制，仅白名单内的用户消息会触发响应">
+                                            <InfoCircleOutlined style={{ marginLeft: 4, fontSize: 10 }} />
+                                          </Tooltip>
+                                        </div>
+                                        <div style={{ display: 'flex', gap: 4, marginBottom: 4 }}>
+                                          <Input
+                                            size="small"
+                                            placeholder="Open ID"
+                                            value={whitelistBotId === botPushStatus.bot_id ? whitelistOpenId : ''}
+                                            onChange={(e) => { setWhitelistBotId(botPushStatus.bot_id); setWhitelistOpenId(e.target.value); }}
+                                            onFocus={() => { if (whitelistBotId !== botPushStatus.bot_id) loadGroupWhitelist(botPushStatus.bot_id); }}
+                                            style={{ flex: 1, fontSize: 11 }}
+                                          />
+                                          <Input
+                                            size="small"
+                                            placeholder="备注名"
+                                            value={whitelistBotId === botPushStatus.bot_id ? whitelistName : ''}
+                                            onChange={(e) => { setWhitelistBotId(botPushStatus.bot_id); setWhitelistName(e.target.value); }}
+                                            style={{ width: 80, fontSize: 11 }}
+                                          />
+                                          <Button size="small" onClick={handleAddWhitelist}>添加</Button>
+                                        </div>
+                                        {(whitelistBotId === botPushStatus.bot_id ? groupWhitelist : []).map((w) => (
+                                          <div key={w.id} style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 11, marginBottom: 2 }}>
+                                            <span style={{ color: 'var(--color-text)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                              {w.sender_name || w.sender_open_id}
+                                            </span>
+                                            <span style={{ color: 'var(--color-text-tertiary)', fontSize: 10 }}>{w.sender_open_id.slice(0, 12)}...</span>
+                                            <Button size="small" danger type="link" style={{ fontSize: 10, padding: 0 }} onClick={() => handleDeleteWhitelist(w.id)}>删除</Button>
+                                          </div>
+                                        ))}
+                                        {(whitelistBotId === botPushStatus.bot_id ? groupWhitelist : []).length === 0 && (
+                                          <div style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }}>暂无白名单，所有用户均可触发响应</div>
+                                        )}
                                       </div>
                                     )}
                                   </div>

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -447,3 +447,29 @@ export async function updateFeishuHistoryChat(id: number, params: UpdateFeishuHi
 export async function deleteFeishuHistoryChat(id: number): Promise<void> {
   await api.delete(`/xyz/feishu/history-chats/${id}`);
 }
+
+// Group Whitelist APIs
+
+export interface WhitelistEntry {
+  id: number;
+  bot_id: number;
+  sender_open_id: string;
+  sender_name: string | null;
+  created_at: string | null;
+}
+
+export async function getGroupWhitelist(botId: number): Promise<WhitelistEntry[]> {
+  return unwrap(await api.get<ApiResp<WhitelistEntry[]>>('/xyz/agent-bots/feishu/group-whitelist', { params: { bot_id: botId } }));
+}
+
+export async function addGroupWhitelist(botId: number, senderOpenId: string, senderName?: string): Promise<WhitelistEntry> {
+  return unwrap(await api.post<ApiResp<WhitelistEntry>>('/xyz/agent-bots/feishu/group-whitelist', {
+    bot_id: botId,
+    sender_open_id: senderOpenId,
+    sender_name: senderName || null,
+  }));
+}
+
+export async function deleteGroupWhitelist(id: number): Promise<void> {
+  await api.delete(`/xyz/agent-bots/feishu/group-whitelist/${id}`);
+}


### PR DESCRIPTION
## Summary
- 新增群聊响应白名单功能：仅白名单内用户的消息会触发响应，白名单为空时不限制
- 消息记录表新增发送者 ID 复制按钮，方便获取 sender_open_id
- 白名单下拉支持搜索选择历史消息中的发送者（含 Bot 类型标注 [Bot]）
- 实时消息现在也存储 sender_type，与历史消息一致

## Test plan
- [ ] 添加/删除白名单条目
- [ ] 白名单为空时群聊消息正常响应
- [ ] 白名单非空时仅白名单内发送者触发响应
- [ ] 消息记录表复制按钮正常工作
- [ ] 下拉搜索能找到所有发送者（包括 Bot）