### PR TITLE
fix: 修复 ShareCard getSharePrompt SSR fallback 硬编码端口 bug

### DIFF
--- a/frontend/src/components/ShareCard.tsx
+++ b/frontend/src/components/ShareCard.tsx
@@ -3,14 +3,12 @@ import { Card, Button, App } from 'antd';
 import { ShareAltOutlined, CopyOutlined, CheckOutlined } from '@ant-design/icons';
 
 const getSharePrompt = () => {
-  if (typeof window === 'undefined') {
-    return `请在我的电脑上全局安装 ntd (Nothing Todo) 这个工具，执行命令：
-npm install -g @weibaohui/nothing-todo
-安装完成后运行 ntd 启动服务，然后打开浏览器访问 http://localhost:8088`;
-  }
+  const port = typeof window !== 'undefined' ? window.location.port : '8088';
+  const origin =
+    typeof window !== 'undefined' ? window.location.origin : `http://localhost:${port}`;
   return `请在我的电脑上全局安装 ntd (Nothing Todo) 这个工具，执行命令：
 npm install -g @weibaohui/nothing-todo
-安装完成后运行 ntd 启动服务，然后打开浏览器访问 ${window.location.origin}`;
+安装完成后运行 ntd 启动服务，然后打开浏览器访问 ${origin}`;
 };
 
 export function ShareCard() {


### PR DESCRIPTION
## Summary
- 修复 getSharePrompt 在 SSR 环境 fallback 时硬编码返回 8088 端口的问题
- 根据 window.location.port 动态获取实际端口

## Test plan
- [ ] 开发环境 18088 端口验证 SSR fallback 端口正确
- [ ] 生产环境 8088 端口验证功能正常