### PR TITLE
fix: 修复自定义模板自动同步 cron 表达式修改后不生效的问题

### DIFF
--- a/backend/src/handlers/custom_template.rs
+++ b/backend/src/handlers/custom_template.rs
@@ -286,24 +286,44 @@ pub async fn update_auto_sync_config(
 
 /// Start custom template auto sync scheduler
 pub fn start_custom_template_auto_sync(
-    cron_expr: &str,
+    _cron_expr: &str,
     db: Arc<Database>,
+    config: std::sync::Arc<tokio::sync::RwLock<crate::config::Config>>,
 ) -> Result<(), String> {
-    let schedule = cron::Schedule::from_str(cron_expr)
+    // Validate initial cron expression but will re-read from config in the loop
+    let _ = cron::Schedule::from_str(_cron_expr)
         .map_err(|e| format!("Invalid cron: {}", e))?;
 
     let db_clone = db.clone();
     tokio::spawn(async move {
         loop {
-            let next = schedule.upcoming(chrono::Utc).next();
-            let delay = match next {
-                Some(dt) => {
-                    let now = chrono::Utc::now();
-                    (dt - now).to_std().unwrap_or(std::time::Duration::from_secs(60))
+            // Read current config from in-memory state
+            let (enabled, next_delay) = {
+                let cfg = config.read().await;
+                if !cfg.auto_sync_custom_templates_enabled {
+                    // Auto sync disabled, wait and check again
+                    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                    continue;
                 }
-                None => std::time::Duration::from_secs(3600),
+                let schedule = cron::Schedule::from_str(&cfg.auto_sync_custom_templates_cron)
+                    .unwrap_or_else(|_| cron::Schedule::from_str("0 0 * * *").unwrap());
+                let next = schedule.upcoming(chrono::Utc).next();
+                let delay = match next {
+                    Some(dt) => {
+                        let now = chrono::Utc::now();
+                        (dt - now).to_std().unwrap_or(std::time::Duration::from_secs(60))
+                    }
+                    None => std::time::Duration::from_secs(3600),
+                };
+                (cfg.auto_sync_custom_templates_enabled, delay)
             };
-            tokio::time::sleep(delay).await;
+
+            tokio::time::sleep(next_delay).await;
+
+            // Skip sync if disabled while sleeping
+            if !enabled {
+                continue;
+            }
 
             let db = db_clone.clone();
             match perform_sync(&db).await {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -378,7 +378,7 @@ async fn run_server(cli_port: Option<u16>) {
         // 注册自定义模板自动同步定时任务
         if cfg.auto_sync_custom_templates_enabled {
             let db = Arc::clone(&db);
-            match handlers::custom_template::start_custom_template_auto_sync(&cfg.auto_sync_custom_templates_cron, db) {
+            match handlers::custom_template::start_custom_template_auto_sync(&cfg.auto_sync_custom_templates_cron, db, config.clone()) {
                 Ok(()) => info!("Auto custom template sync enabled, cron: {}", cfg.auto_sync_custom_templates_cron),
                 Err(e) => tracing::warn!("Failed to start custom template auto sync: {}", e),
             }


### PR DESCRIPTION
## Summary

- 修复 `start_custom_template_auto_sync` 函数在启动时固定 cron 表达式的问题
- 现在每次循环迭代都从内存配置读取最新的 `auto_sync_custom_templates_enabled` 和 `auto_sync_custom_templates_cron`
- 如果 enabled 变为 false，等待后重试而不是继续执行

## Root Cause

`start_custom_template_auto_sync` 在启动时固定了 cron 表达式，对比 `start_auto_backup` 已经正确实现了从内存配置读取最新值，但 `start_custom_template_auto_sync` 没有这样做。

## Test plan

- [ ] 修改自定义模板的自动同步 cron 表达式
- [ ] 验证定时任务使用新的 cron 表达式调度
- [ ] 验证禁用自动同步后定时任务正确等待

## Related issue

Fixes #309