### PR TITLE
feat: 在 Dashboard 和关于页面添加分享卡片

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -22,6 +22,7 @@ import * as db from '../utils/database';
 import { getExecutorOption } from '../types';
 import type { DashboardStats, FeishuMessageStats } from '../types';
 import { formatRelativeTime } from '../utils/datetime';
+import { ShareCard } from './ShareCard';
 
 const TIME_RANGE_OPTIONS: { label: string; value: number | 'custom' }[] = [
   { label: '5小时', value: 5 },
@@ -865,6 +866,11 @@ export function Dashboard({ onBack }: DashboardProps) {
         </Card>
       );
     },
+  });
+
+  panels.push({
+    key: 'share-card',
+    render: () => <ShareCard />,
   });
 
   panels.push({

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -65,6 +65,7 @@ import yaml from 'js-yaml';
 import { CronPresetSelect } from './CronPresetSelect';
 import { SkillsPanel } from './SkillsPanel';
 import { SessionManager } from './SessionManager';
+import { ShareCard } from './ShareCard';
 
 const { Paragraph } = Typography;
 const { Dragger } = Upload;
@@ -2944,6 +2945,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
               <Empty description="无法获取版本信息" />
             )}
           </Card>
+          <ShareCard />
         </Spin>
       ),
     },

--- a/frontend/src/components/ShareCard.tsx
+++ b/frontend/src/components/ShareCard.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { Card, Button, App } from 'antd';
+import { ShareAltOutlined, CopyOutlined, CheckOutlined } from '@ant-design/icons';
+
+const SHARE_PROMPT = `请在我的电脑上全局安装 ntd (Nothing Todo) 这个工具，执行命令：
+npm install -g @weibaohui/nothing-todo
+安装完成后运行 ntd 启动服务，然后打开浏览器访问 http://localhost:8088`;
+
+export function ShareCard() {
+  const { message } = App.useApp();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(SHARE_PROMPT);
+      setCopied(true);
+      message.success('安装提示词已复制到剪贴板');
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      message.error('复制失败，请手动复制');
+    }
+  };
+
+  return (
+    <Card
+      title={
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <ShareAltOutlined />
+          <span>分享给朋友</span>
+        </div>
+      }
+      className="dashboard-card"
+      style={{ borderRadius: 12 }}
+      bodyStyle={{ padding: '16px 20px' }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>
+          将下方提示词复制发给 AI 助手，即可自动完成安装：
+        </div>
+        <div
+          style={{
+            background: 'var(--color-fill-quaternary)',
+            borderRadius: 8,
+            padding: '12px 16px',
+            fontFamily: 'monospace',
+            fontSize: 13,
+            lineHeight: 1.8,
+            whiteSpace: 'pre-wrap',
+            position: 'relative',
+          }}
+        >
+          {SHARE_PROMPT}
+        </div>
+        <Button
+          type="primary"
+          icon={copied ? <CheckOutlined /> : <CopyOutlined />}
+          onClick={handleCopy}
+          style={{ alignSelf: 'flex-end' }}
+        >
+          {copied ? '已复制' : '复制提示词'}
+        </Button>
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- 新增 ShareCard 组件，包含 AI 安装提示词和一键复制按钮
- Dashboard 页面瀑布流中新增分享卡片
- 设置 > 关于页面版本信息下方新增分享卡片
- 方便用户将安装方式分享给他人，提升传播性

## Test plan
- [ ] 访问 Dashboard 页面，确认分享卡片正常显示
- [ ] 访问 设置 > 关于 页面，确认分享卡片正常显示
- [ ] 点击复制按钮，确认提示词已复制到剪贴板
- [ ] 确认提示词内容与 README 一致

🤖 Generated with [CodeBuddy Code](https://cnb.cool/codebuddy/codebuddy-code)