### PR TITLE
fix: 修复 worktree 开关不显示及参数位置问题

### DIFF
--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -201,19 +201,18 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
         executor.command_args_with_session(&message, Some(session_id_for_executor), is_resume);
 
     // Add worktree flag for claude_code and hermes executors
-    // claude_code: --worktree <path>
+    // claude_code: --worktree (no path argument, Claude Code auto-manages worktree cleanup)
     // hermes: --worktree (no path argument, uses current directory)
+    // Must be placed before --session-id or --resume flag
     let exec_type = executor.executor_type();
     if todo_worktree_enabled {
         match exec_type {
-            ExecutorType::Claudecode => {
-                if let Some(wt) = todo_workspace.as_deref() {
-                    command_args.push("--worktree".to_string());
-                    command_args.push(wt.to_string());
-                }
-            }
-            ExecutorType::Hermes => {
-                command_args.push("--worktree".to_string());
+            ExecutorType::Claudecode | ExecutorType::Hermes => {
+                // Find position of --session-id or --resume and insert before it
+                let insert_pos = command_args.iter()
+                    .position(|s| s == "--session-id" || s == "--resume")
+                    .unwrap_or(command_args.len());
+                command_args.insert(insert_pos, "--worktree".to_string());
             }
             _ => {}
         }

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -544,7 +544,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
           </div>
 
           {/* Worktree Switch */}
-          {(executor === 'claudecode' || executor === 'hermes') && (
+          {(executor === 'claudecode' || executor === 'claude_code' || executor === 'hermes') && (
             <div style={{ marginBottom: 16 }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                 <div style={{ fontWeight: 600, fontSize: 14 }}>
@@ -553,14 +553,8 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
                 <Switch
                   checked={worktreeEnabled}
                   onChange={(checked) => setWorktreeEnabled(checked)}
-                  disabled={!workspace}
                 />
               </div>
-              {!workspace && (
-                <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginTop: 4 }}>
-                  请先设置工作目录
-                </div>
-              )}
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- 前端: 增加 `executor === 'claude_code'` 别名处理数据库名称不匹配导致的 worktree 开关不显示问题
- 前端: 移除 worktree 开关对 workspace 的依赖，两者现在是独立参数
- 后端: Claude Code 的 `--worktree` 不再带路径参数
- 后端: `--worktree` 插入到 `--session-id` 或 `--resume` 前面而非末尾

## Test plan
- [ ] 新建 Todo 时，切换到 Claude 执行器，worktree 开关应正常显示且可点击
- [ ] 启用 worktree 后执行，命令中 --worktree 应在 --session-id 前面