### PR TITLE
fix: 删除 TodoList 头部的'我的任务'标题

### DIFF
--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -60,9 +60,6 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
   if (isLoading) {
     return (
       <div className="todo-list-container">
-        <div className="todo-list-header">
-          <h3 style={{ margin: 0, fontWeight: 700, fontSize: 16, color: 'var(--color-text)' }}>我的任务</h3>
-        </div>
         <SkeletonList />
       </div>
     );
@@ -72,12 +69,6 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
     <div className="todo-list-container">
       {/* Header */}
       <div className="todo-list-header">
-        <h3 style={{ margin: 0, fontWeight: 700, fontSize: 16, color: 'var(--color-text)' }}>
-          我的任务
-          <span style={{ fontSize: 13, color: 'var(--color-text-tertiary)', fontWeight: 500, marginLeft: 8 }}>
-            ({filteredTodos.length})
-          </span>
-        </h3>
         <div className="header-actions">
           <Button
             type="text"


### PR DESCRIPTION
## Summary
- 删除 TodoList 组件头部的"我的任务 (n)"标题文字
- 只保留一排图标按钮（仪表盘、看板、主题切换、设置等）

## Test plan
- [x] Playwright 自动化验证通过，确认"我的任务"文字已移除

## 关联 Issue
Closes #340