### PR TITLE
fix: 修复 scheduler_tests 中的 flaky test test_cron_schedule_next

### DIFF
--- a/backend/tests/scheduler_tests.rs
+++ b/backend/tests/scheduler_tests.rs
@@ -69,9 +69,10 @@ mod cron_validation_tests {
 
         assert!(next.is_some());
         let next_time = next.unwrap();
-        // Next should be at most 10 seconds in the future (strictly less to avoid boundary issues)
+        // Next should be at most 10 seconds in the future
+        // Allow 0 seconds for boundary conditions (when current time is exactly on a schedule boundary)
         let duration = next_time.signed_duration_since(now);
-        assert!(duration.num_seconds() > 0 && duration.num_seconds() < 10,
+        assert!(duration.num_seconds() >= 0 && duration.num_seconds() < 10,
             "next run should be within 10 seconds, got {} seconds", duration.num_seconds());
     }
 }


### PR DESCRIPTION
## Summary
- 修复 `test_cron_schedule_next` 测试中的 flaky test 问题
- 当系统时间恰好在 cron 表达式边界时，`upcoming()` 可能返回当前时间（duration=0）

## Test plan
- [x] 验证修改后的断言逻辑正确
- [x] 运行 `cargo test --test scheduler_tests` 通过

## Related issue
Fixes #342