### PR TITLE
fix: 修复 NarrowLogView 组件违反 React Hooks 规则

### DIFF
--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1821,9 +1821,9 @@ function NarrowLogView({ record, isRunning, displayLogs, liveLogs, viewMode, onR
   onRefresh: (id: number) => Promise<void>;
   onViewModeChange: (mode: 'log' | 'chat') => void;
 }) {
-  if (!isRunning && displayLogs.length === 0) return null;
   const defaultOpen = isRunning || viewMode === 'chat';
   const [isExpanded, setIsExpanded] = useState(defaultOpen);
+  if (!isRunning && displayLogs.length === 0) return null;
   const title = viewMode === 'chat'
     ? `对话视图 (${displayLogs.length} 条)${isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}`
     : `查看日志 (${displayLogs.length} 条)${isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''}`;


### PR DESCRIPTION
## Summary
- 修复 `NarrowLogView` 组件中 `useState` 在 early return 之后调用的问题
- 将 `useState` 调用移到 early return 之前，确保 React Hooks 调用顺序稳定
- 参考 `d501374` 提交对 `ContinuationLogsLoader` 的同样修复

## Test plan
- [x] 前端编译通过
- [ ] 移动端浏览器测试验证

## 关联 Issue
Closes #312