### PR TITLE
fix: 首次运行时正确展开 ~ 路径为 home 目录 (Issue #372)

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -158,6 +158,7 @@ impl Config {
             } else {
                 Config::default()
             };
+            cfg.normalize_paths();
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent).ok();
             }
@@ -180,7 +181,9 @@ impl Config {
             }
             Err(e) => {
                 eprintln!("Warning: failed to read config file ({}), using defaults", e);
-                Config::default()
+                let mut cfg = Config::default();
+                cfg.normalize_paths();
+                cfg
             }
         }
     }


### PR DESCRIPTION
## 修复内容

问题：首次运行创建数据库时，`db_path` 为 `~/.ntd/data.db` 未被展开，导致程序尝试创建路径字面量为 `~/.ntd/data.db` 的文件。

修复：在 `Config::load()` 返回默认配置前调用 `normalize_paths()`，确保 `~` 被正确展开为 home 目录绝对路径。

## 修改文件

- `backend/src/config.rs`：在返回默认配置的代码路径中添加 `normalize_paths()` 调用

## 测试

- [ ] 在全新环境首次运行，数据库路径应正确展开为 `/home/user/.ntd/data.db`

Closes #372