### PR TITLE
fix: 飞书看板卡片堆叠与 footer 显示

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2498,6 +2498,7 @@ code {
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border-light);
   max-height: 100%;
+  min-height: 0;
   transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
@@ -2560,11 +2561,11 @@ code {
 .kanban-column-body {
   flex: 1;
   overflow-y: auto;
+  min-height: 0;
   padding: var(--space-sm);
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
-  min-height: 60px;
 }
 
 .kanban-column-body::-webkit-scrollbar {
@@ -2602,6 +2603,8 @@ code {
   display: flex;
   flex-direction: column;
   padding: 0;
+  flex-shrink: 0;
+  min-height: 80px;
 }
 
 .kanban-card:hover {


### PR DESCRIPTION
## 问题

飞书看板模式下：
1. todo 卡片互相堆叠重叠
2. 底部 footer 缺失

## 根因

- 列容器 `align-items: flex-start` 导致列高度未受容器约束
- `.kanban-column` 的 `max-height: 100%` 因 flex 默认 `min-height: auto` 无法生效
- 列体内卡片被 flex 布局压缩

## 修改

`frontend/src/App.css` 三处改动：

- **`.kanban-card`**: 添加 `flex-shrink: 0` 和 `min-height: 80px`，防止卡片被压缩
- **`.kanban-column`**: 添加 `min-height: 0`，允许 `max-height: 100%` 正确约束列高度
- **`.kanban-column-body`**: 将 `min-height: 60px` 改为 `min-height: 0`，使溢出时能正确触发滚动

## 验证

- 前端构建通过 (`tsc && vite build`)
- 后端编译通过 (`cargo build --release`)
- 服务启动正常，返回 200