### PR TITLE
docs: add ntd skill install command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ ntd upgrade      # 升级到最新版本
 ntd --help       # 查看帮助
 ```
 
+### Skill 安装
+
+`ntd skill install` 将内置的 ntd 使用技能安装到各 AI 执行器的 skill 目录（如 `~/.claude/skills/ntd-usage/`），让 AI 执行器在执行任务时能更好地理解和使用 ntd。
+
+```bash
+ntd skill install              # 安装到所有已配置的执行器
+ntd skill install --force       # 强制重新安装（覆盖已有）
+ntd skill install -e claudecode # 仅安装到指定执行器
+```
+
+支持的执行器：Claude Code、AtomCode 等（根据你配置的 AI 执行器自动适配）。
+
 ### 升级
 
 ```bash


### PR DESCRIPTION
## 变更内容

为 README.md 添加   ✓ Installed ntd-usage skill for claudecode (1 files)
  ✓ Installed ntd-usage skill for hermes (1 files)
  ✓ Installed ntd-usage skill for codex (1 files)
  ✓ Installed ntd-usage skill for codebuddy (1 files)
  ✓ Installed ntd-usage skill for opencode (1 files)
  ✓ Installed ntd-usage skill for atomcode (1 files)
  ✓ Installed ntd-usage skill for kimi (1 files)
  ✓ Installed ntd-usage skill for joinai (1 files)
Done. Installed for 8 executor(s), skipped 0 (already present). 命令的使用说明。

### 新增内容

在「命令行」部分后添加「Skill 安装」小节，说明：
-   ✓ claudecode already installed (use --force to reinstall)
  ✓ hermes already installed (use --force to reinstall)
  ✓ codex already installed (use --force to reinstall)
  ✓ codebuddy already installed (use --force to reinstall)
  ✓ opencode already installed (use --force to reinstall)
  ✓ atomcode already installed (use --force to reinstall)
  ✓ kimi already installed (use --force to reinstall)
  ✓ joinai already installed (use --force to reinstall)
All skills already installed. Use `ntd skill install --force` to reinstall. — 安装内置技能到 AI 执行器
-  参数 — 强制重新安装
-  参数 — 仅安装到指定执行器

### 相关 Issue

Fixes #352