### PR TITLE
feat: 飞书看板手机模式改为 Tab 滑动切换显示

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2188,6 +2188,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2875,4 +2875,25 @@ code {
     min-width: 200px;
     max-width: 260px;
   }
+
+  .kanban-mobile-tabs {
+    padding: 0;
+  }
+
+  .kanban-mobile-tabs .ant-tabs-nav {
+    margin-bottom: 0;
+  }
+
+  .kanban-mobile-tabs .ant-tabs-tab {
+    font-size: 13px;
+  }
+
+  .kanban-mobile-list {
+    padding: var(--space-sm);
+  }
+
+  .kanban-mobile-list .kanban-card {
+    margin-bottom: var(--space-sm);
+    cursor: default;
+  }
 }

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -57,6 +57,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
   const [todoResults, setTodoResults] = useState<Record<number, string>>({});
   const [loadingResults, setLoadingResults] = useState<Set<number>>(new Set());
   const isMobile = useIsMobile();
+  const [activeKey, setActiveKey] = useState<Todo['status']>('pending');
 
   /* ─── Eagerly fetch execution records for completed/failed todos ─── */
   const [execRecordCache, setExecRecordCache] = useState<Record<number, ExecutionRecord>>({});
@@ -312,6 +313,47 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
     );
   };
 
+  /* ─── Touch Swipe Handlers for Mobile Tabs ─── */
+  const touchStartRef = useRef<{ x: number; y: number; time: number } | null>(null);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    touchStartRef.current = {
+      x: touch.clientX,
+      y: touch.clientY,
+      time: Date.now(),
+    };
+  }, []);
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (!touchStartRef.current) return;
+
+    const touch = e.changedTouches[0];
+    const deltaX = touch.clientX - touchStartRef.current.x;
+    const deltaY = touch.clientY - touchStartRef.current.y;
+    const deltaTime = Date.now() - touchStartRef.current.time;
+
+    // Detect horizontal swipe: threshold 50px, max time 300ms, and horizontal movement > vertical
+    if (Math.abs(deltaX) > 50 && deltaTime < 300 && Math.abs(deltaX) > Math.abs(deltaY)) {
+      const currentIndex = COLUMNS.findIndex(col => col.status === activeKey);
+      let nextIndex = currentIndex;
+
+      if (deltaX > 0 && currentIndex > 0) {
+        // Swipe right -> go to previous tab
+        nextIndex = currentIndex - 1;
+      } else if (deltaX < 0 && currentIndex < COLUMNS.length - 1) {
+        // Swipe left -> go to next tab
+        nextIndex = currentIndex + 1;
+      }
+
+      if (nextIndex !== currentIndex) {
+        setActiveKey(COLUMNS[nextIndex].status);
+      }
+    }
+
+    touchStartRef.current = null;
+  }, [activeKey]);
+
   /* ─── Render ─── */
   return (
     <div className="kanban-board">
@@ -373,22 +415,29 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
 
       {/* Mobile: Swipeable Tabs */}
       {isMobile && (
-        <Tabs
-          className="kanban-mobile-tabs"
-          items={COLUMNS.map(col => ({
-            key: col.status,
-            label: `${col.label} (${grouped[col.status].length})`,
-            children: (
-              <div className="kanban-mobile-list">
-                {grouped[col.status].length === 0 ? (
-                  <div className="kanban-column-empty">暂无任务</div>
-                ) : (
-                  grouped[col.status].map(renderCard)
-                )}
-              </div>
-            ),
-          }))}
-        />
+        <div
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
+        >
+          <Tabs
+            className="kanban-mobile-tabs"
+            activeKey={activeKey}
+            onChange={(key) => setActiveKey(key as Todo['status'])}
+            items={COLUMNS.map(col => ({
+              key: col.status,
+              label: `${col.label} (${grouped[col.status].length})`,
+              children: (
+                <div className="kanban-mobile-list">
+                  {grouped[col.status].length === 0 ? (
+                    <div className="kanban-column-empty">暂无任务</div>
+                  ) : (
+                    grouped[col.status].map(renderCard)
+                  )}
+                </div>
+              ),
+            }))}
+          />
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -1,7 +1,8 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
-import { Input, Segmented, App } from 'antd';
+import { Input, Segmented, App, Tabs } from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
 import { useApp } from '../hooks/useApp';
+import { useIsMobile } from '../hooks/useIsMobile';
 import { TodoCard } from './TodoCard';
 import * as db from '../utils/database';
 import { formatRelativeTime } from '../utils/datetime';
@@ -55,6 +56,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
   const [expandedResultIds, setExpandedResultIds] = useState<Set<number>>(new Set());
   const [todoResults, setTodoResults] = useState<Record<number, string>>({});
   const [loadingResults, setLoadingResults] = useState<Set<number>>(new Set());
+  const isMobile = useIsMobile();
 
   /* ─── Eagerly fetch execution records for completed/failed todos ─── */
   const [execRecordCache, setExecRecordCache] = useState<Record<number, ExecutionRecord>>({});
@@ -362,10 +364,32 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
         </div>
       ) : null}
 
-      {/* Columns */}
-      <div className="kanban-columns-container">
-        {COLUMNS.map(renderColumn)}
-      </div>
+      {/* Desktop: Columns */}
+      {!isMobile && (
+        <div className="kanban-columns-container">
+          {COLUMNS.map(renderColumn)}
+        </div>
+      )}
+
+      {/* Mobile: Swipeable Tabs */}
+      {isMobile && (
+        <Tabs
+          className="kanban-mobile-tabs"
+          items={COLUMNS.map(col => ({
+            key: col.status,
+            label: `${col.label} (${grouped[col.status].length})`,
+            children: (
+              <div className="kanban-mobile-list">
+                {grouped[col.status].length === 0 ? (
+                  <div className="kanban-column-empty">暂无任务</div>
+                ) : (
+                  grouped[col.status].map(renderCard)
+                )}
+              </div>
+            ),
+          }))}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 手机模式下飞书看板使用 antd Tabs 组件替代横向滚动列布局
- 四种状态（待办/进行中/已完成/失败）支持左右滑动切换
- 每个 tab 显示对应状态的 todo 卡片，样式与执行结论模式一致

## Test plan
- [ ] 手机模式（宽度 < 768px）下访问看板
- [ ] 切换到飞书看板模式
- [ ] 验证左右滑动切换四个状态
- [ ] 验证每个卡片样式与执行结论模式一致