### PR TITLE
fix: 修复代码审查发现的3个最严重问题

### DIFF
--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -11,6 +11,13 @@ use crate::handlers::ExecEvent;
 use crate::models::{ExecutorType, ParsedLogEntry};
 use crate::task_manager::TaskManager;
 
+use std::sync::OnceLock;
+
+fn concurrency_gate() -> &'static tokio::sync::Mutex<()> {
+    static GATE: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    GATE.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
 fn send_event(tx: &broadcast::Sender<ExecEvent>, event: ExecEvent) {
     let _ = tx.send(event);
 }
@@ -72,6 +79,10 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
         let cfg = config.read().await;
         (cfg.max_concurrent_todos, cfg.execution_timeout_secs)
     };
+
+    // Global concurrency gate: 确保并发数检查和 DB 状态写入是原子的，
+    // 防止 TOCTOU 竞态导致超额执行不同的 todo
+    let _concurrency_guard = concurrency_gate().lock().await;
 
     // Get todo to read stored executor and check concurrency
     let todo = match db.get_todo(todo_id).await {
@@ -288,6 +299,9 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
             record_id: Some(record_id),
         };
     }
+
+    // 释放并发门控 — 从此刻起 DB 状态已一致，后续请求会看到 Running 状态
+    drop(_concurrency_guard);
 
     let task_id_return = task_id.clone();
     let db_clone = db.clone();

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -249,7 +249,20 @@ pub async fn force_fail_execution_handler(
 
     // Try to cancel in-memory task if it exists
     if let Some(task_id) = &record.task_id {
-        state.task_manager.cancel(task_id).await;
+        let cancelled = state.task_manager.cancel(task_id).await;
+        if !cancelled {
+            // 任务已在 task_manager 中不存在，说明 spawned task 已自行完成清理
+            // 此时不应再写入 DB，避免与 spawned task 的最终状态更新产生竞态
+            tracing::warn!(
+                "Task {} was not found in task manager for force-fail (may have already finished its cleanup), \
+                 skipping DB update to avoid race condition",
+                task_id
+            );
+            return Ok(ApiResponse::ok(()));
+        }
+        // 取消成功时，等待一小段时间确保 spawn 的 task 收到取消信号并进入其取消处理分支
+        // 从而避免与 force_fail_execution_record 同时写入造成竞态
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     }
 
     state

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -156,6 +156,35 @@ pub async fn update_todo(
         .await
         .map_err(AppError::from)?;
 
+    // 同步更新 scheduler 中的定时任务（如果 scheduler_enabled 或 scheduler_config 发生了变化）
+    if req.scheduler_enabled.is_some() || req.scheduler_config.is_some() {
+        let final_enabled = req.scheduler_enabled.unwrap_or(current.scheduler_enabled);
+        let final_config = scheduler_config.clone()
+            .or_else(|| current.scheduler_config.clone())
+            .filter(|s| !s.is_empty());
+        if final_enabled {
+            if let Some(cfg) = &final_config {
+                if let Err(e) = state
+                    .scheduler
+                    .upsert_task(
+                        state.db.clone(),
+                        state.executor_registry.clone(),
+                        state.tx.clone(),
+                        id,
+                        cfg.clone(),
+                        state.task_manager.clone(),
+                        state.config.clone(),
+                    )
+                    .await
+                {
+                    tracing::warn!("Failed to update scheduler task for todo {}: {}", id, e);
+                }
+            }
+        } else {
+            state.scheduler.remove_task_for_todo(id).await;
+        }
+    }
+
     let todo = state.require_todo(id).await?;
     Ok(ApiResponse::ok(todo))
 }

--- a/backend/tests/api_integration_test.rs
+++ b/backend/tests/api_integration_test.rs
@@ -25,15 +25,14 @@ async fn create_test_app() -> axum::Router {
 
     let (tx, _rx) = broadcast::channel(100);
     let task_manager = Arc::new(TaskManager::new());
+    let config = Arc::new(tokio::sync::RwLock::new(Config::default()));
 
     let scheduler = Arc::new(TodoScheduler::new().await.unwrap());
     scheduler
-        .load_from_db(db.clone(), executor_registry.clone(), tx.clone(), task_manager.clone())
+        .load_from_db(db.clone(), executor_registry.clone(), tx.clone(), task_manager.clone(), config.clone())
         .await
         .unwrap();
     scheduler.start().await.unwrap();
-
-    let config = Arc::new(tokio::sync::RwLock::new(Config::default()));
 
     create_app(db, executor_registry, tx, scheduler, task_manager, config)
 }


### PR DESCRIPTION
## 问题列表

### 1. force_fail_execution_handler 竞态条件（数据损坏风险）
**严重性**: 高
**描述**: `force_fail_execution_handler` 在调用 `task_manager.cancel()` 后无条件写入 DB，即使 cancel 返回 false（表示 spawned task 已自行完成清理）。这与 spawned task 的最终状态更新产生竞态，可能造成数据覆盖或不一致。而 `stop_execution_handler` 已有正确处理逻辑。
**修复**: 与 `stop_execution_handler` 保持一致，cancel 失败时跳过 DB 写入，并加入 200ms 等待确保取消信号送达。

### 2. 全局并发数检查存在 TOCTOU 竞态（超额执行）
**严重性**: 中-高
**描述**: `run_todo_execution` 中的 `get_running_todos() >= max_concurrent` 检查和 `start_todo_execution()` DB 写入之间存在时间窗口。两个请求同时到达时，可能都通过检查然后都开始执行，绕过并发限制。
**修复**: 在 `executor_service` 中添加全局 `concurrency_gate()`（`OnceLock<Mutex>`），将并发数检查到 DB 状态写入的整个序列置于互斥保护下，保证原子性。

### 3. update_todo 更新 scheduler 配置后未同步定时任务（功能 bug）
**严重性**: 中
**描述**: 通过 REST API `PATCH /todos/:id` 更新 `scheduler_config` 或 `scheduler_enabled` 时，仅写入了 DB，但未同步更新 `TodoScheduler` 中运行的定时任务。需要重启服务才能使新配置生效。
**修复**: 更新 scheduler 相关字段后，调用 `state.scheduler.upsert_task()` 或 `remove_task_for_todo()` 来同步调度器状态。

## 测试
- `cargo check`: 通过
- `cargo test --test api_integration_test`: 27/27 通过
- 预存在的 `test_cron_weekday_schedule` 测试失败（时区相关问题，与本 PR 无关）

## 变更文件
- `src/executor_service.rs`: +14 行（新增 concurrency_gate 和 guard 保护）
- `src/handlers/execution.rs`: +15/-1 行（force_fail 竞态修复）
- `src/handlers/todo.rs`: +29 行（scheduler 同步修复）
- `tests/api_integration_test.rs`: -2/+3 行（测试修复）