### PR TITLE
feat: Prompt编辑时支持在光标位置插入模板和Skill

### DIFF
--- a/frontend/src/components/MdEditor.tsx
+++ b/frontend/src/components/MdEditor.tsx
@@ -5,12 +5,15 @@ interface MdEditorProps {
   value: string;
   onChange: (value: string) => void;
   height?: number | string;
+  /** 暴露 editor ref，可用于获取 textarea 和光标位置 */
+  editorRef?: React.RefObject<any>;
 }
 
 export function MdEditor({
   value,
   onChange,
   height,
+  editorRef,
 }: MdEditorProps) {
   const { themeMode } = useTheme();
 
@@ -21,6 +24,7 @@ export function MdEditor({
         onChange={(val) => onChange(val || '')}
         preview="edit"
         style={{ flex: 1, minHeight: typeof height === 'number' ? height : (height || '100%') }}
+        ref={editorRef}
       />
     </div>
   );

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -65,7 +65,10 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
     const editor = editorRef.current;
     if (!editor || !editor.textarea) {
       // Fallback: append to end
-      setPrompt(prev => prev + (prev.endsWith('\n') ? '' : '\n') + text);
+      setPrompt(prev => {
+        if (!prev) return text;
+        return prev + (prev.endsWith('\n') ? '' : '\n') + text;
+      });
       return;
     }
     const textarea = editor.textarea as HTMLTextAreaElement;
@@ -170,16 +173,19 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
       // If prompt is empty, use template content (create mode)
       setTitle(template.title);
       setPrompt(template.prompt || '');
+      message.success('已应用模板');
     } else {
       // If prompt has content, insert template content at cursor position
       if (template.prompt) {
         insertTextAtCursor(template.prompt);
+        message.success('已插入模板内容');
+      } else {
+        message.warning('模板内容为空，未插入');
       }
     }
     setTemplateModalOpen(false);
     setSearchText('');
     setSelectedCategory(null);
-    message.success('已插入模板内容');
   };
 
   // Get unique categories from templates

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { Drawer, Input, Button, App, AutoComplete, Divider, Switch, Tooltip, Tag, Empty, Spin, Modal, Card } from 'antd';
 import { CheckOutlined, FolderOutlined, ClockCircleOutlined, FileTextOutlined, ThunderboltOutlined, RightOutlined, SearchOutlined } from '@ant-design/icons';
 import { Cron } from 'react-js-cron';
@@ -56,6 +56,33 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
 
   // Loading states
   const [loading, setLoading] = useState(false);
+
+  // Editor ref for cursor position tracking
+  const editorRef = useRef<any>(null);
+
+  // Insert text at cursor position in the editor
+  const insertTextAtCursor = (text: string) => {
+    const editor = editorRef.current;
+    if (!editor || !editor.textarea) {
+      // Fallback: append to end
+      setPrompt(prev => prev + (prev.endsWith('\n') ? '' : '\n') + text);
+      return;
+    }
+    const textarea = editor.textarea as HTMLTextAreaElement;
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    // Use functional update to ensure we get the latest value
+    setPrompt(prev => {
+      const currentValue = prev;
+      const newValue = currentValue.substring(0, start) + text + currentValue.substring(end);
+      return newValue;
+    });
+    // Restore cursor position after insertion
+    setTimeout(() => {
+      textarea.selectionStart = textarea.selectionEnd = start + text.length;
+      textarea.focus();
+    }, 0);
+  };
 
   // Template selection state
   const [templateModalOpen, setTemplateModalOpen] = useState(false);
@@ -121,12 +148,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
 
   const handleSkillClick = (skill: SkillMeta) => {
     const skillRef = `/${skill.name}`;
-    setPrompt(prev => {
-      if (!prev.trim()) return skillRef;
-      // If prompt already ends with newline, just append
-      if (prev.endsWith('\n')) return prev + skillRef;
-      return prev + '\n' + skillRef;
-    });
+    insertTextAtCursor(skillRef);
   };
 
   // Template functions
@@ -144,12 +166,20 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
   };
 
   const selectTemplate = (template: TodoTemplate) => {
-    setTitle(template.title);
-    setPrompt(template.prompt || '');
+    if (!prompt.trim()) {
+      // If prompt is empty, use template content (create mode)
+      setTitle(template.title);
+      setPrompt(template.prompt || '');
+    } else {
+      // If prompt has content, insert template content at cursor position
+      if (template.prompt) {
+        insertTextAtCursor(template.prompt);
+      }
+    }
     setTemplateModalOpen(false);
     setSearchText('');
     setSelectedCategory(null);
-    message.success('已应用模板');
+    message.success('已插入模板内容');
   };
 
   // Get unique categories from templates
@@ -387,6 +417,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
               value={prompt}
               onChange={setPrompt}
               height={200}
+              editorRef={editorRef}
             />
             {/* Prompt parameter hints */}
             <div style={{
@@ -401,7 +432,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
                 <Tooltip key={p.key} title={p.desc}>
                   <code
                     onClick={() => {
-                      setPrompt(prev => prev + p.key);
+                      insertTextAtCursor(p.key);
                     }}
                     style={{
                       fontSize: 11,


### PR DESCRIPTION
## Summary
- MdEditor 新增 editorRef 支持，获取 textarea 光标位置
- Skill 点击后插入到光标位置而非末尾
- 参数({{content}}等) 点击后插入到光标位置
- 模板选择时，若 prompt 非空则插入到光标位置而非完全替换

## Test plan
- [x] 参数插入验证：光标在中间时点击参数，插入到光标位置 ✓
- [x] Skill 插入验证：光标在中间时点击 Skill，插入到光标位置 ✓
- [x] 模板插入验证：prompt 非空时选择模板，插入到光标位置 ✓