### PR TITLE
fix: SmartCreate handler 保留模板内容并追加用户输入

### DIFF
--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -487,11 +487,15 @@ pub async fn smart_create_handler(
 
     let mut message = todo.prompt.clone();
 
-    // 如果 prompt 模板中没有任何占位符，说明模板不期望用户输入作为参数，
-    // 此时直接用用户内容作为消息，而不是追加到模板末尾（避免模板中的其他占位符被保留）
+    // 如果 prompt 模板中没有任何标准占位符（{{content}}、{{message}}、{{raw_message}}），
+    // 将用户内容追加到模板末尾，确保用户输入能被执行器收到
     let has_placeholder = params.keys().any(|key| message.contains(&format!("{{{{{}}}}}", key)));
     if !has_placeholder {
-        message = content.to_string();
+        if message.is_empty() {
+            message = content.to_string();
+        } else {
+            message = format!("{}\n\n{}", message, content);
+        }
     }
 
     let result = start_todo_execution(RunTodoExecutionRequest {


### PR DESCRIPTION
## Summary

修复 SmartCreate handler 在模板无标准占位符时丢失模板上下文的问题。

- **问题**：当 Todo 模板不包含 `{{content}}`、`{{message}}`、`{{raw_message}}` 时，原行为直接用用户内容替换整个模板，导致模板中的指令和上下文丢失
- **修复**：如果模板非空则追加用户内容到模板末尾，只有模板为空时才替换

## Test plan

- [ ] 创建包含自定义 prompt 模板的 Todo
- [ ] 使用 SmartCreate 触发执行
- [ ] 验证执行器收到的消息包含完整的模板内容 + 用户输入

## Related Issue

#376