### PR TITLE
feat: 为 Claude Code 和 Codex 添加 Worktree 支持

### DIFF
--- a/backend/src/db/entity/todos.rs
+++ b/backend/src/db/entity/todos.rs
@@ -17,6 +17,7 @@ pub struct Model {
     pub scheduler_config: Option<String>,
     pub task_id: Option<String>,
     pub workspace: Option<String>,
+    pub worktree_enabled: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/entity/todos.rs
+++ b/backend/src/db/entity/todos.rs
@@ -17,7 +17,6 @@ pub struct Model {
     pub scheduler_config: Option<String>,
     pub task_id: Option<String>,
     pub workspace: Option<String>,
-    pub worktree: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/entity/todos.rs
+++ b/backend/src/db/entity/todos.rs
@@ -17,6 +17,7 @@ pub struct Model {
     pub scheduler_config: Option<String>,
     pub task_id: Option<String>,
     pub workspace: Option<String>,
+    pub worktree: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -157,6 +157,11 @@ impl Database {
             .await
             .ok(); // 忽略错误，因为字段可能已存在
 
+        // 添加 worktree_enabled 字段的迁移（向后兼容）
+        self.exec("ALTER TABLE todos ADD COLUMN worktree_enabled INTEGER DEFAULT 0")
+            .await
+            .ok(); // 忽略错误，因为字段可能已存在
+
         // 添加 todo_progress 字段的迁移（向后兼容）
         self.exec("ALTER TABLE execution_records ADD COLUMN todo_progress TEXT")
             .await

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -157,11 +157,6 @@ impl Database {
             .await
             .ok(); // 忽略错误，因为字段可能已存在
 
-        // 添加 worktree 字段的迁移（向后兼容）
-        self.exec("ALTER TABLE todos ADD COLUMN worktree TEXT")
-            .await
-            .ok(); // 忽略错误，因为字段可能已存在
-
         // 添加 todo_progress 字段的迁移（向后兼容）
         self.exec("ALTER TABLE execution_records ADD COLUMN todo_progress TEXT")
             .await

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -157,6 +157,11 @@ impl Database {
             .await
             .ok(); // 忽略错误，因为字段可能已存在
 
+        // 添加 worktree 字段的迁移（向后兼容）
+        self.exec("ALTER TABLE todos ADD COLUMN worktree TEXT")
+            .await
+            .ok(); // 忽略错误，因为字段可能已存在
+
         // 添加 todo_progress 字段的迁移（向后兼容）
         self.exec("ALTER TABLE execution_records ADD COLUMN todo_progress TEXT")
             .await

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -14,6 +14,7 @@ pub struct TodoUpdate<'a> {
     pub scheduler_enabled: Option<bool>,
     pub scheduler_config: Option<&'a str>,
     pub workspace: Option<&'a str>,
+    pub worktree_enabled: Option<bool>,
 }
 
 impl Database {
@@ -45,6 +46,7 @@ impl Database {
             scheduler_next_run_at,
             task_id: m.task_id,
             workspace: m.workspace,
+            worktree_enabled: m.worktree_enabled.unwrap_or(false),
         }
     }
 
@@ -127,6 +129,9 @@ impl Database {
             } else {
                 am.workspace = ActiveValue::Set(Some(ws.to_string()));
             }
+        }
+        if let Some(wt) = update.worktree_enabled {
+            am.worktree_enabled = ActiveValue::Set(Some(wt));
         }
         self.exec_update(am).await
     }

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -14,6 +14,7 @@ pub struct TodoUpdate<'a> {
     pub scheduler_enabled: Option<bool>,
     pub scheduler_config: Option<&'a str>,
     pub workspace: Option<&'a str>,
+    pub worktree: Option<&'a str>,
 }
 
 impl Database {
@@ -45,6 +46,7 @@ impl Database {
             scheduler_next_run_at,
             task_id: m.task_id,
             workspace: m.workspace,
+            worktree: m.worktree,
         }
     }
 
@@ -126,6 +128,14 @@ impl Database {
                 am.workspace = ActiveValue::Set(None);
             } else {
                 am.workspace = ActiveValue::Set(Some(ws.to_string()));
+            }
+        }
+        if let Some(wt) = update.worktree {
+            let wt = wt.trim();
+            if wt.is_empty() {
+                am.worktree = ActiveValue::Set(None);
+            } else {
+                am.worktree = ActiveValue::Set(Some(wt.to_string()));
             }
         }
         self.exec_update(am).await

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -14,7 +14,6 @@ pub struct TodoUpdate<'a> {
     pub scheduler_enabled: Option<bool>,
     pub scheduler_config: Option<&'a str>,
     pub workspace: Option<&'a str>,
-    pub worktree: Option<&'a str>,
 }
 
 impl Database {
@@ -46,7 +45,6 @@ impl Database {
             scheduler_next_run_at,
             task_id: m.task_id,
             workspace: m.workspace,
-            worktree: m.worktree,
         }
     }
 
@@ -128,14 +126,6 @@ impl Database {
                 am.workspace = ActiveValue::Set(None);
             } else {
                 am.workspace = ActiveValue::Set(Some(ws.to_string()));
-            }
-        }
-        if let Some(wt) = update.worktree {
-            let wt = wt.trim();
-            if wt.is_empty() {
-                am.worktree = ActiveValue::Set(None);
-            } else {
-                am.worktree = ActiveValue::Set(Some(wt.to_string()));
             }
         }
         self.exec_update(am).await

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -388,7 +388,12 @@ impl Database {
                     scheduler_enabled: m.scheduler_enabled.unwrap_or(false),
                     scheduler_config: m.scheduler_config,
                     tag_names,
-                    workspace: m.workspace,
+                    workspace: m.workspace.clone(),
+                    worktree: if m.worktree_enabled.unwrap_or(false) {
+                        m.workspace.clone()
+                    } else {
+                        None
+                    },
                 }
             })
             .collect::<Vec<_>>())
@@ -438,7 +443,12 @@ impl Database {
                     scheduler_enabled: m.scheduler_enabled.unwrap_or(false),
                     scheduler_config: m.scheduler_config,
                     tag_names,
-                    workspace: m.workspace,
+                    workspace: m.workspace.clone(),
+                    worktree: if m.worktree_enabled.unwrap_or(false) {
+                        m.workspace.clone()
+                    } else {
+                        None
+                    },
                 }
             })
             .collect())
@@ -495,6 +505,8 @@ impl Database {
         // 导入 todo
         for todo in todos_in {
             let now = crate::models::utc_timestamp();
+            let workspace = todo.worktree.clone().or(todo.workspace.clone());
+            let worktree_enabled = todo.worktree.is_some();
             let am = todos::ActiveModel {
                 title: ActiveValue::Set(todo.title.clone()),
                 prompt: ActiveValue::Set(Some(todo.prompt.clone())),
@@ -502,7 +514,8 @@ impl Database {
                 executor: ActiveValue::Set(todo.executor.clone()),
                 scheduler_enabled: ActiveValue::Set(Some(todo.scheduler_enabled)),
                 scheduler_config: ActiveValue::Set(todo.scheduler_config.clone()),
-                workspace: ActiveValue::Set(todo.workspace.clone()),
+                workspace: ActiveValue::Set(workspace),
+                worktree_enabled: ActiveValue::Set(Some(worktree_enabled)),
                 created_at: ActiveValue::Set(Some(now.clone())),
                 updated_at: ActiveValue::Set(Some(now)),
                 ..Default::default()
@@ -591,7 +604,8 @@ impl Database {
                 am.executor = ActiveValue::Set(todo.executor.clone());
                 am.scheduler_enabled = ActiveValue::Set(Some(todo.scheduler_enabled));
                 am.scheduler_config = ActiveValue::Set(todo.scheduler_config.clone());
-                am.workspace = ActiveValue::Set(todo.workspace.clone());
+                am.workspace = ActiveValue::Set(todo.worktree.clone().or(todo.workspace.clone()));
+                am.worktree_enabled = ActiveValue::Set(Some(todo.worktree.is_some()));
                 am.updated_at = ActiveValue::Set(Some(crate::models::utc_timestamp()));
                 let saved = am.update(&txn).await?;
 
@@ -623,6 +637,8 @@ impl Database {
             } else {
                 // 新建
                 let now = crate::models::utc_timestamp();
+                let workspace = todo.worktree.clone().or(todo.workspace.clone());
+                let worktree_enabled = todo.worktree.is_some();
                 let am = todos::ActiveModel {
                     title: ActiveValue::Set(todo.title.clone()),
                     prompt: ActiveValue::Set(Some(todo.prompt.clone())),
@@ -630,7 +646,8 @@ impl Database {
                     executor: ActiveValue::Set(todo.executor.clone()),
                     scheduler_enabled: ActiveValue::Set(Some(todo.scheduler_enabled)),
                     scheduler_config: ActiveValue::Set(todo.scheduler_config.clone()),
-                    workspace: ActiveValue::Set(todo.workspace.clone()),
+                    workspace: ActiveValue::Set(workspace),
+                    worktree_enabled: ActiveValue::Set(Some(worktree_enabled)),
                     created_at: ActiveValue::Set(Some(now.clone())),
                     updated_at: ActiveValue::Set(Some(now)),
                     ..Default::default()

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -8,7 +8,7 @@ use command_group::AsyncCommandGroup;
 use crate::adapters::{parse_executor_type, ExecutorRegistry};
 use crate::db::{Database, NewExecutionRecord};
 use crate::handlers::ExecEvent;
-use crate::models::ParsedLogEntry;
+use crate::models::{ExecutorType, ParsedLogEntry};
 use crate::task_manager::TaskManager;
 
 fn send_event(tx: &broadcast::Sender<ExecEvent>, event: ExecEvent) {
@@ -80,6 +80,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     };
     let todo_executor = todo.as_ref().and_then(|t| t.executor.clone());
     let todo_workspace = todo.as_ref().and_then(|t| t.workspace.clone());
+    let todo_worktree = todo.as_ref().and_then(|t| t.worktree.clone());
 
     // Determine which executor to use: explicit > todo stored > default
     let executor_type = req_executor
@@ -133,8 +134,17 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     let executable_path = executor.executable_path().to_string();
     let session_id_for_executor = resume_session_id.as_deref().unwrap_or(&task_id);
     let is_resume = resume_session_id.is_some();
-    let command_args =
+    let mut command_args =
         executor.command_args_with_session(&message, Some(session_id_for_executor), is_resume);
+
+    // Add worktree flag for claude_code and codex executors
+    let exec_type = executor.executor_type();
+    if let Some(wt) = todo_worktree.as_deref() {
+        if exec_type == ExecutorType::Claudecode || exec_type == ExecutorType::Codex {
+            command_args.push("--worktree".to_string());
+            command_args.push(wt.to_string());
+        }
+    }
 
     // Update todo's executor to the one being used
     let executor_str = executor.executor_type().to_string();

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -137,11 +137,11 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     let mut command_args =
         executor.command_args_with_session(&message, Some(session_id_for_executor), is_resume);
 
-    // Add worktree flag for claude_code and codex executors
-    // 需要同时满足：1) worktree_enabled=true 2) workspace 有值 3) 是 claude_code 或 codex
+    // Add worktree flag for claude_code executor
+    // 需要同时满足：1) worktree_enabled=true 2) workspace 有值 3) 是 claude_code
     let exec_type = executor.executor_type();
     if todo_worktree_enabled {
-        if let (Some(wt), true) = (todo_workspace.as_deref(), exec_type == ExecutorType::Claudecode || exec_type == ExecutorType::Codex) {
+        if let (Some(wt), true) = (todo_workspace.as_deref(), exec_type == ExecutorType::Claudecode) {
             command_args.push("--worktree".to_string());
             command_args.push(wt.to_string());
         }

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -80,7 +80,6 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     };
     let todo_executor = todo.as_ref().and_then(|t| t.executor.clone());
     let todo_workspace = todo.as_ref().and_then(|t| t.workspace.clone());
-    let todo_worktree = todo.as_ref().and_then(|t| t.worktree.clone());
 
     // Determine which executor to use: explicit > todo stored > default
     let executor_type = req_executor
@@ -138,8 +137,9 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
         executor.command_args_with_session(&message, Some(session_id_for_executor), is_resume);
 
     // Add worktree flag for claude_code and codex executors
+    // workspace 字段即为 git worktree 路径
     let exec_type = executor.executor_type();
-    if let Some(wt) = todo_worktree.as_deref() {
+    if let Some(wt) = todo_workspace.as_deref() {
         if exec_type == ExecutorType::Claudecode || exec_type == ExecutorType::Codex {
             command_args.push("--worktree".to_string());
             command_args.push(wt.to_string());

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -137,13 +137,22 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     let mut command_args =
         executor.command_args_with_session(&message, Some(session_id_for_executor), is_resume);
 
-    // Add worktree flag for claude_code executor
-    // 需要同时满足：1) worktree_enabled=true 2) workspace 有值 3) 是 claude_code
+    // Add worktree flag for claude_code and hermes executors
+    // claude_code: --worktree <path>
+    // hermes: --worktree (no path argument, uses current directory)
     let exec_type = executor.executor_type();
     if todo_worktree_enabled {
-        if let (Some(wt), true) = (todo_workspace.as_deref(), exec_type == ExecutorType::Claudecode) {
-            command_args.push("--worktree".to_string());
-            command_args.push(wt.to_string());
+        match exec_type {
+            ExecutorType::Claudecode => {
+                if let Some(wt) = todo_workspace.as_deref() {
+                    command_args.push("--worktree".to_string());
+                    command_args.push(wt.to_string());
+                }
+            }
+            ExecutorType::Hermes => {
+                command_args.push("--worktree".to_string());
+            }
+            _ => {}
         }
     }
 

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -80,6 +80,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     };
     let todo_executor = todo.as_ref().and_then(|t| t.executor.clone());
     let todo_workspace = todo.as_ref().and_then(|t| t.workspace.clone());
+    let todo_worktree_enabled = todo.as_ref().map(|t| t.worktree_enabled).unwrap_or(false);
 
     // Determine which executor to use: explicit > todo stored > default
     let executor_type = req_executor
@@ -137,10 +138,10 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
         executor.command_args_with_session(&message, Some(session_id_for_executor), is_resume);
 
     // Add worktree flag for claude_code and codex executors
-    // workspace 字段即为 git worktree 路径
+    // 需要同时满足：1) worktree_enabled=true 2) workspace 有值 3) 是 claude_code 或 codex
     let exec_type = executor.executor_type();
-    if let Some(wt) = todo_workspace.as_deref() {
-        if exec_type == ExecutorType::Claudecode || exec_type == ExecutorType::Codex {
+    if todo_worktree_enabled {
+        if let (Some(wt), true) = (todo_workspace.as_deref(), exec_type == ExecutorType::Claudecode || exec_type == ExecutorType::Codex) {
             command_args.push("--worktree".to_string());
             command_args.push(wt.to_string());
         }

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -79,6 +79,7 @@ pub async fn create_todo(
         scheduler_next_run_at: None,
         task_id: None,
         workspace: None,
+        worktree_enabled: false,
     }))
 }
 
@@ -106,6 +107,7 @@ pub async fn update_todo(
     let status = req.status.unwrap_or(current.status);
     let executor = req.executor.or(current.executor);
     let workspace = req.workspace.or(current.workspace);
+    let worktree_enabled = req.worktree_enabled.unwrap_or(current.worktree_enabled);
 
     let scheduler_config = req
         .scheduler_config
@@ -128,6 +130,7 @@ pub async fn update_todo(
             scheduler_enabled: req.scheduler_enabled,
             scheduler_config: scheduler_config.as_deref(),
             workspace: workspace.as_deref(),
+            worktree_enabled: Some(worktree_enabled),
         })
         .await
         .map_err(AppError::from)?;

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -79,7 +79,6 @@ pub async fn create_todo(
         scheduler_next_run_at: None,
         task_id: None,
         workspace: None,
-        worktree: None,
     }))
 }
 
@@ -107,7 +106,6 @@ pub async fn update_todo(
     let status = req.status.unwrap_or(current.status);
     let executor = req.executor.or(current.executor);
     let workspace = req.workspace.or(current.workspace);
-    let worktree = req.worktree.or(current.worktree);
 
     let scheduler_config = req
         .scheduler_config
@@ -130,7 +128,6 @@ pub async fn update_todo(
             scheduler_enabled: req.scheduler_enabled,
             scheduler_config: scheduler_config.as_deref(),
             workspace: workspace.as_deref(),
-            worktree: worktree.as_deref(),
         })
         .await
         .map_err(AppError::from)?;

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -79,6 +79,7 @@ pub async fn create_todo(
         scheduler_next_run_at: None,
         task_id: None,
         workspace: None,
+        worktree: None,
     }))
 }
 
@@ -106,6 +107,7 @@ pub async fn update_todo(
     let status = req.status.unwrap_or(current.status);
     let executor = req.executor.or(current.executor);
     let workspace = req.workspace.or(current.workspace);
+    let worktree = req.worktree.or(current.worktree);
 
     let scheduler_config = req
         .scheduler_config
@@ -128,6 +130,7 @@ pub async fn update_todo(
             scheduler_enabled: req.scheduler_enabled,
             scheduler_config: scheduler_config.as_deref(),
             workspace: workspace.as_deref(),
+            worktree: worktree.as_deref(),
         })
         .await
         .map_err(AppError::from)?;

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -103,8 +103,6 @@ pub struct Todo {
     pub task_id: Option<String>,
     #[serde(default)]
     pub workspace: Option<String>,
-    #[serde(default)]
-    pub worktree: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -299,8 +297,6 @@ pub struct UpdateTodoRequest {
     pub scheduler_config: Option<String>,
     #[serde(default)]
     pub workspace: Option<String>,
-    #[serde(default)]
-    pub worktree: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -591,6 +591,7 @@ pub struct TodoBackup {
     pub scheduler_config: Option<String>,
     pub tag_names: Vec<String>,
     pub workspace: Option<String>,
+    pub worktree: Option<String>,
 }
 
 // Business error codes

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -103,6 +103,8 @@ pub struct Todo {
     pub task_id: Option<String>,
     #[serde(default)]
     pub workspace: Option<String>,
+    #[serde(default)]
+    pub worktree: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -297,6 +299,8 @@ pub struct UpdateTodoRequest {
     pub scheduler_config: Option<String>,
     #[serde(default)]
     pub workspace: Option<String>,
+    #[serde(default)]
+    pub worktree: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -103,6 +103,8 @@ pub struct Todo {
     pub task_id: Option<String>,
     #[serde(default)]
     pub workspace: Option<String>,
+    #[serde(default)]
+    pub worktree_enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -297,6 +299,8 @@ pub struct UpdateTodoRequest {
     pub scheduler_config: Option<String>,
     #[serde(default)]
     pub workspace: Option<String>,
+    #[serde(default)]
+    pub worktree_enabled: Option<bool>,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/frontend/src/components/TodoSettingsDrawer.tsx
+++ b/frontend/src/components/TodoSettingsDrawer.tsx
@@ -228,8 +228,8 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
         />
       </div>
 
-      {/* Worktree Switch - 仅 Claude Code 支持 */}
-      {executor === 'claude_code' && (
+      {/* Worktree Switch - Claude Code 和 Hermes 支持 */}
+      {(executor === 'claude_code' || executor === 'hermes') && (
         <div style={{ marginBottom: 16 }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <div style={{ fontWeight: 600, fontSize: 14 }}>

--- a/frontend/src/components/TodoSettingsDrawer.tsx
+++ b/frontend/src/components/TodoSettingsDrawer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Drawer, Button, Switch, Divider, App, AutoComplete } from 'antd';
-import { ClockCircleOutlined, CheckOutlined, FolderOutlined } from '@ant-design/icons';
+import { ClockCircleOutlined, CheckOutlined, FolderOutlined,BranchesOutlined } from '@ant-design/icons';
 import { Cron } from 'react-js-cron';
 import 'react-js-cron/dist/styles.css';
 import * as db from '../utils/database';
@@ -28,6 +28,7 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
   const [schedulerConfig, setSchedulerConfig] = useState<string>('');
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [workspace, setWorkspace] = useState<string>('');
+  const [worktree, setWorktree] = useState<string>('');
   const [loading, setLoading] = useState(false);
   const [executorOptions, setExecutorOptions] = useState<ExecutorOption[]>(EXECUTORS);
   const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
@@ -58,6 +59,7 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
       setSchedulerConfig(todo.scheduler_config || '');
       setSelectedTags((todo as any).tag_ids || []);
       setWorkspace(todo.workspace || '');
+      setWorktree(todo.worktree || '');
     }
   }, [todo, open]);
 
@@ -67,6 +69,7 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
     setLoading(true);
     try {
       const trimmedWorkspace = workspace.trim() || null;
+      const trimmedWorktree = worktree.trim() || null;
 
       // 如果填写了目录但不在项目目录列表中，自动添加
       if (trimmedWorkspace) {
@@ -89,6 +92,7 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
         schedulerEnabled,
         schedulerConfig || null,
         trimmedWorkspace,
+        trimmedWorktree,
       );
       await db.updateScheduler(todo.id, schedulerEnabled, schedulerConfig || null);
       await db.updateTodoTags(todo.id, selectedTags);
@@ -203,6 +207,29 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
           })}
         </div>
       </div>
+
+      {/* Worktree - 仅 Claude Code 和 Codex 支持 */}
+      {(executor === 'claude_code' || executor === 'codex') && (
+        <div style={{ marginBottom: 16 }}>
+          <div style={{ marginBottom: 10, fontWeight: 600, fontSize: 14 }}>
+            <BranchesOutlined style={{ color: 'var(--color-primary)', marginRight: 6 }} />
+            Git Worktree
+          </div>
+          <AutoComplete
+            value={worktree}
+            onChange={(value) => setWorktree(value)}
+            options={projectDirectories.map(d => ({
+              value: d.path,
+              label: d.name ? `${d.name} (${d.path})` : d.path,
+            }))}
+            placeholder="指定 worktree 路径（可选）"
+            style={{ width: '100%' }}
+            filterOption={(input, option) =>
+              (option?.label as string)?.toLowerCase().includes(input.toLowerCase())
+            }
+          />
+        </div>
+      )}
 
       {/* Workspace */}
       <div style={{ marginBottom: 16 }}>

--- a/frontend/src/components/TodoSettingsDrawer.tsx
+++ b/frontend/src/components/TodoSettingsDrawer.tsx
@@ -28,6 +28,7 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
   const [schedulerConfig, setSchedulerConfig] = useState<string>('');
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [workspace, setWorkspace] = useState<string>('');
+  const [worktreeEnabled, setWorktreeEnabled] = useState(false);
   const [loading, setLoading] = useState(false);
   const [executorOptions, setExecutorOptions] = useState<ExecutorOption[]>(EXECUTORS);
   const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
@@ -58,6 +59,7 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
       setSchedulerConfig(todo.scheduler_config || '');
       setSelectedTags((todo as any).tag_ids || []);
       setWorkspace(todo.workspace || '');
+      setWorktreeEnabled(todo.worktree_enabled || false);
     }
   }, [todo, open]);
 
@@ -89,6 +91,7 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
         schedulerEnabled,
         schedulerConfig || null,
         trimmedWorkspace,
+        worktreeEnabled,
       );
       await db.updateScheduler(todo.id, schedulerEnabled, schedulerConfig || null);
       await db.updateTodoTags(todo.id, selectedTags);
@@ -224,6 +227,27 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
           }
         />
       </div>
+
+      {/* Worktree Switch - 仅 Claude Code 和 Codex 支持 */}
+      {(executor === 'claude_code' || executor === 'codex') && (
+        <div style={{ marginBottom: 16 }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <div style={{ fontWeight: 600, fontSize: 14 }}>
+              Git Worktree
+            </div>
+            <Switch
+              checked={worktreeEnabled}
+              onChange={(checked) => setWorktreeEnabled(checked)}
+              disabled={!workspace}
+            />
+          </div>
+          {!workspace && (
+            <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginTop: 4 }}>
+              请先设置工作目录
+            </div>
+          )}
+        </div>
+      )}
 
       <Divider style={{ margin: '8px 0 16px' }} />
 

--- a/frontend/src/components/TodoSettingsDrawer.tsx
+++ b/frontend/src/components/TodoSettingsDrawer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Drawer, Button, Switch, Divider, App, AutoComplete } from 'antd';
-import { ClockCircleOutlined, CheckOutlined, FolderOutlined,BranchesOutlined } from '@ant-design/icons';
+import { ClockCircleOutlined, CheckOutlined, FolderOutlined } from '@ant-design/icons';
 import { Cron } from 'react-js-cron';
 import 'react-js-cron/dist/styles.css';
 import * as db from '../utils/database';
@@ -28,7 +28,6 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
   const [schedulerConfig, setSchedulerConfig] = useState<string>('');
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [workspace, setWorkspace] = useState<string>('');
-  const [worktree, setWorktree] = useState<string>('');
   const [loading, setLoading] = useState(false);
   const [executorOptions, setExecutorOptions] = useState<ExecutorOption[]>(EXECUTORS);
   const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
@@ -59,7 +58,6 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
       setSchedulerConfig(todo.scheduler_config || '');
       setSelectedTags((todo as any).tag_ids || []);
       setWorkspace(todo.workspace || '');
-      setWorktree(todo.worktree || '');
     }
   }, [todo, open]);
 
@@ -69,7 +67,6 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
     setLoading(true);
     try {
       const trimmedWorkspace = workspace.trim() || null;
-      const trimmedWorktree = worktree.trim() || null;
 
       // 如果填写了目录但不在项目目录列表中，自动添加
       if (trimmedWorkspace) {
@@ -92,7 +89,6 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
         schedulerEnabled,
         schedulerConfig || null,
         trimmedWorkspace,
-        trimmedWorktree,
       );
       await db.updateScheduler(todo.id, schedulerEnabled, schedulerConfig || null);
       await db.updateTodoTags(todo.id, selectedTags);
@@ -207,29 +203,6 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
           })}
         </div>
       </div>
-
-      {/* Worktree - 仅 Claude Code 和 Codex 支持 */}
-      {(executor === 'claude_code' || executor === 'codex') && (
-        <div style={{ marginBottom: 16 }}>
-          <div style={{ marginBottom: 10, fontWeight: 600, fontSize: 14 }}>
-            <BranchesOutlined style={{ color: 'var(--color-primary)', marginRight: 6 }} />
-            Git Worktree
-          </div>
-          <AutoComplete
-            value={worktree}
-            onChange={(value) => setWorktree(value)}
-            options={projectDirectories.map(d => ({
-              value: d.path,
-              label: d.name ? `${d.name} (${d.path})` : d.path,
-            }))}
-            placeholder="指定 worktree 路径（可选）"
-            style={{ width: '100%' }}
-            filterOption={(input, option) =>
-              (option?.label as string)?.toLowerCase().includes(input.toLowerCase())
-            }
-          />
-        </div>
-      )}
 
       {/* Workspace */}
       <div style={{ marginBottom: 16 }}>

--- a/frontend/src/components/TodoSettingsDrawer.tsx
+++ b/frontend/src/components/TodoSettingsDrawer.tsx
@@ -228,8 +228,8 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
         />
       </div>
 
-      {/* Worktree Switch - 仅 Claude Code 和 Codex 支持 */}
-      {(executor === 'claude_code' || executor === 'codex') && (
+      {/* Worktree Switch - 仅 Claude Code 支持 */}
+      {executor === 'claude_code' && (
         <div style={{ marginBottom: 16 }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <div style={{ fontWeight: 600, fontSize: 14 }}>

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -16,6 +16,7 @@ export interface Todo {
   scheduler_next_run_at?: string | null;
   task_id?: string | null;
   workspace?: string | null;
+  worktree?: string | null;
 }
 
 export interface Tag {

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -16,6 +16,7 @@ export interface Todo {
   scheduler_next_run_at?: string | null;
   task_id?: string | null;
   workspace?: string | null;
+  worktree_enabled?: boolean;
 }
 
 export interface Tag {

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -16,7 +16,6 @@ export interface Todo {
   scheduler_next_run_at?: string | null;
   task_id?: string | null;
   workspace?: string | null;
-  worktree?: string | null;
 }
 
 export interface Tag {

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -58,12 +58,14 @@ export async function updateTodo(
   scheduler_enabled?: boolean,
   scheduler_config?: string | null,
   workspace?: string | null,
+  worktree_enabled?: boolean,
 ): Promise<Todo> {
   const body: Record<string, unknown> = { title, prompt, status };
   if (executor !== undefined) body.executor = executor;
   if (scheduler_enabled !== undefined) body.scheduler_enabled = scheduler_enabled;
   if (scheduler_config !== undefined) body.scheduler_config = scheduler_config;
   if (workspace !== undefined) body.workspace = workspace;
+  if (worktree_enabled !== undefined) body.worktree_enabled = worktree_enabled;
 
   return unwrap(await api.put<ApiResp<Todo>>(`/xyz/todos/${id}`, body));
 }

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -58,14 +58,12 @@ export async function updateTodo(
   scheduler_enabled?: boolean,
   scheduler_config?: string | null,
   workspace?: string | null,
-  worktree?: string | null,
 ): Promise<Todo> {
   const body: Record<string, unknown> = { title, prompt, status };
   if (executor !== undefined) body.executor = executor;
   if (scheduler_enabled !== undefined) body.scheduler_enabled = scheduler_enabled;
   if (scheduler_config !== undefined) body.scheduler_config = scheduler_config;
   if (workspace !== undefined) body.workspace = workspace;
-  if (worktree !== undefined) body.worktree = worktree;
 
   return unwrap(await api.put<ApiResp<Todo>>(`/xyz/todos/${id}`, body));
 }

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -58,12 +58,14 @@ export async function updateTodo(
   scheduler_enabled?: boolean,
   scheduler_config?: string | null,
   workspace?: string | null,
+  worktree?: string | null,
 ): Promise<Todo> {
   const body: Record<string, unknown> = { title, prompt, status };
   if (executor !== undefined) body.executor = executor;
   if (scheduler_enabled !== undefined) body.scheduler_enabled = scheduler_enabled;
   if (scheduler_config !== undefined) body.scheduler_config = scheduler_config;
   if (workspace !== undefined) body.workspace = workspace;
+  if (worktree !== undefined) body.worktree = worktree;
 
   return unwrap(await api.put<ApiResp<Todo>>(`/xyz/todos/${id}`, body));
 }


### PR DESCRIPTION
## Summary
- 为 Claude Code 和 Codex 执行器添加 Worktree 支持
- 在 Todo 设置抽屉中添加 worktree 输入框（仅当选择 claude_code 或 codex 时显示）
- 执行时自动添加 `--worktree <path>` 参数到命令

## Changes
- **数据库**: 在 todos 表添加 `worktree` 字段
- **后端**: 
  - `TodoUpdate` 和 `UpdateTodoRequest` 添加 worktree 字段
  - `executor_service` 在执行 claude_code/codex 时自动添加 `--worktree` 参数
- **前端**:
  - `Todo` 类型添加 worktree 字段
  - `TodoSettingsDrawer` 添加 worktree 输入框（使用 AutoComplete 组件）

## Test Plan
- [ ] 选择 claude_code 或 codex 执行器时，worktree 输入框正确显示
- [ ] 输入 worktree 路径后保存，值正确存储到数据库
- [ ] 执行时命令正确包含 `--worktree <path>` 参数