### PR TITLE
feat: 添加云端同步功能基础框架

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -138,10 +138,8 @@ impl Default for SlashCommandRule {
 pub struct CloudSyncConfig {
     /// 云端服务器地址
     pub server_url: String,
-    /// 认证 token
-    pub token: Option<String>,
-    /// 设备 ID
-    pub device_id: Option<i64>,
+    /// 同步 Token (ntd_xxx 格式)
+    pub sync_token: Option<String>,
     /// 最后同步时间
     pub last_sync_at: Option<String>,
     /// 默认冲突解决模式
@@ -152,8 +150,7 @@ impl Default for CloudSyncConfig {
     fn default() -> Self {
         Self {
             server_url: String::new(),
-            token: None,
-            device_id: None,
+            sync_token: None,
             last_sync_at: None,
             default_conflict_mode: "overwrite".to_string(),
         }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -73,6 +73,8 @@ pub struct Config {
     pub auto_usage_stats_enabled: bool,
     /// AI 使用统计自动归档 cron 表达式（6 字段，含秒），默认每天凌晨 1 点执行
     pub auto_usage_stats_cron: String,
+    /// 云端同步配置
+    pub cloud_sync: CloudSyncConfig,
 }
 
 /// Paths for each supported executor binary.
@@ -130,6 +132,34 @@ impl Default for SlashCommandRule {
     }
 }
 
+/// 云端同步配置
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CloudSyncConfig {
+    /// 云端服务器地址
+    pub server_url: String,
+    /// 认证 token
+    pub token: Option<String>,
+    /// 设备 ID
+    pub device_id: Option<i64>,
+    /// 最后同步时间
+    pub last_sync_at: Option<String>,
+    /// 默认冲突解决模式
+    pub default_conflict_mode: String,
+}
+
+impl Default for CloudSyncConfig {
+    fn default() -> Self {
+        Self {
+            server_url: String::new(),
+            token: None,
+            device_id: None,
+            last_sync_at: None,
+            default_conflict_mode: "overwrite".to_string(),
+        }
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -158,6 +188,7 @@ impl Default for Config {
             scheduler_default_timezone: None,
             auto_usage_stats_enabled: false,
             auto_usage_stats_cron: "0 0 1 * * *".to_string(),
+            cloud_sync: CloudSyncConfig::default(),
         }
     }
 }

--- a/backend/src/db/entity/mod.rs
+++ b/backend/src/db/entity/mod.rs
@@ -9,6 +9,7 @@ pub mod feishu_push_targets;
 pub mod feishu_response_config;
 pub mod feishu_group_whitelist;
 pub mod project_directories;
+pub mod sync_records;
 pub mod tags;
 pub mod todo_tags;
 pub mod todo_templates;
@@ -31,6 +32,7 @@ pub mod prelude {
     pub use super::feishu_response_config::Entity as FeishuResponseConfig;
     pub use super::feishu_group_whitelist::Entity as FeishuGroupWhitelist;
     pub use super::project_directories::Entity as ProjectDirectories;
+    pub use super::sync_records::Entity as SyncRecords;
     pub use super::tags::Entity as Tags;
     pub use super::todo_tags::Entity as TodoTags;
     pub use super::todo_templates::Entity as TodoTemplates;

--- a/backend/src/db/entity/sync_records.rs
+++ b/backend/src/db/entity/sync_records.rs
@@ -1,0 +1,28 @@
+//! Sync records entity
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "sync_records")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    #[sea_orm(column_name = "direction")]
+    pub direction: String,
+    #[sea_orm(column_name = "conflict_mode")]
+    pub conflict_mode: String,
+    #[sea_orm(column_name = "status")]
+    pub status: String,
+    #[sea_orm(column_name = "data_type")]
+    pub data_type: String,
+    #[sea_orm(column_name = "details")]
+    pub details: Option<String>,
+    #[sea_orm(column_name = "error_message")]
+    pub error_message: Option<String>,
+    #[sea_orm(column_name = "created_at")]
+    pub created_at: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -10,10 +10,11 @@ use std::time::Duration;
 use sea_orm::{
     ActiveModelBehavior, ActiveModelTrait, ColumnTrait, ConnectOptions, ConnectionTrait,
     Database as SeaDatabase, DatabaseConnection, DbBackend, EntityTrait, IntoActiveModel,
-    Order, QueryFilter, QueryOrder, Statement,
+    Order, QueryFilter, QueryOrder, QuerySelect, Statement,
 };
 
 pub mod entity;
+pub mod sync_record;
 pub use entity::prelude::*;
 
 /// Model breakdown with date (for API responses)
@@ -911,6 +912,23 @@ impl Database {
              END",
         )
         .await?;
+
+        // 同步记录表
+        self.exec(
+            "CREATE TABLE IF NOT EXISTS sync_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                direction TEXT NOT NULL,
+                conflict_mode TEXT NOT NULL,
+                status TEXT NOT NULL,
+                data_type TEXT NOT NULL,
+                details TEXT,
+                error_message TEXT,
+                created_at TEXT
+            )",
+        )
+        .await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_sync_records_created_at ON sync_records(created_at DESC)")
+            .await?;
 
         Ok(())
     }

--- a/backend/src/db/sync_record.rs
+++ b/backend/src/db/sync_record.rs
@@ -1,0 +1,43 @@
+//! Sync records database operations
+use sea_orm::{ActiveModelTrait, ActiveValue, EntityTrait, QueryOrder, QuerySelect};
+use crate::db::Database;
+use crate::db::entity::sync_records;
+
+impl Database {
+    /// 创建同步记录
+    pub async fn create_sync_record(
+        &self,
+        direction: &str,
+        conflict_mode: &str,
+        status: &str,
+        data_type: &str,
+        details: Option<&str>,
+        error_message: Option<&str>,
+    ) -> Result<i64, sea_orm::DbErr> {
+        let am = sync_records::ActiveModel {
+            direction: ActiveValue::Set(direction.to_string()),
+            conflict_mode: ActiveValue::Set(conflict_mode.to_string()),
+            status: ActiveValue::Set(status.to_string()),
+            data_type: ActiveValue::Set(data_type.to_string()),
+            details: ActiveValue::Set(details.map(|s| s.to_string())),
+            error_message: ActiveValue::Set(error_message.map(|s| s.to_string())),
+            ..Default::default()
+        };
+        let result = am.insert(&self.conn).await?;
+        Ok(result.id)
+    }
+
+    /// 获取同步记录列表
+    pub async fn get_sync_records(
+        &self,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<sync_records::Model>, sea_orm::DbErr> {
+        sync_records::Entity::find()
+            .order_by_desc(sync_records::Column::CreatedAt)
+            .limit(limit as u64)
+            .offset(offset as u64)
+            .all(&self.conn)
+            .await
+    }
+}

--- a/backend/src/db/sync_record.rs
+++ b/backend/src/db/sync_record.rs
@@ -3,6 +3,8 @@ use sea_orm::{ActiveModelTrait, ActiveValue, EntityTrait, QueryOrder, QuerySelec
 use crate::db::Database;
 use crate::db::entity::sync_records;
 
+
+
 impl Database {
     /// 创建同步记录
     pub async fn create_sync_record(
@@ -14,6 +16,8 @@ impl Database {
         details: Option<&str>,
         error_message: Option<&str>,
     ) -> Result<i64, sea_orm::DbErr> {
+        // 显式设置 created_at，避免 SQLite 把 NULL 排到结果最前面
+        let now = chrono::Utc::now().to_rfc3339();
         let am = sync_records::ActiveModel {
             direction: ActiveValue::Set(direction.to_string()),
             conflict_mode: ActiveValue::Set(conflict_mode.to_string()),
@@ -21,6 +25,7 @@ impl Database {
             data_type: ActiveValue::Set(data_type.to_string()),
             details: ActiveValue::Set(details.map(|s| s.to_string())),
             error_message: ActiveValue::Set(error_message.map(|s| s.to_string())),
+            created_at: ActiveValue::Set(Some(now)),
             ..Default::default()
         };
         let result = am.insert(&self.conn).await?;
@@ -33,11 +38,30 @@ impl Database {
         limit: i64,
         offset: i64,
     ) -> Result<Vec<sync_records::Model>, sea_orm::DbErr> {
+        // 按 id 倒序：id 是自增主键，等同于按插入时间倒序，
+        // 而且避免了 created_at 为 NULL 时 SQLite 排序不稳定的问题
         sync_records::Entity::find()
-            .order_by_desc(sync_records::Column::CreatedAt)
+            .order_by_desc(sync_records::Column::Id)
             .limit(limit as u64)
             .offset(offset as u64)
             .all(&self.conn)
             .await
+    }
+
+    /// 统计同步记录总数，给前端分页用
+    pub async fn count_sync_records(&self) -> Result<i64, sea_orm::DbErr> {
+        use sea_orm::PaginatorTrait;
+        let n = sync_records::Entity::find()
+            .count(&self.conn)
+            .await?;
+        Ok(n as i64)
+    }
+
+    /// 清空全部同步历史，返回实际删除条数
+    pub async fn clear_sync_records(&self) -> Result<u64, sea_orm::DbErr> {
+        let res = sync_records::Entity::delete_many()
+            .exec(&self.conn)
+            .await?;
+        Ok(res.rows_affected)
     }
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -594,8 +594,6 @@ pub fn create_app(
         .route("/api/cloud/config", get(sync::cloud_get_config).post(sync::cloud_save_config))
         .route("/api/cloud/sync/status", get(sync::cloud_sync_status))
         .route("/api/cloud/sync/records", get(sync::cloud_sync_records))
-        .route("/api/cloud/auth/logout", post(sync::cloud_logout))
-        .route("/api/cloud/devices", post(sync::cloud_create_device))
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024)) // 10MB
         .layer(CompressionLayer::new())
         .layer(

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -593,9 +593,9 @@ pub fn create_app(
         // 云端同步路由
         .route("/api/cloud/config", get(sync::cloud_get_config).post(sync::cloud_save_config))
         .route("/api/cloud/sync/status", get(sync::cloud_sync_status))
-        .route("/api/cloud/sync/records", get(sync::cloud_sync_records))
-        .route("/api/cloud/sync/push", get(sync::cloud_sync_push))
-        .route("/api/cloud/sync/pull", get(sync::cloud_sync_pull))
+        .route("/api/cloud/sync/records", get(sync::cloud_sync_records).delete(sync::cloud_clear_sync_records))
+        .route("/api/cloud/sync/push", post(sync::cloud_sync_push))
+        .route("/api/cloud/sync/pull", post(sync::cloud_sync_pull))
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024)) // 10MB
         .layer(CompressionLayer::new())
         .layer(

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -594,6 +594,8 @@ pub fn create_app(
         .route("/api/cloud/config", get(sync::cloud_get_config).post(sync::cloud_save_config))
         .route("/api/cloud/sync/status", get(sync::cloud_sync_status))
         .route("/api/cloud/sync/records", get(sync::cloud_sync_records))
+        .route("/api/cloud/sync/push", get(sync::cloud_sync_push))
+        .route("/api/cloud/sync/pull", get(sync::cloud_sync_pull))
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024)) // 10MB
         .layer(CompressionLayer::new())
         .layer(

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -160,6 +160,7 @@ pub(crate) mod todo_template;
 pub mod custom_template;
 pub mod webhook;
 pub mod usage_stats;
+pub mod sync;
 
 // WebSocket handler
 pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
@@ -589,6 +590,12 @@ pub fn create_app(
         .route("/api/custom-templates/unsubscribe", post(custom_template::unsubscribe_custom_template))
         .route("/api/custom-templates/sync", post(custom_template::sync_custom_template))
         .route("/api/custom-templates/auto-sync", put(custom_template::update_auto_sync_config))
+        // 云端同步路由
+        .route("/api/cloud/config", get(sync::cloud_get_config).post(sync::cloud_save_config))
+        .route("/api/cloud/sync/status", get(sync::cloud_sync_status))
+        .route("/api/cloud/sync/records", get(sync::cloud_sync_records))
+        .route("/api/cloud/auth/logout", post(sync::cloud_logout))
+        .route("/api/cloud/devices", post(sync::cloud_create_device))
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024)) // 10MB
         .layer(CompressionLayer::new())
         .layer(

--- a/backend/src/handlers/sync.rs
+++ b/backend/src/handlers/sync.rs
@@ -4,8 +4,11 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
+use crate::db::Database;
 use crate::handlers::{ApiResponse, AppError, AppState};
+use crate::models::{Todo, TodoStatus};
 
 // ============ Types ============
 
@@ -29,6 +32,91 @@ impl Default for CloudConfig {
             default_conflict_mode: "overwrite".to_string(),
         }
     }
+}
+
+// 云端同步的 TodoItem 格式
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudTodoItem {
+    pub title: String,
+    #[serde(default)]
+    pub prompt: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub executor: Option<String>,
+    #[serde(default)]
+    pub scheduler_enabled: bool,
+    #[serde(default)]
+    pub scheduler_config: Option<String>,
+    #[serde(default)]
+    pub tag_names: Vec<String>,
+    #[serde(default)]
+    pub workspace: Option<String>,
+    #[serde(default)]
+    pub worktree: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudSyncData {
+    pub version: String,
+    #[serde(default)]
+    pub todos: Vec<CloudTodoItem>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub skills: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudSyncResponse {
+    pub success: bool,
+    #[serde(default)]
+    pub merged_data: Option<CloudSyncData>,
+    #[serde(default)]
+    pub preview: Option<bool>,
+    #[serde(default)]
+    pub conflicts: Option<Vec<CloudConflict>>,
+    #[serde(default)]
+    pub summary: Option<CloudSyncSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudConflict {
+    pub title: String,
+    #[serde(default)]
+    pub action: Option<String>,
+    #[serde(default)]
+    pub server_item: Option<CloudTodoItem>,
+    #[serde(default)]
+    pub client_item: Option<CloudTodoItem>,
+    #[serde(default)]
+    pub new_title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudSyncSummary {
+    #[serde(default)]
+    pub total_client_items: i64,
+    #[serde(default)]
+    pub new_items: i64,
+    #[serde(default)]
+    pub overwritten: i64,
+    #[serde(default)]
+    pub skipped: i64,
+    #[serde(default)]
+    pub renamed: i64,
+    #[serde(default)]
+    pub final_total: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudPullResponse {
+    #[serde(default)]
+    pub data_type: String,
+    #[serde(default)]
+    pub data: Option<String>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
 }
 
 // ============ Sync Status Handlers ============
@@ -147,6 +235,263 @@ pub async fn cloud_save_config(
     Ok(ApiResponse::ok(SaveResponse { saved: true }))
 }
 
+// ============ Sync Handlers ============
+
+#[derive(Deserialize)]
+pub struct SyncQuery {
+    pub conflict_mode: Option<String>,
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Serialize)]
+pub struct SyncResult {
+    pub success: bool,
+    pub direction: String,
+    pub conflict_mode: String,
+    pub dry_run: bool,
+    pub pushed_count: i64,
+    pub pulled_count: i64,
+    pub conflicts_count: i64,
+    pub errors: Vec<String>,
+}
+
+fn local_todos_to_cloud(todos: Vec<Todo>, tag_map: HashMap<i64, String>) -> CloudSyncData {
+    let cloud_todos: Vec<CloudTodoItem> = todos
+        .into_iter()
+        .map(|t| {
+            let tag_names: Vec<String> = t
+                .tag_ids
+                .iter()
+                .filter_map(|id| tag_map.get(id).cloned())
+                .collect();
+
+            CloudTodoItem {
+                title: t.title,
+                prompt: t.prompt,
+                status: t.status.to_string(),
+                executor: t.executor,
+                scheduler_enabled: t.scheduler_enabled,
+                scheduler_config: t.scheduler_config,
+                tag_names,
+                workspace: t.workspace,
+                worktree: t.worktree_enabled.then(|| "auto".to_string()),
+            }
+        })
+        .collect();
+
+    CloudSyncData {
+        version: "1.0".to_string(),
+        todos: cloud_todos,
+        tags: vec![],
+        skills: vec![],
+    }
+}
+
+/// POST /api/cloud/sync/push - 向上同步（上传本地 todos 到云端）
+pub async fn cloud_sync_push(
+    State(state): State<AppState>,
+    Query(query): Query<SyncQuery>,
+) -> Result<ApiResponse<SyncResult>, AppError> {
+    let cfg = state.config.read().await;
+
+    let token = cfg
+        .cloud_sync
+        .sync_token
+        .as_ref()
+        .ok_or_else(|| AppError::BadRequest("请先配置同步 Token".to_string()))?;
+
+    let server_url = cfg.cloud_sync.server_url.clone();
+    let conflict_mode = query
+        .conflict_mode
+        .as_deref()
+        .unwrap_or(&cfg.cloud_sync.default_conflict_mode);
+    let dry_run = query.dry_run.unwrap_or(false);
+
+    // 获取本地 todos
+    let todos = state.db.get_todos().await.map_err(|e| {
+        AppError::Internal(format!("获取本地 todos 失败: {}", e))
+    })?;
+
+    // 获取标签映射
+    let tags = state.db.get_tags().await.map_err(|e| {
+        AppError::Internal(format!("获取本地标签失败: {}", e))
+    })?;
+    let tag_map: HashMap<i64, String> = tags.into_iter().map(|t| (t.id, t.name)).collect();
+
+    // 转换为云端格式
+    let cloud_data = local_todos_to_cloud(todos, tag_map);
+    let yaml_content = serde_yaml::to_string(&cloud_data)
+        .map_err(|e| AppError::Internal(format!("序列化失败: {}", e)))?;
+
+    // 调用云端 API
+    let client = reqwest::Client::new();
+    let body = format!(
+        "data_type: todos\nconflict_mode: {}\ndry_run: {}\ndata: |\n{}",
+        conflict_mode,
+        dry_run,
+        yaml_content.lines().map(|l| format!("  {}", l)).collect::<Vec<_>>().join("\n")
+    );
+
+    let resp = client
+        .post(format!("{}/api/v1/sync/push", server_url))
+        .header("Authorization", format!("Bearer {}", token))
+        .header("Content-Type", "text/yaml")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("网络请求失败: {}", e)))?;
+
+    let status = resp.status();
+    let cloud_resp_text = resp.text().await.unwrap_or_default();
+
+    // 记录同步结果
+    let success = status.is_success();
+    let pushed_count = if success { cloud_data.todos.len() as i64 } else { 0 };
+    let errors = if !success {
+        vec![cloud_resp_text.clone()]
+    } else {
+        vec![]
+    };
+
+    // 保存同步记录
+    let _ = state
+        .db
+        .create_sync_record(
+            "push",
+            conflict_mode,
+            if success { "success" } else { "failed" },
+            "todos",
+            Some(&serde_json::json!({
+                "pushed_count": pushed_count,
+                "dry_run": dry_run
+            }).to_string()),
+            if !success { Some(&cloud_resp_text) } else { None },
+        )
+        .await;
+
+    // 更新最后同步时间
+    if success && !dry_run {
+        let mut cfg = state.config.write().await;
+        cfg.cloud_sync.last_sync_at = Some(chrono::Utc::now().to_rfc3339());
+        let _ = cfg.save();
+    }
+
+    Ok(ApiResponse::ok(SyncResult {
+        success,
+        direction: "push".to_string(),
+        conflict_mode: conflict_mode.to_string(),
+        dry_run,
+        pushed_count,
+        pulled_count: 0,
+        conflicts_count: 0,
+        errors,
+    }))
+}
+
+/// GET /api/cloud/sync/pull - 向下同步（从云端拉取 todos）
+pub async fn cloud_sync_pull(
+    State(state): State<AppState>,
+    Query(query): Query<SyncQuery>,
+) -> Result<ApiResponse<SyncResult>, AppError> {
+    let cfg = state.config.read().await;
+
+    let token = cfg
+        .cloud_sync
+        .sync_token
+        .as_ref()
+        .ok_or_else(|| AppError::BadRequest("请先配置同步 Token".to_string()))?;
+
+    let server_url = cfg.cloud_sync.server_url.clone();
+    let conflict_mode = query
+        .conflict_mode
+        .as_deref()
+        .unwrap_or(&cfg.cloud_sync.default_conflict_mode);
+    let dry_run = query.dry_run.unwrap_or(false);
+
+    // 调用云端 API 获取数据
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{}/api/v1/sync/pull?data_type=todos", server_url))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("网络请求失败: {}", e)))?;
+
+    let status = resp.status();
+
+    if !status.is_success() {
+        let err_text = resp.text().await.unwrap_or_default();
+        // 记录失败
+        let _ = state
+            .db
+            .create_sync_record(
+                "pull",
+                conflict_mode,
+                "failed",
+                "todos",
+                None,
+                Some(&err_text),
+            )
+            .await;
+
+        return Err(AppError::BadRequest(format!("拉取失败: {}", err_text)));
+    }
+
+    let cloud_resp: CloudPullResponse = resp
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("解析响应失败: {}", e)))?;
+
+    let pulled_count = if let Some(data_str) = &cloud_resp.data {
+        if let Ok(cloud_data) = serde_yaml::from_str::<CloudSyncData>(data_str) {
+            if !dry_run {
+                // TODO: 根据 conflict_mode 合并 todos 到本地数据库
+                cloud_data.todos.len() as i64
+            } else {
+                cloud_data.todos.len() as i64
+            }
+        } else {
+            0
+        }
+    } else {
+        0
+    };
+
+    // 记录同步结果
+    let _ = state
+        .db
+        .create_sync_record(
+            "pull",
+            conflict_mode,
+            if dry_run { "dry_run" } else { "success" },
+            "todos",
+            Some(&serde_json::json!({
+                "pulled_count": pulled_count,
+                "dry_run": dry_run
+            }).to_string()),
+            None,
+        )
+        .await;
+
+    // 更新最后同步时间
+    if !dry_run {
+        let mut cfg = state.config.write().await;
+        cfg.cloud_sync.last_sync_at = Some(chrono::Utc::now().to_rfc3339());
+        let _ = cfg.save();
+    }
+
+    Ok(ApiResponse::ok(SyncResult {
+        success: true,
+        direction: "pull".to_string(),
+        conflict_mode: conflict_mode.to_string(),
+        dry_run,
+        pushed_count: 0,
+        pulled_count,
+        conflicts_count: 0,
+        errors: vec![],
+    }))
+}
+
 // ============ Sync Records Handlers ============
 
 #[derive(Serialize)]
@@ -178,16 +523,19 @@ pub async fn cloud_sync_records(
     let records = state.db.get_sync_records(limit, offset).await
         .map_err(|e| AppError::Internal(format!("获取同步记录失败: {}", e)))?;
 
-    let response: Vec<SyncRecord> = records.into_iter().map(|r| SyncRecord {
-        id: r.id,
-        direction: r.direction,
-        conflict_mode: r.conflict_mode,
-        status: r.status,
-        data_type: r.data_type,
-        details: r.details,
-        error_message: r.error_message,
-        created_at: r.created_at,
-    }).collect();
+    let response: Vec<SyncRecord> = records
+        .into_iter()
+        .map(|r| SyncRecord {
+            id: r.id,
+            direction: r.direction,
+            conflict_mode: r.conflict_mode,
+            status: r.status,
+            data_type: r.data_type,
+            details: r.details,
+            error_message: r.error_message,
+            created_at: r.created_at,
+        })
+        .collect();
 
     Ok(ApiResponse::ok(response))
 }

--- a/backend/src/handlers/sync.rs
+++ b/backend/src/handlers/sync.rs
@@ -138,29 +138,38 @@ struct CloudSyncStatusResponse {
 pub async fn cloud_sync_status(
     State(state): State<AppState>,
 ) -> Result<ApiResponse<SyncStatusResponse>, AppError> {
-    let cfg = state.config.read().await;
-
-    let connected = !cfg.cloud_sync.server_url.is_empty();
-    let authenticated = cfg.cloud_sync.sync_token.is_some();
-    let server_url = cfg.cloud_sync.server_url.clone();
+    // 关键：先把所有需要从 config 读的值一次性拷出来，然后立刻释放读锁。
+    // 之后再去打云端 HTTP，否则在网络抖动期间会一直持读锁，阻塞其他写者。
+    let (connected, authenticated, server_url, token, last_sync_at_fallback) = {
+        let cfg = state.config.read().await;
+        let server_url = cfg.cloud_sync.server_url.clone();
+        let token = cfg.cloud_sync.sync_token.clone();
+        let last_sync_at = cfg.cloud_sync.last_sync_at.clone();
+        let connected = !server_url.is_empty();
+        let authenticated = token.is_some();
+        (connected, authenticated, server_url, token, last_sync_at)
+    };
 
     // 如果已配置 token，尝试从云端获取真实同步状态
-    let last_sync_at = if let Some(token) = &cfg.cloud_sync.sync_token {
-        if !cfg.cloud_sync.server_url.is_empty() {
+    let last_sync_at = if let Some(token) = &token {
+        if !server_url.is_empty() {
             match reqwest::Client::new()
-                .get(format!("{}/api/v1/sync/status?data_type=todos", cfg.cloud_sync.server_url))
+                .get(format!("{}/api/v1/sync/status?data_type=todos", server_url))
                 .header("Authorization", format!("Bearer {}", token))
                 .send()
                 .await
             {
                 Ok(resp) if resp.status().is_success() => {
-                    match resp.json::<CloudSyncStatusResponse>().await {
-                        Ok(data) => data.last_sync_at,
-                        Err(_) => cfg.cloud_sync.last_sync_at.clone(),
+                    match resp.text().await {
+                        Ok(body) => match serde_yaml::from_str::<CloudSyncStatusResponse>(&body) {
+                            Ok(data) => data.last_sync_at,
+                            Err(_) => last_sync_at_fallback,
+                        },
+                        Err(_) => last_sync_at_fallback,
                     }
                 }
-                Ok(_) => cfg.cloud_sync.last_sync_at.clone(),
-                Err(_) => cfg.cloud_sync.last_sync_at.clone(),
+                Ok(_) => last_sync_at_fallback,
+                Err(_) => last_sync_at_fallback,
             }
         } else {
             None
@@ -255,6 +264,91 @@ pub struct SyncResult {
     pub errors: Vec<String>,
 }
 
+/// 将云端 todos 合并到本地数据库
+/// 冲突策略（按 title 匹配）：
+/// - overwrite: 覆盖本地同名 todo 的 prompt/status
+/// - skip:      跳过云端这条，保留本地
+/// - rename:    将云端 todo 重命名后插入（追加 "(云端)" 后缀）
+/// 返回成功插入/更新的条数
+async fn merge_cloud_todos_to_local(
+    db: &Database,
+    cloud_todos: &[CloudTodoItem],
+    conflict_mode: &str,
+) -> Result<i64, String> {
+    let mut affected = 0i64;
+    let local_todos = db.get_todos().await.map_err(|e| e.to_string())?;
+    // 用 title 作为冲突判断键（小写比较避免大小写差异）
+    let local_by_title: HashMap<String, i64> = local_todos
+        .iter()
+        .map(|t| (t.title.trim().to_lowercase(), t.id))
+        .collect();
+
+    for item in cloud_todos {
+        let title = item.title.trim();
+        if title.is_empty() {
+            continue;
+        }
+        let key = title.to_lowercase();
+        match conflict_mode {
+            "skip" => {
+                // 跳过：本地已有同名 todo 就忽略
+                if local_by_title.contains_key(&key) {
+                    continue;
+                }
+                let new_id = db.create_todo(title, &item.prompt).await.map_err(|e| e.to_string())?;
+                affected += 1;
+                tracing::info!("pull: 新增 todo id={} title={}", new_id, title);
+            }
+            "overwrite" => {
+                if let Some(&id) = local_by_title.get(&key) {
+                    // 覆盖：用云端数据更新本地
+                    let status = item.status.parse::<TodoStatus>().unwrap_or(TodoStatus::Pending);
+                    let executor = item.executor.as_deref();
+                    db.update_todo_full(crate::db::TodoUpdate {
+                        id,
+                        title,
+                        prompt: &item.prompt,
+                        status,
+                        executor,
+                        scheduler_enabled: None,
+                        scheduler_config: None,
+                        scheduler_timezone: None,
+                        workspace: item.workspace.as_deref(),
+                        worktree_enabled: None,
+                    })
+                    .await
+                    .map_err(|e| e.to_string())?;
+                    affected += 1;
+                    tracing::info!("pull: 覆盖 todo id={} title={}", id, title);
+                } else {
+                    let new_id = db.create_todo(title, &item.prompt).await.map_err(|e| e.to_string())?;
+                    affected += 1;
+                    tracing::info!("pull: 新增 todo id={} title={}", new_id, title);
+                }
+            }
+            "rename" => {
+                // 重命名：本地已有同名就改个名字再插入
+                let final_title = if local_by_title.contains_key(&key) {
+                    format!("{} (云端)", title)
+                } else {
+                    title.to_string()
+                };
+                let new_id = db.create_todo(&final_title, &item.prompt).await.map_err(|e| e.to_string())?;
+                affected += 1;
+                tracing::info!("pull: 新增 todo id={} title={}", new_id, final_title);
+            }
+            _ => {
+                // 未知策略：当作 skip 处理
+                if !local_by_title.contains_key(&key) {
+                    let new_id = db.create_todo(title, &item.prompt).await.map_err(|e| e.to_string())?;
+                    affected += 1;
+                }
+            }
+        }
+    }
+    Ok(affected)
+}
+
 fn local_todos_to_cloud(todos: Vec<Todo>, tag_map: HashMap<i64, String>) -> CloudSyncData {
     let cloud_todos: Vec<CloudTodoItem> = todos
         .into_iter()
@@ -292,20 +386,25 @@ pub async fn cloud_sync_push(
     State(state): State<AppState>,
     Query(query): Query<SyncQuery>,
 ) -> Result<ApiResponse<SyncResult>, AppError> {
-    let cfg = state.config.read().await;
-
-    let token = cfg
-        .cloud_sync
-        .sync_token
-        .as_ref()
-        .ok_or_else(|| AppError::BadRequest("请先配置同步 Token".to_string()))?;
-
-    let server_url = cfg.cloud_sync.server_url.clone();
-    let conflict_mode = query
-        .conflict_mode
-        .as_deref()
-        .unwrap_or(&cfg.cloud_sync.default_conflict_mode);
+    // 关键：先把所有需要从 config 读的值一次性拷出来，然后立刻释放读锁。
+    // 之前这里把读锁一路持有到函数末尾，并随后在同一任务里取写锁，
+    // tokio::sync::RwLock 不允许同一任务持读锁时再等待写锁，会自我死锁——
+    // 云端早就返回了，本端 HTTP 响应却永远不返回。修法：缩短临界区。
     let dry_run = query.dry_run.unwrap_or(false);
+    let (server_url, token, conflict_mode) = {
+        let cfg = state.config.read().await;
+        let token = cfg
+            .cloud_sync
+            .sync_token
+            .clone()
+            .ok_or_else(|| AppError::BadRequest("请先配置同步 Token".to_string()))?;
+        let server_url = cfg.cloud_sync.server_url.clone();
+        let conflict_mode = query
+            .conflict_mode
+            .clone()
+            .unwrap_or_else(|| cfg.cloud_sync.default_conflict_mode.clone());
+        (server_url, token, conflict_mode)
+    };
 
     // 获取本地 todos
     let todos = state.db.get_todos().await.map_err(|e| {
@@ -324,14 +423,18 @@ pub async fn cloud_sync_push(
         .map_err(|e| AppError::Internal(format!("序列化失败: {}", e)))?;
 
     // 调用云端 API
-    let client = reqwest::Client::new();
+    // 同步可能慢（拉全量 + 远端往返），给 reqwest 显式 5 分钟上限；
+    // 0 是「无超时」，本场景下会让前端超时后本端继续挂起，徒增风险。
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(300))
+        .build()
+        .map_err(|e| AppError::Internal(format!("构造 HTTP 客户端失败: {}", e)))?;
     let body = format!(
         "data_type: todos\nconflict_mode: {}\ndry_run: {}\ndata: |\n{}",
         conflict_mode,
         dry_run,
         yaml_content.lines().map(|l| format!("  {}", l)).collect::<Vec<_>>().join("\n")
     );
-
     let resp = client
         .post(format!("{}/api/v1/sync/push", server_url))
         .header("Authorization", format!("Bearer {}", token))
@@ -344,13 +447,55 @@ pub async fn cloud_sync_push(
     let status = resp.status();
     let cloud_resp_text = resp.text().await.unwrap_or_default();
 
-    // 记录同步结果
-    let success = status.is_success();
-    let pushed_count = if success { cloud_data.todos.len() as i64 } else { 0 };
-    let errors = if !success {
-        vec![cloud_resp_text.clone()]
+    // 必须以云端业务字段 `success` 为准，HTTP 2x 不代表同步成功。
+    // 同时兼容 4xx/5xx：把响应体作为错误信息透传给用户。
+    //
+    // 云端 push 响应是 YAML（不是 JSON），且 `merged_data` 是 literal block 字符串，
+    // 与 CloudSyncResponse 的 Option<CloudSyncData> 不匹配。只需要 success 字段，
+    // 拆出一个最小结构避免误把 `merged_data` 当对象解析而炸掉。
+    #[derive(Deserialize)]
+    struct CloudPushStatusOnly {
+        success: bool,
+    }
+
+    let (success, errors) = if !status.is_success() {
+        (
+            false,
+            vec![format!("HTTP {}: {}", status.as_u16(), cloud_resp_text)],
+        )
     } else {
-        vec![]
+        match serde_yaml::from_str::<CloudPushStatusOnly>(&cloud_resp_text) {
+            Ok(parsed) if parsed.success => (true, vec![]),
+            Ok(_) => {
+                // 业务失败：HTTP 200 但 success=false，尝试提取 summary 字段给用户看。
+                let summary = serde_yaml::from_str::<CloudSyncResponse>(&cloud_resp_text)
+                    .ok()
+                    .and_then(|r| r.summary)
+                    .map(|s| {
+                        format!(
+                            "total={} new={} overwrite={} skip={} rename={}",
+                            s.total_client_items, s.new_items, s.overwritten, s.skipped, s.renamed
+                        )
+                    })
+                    .unwrap_or_default();
+                let msg = if summary.is_empty() {
+                    "云端未说明失败原因".to_string()
+                } else {
+                    format!("云端业务失败：{}", summary)
+                };
+                (false, vec![msg])
+            }
+            Err(e) => (
+                false,
+                vec![format!("解析云端响应失败: {} (body: {})", e, cloud_resp_text)],
+            ),
+        }
+    };
+    let pushed_count = if success { cloud_data.todos.len() as i64 } else { 0 };
+    let error_message = if !success {
+        Some(errors.join("\n"))
+    } else {
+        None
     };
 
     // 保存同步记录
@@ -358,18 +503,22 @@ pub async fn cloud_sync_push(
         .db
         .create_sync_record(
             "push",
-            conflict_mode,
-            if success { "success" } else { "failed" },
+            &conflict_mode,
+            if success {
+                if dry_run { "dry_run" } else { "success" }
+            } else {
+                "failed"
+            },
             "todos",
             Some(&serde_json::json!({
                 "pushed_count": pushed_count,
                 "dry_run": dry_run
             }).to_string()),
-            if !success { Some(&cloud_resp_text) } else { None },
+            error_message.as_deref(),
         )
         .await;
 
-    // 更新最后同步时间
+    // 更新最后同步时间：现在没有别的读锁阻塞，可以安全取写锁。
     if success && !dry_run {
         let mut cfg = state.config.write().await;
         cfg.cloud_sync.last_sync_at = Some(chrono::Utc::now().to_rfc3339());
@@ -379,7 +528,7 @@ pub async fn cloud_sync_push(
     Ok(ApiResponse::ok(SyncResult {
         success,
         direction: "push".to_string(),
-        conflict_mode: conflict_mode.to_string(),
+        conflict_mode,
         dry_run,
         pushed_count,
         pulled_count: 0,
@@ -393,23 +542,29 @@ pub async fn cloud_sync_pull(
     State(state): State<AppState>,
     Query(query): Query<SyncQuery>,
 ) -> Result<ApiResponse<SyncResult>, AppError> {
-    let cfg = state.config.read().await;
-
-    let token = cfg
-        .cloud_sync
-        .sync_token
-        .as_ref()
-        .ok_or_else(|| AppError::BadRequest("请先配置同步 Token".to_string()))?;
-
-    let server_url = cfg.cloud_sync.server_url.clone();
-    let conflict_mode = query
-        .conflict_mode
-        .as_deref()
-        .unwrap_or(&cfg.cloud_sync.default_conflict_mode);
+    // 关键：先把所有需要从 config 读的值一次性拷出来，然后立刻释放读锁。
+    // 详见 cloud_sync_push 的注释。
     let dry_run = query.dry_run.unwrap_or(false);
+    let (server_url, token, conflict_mode) = {
+        let cfg = state.config.read().await;
+        let token = cfg
+            .cloud_sync
+            .sync_token
+            .clone()
+            .ok_or_else(|| AppError::BadRequest("请先配置同步 Token".to_string()))?;
+        let server_url = cfg.cloud_sync.server_url.clone();
+        let conflict_mode = query
+            .conflict_mode
+            .clone()
+            .unwrap_or_else(|| cfg.cloud_sync.default_conflict_mode.clone());
+        (server_url, token, conflict_mode)
+    };
 
     // 调用云端 API 获取数据
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(300))
+        .build()
+        .map_err(|e| AppError::Internal(format!("构造 HTTP 客户端失败: {}", e)))?;
     let resp = client
         .get(format!("{}/api/v1/sync/pull?data_type=todos", server_url))
         .header("Authorization", format!("Bearer {}", token))
@@ -426,7 +581,7 @@ pub async fn cloud_sync_pull(
             .db
             .create_sync_record(
                 "pull",
-                conflict_mode,
+                &conflict_mode,
                 "failed",
                 "todos",
                 None,
@@ -437,16 +592,24 @@ pub async fn cloud_sync_pull(
         return Err(AppError::BadRequest(format!("拉取失败: {}", err_text)));
     }
 
-    let cloud_resp: CloudPullResponse = resp
-        .json()
+    // 云端返回 YAML（text/yaml），不是 JSON。
+    let body = resp
+        .text()
         .await
-        .map_err(|e| AppError::Internal(format!("解析响应失败: {}", e)))?;
+        .map_err(|e| AppError::Internal(format!("读取响应失败: {}", e)))?;
+    let cloud_resp: CloudPullResponse = serde_yaml::from_str(&body)
+        .map_err(|e| AppError::Internal(format!("解析云端响应失败: {} (body: {})", e, body)))?;
 
     let pulled_count = if let Some(data_str) = &cloud_resp.data {
         if let Ok(cloud_data) = serde_yaml::from_str::<CloudSyncData>(data_str) {
             if !dry_run {
-                // TODO: 根据 conflict_mode 合并 todos 到本地数据库
-                cloud_data.todos.len() as i64
+                // 实际合并云端 todos 到本地数据库
+                match merge_cloud_todos_to_local(&state.db, &cloud_data.todos, &conflict_mode).await {
+                    Ok(n) => n,
+                    Err(e) => {
+                        return Err(AppError::Internal(format!("合并数据失败: {}", e)));
+                    }
+                }
             } else {
                 cloud_data.todos.len() as i64
             }
@@ -462,7 +625,7 @@ pub async fn cloud_sync_pull(
         .db
         .create_sync_record(
             "pull",
-            conflict_mode,
+            &conflict_mode,
             if dry_run { "dry_run" } else { "success" },
             "todos",
             Some(&serde_json::json!({
@@ -473,7 +636,7 @@ pub async fn cloud_sync_pull(
         )
         .await;
 
-    // 更新最后同步时间
+    // 更新最后同步时间：现在没有别的读锁阻塞，可以安全取写锁。
     if !dry_run {
         let mut cfg = state.config.write().await;
         cfg.cloud_sync.last_sync_at = Some(chrono::Utc::now().to_rfc3339());
@@ -483,7 +646,7 @@ pub async fn cloud_sync_pull(
     Ok(ApiResponse::ok(SyncResult {
         success: true,
         direction: "pull".to_string(),
-        conflict_mode: conflict_mode.to_string(),
+        conflict_mode,
         dry_run,
         pushed_count: 0,
         pulled_count,
@@ -512,30 +675,65 @@ pub struct SyncRecordsQuery {
     pub offset: Option<i64>,
 }
 
+/// 同步历史分页响应：records 是当前页数据，total 是全部记录数
+#[derive(Serialize)]
+pub struct SyncRecordsResponse {
+    pub records: Vec<SyncRecord>,
+    pub total: i64,
+    pub limit: i64,
+    pub offset: i64,
+}
+
 /// GET /api/cloud/sync/records - 获取同步历史记录
 pub async fn cloud_sync_records(
     State(state): State<AppState>,
     Query(query): Query<SyncRecordsQuery>,
-) -> Result<ApiResponse<Vec<SyncRecord>>, AppError> {
+) -> Result<ApiResponse<SyncRecordsResponse>, AppError> {
     let limit = query.limit.unwrap_or(50);
     let offset = query.offset.unwrap_or(0);
 
-    let records = state.db.get_sync_records(limit, offset).await
-        .map_err(|e| AppError::Internal(format!("获取同步记录失败: {}", e)))?;
+    // 并行获取当前页 + 总数，避免分页信息错乱
+    let (records, total) = tokio::try_join!(
+        state.db.get_sync_records(limit, offset),
+        state.db.count_sync_records(),
+    )
+    .map_err(|e: sea_orm::DbErr| AppError::Internal(format!("获取同步记录失败: {}", e)))?;
 
-    let response: Vec<SyncRecord> = records
-        .into_iter()
-        .map(|r| SyncRecord {
-            id: r.id,
-            direction: r.direction,
-            conflict_mode: r.conflict_mode,
-            status: r.status,
-            data_type: r.data_type,
-            details: r.details,
-            error_message: r.error_message,
-            created_at: r.created_at,
-        })
-        .collect();
+    let response = SyncRecordsResponse {
+        records: records
+            .into_iter()
+            .map(|r| SyncRecord {
+                id: r.id,
+                direction: r.direction,
+                conflict_mode: r.conflict_mode,
+                status: r.status,
+                data_type: r.data_type,
+                details: r.details,
+                error_message: r.error_message,
+                created_at: r.created_at,
+            })
+            .collect(),
+        total,
+        limit,
+        offset,
+    };
 
     Ok(ApiResponse::ok(response))
+}
+
+#[derive(Serialize)]
+pub struct ClearSyncRecordsResponse {
+    pub deleted: u64,
+}
+
+/// DELETE /api/cloud/sync/records - 清空全部同步历史
+pub async fn cloud_clear_sync_records(
+    State(state): State<AppState>,
+) -> Result<ApiResponse<ClearSyncRecordsResponse>, AppError> {
+    let deleted = state
+        .db
+        .clear_sync_records()
+        .await
+        .map_err(|e| AppError::Internal(format!("清空同步历史失败: {}", e)))?;
+    Ok(ApiResponse::ok(ClearSyncRecordsResponse { deleted }))
 }

--- a/backend/src/handlers/sync.rs
+++ b/backend/src/handlers/sync.rs
@@ -1,0 +1,234 @@
+//! 云端同步 handlers
+use axum::{
+    extract::{Query, State},
+    response::IntoResponse,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::db::Database;
+use crate::handlers::{ApiResponse, AppError, AppState};
+
+// ============ Types ============
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloudConfig {
+    pub server_url: String,
+    pub token: Option<String>,
+    pub device_id: Option<i64>,
+    pub last_sync_at: Option<String>,
+    pub default_conflict_mode: String,
+}
+
+impl Default for CloudConfig {
+    fn default() -> Self {
+        Self {
+            server_url: String::new(),
+            token: None,
+            device_id: None,
+            last_sync_at: None,
+            default_conflict_mode: "overwrite".to_string(),
+        }
+    }
+}
+
+// ============ Device Handlers ============
+
+#[derive(Deserialize)]
+pub struct DeviceRequest {
+    pub device_name: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DeviceResponse {
+    pub id: i64,
+    pub device_name: String,
+    pub last_seen_at: Option<String>,
+    pub created_at: Option<String>,
+}
+
+/// POST /api/cloud/devices - 创建设备
+pub async fn cloud_create_device(
+    State(state): State<AppState>,
+    Json(req): Json<DeviceRequest>,
+) -> Result<ApiResponse<DeviceResponse>, AppError> {
+    let (token, server_url) = {
+        let cfg = state.config.read().await;
+        (cfg.cloud_sync.token.clone(), cfg.cloud_sync.server_url.clone())
+    };
+
+    let token = token.ok_or_else(|| AppError::BadRequest("请先配置 Token".to_string()))?;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/api/devices", server_url))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&serde_json::json!({ "device_name": req.device_name }))
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("网络错误: {}", e)))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(AppError::BadRequest(format!("设备注册失败 ({}): {}", status, text)));
+    }
+
+    let device_resp: DeviceResponse = resp.json().await
+        .map_err(|e| AppError::Internal(format!("响应解析失败: {}", e)))?;
+
+    // 保存 device_id 到配置
+    {
+        let mut cfg = state.config.write().await;
+        cfg.cloud_sync.device_id = Some(device_resp.id);
+        cfg.save().map_err(|e| AppError::Internal(e.to_string()))?;
+    }
+
+    Ok(ApiResponse::ok(device_resp))
+}
+
+// ============ Sync Status Handlers ============
+
+#[derive(Serialize)]
+pub struct SyncStatusResponse {
+    pub connected: bool,
+    pub authenticated: bool,
+    pub device_id: Option<i64>,
+    pub last_sync_at: Option<String>,
+    pub server_url: String,
+}
+
+/// GET /api/cloud/sync/status - 获取同步状态
+pub async fn cloud_sync_status(
+    State(state): State<AppState>,
+) -> Result<ApiResponse<SyncStatusResponse>, AppError> {
+    let cfg = state.config.read().await;
+
+    let connected = !cfg.cloud_sync.server_url.is_empty();
+    let authenticated = cfg.cloud_sync.token.is_some();
+    let device_id = cfg.cloud_sync.device_id;
+    let last_sync_at = cfg.cloud_sync.last_sync_at.clone();
+    let server_url = cfg.cloud_sync.server_url.clone();
+
+    Ok(ApiResponse::ok(SyncStatusResponse {
+        connected,
+        authenticated,
+        device_id,
+        last_sync_at,
+        server_url,
+    }))
+}
+
+// ============ Config Handlers ============
+
+#[derive(Deserialize)]
+pub struct CloudConfigRequest {
+    pub server_url: Option<String>,
+    pub token: Option<String>,
+    pub default_conflict_mode: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct CloudConfigResponse {
+    pub server_url: String,
+    pub token: Option<String>,
+    pub device_id: Option<i64>,
+    pub last_sync_at: Option<String>,
+    pub default_conflict_mode: String,
+}
+
+/// GET /api/cloud/config - 获取云端配置
+pub async fn cloud_get_config(
+    State(state): State<AppState>,
+) -> Result<ApiResponse<CloudConfigResponse>, AppError> {
+    let cfg = state.config.read().await;
+
+    Ok(ApiResponse::ok(CloudConfigResponse {
+        server_url: cfg.cloud_sync.server_url.clone(),
+        token: cfg.cloud_sync.token.clone(),
+        device_id: cfg.cloud_sync.device_id,
+        last_sync_at: cfg.cloud_sync.last_sync_at.clone(),
+        default_conflict_mode: cfg.cloud_sync.default_conflict_mode.clone(),
+    }))
+}
+
+/// POST /api/cloud/config - 保存云端配置（包含 token）
+pub async fn cloud_save_config(
+    State(state): State<AppState>,
+    Json(req): Json<CloudConfigRequest>,
+) -> Result<ApiResponse<()>, AppError> {
+    let mut cfg = state.config.write().await;
+    if let Some(url) = req.server_url {
+        cfg.cloud_sync.server_url = url.trim_end_matches('/').to_string();
+    }
+    if let Some(token) = req.token {
+        cfg.cloud_sync.token = Some(token);
+    }
+    if let Some(mode) = req.default_conflict_mode {
+        cfg.cloud_sync.default_conflict_mode = mode;
+    }
+    cfg.save().map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(ApiResponse::ok(()))
+}
+
+// ============ Sync Records Handlers ============
+
+#[derive(Serialize)]
+pub struct SyncRecord {
+    pub id: i64,
+    pub direction: String,
+    pub conflict_mode: String,
+    pub status: String,
+    pub data_type: String,
+    pub details: Option<String>,
+    pub error_message: Option<String>,
+    pub created_at: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct SyncRecordsQuery {
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+/// GET /api/cloud/sync/records - 获取同步历史记录
+pub async fn cloud_sync_records(
+    State(state): State<AppState>,
+    Query(query): Query<SyncRecordsQuery>,
+) -> Result<ApiResponse<Vec<SyncRecord>>, AppError> {
+    let limit = query.limit.unwrap_or(50);
+    let offset = query.offset.unwrap_or(0);
+
+    let records = state.db.get_sync_records(limit, offset).await
+        .map_err(|e| AppError::Internal(format!("获取同步记录失败: {}", e)))?;
+
+    let response: Vec<SyncRecord> = records.into_iter().map(|r| SyncRecord {
+        id: r.id,
+        direction: r.direction,
+        conflict_mode: r.conflict_mode,
+        status: r.status,
+        data_type: r.data_type,
+        details: r.details,
+        error_message: r.error_message,
+        created_at: r.created_at,
+    }).collect();
+
+    Ok(ApiResponse::ok(response))
+}
+
+// ============ Logout Handler ============
+
+/// POST /api/cloud/auth/logout - 清除 Token
+pub async fn cloud_logout(
+    State(state): State<AppState>,
+) -> Result<ApiResponse<()>, AppError> {
+    let mut cfg = state.config.write().await;
+    cfg.cloud_sync.token = None;
+    cfg.cloud_sync.device_id = None;
+    cfg.cloud_sync.last_sync_at = None;
+    cfg.save().map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(ApiResponse::ok(()))
+}

--- a/backend/src/handlers/sync.rs
+++ b/backend/src/handlers/sync.rs
@@ -1,13 +1,10 @@
 //! 云端同步 handlers
 use axum::{
     extract::{Query, State},
-    response::IntoResponse,
     Json,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
-use crate::db::Database;
 use crate::handlers::{ApiResponse, AppError, AppState};
 
 // ============ Types ============
@@ -15,9 +12,11 @@ use crate::handlers::{ApiResponse, AppError, AppState};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CloudConfig {
     pub server_url: String,
-    pub token: Option<String>,
-    pub device_id: Option<i64>,
+    /// 同步 Token (ntd_xxx 格式)
+    pub sync_token: Option<String>,
+    /// 最后同步时间
     pub last_sync_at: Option<String>,
+    /// 默认冲突解决模式
     pub default_conflict_mode: String,
 }
 
@@ -25,67 +24,11 @@ impl Default for CloudConfig {
     fn default() -> Self {
         Self {
             server_url: String::new(),
-            token: None,
-            device_id: None,
+            sync_token: None,
             last_sync_at: None,
             default_conflict_mode: "overwrite".to_string(),
         }
     }
-}
-
-// ============ Device Handlers ============
-
-#[derive(Deserialize)]
-pub struct DeviceRequest {
-    pub device_name: String,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct DeviceResponse {
-    pub id: i64,
-    pub device_name: String,
-    pub last_seen_at: Option<String>,
-    pub created_at: Option<String>,
-}
-
-/// POST /api/cloud/devices - 创建设备
-pub async fn cloud_create_device(
-    State(state): State<AppState>,
-    Json(req): Json<DeviceRequest>,
-) -> Result<ApiResponse<DeviceResponse>, AppError> {
-    let (token, server_url) = {
-        let cfg = state.config.read().await;
-        (cfg.cloud_sync.token.clone(), cfg.cloud_sync.server_url.clone())
-    };
-
-    let token = token.ok_or_else(|| AppError::BadRequest("请先配置 Token".to_string()))?;
-
-    let client = reqwest::Client::new();
-    let resp = client
-        .post(format!("{}/api/devices", server_url))
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&serde_json::json!({ "device_name": req.device_name }))
-        .send()
-        .await
-        .map_err(|e| AppError::Internal(format!("网络错误: {}", e)))?;
-
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
-        return Err(AppError::BadRequest(format!("设备注册失败 ({}): {}", status, text)));
-    }
-
-    let device_resp: DeviceResponse = resp.json().await
-        .map_err(|e| AppError::Internal(format!("响应解析失败: {}", e)))?;
-
-    // 保存 device_id 到配置
-    {
-        let mut cfg = state.config.write().await;
-        cfg.cloud_sync.device_id = Some(device_resp.id);
-        cfg.save().map_err(|e| AppError::Internal(e.to_string()))?;
-    }
-
-    Ok(ApiResponse::ok(device_resp))
 }
 
 // ============ Sync Status Handlers ============
@@ -94,9 +37,13 @@ pub async fn cloud_create_device(
 pub struct SyncStatusResponse {
     pub connected: bool,
     pub authenticated: bool,
-    pub device_id: Option<i64>,
     pub last_sync_at: Option<String>,
     pub server_url: String,
+}
+
+#[derive(Deserialize)]
+struct CloudSyncStatusResponse {
+    last_sync_at: Option<String>,
 }
 
 /// GET /api/cloud/sync/status - 获取同步状态
@@ -106,15 +53,37 @@ pub async fn cloud_sync_status(
     let cfg = state.config.read().await;
 
     let connected = !cfg.cloud_sync.server_url.is_empty();
-    let authenticated = cfg.cloud_sync.token.is_some();
-    let device_id = cfg.cloud_sync.device_id;
-    let last_sync_at = cfg.cloud_sync.last_sync_at.clone();
+    let authenticated = cfg.cloud_sync.sync_token.is_some();
     let server_url = cfg.cloud_sync.server_url.clone();
+
+    // 如果已配置 token，尝试从云端获取真实同步状态
+    let last_sync_at = if let Some(token) = &cfg.cloud_sync.sync_token {
+        if !cfg.cloud_sync.server_url.is_empty() {
+            match reqwest::Client::new()
+                .get(format!("{}/api/v1/sync/status?data_type=todos", cfg.cloud_sync.server_url))
+                .header("Authorization", format!("Bearer {}", token))
+                .send()
+                .await
+            {
+                Ok(resp) if resp.status().is_success() => {
+                    match resp.json::<CloudSyncStatusResponse>().await {
+                        Ok(data) => data.last_sync_at,
+                        Err(_) => cfg.cloud_sync.last_sync_at.clone(),
+                    }
+                }
+                Ok(_) => cfg.cloud_sync.last_sync_at.clone(),
+                Err(_) => cfg.cloud_sync.last_sync_at.clone(),
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
 
     Ok(ApiResponse::ok(SyncStatusResponse {
         connected,
         authenticated,
-        device_id,
         last_sync_at,
         server_url,
     }))
@@ -125,17 +94,23 @@ pub async fn cloud_sync_status(
 #[derive(Deserialize)]
 pub struct CloudConfigRequest {
     pub server_url: Option<String>,
-    pub token: Option<String>,
+    /// 同步 Token (ntd_xxx 格式)
+    pub sync_token: Option<String>,
     pub default_conflict_mode: Option<String>,
 }
 
 #[derive(Serialize)]
 pub struct CloudConfigResponse {
     pub server_url: String,
-    pub token: Option<String>,
-    pub device_id: Option<i64>,
+    /// 是否已配置 Token (不返回实际 token)
+    pub has_token: bool,
     pub last_sync_at: Option<String>,
     pub default_conflict_mode: String,
+}
+
+#[derive(Serialize)]
+pub struct SaveResponse {
+    pub saved: bool,
 }
 
 /// GET /api/cloud/config - 获取云端配置
@@ -146,31 +121,30 @@ pub async fn cloud_get_config(
 
     Ok(ApiResponse::ok(CloudConfigResponse {
         server_url: cfg.cloud_sync.server_url.clone(),
-        token: cfg.cloud_sync.token.clone(),
-        device_id: cfg.cloud_sync.device_id,
+        has_token: cfg.cloud_sync.sync_token.is_some(),
         last_sync_at: cfg.cloud_sync.last_sync_at.clone(),
         default_conflict_mode: cfg.cloud_sync.default_conflict_mode.clone(),
     }))
 }
 
-/// POST /api/cloud/config - 保存云端配置（包含 token）
+/// POST /api/cloud/config - 保存云端配置
 pub async fn cloud_save_config(
     State(state): State<AppState>,
     Json(req): Json<CloudConfigRequest>,
-) -> Result<ApiResponse<()>, AppError> {
+) -> Result<ApiResponse<SaveResponse>, AppError> {
     let mut cfg = state.config.write().await;
     if let Some(url) = req.server_url {
         cfg.cloud_sync.server_url = url.trim_end_matches('/').to_string();
     }
-    if let Some(token) = req.token {
-        cfg.cloud_sync.token = Some(token);
+    if let Some(token) = req.sync_token {
+        cfg.cloud_sync.sync_token = Some(token);
     }
     if let Some(mode) = req.default_conflict_mode {
         cfg.cloud_sync.default_conflict_mode = mode;
     }
     cfg.save().map_err(|e| AppError::Internal(e.to_string()))?;
 
-    Ok(ApiResponse::ok(()))
+    Ok(ApiResponse::ok(SaveResponse { saved: true }))
 }
 
 // ============ Sync Records Handlers ============
@@ -216,19 +190,4 @@ pub async fn cloud_sync_records(
     }).collect();
 
     Ok(ApiResponse::ok(response))
-}
-
-// ============ Logout Handler ============
-
-/// POST /api/cloud/auth/logout - 清除 Token
-pub async fn cloud_logout(
-    State(state): State<AppState>,
-) -> Result<ApiResponse<()>, AppError> {
-    let mut cfg = state.config.write().await;
-    cfg.cloud_sync.token = None;
-    cfg.cloud_sync.device_id = None;
-    cfg.cloud_sync.last_sync_at = None;
-    cfg.save().map_err(|e| AppError::Internal(e.to_string()))?;
-
-    Ok(ApiResponse::ok(()))
 }

--- a/backend/tests/cloud_sync_tests.rs
+++ b/backend/tests/cloud_sync_tests.rs
@@ -1,0 +1,196 @@
+// 回归测试：cloud 同步 handler 不能因为持读锁再申请写锁而自我死锁。
+//
+// 之前 cloud_sync_push / cloud_sync_pull 把 config 读锁一路持有到函数末尾，
+// 随后在同一任务里调 `state.config.write().await`。tokio::sync::RwLock
+// 不允许同一任务在持读锁时再等写锁 —— 整个 future 永远不被唤醒，
+// 于是本端 HTTP 响应永远不返回（云端早处理完）。
+//
+// 修法：把所有要从 config 读的值一次性拷出来，立刻释放读锁，再去打云端。
+// 这里用一个最朴素的 mock HTTP server（tokio TcpListener）验证：
+// 1) push 在合理时间内返回，不会自我死锁；
+// 2) 拿到的 last_sync_at 在成功 push 后被写入。
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{Request, StatusCode},
+};
+use tokio::sync::broadcast;
+use tower::ServiceExt;
+
+use ntd::{
+    adapters::{ExecutorRegistry, claude_code::ClaudeCodeExecutor},
+    config::{CloudSyncConfig, Config},
+    db::Database,
+    handlers::create_app,
+    scheduler::TodoScheduler,
+    service_context::ServiceContext,
+    task_manager::TaskManager,
+};
+
+/// 起一个最小 HTTP mock：任意 POST 都回 `success: true` 的 YAML。
+/// 返回实际监听的 URL（`http://127.0.0.1:<port>`）。
+async fn spawn_mock_cloud() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = match listener.accept().await {
+                Ok(p) => p,
+                Err(_) => break,
+            };
+            tokio::spawn(async move {
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                // 读完请求（不解析，直接吞掉）。
+                let mut buf = [0u8; 4096];
+                let _ = sock.read(&mut buf).await;
+                let body = "success: true\nmerged_data: |\n  version: '1.0'\n  todos: []\n  tags: []\n  skills: []\n";
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/yaml; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            });
+        }
+    });
+    format!("http://{}", addr)
+}
+
+async fn build_test_app() -> (axum::Router, Arc<tokio::sync::RwLock<Config>>) {
+    let db = Arc::new(Database::new(":memory:").await.unwrap());
+    let executor_registry = Arc::new(ExecutorRegistry::new());
+    executor_registry
+        .register(ClaudeCodeExecutor::new("claude".to_string()))
+        .await;
+    let (tx, _rx) = broadcast::channel(100);
+    let task_manager = Arc::new(TaskManager::new());
+
+    let config = Arc::new(tokio::sync::RwLock::new(Config::default()));
+    let scheduler = Arc::new(TodoScheduler::new().await.unwrap());
+    let ctx = ServiceContext {
+        db: db.clone(),
+        executor_registry: executor_registry.clone(),
+        tx: tx.clone(),
+        task_manager: task_manager.clone(),
+        config: config.clone(),
+    };
+    scheduler.load_from_db(&ctx).await.unwrap();
+    scheduler.start().await.unwrap();
+    (create_app(ctx, scheduler), config)
+}
+
+async fn read_json(response: axum::response::Response) -> serde_json::Value {
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+/// 关键回归测试：把 mock 云端地址配进 config，调一次 push 必须在合理时间内返回。
+/// 修改前：会无限期挂起（读锁 + 同任务写锁 = tokio RwLock 自我死锁）。
+/// 修改后：正常返回，云端响应解析后 `success=true`。
+#[tokio::test]
+async fn cloud_sync_push_does_not_deadlock_with_config_write() {
+    let (app, config) = build_test_app().await;
+    let cloud_url = spawn_mock_cloud().await;
+
+    {
+        let mut cfg = config.write().await;
+        cfg.cloud_sync = CloudSyncConfig {
+            server_url: cloud_url,
+            sync_token: Some("ntd_test_token".to_string()),
+            last_sync_at: None,
+            default_conflict_mode: "overwrite".to_string(),
+        };
+    }
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/cloud/sync/push?conflict_mode=overwrite&dry_run=false")
+        .body(Body::empty())
+        .unwrap();
+
+    // 关键：给个 10s 总超时。如果读锁 + 写锁自我死锁，这一行永远不返回。
+    let response = tokio::time::timeout(Duration::from_secs(10), app.oneshot(req))
+        .await
+        .expect("cloud push 请求挂起 — 怀疑 config 读/写锁自我死锁回归")
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_json(response).await;
+    assert_eq!(body["code"], 0, "顶层 code 应为 0: {:?}", body);
+    let data = &body["data"];
+    assert_eq!(data["success"], true, "push 业务应成功: {:?}", data);
+    assert_eq!(data["direction"], "push");
+
+    // 成功 push 之后，last_sync_at 应被写回 config。
+    let cfg = config.read().await;
+    assert!(
+        cfg.cloud_sync.last_sync_at.is_some(),
+        "成功 push 之后 last_sync_at 必须被更新"
+    );
+}
+
+/// 同样覆盖 pull 路径，避免在 push 修好后 pull 又踩同一个坑。
+#[tokio::test]
+async fn cloud_sync_pull_does_not_deadlock_with_config_write() {
+    let (app, config) = build_test_app().await;
+
+    // pull 调的是 GET /api/v1/sync/pull，mock 对所有请求都回 success: true。
+    let cloud_url = spawn_mock_cloud().await;
+    {
+        let mut cfg = config.write().await;
+        cfg.cloud_sync = CloudSyncConfig {
+            server_url: cloud_url,
+            sync_token: Some("ntd_test_token".to_string()),
+            last_sync_at: None,
+            default_conflict_mode: "overwrite".to_string(),
+        };
+    }
+
+    let req = Request::builder()
+        .method("POST") // 路由是 POST（见 handlers/mod.rs）
+        .uri("/api/cloud/sync/pull?conflict_mode=overwrite&dry_run=false")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = tokio::time::timeout(Duration::from_secs(10), app.oneshot(req))
+        .await
+        .expect("cloud pull 请求挂起 — 怀疑 config 读/写锁自我死锁回归")
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_json(response).await;
+    assert_eq!(body["code"], 0, "顶层 code 应为 0: {:?}", body);
+    let data = &body["data"];
+    assert_eq!(data["direction"], "pull");
+}
+
+/// token 没配时，handler 应直接返回 400 BadRequest，绝不会去申请写锁、也不会
+/// 卡在读锁里。顺便覆盖「缺 token」分支，避免有人误把读锁范围扩大。
+#[tokio::test]
+async fn cloud_sync_push_missing_token_returns_bad_request() {
+    let (app, config) = build_test_app().await;
+    {
+        let mut cfg = config.write().await;
+        cfg.cloud_sync = CloudSyncConfig {
+            server_url: "http://127.0.0.1:1".to_string(),
+            sync_token: None, // 关键：没配 token
+            last_sync_at: None,
+            default_conflict_mode: "overwrite".to_string(),
+        };
+    }
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/cloud/sync/push")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = tokio::time::timeout(Duration::from_secs(5), app.oneshot(req))
+        .await
+        .expect("缺 token 的 push 也应快速返回")
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -14,6 +14,7 @@ import {
   FileTextOutlined,
   LeftOutlined,
   ApiOutlined,
+  CloudOutlined,
 } from '@ant-design/icons';
 import { useApp } from '../hooks/useApp';
 import * as db from '../utils/database';
@@ -30,6 +31,7 @@ import { RuntimePanel } from './settings/RuntimePanel';
 import { MessagesPanel } from './settings/MessagesPanel';
 import { TemplatesPanel } from './settings/TemplatesPanel';
 import { AboutPanel } from './settings/AboutPanel';
+import { CloudSyncPanel } from './settings/CloudSyncPanel';
 
 interface SettingsPageProps {
   onBack?: () => void;
@@ -225,6 +227,11 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       key: 'about',
       label: <span><InfoCircleOutlined style={{ marginRight: 6 }} />关于</span>,
       children: <AboutPanel />,
+    },
+    {
+      key: 'cloudSync',
+      label: <span><CloudOutlined style={{ marginRight: 6 }} />云端同步</span>,
+      children: <CloudSyncPanel />,
     },
   ];
 

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -224,14 +224,14 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       children: <WebhooksPanel todos={state.todos} />,
     },
     {
-      key: 'about',
-      label: <span><InfoCircleOutlined style={{ marginRight: 6 }} />关于</span>,
-      children: <AboutPanel />,
-    },
-    {
       key: 'cloudSync',
       label: <span><CloudOutlined style={{ marginRight: 6 }} />云端同步</span>,
       children: <CloudSyncPanel />,
+    },
+    {
+      key: 'about',
+      label: <span><InfoCircleOutlined style={{ marginRight: 6 }} />关于</span>,
+      children: <AboutPanel />,
     },
   ];
 

--- a/frontend/src/components/settings/CloudSyncPanel.css
+++ b/frontend/src/components/settings/CloudSyncPanel.css
@@ -1,0 +1,63 @@
+/* 云端同步面板响应式样式 */
+.cloud-sync-panel {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+/* 手机端适配 */
+@media screen and (max-width: 576px) {
+  .cloud-sync-panel {
+    padding: 8px !important;
+  }
+
+  .cloud-sync-panel .ant-card {
+    font-size: 12px;
+  }
+
+  .cloud-sync-panel .ant-card-head {
+    min-height: 40px;
+    padding: 0 12px;
+  }
+
+  .cloud-sync-panel .ant-card-body {
+    padding: 12px;
+  }
+
+  .cloud-sync-panel .status-text {
+    font-size: 11px;
+    word-break: break-all;
+  }
+
+  .cloud-sync-panel .ant-form-item-label {
+    padding: 0 0 4px;
+  }
+
+  .cloud-sync-panel .ant-form-item-label > label {
+    font-size: 12px;
+  }
+
+  .cloud-sync-panel .ant-divider {
+    margin: 12px 0;
+  }
+
+  .cloud-sync-panel .ant-table {
+    font-size: 11px;
+  }
+
+  .cloud-sync-panel .ant-table-thead > tr > th {
+    padding: 8px 4px;
+    font-size: 11px;
+  }
+
+  .cloud-sync-panel .ant-table-tbody > tr > td {
+    padding: 6px 4px;
+  }
+}
+
+/* 平板适配 */
+@media screen and (min-width: 577px) and (max-width: 768px) {
+  .cloud-sync-panel {
+    padding: 12px;
+  }
+}

--- a/frontend/src/components/settings/CloudSyncPanel.tsx
+++ b/frontend/src/components/settings/CloudSyncPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Card, Form, Input, Button, Space, Table, Tag, message, Divider, Alert, Modal, Checkbox, Radio } from 'antd';
-import { CloudOutlined, SyncOutlined, SaveOutlined, CheckCircleFilled, ExclamationCircleFilled } from '@ant-design/icons';
+import { CloudOutlined, SyncOutlined, SaveOutlined, CheckCircleFilled, ExclamationCircleFilled, DeleteOutlined } from '@ant-design/icons';
 import * as syncApi from '../../utils/database/sync';
 import './CloudSyncPanel.css';
 
@@ -12,6 +12,12 @@ export function CloudSyncPanel() {
   const [configForm] = Form.useForm();
   const [hasToken, setHasToken] = useState(false);
   const tokenRef = useRef('');
+
+  // 受控 Modal 状态：解决 Modal.confirm content 只渲染一次的问题
+  const [syncModalVisible, setSyncModalVisible] = useState(false);
+  const [syncModalDirection, setSyncModalDirection] = useState<'push' | 'pull'>('push');
+  const [selectedMode, setSelectedMode] = useState('overwrite');
+  const [dryRun, setDryRun] = useState(false);
 
   // 加载配置和状态
   const loadData = useCallback(async () => {
@@ -33,11 +39,19 @@ export function CloudSyncPanel() {
     }
   }, [configForm]);
 
-  // 加载同步历史
-  const loadSyncHistory = useCallback(async () => {
+  // 同步历史分页状态
+  const [historyPage, setHistoryPage] = useState(1);
+  const [historyPageSize] = useState(10);
+  const [historyTotal, setHistoryTotal] = useState(0);
+
+  // 加载同步历史（按分页）
+  const loadSyncHistory = useCallback(async (page: number, pageSize: number) => {
     try {
-      const records = await syncApi.getSyncRecords({ limit: 20 });
-      setSyncHistory(records);
+      // limit 是单页大小，offset = (page - 1) * pageSize
+      const offset = (page - 1) * pageSize;
+      const resp = await syncApi.getSyncRecords({ limit: pageSize, offset });
+      setSyncHistory(resp.records);
+      setHistoryTotal(resp.total);
     } catch (err) {
       console.error('加载同步历史失败:', err);
     }
@@ -45,7 +59,11 @@ export function CloudSyncPanel() {
 
   useEffect(() => {
     loadData();
-    loadSyncHistory();
+    // 初次加载第 1 页
+    loadSyncHistory(historyPage, historyPageSize);
+    // 故意省略依赖，避免初次之外重复触发；
+    // 切换页码由 Table.onChange 显式调用 loadSyncHistory
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loadData, loadSyncHistory]);
 
   // 保存配置
@@ -68,81 +86,83 @@ export function CloudSyncPanel() {
     }
   };
 
-  // 执行同步
-  const handleSync = async (direction: 'push' | 'pull') => {
+  // 打开同步确认弹窗
+  const openSyncModal = (direction: 'push' | 'pull') => {
     if (!statusInfo?.authenticated && !hasToken) {
       message.warning('请先配置同步 Token');
       return;
     }
+    // 重置为默认值
+    setSelectedMode('overwrite');
+    setDryRun(false);
+    setSyncModalDirection(direction);
+    setSyncModalVisible(true);
+  };
 
-    // 弹出确认框选择冲突模式
-    let selectedMode = 'overwrite';
-    let dryRun = false;
+  // 执行同步（从 Modal 确认后调用）
+  const handleSyncConfirm = async () => {
+    setSyncModalVisible(false);
+    try {
+      setSyncing(true);
+      let result: syncApi.SyncResult;
+      if (syncModalDirection === 'push') {
+        result = await syncApi.syncPush({ conflict_mode: selectedMode, dry_run: dryRun });
+      } else {
+        result = await syncApi.syncPull({ conflict_mode: selectedMode, dry_run: dryRun });
+      }
 
-    // 根据方向显示不同的策略文案
-    const isPush = direction === 'push';
-    const modeOptions = isPush ? [
-      { value: 'overwrite', label: '覆盖（以本地数据为准，覆盖云端）' },
-      { value: 'skip', label: '跳过（保留云端，忽略本地冲突项）' },
-      { value: 'rename', label: '重命名（避免冲突，本地项重命名保留）' },
-    ] : [
-      { value: 'overwrite', label: '覆盖（以云端数据为准，覆盖本地）' },
-      { value: 'skip', label: '跳过（保留本地，忽略云端冲突项）' },
-      { value: 'rename', label: '重命名（避免冲突，云端项重命名保留）' },
-    ];
+      if (result.success) {
+        const msg = dryRun ? '预览成功' : '同步成功';
+        if (syncModalDirection === 'push') {
+          message.success(`${msg}：推送 ${result.pushed_count} 条`);
+        } else {
+          message.success(`${msg}：拉取 ${result.pulled_count} 条`);
+        }
+      } else {
+        message.error('同步失败：' + (result.errors[0] || '未知错误'));
+      }
+      // 刷新当前页数据，让新记录立即可见
+      await loadSyncHistory(historyPage, historyPageSize);
+    } catch (err: any) {
+      message.error('同步失败：' + (err?.message || String(err)));
+    } finally {
+      setSyncing(false);
+    }
+  };
 
+  // 清空同步历史
+  const handleClearHistory = () => {
     Modal.confirm({
-      title: isPush ? '确认向上同步（推送至云端）' : '确认向下同步（拉取至本地）',
-      content: (
-        <div>
-          <p>冲突解决策略：</p>
-          <Radio.Group
-            value={selectedMode}
-            onChange={e => { selectedMode = e.target.value; }}
-            style={{ marginBottom: 16 }}
-          >
-            {modeOptions.map(opt => (
-              <Radio key={opt.value} value={opt.value} style={{ display: 'block', marginBottom: 8 }}>{opt.label}</Radio>
-            ))}
-          </Radio.Group>
-          <Checkbox
-            onChange={e => { dryRun = e.target.checked; }}
-          >
-            预览模式 (Dry Run)
-          </Checkbox>
-        </div>
-      ),
-      okText: '执行同步',
+      title: '确认清空同步历史',
+      content: `此操作将删除全部 ${historyTotal} 条同步历史记录，且不可恢复。是否继续？`,
+      okText: '清空',
+      okType: 'danger',
       cancelText: '取消',
       onOk: async () => {
         try {
-          setSyncing(true);
-          let result: syncApi.SyncResult;
-          if (direction === 'push') {
-            result = await syncApi.syncPush({ conflict_mode: selectedMode, dry_run: dryRun });
-          } else {
-            result = await syncApi.syncPull({ conflict_mode: selectedMode, dry_run: dryRun });
-          }
-
-          if (result.success) {
-            const msg = dryRun ? '预览成功' : '同步成功';
-            if (direction === 'push') {
-              message.success(`${msg}：推送 ${result.pushed_count} 条`);
-            } else {
-              message.success(`${msg}：拉取 ${result.pulled_count} 条`);
-            }
-          } else {
-            message.error('同步失败：' + (result.errors[0] || '未知错误'));
-          }
-          await loadSyncHistory();
+          await syncApi.clearSyncRecords();
+          message.success('同步历史已清空');
+          // 清空后回到第 1 页重新加载
+          setHistoryPage(1);
+          await loadSyncHistory(1, historyPageSize);
         } catch (err: any) {
-          message.error('同步失败：' + (err?.message || String(err)));
-        } finally {
-          setSyncing(false);
+          message.error('清空失败：' + (err?.message || String(err)));
         }
       },
     });
   };
+
+  // 根据方向获取策略文案
+  const isPush = syncModalDirection === 'push';
+  const modeOptions = isPush ? [
+    { value: 'overwrite', label: '覆盖（以本地数据为准，覆盖云端）' },
+    { value: 'skip', label: '跳过（保留云端，忽略本地冲突项）' },
+    { value: 'rename', label: '重命名（避免冲突，本地项重命名保留）' },
+  ] : [
+    { value: 'overwrite', label: '覆盖（以云端数据为准，覆盖本地）' },
+    { value: 'skip', label: '跳过（保留本地，忽略云端冲突项）' },
+    { value: 'rename', label: '重命名（避免冲突，云端项重命名保留）' },
+  ];
 
   const isAuthenticated = statusInfo?.authenticated ?? hasToken;
   const isConnected = statusInfo?.connected ?? false;
@@ -199,7 +219,7 @@ export function CloudSyncPanel() {
                 <Button
                   size="small"
                   icon={<SyncOutlined />}
-                  onClick={() => handleSync('push')}
+                  onClick={() => openSyncModal('push')}
                   loading={syncing}
                 >
                   推送
@@ -207,7 +227,7 @@ export function CloudSyncPanel() {
                 <Button
                   size="small"
                   icon={<SyncOutlined style={{ transform: 'rotate(180deg)' }} />}
-                  onClick={() => handleSync('pull')}
+                  onClick={() => openSyncModal('pull')}
                   loading={syncing}
                 >
                   拉取
@@ -287,18 +307,70 @@ export function CloudSyncPanel() {
           </Form.Item>
         </Form>
 
-        <Divider style={{ margin: '16px 0' }}>同步历史</Divider>
+        <Divider style={{ margin: '16px 0' }}>
+          <Space>
+            <span>同步历史</span>
+            <Button
+              type="link"
+              size="small"
+              danger
+              icon={<DeleteOutlined />}
+              disabled={historyTotal === 0}
+              onClick={handleClearHistory}
+            >
+              清空
+            </Button>
+          </Space>
+        </Divider>
 
         <Table
           columns={columns}
           dataSource={syncHistory}
           rowKey="id"
           size="small"
-          pagination={{ pageSize: 10, showSizeChanger: false }}
+          pagination={{
+            current: historyPage,
+            pageSize: historyPageSize,
+            total: historyTotal,
+            showSizeChanger: false,
+            // 切换页码时按需加载对应分页的数据
+            onChange: (page) => {
+              setHistoryPage(page);
+              loadSyncHistory(page, historyPageSize);
+            },
+          }}
           locale={{ emptyText: '暂无同步记录' }}
           scroll={{ x: 400 }}
         />
       </Card>
+
+      {/* 同步策略选择弹窗（受控组件，解决 Modal.confirm 闭包问题） */}
+      <Modal
+        title={isPush ? '确认向上同步（推送至云端）' : '确认向下同步（拉取至本地）'}
+        open={syncModalVisible}
+        onOk={handleSyncConfirm}
+        onCancel={() => setSyncModalVisible(false)}
+        okText="执行同步"
+        cancelText="取消"
+        confirmLoading={syncing}
+      >
+        <p>冲突解决策略：</p>
+        <Radio.Group
+          value={selectedMode}
+          onChange={e => setSelectedMode(e.target.value)}
+          style={{ marginBottom: 16 }}
+        >
+          {modeOptions.map(opt => (
+            <Radio key={opt.value} value={opt.value} style={{ display: 'block', marginBottom: 8 }}>{opt.label}</Radio>
+          ))}
+        </Radio.Group>
+        <Checkbox
+          checked={dryRun}
+          onChange={e => setDryRun(e.target.checked)}
+        >
+          预览模式 (Dry Run)
+        </Checkbox>
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/components/settings/CloudSyncPanel.tsx
+++ b/frontend/src/components/settings/CloudSyncPanel.tsx
@@ -1,0 +1,352 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Card, Form, Input, Button, Select, Space, Table, Tag, message, Modal, Divider, Alert, Typography, Popconfirm } from 'antd';
+import { CloudOutlined, SyncOutlined, SaveOutlined, CheckCircleFilled, ExclamationCircleFilled, DeleteOutlined } from '@ant-design/icons';
+import * as syncApi from '../../utils/database/sync';
+import { getDeviceName } from '../../utils/device';
+
+const { Text, Paragraph } = Typography;
+
+export function CloudSyncPanel() {
+  const [loading, setLoading] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [deviceModalOpen, setDeviceModalOpen] = useState(false);
+  const [deviceLoading, setDeviceLoading] = useState(false);
+  const [syncHistory, setSyncHistory] = useState<syncApi.SyncRecord[]>([]);
+  const [statusInfo, setStatusInfo] = useState<syncApi.SyncStatusResponse | null>(null);
+  const [configForm] = Form.useForm();
+
+  // 加载配置和状态
+  const loadData = useCallback(async () => {
+    try {
+      const [status, config] = await Promise.all([
+        syncApi.getCloudSyncStatus(),
+        syncApi.getCloudConfig(),
+      ]);
+      setStatusInfo(status);
+      configForm.setFieldsValue({
+        server_url: config.server_url,
+        token: config.token || '',
+        default_conflict_mode: config.default_conflict_mode,
+      });
+    } catch (err) {
+      console.error('加载云端配置失败:', err);
+    }
+  }, [configForm]);
+
+  // 加载同步历史
+  const loadSyncHistory = useCallback(async () => {
+    try {
+      const records = await syncApi.getSyncRecords({ limit: 20 });
+      setSyncHistory(records);
+    } catch (err) {
+      console.error('加载同步历史失败:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+    loadSyncHistory();
+  }, [loadData, loadSyncHistory]);
+
+  // 保存配置
+  const handleSaveConfig = async () => {
+    try {
+      const values = await configForm.validateFields();
+      setLoading(true);
+      await syncApi.saveCloudConfig({
+        server_url: values.server_url,
+        token: values.token || null,
+        default_conflict_mode: values.default_conflict_mode,
+      });
+      message.success('配置已保存');
+      await loadData();
+    } catch (err: any) {
+      message.error('保存失败: ' + (err?.message || String(err)));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 创建设备
+  const handleCreateDevice = async () => {
+    if (!statusInfo?.authenticated) {
+      message.warning('请先配置 Token');
+      return;
+    }
+    try {
+      setDeviceLoading(true);
+      const deviceName = getDeviceName();
+      await syncApi.cloudCreateDevice(deviceName);
+      message.success('设备注册成功');
+      setDeviceModalOpen(false);
+      await loadData();
+    } catch (err: any) {
+      message.error('设备注册失败: ' + (err?.message || String(err)));
+    } finally {
+      setDeviceLoading(false);
+    }
+  };
+
+  // 清除 Token
+  const handleClearToken = async () => {
+    try {
+      await syncApi.saveCloudConfig({
+        server_url: statusInfo?.server_url,
+        token: '',
+      });
+      message.success('已清除 Token');
+      await loadData();
+    } catch (err: any) {
+      message.error('清除失败: ' + (err?.message || String(err)));
+    }
+  };
+
+  // 执行同步
+  const handleSync = async (direction: 'push' | 'pull') => {
+    if (!statusInfo?.authenticated) {
+      message.warning('请先配置 Token');
+      return;
+    }
+
+    try {
+      setSyncing(true);
+      message.info(direction === 'push' ? '向上同步功能开发中...' : '向下同步功能开发中...');
+      await loadSyncHistory();
+    } catch (err: any) {
+      message.error('同步失败: ' + (err?.message || String(err)));
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const isAuthenticated = statusInfo?.authenticated ?? false;
+  const isConnected = statusInfo?.connected ?? false;
+
+  const columns = [
+    {
+      title: '时间',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      width: 160,
+      render: (text: string) => text ? new Date(text).toLocaleString('zh-CN') : '-',
+    },
+    {
+      title: '方向',
+      dataIndex: 'direction',
+      key: 'direction',
+      width: 80,
+      render: (dir: string) => dir === 'push'
+        ? <Tag color="blue">推送</Tag>
+        : <Tag color="green">拉取</Tag>,
+    },
+    {
+      title: '冲突模式',
+      dataIndex: 'conflict_mode',
+      key: 'conflict_mode',
+      width: 100,
+      render: (mode: string) => {
+        const map: Record<string, string> = { overwrite: '覆盖', skip: '跳过', rename: '重命名' };
+        return map[mode] || mode;
+      },
+    },
+    {
+      title: '状态',
+      dataIndex: 'status',
+      key: 'status',
+      width: 80,
+      render: (status: string) => {
+        const color = status === 'success' ? 'green' : status === 'failed' ? 'red' : 'orange';
+        const text = status === 'success' ? '成功' : status === 'failed' ? '失败' : '预览';
+        return <Tag color={color}>{text}</Tag>;
+      },
+    },
+    {
+      title: '详情',
+      dataIndex: 'details',
+      key: 'details',
+      ellipsis: true,
+    },
+  ];
+
+  return (
+    <div style={{ padding: 24 }}>
+      <Card
+        title={
+          <Space>
+            <CloudOutlined />
+            <span>云端同步</span>
+          </Space>
+        }
+        extra={
+          <Space>
+            {isAuthenticated && (
+              <>
+                <Button
+                  icon={<SyncOutlined />}
+                  onClick={() => handleSync('push')}
+                  loading={syncing}
+                >
+                  向上同步
+                </Button>
+                <Button
+                  icon={<SyncOutlined style={{ transform: 'rotate(180deg)' }} />}
+                  onClick={() => handleSync('pull')}
+                  loading={syncing}
+                >
+                  从云上拉取
+                </Button>
+              </>
+            )}
+          </Space>
+        }
+      >
+        {/* 连接状态 */}
+        <div style={{ marginBottom: 16 }}>
+          {isConnected ? (
+            isAuthenticated ? (
+              <Alert
+                message={
+                  <Space>
+                    <CheckCircleFilled style={{ color: '#52c41a' }} />
+                    已连接到云端服务器 ({statusInfo?.server_url})
+                    {statusInfo?.device_id && <span>设备ID: {statusInfo.device_id}</span>}
+                    {statusInfo?.last_sync_at && <span>最后同步: {new Date(statusInfo.last_sync_at).toLocaleString('zh-CN')}</span>}
+                  </Space>
+                }
+                type="success"
+                showIcon
+              />
+            ) : (
+              <Alert
+                message={
+                  <Space>
+                    <ExclamationCircleFilled style={{ color: '#faad14' }} />
+                    已连接到云端服务器 ({statusInfo?.server_url})，但未配置 Token
+                  </Space>
+                }
+                type="warning"
+                showIcon
+              />
+            )
+          ) : (
+            <Alert
+              message="未配置云端服务器地址"
+              description="请在下方配置服务器地址和 Token。"
+              type="info"
+              showIcon
+            />
+          )}
+        </div>
+
+        {/* 配置表单 */}
+        <Form form={configForm} layout="vertical">
+          <Form.Item
+            label="云端服务器地址"
+            name="server_url"
+            rules={[{ required: true, message: '请输入服务器地址' }]}
+          >
+            <Input placeholder="http://localhost:8089" />
+          </Form.Item>
+
+          <Form.Item
+            label="Token"
+            name="token"
+            rules={[{ required: true, message: '请输入 Token' }]}
+          >
+            <Input.Password placeholder="从云端获取的 JWT Token" />
+          </Form.Item>
+
+          <Form.Item
+            label="默认冲突解决模式"
+            name="default_conflict_mode"
+          >
+            <Select>
+              <Select.Option value="overwrite">
+                <Space>
+                  <span>覆盖</span>
+                  <Text type="secondary">（以云端数据为准）</Text>
+                </Space>
+              </Select.Option>
+              <Select.Option value="skip">
+                <Space>
+                  <span>跳过</span>
+                  <Text type="secondary">（保留本地数据）</Text>
+                </Space>
+              </Select.Option>
+              <Select.Option value="rename">
+                <Space>
+                  <span>重命名</span>
+                  <Text type="secondary">（冲突项重命名保留）</Text>
+                </Space>
+              </Select.Option>
+            </Select>
+          </Form.Item>
+
+          <Form.Item>
+            <Space>
+              <Button
+                type="primary"
+                icon={<SaveOutlined />}
+                onClick={handleSaveConfig}
+                loading={loading}
+              >
+                保存配置
+              </Button>
+              {isAuthenticated && statusInfo?.device_id && (
+                <Popconfirm
+                  title="确定要清除 Token 吗？"
+                  onConfirm={handleClearToken}
+                  okText="确定"
+                  cancelText="取消"
+                >
+                  <Button danger icon={<DeleteOutlined />}>
+                    清除 Token
+                  </Button>
+                </Popconfirm>
+              )}
+            </Space>
+          </Form.Item>
+
+          <Divider style={{ margin: '16px 0' }} />
+
+          <Paragraph type="secondary" style={{ marginBottom: 8 }}>
+            如果还没有设备 ID，请先在云端创建设备后填入 Token，然后点击下方按钮注册本设备。
+          </Paragraph>
+          <Button
+            onClick={() => setDeviceModalOpen(true)}
+            disabled={!isAuthenticated}
+          >
+            注册本设备
+          </Button>
+        </Form>
+
+        <Divider>同步历史</Divider>
+
+        <Table
+          columns={columns}
+          dataSource={syncHistory}
+          rowKey="id"
+          size="small"
+          pagination={{ pageSize: 10, showSizeChanger: false }}
+          locale={{ emptyText: '暂无同步记录' }}
+        />
+      </Card>
+
+      {/* 注册设备弹窗 */}
+      <Modal
+        title="注册本设备"
+        open={deviceModalOpen}
+        onCancel={() => setDeviceModalOpen(false)}
+        onOk={handleCreateDevice}
+        confirmLoading={deviceLoading}
+        okText="注册"
+        cancelText="取消"
+      >
+        <Paragraph>
+          确定要注册本设备吗？<br />
+          设备名称: <strong>{getDeviceName()}</strong>
+        </Paragraph>
+      </Modal>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/CloudSyncPanel.tsx
+++ b/frontend/src/components/settings/CloudSyncPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Card, Form, Input, Button, Select, Space, Table, Tag, message, Divider, Alert, Typography, Modal } from 'antd';
+import { Card, Form, Input, Button, Select, Space, Table, Tag, message, Divider, Alert, Typography, Modal, Checkbox } from 'antd';
 import { CloudOutlined, SyncOutlined, SaveOutlined, CheckCircleFilled, ExclamationCircleFilled } from '@ant-design/icons';
 import * as syncApi from '../../utils/database/sync';
 import './CloudSyncPanel.css';
@@ -99,11 +99,11 @@ export function CloudSyncPanel() {
             <Select.Option value="skip">跳过（保留本地数据）</Select.Option>
             <Select.Option value="rename">重命名（避免冲突）</Select.Option>
           </Select>
-          <p>
-            <Button size="small" onClick={() => { dryRun = true; }}>
-              预览 (Dry Run)
-            </Button>
-          </p>
+          <Checkbox
+            onChange={(e) => { dryRun = e.target.checked; }}
+          >
+            预览模式 (Dry Run)
+          </Checkbox>
         </div>
       ),
       okText: '执行同步',

--- a/frontend/src/components/settings/CloudSyncPanel.tsx
+++ b/frontend/src/components/settings/CloudSyncPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Card, Form, Input, Button, Select, Space, Table, Tag, message, Divider, Alert, Modal, Checkbox } from 'antd';
+import { Card, Form, Input, Button, Space, Table, Tag, message, Divider, Alert, Modal, Checkbox, Radio } from 'antd';
 import { CloudOutlined, SyncOutlined, SaveOutlined, CheckCircleFilled, ExclamationCircleFilled } from '@ant-design/icons';
 import * as syncApi from '../../utils/database/sync';
 import './CloudSyncPanel.css';
@@ -95,18 +95,18 @@ export function CloudSyncPanel() {
       title: isPush ? '确认向上同步（推送至云端）' : '确认向下同步（拉取至本地）',
       content: (
         <div>
-          <p>选择冲突解决策略：</p>
-          <Select
+          <p>冲突解决策略：</p>
+          <Radio.Group
             value={selectedMode}
-            onChange={(v) => { selectedMode = v; }}
-            style={{ width: '100%', marginBottom: 16 }}
+            onChange={e => { selectedMode = e.target.value; }}
+            style={{ marginBottom: 16 }}
           >
             {modeOptions.map(opt => (
-              <Select.Option key={opt.value} value={opt.value}>{opt.label}</Select.Option>
+              <Radio key={opt.value} value={opt.value} style={{ display: 'block', marginBottom: 8 }}>{opt.label}</Radio>
             ))}
-          </Select>
+          </Radio.Group>
           <Checkbox
-            onChange={(e) => { dryRun = e.target.checked; }}
+            onChange={e => { dryRun = e.target.checked; }}
           >
             预览模式 (Dry Run)
           </Checkbox>

--- a/frontend/src/components/settings/CloudSyncPanel.tsx
+++ b/frontend/src/components/settings/CloudSyncPanel.tsx
@@ -1,19 +1,19 @@
-import { useState, useEffect, useCallback } from 'react';
-import { Card, Form, Input, Button, Select, Space, Table, Tag, message, Modal, Divider, Alert, Typography, Popconfirm } from 'antd';
-import { CloudOutlined, SyncOutlined, SaveOutlined, CheckCircleFilled, ExclamationCircleFilled, DeleteOutlined } from '@ant-design/icons';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Card, Form, Input, Button, Select, Space, Table, Tag, message, Divider, Alert, Typography } from 'antd';
+import { CloudOutlined, SyncOutlined, SaveOutlined, CheckCircleFilled, ExclamationCircleFilled } from '@ant-design/icons';
 import * as syncApi from '../../utils/database/sync';
-import { getDeviceName } from '../../utils/device';
+import './CloudSyncPanel.css';
 
-const { Text, Paragraph } = Typography;
+const { Text } = Typography;
 
 export function CloudSyncPanel() {
   const [loading, setLoading] = useState(false);
   const [syncing, setSyncing] = useState(false);
-  const [deviceModalOpen, setDeviceModalOpen] = useState(false);
-  const [deviceLoading, setDeviceLoading] = useState(false);
   const [syncHistory, setSyncHistory] = useState<syncApi.SyncRecord[]>([]);
   const [statusInfo, setStatusInfo] = useState<syncApi.SyncStatusResponse | null>(null);
   const [configForm] = Form.useForm();
+  const [hasToken, setHasToken] = useState(false);
+  const tokenRef = useRef('');
 
   // 加载配置和状态
   const loadData = useCallback(async () => {
@@ -23,9 +23,11 @@ export function CloudSyncPanel() {
         syncApi.getCloudConfig(),
       ]);
       setStatusInfo(status);
+      setHasToken(config.has_token ?? false);
+      // 保持当前输入的 token 不变
       configForm.setFieldsValue({
         server_url: config.server_url,
-        token: config.token || '',
+        sync_token: tokenRef.current || '',
         default_conflict_mode: config.default_conflict_mode,
       });
     } catch (err) {
@@ -53,13 +55,17 @@ export function CloudSyncPanel() {
     try {
       const values = await configForm.validateFields();
       setLoading(true);
+      // 保存时使用当前输入的 token
+      const tokenToSave = values.sync_token || values.sync_token === '' ? values.sync_token : tokenRef.current;
       await syncApi.saveCloudConfig({
         server_url: values.server_url,
-        token: values.token || null,
+        sync_token: tokenToSave,
         default_conflict_mode: values.default_conflict_mode,
       });
+      // 保存成功后更新本地状态
+      tokenRef.current = values.sync_token || '';
+      setHasToken(!!values.sync_token);
       message.success('配置已保存');
-      await loadData();
     } catch (err: any) {
       message.error('保存失败: ' + (err?.message || String(err)));
     } finally {
@@ -67,44 +73,10 @@ export function CloudSyncPanel() {
     }
   };
 
-  // 创建设备
-  const handleCreateDevice = async () => {
-    if (!statusInfo?.authenticated) {
-      message.warning('请先配置 Token');
-      return;
-    }
-    try {
-      setDeviceLoading(true);
-      const deviceName = getDeviceName();
-      await syncApi.cloudCreateDevice(deviceName);
-      message.success('设备注册成功');
-      setDeviceModalOpen(false);
-      await loadData();
-    } catch (err: any) {
-      message.error('设备注册失败: ' + (err?.message || String(err)));
-    } finally {
-      setDeviceLoading(false);
-    }
-  };
-
-  // 清除 Token
-  const handleClearToken = async () => {
-    try {
-      await syncApi.saveCloudConfig({
-        server_url: statusInfo?.server_url,
-        token: '',
-      });
-      message.success('已清除 Token');
-      await loadData();
-    } catch (err: any) {
-      message.error('清除失败: ' + (err?.message || String(err)));
-    }
-  };
-
   // 执行同步
   const handleSync = async (direction: 'push' | 'pull') => {
-    if (!statusInfo?.authenticated) {
-      message.warning('请先配置 Token');
+    if (!statusInfo?.authenticated && !hasToken) {
+      message.warning('请先配置同步 Token');
       return;
     }
 
@@ -119,7 +91,7 @@ export function CloudSyncPanel() {
     }
   };
 
-  const isAuthenticated = statusInfo?.authenticated ?? false;
+  const isAuthenticated = statusInfo?.authenticated ?? hasToken;
   const isConnected = statusInfo?.connected ?? false;
 
   const columns = [
@@ -127,33 +99,23 @@ export function CloudSyncPanel() {
       title: '时间',
       dataIndex: 'created_at',
       key: 'created_at',
-      width: 160,
+      width: 140,
       render: (text: string) => text ? new Date(text).toLocaleString('zh-CN') : '-',
     },
     {
       title: '方向',
       dataIndex: 'direction',
       key: 'direction',
-      width: 80,
+      width: 60,
       render: (dir: string) => dir === 'push'
         ? <Tag color="blue">推送</Tag>
         : <Tag color="green">拉取</Tag>,
     },
     {
-      title: '冲突模式',
-      dataIndex: 'conflict_mode',
-      key: 'conflict_mode',
-      width: 100,
-      render: (mode: string) => {
-        const map: Record<string, string> = { overwrite: '覆盖', skip: '跳过', rename: '重命名' };
-        return map[mode] || mode;
-      },
-    },
-    {
       title: '状态',
       dataIndex: 'status',
       key: 'status',
-      width: 80,
+      width: 60,
       render: (status: string) => {
         const color = status === 'success' ? 'green' : status === 'failed' ? 'red' : 'orange';
         const text = status === 'success' ? '成功' : status === 'failed' ? '失败' : '预览';
@@ -169,7 +131,7 @@ export function CloudSyncPanel() {
   ];
 
   return (
-    <div style={{ padding: 24 }}>
+    <div style={{ padding: 16 }} className="cloud-sync-panel">
       <Card
         title={
           <Space>
@@ -178,22 +140,24 @@ export function CloudSyncPanel() {
           </Space>
         }
         extra={
-          <Space>
+          <Space size="small">
             {isAuthenticated && (
               <>
                 <Button
+                  size="small"
                   icon={<SyncOutlined />}
                   onClick={() => handleSync('push')}
                   loading={syncing}
                 >
-                  向上同步
+                  推送
                 </Button>
                 <Button
+                  size="small"
                   icon={<SyncOutlined style={{ transform: 'rotate(180deg)' }} />}
                   onClick={() => handleSync('pull')}
                   loading={syncing}
                 >
-                  从云上拉取
+                  拉取
                 </Button>
               </>
             )}
@@ -206,11 +170,12 @@ export function CloudSyncPanel() {
             isAuthenticated ? (
               <Alert
                 message={
-                  <Space>
+                  <Space size="small">
                     <CheckCircleFilled style={{ color: '#52c41a' }} />
-                    已连接到云端服务器 ({statusInfo?.server_url})
-                    {statusInfo?.device_id && <span>设备ID: {statusInfo.device_id}</span>}
-                    {statusInfo?.last_sync_at && <span>最后同步: {new Date(statusInfo.last_sync_at).toLocaleString('zh-CN')}</span>}
+                    <span className="status-text">已连接 ({statusInfo?.server_url})</span>
+                    {statusInfo?.last_sync_at && (
+                      <span className="status-text">最后同步: {new Date(statusInfo.last_sync_at).toLocaleString('zh-CN')}</span>
+                    )}
                   </Space>
                 }
                 type="success"
@@ -219,9 +184,9 @@ export function CloudSyncPanel() {
             ) : (
               <Alert
                 message={
-                  <Space>
+                  <Space size="small">
                     <ExclamationCircleFilled style={{ color: '#faad14' }} />
-                    已连接到云端服务器 ({statusInfo?.server_url})，但未配置 Token
+                    <span className="status-text">已连接但未配置 Token</span>
                   </Space>
                 }
                 type="warning"
@@ -231,7 +196,7 @@ export function CloudSyncPanel() {
           ) : (
             <Alert
               message="未配置云端服务器地址"
-              description="请在下方配置服务器地址和 Token。"
+              description="请在下方配置服务器地址和同步 Token。"
               type="info"
               showIcon
             />
@@ -239,9 +204,9 @@ export function CloudSyncPanel() {
         </div>
 
         {/* 配置表单 */}
-        <Form form={configForm} layout="vertical">
+        <Form form={configForm} layout="vertical" size="small">
           <Form.Item
-            label="云端服务器地址"
+            label="服务器地址"
             name="server_url"
             rules={[{ required: true, message: '请输入服务器地址' }]}
           >
@@ -249,78 +214,44 @@ export function CloudSyncPanel() {
           </Form.Item>
 
           <Form.Item
-            label="Token"
-            name="token"
-            rules={[{ required: true, message: '请输入 Token' }]}
+            label="同步 Token"
+            name="sync_token"
+            rules={[{ required: true, message: '请输入同步 Token' }]}
           >
-            <Input.Password placeholder="从云端获取的 JWT Token" />
+            <Input.Password placeholder="ntd_xxx 格式的同步 Token" />
           </Form.Item>
 
-          <Form.Item
-            label="默认冲突解决模式"
-            name="default_conflict_mode"
-          >
-            <Select>
+          <Form.Item label="冲突模式" name="default_conflict_mode">
+            <Select size="small">
               <Select.Option value="overwrite">
-                <Space>
-                  <span>覆盖</span>
-                  <Text type="secondary">（以云端数据为准）</Text>
-                </Space>
+                <span>覆盖</span>
+                <Text type="secondary" style={{ fontSize: 12 }}>（以云端为准）</Text>
               </Select.Option>
               <Select.Option value="skip">
-                <Space>
-                  <span>跳过</span>
-                  <Text type="secondary">（保留本地数据）</Text>
-                </Space>
+                <span>跳过</span>
+                <Text type="secondary" style={{ fontSize: 12 }}>（保留本地）</Text>
               </Select.Option>
               <Select.Option value="rename">
-                <Space>
-                  <span>重命名</span>
-                  <Text type="secondary">（冲突项重命名保留）</Text>
-                </Space>
+                <span>重命名</span>
+                <Text type="secondary" style={{ fontSize: 12 }}>（避免冲突）</Text>
               </Select.Option>
             </Select>
           </Form.Item>
 
-          <Form.Item>
-            <Space>
-              <Button
-                type="primary"
-                icon={<SaveOutlined />}
-                onClick={handleSaveConfig}
-                loading={loading}
-              >
-                保存配置
-              </Button>
-              {isAuthenticated && statusInfo?.device_id && (
-                <Popconfirm
-                  title="确定要清除 Token 吗？"
-                  onConfirm={handleClearToken}
-                  okText="确定"
-                  cancelText="取消"
-                >
-                  <Button danger icon={<DeleteOutlined />}>
-                    清除 Token
-                  </Button>
-                </Popconfirm>
-              )}
-            </Space>
+          <Form.Item style={{ marginBottom: 0 }}>
+            <Button
+              type="primary"
+              icon={<SaveOutlined />}
+              onClick={handleSaveConfig}
+              loading={loading}
+              size="small"
+            >
+              保存配置
+            </Button>
           </Form.Item>
-
-          <Divider style={{ margin: '16px 0' }} />
-
-          <Paragraph type="secondary" style={{ marginBottom: 8 }}>
-            如果还没有设备 ID，请先在云端创建设备后填入 Token，然后点击下方按钮注册本设备。
-          </Paragraph>
-          <Button
-            onClick={() => setDeviceModalOpen(true)}
-            disabled={!isAuthenticated}
-          >
-            注册本设备
-          </Button>
         </Form>
 
-        <Divider>同步历史</Divider>
+        <Divider style={{ margin: '16px 0' }}>同步历史</Divider>
 
         <Table
           columns={columns}
@@ -329,24 +260,9 @@ export function CloudSyncPanel() {
           size="small"
           pagination={{ pageSize: 10, showSizeChanger: false }}
           locale={{ emptyText: '暂无同步记录' }}
+          scroll={{ x: 400 }}
         />
       </Card>
-
-      {/* 注册设备弹窗 */}
-      <Modal
-        title="注册本设备"
-        open={deviceModalOpen}
-        onCancel={() => setDeviceModalOpen(false)}
-        onOk={handleCreateDevice}
-        confirmLoading={deviceLoading}
-        okText="注册"
-        cancelText="取消"
-      >
-        <Paragraph>
-          确定要注册本设备吗？<br />
-          设备名称: <strong>{getDeviceName()}</strong>
-        </Paragraph>
-      </Modal>
     </div>
   );
 }

--- a/frontend/src/components/settings/CloudSyncPanel.tsx
+++ b/frontend/src/components/settings/CloudSyncPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Card, Form, Input, Button, Select, Space, Table, Tag, message, Divider, Alert, Typography } from 'antd';
+import { Card, Form, Input, Button, Select, Space, Table, Tag, message, Divider, Alert, Typography, Modal } from 'antd';
 import { CloudOutlined, SyncOutlined, SaveOutlined, CheckCircleFilled, ExclamationCircleFilled } from '@ant-design/icons';
 import * as syncApi from '../../utils/database/sync';
 import './CloudSyncPanel.css';
@@ -14,6 +14,7 @@ export function CloudSyncPanel() {
   const [configForm] = Form.useForm();
   const [hasToken, setHasToken] = useState(false);
   const tokenRef = useRef('');
+  const [conflictMode, setConflictMode] = useState('overwrite');
 
   // 加载配置和状态
   const loadData = useCallback(async () => {
@@ -24,6 +25,7 @@ export function CloudSyncPanel() {
       ]);
       setStatusInfo(status);
       setHasToken(config.has_token ?? false);
+      setConflictMode(config.default_conflict_mode);
       // 保持当前输入的 token 不变
       configForm.setFieldsValue({
         server_url: config.server_url,
@@ -55,16 +57,15 @@ export function CloudSyncPanel() {
     try {
       const values = await configForm.validateFields();
       setLoading(true);
-      // 保存时使用当前输入的 token
       const tokenToSave = values.sync_token || values.sync_token === '' ? values.sync_token : tokenRef.current;
       await syncApi.saveCloudConfig({
         server_url: values.server_url,
         sync_token: tokenToSave,
         default_conflict_mode: values.default_conflict_mode,
       });
-      // 保存成功后更新本地状态
       tokenRef.current = values.sync_token || '';
       setHasToken(!!values.sync_token);
+      setConflictMode(values.default_conflict_mode);
       message.success('配置已保存');
     } catch (err: any) {
       message.error('保存失败: ' + (err?.message || String(err)));
@@ -80,15 +81,61 @@ export function CloudSyncPanel() {
       return;
     }
 
-    try {
-      setSyncing(true);
-      message.info(direction === 'push' ? '向上同步功能开发中...' : '向下同步功能开发中...');
-      await loadSyncHistory();
-    } catch (err: any) {
-      message.error('同步失败: ' + (err?.message || String(err)));
-    } finally {
-      setSyncing(false);
-    }
+    // 弹出确认框选择冲突模式
+    let selectedMode = conflictMode;
+    let dryRun = false;
+
+    Modal.confirm({
+      title: direction === 'push' ? '确认向上同步' : '确认向下同步',
+      content: (
+        <div>
+          <p>选择同步模式：</p>
+          <Select
+            value={selectedMode}
+            onChange={(v) => { selectedMode = v; }}
+            style={{ width: '100%', marginBottom: 16 }}
+          >
+            <Select.Option value="overwrite">覆盖（以云端数据为准）</Select.Option>
+            <Select.Option value="skip">跳过（保留本地数据）</Select.Option>
+            <Select.Option value="rename">重命名（避免冲突）</Select.Option>
+          </Select>
+          <p>
+            <Button size="small" onClick={() => { dryRun = true; }}>
+              预览 (Dry Run)
+            </Button>
+          </p>
+        </div>
+      ),
+      okText: '执行同步',
+      cancelText: '取消',
+      onOk: async () => {
+        try {
+          setSyncing(true);
+          let result: syncApi.SyncResult;
+          if (direction === 'push') {
+            result = await syncApi.syncPush({ conflict_mode: selectedMode, dry_run: dryRun });
+          } else {
+            result = await syncApi.syncPull({ conflict_mode: selectedMode, dry_run: dryRun });
+          }
+
+          if (result.success) {
+            const msg = dryRun ? '预览成功' : '同步成功';
+            if (direction === 'push') {
+              message.success(`${msg}：推送 ${result.pushed_count} 条`);
+            } else {
+              message.success(`${msg}：拉取 ${result.pulled_count} 条`);
+            }
+          } else {
+            message.error('同步失败：' + (result.errors[0] || '未知错误'));
+          }
+          await loadSyncHistory();
+        } catch (err: any) {
+          message.error('同步失败：' + (err?.message || String(err)));
+        } finally {
+          setSyncing(false);
+        }
+      },
+    });
   };
 
   const isAuthenticated = statusInfo?.authenticated ?? hasToken;

--- a/frontend/src/components/settings/CloudSyncPanel.tsx
+++ b/frontend/src/components/settings/CloudSyncPanel.tsx
@@ -1,10 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Card, Form, Input, Button, Select, Space, Table, Tag, message, Divider, Alert, Typography, Modal, Checkbox } from 'antd';
+import { Card, Form, Input, Button, Select, Space, Table, Tag, message, Divider, Alert, Modal, Checkbox } from 'antd';
 import { CloudOutlined, SyncOutlined, SaveOutlined, CheckCircleFilled, ExclamationCircleFilled } from '@ant-design/icons';
 import * as syncApi from '../../utils/database/sync';
 import './CloudSyncPanel.css';
-
-const { Text } = Typography;
 
 export function CloudSyncPanel() {
   const [loading, setLoading] = useState(false);
@@ -14,7 +12,6 @@ export function CloudSyncPanel() {
   const [configForm] = Form.useForm();
   const [hasToken, setHasToken] = useState(false);
   const tokenRef = useRef('');
-  const [conflictMode, setConflictMode] = useState('overwrite');
 
   // 加载配置和状态
   const loadData = useCallback(async () => {
@@ -25,7 +22,6 @@ export function CloudSyncPanel() {
       ]);
       setStatusInfo(status);
       setHasToken(config.has_token ?? false);
-      setConflictMode(config.default_conflict_mode);
       // 保持当前输入的 token 不变
       configForm.setFieldsValue({
         server_url: config.server_url,
@@ -61,11 +57,9 @@ export function CloudSyncPanel() {
       await syncApi.saveCloudConfig({
         server_url: values.server_url,
         sync_token: tokenToSave,
-        default_conflict_mode: values.default_conflict_mode,
       });
       tokenRef.current = values.sync_token || '';
       setHasToken(!!values.sync_token);
-      setConflictMode(values.default_conflict_mode);
       message.success('配置已保存');
     } catch (err: any) {
       message.error('保存失败: ' + (err?.message || String(err)));
@@ -82,22 +76,34 @@ export function CloudSyncPanel() {
     }
 
     // 弹出确认框选择冲突模式
-    let selectedMode = conflictMode;
+    let selectedMode = 'overwrite';
     let dryRun = false;
 
+    // 根据方向显示不同的策略文案
+    const isPush = direction === 'push';
+    const modeOptions = isPush ? [
+      { value: 'overwrite', label: '覆盖（以本地数据为准，覆盖云端）' },
+      { value: 'skip', label: '跳过（保留云端，忽略本地冲突项）' },
+      { value: 'rename', label: '重命名（避免冲突，本地项重命名保留）' },
+    ] : [
+      { value: 'overwrite', label: '覆盖（以云端数据为准，覆盖本地）' },
+      { value: 'skip', label: '跳过（保留本地，忽略云端冲突项）' },
+      { value: 'rename', label: '重命名（避免冲突，云端项重命名保留）' },
+    ];
+
     Modal.confirm({
-      title: direction === 'push' ? '确认向上同步' : '确认向下同步',
+      title: isPush ? '确认向上同步（推送至云端）' : '确认向下同步（拉取至本地）',
       content: (
         <div>
-          <p>选择同步模式：</p>
+          <p>选择冲突解决策略：</p>
           <Select
             value={selectedMode}
             onChange={(v) => { selectedMode = v; }}
             style={{ width: '100%', marginBottom: 16 }}
           >
-            <Select.Option value="overwrite">覆盖（以云端数据为准）</Select.Option>
-            <Select.Option value="skip">跳过（保留本地数据）</Select.Option>
-            <Select.Option value="rename">重命名（避免冲突）</Select.Option>
+            {modeOptions.map(opt => (
+              <Select.Option key={opt.value} value={opt.value}>{opt.label}</Select.Option>
+            ))}
           </Select>
           <Checkbox
             onChange={(e) => { dryRun = e.target.checked; }}
@@ -266,23 +272,6 @@ export function CloudSyncPanel() {
             rules={[{ required: true, message: '请输入同步 Token' }]}
           >
             <Input.Password placeholder="ntd_xxx 格式的同步 Token" />
-          </Form.Item>
-
-          <Form.Item label="冲突模式" name="default_conflict_mode">
-            <Select size="small">
-              <Select.Option value="overwrite">
-                <span>覆盖</span>
-                <Text type="secondary" style={{ fontSize: 12 }}>（以云端为准）</Text>
-              </Select.Option>
-              <Select.Option value="skip">
-                <span>跳过</span>
-                <Text type="secondary" style={{ fontSize: 12 }}>（保留本地）</Text>
-              </Select.Option>
-              <Select.Option value="rename">
-                <span>重命名</span>
-                <Text type="secondary" style={{ fontSize: 12 }}>（避免冲突）</Text>
-              </Select.Option>
-            </Select>
           </Form.Item>
 
           <Form.Item style={{ marginBottom: 0 }}>

--- a/frontend/src/utils/database/sync.ts
+++ b/frontend/src/utils/database/sync.ts
@@ -46,8 +46,19 @@ export async function saveCloudConfig(config: Partial<CloudConfig>): Promise<voi
 
 // ============ Sync Records APIs ============
 
-export async function getSyncRecords(params?: { limit?: number; offset?: number }): Promise<SyncRecord[]> {
+export interface SyncRecordsResponse {
+  records: SyncRecord[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export async function getSyncRecords(params?: { limit?: number; offset?: number }): Promise<SyncRecordsResponse> {
   return unwrap(await api.get('/api/cloud/sync/records', { params }));
+}
+
+export async function clearSyncRecords(): Promise<{ deleted: number }> {
+  return unwrap(await api.delete('/api/cloud/sync/records'));
 }
 
 // ============ Sync APIs ============
@@ -63,10 +74,15 @@ export interface SyncResult {
   errors: string[];
 }
 
+// 同步接口可能耗时较长（上传/下载本地全部 todos + 远端往返），
+// 不应被 client.ts 的 15s 全局 axios 超时截断。这里显式传 timeout: 0，
+// 由后端 reqwest 自行把控；后端返回后立即结束。
+const SYNC_TIMEOUT_MS = 0;
+
 export async function syncPush(params?: { conflict_mode?: string; dry_run?: boolean }): Promise<SyncResult> {
-  return unwrap(await api.get('/api/cloud/sync/push', { params }));
+  return unwrap(await api.post('/api/cloud/sync/push', null, { params, timeout: SYNC_TIMEOUT_MS }));
 }
 
 export async function syncPull(params?: { conflict_mode?: string; dry_run?: boolean }): Promise<SyncResult> {
-  return unwrap(await api.get('/api/cloud/sync/pull', { params }));
+  return unwrap(await api.post('/api/cloud/sync/pull', null, { params, timeout: SYNC_TIMEOUT_MS }));
 }

--- a/frontend/src/utils/database/sync.ts
+++ b/frontend/src/utils/database/sync.ts
@@ -4,23 +4,15 @@ import { api, unwrap } from './client';
 
 export interface CloudConfig {
   server_url: string;
-  token?: string;
-  device_id?: number;
+  sync_token?: string;
+  has_token?: boolean;
   last_sync_at?: string;
   default_conflict_mode: 'overwrite' | 'skip' | 'rename';
-}
-
-export interface DeviceResponse {
-  id: number;
-  device_name: string;
-  last_seen_at?: string;
-  created_at?: string;
 }
 
 export interface SyncStatusResponse {
   connected: boolean;
   authenticated: boolean;
-  device_id?: number;
   last_sync_at?: string;
   server_url: string;
 }
@@ -34,12 +26,6 @@ export interface SyncRecord {
   details?: string;
   error_message?: string;
   created_at?: string;
-}
-
-// ============ Device APIs ============
-
-export async function cloudCreateDevice(deviceName: string): Promise<DeviceResponse> {
-  return unwrap(await api.post('/api/cloud/devices', { device_name: deviceName }));
 }
 
 // ============ Sync Status APIs ============

--- a/frontend/src/utils/database/sync.ts
+++ b/frontend/src/utils/database/sync.ts
@@ -1,0 +1,65 @@
+import { api, unwrap } from './client';
+
+// ============ Types ============
+
+export interface CloudConfig {
+  server_url: string;
+  token?: string;
+  device_id?: number;
+  last_sync_at?: string;
+  default_conflict_mode: 'overwrite' | 'skip' | 'rename';
+}
+
+export interface DeviceResponse {
+  id: number;
+  device_name: string;
+  last_seen_at?: string;
+  created_at?: string;
+}
+
+export interface SyncStatusResponse {
+  connected: boolean;
+  authenticated: boolean;
+  device_id?: number;
+  last_sync_at?: string;
+  server_url: string;
+}
+
+export interface SyncRecord {
+  id: number;
+  direction: 'push' | 'pull';
+  conflict_mode: string;
+  status: 'success' | 'failed' | 'dry_run';
+  data_type: string;
+  details?: string;
+  error_message?: string;
+  created_at?: string;
+}
+
+// ============ Device APIs ============
+
+export async function cloudCreateDevice(deviceName: string): Promise<DeviceResponse> {
+  return unwrap(await api.post('/api/cloud/devices', { device_name: deviceName }));
+}
+
+// ============ Sync Status APIs ============
+
+export async function getCloudSyncStatus(): Promise<SyncStatusResponse> {
+  return unwrap(await api.get('/api/cloud/sync/status'));
+}
+
+// ============ Config APIs ============
+
+export async function getCloudConfig(): Promise<CloudConfig> {
+  return unwrap(await api.get('/api/cloud/config'));
+}
+
+export async function saveCloudConfig(config: Partial<CloudConfig>): Promise<void> {
+  return unwrap(await api.post('/api/cloud/config', config));
+}
+
+// ============ Sync Records APIs ============
+
+export async function getSyncRecords(params?: { limit?: number; offset?: number }): Promise<SyncRecord[]> {
+  return unwrap(await api.get('/api/cloud/sync/records', { params }));
+}

--- a/frontend/src/utils/database/sync.ts
+++ b/frontend/src/utils/database/sync.ts
@@ -49,3 +49,24 @@ export async function saveCloudConfig(config: Partial<CloudConfig>): Promise<voi
 export async function getSyncRecords(params?: { limit?: number; offset?: number }): Promise<SyncRecord[]> {
   return unwrap(await api.get('/api/cloud/sync/records', { params }));
 }
+
+// ============ Sync APIs ============
+
+export interface SyncResult {
+  success: boolean;
+  direction: string;
+  conflict_mode: string;
+  dry_run: boolean;
+  pushed_count: number;
+  pulled_count: number;
+  conflicts_count: number;
+  errors: string[];
+}
+
+export async function syncPush(params?: { conflict_mode?: string; dry_run?: boolean }): Promise<SyncResult> {
+  return unwrap(await api.get('/api/cloud/sync/push', { params }));
+}
+
+export async function syncPull(params?: { conflict_mode?: string; dry_run?: boolean }): Promise<SyncResult> {
+  return unwrap(await api.get('/api/cloud/sync/pull', { params }));
+}

--- a/frontend/src/utils/device.ts
+++ b/frontend/src/utils/device.ts
@@ -1,0 +1,14 @@
+// 获取或生成设备ID
+export function getDeviceId(): string {
+  let deviceId = localStorage.getItem('ntd_device_id');
+  if (!deviceId) {
+    deviceId = 'device-' + Math.random().toString(36).substr(2, 9) + '-' + Date.now().toString(36);
+    localStorage.setItem('ntd_device_id', deviceId);
+  }
+  return deviceId;
+}
+
+// 获取设备名称
+export function getDeviceName(): string {
+  return navigator.platform || 'Unknown Device';
+}

--- a/frontend/test-results/e2e-test-Executor-UI-Tests-640df--a-todo-and-start-execution/error-context.md
+++ b/frontend/test-results/e2e-test-Executor-UI-Tests-640df--a-todo-and-start-execution/error-context.md
@@ -1,0 +1,108 @@
+# Instructions
+
+- Following Playwright test failed.
+- Explain why, be concise, respect Playwright best practices.
+- Provide a snippet of code with the fix, if possible.
+
+# Test info
+
+- Name: e2e-test.spec.ts >> Executor UI Tests >> should create a todo and start execution
+- Location: e2e-test.spec.ts:16:3
+
+# Error details
+
+```
+Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+Call log:
+  - navigating to "http://localhost:5173/", waiting until "load"
+
+```
+
+# Test source
+
+```ts
+  1  | import { test, expect } from '@playwright/test';
+  2  | 
+  3  | test.describe('Executor UI Tests', () => {
+  4  |   test.beforeEach(async ({ page }) => {
+  5  |     // Go to the app
+> 6  |     await page.goto('http://localhost:5173');
+     |                ^ Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+  7  |     // Wait for page to load
+  8  |     await page.waitForLoadState('networkidle');
+  9  |   });
+  10 | 
+  11 |   test('should load the main page', async ({ page }) => {
+  12 |     // Check page title or main content
+  13 |     await expect(page.locator('body')).toBeVisible();
+  14 |   });
+  15 | 
+  16 |   test('should create a todo and start execution', async ({ page }) => {
+  17 |     // Click the add button or navigate to create todo
+  18 |     const addButton = page.locator('button').filter({ hasText: /新建|新增|添加|add/i }).first();
+  19 |     if (await addButton.isVisible()) {
+  20 |       await addButton.click();
+  21 |       await page.waitForTimeout(500);
+  22 |     }
+  23 | 
+  24 |     // Mobile FAB entry
+  25 |     const mobileFab = page.locator('[aria-label="新建任务"]').first();
+  26 |     if (await mobileFab.isVisible({ timeout: 1000 }).catch(() => false)) {
+  27 |       await mobileFab.click();
+  28 |       await page.waitForTimeout(500);
+  29 |     }
+  30 | 
+  31 |     // Find the title input and fill it
+  32 |     await page.getByPlaceholder('输入 Todo 标题').fill('Test task for UI');
+  33 | 
+  34 |     // Find prompt textarea and fill with simple prompt
+  35 |     await page.getByPlaceholder('输入 Prompt（会作为任务执行的内容，留空则使用标题）').fill('Say hello in 3 words');
+  36 | 
+  37 |     // 这里当前 UI 没有 executor 选择器；如果后续补了控件，再加稳定的 locator。
+  38 | 
+  39 |     // Submit the form
+  40 |     const submitButton = page.locator('button').filter({ hasText: /创建|提交|确定|submit|create/i }).first();
+  41 |     await submitButton.click();
+  42 |     await page.waitForTimeout(1000);
+  43 | 
+  44 |     // Check if todo was created
+  45 |     await page.waitForTimeout(500);
+  46 |   });
+  47 | 
+  48 |   test('should list todos', async ({ page }) => {
+  49 |     // Check if todo list exists
+  50 |     const todoList = page.locator('.todo-list-container');
+  51 |     await expect(todoList).toBeVisible({ timeout: 3000 });
+  52 | 
+  53 |     // Count todo items
+  54 |     const todoItems = todoList.locator('[role="listitem"], li, tr');
+  55 |     const count = await todoItems.count();
+  56 |     expect(count).toBeGreaterThanOrEqual(0);
+  57 |   });
+  58 | 
+  59 |   test('should toggle theme between light and dark', async ({ page }) => {
+  60 |     // Find the theme toggle button
+  61 |     const themeToggle = page.locator('[aria-label="切换主题"]');
+  62 |     await expect(themeToggle).toBeVisible({ timeout: 3000 });
+  63 | 
+  64 |     // Get initial theme from localStorage
+  65 |     const initialTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  66 | 
+  67 |     // Click to toggle theme
+  68 |     await themeToggle.click();
+  69 |     await page.waitForTimeout(500);
+  70 | 
+  71 |     // Verify theme changed
+  72 |     const newTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  73 |     expect(newTheme).not.toBe(initialTheme);
+  74 | 
+  75 |     // Toggle back
+  76 |     await themeToggle.click();
+  77 |     await page.waitForTimeout(500);
+  78 | 
+  79 |     // Verify theme reverted
+  80 |     const revertedTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  81 |     expect(revertedTheme).toBe(initialTheme);
+  82 |   });
+  83 | });
+```

--- a/frontend/test-results/e2e-test-Executor-UI-Tests-82c5d-heme-between-light-and-dark/error-context.md
+++ b/frontend/test-results/e2e-test-Executor-UI-Tests-82c5d-heme-between-light-and-dark/error-context.md
@@ -1,0 +1,108 @@
+# Instructions
+
+- Following Playwright test failed.
+- Explain why, be concise, respect Playwright best practices.
+- Provide a snippet of code with the fix, if possible.
+
+# Test info
+
+- Name: e2e-test.spec.ts >> Executor UI Tests >> should toggle theme between light and dark
+- Location: e2e-test.spec.ts:59:3
+
+# Error details
+
+```
+Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+Call log:
+  - navigating to "http://localhost:5173/", waiting until "load"
+
+```
+
+# Test source
+
+```ts
+  1  | import { test, expect } from '@playwright/test';
+  2  | 
+  3  | test.describe('Executor UI Tests', () => {
+  4  |   test.beforeEach(async ({ page }) => {
+  5  |     // Go to the app
+> 6  |     await page.goto('http://localhost:5173');
+     |                ^ Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+  7  |     // Wait for page to load
+  8  |     await page.waitForLoadState('networkidle');
+  9  |   });
+  10 | 
+  11 |   test('should load the main page', async ({ page }) => {
+  12 |     // Check page title or main content
+  13 |     await expect(page.locator('body')).toBeVisible();
+  14 |   });
+  15 | 
+  16 |   test('should create a todo and start execution', async ({ page }) => {
+  17 |     // Click the add button or navigate to create todo
+  18 |     const addButton = page.locator('button').filter({ hasText: /新建|新增|添加|add/i }).first();
+  19 |     if (await addButton.isVisible()) {
+  20 |       await addButton.click();
+  21 |       await page.waitForTimeout(500);
+  22 |     }
+  23 | 
+  24 |     // Mobile FAB entry
+  25 |     const mobileFab = page.locator('[aria-label="新建任务"]').first();
+  26 |     if (await mobileFab.isVisible({ timeout: 1000 }).catch(() => false)) {
+  27 |       await mobileFab.click();
+  28 |       await page.waitForTimeout(500);
+  29 |     }
+  30 | 
+  31 |     // Find the title input and fill it
+  32 |     await page.getByPlaceholder('输入 Todo 标题').fill('Test task for UI');
+  33 | 
+  34 |     // Find prompt textarea and fill with simple prompt
+  35 |     await page.getByPlaceholder('输入 Prompt（会作为任务执行的内容，留空则使用标题）').fill('Say hello in 3 words');
+  36 | 
+  37 |     // 这里当前 UI 没有 executor 选择器；如果后续补了控件，再加稳定的 locator。
+  38 | 
+  39 |     // Submit the form
+  40 |     const submitButton = page.locator('button').filter({ hasText: /创建|提交|确定|submit|create/i }).first();
+  41 |     await submitButton.click();
+  42 |     await page.waitForTimeout(1000);
+  43 | 
+  44 |     // Check if todo was created
+  45 |     await page.waitForTimeout(500);
+  46 |   });
+  47 | 
+  48 |   test('should list todos', async ({ page }) => {
+  49 |     // Check if todo list exists
+  50 |     const todoList = page.locator('.todo-list-container');
+  51 |     await expect(todoList).toBeVisible({ timeout: 3000 });
+  52 | 
+  53 |     // Count todo items
+  54 |     const todoItems = todoList.locator('[role="listitem"], li, tr');
+  55 |     const count = await todoItems.count();
+  56 |     expect(count).toBeGreaterThanOrEqual(0);
+  57 |   });
+  58 | 
+  59 |   test('should toggle theme between light and dark', async ({ page }) => {
+  60 |     // Find the theme toggle button
+  61 |     const themeToggle = page.locator('[aria-label="切换主题"]');
+  62 |     await expect(themeToggle).toBeVisible({ timeout: 3000 });
+  63 | 
+  64 |     // Get initial theme from localStorage
+  65 |     const initialTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  66 | 
+  67 |     // Click to toggle theme
+  68 |     await themeToggle.click();
+  69 |     await page.waitForTimeout(500);
+  70 | 
+  71 |     // Verify theme changed
+  72 |     const newTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  73 |     expect(newTheme).not.toBe(initialTheme);
+  74 | 
+  75 |     // Toggle back
+  76 |     await themeToggle.click();
+  77 |     await page.waitForTimeout(500);
+  78 | 
+  79 |     // Verify theme reverted
+  80 |     const revertedTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  81 |     expect(revertedTheme).toBe(initialTheme);
+  82 |   });
+  83 | });
+```

--- a/frontend/test-results/e2e-test-Executor-UI-Tests-should-list-todos/error-context.md
+++ b/frontend/test-results/e2e-test-Executor-UI-Tests-should-list-todos/error-context.md
@@ -1,0 +1,108 @@
+# Instructions
+
+- Following Playwright test failed.
+- Explain why, be concise, respect Playwright best practices.
+- Provide a snippet of code with the fix, if possible.
+
+# Test info
+
+- Name: e2e-test.spec.ts >> Executor UI Tests >> should list todos
+- Location: e2e-test.spec.ts:48:3
+
+# Error details
+
+```
+Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+Call log:
+  - navigating to "http://localhost:5173/", waiting until "load"
+
+```
+
+# Test source
+
+```ts
+  1  | import { test, expect } from '@playwright/test';
+  2  | 
+  3  | test.describe('Executor UI Tests', () => {
+  4  |   test.beforeEach(async ({ page }) => {
+  5  |     // Go to the app
+> 6  |     await page.goto('http://localhost:5173');
+     |                ^ Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+  7  |     // Wait for page to load
+  8  |     await page.waitForLoadState('networkidle');
+  9  |   });
+  10 | 
+  11 |   test('should load the main page', async ({ page }) => {
+  12 |     // Check page title or main content
+  13 |     await expect(page.locator('body')).toBeVisible();
+  14 |   });
+  15 | 
+  16 |   test('should create a todo and start execution', async ({ page }) => {
+  17 |     // Click the add button or navigate to create todo
+  18 |     const addButton = page.locator('button').filter({ hasText: /新建|新增|添加|add/i }).first();
+  19 |     if (await addButton.isVisible()) {
+  20 |       await addButton.click();
+  21 |       await page.waitForTimeout(500);
+  22 |     }
+  23 | 
+  24 |     // Mobile FAB entry
+  25 |     const mobileFab = page.locator('[aria-label="新建任务"]').first();
+  26 |     if (await mobileFab.isVisible({ timeout: 1000 }).catch(() => false)) {
+  27 |       await mobileFab.click();
+  28 |       await page.waitForTimeout(500);
+  29 |     }
+  30 | 
+  31 |     // Find the title input and fill it
+  32 |     await page.getByPlaceholder('输入 Todo 标题').fill('Test task for UI');
+  33 | 
+  34 |     // Find prompt textarea and fill with simple prompt
+  35 |     await page.getByPlaceholder('输入 Prompt（会作为任务执行的内容，留空则使用标题）').fill('Say hello in 3 words');
+  36 | 
+  37 |     // 这里当前 UI 没有 executor 选择器；如果后续补了控件，再加稳定的 locator。
+  38 | 
+  39 |     // Submit the form
+  40 |     const submitButton = page.locator('button').filter({ hasText: /创建|提交|确定|submit|create/i }).first();
+  41 |     await submitButton.click();
+  42 |     await page.waitForTimeout(1000);
+  43 | 
+  44 |     // Check if todo was created
+  45 |     await page.waitForTimeout(500);
+  46 |   });
+  47 | 
+  48 |   test('should list todos', async ({ page }) => {
+  49 |     // Check if todo list exists
+  50 |     const todoList = page.locator('.todo-list-container');
+  51 |     await expect(todoList).toBeVisible({ timeout: 3000 });
+  52 | 
+  53 |     // Count todo items
+  54 |     const todoItems = todoList.locator('[role="listitem"], li, tr');
+  55 |     const count = await todoItems.count();
+  56 |     expect(count).toBeGreaterThanOrEqual(0);
+  57 |   });
+  58 | 
+  59 |   test('should toggle theme between light and dark', async ({ page }) => {
+  60 |     // Find the theme toggle button
+  61 |     const themeToggle = page.locator('[aria-label="切换主题"]');
+  62 |     await expect(themeToggle).toBeVisible({ timeout: 3000 });
+  63 | 
+  64 |     // Get initial theme from localStorage
+  65 |     const initialTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  66 | 
+  67 |     // Click to toggle theme
+  68 |     await themeToggle.click();
+  69 |     await page.waitForTimeout(500);
+  70 | 
+  71 |     // Verify theme changed
+  72 |     const newTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  73 |     expect(newTheme).not.toBe(initialTheme);
+  74 | 
+  75 |     // Toggle back
+  76 |     await themeToggle.click();
+  77 |     await page.waitForTimeout(500);
+  78 | 
+  79 |     // Verify theme reverted
+  80 |     const revertedTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  81 |     expect(revertedTheme).toBe(initialTheme);
+  82 |   });
+  83 | });
+```

--- a/frontend/test-results/e2e-test-Executor-UI-Tests-should-load-the-main-page/error-context.md
+++ b/frontend/test-results/e2e-test-Executor-UI-Tests-should-load-the-main-page/error-context.md
@@ -1,0 +1,108 @@
+# Instructions
+
+- Following Playwright test failed.
+- Explain why, be concise, respect Playwright best practices.
+- Provide a snippet of code with the fix, if possible.
+
+# Test info
+
+- Name: e2e-test.spec.ts >> Executor UI Tests >> should load the main page
+- Location: e2e-test.spec.ts:11:3
+
+# Error details
+
+```
+Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+Call log:
+  - navigating to "http://localhost:5173/", waiting until "load"
+
+```
+
+# Test source
+
+```ts
+  1  | import { test, expect } from '@playwright/test';
+  2  | 
+  3  | test.describe('Executor UI Tests', () => {
+  4  |   test.beforeEach(async ({ page }) => {
+  5  |     // Go to the app
+> 6  |     await page.goto('http://localhost:5173');
+     |                ^ Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/
+  7  |     // Wait for page to load
+  8  |     await page.waitForLoadState('networkidle');
+  9  |   });
+  10 | 
+  11 |   test('should load the main page', async ({ page }) => {
+  12 |     // Check page title or main content
+  13 |     await expect(page.locator('body')).toBeVisible();
+  14 |   });
+  15 | 
+  16 |   test('should create a todo and start execution', async ({ page }) => {
+  17 |     // Click the add button or navigate to create todo
+  18 |     const addButton = page.locator('button').filter({ hasText: /新建|新增|添加|add/i }).first();
+  19 |     if (await addButton.isVisible()) {
+  20 |       await addButton.click();
+  21 |       await page.waitForTimeout(500);
+  22 |     }
+  23 | 
+  24 |     // Mobile FAB entry
+  25 |     const mobileFab = page.locator('[aria-label="新建任务"]').first();
+  26 |     if (await mobileFab.isVisible({ timeout: 1000 }).catch(() => false)) {
+  27 |       await mobileFab.click();
+  28 |       await page.waitForTimeout(500);
+  29 |     }
+  30 | 
+  31 |     // Find the title input and fill it
+  32 |     await page.getByPlaceholder('输入 Todo 标题').fill('Test task for UI');
+  33 | 
+  34 |     // Find prompt textarea and fill with simple prompt
+  35 |     await page.getByPlaceholder('输入 Prompt（会作为任务执行的内容，留空则使用标题）').fill('Say hello in 3 words');
+  36 | 
+  37 |     // 这里当前 UI 没有 executor 选择器；如果后续补了控件，再加稳定的 locator。
+  38 | 
+  39 |     // Submit the form
+  40 |     const submitButton = page.locator('button').filter({ hasText: /创建|提交|确定|submit|create/i }).first();
+  41 |     await submitButton.click();
+  42 |     await page.waitForTimeout(1000);
+  43 | 
+  44 |     // Check if todo was created
+  45 |     await page.waitForTimeout(500);
+  46 |   });
+  47 | 
+  48 |   test('should list todos', async ({ page }) => {
+  49 |     // Check if todo list exists
+  50 |     const todoList = page.locator('.todo-list-container');
+  51 |     await expect(todoList).toBeVisible({ timeout: 3000 });
+  52 | 
+  53 |     // Count todo items
+  54 |     const todoItems = todoList.locator('[role="listitem"], li, tr');
+  55 |     const count = await todoItems.count();
+  56 |     expect(count).toBeGreaterThanOrEqual(0);
+  57 |   });
+  58 | 
+  59 |   test('should toggle theme between light and dark', async ({ page }) => {
+  60 |     // Find the theme toggle button
+  61 |     const themeToggle = page.locator('[aria-label="切换主题"]');
+  62 |     await expect(themeToggle).toBeVisible({ timeout: 3000 });
+  63 | 
+  64 |     // Get initial theme from localStorage
+  65 |     const initialTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  66 | 
+  67 |     // Click to toggle theme
+  68 |     await themeToggle.click();
+  69 |     await page.waitForTimeout(500);
+  70 | 
+  71 |     // Verify theme changed
+  72 |     const newTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  73 |     expect(newTheme).not.toBe(initialTheme);
+  74 | 
+  75 |     // Toggle back
+  76 |     await themeToggle.click();
+  77 |     await page.waitForTimeout(500);
+  78 | 
+  79 |     // Verify theme reverted
+  80 |     const revertedTheme = await page.evaluate(() => localStorage.getItem('app_theme'));
+  81 |     expect(revertedTheme).toBe(initialTheme);
+  82 |   });
+  83 | });
+```

--- a/test_sync.cjs
+++ b/test_sync.cjs
@@ -1,0 +1,78 @@
+const { chromium } = require('@playwright/test');
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const errors = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+
+  try {
+    console.log('1. 访问应用...');
+    await page.goto('http://localhost:18088');
+    await page.waitForTimeout(3000);
+
+    console.log('2. 点击设置图标...');
+    await page.locator('.anticon-setting').click();
+    await page.waitForTimeout(1500);
+
+    console.log('3. 点击云端同步 tab...');
+    await page.locator('.ant-tabs-tab:has-text("云端同步")').click();
+    await page.waitForTimeout(1500);
+
+    console.log('4. 填写服务器地址...');
+    await page.locator('.cloud-sync-panel input[placeholder="http://localhost:8089"]').fill('http://localhost:8089');
+
+    console.log('5. 填写 Token...');
+    await page.locator('.cloud-sync-panel input[placeholder="ntd_xxx 格式的同步 Token"]').fill('ntd_291df6c5-2f39-431c-b269-867406ed9e39');
+
+    console.log('6. 点击保存配置...');
+    await page.locator('.cloud-sync-panel button:has-text("保存配置")').click();
+    await page.waitForTimeout(2000);
+
+    console.log('7. 检查状态...');
+    const success = await page.locator('.cloud-sync-panel .ant-alert-success').isVisible();
+    console.log(success ? '✓ 已连接' : '⚠ 未连接');
+
+    console.log('8. 点击推送按钮...');
+    await page.locator('.cloud-sync-panel button:has-text("推送")').click();
+    await page.waitForTimeout(1000);
+
+    console.log('9. 检查弹窗...');
+    const modal = await page.locator('.ant-modal').isVisible();
+    console.log(modal ? '✓ 弹窗显示' : '⚠ 弹窗未显示');
+
+    if (modal) {
+      console.log('10. 检查弹窗标题...');
+      const title = await page.locator('.ant-modal-title').textContent();
+      console.log('弹窗标题:', title);
+
+      console.log('11. 检查策略选项...');
+      const options = await page.locator('.ant-modal .ant-select-item').count();
+      console.log('策略选项数量:', options);
+
+      console.log('12. 点击执行同步...');
+      await page.locator('.ant-modal button:has-text("执行同步")').click();
+      await page.waitForTimeout(3000);
+
+      console.log('13. 检查消息提示...');
+      const msg = await page.locator('.ant-message').isVisible();
+      console.log(msg ? '✓ 显示消息' : '⚠ 未显示消息');
+    }
+
+    if (errors.length > 0) {
+      console.log('\n⚠ Console errors:', errors.slice(0, 3));
+    } else {
+      console.log('✓ 无 console 错误');
+    }
+
+    console.log('\n=== 测试完成 ===');
+  } catch (e) {
+    console.log('测试失败:', e.message);
+  }
+
+  await browser.close();
+})();


### PR DESCRIPTION
## 功能描述

实现云端同步功能的基础框架，支持配置云端服务器、用户登录注册、同步状态显示和同步历史记录。

### 后端改动

1. **配置管理** ()
   - 新增  结构：server_url、token、device_id、last_sync_at、default_conflict_mode

2. **数据库** 
   -  表 entity 定义
   -  表初始化和索引
   - 数据库操作方法：、

3. **API Handlers** ()
   -  - 用户注册
   -  - 用户登录
   -  - 退出登录
   -  - 创建设备
   -  - 获取配置
   -  - 保存配置
   -  - 获取同步状态
   -  - 获取同步历史

### 前端改动

1. **API 客户端** ()
2. **设备工具** ()
3. **云端同步面板** ()
   - 服务器地址配置
   - 登录/注册（邮箱+密码，自动创建设备）
   - 同步状态显示（已连接/未登录/未配置）
   - 同步历史记录表格
   - 退出登录

### 待完成

- [ ] Push（向上同步）API 集成
- [ ] Pull（向下同步）API 集成  
- [ ] 冲突解决策略的完整实现
- [ ] Dry Run 预览功能