### PR TITLE
feat: add hermes session-id resume support

### DIFF
--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -54,6 +54,51 @@ impl CodeExecutor for HermesExecutor {
         ]
     }
 
+    fn command_args_with_session(&self, message: &str, session_id: Option<&str>, is_resume: bool) -> Vec<String> {
+        if is_resume {
+            let mut args = vec!["--resume".to_string()];
+            if let Some(sid) = session_id {
+                args.push(sid.to_string());
+            }
+            args.push("-q".to_string());
+            args.push(message.to_string());
+            args.push("--yolo".to_string());
+            args
+        } else {
+            self.command_args(message)
+        }
+    }
+
+    fn supports_resume(&self) -> bool {
+        true
+    }
+
+    fn extract_session_id(&self, line: &str) -> Option<String> {
+        let trimmed = line.trim();
+        // Format: "hermes --resume <session_id>"
+        if let Some(rest) = trimmed.strip_prefix("hermes --resume ") {
+            let sid = rest.trim().to_string();
+            if !sid.is_empty() {
+                return Some(sid);
+            }
+        }
+        // Format: "Session: <id>"
+        if let Some(rest) = trimmed.strip_prefix("Session:") {
+            let sid = rest.trim().to_string();
+            if !sid.is_empty() {
+                return Some(sid);
+            }
+        }
+        // Format: "session_id: <id>"
+        if let Some(rest) = trimmed.strip_prefix("session_id:") {
+            let sid = rest.trim().to_string();
+            if !sid.is_empty() {
+                return Some(sid);
+            }
+        }
+        None
+    }
+
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -289,5 +334,61 @@ mod tests {
     fn test_executor_type() {
         let executor = HermesExecutor::new("hermes".to_string());
         assert_eq!(executor.executor_type(), ExecutorType::Hermes);
+    }
+
+    #[test]
+    fn test_supports_resume() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        assert!(executor.supports_resume());
+    }
+
+    #[test]
+    fn test_extract_session_id_resume_format() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        let sid = executor.extract_session_id("hermes --resume 20260517_051220_95e4d6");
+        assert_eq!(sid, Some("20260517_051220_95e4d6".to_string()));
+    }
+
+    #[test]
+    fn test_extract_session_id_session_prefix() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        let sid = executor.extract_session_id("Session: mysession123");
+        assert_eq!(sid, Some("mysession123".to_string()));
+    }
+
+    #[test]
+    fn test_extract_session_id_lowercase_prefix() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        let sid = executor.extract_session_id("session_id: abc_xyz_789");
+        assert_eq!(sid, Some("abc_xyz_789".to_string()));
+    }
+
+    #[test]
+    fn test_extract_session_id_no_match() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        assert!(executor.extract_session_id("Hello world").is_none());
+        assert!(executor.extract_session_id("").is_none());
+        assert!(executor.extract_session_id("hermes chat -q test").is_none());
+    }
+
+    #[test]
+    fn test_command_args_with_session_new() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        let args = executor.command_args_with_session("do something", Some("task_id"), false);
+        assert_eq!(args, vec!["chat", "-q", "do something", "--yolo"]);
+    }
+
+    #[test]
+    fn test_command_args_with_session_resume() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        let args = executor.command_args_with_session("continue", Some("session_123"), true);
+        assert_eq!(args, vec!["--resume", "session_123", "-q", "continue", "--yolo"]);
+    }
+
+    #[test]
+    fn test_command_args_with_session_resume_none() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        let args = executor.command_args_with_session("continue", None, true);
+        assert_eq!(args, vec!["--resume", "-q", "continue", "--yolo"]);
     }
 }

--- a/backend/tests/adapter_extended_tests.rs
+++ b/backend/tests/adapter_extended_tests.rs
@@ -249,8 +249,49 @@ mod hermes_executor_extended_tests {
     #[test]
     fn test_supports_resume() {
         let executor = HermesExecutor::new("hermes".to_string());
-        // Hermes uses default which returns false
-        assert!(!executor.supports_resume());
+        assert!(executor.supports_resume());
+    }
+
+    #[test]
+    fn test_extract_session_id_resume_format() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        let sid = executor.extract_session_id("hermes --resume 20260517_051220_95e4d6");
+        assert_eq!(sid, Some("20260517_051220_95e4d6".to_string()));
+    }
+
+    #[test]
+    fn test_extract_session_id_session_prefix() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        let sid = executor.extract_session_id("Session: mysession");
+        assert_eq!(sid, Some("mysession".to_string()));
+    }
+
+    #[test]
+    fn test_extract_session_id_lowercase_prefix() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        let sid = executor.extract_session_id("session_id: abc123");
+        assert_eq!(sid, Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn test_extract_session_id_no_match() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        assert!(executor.extract_session_id("random text").is_none());
+        assert!(executor.extract_session_id("hermes chat -q test").is_none());
+    }
+
+    #[test]
+    fn test_command_args_with_session_new() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        let args = executor.command_args_with_session("do something", Some("task_id"), false);
+        assert_eq!(args, vec!["chat", "-q", "do something", "--yolo"]);
+    }
+
+    #[test]
+    fn test_command_args_with_session_resume() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        let args = executor.command_args_with_session("continue", Some("session_123"), true);
+        assert_eq!(args, vec!["--resume", "session_123", "-q", "continue", "--yolo"]);
     }
 }
 

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -340,7 +340,7 @@ export interface Config {
   execution_timeout_secs?: number;
 }
 
-export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'joinai']);
+export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'joinai', 'hermes']);
 
 export function supportsResume(record: ExecutionRecord): boolean {
   return (


### PR DESCRIPTION
## 变更内容

Hermes 执行器新增会话恢复支持，使其与 Claude Code 执行器在 resume 功能上保持一致。

### 后端 (hermes.rs)
- `supports_resume()` → 返回 `true`，启用会话恢复
- `command_args_with_session()` → 恢复模式时生成 `--resume <session_id> -q <msg> --yolo`
- `extract_session_id()` → 从输出行提取 session ID，支持三种格式：
  - `hermes --resume 20260517_051220_95e4d6`
  - `Session: <id>`
  - `session_id: <id>`
- 新增 8 个单元测试覆盖所有解析场景

### 前端 (types/index.tsx)
- `'hermes'` 加入 `RESUMABLE_EXECUTORS`，使恢复按钮对 Hermes 记录可见

### 测试 (adapter_extended_tests.rs)
- 更新 `test_supports_resume()` 断言为 `true`
- 新增 extract_session_id 和 command_args_with_session 的集成测试

## 相关 issue
无