### PR TITLE
fix: Hermes executor extract_session_id 使用 rfind 避免匹配用户消息中的 --resume

### DIFF
--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -84,9 +84,10 @@ impl CodeExecutor for HermesExecutor {
             }
         }
         // Format: "hermes chat ... --resume <session_id> ..."
+        // Use rfind to match the last --resume (which is the command argument, not user message content)
         if trimmed.starts_with("hermes chat ") {
             if let Some(after_hermes_chat) = trimmed.strip_prefix("hermes chat ") {
-                if let Some(resume_pos) = after_hermes_chat.find("--resume ") {
+                if let Some(resume_pos) = after_hermes_chat.rfind("--resume ") {
                     let after_resume = &after_hermes_chat[resume_pos + 9..]; // 9 = len("--resume ")
                     let sid = after_resume.split_whitespace().next()?;
                     if !sid.is_empty() {

--- a/backend/tests/adapter_extended_tests.rs
+++ b/backend/tests/adapter_extended_tests.rs
@@ -268,6 +268,14 @@ mod hermes_executor_extended_tests {
     }
 
     #[test]
+    fn test_extract_session_id_resume_chat_format_with_resume_in_message() {
+        let executor = HermesExecutor::new("hermes".to_string());
+        // When user message contains "--resume", we must match the last --resume (command argument)
+        let sid = executor.extract_session_id("hermes chat -q please --resume this task --resume session_abc_123 --yolo");
+        assert_eq!(sid, Some("session_abc_123".to_string()));
+    }
+
+    #[test]
     fn test_extract_session_id_session_prefix() {
         let executor = HermesExecutor::new("hermes".to_string());
         let sid = executor.extract_session_id("Session: mysession");


### PR DESCRIPTION
## Summary
- 修复 Hermes executor `extract_session_id` 函数在用户消息包含 `--resume` 文本时错误匹配的问题
- 使用 `rfind` 代替 `find` 从字符串末尾查找 `--resume`，确保匹配命令参数中的 session_id

## Test plan
- [x] 添加测试用例 `test_extract_session_id_resume_chat_format_with_resume_in_message`
- [x] 运行 adapter_extended_tests，所有 19 个 Hermes 相关测试通过

## 关联 Issue
Closes #326