### PR TITLE
fix: yaml.load() 使用安全 JSON_SCHEMA 防止远程代码执行

### DIFF
--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -525,7 +525,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
   const handleImportFile = async (file: File) => {
     const text = await file.text();
     try {
-      const data = yaml.load(text) as BackupDataYaml;
+      const data = yaml.load(text, { schema: yaml.JSON_SCHEMA }) as BackupDataYaml;
       if (!data.todos || data.todos.length === 0) {
         message.error('备份文件中没有 Todo 数据');
         return false;


### PR DESCRIPTION
## Summary
- 使用 `yaml.load(text, { schema: yaml.JSON_SCHEMA })` 替代不安全的 `yaml.load(text)`，防止 `!!js/function` 等 YAML 类型导致远程代码执行

Closes #154