### PR TITLE
fix: 统一 executor 命名为 claudecode

### DIFF
--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -166,7 +166,7 @@ impl ExecutorRegistry {
     /// Create an executor instance by name and path.
     pub fn create_executor(name: &str, path: &str) -> Option<Arc<dyn CodeExecutor>> {
         match name {
-            "claude_code" => Some(Arc::new(claude_code::ClaudeCodeExecutor::new(path.to_string()))),
+            "claudecode" => Some(Arc::new(claude_code::ClaudeCodeExecutor::new(path.to_string()))),
             "joinai" => Some(Arc::new(joinai::JoinaiExecutor::new(path.to_string()))),
             "codebuddy" => Some(Arc::new(codebuddy::CodebuddyExecutor::new(path.to_string()))),
             "opencode" => Some(Arc::new(opencode::OpencodeExecutor::new(path.to_string()))),

--- a/backend/src/db/executor_config.rs
+++ b/backend/src/db/executor_config.rs
@@ -25,7 +25,7 @@ struct DefaultExecutor {
 }
 
 const DEFAULT_EXECUTORS: &[DefaultExecutor] = &[
-    DefaultExecutor { name: "claude_code", path: "claude", display_name: "Claude Code", session_dir: "~/.claude" },
+    DefaultExecutor { name: "claudecode", path: "claude", display_name: "Claude Code", session_dir: "~/.claude" },
     DefaultExecutor { name: "joinai", path: "joinai", display_name: "JoinAI", session_dir: "" },
     DefaultExecutor { name: "codebuddy", path: "codebuddy", display_name: "CodeBuddy", session_dir: "~/.codebuddy" },
     DefaultExecutor { name: "opencode", path: "opencode", display_name: "Opencode", session_dir: "~/.opencode" },
@@ -109,7 +109,7 @@ impl Database {
 
         for d in DEFAULT_EXECUTORS {
             let path = match d.name {
-                "claude_code" => &cfg_executors.claude_code,
+                "claudecode" => &cfg_executors.claude_code,
                 "joinai" => &cfg_executors.joinai,
                 "codebuddy" => &cfg_executors.codebuddy,
                 "opencode" => &cfg_executors.opencode,

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -233,7 +233,7 @@ fn scan_claude_code(sessions: &mut Vec<SessionInfo>) {
 
                     sessions.push(SessionInfo {
                         session_id: session_id.clone(),
-                        source: "claude_code".to_string(),
+                        source: "claudecode".to_string(),
                         project_path: project_path.clone(),
                         status: if active_set.contains(&session_id) { "active".into() } else { "completed".into() },
                         executor: executor.unwrap_or_else(|| "unknown".into()),
@@ -621,7 +621,7 @@ fn scan_atomcode(sessions: &mut Vec<SessionInfo>) {
 /// Only executors listed here will be scanned.
 fn get_scanner(name: &str) -> Option<fn(&mut Vec<SessionInfo>)> {
     match name {
-        "claude_code" => Some(scan_claude_code),
+        "claudecode" => Some(scan_claude_code),
         "codex" => Some(scan_codex),
         "hermes" => Some(scan_hermes),
         "kimi" => Some(scan_kimi),
@@ -902,7 +902,7 @@ fn get_claude_detail(session_id: &str) -> Option<SessionDetail> {
     Some(SessionDetail {
         info: SessionInfo {
             session_id: session_id.to_string(),
-            source: "claude_code".to_string(),
+            source: "claudecode".to_string(),
             project_path,
             status: if active_set.contains(session_id) { "active".into() } else { "completed".into() },
             executor: executor.unwrap_or_else(|| "unknown".into()),

--- a/frontend/src/components/SessionManager.tsx
+++ b/frontend/src/components/SessionManager.tsx
@@ -38,7 +38,7 @@ const { Text, Paragraph } = Typography;
 // ─── Source display config ────────────────────────────────
 
 const sourceConfig: Record<string, { label: string; color: string }> = {
-  'claude_code': { label: 'Claude Code', color: '#d97706' },
+  'claudecode': { label: 'Claude Code', color: '#d97706' },
   'codex': { label: 'Codex', color: '#10a37f' },
   'hermes': { label: 'Hermes', color: '#8b5cf6' },
   'kimi': { label: 'Kimi', color: '#3b82f6' },

--- a/frontend/src/components/TodoSettingsDrawer.tsx
+++ b/frontend/src/components/TodoSettingsDrawer.tsx
@@ -229,7 +229,7 @@ export function TodoSettingsDrawer({ open, todo, tags, onClose, onUpdated }: Tod
       </div>
 
       {/* Worktree Switch - Claude Code 和 Hermes 支持 */}
-      {(executor === 'claude_code' || executor === 'hermes') && (
+      {(executor === 'claudecode' || executor === 'hermes') && (
         <div style={{ marginBottom: 16 }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <div style={{ fontWeight: 600, fontSize: 14 }}>

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -252,7 +252,7 @@ export interface ExecutorOption {
 }
 
 export const EXECUTORS: ExecutorOption[] = [
-  { value: 'claude_code', label: 'Claude',    color: '#e17055', icon: <FaSquare color="#e17055" size={14} /> },
+  { value: 'claudecode', label: 'Claude',    color: '#e17055', icon: <FaSquare color="#e17055" size={14} /> },
   { value: 'codebuddy',  label: 'CodeBuddy', color: '#00b894', icon: <FaSquare color="#00b894" size={14} /> },
   { value: 'opencode',   label: 'Opencode',  color: '#fdcb6e', icon: <FaSquare color="#fdcb6e" size={14} /> },
   { value: 'joinai',     label: 'JoinAI',    color: '#6c5ce7', icon: <FaSquare color="#6c5ce7" size={14} /> },
@@ -263,7 +263,7 @@ export const EXECUTORS: ExecutorOption[] = [
 ];
 
 export const EXECUTOR_COLORS: Record<string, string> = {
-  claude_code: '#e17055',
+  claudecode: '#e17055',
   codebuddy: '#00b894',
   opencode: '#fdcb6e',
   joinai: '#6c5ce7',
@@ -310,7 +310,7 @@ export interface Config {
   history_message_max_age_secs?: number;
 }
 
-export const RESUMABLE_EXECUTORS = new Set(['claude_code', 'kimi', 'opencode', 'joinai']);
+export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'joinai']);
 
 export function supportsResume(record: ExecutionRecord): boolean {
   return (


### PR DESCRIPTION
## Summary
- 修复前后端 executor 命名不一致问题
- 将 `claude_code` 统一为 `claudecode`（无下划线）

## Changes
- 前端: `types/index.tsx`, `SessionManager.tsx`, `TodoSettingsDrawer.tsx`
- 后端: `handlers/session.rs`, `db/executor_config.rs`, `adapters/mod.rs`

## Test plan
- [x] 后端编译通过
- [x] 前端编译通过