### PR TITLE
fix: 修复继续对话执行记录展开时页面崩溃 (#272)

### DIFF
--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -28,6 +28,9 @@ export function parseLogsToMessages(logs: LogEntry[]): ChatMessage[] {
   let isCollectingTool = false;
 
   for (const log of logs) {
+    // Skip logs with null/undefined content to prevent crashes
+    if (log.content == null) continue;
+
     switch (log.type) {
       case 'user':
         messages.push({ role: 'user', content: log.content, timestamp: log.timestamp });

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -917,7 +917,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                               <span style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 10, color: 'var(--color-primary)', fontWeight: 500 }}>
                                 <LinkOutlined style={{ fontSize: 10 }} />
                                 {record.resume_message ? (
-                                  <span style={{ color: 'var(--color-text-secondary)', fontWeight: 400 }}>{record.resume_message.length > 30 ? record.resume_message.substring(0, 30) + '...' : record.resume_message}</span>
+                                  <span style={{ color: 'var(--color-text-secondary)', fontWeight: 400 }}>{String(record.resume_message).length > 30 ? String(record.resume_message).substring(0, 30) + '...' : record.resume_message}</span>
                                 ) : (
                                   <span>继续对话</span>
                                 )}
@@ -1026,7 +1026,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                             <>
                               <span style={{ color: 'var(--color-border)' }}>·</span>
                               <span style={{ color: 'var(--color-text-secondary)', fontStyle: 'italic' }}>
-                                "{record.resume_message.length > 40 ? record.resume_message.substring(0, 40) + '...' : record.resume_message}"
+                                "{String(record.resume_message).length > 40 ? String(record.resume_message).substring(0, 40) + '...' : record.resume_message}"
                               </span>
                             </>
                           )}
@@ -1514,7 +1514,7 @@ function ContinuationLogsLoader({ record, viewMode, onRefresh, onViewModeChange 
           {logs.map((log, i) => (
             <div key={i} style={{ marginBottom: 3, display: 'flex', gap: 6 }}>
               <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
-              <span>{log.content}</span>
+              <span>{log.content ?? ''}</span>
             </div>
           ))}
         </div>
@@ -1564,7 +1564,7 @@ function ContinuationLogView({ logs, isRunning, viewMode, onRefresh, onViewModeC
                 <span style={{ color: logTypeColors[log.type || ''] || 'var(--log-text)' }}>
                   [{logTypeLabels[log.type || ''] || log.type}]
                 </span>
-                <span>{log.content}</span>
+                <span>{log.content ?? ''}</span>
               </div>
             ))
           )}


### PR DESCRIPTION
## Summary
- 修复继续对话产生的执行记录，点击标题展开时导致页面崩溃的问题

## Problem
Issue #272 描述的问题：继续对话产生的执行记录，点击标题展开时，导致页面崩溃

## Root Cause
1. `parseLogsToMessages` 函数没有处理 `log.content` 为 `null` 的情况
2. `resume_message` 字段可能为 `null`，直接调用 `.length` 会报错
3. `log.content` 渲染时没有处理 `null` 值

## Fix
1. 在 `parseLogsToMessages` 开头添加 null 检查，跳过内容为空的日志
2. 将 `resume_message` 转换为字符串后再调用 `.length`
3. 将 `log.content` 渲染改为使用空字符串替代 null 值

## Test Plan
- [ ] 构建成功
- [ ] 页面加载正常
- [ ] 继续对话执行记录展开功能正常

## Related Issue
Closes #272