### PR TITLE
refactor: 看板改为瀑布流布局 + Markdown 渲染 + 复制按钮

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2021,7 +2021,7 @@ code {
 }
 
 /* ============================================================
-   Memorial Board — 奏折看板
+   Kanban Board — 看板
    ============================================================ */
 
 .memorial-board {
@@ -2060,17 +2060,17 @@ code {
   color: var(--color-text-secondary);
 }
 
-.memorial-summary-item strong {
-  font-weight: 600;
-  color: var(--color-text);
+.memorial-stat-dot {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
 }
 
-.memorial-summary-success {
-  color: var(--color-success);
-}
-
-.memorial-summary-failed {
-  color: var(--color-error);
+.memorial-stat-success { color: var(--color-success); }
+.memorial-stat-failed { color: var(--color-error); }
+.memorial-stat-success strong,
+.memorial-stat-failed strong {
+  font-weight: 700;
 }
 
 .memorial-empty {
@@ -2080,20 +2080,25 @@ code {
   justify-content: center;
 }
 
-.memorial-list {
+/* ——— Masonry Layout (CSS Columns) ——— */
+.memorial-grid {
   flex: 1;
   overflow-y: auto;
   padding: var(--space-md) var(--space-lg);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
+  column-count: 4;
+  column-gap: var(--space-md);
+  align-content: start;
 }
 
+/* ——— Card ——— */
 .memorial-card {
   border-radius: var(--radius-md) !important;
   box-shadow: var(--shadow-sm);
-  transition: box-shadow var(--transition-base), transform var(--transition-fast);
+  transition: box-shadow var(--transition-base);
   cursor: pointer;
+  overflow: hidden;
+  break-inside: avoid;
+  margin-bottom: var(--space-md);
 }
 
 .memorial-card:hover {
@@ -2104,106 +2109,228 @@ code {
   box-shadow: var(--shadow-md);
 }
 
-.memorial-card .ant-card-body {
-  padding: var(--space-md) var(--space-lg) !important;
-}
-
-.memorial-card-body {
+/* ——— Card Header ——— */
+.memorial-card-header {
+  padding: var(--space-md) var(--space-lg);
+  border-bottom: 1px solid var(--color-border-light);
   display: flex;
   flex-direction: column;
-  gap: var(--space-sm);
+  gap: var(--space-xs);
 }
 
-.memorial-card-title-row {
+.memorial-card-top {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-sm);
-  flex-wrap: wrap;
 }
 
 .memorial-card-title {
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--color-text);
   cursor: pointer;
   transition: color var(--transition-fast);
-  overflow-wrap: break-word;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  line-height: 1.5;
+  word-break: break-word;
 }
 
 .memorial-card-title:hover {
   color: var(--color-primary);
 }
 
-.memorial-card-meta {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
+.memorial-status-icon {
+  font-size: 16px;
   flex-shrink: 0;
+  margin-top: 2px;
 }
 
-.memorial-card-info {
+.memorial-success { color: var(--color-success); }
+.memorial-failed { color: var(--color-error); }
+
+.memorial-card-meta-row {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--space-sm);
-  font-size: 12px;
+  font-size: 11px;
   color: var(--color-text-tertiary);
 }
 
-.memorial-info-item {
+.memorial-meta-time,
+.memorial-meta-model {
   display: inline-flex;
   align-items: center;
   gap: 2px;
   white-space: nowrap;
 }
 
-.memorial-info-tokens {
-  font-family: var(--font-mono);
-  font-size: 11px;
-}
-
-.memorial-info-cost {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--color-warning);
-}
-
 .memorial-card-tags {
   display: flex;
-  gap: 4px;
   flex-wrap: wrap;
+  gap: 4px;
 }
 
-.memorial-card-result {
-  margin-top: var(--space-xs);
-  padding-top: var(--space-sm);
-  border-top: 1px solid var(--color-border-light);
-  font-size: 14px;
+.memorial-tag {
+  font-size: 11px !important;
+  padding: 0 6px !important;
+  line-height: 18px !important;
+  margin: 0 !important;
+}
+
+/* ——— Card Footer (Result) ——— */
+.memorial-card-footer {
+  padding: var(--space-md) var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.memorial-result {
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--color-text-secondary);
+  max-height: 160px;
+  overflow: hidden;
+  position: relative;
+}
+
+.memorial-result::after {
+  content: '';
+  display: table;
+}
+
+.memorial-result.expanded {
+  max-height: none;
+}
+
+/* Markdown styles inside card */
+.memorial-result p {
+  margin: 0 0 4px;
+  font-size: 13px;
   line-height: 1.7;
   color: var(--color-text-secondary);
 }
 
-.memorial-result .ant-typography {
-  font-size: 14px;
-  line-height: 1.7;
+.memorial-result p:last-child {
+  margin-bottom: 0;
 }
 
-.memorial-expand-hint {
+.memorial-result strong {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.memorial-result code {
+  background: var(--color-bg);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-primary);
+}
+
+.memorial-result pre {
+  background: var(--color-bg);
+  padding: 8px;
+  border-radius: 6px;
+  overflow-x: auto;
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 4px 0;
+}
+
+.memorial-result pre code {
+  background: none;
+  padding: 0;
+  color: inherit;
+}
+
+.memorial-result ul,
+.memorial-result ol {
+  margin: 4px 0;
+  padding-left: 18px;
+}
+
+.memorial-result li {
+  margin: 2px 0;
+}
+
+.memorial-copy-btn {
+  float: right;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-tertiary);
+  font-size: 13px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: color var(--transition-fast), background var(--transition-fast);
+  line-height: 1;
+}
+
+.memorial-copy-btn:hover {
+  color: var(--color-primary);
+  background: var(--color-primary-bg);
+}
+
+.memorial-expand-btn {
   display: inline-block;
-  margin-top: var(--space-xs);
+  margin-top: 4px;
   font-size: 12px;
   color: var(--color-primary);
   cursor: pointer;
-  user-select: none;
+  background: none;
+  border: none;
+  padding: 0;
   transition: opacity var(--transition-fast);
 }
 
-.memorial-expand-hint:hover {
-  opacity: 0.8;
+.memorial-expand-btn:hover {
+  opacity: 0.7;
 }
 
-/* Responsive */
+.memorial-no-result {
+  font-size: 13px;
+  color: var(--color-text-tertiary);
+  font-style: italic;
+}
+
+/* ——— Usage Stats Row ——— */
+.memorial-usage-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  padding-top: var(--space-xs);
+  border-top: 1px solid var(--color-border-light);
+}
+
+.memorial-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  white-space: nowrap;
+}
+
+.memorial-tokens {
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.memorial-cost {
+  color: var(--color-warning);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+/* ——— Responsive ——— */
 @media (max-width: 768px) {
   .memorial-header {
     padding: var(--space-sm);
@@ -2213,16 +2340,26 @@ code {
     font-size: 16px;
   }
 
-  .memorial-list {
+  .memorial-grid {
     padding: var(--space-sm);
-    gap: var(--space-sm);
+    column-count: 1;
   }
+}
 
-  .memorial-card .ant-card-body {
-    padding: var(--space-sm) var(--space-md) !important;
+@media (min-width: 769px) {
+  .memorial-grid {
+    column-count: 2;
   }
+}
 
-  .memorial-card-title {
-    font-size: 15px;
+@media (min-width: 1100px) {
+  .memorial-grid {
+    column-count: 3;
+  }
+}
+
+@media (min-width: 1600px) {
+  .memorial-grid {
+    column-count: 4;
   }
 }

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -1,21 +1,18 @@
 import { useEffect, useState } from 'react';
-import { Card, Tag, Segmented, Skeleton, Empty, Typography } from 'antd';
+import { Card, Tag, Segmented, Skeleton, Empty, Badge, message } from 'antd';
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
   ClockCircleOutlined,
-  ThunderboltOutlined,
   RobotOutlined,
-  ExpandOutlined,
-  CompressOutlined,
+  CopyOutlined,
 } from '@ant-design/icons';
+import ReactMarkdown from 'react-markdown';
 import { useApp } from '../hooks/useApp';
 import { ExecutorBadge } from './ExecutorBadge';
 import * as db from '../utils/database';
 import { formatRelativeTime } from '../utils/datetime';
 import type { RecentCompletedTodo } from '../types';
-
-const { Paragraph, Text } = Typography;
 
 const TIME_OPTIONS: { label: string; value: number }[] = [
   { label: '6h', value: 6 },
@@ -32,8 +29,8 @@ function formatTokens(n: number): string {
 }
 
 function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  if (ms < 60_000) return `${(ms / 1000).toFixed(0)}s`;
+  if (ms < 1_000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1_000).toFixed(0)}s`;
   return `${(ms / 60_000).toFixed(1)}m`;
 }
 
@@ -76,65 +73,126 @@ export function MemorialBoard({ onBack: _onBack }: MemorialBoardProps) {
     });
   };
 
-  const handleSelectTodo = (todoId: number) => {
+  const handleSelectTodo = (todoId: number, e: React.MouseEvent) => {
+    e.stopPropagation();
     dispatch({ type: 'SELECT_TODO', payload: todoId });
   };
 
   const successCount = items.filter(i => i.execution_status === 'success').length;
   const failedCount = items.filter(i => i.execution_status === 'failed').length;
 
-  const renderResult = (result: string | null, expanded: boolean) => {
-    if (!result) return <Text type="secondary" italic>暂无结论</Text>;
-    const preview = expanded ? result : result.slice(0, 300);
-    const needExpand = result.length > 300;
+  const renderCard = (item: RecentCompletedTodo) => {
+    const isSuccess = item.execution_status === 'success';
+    const expanded = expandedIds.has(item.todo_id);
+    const result = item.result || '';
+    const previewMd = result.length > 200 && !expanded ? result.slice(0, 200) + '…' : result;
+
     return (
-      <div className="memorial-result">
-        <Paragraph
-          style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-          ellipsis={!expanded ? { rows: 4, expandable: false } : false}
-        >
-          {preview}
-        </Paragraph>
-        {needExpand && (
-          <span className="memorial-expand-hint">
-            {expanded ? (
-              <><CompressOutlined /> 收起</>
+      <Card
+        key={item.todo_id}
+        className={`memorial-card ${expanded ? 'expanded' : ''}`}
+        size="small"
+        onClick={() => toggleExpand(item.todo_id)}
+        style={{
+          borderTop: `3px solid ${isSuccess ? '#22c55e' : '#ef4444'}`,
+        }}
+        bodyStyle={{ padding: 0 }}
+      >
+        {/* Card Header */}
+        <div className="memorial-card-header">
+          <div className="memorial-card-top">
+            <span
+              className="memorial-card-title"
+              onClick={e => handleSelectTodo(item.todo_id, e)}
+              title={item.title}
+            >
+              {item.title}
+            </span>
+            {isSuccess ? (
+              <CheckCircleOutlined className="memorial-status-icon memorial-success" />
             ) : (
-              <><ExpandOutlined /> 展开完整结论</>
+              <CloseCircleOutlined className="memorial-status-icon memorial-failed" />
             )}
-          </span>
-        )}
-      </div>
+          </div>
+          <div className="memorial-card-meta-row">
+            {item.executor && <ExecutorBadge executor={item.executor} />}
+            <span className="memorial-meta-time">
+              <ClockCircleOutlined /> {formatRelativeTime(item.completed_at)}
+            </span>
+            {item.model && (
+              <span className="memorial-meta-model">
+                <RobotOutlined /> {item.model}
+              </span>
+            )}
+          </div>
+          {item.tag_ids.length > 0 && (
+            <div className="memorial-card-tags">
+              {item.tag_ids.map(tid => {
+                const tag = state.tags.find(t => t.id === tid);
+                if (!tag) return null;
+                return (
+                  <Tag key={tid} color={tag.color} className="memorial-tag">
+                    {tag.name}
+                  </Tag>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Card Footer — Result */}
+        <div className="memorial-card-footer">
+          {result ? (
+            <div className={`memorial-result ${expanded ? 'expanded' : ''}`}>
+              <button
+                className="memorial-copy-btn"
+                onClick={e => {
+                  e.stopPropagation();
+                  navigator.clipboard.writeText(result).then(() => message.success('已复制'));
+                }}
+                title="复制结论"
+              >
+                <CopyOutlined />
+              </button>
+              <ReactMarkdown>
+                {previewMd}
+              </ReactMarkdown>
+              {result.length > 200 && (
+                <button className="memorial-expand-btn" onClick={e => { e.stopPropagation(); toggleExpand(item.todo_id); }}>
+                  {expanded ? '收起' : '展开'}
+                </button>
+              )}
+            </div>
+          ) : (
+            <span className="memorial-no-result">暂无结论</span>
+          )}
+
+          {/* Usage stats */}
+          {item.usage && (
+            <div className="memorial-usage-row">
+              {item.usage.duration_ms != null && (
+                <span className="memorial-stat">{formatDuration(item.usage.duration_ms)}</span>
+              )}
+              <span className="memorial-stat memorial-tokens">
+                {formatTokens(item.usage.input_tokens)} + {formatTokens(item.usage.output_tokens)} tokens
+              </span>
+              {item.usage.total_cost_usd != null && item.usage.total_cost_usd > 0 && (
+                <span className="memorial-stat memorial-cost">
+                  ${item.usage.total_cost_usd.toFixed(4)}
+                </span>
+              )}
+              {item.trigger_type && item.trigger_type !== 'manual' && (
+                <Badge
+                  count={item.trigger_type === 'scheduler' ? '定时' : item.trigger_type}
+                  style={{ fontSize: 10, height: 16, lineHeight: '16px' }}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      </Card>
     );
   };
-
-  if (loading) {
-    return (
-      <div className="memorial-board">
-        <div className="memorial-header">
-          <div className="memorial-header-top">
-            <h2 className="memorial-title">看板</h2>
-            <Segmented
-              size="small"
-              options={TIME_OPTIONS.map(o => o.label)}
-              value={TIME_OPTIONS.find(o => o.value === hours)?.label || '24h'}
-              onChange={label => {
-                const opt = TIME_OPTIONS.find(o => o.label === label);
-                if (opt) setHours(opt.value);
-              }}
-            />
-          </div>
-        </div>
-        <div className="memorial-list">
-          {[1, 2, 3].map(i => (
-            <Card key={i} className="memorial-card" size="small">
-              <Skeleton active paragraph={{ rows: 3 }} />
-            </Card>
-          ))}
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="memorial-board">
@@ -143,7 +201,7 @@ export function MemorialBoard({ onBack: _onBack }: MemorialBoardProps) {
           <h2 className="memorial-title">看板</h2>
           <Segmented
             size="small"
-            options={TIME_OPTIONS.map(o => o.label)}
+            options={TIME_OPTIONS.map(o => ({ label: o.label, value: o.label }))}
             value={TIME_OPTIONS.find(o => o.value === hours)?.label || '24h'}
             onChange={label => {
               const opt = TIME_OPTIONS.find(o => o.label === label);
@@ -152,126 +210,31 @@ export function MemorialBoard({ onBack: _onBack }: MemorialBoardProps) {
           />
         </div>
         <div className="memorial-summary">
-          <span className="memorial-summary-item">
-            共 <strong>{items.length}</strong> 条
+          <span className="memorial-stat-dot memorial-stat-all">共 <strong>{items.length}</strong> 条</span>
+          <span className="memorial-stat-dot memorial-stat-success">
+            <CheckCircleOutlined /> <strong>{successCount}</strong> 成功
           </span>
-          <span className="memorial-summary-item memorial-summary-success">
-            <CheckCircleOutlined style={{ marginRight: 2 }} />
-            <strong>{successCount}</strong> 成功
-          </span>
-          <span className="memorial-summary-item memorial-summary-failed">
-            <CloseCircleOutlined style={{ marginRight: 2 }} />
-            <strong>{failedCount}</strong> 失败
+          <span className="memorial-stat-dot memorial-stat-failed">
+            <CloseCircleOutlined /> <strong>{failedCount}</strong> 失败
           </span>
         </div>
       </div>
 
-      {items.length === 0 ? (
+      {loading ? (
+        <div className="memorial-grid">
+          {[1, 2, 3, 4].map(i => (
+            <Card key={i} className="memorial-card" size="small" bodyStyle={{ padding: 12 }}>
+              <Skeleton active paragraph={{ rows: 4 }} />
+            </Card>
+          ))}
+        </div>
+      ) : items.length === 0 ? (
         <div className="memorial-empty">
-          <Empty
-            description={
-              <span style={{ color: 'var(--color-text-tertiary)' }}>
-                最近 {hours} 小时内暂无完成的任务
-              </span>
-            }
-          />
+          <Empty description={<span style={{ color: 'var(--color-text-tertiary)' }}>最近 {hours} 小时内暂无完成的任务</span>} />
         </div>
       ) : (
-        <div className="memorial-list">
-          {items.map(item => {
-            const isSuccess = item.execution_status === 'success';
-            const expanded = expandedIds.has(item.todo_id);
-
-            return (
-              <Card
-                key={item.todo_id}
-                className={`memorial-card ${expanded ? 'expanded' : ''}`}
-                size="small"
-                onClick={() => toggleExpand(item.todo_id)}
-                hoverable
-                style={{
-                  borderLeft: `3px solid ${isSuccess ? '#22c55e' : '#ef4444'}`,
-                }}
-              >
-                <div className="memorial-card-body">
-                  {/* Title row */}
-                  <div className="memorial-card-title-row">
-                    <a
-                      className="memorial-card-title"
-                      onClick={e => {
-                        e.stopPropagation();
-                        handleSelectTodo(item.todo_id);
-                      }}
-                    >
-                      {item.title}
-                    </a>
-                    <div className="memorial-card-meta">
-                      {isSuccess ? (
-                        <Tag color="success" icon={<CheckCircleOutlined />}>成功</Tag>
-                      ) : (
-                        <Tag color="error" icon={<CloseCircleOutlined />}>失败</Tag>
-                      )}
-                      {item.executor && <ExecutorBadge executor={item.executor} />}
-                    </div>
-                  </div>
-
-                  {/* Info row */}
-                  <div className="memorial-card-info">
-                    <span className="memorial-info-item">
-                      <ClockCircleOutlined /> {formatRelativeTime(item.completed_at)}
-                    </span>
-                    {item.model && (
-                      <span className="memorial-info-item">
-                        <RobotOutlined /> {item.model}
-                      </span>
-                    )}
-                    {item.trigger_type && item.trigger_type !== 'manual' && (
-                      <span className="memorial-info-item">
-                        <ThunderboltOutlined /> {item.trigger_type === 'scheduler' ? '定时' : item.trigger_type}
-                      </span>
-                    )}
-                    {item.usage && (
-                      <>
-                        <span className="memorial-info-item memorial-info-tokens">
-                          {formatTokens(item.usage.input_tokens)}+{formatTokens(item.usage.output_tokens)} tokens
-                        </span>
-                        {item.usage.total_cost_usd != null && item.usage.total_cost_usd > 0 && (
-                          <span className="memorial-info-item memorial-info-cost">
-                            ${item.usage.total_cost_usd.toFixed(4)}
-                          </span>
-                        )}
-                        {item.usage.duration_ms != null && (
-                          <span className="memorial-info-item">
-                            {formatDuration(item.usage.duration_ms)}
-                          </span>
-                        )}
-                      </>
-                    )}
-                  </div>
-
-                  {/* Tags row */}
-                  {item.tag_ids.length > 0 && (
-                    <div className="memorial-card-tags">
-                      {item.tag_ids.map(tid => {
-                        const tag = state.tags.find(t => t.id === tid);
-                        if (!tag) return null;
-                        return (
-                          <Tag key={tid} color={tag.color} style={{ margin: 0 }}>
-                            {tag.name}
-                          </Tag>
-                        );
-                      })}
-                    </div>
-                  )}
-
-                  {/* Result preview */}
-                  <div className="memorial-card-result">
-                    {renderResult(item.result, expanded)}
-                  </div>
-                </div>
-              </Card>
-            );
-          })}
+        <div className="memorial-grid">
+          {items.map(renderCard)}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Grid 布局改为 CSS Columns 瀑布流，展开卡片可独立撑高，不再被行高约束
- 结论区域使用 `react-markdown` 渲染，支持 Markdown 语法高亮
- 增加复制按钮，一键复制完整结论到剪贴板
- 响应式列数：移动端 1 列 → 768px 2 列 → 1100px 3 列 → 1600px 4 列

## Test plan
- [x] 瀑布流展开不受同行卡片高度限制
- [x] Markdown 结论正常渲染
- [x] 复制按钮点击即复制并提示