### PR TITLE
feat: Dashboard 增加统计区间选择功能

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -325,12 +325,15 @@ impl Database {
 
     pub async fn get_dashboard_stats(
         &self,
+        hours: Option<u32>,
     ) -> Result<crate::models::DashboardStats, sea_orm::DbErr> {
         use std::collections::HashMap;
 
         let backend = self.conn.get_database_backend();
+        let hours = hours.unwrap_or(2160); // default 90 days = 2160 hours
+        let time_filter = format!("datetime('now', '-{} hours')", hours);
+        let daily_limit = (hours / 24).max(1).min(365) as i64;
 
-        // 1. Todo status counts via SQL (replaces get_todos() + in-memory filtering)
         let todo_sql = "SELECT \
             COUNT(*) as total, \
             COALESCE(SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), 0) as pending, \
@@ -339,6 +342,24 @@ impl Database {
             COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed, \
             COALESCE(SUM(CASE WHEN scheduler_enabled = 1 AND scheduler_config IS NOT NULL THEN 1 ELSE 0 END), 0) as scheduled \
             FROM todos WHERE deleted_at IS NULL";
+
+        // Build time-filtered SQL queries
+        let overall_sql = format!(
+            "SELECT \
+            COUNT(*) as total, \
+            COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success, \
+            COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed, \
+            COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
+            COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
+            COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read, \
+            COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
+            COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as total_cost, \
+            COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN json_extract(usage, '$.duration_ms') ELSE 0 END), 0) as total_duration, \
+            COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN 1 ELSE 0 END), 0) as duration_count \
+            FROM execution_records \
+            WHERE started_at >= {}",
+            time_filter
+        );
 
         let (
             total_todos,
@@ -404,21 +425,6 @@ impl Database {
             })
             .collect();
 
-        // 2. Overall execution stats with token aggregation
-        let overall_sql = "SELECT \
-            COUNT(*) as total, \
-            COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success, \
-            COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as total_cost, \
-            COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN json_extract(usage, '$.duration_ms') ELSE 0 END), 0) as total_duration, \
-            COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN 1 ELSE 0 END), 0) as duration_count \
-            FROM execution_records \
-            WHERE started_at >= date('now', '-90 days')";
-
         let (
             total_executions,
             success_executions,
@@ -459,7 +465,8 @@ impl Database {
         };
 
         // 3. Executor distribution via SQL
-        let executor_sql = "SELECT \
+        let executor_sql = format!(
+            "SELECT \
             COALESCE(executor, 'claudecode') as executor, \
             COUNT(*) as execution_count, \
             COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
@@ -468,8 +475,10 @@ impl Database {
             COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
             COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
             FROM execution_records \
-            WHERE started_at >= date('now', '-90 days') \
-            GROUP BY COALESCE(executor, 'claudecode')";
+            WHERE started_at >= {} \
+            GROUP BY COALESCE(executor, 'claudecode')",
+            time_filter
+        );
 
         let mut executor_distribution: Vec<crate::models::ExecutorCount> = self
             .conn
@@ -502,7 +511,8 @@ impl Database {
         executor_distribution.sort_by(|a, b| b.execution_count.cmp(&a.execution_count));
 
         // 4. Model distribution via SQL
-        let model_sql = "SELECT \
+        let model_sql = format!(
+            "SELECT \
             COALESCE(model, 'unknown') as model, \
             COUNT(*) as execution_count, \
             COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
@@ -513,8 +523,10 @@ impl Database {
             COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
             COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
             FROM execution_records \
-            WHERE started_at >= date('now', '-90 days') \
-            GROUP BY COALESCE(model, 'unknown')";
+            WHERE started_at >= {} \
+            GROUP BY COALESCE(model, 'unknown')",
+            time_filter
+        );
 
         let mut model_distribution: Vec<crate::models::ModelCount> = self
             .conn
@@ -551,14 +563,17 @@ impl Database {
         model_distribution.sort_by(|a, b| b.execution_count.cmp(&a.execution_count));
 
         // Trigger type distribution
-        let trigger_sql = "SELECT \
+        let trigger_sql = format!(
+            "SELECT \
             COALESCE(trigger_type, 'manual') as trigger_type, \
             COUNT(*) as count, \
             COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
             COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count \
             FROM execution_records \
-            WHERE started_at >= date('now', '-90 days') \
-            GROUP BY COALESCE(trigger_type, 'manual')";
+            WHERE started_at >= {} \
+            GROUP BY COALESCE(trigger_type, 'manual')",
+            time_filter
+        );
 
         let mut trigger_type_distribution: Vec<crate::models::TriggerTypeCount> = self.conn
             .query_all(Statement::from_string(backend, trigger_sql.to_string()))
@@ -580,13 +595,16 @@ impl Database {
         trigger_type_distribution.sort_by(|a, b| b.count.cmp(&a.count));
 
         // Executor average duration
-        let duration_sql = "SELECT \
+        let duration_sql = format!(
+            "SELECT \
             COALESCE(executor, 'claudecode') as executor, \
             ROUND(AVG(json_extract(usage, '$.duration_ms')), 0) as avg_duration, \
             COUNT(*) as execution_count \
             FROM execution_records \
-            WHERE started_at >= date('now', '-90 days') AND json_extract(usage, '$.duration_ms') IS NOT NULL \
-            GROUP BY COALESCE(executor, 'claudecode')";
+            WHERE started_at >= {} AND json_extract(usage, '$.duration_ms') IS NOT NULL \
+            GROUP BY COALESCE(executor, 'claudecode')",
+            time_filter
+        );
 
         let mut executor_duration_stats: Vec<crate::models::ExecutorDuration> = self.conn
             .query_all(Statement::from_string(backend, duration_sql.to_string()))
@@ -606,13 +624,16 @@ impl Database {
         executor_duration_stats.sort_by(|a, b| b.avg_duration_ms.partial_cmp(&a.avg_duration_ms).unwrap_or(std::cmp::Ordering::Equal));
 
         // Model cache stats
-        let cache_sql = "SELECT \
+        let cache_sql = format!(
+            "SELECT \
             COALESCE(model, 'unknown') as model, \
             COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
             COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read \
             FROM execution_records \
-            WHERE started_at >= date('now', '-90 days') AND model IS NOT NULL \
-            GROUP BY COALESCE(model, 'unknown')";
+            WHERE started_at >= {} AND model IS NOT NULL \
+            GROUP BY COALESCE(model, 'unknown')",
+            time_filter
+        );
 
         let mut model_cache_stats: Vec<crate::models::ModelCacheStat> = self.conn
             .query_all(Statement::from_string(backend, cache_sql.to_string()))
@@ -636,7 +657,8 @@ impl Database {
         model_cache_stats.retain(|m| m.total_input_tokens > 0 || m.total_cache_read_tokens > 0);
 
         // 5. Daily execution stats via SQL
-        let daily_sql = "SELECT \
+        let daily_sql = format!(
+            "SELECT \
             SUBSTR(COALESCE(started_at, ''), 1, 10) as day, \
             COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success, \
             COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed, \
@@ -646,10 +668,12 @@ impl Database {
             COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
             COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
             FROM execution_records \
-            WHERE started_at IS NOT NULL AND LENGTH(started_at) >= 10 AND started_at >= date('now', '-90 days') \
+            WHERE started_at IS NOT NULL AND LENGTH(started_at) >= 10 AND started_at >= {} \
             GROUP BY SUBSTR(started_at, 1, 10) \
             ORDER BY day DESC \
-            LIMIT 30";
+            LIMIT {}",
+            time_filter, daily_limit
+        );
 
         let daily_rows = self
             .conn
@@ -688,7 +712,8 @@ impl Database {
         daily_token_stats.reverse();
 
         // 6. Tag distribution via SQL (join through todo_tags)
-        let tag_sql = "SELECT \
+        let tag_sql = format!(
+            "SELECT \
             tt.tag_id, \
             COUNT(*) as execution_count, \
             COALESCE(SUM(CASE WHEN er.status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
@@ -698,8 +723,10 @@ impl Database {
             COALESCE(SUM(COALESCE(json_extract(er.usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
             FROM execution_records er \
             INNER JOIN todo_tags tt ON tt.todo_id = er.todo_id \
-            WHERE er.todo_id IS NOT NULL \
-            GROUP BY tt.tag_id";
+            WHERE er.todo_id IS NOT NULL AND er.started_at >= {} \
+            GROUP BY tt.tag_id",
+            time_filter
+        );
 
         let tag_rows = self
             .conn
@@ -746,11 +773,42 @@ impl Database {
         tag_distribution.sort_by(|a, b| b.execution_count.cmp(&a.execution_count));
 
         // 7. Recent executions (only load 10 rows, not the entire table)
-        let recent_records = execution_records::Entity::find()
-            .order_by_desc(execution_records::Column::StartedAt)
-            .limit(10)
-            .all(&self.conn)
-            .await?;
+        let recent_sql = format!(
+            "SELECT id, todo_id, executor, trigger_type, status, started_at, finished_at, usage, task_id, session_id, result, resume_message FROM execution_records \
+            WHERE started_at >= {} \
+            ORDER BY started_at DESC LIMIT 10",
+            time_filter
+        );
+        let recent_records: Vec<execution_records::Model> = self
+            .conn
+            .query_all(Statement::from_string(backend, recent_sql))
+            .await?
+            .into_iter()
+            .map(|row| {
+                execution_records::Model {
+                    id: row.try_get_by("id").unwrap_or(0),
+                    todo_id: row.try_get_by("todo_id").ok(),
+                    executor: row.try_get_by("executor").ok(),
+                    trigger_type: row.try_get_by("trigger_type").ok(),
+                    status: row.try_get_by("status").ok(),
+                    started_at: row.try_get_by("started_at").ok(),
+                    finished_at: row.try_get_by("finished_at").ok(),
+                    usage: row.try_get_by("usage").ok(),
+                    task_id: row.try_get_by("task_id").ok(),
+                    session_id: row.try_get_by("session_id").ok(),
+                    result: row.try_get_by("result").ok(),
+                    resume_message: row.try_get_by("resume_message").ok(),
+                    command: None,
+                    stdout: None,
+                    stderr: None,
+                    logs: None,
+                    model: None,
+                    pid: None,
+                    todo_progress: None,
+                    execution_stats: None,
+                }
+            })
+            .collect();
 
         let recent_executions: Vec<crate::models::ExecutionRecord> =
             recent_records.into_iter().map(Into::into).collect();

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -330,7 +330,7 @@ impl Database {
         use std::collections::HashMap;
 
         let backend = self.conn.get_database_backend();
-        let hours = hours.unwrap_or(2160); // default 90 days = 2160 hours
+        let hours = hours.unwrap_or(720); // default 30 days = 720 hours (matches frontend)
         let time_filter = format!("datetime('now', '-{} hours')", hours);
         let daily_limit = (hours / 24).max(1).min(365) as i64;
 
@@ -773,6 +773,8 @@ impl Database {
         tag_distribution.sort_by(|a, b| b.execution_count.cmp(&a.execution_count));
 
         // 7. Recent executions (only load 10 rows, not the entire table)
+        // Note: Only essential fields are loaded for performance; logs, stdout, stderr,
+        // command, model, pid, todo_progress, execution_stats are omitted as they're large
         let recent_sql = format!(
             "SELECT id, todo_id, executor, trigger_type, status, started_at, finished_at, usage, task_id, session_id, result, resume_message FROM execution_records \
             WHERE started_at >= {} \

--- a/backend/src/db/feishu_message.rs
+++ b/backend/src/db/feishu_message.rs
@@ -284,7 +284,7 @@ impl Database {
 
     pub async fn get_feishu_message_stats(&self, hours: Option<u32>) -> Result<crate::models::FeishuMessageStats, sea_orm::DbErr> {
         let backend = self.conn.get_database_backend();
-        let hours = hours.unwrap_or(2160); // default 90 days = 2160 hours
+        let hours = hours.unwrap_or(720); // default 30 days = 720 hours (matches frontend)
         let time_filter = format!("datetime('now', '-{} hours')", hours);
 
         let stats_sql = format!(

--- a/backend/src/db/feishu_message.rs
+++ b/backend/src/db/feishu_message.rs
@@ -296,7 +296,7 @@ impl Database {
             COUNT(DISTINCT sender_open_id) as unique_senders, \
             COUNT(DISTINCT chat_id) as unique_chats \
             FROM feishu_messages \
-            WHERE created_at >= {}", time_filter);
+            WHERE datetime(created_at) >= {}", time_filter);
 
         let mut stats = if let Some(row) = self.conn.query_one(Statement::from_string(backend, stats_sql.to_string())).await? {
             crate::models::FeishuMessageStats {

--- a/backend/src/db/feishu_message.rs
+++ b/backend/src/db/feishu_message.rs
@@ -282,17 +282,21 @@ impl Database {
         Ok(())
     }
 
-    pub async fn get_feishu_message_stats(&self) -> Result<crate::models::FeishuMessageStats, sea_orm::DbErr> {
+    pub async fn get_feishu_message_stats(&self, hours: Option<u32>) -> Result<crate::models::FeishuMessageStats, sea_orm::DbErr> {
         let backend = self.conn.get_database_backend();
+        let hours = hours.unwrap_or(2160); // default 90 days = 2160 hours
+        let time_filter = format!("datetime('now', '-{} hours')", hours);
 
-        let stats_sql = "SELECT \
+        let stats_sql = format!(
+            "SELECT \
             COUNT(*) as total, \
             COALESCE(SUM(CASE WHEN processed = 1 OR processed = 'true' THEN 1 ELSE 0 END), 0) as processed, \
             COALESCE(SUM(CASE WHEN processed IS NULL OR processed = 0 OR processed = 'false' THEN 1 ELSE 0 END), 0) as unprocessed, \
             COALESCE(SUM(CASE WHEN processed_todo_id IS NOT NULL THEN 1 ELSE 0 END), 0) as triggered_todos, \
             COUNT(DISTINCT sender_open_id) as unique_senders, \
             COUNT(DISTINCT chat_id) as unique_chats \
-            FROM feishu_messages";
+            FROM feishu_messages \
+            WHERE created_at >= {}", time_filter);
 
         let mut stats = if let Some(row) = self.conn.query_one(Statement::from_string(backend, stats_sql.to_string())).await? {
             crate::models::FeishuMessageStats {

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -312,8 +312,15 @@ pub async fn get_execution_summary(
 
 pub async fn get_dashboard_stats(
     State(state): State<AppState>,
+    Query(params): Query<DashboardStatsParams>,
 ) -> Result<ApiResponse<DashboardStats>, AppError> {
-    Ok(ApiResponse::ok(state.db.get_dashboard_stats().await?))
+    Ok(ApiResponse::ok(state.db.get_dashboard_stats(params.hours).await?))
+}
+
+#[derive(Deserialize)]
+pub struct DashboardStatsParams {
+    #[serde(default)]
+    pub hours: Option<u32>,
 }
 
 pub async fn get_running_todos(

--- a/backend/src/handlers/feishu_history.rs
+++ b/backend/src/handlers/feishu_history.rs
@@ -213,7 +213,14 @@ pub async fn delete_history_chat(
 
 pub async fn get_message_stats(
     State(state): State<AppState>,
+    Query(params): Query<MessageStatsParams>,
 ) -> Result<Json<ApiResponse<FeishuMessageStats>>, AppError> {
-    let stats = state.db.get_feishu_message_stats().await?;
+    let stats = state.db.get_feishu_message_stats(params.hours).await?;
     Ok(Json(ApiResponse::ok(stats)))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MessageStatsParams {
+    #[serde(default)]
+    pub hours: Option<u32>,
 }

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -205,10 +205,8 @@ export function Dashboard({ onBack }: DashboardProps) {
   };
 
   useEffect(() => {
-    const initialHours = timeRange === 'custom' ? undefined : timeRange;
-    loadStats(initialHours);
-    loadMsgStats(initialHours);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    loadStats(720);
+    loadMsgStats(720);
   }, []);
 
   const loadMsgStats = async (hours?: number) => {

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Card, Table, Badge, Tag, Empty, Masonry, App, Button } from 'antd';
+import { Card, Table, Badge, Tag, Empty, Masonry, App, Button, Segmented, DatePicker } from 'antd';
 import {
   ArrowLeftOutlined,
   FileTextOutlined,
@@ -13,6 +13,7 @@ import {
   BarChartOutlined,
   MessageOutlined,
 } from '@ant-design/icons';
+import dayjs from 'dayjs';
 import { useApp } from '../hooks/useApp';
 import { PieChart, PieChartLegend } from './PieChart';
 import { TrendChart } from './dashboard/DashboardCharts';
@@ -21,6 +22,14 @@ import * as db from '../utils/database';
 import { getExecutorOption } from '../types';
 import type { DashboardStats, FeishuMessageStats } from '../types';
 import { formatRelativeTime } from '../utils/datetime';
+
+const TIME_RANGE_OPTIONS: { label: string; value: number | 'custom' }[] = [
+  { label: '5小时', value: 5 },
+  { label: '7天', value: 168 },
+  { label: '14天', value: 336 },
+  { label: '30天', value: 720 },
+  { label: '自定义', value: 'custom' },
+];
 
 const STATUS_COLORS: Record<string, string> = {
   pending: '#94a3b8',
@@ -160,42 +169,57 @@ export function Dashboard({ onBack }: DashboardProps) {
   const [loading, setLoading] = useState(true);
   const [msgStats, setMsgStats] = useState<FeishuMessageStats | null>(null);
   const [msgStatsError, setMsgStatsError] = useState(false);
+  const [timeRange, setTimeRange] = useState<number | 'custom'>(720); // default 30 days
+  const [customRange, setCustomRange] = useState<[dayjs.Dayjs, dayjs.Dayjs] | null>(null);
+
+  const loadStats = async (hours?: number) => {
+    try {
+      setLoading(true);
+      const data = await db.getDashboardStats(hours);
+      setStats(data);
+    } catch {
+      message.error('加载统计数据失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleTimeRangeChange = (value: number | 'custom') => {
+    setTimeRange(value);
+    if (value === 'custom') {
+      // Don't load yet, wait for date selection
+    } else {
+      setCustomRange(null);
+      loadStats(value);
+      loadMsgStats(value);
+    }
+  };
+
+  const handleCustomRangeChange = (dates: [dayjs.Dayjs, dayjs.Dayjs] | null) => {
+    setCustomRange(dates);
+    if (dates) {
+      const hours = Math.round(dates[1].diff(dates[0], 'hour', true));
+      loadStats(hours);
+      loadMsgStats(hours);
+    }
+  };
 
   useEffect(() => {
-    let cancelled = false;
-    async function load() {
-      try {
-        setLoading(true);
-        const data = await db.getDashboardStats();
-        if (!cancelled) setStats(data);
-      } catch {
-        if (!cancelled) {
-          message.error('加载统计数据失败');
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-    load();
-    return () => { cancelled = true; };
+    const initialHours = timeRange === 'custom' ? undefined : timeRange;
+    loadStats(initialHours);
+    loadMsgStats(initialHours);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    let cancelled = false;
-    async function loadMsgStats() {
-      try {
-        if (!cancelled) setMsgStatsError(false);
-        const data = await db.getFeishuMessageStats();
-        if (!cancelled) setMsgStats(data);
-      } catch {
-        if (!cancelled) setMsgStatsError(true);
-      }
+  const loadMsgStats = async (hours?: number) => {
+    try {
+      setMsgStatsError(false);
+      const data = await db.getFeishuMessageStats(hours);
+      setMsgStats(data);
+    } catch {
+      setMsgStatsError(true);
     }
-    loadMsgStats();
-    return () => { cancelled = true; };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  };
 
   const totalTodos = stats?.total_todos ?? todos.length;
 
@@ -611,7 +635,7 @@ export function Dashboard({ onBack }: DashboardProps) {
     key: 'trend-chart',
     render: () => (
       <Card
-        title={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><BarChartOutlined /><span>执行趋势（近30天）</span></div>}
+        title={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><BarChartOutlined /><span>执行趋势</span></div>}
         className="dashboard-card" style={{ borderRadius: 12 }}
         bodyStyle={{ padding: '16px 20px' }}
       >
@@ -806,7 +830,7 @@ export function Dashboard({ onBack }: DashboardProps) {
 
       return (
         <Card
-          title={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><BarChartOutlined /><span>Token 趋势（近30天）</span></div>}
+          title={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><BarChartOutlined /><span>Token 趋势</span></div>}
           className="dashboard-card" style={{ borderRadius: 12 }}
           bodyStyle={{ padding: '16px 20px' }}
         >
@@ -958,6 +982,23 @@ export function Dashboard({ onBack }: DashboardProps) {
           返回任务列表
         </Button>
       )}
+      {/* Time Range Selector */}
+      <div style={{ marginBottom: 16, display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+        <Segmented
+          value={timeRange}
+          onChange={(value) => handleTimeRangeChange(value as number | 'custom')}
+          options={TIME_RANGE_OPTIONS}
+        />
+        {timeRange === 'custom' && (
+          <DatePicker.RangePicker
+            value={customRange}
+            onChange={(dates) => handleCustomRangeChange(dates as [dayjs.Dayjs, dayjs.Dayjs] | null)}
+            showTime={{ format: 'HH:mm' }}
+            format="YYYY-MM-DD HH:mm"
+            style={{ minWidth: 280 }}
+          />
+        )}
+      </div>
       <Masonry
         columns={{ xs: 1, sm: 1, md: 2, lg: 2, xl: 3 }}
         gutter={[16, 16]}

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -148,8 +148,8 @@ export async function getExecutionSummary(todoId: number): Promise<ExecutionSumm
 }
 
 export async function getDashboardStats(hours?: number): Promise<import('../types').DashboardStats> {
-  const params = hours ? `?hours=${hours}` : '';
-  return unwrap(await api.get<ApiResp<import('../types').DashboardStats>>(`/xyz/dashboard-stats${params}`));
+  const params = hours !== undefined ? { hours } : undefined;
+  return unwrap(await api.get<ApiResp<import('../types').DashboardStats>>('/xyz/dashboard-stats', { params }));
 }
 
 export async function stopExecution(recordId: number): Promise<void> {
@@ -485,8 +485,8 @@ export async function getFeishuHistoryMessages(params?: {
 }
 
 export async function getFeishuMessageStats(hours?: number): Promise<FeishuMessageStats> {
-  const params = hours ? `?hours=${hours}` : '';
-  return unwrap(await api.get<ApiResp<FeishuMessageStats>>(`/xyz/feishu/message-stats${params}`));
+  const params = hours !== undefined ? { hours } : undefined;
+  return unwrap(await api.get<ApiResp<FeishuMessageStats>>('/xyz/feishu/message-stats', { params }));
 }
 
 export interface FeishuSenderItem {

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -147,8 +147,9 @@ export async function getExecutionSummary(todoId: number): Promise<ExecutionSumm
   return unwrap(await api.get<ApiResp<ExecutionSummary>>(`/xyz/todos/${todoId}/summary`));
 }
 
-export async function getDashboardStats(): Promise<import('../types').DashboardStats> {
-  return unwrap(await api.get<ApiResp<import('../types').DashboardStats>>('/xyz/dashboard-stats'));
+export async function getDashboardStats(hours?: number): Promise<import('../types').DashboardStats> {
+  const params = hours ? `?hours=${hours}` : '';
+  return unwrap(await api.get<ApiResp<import('../types').DashboardStats>>(`/xyz/dashboard-stats${params}`));
 }
 
 export async function stopExecution(recordId: number): Promise<void> {
@@ -483,8 +484,9 @@ export async function getFeishuHistoryMessages(params?: {
   return unwrap(await api.get<ApiResp<FeishuHistoryMessagesPage>>('/xyz/feishu/history-messages', { params }));
 }
 
-export async function getFeishuMessageStats(): Promise<FeishuMessageStats> {
-  return unwrap(await api.get<ApiResp<FeishuMessageStats>>('/xyz/feishu/message-stats'));
+export async function getFeishuMessageStats(hours?: number): Promise<FeishuMessageStats> {
+  const params = hours ? `?hours=${hours}` : '';
+  return unwrap(await api.get<ApiResp<FeishuMessageStats>>(`/xyz/feishu/message-stats${params}`));
 }
 
 export interface FeishuSenderItem {


### PR DESCRIPTION
## Summary
- 添加时间范围选择器：5小时、7天、14天、30天、自定义日期范围
- 所有 execution_records 相关统计查询添加时间过滤
- feishu_messages 消息统计添加时间过滤
- 默认显示最近30天数据
- 趋势图表标题移除时间范围描述

## Test plan
- [ ] 验证默认显示30天数据
- [ ] 验证切换时间范围后统计数据正确更新
- [ ] 验证自定义日期范围选择功能正常
- [ ] 验证消息记录分析统计也随时间范围变化