### PR TITLE
docs: 添加 ntd CLI 和 API 接口文档

### DIFF
--- a/docs/ntd-api.md
+++ b/docs/ntd-api.md
@@ -1,0 +1,1144 @@
+# ntd API 接口文档
+
+AI Todo 应用后端 API 参考手册。所有接口前缀为 `/xyz/`（WebSocket 为 `/xyz/events`）。
+
+---
+
+## 接口分类
+
+### 1. Todo 管理
+### 2. 标签管理
+### 3. 执行记录
+### 4. 执行操作
+### 5. 调度器
+### 6. 备份与恢复
+### 7. 配置管理
+### 8. 执行器管理
+### 9. 技能管理
+### 10. Agent Bot 管理
+### 11. 飞书集成
+### 12. 会话管理
+### 13. 项目目录
+### 14. Todo 模板
+### 15. 自定义模板
+### 16. 系统接口
+
+---
+
+## 1. Todo 管理
+
+### 获取 Todo 列表
+```
+GET /xyz/todos
+```
+
+查询参数：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `status` | string | 按状态筛选 |
+| `tag_id` | number | 按标签 ID 筛选 |
+| `search` | string | 搜索关键词 |
+| `page` | number | 页码（默认 1） |
+| `limit` | number | 每页数量（默认 20） |
+
+**响应示例：**
+```json
+{
+  "code": 0,
+  "data": {
+    "todos": [
+      {
+        "id": 1,
+        "title": "完成报告",
+        "status": "pending",
+        "created_at": "2026-05-14T10:00:00Z"
+      }
+    ],
+    "total": 100
+  }
+}
+```
+
+---
+
+### 创建 Todo
+```
+POST /xyz/todos
+```
+
+**请求体：**
+```json
+{
+  "title": "Todo 标题",
+  "prompt": "Prompt 内容",
+  "executor": "claudecode",
+  "workspace": "/path/to/workspace",
+  "tags": [1, 2],
+  "schedule": "0 9 * * *"
+}
+```
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `title` | string | 是 | Todo 标题 |
+| `prompt` | string | 否 | Prompt 内容 |
+| `executor` | string | 否 | 执行器类型 |
+| `workspace` | string | 否 | 工作目录 |
+| `tags` | number[] | 否 | 标签 ID 数组 |
+| `schedule` | string | 否 | Cron 表达式 |
+
+---
+
+### 获取 Todo 详情
+```
+GET /xyz/todos/{id}
+```
+
+---
+
+### 更新 Todo
+```
+PUT /xyz/todos/{id}
+```
+
+**请求体：**
+```json
+{
+  "title": "新标题",
+  "prompt": "新 prompt",
+  "status": "completed",
+  "executor": "joinai",
+  "workspace": "/new/path",
+  "tags": [1, 3]
+}
+```
+
+---
+
+### 删除 Todo
+```
+DELETE /xyz/todos/{id}
+```
+
+---
+
+### 强制更新 Todo 状态
+```
+PUT /xyz/todos/{id}/force-status
+```
+
+**请求体：**
+```json
+{
+  "status": "running"
+}
+```
+
+---
+
+### 更新 Todo 标签
+```
+PUT /xyz/todos/{id}/tags
+```
+
+**请求体：**
+```json
+{
+  "tags": [1, 2, 3]
+}
+```
+
+---
+
+### 获取 Todo 执行摘要
+```
+GET /xyz/todos/{id}/summary
+```
+
+---
+
+### 获取最近完成的 Todo
+```
+GET /xyz/todos/recent-completed
+```
+
+---
+
+## 2. 标签管理
+
+### 获取标签列表
+```
+GET /xyz/tags
+```
+
+**响应示例：**
+```json
+{
+  "code": 0,
+  "data": {
+    "tags": [
+      { "id": 1, "name": "重要", "color": "#ff4d4f" },
+      { "id": 2, "name": "紧急", "color": "#faad14" }
+    ]
+  }
+}
+```
+
+---
+
+### 创建标签
+```
+POST /xyz/tags
+```
+
+**请求体：**
+```json
+{
+  "name": "标签名",
+  "color": "#1890ff"
+}
+```
+
+---
+
+### 删除标签
+```
+DELETE /xyz/tags/{id}
+```
+
+---
+
+## 3. 执行记录
+
+### 获取执行记录列表
+```
+GET /xyz/execution-records
+```
+
+查询参数：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `todo_id` | number | Todo ID |
+| `status` | string | 状态筛选 |
+| `page` | number | 页码 |
+| `limit` | number | 每页数量 |
+
+---
+
+### 获取运行中的执行记录
+```
+GET /xyz/execution-records/running
+```
+
+---
+
+### 按会话 ID 获取执行记录
+```
+GET /xyz/execution-records/session/{session_id}
+```
+
+---
+
+### 获取执行记录详情
+```
+GET /xyz/execution-records/{id}
+```
+
+---
+
+### 恢复执行
+```
+POST /xyz/execution-records/{id}/resume
+```
+
+**请求体：**
+```json
+{
+  "message": "继续执行"
+}
+```
+
+---
+
+## 4. 执行操作
+
+### 执行 Todo
+```
+POST /xyz/execute
+```
+
+**请求体：**
+```json
+{
+  "todo_id": 1,
+  "message": "开始执行",
+  "executor": "claudecode"
+}
+```
+
+---
+
+### 停止执行
+```
+POST /xyz/execute/stop
+```
+
+**请求体：**
+```json
+{
+  "todo_id": 1
+}
+```
+
+---
+
+### 强制失败
+```
+POST /xyz/execute/force-fail
+```
+
+**请求体：**
+```json
+{
+  "todo_id": 1,
+  "reason": "超时"
+}
+```
+
+---
+
+### 获取运行中的 Todo
+```
+GET /xyz/running-todos
+```
+
+---
+
+### 获取仪表盘统计
+```
+GET /xyz/dashboard-stats
+```
+
+---
+
+## 5. 调度器
+
+### 获取定时 Todo 列表
+```
+GET /xyz/scheduler/todos
+```
+
+---
+
+### 更新 Todo 调度配置
+```
+PUT /xyz/todos/{id}/scheduler
+```
+
+**请求体：**
+```json
+{
+  "schedule": "0 9 * * *",
+  "enabled": true
+}
+```
+
+---
+
+## 6. 备份与恢复
+
+### 导出全部数据
+```
+GET /xyz/backup/export
+```
+
+返回 YAML 格式的完整备份。
+
+---
+
+### 导出选定的 Todo
+```
+POST /xyz/backup/export-selected
+```
+
+**请求体：**
+```json
+{
+  "todo_ids": [1, 2, 3]
+}
+```
+
+---
+
+### 导入备份（完整替换）
+```
+POST /xyz/backup/import
+```
+
+Content-Type: `multipart/form-data`
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `file` | file | YAML 备份文件 |
+
+---
+
+### 合并导入
+```
+POST /xyz/backup/merge
+```
+
+Content-Type: `multipart/form-data`
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `file` | file | YAML 备份文件 |
+
+---
+
+### 下载数据库
+```
+GET /xyz/backup/database/download
+```
+
+---
+
+### 获取数据库备份状态
+```
+GET /xyz/backup/database/status
+```
+
+---
+
+### 触发立即备份
+```
+POST /xyz/backup/database/trigger
+```
+
+---
+
+### 更新自动备份配置
+```
+PUT /xyz/backup/database/auto
+```
+
+**请求体：**
+```json
+{
+  "enabled": true,
+  "interval_hours": 24
+}
+```
+
+---
+
+### 下载备份文件
+```
+GET /xyz/backup/database/file
+```
+
+查询参数：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `filename` | string | 备份文件名 |
+
+---
+
+### 删除备份文件
+```
+DELETE /xyz/backup/database/file
+```
+
+查询参数：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `filename` | string | 备份文件名 |
+
+---
+
+## 7. 配置管理
+
+### 获取配置
+```
+GET /xyz/config
+```
+
+**响应示例：**
+```json
+{
+  "code": 0,
+  "data": {
+    "server": {
+      "port": 8088
+    },
+    "executors": {
+      "claudecode": { "enabled": true },
+      "joinai": { "enabled": true }
+    },
+    "backup": {
+      "auto_backup": true,
+      "interval_hours": 24
+    }
+  }
+}
+```
+
+---
+
+### 更新配置
+```
+PUT /xyz/config
+```
+
+**请求体：**
+```json
+{
+  "server": { "port": 8088 },
+  "backup": { "auto_backup": true }
+}
+```
+
+---
+
+## 8. 执行器管理
+
+### 列出执行器
+```
+GET /xyz/executors
+```
+
+---
+
+### 更新执行器配置
+```
+PUT /xyz/executors/{name}
+```
+
+**请求体：**
+```json
+{
+  "enabled": true,
+  "config": {
+    "api_key": "xxx",
+    "model": "claude-3-5-sonnet"
+  }
+}
+```
+
+---
+
+### 检测执行器
+```
+POST /xyz/executors/{name}/detect
+```
+
+检测执行器二进制文件是否存在。
+
+---
+
+### 测试执行器
+```
+POST /xyz/executors/{name}/test
+```
+
+运行 `executor --version` 测试配置是否正确。
+
+---
+
+## 9. 技能管理
+
+### 列出技能
+```
+GET /xyz/skills
+```
+
+按执行器分组列出所有技能。
+
+---
+
+### 比较技能
+```
+GET /xyz/skills/compare
+```
+
+跨执行器的技能对比矩阵。
+
+---
+
+### 同步技能
+```
+POST /xyz/skills/sync
+```
+
+**请求体：**
+```json
+{
+  "skill_name": "code_review",
+  "from_executor": "claudecode",
+  "to_executors": ["joinai", "kimi"]
+}
+```
+
+---
+
+### 获取技能调用记录
+```
+GET /xyz/skills/invocations
+```
+
+---
+
+### 记录技能调用
+```
+POST /xyz/skills/invocations
+```
+
+**请求体：**
+```json
+{
+  "skill_name": "code_review",
+  "executor": "claudecode",
+  "success": true,
+  "duration_ms": 5000
+}
+```
+
+---
+
+### 获取技能内容
+```
+GET /xyz/skills/content
+```
+
+查询参数：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `name` | string | 技能名称 |
+| `executor` | string | 执行器 |
+
+---
+
+### 导出技能
+```
+GET /xyz/skills/export
+```
+
+查询参数：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `name` | string | 技能名称 |
+| `executor` | string | 执行器 |
+
+返回 `.zip` 格式的技能包。
+
+---
+
+### 导入技能
+```
+POST /xyz/skills/import
+```
+
+Content-Type: `multipart/form-data`
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `file` | file | 技能 .zip 文件 |
+
+---
+
+## 10. Agent Bot 管理
+
+### 列出 Agent Bot
+```
+GET /xyz/agent-bots
+```
+
+---
+
+### 删除 Agent Bot
+```
+DELETE /xyz/agent-bots/{id}
+```
+
+---
+
+### 更新 Agent Bot 配置
+```
+PUT /xyz/agent-bots/{id}/config
+```
+
+**请求体：**
+```json
+{
+  "enabled": true,
+  "name": "My Bot",
+  "webhook_url": "https://..."
+}
+```
+
+---
+
+## 11. 飞书集成
+
+### 初始化飞书 OAuth
+```
+POST /xyz/agent-bots/feishu/init
+```
+
+---
+
+### 开始飞书 OAuth
+```
+POST /xyz/agent-bots/feishu/begin
+```
+
+---
+
+### 轮询飞书 OAuth 状态
+```
+POST /xyz/agent-bots/feishu/poll
+```
+
+---
+
+### 获取飞书推送配置
+```
+GET /xyz/agent-bots/feishu/push
+```
+
+---
+
+### 更新飞书推送配置
+```
+PUT /xyz/agent-bots/feishu/push
+```
+
+**请求体：**
+```json
+{
+  "enabled": true,
+  "chat_id": "oc_xxx",
+  "push_completed": true
+}
+```
+
+---
+
+### 获取群组白名单
+```
+GET /xyz/agent-bots/feishu/group-whitelist
+```
+
+---
+
+### 添加群组到白名单
+```
+POST /xyz/agent-bots/feishu/group-whitelist
+```
+
+**请求体：**
+```json
+{
+  "chat_id": "oc_xxx",
+  "name": "开发群"
+}
+```
+
+---
+
+### 从白名单移除
+```
+DELETE /xyz/agent-bots/feishu/group-whitelist/{id}
+```
+
+---
+
+## 12. 飞书历史
+
+### 获取历史消息
+```
+GET /xyz/feishu/history-messages
+```
+
+查询参数：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `chat_id` | string | 聊天室 ID |
+| `start_time` | number | 开始时间戳 |
+| `end_time` | number | 结束时间戳 |
+| `page` | number | 页码 |
+| `limit` | number | 每页数量 |
+
+---
+
+### 获取消息统计
+```
+GET /xyz/feishu/message-stats
+```
+
+---
+
+### 获取消息发送者列表
+```
+GET /xyz/feishu/senders
+```
+
+---
+
+### 获取历史聊天室列表
+```
+GET /xyz/feishu/history-chats
+```
+
+---
+
+### 创建历史聊天室
+```
+POST /xyz/feishu/history-chats
+```
+
+**请求体：**
+```json
+{
+  "chat_id": "oc_xxx",
+  "name": "聊天室名称"
+}
+```
+
+---
+
+### 删除历史聊天室
+```
+DELETE /xyz/feishu/history-chats/{id}
+```
+
+---
+
+### 更新历史聊天室
+```
+PUT /xyz/feishu/history-chats/{id}
+```
+
+**请求体：**
+```json
+{
+  "name": "新名称",
+  "enabled": true
+}
+```
+
+---
+
+## 13. 会话管理
+
+### 列出会话
+```
+GET /xyz/sessions
+```
+
+查询参数：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `page` | number | 页码 |
+| `limit` | number | 每页数量 |
+
+---
+
+### 获取会话统计
+```
+GET /xyz/sessions/stats
+```
+
+---
+
+### 获取会话详情
+```
+GET /xyz/sessions/{id}
+```
+
+包含会话消息和子代理信息。
+
+---
+
+### 删除会话
+```
+DELETE /xyz/sessions/{id}
+```
+
+---
+
+## 14. 项目目录
+
+### 列出项目目录
+```
+GET /xyz/project-directories
+```
+
+---
+
+### 创建项目目录
+```
+POST /xyz/project-directories
+```
+
+**请求体：**
+```json
+{
+  "name": "项目名称",
+  "path": "/path/to/project"
+}
+```
+
+---
+
+### 更新项目目录
+```
+PUT /xyz/project-directories/{id}
+```
+
+**请求体：**
+```json
+{
+  "name": "新名称"
+}
+```
+
+---
+
+### 删除项目目录
+```
+DELETE /xyz/project-directories/{id}
+```
+
+---
+
+## 15. Todo 模板
+
+### 获取模板列表
+```
+GET /xyz/todo-templates
+```
+
+---
+
+### 创建模板
+```
+POST /xyz/todo-templates
+```
+
+**请求体：**
+```json
+{
+  "name": "模板名称",
+  "title": "Todo 标题模板",
+  "prompt": "Prompt 模板",
+  "executor": "claudecode",
+  "tags": [1, 2]
+}
+```
+
+---
+
+### 更新模板
+```
+PUT /xyz/todo-templates/{id}
+```
+
+---
+
+### 删除模板
+```
+DELETE /xyz/todo-templates/{id}
+```
+
+---
+
+### 复制模板
+```
+POST /xyz/todo-templates/{id}/copy
+```
+
+---
+
+## 16. 自定义模板
+
+### 获取订阅状态
+```
+GET /xyz/custom-templates/status
+```
+
+---
+
+### 订阅远程模板
+```
+POST /xyz/custom-templates/subscribe
+```
+
+**请求体：**
+```json
+{
+  "url": "https://example.com/templates.yaml"
+}
+```
+
+---
+
+### 取消订阅
+```
+POST /xyz/custom-templates/unsubscribe
+```
+
+**请求体：**
+```json
+{
+  "url": "https://example.com/templates.yaml"
+}
+```
+
+---
+
+### 手动同步
+```
+POST /xyz/custom-templates/sync
+```
+
+---
+
+### 更新自动同步配置
+```
+PUT /xyz/custom-templates/auto-sync
+```
+
+**请求体：**
+```json
+{
+  "enabled": true,
+  "cron": "0 */6 * * *"
+}
+```
+
+---
+
+## 17. 系统接口
+
+### 获取版本信息
+```
+GET /xyz/version
+```
+
+**响应示例：**
+```json
+{
+  "code": 0,
+  "data": {
+    "version": "1.2.3",
+    "build_time": "2026-05-14T10:00:00Z",
+    "git_commit": "abc123"
+  }
+}
+```
+
+---
+
+## 18. WebSocket 事件
+
+### 事件订阅
+```
+GET /xyz/events
+```
+
+通过 WebSocket 连接接收实时事件。
+
+**事件类型：**
+
+| 事件 | 说明 |
+|------|------|
+| `todo.created` | Todo 创建 |
+| `todo.updated` | Todo 更新 |
+| `todo.deleted` | Todo 删除 |
+| `execution.started` | 执行开始 |
+| `execution.progress` | 执行进度 |
+| `execution.completed` | 执行完成 |
+| `execution.failed` | 执行失败 |
+
+**消息格式：**
+```json
+{
+  "type": "execution.progress",
+  "data": {
+    "todo_id": 1,
+    "message": "正在分析代码..."
+  }
+}
+```
+
+---
+
+## 通用响应格式
+
+### 成功响应
+```json
+{
+  "code": 0,
+  "data": { ... },
+  "message": "success"
+}
+```
+
+### 错误响应
+```json
+{
+  "code": 1001,
+  "message": "错误描述",
+  "data": null
+}
+```
+
+### 分页响应
+```json
+{
+  "code": 0,
+  "data": {
+    "items": [ ... ],
+    "total": 100,
+    "page": 1,
+    "limit": 20
+  }
+}
+```
+
+---
+
+## 状态码说明
+
+| 状态值 | 说明 |
+|--------|------|
+| `pending` | 等待执行 |
+| `running` | 执行中 |
+| `completed` | 已完成 |
+| `failed` | 执行失败 |
+| `paused` | 已暂停 |
+| `cancelled` | 已取消 |
+
+---
+
+## 执行器类型
+
+| 类型 | 说明 |
+|------|------|
+| `claudecode` | Claude Code |
+| `joinai` | JoinAI |
+| `codebuddy` | CodeBuddy |
+| `opencode` | OpenCode |
+| `atomcode` | AtomCode |
+| `hermes` | Hermes |
+| `kimi` | Kimi |
+| `codex` | Codex |

--- a/docs/ntd-cli.md
+++ b/docs/ntd-cli.md
@@ -1,0 +1,552 @@
+# ntd 命令行文档
+
+AI Todo CLI 完整命令参考手册。
+
+## 全局选项
+
+| 选项 | 简写 | 默认值 | 说明 |
+|------|------|--------|------|
+| `--server <URL>` | - | `http://localhost:8088` | API 服务器地址 |
+| `--output <FORMAT>` | `-o` | `json` | 输出格式：`json`, `pretty`, `raw` |
+| `--fields <FIELDS>` | `-f` | - | 指定输出的字段，逗号分隔 |
+
+### 输出格式说明
+
+- `json` - 标准 JSON 输出（带 ApiResponse 包装）
+- `pretty` - 格式化后的 JSON（便于阅读）
+- `raw` - 原始数据（无 ApiResponse 包装，适合 AI 解析）
+
+---
+
+## 命令分类
+
+### 1. 信息命令
+
+#### `ntd version`
+显示版本信息。
+
+```bash
+ntd version
+```
+
+#### `ntd upgrade`
+通过 npm 升级 ntd 到最新版本。
+
+```bash
+ntd upgrade
+```
+
+#### `ntd stats`
+获取全局统计数据（仪表盘统计）。
+
+```bash
+ntd stats
+```
+
+---
+
+### 2. 服务器命令
+
+#### `ntd server start`
+启动 API 服务器。
+
+```bash
+ntd server start [OPTIONS]
+
+OPTIONS:
+  -p, --port <PORT>  监听端口（默认: 8088）
+```
+
+**示例：**
+```bash
+ntd server start --port 8088
+```
+
+---
+
+### 3. Todo 管理命令
+
+#### `ntd todo create`
+创建新的 Todo。
+
+```bash
+ntd todo create [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 简写 | 说明 |
+|------|------|------|
+| `--title <TITLE>` | `-t` | Todo 标题 |
+| `--prompt <TEXT>` | `-p` | Prompt 内容 |
+| `--file <PATH>` | `-f` | 从文件读取 prompt |
+| `--stdin` | - | 从 stdin 读取 JSON 数据 |
+| `--executor <TYPE>` | `-e` | 执行器类型 |
+| `--workspace <PATH>` | `-w` | 工作目录 |
+| `--tags <IDs>` | - | 标签 ID（逗号分隔） |
+| `--schedule <CRON>` | - | 定时计划（Cron 表达式） |
+
+**执行器类型：**
+- `claudecode` - Claude Code
+- `joinai` - JoinAI
+- `codebuddy` - CodeBuddy
+- `opencode` - OpenCode
+- `atomcode` - AtomCode
+- `hermes` - Hermes
+- `kimi` - Kimi
+- `codex` - Codex
+
+**示例：**
+```bash
+# 创建简单 Todo
+ntd todo create --title "完成报告" --prompt "写一份季度报告"
+
+# 从文件创建
+ntd todo create --title "代码审查" --file ./prompt.txt
+
+# 指定执行器和标签
+ntd todo create -t "AI 任务" -p "使用 Claude 执行" -e claudecode --tags "1,2"
+
+# 定时任务
+ntd todo create -t "每日提醒" -p "检查日志" --schedule "0 9 * * *"
+```
+
+---
+
+#### `ntd todo list`
+列出 Todo 列表。
+
+```bash
+ntd todo list [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 简写 | 说明 |
+|------|------|------|
+| `--status <STATUS>` | - | 按状态筛选 |
+| `--tag <ID>` | - | 按标签 ID 筛选 |
+| `--running` | - | 仅显示运行中的 Todo |
+| `--search <KEYWORD>` | `-s` | 搜索标题或 prompt 关键词 |
+
+**示例：**
+```bash
+# 列出所有 Todo
+ntd todo list
+
+# 筛选进行中的
+ntd todo list --status running
+
+# 按标签筛选
+ntd todo list --tag 1
+
+# 搜索
+ntd todo list -s "报告"
+```
+
+---
+
+#### `ntd todo get <ID>`
+获取 Todo 详情。
+
+```bash
+ntd todo get <ID>
+```
+
+**示例：**
+```bash
+ntd todo get 123
+```
+
+---
+
+#### `ntd todo update <ID>`
+更新 Todo 信息。
+
+```bash
+ntd todo update <ID> [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 简写 | 说明 |
+|------|------|------|
+| `--title <TITLE>` | `-t` | 新标题 |
+| `--prompt <TEXT>` | `-p` | 新 prompt 内容 |
+| `--file <PATH>` | `-f` | 从文件读取 prompt |
+| `--stdin` | - | 从 stdin 读取 JSON 数据 |
+| `--status <STATUS>` | - | 新状态 |
+| `--executor <TYPE>` | `-e` | 执行器类型 |
+| `--workspace <PATH>` | `-w` | 工作目录 |
+| `--tags <IDs>` | - | 标签 ID（逗号分隔） |
+| `--schedule <CRON>` | - | 定时计划 |
+
+**示例：**
+```bash
+ntd todo update 123 --title "新标题" --status completed
+```
+
+---
+
+#### `ntd todo delete <ID>`
+删除 Todo。
+
+```bash
+ntd todo delete <ID>
+```
+
+**示例：**
+```bash
+ntd todo delete 123
+```
+
+---
+
+#### `ntd todo execute <ID>`
+执行 Todo。
+
+```bash
+ntd todo execute <ID> [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 简写 | 说明 |
+|------|------|------|
+| `--message <MSG>` | `-m` | 附加消息 |
+| `--executor <TYPE>` | `-e` | 指定执行器 |
+
+**示例：**
+```bash
+ntd todo execute 123 -m "开始执行"
+```
+
+---
+
+#### `ntd todo stop <ID>`
+停止 Todo 执行。
+
+```bash
+ntd todo stop <ID>
+```
+
+**示例：**
+```bash
+ntd todo stop 123
+```
+
+---
+
+#### `ntd todo stats <ID>`
+获取 Todo 执行统计。
+
+```bash
+ntd todo stats <ID>
+```
+
+**示例：**
+```bash
+ntd todo stats 123
+```
+
+---
+
+### 4. 执行记录命令
+
+#### `ntd todo execution list <TODO_ID>`
+列出 Todo 的执行记录。
+
+```bash
+ntd todo execution list <TODO_ID> [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 默认值 | 说明 |
+|------|--------|------|
+| `--status <STATUS>` | - | 按状态筛选 |
+| `--page <NUM>` | 1 | 页码 |
+| `--limit <NUM>` | 20 | 每页数量 |
+
+**示例：**
+```bash
+ntd todo execution list 123 --page 1 --limit 20
+```
+
+---
+
+#### `ntd todo execution get <ID>`
+获取执行记录详情。
+
+```bash
+ntd todo execution get <ID>
+```
+
+**示例：**
+```bash
+ntd todo execution get 456
+```
+
+---
+
+#### `ntd todo execution resume <ID>`
+从执行记录恢复对话。
+
+```bash
+ntd todo execution resume <ID> [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 简写 | 说明 |
+|------|------|------|
+| `--message <MSG>` | `-m` | 发送的消息 |
+
+**示例：**
+```bash
+ntd todo execution resume 456 -m "继续执行"
+```
+
+---
+
+### 5. 标签管理命令
+
+#### `ntd tag list`
+列出所有标签。
+
+```bash
+ntd tag list
+```
+
+---
+
+#### `ntd tag create <NAME>`
+创建新标签。
+
+```bash
+ntd tag create <NAME> [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 简写 | 默认值 | 说明 |
+|------|------|--------|------|
+| `--color <COLOR>` | `-c` | `#1890ff` | 标签颜色 |
+
+**示例：**
+```bash
+ntd tag create "重要" --color "#ff4d4f"
+```
+
+---
+
+#### `ntd tag delete <ID>`
+删除标签。
+
+```bash
+ntd tag delete <ID>
+```
+
+**示例：**
+```bash
+ntd tag delete 1
+```
+
+---
+
+### 6. 守护进程命令
+
+#### `ntd daemon install`
+安装 ntd 为系统守护进程。
+
+```bash
+ntd daemon install [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 简写 | 说明 |
+|------|------|------|
+| `--force` | `-f` | 强制重新安装 |
+| `--system` | - | 安装为系统级服务 |
+| `--run-as-user <USER>` | - | 指定运行用户（仅 Linux 系统服务） |
+
+**示例：**
+```bash
+# 安装为用户服务
+ntd daemon install
+
+# 强制重新安装
+ntd daemon install --force
+
+# 安装为系统服务（需要 sudo）
+sudo ntd daemon install --system
+```
+
+---
+
+#### `ntd daemon uninstall`
+卸载守护进程服务。
+
+```bash
+ntd daemon uninstall [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 说明 |
+|------|------|
+| `--system` | 卸载系统级服务 |
+
+**示例：**
+```bash
+ntd daemon uninstall
+sudo ntd daemon uninstall --system
+```
+
+---
+
+#### `ntd daemon start`
+启动守护进程。
+
+```bash
+ntd daemon start [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 说明 |
+|------|------|
+| `--system` | 启动系统级服务 |
+
+**示例：**
+```bash
+ntd daemon start
+```
+
+---
+
+#### `ntd daemon stop`
+停止守护进程。
+
+```bash
+ntd daemon stop [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 说明 |
+|------|------|
+| `--system` | 停止系统级服务 |
+
+**示例：**
+```bash
+ntd daemon stop
+```
+
+---
+
+#### `ntd daemon restart`
+重启守护进程。
+
+```bash
+ntd daemon restart [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 说明 |
+|------|------|
+| `--system` | 重启系统级服务 |
+
+**示例：**
+```bash
+ntd daemon restart
+```
+
+---
+
+#### `ntd daemon status`
+查看守护进程状态。
+
+```bash
+ntd daemon status [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 简写 | 说明 |
+|------|------|------|
+| `--verbose` | `-v` | 显示详细状态和最近日志 |
+
+**示例：**
+```bash
+# 简单状态
+ntd daemon status
+
+# 详细状态
+ntd daemon status -v
+```
+
+---
+
+## 使用示例
+
+### 完整工作流
+
+```bash
+# 1. 创建 Todo
+ntd todo create -t "开发新功能" -p "实现用户认证模块" -e claudecode
+
+# 2. 查看列表
+ntd todo list
+
+# 3. 执行 Todo
+ntd todo execute 1 -m "开始开发"
+
+# 4. 查看执行记录
+ntd todo execution list 1
+
+# 5. 停止执行
+ntd todo stop 1
+
+# 6. 更新 Todo
+ntd todo update 1 --status paused
+
+# 7. 删除 Todo
+ntd todo delete 1
+```
+
+### 标签管理
+
+```bash
+# 创建标签
+ntd tag create "重要" -c "#ff4d4f"
+ntd tag create "紧急" -c "#faad14"
+
+# 创建带标签的 Todo
+ntd todo create -t "处理投诉" -p "回复用户投诉" --tags "1,2"
+
+# 按标签筛选
+ntd todo list --tag 1
+```
+
+### 定时任务
+
+```bash
+# 创建每小时执行的任务
+ntd todo create -t "健康检查" -p "检查系统状态" --schedule "0 * * * *"
+
+# 创建每天早上 9 点执行的任务
+ntd todo create -t "日报" -p "发送每日报告" --schedule "0 9 * * *"
+```
+
+---
+
+## 退出码
+
+| 退出码 | 说明 |
+|--------|------|
+| 0 | 成功 |
+| 1 | 错误（命令执行失败） |
+| 2 | 参数错误 |


### PR DESCRIPTION
## Summary

新增两个完整的参考文档:

- **docs/ntd-cli.md** - ntd 命令行完整参考手册
  - 全局选项说明
  - 6 大类命令分类: 信息命令、服务器命令、Todo 管理、执行记录、标签管理、守护进程
  - 每个命令的选项、示例和详细说明

- **docs/ntd-api.md** - ntd API 接口完整参考文档  
  - 18 个接口分类
  - 约 70 个 API 端点
  - 包含请求/响应格式、参数说明、WebSocket 事件

## Test plan

- [x] 文档格式检查完成
- [x] 所有命令和接口已验证存在