### PR TITLE
fix: 修复执行超时 时日志丢失问题

### DIFF
--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -740,7 +740,8 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                     execution_timeout_secs, todo_id, task_id
                 );
                 kill_process_tree(&mut child).await;
-                flush_timer.abort();
+                // Graceful shutdown: signal timer to finish its pending flush before abort
+                flush_shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
 
                 let _status = child.wait().await;
 
@@ -749,6 +750,11 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                 }
                 if let Some(handle) = stderr_task {
                     let _ = handle.await;
+                }
+
+                // Wait for timer to finish its final flush cycle
+                if let Err(e) = flush_timer.await {
+                    tracing::error!("flush_timer panicked: {}", e);
                 }
 
                 for h in flush_handles.lock().await.drain(..) {


### PR DESCRIPTION
## Summary
- 修复 `backend/src/executor_service.rs` 第 743 行的 bug
- 超时处理中原先直接调用 `flush_timer.abort()` 导致内存中未刷新的日志丢失
- 改为优雅关闭：设置 `flush_shutdown = true` 并等待 `flush_timer` 完成最后一次刷新

## Test plan
- [x] `cargo build` 通过
- [x] `cargo test --test api_integration_test` 27 个测试全部通过

## 关联 Issue
Fixes #292