### PR TITLE
fix: fix 3 critical issues from code review v2

### DIFF
--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -23,6 +23,9 @@ async fn kill_process_tree(child: &mut command_group::AsyncGroupChild) {
     }
 }
 
+/// 最大执行时长（秒），超过此时间将自动终止进程（执行器被挂起/卡住时释放资源）
+const MAX_EXECUTION_TIMEOUT_SECS: u64 = 1800; // 30 分钟
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ExecutionResult {
     pub task_id: String,
@@ -67,7 +70,29 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
 
     // Get todo to read stored executor
     let todo = match db.get_todo(todo_id).await {
-        Ok(Some(t)) => Some(t),
+        Ok(Some(t)) => {
+            // 检查 todo 是否正在执行中，防止重复执行
+            if t.status == crate::models::TodoStatus::Running {
+                tracing::warn!("Todo {} is already running, skipping execution", todo_id);
+                task_manager.remove(&task_id).await;
+                send_event(
+                    &tx,
+                    ExecEvent::Finished {
+                        task_id: task_id.clone(),
+                        todo_id,
+                        todo_title: t.title.clone(),
+                        executor: "".to_string(),
+                        success: false,
+                        result: Some(format!("Todo {} is already running", todo_id)),
+                    },
+                );
+                return ExecutionResult {
+                    task_id,
+                    record_id: None,
+                };
+            }
+            Some(t)
+        }
         Ok(None) => None,
         Err(e) => {
             tracing::error!(
@@ -591,6 +616,45 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                 let entry = ParsedLogEntry::error("Execution cancelled by user");
                 send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
                 send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: Some("Task was cancelled by user".to_string()) });
+                task_manager_spawn.remove(&task_id).await;
+                return;
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_secs(MAX_EXECUTION_TIMEOUT_SECS)) => {
+                // Timeout: 自动终止执行时间过长的进程，释放资源
+                tracing::warn!(
+                    "Execution timeout reached ({}s) for todo {} (task {}), killing process",
+                    MAX_EXECUTION_TIMEOUT_SECS, todo_id, task_id
+                );
+                kill_process_tree(&mut child).await;
+                flush_timer.abort();
+
+                let _status = child.wait().await;
+
+                if let Some(handle) = stdout_task {
+                    let _ = handle.await;
+                }
+                if let Some(handle) = stderr_task {
+                    let _ = handle.await;
+                }
+
+                for h in flush_handles.lock().await.drain(..) {
+                    let _ = h.await;
+                }
+
+                let logs_json = serde_json::to_string(&*logs.lock().await)
+                    .unwrap_or_else(|e| { tracing::error!("Failed to serialize logs: {}", e); "[]".to_string() });
+                let _ = db_clone.update_execution_record(
+                    record_id,
+                    crate::models::ExecutionStatus::Failed.as_str(),
+                    &logs_json,
+                    "执行超时",
+                    None,
+                    None,
+                ).await;
+
+                let entry = ParsedLogEntry::error("Execution timeout - process was automatically terminated");
+                send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
+                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: Some("Execution timed out after 30 minutes".to_string()) });
                 task_manager_spawn.remove(&task_id).await;
                 return;
             }

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -81,6 +81,14 @@ pub async fn execute_handler(
         .await?
         .ok_or_else(|| AppError::BadRequest(format!("Todo {} not found", req.todo_id)))?;
 
+    // 检查 todo 是否正在执行中，防止重复执行造成状态混乱
+    if todo.status == crate::models::TodoStatus::Running {
+        return Err(AppError::BadRequest(format!(
+            "Todo {} is already running. Please stop the current execution first.",
+            req.todo_id
+        )));
+    }
+
     // Fall back to todo.prompt if message is None or whitespace-only
     let message = req
         .message
@@ -146,24 +154,15 @@ pub async fn stop_execution_handler(
         );
         let cancelled = state.task_manager.cancel(task_id).await;
         if !cancelled {
+            // 任务已在 task_manager 中不存在，说明 spawned task 已完成对自身 task_id 的清理，
+            // 正在执行最终的 update_execution_record。此时不应再写入 DB，避免与 spawned task
+            // 的最终状态更新产生竞态。spawned task 会自行写入正确的结束状态。
             tracing::warn!(
-                "Task {} was not found in task manager (may have already finished), \
-                 fallback to direct DB update",
+                "Task {} was not found in task manager (may have already finished its cleanup), \
+                 skipping DB update to avoid race condition with the task's own final write",
                 task_id
             );
-            // 任务已不存在（正常结束），回退直接更新数据库
-            let logs_json = record.logs.clone();
-            let _ = state
-                .db
-                .update_execution_record(
-                    req.record_id,
-                    crate::models::ExecutionStatus::Failed.as_str(),
-                    &logs_json,
-                    "任务已被手动停止",
-                    None,
-                    None,
-                )
-                .await;
+            return Ok(ApiResponse::ok(()));
         }
         // 取消成功时，由任务内部的 cancel 分支处理 DB 更新，
         // 避免与 stop handler 同时写入造成竞态条件
@@ -265,6 +264,14 @@ pub async fn resume_execution_handler(
         .get_todo(todo_id)
         .await?
         .ok_or(AppError::NotFound)?;
+
+    // 检查 todo 是否正在执行中，防止重复执行造成状态混乱
+    if todo.status == crate::models::TodoStatus::Running {
+        return Err(AppError::BadRequest(format!(
+            "Todo {} is already running. Cannot resume.",
+            todo_id
+        )));
+    }
 
     let message = req
         .message


### PR DESCRIPTION
## 修复 3 个关键代码问题

### Issue 1: 执行器进程没有超时机制
- 添加 `MAX_EXECUTION_TIMEOUT_SECS`（30分钟）作为 `tokio::select!` 的第三个分支
- 超时时自动杀死进程树、释放资源、记录失败

### Issue 2: `stop_execution_handler` 回退写入与 spawned task 竞态
- 当 `cancel()` 返回 false（任务已不在 task_manager 中）时，不再回退写入 DB
- 由 spawned task 自行写入正确的最终状态，避免 success 被 failed 覆盖

### Issue 3: 同一 todo 重复执行
- 在 `execute_handler`、`resume_execution_handler`、`run_todo_execution` 中增加状态检查
- 如果 todo 已处于 Running 状态，拒绝重复执行