### PR TITLE
feat(skills): Skill 详情抽屉增加同步和删除功能

### DIFF
--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -443,7 +443,7 @@ pub fn create_app(
         .route("/xyz/executors/{name}/detect", post(executor_config::detect_executor))
         .route("/xyz/executors/{name}/test", post(executor_config::test_executor))
         .route("/xyz/executors/detect-all", post(executor_config::detect_all_executors))
-        .route("/xyz/skills", get(skills::list_skills))
+        .route("/xyz/skills", get(skills::list_skills).delete(skills::delete_skill))
         .route("/xyz/skills/compare", get(skills::compare_skills))
         .route("/xyz/skills/sync", post(skills::sync_skill))
         .route("/xyz/skills/invocations", get(skills::list_invocations).post(skills::record_invocation))

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -143,6 +143,12 @@ pub struct RecordInvocationRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct DeleteSkillQuery {
+    pub executor: String,
+    pub skill_name: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct SkillContentQuery {
     pub executor: String,
     pub skill_name: String,
@@ -422,6 +428,41 @@ pub async fn get_skill_content(
     .map_err(|e| AppError::Internal(format!("spawn_blocking join error: {}", e)))?;
 
     Ok(ApiResponse::ok(result))
+}
+
+/// DELETE /xyz/skills - Delete a skill from an executor
+pub async fn delete_skill(
+    Query(query): Query<DeleteSkillQuery>,
+) -> Result<ApiResponse<String>, AppError> {
+    let et = crate::adapters::parse_executor_type(&query.executor)
+        .ok_or_else(|| AppError::BadRequest(format!("Unknown executor: {}", query.executor)))?;
+
+    let skills_dir = executor_skills_dir(et)
+        .ok_or_else(|| AppError::BadRequest("No skills directory for this executor".to_string()))?;
+
+    let skill_dir = skills_dir.join(&query.skill_name);
+    if !skill_dir.exists() {
+        return Err(AppError::NotFound);
+    }
+
+    // Verify the path is under the skills directory
+    let skill_dir_canonical = skill_dir.canonicalize()
+        .map_err(|e| AppError::Internal(format!("Failed to resolve skill dir: {}", e)))?;
+    let skills_dir_canonical = skills_dir.canonicalize()
+        .map_err(|e| AppError::Internal(format!("Failed to resolve skills dir: {}", e)))?;
+    if !skill_dir_canonical.starts_with(&skills_dir_canonical) {
+        return Err(AppError::BadRequest("Invalid skill name: path escapes skills directory".to_string()));
+    }
+
+    let skill_name = query.skill_name.clone();
+    tokio::task::spawn_blocking(move || {
+        std::fs::remove_dir_all(&skill_dir)
+            .map_err(|e| AppError::Internal(format!("Failed to delete skill: {}", e)))
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("spawn_blocking join error: {}", e)))??;
+
+    Ok(ApiResponse::ok(format!("Skill '{}' deleted", skill_name)))
 }
 
 /// GET /xyz/skills/export - Export skill as .zip

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -440,18 +440,29 @@ pub async fn delete_skill(
     let skills_dir = executor_skills_dir(et)
         .ok_or_else(|| AppError::BadRequest("No skills directory for this executor".to_string()))?;
 
+    // Reject skill names with path separators or parent traversal
+    if query.skill_name.contains('/') || query.skill_name.contains('\\') || query.skill_name.contains("..") {
+        return Err(AppError::BadRequest("Invalid skill name: path separators and '..' are not allowed".to_string()));
+    }
+
     let skill_dir = skills_dir.join(&query.skill_name);
-    if !skill_dir.exists() {
+    if !skill_dir.exists() || !skill_dir.is_dir() {
         return Err(AppError::NotFound);
     }
 
-    // Verify the path is under the skills directory
+    // Verify the path is under the skills directory and is a direct child
     let skill_dir_canonical = skill_dir.canonicalize()
         .map_err(|e| AppError::Internal(format!("Failed to resolve skill dir: {}", e)))?;
     let skills_dir_canonical = skills_dir.canonicalize()
         .map_err(|e| AppError::Internal(format!("Failed to resolve skills dir: {}", e)))?;
+    if skill_dir_canonical == skills_dir_canonical {
+        return Err(AppError::BadRequest("Cannot delete the skills root directory".to_string()));
+    }
     if !skill_dir_canonical.starts_with(&skills_dir_canonical) {
         return Err(AppError::BadRequest("Invalid skill name: path escapes skills directory".to_string()));
+    }
+    if skill_dir_canonical.parent() != Some(skills_dir_canonical.as_path()) {
+        return Err(AppError::BadRequest("Invalid skill name: must be a direct child of skills directory".to_string()));
     }
 
     let skill_name = query.skill_name.clone();

--- a/frontend/src/components/skills/SkillDetailDrawer.tsx
+++ b/frontend/src/components/skills/SkillDetailDrawer.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
-import { Spin, Drawer, Descriptions, Tag, Alert, Button, Space, message } from 'antd';
+import { Spin, Drawer, Descriptions, Tag, Alert, Button, Space, message, Modal, Checkbox, Row, Col, Popconfirm } from 'antd';
 import Typography from 'antd/es/typography';
-import { FileTextOutlined, DownloadOutlined, InfoCircleOutlined } from '@ant-design/icons';
+import { FileTextOutlined, DownloadOutlined, InfoCircleOutlined, SwapOutlined, DeleteOutlined } from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
 import * as db from '../../utils/database';
 import { formatSize, formatTime, EXECUTOR_COLORS } from './helpers';
+import { EXECUTORS, type ExecutorSkills } from '../../types';
 import type { SkillMeta } from '../../types';
 
 const { Text } = Typography;
@@ -15,11 +16,17 @@ interface SkillDetailDrawerProps {
   executorLabel: string;
   open: boolean;
   onClose: () => void;
+  onSyncSuccess?: () => void;
+  onDeleteSuccess?: () => void;
 }
 
-export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClose }: SkillDetailDrawerProps) {
+export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClose, onSyncSuccess, onDeleteSuccess }: SkillDetailDrawerProps) {
   const [content, setContent] = useState<string>('');
   const [loading, setLoading] = useState(false);
+  const [syncModalOpen, setSyncModalOpen] = useState(false);
+  const [targetExecutors, setTargetExecutors] = useState<string[]>([]);
+  const [syncing, setSyncing] = useState(false);
+  const [executorsData, setExecutorsData] = useState<ExecutorSkills[]>([]);
 
   useEffect(() => {
     if (open && skill) {
@@ -36,6 +43,30 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
     }
   }, [open, skill, executor]);
 
+  const handleOpenSyncModal = () => {
+    setTargetExecutors([]);
+    db.getSkillsList()
+      .then(data => setExecutorsData(data.filter(e => e.skills_dir_exists)))
+      .catch(() => setExecutorsData([]))
+      .finally(() => setSyncModalOpen(true));
+  };
+
+  const handleSync = async () => {
+    if (!skill || targetExecutors.length === 0) return;
+    setSyncing(true);
+    try {
+      const result = await db.syncSkill(executor, skill.name, targetExecutors);
+      message.success(result || '同步完成');
+      setSyncModalOpen(false);
+      setTargetExecutors([]);
+      onSyncSuccess?.();
+    } catch (err: any) {
+      message.error('同步失败: ' + (err?.message || String(err)));
+    } finally {
+      setSyncing(false);
+    }
+  };
+
   const handleExport = async () => {
     if (!skill) return;
     try {
@@ -49,6 +80,18 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
       message.success(`导出 ${skill.name} 成功`);
     } catch {
       message.error(`导出 ${skill.name} 失败`);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!skill) return;
+    try {
+      await db.deleteSkill(executor, skill.name);
+      message.success(`已删除 ${skill.name}`);
+      onClose();
+      onDeleteSuccess?.();
+    } catch (err: any) {
+      message.error('删除失败: ' + (err?.message || String(err)));
     }
   };
 
@@ -67,9 +110,24 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
       open={open}
       extra={
         <Space>
+          <Button icon={<SwapOutlined />} onClick={handleOpenSyncModal}>
+            同步
+          </Button>
           <Button icon={<DownloadOutlined />} onClick={handleExport}>
             导出
           </Button>
+          <Popconfirm
+            title="删除 Skill"
+            description={`确定要删除 ${executorLabel} 下的「${skill?.name}」吗？此操作不可恢复。`}
+            onConfirm={handleDelete}
+            okText="删除"
+            cancelText="取消"
+            okButtonProps={{ danger: true }}
+          >
+            <Button icon={<DeleteOutlined />} danger>
+              删除
+            </Button>
+          </Popconfirm>
         </Space>
       }
     >
@@ -132,6 +190,53 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
           />
         </div>
       )}
+      <Modal
+        title={
+          <Space>
+            <SwapOutlined style={{ color: '#7C3AED' }} />
+            <span>同步 Skill 到其他执行器</span>
+          </Space>
+        }
+        open={syncModalOpen}
+        onCancel={() => setSyncModalOpen(false)}
+        onOk={handleSync}
+        okText={`同步到 ${targetExecutors.length} 个执行器`}
+        okButtonProps={{ disabled: targetExecutors.length === 0 }}
+        confirmLoading={syncing}
+        width={480}
+      >
+        <div style={{ marginBottom: 16 }}>
+          <Text type="secondary">
+            将 <Text strong>{skill?.name}</Text> 从 <Tag color={EXECUTOR_COLORS[executor]}>{executorLabel}</Tag> 复制到以下执行器：
+          </Text>
+        </div>
+        <Checkbox.Group
+          value={targetExecutors}
+          onChange={v => setTargetExecutors(v as string[])}
+          style={{ width: '100%' }}
+        >
+          <Row gutter={[8, 8]}>
+            {EXECUTORS.filter(e => e.value !== executor).map(exec => {
+              const exists = executorsData.find(ex => ex.executor === exec.value);
+              const alreadyHas = exists?.skills.find(s => s.name === skill?.name);
+              return (
+                <Col span={12} key={exec.value}>
+                  <Checkbox value={exec.value}>
+                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                      <span style={{
+                        width: 6, height: 6, borderRadius: '50%',
+                        backgroundColor: exec.color,
+                      }} />
+                      {exec.label}
+                      {alreadyHas && <Tag color="orange" style={{ fontSize: 10 }}>已存在</Tag>}
+                    </span>
+                  </Checkbox>
+                </Col>
+              );
+            })}
+          </Row>
+        </Checkbox.Group>
+      </Modal>
     </Drawer>
   );
 }

--- a/frontend/src/components/skills/SkillDetailDrawer.tsx
+++ b/frontend/src/components/skills/SkillDetailDrawer.tsx
@@ -218,7 +218,8 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
           <Row gutter={[8, 8]}>
             {EXECUTORS.filter(e => e.value !== executor).map(exec => {
               const exists = executorsData.find(ex => ex.executor === exec.value);
-              const alreadyHas = exists?.skills.find(s => s.name === skill?.name);
+              const targetName = skill?.name?.split('/').pop() || skill?.name;
+              const alreadyHas = exists?.skills.find(s => s.name === targetName);
               return (
                 <Col span={12} key={exec.value}>
                   <Checkbox value={exec.value}>

--- a/frontend/src/components/skills/SkillsOverview.tsx
+++ b/frontend/src/components/skills/SkillsOverview.tsx
@@ -30,12 +30,11 @@ export function SkillsOverview() {
     db.getSkillsList()
       .then(data => {
         setData(data);
-        const withSkills = data.find(e => e.skills.length > 0);
-        if (withSkills) {
-          setSelectedExecutor(withSkills.executor);
-        } else if (data.length > 0) {
-          setSelectedExecutor(data[0].executor);
-        }
+        setSelectedExecutor(prev => {
+          if (prev && data.some(e => e.executor === prev)) return prev;
+          const withSkills = data.find(e => e.skills.length > 0);
+          return withSkills?.executor ?? data[0]?.executor ?? '';
+        });
       })
       .catch(err => message.error('加载失败: ' + err.message))
       .finally(() => setLoading(false));

--- a/frontend/src/components/skills/SkillsOverview.tsx
+++ b/frontend/src/components/skills/SkillsOverview.tsx
@@ -25,7 +25,7 @@ export function SkillsOverview() {
   const [exportMode, setExportMode] = useState<'import' | 'export'>('export');
   const [initialSelectedSkills, setInitialSelectedSkills] = useState<string[] | undefined>(undefined);
 
-  useEffect(() => {
+  const loadData = () => {
     setLoading(true);
     db.getSkillsList()
       .then(data => {
@@ -39,6 +39,10 @@ export function SkillsOverview() {
       })
       .catch(err => message.error('加载失败: ' + err.message))
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadData();
   }, []);
 
   const handleSkillClick = (skill: SkillMeta, executor: string) => {
@@ -179,6 +183,8 @@ export function SkillsOverview() {
         executorLabel={EXECUTORS.find(e => e.value === selectedExecutor)?.label || selectedExecutor}
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
+        onSyncSuccess={loadData}
+        onDeleteSuccess={loadData}
       />
 
       <ImportExportModal

--- a/frontend/src/utils/database/skills.ts
+++ b/frontend/src/utils/database/skills.ts
@@ -17,6 +17,12 @@ export async function syncSkill(sourceExecutor: string, skillName: string, targe
   }));
 }
 
+export async function deleteSkill(executor: string, skillName: string): Promise<string> {
+  return unwrap(await api.delete('/xyz/skills', {
+    params: { executor, skill_name: skillName },
+  }));
+}
+
 export async function getSkillInvocations(params?: { page?: number; limit?: number; skill_name?: string; executor?: string }): Promise<PaginatedInvocations> {
   return unwrap(await api.get('/xyz/skills/invocations', { params }));
 }


### PR DESCRIPTION
## Summary
- Skill 详情抽屉新增**同步**按钮，点击弹出模态框选择目标执行器，复用 syncSkill API 将 skill 复制到其他执行器
- Skill 详情抽屉新增**删除**按钮，使用 Popconfirm 确认后删除（与项目其他删除操作风格一致）
- 后端新增 DELETE /xyz/skills API，含路径安全校验防止目录穿越
- 同步/删除成功后自动刷新 Skill 列表数据

## Test plan
- [x] Playwright 自动化验证同步/删除功能
- [x] TypeScript 类型检查通过
- [x] Rust cargo check 通过

🤖 Generated with [CodeBuddy Code]