### PR TITLE
refactor(webhook): remove ambiguous /webhook/trigger (no-id) route

### DIFF
--- a/backend/src/db/webhook.rs
+++ b/backend/src/db/webhook.rs
@@ -54,18 +54,6 @@ impl Database {
             .await
     }
 
-    /// Get the most recently created enabled webhook.
-    /// Note: This returns the most recently created (highest ID) enabled webhook,
-    /// not a webhook explicitly marked as "default". If multiple webhooks exist,
-    /// the one created last will be selected.
-    pub async fn get_most_recent_enabled_webhook(&self) -> Result<Option<webhooks::Model>, sea_orm::DbErr> {
-        webhooks::Entity::find()
-            .filter(webhooks::Column::Enabled.eq(true))
-            .order_by_desc(webhooks::Column::Id)
-            .one(&self.conn)
-            .await
-    }
-
     /// Get an enabled webhook that has the given todo_id as its default_todo_id.
     pub async fn get_webhook_by_default_todo(&self, todo_id: i64) -> Result<Option<webhooks::Model>, sea_orm::DbErr> {
         webhooks::Entity::find()

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -465,8 +465,8 @@ pub fn create_app(
         .route("/api/agent-bots/{id}", delete(agent_bot::delete_agent_bot))
         .route("/api/agent-bots/{id}/config", put(agent_bot::update_agent_bot_config))
         .route("/health", get(health_handler))
-        // Webhook trigger endpoints (no /api/ prefix, accessible externally)
-        .route("/webhook/trigger", get(webhook::trigger_webhook_default).post(webhook::trigger_webhook_default_post_json))
+        // Webhook trigger endpoint (no /api/ prefix, accessible externally).
+        // todo_id is required — explicit, deterministic, no "most recent enabled" race.
         .route("/webhook/trigger/{todo_id}", get(webhook::trigger_webhook_with_todo).post(webhook::trigger_webhook_with_todo_post_json))
         // Webhook management APIs
         .route("/api/webhooks", get(webhook::list_webhooks).post(webhook::create_webhook))

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -225,64 +225,6 @@ pub async fn get_webhook_record(
     }
 }
 
-/// Trigger endpoint for webhook (without todo_id - uses default webhook todo)
-pub async fn trigger_webhook_default(
-    State(state): State<AppState>,
-    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
-) -> Result<impl IntoResponse, AppError> {
-    // Get the most recently created enabled webhook
-    let webhook = state.db.get_most_recent_enabled_webhook().await?;
-    let webhook = webhook.ok_or_else(|| AppError::BadRequest("No enabled webhook configured".to_string()))?;
-
-    let default_todo_id = webhook.default_todo_id
-        .ok_or_else(|| AppError::BadRequest("Webhook has no default todo configured".to_string()))?;
-
-    trigger_webhook_internal(
-        Arc::new(state),
-        WebhookTriggerRequest {
-            todo_id: default_todo_id,
-            webhook_id: Some(webhook.id),
-            method: "GET".to_string(),
-            path: "/webhook/trigger".to_string(),
-            query_params: params,
-            content_type: None,
-            body: None,
-        },
-    ).await
-}
-
-/// Trigger endpoint for webhook (without todo_id - uses default webhook todo) - POST with JSON body
-pub async fn trigger_webhook_default_post_json(
-    State(state): State<AppState>,
-    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
-    Json(body): Json<serde_json::Value>,
-) -> Result<impl IntoResponse, AppError> {
-    // Get the most recently created enabled webhook
-    let webhook = state.db.get_most_recent_enabled_webhook().await?;
-    let webhook = webhook.ok_or_else(|| AppError::BadRequest("No enabled webhook configured".to_string()))?;
-
-    let default_todo_id = webhook.default_todo_id
-        .ok_or_else(|| AppError::BadRequest("Webhook has no default todo configured".to_string()))?;
-
-    let body_str = serde_json::to_string(&body)
-        .map_err(|e| {
-            tracing::warn!("Failed to serialize webhook body: {}", e);
-            AppError::BadRequest(format!("Invalid body: {}", e))
-        })?;
-    trigger_webhook_internal(
-        Arc::new(state),
-        WebhookTriggerRequest {
-            todo_id: default_todo_id,
-            webhook_id: Some(webhook.id),
-            method: "POST".to_string(),
-            path: "/webhook/trigger".to_string(),
-            query_params: params,
-            content_type: Some("application/json".to_string()),
-            body: Some(body_str),
-        },
-    ).await
-}
-
 /// Trigger endpoint for webhook (with todo_id) - GET
 pub async fn trigger_webhook_with_todo(
     State(state): State<AppState>,

--- a/frontend/src/components/WebhooksPanel.tsx
+++ b/frontend/src/components/WebhooksPanel.tsx
@@ -15,7 +15,7 @@ import {
   Descriptions,
   Tabs,
   Empty,
-  Typography,
+  Tooltip,
 } from 'antd';
 import {
   PlusOutlined,
@@ -23,16 +23,196 @@ import {
   EditOutlined,
   ApiOutlined,
   HistoryOutlined,
+  LinkOutlined,
+  CopyOutlined,
 } from '@ant-design/icons';
 import * as db from '../utils/database';
 import type { Webhook, WebhookRecord } from '../utils/database';
 import type { Todo } from '../types';
+import { useIsMobile } from '../hooks/useIsMobile';
 
 interface WebhooksPanelProps {
   todos: Todo[];
 }
 
+/** 单个 URL 的复制块：移动端省略中间，桌面端显示全文（仍可复制） */
+function CopyableUrl({ url, compact }: { url: string; compact: boolean }) {
+  const display = useMemo(() => {
+    if (!compact) return url;
+    // 移动端：保留协议+域名+末尾路径关键部分，中间省略
+    try {
+      const u = new URL(url);
+      const path = u.pathname;
+      if (path.length <= 14) return `${u.host}${path}`;
+      const head = path.slice(0, 8);
+      const tail = path.slice(-6);
+      return `${u.host}${head}…${tail}`;
+    } catch {
+      // 退化为简单截断
+      if (url.length <= 28) return url;
+      return `${url.slice(0, 14)}…${url.slice(-8)}`;
+    }
+  }, [url, compact]);
+
+  return (
+    <Tooltip title={url} mouseEnterDelay={0.4}>
+      <Button
+        type="text"
+        size="small"
+        icon={<LinkOutlined />}
+        onClick={() => {
+          navigator.clipboard?.writeText(url);
+          message.success('已复制 URL');
+        }}
+        style={{
+          padding: compact ? '0 6px' : '0 8px',
+          height: compact ? 24 : 28,
+          fontSize: compact ? 11 : 12,
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          maxWidth: '100%',
+        }}
+      >
+        <span
+          style={{
+            display: 'inline-block',
+            maxWidth: compact ? 180 : 240,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            verticalAlign: 'bottom',
+          }}
+        >
+          {display}
+        </span>
+        <CopyOutlined style={{ fontSize: 11, marginLeft: 4, opacity: 0.6 }} />
+      </Button>
+    </Tooltip>
+  );
+}
+
+/** 移动端单条 webhook 卡片 */
+function WebhookCard({
+  webhook,
+  todo,
+  baseUrl,
+  onEdit,
+  onDelete,
+  onToggle,
+}: {
+  webhook: Webhook;
+  todo: Todo | undefined;
+  baseUrl: string;
+  onEdit: () => void;
+  onDelete: () => void;
+  onToggle: () => void;
+}) {
+  return (
+    <Card
+      size="small"
+      style={{ marginBottom: 12 }}
+      styles={{ body: { padding: 12 } }}
+    >
+      {/* 顶部：名称 + 启用开关 + 操作 */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 8,
+          marginBottom: 8,
+        }}
+      >
+        <div
+          style={{
+            fontWeight: 500,
+            fontSize: 14,
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          title={webhook.name}
+        >
+          {webhook.name}
+        </div>
+        <Space size={4} style={{ flexShrink: 0 }}>
+          <Switch
+            checked={webhook.enabled}
+            onChange={onToggle}
+            size="small"
+          />
+          <Button
+            type="text"
+            size="small"
+            icon={<EditOutlined />}
+            onClick={onEdit}
+            aria-label="编辑"
+          />
+          <Popconfirm
+            title="确定删除此 Webhook？"
+            onConfirm={onDelete}
+            okType="danger"
+          >
+            <Button
+              type="text"
+              size="small"
+              danger
+              icon={<DeleteOutlined />}
+              aria-label="删除"
+            />
+          </Popconfirm>
+        </Space>
+      </div>
+
+      {/* 默认触发 Todo */}
+      <div
+        style={{
+          fontSize: 12,
+          color: 'var(--color-text-secondary)',
+          marginBottom: 6,
+          display: 'flex',
+          gap: 4,
+        }}
+      >
+        <span style={{ flexShrink: 0 }}>默认 Todo：</span>
+        <span
+          style={{
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          title={todo?.title || (webhook.default_todo_id ? `Todo #${webhook.default_todo_id}` : '')}
+        >
+          {webhook.default_todo_id
+            ? (todo?.title || `Todo #${webhook.default_todo_id}`)
+            : <span style={{ opacity: 0.5 }}>未设置</span>}
+        </span>
+      </div>
+
+      {/* URL 区域 */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 6 }}>
+        <CopyableUrl url={`${baseUrl}/webhook/trigger`} compact />
+        {webhook.default_todo_id && (
+          <CopyableUrl
+            url={`${baseUrl}/webhook/trigger/${webhook.default_todo_id}`}
+            compact
+          />
+        )}
+      </div>
+
+      {/* 创建时间 */}
+      <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>
+        创建：{webhook.created_at ? new Date(webhook.created_at).toLocaleString() : '-'}
+      </div>
+    </Card>
+  );
+}
+
 export function WebhooksPanel({ todos }: WebhooksPanelProps) {
+  const isMobile = useIsMobile();
   const [webhooks, setWebhooks] = useState<Webhook[]>([]);
   const [webhooksLoading, setWebhooksLoading] = useState(false);
   const [webhookFormOpen, setWebhookFormOpen] = useState(false);
@@ -168,22 +348,15 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
     {
       title: '触发 URL',
       key: 'urls',
-      width: 300,
+      width: 320,
       render: (_: any, record: Webhook) => (
-        <Space direction="vertical" size={4}>
-          <Typography.Text
-            copyable={{ text: `${baseUrl}/webhook/trigger` }}
-            style={{ fontSize: 11 }}
-          >
-            <code>{baseUrl}/webhook/trigger</code>
-          </Typography.Text>
+        <Space direction="vertical" size={4} style={{ width: '100%' }}>
+          <CopyableUrl url={`${baseUrl}/webhook/trigger`} compact={false} />
           {record.default_todo_id && (
-            <Typography.Text
-              copyable={{ text: `${baseUrl}/webhook/trigger/${record.default_todo_id}` }}
-              style={{ fontSize: 11 }}
-            >
-              <code>{baseUrl}/webhook/trigger/{record.default_todo_id}</code>
-            </Typography.Text>
+            <CopyableUrl
+              url={`${baseUrl}/webhook/trigger/${record.default_todo_id}`}
+              compact={false}
+            />
           )}
         </Space>
       ),
@@ -297,22 +470,54 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
               <Card
                 title="Webhook 列表"
                 extra={
-                  <Button type="primary" icon={<PlusOutlined />} onClick={handleCreateWebhook}>
-                    添加 Webhook
+                  <Button
+                    type="primary"
+                    icon={<PlusOutlined />}
+                    onClick={handleCreateWebhook}
+                    size={isMobile ? 'small' : 'middle'}
+                  >
+                    {isMobile ? '添加' : '添加 Webhook'}
                   </Button>
                 }
                 style={{ marginBottom: 16 }}
+                styles={{ body: { padding: isMobile ? 12 : 24 } }}
               >
-                <Table
-                  dataSource={webhooks}
-                  columns={webhookColumns}
-                  rowKey="id"
-                  loading={webhooksLoading}
-                  pagination={false}
-                  size="small"
-                />
-                {webhooks.length === 0 && !webhooksLoading && (
-                  <Empty description="暂无 Webhook，点击添加按钮创建" style={{ marginTop: 24 }} />
+                {isMobile ? (
+                  <>
+                    {webhooks.map(wh => (
+                      <WebhookCard
+                        key={wh.id}
+                        webhook={wh}
+                        todo={todos.find(t => t.id === wh.default_todo_id)}
+                        baseUrl={baseUrl}
+                        onEdit={() => handleEditWebhook(wh)}
+                        onDelete={() => handleDeleteWebhook(wh.id)}
+                        onToggle={() => handleToggleEnabled(wh)}
+                      />
+                    ))}
+                    {webhooks.length === 0 && !webhooksLoading && (
+                      <Empty description="暂无 Webhook，点击添加按钮创建" style={{ marginTop: 24 }} />
+                    )}
+                    {webhooksLoading && webhooks.length === 0 && (
+                      <div style={{ textAlign: 'center', padding: 24, color: 'var(--color-text-tertiary)' }}>
+                        加载中...
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <Table
+                      dataSource={webhooks}
+                      columns={webhookColumns}
+                      rowKey="id"
+                      loading={webhooksLoading}
+                      pagination={false}
+                      size="small"
+                    />
+                    {webhooks.length === 0 && !webhooksLoading && (
+                      <Empty description="暂无 Webhook，点击添加按钮创建" style={{ marginTop: 24 }} />
+                    )}
+                  </>
                 )}
               </Card>
             ),
@@ -326,12 +531,13 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
               </span>
             ),
             children: (
-              <Card title="Webhook 调用记录">
+              <Card title="Webhook 调用记录" styles={{ body: { padding: isMobile ? 12 : 24 } }}>
                 <Table
                   dataSource={records}
                   columns={recordColumns}
                   rowKey="id"
                   loading={recordsLoading}
+                  scroll={isMobile ? { x: 720 } : undefined}
                   size="small"
                   pagination={{
                     current: recordsPage,

--- a/frontend/src/components/WebhooksPanel.tsx
+++ b/frontend/src/components/WebhooksPanel.tsx
@@ -192,16 +192,26 @@ function WebhookCard({
         </span>
       </div>
 
-      {/* URL 区域 */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 6 }}>
-        <CopyableUrl url={`${baseUrl}/webhook/trigger`} compact />
-        {webhook.default_todo_id && (
+      {/* URL 区域 —— 仅在配置了默认 Todo 时显示触发 URL */}
+      {webhook.default_todo_id ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 6 }}>
           <CopyableUrl
             url={`${baseUrl}/webhook/trigger/${webhook.default_todo_id}`}
             compact
           />
-        )}
-      </div>
+        </div>
+      ) : (
+        <div
+          style={{
+            fontSize: 11,
+            color: 'var(--color-text-tertiary)',
+            marginBottom: 6,
+            padding: '4px 0',
+          }}
+        >
+          未配置默认 Todo，无法生成触发 URL
+        </div>
+      )}
 
       {/* 创建时间 */}
       <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>
@@ -349,17 +359,21 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
       title: '触发 URL',
       key: 'urls',
       width: 320,
-      render: (_: any, record: Webhook) => (
-        <Space direction="vertical" size={4} style={{ width: '100%' }}>
-          <CopyableUrl url={`${baseUrl}/webhook/trigger`} compact={false} />
-          {record.default_todo_id && (
-            <CopyableUrl
-              url={`${baseUrl}/webhook/trigger/${record.default_todo_id}`}
-              compact={false}
-            />
-          )}
-        </Space>
-      ),
+      render: (_: any, record: Webhook) => {
+        if (!record.default_todo_id) {
+          return (
+            <span style={{ color: 'var(--color-text-tertiary)', fontSize: 12 }}>
+              请先配置默认 Todo
+            </span>
+          );
+        }
+        return (
+          <CopyableUrl
+            url={`${baseUrl}/webhook/trigger/${record.default_todo_id}`}
+            compact={false}
+          />
+        );
+      },
     },
     {
       title: '创建时间',
@@ -588,7 +602,7 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
           <Form.Item
             name="default_todo_id"
             label="默认触发 Todo"
-            tooltip="当使用 /webhook/trigger 路径时触发的 Todo"
+            tooltip="配置后可通过 /webhook/trigger/{todo_id} 显式触发；必须设置才能生成触发 URL"
           >
             <Select
               allowClear


### PR DESCRIPTION
## 背景

PR #418 重做 Webhook 移动端 UI 时发现一个不科学的设计：每条 webhook 卡片里展示两个 URL：
- `/webhook/trigger` （无 ID）
- `/webhook/trigger/{todo_id}` （有 ID）

## 问题

后端 `/webhook/trigger`（无 ID）走的是 `get_most_recent_enabled_webhook()` —— 总是落到**最新创建且已启用**的 webhook 上。这意味着：

1. **隐性 race**：用户任何时候新建一个启用 webhook，所有老的 `/webhook/trigger` 调用就会静默改投到新 webhook
2. **冗余**：当此 webhook 本身就是"最近"那个时，两个 URL 指向同一 todo，毫无意义
3. **不一致**：没有 `default_todo_id` 的 webhook，带 ID 的 URL 返回 400；不带 ID 的返回不同错误信息 —— 用户搞不清

## 修复

彻底删除无 ID 的调用方式（你要求）：

**后端**（`-58` 行）：
- `handlers/webhook.rs`：删除 `trigger_webhook_default` 和 `trigger_webhook_default_post_json`
- `handlers/mod.rs`：删除 `/webhook/trigger` 路由
- `db/webhook.rs`：删除 `get_most_recent_enabled_webhook` 方法

**前端**：
- `WebhooksPanel.tsx`：每条 webhook 最多展示一个 URL（带 ID）；没有 `default_todo_id` 时显示"未配置默认 Todo，无法生成触发 URL"
- 表单 tooltip 更新为 `/webhook/trigger/{todo_id}` 显式描述

## 验证

**后端**（curl）：
| 路径 | 状态 |
|------|------|
| `GET /webhook/trigger` | **404** （路由已删除） |
| `GET /webhook/trigger/1` | 200 （仍可用） |
| `GET /webhook/trigger/999999` | 400 （无可用 webhook） |

**前端**（Playwright iPhone 12 Pro 390×844）：
- `URL buttons on page` 仅包含 `/webhook/trigger/1` 形式
- 没有 `default_todo_id` 的卡片显示明确的提示文字

**构建**：
- `cargo check` ✅
- `tsc --noEmit` ✅
- `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)