### PR TITLE
feat: Tauri app loads ntd frontend dynamically instead of bundling

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -496,6 +496,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -517,9 +527,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -530,7 +540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1000,12 +1010,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1018,6 +1037,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1412,6 +1437,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1559,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1523,6 +1568,37 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1543,9 +1619,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2038,6 +2116,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,6 +2168,7 @@ version = "0.1.0"
 dependencies = [
  "dirs",
  "log",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2333,6 +2429,49 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2756,6 +2895,46 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -2789,6 +2968,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,6 +3010,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,6 +3061,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2893,6 +3128,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3016,6 +3274,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3272,6 +3542,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3324,6 +3600,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3344,7 +3641,7 @@ checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -3423,7 +3720,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3843,6 +4140,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4168,6 +4485,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4215,6 +4538,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -4645,6 +4974,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4687,6 +5027,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5223,6 +5572,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -704,11 +704,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -719,7 +740,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2071,9 +2092,11 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 name = "ntd-desktop"
 version = "0.1.0"
 dependencies = [
+ "dirs 5.0.1",
  "log",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
@@ -2694,6 +2717,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -2819,6 +2853,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3040,6 +3080,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3381,7 +3434,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -3431,7 +3484,7 @@ checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4037,7 +4090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -4139,6 +4192,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
@@ -4664,6 +4723,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -4702,6 +4770,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4763,6 +4846,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4781,6 +4870,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4796,6 +4891,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4829,6 +4930,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4844,6 +4951,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4865,6 +4978,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4880,6 +4999,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5037,7 +5162,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -704,32 +704,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys 0.5.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.4.6",
- "windows-sys 0.48.0",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -740,7 +719,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.2",
+ "redox_users",
  "windows-sys 0.61.2",
 ]
 
@@ -2092,7 +2071,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 name = "ntd-desktop"
 version = "0.1.0"
 dependencies = [
- "dirs 5.0.1",
+ "dirs",
  "log",
  "serde",
  "serde_json",
@@ -2713,17 +2692,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.1",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3434,7 +3402,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs 6.0.0",
+ "dirs",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -3484,7 +3452,7 @@ checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs 6.0.0",
+ "dirs",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4090,7 +4058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
- "dirs 6.0.0",
+ "dirs",
  "libappindicator",
  "muda",
  "objc2",
@@ -4723,15 +4691,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -4770,21 +4729,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4846,12 +4790,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4870,12 +4808,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4891,12 +4823,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4930,12 +4856,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4951,12 +4871,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4978,12 +4892,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4999,12 +4907,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5162,7 +5064,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs 6.0.0",
+ "dirs",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,3 +22,4 @@ serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }
 log = "0.4"
 dirs = "6"
+reqwest = { version = "0.12", features = ["json"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,4 +21,4 @@ serde_json = "1"
 serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }
 log = "0.4"
-dirs = "5"
+dirs = "6"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,5 +18,7 @@ tauri-plugin-window-state = "2"
 tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }
 log = "0.4"
+dirs = "5"

--- a/src-tauri/src/backend.rs
+++ b/src-tauri/src/backend.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::process::Command;
 use tokio::process::Command as TokioCommand;
 use tokio::time::Duration;
 
@@ -10,9 +11,20 @@ pub enum NtdStatus {
     NotInstalled,
 }
 
-/// Read port from ~/.ntd/config.yaml
+fn expand_tilde(path: &str) -> Result<PathBuf, String> {
+    if path.starts_with("~/") {
+        let home = dirs::home_dir().ok_or("Cannot find home directory")?;
+        Ok(home.join(path.trim_start_matches("~/")))
+    } else {
+        Ok(PathBuf::from(path))
+    }
+}
+
 fn read_port_from_config() -> u16 {
-    let path = expand_tilde(CONFIG_PATH);
+    let path = match expand_tilde(CONFIG_PATH) {
+        Ok(p) => p,
+        Err(_) => return DEFAULT_PORT,
+    };
     if let Ok(content) = std::fs::read_to_string(&path) {
         if let Ok(map) = serde_yaml::from_str::<serde_yaml::Value>(&content) {
             if let Some(port) = map.get("port").and_then(|v| v.as_u64()) {
@@ -23,25 +35,23 @@ fn read_port_from_config() -> u16 {
     DEFAULT_PORT
 }
 
-fn expand_tilde(path: &str) -> PathBuf {
-    if path.starts_with("~/") {
-        if let Some(home) = dirs::home_dir() {
-            return home.join(path.trim_start_matches("~/"));
+fn is_file_executable(path: &PathBuf) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(metadata) = std::fs::metadata(path) {
+            let mode = metadata.permissions().mode();
+            return (mode & 0o111) != 0;
         }
+        return false;
     }
-    PathBuf::from(path)
-}
-
-/// Check if ntd is running on the given port
-async fn is_ntd_running(port: u16) -> bool {
-    tokio::net::TcpStream::connect(format!("localhost:{}", port))
-        .await
-        .is_ok()
+    #[cfg(not(unix))]
+    true
 }
 
 fn find_ntd_binary() -> Option<String> {
     // Try ntd --version to verify it's installed and executable
-    if std::process::Command::new("ntd")
+    if Command::new("ntd")
         .arg("--version")
         .output()
         .map(|o| o.status.success())
@@ -56,9 +66,8 @@ fn find_ntd_binary() -> Option<String> {
     if let Some(home) = dirs::home_dir() {
         for candidate in &candidates {
             let path = home.join(candidate);
-            if path.exists() {
-                // Verify it's executable
-                if std::process::Command::new(&path)
+            if path.exists() && is_file_executable(&path) {
+                if Command::new(&path)
                     .arg("--version")
                     .output()
                     .map(|o| o.status.success())
@@ -73,7 +82,20 @@ fn find_ntd_binary() -> Option<String> {
     None
 }
 
-/// Check ntd installation and running status
+async fn is_ntd_responding(port: u16) -> bool {
+    let url = format!("http://localhost:{}/health", port);
+    match reqwest::get(&url).await {
+        Ok(resp) => resp.status().is_success(),
+        Err(_) => false,
+    }
+}
+
+async fn is_port_open(port: u16) -> bool {
+    tokio::net::TcpStream::connect(format!("localhost:{}", port))
+        .await
+        .is_ok()
+}
+
 pub async fn check_ntd_status() -> NtdStatus {
     let port = read_port_from_config();
 
@@ -81,14 +103,13 @@ pub async fn check_ntd_status() -> NtdStatus {
         return NtdStatus::NotInstalled;
     }
 
-    if is_ntd_running(port).await {
+    if is_port_open(port).await && is_ntd_responding(port).await {
         NtdStatus::Installed { running: true, port }
     } else {
         NtdStatus::Installed { running: false, port }
     }
 }
 
-/// Start ntd daemon
 pub async fn start_ntd_daemon(port: u16) -> Result<u16, String> {
     let ntd_bin = find_ntd_binary().ok_or("ntd binary not found")?;
 
@@ -97,14 +118,14 @@ pub async fn start_ntd_daemon(port: u16) -> Result<u16, String> {
         .spawn()
         .map_err(|e| format!("Failed to spawn ntd daemon: {}", e))?;
 
-    // Wait for ntd to be ready
+    // Wait for ntd to be ready with health check
     let start = std::time::Instant::now();
     while start.elapsed() < Duration::from_secs(30) {
-        if is_ntd_running(port).await {
+        if is_port_open(port).await && is_ntd_responding(port).await {
             return Ok(port);
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
-    Err("ntd daemon failed to start".to_string())
+    Err("ntd daemon failed to start or health check timeout".to_string())
 }

--- a/src-tauri/src/backend.rs
+++ b/src-tauri/src/backend.rs
@@ -99,7 +99,7 @@ pub async fn start_ntd_daemon(port: u16) -> Result<u16, String> {
 
     // Wait for ntd to be ready
     let start = std::time::Instant::now();
-    while start.elapsed() < Duration::from_secs(10) {
+    while start.elapsed() < Duration::from_secs(30) {
         if is_ntd_running(port).await {
             return Ok(port);
         }

--- a/src-tauri/src/backend.rs
+++ b/src-tauri/src/backend.rs
@@ -1,74 +1,102 @@
 use std::path::PathBuf;
-use tokio::process::Command;
+use tokio::process::Command as TokioCommand;
 use tokio::time::Duration;
 
-pub async fn spawn_backend() -> Result<u16, String> {
-    let exe_path = std::env::current_exe()
-        .map_err(|e| format!("Failed to get exe path: {}", e))?;
+const CONFIG_PATH: &str = "~/.ntd/config.yaml";
+const DEFAULT_PORT: u16 = 8088;
 
-    let backend_bin = find_backend_binary(&exe_path)?;
-    let port = find_available_port().await?;
+pub enum NtdStatus {
+    Installed { running: bool, port: u16 },
+    NotInstalled,
+}
 
-    let mut child = Command::new(&backend_bin)
-        .args(["server", "start", "--port", &port.to_string()])
+/// Read port from ~/.ntd/config.yaml
+fn read_port_from_config() -> u16 {
+    let path = expand_tilde(CONFIG_PATH);
+    if let Ok(content) = std::fs::read_to_string(&path) {
+        if let Ok(map) = serde_yaml::from_str::<serde_yaml::Value>(&content) {
+            if let Some(port) = map.get("port").and_then(|v| v.as_u64()) {
+                return port as u16;
+            }
+        }
+    }
+    DEFAULT_PORT
+}
+
+fn expand_tilde(path: &str) -> PathBuf {
+    if path.starts_with("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(path.trim_start_matches("~/").trim_start_matches('/'));
+        }
+    }
+    PathBuf::from(path)
+}
+
+/// Check if ntd is running on the given port
+async fn is_ntd_running(port: u16) -> bool {
+    tokio::net::TcpStream::connect(format!("localhost:{}", port))
+        .await
+        .is_ok()
+}
+
+fn find_ntd_binary() -> Option<String> {
+    // Check if ntd is in PATH
+    if std::process::Command::new("which")
+        .arg("ntd")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+    {
+        return Some("ntd".to_string());
+    }
+
+    // Check common installation locations
+    let candidates = [".local/bin/ntd", "bin/ntd"];
+
+    if let Some(home) = dirs::home_dir() {
+        for candidate in &candidates {
+            let path = home.join(candidate);
+            if path.exists() {
+                return Some(path.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    None
+}
+
+/// Check ntd installation and running status
+pub async fn check_ntd_status() -> NtdStatus {
+    let port = read_port_from_config();
+
+    if find_ntd_binary().is_none() {
+        return NtdStatus::NotInstalled;
+    }
+
+    if is_ntd_running(port).await {
+        NtdStatus::Installed { running: true, port }
+    } else {
+        NtdStatus::Installed { running: false, port }
+    }
+}
+
+/// Start ntd daemon
+pub async fn start_ntd_daemon(port: u16) -> Result<u16, String> {
+    let ntd_bin = find_ntd_binary().ok_or("ntd binary not found")?;
+
+    TokioCommand::new(&ntd_bin)
+        .args(["daemon", "start"])
         .spawn()
-        .map_err(|e| format!("Failed to spawn backend: {}", e))?;
+        .map_err(|e| format!("Failed to spawn ntd daemon: {}", e))?;
 
-    // Wait for backend to be ready
+    // Wait for ntd to be ready
     let start = std::time::Instant::now();
-
     while start.elapsed() < Duration::from_secs(10) {
-        if tokio::net::TcpStream::connect(format!("localhost:{}", port))
-            .await
-            .is_ok()
-        {
+        if is_ntd_running(port).await {
             return Ok(port);
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
-    let _ = child.kill().await;
-    Err("Backend failed to start".to_string())
-}
-
-fn find_backend_binary(exe_path: &PathBuf) -> Result<PathBuf, String> {
-    // Development: use locally-built binary (relative to src-tauri/)
-    let dev_path = PathBuf::from("../../backend/target/release/ntd");
-    if dev_path.exists() {
-        return Ok(dev_path);
-    }
-
-    // Release: binary is bundled alongside Tauri app
-    // Check both with and without .exe suffix for cross-platform compatibility
-    if let Some(parent) = exe_path.parent() {
-        let candidates = if cfg!(windows) {
-            vec![parent.join("ntd.exe"), parent.join("ntd")]
-        } else {
-            vec![parent.join("ntd")]
-        };
-
-        for candidate in candidates {
-            if candidate.exists() {
-                return Ok(candidate);
-            }
-        }
-    }
-
-    Err("Could not find ntd backend binary".to_string())
-}
-
-/// Find an available port in range 8089-8189.
-/// Note: This is best-effort due to TOCTOU race condition - another process
-/// may bind the port between our check and actual use. The spawn_backend()
-/// function validates by waiting for the server to actually start.
-async fn find_available_port() -> Result<u16, String> {
-    for port in 8089..8189 {
-        if tokio::net::TcpStream::connect(format!("localhost:{}", port))
-            .await
-            .is_err()
-        {
-            return Ok(port);
-        }
-    }
-    Err("No available port found".to_string())
+    Err("ntd daemon failed to start".to_string())
 }

--- a/src-tauri/src/backend.rs
+++ b/src-tauri/src/backend.rs
@@ -26,7 +26,7 @@ fn read_port_from_config() -> u16 {
 fn expand_tilde(path: &str) -> PathBuf {
     if path.starts_with("~/") {
         if let Some(home) = dirs::home_dir() {
-            return home.join(path.trim_start_matches("~/").trim_start_matches('/'));
+            return home.join(path.trim_start_matches("~/"));
         }
     }
     PathBuf::from(path)
@@ -40,9 +40,9 @@ async fn is_ntd_running(port: u16) -> bool {
 }
 
 fn find_ntd_binary() -> Option<String> {
-    // Check if ntd is in PATH
-    if std::process::Command::new("which")
-        .arg("ntd")
+    // Try ntd --version to verify it's installed and executable
+    if std::process::Command::new("ntd")
+        .arg("--version")
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
@@ -57,7 +57,15 @@ fn find_ntd_binary() -> Option<String> {
         for candidate in &candidates {
             let path = home.join(candidate);
             if path.exists() {
-                return Some(path.to_string_lossy().to_string());
+                // Verify it's executable
+                if std::process::Command::new(&path)
+                    .arg("--version")
+                    .output()
+                    .map(|o| o.status.success())
+                    .unwrap_or(false)
+                {
+                    return Some(path.to_string_lossy().to_string());
+                }
             }
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tauri::{
     menu::{Menu, MenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
@@ -8,24 +9,131 @@ use tauri::{
 mod backend;
 
 pub struct AppState {
-    pub backend_port: Mutex<u16>,
+    pub backend_url: Mutex<String>,
 }
 
 #[tauri::command]
 fn get_backend_url(state: tauri::State<Arc<AppState>>) -> String {
-    let port = *state.backend_port.lock().expect("backend_port mutex poisoned");
-    format!("http://localhost:{}", port)
+    state.backend_url.lock().expect("backend_url mutex poisoned").clone()
 }
+
+const INSTALL_PAGE: &str = r#"<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ntd - 安装</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .container {
+      background: white;
+      border-radius: 16px;
+      padding: 48px;
+      max-width: 500px;
+      text-align: center;
+      box-shadow: 0 25px 50px -12px rgba(0,0,0,0.25);
+    }
+    h1 {
+      color: #1a1a2e;
+      margin-bottom: 16px;
+      font-size: 28px;
+    }
+    p {
+      color: #64748b;
+      margin-bottom: 24px;
+      line-height: 1.6;
+    }
+    .command {
+      background: #1a1a2e;
+      color: #a5f3fc;
+      padding: 16px 24px;
+      border-radius: 8px;
+      font-family: 'SF Mono', Monaco, monospace;
+      font-size: 14px;
+      margin-bottom: 24px;
+      word-break: break-all;
+    }
+    .step {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 16px;
+      text-align: left;
+    }
+    .step-num {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      background: #667eea;
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: bold;
+      flex-shrink: 0;
+    }
+    .step-text {
+      color: #334155;
+    }
+    .spinner {
+      width: 40px;
+      height: 40px;
+      border: 4px solid #e2e8f0;
+      border-top-color: #667eea;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+      margin: 0 auto 24px;
+    }
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+    .hidden { display: none; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div id="install-section">
+      <h1>欢迎使用 ntd</h1>
+      <p>看起来你还没有安装 ntd，请按照以下步骤安装：</p>
+      <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-text">安装 ntd</div>
+      </div>
+      <div class="command">npm install -g @weibaohui/nothing-todo@latest</div>
+      <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-text">启动 ntd 服务</div>
+      </div>
+      <div class="command">ntd daemon start</div>
+      <p style="color: #94a3b8; font-size: 14px; margin-top: 24px;">
+        安装并启动后，关闭此窗口重新打开即可。
+      </p>
+    </div>
+    <div id="loading-section" class="hidden">
+      <div class="spinner"></div>
+      <h1>正在启动...</h1>
+      <p>请稍候，正在启动 ntd 服务</p>
+    </div>
+  </div>
+</body>
+</html>
+"#;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // Create the shared state before setup
     let app_state = Arc::new(AppState {
-        backend_port: Mutex::new(0),
+        backend_url: Mutex::new(String::new()),
     });
 
-    // Clone for the spawned task
-    let state_for_task = app_state.clone();
+    let state_for_setup = app_state.clone();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -37,16 +145,52 @@ pub fn run() {
             }
         }))
         .manage(app_state)
-        .setup(move |_app| {
-            // Spawn backend using Tauri's async runtime to avoid "runtime within runtime" panic
+        .setup(move |app| {
+            let main_window = app.get_webview_window("main").unwrap();
+
             tauri::async_runtime::spawn(async move {
-                match backend::spawn_backend().await {
-                    Ok(port) => {
-                        *state_for_task.backend_port.lock().expect("backend_port mutex poisoned") = port;
-                        log::info!("Backend spawned on port {}", port);
+                match backend::check_ntd_status().await {
+                    backend::NtdStatus::NotInstalled => {
+                        log::info!("ntd not installed, showing install page");
+                        if let Err(e) = main_window.eval(&format!(
+                            "document.write('{}'); document.close()",
+                            INSTALL_PAGE.replace('\\', "\\\\").replace('\'', "\\'").replace('\n', "\\n")
+                        )) {
+                            log::error!("Failed to show install page: {}", e);
+                        }
                     }
-                    Err(e) => {
-                        log::error!("Failed to spawn backend: {}", e);
+                    backend::NtdStatus::Installed { running: true, port } => {
+                        let url = format!("http://localhost:{}", port);
+                        *state_for_setup.backend_url.lock().expect("backend_url mutex poisoned") = url.clone();
+                        log::info!("ntd already running on {}, redirecting", port);
+                        if let Err(e) = main_window.eval(&format!("window.location.href = '{}'", url)) {
+                            log::error!("Failed to redirect: {}", e);
+                        }
+                    }
+                    backend::NtdStatus::Installed { running: false, port } => {
+                        log::info!("ntd installed but not running, starting daemon on port {}", port);
+                        // Show loading page first
+                        if let Err(e) = main_window.eval(&format!(
+                            "document.write('{}'); document.close()",
+                            INSTALL_PAGE.replace('\\', "\\\\").replace('\'', "\\'").replace('\n', "\\n")
+                        )) {
+                            log::error!("Failed to show loading: {}", e);
+                        }
+
+                        match backend::start_ntd_daemon(port).await {
+                            Ok(port) => {
+                                let url = format!("http://localhost:{}", port);
+                                *state_for_setup.backend_url.lock().expect("backend_url mutex poisoned") = url.clone();
+                                // Small delay then redirect
+                                tokio::time::sleep(Duration::from_secs(1)).await;
+                                if let Err(e) = main_window.eval(&format!("window.location.href = '{}'", url)) {
+                                    log::error!("Failed to redirect: {}", e);
+                                }
+                            }
+                            Err(e) => {
+                                log::error!("Failed to start ntd daemon: {}", e);
+                            }
+                        }
                     }
                 }
             });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,16 +41,8 @@ const INSTALL_PAGE: &str = r#"<!DOCTYPE html>
       text-align: center;
       box-shadow: 0 25px 50px -12px rgba(0,0,0,0.25);
     }
-    h1 {
-      color: #1a1a2e;
-      margin-bottom: 16px;
-      font-size: 28px;
-    }
-    p {
-      color: #64748b;
-      margin-bottom: 24px;
-      line-height: 1.6;
-    }
+    h1 { color: #1a1a2e; margin-bottom: 16px; font-size: 28px; }
+    p { color: #64748b; margin-bottom: 24px; line-height: 1.6; }
     .command {
       background: #1a1a2e;
       color: #a5f3fc;
@@ -61,27 +53,60 @@ const INSTALL_PAGE: &str = r#"<!DOCTYPE html>
       margin-bottom: 24px;
       word-break: break-all;
     }
-    .step {
-      display: flex;
-      align-items: center;
-      gap: 16px;
-      margin-bottom: 16px;
-      text-align: left;
-    }
+    .step { display: flex; align-items: center; gap: 16px; margin-bottom: 16px; text-align: left; }
     .step-num {
-      width: 32px;
-      height: 32px;
-      border-radius: 50%;
-      background: #667eea;
-      color: white;
+      width: 32px; height: 32px; border-radius: 50%;
+      background: #667eea; color: white;
+      display: flex; align-items: center; justify-content: center;
+      font-weight: bold; flex-shrink: 0;
+    }
+    .step-text { color: #334155; }
+    .hint { color: #94a3b8; font-size: 14px; margin-top: 24px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>欢迎使用 ntd</h1>
+    <p>请按照以下步骤安装：</p>
+    <div class="step">
+      <div class="step-num">1</div>
+      <div class="step-text">安装 ntd</div>
+    </div>
+    <div class="command">npm install -g @weibaohui/nothing-todo@latest</div>
+    <div class="step">
+      <div class="step-num">2</div>
+      <div class="step-text">启动 ntd 服务</div>
+    </div>
+    <div class="command">ntd daemon start</div>
+    <p class="hint">安装并启动后，关闭此窗口重新打开即可。</p>
+  </div>
+</body>
+</html>
+"#;
+
+const LOADING_PAGE: &str = r#"<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ntd - 启动中</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      min-height: 100vh;
       display: flex;
       align-items: center;
       justify-content: center;
-      font-weight: bold;
-      flex-shrink: 0;
     }
-    .step-text {
-      color: #334155;
+    .container {
+      background: white;
+      border-radius: 16px;
+      padding: 48px;
+      max-width: 400px;
+      text-align: center;
+      box-shadow: 0 25px 50px -12px rgba(0,0,0,0.25);
     }
     .spinner {
       width: 40px;
@@ -92,40 +117,30 @@ const INSTALL_PAGE: &str = r#"<!DOCTYPE html>
       animation: spin 1s linear infinite;
       margin: 0 auto 24px;
     }
-    @keyframes spin {
-      to { transform: rotate(360deg); }
-    }
-    .hidden { display: none; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    h1 { color: #1a1a2e; margin-bottom: 8px; font-size: 24px; }
+    p { color: #64748b; }
   </style>
 </head>
 <body>
   <div class="container">
-    <div id="install-section">
-      <h1>欢迎使用 ntd</h1>
-      <p>看起来你还没有安装 ntd，请按照以下步骤安装：</p>
-      <div class="step">
-        <div class="step-num">1</div>
-        <div class="step-text">安装 ntd</div>
-      </div>
-      <div class="command">npm install -g @weibaohui/nothing-todo@latest</div>
-      <div class="step">
-        <div class="step-num">2</div>
-        <div class="step-text">启动 ntd 服务</div>
-      </div>
-      <div class="command">ntd daemon start</div>
-      <p style="color: #94a3b8; font-size: 14px; margin-top: 24px;">
-        安装并启动后，关闭此窗口重新打开即可。
-      </p>
-    </div>
-    <div id="loading-section" class="hidden">
-      <div class="spinner"></div>
-      <h1>正在启动...</h1>
-      <p>请稍候，正在启动 ntd 服务</p>
-    </div>
+    <div class="spinner"></div>
+    <h1>正在启动...</h1>
+    <p>请稍候</p>
   </div>
 </body>
 </html>
 "#;
+
+fn show_html(window: &tauri::WebviewWindow, html: &str) {
+    let escaped = html
+        .replace('\\', "\\\\")
+        .replace('\'', "\\'")
+        .replace('\n', "\\n");
+    if let Err(e) = window.eval(&format!("document.write('{}'); document.close()", escaped)) {
+        log::error!("Failed to show HTML: {}", e);
+    }
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -146,18 +161,15 @@ pub fn run() {
         }))
         .manage(app_state)
         .setup(move |app| {
-            let main_window = app.get_webview_window("main").unwrap();
+            let main_window = app
+                .get_webview_window("main")
+                .expect("main window not found");
 
             tauri::async_runtime::spawn(async move {
                 match backend::check_ntd_status().await {
                     backend::NtdStatus::NotInstalled => {
                         log::info!("ntd not installed, showing install page");
-                        if let Err(e) = main_window.eval(&format!(
-                            "document.write('{}'); document.close()",
-                            INSTALL_PAGE.replace('\\', "\\\\").replace('\'', "\\'").replace('\n', "\\n")
-                        )) {
-                            log::error!("Failed to show install page: {}", e);
-                        }
+                        show_html(&main_window, INSTALL_PAGE);
                     }
                     backend::NtdStatus::Installed { running: true, port } => {
                         let url = format!("http://localhost:{}", port);
@@ -169,19 +181,12 @@ pub fn run() {
                     }
                     backend::NtdStatus::Installed { running: false, port } => {
                         log::info!("ntd installed but not running, starting daemon on port {}", port);
-                        // Show loading page first
-                        if let Err(e) = main_window.eval(&format!(
-                            "document.write('{}'); document.close()",
-                            INSTALL_PAGE.replace('\\', "\\\\").replace('\'', "\\'").replace('\n', "\\n")
-                        )) {
-                            log::error!("Failed to show loading: {}", e);
-                        }
+                        show_html(&main_window, LOADING_PAGE);
 
                         match backend::start_ntd_daemon(port).await {
                             Ok(port) => {
                                 let url = format!("http://localhost:{}", port);
                                 *state_for_setup.backend_url.lock().expect("backend_url mutex poisoned") = url.clone();
-                                // Small delay then redirect
                                 tokio::time::sleep(Duration::from_secs(1)).await;
                                 if let Err(e) = main_window.eval(&format!("window.location.href = '{}'", url)) {
                                     log::error!("Failed to redirect: {}", e);
@@ -198,7 +203,6 @@ pub fn run() {
             Ok(())
         })
         .setup(|app| {
-            // System tray
             let quit_item = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
             let show_item = MenuItem::with_id(app, "show", "Show", true, None::<&str>)?;
             let menu = Menu::with_items(app, &[&show_item, &quit_item])?;
@@ -231,7 +235,6 @@ pub fn run() {
                 })
                 .build(app)?;
 
-            // Close to tray
             if let Some(main_window) = app.get_webview_window("main") {
                 let window_clone = main_window.clone();
                 main_window.on_window_event(move |event| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -132,6 +132,58 @@ const LOADING_PAGE: &str = r#"<!DOCTYPE html>
 </html>
 "#;
 
+const ERROR_PAGE: &str = r#"<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ntd - 启动失败</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .container {
+      background: white;
+      border-radius: 16px;
+      padding: 48px;
+      max-width: 500px;
+      text-align: center;
+      box-shadow: 0 25px 50px -12px rgba(0,0,0,0.25);
+    }
+    h1 { color: #1a1a2e; margin-bottom: 16px; font-size: 28px; }
+    p { color: #64748b; margin-bottom: 24px; line-height: 1.6; }
+    .command {
+      background: #1a1a2e;
+      color: #a5f3fc;
+      padding: 16px 24px;
+      border-radius: 8px;
+      font-family: 'SF Mono', Monaco, monospace;
+      font-size: 14px;
+      margin-bottom: 24px;
+      word-break: break-all;
+    }
+    .hint { color: #94a3b8; font-size: 14px; margin-top: 24px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>启动失败</h1>
+    <p>无法自动启动 ntd 服务，请手动启动：</p>
+    <div class="command">ntd daemon start</div>
+    <p class="hint">启动后关闭此窗口重新打开即可。</p>
+  </div>
+</body>
+</html>
+"#;
+
+/// Shows HTML content by replacing the entire document.
+/// This is intentional for the loading/install/error pages - we want to replace everything.
 fn show_html(window: &tauri::WebviewWindow, html: &str) {
     let escaped = html
         .replace('\\', "\\\\")
@@ -194,6 +246,7 @@ pub fn run() {
                             }
                             Err(e) => {
                                 log::error!("Failed to start ntd daemon: {}", e);
+                                show_html(&main_window, ERROR_PAGE);
                             }
                         }
                     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,9 +4,7 @@
   "version": "0.1.0",
   "identifier": "com.ntd.desktop",
   "build": {
-    "devUrl": "http://localhost:5173",
-    "beforeDevCommand": "cd ../frontend && npm run dev",
-    "frontendDist": "../frontend/dist"
+    "devUrl": "http://localhost:8088"
   },
   "app": {
     "windows": [{


### PR DESCRIPTION
## Summary

- Tauri 现在动态加载 ntd 前端，不再打包 frontend/dist
- 从 `~/.ntd/config.yaml` 读取端口配置
- 未安装 ntd 时显示安装引导页面
- 已安装但未运行时自动执行 `ntd daemon start`
- 已运行则直接跳转 `http://localhost:{port}`

## Test plan

- [ ] 构建 Tauri app 并运行
- [ ] 验证未安装 ntd 时显示引导页面
- [ ] 验证已安装但未运行时自动启动
- [ ] 验证已运行时直接加载页面
- [ ] 验证 DMG 打包正常