### PR TITLE
chore: 依赖清理

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,6 @@
     "@ant-design/icons": "^6.1.1",
     "@ant-design/x-markdown": "^2.5.0",
     "@fontsource/jetbrains-mono": "^5.2.8",
-    "@types/qrcode": "^1.5.6",
     "@uiw/react-md-editor": "^4.1.0",
     "antd": "^6.3.6",
     "axios": "^1.15.2",
@@ -30,6 +29,7 @@
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@types/js-yaml": "^4.0.9",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",


### PR DESCRIPTION
## Summary
将  从 dependencies 移到 devDependencies。

## 说明
 是 TypeScript 类型定义包，不应在生产依赖中。

## Issue #170 核验结果
经实际代码检查，issue 中提到的其他依赖无法清理：
-  - 在 config.rs 中使用
-  - 在 feishu ws_client 中使用
-  - sea-orm 的传递依赖
-  - 在 types/index.tsx 中使用
-  - 在 TimelineFlow 中使用