### PR TITLE
feat: 飞书看板 — 新增 Feishu 风格任务看板视图

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1789,16 +1789,13 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
- "ipnet",
  "libc",
- "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2011,16 +2008,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-terminal"
@@ -3197,25 +3184,30 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "ipnet",
  "js-sys",
  "log",
+ "mime",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls 0.23.40",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3223,14 +3215,13 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
- "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 0.26.11",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3411,6 +3402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3851,7 +3851,7 @@ dependencies = [
  "percent-encoding",
  "rust_decimal",
  "rustls 0.21.12",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "sha2",
@@ -4461,14 +4461,11 @@ dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5169,6 +5166,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5184,6 +5201,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2397,3 +2397,301 @@ code {
     column-count: 4;
   }
 }
+
+/* ============================================================
+   Feishu Kanban Board — 飞书看板
+   ============================================================ */
+
+.kanban-board {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  height: 100%;
+}
+
+/* ─── Top Bar ─── */
+.kanban-topbar {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-lg);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-elevated);
+}
+
+.kanban-topbar-left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.kanban-search {
+  border-radius: var(--radius-sm);
+}
+
+.kanban-topbar-right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: 12px;
+  flex-wrap: wrap;
+}
+
+.kanban-summary-item {
+  white-space: nowrap;
+  font-size: 12px;
+}
+
+.kanban-summary-item strong {
+  font-weight: 700;
+}
+
+.kanban-summary-divider {
+  width: 1px;
+  height: 14px;
+  background: var(--color-border);
+}
+
+/* ─── Columns Container ─── */
+.kanban-columns-container {
+  flex: 1;
+  display: flex;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+  overflow-x: auto;
+  overflow-y: hidden;
+  align-items: flex-start;
+}
+
+.kanban-columns-container::-webkit-scrollbar {
+  height: 6px;
+}
+
+.kanban-columns-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.kanban-columns-container::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: 3px;
+}
+
+/* ─── Column ─── */
+.kanban-column {
+  flex: 1;
+  min-width: 240px;
+  max-width: 340px;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-fill-quaternary, #f1f5f9);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-light);
+  max-height: 100%;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+[data-theme="dark"] .kanban-column {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.kanban-column.drag-over {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-primary-light);
+  background: var(--color-primary-bg);
+}
+
+/* ─── Column Header ─── */
+.kanban-column-header {
+  flex-shrink: 0;
+  padding: var(--space-md) var(--space-md);
+  border-bottom: 2px solid;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.kanban-column-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.kanban-column-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.kanban-column-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 700;
+  background: var(--color-fill-quaternary, #e2e8f0);
+  color: var(--color-text-secondary);
+  line-height: 1;
+}
+
+[data-theme="dark"] .kanban-column-count {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* ─── Column Body ─── */
+.kanban-column-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-height: 60px;
+}
+
+.kanban-column-body::-webkit-scrollbar {
+  width: 4px;
+}
+
+.kanban-column-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.kanban-column-body::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: 2px;
+}
+
+.kanban-column-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60px;
+  font-size: 13px;
+  color: var(--color-text-tertiary);
+  font-style: italic;
+}
+
+/* ─── Card ─── */
+.kanban-card {
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-sm);
+  padding: var(--space-md);
+  border: 1px solid var(--color-border-light);
+  border-left: 3px solid;
+  cursor: pointer;
+  transition: box-shadow var(--transition-fast), transform var(--transition-fast);
+  user-select: none;
+}
+
+.kanban-card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.kanban-card.selected {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-primary);
+}
+
+.kanban-card.dragging {
+  opacity: 0.5;
+  box-shadow: var(--shadow-md);
+}
+
+.kanban-card:active {
+  cursor: grabbing;
+}
+
+.kanban-card-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.5;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+  margin-bottom: var(--space-xs);
+}
+
+.kanban-card-desc {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  line-height: 1.5;
+  margin-bottom: var(--space-sm);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.kanban-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: var(--space-sm);
+}
+
+.kanban-tag-badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-weight: 500;
+  line-height: 1.6;
+}
+
+.kanban-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  font-size: 11px;
+}
+
+.kanban-card-time {
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
+  font-size: 11px;
+}
+
+/* ─── Responsive ─── */
+@media (max-width: 768px) {
+  .kanban-topbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .kanban-topbar-left {
+    width: 100%;
+  }
+
+  .kanban-search {
+    width: 100% !important;
+  }
+
+  .kanban-topbar-right {
+    justify-content: center;
+  }
+
+  .kanban-columns-container {
+    padding: var(--space-sm);
+    gap: var(--space-sm);
+  }
+
+  .kanban-column {
+    min-width: 200px;
+    max-width: 260px;
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2621,7 +2621,8 @@ code {
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  word-break: break-word;
+  overflow-wrap: anywhere;
+  word-break: normal;
   margin-bottom: var(--space-xs);
 }
 

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -1,0 +1,292 @@
+import { useState, useMemo, useCallback } from 'react';
+import { Input, App } from 'antd';
+import { SearchOutlined } from '@ant-design/icons';
+import { useApp } from '../hooks/useApp';
+import { ExecutorBadge } from './ExecutorBadge';
+import * as db from '../utils/database';
+import { formatRelativeTime } from '../utils/datetime';
+import type { Todo } from '../types';
+
+/* ─── Column Definitions ─── */
+
+interface ColumnDef {
+  status: Todo['status'];
+  label: string;
+  color: string;
+}
+
+const COLUMNS: ColumnDef[] = [
+  { status: 'pending',   label: '待办',     color: '#3b82f6' },
+  { status: 'running',   label: '进行中',   color: '#f59e0b' },
+  { status: 'completed', label: '已完成',   color: '#22c55e' },
+  { status: 'failed',    label: '失败',     color: '#ef4444' },
+];
+
+/* ─── Helpers ─── */
+
+function getColumnForStatus(status: Todo['status']): ColumnDef {
+  return COLUMNS.find(c => c.status === status) || COLUMNS[0];
+}
+
+/* ─── Props ─── */
+
+interface KanbanBoardProps {
+  onSelectTodo?: (todoId: number) => void;
+}
+
+/* ─── Component ─── */
+
+export function KanbanBoard({ onSelectTodo }: KanbanBoardProps) {
+  const { state, dispatch } = useApp();
+  const { message } = App.useApp();
+  const { todos, tags, selectedTodoId } = state;
+
+  const [searchText, setSearchText] = useState('');
+  const [draggingId, setDraggingId] = useState<number | null>(null);
+  const [dragOverStatus, setDragOverStatus] = useState<Todo['status'] | null>(null);
+
+  /* ─── Filter by search ─── */
+  const filteredTodos = useMemo(() => {
+    if (!searchText.trim()) return todos;
+    const q = searchText.toLowerCase();
+    return todos.filter(t =>
+      t.title.toLowerCase().includes(q) ||
+      (t.prompt && t.prompt.toLowerCase().includes(q))
+    );
+  }, [todos, searchText]);
+
+  /* ─── Group by status ─── */
+  const grouped = useMemo(() => {
+    const map: Record<Todo['status'], Todo[]> = {
+      pending: [],
+      running: [],
+      completed: [],
+      failed: [],
+    };
+    for (const todo of filteredTodos) {
+      if (map[todo.status]) {
+        map[todo.status].push(todo);
+      } else {
+        map.pending.push(todo);
+      }
+    }
+    return map;
+  }, [filteredTodos]);
+
+  /* ─── Stats ─── */
+  const totalCount = filteredTodos.length;
+  const stats = useMemo(() => ({
+    pending: grouped.pending.length,
+    running: grouped.running.length,
+    completed: grouped.completed.length,
+    failed: grouped.failed.length,
+  }), [grouped]);
+
+  /* ─── Drag & Drop Handlers ─── */
+
+  const handleDragStart = useCallback((todoId: number, e: React.DragEvent) => {
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', String(todoId));
+    setDraggingId(todoId);
+  }, []);
+
+  const handleDragEnd = useCallback(() => {
+    setDraggingId(null);
+    setDragOverStatus(null);
+  }, []);
+
+  const handleDragOver = useCallback((status: Todo['status'], e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setDragOverStatus(status);
+  }, []);
+
+  const handleDragLeave = useCallback((status: Todo['status']) => {
+    setDragOverStatus(prev => prev === status ? null : prev);
+  }, []);
+
+  const handleDrop = useCallback(async (targetStatus: Todo['status'], e: React.DragEvent) => {
+    e.preventDefault();
+    setDraggingId(null);
+    setDragOverStatus(null);
+
+    const todoId = parseInt(e.dataTransfer.getData('text/plain'), 10);
+    if (isNaN(todoId)) return;
+
+    const todo = todos.find(t => t.id === todoId);
+    if (!todo || todo.status === targetStatus) return;
+
+    try {
+      const updated = await db.updateTodo(
+        todoId,
+        todo.title,
+        todo.prompt || '',
+        targetStatus,
+        todo.executor,
+      );
+      dispatch({ type: 'UPDATE_TODO', payload: updated });
+      message.success(`已移动到「${getColumnForStatus(targetStatus).label}」`);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : '更新状态失败';
+      message.error(msg);
+    }
+  }, [todos, dispatch, message]);
+
+  /* ─── Click to select ─── */
+  const handleCardClick = useCallback((todoId: number) => {
+    dispatch({ type: 'SELECT_TODO', payload: todoId });
+    onSelectTodo?.(todoId);
+  }, [dispatch, onSelectTodo]);
+
+  /* ─── Render Card ─── */
+  const renderCard = (todo: Todo) => {
+    const column = getColumnForStatus(todo.status);
+    const todoTags = tags.filter(t => todo.tag_ids?.includes(t.id));
+    const isDragging = draggingId === todo.id;
+
+    return (
+      <div
+        key={todo.id}
+        className={`kanban-card ${selectedTodoId === todo.id ? 'selected' : ''} ${isDragging ? 'dragging' : ''}`}
+        draggable
+        onDragStart={e => handleDragStart(todo.id, e)}
+        onDragEnd={handleDragEnd}
+        onClick={() => handleCardClick(todo.id)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleCardClick(todo.id);
+          }
+        }}
+        style={{ borderLeftColor: column.color }}
+      >
+        {/* Title */}
+        <div className="kanban-card-title" title={todo.title}>
+          {todo.title}
+        </div>
+
+        {/* Prompt preview */}
+        {todo.prompt && todo.prompt !== todo.title && (
+          <div className="kanban-card-desc">
+            {todo.prompt.length > 50 ? todo.prompt.slice(0, 50) + '…' : todo.prompt}
+          </div>
+        )}
+
+        {/* Tags */}
+        {todoTags.length > 0 && (
+          <div className="kanban-card-tags">
+            {todoTags.map(tag => (
+              <span
+                key={tag.id}
+                className="kanban-tag-badge"
+                style={{
+                  backgroundColor: tag.color + '18',
+                  color: tag.color,
+                  border: `1px solid ${tag.color}30`,
+                }}
+              >
+                {tag.name}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="kanban-card-footer">
+          {todo.executor && <ExecutorBadge executor={todo.executor} />}
+          <span className="kanban-card-time">
+            {formatRelativeTime(todo.updated_at)}
+          </span>
+        </div>
+      </div>
+    );
+  };
+
+  /* ─── Render Column ─── */
+  const renderColumn = (column: ColumnDef) => {
+    const items = grouped[column.status];
+    const isOver = dragOverStatus === column.status;
+
+    return (
+      <div
+        key={column.status}
+        className={`kanban-column ${isOver ? 'drag-over' : ''}`}
+        onDragOver={e => handleDragOver(column.status, e)}
+        onDragLeave={() => handleDragLeave(column.status)}
+        onDrop={e => handleDrop(column.status, e)}
+      >
+        {/* Column Header */}
+        <div className="kanban-column-header" style={{ borderBottomColor: column.color }}>
+          <div className="kanban-column-title">
+            <div
+              className="kanban-column-dot"
+              style={{ backgroundColor: column.color }}
+            />
+            <span>{column.label}</span>
+            <span className="kanban-column-count">{items.length}</span>
+          </div>
+        </div>
+
+        {/* Column Body */}
+        <div className="kanban-column-body">
+          {items.length === 0 ? (
+            <div className="kanban-column-empty">
+              暂无任务
+            </div>
+          ) : (
+            items.map(renderCard)
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  /* ─── Render ─── */
+  return (
+    <div className="kanban-board">
+      {/* Top Bar */}
+      <div className="kanban-topbar">
+        <div className="kanban-topbar-left">
+          <Input
+            className="kanban-search"
+            placeholder="搜索任务…"
+            prefix={<SearchOutlined style={{ color: 'var(--color-text-tertiary)' }} />}
+            value={searchText}
+            onChange={e => setSearchText(e.target.value)}
+            allowClear
+            size="small"
+            style={{ width: 220 }}
+          />
+        </div>
+        <div className="kanban-topbar-right">
+          <span className="kanban-summary-item" style={{ color: '#3b82f6' }}>
+            待办 <strong>{stats.pending}</strong>
+          </span>
+          <span className="kanban-summary-divider" />
+          <span className="kanban-summary-item" style={{ color: '#f59e0b' }}>
+            进行中 <strong>{stats.running}</strong>
+          </span>
+          <span className="kanban-summary-divider" />
+          <span className="kanban-summary-item" style={{ color: '#22c55e' }}>
+            已完成 <strong>{stats.completed}</strong>
+          </span>
+          <span className="kanban-summary-divider" />
+          <span className="kanban-summary-item" style={{ color: '#ef4444' }}>
+            失败 <strong>{stats.failed}</strong>
+          </span>
+          <span className="kanban-summary-divider" />
+          <span className="kanban-summary-item" style={{ color: 'var(--color-text-secondary)' }}>
+            共 <strong>{totalCount}</strong>
+          </span>
+        </div>
+      </div>
+
+      {/* Columns */}
+      <div className="kanban-columns-container">
+        {COLUMNS.map(renderColumn)}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -134,8 +134,11 @@ export function KanbanBoard({ onSelectTodo }: KanbanBoardProps) {
 
   /* ─── Click to select ─── */
   const handleCardClick = useCallback((todoId: number) => {
-    dispatch({ type: 'SELECT_TODO', payload: todoId });
-    onSelectTodo?.(todoId);
+    if (onSelectTodo) {
+      onSelectTodo(todoId);
+    } else {
+      dispatch({ type: 'SELECT_TODO', payload: todoId });
+    }
   }, [dispatch, onSelectTodo]);
 
   /* ─── Render Card ─── */

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -7,10 +7,13 @@ import {
   RobotOutlined,
   CopyOutlined,
   LeftOutlined,
+  AppstoreOutlined,
+  ProfileOutlined,
 } from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
 import { useApp } from '../hooks/useApp';
 import { ExecutorBadge } from './ExecutorBadge';
+import { KanbanBoard } from './KanbanBoard';
 import * as db from '../utils/database';
 import { formatRelativeTime } from '../utils/datetime';
 import type { RecentCompletedTodo } from '../types';
@@ -39,8 +42,14 @@ interface MemorialBoardProps {
   onBack?: () => void;
 }
 
+type BoardMode = 'memorial' | 'kanban';
+
 export function MemorialBoard({ onBack }: MemorialBoardProps) {
   const { state, dispatch } = useApp();
+  const { onSelectTodo } = { onSelectTodo: (todoId: number) => {
+    dispatch({ type: 'SELECT_TODO', payload: todoId });
+  } };
+  const [boardMode, setBoardMode] = useState<BoardMode>('memorial');
   const [items, setItems] = useState<RecentCompletedTodo[]>([]);
   const [loading, setLoading] = useState(true);
   const [hours, setHours] = useState(24);
@@ -210,26 +219,41 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
           <h2 className="memorial-title">看板</h2>
           <Segmented
             size="small"
-            options={TIME_OPTIONS.map(o => ({ label: o.label, value: o.label }))}
-            value={TIME_OPTIONS.find(o => o.value === hours)?.label || '24h'}
-            onChange={label => {
-              const opt = TIME_OPTIONS.find(o => o.label === label);
-              if (opt) setHours(opt.value);
-            }}
+            value={boardMode}
+            onChange={value => setBoardMode(value as BoardMode)}
+            options={[
+              { label: <span><ProfileOutlined /> 执行结论</span>, value: 'memorial' },
+              { label: <span><AppstoreOutlined /> 飞书看板</span>, value: 'kanban' },
+            ]}
           />
+          {boardMode === 'memorial' && (
+            <Segmented
+              size="small"
+              options={TIME_OPTIONS.map(o => ({ label: o.label, value: o.label }))}
+              value={TIME_OPTIONS.find(o => o.value === hours)?.label || '24h'}
+              onChange={label => {
+                const opt = TIME_OPTIONS.find(o => o.label === label);
+                if (opt) setHours(opt.value);
+              }}
+            />
+          )}
         </div>
-        <div className="memorial-summary">
-          <span className="memorial-stat-dot memorial-stat-all">共 <strong>{items.length}</strong> 条</span>
-          <span className="memorial-stat-dot memorial-stat-success">
-            <CheckCircleOutlined /> <strong>{successCount}</strong> 成功
-          </span>
-          <span className="memorial-stat-dot memorial-stat-failed">
-            <CloseCircleOutlined /> <strong>{failedCount}</strong> 失败
-          </span>
-        </div>
+        {boardMode === 'memorial' && (
+          <div className="memorial-summary">
+            <span className="memorial-stat-dot memorial-stat-all">共 <strong>{items.length}</strong> 条</span>
+            <span className="memorial-stat-dot memorial-stat-success">
+              <CheckCircleOutlined /> <strong>{successCount}</strong> 成功
+            </span>
+            <span className="memorial-stat-dot memorial-stat-failed">
+              <CloseCircleOutlined /> <strong>{failedCount}</strong> 失败
+            </span>
+          </div>
+        )}
       </div>
 
-      {loading ? (
+      {boardMode === 'kanban' ? (
+        <KanbanBoard onSelectTodo={onSelectTodo} />
+      ) : loading ? (
         <div className="memorial-grid">
           {[1, 2, 3, 4].map(i => (
             <Card key={i} className="memorial-card" size="small" bodyStyle={{ padding: 12 }}>

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -56,6 +56,7 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
   const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
+    if (boardMode !== 'memorial') return;
     let cancelled = false;
     setLoading(true);
     db.getRecentCompletedTodos(hours)
@@ -69,7 +70,7 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
         if (!cancelled) setLoading(false);
       });
     return () => { cancelled = true; };
-  }, [hours]);
+  }, [hours, boardMode]);
 
   const toggleExpand = (todoId: number) => {
     setExpandedIds(prev => {


### PR DESCRIPTION
## 变更内容

在看板页面新增 **飞书看板** 模式，保留原有的「执行结论」模式。

### 新增文件
- `frontend/src/components/KanbanBoard.tsx` — 飞书看板组件

### 修改文件
- `frontend/src/components/MemorialBoard.tsx` — 添加模式切换 Segmented
- `frontend/src/App.css` — 添加 kanban 样式

### 功能说明

**执行结论模式**（原有）：仅展示有执行结果的任务卡片，支持 6h/12h/24h/3d/7d 时间范围筛选。

**飞书看板模式**（新增）：
- 所有任务按状态分为四列：待办 / 进行中 / 已完成 / 失败
- 每列独立滚动，列头显示状态色点和计数
- 卡片展示：标题、prompt 预览、标签、执行器、更新时间
- **拖拽卡片**到其他列可自动更新任务状态
- **搜索栏**过滤所有任务
- 点击卡片选中，右侧面板查看详情
- 适配亮/暗主题

### 验证
- TypeScript 编译：0 error
- Vite build：通过
- Rust cargo build：通过