### PR TITLE
fix: 修复执行历史过滤状态切换后不自动刷新

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -69,9 +69,17 @@ impl Database {
         todo_id: i64,
         limit: i64,
         offset: i64,
+        status: Option<&str>,
     ) -> Result<(Vec<ExecutionRecord>, i64), sea_orm::DbErr> {
+        let base_filter = execution_records::Column::TodoId.eq(todo_id);
+        let filter = if let Some(s) = status {
+            base_filter.and(execution_records::Column::Status.eq(s))
+        } else {
+            base_filter
+        };
+
         let total: i64 = execution_records::Entity::find()
-            .filter(execution_records::Column::TodoId.eq(todo_id))
+            .filter(filter.clone())
             .count(&self.conn)
             .await? as i64;
 
@@ -79,7 +87,7 @@ impl Database {
         let offset_u = if offset < 0 { 0 } else { offset as u64 };
 
         let records = execution_records::Entity::find()
-            .filter(execution_records::Column::TodoId.eq(todo_id))
+            .filter(filter)
             .order_by_desc(execution_records::Column::StartedAt)
             .limit(limit_u)
             .offset(offset_u)

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -828,7 +828,7 @@ mod tests {
         let record_id = create_test_execution_record(&db, todo_id, "echo hi").await;
         let after = truncate_seconds(Utc::now());
 
-        let (records, _) = db.get_execution_records(todo_id, 100, 0).await.unwrap();
+        let (records, _) = db.get_execution_records(todo_id, 100, 0, None).await.unwrap();
         let record = records.into_iter().find(|r| r.id == record_id).unwrap();
         let started = truncate_seconds(parse_utc(&record.started_at));
 
@@ -856,7 +856,7 @@ mod tests {
         .unwrap();
         let after = truncate_seconds(Utc::now());
 
-        let (records, _) = db.get_execution_records(todo_id, 100, 0).await.unwrap();
+        let (records, _) = db.get_execution_records(todo_id, 100, 0, None).await.unwrap();
         let record = records.into_iter().find(|r| r.id == record_id).unwrap();
         let finished_at = record.finished_at.unwrap();
         let finished = truncate_seconds(parse_utc(&finished_at));
@@ -1135,7 +1135,7 @@ mod tests {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         let record_id = create_test_execution_record(&db, todo_id, "echo hi").await;
-        let (records, total) = db.get_execution_records(todo_id, 100, 0).await.unwrap();
+        let (records, total) = db.get_execution_records(todo_id, 100, 0, None).await.unwrap();
         assert_eq!(total, 1);
         let record = records.iter().find(|r| r.id == record_id).unwrap();
         assert_eq!(record.status, crate::models::ExecutionStatus::Running);
@@ -1152,7 +1152,7 @@ mod tests {
         for i in 0..5 {
             create_test_execution_record(&db, todo_id, &format!("cmd{}", i)).await;
         }
-        let (records, total) = db.get_execution_records(todo_id, 2, 0).await.unwrap();
+        let (records, total) = db.get_execution_records(todo_id, 2, 0, None).await.unwrap();
         assert_eq!(total, 5);
         assert_eq!(records.len(), 2);
     }
@@ -1164,7 +1164,7 @@ mod tests {
         for i in 0..3 {
             create_test_execution_record(&db, todo_id, &format!("cmd{}", i)).await;
         }
-        let (records, total) = db.get_execution_records(todo_id, 10, 2).await.unwrap();
+        let (records, total) = db.get_execution_records(todo_id, 10, 2, None).await.unwrap();
         assert_eq!(total, 3);
         assert_eq!(records.len(), 1);
     }
@@ -1192,7 +1192,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let (records, _) = db.get_execution_records(todo_id, 100, 0).await.unwrap();
+        let (records, _) = db.get_execution_records(todo_id, 100, 0, None).await.unwrap();
         let record = records.iter().find(|r| r.id == record_id).unwrap();
         assert_eq!(record.status, crate::models::ExecutionStatus::Success);
         assert_eq!(record.result, Some("done".to_string()));

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1170,6 +1170,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_execution_records_with_status_filter() {
+        let db = setup_db().await;
+        let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
+
+        let running_id = create_test_execution_record(&db, todo_id, "cmd-running").await;
+        let success_id = create_test_execution_record(&db, todo_id, "cmd-success").await;
+        db.update_execution_record(success_id, "success", "[]", "", None, None)
+            .await
+            .unwrap();
+        let failed_id = create_test_execution_record(&db, todo_id, "cmd-failed").await;
+        db.update_execution_record(failed_id, "failed", "[]", "", None, None)
+            .await
+            .unwrap();
+
+        let (running, total_running) =
+            db.get_execution_records(todo_id, 10, 0, Some("running"))
+                .await
+                .unwrap();
+        assert_eq!(total_running, 1);
+        assert_eq!(running.len(), 1);
+        assert_eq!(running[0].id, running_id);
+
+        let (success, total_success) =
+            db.get_execution_records(todo_id, 10, 0, Some("success"))
+                .await
+                .unwrap();
+        assert_eq!(total_success, 1);
+        assert_eq!(success.len(), 1);
+        assert_eq!(success[0].id, success_id);
+
+        let (failed, total_failed) =
+            db.get_execution_records(todo_id, 10, 0, Some("failed"))
+                .await
+                .unwrap();
+        assert_eq!(total_failed, 1);
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0].id, failed_id);
+
+        let (all, total_all) = db.get_execution_records(todo_id, 10, 0, None).await.unwrap();
+        assert_eq!(total_all, 3);
+        assert_eq!(all.len(), 3);
+    }
+
+    #[tokio::test]
     async fn test_update_execution_record() {
         let db = setup_db().await;
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -35,12 +35,14 @@ pub async fn get_execution_records(
     let page = query.page.unwrap_or(1).max(1);
     let limit = query.limit.unwrap_or(10).clamp(1, 100);
     let offset = (page - 1) * limit;
-    let status = query
-        .status
-        .as_deref()
-        .map(|s| s.parse::<ExecutionStatus>().map(|v| v.as_str()))
-        .transpose()
-        .map_err(AppError::BadRequest)?;
+    let status = match query.status.as_deref() {
+        Some("all") | None => None,
+        Some(s) => Some(
+            s.parse::<ExecutionStatus>()
+                .map(|v| v.as_str())
+                .map_err(AppError::BadRequest)?
+        ),
+    };
     let (records, total) = state
         .db
         .get_execution_records(query.todo_id, limit, offset, status)

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -37,7 +37,7 @@ pub async fn get_execution_records(
     let offset = (page - 1) * limit;
     let (records, total) = state
         .db
-        .get_execution_records(query.todo_id, limit, offset)
+        .get_execution_records(query.todo_id, limit, offset, query.status.as_deref())
         .await?;
     Ok(ApiResponse::ok(ExecutionRecordsPage {
         records,

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -35,9 +35,15 @@ pub async fn get_execution_records(
     let page = query.page.unwrap_or(1).max(1);
     let limit = query.limit.unwrap_or(10).clamp(1, 100);
     let offset = (page - 1) * limit;
+    let status = query
+        .status
+        .as_deref()
+        .map(|s| s.parse::<ExecutionStatus>().map(|v| v.as_str()))
+        .transpose()
+        .map_err(AppError::BadRequest)?;
     let (records, total) = state
         .db
-        .get_execution_records(query.todo_id, limit, offset, query.status.as_deref())
+        .get_execution_records(query.todo_id, limit, offset, status)
         .await?;
     Ok(ApiResponse::ok(ExecutionRecordsPage {
         records,

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -331,6 +331,8 @@ pub struct TodoIdQuery {
     pub page: Option<i64>,
     #[serde(default)]
     pub limit: Option<i64>,
+    #[serde(default)]
+    pub status: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -508,7 +508,8 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
   const loadExecutionRecords = async (page = 1, limit = historyLimit) => {
     if (!selectedTodo) return;
     try {
-      const pageData = await db.getExecutionRecords(selectedTodo.id, page, limit);
+      const statusFilter = historyStatusFilter === 'all' ? undefined : historyStatusFilter;
+      const pageData = await db.getExecutionRecords(selectedTodo.id, page, limit, statusFilter);
 
       // 只加载当前页的记录，不再预加载会话链（会话链在点击查看详情时单独加载）
       dispatch({
@@ -541,7 +542,8 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
     if (selectedTodo) {
       setHistoryPage(1);
 
-      db.getExecutionRecords(selectedTodo.id, 1, historyLimit).then(pageData => {
+      const statusFilter = historyStatusFilter === 'all' ? undefined : historyStatusFilter;
+      db.getExecutionRecords(selectedTodo.id, 1, historyLimit, statusFilter).then(pageData => {
         if (cancelled) return;
         dispatch({
           type: 'SET_EXECUTION_RECORDS',
@@ -559,7 +561,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
       setTodoDrawerOpen(false);
     }
     return () => { cancelled = true; };
-  }, [selectedTodoId, selectedTodo, dispatch, historyLimit]);
+  }, [selectedTodoId, selectedTodo, dispatch, historyLimit, historyStatusFilter]);
 
   useEffect(() => {
     setSelectedHistoryRecordId(null);
@@ -601,14 +603,8 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
   const [resumeMessage, setResumeMessage] = useState('');
   const [resumeLoading, setResumeLoading] = useState(false);
 
-  // Filter records by status
-  const filteredRecords = useMemo(() => {
-    if (historyStatusFilter === 'all') return records;
-    return records.filter(r => r.status === historyStatusFilter);
-  }, [records, historyStatusFilter]);
-
   // Always group execution records by session_id
-  const sessionGroups = useMemo(() => groupBySession(filteredRecords), [filteredRecords]);
+  const sessionGroups = useMemo(() => groupBySession(records), [records]);
 
   const handleOpenResume = (record: ExecutionRecord) => {
     setResumeRecordId(record.id);

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -182,10 +182,11 @@ export async function deleteProjectDirectory(id: number): Promise<void> {
 
 // Execution APIs
 
-export async function getExecutionRecords(todoId: number, page?: number, limit?: number): Promise<ExecutionRecordsPage> {
+export async function getExecutionRecords(todoId: number, page?: number, limit?: number, status?: string): Promise<ExecutionRecordsPage> {
   const params: Record<string, unknown> = { todo_id: todoId };
   if (page !== undefined) params.page = page;
   if (limit !== undefined) params.limit = limit;
+  if (status !== undefined) params.status = status;
   return unwrap(await api.get<ApiResp<ExecutionRecordsPage>>(`/xyz/execution-records`, { params }));
 }
 


### PR DESCRIPTION
## Summary
- 后端 `get_execution_records` 接口新增 `status` 过滤参数
- 前端切换过滤状态（全部/运行中/成功/失败）时自动重新加载记录，无需手动刷新

## Test plan
- [ ] 打开 Todo 详情页，切换执行历史过滤状态，验证记录是否立即更新