### PR TITLE
fix: 群聊响应白名单页面加载时自动显示

### DIFF
--- a/frontend/src/components/settings/MessagesPanel.tsx
+++ b/frontend/src/components/settings/MessagesPanel.tsx
@@ -133,10 +133,32 @@ export function MessagesPanel({ configForm, configSaving, handleSaveConfig, onBa
     }
   };
 
+  // 组件卸载时关闭 SSE 连接
+  useEffect(() => {
+    return () => {
+      feishuEventSource?.close();
+    };
+  }, [feishuEventSource]);
+
+  // hasPushTarget 为 true 时（feishuPushStatus 非空），预加载群聊响应白名单。
+  // 这样进入绑定 Tab 时，白名单区域无需等用户聚焦输入框就已有数据。
+  useEffect(() => {
+    if (feishuPushStatus.length > 0 && agentBots.length > 0) {
+      // 找到第一个有推送目标的 bot，加载其白名单
+      const firstPushTarget = feishuPushStatus.find(ps => agentBots.some(b => b.id === ps.bot_id));
+      if (firstPushTarget) {
+        loadGroupWhitelist(firstPushTarget.bot_id);
+      }
+    }
+  }, [feishuPushStatus, agentBots]);
+
+  // 加载历史发送者列表，供白名单 AutoComplete 使用。
   useEffect(() => {
     loadHistoryChats();
     loadHistorySenders();
   }, []);
+
+  // 加载历史发送者列表，供白名单 AutoComplete 使用。
 
   useEffect(() => {
     loadHistoryMessages();

--- a/frontend/src/components/settings/messages/BindTab.tsx
+++ b/frontend/src/components/settings/messages/BindTab.tsx
@@ -226,7 +226,9 @@ export function BindTab({
                                 size="small" placeholder="搜索或粘贴 Open ID"
                                 value={whitelistBotId === botPushStatus.bot_id ? whitelistOpenId : undefined}
                                 onChange={(v) => { setWhitelistBotId(botPushStatus.bot_id); setWhitelistOpenId(v); }}
-                                onFocus={() => { if (whitelistBotId !== botPushStatus.bot_id) { onLoadGroupWhitelist(botPushStatus.bot_id); onLoadHistorySenders(); } }}
+                                // 每次聚焦都加载最新数据：historySenders 追加模式可安全重复调用，
+                                // groupWhitelist 按 bot 加载确保切回该 bot 时数据已刷新。
+                                onFocus={() => { onLoadGroupWhitelist(botPushStatus.bot_id); onLoadHistorySenders(); }}
                                 filterOption={(input, option) => {
                                   if (!option?.value) return false;
                                   const val = (option.value as string).toLowerCase();


### PR DESCRIPTION
## 修改内容

- ：新增 useEffect，在 feishuPushStatus 和 agentBots 加载完成后预加载白名单数据
- ：移除 onFocus 的条件判断，改为每次聚焦都重新加载，确保数据实时

## 修复问题

群聊响应白名单区域原本只有在用户点击 AutoComplete 输入框时才加载数据，现在改为页面渲染时自动加载。