### PR TITLE
feat: 添加 detect_all_executors API 批量检测 executor 端点

### DIFF
--- a/backend/src/handlers/executor_config.rs
+++ b/backend/src/handlers/executor_config.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::handlers::{ApiJson, AppError, AppState};
-use crate::models::{ApiResponse, ExecutorConfig, ExecutorDetectResult, ExecutorTestResult, UpdateExecutorRequest};
+use crate::models::{ApiResponse, ExecutorConfig, ExecutorDetectResult, ExecutorTestResult, UpdateExecutorRequest, ExecutorBatchDetectResult, ExecutorDetectInfo};
 
 pub async fn list_executors(State(state): State<AppState>) -> Result<ApiResponse<Vec<ExecutorConfig>>, AppError> {
     let executors = state.db.get_executors().await.map_err(|e| AppError::Internal(e.to_string()))?;
@@ -134,4 +134,78 @@ fn detect_binary(path: &str) -> (bool, Option<String>) {
         Ok(resolved) => (true, Some(resolved.to_string_lossy().to_string())),
         Err(_) => (false, None),
     }
+}
+
+pub async fn detect_all_executors(
+    State(state): State<AppState>,
+) -> Result<ApiResponse<ExecutorBatchDetectResult>, AppError> {
+    let executors = state.db.get_executors().await.map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let mut results: Vec<ExecutorDetectInfo> = Vec::new();
+    let mut found_count = 0;
+
+    for ec in executors {
+        // If path is empty, detection fails (no valid path to detect)
+        if ec.path.is_empty() {
+            if ec.enabled {
+                // Was enabled but path is empty - disable it
+                state.db.update_executor(&ec.name, None, Some(false), None, None)
+                    .await
+                    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+                if let Some(et) = crate::adapters::parse_executor_type(&ec.name) {
+                    state.executor_registry.unregister(et).await;
+                }
+            }
+
+            results.push(ExecutorDetectInfo {
+                name: ec.name,
+                display_name: ec.display_name,
+                binary_found: false,
+                path_resolved: None,
+                enabled: false,
+            });
+            continue;
+        }
+
+        let (found, resolved) = detect_binary(&ec.path);
+        // Clone resolved for path_resolved field before moving
+        let path_resolved = resolved.clone();
+
+        // Update executor enabled state based on detection result
+        let new_enabled = found;
+        if ec.enabled != new_enabled {
+            state.db.update_executor(&ec.name, None, Some(new_enabled), None, None)
+                .await
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+
+            // Update registry based on new enabled state
+            if new_enabled {
+                // Use resolved path if available, otherwise clone original path
+                let path_to_register = resolved.unwrap_or_else(|| ec.path.clone());
+                state.executor_registry.register_by_name(&ec.name, &path_to_register).await;
+            } else if let Some(et) = crate::adapters::parse_executor_type(&ec.name) {
+                state.executor_registry.unregister(et).await;
+            }
+        }
+
+        if found {
+            found_count += 1;
+        }
+
+        results.push(ExecutorDetectInfo {
+            name: ec.name,
+            display_name: ec.display_name,
+            binary_found: found,
+            path_resolved,
+            enabled: new_enabled,
+        });
+    }
+
+    let total = results.len();
+    Ok(ApiResponse::ok(ExecutorBatchDetectResult {
+        results,
+        total,
+        found_count,
+    }))
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -423,6 +423,7 @@ pub fn create_app(
         .route("/xyz/executors/{name}", put(executor_config::update_executor))
         .route("/xyz/executors/{name}/detect", post(executor_config::detect_executor))
         .route("/xyz/executors/{name}/test", post(executor_config::test_executor))
+        .route("/xyz/executors/detect-all", post(executor_config::detect_all_executors))
         .route("/xyz/skills", get(skills::list_skills))
         .route("/xyz/skills/compare", get(skills::compare_skills))
         .route("/xyz/skills/sync", post(skills::sync_skill))

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -544,6 +544,22 @@ pub struct ExecutorTestResult {
     pub error: Option<String>,
 }
 
+#[derive(Serialize)]
+pub struct ExecutorDetectInfo {
+    pub name: String,
+    pub display_name: String,
+    pub binary_found: bool,
+    pub path_resolved: Option<String>,
+    pub enabled: bool,
+}
+
+#[derive(Serialize)]
+pub struct ExecutorBatchDetectResult {
+    pub results: Vec<ExecutorDetectInfo>,
+    pub total: usize,
+    pub found_count: usize,
+}
+
 // Executor types
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "lowercase")]

--- a/frontend/src/components/ShareCard.tsx
+++ b/frontend/src/components/ShareCard.tsx
@@ -3,14 +3,12 @@ import { Card, Button, App } from 'antd';
 import { ShareAltOutlined, CopyOutlined, CheckOutlined } from '@ant-design/icons';
 
 const getSharePrompt = () => {
-  if (typeof window === 'undefined') {
-    return `请在我的电脑上全局安装 ntd (Nothing Todo) 这个工具，执行命令：
-npm install -g @weibaohui/nothing-todo
-安装完成后运行 ntd 启动服务，然后打开浏览器访问 http://localhost:8088`;
-  }
+  const port = typeof window !== 'undefined' ? window.location.port : '8088';
+  const origin =
+    typeof window !== 'undefined' ? window.location.origin : `http://localhost:${port}`;
   return `请在我的电脑上全局安装 ntd (Nothing Todo) 这个工具，执行命令：
 npm install -g @weibaohui/nothing-todo
-安装完成后运行 ntd 启动服务，然后打开浏览器访问 ${window.location.origin}`;
+安装完成后运行 ntd 启动服务，然后打开浏览器访问 ${origin}`;
 };
 
 export function ShareCard() {


### PR DESCRIPTION
## Summary

- 添加 `detect_all_executors` 函数用于批量检测所有 executor 的可用性
- 注册 `/xyz/executors/detect-all` POST 路由
- 根据检测结果自动更新 executor 的启用/禁用状态

## 修复的问题

fix #367

## Test plan

- [ ] 验证 `/xyz/executors/detect-all` 路由可正常访问
- [ ] 验证批量检测返回正确的结果格式
- [ ] 验证 executor 状态自动更新逻辑正确