### PR TITLE
fix: 修复 ShareCard getSharePrompt fallback 逻辑潜在 bug

### DIFF
--- a/frontend/src/components/ShareCard.tsx
+++ b/frontend/src/components/ShareCard.tsx
@@ -3,11 +3,14 @@ import { Card, Button, App } from 'antd';
 import { ShareAltOutlined, CopyOutlined, CheckOutlined } from '@ant-design/icons';
 
 const getSharePrompt = () => {
-  const port = typeof window !== 'undefined' ? window.location.port : '8088';
-  const origin = typeof window !== 'undefined' ? window.location.origin : `http://localhost:${port}`;
+  if (typeof window === 'undefined') {
+    return `请在我的电脑上全局安装 ntd (Nothing Todo) 这个工具，执行命令：
+npm install -g @weibaohui/nothing-todo
+安装完成后运行 ntd 启动服务，然后打开浏览器访问 http://localhost:8088`;
+  }
   return `请在我的电脑上全局安装 ntd (Nothing Todo) 这个工具，执行命令：
 npm install -g @weibaohui/nothing-todo
-安装完成后运行 ntd 启动服务，然后打开浏览器访问 ${origin}`;
+安装完成后运行 ntd 启动服务，然后打开浏览器访问 ${window.location.origin}`;
 };
 
 export function ShareCard() {


### PR DESCRIPTION
## Summary
- 修复 ShareCard 组件中 `getSharePrompt` 函数的 fallback 逻辑潜在 bug
- 当 `window.location.port` 为空且 `window.location.origin` 未定义时，原代码会 fallback 到无效 URL `http://localhost:`

## Test plan
- [ ] 验证浏览器环境下 ShareCard 显示正确的 origin
- [ ] 验证 SSR 环境下 fallback 到 http://localhost:8088

## 关联 Issue
Fixes #345