### PR TITLE
feat: 在 TodoList 标题前显示灰色小号 #id

### DIFF
--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -208,7 +208,7 @@ export function TodoList({ onOpenCreateModal, onSelectTodo, onShowDashboard, onS
                         className="todo-item-title"
                         style={{ opacity: isCompleted ? 0.6 : 1 }}
                       >
-                        {todo.title}
+                        <span style={{ color: '#999', marginRight: 4, fontSize: 13 }}>#{todo.id}</span>{todo.title}
                       </div>
                       <ExecutorBadge executor={todo.executor || 'claudecode'} />
                     </div>


### PR DESCRIPTION
## 改动内容

在 TodoList（左侧任务列表）的标题前增加  前缀，样式与 KanbanBoard 的 TodoCard 保持一致：

- 颜色: （灰色）
- 字号: （比标题 15px 小）
- 效果不抢眼，能看见但不喧宾夺主

## 验证

- 后端重启后通过浏览器 console 验证，输出：

## 相关

- Issue #277