### PR TITLE
fix: ntd todo create --schedule 参数不生效的 bug

### DIFF
--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -323,8 +323,8 @@ async fn handle_todo(
     fields: &Option<String>,
 ) -> Result<()> {
     match action {
-        TodoAction::Create { title, prompt, file, stdin, executor, workspace, tags, schedule: _ } => {
-            let req = if *stdin {
+        TodoAction::Create { title, prompt, file, stdin, executor, workspace, tags, schedule } => {
+            let mut req = if *stdin {
                 // Read from stdin
                 let value = read_stdin_json()?;
                 let req = serde_json::from_value::<CreateTodoRequest>(value.clone())
@@ -336,6 +336,8 @@ async fn handle_todo(
                             .map(|arr| arr.iter().filter_map(|v| v.as_i64()).collect())
                             .unwrap_or_default(),
                         executor: value.get("executor").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                        scheduler_enabled: None,
+                        scheduler_config: None,
                     });
                 if workspace.is_some() {
                     // workspace is sent separately in the full JSON body
@@ -354,8 +356,18 @@ async fn handle_todo(
                     prompt: prompt_content,
                     tag_ids: parse_tags(tags),
                     executor: executor.clone(),
+                    scheduler_enabled: None,
+                    scheduler_config: None,
                 }
             };
+
+            // Set scheduler options from CLI args
+            if let Some(s) = schedule {
+                if !s.is_empty() {
+                    req.scheduler_enabled = Some(true);
+                    req.scheduler_config = Some(s.clone());
+                }
+            }
 
             let resp: ClientResponse<Todo> = client.post("/todos", &req).await?;
             print_response(resp, output, fields)?;

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -67,6 +67,28 @@ pub async fn create_todo(
         state.db.add_todo_tag(id, *tag_id).await?;
     }
 
+    // Handle scheduler settings
+    let scheduler_enabled = req.scheduler_enabled.unwrap_or(false);
+    let scheduler_config = req
+        .scheduler_config
+        .as_ref()
+        .filter(|s| !s.is_empty())
+        .cloned();
+
+    // Validate cron expression if scheduler config is provided
+    if let Some(ref config) = scheduler_config {
+        validate_cron_expression(config)?;
+    }
+
+    // Update scheduler if enabled
+    if scheduler_enabled {
+        if let Some(ref config) = scheduler_config {
+            if let Err(e) = state.db.update_todo_scheduler(id, true, Some(config)).await {
+                tracing::warn!("Failed to update scheduler for todo {}: {}", id, e);
+            }
+        }
+    }
+
     Ok(ApiResponse::ok(Todo {
         id,
         title: title.to_string(),
@@ -76,8 +98,8 @@ pub async fn create_todo(
         updated_at: now,
         tag_ids: req.tag_ids.clone(),
         executor: Some(executor),
-        scheduler_enabled: false,
-        scheduler_config: None,
+        scheduler_enabled,
+        scheduler_config: scheduler_config.clone(),
         scheduler_next_run_at: None,
         task_id: None,
         workspace: None,

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -80,13 +80,10 @@ pub async fn create_todo(
         validate_cron_expression(config)?;
     }
 
-    // Update scheduler if enabled
-    if scheduler_enabled {
-        if let Some(ref config) = scheduler_config {
-            if let Err(e) = state.db.update_todo_scheduler(id, true, Some(config)).await {
-                tracing::warn!("Failed to update scheduler for todo {}: {}", id, e);
-            }
-        }
+    // Update scheduler - always call to ensure consistent state
+    // When scheduler_enabled is false or config is empty, scheduler will be disabled
+    if let Err(e) = state.db.update_todo_scheduler(id, scheduler_enabled, scheduler_config.as_deref()).await {
+        tracing::warn!("Failed to update scheduler for todo {}: {}", id, e);
     }
 
     Ok(ApiResponse::ok(Todo {

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -281,6 +281,10 @@ pub struct CreateTodoRequest {
     pub tag_ids: Vec<i64>,
     #[serde(default)]
     pub executor: Option<String>,
+    #[serde(default)]
+    pub scheduler_enabled: Option<bool>,
+    #[serde(default)]
+    pub scheduler_config: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]


### PR DESCRIPTION
修复  参数不生效的问题。

## 问题原因
CreateTodoRequest 结构体新增了 `scheduler_enabled` / `scheduler_config` 字段，但 CLI 的 `todo create` 命令在构造请求体时未将 `--schedule` 参数传递到请求中。

## 修改内容
1. **backend/src/models/mod.rs** — CreateTodoRequest 新增 `scheduler_enabled` 和 `scheduler_config` 可选字段
2. **backend/src/cli/commands.rs** — 从 CLI 参数解析 `--schedule` 并设置到请求体
3. **backend/src/handlers/todo.rs** — 创建 todo 时将 scheduler 配置写入数据库

Closes #239