### PR TITLE
fix: merge all text entries into execution result

### DIFF
--- a/backend/src/adapters/kimi.rs
+++ b/backend/src/adapters/kimi.rs
@@ -193,11 +193,17 @@ impl CodeExecutor for KimiExecutor {
     }
 
     fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
-        // Get the last text response as final result
-        logs.iter()
-            .rev()
-            .find(|l| l.log_type == "text")
-            .map(|l| l.content.clone())
+        let texts: Vec<String> = logs.iter()
+            .filter(|l| l.log_type == "text")
+            .map(|l| l.content.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect();
+
+        if texts.is_empty() {
+            None
+        } else {
+            Some(texts.join("\n\n"))
+        }
     }
 
     fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -31,19 +31,22 @@ pub fn strip_think_tags(content: &str) -> String {
 }
 
 /// Default `get_final_result` for executors that use text+stderr logs with think-tag stripping.
-/// Returns the last "text" log (with think tags stripped), falling back to last "stderr" log.
+/// Collects all "text" log entries (with think tags stripped), falling back to last "stderr" log.
 pub fn default_final_result_with_think_stripping(logs: &[ParsedLogEntry]) -> Option<String> {
-    let text_result = logs.iter()
-        .rev()
-        .find(|l| l.log_type == "text")
-        .map(|l| strip_think_tags(&l.content));
+    let texts: Vec<String> = logs.iter()
+        .filter(|l| l.log_type == "text")
+        .map(|l| strip_think_tags(&l.content))
+        .filter(|t| !t.trim().is_empty())
+        .collect();
 
-    let fallback = logs.iter()
+    if !texts.is_empty() {
+        return Some(texts.join("\n\n"));
+    }
+
+    logs.iter()
         .rev()
         .find(|l| l.log_type == "stderr")
-        .map(|l| l.content.clone());
-
-    text_result.or(fallback)
+        .map(|l| l.content.clone())
 }
 
 /// Extract usage from the last "result" log entry (used by claude_code, codebuddy).

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -40,13 +40,13 @@ pub fn default_final_result_with_think_stripping(logs: &[ParsedLogEntry]) -> Opt
         .collect();
 
     if !texts.is_empty() {
-        return Some(texts.join("\n\n"));
+        Some(texts.join("\n\n"))
+    } else {
+        logs.iter()
+            .rev()
+            .find(|l| l.log_type == "stderr")
+            .map(|l| l.content.clone())
     }
-
-    logs.iter()
-        .rev()
-        .find(|l| l.log_type == "stderr")
-        .map(|l| l.content.clone())
 }
 
 /// Extract usage from the last "result" log entry (used by claude_code, codebuddy).


### PR DESCRIPTION
## Summary
- **问题**：opencode/atomcode/hermes/joinai/codex/kimi 等执行器的 result 字段只取最后一个 `text` 日志条目，多步骤执行时丢失前面步骤的输出
- **修复**：将所有 `text` 类型的日志内容合并（用 `\n\n` 分隔），形成完整的 result
- claude_code / codebuddy 不受影响（它们使用专门的 `result` 类型日志）

**修改前** (record 87): result = `"所有四个事项已全部标记为 completed。"`
**修改后**: result = `"我将按顺序完成这个任务...\n\n已创建包含A、B、C、D的待办列表...\n\n已完成A...\n\n已完成B...\n\n已完成C...\n\n所有四个事项已全部标记为 completed。"`

## Test plan
- [ ] 使用 opencode 执行多步骤任务，确认 result 包含所有步骤输出
- [ ] 确认 claude_code 执行仍正常（不受影响）