### PR TITLE
fix: 修复执行历史不实时更新和结论不显示问题

### DIFF
--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -236,13 +236,18 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
       );
       message.success('任务已开始执行');
       // 获取新创建的执行记录并立即添加到状态中
-      const newRecord = await db.getExecutionRecord(result.record_id);
-      dispatch({
-        type: 'ADD_EXECUTION_RECORD',
-        payload: { todoId: selectedTodo.id, record: newRecord }
-      });
-      // 选中新记录
-      setSelectedHistoryRecordId(result.record_id);
+      try {
+        const newRecord = await db.getExecutionRecord(result.record_id);
+        dispatch({
+          type: 'ADD_EXECUTION_RECORD',
+          payload: { todoId: selectedTodo.id, record: newRecord }
+        });
+        // 选中新记录
+        setSelectedHistoryRecordId(result.record_id);
+      } catch {
+        // 获取新记录失败时回退到刷新列表
+        await loadExecutionRecords(1, historyLimit);
+      }
     } catch (error) {
       message.error('执行失败: ' + (error instanceof Error ? error.message : String(error)));
     }
@@ -271,13 +276,18 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
       setExecuteWithArgsModalOpen(false);
       setExecuteArgs('');
       // 获取新创建的执行记录并立即添加到状态中
-      const newRecord = await db.getExecutionRecord(result.record_id);
-      dispatch({
-        type: 'ADD_EXECUTION_RECORD',
-        payload: { todoId: selectedTodo.id, record: newRecord }
-      });
-      // 选中新记录
-      setSelectedHistoryRecordId(result.record_id);
+      try {
+        const newRecord = await db.getExecutionRecord(result.record_id);
+        dispatch({
+          type: 'ADD_EXECUTION_RECORD',
+          payload: { todoId: selectedTodo.id, record: newRecord }
+        });
+        // 选中新记录
+        setSelectedHistoryRecordId(result.record_id);
+      } catch {
+        // 获取新记录失败时回退到刷新列表
+        await loadExecutionRecords(1, historyLimit);
+      }
     } catch (error) {
       message.error('执行失败: ' + (error instanceof Error ? error.message : String(error)));
     } finally {

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -48,6 +48,20 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
     return () => clearInterval(interval);
   }, [isExecuting]);
 
+  // 当执行结束时，刷新执行记录和日志
+  const prevIsExecutingRef = useRef(isExecuting);
+  useEffect(() => {
+    if (prevIsExecutingRef.current && !isExecuting && selectedTodoId) {
+      // 执行刚结束，刷新执行记录
+      loadExecutionRecords(historyPage, historyLimit);
+      // 如果有选中的记录，刷新其日志
+      if (selectedHistoryRecordId) {
+        loadLogs(selectedHistoryRecordId, 1);
+      }
+    }
+    prevIsExecutingRef.current = isExecuting;
+  }, [isExecuting, selectedTodoId, selectedHistoryRecordId]);
+
   const records = selectedTodoId ? executionRecords[selectedTodoId] || [] : [];
 
   const [historyStatusFilter, setHistoryStatusFilter] = useState<'all' | 'running' | 'success' | 'failed'>('all');
@@ -205,14 +219,20 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
   const handleExecute = async () => {
     if (!selectedTodo) return;
     try {
-      await db.executeTodo(
+      const result = await db.executeTodo(
         selectedTodo.id,
         selectedTodo.executor || undefined,
         undefined
       );
       message.success('任务已开始执行');
-      // 立即刷新执行记录列表，确保新建的记录立刻显示；回到第 1 页让用户看到新记录
-      await loadExecutionRecords(1, historyLimit);
+      // 获取新创建的执行记录并立即添加到状态中
+      const newRecord = await db.getExecutionRecord(result.record_id);
+      dispatch({
+        type: 'ADD_EXECUTION_RECORD',
+        payload: { todoId: selectedTodo.id, record: newRecord }
+      });
+      // 选中新记录
+      setSelectedHistoryRecordId(result.record_id);
     } catch (error) {
       message.error('执行失败: ' + (error instanceof Error ? error.message : String(error)));
     }
@@ -232,7 +252,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
     setExecuteWithArgsLoading(true);
     try {
       const params = executeArgs.trim() ? { message: executeArgs.trim() } : undefined;
-      await db.executeTodo(
+      const result = await db.executeTodo(
         selectedTodo.id,
         selectedTodo.executor || undefined,
         params
@@ -240,8 +260,14 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
       message.success('任务已开始执行');
       setExecuteWithArgsModalOpen(false);
       setExecuteArgs('');
-      // 立即刷新执行记录列表，确保新建的记录立刻显示；回到第 1 页让用户看到新记录
-      await loadExecutionRecords(1, historyLimit);
+      // 获取新创建的执行记录并立即添加到状态中
+      const newRecord = await db.getExecutionRecord(result.record_id);
+      dispatch({
+        type: 'ADD_EXECUTION_RECORD',
+        payload: { todoId: selectedTodo.id, record: newRecord }
+      });
+      // 选中新记录
+      setSelectedHistoryRecordId(result.record_id);
     } catch (error) {
       message.error('执行失败: ' + (error instanceof Error ? error.message : String(error)));
     } finally {

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -58,7 +58,14 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
       loadExecutionRecords(historyPage, historyLimit);
       // 如果有选中的记录，刷新单条记录详情（包含 result）和日志
       if (selectedHistoryRecordId) {
-        refreshSingleRecord(selectedHistoryRecordId);
+        // 直接更新 selectedHistoryRecordDetail 和 dispatch 更新 store
+        db.getExecutionRecord(selectedHistoryRecordId).then(detail => {
+          setSelectedHistoryRecordDetail(detail);
+          dispatch({
+            type: 'UPDATE_EXECUTION_RECORD',
+            payload: { todoId: selectedTodoId, record: detail }
+          });
+        });
         loadLogs(selectedHistoryRecordId, 1);
       }
     }

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -51,16 +51,19 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
   // 当执行结束时，刷新执行记录和日志
   const prevIsExecutingRef = useRef(isExecuting);
   useEffect(() => {
-    if (prevIsExecutingRef.current && !isExecuting && selectedTodoId) {
-      // 执行刚结束，刷新执行记录
+    const prev = prevIsExecutingRef.current;
+    // 当 isExecuting 从 true 变为 false 时，表示执行刚结束
+    if (prev && !isExecuting && selectedTodoId) {
+      // 刷新执行记录列表（包含结论）
       loadExecutionRecords(historyPage, historyLimit);
-      // 如果有选中的记录，刷新其日志
+      // 如果有选中的记录，刷新单条记录详情（包含 result）和日志
       if (selectedHistoryRecordId) {
+        refreshSingleRecord(selectedHistoryRecordId);
         loadLogs(selectedHistoryRecordId, 1);
       }
     }
     prevIsExecutingRef.current = isExecuting;
-  }, [isExecuting, selectedTodoId, selectedHistoryRecordId]);
+  }, [isExecuting, selectedTodoId, selectedHistoryRecordId, historyPage, historyLimit]);
 
   const records = selectedTodoId ? executionRecords[selectedTodoId] || [] : [];
 

--- a/frontend/src/hooks/useApp.tsx
+++ b/frontend/src/hooks/useApp.tsx
@@ -83,7 +83,7 @@ type ExecutionAction =
   | { type: 'UPDATE_EXECUTION_RECORD'; payload: { todoId: number; record: ExecutionRecord } }
   | { type: 'ADD_RUNNING_TASK'; payload: RunningTask }
   | { type: 'APPEND_TASK_LOG'; payload: { taskId: string; log: LogEntry } }
-  | { type: 'FINISH_TASK'; payload: { taskId: string; success: boolean; result: string | null } }
+  | { type: 'FINISH_TASK'; payload: { taskId: string; todoId: number; success: boolean; result: string | null } }
   | { type: 'REMOVE_RUNNING_TASK'; payload: string }
   | { type: 'CLEAR_RUNNING_TASKS' }
   | { type: 'SET_ACTIVE_TASK'; payload: string | null }

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -164,6 +164,7 @@ export function useExecutionEvents() {
                 type: 'FINISH_TASK',
                 payload: {
                   taskId: data.task_id,
+                  todoId: data.todo_id,
                   success: data.success,
                   result: data.result,
                 },

--- a/frontend/src/utils/database/executions.ts
+++ b/frontend/src/utils/database/executions.ts
@@ -24,6 +24,10 @@ export async function getExecutionRecordsBySession(sessionId: string): Promise<E
   return unwrap(await api.get(`/api/execution-records/session/${encodeURIComponent(sessionId)}`));
 }
 
+/**
+ * 执行指定 todo 任务。
+ * 返回 task_id 用于 WebSocket 事件追踪，record_id 用于 UI 层立即获取并选中新创建的执行记录。
+ */
 export async function executeTodo(todoId: number, executor?: string, params?: Record<string, string>): Promise<{ task_id: string; record_id: number }> {
   return unwrap(await api.post('/api/execute', { todo_id: todoId, executor, params }));
 }

--- a/frontend/src/utils/database/executions.ts
+++ b/frontend/src/utils/database/executions.ts
@@ -24,7 +24,7 @@ export async function getExecutionRecordsBySession(sessionId: string): Promise<E
   return unwrap(await api.get(`/api/execution-records/session/${encodeURIComponent(sessionId)}`));
 }
 
-export async function executeTodo(todoId: number, executor?: string, params?: Record<string, string>): Promise<{ task_id: string }> {
+export async function executeTodo(todoId: number, executor?: string, params?: Record<string, string>): Promise<{ task_id: string; record_id: number }> {
   return unwrap(await api.post('/api/execute', { todo_id: todoId, executor, params }));
 }
 


### PR DESCRIPTION
## 修复内容

### 问题描述
1. 点击直接执行后，执行历史列表没有实时增加新记录
2. 执行完成后，结论框不显示，需要手动点击左侧执行历史才能看到
3. 执行过程中输出的日志在执行结束后被清空

### 修复方案

1. **executeTodo 返回 record_id**
   - 后端已返回 record_id，前端之前没使用
   - 修改  的返回类型

2. **执行后立即显示新记录**
   -  和  执行后立即获取新记录
   - 通过  action 添加到状态
   - 自动选中新记录

3. **执行结束自动刷新**
   - 监听  状态变化
   - 从 true 变为 false 时触发刷新：
     - 刷新执行记录列表
     - 刷新 （包含 result 结论）
     - 刷新日志

4. **FINISH_TASK action 添加 todoId**
   - 便于追踪执行结束的 todo

### 修改文件
- 
- 
- 
- 