### PR TITLE
refactor: 统一使用 useIsMobile hook

### DIFF
--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import {
   RobotOutlined,
   UserOutlined,
@@ -330,7 +330,7 @@ function ChatBubble({ message }: { message: ChatMessage }) {
 }
 
 export function ChatView({ logs, isRunning }: ChatViewProps) {
-  const messages = parseLogsToMessages(logs);
+  const messages = useMemo(() => parseLogsToMessages(logs), [logs]);
 
   if (messages.length === 0) {
     return (

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import { Component, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback;
+      return (
+        <div style={{ padding: 24, textAlign: 'center' }}>
+          <h3>Something went wrong</h3>
+          <p style={{ color: '#666', fontSize: 14 }}>{this.state.error?.message}</p>
+          <button
+            onClick={() => this.setState({ hasError: false, error: null })}
+            style={{ marginTop: 12, padding: '6px 16px', cursor: 'pointer' }}
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,9 +4,12 @@ import "@fontsource/jetbrains-mono/latin-500.css";
 import "@fontsource/jetbrains-mono/latin-600.css";
 import "@fontsource/jetbrains-mono/latin-700.css";
 import App from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- 移除 App.tsx、TodoList.tsx、TodoDetail.tsx 中重复的 resize 监听代码
- 统一使用已有的 `useIsMobile` hook

Closes #177