### PR TITLE
调整日志/对话切换按钮位置

### DIFF
--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1479,45 +1479,38 @@ function ContinuationLogsLoader({ record, viewMode, onRefresh, onViewModeChange 
   }, [record.id]);
   if (logs === null) return null;
   if (logs.length === 0) return null;
-  if (viewMode === 'chat') {
-    return (
-      <div style={{ marginTop: 6 }}>
-        <div style={{ marginBottom: 4 }}>
-          <LogViewHeader
-            title={`对话 (${logs.length})`}
-            viewMode={viewMode}
-            onViewModeChange={onViewModeChange}
-            onRefresh={() => onRefresh(record.id)}
-          />
-        </div>
-        <div style={{ maxHeight: 300, overflow: 'auto' }}>
-          <ChatView logs={logs as LogEntry[]} isRunning={false} />
-        </div>
-      </div>
-    );
-  }
+  const defaultOpen = viewMode === 'chat';
+  const [isExpanded, setIsExpanded] = useState(defaultOpen);
+  const title = viewMode === 'chat' ? `对话 (${logs.length})` : `日志 (${logs.length})`;
   return (
-    <details style={{ marginTop: 6 }} open>
+    <details style={{ marginTop: 6 }} open={isExpanded} onToggle={(e) => setIsExpanded((e.target as HTMLDetailsElement).open)}>
       <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 10, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span>日志 ({logs.length})</span>
+        <span>{title}</span>
         <LogViewHeader
           title=""
           viewMode={viewMode}
           onViewModeChange={onViewModeChange}
           onRefresh={() => onRefresh(record.id)}
+          fontSize={10}
         />
       </summary>
-      <div style={{
-        background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
-        fontFamily: 'var(--font-mono)', fontSize: 10, maxHeight: 200, overflow: 'auto',
-      }}>
-        {logs.map((log, i) => (
-          <div key={i} style={{ marginBottom: 3, display: 'flex', gap: 6 }}>
-            <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
-            <span>{log.content}</span>
-          </div>
-        ))}
-      </div>
+      {viewMode === 'chat' ? (
+        <div style={{ maxHeight: 300, overflow: 'auto' }}>
+          <ChatView logs={logs as LogEntry[]} isRunning={false} />
+        </div>
+      ) : (
+        <div style={{
+          background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
+          fontFamily: 'var(--font-mono)', fontSize: 10, maxHeight: 200, overflow: 'auto',
+        }}>
+          {logs.map((log, i) => (
+            <div key={i} style={{ marginBottom: 3, display: 'flex', gap: 6 }}>
+              <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
+              <span>{log.content}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </details>
   );
 }
@@ -1731,53 +1724,45 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                   if (!isRunning && logs.length === 0) {
                     return <ContinuationLogsLoader record={record} viewMode={viewMode} onRefresh={onRefresh} onViewModeChange={onViewModeChange} />;
                   }
-                  if (viewMode === 'chat') {
-                    return (
-                      <div style={{ marginTop: 6 }}>
-                        <div style={{ marginBottom: 4 }}>
-                          <LogViewHeader
-                            title={`对话 (${logs.length})`}
-                            viewMode={viewMode}
-                            onViewModeChange={onViewModeChange}
-                            onRefresh={() => onRefresh(record.id)}
-                            fontSize={10}
-                          />
-                        </div>
-                        <div style={{ maxHeight: 300, overflow: 'auto' }}>
-                          <ChatView logs={logs as LogEntry[]} isRunning={isRunning} />
-                        </div>
-                      </div>
-                    );
-                  }
+                  const defaultOpen = isRunning || viewMode === 'chat';
+                  const [isExpanded, setIsExpanded] = useState(defaultOpen);
+                  const title = viewMode === 'chat' ? `对话 (${logs.length})` : `日志 (${logs.length})`;
                   return (
-                    <details style={{ marginTop: 6 }} open={isRunning}>
+                    <details style={{ marginTop: 6 }} open={isExpanded} onToggle={(e) => setIsExpanded((e.target as HTMLDetailsElement).open)}>
                       <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 10, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <span>日志 ({logs.length})</span>
+                        <span>{title}</span>
                         <LogViewHeader
                           title=""
                           viewMode={viewMode}
                           onViewModeChange={onViewModeChange}
                           onRefresh={() => onRefresh(record.id)}
+                          fontSize={10}
                         />
                       </summary>
-                      <div style={{
-                        background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
-                        fontFamily: 'var(--font-mono)', fontSize: 10, maxHeight: 200, overflow: 'auto',
-                      }}>
-                        {logs.length === 0 ? (
-                          <div style={{ color: 'var(--log-text-muted)' }}>等待输出...</div>
-                        ) : (
-                          logs.map((log, i) => (
-                            <div key={i} style={{ marginBottom: 3, display: 'flex', gap: 6 }}>
-                              <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
-                              <span style={{ color: logTypeColors[log.type || ''] || 'var(--log-text)' }}>
-                                [{logTypeLabels[log.type || ''] || log.type}]
-                              </span>
-                              <span>{log.content}</span>
-                            </div>
-                          ))
-                        )}
-                      </div>
+                      {viewMode === 'chat' ? (
+                        <div style={{ maxHeight: 300, overflow: 'auto' }}>
+                          <ChatView logs={logs as LogEntry[]} isRunning={isRunning} />
+                        </div>
+                      ) : (
+                        <div style={{
+                          background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
+                          fontFamily: 'var(--font-mono)', fontSize: 10, maxHeight: 200, overflow: 'auto',
+                        }}>
+                          {logs.length === 0 ? (
+                            <div style={{ color: 'var(--log-text-muted)' }}>等待输出...</div>
+                          ) : (
+                            logs.map((log, i) => (
+                              <div key={i} style={{ marginBottom: 3, display: 'flex', gap: 6 }}>
+                                <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
+                                <span style={{ color: logTypeColors[log.type || ''] || 'var(--log-text)' }}>
+                                  [{logTypeLabels[log.type || ''] || log.type}]
+                                </span>
+                                <span>{log.content}</span>
+                              </div>
+                            ))
+                          )}
+                        </div>
+                      )}
                     </details>
                   );
                 })()}
@@ -1799,27 +1784,15 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
 /** Shared log rendering for narrow mode cards */
 function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLogs: LogEntry[], liveLogs: LogEntry[] | null, viewMode: 'log' | 'chat', onRefresh: (id: number) => Promise<void>, onViewModeChange: (mode: 'log' | 'chat') => void) {
   if (!isRunning && displayLogs.length === 0) return null;
-  if (viewMode === 'chat') {
-    return (
-      <div style={{ marginTop: 8 }}>
-        <div style={{ marginBottom: 8 }}>
-          <LogViewHeader
-            title={`对话视图 (${displayLogs.length} 条)${isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}`}
-            viewMode={viewMode}
-            onViewModeChange={onViewModeChange}
-            onRefresh={() => onRefresh(record.id)}
-          />
-        </div>
-        <div style={{ maxHeight: 400, overflow: 'auto' }}>
-          <ChatView logs={displayLogs as LogEntry[]} isRunning={isRunning} />
-        </div>
-      </div>
-    );
-  }
+  const defaultOpen = isRunning || viewMode === 'chat';
+  const [isExpanded, setIsExpanded] = useState(defaultOpen);
+  const title = viewMode === 'chat'
+    ? `对话视图 (${displayLogs.length} 条)${isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}`
+    : `查看日志 (${displayLogs.length} 条)${isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}`;
   return (
-    <details style={{ marginTop: 8 }} open={isRunning}>
+    <details style={{ marginTop: 8 }} open={isExpanded} onToggle={(e) => setIsExpanded((e.target as HTMLDetailsElement).open)}>
       <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 12, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span>查看日志 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}</span>
+        <span>{title}</span>
         <LogViewHeader
           title=""
           viewMode={viewMode}
@@ -1827,24 +1800,30 @@ function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLo
           onRefresh={() => onRefresh(record.id)}
         />
       </summary>
-      <div style={{
-        background: 'var(--log-bg)', color: 'var(--log-text)', padding: 8, borderRadius: 8,
-        fontFamily: 'var(--font-mono)', fontSize: 11, maxHeight: 250, overflow: 'auto',
-      }}>
-        {displayLogs.length === 0 ? (
-          <div style={{ color: 'var(--log-text-muted)' }}>等待输出...</div>
-        ) : (
-          displayLogs.map((log, idx) => (
-            <div key={idx} style={{ marginBottom: 4, display: 'flex', gap: 8 }}>
-              <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
-              <span style={{ color: logTypeColors[log.type || ''] || 'var(--log-text)' }}>
-                [{logTypeLabels[log.type || ''] || log.type}]
-              </span>
-              <span>{log.content}</span>
-            </div>
-          ))
-        )}
-      </div>
+      {viewMode === 'chat' ? (
+        <div style={{ maxHeight: 400, overflow: 'auto' }}>
+          <ChatView logs={displayLogs as LogEntry[]} isRunning={isRunning} />
+        </div>
+      ) : (
+        <div style={{
+          background: 'var(--log-bg)', color: 'var(--log-text)', padding: 8, borderRadius: 8,
+          fontFamily: 'var(--font-mono)', fontSize: 11, maxHeight: 250, overflow: 'auto',
+        }}>
+          {displayLogs.length === 0 ? (
+            <div style={{ color: 'var(--log-text-muted)' }}>等待输出...</div>
+          ) : (
+            displayLogs.map((log, idx) => (
+              <div key={idx} style={{ marginBottom: 4, display: 'flex', gap: 8 }}>
+                <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
+                <span style={{ color: logTypeColors[log.type || ''] || 'var(--log-text)' }}>
+                  [{logTypeLabels[log.type || ''] || log.type}]
+                </span>
+                <span>{log.content}</span>
+              </div>
+            ))
+          )}
+        </div>
+      )}
     </details>
   );
 }

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -17,6 +17,12 @@ import { ExecutorBadge } from './ExecutorBadge';
 import XMarkdown from '@ant-design/x-markdown';
 import type { ExecutionSummary, Todo, TodoItem, ExecutionRecord, ExecutionStats, LogEntry } from '../types';
 
+/** 统一刷新按钮组件 */
+const RefreshBtn = ({ onClick, size = 'small' }: { onClick: () => void; size?: 'small' | 'middle' }) => (
+  <Button type="text" size={size} icon={<ReloadOutlined />} aria-label="刷新"
+    onClick={(e) => { e.stopPropagation(); onClick(); }} />
+);
+
 /** 计算从 started_at 到现在的 elapsed time (秒) */
 function getElapsedSeconds(startedAt: string): number {
   const start = new Date(startedAt).getTime();
@@ -1113,7 +1119,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                                 <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-primary)' }}>
                                   对话视图 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}
                                 </span>
-                                <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => refreshSingleRecord(record.id)} />
+                                <RefreshBtn onClick={() => refreshSingleRecord(record.id)} />
                               </div>
                               <Segmented
                                 size="small"
@@ -1136,7 +1142,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                               <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-primary)' }}>
                                 执行过程 ({isRunning ? displayLogs.length : logsTotal} 条{isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''})
                               </span>
-                              <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => {
+                              <RefreshBtn onClick={() => {
                                 refreshSingleRecord(record.id);
                                 loadLogs(record.id, logsPage);
                               }} />
@@ -1451,7 +1457,7 @@ function ContinuationLogsLoader({ record, viewMode, onRefresh, onViewModeChange 
     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6, marginBottom: 4 }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
         <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>{title}</span>
-        <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => onRefresh(record.id)} />
+        <RefreshBtn onClick={() => onRefresh(record.id)} />
       </div>
       <Segmented
         size="small"
@@ -1706,7 +1712,7 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6, marginBottom: 4 }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                         <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>{title}</span>
-                        <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => onRefresh(record.id)} />
+                        <RefreshBtn onClick={() => onRefresh(record.id)} />
                       </div>
                       <Segmented
                         size="small"
@@ -1778,7 +1784,7 @@ function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLo
         <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-primary)' }}>
           {title}
         </span>
-        <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => onRefresh(record.id)} />
+        <RefreshBtn onClick={() => onRefresh(record.id)} />
       </div>
       <Segmented
         size="small"

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1515,6 +1515,57 @@ function ContinuationLogsLoader({ record, viewMode, onRefresh, onViewModeChange 
   );
 }
 
+/** 内联日志视图组件 (用于 ChainGroupCard 内部) */
+function ContinuationLogView({ logs, isRunning, viewMode, onRefresh, onViewModeChange }: {
+  logs: LogEntry[];
+  isRunning: boolean;
+  viewMode: 'log' | 'chat';
+  onRefresh: () => void;
+  onViewModeChange: (mode: 'log' | 'chat') => void;
+}) {
+  const defaultOpen = isRunning || viewMode === 'chat';
+  const [isExpanded, setIsExpanded] = useState(defaultOpen);
+  const title = viewMode === 'chat' ? `对话 (${logs.length})` : `日志 (${logs.length})`;
+  return (
+    <details style={{ marginTop: 6 }} open={isExpanded} onToggle={(e) => setIsExpanded((e.target as HTMLDetailsElement).open)}>
+      <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 10, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span>{title}</span>
+        <LogViewHeader
+          title=""
+          viewMode={viewMode}
+          onViewModeChange={onViewModeChange}
+          onRefresh={onRefresh}
+          fontSize={10}
+        />
+      </summary>
+      {viewMode === 'chat' ? (
+        <div style={{ maxHeight: 300, overflow: 'auto' }}>
+          <ChatView logs={logs as LogEntry[]} isRunning={isRunning} />
+        </div>
+      ) : (
+        <div style={{
+          background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
+          fontFamily: 'var(--font-mono)', fontSize: 10, maxHeight: 200, overflow: 'auto',
+        }}>
+          {logs.length === 0 ? (
+            <div style={{ color: 'var(--log-text-muted)' }}>等待输出...</div>
+          ) : (
+            logs.map((log, i) => (
+              <div key={i} style={{ marginBottom: 3, display: 'flex', gap: 6 }}>
+                <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
+                <span style={{ color: logTypeColors[log.type || ''] || 'var(--log-text)' }}>
+                  [{logTypeLabels[log.type || ''] || log.type}]
+                </span>
+                <span>{log.content}</span>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </details>
+  );
+}
+
 function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, viewMode, parseLogs, onRefresh, resolveStats, onViewModeChange }: {
   group: SessionGroup;
   onOpenResume: (r: ExecutionRecord) => void;
@@ -1629,6 +1680,8 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
       {continuations.map((record, idx) => {
         const isLast = idx === continuations.length - 1;
         const isExpanded = expandedId === record.id;
+        const logs = parseLogs(record);
+        const isRunning = record.status === 'running';
         return (
           <div key={record.id} style={{
             marginLeft: 14,
@@ -1718,54 +1771,17 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                     </Popconfirm>
                   )}
                 </div>
-                {(() => {
-                  const logs = parseLogs(record);
-                  const isRunning = record.status === 'running';
-                  if (!isRunning && logs.length === 0) {
-                    return <ContinuationLogsLoader record={record} viewMode={viewMode} onRefresh={onRefresh} onViewModeChange={onViewModeChange} />;
-                  }
-                  const defaultOpen = isRunning || viewMode === 'chat';
-                  const [isExpanded, setIsExpanded] = useState(defaultOpen);
-                  const title = viewMode === 'chat' ? `对话 (${logs.length})` : `日志 (${logs.length})`;
-                  return (
-                    <details style={{ marginTop: 6 }} open={isExpanded} onToggle={(e) => setIsExpanded((e.target as HTMLDetailsElement).open)}>
-                      <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 10, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <span>{title}</span>
-                        <LogViewHeader
-                          title=""
-                          viewMode={viewMode}
-                          onViewModeChange={onViewModeChange}
-                          onRefresh={() => onRefresh(record.id)}
-                          fontSize={10}
-                        />
-                      </summary>
-                      {viewMode === 'chat' ? (
-                        <div style={{ maxHeight: 300, overflow: 'auto' }}>
-                          <ChatView logs={logs as LogEntry[]} isRunning={isRunning} />
-                        </div>
-                      ) : (
-                        <div style={{
-                          background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
-                          fontFamily: 'var(--font-mono)', fontSize: 10, maxHeight: 200, overflow: 'auto',
-                        }}>
-                          {logs.length === 0 ? (
-                            <div style={{ color: 'var(--log-text-muted)' }}>等待输出...</div>
-                          ) : (
-                            logs.map((log, i) => (
-                              <div key={i} style={{ marginBottom: 3, display: 'flex', gap: 6 }}>
-                                <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
-                                <span style={{ color: logTypeColors[log.type || ''] || 'var(--log-text)' }}>
-                                  [{logTypeLabels[log.type || ''] || log.type}]
-                                </span>
-                                <span>{log.content}</span>
-                              </div>
-                            ))
-                          )}
-                        </div>
-                      )}
-                    </details>
-                  );
-                })()}
+                {!isRunning && logs.length === 0 ? (
+                  <ContinuationLogsLoader record={record} viewMode={viewMode} onRefresh={onRefresh} onViewModeChange={onViewModeChange} />
+                ) : (
+                  <ContinuationLogView
+                    logs={logs}
+                    isRunning={isRunning}
+                    viewMode={viewMode}
+                    onRefresh={() => onRefresh(record.id)}
+                    onViewModeChange={onViewModeChange}
+                  />
+                )}
               </div>
             )}
             {/* Continue button on last continuation */}

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1446,24 +1446,28 @@ function ContinuationLogsLoader({ record, viewMode, onRefresh, onViewModeChange 
   }, [record.id]);
   if (logs === null) return null;
   if (logs.length === 0) return null;
+  // Always show Segmented control for view switching
+  const renderHeader = (title: string) => (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6, marginBottom: 4 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>{title}</span>
+        <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => onRefresh(record.id)} />
+      </div>
+      <Segmented
+        size="small"
+        value={viewMode}
+        onChange={(value) => onViewModeChange(value as 'log' | 'chat')}
+        options={[
+          { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
+          { value: 'chat', icon: <MessageOutlined />, label: '对话' },
+        ]}
+      />
+    </div>
+  );
   if (viewMode === 'chat') {
     return (
       <div style={{ marginTop: 6 }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6, marginBottom: 4 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-            <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>对话 ({logs.length})</span>
-            <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => onRefresh(record.id)} />
-          </div>
-          <Segmented
-            size="small"
-            value={viewMode}
-            onChange={(value) => onViewModeChange(value as 'log' | 'chat')}
-            options={[
-              { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
-              { value: 'chat', icon: <MessageOutlined />, label: '对话' },
-            ]}
-          />
-        </div>
+        {renderHeader(`对话 (${logs.length})`)}
         <div style={{ maxHeight: 300, overflow: 'auto' }}>
           <ChatView logs={logs as LogEntry[]} isRunning={false} />
         </div>
@@ -1471,14 +1475,11 @@ function ContinuationLogsLoader({ record, viewMode, onRefresh, onViewModeChange 
     );
   }
   return (
-    <details style={{ marginTop: 6 }} open>
-      <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 10, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6 }}>
-        <span>日志 ({logs.length})</span>
-        <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
-      </summary>
+    <div style={{ marginTop: 6 }}>
+      {renderHeader(`日志 (${logs.length})`)}
       <div style={{
         background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
-        fontFamily: 'var(--font-mono)', fontSize: 10, marginTop: 4, maxHeight: 200, overflow: 'auto',
+        fontFamily: 'var(--font-mono)', fontSize: 10, maxHeight: 200, overflow: 'auto',
       }}>
         {logs.map((log, i) => (
           <div key={i} style={{ marginBottom: 3, display: 'flex', gap: 6 }}>
@@ -1487,7 +1488,7 @@ function ContinuationLogsLoader({ record, viewMode, onRefresh, onViewModeChange 
           </div>
         ))}
       </div>
-    </details>
+    </div>
   );
 }
 
@@ -1700,24 +1701,28 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                   if (!isRunning && logs.length === 0) {
                     return <ContinuationLogsLoader record={record} viewMode={viewMode} onRefresh={onRefresh} onViewModeChange={onViewModeChange} />;
                   }
+                  // Always show Segmented control for view switching
+                  const renderHeader = (title: string) => (
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6, marginBottom: 4 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                        <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>{title}</span>
+                        <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => onRefresh(record.id)} />
+                      </div>
+                      <Segmented
+                        size="small"
+                        value={viewMode}
+                        onChange={(value) => onViewModeChange(value as 'log' | 'chat')}
+                        options={[
+                          { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
+                          { value: 'chat', icon: <MessageOutlined />, label: '对话' },
+                        ]}
+                      />
+                    </div>
+                  );
                   if (viewMode === 'chat') {
                     return (
                       <div style={{ marginTop: 6 }}>
-                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6, marginBottom: 4 }}>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                            <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>对话 ({logs.length})</span>
-                            <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => onRefresh(record.id)} />
-                          </div>
-                          <Segmented
-                            size="small"
-                            value={viewMode}
-                            onChange={(value) => onViewModeChange(value as 'log' | 'chat')}
-                            options={[
-                              { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
-                              { value: 'chat', icon: <MessageOutlined />, label: '对话' },
-                            ]}
-                          />
-                        </div>
+                        {renderHeader(`对话 (${logs.length})`)}
                         <div style={{ maxHeight: 300, overflow: 'auto' }}>
                           <ChatView logs={logs as LogEntry[]} isRunning={isRunning} />
                         </div>
@@ -1725,14 +1730,11 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                     );
                   }
                   return (
-                    <details style={{ marginTop: 6 }} open={isRunning}>
-                      <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 10, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6 }}>
-                        <span>日志 ({logs.length})</span>
-                        <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
-                      </summary>
+                    <div style={{ marginTop: 6 }}>
+                      {renderHeader(`日志 (${logs.length})`)}
                       <div style={{
                         background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
-                        fontFamily: 'var(--font-mono)', fontSize: 10, marginTop: 4, maxHeight: 200, overflow: 'auto',
+                        fontFamily: 'var(--font-mono)', fontSize: 10, maxHeight: 200, overflow: 'auto',
                       }}>
                         {logs.length === 0 ? (
                           <div style={{ color: 'var(--log-text-muted)' }}>等待输出...</div>
@@ -1748,7 +1750,7 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                           ))
                         )}
                       </div>
-                    </details>
+                    </div>
                   );
                 })()}
               </div>
@@ -1769,26 +1771,30 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
 /** Shared log rendering for narrow mode cards */
 function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLogs: LogEntry[], liveLogs: LogEntry[] | null, viewMode: 'log' | 'chat', onRefresh: (id: number) => Promise<void>, onViewModeChange: (mode: 'log' | 'chat') => void) {
   if (!isRunning && displayLogs.length === 0) return null;
+  // Always show Segmented control for view switching
+  const renderHeader = (title: string) => (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8, gap: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-primary)' }}>
+          {title}
+        </span>
+        <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => onRefresh(record.id)} />
+      </div>
+      <Segmented
+        size="small"
+        value={viewMode}
+        onChange={(value) => onViewModeChange(value as 'log' | 'chat')}
+        options={[
+          { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
+          { value: 'chat', icon: <MessageOutlined />, label: '对话' },
+        ]}
+      />
+    </div>
+  );
   if (viewMode === 'chat') {
     return (
       <div style={{ marginTop: 8 }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8, gap: 8 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-primary)' }}>
-              对话视图 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}
-            </span>
-            <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => onRefresh(record.id)} />
-          </div>
-          <Segmented
-            size="small"
-            value={viewMode}
-            onChange={(value) => onViewModeChange(value as 'log' | 'chat')}
-            options={[
-              { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
-              { value: 'chat', icon: <MessageOutlined />, label: '对话' },
-            ]}
-          />
-        </div>
+        {renderHeader(`对话视图 (${displayLogs.length} 条)${isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}`)}
         <div style={{ maxHeight: 400, overflow: 'auto' }}>
           <ChatView logs={displayLogs as LogEntry[]} isRunning={isRunning} />
         </div>
@@ -1796,14 +1802,11 @@ function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLo
     );
   }
   return (
-    <details style={{ marginTop: 8 }} open={isRunning}>
-      <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 12, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span>查看日志 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}</span>
-        <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
-      </summary>
+    <div style={{ marginTop: 8 }}>
+      {renderHeader(`查看日志 (${displayLogs.length} 条)${isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}`)}
       <div style={{
         background: 'var(--log-bg)', color: 'var(--log-text)', padding: 8, borderRadius: 8,
-        fontFamily: 'var(--font-mono)', fontSize: 11, marginTop: 8, maxHeight: 250, overflow: 'auto',
+        fontFamily: 'var(--font-mono)', fontSize: 11, maxHeight: 250, overflow: 'auto',
       }}>
         {displayLogs.length === 0 ? (
           <div style={{ color: 'var(--log-text-muted)' }}>等待输出...</div>
@@ -1819,7 +1822,7 @@ function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLo
           ))
         )}
       </div>
-    </details>
+    </div>
   );
 }
 

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1458,7 +1458,15 @@ function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, o
           </div>
         );
       })()}
-      {renderNarrowLogs(record, isRunning, displayLogs, liveLogs, viewMode, onRefresh, onViewModeChange)}
+      <NarrowLogView
+        record={record}
+        isRunning={isRunning}
+        displayLogs={displayLogs}
+        liveLogs={liveLogs}
+        viewMode={viewMode}
+        onRefresh={onRefresh}
+        onViewModeChange={onViewModeChange}
+      />
     </div>
   );
 }
@@ -1673,7 +1681,15 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
             </div>
           );
         })()}
-        {renderNarrowLogs(mainRecord, mainRecord.status === 'running', mainDisplayLogs, null, viewMode, onRefresh, onViewModeChange)}
+        <NarrowLogView
+          record={mainRecord}
+          isRunning={mainRecord.status === 'running'}
+          displayLogs={mainDisplayLogs}
+          liveLogs={null}
+          viewMode={viewMode}
+          onRefresh={onRefresh}
+          onViewModeChange={onViewModeChange}
+        />
       </div>
 
       {/* Indented continuation entries */}
@@ -1797,8 +1813,16 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
   );
 }
 
-/** Shared log rendering for narrow mode cards */
-function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLogs: LogEntry[], liveLogs: LogEntry[] | null, viewMode: 'log' | 'chat', onRefresh: (id: number) => Promise<void>, onViewModeChange: (mode: 'log' | 'chat') => void) {
+/** Shared log rendering for narrow mode cards - as a proper component */
+function NarrowLogView({ record, isRunning, displayLogs, liveLogs, viewMode, onRefresh, onViewModeChange }: {
+  record: ExecutionRecord;
+  isRunning: boolean;
+  displayLogs: LogEntry[];
+  liveLogs: LogEntry[] | null;
+  viewMode: 'log' | 'chat';
+  onRefresh: (id: number) => Promise<void>;
+  onViewModeChange: (mode: 'log' | 'chat') => void;
+}) {
   if (!isRunning && displayLogs.length === 0) return null;
   const defaultOpen = isRunning || viewMode === 'chat';
   const [isExpanded, setIsExpanded] = useState(defaultOpen);

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -23,6 +23,33 @@ const RefreshBtn = ({ onClick, size = 'small' }: { onClick: () => void; size?: '
     onClick={(e) => { e.stopPropagation(); onClick(); }} />
 );
 
+/** 日志视图头部组件 */
+function LogViewHeader({ title, viewMode, onViewModeChange, onRefresh, fontSize = 12 }: {
+  title: string;
+  viewMode: 'log' | 'chat';
+  onViewModeChange: (mode: 'log' | 'chat') => void;
+  onRefresh: () => void;
+  fontSize?: number;
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontSize, fontWeight: 600, color: 'var(--color-primary)' }}>{title}</span>
+        <RefreshBtn onClick={onRefresh} />
+      </div>
+      <Segmented
+        size="small"
+        value={viewMode}
+        onChange={(value) => onViewModeChange(value as 'log' | 'chat')}
+        options={[
+          { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
+          { value: 'chat', icon: <MessageOutlined />, label: '对话' },
+        ]}
+      />
+    </div>
+  );
+}
+
 /** 计算从 started_at 到现在的 elapsed time (秒) */
 function getElapsedSeconds(startedAt: string): number {
   const start = new Date(startedAt).getTime();
@@ -1452,28 +1479,17 @@ function ContinuationLogsLoader({ record, viewMode, onRefresh, onViewModeChange 
   }, [record.id]);
   if (logs === null) return null;
   if (logs.length === 0) return null;
-  // Always show Segmented control for view switching
-  const renderHeader = (title: string) => (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6, marginBottom: 4 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-        <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>{title}</span>
-        <RefreshBtn onClick={() => onRefresh(record.id)} />
-      </div>
-      <Segmented
-        size="small"
-        value={viewMode}
-        onChange={(value) => onViewModeChange(value as 'log' | 'chat')}
-        options={[
-          { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
-          { value: 'chat', icon: <MessageOutlined />, label: '对话' },
-        ]}
-      />
-    </div>
-  );
   if (viewMode === 'chat') {
     return (
       <div style={{ marginTop: 6 }}>
-        {renderHeader(`对话 (${logs.length})`)}
+        <div style={{ marginBottom: 4 }}>
+          <LogViewHeader
+            title={`对话 (${logs.length})`}
+            viewMode={viewMode}
+            onViewModeChange={onViewModeChange}
+            onRefresh={() => onRefresh(record.id)}
+          />
+        </div>
         <div style={{ maxHeight: 300, overflow: 'auto' }}>
           <ChatView logs={logs as LogEntry[]} isRunning={false} />
         </div>
@@ -1481,8 +1497,16 @@ function ContinuationLogsLoader({ record, viewMode, onRefresh, onViewModeChange 
     );
   }
   return (
-    <div style={{ marginTop: 6 }}>
-      {renderHeader(`日志 (${logs.length})`)}
+    <details style={{ marginTop: 6 }} open>
+      <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 10, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span>日志 ({logs.length})</span>
+        <LogViewHeader
+          title=""
+          viewMode={viewMode}
+          onViewModeChange={onViewModeChange}
+          onRefresh={() => onRefresh(record.id)}
+        />
+      </summary>
       <div style={{
         background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
         fontFamily: 'var(--font-mono)', fontSize: 10, maxHeight: 200, overflow: 'auto',
@@ -1494,7 +1518,7 @@ function ContinuationLogsLoader({ record, viewMode, onRefresh, onViewModeChange 
           </div>
         ))}
       </div>
-    </div>
+    </details>
   );
 }
 
@@ -1707,28 +1731,18 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                   if (!isRunning && logs.length === 0) {
                     return <ContinuationLogsLoader record={record} viewMode={viewMode} onRefresh={onRefresh} onViewModeChange={onViewModeChange} />;
                   }
-                  // Always show Segmented control for view switching
-                  const renderHeader = (title: string) => (
-                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6, marginBottom: 4 }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                        <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>{title}</span>
-                        <RefreshBtn onClick={() => onRefresh(record.id)} />
-                      </div>
-                      <Segmented
-                        size="small"
-                        value={viewMode}
-                        onChange={(value) => onViewModeChange(value as 'log' | 'chat')}
-                        options={[
-                          { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
-                          { value: 'chat', icon: <MessageOutlined />, label: '对话' },
-                        ]}
-                      />
-                    </div>
-                  );
                   if (viewMode === 'chat') {
                     return (
                       <div style={{ marginTop: 6 }}>
-                        {renderHeader(`对话 (${logs.length})`)}
+                        <div style={{ marginBottom: 4 }}>
+                          <LogViewHeader
+                            title={`对话 (${logs.length})`}
+                            viewMode={viewMode}
+                            onViewModeChange={onViewModeChange}
+                            onRefresh={() => onRefresh(record.id)}
+                            fontSize={10}
+                          />
+                        </div>
                         <div style={{ maxHeight: 300, overflow: 'auto' }}>
                           <ChatView logs={logs as LogEntry[]} isRunning={isRunning} />
                         </div>
@@ -1736,8 +1750,16 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                     );
                   }
                   return (
-                    <div style={{ marginTop: 6 }}>
-                      {renderHeader(`日志 (${logs.length})`)}
+                    <details style={{ marginTop: 6 }} open={isRunning}>
+                      <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 10, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
+                        <span>日志 ({logs.length})</span>
+                        <LogViewHeader
+                          title=""
+                          viewMode={viewMode}
+                          onViewModeChange={onViewModeChange}
+                          onRefresh={() => onRefresh(record.id)}
+                        />
+                      </summary>
                       <div style={{
                         background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
                         fontFamily: 'var(--font-mono)', fontSize: 10, maxHeight: 200, overflow: 'auto',
@@ -1756,7 +1778,7 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                           ))
                         )}
                       </div>
-                    </div>
+                    </details>
                   );
                 })()}
               </div>
@@ -1777,30 +1799,17 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
 /** Shared log rendering for narrow mode cards */
 function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLogs: LogEntry[], liveLogs: LogEntry[] | null, viewMode: 'log' | 'chat', onRefresh: (id: number) => Promise<void>, onViewModeChange: (mode: 'log' | 'chat') => void) {
   if (!isRunning && displayLogs.length === 0) return null;
-  // Always show Segmented control for view switching
-  const renderHeader = (title: string) => (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8, gap: 8 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-primary)' }}>
-          {title}
-        </span>
-        <RefreshBtn onClick={() => onRefresh(record.id)} />
-      </div>
-      <Segmented
-        size="small"
-        value={viewMode}
-        onChange={(value) => onViewModeChange(value as 'log' | 'chat')}
-        options={[
-          { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
-          { value: 'chat', icon: <MessageOutlined />, label: '对话' },
-        ]}
-      />
-    </div>
-  );
   if (viewMode === 'chat') {
     return (
       <div style={{ marginTop: 8 }}>
-        {renderHeader(`对话视图 (${displayLogs.length} 条)${isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}`)}
+        <div style={{ marginBottom: 8 }}>
+          <LogViewHeader
+            title={`对话视图 (${displayLogs.length} 条)${isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}`}
+            viewMode={viewMode}
+            onViewModeChange={onViewModeChange}
+            onRefresh={() => onRefresh(record.id)}
+          />
+        </div>
         <div style={{ maxHeight: 400, overflow: 'auto' }}>
           <ChatView logs={displayLogs as LogEntry[]} isRunning={isRunning} />
         </div>
@@ -1808,8 +1817,16 @@ function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLo
     );
   }
   return (
-    <div style={{ marginTop: 8 }}>
-      {renderHeader(`查看日志 (${displayLogs.length} 条)${isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}`)}
+    <details style={{ marginTop: 8 }} open={isRunning}>
+      <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 12, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span>查看日志 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}</span>
+        <LogViewHeader
+          title=""
+          viewMode={viewMode}
+          onViewModeChange={onViewModeChange}
+          onRefresh={() => onRefresh(record.id)}
+        />
+      </summary>
       <div style={{
         background: 'var(--log-bg)', color: 'var(--log-text)', padding: 8, borderRadius: 8,
         fontFamily: 'var(--font-mono)', fontSize: 11, maxHeight: 250, overflow: 'auto',
@@ -1828,7 +1845,7 @@ function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLo
           ))
         )}
       </div>
-    </div>
+    </details>
   );
 }
 

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -815,26 +815,15 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
       >
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12, ...(isWide ? { flexShrink: 0 } : {}) }}>
           <h4 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: 'var(--color-text)' }}>执行历史</h4>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <Segmented
-              size="small"
-              value={viewMode}
-              onChange={(value) => setViewMode(value as 'log' | 'chat')}
-              options={[
-                { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
-                { value: 'chat', icon: <MessageOutlined />, label: '对话' },
-              ]}
-            />
-            <Button
-              type="text"
-              size="small"
-              icon={<ReloadOutlined />}
-              onClick={() => loadExecutionRecords(historyPage, historyLimit)}
-              loading={isExecuting}
-            >
-              刷新
-            </Button>
-          </div>
+          <Button
+            type="text"
+            size="small"
+            icon={<ReloadOutlined />}
+            onClick={() => loadExecutionRecords(historyPage, historyLimit)}
+            loading={isExecuting}
+          >
+            刷新
+          </Button>
         </div>
         {records.length === 0 ? (
           <Empty description="暂无执行记录" image={Empty.PRESENTED_IMAGE_SIMPLE} />
@@ -1119,13 +1108,24 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                       if (viewMode === 'chat') {
                         return (
                           <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8, flexShrink: 0 }}>
-                              <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-primary)' }}>
-                                对话视图 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}
-                              </span>
-                              <ReloadOutlined
-                                style={{ fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer' }}
-                                onClick={() => refreshSingleRecord(record.id)}
+                            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8, flexShrink: 0 }}>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-primary)' }}>
+                                  对话视图 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}
+                                </span>
+                                <ReloadOutlined
+                                  style={{ fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer' }}
+                                  onClick={() => refreshSingleRecord(record.id)}
+                                />
+                              </div>
+                              <Segmented
+                                size="small"
+                                value={viewMode}
+                                onChange={(value) => setViewMode(value as 'log' | 'chat')}
+                                options={[
+                                  { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
+                                  { value: 'chat', icon: <MessageOutlined />, label: '对话' },
+                                ]}
                               />
                             </div>
                             <ChatView logs={displayLogs as LogEntry[]} isRunning={isRunning} />
@@ -1134,16 +1134,27 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                       }
                       return (
                         <div>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-                            <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-primary)' }}>
-                              执行过程 ({isRunning ? displayLogs.length : logsTotal} 条{isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''})
-                            </span>
-                            <ReloadOutlined
-                              style={{ fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer' }}
-                              onClick={() => {
-                                refreshSingleRecord(record.id);
-                                loadLogs(record.id, logsPage);
-                              }}
+                          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                              <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-primary)' }}>
+                                执行过程 ({isRunning ? displayLogs.length : logsTotal} 条{isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''})
+                              </span>
+                              <ReloadOutlined
+                                style={{ fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer' }}
+                                onClick={() => {
+                                  refreshSingleRecord(record.id);
+                                  loadLogs(record.id, logsPage);
+                                }}
+                              />
+                            </div>
+                            <Segmented
+                              size="small"
+                              value={viewMode}
+                              onChange={(value) => setViewMode(value as 'log' | 'chat')}
+                              options={[
+                                { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
+                                { value: 'chat', icon: <MessageOutlined />, label: '对话' },
+                              ]}
                             />
                           </div>
                           <div style={{

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1113,10 +1113,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                                 <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-primary)' }}>
                                   对话视图 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}
                                 </span>
-                                <ReloadOutlined
-                                  style={{ fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer' }}
-                                  onClick={() => refreshSingleRecord(record.id)}
-                                />
+                                <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => refreshSingleRecord(record.id)} />
                               </div>
                               <Segmented
                                 size="small"
@@ -1139,13 +1136,10 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                               <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-primary)' }}>
                                 执行过程 ({isRunning ? displayLogs.length : logsTotal} 条{isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''})
                               </span>
-                              <ReloadOutlined
-                                style={{ fontSize: 12, color: 'var(--color-text-tertiary)', cursor: 'pointer' }}
-                                onClick={() => {
-                                  refreshSingleRecord(record.id);
-                                  loadLogs(record.id, logsPage);
-                                }}
-                              />
+                              <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => {
+                                refreshSingleRecord(record.id);
+                                loadLogs(record.id, logsPage);
+                              }} />
                             </div>
                             <Segmented
                               size="small"
@@ -1221,6 +1215,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                     resolveStats={resolveExecutionStats}
                     parseLogs={parseRecordLogs}
                     messageApi={message}
+                    onViewModeChange={setViewMode}
                   />
                 ));
               }
@@ -1236,6 +1231,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                   parseLogs={parseRecordLogs}
                   onRefresh={refreshSingleRecord}
                   resolveStats={resolveExecutionStats}
+                  onViewModeChange={setViewMode}
                 />
               );
             })}
@@ -1311,7 +1307,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
 }
 
 /** Narrow mode: single history card */
-function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, onRefresh, getRunningTask, resolveStats, parseLogs, messageApi }: {
+function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, onRefresh, getRunningTask, resolveStats, parseLogs, messageApi, onViewModeChange }: {
   record: ExecutionRecord;
   viewMode: 'log' | 'chat';
   onOpenResume: (r: ExecutionRecord) => void;
@@ -1322,6 +1318,7 @@ function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, o
   resolveStats: (r: ExecutionRecord, running: boolean) => ExecutionStats | null | undefined;
   parseLogs: (r: ExecutionRecord) => LogEntry[];
   messageApi: any;
+  onViewModeChange: (mode: 'log' | 'chat') => void;
 }) {
   const isRunning = record.status === 'running';
   const runningTask = isRunning ? getRunningTask(record) : null;
@@ -1428,17 +1425,18 @@ function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, o
           </div>
         );
       })()}
-      {renderNarrowLogs(record, isRunning, displayLogs, liveLogs, viewMode, onRefresh)}
+      {renderNarrowLogs(record, isRunning, displayLogs, liveLogs, viewMode, onRefresh, onViewModeChange)}
     </div>
   );
 }
 
 /** Narrow mode: chain group card — main record with indented continuations */
 /** Lazy-load logs for a continuation record in ChainGroupCard */
-function ContinuationLogsLoader({ record, viewMode, onRefresh }: {
+function ContinuationLogsLoader({ record, viewMode, onRefresh, onViewModeChange }: {
   record: ExecutionRecord;
   viewMode: 'log' | 'chat';
   onRefresh: (id: number) => Promise<void>;
+  onViewModeChange: (mode: 'log' | 'chat') => void;
 }) {
   const [logs, setLogs] = useState<LogEntry[] | null>(null);
   useEffect(() => {
@@ -1451,9 +1449,20 @@ function ContinuationLogsLoader({ record, viewMode, onRefresh }: {
   if (viewMode === 'chat') {
     return (
       <div style={{ marginTop: 6 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
-          <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>对话 ({logs.length})</span>
-          <ReloadOutlined style={{ fontSize: 10, cursor: 'pointer' }} onClick={(e) => { e.stopPropagation(); onRefresh(record.id); }} />
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6, marginBottom: 4 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>对话 ({logs.length})</span>
+            <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => onRefresh(record.id)} />
+          </div>
+          <Segmented
+            size="small"
+            value={viewMode}
+            onChange={(value) => onViewModeChange(value as 'log' | 'chat')}
+            options={[
+              { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
+              { value: 'chat', icon: <MessageOutlined />, label: '对话' },
+            ]}
+          />
         </div>
         <div style={{ maxHeight: 300, overflow: 'auto' }}>
           <ChatView logs={logs as LogEntry[]} isRunning={false} />
@@ -1465,7 +1474,7 @@ function ContinuationLogsLoader({ record, viewMode, onRefresh }: {
     <details style={{ marginTop: 6 }} open>
       <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 10, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6 }}>
         <span>日志 ({logs.length})</span>
-        <ReloadOutlined style={{ fontSize: 9 }} onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
+        <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
       </summary>
       <div style={{
         background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
@@ -1482,7 +1491,7 @@ function ContinuationLogsLoader({ record, viewMode, onRefresh }: {
   );
 }
 
-function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, viewMode, parseLogs, onRefresh, resolveStats }: {
+function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, viewMode, parseLogs, onRefresh, resolveStats, onViewModeChange }: {
   group: SessionGroup;
   onOpenResume: (r: ExecutionRecord) => void;
   onExport: (r: ExecutionRecord) => void;
@@ -1492,6 +1501,7 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
   parseLogs: (r: ExecutionRecord) => LogEntry[];
   onRefresh: (id: number) => Promise<void>;
   resolveStats: (r: ExecutionRecord, running: boolean) => ExecutionStats | null | undefined;
+  onViewModeChange: (mode: 'log' | 'chat') => void;
 }) {
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const mainRecord = group.records[0];
@@ -1588,7 +1598,7 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
             </div>
           );
         })()}
-        {renderNarrowLogs(mainRecord, mainRecord.status === 'running', mainDisplayLogs, null, viewMode, onRefresh)}
+        {renderNarrowLogs(mainRecord, mainRecord.status === 'running', mainDisplayLogs, null, viewMode, onRefresh, onViewModeChange)}
       </div>
 
       {/* Indented continuation entries */}
@@ -1688,14 +1698,25 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                   const logs = parseLogs(record);
                   const isRunning = record.status === 'running';
                   if (!isRunning && logs.length === 0) {
-                    return <ContinuationLogsLoader record={record} viewMode={viewMode} onRefresh={onRefresh} />;
+                    return <ContinuationLogsLoader record={record} viewMode={viewMode} onRefresh={onRefresh} onViewModeChange={onViewModeChange} />;
                   }
                   if (viewMode === 'chat') {
                     return (
                       <div style={{ marginTop: 6 }}>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
-                          <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>对话 ({logs.length})</span>
-                          <ReloadOutlined style={{ fontSize: 10, cursor: 'pointer' }} onClick={(e) => { e.stopPropagation(); onRefresh(record.id); }} />
+                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6, marginBottom: 4 }}>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                            <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)' }}>对话 ({logs.length})</span>
+                            <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => onRefresh(record.id)} />
+                          </div>
+                          <Segmented
+                            size="small"
+                            value={viewMode}
+                            onChange={(value) => onViewModeChange(value as 'log' | 'chat')}
+                            options={[
+                              { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
+                              { value: 'chat', icon: <MessageOutlined />, label: '对话' },
+                            ]}
+                          />
                         </div>
                         <div style={{ maxHeight: 300, overflow: 'auto' }}>
                           <ChatView logs={logs as LogEntry[]} isRunning={isRunning} />
@@ -1707,7 +1728,7 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                     <details style={{ marginTop: 6 }} open={isRunning}>
                       <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 10, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6 }}>
                         <span>日志 ({logs.length})</span>
-                        <ReloadOutlined style={{ fontSize: 9 }} onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
+                        <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
                       </summary>
                       <div style={{
                         background: 'var(--log-bg)', color: 'var(--log-text)', padding: 6, borderRadius: 6,
@@ -1746,16 +1767,27 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
 }
 
 /** Shared log rendering for narrow mode cards */
-function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLogs: LogEntry[], liveLogs: LogEntry[] | null, viewMode: 'log' | 'chat', onRefresh: (id: number) => Promise<void>) {
+function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLogs: LogEntry[], liveLogs: LogEntry[] | null, viewMode: 'log' | 'chat', onRefresh: (id: number) => Promise<void>, onViewModeChange: (mode: 'log' | 'chat') => void) {
   if (!isRunning && displayLogs.length === 0) return null;
   if (viewMode === 'chat') {
     return (
       <div style={{ marginTop: 8 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-primary)' }}>
-            对话视图 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}
-          </span>
-          <ReloadOutlined style={{ fontSize: 11 }} onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8, gap: 8 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-primary)' }}>
+              对话视图 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}
+            </span>
+            <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={() => onRefresh(record.id)} />
+          </div>
+          <Segmented
+            size="small"
+            value={viewMode}
+            onChange={(value) => onViewModeChange(value as 'log' | 'chat')}
+            options={[
+              { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
+              { value: 'chat', icon: <MessageOutlined />, label: '对话' },
+            ]}
+          />
         </div>
         <div style={{ maxHeight: 400, overflow: 'auto' }}>
           <ChatView logs={displayLogs as LogEntry[]} isRunning={isRunning} />
@@ -1767,7 +1799,7 @@ function renderNarrowLogs(record: ExecutionRecord, isRunning: boolean, displayLo
     <details style={{ marginTop: 8 }} open={isRunning}>
       <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 12, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
         <span>查看日志 ({displayLogs.length} 条){isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}</span>
-        <ReloadOutlined style={{ fontSize: 11 }} onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
+        <Button type="text" size="small" icon={<ReloadOutlined />} aria-label="刷新" onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRefresh(record.id); }} />
       </summary>
       <div style={{
         background: 'var(--log-bg)', color: 'var(--log-text)', padding: 8, borderRadius: 8,


### PR DESCRIPTION
## 变更内容\n\n将日志/对话切换按钮（Segmented）从执行历史头部移动到各个记录卡片内部。\n\n### 主要变化\n\n- **移除**：执行历史标题上方的统一 Segmented 切换按钮 + 刷新按钮\n- **新增**：在每个记录的日志视图和对话视图内部，各自显示 Segmented 切换按钮\n- 每个视图头部增加了  布局，将标题/刷新按钮和切换按钮左右分布