### PR TITLE
fix: remove logs column from execution_records, migrate to execution_logs table

### DIFF
--- a/backend/src/db/entity/execution_logs.rs
+++ b/backend/src/db/entity/execution_logs.rs
@@ -1,0 +1,35 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "execution_logs")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub record_id: i64,
+    pub timestamp: String,
+    pub log_type: String,
+    #[sea_orm(column_type = "Text")]
+    pub content: String,
+    pub metadata: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::execution_records::Entity",
+        from = "Column::RecordId",
+        to = "super::execution_records::Column::Id",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    ExecutionRecords,
+}
+
+impl Related<super::execution_records::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::ExecutionRecords.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/entity/execution_records.rs
+++ b/backend/src/db/entity/execution_records.rs
@@ -11,7 +11,6 @@ pub struct Model {
     pub command: Option<String>,
     pub stdout: Option<String>,
     pub stderr: Option<String>,
-    pub logs: Option<String>,
     pub result: Option<String>,
     pub usage: Option<String>,
     pub executor: Option<String>,

--- a/backend/src/db/entity/mod.rs
+++ b/backend/src/db/entity/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent_bots;
+pub mod execution_logs;
 pub mod execution_records;
 pub mod executors;
 pub mod feishu_homes;
@@ -15,6 +16,7 @@ pub mod todos;
 
 pub mod prelude {
     pub use super::agent_bots::Entity as AgentBots;
+    pub use super::execution_logs::Entity as ExecutionLogs;
     pub use super::execution_records::Entity as ExecutionRecords;
     pub use super::executors::Entity as Executors;
     pub use super::feishu_homes::Entity as FeishuHomes;

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -3,9 +3,10 @@ use sea_orm::{
     QueryFilter, QueryOrder, QuerySelect, Statement,
 };
 
+use crate::db::entity::execution_logs;
 use crate::db::entity::execution_records;
 use crate::db::Database;
-use crate::models::{ExecutionRecord, ExecutionStatus, ExecutionSummary, ExecutionUsage};
+use crate::models::{ExecutionRecord, ExecutionStatus, ExecutionSummary, ExecutionUsage, ParsedLogEntry};
 
 pub struct NewExecutionRecord<'a> {
     pub todo_id: i64,
@@ -45,7 +46,6 @@ impl From<execution_records::Model> for ExecutionRecord {
             command: m.command.unwrap_or_default(),
             stdout: m.stdout.unwrap_or_default(),
             stderr: m.stderr.unwrap_or_default(),
-            logs: m.logs.unwrap_or_default(),
             result: m.result,
             started_at: m.started_at.unwrap_or_default(),
             finished_at: m.finished_at,
@@ -139,32 +139,21 @@ impl Database {
     /// Update execution record status, but only if it is still "running".
     /// This prevents race conditions where both a stop handler and a spawned task
     /// try to update the same record concurrently -- only the first write succeeds.
+    /// remaining_logs: 内存中尚未刷入 execution_logs 表的剩余日志
     /// Returns Ok(true) if the row was updated, Ok(false) if status was not "running".
     pub async fn update_execution_record(
         &self,
         id: i64,
         status: &str,
-        logs: &str,
+        remaining_logs: &str,
         result: &str,
         usage: Option<&ExecutionUsage>,
         model: Option<&str>,
     ) -> Result<bool, sea_orm::DbErr> {
-        // Merge new logs with existing logs in DB (since periodic flush may have drained in-memory vec)
-        let existing: Option<String> = execution_records::Entity::find_by_id(id)
-            .one(&self.conn)
-            .await?
-            .and_then(|r| r.logs);
-
-        let merged_logs = match existing {
-            Some(ref json) if !json.is_empty() && json != "[]" => {
-                let mut base: Vec<serde_json::Value> =
-                    serde_json::from_str(json).unwrap_or_default();
-                let append: Vec<serde_json::Value> = serde_json::from_str(logs).unwrap_or_default();
-                base.extend(append);
-                serde_json::to_string(&base).unwrap_or_else(|_| logs.to_string())
-            }
-            _ => logs.to_string(),
-        };
+        // 将剩余日志写入 execution_logs 表
+        if !remaining_logs.is_empty() && remaining_logs != "[]" {
+            self.insert_execution_logs(id, remaining_logs).await?;
+        }
 
         let now = crate::models::utc_timestamp();
         let usage_json = usage.map(|u| {
@@ -181,12 +170,11 @@ impl Database {
         let backend = self.conn.get_database_backend();
         let sql = "UPDATE execution_records SET \
             status = $1, \
-            logs = $2, \
-            result = $3, \
-            usage = $4, \
-            model = $5, \
-            finished_at = $6 \
-            WHERE id = $7 AND status = 'running'";
+            result = $2, \
+            usage = $3, \
+            model = $4, \
+            finished_at = $5 \
+            WHERE id = $6 AND status = 'running'";
 
         let res = self
             .conn
@@ -195,7 +183,6 @@ impl Database {
                 sql,
                 [
                     status.into(),
-                    merged_logs.into(),
                     result.into(),
                     usage_json.into(),
                     model_val.into(),
@@ -263,49 +250,128 @@ impl Database {
         self.exec_update(am).await
     }
 
-    /// 追加日志条目到执行记录（读取已有日志 + 合并新条目 + 写回，防止覆盖）
+    /// 追加日志条目到执行记录（直接写入 execution_logs 表，支持分页加载）
     pub async fn append_execution_record_logs(
         &self,
         id: i64,
         new_logs_json: &str,
     ) -> Result<(), sea_orm::DbErr> {
-        let existing: Option<String> = execution_records::Entity::find_by_id(id)
-            .one(&self.conn)
-            .await?
-            .and_then(|r| r.logs);
+        if new_logs_json.is_empty() || new_logs_json == "[]" {
+            return Ok(());
+        }
+        self.insert_execution_logs(id, new_logs_json).await
+    }
 
-        let merged = match existing {
-            Some(ref json) if !json.is_empty() && json != "[]" => {
-                let mut base: Vec<serde_json::Value> = match serde_json::from_str(json) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        tracing::warn!(
-                            "Failed to parse existing logs JSON for record {}: {}",
-                            id,
-                            e
-                        );
-                        Vec::new()
-                    }
-                };
-                let append: Vec<serde_json::Value> = match serde_json::from_str(new_logs_json) {
-                    Ok(a) => a,
-                    Err(e) => {
-                        tracing::warn!("Failed to parse new logs JSON for record {}: {}", id, e);
-                        Vec::new()
-                    }
-                };
-                base.extend(append);
-                serde_json::to_string(&base).unwrap_or_else(|_| new_logs_json.to_string())
+    /// 将 JSON 格式的日志条目批量插入 execution_logs 表
+    pub async fn insert_execution_logs(
+        &self,
+        record_id: i64,
+        logs_json: &str,
+    ) -> Result<(), sea_orm::DbErr> {
+        let entries: Vec<ParsedLogEntry> = match serde_json::from_str(logs_json) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("Failed to parse logs JSON for record {}: {}", record_id, e);
+                return Ok(());
             }
-            _ => new_logs_json.to_string(),
         };
+        if entries.is_empty() {
+            return Ok(());
+        }
 
-        let am = execution_records::ActiveModel {
-            id: ActiveValue::Unchanged(id),
-            logs: ActiveValue::Set(Some(merged)),
-            ..Default::default()
-        };
-        self.exec_update(am).await
+        let models: Vec<execution_logs::ActiveModel> = entries
+            .into_iter()
+            .map(|e| {
+                let metadata = serde_json::json!({
+                    "usage": e.usage,
+                    "tool_name": e.tool_name,
+                    "tool_input_json": e.tool_input_json,
+                });
+                let metadata_str = serde_json::to_string(&metadata).unwrap_or_default();
+                execution_logs::ActiveModel {
+                    record_id: ActiveValue::Set(record_id),
+                    timestamp: ActiveValue::Set(e.timestamp),
+                    log_type: ActiveValue::Set(e.log_type),
+                    content: ActiveValue::Set(e.content),
+                    metadata: ActiveValue::Set(Some(metadata_str)),
+                    ..Default::default()
+                }
+            })
+            .collect();
+
+        execution_logs::Entity::insert_many(models)
+            .exec(&self.conn)
+            .await?;
+        Ok(())
+    }
+
+    /// 分页获取执行日志
+    pub async fn get_execution_logs(
+        &self,
+        record_id: i64,
+        page: i64,
+        per_page: i64,
+    ) -> Result<(Vec<ParsedLogEntry>, i64), sea_orm::DbErr> {
+        let total: i64 = execution_logs::Entity::find()
+            .filter(execution_logs::Column::RecordId.eq(record_id))
+            .count(&self.conn)
+            .await? as i64;
+
+        if total == 0 {
+            return Ok((Vec::new(), 0));
+        }
+
+        let offset = ((page - 1) * per_page).max(0) as u64;
+        let entries = execution_logs::Entity::find()
+            .filter(execution_logs::Column::RecordId.eq(record_id))
+            .order_by_asc(execution_logs::Column::Id)
+            .limit(per_page as u64)
+            .offset(offset)
+            .all(&self.conn)
+            .await?;
+
+        let logs: Vec<ParsedLogEntry> = entries
+            .into_iter()
+            .map(|m| {
+                let (usage, tool_name, tool_input_json) = m
+                    .metadata
+                    .as_deref()
+                    .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+                    .map(|v| {
+                        (
+                            v.get("usage")
+                                .and_then(|u| serde_json::from_value(u.clone()).ok()),
+                            v.get("tool_name")
+                                .and_then(|n| n.as_str().map(String::from)),
+                            v.get("tool_input_json")
+                                .and_then(|t| t.as_str().map(String::from)),
+                        )
+                    })
+                    .unwrap_or((None, None, None));
+
+                ParsedLogEntry {
+                    timestamp: m.timestamp,
+                    log_type: m.log_type,
+                    content: m.content,
+                    usage,
+                    tool_name,
+                    tool_input_json,
+                }
+            })
+            .collect();
+
+        Ok((logs, total))
+    }
+
+    /// 获取所有执行日志（用于 WebSocket 同步等场景，请谨慎使用）
+    pub async fn get_all_execution_logs(
+        &self,
+        record_id: i64,
+    ) -> Result<Vec<ParsedLogEntry>, sea_orm::DbErr> {
+        let (logs, _) = self
+            .get_execution_logs(record_id, 1, i64::MAX)
+            .await?;
+        Ok(logs)
     }
 
     /// 根据 session_id 获取所有执行记录（按 started_at 排序）
@@ -806,7 +872,6 @@ impl Database {
                     command: None,
                     stdout: None,
                     stderr: None,
-                    logs: None,
                     model: None,
                     pid: None,
                     todo_progress: None,

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -150,11 +150,6 @@ impl Database {
         usage: Option<&ExecutionUsage>,
         model: Option<&str>,
     ) -> Result<bool, sea_orm::DbErr> {
-        // 将剩余日志写入 execution_logs 表
-        if !remaining_logs.is_empty() && remaining_logs != "[]" {
-            self.insert_execution_logs(id, remaining_logs).await?;
-        }
-
         let now = crate::models::utc_timestamp();
         let usage_json = usage.map(|u| {
             serde_json::to_string(u).unwrap_or_else(|e| {
@@ -191,7 +186,14 @@ impl Database {
                 ],
             ))
             .await?;
-        Ok(res.rows_affected() > 0)
+        let updated = res.rows_affected() > 0;
+
+        // Only insert logs if the status update succeeded (prevent duplicate logs on concurrent writes)
+        if updated && !remaining_logs.is_empty() && remaining_logs != "[]" {
+            self.insert_execution_logs(id, remaining_logs).await?;
+        }
+
+        Ok(updated)
     }
 
     /// 更新执行记录的 pid
@@ -268,13 +270,11 @@ impl Database {
         record_id: i64,
         logs_json: &str,
     ) -> Result<(), sea_orm::DbErr> {
-        let entries: Vec<ParsedLogEntry> = match serde_json::from_str(logs_json) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!("Failed to parse logs JSON for record {}: {}", record_id, e);
-                return Ok(());
-            }
-        };
+        let entries: Vec<ParsedLogEntry> = serde_json::from_str(logs_json)
+            .map_err(|e| sea_orm::DbErr::Custom(format!(
+                "Failed to parse logs JSON for record {}: {}",
+                record_id, e
+            )))?;
         if entries.is_empty() {
             return Ok(());
         }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -101,16 +101,27 @@ impl Database {
             .await?;
 
         let mut migrated = 0u64;
+        let mut failed = 0u64;
         for row in rows {
             let id: i64 = row.try_get_by("id")?;
             let logs_json: String = row.try_get_by("logs")?;
             if !logs_json.is_empty() && logs_json != "[]" {
                 if let Err(e) = self.insert_execution_logs(id, &logs_json).await {
                     tracing::warn!("Failed to migrate logs for record {}: {}", id, e);
+                    failed += 1;
                 } else {
                     migrated += 1;
                 }
             }
+        }
+
+        // 有任意记录迁移失败则不删除旧列，保留数据等待下次重试
+        if failed > 0 {
+            tracing::warn!(
+                "Logs migration incomplete: {} succeeded, {} failed. Keeping old logs column for retry.",
+                migrated, failed
+            );
+            return Ok(());
         }
 
         // 删除旧列

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -74,6 +74,54 @@ impl Database {
         model.update(&self.conn).await.map(|_| ())
     }
 
+    /// 迁移：将 execution_records.logs 旧字段数据迁移到 execution_logs 表，并删除旧字段
+    async fn migrate_logs_to_execution_logs(&self) -> Result<(), sea_orm::DbErr> {
+        // 检查 logs 列是否存在
+        let check_sql = "SELECT COUNT(*) FROM pragma_table_info('execution_records') WHERE name='logs'";
+        let result = self
+            .conn
+            .query_one(Statement::from_string(DbBackend::Sqlite, check_sql.to_string()))
+            .await?;
+        let col_exists = result
+            .and_then(|r| r.try_get_by_index::<i64>(0).ok())
+            .unwrap_or(0) > 0;
+        if !col_exists {
+            return Ok(());
+        }
+
+        tracing::info!("Migrating old logs column to execution_logs table...");
+
+        // 迁移未迁移的记录（execution_logs 表中没有数据的记录）
+        let select_sql = "SELECT id, logs FROM execution_records \
+            WHERE logs IS NOT NULL AND logs != '' AND logs != '[]' \
+            AND id NOT IN (SELECT DISTINCT record_id FROM execution_logs)";
+        let rows = self
+            .conn
+            .query_all(Statement::from_string(DbBackend::Sqlite, select_sql.to_string()))
+            .await?;
+
+        let mut migrated = 0u64;
+        for row in rows {
+            let id: i64 = row.try_get_by("id")?;
+            let logs_json: String = row.try_get_by("logs")?;
+            if !logs_json.is_empty() && logs_json != "[]" {
+                if let Err(e) = self.insert_execution_logs(id, &logs_json).await {
+                    tracing::warn!("Failed to migrate logs for record {}: {}", id, e);
+                } else {
+                    migrated += 1;
+                }
+            }
+        }
+
+        // 删除旧列
+        self.exec("ALTER TABLE execution_records DROP COLUMN logs").await?;
+        tracing::info!(
+            "Migrated {} execution records, dropped logs column",
+            migrated
+        );
+        Ok(())
+    }
+
     async fn init_tables(&self) -> Result<(), sea_orm::DbErr> {
         self.exec(
             "CREATE TABLE IF NOT EXISTS todos (
@@ -122,7 +170,6 @@ impl Database {
                 command TEXT,
                 stdout TEXT DEFAULT '',
                 stderr TEXT DEFAULT '',
-                logs TEXT DEFAULT '[]',
                 result TEXT,
                 usage TEXT,
                 executor TEXT,
@@ -137,6 +184,22 @@ impl Database {
             )",
         )
         .await?;
+
+        // 执行日志表（每条日志一行，支持分页加载）
+        self.exec(
+            "CREATE TABLE IF NOT EXISTS execution_logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                record_id INTEGER NOT NULL,
+                timestamp TEXT NOT NULL,
+                log_type TEXT NOT NULL DEFAULT 'info',
+                content TEXT NOT NULL DEFAULT '',
+                metadata TEXT DEFAULT '{}',
+                FOREIGN KEY (record_id) REFERENCES execution_records(id) ON DELETE CASCADE
+            )",
+        )
+        .await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_execution_logs_record ON execution_logs(record_id)")
+            .await?;
 
         // 添加 pid 字段的迁移（向后兼容）
         self.exec("ALTER TABLE execution_records ADD COLUMN pid INTEGER")
@@ -177,6 +240,10 @@ impl Database {
         self.exec("ALTER TABLE execution_records ADD COLUMN resume_message TEXT")
             .await
             .ok(); // 忽略错误，因为字段可能已存在
+
+        // 迁移：将 execution_records.logs 旧字段数据转移到 execution_logs 表，并删除旧字段
+        self.migrate_logs_to_execution_logs().await
+            .unwrap_or_else(|e| tracing::error!("Failed to migrate logs column: {}", e));
 
         // Skill invocations tracking table
         self.exec(
@@ -1100,7 +1167,7 @@ mod tests {
         db.update_execution_record(
             record_id,
             "success",
-            "[{\"type\":\"info\"}]",
+            "[{\"timestamp\":\"2026-01-01T00:00:00.000Z\",\"type\":\"info\",\"content\":\"test log\"}]",
             "done",
             Some(&usage),
             Some("claude-3"),
@@ -1110,13 +1177,18 @@ mod tests {
         let (records, _) = db.get_execution_records(todo_id, 100, 0).await.unwrap();
         let record = records.iter().find(|r| r.id == record_id).unwrap();
         assert_eq!(record.status, crate::models::ExecutionStatus::Success);
-        assert_eq!(record.logs, "[{\"type\":\"info\"}]");
         assert_eq!(record.result, Some("done".to_string()));
         assert_eq!(record.model, Some("claude-3".to_string()));
         assert!(record.finished_at.is_some());
         let record_usage = record.usage.as_ref().unwrap();
         assert_eq!(record_usage.input_tokens, 100);
         assert_eq!(record_usage.output_tokens, 50);
+
+        // 验证日志已写入 execution_logs 表
+        let (logs, total) = db.get_execution_logs(record_id, 1, 10).await.unwrap();
+        assert_eq!(total, 1);
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].log_type, "info");
     }
 
     #[tokio::test]

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -243,7 +243,7 @@ impl Database {
 
         // 迁移：将 execution_records.logs 旧字段数据转移到 execution_logs 表，并删除旧字段
         self.migrate_logs_to_execution_logs().await
-            .unwrap_or_else(|e| tracing::error!("Failed to migrate logs column: {}", e));
+            .unwrap_or_else(|e| tracing::warn!("Failed to migrate logs column: {}", e));
 
         // Skill invocations tracking table
         self.exec(

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -668,6 +668,8 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                     let _ = handle.await;
                 }
 
+                // Graceful shutdown: wait for timer to finish its final flush cycle
+                let _ = flush_timer.await;
                 // 等待所有进行中的 flush 任务完成，防止旧快照覆盖
                 for h in flush_handles.lock().await.drain(..) {
                     let _ = h.await;
@@ -771,6 +773,8 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
             }
         }
 
+        // Graceful shutdown: wait for timer to finish its final flush cycle
+        let _ = flush_timer.await;
         // 等待所有进行中的 flush 任务完成，防止旧快照覆盖最终写入
         for h in flush_handles.lock().await.drain(..) {
             let _ = h.await;

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -776,30 +776,18 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
             let _ = h.await;
         }
 
-        // 从数据库读取完整的日志集（因为定期 flush 会 drain 内存中的 vec）
+        // 从 execution_logs 表读取已刷入的日志，与内存中剩余的日志合并形成完整快照
         let remaining = std::mem::take(&mut *logs_for_result.lock().await);
-        let all_logs_snapshot = match db_clone.get_execution_record(record_id).await {
-            Ok(Some(record)) if !record.logs.is_empty() && record.logs != "[]" => {
-                let mut base: Vec<ParsedLogEntry> = match serde_json::from_str(&record.logs) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        tracing::warn!(
-                            "Failed to parse execution logs JSON, record_id={}: {}",
-                            record_id,
-                            e
-                        );
-                        Vec::new()
-                    }
-                };
-                base.extend(remaining);
-                base
-            }
-            Ok(_) => remaining,
-            Err(e) => {
-                tracing::error!("Failed to fetch execution record {}: {}", record_id, e);
-                remaining
-            }
-        };
+        let remaining_json = serde_json::to_string(&remaining).unwrap_or_else(|e| {
+            tracing::error!("Failed to serialize remaining logs: {}", e);
+            "[]".to_string()
+        });
+        let flushed_logs = db_clone
+            .get_all_execution_logs(record_id)
+            .await
+            .unwrap_or_default();
+        let mut all_logs_snapshot = flushed_logs;
+        all_logs_snapshot.extend(remaining);
         let result_str = executor_spawn
             .get_final_result(&all_logs_snapshot)
             .unwrap_or_default();
@@ -837,10 +825,6 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
         } else {
             crate::models::ExecutionStatus::Failed.as_str()
         };
-        let logs_json = serde_json::to_string(&all_logs_snapshot).unwrap_or_else(|e| {
-            tracing::error!("Failed to serialize logs: {}", e);
-            "[]".to_string()
-        });
         let mut usage = executor_spawn.get_usage(&all_logs_snapshot);
         let model = executor_spawn.get_model();
 
@@ -868,7 +852,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
             .update_execution_record(
                 record_id,
                 final_status,
-                &logs_json,
+                &remaining_json,
                 &result_str,
                 usage.as_ref(),
                 model.as_deref(),

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -7,8 +7,8 @@ use crate::executor_service::{
 };
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::{
-    ApiResponse, DashboardStats, ExecuteRequest, ExecutionRecordsPage, ExecutionStatus,
-    ExecutionSummary, TodoIdQuery,
+    ApiResponse, DashboardStats, ExecuteRequest, ExecutionLogsPage, ExecutionRecordsPage,
+    ExecutionStatus, ExecutionSummary, TodoIdQuery,
 };
 
 /// 统一启动一条 Todo 执行，供手动执行、消息路由等入口复用。
@@ -57,6 +57,36 @@ pub async fn get_execution_record(
         .await?
         .ok_or(AppError::NotFound)?;
     Ok(ApiResponse::ok(record))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ExecutionLogsQuery {
+    #[serde(default = "default_page")]
+    pub page: i64,
+    #[serde(default = "default_per_page")]
+    pub per_page: i64,
+}
+
+fn default_page() -> i64 { 1 }
+fn default_per_page() -> i64 { 200 }
+
+pub async fn get_execution_logs_handler(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Query(query): Query<ExecutionLogsQuery>,
+) -> Result<ApiResponse<ExecutionLogsPage>, AppError> {
+    let page = query.page.max(1);
+    let per_page = query.per_page.clamp(10, 1000);
+    let (logs, total) = state
+        .db
+        .get_execution_logs(id, page, per_page)
+        .await?;
+    Ok(ApiResponse::ok(ExecutionLogsPage {
+        logs,
+        total,
+        page,
+        per_page,
+    }))
 }
 
 pub async fn get_execution_records_by_session(

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -165,9 +165,12 @@ pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade)
         // 每个任务需要从数据库获取最新的日志
         let mut running_tasks = state.task_manager.get_all_task_infos().await;
         for task in &mut running_tasks {
-            // 从数据库获取该任务的执行记录日志
+            // 从 execution_logs 表获取该任务的执行记录日志
             match state.db.get_execution_record_by_task_id(&task.task_id).await {
-                Ok(Some(record)) => task.logs = record.logs,
+                Ok(Some(record)) => {
+                    let logs = state.db.get_all_execution_logs(record.id).await.unwrap_or_default();
+                    task.logs = serde_json::to_string(&logs).unwrap_or_default();
+                }
                 Ok(None) => {}
                 Err(e) => tracing::debug!("No execution record found for task_id {}: {}", task.task_id, e),
             }
@@ -393,6 +396,7 @@ pub fn create_app(
         .route("/xyz/execution-records", get(execution::get_execution_records))
         .route("/xyz/execution-records/running", get(execution::get_running_execution_records_handler))
         .route("/xyz/execution-records/session/{session_id}", get(execution::get_execution_records_by_session))
+        .route("/xyz/execution-records/{id}/logs", get(execution::get_execution_logs_handler))
         .route("/xyz/execution-records/{id}", get(execution::get_execution_record))
         .route("/xyz/execution-records/{id}/resume", post(execution::resume_execution_handler))
         .route("/xyz/dashboard-stats", get(execution::get_dashboard_stats))

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -167,7 +167,6 @@ pub struct ExecutionRecord {
     pub command: String,
     pub stdout: String,
     pub stderr: String,
-    pub logs: String,
     pub result: Option<String>,
     pub started_at: String,
     pub finished_at: Option<String>,
@@ -340,6 +339,14 @@ pub struct ExecutionRecordsPage {
     pub total: i64,
     pub page: i64,
     pub limit: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionLogsPage {
+    pub logs: Vec<ParsedLogEntry>,
+    pub total: i64,
+    pub page: i64,
+    pub per_page: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 import { useApp } from '../hooks/useApp';
 import { Button, Empty, App, Popconfirm, Tag, Badge, Pagination, Segmented, Modal, Input, Tooltip } from 'antd';
 import { PlayCircleOutlined, EditOutlined, DeleteOutlined, SettingOutlined, CheckCircleOutlined, ReloadOutlined, CopyOutlined, ArrowLeftOutlined, StopOutlined, DownOutlined, UpOutlined, UnorderedListOutlined, MessageOutlined, FileTextOutlined, LinkOutlined, LoadingOutlined } from '@ant-design/icons';
@@ -388,24 +388,27 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
   const [logsPage, setLogsPage] = useState(1);
   const [logsPerPage] = useState(200);
   const [isLoadingLogs, setIsLoadingLogs] = useState(false);
+  const activeRecordIdRef = useRef<number | null>(null);
 
   // 加载分页日志
   const loadLogs = async (recordId: number, page: number) => {
     setIsLoadingLogs(true);
     try {
       const result = await db.getExecutionLogs(recordId, page, logsPerPage);
+      if (activeRecordIdRef.current !== recordId) return;
       setPaginatedLogs(result.logs);
       setLogsTotal(result.total);
       setLogsPage(result.page);
     } catch {
-      setPaginatedLogs([]);
+      if (activeRecordIdRef.current === recordId) setPaginatedLogs([]);
     } finally {
-      setIsLoadingLogs(false);
+      if (activeRecordIdRef.current === recordId) setIsLoadingLogs(false);
     }
   };
 
   // 当选择的记录变化时，懒加载详情
   useEffect(() => {
+    activeRecordIdRef.current = selectedHistoryRecordId;
     if (!selectedHistoryRecordId) {
       setSelectedHistoryRecordDetail(null);
       setPaginatedLogs([]);
@@ -413,13 +416,15 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
       setLogsPage(1);
       return;
     }
+    const requestId = selectedHistoryRecordId;
     // 先从 records 中找到基本记录
-    const basicRecord = records.find(r => r.id === selectedHistoryRecordId);
+    const basicRecord = records.find(r => r.id === requestId);
 
     // 懒加载完整记录（即使 basicRecord 不存在也触发）
     setIsLoadingDetail(true);
-    db.getExecutionRecord(selectedHistoryRecordId)
+    db.getExecutionRecord(requestId)
       .then(detail => {
+        if (activeRecordIdRef.current !== requestId) return;
         setSelectedHistoryRecordDetail(detail);
         if (selectedTodoId) {
           dispatch({
@@ -429,16 +434,17 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
         }
       })
       .catch(() => {
+        if (activeRecordIdRef.current !== requestId) return;
         if (basicRecord) {
           setSelectedHistoryRecordDetail(basicRecord);
         }
       })
       .finally(() => {
-        setIsLoadingDetail(false);
+        if (activeRecordIdRef.current === requestId) setIsLoadingDetail(false);
       });
 
     // 同时加载第一页日志
-    loadLogs(selectedHistoryRecordId, 1);
+    loadLogs(requestId, 1);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedHistoryRecordId]);
 
@@ -1417,6 +1423,54 @@ function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, o
 }
 
 /** Narrow mode: chain group card — main record with indented continuations */
+/** Lazy-load logs for a continuation record in ChainGroupCard */
+function ContinuationLogsLoader({ record, viewMode, onRefresh }: {
+  record: ExecutionRecord;
+  viewMode: 'log' | 'chat';
+  onRefresh: (id: number) => Promise<void>;
+}) {
+  const [logs, setLogs] = useState<LogEntry[] | null>(null);
+  useEffect(() => {
+    db.getExecutionLogs(record.id, 1, 200)
+      .then(r => setLogs(r.logs))
+      .catch(() => setLogs([]));
+  }, [record.id]);
+  if (logs === null) return null;
+  if (logs.length === 0) return null;
+  if (viewMode === 'chat') {
+    return (
+      <div style={{ marginTop: 6 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+          <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>对话 ({logs.length})</span>
+          <ReloadOutlined style={{ fontSize: 10, cursor: 'pointer' }} onClick={(e) => { e.stopPropagation(); onRefresh(record.id); }} />
+        </div>
+        <div style={{ maxHeight: 300, overflow: 'auto' }}>
+          <ChatView logs={logs as LogEntry[]} isRunning={false} />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <details style={{ marginTop: 6 }} open>
+      <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 10, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6 }}>
+        <span>日志 ({logs.length})</span>
+        <ReloadOutlined style={{ fontSize: 9 }} onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
+      </summary>
+      <div style={{
+        background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
+        fontFamily: 'var(--font-mono)', fontSize: 10, marginTop: 4, maxHeight: 200, overflow: 'auto',
+      }}>
+        {logs.map((log, i) => (
+          <div key={i} style={{ marginBottom: 3, display: 'flex', gap: 6 }}>
+            <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
+            <span>{log.content}</span>
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+}
+
 function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, viewMode, parseLogs, onRefresh, resolveStats }: {
   group: SessionGroup;
   onOpenResume: (r: ExecutionRecord) => void;
@@ -1622,7 +1676,9 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                 {(() => {
                   const logs = parseLogs(record);
                   const isRunning = record.status === 'running';
-                  if (!isRunning && logs.length === 0) return null;
+                  if (!isRunning && logs.length === 0) {
+                    return <ContinuationLogsLoader record={record} viewMode={viewMode} onRefresh={onRefresh} />;
+                  }
                   if (viewMode === 'chat') {
                     return (
                       <div style={{ marginTop: 6 }}>

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -322,12 +322,6 @@ function CompactHistoryItem({ record, onOpenResume, onExport }: {
 }
 
 function hasLogsStatic(record: ExecutionRecord): boolean {
-  // 新记录：有 execution_stats 表示有日志
-  if (record.execution_stats) {
-    const s = record.execution_stats;
-    if (s.tool_calls > 0 || s.conversation_turns > 0 || s.thinking_count > 0) return true;
-  }
-  // 已完成的记录通常有日志
   return record.status !== 'running' && !!record.finished_at;
 }
 

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -322,7 +322,13 @@ function CompactHistoryItem({ record, onOpenResume, onExport }: {
 }
 
 function hasLogsStatic(record: ExecutionRecord): boolean {
-  return !!record.logs && record.logs !== '[]';
+  // 新记录：有 execution_stats 表示有日志
+  if (record.execution_stats) {
+    const s = record.execution_stats;
+    if (s.tool_calls > 0 || s.conversation_turns > 0 || s.thinking_count > 0) return true;
+  }
+  // 已完成的记录通常有日志
+  return record.status !== 'running' && !!record.finished_at;
 }
 
 /** 任务详情面板，包含执行、编辑、历史记录等功能 */
@@ -378,32 +384,49 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
 
   const records = selectedTodoId ? executionRecords[selectedTodoId] || [] : [];
 
-  // 懒加载：点击记录时才获取完整详情（含 logs）
+  // 懒加载：点击记录时才获取完整详情（含分页 logs）
   const [selectedHistoryRecordDetail, setSelectedHistoryRecordDetail] = useState<ExecutionRecord | null>(null);
   const [isLoadingDetail, setIsLoadingDetail] = useState(false);
+
+  // 分页日志状态
+  const [paginatedLogs, setPaginatedLogs] = useState<LogEntry[]>([]);
+  const [logsTotal, setLogsTotal] = useState(0);
+  const [logsPage, setLogsPage] = useState(1);
+  const [logsPerPage] = useState(200);
+  const [isLoadingLogs, setIsLoadingLogs] = useState(false);
+
+  // 加载分页日志
+  const loadLogs = async (recordId: number, page: number) => {
+    setIsLoadingLogs(true);
+    try {
+      const result = await db.getExecutionLogs(recordId, page, logsPerPage);
+      setPaginatedLogs(result.logs);
+      setLogsTotal(result.total);
+      setLogsPage(result.page);
+    } catch {
+      setPaginatedLogs([]);
+    } finally {
+      setIsLoadingLogs(false);
+    }
+  };
 
   // 当选择的记录变化时，懒加载详情
   useEffect(() => {
     if (!selectedHistoryRecordId) {
       setSelectedHistoryRecordDetail(null);
+      setPaginatedLogs([]);
+      setLogsTotal(0);
+      setLogsPage(1);
       return;
     }
     // 先从 records 中找到基本记录
     const basicRecord = records.find(r => r.id === selectedHistoryRecordId);
 
-    // 如果记录已经有 logs 字段且非空，直接使用
-    if (basicRecord?.logs && basicRecord.logs !== '[]') {
-      setSelectedHistoryRecordDetail(basicRecord);
-      setIsLoadingDetail(false);
-      return;
-    }
-
-    // 否则懒加载完整记录（即使 basicRecord 不存在也触发）
+    // 懒加载完整记录（即使 basicRecord 不存在也触发）
     setIsLoadingDetail(true);
     db.getExecutionRecord(selectedHistoryRecordId)
       .then(detail => {
         setSelectedHistoryRecordDetail(detail);
-        // 更新到全局状态
         if (selectedTodoId) {
           dispatch({
             type: 'UPDATE_EXECUTION_RECORD',
@@ -419,7 +442,11 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
       .finally(() => {
         setIsLoadingDetail(false);
       });
-  }, [selectedHistoryRecordId, records, selectedTodoId, dispatch]);
+
+    // 同时加载第一页日志
+    loadLogs(selectedHistoryRecordId, 1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedHistoryRecordId]);
 
   // selectedHistoryRecord 优先使用懒加载的详情，否则用列表中的基本记录
   const selectedHistoryRecord = selectedHistoryRecordDetail || (selectedHistoryRecordId
@@ -564,20 +591,20 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
     }
   };
 
-  const parseRecordLogs = (record: ExecutionRecord): LogEntry[] => {
+  const parseRecordLogs = (_record: ExecutionRecord): LogEntry[] => {
+    return [];
+  };
+
+  const hasLogs = (record: ExecutionRecord): boolean => hasLogsStatic(record);
+
+  const handleExportMarkdown = async (record: ExecutionRecord) => {
+    let logs: LogEntry[] = [];
     try {
-      return record.logs && record.logs !== '[]' ? JSON.parse(record.logs) : [];
+      const result = await db.getExecutionLogs(record.id, 1, 100000);
+      logs = result.logs;
     } catch {
-      return [];
+      // ignore
     }
-  };
-
-  const hasLogs = (record: ExecutionRecord): boolean => {
-    return !!record.logs && record.logs !== '[]';
-  };
-
-  const handleExportMarkdown = (record: ExecutionRecord) => {
-    const logs = parseRecordLogs(record);
     const messages = parseLogsToMessages(logs);
     const executorLabel = record.executor ? getExecutorOption(record.executor).label : undefined;
     const content = conversationToYaml(messages, {
@@ -949,8 +976,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                 const isRunning = record.status === 'running';
                 const runningTask = isRunning ? getRunningTaskForRecord(record) : null;
                 const liveLogs = runningTask ? runningTask.logs : null;
-                const restLogs = parseRecordLogs(record);
-                const displayLogs = liveLogs && liveLogs.length > 0 ? liveLogs : restLogs;
+                const displayLogs = liveLogs && liveLogs.length > 0 ? liveLogs : paginatedLogs;
                 return (
                   <>
                     {/* Chain breadcrumb — when viewing a continuation record */}
@@ -1110,11 +1136,14 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                         <div>
                           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
                             <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-primary)' }}>
-                              执行过程 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}
+                              执行过程 ({isRunning ? displayLogs.length : logsTotal} 条{isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''})
                             </span>
                             <ReloadOutlined
                               style={{ fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer' }}
-                              onClick={() => refreshSingleRecord(record.id)}
+                              onClick={() => {
+                                refreshSingleRecord(record.id);
+                                loadLogs(record.id, logsPage);
+                              }}
                             />
                           </div>
                           <div style={{
@@ -1127,7 +1156,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                             overflow: 'auto',
                           }}>
                             {displayLogs.length === 0 ? (
-                              <div style={{ color: 'var(--log-text-muted)' }}>等待输出...</div>
+                              <div style={{ color: 'var(--log-text-muted)' }}>{isRunning ? '等待输出...' : (isLoadingLogs ? '加载中...' : '暂无日志')}</div>
                             ) : (
                               displayLogs.map((log, idx) => (
                                 <div key={idx} style={{ marginBottom: 4, display: 'flex', gap: 8 }}>
@@ -1140,6 +1169,17 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                               ))
                             )}
                           </div>
+                          {!isRunning && logsTotal > logsPerPage && (
+                            <Pagination
+                              simple
+                              current={logsPage}
+                              pageSize={logsPerPage}
+                              total={logsTotal}
+                              onChange={(page) => loadLogs(record.id, page)}
+                              size="small"
+                              style={{ marginTop: 8, textAlign: 'center' }}
+                            />
+                          )}
                         </div>
                       );
                     })()}
@@ -1276,7 +1316,19 @@ function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, o
   const runningTask = isRunning ? getRunningTask(record) : null;
   const liveLogs = runningTask ? runningTask.logs : null;
   const restLogs = parseLogs(record);
-  const displayLogs = liveLogs && liveLogs.length > 0 ? liveLogs : restLogs;
+
+  // 懒加载日志（新记录没有旧字段数据时从新表加载）
+  const [loadedLogs, setLoadedLogs] = useState<LogEntry[] | null>(null);
+  useEffect(() => {
+    if (restLogs.length > 0 || isRunning || loadedLogs !== null) return;
+    db.getExecutionLogs(record.id, 1, 200)
+      .then(r => setLoadedLogs(r.logs))
+      .catch(() => setLoadedLogs([]));
+  }, [record.id, restLogs.length, isRunning, loadedLogs]);
+
+  const displayLogs = liveLogs && liveLogs.length > 0 ? liveLogs :
+    restLogs.length > 0 ? restLogs :
+    loadedLogs || [];
 
   return (
     <div className={`history-card history-card-${record.status}`}>
@@ -1386,6 +1438,17 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
   const mainRecord = group.records[0];
   const continuations = group.records.slice(1);
 
+  // 懒加载主记录日志
+  const mainRestLogs = parseLogs(mainRecord);
+  const [mainLoadedLogs, setMainLoadedLogs] = useState<LogEntry[] | null>(null);
+  useEffect(() => {
+    if (mainRestLogs.length > 0 || mainRecord.status === 'running' || mainLoadedLogs !== null) return;
+    db.getExecutionLogs(mainRecord.id, 1, 200)
+      .then(r => setMainLoadedLogs(r.logs))
+      .catch(() => setMainLoadedLogs([]));
+  }, [mainRecord.id, mainRestLogs.length, mainRecord.status, mainLoadedLogs]);
+  const mainDisplayLogs = mainRestLogs.length > 0 ? mainRestLogs : mainLoadedLogs || [];
+
   return (
     <div>
       {/* Main record card */}
@@ -1466,7 +1529,7 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
             </div>
           );
         })()}
-        {renderNarrowLogs(mainRecord, mainRecord.status === 'running', parseLogs(mainRecord), null, viewMode, onRefresh)}
+        {renderNarrowLogs(mainRecord, mainRecord.status === 'running', mainDisplayLogs, null, viewMode, onRefresh)}
       </div>
 
       {/* Indented continuation entries */}

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -82,7 +82,6 @@ export interface ExecutionRecord {
   command: string;
   stdout: string;
   stderr: string;
-  logs: string;
   result: string | null;
   started_at: string;
   finished_at: string | null;
@@ -231,6 +230,13 @@ export interface ExecutionRecordsPage {
   total: number;
   page: number;
   limit: number;
+}
+
+export interface ExecutionLogsPage {
+  logs: LogEntry[];
+  total: number;
+  page: number;
+  per_page: number;
 }
 
 export interface ExecuteResult {

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { Todo, Tag, ExecutionRecord, ExecutionSummary, ExecutionRecordsPage, ExecutorSkills, SkillComparison, PaginatedInvocations, FeishuHistoryMessagesPage, FeishuHistoryChat, FeishuMessageStats, TodoTemplate, CustomTemplateStatus } from '../types';
+import type { Todo, Tag, ExecutionRecord, ExecutionSummary, ExecutionRecordsPage, ExecutionLogsPage, ExecutorSkills, SkillComparison, PaginatedInvocations, FeishuHistoryMessagesPage, FeishuHistoryChat, FeishuMessageStats, TodoTemplate, CustomTemplateStatus } from '../types';
 
 interface ApiResp<T> {
   code: number;
@@ -191,6 +191,13 @@ export async function getExecutionRecords(todoId: number, page?: number, limit?:
 
 export async function getExecutionRecord(recordId: number): Promise<ExecutionRecord> {
   return unwrap(await api.get<ApiResp<ExecutionRecord>>(`/xyz/execution-records/${recordId}`));
+}
+
+export async function getExecutionLogs(recordId: number, page?: number, perPage?: number): Promise<ExecutionLogsPage> {
+  const params: Record<string, unknown> = {};
+  if (page !== undefined) params.page = page;
+  if (perPage !== undefined) params.per_page = perPage;
+  return unwrap(await api.get<ApiResp<ExecutionLogsPage>>(`/xyz/execution-records/${recordId}/logs`, { params }));
 }
 
 export async function getExecutionRecordsBySession(sessionId: string): Promise<ExecutionRecord[]> {


### PR DESCRIPTION
## Summary
- Drop legacy `logs` TEXT column from `execution_records` that stored all log entries as a single JSON blob (could reach tens of MB)
- Startup migration copies remaining old data to the normalized `execution_logs` table, then drops the column
- Remove `logs` field from SeaORM entity, API model, and frontend `ExecutionRecord` type
- Frontend now loads logs exclusively via paginated `/xyz/execution-records/{id}/logs` API

## Test plan
- [x] Backend: all 213 lib tests pass
- [x] Frontend: TypeScript compilation and Vite build pass
- [x] API `/xyz/execution-records?todo_id=N` no longer returns `logs` field
- [x] Service restarts cleanly with migration running on startup