### PR TITLE
fix: 修复 db layer get_execution_records 不处理 'all' 状态的问题 (#321)

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -73,7 +73,11 @@ impl Database {
     ) -> Result<(Vec<ExecutionRecord>, i64), sea_orm::DbErr> {
         let base_filter = execution_records::Column::TodoId.eq(todo_id);
         let filter = if let Some(s) = status {
-            base_filter.and(execution_records::Column::Status.eq(s))
+            if s == "all" {
+                base_filter // "all" 等同于不传过滤条件
+            } else {
+                base_filter.and(execution_records::Column::Status.eq(s))
+            }
         } else {
             base_filter
         };

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1211,6 +1211,14 @@ mod tests {
         let (all, total_all) = db.get_execution_records(todo_id, 10, 0, None).await.unwrap();
         assert_eq!(total_all, 3);
         assert_eq!(all.len(), 3);
+
+        // Test Some("all") returns all records (db layer should treat "all" as no filter)
+        let (all_filter, total_all_filter) =
+            db.get_execution_records(todo_id, 10, 0, Some("all"))
+                .await
+                .unwrap();
+        assert_eq!(total_all_filter, 3);
+        assert_eq!(all_filter.len(), 3);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- 在 `backend/src/db/execution.rs` 的 `get_execution_records` 函数中添加对 `Some("all")` 的处理
- 将 `status = Some("all")` 视为 `status = None`（即不过滤）
- 添加测试用例覆盖 `Some("all")` 场景

## Test plan

- [x] 运行 `test_get_execution_records_with_status_filter` 测试通过
- [x] 运行所有 db layer 测试通过（共 36 个测试）

## Related Issue

Fixes #321