### PR TITLE
fix: 修复 db layer get_execution_records 不处理 'all' 状态的问题 (#321)

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -73,7 +73,11 @@ impl Database {
     ) -> Result<(Vec<ExecutionRecord>, i64), sea_orm::DbErr> {
         let base_filter = execution_records::Column::TodoId.eq(todo_id);
         let filter = if let Some(s) = status {
-            base_filter.and(execution_records::Column::Status.eq(s))
+            if s == "all" {
+                base_filter
+            } else {
+                base_filter.and(execution_records::Column::Status.eq(s))
+            }
         } else {
             base_filter
         };

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1211,6 +1211,14 @@ mod tests {
         let (all, total_all) = db.get_execution_records(todo_id, 10, 0, None).await.unwrap();
         assert_eq!(total_all, 3);
         assert_eq!(all.len(), 3);
+
+        // Test that Some("all") also returns all records (issue #321)
+        let (all_filter, total_all_filter) =
+            db.get_execution_records(todo_id, 10, 0, Some("all"))
+                .await
+                .unwrap();
+        assert_eq!(total_all_filter, 3);
+        assert_eq!(all_filter.len(), 3);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- 修复 DB 层 `get_execution_records` 函数不处理 `"all"` 状态的问题
- 当 `status` 参数为 `"all"` 时，原代码会尝试过滤 `status = 'all'`，但数据库中并无此状态值，导致返回空结果

## Fix
在 DB 层直接处理 `"all"` 字符串：当 `status` 为 `"all"` 时，跳过状态过滤，返回该 todo_id 下的所有记录。

## Test plan
- [x] 添加了集成测试用例 `test_get_execution_records_with_status_filter`，验证 `Some("all")` 与 `None` 返回相同结果
- [x] 所有现有测试通过

## Related Issue
Fixes #321