### PR TITLE
fix: 修复 api_integration_test 缺少 app_config 参数导致编译错误

### DIFF
--- a/backend/tests/api_integration_test.rs
+++ b/backend/tests/api_integration_test.rs
@@ -26,14 +26,13 @@ async fn create_test_app() -> axum::Router {
     let (tx, _rx) = broadcast::channel(100);
     let task_manager = Arc::new(TaskManager::new());
 
+    let config = Arc::new(tokio::sync::RwLock::new(Config::default()));
     let scheduler = Arc::new(TodoScheduler::new().await.unwrap());
     scheduler
-        .load_from_db(db.clone(), executor_registry.clone(), tx.clone(), task_manager.clone())
+        .load_from_db(db.clone(), executor_registry.clone(), tx.clone(), task_manager.clone(), config.clone())
         .await
         .unwrap();
     scheduler.start().await.unwrap();
-
-    let config = Arc::new(tokio::sync::RwLock::new(Config::default()));
 
     create_app(db, executor_registry, tx, scheduler, task_manager, config)
 }


### PR DESCRIPTION
## Summary
- 修复 `api_integration_test.rs` 调用 `load_from_db` 时缺少 `app_config` 参数导致编译错误
- 将 `config` 定义移至 `load_from_db` 调用之前，并传入缺失的 `config` 参数

## 问题描述
`load_from_db` 方法需要 5 个参数，但测试代码只传了 4 个：
```
error[E0061]: this method takes 5 arguments but 4 arguments were supplied
```

## Test plan
- [x] `cargo check --tests` 编译通过
- [ ] 运行集成测试验证

## 相关 Issue
docs/issue_test_compile_error.md