### PR TITLE
feat: 备份增加保留数量限制及下载按钮

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -34,6 +34,8 @@ pub struct Config {
     pub auto_backup_enabled: bool,
     /// 自动备份 cron 表达式（6 字段，含秒）
     pub auto_backup_cron: String,
+    /// 自动备份最大保留文件数
+    pub auto_backup_max_files: usize,
     /// 全局斜杠命令规则
     pub slash_command_rules: Vec<SlashCommandRule>,
     /// 默认响应：当没有匹配到斜杠命令时执行的 Todo ID
@@ -99,6 +101,7 @@ impl Default for Config {
             executors: ExecutorPaths::default(),
             auto_backup_enabled: false,
             auto_backup_cron: "0 0 3 * * *".to_string(),
+            auto_backup_max_files: 30,
             slash_command_rules: Vec::new(),
             default_response_todo_id: None,
             history_message_max_age_secs: 600,

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::State,
+    extract::{State, Query},
     body::Bytes,
     response::IntoResponse,
     http::header,
@@ -167,8 +167,8 @@ pub async fn trigger_local_backup() -> Result<ApiResponse<String>, AppError> {
     .map_err(|e| AppError::Internal(format!("Task join error: {}", e)))?
     .map_err(|e| AppError::Internal(format!("Failed to copy database: {}", e)))?;
 
-    // 清理旧备份，保留最近 30 个
-    cleanup_old_backups(30);
+    // 清理旧备份
+    cleanup_old_backups(cfg.auto_backup_max_files);
 
     Ok(ApiResponse::ok(format!("备份成功: {}", backup_path.display())))
 }
@@ -184,6 +184,7 @@ pub struct BackupFile {
 pub struct BackupStatus {
     pub auto_backup_enabled: bool,
     pub auto_backup_cron: String,
+    pub auto_backup_max_files: usize,
     pub last_backup: Option<String>,
     pub files: Vec<BackupFile>,
 }
@@ -228,6 +229,7 @@ pub async fn get_database_backup_status() -> Result<ApiResponse<BackupStatus>, A
     Ok(ApiResponse::ok(BackupStatus {
         auto_backup_enabled: cfg.auto_backup_enabled,
         auto_backup_cron: cfg.auto_backup_cron,
+        auto_backup_max_files: cfg.auto_backup_max_files,
         last_backup,
         files,
     }))
@@ -238,6 +240,7 @@ pub async fn get_database_backup_status() -> Result<ApiResponse<BackupStatus>, A
 pub struct UpdateAutoBackupRequest {
     pub enabled: bool,
     pub cron: String,
+    pub max_files: Option<usize>,
 }
 
 pub async fn update_auto_backup(
@@ -255,6 +258,12 @@ pub async fn update_auto_backup(
     let mut cfg = crate::config::Config::load();
     cfg.auto_backup_enabled = req.enabled;
     cfg.auto_backup_cron = req.cron;
+    if let Some(max_files) = req.max_files {
+        if max_files == 0 {
+            return Err(AppError::BadRequest("保留数量不能为 0".to_string()));
+        }
+        cfg.auto_backup_max_files = max_files;
+    }
     cfg.save().map_err(|e| AppError::Internal(e))?;
 
     Ok(ApiResponse::ok("自动备份配置已更新".to_string()))
@@ -284,6 +293,39 @@ pub async fn delete_backup_file(
     Ok(ApiResponse::ok("已删除".to_string()))
 }
 
+/// 下载指定备份文件
+#[derive(Deserialize)]
+pub struct DownloadBackupQuery {
+    pub filename: String,
+}
+
+pub async fn download_backup_file(
+    Query(query): Query<DownloadBackupQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    if query.filename.contains('/') || query.filename.contains('\\') || query.filename.contains("..") {
+        return Err(AppError::BadRequest("Invalid filename".to_string()));
+    }
+    let path = backup_dir().join(&query.filename);
+    if !path.exists() {
+        return Err(AppError::NotFound);
+    }
+
+    let filename = query.filename.clone();
+    let bytes = tokio::task::spawn_blocking(move || std::fs::read(&path))
+        .await
+        .map_err(|e| AppError::Internal(format!("Task join error: {}", e)))?
+        .map_err(|e| AppError::Internal(format!("Failed to read backup file: {}", e)))?;
+
+    let disposition = format!("attachment; filename=\"{}\"", filename);
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/octet-stream".to_string()),
+            (header::CONTENT_DISPOSITION, disposition),
+        ],
+        bytes,
+    ))
+}
+
 /// 执行数据库文件备份（供定时任务调用）
 pub fn perform_database_backup() -> Result<String, String> {
     let cfg = crate::config::Config::load();
@@ -303,7 +345,7 @@ pub fn perform_database_backup() -> Result<String, String> {
     std::fs::copy(&db_path, &backup_path)
         .map_err(|e| format!("Failed to copy database: {}", e))?;
 
-    cleanup_old_backups(30);
+    cleanup_old_backups(cfg.auto_backup_max_files);
 
     Ok(format!("Auto backup: {}", backup_path.display()))
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -406,7 +406,7 @@ pub fn create_app(
         .route("/xyz/backup/database/status", get(backup::get_database_backup_status))
         .route("/xyz/backup/database/trigger", post(backup::trigger_local_backup))
         .route("/xyz/backup/database/auto", put(backup::update_auto_backup))
-        .route("/xyz/backup/database/file", delete(backup::delete_backup_file))
+        .route("/xyz/backup/database/file", get(backup::download_backup_file).delete(backup::delete_backup_file))
         .route("/xyz/config", get(config::get_config).put(config::update_config))
         .route("/xyz/executors", get(executor_config::list_executors))
         .route("/xyz/executors/{name}", put(executor_config::update_executor))

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -99,11 +99,13 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
   const [backupStatus, setBackupStatus] = useState<{
     auto_backup_enabled: boolean;
     auto_backup_cron: string;
+    auto_backup_max_files: number;
     last_backup: string | null;
     files: { name: string; size: number; created_at: string }[];
   } | null>(null);
   const [autoBackupEnabled, setAutoBackupEnabled] = useState(false);
   const [autoBackupCron, setAutoBackupCron] = useState('0 0 3 * * *');
+  const [autoBackupMaxFiles, setAutoBackupMaxFiles] = useState(30);
   const [backupLoading, setBackupLoading] = useState(false);
 
   // Version info state
@@ -230,6 +232,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
         setBackupStatus(status);
         setAutoBackupEnabled(status.auto_backup_enabled);
         setAutoBackupCron(status.auto_backup_cron);
+        setAutoBackupMaxFiles(status.auto_backup_max_files);
       })
       .catch(() => {});
   }, []);
@@ -660,7 +663,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
   const handleSaveAutoBackup = async () => {
     setBackupLoading(true);
     try {
-      await db.updateAutoBackup(autoBackupEnabled, autoBackupCron);
+      await db.updateAutoBackup(autoBackupEnabled, autoBackupCron, autoBackupMaxFiles);
       message.success('自动备份配置已保存');
     } catch (err: any) {
       message.error(err?.message || '保存失败');
@@ -678,6 +681,16 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
     } catch (err: any) {
       message.error(err?.message || '删除失败');
     }
+  };
+
+  const handleDownloadBackupFile = (filename: string) => {
+    const url = db.downloadBackupFileUrl(filename);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
   };
 
   // Load running execution records from DB
@@ -1135,6 +1148,20 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                     allowClear={false}
                   />
                 )}
+                {autoBackupEnabled && (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 8 }}>
+                    <span style={{ fontSize: 12, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>保留数量</span>
+                    <InputNumber
+                      min={1}
+                      max={1000}
+                      value={autoBackupMaxFiles}
+                      onChange={(v) => v && setAutoBackupMaxFiles(v)}
+                      style={{ width: 80 }}
+                      size="small"
+                    />
+                    <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>个备份文件</span>
+                  </div>
+                )}
                 <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 8 }}>
                   <Button size="small" type="primary" onClick={handleSaveAutoBackup} loading={backupLoading}>
                     保存
@@ -1158,9 +1185,12 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                             {(file.size / 1024).toFixed(1)} KB · {file.created_at}
                           </div>
                         </div>
-                        <Popconfirm title="确定删除此备份？" onConfirm={() => handleDeleteBackup(file.name)}>
-                          <Button type="text" danger icon={<DeleteOutlined />} size="small" />
-                        </Popconfirm>
+                        <Space size={4}>
+                          <Button type="text" icon={<DownloadOutlined />} size="small" onClick={() => handleDownloadBackupFile(file.name)} />
+                          <Popconfirm title="确定删除此备份？" onConfirm={() => handleDeleteBackup(file.name)}>
+                            <Button type="text" danger icon={<DeleteOutlined />} size="small" />
+                          </Popconfirm>
+                        </Space>
                       </List.Item>
                     )}
                   />

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -210,7 +210,11 @@ export async function getDatabaseBackupStatus(): Promise<{
 }
 
 export async function updateAutoBackup(enabled: boolean, cron: string, maxFiles?: number): Promise<string> {
-  return unwrap(await api.put<ApiResp<string>>('/xyz/backup/database/auto', { enabled, cron, max_files: maxFiles }));
+  const body: Record<string, unknown> = { enabled, cron };
+  if (maxFiles !== undefined) {
+    body.max_files = maxFiles;
+  }
+  return unwrap(await api.put<ApiResp<string>>('/xyz/backup/database/auto', body));
 }
 
 export async function deleteBackupFile(filename: string): Promise<string> {

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -196,23 +196,29 @@ export async function triggerLocalBackup(): Promise<string> {
 export async function getDatabaseBackupStatus(): Promise<{
   auto_backup_enabled: boolean;
   auto_backup_cron: string;
+  auto_backup_max_files: number;
   last_backup: string | null;
   files: { name: string; size: number; created_at: string }[];
 }> {
   return unwrap(await api.get<ApiResp<{
     auto_backup_enabled: boolean;
     auto_backup_cron: string;
+    auto_backup_max_files: number;
     last_backup: string | null;
     files: { name: string; size: number; created_at: string }[];
   }>>('/xyz/backup/database/status'));
 }
 
-export async function updateAutoBackup(enabled: boolean, cron: string): Promise<string> {
-  return unwrap(await api.put<ApiResp<string>>('/xyz/backup/database/auto', { enabled, cron }));
+export async function updateAutoBackup(enabled: boolean, cron: string, maxFiles?: number): Promise<string> {
+  return unwrap(await api.put<ApiResp<string>>('/xyz/backup/database/auto', { enabled, cron, max_files: maxFiles }));
 }
 
 export async function deleteBackupFile(filename: string): Promise<string> {
   return unwrap(await api.delete<ApiResp<string>>('/xyz/backup/database/file', { data: { filename } }));
+}
+
+export function downloadBackupFileUrl(filename: string): string {
+  return `/xyz/backup/database/file?filename=${encodeURIComponent(filename)}`;
 }
 
 // Config APIs


### PR DESCRIPTION
## Summary
- 自动备份数量可在设置页面配置（默认保留 30 个），清理逻辑从硬编码改为读取配置
- 备份文件列表每项增加下载按钮，与删除按钮并排显示
- 后端新增 `GET /xyz/backup/database/file?filename=xxx` 接口用于下载指定备份文件

## Changes
- `backend/src/config.rs` — 新增 `auto_backup_max_files` 配置字段
- `backend/src/handlers/backup.rs` — 清理逻辑、状态返回、更新接口支持 max_files、新增下载 handler
- `backend/src/handlers/mod.rs` — 备份文件路由增加 GET 方法
- `frontend/src/utils/database.ts` — API 函数适配
- `frontend/src/components/SettingsPage.tsx` — 自动备份区域增加保留数量 InputNumber；备份列表增加下载按钮

## Test plan
- [x] 构建通过，服务正常启动
- [x] Playwright 验证：保留数量 UI 正常显示
- [x] Playwright 验证：下载 API 返回 200 + 正确文件大小
- [x] Playwright 验证：每个备份文件项同时有下载和删除按钮
- [ ] 手动测试：修改保留数量保存后，触发备份验证旧文件被正确清理