### PR TITLE
fix: Dashboard 日期过滤一致性修复

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -325,7 +325,8 @@ impl Database {
             COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as total_cost, \
             COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN json_extract(usage, '$.duration_ms') ELSE 0 END), 0) as total_duration, \
             COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN 1 ELSE 0 END), 0) as duration_count \
-            FROM execution_records";
+            FROM execution_records \
+            WHERE started_at >= date('now', '-90 days')";
 
         let (total_executions, success_executions, failed_executions,
              total_input_tokens, total_output_tokens, total_cache_read_tokens,
@@ -358,6 +359,7 @@ impl Database {
             COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
             COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
             FROM execution_records \
+            WHERE started_at >= date('now', '-90 days') \
             GROUP BY COALESCE(executor, 'claudecode')";
 
         let mut executor_distribution: Vec<crate::models::ExecutorCount> = self.conn
@@ -400,6 +402,7 @@ impl Database {
             COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
             COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
             FROM execution_records \
+            WHERE started_at >= date('now', '-90 days') \
             GROUP BY COALESCE(model, 'unknown')";
 
         let mut model_distribution: Vec<crate::models::ModelCount> = self.conn
@@ -445,7 +448,7 @@ impl Database {
             COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
             COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
             FROM execution_records \
-            WHERE started_at IS NOT NULL AND LENGTH(started_at) >= 10 \
+            WHERE started_at IS NOT NULL AND LENGTH(started_at) >= 10 AND started_at >= date('now', '-90 days') \
             GROUP BY SUBSTR(started_at, 1, 10) \
             ORDER BY day DESC \
             LIMIT 30";

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -204,6 +204,9 @@ impl Database {
         self.exec("CREATE INDEX IF NOT EXISTS idx_skill_invocations_skill_name ON skill_invocations(skill_name)").await?;
         self.exec("CREATE INDEX IF NOT EXISTS idx_skill_invocations_executor ON skill_invocations(executor)").await?;
         self.exec("CREATE INDEX IF NOT EXISTS idx_skill_invocations_todo_id ON skill_invocations(todo_id)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_execution_records_started_at ON execution_records(started_at)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_execution_records_executor ON execution_records(executor)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_execution_records_model ON execution_records(model)").await?;
 
         // Trigger: fill created_at with UTC time on INSERT if not set
         self.exec(


### PR DESCRIPTION
## Summary
- 为 executor_sql、model_sql、daily_sql 添加 90 天日期过滤，与 overall_sql 保持一致
- 添加数据库索引：idx_execution_records_started_at、idx_execution_records_executor、idx_execution_records_model

## 问题
Dashboard 的总体统计（90 天过滤）与各维度分解（executor/model/daily）数据不一致，因为后者没有日期过滤。

## 修复
在所有 Dashboard SQL 查询中添加一致的  过滤条件。

Closes 参考 PR #185 评审意见