### PR TITLE
fix: 修复 Joinai 执行器无法解析 sessionID 的问题

### DIFF
--- a/backend/src/adapters/joinai_event.rs
+++ b/backend/src/adapters/joinai_event.rs
@@ -50,7 +50,7 @@ pub struct JoinaiAgentEvent {
     pub event_type: String,
     #[serde(default)]
     pub timestamp: Option<JoinAITimestamp>,
-    #[serde(default)]
+    #[serde(default, rename = "sessionID")]
     pub session_id: Option<String>,
     #[serde(default)]
     pub part: Option<JoinaiAgentPart>,
@@ -72,7 +72,7 @@ pub struct JoinaiAgentPart {
     pub state: Option<JoinaiAgentToolState>,
     #[serde(default)]
     pub message_id: Option<String>,
-    #[serde(default)]
+    #[serde(default, rename = "sessionID")]
     pub session_id: Option<String>,
     #[serde(default)]
     pub tokens: Option<JoinaiAgentTokens>,

--- a/backend/tests/adapter_extended_tests.rs
+++ b/backend/tests/adapter_extended_tests.rs
@@ -442,7 +442,7 @@ mod joinai_executor_extended_tests {
     #[test]
     fn test_extract_session_id_from_event() {
         let executor = JoinaiExecutor::new("joinai".to_string());
-        let line = r#"{"type":"step_start","session_id":"ses_abc123"}"#;
+        let line = r#"{"type":"step_start","sessionID":"ses_abc123"}"#;
         let session = executor.extract_session_id(line);
         assert_eq!(session, Some("ses_abc123".to_string()));
     }
@@ -450,7 +450,7 @@ mod joinai_executor_extended_tests {
     #[test]
     fn test_extract_session_id_from_part() {
         let executor = JoinaiExecutor::new("joinai".to_string());
-        let line = r#"{"type":"text","part":{"session_id":"ses_xyz789"},"text":"hello"}"#;
+        let line = r#"{"type":"text","part":{"sessionID":"ses_xyz789"},"text":"hello"}"#;
         let session = executor.extract_session_id(line);
         assert_eq!(session, Some("ses_xyz789".to_string()));
     }
@@ -474,6 +474,25 @@ mod joinai_executor_extended_tests {
     fn test_supports_resume() {
         let executor = JoinaiExecutor::new("joinai".to_string());
         assert!(executor.supports_resume());
+    }
+
+    #[test]
+    fn test_extract_session_id_from_real_api_response() {
+        let executor = JoinaiExecutor::new("joinai".to_string());
+        let line = r#"{"type":"step_start","timestamp":1779069382034,"sessionID":"ses_1c73b5ee0ffef5UHX2DuxZj9uF","part":{"id":"prt_e38cc6d8f001nXvt3aI6D6IfT7","sessionID":"ses_1c73b5ee0ffef5UHX2DuxZj9uF","messageID":"msg_e38cb2991001z0vtz9Wng3siRh","type":"step-start","snapshot":"1779069382030"}}"#;
+        let session = executor.extract_session_id(line);
+        assert_eq!(session, Some("ses_1c73b5ee0ffef5UHX2DuxZj9uF".to_string()));
+    }
+
+    #[test]
+    fn test_command_args_with_session() {
+        let executor = JoinaiExecutor::new("joinai".to_string());
+        let args = executor.command_args_with_session("continue", Some("ses_abc123"), true);
+        assert!(args.contains(&"-s".to_string()));
+        assert!(args.contains(&"ses_abc123".to_string()));
+        assert_eq!(args[0], "run");
+        assert_eq!(args[1], "--format");
+        assert_eq!(args[2], "json");
     }
 }
 


### PR DESCRIPTION
## Summary

- 修复 Joinai 执行器无法从 API 响应中解析 sessionID 的问题
- Joinai API 返回的 JSON 使用大写 `sessionID`，而结构体定义的是小写 `session_id`
- 通过添加 `#[serde(default, rename = "sessionID")]` 属性解决此问题

## Test plan

- [x] 所有 joinai 相关测试通过（69 个测试）
- [x] 验证真实 API 响应格式能正确解析 sessionID
- [x] 验证 `-s sessionID` 命令参数正确添加