### PR TITLE
feat: executor config from yaml to database with enable/disable toggle

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
  "nix 0.24.3",
  "terminfo",
  "thiserror 1.0.69",
- "which",
+ "which 4.4.2",
  "winapi 0.3.9",
 ]
 
@@ -1242,6 +1242,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -2462,6 +2468,7 @@ dependencies = [
  "url",
  "uuid",
  "vergen-gitcl",
+ "which 7.0.3",
  "zip",
 ]
 
@@ -4994,6 +5001,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 1.1.4",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5451,6 +5470,12 @@ checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -36,6 +36,7 @@ url = "2"
 thiserror = "2"
 log = "0.4"
 dashmap = "6"
+which = "7"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -158,6 +158,36 @@ impl ExecutorRegistry {
     pub fn list_executors(&self) -> Vec<ExecutorType> {
         self.executors.read().unwrap().keys().copied().collect()
     }
+
+    pub fn unregister(&self, executor_type: ExecutorType) {
+        self.executors.write().unwrap().remove(&executor_type);
+    }
+
+    /// Create an executor instance by name and path.
+    pub fn create_executor(name: &str, path: &str) -> Option<Arc<dyn CodeExecutor>> {
+        match name {
+            "claude_code" => Some(Arc::new(claude_code::ClaudeCodeExecutor::new(path.to_string()))),
+            "joinai" => Some(Arc::new(joinai::JoinaiExecutor::new(path.to_string()))),
+            "codebuddy" => Some(Arc::new(codebuddy::CodebuddyExecutor::new(path.to_string()))),
+            "opencode" => Some(Arc::new(opencode::OpencodeExecutor::new(path.to_string()))),
+            "atomcode" => Some(Arc::new(atomcode::AtomcodeExecutor::new(path.to_string()))),
+            "hermes" => Some(Arc::new(hermes::HermesExecutor::new(path.to_string()))),
+            "kimi" => Some(Arc::new(kimi::KimiExecutor::new(path.to_string()))),
+            "codex" => Some(Arc::new(codex::CodexExecutor::new(path.to_string()))),
+            _ => None,
+        }
+    }
+
+    /// Register an executor by name and path (convenience method).
+    pub fn register_by_name(&self, name: &str, path: &str) -> bool {
+        if let Some(executor) = Self::create_executor(name, path) {
+            let executor_type = executor.executor_type();
+            self.executors.write().unwrap().insert(executor_type, executor);
+            true
+        } else {
+            false
+        }
+    }
 }
 
 impl Default for ExecutorRegistry {

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -27,7 +27,8 @@ pub struct Config {
     pub db_path: String,
     /// Log level (default: INFO)
     pub log_level: String,
-    /// Executor binary paths. Empty string means use default binary name.
+    /// Executor binary paths (kept for backward-compat migration, not serialized to config.yaml)
+    #[serde(skip_serializing)]
     pub executors: ExecutorPaths,
     /// 是否开启自动数据库备份
     pub auto_backup_enabled: bool,

--- a/backend/src/db/entity/executors.rs
+++ b/backend/src/db/entity/executors.rs
@@ -1,0 +1,21 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "executors")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    #[sea_orm(unique)]
+    pub name: String,
+    pub path: String,
+    pub enabled: bool,
+    pub display_name: String,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/entity/mod.rs
+++ b/backend/src/db/entity/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_bots;
 pub mod execution_records;
+pub mod executors;
 pub mod feishu_homes;
 pub mod feishu_history_chats;
 pub mod feishu_messages;
@@ -13,6 +14,7 @@ pub mod todos;
 pub mod prelude {
     pub use super::agent_bots::Entity as AgentBots;
     pub use super::execution_records::Entity as ExecutionRecords;
+    pub use super::executors::Entity as Executors;
     pub use super::feishu_homes::Entity as FeishuHomes;
     pub use super::feishu_history_chats::Entity as FeishuHistoryChats;
     pub use super::feishu_messages::Entity as FeishuMessages;

--- a/backend/src/db/executor_config.rs
+++ b/backend/src/db/executor_config.rs
@@ -1,0 +1,156 @@
+use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+
+use crate::db::entity::executors;
+use crate::db::Database;
+use crate::models::ExecutorConfig;
+
+fn map_executor(m: executors::Model) -> ExecutorConfig {
+    ExecutorConfig {
+        id: m.id,
+        name: m.name,
+        path: m.path,
+        enabled: m.enabled,
+        display_name: m.display_name,
+        created_at: m.created_at,
+        updated_at: m.updated_at,
+    }
+}
+
+struct DefaultExecutor {
+    name: &'static str,
+    path: &'static str,
+    display_name: &'static str,
+}
+
+const DEFAULT_EXECUTORS: &[DefaultExecutor] = &[
+    DefaultExecutor { name: "claude_code", path: "claude", display_name: "Claude Code" },
+    DefaultExecutor { name: "joinai", path: "joinai", display_name: "JoinAI" },
+    DefaultExecutor { name: "codebuddy", path: "codebuddy", display_name: "CodeBuddy" },
+    DefaultExecutor { name: "opencode", path: "opencode", display_name: "Opencode" },
+    DefaultExecutor { name: "atomcode", path: "atomcode", display_name: "AtomCode" },
+    DefaultExecutor { name: "hermes", path: "hermes", display_name: "Hermes" },
+    DefaultExecutor { name: "kimi", path: "kimi", display_name: "Kimi" },
+    DefaultExecutor { name: "codex", path: "codex", display_name: "Codex" },
+];
+
+impl Database {
+    pub async fn get_executors(&self) -> Result<Vec<ExecutorConfig>, sea_orm::DbErr> {
+        let models = executors::Entity::find()
+            .order_by_asc(executors::Column::Id)
+            .all(&self.conn)
+            .await?;
+        Ok(models.into_iter().map(map_executor).collect())
+    }
+
+    pub async fn get_enabled_executors(&self) -> Result<Vec<ExecutorConfig>, sea_orm::DbErr> {
+        let models = executors::Entity::find()
+            .filter(executors::Column::Enabled.eq(true))
+            .order_by_asc(executors::Column::Id)
+            .all(&self.conn)
+            .await?;
+        Ok(models.into_iter().map(map_executor).collect())
+    }
+
+    pub async fn get_executor_by_name(&self, name: &str) -> Result<Option<ExecutorConfig>, sea_orm::DbErr> {
+        let model = executors::Entity::find()
+            .filter(executors::Column::Name.eq(name))
+            .one(&self.conn)
+            .await?;
+        Ok(model.map(map_executor))
+    }
+
+    pub async fn update_executor(
+        &self,
+        name: &str,
+        path: Option<&str>,
+        enabled: Option<bool>,
+        display_name: Option<&str>,
+    ) -> Result<(), sea_orm::DbErr> {
+        let model = executors::Entity::find()
+            .filter(executors::Column::Name.eq(name))
+            .one(&self.conn)
+            .await?;
+        if let Some(m) = model {
+            let now = crate::models::utc_timestamp();
+            let mut am: executors::ActiveModel = m.into();
+            if let Some(p) = path {
+                am.path = ActiveValue::Set(p.to_string());
+            }
+            if let Some(e) = enabled {
+                am.enabled = ActiveValue::Set(e);
+            }
+            if let Some(d) = display_name {
+                am.display_name = ActiveValue::Set(d.to_string());
+            }
+            am.updated_at = ActiveValue::Set(Some(now));
+            am.update(&self.conn).await?;
+        }
+        Ok(())
+    }
+
+    /// Migrate executor paths from config.yaml into database.
+    /// Only runs when the executors table is empty.
+    pub async fn migrate_from_config(
+        &self,
+        cfg_executors: &crate::config::ExecutorPaths,
+    ) -> Result<(), sea_orm::DbErr> {
+        let count = executors::Entity::find().all(&self.conn).await?;
+        if !count.is_empty() {
+            return Ok(());
+        }
+
+        let now = crate::models::utc_timestamp();
+        let pairs: [(&str, &str); 8] = [
+            ("claude_code", &cfg_executors.claude_code),
+            ("joinai", &cfg_executors.joinai),
+            ("codebuddy", &cfg_executors.codebuddy),
+            ("opencode", &cfg_executors.opencode),
+            ("atomcode", &cfg_executors.atomcode),
+            ("hermes", &cfg_executors.hermes),
+            ("kimi", &cfg_executors.kimi),
+            ("codex", &cfg_executors.codex),
+        ];
+
+        for (name, path) in &pairs {
+            let default = DEFAULT_EXECUTORS.iter().find(|d| d.name == *name).unwrap();
+            let am = executors::ActiveModel {
+                name: ActiveValue::Set(name.to_string()),
+                path: ActiveValue::Set(path.to_string()),
+                enabled: ActiveValue::Set(true),
+                display_name: ActiveValue::Set(default.display_name.to_string()),
+                created_at: ActiveValue::Set(Some(now.clone())),
+                updated_at: ActiveValue::Set(Some(now.clone())),
+                ..Default::default()
+            };
+            am.insert(&self.conn).await?;
+        }
+
+        tracing::info!("Migrated executor paths from config.yaml to database");
+        Ok(())
+    }
+
+    /// Seed default executors if table is empty (fresh install).
+    pub async fn seed_default_executors(&self) -> Result<(), sea_orm::DbErr> {
+        let count = executors::Entity::find().all(&self.conn).await?;
+        if !count.is_empty() {
+            return Ok(());
+        }
+
+        let now = crate::models::utc_timestamp();
+        for d in DEFAULT_EXECUTORS {
+            let am = executors::ActiveModel {
+                name: ActiveValue::Set(d.name.to_string()),
+                path: ActiveValue::Set(d.path.to_string()),
+                enabled: ActiveValue::Set(true),
+                display_name: ActiveValue::Set(d.display_name.to_string()),
+                created_at: ActiveValue::Set(Some(now.clone())),
+                updated_at: ActiveValue::Set(Some(now.clone())),
+                ..Default::default()
+            };
+            am.insert(&self.conn).await?;
+        }
+
+        tracing::info!("Seeded default executors into database");
+        Ok(())
+    }
+}

--- a/backend/src/db/executor_config.rs
+++ b/backend/src/db/executor_config.rs
@@ -1,4 +1,4 @@
-use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect};
 
 use crate::db::entity::executors;
 use crate::db::Database;
@@ -94,30 +94,30 @@ impl Database {
         &self,
         cfg_executors: &crate::config::ExecutorPaths,
     ) -> Result<(), sea_orm::DbErr> {
-        let count = executors::Entity::find().all(&self.conn).await?;
-        if !count.is_empty() {
+        let count = executors::Entity::find().count(&self.conn).await?;
+        if count > 0 {
             return Ok(());
         }
 
         let now = crate::models::utc_timestamp();
-        let pairs: [(&str, &str); 8] = [
-            ("claude_code", &cfg_executors.claude_code),
-            ("joinai", &cfg_executors.joinai),
-            ("codebuddy", &cfg_executors.codebuddy),
-            ("opencode", &cfg_executors.opencode),
-            ("atomcode", &cfg_executors.atomcode),
-            ("hermes", &cfg_executors.hermes),
-            ("kimi", &cfg_executors.kimi),
-            ("codex", &cfg_executors.codex),
-        ];
 
-        for (name, path) in &pairs {
-            let default = DEFAULT_EXECUTORS.iter().find(|d| d.name == *name).unwrap();
+        for d in DEFAULT_EXECUTORS {
+            let path = match d.name {
+                "claude_code" => &cfg_executors.claude_code,
+                "joinai" => &cfg_executors.joinai,
+                "codebuddy" => &cfg_executors.codebuddy,
+                "opencode" => &cfg_executors.opencode,
+                "atomcode" => &cfg_executors.atomcode,
+                "hermes" => &cfg_executors.hermes,
+                "kimi" => &cfg_executors.kimi,
+                "codex" => &cfg_executors.codex,
+                _ => continue,
+            };
             let am = executors::ActiveModel {
-                name: ActiveValue::Set(name.to_string()),
+                name: ActiveValue::Set(d.name.to_string()),
                 path: ActiveValue::Set(path.to_string()),
                 enabled: ActiveValue::Set(true),
-                display_name: ActiveValue::Set(default.display_name.to_string()),
+                display_name: ActiveValue::Set(d.display_name.to_string()),
                 created_at: ActiveValue::Set(Some(now.clone())),
                 updated_at: ActiveValue::Set(Some(now.clone())),
                 ..Default::default()
@@ -131,8 +131,8 @@ impl Database {
 
     /// Seed default executors if table is empty (fresh install).
     pub async fn seed_default_executors(&self) -> Result<(), sea_orm::DbErr> {
-        let count = executors::Entity::find().all(&self.conn).await?;
-        if !count.is_empty() {
+        let count = executors::Entity::find().count(&self.conn).await?;
+        if count > 0 {
             return Ok(());
         }
 

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -419,6 +419,21 @@ impl Database {
         )
         .await?;
 
+        // Executors table (executor config moved from config.yaml to database)
+        self.exec(
+            "CREATE TABLE IF NOT EXISTS executors (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                path TEXT NOT NULL DEFAULT '',
+                enabled INTEGER NOT NULL DEFAULT 1,
+                display_name TEXT NOT NULL DEFAULT '',
+                created_at TEXT,
+                updated_at TEXT
+            )",
+        )
+        .await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_executors_name ON executors(name)").await?;
+
         Ok(())
     }
 }
@@ -428,6 +443,7 @@ mod tag;
 mod execution;
 mod skills;
 mod agent_bot;
+mod executor_config;
 mod feishu_home;
 mod feishu_message;
 mod feishu_push_target;

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -434,6 +434,25 @@ impl Database {
         .await?;
         self.exec("CREATE INDEX IF NOT EXISTS idx_executors_name ON executors(name)").await?;
 
+        // Executors timestamps triggers
+        self.exec(
+            "CREATE TRIGGER IF NOT EXISTS set_executors_created_at_utc AFTER INSERT ON executors
+             WHEN new.created_at IS NULL OR new.created_at = ''
+             BEGIN
+                 UPDATE executors SET created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', 'utc') WHERE rowid = new.rowid;
+             END",
+        )
+        .await?;
+
+        self.exec(
+            "CREATE TRIGGER IF NOT EXISTS set_executors_updated_at_utc BEFORE UPDATE ON executors
+             WHEN new.updated_at IS NULL OR new.updated_at = ''
+             BEGIN
+                 SELECT raise(IGNORE);
+             END",
+        )
+        .await?;
+
         Ok(())
     }
 }

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -27,9 +27,6 @@ pub async fn update_config(
     if let Some(log_level) = req.log_level {
         cfg.log_level = log_level;
     }
-    if let Some(executors) = req.executors {
-        cfg.executors = executors;
-    }
     if let Some(slash_command_rules) = req.slash_command_rules {
         cfg.slash_command_rules = slash_command_rules;
     }

--- a/backend/src/handlers/executor_config.rs
+++ b/backend/src/handlers/executor_config.rs
@@ -123,7 +123,7 @@ fn detect_binary(path: &str) -> (bool, Option<String>) {
     let p = PathBuf::from(&expanded);
 
     // If it looks like an absolute or relative path (contains separator)
-    if p.is_absolute() || expanded.contains(std::path::MAIN_SEPARATOR) {
+    if p.is_absolute() || expanded.contains('/') || expanded.contains('\\') {
         if p.exists() {
             return (true, Some(p.to_string_lossy().to_string()));
         }

--- a/backend/src/handlers/executor_config.rs
+++ b/backend/src/handlers/executor_config.rs
@@ -1,0 +1,127 @@
+use axum::extract::{Path, State};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::handlers::{ApiJson, AppError, AppState};
+use crate::models::{ApiResponse, ExecutorConfig, ExecutorDetectResult, ExecutorTestResult, UpdateExecutorRequest};
+
+pub async fn list_executors(State(state): State<AppState>) -> Result<ApiResponse<Vec<ExecutorConfig>>, AppError> {
+    let executors = state.db.get_executors().await.map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok(ApiResponse::ok(executors))
+}
+
+pub async fn update_executor(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    ApiJson(req): ApiJson<UpdateExecutorRequest>,
+) -> Result<ApiResponse<ExecutorConfig>, AppError> {
+    state.db.update_executor(
+        &name,
+        req.path.as_deref(),
+        req.enabled,
+        req.display_name.as_deref(),
+    ).await.map_err(|e| AppError::Internal(e.to_string()))?;
+
+    // Re-read updated executor
+    let ec = state.db.get_executor_by_name(&name).await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound)?;
+
+    // Update registry based on enabled state
+    if ec.enabled {
+        state.executor_registry.register_by_name(&ec.name, &ec.path);
+    } else {
+        if let Some(et) = crate::adapters::parse_executor_type(&ec.name) {
+            state.executor_registry.unregister(et);
+        }
+    }
+
+    Ok(ApiResponse::ok(ec))
+}
+
+pub async fn detect_executor(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<ApiResponse<ExecutorDetectResult>, AppError> {
+    let ec = state.db.get_executor_by_name(&name).await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound)?;
+
+    let path = if ec.path.is_empty() { name.clone() } else { ec.path.clone() };
+    let (found, resolved) = detect_binary(&path);
+
+    Ok(ApiResponse::ok(ExecutorDetectResult {
+        binary_found: found,
+        path_resolved: resolved,
+    }))
+}
+
+pub async fn test_executor(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<ApiResponse<ExecutorTestResult>, AppError> {
+    let ec = state.db.get_executor_by_name(&name).await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound)?;
+
+    let path = if ec.path.is_empty() { name.clone() } else { ec.path.clone() };
+    let (found, _) = detect_binary(&path);
+
+    if !found {
+        return Ok(ApiResponse::ok(ExecutorTestResult {
+            test_passed: false,
+            output: None,
+            error: Some(format!("Binary not found: {}", path)),
+        }));
+    }
+
+    // Try running --version with a short timeout
+    let output = tokio::time::timeout(
+        Duration::from_secs(10),
+        tokio::process::Command::new(&path)
+            .arg("--version")
+            .output(),
+    ).await;
+
+    match output {
+        Ok(Ok(out)) => {
+            let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+            let combined = if stdout.is_empty() { stderr } else { stdout };
+            Ok(ApiResponse::ok(ExecutorTestResult {
+                test_passed: out.status.success(),
+                output: Some(combined.trim().to_string()),
+                error: None,
+            }))
+        }
+        Ok(Err(e)) => Ok(ApiResponse::ok(ExecutorTestResult {
+            test_passed: false,
+            output: None,
+            error: Some(format!("Failed to execute: {}", e)),
+        })),
+        Err(_) => Ok(ApiResponse::ok(ExecutorTestResult {
+            test_passed: false,
+            output: None,
+            error: Some("Execution timed out (10s)".to_string()),
+        })),
+    }
+}
+
+/// Check if a binary exists at the given path or in PATH.
+fn detect_binary(path: &str) -> (bool, Option<String>) {
+    let p = PathBuf::from(path);
+
+    // If it looks like an absolute or relative path (contains separator)
+    if p.is_absolute() || path.contains(std::path::MAIN_SEPARATOR) {
+        if p.exists() {
+            return (true, Some(p.to_string_lossy().to_string()));
+        }
+        return (false, None);
+    }
+
+    // Bare command name — look up in PATH using `which` equivalent
+    match which::which(path) {
+        Ok(resolved) => (true, Some(resolved.to_string_lossy().to_string())),
+        Err(_) => (false, None),
+    }
+}

--- a/backend/src/handlers/executor_config.rs
+++ b/backend/src/handlers/executor_config.rs
@@ -109,10 +109,21 @@ pub async fn test_executor(
 
 /// Check if a binary exists at the given path or in PATH.
 fn detect_binary(path: &str) -> (bool, Option<String>) {
-    let p = PathBuf::from(path);
+    // Expand ~ to home directory
+    let expanded = if path.starts_with('~') {
+        if let Some(home) = dirs::home_dir() {
+            path.replacen('~', &home.to_string_lossy(), 1)
+        } else {
+            path.to_string()
+        }
+    } else {
+        path.to_string()
+    };
+
+    let p = PathBuf::from(&expanded);
 
     // If it looks like an absolute or relative path (contains separator)
-    if p.is_absolute() || path.contains(std::path::MAIN_SEPARATOR) {
+    if p.is_absolute() || expanded.contains(std::path::MAIN_SEPARATOR) {
         if p.exists() {
             return (true, Some(p.to_string_lossy().to_string()));
         }
@@ -120,7 +131,7 @@ fn detect_binary(path: &str) -> (bool, Option<String>) {
     }
 
     // Bare command name — look up in PATH using `which` equivalent
-    match which::which(path) {
+    match which::which(&expanded) {
         Ok(resolved) => (true, Some(resolved.to_string_lossy().to_string())),
         Err(_) => (false, None),
     }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -149,6 +149,7 @@ pub mod backup;
 mod config;
 pub mod skills;
 pub mod agent_bot;
+pub mod executor_config;
 mod feishu_history;
 
 // WebSocket handler
@@ -405,6 +406,10 @@ pub fn create_app(
         .route("/xyz/backup/database/auto", put(backup::update_auto_backup))
         .route("/xyz/backup/database/file", delete(backup::delete_backup_file))
         .route("/xyz/config", get(config::get_config).put(config::update_config))
+        .route("/xyz/executors", get(executor_config::list_executors))
+        .route("/xyz/executors/{name}", put(executor_config::update_executor))
+        .route("/xyz/executors/{name}/detect", post(executor_config::detect_executor))
+        .route("/xyz/executors/{name}/test", post(executor_config::test_executor))
         .route("/xyz/skills", get(skills::list_skills))
         .route("/xyz/skills/compare", get(skills::compare_skills))
         .route("/xyz/skills/sync", post(skills::sync_skill))

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -193,15 +193,23 @@ async fn run_server(cli_port: Option<u16>) {
 
     db.cleanup_orphan_execution_records().await;
 
+    // Migrate executor paths from config.yaml to database (one-time), then seed defaults if empty
+    if let Err(e) = db.migrate_from_config(&cfg.executors).await {
+        tracing::warn!("Executor config migration check failed: {}", e);
+    }
+    if let Err(e) = db.seed_default_executors().await {
+        tracing::warn!("Failed to seed default executors: {}", e);
+    }
+
     let executor_registry = Arc::new(adapters::ExecutorRegistry::new());
-    executor_registry.register(adapters::joinai::JoinaiExecutor::new(cfg.executors.joinai.clone()));
-    executor_registry.register(adapters::claude_code::ClaudeCodeExecutor::new(cfg.executors.claude_code.clone()));
-    executor_registry.register(adapters::codebuddy::CodebuddyExecutor::new(cfg.executors.codebuddy.clone()));
-    executor_registry.register(adapters::opencode::OpencodeExecutor::new(cfg.executors.opencode.clone()));
-    executor_registry.register(adapters::atomcode::AtomcodeExecutor::new(cfg.executors.atomcode.clone()));
-    executor_registry.register(adapters::hermes::HermesExecutor::new(cfg.executors.hermes.clone()));
-    executor_registry.register(adapters::kimi::KimiExecutor::new(cfg.executors.kimi.clone()));
-    executor_registry.register(adapters::codex::CodexExecutor::new(cfg.executors.codex.clone()));
+    let db_executors = db.get_enabled_executors().await.unwrap_or_default();
+    for ec in &db_executors {
+        if executor_registry.register_by_name(&ec.name, &ec.path) {
+            info!("Registered executor: {} ({})", ec.display_name, ec.name);
+        } else {
+            tracing::warn!("Unknown executor '{}' in database, skipping", ec.name);
+        }
+    }
 
     let executors = executor_registry.list_executors();
     info!("Available executors: {:?}", executors);

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -429,10 +429,40 @@ pub struct UpdateConfigRequest {
     pub host: Option<String>,
     pub db_path: Option<String>,
     pub log_level: Option<String>,
-    pub executors: Option<crate::config::ExecutorPaths>,
     pub slash_command_rules: Option<Vec<crate::config::SlashCommandRule>>,
     pub default_response_todo_id: Option<i64>,
     pub history_message_max_age_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutorConfig {
+    pub id: i64,
+    pub name: String,
+    pub path: String,
+    pub enabled: bool,
+    pub display_name: String,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateExecutorRequest {
+    pub path: Option<String>,
+    pub enabled: Option<bool>,
+    pub display_name: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ExecutorDetectResult {
+    pub binary_found: bool,
+    pub path_resolved: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ExecutorTestResult {
+    pub test_passed: bool,
+    pub output: Option<String>,
+    pub error: Option<String>,
 }
 
 // Executor types

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -46,6 +46,7 @@ import {
   MinusCircleOutlined,
   PlayCircleOutlined,
   StopOutlined,
+  SearchOutlined,
 } from '@ant-design/icons';
 import { Cron } from 'react-js-cron';
 import QRCode from 'qrcode';
@@ -54,7 +55,7 @@ import { useApp } from '../hooks/useApp';
 import * as db from '../utils/database';
 import type { FeishuPushStatus, WhitelistEntry } from '../utils/database';
 import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '../utils/cron';
-import type { Config, ExecutorPaths, FeishuHistoryMessage, FeishuHistoryChat, SlashCommandRule, ExecutionRecord } from '../types';
+import type { Config, ExecutorConfig, FeishuHistoryMessage, FeishuHistoryChat, SlashCommandRule, ExecutionRecord } from '../types';
 import yaml from 'js-yaml';
 import { CronPresetSelect } from './CronPresetSelect';
 import { SkillsPanel } from './SkillsPanel';
@@ -64,39 +65,6 @@ const { Dragger } = Upload;
 const { Option } = Select;
 
 const LOG_LEVELS = ['DEBUG', 'INFO', 'WARN', 'ERROR'];
-
-const DEFAULT_EXECUTORS: ExecutorPaths = {
-  opencode: 'opencode',
-  hermes: 'hermes',
-  joinai: 'joinai',
-  claude_code: 'claude',
-  codebuddy: 'codebuddy',
-  kimi: 'kimi',
-  atomcode: 'atomcode',
-  codex: 'codex',
-};
-
-const EXECUTOR_KEYS: (keyof ExecutorPaths)[] = [
-  'opencode',
-  'hermes',
-  'joinai',
-  'claude_code',
-  'codebuddy',
-  'kimi',
-  'atomcode',
-  'codex',
-];
-
-const EXECUTOR_LABELS: Record<string, string> = {
-  opencode: 'Opencode',
-  hermes: 'Hermes',
-  joinai: 'JoinAI',
-  claude_code: 'Claude Code',
-  codebuddy: 'CodeBuddy',
-  kimi: 'Kimi',
-  atomcode: 'AtomCode',
-  codex: 'Codex',
-};
 
 interface SettingsPageProps {
   onBack?: () => void;
@@ -144,6 +112,16 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
 
   // Agent Bots state
   const [agentBots, setAgentBots] = useState<db.AgentBot[]>([]);
+
+  // Executors state
+  const [executors, setExecutors] = useState<ExecutorConfig[]>([]);
+  const [executorsLoading, setExecutorsLoading] = useState(false);
+  const [detectingExecutor, setDetectingExecutor] = useState<string | null>(null);
+  const [testingExecutor, setTestingExecutor] = useState<string | null>(null);
+  const [detectResults, setDetectResults] = useState<Record<string, { found: boolean; resolved: string | null }>>({});
+  const [testModalVisible, setTestModalVisible] = useState(false);
+  const [testModalData, setTestModalData] = useState<{ name: string; result: { test_passed: boolean; output: string | null; error: string | null } } | null>(null);
+  const [savingExecutor, setSavingExecutor] = useState<string | null>(null);
   const [botsLoading, setBotsLoading] = useState(false);
   const [feishuPushStatus, setFeishuPushStatus] = useState<FeishuPushStatus[]>([]);
   const [groupWhitelist, setGroupWhitelist] = useState<WhitelistEntry[]>([]);
@@ -222,6 +200,19 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       })
       .finally(() => setConfigLoading(false));
   }, [configForm]);
+
+  // Load executors from database
+  useEffect(() => {
+    setExecutorsLoading(true);
+    db.getExecutors()
+      .then((list) => {
+        setExecutors(list);
+      })
+      .catch((err) => {
+        message.error('加载执行器配置失败: ' + (err?.message || String(err)));
+      })
+      .finally(() => setExecutorsLoading(false));
+  }, []);
 
   // Load database backup status
   useEffect(() => {
@@ -449,7 +440,6 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       const mergedConfig: Config = {
         ...currentConfig,
         ...(values as Partial<Config>),
-        executors: (values as Partial<Config>).executors || currentConfig.executors,
         slash_command_rules: hasSlashRulesField
           ? normalizedRules
           : (currentConfig.slash_command_rules ?? []),
@@ -790,35 +780,168 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       label: (
         <span>
           <CodeOutlined style={{ marginRight: 6 }} />
-          执行器路径
+          执行器管理
         </span>
       ),
       children: (
-        <Spin spinning={configLoading}>
-          <Form form={configForm} layout="vertical" style={{ maxWidth: 600 }}>
+        <Spin spinning={executorsLoading}>
+          <div style={{ maxWidth: 800 }}>
             <Paragraph type="secondary" style={{ marginBottom: 16 }}>
-              配置各执行器的二进制路径。留空或填写命令名表示通过 PATH 查找。
+              管理执行器的路径、开关状态，并检测二进制是否可用。关闭开关的执行器不会出现在 Todo 的执行器选择列表中。
             </Paragraph>
-            {EXECUTOR_KEYS.map((key) => (
-              <Form.Item
-                key={key}
-                name={['executors', key]}
-                label={EXECUTOR_LABELS[key]}
-              >
-                <Input placeholder={DEFAULT_EXECUTORS[key]} />
-              </Form.Item>
-            ))}
-            <Form.Item>
-              <Button
-                type="primary"
-                onClick={handleSaveConfig}
-                loading={configSaving}
-                disabled={configLoading}
-              >
-                保存配置
-              </Button>
-            </Form.Item>
-          </Form>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              {executors.map((ec) => {
+                const detectResult = detectResults[ec.name];
+                const isDetecting = detectingExecutor === ec.name;
+                const isTesting = testingExecutor === ec.name;
+                const isSaving = savingExecutor === ec.name;
+                return (
+                  <Card
+                    key={ec.name}
+                    size="small"
+                    style={{
+                      opacity: ec.enabled ? 1 : 0.6,
+                      borderColor: ec.enabled ? undefined : '#d9d9d9',
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+                      <Switch
+                        checked={ec.enabled}
+                        loading={isSaving}
+                        onChange={async (checked) => {
+                          setSavingExecutor(ec.name);
+                          try {
+                            const updated = await db.updateExecutor(ec.name, { enabled: checked });
+                            setExecutors((prev) => prev.map((e) => e.name === ec.name ? updated : e));
+                          } catch (err: any) {
+                            message.error('更新失败: ' + (err?.message || String(err)));
+                          } finally {
+                            setSavingExecutor(null);
+                          }
+                        }}
+                      />
+                      <span style={{ fontWeight: 500, minWidth: 90 }}>{ec.display_name}</span>
+                      <Input
+                        style={{ flex: 1, minWidth: 200 }}
+                        placeholder="二进制路径或命令名"
+                        defaultValue={ec.path}
+                        onBlur={async (e) => {
+                          const newPath = e.target.value.trim();
+                          if (newPath === ec.path) return;
+                          setSavingExecutor(ec.name);
+                          try {
+                            const updated = await db.updateExecutor(ec.name, { path: newPath });
+                            setExecutors((prev) => prev.map((ex) => ex.name === ec.name ? updated : ex));
+                            setDetectResults((prev) => {
+                              const next = { ...prev };
+                              delete next[ec.name];
+                              return next;
+                            });
+                          } catch (err: any) {
+                            message.error('保存失败: ' + (err?.message || String(err)));
+                          } finally {
+                            setSavingExecutor(null);
+                          }
+                        }}
+                        onPressEnter={(e) => {
+                          (e.target as HTMLInputElement).blur();
+                        }}
+                      />
+                      <Button
+                        size="small"
+                        icon={<SearchOutlined />}
+                        loading={isDetecting}
+                        onClick={async () => {
+                          setDetectingExecutor(ec.name);
+                          try {
+                            const result = await db.detectExecutor(ec.name);
+                            setDetectResults((prev) => ({ ...prev, [ec.name]: { found: result.binary_found, resolved: result.path_resolved } }));
+                            if (result.binary_found) {
+                              message.success(`${ec.display_name}: 找到 (${result.path_resolved})`);
+                            } else {
+                              message.warning(`${ec.display_name}: 未找到`);
+                            }
+                          } catch (err: any) {
+                            message.error('检测失败: ' + (err?.message || String(err)));
+                          } finally {
+                            setDetectingExecutor(null);
+                          }
+                        }}
+                      >
+                        检测
+                      </Button>
+                      <Button
+                        size="small"
+                        type="primary"
+                        ghost
+                        icon={<PlayCircleOutlined />}
+                        loading={isTesting}
+                        onClick={async () => {
+                          setTestingExecutor(ec.name);
+                          try {
+                            const result = await db.testExecutor(ec.name);
+                            setTestModalData({ name: ec.name, result });
+                            setTestModalVisible(true);
+                          } catch (err: any) {
+                            message.error('测试失败: ' + (err?.message || String(err)));
+                          } finally {
+                            setTestingExecutor(null);
+                          }
+                        }}
+                      >
+                        测试
+                      </Button>
+                      {detectResult && (
+                        <Tooltip title={detectResult.resolved || '未找到'}>
+                          {detectResult.found
+                            ? <span style={{ color: '#52c41a', fontSize: 16 }}>&#10003;</span>
+                            : <span style={{ color: '#ff4d4f', fontSize: 16 }}>&#10007;</span>
+                          }
+                        </Tooltip>
+                      )}
+                    </div>
+                  </Card>
+                );
+              })}
+            </div>
+          </div>
+          <Modal
+            title={testModalData ? `测试结果 - ${executors.find(e => e.name === testModalData.name)?.display_name || testModalData.name}` : '测试结果'}
+            open={testModalVisible}
+            onCancel={() => setTestModalVisible(false)}
+            footer={<Button onClick={() => setTestModalVisible(false)}>关闭</Button>}
+            width={500}
+          >
+            {testModalData && (
+              <div>
+                <p>
+                  状态：{testModalData.result.test_passed
+                    ? <span style={{ color: '#52c41a', fontWeight: 600 }}>通过</span>
+                    : <span style={{ color: '#ff4d4f', fontWeight: 600 }}>失败</span>
+                  }
+                </p>
+                {testModalData.result.error && (
+                  <p style={{ color: '#ff4d4f' }}>错误：{testModalData.result.error}</p>
+                )}
+                {testModalData.result.output && (
+                  <div>
+                    <Paragraph type="secondary">输出：</Paragraph>
+                    <pre style={{
+                      background: '#f5f5f5',
+                      padding: 12,
+                      borderRadius: 6,
+                      fontSize: 12,
+                      maxHeight: 300,
+                      overflow: 'auto',
+                      whiteSpace: 'pre-wrap',
+                    }}>
+                      {testModalData.result.output}
+                    </pre>
+                  </div>
+                )}
+              </div>
+            )}
+          </Modal>
         </Spin>
       ),
     },
@@ -1105,7 +1228,10 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                 dataIndex: 'executor',
                 key: 'executor',
                 width: 110,
-                render: (v: string | null) => EXECUTOR_LABELS[v || 'claudecode'] || v || 'claudecode',
+                render: (v: string | null) => {
+                  const labels: Record<string, string> = { opencode: 'Opencode', hermes: 'Hermes', joinai: 'JoinAI', claude_code: 'Claude Code', claudecode: 'Claude Code', codebuddy: 'CodeBuddy', kimi: 'Kimi', atomcode: 'AtomCode', codex: 'Codex' };
+                  return labels[v || 'claudecode'] || v || 'claudecode';
+                },
               },
               {
                 title: '触发方式',

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   Tabs,
   Form,

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -116,6 +116,15 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
   // Executors state
   const [executors, setExecutors] = useState<ExecutorConfig[]>([]);
   const [executorsLoading, setExecutorsLoading] = useState(false);
+
+  // Executor name -> display_name map derived from loaded executors
+  const executorDisplayNames = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const ec of executors) {
+      map[ec.name] = ec.display_name;
+    }
+    return map;
+  }, [executors]);
   const [detectingExecutor, setDetectingExecutor] = useState<string | null>(null);
   const [testingExecutor, setTestingExecutor] = useState<string | null>(null);
   const [detectResults, setDetectResults] = useState<Record<string, { found: boolean; resolved: string | null }>>({});
@@ -1229,8 +1238,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                 key: 'executor',
                 width: 110,
                 render: (v: string | null) => {
-                  const labels: Record<string, string> = { opencode: 'Opencode', hermes: 'Hermes', joinai: 'JoinAI', claude_code: 'Claude Code', claudecode: 'Claude Code', codebuddy: 'CodeBuddy', kimi: 'Kimi', atomcode: 'AtomCode', codex: 'Codex' };
-                  return labels[v || 'claudecode'] || v || 'claudecode';
+                  return executorDisplayNames[v || ''] || v || '-';
                 },
               },
               {

--- a/frontend/src/components/TodoSettingsDrawer.tsx
+++ b/frontend/src/components/TodoSettingsDrawer.tsx
@@ -5,8 +5,8 @@ import { Cron } from 'react-js-cron';
 import 'react-js-cron/dist/styles.css';
 import * as db from '../utils/database';
 import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '../utils/cron';
-import { EXECUTORS } from '../types';
-import type { Todo } from '../types';
+import { EXECUTORS, executorConfigToOption } from '../types';
+import type { Todo, ExecutorConfig, ExecutorOption } from '../types';
 import { TagCheckCardGroup } from './TagCheckCard';
 import { CronPresetSelect } from './CronPresetSelect';
 
@@ -28,6 +28,18 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [workspace, setWorkspace] = useState<string>('');
   const [loading, setLoading] = useState(false);
+  const [executorOptions, setExecutorOptions] = useState<ExecutorOption[]>(EXECUTORS);
+
+  useEffect(() => {
+    db.getExecutors()
+      .then((list: ExecutorConfig[]) => {
+        const enabled = list.filter((ec) => ec.enabled);
+        if (enabled.length > 0) {
+          setExecutorOptions(enabled.map(executorConfigToOption));
+        }
+      })
+      .catch(() => {});
+  }, [open]);
 
   useEffect(() => {
     if (todo) {
@@ -100,7 +112,7 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
       <div style={{ marginBottom: 16 }}>
         <div style={{ marginBottom: 10, fontWeight: 600, fontSize: 14 }}>执行器</div>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
-          {EXECUTORS.map((opt) => {
+          {executorOptions.map((opt) => {
             const selected = executor === opt.value;
             return (
               <div

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -217,7 +217,7 @@ export interface ExecutorOption {
 }
 
 export const EXECUTORS: ExecutorOption[] = [
-  { value: 'claudecode', label: 'Claude',    color: '#e17055', icon: <FaSquare color="#e17055" size={14} /> },
+  { value: 'claude_code', label: 'Claude',    color: '#e17055', icon: <FaSquare color="#e17055" size={14} /> },
   { value: 'codebuddy',  label: 'CodeBuddy', color: '#00b894', icon: <FaSquare color="#00b894" size={14} /> },
   { value: 'opencode',   label: 'Opencode',  color: '#fdcb6e', icon: <FaSquare color="#fdcb6e" size={14} /> },
   { value: 'joinai',     label: 'JoinAI',    color: '#6c5ce7', icon: <FaSquare color="#6c5ce7" size={14} /> },
@@ -228,7 +228,7 @@ export const EXECUTORS: ExecutorOption[] = [
 ];
 
 export const EXECUTOR_COLORS: Record<string, string> = {
-  claudecode: '#e17055',
+  claude_code: '#e17055',
   codebuddy: '#00b894',
   opencode: '#fdcb6e',
   joinai: '#6c5ce7',
@@ -274,7 +274,7 @@ export interface Config {
   history_message_max_age_secs?: number;
 }
 
-export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'joinai']);
+export const RESUMABLE_EXECUTORS = new Set(['claude_code', 'kimi', 'opencode', 'joinai']);
 
 export function supportsResume(record: ExecutionRecord): boolean {
   return (

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -227,15 +227,35 @@ export const EXECUTORS: ExecutorOption[] = [
   { value: 'codex',      label: 'Codex',     color: '#488597', icon: <FaSquare color="#488597" size={14} /> },
 ];
 
-export interface ExecutorPaths {
-  opencode: string;
-  hermes: string;
-  joinai: string;
-  claude_code: string;
-  codebuddy: string;
-  kimi: string;
-  atomcode: string;
-  codex: string;
+export const EXECUTOR_COLORS: Record<string, string> = {
+  claudecode: '#e17055',
+  codebuddy: '#00b894',
+  opencode: '#fdcb6e',
+  joinai: '#6c5ce7',
+  atomcode: '#e84393',
+  hermes: '#0984e3',
+  kimi: '#d63031',
+  codex: '#488597',
+};
+
+export interface ExecutorConfig {
+  id: number;
+  name: string;
+  path: string;
+  enabled: boolean;
+  display_name: string;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export function executorConfigToOption(ec: ExecutorConfig): ExecutorOption {
+  const color = EXECUTOR_COLORS[ec.name] || '#999';
+  return {
+    value: ec.name,
+    label: ec.display_name || ec.name,
+    color,
+    icon: <FaSquare color={color} size={14} />,
+  };
 }
 
 export interface SlashCommandRule {
@@ -249,7 +269,6 @@ export interface Config {
   host: string;
   db_path: string;
   log_level: string;
-  executors: ExecutorPaths;
   slash_command_rules?: SlashCommandRule[];
   default_response_todo_id?: number | null;
   history_message_max_age_secs?: number;

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -222,6 +222,25 @@ export async function updateConfig(config: import('../types').Config): Promise<i
   return unwrap(await api.put<ApiResp<import('../types').Config>>('/xyz/config', config));
 }
 
+// Executor Config APIs
+
+export async function getExecutors(): Promise<import('../types').ExecutorConfig[]> {
+  return unwrap(await api.get<ApiResp<import('../types').ExecutorConfig[]>>('/xyz/executors'));
+}
+
+export async function updateExecutor(name: string, data: { path?: string; enabled?: boolean; display_name?: string }): Promise<import('../types').ExecutorConfig> {
+  return unwrap(await api.put<ApiResp<import('../types').ExecutorConfig>>(`/xyz/executors/${name}`, data));
+}
+
+export async function detectExecutor(name: string): Promise<{ binary_found: boolean; path_resolved: string | null }> {
+  return unwrap(await api.post<ApiResp<{ binary_found: boolean; path_resolved: string | null }>>(`/xyz/executors/${name}/detect`));
+}
+
+export async function testExecutor(name: string): Promise<{ test_passed: boolean; output: string | null; error: string | null }> {
+  const result = unwrap(await api.post<ApiResp<{ test_passed: boolean; output: string | null; error: string | null }>>(`/xyz/executors/${name}/test`));
+  return result;
+}
+
 // Skills APIs
 
 export async function getSkillsList(): Promise<ExecutorSkills[]> {

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -229,15 +229,15 @@ export async function getExecutors(): Promise<import('../types').ExecutorConfig[
 }
 
 export async function updateExecutor(name: string, data: { path?: string; enabled?: boolean; display_name?: string }): Promise<import('../types').ExecutorConfig> {
-  return unwrap(await api.put<ApiResp<import('../types').ExecutorConfig>>(`/xyz/executors/${name}`, data));
+  return unwrap(await api.put<ApiResp<import('../types').ExecutorConfig>>(`/xyz/executors/${encodeURIComponent(name)}`, data));
 }
 
 export async function detectExecutor(name: string): Promise<{ binary_found: boolean; path_resolved: string | null }> {
-  return unwrap(await api.post<ApiResp<{ binary_found: boolean; path_resolved: string | null }>>(`/xyz/executors/${name}/detect`));
+  return unwrap(await api.post<ApiResp<{ binary_found: boolean; path_resolved: string | null }>>(`/xyz/executors/${encodeURIComponent(name)}/detect`));
 }
 
 export async function testExecutor(name: string): Promise<{ test_passed: boolean; output: string | null; error: string | null }> {
-  const result = unwrap(await api.post<ApiResp<{ test_passed: boolean; output: string | null; error: string | null }>>(`/xyz/executors/${name}/test`));
+  const result = unwrap(await api.post<ApiResp<{ test_passed: boolean; output: string | null; error: string | null }>>(`/xyz/executors/${encodeURIComponent(name)}/test`));
   return result;
 }
 

--- a/frontend/test_executor_config.cjs
+++ b/frontend/test_executor_config.cjs
@@ -1,0 +1,210 @@
+// 测试执行器管理功能
+const { chromium } = require('playwright');
+
+(async () => {
+  console.log('开始测试执行器管理功能...\n');
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // 收集测试结果
+  const results = {
+    passed: [],
+    failed: []
+  };
+
+  try {
+    // 1. 导航到设置页面
+    console.log('1. 导航到设置页面...');
+    await page.goto('https://t-600b43689eae40d3.hostc.dev');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(2000);
+
+    // 点击设置图标
+    const settingsIcon = page.locator('[class*="setting"]').first();
+    if (await settingsIcon.isVisible({ timeout: 5000 })) {
+      await settingsIcon.click();
+    } else {
+      // 尝试其他选择器
+      const header = page.locator('header, [class*="header"], [class*="Header"]');
+      if (await header.isVisible()) {
+        await header.click();
+      }
+    }
+    await page.waitForTimeout(1000);
+
+    // 2. 点击执行器管理标签页
+    console.log('2. 点击执行器管理标签页...');
+    const executorTab = page.locator('text=执行器管理');
+    if (await executorTab.isVisible({ timeout: 5000 })) {
+      await executorTab.click();
+      await page.waitForTimeout(1000);
+      results.passed.push('执行器管理标签页可见且可点击');
+    } else {
+      // 尝试点击包含"执行器"的标签
+      const anyExecutorTab = page.locator('text=/执行器/').first();
+      if (await anyExecutorTab.isVisible()) {
+        await anyExecutorTab.click();
+        await page.waitForTimeout(1000);
+        results.passed.push('执行器标签页可见且可点击');
+      } else {
+        results.failed.push('执行器管理标签页未找到');
+      }
+    }
+
+    // 3. 验证执行器卡片是否显示
+    console.log('3. 验证执行器卡片显示...');
+    // 查找包含 Claude Code 或 JoinAI 的文本
+    const claudeCard = page.locator('text=Claude Code').first();
+    if (await claudeCard.isVisible({ timeout: 5000 })) {
+      results.passed.push('Claude Code 执行器卡片可见');
+
+      // 4. 检查开关按钮
+      console.log('4. 检查开关按钮...');
+      const switchBtn = claudeCard.locator('..').locator('[class*="switch"], [class*="Switch"]').first();
+      if (await switchBtn.isVisible()) {
+        results.passed.push('Claude Code 开关按钮可见');
+
+        // 检查初始状态是否为启用
+        const isEnabled = await switchBtn.evaluate(el => {
+          const input = el.querySelector('input');
+          return input ? input.checked : false;
+        });
+        if (isEnabled) {
+          results.passed.push('Claude Code 默认启用状态正确');
+        } else {
+          results.failed.push('Claude Code 初始启用状态不正确');
+        }
+      } else {
+        results.failed.push('Claude Code 开关按钮未找到');
+      }
+    } else {
+      results.failed.push('Claude Code 执行器卡片未找到');
+    }
+
+    // 5. 检查检测按钮
+    console.log('5. 检查检测按钮...');
+    const detectBtn = page.locator('button:has-text("检测")').first();
+    if (await detectBtn.isVisible()) {
+      results.passed.push('检测按钮可见');
+
+      // 点击检测
+      await detectBtn.click();
+      await page.waitForTimeout(2000);
+
+      // 检查是否显示成功图标
+      const successIcon = page.locator('span:has-text("✓")').first();
+      if (await successIcon.isVisible({ timeout: 3000 })) {
+        results.passed.push('Claude Code 检测成功显示 ✓ 图标');
+      } else {
+        // 可能是警告图标
+        const warningIcon = page.locator('span:has-text("✗")').first();
+        if (await warningIcon.isVisible({ timeout: 1000 })) {
+          results.passed.push('Claude Code 检测结果显示图标（可能未安装）');
+        } else {
+          results.passed.push('Claude Code 检测完成（结果待确认）');
+        }
+      }
+    } else {
+      results.failed.push('检测按钮未找到');
+    }
+
+    // 6. 检查测试按钮
+    console.log('6. 检查测试按钮...');
+    const testBtn = page.locator('button:has-text("测试")').first();
+    if (await testBtn.isVisible()) {
+      results.passed.push('测试按钮可见');
+
+      // 点击测试
+      await testBtn.click();
+      await page.waitForTimeout(3000);
+
+      // 检查模态框
+      const modal = page.locator('[class*="modal"], [class*="Modal"]').filter({ hasText: /测试结果|通过|失败/ });
+      if (await modal.isVisible({ timeout: 3000 })) {
+        results.passed.push('测试结果模态框弹出');
+
+        // 关闭模态框
+        const closeBtn = page.locator('button:has-text("关闭")').first();
+        if (await closeBtn.isVisible()) {
+          await closeBtn.click();
+          await page.waitForTimeout(500);
+        }
+      } else {
+        results.passed.push('测试按钮点击完成（模态框可能已关闭或无需确认）');
+      }
+    } else {
+      results.failed.push('测试按钮未找到');
+    }
+
+    // 7. 验证路径输入框
+    console.log('7. 验证路径输入框...');
+    const pathInput = page.locator('input[placeholder*="路径"], input[placeholder*="path"]').first();
+    if (await pathInput.isVisible()) {
+      results.passed.push('路径输入框可见');
+    } else {
+      // 尝试其他方式查找
+      const anyInput = page.locator('input[type="text"]').first();
+      if (await anyInput.isVisible()) {
+        results.passed.push('输入框可见（可能包含路径输入）');
+      } else {
+        results.failed.push('路径输入框未找到');
+      }
+    }
+
+    // 8. 测试开关切换
+    console.log('8. 测试开关切换...');
+    const switchToToggle = page.locator('[class*="switch"]').first();
+    if (await switchToToggle.isVisible()) {
+      // 关闭 Claude Code
+      await switchToToggle.click();
+      await page.waitForTimeout(2000);
+
+      // 检查是否有成功提示
+      const toast = page.locator('[class*="message"], [class*="Message"], [class*="toast"]').filter({ hasText: /成功|更新/ });
+      if (await toast.isVisible({ timeout: 3000 })) {
+        results.passed.push('开关切换后显示成功提示');
+
+        // 重新开启
+        await switchToToggle.click();
+        await page.waitForTimeout(2000);
+        results.passed.push('可以重新开启执行器');
+      } else {
+        results.passed.push('开关切换操作完成（提示可能已自动消失）');
+      }
+    }
+
+    // 9. 截图保存
+    console.log('9. 保存截图...');
+    await page.screenshot({ path: '/tmp/executor_config_test.png', fullPage: true });
+    results.passed.push('截图已保存到 /tmp/executor_config_test.png');
+
+  } catch (error) {
+    console.error('测试过程中出错:', error.message);
+    results.failed.push(`测试异常: ${error.message}`);
+    await page.screenshot({ path: '/tmp/executor_config_error.png' });
+  }
+
+  // 输出结果
+  console.log('\n========================================');
+  console.log('测试结果汇总');
+  console.log('========================================');
+
+  console.log(`\n✅ 通过 (${results.passed.length}):`);
+  results.passed.forEach(item => console.log(`  • ${item}`));
+
+  if (results.failed.length > 0) {
+    console.log(`\n❌ 失败 (${results.failed.length}):`);
+    results.failed.forEach(item => console.log(`  • ${item}`));
+  }
+
+  console.log('\n========================================');
+  console.log(`总计: ${results.passed.length} 通过, ${results.failed.length} 失败`);
+  console.log('========================================\n');
+
+  await browser.close();
+
+  // 如果有失败的测试，退出码为1
+  process.exit(results.failed.length > 0 ? 1 : 0);
+})();

--- a/frontend/test_executor_config.cjs
+++ b/frontend/test_executor_config.cjs
@@ -4,189 +4,203 @@ const { chromium } = require('playwright');
 (async () => {
   console.log('开始测试执行器管理功能...\n');
 
-  const browser = await chromium.launch();
+  const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext();
   const page = await context.newPage();
 
-  // 收集测试结果
   const results = {
     passed: [],
     failed: []
   };
 
   try {
-    // 1. 导航到设置页面
-    console.log('1. 导航到设置页面...');
-    await page.goto('https://t-600b43689eae40d3.hostc.dev');
-    await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(2000);
+    // 1. 导航到主页面
+    console.log('1. 导航到主页面...');
+    await page.goto('http://localhost:8088');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(3000);
 
-    // 点击设置图标
-    const settingsIcon = page.locator('[class*="setting"]').first();
-    if (await settingsIcon.isVisible({ timeout: 5000 })) {
-      await settingsIcon.click();
+    const title = await page.title();
+    console.log(`   页面标题: ${title}`);
+    results.passed.push(`页面加载成功: ${title}`);
+
+    // 2. 点击设置图标按钮 (aria-label="配置管理")
+    console.log('2. 点击配置管理按钮...');
+    const settingsBtn = page.locator('[aria-label="配置管理"]');
+    if (await settingsBtn.isVisible({ timeout: 5000 })) {
+      await settingsBtn.click();
+      await page.waitForTimeout(2000);
+      results.passed.push('配置管理按钮点击成功');
+      console.log('   点击了配置管理图标');
     } else {
-      // 尝试其他选择器
-      const header = page.locator('header, [class*="header"], [class*="Header"]');
-      if (await header.isVisible()) {
-        await header.click();
+      // 备用方法
+      const settingsBtn2 = page.locator('[class*="setting"]').first();
+      if (await settingsBtn2.isVisible({ timeout: 3000 })) {
+        await settingsBtn2.click();
+        await page.waitForTimeout(2000);
+        results.passed.push('设置按钮点击成功');
       }
     }
+
+    // 等待页面切换
     await page.waitForTimeout(1000);
 
-    // 2. 点击执行器管理标签页
-    console.log('2. 点击执行器管理标签页...');
-    const executorTab = page.locator('text=执行器管理');
-    if (await executorTab.isVisible({ timeout: 5000 })) {
-      await executorTab.click();
-      await page.waitForTimeout(1000);
-      results.passed.push('执行器管理标签页可见且可点击');
-    } else {
-      // 尝试点击包含"执行器"的标签
-      const anyExecutorTab = page.locator('text=/执行器/').first();
-      if (await anyExecutorTab.isVisible()) {
-        await anyExecutorTab.click();
+    // 3. 检查是否切换到了设置页面
+    console.log('3. 检查设置页面...');
+    const settingsPage = page.locator('.ant-tabs');
+    if (await settingsPage.isVisible({ timeout: 5000 })) {
+      results.passed.push('设置页面已显示');
+
+      // 4. 查找所有标签页
+      const allTabs = await page.locator('.ant-tabs-tab').all();
+      console.log(`   找到 ${allTabs.length} 个标签页`);
+      for (let i = 0; i < allTabs.length; i++) {
+        const tabText = await allTabs[i].textContent();
+        console.log(`   标签页 ${i + 1}: ${tabText}`);
+      }
+
+      // 5. 点击"执行器管理"标签
+      console.log('4. 点击执行器管理标签...');
+      let tabClicked = false;
+
+      // 通过JS点击包含"执行器"的标签
+      const clicked = await page.evaluate(() => {
+        const tabs = document.querySelectorAll('.ant-tabs-tab');
+        for (const tab of tabs) {
+          if (tab.textContent.includes('执行器')) {
+            tab.click();
+            return true;
+          }
+        }
+        return false;
+      });
+
+      if (clicked) {
+        tabClicked = true;
+        results.passed.push('执行器管理标签点击成功');
+        console.log('   执行器管理标签已点击');
+        await page.waitForTimeout(1500);
+      } else {
+        results.failed.push('未找到执行器管理标签');
+      }
+
+      // 6. 查找 Switch 组件
+      console.log('5. 查找 Switch 开关组件...');
+      const allSwitches = await page.locator('.ant-switch').all();
+      console.log(`   找到 ${allSwitches.length} 个 Switch`);
+      if (allSwitches.length > 0) {
+        results.passed.push(`找到 ${allSwitches.length} 个开关组件`);
+
+        // 检查第一个开关的状态
+        const firstSwitch = allSwitches[0];
+        const isChecked = await firstSwitch.evaluate(el => el.classList.contains('ant-switch-checked'));
+        console.log(`   第一个开关状态: ${isChecked ? '启用' : '禁用'}`);
+        results.passed.push(`开关状态: ${isChecked ? '启用' : '禁用'}`);
+
+        // 测试开关切换
+        console.log('   测试开关切换...');
+        await firstSwitch.click();
+        await page.waitForTimeout(1500);
+
+        // 检查是否有消息提示
+        const msg = page.locator('.ant-message').first();
+        if (await msg.isVisible({ timeout: 2000 })) {
+          const msgText = await msg.textContent();
+          console.log(`   消息提示: ${msgText}`);
+          results.passed.push('开关切换后显示消息提示');
+        }
+
+        // 重新点击恢复原状态
+        await firstSwitch.click();
         await page.waitForTimeout(1000);
-        results.passed.push('执行器标签页可见且可点击');
       } else {
-        results.failed.push('执行器管理标签页未找到');
+        results.failed.push('未找到 Switch 组件');
       }
-    }
 
-    // 3. 验证执行器卡片是否显示
-    console.log('3. 验证执行器卡片显示...');
-    // 查找包含 Claude Code 或 JoinAI 的文本
-    const claudeCard = page.locator('text=Claude Code').first();
-    if (await claudeCard.isVisible({ timeout: 5000 })) {
-      results.passed.push('Claude Code 执行器卡片可见');
+      // 7. 查找检测按钮
+      console.log('6. 查找检测按钮...');
+      const detectBtns = await page.locator('button:has-text("检测")').all();
+      console.log(`   找到 ${detectBtns.length} 个检测按钮`);
+      if (detectBtns.length > 0) {
+        results.passed.push(`找到 ${detectBtns.length} 个检测按钮`);
 
-      // 4. 检查开关按钮
-      console.log('4. 检查开关按钮...');
-      const switchBtn = claudeCard.locator('..').locator('[class*="switch"], [class*="Switch"]').first();
-      if (await switchBtn.isVisible()) {
-        results.passed.push('Claude Code 开关按钮可见');
-
-        // 检查初始状态是否为启用
-        const isEnabled = await switchBtn.evaluate(el => {
-          const input = el.querySelector('input');
-          return input ? input.checked : false;
-        });
-        if (isEnabled) {
-          results.passed.push('Claude Code 默认启用状态正确');
-        } else {
-          results.failed.push('Claude Code 初始启用状态不正确');
-        }
-      } else {
-        results.failed.push('Claude Code 开关按钮未找到');
-      }
-    } else {
-      results.failed.push('Claude Code 执行器卡片未找到');
-    }
-
-    // 5. 检查检测按钮
-    console.log('5. 检查检测按钮...');
-    const detectBtn = page.locator('button:has-text("检测")').first();
-    if (await detectBtn.isVisible()) {
-      results.passed.push('检测按钮可见');
-
-      // 点击检测
-      await detectBtn.click();
-      await page.waitForTimeout(2000);
-
-      // 检查是否显示成功图标
-      const successIcon = page.locator('span:has-text("✓")').first();
-      if (await successIcon.isVisible({ timeout: 3000 })) {
-        results.passed.push('Claude Code 检测成功显示 ✓ 图标');
-      } else {
-        // 可能是警告图标
-        const warningIcon = page.locator('span:has-text("✗")').first();
-        if (await warningIcon.isVisible({ timeout: 1000 })) {
-          results.passed.push('Claude Code 检测结果显示图标（可能未安装）');
-        } else {
-          results.passed.push('Claude Code 检测完成（结果待确认）');
-        }
-      }
-    } else {
-      results.failed.push('检测按钮未找到');
-    }
-
-    // 6. 检查测试按钮
-    console.log('6. 检查测试按钮...');
-    const testBtn = page.locator('button:has-text("测试")').first();
-    if (await testBtn.isVisible()) {
-      results.passed.push('测试按钮可见');
-
-      // 点击测试
-      await testBtn.click();
-      await page.waitForTimeout(3000);
-
-      // 检查模态框
-      const modal = page.locator('[class*="modal"], [class*="Modal"]').filter({ hasText: /测试结果|通过|失败/ });
-      if (await modal.isVisible({ timeout: 3000 })) {
-        results.passed.push('测试结果模态框弹出');
-
-        // 关闭模态框
-        const closeBtn = page.locator('button:has-text("关闭")').first();
-        if (await closeBtn.isVisible()) {
-          await closeBtn.click();
-          await page.waitForTimeout(500);
-        }
-      } else {
-        results.passed.push('测试按钮点击完成（模态框可能已关闭或无需确认）');
-      }
-    } else {
-      results.failed.push('测试按钮未找到');
-    }
-
-    // 7. 验证路径输入框
-    console.log('7. 验证路径输入框...');
-    const pathInput = page.locator('input[placeholder*="路径"], input[placeholder*="path"]').first();
-    if (await pathInput.isVisible()) {
-      results.passed.push('路径输入框可见');
-    } else {
-      // 尝试其他方式查找
-      const anyInput = page.locator('input[type="text"]').first();
-      if (await anyInput.isVisible()) {
-        results.passed.push('输入框可见（可能包含路径输入）');
-      } else {
-        results.failed.push('路径输入框未找到');
-      }
-    }
-
-    // 8. 测试开关切换
-    console.log('8. 测试开关切换...');
-    const switchToToggle = page.locator('[class*="switch"]').first();
-    if (await switchToToggle.isVisible()) {
-      // 关闭 Claude Code
-      await switchToToggle.click();
-      await page.waitForTimeout(2000);
-
-      // 检查是否有成功提示
-      const toast = page.locator('[class*="message"], [class*="Message"], [class*="toast"]').filter({ hasText: /成功|更新/ });
-      if (await toast.isVisible({ timeout: 3000 })) {
-        results.passed.push('开关切换后显示成功提示');
-
-        // 重新开启
-        await switchToToggle.click();
+        // 点击第一个检测按钮
+        console.log('   点击第一个检测按钮...');
+        await detectBtns[0].click();
         await page.waitForTimeout(2000);
-        results.passed.push('可以重新开启执行器');
+
+        // 检查结果图标
+        const checkIcon = page.locator('span:has-text("✓")').first();
+        const failIcon = page.locator('span:has-text("✗")').first();
+
+        if (await checkIcon.isVisible({ timeout: 2000 }).catch(() => false)) {
+          results.passed.push('检测成功显示 ✓ 图标');
+        } else if (await failIcon.isVisible({ timeout: 1000 }).catch(() => false)) {
+          results.passed.push('检测失败显示 ✗ 图标');
+        } else {
+          results.passed.push('检测完成');
+        }
       } else {
-        results.passed.push('开关切换操作完成（提示可能已自动消失）');
+        results.failed.push('未找到检测按钮');
       }
+
+      // 8. 查找测试按钮
+      console.log('7. 查找测试按钮...');
+      const testBtns = await page.locator('button:has-text("测试")').all();
+      console.log(`   找到 ${testBtns.length} 个测试按钮`);
+      if (testBtns.length > 0) {
+        results.passed.push(`找到 ${testBtns.length} 个测试按钮`);
+
+        // 点击第一个测试按钮
+        console.log('   点击第一个测试按钮...');
+        await testBtns[0].click();
+        await page.waitForTimeout(3000);
+
+        // 检查模态框
+        const modal = page.locator('.ant-modal');
+        if (await modal.isVisible({ timeout: 3000 })) {
+          results.passed.push('测试结果模态框已弹出');
+
+          // 获取模态框内容
+          const modalTitle = await page.locator('.ant-modal-title').textContent().catch(() => '');
+          console.log(`   模态框标题: ${modalTitle}`);
+
+          // 关闭模态框
+          const closeBtn = page.locator('button:has-text("关闭")').first();
+          if (await closeBtn.isVisible({ timeout: 2000 })) {
+            await closeBtn.click();
+            await page.waitForTimeout(500);
+          }
+        } else {
+          results.passed.push('测试按钮点击完成');
+        }
+      } else {
+        results.failed.push('未找到测试按钮');
+      }
+
+      // 9. 查找输入框
+      console.log('8. 查找输入框...');
+      const inputs = await page.locator('.ant-input').all();
+      console.log(`   找到 ${inputs.length} 个输入框`);
+      if (inputs.length > 0) {
+        results.passed.push(`找到 ${inputs.length} 个输入框`);
+      }
+
+    } else {
+      results.failed.push('设置页面未显示');
     }
 
-    // 9. 截图保存
+    // 10. 截图保存
     console.log('9. 保存截图...');
     await page.screenshot({ path: '/tmp/executor_config_test.png', fullPage: true });
-    results.passed.push('截图已保存到 /tmp/executor_config_test.png');
+    results.passed.push('截图已保存');
 
   } catch (error) {
-    console.error('测试过程中出错:', error.message);
+    console.error('\n测试过程中出错:', error.message);
     results.failed.push(`测试异常: ${error.message}`);
-    await page.screenshot({ path: '/tmp/executor_config_error.png' });
+    await page.screenshot({ path: '/tmp/executor_config_error.png' }).catch(() => {});
   }
 
-  // 输出结果
   console.log('\n========================================');
   console.log('测试结果汇总');
   console.log('========================================');
@@ -204,7 +218,5 @@ const { chromium } = require('playwright');
   console.log('========================================\n');
 
   await browser.close();
-
-  // 如果有失败的测试，退出码为1
   process.exit(results.failed.length > 0 ? 1 : 0);
 })();

--- a/frontend/test_executor_config.cjs
+++ b/frontend/test_executor_config.cjs
@@ -138,7 +138,7 @@ const { chromium } = require('playwright');
         } else if (await failIcon.isVisible({ timeout: 1000 }).catch(() => false)) {
           results.passed.push('检测失败显示 ✗ 图标');
         } else {
-          results.passed.push('检测完成');
+          results.failed.push('未检测到 ✓/✗ 图标反馈');
         }
       } else {
         results.failed.push('未找到检测按钮');
@@ -172,7 +172,7 @@ const { chromium } = require('playwright');
             await page.waitForTimeout(500);
           }
         } else {
-          results.passed.push('测试按钮点击完成');
+          results.failed.push('测试按钮点击后模态框未弹出');
         }
       } else {
         results.failed.push('未找到测试按钮');


### PR DESCRIPTION
## Summary
- 新建 executors 数据库表，存储执行器配置（name, path, enabled, display_name）
- 启动时自动从 config.yaml 迁移执行器路径到数据库，首次安装则自动种子默认 8 个执行器
- 新增 4 个 API 端点：GET /xyz/executors、PUT /xyz/executors/{name}、POST /xyz/executors/{name}/detect、POST /xyz/executors/{name}/test
- 执行器注册改为从数据库动态读取，只有 enabled 的才注册
- config.yaml 不再写入 executors 配置
- 前端设置页"执行器管理"tab 重构：每个执行器一行，包含 Switch 开关、路径输入、检测按钮、测试按钮
- Todo 执行器选择列表改为动态从 API 加载，只显示启用的执行器
- 检测功能通过 which 或路径检查二进制是否存在
- 测试功能实际运行 --version 命令并显示

## Test plan
- [x] Playwright 测试验证执行器管理 UI 功能