### PR TITLE
fix: 确保继续对话框关闭时输入框保持为空 (#286)

### DIFF
--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -616,6 +616,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
       await db.resumeExecutionRecord(resumeRecordId, resumeMessage);
       message.success('已继续对话，任务开始执行');
       setResumeModalOpen(false);
+      setResumeMessage('');
       await loadExecutionRecords(historyPage, historyLimit);
     } catch (error) {
       message.error('继续对话失败: ' + (error instanceof Error ? error.message : String(error)));
@@ -1320,7 +1321,10 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
         title="继续对话"
         open={resumeModalOpen}
         onOk={handleResumeConfirm}
-        onCancel={() => setResumeModalOpen(false)}
+        onCancel={() => {
+          setResumeModalOpen(false);
+          setResumeMessage('');
+        }}
         confirmLoading={resumeLoading}
         okText="开始执行"
         cancelText="取消"


### PR DESCRIPTION
## Summary
- 在 `handleResumeConfirm` 中添加 `setResumeMessage('')`，确保执行后清空输入框
- 在 `onCancel` 中添加 `setResumeMessage('')`，确保取消关闭时清空输入框

## Test plan
- [ ] 打开继续对话框，输入一些内容，然后点击取消，再次打开对话框验证输入框是否为空
- [ ] 打开继续对话框，输入一些内容，然后点击"开始执行"，再次打开对话框验证输入框是否为空

## Related Issue
- Fixes #286