### PR TITLE
feat: Dashboard 新增 Skills 和 Backup 指标卡片

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -1100,6 +1100,12 @@ impl Database {
             })
             .collect();
 
+        // Skills invocation statistics
+        let skills_stats = self.get_skills_stats(&time_filter).await;
+
+        // Backup statistics (filesystem scan)
+        let backup_stats = self.get_backup_stats().await;
+
         Ok(crate::models::DashboardStats {
             total_todos,
             pending_todos,
@@ -1137,6 +1143,9 @@ impl Database {
             top_model,
             top_model_tokens,
             leaderboard,
+            // Skills & Backup metrics
+            skills_stats: skills_stats.unwrap_or(None),
+            backup_stats: backup_stats.unwrap_or(None),
         })
     }
 
@@ -1272,5 +1281,308 @@ impl Database {
             tracing::info!("Cleaned up {} orphan execution records", rows);
         }
         Ok(())
+    }
+
+    /// Get skills invocation statistics
+    async fn get_skills_stats(
+        &self,
+        time_filter: &str,
+    ) -> Result<Option<crate::models::SkillsStats>, sea_orm::DbErr> {
+        let backend = self.conn.get_database_backend();
+
+        // Skills overall stats
+        let skills_overall_sql = format!(
+            "SELECT \
+            COUNT(*) as total, \
+            COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success, \
+            COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed, \
+            COALESCE(AVG(duration_ms), 0) as avg_duration, \
+            COALESCE(SUM(CASE WHEN date(invoked_at) = date('now') THEN 1 ELSE 0 END), 0) as today \
+            FROM skill_invocations \
+            WHERE invoked_at >= {}",
+            time_filter
+        );
+
+        let (total_invocations, success_invocations, failed_invocations, avg_duration_ms, invocations_today) =
+            if let Some(row) = self.conn.query_one(Statement::from_string(backend, skills_overall_sql)).await? {
+                (
+                    row.try_get_by::<i64, _>("total").unwrap_or(0),
+                    row.try_get_by::<i64, _>("success").unwrap_or(0),
+                    row.try_get_by::<i64, _>("failed").unwrap_or(0),
+                    row.try_get_by::<f64, _>("avg_duration").unwrap_or(0.0),
+                    row.try_get_by::<i64, _>("today").unwrap_or(0),
+                )
+            } else {
+                (0, 0, 0, 0.0, 0)
+            };
+
+        // If no invocations, return None
+        if total_invocations == 0 {
+            return Ok(None);
+        }
+
+        // Top skills by invocation count
+        let top_skills_sql = format!(
+            "SELECT skill_name, COUNT(*) as count, \
+            CAST(COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) AS FLOAT) / COUNT(*) * 100 as success_rate \
+            FROM skill_invocations \
+            WHERE invoked_at >= {} \
+            GROUP BY skill_name \
+            ORDER BY count DESC LIMIT 10",
+            time_filter
+        );
+
+        let top_skills: Vec<crate::models::SkillTop> = self.conn
+            .query_all(Statement::from_string(backend, top_skills_sql))
+            .await?
+            .into_iter()
+            .filter_map(|row| {
+                let skill_name: String = row.try_get_by("skill_name").ok()?;
+                let count: i64 = row.try_get_by("count").ok()?;
+                let success_rate: f64 = row.try_get_by("success_rate").ok()?;
+                Some(crate::models::SkillTop {
+                    skill_name,
+                    count,
+                    success_rate,
+                })
+            })
+            .collect();
+
+        // Executor skills count (distinct skill names per executor)
+        let executor_skills_sql = format!(
+            "SELECT executor, COUNT(DISTINCT skill_name) as skills_count \
+            FROM skill_invocations \
+            WHERE invoked_at >= {} \
+            GROUP BY executor",
+            time_filter
+        );
+
+        let executor_skills_count: Vec<crate::models::ExecutorSkillCount> = self.conn
+            .query_all(Statement::from_string(backend, executor_skills_sql))
+            .await?
+            .into_iter()
+            .filter_map(|row| {
+                let executor: String = row.try_get_by("executor").ok()?;
+                let skills_count: i64 = row.try_get_by("skills_count").ok()?;
+                Some(crate::models::ExecutorSkillCount {
+                    executor,
+                    skills_count,
+                })
+            })
+            .collect();
+
+        // Daily skill invocations (last 30 days)
+        let daily_skills_sql = format!(
+            "SELECT SUBSTR(COALESCE(invoked_at, ''), 1, 10) as day, \
+            COUNT(*) as count, \
+            COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success \
+            FROM skill_invocations \
+            WHERE invoked_at IS NOT NULL AND LENGTH(invoked_at) >= 10 AND invoked_at >= {} \
+            GROUP BY SUBSTR(invoked_at, 1, 10) \
+            ORDER BY day DESC LIMIT 30",
+            time_filter
+        );
+
+        let daily_invocations: Vec<crate::models::DailySkillInvocation> = self.conn
+            .query_all(Statement::from_string(backend, daily_skills_sql))
+            .await?
+            .into_iter()
+            .filter_map(|row| {
+                let date: String = row.try_get_by("day").ok()?;
+                let count: i64 = row.try_get_by("count").ok()?;
+                let success: i64 = row.try_get_by("success").ok()?;
+                Some(crate::models::DailySkillInvocation {
+                    date,
+                    count,
+                    success,
+                })
+            })
+            .collect();
+
+        Ok(Some(crate::models::SkillsStats {
+            total_invocations,
+            success_invocations,
+            failed_invocations,
+            avg_duration_ms,
+            invocations_today,
+            top_skills,
+            executor_skills_count,
+            daily_invocations,
+        }))
+    }
+
+    /// Get backup statistics by scanning filesystem
+    async fn get_backup_stats(&self) -> Result<Option<crate::models::BackupStats>, sea_orm::DbErr> {
+        let backup_dir = dirs::home_dir()
+            .map(|h| h.join(".ntd").join("backups"))
+            .unwrap_or_else(|| std::path::PathBuf::from(".ntd/backups"));
+
+        if !backup_dir.exists() {
+            return Ok(None);
+        }
+
+        // Scan backup subdirectories
+        let database_stats = Self::scan_backup_category(&backup_dir.join("db"));
+        let todo_stats = Self::scan_backup_category(&backup_dir.join("todo"));
+        let skills_stats = Self::scan_backup_category(&backup_dir.join("skills"));
+
+        let total_file_count = database_stats.file_count + todo_stats.file_count + skills_stats.file_count;
+        let total_size = database_stats.total_size + todo_stats.total_size + skills_stats.total_size;
+
+        // Collect recent backups from all categories
+        let mut recent_backups: Vec<crate::models::RecentBackup> = Vec::new();
+
+        if let Some(files) = Self::collect_backup_files(&backup_dir.join("db")) {
+            for f in files.into_iter().take(5) {
+                recent_backups.push(crate::models::RecentBackup {
+                    backup_type: "database".to_string(),
+                    name: f.name,
+                    size: f.size,
+                    created_at: f.created_at,
+                });
+            }
+        }
+        if let Some(files) = Self::collect_backup_files(&backup_dir.join("todo")) {
+            for f in files.into_iter().take(5) {
+                recent_backups.push(crate::models::RecentBackup {
+                    backup_type: "todo".to_string(),
+                    name: f.name,
+                    size: f.size,
+                    created_at: f.created_at,
+                });
+            }
+        }
+        if let Some(files) = Self::collect_backup_files(&backup_dir.join("skills")) {
+            for f in files.into_iter().take(5) {
+                recent_backups.push(crate::models::RecentBackup {
+                    backup_type: "skills".to_string(),
+                    name: f.name,
+                    size: f.size,
+                    created_at: f.created_at,
+                });
+            }
+        }
+
+        // Sort by created_at desc and take top 10
+        recent_backups.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        recent_backups.truncate(10);
+
+        // Find overall last backup time
+        let last_backup = recent_backups.first().map(|b| b.created_at.clone());
+
+        // Format total size
+        let total_size_formatted = Self::format_bytes(total_size as u64);
+
+        Ok(Some(crate::models::BackupStats {
+            auto_backup_enabled: false,
+            last_backup,
+            auto_backup_cron: String::new(),
+            database: database_stats,
+            todo: todo_stats,
+            skills: skills_stats,
+            total_file_count,
+            total_size,
+            total_size_formatted,
+            recent_backups,
+        }))
+    }
+
+    /// Scan a backup category directory and return stats
+    fn scan_backup_category(dir: &std::path::Path) -> crate::models::BackupCategoryStats {
+        use std::fs;
+
+        if !dir.exists() {
+            return crate::models::BackupCategoryStats {
+                file_count: 0,
+                total_size: 0,
+                last_backup: None,
+            };
+        }
+
+        let mut file_count = 0i64;
+        let mut total_size = 0i64;
+        let mut last_backup: Option<String> = None;
+
+        if let Ok(entries) = fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                if let Ok(metadata) = entry.metadata() {
+                    if metadata.is_file() {
+                        file_count += 1;
+                        total_size += metadata.len() as i64;
+
+                        if let Ok(modified) = metadata.modified() {
+                            let modified_str = Self::system_time_to_iso_string(modified);
+                            if last_backup.is_none() || modified_str > *last_backup.as_ref().unwrap() {
+                                last_backup = Some(modified_str);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        crate::models::BackupCategoryStats {
+            file_count,
+            total_size,
+            last_backup,
+        }
+    }
+
+    /// Collect backup files from a directory
+    fn collect_backup_files(dir: &std::path::Path) -> Option<Vec<crate::models::RecentBackup>> {
+        use std::fs;
+
+        if !dir.exists() {
+            return None;
+        }
+
+        let mut files: Vec<crate::models::RecentBackup> = Vec::new();
+
+        if let Ok(entries) = fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                if let Ok(metadata) = entry.metadata() {
+                    if metadata.is_file() {
+                        let name = entry.file_name().to_string_lossy().to_string();
+                        let size = metadata.len() as i64;
+                        let created_at = metadata.modified().ok()
+                            .map(|t| Self::system_time_to_iso_string(t))
+                            .unwrap_or_default();
+
+                        files.push(crate::models::RecentBackup {
+                            backup_type: String::new(), // Will be set by caller
+                            name,
+                            size,
+                            created_at,
+                        });
+                    }
+                }
+            }
+        }
+
+        Some(files)
+    }
+
+    /// Convert SystemTime to ISO string
+    fn system_time_to_iso_string(time: std::time::SystemTime) -> String {
+        use chrono::{DateTime, Utc};
+        let datetime: DateTime<Utc> = time.into();
+        datetime.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+    }
+
+    /// Format bytes to human readable string
+    fn format_bytes(bytes: u64) -> String {
+        const KB: u64 = 1024;
+        const MB: u64 = KB * 1024;
+        const GB: u64 = MB * 1024;
+
+        if bytes >= GB {
+            format!("{:.2} GB", bytes as f64 / GB as f64)
+        } else if bytes >= MB {
+            format!("{:.2} MB", bytes as f64 / MB as f64)
+        } else if bytes >= KB {
+            format!("{:.2} KB", bytes as f64 / KB as f64)
+        } else {
+            format!("{} B", bytes)
+        }
     }
 }

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -1101,10 +1101,22 @@ impl Database {
             .collect();
 
         // Skills invocation statistics
-        let skills_stats = self.get_skills_stats(&time_filter).await;
+        let skills_stats = match self.get_skills_stats(&time_filter).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("Failed to load skills stats: {}", e);
+                None
+            }
+        };
 
         // Backup statistics (filesystem scan)
-        let backup_stats = self.get_backup_stats().await;
+        let backup_stats = match self.get_backup_stats().await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("Failed to load backup stats: {}", e);
+                None
+            }
+        };
 
         Ok(crate::models::DashboardStats {
             total_todos,
@@ -1144,8 +1156,8 @@ impl Database {
             top_model_tokens,
             leaderboard,
             // Skills & Backup metrics
-            skills_stats: skills_stats.unwrap_or(None),
-            backup_stats: backup_stats.unwrap_or(None),
+            skills_stats,
+            backup_stats,
         })
     }
 
@@ -1558,6 +1570,9 @@ impl Database {
                 }
             }
         }
+
+        // Sort by created_at descending (newest first)
+        files.sort_by(|a, b| b.created_at.cmp(&a.created_at));
 
         Some(files)
     }

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -459,6 +459,10 @@ pub struct DashboardStats {
     pub top_model: Option<String>,
     pub top_model_tokens: Option<u64>,
     pub leaderboard: Vec<LeaderboardItem>,
+    // Skills metrics
+    pub skills_stats: Option<SkillsStats>,
+    // Backup metrics
+    pub backup_stats: Option<BackupStats>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -507,6 +511,70 @@ pub struct ModelCacheStat {
     pub total_input_tokens: u64,
     pub total_cache_read_tokens: u64,
     pub cache_hit_rate: f64,
+}
+
+// Skills invocation statistics
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillsStats {
+    pub total_invocations: i64,
+    pub success_invocations: i64,
+    pub failed_invocations: i64,
+    pub avg_duration_ms: f64,
+    pub invocations_today: i64,
+    pub top_skills: Vec<SkillTop>,
+    pub executor_skills_count: Vec<ExecutorSkillCount>,
+    pub daily_invocations: Vec<DailySkillInvocation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillTop {
+    pub skill_name: String,
+    pub count: i64,
+    pub success_rate: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutorSkillCount {
+    pub executor: String,
+    pub skills_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DailySkillInvocation {
+    pub date: String,
+    pub count: i64,
+    pub success: i64,
+}
+
+// Backup statistics
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupStats {
+    pub auto_backup_enabled: bool,
+    pub last_backup: Option<String>,
+    pub auto_backup_cron: String,
+    pub database: BackupCategoryStats,
+    pub todo: BackupCategoryStats,
+    pub skills: BackupCategoryStats,
+    pub total_file_count: i64,
+    pub total_size: i64,
+    pub total_size_formatted: String,
+    pub recent_backups: Vec<RecentBackup>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupCategoryStats {
+    pub file_count: i64,
+    pub total_size: i64,
+    pub last_backup: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecentBackup {
+    #[serde(rename = "type")]
+    pub backup_type: String,
+    pub name: String,
+    pub size: i64,
+    pub created_at: String,
 }
 
 #[derive(Deserialize)]

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1125,6 +1125,109 @@ export function Dashboard({ onBack }: DashboardProps) {
     ),
   });
 
+  // Skills Invocation Statistics
+  panels.push({
+    key: 'skills-stats',
+    render: () => {
+      const skillsStats = stats?.skills_stats;
+      const skillsSuccessRate = skillsStats && skillsStats.total_invocations > 0
+        ? (skillsStats.success_invocations / skillsStats.total_invocations * 100)
+        : 0;
+
+      return (
+        <Card
+          title={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><ThunderboltOutlined /><span>Skills 调用统计</span></div>}
+          extra={<ClockCircleOutlined style={{ color: 'var(--color-text-tertiary)' }} />}
+          className="dashboard-card" style={{ borderRadius: 12 }}
+          bodyStyle={{ padding: '16px 20px' }}
+        >
+          {skillsStats ? (
+            <div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12, marginBottom: 16 }}>
+                <MetricCard
+                  title="总调用"
+                  value={skillsStats.total_invocations}
+                  prefix={<ThunderboltOutlined />}
+                  color="#6366f1"
+                  loading={loading}
+                  chineseFormat
+                />
+                <MetricCard
+                  title="今日调用"
+                  value={skillsStats.invocations_today}
+                  prefix={<ThunderboltOutlined />}
+                  color="#22c55e"
+                  loading={loading}
+                />
+                <MetricCard
+                  title="成功率"
+                  value={skillsSuccessRate}
+                  suffix="%"
+                  prefix={<CheckCircleOutlined />}
+                  color="#3b82f6"
+                  loading={loading}
+                  decimals={1}
+                />
+                <MetricCard
+                  title="平均耗时"
+                  value={skillsStats.avg_duration_ms}
+                  suffix="ms"
+                  prefix={<BarChartOutlined />}
+                  color="#f59e0b"
+                  loading={loading}
+                />
+              </div>
+              {skillsStats.top_skills && skillsStats.top_skills.length > 0 && (
+                <div>
+                  <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 8 }}>Top Skills</div>
+                  {skillsStats.top_skills.slice(0, 5).map((skill) => (
+                    <CompactRow
+                      key={skill.skill_name}
+                      name={skill.skill_name}
+                      value={skill.count}
+                      sub={`成功率 ${skill.success_rate.toFixed(1)}%`}
+                      color="#6366f1"
+                      barPct={(skill.count / (skillsStats.top_skills[0]?.count || 1)) * 100}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : (
+            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无 Skills 调用数据" />
+          )}
+        </Card>
+      );
+    },
+  });
+
+  // Backup Statistics
+  panels.push({
+    key: 'backup-stats',
+    render: () => {
+      const backupStats = stats?.backup_stats;
+
+      return (
+        <Card
+          title={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><FileTextOutlined /><span>备份统计</span></div>}
+          className="dashboard-card" style={{ borderRadius: 12 }}
+          bodyStyle={{ padding: '16px 20px' }}
+        >
+          {backupStats ? (
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 16 }}>
+              <MiniStat title="数据库备份" value={backupStats.database.file_count} suffix="个" prefix={<FileTextOutlined />} color="#3b82f6" loading={loading} />
+              <MiniStat title="Todo 备份" value={backupStats.todo.file_count} suffix="个" prefix={<FileTextOutlined />} color="#22c55e" loading={loading} />
+              <MiniStat title="Skills 备份" value={backupStats.skills.file_count} suffix="个" prefix={<FileTextOutlined />} color="#f59e0b" loading={loading} />
+              <MiniStat title="总大小" value={parseFloat(backupStats.total_size_formatted) || 0} suffix={backupStats.total_size_formatted.replace(/[\d.]+/g, '')} prefix={<FileTextOutlined />} color="#8b5cf6" loading={loading} />
+            </div>
+          ) : (
+            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无备份数据" />
+          )}
+        </Card>
+      );
+    },
+  });
+
   return (
     <div style={{ height: '100%', overflow: 'auto', padding: '16px 20px', background: 'var(--color-bg-layout)' }}>
       <style>{`

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1218,7 +1218,17 @@ export function Dashboard({ onBack }: DashboardProps) {
               <MiniStat title="数据库备份" value={backupStats.database.file_count} suffix="个" prefix={<FileTextOutlined />} color="#3b82f6" loading={loading} />
               <MiniStat title="Todo 备份" value={backupStats.todo.file_count} suffix="个" prefix={<FileTextOutlined />} color="#22c55e" loading={loading} />
               <MiniStat title="Skills 备份" value={backupStats.skills.file_count} suffix="个" prefix={<FileTextOutlined />} color="#f59e0b" loading={loading} />
-              <MiniStat title="总大小" value={parseFloat(backupStats.total_size_formatted) || 0} suffix={backupStats.total_size_formatted.replace(/[\d.]+/g, '')} prefix={<FileTextOutlined />} color="#8b5cf6" loading={loading} />
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', borderRadius: 10, background: 'var(--color-fill-quaternary)' }}>
+                <div style={{ width: 40, height: 40, borderRadius: 10, backgroundColor: '#8b5f616', color: '#8b5cf6', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18 }}>
+                  <FileTextOutlined />
+                </div>
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 2 }}>总大小</div>
+                  <div style={{ fontSize: 22, fontWeight: 700, color: 'var(--color-text)', lineHeight: 1.2 }}>
+                    {backupStats.total_size_formatted || '0 B'}
+                  </div>
+                </div>
+              </div>
             </div>
           ) : (
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无备份数据" />

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -215,6 +215,10 @@ export interface DashboardStats {
   top_model?: string;
   top_model_tokens?: number;
   leaderboard?: LeaderboardItem[];
+  // Skills metrics
+  skills_stats?: SkillsStats;
+  // Backup metrics
+  backup_stats?: BackupStats;
 }
 
 export interface LeaderboardItem {
@@ -486,4 +490,60 @@ export interface FeishuHistoryChat {
   last_fetch_time: string | null;
   polling_interval_secs: number;
   created_at: string | null;
+}
+
+// Skills statistics
+export interface SkillsStats {
+  total_invocations: number;
+  success_invocations: number;
+  failed_invocations: number;
+  avg_duration_ms: number;
+  invocations_today: number;
+  top_skills: SkillTop[];
+  executor_skills_count: ExecutorSkillCount[];
+  daily_invocations: DailySkillInvocation[];
+}
+
+export interface SkillTop {
+  skill_name: string;
+  count: number;
+  success_rate: number;
+}
+
+export interface ExecutorSkillCount {
+  executor: string;
+  skills_count: number;
+}
+
+export interface DailySkillInvocation {
+  date: string;
+  count: number;
+  success: number;
+}
+
+// Backup statistics
+export interface BackupStats {
+  auto_backup_enabled: boolean;
+  last_backup: string | null;
+  auto_backup_cron: string;
+  database: BackupCategoryStats;
+  todo: BackupCategoryStats;
+  skills: BackupCategoryStats;
+  total_file_count: number;
+  total_size: number;
+  total_size_formatted: string;
+  recent_backups: RecentBackup[];
+}
+
+export interface BackupCategoryStats {
+  file_count: number;
+  total_size: number;
+  last_backup: string | null;
+}
+
+export interface RecentBackup {
+  type: string;
+  name: string;
+  size: number;
+  created_at: string;
 }


### PR DESCRIPTION
## Summary
- Dashboard 新增 **Skills 调用统计** 卡片：显示总调用、成功率、平均耗时、Top Skills 排行
- Dashboard 新增 **备份统计** 卡片：显示数据库/Todo/Skills 备份文件数、总大小

## Test plan
- [x] 后端 API `/xyz/dashboard-stats` 返回 `skills_stats` 和 `backup_stats` 数据
- [x] 前端 Dashboard 正常渲染两个新卡片
- [x] 备份数据准确反映 `~/.ntd/backups/` 目录状态