### PR TITLE
refactor: 后端统一错误处理

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -47,12 +47,11 @@ impl Database {
         todo_id: i64,
         limit: i64,
         offset: i64,
-    ) -> (Vec<ExecutionRecord>, i64) {
+    ) -> Result<(Vec<ExecutionRecord>, i64), sea_orm::DbErr> {
         let total: i64 = execution_records::Entity::find()
             .filter(execution_records::Column::TodoId.eq(todo_id))
             .count(&self.conn)
-            .await
-            .unwrap_or(0) as i64;
+            .await? as i64;
 
         let limit_u = if limit < 0 { 0 } else { limit as u64 };
         let offset_u = if offset < 0 { 0 } else { offset as u64 };
@@ -63,32 +62,29 @@ impl Database {
             .limit(limit_u)
             .offset(offset_u)
             .all(&self.conn)
-            .await
-            .unwrap_or_default()
+            .await?
             .into_iter()
             .map(Into::into)
             .collect();
 
-        (records, total)
+        Ok((records, total))
     }
 
-    pub async fn get_execution_record(&self, record_id: i64) -> Option<ExecutionRecord> {
+    pub async fn get_execution_record(&self, record_id: i64) -> Result<Option<ExecutionRecord>, sea_orm::DbErr> {
         let m = execution_records::Entity::find()
             .filter(execution_records::Column::Id.eq(record_id))
             .one(&self.conn)
-            .await
-            .ok()??;
-        Some(m.into())
+            .await?;
+        Ok(m.map(Into::into))
     }
 
     /// 根据 task_id 获取执行记录
-    pub async fn get_execution_record_by_task_id(&self, task_id: &str) -> Option<ExecutionRecord> {
+    pub async fn get_execution_record_by_task_id(&self, task_id: &str) -> Result<Option<ExecutionRecord>, sea_orm::DbErr> {
         let m = execution_records::Entity::find()
             .filter(execution_records::Column::TaskId.eq(task_id))
             .one(&self.conn)
-            .await
-            .ok()??;
-        Some(m.into())
+            .await?;
+        Ok(m.map(Into::into))
     }
 
     pub async fn create_execution_record(
@@ -256,19 +252,18 @@ impl Database {
     }
 
     /// 根据 session_id 获取所有执行记录（按 started_at 排序）
-    pub async fn get_execution_records_by_session(&self, session_id: &str) -> Vec<ExecutionRecord> {
-        execution_records::Entity::find()
+    pub async fn get_execution_records_by_session(&self, session_id: &str) -> Result<Vec<ExecutionRecord>, sea_orm::DbErr> {
+        Ok(execution_records::Entity::find()
             .filter(execution_records::Column::SessionId.eq(session_id))
             .order_by_asc(execution_records::Column::StartedAt)
             .all(&self.conn)
-            .await
-            .unwrap_or_default()
+            .await?
             .into_iter()
             .map(Into::into)
-            .collect()
+            .collect())
     }
 
-    pub async fn get_dashboard_stats(&self) -> crate::models::DashboardStats {
+    pub async fn get_dashboard_stats(&self) -> Result<crate::models::DashboardStats, sea_orm::DbErr> {
         use std::collections::HashMap;
 
         let backend = self.conn.get_database_backend();
@@ -284,7 +279,7 @@ impl Database {
             FROM todos WHERE deleted_at IS NULL";
 
         let (total_todos, pending_todos, running_todos, completed_todos, failed_todos, scheduled_todos) =
-            if let Ok(Some(row)) = self.conn.query_one(Statement::from_string(backend, todo_sql.to_string())).await {
+            if let Some(row) = self.conn.query_one(Statement::from_string(backend, todo_sql.to_string())).await? {
                 (
                     row.try_get_by("total").unwrap_or(0i64),
                     row.try_get_by("pending").unwrap_or(0i64),
@@ -297,7 +292,7 @@ impl Database {
                 (0i64, 0i64, 0i64, 0i64, 0i64, 0i64)
             };
 
-        let tags = self.get_tags().await.unwrap();
+        let tags = self.get_tags().await?;
         let total_tags = tags.len() as i64;
 
         // Executor todo counts via SQL (replaces in-memory iteration over all todos)
@@ -309,8 +304,8 @@ impl Database {
 
         let executor_todo_counts: HashMap<String, i64> = self.conn
             .query_all(Statement::from_string(backend, executor_todo_sql.to_string()))
-            .await
-            .unwrap_or_default()
+            .await?
+            .into_iter()
             .into_iter()
             .filter_map(|row| {
                 let exec: String = row.try_get_by("executor").ok()?;
@@ -324,8 +319,8 @@ impl Database {
 
         let tag_todo_counts: HashMap<i64, i64> = self.conn
             .query_all(Statement::from_string(backend, tag_todo_sql.to_string()))
-            .await
-            .unwrap_or_default()
+            .await?
+            .into_iter()
             .into_iter()
             .filter_map(|row| {
                 let tag_id: i64 = row.try_get_by("tag_id").ok()?;
@@ -352,7 +347,7 @@ impl Database {
         let (total_executions, success_executions, failed_executions,
              total_input_tokens, total_output_tokens, total_cache_read_tokens,
              total_cache_creation_tokens, total_cost, total_duration, duration_count) =
-            if let Ok(Some(row)) = self.conn.query_one(Statement::from_string(backend, overall_sql.to_string())).await {
+            if let Some(row) = self.conn.query_one(Statement::from_string(backend, overall_sql.to_string())).await? {
                 let t: i64 = row.try_get_by("total").unwrap_or(0);
                 let s: i64 = row.try_get_by("success").unwrap_or(0);
                 let f: i64 = row.try_get_by("failed").unwrap_or(0);
@@ -385,8 +380,7 @@ impl Database {
 
         let mut executor_distribution: Vec<crate::models::ExecutorCount> = self.conn
             .query_all(Statement::from_string(backend, executor_sql.to_string()))
-            .await
-            .unwrap_or_default()
+            .await?
             .into_iter()
             .filter_map(|row| {
                 let exec: String = row.try_get_by("executor").ok()?;
@@ -428,8 +422,7 @@ impl Database {
 
         let mut model_distribution: Vec<crate::models::ModelCount> = self.conn
             .query_all(Statement::from_string(backend, model_sql.to_string()))
-            .await
-            .unwrap_or_default()
+            .await?
             .into_iter()
             .filter_map(|row| {
                 let model: String = row.try_get_by("model").ok()?;
@@ -476,8 +469,7 @@ impl Database {
 
         let daily_rows = self.conn
             .query_all(Statement::from_string(backend, daily_sql.to_string()))
-            .await
-            .unwrap_or_default();
+            .await?;
 
         let mut daily_executions: Vec<crate::models::DailyExecution> = Vec::with_capacity(daily_rows.len());
         let mut daily_token_stats: Vec<crate::models::DailyTokenStats> = Vec::with_capacity(daily_rows.len());
@@ -520,8 +512,7 @@ impl Database {
 
         let tag_rows = self.conn
             .query_all(Statement::from_string(backend, tag_sql.to_string()))
-            .await
-            .unwrap_or_default();
+            .await?;
 
         let mut tag_exec_stats: HashMap<i64, (i64, i64, i64, u64, u64, f64)> = HashMap::new();
         for row in tag_rows {
@@ -559,14 +550,13 @@ impl Database {
             .order_by_desc(execution_records::Column::StartedAt)
             .limit(10)
             .all(&self.conn)
-            .await
-            .unwrap_or_default();
+            .await?;
 
         let recent_executions: Vec<crate::models::ExecutionRecord> = recent_records.into_iter()
             .map(Into::into)
             .collect();
 
-        crate::models::DashboardStats {
+        Ok(crate::models::DashboardStats {
             total_todos,
             pending_todos,
             running_todos,
@@ -589,10 +579,10 @@ impl Database {
             daily_executions,
             daily_token_stats,
             recent_executions,
-        }
+        })
     }
 
-    pub async fn get_execution_summary(&self, todo_id: i64) -> ExecutionSummary {
+    pub async fn get_execution_summary(&self, todo_id: i64) -> Result<ExecutionSummary, sea_orm::DbErr> {
         let backend = self.conn.get_database_backend();
         let sql = "SELECT \
                 COUNT(*) as total, \
@@ -606,7 +596,7 @@ impl Database {
                 COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as total_cost \
                 FROM execution_records WHERE todo_id = $1";
 
-        if let Ok(Some(row)) = self.conn.query_one(Statement::from_sql_and_values(backend, sql, [todo_id.into()])).await {
+        if let Some(row) = self.conn.query_one(Statement::from_sql_and_values(backend, sql, [todo_id.into()])).await? {
             let total_executions: i64 = row.try_get_by("total").unwrap_or(0);
             let success_count: i64 = row.try_get_by("success_count").unwrap_or(0);
             let failed_count: i64 = row.try_get_by("failed_count").unwrap_or(0);
@@ -617,7 +607,7 @@ impl Database {
             let cache_creation: i64 = row.try_get_by("cache_creation").unwrap_or(0);
             let total_cost: f64 = row.try_get_by("total_cost").unwrap_or(0.0);
 
-            ExecutionSummary {
+            Ok(ExecutionSummary {
                 todo_id,
                 total_executions,
                 success_count,
@@ -628,9 +618,9 @@ impl Database {
                 total_cache_read_tokens: cache_read as u64,
                 total_cache_creation_tokens: cache_creation as u64,
                 total_cost_usd: if total_cost > 0.0 { Some(total_cost) } else { None },
-            }
+            })
         } else {
-            ExecutionSummary {
+            Ok(ExecutionSummary {
                 todo_id,
                 total_executions: 0,
                 success_count: 0,
@@ -641,7 +631,7 @@ impl Database {
                 total_cache_read_tokens: 0,
                 total_cache_creation_tokens: 0,
                 total_cost_usd: None,
-            }
+            })
         }
     }
 
@@ -670,7 +660,7 @@ impl Database {
 
     /// 清理孤儿执行记录：状态为running但todo没有对应task_id的记录
     /// 程序崩溃后，执行记录可能保持running状态，需要修复
-    pub async fn cleanup_orphan_execution_records(&self) {
+    pub async fn cleanup_orphan_execution_records(&self) -> Result<(), sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let backend = self.conn.get_database_backend();
         let sql = "UPDATE execution_records SET \
@@ -684,17 +674,12 @@ impl Database {
                     todo_id NOT IN (SELECT id FROM todos WHERE deleted_at IS NULL) \
                     OR todo_id IN (SELECT id FROM todos WHERE task_id IS NULL AND deleted_at IS NULL) \
                 )";
-        match self.conn.execute(Statement::from_sql_and_values(backend, sql, [now.into()])).await {
-            Ok(res) => {
-                let rows = res.rows_affected();
-                if rows > 0 {
-                    tracing::info!("Cleaned up {} orphan execution records", rows);
-                }
-            }
-            Err(e) => {
-                tracing::error!("Failed to cleanup orphan execution records: {}", e);
-            }
+        let res = self.conn.execute(Statement::from_sql_and_values(backend, sql, [now.into()])).await?;
+        let rows = res.rows_affected();
+        if rows > 0 {
+            tracing::info!("Cleaned up {} orphan execution records", rows);
         }
+        Ok(())
     }
 
 }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -497,7 +497,7 @@ mod tests {
         let id = db.create_todo("Test", "Desc").await.unwrap();
         let after = truncate_seconds(Utc::now());
 
-        let todo = db.get_todo(id).await.unwrap();
+        let todo = db.get_todo(id).await.unwrap().unwrap();
         let created = truncate_seconds(parse_utc(&todo.created_at));
 
         assert!(created >= before, "created_at should not be before test start");
@@ -509,7 +509,7 @@ mod tests {
     async fn test_todo_updated_at_changes_on_update() {
         let db = setup_db().await;
         let id = db.create_todo("Test", "Desc").await.unwrap();
-        let original = db.get_todo(id).await.unwrap().updated_at;
+        let original = db.get_todo(id).await.unwrap().unwrap().updated_at;
 
         tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
         db.update_todo_full(
@@ -524,7 +524,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let updated = db.get_todo(id).await.unwrap().updated_at;
+        let updated = db.get_todo(id).await.unwrap().unwrap().updated_at;
 
         assert_ne!(original, updated, "updated_at should change after update");
         assert!(updated.ends_with('Z'));
@@ -576,7 +576,7 @@ mod tests {
             .unwrap();
         let after = truncate_seconds(Utc::now());
 
-        let (records, _) = db.get_execution_records(todo_id, 100, 0).await;
+        let (records, _) = db.get_execution_records(todo_id, 100, 0).await.unwrap();
         let record = records.into_iter().find(|r| r.id == record_id).unwrap();
         let started = truncate_seconds(parse_utc(&record.started_at));
 
@@ -600,7 +600,7 @@ mod tests {
             .unwrap();
         let after = truncate_seconds(Utc::now());
 
-        let (records, _) = db.get_execution_records(todo_id, 100, 0).await;
+        let (records, _) = db.get_execution_records(todo_id, 100, 0).await.unwrap();
         let record = records.into_iter().find(|r| r.id == record_id).unwrap();
         let finished_at = record.finished_at.unwrap();
         let finished = truncate_seconds(parse_utc(&finished_at));
@@ -616,7 +616,7 @@ mod tests {
     async fn test_create_and_get_todo() {
         let db = setup_db().await;
         let id = db.create_todo("Title", "Prompt").await.unwrap();
-        let todo = db.get_todo(id).await.unwrap();
+        let todo = db.get_todo(id).await.unwrap().unwrap();
         assert_eq!(todo.title, "Title");
         assert_eq!(todo.prompt, "Prompt");
         assert_eq!(todo.status, crate::models::TodoStatus::Pending);
@@ -659,7 +659,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let todo = db.get_todo(id).await.unwrap();
+        let todo = db.get_todo(id).await.unwrap().unwrap();
         assert_eq!(todo.title, "New");
         assert_eq!(todo.prompt, "New prompt");
         assert_eq!(todo.status, crate::models::TodoStatus::InProgress);
@@ -674,7 +674,7 @@ mod tests {
         let db = setup_db().await;
         let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.update_todo_executor(id, "joinai").await.unwrap();
-        let todo = db.get_todo(id).await.unwrap();
+        let todo = db.get_todo(id).await.unwrap().unwrap();
         assert_eq!(todo.executor, Some("joinai".to_string()));
     }
 
@@ -683,10 +683,10 @@ mod tests {
         let db = setup_db().await;
         let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.update_todo_task_id(id, Some("task-123")).await.unwrap();
-        let todo = db.get_todo(id).await.unwrap();
+        let todo = db.get_todo(id).await.unwrap().unwrap();
         assert_eq!(todo.task_id, Some("task-123".to_string()));
         db.update_todo_task_id(id, None).await.unwrap();
-        let todo = db.get_todo(id).await.unwrap();
+        let todo = db.get_todo(id).await.unwrap().unwrap();
         assert!(todo.task_id.is_none());
     }
 
@@ -695,7 +695,7 @@ mod tests {
         let db = setup_db().await;
         let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.update_todo_scheduler(id, true, Some("0 0 * * *")).await.unwrap();
-        let todo = db.get_todo(id).await.unwrap();
+        let todo = db.get_todo(id).await.unwrap().unwrap();
         assert!(todo.scheduler_enabled);
         assert_eq!(todo.scheduler_config, Some("0 0 * * *".to_string()));
     }
@@ -705,7 +705,7 @@ mod tests {
         let db = setup_db().await;
         let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.force_update_todo_status(id, crate::models::TodoStatus::Failed).await.unwrap();
-        let todo = db.get_todo(id).await.unwrap();
+        let todo = db.get_todo(id).await.unwrap().unwrap();
         assert_eq!(todo.status, crate::models::TodoStatus::Failed);
     }
 
@@ -714,7 +714,7 @@ mod tests {
         let db = setup_db().await;
         let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.delete_todo(id).await.unwrap();
-        assert!(db.get_todo(id).await.is_none());
+        assert!(db.get_todo(id).await.unwrap().is_none());
         let todos = db.get_todos().await.unwrap();
         assert!(todos.iter().all(|t| t.id != id));
     }
@@ -724,7 +724,7 @@ mod tests {
         let db = setup_db().await;
         let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.start_todo_execution(id, "task-1").await.unwrap();
-        let todo = db.get_todo(id).await.unwrap();
+        let todo = db.get_todo(id).await.unwrap().unwrap();
         assert_eq!(todo.status, crate::models::TodoStatus::Running);
         assert_eq!(todo.task_id, Some("task-1".to_string()));
     }
@@ -735,7 +735,7 @@ mod tests {
         let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.start_todo_execution(id, "task-1").await.unwrap();
         db.finish_todo_execution(id, true).await.unwrap();
-        let todo = db.get_todo(id).await.unwrap();
+        let todo = db.get_todo(id).await.unwrap().unwrap();
         assert_eq!(todo.status, crate::models::TodoStatus::Completed);
         assert!(todo.task_id.is_none());
     }
@@ -746,7 +746,7 @@ mod tests {
         let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.start_todo_execution(id, "task-1").await.unwrap();
         db.finish_todo_execution(id, false).await.unwrap();
-        let todo = db.get_todo(id).await.unwrap();
+        let todo = db.get_todo(id).await.unwrap().unwrap();
         assert_eq!(todo.status, crate::models::TodoStatus::Failed);
     }
 
@@ -767,8 +767,8 @@ mod tests {
         let db = setup_db().await;
         let tag_id = db.create_tag("urgent", "#ff0000").await.unwrap();
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
-        db.add_todo_tag(todo_id, tag_id).await;
-        let todo = db.get_todo(todo_id).await.unwrap();
+        db.add_todo_tag(todo_id, tag_id).await.unwrap();
+        let todo = db.get_todo(todo_id).await.unwrap().unwrap();
         assert_eq!(todo.tag_ids, vec![tag_id]);
     }
 
@@ -800,7 +800,7 @@ mod tests {
     async fn test_delete_tag() {
         let db = setup_db().await;
         let id = db.create_tag("temp", "#000").await.unwrap();
-        db.delete_tag(id).await;
+        db.delete_tag(id).await.unwrap();
         let tags = db.get_tags().await.unwrap();
         assert!(tags.iter().all(|t| t.id != id));
     }
@@ -810,8 +810,8 @@ mod tests {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         let tag_id = db.create_tag("urgent", "#ff0000").await.unwrap();
-        db.add_todo_tag(todo_id, tag_id).await;
-        let todo = db.get_todo(todo_id).await.unwrap();
+        db.add_todo_tag(todo_id, tag_id).await.unwrap();
+        let todo = db.get_todo(todo_id).await.unwrap().unwrap();
         assert_eq!(todo.tag_ids, vec![tag_id]);
     }
 
@@ -820,9 +820,9 @@ mod tests {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         let tag_id = db.create_tag("urgent", "#ff0000").await.unwrap();
-        db.add_todo_tag(todo_id, tag_id).await;
-        db.add_todo_tag(todo_id, tag_id).await; // should not panic
-        let todo = db.get_todo(todo_id).await.unwrap();
+        db.add_todo_tag(todo_id, tag_id).await.unwrap();
+        db.add_todo_tag(todo_id, tag_id).await.unwrap(); // should not panic
+        let todo = db.get_todo(todo_id).await.unwrap().unwrap();
         assert_eq!(todo.tag_ids, vec![tag_id]);
     }
 
@@ -833,9 +833,9 @@ mod tests {
         let tag1 = db.create_tag("a", "#000").await.unwrap();
         let tag2 = db.create_tag("b", "#fff").await.unwrap();
         let tag3 = db.create_tag("c", "#aaa").await.unwrap();
-        db.add_todo_tag(todo_id, tag1).await;
-        db.set_todo_tags(todo_id, &[tag2, tag3]).await;
-        let todo = db.get_todo(todo_id).await.unwrap();
+        db.add_todo_tag(todo_id, tag1).await.unwrap();
+        db.set_todo_tags(todo_id, &[tag2, tag3]).await.unwrap();
+        let todo = db.get_todo(todo_id).await.unwrap().unwrap();
         assert_eq!(todo.tag_ids.len(), 2);
         assert!(todo.tag_ids.contains(&tag2));
         assert!(todo.tag_ids.contains(&tag3));
@@ -847,9 +847,9 @@ mod tests {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         let tag_id = db.create_tag("urgent", "#ff0000").await.unwrap();
-        db.add_todo_tag(todo_id, tag_id).await;
-        db.set_todo_tags(todo_id, &[]).await;
-        let todo = db.get_todo(todo_id).await.unwrap();
+        db.add_todo_tag(todo_id, tag_id).await.unwrap();
+        db.set_todo_tags(todo_id, &[]).await.unwrap();
+        let todo = db.get_todo(todo_id).await.unwrap().unwrap();
         assert!(todo.tag_ids.is_empty());
     }
 
@@ -858,7 +858,7 @@ mod tests {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         let tag_id = db.create_tag("urgent", "#ff0000").await.unwrap();
-        db.add_todo_tag(todo_id, tag_id).await;
+        db.add_todo_tag(todo_id, tag_id).await.unwrap();
         db.delete_todo(todo_id).await.unwrap();
         // tag should still exist but association should be gone
         let tags = db.get_tags().await.unwrap();
@@ -872,7 +872,7 @@ mod tests {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         let record_id = db.create_execution_record(todo_id, "echo hi", "claudecode", "manual", "test-task-id", None, None).await.unwrap();
-        let (records, total) = db.get_execution_records(todo_id, 100, 0).await;
+        let (records, total) = db.get_execution_records(todo_id, 100, 0).await.unwrap();
         assert_eq!(total, 1);
         let record = records.iter().find(|r| r.id == record_id).unwrap();
         assert_eq!(record.status, crate::models::ExecutionStatus::Running);
@@ -889,7 +889,7 @@ mod tests {
         for i in 0..5 {
             db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id", None, None).await.unwrap();
         }
-        let (records, total) = db.get_execution_records(todo_id, 2, 0).await;
+        let (records, total) = db.get_execution_records(todo_id, 2, 0).await.unwrap();
         assert_eq!(total, 5);
         assert_eq!(records.len(), 2);
     }
@@ -901,7 +901,7 @@ mod tests {
         for i in 0..3 {
             db.create_execution_record(todo_id, &format!("cmd{}", i), "claudecode", "manual", "test-task-id", None, None).await.unwrap();
         }
-        let (records, total) = db.get_execution_records(todo_id, 10, 2).await;
+        let (records, total) = db.get_execution_records(todo_id, 10, 2).await.unwrap();
         assert_eq!(total, 3);
         assert_eq!(records.len(), 1);
     }
@@ -920,7 +920,7 @@ mod tests {
             duration_ms: Some(1000),
         };
         db.update_execution_record(record_id, "success", "[{\"type\":\"info\"}]", "done", Some(&usage), Some("claude-3")).await.unwrap();
-        let (records, _) = db.get_execution_records(todo_id, 100, 0).await;
+        let (records, _) = db.get_execution_records(todo_id, 100, 0).await.unwrap();
         let record = records.iter().find(|r| r.id == record_id).unwrap();
         assert_eq!(record.status, crate::models::ExecutionStatus::Success);
         assert_eq!(record.logs, "[{\"type\":\"info\"}]");
@@ -936,7 +936,7 @@ mod tests {
     async fn test_get_execution_summary_empty() {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
-        let summary = db.get_execution_summary(todo_id).await;
+        let summary = db.get_execution_summary(todo_id).await.unwrap();
         assert_eq!(summary.todo_id, todo_id);
         assert_eq!(summary.total_executions, 0);
         assert_eq!(summary.success_count, 0);
@@ -955,7 +955,7 @@ mod tests {
         db.update_execution_record(r2, "failed", "[]", "", None, None).await.unwrap();
         let _r3 = db.create_execution_record(todo_id, "cmd3", "claudecode", "manual", "test-task-id", None, None).await.unwrap();
         // r3 stays "running"
-        let summary = db.get_execution_summary(todo_id).await;
+        let summary = db.get_execution_summary(todo_id).await.unwrap();
         assert_eq!(summary.total_executions, 3);
         assert_eq!(summary.success_count, 1);
         assert_eq!(summary.failed_count, 1);
@@ -986,7 +986,7 @@ mod tests {
             duration_ms: Some(2000),
         };
         db.update_execution_record(r2, "success", "[]", "", Some(&usage2), None).await.unwrap();
-        let summary = db.get_execution_summary(todo_id).await;
+        let summary = db.get_execution_summary(todo_id).await.unwrap();
         assert_eq!(summary.total_input_tokens, 300);
         assert_eq!(summary.total_output_tokens, 150);
         assert_eq!(summary.total_cache_read_tokens, 20);

--- a/backend/src/db/tag.rs
+++ b/backend/src/db/tag.rs
@@ -37,18 +37,17 @@ impl Database {
         Ok(inserted.id)
     }
 
-    pub async fn delete_tag(&self, id: i64) {
-        if let Err(e) = tags::Entity::delete_by_id(id).exec(&self.conn).await {
-            tracing::error!("Database delete failed: {}", e);
-        }
+    pub async fn delete_tag(&self, id: i64) -> Result<(), sea_orm::DbErr> {
+        tags::Entity::delete_by_id(id).exec(&self.conn).await?;
+        Ok(())
     }
 
-    pub async fn add_todo_tag(&self, todo_id: i64, tag_id: i64) {
+    pub async fn add_todo_tag(&self, todo_id: i64, tag_id: i64) -> Result<(), sea_orm::DbErr> {
         let am = todo_tags::ActiveModel {
             todo_id: ActiveValue::Set(todo_id),
             tag_id: ActiveValue::Set(tag_id),
         };
-        if let Err(e) = todo_tags::Entity::insert(am)
+        match todo_tags::Entity::insert(am)
             .on_conflict(
                 sea_orm::sea_query::OnConflict::columns([
                     todo_tags::Column::TodoId,
@@ -60,13 +59,14 @@ impl Database {
             .exec(&self.conn)
             .await
         {
-            tracing::warn!("Failed to add tag {} to todo {}: {}", tag_id, todo_id, e);
+            Ok(_) | Err(sea_orm::DbErr::RecordNotInserted) => Ok(()),
+            Err(e) => Err(e),
         }
     }
 
-    pub async fn set_todo_tags(&self, todo_id: i64, tag_ids: &[i64]) {
+    pub async fn set_todo_tags(&self, todo_id: i64, tag_ids: &[i64]) -> Result<(), sea_orm::DbErr> {
         let tag_ids = tag_ids.to_vec();
-        if let Err(e) = self
+        self
             .conn
             .transaction::<_, (), sea_orm::DbErr>(|txn| {
                 Box::pin(async move {
@@ -103,31 +103,31 @@ impl Database {
                 })
             })
             .await
-        {
-            tracing::warn!("Failed to set tags for todo {}: {}", todo_id, e);
-        }
+            .map_err(|e| match e {
+                sea_orm::TransactionError::Connection(err) => err,
+                sea_orm::TransactionError::Transaction(err) => err,
+            })?;
+        Ok(())
     }
 
-    pub async fn get_tag_backups(&self) -> Vec<TagBackup> {
-        tags::Entity::find()
+    pub async fn get_tag_backups(&self) -> Result<Vec<TagBackup>, sea_orm::DbErr> {
+        Ok(tags::Entity::find()
             .all(&self.conn)
-            .await
-            .unwrap_or_default()
+            .await?
             .into_iter()
             .map(|m| TagBackup {
                 name: m.name,
                 color: m.color.unwrap_or_default(),
             })
-            .collect()
+            .collect())
     }
 
-    pub async fn find_tag_by_name(&self, name: &str) -> Option<i64> {
+    pub async fn find_tag_by_name(&self, name: &str) -> Result<Option<i64>, sea_orm::DbErr> {
         use sea_orm::ColumnTrait;
-        tags::Entity::find()
+        Ok(tags::Entity::find()
             .filter(tags::Column::Name.eq(name))
             .one(&self.conn)
-            .await
-            .unwrap_or(None)
-            .map(|m| m.id)
+            .await?
+            .map(|m| m.id))
     }
 }

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -188,22 +188,23 @@ impl Database {
         self.exec_update(am).await
     }
 
-    pub async fn get_todo(&self, id: i64) -> Option<Todo> {
-        let model = todos::Entity::find_by_id(id)
+    pub async fn get_todo(&self, id: i64) -> Result<Option<Todo>, sea_orm::DbErr> {
+        let model = match todos::Entity::find_by_id(id)
             .filter(todos::Column::DeletedAt.is_null())
             .one(&self.conn)
-            .await
-            .ok()
-            .flatten()?;
+            .await?
+        {
+            Some(m) => m,
+            None => return Ok(None),
+        };
         let tag_ids = todo_tags::Entity::find()
             .filter(todo_tags::Column::TodoId.eq(id))
             .all(&self.conn)
-            .await
-            .unwrap_or_default()
+            .await?
             .into_iter()
             .map(|t| t.tag_id)
             .collect();
-        Some(Self::model_to_todo(model, tag_ids))
+        Ok(Some(Self::model_to_todo(model, tag_ids)))
     }
 
     pub async fn get_scheduler_todos(&self) -> Result<Vec<Todo>, sea_orm::DbErr> {
@@ -283,40 +284,40 @@ impl Database {
     }
 
     /// 根据task_id查找对应的todo
-    pub async fn get_todo_by_task_id(&self, task_id: &str) -> Option<Todo> {
-        let model = todos::Entity::find()
+    pub async fn get_todo_by_task_id(&self, task_id: &str) -> Result<Option<Todo>, sea_orm::DbErr> {
+        let model = match todos::Entity::find()
             .filter(todos::Column::TaskId.eq(task_id))
             .filter(todos::Column::DeletedAt.is_null())
             .one(&self.conn)
-            .await
-            .unwrap_or(None)?;
-
-        let tag_map = self.fetch_tag_ids_for_many(&[model.id]).await.unwrap();
+            .await?
+        {
+            Some(m) => m,
+            None => return Ok(None),
+        };
+        let tag_map = self.fetch_tag_ids_for_many(&[model.id]).await?;
         let tag_ids = tag_map.get(&model.id).cloned().unwrap_or_default();
-        Some(Self::model_to_todo(model, tag_ids))
+        Ok(Some(Self::model_to_todo(model, tag_ids)))
     }
 
     /// 获取所有 todo 的备份数据（非软删除），包含标签名称
-    pub async fn get_todo_backups(&self) -> Vec<TodoBackup> {
+    pub async fn get_todo_backups(&self) -> Result<Vec<TodoBackup>, sea_orm::DbErr> {
         let models = todos::Entity::find()
             .filter(todos::Column::DeletedAt.is_null())
             .all(&self.conn)
-            .await
-            .unwrap_or_default();
+            .await?;
 
         let ids: Vec<i64> = models.iter().map(|m| m.id).collect();
-        let tag_map = self.fetch_tag_ids_for_many(&ids).await.unwrap();
+        let tag_map = self.fetch_tag_ids_for_many(&ids).await?;
 
         // 获取所有标签 id -> name 映射
         let all_tags: std::collections::HashMap<i64, String> = tags::Entity::find()
             .all(&self.conn)
-            .await
-            .unwrap_or_default()
+            .await?
             .into_iter()
             .map(|t| (t.id, t.name))
             .collect();
 
-        models
+        Ok(models
             .into_iter()
             .map(|m| {
                 let tag_ids = tag_map.get(&m.id).cloned().unwrap_or_default();
@@ -335,33 +336,31 @@ impl Database {
                     workspace: m.workspace,
                 }
             })
-            .collect()
+            .collect::<Vec<_>>())
     }
 
     /// 按 ID 列表获取 todo 的备份数据
-    pub async fn get_todo_backups_by_ids(&self, ids: &[i64]) -> Vec<TodoBackup> {
+    pub async fn get_todo_backups_by_ids(&self, ids: &[i64]) -> Result<Vec<TodoBackup>, sea_orm::DbErr> {
         if ids.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
         let models = todos::Entity::find()
             .filter(todos::Column::Id.is_in(ids.to_vec()))
             .filter(todos::Column::DeletedAt.is_null())
             .all(&self.conn)
-            .await
-            .unwrap_or_default();
+            .await?;
 
         let model_ids: Vec<i64> = models.iter().map(|m| m.id).collect();
-        let tag_map = self.fetch_tag_ids_for_many(&model_ids).await.unwrap();
+        let tag_map = self.fetch_tag_ids_for_many(&model_ids).await?;
 
         let all_tags: std::collections::HashMap<i64, String> = tags::Entity::find()
             .all(&self.conn)
-            .await
-            .unwrap_or_default()
+            .await?
             .into_iter()
             .map(|t| (t.id, t.name))
             .collect();
 
-        models
+        Ok(models
             .into_iter()
             .map(|m| {
                 let tag_ids = tag_map.get(&m.id).cloned().unwrap_or_default();
@@ -380,25 +379,24 @@ impl Database {
                     workspace: m.workspace,
                 }
             })
-            .collect()
+            .collect())
     }
 
     /// 按 tag name 列表查询 tag 备份数据
-    pub async fn get_tag_backups_by_names(&self, names: &[&str]) -> Vec<crate::models::TagBackup> {
+    pub async fn get_tag_backups_by_names(&self, names: &[&str]) -> Result<Vec<crate::models::TagBackup>, sea_orm::DbErr> {
         if names.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
-        tags::Entity::find()
+        Ok(tags::Entity::find()
             .filter(tags::Column::Name.is_in(names.iter().map(|s| s.to_string()).collect::<Vec<_>>()))
             .all(&self.conn)
-            .await
-            .unwrap_or_default()
+            .await?
             .into_iter()
             .map(|t| crate::models::TagBackup {
                 name: t.name,
                 color: t.color.unwrap_or_default(),
             })
-            .collect()
+            .collect())
     }
 
     /// 从备份数据导入 todo（清空现有数据后导入，失败时自动回滚）

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -46,7 +46,14 @@ pub async fn run_todo_execution(
     let mut cancel_rx = task_manager.register(task_id.clone()).await;
 
     // Get todo to read stored executor
-    let todo = db.get_todo(todo_id).await.ok().flatten();
+    let todo = match db.get_todo(todo_id).await {
+        Ok(Some(t)) => Some(t),
+        Ok(None) => None,
+        Err(e) => {
+            tracing::error!("Failed to fetch todo {} for executor selection: {}", todo_id, e);
+            None
+        }
+    };
     let todo_executor = todo.as_ref().and_then(|t| t.executor.clone());
     let todo_workspace = todo.as_ref().and_then(|t| t.workspace.clone());
 
@@ -435,8 +442,8 @@ pub async fn run_todo_execution(
 
         // 从数据库读取完整的日志集（因为定期 flush 会 drain 内存中的 vec）
         let remaining = std::mem::take(&mut *logs_for_result.lock().await);
-        let all_logs_snapshot = match db_clone.get_execution_record(record_id).await.ok().flatten() {
-            Some(record) if !record.logs.is_empty() && record.logs != "[]" => {
+        let all_logs_snapshot = match db_clone.get_execution_record(record_id).await {
+            Ok(Some(record)) if !record.logs.is_empty() && record.logs != "[]" => {
                 let mut base: Vec<ParsedLogEntry> = match serde_json::from_str(&record.logs) {
                     Ok(b) => b,
                     Err(e) => {
@@ -447,7 +454,11 @@ pub async fn run_todo_execution(
                 base.extend(remaining);
                 base
             }
-            _ => remaining,
+            Ok(_) => remaining,
+            Err(e) => {
+                tracing::error!("Failed to fetch execution record {}: {}", record_id, e);
+                remaining
+            }
         };
         let result_str = executor_spawn.get_final_result(&all_logs_snapshot).unwrap_or_default();
 

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -46,7 +46,7 @@ pub async fn run_todo_execution(
     let mut cancel_rx = task_manager.register(task_id.clone()).await;
 
     // Get todo to read stored executor
-    let todo = db.get_todo(todo_id).await;
+    let todo = db.get_todo(todo_id).await.ok().flatten();
     let todo_executor = todo.as_ref().and_then(|t| t.executor.clone());
     let todo_workspace = todo.as_ref().and_then(|t| t.workspace.clone());
 
@@ -435,7 +435,7 @@ pub async fn run_todo_execution(
 
         // 从数据库读取完整的日志集（因为定期 flush 会 drain 内存中的 vec）
         let remaining = std::mem::take(&mut *logs_for_result.lock().await);
-        let all_logs_snapshot = match db_clone.get_execution_record(record_id).await {
+        let all_logs_snapshot = match db_clone.get_execution_record(record_id).await.ok().flatten() {
             Some(record) if !record.logs.is_empty() && record.logs != "[]" => {
                 let mut base: Vec<ParsedLogEntry> = match serde_json::from_str(&record.logs) {
                     Ok(b) => b,

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -15,8 +15,8 @@ use crate::models::{ApiResponse, BackupData, TagBackup, TodoBackup, utc_timestam
 pub async fn export_backup(
     State(state): State<AppState>,
 ) -> Result<impl IntoResponse, AppError> {
-    let tags = state.db.get_tag_backups().await;
-    let todos = state.db.get_todo_backups().await;
+    let tags = state.db.get_tag_backups().await?;
+    let todos = state.db.get_todo_backups().await?;
     let data = BackupData {
         version: "1.0".to_string(),
         created_at: utc_timestamp(),
@@ -43,7 +43,7 @@ pub async fn export_selected(
     if req.todo_ids.is_empty() {
         return Err(AppError::BadRequest("No todo IDs provided".to_string()));
     }
-    let todos = state.db.get_todo_backups_by_ids(&req.todo_ids).await;
+    let todos = state.db.get_todo_backups_by_ids(&req.todo_ids).await?;
     if todos.is_empty() {
         return Err(AppError::BadRequest("No todos found for given IDs".to_string()));
     }
@@ -51,7 +51,7 @@ pub async fn export_selected(
     let tag_names: std::collections::HashSet<&str> = todos.iter()
         .flat_map(|t| t.tag_names.iter().map(|s| s.as_str()))
         .collect();
-    let tags = state.db.get_tag_backups_by_names(&tag_names.into_iter().collect::<Vec<_>>()).await;
+    let tags = state.db.get_tag_backups_by_names(&tag_names.into_iter().collect::<Vec<_>>()).await?;
     let data = BackupData {
         version: "1.0".to_string(),
         created_at: utc_timestamp(),

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -78,7 +78,7 @@ pub async fn get_execution_records(
     let (records, total) = state
         .db
         .get_execution_records(query.todo_id, limit, offset)
-        .await;
+        .await?;
     Ok(ApiResponse::ok(ExecutionRecordsPage {
         records,
         total,
@@ -94,7 +94,7 @@ pub async fn get_execution_record(
     let record = state
         .db
         .get_execution_record(id)
-        .await
+        .await?
         .ok_or(AppError::NotFound)?;
     Ok(ApiResponse::ok(record))
 }
@@ -106,7 +106,7 @@ pub async fn get_execution_records_by_session(
     let records = state
         .db
         .get_execution_records_by_session(&session_id)
-        .await;
+        .await?;
     Ok(ApiResponse::ok(records))
 }
 
@@ -115,7 +115,7 @@ pub async fn execute_handler(
     ApiJson(req): ApiJson<ExecuteRequest>,
 ) -> Result<ApiResponse<serde_json::Value>, AppError> {
     // Get the todo to use its prompt as fallback when message is not provided
-    let todo = state.db.get_todo(req.todo_id).await
+    let todo = state.db.get_todo(req.todo_id).await?
         .ok_or_else(|| AppError::BadRequest(format!("Todo {} not found", req.todo_id)))?;
 
     // Fall back to todo.prompt if message is None or whitespace-only
@@ -157,7 +157,7 @@ pub async fn stop_execution_handler(
 ) -> Result<ApiResponse<()>, AppError> {
     tracing::info!("Stopping execution record: {}", req.record_id);
 
-    let record = state.db.get_execution_record(req.record_id).await
+    let record = state.db.get_execution_record(req.record_id).await?
         .ok_or(AppError::BadRequest("Execution record not found".to_string()))?;
 
     if record.status != ExecutionStatus::Running {
@@ -203,7 +203,7 @@ pub async fn force_fail_execution_handler(
     State(state): State<AppState>,
     ApiJson(req): ApiJson<ForceFailRequest>,
 ) -> Result<ApiResponse<()>, AppError> {
-    let record = state.db.get_execution_record(req.record_id).await
+    let record = state.db.get_execution_record(req.record_id).await?
         .ok_or(AppError::BadRequest("Execution record not found".to_string()))?;
 
     if record.status != ExecutionStatus::Running {
@@ -230,7 +230,7 @@ pub async fn resume_execution_handler(
     Path(id): Path<i64>,
     ApiJson(req): ApiJson<ResumeExecutionRequest>,
 ) -> Result<ApiResponse<serde_json::Value>, AppError> {
-    let record = state.db.get_execution_record(id).await
+    let record = state.db.get_execution_record(id).await?
         .ok_or(AppError::NotFound)?;
 
     if record.status == ExecutionStatus::Running {
@@ -249,7 +249,7 @@ pub async fn resume_execution_handler(
     }
 
     let todo_id = record.todo_id;
-    let todo = state.db.get_todo(todo_id).await
+    let todo = state.db.get_todo(todo_id).await?
         .ok_or(AppError::NotFound)?;
 
     let message = req.message
@@ -293,7 +293,7 @@ pub async fn get_execution_summary(
     Path(id): Path<i64>,
 ) -> Result<ApiResponse<ExecutionSummary>, AppError> {
     Ok(ApiResponse::ok(
-        state.db.get_execution_summary(id).await,
+        state.db.get_execution_summary(id).await?,
     ))
 }
 
@@ -301,7 +301,7 @@ pub async fn get_dashboard_stats(
     State(state): State<AppState>,
 ) -> Result<ApiResponse<DashboardStats>, AppError> {
     Ok(ApiResponse::ok(
-        state.db.get_dashboard_stats().await,
+        state.db.get_dashboard_stats().await?,
     ))
 }
 

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -37,7 +37,7 @@ pub struct AppState {
 impl AppState {
     /// 根据 id 获取 todo，不存在时返回 NotFound 错误
     pub async fn require_todo(&self, id: i64) -> Result<crate::models::Todo, AppError> {
-        self.db.get_todo(id).await.ok_or(AppError::NotFound)
+        self.db.get_todo(id).await?.ok_or(AppError::NotFound)
     }
 }
 
@@ -162,7 +162,7 @@ pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade)
         let mut running_tasks = state.task_manager.get_all_task_infos().await;
         for task in &mut running_tasks {
             // 从数据库获取该任务的执行记录日志
-            if let Some(record) = state.db.get_execution_record_by_task_id(&task.task_id).await {
+            if let Ok(Some(record)) = state.db.get_execution_record_by_task_id(&task.task_id).await {
                 task.logs = record.logs;
             }
         }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -162,8 +162,10 @@ pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade)
         let mut running_tasks = state.task_manager.get_all_task_infos().await;
         for task in &mut running_tasks {
             // 从数据库获取该任务的执行记录日志
-            if let Ok(Some(record)) = state.db.get_execution_record_by_task_id(&task.task_id).await {
-                task.logs = record.logs;
+            match state.db.get_execution_record_by_task_id(&task.task_id).await {
+                Ok(Some(record)) => task.logs = record.logs,
+                Ok(None) => {}
+                Err(e) => tracing::debug!("No execution record found for task_id {}: {}", task.task_id, e),
             }
         }
         let sync_event = ExecEvent::Sync { tasks: running_tasks };

--- a/backend/src/handlers/tag.rs
+++ b/backend/src/handlers/tag.rs
@@ -33,6 +33,6 @@ pub async fn delete_tag(
     State(state): State<AppState>,
     Path(id): Path<i64>,
 ) -> Result<ApiResponse<()>, AppError> {
-    state.db.delete_tag(id).await;
+    state.db.delete_tag(id).await?;
     Ok(ApiResponse::ok(()))
 }

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -60,7 +60,7 @@ pub async fn create_todo(
     }
 
     for tag_id in &req.tag_ids {
-        state.db.add_todo_tag(id, *tag_id).await;
+        state.db.add_todo_tag(id, *tag_id).await?;
     }
 
     Ok(ApiResponse::ok(Todo {
@@ -134,7 +134,7 @@ pub async fn update_todo_tags(
     Path(id): Path<i64>,
     ApiJson(req): ApiJson<UpdateTagsRequest>,
 ) -> Result<ApiResponse<()>, AppError> {
-    state.db.set_todo_tags(id, &req.tag_ids).await;
+    state.db.set_todo_tags(id, &req.tag_ids).await?;
     Ok(ApiResponse::ok(()))
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -191,7 +191,9 @@ async fn run_server(cli_port: Option<u16>) {
         }
     };
 
-    db.cleanup_orphan_execution_records().await;
+    if let Err(e) = db.cleanup_orphan_execution_records().await {
+        tracing::error!("Failed to cleanup orphan execution records: {}", e);
+    }
 
     // Migrate executor paths from config.yaml to database (one-time), then seed defaults if empty
     if let Err(e) = db.migrate_from_config(&cfg.executors).await {

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -93,11 +93,15 @@ impl TodoScheduler {
             let tm = tm_clone.clone();
 
             Box::pin(async move {
-                if let Ok(Some(todo)) = db.get_todo(todo_id).await {
-                    let message = if todo.prompt.is_empty() { todo.title.clone() } else { todo.prompt.clone() };
-                    let executor = todo.executor.clone();
-                    info!("Scheduled execution triggered for todo {}", todo_id);
-                    run_todo_execution(db, registry, tx, todo_id, message, executor, "cron", tm, None, None).await;
+                match db.get_todo(todo_id).await {
+                    Ok(Some(todo)) => {
+                        let message = if todo.prompt.is_empty() { todo.title.clone() } else { todo.prompt.clone() };
+                        let executor = todo.executor.clone();
+                        info!("Scheduled execution triggered for todo {}", todo_id);
+                        run_todo_execution(db, registry, tx, todo_id, message, executor, "cron", tm, None, None).await;
+                    }
+                    Ok(None) => warn!("Scheduled todo {} not found, skipping", todo_id),
+                    Err(e) => tracing::error!("Failed to fetch scheduled todo {}: {}", todo_id, e),
                 }
             })
         })?;

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -93,7 +93,7 @@ impl TodoScheduler {
             let tm = tm_clone.clone();
 
             Box::pin(async move {
-                if let Some(todo) = db.get_todo(todo_id).await {
+                if let Ok(Some(todo)) = db.get_todo(todo_id).await {
                     let message = if todo.prompt.is_empty() { todo.title.clone() } else { todo.prompt.clone() };
                     let executor = todo.executor.clone();
                     info!("Scheduled execution triggered for todo {}", todo_id);

--- a/backend/src/services/feishu_history_fetcher.rs
+++ b/backend/src/services/feishu_history_fetcher.rs
@@ -409,7 +409,14 @@ impl FeishuHistoryFetcher {
                             // Push to debounce buffer instead of executing directly
                             if let Some(todo_id) = Self::resolve_todo_id(config, msg_content).await {
                                 let (trigger_type, params) = Self::build_trigger_params(msg_content);
-                                let todo_prompt = db.get_todo(todo_id).await.ok().flatten().map(|t| t.prompt.clone()).unwrap_or_default();
+                                let todo_prompt = match db.get_todo(todo_id).await {
+                                    Ok(Some(t)) => Some(t.prompt.clone()),
+                                    Ok(None) => None,
+                                    Err(e) => {
+                                        tracing::error!("Failed to fetch todo {} for feishu history: {}", todo_id, e);
+                                        None
+                                    }
+                                }.unwrap_or_default();
                                 debounce.push(PendingMessage {
                                     bot_id,
                                     chat_id: chat_id.to_string(),

--- a/backend/src/services/feishu_history_fetcher.rs
+++ b/backend/src/services/feishu_history_fetcher.rs
@@ -409,7 +409,7 @@ impl FeishuHistoryFetcher {
                             // Push to debounce buffer instead of executing directly
                             if let Some(todo_id) = Self::resolve_todo_id(config, msg_content).await {
                                 let (trigger_type, params) = Self::build_trigger_params(msg_content);
-                                let todo_prompt = db.get_todo(todo_id).await.map(|t| t.prompt.clone()).unwrap_or_default();
+                                let todo_prompt = db.get_todo(todo_id).await.ok().flatten().map(|t| t.prompt.clone()).unwrap_or_default();
                                 debounce.push(PendingMessage {
                                     bot_id,
                                     chat_id: chat_id.to_string(),

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -257,7 +257,7 @@ impl FeishuListener {
 
             if let Some(rule) = matched_rule {
                 if !command_ctx.body.is_empty() {
-                    let todo = db.get_todo(rule.todo_id).await;
+                    let todo = db.get_todo(rule.todo_id).await.ok().flatten();
                     if let Some(todo) = todo {
                         let mut params = HashMap::new();
                         params.insert("content".to_string(), command_ctx.body.to_string());
@@ -288,7 +288,7 @@ impl FeishuListener {
                 };
                 if let Some(todo_id) = default_todo_id {
                     if !content.is_empty() {
-                        let todo_prompt = db.get_todo(todo_id).await.map(|t| t.prompt.clone()).unwrap_or_default();
+                        let todo_prompt = db.get_todo(todo_id).await.ok().flatten().map(|t| t.prompt.clone()).unwrap_or_default();
                         debounce.push(PendingMessage {
                             bot_id,
                             chat_id: msg.channel.clone(),
@@ -314,7 +314,7 @@ impl FeishuListener {
 
             if let Some(todo_id) = default_todo_id {
                 if !content.is_empty() {
-                    let todo_prompt = db.get_todo(todo_id).await.map(|t| t.prompt.clone()).unwrap_or_default();
+                    let todo_prompt = db.get_todo(todo_id).await.ok().flatten().map(|t| t.prompt.clone()).unwrap_or_default();
                     debounce.push(PendingMessage {
                         bot_id,
                         chat_id: msg.channel.clone(),

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -257,7 +257,14 @@ impl FeishuListener {
 
             if let Some(rule) = matched_rule {
                 if !command_ctx.body.is_empty() {
-                    let todo = db.get_todo(rule.todo_id).await.ok().flatten();
+                    let todo = match db.get_todo(rule.todo_id).await {
+                        Ok(Some(t)) => Some(t),
+                        Ok(None) => None,
+                        Err(e) => {
+                            tracing::error!("Failed to fetch todo {} for slash command: {}", rule.todo_id, e);
+                            None
+                        }
+                    };
                     if let Some(todo) = todo {
                         let mut params = HashMap::new();
                         params.insert("content".to_string(), command_ctx.body.to_string());
@@ -288,7 +295,14 @@ impl FeishuListener {
                 };
                 if let Some(todo_id) = default_todo_id {
                     if !content.is_empty() {
-                        let todo_prompt = db.get_todo(todo_id).await.ok().flatten().map(|t| t.prompt.clone()).unwrap_or_default();
+                        let todo_prompt = match db.get_todo(todo_id).await {
+                            Ok(Some(t)) => Some(t.prompt.clone()),
+                            Ok(None) => None,
+                            Err(e) => {
+                                tracing::error!("Failed to fetch todo {} for debounce: {}", todo_id, e);
+                                None
+                            }
+                        }.unwrap_or_default();
                         debounce.push(PendingMessage {
                             bot_id,
                             chat_id: msg.channel.clone(),
@@ -314,7 +328,14 @@ impl FeishuListener {
 
             if let Some(todo_id) = default_todo_id {
                 if !content.is_empty() {
-                    let todo_prompt = db.get_todo(todo_id).await.ok().flatten().map(|t| t.prompt.clone()).unwrap_or_default();
+                    let todo_prompt = match db.get_todo(todo_id).await {
+                        Ok(Some(t)) => Some(t.prompt.clone()),
+                        Ok(None) => None,
+                        Err(e) => {
+                            tracing::error!("Failed to fetch todo {} for message debounce: {}", todo_id, e);
+                            None
+                        }
+                    }.unwrap_or_default();
                     debounce.push(PendingMessage {
                         bot_id,
                         chat_id: msg.channel.clone(),


### PR DESCRIPTION
## Summary
- 所有 DB 查询方法改为返回 `Result<T, DbErr>`，移除 `.ok()`、`.unwrap_or_default()`、`.unwrap()` 对 DB 错误的吞没
- Handler 层统一通过 `?` 运算符 + `From<DbErr> for AppError` 转换错误，通过 `.ok_or(AppError::NotFound)?` 处理缺失记录
- DB void 方法（`delete_tag`、`add_todo_tag`、`set_todo_tags`、`cleanup_orphan_execution_records`）改为返回 `Result<(), DbErr>`
- 更新所有 service 层调用方（feishu_listener、feishu_history_fetcher、scheduler、executor_service）适配新返回类型

## 影响范围
14 个文件修改，166 行新增，181 行删除

## 测试
- 212/213 测试通过（1 个失败为预先存在的 joinai 测试问题，与本次修改无关）
- `make restart` 服务正常启动

Closes #165