### PR TITLE
fix: 修正配置注释默认值并统一代码缩进风格

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -47,9 +47,9 @@ pub struct Config {
     pub default_response_todo_id: Option<i64>,
     /// 历史消息最大处理年龄（秒），超过此时间的历史消息拉取后标记跳过不处理（默认 600 = 10 分钟）
     pub history_message_max_age_secs: u64,
-    /// 最大并发执行数（默认 1，即同一时间只能运行一个 Todo）
+    /// 最大并发执行数（默认 3）
     pub max_concurrent_todos: u32,
-    /// 执行超时时间（秒，默认 1800 = 30 分钟），超过此时间将自动终止进程
+    /// 执行超时时间（秒，默认 3600 = 60 分钟），超过此时间将自动终止进程
     pub execution_timeout_secs: u64,
 }
 

--- a/backend/src/db/entity/mod.rs
+++ b/backend/src/db/entity/mod.rs
@@ -15,19 +15,19 @@ pub mod todo_templates;
 pub mod todos;
 
 pub mod prelude {
-  pub use super::agent_bots::Entity as AgentBots;
-  pub use super::execution_logs::Entity as ExecutionLogs;
-  pub use super::execution_records::Entity as ExecutionRecords;
-  pub use super::executors::Entity as Executors;
-  pub use super::feishu_homes::Entity as FeishuHomes;
-  pub use super::feishu_history_chats::Entity as FeishuHistoryChats;
-  pub use super::feishu_messages::Entity as FeishuMessages;
-  pub use super::feishu_push_targets::Entity as FeishuPushTargets;
-  pub use super::feishu_response_config::Entity as FeishuResponseConfig;
-  pub use super::feishu_group_whitelist::Entity as FeishuGroupWhitelist;
-  pub use super::project_directories::Entity as ProjectDirectories;
-  pub use super::tags::Entity as Tags;
-  pub use super::todo_tags::Entity as TodoTags;
-  pub use super::todo_templates::Entity as TodoTemplates;
-  pub use super::todos::Entity as Todos;
+    pub use super::agent_bots::Entity as AgentBots;
+    pub use super::execution_logs::Entity as ExecutionLogs;
+    pub use super::execution_records::Entity as ExecutionRecords;
+    pub use super::executors::Entity as Executors;
+    pub use super::feishu_homes::Entity as FeishuHomes;
+    pub use super::feishu_history_chats::Entity as FeishuHistoryChats;
+    pub use super::feishu_messages::Entity as FeishuMessages;
+    pub use super::feishu_push_targets::Entity as FeishuPushTargets;
+    pub use super::feishu_response_config::Entity as FeishuResponseConfig;
+    pub use super::feishu_group_whitelist::Entity as FeishuGroupWhitelist;
+    pub use super::project_directories::Entity as ProjectDirectories;
+    pub use super::tags::Entity as Tags;
+    pub use super::todo_tags::Entity as TodoTags;
+    pub use super::todo_templates::Entity as TodoTemplates;
+    pub use super::todos::Entity as Todos;
 }


### PR DESCRIPTION
## Summary

修复最近提交（c2fe276）中引入的两个小问题：

1. **配置注释与实际默认值不一致**：`max_concurrent_todos` 和 `execution_timeout_secs` 的注释与实际默认值不匹配
2. **代码缩进不一致**：`db/entity/mod.rs` 中 `prelude` 模块使用了 2 空格缩进而非项目标准的 4 空格

## Changes

- `backend/src/config.rs`：修正注释中的默认值描述
- `backend/src/db/entity/mod.rs`：将 prelude 模块缩进从 2 空格改为 4 空格

## Test plan

- [x] `cargo check` 通过