### PR TITLE
fix: 修复并发限制逻辑

### DIFF
--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -76,46 +76,22 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     // Get todo to read stored executor and check concurrency
     let todo = match db.get_todo(todo_id).await {
         Ok(Some(t)) => {
-            // 检查同一个 todo 是否正在执行中，防止重复执行
-            // 不仅检查数据库状态，还要确认 task_manager 中是否真的有这个 todo 在运行
-            // 如果数据库状态是 Running 但 task_manager 中没有，说明状态异常（可能是异常退出遗留），允许重新执行
-            let running_tasks = task_manager.get_all_task_infos().await;
-            let is_orphan = t.status == crate::models::TodoStatus::Running
-                && !running_tasks.iter().any(|task| task.todo_id == todo_id);
-            if t.status == crate::models::TodoStatus::Running {
-                if running_tasks.iter().any(|task| task.todo_id == todo_id) {
-                    tracing::warn!("Todo {} is already running in task_manager, skipping execution", todo_id);
-                    task_manager.remove(&task_id).await;
-                    send_event(
-                        &tx,
-                        ExecEvent::Finished {
-                            task_id: task_id.clone(),
-                            todo_id,
-                            todo_title: t.title.clone(),
-                            executor: "".to_string(),
-                            success: false,
-                            result: Some(format!("Todo {} is already running", todo_id)),
-                        },
-                    );
+            // 检查该 todo 下正在执行的记录数量是否已达并发上限
+            let running_records = match db.get_running_execution_records().await {
+                Ok(records) => records,
+                Err(e) => {
+                    tracing::error!("Failed to get running execution records: {}", e);
                     return ExecutionResult {
                         task_id,
                         record_id: None,
                     };
-                } else if is_orphan {
-                    tracing::warn!(
-                        "Todo {} has status=Running in DB but not in task_manager (orphan state), will allow execution",
-                        todo_id
-                    );
                 }
-            }
-
-            // 检查全局并发数是否已达上限（排除孤儿任务，因为它们实际上并未运行）
-            let running_count = db.get_running_todos().await.map(|v| v.len()).unwrap_or(0);
-            let running_count = if is_orphan { running_count.saturating_sub(1) } else { running_count };
-            if running_count >= max_concurrent as usize {
+            };
+            let running_count_for_todo = running_records.iter().filter(|r| r.todo_id == todo_id).count();
+            if running_count_for_todo >= max_concurrent as usize {
                 tracing::warn!(
-                    "Concurrent limit reached ({}/{}), rejecting todo {}",
-                    running_count, max_concurrent, todo_id
+                    "Todo {} has {} execution(s) still running (limit: {}), rejecting",
+                    todo_id, running_count_for_todo, max_concurrent
                 );
                 task_manager.remove(&task_id).await;
                 send_event(
@@ -127,8 +103,8 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                         executor: "".to_string(),
                         success: false,
                         result: Some(format!(
-                            "Concurrent limit reached ({}/{}), please wait",
-                            running_count, max_concurrent
+                            "Todo {} has {} execution(s) still running (limit: {}). Please stop them first.",
+                            todo_id, running_count_for_todo, max_concurrent
                         )),
                     },
                 );

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -77,6 +77,8 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     let todo = match db.get_todo(todo_id).await {
         Ok(Some(t)) => {
             // 检查该 todo 下正在执行的记录数量是否已达并发上限
+            // 需要过滤掉孤儿记录：状态为 running 但 task_manager 中没有对应 task
+            let running_tasks = task_manager.get_all_task_infos().await;
             let running_records = match db.get_running_execution_records().await {
                 Ok(records) => records,
                 Err(e) => {
@@ -87,7 +89,18 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                     };
                 }
             };
-            let running_count_for_todo = running_records.iter().filter(|r| r.todo_id == todo_id).count();
+            let running_count_for_todo = running_records
+                .iter()
+                .filter(|r| {
+                    // 排除僵尸记录：状态为 running 但 task_manager 中没有对应 task
+                    if let Some(task_id) = &r.task_id {
+                        running_tasks.iter().any(|t| t.task_id == *task_id)
+                    } else {
+                        false
+                    }
+                })
+                .filter(|r| r.todo_id == todo_id)
+                .count();
             if running_count_for_todo >= max_concurrent as usize {
                 tracing::warn!(
                     "Todo {} has {} execution(s) still running (limit: {}), rejecting",

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -111,34 +111,14 @@ pub async fn execute_handler(
         .await?
         .ok_or_else(|| AppError::BadRequest(format!("Todo {} not found", req.todo_id)))?;
 
-    // 检查 todo 是否正在执行中，防止重复执行造成状态混乱
-    // 不仅检查数据库状态，还要确认 task_manager 中是否真的有这个 todo 在运行
-    // 如果数据库状态是 Running 但 task_manager 中没有，说明状态异常（可能是异常退出遗留），允许重新执行
-    let running_tasks = state.task_manager.get_all_task_infos().await;
-    let is_orphan = todo.status == crate::models::TodoStatus::Running
-        && !running_tasks.iter().any(|task| task.todo_id == req.todo_id);
-    if todo.status == crate::models::TodoStatus::Running {
-        if running_tasks.iter().any(|task| task.todo_id == req.todo_id) {
-            return Err(AppError::BadRequest(format!(
-                "Todo {} is already running. Please stop the current execution first.",
-                req.todo_id
-            )));
-        } else if is_orphan {
-            tracing::warn!(
-                "Todo {} has status=Running in DB but not in task_manager (orphan state), will allow execution",
-                req.todo_id
-            );
-        }
-    }
-
-    // 检查全局并发数是否已达上限（排除孤儿任务，因为它们实际上并未运行）
+    // 检查该 todo 下正在执行的记录数量是否已达并发上限
     let max_concurrent = state.config.read().await.max_concurrent_todos;
-    let running_count = state.db.get_running_todos().await.map(|v| v.len()).unwrap_or(0);
-    let running_count = if is_orphan { running_count.saturating_sub(1) } else { running_count };
-    if running_count >= max_concurrent as usize {
+    let running_records = state.db.get_running_execution_records().await?;
+    let running_count_for_todo = running_records.iter().filter(|r| r.todo_id == req.todo_id).count();
+    if running_count_for_todo >= max_concurrent as usize {
         return Err(AppError::BadRequest(format!(
-            "Concurrent limit reached ({}/{}). Please wait for a running task to finish.",
-            running_count, max_concurrent
+            "Todo {} has {} execution(s) still running (limit: {}). Please stop them first.",
+            req.todo_id, running_count_for_todo, max_concurrent
         )));
     }
 
@@ -319,34 +299,14 @@ pub async fn resume_execution_handler(
         .await?
         .ok_or(AppError::NotFound)?;
 
-    // 检查 todo 是否正在执行中，防止重复执行造成状态混乱
-    // 不仅检查数据库状态，还要确认 task_manager 中是否真的有这个 todo 在运行
-    // 如果数据库状态是 Running 但 task_manager 中没有，说明状态异常（可能是异常退出遗留），允许重新执行
-    let running_tasks = state.task_manager.get_all_task_infos().await;
-    let is_orphan = todo.status == crate::models::TodoStatus::Running
-        && !running_tasks.iter().any(|task| task.todo_id == todo_id);
-    if todo.status == crate::models::TodoStatus::Running {
-        if running_tasks.iter().any(|task| task.todo_id == todo_id) {
-            return Err(AppError::BadRequest(format!(
-                "Todo {} is already running. Cannot resume.",
-                todo_id
-            )));
-        } else if is_orphan {
-            tracing::warn!(
-                "Todo {} has status=Running in DB but not in task_manager (orphan state), will allow resume",
-                todo_id
-            );
-        }
-    }
-
-    // 检查全局并发数是否已达上限（排除孤儿任务，因为它们实际上并未运行）
+    // 检查该 todo 下正在执行的记录数量是否已达并发上限
     let max_concurrent = state.config.read().await.max_concurrent_todos;
-    let running_count = state.db.get_running_todos().await.map(|v| v.len()).unwrap_or(0);
-    let running_count = if is_orphan { running_count.saturating_sub(1) } else { running_count };
-    if running_count >= max_concurrent as usize {
+    let running_records = state.db.get_running_execution_records().await?;
+    let running_count_for_todo = running_records.iter().filter(|r| r.todo_id == todo_id).count();
+    if running_count_for_todo >= max_concurrent as usize {
         return Err(AppError::BadRequest(format!(
-            "Concurrent limit reached ({}/{}). Please wait for a running task to finish.",
-            running_count, max_concurrent
+            "Todo {} has {} execution(s) still running (limit: {}). Cannot resume.",
+            todo_id, running_count_for_todo, max_concurrent
         )));
     }
 

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -112,9 +112,22 @@ pub async fn execute_handler(
         .ok_or_else(|| AppError::BadRequest(format!("Todo {} not found", req.todo_id)))?;
 
     // 检查该 todo 下正在执行的记录数量是否已达并发上限
+    // 需要过滤掉孤儿记录：状态为 running 但 task_manager 中没有对应 task
     let max_concurrent = state.config.read().await.max_concurrent_todos;
+    let running_tasks = state.task_manager.get_all_task_infos().await;
     let running_records = state.db.get_running_execution_records().await?;
-    let running_count_for_todo = running_records.iter().filter(|r| r.todo_id == req.todo_id).count();
+    let running_count_for_todo = running_records
+        .iter()
+        .filter(|r| {
+            // 排除僵尸记录：状态为 running 但 task_manager 中没有对应 task
+            if let Some(task_id) = &r.task_id {
+                running_tasks.iter().any(|t| t.task_id == *task_id)
+            } else {
+                false
+            }
+        })
+        .filter(|r| r.todo_id == req.todo_id)
+        .count();
     if running_count_for_todo >= max_concurrent as usize {
         return Err(AppError::BadRequest(format!(
             "Todo {} has {} execution(s) still running (limit: {}). Please stop them first.",
@@ -300,9 +313,22 @@ pub async fn resume_execution_handler(
         .ok_or(AppError::NotFound)?;
 
     // 检查该 todo 下正在执行的记录数量是否已达并发上限
+    // 需要过滤掉孤儿记录：状态为 running 但 task_manager 中没有对应 task
     let max_concurrent = state.config.read().await.max_concurrent_todos;
+    let running_tasks = state.task_manager.get_all_task_infos().await;
     let running_records = state.db.get_running_execution_records().await?;
-    let running_count_for_todo = running_records.iter().filter(|r| r.todo_id == todo_id).count();
+    let running_count_for_todo = running_records
+        .iter()
+        .filter(|r| {
+            // 排除僵尸记录：状态为 running 但 task_manager 中没有对应 task
+            if let Some(task_id) = &r.task_id {
+                running_tasks.iter().any(|t| t.task_id == *task_id)
+            } else {
+                false
+            }
+        })
+        .filter(|r| r.todo_id == todo_id)
+        .count();
     if running_count_for_todo >= max_concurrent as usize {
         return Err(AppError::BadRequest(format!(
             "Todo {} has {} execution(s) still running (limit: {}). Cannot resume.",


### PR DESCRIPTION
## Summary
- 并发限制逻辑修改：现在检查**该todo下**正在执行的记录数量，而非todo自身的状态
- 设置max_concurrent=3时，该todo下第4个执行会被拦截

## 修改内容
- `execute_handler`: 改为统计todo下running状态的执行记录数
- `resume_handler`: 同样逻辑
- `run_todo_execution`: 同样逻辑

## Test plan
- [ ] 设置max_concurrent=3
- [ ] 对同一todo执行3次，确认都能成功
- [ ] 对同一todo执行第4次，确认被拦截并提示错误