### PR TITLE
chore(gitignore): ignore local .npmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ frontend/test-results/.last-run.json
 frontend/node_modules
 .antigravitycli/
 .codebuddy/
+
+# npm local config
+# 仅包含代理等个人环境配置（127.0.0.1:7890 之类），提交会污染仓库
+# 且对其他协作者不通用，故忽略本机文件，避免误提交
+.npmrc


### PR DESCRIPTION
## 背景
仓库根目录存在一个未追踪的 `.npmrc`，内容为本机 npm 代理配置：

```
proxy=http://127.0.0.1:7890/
https-proxy=http://127.0.0.1:7890/
```

## 变更
在 `.gitignore` 末尾新增：

```
# npm local config
# 仅包含代理等个人环境配置（127.0.0.1:7890 之类），提交会污染仓库
# 且对其他协作者不通用，故忽略本机文件，避免误提交
.npmrc
```

## 影响
- 现有的本地 `.npmrc` 不再显示为 untracked，避免误提交
- 对仓库内其它文件、CI、构建流程无影响（npm 仍会读取该配置文件）

## 验证
```
$ git check-ignore -v .npmrc
.gitignore:63:.npmrc	.npmrc
```