### PR TITLE
perf: Dashboard 统计查询优化 - 添加索引和日期范围过滤

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -325,7 +325,8 @@ impl Database {
             COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as total_cost, \
             COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN json_extract(usage, '$.duration_ms') ELSE 0 END), 0) as total_duration, \
             COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN 1 ELSE 0 END), 0) as duration_count \
-            FROM execution_records";
+            FROM execution_records \
+            WHERE started_at >= date('now', '-90 days')";
 
         let (total_executions, success_executions, failed_executions,
              total_input_tokens, total_output_tokens, total_cache_read_tokens,

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -204,6 +204,9 @@ impl Database {
         self.exec("CREATE INDEX IF NOT EXISTS idx_skill_invocations_skill_name ON skill_invocations(skill_name)").await?;
         self.exec("CREATE INDEX IF NOT EXISTS idx_skill_invocations_executor ON skill_invocations(executor)").await?;
         self.exec("CREATE INDEX IF NOT EXISTS idx_skill_invocations_todo_id ON skill_invocations(todo_id)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_execution_records_started_at ON execution_records(started_at)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_execution_records_executor ON execution_records(executor)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_execution_records_model ON execution_records(model)").await?;
 
         // Trigger: fill created_at with UTC time on INSERT if not set
         self.exec(


### PR DESCRIPTION
## Summary
- 为 `execution_records` 添加 `started_at`、`executor`、`model` 索引
- 整体统计查询添加 90 天日期范围过滤，避免全表扫描

Closes #156