### PR TITLE
feat: 看板和结论视图增加运行历史切换功能

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3026,6 +3026,44 @@ code {
   font-weight: 600;
   color: var(--color-text-secondary);
   flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.kanban-run-tags {
+  display: inline-flex;
+  gap: 2px;
+  align-items: center;
+  margin-left: 4px;
+}
+
+.kanban-run-tag {
+  cursor: pointer;
+  font-size: 10px !important;
+  line-height: 1 !important;
+  padding: 0 4px !important;
+  height: 18px !important;
+  border-radius: 3px !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  margin: 0 !important;
+  background: transparent !important;
+  border: 1px solid var(--color-border) !important;
+  color: var(--color-text-tertiary) !important;
+  transition: all 0.15s;
+}
+
+.kanban-run-tag:hover {
+  border-color: var(--color-primary) !important;
+  color: var(--color-primary) !important;
+}
+
+.kanban-run-tag.kanban-run-tag-active {
+  background: var(--color-primary) !important;
+  border-color: var(--color-primary) !important;
+  color: #fff !important;
 }
 
 .kanban-card-section-toggle {

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -63,6 +63,12 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
   const [execRecordCache, setExecRecordCache] = useState<Record<number, ExecutionRecord>>({});
   const fetchAttempted = useRef<Set<number>>(new Set());
 
+  /* ─── Run history switching ─── */
+  const [selectedRunIndex, setSelectedRunIndex] = useState<Record<number, number>>({});
+  const [totalRunsCache, setTotalRunsCache] = useState<Record<number, number>>({});
+  const [runDataCache, setRunDataCache] = useState<Record<number, (ExecutionRecord | null)[]>>({});
+  const [loadingRunIndex, setLoadingRunIndex] = useState<Record<number, number | null>>({});
+
   useEffect(() => {
     const finished = todos.filter(t => t.status === 'completed' || t.status === 'failed');
     for (const todo of finished) {
@@ -75,12 +81,18 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
         if (!execRecordCache[todo.id]) {
           setExecRecordCache(prev => ({ ...prev, [todo.id]: global[0] }));
         }
+        if (!totalRunsCache[todo.id]) {
+          setTotalRunsCache(prev => ({ ...prev, [todo.id]: global.length }));
+        }
         continue;
       }
       // Lazy-fetch from API
       db.getExecutionRecords(todo.id, 1, 1).then(page => {
         if (page.records.length > 0) {
           setExecRecordCache(prev => ({ ...prev, [todo.id]: page.records[0] }));
+        }
+        if (page.total > 0) {
+          setTotalRunsCache(prev => ({ ...prev, [todo.id]: page.total }));
         }
       }).catch(() => {});
     }
@@ -228,6 +240,48 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
     });
   }, [expandedResultIds, todoResults, loadingResults, state.executionRecords]);
 
+  /* ─── Select run index (on-demand fetch) ─── */
+  const handleSelectRun = useCallback(async (todoId: number, runIndex: number) => {
+    if (selectedRunIndex[todoId] === runIndex) return;
+    setSelectedRunIndex(prev => ({ ...prev, [todoId]: runIndex }));
+
+    if (runDataCache[todoId]?.[runIndex]) return;
+
+    if (runIndex === 0) {
+      const record = execRecordCache[todoId] || state.executionRecords[todoId]?.[0];
+      if (record) {
+        setRunDataCache(prev => {
+          const arr = prev[todoId] || [];
+          const next = [...arr];
+          next[0] = record;
+          return { ...prev, [todoId]: next };
+        });
+      }
+      return;
+    }
+
+    setLoadingRunIndex(prev => ({ ...prev, [todoId]: runIndex }));
+    try {
+      const page = await db.getExecutionRecords(todoId, runIndex + 1, 1);
+      if (page.records.length > 0) {
+        const record = page.records[0];
+        setRunDataCache(prev => {
+          const arr = prev[todoId] || [];
+          const next = [...arr];
+          next[runIndex] = record;
+          return { ...prev, [todoId]: next };
+        });
+        if (!totalRunsCache[todoId] && page.total > 0) {
+          setTotalRunsCache(prev => ({ ...prev, [todoId]: page.total }));
+        }
+      }
+    } catch {
+      // silently ignore
+    } finally {
+      setLoadingRunIndex(prev => ({ ...prev, [todoId]: null }));
+    }
+  }, [selectedRunIndex, runDataCache, execRecordCache, state.executionRecords, totalRunsCache]);
+
   /* ─── Render Card ─── */
   const renderCard = (todo: Todo) => {
     const column = getColumnForStatus(todo.status);
@@ -237,12 +291,38 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
     const isFinished = todo.status === 'completed' || todo.status === 'failed';
     const promptExpanded = expandedPromptIds.has(todo.id);
     const resultExpanded = expandedResultIds.has(todo.id);
-    const recordResult = execRecordCache[todo.id]?.result || state.executionRecords[todo.id]?.[0]?.result;
-    const resultText = todoResults[todo.id] || recordResult || '';
-    const isLoadingResult = loadingResults.has(todo.id);
     const records = state.executionRecords[todo.id] || [];
     const todoExecutionRecord: ExecutionRecord | undefined =
       records.length > 0 ? records[0] : execRecordCache[todo.id];
+
+    // Run history: determine which run to display
+    const runIdx = selectedRunIndex[todo.id] ?? 0;
+    const cachedRun = runDataCache[todo.id]?.[runIdx];
+    let resultText: string;
+    let displayModel: string | null | undefined;
+    let displayUsage: ExecutionRecord['usage'] | null | undefined;
+    let displayTriggerType: string | undefined;
+
+    if (runIdx === 0) {
+      const recordResult = execRecordCache[todo.id]?.result || state.executionRecords[todo.id]?.[0]?.result;
+      resultText = todoResults[todo.id] || recordResult || '';
+      displayModel = todoExecutionRecord?.model;
+      displayUsage = todoExecutionRecord?.usage;
+      displayTriggerType = todoExecutionRecord?.trigger_type;
+    } else if (cachedRun) {
+      resultText = cachedRun.result || '';
+      displayModel = cachedRun.model;
+      displayUsage = cachedRun.usage;
+      displayTriggerType = cachedRun.trigger_type;
+    } else {
+      resultText = '';
+      displayModel = null;
+      displayUsage = null;
+    }
+
+    const isLoadingResult = loadingResults.has(todo.id);
+    const isLoadingRun = loadingRunIndex[todo.id] != null && loadingRunIndex[todo.id] === runIdx && runIdx > 0;
+    const runCount = totalRunsCache[todo.id] ?? (isFinished ? 1 : 0);
 
     return (
       <div
@@ -262,15 +342,19 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
           showResultSection={isFinished}
           executor={todo.executor}
           time={formatRelativeTime(todo.updated_at)}
-          model={todoExecutionRecord?.model}
+          model={displayModel}
           tags={todoTags}
-          usage={todoExecutionRecord?.usage}
-          triggerType={todoExecutionRecord?.trigger_type}
+          usage={displayUsage}
+          triggerType={displayTriggerType}
           promptExpanded={promptExpanded}
           resultExpanded={resultExpanded}
           onTogglePrompt={() => togglePrompt(todo.id)}
           onToggleResult={() => toggleResult(todo)}
           isLoadingResult={isLoadingResult}
+          runCount={runCount}
+          selectedRun={runIdx}
+          onSelectRun={(index) => handleSelectRun(todo.id, index)}
+          isLoadingRun={isLoadingRun}
         />
       </div>
     );

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -13,7 +13,7 @@ import { KanbanBoard } from './KanbanBoard';
 import { TodoCard } from './TodoCard';
 import * as db from '../utils/database';
 import { formatRelativeTime } from '../utils/datetime';
-import type { RecentCompletedTodo, Tag } from '../types';
+import type { RecentCompletedTodo, Tag, ExecutionRecord } from '../types';
 
 const TIME_OPTIONS: { label: string; value: number }[] = [
   { label: '6h', value: 6 },
@@ -39,13 +39,31 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
   const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
   const [promptExpandedIds, setPromptExpandedIds] = useState<Set<number>>(new Set());
 
+  /* ─── Run history switching ─── */
+  const [selectedRunIndex, setSelectedRunIndex] = useState<Record<number, number>>({});
+  const [totalRunsCache, setTotalRunsCache] = useState<Record<number, number>>({});
+  const [runDataCache, setRunDataCache] = useState<Record<number, (ExecutionRecord | null)[]>>({});
+  const [loadingRunIndex, setLoadingRunIndex] = useState<Record<number, number | null>>({});
+
   useEffect(() => {
     if (boardMode !== 'memorial') return;
     let cancelled = false;
     setLoading(true);
     db.getRecentCompletedTodos(hours)
       .then(data => {
-        if (!cancelled) setItems(data);
+        if (!cancelled) {
+          setItems(data);
+          // Fetch total run count for each todo
+          for (const item of data) {
+            if (!totalRunsCache[item.todo_id]) {
+              db.getExecutionRecords(item.todo_id, 1, 1).then(page => {
+                if (page.total > 0) {
+                  setTotalRunsCache(prev => ({ ...prev, [item.todo_id]: page.total }));
+                }
+              }).catch(() => {});
+            }
+          }
+        }
       })
       .catch(() => {
         if (!cancelled) setItems([]);
@@ -78,6 +96,64 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
       }
       return next;
     });
+  };
+
+  /* ─── Select run index (on-demand fetch) ─── */
+  const handleSelectRun = async (todoId: number, runIndex: number) => {
+    if (selectedRunIndex[todoId] === runIndex) return;
+    setSelectedRunIndex(prev => ({ ...prev, [todoId]: runIndex }));
+
+    if (runDataCache[todoId]?.[runIndex]) return;
+
+    if (runIndex === 0) {
+      const item = items.find(i => i.todo_id === todoId);
+      if (item) {
+        const record: ExecutionRecord = {
+          id: item.record_id,
+          todo_id: item.todo_id,
+          status: item.execution_status === 'success' ? 'success' : 'failed',
+          command: '',
+          stdout: '',
+          stderr: '',
+          result: item.result,
+          started_at: '',
+          finished_at: item.completed_at,
+          usage: item.usage,
+          executor: item.executor,
+          model: item.model,
+          trigger_type: item.trigger_type,
+          pid: null,
+        };
+        setRunDataCache(prev => {
+          const arr = prev[todoId] || [];
+          const next = [...arr];
+          next[0] = record;
+          return { ...prev, [todoId]: next };
+        });
+      }
+      return;
+    }
+
+    setLoadingRunIndex(prev => ({ ...prev, [todoId]: runIndex }));
+    try {
+      const page = await db.getExecutionRecords(todoId, runIndex + 1, 1);
+      if (page.records.length > 0) {
+        const record = page.records[0];
+        setRunDataCache(prev => {
+          const arr = prev[todoId] || [];
+          const next = [...arr];
+          next[runIndex] = record;
+          return { ...prev, [todoId]: next };
+        });
+        if (!totalRunsCache[todoId] && page.total > 0) {
+          setTotalRunsCache(prev => ({ ...prev, [todoId]: page.total }));
+        }
+      }
+    } catch {
+      // silently ignore
+    } finally {
+      setLoadingRunIndex(prev => ({ ...prev, [todoId]: null }));
+    }
   };
 
   const handleSelectTodo = (todoId: number, e: React.MouseEvent) => {
@@ -117,8 +193,34 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
   const renderCard = (item: RecentCompletedTodo) => {
     const isSuccess = item.execution_status === 'success';
     const expanded = expandedIds.has(item.todo_id);
-    const result = item.result || '';
     const resolvedTags = item.tag_ids.map(tid => state.tags.find(t => t.id === tid)).filter(Boolean) as Tag[];
+
+    // Run history: determine which run to display
+    const runIdx = selectedRunIndex[item.todo_id] ?? 0;
+    const cachedRun = runDataCache[item.todo_id]?.[runIdx];
+    let resultText: string;
+    let displayModel: string | null | undefined;
+    let displayUsage: ExecutionRecord['usage'] | null | undefined;
+    let displayTriggerType: string | undefined;
+
+    if (runIdx === 0) {
+      resultText = item.result || '';
+      displayModel = item.model;
+      displayUsage = item.usage;
+      displayTriggerType = item.trigger_type;
+    } else if (cachedRun) {
+      resultText = cachedRun.result || '';
+      displayModel = cachedRun.model;
+      displayUsage = cachedRun.usage;
+      displayTriggerType = cachedRun.trigger_type;
+    } else {
+      resultText = '';
+      displayModel = null;
+      displayUsage = null;
+    }
+
+    const isLoadingRun = loadingRunIndex[item.todo_id] != null && loadingRunIndex[item.todo_id] === runIdx && runIdx > 0;
+    const runCount = totalRunsCache[item.todo_id] ?? 1;
 
     return (
       <Card
@@ -135,20 +237,24 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
           id={item.todo_id}
           title={item.title}
           prompt={item.prompt}
-          resultText={result}
+          resultText={resultText}
           isSuccess={isSuccess}
           showResultSection={true}
           executor={item.executor}
           time={formatRelativeTime(item.completed_at)}
-          model={item.model}
+          model={displayModel}
           tags={resolvedTags}
-          usage={item.usage}
-          triggerType={item.trigger_type}
+          usage={displayUsage}
+          triggerType={displayTriggerType}
           promptExpanded={promptExpandedIds.has(item.todo_id)}
           resultExpanded={expanded}
           onTogglePrompt={() => togglePromptExpand(item.todo_id)}
           onToggleResult={() => toggleExpand(item.todo_id)}
           onSelectTodo={(e) => handleSelectTodo(item.todo_id, e)}
+          runCount={runCount}
+          selectedRun={runIdx}
+          onSelectRun={(index) => handleSelectRun(item.todo_id, index)}
+          isLoadingRun={isLoadingRun}
         />
       </Card>
     );

--- a/frontend/src/components/TodoCard.tsx
+++ b/frontend/src/components/TodoCard.tsx
@@ -68,6 +68,12 @@ export interface TodoCardProps {
 
   /** Optional: loading state for async result (KanbanBoard) */
   isLoadingResult?: boolean;
+
+  /** Run history switching */
+  runCount?: number;
+  selectedRun?: number; // 0-based, default 0 (most recent)
+  onSelectRun?: (index: number) => void;
+  isLoadingRun?: boolean;
 }
 
 /* ─── Component ─── */
@@ -91,6 +97,10 @@ export function TodoCard({
   onToggleResult,
   onSelectTodo,
   isLoadingResult,
+  runCount,
+  selectedRun = 0,
+  onSelectRun,
+  isLoadingRun,
 }: TodoCardProps) {
   return (
     <>
@@ -186,6 +196,19 @@ export function TodoCard({
               onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); onToggleResult(); } }}
             >
               <span className="kanban-card-section-label"><FileProtectOutlined /> 结论</span>
+              {runCount != null && runCount > 1 && (
+                <span className="kanban-run-tags" onClick={e => e.stopPropagation()}>
+                  {Array.from({ length: Math.min(runCount, 5) }, (_, i) => (
+                    <Tag
+                      key={i}
+                      className={`kanban-run-tag ${i === selectedRun ? 'kanban-run-tag-active' : ''}`}
+                      onClick={() => onSelectRun?.(i)}
+                    >
+                      {i + 1}
+                    </Tag>
+                  ))}
+                </span>
+              )}
               {resultText && (
                 <button
                   className="kanban-copy-btn"
@@ -199,12 +222,12 @@ export function TodoCard({
                 </button>
               )}
               <span className="kanban-card-section-toggle">
-                {isLoadingResult ? '加载中…' : (resultExpanded ? '收起' : '展开')}
+                {(isLoadingResult || isLoadingRun) ? '加载中…' : (resultExpanded ? '收起' : '展开')}
               </span>
             </div>
             {resultExpanded && (
               <div className="kanban-card-section-content">
-                {isLoadingResult ? (
+                {(isLoadingResult || isLoadingRun) ? (
                   <span className="kanban-loading-text">加载中…</span>
                 ) : resultText ? (
                   <XMarkdown content={resultText} />


### PR DESCRIPTION
## Summary
- 在看板卡片和结论视图的结论区域增加 1-5 的 tag 按钮，点击可切换显示最近 1-5 次运行的结论
- 按需加载，不预缓存，点击 tag 时现场调用 API 获取对应运行记录
- 切换运行记录时同步更新结论、model、usage 等显示信息
- 只有1次运行时不显示 tag

## 改动文件
- `frontend/src/components/TodoCard.tsx` — 新增 runCount/selectedRun/onSelectRun/isLoadingRun props，渲染 1-5 切换 tag
- `frontend/src/components/KanbanBoard.tsx` — 看板视图增加运行历史切换状态管理和按需加载逻辑
- `frontend/src/components/MemorialBoard.tsx` — 结论视图增加同样的运行历史切换功能
- `frontend/src/App.css` — 新增运行编号 tag 样式

## Test plan
- [ ] 验证看板视图中已完成/失败的 todo 卡片结论区域显示 1-N 个 tag（N = 运行次数，最大5）
- [ ] 点击 tag 2-5 切换显示对应运行的结论
- [ ] 验证结论视图中同样可以切换运行历史
- [ ] 验证只有1次运行的 todo 不显示 tag
- [ ] 验证切换时加载状态正确显示

🤖 Generated with [CodeBuddy Code]