### PR TITLE
fix(gui): add GH_TOKEN for gh api in check-trigger step

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Check if this was a tag trigger
         id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Get the workflow run details
           RUN_ID=${{ github.event.workflow_run.id }}


### PR DESCRIPTION
## Summary

**Bug**: Build GUI (Tauri) workflow failed at  step with:


**Root cause**: The  step calls {
  "message": "Not Found",
  "documentation_url": "https://docs.github.com/rest",
  "status": "404"
} but Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:        Authenticate gh and git with GitHub
  browse:      Open the repository in the browser
  codespace:   Connect to and manage codespaces
  gist:        Manage gists
  issue:       Manage issues
  org:         Manage organizations
  pr:          Manage pull requests
  project:     Work with GitHub Projects.
  release:     Manage releases
  repo:        Manage repositories

GITHUB ACTIONS COMMANDS
  cache:       Manage GitHub Actions caches
  run:         View details about workflow runs
  workflow:    View details about GitHub Actions workflows

EXTENSION COMMANDS
  webhook:     Extension webhook

ALIAS COMMANDS
  co:          Alias for "pr checkout"

ADDITIONAL COMMANDS
  alias:       Create command shortcuts
  api:         Make an authenticated GitHub API request
  attestation: Work with artifact attestations
  completion:  Generate shell completion scripts
  config:      Manage configuration for gh
  extension:   Manage gh extensions
  gpg-key:     Manage GPG keys
  label:       Manage labels
  ruleset:     View info about repo rulesets
  search:      Search for repositories, issues, and pull requests
  secret:      Manage GitHub secrets
  ssh-key:     Manage SSH keys
  status:      Print information about relevant issues, pull requests, and notifications across repositories
  variable:    Manage GitHub Actions variables

HELP TOPICS
  actions:     Learn about working with GitHub Actions
  environment: Environment variables that can be used with gh
  exit-codes:  Exit codes used by gh
  formatting:  Formatting options for JSON data exported from gh
  mintty:      Information about using gh with MinTTY
  reference:   A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes` CLI requires  env var to be set in GitHub Actions. The workflow had  permission but didn't set .

**Fix**: Added  to the  step.

**Impact**: Without this fix, the workflow always fails on the  call regardless of whether it was a tag trigger or not. With the fix, the step correctly identifies non-tag runs and sets , allowing the subsequent jobs to be skipped (not failed).