### PR TITLE
fix: 简化分享卡片安装说明

### DIFF
--- a/frontend/src/components/ShareCard.tsx
+++ b/frontend/src/components/ShareCard.tsx
@@ -3,12 +3,7 @@ import { Card, Button, App } from 'antd';
 import { ShareAltOutlined, CopyOutlined, CheckOutlined } from '@ant-design/icons';
 
 const getSharePrompt = () => {
-  const port = typeof window !== 'undefined' ? window.location.port : '8088';
-  const origin =
-    typeof window !== 'undefined' ? window.location.origin : `http://localhost:${port}`;
-  return `请在我的电脑上全局安装 ntd (Nothing Todo) 这个工具，执行命令：
-npm install -g @weibaohui/nothing-todo
-安装完成后运行 ntd 启动服务，然后打开浏览器访问 ${origin}`;
+  return `全局安装 ntd：npm install -g @weibaohui/nothing-todo，然后执行 ntd daemon install && ntd daemon start，可选安装 skills：ntd skills install，访问 8088 端口`;
 };
 
 export function ShareCard() {


### PR DESCRIPTION
## Summary
- 删除动态端口检测逻辑
- 简化为一行安装说明
- 添加 ntd skills install 说明