### PR TITLE
fix: Config load 时规范化路径，避免 ~ 路径导致数据库无法打开

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -147,7 +147,7 @@ impl Config {
     pub fn load() -> Self {
         let path = Self::config_path();
         if !path.exists() {
-            let cfg = if Self::is_dev_mode() {
+            let mut cfg = if Self::is_dev_mode() {
                 // Dev mode defaults: different port and database
                 let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
                 Config {
@@ -161,11 +161,14 @@ impl Config {
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent).ok();
             }
-            if let Ok(yaml) = serde_yaml::to_string(&cfg) {
+            let mut cfg_for_save = cfg.clone();
+            cfg_for_save.normalize_paths();
+            if let Ok(yaml) = serde_yaml::to_string(&cfg_for_save) {
                 if let Err(e) = std::fs::write(&path, yaml) {
                     eprintln!("Warning: failed to write config file ({}), using in-memory defaults", e);
                 }
             }
+            cfg.normalize_paths();
             return cfg;
         }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -310,12 +310,23 @@ async fn run_server(cli_port: Option<u16>) {
         .with_timer(tracing_subscriber::fmt::time::time())
         .init();
 
-    let db_path = &cfg.db_path;
-    if let Some(parent) = std::path::Path::new(db_path).parent() {
+    // Expand tilde in db_path to home directory (normalize_paths is called in Config::load,
+    // but may not have expanded if config file didn't exist or was corrupted)
+    let db_path = if cfg.db_path.starts_with('~') {
+        if let Some(home) = dirs::home_dir() {
+            let relative = cfg.db_path.trim_start_matches('~').trim_start_matches(std::path::MAIN_SEPARATOR);
+            home.join(relative).to_string_lossy().to_string()
+        } else {
+            cfg.db_path.clone()
+        }
+    } else {
+        cfg.db_path.clone()
+    };
+    if let Some(parent) = std::path::Path::new(&db_path).parent() {
         std::fs::create_dir_all(parent).ok();
     }
 
-    let db = match db::Database::new(db_path).await {
+    let db = match db::Database::new(&db_path).await {
         Ok(db) => Arc::new(db),
         Err(e) => {
             eprintln!("Failed to open database at {}: {}", db_path, e);


### PR DESCRIPTION
## Summary

当 Config::load() 创建新配置文件时（配置文件不存在），db_path 默认为 `~/.ntd/data.db`（包含 ~），
但 `normalize_paths()` 未被调用，导致配置文件保存时路径未规范化，服务器启动时也无法正确展开 ~ 路径。

## Fix

- **config.rs**: 在保存配置前克隆并调用 `normalize_paths()`，在返回前对原配置也调用 `normalize_paths()`
- **main.rs**: 启动时手动展开 `~` 路径作为后备方案

## Test plan

- [ ] 删除 `~/.ntd/config.yaml` 或 `~/.ntd/config.dev.yaml`
- [ ] 以 dev 模式启动服务 `NTD_MODE=dev cargo run`
- [ ] 验证服务正常启动，数据库路径已正确展开

## 关联 Issue

Fixes #379