### PR TITLE
chore: update npm publish to use --provenance

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,14 +2,15 @@ name: Build and Release
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
-  contents: write
+  id-token: write # Required for OIDC
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - name: Build frontend
@@ -115,6 +116,9 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -137,10 +141,13 @@ jobs:
           file_glob: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Prepare npm packages
         run: |
@@ -173,7 +180,7 @@ jobs:
           for pkg in nothing-todo-linux-x64 nothing-todo-linux-arm64 nothing-todo-darwin-arm64 nothing-todo-windows-x64; do
             echo "Publishing @weibaohui/$pkg..."
             cd packages/$pkg
-            npm publish --access public
+            npm publish --provenance --access public
             cd ../..
           done
         env:
@@ -182,6 +189,4 @@ jobs:
       - name: Publish wrapper package to npm
         run: |
           cd packages/nothing-todo
-          npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm publish --provenance --access public


### PR DESCRIPTION
## 变更内容

更新 GitHub Actions 发布流程，启用 npm provenance 签名。

### 改动
1. **permissions**: 全局加 `id-token: write`（OIDC），release job 保留 `contents: write`
2. **setup-node**: v4 → v6，node-version: 20 → 24，加 `registry-url`
3. **新增步骤**: `npm install -g npm@latest` 确保 npm ≥ 11.5.1
4. **npm publish**: 加 `--provenance` 参数

### 效果
- npm 包发布会有 provenance 签名，显示 `Verified by: GitHub Actions`
- 权限最小化（全局只读，release job 独立声明写权限）