### PR TITLE
feat: 添加 Webhook 功能

### DIFF
--- a/backend/src/db/entity/mod.rs
+++ b/backend/src/db/entity/mod.rs
@@ -13,6 +13,8 @@ pub mod tags;
 pub mod todo_tags;
 pub mod todo_templates;
 pub mod todos;
+pub mod webhooks;
+pub mod webhook_records;
 
 pub mod prelude {
     pub use super::agent_bots::Entity as AgentBots;
@@ -30,4 +32,6 @@ pub mod prelude {
     pub use super::todo_tags::Entity as TodoTags;
     pub use super::todo_templates::Entity as TodoTemplates;
     pub use super::todos::Entity as Todos;
+    pub use super::webhooks::Entity as Webhooks;
+    pub use super::webhook_records::Entity as WebhookRecords;
 }

--- a/backend/src/db/entity/webhook_records.rs
+++ b/backend/src/db/entity/webhook_records.rs
@@ -1,0 +1,24 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "webhook_records")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub webhook_id: Option<i64>,
+    pub method: String,
+    pub path: String,
+    pub query_params: Option<String>,
+    pub body: Option<String>,
+    pub content_type: Option<String>,
+    pub triggered_todo_id: Option<i64>,
+    pub status_code: Option<i32>,
+    pub response_body: Option<String>,
+    pub created_at: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/entity/webhooks.rs
+++ b/backend/src/db/entity/webhooks.rs
@@ -1,0 +1,19 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "webhooks")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub name: String,
+    pub enabled: bool,
+    pub default_todo_id: Option<i64>,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -771,6 +771,10 @@ impl Database {
         )
         .await?;
 
+        // Indexes for webhook_records (improve N+1 query performance)
+        self.exec("CREATE INDEX IF NOT EXISTS idx_webhook_records_webhook_id ON webhook_records(webhook_id)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_webhook_records_triggered_todo_id ON webhook_records(triggered_todo_id)").await?;
+
         // Webhook records timestamps triggers
         self.exec(
             "CREATE TRIGGER IF NOT EXISTS set_webhook_records_created_at_utc AFTER INSERT ON webhook_records

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -721,6 +721,66 @@ impl Database {
         )
         .await?;
 
+        // Webhooks table
+        self.exec(
+            "CREATE TABLE IF NOT EXISTS webhooks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                default_todo_id INTEGER,
+                created_at TEXT,
+                updated_at TEXT
+            )",
+        )
+        .await?;
+
+        // Webhooks timestamps triggers
+        self.exec(
+            "CREATE TRIGGER IF NOT EXISTS set_webhooks_created_at_utc AFTER INSERT ON webhooks
+             WHEN new.created_at IS NULL OR new.created_at = ''
+             BEGIN
+                 UPDATE webhooks SET created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', 'utc') WHERE rowid = new.rowid;
+             END",
+        )
+        .await?;
+
+        self.exec(
+            "CREATE TRIGGER IF NOT EXISTS set_webhooks_updated_at_utc BEFORE UPDATE ON webhooks
+             WHEN new.updated_at IS NULL OR new.updated_at = ''
+             BEGIN
+                 SELECT raise(IGNORE);
+             END",
+        )
+        .await?;
+
+        // Webhook records table
+        self.exec(
+            "CREATE TABLE IF NOT EXISTS webhook_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                webhook_id INTEGER,
+                method TEXT NOT NULL,
+                path TEXT NOT NULL,
+                query_params TEXT,
+                body TEXT,
+                content_type TEXT,
+                triggered_todo_id INTEGER,
+                status_code INTEGER,
+                response_body TEXT,
+                created_at TEXT
+            )",
+        )
+        .await?;
+
+        // Webhook records timestamps triggers
+        self.exec(
+            "CREATE TRIGGER IF NOT EXISTS set_webhook_records_created_at_utc AFTER INSERT ON webhook_records
+             WHEN new.created_at IS NULL OR new.created_at = ''
+             BEGIN
+                 UPDATE webhook_records SET created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', 'utc') WHERE rowid = new.rowid;
+             END",
+        )
+        .await?;
+
         Ok(())
     }
 }
@@ -742,6 +802,7 @@ mod feishu_push_target;
 mod feishu_response_config;
 pub mod project_directory;
 mod todo_template;
+pub mod webhook;
 
 #[cfg(test)]
 mod tests {

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -774,6 +774,7 @@ impl Database {
         // Indexes for webhook_records (improve N+1 query performance)
         self.exec("CREATE INDEX IF NOT EXISTS idx_webhook_records_webhook_id ON webhook_records(webhook_id)").await?;
         self.exec("CREATE INDEX IF NOT EXISTS idx_webhook_records_triggered_todo_id ON webhook_records(triggered_todo_id)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_webhook_records_created_at ON webhook_records(created_at)").await?;
 
         // Webhook records timestamps triggers
         self.exec(

--- a/backend/src/db/webhook.rs
+++ b/backend/src/db/webhook.rs
@@ -76,12 +76,13 @@ impl Database {
     pub async fn create_webhook(
         &self,
         name: &str,
+        enabled: bool,
         default_todo_id: Option<i64>,
     ) -> Result<webhooks::Model, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let am = webhooks::ActiveModel {
             name: ActiveValue::Set(name.to_string()),
-            enabled: ActiveValue::Set(true),
+            enabled: ActiveValue::Set(enabled),
             default_todo_id: ActiveValue::Set(default_todo_id),
             created_at: ActiveValue::Set(Some(now.clone())),
             updated_at: ActiveValue::Set(Some(now)),

--- a/backend/src/db/webhook.rs
+++ b/backend/src/db/webhook.rs
@@ -2,6 +2,7 @@ use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, Paginator
 use crate::db::Database;
 use crate::db::entity::webhooks;
 use crate::db::entity::webhook_records;
+use crate::db::entity::todos;
 
 #[derive(Debug, Clone)]
 pub struct NewWebhookRecord {
@@ -31,11 +32,42 @@ impl Database {
             .await
     }
 
+    /// Get multiple webhooks by ids (batch query).
+    pub async fn get_webhooks_by_ids(&self, ids: &[i64]) -> Result<Vec<webhooks::Model>, sea_orm::DbErr> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        webhooks::Entity::find()
+            .filter(webhooks::Column::Id.is_in(ids.iter().cloned()))
+            .all(&self.conn)
+            .await
+    }
+
+    /// Get multiple todos by ids (batch query).
+    pub async fn get_todos_by_ids(&self, ids: &[i64]) -> Result<Vec<todos::Model>, sea_orm::DbErr> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        todos::Entity::find()
+            .filter(todos::Column::Id.is_in(ids.iter().cloned()))
+            .all(&self.conn)
+            .await
+    }
+
     /// Get the first enabled webhook (default webhook).
     pub async fn get_default_webhook(&self) -> Result<Option<webhooks::Model>, sea_orm::DbErr> {
         webhooks::Entity::find()
             .filter(webhooks::Column::Enabled.eq(true))
             .order_by_desc(webhooks::Column::Id)
+            .one(&self.conn)
+            .await
+    }
+
+    /// Get an enabled webhook that has the given todo_id as its default_todo_id.
+    pub async fn get_webhook_by_default_todo(&self, todo_id: i64) -> Result<Option<webhooks::Model>, sea_orm::DbErr> {
+        webhooks::Entity::find()
+            .filter(webhooks::Column::Enabled.eq(true))
+            .filter(webhooks::Column::DefaultTodoId.eq(todo_id))
             .one(&self.conn)
             .await
     }

--- a/backend/src/db/webhook.rs
+++ b/backend/src/db/webhook.rs
@@ -54,8 +54,11 @@ impl Database {
             .await
     }
 
-    /// Get the first enabled webhook (default webhook).
-    pub async fn get_default_webhook(&self) -> Result<Option<webhooks::Model>, sea_orm::DbErr> {
+    /// Get the most recently created enabled webhook.
+    /// Note: This returns the most recently created (highest ID) enabled webhook,
+    /// not a webhook explicitly marked as "default". If multiple webhooks exist,
+    /// the one created last will be selected.
+    pub async fn get_most_recent_enabled_webhook(&self) -> Result<Option<webhooks::Model>, sea_orm::DbErr> {
         webhooks::Entity::find()
             .filter(webhooks::Column::Enabled.eq(true))
             .order_by_desc(webhooks::Column::Id)

--- a/backend/src/db/webhook.rs
+++ b/backend/src/db/webhook.rs
@@ -1,0 +1,140 @@
+use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect};
+use crate::db::Database;
+use crate::db::entity::webhooks;
+use crate::db::entity::webhook_records;
+
+#[derive(Debug, Clone)]
+pub struct NewWebhookRecord {
+    pub webhook_id: Option<i64>,
+    pub method: String,
+    pub path: String,
+    pub query_params: Option<String>,
+    pub body: Option<String>,
+    pub content_type: Option<String>,
+    pub triggered_todo_id: Option<i64>,
+    pub status_code: Option<i32>,
+    pub response_body: Option<String>,
+}
+
+impl Database {
+    /// Get all webhooks.
+    pub async fn get_webhooks(&self) -> Result<Vec<webhooks::Model>, sea_orm::DbErr> {
+        webhooks::Entity::find()
+            .all(&self.conn)
+            .await
+    }
+
+    /// Get webhook by id.
+    pub async fn get_webhook(&self, id: i64) -> Result<Option<webhooks::Model>, sea_orm::DbErr> {
+        webhooks::Entity::find_by_id(id)
+            .one(&self.conn)
+            .await
+    }
+
+    /// Get the first enabled webhook (default webhook).
+    pub async fn get_default_webhook(&self) -> Result<Option<webhooks::Model>, sea_orm::DbErr> {
+        webhooks::Entity::find()
+            .filter(webhooks::Column::Enabled.eq(true))
+            .one(&self.conn)
+            .await
+    }
+
+    /// Create a new webhook.
+    pub async fn create_webhook(
+        &self,
+        name: &str,
+        default_todo_id: Option<i64>,
+    ) -> Result<webhooks::Model, sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+        let am = webhooks::ActiveModel {
+            name: ActiveValue::Set(name.to_string()),
+            enabled: ActiveValue::Set(true),
+            default_todo_id: ActiveValue::Set(default_todo_id),
+            created_at: ActiveValue::Set(Some(now.clone())),
+            updated_at: ActiveValue::Set(Some(now)),
+            ..Default::default()
+        };
+        am.insert(&self.conn).await
+    }
+
+    /// Update a webhook.
+    pub async fn update_webhook(
+        &self,
+        id: i64,
+        name: &str,
+        enabled: bool,
+        default_todo_id: Option<i64>,
+    ) -> Result<(), sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+        let existing = webhooks::Entity::find_by_id(id)
+            .one(&self.conn)
+            .await?;
+
+        if let Some(c) = existing {
+            let mut am: webhooks::ActiveModel = c.into();
+            am.name = ActiveValue::Set(name.to_string());
+            am.enabled = ActiveValue::Set(enabled);
+            am.default_todo_id = ActiveValue::Set(default_todo_id);
+            am.updated_at = ActiveValue::Set(Some(now));
+            am.update(&self.conn).await?;
+        }
+        Ok(())
+    }
+
+    /// Delete a webhook.
+    pub async fn delete_webhook(&self, id: i64) -> Result<(), sea_orm::DbErr> {
+        webhooks::Entity::delete_by_id(id)
+            .exec(&self.conn)
+            .await?;
+        Ok(())
+    }
+
+    /// Create a new webhook record.
+    pub async fn create_webhook_record(
+        &self,
+        record: NewWebhookRecord,
+    ) -> Result<webhook_records::Model, sea_orm::DbErr> {
+        let am = webhook_records::ActiveModel {
+            webhook_id: ActiveValue::Set(record.webhook_id),
+            method: ActiveValue::Set(record.method),
+            path: ActiveValue::Set(record.path),
+            query_params: ActiveValue::Set(record.query_params),
+            body: ActiveValue::Set(record.body),
+            content_type: ActiveValue::Set(record.content_type),
+            triggered_todo_id: ActiveValue::Set(record.triggered_todo_id),
+            status_code: ActiveValue::Set(record.status_code),
+            response_body: ActiveValue::Set(record.response_body),
+            ..Default::default()
+        };
+        am.insert(&self.conn).await
+    }
+
+    /// Get webhook records with optional pagination.
+    pub async fn get_webhook_records(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<webhook_records::Model>, sea_orm::DbErr> {
+        webhook_records::Entity::find()
+            .order_by_desc(webhook_records::Column::Id)
+            .limit(limit as u64)
+            .offset(offset as u64)
+            .all(&self.conn)
+            .await
+    }
+
+    /// Get webhook record by id.
+    pub async fn get_webhook_record(&self, id: i64) -> Result<Option<webhook_records::Model>, sea_orm::DbErr> {
+        webhook_records::Entity::find_by_id(id)
+            .one(&self.conn)
+            .await
+    }
+
+    /// Get total count of webhook records.
+    pub async fn get_webhook_records_count(&self) -> Result<i64, sea_orm::DbErr> {
+        webhook_records::Entity::find()
+            .count(&self.conn)
+            .await
+            .map(|c| c as i64)
+    }
+}

--- a/backend/src/db/webhook.rs
+++ b/backend/src/db/webhook.rs
@@ -170,4 +170,21 @@ impl Database {
             .await
             .map(|c| c as i64)
     }
+
+    /// Delete webhook records older than the specified number of days.
+    /// Returns the number of records deleted.
+    pub async fn cleanup_old_webhook_records(&self, days: i64) -> Result<u64, sea_orm::DbErr> {
+        let cutoff = format!(
+            "'{}'",
+            chrono::Utc::now()
+                .checked_sub_signed(chrono::Duration::days(days))
+                .unwrap()
+                .format("%Y-%m-%dT%H:%M:%SZ")
+        );
+        let deleted = webhook_records::Entity::delete_many()
+            .filter(webhook_records::Column::CreatedAt.lt(cutoff))
+            .exec(&self.conn)
+            .await?;
+        Ok(deleted.rows_affected)
+    }
 }

--- a/backend/src/db/webhook.rs
+++ b/backend/src/db/webhook.rs
@@ -35,6 +35,7 @@ impl Database {
     pub async fn get_default_webhook(&self) -> Result<Option<webhooks::Model>, sea_orm::DbErr> {
         webhooks::Entity::find()
             .filter(webhooks::Column::Enabled.eq(true))
+            .order_by_desc(webhooks::Column::Id)
             .one(&self.conn)
             .await
     }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -155,6 +155,7 @@ mod session;
 pub mod project_directory;
 pub(crate) mod todo_template;
 pub mod custom_template;
+pub mod webhook;
 
 // WebSocket handler
 pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
@@ -460,6 +461,14 @@ pub fn create_app(
         .route("/xyz/agent-bots/{id}", delete(agent_bot::delete_agent_bot))
         .route("/xyz/agent-bots/{id}/config", put(agent_bot::update_agent_bot_config))
         .route("/health", get(health_handler))
+        // Webhook trigger endpoints (no /xyz/ prefix, accessible externally)
+        .route("/webhook/trigger", get(webhook::trigger_webhook_default).post(webhook::trigger_webhook_default_post_json))
+        .route("/webhook/trigger/{todo_id}", get(webhook::trigger_webhook_with_todo).post(webhook::trigger_webhook_with_todo_post_json))
+        // Webhook management APIs
+        .route("/xyz/webhooks", get(webhook::list_webhooks).post(webhook::create_webhook))
+        .route("/xyz/webhooks/{id}", get(webhook::get_webhook).put(webhook::update_webhook).delete(webhook::delete_webhook))
+        .route("/xyz/webhook-records", get(webhook::get_webhook_records))
+        .route("/xyz/webhook-records/{id}", get(webhook::get_webhook_record))
         .route("/assets/{*path}", get(static_handler))
         .route("/xyz/version", get(version_handler))
         .route("/xyz/sessions", get(session::list_sessions))

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -110,43 +110,65 @@ pub async fn get_webhook_records(
     State(state): State<AppState>,
     Query(query): Query<WebhookRecordQuery>,
 ) -> Result<impl IntoResponse, AppError> {
+    use std::collections::HashMap;
+
     let limit = query.limit.unwrap_or(50).min(100);
     let offset = query.offset.unwrap_or(0);
 
     let records = state.db.get_webhook_records(limit, offset).await?;
     let total = state.db.get_webhook_records_count().await?;
 
+    // Collect unique webhook_ids and todo_ids
+    let webhook_ids: Vec<i64> = records.iter().filter_map(|r| r.webhook_id).collect();
+    let todo_ids: Vec<i64> = records.iter().filter_map(|r| r.triggered_todo_id).collect();
+
+    // Fetch all webhooks and todos in parallel using tokio::task::spawn
+    let state_db = state.db.clone();
+    let webhook_ids_clone = webhook_ids.clone();
+    let webhook_handle = tokio::spawn(async move {
+        let mut map = HashMap::new();
+        for id in webhook_ids_clone {
+            if let Ok(Some(w)) = state_db.get_webhook(id).await {
+                map.insert(id, w.name);
+            }
+        }
+        map
+    });
+
+    let state_db = state.db.clone();
+    let todo_ids_clone = todo_ids.clone();
+    let todo_handle = tokio::spawn(async move {
+        let mut map = HashMap::new();
+        for id in todo_ids_clone {
+            if let Ok(Some(t)) = state_db.get_todo(id).await {
+                map.insert(id, t.title);
+            }
+        }
+        map
+    });
+
+    let webhook_map = webhook_handle.await.unwrap_or_default();
+    let todo_map = todo_handle.await.unwrap_or_default();
+
     // Enrich records with webhook name and todo title
-    let mut response_records = Vec::new();
-    for record in records {
-        let webhook_name = if let Some(wid) = record.webhook_id {
-            state.db.get_webhook(wid).await.ok().flatten().map(|w| w.name)
-        } else {
-            None
-        };
-
-        let triggered_todo_title = if let Some(tid) = record.triggered_todo_id {
-            state.db.get_todo(tid).await.ok().flatten().map(|t| t.title)
-        } else {
-            None
-        };
-
-        response_records.push(WebhookRecordResponse {
+    let response_records: Vec<WebhookRecordResponse> = records
+        .into_iter()
+        .map(|record| WebhookRecordResponse {
             id: record.id,
             webhook_id: record.webhook_id,
-            webhook_name,
+            webhook_name: record.webhook_id.and_then(|id| webhook_map.get(&id).cloned()),
             method: record.method,
             path: record.path,
             query_params: record.query_params,
             body: record.body,
             content_type: record.content_type,
             triggered_todo_id: record.triggered_todo_id,
-            triggered_todo_title,
+            triggered_todo_title: record.triggered_todo_id.and_then(|id| todo_map.get(&id).cloned()),
             status_code: record.status_code,
             response_body: record.response_body,
             created_at: record.created_at,
-        });
-    }
+        })
+        .collect();
 
     Ok(ApiResponse::ok(WebhookRecordsPage {
         records: response_records,
@@ -332,7 +354,7 @@ async fn trigger_webhook_internal(
     };
 
     // Record the webhook call
-    let _ = state.db.create_webhook_record(NewWebhookRecord {
+    if let Err(e) = state.db.create_webhook_record(NewWebhookRecord {
         webhook_id,
         method,
         path,
@@ -342,7 +364,9 @@ async fn trigger_webhook_internal(
         triggered_todo_id: Some(todo_id),
         status_code: Some(status_code.as_u16() as i32),
         response_body: Some(response_body.clone()),
-    }).await;
+    }).await {
+        tracing::warn!("Failed to create webhook record: {:?}", e);
+    }
 
     let status_code_for_response = status_code.as_u16();
     Ok((

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -1,0 +1,404 @@
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::db::webhook::NewWebhookRecord;
+use crate::handlers::{AppError, AppState};
+use crate::models::ApiResponse;
+use crate::executor_service::RunTodoExecutionRequest;
+
+#[derive(Debug, serde::Deserialize)]
+pub struct CreateWebhookRequest {
+    pub name: String,
+    pub default_todo_id: Option<i64>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct UpdateWebhookRequest {
+    pub name: String,
+    pub enabled: bool,
+    pub default_todo_id: Option<i64>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct WebhookRecordQuery {
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct WebhookRecordResponse {
+    pub id: i64,
+    pub webhook_id: Option<i64>,
+    pub webhook_name: Option<String>,
+    pub method: String,
+    pub path: String,
+    pub query_params: Option<String>,
+    pub body: Option<String>,
+    pub content_type: Option<String>,
+    pub triggered_todo_id: Option<i64>,
+    pub triggered_todo_title: Option<String>,
+    pub status_code: Option<i32>,
+    pub response_body: Option<String>,
+    pub created_at: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct WebhookRecordsPage {
+    pub records: Vec<WebhookRecordResponse>,
+    pub total: i64,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+/// List all webhooks
+pub async fn list_webhooks(
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, AppError> {
+    let webhooks = state.db.get_webhooks().await?;
+    Ok(ApiResponse::ok(webhooks))
+}
+
+/// Get a single webhook
+pub async fn get_webhook(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<impl IntoResponse, AppError> {
+    let webhook = state.db.get_webhook(id).await?;
+    match webhook {
+        Some(w) => Ok(ApiResponse::ok(w)),
+        None => Err(AppError::NotFound),
+    }
+}
+
+/// Create a new webhook
+pub async fn create_webhook(
+    State(state): State<AppState>,
+    Json(req): Json<CreateWebhookRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let webhook = state.db.create_webhook(&req.name, req.default_todo_id).await?;
+    Ok(ApiResponse::ok(webhook))
+}
+
+/// Update a webhook
+pub async fn update_webhook(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Json(req): Json<UpdateWebhookRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    state.db.update_webhook(id, &req.name, req.enabled, req.default_todo_id).await?;
+    let webhook = state.db.get_webhook(id).await?;
+    Ok(ApiResponse::ok(webhook))
+}
+
+/// Delete a webhook
+pub async fn delete_webhook(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<impl IntoResponse, AppError> {
+    state.db.delete_webhook(id).await?;
+    Ok(ApiResponse::ok(()))
+}
+
+/// Get webhook records with pagination
+pub async fn get_webhook_records(
+    State(state): State<AppState>,
+    Query(query): Query<WebhookRecordQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    let limit = query.limit.unwrap_or(50).min(100);
+    let offset = query.offset.unwrap_or(0);
+
+    let records = state.db.get_webhook_records(limit, offset).await?;
+    let total = state.db.get_webhook_records_count().await?;
+
+    // Enrich records with webhook name and todo title
+    let mut response_records = Vec::new();
+    for record in records {
+        let webhook_name = if let Some(wid) = record.webhook_id {
+            state.db.get_webhook(wid).await.ok().flatten().map(|w| w.name)
+        } else {
+            None
+        };
+
+        let triggered_todo_title = if let Some(tid) = record.triggered_todo_id {
+            state.db.get_todo(tid).await.ok().flatten().map(|t| t.title)
+        } else {
+            None
+        };
+
+        response_records.push(WebhookRecordResponse {
+            id: record.id,
+            webhook_id: record.webhook_id,
+            webhook_name,
+            method: record.method,
+            path: record.path,
+            query_params: record.query_params,
+            body: record.body,
+            content_type: record.content_type,
+            triggered_todo_id: record.triggered_todo_id,
+            triggered_todo_title,
+            status_code: record.status_code,
+            response_body: record.response_body,
+            created_at: record.created_at,
+        });
+    }
+
+    Ok(ApiResponse::ok(WebhookRecordsPage {
+        records: response_records,
+        total,
+        limit,
+        offset,
+    }))
+}
+
+/// Get a single webhook record
+pub async fn get_webhook_record(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<impl IntoResponse, AppError> {
+    let record = state.db.get_webhook_record(id).await?;
+    match record {
+        Some(record) => {
+            let webhook_name = if let Some(wid) = record.webhook_id {
+                state.db.get_webhook(wid).await.ok().flatten().map(|w| w.name)
+            } else {
+                None
+            };
+
+            let triggered_todo_title = if let Some(tid) = record.triggered_todo_id {
+                state.db.get_todo(tid).await.ok().flatten().map(|t| t.title)
+            } else {
+                None
+            };
+
+            let response = WebhookRecordResponse {
+                id: record.id,
+                webhook_id: record.webhook_id,
+                webhook_name,
+                method: record.method,
+                path: record.path,
+                query_params: record.query_params,
+                body: record.body,
+                content_type: record.content_type,
+                triggered_todo_id: record.triggered_todo_id,
+                triggered_todo_title,
+                status_code: record.status_code,
+                response_body: record.response_body,
+                created_at: record.created_at,
+            };
+            Ok(ApiResponse::ok(response))
+        }
+        None => Err(AppError::NotFound),
+    }
+}
+
+/// Trigger endpoint for webhook (without todo_id - uses default webhook todo)
+pub async fn trigger_webhook_default(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+) -> Result<impl IntoResponse, AppError> {
+    // Get the default webhook
+    let webhook = state.db.get_default_webhook().await?;
+    let webhook = webhook.ok_or_else(|| AppError::BadRequest("No enabled webhook configured".to_string()))?;
+
+    let default_todo_id = webhook.default_todo_id
+        .ok_or_else(|| AppError::BadRequest("Webhook has no default todo configured".to_string()))?;
+
+    trigger_webhook_internal(
+        Arc::new(state),
+        default_todo_id,
+        Some(webhook.id),
+        "GET".to_string(),
+        "/webhook/trigger".to_string(),
+        params,
+        None,
+        None,
+    ).await
+}
+
+/// Trigger endpoint for webhook (without todo_id - uses default webhook todo) - POST with JSON body
+pub async fn trigger_webhook_default_post_json(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+    Json(body): Json<serde_json::Value>,
+) -> Result<impl IntoResponse, AppError> {
+    // Get the default webhook
+    let webhook = state.db.get_default_webhook().await?;
+    let webhook = webhook.ok_or_else(|| AppError::BadRequest("No enabled webhook configured".to_string()))?;
+
+    let default_todo_id = webhook.default_todo_id
+        .ok_or_else(|| AppError::BadRequest("Webhook has no default todo configured".to_string()))?;
+
+    let body_str = serde_json::to_string(&body).unwrap_or_default();
+    trigger_webhook_internal(
+        Arc::new(state),
+        default_todo_id,
+        Some(webhook.id),
+        "POST".to_string(),
+        "/webhook/trigger".to_string(),
+        params,
+        Some("application/json".to_string()),
+        Some(body_str),
+    ).await
+}
+
+/// Trigger endpoint for webhook (with todo_id) - GET
+pub async fn trigger_webhook_with_todo(
+    State(state): State<AppState>,
+    Path(todo_id): Path<i64>,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+) -> Result<impl IntoResponse, AppError> {
+    trigger_webhook_internal(
+        Arc::new(state),
+        todo_id,
+        None,
+        "GET".to_string(),
+        format!("/webhook/trigger/{}", todo_id),
+        params,
+        None,
+        None,
+    ).await
+}
+
+/// Trigger endpoint for webhook (with todo_id) - POST with JSON body
+pub async fn trigger_webhook_with_todo_post_json(
+    State(state): State<AppState>,
+    Path(todo_id): Path<i64>,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+    Json(body): Json<serde_json::Value>,
+) -> Result<impl IntoResponse, AppError> {
+    let body_str = serde_json::to_string(&body).unwrap_or_default();
+    trigger_webhook_internal(
+        Arc::new(state),
+        todo_id,
+        None,
+        "POST".to_string(),
+        format!("/webhook/trigger/{}", todo_id),
+        params,
+        Some("application/json".to_string()),
+        Some(body_str),
+    ).await
+}
+
+/// Internal trigger implementation
+async fn trigger_webhook_internal(
+    state: Arc<AppState>,
+    todo_id: i64,
+    webhook_id: Option<i64>,
+    method: String,
+    path: String,
+    query_params: HashMap<String, String>,
+    content_type: Option<String>,
+    body: Option<String>,
+) -> Result<impl IntoResponse, AppError> {
+    // Get the todo
+    let todo = state.db.get_todo(todo_id).await?
+        .ok_or_else(|| AppError::NotFound)?;
+
+    // Build message content
+    let (message, raw_message) = build_message_content(&method, &query_params, &body, &content_type);
+
+    // Execute the todo
+    let exec_result = crate::handlers::execution::start_todo_execution(
+        RunTodoExecutionRequest {
+            db: state.db.clone(),
+            executor_registry: state.executor_registry.clone(),
+            tx: state.tx.clone(),
+            task_manager: state.task_manager.clone(),
+            config: state.config.clone(),
+            todo_id,
+            message: todo.prompt.clone(),
+            req_executor: todo.executor.clone(),
+            trigger_type: "webhook".to_string(),
+            params: Some({
+                let mut p = query_params.clone();
+                p.insert("message".to_string(), message.clone());
+                p.insert("raw_message".to_string(), raw_message.clone());
+                p
+            }),
+            resume_session_id: None,
+            resume_message: None,
+        },
+    ).await;
+
+    let (status_code, response_body) = match exec_result {
+        Ok(result) => (StatusCode::OK, serde_json::json!({ "success": true, "record_id": result.record_id }).to_string()),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, serde_json::json!({ "success": false, "error": format!("{:?}", e) }).to_string()),
+    };
+
+    // Record the webhook call
+    let _ = state.db.create_webhook_record(NewWebhookRecord {
+        webhook_id,
+        method,
+        path,
+        query_params: if query_params.is_empty() { None } else { Some(serde_json::to_string(&query_params).unwrap_or_default()) },
+        body,
+        content_type,
+        triggered_todo_id: Some(todo_id),
+        status_code: Some(status_code.as_u16() as i32),
+        response_body: Some(response_body.clone()),
+    }).await;
+
+    let status_code_for_response = status_code.as_u16();
+    Ok((
+        status_code,
+        axum::Json(serde_json::from_str::<serde_json::Value>(&response_body).unwrap_or_else(|_| {
+            serde_json::json!({ "status": status_code_for_response, "body": response_body })
+        }))
+    ).into_response())
+}
+
+fn build_message_content(
+    _method: &str,
+    query_params: &HashMap<String, String>,
+    body: &Option<String>,
+    content_type: &Option<String>,
+) -> (String, String) {
+    let raw = if let Some(ref b) = body {
+        if b.is_empty() {
+            String::new()
+        } else {
+            b.clone()
+        }
+    } else {
+        String::new()
+    };
+    // Avoid unused variable warning
+    let _ = _method;
+
+    let processed = if let Some(ct) = content_type {
+        if ct.contains("application/json") {
+            // Try to parse as JSON and format
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&raw) {
+                serde_json::to_string_pretty(&val).unwrap_or(raw.clone())
+            } else {
+                raw.clone()
+            }
+        } else if ct.contains("application/x-www-form-urlencoded") {
+            // Form data - use as-is
+            raw.clone()
+        } else {
+            raw.clone()
+        }
+    } else {
+        raw.clone()
+    };
+
+    // Include query params in message
+    let message = if !query_params.is_empty() {
+        let params_str = query_params.iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<_>>()
+            .join("&");
+        format!("{}\n\nQuery: {}", processed, params_str)
+    } else {
+        processed
+    };
+
+    (message, raw)
+}

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -111,8 +111,6 @@ pub async fn get_webhook_records(
     State(state): State<AppState>,
     Query(query): Query<WebhookRecordQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    use std::collections::HashMap;
-
     let limit = query.limit.unwrap_or(50).min(100);
     let offset = query.offset.unwrap_or(0);
 
@@ -253,7 +251,11 @@ pub async fn trigger_webhook_default_post_json(
     let default_todo_id = webhook.default_todo_id
         .ok_or_else(|| AppError::BadRequest("Webhook has no default todo configured".to_string()))?;
 
-    let body_str = serde_json::to_string(&body).unwrap_or_default();
+    let body_str = serde_json::to_string(&body)
+        .map_err(|e| {
+            tracing::warn!("Failed to serialize webhook body: {}", e);
+            AppError::BadRequest(format!("Invalid body: {}", e))
+        })?;
     trigger_webhook_internal(
         Arc::new(state),
         default_todo_id,
@@ -299,7 +301,11 @@ pub async fn trigger_webhook_with_todo_post_json(
     let webhook = state.db.get_webhook_by_default_todo(todo_id).await?
         .ok_or_else(|| AppError::BadRequest("No enabled webhook configured for this todo".to_string()))?;
 
-    let body_str = serde_json::to_string(&body).unwrap_or_default();
+    let body_str = serde_json::to_string(&body)
+        .map_err(|e| {
+            tracing::warn!("Failed to serialize webhook body: {}", e);
+            AppError::BadRequest(format!("Invalid body: {}", e))
+        })?;
     trigger_webhook_internal(
         Arc::new(state),
         todo_id,
@@ -364,11 +370,23 @@ async fn trigger_webhook_internal(
     let response_body = response_json.to_string();
 
     // Record the webhook call
+    let query_params_json = if query_params.is_empty() {
+        None
+    } else {
+        match serde_json::to_string(&query_params) {
+            Ok(json) => Some(json),
+            Err(e) => {
+                tracing::warn!("Failed to serialize query_params: {}", e);
+                None
+            }
+        }
+    };
+
     if let Err(e) = state.db.create_webhook_record(NewWebhookRecord {
         webhook_id,
         method,
         path,
-        query_params: if query_params.is_empty() { None } else { Some(serde_json::to_string(&query_params).unwrap_or_default()) },
+        query_params: query_params_json,
         body,
         content_type,
         triggered_todo_id: Some(todo_id),

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -122,33 +122,13 @@ pub async fn get_webhook_records(
     let webhook_ids: Vec<i64> = records.iter().filter_map(|r| r.webhook_id).collect();
     let todo_ids: Vec<i64> = records.iter().filter_map(|r| r.triggered_todo_id).collect();
 
-    // Fetch all webhooks and todos in parallel using tokio::task::spawn
-    let state_db = state.db.clone();
-    let webhook_ids_clone = webhook_ids.clone();
-    let webhook_handle = tokio::spawn(async move {
-        let mut map = HashMap::new();
-        for id in webhook_ids_clone {
-            if let Ok(Some(w)) = state_db.get_webhook(id).await {
-                map.insert(id, w.name);
-            }
-        }
-        map
-    });
+    // Batch fetch all webhooks and todos in a single query each
+    let webhooks = state.db.get_webhooks_by_ids(&webhook_ids).await?;
+    let todos = state.db.get_todos_by_ids(&todo_ids).await?;
 
-    let state_db = state.db.clone();
-    let todo_ids_clone = todo_ids.clone();
-    let todo_handle = tokio::spawn(async move {
-        let mut map = HashMap::new();
-        for id in todo_ids_clone {
-            if let Ok(Some(t)) = state_db.get_todo(id).await {
-                map.insert(id, t.title);
-            }
-        }
-        map
-    });
-
-    let webhook_map = webhook_handle.await.unwrap_or_default();
-    let todo_map = todo_handle.await.unwrap_or_default();
+    // Build lookup maps
+    let webhook_map: HashMap<i64, String> = webhooks.into_iter().map(|w| (w.id, w.name)).collect();
+    let todo_map: HashMap<i64, String> = todos.into_iter().map(|t| (t.id, t.title)).collect();
 
     // Enrich records with webhook name and todo title
     let response_records: Vec<WebhookRecordResponse> = records
@@ -291,10 +271,14 @@ pub async fn trigger_webhook_with_todo(
     Path(todo_id): Path<i64>,
     axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
 ) -> Result<impl IntoResponse, AppError> {
+    // Find webhook that has this todo as default and is enabled
+    let webhook = state.db.get_webhook_by_default_todo(todo_id).await?
+        .ok_or_else(|| AppError::BadRequest("No enabled webhook configured for this todo".to_string()))?;
+
     trigger_webhook_internal(
         Arc::new(state),
         todo_id,
-        None,
+        Some(webhook.id),
         "GET".to_string(),
         format!("/webhook/trigger/{}", todo_id),
         params,
@@ -310,11 +294,15 @@ pub async fn trigger_webhook_with_todo_post_json(
     axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
     Json(body): Json<serde_json::Value>,
 ) -> Result<impl IntoResponse, AppError> {
+    // Find webhook that has this todo as default and is enabled
+    let webhook = state.db.get_webhook_by_default_todo(todo_id).await?
+        .ok_or_else(|| AppError::BadRequest("No enabled webhook configured for this todo".to_string()))?;
+
     let body_str = serde_json::to_string(&body).unwrap_or_default();
     trigger_webhook_internal(
         Arc::new(state),
         todo_id,
-        None,
+        Some(webhook.id),
         "POST".to_string(),
         format!("/webhook/trigger/{}", todo_id),
         params,

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -15,6 +15,7 @@ use crate::executor_service::RunTodoExecutionRequest;
 #[derive(Debug, serde::Deserialize)]
 pub struct CreateWebhookRequest {
     pub name: String,
+    pub enabled: bool,
     pub default_todo_id: Option<i64>,
 }
 
@@ -81,7 +82,7 @@ pub async fn create_webhook(
     State(state): State<AppState>,
     Json(req): Json<CreateWebhookRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    let webhook = state.db.create_webhook(&req.name, req.default_todo_id).await?;
+    let webhook = state.db.create_webhook(&req.name, req.enabled, req.default_todo_id).await?;
     Ok(ApiResponse::ok(webhook))
 }
 
@@ -355,9 +356,8 @@ async fn trigger_webhook_internal(
     let (status_code, response_json) = match exec_result {
         Ok(result) => (StatusCode::OK, serde_json::json!({ "success": true, "record_id": result.record_id })),
         Err(e) => {
-            let err_msg = format!("{:?}", e);
-            let short_err = err_msg.lines().next().unwrap_or("Unknown error").to_string();
-            (StatusCode::INTERNAL_SERVER_ERROR, serde_json::json!({ "success": false, "error": short_err }))
+            tracing::error!("webhook trigger execution failed: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, serde_json::json!({ "success": false, "error": "Internal server error" }))
         }
     };
 

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -354,7 +354,11 @@ async fn trigger_webhook_internal(
 
     let (status_code, response_json) = match exec_result {
         Ok(result) => (StatusCode::OK, serde_json::json!({ "success": true, "record_id": result.record_id })),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, serde_json::json!({ "success": false, "error": format!("{:?}", e) })),
+        Err(e) => {
+            let err_msg = format!("{:?}", e);
+            let short_err = err_msg.lines().next().unwrap_or("Unknown error").to_string();
+            (StatusCode::INTERNAL_SERVER_ERROR, serde_json::json!({ "success": false, "error": short_err }))
+        }
     };
 
     let response_body = response_json.to_string();

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -221,8 +221,8 @@ pub async fn trigger_webhook_default(
     State(state): State<AppState>,
     axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Get the default webhook
-    let webhook = state.db.get_default_webhook().await?;
+    // Get the most recently created enabled webhook
+    let webhook = state.db.get_most_recent_enabled_webhook().await?;
     let webhook = webhook.ok_or_else(|| AppError::BadRequest("No enabled webhook configured".to_string()))?;
 
     let default_todo_id = webhook.default_todo_id
@@ -246,8 +246,8 @@ pub async fn trigger_webhook_default_post_json(
     axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
     Json(body): Json<serde_json::Value>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Get the default webhook
-    let webhook = state.db.get_default_webhook().await?;
+    // Get the most recently created enabled webhook
+    let webhook = state.db.get_most_recent_enabled_webhook().await?;
     let webhook = webhook.ok_or_else(|| AppError::BadRequest("No enabled webhook configured".to_string()))?;
 
     let default_todo_id = webhook.default_todo_id

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -186,17 +186,33 @@ pub async fn get_webhook_record(
     let record = state.db.get_webhook_record(id).await?;
     match record {
         Some(record) => {
-            let webhook_name = if let Some(wid) = record.webhook_id {
-                state.db.get_webhook(wid).await.ok().flatten().map(|w| w.name)
-            } else {
-                None
+            let webhook_id = record.webhook_id;
+            let triggered_todo_id = record.triggered_todo_id;
+
+            // Fetch webhook name and todo title in parallel
+            let webhook_handle = {
+                let db = state.db.clone();
+                tokio::spawn(async move {
+                    if let Some(wid) = webhook_id {
+                        db.get_webhook(wid).await.ok().flatten().map(|w| w.name)
+                    } else {
+                        None
+                    }
+                })
+            };
+            let todo_handle = {
+                let db = state.db.clone();
+                tokio::spawn(async move {
+                    if let Some(tid) = triggered_todo_id {
+                        db.get_todo(tid).await.ok().flatten().map(|t| t.title)
+                    } else {
+                        None
+                    }
+                })
             };
 
-            let triggered_todo_title = if let Some(tid) = record.triggered_todo_id {
-                state.db.get_todo(tid).await.ok().flatten().map(|t| t.title)
-            } else {
-                None
-            };
+            let webhook_name = webhook_handle.await.ok().flatten();
+            let triggered_todo_title = todo_handle.await.ok().flatten();
 
             let response = WebhookRecordResponse {
                 id: record.id,
@@ -348,10 +364,12 @@ async fn trigger_webhook_internal(
         },
     ).await;
 
-    let (status_code, response_body) = match exec_result {
-        Ok(result) => (StatusCode::OK, serde_json::json!({ "success": true, "record_id": result.record_id }).to_string()),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, serde_json::json!({ "success": false, "error": format!("{:?}", e) }).to_string()),
+    let (status_code, response_json) = match exec_result {
+        Ok(result) => (StatusCode::OK, serde_json::json!({ "success": true, "record_id": result.record_id })),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, serde_json::json!({ "success": false, "error": format!("{:?}", e) })),
     };
+
+    let response_body = response_json.to_string();
 
     // Record the webhook call
     if let Err(e) = state.db.create_webhook_record(NewWebhookRecord {
@@ -368,17 +386,11 @@ async fn trigger_webhook_internal(
         tracing::warn!("Failed to create webhook record: {:?}", e);
     }
 
-    let status_code_for_response = status_code.as_u16();
-    Ok((
-        status_code,
-        axum::Json(serde_json::from_str::<serde_json::Value>(&response_body).unwrap_or_else(|_| {
-            serde_json::json!({ "status": status_code_for_response, "body": response_body })
-        }))
-    ).into_response())
+    Ok((status_code, axum::Json(response_json)).into_response())
 }
 
 fn build_message_content(
-    _method: &str,
+    method: &str,
     query_params: &HashMap<String, String>,
     body: &Option<String>,
     content_type: &Option<String>,
@@ -392,8 +404,6 @@ fn build_message_content(
     } else {
         String::new()
     };
-    // Avoid unused variable warning
-    let _ = _method;
 
     let processed = if let Some(ct) = content_type {
         if ct.contains("application/json") {
@@ -413,15 +423,15 @@ fn build_message_content(
         raw.clone()
     };
 
-    // Include query params in message
+    // Build message with method and query params
     let message = if !query_params.is_empty() {
         let params_str = query_params.iter()
             .map(|(k, v)| format!("{}={}", k, v))
             .collect::<Vec<_>>()
             .join("&");
-        format!("{}\n\nQuery: {}", processed, params_str)
+        format!("Method: {}\n{}\n\nQuery: {}", method, processed, params_str)
     } else {
-        processed
+        format!("Method: {}\n{}", method, processed)
     };
 
     (message, raw)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -344,6 +344,13 @@ async fn run_server(cli_port: Option<u16>) {
         tracing::error!("Failed to cleanup orphan execution records: {}", e);
     }
 
+    // Cleanup old webhook records (keep last 30 days)
+    if let Err(e) = db.cleanup_old_webhook_records(30).await {
+        tracing::warn!("Failed to cleanup old webhook records: {}", e);
+    } else {
+        info!("Webhook records cleanup completed");
+    }
+
     // Migrate executor paths from config.yaml to database (one-time), then seed defaults if empty
     if let Err(e) = db.migrate_from_config(&cfg.executors).await {
         tracing::warn!("Executor config migration check failed: {}", e);

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -52,6 +52,7 @@ import {
   EditOutlined,
   FileTextOutlined,
   LeftOutlined,
+  ApiOutlined,
 } from '@ant-design/icons';
 import { Cron } from 'react-js-cron';
 import QRCode from 'qrcode';
@@ -66,6 +67,7 @@ import { CronPresetSelect } from './CronPresetSelect';
 import { SkillsPanel } from './SkillsPanel';
 import { SessionManager } from './SessionManager';
 import { ShareCard } from './ShareCard';
+import { WebhooksPanel } from './WebhooksPanel';
 
 const { Paragraph } = Typography;
 const { Dragger } = Upload;
@@ -3424,6 +3426,16 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
           </Modal>
         </div>
       ),
+    },
+    {
+      key: 'webhooks',
+      label: (
+        <span>
+          <ApiOutlined style={{ marginRight: 6 }} />
+          Webhook
+        </span>
+      ),
+      children: <WebhooksPanel todos={todos} />,
     },
     {
       key: 'about',

--- a/frontend/src/components/WebhooksPanel.tsx
+++ b/frontend/src/components/WebhooksPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   Table,
   Card,
@@ -138,7 +138,7 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
 
   const baseUrl = window.location.origin;
 
-  const webhookColumns = [
+  const webhookColumns = useMemo(() => [
     {
       title: '名称',
       dataIndex: 'name',
@@ -216,9 +216,9 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
         </Space>
       ),
     },
-  ];
+  ], [todos, baseUrl, handleToggleEnabled, handleEditWebhook, handleDeleteWebhook]);
 
-  const recordColumns = [
+  const recordColumns = useMemo(() => [
     {
       title: '时间',
       dataIndex: 'created_at',
@@ -278,7 +278,7 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
         </Button>
       ),
     },
-  ];
+  ], [setViewRecord]);
 
   return (
     <div>

--- a/frontend/src/components/WebhooksPanel.tsx
+++ b/frontend/src/components/WebhooksPanel.tsx
@@ -278,7 +278,7 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
         </Button>
       ),
     },
-  ], [setViewRecord]);
+  ], []);
 
   return (
     <div>

--- a/frontend/src/components/WebhooksPanel.tsx
+++ b/frontend/src/components/WebhooksPanel.tsx
@@ -1,0 +1,450 @@
+import { useState, useEffect } from 'react';
+import {
+  Table,
+  Card,
+  Space,
+  Button,
+  Switch,
+  Modal,
+  Form,
+  Input,
+  Select,
+  message,
+  Popconfirm,
+  Tag,
+  Descriptions,
+  Tabs,
+  Empty,
+  Typography,
+} from 'antd';
+import {
+  PlusOutlined,
+  DeleteOutlined,
+  EditOutlined,
+  ApiOutlined,
+  HistoryOutlined,
+} from '@ant-design/icons';
+import * as db from '../utils/database';
+import type { Webhook, WebhookRecord } from '../utils/database';
+import type { Todo } from '../types';
+
+interface WebhooksPanelProps {
+  todos: Todo[];
+}
+
+export function WebhooksPanel({ todos }: WebhooksPanelProps) {
+  const [webhooks, setWebhooks] = useState<Webhook[]>([]);
+  const [webhooksLoading, setWebhooksLoading] = useState(false);
+  const [webhookFormOpen, setWebhookFormOpen] = useState(false);
+  const [editingWebhook, setEditingWebhook] = useState<Webhook | null>(null);
+  const [webhookForm] = Form.useForm();
+  const [webhookFormSaving, setWebhookFormSaving] = useState(false);
+
+  // Records state
+  const [records, setRecords] = useState<WebhookRecord[]>([]);
+  const [recordsLoading, setRecordsLoading] = useState(false);
+  const [recordsTotal, setRecordsTotal] = useState(0);
+  const [recordsPage, setRecordsPage] = useState(1);
+  const [recordsPageSize, setRecordsPageSize] = useState(20);
+  const [viewRecord, setViewRecord] = useState<WebhookRecord | null>(null);
+
+  const loadWebhooks = async () => {
+    setWebhooksLoading(true);
+    try {
+      const data = await db.getWebhooks();
+      setWebhooks(data);
+    } catch (e: any) {
+      message.error('加载 webhook 失败: ' + (e?.message || String(e)));
+    } finally {
+      setWebhooksLoading(false);
+    }
+  };
+
+  const loadRecords = async (page: number, pageSize: number) => {
+    setRecordsLoading(true);
+    try {
+      const data = await db.getWebhookRecords({ offset: (page - 1) * pageSize, limit: pageSize });
+      setRecords(data.records);
+      setRecordsTotal(data.total);
+    } catch (e: any) {
+      message.error('加载记录失败: ' + (e?.message || String(e)));
+    } finally {
+      setRecordsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadWebhooks();
+    loadRecords(1, recordsPageSize);
+  }, []);
+
+  const handleCreateWebhook = () => {
+    setEditingWebhook(null);
+    webhookForm.resetFields();
+    setWebhookFormOpen(true);
+  };
+
+  const handleEditWebhook = (webhook: Webhook) => {
+    setEditingWebhook(webhook);
+    webhookForm.setFieldsValue({
+      name: webhook.name,
+      enabled: webhook.enabled,
+      default_todo_id: webhook.default_todo_id,
+    });
+    setWebhookFormOpen(true);
+  };
+
+  const handleSaveWebhook = async () => {
+    try {
+      const values = await webhookForm.validateFields();
+      setWebhookFormSaving(true);
+
+      if (editingWebhook) {
+        await db.updateWebhook(editingWebhook.id, values.name, values.enabled, values.default_todo_id);
+        message.success('Webhook 已更新');
+      } else {
+        await db.createWebhook(values.name, values.default_todo_id);
+        message.success('Webhook 已创建');
+      }
+
+      setWebhookFormOpen(false);
+      loadWebhooks();
+    } catch (e: any) {
+      if (e?.errorFields) return; // Form validation error
+      message.error('保存失败: ' + (e?.message || String(e)));
+    } finally {
+      setWebhookFormSaving(false);
+    }
+  };
+
+  const handleDeleteWebhook = async (id: number) => {
+    try {
+      await db.deleteWebhook(id);
+      message.success('Webhook 已删除');
+      loadWebhooks();
+    } catch (e: any) {
+      message.error('删除失败: ' + (e?.message || String(e)));
+    }
+  };
+
+  const handleToggleEnabled = async (webhook: Webhook) => {
+    try {
+      await db.updateWebhook(webhook.id, webhook.name, !webhook.enabled, webhook.default_todo_id ?? undefined);
+      loadWebhooks();
+    } catch (e: any) {
+      message.error('更新失败: ' + (e?.message || String(e)));
+    }
+  };
+
+  const baseUrl = window.location.origin;
+
+  const webhookColumns = [
+    {
+      title: '名称',
+      dataIndex: 'name',
+      key: 'name',
+      width: 150,
+    },
+    {
+      title: '状态',
+      dataIndex: 'enabled',
+      key: 'enabled',
+      width: 80,
+      render: (enabled: boolean, record: Webhook) => (
+        <Switch checked={enabled} onChange={() => handleToggleEnabled(record)} size="small" />
+      ),
+    },
+    {
+      title: '默认触发 Todo',
+      dataIndex: 'default_todo_id',
+      key: 'default_todo_id',
+      width: 200,
+      render: (todoId: number | null) => {
+        if (!todoId) return <span style={{ color: 'var(--color-text-tertiary)' }}>未设置</span>;
+        const todo = todos.find(t => t.id === todoId);
+        return todo ? todo.title : `Todo #${todoId}`;
+      },
+    },
+    {
+      title: '触发 URL',
+      key: 'urls',
+      width: 300,
+      render: (_: any, record: Webhook) => (
+        <Space direction="vertical" size={4}>
+          <Typography.Text
+            copyable={{ text: `${baseUrl}/webhook/trigger` }}
+            style={{ fontSize: 11 }}
+          >
+            <code>{baseUrl}/webhook/trigger</code>
+          </Typography.Text>
+          {record.default_todo_id && (
+            <Typography.Text
+              copyable={{ text: `${baseUrl}/webhook/trigger/${record.default_todo_id}` }}
+              style={{ fontSize: 11 }}
+            >
+              <code>{baseUrl}/webhook/trigger/{record.default_todo_id}</code>
+            </Typography.Text>
+          )}
+        </Space>
+      ),
+    },
+    {
+      title: '创建时间',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      width: 160,
+      render: (t: string) => t ? new Date(t).toLocaleString() : '-',
+    },
+    {
+      title: '操作',
+      key: 'actions',
+      width: 120,
+      render: (_: any, record: Webhook) => (
+        <Space>
+          <Button
+            type="text"
+            size="small"
+            icon={<EditOutlined />}
+            onClick={() => handleEditWebhook(record)}
+          />
+          <Popconfirm
+            title="确定删除此 Webhook？"
+            onConfirm={() => handleDeleteWebhook(record.id)}
+          >
+            <Button type="text" size="small" danger icon={<DeleteOutlined />} />
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  const recordColumns = [
+    {
+      title: '时间',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      width: 160,
+      render: (t: string) => t ? new Date(t).toLocaleString() : '-',
+    },
+    {
+      title: '方法',
+      dataIndex: 'method',
+      key: 'method',
+      width: 70,
+      render: (m: string) => <Tag color={m === 'GET' ? 'blue' : 'green'}>{m}</Tag>,
+    },
+    {
+      title: '路径',
+      dataIndex: 'path',
+      key: 'path',
+      width: 180,
+      ellipsis: true,
+    },
+    {
+      title: 'Webhook',
+      dataIndex: 'webhook_name',
+      key: 'webhook_name',
+      width: 120,
+      render: (n: string | null) => n || '-',
+    },
+    {
+      title: '触发 Todo',
+      dataIndex: 'triggered_todo_title',
+      key: 'triggered_todo_title',
+      width: 150,
+      ellipsis: true,
+      render: (t: string | null, record: WebhookRecord) => {
+        if (!record.triggered_todo_id) return <span style={{ color: 'var(--color-text-tertiary)' }}>未找到</span>;
+        return t || `Todo #${record.triggered_todo_id}`;
+      },
+    },
+    {
+      title: '状态',
+      dataIndex: 'status_code',
+      key: 'status_code',
+      width: 80,
+      render: (code: number | null) => {
+        if (!code) return '-';
+        return <Tag color={code >= 200 && code < 300 ? 'success' : code >= 400 ? 'error' : 'warning'}>{code}</Tag>;
+      },
+    },
+    {
+      title: '操作',
+      key: 'actions',
+      width: 80,
+      render: (_: any, record: WebhookRecord) => (
+        <Button type="text" size="small" onClick={() => setViewRecord(record)}>
+          详情
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <Tabs
+        defaultActiveKey="webhooks"
+        items={[
+          {
+            key: 'webhooks',
+            label: (
+              <span>
+                <ApiOutlined style={{ marginRight: 6 }} />
+                Webhook 配置
+              </span>
+            ),
+            children: (
+              <Card
+                title="Webhook 列表"
+                extra={
+                  <Button type="primary" icon={<PlusOutlined />} onClick={handleCreateWebhook}>
+                    添加 Webhook
+                  </Button>
+                }
+                style={{ marginBottom: 16 }}
+              >
+                <Table
+                  dataSource={webhooks}
+                  columns={webhookColumns}
+                  rowKey="id"
+                  loading={webhooksLoading}
+                  pagination={false}
+                  size="small"
+                />
+                {webhooks.length === 0 && !webhooksLoading && (
+                  <Empty description="暂无 Webhook，点击添加按钮创建" style={{ marginTop: 24 }} />
+                )}
+              </Card>
+            ),
+          },
+          {
+            key: 'records',
+            label: (
+              <span>
+                <HistoryOutlined style={{ marginRight: 6 }} />
+                调用记录
+              </span>
+            ),
+            children: (
+              <Card title="Webhook 调用记录">
+                <Table
+                  dataSource={records}
+                  columns={recordColumns}
+                  rowKey="id"
+                  loading={recordsLoading}
+                  size="small"
+                  pagination={{
+                    current: recordsPage,
+                    pageSize: recordsPageSize,
+                    total: recordsTotal,
+                    onChange: (page, size) => {
+                      setRecordsPage(page);
+                      setRecordsPageSize(size);
+                      loadRecords(page, size);
+                    },
+                    showSizeChanger: true,
+                    pageSizeOptions: ['20', '50', '100'],
+                  }}
+                />
+                {records.length === 0 && !recordsLoading && (
+                  <Empty description="暂无调用记录" style={{ marginTop: 24 }} />
+                )}
+              </Card>
+            ),
+          },
+        ]}
+      />
+
+      <Modal
+        title={editingWebhook ? '编辑 Webhook' : '添加 Webhook'}
+        open={webhookFormOpen}
+        onOk={handleSaveWebhook}
+        onCancel={() => setWebhookFormOpen(false)}
+        confirmLoading={webhookFormSaving}
+        width={500}
+      >
+        <Form form={webhookForm} layout="vertical" style={{ marginTop: 16 }}>
+          <Form.Item
+            name="name"
+            label="名称"
+            rules={[{ required: true, message: '请输入 Webhook 名称' }]}
+          >
+            <Input placeholder="例如: 默认 Webhook" />
+          </Form.Item>
+          <Form.Item
+            name="enabled"
+            label="启用状态"
+            valuePropName="checked"
+            initialValue={true}
+          >
+            <Switch />
+          </Form.Item>
+          <Form.Item
+            name="default_todo_id"
+            label="默认触发 Todo"
+            tooltip="当使用 /webhook/trigger 路径时触发的 Todo"
+          >
+            <Select
+              allowClear
+              placeholder="选择默认触发的 Todo"
+              showSearch
+              filterOption={(input, option) =>
+                (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+              }
+              options={todos.map(t => ({
+                value: t.id,
+                label: t.title,
+              }))}
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      <Modal
+        title="调用记录详情"
+        open={!!viewRecord}
+        onCancel={() => setViewRecord(null)}
+        footer={null}
+        width={600}
+      >
+        {viewRecord && (
+          <Descriptions column={1} size="small" style={{ marginTop: 16 }}>
+            <Descriptions.Item label="记录 ID">{viewRecord.id}</Descriptions.Item>
+            <Descriptions.Item label="时间">{viewRecord.created_at ? new Date(viewRecord.created_at).toLocaleString() : '-'}</Descriptions.Item>
+            <Descriptions.Item label="方法">{viewRecord.method}</Descriptions.Item>
+            <Descriptions.Item label="路径">{viewRecord.path}</Descriptions.Item>
+            <Descriptions.Item label="Content-Type">{viewRecord.content_type || '-'}</Descriptions.Item>
+            <Descriptions.Item label="Webhook">{viewRecord.webhook_name || '-'}</Descriptions.Item>
+            <Descriptions.Item label="触发 Todo">
+              {viewRecord.triggered_todo_title || (viewRecord.triggered_todo_id ? `Todo #${viewRecord.triggered_todo_id}` : '-')}
+            </Descriptions.Item>
+            <Descriptions.Item label="状态码">
+              {viewRecord.status_code && <Tag color={viewRecord.status_code >= 200 && viewRecord.status_code < 300 ? 'success' : 'error'}>{viewRecord.status_code}</Tag>}
+            </Descriptions.Item>
+            {viewRecord.query_params && (
+              <Descriptions.Item label="Query 参数">
+                <pre style={{ background: 'var(--color-fill-quaternary)', padding: 8, borderRadius: 4, fontSize: 12, maxHeight: 150, overflow: 'auto' }}>
+                  {viewRecord.query_params}
+                </pre>
+              </Descriptions.Item>
+            )}
+            {viewRecord.body && (
+              <Descriptions.Item label="请求体">
+                <pre style={{ background: 'var(--color-fill-quaternary)', padding: 8, borderRadius: 4, fontSize: 12, maxHeight: 200, overflow: 'auto', whiteSpace: 'pre-wrap' }}>
+                  {viewRecord.body}
+                </pre>
+              </Descriptions.Item>
+            )}
+            {viewRecord.response_body && (
+              <Descriptions.Item label="响应体">
+                <pre style={{ background: 'var(--color-fill-quaternary)', padding: 8, borderRadius: 4, fontSize: 12, maxHeight: 200, overflow: 'auto', whiteSpace: 'pre-wrap' }}>
+                  {viewRecord.response_body}
+                </pre>
+              </Descriptions.Item>
+            )}
+          </Descriptions>
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/frontend/src/components/WebhooksPanel.tsx
+++ b/frontend/src/components/WebhooksPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import {
   Table,
   Card,
@@ -78,13 +78,13 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
     loadRecords(1, recordsPageSize);
   }, []);
 
-  const handleCreateWebhook = () => {
+  const handleCreateWebhook = useCallback(() => {
     setEditingWebhook(null);
     webhookForm.resetFields();
     setWebhookFormOpen(true);
-  };
+  }, [webhookForm]);
 
-  const handleEditWebhook = (webhook: Webhook) => {
+  const handleEditWebhook = useCallback((webhook: Webhook) => {
     setEditingWebhook(webhook);
     webhookForm.setFieldsValue({
       name: webhook.name,
@@ -92,9 +92,9 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
       default_todo_id: webhook.default_todo_id,
     });
     setWebhookFormOpen(true);
-  };
+  }, [webhookForm]);
 
-  const handleSaveWebhook = async () => {
+  const handleSaveWebhook = useCallback(async () => {
     try {
       const values = await webhookForm.validateFields();
       setWebhookFormSaving(true);
@@ -115,9 +115,9 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
     } finally {
       setWebhookFormSaving(false);
     }
-  };
+  }, [webhookForm, editingWebhook]);
 
-  const handleDeleteWebhook = async (id: number) => {
+  const handleDeleteWebhook = useCallback(async (id: number) => {
     try {
       await db.deleteWebhook(id);
       message.success('Webhook 已删除');
@@ -125,16 +125,16 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
     } catch (e: any) {
       message.error('删除失败: ' + (e?.message || String(e)));
     }
-  };
+  }, []);
 
-  const handleToggleEnabled = async (webhook: Webhook) => {
+  const handleToggleEnabled = useCallback(async (webhook: Webhook) => {
     try {
       await db.updateWebhook(webhook.id, webhook.name, !webhook.enabled, webhook.default_todo_id ?? undefined);
       loadWebhooks();
     } catch (e: any) {
       message.error('更新失败: ' + (e?.message || String(e)));
     }
-  };
+  }, []);
 
   const baseUrl = window.location.origin;
 

--- a/frontend/src/components/WebhooksPanel.tsx
+++ b/frontend/src/components/WebhooksPanel.tsx
@@ -103,7 +103,7 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
         await db.updateWebhook(editingWebhook.id, values.name, values.enabled, values.default_todo_id);
         message.success('Webhook 已更新');
       } else {
-        await db.createWebhook(values.name, values.default_todo_id);
+        await db.createWebhook(values.name, values.enabled, values.default_todo_id);
         message.success('Webhook 已创建');
       }
 

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -866,3 +866,71 @@ export async function getSessionDetail(sessionId: string): Promise<SessionDetail
 export async function deleteSession(sessionId: string): Promise<void> {
   await api.delete(`/xyz/sessions/${sessionId}`);
 }
+
+// Webhook types
+export interface Webhook {
+  id: number;
+  name: string;
+  enabled: boolean;
+  default_todo_id: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WebhookRecord {
+  id: number;
+  webhook_id: number | null;
+  webhook_name: string | null;
+  method: string;
+  path: string;
+  query_params: string | null;
+  body: string | null;
+  content_type: string | null;
+  triggered_todo_id: number | null;
+  triggered_todo_title: string | null;
+  status_code: number | null;
+  response_body: string | null;
+  created_at: string;
+}
+
+export interface WebhookRecordsPage {
+  records: WebhookRecord[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export async function getWebhooks(): Promise<Webhook[]> {
+  return unwrap(await api.get<ApiResp<Webhook[]>>('/xyz/webhooks'));
+}
+
+export async function getWebhook(id: number): Promise<Webhook> {
+  return unwrap(await api.get<ApiResp<Webhook>>(`/xyz/webhooks/${id}`));
+}
+
+export async function createWebhook(name: string, defaultTodoId?: number): Promise<Webhook> {
+  return unwrap(await api.post<ApiResp<Webhook>>('/xyz/webhooks', {
+    name,
+    default_todo_id: defaultTodoId ?? null,
+  }));
+}
+
+export async function updateWebhook(id: number, name: string, enabled: boolean, defaultTodoId?: number): Promise<Webhook> {
+  return unwrap(await api.put<ApiResp<Webhook>>(`/xyz/webhooks/${id}`, {
+    name,
+    enabled,
+    default_todo_id: defaultTodoId ?? null,
+  }));
+}
+
+export async function deleteWebhook(id: number): Promise<void> {
+  await api.delete(`/xyz/webhooks/${id}`);
+}
+
+export async function getWebhookRecords(params?: { limit?: number; offset?: number }): Promise<WebhookRecordsPage> {
+  return unwrap(await api.get<ApiResp<WebhookRecordsPage>>('/xyz/webhook-records', { params }));
+}
+
+export async function getWebhookRecord(id: number): Promise<WebhookRecord> {
+  return unwrap(await api.get<ApiResp<WebhookRecord>>(`/xyz/webhook-records/${id}`));
+}

--- a/frontend/src/utils/database.ts
+++ b/frontend/src/utils/database.ts
@@ -908,9 +908,10 @@ export async function getWebhook(id: number): Promise<Webhook> {
   return unwrap(await api.get<ApiResp<Webhook>>(`/xyz/webhooks/${id}`));
 }
 
-export async function createWebhook(name: string, defaultTodoId?: number): Promise<Webhook> {
+export async function createWebhook(name: string, enabled: boolean, defaultTodoId?: number): Promise<Webhook> {
   return unwrap(await api.post<ApiResp<Webhook>>('/xyz/webhooks', {
     name,
+    enabled,
     default_todo_id: defaultTodoId ?? null,
   }));
 }


### PR DESCRIPTION
## Summary
- 在设置页面新增 Webhook 配置标签页
- 支持配置默认触发的 Todo
- 提供两种触发 URL：`/webhook/trigger`（触发默认 webhook）和 `/webhook/trigger/{todo_id}`（触发指定 todo）
- 支持 GET 和 POST 方法，POST 支持 JSON body
- 调用记录管理：查看历史调用详情（时间、方法、路径、状态码、请求/响应体等）

## Test plan
- [x] Playwright 自动化测试 8/8 通过
- [x] 后端 API 验证通过

## Screenshots
添加 Webhook 后，Settings 页面新增 Webhook Tab，包含：
- Webhook 配置：列表、启用/禁用、编辑、删除
- 调用记录：分页查看历史调用详情