### PR TITLE
feat: add CodeWhale executor

### DIFF
--- a/backend/src/adapters/codewhale.rs
+++ b/backend/src/adapters/codewhale.rs
@@ -1,0 +1,448 @@
+//! Codewhale executor adapter.
+//!
+//! Integrates with `codewhale exec --auto --output-format stream-json <prompt>`.
+//! Output format is NDJSON with events: tool_use, tool_result, content, session_capture, metadata, done.
+//!
+//! Example output:
+//!   {"type":"tool_use","name":"exec_shell","id":"call_xxx","input":{"command":"ls"}}
+//!   {"type":"tool_result","id":"call_xxx","output":"...","status":"success"}
+//!   {"type":"content","content":"Hello"}
+//!   {"type":"session_capture","content":"uuid"}
+//!   {"type":"metadata","meta":{"model":"deepseek-v4-pro","input_tokens":25182,"output_tokens":34,"session_id":"...","status":"completed"}}
+//!   {"type":"done"}
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use serde_json::Value;
+
+use super::{CodeExecutor, ExecutionUsage, ExecutorType, ParsedLogEntry};
+use crate::models::utc_timestamp;
+
+/// Codewhale executor implementation.
+pub struct CodewhaleExecutor {
+    /// Path to the codewhale binary.
+    path: String,
+    /// Stored model name (extracted from metadata event).
+    model: Arc<Mutex<Option<String>>>,
+    /// Stored usage info (extracted from metadata event).
+    usage: Arc<Mutex<Option<ExecutionUsage>>>,
+}
+
+impl CodewhaleExecutor {
+    pub fn new(path: String) -> Self {
+        Self {
+            path,
+            model: Arc::new(Mutex::new(None)),
+            usage: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl Clone for CodewhaleExecutor {
+    fn clone(&self) -> Self {
+        Self {
+            path: self.path.clone(),
+            model: self.model.clone(),
+            usage: self.usage.clone(),
+        }
+    }
+}
+
+impl CodeExecutor for CodewhaleExecutor {
+    fn executor_type(&self) -> ExecutorType {
+        ExecutorType::Codewhale
+    }
+
+    fn executable_path(&self) -> &str {
+        &self.path
+    }
+
+    /// Build command args for a fresh execution (no session).
+    /// Uses --auto to enable tool calls and --output-format stream-json for NDJSON output.
+    fn command_args(&self, message: &str) -> Vec<String> {
+        vec![
+            "exec".to_string(),
+            "--auto".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+            message.to_string(),
+        ]
+    }
+
+    /// Build command args with optional session support.
+    fn command_args_with_session(&self, message: &str, session_id: Option<&str>, is_resume: bool) -> Vec<String> {
+        let mut args = vec![
+            "exec".to_string(),
+            "--auto".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+        ];
+        if is_resume {
+            if let Some(sid) = session_id {
+                args.push("--session-id".to_string());
+                args.push(sid.to_string());
+            }
+        }
+        args.push(message.to_string());
+        args
+    }
+
+    fn supports_resume(&self) -> bool {
+        true
+    }
+
+    /// Extract session_id from session_capture event.
+    fn extract_session_id(&self, line: &str) -> Option<String> {
+        let json = serde_json::from_str::<Value>(line).ok()?;
+        if json.get("type")?.as_str()? == "session_capture" {
+            json.get("content")?.as_str().map(String::from)
+        } else {
+            None
+        }
+    }
+
+    /// Parse a single NDJSON line from codewhale stream-json output.
+    fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        let json = serde_json::from_str::<Value>(trimmed).ok()?;
+        let event_type = json.get("type")?.as_str()?;
+
+        match event_type {
+            "tool_use" => {
+                // {"type":"tool_use","name":"exec_shell","id":"call_xxx","input":{"command":"ls"}}
+                let name = json.get("name").and_then(Value::as_str).unwrap_or("unknown");
+                let input = json.get("input");
+                let command = input
+                    .and_then(|v| v.get("command"))
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                let input_json = input.map(|v| v.to_string());
+
+                Some(ParsedLogEntry {
+                    timestamp: utc_timestamp(),
+                    log_type: "tool_call".to_string(),
+                    content: format!("Calling tool: {} with args: {}", name, command),
+                    usage: None,
+                    tool_name: Some(name.to_string()),
+                    tool_input_json: input_json,
+                })
+            }
+            "tool_result" => {
+                // {"type":"tool_result","id":"call_xxx","output":"...","status":"success"}
+                let output = json.get("output").and_then(Value::as_str).unwrap_or_default();
+                let status = json.get("status").and_then(Value::as_str).unwrap_or("completed");
+                let id = json.get("id").and_then(Value::as_str).unwrap_or_default();
+
+                Some(ParsedLogEntry {
+                    timestamp: utc_timestamp(),
+                    log_type: "tool_result".to_string(),
+                    content: if output.is_empty() {
+                        format!("[{}] (id: {})", status, id)
+                    } else {
+                        format!("[{}] {}", status, output)
+                    },
+                    usage: None,
+                    tool_name: None,
+                    tool_input_json: None,
+                })
+            }
+            "content" => {
+                // {"type":"content","content":"Hello"}
+                let content = json.get("content").and_then(Value::as_str).unwrap_or_default();
+                if content.is_empty() {
+                    return None;
+                }
+                Some(ParsedLogEntry {
+                    timestamp: utc_timestamp(),
+                    log_type: "text".to_string(),
+                    content: content.to_string(),
+                    usage: None,
+                    tool_name: None,
+                    tool_input_json: None,
+                })
+            }
+            "metadata" => {
+                // {"type":"metadata","meta":{"model":"deepseek-v4-pro","input_tokens":25182,"output_tokens":34,"session_id":"...","status":"completed"}}
+                let meta = json.get("meta")?;
+
+                // Extract and store model
+                if let Some(model) = meta.get("model").and_then(Value::as_str) {
+                    *self.model.lock() = Some(model.to_string());
+                }
+
+                // Extract and store usage
+                let input_tokens = meta.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+                let output_tokens = meta.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+
+                if input_tokens > 0 || output_tokens > 0 {
+                    let usage = ExecutionUsage {
+                        input_tokens,
+                        output_tokens,
+                        cache_read_input_tokens: None,
+                        cache_creation_input_tokens: None,
+                        total_cost_usd: None,
+                        duration_ms: None,
+                    };
+                    *self.usage.lock() = Some(usage);
+                }
+
+                let status = meta.get("status").and_then(Value::as_str).unwrap_or("completed");
+                Some(ParsedLogEntry {
+                    timestamp: utc_timestamp(),
+                    log_type: "tokens".to_string(),
+                    content: format!(
+                        "Tokens: input={}, output={}, status={}",
+                        input_tokens, output_tokens, status
+                    ),
+                    usage: self.usage.lock().clone(),
+                    tool_name: None,
+                    tool_input_json: None,
+                })
+            }
+            "done" => {
+                // {"type":"done"} - terminal event, ignore
+                None
+            }
+            _ => None,
+        }
+    }
+
+    fn parse_stderr_line(&self, line: &str) -> Option<ParsedLogEntry> {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        Some(ParsedLogEntry {
+            timestamp: utc_timestamp(),
+            log_type: if trimmed.to_lowercase().contains("error") {
+                "error".to_string()
+            } else {
+                "stderr".to_string()
+            },
+            content: trimmed.to_string(),
+            usage: None,
+            tool_name: None,
+            tool_input_json: None,
+        })
+    }
+
+    fn check_success(&self, exit_code: i32) -> bool {
+        exit_code == 0
+    }
+
+    fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
+        // Collect all text entries, stripping think tags if present
+        let texts: Vec<String> = logs
+            .iter()
+            .filter(|l| l.log_type == "text")
+            .map(|l| super::strip_think_tags(&l.content))
+            .filter(|t| !t.trim().is_empty())
+            .collect();
+
+        if !texts.is_empty() {
+            Some(texts.join("\n\n"))
+        } else {
+            // Fallback: last stderr entry
+            logs.iter()
+                .rev()
+                .find(|l| l.log_type == "stderr")
+                .map(|l| l.content.clone())
+        }
+    }
+
+    fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
+        self.usage.lock().clone()
+    }
+
+    fn get_model(&self) -> Option<String> {
+        self.model.lock().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_args() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let args = executor.command_args("say hello");
+        assert_eq!(
+            args,
+            vec![
+                "exec",
+                "--auto",
+                "--output-format",
+                "stream-json",
+                "say hello"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_command_args_with_session() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let args = executor.command_args_with_session("say hello", Some("session-123"), true);
+        assert_eq!(
+            args,
+            vec![
+                "exec",
+                "--auto",
+                "--output-format",
+                "stream-json",
+                "--session-id",
+                "session-123",
+                "say hello"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_executor_type() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        assert_eq!(executor.executor_type(), ExecutorType::Codewhale);
+    }
+
+    #[test]
+    fn test_parse_tool_use() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let line = r#"{"type":"tool_use","name":"exec_shell","id":"call_001","input":{"command":"ls -la"}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "tool_call");
+        assert_eq!(entry.tool_name, Some("exec_shell".to_string()));
+        assert!(entry.content.contains("ls -la"));
+    }
+
+    #[test]
+    fn test_parse_tool_result() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let line = r#"{"type":"tool_result","id":"call_001","output":"file1.txt\nfile2.txt","status":"success"}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "tool_result");
+        assert!(entry.content.contains("success"));
+        assert!(entry.content.contains("file1.txt"));
+    }
+
+    #[test]
+    fn test_parse_content() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let line = r#"{"type":"content","content":"Hello world"}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "text");
+        assert_eq!(entry.content, "Hello world");
+    }
+
+    #[test]
+    fn test_parse_content_empty() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let line = r#"{"type":"content","content":""}"#;
+        assert!(executor.parse_output_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_metadata() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let line = r#"{"type":"metadata","meta":{"model":"deepseek-v4-pro","input_tokens":25182,"output_tokens":34,"session_id":"abc123","status":"completed"}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "tokens");
+
+        let usage = executor.get_usage(&[]).unwrap();
+        assert_eq!(usage.input_tokens, 25182);
+        assert_eq!(usage.output_tokens, 34);
+
+        let model = executor.get_model().unwrap();
+        assert_eq!(model, "deepseek-v4-pro");
+    }
+
+    #[test]
+    fn test_parse_done() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let line = r#"{"type":"done"}"#;
+        assert!(executor.parse_output_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_unknown_type() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let line = r#"{"type":"unknown","data":"test"}"#;
+        assert!(executor.parse_output_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_invalid_json() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        assert!(executor.parse_output_line("not json").is_none());
+    }
+
+    #[test]
+    fn test_extract_session_id() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let line = r#"{"type":"session_capture","content":"e5b5853f-31a1-4717-88b3-8e8838157586"}"#;
+        let sid = executor.extract_session_id(line).unwrap();
+        assert_eq!(sid, "e5b5853f-31a1-4717-88b3-8e8838157586");
+    }
+
+    #[test]
+    fn test_extract_session_id_not_capture() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let line = r#"{"type":"content","content":"hello"}"#;
+        assert!(executor.extract_session_id(line).is_none());
+    }
+
+    #[test]
+    fn test_get_final_result_with_text() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let logs = vec![
+            ParsedLogEntry::new("text", "  Hello  "),
+            ParsedLogEntry::new("text", "  World  "),
+        ];
+        assert_eq!(executor.get_final_result(&logs), Some("Hello\n\nWorld".to_string()));
+    }
+
+    #[test]
+    fn test_get_final_result_with_think_tags() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let logs = vec![
+            ParsedLogEntry::new("text", "<think>thinking过程</think>Hello"),
+        ];
+        assert_eq!(executor.get_final_result(&logs), Some("Hello".to_string()));
+    }
+
+    #[test]
+    fn test_get_final_result_fallback_to_stderr() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let logs = vec![
+            ParsedLogEntry::new("stderr", "error output"),
+        ];
+        assert_eq!(executor.get_final_result(&logs), Some("error output".to_string()));
+    }
+
+    #[test]
+    fn test_supports_resume() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        assert!(executor.supports_resume());
+    }
+
+    #[test]
+    fn test_parse_stderr_error() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let line = "ERROR: something went wrong";
+        let entry = executor.parse_stderr_line(line).unwrap();
+        assert_eq!(entry.log_type, "error");
+        assert_eq!(entry.content, "ERROR: something went wrong");
+    }
+
+    #[test]
+    fn test_parse_stderr_info() {
+        let executor = CodewhaleExecutor::new("codewhale".to_string());
+        let line = "Just some info";
+        let entry = executor.parse_stderr_line(line).unwrap();
+        assert_eq!(entry.log_type, "stderr");
+        assert_eq!(entry.content, "Just some info");
+    }
+}

--- a/backend/src/adapters/codewhale.rs
+++ b/backend/src/adapters/codewhale.rs
@@ -153,7 +153,8 @@ impl CodeExecutor for CodewhaleExecutor {
             }
             "content" => {
                 // {"type":"content","content":"Hello"}
-                let content = json.get("content").and_then(Value::as_str).unwrap_or_default();
+                // Trim trailing whitespace/newlines to prevent extra line breaks in final result
+                let content = json.get("content").and_then(Value::as_str).unwrap_or_default().trim_end();
                 if content.is_empty() {
                     return None;
                 }
@@ -236,7 +237,9 @@ impl CodeExecutor for CodewhaleExecutor {
     }
 
     fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
-        // Collect all text entries, stripping think tags if present
+        // Collect all text entries, stripping think tags if present.
+        // CodeWhale streams text as small chunks (individual characters or words),
+        // so we join with empty string to preserve natural flow without extra newlines.
         let texts: Vec<String> = logs
             .iter()
             .filter(|l| l.log_type == "text")
@@ -245,7 +248,16 @@ impl CodeExecutor for CodewhaleExecutor {
             .collect();
 
         if !texts.is_empty() {
-            Some(texts.join("\n\n"))
+            // Join with empty string since chunks are already trimmed
+            let joined = texts.join("");
+            // Normalize multiple newlines to single newline for readability
+            let normalized = joined
+                .split('\n')
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+                .join("\n");
+            Some(normalized)
         } else {
             // Fallback: last stderr entry
             logs.iter()

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -105,6 +105,15 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         session_dir: "~/.codex",
         aliases: &[],
     },
+    ExecutorDef {
+        name: "codewhale",
+        executor_type: ExecutorType::Codewhale,
+        binary_name: "codewhale",
+        display_name: "CodeWhale",
+        default_path: "codewhale",
+        session_dir: "~/.codewhale",
+        aliases: &[],
+    },
 ];
 
 /// Find executor definition by name or alias
@@ -164,6 +173,7 @@ pub mod atomcode;
 pub mod hermes;
 pub mod kimi;
 pub mod codex;
+pub mod codewhale;
 
 #[async_trait]
 pub trait CodeExecutor: Send + Sync {
@@ -273,6 +283,7 @@ impl ExecutorRegistry {
             "hermes" => Arc::new(hermes::HermesExecutor::new(path.to_string())),
             "kimi" => Arc::new(kimi::KimiExecutor::new(path.to_string())),
             "codex" => Arc::new(codex::CodexExecutor::new(path.to_string())),
+            "codewhale" => Arc::new(codewhale::CodewhaleExecutor::new(path.to_string())),
             _ => return None,
         };
         Some(executor)
@@ -334,6 +345,12 @@ mod tests {
     fn test_parse_executor_type_codex() {
         assert_eq!(parse_executor_type("codex"), Some(ExecutorType::Codex));
         assert_eq!(parse_executor_type("CODEX"), Some(ExecutorType::Codex));
+    }
+
+    #[test]
+    fn test_parse_executor_type_codewhale() {
+        assert_eq!(parse_executor_type("codewhale"), Some(ExecutorType::Codewhale));
+        assert_eq!(parse_executor_type("CODEWHALE"), Some(ExecutorType::Codewhale));
     }
 
     #[test]

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -80,7 +80,7 @@ pub enum TodoAction {
         #[arg(long)]
         stdin: bool,
 
-        /// Executor type (claudecode, joinai, codebuddy, opencode, atomcode, hermes, kimi, codex)
+        /// Executor type (claudecode, joinai, codebuddy, opencode, atomcode, hermes, kimi, codex, codewhale)
         #[arg(short, long)]
         executor: Option<String>,
 

--- a/backend/src/db/executor_config.rs
+++ b/backend/src/db/executor_config.rs
@@ -158,4 +158,30 @@ impl Database {
         }
         Ok(())
     }
+
+    /// Sync new executors from EXECUTORS static array into database.
+    /// Adds any executors that exist in EXECUTORS but not in the database.
+    pub async fn sync_new_executors(&self) -> Result<(), sea_orm::DbErr> {
+        let existing = executors::Entity::find().all(&self.conn).await?;
+        let existing_names: Vec<&str> = existing.iter().map(|m| m.name.as_str()).collect();
+        let now = crate::models::utc_timestamp();
+
+        for exec in EXECUTORS {
+            if !existing_names.contains(&exec.name) {
+                let am = executors::ActiveModel {
+                    name: ActiveValue::Set(exec.name.to_string()),
+                    path: ActiveValue::Set(exec.default_path.to_string()),
+                    enabled: ActiveValue::Set(true),
+                    display_name: ActiveValue::Set(exec.display_name.to_string()),
+                    session_dir: ActiveValue::Set(exec.session_dir.to_string()),
+                    created_at: ActiveValue::Set(Some(now.clone())),
+                    updated_at: ActiveValue::Set(Some(now.clone())),
+                    ..Default::default()
+                };
+                am.insert(&self.conn).await?;
+                tracing::info!("Added new executor '{}' to database", exec.name);
+            }
+        }
+        Ok(())
+    }
 }

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -120,12 +120,13 @@ fn executor_label(et: ExecutorType) -> &'static str {
         ExecutorType::Atomcode => "AtomCode",
         ExecutorType::Kimi => "Kimi",
         ExecutorType::Joinai => "JoinAI",
+        ExecutorType::Codewhale => "CodeWhale",
     }
 }
 
 // 保留 ALL_EXECUTORS 供其他可能用到的代码；新代码请用 ALL_SKILL_SOURCES
 #[allow(dead_code)]
-const ALL_EXECUTORS: [ExecutorType; 8] = [
+const ALL_EXECUTORS: [ExecutorType; 9] = [
     ExecutorType::Claudecode,
     ExecutorType::Hermes,
     ExecutorType::Codex,
@@ -134,6 +135,7 @@ const ALL_EXECUTORS: [ExecutorType; 8] = [
     ExecutorType::Atomcode,
     ExecutorType::Kimi,
     ExecutorType::Joinai,
+    ExecutorType::Codewhale,
 ];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -191,7 +191,7 @@ fn executor_skills_dir(et: &str) -> Option<PathBuf> {
 
 const ALL_EXECUTORS: &[&str] = &[
     "claudecode", "hermes", "codex", "codebuddy",
-    "opencode", "atomcode", "kimi", "joinai",
+    "opencode", "atomcode", "kimi", "joinai", "codewhale",
 ];
 
 /// Install embedded ntd-usage skill to executor skill directories.

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -359,6 +359,10 @@ async fn run_server(cli_port: Option<u16>) {
     if let Err(e) = db.seed_default_executors().await {
         tracing::warn!("Failed to seed default executors: {}", e);
     }
+    // Sync any new executors added since last version
+    if let Err(e) = db.sync_new_executors().await {
+        tracing::warn!("Failed to sync new executors: {}", e);
+    }
     if let Err(e) = db.backfill_session_dir().await {
         tracing::warn!("Failed to backfill session_dir: {}", e);
     }

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -690,6 +690,7 @@ pub enum ExecutorType {
     Hermes,
     Kimi,
     Codex,
+    Codewhale,
 }
 
 
@@ -704,6 +705,7 @@ impl ExecutorType {
             ExecutorType::Hermes => "hermes",
             ExecutorType::Kimi => "kimi",
             ExecutorType::Codex => "codex",
+            ExecutorType::Codewhale => "codewhale",
         }
     }
 }

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -306,6 +306,7 @@ export const EXECUTORS: ExecutorOption[] = [
   { value: 'hermes',     label: 'Hermes',    color: '#0984e3', icon: <FaSquare color="#0984e3" size={14} /> },
   { value: 'kimi',       label: 'Kimi',      color: '#d63031', icon: <FaSquare color="#d63031" size={14} /> },
   { value: 'codex',      label: 'Codex',     color: '#488597', icon: <FaSquare color="#488597" size={14} /> },
+  { value: 'codewhale',  label: 'CodeWhale', color: '#00cec9', icon: <FaSquare color="#00cec9" size={14} /> },
   // `agents` 是只读 skill 来源（`~/.agents/skills`），不在「执行器管理」显示，
   // 但会出现在 Skills 总览/对比/同步里。这里加进 EXECUTORS 是为了 Tab 渲染。
   // 颜色选深灰 `#2d3436` 故意区别于其他 8 个暖色调（橙/绿/黄/紫/红/蓝/粉），
@@ -322,6 +323,7 @@ export const EXECUTOR_COLORS: Record<string, string> = {
   hermes: '#0984e3',
   kimi: '#d63031',
   codex: '#488597',
+  codewhale: '#00cec9',
   agents: '#2d3436',
   // Aliases for backward compatibility with database names
   'claude_code': '#e17055', // alias for claudecode
@@ -376,7 +378,7 @@ export interface Config {
   scheduler_default_timezone?: string;
 }
 
-export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'joinai', 'hermes']);
+export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'joinai', 'hermes', 'codewhale']);
 
 export function supportsResume(record: ExecutionRecord): boolean {
   return (


### PR DESCRIPTION
## Summary

Add CodeWhale executor integration to ntd.

### Changes

**New adapter** ():
- Uses `codewhale exec --auto --output-format stream-json <prompt>`
- Parses NDJSON events: tool_use, tool_result, content, metadata, done
- Supports session resume via --session-id
- Stores model name and usage from metadata event
- Normalizes streamed text chunks to prevent extra line breaks

**Executor registration**:
- Added `ExecutorType::Codewhale` to backend/src/models/mod.rs
- Registered `CodewhaleExecutor` in backend/src/adapters/mod.rs
- Added to `ALL_EXECUTORS` in main.rs and handlers/skills.rs
- Added to CLI help text

**Frontend**:
- Added codewhale option to EXECUTORS array with color #00cec9
- Added to RESUMABLE_EXECUTORS set

**Bug fix - Auto-sync new executors**:
- Added `sync_new_executors()` to auto-add new executors from EXECUTORS static array to database on startup
- This ensures new executors added in code are automatically available without manual database intervention

### Testing
- All 19 unit tests passing for codewhale adapter
- All existing tests pass