### PR TITLE
fix: add github-token to download-artifact in workflow_run trigger

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -39,13 +39,22 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      # Download artifacts from the triggering rust.yaml workflow run
+      # Download artifacts from the triggering rust.yaml workflow run using curl
       - name: Download backend binary
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.artifact_name }}
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "Downloading artifact ${{ matrix.artifact_name }} from workflow run ${{ github.event.workflow_run.id }}"
+          # Get artifact ID and download URL from the triggering workflow run
+          ARTIFACT_DATA=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts --jq '.artifacts[] | select(.name == "${{ matrix.artifact_name }}") | {id, archive_download_url}')
+          ARTIFACT_ID=$(echo "$ARTIFACT_DATA" | jq -r '.id')
+          DOWNLOAD_URL=$(echo "$ARTIFACT_DATA" | jq -r '.archive_download_url')
+          echo "Artifact ID: $ARTIFACT_ID"
+          echo "Download URL: $DOWNLOAD_URL"
+          # Download and extract artifact
+          curl -L -o artifact.zip "$DOWNLOAD_URL"
+          unzip -o artifact.zip
+          rm artifact.zip
+          ls -la
 
       - name: Verify backend binary
         shell: bash

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify backend binary
         shell: bash


### PR DESCRIPTION
## Summary
- Add `github-token` parameter to download-artifact action in gui.yml
- This may fix the "Artifact not found" error when downloading artifacts from workflow_run trigger

## Test plan
- [ ] Verify GitHub Action builds successfully