### PR TITLE
fix(todo-detail): 点击直接执行后立即刷新执行记录列表

### DIFF
--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -211,6 +211,8 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
         undefined
       );
       message.success('任务已开始执行');
+      // 立即刷新执行记录列表，确保新建的记录立刻显示；回到第 1 页让用户看到新记录
+      await loadExecutionRecords(1, historyLimit);
     } catch (error) {
       message.error('执行失败: ' + (error instanceof Error ? error.message : String(error)));
     }
@@ -238,6 +240,8 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
       message.success('任务已开始执行');
       setExecuteWithArgsModalOpen(false);
       setExecuteArgs('');
+      // 立即刷新执行记录列表，确保新建的记录立刻显示；回到第 1 页让用户看到新记录
+      await loadExecutionRecords(1, historyLimit);
     } catch (error) {
       message.error('执行失败: ' + (error instanceof Error ? error.message : String(error)));
     } finally {


### PR DESCRIPTION
## 问题

在 Todo 详情页面，点击「直接执行」按钮后，新建的执行记录不会自动出现在「执行历史」列表中，必须手动刷新页面才能看到最新记录。

## 根因

`TodoDetail.tsx` 中的 `handleExecute` 和 `handleExecuteWithArgs` 在 `await db.executeTodo()` 之后只显示了 toast，**没有调用 `loadExecutionRecords`** 来刷新列表。

对比同文件的其他 handler：
- `handleStopExecution`（line 252）末尾会 `await loadExecutionRecords(historyPage, historyLimit)`
- `handleResumeConfirm`（line 279）末尾也会 `await loadExecutionRecords(historyPage, historyLimit)`

而 WebSocket 的 `Finished` 事件（`useExecutionEvents.ts`）只更新 `runningTasks` 和 todo 状态，不会触发执行记录列表的重新拉取。所以从用户体感上看，新建的执行记录必须等到下一次 useEffect 依赖变化（切换 todo / 改变 limit / 改变筛选）或者用户点击顶部「刷新」按钮才会出现。

## 修复

在两个 handler 的 toast 之后加上 `await loadExecutionRecords(1, historyLimit)`。
回到第 1 页以确保用户立刻看到刚创建的最新记录（新记录按时间倒序在最前面）。

```diff
   const handleExecute = async () => {
     ...
     message.success('任务已开始执行');
+    // 立即刷新执行记录列表，确保新建的记录立刻显示；回到第 1 页让用户看到新记录
+    await loadExecutionRecords(1, historyLimit);
   } catch (error) { ... }
```

## 验证

使用 Playwright 自动化验证（脚本位于 `/tmp/check_execute_refresh.js`）：

| 指标 | 结果 |
|------|------|
| 后端记录总数 | 6 → 7 ✅ |
| UI 首条记录 | 「8:43 AM 成功」→「9:29 AM 进行中」 ✅ |
| 「进行中」标签数 | 0 → 1 ✅ |
| Toast 提示 | 「任务已开始执行」 ✅ |
| 是否需要手动刷新 | 否 ✅ |

## 影响范围

- 仅修改 `frontend/src/components/TodoDetail.tsx`（+4 行注释 + 2 行调用）
- 行为变化：点击「直接执行」或「带参执行」后，列表回到第 1 页并刷新（之前是不刷新，需要用户手动刷新）