### PR TITLE
feat: 集成 ccusage 使用统计到 Dashboard

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1314,6 +1314,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,6 +2469,7 @@ dependencies = [
  "quick_cache",
  "regex",
  "reqwest",
+ "rusqlite",
  "rust-embed",
  "sea-orm",
  "serde",
@@ -3322,6 +3335,20 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -38,6 +38,7 @@ thiserror = "2"
 log = "0.4"
 dashmap = "6"
 which = "7"
+rusqlite = { version = "0.30", features = ["bundled"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -69,6 +69,10 @@ pub struct Config {
     pub auto_skill_backup_max_files: usize,
     /// 定时任务默认时区（用于 cron 表达式转换）
     pub scheduler_default_timezone: Option<String>,
+    /// 是否开启 AI 使用统计自动归档
+    pub auto_usage_stats_enabled: bool,
+    /// AI 使用统计自动归档 cron 表达式（6 字段，含秒），默认每天凌晨 1 点执行
+    pub auto_usage_stats_cron: String,
 }
 
 /// Paths for each supported executor binary.
@@ -152,6 +156,8 @@ impl Default for Config {
             auto_skill_backup_cron: "0 0 5 * * *".to_string(),
             auto_skill_backup_max_files: 30,
             scheduler_default_timezone: None,
+            auto_usage_stats_enabled: false,
+            auto_usage_stats_cron: "0 0 1 * * *".to_string(),
         }
     }
 }

--- a/backend/src/db/entity/mod.rs
+++ b/backend/src/db/entity/mod.rs
@@ -13,6 +13,9 @@ pub mod tags;
 pub mod todo_tags;
 pub mod todo_templates;
 pub mod todos;
+pub mod usage_model_breakdown;
+pub mod usage_stats;
+pub mod usage_executor_daily;
 pub mod webhooks;
 pub mod webhook_records;
 
@@ -32,6 +35,9 @@ pub mod prelude {
     pub use super::todo_tags::Entity as TodoTags;
     pub use super::todo_templates::Entity as TodoTemplates;
     pub use super::todos::Entity as Todos;
+    pub use super::usage_model_breakdown::Entity as UsageModelBreakdowns;
+    pub use super::usage_stats::Entity as UsageStats;
+    pub use super::usage_executor_daily::Entity as UsageExecutorDaily;
     pub use super::webhooks::Entity as Webhooks;
     pub use super::webhook_records::Entity as WebhookRecords;
 }

--- a/backend/src/db/entity/usage_executor_daily.rs
+++ b/backend/src/db/entity/usage_executor_daily.rs
@@ -1,0 +1,40 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "usage_executor_daily_stats")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    /// Date in YYYY-MM-DD format
+    pub date: String,
+    /// Executor name (e.g., claudecode, opencode, etc.)
+    pub executor: String,
+    /// Input token count
+    pub input_tokens: i64,
+    /// Output token count
+    pub output_tokens: i64,
+    /// Cache creation token count
+    pub cache_creation_tokens: i64,
+    /// Cache read token count
+    pub cache_read_tokens: i64,
+    /// Extra total tokens (e.g., reasoning tokens)
+    pub extra_total_tokens: i64,
+    /// Total cost in USD
+    pub total_cost: f64,
+    /// Credits used (optional)
+    pub credits: Option<f64>,
+    /// Message count
+    pub message_count: Option<i64>,
+    /// Model used
+    pub model: Option<String>,
+    /// Execution count
+    pub execution_count: i64,
+    /// Created at
+    pub created_at: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/entity/usage_model_breakdown.rs
+++ b/backend/src/db/entity/usage_model_breakdown.rs
@@ -1,0 +1,46 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// Model breakdown stored separately for detailed per-model statistics
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "usage_model_breakdowns")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    /// Reference to usage_daily_stats id
+    pub daily_stat_id: i64,
+    /// Model name
+    pub model_name: String,
+    /// Input tokens for this model
+    pub input_tokens: i64,
+    /// Output tokens for this model
+    pub output_tokens: i64,
+    /// Cache creation tokens for this model
+    pub cache_creation_tokens: i64,
+    /// Cache read tokens for this model
+    pub cache_read_tokens: i64,
+    /// Extra total tokens for this model
+    pub extra_total_tokens: i64,
+    /// Cost for this model
+    pub cost: f64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::usage_stats::Entity",
+        from = "Column::DailyStatId",
+        to = "super::usage_stats::Column::Id",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    UsageDailyStats,
+}
+
+impl Related<super::usage_stats::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::UsageDailyStats.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/entity/usage_stats.rs
+++ b/backend/src/db/entity/usage_stats.rs
@@ -1,0 +1,48 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "usage_daily_stats")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    /// Date in YYYY-MM-DD format
+    pub date: String,
+    /// Project path (optional, from session)
+    pub project_path: Option<String>,
+    /// Session ID (optional)
+    pub session_id: Option<String>,
+    /// Input token count
+    pub input_tokens: i64,
+    /// Output token count
+    pub output_tokens: i64,
+    /// Cache creation token count
+    pub cache_creation_tokens: i64,
+    /// Cache read token count
+    pub cache_read_tokens: i64,
+    /// Extra total tokens (e.g., reasoning tokens)
+    pub extra_total_tokens: i64,
+    /// Total cost in USD
+    pub total_cost: f64,
+    /// Credits used (optional)
+    pub credits: Option<f64>,
+    /// Message count
+    pub message_count: Option<i64>,
+    /// Models used (JSON array of strings)
+    pub models_used: String,
+    /// Project name (optional)
+    pub project: Option<String>,
+    /// Versions (JSON array of strings, optional)
+    pub versions: Option<String>,
+    /// Last activity timestamp
+    pub last_activity: Option<String>,
+    /// Statistics type: daily, weekly, monthly
+    pub stats_type: String,
+    /// Created at
+    pub created_at: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -918,38 +918,38 @@ impl Database {
         last_activity: Option<&str>,
         stats_type: &str,
     ) -> Result<i64, sea_orm::DbErr> {
+        use entity::usage_stats;
+        use sea_orm::ActiveValue::Set;
+        use sea_orm::EntityTrait;
+
         let models_used_json = serde_json::to_string(models_used).unwrap_or_else(|_| "[]".to_string());
-        let versions_json = versions.map(|v| serde_json::to_string(v).ok()).flatten().unwrap_or_else(|| "null".to_string());
+        let versions_json = versions.and_then(|v| serde_json::to_string(v).ok());
 
-        let sql = format!(
-            r#"INSERT INTO usage_daily_stats
-               (date, project_path, session_id, input_tokens, output_tokens, cache_creation_tokens,
-                cache_read_tokens, extra_total_tokens, total_cost, credits, message_count,
-                models_used, project, versions, last_activity, stats_type)
-               VALUES ('{}', {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, '{}', {}, {}, '{}', '{}')"#,
-            date,
-            Self::opt_string_to_sql(project_path),
-            Self::opt_string_to_sql(session_id),
-            input_tokens,
-            output_tokens,
-            cache_creation_tokens,
-            cache_read_tokens,
-            extra_total_tokens,
-            total_cost,
-            Self::opt_f64_to_sql(credits),
-            Self::opt_i64_to_sql(message_count),
-            models_used_json,
-            Self::opt_string_to_sql(project),
-            versions_json,
-            Self::opt_string_to_sql(last_activity),
-            stats_type
-        );
+        let active_model = usage_stats::ActiveModel {
+            date: Set(date.to_string()),
+            project_path: Set(project_path.map(|s| s.to_string())),
+            session_id: Set(session_id.map(|s| s.to_string())),
+            input_tokens: Set(input_tokens),
+            output_tokens: Set(output_tokens),
+            cache_creation_tokens: Set(cache_creation_tokens),
+            cache_read_tokens: Set(cache_read_tokens),
+            extra_total_tokens: Set(extra_total_tokens),
+            total_cost: Set(total_cost),
+            credits: Set(credits),
+            message_count: Set(message_count),
+            models_used: Set(models_used_json),
+            project: Set(project.map(|s| s.to_string())),
+            versions: Set(versions_json),
+            last_activity: Set(last_activity.map(|s| s.to_string())),
+            stats_type: Set(stats_type.to_string()),
+            ..Default::default()
+        };
 
-        let result = self.conn
-            .execute(Statement::from_string(DbBackend::Sqlite, sql))
+        let result = usage_stats::Entity::insert(active_model)
+            .exec(&self.conn)
             .await?;
 
-        Ok(result.last_insert_id() as i64)
+        Ok(result.last_insert_id)
     }
 
     /// Create a model breakdown record
@@ -964,26 +964,27 @@ impl Database {
         extra_total_tokens: i64,
         cost: f64,
     ) -> Result<i64, sea_orm::DbErr> {
-        let sql = format!(
-            r#"INSERT INTO usage_model_breakdowns
-               (daily_stat_id, model_name, input_tokens, output_tokens, cache_creation_tokens,
-                cache_read_tokens, extra_total_tokens, cost)
-               VALUES ({}, '{}', {}, {}, {}, {}, {}, {})"#,
-            daily_stat_id,
-            model_name,
-            input_tokens,
-            output_tokens,
-            cache_creation_tokens,
-            cache_read_tokens,
-            extra_total_tokens,
-            cost
-        );
+        use entity::usage_model_breakdown;
+        use sea_orm::ActiveValue::Set;
+        use sea_orm::EntityTrait;
 
-        let result = self.conn
-            .execute(Statement::from_string(DbBackend::Sqlite, sql))
+        let active_model = usage_model_breakdown::ActiveModel {
+            daily_stat_id: Set(daily_stat_id),
+            model_name: Set(model_name.to_string()),
+            input_tokens: Set(input_tokens),
+            output_tokens: Set(output_tokens),
+            cache_creation_tokens: Set(cache_creation_tokens),
+            cache_read_tokens: Set(cache_read_tokens),
+            extra_total_tokens: Set(extra_total_tokens),
+            cost: Set(cost),
+            ..Default::default()
+        };
+
+        let result = usage_model_breakdown::Entity::insert(active_model)
+            .exec(&self.conn)
             .await?;
 
-        Ok(result.last_insert_id() as i64)
+        Ok(result.last_insert_id)
     }
 
     /// Get usage stats by type and date range
@@ -1038,8 +1039,6 @@ impl Database {
         since: Option<&str>,
         until: Option<&str>,
     ) -> Result<Vec<ModelBreakdownWithDate>, sea_orm::DbErr> {
-        use sea_orm::EntityTrait;
-
         // First get daily stats in date range
         let daily_stats = self.get_usage_stats(stats_type, since, until).await?;
 
@@ -1141,12 +1140,11 @@ impl Database {
         model: Option<&str>,
         execution_count: i64,
     ) -> Result<i64, sea_orm::DbErr> {
-        let sql = format!(
-            r#"INSERT INTO usage_executor_daily_stats
+        let sql = r#"INSERT INTO usage_executor_daily_stats
                (date, executor, input_tokens, output_tokens, cache_creation_tokens,
                 cache_read_tokens, extra_total_tokens, total_cost, credits, message_count,
                 model, execution_count)
-               VALUES ('{}', '{}', {}, {}, {}, {}, {}, {}, {}, {}, {}, {})
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(date, executor) DO UPDATE SET
                 input_tokens = input_tokens + excluded.input_tokens,
                 output_tokens = output_tokens + excluded.output_tokens,
@@ -1157,24 +1155,28 @@ impl Database {
                 credits = COALESCE(credits, 0) + COALESCE(excluded.credits, 0),
                 message_count = COALESCE(message_count, 0) + COALESCE(excluded.message_count, 0),
                 model = excluded.model,
-                execution_count = execution_count + excluded.execution_count"#,
-            date,
-            executor,
-            input_tokens,
-            output_tokens,
-            cache_creation_tokens,
-            cache_read_tokens,
-            extra_total_tokens,
-            total_cost,
-            Self::opt_f64_to_sql(credits),
-            Self::opt_i64_to_sql(message_count),
-            Self::opt_string_to_sql(model.as_deref()),
-            execution_count,
+                execution_count = execution_count + excluded.execution_count"#;
+
+        let stmt = Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            sql,
+            vec![
+                date.into(),
+                executor.into(),
+                input_tokens.into(),
+                output_tokens.into(),
+                cache_creation_tokens.into(),
+                cache_read_tokens.into(),
+                extra_total_tokens.into(),
+                total_cost.into(),
+                credits.into(),
+                message_count.into(),
+                model.into(),
+                execution_count.into(),
+            ],
         );
 
-        let result = self.conn
-            .execute(Statement::from_string(DbBackend::Sqlite, sql))
-            .await?;
+        let result = self.conn.execute(stmt).await?;
         Ok(result.last_insert_id() as i64)
     }
 
@@ -1215,30 +1217,6 @@ impl Database {
             .await?;
 
         Ok(())
-    }
-
-    /// Helper to convert optional string to SQL NULL or quoted string
-    fn opt_string_to_sql(s: Option<&str>) -> String {
-        match s {
-            Some(s) => format!("'{}'", s.replace("'", "''")),
-            None => "NULL".to_string(),
-        }
-    }
-
-    /// Helper to convert optional f64 to SQL NULL or value
-    fn opt_f64_to_sql(v: Option<f64>) -> String {
-        match v {
-            Some(v) => v.to_string(),
-            None => "NULL".to_string(),
-        }
-    }
-
-    /// Helper to convert optional i64 to SQL NULL or value
-    fn opt_i64_to_sql(v: Option<i64>) -> String {
-        match v {
-            Some(v) => v.to_string(),
-            None => "NULL".to_string(),
-        }
     }
 }
 

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -8,9 +8,9 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use sea_orm::{
-    ActiveModelBehavior, ActiveModelTrait, ConnectOptions, ConnectionTrait,
+    ActiveModelBehavior, ActiveModelTrait, ColumnTrait, ConnectOptions, ConnectionTrait,
     Database as SeaDatabase, DatabaseConnection, DbBackend, EntityTrait, IntoActiveModel,
-    Statement,
+    Order, QueryFilter, QueryOrder, Statement,
 };
 
 pub mod entity;
@@ -786,7 +786,399 @@ impl Database {
         )
         .await?;
 
+        // Usage daily stats table (stores aggregated usage statistics)
+        self.exec(
+            "CREATE TABLE IF NOT EXISTS usage_daily_stats (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                date TEXT NOT NULL,
+                project_path TEXT,
+                session_id TEXT,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                extra_total_tokens INTEGER NOT NULL DEFAULT 0,
+                total_cost REAL NOT NULL DEFAULT 0.0,
+                credits REAL,
+                message_count INTEGER,
+                models_used TEXT NOT NULL DEFAULT '[]',
+                project TEXT,
+                versions TEXT,
+                last_activity TEXT,
+                stats_type TEXT NOT NULL DEFAULT 'daily',
+                created_at TEXT
+            )",
+        )
+        .await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_usage_daily_stats_date ON usage_daily_stats(date)")
+            .await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_usage_daily_stats_stats_type ON usage_daily_stats(stats_type)")
+            .await?;
+
+        // Usage model breakdowns table (stores per-model breakdown for each daily stat)
+        self.exec(
+            "CREATE TABLE IF NOT EXISTS usage_model_breakdowns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                daily_stat_id INTEGER NOT NULL,
+                model_name TEXT NOT NULL,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                extra_total_tokens INTEGER NOT NULL DEFAULT 0,
+                cost REAL NOT NULL DEFAULT 0.0,
+                FOREIGN KEY (daily_stat_id) REFERENCES usage_daily_stats(id) ON DELETE CASCADE
+            )",
+        )
+        .await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_usage_model_breakdowns_daily_stat_id ON usage_model_breakdowns(daily_stat_id)")
+            .await?;
+
+        // Usage stats timestamps triggers
+        self.exec(
+            "CREATE TRIGGER IF NOT EXISTS set_usage_daily_stats_created_at_utc AFTER INSERT ON usage_daily_stats
+             WHEN new.created_at IS NULL OR new.created_at = ''
+             BEGIN
+                 UPDATE usage_daily_stats SET created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', 'utc') WHERE rowid = new.rowid;
+             END",
+        )
+        .await?;
+
+        // Usage executor daily stats table (stores per-executor daily token usage)
+        self.exec(
+            "CREATE TABLE IF NOT EXISTS usage_executor_daily_stats (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                date TEXT NOT NULL,
+                executor TEXT NOT NULL,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                extra_total_tokens INTEGER NOT NULL DEFAULT 0,
+                total_cost REAL NOT NULL DEFAULT 0.0,
+                credits REAL,
+                message_count INTEGER,
+                model TEXT,
+                execution_count INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT,
+                UNIQUE(date, executor)
+            )",
+        )
+        .await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_usage_executor_daily_stats_date ON usage_executor_daily_stats(date)")
+            .await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_usage_executor_daily_stats_executor ON usage_executor_daily_stats(executor)")
+            .await?;
+
+        // Usage executor daily stats timestamps triggers
+        self.exec(
+            "CREATE TRIGGER IF NOT EXISTS set_usage_executor_daily_stats_created_at_utc AFTER INSERT ON usage_executor_daily_stats
+             WHEN new.created_at IS NULL OR new.created_at = ''
+             BEGIN
+                 UPDATE usage_executor_daily_stats SET created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', 'utc') WHERE rowid = new.rowid;
+             END",
+        )
+        .await?;
+
         Ok(())
+    }
+
+    // ===== Usage Stats methods =====
+
+    /// Create a new usage daily stat record
+    pub async fn create_usage_daily_stat(
+        &self,
+        date: &str,
+        project_path: Option<&str>,
+        session_id: Option<&str>,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_creation_tokens: i64,
+        cache_read_tokens: i64,
+        extra_total_tokens: i64,
+        total_cost: f64,
+        credits: Option<f64>,
+        message_count: Option<i64>,
+        models_used: &[String],
+        project: Option<&str>,
+        versions: Option<&[String]>,
+        last_activity: Option<&str>,
+        stats_type: &str,
+    ) -> Result<i64, sea_orm::DbErr> {
+        let models_used_json = serde_json::to_string(models_used).unwrap_or_else(|_| "[]".to_string());
+        let versions_json = versions.map(|v| serde_json::to_string(v).ok()).flatten().unwrap_or_else(|| "null".to_string());
+
+        let sql = format!(
+            r#"INSERT INTO usage_daily_stats
+               (date, project_path, session_id, input_tokens, output_tokens, cache_creation_tokens,
+                cache_read_tokens, extra_total_tokens, total_cost, credits, message_count,
+                models_used, project, versions, last_activity, stats_type)
+               VALUES ('{}', {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, '{}', {}, {}, '{}', '{}')"#,
+            date,
+            Self::opt_string_to_sql(project_path),
+            Self::opt_string_to_sql(session_id),
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens,
+            cache_read_tokens,
+            extra_total_tokens,
+            total_cost,
+            Self::opt_f64_to_sql(credits),
+            Self::opt_i64_to_sql(message_count),
+            models_used_json,
+            Self::opt_string_to_sql(project),
+            versions_json,
+            Self::opt_string_to_sql(last_activity),
+            stats_type
+        );
+
+        let result = self.conn
+            .execute(Statement::from_string(DbBackend::Sqlite, sql))
+            .await?;
+
+        Ok(result.last_insert_id() as i64)
+    }
+
+    /// Create a model breakdown record
+    pub async fn create_usage_model_breakdown(
+        &self,
+        daily_stat_id: i64,
+        model_name: &str,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_creation_tokens: i64,
+        cache_read_tokens: i64,
+        extra_total_tokens: i64,
+        cost: f64,
+    ) -> Result<i64, sea_orm::DbErr> {
+        let sql = format!(
+            r#"INSERT INTO usage_model_breakdowns
+               (daily_stat_id, model_name, input_tokens, output_tokens, cache_creation_tokens,
+                cache_read_tokens, extra_total_tokens, cost)
+               VALUES ({}, '{}', {}, {}, {}, {}, {}, {})"#,
+            daily_stat_id,
+            model_name,
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens,
+            cache_read_tokens,
+            extra_total_tokens,
+            cost
+        );
+
+        let result = self.conn
+            .execute(Statement::from_string(DbBackend::Sqlite, sql))
+            .await?;
+
+        Ok(result.last_insert_id() as i64)
+    }
+
+    /// Get usage stats by type and date range
+    pub async fn get_usage_stats(
+        &self,
+        stats_type: &str,
+        since: Option<&str>,
+        until: Option<&str>,
+    ) -> Result<Vec<entity::usage_stats::Model>, sea_orm::DbErr> {
+        use sea_orm::{EntityTrait, QueryFilter};
+
+        let mut query = entity::usage_stats::Entity::find();
+
+        // Filter by stats_type
+        query = query.filter(entity::usage_stats::Column::StatsType.eq(stats_type));
+
+        // Filter by date range if provided
+        if let Some(since_date) = since {
+            query = query.filter(entity::usage_stats::Column::Date.gte(since_date));
+        }
+        if let Some(until_date) = until {
+            query = query.filter(entity::usage_stats::Column::Date.lte(until_date));
+        }
+
+        let results = query
+            .order_by(entity::usage_stats::Column::Date, Order::Desc)
+            .all(&self.conn)
+            .await?;
+
+        Ok(results)
+    }
+
+    /// Get model breakdowns for a specific daily stat
+    pub async fn get_usage_model_breakdowns(
+        &self,
+        daily_stat_id: i64,
+    ) -> Result<Vec<entity::usage_model_breakdown::Model>, sea_orm::DbErr> {
+        use sea_orm::EntityTrait;
+
+        let results = entity::usage_model_breakdown::Entity::find()
+            .filter(entity::usage_model_breakdown::Column::DailyStatId.eq(daily_stat_id))
+            .all(&self.conn)
+            .await?;
+
+        Ok(results)
+    }
+
+    /// Delete existing stats for a specific date and type (for re-computation)
+    pub async fn delete_usage_stats_by_date(
+        &self,
+        date: &str,
+        stats_type: &str,
+    ) -> Result<(), sea_orm::DbErr> {
+        // First delete breakdowns for the daily stats
+        let daily_stats: Vec<entity::usage_stats::Model> = entity::usage_stats::Entity::find()
+            .filter(entity::usage_stats::Column::Date.eq(date))
+            .filter(entity::usage_stats::Column::StatsType.eq(stats_type))
+            .all(&self.conn)
+            .await?;
+
+        for stat in daily_stats {
+            let sql = format!(
+                "DELETE FROM usage_model_breakdowns WHERE daily_stat_id = {}",
+                stat.id
+            );
+            self.exec(&sql).await?;
+        }
+
+        // Then delete the daily stats
+        let sql = format!(
+            "DELETE FROM usage_daily_stats WHERE date = '{}' AND stats_type = '{}'",
+            date, stats_type
+        );
+        self.exec(&sql).await?;
+
+        Ok(())
+    }
+
+    /// Get the most recent stat for a specific date and type
+    pub async fn get_latest_usage_stat(
+        &self,
+        date: &str,
+        stats_type: &str,
+    ) -> Result<Option<entity::usage_stats::Model>, sea_orm::DbErr> {
+        use sea_orm::EntityTrait;
+
+        let result = entity::usage_stats::Entity::find()
+            .filter(entity::usage_stats::Column::Date.eq(date))
+            .filter(entity::usage_stats::Column::StatsType.eq(stats_type))
+            .one(&self.conn)
+            .await?;
+
+        Ok(result)
+    }
+
+    // ===== Usage Executor Daily Stats methods =====
+
+    /// Create or update usage executor daily stat record
+    pub async fn upsert_usage_executor_daily_stat(
+        &self,
+        date: &str,
+        executor: &str,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_creation_tokens: i64,
+        cache_read_tokens: i64,
+        extra_total_tokens: i64,
+        total_cost: f64,
+        credits: Option<f64>,
+        message_count: Option<i64>,
+        model: Option<&str>,
+        execution_count: i64,
+    ) -> Result<i64, sea_orm::DbErr> {
+        let sql = format!(
+            r#"INSERT INTO usage_executor_daily_stats
+               (date, executor, input_tokens, output_tokens, cache_creation_tokens,
+                cache_read_tokens, extra_total_tokens, total_cost, credits, message_count,
+                model, execution_count)
+               VALUES ('{}', '{}', {}, {}, {}, {}, {}, {}, {}, {}, {}, {})
+               ON CONFLICT(date, executor) DO UPDATE SET
+                input_tokens = input_tokens + excluded.input_tokens,
+                output_tokens = output_tokens + excluded.output_tokens,
+                cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
+                cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
+                extra_total_tokens = extra_total_tokens + excluded.extra_total_tokens,
+                total_cost = total_cost + excluded.total_cost,
+                credits = COALESCE(credits, 0) + COALESCE(excluded.credits, 0),
+                message_count = COALESCE(message_count, 0) + COALESCE(excluded.message_count, 0),
+                model = excluded.model,
+                execution_count = execution_count + excluded.execution_count"#,
+            date,
+            executor,
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens,
+            cache_read_tokens,
+            extra_total_tokens,
+            total_cost,
+            Self::opt_f64_to_sql(credits),
+            Self::opt_i64_to_sql(message_count),
+            Self::opt_string_to_sql(model.as_deref()),
+            execution_count,
+        );
+
+        let result = self.conn
+            .execute(Statement::from_string(DbBackend::Sqlite, sql))
+            .await?;
+        Ok(result.last_insert_id() as i64)
+    }
+
+    /// Get usage executor daily stats by date range
+    pub async fn get_usage_executor_daily_stats(
+        &self,
+        since: Option<&str>,
+        until: Option<&str>,
+    ) -> Result<Vec<entity::usage_executor_daily::Model>, sea_orm::DbErr> {
+        use sea_orm::{EntityTrait, QueryFilter};
+
+        let mut query = entity::usage_executor_daily::Entity::find();
+
+        if let Some(since_date) = since {
+            query = query.filter(entity::usage_executor_daily::Column::Date.gte(since_date));
+        }
+        if let Some(until_date) = until {
+            query = query.filter(entity::usage_executor_daily::Column::Date.lte(until_date));
+        }
+
+        let results = query
+            .order_by_desc(entity::usage_executor_daily::Column::Date)
+            .order_by_asc(entity::usage_executor_daily::Column::Executor)
+            .all(&self.conn)
+            .await?;
+
+        Ok(results)
+    }
+
+    /// Delete usage executor stats for a specific date
+    pub async fn delete_usage_executor_stats_by_date(&self, date: &str) -> Result<(), sea_orm::DbErr> {
+        let sql = format!(
+            "DELETE FROM usage_executor_daily_stats WHERE date = '{}'",
+            date
+        );
+        self.exec(&sql).await?;
+        Ok(())
+    }
+
+    /// Helper to convert optional string to SQL NULL or quoted string
+    fn opt_string_to_sql(s: Option<&str>) -> String {
+        match s {
+            Some(s) => format!("'{}'", s.replace("'", "''")),
+            None => "NULL".to_string(),
+        }
+    }
+
+    /// Helper to convert optional f64 to SQL NULL or value
+    fn opt_f64_to_sql(v: Option<f64>) -> String {
+        match v {
+            Some(v) => v.to_string(),
+            None => "NULL".to_string(),
+        }
+    }
+
+    /// Helper to convert optional i64 to SQL NULL or value
+    fn opt_i64_to_sql(v: Option<i64>) -> String {
+        match v {
+            Some(v) => v.to_string(),
+            None => "NULL".to_string(),
+        }
     }
 }
 

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1083,6 +1083,8 @@ impl Database {
         date: &str,
         stats_type: &str,
     ) -> Result<(), sea_orm::DbErr> {
+        use sea_orm::Delete;
+
         // First delete breakdowns for the daily stats
         let daily_stats: Vec<entity::usage_stats::Model> = entity::usage_stats::Entity::find()
             .filter(entity::usage_stats::Column::Date.eq(date))
@@ -1091,19 +1093,15 @@ impl Database {
             .await?;
 
         for stat in daily_stats {
-            let sql = format!(
-                "DELETE FROM usage_model_breakdowns WHERE daily_stat_id = {}",
-                stat.id
-            );
-            self.exec(&sql).await?;
+            Delete::one(stat).exec(&self.conn).await?;
         }
 
-        // Then delete the daily stats
-        let sql = format!(
-            "DELETE FROM usage_daily_stats WHERE date = '{}' AND stats_type = '{}'",
-            date, stats_type
-        );
-        self.exec(&sql).await?;
+        // Delete the daily stats using filter-based deletion
+        Delete::many(entity::usage_stats::Entity)
+            .filter(entity::usage_stats::Column::Date.eq(date))
+            .filter(entity::usage_stats::Column::StatsType.eq(stats_type))
+            .exec(&self.conn)
+            .await?;
 
         Ok(())
     }
@@ -1208,11 +1206,14 @@ impl Database {
 
     /// Delete usage executor stats for a specific date
     pub async fn delete_usage_executor_stats_by_date(&self, date: &str) -> Result<(), sea_orm::DbErr> {
-        let sql = format!(
-            "DELETE FROM usage_executor_daily_stats WHERE date = '{}'",
-            date
-        );
-        self.exec(&sql).await?;
+        use sea_orm::Delete;
+
+        // Use filter-based deletion to avoid SQL injection
+        Delete::many(entity::usage_executor_daily::Entity)
+            .filter(entity::usage_executor_daily::Column::Date.eq(date))
+            .exec(&self.conn)
+            .await?;
+
         Ok(())
     }
 

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -16,6 +16,19 @@ use sea_orm::{
 pub mod entity;
 pub use entity::prelude::*;
 
+/// Model breakdown with date (for API responses)
+#[derive(Debug, Clone)]
+pub struct ModelBreakdownWithDate {
+    pub date: String,
+    pub model_name: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub extra_total_tokens: i64,
+    pub cost: f64,
+}
+
 fn compute_next_run(cron_expr: &str, timezone: Option<&str>) -> Option<String> {
     let schedule = cron::Schedule::from_str(cron_expr).ok()?;
 
@@ -1016,6 +1029,52 @@ impl Database {
             .await?;
 
         Ok(results)
+    }
+
+    /// Get model breakdowns for a date range (via join with daily_stats)
+    pub async fn get_usage_model_breakdowns_by_date_range(
+        &self,
+        stats_type: &str,
+        since: Option<&str>,
+        until: Option<&str>,
+    ) -> Result<Vec<ModelBreakdownWithDate>, sea_orm::DbErr> {
+        use sea_orm::EntityTrait;
+
+        // First get daily stats in date range
+        let daily_stats = self.get_usage_stats(stats_type, since, until).await?;
+
+        if daily_stats.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Get all stat IDs and their dates
+        let stat_ids: Vec<i64> = daily_stats.iter().map(|s| s.id).collect();
+        let stat_dates: std::collections::HashMap<i64, String> = daily_stats
+            .iter()
+            .map(|s| (s.id, s.date.clone()))
+            .collect();
+
+        // Get all breakdowns for these stats
+        let mut all_breakdowns: Vec<ModelBreakdownWithDate> = vec![];
+
+        for stat_id in stat_ids {
+            let breakdowns = self.get_usage_model_breakdowns(stat_id).await?;
+            let date = stat_dates.get(&stat_id).cloned().unwrap_or_default();
+            for bd in breakdowns {
+                all_breakdowns.push(ModelBreakdownWithDate {
+                    date: date.clone(),
+                    model_name: bd.model_name,
+                    input_tokens: bd.input_tokens,
+                    output_tokens: bd.output_tokens,
+                    cache_creation_tokens: bd.cache_creation_tokens,
+                    cache_read_tokens: bd.cache_read_tokens,
+                    extra_total_tokens: bd.extra_total_tokens,
+                    cost: bd.cost,
+                });
+            }
+        }
+
+        Ok(all_breakdowns)
     }
 
     /// Delete existing stats for a specific date and type (for re-computation)

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -15,6 +15,7 @@ use sea_orm::{ConnectionTrait, DbBackend, Statement};
 use crate::handlers::{AppError, AppState};
 use crate::models::{ApiResponse, BackupData, TagBackup, TodoBackup, utc_timestamp};
 use crate::db::Database;
+use crate::services::usage_stats::UsageStatsService;
 
 /// 数据库备份压缩级别 (0-9, 9 为最强压缩)
 const BACKUP_COMPRESSION_LEVEL: Option<i64> = Some(9);
@@ -1501,6 +1502,88 @@ pub fn start_skill_auto_backup(
     });
 
     Ok(())
+}
+
+/// 启动 AI 使用统计自动归档定时任务
+pub fn start_usage_stats_archival(
+    db: std::sync::Arc<Database>,
+    config: std::sync::Arc<tokio::sync::RwLock<crate::config::Config>>,
+) -> Result<(), String> {
+    let db_clone = db.clone();
+    tokio::spawn(async move {
+        loop {
+            let (_enabled, next_delay) = {
+                let cfg = config.read().await;
+                if !cfg.auto_usage_stats_enabled {
+                    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                    continue;
+                }
+                let schedule = cron::Schedule::from_str(&cfg.auto_usage_stats_cron)
+                    .unwrap_or_else(|_| cron::Schedule::from_str("0 0 1 * * *").unwrap());
+                let next = schedule.upcoming(chrono::Utc).next();
+                let delay = match next {
+                    Some(dt) => {
+                        let now = chrono::Utc::now();
+                        (dt - now).to_std().unwrap_or(std::time::Duration::from_secs(60))
+                    }
+                    None => std::time::Duration::from_secs(3600),
+                };
+                (cfg.auto_usage_stats_enabled, delay)
+            };
+
+            tokio::time::sleep(next_delay).await;
+
+            let enabled_now = {
+                let cfg = config.read().await;
+                cfg.auto_usage_stats_enabled
+            };
+            if !enabled_now {
+                continue;
+            }
+
+            let db = db_clone.clone();
+            let service = UsageStatsService::new(db.clone());
+
+            match archive_yesterday_stats(&service).await {
+                Ok(msg) => tracing::info!("{}", msg),
+                Err(e) => tracing::error!("Auto usage stats archival failed: {}", e),
+            }
+        }
+    });
+
+    Ok(())
+}
+
+/// 归档昨天的统计数据
+async fn archive_yesterday_stats(service: &UsageStatsService) -> Result<String, String> {
+    // Get yesterday's date
+    let yesterday = (chrono::Utc::now() - chrono::Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+
+    let entries = service.collect_all_entries().await;
+
+    if entries.is_empty() {
+        return Ok(format!("Usage stats archival: no data found for {}", yesterday));
+    }
+
+    // Filter entries for yesterday
+    let yesterday_entries: Vec<_> = entries.iter()
+        .filter(|e| e.date == yesterday)
+        .cloned()
+        .collect();
+
+    if yesterday_entries.is_empty() {
+        return Ok(format!("Usage stats archival: no usage data for {}", yesterday));
+    }
+
+    // Aggregate by day
+    let daily_stats = UsageStatsService::aggregate_by_day(&yesterday_entries);
+
+    // Save to database
+    service.save_daily_stats(&daily_stats).await?;
+
+    Ok(format!("Usage stats archival: saved {} stats for {}", daily_stats.len(), yesterday))
 }
 
 /// 执行 Skill 备份

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -1578,10 +1578,10 @@ async fn archive_yesterday_stats(service: &UsageStatsService) -> Result<String, 
     }
 
     // Aggregate by day
-    let daily_stats = UsageStatsService::aggregate_by_day(&yesterday_entries);
+    let (daily_stats, breakdowns) = UsageStatsService::aggregate_by_day(&yesterday_entries);
 
     // Save to database
-    service.save_daily_stats(&daily_stats).await?;
+    service.save_daily_stats(&daily_stats, &breakdowns).await?;
 
     Ok(format!("Usage stats archival: saved {} stats for {}", daily_stats.len(), yesterday))
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -157,6 +157,7 @@ pub mod project_directory;
 pub(crate) mod todo_template;
 pub mod custom_template;
 pub mod webhook;
+pub mod usage_stats;
 
 // WebSocket handler
 pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
@@ -463,6 +464,9 @@ pub fn create_app(
         .route("/xyz/sessions", get(session::list_sessions))
         .route("/xyz/sessions/stats", get(session::get_session_stats))
         .route("/xyz/sessions/{id}", get(session::get_session_detail).delete(session::delete_session))
+        .route("/xyz/usage-stats", get(usage_stats::get_usage_stats))
+        .route("/xyz/usage-stats/refresh", post(usage_stats::refresh_usage_stats))
+        .route("/xyz/usage-stats/settings", get(usage_stats::get_usage_stats_settings).put(usage_stats::update_usage_stats_settings))
         .merge(project_directory::routes())
         .route("/xyz/todo-templates", get(todo_template::get_templates).post(todo_template::create_template))
         .route("/xyz/todo-templates/{id}", put(todo_template::update_template).delete(todo_template::delete_template))

--- a/backend/src/handlers/usage_stats.rs
+++ b/backend/src/handlers/usage_stats.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use super::{AppError, AppState};
 use crate::models::ApiResponse;
-use crate::services::usage_stats::{UsageReport, UsageStat, UsageStatsService};
+use crate::services::usage_stats::{ModelBreakdown, UsageReport, UsageStat, UsageStatsService};
 
 #[derive(Debug, Deserialize)]
 pub struct UsageStatsQuery {
@@ -17,6 +17,7 @@ pub struct UsageStatsResponse {
     pub daily: Vec<UsageStat>,
     pub weekly: Vec<UsageStat>,
     pub monthly: Vec<UsageStat>,
+    pub breakdowns: Vec<ModelBreakdown>,
 }
 
 impl From<UsageReport> for UsageStatsResponse {
@@ -25,6 +26,7 @@ impl From<UsageReport> for UsageStatsResponse {
             daily: report.daily,
             weekly: report.weekly,
             monthly: report.monthly,
+            breakdowns: vec![],
         }
     }
 }
@@ -50,10 +52,31 @@ pub async fn get_usage_stats(
         .await
         .map_err(|e| AppError::Internal(e))?;
 
+    // Get model breakdowns from database
+    let db_breakdowns = state.db
+        .get_usage_model_breakdowns_by_date_range("daily", query.since.as_deref(), query.until.as_deref())
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let breakdowns: Vec<ModelBreakdown> = db_breakdowns
+        .into_iter()
+        .map(|bd| ModelBreakdown {
+            date: bd.date,
+            model_name: bd.model_name,
+            input_tokens: bd.input_tokens,
+            output_tokens: bd.output_tokens,
+            cache_creation_tokens: bd.cache_creation_tokens,
+            cache_read_tokens: bd.cache_read_tokens,
+            extra_total_tokens: bd.extra_total_tokens,
+            cost: bd.cost,
+        })
+        .collect();
+
     Ok(ApiResponse::ok(UsageStatsResponse {
         daily,
         weekly,
         monthly,
+        breakdowns,
     }))
 }
 

--- a/backend/src/handlers/usage_stats.rs
+++ b/backend/src/handlers/usage_stats.rs
@@ -1,0 +1,119 @@
+use axum::extract::{Query, State};
+use serde::Deserialize;
+use std::str::FromStr;
+
+use super::{AppError, AppState};
+use crate::models::ApiResponse;
+use crate::services::usage_stats::{UsageReport, UsageStat, UsageStatsService};
+
+#[derive(Debug, Deserialize)]
+pub struct UsageStatsQuery {
+    pub since: Option<String>,
+    pub until: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct UsageStatsResponse {
+    pub daily: Vec<UsageStat>,
+    pub weekly: Vec<UsageStat>,
+    pub monthly: Vec<UsageStat>,
+}
+
+impl From<UsageReport> for UsageStatsResponse {
+    fn from(report: UsageReport) -> Self {
+        Self {
+            daily: report.daily,
+            weekly: report.weekly,
+            monthly: report.monthly,
+        }
+    }
+}
+
+pub async fn get_usage_stats(
+    State(state): State<AppState>,
+    Query(query): Query<UsageStatsQuery>,
+) -> Result<ApiResponse<UsageStatsResponse>, AppError> {
+    let service = UsageStatsService::new(state.db.clone());
+
+    let daily = service
+        .get_stats("daily", query.since.as_deref(), query.until.as_deref())
+        .await
+        .map_err(|e| AppError::Internal(e))?;
+
+    let weekly = service
+        .get_stats("weekly", query.since.as_deref(), query.until.as_deref())
+        .await
+        .map_err(|e| AppError::Internal(e))?;
+
+    let monthly = service
+        .get_stats("monthly", query.since.as_deref(), query.until.as_deref())
+        .await
+        .map_err(|e| AppError::Internal(e))?;
+
+    Ok(ApiResponse::ok(UsageStatsResponse {
+        daily,
+        weekly,
+        monthly,
+    }))
+}
+
+pub async fn refresh_usage_stats(
+    State(state): State<AppState>,
+) -> Result<ApiResponse<UsageStatsResponse>, AppError> {
+    let service = UsageStatsService::new(state.db.clone());
+
+    let report = service
+        .refresh_all_stats()
+        .await
+        .map_err(|e| AppError::Internal(e))?;
+
+    Ok(ApiResponse::ok(report.into()))
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct UsageStatsSettings {
+    pub auto_usage_stats_enabled: bool,
+    pub auto_usage_stats_cron: String,
+}
+
+pub async fn get_usage_stats_settings(
+    State(state): State<AppState>,
+) -> Result<ApiResponse<UsageStatsSettings>, AppError> {
+    let cfg = state.config.read().await;
+    Ok(ApiResponse::ok(UsageStatsSettings {
+        auto_usage_stats_enabled: cfg.auto_usage_stats_enabled,
+        auto_usage_stats_cron: cfg.auto_usage_stats_cron.clone(),
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateUsageStatsSettingsRequest {
+    pub enabled: bool,
+    pub cron: String,
+}
+
+pub async fn update_usage_stats_settings(
+    State(state): State<AppState>,
+    axum::Json(req): axum::Json<UpdateUsageStatsSettingsRequest>,
+) -> Result<ApiResponse<String>, AppError> {
+    // Validate cron expression
+    if req.enabled {
+        let schedule = cron::Schedule::from_str(&req.cron)
+            .map_err(|e| AppError::BadRequest(format!("Invalid cron expression: {}", e)))?;
+        schedule.upcoming(chrono::Utc).next()
+            .ok_or_else(|| AppError::BadRequest("Cron expression has no future executions".to_string()))?;
+    }
+
+    let mut cfg = state.config.write().await;
+    cfg.auto_usage_stats_enabled = req.enabled;
+    cfg.auto_usage_stats_cron = req.cron;
+    cfg.normalize_paths();
+
+    let cfg_clone = cfg.clone();
+    tokio::task::spawn_blocking(move || cfg_clone.save())
+        .await
+        .map_err(|e| AppError::Internal(format!("Join error: {}", e)))?
+        .map_err(|e| AppError::Internal(format!("Failed to save config: {}", e)))?;
+
+    Ok(ApiResponse::ok("AI 使用统计配置已更新".to_string()))
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -423,6 +423,14 @@ async fn run_server(cli_port: Option<u16>) {
             }
         }
 
+        // 注册 AI 使用统计自动归档定时任务
+        if cfg.auto_usage_stats_enabled {
+            match handlers::backup::start_usage_stats_archival(db.clone(), config.clone()) {
+                Ok(()) => info!("Auto usage stats archival enabled, cron: {}", cfg.auto_usage_stats_cron),
+                Err(e) => tracing::warn!("Failed to start usage stats archival: {}", e),
+            }
+        }
+
         // 注册自定义模板自动同步定时任务
         if cfg.auto_sync_custom_templates_enabled {
             let db = Arc::clone(&db);

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -2,3 +2,4 @@ pub mod feishu_history_fetcher;
 pub mod feishu_listener;
 pub mod feishu_push;
 pub mod message_debounce;
+pub mod usage_stats;

--- a/backend/src/services/usage_stats.rs
+++ b/backend/src/services/usage_stats.rs
@@ -1,0 +1,814 @@
+//! Usage statistics service
+//!
+//! Reads usage data from various AI code editor databases and aggregates statistics.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use chrono::Datelike;
+use serde::{Deserialize, Serialize};
+
+use crate::db::Database;
+
+/// Represents aggregated usage statistics
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageStat {
+    pub date: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub extra_total_tokens: i64,
+    pub total_cost: f64,
+    pub credits: Option<f64>,
+    pub message_count: Option<i64>,
+    pub models_used: Vec<String>,
+    pub project: Option<String>,
+    pub last_activity: Option<String>,
+    pub stats_type: String,
+}
+
+/// Model breakdown for a specific model
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelBreakdown {
+    pub model_name: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub extra_total_tokens: i64,
+    pub cost: f64,
+}
+
+/// Complete usage report with breakdowns
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageReport {
+    pub daily: Vec<UsageStat>,
+    pub weekly: Vec<UsageStat>,
+    pub monthly: Vec<UsageStat>,
+}
+
+/// Raw usage entry parsed from an editor database
+#[derive(Debug, Clone)]
+pub struct RawUsageEntry {
+    pub timestamp: i64,
+    pub date: String,
+    pub session_id: String,
+    pub project_path: String,
+    pub model: Option<String>,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub extra_total_tokens: u64,
+    pub cost: f64,
+}
+
+/// Statistics collector
+#[derive(Default)]
+struct TokenAccumulator {
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_creation_tokens: u64,
+    cache_read_tokens: u64,
+    extra_total_tokens: u64,
+    cost: f64,
+    models: HashMap<String, ModelAccumulator>,
+}
+
+impl TokenAccumulator {
+    fn add_entry(&mut self, entry: &RawUsageEntry) {
+        self.input_tokens += entry.input_tokens;
+        self.output_tokens += entry.output_tokens;
+        self.cache_creation_tokens += entry.cache_creation_tokens;
+        self.cache_read_tokens += entry.cache_read_tokens;
+        self.extra_total_tokens += entry.extra_total_tokens;
+        self.cost += entry.cost;
+
+        if let Some(ref model) = entry.model {
+            let acc = self.models.entry(model.clone()).or_default();
+            acc.input_tokens += entry.input_tokens;
+            acc.output_tokens += entry.output_tokens;
+            acc.cache_creation_tokens += entry.cache_creation_tokens;
+            acc.cache_read_tokens += entry.cache_read_tokens;
+            acc.extra_total_tokens += entry.extra_total_tokens;
+            acc.cost += entry.cost;
+        }
+    }
+
+    fn into_usage_stat(self, date: &str, stats_type: &str) -> UsageStat {
+        let models_used: Vec<String> = self.models.keys().cloned().collect();
+        UsageStat {
+            date: date.to_string(),
+            input_tokens: self.input_tokens as i64,
+            output_tokens: self.output_tokens as i64,
+            cache_creation_tokens: self.cache_creation_tokens as i64,
+            cache_read_tokens: self.cache_read_tokens as i64,
+            extra_total_tokens: self.extra_total_tokens as i64,
+            total_cost: self.cost,
+            credits: None,
+            message_count: None,
+            models_used,
+            project: None,
+            last_activity: None,
+            stats_type: stats_type.to_string(),
+        }
+    }
+
+    fn into_model_breakdowns(self) -> Vec<ModelBreakdown> {
+        self.models
+            .into_iter()
+            .map(|(model_name, acc)| ModelBreakdown {
+                model_name,
+                input_tokens: acc.input_tokens as i64,
+                output_tokens: acc.output_tokens as i64,
+                cache_creation_tokens: acc.cache_creation_tokens as i64,
+                cache_read_tokens: acc.cache_read_tokens as i64,
+                extra_total_tokens: acc.extra_total_tokens as i64,
+                cost: acc.cost,
+            })
+            .collect()
+    }
+}
+
+#[derive(Default)]
+struct ModelAccumulator {
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_creation_tokens: u64,
+    cache_read_tokens: u64,
+    extra_total_tokens: u64,
+    cost: f64,
+}
+
+/// Usage statistics service
+pub struct UsageStatsService {
+    db: Arc<Database>,
+}
+
+impl UsageStatsService {
+    pub fn new(db: Arc<Database>) -> Self {
+        Self { db }
+    }
+
+    /// Get all known editor database paths and JSON cache files
+    fn get_editor_db_paths() -> Vec<(String, PathBuf)> {
+        let mut paths = Vec::new();
+
+        // Claude Code (claude-code) - ~/.claude/codex.db
+        if let Some(home) = dirs::home_dir() {
+            let db_path = home.join(".claude").join("codex.db");
+            if db_path.exists() {
+                paths.push(("claude-code".to_string(), db_path));
+            }
+            // Also check for stats-cache.json (alternative Claude Code data store)
+            let cache_path = home.join(".claude").join("stats-cache.json");
+            if cache_path.exists() {
+                paths.push(("claude-code-json".to_string(), cache_path));
+            }
+        }
+
+        // OpenCode (opencode) - typically ~/.opencode/db.sqlite
+        if let Some(home) = dirs::home_dir() {
+            let db_path = home.join(".opencode").join("db.sqlite");
+            if db_path.exists() {
+                paths.push(("opencode".to_string(), db_path));
+            }
+
+            // Alternative location
+            let db_path2 = home.join(".opencode").join("data.db");
+            if db_path2.exists() {
+                paths.push(("opencode".to_string(), db_path2));
+            }
+        }
+
+        // Cursor (cursor) - might be in app data
+        if let Some(data_dir) = dirs::data_dir() {
+            let db_path = data_dir.join("Cursor").join("User").join("globalStorage")
+                .join("fdb.kubernetes").join("projects").join(".sqlite");
+            if db_path.exists() {
+                paths.push(("cursor".to_string(), db_path));
+            }
+        }
+
+        // VS Code Copilot - usually in extension storage
+        if let Some(data_dir) = dirs::data_dir() {
+            let copilot_paths = [
+                data_dir.join("Code").join("CachedData").join("*"),
+                data_dir.join("VSCode").join("CachedData").join("*"),
+            ];
+            for p in &copilot_paths {
+                if p.exists() {
+                    paths.push(("copilot".to_string(), p.clone()));
+                }
+            }
+        }
+
+        // Windsurf (windsurf) - ~/.windsurf/db.sqlite
+        if let Some(home) = dirs::home_dir() {
+            let db_path = home.join(".windsurf").join("db.sqlite");
+            if db_path.exists() {
+                paths.push(("windsurf".to_string(), db_path));
+            }
+        }
+
+        // Continue.dev - ~/.continue/db.sqlite
+        if let Some(home) = dirs::home_dir() {
+            let db_path = home.join(".continue").join("db.sqlite");
+            if db_path.exists() {
+                paths.push(("continue".to_string(), db_path));
+            }
+        }
+
+        paths
+    }
+
+    /// Load and parse entries from a database or JSON cache file
+    async fn load_entries_from_db(&self, db_path: &PathBuf) -> Vec<RawUsageEntry> {
+        let mut entries = Vec::new();
+
+        // Check if it's a JSON file (stats-cache.json format)
+        if db_path.extension().map(|e| e == "json").unwrap_or(false) {
+            return self.load_entries_from_json_cache(db_path).await;
+        }
+
+        // Try to read the database using sqlite directly via rusqlite (bundled with libsqlite3-sys)
+        let conn = match rusqlite::Connection::open(db_path) {
+            Ok(conn) => conn,
+            Err(e) => {
+                tracing::debug!("Failed to open database {:?}: {}", db_path, e);
+                return entries;
+            }
+        };
+
+        // Try to query for usage data
+        // The exact schema varies by editor, so we try multiple common schemas
+
+        // Try Claude protocol format
+        let mut stmt = match conn.prepare(
+            "SELECT id, session_id, data FROM message WHERE role = 'assistant'"
+        ) {
+            Ok(stmt) => stmt,
+            Err(_) => {
+                return entries;
+            }
+        };
+
+        let rows: Vec<(String, String, String)> = stmt
+            .query_map([], |row| {
+                let id: String = row.get(0)?;
+                let session_id: String = row.get(1)?;
+                let data: String = row.get(2)?;
+                Ok((id, session_id, data))
+            })
+            .map(|rows| rows.filter_map(|r| r.ok()).collect())
+            .unwrap_or_default();
+
+        for row in rows {
+            if let Some(entry) = self.parse_claude_message(&row.0, &row.1, &row.2) {
+                entries.push(entry);
+            }
+        }
+
+        // Try OpenAI format (used by some editors)
+        if entries.is_empty() {
+            let mut stmt = match conn.prepare(
+                "SELECT created_at, model, usage, cost FROM usage WHERE created_at IS NOT NULL"
+            ) {
+                Ok(stmt) => stmt,
+                Err(_) => {
+                    return entries;
+                }
+            };
+
+            let rows: Vec<(String, String, String, f64)> = stmt
+                .query_map([], |row| {
+                    let created_at: String = row.get(0)?;
+                    let model: String = row.get(1)?;
+                    let usage: String = row.get(2)?;
+                    let cost: f64 = row.get(3).unwrap_or(0.0);
+                    Ok((created_at, model, usage, cost))
+                })
+                .map(|rows| rows.filter_map(|r| r.ok()).collect())
+                .unwrap_or_default();
+
+            for row in rows {
+                if let Some(entry) = self.parse_openai_usage(&row.0, &row.1, &row.2, row.3) {
+                    entries.push(entry);
+                }
+            }
+        }
+
+        entries.sort_by_key(|e| e.timestamp);
+        entries
+    }
+
+    /// Load entries from Claude Code's stats-cache.json
+    async fn load_entries_from_json_cache(&self, path: &PathBuf) -> Vec<RawUsageEntry> {
+        let mut entries = Vec::new();
+
+        let content = match tokio::fs::read_to_string(path).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!("Failed to read JSON cache {:?}: {}", path, e);
+                return entries;
+            }
+        };
+
+        #[derive(Deserialize)]
+        struct StatsCache {
+            #[serde(rename = "dailyModelTokens")]
+            daily_model_tokens: Option<Vec<DailyModelTokens>>,
+            #[serde(rename = "modelUsage")]
+            model_usage: Option<ModelUsage>,
+        }
+
+        #[derive(Deserialize)]
+        struct DailyModelTokens {
+            date: String,
+            #[serde(rename = "tokensByModel")]
+            tokens_by_model: std::collections::HashMap<String, i64>,
+        }
+
+        #[derive(Deserialize)]
+        struct ModelUsage {
+            #[serde(flatten)]
+            models: std::collections::HashMap<String, ModelStats>,
+        }
+
+        #[derive(Deserialize)]
+        struct ModelStats {
+            #[serde(rename = "inputTokens")]
+            input_tokens: Option<i64>,
+            #[serde(rename = "outputTokens")]
+            output_tokens: Option<i64>,
+            #[serde(rename = "cacheReadInputTokens")]
+            cache_read_input_tokens: Option<i64>,
+            #[serde(rename = "cacheCreationInputTokens")]
+            cache_creation_input_tokens: Option<i64>,
+            #[serde(rename = "costUSD")]
+            cost_usd: Option<f64>,
+        }
+
+        let cache: StatsCache = match serde_json::from_str(&content) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!("Failed to parse JSON cache: {}", e);
+                return entries;
+            }
+        };
+
+        // Create entries from daily_model_tokens (daily breakdown)
+        if let Some(daily) = cache.daily_model_tokens {
+            for day_data in daily {
+                for (model, tokens) in day_data.tokens_by_model {
+                    // Parse date to timestamp
+                    let timestamp = chrono::NaiveDate::parse_from_str(&day_data.date, "%Y-%m-%d")
+                        .map(|d| d.and_hms_opt(0, 0, 0).map(|dt| dt.and_utc()).unwrap_or_default().timestamp_millis())
+                        .unwrap_or(0);
+
+                    entries.push(RawUsageEntry {
+                        timestamp,
+                        date: day_data.date.clone(),
+                        session_id: "cached".to_string(),
+                        project_path: "unknown".to_string(),
+                        model: Some(model),
+                        input_tokens: tokens as u64,
+                        output_tokens: 0,
+                        cache_creation_tokens: 0,
+                        cache_read_tokens: 0,
+                        extra_total_tokens: 0,
+                        cost: 0.0,
+                    });
+                }
+            }
+        }
+
+        // Also create entries from model_usage (aggregate data, using "total" as date)
+        if let Some(usage) = cache.model_usage {
+            for (model, stats) in usage.models {
+                entries.push(RawUsageEntry {
+                    timestamp: 0, // Aggregate, no specific date
+                    date: "total".to_string(),
+                    session_id: "cached".to_string(),
+                    project_path: "unknown".to_string(),
+                    model: Some(model),
+                    input_tokens: stats.input_tokens.unwrap_or(0) as u64,
+                    output_tokens: stats.output_tokens.unwrap_or(0) as u64,
+                    cache_creation_tokens: stats.cache_creation_input_tokens.unwrap_or(0) as u64,
+                    cache_read_tokens: stats.cache_read_input_tokens.unwrap_or(0) as u64,
+                    extra_total_tokens: 0,
+                    cost: stats.cost_usd.unwrap_or(0.0),
+                });
+            }
+        }
+
+        entries
+    }
+
+    /// Parse a Claude protocol message
+    fn parse_claude_message(&self, id: &str, session_id: &str, data: &str) -> Option<RawUsageEntry> {
+        let json: serde_json::Value = serde_json::from_str(data).ok()?;
+
+        // Extract timestamp
+        let timestamp = json.get("created_at")
+            .and_then(|v| v.as_i64())
+            .or_else(|| json.get("timestamp").and_then(|v| v.as_i64()))?;
+
+        let date = Self::format_timestamp_date(timestamp);
+        let model = json.get("model").and_then(|v| v.as_str()).map(String::from);
+
+        // Extract usage
+        let usage_obj = json.get("usage")?;
+        let input_tokens = usage_obj.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let output_tokens = usage_obj.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let cache_creation = usage_obj.get("cache_creation_input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let cache_read = usage_obj.get("cache_read_input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+
+        // Extra tokens (reasoning, etc)
+        let reasoning = usage_obj.get("reasoning_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let extra = reasoning;
+
+        let cost = json.get("cost_usd").and_then(|v| v.as_f64()).unwrap_or(0.0);
+
+        Some(RawUsageEntry {
+            timestamp,
+            date,
+            session_id: session_id.to_string(),
+            project_path: "unknown".to_string(),
+            model,
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens: cache_creation,
+            cache_read_tokens: cache_read,
+            extra_total_tokens: extra,
+            cost,
+        })
+    }
+
+    /// Parse OpenAI-style usage
+    fn parse_openai_usage(&self, created_at: &str, model: &str, usage: &str, cost: f64) -> Option<RawUsageEntry> {
+        let usage_json: serde_json::Value = serde_json::from_str(usage).ok()?;
+
+        let timestamp = Self::parse_timestamp(created_at)?;
+        let date = Self::format_timestamp_date(timestamp);
+
+        let input_tokens = usage_json.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let output_tokens = usage_json.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let cache_creation = usage_json.get("cache_creation_input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let cache_read = usage_json.get("cache_read_input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+
+        Some(RawUsageEntry {
+            timestamp,
+            date,
+            session_id: "unknown".to_string(),
+            project_path: "unknown".to_string(),
+            model: Some(model.to_string()),
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens: cache_creation,
+            cache_read_tokens: cache_read,
+            extra_total_tokens: 0,
+            cost,
+        })
+    }
+
+    /// Parse timestamp to i64 milliseconds
+    fn parse_timestamp(s: &str) -> Option<i64> {
+        // Try ISO 8601 format
+        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+            return Some(dt.timestamp_millis());
+        }
+
+        // Try Unix timestamp
+        if let Ok(ts) = s.parse::<i64>() {
+            return Some(ts * 1000);
+        }
+
+        None
+    }
+
+    /// Format timestamp to YYYY-MM-DD
+    fn format_timestamp_date(timestamp_ms: i64) -> String {
+        let secs = timestamp_ms / 1000;
+        match chrono::DateTime::from_timestamp(secs, 0) {
+            Some(dt) => dt.format("%Y-%m-%d").to_string(),
+            None => String::new(),
+        }
+    }
+
+    /// Collect all entries from all editor databases
+    pub async fn collect_all_entries(&self) -> Vec<RawUsageEntry> {
+        let paths = Self::get_editor_db_paths();
+        let mut all_entries = Vec::new();
+
+        for (editor, path) in paths {
+            tracing::debug!("Loading entries from {} at {:?}", editor, path);
+            let entries = self.load_entries_from_db(&path).await;
+            tracing::info!("Loaded {} entries from {}", entries.len(), editor);
+            all_entries.extend(entries);
+        }
+
+        // Sort by timestamp
+        all_entries.sort_by_key(|e| e.timestamp);
+        all_entries
+    }
+
+    /// Aggregate entries by day
+    pub fn aggregate_by_day(entries: &[RawUsageEntry]) -> Vec<UsageStat> {
+        let mut daily_map: HashMap<String, TokenAccumulator> = HashMap::new();
+
+        for entry in entries {
+            let acc = daily_map.entry(entry.date.clone()).or_default();
+            acc.add_entry(entry);
+        }
+
+        daily_map
+            .into_iter()
+            .map(|(date, acc)| acc.into_usage_stat(&date, "daily"))
+            .collect()
+    }
+
+    /// Aggregate daily stats into weekly
+    fn aggregate_by_week(daily: &[UsageStat]) -> Vec<UsageStat> {
+        let mut weekly_map: HashMap<String, TokenAccumulator> = HashMap::new();
+
+        for stat in daily {
+            let week_start = Self::get_week_start(&stat.date);
+            let acc = weekly_map.entry(week_start).or_default();
+            acc.input_tokens += stat.input_tokens as u64;
+            acc.output_tokens += stat.output_tokens as u64;
+            acc.cache_creation_tokens += stat.cache_creation_tokens as u64;
+            acc.cache_read_tokens += stat.cache_read_tokens as u64;
+            acc.extra_total_tokens += stat.extra_total_tokens as u64;
+            acc.cost += stat.total_cost;
+        }
+
+        weekly_map
+            .into_iter()
+            .map(|(date, acc)| acc.into_usage_stat(&date, "weekly"))
+            .collect()
+    }
+
+    /// Aggregate daily stats into monthly
+    fn aggregate_by_month(daily: &[UsageStat]) -> Vec<UsageStat> {
+        let mut monthly_map: HashMap<String, TokenAccumulator> = HashMap::new();
+
+        for stat in daily {
+            let month = stat.date[..7].to_string(); // YYYY-MM
+            let acc = monthly_map.entry(month).or_default();
+            acc.input_tokens += stat.input_tokens as u64;
+            acc.output_tokens += stat.output_tokens as u64;
+            acc.cache_creation_tokens += stat.cache_creation_tokens as u64;
+            acc.cache_read_tokens += stat.cache_read_tokens as u64;
+            acc.extra_total_tokens += stat.extra_total_tokens as u64;
+            acc.cost += stat.total_cost;
+        }
+
+        monthly_map
+            .into_iter()
+            .map(|(date, acc)| acc.into_usage_stat(&date, "monthly"))
+            .collect()
+    }
+
+    /// Get the start of the week (Monday) for a given date
+    fn get_week_start(date: &str) -> String {
+        let dt = chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").ok();
+        if let Some(dt) = dt {
+            let days_since_monday = dt.weekday().num_days_from_monday();
+            let monday = dt - chrono::Duration::days(days_since_monday as i64);
+            monday.format("%Y-%m-%d").to_string()
+        } else {
+            date.to_string()
+        }
+    }
+
+    /// Save aggregated stats to database
+    pub async fn save_daily_stats(&self, stats: &[UsageStat]) -> Result<(), String> {
+        for stat in stats {
+            // Check if we already have this date's stats
+            let existing = self.db.get_latest_usage_stat(&stat.date, "daily").await
+                .map_err(|e| e.to_string())?;
+
+            if existing.is_some() {
+                // Delete and re-insert (update)
+                self.db.delete_usage_stats_by_date(&stat.date, "daily").await
+                    .map_err(|e| e.to_string())?;
+            }
+
+            // Insert new stats
+            let stat_id = self.db.create_usage_daily_stat(
+                &stat.date,
+                stat.project.as_deref(),
+                None,
+                stat.input_tokens,
+                stat.output_tokens,
+                stat.cache_creation_tokens,
+                stat.cache_read_tokens,
+                stat.extra_total_tokens,
+                stat.total_cost,
+                stat.credits,
+                stat.message_count,
+                &stat.models_used,
+                stat.project.as_deref(),
+                None,
+                stat.last_activity.as_deref(),
+                "daily",
+            ).await.map_err(|e| e.to_string())?;
+
+            // Insert model breakdowns
+            // We need to recalculate them from the stat
+            let mut acc = TokenAccumulator::default();
+            for model_name in &stat.models_used {
+                acc.models.insert(model_name.clone(), ModelAccumulator {
+                    input_tokens: 0, // These would need to be tracked separately
+                    output_tokens: 0,
+                    cache_creation_tokens: 0,
+                    cache_read_tokens: 0,
+                    extra_total_tokens: 0,
+                    cost: 0.0,
+                });
+            }
+            // Note: Model breakdowns would need to be stored separately during aggregation
+            // For now, we just store the daily totals
+            let _ = stat_id; // Silence unused warning
+        }
+
+        Ok(())
+    }
+
+    /// Generate and store today's real-time stats
+    pub async fn update_today_stats(&self) -> Result<UsageReport, String> {
+        let entries = self.collect_all_entries().await;
+
+        if entries.is_empty() {
+            return Ok(UsageReport {
+                daily: vec![],
+                weekly: vec![],
+                monthly: vec![],
+            });
+        }
+
+        // Get today's date
+        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+
+        // Filter entries for today
+        let today_entries: Vec<_> = entries.iter()
+            .filter(|e| e.date == today)
+            .cloned()
+            .collect();
+
+        // Aggregate today's entries
+        let daily = if today_entries.is_empty() {
+            vec![]
+        } else {
+            let mut acc = TokenAccumulator::default();
+            for entry in &today_entries {
+                acc.add_entry(entry);
+            }
+            vec![acc.into_usage_stat(&today, "daily")]
+        };
+
+        // For weekly and monthly, we need historical data
+        // For now, just use today's entries aggregated up
+        let weekly = Self::aggregate_by_week(&daily);
+        let monthly = Self::aggregate_by_month(&daily);
+
+        // Save today's stats
+        if !daily.is_empty() {
+            self.save_daily_stats(&daily).await?;
+        }
+
+        Ok(UsageReport {
+            daily,
+            weekly,
+            monthly,
+        })
+    }
+
+    /// Refresh all stats from all sources (including historical data)
+    pub async fn refresh_all_stats(&self) -> Result<UsageReport, String> {
+        let entries = self.collect_all_entries().await;
+
+        if entries.is_empty() {
+            return Ok(UsageReport {
+                daily: vec![],
+                weekly: vec![],
+                monthly: vec![],
+            });
+        }
+
+        // Filter out entries with "total" date (those are aggregates)
+        let dated_entries: Vec<_> = entries.iter()
+            .filter(|e| e.date != "total")
+            .cloned()
+            .collect();
+
+        if dated_entries.is_empty() {
+            return Ok(UsageReport {
+                daily: vec![],
+                weekly: vec![],
+                monthly: vec![],
+            });
+        }
+
+        // Aggregate all dated entries by day
+        let daily = Self::aggregate_by_day(&dated_entries);
+
+        // Save all daily stats
+        if !daily.is_empty() {
+            self.save_daily_stats(&daily).await?;
+        }
+
+        // Aggregate into weekly and monthly
+        let weekly = Self::aggregate_by_week(&daily);
+        let monthly = Self::aggregate_by_month(&daily);
+
+        Ok(UsageReport {
+            daily,
+            weekly,
+            monthly,
+        })
+    }
+
+    /// Get historical stats from database
+    pub async fn get_stats(
+        &self,
+        stats_type: &str,
+        since: Option<&str>,
+        until: Option<&str>,
+    ) -> Result<Vec<UsageStat>, String> {
+        // For weekly/monthly, compute from daily data stored in DB
+        if stats_type == "weekly" || stats_type == "monthly" {
+            // Get all daily stats in the date range
+            let daily_models = self.db.get_usage_stats("daily", since, until)
+                .await
+                .map_err(|e| e.to_string())?;
+
+            if daily_models.is_empty() {
+                return Ok(vec![]);
+            }
+
+            let daily: Vec<UsageStat> = daily_models.into_iter().map(|m| UsageStat {
+                date: m.date,
+                input_tokens: m.input_tokens,
+                output_tokens: m.output_tokens,
+                cache_creation_tokens: m.cache_creation_tokens,
+                cache_read_tokens: m.cache_read_tokens,
+                extra_total_tokens: m.extra_total_tokens,
+                total_cost: m.total_cost,
+                credits: m.credits,
+                message_count: m.message_count,
+                models_used: serde_json::from_str(&m.models_used).unwrap_or_default(),
+                project: m.project,
+                last_activity: m.last_activity,
+                stats_type: m.stats_type,
+            }).collect();
+
+            return if stats_type == "weekly" {
+                Ok(Self::aggregate_by_week(&daily))
+            } else {
+                Ok(Self::aggregate_by_month(&daily))
+            };
+        }
+
+        // For daily, query directly from database
+        let models = self.db.get_usage_stats(stats_type, since, until)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(models.into_iter().map(|m| UsageStat {
+            date: m.date,
+            input_tokens: m.input_tokens,
+            output_tokens: m.output_tokens,
+            cache_creation_tokens: m.cache_creation_tokens,
+            cache_read_tokens: m.cache_read_tokens,
+            extra_total_tokens: m.extra_total_tokens,
+            total_cost: m.total_cost,
+            credits: m.credits,
+            message_count: m.message_count,
+            models_used: serde_json::from_str(&m.models_used).unwrap_or_default(),
+            project: m.project,
+            last_activity: m.last_activity,
+            stats_type: m.stats_type,
+        }).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_week_start() {
+        // Monday 2024-01-08 should return 2024-01-08
+        assert_eq!(UsageStatsService::get_week_start("2024-01-08"), "2024-01-08");
+        // Tuesday 2024-01-09 should return 2024-01-08
+        assert_eq!(UsageStatsService::get_week_start("2024-01-09"), "2024-01-08");
+        // Sunday 2024-01-14 should return 2024-01-08
+        assert_eq!(UsageStatsService::get_week_start("2024-01-14"), "2024-01-08");
+        // Monday 2024-01-15 should return 2024-01-15
+        assert_eq!(UsageStatsService::get_week_start("2024-01-15"), "2024-01-15");
+    }
+}

--- a/backend/src/services/usage_stats.rs
+++ b/backend/src/services/usage_stats.rs
@@ -1,18 +1,20 @@
 //! Usage statistics service
 //!
-//! Reads usage data from various AI code editor databases and aggregates statistics.
+//! Reads usage data from various AI code editor JSONL session files.
+//! Follows ccusage's approach of reading raw session files directly.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use chrono::Datelike;
-use serde::{Deserialize, Serialize};
+use chrono::{Datelike, DateTime, TimeZone};
+use tokio::io::AsyncReadExt;
+use tokio::fs;
 
 use crate::db::Database;
 
 /// Represents aggregated usage statistics
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UsageStat {
     pub date: String,
     pub input_tokens: i64,
@@ -30,8 +32,9 @@ pub struct UsageStat {
 }
 
 /// Model breakdown for a specific model
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ModelBreakdown {
+    pub date: String,
     pub model_name: String,
     pub input_tokens: i64,
     pub output_tokens: i64,
@@ -42,14 +45,14 @@ pub struct ModelBreakdown {
 }
 
 /// Complete usage report with breakdowns
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UsageReport {
     pub daily: Vec<UsageStat>,
     pub weekly: Vec<UsageStat>,
     pub monthly: Vec<UsageStat>,
 }
 
-/// Raw usage entry parsed from an editor database
+/// Raw usage entry parsed from a JSONL session file
 #[derive(Debug, Clone)]
 pub struct RawUsageEntry {
     pub timestamp: i64,
@@ -97,29 +100,11 @@ impl TokenAccumulator {
         }
     }
 
-    fn into_usage_stat(self, date: &str, stats_type: &str) -> UsageStat {
-        let models_used: Vec<String> = self.models.keys().cloned().collect();
-        UsageStat {
-            date: date.to_string(),
-            input_tokens: self.input_tokens as i64,
-            output_tokens: self.output_tokens as i64,
-            cache_creation_tokens: self.cache_creation_tokens as i64,
-            cache_read_tokens: self.cache_read_tokens as i64,
-            extra_total_tokens: self.extra_total_tokens as i64,
-            total_cost: self.cost,
-            credits: None,
-            message_count: None,
-            models_used,
-            project: None,
-            last_activity: None,
-            stats_type: stats_type.to_string(),
-        }
-    }
-
     fn into_model_breakdowns(self) -> Vec<ModelBreakdown> {
         self.models
             .into_iter()
             .map(|(model_name, acc)| ModelBreakdown {
+                date: String::new(),
                 model_name,
                 input_tokens: acc.input_tokens as i64,
                 output_tokens: acc.output_tokens as i64,
@@ -152,371 +137,416 @@ impl UsageStatsService {
         Self { db }
     }
 
-    /// Get all known editor database paths and JSON cache files
-    fn get_editor_db_paths() -> Vec<(String, PathBuf)> {
-        let mut paths = Vec::new();
+    /// Collect all usage entries from all editors
+    pub(crate) async fn collect_all_entries(&self) -> Vec<RawUsageEntry> {
+        let mut all_entries = Vec::new();
 
-        // Claude Code (claude-code) - ~/.claude/codex.db
-        if let Some(home) = dirs::home_dir() {
-            let db_path = home.join(".claude").join("codex.db");
-            if db_path.exists() {
-                paths.push(("claude-code".to_string(), db_path));
-            }
-            // Also check for stats-cache.json (alternative Claude Code data store)
-            let cache_path = home.join(".claude").join("stats-cache.json");
-            if cache_path.exists() {
-                paths.push(("claude-code-json".to_string(), cache_path));
-            }
+        // Claude Code - read from JSONL session files
+        let claude_entries = self.load_claude_jsonl_entries().await;
+        all_entries.extend(claude_entries);
+
+        // Codex - read from session files
+        let codex_entries = self.load_codex_jsonl_entries().await;
+        all_entries.extend(codex_entries);
+
+        // OpenCode - read from session files
+        let opencode_entries = self.load_opencode_jsonl_entries().await;
+        all_entries.extend(opencode_entries);
+
+        // Kimi - read from wire.jsonl files
+        let kimi_entries = self.load_kimi_jsonl_entries().await;
+        all_entries.extend(kimi_entries);
+
+        all_entries.sort_by_key(|e| e.timestamp);
+        all_entries
+    }
+
+    /// Load entries from Claude Code JSONL files (~/.claude/projects/*/*.jsonl)
+    async fn load_claude_jsonl_entries(&self) -> Vec<RawUsageEntry> {
+        let mut entries = Vec::new();
+
+        let Some(home) = dirs::home_dir() else {
+            return entries;
+        };
+
+        let projects_dir = home.join(".claude").join("projects");
+        if !projects_dir.exists() {
+            return entries;
         }
 
-        // OpenCode (opencode) - typically ~/.opencode/db.sqlite
-        if let Some(home) = dirs::home_dir() {
-            let db_path = home.join(".opencode").join("db.sqlite");
-            if db_path.exists() {
-                paths.push(("opencode".to_string(), db_path));
-            }
+        self.load_claude_jsonl_from_dir(&projects_dir, &mut entries).await;
+        entries
+    }
 
-            // Alternative location
-            let db_path2 = home.join(".opencode").join("data.db");
-            if db_path2.exists() {
-                paths.push(("opencode".to_string(), db_path2));
-            }
-        }
+    async fn load_claude_jsonl_from_dir(&self, dir: &PathBuf, entries: &mut Vec<RawUsageEntry>) {
+        let mut stack = vec![dir.clone()];
 
-        // Cursor (cursor) - might be in app data
-        if let Some(data_dir) = dirs::data_dir() {
-            let db_path = data_dir.join("Cursor").join("User").join("globalStorage")
-                .join("fdb.kubernetes").join("projects").join(".sqlite");
-            if db_path.exists() {
-                paths.push(("cursor".to_string(), db_path));
-            }
-        }
-
-        // VS Code Copilot - usually in extension storage
-        if let Some(data_dir) = dirs::data_dir() {
-            let copilot_paths = [
-                data_dir.join("Code").join("CachedData").join("*"),
-                data_dir.join("VSCode").join("CachedData").join("*"),
-            ];
-            for p in &copilot_paths {
-                if p.exists() {
-                    paths.push(("copilot".to_string(), p.clone()));
+        while let Some(current_dir) = stack.pop() {
+            if let Ok(mut dir) = fs::read_dir(&current_dir).await {
+                while let Ok(Some(dir_entry)) = dir.next_entry().await {
+                    let path = dir_entry.path();
+                    if path.is_dir() {
+                        stack.push(path);
+                    } else if path.extension().map(|e| e == "jsonl").unwrap_or(false) {
+                        self.parse_claude_jsonl_file(&path, entries).await;
+                    }
                 }
             }
         }
-
-        // Windsurf (windsurf) - ~/.windsurf/db.sqlite
-        if let Some(home) = dirs::home_dir() {
-            let db_path = home.join(".windsurf").join("db.sqlite");
-            if db_path.exists() {
-                paths.push(("windsurf".to_string(), db_path));
-            }
-        }
-
-        // Continue.dev - ~/.continue/db.sqlite
-        if let Some(home) = dirs::home_dir() {
-            let db_path = home.join(".continue").join("db.sqlite");
-            if db_path.exists() {
-                paths.push(("continue".to_string(), db_path));
-            }
-        }
-
-        paths
     }
 
-    /// Load and parse entries from a database or JSON cache file
-    async fn load_entries_from_db(&self, db_path: &PathBuf) -> Vec<RawUsageEntry> {
-        let mut entries = Vec::new();
+    async fn parse_claude_jsonl_file(&self, path: &PathBuf, entries: &mut Vec<RawUsageEntry>) {
+        let projects_str = ".claude/projects/";
 
-        // Check if it's a JSON file (stats-cache.json format)
-        if db_path.extension().map(|e| e == "json").unwrap_or(false) {
-            return self.load_entries_from_json_cache(db_path).await;
+        // Extract project path from file path
+        let project_path = path.to_string_lossy()
+            .split(projects_str)
+            .nth(1)
+            .and_then(|s| s.split('/').next())
+            .map(|s| {
+                if s.starts_with('-') {
+                    s.replace('-', "/")
+                } else {
+                    s.to_string()
+                }
+            })
+            .unwrap_or_else(|| "unknown".to_string());
+
+        // Extract session ID from filename
+        let session_id = path.file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let mut file = match fs::File::open(path).await {
+            Ok(f) => f,
+            Err(_) => return,
+        };
+
+        let mut contents = String::new();
+        if file.read_to_string(&mut contents).await.is_err() {
+            return;
         }
 
-        // Try to read the database using sqlite directly via rusqlite (bundled with libsqlite3-sys)
-        let conn = match rusqlite::Connection::open(db_path) {
-            Ok(conn) => conn,
-            Err(e) => {
-                tracing::debug!("Failed to open database {:?}: {}", db_path, e);
-                return entries;
-            }
-        };
-
-        // Try to query for usage data
-        // The exact schema varies by editor, so we try multiple common schemas
-
-        // Try Claude protocol format
-        let mut stmt = match conn.prepare(
-            "SELECT id, session_id, data FROM message WHERE role = 'assistant'"
-        ) {
-            Ok(stmt) => stmt,
-            Err(_) => {
-                return entries;
-            }
-        };
-
-        let rows: Vec<(String, String, String)> = stmt
-            .query_map([], |row| {
-                let id: String = row.get(0)?;
-                let session_id: String = row.get(1)?;
-                let data: String = row.get(2)?;
-                Ok((id, session_id, data))
-            })
-            .map(|rows| rows.filter_map(|r| r.ok()).collect())
-            .unwrap_or_default();
-
-        for row in rows {
-            if let Some(entry) = self.parse_claude_message(&row.0, &row.1, &row.2) {
+        for line in contents.lines() {
+            if let Some(entry) = self.parse_claude_jsonl_line(line, &session_id, &project_path) {
                 entries.push(entry);
             }
         }
-
-        // Try OpenAI format (used by some editors)
-        if entries.is_empty() {
-            let mut stmt = match conn.prepare(
-                "SELECT created_at, model, usage, cost FROM usage WHERE created_at IS NOT NULL"
-            ) {
-                Ok(stmt) => stmt,
-                Err(_) => {
-                    return entries;
-                }
-            };
-
-            let rows: Vec<(String, String, String, f64)> = stmt
-                .query_map([], |row| {
-                    let created_at: String = row.get(0)?;
-                    let model: String = row.get(1)?;
-                    let usage: String = row.get(2)?;
-                    let cost: f64 = row.get(3).unwrap_or(0.0);
-                    Ok((created_at, model, usage, cost))
-                })
-                .map(|rows| rows.filter_map(|r| r.ok()).collect())
-                .unwrap_or_default();
-
-            for row in rows {
-                if let Some(entry) = self.parse_openai_usage(&row.0, &row.1, &row.2, row.3) {
-                    entries.push(entry);
-                }
-            }
-        }
-
-        entries.sort_by_key(|e| e.timestamp);
-        entries
     }
 
-    /// Load entries from Claude Code's stats-cache.json
-    async fn load_entries_from_json_cache(&self, path: &PathBuf) -> Vec<RawUsageEntry> {
-        let mut entries = Vec::new();
+    fn parse_claude_jsonl_line(&self, line: &str, session_id: &str, project_path: &str) -> Option<RawUsageEntry> {
+        let json: serde_json::Value = serde_json::from_str(line).ok()?;
 
-        let content = match tokio::fs::read_to_string(path).await {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::debug!("Failed to read JSON cache {:?}: {}", path, e);
-                return entries;
-            }
-        };
-
-        #[derive(Deserialize)]
-        struct StatsCache {
-            #[serde(rename = "dailyModelTokens")]
-            daily_model_tokens: Option<Vec<DailyModelTokens>>,
-            #[serde(rename = "modelUsage")]
-            model_usage: Option<ModelUsage>,
+        // Only process assistant messages with usage data
+        let msg_type = json.get("type")?.as_str()?;
+        if msg_type != "assistant" {
+            return None;
         }
 
-        #[derive(Deserialize)]
-        struct DailyModelTokens {
-            date: String,
-            #[serde(rename = "tokensByModel")]
-            tokens_by_model: std::collections::HashMap<String, i64>,
-        }
+        let message = json.get("message")?;
+        let usage = message.get("usage")?;
 
-        #[derive(Deserialize)]
-        struct ModelUsage {
-            #[serde(flatten)]
-            models: std::collections::HashMap<String, ModelStats>,
-        }
+        let timestamp_str = json.get("timestamp")?.as_str()?;
+        let timestamp = DateTime::parse_from_rfc3339(timestamp_str)
+            .ok()?
+            .timestamp_millis();
 
-        #[derive(Deserialize)]
-        struct ModelStats {
-            #[serde(rename = "inputTokens")]
-            input_tokens: Option<i64>,
-            #[serde(rename = "outputTokens")]
-            output_tokens: Option<i64>,
-            #[serde(rename = "cacheReadInputTokens")]
-            cache_read_input_tokens: Option<i64>,
-            #[serde(rename = "cacheCreationInputTokens")]
-            cache_creation_input_tokens: Option<i64>,
-            #[serde(rename = "costUSD")]
-            cost_usd: Option<f64>,
-        }
+        let date = chrono::Utc.timestamp_millis_opt(timestamp)
+            .single()?
+            .format("%Y-%m-%d")
+            .to_string();
 
-        let cache: StatsCache = match serde_json::from_str(&content) {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::debug!("Failed to parse JSON cache: {}", e);
-                return entries;
-            }
-        };
+        let model = message.get("model")
+            .and_then(|m| m.as_str())
+            .filter(|s| !s.starts_with("<synthetic>"))
+            .map(|s| s.to_string());
 
-        // Create entries from daily_model_tokens (daily breakdown)
-        if let Some(daily) = cache.daily_model_tokens {
-            for day_data in daily {
-                for (model, tokens) in day_data.tokens_by_model {
-                    // Parse date to timestamp
-                    let timestamp = chrono::NaiveDate::parse_from_str(&day_data.date, "%Y-%m-%d")
-                        .map(|d| d.and_hms_opt(0, 0, 0).map(|dt| dt.and_utc()).unwrap_or_default().timestamp_millis())
-                        .unwrap_or(0);
-
-                    entries.push(RawUsageEntry {
-                        timestamp,
-                        date: day_data.date.clone(),
-                        session_id: "cached".to_string(),
-                        project_path: "unknown".to_string(),
-                        model: Some(model),
-                        input_tokens: tokens as u64,
-                        output_tokens: 0,
-                        cache_creation_tokens: 0,
-                        cache_read_tokens: 0,
-                        extra_total_tokens: 0,
-                        cost: 0.0,
-                    });
-                }
-            }
-        }
-
-        // Also create entries from model_usage (aggregate data, using "total" as date)
-        if let Some(usage) = cache.model_usage {
-            for (model, stats) in usage.models {
-                entries.push(RawUsageEntry {
-                    timestamp: 0, // Aggregate, no specific date
-                    date: "total".to_string(),
-                    session_id: "cached".to_string(),
-                    project_path: "unknown".to_string(),
-                    model: Some(model),
-                    input_tokens: stats.input_tokens.unwrap_or(0) as u64,
-                    output_tokens: stats.output_tokens.unwrap_or(0) as u64,
-                    cache_creation_tokens: stats.cache_creation_input_tokens.unwrap_or(0) as u64,
-                    cache_read_tokens: stats.cache_read_input_tokens.unwrap_or(0) as u64,
-                    extra_total_tokens: 0,
-                    cost: stats.cost_usd.unwrap_or(0.0),
-                });
-            }
-        }
-
-        entries
-    }
-
-    /// Parse a Claude protocol message
-    fn parse_claude_message(&self, id: &str, session_id: &str, data: &str) -> Option<RawUsageEntry> {
-        let json: serde_json::Value = serde_json::from_str(data).ok()?;
-
-        // Extract timestamp
-        let timestamp = json.get("created_at")
+        let input_tokens = usage.get("input_tokens")?.as_i64()? as u64;
+        let output_tokens = usage.get("output_tokens")?.as_i64()? as u64;
+        let cache_creation_tokens = usage.get("cache_creation_input_tokens")
             .and_then(|v| v.as_i64())
-            .or_else(|| json.get("timestamp").and_then(|v| v.as_i64()))?;
-
-        let date = Self::format_timestamp_date(timestamp);
-        let model = json.get("model").and_then(|v| v.as_str()).map(String::from);
-
-        // Extract usage
-        let usage_obj = json.get("usage")?;
-        let input_tokens = usage_obj.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
-        let output_tokens = usage_obj.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
-        let cache_creation = usage_obj.get("cache_creation_input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
-        let cache_read = usage_obj.get("cache_read_input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
-
-        // Extra tokens (reasoning, etc)
-        let reasoning = usage_obj.get("reasoning_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
-        let extra = reasoning;
-
-        let cost = json.get("cost_usd").and_then(|v| v.as_f64()).unwrap_or(0.0);
+            .unwrap_or(0) as u64;
+        let cache_read_tokens = usage.get("cache_read_input_tokens")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as u64;
 
         Some(RawUsageEntry {
             timestamp,
             date,
             session_id: session_id.to_string(),
-            project_path: "unknown".to_string(),
+            project_path: project_path.to_string(),
             model,
             input_tokens,
             output_tokens,
-            cache_creation_tokens: cache_creation,
-            cache_read_tokens: cache_read,
-            extra_total_tokens: extra,
-            cost,
+            cache_creation_tokens,
+            cache_read_tokens,
+            extra_total_tokens: 0,
+            cost: 0.0,
         })
     }
 
-    /// Parse OpenAI-style usage
-    fn parse_openai_usage(&self, created_at: &str, model: &str, usage: &str, cost: f64) -> Option<RawUsageEntry> {
-        let usage_json: serde_json::Value = serde_json::from_str(usage).ok()?;
+    /// Load entries from Codex session files (~/.codex/sessions/*.jsonl)
+    async fn load_codex_jsonl_entries(&self) -> Vec<RawUsageEntry> {
+        let mut entries = Vec::new();
 
-        let timestamp = Self::parse_timestamp(created_at)?;
-        let date = Self::format_timestamp_date(timestamp);
+        let Some(home) = dirs::home_dir() else {
+            return entries;
+        };
 
-        let input_tokens = usage_json.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
-        let output_tokens = usage_json.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
-        let cache_creation = usage_json.get("cache_creation_input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
-        let cache_read = usage_json.get("cache_read_input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let sessions_dir = home.join(".codex").join("sessions");
+        if !sessions_dir.exists() {
+            return entries;
+        }
+
+        self.load_jsonl_files_from_dir(&sessions_dir, "codex", &mut entries).await;
+        entries
+    }
+
+    /// Load entries from OpenCode session files
+    async fn load_opencode_jsonl_entries(&self) -> Vec<RawUsageEntry> {
+        let mut entries = Vec::new();
+
+        let Some(home) = dirs::home_dir() else {
+            return entries;
+        };
+
+        // Try ~/.local/share/opencode first
+        let opencode_dir = home.join(".local").join("share").join("opencode");
+        if opencode_dir.exists() {
+            self.load_jsonl_files_from_dir(&opencode_dir, "opencode", &mut entries).await;
+        }
+
+        // Also try ~/.opencode
+        let opencode_dir2 = home.join(".opencode");
+        if opencode_dir2.exists() {
+            self.load_jsonl_files_from_dir(&opencode_dir2, "opencode", &mut entries).await;
+        }
+
+        entries
+    }
+
+    /// Load entries from Kimi wire.jsonl files (~/.kimi/sessions/*/wire.jsonl)
+    async fn load_kimi_jsonl_entries(&self) -> Vec<RawUsageEntry> {
+        let mut entries = Vec::new();
+
+        let Some(home) = dirs::home_dir() else {
+            return entries;
+        };
+
+        let kimi_dir = home.join(".kimi").join("sessions");
+        if !kimi_dir.exists() {
+            return entries;
+        }
+
+        self.load_kimi_wire_files(&kimi_dir, &mut entries).await;
+        entries
+    }
+
+    async fn load_kimi_wire_files(&self, dir: &PathBuf, entries: &mut Vec<RawUsageEntry>) {
+        let mut stack = vec![dir.clone()];
+
+        while let Some(current_dir) = stack.pop() {
+            if let Ok(mut dir) = fs::read_dir(&current_dir).await {
+                while let Ok(Some(dir_entry)) = dir.next_entry().await {
+                    let path = dir_entry.path();
+                    if path.is_dir() {
+                        stack.push(path);
+                    } else if path.file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|n| n == "wire.jsonl")
+                        .unwrap_or(false)
+                    {
+                        self.parse_kimi_wire_file(&path, entries).await;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn parse_kimi_wire_file(&self, path: &PathBuf, entries: &mut Vec<RawUsageEntry>) {
+        let session_id = path.parent()
+            .and_then(|p| p.file_name())
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let project_path = path.parent()
+            .and_then(|p| p.parent())
+            .and_then(|p| p.file_name())
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let mut file = match fs::File::open(path).await {
+            Ok(f) => f,
+            Err(_) => return,
+        };
+
+        let mut contents = String::new();
+        if file.read_to_string(&mut contents).await.is_err() {
+            return;
+        }
+
+        for line in contents.lines() {
+            if let Some(entry) = self.parse_kimi_wire_line(line, &session_id, &project_path) {
+                entries.push(entry);
+            }
+        }
+    }
+
+    fn parse_kimi_wire_line(&self, line: &str, session_id: &str, project_path: &str) -> Option<RawUsageEntry> {
+        let json: serde_json::Value = serde_json::from_str(line).ok()?;
+
+        let timestamp = json.get("timestamp")
+            .and_then(|v| v.as_str())
+            .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.timestamp_millis())
+            .unwrap_or(0);
+
+        let date = chrono::Utc.timestamp_millis_opt(timestamp)
+            .single()?
+            .format("%Y-%m-%d")
+            .to_string();
+
+        // Try to find usage data - format varies by editor
+        let usage = json.get("usage")
+            .or_else(|| json.get("data").and_then(|d| d.get("usage")))?;
+
+        let input_tokens = usage.get("input_tokens")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as u64;
+        let output_tokens = usage.get("output_tokens")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as u64;
+
+        let model = json.get("model")
+            .or_else(|| json.get("data").and_then(|d| d.get("model")))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
 
         Some(RawUsageEntry {
             timestamp,
             date,
-            session_id: "unknown".to_string(),
-            project_path: "unknown".to_string(),
-            model: Some(model.to_string()),
+            session_id: session_id.to_string(),
+            project_path: project_path.to_string(),
+            model,
             input_tokens,
             output_tokens,
-            cache_creation_tokens: cache_creation,
-            cache_read_tokens: cache_read,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
             extra_total_tokens: 0,
-            cost,
+            cost: 0.0,
         })
     }
 
-    /// Parse timestamp to i64 milliseconds
-    fn parse_timestamp(s: &str) -> Option<i64> {
-        // Try ISO 8601 format
-        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
-            return Some(dt.timestamp_millis());
-        }
+    async fn load_jsonl_files_from_dir(&self, dir: &PathBuf, _editor_name: &str, entries: &mut Vec<RawUsageEntry>) {
+        let mut stack = vec![dir.clone()];
 
-        // Try Unix timestamp
-        if let Ok(ts) = s.parse::<i64>() {
-            return Some(ts * 1000);
-        }
-
-        None
-    }
-
-    /// Format timestamp to YYYY-MM-DD
-    fn format_timestamp_date(timestamp_ms: i64) -> String {
-        let secs = timestamp_ms / 1000;
-        match chrono::DateTime::from_timestamp(secs, 0) {
-            Some(dt) => dt.format("%Y-%m-%d").to_string(),
-            None => String::new(),
+        while let Some(current_dir) = stack.pop() {
+            if let Ok(mut dir) = fs::read_dir(&current_dir).await {
+                while let Ok(Some(dir_entry)) = dir.next_entry().await {
+                    let path = dir_entry.path();
+                    if path.is_dir() {
+                        stack.push(path);
+                    } else if path.extension().map(|e| e == "jsonl").unwrap_or(false) {
+                        self.parse_generic_jsonl_file(&path, entries).await;
+                    }
+                }
+            }
         }
     }
 
-    /// Collect all entries from all editor databases
-    pub async fn collect_all_entries(&self) -> Vec<RawUsageEntry> {
-        let paths = Self::get_editor_db_paths();
-        let mut all_entries = Vec::new();
+    async fn parse_generic_jsonl_file(&self, path: &PathBuf, entries: &mut Vec<RawUsageEntry>) {
+        let session_id = path.file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
 
-        for (editor, path) in paths {
-            tracing::debug!("Loading entries from {} at {:?}", editor, path);
-            let entries = self.load_entries_from_db(&path).await;
-            tracing::info!("Loaded {} entries from {}", entries.len(), editor);
-            all_entries.extend(entries);
+        let project_path = path.parent()
+            .and_then(|p| p.file_name())
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let mut file = match fs::File::open(path).await {
+            Ok(f) => f,
+            Err(_) => return,
+        };
+
+        let mut contents = String::new();
+        if file.read_to_string(&mut contents).await.is_err() {
+            return;
         }
 
-        // Sort by timestamp
-        all_entries.sort_by_key(|e| e.timestamp);
-        all_entries
+        for line in contents.lines() {
+            if let Some(entry) = self.parse_generic_jsonl_line(line, &session_id, &project_path) {
+                entries.push(entry);
+            }
+        }
     }
 
-    /// Aggregate entries by day
-    pub fn aggregate_by_day(entries: &[RawUsageEntry]) -> Vec<UsageStat> {
+    fn parse_generic_jsonl_line(&self, line: &str, session_id: &str, project_path: &str) -> Option<RawUsageEntry> {
+        let json: serde_json::Value = serde_json::from_str(line).ok()?;
+
+        // Look for usage data - format varies by editor
+        let usage = json.get("usage")
+            .or_else(|| json.get("data").and_then(|d| d.get("usage")))?;
+
+        // Get timestamp
+        let timestamp = json.get("timestamp")
+            .and_then(|v| v.as_str())
+            .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.timestamp_millis())
+            .or_else(|| {
+                json.get("created_at")
+                    .and_then(|v| v.as_str())
+                    .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                    .map(|dt| dt.timestamp_millis())
+            })
+            .unwrap_or(0);
+
+        let date = chrono::Utc.timestamp_millis_opt(timestamp)
+            .single()?
+            .format("%Y-%m-%d")
+            .to_string();
+
+        let model = json.get("model")
+            .or_else(|| json.get("data").and_then(|d| d.get("model")))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let input_tokens = usage.get("input_tokens")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as u64;
+        let output_tokens = usage.get("output_tokens")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as u64;
+        let cache_read_tokens = usage.get("cache_read_input_tokens")
+            .or_else(|| usage.get("cached_input_tokens"))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as u64;
+        let cache_creation_tokens = usage.get("cache_creation_input_tokens")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as u64;
+
+        Some(RawUsageEntry {
+            timestamp,
+            date,
+            session_id: session_id.to_string(),
+            project_path: project_path.to_string(),
+            model,
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens,
+            cache_read_tokens,
+            extra_total_tokens: 0,
+            cost: 0.0,
+        })
+    }
+
+    /// Aggregate entries by day, returning both stats and per-model breakdowns
+    pub(crate) fn aggregate_by_day(entries: &[RawUsageEntry]) -> (Vec<UsageStat>, Vec<ModelBreakdown>) {
         let mut daily_map: HashMap<String, TokenAccumulator> = HashMap::new();
 
         for entry in entries {
@@ -524,10 +554,40 @@ impl UsageStatsService {
             acc.add_entry(entry);
         }
 
-        daily_map
-            .into_iter()
-            .map(|(date, acc)| acc.into_usage_stat(&date, "daily"))
-            .collect()
+        let mut stats = Vec::new();
+        let mut all_breakdowns = Vec::new();
+
+        for (date, acc) in daily_map {
+            let models_used: Vec<String> = acc.models.keys().cloned().collect();
+            let input_tokens = acc.input_tokens as i64;
+            let output_tokens = acc.output_tokens as i64;
+            let cache_creation_tokens = acc.cache_creation_tokens as i64;
+            let cache_read_tokens = acc.cache_read_tokens as i64;
+            let extra_total_tokens = acc.extra_total_tokens as i64;
+            let total_cost = acc.cost;
+            let breakdowns = acc.into_model_breakdowns();
+            for mut bd in breakdowns {
+                bd.date = date.clone();
+                all_breakdowns.push(bd);
+            }
+            stats.push(UsageStat {
+                date: date.clone(),
+                input_tokens,
+                output_tokens,
+                cache_creation_tokens,
+                cache_read_tokens,
+                extra_total_tokens,
+                total_cost,
+                credits: None,
+                message_count: None,
+                models_used,
+                project: None,
+                last_activity: None,
+                stats_type: "daily".to_string(),
+            });
+        }
+
+        (stats, all_breakdowns)
     }
 
     /// Aggregate daily stats into weekly
@@ -547,7 +607,24 @@ impl UsageStatsService {
 
         weekly_map
             .into_iter()
-            .map(|(date, acc)| acc.into_usage_stat(&date, "weekly"))
+            .map(|(date, acc)| {
+                let models_used: Vec<String> = acc.models.keys().cloned().collect();
+                UsageStat {
+                    date,
+                    input_tokens: acc.input_tokens as i64,
+                    output_tokens: acc.output_tokens as i64,
+                    cache_creation_tokens: acc.cache_creation_tokens as i64,
+                    cache_read_tokens: acc.cache_read_tokens as i64,
+                    extra_total_tokens: acc.extra_total_tokens as i64,
+                    total_cost: acc.cost,
+                    credits: None,
+                    message_count: None,
+                    models_used,
+                    project: None,
+                    last_activity: None,
+                    stats_type: "weekly".to_string(),
+                }
+            })
             .collect()
     }
 
@@ -556,7 +633,7 @@ impl UsageStatsService {
         let mut monthly_map: HashMap<String, TokenAccumulator> = HashMap::new();
 
         for stat in daily {
-            let month = stat.date[..7].to_string(); // YYYY-MM
+            let month = stat.date[..7].to_string();
             let acc = monthly_map.entry(month).or_default();
             acc.input_tokens += stat.input_tokens as u64;
             acc.output_tokens += stat.output_tokens as u64;
@@ -568,16 +645,32 @@ impl UsageStatsService {
 
         monthly_map
             .into_iter()
-            .map(|(date, acc)| acc.into_usage_stat(&date, "monthly"))
+            .map(|(date, acc)| {
+                let models_used: Vec<String> = acc.models.keys().cloned().collect();
+                UsageStat {
+                    date,
+                    input_tokens: acc.input_tokens as i64,
+                    output_tokens: acc.output_tokens as i64,
+                    cache_creation_tokens: acc.cache_creation_tokens as i64,
+                    cache_read_tokens: acc.cache_read_tokens as i64,
+                    extra_total_tokens: acc.extra_total_tokens as i64,
+                    total_cost: acc.cost,
+                    credits: None,
+                    message_count: None,
+                    models_used,
+                    project: None,
+                    last_activity: None,
+                    stats_type: "monthly".to_string(),
+                }
+            })
             .collect()
     }
 
-    /// Get the start of the week (Monday) for a given date
     fn get_week_start(date: &str) -> String {
-        let dt = chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").ok();
-        if let Some(dt) = dt {
-            let days_since_monday = dt.weekday().num_days_from_monday();
-            let monday = dt - chrono::Duration::days(days_since_monday as i64);
+        if let Ok(naive_date) = chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d") {
+            let weekday = naive_date.weekday();
+            let days_since_monday = weekday.num_days_from_monday();
+            let monday = naive_date - chrono::Duration::days(days_since_monday as i64);
             monday.format("%Y-%m-%d").to_string()
         } else {
             date.to_string()
@@ -585,7 +678,7 @@ impl UsageStatsService {
     }
 
     /// Save aggregated stats to database
-    pub async fn save_daily_stats(&self, stats: &[UsageStat]) -> Result<(), String> {
+    pub async fn save_daily_stats(&self, stats: &[UsageStat], breakdowns: &[ModelBreakdown]) -> Result<(), String> {
         for stat in stats {
             // Check if we already have this date's stats
             let existing = self.db.get_latest_usage_stat(&stat.date, "daily").await
@@ -617,22 +710,19 @@ impl UsageStatsService {
                 "daily",
             ).await.map_err(|e| e.to_string())?;
 
-            // Insert model breakdowns
-            // We need to recalculate them from the stat
-            let mut acc = TokenAccumulator::default();
-            for model_name in &stat.models_used {
-                acc.models.insert(model_name.clone(), ModelAccumulator {
-                    input_tokens: 0, // These would need to be tracked separately
-                    output_tokens: 0,
-                    cache_creation_tokens: 0,
-                    cache_read_tokens: 0,
-                    extra_total_tokens: 0,
-                    cost: 0.0,
-                });
+            // Insert model breakdowns for this date
+            for bd in breakdowns.iter().filter(|b| b.date == stat.date) {
+                self.db.create_usage_model_breakdown(
+                    stat_id,
+                    &bd.model_name,
+                    bd.input_tokens,
+                    bd.output_tokens,
+                    bd.cache_creation_tokens,
+                    bd.cache_read_tokens,
+                    bd.extra_total_tokens,
+                    bd.cost,
+                ).await.map_err(|e| e.to_string())?;
             }
-            // Note: Model breakdowns would need to be stored separately during aggregation
-            // For now, we just store the daily totals
-            let _ = stat_id; // Silence unused warning
         }
 
         Ok(())
@@ -660,25 +750,66 @@ impl UsageStatsService {
             .collect();
 
         // Aggregate today's entries
-        let daily = if today_entries.is_empty() {
-            vec![]
+        let (daily, breakdowns) = if today_entries.is_empty() {
+            (vec![], vec![])
         } else {
             let mut acc = TokenAccumulator::default();
             for entry in &today_entries {
                 acc.add_entry(entry);
             }
-            vec![acc.into_usage_stat(&today, "daily")]
+            let models_used: Vec<String> = acc.models.keys().cloned().collect();
+            let input_tokens = acc.input_tokens as i64;
+            let output_tokens = acc.output_tokens as i64;
+            let cache_creation_tokens = acc.cache_creation_tokens as i64;
+            let cache_read_tokens = acc.cache_read_tokens as i64;
+            let extra_total_tokens = acc.extra_total_tokens as i64;
+            let total_cost = acc.cost;
+            let mut bds = acc.into_model_breakdowns();
+            for bd in &mut bds {
+                bd.date = today.clone();
+            }
+            let stats = vec![UsageStat {
+                date: today.clone(),
+                input_tokens,
+                output_tokens,
+                cache_creation_tokens,
+                cache_read_tokens,
+                extra_total_tokens,
+                total_cost,
+                credits: None,
+                message_count: None,
+                models_used,
+                project: None,
+                last_activity: None,
+                stats_type: "daily".to_string(),
+            }];
+            (stats, bds)
         };
-
-        // For weekly and monthly, we need historical data
-        // For now, just use today's entries aggregated up
-        let weekly = Self::aggregate_by_week(&daily);
-        let monthly = Self::aggregate_by_month(&daily);
 
         // Save today's stats
         if !daily.is_empty() {
-            self.save_daily_stats(&daily).await?;
+            self.save_daily_stats(&daily, &breakdowns).await?;
         }
+
+        Ok(UsageReport {
+            daily,
+            weekly: vec![],
+            monthly: vec![],
+        })
+    }
+
+    /// Refresh all usage statistics
+    pub async fn refresh_all_stats(&self) -> Result<UsageReport, String> {
+        // First, archive yesterday's stats
+        self.archive_yesterday_stats().await?;
+
+        // Then update today's stats
+        self.update_today_stats().await?;
+
+        // Return all stats from database
+        let daily = self.get_stats("daily", None, None).await?;
+        let weekly = self.get_stats("weekly", None, None).await?;
+        let monthly = self.get_stats("monthly", None, None).await?;
 
         Ok(UsageReport {
             daily,
@@ -687,49 +818,36 @@ impl UsageStatsService {
         })
     }
 
-    /// Refresh all stats from all sources (including historical data)
-    pub async fn refresh_all_stats(&self) -> Result<UsageReport, String> {
+    /// Archive yesterday's usage stats
+    pub async fn archive_yesterday_stats(&self) -> Result<(), String> {
         let entries = self.collect_all_entries().await;
 
         if entries.is_empty() {
-            return Ok(UsageReport {
-                daily: vec![],
-                weekly: vec![],
-                monthly: vec![],
-            });
+            return Ok(());
         }
 
-        // Filter out entries with "total" date (those are aggregates)
-        let dated_entries: Vec<_> = entries.iter()
-            .filter(|e| e.date != "total")
+        // Get yesterday's date
+        let yesterday = (chrono::Local::now() - chrono::Duration::days(1))
+            .format("%Y-%m-%d")
+            .to_string();
+
+        // Filter entries for yesterday
+        let yesterday_entries: Vec<_> = entries.iter()
+            .filter(|e| e.date == yesterday)
             .cloned()
             .collect();
 
-        if dated_entries.is_empty() {
-            return Ok(UsageReport {
-                daily: vec![],
-                weekly: vec![],
-                monthly: vec![],
-            });
+        if yesterday_entries.is_empty() {
+            return Ok(());
         }
 
-        // Aggregate all dated entries by day
-        let daily = Self::aggregate_by_day(&dated_entries);
+        // Aggregate by day
+        let (daily_stats, breakdowns) = Self::aggregate_by_day(&yesterday_entries);
 
-        // Save all daily stats
-        if !daily.is_empty() {
-            self.save_daily_stats(&daily).await?;
-        }
+        // Save to database
+        self.save_daily_stats(&daily_stats, &breakdowns).await?;
 
-        // Aggregate into weekly and monthly
-        let weekly = Self::aggregate_by_week(&daily);
-        let monthly = Self::aggregate_by_month(&daily);
-
-        Ok(UsageReport {
-            daily,
-            weekly,
-            monthly,
-        })
+        Ok(())
     }
 
     /// Get historical stats from database
@@ -741,7 +859,6 @@ impl UsageStatsService {
     ) -> Result<Vec<UsageStat>, String> {
         // For weekly/monthly, compute from daily data stored in DB
         if stats_type == "weekly" || stats_type == "monthly" {
-            // Get all daily stats in the date range
             let daily_models = self.db.get_usage_stats("daily", since, until)
                 .await
                 .map_err(|e| e.to_string())?;
@@ -793,22 +910,5 @@ impl UsageStatsService {
             last_activity: m.last_activity,
             stats_type: m.stats_type,
         }).collect())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_get_week_start() {
-        // Monday 2024-01-08 should return 2024-01-08
-        assert_eq!(UsageStatsService::get_week_start("2024-01-08"), "2024-01-08");
-        // Tuesday 2024-01-09 should return 2024-01-08
-        assert_eq!(UsageStatsService::get_week_start("2024-01-09"), "2024-01-08");
-        // Sunday 2024-01-14 should return 2024-01-08
-        assert_eq!(UsageStatsService::get_week_start("2024-01-14"), "2024-01-08");
-        // Monday 2024-01-15 should return 2024-01-15
-        assert_eq!(UsageStatsService::get_week_start("2024-01-15"), "2024-01-15");
     }
 }

--- a/backend/src/services/usage_stats.rs
+++ b/backend/src/services/usage_stats.rs
@@ -633,7 +633,13 @@ impl UsageStatsService {
         let mut monthly_map: HashMap<String, TokenAccumulator> = HashMap::new();
 
         for stat in daily {
-            let month = stat.date[..7].to_string();
+            // Safely extract YYYY-MM from date string
+            let month = if stat.date.len() >= 7 {
+                stat.date[..7].to_string()
+            } else {
+                // Fallback to using the full date or a placeholder
+                stat.date.clone()
+            };
             let acc = monthly_map.entry(month).or_default();
             acc.input_tokens += stat.input_tokens as u64;
             acc.output_tokens += stat.output_tokens as u64;

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -14,6 +14,7 @@ import {
   KeyMetricsCard, HighlightStatsCard, TaskStatsCard, ExecStatsCard,
   InferenceStatsCard, OverviewCard, MessageStatsCard, BackupStatsCard,
 } from './dashboard/StatsGridCards';
+import { UsageStatsCard } from './dashboard/UsageStatsCard';
 import {
   ExecutorChartCard, ExecutorDurationCard, TagChartCard,
   ModelTaskChartCard, ModelTokenChartCard, ModelCacheCard, SkillsStatsCard,
@@ -169,6 +170,7 @@ export function Dashboard({ onBack }: { onBack?: () => void }) {
     { key: 'message-stats', render: () => <MessageStatsCard msgStats={msgStats} msgStatsError={msgStatsError} processingRate={processingRate} /> },
     { key: 'skills-stats', render: () => <SkillsStatsCard stats={stats} loading={loading} /> },
     { key: 'backup-stats', render: () => <BackupStatsCard stats={stats} loading={loading} /> },
+    { key: 'usage-stats', render: () => <UsageStatsCard /> },
     { key: 'share-card', render: () => <ShareCardPanel /> },
   ];
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -170,7 +170,21 @@ export function Dashboard({ onBack }: { onBack?: () => void }) {
     { key: 'message-stats', render: () => <MessageStatsCard msgStats={msgStats} msgStatsError={msgStatsError} processingRate={processingRate} /> },
     { key: 'skills-stats', render: () => <SkillsStatsCard stats={stats} loading={loading} /> },
     { key: 'backup-stats', render: () => <BackupStatsCard stats={stats} loading={loading} /> },
-    { key: 'usage-stats', render: () => <UsageStatsCard /> },
+    {
+      key: 'usage-stats',
+      render: () => {
+        let since: string | undefined;
+        let until: string | undefined;
+        if (customRange) {
+          since = customRange[0].toISOString();
+          until = customRange[1].toISOString();
+        } else if (typeof timeRange === 'number') {
+          until = new Date().toISOString();
+          since = new Date(Date.now() - timeRange * 60 * 60 * 1000).toISOString();
+        }
+        return <UsageStatsCard since={since} until={until} />;
+      },
+    },
     { key: 'share-card', render: () => <ShareCardPanel /> },
   ];
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -36,6 +36,7 @@ export function Dashboard({ onBack }: { onBack?: () => void }) {
   const [msgStatsError, setMsgStatsError] = useState(false);
   const [timeRange, setTimeRange] = useState<number | 'custom'>(720);
   const [customRange, setCustomRange] = useState<[dayjs.Dayjs, dayjs.Dayjs] | null>(null);
+  const [usageStatsRange, setUsageStatsRange] = useState<{ since?: string; until?: string }>({});
 
   const totalTodos = stats?.total_todos ?? todos.length;
   const successRate = stats && stats.total_executions > 0
@@ -70,6 +71,10 @@ export function Dashboard({ onBack }: { onBack?: () => void }) {
       // Don't load yet, wait for date selection
     } else {
       setCustomRange(null);
+      setUsageStatsRange({
+        until: new Date().toISOString(),
+        since: new Date(Date.now() - value * 60 * 60 * 1000).toISOString(),
+      });
       loadStats(value);
       loadMsgStats(value);
     }
@@ -78,6 +83,10 @@ export function Dashboard({ onBack }: { onBack?: () => void }) {
   const handleCustomRangeChange = (dates: [dayjs.Dayjs, dayjs.Dayjs] | null) => {
     setCustomRange(dates);
     if (dates) {
+      setUsageStatsRange({
+        since: dates[0].toISOString(),
+        until: dates[1].toISOString(),
+      });
       const hours = Math.round(dates[1].diff(dates[0], 'hour', true));
       loadStats(hours);
       loadMsgStats(hours);
@@ -87,6 +96,10 @@ export function Dashboard({ onBack }: { onBack?: () => void }) {
   useEffect(() => {
     loadStats(720);
     loadMsgStats(720);
+    setUsageStatsRange({
+      until: new Date().toISOString(),
+      since: new Date(Date.now() - 720 * 60 * 60 * 1000).toISOString(),
+    });
   }, []);
 
   const processingRate = msgStats && msgStats.total_messages > 0
@@ -172,18 +185,7 @@ export function Dashboard({ onBack }: { onBack?: () => void }) {
     { key: 'backup-stats', render: () => <BackupStatsCard stats={stats} loading={loading} /> },
     {
       key: 'usage-stats',
-      render: () => {
-        let since: string | undefined;
-        let until: string | undefined;
-        if (customRange) {
-          since = customRange[0].toISOString();
-          until = customRange[1].toISOString();
-        } else if (typeof timeRange === 'number') {
-          until = new Date().toISOString();
-          since = new Date(Date.now() - timeRange * 60 * 60 * 1000).toISOString();
-        }
-        return <UsageStatsCard since={since} until={until} />;
-      },
+      render: () => <UsageStatsCard since={usageStatsRange.since} until={usageStatsRange.until} />,
     },
     { key: 'share-card', render: () => <ShareCardPanel /> },
   ];

--- a/frontend/src/components/dashboard/UsageStatsCard.tsx
+++ b/frontend/src/components/dashboard/UsageStatsCard.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from 'react';
+import { Card, Table, Tag, Empty, Button, App, Segmented } from 'antd';
+import { ReloadOutlined } from '@ant-design/icons';
+import * as db from '../../utils/database';
+import type { UsageStatsResponse } from '../../types';
+
+interface UsageStatsCardProps {
+  since?: string;
+  until?: string;
+}
+
+type StatsTab = 'daily' | 'weekly' | 'monthly';
+
+export function UsageStatsCard({ since, until }: UsageStatsCardProps) {
+  const { message } = App.useApp();
+  const [stats, setStats] = useState<UsageStatsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [activeTab, setActiveTab] = useState<StatsTab>('daily');
+
+  const loadStats = async () => {
+    try {
+      setLoading(true);
+      const data = await db.getUsageStats(since, until);
+      setStats(data);
+    } catch {
+      message.error('加载使用统计失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRefresh = async () => {
+    try {
+      setRefreshing(true);
+      const data = await db.refreshUsageStats();
+      setStats(data);
+      message.success('使用统计已刷新');
+    } catch {
+      message.error('刷新使用统计失败');
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    loadStats();
+  }, [since, until]);
+
+  const currentData = stats?.[activeTab] ?? [];
+  const totals = currentData.reduce(
+    (acc, d) => ({
+      input: acc.input + d.input_tokens,
+      output: acc.output + d.output_tokens,
+      cost: acc.cost + d.total_cost,
+    }),
+    { input: 0, output: 0, cost: 0 }
+  );
+
+  // Format number: if >= 10000 show as 万, otherwise show raw number
+  const formatToken = (v: number) => {
+    if (v >= 10000) {
+      return `${(v / 10000).toFixed(1)}万`;
+    }
+    return v.toLocaleString();
+  };
+
+  const columns = [
+    {
+      title: '日期',
+      dataIndex: 'date',
+      key: 'date',
+      width: 120,
+    },
+    {
+      title: 'Input Tokens',
+      dataIndex: 'input_tokens',
+      key: 'input_tokens',
+      width: 140,
+      render: (v: number) => formatToken(v),
+    },
+    {
+      title: 'Output Tokens',
+      dataIndex: 'output_tokens',
+      key: 'output_tokens',
+      width: 140,
+      render: (v: number) => formatToken(v),
+    },
+    {
+      title: 'Cache Read',
+      dataIndex: 'cache_read_tokens',
+      key: 'cache_read_tokens',
+      width: 120,
+      render: (v: number) => formatToken(v),
+    },
+    {
+      title: 'Cache Create',
+      dataIndex: 'cache_creation_tokens',
+      key: 'cache_creation_tokens',
+      width: 120,
+      render: (v: number) => formatToken(v),
+    },
+    {
+      title: 'Cost',
+      dataIndex: 'total_cost',
+      key: 'total_cost',
+      width: 100,
+      render: (v: number) => `$${v.toFixed(4)}`,
+    },
+    {
+      title: 'Models',
+      dataIndex: 'models_used',
+      key: 'models_used',
+      render: (v: string[]) => v.slice(0, 3).map((m) => (
+        <Tag key={m} style={{ marginInlineEnd: 4 }}>{m}</Tag>
+      )),
+    },
+  ];
+
+  return (
+    <Card
+      title="Token 用量统计"
+      extra={
+        <Button
+          icon={<ReloadOutlined />}
+          size="small"
+          loading={refreshing}
+          onClick={handleRefresh}
+        >
+          刷新
+        </Button>
+      }
+      style={{ borderRadius: 12 }}
+      styles={{ body: { padding: '16px 20px' } }}
+    >
+      {loading ? (
+        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="加载中..." />
+      ) : stats ? (
+        <>
+          <div style={{ marginBottom: 12 }}>
+            <Segmented
+              value={activeTab}
+              onChange={(v) => setActiveTab(v as StatsTab)}
+              options={[
+                { label: '日', value: 'daily' },
+                { label: '周', value: 'weekly' },
+                { label: '月', value: 'monthly' },
+              ]}
+              size="small"
+            />
+          </div>
+          <div style={{ marginBottom: 16, display: 'flex', gap: 24 }}>
+            <div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>Input Tokens</div>
+              <div style={{ fontSize: 20, fontWeight: 600 }}>{formatToken(totals.input)}</div>
+            </div>
+            <div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>Output Tokens</div>
+              <div style={{ fontSize: 20, fontWeight: 600 }}>{formatToken(totals.output)}</div>
+            </div>
+            <div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>Total Cost</div>
+              <div style={{ fontSize: 20, fontWeight: 600 }}>${totals.cost.toFixed(4)}</div>
+            </div>
+          </div>
+          {currentData.length > 0 ? (
+            <Table
+              columns={columns}
+              dataSource={currentData}
+              rowKey="date"
+              pagination={false}
+              size="small"
+              scroll={{ x: 'max-content' }}
+            />
+          ) : (
+            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={`暂无${activeTab === 'daily' ? '日' : activeTab === 'weekly' ? '周' : '月'}度统计数据`} />
+          )}
+        </>
+      ) : (
+        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无统计数据" />
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/dashboard/UsageStatsCard.tsx
+++ b/frontend/src/components/dashboard/UsageStatsCard.tsx
@@ -57,6 +57,9 @@ export function UsageStatsCard({ since, until }: UsageStatsCardProps) {
     { input: 0, output: 0, cost: 0 }
   );
 
+  // Get breakdowns for the selected period
+  const currentBreakdowns = stats?.breakdowns ?? [];
+
   // Format number: if >= 10000 show as 万, otherwise show raw number
   const formatToken = (v: number) => {
     if (v >= 10000) {
@@ -117,6 +120,56 @@ export function UsageStatsCard({ since, until }: UsageStatsCardProps) {
     },
   ];
 
+  const breakdownColumns = [
+    {
+      title: '日期',
+      dataIndex: 'date',
+      key: 'date',
+      width: 120,
+    },
+    {
+      title: 'Model',
+      dataIndex: 'model_name',
+      key: 'model_name',
+      width: 150,
+    },
+    {
+      title: 'Input Tokens',
+      dataIndex: 'input_tokens',
+      key: 'input_tokens',
+      width: 140,
+      render: (v: number) => formatToken(v),
+    },
+    {
+      title: 'Output Tokens',
+      dataIndex: 'output_tokens',
+      key: 'output_tokens',
+      width: 140,
+      render: (v: number) => formatToken(v),
+    },
+    {
+      title: 'Cache Read',
+      dataIndex: 'cache_read_tokens',
+      key: 'cache_read_tokens',
+      width: 120,
+      render: (v: number) => formatToken(v),
+    },
+    {
+      title: 'Cache Create',
+      dataIndex: 'cache_creation_tokens',
+      key: 'cache_creation_tokens',
+      width: 120,
+      render: (v: number) => formatToken(v),
+    },
+    {
+      title: 'Cost',
+      dataIndex: 'cost',
+      key: 'cost',
+      width: 100,
+      render: (v: number) => `$${v.toFixed(4)}`,
+    },
+  ];
+
   return (
     <Card
       title="Token 用量统计"
@@ -171,9 +224,24 @@ export function UsageStatsCard({ since, until }: UsageStatsCardProps) {
               pagination={false}
               size="small"
               scroll={{ x: 'max-content' }}
+              style={{ marginBottom: 24 }}
             />
           ) : (
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={`暂无${activeTab === 'daily' ? '日' : activeTab === 'weekly' ? '周' : '月'}度统计数据`} />
+          )}
+
+          {currentBreakdowns.length > 0 && (
+            <>
+              <div style={{ fontSize: 14, fontWeight: 500, marginBottom: 8 }}>模型维度统计</div>
+              <Table
+                columns={breakdownColumns}
+                dataSource={currentBreakdowns}
+                rowKey={(record) => `${record.date}-${record.model_name}`}
+                pagination={false}
+                size="small"
+                scroll={{ x: 'max-content' }}
+              />
+            </>
           )}
         </>
       ) : (

--- a/frontend/src/components/settings/ExecutorsPanel.tsx
+++ b/frontend/src/components/settings/ExecutorsPanel.tsx
@@ -1,6 +1,10 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Button, Card, Input, Switch, Spin, Tooltip, Modal, message, Typography } from 'antd';
-import { SearchOutlined, PlayCircleOutlined } from '@ant-design/icons';
+import { SearchOutlined, PlayCircleOutlined, ClockCircleOutlined } from '@ant-design/icons';
+import { Cron } from 'react-js-cron';
+import 'react-js-cron/dist/styles.css';
+import { CronPresetSelect } from '../CronPresetSelect';
+import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '../../utils/cron';
 import * as db from '../../utils/database';
 import type { ExecutorConfig } from '../../types';
 
@@ -18,6 +22,41 @@ export function ExecutorsPanel({ executors, setExecutors, executorsLoading }: {
   const [testModalVisible, setTestModalVisible] = useState(false);
   const [testModalData, setTestModalData] = useState<{ name: string; result: { test_passed: boolean; output: string | null; error: string | null } } | null>(null);
   const [savingExecutor, setSavingExecutor] = useState<string | null>(null);
+
+  // Usage stats settings
+  const [usageStatsEnabled, setUsageStatsEnabled] = useState(false);
+  const [usageStatsCron, setUsageStatsCron] = useState('0 0 1 * * *');
+  const [usageStatsLoading, setUsageStatsLoading] = useState(false);
+  const [usageStatsSaving, setUsageStatsSaving] = useState(false);
+
+  useEffect(() => {
+    loadUsageStatsSettings();
+  }, []);
+
+  const loadUsageStatsSettings = async () => {
+    try {
+      setUsageStatsLoading(true);
+      const settings = await db.getUsageStatsSettings();
+      setUsageStatsEnabled(settings.auto_usage_stats_enabled);
+      setUsageStatsCron(settings.auto_usage_stats_cron);
+    } catch {
+      // Ignore errors, use defaults
+    } finally {
+      setUsageStatsLoading(false);
+    }
+  };
+
+  const handleSaveUsageStats = async () => {
+    try {
+      setUsageStatsSaving(true);
+      await db.updateUsageStatsSettings(usageStatsEnabled, usageStatsCron);
+      message.success('AI 使用统计配置已更新');
+    } catch (err: any) {
+      message.error('保存失败: ' + (err?.message || String(err)));
+    } finally {
+      setUsageStatsSaving(false);
+    }
+  };
 
   return (
     <Spin spinning={executorsLoading}>
@@ -205,6 +244,41 @@ export function ExecutorsPanel({ executors, setExecutors, executorsLoading }: {
             );
           })}
         </div>
+
+        <Card
+          size="small"
+          title={<><ClockCircleOutlined style={{ marginRight: 6 }} />AI 使用统计</>}
+          style={{ marginTop: 16 }}
+          extra={
+            <Switch
+              checked={usageStatsEnabled}
+              onChange={(checked) => setUsageStatsEnabled(checked)}
+              loading={usageStatsLoading}
+            />
+          }
+        >
+          {usageStatsEnabled && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <Typography.Paragraph type="secondary" style={{ marginBottom: 8 }}>
+                自动收集本机执行器的 Token 使用量，每日归档到数据库
+              </Typography.Paragraph>
+              <CronPresetSelect value={usageStatsCron} onChange={(val: string) => setUsageStatsCron(val)} />
+              <Cron
+                value={cronTo5(usageStatsCron)}
+                setValue={(val: string) => { setUsageStatsCron(cronTo6(val)); }}
+                locale={CRON_ZH_LOCALE}
+                defaultPeriod="day"
+                humanizeLabels
+                allowClear={false}
+              />
+              <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <Button size="small" type="primary" onClick={handleSaveUsageStats} loading={usageStatsSaving}>
+                  保存
+                </Button>
+              </div>
+            </div>
+          )}
+        </Card>
       </div>
       <Modal
         title={testModalData ? `测试结果 - ${executors.find(e => e.name === testModalData.name)?.display_name || testModalData.name}` : '测试结果'}

--- a/frontend/src/components/settings/ExecutorsPanel.tsx
+++ b/frontend/src/components/settings/ExecutorsPanel.tsx
@@ -252,7 +252,18 @@ export function ExecutorsPanel({ executors, setExecutors, executorsLoading }: {
           extra={
             <Switch
               checked={usageStatsEnabled}
-              onChange={(checked) => setUsageStatsEnabled(checked)}
+              onChange={async (checked) => {
+                setUsageStatsEnabled(checked);
+                try {
+                  setUsageStatsSaving(true);
+                  await db.updateUsageStatsSettings(checked, usageStatsCron);
+                  message.success('AI 使用统计配置已更新');
+                } catch (err: any) {
+                  message.error('保存失败: ' + (err?.message || String(err)));
+                } finally {
+                  setUsageStatsSaving(false);
+                }
+              }}
               loading={usageStatsLoading}
             />
           }

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -566,6 +566,7 @@ export interface UsageStat {
 }
 
 export interface ModelBreakdown {
+  date: string;
   model_name: string;
   input_tokens: number;
   output_tokens: number;
@@ -579,4 +580,5 @@ export interface UsageStatsResponse {
   daily: UsageStat[];
   weekly: UsageStat[];
   monthly: UsageStat[];
+  breakdowns: ModelBreakdown[];
 }

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -547,3 +547,36 @@ export interface RecentBackup {
   size: number;
   created_at: string;
 }
+
+// Usage Statistics types (from ccusage integration)
+export interface UsageStat {
+  date: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_tokens: number;
+  cache_read_tokens: number;
+  extra_total_tokens: number;
+  total_cost: number;
+  credits: number | null;
+  message_count: number | null;
+  models_used: string[];
+  project: string | null;
+  last_activity: string | null;
+  stats_type: string;
+}
+
+export interface ModelBreakdown {
+  model_name: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_tokens: number;
+  cache_read_tokens: number;
+  extra_total_tokens: number;
+  cost: number;
+}
+
+export interface UsageStatsResponse {
+  daily: UsageStat[];
+  weekly: UsageStat[];
+  monthly: UsageStat[];
+}

--- a/frontend/src/utils/database/index.ts
+++ b/frontend/src/utils/database/index.ts
@@ -6,3 +6,4 @@ export * from './skills';
 export * from './bots';
 export * from './sessions';
 export * from './webhooks';
+export * from './usage_stats';

--- a/frontend/src/utils/database/usage_stats.ts
+++ b/frontend/src/utils/database/usage_stats.ts
@@ -1,0 +1,26 @@
+import { api, unwrap } from './client';
+import type { UsageStatsResponse } from '../../types';
+
+export async function getUsageStats(since?: string, until?: string): Promise<UsageStatsResponse> {
+  const params: Record<string, unknown> = {};
+  if (since !== undefined) params.since = since;
+  if (until !== undefined) params.until = until;
+  return unwrap(await api.get('/xyz/usage-stats', { params }));
+}
+
+export async function refreshUsageStats(): Promise<UsageStatsResponse> {
+  return unwrap(await api.post('/xyz/usage-stats/refresh'));
+}
+
+export interface UsageStatsSettings {
+  auto_usage_stats_enabled: boolean;
+  auto_usage_stats_cron: string;
+}
+
+export async function getUsageStatsSettings(): Promise<UsageStatsSettings> {
+  return unwrap(await api.get('/xyz/usage-stats/settings'));
+}
+
+export async function updateUsageStatsSettings(enabled: boolean, cron: string): Promise<string> {
+  return unwrap(await api.put('/xyz/usage-stats/settings', { enabled, cron }));
+}


### PR DESCRIPTION
## Summary

- 新增数据库表 `usage_daily_stats` 和 `usage_executor_daily_stats` 存储使用统计
- 创建 UsageStatsService 从编辑器数据库读取 usage 数据
- Dashboard 新增 Token 用量统计卡片，支持日/周/月视图
- 执行器管理页面增加 AI 使用统计开关和定时配置
- 后台定时任务每日凌晨自动归档前一天的统计数据
- 修复周/月统计数据查询问题（从日数据动态聚合）

## Test plan

- [ ] 访问 Dashboard 查看 Token 用量统计卡片
- [ ] 切换日/周/月视图验证数据正确性
- [ ] 进入设置 → 执行器管理，测试开关和定时配置
- [ ] 验证定时任务是否按配置执行