### PR TITLE
feat: 执行器管理添加批量检测功能

### DIFF
--- a/backend/src/handlers/executor_config.rs
+++ b/backend/src/handlers/executor_config.rs
@@ -145,8 +145,30 @@ pub async fn detect_all_executors(
     let mut found_count = 0;
 
     for ec in executors {
-        let path = if ec.path.is_empty() { ec.name.clone() } else { ec.path.clone() };
-        let (found, resolved) = detect_binary(&path);
+        // If path is empty, detection fails (no valid path to detect)
+        if ec.path.is_empty() {
+            if ec.enabled {
+                // Was enabled but path is empty - disable it
+                state.db.update_executor(&ec.name, None, Some(false), None, None)
+                    .await
+                    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+                if let Some(et) = crate::adapters::parse_executor_type(&ec.name) {
+                    state.executor_registry.unregister(et).await;
+                }
+            }
+
+            results.push(ExecutorDetectInfo {
+                name: ec.name,
+                display_name: ec.display_name,
+                binary_found: false,
+                path_resolved: None,
+                enabled: false,
+            });
+            continue;
+        }
+
+        let (found, resolved) = detect_binary(&ec.path);
 
         // Update executor enabled state based on detection result
         let new_enabled = found;
@@ -157,7 +179,9 @@ pub async fn detect_all_executors(
 
             // Update registry based on new enabled state
             if new_enabled {
-                state.executor_registry.register_by_name(&ec.name, &ec.path).await;
+                // Use resolved path if available, otherwise use original path
+                let path_to_register = resolved.unwrap_or(&ec.path);
+                state.executor_registry.register_by_name(&ec.name, path_to_register).await;
             } else if let Some(et) = crate::adapters::parse_executor_type(&ec.name) {
                 state.executor_registry.unregister(et).await;
             }

--- a/backend/src/handlers/executor_config.rs
+++ b/backend/src/handlers/executor_config.rs
@@ -169,6 +169,8 @@ pub async fn detect_all_executors(
         }
 
         let (found, resolved) = detect_binary(&ec.path);
+        // Clone resolved for path_resolved field before moving
+        let path_resolved = resolved.clone();
 
         // Update executor enabled state based on detection result
         let new_enabled = found;
@@ -195,7 +197,7 @@ pub async fn detect_all_executors(
             name: ec.name,
             display_name: ec.display_name,
             binary_found: found,
-            path_resolved: resolved,
+            path_resolved,
             enabled: new_enabled,
         });
     }

--- a/backend/src/handlers/executor_config.rs
+++ b/backend/src/handlers/executor_config.rs
@@ -179,9 +179,9 @@ pub async fn detect_all_executors(
 
             // Update registry based on new enabled state
             if new_enabled {
-                // Use resolved path if available, otherwise use original path
-                let path_to_register = resolved.unwrap_or(&ec.path);
-                state.executor_registry.register_by_name(&ec.name, path_to_register).await;
+                // Use resolved path if available, otherwise clone original path
+                let path_to_register = resolved.unwrap_or_else(|| ec.path.clone());
+                state.executor_registry.register_by_name(&ec.name, &path_to_register).await;
             } else if let Some(et) = crate::adapters::parse_executor_type(&ec.name) {
                 state.executor_registry.unregister(et).await;
             }

--- a/backend/src/handlers/executor_config.rs
+++ b/backend/src/handlers/executor_config.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::handlers::{ApiJson, AppError, AppState};
-use crate::models::{ApiResponse, ExecutorConfig, ExecutorDetectResult, ExecutorTestResult, UpdateExecutorRequest};
+use crate::models::{ApiResponse, ExecutorConfig, ExecutorDetectResult, ExecutorTestResult, UpdateExecutorRequest, ExecutorBatchDetectResult, ExecutorDetectInfo};
 
 pub async fn list_executors(State(state): State<AppState>) -> Result<ApiResponse<Vec<ExecutorConfig>>, AppError> {
     let executors = state.db.get_executors().await.map_err(|e| AppError::Internal(e.to_string()))?;
@@ -134,4 +134,52 @@ fn detect_binary(path: &str) -> (bool, Option<String>) {
         Ok(resolved) => (true, Some(resolved.to_string_lossy().to_string())),
         Err(_) => (false, None),
     }
+}
+
+pub async fn detect_all_executors(
+    State(state): State<AppState>,
+) -> Result<ApiResponse<ExecutorBatchDetectResult>, AppError> {
+    let executors = state.db.get_executors().await.map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let mut results: Vec<ExecutorDetectInfo> = Vec::new();
+    let mut found_count = 0;
+
+    for ec in executors {
+        let path = if ec.path.is_empty() { ec.name.clone() } else { ec.path.clone() };
+        let (found, resolved) = detect_binary(&path);
+
+        // Update executor enabled state based on detection result
+        let new_enabled = found;
+        if ec.enabled != new_enabled {
+            state.db.update_executor(&ec.name, None, Some(new_enabled), None, None)
+                .await
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+
+            // Update registry based on new enabled state
+            if new_enabled {
+                state.executor_registry.register_by_name(&ec.name, &ec.path).await;
+            } else if let Some(et) = crate::adapters::parse_executor_type(&ec.name) {
+                state.executor_registry.unregister(et).await;
+            }
+        }
+
+        if found {
+            found_count += 1;
+        }
+
+        results.push(ExecutorDetectInfo {
+            name: ec.name,
+            display_name: ec.display_name,
+            binary_found: found,
+            path_resolved: resolved,
+            enabled: new_enabled,
+        });
+    }
+
+    let total = results.len();
+    Ok(ApiResponse::ok(ExecutorBatchDetectResult {
+        results,
+        total,
+        found_count,
+    }))
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -423,6 +423,7 @@ pub fn create_app(
         .route("/xyz/executors/{name}", put(executor_config::update_executor))
         .route("/xyz/executors/{name}/detect", post(executor_config::detect_executor))
         .route("/xyz/executors/{name}/test", post(executor_config::test_executor))
+        .route("/xyz/executors/detect-all", post(executor_config::detect_all_executors))
         .route("/xyz/skills", get(skills::list_skills))
         .route("/xyz/skills/compare", get(skills::compare_skills))
         .route("/xyz/skills/sync", post(skills::sync_skill))

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -544,6 +544,22 @@ pub struct ExecutorTestResult {
     pub error: Option<String>,
 }
 
+#[derive(Serialize)]
+pub struct ExecutorBatchDetectResult {
+    pub results: Vec<ExecutorDetectInfo>,
+    pub total: usize,
+    pub found_count: usize,
+}
+
+#[derive(Serialize)]
+pub struct ExecutorDetectInfo {
+    pub name: String,
+    pub display_name: String,
+    pub binary_found: bool,
+    pub path_resolved: Option<String>,
+    pub enabled: bool,
+}
+
 // Executor types
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1086,28 +1086,44 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                 loading={batchDetecting}
                 onClick={async () => {
                   setBatchDetecting(true);
+                  let foundCount = 0;
                   try {
-                    const result = await db.detectAllExecutors();
-                    // Update executors state with new enabled states
-                    setExecutors((prev) =>
-                      prev.map((ec) => {
-                        const detected = result.results.find((r) => r.name === ec.name);
-                        if (detected) {
-                          return { ...ec, enabled: detected.enabled };
+                    for (const ec of executors) {
+                      setDetectingExecutor(ec.name);
+                      try {
+                        const result = await db.detectExecutor(ec.name);
+                        // Update detect results immediately
+                        setDetectResults((prev) => ({
+                          ...prev,
+                          [ec.name]: { found: result.binary_found, resolved: result.path_resolved },
+                        }));
+
+                        // Update executor enabled state if detection result differs
+                        if (result.binary_found && !ec.enabled) {
+                          const updated = await db.updateExecutor(ec.name, { enabled: true });
+                          setExecutors((prev) =>
+                            prev.map((e) => (e.name === ec.name ? updated : e))
+                          );
+                          foundCount++;
+                        } else if (!result.binary_found && ec.enabled) {
+                          const updated = await db.updateExecutor(ec.name, { enabled: false });
+                          setExecutors((prev) =>
+                            prev.map((e) => (e.name === ec.name ? updated : e))
+                          );
+                        } else if (result.binary_found) {
+                          foundCount++;
                         }
-                        return ec;
-                      })
-                    );
-                    // Update detect results
-                    const newDetectResults: Record<string, { found: boolean; resolved: string | null }> = {};
-                    for (const r of result.results) {
-                      newDetectResults[r.name] = { found: r.binary_found, resolved: r.path_resolved };
+                      } catch (err) {
+                        // Continue with next executor on individual detection failure
+                      }
+                      // Small delay between detections to avoid overwhelming the system
+                      await new Promise((resolve) => setTimeout(resolve, 100));
                     }
-                    setDetectResults(newDetectResults);
-                    message.success(`批量检测完成：${result.found_count}/${result.total} 个执行器可用`);
+                    message.success(`批量检测完成：${foundCount}/${executors.length} 个执行器可用`);
                   } catch (err: any) {
                     message.error('批量检测失败: ' + (err?.message || String(err)));
                   } finally {
+                    setDetectingExecutor(null);
                     setBatchDetecting(false);
                   }
                 }}

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -163,6 +163,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
   }, [executors]);
   const [detectingExecutor, setDetectingExecutor] = useState<string | null>(null);
   const [testingExecutor, setTestingExecutor] = useState<string | null>(null);
+  const [batchDetecting, setBatchDetecting] = useState(false);
   const [detectResults, setDetectResults] = useState<Record<string, { found: boolean; resolved: string | null }>>({});
   const [testModalVisible, setTestModalVisible] = useState(false);
   const [testModalData, setTestModalData] = useState<{ name: string; result: { test_passed: boolean; output: string | null; error: string | null } } | null>(null);
@@ -1078,6 +1079,42 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
             <Paragraph type="secondary" style={{ marginBottom: 16 }}>
               管理执行器的路径、开关状态，并检测二进制是否可用。关闭开关的执行器不会出现在 Todo 的执行器选择列表中。
             </Paragraph>
+            <div style={{ marginBottom: 12 }}>
+              <Button
+                type="primary"
+                icon={<SearchOutlined />}
+                loading={batchDetecting}
+                onClick={async () => {
+                  setBatchDetecting(true);
+                  try {
+                    const result = await db.detectAllExecutors();
+                    // Update executors state with new enabled states
+                    setExecutors((prev) =>
+                      prev.map((ec) => {
+                        const detected = result.results.find((r) => r.name === ec.name);
+                        if (detected) {
+                          return { ...ec, enabled: detected.enabled };
+                        }
+                        return ec;
+                      })
+                    );
+                    // Update detect results
+                    const newDetectResults: Record<string, { found: boolean; resolved: string | null }> = {};
+                    for (const r of result.results) {
+                      newDetectResults[r.name] = { found: r.binary_found, resolved: r.path_resolved };
+                    }
+                    setDetectResults(newDetectResults);
+                    message.success(`批量检测完成：${result.found_count}/${result.total} 个执行器可用`);
+                  } catch (err: any) {
+                    message.error('批量检测失败: ' + (err?.message || String(err)));
+                  } finally {
+                    setBatchDetecting(false);
+                  }
+                }}
+              >
+                批量检测
+              </Button>
+            </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
               {executors.map((ec) => {
                 const detectResult = detectResults[ec.name];

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1086,10 +1086,9 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                 loading={batchDetecting}
                 onClick={async () => {
                   setBatchDetecting(true);
-                  let foundCount = 0;
+                  let availableCount = 0;
                   try {
                     for (const ec of executors) {
-                      setDetectingExecutor(ec.name);
                       try {
                         const result = await db.detectExecutor(ec.name);
                         // Update detect results immediately
@@ -1098,30 +1097,29 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                           [ec.name]: { found: result.binary_found, resolved: result.path_resolved },
                         }));
 
-                        // Update executor enabled state if detection result differs
-                        if (result.binary_found && !ec.enabled) {
-                          const updated = await db.updateExecutor(ec.name, { enabled: true });
-                          setExecutors((prev) =>
-                            prev.map((e) => (e.name === ec.name ? updated : e))
-                          );
-                          foundCount++;
-                        } else if (!result.binary_found && ec.enabled) {
+                        // Update executor enabled state based on detection result
+                        if (result.binary_found) {
+                          availableCount++;
+                          if (!ec.enabled) {
+                            const updated = await db.updateExecutor(ec.name, { enabled: true });
+                            setExecutors((prev) =>
+                              prev.map((e) => (e.name === ec.name ? updated : e))
+                            );
+                          }
+                        } else if (ec.enabled) {
                           const updated = await db.updateExecutor(ec.name, { enabled: false });
                           setExecutors((prev) =>
                             prev.map((e) => (e.name === ec.name ? updated : e))
                           );
-                        } else if (result.binary_found) {
-                          foundCount++;
                         }
                       } catch (err) {
                         // Continue with next executor on individual detection failure
                       }
                     }
-                    message.success(`批量检测完成：${foundCount}/${executors.length} 个执行器可用`);
+                    message.success(`批量检测完成：${availableCount}/${executors.length} 个执行器可用`);
                   } catch (err: any) {
                     message.error('批量检测失败: ' + (err?.message || String(err)));
                   } finally {
-                    setDetectingExecutor(null);
                     setBatchDetecting(false);
                   }
                 }}

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1116,8 +1116,6 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
                       } catch (err) {
                         // Continue with next executor on individual detection failure
                       }
-                      // Small delay between detections to avoid overwhelming the system
-                      await new Promise((resolve) => setTimeout(resolve, 100));
                     }
                     message.success(`批量检测完成：${foundCount}/${executors.length} 个执行器可用`);
                   } catch (err: any) {

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -371,6 +371,22 @@ export async function testExecutor(name: string): Promise<{ test_passed: boolean
   return result;
 }
 
+export interface ExecutorBatchDetectResult {
+  results: {
+    name: string;
+    display_name: string;
+    binary_found: boolean;
+    path_resolved: string | null;
+    enabled: boolean;
+  }[];
+  total: number;
+  found_count: number;
+}
+
+export async function detectAllExecutors(): Promise<ExecutorBatchDetectResult> {
+  return unwrap(await api.post<ApiResp<ExecutorBatchDetectResult>>('/xyz/executors/detect-all'));
+}
+
 // Skills APIs
 
 export async function getSkillsList(): Promise<ExecutorSkills[]> {


### PR DESCRIPTION
## Summary
- 后端添加 `POST /xyz/executors/detect-all` 接口，批量检测所有执行器的二进制文件可用性
- 检测结果根据二进制是否找到自动设置执行器的启用/禁用状态
- 前端设置页面添加"批量检测"按钮，一键检测所有执行器并更新状态

## Test plan
- [ ] 启动开发服务 `make dev`
- [ ] 访问设置 -> 执行器管理页面
- [ ] 点击"批量检测"按钮
- [ ] 验证执行器状态根据检测结果正确更新

## 关联 Issue
Closes #355