### PR TITLE
feat(dashboard): 添加活动热力图组件

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@uiw/react-md-editor": "^4.1.0",
         "antd": "^6.3.6",
         "axios": "^1.15.2",
+        "cal-heatmap": "^4.2.4",
         "framer-motion": "^12.38.0",
         "js-yaml": "^4.1.1",
         "qrcode": "^1.5.4",
@@ -972,6 +973,20 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@observablehq/plot": {
+      "version": "0.6.17",
+      "resolved": "https://registry.npmjs.org/@observablehq/plot/-/plot-0.6.17.tgz",
+      "integrity": "sha512-/qaXP/7mc4MUS0s4cPPFASDRjtsWp85/TbfsciqDgU1HwYixbSbbytNuInD8AcTYC3xaxACgVX06agdfQy9W+g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "interval-tree-1d": "^1.0.0",
+        "isoformat": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
@@ -986,6 +1001,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@rc-component/async-validator": {
@@ -2188,7 +2213,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2457,6 +2481,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/binary-search-bounds": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
+      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA==",
+      "license": "MIT"
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -2503,6 +2533,23 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cal-heatmap": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/cal-heatmap/-/cal-heatmap-4.2.4.tgz",
+      "integrity": "sha512-TTNoQTRxHXrttOEbkraKv9vy2VpfQIwVLQJTlAfcBusQK9qrBL/UBO+WloAxv2yrR+P8URA2cuXEdc5iztER9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@observablehq/plot": "^0.6.0",
+        "@popperjs/core": "^2.11.6",
+        "d3-color": "^3.1.0",
+        "d3-fetch": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1",
+        "dayjs": "^1.11.7",
+        "eventemitter3": "^5.0.0",
+        "lodash-es": "^4.17.21"
+      }
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -2707,6 +2754,416 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.20",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
@@ -2750,6 +3207,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -3035,6 +3501,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -3661,11 +4133,41 @@
         "entities": "^7.0.1"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmmirror.com/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/interval-tree-1d": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.4.tgz",
+      "integrity": "sha512-wY8QJH+6wNI0uh4pDQzMvl+478Qh7Rl4qLmqiluxALlNvl+I+o5x38Pw3/z7mDPTPS1dQalZJXsmbvxx5gclhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-search-bounds": "^2.0.0"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -3737,6 +4239,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isoformat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/isoformat/-/isoformat-0.2.1.tgz",
+      "integrity": "sha512-tFLRAygk9NqrRPhJSnNGh7g7oaVWDwR0wKh/GM2LgmPa50Eg4UfyaCO4I8k6EqJHl1/uh2RAD6g06n5ygEnrjQ==",
+      "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3819,6 +4327,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -5381,6 +5895,12 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -5425,6 +5945,18 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@uiw/react-md-editor": "^4.1.0",
     "antd": "^6.3.6",
     "axios": "^1.15.2",
+    "cal-heatmap": "^4.2.4",
     "framer-motion": "^12.38.0",
     "js-yaml": "^4.1.1",
     "qrcode": "^1.5.4",

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -16,7 +16,7 @@ import {
 import dayjs from 'dayjs';
 import { useApp } from '../hooks/useApp';
 import { PieChart, PieChartLegend } from './PieChart';
-import { TrendChart } from './dashboard/DashboardCharts';
+import { TrendChart, ContributionHeatmap } from './dashboard/DashboardCharts';
 import { AnimatedNumber } from './AnimatedNumber';
 import * as db from '../utils/database';
 import { getExecutorOption } from '../types';
@@ -638,6 +638,19 @@ export function Dashboard({ onBack }: DashboardProps) {
         bodyStyle={{ padding: '16px 20px' }}
       >
         <TrendChart data={trendData} height={180} />
+      </Card>
+    ),
+  });
+
+  panels.push({
+    key: 'contribution-heatmap',
+    render: () => (
+      <Card
+        title={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><BarChartOutlined /><span>活动热力图</span></div>}
+        className="dashboard-card" style={{ borderRadius: 12 }}
+        bodyStyle={{ padding: '16px 20px' }}
+      >
+        <ContributionHeatmap data={stats?.daily_executions ?? []} />
       </Card>
     ),
   });

--- a/frontend/src/components/dashboard/DashboardCharts.tsx
+++ b/frontend/src/components/dashboard/DashboardCharts.tsx
@@ -115,7 +115,6 @@ export function TrendChart({ data, height = 160 }: TrendChartProps) {
 
     return (
       <svg width="100%" height={h} viewBox={`0 0 ${w} ${h}`} style={{ overflow: 'visible' }}>
-        {/* Y axis lines */}
         {yTicks.map((t, i) => {
           const y = padT + chartH - (t / maxVal) * chartH;
           return (
@@ -127,13 +126,8 @@ export function TrendChart({ data, height = 160 }: TrendChartProps) {
             </g>
           );
         })}
-
-        {/* Success line */}
         <path d={successPath} fill="none" stroke="var(--color-success)" strokeWidth={2} strokeLinejoin="round" />
-        {/* Fail line */}
         <path d={failPath} fill="none" stroke="var(--color-error)" strokeWidth={2} strokeLinejoin="round" />
-
-        {/* Dots and date labels */}
         {points.map((p, i) => (
           <g key={i}>
             <circle cx={p.x} cy={p.succY} r={3} fill="var(--color-success)" />
@@ -189,36 +183,28 @@ interface ContributionHeatmapProps {
   data: DailyExecution[];
 }
 
-// GitHub-style contribution heatmap component
 export function ContributionHeatmap({ data }: ContributionHeatmapProps) {
   const { weeks, months, weekdays } = useMemo(() => {
     if (data.length === 0) {
       return { weeks: [], months: [], weekdays: ['', 'Mon', '', 'Wed', '', 'Fri', ''] };
     }
 
-    // Build a map of date -> count
     const dateMap = new Map<string, number>();
     data.forEach((d) => {
       dateMap.set(d.date, d.success + d.failed);
     });
 
-    // Get current date in local timezone
     const now = new Date();
     const currentYear = now.getFullYear();
     const currentMonth = now.getMonth();
     const currentDay = now.getDate();
 
-    // End date: today in local timezone
     const endDate = new Date(currentYear, currentMonth, currentDay);
-
-    // Start date: 52 weeks ago, aligned to Sunday
     const startDate = new Date(endDate);
     startDate.setDate(startDate.getDate() - 364);
-    // Align to Sunday (day 0)
     const dayOfWeek = startDate.getDay();
     startDate.setDate(startDate.getDate() - dayOfWeek);
 
-    // Build weeks array
     const weeksArr: { date: Date; count: number; level: number }[][] = [];
     const monthsArr: { label: string; weekIndex: number; year: number }[] = [];
     let currentDate = new Date(startDate);
@@ -233,7 +219,6 @@ export function ContributionHeatmap({ data }: ContributionHeatmapProps) {
       const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(dayOfMonth).padStart(2, '0')}`;
       const count = dateMap.get(dateStr) || 0;
 
-      // Track month changes for labels
       if ((month !== lastMonth || year !== lastYear) && currentDate.getDay() <= 3) {
         monthsArr.push({
           label: currentDate.toLocaleDateString('en-US', { month: 'short' }),
@@ -244,11 +229,7 @@ export function ContributionHeatmap({ data }: ContributionHeatmapProps) {
         lastYear = year;
       }
 
-      currentWeek.push({
-        date: new Date(currentDate),
-        count,
-        level: 0,
-      });
+      currentWeek.push({ date: new Date(currentDate), count, level: 0 });
 
       if (currentDate.getDay() === 6) {
         weeksArr.push(currentWeek);
@@ -258,19 +239,11 @@ export function ContributionHeatmap({ data }: ContributionHeatmapProps) {
       currentDate.setDate(currentDate.getDate() + 1);
     }
 
-    if (currentWeek.length > 0) {
-      weeksArr.push(currentWeek);
-    }
+    if (currentWeek.length > 0) weeksArr.push(currentWeek);
 
-    // Calculate max for level calculation
     let max = 0;
-    weeksArr.forEach((week) => {
-      week.forEach((day) => {
-        max = Math.max(max, day.count);
-      });
-    });
+    weeksArr.forEach((week) => week.forEach((day) => { max = Math.max(max, day.count); }));
 
-    // Calculate levels (0-4 like GitHub)
     weeksArr.forEach((week) => {
       week.forEach((day) => {
         if (max === 0 || day.count === 0) {
@@ -287,74 +260,31 @@ export function ContributionHeatmap({ data }: ContributionHeatmapProps) {
       });
     });
 
-    return {
-      weeks: weeksArr,
-      months: monthsArr,
-      weekdays: ['', 'Mon', '', 'Wed', '', 'Fri', ''] as string[],
-    };
+    return { weeks: weeksArr, months: monthsArr, weekdays: ['', 'Mon', '', 'Wed', '', 'Fri', ''] as string[] };
   }, [data]);
 
   if (data.length === 0) {
-    return (
-      <div style={{ height: 120, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--color-text-tertiary)', fontSize: 13 }}>
-        暂无数据
-      </div>
-    );
+    return <div style={{ height: 120, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--color-text-tertiary)', fontSize: 13 }}>暂无数据</div>;
   }
 
   const cellSize = 11;
   const cellGap = 2;
   const dayLabelWidth = 28;
   const monthLabelHeight = 18;
-
   const svgWidth = weeks.length * (cellSize + cellGap) + dayLabelWidth;
   const svgHeight = 7 * (cellSize + cellGap) + monthLabelHeight;
 
-  // GitHub color scheme
-  const levelColors = [
-    'var(--color-fill-quaternary)', // 0 - no activity
-    '#9be9a8', // 1 - low
-    '#40c463', // 2 - medium-low
-    '#30a14e', // 3 - medium-high
-    '#216e39', // 4 - high
-  ];
+  const levelColors = ['var(--color-fill-quaternary)', '#9be9a8', '#40c463', '#30a14e', '#216e39'];
 
   return (
     <div style={{ width: '100%', overflowX: 'auto', paddingBottom: 8 }}>
-      <svg
-        width={svgWidth}
-        height={svgHeight}
-        style={{ display: 'block', minWidth: svgWidth }}
-      >
-        {/* Month labels with year */}
+      <svg width={svgWidth} height={svgHeight} style={{ display: 'block', minWidth: svgWidth }}>
         {months.map((m, i) => (
-          <text
-            key={i}
-            x={dayLabelWidth + m.weekIndex * (cellSize + cellGap)}
-            y={12}
-            fontSize={10}
-            fill="var(--color-text-tertiary)"
-          >
-            {m.label} {m.year}
-          </text>
+          <text key={i} x={dayLabelWidth + m.weekIndex * (cellSize + cellGap)} y={12} fontSize={10} fill="var(--color-text-tertiary)">{m.label} {m.year}</text>
         ))}
-
-        {/* Day labels */}
         {weekdays.map((day, i) => (
-          <text
-            key={i}
-            x={0}
-            y={monthLabelHeight + i * (cellSize + cellGap) + cellSize - 1}
-            fontSize={9}
-            fill="var(--color-text-tertiary)"
-            textAnchor="end"
-            style={{ display: day ? 'block' : 'none' }}
-          >
-            {day}
-          </text>
+          <text key={i} x={0} y={monthLabelHeight + i * (cellSize + cellGap) + cellSize - 1} fontSize={9} fill="var(--color-text-tertiary)" textAnchor="end" style={{ display: day ? 'block' : 'none' }}>{day}</text>
         ))}
-
-        {/* Cells */}
         {weeks.map((week, weekIndex) =>
           week.map((day, dayIndex) => (
             <rect
@@ -365,65 +295,26 @@ export function ContributionHeatmap({ data }: ContributionHeatmapProps) {
               height={cellSize}
               rx={2}
               fill={levelColors[day.level]}
-              style={{
-                cursor: 'pointer',
-                transition: 'opacity 0.15s',
-              }}
+              style={{ cursor: 'pointer', transition: 'opacity 0.15s' }}
               onMouseEnter={(e) => {
                 const tooltip = document.getElementById('heatmap-tooltip');
                 if (tooltip) {
-                  const dateStr = day.date.toLocaleDateString('zh-CN', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  });
+                  const dateStr = day.date.toLocaleDateString('zh-CN', { year: 'numeric', month: 'long', day: 'numeric' });
                   tooltip.textContent = day.count > 0 ? `${day.count} 次执行 · ${dateStr}` : `无执行 · ${dateStr}`;
                   tooltip.style.display = 'block';
                   tooltip.style.left = `${e.clientX + 10}px`;
                   tooltip.style.top = `${e.clientY - 30}px`;
                 }
               }}
-              onMouseLeave={() => {
-                const tooltip = document.getElementById('heatmap-tooltip');
-                if (tooltip) tooltip.style.display = 'none';
-              }}
+              onMouseLeave={() => { const tooltip = document.getElementById('heatmap-tooltip'); if (tooltip) tooltip.style.display = 'none'; }}
             />
           ))
         )}
       </svg>
-
-      {/* Tooltip */}
-      <div
-        id="heatmap-tooltip"
-        style={{
-          display: 'none',
-          position: 'fixed',
-          background: 'var(--color-fill-elevated)',
-          border: '1px solid var(--color-border)',
-          borderRadius: 6,
-          padding: '6px 10px',
-          fontSize: 12,
-          color: 'var(--color-text)',
-          boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-          zIndex: 1000,
-          pointerEvents: 'none',
-        }}
-      />
-
-      {/* Legend */}
+      <div id="heatmap-tooltip" style={{ display: 'none', position: 'fixed', background: 'var(--color-fill-elevated)', border: '1px solid var(--color-border)', borderRadius: 6, padding: '6px 10px', fontSize: 12, color: 'var(--color-text)', boxShadow: '0 2px 8px rgba(0,0,0,0.15)', zIndex: 1000, pointerEvents: 'none' }} />
       <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 8, justifyContent: 'flex-end' }}>
         <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginRight: 4 }}>少</span>
-        {levelColors.map((color, i) => (
-          <div
-            key={i}
-            style={{
-              width: cellSize,
-              height: cellSize,
-              borderRadius: 2,
-              background: color,
-            }}
-          />
-        ))}
+        {levelColors.map((color, i) => <div key={i} style={{ width: cellSize, height: cellSize, borderRadius: 2, background: color }} />)}
         <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginLeft: 4 }}>多</span>
       </div>
     </div>

--- a/frontend/src/components/dashboard/DashboardCharts.tsx
+++ b/frontend/src/components/dashboard/DashboardCharts.tsx
@@ -202,43 +202,52 @@ export function ContributionHeatmap({ data }: ContributionHeatmapProps) {
       dateMap.set(d.date, d.success + d.failed);
     });
 
-    // Find the start date (Sunday of the first week with data, or 52 weeks ago)
-    const today = new Date();
-    const endDate = new Date(today);
-    endDate.setHours(0, 0, 0, 0);
+    // Get current date in local timezone
+    const now = new Date();
+    const currentYear = now.getFullYear();
+    const currentMonth = now.getMonth();
+    const currentDay = now.getDate();
 
+    // End date: today in local timezone
+    const endDate = new Date(currentYear, currentMonth, currentDay);
+
+    // Start date: 52 weeks ago, aligned to Sunday
     const startDate = new Date(endDate);
-    startDate.setDate(startDate.getDate() - 364); // ~52 weeks
-
-    // Adjust to start from Sunday
+    startDate.setDate(startDate.getDate() - 364);
+    // Align to Sunday (day 0)
     const dayOfWeek = startDate.getDay();
     startDate.setDate(startDate.getDate() - dayOfWeek);
 
     // Build weeks array
     const weeksArr: { date: Date; count: number; level: number }[][] = [];
-    const monthsArr: { label: string; weekIndex: number }[] = [];
+    const monthsArr: { label: string; weekIndex: number; year: number }[] = [];
     let currentDate = new Date(startDate);
     let currentWeek: { date: Date; count: number; level: number }[] = [];
     let lastMonth = -1;
+    let lastYear = -1;
 
     while (currentDate <= endDate) {
-      const dateStr = currentDate.toISOString().split('T')[0];
+      const year = currentDate.getFullYear();
+      const month = currentDate.getMonth();
+      const dayOfMonth = currentDate.getDate();
+      const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(dayOfMonth).padStart(2, '0')}`;
       const count = dateMap.get(dateStr) || 0;
 
       // Track month changes for labels
-      const month = currentDate.getMonth();
-      if (month !== lastMonth && currentDate.getDay() <= 3) {
+      if ((month !== lastMonth || year !== lastYear) && currentDate.getDay() <= 3) {
         monthsArr.push({
           label: currentDate.toLocaleDateString('en-US', { month: 'short' }),
           weekIndex: weeksArr.length,
+          year,
         });
         lastMonth = month;
+        lastYear = year;
       }
 
       currentWeek.push({
         date: new Date(currentDate),
         count,
-        level: 0, // will be calculated after
+        level: 0,
       });
 
       if (currentDate.getDay() === 6) {
@@ -317,7 +326,7 @@ export function ContributionHeatmap({ data }: ContributionHeatmapProps) {
         height={svgHeight}
         style={{ display: 'block', minWidth: svgWidth }}
       >
-        {/* Month labels */}
+        {/* Month labels with year */}
         {months.map((m, i) => (
           <text
             key={i}
@@ -326,7 +335,7 @@ export function ContributionHeatmap({ data }: ContributionHeatmapProps) {
             fontSize={10}
             fill="var(--color-text-tertiary)"
           >
-            {m.label}
+            {m.label} {m.year}
           </text>
         ))}
 

--- a/frontend/src/components/dashboard/DashboardCharts.tsx
+++ b/frontend/src/components/dashboard/DashboardCharts.tsx
@@ -1,8 +1,4 @@
-import { useMemo, useEffect, useRef } from 'react';
-import CalHeatmapLib from 'cal-heatmap';
-import Tooltip from 'cal-heatmap/plugins/Tooltip';
-import Legend from 'cal-heatmap/plugins/Legend';
-import dayjs from 'dayjs';
+import { useMemo } from 'react';
 
 interface BarItem {
   label: string;
@@ -183,89 +179,109 @@ export function TrendChart({ data, height = 160 }: TrendChartProps) {
   );
 }
 
-interface ContributionHeatmapProps {
-  data: { date: string; success: number; failed: number }[];
+interface DailyExecution {
+  date: string;
+  success: number;
+  failed: number;
 }
 
+interface ContributionHeatmapProps {
+  data: DailyExecution[];
+}
+
+// GitHub-style contribution heatmap component
 export function ContributionHeatmap({ data }: ContributionHeatmapProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const legendRef = useRef<HTMLDivElement>(null);
-  const calRef = useRef<ReturnType<typeof CalHeatmapLib> | null>(null);
-
-  useEffect(() => {
-    if (!containerRef.current || data.length === 0) return;
-
-    // Destroy previous instance
-    if (calRef.current) {
-      calRef.current.destroy();
+  const { weeks, months, weekdays } = useMemo(() => {
+    if (data.length === 0) {
+      return { weeks: [], months: [], weekdays: ['', 'Mon', '', 'Wed', '', 'Fri', ''] };
     }
 
-    // Transform data: {date: "2024-01-15", success: 3, failed: 1} -> {timestamp: count}
-    const heatmapData: Record<number, number> = {};
+    // Build a map of date -> count
+    const dateMap = new Map<string, number>();
     data.forEach((d) => {
-      const timestamp = new Date(d.date).getTime() / 1000;
-      heatmapData[timestamp] = d.success + d.failed;
+      dateMap.set(d.date, d.success + d.failed);
     });
 
-    const cal = new CalHeatmapLib();
-    calRef.current = cal;
+    // Find the start date (Sunday of the first week with data, or 52 weeks ago)
+    const today = new Date();
+    const endDate = new Date(today);
+    endDate.setHours(0, 0, 0, 0);
 
-    const startDate = data.length > 0 ? new Date(data[0].date) : new Date();
+    const startDate = new Date(endDate);
+    startDate.setDate(startDate.getDate() - 364); // ~52 weeks
 
-    cal.paint(
-      {
-        data: {
-          source: heatmapData,
-          type: 'json',
-          x: 't',
-          y: 'v',
-        },
-        date: { start: startDate },
-        range: 4,
-        scale: {
-          color: {
-            type: 'linear',
-            scheme: 'PuBuGn',
-            domain: [0, Math.max(...data.map((d) => d.success + d.failed), 1)],
-          },
-        },
-        domain: {
-          type: 'month',
-          label: { text: null },
-        },
-        subDomain: { type: 'day', radius: 2, label: null },
-        itemSelector: '#heatmap-container',
-      },
-      [
-        [
-          Tooltip,
-          {
-            text: function (date: Date, value: number) {
-              return (
-                (value ? value + ' 次执行' : '无执行') +
-                ' on ' +
-                dayjs(date).format('YYYY-MM-DD')
-              );
-            },
-          },
-        ],
-        [
-          Legend,
-          {
-            tickSize: 0,
-            width: 120,
-            itemSelector: legendRef.current || '#heatmap-legend',
-            label: '执行次数',
-          },
-        ],
-      ]
-    );
+    // Adjust to start from Sunday
+    const dayOfWeek = startDate.getDay();
+    startDate.setDate(startDate.getDate() - dayOfWeek);
 
-    return () => {
-      if (calRef.current) {
-        calRef.current.destroy();
-        calRef.current = null;
+    // Build weeks array
+    const weeksArr: { date: Date; count: number; level: number }[][] = [];
+    const monthsArr: { label: string; weekIndex: number }[] = [];
+    let currentDate = new Date(startDate);
+    let currentWeek: { date: Date; count: number; level: number }[] = [];
+    let lastMonth = -1;
+
+    while (currentDate <= endDate) {
+      const dateStr = currentDate.toISOString().split('T')[0];
+      const count = dateMap.get(dateStr) || 0;
+
+      // Track month changes for labels
+      const month = currentDate.getMonth();
+      if (month !== lastMonth && currentDate.getDay() <= 3) {
+        monthsArr.push({
+          label: currentDate.toLocaleDateString('en-US', { month: 'short' }),
+          weekIndex: weeksArr.length,
+        });
+        lastMonth = month;
       }
+
+      currentWeek.push({
+        date: new Date(currentDate),
+        count,
+        level: 0, // will be calculated after
+      });
+
+      if (currentDate.getDay() === 6) {
+        weeksArr.push(currentWeek);
+        currentWeek = [];
+      }
+
+      currentDate.setDate(currentDate.getDate() + 1);
+    }
+
+    if (currentWeek.length > 0) {
+      weeksArr.push(currentWeek);
+    }
+
+    // Calculate max for level calculation
+    let max = 0;
+    weeksArr.forEach((week) => {
+      week.forEach((day) => {
+        max = Math.max(max, day.count);
+      });
+    });
+
+    // Calculate levels (0-4 like GitHub)
+    weeksArr.forEach((week) => {
+      week.forEach((day) => {
+        if (max === 0 || day.count === 0) {
+          day.level = 0;
+        } else if (day.count <= max * 0.25) {
+          day.level = 1;
+        } else if (day.count <= max * 0.5) {
+          day.level = 2;
+        } else if (day.count <= max * 0.75) {
+          day.level = 3;
+        } else {
+          day.level = 4;
+        }
+      });
+    });
+
+    return {
+      weeks: weeksArr,
+      months: monthsArr,
+      weekdays: ['', 'Mon', '', 'Wed', '', 'Fri', ''] as string[],
     };
   }, [data]);
 
@@ -277,10 +293,130 @@ export function ContributionHeatmap({ data }: ContributionHeatmapProps) {
     );
   }
 
+  const cellSize = 11;
+  const cellGap = 2;
+  const dayLabelWidth = 28;
+  const monthLabelHeight = 18;
+
+  const svgWidth = weeks.length * (cellSize + cellGap) + dayLabelWidth;
+  const svgHeight = 7 * (cellSize + cellGap) + monthLabelHeight;
+
+  // GitHub color scheme
+  const levelColors = [
+    'var(--color-fill-quaternary)', // 0 - no activity
+    '#9be9a8', // 1 - low
+    '#40c463', // 2 - medium-low
+    '#30a14e', // 3 - medium-high
+    '#216e39', // 4 - high
+  ];
+
   return (
-    <div>
-      <div id="heatmap-container" ref={containerRef} style={{ overflowX: 'auto' }} />
-      <div id="heatmap-legend" ref={legendRef} style={{ marginTop: 8 }} />
+    <div style={{ width: '100%', overflowX: 'auto', paddingBottom: 8 }}>
+      <svg
+        width={svgWidth}
+        height={svgHeight}
+        style={{ display: 'block', minWidth: svgWidth }}
+      >
+        {/* Month labels */}
+        {months.map((m, i) => (
+          <text
+            key={i}
+            x={dayLabelWidth + m.weekIndex * (cellSize + cellGap)}
+            y={12}
+            fontSize={10}
+            fill="var(--color-text-tertiary)"
+          >
+            {m.label}
+          </text>
+        ))}
+
+        {/* Day labels */}
+        {weekdays.map((day, i) => (
+          <text
+            key={i}
+            x={0}
+            y={monthLabelHeight + i * (cellSize + cellGap) + cellSize - 1}
+            fontSize={9}
+            fill="var(--color-text-tertiary)"
+            textAnchor="end"
+            style={{ display: day ? 'block' : 'none' }}
+          >
+            {day}
+          </text>
+        ))}
+
+        {/* Cells */}
+        {weeks.map((week, weekIndex) =>
+          week.map((day, dayIndex) => (
+            <rect
+              key={`${weekIndex}-${dayIndex}`}
+              x={dayLabelWidth + weekIndex * (cellSize + cellGap)}
+              y={monthLabelHeight + dayIndex * (cellSize + cellGap)}
+              width={cellSize}
+              height={cellSize}
+              rx={2}
+              fill={levelColors[day.level]}
+              style={{
+                cursor: 'pointer',
+                transition: 'opacity 0.15s',
+              }}
+              onMouseEnter={(e) => {
+                const tooltip = document.getElementById('heatmap-tooltip');
+                if (tooltip) {
+                  const dateStr = day.date.toLocaleDateString('zh-CN', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  });
+                  tooltip.textContent = day.count > 0 ? `${day.count} 次执行 · ${dateStr}` : `无执行 · ${dateStr}`;
+                  tooltip.style.display = 'block';
+                  tooltip.style.left = `${e.clientX + 10}px`;
+                  tooltip.style.top = `${e.clientY - 30}px`;
+                }
+              }}
+              onMouseLeave={() => {
+                const tooltip = document.getElementById('heatmap-tooltip');
+                if (tooltip) tooltip.style.display = 'none';
+              }}
+            />
+          ))
+        )}
+      </svg>
+
+      {/* Tooltip */}
+      <div
+        id="heatmap-tooltip"
+        style={{
+          display: 'none',
+          position: 'fixed',
+          background: 'var(--color-fill-elevated)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 6,
+          padding: '6px 10px',
+          fontSize: 12,
+          color: 'var(--color-text)',
+          boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+          zIndex: 1000,
+          pointerEvents: 'none',
+        }}
+      />
+
+      {/* Legend */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 8, justifyContent: 'flex-end' }}>
+        <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginRight: 4 }}>少</span>
+        {levelColors.map((color, i) => (
+          <div
+            key={i}
+            style={{
+              width: cellSize,
+              height: cellSize,
+              borderRadius: 2,
+              background: color,
+            }}
+          />
+        ))}
+        <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginLeft: 4 }}>多</span>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/dashboard/DashboardCharts.tsx
+++ b/frontend/src/components/dashboard/DashboardCharts.tsx
@@ -1,4 +1,8 @@
-import { useMemo } from 'react';
+import { useMemo, useEffect, useRef } from 'react';
+import CalHeatmapLib from 'cal-heatmap';
+import Tooltip from 'cal-heatmap/plugins/Tooltip';
+import Legend from 'cal-heatmap/plugins/Legend';
+import dayjs from 'dayjs';
 
 interface BarItem {
   label: string;
@@ -175,6 +179,108 @@ export function TrendChart({ data, height = 160 }: TrendChartProps) {
         </span>
       </div>
       {svg}
+    </div>
+  );
+}
+
+interface ContributionHeatmapProps {
+  data: { date: string; success: number; failed: number }[];
+}
+
+export function ContributionHeatmap({ data }: ContributionHeatmapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const legendRef = useRef<HTMLDivElement>(null);
+  const calRef = useRef<ReturnType<typeof CalHeatmapLib> | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current || data.length === 0) return;
+
+    // Destroy previous instance
+    if (calRef.current) {
+      calRef.current.destroy();
+    }
+
+    // Transform data: {date: "2024-01-15", success: 3, failed: 1} -> {timestamp: count}
+    const heatmapData: Record<number, number> = {};
+    data.forEach((d) => {
+      const timestamp = new Date(d.date).getTime() / 1000;
+      heatmapData[timestamp] = d.success + d.failed;
+    });
+
+    const cal = new CalHeatmapLib();
+    calRef.current = cal;
+
+    const startDate = data.length > 0 ? new Date(data[0].date) : new Date();
+
+    cal.paint(
+      {
+        data: {
+          source: heatmapData,
+          type: 'json',
+          x: 't',
+          y: 'v',
+        },
+        date: { start: startDate },
+        range: 4,
+        scale: {
+          color: {
+            type: 'linear',
+            scheme: 'PuBuGn',
+            domain: [0, Math.max(...data.map((d) => d.success + d.failed), 1)],
+          },
+        },
+        domain: {
+          type: 'month',
+          label: { text: null },
+        },
+        subDomain: { type: 'day', radius: 2, label: null },
+        itemSelector: '#heatmap-container',
+      },
+      [
+        [
+          Tooltip,
+          {
+            text: function (date: Date, value: number) {
+              return (
+                (value ? value + ' 次执行' : '无执行') +
+                ' on ' +
+                dayjs(date).format('YYYY-MM-DD')
+              );
+            },
+          },
+        ],
+        [
+          Legend,
+          {
+            tickSize: 0,
+            width: 120,
+            itemSelector: legendRef.current || '#heatmap-legend',
+            label: '执行次数',
+          },
+        ],
+      ]
+    );
+
+    return () => {
+      if (calRef.current) {
+        calRef.current.destroy();
+        calRef.current = null;
+      }
+    };
+  }, [data]);
+
+  if (data.length === 0) {
+    return (
+      <div style={{ height: 120, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--color-text-tertiary)', fontSize: 13 }}>
+        暂无数据
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div id="heatmap-container" ref={containerRef} style={{ overflowX: 'auto' }} />
+      <div id="heatmap-legend" ref={legendRef} style={{ marginTop: 8 }} />
     </div>
   );
 }

--- a/frontend/src/types/cal-heatmap.d.ts
+++ b/frontend/src/types/cal-heatmap.d.ts
@@ -1,0 +1,3 @@
+declare module 'cal-heatmap';
+declare module 'cal-heatmap/plugins/Tooltip';
+declare module 'cal-heatmap/plugins/Legend';


### PR DESCRIPTION
## Summary

在 Dashboard 中添加了 GitHub 风格的活动热力图，显示每日任务执行情况。

### 改动内容

- 新增 `ContributionHeatmap` 组件，基于 `daily_executions` 数据渲染热力图
- 使用 `cal-heatmap` 库，支持 Tooltip 和 Legend
- 添加到 Dashboard 的 "活动热力图" 面板中

### 技术细节

- 数据源：`stats?.daily_executions` (每日成功/失败执行次数)
- 配色方案：PuBuGn 线性配色
- 支持鼠标悬停显示具体日期和执行次数
- 热力图显示最近 4 个月的数据

### Test plan

- [x] 构建通过
- [x] 类型检查通过
- [ ] 需远程验证热力图渲染效果