### PR TITLE
fix(webhooks-panel): redesign Webhook list for mobile

### DIFF
--- a/frontend/src/components/WebhooksPanel.tsx
+++ b/frontend/src/components/WebhooksPanel.tsx
@@ -60,9 +60,17 @@ function CopyableUrl({ url, compact }: { url: string; compact: boolean }) {
         type="text"
         size="small"
         icon={<LinkOutlined />}
-        onClick={() => {
-          navigator.clipboard?.writeText(url);
-          message.success('已复制 URL');
+        onClick={async () => {
+          if (!navigator.clipboard?.writeText) {
+            message.error('当前环境不支持复制');
+            return;
+          }
+          try {
+            await navigator.clipboard.writeText(url);
+            message.success('已复制 URL');
+          } catch {
+            message.error('复制失败，请手动复制');
+          }
         }}
         style={{
           padding: compact ? '0 6px' : '0 8px',
@@ -73,12 +81,15 @@ function CopyableUrl({ url, compact }: { url: string; compact: boolean }) {
         }}
       >
         <span
-          style={{
+          style={compact ? {
             display: 'inline-block',
-            maxWidth: compact ? 180 : 240,
+            maxWidth: 180,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
+            verticalAlign: 'bottom',
+          } : {
+            display: 'inline-block',
             verticalAlign: 'bottom',
           }}
         >
@@ -505,19 +516,22 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
                     )}
                   </>
                 ) : (
-                  <>
-                    <Table
-                      dataSource={webhooks}
-                      columns={webhookColumns}
-                      rowKey="id"
-                      loading={webhooksLoading}
-                      pagination={false}
-                      size="small"
-                    />
-                    {webhooks.length === 0 && !webhooksLoading && (
-                      <Empty description="暂无 Webhook，点击添加按钮创建" style={{ marginTop: 24 }} />
-                    )}
-                  </>
+                  <Table
+                    dataSource={webhooks}
+                    columns={webhookColumns}
+                    rowKey="id"
+                    loading={webhooksLoading}
+                    pagination={false}
+                    size="small"
+                    locale={{
+                      emptyText: (
+                        <Empty
+                          description="暂无 Webhook，点击添加按钮创建"
+                          style={{ marginTop: 24 }}
+                        />
+                      ),
+                    }}
+                  />
                 )}
               </Card>
             ),

--- a/frontend/src/components/WebhooksPanel.tsx
+++ b/frontend/src/components/WebhooksPanel.tsx
@@ -15,7 +15,7 @@ import {
   Descriptions,
   Tabs,
   Empty,
-  Typography,
+  Tooltip,
 } from 'antd';
 import {
   PlusOutlined,
@@ -23,16 +23,196 @@ import {
   EditOutlined,
   ApiOutlined,
   HistoryOutlined,
+  LinkOutlined,
+  CopyOutlined,
 } from '@ant-design/icons';
 import * as db from '../utils/database';
 import type { Webhook, WebhookRecord } from '../utils/database';
 import type { Todo } from '../types';
+import { useIsMobile } from '../hooks/useIsMobile';
 
 interface WebhooksPanelProps {
   todos: Todo[];
 }
 
+/** 单个 URL 的复制块：移动端省略中间，桌面端显示全文（仍可复制） */
+function CopyableUrl({ url, compact }: { url: string; compact: boolean }) {
+  const display = useMemo(() => {
+    if (!compact) return url;
+    // 移动端：保留协议+域名+末尾路径关键部分，中间省略
+    try {
+      const u = new URL(url);
+      const path = u.pathname;
+      if (path.length <= 14) return `${u.host}${path}`;
+      const head = path.slice(0, 8);
+      const tail = path.slice(-6);
+      return `${u.host}${head}…${tail}`;
+    } catch {
+      // 退化为简单截断
+      if (url.length <= 28) return url;
+      return `${url.slice(0, 14)}…${url.slice(-8)}`;
+    }
+  }, [url, compact]);
+
+  return (
+    <Tooltip title={url} mouseEnterDelay={0.4}>
+      <Button
+        type="text"
+        size="small"
+        icon={<LinkOutlined />}
+        onClick={() => {
+          navigator.clipboard?.writeText(url);
+          message.success('已复制 URL');
+        }}
+        style={{
+          padding: compact ? '0 6px' : '0 8px',
+          height: compact ? 24 : 28,
+          fontSize: compact ? 11 : 12,
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          maxWidth: '100%',
+        }}
+      >
+        <span
+          style={{
+            display: 'inline-block',
+            maxWidth: compact ? 180 : 240,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            verticalAlign: 'bottom',
+          }}
+        >
+          {display}
+        </span>
+        <CopyOutlined style={{ fontSize: 11, marginLeft: 4, opacity: 0.6 }} />
+      </Button>
+    </Tooltip>
+  );
+}
+
+/** 移动端单条 webhook 卡片 */
+function WebhookCard({
+  webhook,
+  todo,
+  baseUrl,
+  onEdit,
+  onDelete,
+  onToggle,
+}: {
+  webhook: Webhook;
+  todo: Todo | undefined;
+  baseUrl: string;
+  onEdit: () => void;
+  onDelete: () => void;
+  onToggle: () => void;
+}) {
+  return (
+    <Card
+      size="small"
+      style={{ marginBottom: 12 }}
+      styles={{ body: { padding: 12 } }}
+    >
+      {/* 顶部：名称 + 启用开关 + 操作 */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 8,
+          marginBottom: 8,
+        }}
+      >
+        <div
+          style={{
+            fontWeight: 500,
+            fontSize: 14,
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          title={webhook.name}
+        >
+          {webhook.name}
+        </div>
+        <Space size={4} style={{ flexShrink: 0 }}>
+          <Switch
+            checked={webhook.enabled}
+            onChange={onToggle}
+            size="small"
+          />
+          <Button
+            type="text"
+            size="small"
+            icon={<EditOutlined />}
+            onClick={onEdit}
+            aria-label="编辑"
+          />
+          <Popconfirm
+            title="确定删除此 Webhook？"
+            onConfirm={onDelete}
+            okType="danger"
+          >
+            <Button
+              type="text"
+              size="small"
+              danger
+              icon={<DeleteOutlined />}
+              aria-label="删除"
+            />
+          </Popconfirm>
+        </Space>
+      </div>
+
+      {/* 默认触发 Todo */}
+      <div
+        style={{
+          fontSize: 12,
+          color: 'var(--color-text-secondary)',
+          marginBottom: 6,
+          display: 'flex',
+          gap: 4,
+        }}
+      >
+        <span style={{ flexShrink: 0 }}>默认 Todo：</span>
+        <span
+          style={{
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          title={todo?.title || (webhook.default_todo_id ? `Todo #${webhook.default_todo_id}` : '')}
+        >
+          {webhook.default_todo_id
+            ? (todo?.title || `Todo #${webhook.default_todo_id}`)
+            : <span style={{ opacity: 0.5 }}>未设置</span>}
+        </span>
+      </div>
+
+      {/* URL 区域 */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 6 }}>
+        <CopyableUrl url={`${baseUrl}/webhook/trigger`} compact />
+        {webhook.default_todo_id && (
+          <CopyableUrl
+            url={`${baseUrl}/webhook/trigger/${webhook.default_todo_id}`}
+            compact
+          />
+        )}
+      </div>
+
+      {/* 创建时间 */}
+      <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>
+        创建：{webhook.created_at ? new Date(webhook.created_at).toLocaleString() : '-'}
+      </div>
+    </Card>
+  );
+}
+
 export function WebhooksPanel({ todos }: WebhooksPanelProps) {
+  const isMobile = useIsMobile();
   const [webhooks, setWebhooks] = useState<Webhook[]>([]);
   const [webhooksLoading, setWebhooksLoading] = useState(false);
   const [webhookFormOpen, setWebhookFormOpen] = useState(false);
@@ -168,22 +348,15 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
     {
       title: '触发 URL',
       key: 'urls',
-      width: 300,
+      width: 320,
       render: (_: any, record: Webhook) => (
-        <Space direction="vertical" size={4}>
-          <Typography.Text
-            copyable={{ text: `${baseUrl}/webhook/trigger` }}
-            style={{ fontSize: 11 }}
-          >
-            <code>{baseUrl}/webhook/trigger</code>
-          </Typography.Text>
+        <Space direction="vertical" size={4} style={{ width: '100%' }}>
+          <CopyableUrl url={`${baseUrl}/webhook/trigger`} compact={false} />
           {record.default_todo_id && (
-            <Typography.Text
-              copyable={{ text: `${baseUrl}/webhook/trigger/${record.default_todo_id}` }}
-              style={{ fontSize: 11 }}
-            >
-              <code>{baseUrl}/webhook/trigger/{record.default_todo_id}</code>
-            </Typography.Text>
+            <CopyableUrl
+              url={`${baseUrl}/webhook/trigger/${record.default_todo_id}`}
+              compact={false}
+            />
           )}
         </Space>
       ),
@@ -297,22 +470,54 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
               <Card
                 title="Webhook 列表"
                 extra={
-                  <Button type="primary" icon={<PlusOutlined />} onClick={handleCreateWebhook}>
-                    添加 Webhook
+                  <Button
+                    type="primary"
+                    icon={<PlusOutlined />}
+                    onClick={handleCreateWebhook}
+                    size={isMobile ? 'small' : 'middle'}
+                  >
+                    {isMobile ? '添加' : '添加 Webhook'}
                   </Button>
                 }
                 style={{ marginBottom: 16 }}
+                styles={{ body: { padding: isMobile ? 12 : 24 } }}
               >
-                <Table
-                  dataSource={webhooks}
-                  columns={webhookColumns}
-                  rowKey="id"
-                  loading={webhooksLoading}
-                  pagination={false}
-                  size="small"
-                />
-                {webhooks.length === 0 && !webhooksLoading && (
-                  <Empty description="暂无 Webhook，点击添加按钮创建" style={{ marginTop: 24 }} />
+                {isMobile ? (
+                  <>
+                    {webhooks.map(wh => (
+                      <WebhookCard
+                        key={wh.id}
+                        webhook={wh}
+                        todo={todos.find(t => t.id === wh.default_todo_id)}
+                        baseUrl={baseUrl}
+                        onEdit={() => handleEditWebhook(wh)}
+                        onDelete={() => handleDeleteWebhook(wh.id)}
+                        onToggle={() => handleToggleEnabled(wh)}
+                      />
+                    ))}
+                    {webhooks.length === 0 && !webhooksLoading && (
+                      <Empty description="暂无 Webhook，点击添加按钮创建" style={{ marginTop: 24 }} />
+                    )}
+                    {webhooksLoading && webhooks.length === 0 && (
+                      <div style={{ textAlign: 'center', padding: 24, color: 'var(--color-text-tertiary)' }}>
+                        加载中...
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <Table
+                      dataSource={webhooks}
+                      columns={webhookColumns}
+                      rowKey="id"
+                      loading={webhooksLoading}
+                      pagination={false}
+                      size="small"
+                    />
+                    {webhooks.length === 0 && !webhooksLoading && (
+                      <Empty description="暂无 Webhook，点击添加按钮创建" style={{ marginTop: 24 }} />
+                    )}
+                  </>
                 )}
               </Card>
             ),
@@ -326,12 +531,13 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
               </span>
             ),
             children: (
-              <Card title="Webhook 调用记录">
+              <Card title="Webhook 调用记录" styles={{ body: { padding: isMobile ? 12 : 24 } }}>
                 <Table
                   dataSource={records}
                   columns={recordColumns}
                   rowKey="id"
                   loading={recordsLoading}
+                  scroll={isMobile ? { x: 720 } : undefined}
                   size="small"
                   pagination={{
                     current: recordsPage,


### PR DESCRIPTION
## 问题

设置 → Webhook tab 在移动端 (< 768px) 显示非常糟糕。`WebhooksPanel` 渲染 6 列 Table，总宽 1010px，而手机视口只有 ~390px。「触发 URL」列被挤到 37px 宽，单元格内的 `<code>http://localhost:18088/webhook/trigger/{id}</code>` 强制逐字符换行，每行被撑到 **651px 高**，整页被撑得极长，操作列也滚到视口外无法使用。

Playwright 验证数据 (iPhone 12 Pro 390x844)：
- 行高：651px
- URL 单元格：37×651
- 滚动总高：数千 px

## 修复

- 新增 `CopyableUrl` 组件（统一桌面/移动两端的 URL 展示 + 复制交互）
- 新增 `WebhookCard` 组件：移动端每条 webhook 一张紧凑卡片
  - 顶部：名称 + Switch + 编辑/删除
  - 默认 Todo 一行
  - 触发 URL：紧凑展示 + 点击复制
  - 创建时间
- `useIsMobile()` (< 768px) 切换：
  - 移动端 → 卡片列表
  - 桌面端 → 原表格
- 调用记录表加 `scroll={{ x: 720 }}`，避免再次发生列被挤变形的问题

## 验证

Playwright (iPhone 12 Pro 390x844) 截图前后对比：

| 指标 | 修复前 | 修复后 |
|------|--------|--------|
| 渲染方式 | Table (6 列挤在 274px) | 7 张卡片堆叠 |
| 单行/卡片高度 | 651px | 160.5px (-75%) |
| URL 单元格宽 | 37px | 自适应 |
| 每屏可见 | ~1 行 | 4 张卡片 |

桌面端 1440×900 验证：
- Table 布局保留，列宽适配
- 行高 77px，URL 列宽 319px，6 列全部正常渲染
- 复制按钮在两端均可用

构建验证：`tsc --noEmit` ✅ / `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)