### PR TITLE
[codex] Improve settings page styling

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1820,6 +1820,152 @@ code {
   color: var(--color-text-secondary);
 }
 
+/* ---------- Settings Page ---------- */
+.settings-page-root {
+  padding: var(--space-xl);
+}
+
+.settings-header-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: var(--space-lg);
+}
+
+.settings-header-card .ant-typography {
+  color: var(--color-text-secondary);
+}
+
+.settings-tabs > .ant-tabs-nav {
+  margin-bottom: 0;
+}
+
+.settings-tabs > .ant-tabs-nav::before {
+  border-color: var(--color-border-light);
+}
+
+.settings-tabs.ant-tabs-card > .ant-tabs-nav .ant-tabs-tab {
+  border-color: var(--color-border-light);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-secondary);
+  transition: all var(--transition-fast);
+}
+
+.settings-tabs.ant-tabs-card > .ant-tabs-nav .ant-tabs-tab:hover {
+  color: var(--color-text);
+  border-color: var(--color-primary);
+  background: var(--color-primary-bg);
+}
+
+.settings-tabs.ant-tabs-card > .ant-tabs-nav .ant-tabs-tab-active {
+  border-color: var(--color-primary);
+  background: var(--color-primary-bg);
+  box-shadow: var(--shadow-primary);
+}
+
+.settings-tabs.ant-tabs-card > .ant-tabs-nav .ant-tabs-tab-active .ant-tabs-tab-btn {
+  color: var(--color-primary);
+  font-weight: 700;
+}
+
+.settings-tabs > .ant-tabs-content-holder {
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-light);
+  border-top: 0;
+  border-radius: 0 var(--radius-md) var(--radius-md) var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  min-height: 0;
+}
+
+.settings-tabs > .ant-tabs-content-holder > .ant-tabs-content > .ant-tabs-tabpane {
+  padding: var(--space-xl);
+}
+
+.settings-page-root .ant-card {
+  background: var(--color-bg-elevated);
+  border-color: var(--color-border-light);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+
+.settings-page-root .ant-card-head {
+  min-height: 42px;
+  border-color: var(--color-border-light);
+}
+
+.settings-page-root .ant-card-head-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.settings-page-root .ant-card-body {
+  color: var(--color-text);
+}
+
+.settings-page-root .ant-form-item-label > label {
+  color: var(--color-text-secondary);
+  font-size: 13px;
+}
+
+.settings-page-root .ant-form-item-required::before {
+  color: var(--color-error) !important;
+}
+
+.settings-page-root .ant-input,
+.settings-page-root .ant-input-number,
+.settings-page-root .ant-input-affix-wrapper,
+.settings-page-root .ant-select-selector,
+.settings-page-root .ant-picker {
+  background: var(--color-bg-elevated) !important;
+  border-color: var(--color-border) !important;
+  color: var(--color-text) !important;
+  box-shadow: none !important;
+}
+
+.settings-page-root .ant-input:hover,
+.settings-page-root .ant-input-number:hover,
+.settings-page-root .ant-input-affix-wrapper:hover,
+.settings-page-root .ant-select-selector:hover,
+.settings-page-root .ant-picker:hover {
+  border-color: var(--color-primary) !important;
+}
+
+.settings-page-root .ant-input:focus,
+.settings-page-root .ant-input-number-focused,
+.settings-page-root .ant-input-affix-wrapper-focused,
+.settings-page-root .ant-select-focused .ant-select-selector,
+.settings-page-root .ant-picker-focused {
+  border-color: var(--color-primary) !important;
+  box-shadow: 0 0 0 2px rgba(8, 145, 178, 0.18) !important;
+}
+
+.settings-page-root .ant-table-wrapper,
+.settings-page-root .ant-list {
+  color: var(--color-text);
+}
+
+.settings-page-root .ant-table {
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.settings-page-root .ant-table-thead > tr > th {
+  background: var(--color-bg-hover, var(--color-border-light));
+  border-color: var(--color-border-light);
+  color: var(--color-text-secondary);
+  font-size: 12px;
+}
+
+.settings-page-root .ant-table-tbody > tr > td {
+  border-color: var(--color-border-light);
+}
+
+.settings-page-root .ant-table-tbody > tr:hover > td {
+  background: var(--color-primary-bg);
+}
+
 /* ---------- Settings Page Mobile Responsive ---------- */
 @media (max-width: 767px) {
   .settings-page-root {

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -2247,15 +2247,13 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
 
   return (
     <div
-      className="settings-page-root"
+      className="settings-page-root detail-panel"
       style={{
         height: '100%',
         overflowY: 'auto',
-        padding: '24px 32px',
-        background: 'var(--color-bg-layout, #f8fafc)',
       }}
     >
-      <div style={{ marginBottom: 24, display: 'flex', alignItems: 'center', gap: 12 }}>
+      <div className="settings-header-card detail-card header-card">
         {onBack && (
           <button
             onClick={onBack}
@@ -2276,13 +2274,13 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
           </button>
         )}
         <div style={{ minWidth: 0 }}>
-          <h2 style={{ margin: 0, fontSize: 22, fontWeight: 700 }}>配置管理</h2>
+          <h2 className="card-title">配置管理</h2>
           <Paragraph type="secondary" style={{ marginTop: 4, fontSize: 13 }}>
             管理系统配置、执行器路径、标签、备份和消息智能体
           </Paragraph>
         </div>
       </div>
-      <Tabs items={tabItems} type="card" size="small" />
+      <Tabs className="settings-tabs" items={tabItems} type="card" size="small" />
 
       <Modal
         title="导入预览"

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useApp } from '../hooks/useApp';
 import { Button, Empty, Tooltip } from 'antd';
-import { PlusOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, SettingOutlined, SunOutlined, MoonOutlined, DesktopOutlined } from '@ant-design/icons';
+import { PlusOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, SettingOutlined, SunOutlined, MoonOutlined } from '@ant-design/icons';
 import { useTheme } from '../hooks/useTheme';
 import { StatusPicker } from './StatusPicker';
 import * as db from '../utils/database';
@@ -85,11 +85,11 @@ export function TodoList({ onOpenCreateModal, onSelectTodo, onShowDashboard, onS
             className="tag-btn"
             aria-label="查看仪表盘"
           />
-          <Tooltip title={themeMode === 'light' ? '切换暗色主题' : themeMode === 'dark' ? '切换自动主题' : '切换亮色主题'}>
+          <Tooltip title={themeMode === 'light' ? '切换暗色主题' : '切换亮色主题'}>
             <Button
               type="text"
               size="small"
-              icon={themeMode === 'light' ? <MoonOutlined /> : themeMode === 'dark' ? <DesktopOutlined /> : <SunOutlined />}
+              icon={themeMode === 'light' ? <MoonOutlined /> : <SunOutlined />}
               onClick={toggleTheme}
               className="tag-btn"
               aria-label="切换主题"

--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -16,37 +16,17 @@ const STORAGE_KEY = 'app_theme';
 function getInitialTheme(): ThemeMode {
   try {
     const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved === 'dark' || saved === 'light' || saved === 'auto') return saved;
+    if (saved === 'dark' || saved === 'light') return saved;
   } catch {}
-  return 'auto';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [themeMode, setThemeMode] = useState<ThemeMode>(getInitialTheme);
 
-  // 计算解析后的主题（auto 模式根据系统偏好）
-  const getResolvedTheme = (mode: ThemeMode): 'light' | 'dark' => {
-    if (mode === 'auto') {
-      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
-    return mode;
-  };
-
-  const resolvedTheme = getResolvedTheme(themeMode);
-
   useLayoutEffect(() => {
-    document.documentElement.setAttribute('data-theme', resolvedTheme);
-
-    // 监听系统主题变化，当处于 auto 模式时自动更新
-    if (themeMode === 'auto') {
-      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-      const handler = (e: MediaQueryListEvent) => {
-        document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
-      };
-      mediaQuery.addEventListener('change', handler);
-      return () => mediaQuery.removeEventListener('change', handler);
-    }
-  }, [themeMode, resolvedTheme]);
+    document.documentElement.setAttribute('data-theme', themeMode);
+  }, [themeMode]);
 
   useLayoutEffect(() => {
     try {
@@ -55,14 +35,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   }, [themeMode]);
 
   const toggleTheme = () => {
-    setThemeMode(prev => {
-      if (prev === 'light') return 'dark';
-      if (prev === 'dark') return 'auto';
-      return 'light';
-    });
+    setThemeMode(prev => (prev === 'light' ? 'dark' : 'light'));
   };
 
-  const themeConfig = themeMap[resolvedTheme];
+  const themeConfig = themeMap[themeMode];
 
   return (
     <ThemeContext.Provider value={{ themeMode, themeConfig, toggleTheme }}>

--- a/frontend/src/themes/index.ts
+++ b/frontend/src/themes/index.ts
@@ -194,10 +194,9 @@ export const darkTheme: ThemeConfig = {
 export const darkPalette = catppuccinMocha;
 export const darkAccent = cyanAccent;
 
-export type ThemeMode = 'light' | 'dark' | 'auto';
+export type ThemeMode = 'light' | 'dark';
 
 export const themeMap: Record<ThemeMode, ThemeConfig> = {
   light: lightTheme,
   dark: darkTheme,
-  auto: lightTheme, // auto 使用 lightTheme 作为默认值，实际主题由 CSS media query 控制
 };


### PR DESCRIPTION
## Summary

- Restyle the settings page to match the Todo detail panel visual language.
- Scope settings-page styles for tabs, cards, forms, and tables without changing business logic.
- Simplify theme switching from light/dark/auto to light/dark only.

## Validation

- npm run build
- Local Vite render check for the settings page shell and tab container