### PR TITLE
fix: optimize execution record loading with lazy loading

### DIFF
--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -279,10 +279,10 @@ impl ExecutorRegistry {
     }
 
     /// Register an executor by name and path (convenience method).
-    pub fn register_by_name(&self, name: &str, path: &str) -> bool {
+    pub async fn register_by_name(&self, name: &str, path: &str) -> bool {
         if let Some(executor) = Self::create_executor(name, path) {
             let executor_type = executor.executor_type();
-            self.executors.blocking_write().insert(executor_type, executor);
+            self.executors.write().await.insert(executor_type, executor);
             true
         } else {
             false

--- a/backend/src/handlers/executor_config.rs
+++ b/backend/src/handlers/executor_config.rs
@@ -30,7 +30,7 @@ pub async fn update_executor(
 
     // Update registry based on enabled state
     if ec.enabled {
-        state.executor_registry.register_by_name(&ec.name, &ec.path);
+        state.executor_registry.register_by_name(&ec.name, &ec.path).await;
     } else if let Some(et) = crate::adapters::parse_executor_type(&ec.name) {
         state.executor_registry.unregister(et).await;
     }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -200,7 +200,7 @@ async fn run_server(cli_port: Option<u16>) {
     let executor_registry = Arc::new(adapters::ExecutorRegistry::new());
     let db_executors = db.get_enabled_executors().await.unwrap_or_default();
     for ec in &db_executors {
-        if executor_registry.register_by_name(&ec.name, &ec.path) {
+        if executor_registry.register_by_name(&ec.name, &ec.path).await {
             info!("Registered executor: {} ({})", ec.display_name, ec.name);
         } else {
             tracing::warn!("Unknown executor '{}' in database, skipping", ec.name);

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useApp } from '../hooks/useApp';
 import { Button, Empty, App, Popconfirm, Tag, Badge, Pagination, Segmented, Modal, Input, Tooltip } from 'antd';
-import { PlayCircleOutlined, EditOutlined, DeleteOutlined, SettingOutlined, CheckCircleOutlined, ReloadOutlined, CopyOutlined, ArrowLeftOutlined, StopOutlined, DownOutlined, UpOutlined, UnorderedListOutlined, MessageOutlined, FileTextOutlined, LinkOutlined } from '@ant-design/icons';
+import { PlayCircleOutlined, EditOutlined, DeleteOutlined, SettingOutlined, CheckCircleOutlined, ReloadOutlined, CopyOutlined, ArrowLeftOutlined, StopOutlined, DownOutlined, UpOutlined, UnorderedListOutlined, MessageOutlined, FileTextOutlined, LinkOutlined, LoadingOutlined } from '@ant-design/icons';
 import { StatusPicker } from './StatusPicker';
 import { PieChart } from './PieChart';
 import { TodoSettingsDrawer } from './TodoSettingsDrawer';
@@ -377,9 +377,54 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
   useEffect(() => { void tick; }, [tick]);
 
   const records = selectedTodoId ? executionRecords[selectedTodoId] || [] : [];
-  const selectedHistoryRecord = selectedHistoryRecordId
+
+  // 懒加载：点击记录时才获取完整详情（含 logs）
+  const [selectedHistoryRecordDetail, setSelectedHistoryRecordDetail] = useState<ExecutionRecord | null>(null);
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false);
+
+  // 当选择的记录变化时，懒加载详情
+  useEffect(() => {
+    if (!selectedHistoryRecordId) {
+      setSelectedHistoryRecordDetail(null);
+      return;
+    }
+    // 先从 records 中找到基本记录
+    const basicRecord = records.find(r => r.id === selectedHistoryRecordId);
+
+    // 如果记录已经有 logs 字段且非空，直接使用
+    if (basicRecord?.logs && basicRecord.logs !== '[]') {
+      setSelectedHistoryRecordDetail(basicRecord);
+      setIsLoadingDetail(false);
+      return;
+    }
+
+    // 否则懒加载完整记录（即使 basicRecord 不存在也触发）
+    setIsLoadingDetail(true);
+    db.getExecutionRecord(selectedHistoryRecordId)
+      .then(detail => {
+        setSelectedHistoryRecordDetail(detail);
+        // 更新到全局状态
+        if (selectedTodoId) {
+          dispatch({
+            type: 'UPDATE_EXECUTION_RECORD',
+            payload: { todoId: selectedTodoId, record: detail }
+          });
+        }
+      })
+      .catch(() => {
+        if (basicRecord) {
+          setSelectedHistoryRecordDetail(basicRecord);
+        }
+      })
+      .finally(() => {
+        setIsLoadingDetail(false);
+      });
+  }, [selectedHistoryRecordId, records, selectedTodoId, dispatch]);
+
+  // selectedHistoryRecord 优先使用懒加载的详情，否则用列表中的基本记录
+  const selectedHistoryRecord = selectedHistoryRecordDetail || (selectedHistoryRecordId
     ? records.find(r => r.id === selectedHistoryRecordId) || null
-    : null;
+    : null);
 
   // Find the running task that matches a specific execution record by task_id
   const getRunningTaskForRecord = (record: ExecutionRecord) => {
@@ -404,28 +449,10 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
     try {
       const pageData = await db.getExecutionRecords(selectedTodo.id, page, limit);
 
-      // Fetch complete session chains to avoid splitting sessions across pages
-      const sessionIds = [...new Set(
-        pageData.records
-          .filter(r => r.session_id)
-          .map(r => r.session_id!)
-      )];
-
-      let completeRecords = pageData.records;
-      if (sessionIds.length > 0) {
-        const sessionRecordsArrays = await Promise.all(
-          sessionIds.map(sid => db.getExecutionRecordsBySession(sid))
-        );
-        const sessionRecords = sessionRecordsArrays.flat();
-        // Merge: page records + additional session records not already in page
-        const pageIds = new Set(pageData.records.map(r => r.id));
-        const additional = sessionRecords.filter(r => !pageIds.has(r.id));
-        completeRecords = [...pageData.records, ...additional];
-      }
-
+      // 只加载当前页的记录，不再预加载会话链（会话链在点击查看详情时单独加载）
       dispatch({
         type: 'SET_EXECUTION_RECORDS',
-        payload: { todoId: selectedTodo.id, records: completeRecords }
+        payload: { todoId: selectedTodo.id, records: pageData.records }
       });
       setHistoryPage(pageData.page);
       setHistoryLimit(pageData.limit);
@@ -912,7 +939,12 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
             <div style={{ width: 1, background: 'var(--color-border-light)', flexShrink: 0 }} />
             {/* Right: Record Detail */}
             <div className="history-detail-column">
-              {selectedHistoryRecord ? (() => {
+              {isLoadingDetail ? (
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', gap: 8, color: 'var(--color-text-secondary)' }}>
+                  <LoadingOutlined style={{ fontSize: 20, color: 'var(--color-primary)' }} />
+                  <span>加载执行详情...</span>
+                </div>
+              ) : selectedHistoryRecord ? (() => {
                 const record = selectedHistoryRecord;
                 const isRunning = record.status === 'running';
                 const runningTask = isRunning ? getRunningTaskForRecord(record) : null;


### PR DESCRIPTION
## Summary

- 修复 `register_by_name` 中的 async/await panic 问题（`blocking_write` → `write().await`）
- 为执行记录详情添加懒加载机制（点击时才加载完整数据，不再预加载）
- 移除 session chain 预加载，避免一次性获取所有关联记录导致 13MB+ 响应

## Test plan

- [ ] 验证执行记录列表加载正常
- [ ] 验证点击记录后详情能正确加载
- [ ] 验证结论（result）字段正确显示
- [ ] 验证大量执行记录时页面不卡顿