### PR TITLE
fix: unwrap 函数空数据时抛出明确错误

### DIFF
--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -33,7 +33,10 @@ api.interceptors.response.use(
 );
 
 function unwrap<T>(res: { data: ApiResp<T> }): T {
-  return res.data.data as T;
+  if (res.data.data === null || res.data.data === undefined) {
+    throw new Error(res.data.message || 'API 返回数据为空');
+  }
+  return res.data.data;
 }
 
 // Todo APIs


### PR DESCRIPTION
## Summary
- `unwrap` 函数在 `data` 为 `null` 时抛出明确错误，而非强制 `as T` 类型转换导致后续 TypeError

Closes #159