### PR TITLE
fix: 给 Joinai 执行器添加 --agent yolo 参数

### DIFF
--- a/backend/src/adapters/joinai.rs
+++ b/backend/src/adapters/joinai.rs
@@ -34,6 +34,8 @@ impl CodeExecutor for JoinaiExecutor {
     fn command_args(&self, message: &str) -> Vec<String> {
         vec![
             "run".to_string(),
+            "--agent".to_string(),
+            "yolo".to_string(),
             "--format".to_string(),
             "json".to_string(),
             message.to_string(),
@@ -43,6 +45,8 @@ impl CodeExecutor for JoinaiExecutor {
     fn command_args_with_session(&self, message: &str, session_id: Option<&str>, is_resume: bool) -> Vec<String> {
         let mut args = vec![
             "run".to_string(),
+            "--agent".to_string(),
+            "yolo".to_string(),
             "--format".to_string(),
             "json".to_string(),
         ];

--- a/backend/tests/adapter_extended_tests.rs
+++ b/backend/tests/adapter_extended_tests.rs
@@ -490,9 +490,25 @@ mod joinai_executor_extended_tests {
         let args = executor.command_args_with_session("continue", Some("ses_abc123"), true);
         assert!(args.contains(&"-s".to_string()));
         assert!(args.contains(&"ses_abc123".to_string()));
+        assert!(args.contains(&"--agent".to_string()));
+        assert!(args.contains(&"yolo".to_string()));
         assert_eq!(args[0], "run");
-        assert_eq!(args[1], "--format");
-        assert_eq!(args[2], "json");
+        assert_eq!(args[1], "--agent");
+        assert_eq!(args[2], "yolo");
+        assert_eq!(args[3], "--format");
+        assert_eq!(args[4], "json");
+    }
+
+    #[test]
+    fn test_command_args() {
+        let executor = JoinaiExecutor::new("joinai".to_string());
+        let args = executor.command_args("讲个笑话");
+        assert_eq!(args[0], "run");
+        assert_eq!(args[1], "--agent");
+        assert_eq!(args[2], "yolo");
+        assert_eq!(args[3], "--format");
+        assert_eq!(args[4], "json");
+        assert_eq!(args[5], "讲个笑话");
     }
 }
 


### PR DESCRIPTION
## Summary

- 在 `joinai run` 命令中添加 `--agent yolo` 参数
- 与用户提供的命令格式保持一致：`joinai run --agent yolo -s ses_xxx --format json`

## Test plan

- [x] 所有 joinai 相关测试通过（8 个测试）
- [x] 验证 command_args 和 command_args_with_session 都包含 --agent yolo