### PR TITLE
feat: TODO 标题前增加灰色 #数字 前缀

### DIFF
--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -254,6 +254,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
         style={{ borderTop: `3px solid ${column.color}` }}
       >
         <TodoCard
+          id={todo.id}
           title={todo.title}
           prompt={todo.prompt}
           resultText={resultText}

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -132,6 +132,7 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
         bodyStyle={{ padding: 0 }}
       >
         <TodoCard
+          id={item.todo_id}
           title={item.title}
           prompt={item.prompt}
           resultText={result}

--- a/frontend/src/components/TodoCard.tsx
+++ b/frontend/src/components/TodoCard.tsx
@@ -29,6 +29,7 @@ function formatDuration(ms: number): string {
 
 export interface TodoCardProps {
   /** Core content */
+  id: number;
   title: string;
   prompt: string | null;
   resultText: string | null;
@@ -72,6 +73,7 @@ export interface TodoCardProps {
 /* ─── Component ─── */
 
 export function TodoCard({
+  id,
   title,
   prompt,
   resultText,
@@ -100,7 +102,7 @@ export function TodoCard({
             onClick={onSelectTodo}
             title={title}
           >
-            {title}
+            <span style={{ color: '#999', marginRight: 4 }}>#{id}</span>{title}
           </span>
           <span>
             {isSuccess ? (


### PR DESCRIPTION
## Summary
- 为 TodoCard 添加 `id` 属性
- 在标题前显示灰色的 `#数字` 前缀，便于快速识别 TODO 编号
- 修改了 KanbanBoard、MemorialBoard 和 TodoCard 三个文件

## Test plan
- [x] 前端构建通过
- [x] 需要人工验证 UI 效果

## 关联 Issue
Fixes #267