### PR TITLE
fix: 修复 server 重启后 running 状态日志无法显示

### DIFF
--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1361,11 +1361,11 @@ function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, o
   // 懒加载日志（新记录没有旧字段数据时从新表加载）
   const [loadedLogs, setLoadedLogs] = useState<LogEntry[] | null>(null);
   useEffect(() => {
-    if (restLogs.length > 0 || isRunning || loadedLogs !== null) return;
+    if (restLogs.length > 0 || loadedLogs !== null) return;
     db.getExecutionLogs(record.id, 1, 200)
       .then(r => setLoadedLogs(r.logs))
       .catch(() => setLoadedLogs([]));
-  }, [record.id, restLogs.length, isRunning, loadedLogs]);
+  }, [record.id, restLogs.length, loadedLogs]);
 
   const displayLogs = liveLogs && liveLogs.length > 0 ? liveLogs :
     restLogs.length > 0 ? restLogs :
@@ -1594,11 +1594,11 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
   const mainRestLogs = parseLogs(mainRecord);
   const [mainLoadedLogs, setMainLoadedLogs] = useState<LogEntry[] | null>(null);
   useEffect(() => {
-    if (mainRestLogs.length > 0 || mainRecord.status === 'running' || mainLoadedLogs !== null) return;
+    if (mainRestLogs.length > 0 || mainLoadedLogs !== null) return;
     db.getExecutionLogs(mainRecord.id, 1, 200)
       .then(r => setMainLoadedLogs(r.logs))
       .catch(() => setMainLoadedLogs([]));
-  }, [mainRecord.id, mainRestLogs.length, mainRecord.status, mainLoadedLogs]);
+  }, [mainRecord.id, mainRestLogs.length, mainLoadedLogs]);
   const mainDisplayLogs = mainRestLogs.length > 0 ? mainRestLogs : mainLoadedLogs || [];
 
   return (


### PR DESCRIPTION
## Summary
- 修复前端对 running 状态的记录不查数据库的问题
- server 重启后 WebSocket 断开，导致日志显示为空

## Test plan
- [ ] 重启 server 后，验证 running 状态的 TODO 日志能正常显示
- [ ] 验证正常执行的 TODO 日志显示正常