### PR TITLE
fix: 修复孤儿任务导致并发限制检查错误

### DIFF
--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -77,28 +77,41 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     let todo = match db.get_todo(todo_id).await {
         Ok(Some(t)) => {
             // 检查同一个 todo 是否正在执行中，防止重复执行
+            // 不仅检查数据库状态，还要确认 task_manager 中是否真的有这个 todo 在运行
+            // 如果数据库状态是 Running 但 task_manager 中没有，说明状态异常（可能是异常退出遗留），允许重新执行
+            let running_tasks = task_manager.get_all_task_infos().await;
+            let is_orphan = t.status == crate::models::TodoStatus::Running
+                && !running_tasks.iter().any(|task| task.todo_id == todo_id);
             if t.status == crate::models::TodoStatus::Running {
-                tracing::warn!("Todo {} is already running, skipping execution", todo_id);
-                task_manager.remove(&task_id).await;
-                send_event(
-                    &tx,
-                    ExecEvent::Finished {
-                        task_id: task_id.clone(),
-                        todo_id,
-                        todo_title: t.title.clone(),
-                        executor: "".to_string(),
-                        success: false,
-                        result: Some(format!("Todo {} is already running", todo_id)),
-                    },
-                );
-                return ExecutionResult {
-                    task_id,
-                    record_id: None,
-                };
+                if running_tasks.iter().any(|task| task.todo_id == todo_id) {
+                    tracing::warn!("Todo {} is already running in task_manager, skipping execution", todo_id);
+                    task_manager.remove(&task_id).await;
+                    send_event(
+                        &tx,
+                        ExecEvent::Finished {
+                            task_id: task_id.clone(),
+                            todo_id,
+                            todo_title: t.title.clone(),
+                            executor: "".to_string(),
+                            success: false,
+                            result: Some(format!("Todo {} is already running", todo_id)),
+                        },
+                    );
+                    return ExecutionResult {
+                        task_id,
+                        record_id: None,
+                    };
+                } else if is_orphan {
+                    tracing::warn!(
+                        "Todo {} has status=Running in DB but not in task_manager (orphan state), will allow execution",
+                        todo_id
+                    );
+                }
             }
 
-            // 检查全局并发数是否已达上限
+            // 检查全局并发数是否已达上限（排除孤儿任务，因为它们实际上并未运行）
             let running_count = db.get_running_todos().await.map(|v| v.len()).unwrap_or(0);
+            let running_count = if is_orphan { running_count.saturating_sub(1) } else { running_count };
             if running_count >= max_concurrent as usize {
                 tracing::warn!(
                     "Concurrent limit reached ({}/{}), rejecting todo {}",

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -112,16 +112,29 @@ pub async fn execute_handler(
         .ok_or_else(|| AppError::BadRequest(format!("Todo {} not found", req.todo_id)))?;
 
     // 检查 todo 是否正在执行中，防止重复执行造成状态混乱
+    // 不仅检查数据库状态，还要确认 task_manager 中是否真的有这个 todo 在运行
+    // 如果数据库状态是 Running 但 task_manager 中没有，说明状态异常（可能是异常退出遗留），允许重新执行
+    let running_tasks = state.task_manager.get_all_task_infos().await;
+    let is_orphan = todo.status == crate::models::TodoStatus::Running
+        && !running_tasks.iter().any(|task| task.todo_id == req.todo_id);
     if todo.status == crate::models::TodoStatus::Running {
-        return Err(AppError::BadRequest(format!(
-            "Todo {} is already running. Please stop the current execution first.",
-            req.todo_id
-        )));
+        if running_tasks.iter().any(|task| task.todo_id == req.todo_id) {
+            return Err(AppError::BadRequest(format!(
+                "Todo {} is already running. Please stop the current execution first.",
+                req.todo_id
+            )));
+        } else if is_orphan {
+            tracing::warn!(
+                "Todo {} has status=Running in DB but not in task_manager (orphan state), will allow execution",
+                req.todo_id
+            );
+        }
     }
 
-    // 检查全局并发数是否已达上限
+    // 检查全局并发数是否已达上限（排除孤儿任务，因为它们实际上并未运行）
     let max_concurrent = state.config.read().await.max_concurrent_todos;
     let running_count = state.db.get_running_todos().await.map(|v| v.len()).unwrap_or(0);
+    let running_count = if is_orphan { running_count.saturating_sub(1) } else { running_count };
     if running_count >= max_concurrent as usize {
         return Err(AppError::BadRequest(format!(
             "Concurrent limit reached ({}/{}). Please wait for a running task to finish.",
@@ -307,16 +320,29 @@ pub async fn resume_execution_handler(
         .ok_or(AppError::NotFound)?;
 
     // 检查 todo 是否正在执行中，防止重复执行造成状态混乱
+    // 不仅检查数据库状态，还要确认 task_manager 中是否真的有这个 todo 在运行
+    // 如果数据库状态是 Running 但 task_manager 中没有，说明状态异常（可能是异常退出遗留），允许重新执行
+    let running_tasks = state.task_manager.get_all_task_infos().await;
+    let is_orphan = todo.status == crate::models::TodoStatus::Running
+        && !running_tasks.iter().any(|task| task.todo_id == todo_id);
     if todo.status == crate::models::TodoStatus::Running {
-        return Err(AppError::BadRequest(format!(
-            "Todo {} is already running. Cannot resume.",
-            todo_id
-        )));
+        if running_tasks.iter().any(|task| task.todo_id == todo_id) {
+            return Err(AppError::BadRequest(format!(
+                "Todo {} is already running. Cannot resume.",
+                todo_id
+            )));
+        } else if is_orphan {
+            tracing::warn!(
+                "Todo {} has status=Running in DB but not in task_manager (orphan state), will allow resume",
+                todo_id
+            );
+        }
     }
 
-    // 检查全局并发数是否已达上限
+    // 检查全局并发数是否已达上限（排除孤儿任务，因为它们实际上并未运行）
     let max_concurrent = state.config.read().await.max_concurrent_todos;
     let running_count = state.db.get_running_todos().await.map(|v| v.len()).unwrap_or(0);
+    let running_count = if is_orphan { running_count.saturating_sub(1) } else { running_count };
     if running_count >= max_concurrent as usize {
         return Err(AppError::BadRequest(format!(
             "Concurrent limit reached ({}/{}). Please wait for a running task to finish.",


### PR DESCRIPTION
## Summary
- 修复任务异常退出后数据库状态残留为 Running 但实际无任务运行导致的并发计数错误
- 如果数据库状态是 Running 但 task_manager 中没有这个 todo_id，说明是孤儿状态，允许重新执行

## Test plan
- [ ] 验证任务异常退出后状态清理正常
- [ ] 验证并发数限制正确工作