### PR TITLE
fix: ShareCard 使用动态端口替代硬编码的 8088

### DIFF
--- a/frontend/src/components/ShareCard.tsx
+++ b/frontend/src/components/ShareCard.tsx
@@ -2,9 +2,13 @@ import { useState } from 'react';
 import { Card, Button, App } from 'antd';
 import { ShareAltOutlined, CopyOutlined, CheckOutlined } from '@ant-design/icons';
 
-const SHARE_PROMPT = `请在我的电脑上全局安装 ntd (Nothing Todo) 这个工具，执行命令：
+const getSharePrompt = () => {
+  const port = typeof window !== 'undefined' ? window.location.port : '8088';
+  const origin = typeof window !== 'undefined' ? window.location.origin : `http://localhost:${port}`;
+  return `请在我的电脑上全局安装 ntd (Nothing Todo) 这个工具，执行命令：
 npm install -g @weibaohui/nothing-todo
-安装完成后运行 ntd 启动服务，然后打开浏览器访问 http://localhost:8088`;
+安装完成后运行 ntd 启动服务，然后打开浏览器访问 ${origin}`;
+};
 
 export function ShareCard() {
   const { message } = App.useApp();
@@ -12,7 +16,7 @@ export function ShareCard() {
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(SHARE_PROMPT);
+      await navigator.clipboard.writeText(getSharePrompt());
       setCopied(true);
       message.success('安装提示词已复制到剪贴板');
       setTimeout(() => setCopied(false), 2000);
@@ -49,7 +53,7 @@ export function ShareCard() {
             position: 'relative',
           }}
         >
-          {SHARE_PROMPT}
+          {getSharePrompt()}
         </div>
         <Button
           type="primary"


### PR DESCRIPTION
## Summary
- 将 SHARE_PROMPT 从常量改为函数，使用 window.location.origin 动态获取当前端口
- 解决开发环境（端口 18088）用户看到错误端口的问题

## Test plan
- [ ] 验证开发环境下分享卡片显示正确端口
- [ ] 验证复制功能正常工作

## 关联 Issue
Closes #337