### PR TITLE
fix: 修复 Hermes executor extract_session_id 无法匹配新的命令格式

### DIFF
--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -83,6 +83,18 @@ impl CodeExecutor for HermesExecutor {
                 return Some(sid);
             }
         }
+        // Format: "hermes chat ... --resume <session_id> ..."
+        if trimmed.starts_with("hermes chat ") {
+            if let Some(after_hermes_chat) = trimmed.strip_prefix("hermes chat ") {
+                if let Some(resume_pos) = after_hermes_chat.find("--resume ") {
+                    let after_resume = &after_hermes_chat[resume_pos + 9..]; // 9 = len("--resume ")
+                    let sid = after_resume.split_whitespace().next()?;
+                    if !sid.is_empty() {
+                        return Some(sid.to_string());
+                    }
+                }
+            }
+        }
         // Format: "Session: <id>"
         if let Some(rest) = trimmed.strip_prefix("Session:") {
             let sid = rest.trim().to_string();

--- a/backend/tests/adapter_extended_tests.rs
+++ b/backend/tests/adapter_extended_tests.rs
@@ -260,6 +260,14 @@ mod hermes_executor_extended_tests {
     }
 
     #[test]
+    fn test_extract_session_id_resume_chat_format() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        // New format from command_args_with_session: "hermes chat -q <message> --resume <session_id> --yolo"
+        let sid = executor.extract_session_id("hermes chat -q continue --resume 20260517_051220_95e4d6 --yolo");
+        assert_eq!(sid, Some("20260517_051220_95e4d6".to_string()));
+    }
+
+    #[test]
     fn test_extract_session_id_session_prefix() {
         let executor = HermesExecutor::new("hermes".to_string());
         let sid = executor.extract_session_id("Session: mysession");


### PR DESCRIPTION
## Summary
- 修复 Hermes executor 的 `extract_session_id` 方法无法匹配新命令格式的问题
- commit 0a1b52c 将 `command_args_with_session` 的输出从 `hermes --resume session_id -q message --yolo` 改为 `hermes chat -q message --resume session_id --yolo`
- 但 `extract_session_id` 仍只匹配旧格式，导致 resume 后无法提取 session_id

## Test plan
- [x] 新增 `test_extract_session_id_resume_chat_format` 测试验证新格式解析
- [x] 现有 `test_extract_session_id_resume_format` 测试继续通过（兼容旧格式）
- [x] 所有 546 个后端测试通过

## Issue
关联 #324