### PR TITLE
feat: 运行管理增加最大并发数和超时时间配置项

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -47,6 +47,10 @@ pub struct Config {
     pub default_response_todo_id: Option<i64>,
     /// 历史消息最大处理年龄（秒），超过此时间的历史消息拉取后标记跳过不处理（默认 600 = 10 分钟）
     pub history_message_max_age_secs: u64,
+    /// 最大并发执行数（默认 1，即同一时间只能运行一个 Todo）
+    pub max_concurrent_todos: u32,
+    /// 执行超时时间（秒，默认 1800 = 30 分钟），超过此时间将自动终止进程
+    pub execution_timeout_secs: u64,
 }
 
 /// Paths for each supported executor binary.
@@ -120,6 +124,8 @@ impl Default for Config {
             slash_command_rules: Vec::new(),
             default_response_todo_id: None,
             history_message_max_age_secs: 600,
+            max_concurrent_todos: 3,
+            execution_timeout_secs: 3600,
         }
     }
 }

--- a/backend/src/db/entity/mod.rs
+++ b/backend/src/db/entity/mod.rs
@@ -15,19 +15,19 @@ pub mod todo_templates;
 pub mod todos;
 
 pub mod prelude {
-    pub use super::agent_bots::Entity as AgentBots;
-    pub use super::execution_logs::Entity as ExecutionLogs;
-    pub use super::execution_records::Entity as ExecutionRecords;
-    pub use super::executors::Entity as Executors;
-    pub use super::feishu_homes::Entity as FeishuHomes;
-    pub use super::feishu_history_chats::Entity as FeishuHistoryChats;
-    pub use super::feishu_messages::Entity as FeishuMessages;
-    pub use super::feishu_push_targets::Entity as FeishuPushTargets;
-    pub use super::feishu_response_config::Entity as FeishuResponseConfig;
-    pub use super::feishu_group_whitelist::Entity as FeishuGroupWhitelist;
-    pub use super::project_directories::Entity as ProjectDirectories;
-    pub use super::tags::Entity as Tags;
-    pub use super::todo_tags::Entity as TodoTags;
-    pub use super::todo_templates::Entity as TodoTemplates;
-    pub use super::todos::Entity as Todos;
+  pub use super::agent_bots::Entity as AgentBots;
+  pub use super::execution_logs::Entity as ExecutionLogs;
+  pub use super::execution_records::Entity as ExecutionRecords;
+  pub use super::executors::Entity as Executors;
+  pub use super::feishu_homes::Entity as FeishuHomes;
+  pub use super::feishu_history_chats::Entity as FeishuHistoryChats;
+  pub use super::feishu_messages::Entity as FeishuMessages;
+  pub use super::feishu_push_targets::Entity as FeishuPushTargets;
+  pub use super::feishu_response_config::Entity as FeishuResponseConfig;
+  pub use super::feishu_group_whitelist::Entity as FeishuGroupWhitelist;
+  pub use super::project_directories::Entity as ProjectDirectories;
+  pub use super::tags::Entity as Tags;
+  pub use super::todo_tags::Entity as TodoTags;
+  pub use super::todo_templates::Entity as TodoTemplates;
+  pub use super::todos::Entity as Todos;
 }

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -23,9 +23,6 @@ async fn kill_process_tree(child: &mut command_group::AsyncGroupChild) {
     }
 }
 
-/// 最大执行时长（秒），超过此时间将自动终止进程（执行器被挂起/卡住时释放资源）
-const MAX_EXECUTION_TIMEOUT_SECS: u64 = 1800; // 30 分钟
-
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ExecutionResult {
     pub task_id: String,
@@ -37,6 +34,7 @@ pub struct RunTodoExecutionRequest {
     pub executor_registry: Arc<ExecutorRegistry>,
     pub tx: broadcast::Sender<ExecEvent>,
     pub task_manager: Arc<TaskManager>,
+    pub config: Arc<tokio::sync::RwLock<crate::config::Config>>,
     pub todo_id: i64,
     pub message: String,
     pub req_executor: Option<String>,
@@ -53,6 +51,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
         executor_registry,
         tx,
         task_manager,
+        config,
         todo_id,
         message,
         req_executor,
@@ -68,10 +67,16 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     let task_id = Uuid::new_v4().to_string();
     let mut cancel_rx = task_manager.register(task_id.clone()).await;
 
-    // Get todo to read stored executor
+    // Read runtime settings from config
+    let (max_concurrent, timeout_secs) = {
+        let cfg = config.read().await;
+        (cfg.max_concurrent_todos, cfg.execution_timeout_secs)
+    };
+
+    // Get todo to read stored executor and check concurrency
     let todo = match db.get_todo(todo_id).await {
         Ok(Some(t)) => {
-            // 检查 todo 是否正在执行中，防止重复执行
+            // 检查同一个 todo 是否正在执行中，防止重复执行
             if t.status == crate::models::TodoStatus::Running {
                 tracing::warn!("Todo {} is already running, skipping execution", todo_id);
                 task_manager.remove(&task_id).await;
@@ -91,6 +96,35 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                     record_id: None,
                 };
             }
+
+            // 检查全局并发数是否已达上限
+            let running_count = db.get_running_todos().await.map(|v| v.len()).unwrap_or(0);
+            if running_count >= max_concurrent as usize {
+                tracing::warn!(
+                    "Concurrent limit reached ({}/{}), rejecting todo {}",
+                    running_count, max_concurrent, todo_id
+                );
+                task_manager.remove(&task_id).await;
+                send_event(
+                    &tx,
+                    ExecEvent::Finished {
+                        task_id: task_id.clone(),
+                        todo_id,
+                        todo_title: t.title.clone(),
+                        executor: "".to_string(),
+                        success: false,
+                        result: Some(format!(
+                            "Concurrent limit reached ({}/{}), please wait",
+                            running_count, max_concurrent
+                        )),
+                    },
+                );
+                return ExecutionResult {
+                    task_id,
+                    record_id: None,
+                };
+            }
+
             Some(t)
         }
         Ok(None) => None,
@@ -262,6 +296,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     let task_manager_spawn = task_manager.clone();
 
     let todo_title = todo.as_ref().map(|t| t.title.clone()).unwrap_or_default();
+    let execution_timeout_secs = timeout_secs;
 
     // 注册任务信息，用于 WebSocket 同步
     task_manager
@@ -696,11 +731,11 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                 task_manager_spawn.remove(&task_id).await;
                 return;
             }
-            _ = tokio::time::sleep(std::time::Duration::from_secs(MAX_EXECUTION_TIMEOUT_SECS)) => {
+            _ = tokio::time::sleep(std::time::Duration::from_secs(execution_timeout_secs)) => {
                 // Timeout: 自动终止执行时间过长的进程，释放资源
                 tracing::warn!(
                     "Execution timeout reached ({}s) for todo {} (task {}), killing process",
-                    MAX_EXECUTION_TIMEOUT_SECS, todo_id, task_id
+                    execution_timeout_secs, todo_id, task_id
                 );
                 kill_process_tree(&mut child).await;
                 flush_timer.abort();
@@ -731,7 +766,8 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
 
                 let entry = ParsedLogEntry::error("Execution timeout - process was automatically terminated");
                 send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
-                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: Some("Execution timed out after 30 minutes".to_string()) });
+                let timeout_mins = execution_timeout_secs / 60;
+                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: Some(format!("Execution timed out after {} minutes", timeout_mins)) });
                 task_manager_spawn.remove(&task_id).await;
                 return;
             }

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -36,6 +36,18 @@ pub async fn update_config(
     if let Some(history_message_max_age_secs) = req.history_message_max_age_secs {
         cfg.history_message_max_age_secs = history_message_max_age_secs;
     }
+    if let Some(max_concurrent_todos) = req.max_concurrent_todos {
+        if max_concurrent_todos == 0 {
+            return Err(AppError::BadRequest("max_concurrent_todos must be at least 1".to_string()));
+        }
+        cfg.max_concurrent_todos = max_concurrent_todos;
+    }
+    if let Some(execution_timeout_secs) = req.execution_timeout_secs {
+        if execution_timeout_secs < 60 {
+            return Err(AppError::BadRequest("execution_timeout_secs must be at least 60".to_string()));
+        }
+        cfg.execution_timeout_secs = execution_timeout_secs;
+    }
 
     cfg.normalize_paths();
 

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -119,6 +119,16 @@ pub async fn execute_handler(
         )));
     }
 
+    // 检查全局并发数是否已达上限
+    let max_concurrent = state.config.read().await.max_concurrent_todos;
+    let running_count = state.db.get_running_todos().await.map(|v| v.len()).unwrap_or(0);
+    if running_count >= max_concurrent as usize {
+        return Err(AppError::BadRequest(format!(
+            "Concurrent limit reached ({}/{}). Please wait for a running task to finish.",
+            running_count, max_concurrent
+        )));
+    }
+
     // Fall back to todo.prompt if message is None or whitespace-only
     let message = req
         .message
@@ -133,6 +143,7 @@ pub async fn execute_handler(
         executor_registry: state.executor_registry.clone(),
         tx: state.tx.clone(),
         task_manager: state.task_manager.clone(),
+        config: state.config.clone(),
         todo_id: req.todo_id,
         message,
         req_executor: req.executor,
@@ -303,6 +314,16 @@ pub async fn resume_execution_handler(
         )));
     }
 
+    // 检查全局并发数是否已达上限
+    let max_concurrent = state.config.read().await.max_concurrent_todos;
+    let running_count = state.db.get_running_todos().await.map(|v| v.len()).unwrap_or(0);
+    if running_count >= max_concurrent as usize {
+        return Err(AppError::BadRequest(format!(
+            "Concurrent limit reached ({}/{}). Please wait for a running task to finish.",
+            running_count, max_concurrent
+        )));
+    }
+
     let message = req
         .message
         .as_ref()
@@ -327,6 +348,7 @@ pub async fn resume_execution_handler(
         executor_registry: state.executor_registry.clone(),
         tx: state.tx.clone(),
         task_manager: state.task_manager.clone(),
+        config: state.config.clone(),
         todo_id,
         message,
         req_executor: record.executor.clone(),

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -306,6 +306,7 @@ pub fn create_app(
         executor_registry.clone(),
         tx.clone(),
         task_manager.clone(),
+        config.clone(),
     ));
 
     let feishu_listener = Arc::new(FeishuListener::new(

--- a/backend/src/handlers/scheduler.rs
+++ b/backend/src/handlers/scheduler.rs
@@ -22,6 +22,7 @@ pub async fn update_scheduler(
                     id,
                     config.clone(),
                     state.task_manager.clone(),
+                    state.config.clone(),
                 )
                 .await
             {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -212,13 +212,14 @@ async fn run_server(cli_port: Option<u16>) {
 
     let (tx, _rx) = broadcast::channel(100);
     let task_manager = Arc::new(TaskManager::new());
+    let config = Arc::new(tokio::sync::RwLock::new(cfg.clone()));
 
     let scheduler = Arc::new({
         let sched = TodoScheduler::new().await.unwrap_or_else(|e| {
             tracing::error!("Failed to create scheduler: {}. Exiting.", e);
             std::process::exit(1);
         });
-        if let Err(e) = sched.load_from_db(db.clone(), executor_registry.clone(), tx.clone(), task_manager.clone()).await {
+        if let Err(e) = sched.load_from_db(db.clone(), executor_registry.clone(), tx.clone(), task_manager.clone(), config.clone()).await {
             tracing::warn!("Failed to load scheduled tasks: {}", e);
         }
         if let Err(e) = sched.start().await {
@@ -245,8 +246,7 @@ async fn run_server(cli_port: Option<u16>) {
         sched
     });
 
-    let config = Arc::new(tokio::sync::RwLock::new(cfg.clone()));
-    let app = handlers::create_app(db, executor_registry, tx, scheduler, task_manager, config);
+    let app = handlers::create_app(db, executor_registry, tx, scheduler, task_manager, config.clone());
 
     let port = cli_port.unwrap_or(cfg.port);
 

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -489,6 +489,8 @@ pub struct UpdateConfigRequest {
     pub slash_command_rules: Option<Vec<crate::config::SlashCommandRule>>,
     pub default_response_todo_id: Option<i64>,
     pub history_message_max_age_secs: Option<u64>,
+    pub max_concurrent_todos: Option<u32>,
+    pub execution_timeout_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -6,6 +6,7 @@ use tokio_cron_scheduler::{Job, JobScheduler};
 use tracing::{error, info, warn};
 
 use crate::adapters::ExecutorRegistry;
+use crate::config::Config;
 use crate::db::Database;
 use crate::executor_service::{run_todo_execution, RunTodoExecutionRequest};
 use crate::handlers::ExecEvent;
@@ -31,6 +32,7 @@ impl TodoScheduler {
         executor_registry: Arc<ExecutorRegistry>,
         tx: broadcast::Sender<ExecEvent>,
         task_manager: Arc<TaskManager>,
+        app_config: Arc<tokio::sync::RwLock<Config>>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let todos = db.get_scheduler_todos().await?;
 
@@ -49,6 +51,7 @@ impl TodoScheduler {
                             todo.id,
                             config.clone(),
                             task_manager.clone(),
+                            app_config.clone(),
                         )
                         .await
                     {
@@ -72,6 +75,7 @@ impl TodoScheduler {
         todo_id: i64,
         cron_expr: String,
         task_manager: Arc<TaskManager>,
+        config: Arc<tokio::sync::RwLock<Config>>,
     ) -> Result<uuid::Uuid, Box<dyn std::error::Error + Send + Sync>> {
         // Validate cron expression
         if cron::Schedule::from_str(&cron_expr).is_err() {
@@ -93,6 +97,7 @@ impl TodoScheduler {
         let registry_clone = executor_registry.clone();
         let tx_clone = tx.clone();
         let tm_clone = task_manager.clone();
+        let config_clone = config.clone();
 
         info!("Creating job for todo {} with cron: {}", todo_id, cron_expr);
         let job = Job::new_async(&cron_expr, move |_uuid, _l| {
@@ -100,6 +105,7 @@ impl TodoScheduler {
             let registry = registry_clone.clone();
             let tx = tx_clone.clone();
             let tm = tm_clone.clone();
+            let cfg = config_clone.clone();
 
             Box::pin(async move {
                 match db.get_todo(todo_id).await {
@@ -116,6 +122,7 @@ impl TodoScheduler {
                             executor_registry: registry,
                             tx,
                             task_manager: tm,
+                            config: cfg,
                             todo_id,
                             message,
                             req_executor: executor,

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -6,6 +6,7 @@ use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
 use crate::adapters::ExecutorRegistry;
+use crate::config::Config;
 use crate::db::Database;
 use crate::executor_service::RunTodoExecutionRequest;
 use crate::handlers::execution::start_todo_execution;
@@ -38,6 +39,7 @@ pub struct MessageDebounce {
     executor_registry: Arc<ExecutorRegistry>,
     tx: broadcast::Sender<ExecEvent>,
     task_manager: Arc<TaskManager>,
+    config: Arc<tokio::sync::RwLock<Config>>,
 }
 
 impl MessageDebounce {
@@ -46,6 +48,7 @@ impl MessageDebounce {
         executor_registry: Arc<ExecutorRegistry>,
         tx: broadcast::Sender<ExecEvent>,
         task_manager: Arc<TaskManager>,
+        config: Arc<tokio::sync::RwLock<Config>>,
     ) -> Self {
         Self {
             entries: Arc::new(DashMap::new()),
@@ -53,6 +56,7 @@ impl MessageDebounce {
             executor_registry,
             tx,
             task_manager,
+            config,
         }
     }
 
@@ -78,6 +82,7 @@ impl MessageDebounce {
             let executor_registry = self.executor_registry.clone();
             let tx = self.tx.clone();
             let task_manager = self.task_manager.clone();
+            let config = self.config.clone();
             let bot_id = key.0;
             let chat_id = key.1.clone();
             let target_type = all_msgs
@@ -117,6 +122,7 @@ impl MessageDebounce {
                         executor_registry,
                         tx,
                         task_manager,
+                        config,
                         todo_id: last.todo_id,
                         message: last.todo_prompt.clone(),
                         req_executor: last.executor.clone(),

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1609,6 +1609,62 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       ),
       children: (
         <div style={{ padding: '8px 0' }}>
+          {/* 运行配置 */}
+          <Card
+            size="small"
+            title="运行配置"
+            style={{ marginBottom: 16 }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>最大并发数</span>
+                <InputNumber
+                  size="small"
+                  min={1}
+                  max={20}
+                  value={configForm.getFieldValue('max_concurrent_todos') ?? 1}
+                  onChange={(v) => {
+                    if (v) {
+                      configForm.setFieldsValue({ max_concurrent_todos: v });
+                    }
+                  }}
+                  style={{ width: 70 }}
+                />
+                <Tooltip title="同时运行的最大 Todo 数量，超出将排队等待">
+                  <InfoCircleOutlined style={{ color: 'var(--color-text-quaternary)', fontSize: 12 }} />
+                </Tooltip>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>超时时间(分钟)</span>
+                <InputNumber
+                  size="small"
+                  min={1}
+                  max={1440}
+                  style={{ width: 80 }}
+                  value={Math.round((configForm.getFieldValue('execution_timeout_secs') ?? 1800) / 60)}
+                  onChange={(v) => {
+                    if (v) {
+                      configForm.setFieldsValue({ execution_timeout_secs: v * 60 });
+                    }
+                  }}
+                />
+                <Tooltip title="单个对话执行的最大时长，超时将自动终止">
+                  <InfoCircleOutlined style={{ color: 'var(--color-text-quaternary)', fontSize: 12 }} />
+                </Tooltip>
+              </div>
+              <Button
+                size="small"
+                type="primary"
+                icon={<SaveOutlined />}
+                loading={configSaving}
+                onClick={handleSaveConfig}
+              >
+                保存
+              </Button>
+            </div>
+          </Card>
+
+          {/* 运行中任务列表 */}
           <div style={{ marginBottom: 12, display: 'flex', alignItems: 'center', gap: 8 }}>
             <Button
               danger

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -336,6 +336,8 @@ export interface Config {
   slash_command_rules?: SlashCommandRule[];
   default_response_todo_id?: number | null;
   history_message_max_age_secs?: number;
+  max_concurrent_todos?: number;
+  execution_timeout_secs?: number;
 }
 
 export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'joinai']);


### PR DESCRIPTION
## Summary
- Config 新增 `max_concurrent_todos`(默认3) 和 `execution_timeout_secs`(默认3600/1小时) 字段，持久化到 config.yaml
- 执行前检查全局并发数，超出限制拒绝执行（原来只能一个 todo 运行，现在支持配置并发数）
- 超时时间从配置读取替代硬编码 30 分钟，动态显示分钟数
- 运行管理 Tab 新增"运行配置"卡片，支持修改并保存

## Test plan
- [ ] 访问设置 -> 运行管理，验证"运行配置"卡片显示最大并发数和超时时间
- [ ] 修改配置值并保存，验证 config.yaml 更新
- [ ] 重启后验证配置值从 config.yaml 正确加载
- [ ] 并发执行超过 max_concurrent_todos 时验证拒绝提示

🤖 Generated with [CodeBuddy Code]