### PR TITLE
feat: 添加智能新建功能

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install build clean dev stop kill-port cross-build cross-list
+.PHONY: setup install build clean dev watch stop kill-port cross-build cross-list
 
 # Source cargo env for all Rust commands
 export PATH := $(HOME)/.cargo/bin:$(PATH)
@@ -76,6 +76,21 @@ dev: stop
 	@echo "Backend logs: tail -f backend.dev.log"
 	@echo ""
 	@echo "Press Ctrl+C to stop"
+
+# Development mode with hot reload (requires cargo-watch)
+watch: stop
+	@echo "[1/2] Building frontend..."
+	cd frontend && npm run build
+	@echo "[2/2] Starting backend with cargo-watch..."
+	cd backend && $(CARGO_ENV) NTD_MODE=dev RUST_BACKTRACE=1 RUST_LOG=info cargo watch -x run 2>&1 | tee ../backend.dev.log &
+	@echo $$! > $$HOME/.ntd/dev.pid
+	@echo "==========================================="
+	@echo "  Dev mode (watch): http://localhost:18088"
+	@echo "==========================================="
+	@echo "Backend logs: tail -f backend.dev.log"
+	@echo "Note: cargo-watch auto-rebuilds on code changes"
+	@echo "      but will NOT pick up frontend dist changes"
+	@echo "      Run 'make dev' for full rebuilds"
 
 # Cross-build for Windows (x86_64 + i686), macOS (x86_64 + aarch64), Linux (x86_64 + aarch64)
 cross-build:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install build clean dev watch stop kill-port cross-build cross-list
+.PHONY: setup install build clean dev stop kill-port cross-build cross-list
 
 # Source cargo env for all Rust commands
 export PATH := $(HOME)/.cargo/bin:$(PATH)
@@ -76,21 +76,6 @@ dev: stop
 	@echo "Backend logs: tail -f backend.dev.log"
 	@echo ""
 	@echo "Press Ctrl+C to stop"
-
-# Development mode with hot reload (requires cargo-watch)
-watch: stop
-	@echo "[1/2] Building frontend..."
-	cd frontend && npm run build
-	@echo "[2/2] Starting backend with cargo-watch..."
-	cd backend && $(CARGO_ENV) NTD_MODE=dev RUST_BACKTRACE=1 RUST_LOG=info cargo watch -x run 2>&1 | tee ../backend.dev.log &
-	@echo $$! > $$HOME/.ntd/dev.pid
-	@echo "==========================================="
-	@echo "  Dev mode (watch): http://localhost:18088"
-	@echo "==========================================="
-	@echo "Backend logs: tail -f backend.dev.log"
-	@echo "Note: cargo-watch auto-rebuilds on code changes"
-	@echo "      but will NOT pick up frontend dist changes"
-	@echo "      Run 'make dev' for full rebuilds"
 
 # Cross-build for Windows (x86_64 + i686), macOS (x86_64 + aarch64), Linux (x86_64 + aarch64)
 cross-build:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install build clean dev stop watch kill-port cross-build cross-list
+.PHONY: setup install build clean dev stop kill-port cross-build cross-list
 
 # Source cargo env for all Rust commands
 export PATH := $(HOME)/.cargo/bin:$(PATH)
@@ -8,22 +8,19 @@ CARGO_ENV := source $(HOME)/.cargo/env &&
 setup:
 	@echo "=== Setting up ntd ==="
 	@echo ""
-	@echo "[1/5] Checking Rust toolchain..."
+	@echo "[1/4] Checking Rust toolchain..."
 	@which rustc > /dev/null 2>&1 || (echo "Installing Rust..." && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y)
 	@$(CARGO_ENV) echo "  Rust: $$(rustc --version 2>/dev/null || echo 'NOT FOUND')"
 	@echo ""
-	@echo "[2/5] Checking Node.js..."
+	@echo "[2/4] Checking Node.js..."
 	@echo "  Node: $$(node --version 2>/dev/null || echo 'NOT FOUND')"
 	@echo "  npm:  $$(npm --version 2>/dev/null || echo 'NOT FOUND')"
 	@echo ""
-	@echo "[3/5] Installing frontend dependencies..."
+	@echo "[3/4] Installing frontend dependencies..."
 	cd frontend && npm install --legacy-peer-deps
 	@echo ""
-	@echo "[4/5] Pre-compiling Rust backend (downloads deps)..."
+	@echo "[4/4] Pre-compiling Rust backend (downloads deps)..."
 	cd backend && $(CARGO_ENV) cargo fetch
-	@echo ""
-	@echo "[5/5] Installing dev tools (cargo-watch)..."
-	@$(CARGO_ENV) which cargo-watch > /dev/null 2>&1 || $(CARGO_ENV) cargo install cargo-watch
 	@echo ""
 	@echo "[OPT] Installing cross-build tool (cross)..."
 	@$(CARGO_ENV) which cross > /dev/null 2>&1 || $(CARGO_ENV) cargo install cross --locked
@@ -66,10 +63,12 @@ stop:
 	-@fuser -k 18088/tcp 2>/dev/null || true
 	@sleep 1
 
-# Development mode - build frontend + run backend with embedded frontend on port 18088
+# Development mode - build frontend + build backend + run on port 18088
 dev: stop
+	@echo "[1/2] Building frontend..."
 	cd frontend && npm run build
-	(cd backend && $(CARGO_ENV) NTD_MODE=dev RUST_BACKTRACE=1 RUST_LOG=info cargo watch -x run 2>&1 | tee ../backend.dev.log) &
+	@echo "[2/2] Building & running backend..."
+	cd backend && $(CARGO_ENV) NTD_MODE=dev RUST_BACKTRACE=1 RUST_LOG=info cargo run 2>&1 | tee ../backend.dev.log &
 	@echo $$! > $$HOME/.ntd/dev.pid
 	@echo "==========================================="
 	@echo "  Dev mode: http://localhost:18088"

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -168,7 +168,8 @@ pub async fn execute_handler(
     })
     .await;
     let result = result?;
-    let record_id = result.record_id.expect("record_id checked above");
+    let record_id = result.record_id
+        .ok_or_else(|| AppError::Internal("执行启动失败：未获取到执行记录 ID".to_string()))?;
 
     Ok(ApiResponse::ok(
         serde_json::json!({ "task_id": result.task_id, "record_id": record_id }),
@@ -395,7 +396,8 @@ pub async fn resume_execution_handler(
         resume_message,
     })
     .await?;
-    let record_id = result.record_id.expect("record_id checked above");
+    let record_id = result.record_id
+        .ok_or_else(|| AppError::Internal("执行启动失败：未获取到执行记录 ID".to_string()))?;
 
     Ok(ApiResponse::ok(
         serde_json::json!({ "task_id": result.task_id, "record_id": record_id }),
@@ -512,7 +514,8 @@ pub async fn smart_create_handler(
     })
     .await?;
 
-    let record_id = result.record_id.expect("record_id checked above");
+    let record_id = result.record_id
+        .ok_or_else(|| AppError::Internal("执行启动失败：未获取到执行记录 ID".to_string()))?;
 
     Ok(ApiResponse::ok(serde_json::json!({
         "task_id": result.task_id,

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -8,7 +8,7 @@ use crate::executor_service::{
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::{
     ApiResponse, DashboardStats, ExecuteRequest, ExecutionLogsPage, ExecutionRecordsPage,
-    ExecutionStatus, ExecutionSummary, TodoIdQuery,
+    ExecutionStatus, ExecutionSummary, SmartCreateRequest, TodoIdQuery,
 };
 
 /// 统一启动一条 Todo 执行，供手动执行、消息路由等入口复用。
@@ -427,4 +427,97 @@ pub async fn get_running_todos(
 ) -> Result<ApiResponse<Vec<crate::models::Todo>>, AppError> {
     let running_todos = state.db.get_running_todos().await?;
     Ok(ApiResponse::ok(running_todos))
+}
+
+/// 智能新建：用户提交自然语言描述，通过默认响应 Todo 自动执行
+pub async fn smart_create_handler(
+    State(state): State<AppState>,
+    ApiJson(req): ApiJson<SmartCreateRequest>,
+) -> Result<ApiResponse<serde_json::Value>, AppError> {
+    let content = req.content.trim();
+    if content.is_empty() {
+        return Err(AppError::BadRequest("内容不能为空".to_string()));
+    }
+
+    // 读取默认响应 Todo ID
+    let default_todo_id = {
+        let cfg = state.config.read().await;
+        cfg.default_response_todo_id
+    };
+
+    let todo_id = default_todo_id
+        .ok_or_else(|| AppError::BadRequest("尚未配置默认响应 Todo，请先在设置中配置".to_string()))?;
+
+    // 验证 Todo 存在
+    let todo = state
+        .db
+        .get_todo(todo_id)
+        .await?
+        .ok_or_else(|| AppError::BadRequest(format!("默认响应 Todo #{} 不存在", todo_id)))?;
+
+    // 检查并发限制
+    let max_concurrent = state.config.read().await.max_concurrent_todos;
+    let running_tasks = state.task_manager.get_all_task_infos().await;
+    let running_records = state.db.get_running_execution_records().await?;
+    let running_count_for_todo = running_records
+        .iter()
+        .filter(|r| {
+            if let Some(task_id) = &r.task_id {
+                running_tasks.iter().any(|t| t.task_id == *task_id)
+            } else {
+                false
+            }
+        })
+        .filter(|r| r.todo_id == todo_id)
+        .count();
+    if running_count_for_todo >= max_concurrent as usize {
+        return Err(AppError::BadRequest(format!(
+            "默认响应 Todo #{} 已有 {} 个执行在运行中（上限 {}），请稍后再试",
+            todo_id, running_count_for_todo, max_concurrent
+        )));
+    }
+
+    // 构建模板参数
+    let mut params = std::collections::HashMap::new();
+    params.insert("content".to_string(), content.to_string());
+    params.insert("message".to_string(), content.to_string());
+    params.insert("raw_message".to_string(), content.to_string());
+
+    let mut message = todo.prompt.clone();
+
+    // 如果 prompt 模板中没有任何占位符，将用户内容追加到 message 末尾，
+    // 确保用户提交的内容一定能传递到执行器
+    let has_placeholder = params.keys().any(|key| message.contains(&format!("{{{{{}}}}}", key)));
+    if !has_placeholder {
+        if message.is_empty() {
+            message = content.to_string();
+        } else {
+            message = format!("{}\n\n{}", message, content);
+        }
+    }
+
+    let result = start_todo_execution(RunTodoExecutionRequest {
+        db: state.db.clone(),
+        executor_registry: state.executor_registry.clone(),
+        tx: state.tx.clone(),
+        task_manager: state.task_manager.clone(),
+        config: state.config.clone(),
+        todo_id,
+        message,
+        req_executor: None,
+        trigger_type: "smart_create".to_string(),
+        params: Some(params),
+        resume_session_id: None,
+        resume_message: None,
+    })
+    .await?;
+
+    let record_id = result.record_id.expect("record_id checked above");
+
+    Ok(ApiResponse::ok(serde_json::json!({
+        "task_id": result.task_id,
+        "record_id": record_id,
+        "todo_id": todo_id,
+        "todo_title": todo.title,
+    })))
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -402,6 +402,7 @@ pub fn create_app(
         .route("/xyz/execution-records/{id}/resume", post(execution::resume_execution_handler))
         .route("/xyz/dashboard-stats", get(execution::get_dashboard_stats))
         .route("/xyz/execute", post(execution::execute_handler))
+        .route("/xyz/smart-create", post(execution::smart_create_handler))
         .route("/xyz/execute/stop", post(execution::stop_execution_handler))
         .route("/xyz/execute/force-fail", post(execution::force_fail_execution_handler))
         .route("/xyz/running-todos", get(execution::get_running_todos))

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -325,6 +325,11 @@ pub struct ExecuteRequest {
 }
 
 #[derive(Deserialize)]
+pub struct SmartCreateRequest {
+    pub content: String,
+}
+
+#[derive(Deserialize)]
 pub struct TodoIdQuery {
     pub todo_id: i64,
     #[serde(default)]

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1183,6 +1183,13 @@ body {
   font-size: 11px;
   color: var(--color-text-quaternary, #bbb);
   white-space: nowrap;
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+}
+
+.smart-create-shortcut.active {
+  opacity: 1;
+  color: var(--color-primary);
 }
 
 .smart-create-empty {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -224,18 +224,33 @@ body {
 }
 
 .todo-list-header {
-  padding: var(--space-lg) var(--space-xl);
+  padding: 12px 20px;
   border-bottom: 1px solid var(--color-border-light);
   display: flex;
   justify-content: space-between;
   align-items: center;
   flex-shrink: 0;
+  gap: 8px;
+  height: 56px;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.todo-list-header h3 {
+  line-height: 24px !important;
+  height: 24px !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 1;
+  min-width: 0;
 }
 
 .header-actions {
   display: flex;
-  gap: 8px;
+  gap: 4px;
   align-items: center;
+  flex-shrink: 0;
 }
 
 /* Tag Filter Bar */
@@ -983,6 +998,285 @@ body {
 
 .mobile-fab:active {
   transform: scale(0.95);
+}
+
+/* ---------- Mobile FAB Group (Speed Dial) ---------- */
+.mobile-fab-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: calc(var(--z-fab) - 1);
+  background: transparent;
+}
+
+.mobile-fab-group {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: var(--z-fab);
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.mobile-fab-main {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: #ffffff;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-md);
+  z-index: 1;
+  transition: all 0.2s ease;
+}
+
+.mobile-fab-main:hover {
+  background: var(--color-primary-hover);
+}
+
+.mobile-fab-main:active {
+  transform: scale(0.95);
+}
+
+.mobile-fab-main.expanded {
+  transform: rotate(45deg);
+}
+
+.mobile-fab-main.expanded:active {
+  transform: rotate(45deg) scale(0.95);
+}
+
+.mobile-fab-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  animation: fabItemIn 0.2s ease forwards;
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+@keyframes fabItemIn {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.mobile-fab-item-btn {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-md);
+  transition: all 0.15s ease;
+}
+
+.mobile-fab-item-btn:active {
+  transform: scale(0.92);
+}
+
+.mobile-fab-item-label {
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  background: var(--color-bg-elevated);
+  box-shadow: var(--shadow-sm);
+  color: var(--color-text);
+}
+
+.mobile-fab-create {
+  background: var(--color-primary);
+  color: #ffffff;
+}
+
+.mobile-fab-smart {
+  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+  color: #ffffff;
+}
+
+/* ---------- Smart Create Styles ---------- */
+.header-actions-divider {
+  width: 1px;
+  height: 16px;
+  background: var(--color-border-light, #e5e7eb);
+  flex-shrink: 0;
+}
+
+.smart-create-btn {
+  color: #3b82f6 !important;
+  transition: all var(--transition-base, 0.2s ease);
+}
+
+.smart-create-btn:hover {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(139, 92, 246, 0.1)) !important;
+  color: #2563eb !important;
+}
+
+.create-btn {
+  color: var(--color-primary) !important;
+  transition: all var(--transition-base, 0.2s ease);
+}
+
+.create-btn:hover {
+  background: var(--color-primary-light) !important;
+  color: var(--color-primary-hover) !important;
+}
+
+.smart-create-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 4px 0;
+}
+
+.smart-create-content .ant-input-textarea textarea {
+  background: var(--color-bg);
+  border-radius: var(--radius-sm, 8px);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.smart-create-hint {
+  font-size: 12px;
+  color: var(--color-text-tertiary, #999);
+  line-height: 1.6;
+}
+
+.smart-create-config-info {
+  font-size: 13px;
+  color: #3b82f6;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.smart-create-footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  padding-top: 8px;
+}
+
+.smart-create-footer .ant-btn-primary {
+  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+  border: none;
+  box-shadow: 0 4px 14px rgba(59, 130, 246, 0.25);
+}
+
+.smart-create-footer .ant-btn-primary:hover:not(:disabled) {
+  background: linear-gradient(135deg, #2563eb, #7c3aed) !important;
+}
+
+.smart-create-shortcut {
+  font-size: 11px;
+  color: var(--color-text-quaternary, #bbb);
+  white-space: nowrap;
+}
+
+.smart-create-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  text-align: center;
+}
+
+.smart-create-empty-icon {
+  font-size: 48px;
+  color: var(--color-warning, #faad14);
+  margin-bottom: 16px;
+}
+
+.smart-create-empty-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: 8px;
+}
+
+.smart-create-empty-desc {
+  font-size: 13px;
+  color: var(--color-text-secondary, #666);
+  line-height: 1.6;
+  margin-bottom: 20px;
+}
+
+/* Dark theme smart create adjustments */
+[data-theme="dark"] .smart-create-btn {
+  color: #60a5fa !important;
+}
+
+[data-theme="dark"] .smart-create-btn:hover {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(139, 92, 246, 0.15)) !important;
+  color: #93bbfd !important;
+}
+
+[data-theme="dark"] .create-btn {
+  color: #22d3ee !important;
+}
+
+[data-theme="dark"] .create-btn:hover {
+  background: rgba(8, 145, 178, 0.15) !important;
+  color: #67e8f9 !important;
+}
+
+[data-theme="dark"] .smart-create-config-info {
+  color: #60a5fa;
+}
+
+[data-theme="dark"] .mobile-fab-smart {
+  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+}
+
+[data-theme="dark"] .smart-create-footer .ant-btn-primary {
+  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+  box-shadow: 0 4px 14px rgba(59, 130, 246, 0.35);
+}
+
+/* Mobile smart create drawer adjustments */
+@media (max-width: 767px) {
+  .smart-create-content {
+    padding-bottom: env(safe-area-inset-bottom, 16px);
+  }
+
+  .smart-create-footer {
+    flex-direction: column;
+  }
+
+  .smart-create-footer .ant-btn {
+    width: 100%;
+    height: 44px;
+    font-size: 15px;
+  }
+
+  .smart-create-shortcut {
+    display: none;
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .mobile-fab-item {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+  .mobile-fab-main.expanded {
+    transform: none;
+  }
 }
 
 /* ---------- Ant Design Custom Styles ---------- */

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { ConfigProvider, Layout, Spin, App as AntApp } from 'antd';
-import { PlusOutlined } from '@ant-design/icons';
+import { PlusOutlined, ThunderboltOutlined, CloseOutlined } from '@ant-design/icons';
 import { AppProvider, useApp } from './hooks/useApp';
 import { useExecutionEvents } from './hooks/useExecutionEvents';
 import { ThemeProvider, useTheme } from './hooks/useTheme';
@@ -11,7 +11,9 @@ import { MemorialBoard } from './components/MemorialBoard';
 import { SettingsPage } from './components/SettingsPage';
 import { ExecutionPanel } from './components/ExecutionPanel';
 import { TodoDrawer } from './components/TodoDrawer';
+import { SmartCreateModal } from './components/SmartCreateModal';
 import * as db from './utils/database';
+import type { Config } from './types';
 import zhCN from 'antd/locale/zh_CN';
 import './App.css';
 
@@ -22,6 +24,9 @@ const MOBILE_BREAKPOINT = 768;
 function AppContent() {
   const { state, dispatch, clearSelection } = useApp();
   const [todoModalOpen, setTodoModalOpen] = useState(false);
+  const [smartCreateOpen, setSmartCreateOpen] = useState(false);
+  const [fabExpanded, setFabExpanded] = useState(false);
+  const [appConfig, setAppConfig] = useState<Config | null>(null);
   const [isMobile, setIsMobile] = useState(false);
   const [selectedPanel, setSelectedPanel] = useState<'list' | 'detail'>('list');
   const [activeView, setActiveView] = useState<'dashboard' | 'settings' | 'memorial'>('dashboard');
@@ -45,6 +50,11 @@ function AppContent() {
     checkMobile();
     window.addEventListener('resize', checkMobile);
     return () => window.removeEventListener('resize', checkMobile);
+  }, []);
+
+  // 加载配置
+  useEffect(() => {
+    db.getConfig().then(setAppConfig).catch(() => {});
   }, []);
 
   if (state.loading) {
@@ -85,17 +95,74 @@ function AppContent() {
     setSelectedPanel('list');
   };
 
+  const handleSmartCreateSubmitted = () => {
+    // 刷新 todo 列表
+    db.getAllTodos().then(todos => {
+      dispatch({ type: 'SET_TODOS', payload: todos });
+    });
+  };
+
+  const handleGoToSettings = () => {
+    handleShowSettings();
+  };
+
+  // 点击 FAB 外部收起
+  const handleFabBackdropClick = () => {
+    setFabExpanded(false);
+  };
+
   return (
     <Layout style={{ height: '100vh' }}>
-      {/* Mobile FAB */}
+      {/* Mobile FAB Group */}
       {isMobile && selectedPanel === 'list' && (
-        <button
-          className="mobile-fab"
-          onClick={() => setTodoModalOpen(true)}
-          aria-label="新建任务"
-        >
-          <PlusOutlined style={{ fontSize: 24, color: '#fff' }} />
-        </button>
+        <>
+          {fabExpanded && (
+            <div className="mobile-fab-backdrop" onClick={handleFabBackdropClick} />
+          )}
+          <div className="mobile-fab-group">
+            {fabExpanded && (
+              <>
+                <div className="mobile-fab-item" style={{ animationDelay: '0ms' }}>
+                  <span className="mobile-fab-item-label">智能新建</span>
+                  <button
+                    className="mobile-fab-item-btn mobile-fab-smart"
+                    onClick={() => {
+                      setFabExpanded(false);
+                      setSmartCreateOpen(true);
+                    }}
+                    aria-label="智能新建"
+                  >
+                    <ThunderboltOutlined style={{ fontSize: 20, color: '#fff' }} />
+                  </button>
+                </div>
+                <div className="mobile-fab-item" style={{ animationDelay: '50ms' }}>
+                  <span className="mobile-fab-item-label">新建</span>
+                  <button
+                    className="mobile-fab-item-btn mobile-fab-create"
+                    onClick={() => {
+                      setFabExpanded(false);
+                      setTodoModalOpen(true);
+                    }}
+                    aria-label="新建任务"
+                  >
+                    <PlusOutlined style={{ fontSize: 20, color: '#fff' }} />
+                  </button>
+                </div>
+              </>
+            )}
+            <button
+              className={`mobile-fab-main ${fabExpanded ? 'expanded' : ''}`}
+              onClick={() => setFabExpanded(!fabExpanded)}
+              aria-label={fabExpanded ? '关闭' : '创建任务'}
+            >
+              {fabExpanded ? (
+                <CloseOutlined style={{ fontSize: 22, color: '#fff' }} />
+              ) : (
+                <PlusOutlined style={{ fontSize: 24, color: '#fff' }} />
+              )}
+            </button>
+          </div>
+        </>
       )}
 
       <Layout>
@@ -123,6 +190,7 @@ function AppContent() {
           >
             <TodoList
               onOpenCreateModal={() => setTodoModalOpen(true)}
+              onOpenSmartCreate={() => setSmartCreateOpen(true)}
               onSelectTodo={handleSelectTodo}
               onShowDashboard={handleShowDashboard}
               onShowMemorial={handleShowMemorial}
@@ -164,6 +232,16 @@ function AppContent() {
           });
         }}
       />
+
+      <SmartCreateModal
+        open={smartCreateOpen}
+        onClose={() => setSmartCreateOpen(false)}
+        isMobile={isMobile}
+        config={appConfig}
+        onGoToSettings={handleGoToSettings}
+        onSubmitted={handleSmartCreateSubmitted}
+      />
+
       <ExecutionPanel
         collapsed={panelCollapsed}
         onToggleCollapse={() => {

--- a/frontend/src/components/SmartCreateModal.tsx
+++ b/frontend/src/components/SmartCreateModal.tsx
@@ -1,0 +1,159 @@
+import { useState, useRef, useEffect } from 'react';
+import { Modal, Drawer, Input, Button, message } from 'antd';
+import { ThunderboltOutlined, BulbOutlined, SettingOutlined, WarningOutlined } from '@ant-design/icons';
+import { smartCreate } from '../utils/database';
+import type { Config } from '../types';
+
+interface SmartCreateModalProps {
+  open: boolean;
+  onClose: () => void;
+  isMobile: boolean;
+  config: Config | null;
+  onGoToSettings?: () => void;
+  onSubmitted?: () => void;
+}
+
+export function SmartCreateModal({ open, onClose, isMobile, config, onGoToSettings, onSubmitted }: SmartCreateModalProps) {
+  const [content, setContent] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const textAreaRef = useRef<any>(null);
+  const defaultTodoId = config?.default_response_todo_id ?? null;
+
+  // 打开时自动聚焦
+  useEffect(() => {
+    if (open && !isMobile) {
+      setTimeout(() => textAreaRef.current?.focus(), 100);
+    }
+  }, [open, isMobile]);
+
+  // 关闭时清空
+  const handleClose = () => {
+    setContent('');
+    setSubmitting(false);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    const trimmed = content.trim();
+    if (!trimmed) return;
+
+    setSubmitting(true);
+    try {
+      const result = await smartCreate(trimmed);
+      message.success(`已提交智能执行，任务 #${result.todo_id} ${result.todo_title} 正在处理中`);
+      onSubmitted?.();
+      handleClose();
+    } catch (err: any) {
+      message.error(err?.message || '智能执行失败');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  // 默认响应未配置
+  const renderEmptyState = () => (
+    <div className="smart-create-empty">
+      <WarningOutlined className="smart-create-empty-icon" />
+      <div className="smart-create-empty-title">尚未配置默认响应 Todo</div>
+      <div className="smart-create-empty-desc">
+        智能新建需要先在「设置 → 消息规则 → 默认响应」中指定一个 Todo 作为默认处理器。
+      </div>
+      <Button
+        type="primary"
+        icon={<SettingOutlined />}
+        onClick={() => {
+          handleClose();
+          onGoToSettings?.();
+        }}
+      >
+        前往配置
+      </Button>
+    </div>
+  );
+
+  // 正常内容
+  const renderContent = () => (
+    <div className="smart-create-content">
+      <Input.TextArea
+        ref={textAreaRef}
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="描述你的需求，AI 会自动处理..."
+        autoSize={{ minRows: 3, maxRows: 8 }}
+        disabled={submitting}
+      />
+      <div className="smart-create-hint">
+        <BulbOutlined style={{ marginRight: 4 }} />
+        输入自然语言描述，如"帮我分析一下最近的销售数据趋势"或"写一封周报总结"
+      </div>
+      {defaultTodoId && (
+        <div className="smart-create-config-info">
+          <SettingOutlined />
+          默认响应：#{defaultTodoId}
+        </div>
+      )}
+      <div className="smart-create-footer">
+        {!isMobile && (
+          <Button onClick={handleClose} disabled={submitting}>
+            取消
+          </Button>
+        )}
+        <Button
+          type="primary"
+          icon={<ThunderboltOutlined />}
+          onClick={handleSubmit}
+          loading={submitting}
+          disabled={!content.trim()}
+          block={isMobile}
+        >
+          {submitting ? '执行中...' : '智能执行'}
+        </Button>
+        {!isMobile && !submitting && content.trim() && (
+          <span className="smart-create-shortcut">Ctrl+Enter</span>
+        )}
+      </div>
+    </div>
+  );
+
+  const bodyContent = defaultTodoId ? renderContent() : renderEmptyState();
+
+  // 移动端：底部 Drawer
+  if (isMobile) {
+    return (
+      <Drawer
+        title={<><ThunderboltOutlined style={{ marginRight: 8 }} />智能新建</>}
+        placement="bottom"
+        open={open}
+        onClose={handleClose}
+        height="auto"
+        className="smart-create-drawer"
+        destroyOnClose
+      >
+        {bodyContent}
+      </Drawer>
+    );
+  }
+
+  // PC 端：居中 Modal
+  return (
+    <Modal
+      title={<><ThunderboltOutlined style={{ marginRight: 8 }} />智能新建</>}
+      open={open}
+      onCancel={handleClose}
+      width={520}
+      centered
+      destroyOnClose
+      footer={null}
+    >
+      {bodyContent}
+    </Modal>
+  );
+}

--- a/frontend/src/components/SmartCreateModal.tsx
+++ b/frontend/src/components/SmartCreateModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { Modal, Drawer, Input, Button, message } from 'antd';
+import type { InputRef } from 'antd';
 import { ThunderboltOutlined, BulbOutlined, SettingOutlined, WarningOutlined } from '@ant-design/icons';
 import { smartCreate } from '../utils/database';
 import type { Config } from '../types';
@@ -16,7 +17,7 @@ interface SmartCreateModalProps {
 export function SmartCreateModal({ open, onClose, isMobile, config, onGoToSettings, onSubmitted }: SmartCreateModalProps) {
   const [content, setContent] = useState('');
   const [submitting, setSubmitting] = useState(false);
-  const textAreaRef = useRef<any>(null);
+  const textAreaRef = useRef<InputRef>(null);
   const defaultTodoId = config?.default_response_todo_id ?? null;
 
   // 打开时自动聚焦
@@ -40,7 +41,10 @@ export function SmartCreateModal({ open, onClose, isMobile, config, onGoToSettin
     setSubmitting(true);
     try {
       const result = await smartCreate(trimmed);
-      message.success(`已提交智能执行，任务 #${result.todo_id} ${result.todo_title} 正在处理中`);
+      const title = result.todo_title.length > 20
+        ? result.todo_title.slice(0, 20) + '...'
+        : result.todo_title;
+      message.success(`已提交智能执行，任务 #${result.todo_id} ${title} 正在处理中`);
       onSubmitted?.();
       handleClose();
     } catch (err: any) {
@@ -116,8 +120,10 @@ export function SmartCreateModal({ open, onClose, isMobile, config, onGoToSettin
         >
           {submitting ? '执行中...' : '智能执行'}
         </Button>
-        {!isMobile && !submitting && content.trim() && (
-          <span className="smart-create-shortcut">Ctrl+Enter</span>
+        {!isMobile && (
+          <span className={`smart-create-shortcut ${content.trim() && !submitting ? 'active' : ''}`}>
+            Ctrl+Enter
+          </span>
         )}
       </div>
     </div>

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useApp } from '../hooks/useApp';
 import { Button, Empty, Tooltip } from 'antd';
-import { PlusOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined } from '@ant-design/icons';
+import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined } from '@ant-design/icons';
 import { useTheme } from '../hooks/useTheme';
 import { StatusPicker } from './StatusPicker';
 import * as db from '../utils/database';
@@ -10,6 +10,7 @@ import { formatRelativeTime, formatLocalDateTime } from '../utils/datetime';
 
 interface TodoListProps {
   onOpenCreateModal: () => void;
+  onOpenSmartCreate: () => void;
   onSelectTodo?: (todoId: string | number) => void;
   onShowDashboard?: () => void;
   onShowMemorial?: () => void;
@@ -30,7 +31,7 @@ function SkeletonList() {
   );
 }
 
-export function TodoList({ onOpenCreateModal, onSelectTodo, onShowDashboard, onShowMemorial, onShowSettings }: TodoListProps) {
+export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, onShowDashboard, onShowMemorial, onShowSettings }: TodoListProps) {
   const { state, dispatch } = useApp();
   const { themeMode, toggleTheme } = useTheme();
   const { todos, selectedTodoId, selectedTagId, tags } = state;
@@ -115,15 +116,29 @@ export function TodoList({ onOpenCreateModal, onSelectTodo, onShowDashboard, onS
             aria-label="配置管理"
           />
           {!isMobile && (
-            <Button
-              type="primary"
-              size="small"
-              icon={<PlusOutlined />}
-              className="action-btn action-btn-primary"
-              onClick={onOpenCreateModal}
-            >
-              新建
-            </Button>
+            <>
+              <span className="header-actions-divider" />
+              <Tooltip title="智能新建">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<ThunderboltOutlined />}
+                  className="smart-create-btn"
+                  onClick={onOpenSmartCreate}
+                  aria-label="智能新建"
+                />
+              </Tooltip>
+              <Tooltip title="新建任务">
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<PlusOutlined />}
+                  className="create-btn"
+                  onClick={onOpenCreateModal}
+                  aria-label="新建任务"
+                />
+              </Tooltip>
+            </>
           )}
         </div>
       </div>

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -239,6 +239,19 @@ export async function resumeExecutionRecord(recordId: number, message?: string):
   return unwrap(await api.post<ApiResp<{ task_id: string; record_id: number }>>(`/xyz/execution-records/${recordId}/resume`, { message }));
 }
 
+// Smart Create API
+
+export interface SmartCreateResult {
+  task_id: string;
+  record_id: number;
+  todo_id: number;
+  todo_title: string;
+}
+
+export async function smartCreate(content: string): Promise<SmartCreateResult> {
+  return unwrap(await api.post<ApiResp<SmartCreateResult>>('/xyz/smart-create', { content }));
+}
+
 // Scheduler APIs
 
 export async function updateScheduler(


### PR DESCRIPTION
## Summary
- 新增智能新建（Smart Create）功能，用户可通过自然语言直接提交任务，触发默认响应 Todo 自动处理
- 后端新增 `/xyz/smart-create` API 端点，基于 `default_response_todo_id` 配置执行任务
- 前端新增 `SmartCreateModal` 组件，PC 端使用 Modal 弹窗，移动端使用底部 Drawer
- PC 端 Header 新增闪电图标按钮，移动端 FAB 扩展为 Speed Dial 组合按钮
- 支持模板参数替换 `{{content}}`/`{{message}}`/`{{raw_message}}`，当 Todo prompt 无占位符时自动追加用户内容
- 修复 Header 布局溢出问题，按钮改为图标+Tooltip 方式
- Makefile 改用 `cargo run` 替代 `cargo watch`，避免 RustEmbed 缓存问题

## Test plan
- [ ] PC 端点击闪电图标，弹出智能新建弹窗，输入内容提交
- [ ] 移动端点击 FAB，展开 Speed Dial，选择智能新建
- [ ] 未配置默认响应 Todo 时显示警告提示并跳转设置
- [ ] 验证提交内容正确传递到执行器参数（有/无占位符两种情况）
- [ ] Header 布局在不同屏幕宽度下不溢出

🤖 Generated with [CodeBuddy Code]