### PR TITLE
fix: 修复 3 个严重缺陷（竞争条件、路径遍历、runtime 阻塞）

### DIFF
--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -115,10 +115,22 @@ fn backup_dir() -> PathBuf {
 
 /// 手动下载数据库文件
 pub async fn download_database(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
 ) -> Result<impl IntoResponse, AppError> {
-    let cfg = crate::config::Config::load();
+    let cfg = state.config.read().await;
     let db_path = PathBuf::from(&cfg.db_path);
+
+    // 路径穿越防护：验证数据库路径位于安全目录 ~/.ntd/ 内
+    let canonicalized = std::fs::canonicalize(&db_path)
+        .map_err(|_| AppError::BadRequest("Invalid database path".to_string()))?;
+    let safe_dir = dirs::home_dir()
+        .ok_or_else(|| AppError::Internal("Cannot determine home directory".to_string()))?
+        .join(".ntd");
+    let safe_dir_canonical = std::fs::canonicalize(&safe_dir)
+        .unwrap_or(safe_dir);
+    if !canonicalized.starts_with(&safe_dir_canonical) {
+        return Err(AppError::BadRequest("Database path outside safe directory".to_string()));
+    }
 
     if !db_path.exists() {
         return Err(AppError::Internal("Database file not found".to_string()));

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -39,9 +39,11 @@ pub async fn update_config(
 
     cfg.normalize_paths();
 
-    if let Err(e) = cfg.save() {
-        return Err(AppError::Internal(format!("Failed to save config: {}", e)));
-    }
+    let cfg_clone = cfg.clone();
+    tokio::task::spawn_blocking(move || cfg_clone.save())
+        .await
+        .map_err(|e| AppError::Internal(format!("Join error: {}", e)))?
+        .map_err(|e| AppError::Internal(format!("Failed to save config: {}", e)))?;
 
     Ok(ApiResponse::ok(cfg.clone()))
 }

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -151,19 +151,7 @@ pub async fn stop_execution_handler(
                 task_id
             );
         }
-        // 更新数据库状态为失败，保留定时刷新已写入的日志
-        let logs_json = record.logs.clone();
-        let _ = state
-            .db
-            .update_execution_record(
-                req.record_id,
-                crate::models::ExecutionStatus::Failed.as_str(),
-                &logs_json,
-                "任务已被手动停止",
-                None,
-                None,
-            )
-            .await;
+        // 只需发送取消信号，cancel handler 会在 executor_service 中更新数据库
         tracing::info!("Successfully stopped execution record {}", req.record_id);
         Ok(ApiResponse::ok(()))
     } else {


### PR DESCRIPTION
## 修复内容

### 1. 竞争条件：stop_execution_handler 双写 DB (CRITICAL)
- **问题**： 调用  后立即使用过期日志快照写入 DB，而  的 cancel 分支也在同时做最终日志写入，两者并发导致日志丢失或状态被覆盖
- **修复**：移除 handler 中的冗余 DB 写入，仅发送取消信号。最终的 DB 更新全权由 cancel 分支处理

### 2. 路径遍历：download_database 可读取任意文件 (CRITICAL)  
- **问题**： 每次都从磁盘  加载 。攻击者可先通过 PUT  将  设为 ，再调用下载端点读取任意文件
- **修复**：使用  内存中的配置替代磁盘重载，并添加  路径白名单验证

### 3. Runtime 阻塞：Config::save() 同步 I/O (CRITICAL)
- **问题**： 在 async 上下文中直接调用 （含  + ），阻塞 tokio 工作线程
- **修复**：通过  将文件 I/O 移至阻塞线程池