### PR TITLE
fix: 修复 scheduler_module_tests 中的 flaky test

### DIFF
--- a/backend/tests/scheduler_module_tests.rs
+++ b/backend/tests/scheduler_module_tests.rs
@@ -91,8 +91,9 @@ mod scheduler_cron_validation_tests {
         let next_time = next.unwrap();
 
         // Next run should be in the future (within 10 seconds)
+        // Allow 0 seconds for boundary conditions (when current time is exactly on a schedule boundary)
         let duration = next_time.signed_duration_since(now);
-        assert!(duration.num_seconds() > 0, "Next run should be in the future");
+        assert!(duration.num_seconds() >= 0, "Next run should be in the future");
         assert!(duration.num_seconds() <= 10, "Next run should be within 10 seconds");
     }
 


### PR DESCRIPTION
## Summary

- 修复  中  测试的 flaky 问题
- 将断言从  改为 ，允许边界条件下的 0 秒情况

## Test plan

- [ ] 运行  验证测试通过

## Related Issue

Fixes #349