### PR TITLE
feat: 显示TODO标题时前面增加#数字前缀

### DIFF
--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -767,7 +767,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
         {/* Row 1: Title + Action Buttons */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
           <StatusPicker value={selectedTodo.status} onChange={handleStatusChange} disabled={isExecuting} />
-          <h2 className="card-title" style={{ margin: 0, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{selectedTodo.title}</h2>
+          <h2 className="card-title" style={{ margin: 0, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}><span style={{ color: '#999', marginRight: 4, fontSize: '0.9em' }}>#{selectedTodo.id}</span>{selectedTodo.title}</h2>
           <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
             <Button type="text" icon={<SettingOutlined />} onClick={() => setSettingsOpen(true)} className="icon-btn" aria-label="任务设置" />
             <Button type="text" icon={<EditOutlined />} onClick={() => setIsEditing(true)} className="icon-btn" aria-label="编辑任务" />

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -208,7 +208,7 @@ export function TodoList({ onOpenCreateModal, onSelectTodo, onShowDashboard, onS
                         className="todo-item-title"
                         style={{ opacity: isCompleted ? 0.6 : 1 }}
                       >
-                        {todo.title}
+                        <span style={{ color: '#999', marginRight: 4, fontSize: '0.9em' }}>#{todo.id}</span>{todo.title}
                       </div>
                       <ExecutorBadge executor={todo.executor || 'claudecode'} />
                     </div>


### PR DESCRIPTION
## Summary
- 在 TodoList 和 TodoDetail 中为 TODO 标题添加 #id 前缀
- 使用灰色(#999)、小号字体(0.9em)，不抢眼但可见

## Test plan
- [ ] 验证 TodoList 中 TODO 标题显示 #数字 前缀
- [ ] 验证 TodoDetail 中标题显示 #数字 前缀
- [ ] 确认样式为灰色、小号字体

## Related Issue
Closes #277