### PR TITLE
feat(settings): 调整设置页面Tab顺序，按逻辑分组排列

### DIFF
--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -140,6 +140,14 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
     }
   };
 
+  // Tab 顺序说明：
+  // 1. 系统设置、执行器管理、标签管理 → 基础配置优先
+  // 2. 消息、Session 管理 → 用户个性化配置紧随其后
+  // 3. 项目目录、模板管理 → 项目相关
+  // 4. 备份与恢复 → 数据安全（用户配置完毕后最后考虑）
+  // 5. Skills 管理、运行管理 → 高级功能放中间层
+  // 6. Webhook、云端同步 → 外部集成邻近放置
+  // 7. 关于 → 信息页末位
   const tabItems = [
     {
       key: 'system',
@@ -170,9 +178,31 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       children: <TagsPanel tags={tags} dispatch={dispatch} />,
     },
     {
+      key: 'messages',
+      label: <span><MessageOutlined style={{ marginRight: 6 }} />消息</span>,
+      children: (
+        <MessagesPanel
+          configForm={configForm}
+          configSaving={configSaving}
+          handleSaveConfig={handleSaveConfig}
+          onBack={onBack}
+        />
+      ),
+    },
+    {
+      key: 'sessions',
+      label: <span><LaptopOutlined style={{ marginRight: 6 }} />Session 管理</span>,
+      children: <SessionManager />,
+    },
+    {
       key: 'projectDirectories',
       label: <span><FolderOutlined style={{ marginRight: 6 }} />项目目录</span>,
       children: <ProjectDirectoriesPanel />,
+    },
+    {
+      key: 'templates',
+      label: <span><FileTextOutlined style={{ marginRight: 6 }} />模板管理</span>,
+      children: <TemplatesPanel />,
     },
     {
       key: 'backup',
@@ -195,28 +225,6 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
           executorDisplayNames={executorDisplayNames}
         />
       ),
-    },
-    {
-      key: 'messages',
-      label: <span><MessageOutlined style={{ marginRight: 6 }} />消息</span>,
-      children: (
-        <MessagesPanel
-          configForm={configForm}
-          configSaving={configSaving}
-          handleSaveConfig={handleSaveConfig}
-          onBack={onBack}
-        />
-      ),
-    },
-    {
-      key: 'sessions',
-      label: <span><LaptopOutlined style={{ marginRight: 6 }} />Session 管理</span>,
-      children: <SessionManager />,
-    },
-    {
-      key: 'templates',
-      label: <span><FileTextOutlined style={{ marginRight: 6 }} />模板管理</span>,
-      children: <TemplatesPanel />,
     },
     {
       key: 'webhooks',


### PR DESCRIPTION
## 变更内容

调整设置页面的 13 个 Tab 的排列顺序，按照用户使用逻辑分组：

| 顺序 | Tab | 调整说明 |
|------|-----|----------|
| 1 | 系统设置 | 基础配置首选 |
| 2 | 执行器管理 | 核心功能配置 |
| 3 | 标签管理 | 基础配置 |
| 4 | 消息 | **提前**（原第8位） |
| 5 | Session 管理 | **提前**（原第9位） |
| 6 | 项目目录 | 保持 |
| 7 | 模板管理 | **提前**（原第10位） |
| 8 | 备份与恢复 | **后移**（原第5位） |
| 9 | Skills 管理 | **后移**（原第6位） |
| 10 | 运行管理 | **后移**（原第7位） |
| 11 | Webhook | 保持 |
| 12 | 云端同步 | 保持 |
| 13 | 关于 | 保持 |

## 调整逻辑

按「基础配置 → 用户个性化 → 项目相关 → 数据安全 → 高级功能 → 外部集成 → 信息」的层次排列，让高频配置项更早触达用户。