### PR TITLE
feat: 添加版本检查和一键升级功能

### DIFF
--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -298,6 +298,103 @@ async fn version_handler() -> impl IntoResponse {
     ApiResponse::ok(response)
 }
 
+/// 查询 npm 最新版本号，用于前端版本检查提示。
+/// 调用 `npm view @weibaohui/nothing-todo version` 获取远程最新版本。
+async fn version_latest_handler() -> impl IntoResponse {
+    let output = std::process::Command::new("npm")
+        .args(["view", "@weibaohui/nothing-todo", "version"])
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            // npm view 输出格式为 "x.y.z\n"，需要 trim 掉换行符
+            let latest = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            ApiResponse::ok(serde_json::json!({ "latest": latest }))
+        }
+        Ok(out) => {
+            let err_msg = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            tracing::warn!("npm view failed: {}", err_msg);
+            ApiResponse::ok(serde_json::json!({ "latest": null, "error": err_msg }))
+        }
+        Err(e) => {
+            tracing::warn!("Failed to run npm view: {}", e);
+            ApiResponse::ok(serde_json::json!({ "latest": null, "error": e.to_string() }))
+        }
+    }
+}
+
+/// 执行 npm 升级并重启服务。
+/// 1. 调用 `npm install -g @weibaohui/nothing-todo@latest` 升级
+/// 2. 调用 `ntd daemon restart` 重启服务
+async fn version_upgrade_handler() -> impl IntoResponse {
+    // 先执行 npm 升级，捕获输出以便返回给前端展示
+    let npm_output = std::process::Command::new("npm")
+        .args(["install", "-g", "@weibaohui/nothing-todo@latest"])
+        .output();
+
+    let npm_stdout;
+    let npm_stderr;
+    let npm_success;
+
+    match &npm_output {
+        Ok(out) => {
+            npm_stdout = String::from_utf8_lossy(&out.stdout).to_string();
+            npm_stderr = String::from_utf8_lossy(&out.stderr).to_string();
+            npm_success = out.status.success();
+            tracing::info!("npm upgrade stdout: {}, stderr: {}", npm_stdout, npm_stderr);
+        }
+        Err(e) => {
+            npm_stdout = String::new();
+            npm_stderr = e.to_string();
+            npm_success = false;
+            tracing::error!("Failed to run npm: {}", e);
+        }
+    }
+
+    if !npm_success {
+        let err_msg = if npm_stderr.is_empty() {
+            "npm upgrade failed".to_string()
+        } else {
+            format!("npm upgrade failed: {}", npm_stderr)
+        };
+        return ApiResponse::err(1, &err_msg);
+    }
+
+    // npm 升级成功后执行 daemon restart
+    // 注意：restart 成功后当前进程会被终止，所以这行代码之后不会有任何输出
+    let restart_status = std::process::Command::new("ntd")
+        .args(["daemon", "restart"])
+        .status();
+
+    let restarted;
+    let restart_message;
+
+    match restart_status {
+        Ok(status) if status.success() => {
+            restarted = true;
+            restart_message = String::new();
+            tracing::info!("Daemon restart triggered");
+        }
+        Ok(status) => {
+            restarted = false;
+            restart_message = format!("Daemon restart failed with exit code: {}. Please run 'ntd daemon restart' manually.", status);
+            tracing::error!("{}", restart_message);
+        }
+        Err(e) => {
+            restarted = false;
+            restart_message = format!("Failed to run ntd daemon restart: {}. Please run 'ntd daemon restart' manually.", e);
+            tracing::error!("{}", restart_message);
+        }
+    }
+
+    ApiResponse::ok(serde_json::json!({
+        "upgraded": true,
+        "restarted": restarted,
+        "npmOutput": npm_stdout,
+        "restartMessage": restart_message
+    }))
+}
+
 // Build router
 pub fn create_app(
     ctx: ServiceContext,
@@ -475,6 +572,8 @@ pub fn create_app(
         .route("/api/webhook-records/{id}", get(webhook::get_webhook_record))
         .route("/assets/{*path}", get(static_handler))
         .route("/api/version", get(version_handler))
+        .route("/api/version/latest", get(version_latest_handler))
+        .route("/api/version/upgrade", post(version_upgrade_handler))
         .route("/api/sessions", get(session::list_sessions))
         .route("/api/sessions/stats", get(session::get_session_stats))
         .route("/api/sessions/{id}", get(session::get_session_detail).delete(session::delete_session))

--- a/frontend/src/components/settings/AboutPanel.tsx
+++ b/frontend/src/components/settings/AboutPanel.tsx
@@ -1,13 +1,32 @@
 import { useState, useEffect } from 'react';
-import { Spin, Card, Empty, Space, Typography } from 'antd';
+import { Spin, Card, Empty, Space, Typography, Button, Alert, Modal, message } from 'antd';
+import { CheckCircleFilled, CloseCircleFilled, ReloadOutlined, CloudDownloadOutlined, ExclamationCircleFilled } from '@ant-design/icons';
 import * as db from '../../utils/database';
 import { ShareCard } from '../ShareCard';
 
 const { Paragraph } = Typography;
 
+interface VersionStatus {
+  current: string;
+  latest: string | null;
+  isUpToDate: boolean | null; // null = 还没检查
+  error?: string;
+}
+
+interface UpgradeResult {
+  upgraded: boolean;
+  restarted: boolean;
+  npmOutput?: string;
+  restartMessage?: string;
+}
+
 export function AboutPanel() {
   const [versionInfo, setVersionInfo] = useState<{ version: string; git_sha: string; git_describe: string } | null>(null);
   const [versionLoading, setVersionLoading] = useState(false);
+  const [versionStatus, setVersionStatus] = useState<VersionStatus | null>(null);
+  const [checkingUpdate, setCheckingUpdate] = useState(false);
+  const [upgrading, setUpgrading] = useState(false);
+  const [upgradeResult, setUpgradeResult] = useState<UpgradeResult | null>(null);
 
   useEffect(() => {
     setVersionLoading(true);
@@ -19,6 +38,115 @@ export function AboutPanel() {
       .finally(() => setVersionLoading(false));
   }, []);
 
+  // 规范化版本号：去除 v 前缀、-dirty/-alpha 等后缀，只保留 semver 主干
+  // 例如 "v0.0.50-dirty" -> "0.0.50"，"0.0.50-alpha" -> "0.0.50"
+  const normalizeVersion = (v: string): string => {
+    return v.replace(/^v/, '').replace(/-.+$/, '').trim();
+  };
+
+  // 版本比较函数：比较两个版本号，返回 1 表示 a 更新，-1 表示 b 更新，0 表示相等
+  const compareVersions = (a: string, b: string): number => {
+    const normA = normalizeVersion(a);
+    const normB = normalizeVersion(b);
+    const partsA = normA.split('.').map(Number);
+    const partsB = normB.split('.').map(Number);
+    for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+      const pA = partsA[i] ?? 0;
+      const pB = partsB[i] ?? 0;
+      if (pA > pB) return 1;
+      if (pA < pB) return -1;
+    }
+    return 0;
+  };
+
+  // 检查最新版本
+  const checkForUpdate = async () => {
+    if (!versionInfo) return;
+    setCheckingUpdate(true);
+    setUpgradeResult(null); // 清除之前的升级结果
+    try {
+      const result = await db.getLatestVersion();
+      if (result.latest) {
+        const isUpToDate = compareVersions(versionInfo.version, result.latest) >= 0;
+        setVersionStatus({
+          current: versionInfo.version,
+          latest: result.latest,
+          isUpToDate,
+        });
+      } else {
+        setVersionStatus({
+          current: versionInfo.version,
+          latest: null,
+          isUpToDate: null,
+          error: result.error || '无法获取最新版本',
+        });
+      }
+    } catch (e) {
+      setVersionStatus({
+        current: versionInfo.version,
+        latest: null,
+        isUpToDate: null,
+        error: '检查更新失败',
+      });
+    } finally {
+      setCheckingUpdate(false);
+    }
+  };
+
+  // 执行一键更新
+  const handleUpgrade = async () => {
+    if (!versionStatus?.latest) return;
+
+    // 弹出确认框，显示将要执行的命令
+    Modal.confirm({
+      title: '确认执行以下命令',
+      icon: <ExclamationCircleFilled style={{ color: '#faad14' }} />,
+      content: (
+        <div style={{ marginTop: 12 }}>
+          <Paragraph>即将执行以下命令完成更新：</Paragraph>
+          <div style={{ background: '#f5f5f5', padding: 12, borderRadius: 4, fontFamily: 'monospace' }}>
+            <div style={{ marginBottom: 8 }}>
+              <strong>1. 升级 npm 包：</strong><br />
+              <code style={{ color: '#d46b08' }}>npm install -g @weibaohui/nothing-todo@latest</code>
+            </div>
+            <div>
+              <strong>2. 重启服务：</strong><br />
+              <code style={{ color: '#d46b08' }}>ntd daemon restart</code>
+            </div>
+          </div>
+          <Paragraph type="secondary" style={{ marginTop: 12, marginBottom: 0 }}>
+            更新完成后服务将自动重启，请稍后刷新页面。
+          </Paragraph>
+        </div>
+      ),
+      okText: '执行更新',
+      cancelText: '取消',
+      onOk: async () => {
+        setUpgrading(true);
+        try {
+          const result = await db.upgradeVersion();
+          setUpgradeResult(result);
+          if (result.upgraded && result.restarted) {
+            message.success('更新命令已执行，服务正在重启...');
+          } else if (result.upgraded && !result.restarted) {
+            message.warning('更新完成，但服务重启失败，请手动重启');
+          }
+          // 重置版本状态，让用户可以重新检查
+          setVersionStatus(null);
+        } catch (e) {
+          setUpgradeResult({
+            upgraded: false,
+            restarted: false,
+            restartMessage: e instanceof Error ? e.message : '未知错误',
+          });
+          message.error('更新失败：' + (e instanceof Error ? e.message : '未知错误'));
+        } finally {
+          setUpgrading(false);
+        }
+      },
+    });
+  };
+
   return (
     <Spin spinning={versionLoading}>
       <Card title="NTD 版本信息" style={{ maxWidth: 600 }}>
@@ -28,6 +156,114 @@ export function AboutPanel() {
               <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 4 }}>版本号</div>
               <div style={{ fontSize: 24, fontWeight: 700, fontFamily: 'monospace' }}>{versionInfo.version}</div>
             </div>
+
+            {/* 版本检查区域 */}
+            <div style={{ borderTop: '1px solid var(--color-border-light)', paddingTop: 16 }}>
+              <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 8 }}>版本检查</div>
+              {versionStatus && (
+                <div style={{ marginBottom: 12 }}>
+                  {versionStatus.error ? (
+                    <Alert type="warning" message={versionStatus.error} showIcon />
+                  ) : versionStatus.isUpToDate === true ? (
+                    <Alert
+                      type="success"
+                      message={
+                        <Space>
+                          <CheckCircleFilled style={{ color: '#52c41a' }} />
+                          当前已是最新版本 {versionStatus.current}
+                        </Space>
+                      }
+                      showIcon
+                    />
+                  ) : versionStatus.isUpToDate === false ? (
+                    <Alert
+                      type="info"
+                      message={
+                        <Space direction="vertical" size={4}>
+                          <span>
+                            <CloseCircleFilled style={{ color: '#1677ff', marginRight: 6 }} />
+                            发现新版本：<strong>{versionStatus.latest}</strong>
+                          </span>
+                          <span style={{ fontSize: 12, color: 'var(--color-text-secondary)' }}>
+                            当前版本：{versionStatus.current}
+                          </span>
+                        </Space>
+                      }
+                      showIcon
+                    />
+                  ) : null}
+                </div>
+              )}
+
+              {/* 升级结果展示 */}
+              {upgradeResult && (
+                <div style={{ marginBottom: 12 }}>
+                  {upgradeResult.upgraded && upgradeResult.restarted ? (
+                    <Alert
+                      type="success"
+                      message={
+                        <Space direction="vertical" size={4}>
+                          <span>
+                            <CheckCircleFilled style={{ color: '#52c41a', marginRight: 6 }} />
+                            更新命令执行成功，服务正在重启
+                          </span>
+                          {upgradeResult.npmOutput && (
+                            <code style={{ fontSize: 11, color: 'var(--color-text-secondary)', display: 'block', marginTop: 4 }}>
+                              {upgradeResult.npmOutput}
+                            </code>
+                          )}
+                        </Space>
+                      }
+                      showIcon
+                    />
+                  ) : (
+                    <Alert
+                      type="warning"
+                      message={
+                        <Space direction="vertical" size={4}>
+                          <span>
+                            <ExclamationCircleFilled style={{ color: '#faad14', marginRight: 6 }} />
+                            更新完成，但服务重启失败
+                          </span>
+                          {upgradeResult.npmOutput && (
+                            <code style={{ fontSize: 11, color: 'var(--color-text-secondary)', display: 'block', marginTop: 4 }}>
+                              {upgradeResult.npmOutput}
+                            </code>
+                          )}
+                          {upgradeResult.restartMessage && (
+                            <span style={{ fontSize: 12 }}>{upgradeResult.restartMessage}</span>
+                          )}
+                        </Space>
+                      }
+                      showIcon
+                    />
+                  )}
+                </div>
+              )}
+
+              <Space>
+                <Button
+                  icon={<ReloadOutlined />}
+                  onClick={checkForUpdate}
+                  loading={checkingUpdate}
+                  disabled={!versionInfo}
+                >
+                  {versionStatus === null ? '检查更新' : '重新检查'}
+                </Button>
+                {/* 发现新版本时显示一键更新按钮 */}
+                {versionStatus?.isUpToDate === false && (
+                  <Button
+                    type="primary"
+                    icon={<CloudDownloadOutlined />}
+                    onClick={handleUpgrade}
+                    loading={upgrading}
+                  >
+                    一键更新到 {versionStatus.latest}
+                  </Button>
+                )}
+              </Space>
+            </div>
+
             <div style={{ borderTop: '1px solid var(--color-border-light)', paddingTop: 16 }}>
               <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 8 }}>详细信息</div>
               <Space direction="vertical" size={8}>

--- a/frontend/src/utils/database/skills.ts
+++ b/frontend/src/utils/database/skills.ts
@@ -131,3 +131,18 @@ export interface VersionInfo {
 export async function getVersion(): Promise<VersionInfo> {
   return unwrap(await api.get('/api/version'));
 }
+
+/** 从 npm 获取 @weibaohui/nothing-todo 的最新版本号 */
+export async function getLatestVersion(): Promise<{ latest: string | null; error?: string }> {
+  return unwrap(await api.get('/api/version/latest'));
+}
+
+/** 执行 npm 升级并重启服务 */
+export async function upgradeVersion(): Promise<{
+  upgraded: boolean;
+  restarted: boolean;
+  npmOutput?: string;
+  restartMessage?: string;
+}> {
+  return unwrap(await api.post('/api/version/upgrade'));
+}


### PR DESCRIPTION
## 功能描述

在设置-关于面板中增加版本检查和一键升级功能：

### 后端改动
- 新增  接口：调用 0.0.50 查询 npm 最新版本
- 新增  接口：执行 npm 升级后调用  重启服务

### 前端改动
- AboutPanel 增加版本检查按钮
- 发现新版本时显示一键更新按钮
- 更新前弹出确认框，显示将要执行的命令：
  - 
added 2 packages in 19s
  - Service is not running
Service not installed. Regenerating...
Service started
- 更新后显示执行结果（成功/失败及详细信息）

### 其他
- 兼容处理  等带后缀的版本号比较

## 验证
- [x] Rust 编译通过
- [x] TypeScript 编译通过
- [x] API 接口测试正常