### PR TITLE
feat: 新增 Todo 看板功能，展示最近完成任务的结论

### DIFF
--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -699,7 +699,7 @@ impl Database {
              JOIN execution_records er ON er.id = ( \
                  SELECT er2.id FROM execution_records er2 \
                  WHERE er2.todo_id = t.id \
-                 ORDER BY er2.started_at DESC LIMIT 1 \
+                 ORDER BY er2.finished_at DESC LIMIT 1 \
              ) \
              WHERE t.deleted_at IS NULL \
                AND t.status IN ('completed', 'failed') \

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -1,4 +1,7 @@
-use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter,
+    QueryOrder, Statement,
+};
 
 use crate::db::entity::tags;
 use crate::db::entity::{todo_tags, todos};
@@ -679,5 +682,77 @@ impl Database {
 
         txn.commit().await?;
         Ok((created, updated))
+    }
+
+    pub async fn get_recent_completed_todos(
+        &self,
+        hours: u32,
+    ) -> Result<Vec<crate::models::RecentCompletedTodo>, sea_orm::DbErr> {
+        let backend = self.conn.get_database_backend();
+        let time_filter = format!("datetime('now', '-{} hours')", hours);
+
+        let sql = format!(
+            "SELECT t.id as todo_id, t.title, t.executor, \
+             er.status as execution_status, er.finished_at, er.result, er.model, er.usage, \
+             er.trigger_type, er.id as record_id \
+             FROM todos t \
+             JOIN execution_records er ON er.id = ( \
+                 SELECT er2.id FROM execution_records er2 \
+                 WHERE er2.todo_id = t.id \
+                 ORDER BY er2.started_at DESC LIMIT 1 \
+             ) \
+             WHERE t.deleted_at IS NULL \
+               AND t.status IN ('completed', 'failed') \
+               AND er.finished_at >= {} \
+             ORDER BY er.finished_at DESC",
+            time_filter
+        );
+
+        let rows = self
+            .conn
+            .query_all(Statement::from_string(backend, sql))
+            .await?;
+
+        let todo_ids: Vec<i64> = rows
+            .iter()
+            .filter_map(|r| r.try_get_by("todo_id").ok())
+            .collect();
+        let tag_map = self.fetch_tag_ids_for_many(&todo_ids).await?;
+
+        Ok(rows
+            .into_iter()
+            .filter_map(|row| {
+                let todo_id: i64 = row.try_get_by("todo_id").ok()?;
+                let title: String = row.try_get_by("title").ok()?;
+                let executor: Option<String> = row.try_get_by("executor").ok().flatten();
+                let completed_at: String =
+                    row.try_get_by("finished_at").ok().flatten().unwrap_or_default();
+                let result: Option<String> = row.try_get_by("result").ok().flatten();
+                let model: Option<String> = row.try_get_by("model").ok().flatten();
+                let usage: Option<String> = row.try_get_by("usage").ok().flatten();
+                let trigger_type: String =
+                    row.try_get_by("trigger_type").ok().flatten().unwrap_or_default();
+                let execution_status: String =
+                    row.try_get_by("execution_status").ok().flatten().unwrap_or_default();
+                let record_id: i64 = row.try_get_by("record_id").ok()?;
+
+                let usage: Option<crate::models::ExecutionUsage> =
+                    usage.and_then(|u| serde_json::from_str(&u).ok());
+
+                Some(crate::models::RecentCompletedTodo {
+                    todo_id,
+                    title,
+                    executor,
+                    tag_ids: tag_map.get(&todo_id).cloned().unwrap_or_default(),
+                    completed_at,
+                    result,
+                    model,
+                    usage,
+                    execution_status,
+                    trigger_type,
+                    record_id,
+                })
+            })
+            .collect())
     }
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -381,6 +381,7 @@ pub fn create_app(
         .route("/xyz/todos/{id}/tags", put(todo::update_todo_tags))
         .route("/xyz/todos/{id}/summary", get(execution::get_execution_summary))
         .route("/xyz/todos/{id}/scheduler", put(scheduler::update_scheduler))
+        .route("/xyz/todos/recent-completed", get(todo::get_recent_completed_todos))
         .route("/xyz/todos/{id}", get(todo::get_todo).put(todo::update_todo).delete(todo::delete_todo))
         .route("/xyz/tags", get(tag::get_tags).post(tag::create_tag))
         .route("/xyz/tags/{id}", delete(tag::delete_tag))

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -1,11 +1,13 @@
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use cron::Schedule;
+use serde::Deserialize;
 use std::str::FromStr;
 
 use crate::db::TodoUpdate;
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::{
-    utc_timestamp, ApiResponse, CreateTodoRequest, Todo, UpdateTagsRequest, UpdateTodoRequest,
+    utc_timestamp, ApiResponse, CreateTodoRequest, RecentCompletedTodo, Todo, UpdateTagsRequest,
+    UpdateTodoRequest,
 };
 
 /// Validate cron expression, return helpful error for invalid ones
@@ -170,4 +172,24 @@ pub async fn force_update_todo_status(
     }
     let todo = state.require_todo(id).await?;
     Ok(ApiResponse::ok(todo))
+}
+
+#[derive(Deserialize)]
+pub struct RecentCompletedParams {
+    #[serde(default = "default_recent_hours")]
+    pub hours: u32,
+}
+
+fn default_recent_hours() -> u32 {
+    24
+}
+
+pub async fn get_recent_completed_todos(
+    State(state): State<AppState>,
+    Query(params): Query<RecentCompletedParams>,
+) -> Result<ApiResponse<Vec<RecentCompletedTodo>>, AppError> {
+    let hours = params.hours.clamp(1, 720);
+    Ok(ApiResponse::ok(
+        state.db.get_recent_completed_todos(hours).await?,
+    ))
 }

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -425,6 +425,21 @@ pub struct DashboardStats {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecentCompletedTodo {
+    pub todo_id: i64,
+    pub title: String,
+    pub executor: Option<String>,
+    pub tag_ids: Vec<i64>,
+    pub completed_at: String,
+    pub result: Option<String>,
+    pub model: Option<String>,
+    pub usage: Option<ExecutionUsage>,
+    pub execution_status: String,
+    pub trigger_type: String,
+    pub record_id: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TriggerTypeCount {
     pub trigger_type: String,
     pub count: i64,

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2128,7 +2128,7 @@ code {
   color: var(--color-text);
   cursor: pointer;
   transition: color var(--transition-fast);
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .memorial-card-title:hover {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2019,3 +2019,210 @@ code {
     padding: 12px;
   }
 }
+
+/* ============================================================
+   Memorial Board — 奏折看板
+   ============================================================ */
+
+.memorial-board {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.memorial-header {
+  flex-shrink: 0;
+  padding: var(--space-lg);
+  padding-bottom: var(--space-sm);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.memorial-header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-sm);
+}
+
+.memorial-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: 1px;
+}
+
+.memorial-summary {
+  display: flex;
+  gap: 16px;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.memorial-summary-item strong {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.memorial-summary-success {
+  color: var(--color-success);
+}
+
+.memorial-summary-failed {
+  color: var(--color-error);
+}
+
+.memorial-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.memorial-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-md) var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.memorial-card {
+  border-radius: var(--radius-md) !important;
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-base), transform var(--transition-fast);
+  cursor: pointer;
+}
+
+.memorial-card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.memorial-card.expanded {
+  box-shadow: var(--shadow-md);
+}
+
+.memorial-card .ant-card-body {
+  padding: var(--space-md) var(--space-lg) !important;
+}
+
+.memorial-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.memorial-card-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.memorial-card-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: color var(--transition-fast);
+  word-break: break-word;
+}
+
+.memorial-card-title:hover {
+  color: var(--color-primary);
+}
+
+.memorial-card-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-shrink: 0;
+}
+
+.memorial-card-info {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+}
+
+.memorial-info-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  white-space: nowrap;
+}
+
+.memorial-info-tokens {
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.memorial-info-cost {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-warning);
+}
+
+.memorial-card-tags {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.memorial-card-result {
+  margin-top: var(--space-xs);
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--color-border-light);
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--color-text-secondary);
+}
+
+.memorial-result .ant-typography {
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.memorial-expand-hint {
+  display: inline-block;
+  margin-top: var(--space-xs);
+  font-size: 12px;
+  color: var(--color-primary);
+  cursor: pointer;
+  user-select: none;
+  transition: opacity var(--transition-fast);
+}
+
+.memorial-expand-hint:hover {
+  opacity: 0.8;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .memorial-header {
+    padding: var(--space-sm);
+  }
+
+  .memorial-title {
+    font-size: 16px;
+  }
+
+  .memorial-list {
+    padding: var(--space-sm);
+    gap: var(--space-sm);
+  }
+
+  .memorial-card .ant-card-body {
+    padding: var(--space-sm) var(--space-md) !important;
+  }
+
+  .memorial-card-title {
+    font-size: 15px;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider, useTheme } from './hooks/useTheme';
 import { TodoList } from './components/TodoList';
 import { TodoDetail } from './components/TodoDetail';
 import { Dashboard } from './components/Dashboard';
+import { MemorialBoard } from './components/MemorialBoard';
 import { SettingsPage } from './components/SettingsPage';
 import { ExecutionPanel } from './components/ExecutionPanel';
 import { CreateTodoModal } from './components/CreateTodoModal';
@@ -22,7 +23,7 @@ function AppContent() {
   const [todoModalOpen, setTodoModalOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const [selectedPanel, setSelectedPanel] = useState<'list' | 'detail'>('list');
-  const [activeView, setActiveView] = useState<'dashboard' | 'settings'>('dashboard');
+  const [activeView, setActiveView] = useState<'dashboard' | 'settings' | 'memorial'>('dashboard');
   const [panelCollapsed, setPanelCollapsed] = useState(() => {
     try {
       return localStorage.getItem('execution_panel_collapsed') === 'true';
@@ -62,6 +63,12 @@ function AppContent() {
   const handleShowDashboard = () => {
     clearSelection();
     setActiveView('dashboard');
+    setSelectedPanel('detail');
+  };
+
+  const handleShowMemorial = () => {
+    clearSelection();
+    setActiveView('memorial');
     setSelectedPanel('detail');
   };
 
@@ -117,6 +124,7 @@ function AppContent() {
               onOpenCreateModal={() => setTodoModalOpen(true)}
               onSelectTodo={handleSelectTodo}
               onShowDashboard={handleShowDashboard}
+              onShowMemorial={handleShowMemorial}
               onShowSettings={handleShowSettings}
             />
           </div>
@@ -135,6 +143,8 @@ function AppContent() {
               <TodoDetail onBack={isMobile ? handleBackToList : undefined} />
             ) : activeView === 'settings' ? (
               <SettingsPage onBack={isMobile ? handleBackToList : undefined} />
+            ) : activeView === 'memorial' ? (
+              <MemorialBoard onBack={isMobile ? handleBackToList : undefined} />
             ) : (
               <Dashboard onBack={isMobile ? handleBackToList : undefined} />
             )}

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -1,0 +1,279 @@
+import { useEffect, useState } from 'react';
+import { Card, Tag, Segmented, Skeleton, Empty, Typography } from 'antd';
+import {
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  ClockCircleOutlined,
+  ThunderboltOutlined,
+  RobotOutlined,
+  ExpandOutlined,
+  CompressOutlined,
+} from '@ant-design/icons';
+import { useApp } from '../hooks/useApp';
+import { ExecutorBadge } from './ExecutorBadge';
+import * as db from '../utils/database';
+import { formatRelativeTime } from '../utils/datetime';
+import type { RecentCompletedTodo } from '../types';
+
+const { Paragraph, Text } = Typography;
+
+const TIME_OPTIONS: { label: string; value: number }[] = [
+  { label: '6h', value: 6 },
+  { label: '12h', value: 12 },
+  { label: '24h', value: 24 },
+  { label: '3d', value: 72 },
+  { label: '7d', value: 168 },
+];
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(0)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+interface MemorialBoardProps {
+  onBack?: () => void;
+}
+
+export function MemorialBoard({ onBack: _onBack }: MemorialBoardProps) {
+  const { state, dispatch } = useApp();
+  const [items, setItems] = useState<RecentCompletedTodo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [hours, setHours] = useState(24);
+  const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    db.getRecentCompletedTodos(hours)
+      .then(data => {
+        if (!cancelled) setItems(data);
+      })
+      .catch(() => {
+        if (!cancelled) setItems([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [hours]);
+
+  const toggleExpand = (todoId: number) => {
+    setExpandedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(todoId)) {
+        next.delete(todoId);
+      } else {
+        next.add(todoId);
+      }
+      return next;
+    });
+  };
+
+  const handleSelectTodo = (todoId: number) => {
+    dispatch({ type: 'SELECT_TODO', payload: todoId });
+  };
+
+  const successCount = items.filter(i => i.execution_status === 'success').length;
+  const failedCount = items.filter(i => i.execution_status === 'failed').length;
+
+  const renderResult = (result: string | null, expanded: boolean) => {
+    if (!result) return <Text type="secondary" italic>暂无结论</Text>;
+    const preview = expanded ? result : result.slice(0, 300);
+    const needExpand = result.length > 300;
+    return (
+      <div className="memorial-result">
+        <Paragraph
+          style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+          ellipsis={!expanded ? { rows: 4, expandable: false } : false}
+        >
+          {preview}
+        </Paragraph>
+        {needExpand && (
+          <span className="memorial-expand-hint">
+            {expanded ? (
+              <><CompressOutlined /> 收起</>
+            ) : (
+              <><ExpandOutlined /> 展开完整结论</>
+            )}
+          </span>
+        )}
+      </div>
+    );
+  };
+
+  if (loading) {
+    return (
+      <div className="memorial-board">
+        <div className="memorial-header">
+          <div className="memorial-header-top">
+            <h2 className="memorial-title">看板</h2>
+            <Segmented
+              size="small"
+              options={TIME_OPTIONS.map(o => o.label)}
+              value={TIME_OPTIONS.find(o => o.value === hours)?.label || '24h'}
+              onChange={label => {
+                const opt = TIME_OPTIONS.find(o => o.label === label);
+                if (opt) setHours(opt.value);
+              }}
+            />
+          </div>
+        </div>
+        <div className="memorial-list">
+          {[1, 2, 3].map(i => (
+            <Card key={i} className="memorial-card" size="small">
+              <Skeleton active paragraph={{ rows: 3 }} />
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="memorial-board">
+      <div className="memorial-header">
+        <div className="memorial-header-top">
+          <h2 className="memorial-title">看板</h2>
+          <Segmented
+            size="small"
+            options={TIME_OPTIONS.map(o => o.label)}
+            value={TIME_OPTIONS.find(o => o.value === hours)?.label || '24h'}
+            onChange={label => {
+              const opt = TIME_OPTIONS.find(o => o.label === label);
+              if (opt) setHours(opt.value);
+            }}
+          />
+        </div>
+        <div className="memorial-summary">
+          <span className="memorial-summary-item">
+            共 <strong>{items.length}</strong> 条
+          </span>
+          <span className="memorial-summary-item memorial-summary-success">
+            <CheckCircleOutlined style={{ marginRight: 2 }} />
+            <strong>{successCount}</strong> 成功
+          </span>
+          <span className="memorial-summary-item memorial-summary-failed">
+            <CloseCircleOutlined style={{ marginRight: 2 }} />
+            <strong>{failedCount}</strong> 失败
+          </span>
+        </div>
+      </div>
+
+      {items.length === 0 ? (
+        <div className="memorial-empty">
+          <Empty
+            description={
+              <span style={{ color: 'var(--color-text-tertiary)' }}>
+                最近 {hours} 小时内暂无完成的任务
+              </span>
+            }
+          />
+        </div>
+      ) : (
+        <div className="memorial-list">
+          {items.map(item => {
+            const isSuccess = item.execution_status === 'success';
+            const expanded = expandedIds.has(item.todo_id);
+
+            return (
+              <Card
+                key={item.todo_id}
+                className={`memorial-card ${expanded ? 'expanded' : ''}`}
+                size="small"
+                onClick={() => toggleExpand(item.todo_id)}
+                hoverable
+                style={{
+                  borderLeft: `3px solid ${isSuccess ? '#22c55e' : '#ef4444'}`,
+                }}
+              >
+                <div className="memorial-card-body">
+                  {/* Title row */}
+                  <div className="memorial-card-title-row">
+                    <a
+                      className="memorial-card-title"
+                      onClick={e => {
+                        e.stopPropagation();
+                        handleSelectTodo(item.todo_id);
+                      }}
+                    >
+                      {item.title}
+                    </a>
+                    <div className="memorial-card-meta">
+                      {isSuccess ? (
+                        <Tag color="success" icon={<CheckCircleOutlined />}>成功</Tag>
+                      ) : (
+                        <Tag color="error" icon={<CloseCircleOutlined />}>失败</Tag>
+                      )}
+                      {item.executor && <ExecutorBadge executor={item.executor} />}
+                    </div>
+                  </div>
+
+                  {/* Info row */}
+                  <div className="memorial-card-info">
+                    <span className="memorial-info-item">
+                      <ClockCircleOutlined /> {formatRelativeTime(item.completed_at)}
+                    </span>
+                    {item.model && (
+                      <span className="memorial-info-item">
+                        <RobotOutlined /> {item.model}
+                      </span>
+                    )}
+                    {item.trigger_type && item.trigger_type !== 'manual' && (
+                      <span className="memorial-info-item">
+                        <ThunderboltOutlined /> {item.trigger_type === 'scheduler' ? '定时' : item.trigger_type}
+                      </span>
+                    )}
+                    {item.usage && (
+                      <>
+                        <span className="memorial-info-item memorial-info-tokens">
+                          {formatTokens(item.usage.input_tokens)}+{formatTokens(item.usage.output_tokens)} tokens
+                        </span>
+                        {item.usage.total_cost_usd != null && item.usage.total_cost_usd > 0 && (
+                          <span className="memorial-info-item memorial-info-cost">
+                            ${item.usage.total_cost_usd.toFixed(4)}
+                          </span>
+                        )}
+                        {item.usage.duration_ms != null && (
+                          <span className="memorial-info-item">
+                            {formatDuration(item.usage.duration_ms)}
+                          </span>
+                        )}
+                      </>
+                    )}
+                  </div>
+
+                  {/* Tags row */}
+                  {item.tag_ids.length > 0 && (
+                    <div className="memorial-card-tags">
+                      {item.tag_ids.map(tid => {
+                        const tag = state.tags.find(t => t.id === tid);
+                        if (!tag) return null;
+                        return (
+                          <Tag key={tid} color={tag.color} style={{ margin: 0 }}>
+                            {tag.name}
+                          </Tag>
+                        );
+                      })}
+                    </div>
+                  )}
+
+                  {/* Result preview */}
+                  <div className="memorial-card-result">
+                    {renderResult(item.result, expanded)}
+                  </div>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useApp } from '../hooks/useApp';
 import { Button, Empty, Tooltip } from 'antd';
-import { PlusOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, SettingOutlined, SunOutlined, MoonOutlined } from '@ant-design/icons';
+import { PlusOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined } from '@ant-design/icons';
 import { useTheme } from '../hooks/useTheme';
 import { StatusPicker } from './StatusPicker';
 import * as db from '../utils/database';
@@ -12,6 +12,7 @@ interface TodoListProps {
   onOpenCreateModal: () => void;
   onSelectTodo?: (todoId: string | number) => void;
   onShowDashboard?: () => void;
+  onShowMemorial?: () => void;
   onShowSettings?: () => void;
 }
 
@@ -29,7 +30,7 @@ function SkeletonList() {
   );
 }
 
-export function TodoList({ onOpenCreateModal, onSelectTodo, onShowDashboard, onShowSettings }: TodoListProps) {
+export function TodoList({ onOpenCreateModal, onSelectTodo, onShowDashboard, onShowMemorial, onShowSettings }: TodoListProps) {
   const { state, dispatch } = useApp();
   const { themeMode, toggleTheme } = useTheme();
   const { todos, selectedTodoId, selectedTagId, tags } = state;
@@ -85,6 +86,16 @@ export function TodoList({ onOpenCreateModal, onSelectTodo, onShowDashboard, onS
             className="tag-btn"
             aria-label="查看仪表盘"
           />
+          <Tooltip title="看板">
+            <Button
+              type="text"
+              size="small"
+              icon={<ReadOutlined />}
+              onClick={onShowMemorial}
+              className="tag-btn"
+              aria-label="看板"
+            />
+          </Tooltip>
           <Tooltip title={themeMode === 'light' ? '切换暗色主题' : '切换亮色主题'}>
             <Button
               type="text"

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -91,7 +91,7 @@ export function TodoList({ onOpenCreateModal, onSelectTodo, onShowDashboard, onS
               type="text"
               size="small"
               icon={<ReadOutlined />}
-              onClick={onShowMemorial}
+              onClick={() => onShowMemorial?.()}
               className="tag-btn"
               aria-label="看板"
             />

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -411,6 +411,20 @@ export interface FeishuMessageStats {
   unique_chats: number;
 }
 
+export interface RecentCompletedTodo {
+  todo_id: number;
+  title: string;
+  executor: string | null;
+  tag_ids: number[];
+  completed_at: string;
+  result: string | null;
+  model: string | null;
+  usage: ExecutionUsage | null;
+  execution_status: string;
+  trigger_type: string;
+  record_id: number;
+}
+
 export interface FeishuHistoryChat {
   id: number;
   bot_id: number;

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -174,6 +174,11 @@ export async function getExecutionSummary(todoId: number): Promise<ExecutionSumm
   return unwrap(await api.get<ApiResp<ExecutionSummary>>(`/xyz/todos/${todoId}/summary`));
 }
 
+export async function getRecentCompletedTodos(hours?: number): Promise<import('../types').RecentCompletedTodo[]> {
+  const params = hours !== undefined ? { hours } : undefined;
+  return unwrap(await api.get<ApiResp<import('../types').RecentCompletedTodo[]>>('/xyz/todos/recent-completed', { params }));
+}
+
 export async function getDashboardStats(hours?: number): Promise<import('../types').DashboardStats> {
   const params = hours !== undefined ? { hours } : undefined;
   return unwrap(await api.get<ApiResp<import('../types').DashboardStats>>('/xyz/dashboard-stats', { params }));


### PR DESCRIPTION
## Summary
- 新增 `GET /xyz/todos/recent-completed?hours=24` API，JOIN 查询最近完成的 Todo 及其执行结论
- 前端新增"看板"视图，以卡片形式展示最近完成的 Todo，默认最近 24 小时
- 每条卡片展示：标题、执行器、标签、完成时间、token/耗时、结论预览（前 300 字）
- 点击卡片展开/折叠完整结论，无需跳转页面
- 点击标题可跳转到任务详情页
- 支持 6h/12h/24h/3d/7d 时间范围切换

## Test plan
- [x] 后端 API 返回正确数据
- [x] 前端看板页面渲染正常
- [x] 卡片展开/折叠功能正常
- [x] 时间范围切换正常
- [x] Playwright 自动化验证通过