### PR TITLE
fix: fix top 3 critical issues from code review

### DIFF
--- a/backend/src/handlers/custom_template.rs
+++ b/backend/src/handlers/custom_template.rs
@@ -96,6 +96,9 @@ pub async fn fetch_remote_templates(url: &str) -> Result<Vec<RemoteTemplate>, St
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
+        // 禁止重定向以防止 SSRF 绕过：
+        // 攻击者可以提供一个指向公共服务器的 URL，该服务器再重定向到内网地址
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
 

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -147,23 +147,26 @@ pub async fn stop_execution_handler(
         let cancelled = state.task_manager.cancel(task_id).await;
         if !cancelled {
             tracing::warn!(
-                "Task {} was not found in task manager (may have already finished)",
+                "Task {} was not found in task manager (may have already finished), \
+                 fallback to direct DB update",
                 task_id
             );
+            // 任务已不存在（正常结束），回退直接更新数据库
+            let logs_json = record.logs.clone();
+            let _ = state
+                .db
+                .update_execution_record(
+                    req.record_id,
+                    crate::models::ExecutionStatus::Failed.as_str(),
+                    &logs_json,
+                    "任务已被手动停止",
+                    None,
+                    None,
+                )
+                .await;
         }
-        // 更新数据库状态为失败，保留定时刷新已写入的日志
-        let logs_json = record.logs.clone();
-        let _ = state
-            .db
-            .update_execution_record(
-                req.record_id,
-                crate::models::ExecutionStatus::Failed.as_str(),
-                &logs_json,
-                "任务已被手动停止",
-                None,
-                None,
-            )
-            .await;
+        // 取消成功时，由任务内部的 cancel 分支处理 DB 更新，
+        // 避免与 stop handler 同时写入造成竞态条件
         tracing::info!("Successfully stopped execution record {}", req.record_id);
         Ok(ApiResponse::ok(()))
     } else {

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -173,6 +173,16 @@ pub async fn delete_todo(
     State(state): State<AppState>,
     Path(id): Path<i64>,
 ) -> Result<ApiResponse<()>, AppError> {
+    // 先清理调度器任务（如果有）
+    state.scheduler.remove_task_for_todo(id).await;
+
+    // 如果 todo 正在执行，尝试取消
+    if let Ok(Some(todo)) = state.db.get_todo(id).await {
+        if let Some(task_id) = todo.task_id {
+            state.task_manager.cancel(&task_id).await;
+        }
+    }
+
     state.db.delete_todo(id).await.map_err(AppError::from)?;
     Ok(ApiResponse::ok(()))
 }


### PR DESCRIPTION
## 修复代码审查发现的 3 个严重问题

### 1. SSRF 重定向绕过 (custom_template.rs)
禁用 reqwest 默认的自动重定向功能，防止攻击者利用第三方 URL 重定向到内网地址绕过 `is_private_host` 校验。

### 2. 停止执行时日志丢失/状态覆盖 (execution.rs)
`stop_execution_handler` 之前无论是否成功取消任务，都会直接更新执行记录为 Failed。这与任务内的 cancel 分支形成竞态：
- 若 cancel 分支先写入 Success，stop handler 后写入 Failed → 状态被错误覆盖
- 若 stop handler 先写入 Failed 但日志不全 → cancel 分支的完整日志被丢弃

修复：只在任务不存在（cancel 返回 false）时才回退由 stop handler 更新 DB；成功取消时由任务内的 cancel 分支负责 DB 更新。

### 3. 删除正在运行的 todo 未清理调度器/执行 (todo.rs)
`delete_todo` 软删除 todo 前没有：
- 从调度器中移除对应的 cron job → 已删除的 todo 仍会被定时执行
- 取消正在进行的执行进程 → 孤儿进程泄露

修复：在软删除前调用 `remove_task_for_todo` 清理调度器，并检查 `task_id` 取消运行中的执行。

- [x] 编译通过 (`cargo check`)
