### PR TITLE
feat: 看板视图 UI 优化 — 结论视图固定列和看板视图四列铺满

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2389,14 +2389,23 @@ code {
   justify-content: center;
 }
 
-/* ——— Masonry Layout (CSS Columns) ——— */
+/* ——— Masonry Layout ——— */
 .memorial-grid {
   flex: 1;
   overflow-y: auto;
   padding: var(--space-md) var(--space-lg);
-  column-count: 4;
-  column-gap: var(--space-md);
-  align-content: start;
+  display: flex;
+  gap: var(--space-md);
+  align-items: start;
+}
+
+/* ——— Column ——— */
+.memorial-column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  min-width: 0;
 }
 
 /* ——— Card ——— */
@@ -2406,8 +2415,6 @@ code {
   transition: box-shadow var(--transition-base);
   cursor: pointer;
   overflow: hidden;
-  break-inside: avoid;
-  margin-bottom: var(--space-md);
 }
 
 .memorial-card:hover {
@@ -2685,25 +2692,7 @@ code {
 
   .memorial-grid {
     padding: var(--space-sm);
-    column-count: 1;
-  }
-}
-
-@media (min-width: 769px) {
-  .memorial-grid {
-    column-count: 2;
-  }
-}
-
-@media (min-width: 1100px) {
-  .memorial-grid {
-    column-count: 3;
-  }
-}
-
-@media (min-width: 1600px) {
-  .memorial-grid {
-    column-count: 4;
+    flex-direction: column;
   }
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2780,6 +2780,8 @@ code {
 /* ─── Column ─── */
 .kanban-column {
   flex: 1;
+  min-width: 200px;
+  max-width: 360px;
   display: flex;
   flex-direction: column;
   background: var(--color-fill-quaternary, #f1f5f9);

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2758,7 +2758,7 @@ code {
   flex: 1;
   display: flex;
   gap: var(--space-md);
-  padding: var(--space-md) var(--space-lg);
+  padding: var(--space-md) 0;
   overflow-x: auto;
   overflow-y: hidden;
   align-items: flex-start;
@@ -2780,8 +2780,6 @@ code {
 /* ─── Column ─── */
 .kanban-column {
   flex: 1;
-  min-width: 240px;
-  max-width: 340px;
   display: flex;
   flex-direction: column;
   background: var(--color-fill-quaternary, #f1f5f9);
@@ -3323,13 +3321,12 @@ code {
   }
 
   .kanban-columns-container {
-    padding: var(--space-sm);
+    padding: var(--space-sm) 0;
     gap: var(--space-sm);
   }
 
   .kanban-column {
-    min-width: 200px;
-    max-width: 260px;
+    min-width: 0;
   }
 
   .kanban-mobile-tabs {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { Dashboard } from './components/Dashboard';
 import { MemorialBoard } from './components/MemorialBoard';
 import { SettingsPage } from './components/SettingsPage';
 import { ExecutionPanel } from './components/ExecutionPanel';
+import { SnakeGame } from './components/SnakeGame';
 import { TodoDrawer } from './components/TodoDrawer';
 import { SmartCreateModal } from './components/SmartCreateModal';
 import * as db from './utils/database';
@@ -29,7 +30,7 @@ function AppContent() {
   const [appConfig, setAppConfig] = useState<Config | null>(null);
   const [isMobile, setIsMobile] = useState(false);
   const [selectedPanel, setSelectedPanel] = useState<'list' | 'detail'>('list');
-  const [activeView, setActiveView] = useState<'dashboard' | 'settings' | 'memorial'>('dashboard');
+  const [activeView, setActiveView] = useState<'dashboard' | 'settings' | 'memorial' | 'game'>('dashboard');
   const [panelCollapsed, setPanelCollapsed] = useState(() => {
     try {
       return localStorage.getItem('execution_panel_collapsed') === 'true';
@@ -88,6 +89,7 @@ function AppContent() {
     setActiveView('settings');
     setSelectedPanel('detail');
   };
+
 
   const handleBackToList = () => {
     clearSelection();
@@ -214,6 +216,8 @@ function AppContent() {
               <SettingsPage onBack={isMobile ? handleBackToList : undefined} />
             ) : activeView === 'memorial' ? (
               <MemorialBoard onBack={isMobile ? handleBackToList : undefined} />
+            ) : activeView === 'game' ? (
+              <SnakeGame />
             ) : (
               <Dashboard onBack={isMobile ? handleBackToList : undefined} />
             )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,6 @@ import { Dashboard } from './components/Dashboard';
 import { MemorialBoard } from './components/MemorialBoard';
 import { SettingsPage } from './components/SettingsPage';
 import { ExecutionPanel } from './components/ExecutionPanel';
-import { SnakeGame } from './components/SnakeGame';
 import { TodoDrawer } from './components/TodoDrawer';
 import { SmartCreateModal } from './components/SmartCreateModal';
 import * as db from './utils/database';
@@ -30,7 +29,7 @@ function AppContent() {
   const [appConfig, setAppConfig] = useState<Config | null>(null);
   const [isMobile, setIsMobile] = useState(false);
   const [selectedPanel, setSelectedPanel] = useState<'list' | 'detail'>('list');
-  const [activeView, setActiveView] = useState<'dashboard' | 'settings' | 'memorial' | 'game'>('dashboard');
+  const [activeView, setActiveView] = useState<'dashboard' | 'settings' | 'memorial'>('dashboard');
   const [panelCollapsed, setPanelCollapsed] = useState(() => {
     try {
       return localStorage.getItem('execution_panel_collapsed') === 'true';
@@ -216,8 +215,6 @@ function AppContent() {
               <SettingsPage onBack={isMobile ? handleBackToList : undefined} />
             ) : activeView === 'memorial' ? (
               <MemorialBoard onBack={isMobile ? handleBackToList : undefined} />
-            ) : activeView === 'game' ? (
-              <SnakeGame />
             ) : (
               <Dashboard onBack={isMobile ? handleBackToList : undefined} />
             )}

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -170,6 +170,38 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
     );
   }, [items, searchText]);
 
+  /* ─── Responsive column count ─── */
+  const [columnCount, setColumnCount] = useState(() => {
+    const w = window.innerWidth;
+    if (w >= 1600) return 4;
+    if (w >= 1100) return 3;
+    if (w >= 769) return 2;
+    return 1;
+  });
+
+  useEffect(() => {
+    const onResize = () => {
+      const w = window.innerWidth;
+      setColumnCount(
+        w >= 1600 ? 4 :
+        w >= 1100 ? 3 :
+        w >= 769  ? 2 :
+                    1
+      );
+    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  /* ─── Split items into columns ─── */
+  const columns = useMemo(() => {
+    const cols: typeof filteredItems[] = Array.from({ length: columnCount }, () => []);
+    filteredItems.forEach((item, i) => {
+      cols[i % columnCount].push(item);
+    });
+    return cols;
+  }, [filteredItems, columnCount]);
+
   const successCount = filteredItems.filter(i => i.execution_status === 'success').length;
   const failedCount = filteredItems.filter(i => i.execution_status === 'failed').length;
 
@@ -330,10 +362,14 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
         <KanbanBoard searchText={searchText} hours={hours} onSearchChange={setSearchText} onHoursChange={setHours} />
       ) : loading ? (
         <div className="memorial-grid">
-          {[1, 2, 3, 4].map(i => (
-            <Card key={i} className="memorial-card" size="small" bodyStyle={{ padding: 12 }}>
-              <Skeleton active paragraph={{ rows: 4 }} />
-            </Card>
+          {columns.map((col, colIdx) => (
+            <div key={colIdx} className="memorial-column">
+              {col.map((item) => (
+                <Card key={item.todo_id} className="memorial-card" size="small" bodyStyle={{ padding: 12 }}>
+                  <Skeleton active paragraph={{ rows: 4 }} />
+                </Card>
+              ))}
+            </div>
           ))}
         </div>
       ) : items.length === 0 ? (
@@ -342,7 +378,11 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
         </div>
       ) : (
         <div className="memorial-grid">
-          {filteredItems.map(renderCard)}
+          {columns.map((col, colIdx) => (
+            <div key={colIdx} className="memorial-column">
+              {col.map(item => renderCard(item))}
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -180,17 +180,24 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
   });
 
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
     const onResize = () => {
-      const w = window.innerWidth;
-      setColumnCount(
-        w >= 1600 ? 4 :
-        w >= 1100 ? 3 :
-        w >= 769  ? 2 :
-                    1
-      );
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        const w = window.innerWidth;
+        setColumnCount(
+          w >= 1600 ? 4 :
+          w >= 1100 ? 3 :
+          w >= 769  ? 2 :
+                      1
+        );
+      }, 150);
     };
     window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
+    return () => {
+      clearTimeout(timeoutId);
+      window.removeEventListener('resize', onResize);
+    };
   }, []);
 
   /* ─── Split items into columns ─── */
@@ -362,15 +369,27 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
         <KanbanBoard searchText={searchText} hours={hours} onSearchChange={setSearchText} onHoursChange={setHours} />
       ) : loading ? (
         <div className="memorial-grid">
-          {columns.map((col, colIdx) => (
-            <div key={colIdx} className="memorial-column">
-              {col.map((item) => (
-                <Card key={item.todo_id} className="memorial-card" size="small" bodyStyle={{ padding: 12 }}>
-                  <Skeleton active paragraph={{ rows: 4 }} />
-                </Card>
-              ))}
-            </div>
-          ))}
+          {columns.some(col => col.length > 0) ? (
+            columns.map((col, colIdx) => (
+              <div key={colIdx} className="memorial-column">
+                {col.map((item) => (
+                  <Card key={item.todo_id} className="memorial-card" size="small" bodyStyle={{ padding: 12 }}>
+                    <Skeleton active paragraph={{ rows: 4 }} />
+                  </Card>
+                ))}
+              </div>
+            ))
+          ) : (
+            Array.from({ length: columnCount }).map((_, colIdx) => (
+              <div key={colIdx} className="memorial-column">
+                {Array.from({ length: 6 }).map((__, idx) => (
+                  <Card key={`skeleton-${colIdx}-${idx}`} className="memorial-card" size="small" bodyStyle={{ padding: 12 }}>
+                    <Skeleton active paragraph={{ rows: 4 }} />
+                  </Card>
+                ))}
+              </div>
+            ))
+          )}
         </div>
       ) : items.length === 0 ? (
         <div className="memorial-empty">

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -172,7 +172,7 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
 
   /* ─── Responsive column count ─── */
   const [columnCount, setColumnCount] = useState(() => {
-    const w = window.innerWidth;
+    const w = typeof window !== 'undefined' ? window.innerWidth : 1600;
     if (w >= 1600) return 4;
     if (w >= 1100) return 3;
     if (w >= 769) return 2;
@@ -207,7 +207,7 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
       cols[i % columnCount].push(item);
     });
     return cols;
-  }, [filteredItems, columnCount]);
+  }, [filteredItems, columnCount, loading]);
 
   const successCount = filteredItems.filter(i => i.execution_status === 'success').length;
   const failedCount = filteredItems.filter(i => i.execution_status === 'failed').length;
@@ -369,27 +369,15 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
         <KanbanBoard searchText={searchText} hours={hours} onSearchChange={setSearchText} onHoursChange={setHours} />
       ) : loading ? (
         <div className="memorial-grid">
-          {columns.some(col => col.length > 0) ? (
-            columns.map((col, colIdx) => (
-              <div key={colIdx} className="memorial-column">
-                {col.map((item) => (
-                  <Card key={item.todo_id} className="memorial-card" size="small" bodyStyle={{ padding: 12 }}>
-                    <Skeleton active paragraph={{ rows: 4 }} />
-                  </Card>
-                ))}
-              </div>
-            ))
-          ) : (
-            Array.from({ length: columnCount }).map((_, colIdx) => (
-              <div key={colIdx} className="memorial-column">
-                {Array.from({ length: 6 }).map((__, idx) => (
-                  <Card key={`skeleton-${colIdx}-${idx}`} className="memorial-card" size="small" bodyStyle={{ padding: 12 }}>
-                    <Skeleton active paragraph={{ rows: 4 }} />
-                  </Card>
-                ))}
-              </div>
-            ))
-          )}
+          {Array.from({ length: columnCount }).map((_, colIdx) => (
+            <div key={colIdx} className="memorial-column">
+              {Array.from({ length: 6 }).map((__, idx) => (
+                <Card key={`skeleton-${colIdx}-${idx}`} className="memorial-card" size="small" bodyStyle={{ padding: 12 }}>
+                  <Skeleton active paragraph={{ rows: 4 }} />
+                </Card>
+              ))}
+            </div>
+          ))}
         </div>
       ) : items.length === 0 ? (
         <div className="memorial-empty">

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useApp } from '../hooks/useApp';
 import { Button, Empty, Tooltip } from 'antd';
-import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined } from '@ant-design/icons';
+import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, BugOutlined } from '@ant-design/icons';
 import { useTheme } from '../hooks/useTheme';
 import { StatusPicker } from './StatusPicker';
 import * as db from '../utils/database';
@@ -15,6 +15,7 @@ interface TodoListProps {
   onShowDashboard?: () => void;
   onShowMemorial?: () => void;
   onShowSettings?: () => void;
+  onShowGame?: () => void;
 }
 
 function SkeletonRow() {
@@ -31,7 +32,7 @@ function SkeletonList() {
   );
 }
 
-export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, onShowDashboard, onShowMemorial, onShowSettings }: TodoListProps) {
+export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, onShowDashboard, onShowMemorial, onShowSettings, onShowGame }: TodoListProps) {
   const { state, dispatch } = useApp();
   const { themeMode, toggleTheme } = useTheme();
   const { todos, selectedTodoId, selectedTagId, tags } = state;
@@ -100,6 +101,14 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
               aria-label="切换主题"
             />
           </Tooltip>
+          <Button
+            type="text"
+            size="small"
+            icon={<BugOutlined />}
+            onClick={onShowGame}
+            className="tag-btn"
+            aria-label="小游戏"
+          />
           <Button
             type="text"
             size="small"

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useApp } from '../hooks/useApp';
 import { Button, Empty, Tooltip } from 'antd';
-import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, BugOutlined } from '@ant-design/icons';
+import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined } from '@ant-design/icons';
 import { useTheme } from '../hooks/useTheme';
 import { StatusPicker } from './StatusPicker';
 import * as db from '../utils/database';
@@ -15,7 +15,6 @@ interface TodoListProps {
   onShowDashboard?: () => void;
   onShowMemorial?: () => void;
   onShowSettings?: () => void;
-  onShowGame?: () => void;
 }
 
 function SkeletonRow() {
@@ -32,7 +31,7 @@ function SkeletonList() {
   );
 }
 
-export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, onShowDashboard, onShowMemorial, onShowSettings, onShowGame }: TodoListProps) {
+export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, onShowDashboard, onShowMemorial, onShowSettings }: TodoListProps) {
   const { state, dispatch } = useApp();
   const { themeMode, toggleTheme } = useTheme();
   const { todos, selectedTodoId, selectedTagId, tags } = state;
@@ -101,14 +100,6 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
               aria-label="切换主题"
             />
           </Tooltip>
-          <Button
-            type="text"
-            size="small"
-            icon={<BugOutlined />}
-            onClick={onShowGame}
-            className="tag-btn"
-            aria-label="小游戏"
-          />
           <Button
             type="text"
             size="small"


### PR DESCRIPTION

## 改动内容

### 1. 结论视图 — 卡片不再跳跃
- **问题**：CSS `column-count` 多列布局下，展开结论会导致所有卡片重排，被点击的卡片跳到别的位置
- **解决**：改为手动分列（column splitting）+ flex 垂直排列，每列独立渲染，展开卡片只影响所在列的高度，其他列不受影响

### 2. 看板视图 — 四列 100% 铺满
- **问题**：每列受 `min-width: 240px` / `max-width: 340px` 限制，不能自适应铺满页面
- **解决**：移除硬限制，`flex: 1` 自动均分四列各 25%，卡片宽度随屏幕自适应缩放
- 容器去掉左右 padding，横向贴边

## 涉及文件
- `frontend/src/App.css` — 看板列 CSS 调整
- `frontend/src/MemorialBoard.tsx` — 结论视图手动分列逻辑
- `frontend/src/App.css` — 结论网格 flex 布局替代 column-count

## 验证
- 前端 TypeScript 编译通过 ✅
