### PR TITLE
fix: SmartCreate handler 模板无占位符时直接使用用户内容

### DIFF
--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -487,15 +487,11 @@ pub async fn smart_create_handler(
 
     let mut message = todo.prompt.clone();
 
-    // 如果 prompt 模板中没有任何占位符，将用户内容追加到 message 末尾，
-    // 确保用户提交的内容一定能传递到执行器
+    // 如果 prompt 模板中没有任何占位符，说明模板不期望用户输入作为参数，
+    // 此时直接用用户内容作为消息，而不是追加到模板末尾（避免模板中的其他占位符被保留）
     let has_placeholder = params.keys().any(|key| message.contains(&format!("{{{{{}}}}}", key)));
     if !has_placeholder {
-        if message.is_empty() {
-            message = content.to_string();
-        } else {
-            message = format!("{}\n\n{}", message, content);
-        }
+        message = content.to_string();
     }
 
     let result = start_todo_execution(RunTodoExecutionRequest {


### PR DESCRIPTION
## Summary

- 当 Todo 模板不包含 `{{content}}`、`{{message}}`、`{{raw_message}}` 占位符时，直接用用户输入内容替换整个模板，而不是追加内容到模板末尾
- 修复了当模板包含其他占位符（如 `{{input}}`）时，这些占位符不会被替换导致最终消息包含未解析占位符的问题

## Test plan

- [x] 现有测试全部通过
- [ ] 需要手动测试：创建包含非标准占位符的 Todo，使用 SmartCreate 提交内容，验证消息中无未解析占位符

## Related Issue

Fixes #356