### PR TITLE
fix: stop dropping feishu config tables on restart

### DIFF
--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -361,9 +361,8 @@ impl Database {
         .await?;
 
         // Feishu Push Targets — one row per bot, p2p and group IDs as separate fields
-        self.exec("DROP TABLE IF EXISTS feishu_push_targets").await?;
         self.exec(
-            "CREATE TABLE feishu_push_targets (
+            "CREATE TABLE IF NOT EXISTS feishu_push_targets (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 bot_id INTEGER NOT NULL,
                 p2p_receive_id TEXT NOT NULL DEFAULT '',
@@ -380,9 +379,8 @@ impl Database {
         .await?;
 
         // feishu_response_config 表（响应开关独立配置）
-        self.exec("DROP TABLE IF EXISTS feishu_response_config").await?;
         self.exec(
-            "CREATE TABLE feishu_response_config (
+            "CREATE TABLE IF NOT EXISTS feishu_response_config (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 bot_id INTEGER NOT NULL,
                 target_type TEXT NOT NULL,
@@ -395,7 +393,7 @@ impl Database {
         )
         .await?;
 
-        // Migrate: add debounce_secs column if missing
+        // Migrate: add debounce_secs column if missing (for existing tables created before this column)
         let has_debounce: i64 = self.conn
             .query_one(Statement::from_string(
                 sea_orm::DatabaseBackend::Sqlite,
@@ -409,9 +407,8 @@ impl Database {
         }
 
         // feishu_group_whitelist 表（群聊响应白名单）
-        self.exec("DROP TABLE IF EXISTS feishu_group_whitelist").await?;
         self.exec(
-            "CREATE TABLE feishu_group_whitelist (
+            "CREATE TABLE IF NOT EXISTS feishu_group_whitelist (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 bot_id INTEGER NOT NULL,
                 sender_open_id TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- **Root cause**: `init_tables()` 每次启动时对 `feishu_push_targets`、`feishu_response_config`、`feishu_group_whitelist` 执行 `DROP TABLE IF EXISTS + CREATE TABLE`，直接清空所有配置
- 修复为 `CREATE TABLE IF NOT EXISTS`，保留已有数据
- 保留 `debounce_secs` 列迁移逻辑兼容旧表

## Test plan
- [ ] 设置群聊ID和私聊ID，重启服务，确认ID仍然存在
- [ ] 重启后确认白名单、响应开关、debounce配置均保留