### PR TITLE
feat: 添加 Todo 关联图功能

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,9 +12,9 @@
         "@ant-design/x-markdown": "^2.5.0",
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@uiw/react-md-editor": "^4.1.0",
+        "@xyflow/react": "^12.11.0",
         "antd": "^6.3.6",
         "axios": "^1.15.2",
-        "framer-motion": "^12.38.0",
         "js-yaml": "^4.1.1",
         "qrcode": "^1.5.4",
         "react": "^19.1.0",
@@ -2103,6 +2103,55 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmmirror.com/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmmirror.com/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2188,7 +2237,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2198,7 +2246,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -2298,6 +2346,48 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.0",
+      "resolved": "https://registry.npmmirror.com/@xyflow/react/-/react-12.11.0.tgz",
+      "integrity": "sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.77",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.77",
+      "resolved": "https://registry.npmmirror.com/@xyflow/system/-/system-0.0.77.tgz",
+      "integrity": "sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/acorn": {
@@ -2597,6 +2687,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmmirror.com/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -2706,6 +2802,111 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/dayjs": {
       "version": "1.11.20",
@@ -3107,33 +3308,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/framer-motion": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
-      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.38.0",
-        "motion-utils": "^12.36.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/fsevents": {
@@ -4713,21 +4887,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/motion-dom": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
-      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.36.0"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.36.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
-      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5640,12 +5799,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -5794,6 +5947,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vfile": {
@@ -5989,6 +6151,34 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmmirror.com/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,9 +15,9 @@
     "@ant-design/x-markdown": "^2.5.0",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@uiw/react-md-editor": "^4.1.0",
+    "@xyflow/react": "^12.11.0",
     "antd": "^6.3.6",
     "axios": "^1.15.2",
-
     "js-yaml": "^4.1.1",
     "qrcode": "^1.5.4",
     "react": "^19.1.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -280,7 +280,7 @@ function AppContent() {
               ) : activeView === 'memorial' ? (
                 <MemorialBoard onBack={isMobile ? handleBackToList : undefined} />
               ) : activeView === 'relation' ? (
-                <RelationMap />
+                <RelationMap onBack={isMobile ? handleBackToList : undefined} />
               ) : (
                 <Dashboard onBack={isMobile ? handleBackToList : undefined} />
               )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { TodoList } from './components/TodoList';
 import { TodoDetail } from './components/TodoDetail';
 import { Dashboard } from './components/Dashboard';
 import { MemorialBoard } from './components/MemorialBoard';
+import { RelationMap } from './components/relation-map';
 import { SettingsPage } from './components/SettingsPage';
 import { ExecutionPanel } from './components/ExecutionPanel';
 import { TodoDrawer } from './components/TodoDrawer';
@@ -31,13 +32,13 @@ function AppContent() {
   const getInitialView = () => {
     const params = new URLSearchParams(window.location.search);
     const view = params.get('view');
-    if (view === 'settings' || view === 'memorial') return view;
+    if (view === 'settings' || view === 'memorial' || view === 'relation') return view;
     return 'dashboard';
   };
-  const getInitialPanel = (view: 'dashboard' | 'settings' | 'memorial') => {
+  const getInitialPanel = (view: 'dashboard' | 'settings' | 'memorial' | 'relation') => {
     return view === 'dashboard' ? 'list' : 'detail';
   };
-  const [activeView, setActiveView] = useState<'dashboard' | 'settings' | 'memorial'>(getInitialView);
+  const [activeView, setActiveView] = useState<'dashboard' | 'settings' | 'memorial' | 'relation'>(getInitialView);
   const [selectedPanel, setSelectedPanel] = useState<'list' | 'detail'>(() => getInitialPanel(getInitialView()));
 
   const [panelCollapsed, setPanelCollapsed] = useState(() => {
@@ -83,7 +84,7 @@ function AppContent() {
         setSelectedPanel('detail');
       } else {
         dispatch({ type: 'SELECT_TODO', payload: null });
-        if (view === 'settings' || view === 'memorial') {
+        if (view === 'settings' || view === 'memorial' || view === 'relation') {
           setActiveView(view);
           setSelectedPanel('detail');
         } else {
@@ -141,6 +142,13 @@ function AppContent() {
     setActiveView('settings');
     setSelectedPanel('detail');
     pushUrl('settings');
+  };
+
+  const handleShowRelationMap = () => {
+    clearSelection();
+    setActiveView('relation');
+    setSelectedPanel('detail');
+    pushUrl('relation');
   };
 
 
@@ -250,6 +258,7 @@ function AppContent() {
               onSelectTodo={handleSelectTodo}
               onShowDashboard={handleShowDashboard}
               onShowMemorial={handleShowMemorial}
+              onShowRelationMap={handleShowRelationMap}
               onShowSettings={handleShowSettings}
             />
           </div>
@@ -270,6 +279,8 @@ function AppContent() {
                 <SettingsPage onBack={isMobile ? handleBackToList : undefined} />
               ) : activeView === 'memorial' ? (
                 <MemorialBoard onBack={isMobile ? handleBackToList : undefined} />
+              ) : activeView === 'relation' ? (
+                <RelationMap />
               ) : (
                 <Dashboard onBack={isMobile ? handleBackToList : undefined} />
               )}

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useApp } from '../hooks/useApp';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { Button, Empty, Tooltip } from 'antd';
-import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined } from '@ant-design/icons';
+import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, ApartmentOutlined } from '@ant-design/icons';
 import { useTheme } from '../hooks/useTheme';
 import { StatusPicker } from './StatusPicker';
 import * as db from '../utils/database';
@@ -15,6 +15,7 @@ interface TodoListProps {
   onSelectTodo?: (todoId: string | number) => void;
   onShowDashboard?: () => void;
   onShowMemorial?: () => void;
+  onShowRelationMap?: () => void;
   onShowSettings?: () => void;
 }
 
@@ -32,7 +33,7 @@ function SkeletonList() {
   );
 }
 
-export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, onShowDashboard, onShowMemorial, onShowSettings }: TodoListProps) {
+export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, onShowDashboard, onShowMemorial, onShowRelationMap, onShowSettings }: TodoListProps) {
   const { state, dispatch } = useApp();
   const { themeMode, toggleTheme } = useTheme();
   const { todos, selectedTodoId, selectedTagId, tags } = state;
@@ -96,6 +97,16 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
               onClick={() => onShowMemorial?.()}
               className="tag-btn"
               aria-label="看板"
+            />
+          </Tooltip>
+          <Tooltip title="关联图">
+            <Button
+              type="text"
+              size="small"
+              icon={<ApartmentOutlined />}
+              onClick={() => onShowRelationMap?.()}
+              className="tag-btn"
+              aria-label="关联图"
             />
           </Tooltip>
           <Tooltip title={themeMode === 'light' ? '切换暗色主题' : '切换亮色主题'}>

--- a/frontend/src/components/relation-map/Edges.tsx
+++ b/frontend/src/components/relation-map/Edges.tsx
@@ -1,0 +1,186 @@
+import { useCallback } from 'react';
+import {
+  BaseEdge,
+  getBezierPath,
+  type EdgeProps,
+  EdgeLabelRenderer,
+} from '@xyflow/react';
+
+/** Hook 边：带触发条件标签 */
+export function HookEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+  selected,
+}: EdgeProps & { data?: { trigger?: string; hookId?: number; enabled?: boolean } }) {
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  });
+
+  const trigger = data?.trigger || '';
+  const getTriggerColor = useCallback((t: string) => {
+    switch (t) {
+      case 'state_changed_to_completed': return '#52c41a';
+      case 'state_changed_to_failed': return '#ff4d4f';
+      case 'state_changed_to_pending': return '#8c8c8c';
+      case 'state_changed_to_in_progress': return '#1677ff';
+      default: return '#999';
+    }
+  }, []);
+
+  const getTriggerLabel = useCallback((t: string) => {
+    switch (t) {
+      case 'state_changed_to_completed': return '已完成';
+      case 'state_changed_to_failed': return '失败';
+      case 'state_changed_to_pending': return '待执行';
+      case 'state_changed_to_in_progress': return '执行中';
+      default: return t;
+    }
+  }, []);
+
+  const color = getTriggerColor(trigger);
+
+  return (
+    <>
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        style={{
+          stroke: selected ? color : '#555',
+          strokeWidth: selected ? 2.5 : 1.5,
+          strokeDasharray: data?.enabled === false ? '5 5' : undefined,
+        }}
+      />
+      {trigger && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+              pointerEvents: 'all',
+              fontSize: 10,
+              background: 'var(--color-bg-elevated, #1e1e2e)',
+              border: `1px solid ${color}`,
+              borderRadius: 4,
+              padding: '1px 6px',
+              color,
+              whiteSpace: 'nowrap',
+            }}
+            className="nodrag nopan"
+          >
+            {getTriggerLabel(trigger)} →
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}
+
+/** Webhook 边：紫色虚线 */
+export function WebhookEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  selected,
+}: EdgeProps) {
+  const [edgePath] = getBezierPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  });
+
+  return (
+    <BaseEdge
+      id={id}
+      path={edgePath}
+      style={{
+        stroke: selected ? '#9254de' : '#722ed1',
+        strokeWidth: selected ? 2.5 : 1.5,
+        strokeDasharray: '6 3',
+      }}
+    />
+  );
+}
+
+/** 飞书消息边：蓝色点线 */
+export function FeishuEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  selected,
+}: EdgeProps) {
+  const [edgePath] = getBezierPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  });
+
+  return (
+    <BaseEdge
+      id={id}
+      path={edgePath}
+      style={{
+        stroke: selected ? '#40a9ff' : '#1890ff',
+        strokeWidth: selected ? 2.5 : 1.5,
+        strokeDasharray: '3 3',
+      }}
+    />
+  );
+}
+
+/** 调度器边：橙色虚线 */
+export function SchedulerEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  selected,
+}: EdgeProps) {
+  const [edgePath] = getBezierPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  });
+
+  return (
+    <BaseEdge
+      id={id}
+      path={edgePath}
+      style={{
+        stroke: selected ? '#ffa940' : '#fa8c16',
+        strokeWidth: selected ? 2.5 : 1.5,
+        strokeDasharray: '8 4',
+      }}
+    />
+  );
+}

--- a/frontend/src/components/relation-map/GraphBuilder.ts
+++ b/frontend/src/components/relation-map/GraphBuilder.ts
@@ -123,6 +123,10 @@ function buildWebhookRelations(
 
   for (const wh of webhooks) {
     if (wh.default_todo_id == null) continue;
+    // 仅在目标 Todo 存在时，才创建 Webhook 节点及其边
+    // 避免出现没有连线的孤立 Webhook 节点
+    if (!existingTodoIds.has(wh.default_todo_id)) continue;
+
     nodes.push({
       id: `webhook-${wh.id}`,
       type: 'webhook',
@@ -136,20 +140,17 @@ function buildWebhookRelations(
     });
 
     const targetId = `todo-${wh.default_todo_id}`;
-    // 只关联已存在的 todo 节点
-    if (existingTodoIds.has(wh.default_todo_id)) {
-      edges.push({
-        id: `webhook-edge-${wh.id}`,
-        source: `webhook-${wh.id}`,
-        target: targetId,
-        type: 'webhook',
-        data: {
-          webhookId: wh.id,
-          webhookName: wh.name,
-        },
-        animated: false,
-      });
-    }
+    edges.push({
+      id: `webhook-edge-${wh.id}`,
+      source: `webhook-${wh.id}`,
+      target: targetId,
+      type: 'webhook',
+      data: {
+        webhookId: wh.id,
+        webhookName: wh.name,
+      },
+      animated: false,
+    });
   }
 
   return { nodes, edges };
@@ -291,11 +292,14 @@ function applyLayout(nodes: RelationMapNode[], edges: RelationMapEdge[]): Relati
 
   while (queue.length > 0) {
     const { id: srcId, layer } = queue.shift()!;
+    // 防御环路：层级超过节点数则视为出现环路，停止继续提升
+    if (layer > nodes.length) continue;
     const targets = edgeFrom.get(srcId) || [];
     for (const tId of targets) {
       const current = layers.get(tId) ?? -1;
       const newLayer = layer + 1;
-      if (newLayer > current) {
+      // 同样限制 newLayer 不得超过节点数，避免在有向环上无限自增
+      if (newLayer > current && newLayer <= nodes.length) {
         layers.set(tId, newLayer);
         queue.push({ id: tId, layer: newLayer });
       }
@@ -348,6 +352,77 @@ function applyLayout(nodes: RelationMapNode[], edges: RelationMapEdge[]): Relati
   return result;
 }
 
+/** 收集被任意关系引用到的 Todo 节点和 id 集合（与 showHooks 解耦） */
+function collectReferencedTodoIds(
+  todos: Todo[],
+  webhooks: Webhook[],
+  config: Config | null,
+): { referencedTodoIds: Set<number>; todoNodes: RelationMapNode[] } {
+  const todoMap = new Map<number, Todo>();
+  for (const t of todos) {
+    todoMap.set(t.id, t);
+  }
+
+  const referencedTodoIds = new Set<number>();
+
+  // 1. Hook 关系中涉及的 Todo
+  for (const t of todos) {
+    if (t.hooks && t.hooks.length > 0) {
+      referencedTodoIds.add(t.id);
+      for (const h of t.hooks) {
+        if (h.enabled) referencedTodoIds.add(h.target_todo_id);
+      }
+    }
+  }
+
+  // 2. Webhook 的默认目标 Todo
+  for (const wh of webhooks) {
+    if (wh.default_todo_id != null) {
+      referencedTodoIds.add(wh.default_todo_id);
+    }
+  }
+
+  // 3. 飞书斜杠命令的目标 Todo
+  for (const rule of config?.slash_command_rules || []) {
+    if (rule.enabled) referencedTodoIds.add(rule.todo_id);
+  }
+
+  // 4. 飞书默认响应 Todo
+  if (config?.default_response_todo_id) {
+    referencedTodoIds.add(config.default_response_todo_id);
+  }
+
+  // 5. 启用了调度的 Todo
+  for (const t of todos) {
+    if (t.scheduler_enabled && t.scheduler_config) {
+      referencedTodoIds.add(t.id);
+    }
+  }
+
+  // 为所有被引用的 Todo 创建基础节点（与 showHooks 解耦）
+  const todoNodes: RelationMapNode[] = [];
+  for (const id of referencedTodoIds) {
+    const t = todoMap.get(id);
+    if (!t) continue;
+    const executor = EXECUTORS.find(e => e.value === (t.executor || 'claudecode'));
+    todoNodes.push({
+      id: `todo-${id}`,
+      type: 'todo',
+      position: { x: 0, y: 0 },
+      data: {
+        title: t.title,
+        status: t.status,
+        executor: t.executor || 'claudecode',
+        executorName: executor?.label || t.executor || 'Claude',
+        hasHooks: !!(t.hooks && t.hooks.length > 0),
+        todoId: id,
+      },
+    });
+  }
+
+  return { referencedTodoIds, todoNodes };
+}
+
 /** 主构建函数 */
 export function buildRelationMap(
   todos: Todo[],
@@ -361,6 +436,11 @@ export function buildRelationMap(
   const allNodes: RelationMapNode[] = [];
   const allEdges: RelationMapEdge[] = [];
 
+  // 收集被任意关系引用到的 Todo 节点和 id 集合
+  // 这一步与 showHooks 解耦，确保关闭 Hook 开关后其它类型仍能正确指向 Todo 节点
+  const { referencedTodoIds, todoNodes } = collectReferencedTodoIds(todos, webhooks, config);
+  allNodes.push(...todoNodes);
+
   // Hook 关系
   if (showHooks) {
     const { nodes, edges } = buildHookRelations(todos);
@@ -368,18 +448,16 @@ export function buildRelationMap(
     allEdges.push(...edges);
   }
 
-  const existingTodoIds = new Set(allNodes.map(n => n.data.todoId as number).filter(Boolean));
-
-  // Webhook 关系
+  // Webhook 关系（基于被引用的 Todo id 集合，不再受 showHooks 影响）
   if (showWebhooks) {
-    const { nodes, edges } = buildWebhookRelations(webhooks, existingTodoIds);
+    const { nodes, edges } = buildWebhookRelations(webhooks, referencedTodoIds);
     allNodes.push(...nodes);
     allEdges.push(...edges);
   }
 
   // 飞书和调度器关系
   if (showFeishu || showScheduler) {
-    const { nodes, edges } = buildTriggerSourceRelations(todos, config, existingTodoIds);
+    const { nodes, edges } = buildTriggerSourceRelations(todos, config, referencedTodoIds);
     for (const n of nodes) {
       const isFeishu = n.type === 'feishu';
       const isScheduler = n.type === 'scheduler';

--- a/frontend/src/components/relation-map/GraphBuilder.ts
+++ b/frontend/src/components/relation-map/GraphBuilder.ts
@@ -1,0 +1,414 @@
+import type { Node, Edge } from '@xyflow/react';
+import type { Todo, Config, SlashCommandRule } from '../../types';
+import type { Webhook } from '../../utils/database/webhooks';
+import { EXECUTORS } from '../../types';
+
+export interface TodoNodeData extends Record<string, unknown> {
+  title: string;
+  status: string;
+  executor: string;
+  executorName: string;
+  hasHooks: boolean;
+  todoId: number;
+}
+
+export interface WebhookNodeData extends Record<string, unknown> {
+  name: string;
+  enabled: boolean;
+  webhookId: number;
+  defaultTodoId: number | null;
+}
+
+export interface FeishuNodeData extends Record<string, unknown> {
+  label: string;
+  slashCommand?: string;
+  todoId: number;
+  type: 'slash_command' | 'default_response';
+}
+
+export interface SchedulerNodeData extends Record<string, unknown> {
+  label: string;
+  cron: string;
+  todoId: number;
+}
+
+export interface HookEdgeData extends Record<string, unknown> {
+  trigger: string;
+  hookId: number;
+  enabled: boolean;
+}
+
+export interface WebhookEdgeData extends Record<string, unknown> {
+  webhookId: number;
+  webhookName: string;
+}
+
+export type RelationMapNode = Node<TodoNodeData | WebhookNodeData | FeishuNodeData | SchedulerNodeData>;
+export type RelationMapEdge = Edge<HookEdgeData | WebhookEdgeData | Record<string, unknown>>;
+
+/** 构建 Todo → Hook → Todo 的节点和边 */
+function buildHookRelations(
+  todos: Todo[],
+): { nodes: RelationMapNode[]; edges: RelationMapEdge[] } {
+  const nodes: RelationMapNode[] = [];
+  const edges: RelationMapEdge[] = [];
+  const todoMap = new Map<number, Todo>();
+
+  for (const t of todos) {
+    todoMap.set(t.id, t);
+  }
+  const hookTodoIds = new Set<number>();
+  for (const t of todos) {
+    if (t.hooks && t.hooks.length > 0) {
+      hookTodoIds.add(t.id);
+      for (const h of t.hooks) {
+        if (h.enabled) hookTodoIds.add(h.target_todo_id);
+      }
+    }
+  }
+
+  // 创建 Todo 节点
+  let todoIndex = 0;
+  for (const id of hookTodoIds) {
+    const t = todoMap.get(id);
+    if (!t) continue;
+    const executor = EXECUTORS.find(e => e.value === (t.executor || 'claudecode'));
+    nodes.push({
+      id: `todo-${id}`,
+      type: 'todo',
+      position: { x: 0, y: 0 }, // layout 会重新计算
+      data: {
+        title: t.title,
+        status: t.status,
+        executor: t.executor || 'claudecode',
+        executorName: executor?.label || t.executor || 'Claude',
+        hasHooks: !!(t.hooks && t.hooks.length > 0),
+        todoId: id,
+      },
+    });
+    todoIndex++;
+  }
+
+  // 创建 Hook 边
+  for (const t of todos) {
+    if (!t.hooks) continue;
+    for (const h of t.hooks) {
+      if (!h.enabled) continue;
+      if (!hookTodoIds.has(h.target_todo_id)) continue;
+      edges.push({
+        id: `hook-${h.id}`,
+        source: `todo-${t.id}`,
+        target: `todo-${h.target_todo_id}`,
+        type: 'hook',
+        data: {
+          trigger: h.trigger,
+          hookId: h.id,
+          enabled: h.enabled,
+        },
+        animated: false,
+      });
+    }
+  }
+
+  return { nodes, edges };
+}
+
+/** 构建 Webhook → Todo 的节点和边 */
+function buildWebhookRelations(
+  webhooks: Webhook[],
+  existingTodoIds: Set<number>,
+): { nodes: RelationMapNode[]; edges: RelationMapEdge[] } {
+  const nodes: RelationMapNode[] = [];
+  const edges: RelationMapEdge[] = [];
+
+  for (const wh of webhooks) {
+    if (wh.default_todo_id == null) continue;
+    nodes.push({
+      id: `webhook-${wh.id}`,
+      type: 'webhook',
+      position: { x: 0, y: 0 },
+      data: {
+        name: wh.name,
+        enabled: wh.enabled,
+        webhookId: wh.id,
+        defaultTodoId: wh.default_todo_id,
+      },
+    });
+
+    const targetId = `todo-${wh.default_todo_id}`;
+    // 只关联已存在的 todo 节点
+    if (existingTodoIds.has(wh.default_todo_id)) {
+      edges.push({
+        id: `webhook-edge-${wh.id}`,
+        source: `webhook-${wh.id}`,
+        target: targetId,
+        type: 'webhook',
+        data: {
+          webhookId: wh.id,
+          webhookName: wh.name,
+        },
+        animated: false,
+      });
+    }
+  }
+
+  return { nodes, edges };
+}
+
+/** 构建飞书消息 → Todo 和 调度器 → Todo 的节点和边 */
+function buildTriggerSourceRelations(
+  todos: Todo[],
+  config: Config | null,
+  existingTodoIds: Set<number>,
+): { nodes: RelationMapNode[]; edges: RelationMapEdge[] } {
+  const nodes: RelationMapNode[] = [];
+  const edges: RelationMapEdge[] = [];
+
+  // 斜杠命令规则
+  const slashRules: SlashCommandRule[] = config?.slash_command_rules || [];
+  for (const rule of slashRules) {
+    if (!rule.enabled) continue;
+    if (!existingTodoIds.has(rule.todo_id)) continue;
+    const node: RelationMapNode = {
+      id: `feishu-slash-${rule.todo_id}`,
+      type: 'feishu',
+      position: { x: 0, y: 0 },
+      data: {
+        label: '飞书命令',
+        slashCommand: rule.slash_command,
+        todoId: rule.todo_id,
+        type: 'slash_command',
+      },
+    };
+    nodes.push(node);
+    edges.push({
+      id: `feishu-slash-edge-${rule.todo_id}`,
+      source: `feishu-slash-${rule.todo_id}`,
+      target: `todo-${rule.todo_id}`,
+      type: 'feishu',
+      data: { triggerType: 'slash_command' },
+      animated: false,
+    });
+  }
+
+  // 默认响应 Todo
+  const defaultResponseTodoId = config?.default_response_todo_id;
+  if (defaultResponseTodoId && existingTodoIds.has(defaultResponseTodoId)) {
+    nodes.push({
+      id: 'feishu-default',
+      type: 'feishu',
+      position: { x: 0, y: 0 },
+      data: {
+        label: '飞书消息',
+        todoId: defaultResponseTodoId,
+        type: 'default_response',
+      },
+    });
+    edges.push({
+      id: 'feishu-default-edge',
+      source: 'feishu-default',
+      target: `todo-${defaultResponseTodoId}`,
+      type: 'feishu',
+      data: { triggerType: 'default_response' },
+      animated: false,
+    });
+  }
+
+  // 调度器节点
+  for (const t of todos) {
+    if (!t.scheduler_enabled || !t.scheduler_config) continue;
+    if (!existingTodoIds.has(t.id)) continue;
+    nodes.push({
+      id: `scheduler-${t.id}`,
+      type: 'scheduler',
+      position: { x: 0, y: 0 },
+      data: {
+        label: '定时调度',
+        cron: t.scheduler_config,
+        todoId: t.id,
+      },
+    });
+    edges.push({
+      id: `scheduler-edge-${t.id}`,
+      source: `scheduler-${t.id}`,
+      target: `todo-${t.id}`,
+      type: 'scheduler',
+      data: {},
+      animated: false,
+    });
+  }
+
+  return { nodes, edges };
+}
+
+/** 简单的分层布局算法（从左到右） */
+function applyLayout(nodes: RelationMapNode[], edges: RelationMapEdge[]): RelationMapNode[] {
+  // 分层：source 节点在左，纯目标在右
+  const sourceIds = new Set<string>();
+  const targetIds = new Set<string>();
+
+  for (const e of edges) {
+    sourceIds.add(e.source);
+    targetIds.add(e.target);
+  }
+
+  // 拓扑排序分层
+  const layers = new Map<string, number>();
+
+  // BFS 分层
+  const queue: Array<{ id: string; layer: number }> = [];
+
+  // source 节点（没有入边的）放在第 0 层
+  for (const n of nodes) {
+    if (!targetIds.has(n.id)) {
+      layers.set(n.id, 0);
+      queue.push({ id: n.id, layer: 0 });
+    }
+  }
+
+  // 如果没有纯 source，从 hook/webhook/feishu/scheduler 类型开始
+  if (queue.length === 0) {
+    for (const n of nodes) {
+      if (n.type !== 'todo') {
+        layers.set(n.id, 0);
+        queue.push({ id: n.id, layer: 0 });
+      }
+    }
+  }
+
+  // 如果还是没有，取第一个
+  if (queue.length === 0 && nodes.length > 0) {
+    layers.set(nodes[0].id, 0);
+    queue.push({ id: nodes[0].id, layer: 0 });
+  }
+
+  const edgeFrom = new Map<string, string[]>();
+  for (const e of edges) {
+    const list = edgeFrom.get(e.source) || [];
+    list.push(e.target);
+    edgeFrom.set(e.source, list);
+  }
+
+  while (queue.length > 0) {
+    const { id: srcId, layer } = queue.shift()!;
+    const targets = edgeFrom.get(srcId) || [];
+    for (const tId of targets) {
+      const current = layers.get(tId) ?? -1;
+      const newLayer = layer + 1;
+      if (newLayer > current) {
+        layers.set(tId, newLayer);
+        queue.push({ id: tId, layer: newLayer });
+      }
+    }
+  }
+
+  // 未被分配层次的节点
+  for (const n of nodes) {
+    if (!layers.has(n.id)) {
+      layers.set(n.id, 1);
+    }
+  }
+
+  // 按层分组
+  const layerGroups = new Map<number, RelationMapNode[]>();
+  for (const n of nodes) {
+    const l = layers.get(n.id) || 0;
+    const group = layerGroups.get(l) || [];
+    group.push(n);
+    layerGroups.set(l, group);
+  }
+
+  const H_GAP = 280;
+  const V_GAP = 100;
+  const result: RelationMapNode[] = [];
+
+  const sortedLayers = Array.from(layerGroups.entries()).sort((a, b) => a[0] - b[0]);
+  for (const [, group] of sortedLayers) {
+    // 按类型排序：source 类型在上，todo 在下
+    const sorted = [...group].sort((a, b) => {
+      const typeOrder: Record<string, number> = { webhook: 0, feishu: 1, scheduler: 2, todo: 3 };
+      return (typeOrder[a.type || ''] ?? 3) - (typeOrder[b.type || ''] ?? 3);
+    });
+
+    const totalHeight = sorted.length * V_GAP;
+    const startY = -totalHeight / 2;
+
+    for (let i = 0; i < sorted.length; i++) {
+      const layer = layers.get(sorted[i].id) || 0;
+      result.push({
+        ...sorted[i],
+        position: {
+          x: layer * H_GAP,
+          y: startY + i * V_GAP,
+        },
+      });
+    }
+  }
+
+  return result;
+}
+
+/** 主构建函数 */
+export function buildRelationMap(
+  todos: Todo[],
+  webhooks: Webhook[],
+  config: Config | null,
+  showHooks: boolean,
+  showWebhooks: boolean,
+  showFeishu: boolean,
+  showScheduler: boolean,
+): { nodes: RelationMapNode[]; edges: RelationMapEdge[] } {
+  const allNodes: RelationMapNode[] = [];
+  const allEdges: RelationMapEdge[] = [];
+
+  // Hook 关系
+  if (showHooks) {
+    const { nodes, edges } = buildHookRelations(todos);
+    allNodes.push(...nodes);
+    allEdges.push(...edges);
+  }
+
+  const existingTodoIds = new Set(allNodes.map(n => n.data.todoId as number).filter(Boolean));
+
+  // Webhook 关系
+  if (showWebhooks) {
+    const { nodes, edges } = buildWebhookRelations(webhooks, existingTodoIds);
+    allNodes.push(...nodes);
+    allEdges.push(...edges);
+  }
+
+  // 飞书和调度器关系
+  if (showFeishu || showScheduler) {
+    const { nodes, edges } = buildTriggerSourceRelations(todos, config, existingTodoIds);
+    for (const n of nodes) {
+      const isFeishu = n.type === 'feishu';
+      const isScheduler = n.type === 'scheduler';
+      if ((isFeishu && showFeishu) || (isScheduler && showScheduler)) {
+        allNodes.push(n);
+      }
+    }
+    for (const e of edges) {
+      const isFeishuEdge = e.type === 'feishu';
+      const isSchedulerEdge = e.type === 'scheduler';
+      if ((isFeishuEdge && showFeishu) || (isSchedulerEdge && showScheduler)) {
+        allEdges.push(e);
+      }
+    }
+  }
+
+  // 去重节点（同一个 todo 可能被多种方式关联）
+  const uniqueNodes = new Map<string, RelationMapNode>();
+  for (const n of allNodes) {
+    uniqueNodes.set(n.id, n);
+  }
+
+  // 去重边
+  const uniqueEdges = new Map<string, RelationMapEdge>();
+  for (const e of allEdges) {
+    uniqueEdges.set(e.id, e);
+  }
+
+  const nodes = applyLayout(Array.from(uniqueNodes.values()), Array.from(uniqueEdges.values()));
+
+  return { nodes, edges: Array.from(uniqueEdges.values()) };
+}

--- a/frontend/src/components/relation-map/Nodes.tsx
+++ b/frontend/src/components/relation-map/Nodes.tsx
@@ -63,7 +63,7 @@ export function TodoNode({ data, selected }: NodeProps & { data: TodoNodeData })
 /** Webhook 节点 */
 export function WebhookNode({ data, selected }: NodeProps & { data: WebhookNodeData }) {
   return (
-    <div className={`relation-map-node webhook-node ${selected ? 'selected' : ''}`}>
+    <div className={`relation-map-node source-node webhook-node ${selected ? 'selected' : ''}`}>
       <Handle type="source" position={Position.Right} className="relation-map-handle" />
 
       <div className="source-node-icon" style={{ background: '#722ed1' }}>

--- a/frontend/src/components/relation-map/Nodes.tsx
+++ b/frontend/src/components/relation-map/Nodes.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useMemo } from 'react';
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { Tag } from 'antd';
+import {
+  CheckCircleOutlined,
+  ClockCircleOutlined,
+  ExclamationCircleOutlined,
+  PlayCircleOutlined,
+  ApiOutlined,
+  MessageOutlined,
+  ScheduleOutlined,
+} from '@ant-design/icons';
+import { getExecutorColor } from '../../types';
+import type { TodoNodeData, WebhookNodeData, FeishuNodeData, SchedulerNodeData } from './types';
+
+const STATUS_CONFIG: Record<string, { color: string; icon: React.ReactNode; label: string }> = {
+  pending: { color: '#8c8c8c', icon: <ClockCircleOutlined />, label: '待执行' },
+  in_progress: { color: '#1677ff', icon: <PlayCircleOutlined />, label: '进行中' },
+  running: { color: '#1677ff', icon: <PlayCircleOutlined />, label: '执行中' },
+  completed: { color: '#52c41a', icon: <CheckCircleOutlined />, label: '已完成' },
+  failed: { color: '#ff4d4f', icon: <ExclamationCircleOutlined />, label: '失败' },
+};
+
+/** Todo 节点 */
+export function TodoNode({ data, selected }: NodeProps & { data: TodoNodeData }) {
+  const status = STATUS_CONFIG[data.status] || STATUS_CONFIG.pending;
+  const executorColor = getExecutorColor(data.executor);
+  const isRunning = data.status === 'running' || data.status === 'in_progress';
+
+  return (
+    <div
+      className={`relation-map-node todo-node ${selected ? 'selected' : ''} ${isRunning ? 'running' : ''}`}
+      style={{ '--status-color': status.color, '--executor-color': executorColor } as React.CSSProperties}
+    >
+      <Handle type="target" position={Position.Left} className="relation-map-handle" />
+
+      <div className="todo-node-header">
+        <span className="todo-node-status-icon" style={{ color: status.color }}>{status.icon}</span>
+        <span className="todo-node-title">{data.title}</span>
+      </div>
+
+      <div className="todo-node-footer">
+        <Tag
+          color={executorColor}
+          style={{ fontSize: 11, lineHeight: '18px', padding: '0 4px', margin: 0, borderRadius: 4 }}
+        >
+          {data.executorName || data.executor || 'claudecode'}
+        </Tag>
+        <span className="todo-node-status" style={{ color: status.color }}>{status.label}</span>
+      </div>
+
+      {data.hasHooks && (
+        <div className="todo-node-hook-indicator" title="有 Hook 关联">H</div>
+      )}
+
+      {isRunning && <div className="todo-node-pulse" />}
+
+      <Handle type="source" position={Position.Right} className="relation-map-handle" />
+    </div>
+  );
+}
+
+/** Webhook 节点 */
+export function WebhookNode({ data, selected }: NodeProps & { data: WebhookNodeData }) {
+  return (
+    <div className={`relation-map-node webhook-node ${selected ? 'selected' : ''}`}>
+      <Handle type="source" position={Position.Right} className="relation-map-handle" />
+
+      <div className="source-node-icon" style={{ background: '#722ed1' }}>
+        <ApiOutlined style={{ color: '#fff', fontSize: 18 }} />
+      </div>
+      <div className="source-node-label">{data.name}</div>
+      {data.enabled ? (
+        <Tag color="green" style={{ fontSize: 10, lineHeight: '16px', padding: '0 4px', margin: 0 }}>已启用</Tag>
+      ) : (
+        <Tag color="default" style={{ fontSize: 10, lineHeight: '16px', padding: '0 4px', margin: 0 }}>已禁用</Tag>
+      )}
+    </div>
+  );
+}
+
+/** 飞书消息节点 */
+export function FeishuNode({ data, selected }: NodeProps & { data: FeishuNodeData }) {
+  return (
+    <div className={`relation-map-node source-node feishu-node ${selected ? 'selected' : ''}`}>
+      <Handle type="source" position={Position.Right} className="relation-map-handle" />
+
+      <div className="source-node-icon" style={{ background: '#1890ff' }}>
+        <MessageOutlined style={{ color: '#fff', fontSize: 18 }} />
+      </div>
+      <div className="source-node-label">{data.label}</div>
+      {data.slashCommand && (
+        <Tag color="blue" style={{ fontSize: 10, lineHeight: '16px', padding: '0 4px', margin: 0 }}>
+          {data.slashCommand}
+        </Tag>
+      )}
+    </div>
+  );
+}
+
+/** 调度器节点 */
+export function SchedulerNode({ data, selected }: NodeProps & { data: SchedulerNodeData }) {
+  return (
+    <div className={`relation-map-node source-node scheduler-node ${selected ? 'selected' : ''}`}>
+      <Handle type="source" position={Position.Right} className="relation-map-handle" />
+
+      <div className="source-node-icon" style={{ background: '#fa8c16' }}>
+        <ScheduleOutlined style={{ color: '#fff', fontSize: 18 }} />
+      </div>
+      <div className="source-node-label">{data.label}</div>
+      {data.cron && (
+        <Tag color="orange" style={{ fontSize: 10, lineHeight: '16px', padding: '0 4px', margin: 0 }}>
+          {data.cron}
+        </Tag>
+      )}
+    </div>
+  );
+}
+
+/** Hook 边的标签 */
+export function HookEdgeLabel({ trigger }: { trigger: string }) {
+  const getTriggerInfo = useCallback((t: string) => {
+    switch (t) {
+      case 'state_changed_to_completed':
+        return { label: 'completed', color: '#52c41a' };
+      case 'state_changed_to_failed':
+        return { label: 'failed', color: '#ff4d4f' };
+      case 'state_changed_to_pending':
+        return { label: 'pending', color: '#8c8c8c' };
+      case 'state_changed_to_in_progress':
+        return { label: 'in_progress', color: '#1677ff' };
+      default:
+        return { label: t, color: '#999' };
+    }
+  }, []);
+
+  const info = useMemo(() => getTriggerInfo(trigger), [trigger, getTriggerInfo]);
+
+  return (
+    <div className="hook-edge-label" style={{ borderColor: info.color }}>
+      <span style={{ color: info.color, fontSize: 10 }}>{info.label}</span>
+      <span style={{ fontSize: 9, color: '#999' }}>→</span>
+    </div>
+  );
+}

--- a/frontend/src/components/relation-map/RelationMap.tsx
+++ b/frontend/src/components/relation-map/RelationMap.tsx
@@ -1,0 +1,219 @@
+import { useState, useEffect, useMemo } from 'react';
+import {
+  ReactFlow,
+  Background,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+  type NodeTypes,
+  type EdgeTypes,
+  Panel,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { Switch, Empty, Spin } from 'antd';
+import {
+  ApiOutlined,
+  MessageOutlined,
+  ScheduleOutlined,
+  LinkOutlined,
+} from '@ant-design/icons';
+import { useApp } from '../../hooks/useApp';
+import { useTheme } from '../../hooks/useTheme';
+import * as db from '../../utils/database';
+import type { Webhook } from '../../utils/database/webhooks';
+import type { Config } from '../../types';
+import { TodoNode, WebhookNode, FeishuNode, SchedulerNode } from './Nodes';
+import { HookEdge, WebhookEdge, FeishuEdge, SchedulerEdge } from './Edges';
+import { buildRelationMap } from './GraphBuilder';
+import './relation-map.css';
+
+const nodeTypes: NodeTypes = {
+  todo: TodoNode,
+  webhook: WebhookNode,
+  feishu: FeishuNode,
+  scheduler: SchedulerNode,
+};
+
+const edgeTypes: EdgeTypes = {
+  hook: HookEdge,
+  webhook: WebhookEdge,
+  feishu: FeishuEdge,
+  scheduler: SchedulerEdge,
+};
+
+export function RelationMap() {
+  const { state } = useApp();
+  const { themeMode } = useTheme();
+  const [webhooks, setWebhooks] = useState<Webhook[]>([]);
+  const [config, setConfig] = useState<Config | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // 过滤器
+  const [showHooks, setShowHooks] = useState(true);
+  const [showWebhooks, setShowWebhooks] = useState(true);
+  const [showFeishu, setShowFeishu] = useState(true);
+  const [showScheduler, setShowScheduler] = useState(true);
+
+  // 加载额外数据
+  useEffect(() => {
+    Promise.all([
+      db.getWebhooks().catch(() => []),
+      db.getConfig().catch(() => null),
+    ]).then(([wh, cfg]) => {
+      setWebhooks(wh as Webhook[]);
+      setConfig(cfg as Config | null);
+      setLoading(false);
+    });
+  }, []);
+
+  // 构建图数据
+  const { nodes: builtNodes, edges: builtEdges } = useMemo(
+    () => buildRelationMap(state.todos, webhooks, config, showHooks, showWebhooks, showFeishu, showScheduler),
+    [state.todos, webhooks, config, showHooks, showWebhooks, showFeishu, showScheduler],
+  );
+
+  const [nodes, setNodes, onNodesChange] = useNodesState(builtNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(builtEdges);
+
+  // 当构建数据变化时同步
+  useEffect(() => {
+    setNodes(builtNodes);
+    setEdges(builtEdges);
+  }, [builtNodes, builtEdges, setNodes, setEdges]);
+
+  // 实时状态更新：当有 todo 状态变化时，更新对应节点的数据
+  useEffect(() => {
+    setNodes(nds =>
+      nds.map(n => {
+        if (n.type !== 'todo') return n;
+        const todoId = n.data?.todoId as number;
+        if (!todoId) return n;
+        const todo = state.todos.find(t => t.id === todoId);
+        if (!todo) return n;
+        if (n.data?.status === todo.status) return n;
+        return {
+          ...n,
+          data: {
+            ...n.data,
+            status: todo.status,
+          },
+        };
+      }),
+    );
+  }, [state.todos, setNodes]);
+
+  const isDark = themeMode === 'dark';
+
+  if (loading) {
+    return (
+      <div className="relation-map-loading">
+        <Spin size="large" description="加载关联图数据..." />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`relation-map-container ${isDark ? 'dark' : 'light'}`}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        fitView
+        fitViewOptions={{ padding: 0.6 }}
+        minZoom={0.1}
+        maxZoom={2}
+        proOptions={{ hideAttribution: true }}
+        className="relation-map-canvas"
+      >
+        <Background
+          color={isDark ? '#333' : '#ddd'}
+          gap={20}
+          size={1}
+        />
+        <MiniMap
+          nodeColor={(node) => {
+            if (node.type === 'webhook') return '#722ed1';
+            if (node.type === 'feishu') return '#1890ff';
+            if (node.type === 'scheduler') return '#fa8c16';
+            // todo 节点按状态着色
+            const status = node.data?.status as string;
+            switch (status) {
+              case 'running': return '#1677ff';
+              case 'completed': return '#52c41a';
+              case 'failed': return '#ff4d4f';
+              default: return '#8c8c8c';
+            }
+          }}
+          maskColor={isDark ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.6)'}
+          style={{ borderRadius: 8 }}
+        />
+
+        {/* 右侧过滤面板 */}
+        <Panel position="top-right" className="relation-map-filters">
+          <div className="filter-group">
+            <div className="filter-item">
+              <LinkOutlined style={{ color: '#52c41a', marginRight: 4 }} />
+              <span className="filter-label">Hook</span>
+              <Switch size="small" checked={showHooks} onChange={setShowHooks} />
+            </div>
+            <div className="filter-item">
+              <ApiOutlined style={{ color: '#722ed1', marginRight: 4 }} />
+              <span className="filter-label">Webhook</span>
+              <Switch size="small" checked={showWebhooks} onChange={setShowWebhooks} />
+            </div>
+            <div className="filter-item">
+              <MessageOutlined style={{ color: '#1890ff', marginRight: 4 }} />
+              <span className="filter-label">飞书</span>
+              <Switch size="small" checked={showFeishu} onChange={setShowFeishu} />
+            </div>
+            <div className="filter-item">
+              <ScheduleOutlined style={{ color: '#fa8c16', marginRight: 4 }} />
+              <span className="filter-label">调度</span>
+              <Switch size="small" checked={showScheduler} onChange={setShowScheduler} />
+            </div>
+          </div>
+        </Panel>
+
+        {/* 底部图例 */}
+        <Panel position="bottom-left" className="relation-map-legend">
+          <div className="legend-item">
+            <span className="legend-line solid" style={{ background: '#52c41a' }} />
+            <span>Hook（实线）</span>
+          </div>
+          <div className="legend-item">
+            <span className="legend-line dashed" style={{ background: '#722ed1' }} />
+            <span>Webhook（虚线）</span>
+          </div>
+          <div className="legend-item">
+            <span className="legend-line dotted" style={{ background: '#1890ff' }} />
+            <span>飞书消息（点线）</span>
+          </div>
+          <div className="legend-item">
+            <span className="legend-line dashed-long" style={{ background: '#fa8c16' }} />
+            <span>定时调度（长虚线）</span>
+          </div>
+        </Panel>
+
+        {/* 空状态提示 - 画板内居中 */}
+        {builtNodes.length === 0 && (
+          <Panel position="top-center" className="relation-map-empty-panel">
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description={
+                <div>
+                  <p style={{ color: 'var(--color-text-secondary)', marginBottom: 8 }}>暂无关联关系</p>
+                  <p style={{ color: 'var(--color-text-tertiary)', fontSize: 13 }}>
+                    为 Todo 添加 Hook 或配置 Webhook 后，关联关系将在此显示
+                  </p>
+                </div>
+              }
+            />
+          </Panel>
+        )}
+      </ReactFlow>
+    </div>
+  );
+}

--- a/frontend/src/components/relation-map/RelationMap.tsx
+++ b/frontend/src/components/relation-map/RelationMap.tsx
@@ -10,12 +10,13 @@ import {
   Panel,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { Switch, Empty, Spin } from 'antd';
+import { Switch, Empty, Spin, Button } from 'antd';
 import {
   ApiOutlined,
   MessageOutlined,
   ScheduleOutlined,
   LinkOutlined,
+  LeftOutlined,
 } from '@ant-design/icons';
 import { useApp } from '../../hooks/useApp';
 import { useTheme } from '../../hooks/useTheme';
@@ -41,7 +42,11 @@ const edgeTypes: EdgeTypes = {
   scheduler: SchedulerEdge,
 };
 
-export function RelationMap() {
+interface RelationMapProps {
+  onBack?: () => void;
+}
+
+export function RelationMap({ onBack }: RelationMapProps) {
   const { state } = useApp();
   const { themeMode } = useTheme();
   const [webhooks, setWebhooks] = useState<Webhook[]>([]);
@@ -114,6 +119,16 @@ export function RelationMap() {
 
   return (
     <div className={`relation-map-container ${isDark ? 'dark' : 'light'}`}>
+      {onBack && (
+        <Button
+          type="text"
+          size="small"
+          icon={<LeftOutlined />}
+          onClick={onBack}
+          className="relation-map-back-btn"
+          aria-label="返回"
+        />
+      )}
       <ReactFlow
         nodes={nodes}
         edges={edges}

--- a/frontend/src/components/relation-map/index.ts
+++ b/frontend/src/components/relation-map/index.ts
@@ -1,0 +1,1 @@
+export { RelationMap } from './RelationMap';

--- a/frontend/src/components/relation-map/relation-map.css
+++ b/frontend/src/components/relation-map/relation-map.css
@@ -8,6 +8,16 @@
   position: relative;
 }
 
+.relation-map-back-btn {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 10;
+  background: var(--color-bg-container, #ffffff) !important;
+  border: 1px solid var(--color-border-secondary, #334155) !important;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08) !important;
+}
+
 .relation-map-container.dark {
   background: #0f172a;
 }
@@ -339,8 +349,8 @@
 .legend-line.dashed {
   background: repeating-linear-gradient(
     90deg,
-    currentColor 0,
-    currentColor 4px,
+    currentcolor 0,
+    currentcolor 4px,
     transparent 4px,
     transparent 7px
   ) !important;
@@ -349,8 +359,8 @@
 .legend-line.dotted {
   background: repeating-linear-gradient(
     90deg,
-    currentColor 0,
-    currentColor 2px,
+    currentcolor 0,
+    currentcolor 2px,
     transparent 2px,
     transparent 5px
   ) !important;
@@ -359,8 +369,8 @@
 .legend-line.dashed-long {
   background: repeating-linear-gradient(
     90deg,
-    currentColor 0,
-    currentColor 6px,
+    currentcolor 0,
+    currentcolor 6px,
     transparent 6px,
     transparent 10px
   ) !important;

--- a/frontend/src/components/relation-map/relation-map.css
+++ b/frontend/src/components/relation-map/relation-map.css
@@ -1,0 +1,375 @@
+/* ===== Relation Map 画板 ===== */
+
+.relation-map-container {
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+  overflow: hidden;
+  position: relative;
+}
+
+.relation-map-container.dark {
+  background: #0f172a;
+}
+
+.relation-map-container.light {
+  background: #f8fafc;
+}
+
+.relation-map-canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.relation-map-empty-panel {
+  position: absolute !important;
+  top: 50% !important;
+  left: 50% !important;
+  transform: translate(-50%, -50%) !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  pointer-events: none;
+}
+
+.relation-map-loading,
+.relation-map-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+}
+
+/* ===== 通用节点样式 ===== */
+
+.relation-map-node {
+  position: relative;
+  border-radius: 10px;
+  padding: 10px 14px;
+  min-width: 140px;
+  max-width: 220px;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.relation-map-node.selected {
+  box-shadow: 0 0 0 2px var(--ant-color-primary, #1677ff);
+}
+
+/* ===== Handle 样式 ===== */
+
+.relation-map-handle {
+  width: 8px !important;
+  height: 8px !important;
+  border-radius: 50% !important;
+  background: #555 !important;
+  border: 2px solid #333 !important;
+}
+
+/* ===== Todo 节点 ===== */
+
+.todo-node {
+  background: var(--color-bg-elevated, #1e1e2e);
+  border: 1px solid var(--color-border-secondary, #333);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.dark .todo-node {
+  background: #1e293b;
+  border-color: #334155;
+}
+
+.light .todo-node {
+  background: #ffffff;
+  border-color: #e2e8f0;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.todo-node:hover {
+  border-color: var(--status-color, #1677ff);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.todo-node.running {
+  border-color: #1677ff;
+}
+
+.todo-node-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.todo-node-status-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.todo-node-title {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text, #f8fafc);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  line-height: 1.4;
+}
+
+.light .todo-node-title {
+  color: #1e293b;
+}
+
+.todo-node-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.todo-node-status {
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.todo-node-hook-indicator {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #52c41a;
+  color: #fff;
+  font-size: 9px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 1px 4px rgba(82, 196, 26, 0.4);
+}
+
+/* Running 脉冲动画 */
+.todo-node-pulse {
+  position: absolute;
+  inset: -3px;
+  border-radius: 12px;
+  border: 2px solid #1677ff;
+  animation: pulse-ring 2s ease-out infinite;
+  pointer-events: none;
+}
+
+@keyframes pulse-ring {
+  0% {
+    opacity: 0.8;
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .todo-node-pulse {
+    animation: none;
+    border-style: dashed;
+    opacity: 0.5;
+  }
+}
+
+/* ===== Source 节点通用（Webhook/Feishu/Scheduler）===== */
+
+.source-node {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 12px;
+  min-width: 100px;
+}
+
+.source-node-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.source-node-label {
+  font-size: 11px;
+  color: var(--color-text-secondary, #94a3b8);
+  text-align: center;
+  line-height: 1.3;
+}
+
+/* ===== Webhook 节点 ===== */
+
+.webhook-node {
+  background: var(--color-bg-elevated, #1e1e2e);
+  border: 1.5px dashed #722ed1;
+}
+
+.dark .webhook-node {
+  background: #1e1533;
+  border-color: #722ed1;
+}
+
+.light .webhook-node {
+  background: #faf5ff;
+  border-color: #d3adf7;
+}
+
+/* ===== Feishu 节点 ===== */
+
+.feishu-node {
+  background: var(--color-bg-elevated, #1e1e2e);
+  border: 1.5px dashed #1890ff;
+}
+
+.dark .feishu-node {
+  background: #0c1929;
+  border-color: #1890ff;
+}
+
+.light .feishu-node {
+  background: #f0f5ff;
+  border-color: #91caff;
+}
+
+/* ===== Scheduler 节点 ===== */
+
+.scheduler-node {
+  background: var(--color-bg-elevated, #1e1e2e);
+  border: 1.5px dashed #fa8c16;
+}
+
+.dark .scheduler-node {
+  background: #1c1508;
+  border-color: #fa8c16;
+}
+
+.light .scheduler-node {
+  background: #fff8f0;
+  border-color: #ffd591;
+}
+
+/* ===== 过滤面板 ===== */
+
+.relation-map-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--color-bg-elevated, #1e293b);
+  padding: 10px 12px !important;
+  border-radius: 0 0 0 10px;
+  border-left: 1px solid var(--color-border-secondary, #334155);
+  border-bottom: 1px solid var(--color-border-secondary, #334155);
+}
+
+.light .relation-map-filters {
+  background: #ffffff;
+  border-color: #e2e8f0;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.filter-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.filter-label {
+  font-size: 12px;
+  color: var(--color-text-secondary, #94a3b8);
+  min-width: 40px;
+}
+
+.light .filter-label {
+  color: #64748b;
+}
+
+/* ===== 图例 ===== */
+
+.relation-map-legend {
+  display: flex;
+  gap: 16px;
+  background: var(--color-bg-elevated, #1e293b);
+  padding: 6px 14px !important;
+  border-radius: 0 8px 0 0;
+  border-top: 1px solid var(--color-border-secondary, #334155);
+  border-right: 1px solid var(--color-border-secondary, #334155);
+}
+
+.light .relation-map-legend {
+  background: #ffffff;
+  border-color: #e2e8f0;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--color-text-secondary, #94a3b8);
+}
+
+.light .legend-item {
+  color: #64748b;
+}
+
+.legend-line {
+  display: inline-block;
+  width: 24px;
+  height: 2px;
+}
+
+.legend-line.solid {
+  height: 2px;
+}
+
+.legend-line.dashed {
+  background: repeating-linear-gradient(
+    90deg,
+    currentColor 0,
+    currentColor 4px,
+    transparent 4px,
+    transparent 7px
+  ) !important;
+}
+
+.legend-line.dotted {
+  background: repeating-linear-gradient(
+    90deg,
+    currentColor 0,
+    currentColor 2px,
+    transparent 2px,
+    transparent 5px
+  ) !important;
+}
+
+.legend-line.dashed-long {
+  background: repeating-linear-gradient(
+    90deg,
+    currentColor 0,
+    currentColor 6px,
+    transparent 6px,
+    transparent 10px
+  ) !important;
+}
+
+/* ===== MiniMap 覆盖 ===== */
+
+.relation-map-container .react-flow__minimap {
+  border-radius: 8px;
+  border: 1px solid var(--color-border-secondary, #334155);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}

--- a/frontend/src/components/relation-map/types.ts
+++ b/frontend/src/components/relation-map/types.ts
@@ -1,0 +1,13 @@
+export { TodoNode, WebhookNode, FeishuNode, SchedulerNode } from './Nodes';
+export { HookEdge, WebhookEdge, FeishuEdge, SchedulerEdge } from './Edges';
+export { buildRelationMap } from './GraphBuilder';
+export type {
+  TodoNodeData,
+  WebhookNodeData,
+  FeishuNodeData,
+  SchedulerNodeData,
+  HookEdgeData,
+  WebhookEdgeData,
+  RelationMapNode,
+  RelationMapEdge,
+} from './GraphBuilder';


### PR DESCRIPTION
## 功能概述

新增 Todo 关联图（Relation Map），基于 React Flow 可视化展示 Todo 之间的关联关系。

### 主要特性
- **四种关联类型可视化**：Hook、Webhook、飞书消息、定时调度
- **自定义节点**：TodoNode / WebhookNode / FeishuNode / SchedulerNode，运行中 Todo 带脉冲动画
- **自定义边样式**：实线（Hook）、虚线（Webhook）、点线（飞书）、长虚线（调度）
- **右侧过滤面板**：按类型开关显示关联
- **底部图例**：说明各线型含义
- **BFS 拓扑布局**：自动排列节点，左到右分层
- **实时状态更新**：Todo 状态变化实时反映到图中
- **默认缩放调小**：初始视图显示更完整的全局关系

### 文件变更
- 新增 `frontend/src/components/relation-map/` 目录（RelationMap、Nodes、Edges、GraphBuilder、CSS）
- 修改 `App.tsx`：添加关联图视图路由
- 修改 `TodoList.tsx`：添加关联图入口按钮
- 添加 `@xyflow/react` 依赖