### PR TITLE
fix: SmartCreate handler 模板含非标准占位符时正确替换

### DIFF
--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -1,4 +1,5 @@
 use axum::extract::{Path, Query, State};
+use regex::Regex;
 use serde::Deserialize;
 
 use crate::adapters::parse_executor_type;
@@ -486,29 +487,6 @@ pub async fn smart_create_handler(
     params.insert("raw_message".to_string(), content.to_string());
 
     let mut message = todo.prompt.clone();
-
-    // 如果 prompt 模板中没有任何占位符，将用户内容追加到 message 末尾，
-    // 确保用户提交的内容一定能传递到执行器
-    let has_placeholder = params.keys().any(|key| message.contains(&format!("{{{{{}}}}}", key)));
-    if !has_placeholder {
-        if message.is_empty() {
-            message = content.to_string();
-        } else {
-            message = format!("{}\n\n{}", message, content);
-        }
-    }
-
-    let result = start_todo_execution(RunTodoExecutionRequest {
-        db: state.db.clone(),
-        executor_registry: state.executor_registry.clone(),
-        tx: state.tx.clone(),
-        task_manager: state.task_manager.clone(),
-        config: state.config.clone(),
-        todo_id,
-        message,
-        req_executor: None,
-        trigger_type: "smart_create".to_string(),
-        params: Some(params),
         resume_session_id: None,
         resume_message: None,
     })

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -487,6 +487,36 @@ pub async fn smart_create_handler(
     params.insert("raw_message".to_string(), content.to_string());
 
     let mut message = todo.prompt.clone();
+    // 检查是否有标准占位符 ({{content}}, {{message}}, {{raw_message}})
+    let has_standard_placeholder = params.keys().any(|key| message.contains(&format!("{{{{{}}}}}", key)));
+
+    // 检查是否有任何 {{...}} 格式的占位符
+    let placeholder_re = Regex::new(r"\{\{[^}]+\}\}").unwrap();
+    let has_any_placeholder = placeholder_re.is_match(&message);
+
+    if has_any_placeholder {
+        // 模板包含任意占位符（包括非标准占位符如 {{input}}），
+        // 将所有 {{...}} 替换为用户内容
+        message = placeholder_re.replace_all(&message, content.as_str()).to_string();
+    } else if message.is_empty() {
+        // 模板没有任何占位符且为空，直接用用户内容作为消息
+        message = content.to_string();
+    } else {
+        // 模板没有任何占位符但不为空，将用户内容追加到模板末尾
+        message = format!("{}\n\n{}", message, content);
+    }
+
+    let result = start_todo_execution(RunTodoExecutionRequest {
+        db: state.db.clone(),
+        executor_registry: state.executor_registry.clone(),
+        tx: state.tx.clone(),
+        task_manager: state.task_manager.clone(),
+        config: state.config.clone(),
+        todo_id,
+        message,
+        req_executor: None,
+        trigger_type: "smart_create".to_string(),
+        params: Some(params),
         resume_session_id: None,
         resume_message: None,
     })


### PR DESCRIPTION
## Summary
- 当模板包含非标准占位符（如 `{{input}}`）但不含标准占位符时，修复占位符替换逻辑
- 使用正则检测模板中任何 `{{...}}` 格式的占位符，如果存在非标准占位符则全部替换为用户内容

## Test plan
- [ ] 模板 `请帮我处理以下任务：{{input}}\n请用中文回复`，用户输入 `帮我查询天气`
- [ ] 期望输出：`请帮我处理以下任务：帮我查询天气\n请用中文回复`

## 关联 Issue
- Fixes #376