### PR TITLE
feat: Session 管理功能

### DIFF
--- a/backend/src/db/entity/executors.rs
+++ b/backend/src/db/entity/executors.rs
@@ -11,6 +11,7 @@ pub struct Model {
     pub path: String,
     pub enabled: bool,
     pub display_name: String,
+    pub session_dir: String,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }

--- a/backend/src/db/executor_config.rs
+++ b/backend/src/db/executor_config.rs
@@ -11,6 +11,7 @@ fn map_executor(m: executors::Model) -> ExecutorConfig {
         path: m.path,
         enabled: m.enabled,
         display_name: m.display_name,
+        session_dir: m.session_dir,
         created_at: m.created_at,
         updated_at: m.updated_at,
     }
@@ -20,17 +21,18 @@ struct DefaultExecutor {
     name: &'static str,
     path: &'static str,
     display_name: &'static str,
+    session_dir: &'static str,
 }
 
 const DEFAULT_EXECUTORS: &[DefaultExecutor] = &[
-    DefaultExecutor { name: "claude_code", path: "claude", display_name: "Claude Code" },
-    DefaultExecutor { name: "joinai", path: "joinai", display_name: "JoinAI" },
-    DefaultExecutor { name: "codebuddy", path: "codebuddy", display_name: "CodeBuddy" },
-    DefaultExecutor { name: "opencode", path: "opencode", display_name: "Opencode" },
-    DefaultExecutor { name: "atomcode", path: "atomcode", display_name: "AtomCode" },
-    DefaultExecutor { name: "hermes", path: "hermes", display_name: "Hermes" },
-    DefaultExecutor { name: "kimi", path: "kimi", display_name: "Kimi" },
-    DefaultExecutor { name: "codex", path: "codex", display_name: "Codex" },
+    DefaultExecutor { name: "claude_code", path: "claude", display_name: "Claude Code", session_dir: "~/.claude" },
+    DefaultExecutor { name: "joinai", path: "joinai", display_name: "JoinAI", session_dir: "" },
+    DefaultExecutor { name: "codebuddy", path: "codebuddy", display_name: "CodeBuddy", session_dir: "~/.codebuddy" },
+    DefaultExecutor { name: "opencode", path: "opencode", display_name: "Opencode", session_dir: "~/.opencode" },
+    DefaultExecutor { name: "atomcode", path: "atomcode", display_name: "AtomCode", session_dir: "~/.atomcode" },
+    DefaultExecutor { name: "hermes", path: "hermes", display_name: "Hermes", session_dir: "~/.hermes" },
+    DefaultExecutor { name: "kimi", path: "kimi", display_name: "Kimi", session_dir: "~/.kimi" },
+    DefaultExecutor { name: "codex", path: "codex", display_name: "Codex", session_dir: "~/.codex" },
 ];
 
 impl Database {
@@ -65,6 +67,7 @@ impl Database {
         path: Option<&str>,
         enabled: Option<bool>,
         display_name: Option<&str>,
+        session_dir: Option<&str>,
     ) -> Result<(), sea_orm::DbErr> {
         let model = executors::Entity::find()
             .filter(executors::Column::Name.eq(name))
@@ -81,6 +84,9 @@ impl Database {
             }
             if let Some(d) = display_name {
                 am.display_name = ActiveValue::Set(d.to_string());
+            }
+            if let Some(sd) = session_dir {
+                am.session_dir = ActiveValue::Set(sd.to_string());
             }
             am.updated_at = ActiveValue::Set(Some(now));
             am.update(&self.conn).await?;
@@ -118,6 +124,7 @@ impl Database {
                 path: ActiveValue::Set(path.to_string()),
                 enabled: ActiveValue::Set(true),
                 display_name: ActiveValue::Set(d.display_name.to_string()),
+                session_dir: ActiveValue::Set(d.session_dir.to_string()),
                 created_at: ActiveValue::Set(Some(now.clone())),
                 updated_at: ActiveValue::Set(Some(now.clone())),
                 ..Default::default()
@@ -143,6 +150,7 @@ impl Database {
                 path: ActiveValue::Set(d.path.to_string()),
                 enabled: ActiveValue::Set(true),
                 display_name: ActiveValue::Set(d.display_name.to_string()),
+                session_dir: ActiveValue::Set(d.session_dir.to_string()),
                 created_at: ActiveValue::Set(Some(now.clone())),
                 updated_at: ActiveValue::Set(Some(now.clone())),
                 ..Default::default()
@@ -151,6 +159,25 @@ impl Database {
         }
 
         tracing::info!("Seeded default executors into database");
+        Ok(())
+    }
+
+    /// Backfill session_dir for existing executors that have empty session_dir.
+    pub async fn backfill_session_dir(&self) -> Result<(), sea_orm::DbErr> {
+        let models = executors::Entity::find().all(&self.conn).await?;
+        for m in models {
+            if m.session_dir.is_empty() {
+                let default_dir = DEFAULT_EXECUTORS.iter()
+                    .find(|d| d.name == m.name)
+                    .map(|d| d.session_dir)
+                    .unwrap_or("");
+                if !default_dir.is_empty() {
+                    let mut am: executors::ActiveModel = m.into();
+                    am.session_dir = ActiveValue::Set(default_dir.to_string());
+                    am.update(&self.conn).await?;
+                }
+            }
+        }
         Ok(())
     }
 }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -430,12 +430,16 @@ impl Database {
                 path TEXT NOT NULL DEFAULT '',
                 enabled INTEGER NOT NULL DEFAULT 1,
                 display_name TEXT NOT NULL DEFAULT '',
+                session_dir TEXT NOT NULL DEFAULT '',
                 created_at TEXT,
                 updated_at TEXT
             )",
         )
         .await?;
         self.exec("CREATE INDEX IF NOT EXISTS idx_executors_name ON executors(name)").await?;
+
+        // Migration: add session_dir column if missing (existing databases)
+        let _ = self.exec("ALTER TABLE executors ADD COLUMN session_dir TEXT NOT NULL DEFAULT ''").await;
 
         // Executors timestamps triggers
         self.exec(

--- a/backend/src/handlers/executor_config.rs
+++ b/backend/src/handlers/executor_config.rs
@@ -20,6 +20,7 @@ pub async fn update_executor(
         req.path.as_deref(),
         req.enabled,
         req.display_name.as_deref(),
+        req.session_dir.as_deref(),
     ).await.map_err(|e| AppError::Internal(e.to_string()))?;
 
     // Re-read updated executor

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -151,6 +151,7 @@ pub mod skills;
 pub mod agent_bot;
 pub mod executor_config;
 mod feishu_history;
+mod session;
 
 // WebSocket handler
 pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
@@ -434,6 +435,9 @@ pub fn create_app(
         .route("/xyz/agent-bots/{id}/config", put(agent_bot::update_agent_bot_config))
         .route("/assets/{*path}", get(static_handler))
         .route("/xyz/version", get(version_handler))
+        .route("/xyz/sessions", get(session::list_sessions))
+        .route("/xyz/sessions/stats", get(session::get_session_stats))
+        .route("/xyz/sessions/{id}", get(session::get_session_detail).delete(session::delete_session))
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024)) // 10MB
         .layer(CompressionLayer::new())
         .layer(

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -230,7 +230,7 @@ fn scan_claude_code(sessions: &mut Vec<SessionInfo>) {
 
                     sessions.push(SessionInfo {
                         session_id: session_id.clone(),
-                        source: "claude-code".to_string(),
+                        source: "claude_code".to_string(),
                         project_path: project_path.clone(),
                         status: if active_set.contains(&session_id) { "active".into() } else { "completed".into() },
                         executor: executor.unwrap_or_else(|| "unknown".into()),
@@ -693,14 +693,36 @@ fn scan_ccconnect(sessions: &mut Vec<SessionInfo>) {
 
 // ─── Unified scan ─────────────────────────────────────────
 
-fn scan_all_sources() -> Vec<SessionInfo> {
+/// Map executor name to scanner function and default source name.
+/// Only executors listed here will be scanned.
+fn get_scanner(name: &str) -> Option<fn(&mut Vec<SessionInfo>)> {
+    match name {
+        "claude_code" => Some(scan_claude_code),
+        "codex" => Some(scan_codex),
+        "hermes" => Some(scan_hermes),
+        "kimi" => Some(scan_kimi),
+        "atomcode" => Some(scan_atomcode),
+        "codebuddy" | "opencode" | "joinai" => None, // no session storage found
+        _ => None,
+    }
+}
+
+fn scan_for_executors(enabled_executors: &[crate::models::ExecutorConfig]) -> Vec<SessionInfo> {
     let mut sessions = Vec::new();
-    scan_claude_code(&mut sessions);
-    scan_codex(&mut sessions);
-    scan_hermes(&mut sessions);
-    scan_kimi(&mut sessions);
-    scan_atomcode(&mut sessions);
-    scan_ccconnect(&mut sessions);
+
+    for exec in enabled_executors {
+        // Check if session_dir is configured and exists
+        if !exec.session_dir.is_empty() {
+            let expanded = exec.session_dir.replace('~', &dirs::home_dir().unwrap_or_default().to_string_lossy());
+            if !std::path::Path::new(&expanded).exists() {
+                continue;
+            }
+        }
+
+        if let Some(scanner) = get_scanner(&exec.name) {
+            scanner(&mut sessions);
+        }
+    }
 
     // Sort by last_active_at descending
     sessions.sort_by(|a, b| b.last_active_at.cmp(&a.last_active_at));
@@ -710,14 +732,16 @@ fn scan_all_sources() -> Vec<SessionInfo> {
 // ─── Handlers ─────────────────────────────────────────────
 
 pub async fn list_sessions(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     Query(query): Query<ListSessionsQuery>,
 ) -> Result<ApiResponse<SessionListResponse>, AppError> {
     let page = query.page.unwrap_or(1);
     let page_size = query.page_size.unwrap_or(20);
 
+    let executors = state.db.get_enabled_executors().await.map_err(|e| AppError::Internal(e.to_string()))?;
+
     let result = tokio::task::spawn_blocking(move || {
-        let mut sessions = scan_all_sources();
+        let mut sessions = scan_for_executors(&executors);
 
         // Apply filters
         if let Some(ref status) = query.status {
@@ -759,10 +783,12 @@ pub async fn list_sessions(
 }
 
 pub async fn get_session_stats(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
 ) -> Result<ApiResponse<SessionStats>, AppError> {
+    let executors = state.db.get_enabled_executors().await.map_err(|e| AppError::Internal(e.to_string()))?;
+
     let stats = tokio::task::spawn_blocking(move || {
-        let sessions = scan_all_sources();
+        let sessions = scan_for_executors(&executors);
         let now = chrono::Utc::now();
         let today_start = now.date_naive().and_hms_opt(0, 0, 0).unwrap();
 
@@ -955,7 +981,7 @@ fn get_claude_detail(session_id: &str) -> Option<SessionDetail> {
     Some(SessionDetail {
         info: SessionInfo {
             session_id: session_id.to_string(),
-            source: "claude-code".to_string(),
+            source: "claude_code".to_string(),
             project_path,
             status: if active_set.contains(session_id) { "active".into() } else { "completed".into() },
             executor: executor.unwrap_or_else(|| "unknown".into()),

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -1,0 +1,665 @@
+use axum::{
+    extract::{Path, Query, State},
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use super::{AppError, AppState};
+use crate::models::ApiResponse;
+
+// ─── Request / Response types ─────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct ListSessionsQuery {
+    pub page: Option<u64>,
+    pub page_size: Option<u64>,
+    pub status: Option<String>,    // "active" | "completed"
+    pub executor: Option<String>,  // filter by entrypoint
+    pub project: Option<String>,   // filter by project path (partial match)
+    pub search: Option<String>,    // search in first prompt
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionInfo {
+    pub session_id: String,
+    pub project_path: String,
+    pub status: String,
+    pub executor: String,
+    pub model: String,
+    pub git_branch: Option<String>,
+    pub message_count: u32,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub first_prompt: Option<String>,
+    pub created_at: Option<String>,
+    pub last_active_at: Option<String>,
+    pub file_size: u64,
+    pub version: Option<String>,
+    pub subagent_count: u32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionListResponse {
+    pub sessions: Vec<SessionInfo>,
+    pub total: u64,
+    pub page: u64,
+    pub page_size: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionStats {
+    pub total_sessions: u64,
+    pub active_sessions: u64,
+    pub today_sessions: u64,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub by_executor: HashMap<String, u64>,
+    pub by_project: HashMap<String, u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionMessage {
+    pub role: String,
+    pub content_preview: String,
+    pub model: Option<String>,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub timestamp: Option<String>,
+    pub stop_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SubAgentInfo {
+    pub agent_type: String,
+    pub description: String,
+    pub message_count: u32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionDetail {
+    pub info: SessionInfo,
+    pub messages: Vec<SessionMessage>,
+    pub subagents: Vec<SubAgentInfo>,
+}
+
+// ─── Helpers ──────────────────────────────────────────────
+
+fn claude_home() -> PathBuf {
+    dirs::home_dir()
+        .expect("no home directory")
+        .join(".claude")
+}
+
+/// Decode project path from encoded directory name.
+/// e.g. "-Users-weibh-projects-rust-aitodo" -> "/Users/weibh/projects/rust/aitodo"
+fn decode_project_path(encoded: &str) -> String {
+    let s = encoded.strip_prefix('-').unwrap_or(encoded);
+    // The encoding replaces '/' with '-'. We need to restore them.
+    // But path components like "/Users/weibh" also have separators.
+    // Strategy: split on '-', try to reconstruct valid path with '/'.
+    // Since home dir starts with /Users, we know the first segment is empty.
+    format!("/{}", s.replace('-', "/"))
+}
+
+/// Truncate a string to at most `max_len` chars, appending "..." if truncated.
+fn truncate_str(s: &str, max_len: usize) -> String {
+    if s.chars().count() <= max_len {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max_len).collect();
+        format!("{}...", truncated)
+    }
+}
+
+/// Extract text content from a JSON value that may be a string or array of content blocks.
+fn extract_text_content(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Array(blocks) => {
+            let mut texts = Vec::new();
+            for block in blocks {
+                if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                    texts.push(text.to_string());
+                }
+            }
+            texts.join("\n")
+        }
+        _ => String::new(),
+    }
+}
+
+/// Parse a single JSONL line into session metadata contributions.
+fn parse_line_metadata(
+    line: &str,
+) -> Option<(
+    Option<String>,    // timestamp
+    Option<String>,    // model
+    Option<String>,    // git_branch
+    Option<String>,    // version
+    Option<String>,    // executor / entrypoint
+    Option<String>,    // first prompt content
+    Option<u64>,       // input_tokens
+    Option<u64>,       // output_tokens
+    String,            // role
+)> {
+    let v: serde_json::Value = serde_json::from_str(line).ok()?;
+    let msg_type = v.get("type")?.as_str()?;
+
+    match msg_type {
+        "user" => {
+            let ts = v.get("timestamp").and_then(|t| t.as_str()).map(|s| s.to_string());
+            let branch = v.get("gitBranch").and_then(|b| b.as_str()).map(|s| s.to_string());
+            let ver = v.get("version").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let entry = v.get("entrypoint").and_then(|e| e.as_str()).map(|s| s.to_string());
+            let content = v.get("message")
+                .and_then(|m| m.get("content"))
+                .map(|c| extract_text_content(c));
+            Some((ts, None, branch, ver, entry, content, None, None, "user".to_string()))
+        }
+        "assistant" => {
+            let ts = v.get("timestamp").and_then(|t| t.as_str()).map(|s| s.to_string());
+            let msg = v.get("message")?;
+            let model = msg.get("model").and_then(|m| m.as_str()).map(|s| s.to_string());
+            let usage = msg.get("usage");
+            let input_tokens = usage
+                .and_then(|u| u.get("input_tokens"))
+                .and_then(|t| t.as_u64());
+            let output_tokens = usage
+                .and_then(|u| u.get("output_tokens"))
+                .and_then(|t| t.as_u64());
+            Some((ts, model, None, None, None, None, input_tokens, output_tokens, "assistant".to_string()))
+        }
+        "queue-operation" => {
+            if v.get("operation").and_then(|o| o.as_str()) == Some("enqueue") {
+                let ts = v.get("timestamp").and_then(|t| t.as_str()).map(|s| s.to_string());
+                let content = v.get("content").and_then(|c| c.as_str()).map(|s| s.to_string());
+                Some((ts, None, None, None, None, content, None, None, "queue".to_string()))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Collect all active session IDs from ~/.claude/sessions/
+fn collect_active_sessions() -> std::collections::HashSet<String> {
+    let sessions_dir = claude_home().join("sessions");
+    let mut active = std::collections::HashSet::new();
+    if let Ok(entries) = std::fs::read_dir(&sessions_dir) {
+        for entry in entries.flatten() {
+            if let Ok(content) = std::fs::read_to_string(entry.path()) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                    if let Some(sid) = v.get("sessionId").and_then(|s| s.as_str()) {
+                        active.insert(sid.to_string());
+                    }
+                }
+            }
+        }
+    }
+    active
+}
+
+/// Scan all project directories and collect session JSONL metadata.
+fn scan_all_sessions(
+    active_set: &std::collections::HashSet<String>,
+) -> Vec<SessionInfo> {
+    let projects_dir = claude_home().join("projects");
+    let mut sessions = Vec::new();
+
+    if let Ok(project_entries) = std::fs::read_dir(&projects_dir) {
+        for project_entry in project_entries.flatten() {
+            let project_name = project_entry.file_name();
+            let project_name_str = project_name.to_string_lossy().to_string();
+
+            // Skip non-directory entries and known non-project dirs
+            if !project_entry.path().is_dir() {
+                continue;
+            }
+            if project_name_str.starts_with('.') || project_name_str == "memory" {
+                continue;
+            }
+
+            let project_path = decode_project_path(&project_name_str);
+
+            if let Ok(session_entries) = std::fs::read_dir(project_entry.path()) {
+                for session_entry in session_entries.flatten() {
+                    let path = session_entry.path();
+                    if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                        continue;
+                    }
+
+                    let session_id = path
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("")
+                        .to_string();
+
+                    let file_size = std::fs::metadata(&path)
+                        .map(|m| m.len())
+                        .unwrap_or(0);
+
+                    // Parse JSONL for metadata — read up to 2MB to get initial metadata
+                    let file_content = std::fs::read_to_string(&path).unwrap_or_default();
+
+                    let mut first_timestamp: Option<String> = None;
+                    let mut last_timestamp: Option<String> = None;
+                    let mut model: Option<String> = None;
+                    let mut git_branch: Option<String> = None;
+                    let mut version: Option<String> = None;
+                    let mut executor: Option<String> = None;
+                    let mut first_prompt: Option<String> = None;
+                    let mut message_count: u32 = 0;
+                    let mut total_input_tokens: u64 = 0;
+                    let mut total_output_tokens: u64 = 0;
+
+                    for line in file_content.lines() {
+                        if let Some((ts, mdl, branch, ver, entry, prompt, inp_tok, out_tok, role)) =
+                            parse_line_metadata(line)
+                        {
+                            if first_timestamp.is_none() {
+                                first_timestamp = ts.clone();
+                            }
+                            if ts.is_some() {
+                                last_timestamp = ts;
+                            }
+                            if mdl.is_some() {
+                                model = mdl;
+                            }
+                            if branch.is_some() {
+                                git_branch = branch;
+                            }
+                            if ver.is_some() {
+                                version = ver;
+                            }
+                            if entry.is_some() {
+                                executor = entry;
+                            }
+                            if first_prompt.is_none() && prompt.is_some() {
+                                first_prompt = prompt;
+                            }
+                            if role == "user" || role == "assistant" {
+                                message_count += 1;
+                            }
+                            if let Some(inp) = inp_tok {
+                                total_input_tokens += inp;
+                            }
+                            if let Some(out) = out_tok {
+                                total_output_tokens += out;
+                            }
+                        }
+                    }
+
+                    let status = if active_set.contains(&session_id) {
+                        "active"
+                    } else {
+                        "completed"
+                    };
+
+                    // Truncate first_prompt for display
+                    let display_prompt = first_prompt.map(|p| {
+                        if p.len() > 200 {
+                            truncate_str(&p, 200)
+                        } else {
+                            p
+                        }
+                    });
+
+                    sessions.push(SessionInfo {
+                        session_id,
+                        project_path: project_path.clone(),
+                        status: status.to_string(),
+                        executor: executor.unwrap_or_else(|| "unknown".to_string()),
+                        model: model.unwrap_or_else(|| "-".to_string()),
+                        git_branch,
+                        message_count,
+                        total_input_tokens,
+                        total_output_tokens,
+                        first_prompt: display_prompt,
+                        created_at: first_timestamp,
+                        last_active_at: last_timestamp,
+                        file_size,
+                        version,
+                        subagent_count: 0, // will be filled later if needed
+                    });
+                }
+            }
+        }
+    }
+
+    // Sort by last_active_at descending
+    sessions.sort_by(|a, b| {
+        b.last_active_at
+            .cmp(&a.last_active_at)
+    });
+
+    sessions
+}
+
+// ─── Handlers ─────────────────────────────────────────────
+
+pub async fn list_sessions(
+    State(_state): State<AppState>,
+    Query(query): Query<ListSessionsQuery>,
+) -> Result<ApiResponse<SessionListResponse>, AppError> {
+    let page = query.page.unwrap_or(1);
+    let page_size = query.page_size.unwrap_or(20);
+
+    let sessions = tokio::task::spawn_blocking(move || {
+        let active_set = collect_active_sessions();
+        let mut sessions = scan_all_sessions(&active_set);
+
+        // Apply filters
+        if let Some(ref status) = query.status {
+            sessions.retain(|s| &s.status == status);
+        }
+        if let Some(ref executor) = query.executor {
+            sessions.retain(|s| s.executor == *executor);
+        }
+        if let Some(ref project) = query.project {
+            sessions.retain(|s| s.project_path.contains(project));
+        }
+        if let Some(ref search) = query.search {
+            let search_lower = search.to_lowercase();
+            sessions.retain(|s| {
+                s.first_prompt
+                    .as_ref()
+                    .map(|p| p.to_lowercase().contains(&search_lower))
+                    .unwrap_or(false)
+            });
+        }
+
+        let total = sessions.len() as u64;
+        let start = ((page - 1) * page_size) as usize;
+        let end = (start + page_size as usize).min(sessions.len());
+        let page_data = if start < sessions.len() {
+            sessions[start..end].to_vec()
+        } else {
+            Vec::new()
+        };
+
+        SessionListResponse {
+            sessions: page_data,
+            total,
+            page,
+            page_size,
+        }
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(ApiResponse::ok(sessions))
+}
+
+pub async fn get_session_stats(
+    State(_state): State<AppState>,
+) -> Result<ApiResponse<SessionStats>, AppError> {
+    let stats = tokio::task::spawn_blocking(move || {
+        let active_set = collect_active_sessions();
+        let sessions = scan_all_sessions(&active_set);
+
+        let now = chrono::Utc::now();
+        let today_start = now.date_naive().and_hms_opt(0, 0, 0).unwrap();
+
+        let mut by_executor: HashMap<String, u64> = HashMap::new();
+        let mut by_project: HashMap<String, u64> = HashMap::new();
+        let mut active_count = 0u64;
+        let mut today_count = 0u64;
+        let mut total_input = 0u64;
+        let mut total_output = 0u64;
+
+        for s in &sessions {
+            *by_executor.entry(s.executor.clone()).or_insert(0) += 1;
+            *by_project.entry(s.project_path.clone()).or_insert(0) += 1;
+            total_input += s.total_input_tokens;
+            total_output += s.total_output_tokens;
+            if s.status == "active" {
+                active_count += 1;
+            }
+            if let Some(ref created) = s.created_at {
+                if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(created) {
+                    if dt.naive_utc() >= today_start {
+                        today_count += 1;
+                    }
+                }
+            }
+        }
+
+        SessionStats {
+            total_sessions: sessions.len() as u64,
+            active_sessions: active_count,
+            today_sessions: today_count,
+            total_input_tokens: total_input,
+            total_output_tokens: total_output,
+            by_executor,
+            by_project,
+        }
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(ApiResponse::ok(stats))
+}
+
+pub async fn get_session_detail(
+    State(_state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Result<ApiResponse<SessionDetail>, AppError> {
+    let detail = tokio::task::spawn_blocking(move || {
+        let projects_dir = claude_home().join("projects");
+
+        // Find the JSONL file for this session_id across all projects
+        let mut jsonl_path: Option<PathBuf> = None;
+        let mut project_path = String::new();
+
+        if let Ok(project_entries) = std::fs::read_dir(&projects_dir) {
+            for project_entry in project_entries.flatten() {
+                let candidate = project_entry.path().join(format!("{}.jsonl", session_id));
+                if candidate.exists() {
+                    jsonl_path = Some(candidate);
+                    let name = project_entry.file_name().to_string_lossy().to_string();
+                    project_path = decode_project_path(&name);
+                    break;
+                }
+            }
+        }
+
+        let jsonl_path = match jsonl_path {
+            Some(p) => p,
+            None => return None,
+        };
+
+        let active_set = collect_active_sessions();
+        let file_content = std::fs::read_to_string(&jsonl_path).ok()?;
+        let file_size = std::fs::metadata(&jsonl_path).map(|m| m.len()).unwrap_or(0);
+
+        let mut first_timestamp: Option<String> = None;
+        let mut last_timestamp: Option<String> = None;
+        let mut model: Option<String> = None;
+        let mut git_branch: Option<String> = None;
+        let mut version: Option<String> = None;
+        let mut executor: Option<String> = None;
+        let mut first_prompt: Option<String> = None;
+        let mut message_count: u32 = 0;
+        let mut total_input_tokens: u64 = 0;
+        let mut total_output_tokens: u64 = 0;
+        let mut messages: Vec<SessionMessage> = Vec::new();
+
+        for line in file_content.lines() {
+            if let Some((ts, mdl, branch, ver, entry, prompt, inp_tok, out_tok, role)) =
+                parse_line_metadata(line)
+            {
+                if first_timestamp.is_none() {
+                    first_timestamp = ts.clone();
+                }
+                if ts.is_some() {
+                    last_timestamp = ts.clone();
+                }
+                if mdl.is_some() {
+                    model = mdl.clone();
+                }
+                if branch.is_some() {
+                    git_branch = branch;
+                }
+                if ver.is_some() {
+                    version = ver;
+                }
+                if entry.is_some() {
+                    executor = entry;
+                }
+                if first_prompt.is_none() && prompt.is_some() {
+                    first_prompt = prompt.clone();
+                }
+                if role == "user" || role == "assistant" {
+                    message_count += 1;
+
+                    let content_preview = match &prompt {
+                        Some(p) => {
+                            if p.len() > 500 {
+                                truncate_str(&p, 500)
+                            } else {
+                                p.clone()
+                            }
+                        }
+                        None => String::new(),
+                    };
+
+                    messages.push(SessionMessage {
+                        role: role.clone(),
+                        content_preview,
+                        model: mdl.clone(),
+                        input_tokens: inp_tok,
+                        output_tokens: out_tok,
+                        timestamp: ts,
+                        stop_reason: None,
+                    });
+                }
+                if let Some(inp) = inp_tok {
+                    total_input_tokens += inp;
+                }
+                if let Some(out) = out_tok {
+                    total_output_tokens += out;
+                }
+            }
+        }
+
+        let status = if active_set.contains(&session_id) {
+            "active"
+        } else {
+            "completed"
+        };
+
+        // Check for subagents
+        let session_dir = jsonl_path.with_extension("");
+        let subagents_dir = session_dir.join("subagents");
+        let mut subagents: Vec<SubAgentInfo> = Vec::new();
+
+        if subagents_dir.exists() {
+            if let Ok(entries) = std::fs::read_dir(&subagents_dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().and_then(|e| e.to_str()) == Some("json") {
+                        if let Some(name) = path.file_stem().and_then(|n| n.to_str()) {
+                            if name.ends_with(".meta") {
+                                if let Ok(content) = std::fs::read_to_string(&path) {
+                                    if let Ok(meta) =
+                                        serde_json::from_str::<serde_json::Value>(&content)
+                                    {
+                                        subagents.push(SubAgentInfo {
+                                            agent_type: meta
+                                                .get("agentType")
+                                                .and_then(|t| t.as_str())
+                                                .unwrap_or("unknown")
+                                                .to_string(),
+                                            description: meta
+                                                .get("description")
+                                                .and_then(|d| d.as_str())
+                                                .unwrap_or("")
+                                                .to_string(),
+                                            message_count: 0,
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let display_prompt = first_prompt.map(|p| {
+            if p.len() > 200 {
+                format!("{}...", &p[..200])
+            } else {
+                p
+            }
+        });
+
+        let info = SessionInfo {
+            session_id,
+            project_path,
+            status: status.to_string(),
+            executor: executor.unwrap_or_else(|| "unknown".to_string()),
+            model: model.unwrap_or_else(|| "-".to_string()),
+            git_branch,
+            message_count,
+            total_input_tokens,
+            total_output_tokens,
+            first_prompt: display_prompt,
+            created_at: first_timestamp,
+            last_active_at: last_timestamp,
+            file_size,
+            version,
+            subagent_count: subagents.len() as u32,
+        };
+
+        Some(SessionDetail {
+            info,
+            messages,
+            subagents,
+        })
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    match detail {
+        Some(d) => Ok(ApiResponse::ok(d)),
+        None => Err(AppError::NotFound),
+    }
+}
+
+pub async fn delete_session(
+    State(_state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Result<ApiResponse<()>, AppError> {
+    tokio::task::spawn_blocking(move || {
+        let projects_dir = claude_home().join("projects");
+
+        if let Ok(project_entries) = std::fs::read_dir(&projects_dir) {
+            for project_entry in project_entries.flatten() {
+                let jsonl_path = project_entry.path().join(format!("{}.jsonl", session_id));
+                if jsonl_path.exists() {
+                    // Delete JSONL file
+                    let _ = std::fs::remove_file(&jsonl_path);
+                    // Delete session directory (subagents, tool-results) if exists
+                    let session_dir = jsonl_path.with_extension("");
+                    if session_dir.is_dir() {
+                        let _ = std::fs::remove_dir_all(&session_dir);
+                    }
+                    // Delete session-env directory
+                    let env_dir = claude_home().join("session-env").join(&session_id);
+                    if env_dir.is_dir() {
+                        let _ = std::fs::remove_dir_all(&env_dir);
+                    }
+                    return true;
+                }
+            }
+        }
+        false
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(ApiResponse::ok(()))
+}

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -15,6 +15,7 @@ pub struct ListSessionsQuery {
     pub page: Option<u64>,
     pub page_size: Option<u64>,
     pub status: Option<String>,    // "active" | "completed"
+    pub source: Option<String>,    // filter by tool source: "claude-code", "codex", "hermes", etc.
     pub executor: Option<String>,  // filter by entrypoint
     pub project: Option<String>,   // filter by project path (partial match)
     pub search: Option<String>,    // search in first prompt
@@ -23,6 +24,7 @@ pub struct ListSessionsQuery {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionInfo {
     pub session_id: String,
+    pub source: String,            // "claude-code" | "codex" | "hermes" | "kimi" | "atomcode" | "cc-connect"
     pub project_path: String,
     pub status: String,
     pub executor: String,
@@ -54,6 +56,7 @@ pub struct SessionStats {
     pub today_sessions: u64,
     pub total_input_tokens: u64,
     pub total_output_tokens: u64,
+    pub by_source: HashMap<String, u64>,
     pub by_executor: HashMap<String, u64>,
     pub by_project: HashMap<String, u64>,
 }
@@ -85,21 +88,8 @@ pub struct SessionDetail {
 
 // ─── Helpers ──────────────────────────────────────────────
 
-fn claude_home() -> PathBuf {
-    dirs::home_dir()
-        .expect("no home directory")
-        .join(".claude")
-}
-
-/// Decode project path from encoded directory name.
-/// e.g. "-Users-weibh-projects-rust-aitodo" -> "/Users/weibh/projects/rust/aitodo"
-fn decode_project_path(encoded: &str) -> String {
-    let s = encoded.strip_prefix('-').unwrap_or(encoded);
-    // The encoding replaces '/' with '-'. We need to restore them.
-    // But path components like "/Users/weibh" also have separators.
-    // Strategy: split on '-', try to reconstruct valid path with '/'.
-    // Since home dir starts with /Users, we know the first segment is empty.
-    format!("/{}", s.replace('-', "/"))
+fn home_dir() -> PathBuf {
+    dirs::home_dir().expect("no home directory")
 }
 
 /// Truncate a string to at most `max_len` chars, appending "..." if truncated.
@@ -129,65 +119,52 @@ fn extract_text_content(value: &serde_json::Value) -> String {
     }
 }
 
-/// Parse a single JSONL line into session metadata contributions.
-fn parse_line_metadata(
+// ─── Claude Code Scanner ──────────────────────────────────
+
+fn decode_project_path(encoded: &str) -> String {
+    let s = encoded.strip_prefix('-').unwrap_or(encoded);
+    format!("/{}", s.replace('-', "/"))
+}
+
+fn parse_claude_line_metadata(
     line: &str,
 ) -> Option<(
-    Option<String>,    // timestamp
-    Option<String>,    // model
-    Option<String>,    // git_branch
-    Option<String>,    // version
-    Option<String>,    // executor / entrypoint
-    Option<String>,    // first prompt content
-    Option<u64>,       // input_tokens
-    Option<u64>,       // output_tokens
-    String,            // role
+    Option<String>, Option<String>, Option<String>, Option<String>,
+    Option<String>, Option<String>, Option<u64>, Option<u64>, String,
 )> {
     let v: serde_json::Value = serde_json::from_str(line).ok()?;
     let msg_type = v.get("type")?.as_str()?;
-
     match msg_type {
         "user" => {
-            let ts = v.get("timestamp").and_then(|t| t.as_str()).map(|s| s.to_string());
-            let branch = v.get("gitBranch").and_then(|b| b.as_str()).map(|s| s.to_string());
-            let ver = v.get("version").and_then(|v| v.as_str()).map(|s| s.to_string());
-            let entry = v.get("entrypoint").and_then(|e| e.as_str()).map(|s| s.to_string());
-            let content = v.get("message")
-                .and_then(|m| m.get("content"))
-                .map(|c| extract_text_content(c));
-            Some((ts, None, branch, ver, entry, content, None, None, "user".to_string()))
+            let ts = v.get("timestamp").and_then(|t| t.as_str()).map(String::from);
+            let branch = v.get("gitBranch").and_then(|b| b.as_str()).map(String::from);
+            let ver = v.get("version").and_then(|v| v.as_str()).map(String::from);
+            let entry = v.get("entrypoint").and_then(|e| e.as_str()).map(String::from);
+            let content = v.get("message").and_then(|m| m.get("content")).map(|c| extract_text_content(c));
+            Some((ts, None, branch, ver, entry, content, None, None, "user".into()))
         }
         "assistant" => {
-            let ts = v.get("timestamp").and_then(|t| t.as_str()).map(|s| s.to_string());
+            let ts = v.get("timestamp").and_then(|t| t.as_str()).map(String::from);
             let msg = v.get("message")?;
-            let model = msg.get("model").and_then(|m| m.as_str()).map(|s| s.to_string());
+            let model = msg.get("model").and_then(|m| m.as_str()).map(String::from);
             let usage = msg.get("usage");
-            let input_tokens = usage
-                .and_then(|u| u.get("input_tokens"))
-                .and_then(|t| t.as_u64());
-            let output_tokens = usage
-                .and_then(|u| u.get("output_tokens"))
-                .and_then(|t| t.as_u64());
-            Some((ts, model, None, None, None, None, input_tokens, output_tokens, "assistant".to_string()))
+            let input_tokens = usage.and_then(|u| u.get("input_tokens")).and_then(|t| t.as_u64());
+            let output_tokens = usage.and_then(|u| u.get("output_tokens")).and_then(|t| t.as_u64());
+            Some((ts, model, None, None, None, None, input_tokens, output_tokens, "assistant".into()))
         }
-        "queue-operation" => {
-            if v.get("operation").and_then(|o| o.as_str()) == Some("enqueue") {
-                let ts = v.get("timestamp").and_then(|t| t.as_str()).map(|s| s.to_string());
-                let content = v.get("content").and_then(|c| c.as_str()).map(|s| s.to_string());
-                Some((ts, None, None, None, None, content, None, None, "queue".to_string()))
-            } else {
-                None
-            }
+        "queue-operation" if v.get("operation").and_then(|o| o.as_str()) == Some("enqueue") => {
+            let ts = v.get("timestamp").and_then(|t| t.as_str()).map(String::from);
+            let content = v.get("content").and_then(|c| c.as_str()).map(String::from);
+            Some((ts, None, None, None, None, content, None, None, "queue".into()))
         }
         _ => None,
     }
 }
 
-/// Collect all active session IDs from ~/.claude/sessions/
-fn collect_active_sessions() -> std::collections::HashSet<String> {
-    let sessions_dir = claude_home().join("sessions");
+fn collect_claude_active_sessions() -> std::collections::HashSet<String> {
+    let dir = home_dir().join(".claude/sessions");
     let mut active = std::collections::HashSet::new();
-    if let Ok(entries) = std::fs::read_dir(&sessions_dir) {
+    if let Ok(entries) = std::fs::read_dir(&dir) {
         for entry in entries.flatten() {
             if let Ok(content) = std::fs::read_to_string(entry.path()) {
                 if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
@@ -201,139 +178,532 @@ fn collect_active_sessions() -> std::collections::HashSet<String> {
     active
 }
 
-/// Scan all project directories and collect session JSONL metadata.
-fn scan_all_sessions(
-    active_set: &std::collections::HashSet<String>,
-) -> Vec<SessionInfo> {
-    let projects_dir = claude_home().join("projects");
-    let mut sessions = Vec::new();
+fn scan_claude_code(sessions: &mut Vec<SessionInfo>) {
+    let active_set = collect_claude_active_sessions();
+    let projects_dir = home_dir().join(".claude/projects");
+    if !projects_dir.exists() { return; }
 
     if let Ok(project_entries) = std::fs::read_dir(&projects_dir) {
         for project_entry in project_entries.flatten() {
-            let project_name = project_entry.file_name();
-            let project_name_str = project_name.to_string_lossy().to_string();
-
-            // Skip non-directory entries and known non-project dirs
-            if !project_entry.path().is_dir() {
+            let project_name = project_entry.file_name().to_string_lossy().to_string();
+            if !project_entry.path().is_dir() || project_name.starts_with('.') || project_name == "memory" {
                 continue;
             }
-            if project_name_str.starts_with('.') || project_name_str == "memory" {
-                continue;
-            }
-
-            let project_path = decode_project_path(&project_name_str);
+            let project_path = decode_project_path(&project_name);
 
             if let Ok(session_entries) = std::fs::read_dir(project_entry.path()) {
                 for session_entry in session_entries.flatten() {
                     let path = session_entry.path();
-                    if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-                        continue;
-                    }
+                    if path.extension().and_then(|e| e.to_str()) != Some("jsonl") { continue; }
 
-                    let session_id = path
-                        .file_stem()
-                        .and_then(|s| s.to_str())
-                        .unwrap_or("")
-                        .to_string();
-
-                    let file_size = std::fs::metadata(&path)
-                        .map(|m| m.len())
-                        .unwrap_or(0);
-
-                    // Parse JSONL for metadata — read up to 2MB to get initial metadata
+                    let session_id = path.file_stem().and_then(|s| s.to_str()).unwrap_or("").to_string();
+                    let file_size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
                     let file_content = std::fs::read_to_string(&path).unwrap_or_default();
 
-                    let mut first_timestamp: Option<String> = None;
-                    let mut last_timestamp: Option<String> = None;
+                    let mut first_ts: Option<String> = None;
+                    let mut last_ts: Option<String> = None;
                     let mut model: Option<String> = None;
                     let mut git_branch: Option<String> = None;
                     let mut version: Option<String> = None;
                     let mut executor: Option<String> = None;
                     let mut first_prompt: Option<String> = None;
-                    let mut message_count: u32 = 0;
-                    let mut total_input_tokens: u64 = 0;
-                    let mut total_output_tokens: u64 = 0;
+                    let mut msg_count: u32 = 0;
+                    let mut total_in: u64 = 0;
+                    let mut total_out: u64 = 0;
 
                     for line in file_content.lines() {
-                        if let Some((ts, mdl, branch, ver, entry, prompt, inp_tok, out_tok, role)) =
-                            parse_line_metadata(line)
+                        if let Some((ts, mdl, branch, ver, entry, prompt, inp, out, role)) =
+                            parse_claude_line_metadata(line)
                         {
-                            if first_timestamp.is_none() {
-                                first_timestamp = ts.clone();
-                            }
-                            if ts.is_some() {
-                                last_timestamp = ts;
-                            }
-                            if mdl.is_some() {
-                                model = mdl;
-                            }
-                            if branch.is_some() {
-                                git_branch = branch;
-                            }
-                            if ver.is_some() {
-                                version = ver;
-                            }
-                            if entry.is_some() {
-                                executor = entry;
-                            }
-                            if first_prompt.is_none() && prompt.is_some() {
-                                first_prompt = prompt;
-                            }
-                            if role == "user" || role == "assistant" {
-                                message_count += 1;
-                            }
-                            if let Some(inp) = inp_tok {
-                                total_input_tokens += inp;
-                            }
-                            if let Some(out) = out_tok {
-                                total_output_tokens += out;
-                            }
+                            if first_ts.is_none() { first_ts = ts.clone(); }
+                            if ts.is_some() { last_ts = ts; }
+                            if mdl.is_some() { model = mdl; }
+                            if branch.is_some() { git_branch = branch; }
+                            if ver.is_some() { version = ver; }
+                            if entry.is_some() { executor = entry; }
+                            if first_prompt.is_none() && prompt.is_some() { first_prompt = prompt; }
+                            if role == "user" || role == "assistant" { msg_count += 1; }
+                            if let Some(i) = inp { total_in += i; }
+                            if let Some(o) = out { total_out += o; }
                         }
                     }
 
-                    let status = if active_set.contains(&session_id) {
-                        "active"
-                    } else {
-                        "completed"
-                    };
-
-                    // Truncate first_prompt for display
-                    let display_prompt = first_prompt.map(|p| {
-                        if p.len() > 200 {
-                            truncate_str(&p, 200)
-                        } else {
-                            p
-                        }
-                    });
-
                     sessions.push(SessionInfo {
-                        session_id,
+                        session_id: session_id.clone(),
+                        source: "claude-code".to_string(),
                         project_path: project_path.clone(),
-                        status: status.to_string(),
-                        executor: executor.unwrap_or_else(|| "unknown".to_string()),
-                        model: model.unwrap_or_else(|| "-".to_string()),
+                        status: if active_set.contains(&session_id) { "active".into() } else { "completed".into() },
+                        executor: executor.unwrap_or_else(|| "unknown".into()),
+                        model: model.unwrap_or_else(|| "-".into()),
                         git_branch,
-                        message_count,
-                        total_input_tokens,
-                        total_output_tokens,
-                        first_prompt: display_prompt,
-                        created_at: first_timestamp,
-                        last_active_at: last_timestamp,
+                        message_count: msg_count,
+                        total_input_tokens: total_in,
+                        total_output_tokens: total_out,
+                        first_prompt: first_prompt.map(|p| truncate_str(&p, 200)),
+                        created_at: first_ts,
+                        last_active_at: last_ts,
                         file_size,
                         version,
-                        subagent_count: 0, // will be filled later if needed
+                        subagent_count: 0,
                     });
                 }
             }
         }
     }
+}
+
+// ─── Codex CLI Scanner ────────────────────────────────────
+
+fn scan_codex(sessions: &mut Vec<SessionInfo>) {
+    let base = home_dir().join(".codex/sessions");
+    if !base.exists() { return; }
+
+    // Walk date-organized directories: sessions/YYYY/MM/DD/rollout-*.jsonl
+    if let Ok(years) = std::fs::read_dir(&base) {
+        for year_entry in years.flatten() {
+            if !year_entry.path().is_dir() { continue; }
+            if let Ok(months) = std::fs::read_dir(year_entry.path()) {
+                for month_entry in months.flatten() {
+                    if !month_entry.path().is_dir() { continue; }
+                    if let Ok(days) = std::fs::read_dir(month_entry.path()) {
+                        for day_entry in days.flatten() {
+                            let day_path = day_entry.path();
+                            if !day_path.is_dir() { continue; }
+                            // Iterate files inside the day directory
+                            if let Ok(files) = std::fs::read_dir(&day_path) {
+                                for file_entry in files.flatten() {
+                                    let path = file_entry.path();
+                                    if !path.is_file() { continue; }
+                                    let name = file_entry.file_name().to_string_lossy().to_string();
+                                    if !name.starts_with("rollout-") || !name.ends_with(".jsonl") { continue; }
+
+                            let file_size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+                            let content = match std::fs::read_to_string(&path) {
+                                Ok(c) => c,
+                                Err(_) => continue,
+                            };
+
+                            let mut session_id = String::new();
+                            let mut project_path = String::new();
+                            let mut version = String::new();
+                            let mut model = String::new();
+                            let mut first_ts: Option<String> = None;
+                            let mut last_ts: Option<String> = None;
+                            let mut first_prompt: Option<String> = None;
+                            let mut msg_count: u32 = 0;
+
+                            for line in content.lines() {
+                                if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+                                    let ts = v.get("timestamp").and_then(|t| t.as_str()).map(String::from);
+                                    let line_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+                                    match line_type {
+                                        "session_meta" => {
+                                            if let Some(payload) = v.get("payload") {
+                                                session_id = payload.get("id").and_then(|i| i.as_str()).unwrap_or("").to_string();
+                                                project_path = payload.get("cwd").and_then(|c| c.as_str()).unwrap_or("").to_string();
+                                                version = payload.get("cli_version").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                                                model = payload.get("model_provider").and_then(|m| m.as_str()).unwrap_or("openai").to_string();
+                                            }
+                                            first_ts = ts.clone();
+                                        }
+                                        "event_msg" => {
+                                            if let Some(payload) = v.get("payload") {
+                                                let event_type = payload.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                                                if event_type == "message" {
+                                                    let role = payload.get("message").and_then(|m| m.get("role")).and_then(|r| r.as_str()).unwrap_or("");
+                                                    if role == "user" {
+                                                        let text = payload.get("message")
+                                                            .and_then(|m| m.get("content"))
+                                                            .and_then(|c| c.as_str())
+                                                            .unwrap_or("");
+                                                        if first_prompt.is_none() && !text.is_empty() {
+                                                            first_prompt = Some(truncate_str(text, 200));
+                                                        }
+                                                    }
+                                                    msg_count += 1;
+                                                }
+                                            }
+                                        }
+                                        _ => {}
+                                    }
+                                    if ts.is_some() { last_ts = ts; }
+                                }
+                            }
+
+                            if session_id.is_empty() {
+                                session_id = name.trim_end_matches(".jsonl").to_string();
+                            }
+
+                            sessions.push(SessionInfo {
+                                session_id,
+                                source: "codex".to_string(),
+                                project_path,
+                                status: "completed".to_string(),
+                                executor: "codex".to_string(),
+                                model,
+                                git_branch: None,
+                                message_count: msg_count,
+                                total_input_tokens: 0,
+                                total_output_tokens: 0,
+                                first_prompt,
+                                created_at: first_ts,
+                                last_active_at: last_ts,
+                                file_size,
+                                version: if version.is_empty() { None } else { Some(version) },
+                                subagent_count: 0,
+                            });
+                            } // end for file_entry
+                            } // end if let Ok(files)
+                        } // end for day_entry
+                    } // end if let Ok(days)
+                } // end for month
+            } // end if let Ok(months)
+        } // end for year
+    } // end if let Ok(years)
+}
+
+// ─── Hermes Scanner ───────────────────────────────────────
+
+fn scan_hermes(sessions: &mut Vec<SessionInfo>) {
+    let dir = home_dir().join(".hermes/sessions");
+    if !dir.exists() { return; }
+
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") { continue; }
+
+            let name = entry.file_name().to_string_lossy().to_string();
+            let file_size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            let mut first_ts: Option<String> = None;
+            let mut last_ts: Option<String> = None;
+            let mut model: Option<String> = None;
+            let mut first_prompt: Option<String> = None;
+            let mut msg_count: u32 = 0;
+            let mut project_path = String::new();
+
+            for line in content.lines() {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+                    let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("");
+
+                    if role == "session_meta" {
+                        first_ts = v.get("timestamp").and_then(|t| t.as_str()).map(String::from);
+                    } else if role == "user" {
+                        msg_count += 1;
+                        let text = v.get("content")
+                            .and_then(|c| c.as_str())
+                            .unwrap_or("");
+                        if first_prompt.is_none() && !text.is_empty() {
+                            first_prompt = Some(truncate_str(text, 200));
+                        }
+                        // Try to get cwd from tool calls or context
+                        if project_path.is_empty() {
+                            if let Some(tool_calls) = v.get("tool_calls") {
+                                for tc in tool_calls.as_array().unwrap_or(&vec![]) {
+                                    if let Some(inp) = tc.get("function").and_then(|f| f.get("arguments")) {
+                                        if let Some(cwd) = inp.get("cwd").and_then(|c| c.as_str()) {
+                                            project_path = cwd.to_string();
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } else if role == "assistant" {
+                        msg_count += 1;
+                        if model.is_none() {
+                            model = v.get("model").and_then(|m| m.as_str()).map(String::from);
+                        }
+                    }
+
+                    if let Some(ts) = v.get("timestamp").and_then(|t| t.as_str()) {
+                        last_ts = Some(ts.to_string());
+                    }
+                }
+            }
+
+            let session_id = name.trim_end_matches(".jsonl").to_string();
+
+            sessions.push(SessionInfo {
+                session_id,
+                source: "hermes".to_string(),
+                project_path,
+                status: "completed".to_string(),
+                executor: "hermes".to_string(),
+                model: model.unwrap_or_else(|| "-".into()),
+                git_branch: None,
+                message_count: msg_count,
+                total_input_tokens: 0,
+                total_output_tokens: 0,
+                first_prompt,
+                created_at: first_ts,
+                last_active_at: last_ts,
+                file_size,
+                version: None,
+                subagent_count: 0,
+            });
+        }
+    }
+}
+
+// ─── Kimi Code Scanner ────────────────────────────────────
+
+fn scan_kimi(sessions: &mut Vec<SessionInfo>) {
+    let base = home_dir().join(".kimi/sessions");
+    if !base.exists() { return; }
+
+    // sessions/<project-hash>/<session-uuid>/context.jsonl
+    if let Ok(project_dirs) = std::fs::read_dir(&base) {
+        for project_dir in project_dirs.flatten() {
+            if !project_dir.path().is_dir() { continue; }
+            let project_hash = project_dir.file_name().to_string_lossy().to_string();
+
+            if let Ok(session_dirs) = std::fs::read_dir(project_dir.path()) {
+                for session_dir in session_dirs.flatten() {
+                    if !session_dir.path().is_dir() { continue; }
+                    let sid = session_dir.file_name().to_string_lossy().to_string();
+
+                    let context_path = session_dir.path().join("context.jsonl");
+                    let state_path = session_dir.path().join("state.json");
+
+                    if !context_path.exists() { continue; }
+
+                    // Get total file size of session directory
+                    let file_size = std::fs::metadata(&context_path).map(|m| m.len()).unwrap_or(0);
+                    let content = match std::fs::read_to_string(&context_path) {
+                        Ok(c) => c,
+                        Err(_) => continue,
+                    };
+
+                    // Parse state.json for title
+                    let state: Option<serde_json::Value> = std::fs::read_to_string(&state_path)
+                        .ok()
+                        .and_then(|s| serde_json::from_str(&s).ok());
+                    let title = state.as_ref()
+                        .and_then(|s| s.get("custom_title"))
+                        .and_then(|t| t.as_str())
+                        .map(String::from);
+
+                    let mut first_ts: Option<String> = None;
+                    let mut last_ts: Option<String> = None;
+                    let mut model: Option<String> = None;
+                    let mut first_prompt: Option<String> = None;
+                    let mut msg_count: u32 = 0;
+
+                    for line in content.lines() {
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+                            let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("");
+
+                            if role == "user" {
+                                msg_count += 1;
+                                let text = v.get("content").and_then(|c| c.as_str()).unwrap_or("");
+                                if first_prompt.is_none() && !text.is_empty() {
+                                    first_prompt = Some(truncate_str(text, 200));
+                                }
+                            } else if role == "assistant" {
+                                msg_count += 1;
+                                if model.is_none() {
+                                    model = v.get("model").and_then(|m| m.as_str()).map(String::from);
+                                }
+                            }
+
+                            if let Some(ts) = v.get("timestamp").and_then(|t| t.as_str()) {
+                                if first_ts.is_none() { first_ts = Some(ts.to_string()); }
+                                last_ts = Some(ts.to_string());
+                            }
+                        }
+                    }
+
+                    sessions.push(SessionInfo {
+                        session_id: sid,
+                        source: "kimi".to_string(),
+                        project_path: project_hash.clone(),
+                        status: "completed".to_string(),
+                        executor: "kimi".to_string(),
+                        model: model.unwrap_or_else(|| "-".into()),
+                        git_branch: None,
+                        message_count: msg_count,
+                        total_input_tokens: 0,
+                        total_output_tokens: 0,
+                        first_prompt: first_prompt.or(title),
+                        created_at: first_ts,
+                        last_active_at: last_ts,
+                        file_size,
+                        version: None,
+                        subagent_count: 0,
+                    });
+                }
+            }
+        }
+    }
+}
+
+// ─── AtomCode Scanner ─────────────────────────────────────
+
+fn scan_atomcode(sessions: &mut Vec<SessionInfo>) {
+    let base = home_dir().join(".atomcode/sessions");
+    if !base.exists() { return; }
+
+    // sessions/<project-hash>/<session-uuid>.json
+    if let Ok(project_dirs) = std::fs::read_dir(&base) {
+        for project_dir in project_dirs.flatten() {
+            if !project_dir.path().is_dir() { continue; }
+
+            if let Ok(files) = std::fs::read_dir(project_dir.path()) {
+                for file in files.flatten() {
+                    let path = file.path();
+                    if path.extension().and_then(|e| e.to_str()) != Some("json") { continue; }
+
+                    let content = match std::fs::read_to_string(&path) {
+                        Ok(c) => c,
+                        Err(_) => continue,
+                    };
+                    let v: serde_json::Value = match serde_json::from_str(&content) {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+
+                    let session_id = v.get("id").and_then(|i| i.as_str()).unwrap_or("").to_string();
+                    let working_dir = v.get("working_dir").and_then(|w| w.as_str()).unwrap_or("").to_string();
+                    let created_at = v.get("created_at").and_then(|t| t.as_u64());
+                    let file_size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+
+                    let messages = v.get("messages").and_then(|m| m.as_array());
+                    let msg_count = messages.map(|m| m.len()).unwrap_or(0) as u32;
+                    let first_prompt = messages.and_then(|msgs| {
+                        msgs.first().and_then(|m| m.get("content").and_then(|c| c.get("Text")).and_then(|t| t.as_str()))
+                            .map(|t| truncate_str(t, 200))
+                    });
+
+                    let created_str = created_at.map(|ts| {
+                        chrono::DateTime::from_timestamp(ts as i64, 0)
+                            .map(|dt| dt.to_rfc3339())
+                            .unwrap_or_default()
+                    });
+
+                    sessions.push(SessionInfo {
+                        session_id: if session_id.is_empty() { path.file_stem().unwrap_or_default().to_string_lossy().to_string() } else { session_id },
+                        source: "atomcode".to_string(),
+                        project_path: working_dir,
+                        status: "completed".to_string(),
+                        executor: "atomcode".to_string(),
+                        model: "-".to_string(),
+                        git_branch: None,
+                        message_count: msg_count,
+                        total_input_tokens: 0,
+                        total_output_tokens: 0,
+                        first_prompt,
+                        created_at: created_str.clone(),
+                        last_active_at: created_str,
+                        file_size,
+                        version: None,
+                        subagent_count: 0,
+                    });
+                }
+            }
+        }
+    }
+}
+
+// ─── CC-Connect Scanner ───────────────────────────────────
+
+fn scan_ccconnect(sessions: &mut Vec<SessionInfo>) {
+    let dir = home_dir().join(".cc-connect/sessions");
+    if !dir.exists() { return; }
+
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") { continue; }
+
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let v: serde_json::Value = match serde_json::from_str(&content) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            let file_name = path.file_stem().unwrap_or_default().to_string_lossy().to_string();
+            let file_size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+
+            let sess_map = v.get("sessions").and_then(|s| s.as_object());
+            if let Some(sess_map) = sess_map {
+                for (sess_key, sess_val) in sess_map {
+                    let history = sess_val.get("history").and_then(|h| h.as_array());
+                    let msg_count = history.map(|h| h.len()).unwrap_or(0) as u32;
+
+                    let first_prompt = history.and_then(|h| {
+                        h.first()
+                            .and_then(|m| m.get("content"))
+                            .and_then(|c| c.as_str())
+                            .map(|t| truncate_str(t, 200))
+                    });
+
+                    let first_ts = history.and_then(|h| {
+                        h.first().and_then(|m| m.get("timestamp")).and_then(|t| t.as_f64())
+                    });
+                    let last_ts = history.and_then(|h| {
+                        h.last().and_then(|m| m.get("timestamp")).and_then(|t| t.as_f64())
+                    });
+
+                    let created_at = first_ts.map(|ts| {
+                        chrono::DateTime::from_timestamp(ts as i64, 0)
+                            .map(|dt| dt.to_rfc3339())
+                            .unwrap_or_default()
+                    });
+                    let last_active_at = last_ts.map(|ts| {
+                        chrono::DateTime::from_timestamp(ts as i64, 0)
+                            .map(|dt| dt.to_rfc3339())
+                            .unwrap_or_default()
+                    });
+
+                    // Determine project from file name (e.g. "aitodo_3c4bc799")
+                    let project_name = file_name.split('_').next().unwrap_or(&file_name).to_string();
+
+                    sessions.push(SessionInfo {
+                        session_id: format!("cc-connect-{}-{}", file_name, sess_key),
+                        source: "cc-connect".to_string(),
+                        project_path: project_name,
+                        status: "completed".to_string(),
+                        executor: "cc-connect".to_string(),
+                        model: "-".to_string(),
+                        git_branch: None,
+                        message_count: msg_count,
+                        total_input_tokens: 0,
+                        total_output_tokens: 0,
+                        first_prompt,
+                        created_at,
+                        last_active_at,
+                        file_size: file_size / (sess_map.len().max(1) as u64),
+                        version: None,
+                        subagent_count: 0,
+                    });
+                }
+            }
+        }
+    }
+}
+
+// ─── Unified scan ─────────────────────────────────────────
+
+fn scan_all_sources() -> Vec<SessionInfo> {
+    let mut sessions = Vec::new();
+    scan_claude_code(&mut sessions);
+    scan_codex(&mut sessions);
+    scan_hermes(&mut sessions);
+    scan_kimi(&mut sessions);
+    scan_atomcode(&mut sessions);
+    scan_ccconnect(&mut sessions);
 
     // Sort by last_active_at descending
-    sessions.sort_by(|a, b| {
-        b.last_active_at
-            .cmp(&a.last_active_at)
-    });
-
+    sessions.sort_by(|a, b| b.last_active_at.cmp(&a.last_active_at));
     sessions
 }
 
@@ -346,13 +716,15 @@ pub async fn list_sessions(
     let page = query.page.unwrap_or(1);
     let page_size = query.page_size.unwrap_or(20);
 
-    let sessions = tokio::task::spawn_blocking(move || {
-        let active_set = collect_active_sessions();
-        let mut sessions = scan_all_sessions(&active_set);
+    let result = tokio::task::spawn_blocking(move || {
+        let mut sessions = scan_all_sources();
 
         // Apply filters
         if let Some(ref status) = query.status {
             sessions.retain(|s| &s.status == status);
+        }
+        if let Some(ref source) = query.source {
+            sessions.retain(|s| s.source == *source);
         }
         if let Some(ref executor) = query.executor {
             sessions.retain(|s| s.executor == *executor);
@@ -363,8 +735,7 @@ pub async fn list_sessions(
         if let Some(ref search) = query.search {
             let search_lower = search.to_lowercase();
             sessions.retain(|s| {
-                s.first_prompt
-                    .as_ref()
+                s.first_prompt.as_ref()
                     .map(|p| p.to_lowercase().contains(&search_lower))
                     .unwrap_or(false)
             });
@@ -379,49 +750,40 @@ pub async fn list_sessions(
             Vec::new()
         };
 
-        SessionListResponse {
-            sessions: page_data,
-            total,
-            page,
-            page_size,
-        }
+        SessionListResponse { sessions: page_data, total, page, page_size }
     })
     .await
     .map_err(|e| AppError::Internal(e.to_string()))?;
 
-    Ok(ApiResponse::ok(sessions))
+    Ok(ApiResponse::ok(result))
 }
 
 pub async fn get_session_stats(
     State(_state): State<AppState>,
 ) -> Result<ApiResponse<SessionStats>, AppError> {
     let stats = tokio::task::spawn_blocking(move || {
-        let active_set = collect_active_sessions();
-        let sessions = scan_all_sessions(&active_set);
-
+        let sessions = scan_all_sources();
         let now = chrono::Utc::now();
         let today_start = now.date_naive().and_hms_opt(0, 0, 0).unwrap();
 
+        let mut by_source: HashMap<String, u64> = HashMap::new();
         let mut by_executor: HashMap<String, u64> = HashMap::new();
         let mut by_project: HashMap<String, u64> = HashMap::new();
         let mut active_count = 0u64;
         let mut today_count = 0u64;
-        let mut total_input = 0u64;
-        let mut total_output = 0u64;
+        let mut total_in = 0u64;
+        let mut total_out = 0u64;
 
         for s in &sessions {
+            *by_source.entry(s.source.clone()).or_insert(0) += 1;
             *by_executor.entry(s.executor.clone()).or_insert(0) += 1;
             *by_project.entry(s.project_path.clone()).or_insert(0) += 1;
-            total_input += s.total_input_tokens;
-            total_output += s.total_output_tokens;
-            if s.status == "active" {
-                active_count += 1;
-            }
+            total_in += s.total_input_tokens;
+            total_out += s.total_output_tokens;
+            if s.status == "active" { active_count += 1; }
             if let Some(ref created) = s.created_at {
                 if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(created) {
-                    if dt.naive_utc() >= today_start {
-                        today_count += 1;
-                    }
+                    if dt.naive_utc() >= today_start { today_count += 1; }
                 }
             }
         }
@@ -430,8 +792,9 @@ pub async fn get_session_stats(
             total_sessions: sessions.len() as u64,
             active_sessions: active_count,
             today_sessions: today_count,
-            total_input_tokens: total_input,
-            total_output_tokens: total_output,
+            total_input_tokens: total_in,
+            total_output_tokens: total_out,
+            by_source,
             by_executor,
             by_project,
         }
@@ -447,178 +810,22 @@ pub async fn get_session_detail(
     Path(session_id): Path<String>,
 ) -> Result<ApiResponse<SessionDetail>, AppError> {
     let detail = tokio::task::spawn_blocking(move || {
-        let projects_dir = claude_home().join("projects");
+        // Try each source to find the session
 
-        // Find the JSONL file for this session_id across all projects
-        let mut jsonl_path: Option<PathBuf> = None;
-        let mut project_path = String::new();
+        // Claude Code
+        if let Some(d) = get_claude_detail(&session_id) { return Some(d); }
+        // Codex
+        if let Some(d) = get_codex_detail(&session_id) { return Some(d); }
+        // Hermes
+        if let Some(d) = get_hermes_detail(&session_id) { return Some(d); }
+        // Kimi
+        if let Some(d) = get_kimi_detail(&session_id) { return Some(d); }
+        // AtomCode
+        if let Some(d) = get_atomcode_detail(&session_id) { return Some(d); }
+        // CC-Connect
+        if let Some(d) = get_ccconnect_detail(&session_id) { return Some(d); }
 
-        if let Ok(project_entries) = std::fs::read_dir(&projects_dir) {
-            for project_entry in project_entries.flatten() {
-                let candidate = project_entry.path().join(format!("{}.jsonl", session_id));
-                if candidate.exists() {
-                    jsonl_path = Some(candidate);
-                    let name = project_entry.file_name().to_string_lossy().to_string();
-                    project_path = decode_project_path(&name);
-                    break;
-                }
-            }
-        }
-
-        let jsonl_path = match jsonl_path {
-            Some(p) => p,
-            None => return None,
-        };
-
-        let active_set = collect_active_sessions();
-        let file_content = std::fs::read_to_string(&jsonl_path).ok()?;
-        let file_size = std::fs::metadata(&jsonl_path).map(|m| m.len()).unwrap_or(0);
-
-        let mut first_timestamp: Option<String> = None;
-        let mut last_timestamp: Option<String> = None;
-        let mut model: Option<String> = None;
-        let mut git_branch: Option<String> = None;
-        let mut version: Option<String> = None;
-        let mut executor: Option<String> = None;
-        let mut first_prompt: Option<String> = None;
-        let mut message_count: u32 = 0;
-        let mut total_input_tokens: u64 = 0;
-        let mut total_output_tokens: u64 = 0;
-        let mut messages: Vec<SessionMessage> = Vec::new();
-
-        for line in file_content.lines() {
-            if let Some((ts, mdl, branch, ver, entry, prompt, inp_tok, out_tok, role)) =
-                parse_line_metadata(line)
-            {
-                if first_timestamp.is_none() {
-                    first_timestamp = ts.clone();
-                }
-                if ts.is_some() {
-                    last_timestamp = ts.clone();
-                }
-                if mdl.is_some() {
-                    model = mdl.clone();
-                }
-                if branch.is_some() {
-                    git_branch = branch;
-                }
-                if ver.is_some() {
-                    version = ver;
-                }
-                if entry.is_some() {
-                    executor = entry;
-                }
-                if first_prompt.is_none() && prompt.is_some() {
-                    first_prompt = prompt.clone();
-                }
-                if role == "user" || role == "assistant" {
-                    message_count += 1;
-
-                    let content_preview = match &prompt {
-                        Some(p) => {
-                            if p.len() > 500 {
-                                truncate_str(&p, 500)
-                            } else {
-                                p.clone()
-                            }
-                        }
-                        None => String::new(),
-                    };
-
-                    messages.push(SessionMessage {
-                        role: role.clone(),
-                        content_preview,
-                        model: mdl.clone(),
-                        input_tokens: inp_tok,
-                        output_tokens: out_tok,
-                        timestamp: ts,
-                        stop_reason: None,
-                    });
-                }
-                if let Some(inp) = inp_tok {
-                    total_input_tokens += inp;
-                }
-                if let Some(out) = out_tok {
-                    total_output_tokens += out;
-                }
-            }
-        }
-
-        let status = if active_set.contains(&session_id) {
-            "active"
-        } else {
-            "completed"
-        };
-
-        // Check for subagents
-        let session_dir = jsonl_path.with_extension("");
-        let subagents_dir = session_dir.join("subagents");
-        let mut subagents: Vec<SubAgentInfo> = Vec::new();
-
-        if subagents_dir.exists() {
-            if let Ok(entries) = std::fs::read_dir(&subagents_dir) {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    if path.extension().and_then(|e| e.to_str()) == Some("json") {
-                        if let Some(name) = path.file_stem().and_then(|n| n.to_str()) {
-                            if name.ends_with(".meta") {
-                                if let Ok(content) = std::fs::read_to_string(&path) {
-                                    if let Ok(meta) =
-                                        serde_json::from_str::<serde_json::Value>(&content)
-                                    {
-                                        subagents.push(SubAgentInfo {
-                                            agent_type: meta
-                                                .get("agentType")
-                                                .and_then(|t| t.as_str())
-                                                .unwrap_or("unknown")
-                                                .to_string(),
-                                            description: meta
-                                                .get("description")
-                                                .and_then(|d| d.as_str())
-                                                .unwrap_or("")
-                                                .to_string(),
-                                            message_count: 0,
-                                        });
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        let display_prompt = first_prompt.map(|p| {
-            if p.len() > 200 {
-                format!("{}...", &p[..200])
-            } else {
-                p
-            }
-        });
-
-        let info = SessionInfo {
-            session_id,
-            project_path,
-            status: status.to_string(),
-            executor: executor.unwrap_or_else(|| "unknown".to_string()),
-            model: model.unwrap_or_else(|| "-".to_string()),
-            git_branch,
-            message_count,
-            total_input_tokens,
-            total_output_tokens,
-            first_prompt: display_prompt,
-            created_at: first_timestamp,
-            last_active_at: last_timestamp,
-            file_size,
-            version,
-            subagent_count: subagents.len() as u32,
-        };
-
-        Some(SessionDetail {
-            info,
-            messages,
-            subagents,
-        })
+        None
     })
     .await
     .map_err(|e| AppError::Internal(e.to_string()))?;
@@ -634,24 +841,15 @@ pub async fn delete_session(
     Path(session_id): Path<String>,
 ) -> Result<ApiResponse<()>, AppError> {
     tokio::task::spawn_blocking(move || {
-        let projects_dir = claude_home().join("projects");
-
-        if let Ok(project_entries) = std::fs::read_dir(&projects_dir) {
-            for project_entry in project_entries.flatten() {
-                let jsonl_path = project_entry.path().join(format!("{}.jsonl", session_id));
-                if jsonl_path.exists() {
-                    // Delete JSONL file
-                    let _ = std::fs::remove_file(&jsonl_path);
-                    // Delete session directory (subagents, tool-results) if exists
-                    let session_dir = jsonl_path.with_extension("");
-                    if session_dir.is_dir() {
-                        let _ = std::fs::remove_dir_all(&session_dir);
-                    }
-                    // Delete session-env directory
-                    let env_dir = claude_home().join("session-env").join(&session_id);
-                    if env_dir.is_dir() {
-                        let _ = std::fs::remove_dir_all(&env_dir);
-                    }
+        // Try to delete from each source
+        let claude_dir = home_dir().join(".claude/projects");
+        if let Ok(entries) = std::fs::read_dir(&claude_dir) {
+            for entry in entries.flatten() {
+                let jsonl = entry.path().join(format!("{}.jsonl", session_id));
+                if jsonl.exists() {
+                    let _ = std::fs::remove_file(&jsonl);
+                    let dir = jsonl.with_extension("");
+                    if dir.is_dir() { let _ = std::fs::remove_dir_all(&dir); }
                     return true;
                 }
             }
@@ -662,4 +860,543 @@ pub async fn delete_session(
     .map_err(|e| AppError::Internal(e.to_string()))?;
 
     Ok(ApiResponse::ok(()))
+}
+
+// ─── Detail getters per source ────────────────────────────
+
+fn get_claude_detail(session_id: &str) -> Option<SessionDetail> {
+    let projects_dir = home_dir().join(".claude/projects");
+    let mut jsonl_path: Option<PathBuf> = None;
+    let mut project_path = String::new();
+
+    if let Ok(entries) = std::fs::read_dir(&projects_dir) {
+        for entry in entries.flatten() {
+            let candidate = entry.path().join(format!("{}.jsonl", session_id));
+            if candidate.exists() {
+                jsonl_path = Some(candidate);
+                project_path = decode_project_path(&entry.file_name().to_string_lossy());
+                break;
+            }
+        }
+    }
+    let path = jsonl_path?;
+    let content = std::fs::read_to_string(&path).ok()?;
+    let file_size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+    let active_set = collect_claude_active_sessions();
+
+    let mut first_ts: Option<String> = None;
+    let mut last_ts: Option<String> = None;
+    let mut model: Option<String> = None;
+    let mut git_branch: Option<String> = None;
+    let mut version: Option<String> = None;
+    let mut executor: Option<String> = None;
+    let mut first_prompt: Option<String> = None;
+    let mut msg_count: u32 = 0;
+    let mut total_in: u64 = 0;
+    let mut total_out: u64 = 0;
+    let mut messages: Vec<SessionMessage> = Vec::new();
+
+    for line in content.lines() {
+        if let Some((ts, mdl, branch, ver, entry, prompt, inp, out, role)) =
+            parse_claude_line_metadata(line)
+        {
+            if first_ts.is_none() { first_ts = ts.clone(); }
+            if ts.is_some() { last_ts = ts.clone(); }
+            if mdl.is_some() { model = mdl.clone(); }
+            if branch.is_some() { git_branch = branch; }
+            if ver.is_some() { version = ver; }
+            if entry.is_some() { executor = entry; }
+            if first_prompt.is_none() && prompt.is_some() { first_prompt = prompt.clone(); }
+            if role == "user" || role == "assistant" {
+                msg_count += 1;
+                let preview = prompt.map(|p| truncate_str(&p, 500)).unwrap_or_default();
+                messages.push(SessionMessage {
+                    role: role.clone(),
+                    content_preview: preview,
+                    model: mdl.clone(),
+                    input_tokens: inp,
+                    output_tokens: out,
+                    timestamp: ts,
+                    stop_reason: None,
+                });
+            }
+            if let Some(i) = inp { total_in += i; }
+            if let Some(o) = out { total_out += o; }
+        }
+    }
+
+    // Subagents
+    let session_dir = path.with_extension("");
+    let subagents_dir = session_dir.join("subagents");
+    let mut subagents: Vec<SubAgentInfo> = Vec::new();
+    if subagents_dir.exists() {
+        if let Ok(entries) = std::fs::read_dir(&subagents_dir) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.extension().and_then(|e| e.to_str()) == Some("json") {
+                    if let Some(name) = p.file_stem().and_then(|n| n.to_str()) {
+                        if name.ends_with(".meta") {
+                            if let Ok(c) = std::fs::read_to_string(&p) {
+                                if let Ok(meta) = serde_json::from_str::<serde_json::Value>(&c) {
+                                    subagents.push(SubAgentInfo {
+                                        agent_type: meta.get("agentType").and_then(|t| t.as_str()).unwrap_or("unknown").to_string(),
+                                        description: meta.get("description").and_then(|d| d.as_str()).unwrap_or("").to_string(),
+                                        message_count: 0,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Some(SessionDetail {
+        info: SessionInfo {
+            session_id: session_id.to_string(),
+            source: "claude-code".to_string(),
+            project_path,
+            status: if active_set.contains(session_id) { "active".into() } else { "completed".into() },
+            executor: executor.unwrap_or_else(|| "unknown".into()),
+            model: model.unwrap_or_else(|| "-".into()),
+            git_branch,
+            message_count: msg_count,
+            total_input_tokens: total_in,
+            total_output_tokens: total_out,
+            first_prompt: first_prompt.map(|p| truncate_str(&p, 200)),
+            created_at: first_ts,
+            last_active_at: last_ts,
+            file_size,
+            version,
+            subagent_count: subagents.len() as u32,
+        },
+        messages,
+        subagents,
+    })
+}
+
+fn get_codex_detail(session_id: &str) -> Option<SessionDetail> {
+    let base = home_dir().join(".codex/sessions");
+    if !base.exists() { return None; }
+
+    // Walk to find matching rollout file
+    if let Ok(y1) = std::fs::read_dir(&base) {
+        for y in y1.flatten().filter(|e| e.path().is_dir()) {
+            if let Ok(m1) = std::fs::read_dir(y.path()) {
+                for m in m1.flatten().filter(|e| e.path().is_dir()) {
+                    if let Ok(d1) = std::fs::read_dir(m.path()) {
+                        for f in d1.flatten() {
+                            let p = f.path();
+                            if !p.is_file() { continue; }
+                            let name = f.file_name().to_string_lossy().to_string();
+                            if !name.starts_with("rollout-") || !name.ends_with(".jsonl") { continue; }
+
+                            // Check if session_id matches the id in session_meta
+                            let content = std::fs::read_to_string(&p).ok()?;
+                            let first_line = content.lines().next()?;
+                            let first: serde_json::Value = serde_json::from_str(first_line).ok()?;
+                            let sid = first.get("payload").and_then(|p| p.get("id")).and_then(|i| i.as_str()).unwrap_or("");
+                            if sid != session_id && !name.contains(session_id) { continue; }
+
+                            let file_size = std::fs::metadata(&p).map(|m| m.len()).unwrap_or(0);
+                            let mut project_path = String::new();
+                            let mut version = String::new();
+                            let mut model = String::new();
+                            let mut first_ts: Option<String> = None;
+                            let mut last_ts: Option<String> = None;
+                            let mut first_prompt: Option<String> = None;
+                            let mut msg_count: u32 = 0;
+                            let mut messages: Vec<SessionMessage> = Vec::new();
+
+                            for line in content.lines() {
+                                if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+                                    let ts = v.get("timestamp").and_then(|t| t.as_str()).map(String::from);
+                                    let line_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+                                    match line_type {
+                                        "session_meta" => {
+                                            if let Some(payload) = v.get("payload") {
+                                                project_path = payload.get("cwd").and_then(|c| c.as_str()).unwrap_or("").to_string();
+                                                version = payload.get("cli_version").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                                                model = payload.get("model_provider").and_then(|m| m.as_str()).unwrap_or("openai").to_string();
+                                            }
+                                            first_ts = ts.clone();
+                                        }
+                                        "event_msg" => {
+                                            if let Some(payload) = v.get("payload") {
+                                                let event_type = payload.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                                                if event_type == "message" {
+                                                    let role = payload.get("message").and_then(|m| m.get("role")).and_then(|r| r.as_str()).unwrap_or("").to_string();
+                                                    let text = payload.get("message")
+                                                        .and_then(|m| m.get("content"))
+                                                        .and_then(|c| c.as_str())
+                                                        .unwrap_or("").to_string();
+                                                    if first_prompt.is_none() && role == "user" && !text.is_empty() {
+                                                        first_prompt = Some(truncate_str(&text, 200));
+                                                    }
+                                                    msg_count += 1;
+                                                    messages.push(SessionMessage {
+                                                        role: role.clone(),
+                                                        content_preview: truncate_str(&text, 500),
+                                                        model: if role == "assistant" { Some(model.clone()) } else { None },
+                                                        input_tokens: None,
+                                                        output_tokens: None,
+                                                        timestamp: ts.clone(),
+                                                        stop_reason: None,
+                                                    });
+                                                }
+                                            }
+                                        }
+                                        _ => {}
+                                    }
+                                    if ts.is_some() { last_ts = ts; }
+                                }
+                            }
+
+                            return Some(SessionDetail {
+                                info: SessionInfo {
+                                    session_id: session_id.to_string(),
+                                    source: "codex".to_string(),
+                                    project_path,
+                                    status: "completed".to_string(),
+                                    executor: "codex".to_string(),
+                                    model,
+                                    git_branch: None,
+                                    message_count: msg_count,
+                                    total_input_tokens: 0,
+                                    total_output_tokens: 0,
+                                    first_prompt,
+                                    created_at: first_ts,
+                                    last_active_at: last_ts,
+                                    file_size,
+                                    version: if version.is_empty() { None } else { Some(version) },
+                                    subagent_count: 0,
+                                },
+                                messages,
+                                subagents: vec![],
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn get_hermes_detail(session_id: &str) -> Option<SessionDetail> {
+    let path = home_dir().join(".hermes/sessions").join(format!("{}.jsonl", session_id));
+    if !path.exists() { return None; }
+
+    let content = std::fs::read_to_string(&path).ok()?;
+    let file_size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+
+    let mut first_ts: Option<String> = None;
+    let mut last_ts: Option<String> = None;
+    let mut model: Option<String> = None;
+    let mut first_prompt: Option<String> = None;
+    let mut msg_count: u32 = 0;
+    let mut messages: Vec<SessionMessage> = Vec::new();
+    let mut project_path = String::new();
+
+    for line in content.lines() {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("").to_string();
+            if role == "session_meta" {
+                first_ts = v.get("timestamp").and_then(|t| t.as_str()).map(String::from);
+            } else if role == "user" || role == "assistant" {
+                msg_count += 1;
+                let text = v.get("content").and_then(|c| c.as_str()).unwrap_or("").to_string();
+                if first_prompt.is_none() && role == "user" && !text.is_empty() {
+                    first_prompt = Some(truncate_str(&text, 200));
+                }
+                messages.push(SessionMessage {
+                    role: role.clone(),
+                    content_preview: truncate_str(&text, 500),
+                    model: if role == "assistant" { model.clone() } else { None },
+                    input_tokens: None,
+                    output_tokens: None,
+                    timestamp: v.get("timestamp").and_then(|t| t.as_str()).map(String::from),
+                    stop_reason: None,
+                });
+            }
+            if let Some(ts) = v.get("timestamp").and_then(|t| t.as_str()) {
+                last_ts = Some(ts.to_string());
+            }
+            if model.is_none() && role == "assistant" {
+                model = v.get("model").and_then(|m| m.as_str()).map(String::from);
+            }
+        }
+    }
+
+    Some(SessionDetail {
+        info: SessionInfo {
+            session_id: session_id.to_string(),
+            source: "hermes".to_string(),
+            project_path,
+            status: "completed".to_string(),
+            executor: "hermes".to_string(),
+            model: model.unwrap_or_else(|| "-".into()),
+            git_branch: None,
+            message_count: msg_count,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            first_prompt,
+            created_at: first_ts,
+            last_active_at: last_ts,
+            file_size,
+            version: None,
+            subagent_count: 0,
+        },
+        messages,
+        subagents: vec![],
+    })
+}
+
+fn get_kimi_detail(session_id: &str) -> Option<SessionDetail> {
+    let base = home_dir().join(".kimi/sessions");
+    if !base.exists() { return None; }
+
+    if let Ok(project_dirs) = std::fs::read_dir(&base) {
+        for project_dir in project_dirs.flatten().filter(|e| e.path().is_dir()) {
+            let session_dir = project_dir.path().join(session_id);
+            let context_path = session_dir.join("context.jsonl");
+            if !context_path.exists() { continue; }
+
+            let project_hash = project_dir.file_name().to_string_lossy().to_string();
+            let content = std::fs::read_to_string(&context_path).ok()?;
+            let file_size = std::fs::metadata(&context_path).map(|m| m.len()).unwrap_or(0);
+
+            let state: Option<serde_json::Value> = std::fs::read_to_string(session_dir.join("state.json"))
+                .ok().and_then(|s| serde_json::from_str(&s).ok());
+            let title = state.as_ref().and_then(|s| s.get("custom_title")).and_then(|t| t.as_str()).map(String::from);
+
+            let mut first_ts: Option<String> = None;
+            let mut last_ts: Option<String> = None;
+            let mut model: Option<String> = None;
+            let mut first_prompt: Option<String> = None;
+            let mut msg_count: u32 = 0;
+            let mut messages: Vec<SessionMessage> = Vec::new();
+
+            for line in content.lines() {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+                    let role = v.get("role").and_then(|r| r.as_str()).unwrap_or("").to_string();
+                    if role == "user" || role == "assistant" {
+                        msg_count += 1;
+                        let text = v.get("content").and_then(|c| c.as_str()).unwrap_or("").to_string();
+                        if first_prompt.is_none() && role == "user" && !text.is_empty() {
+                            first_prompt = Some(truncate_str(&text, 200));
+                        }
+                        if model.is_none() && role == "assistant" {
+                            model = v.get("model").and_then(|m| m.as_str()).map(String::from);
+                        }
+                        messages.push(SessionMessage {
+                            role: role.clone(),
+                            content_preview: truncate_str(&text, 500),
+                            model: if role == "assistant" { model.clone() } else { None },
+                            input_tokens: None,
+                            output_tokens: None,
+                            timestamp: v.get("timestamp").and_then(|t| t.as_str()).map(String::from),
+                            stop_reason: None,
+                        });
+                    }
+                    if let Some(ts) = v.get("timestamp").and_then(|t| t.as_str()) {
+                        if first_ts.is_none() { first_ts = Some(ts.to_string()); }
+                        last_ts = Some(ts.to_string());
+                    }
+                }
+            }
+
+            return Some(SessionDetail {
+                info: SessionInfo {
+                    session_id: session_id.to_string(),
+                    source: "kimi".to_string(),
+                    project_path: project_hash,
+                    status: "completed".to_string(),
+                    executor: "kimi".to_string(),
+                    model: model.unwrap_or_else(|| "-".into()),
+                    git_branch: None,
+                    message_count: msg_count,
+                    total_input_tokens: 0,
+                    total_output_tokens: 0,
+                    first_prompt: first_prompt.or(title),
+                    created_at: first_ts,
+                    last_active_at: last_ts,
+                    file_size,
+                    version: None,
+                    subagent_count: 0,
+                },
+                messages,
+                subagents: vec![],
+            });
+        }
+    }
+    None
+}
+
+fn get_atomcode_detail(session_id: &str) -> Option<SessionDetail> {
+    let base = home_dir().join(".atomcode/sessions");
+    if !base.exists() { return None; }
+
+    if let Ok(project_dirs) = std::fs::read_dir(&base) {
+        for project_dir in project_dirs.flatten().filter(|e| e.path().is_dir()) {
+            if let Ok(files) = std::fs::read_dir(project_dir.path()) {
+                for file in files.flatten() {
+                    let path = file.path();
+                    if path.extension().and_then(|e| e.to_str()) != Some("json") { continue; }
+                    let content = std::fs::read_to_string(&path).ok()?;
+                    let v: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+                    let sid = v.get("id").and_then(|i| i.as_str()).unwrap_or("");
+                    if sid != session_id { continue; }
+
+                    let working_dir = v.get("working_dir").and_then(|w| w.as_str()).unwrap_or("").to_string();
+                    let created_at_ts = v.get("created_at").and_then(|t| t.as_u64());
+                    let file_size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+                    let msgs_arr = v.get("messages").and_then(|m| m.as_array());
+                    let msg_count = msgs_arr.map(|m| m.len()).unwrap_or(0) as u32;
+
+                    let created_str = created_at_ts.and_then(|ts| {
+                        chrono::DateTime::from_timestamp(ts as i64, 0).map(|dt| dt.to_rfc3339())
+                    });
+
+                    let mut messages: Vec<SessionMessage> = Vec::new();
+                    let mut first_prompt: Option<String> = None;
+
+                    if let Some(msgs) = msgs_arr {
+                        for msg in msgs {
+                            let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("").to_string();
+                            let text = msg.get("content").and_then(|c| c.get("Text")).and_then(|t| t.as_str()).unwrap_or("").to_string();
+                            if first_prompt.is_none() && role == "User" && !text.is_empty() {
+                                first_prompt = Some(truncate_str(&text, 200));
+                            }
+                            messages.push(SessionMessage {
+                                role: if role == "User" { "user".into() } else { "assistant".into() },
+                                content_preview: truncate_str(&text, 500),
+                                model: None,
+                                input_tokens: None,
+                                output_tokens: None,
+                                timestamp: created_str.clone(),
+                                stop_reason: None,
+                            });
+                        }
+                    }
+
+                    return Some(SessionDetail {
+                        info: SessionInfo {
+                            session_id: session_id.to_string(),
+                            source: "atomcode".to_string(),
+                            project_path: working_dir,
+                            status: "completed".to_string(),
+                            executor: "atomcode".to_string(),
+                            model: "-".to_string(),
+                            git_branch: None,
+                            message_count: msg_count,
+                            total_input_tokens: 0,
+                            total_output_tokens: 0,
+                            first_prompt,
+                            created_at: created_str.clone(),
+                            last_active_at: created_str,
+                            file_size,
+                            version: None,
+                            subagent_count: 0,
+                        },
+                        messages,
+                        subagents: vec![],
+                    });
+                }
+            }
+        }
+    }
+    None
+}
+
+fn get_ccconnect_detail(session_id: &str) -> Option<SessionDetail> {
+    // session_id format: "cc-connect-{file_name}-{sess_key}"
+    if !session_id.starts_with("cc-connect-") { return None; }
+    let rest = &session_id["cc-connect-".len()..];
+    // Try to find the file by scanning
+    let dir = home_dir().join(".cc-connect/sessions");
+    if !dir.exists() { return None; }
+
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") { continue; }
+            let file_name = path.file_stem()?.to_string_lossy().to_string();
+
+            // Check if session_id starts with "cc-connect-{file_name}"
+            let prefix = format!("cc-connect-{}", file_name);
+            if !session_id.starts_with(&prefix) { continue; }
+
+            let content = std::fs::read_to_string(&path).ok()?;
+            let v: serde_json::Value = serde_json::from_str(&content).ok()?;
+            let file_size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+
+            let sess_map = v.get("sessions")?.as_object()?;
+            for (key, val) in sess_map {
+                let expected_id = format!("cc-connect-{}-{}", file_name, key);
+                if expected_id != session_id { continue; }
+
+                let history = val.get("history").and_then(|h| h.as_array());
+                let msg_count = history.map(|h| h.len()).unwrap_or(0) as u32;
+                let project_name = file_name.split('_').next().unwrap_or(&file_name).to_string();
+
+                let mut messages: Vec<SessionMessage> = Vec::new();
+                let mut first_prompt: Option<String> = None;
+                let mut first_ts: Option<String> = None;
+                let mut last_ts: Option<String> = None;
+
+                if let Some(hist) = history {
+                    for msg in hist {
+                        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("").to_string();
+                        let text = msg.get("content").and_then(|c| c.as_str()).unwrap_or("").to_string();
+                        if first_prompt.is_none() && role == "user" && !text.is_empty() {
+                            first_prompt = Some(truncate_str(&text, 200));
+                        }
+                        let ts = msg.get("timestamp").and_then(|t| t.as_f64()).and_then(|ts| {
+                            chrono::DateTime::from_timestamp(ts as i64, 0).map(|dt| dt.to_rfc3339())
+                        });
+                        if first_ts.is_none() { first_ts = ts.clone(); }
+                        if ts.is_some() { last_ts = ts.clone(); }
+
+                        messages.push(SessionMessage {
+                            role,
+                            content_preview: truncate_str(&text, 500),
+                            model: None,
+                            input_tokens: None,
+                            output_tokens: None,
+                            timestamp: ts,
+                            stop_reason: None,
+                        });
+                    }
+                }
+
+                return Some(SessionDetail {
+                    info: SessionInfo {
+                        session_id: session_id.to_string(),
+                        source: "cc-connect".to_string(),
+                        project_path: project_name,
+                        status: "completed".to_string(),
+                        executor: "cc-connect".to_string(),
+                        model: "-".to_string(),
+                        git_branch: None,
+                        message_count: msg_count,
+                        total_input_tokens: 0,
+                        total_output_tokens: 0,
+                        first_prompt,
+                        created_at: first_ts,
+                        last_active_at: last_ts,
+                        file_size: file_size / (sess_map.len().max(1) as u64),
+                        version: None,
+                        subagent_count: 0,
+                    },
+                    messages,
+                    subagents: vec![],
+                });
+            }
+        }
+    }
+    None
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -202,6 +202,9 @@ async fn run_server(cli_port: Option<u16>) {
     if let Err(e) = db.seed_default_executors().await {
         tracing::warn!("Failed to seed default executors: {}", e);
     }
+    if let Err(e) = db.backfill_session_dir().await {
+        tracing::warn!("Failed to backfill session_dir: {}", e);
+    }
 
     let executor_registry = Arc::new(adapters::ExecutorRegistry::new());
     let db_executors = db.get_enabled_executors().await.unwrap_or_default();

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -441,6 +441,7 @@ pub struct ExecutorConfig {
     pub path: String,
     pub enabled: bool,
     pub display_name: String,
+    pub session_dir: String,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }
@@ -450,6 +451,7 @@ pub struct UpdateExecutorRequest {
     pub path: Option<String>,
     pub enabled: Option<bool>,
     pub display_name: Option<String>,
+    pub session_dir: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/docs/session-management-design.md
+++ b/docs/session-management-design.md
@@ -1,0 +1,175 @@
+# Session 管理功能设计文档
+
+## 概述
+
+在设置页面新增「Session 管理」标签页，提供 Claude Code 会话的只读浏览功能。展示所有会话的元信息，帮助用户了解各个执行器的使用情况、会话历史等。
+
+## 数据来源
+
+Claude Code 的会话存储在 `~/.claude/` 目录下：
+
+| 路径 | 说明 |
+|------|------|
+| `~/.claude/sessions/<pid>.json` | 活跃会话注册表，包含 PID、sessionId、cwd、启动时间、版本等 |
+| `~/.claude/projects/<encoded-path>/<uuid>.jsonl` | 会话对话记录（JSONL 格式，每行一个消息） |
+| `~/.claude/projects/<encoded-path>/<uuid>/subagents/` | 子代理目录 |
+| `~/.claude/history.jsonl` | 全局命令历史 |
+
+### 会话 JSONL 关键字段
+
+每行 JSON 包含 `type` 字段，主要类型：
+- `user` - 用户消息，含 `message.role`、`message.content`、`sessionId`、`cwd`、`gitBranch`、`version`、`entrypoint`
+- `assistant` - 助手回复，含 `message.model`、`message.usage`（token 用量）、`message.stop_reason`
+- `queue-operation` - 队列操作，含用户输入的 prompt
+- `last-prompt` - 最后一条 prompt
+- `attachment` - 附件信息
+
+### 活跃会话 PID 文件字段
+
+```json
+{
+  "pid": 74512,
+  "sessionId": "uuid",
+  "cwd": "/path/to/project",
+  "startedAt": 1778538856977,
+  "procStart": "Mon May 11 22:34:16 2026",
+  "version": "2.1.138",
+  "kind": "interactive",
+  "entrypoint": "sdk-cli"
+}
+```
+
+## 功能列表
+
+### P0 - 核心功能（必须完成）
+
+#### F1. Session 列表 API
+- **后端** 新增 `/xyz/sessions` GET 接口
+- 扫描 `~/.claude/sessions/` 获取活跃会话
+- 扫描 `~/.claude/projects/` 下所有项目的 JSONL 文件
+- 解析 JSONL 提取会话元信息：sessionId、项目路径、创建时间、最后活跃时间、消息数、token 用量、模型名称、git 分支、entrypoint
+- 支持分页参数 `page`、`page_size`
+- 支持过滤参数：`executor`（entrypoint 过滤）、`project`（项目路径过滤）、`status`（active/completed）、`search`（搜索 prompt 内容）
+
+#### F2. Session 列表 UI
+- 在设置页 Tabs 中新增「Session 管理」标签
+- 使用 Ant Design Table 展示会话列表
+- 列：状态指示灯（活跃/已完成）、Session ID（缩短显示）、项目路径、执行器类型、模型、Git 分支、消息数、Token 用量、创建时间、最后活跃时间
+- 支持分页
+- 支持按状态过滤（全部/活跃/已完成）
+- 支持按执行器过滤
+- 支持搜索
+
+#### F3. Session 详情 API
+- **后端** 新增 `/xyz/sessions/:id` GET 接口
+- 读取指定 session 的 JSONL 文件
+- 返回完整的消息列表（用户消息 + 助手回复，按时间排序）
+- 包含每条消息的 role、content 摘要、model、token 用量、时间戳
+
+#### F4. Session 详情 UI（只读查看器）
+- 点击列表中的 session 行，弹出 Drawer 或 Modal 显示详情
+- 按时间线展示对话记录
+- 用户消息和助手回复用不同样式区分
+- 显示每条消息的元信息（模型、token 数、时间）
+- 只读模式，不允许编辑
+
+### P1 - 增强功能
+
+#### F5. Session 统计概览
+- 在列表上方显示统计卡片
+- 总会话数、活跃会话数、今日新会话、总 Token 消耗
+- 按执行器分组的会话数量饼图或统计条
+
+#### F6. Session 详情 - 子代理信息
+- 在详情页展示该会话产生的子代理列表
+- 显示子代理类型、描述、执行时间
+- 可展开查看子代理的对话记录
+
+#### F7. Session 批量清理
+- 支持选择多个已完成的旧会话进行清理
+- 清理前确认对话框
+- 仅删除 JSONL 文件和对应目录，不影响数据库
+
+## 技术方案
+
+### 后端
+
+新增文件：
+- `backend/src/handlers/session.rs` - 会话管理 API 处理器
+- 在 `handlers/mod.rs` 中注册模块和路由
+
+路由：
+```
+GET  /xyz/sessions           - 列表（支持分页和过滤）
+GET  /xyz/sessions/:id       - 详情
+GET  /xyz/sessions/stats     - 统计数据
+DELETE /xyz/sessions/:id     - 删除（仅 JSONL 文件）
+```
+
+数据结构：
+```rust
+struct SessionInfo {
+    session_id: String,
+    project_path: String,       // 从 cwd 或目录名解码
+    status: String,             // "active" | "completed"
+    executor: String,           // entrypoint 字段
+    model: String,              // 从 assistant 消息提取
+    git_branch: Option<String>,
+    message_count: u32,
+    total_tokens: u64,          // input + output tokens
+    created_at: String,         // 第一条消息的时间
+    last_active_at: String,     // 最后一条消息的时间
+    file_size: u64,             // JSONL 文件大小
+    version: Option<String>,    // Claude Code 版本
+}
+
+struct SessionDetail {
+    info: SessionInfo,
+    messages: Vec<SessionMessage>,
+    subagents: Vec<SubAgentInfo>,
+}
+
+struct SessionMessage {
+    role: String,               // "user" | "assistant"
+    content: String,            // 内容摘要（截断）
+    model: Option<String>,
+    input_tokens: Option<u32>,
+    output_tokens: Option<u32>,
+    timestamp: String,
+    stop_reason: Option<String>,
+}
+
+struct SubAgentInfo {
+    agent_type: String,
+    description: String,
+    message_count: u32,
+}
+```
+
+性能考量：
+- 使用 `tokio::task::spawn_blocking()` 包装文件 I/O
+- 大 JSONL 文件只读取头部和尾部来提取元信息，避免全量解析
+- 列表接口只返回元信息，不包含对话内容
+- 分页在服务端实现
+
+### 前端
+
+修改文件：
+- `frontend/src/components/SettingsPage.tsx` - 新增 Session 管理标签页
+- `frontend/src/utils/database.ts` - 新增 session API 调用
+
+UI 组件：
+- Ant Design Table 作为主列表
+- Ant Design Drawer 作为详情查看器
+- Ant Design Statistic + Card 作为统计概览
+- Ant Design Tag 作为状态/执行器标签
+
+## 进度追踪
+
+- [x] F1. Session 列表 API
+- [x] F2. Session 列表 UI
+- [x] F3. Session 详情 API
+- [x] F4. Session 详情 UI
+- [x] F5. Session 统计概览
+- [x] F6. Session 子代理信息
+- [x] F7. Session 批量清理

--- a/docs/session-management-design.md
+++ b/docs/session-management-design.md
@@ -173,3 +173,4 @@ UI 组件：
 - [x] F5. Session 统计概览
 - [x] F6. Session 子代理信息
 - [x] F7. Session 批量清理
+- [x] F8. 多工具 Session 扫描（Claude Code / Codex / Hermes / Kimi / AtomCode / CC-Connect）

--- a/frontend/src/components/SessionManager.tsx
+++ b/frontend/src/components/SessionManager.tsx
@@ -1,0 +1,553 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Table,
+  Tag,
+  Space,
+  Input,
+  Select,
+  Drawer,
+  Button,
+  Popconfirm,
+  Statistic,
+  Card,
+  Row,
+  Col,
+  Spin,
+  Empty,
+  Typography,
+  Tooltip,
+  message,
+} from 'antd';
+import {
+  SearchOutlined,
+  ReloadOutlined,
+  EyeOutlined,
+  DeleteOutlined,
+  RobotOutlined,
+  ClockCircleOutlined,
+  ThunderboltOutlined,
+  TeamOutlined,
+  ApiOutlined,
+} from '@ant-design/icons';
+import * as db from '../utils/database';
+import type { SessionInfo, SessionDetail, SessionStats } from '../utils/database';
+
+const { Text, Paragraph } = Typography;
+
+// ─── Helpers ──────────────────────────────────────────────
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}K`;
+  return `${(n / 1_000_000).toFixed(2)}M`;
+}
+
+function formatTime(iso?: string | null): string {
+  if (!iso) return '-';
+  try {
+    const d = new Date(iso);
+    const now = new Date();
+    const diffMs = now.getTime() - d.getTime();
+    const diffMin = Math.floor(diffMs / 60000);
+
+    if (diffMin < 1) return '刚刚';
+    if (diffMin < 60) return `${diffMin} 分钟前`;
+    const diffHour = Math.floor(diffMin / 60);
+    if (diffHour < 24) return `${diffHour} 小时前`;
+    const diffDay = Math.floor(diffHour / 24);
+    if (diffDay < 30) return `${diffDay} 天前`;
+
+    return d.toLocaleDateString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return iso;
+  }
+}
+
+function shortId(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 8)}...${id.slice(-4)}` : id;
+}
+
+const executorColorMap: Record<string, string> = {
+  'sdk-cli': 'blue',
+  'cli': 'geekblue',
+  'vscode': 'green',
+  'jetbrains': 'purple',
+  'web': 'cyan',
+};
+
+function executorTag(executor: string) {
+  const color = executorColorMap[executor] || 'default';
+  return <Tag color={color}>{executor}</Tag>;
+}
+
+// ─── Stats Cards ──────────────────────────────────────────
+
+function StatsCards({ stats }: { stats: SessionStats | null }) {
+  if (!stats) return null;
+  return (
+    <Row gutter={[12, 12]} style={{ marginBottom: 16 }}>
+      <Col span={6}>
+        <Card size="small" style={{ textAlign: 'center' }}>
+          <Statistic
+            title={<Text type="secondary" style={{ fontSize: 12 }}>总会话</Text>}
+            value={stats.total_sessions}
+            prefix={<TeamOutlined />}
+            valueStyle={{ fontSize: 20 }}
+          />
+        </Card>
+      </Col>
+      <Col span={6}>
+        <Card size="small" style={{ textAlign: 'center' }}>
+          <Statistic
+            title={<Text type="secondary" style={{ fontSize: 12 }}>活跃会话</Text>}
+            value={stats.active_sessions}
+            prefix={<ClockCircleOutlined />}
+            valueStyle={{ fontSize: 20, color: '#52c41a' }}
+          />
+        </Card>
+      </Col>
+      <Col span={6}>
+        <Card size="small" style={{ textAlign: 'center' }}>
+          <Statistic
+            title={<Text type="secondary" style={{ fontSize: 12 }}>今日新增</Text>}
+            value={stats.today_sessions}
+            prefix={<ThunderboltOutlined />}
+            valueStyle={{ fontSize: 20, color: '#faad14' }}
+          />
+        </Card>
+      </Col>
+      <Col span={6}>
+        <Card size="small" style={{ textAlign: 'center' }}>
+          <Statistic
+            title={<Text type="secondary" style={{ fontSize: 12 }}>总 Token</Text>}
+            value={formatTokens(stats.total_input_tokens + stats.total_output_tokens)}
+            prefix={<ApiOutlined />}
+            valueStyle={{ fontSize: 20, color: '#1677ff' }}
+          />
+        </Card>
+      </Col>
+    </Row>
+  );
+}
+
+// ─── Session Detail Drawer ────────────────────────────────
+
+function SessionDetailDrawer({
+  sessionId,
+  open,
+  onClose,
+}: {
+  sessionId: string | null;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [detail, setDetail] = useState<SessionDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (open && sessionId) {
+      setLoading(true);
+      db.getSessionDetail(sessionId)
+        .then(setDetail)
+        .catch(() => setDetail(null))
+        .finally(() => setLoading(false));
+    } else {
+      setDetail(null);
+    }
+  }, [open, sessionId]);
+
+  return (
+    <Drawer
+      title={detail ? `Session ${shortId(detail.info.session_id)}` : 'Session 详情'}
+      open={open}
+      onClose={onClose}
+      width={680}
+      styles={{ body: { padding: '16px 24px' } }}
+    >
+      <Spin spinning={loading}>
+        {detail ? (
+          <>
+            {/* Meta Info */}
+            <Card size="small" title="基本信息" style={{ marginBottom: 16 }}>
+              <Row gutter={[16, 8]}>
+                <Col span={12}><Text type="secondary">项目：</Text><Text>{detail.info.project_path}</Text></Col>
+                <Col span={12}><Text type="secondary">状态：</Text>
+                  <Tag color={detail.info.status === 'active' ? 'green' : 'default'}>
+                    {detail.info.status === 'active' ? '活跃' : '已完成'}
+                  </Tag>
+                </Col>
+                <Col span={12}><Text type="secondary">执行器：</Text>{executorTag(detail.info.executor)}</Col>
+                <Col span={12}><Text type="secondary">模型：</Text><Text code>{detail.info.model}</Text></Col>
+                <Col span={12}><Text type="secondary">Git 分支：</Text><Text code>{detail.info.git_branch || '-'}</Text></Col>
+                <Col span={12}><Text type="secondary">版本：</Text><Text code>{detail.info.version || '-'}</Text></Col>
+                <Col span={12}><Text type="secondary">消息数：</Text><Text>{detail.info.message_count}</Text></Col>
+                <Col span={12}>
+                  <Text type="secondary">文件大小：</Text>
+                  <Text>{formatBytes(detail.info.file_size)}</Text>
+                </Col>
+                <Col span={12}>
+                  <Text type="secondary">Token：</Text>
+                  <Tooltip title={`输入: ${formatTokens(detail.info.total_input_tokens)} / 输出: ${formatTokens(detail.info.total_output_tokens)}`}>
+                    <Text>{formatTokens(detail.info.total_input_tokens + detail.info.total_output_tokens)}</Text>
+                  </Tooltip>
+                </Col>
+                <Col span={12}><Text type="secondary">子代理：</Text><Text>{detail.info.subagent_count}</Text></Col>
+                <Col span={24}>
+                  <Text type="secondary">首条 Prompt：</Text>
+                  <Paragraph
+                    ellipsis={{ rows: 3, expandable: true, symbol: '展开' }}
+                    style={{ marginTop: 4, marginBottom: 0 }}
+                  >
+                    {detail.info.first_prompt || '-'}
+                  </Paragraph>
+                </Col>
+              </Row>
+            </Card>
+
+            {/* Subagents */}
+            {detail.subagents.length > 0 && (
+              <Card size="small" title={`子代理 (${detail.subagents.length})`} style={{ marginBottom: 16 }}>
+                {detail.subagents.map((sa, i) => (
+                  <div key={i} style={{ padding: '6px 0', borderBottom: i < detail.subagents.length - 1 ? '1px solid var(--color-border-light)' : 'none' }}>
+                    <Space>
+                      <Tag color="purple">{sa.agent_type}</Tag>
+                      <Text>{sa.description}</Text>
+                    </Space>
+                  </div>
+                ))}
+              </Card>
+            )}
+
+            {/* Messages Timeline */}
+            <Card size="small" title={`对话记录 (${detail.messages.length})`}>
+              <div style={{ maxHeight: 500, overflowY: 'auto' }}>
+                {detail.messages.length === 0 ? (
+                  <Empty description="无对话记录" />
+                ) : (
+                  detail.messages.map((msg, i) => (
+                    <div
+                      key={i}
+                      style={{
+                        marginBottom: 12,
+                        padding: '8px 12px',
+                        borderRadius: 8,
+                        background: msg.role === 'user'
+                          ? 'var(--color-bg-elevated)'
+                          : 'rgba(22, 119, 255, 0.06)',
+                        borderLeft: msg.role === 'user'
+                          ? '3px solid var(--color-border)'
+                          : '3px solid #1677ff',
+                      }}
+                    >
+                      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
+                        <Space size={4}>
+                          <RobotOutlined style={{ color: msg.role === 'user' ? undefined : '#1677ff' }} />
+                          <Text strong style={{ fontSize: 12 }}>
+                            {msg.role === 'user' ? '用户' : '助手'}
+                          </Text>
+                          {msg.model && <Tag color="blue" style={{ fontSize: 10, lineHeight: '16px', padding: '0 4px' }}>{msg.model}</Tag>}
+                        </Space>
+                        <Space size={8}>
+                          {msg.input_tokens != null && (
+                            <Text type="secondary" style={{ fontSize: 11 }}>
+                              ↑{formatTokens(msg.input_tokens)}
+                            </Text>
+                          )}
+                          {msg.output_tokens != null && (
+                            <Text type="secondary" style={{ fontSize: 11 }}>
+                              ↓{formatTokens(msg.output_tokens)}
+                            </Text>
+                          )}
+                          <Text type="secondary" style={{ fontSize: 11 }}>{formatTime(msg.timestamp)}</Text>
+                        </Space>
+                      </div>
+                      <Paragraph
+                        ellipsis={{ rows: 4, expandable: true, symbol: '展开' }}
+                        style={{ margin: 0, fontSize: 13, whiteSpace: 'pre-wrap' }}
+                      >
+                        {msg.content_preview || '(无内容)'}
+                      </Paragraph>
+                    </div>
+                  ))
+                )}
+              </div>
+            </Card>
+          </>
+        ) : (
+          <Empty description="选择一个 Session 查看详情" />
+        )}
+      </Spin>
+    </Drawer>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────
+
+export function SessionManager() {
+  const [sessions, setSessions] = useState<SessionInfo[]>([]);
+  const [stats, setStats] = useState<SessionStats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [statusFilter, setStatusFilter] = useState<string | undefined>();
+  const [executorFilter, setExecutorFilter] = useState<string | undefined>();
+  const [searchText, setSearchText] = useState('');
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const fetchSessions = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await db.listSessions({
+        page,
+        page_size: pageSize,
+        status: statusFilter,
+        executor: executorFilter,
+        search: searchText || undefined,
+      });
+      setSessions(res.sessions);
+      setTotal(res.total);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, [page, pageSize, statusFilter, executorFilter, searchText]);
+
+  const fetchStats = useCallback(async () => {
+    try {
+      const s = await db.getSessionStats();
+      setStats(s);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSessions();
+  }, [fetchSessions]);
+
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
+  const handleDelete = async (sessionId: string) => {
+    try {
+      await db.deleteSession(sessionId);
+      message.success('已删除');
+      fetchSessions();
+      fetchStats();
+    } catch (e: any) {
+      message.error(e.message || '删除失败');
+    }
+  };
+
+  // Extract unique executors from stats
+  const executorOptions = stats
+    ? Object.keys(stats.by_executor).map((e) => ({ label: e, value: e }))
+    : [];
+
+  const columns = [
+    {
+      title: '状态',
+      dataIndex: 'status',
+      width: 70,
+      render: (s: string) => (
+        <Tooltip title={s === 'active' ? '活跃' : '已完成'}>
+          <span
+            style={{
+              display: 'inline-block',
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: s === 'active' ? '#52c41a' : '#d9d9d9',
+              boxShadow: s === 'active' ? '0 0 6px rgba(82, 196, 26, 0.5)' : 'none',
+            }}
+          />
+        </Tooltip>
+      ),
+    },
+    {
+      title: 'Session ID',
+      dataIndex: 'session_id',
+      width: 130,
+      render: (id: string) => (
+        <Tooltip title={id}>
+          <Text code style={{ fontSize: 12 }}>{shortId(id)}</Text>
+        </Tooltip>
+      ),
+    },
+    {
+      title: '项目',
+      dataIndex: 'project_path',
+      width: 200,
+      ellipsis: true,
+      render: (p: string) => {
+        const short = p.split('/').slice(-2).join('/');
+        return <Tooltip title={p}><Text style={{ fontSize: 12 }}>{short}</Text></Tooltip>;
+      },
+    },
+    {
+      title: '执行器',
+      dataIndex: 'executor',
+      width: 100,
+      render: (e: string) => executorTag(e),
+    },
+    {
+      title: '模型',
+      dataIndex: 'model',
+      width: 100,
+      ellipsis: true,
+      render: (m: string) => <Text style={{ fontSize: 12 }}>{m}</Text>,
+    },
+    {
+      title: '分支',
+      dataIndex: 'git_branch',
+      width: 90,
+      ellipsis: true,
+      render: (b: string | null) => b ? <Tag style={{ fontSize: 11 }}>{b}</Tag> : <Text type="secondary">-</Text>,
+    },
+    {
+      title: '消息',
+      dataIndex: 'message_count',
+      width: 60,
+      align: 'center' as const,
+      render: (n: number) => <Text style={{ fontSize: 12 }}>{n}</Text>,
+    },
+    {
+      title: 'Token',
+      width: 80,
+      align: 'right' as const,
+      render: (_: unknown, r: SessionInfo) => (
+        <Tooltip title={`输入: ${formatTokens(r.total_input_tokens)} / 输出: ${formatTokens(r.total_output_tokens)}`}>
+          <Text style={{ fontSize: 12 }}>{formatTokens(r.total_input_tokens + r.total_output_tokens)}</Text>
+        </Tooltip>
+      ),
+    },
+    {
+      title: '首条 Prompt',
+      dataIndex: 'first_prompt',
+      ellipsis: true,
+      render: (p: string | null) => (
+        <Text type="secondary" style={{ fontSize: 12 }}>{p || '-'}</Text>
+      ),
+    },
+    {
+      title: '最后活跃',
+      dataIndex: 'last_active_at',
+      width: 120,
+      render: (t: string | null) => (
+        <Tooltip title={t || ''}>
+          <Text style={{ fontSize: 12 }}>{formatTime(t)}</Text>
+        </Tooltip>
+      ),
+    },
+    {
+      title: '大小',
+      dataIndex: 'file_size',
+      width: 70,
+      align: 'right' as const,
+      render: (s: number) => <Text type="secondary" style={{ fontSize: 11 }}>{formatBytes(s)}</Text>,
+    },
+    {
+      title: '操作',
+      width: 80,
+      fixed: 'right' as const,
+      render: (_: unknown, r: SessionInfo) => (
+        <Space size={4}>
+          <Button
+            type="text"
+            size="small"
+            icon={<EyeOutlined />}
+            onClick={() => { setSelectedSessionId(r.session_id); setDrawerOpen(true); }}
+          />
+          <Popconfirm
+            title="确定删除该 Session？"
+            description="将删除会话的 JSONL 文件和子代理数据"
+            onConfirm={() => handleDelete(r.session_id)}
+            okText="删除"
+            cancelText="取消"
+          >
+            <Button type="text" size="small" danger icon={<DeleteOutlined />} />
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <StatsCards stats={stats} />
+
+      {/* Filters */}
+      <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
+        <Input
+          placeholder="搜索 Prompt 内容..."
+          prefix={<SearchOutlined />}
+          value={searchText}
+          onChange={(e) => { setSearchText(e.target.value); setPage(1); }}
+          style={{ width: 240 }}
+          allowClear
+        />
+        <Select
+          placeholder="状态"
+          value={statusFilter}
+          onChange={(v) => { setStatusFilter(v); setPage(1); }}
+          style={{ width: 120 }}
+          allowClear
+          options={[
+            { label: '活跃', value: 'active' },
+            { label: '已完成', value: 'completed' },
+          ]}
+        />
+        <Select
+          placeholder="执行器"
+          value={executorFilter}
+          onChange={(v) => { setExecutorFilter(v); setPage(1); }}
+          style={{ width: 140 }}
+          allowClear
+          options={executorOptions}
+        />
+        <Button icon={<ReloadOutlined />} onClick={() => { fetchSessions(); fetchStats(); }}>
+          刷新
+        </Button>
+      </div>
+
+      {/* Table */}
+      <Table
+        dataSource={sessions}
+        columns={columns}
+        rowKey="session_id"
+        loading={loading}
+        size="small"
+        scroll={{ x: 1200 }}
+        pagination={{
+          current: page,
+          pageSize,
+          total,
+          showSizeChanger: true,
+          showTotal: (t) => `共 ${t} 条`,
+          onChange: (p, ps) => { setPage(p); setPageSize(ps); },
+        }}
+        onRow={(record) => ({
+          onClick: () => { setSelectedSessionId(record.session_id); setDrawerOpen(true); },
+          style: { cursor: 'pointer' },
+        })}
+      />
+
+      {/* Detail Drawer */}
+      <SessionDetailDrawer
+        sessionId={selectedSessionId}
+        open={drawerOpen}
+        onClose={() => { setDrawerOpen(false); setSelectedSessionId(null); }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/SessionManager.tsx
+++ b/frontend/src/components/SessionManager.tsx
@@ -37,13 +37,15 @@ const { Text, Paragraph } = Typography;
 
 // ─── Source display config ────────────────────────────────
 
-const sourceConfig: Record<string, { label: string; color: string; icon?: string }> = {
-  'claude-code': { label: 'Claude Code', color: '#d97706' },
+const sourceConfig: Record<string, { label: string; color: string }> = {
+  'claude_code': { label: 'Claude Code', color: '#d97706' },
   'codex': { label: 'Codex', color: '#10a37f' },
   'hermes': { label: 'Hermes', color: '#8b5cf6' },
   'kimi': { label: 'Kimi', color: '#3b82f6' },
   'atomcode': { label: 'AtomCode', color: '#ef4444' },
-  'cc-connect': { label: 'CC-Connect', color: '#06b6d4' },
+  'codebuddy': { label: 'CodeBuddy', color: '#f59e0b' },
+  'opencode': { label: 'OpenCode', color: '#22c55e' },
+  'joinai': { label: 'JoinAI', color: '#6366f1' },
 };
 
 function sourceTag(source: string) {

--- a/frontend/src/components/SessionManager.tsx
+++ b/frontend/src/components/SessionManager.tsx
@@ -28,11 +28,32 @@ import {
   ThunderboltOutlined,
   TeamOutlined,
   ApiOutlined,
+  FilterOutlined,
 } from '@ant-design/icons';
 import * as db from '../utils/database';
 import type { SessionInfo, SessionDetail, SessionStats } from '../utils/database';
 
 const { Text, Paragraph } = Typography;
+
+// ─── Source display config ────────────────────────────────
+
+const sourceConfig: Record<string, { label: string; color: string; icon?: string }> = {
+  'claude-code': { label: 'Claude Code', color: '#d97706' },
+  'codex': { label: 'Codex', color: '#10a37f' },
+  'hermes': { label: 'Hermes', color: '#8b5cf6' },
+  'kimi': { label: 'Kimi', color: '#3b82f6' },
+  'atomcode': { label: 'AtomCode', color: '#ef4444' },
+  'cc-connect': { label: 'CC-Connect', color: '#06b6d4' },
+};
+
+function sourceTag(source: string) {
+  const cfg = sourceConfig[source] || { label: source, color: '#6b7280' };
+  return (
+    <Tag color={cfg.color} style={{ fontSize: 11, lineHeight: '18px', padding: '0 6px' }}>
+      {cfg.label}
+    </Tag>
+  );
+}
 
 // ─── Helpers ──────────────────────────────────────────────
 
@@ -73,66 +94,74 @@ function shortId(id: string): string {
   return id.length > 12 ? `${id.slice(0, 8)}...${id.slice(-4)}` : id;
 }
 
-const executorColorMap: Record<string, string> = {
-  'sdk-cli': 'blue',
-  'cli': 'geekblue',
-  'vscode': 'green',
-  'jetbrains': 'purple',
-  'web': 'cyan',
-};
-
-function executorTag(executor: string) {
-  const color = executorColorMap[executor] || 'default';
-  return <Tag color={color}>{executor}</Tag>;
-}
-
 // ─── Stats Cards ──────────────────────────────────────────
 
 function StatsCards({ stats }: { stats: SessionStats | null }) {
   if (!stats) return null;
+
+  // Source breakdown row
+  const sourceEntries = Object.entries(stats.by_source).sort((a, b) => b[1] - a[1]);
+
   return (
-    <Row gutter={[12, 12]} style={{ marginBottom: 16 }}>
-      <Col span={6}>
-        <Card size="small" style={{ textAlign: 'center' }}>
-          <Statistic
-            title={<Text type="secondary" style={{ fontSize: 12 }}>总会话</Text>}
-            value={stats.total_sessions}
-            prefix={<TeamOutlined />}
-            valueStyle={{ fontSize: 20 }}
-          />
-        </Card>
-      </Col>
-      <Col span={6}>
-        <Card size="small" style={{ textAlign: 'center' }}>
-          <Statistic
-            title={<Text type="secondary" style={{ fontSize: 12 }}>活跃会话</Text>}
-            value={stats.active_sessions}
-            prefix={<ClockCircleOutlined />}
-            valueStyle={{ fontSize: 20, color: '#52c41a' }}
-          />
-        </Card>
-      </Col>
-      <Col span={6}>
-        <Card size="small" style={{ textAlign: 'center' }}>
-          <Statistic
-            title={<Text type="secondary" style={{ fontSize: 12 }}>今日新增</Text>}
-            value={stats.today_sessions}
-            prefix={<ThunderboltOutlined />}
-            valueStyle={{ fontSize: 20, color: '#faad14' }}
-          />
-        </Card>
-      </Col>
-      <Col span={6}>
-        <Card size="small" style={{ textAlign: 'center' }}>
-          <Statistic
-            title={<Text type="secondary" style={{ fontSize: 12 }}>总 Token</Text>}
-            value={formatTokens(stats.total_input_tokens + stats.total_output_tokens)}
-            prefix={<ApiOutlined />}
-            valueStyle={{ fontSize: 20, color: '#1677ff' }}
-          />
-        </Card>
-      </Col>
-    </Row>
+    <>
+      <Row gutter={[12, 12]} style={{ marginBottom: 12 }}>
+        <Col span={6}>
+          <Card size="small" style={{ textAlign: 'center' }}>
+            <Statistic
+              title={<Text type="secondary" style={{ fontSize: 12 }}>总会话</Text>}
+              value={stats.total_sessions}
+              prefix={<TeamOutlined />}
+              valueStyle={{ fontSize: 20 }}
+            />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card size="small" style={{ textAlign: 'center' }}>
+            <Statistic
+              title={<Text type="secondary" style={{ fontSize: 12 }}>活跃会话</Text>}
+              value={stats.active_sessions}
+              prefix={<ClockCircleOutlined />}
+              valueStyle={{ fontSize: 20, color: '#52c41a' }}
+            />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card size="small" style={{ textAlign: 'center' }}>
+            <Statistic
+              title={<Text type="secondary" style={{ fontSize: 12 }}>今日新增</Text>}
+              value={stats.today_sessions}
+              prefix={<ThunderboltOutlined />}
+              valueStyle={{ fontSize: 20, color: '#faad14' }}
+            />
+          </Card>
+        </Col>
+        <Col span={6}>
+          <Card size="small" style={{ textAlign: 'center' }}>
+            <Statistic
+              title={<Text type="secondary" style={{ fontSize: 12 }}>总 Token</Text>}
+              value={formatTokens(stats.total_input_tokens + stats.total_output_tokens)}
+              prefix={<ApiOutlined />}
+              valueStyle={{ fontSize: 20, color: '#1677ff' }}
+            />
+          </Card>
+        </Col>
+      </Row>
+      {/* Source breakdown */}
+      {sourceEntries.length > 0 && (
+        <div style={{ marginBottom: 12, display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
+          <FilterOutlined style={{ color: 'var(--color-text-secondary)' }} />
+          <Text type="secondary" style={{ fontSize: 12 }}>工具分布：</Text>
+          {sourceEntries.map(([source, count]) => {
+            const cfg = sourceConfig[source] || { label: source, color: '#6b7280' };
+            return (
+              <Tag key={source} color={cfg.color} style={{ fontSize: 11, margin: 0 }}>
+                {cfg.label} {count}
+              </Tag>
+            );
+          })}
+        </div>
+      )}
+    </>
   );
 }
 
@@ -164,7 +193,12 @@ function SessionDetailDrawer({
 
   return (
     <Drawer
-      title={detail ? `Session ${shortId(detail.info.session_id)}` : 'Session 详情'}
+      title={detail ? (
+        <Space>
+          {sourceTag(detail.info.source)}
+          <span>Session {shortId(detail.info.session_id)}</span>
+        </Space>
+      ) : 'Session 详情'}
       open={open}
       onClose={onClose}
       width={680}
@@ -176,13 +210,14 @@ function SessionDetailDrawer({
             {/* Meta Info */}
             <Card size="small" title="基本信息" style={{ marginBottom: 16 }}>
               <Row gutter={[16, 8]}>
-                <Col span={12}><Text type="secondary">项目：</Text><Text>{detail.info.project_path}</Text></Col>
+                <Col span={12}><Text type="secondary">工具：</Text>{sourceTag(detail.info.source)}</Col>
                 <Col span={12}><Text type="secondary">状态：</Text>
                   <Tag color={detail.info.status === 'active' ? 'green' : 'default'}>
                     {detail.info.status === 'active' ? '活跃' : '已完成'}
                   </Tag>
                 </Col>
-                <Col span={12}><Text type="secondary">执行器：</Text>{executorTag(detail.info.executor)}</Col>
+                <Col span={12}><Text type="secondary">项目：</Text><Text>{detail.info.project_path}</Text></Col>
+                <Col span={12}><Text type="secondary">执行器：</Text><Text>{detail.info.executor}</Text></Col>
                 <Col span={12}><Text type="secondary">模型：</Text><Text code>{detail.info.model}</Text></Col>
                 <Col span={12}><Text type="secondary">Git 分支：</Text><Text code>{detail.info.git_branch || '-'}</Text></Col>
                 <Col span={12}><Text type="secondary">版本：</Text><Text code>{detail.info.version || '-'}</Text></Col>
@@ -297,7 +332,7 @@ export function SessionManager() {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
   const [statusFilter, setStatusFilter] = useState<string | undefined>();
-  const [executorFilter, setExecutorFilter] = useState<string | undefined>();
+  const [sourceFilter, setSourceFilter] = useState<string | undefined>();
   const [searchText, setSearchText] = useState('');
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -309,7 +344,7 @@ export function SessionManager() {
         page,
         page_size: pageSize,
         status: statusFilter,
-        executor: executorFilter,
+        source: sourceFilter,
         search: searchText || undefined,
       });
       setSessions(res.sessions);
@@ -319,7 +354,7 @@ export function SessionManager() {
     } finally {
       setLoading(false);
     }
-  }, [page, pageSize, statusFilter, executorFilter, searchText]);
+  }, [page, pageSize, statusFilter, sourceFilter, searchText]);
 
   const fetchStats = useCallback(async () => {
     try {
@@ -349,16 +384,19 @@ export function SessionManager() {
     }
   };
 
-  // Extract unique executors from stats
-  const executorOptions = stats
-    ? Object.keys(stats.by_executor).map((e) => ({ label: e, value: e }))
+  // Source filter options from stats
+  const sourceOptions = stats
+    ? Object.keys(stats.by_source).map((s) => {
+        const cfg = sourceConfig[s] || { label: s };
+        return { label: `${cfg.label} (${stats.by_source[s]})`, value: s };
+      })
     : [];
 
   const columns = [
     {
       title: '状态',
       dataIndex: 'status',
-      width: 70,
+      width: 60,
       render: (s: string) => (
         <Tooltip title={s === 'active' ? '活跃' : '已完成'}>
           <span
@@ -375,6 +413,12 @@ export function SessionManager() {
       ),
     },
     {
+      title: '工具',
+      dataIndex: 'source',
+      width: 120,
+      render: (source: string) => sourceTag(source),
+    },
+    {
       title: 'Session ID',
       dataIndex: 'session_id',
       width: 130,
@@ -387,7 +431,7 @@ export function SessionManager() {
     {
       title: '项目',
       dataIndex: 'project_path',
-      width: 200,
+      width: 180,
       ellipsis: true,
       render: (p: string) => {
         const short = p.split('/').slice(-2).join('/');
@@ -395,41 +439,39 @@ export function SessionManager() {
       },
     },
     {
-      title: '执行器',
-      dataIndex: 'executor',
-      width: 100,
-      render: (e: string) => executorTag(e),
-    },
-    {
       title: '模型',
       dataIndex: 'model',
-      width: 100,
+      width: 90,
       ellipsis: true,
       render: (m: string) => <Text style={{ fontSize: 12 }}>{m}</Text>,
     },
     {
       title: '分支',
       dataIndex: 'git_branch',
-      width: 90,
+      width: 85,
       ellipsis: true,
       render: (b: string | null) => b ? <Tag style={{ fontSize: 11 }}>{b}</Tag> : <Text type="secondary">-</Text>,
     },
     {
       title: '消息',
       dataIndex: 'message_count',
-      width: 60,
+      width: 55,
       align: 'center' as const,
       render: (n: number) => <Text style={{ fontSize: 12 }}>{n}</Text>,
     },
     {
       title: 'Token',
-      width: 80,
+      width: 75,
       align: 'right' as const,
-      render: (_: unknown, r: SessionInfo) => (
-        <Tooltip title={`输入: ${formatTokens(r.total_input_tokens)} / 输出: ${formatTokens(r.total_output_tokens)}`}>
-          <Text style={{ fontSize: 12 }}>{formatTokens(r.total_input_tokens + r.total_output_tokens)}</Text>
-        </Tooltip>
-      ),
+      render: (_: unknown, r: SessionInfo) => {
+        const total = r.total_input_tokens + r.total_output_tokens;
+        if (total === 0) return <Text type="secondary" style={{ fontSize: 12 }}>-</Text>;
+        return (
+          <Tooltip title={`输入: ${formatTokens(r.total_input_tokens)} / 输出: ${formatTokens(r.total_output_tokens)}`}>
+            <Text style={{ fontSize: 12 }}>{formatTokens(total)}</Text>
+          </Tooltip>
+        );
+      },
     },
     {
       title: '首条 Prompt',
@@ -442,7 +484,7 @@ export function SessionManager() {
     {
       title: '最后活跃',
       dataIndex: 'last_active_at',
-      width: 120,
+      width: 110,
       render: (t: string | null) => (
         <Tooltip title={t || ''}>
           <Text style={{ fontSize: 12 }}>{formatTime(t)}</Text>
@@ -450,15 +492,8 @@ export function SessionManager() {
       ),
     },
     {
-      title: '大小',
-      dataIndex: 'file_size',
-      width: 70,
-      align: 'right' as const,
-      render: (s: number) => <Text type="secondary" style={{ fontSize: 11 }}>{formatBytes(s)}</Text>,
-    },
-    {
       title: '操作',
-      width: 80,
+      width: 70,
       fixed: 'right' as const,
       render: (_: unknown, r: SessionInfo) => (
         <Space size={4}>
@@ -466,16 +501,16 @@ export function SessionManager() {
             type="text"
             size="small"
             icon={<EyeOutlined />}
-            onClick={() => { setSelectedSessionId(r.session_id); setDrawerOpen(true); }}
+            onClick={(e) => { e.stopPropagation(); setSelectedSessionId(r.session_id); setDrawerOpen(true); }}
           />
           <Popconfirm
             title="确定删除该 Session？"
-            description="将删除会话的 JSONL 文件和子代理数据"
-            onConfirm={() => handleDelete(r.session_id)}
+            description="将删除会话文件数据（不可恢复）"
+            onConfirm={(e) => { e?.stopPropagation(); handleDelete(r.session_id); }}
             okText="删除"
             cancelText="取消"
           >
-            <Button type="text" size="small" danger icon={<DeleteOutlined />} />
+            <Button type="text" size="small" danger icon={<DeleteOutlined />} onClick={(e) => e.stopPropagation()} />
           </Popconfirm>
         </Space>
       ),
@@ -493,27 +528,27 @@ export function SessionManager() {
           prefix={<SearchOutlined />}
           value={searchText}
           onChange={(e) => { setSearchText(e.target.value); setPage(1); }}
-          style={{ width: 240 }}
+          style={{ width: 220 }}
           allowClear
+        />
+        <Select
+          placeholder="工具来源"
+          value={sourceFilter}
+          onChange={(v) => { setSourceFilter(v); setPage(1); }}
+          style={{ width: 170 }}
+          allowClear
+          options={sourceOptions}
         />
         <Select
           placeholder="状态"
           value={statusFilter}
           onChange={(v) => { setStatusFilter(v); setPage(1); }}
-          style={{ width: 120 }}
+          style={{ width: 110 }}
           allowClear
           options={[
             { label: '活跃', value: 'active' },
             { label: '已完成', value: 'completed' },
           ]}
-        />
-        <Select
-          placeholder="执行器"
-          value={executorFilter}
-          onChange={(v) => { setExecutorFilter(v); setPage(1); }}
-          style={{ width: 140 }}
-          allowClear
-          options={executorOptions}
         />
         <Button icon={<ReloadOutlined />} onClick={() => { fetchSessions(); fetchStats(); }}>
           刷新
@@ -527,7 +562,7 @@ export function SessionManager() {
         rowKey="session_id"
         loading={loading}
         size="small"
-        scroll={{ x: 1200 }}
+        scroll={{ x: 1300 }}
         pagination={{
           current: page,
           pageSize,

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -871,6 +871,27 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                           (e.target as HTMLInputElement).blur();
                         }}
                       />
+                      <Input
+                        style={{ flex: 1, minWidth: 180 }}
+                        placeholder="Session 目录（如 ~/.claude）"
+                        defaultValue={ec.session_dir}
+                        onBlur={async (e) => {
+                          const newDir = e.target.value.trim();
+                          if (newDir === ec.session_dir) return;
+                          setSavingExecutor(ec.name);
+                          try {
+                            const updated = await db.updateExecutor(ec.name, { session_dir: newDir });
+                            setExecutors((prev) => prev.map((ex) => ex.name === ec.name ? updated : ex));
+                          } catch (err: any) {
+                            message.error('保存失败: ' + (err?.message || String(err)));
+                          } finally {
+                            setSavingExecutor(null);
+                          }
+                        }}
+                        onPressEnter={(e) => {
+                          (e.target as HTMLInputElement).blur();
+                        }}
+                      />
                       <Button
                         size="small"
                         icon={<SearchOutlined />}

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -47,6 +47,7 @@ import {
   PlayCircleOutlined,
   StopOutlined,
   SearchOutlined,
+  LaptopOutlined,
 } from '@ant-design/icons';
 import { Cron } from 'react-js-cron';
 import QRCode from 'qrcode';
@@ -59,6 +60,7 @@ import type { Config, ExecutorConfig, FeishuHistoryMessage, FeishuHistoryChat, S
 import yaml from 'js-yaml';
 import { CronPresetSelect } from './CronPresetSelect';
 import { SkillsPanel } from './SkillsPanel';
+import { SessionManager } from './SessionManager';
 
 const { Paragraph } = Typography;
 const { Dragger } = Upload;
@@ -2166,6 +2168,16 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
           ]}
         />
       ),
+    },
+    {
+      key: 'sessions',
+      label: (
+        <span>
+          <LaptopOutlined style={{ marginRight: 6 }} />
+          Session 管理
+        </span>
+      ),
+      children: <SessionManager />,
     },
     {
       key: 'about',

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -244,6 +244,7 @@ export interface ExecutorConfig {
   path: string;
   enabled: boolean;
   display_name: string;
+  session_dir: string;
   created_at: string | null;
   updated_at: string | null;
 }

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -241,7 +241,7 @@ export async function getExecutors(): Promise<import('../types').ExecutorConfig[
   return unwrap(await api.get<ApiResp<import('../types').ExecutorConfig[]>>('/xyz/executors'));
 }
 
-export async function updateExecutor(name: string, data: { path?: string; enabled?: boolean; display_name?: string }): Promise<import('../types').ExecutorConfig> {
+export async function updateExecutor(name: string, data: { path?: string; enabled?: boolean; display_name?: string; session_dir?: string }): Promise<import('../types').ExecutorConfig> {
   return unwrap(await api.put<ApiResp<import('../types').ExecutorConfig>>(`/xyz/executors/${encodeURIComponent(name)}`, data));
 }
 

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -519,3 +519,85 @@ export async function addGroupWhitelist(botId: number, senderOpenId: string, sen
 export async function deleteGroupWhitelist(id: number): Promise<void> {
   await api.delete(`/xyz/agent-bots/feishu/group-whitelist/${id}`);
 }
+
+// ─── Session APIs ──────────────────────────────────────────
+
+export interface SessionInfo {
+  session_id: string;
+  project_path: string;
+  status: string;
+  executor: string;
+  model: string;
+  git_branch: string | null;
+  message_count: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  first_prompt: string | null;
+  created_at: string | null;
+  last_active_at: string | null;
+  file_size: number;
+  version: string | null;
+  subagent_count: number;
+}
+
+export interface SessionListResponse {
+  sessions: SessionInfo[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+export interface SessionStats {
+  total_sessions: number;
+  active_sessions: number;
+  today_sessions: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  by_executor: Record<string, number>;
+  by_project: Record<string, number>;
+}
+
+export interface SessionMessage {
+  role: string;
+  content_preview: string;
+  model: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  timestamp: string | null;
+  stop_reason: string | null;
+}
+
+export interface SubAgentInfo {
+  agent_type: string;
+  description: string;
+  message_count: number;
+}
+
+export interface SessionDetail {
+  info: SessionInfo;
+  messages: SessionMessage[];
+  subagents: SubAgentInfo[];
+}
+
+export async function listSessions(params: {
+  page?: number;
+  page_size?: number;
+  status?: string;
+  executor?: string;
+  project?: string;
+  search?: string;
+}): Promise<SessionListResponse> {
+  return unwrap(await api.get<ApiResp<SessionListResponse>>('/xyz/sessions', { params }));
+}
+
+export async function getSessionStats(): Promise<SessionStats> {
+  return unwrap(await api.get<ApiResp<SessionStats>>('/xyz/sessions/stats'));
+}
+
+export async function getSessionDetail(sessionId: string): Promise<SessionDetail> {
+  return unwrap(await api.get<ApiResp<SessionDetail>>(`/xyz/sessions/${sessionId}`));
+}
+
+export async function deleteSession(sessionId: string): Promise<void> {
+  await api.delete(`/xyz/sessions/${sessionId}`);
+}

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -524,6 +524,7 @@ export async function deleteGroupWhitelist(id: number): Promise<void> {
 
 export interface SessionInfo {
   session_id: string;
+  source: string;
   project_path: string;
   status: string;
   executor: string;
@@ -553,6 +554,7 @@ export interface SessionStats {
   today_sessions: number;
   total_input_tokens: number;
   total_output_tokens: number;
+  by_source: Record<string, number>;
   by_executor: Record<string, number>;
   by_project: Record<string, number>;
 }
@@ -583,6 +585,7 @@ export async function listSessions(params: {
   page?: number;
   page_size?: number;
   status?: string;
+  source?: string;
   executor?: string;
   project?: string;
   search?: string;


### PR DESCRIPTION
## Summary
- 在设置页新增「Session 管理」标签页，支持浏览 AI 编码工具的会话记录
- 后端 API：列表（分页/过滤）、详情、统计、删除
- 前端组件：统计卡片 + 数据表格 + 详情 Drawer + 过滤搜索
- 当前仅支持 Claude Code 会话，后续将扩展支持更多执行器

## Test plan
- [x] 后端编译通过
- [x] API 接口测试通过（列表/详情/统计/删除）
- [x] Playwright 前端 UI 验证通过
- [x] 统计卡片、表格、Drawer 详情均正常显示