### PR TITLE
fix: 删除飞书绑定机器人时级联删除关联子表数据

### DIFF
--- a/backend/src/db/agent_bot.rs
+++ b/backend/src/db/agent_bot.rs
@@ -1,12 +1,7 @@
-use sea_orm::{ActiveModelTrait, ActiveValue, EntityTrait, QueryOrder, QueryFilter, ColumnTrait};
+use sea_orm::{ActiveModelTrait, ActiveValue, EntityTrait, QueryOrder};
 use crate::db::Database;
 use crate::db::entity::agent_bots;
 use crate::db::entity::feishu_response_config;
-use crate::db::entity::feishu_homes;
-use crate::db::entity::feishu_messages;
-use crate::db::entity::feishu_history_chats;
-use crate::db::entity::feishu_push_targets;
-use crate::db::entity::feishu_group_whitelist;
 use crate::models::AgentBot;
 
 fn map_bot(m: agent_bots::Model) -> AgentBot {
@@ -77,34 +72,7 @@ impl Database {
     }
 
     pub async fn delete_agent_bot(&self, id: i64) -> Result<(), sea_orm::DbErr> {
-        // Cascade delete all related feishu child tables before deleting the bot
-        // Tables with FOREIGN KEY constraint on bot_id (must be deleted first):
-        feishu_homes::Entity::delete_many()
-            .filter(feishu_homes::Column::BotId.eq(id))
-            .exec(&self.conn)
-            .await?;
-        feishu_messages::Entity::delete_many()
-            .filter(feishu_messages::Column::BotId.eq(id))
-            .exec(&self.conn)
-            .await?;
-        feishu_history_chats::Entity::delete_many()
-            .filter(feishu_history_chats::Column::BotId.eq(id))
-            .exec(&self.conn)
-            .await?;
-        feishu_push_targets::Entity::delete_many()
-            .filter(feishu_push_targets::Column::BotId.eq(id))
-            .exec(&self.conn)
-            .await?;
-        // Tables without FK constraint but also reference bot_id:
-        feishu_response_config::Entity::delete_many()
-            .filter(feishu_response_config::Column::BotId.eq(id))
-            .exec(&self.conn)
-            .await?;
-        feishu_group_whitelist::Entity::delete_many()
-            .filter(feishu_group_whitelist::Column::BotId.eq(id))
-            .exec(&self.conn)
-            .await?;
-
+        // Child rows in feishu_* tables are cleaned up by ON DELETE CASCADE.
         agent_bots::Entity::delete_by_id(id).exec(&self.conn).await?;
         Ok(())
     }

--- a/backend/src/db/agent_bot.rs
+++ b/backend/src/db/agent_bot.rs
@@ -1,7 +1,12 @@
-use sea_orm::{ActiveModelTrait, ActiveValue, EntityTrait, QueryOrder};
+use sea_orm::{ActiveModelTrait, ActiveValue, EntityTrait, QueryOrder, QueryFilter, ColumnTrait};
 use crate::db::Database;
 use crate::db::entity::agent_bots;
 use crate::db::entity::feishu_response_config;
+use crate::db::entity::feishu_homes;
+use crate::db::entity::feishu_messages;
+use crate::db::entity::feishu_history_chats;
+use crate::db::entity::feishu_push_targets;
+use crate::db::entity::feishu_group_whitelist;
 use crate::models::AgentBot;
 
 fn map_bot(m: agent_bots::Model) -> AgentBot {
@@ -72,6 +77,34 @@ impl Database {
     }
 
     pub async fn delete_agent_bot(&self, id: i64) -> Result<(), sea_orm::DbErr> {
+        // Cascade delete all related feishu child tables before deleting the bot
+        // Tables with FOREIGN KEY constraint on bot_id (must be deleted first):
+        feishu_homes::Entity::delete_many()
+            .filter(feishu_homes::Column::BotId.eq(id))
+            .exec(&self.conn)
+            .await?;
+        feishu_messages::Entity::delete_many()
+            .filter(feishu_messages::Column::BotId.eq(id))
+            .exec(&self.conn)
+            .await?;
+        feishu_history_chats::Entity::delete_many()
+            .filter(feishu_history_chats::Column::BotId.eq(id))
+            .exec(&self.conn)
+            .await?;
+        feishu_push_targets::Entity::delete_many()
+            .filter(feishu_push_targets::Column::BotId.eq(id))
+            .exec(&self.conn)
+            .await?;
+        // Tables without FK constraint but also reference bot_id:
+        feishu_response_config::Entity::delete_many()
+            .filter(feishu_response_config::Column::BotId.eq(id))
+            .exec(&self.conn)
+            .await?;
+        feishu_group_whitelist::Entity::delete_many()
+            .filter(feishu_group_whitelist::Column::BotId.eq(id))
+            .exec(&self.conn)
+            .await?;
+
         agent_bots::Entity::delete_by_id(id).exec(&self.conn).await?;
         Ok(())
     }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -130,6 +130,181 @@ impl Database {
         model.update(&self.conn).await.map(|_| ())
     }
 
+    /// 迁移：为飞书子表添加 ON DELETE CASCADE 外键约束
+    /// SQLite 不支持 ALTER TABLE 修改外键约束，需要重建表（创建新表→复制数据→删除旧表→重命名）
+    async fn migrate_feishu_fk_cascade(&self) -> Result<(), sea_orm::DbErr> {
+        // 检查 feishu_homes 是否已有 ON DELETE CASCADE
+        let needs_migration = self.table_fk_has_cascade("feishu_homes").await?;
+        if !needs_migration {
+            return Ok(());
+        }
+
+        tracing::info!("Migrating feishu tables to add ON DELETE CASCADE...");
+
+        // feishu_homes
+        self.rebuild_table_with_cascade(
+            "feishu_homes",
+            "id INTEGER PRIMARY KEY AUTOINCREMENT,
+             bot_id INTEGER NOT NULL,
+             user_open_id TEXT NOT NULL,
+             chat_id TEXT,
+             receive_id TEXT NOT NULL,
+             receive_id_type TEXT NOT NULL,
+             created_at TEXT,
+             updated_at TEXT,
+             FOREIGN KEY (bot_id) REFERENCES agent_bots(id) ON DELETE CASCADE,
+             UNIQUE(bot_id, user_open_id)",
+        ).await?;
+
+        // feishu_messages
+        self.rebuild_table_with_cascade(
+            "feishu_messages",
+            "id INTEGER PRIMARY KEY AUTOINCREMENT,
+             bot_id INTEGER NOT NULL,
+             message_id TEXT NOT NULL UNIQUE,
+             chat_id TEXT NOT NULL,
+             chat_type TEXT NOT NULL,
+             sender_open_id TEXT NOT NULL,
+             sender_nickname TEXT,
+             sender_type TEXT,
+             content TEXT,
+             msg_type TEXT NOT NULL DEFAULT 'text',
+             is_mention INTEGER DEFAULT 0,
+             processed INTEGER DEFAULT 0,
+             is_history INTEGER DEFAULT 0,
+             fetch_time TEXT,
+             created_at TEXT,
+             processed_todo_id INTEGER,
+             execution_record_id INTEGER,
+             FOREIGN KEY (bot_id) REFERENCES agent_bots(id) ON DELETE CASCADE",
+        ).await?;
+        // 重建索引
+        self.exec("CREATE INDEX IF NOT EXISTS idx_feishu_messages_chat_id ON feishu_messages(chat_id)").await?;
+        self.exec("CREATE INDEX IF NOT EXISTS idx_feishu_messages_created_at ON feishu_messages(created_at)").await?;
+
+        // feishu_history_chats
+        self.rebuild_table_with_cascade(
+            "feishu_history_chats",
+            "id INTEGER PRIMARY KEY AUTOINCREMENT,
+             bot_id INTEGER NOT NULL,
+             chat_id TEXT NOT NULL,
+             chat_name TEXT,
+             enabled INTEGER DEFAULT 1,
+             last_fetch_time TEXT,
+             polling_interval_secs INTEGER DEFAULT 60,
+             created_at TEXT,
+             FOREIGN KEY (bot_id) REFERENCES agent_bots(id) ON DELETE CASCADE,
+             UNIQUE(bot_id, chat_id)",
+        ).await?;
+
+        // feishu_push_targets
+        self.rebuild_table_with_cascade(
+            "feishu_push_targets",
+            "id INTEGER PRIMARY KEY AUTOINCREMENT,
+             bot_id INTEGER NOT NULL,
+             p2p_receive_id TEXT NOT NULL DEFAULT '',
+             group_chat_id TEXT NOT NULL DEFAULT '',
+             receive_id_type TEXT NOT NULL DEFAULT 'open_id',
+             push_level TEXT DEFAULT 'result_only',
+             p2p_response_enabled INTEGER DEFAULT 1,
+             group_response_enabled INTEGER DEFAULT 1,
+             created_at TEXT,
+             updated_at TEXT,
+             FOREIGN KEY (bot_id) REFERENCES agent_bots(id) ON DELETE CASCADE",
+        ).await?;
+
+        // feishu_response_config
+        self.rebuild_table_with_cascade(
+            "feishu_response_config",
+            "id INTEGER PRIMARY KEY AUTOINCREMENT,
+             bot_id INTEGER NOT NULL,
+             target_type TEXT NOT NULL,
+             enabled INTEGER NOT NULL DEFAULT 1,
+             debounce_secs INTEGER DEFAULT 20,
+             created_at TEXT,
+             updated_at TEXT,
+             FOREIGN KEY (bot_id) REFERENCES agent_bots(id) ON DELETE CASCADE,
+             UNIQUE(bot_id, target_type)",
+        ).await?;
+
+        // feishu_group_whitelist
+        self.rebuild_table_with_cascade(
+            "feishu_group_whitelist",
+            "id INTEGER PRIMARY KEY AUTOINCREMENT,
+             bot_id INTEGER NOT NULL,
+             sender_open_id TEXT NOT NULL,
+             sender_name TEXT,
+             created_at TEXT,
+             FOREIGN KEY (bot_id) REFERENCES agent_bots(id) ON DELETE CASCADE,
+             UNIQUE(bot_id, sender_open_id)",
+        ).await?;
+
+        tracing::info!("Feishu FK cascade migration completed.");
+        Ok(())
+    }
+
+    /// 检查表的外键是否缺少 ON DELETE CASCADE（返回 true 表示需要迁移）
+    async fn table_fk_has_cascade(&self, table: &str) -> Result<bool, sea_orm::DbErr> {
+        let sql = format!("SELECT sql FROM sqlite_master WHERE type='table' AND name='{}'", table);
+        let result = self.conn
+            .query_one(Statement::from_string(DbBackend::Sqlite, sql))
+            .await?;
+        if let Some(row) = result {
+            let ddl: String = row.try_get_by("sql")?;
+            // 如果 DDL 中包含 ON DELETE CASCADE，说明已经是新 schema
+            return Ok(!ddl.contains("ON DELETE CASCADE"));
+        }
+        // 表不存在，CREATE TABLE IF NOT EXISTS 会创建正确的 schema
+        Ok(false)
+    }
+
+    /// 重建表以添加 ON DELETE CASCADE 外键约束
+    /// SQLite 标准迁移流程：新建→复制→删除→重命名
+    async fn rebuild_table_with_cascade(&self, table: &str, columns: &str) -> Result<(), sea_orm::DbErr> {
+        let tmp = format!("{}_new", table);
+        tracing::info!("Rebuilding table {} to add ON DELETE CASCADE...", table);
+
+        // 暂时关闭外键检查以避免重建过程中的约束冲突
+        self.exec("PRAGMA foreign_keys = OFF").await?;
+
+        // 创建新表
+        self.exec(&format!(
+            "CREATE TABLE IF NOT EXISTS {} ({})",
+            tmp, columns
+        )).await?;
+
+        // 获取旧表列名列表，用于安全的数据复制
+        let col_rows = self.conn
+            .query_all(Statement::from_string(
+                DbBackend::Sqlite,
+                format!("PRAGMA table_info('{}')", table),
+            ))
+            .await?;
+        let col_names: Vec<String> = col_rows
+            .iter()
+            .filter_map(|r| r.try_get::<String>("", "name").ok())
+            .collect();
+        let cols_str = col_names.join(", ");
+
+        // 复制数据
+        self.exec(&format!(
+            "INSERT INTO {} ({}) SELECT {} FROM {}",
+            tmp, cols_str, cols_str, table
+        )).await?;
+
+        // 删除旧表
+        self.exec(&format!("DROP TABLE {}", table)).await?;
+
+        // 重命名新表
+        self.exec(&format!("ALTER TABLE {} RENAME TO {}", tmp, table)).await?;
+
+        // 重新启用外键检查
+        self.exec("PRAGMA foreign_keys = ON").await?;
+
+        tracing::info!("Table {} rebuilt successfully.", table);
+        Ok(())
+    }
+
     /// 迁移：将 execution_records.logs 旧字段数据迁移到 execution_logs 表，并删除旧字段
     async fn migrate_logs_to_execution_logs(&self) -> Result<(), sea_orm::DbErr> {
         // 检查 logs 列是否存在
@@ -454,7 +629,7 @@ impl Database {
                 receive_id_type TEXT NOT NULL,
                 created_at TEXT,
                 updated_at TEXT,
-                FOREIGN KEY (bot_id) REFERENCES agent_bots(id),
+                FOREIGN KEY (bot_id) REFERENCES agent_bots(id) ON DELETE CASCADE,
                 UNIQUE(bot_id, user_open_id)
             )",
         )
@@ -478,7 +653,7 @@ impl Database {
                 is_history INTEGER DEFAULT 0,
                 fetch_time TEXT,
                 created_at TEXT,
-                FOREIGN KEY (bot_id) REFERENCES agent_bots(id)
+                FOREIGN KEY (bot_id) REFERENCES agent_bots(id) ON DELETE CASCADE
             )",
         )
         .await?;
@@ -541,7 +716,7 @@ impl Database {
                 last_fetch_time TEXT,
                 polling_interval_secs INTEGER DEFAULT 60,
                 created_at TEXT,
-                FOREIGN KEY (bot_id) REFERENCES agent_bots(id),
+                FOREIGN KEY (bot_id) REFERENCES agent_bots(id) ON DELETE CASCADE,
                 UNIQUE(bot_id, chat_id)
             )",
         )
@@ -564,7 +739,7 @@ impl Database {
                 group_response_enabled INTEGER DEFAULT 1,
                 created_at TEXT,
                 updated_at TEXT,
-                FOREIGN KEY (bot_id) REFERENCES agent_bots(id)
+                FOREIGN KEY (bot_id) REFERENCES agent_bots(id) ON DELETE CASCADE
             )",
         )
         .await?;
@@ -579,6 +754,7 @@ impl Database {
                 debounce_secs INTEGER DEFAULT 20,
                 created_at TEXT,
                 updated_at TEXT,
+                FOREIGN KEY (bot_id) REFERENCES agent_bots(id) ON DELETE CASCADE,
                 UNIQUE(bot_id, target_type)
             )",
         )
@@ -608,6 +784,7 @@ impl Database {
                 sender_open_id TEXT NOT NULL,
                 sender_name TEXT,
                 created_at TEXT,
+                FOREIGN KEY (bot_id) REFERENCES agent_bots(id) ON DELETE CASCADE,
                 UNIQUE(bot_id, sender_open_id)
             )",
         )
@@ -929,6 +1106,10 @@ impl Database {
         .await?;
         self.exec("CREATE INDEX IF NOT EXISTS idx_sync_records_created_at ON sync_records(created_at DESC)")
             .await?;
+
+        // 迁移：为飞书子表添加 ON DELETE CASCADE 外键约束
+        self.migrate_feishu_fk_cascade().await
+            .unwrap_or_else(|e| tracing::warn!("Failed to migrate feishu FK cascade: {}", e));
 
         Ok(())
     }

--- a/backend/tests/feishu_tests.rs
+++ b/backend/tests/feishu_tests.rs
@@ -244,3 +244,71 @@ mod pending_message_tests {
         assert_eq!(msg.params.as_ref().unwrap().get("key"), Some(&"value".to_string()));
     }
 }
+
+#[cfg(test)]
+mod cascade_delete_tests {
+    use ntd::db::Database;
+
+    /// Regression test: deleting an agent_bot should cascade-delete all
+    /// related rows in feishu child tables (ON DELETE CASCADE).
+    /// Previously this raised FOREIGN KEY constraint failed.
+    #[tokio::test]
+    async fn test_delete_agent_bot_cascades_feishu_children() {
+        let db = Database::new(":memory:").await.unwrap();
+
+        // 1. Create a feishu bot (also creates feishu_response_config rows)
+        let bot_id = db
+            .create_agent_bot("feishu", "test-bot", "app_id", "app_secret", None, None)
+            .await
+            .unwrap();
+
+        // 2. Insert a row into each feishu child table
+        db.set_feishu_home(bot_id, "ou_user1", Some("oc_chat1"), "rid1", "open_id")
+            .await
+            .unwrap();
+
+        db.save_feishu_message(ntd::db::NewFeishuMessage {
+            bot_id,
+            message_id: "msg_001",
+            chat_id: "oc_chat1",
+            chat_type: "p2p",
+            sender_open_id: "ou_user1",
+            sender_type: None,
+            content: Some("hello"),
+            msg_type: "text",
+            is_mention: false,
+        })
+        .await
+        .unwrap();
+
+        db.create_feishu_history_chat(bot_id, "oc_chat2", Some("Test Group"))
+            .await
+            .unwrap();
+
+        db.add_group_whitelist(bot_id, "ou_sender1", Some("Alice"))
+            .await
+            .unwrap();
+
+        // 3. Verify child data exists before delete
+        assert!(db.get_feishu_home(bot_id, "ou_user1").await.unwrap().is_some());
+        assert!(db.get_feishu_history_chats(bot_id).await.unwrap().len() > 0);
+        assert!(db.get_group_whitelist(bot_id).await.unwrap().len() > 0);
+        assert!(db.get_feishu_response_configs(bot_id).await.unwrap().len() > 0);
+
+        // 4. Delete the bot — should NOT error due to FK constraint
+        db.delete_agent_bot(bot_id).await.unwrap();
+
+        // 5. Verify the bot is gone
+        assert!(db.get_agent_bot(bot_id).await.unwrap().is_none());
+
+        // 6. Verify child data is gone (cascade worked)
+        assert!(db.get_feishu_home(bot_id, "ou_user1").await.unwrap().is_none(),
+            "feishu_homes should be empty after cascade");
+        assert!(db.get_feishu_history_chats(bot_id).await.unwrap().is_empty(),
+            "feishu_history_chats should be empty after cascade");
+        assert!(db.get_group_whitelist(bot_id).await.unwrap().is_empty(),
+            "feishu_group_whitelist should be empty after cascade");
+        assert!(db.get_feishu_response_configs(bot_id).await.unwrap().is_empty(),
+            "feishu_response_config should be empty after cascade");
+    }
+}


### PR DESCRIPTION
## 问题
删除飞书绑定机器人时，点击删除按钮报错：
`FOREIGN KEY constraint failed`

## 原因
6 个飞书子表的外键约束缺少 `ON DELETE CASCADE`，SQLite 在删除父行 `agent_bots` 时拒绝操作。

## 修复方案：DB 级级联（ON DELETE CASCADE）
与 `todo_tags`、`execution_records` 等已有表保持一致，在 DB 层通过 `ON DELETE CASCADE` 自动级联删除，而非应用层手动逐表 delete_many。

### 变更明细
1. **Schema 修改**：6 个飞书子表的 `FOREIGN KEY (bot_id) REFERENCES agent_bots(id)` 全部加上 `ON DELETE CASCADE`
   - `feishu_homes`、`feishu_messages`、`feishu_history_chats`、`feishu_push_targets`（原有 FK，补 CASCADE）
   - `feishu_response_config`、`feishu_group_whitelist`（新增 FK + CASCADE）
2. **迁移逻辑**：`migrate_feishu_fk_cascade()` 检测已有表是否缺少 CASCADE，自动通过 SQLite 标准重建表流程（新建→复制→删除→重命名）完成迁移
3. **应用层简化**：`delete_agent_bot` 恢复为仅删除主表，34 行应用层级联代码全部删除
4. **回归测试**：`test_delete_agent_bot_cascades_feishu_children` 插入 1 个 bot + 各子表数据，删除后断言 6 张表均清空