### PR TITLE
fix: 更换图标并修复手机端看板展开问题

### DIFF
--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -314,7 +314,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
   };
 
   /* ─── Touch Swipe Handlers for Mobile Tabs ─── */
-  const mobileTabItems = useMemo(() => COLUMNS.map(col => ({
+  const mobileTabItems = COLUMNS.map(col => ({
     key: col.status,
     label: `${col.label} (${grouped[col.status].length})`,
     children: (
@@ -326,7 +326,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
         )}
       </div>
     ),
-  })), [grouped]);
+  }));
 
   const touchStartRef = useRef<{ x: number; y: number; time: number } | null>(null);
 

--- a/frontend/src/components/TodoCard.tsx
+++ b/frontend/src/components/TodoCard.tsx
@@ -5,6 +5,8 @@ import {
   ClockCircleOutlined,
   RobotOutlined,
   CopyOutlined,
+  EditOutlined,
+  FileProtectOutlined,
 } from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
 import { ExecutorBadge } from './ExecutorBadge';
@@ -146,7 +148,7 @@ export function TodoCard({
               tabIndex={0}
               onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); onTogglePrompt(); } }}
             >
-              <span className="kanban-card-section-label">📋 Prompt</span>
+              <span className="kanban-card-section-label"><EditOutlined /> Prompt</span>
               {prompt && (
                 <button
                   className="kanban-copy-btn"
@@ -181,9 +183,7 @@ export function TodoCard({
               tabIndex={0}
               onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); onToggleResult(); } }}
             >
-              <span className="kanban-card-section-label">
-                {isSuccess ? <CheckCircleOutlined /> : <CloseCircleOutlined />} 结论
-              </span>
+              <span className="kanban-card-section-label"><FileProtectOutlined /> 结论</span>
               {resultText && (
                 <button
                   className="kanban-copy-btn"


### PR DESCRIPTION
## Summary
- Prompt 图标从 emoji 📋 更换为 Ant Design 图标 EditOutlined
- 结论图标从成功/失败状态图标更换为统一的 FileProtectOutlined 图标
- 修复手机端看板视图点击展开无反应的问题

## Bug Fix
手机端看板视图展开功能失效的原因：`mobileTabItems` 使用 `useMemo` 依赖 `grouped`，当 `expandedPromptIds` 状态变化时，`grouped` 未变，导致 Ant Design Tabs 组件认为 props 未变化，跳过了子组件重新渲染。

## Test plan
- [x] 桌面端看板视图展开功能正常
- [x] 手机端看板视图展开功能正常
- [x] 结论视图展开功能正常