### PR TITLE
feat: 添加飞书聊天 ID 设置提示

### DIFF
--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1874,6 +1874,9 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                                                 { value: 'chat_id', label: '群聊' },
                                               ]}
                                             />
+                                            <span style={{ fontSize: 10, color: 'var(--color-text-tertiary)', marginLeft: 84 }}>
+                                              提示：向机器人发送 \set home 可快速设置当前对话的 ID
+                                            </span>
                                           </div>
                                         </div>
                                       </div>

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1875,7 +1875,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                                               ]}
                                             />
                                             <span style={{ fontSize: 10, color: 'var(--color-text-tertiary)', marginLeft: 84 }}>
-                                              提示：向机器人发送 \set home 可快速设置当前对话的 ID
+                                              提示：向机器人发送 /sethome 可快速设置当前对话的 ID
                                             </span>
                                           </div>
                                         </div>


### PR DESCRIPTION
## Summary

在设置页面的飞书消息配置区域，发送类型选择器下方添加小字提示：
"提示：向机器人发送 \set home 可快速设置当前对话的 ID"

帮助用户快速发现通过发送命令来设置聊天 ID 的方式。

## Test plan

- [x] Build 成功