### PR TITLE
fix: SmartCreate handler 模板无占位符时追加用户内容而非替换模板

### DIFF
--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -487,11 +487,15 @@ pub async fn smart_create_handler(
 
     let mut message = todo.prompt.clone();
 
-    // 如果 prompt 模板中没有任何占位符，说明模板不期望用户输入作为参数，
-    // 此时直接用用户内容作为消息，而不是追加到模板末尾（避免模板中的其他占位符被保留）
+    // 如果 prompt 模板中没有任何占位符，将用户内容追加到 message 末尾，
+    // 确保用户提交的内容一定能传递到执行器
     let has_placeholder = params.keys().any(|key| message.contains(&format!("{{{{{}}}}}", key)));
     if !has_placeholder {
-        message = content.to_string();
+        if message.is_empty() {
+            message = content.to_string();
+        } else {
+            message = format!("{}\n\n{}", message, content);
+        }
     }
 
     let result = start_todo_execution(RunTodoExecutionRequest {


### PR DESCRIPTION
## Summary

当 Todo 模板不包含标准占位符（{{content}}、{{message}}、{{raw_message}}）时，将用户输入内容追加到模板末尾，而不是直接替换整个模板。这样可以确保模板中的指令信息不会被丢失。

## Test plan

- [ ] 创建包含指令但无标准占位符的 Todo，使用 SmartCreate 提交内容，验证消息中指令被保留
- [ ] 创建空模板的 Todo，使用 SmartCreate 提交内容，验证用户内容正常传递
- [ ] 现有测试全部通过

## Related Issue

Fixes #374