### PR TITLE
fix: record execution_record_id after debounce + clickable links

### DIFF
--- a/backend/src/services/feishu_history_fetcher.rs
+++ b/backend/src/services/feishu_history_fetcher.rs
@@ -421,11 +421,9 @@ impl FeishuHistoryFetcher {
                                     executor: None,
                                     trigger_type,
                                     params,
+                                    message_id: Some(item.message_id.clone()),
                                 });
-                                // Mark message as processed (execution_record_id will be set later by debounce)
-                                if let Err(e) = db.mark_feishu_message_processed(&item.message_id, todo_id, None).await {
-                                    warn!("[feishu-history-fetcher] failed to mark message {} as processed: {}", item.message_id, e);
-                                }
+                                // Debounce timer will mark message as processed with execution_record_id
                             }
                         }
                     }

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -277,6 +277,7 @@ impl FeishuListener {
                             executor: todo.executor.clone(),
                             trigger_type: "slash_command".to_string(),
                             params: Some(params),
+                            message_id: Some(msg.id.clone()),
                         });
                     }
                 }
@@ -300,6 +301,7 @@ impl FeishuListener {
                             executor: None,
                             trigger_type: "default_response".to_string(),
                             params: None,
+                            message_id: Some(msg.id.clone()),
                         });
                     }
                 }
@@ -325,6 +327,7 @@ impl FeishuListener {
                         executor: None,
                         trigger_type: "default_response".to_string(),
                         params: None,
+                        message_id: Some(msg.id.clone()),
                     });
                 }
             }

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -23,6 +23,7 @@ pub struct PendingMessage {
     pub executor: Option<String>,
     pub trigger_type: String,
     pub params: Option<HashMap<String, String>>,
+    pub message_id: Option<String>,
 }
 
 struct DebounceEntry {
@@ -98,7 +99,7 @@ impl MessageDebounce {
                     merged_params.insert("message".to_string(), merged_content);
 
                     let result = start_todo_execution(
-                        db,
+                        db.clone(),
                         executor_registry,
                         tx,
                         task_manager,
@@ -111,8 +112,27 @@ impl MessageDebounce {
                         None,
                     ).await;
 
-                    if let Err(e) = result {
-                        tracing::warn!("[debounce] failed to execute todo {}: {:?}", last.todo_id, e);
+                    match result {
+                        Ok(exec_result) => {
+                            // Update all pending messages with todo_id and execution_record_id
+                            let record_id = exec_result.record_id;
+                            for msg in &entry.messages {
+                                if let Some(ref msg_id) = msg.message_id {
+                                    if let Err(e) = db.mark_feishu_message_processed(msg_id, msg.todo_id, record_id).await {
+                                        tracing::warn!("[debounce] failed to mark message {} as processed: {:?}", msg_id, e);
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("[debounce] failed to execute todo {}: {:?}", last.todo_id, e);
+                            // Still mark messages as processed with todo_id but no record_id
+                            for msg in &entry.messages {
+                                if let Some(ref msg_id) = msg.message_id {
+                                    let _ = db.mark_feishu_message_processed(msg_id, msg.todo_id, None).await;
+                                }
+                            }
+                        }
                     }
                 }
             })

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -129,7 +129,9 @@ impl MessageDebounce {
                             // Still mark messages as processed with todo_id but no record_id
                             for msg in &entry.messages {
                                 if let Some(ref msg_id) = msg.message_id {
-                                    let _ = db.mark_feishu_message_processed(msg_id, msg.todo_id, None).await;
+                                    if let Err(mark_err) = db.mark_feishu_message_processed(msg_id, msg.todo_id, None).await {
+                                        tracing::warn!("[debounce] failed to mark message {} after execution failure: {:?}", msg_id, mark_err);
+                                    }
                                 }
                             }
                         }

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -120,6 +120,8 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
   const [selectedRecordIds, setSelectedRecordIds] = useState<number[]>([]);
   const [stoppingRecords, setStoppingRecords] = useState(false);
   const [runningRecords, setRunningRecords] = useState<ExecutionRecord[]>([]);
+  // Execution record detail modal state
+  const [execDetailRecord, setExecDetailRecord] = useState<ExecutionRecord | null>(null);
   // Selective export state
   const [exportModalOpen, setExportModalOpen] = useState(false);
   const [exportTodoKeys, setExportTodoKeys] = useState<number[]>([]);
@@ -1918,9 +1920,15 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                         width: 80,
                         render: (_, record) => (
                           record.processed_todo_id ? (
-                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                            <Typography.Link
+                              style={{ fontSize: 12 }}
+                              onClick={() => {
+                                dispatch({ type: 'SELECT_TODO', payload: record.processed_todo_id });
+                                onBack?.();
+                              }}
+                            >
                               #{record.processed_todo_id}
-                            </Typography.Text>
+                            </Typography.Link>
                           ) : (
                             <span style={{ color: 'var(--color-text-tertiary)', fontSize: 12 }}>-</span>
                           )
@@ -1932,9 +1940,14 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                         width: 80,
                         render: (_, record) => (
                           record.execution_record_id ? (
-                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                            <Typography.Link
+                              style={{ fontSize: 12 }}
+                              onClick={() => {
+                                db.getExecutionRecord(record.execution_record_id!).then(r => setExecDetailRecord(r)).catch(() => {});
+                              }}
+                            >
                               #{record.execution_record_id}
-                            </Typography.Text>
+                            </Typography.Link>
                           ) : (
                             <span style={{ color: 'var(--color-text-tertiary)', fontSize: 12 }}>-</span>
                           )
@@ -2187,6 +2200,53 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
             },
           ]}
         />
+      </Modal>
+
+      <Modal
+        title={execDetailRecord ? `执行记录 #${execDetailRecord.id}` : '执行记录'}
+        open={!!execDetailRecord}
+        onCancel={() => setExecDetailRecord(null)}
+        footer={null}
+        width={700}
+      >
+        {execDetailRecord && (
+          <div style={{ maxHeight: '60vh', overflow: 'auto' }}>
+            <div style={{ display: 'flex', gap: 16, marginBottom: 12, flexWrap: 'wrap' }}>
+              <span><strong>状态:</strong> {execDetailRecord.status}</span>
+              <span><strong>执行器:</strong> {execDetailRecord.executor || '-'}</span>
+              <span><strong>触发:</strong> {execDetailRecord.trigger_type}</span>
+              {execDetailRecord.model && <span><strong>模型:</strong> {execDetailRecord.model}</span>}
+            </div>
+            <div style={{ marginBottom: 8, fontSize: 12, color: 'var(--color-text-secondary)' }}>
+              开始: {execDetailRecord.started_at ? new Date(execDetailRecord.started_at).toLocaleString() : '-'}
+              {execDetailRecord.finished_at && ` | 结束: ${new Date(execDetailRecord.finished_at).toLocaleString()}`}
+            </div>
+            {execDetailRecord.result && (
+              <div style={{ marginBottom: 12 }}>
+                <strong>结果:</strong>
+                <pre style={{ background: 'var(--color-fill-quaternary)', padding: 8, borderRadius: 4, fontSize: 12, maxHeight: 200, overflow: 'auto', whiteSpace: 'pre-wrap', marginTop: 4 }}>
+                  {execDetailRecord.result}
+                </pre>
+              </div>
+            )}
+            {execDetailRecord.stdout && (
+              <div style={{ marginBottom: 12 }}>
+                <strong>输出:</strong>
+                <pre style={{ background: 'var(--color-fill-quaternary)', padding: 8, borderRadius: 4, fontSize: 12, maxHeight: 200, overflow: 'auto', whiteSpace: 'pre-wrap', marginTop: 4 }}>
+                  {execDetailRecord.stdout}
+                </pre>
+              </div>
+            )}
+            {execDetailRecord.stderr && (
+              <div>
+                <strong>错误:</strong>
+                <pre style={{ background: 'var(--color-fill-quaternary)', padding: 8, borderRadius: 4, fontSize: 12, maxHeight: 150, overflow: 'auto', whiteSpace: 'pre-wrap', marginTop: 4, color: 'var(--color-error)' }}>
+                  {execDetailRecord.stderr}
+                </pre>
+              </div>
+            )}
+          </div>
+        )}
       </Modal>
     </div>
   );

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1943,7 +1943,11 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                             <Typography.Link
                               style={{ fontSize: 12 }}
                               onClick={() => {
-                                db.getExecutionRecord(record.execution_record_id!).then(r => setExecDetailRecord(r)).catch(() => {});
+                                db.getExecutionRecord(record.execution_record_id!)
+                                  .then(r => setExecDetailRecord(r))
+                                  .catch((err) => {
+                                    message.error('加载执行记录失败: ' + (err instanceof Error ? err.message : '未知错误'));
+                                  });
                               }}
                             >
                               #{record.execution_record_id}


### PR DESCRIPTION
## Summary
- Debounce timer 现在会在执行成功后调用 `mark_feishu_message_processed` 写入 `todo_id` 和 `execution_record_id`
- `PendingMessage` 新增 `message_id` 字段，支持 debounce 回调关联回消息记录
- 消息记录表中 todo_id 可点击跳转到 Todo 详情页
- 消息记录表中 execution_record_id 可点击弹出执行记录详情 Modal

## Test plan
- [ ] 发送消息触发 debounce，确认消息记录表中有 execution_record_id
- [ ] 点击 todo_id 链接，确认跳转到对应 Todo 详情
- [ ] 点击 execution_record_id 链接，确认弹出执行记录详情