### PR TITLE
fix: 继续对话打开时保持对话框为空

### DIFF
--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -605,7 +605,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
 
   const handleOpenResume = (record: ExecutionRecord) => {
     setResumeRecordId(record.id);
-    setResumeMessage(selectedTodo?.prompt || selectedTodo?.title || '');
+    setResumeMessage('');
     setResumeModalOpen(true);
   };
 


### PR DESCRIPTION
## Summary
- 修复继续对话功能打开时，对话框预填充prompt内容的问题
- 现在打开继续对话时，对话框保持为空

## Test plan
- [ ] 打开一个有执行记录的任务
- [ ] 点击继续对话按钮
- [ ] 验证对话框为空，不预填任何内容

Fixes #270