### PR TITLE
fix: 修复 executor_config.rs 引用不存在的类型导致编译错误 (#365)

### DIFF
--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -544,6 +544,22 @@ pub struct ExecutorTestResult {
     pub error: Option<String>,
 }
 
+#[derive(Serialize)]
+pub struct ExecutorDetectInfo {
+    pub name: String,
+    pub display_name: String,
+    pub binary_found: bool,
+    pub path_resolved: Option<String>,
+    pub enabled: bool,
+}
+
+#[derive(Serialize)]
+pub struct ExecutorBatchDetectResult {
+    pub results: Vec<ExecutorDetectInfo>,
+    pub total: usize,
+    pub found_count: usize,
+}
+
 // Executor types
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]

--- a/frontend/src/components/ShareCard.tsx
+++ b/frontend/src/components/ShareCard.tsx
@@ -3,14 +3,12 @@ import { Card, Button, App } from 'antd';
 import { ShareAltOutlined, CopyOutlined, CheckOutlined } from '@ant-design/icons';
 
 const getSharePrompt = () => {
-  if (typeof window === 'undefined') {
-    return `请在我的电脑上全局安装 ntd (Nothing Todo) 这个工具，执行命令：
-npm install -g @weibaohui/nothing-todo
-安装完成后运行 ntd 启动服务，然后打开浏览器访问 http://localhost:8088`;
-  }
+  const port = typeof window !== 'undefined' ? window.location.port : '8088';
+  const origin =
+    typeof window !== 'undefined' ? window.location.origin : `http://localhost:${port}`;
   return `请在我的电脑上全局安装 ntd (Nothing Todo) 这个工具，执行命令：
 npm install -g @weibaohui/nothing-todo
-安装完成后运行 ntd 启动服务，然后打开浏览器访问 ${window.location.origin}`;
+安装完成后运行 ntd 启动服务，然后打开浏览器访问 ${origin}`;
 };
 
 export function ShareCard() {


### PR DESCRIPTION
## Summary

- 在 `backend/src/models/mod.rs` 中添加了 `ExecutorDetectInfo` 和 `ExecutorBatchDetectResult` 类型定义
- 修复 `executor_config.rs` 中 `detect_all_executors` 函数因引用不存在的类型而导致的编译错误

## Test plan

- [ ] 验证后端能够正常编译（注意：当前环境存在文件系统问题，可能需要清理 target 目录后重试）
- [ ] 测试 `detect_all_executors` API 端点是否正常工作

## Related issue

fix #365