### PR TITLE
fix: 修复无效的转义序列 $\\ in execution.rs

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -156,13 +156,13 @@ impl Database {
         // update the same record concurrently -- only the first write succeeds.
         let backend = self.conn.get_database_backend();
         let sql = "UPDATE execution_records SET \
-            status = \$1, \
-            logs = \$2, \
-            result = \$3, \
-            usage = \$4, \
-            model = \$5, \
-            finished_at = \$6 \
-            WHERE id = \$7 AND status = 'running'";
+            status = $1, \
+            logs = $2, \
+            result = $3, \
+            usage = $4, \
+            model = $5, \
+            finished_at = $6 \
+            WHERE id = $7 AND status = 'running'";
 
         let res = self.conn.execute(
             Statement::from_sql_and_values(backend, sql, [


### PR DESCRIPTION
## Summary
修复  中 SQL 语句参数占位符的无效转义序列。

## 问题
SQL 语句中的 ,  等是无效的 Rust 字符串转义序列，应改为 , 。

## 修复
将所有  替换为 。