### PR TITLE
feat: 项目目录管理功能

### DIFF
--- a/backend/src/db/entity/mod.rs
+++ b/backend/src/db/entity/mod.rs
@@ -7,6 +7,7 @@ pub mod feishu_messages;
 pub mod feishu_push_targets;
 pub mod feishu_response_config;
 pub mod feishu_group_whitelist;
+pub mod project_directories;
 pub mod tags;
 pub mod todo_tags;
 pub mod todos;
@@ -21,6 +22,7 @@ pub mod prelude {
     pub use super::feishu_push_targets::Entity as FeishuPushTargets;
     pub use super::feishu_response_config::Entity as FeishuResponseConfig;
     pub use super::feishu_group_whitelist::Entity as FeishuGroupWhitelist;
+    pub use super::project_directories::Entity as ProjectDirectories;
     pub use super::tags::Entity as Tags;
     pub use super::todo_tags::Entity as TodoTags;
     pub use super::todos::Entity as Todos;

--- a/backend/src/db/entity/project_directories.rs
+++ b/backend/src/db/entity/project_directories.rs
@@ -1,0 +1,19 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "project_directories")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    #[sea_orm(unique)]
+    pub path: String,
+    pub name: Option<String>,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -468,6 +468,39 @@ impl Database {
             .exec("ALTER TABLE executors ADD COLUMN session_dir TEXT NOT NULL DEFAULT ''")
             .await;
 
+        // Project directories table
+        self.exec(
+            "CREATE TABLE IF NOT EXISTS project_directories (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                path TEXT NOT NULL UNIQUE,
+                name TEXT,
+                created_at TEXT,
+                updated_at TEXT
+            )",
+        )
+        .await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_project_directories_path ON project_directories(path)")
+            .await?;
+
+        // Project directories timestamps triggers
+        self.exec(
+            "CREATE TRIGGER IF NOT EXISTS set_project_directories_created_at_utc AFTER INSERT ON project_directories
+             WHEN new.created_at IS NULL OR new.created_at = ''
+             BEGIN
+                 UPDATE project_directories SET created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', 'utc') WHERE rowid = new.rowid;
+             END",
+        )
+        .await?;
+
+        self.exec(
+            "CREATE TRIGGER IF NOT EXISTS set_project_directories_updated_at_utc BEFORE UPDATE ON project_directories
+             WHEN new.updated_at IS NULL OR new.updated_at = ''
+             BEGIN
+                 SELECT raise(IGNORE);
+             END",
+        )
+        .await?;
+
         // Executors timestamps triggers
         self.exec(
             "CREATE TRIGGER IF NOT EXISTS set_executors_created_at_utc AFTER INSERT ON executors
@@ -506,6 +539,7 @@ mod feishu_group_whitelist;
 mod feishu_history_chat;
 mod feishu_push_target;
 mod feishu_response_config;
+pub mod project_directory;
 
 #[cfg(test)]
 mod tests {

--- a/backend/src/db/project_directory.rs
+++ b/backend/src/db/project_directory.rs
@@ -1,0 +1,109 @@
+use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+use serde::{Deserialize, Serialize};
+
+use crate::db::entity::project_directories;
+use crate::db::Database;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectDirectory {
+    pub id: i64,
+    pub path: String,
+    pub name: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl Database {
+    pub async fn get_project_directories(&self) -> Result<Vec<ProjectDirectory>, sea_orm::DbErr> {
+        let models = project_directories::Entity::find()
+            .order_by_asc(project_directories::Column::Path)
+            .all(&self.conn)
+            .await?;
+
+        Ok(models
+            .into_iter()
+            .map(|m| ProjectDirectory {
+                id: m.id,
+                path: m.path,
+                name: m.name,
+                created_at: m.created_at.unwrap_or_default(),
+                updated_at: m.updated_at.unwrap_or_default(),
+            })
+            .collect())
+    }
+
+    pub async fn create_project_directory(
+        &self,
+        path: &str,
+        name: Option<&str>,
+    ) -> Result<i64, sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+        let am = project_directories::ActiveModel {
+            path: ActiveValue::Set(path.to_string()),
+            name: ActiveValue::Set(name.map(|s| s.to_string())),
+            created_at: ActiveValue::Set(Some(now.clone())),
+            updated_at: ActiveValue::Set(Some(now)),
+            ..Default::default()
+        };
+        let inserted = am.insert(&self.conn).await?;
+        Ok(inserted.id)
+    }
+
+    pub async fn update_project_directory(
+        &self,
+        id: i64,
+        name: Option<&str>,
+    ) -> Result<(), sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+        let am = project_directories::ActiveModel {
+            id: ActiveValue::Unchanged(id),
+            name: ActiveValue::Set(name.map(|s| s.to_string())),
+            updated_at: ActiveValue::Set(Some(now)),
+            ..Default::default()
+        };
+        self.exec_update(am).await
+    }
+
+    pub async fn delete_project_directory(&self, id: i64) -> Result<(), sea_orm::DbErr> {
+        project_directories::Entity::delete_by_id(id)
+            .exec(&self.conn)
+            .await
+            .map(|_| ())
+    }
+
+    pub async fn get_project_directory_by_path(
+        &self,
+        path: &str,
+    ) -> Result<Option<ProjectDirectory>, sea_orm::DbErr> {
+        let model = project_directories::Entity::find()
+            .filter(project_directories::Column::Path.eq(path))
+            .one(&self.conn)
+            .await?;
+
+        Ok(model.map(|m| ProjectDirectory {
+            id: m.id,
+            path: m.path,
+            name: m.name,
+            created_at: m.created_at.unwrap_or_default(),
+            updated_at: m.updated_at.unwrap_or_default(),
+        }))
+    }
+
+    /// 如果目录不存在则创建，返回目录信息
+    pub async fn get_or_create_project_directory(
+        &self,
+        path: &str,
+    ) -> Result<ProjectDirectory, sea_orm::DbErr> {
+        if let Some(existing) = self.get_project_directory_by_path(path).await? {
+            return Ok(existing);
+        }
+        let id = self.create_project_directory(path, None).await?;
+        Ok(ProjectDirectory {
+            id,
+            path: path.to_string(),
+            name: None,
+            created_at: crate::models::utc_timestamp(),
+            updated_at: crate::models::utc_timestamp(),
+        })
+    }
+}

--- a/backend/src/db/project_directory.rs
+++ b/backend/src/db/project_directory.rs
@@ -9,8 +9,8 @@ pub struct ProjectDirectory {
     pub id: i64,
     pub path: String,
     pub name: Option<String>,
-    pub created_at: String,
-    pub updated_at: String,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
 }
 
 impl Database {
@@ -26,8 +26,8 @@ impl Database {
                 id: m.id,
                 path: m.path,
                 name: m.name,
-                created_at: m.created_at.unwrap_or_default(),
-                updated_at: m.updated_at.unwrap_or_default(),
+                created_at: m.created_at,
+                updated_at: m.updated_at,
             })
             .collect())
     }
@@ -84,8 +84,25 @@ impl Database {
             id: m.id,
             path: m.path,
             name: m.name,
-            created_at: m.created_at.unwrap_or_default(),
-            updated_at: m.updated_at.unwrap_or_default(),
+            created_at: m.created_at,
+            updated_at: m.updated_at,
+        }))
+    }
+
+    pub async fn get_project_directory_by_id(
+        &self,
+        id: i64,
+    ) -> Result<Option<ProjectDirectory>, sea_orm::DbErr> {
+        let model = project_directories::Entity::find_by_id(id)
+            .one(&self.conn)
+            .await?;
+
+        Ok(model.map(|m| ProjectDirectory {
+            id: m.id,
+            path: m.path,
+            name: m.name,
+            created_at: m.created_at,
+            updated_at: m.updated_at,
         }))
     }
 
@@ -98,12 +115,9 @@ impl Database {
             return Ok(existing);
         }
         let id = self.create_project_directory(path, None).await?;
-        Ok(ProjectDirectory {
-            id,
-            path: path.to_string(),
-            name: None,
-            created_at: crate::models::utc_timestamp(),
-            updated_at: crate::models::utc_timestamp(),
-        })
+        // 从数据库重新查询以获取准确的时间戳
+        self.get_project_directory_by_id(id)
+            .await?
+            .ok_or_else(|| sea_orm::DbErr::Custom("Failed to retrieve created directory".into()))
     }
 }

--- a/backend/src/db/project_directory.rs
+++ b/backend/src/db/project_directory.rs
@@ -107,6 +107,7 @@ impl Database {
     }
 
     /// 如果目录不存在则创建，返回目录信息
+    /// 处理并发竞态：捕获唯一约束冲突并重试查询
     pub async fn get_or_create_project_directory(
         &self,
         path: &str,
@@ -114,10 +115,29 @@ impl Database {
         if let Some(existing) = self.get_project_directory_by_path(path).await? {
             return Ok(existing);
         }
-        let id = self.create_project_directory(path, None).await?;
-        // 从数据库重新查询以获取准确的时间戳
-        self.get_project_directory_by_id(id)
-            .await?
-            .ok_or_else(|| sea_orm::DbErr::Custom("Failed to retrieve created directory".into()))
+
+        match self.create_project_directory(path, None).await {
+            Ok(id) => {
+                // 创建成功后从数据库查询以获取准确的时间戳
+                self.get_project_directory_by_id(id)
+                    .await?
+                    .ok_or_else(|| sea_orm::DbErr::Custom("Failed to retrieve created directory".into()))
+            }
+            Err(e) => {
+                // 如果是唯一约束冲突，说明另一个请求已经创建了该目录，重试查询
+                if is_unique_constraint_error(&e) {
+                    self.get_project_directory_by_path(path)
+                        .await?
+                        .ok_or_else(|| sea_orm::DbErr::Custom("Directory disappeared after conflict".into()))
+                } else {
+                    Err(e)
+                }
+            }
+        }
     }
+}
+
+fn is_unique_constraint_error(err: &sea_orm::DbErr) -> bool {
+    let err_str = format!("{:?}", err);
+    err_str.contains("UNIQUE constraint failed")
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -152,6 +152,7 @@ pub mod agent_bot;
 pub mod executor_config;
 mod feishu_history;
 mod session;
+pub mod project_directory;
 
 // WebSocket handler
 pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
@@ -434,6 +435,7 @@ pub fn create_app(
         .route("/xyz/sessions", get(session::list_sessions))
         .route("/xyz/sessions/stats", get(session::get_session_stats))
         .route("/xyz/sessions/{id}", get(session::get_session_detail).delete(session::delete_session))
+        .merge(project_directory::routes())
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024)) // 10MB
         .layer(CompressionLayer::new())
         .layer(

--- a/backend/src/handlers/project_directory.rs
+++ b/backend/src/handlers/project_directory.rs
@@ -1,0 +1,80 @@
+use axum::extract::State;
+use axum::routing::{delete, get, post, put};
+use axum::Router;
+use serde::{Deserialize, Serialize};
+
+use super::{ApiJson, AppState};
+use crate::models::ApiResponse;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateProjectDirectoryRequest {
+    pub path: String,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateProjectDirectoryRequest {
+    pub name: Option<String>,
+}
+
+pub async fn list_project_directories(
+    State(state): State<AppState>,
+) -> ApiResponse<Vec<crate::db::project_directory::ProjectDirectory>> {
+    let directories = state.db.get_project_directories().await.unwrap_or_default();
+    ApiResponse::ok(directories)
+}
+
+pub async fn create_project_directory(
+    State(state): State<AppState>,
+    ApiJson(req): ApiJson<CreateProjectDirectoryRequest>,
+) -> ApiResponse<crate::db::project_directory::ProjectDirectory> {
+    if req.path.trim().is_empty() {
+        return ApiResponse::err(crate::models::codes::BAD_REQUEST, "Path is required");
+    }
+    // 检查是否已存在
+    if let Some(existing) = state.db.get_project_directory_by_path(&req.path).await.unwrap_or(None) {
+        return ApiResponse::ok(existing);
+    }
+    let id = state
+        .db
+        .create_project_directory(&req.path, req.name.as_deref())
+        .await
+        .unwrap_or(0);
+    let directory = crate::db::project_directory::ProjectDirectory {
+        id,
+        path: req.path,
+        name: req.name,
+        created_at: crate::models::utc_timestamp(),
+        updated_at: crate::models::utc_timestamp(),
+    };
+    ApiResponse::ok(directory)
+}
+
+pub async fn update_project_directory(
+    State(state): State<AppState>,
+    axum::extract::Path(id): axum::extract::Path<i64>,
+    ApiJson(req): ApiJson<UpdateProjectDirectoryRequest>,
+) -> ApiResponse<()> {
+    state
+        .db
+        .update_project_directory(id, req.name.as_deref())
+        .await
+        .ok();
+    ApiResponse::ok(())
+}
+
+pub async fn delete_project_directory(
+    State(state): State<AppState>,
+    axum::extract::Path(id): axum::extract::Path<i64>,
+) -> ApiResponse<()> {
+    state.db.delete_project_directory(id).await.ok();
+    ApiResponse::ok(())
+}
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/xyz/project-directories", get(list_project_directories))
+        .route("/xyz/project-directories", post(create_project_directory))
+        .route("/xyz/project-directories/{id}", put(update_project_directory))
+        .route("/xyz/project-directories/{id}", delete(delete_project_directory))
+}

--- a/backend/src/handlers/project_directory.rs
+++ b/backend/src/handlers/project_directory.rs
@@ -19,56 +19,43 @@ pub struct UpdateProjectDirectoryRequest {
 
 pub async fn list_project_directories(
     State(state): State<AppState>,
-) -> ApiResponse<Vec<crate::db::project_directory::ProjectDirectory>> {
-    let directories = state.db.get_project_directories().await.unwrap_or_default();
-    ApiResponse::ok(directories)
+) -> Result<ApiResponse<Vec<crate::db::project_directory::ProjectDirectory>>, super::AppError> {
+    let directories = state.db.get_project_directories().await?;
+    Ok(ApiResponse::ok(directories))
 }
 
 pub async fn create_project_directory(
     State(state): State<AppState>,
     ApiJson(req): ApiJson<CreateProjectDirectoryRequest>,
-) -> ApiResponse<crate::db::project_directory::ProjectDirectory> {
+) -> Result<ApiResponse<crate::db::project_directory::ProjectDirectory>, super::AppError> {
     if req.path.trim().is_empty() {
-        return ApiResponse::err(crate::models::codes::BAD_REQUEST, "Path is required");
+        return Ok(ApiResponse::err(crate::models::codes::BAD_REQUEST, "Path is required"));
     }
-    // 检查是否已存在
-    if let Some(existing) = state.db.get_project_directory_by_path(&req.path).await.unwrap_or(None) {
-        return ApiResponse::ok(existing);
-    }
-    let id = state
+    let directory = state
         .db
-        .create_project_directory(&req.path, req.name.as_deref())
-        .await
-        .unwrap_or(0);
-    let directory = crate::db::project_directory::ProjectDirectory {
-        id,
-        path: req.path,
-        name: req.name,
-        created_at: crate::models::utc_timestamp(),
-        updated_at: crate::models::utc_timestamp(),
-    };
-    ApiResponse::ok(directory)
+        .get_or_create_project_directory(&req.path)
+        .await?;
+    Ok(ApiResponse::ok(directory))
 }
 
 pub async fn update_project_directory(
     State(state): State<AppState>,
     axum::extract::Path(id): axum::extract::Path<i64>,
     ApiJson(req): ApiJson<UpdateProjectDirectoryRequest>,
-) -> ApiResponse<()> {
+) -> Result<ApiResponse<()>, super::AppError> {
     state
         .db
         .update_project_directory(id, req.name.as_deref())
-        .await
-        .ok();
-    ApiResponse::ok(())
+        .await?;
+    Ok(ApiResponse::ok(()))
 }
 
 pub async fn delete_project_directory(
     State(state): State<AppState>,
     axum::extract::Path(id): axum::extract::Path<i64>,
-) -> ApiResponse<()> {
-    state.db.delete_project_directory(id).await.ok();
-    ApiResponse::ok(())
+) -> Result<ApiResponse<()>, super::AppError> {
+    state.db.delete_project_directory(id).await?;
+    Ok(ApiResponse::ok(()))
 }
 
 pub fn routes() -> Router<AppState> {

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -48,13 +48,15 @@ import {
   StopOutlined,
   SearchOutlined,
   LaptopOutlined,
+  FolderOutlined,
+  EditOutlined,
 } from '@ant-design/icons';
 import { Cron } from 'react-js-cron';
 import QRCode from 'qrcode';
 import 'react-js-cron/dist/styles.css';
 import { useApp } from '../hooks/useApp';
 import * as db from '../utils/database';
-import type { FeishuPushStatus, WhitelistEntry } from '../utils/database';
+import type { FeishuPushStatus, WhitelistEntry, ProjectDirectory } from '../utils/database';
 import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '../utils/cron';
 import type { Config, ExecutorConfig, FeishuHistoryMessage, FeishuHistoryChat, SlashCommandRule, ExecutionRecord } from '../types';
 import yaml from 'js-yaml';
@@ -83,6 +85,15 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
   const [tagName, setTagName] = useState('');
   const [tagColor, setTagColor] = useState('#0891b2');
   const [tagCreating, setTagCreating] = useState(false);
+
+  // Project directories state
+  const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
+  const [projectDirsLoading, setProjectDirsLoading] = useState(false);
+  const [newDirPath, setNewDirPath] = useState('');
+  const [newDirName, setNewDirName] = useState('');
+  const [addingDir, setAddingDir] = useState(false);
+  const [editingDirId, setEditingDirId] = useState<number | null>(null);
+  const [editingDirName, setEditingDirName] = useState('');
 
   const [importing, setImporting] = useState(false);
 
@@ -497,6 +508,61 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       await db.deleteTag(tagId);
       dispatch({ type: 'DELETE_TAG', payload: tagId });
       message.success('标签已删除');
+    } catch (err: any) {
+      message.error('删除失败: ' + (err?.message || String(err)));
+    }
+  };
+
+  // Project directories handlers
+  const loadProjectDirectories = () => {
+    setProjectDirsLoading(true);
+    db.getProjectDirectories()
+      .then(setProjectDirectories)
+      .catch((err: any) => message.error('加载项目目录失败: ' + (err?.message || String(err))))
+      .finally(() => setProjectDirsLoading(false));
+  };
+
+  useEffect(() => {
+    loadProjectDirectories();
+  }, []);
+
+  const handleAddProjectDirectory = async () => {
+    const path = newDirPath.trim();
+    if (!path) {
+      message.error('请输入目录路径');
+      return;
+    }
+    setAddingDir(true);
+    try {
+      const dir = await db.createProjectDirectory(path, newDirName.trim() || undefined);
+      setProjectDirectories(prev => [...prev.filter(d => d.id !== dir.id), dir].sort((a, b) => a.path.localeCompare(b.path)));
+      setNewDirPath('');
+      setNewDirName('');
+      message.success('添加成功');
+    } catch (err: any) {
+      message.error('添加失败: ' + (err?.message || String(err)));
+    } finally {
+      setAddingDir(false);
+    }
+  };
+
+  const handleUpdateProjectDirectoryName = async (id: number) => {
+    try {
+      await db.updateProjectDirectory(id, editingDirName.trim() || undefined);
+      setProjectDirectories(prev => prev.map(d => d.id === id ? { ...d, name: editingDirName.trim() || null } : d));
+      setEditingDirId(null);
+      setEditingDirName('');
+      message.success('更新成功');
+    } catch (err: any) {
+      message.error('更新失败: ' + (err?.message || String(err)));
+    }
+  };
+
+  const handleDeleteProjectDirectory = async (id: number) => {
+    try {
+      await db.deleteProjectDirectory(id);
+      setProjectDirectories(prev => prev.filter(d => d.id !== id));
+      message.success('删除成功');
     } catch (err: any) {
       message.error('删除失败: ' + (err?.message || String(err)));
     }
@@ -1068,6 +1134,121 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
               )}
             />
           )}
+        </div>
+      ),
+    },
+    {
+      key: 'projectDirectories',
+      label: (
+        <span>
+          <FolderOutlined style={{ marginRight: 6 }} />
+          项目目录
+        </span>
+      ),
+      children: (
+        <div style={{ maxWidth: 700 }}>
+          <Spin spinning={projectDirsLoading}>
+            <Card title="添加项目目录" size="small" style={{ marginBottom: 24 }}>
+              <Space direction="vertical" style={{ width: '100%' }}>
+                <Paragraph type="secondary" style={{ fontSize: 13 }}>
+                  添加常用项目目录，方便在为 Todo 选择执行目录时快速点选。目录路径必填，名称选填。
+                </Paragraph>
+                <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+                  <Input
+                    value={newDirPath}
+                    onChange={(e) => setNewDirPath(e.target.value)}
+                    placeholder="目录路径（必填）"
+                    style={{ flex: 2 }}
+                    onPressEnter={handleAddProjectDirectory}
+                  />
+                  <Input
+                    value={newDirName}
+                    onChange={(e) => setNewDirName(e.target.value)}
+                    placeholder="名称（选填）"
+                    style={{ flex: 1 }}
+                    onPressEnter={handleAddProjectDirectory}
+                  />
+                  <Button
+                    type="primary"
+                    icon={<PlusOutlined />}
+                    loading={addingDir}
+                    onClick={handleAddProjectDirectory}
+                  >
+                    添加
+                  </Button>
+                </div>
+              </Space>
+            </Card>
+
+            <div style={{ marginBottom: 12, fontWeight: 600 }}>已添加的目录</div>
+            {projectDirectories.length === 0 ? (
+              <Empty description="暂无项目目录" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+            ) : (
+              <List
+                dataSource={projectDirectories}
+                renderItem={(dir) => (
+                  <List.Item
+                    style={{
+                      padding: '12px',
+                      background: 'var(--color-bg)',
+                      borderRadius: 6,
+                      marginBottom: 8,
+                      border: '1px solid var(--color-border-light)',
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1, minWidth: 0 }}>
+                      <FolderOutlined style={{ fontSize: 18, color: '#1890ff', flexShrink: 0 }} />
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        {editingDirId === dir.id ? (
+                          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                            <Input
+                              value={editingDirName}
+                              onChange={(e) => setEditingDirName(e.target.value)}
+                              placeholder="输入名称"
+                              size="small"
+                              style={{ width: 120 }}
+                              onPressEnter={() => handleUpdateProjectDirectoryName(dir.id)}
+                              autoFocus
+                            />
+                            <Button size="small" type="primary" onClick={() => handleUpdateProjectDirectoryName(dir.id)}>保存</Button>
+                            <Button size="small" onClick={() => { setEditingDirId(null); setEditingDirName(''); }}>取消</Button>
+                          </div>
+                        ) : (
+                          <>
+                            <div style={{ fontSize: 14, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                              {dir.name || dir.path}
+                            </div>
+                            {dir.name && (
+                              <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                {dir.path}
+                              </div>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    </div>
+                    <Space size={4}>
+                      {editingDirId !== dir.id && (
+                        <Button
+                          type="text"
+                          icon={<EditOutlined />}
+                          size="small"
+                          onClick={() => { setEditingDirId(dir.id); setEditingDirName(dir.name || ''); }}
+                        />
+                      )}
+                      <Popconfirm
+                        title="删除目录"
+                        description={`确定要删除 "${dir.name || dir.path}" 吗？`}
+                        onConfirm={() => handleDeleteProjectDirectory(dir.id)}
+                      >
+                        <Button type="text" danger icon={<DeleteOutlined />} size="small" />
+                      </Popconfirm>
+                    </Space>
+                  </List.Item>
+                )}
+              />
+            )}
+          </Spin>
         </div>
       ),
     },

--- a/frontend/src/components/TodoSettingsDrawer.tsx
+++ b/frontend/src/components/TodoSettingsDrawer.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
-import { Drawer, Input, Button, Switch, Divider, App } from 'antd';
+import { Drawer, Button, Switch, Divider, App, AutoComplete } from 'antd';
 import { ClockCircleOutlined, CheckOutlined, FolderOutlined } from '@ant-design/icons';
 import { Cron } from 'react-js-cron';
 import 'react-js-cron/dist/styles.css';
 import * as db from '../utils/database';
+import type { ProjectDirectory } from '../utils/database';
 import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '../utils/cron';
 import { EXECUTORS, executorConfigToOption } from '../types';
 import type { Todo, ExecutorConfig, ExecutorOption } from '../types';
@@ -29,6 +30,7 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
   const [workspace, setWorkspace] = useState<string>('');
   const [loading, setLoading] = useState(false);
   const [executorOptions, setExecutorOptions] = useState<ExecutorOption[]>(EXECUTORS);
+  const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
 
   useEffect(() => {
     db.getExecutors()
@@ -39,6 +41,14 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
         }
       })
       .catch(() => {});
+  }, [open]);
+
+  useEffect(() => {
+    if (open) {
+      db.getProjectDirectories()
+        .then(setProjectDirectories)
+        .catch(() => {});
+    }
   }, [open]);
 
   useEffect(() => {
@@ -57,6 +67,19 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
     setLoading(true);
     try {
       const trimmedWorkspace = workspace.trim() || null;
+
+      // 如果填写了目录但不在项目目录列表中，自动添加
+      if (trimmedWorkspace) {
+        const exists = projectDirectories.some(d => d.path === trimmedWorkspace);
+        if (!exists) {
+          try {
+            await db.createProjectDirectory(trimmedWorkspace);
+          } catch {
+            // 忽略添加失败，可能是已存在
+          }
+        }
+      }
+
       await db.updateTodo(
         todo.id,
         todo.title,
@@ -187,11 +210,18 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
           <FolderOutlined style={{ color: 'var(--color-primary)', marginRight: 6 }} />
           工作目录
         </div>
-        <Input
+        <AutoComplete
           value={workspace}
-          onChange={(e) => setWorkspace(e.target.value)}
-          placeholder="设置执行器的工作目录（可选）"
+          onChange={(value) => setWorkspace(value)}
+          options={projectDirectories.map(d => ({
+            value: d.path,
+            label: d.name ? `${d.name} (${d.path})` : d.path,
+          }))}
+          placeholder="从项目目录选择或手动输入路径"
           style={{ width: '100%' }}
+          filterOption={(input, option) =>
+            (option?.label as string)?.toLowerCase().includes(input.toLowerCase())
+          }
         />
       </div>
 

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -94,6 +94,32 @@ export async function deleteTag(id: number): Promise<void> {
   await api.delete(`/xyz/tags/${id}`);
 }
 
+// Project Directory APIs
+
+export interface ProjectDirectory {
+  id: number;
+  path: string;
+  name: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function getProjectDirectories(): Promise<ProjectDirectory[]> {
+  return unwrap(await api.get<ApiResp<ProjectDirectory[]>>('/xyz/project-directories'));
+}
+
+export async function createProjectDirectory(path: string, name?: string): Promise<ProjectDirectory> {
+  return unwrap(await api.post<ApiResp<ProjectDirectory>>('/xyz/project-directories', { path, name }));
+}
+
+export async function updateProjectDirectory(id: number, name?: string): Promise<void> {
+  await api.put(`/xyz/project-directories/${id}`, { name });
+}
+
+export async function deleteProjectDirectory(id: number): Promise<void> {
+  await api.delete(`/xyz/project-directories/${id}`);
+}
+
 // Execution APIs
 
 export async function getExecutionRecords(todoId: number, page?: number, limit?: number): Promise<ExecutionRecordsPage> {

--- a/frontend/test-results/e2e-test-Executor-UI-Tests-640df--a-todo-and-start-execution/error-context.md
+++ b/frontend/test-results/e2e-test-Executor-UI-Tests-640df--a-todo-and-start-execution/error-context.md
@@ -1,0 +1,108 @@
+# Instructions
+
+- Following Playwright test failed.
+- Explain why, be concise, respect Playwright best practices.
+- Provide a snippet of code with the fix, if possible.
+
+# Test info
+
+- Name: e2e-test.spec.ts >> Executor UI Tests >> should create a todo and start execution
+- Location: e2e-test.spec.ts:16:3
+
+# Error details
+
+```
+Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+Call log:
+  - navigating to "http://localhost:5173/", waiting until "load"
+
+```
+
+# Test source
+
+```ts
+  1  | import { test, expect } from '@playwright/test';
+  2  | 
+  3  | test.describe('Executor UI Tests', () => {
+  4  |   test.beforeEach(async ({ page }) => {
+  5  |     // Go to the app
+> 6  |     await page.goto('http://localhost:5173');
+     |                ^ Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+  7  |     // Wait for page to load
+  8  |     await page.waitForLoadState('networkidle');
+  9  |   });
+  10 | 
+  11 |   test('should load the main page', async ({ page }) => {
+  12 |     // Check page title or main content
+  13 |     await expect(page.locator('body')).toBeVisible();
+  14 |   });
+  15 | 
+  16 |   test('should create a todo and start execution', async ({ page }) => {
+  17 |     // Click the add button or navigate to create todo
+  18 |     const addButton = page.locator('button').filter({ hasText: /新建|新增|添加|add/i }).first();
+  19 |     if (await addButton.isVisible()) {
+  20 |       await addButton.click();
+  21 |       await page.waitForTimeout(500);
+  22 |     }
+  23 | 
+  24 |     // Mobile FAB entry
+  25 |     const mobileFab = page.locator('[aria-label="新建任务"]').first();
+  26 |     if (await mobileFab.isVisible({ timeout: 1000 }).catch(() => false)) {
+  27 |       await mobileFab.click();
+  28 |       await page.waitForTimeout(500);
+  29 |     }
+  30 | 
+  31 |     // Find the title input and fill it
+  32 |     await page.getByPlaceholder('输入 Todo 标题').fill('Test task for UI');
+  33 | 
+  34 |     // Find prompt textarea and fill with simple prompt
+  35 |     await page.getByPlaceholder('输入 Prompt（会作为任务执行的内容，留空则使用标题）').fill('Say hello in 3 words');
+  36 | 
+  37 |     // 这里当前 UI 没有 executor 选择器；如果后续补了控件，再加稳定的 locator。
+  38 | 
+  39 |     // Submit the form
+  40 |     const submitButton = page.locator('button').filter({ hasText: /创建|提交|确定|submit|create/i }).first();
+  41 |     await submitButton.click();
+  42 |     await page.waitForTimeout(1000);
+  43 | 
+  44 |     // Check if todo was created
+  45 |     await page.waitForTimeout(500);
+  46 |   });
+  47 | 
+  48 |   test('should list todos', async ({ page }) => {
+  49 |     // Check if todo list exists
+  50 |     const todoList = page.locator('.todo-list-container');
+  51 |     await expect(todoList).toBeVisible({ timeout: 3000 });
+  52 | 
+  53 |     // Count todo items
+  54 |     const todoItems = todoList.locator('[role="listitem"], li, tr');
+  55 |     const count = await todoItems.count();
+  56 |     expect(count).toBeGreaterThanOrEqual(0);
+  57 |   });
+  58 | 
+  59 |   test('should toggle theme between light and dark', async ({ page }) => {
+  60 |     // Find the theme toggle button
+  61 |     const themeToggle = page.locator('[aria-label="切换主题"]');
+  62 |     await expect(themeToggle).toBeVisible({ timeout: 3000 });
+  63 | 
+  64 |     // Get initial theme from localStorage
+  65 |     const initialTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  66 | 
+  67 |     // Click to toggle theme
+  68 |     await themeToggle.click();
+  69 |     await page.waitForTimeout(500);
+  70 | 
+  71 |     // Verify theme changed
+  72 |     const newTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  73 |     expect(newTheme).not.toBe(initialTheme);
+  74 | 
+  75 |     // Toggle back
+  76 |     await themeToggle.click();
+  77 |     await page.waitForTimeout(500);
+  78 | 
+  79 |     // Verify theme reverted
+  80 |     const revertedTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  81 |     expect(revertedTheme).toBe(initialTheme);
+  82 |   });
+  83 | });
+```

--- a/frontend/test-results/e2e-test-Executor-UI-Tests-82c5d-heme-between-light-and-dark/error-context.md
+++ b/frontend/test-results/e2e-test-Executor-UI-Tests-82c5d-heme-between-light-and-dark/error-context.md
@@ -1,0 +1,108 @@
+# Instructions
+
+- Following Playwright test failed.
+- Explain why, be concise, respect Playwright best practices.
+- Provide a snippet of code with the fix, if possible.
+
+# Test info
+
+- Name: e2e-test.spec.ts >> Executor UI Tests >> should toggle theme between light and dark
+- Location: e2e-test.spec.ts:59:3
+
+# Error details
+
+```
+Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+Call log:
+  - navigating to "http://localhost:5173/", waiting until "load"
+
+```
+
+# Test source
+
+```ts
+  1  | import { test, expect } from '@playwright/test';
+  2  | 
+  3  | test.describe('Executor UI Tests', () => {
+  4  |   test.beforeEach(async ({ page }) => {
+  5  |     // Go to the app
+> 6  |     await page.goto('http://localhost:5173');
+     |                ^ Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+  7  |     // Wait for page to load
+  8  |     await page.waitForLoadState('networkidle');
+  9  |   });
+  10 | 
+  11 |   test('should load the main page', async ({ page }) => {
+  12 |     // Check page title or main content
+  13 |     await expect(page.locator('body')).toBeVisible();
+  14 |   });
+  15 | 
+  16 |   test('should create a todo and start execution', async ({ page }) => {
+  17 |     // Click the add button or navigate to create todo
+  18 |     const addButton = page.locator('button').filter({ hasText: /新建|新增|添加|add/i }).first();
+  19 |     if (await addButton.isVisible()) {
+  20 |       await addButton.click();
+  21 |       await page.waitForTimeout(500);
+  22 |     }
+  23 | 
+  24 |     // Mobile FAB entry
+  25 |     const mobileFab = page.locator('[aria-label="新建任务"]').first();
+  26 |     if (await mobileFab.isVisible({ timeout: 1000 }).catch(() => false)) {
+  27 |       await mobileFab.click();
+  28 |       await page.waitForTimeout(500);
+  29 |     }
+  30 | 
+  31 |     // Find the title input and fill it
+  32 |     await page.getByPlaceholder('输入 Todo 标题').fill('Test task for UI');
+  33 | 
+  34 |     // Find prompt textarea and fill with simple prompt
+  35 |     await page.getByPlaceholder('输入 Prompt（会作为任务执行的内容，留空则使用标题）').fill('Say hello in 3 words');
+  36 | 
+  37 |     // 这里当前 UI 没有 executor 选择器；如果后续补了控件，再加稳定的 locator。
+  38 | 
+  39 |     // Submit the form
+  40 |     const submitButton = page.locator('button').filter({ hasText: /创建|提交|确定|submit|create/i }).first();
+  41 |     await submitButton.click();
+  42 |     await page.waitForTimeout(1000);
+  43 | 
+  44 |     // Check if todo was created
+  45 |     await page.waitForTimeout(500);
+  46 |   });
+  47 | 
+  48 |   test('should list todos', async ({ page }) => {
+  49 |     // Check if todo list exists
+  50 |     const todoList = page.locator('.todo-list-container');
+  51 |     await expect(todoList).toBeVisible({ timeout: 3000 });
+  52 | 
+  53 |     // Count todo items
+  54 |     const todoItems = todoList.locator('[role="listitem"], li, tr');
+  55 |     const count = await todoItems.count();
+  56 |     expect(count).toBeGreaterThanOrEqual(0);
+  57 |   });
+  58 | 
+  59 |   test('should toggle theme between light and dark', async ({ page }) => {
+  60 |     // Find the theme toggle button
+  61 |     const themeToggle = page.locator('[aria-label="切换主题"]');
+  62 |     await expect(themeToggle).toBeVisible({ timeout: 3000 });
+  63 | 
+  64 |     // Get initial theme from localStorage
+  65 |     const initialTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  66 | 
+  67 |     // Click to toggle theme
+  68 |     await themeToggle.click();
+  69 |     await page.waitForTimeout(500);
+  70 | 
+  71 |     // Verify theme changed
+  72 |     const newTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  73 |     expect(newTheme).not.toBe(initialTheme);
+  74 | 
+  75 |     // Toggle back
+  76 |     await themeToggle.click();
+  77 |     await page.waitForTimeout(500);
+  78 | 
+  79 |     // Verify theme reverted
+  80 |     const revertedTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  81 |     expect(revertedTheme).toBe(initialTheme);
+  82 |   });
+  83 | });
+```

--- a/frontend/test-results/e2e-test-Executor-UI-Tests-should-list-todos/error-context.md
+++ b/frontend/test-results/e2e-test-Executor-UI-Tests-should-list-todos/error-context.md
@@ -1,0 +1,108 @@
+# Instructions
+
+- Following Playwright test failed.
+- Explain why, be concise, respect Playwright best practices.
+- Provide a snippet of code with the fix, if possible.
+
+# Test info
+
+- Name: e2e-test.spec.ts >> Executor UI Tests >> should list todos
+- Location: e2e-test.spec.ts:48:3
+
+# Error details
+
+```
+Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+Call log:
+  - navigating to "http://localhost:5173/", waiting until "load"
+
+```
+
+# Test source
+
+```ts
+  1  | import { test, expect } from '@playwright/test';
+  2  | 
+  3  | test.describe('Executor UI Tests', () => {
+  4  |   test.beforeEach(async ({ page }) => {
+  5  |     // Go to the app
+> 6  |     await page.goto('http://localhost:5173');
+     |                ^ Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+  7  |     // Wait for page to load
+  8  |     await page.waitForLoadState('networkidle');
+  9  |   });
+  10 | 
+  11 |   test('should load the main page', async ({ page }) => {
+  12 |     // Check page title or main content
+  13 |     await expect(page.locator('body')).toBeVisible();
+  14 |   });
+  15 | 
+  16 |   test('should create a todo and start execution', async ({ page }) => {
+  17 |     // Click the add button or navigate to create todo
+  18 |     const addButton = page.locator('button').filter({ hasText: /新建|新增|添加|add/i }).first();
+  19 |     if (await addButton.isVisible()) {
+  20 |       await addButton.click();
+  21 |       await page.waitForTimeout(500);
+  22 |     }
+  23 | 
+  24 |     // Mobile FAB entry
+  25 |     const mobileFab = page.locator('[aria-label="新建任务"]').first();
+  26 |     if (await mobileFab.isVisible({ timeout: 1000 }).catch(() => false)) {
+  27 |       await mobileFab.click();
+  28 |       await page.waitForTimeout(500);
+  29 |     }
+  30 | 
+  31 |     // Find the title input and fill it
+  32 |     await page.getByPlaceholder('输入 Todo 标题').fill('Test task for UI');
+  33 | 
+  34 |     // Find prompt textarea and fill with simple prompt
+  35 |     await page.getByPlaceholder('输入 Prompt（会作为任务执行的内容，留空则使用标题）').fill('Say hello in 3 words');
+  36 | 
+  37 |     // 这里当前 UI 没有 executor 选择器；如果后续补了控件，再加稳定的 locator。
+  38 | 
+  39 |     // Submit the form
+  40 |     const submitButton = page.locator('button').filter({ hasText: /创建|提交|确定|submit|create/i }).first();
+  41 |     await submitButton.click();
+  42 |     await page.waitForTimeout(1000);
+  43 | 
+  44 |     // Check if todo was created
+  45 |     await page.waitForTimeout(500);
+  46 |   });
+  47 | 
+  48 |   test('should list todos', async ({ page }) => {
+  49 |     // Check if todo list exists
+  50 |     const todoList = page.locator('.todo-list-container');
+  51 |     await expect(todoList).toBeVisible({ timeout: 3000 });
+  52 | 
+  53 |     // Count todo items
+  54 |     const todoItems = todoList.locator('[role="listitem"], li, tr');
+  55 |     const count = await todoItems.count();
+  56 |     expect(count).toBeGreaterThanOrEqual(0);
+  57 |   });
+  58 | 
+  59 |   test('should toggle theme between light and dark', async ({ page }) => {
+  60 |     // Find the theme toggle button
+  61 |     const themeToggle = page.locator('[aria-label="切换主题"]');
+  62 |     await expect(themeToggle).toBeVisible({ timeout: 3000 });
+  63 | 
+  64 |     // Get initial theme from localStorage
+  65 |     const initialTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  66 | 
+  67 |     // Click to toggle theme
+  68 |     await themeToggle.click();
+  69 |     await page.waitForTimeout(500);
+  70 | 
+  71 |     // Verify theme changed
+  72 |     const newTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  73 |     expect(newTheme).not.toBe(initialTheme);
+  74 | 
+  75 |     // Toggle back
+  76 |     await themeToggle.click();
+  77 |     await page.waitForTimeout(500);
+  78 | 
+  79 |     // Verify theme reverted
+  80 |     const revertedTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  81 |     expect(revertedTheme).toBe(initialTheme);
+  82 |   });
+  83 | });
+```

--- a/frontend/test-results/e2e-test-Executor-UI-Tests-should-load-the-main-page/error-context.md
+++ b/frontend/test-results/e2e-test-Executor-UI-Tests-should-load-the-main-page/error-context.md
@@ -1,0 +1,108 @@
+# Instructions
+
+- Following Playwright test failed.
+- Explain why, be concise, respect Playwright best practices.
+- Provide a snippet of code with the fix, if possible.
+
+# Test info
+
+- Name: e2e-test.spec.ts >> Executor UI Tests >> should load the main page
+- Location: e2e-test.spec.ts:11:3
+
+# Error details
+
+```
+Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+Call log:
+  - navigating to "http://localhost:5173/", waiting until "load"
+
+```
+
+# Test source
+
+```ts
+  1  | import { test, expect } from '@playwright/test';
+  2  | 
+  3  | test.describe('Executor UI Tests', () => {
+  4  |   test.beforeEach(async ({ page }) => {
+  5  |     // Go to the app
+> 6  |     await page.goto('http://localhost:5173');
+     |                ^ Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+  7  |     // Wait for page to load
+  8  |     await page.waitForLoadState('networkidle');
+  9  |   });
+  10 | 
+  11 |   test('should load the main page', async ({ page }) => {
+  12 |     // Check page title or main content
+  13 |     await expect(page.locator('body')).toBeVisible();
+  14 |   });
+  15 | 
+  16 |   test('should create a todo and start execution', async ({ page }) => {
+  17 |     // Click the add button or navigate to create todo
+  18 |     const addButton = page.locator('button').filter({ hasText: /新建|新增|添加|add/i }).first();
+  19 |     if (await addButton.isVisible()) {
+  20 |       await addButton.click();
+  21 |       await page.waitForTimeout(500);
+  22 |     }
+  23 | 
+  24 |     // Mobile FAB entry
+  25 |     const mobileFab = page.locator('[aria-label="新建任务"]').first();
+  26 |     if (await mobileFab.isVisible({ timeout: 1000 }).catch(() => false)) {
+  27 |       await mobileFab.click();
+  28 |       await page.waitForTimeout(500);
+  29 |     }
+  30 | 
+  31 |     // Find the title input and fill it
+  32 |     await page.getByPlaceholder('输入 Todo 标题').fill('Test task for UI');
+  33 | 
+  34 |     // Find prompt textarea and fill with simple prompt
+  35 |     await page.getByPlaceholder('输入 Prompt（会作为任务执行的内容，留空则使用标题）').fill('Say hello in 3 words');
+  36 | 
+  37 |     // 这里当前 UI 没有 executor 选择器；如果后续补了控件，再加稳定的 locator。
+  38 | 
+  39 |     // Submit the form
+  40 |     const submitButton = page.locator('button').filter({ hasText: /创建|提交|确定|submit|create/i }).first();
+  41 |     await submitButton.click();
+  42 |     await page.waitForTimeout(1000);
+  43 | 
+  44 |     // Check if todo was created
+  45 |     await page.waitForTimeout(500);
+  46 |   });
+  47 | 
+  48 |   test('should list todos', async ({ page }) => {
+  49 |     // Check if todo list exists
+  50 |     const todoList = page.locator('.todo-list-container');
+  51 |     await expect(todoList).toBeVisible({ timeout: 3000 });
+  52 | 
+  53 |     // Count todo items
+  54 |     const todoItems = todoList.locator('[role="listitem"], li, tr');
+  55 |     const count = await todoItems.count();
+  56 |     expect(count).toBeGreaterThanOrEqual(0);
+  57 |   });
+  58 | 
+  59 |   test('should toggle theme between light and dark', async ({ page }) => {
+  60 |     // Find the theme toggle button
+  61 |     const themeToggle = page.locator('[aria-label="切换主题"]');
+  62 |     await expect(themeToggle).toBeVisible({ timeout: 3000 });
+  63 | 
+  64 |     // Get initial theme from localStorage
+  65 |     const initialTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  66 | 
+  67 |     // Click to toggle theme
+  68 |     await themeToggle.click();
+  69 |     await page.waitForTimeout(500);
+  70 | 
+  71 |     // Verify theme changed
+  72 |     const newTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  73 |     expect(newTheme).not.toBe(initialTheme);
+  74 | 
+  75 |     // Toggle back
+  76 |     await themeToggle.click();
+  77 |     await page.waitForTimeout(500);
+  78 | 
+  79 |     // Verify theme reverted
+  80 |     const revertedTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  81 |     expect(revertedTheme).toBe(initialTheme);
+  82 |   });
+  83 | });
+```


### PR DESCRIPTION
## Summary

新增项目目录管理功能，方便用户管理常用项目路径并在创建 Todo 时快速选择执行目录。

### 主要改动

- **数据库**: 新增 `project_directories` 表，存储项目目录路径和名称
- **后端 API**: 添加 `/xyz/project-directories` 接口，支持 CRUD 操作
- **前端**: 设置页面新增"项目目录" Tab 页，可添加/编辑/删除目录
- **Todo 设置**: 工作目录改为下拉选择 + 手动输入混合模式，支持快速选择项目目录或自定义路径

### 功能说明

1. 用户可在设置页面管理项目目录（目录必填，名称选填）
2. 编辑 Todo 时，工作目录支持下拉选择已有目录或手动输入新路径
3. 手动输入的路径会自动入库，方便后续快速选择

## Test plan

- [ ] 测试项目目录的添加、编辑、删除功能
- [ ] 测试 Todo 设置中选择工作目录
- [ ] 测试手动输入新路径后自动入库