### PR TITLE
fix: use --dangerously-skip-permissions for atomcode

### DIFF
--- a/backend/src/adapters/atomcode.rs
+++ b/backend/src/adapters/atomcode.rs
@@ -42,6 +42,7 @@ impl CodeExecutor for AtomcodeExecutor {
     fn command_args(&self, message: &str) -> Vec<String> {
         vec![
             "-v".to_string(),
+            "--dangerously-skip-permissions".to_string(),
             "-p".to_string(),
             message.to_string(),
         ]
@@ -347,7 +348,7 @@ mod tests {
     fn test_command_args() {
         let executor = AtomcodeExecutor::new("atomcode".to_string());
         let args = executor.command_args("do something");
-        assert_eq!(args, vec!["-v", "-p", "do something"]);
+        assert_eq!(args, vec!["-v", "--dangerously-skip-permissions", "-p", "do something"]);
     }
 
     #[test]


### PR DESCRIPTION
修复 atomcode executor 使用错误标志的问题。

- 将  替换为标准的  参数
- 与 claude_code、opencode 保持一致