### PR TITLE
fix: 移除 feishu_poll 响应中的 app_secret 防止凭证泄露

### DIFF
--- a/backend/src/handlers/agent_bot.rs
+++ b/backend/src/handlers/agent_bot.rs
@@ -200,7 +200,7 @@ pub async fn feishu_poll(
             return Ok(ApiResponse::ok(FeishuPollResponse {
                 success: true,
                 app_id: Some(app_id.to_string()),
-                app_secret: Some(app_secret.to_string()),
+                app_secret: None,
                 domain,
                 open_id: open_id.map(String::from),
                 bot_name,


### PR DESCRIPTION
## Summary
- `feishu_poll` 响应中移除 `app_secret` 字段，与 list 接口（`#[serde(skip_serializing)]`）保持一致

Closes #155