### PR TITLE
feat: 项目目录功能升级 (#441)

### DIFF
--- a/backend/src/db/project_directory.rs
+++ b/backend/src/db/project_directory.rs
@@ -164,6 +164,36 @@ impl Database {
             }
         }
     }
+
+    /// 如果目录不存在则创建（仅创建时写入 name），存在时直接返回原记录不做任何更新。
+    /// 用于 TodoDrawer 的兜底场景：用户手动输入路径时，不应覆盖管理员预设的名称。
+    pub async fn get_or_create_project_directory_strict(
+        &self,
+        path: &str,
+        name: Option<&str>,
+    ) -> Result<ProjectDirectory, sea_orm::DbErr> {
+        if let Some(existing) = self.get_project_directory_by_path(path).await? {
+            // 存在则直接返回，不更新任何字段
+            return Ok(existing);
+        }
+
+        match self.create_project_directory(path, name).await {
+            Ok(id) => {
+                self.get_project_directory_by_id(id)
+                    .await?
+                    .ok_or_else(|| sea_orm::DbErr::Custom("Failed to retrieve created directory".into()))
+            }
+            Err(e) => {
+                if is_unique_constraint_error(&e) {
+                    self.get_project_directory_by_path(path)
+                        .await?
+                        .ok_or_else(|| sea_orm::DbErr::Custom("Directory disappeared after conflict".into()))
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
 }
 
 fn is_unique_constraint_error(err: &sea_orm::DbErr) -> bool {

--- a/backend/src/db/project_directory.rs
+++ b/backend/src/db/project_directory.rs
@@ -108,15 +108,31 @@ impl Database {
 
     /// 如果目录不存在则创建，返回目录信息
     /// 处理并发竞态：捕获唯一约束冲突并重试查询
+    /// 当 `name` 不为 None 时，若目标记录已存在且名称不同，会同步把名称更新为新值，
+    /// 避免前端补全名称时留下"无名"历史记录
     pub async fn get_or_create_project_directory(
         &self,
         path: &str,
+        name: Option<&str>,
     ) -> Result<ProjectDirectory, sea_orm::DbErr> {
         if let Some(existing) = self.get_project_directory_by_path(path).await? {
+            // name=None 时是 no-op：不应被解读为"清空名称"，仅保持现有值不变。
+            // name=Some 且与现有名称不同时才触发更新，兼容"先有路径、后补名称"的使用路径。
+            if let Some(new_name) = name {
+                if existing.name.as_deref() != Some(new_name) {
+                    self.update_project_directory(existing.id, Some(new_name)).await?;
+                    return self
+                        .get_project_directory_by_id(existing.id)
+                        .await?
+                        .ok_or_else(|| {
+                            sea_orm::DbErr::Custom("Directory disappeared after rename".into())
+                        });
+                }
+            }
             return Ok(existing);
         }
 
-        match self.create_project_directory(path, None).await {
+        match self.create_project_directory(path, name).await {
             Ok(id) => {
                 // 创建成功后从数据库查询以获取准确的时间戳
                 self.get_project_directory_by_id(id)
@@ -126,9 +142,22 @@ impl Database {
             Err(e) => {
                 // 如果是唯一约束冲突，说明另一个请求已经创建了该目录，重试查询
                 if is_unique_constraint_error(&e) {
-                    self.get_project_directory_by_path(path)
+                    let existing = self
+                        .get_project_directory_by_path(path)
                         .await?
-                        .ok_or_else(|| sea_orm::DbErr::Custom("Directory disappeared after conflict".into()))
+                        .ok_or_else(|| sea_orm::DbErr::Custom("Directory disappeared after conflict".into()))?;
+                    if let Some(new_name) = name {
+                        if existing.name.as_deref() != Some(new_name) {
+                            self.update_project_directory(existing.id, Some(new_name)).await?;
+                            return self
+                                .get_project_directory_by_id(existing.id)
+                                .await?
+                                .ok_or_else(|| {
+                                    sea_orm::DbErr::Custom("Directory disappeared after rename".into())
+                                });
+                        }
+                    }
+                    Ok(existing)
                 } else {
                     Err(e)
                 }

--- a/backend/src/db/project_directory.rs
+++ b/backend/src/db/project_directory.rs
@@ -164,36 +164,6 @@ impl Database {
             }
         }
     }
-
-    /// 如果目录不存在则创建（仅创建时写入 name），存在时直接返回原记录不做任何更新。
-    /// 用于 TodoDrawer 的兜底场景：用户手动输入路径时，不应覆盖管理员预设的名称。
-    pub async fn get_or_create_project_directory_strict(
-        &self,
-        path: &str,
-        name: Option<&str>,
-    ) -> Result<ProjectDirectory, sea_orm::DbErr> {
-        if let Some(existing) = self.get_project_directory_by_path(path).await? {
-            // 存在则直接返回，不更新任何字段
-            return Ok(existing);
-        }
-
-        match self.create_project_directory(path, name).await {
-            Ok(id) => {
-                self.get_project_directory_by_id(id)
-                    .await?
-                    .ok_or_else(|| sea_orm::DbErr::Custom("Failed to retrieve created directory".into()))
-            }
-            Err(e) => {
-                if is_unique_constraint_error(&e) {
-                    self.get_project_directory_by_path(path)
-                        .await?
-                        .ok_or_else(|| sea_orm::DbErr::Custom("Directory disappeared after conflict".into()))
-                } else {
-                    Err(e)
-                }
-            }
-        }
-    }
 }
 
 fn is_unique_constraint_error(err: &sea_orm::DbErr) -> bool {

--- a/backend/src/handlers/project_directory.rs
+++ b/backend/src/handlers/project_directory.rs
@@ -9,12 +9,13 @@ use crate::models::ApiResponse;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateProjectDirectoryRequest {
     pub path: String,
-    pub name: Option<String>,
+    // 项目名称必填，Todo 选择目录时按名称展示
+    pub name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateProjectDirectoryRequest {
-    pub name: Option<String>,
+    pub name: String,
 }
 
 pub async fn list_project_directories(
@@ -28,12 +29,18 @@ pub async fn create_project_directory(
     State(state): State<AppState>,
     ApiJson(req): ApiJson<CreateProjectDirectoryRequest>,
 ) -> Result<ApiResponse<crate::db::project_directory::ProjectDirectory>, super::AppError> {
+    // 路径和名称都必填：项目目录是用户按"项目"维度组织 Todo 的核心维度，
+    // 缺一项就无法在 Todo 侧按名称识别目录。
     if req.path.trim().is_empty() {
         return Ok(ApiResponse::err(crate::models::codes::BAD_REQUEST, "Path is required"));
     }
+    let name = req.name.trim();
+    if name.is_empty() {
+        return Ok(ApiResponse::err(crate::models::codes::BAD_REQUEST, "Name is required"));
+    }
     let directory = state
         .db
-        .get_or_create_project_directory(&req.path)
+        .get_or_create_project_directory(&req.path, Some(name))
         .await?;
     Ok(ApiResponse::ok(directory))
 }
@@ -43,9 +50,14 @@ pub async fn update_project_directory(
     axum::extract::Path(id): axum::extract::Path<i64>,
     ApiJson(req): ApiJson<UpdateProjectDirectoryRequest>,
 ) -> Result<ApiResponse<()>, super::AppError> {
+    // 更新也要求名称非空，与新增保持一致约束，避免出现"无名项目"的历史脏数据
+    let name = req.name.trim();
+    if name.is_empty() {
+        return Ok(ApiResponse::err(crate::models::codes::BAD_REQUEST, "Name is required"));
+    }
     state
         .db
-        .update_project_directory(id, req.name.as_deref())
+        .update_project_directory(id, Some(name))
         .await?;
     Ok(ApiResponse::ok(()))
 }

--- a/backend/src/handlers/project_directory.rs
+++ b/backend/src/handlers/project_directory.rs
@@ -18,6 +18,13 @@ pub struct UpdateProjectDirectoryRequest {
     pub name: String,
 }
 
+// 仅路径必填，名称可选；存在时不覆盖已有名称，用于 TodoDrawer 手动输入路径的兜底
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpsertProjectDirectoryRequest {
+    pub path: String,
+    pub name: Option<String>,
+}
+
 pub async fn list_project_directories(
     State(state): State<AppState>,
 ) -> Result<ApiResponse<Vec<crate::db::project_directory::ProjectDirectory>>, super::AppError> {
@@ -41,6 +48,22 @@ pub async fn create_project_directory(
     let directory = state
         .db
         .get_or_create_project_directory(&req.path, Some(name))
+        .await?;
+    Ok(ApiResponse::ok(directory))
+}
+
+// 兜底用 endpoint：路径存在时直接返回已有记录不更新名称，不存在时创建
+pub async fn upsert_project_directory_if_not_exists(
+    State(state): State<AppState>,
+    ApiJson(req): ApiJson<UpsertProjectDirectoryRequest>,
+) -> Result<ApiResponse<crate::db::project_directory::ProjectDirectory>, super::AppError> {
+    if req.path.trim().is_empty() {
+        return Ok(ApiResponse::err(crate::models::codes::BAD_REQUEST, "Path is required"));
+    }
+    let name = req.name.as_ref().map(|s| s.trim());
+    let directory = state
+        .db
+        .get_or_create_project_directory_strict(&req.path, name)
         .await?;
     Ok(ApiResponse::ok(directory))
 }
@@ -74,6 +97,7 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/api/project-directories", get(list_project_directories))
         .route("/api/project-directories", post(create_project_directory))
+        .route("/api/project-directories/upsert-if-not-exists", post(upsert_project_directory_if_not_exists))
         .route("/api/project-directories/{id}", put(update_project_directory))
         .route("/api/project-directories/{id}", delete(delete_project_directory))
 }

--- a/backend/src/handlers/project_directory.rs
+++ b/backend/src/handlers/project_directory.rs
@@ -18,13 +18,6 @@ pub struct UpdateProjectDirectoryRequest {
     pub name: String,
 }
 
-// 仅路径必填，名称可选；存在时不覆盖已有名称，用于 TodoDrawer 手动输入路径的兜底
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UpsertProjectDirectoryRequest {
-    pub path: String,
-    pub name: Option<String>,
-}
-
 pub async fn list_project_directories(
     State(state): State<AppState>,
 ) -> Result<ApiResponse<Vec<crate::db::project_directory::ProjectDirectory>>, super::AppError> {
@@ -48,22 +41,6 @@ pub async fn create_project_directory(
     let directory = state
         .db
         .get_or_create_project_directory(&req.path, Some(name))
-        .await?;
-    Ok(ApiResponse::ok(directory))
-}
-
-// 兜底用 endpoint：路径存在时直接返回已有记录不更新名称，不存在时创建
-pub async fn upsert_project_directory_if_not_exists(
-    State(state): State<AppState>,
-    ApiJson(req): ApiJson<UpsertProjectDirectoryRequest>,
-) -> Result<ApiResponse<crate::db::project_directory::ProjectDirectory>, super::AppError> {
-    if req.path.trim().is_empty() {
-        return Ok(ApiResponse::err(crate::models::codes::BAD_REQUEST, "Path is required"));
-    }
-    let name = req.name.as_ref().map(|s| s.trim());
-    let directory = state
-        .db
-        .get_or_create_project_directory_strict(&req.path, name)
         .await?;
     Ok(ApiResponse::ok(directory))
 }
@@ -97,7 +74,6 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/api/project-directories", get(list_project_directories))
         .route("/api/project-directories", post(create_project_directory))
-        .route("/api/project-directories/upsert-if-not-exists", post(upsert_project_directory_if_not_exists))
         .route("/api/project-directories/{id}", put(update_project_directory))
         .route("/api/project-directories/{id}", delete(delete_project_directory))
 }

--- a/backend/tests/db_feature_supplement_tests.rs
+++ b/backend/tests/db_feature_supplement_tests.rs
@@ -392,16 +392,21 @@ async fn test_project_directory_get_or_create_idempotent() {
     // 第一次调用：新建；第二次：复用，name 字段保持首次插入的值。
     let db = setup_db().await;
     let d1 = db
-        .get_or_create_project_directory("/tmp/goc-1")
+        .get_or_create_project_directory("/tmp/goc-1", Some("goc-name"))
         .await
         .unwrap();
     let d2 = db
-        .get_or_create_project_directory("/tmp/goc-1")
+        .get_or_create_project_directory("/tmp/goc-1", None)
         .await
         .unwrap();
     assert_eq!(d1.id, d2.id, "幂等：同一 path 必须返回同一 id");
     assert_eq!(d2.path, "/tmp/goc-1");
-    assert!(d2.name.is_none(), "通过 get_or_create 不会写入 name");
+    // 已有记录不传 name 时，名称应保持首次写入值，不被覆盖为 None
+    assert_eq!(
+        d2.name.as_deref(),
+        Some("goc-name"),
+        "name 应保持首次插入值"
+    );
 }
 
 #[tokio::test]

--- a/backend/tests/db_feature_supplement_tests.rs
+++ b/backend/tests/db_feature_supplement_tests.rs
@@ -410,6 +410,33 @@ async fn test_project_directory_get_or_create_idempotent() {
 }
 
 #[tokio::test]
+async fn test_project_directory_get_or_create_renames_on_mismatch() {
+    // 当 path 已存在但 name 不同时，get_or_create 应自动把 name 同步为新值
+    let db = setup_db().await;
+    let d1 = db
+        .get_or_create_project_directory("/tmp/rename-test", Some("Original Name"))
+        .await
+        .unwrap();
+    assert_eq!(d1.name.as_deref(), Some("Original Name"));
+
+    // 再次传入不同 name，应触发 rename
+    let d2 = db
+        .get_or_create_project_directory("/tmp/rename-test", Some("New Name"))
+        .await
+        .unwrap();
+    assert_eq!(d1.id, d2.id, "id 不应变化");
+    assert_eq!(d2.name.as_deref(), Some("New Name"), "name 应被同步为新值");
+
+    // 传入相同 name，不应触发 UPDATE（保持原值）
+    let d3 = db
+        .get_or_create_project_directory("/tmp/rename-test", Some("New Name"))
+        .await
+        .unwrap();
+    assert_eq!(d3.id, d2.id);
+    assert_eq!(d3.name.as_deref(), Some("New Name"));
+}
+
+#[tokio::test]
 async fn test_project_directory_update_name() {
     // 仅更新 name，并刷新 updated_at；path 保持不变。
     let db = setup_db().await;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -409,6 +409,69 @@ body {
   background: var(--color-border-light);
 }
 
+/* ---------- Grouped Todo View ---------- */
+/* 分组视图把 todo 按"项目目录"折叠成文件夹；每个分组是一块带左侧色条与标题的卡片 */
+.todo-grouped-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.todo-group {
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.todo-group-header {
+  display: flex;
+  align-items: center;
+  padding: 10px 14px;
+  background: var(--color-bg);
+  border-bottom: 1px solid var(--color-border-light);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.todo-group-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.todo-group-count {
+  /* 项目下 todo 数量的徽标；浅色背景 + 主色字，与主色调一致 */
+  background: var(--color-primary-bg);
+  color: var(--color-primary);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 1px 8px;
+  border-radius: 10px;
+  margin-left: 8px;
+  flex-shrink: 0;
+}
+
+.todo-group-items {
+  padding: var(--space-sm) var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+/* 分组内的 todo 取消外边距，让卡片在文件夹里更紧凑 */
+.todo-group-items .todo-item {
+  margin-bottom: 0;
+}
+
+[data-theme="dark"] .todo-group-header {
+  background: var(--color-bg);
+}
+
 /* ---------- Detail Panel ---------- */
 .detail-panel {
   background: var(--color-bg-elevated);

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -37,11 +37,16 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
   /* ─── Execution record cache (delegated to hook) ─── */
   const cache = useKanbanExecutionCache({ todos, storeRecords: state.executionRecords });
 
-  // 加载项目目录
+  // 加载项目目录，监听 TodoDrawer 快速新增事件及时刷新
   useEffect(() => {
-    db.getProjectDirectories()
-      .then(setProjectDirectories)
-      .catch(() => setProjectDirectories([]));
+    const reload = () => {
+      db.getProjectDirectories()
+        .then(setProjectDirectories)
+        .catch(() => setProjectDirectories([]));
+    };
+    reload();
+    window.addEventListener('projectDirectoryAdded', reload);
+    return () => window.removeEventListener('projectDirectoryAdded', reload);
   }, []);
 
   /* ─── Filter by search + time ─── */

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -1,13 +1,13 @@
-import { useState, useMemo, useCallback, useRef } from 'react';
-import { Input, Segmented, App, Tabs } from 'antd';
-import { SearchOutlined } from '@ant-design/icons';
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import { Input, Segmented, App, Tabs, Select } from 'antd';
+import { SearchOutlined, FolderOutlined } from '@ant-design/icons';
 import { useApp } from '../hooks/useApp';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { useKanbanExecutionCache } from '../hooks/useKanbanExecutionCache';
 import { TodoCard } from './TodoCard';
 import * as db from '../utils/database';
 import { formatRelativeTime } from '../utils/datetime';
-import type { Todo, ExecutionRecord } from '../types';
+import type { Todo, ExecutionRecord, ProjectDirectory } from '../types';
 import { TIME_OPTIONS, COLUMNS } from './kanban/constants';
 import { getColumnForStatus } from './kanban/helpers';
 import type { ColumnDef } from './kanban/constants';
@@ -18,6 +18,8 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
   const { state, dispatch } = useApp();
   const { message } = App.useApp();
   const { todos, tags, selectedTodoId } = state;
+  const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
+  const [selectedProject, setSelectedProject] = useState<string | null>(null);
 
   const [internalSearch, setInternalSearch] = useState('');
   const [internalHours, setInternalHours] = useState(24);
@@ -35,10 +37,22 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
   /* ─── Execution record cache (delegated to hook) ─── */
   const cache = useKanbanExecutionCache({ todos, storeRecords: state.executionRecords });
 
+  // 加载项目目录
+  useEffect(() => {
+    db.getProjectDirectories()
+      .then(setProjectDirectories)
+      .catch(() => setProjectDirectories([]));
+  }, []);
+
   /* ─── Filter by search + time ─── */
   const filteredTodos = useMemo(() => {
+    let result = todos;
+    // 项目过滤
+    if (selectedProject) {
+      result = result.filter(t => t.workspace === selectedProject);
+    }
     const cutoff = hours ? Date.now() - hours * 3600 * 1000 : 0;
-    return todos.filter(t => {
+    return result.filter(t => {
       // Time filter: only for completed/failed todos
       if ((t.status === 'completed' || t.status === 'failed') && cutoff > 0) {
         const tUpdated = new Date(t.updated_at).getTime();
@@ -161,6 +175,8 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
   const renderCard = (todo: Todo) => {
     const column = getColumnForStatus(todo.status);
     const todoTags = tags.filter(t => todo.tag_ids?.includes(t.id));
+    const projectDir = projectDirectories.find(d => d.path === todo.workspace);
+    const projectName = projectDir?.name || null;
     const isDragging = draggingId === todo.id;
     const isSuccess = todo.status === 'completed';
     const isFinished = todo.status === 'completed' || todo.status === 'failed';
@@ -216,6 +232,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
           executor={todo.executor}
           time={formatRelativeTime(todo.updated_at)}
           model={displayModel}
+          projectName={projectName}
           tags={todoTags}
           usage={displayUsage}
           triggerType={displayTriggerType}
@@ -353,6 +370,19 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
                 if (opt) handleHoursChange(opt.value);
               }}
               style={{ marginLeft: 8 }}
+            />
+            <Select
+              size="small"
+              placeholder="项目过滤"
+              allowClear
+              value={selectedProject}
+              onChange={setSelectedProject}
+              style={{ width: 150, marginLeft: 8 }}
+              suffixIcon={<FolderOutlined />}
+              options={projectDirectories.map(d => ({
+                value: d.path,
+                label: d.name || d.path,
+              }))}
             />
           </div>
           <div className="kanban-topbar-right">

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo } from 'react';
-import { Card, Segmented, Skeleton, Empty, Button, Input } from 'antd';
+import { Card, Segmented, Skeleton, Empty, Button, Input, Select } from 'antd';
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
@@ -7,13 +7,14 @@ import {
   AppstoreOutlined,
   ProfileOutlined,
   SearchOutlined,
+  FolderOutlined,
 } from '@ant-design/icons';
 import { useApp } from '../hooks/useApp';
 import { KanbanBoard } from './KanbanBoard';
 import { TodoCard } from './TodoCard';
 import * as db from '../utils/database';
 import { formatRelativeTime } from '../utils/datetime';
-import type { RecentCompletedTodo, Tag, ExecutionRecord } from '../types';
+import type { RecentCompletedTodo, Tag, ExecutionRecord, ProjectDirectory } from '../types';
 
 const TIME_OPTIONS: { label: string; value: number }[] = [
   { label: '6h', value: 6 },
@@ -38,6 +39,8 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
   const [searchText, setSearchText] = useState('');
   const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
   const [promptExpandedIds, setPromptExpandedIds] = useState<Set<number>>(new Set());
+  const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
+  const [selectedProject, setSelectedProject] = useState<string | null>(null);
 
   /* ─── Run history switching ─── */
   const [selectedRunIndex, setSelectedRunIndex] = useState<Record<number, number>>({});
@@ -73,6 +76,13 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
       });
     return () => { cancelled = true; };
   }, [hours, boardMode]);
+
+  // 加载项目目录用于过滤
+  useEffect(() => {
+    db.getProjectDirectories()
+      .then(setProjectDirectories)
+      .catch(() => setProjectDirectories([]));
+  }, []);
 
   const toggleExpand = (todoId: number) => {
     setExpandedIds(prev => {
@@ -162,13 +172,24 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
   };
 
   const filteredItems = useMemo(() => {
-    if (!searchText.trim()) return items;
-    const q = searchText.toLowerCase();
-    return items.filter(i =>
-      i.title.toLowerCase().includes(q) ||
-      (i.prompt && i.prompt.toLowerCase().includes(q))
-    );
-  }, [items, searchText]);
+    let result = items;
+    // 按项目过滤
+    if (selectedProject) {
+      result = result.filter(i => {
+        const todo = state.todos.find(t => t.id === i.todo_id);
+        return todo?.workspace === selectedProject;
+      });
+    }
+    // 按搜索文本过滤
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      result = result.filter(i =>
+        i.title.toLowerCase().includes(q) ||
+        (i.prompt && i.prompt.toLowerCase().includes(q))
+      );
+    }
+    return result;
+  }, [items, searchText, selectedProject, state.todos]);
 
   /* ─── Responsive column count ─── */
   const [columnCount, setColumnCount] = useState(() => {
@@ -233,6 +254,10 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
     const isSuccess = item.execution_status === 'success';
     const expanded = expandedIds.has(item.todo_id);
     const resolvedTags = item.tag_ids.map(tid => state.tags.find(t => t.id === tid)).filter(Boolean) as Tag[];
+    // 获取项目名称
+    const todo = state.todos.find(t => t.id === item.todo_id);
+    const projectDir = projectDirectories.find(d => d.path === todo?.workspace);
+    const projectName = projectDir?.name || null;
 
     // Run history: determine which run to display
     const runIdx = selectedRunIndex[item.todo_id] ?? 0;
@@ -282,6 +307,7 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
           executor={item.executor}
           time={formatRelativeTime(item.completed_at)}
           model={displayModel}
+          projectName={projectName}
           tags={resolvedTags}
           usage={displayUsage}
           triggerType={displayTriggerType}
@@ -342,6 +368,19 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
               const opt = TIME_OPTIONS.find(o => o.label === label);
               if (opt) setHours(opt.value);
             }}
+          />
+          <Select
+            size="small"
+            placeholder="项目过滤"
+            allowClear
+            value={selectedProject}
+            onChange={setSelectedProject}
+            style={{ width: 150 }}
+            suffixIcon={<FolderOutlined />}
+            options={projectDirectories.map(d => ({
+              value: d.path,
+              label: d.name || d.path,
+            }))}
           />
           {boardMode === 'memorial' ? (
             <div className="memorial-summary">

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -77,11 +77,16 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
     return () => { cancelled = true; };
   }, [hours, boardMode]);
 
-  // 加载项目目录用于过滤
+  // 加载项目目录用于过滤，监听 TodoDrawer 快速新增事件及时刷新
   useEffect(() => {
-    db.getProjectDirectories()
-      .then(setProjectDirectories)
-      .catch(() => setProjectDirectories([]));
+    const reload = () => {
+      db.getProjectDirectories()
+        .then(setProjectDirectories)
+        .catch(() => setProjectDirectories([]));
+    };
+    reload();
+    window.addEventListener('projectDirectoryAdded', reload);
+    return () => window.removeEventListener('projectDirectoryAdded', reload);
   }, []);
 
   const toggleExpand = (todoId: number) => {

--- a/frontend/src/components/TodoCard.tsx
+++ b/frontend/src/components/TodoCard.tsx
@@ -44,6 +44,9 @@ export interface TodoCardProps {
   time: string; // already formatted relative time
   model?: string | null;
 
+  /** Project (workspace) name to display as tag */
+  projectName?: string | null;
+
   /** Tags (already resolved) */
   tags: Array<{ id: number; name: string; color: string }>;
 
@@ -89,6 +92,7 @@ export const TodoCard = memo(function TodoCard({
   executor,
   time,
   model,
+  projectName,
   tags,
   usage,
   triggerType,
@@ -127,6 +131,11 @@ export const TodoCard = memo(function TodoCard({
         {/* Meta Row */}
         <div className="kanban-card-meta-row">
           {executor && <ExecutorBadge executor={executor} />}
+          {projectName && (
+            <Tag className="kanban-tag-badge" style={{ backgroundColor: '#e6f4ff', borderColor: '#91caff', color: '#1677ff' }}>
+              {projectName}
+            </Tag>
+          )}
           <span className="kanban-card-meta-time">
             <ClockCircleOutlined /> {time}
           </span>

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { Drawer, Input, Button, App, AutoComplete, Divider, Switch } from 'antd';
-import { FolderOutlined } from '@ant-design/icons';
+import { Drawer, Input, Button, App, AutoComplete, Divider, Switch, Modal, Form, Empty, Space } from 'antd';
+import { FolderOutlined, PlusOutlined } from '@ant-design/icons';
 import * as db from '../utils/database';
 import type { ProjectDirectory } from '../utils/database';
 import type { TodoHookItem } from '../utils/database/hooks';
@@ -31,6 +31,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
   const [prompt, setPrompt] = useState('');
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [executor, setExecutor] = useState<string>('claudecode');
+  // workspace 存的是路径；与 ProjectDirectory.path 对应，确保值可以直接命中已配置的目录
   const [workspace, setWorkspace] = useState<string>('');
   const [worktreeEnabled, setWorktreeEnabled] = useState(false);
   const [executorOptions, setExecutorOptions] = useState<ExecutorOption[]>(EXECUTORS);
@@ -43,6 +44,10 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
   const [schedulerConfig, setSchedulerConfig] = useState<string>('');
   const [hooks, setHooks] = useState<TodoHookItem[]>([]);
   const [loading, setLoading] = useState(false);
+  // 快速新增项目目录的弹窗：与抽屉同级，关闭抽屉时一起清理
+  const [quickAddOpen, setQuickAddOpen] = useState(false);
+  const [quickAddForm] = Form.useForm<{ name: string; path: string }>();
+  const [quickAddSubmitting, setQuickAddSubmitting] = useState(false);
   const editorRef = useRef<any>(null);
   const { state: appState } = useApp();
 
@@ -156,6 +161,40 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
     setTemplateModalOpen(false);
   }, [prompt, insertTextAtCursor, message]);
 
+  // 快速新增项目目录：用户在工作目录区域点"+"即可补一个项目，无需跳到设置页
+  const handleQuickAddProjectDirectory = async () => {
+    let values: { name: string; path: string };
+    try {
+      values = await quickAddForm.validateFields();
+    } catch {
+      // antd 校验失败时会自行提示，这里直接返回
+      return;
+    }
+    const name = values.name.trim();
+    const path = values.path.trim();
+    if (!name || !path) {
+      message.error('项目名称与目录路径均为必填');
+      return;
+    }
+    setQuickAddSubmitting(true);
+    try {
+      const dir = await db.createProjectDirectory(path, name);
+      setProjectDirectories(prev =>
+        [...prev.filter(d => d.id !== dir.id), dir].sort((a, b) => a.path.localeCompare(b.path))
+      );
+      // 保存后立即把新目录选中并写入工作目录，减少二次操作
+      setWorkspace(dir.path);
+      setQuickAddOpen(false);
+      message.success(`已添加项目"${dir.name}"`);
+      // 通知其他组件（如 TodoList 分组视图）项目目录已更新
+      window.dispatchEvent(new CustomEvent('projectDirectoryAdded', { detail: dir }));
+    } catch (err: any) {
+      message.error('添加项目目录失败: ' + (err?.message || String(err)));
+    } finally {
+      setQuickAddSubmitting(false);
+    }
+  };
+
   const handleSave = async () => {
     if (!title.trim()) {
       message.error('请输入任务标题');
@@ -170,7 +209,8 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         if (trimmedWorkspace) {
           const exists = projectDirectories.some(d => d.path === trimmedWorkspace);
           if (!exists) {
-            try { await db.createProjectDirectory(trimmedWorkspace); } catch { }
+            // 容错：用户选了 AutoComplete 模糊匹配之外的路径，依然按"项目名称 = 路径同名"思路兜底创建
+            try { await db.createProjectDirectory(trimmedWorkspace, trimmedWorkspace); } catch { }
           }
         }
 
@@ -190,7 +230,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
           if (trimmedWorkspace) {
             const exists = projectDirectories.some(d => d.path === trimmedWorkspace);
             if (!exists) {
-              try { await db.createProjectDirectory(trimmedWorkspace); } catch { }
+              try { await db.createProjectDirectory(trimmedWorkspace, trimmedWorkspace); } catch { }
             }
           }
           await db.updateTodo(
@@ -215,6 +255,17 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
   };
 
   const executorColor = getExecutorColor(executor);
+
+  // 把项目目录拍平成 AutoComplete 的可选项：value 仍存路径（与后端 workspace 字段兼容），
+  // label 同时展示"项目名称（路径）"，保证用户能看到项目维度的名字
+  const workspaceOptions = useMemo(
+    () =>
+      projectDirectories.map(d => ({
+        value: d.path,
+        label: d.name ? `${d.name}（${d.path}）` : d.path,
+      })),
+    [projectDirectories]
+  );
 
   return (
     <Drawer
@@ -284,21 +335,57 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
           <div style={{ marginBottom: 16 }}>
             <div style={{ marginBottom: 10, fontWeight: 600, fontSize: 14 }}>
               <FolderOutlined style={{ color: 'var(--color-primary)', marginRight: 6 }} />
-              工作目录
+              项目目录
             </div>
-            <AutoComplete
-              value={workspace}
-              onChange={(value) => setWorkspace(value)}
-              options={projectDirectories.map(d => ({
-                value: d.path,
-                label: d.name ? `${d.name} (${d.path})` : d.path,
-              }))}
-              placeholder="从项目目录选择或手动输入路径"
-              style={{ width: '100%' }}
-              filterOption={(input, option) =>
-                (option?.label as string)?.toLowerCase().includes(input.toLowerCase())
-              }
-            />
+            {projectDirectories.length === 0 ? (
+              // 没有可用项目目录时给出空态提示，避免用户面对一个无选项的下拉茫然
+              <div
+                style={{
+                  padding: 16,
+                  border: '1px dashed var(--color-border)',
+                  borderRadius: 6,
+                  background: 'var(--color-bg)',
+                }}
+              >
+                <Empty
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  description={
+                    <div style={{ color: 'var(--color-text-secondary)' }}>
+                      尚未配置任何项目目录，请先创建后再选择
+                    </div>
+                  }
+                  style={{ margin: 0 }}
+                >
+                  <Button
+                    type="primary"
+                    icon={<PlusOutlined />}
+                    onClick={() => setQuickAddOpen(true)}
+                  >
+                    快速新增项目目录
+                  </Button>
+                </Empty>
+              </div>
+            ) : (
+              // 有项目目录时，下拉里展示的是项目名称（value 仍是路径，与后端模型兼容）
+              <Space.Compact style={{ width: '100%' }}>
+                <AutoComplete
+                  value={workspace}
+                  onChange={(value) => setWorkspace(value)}
+                  options={workspaceOptions}
+                  placeholder="选择项目目录或手动输入路径"
+                  style={{ flex: 1 }}
+                  filterOption={(input, option) =>
+                    (option?.label as string)?.toLowerCase().includes(input.toLowerCase())
+                  }
+                />
+                <Button
+                  icon={<PlusOutlined />}
+                  onClick={() => setQuickAddOpen(true)}
+                  title="快速新增项目目录"
+                  aria-label="快速新增项目目录"
+                />
+              </Space.Compact>
+            )}
           </div>
 
           {(executor === 'claudecode' || executor === 'claude_code' || executor === 'hermes') && (
@@ -339,6 +426,41 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         onClose={() => setTemplateModalOpen(false)}
         onSelect={handleSelectTemplate}
       />
+
+      {/* 快速新增项目目录：与抽屉同期挂载，避免切走 drawer 后弹窗无法关闭 */}
+      <Modal
+        title="快速新增项目目录"
+        open={quickAddOpen}
+        onCancel={() => {
+          if (quickAddSubmitting) return;
+          setQuickAddOpen(false);
+          quickAddForm.resetFields();
+        }}
+        onOk={handleQuickAddProjectDirectory}
+        confirmLoading={quickAddSubmitting}
+        okText="保存并使用"
+        cancelText="取消"
+        destroyOnClose
+        maskClosable={!quickAddSubmitting}
+      >
+        <Form form={quickAddForm} layout="vertical" preserve={false}>
+          <Form.Item
+            label="项目名称"
+            name="name"
+            // 名称必填：在 Todo 列表分组展示时是主标识
+            rules={[{ required: true, message: '请输入项目名称' }]}
+          >
+            <Input placeholder="例如：ntd 官网重构" autoFocus />
+          </Form.Item>
+          <Form.Item
+            label="目录路径"
+            name="path"
+            rules={[{ required: true, message: '请输入目录路径' }]}
+          >
+            <Input placeholder="例如：/Users/me/projects/ntd-site" />
+          </Form.Item>
+        </Form>
+      </Modal>
     </Drawer>
   );
 }

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -206,18 +206,13 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
       const trimmedWorkspace = workspace.trim() || null;
 
       if (isEditMode && todo) {
-        if (trimmedWorkspace) {
-          const exists = projectDirectories.some(d => d.path === trimmedWorkspace);
-          if (!exists) {
-            // 容错：用户选了 AutoComplete 模糊匹配之外的路径，依然按"项目名称 = 路径同名"思路兜底创建
-            try { await db.upsertProjectDirectoryIfNotExists(trimmedWorkspace); } catch { }
-          }
-        }
+        // 如果用户输入了路径但不在下拉列表中，不自动创建（name 必填约束），让用户使用快速新增功能
+        const workspaceToSave = trimmedWorkspace && projectDirectories.some(d => d.path === trimmedWorkspace) ? trimmedWorkspace : null;
 
         await db.updateTodo(
           todo.id, title.trim(), prompt.trim(), todo.status,
           executor, schedulerEnabled, schedulerConfig || null,
-          trimmedWorkspace, worktreeEnabled,
+          workspaceToSave, worktreeEnabled,
           hooks,
         );
         await db.updateScheduler(todo.id, schedulerEnabled, schedulerConfig || null);
@@ -226,17 +221,14 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
       } else {
         const newTodo = await db.createTodo(title.trim(), prompt.trim(), selectedTags, hooks);
 
-        if (trimmedWorkspace || schedulerEnabled || executor !== 'claudecode' || worktreeEnabled) {
-          if (trimmedWorkspace) {
-            const exists = projectDirectories.some(d => d.path === trimmedWorkspace);
-            if (!exists) {
-              try { await db.upsertProjectDirectoryIfNotExists(trimmedWorkspace); } catch { }
-            }
-          }
+        // workspaceToSave 只在路径存在于下拉列表时设置，否则为 null（避免创建无名项目）
+        const workspaceToSave = trimmedWorkspace && projectDirectories.some(d => d.path === trimmedWorkspace) ? trimmedWorkspace : null;
+
+        if (workspaceToSave || schedulerEnabled || executor !== 'claudecode' || worktreeEnabled) {
           await db.updateTodo(
             newTodo.id, newTodo.title, newTodo.prompt, newTodo.status,
             executor, schedulerEnabled, schedulerConfig || null,
-            trimmedWorkspace, worktreeEnabled,
+            workspaceToSave, worktreeEnabled,
             hooks,
           );
           await db.updateScheduler(newTodo.id, schedulerEnabled, schedulerConfig || null);

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -210,7 +210,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
           const exists = projectDirectories.some(d => d.path === trimmedWorkspace);
           if (!exists) {
             // 容错：用户选了 AutoComplete 模糊匹配之外的路径，依然按"项目名称 = 路径同名"思路兜底创建
-            try { await db.createProjectDirectory(trimmedWorkspace, trimmedWorkspace); } catch { }
+            try { await db.upsertProjectDirectoryIfNotExists(trimmedWorkspace); } catch { }
           }
         }
 
@@ -230,7 +230,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
           if (trimmedWorkspace) {
             const exists = projectDirectories.some(d => d.path === trimmedWorkspace);
             if (!exists) {
-              try { await db.createProjectDirectory(trimmedWorkspace, trimmedWorkspace); } catch { }
+              try { await db.upsertProjectDirectoryIfNotExists(trimmedWorkspace); } catch { }
             }
           }
           await db.updateTodo(

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useApp } from '../hooks/useApp';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { Button, Empty, Tooltip } from 'antd';
-import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, ApartmentOutlined, UnorderedListOutlined, FolderOpenOutlined, FolderOutlined } from '@ant-design/icons';
+import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, ApartmentOutlined, UnorderedListOutlined, FolderOpenOutlined, RightOutlined } from '@ant-design/icons';
 import { useTheme } from '../hooks/useTheme';
 import { StatusPicker } from './StatusPicker';
 import * as db from '../utils/database';
@@ -48,6 +48,8 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
   // 项目目录：分组视图需要按项目维度折叠，必须先有这份映射；
   // 即使切回平铺视图也保留数据，避免切换时闪烁
   const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
+  // 记录每个分组的折叠状态，key 为 workspace 路径
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     setIsLoading(false);
@@ -368,18 +370,62 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
           // 分组视图：每个项目一个"文件夹"块，块内平铺 todo；
           // 文件夹头部用项目名 + 数量徽标，方便一眼看清每个项目下堆积了多少 todo
           <div className="todo-grouped-list">
-            {groupedByProject.map(([key, group]) => (
-              <div key={key} className="todo-group">
-                <div className="todo-group-header">
-                  <FolderOutlined style={{ color: 'var(--color-primary)', marginRight: 6 }} />
-                  <span className="todo-group-title">{group.name}</span>
-                  <span className="todo-group-count">{group.items.length}</span>
+            {groupedByProject.map(([key, group]) => {
+              const isCollapsed = collapsedGroups.has(key);
+              return (
+                <div key={key} className="todo-group">
+                  <div
+                    className="todo-group-header"
+                    onClick={() => {
+                      setCollapsedGroups(prev => {
+                        const next = new Set(prev);
+                        if (isCollapsed) {
+                          next.delete(key);
+                        } else {
+                          next.add(key);
+                        }
+                        return next;
+                      });
+                    }}
+                    style={{ cursor: 'pointer' }}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        setCollapsedGroups(prev => {
+                          const next = new Set(prev);
+                          if (isCollapsed) {
+                            next.delete(key);
+                          } else {
+                            next.add(key);
+                          }
+                          return next;
+                        });
+                      }
+                    }}
+                    aria-expanded={!isCollapsed}
+                  >
+                    <RightOutlined
+                      style={{
+                        color: 'var(--color-primary)',
+                        marginRight: 6,
+                        fontSize: 10,
+                        transform: isCollapsed ? 'rotate(0deg)' : 'rotate(90deg)',
+                        transition: 'transform 0.2s',
+                      }}
+                    />
+                    <span className="todo-group-title">{group.name}</span>
+                    <span className="todo-group-count">{group.items.length}</span>
+                  </div>
+                  {!isCollapsed && (
+                    <div className="todo-group-items">
+                      {group.items.map(renderTodoItem)}
+                    </div>
+                  )}
                 </div>
-                <div className="todo-group-items">
-                  {group.items.map(renderTodoItem)}
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         ) : (
           filteredTodos.map(renderTodoItem)

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -2,10 +2,11 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useApp } from '../hooks/useApp';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { Button, Empty, Tooltip } from 'antd';
-import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, ApartmentOutlined } from '@ant-design/icons';
+import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, ApartmentOutlined, UnorderedListOutlined, FolderOpenOutlined, FolderOutlined } from '@ant-design/icons';
 import { useTheme } from '../hooks/useTheme';
 import { StatusPicker } from './StatusPicker';
 import * as db from '../utils/database';
+import type { ProjectDirectory, Todo } from '../types';
 import { ExecutorBadge } from './ExecutorBadge';
 import { formatRelativeTime } from '../utils/datetime';
 
@@ -33,16 +34,41 @@ function SkeletonList() {
   );
 }
 
+// 列表显示模式：flat 是当前的平铺模式；grouped 按项目目录把 todo 折叠成"文件夹"分组
+type ListDisplayMode = 'flat' | 'grouped';
+
 export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, onShowDashboard, onShowMemorial, onShowRelationMap, onShowSettings }: TodoListProps) {
   const { state, dispatch } = useApp();
   const { themeMode, toggleTheme } = useTheme();
   const { todos, selectedTodoId, selectedTagId, tags } = state;
   const isMobile = useIsMobile();
   const [isLoading, setIsLoading] = useState(true);
+  // 显示模式：默认平铺；用户切换时只影响本地视图，刷新后会回到默认
+  const [displayMode, setDisplayMode] = useState<ListDisplayMode>('flat');
+  // 项目目录：分组视图需要按项目维度折叠，必须先有这份映射；
+  // 即使切回平铺视图也保留数据，避免切换时闪烁
+  const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
 
   useEffect(() => {
     setIsLoading(false);
   }, []);
+
+  // 进入页面时拉取项目目录；后续 Todo 抽屉新增/删除目录时也会主动重拉，确保分组始终准确
+  const reloadProjectDirectories = useCallback(() => {
+    db.getProjectDirectories()
+      .then(setProjectDirectories)
+      .catch(() => {
+        // 静默失败：分组视图退化为只显示路径即可，不阻塞主流程
+      });
+  }, []);
+
+  useEffect(() => {
+    reloadProjectDirectories();
+    // 监听 TodoDrawer 快速新增项目目录的事件，及时刷新
+    const handleDirAdded = () => reloadProjectDirectories();
+    window.addEventListener('projectDirectoryAdded', handleDirAdded);
+    return () => window.removeEventListener('projectDirectoryAdded', handleDirAdded);
+  }, [reloadProjectDirectories]);
 
   const filteredTodos = useMemo(() =>
     selectedTagId
@@ -50,6 +76,36 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
       : todos,
     [todos, selectedTagId]
   );
+
+  // 按 workspace 路径分组；workspace 为空或 null 的归入"未分组"虚拟分组，
+  // 保证游离 todo 不会消失，只是放到列表底部
+  const groupedByProject = useMemo(() => {
+    // path -> { name, items }：用 path 作为 key，避免同路径多份目录实体造成的重复分组
+    // 用 Map 存储目录查找表，把内层 O(n·m) 查找降为 O(1)
+    const dirByPath = new Map(projectDirectories.map(d => [d.path, d]));
+    const groups = new Map<string, { name: string; items: Todo[] }>();
+    for (const todo of filteredTodos) {
+      const ws = (todo.workspace || '').trim();
+      if (!ws) {
+        const bucket = groups.get('__ungrouped__') ?? { name: '未分组', items: [] };
+        bucket.items.push(todo);
+        groups.set('__ungrouped__', bucket);
+        continue;
+      }
+      const dir = dirByPath.get(ws);
+      const bucket = groups.get(ws) ?? { name: dir?.name || ws, items: [] };
+      bucket.items.push(todo);
+      groups.set(ws, bucket);
+    }
+    // 稳定顺序：项目目录按 name 排序，未分组始终在最末
+    const entries = Array.from(groups.entries());
+    entries.sort((a, b) => {
+      if (a[0] === '__ungrouped__') return 1;
+      if (b[0] === '__ungrouped__') return -1;
+      return a[1].name.localeCompare(b[1].name);
+    });
+    return entries;
+  }, [filteredTodos, projectDirectories]);
 
   const handleStatusChange = useCallback(async (todoId: number, title: string, prompt: string, newStatus: string) => {
     try {
@@ -65,6 +121,104 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
     for (const tag of tags) map.set(tag.id, tag);
     return map;
   }, [tags]);
+
+  // 抽离 Todo 行渲染，平铺与分组两个模式共用，避免重复代码
+  const renderTodoItem = (todo: Todo) => {
+    const todoTags = ((todo as any).tag_ids as number[] | undefined)?.map(id => tagMap.get(id)).filter((t): t is typeof tags[0] => !!t) ?? [];
+    const primaryTag = todoTags[0];
+    const isCompleted = todo.status === 'completed';
+
+    return (
+      <div
+        key={todo.id}
+        onClick={() => {
+          dispatch({ type: 'SELECT_TODO', payload: todo.id });
+          onSelectTodo?.(todo.id);
+        }}
+        className={`todo-item ${selectedTodoId === todo.id ? 'selected' : ''}`}
+        style={{
+          cursor: 'pointer',
+          borderLeftColor: primaryTag?.color || '#cbd5e1',
+          borderLeftWidth: 4,
+          borderLeftStyle: 'solid',
+        }}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            dispatch({ type: 'SELECT_TODO', payload: todo.id });
+            onSelectTodo?.(todo.id);
+          }
+        }}
+      >
+        <div className="todo-item-content">
+          <div className="todo-item-main">
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+              <div
+                className="todo-item-title"
+                style={{ opacity: isCompleted ? 0.6 : 1 }}
+              >
+                <span style={{ color: '#999', marginRight: 4, fontSize: 13 }}>#{todo.id}</span>{todo.title}
+              </div>
+              <ExecutorBadge executor={todo.executor || 'claudecode'} />
+            </div>
+            {todo.prompt && (
+              <div className="todo-item-desc">
+                {todo.prompt.length > 60 ? todo.prompt.substring(0, 60) + '...' : todo.prompt}
+              </div>
+            )}
+            <div className="todo-item-tags" style={{ justifyContent: 'space-between' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' }}>
+                {todoTags.map(t => (
+                  <span
+                    key={t.id}
+                    className="todo-tag-badge"
+                    style={{
+                      backgroundColor: t.color + '18',
+                      color: t.color,
+                      border: `1px solid ${t.color}30`,
+                    }}
+                  >
+                    {t.name}
+                  </span>
+                ))}
+                {todo.scheduler_config && (
+                  <ClockCircleOutlined
+                    style={{
+                      fontSize: 12,
+                      color: todo.scheduler_enabled ? 'var(--color-warning)' : 'var(--color-text-tertiary)',
+                      marginLeft: todoTags.length > 0 ? 4 : 0,
+                    }}
+                  />
+                )}
+              </div>
+              <span
+                style={{
+                  fontSize: 11,
+                  color: 'var(--color-text-quaternary)',
+                  flexShrink: 0,
+                  marginLeft: 8,
+                }}
+                title={formatRelativeTime(todo.updated_at)}
+              >
+                {formatRelativeTime(todo.updated_at)}
+              </span>
+            </div>
+          </div>
+          <div
+            className="todo-item-status"
+            aria-label="更改任务状态"
+          >
+            <StatusPicker
+              value={todo.status}
+              onChange={(newStatus) => handleStatusChange(todo.id, todo.title, todo.prompt || '', newStatus)}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  };
 
   if (isLoading) {
     return (
@@ -107,6 +261,18 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
               onClick={() => onShowRelationMap?.()}
               className="tag-btn"
               aria-label="关联图"
+            />
+          </Tooltip>
+          {/* 列表显示模式切换：图标上区分平铺 vs 项目分组；选中态给个浅色高亮 */}
+          <Tooltip title={displayMode === 'flat' ? '切换为按项目分组' : '切换为平铺列表'}>
+            <Button
+              type="text"
+              size="small"
+              icon={displayMode === 'flat' ? <UnorderedListOutlined /> : <FolderOpenOutlined />}
+              onClick={() => setDisplayMode(prev => (prev === 'flat' ? 'grouped' : 'flat'))}
+              className={`tag-btn ${displayMode === 'grouped' ? 'active' : ''}`}
+              aria-label="切换列表显示模式"
+              aria-pressed={displayMode === 'grouped'}
             />
           </Tooltip>
           <Tooltip title={themeMode === 'light' ? '切换暗色主题' : '切换亮色主题'}>
@@ -198,103 +364,25 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
               image={Empty.PRESENTED_IMAGE_SIMPLE}
             />
           </div>
-        ) : (
-          filteredTodos.map(todo => {
-            const todoTags = ((todo as any).tag_ids as number[] | undefined)?.map(id => tagMap.get(id)).filter((t): t is typeof tags[0] => !!t) ?? [];
-            const primaryTag = todoTags[0];
-            const isCompleted = todo.status === 'completed';
-
-            return (
-              <div
-                key={todo.id}
-                onClick={() => {
-                  dispatch({ type: 'SELECT_TODO', payload: todo.id });
-                  onSelectTodo?.(todo.id);
-                }}
-                className={`todo-item ${selectedTodoId === todo.id ? 'selected' : ''}`}
-                style={{
-                  cursor: 'pointer',
-                  borderLeftColor: primaryTag?.color || '#cbd5e1',
-                  borderLeftWidth: 4,
-                  borderLeftStyle: 'solid',
-                }}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    dispatch({ type: 'SELECT_TODO', payload: todo.id });
-                    onSelectTodo?.(todo.id);
-                  }
-                }}
-              >
-                <div className="todo-item-content">
-                  <div className="todo-item-main">
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-                      <div
-                        className="todo-item-title"
-                        style={{ opacity: isCompleted ? 0.6 : 1 }}
-                      >
-                        <span style={{ color: '#999', marginRight: 4, fontSize: 13 }}>#{todo.id}</span>{todo.title}
-                      </div>
-                      <ExecutorBadge executor={todo.executor || 'claudecode'} />
-                    </div>
-                    {todo.prompt && (
-                      <div className="todo-item-desc">
-                        {todo.prompt.length > 60 ? todo.prompt.substring(0, 60) + '...' : todo.prompt}
-                      </div>
-                    )}
-                    <div className="todo-item-tags" style={{ justifyContent: 'space-between' }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' }}>
-                        {todoTags.map(t => (
-                          <span
-                            key={t.id}
-                            className="todo-tag-badge"
-                            style={{
-                              backgroundColor: t.color + '18',
-                              color: t.color,
-                              border: `1px solid ${t.color}30`,
-                            }}
-                          >
-                            {t.name}
-                          </span>
-                        ))}
-                        {todo.scheduler_config && (
-                          <ClockCircleOutlined
-                            style={{
-                              fontSize: 12,
-                              color: todo.scheduler_enabled ? 'var(--color-warning)' : 'var(--color-text-tertiary)',
-                              marginLeft: todoTags.length > 0 ? 4 : 0,
-                            }}
-                          />
-                        )}
-                      </div>
-                      <span
-                        style={{
-                          fontSize: 11,
-                          color: 'var(--color-text-quaternary)',
-                          flexShrink: 0,
-                          marginLeft: 8,
-                        }}
-                        title={formatRelativeTime(todo.updated_at)}
-                      >
-                        {formatRelativeTime(todo.updated_at)}
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="todo-item-status"
-                    aria-label="更改任务状态"
-                  >
-                    <StatusPicker
-                      value={todo.status}
-                      onChange={(newStatus) => handleStatusChange(todo.id, todo.title, todo.prompt || '', newStatus)}
-                    />
-                  </div>
+        ) : displayMode === 'grouped' ? (
+          // 分组视图：每个项目一个"文件夹"块，块内平铺 todo；
+          // 文件夹头部用项目名 + 数量徽标，方便一眼看清每个项目下堆积了多少 todo
+          <div className="todo-grouped-list">
+            {groupedByProject.map(([key, group]) => (
+              <div key={key} className="todo-group">
+                <div className="todo-group-header">
+                  <FolderOutlined style={{ color: 'var(--color-primary)', marginRight: 6 }} />
+                  <span className="todo-group-title">{group.name}</span>
+                  <span className="todo-group-count">{group.items.length}</span>
+                </div>
+                <div className="todo-group-items">
+                  {group.items.map(renderTodoItem)}
                 </div>
               </div>
-            );
-          })
+            ))}
+          </div>
+        ) : (
+          filteredTodos.map(renderTodoItem)
         )}
       </div>
     </div>

--- a/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
+++ b/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
@@ -26,6 +26,10 @@ export function ProjectDirectoriesPanel() {
 
   useEffect(() => {
     loadProjectDirectories();
+    // 监听其他组件新增目录的事件，及时刷新列表
+    const reload = () => loadProjectDirectories();
+    window.addEventListener('projectDirectoryAdded', reload);
+    return () => window.removeEventListener('projectDirectoryAdded', reload);
   }, []);
 
   const handleAddProjectDirectory = async () => {

--- a/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
+++ b/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
@@ -5,14 +5,17 @@ import * as db from '../../utils/database';
 import type { ProjectDirectory } from '../../utils/database';
 
 export function ProjectDirectoriesPanel() {
+  // 项目目录列表；按 path 升序，保持稳定可读
   const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
   const [projectDirsLoading, setProjectDirsLoading] = useState(false);
+  // 新增表单的路径与名称：均为必填项，名称是 Todo 侧按"项目"识别目录的唯一 key
   const [newDirPath, setNewDirPath] = useState('');
   const [newDirName, setNewDirName] = useState('');
   const [addingDir, setAddingDir] = useState(false);
   const [editingDirId, setEditingDirId] = useState<number | null>(null);
   const [editingDirName, setEditingDirName] = useState('');
 
+  // 每次进入页面都重新拉取一次，确保用户在其他地方新增/删除后能立刻看到
   const loadProjectDirectories = () => {
     setProjectDirsLoading(true);
     db.getProjectDirectories()
@@ -27,13 +30,20 @@ export function ProjectDirectoriesPanel() {
 
   const handleAddProjectDirectory = async () => {
     const path = newDirPath.trim();
+    const name = newDirName.trim();
+    // 名称与路径都为必填：项目目录是 Todo 按"项目"维度分组的依据，
+    // 任意一项缺失都会让 Todo 侧无法定位到具体项目分组
     if (!path) {
       message.error('请输入目录路径');
       return;
     }
+    if (!name) {
+      message.error('请输入项目名称');
+      return;
+    }
     setAddingDir(true);
     try {
-      const dir = await db.createProjectDirectory(path, newDirName.trim() || undefined);
+      const dir = await db.createProjectDirectory(path, name);
       setProjectDirectories(prev => [...prev.filter(d => d.id !== dir.id), dir].sort((a, b) => a.path.localeCompare(b.path)));
       setNewDirPath('');
       setNewDirName('');
@@ -46,9 +56,14 @@ export function ProjectDirectoriesPanel() {
   };
 
   const handleUpdateProjectDirectoryName = async (id: number) => {
+    const name = editingDirName.trim();
+    if (!name) {
+      message.error('请输入项目名称');
+      return;
+    }
     try {
-      await db.updateProjectDirectory(id, editingDirName.trim() || undefined);
-      setProjectDirectories(prev => prev.map(d => d.id === id ? { ...d, name: editingDirName.trim() || null } : d));
+      await db.updateProjectDirectory(id, name);
+      setProjectDirectories(prev => prev.map(d => d.id === id ? { ...d, name } : d));
       setEditingDirId(null);
       setEditingDirName('');
       message.success('更新成功');
@@ -73,7 +88,7 @@ export function ProjectDirectoriesPanel() {
         <div style={{ marginBottom: 12, fontWeight: 600 }}>添加项目目录</div>
         <div style={{ marginBottom: 24 }}>
           <div style={{ fontSize: 13, color: 'var(--color-text-secondary)', marginBottom: 12 }}>
-            添加常用项目目录，方便在为 Todo 选择执行目录时快速点选。目录路径必填，名称选填。
+            添加常用项目目录。目录路径与项目名称均为必填，Todo 侧会按项目名称来选择与展示。
           </div>
           <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
             <Input
@@ -86,7 +101,7 @@ export function ProjectDirectoriesPanel() {
             <Input
               value={newDirName}
               onChange={(e) => setNewDirName(e.target.value)}
-              placeholder="名称（选填）"
+              placeholder="项目名称（必填）"
               style={{ flex: 1 }}
               onPressEnter={handleAddProjectDirectory}
             />
@@ -125,9 +140,9 @@ export function ProjectDirectoriesPanel() {
                         <Input
                           value={editingDirName}
                           onChange={(e) => setEditingDirName(e.target.value)}
-                          placeholder="输入名称"
+                          placeholder="输入项目名称"
                           size="small"
-                          style={{ width: 120 }}
+                          style={{ width: 160 }}
                           onPressEnter={() => handleUpdateProjectDirectoryName(dir.id)}
                           autoFocus
                         />
@@ -136,14 +151,13 @@ export function ProjectDirectoriesPanel() {
                       </div>
                     ) : (
                       <>
+                        {/* 名称是项目维度的"主键"，固定作为第一行显示；缺失时退化到路径但给出视觉提示 */}
                         <div style={{ fontSize: 14, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                          {dir.name || dir.path}
+                          {dir.name || <span style={{ color: 'var(--color-warning)' }}>{dir.path}（未命名）</span>}
                         </div>
-                        {dir.name && (
-                          <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                            {dir.path}
-                          </div>
-                        )}
+                        <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {dir.path}
+                        </div>
                       </>
                     )}
                   </div>

--- a/frontend/src/types/todo.ts
+++ b/frontend/src/types/todo.ts
@@ -61,3 +61,6 @@ export interface CustomTemplateStatus {
   auto_sync_cron: string;
   templates: TodoTemplate[];
 }
+
+// 复用 database/todos.ts 中的定义，避免多处定义造成漂移
+export type { ProjectDirectory } from '../utils/database/todos';

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -138,11 +138,6 @@ export async function createProjectDirectory(path: string, name: string): Promis
   return unwrap(await api.post('/api/project-directories', { path, name }));
 }
 
-// 兜底用：路径存在时直接返回已有记录不更新名称，不存在时创建（name 可选）
-export async function upsertProjectDirectoryIfNotExists(path: string, name?: string): Promise<ProjectDirectory> {
-  return unwrap(await api.post('/api/project-directories/upsert-if-not-exists', { path, name: name || null }));
-}
-
 export async function updateProjectDirectory(id: number, name: string): Promise<void> {
   // 与新增保持一致：名称必填
   await api.put(`/api/project-directories/${id}`, { name });

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -133,11 +133,13 @@ export async function getProjectDirectories(): Promise<ProjectDirectory[]> {
   return unwrap(await api.get('/api/project-directories'));
 }
 
-export async function createProjectDirectory(path: string, name?: string): Promise<ProjectDirectory> {
+export async function createProjectDirectory(path: string, name: string): Promise<ProjectDirectory> {
+  // 后端要求 name 必填；调用方需要保证传入非空字符串
   return unwrap(await api.post('/api/project-directories', { path, name }));
 }
 
-export async function updateProjectDirectory(id: number, name?: string): Promise<void> {
+export async function updateProjectDirectory(id: number, name: string): Promise<void> {
+  // 与新增保持一致：名称必填
   await api.put(`/api/project-directories/${id}`, { name });
 }
 

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -138,6 +138,11 @@ export async function createProjectDirectory(path: string, name: string): Promis
   return unwrap(await api.post('/api/project-directories', { path, name }));
 }
 
+// 兜底用：路径存在时直接返回已有记录不更新名称，不存在时创建（name 可选）
+export async function upsertProjectDirectoryIfNotExists(path: string, name?: string): Promise<ProjectDirectory> {
+  return unwrap(await api.post('/api/project-directories/upsert-if-not-exists', { path, name: name || null }));
+}
+
 export async function updateProjectDirectory(id: number, name: string): Promise<void> {
   // 与新增保持一致：名称必填
   await api.put(`/api/project-directories/${id}`, { name });


### PR DESCRIPTION
## 概述
对应 Issue #441「项目目录功能升级」：把项目目录从「路径主导、名称可选」升级为「项目名称必填、Todo 侧按名称识别」。

## 变更内容

### 1. 设置 → 项目目录：项目名称改为必填
- 前端 `ProjectDirectoriesPanel`：新增 / 编辑时强制要求填写项目名称
- 后端 `handlers/project_directory.rs`：`CreateProjectDirectoryRequest.name` / `UpdateProjectDirectoryRequest.name` 改为必填字段
- 后端 `db/project_directory.rs::get_or_create_project_directory` 新增 `name` 参数：记录已存在但名称不一致时会自动同步为最新值

### 2. Todo 新增/编辑页：项目目录选择体验升级
- 标题从「工作目录」改为「项目目录」
- 下拉选项 label 展示为「项目名称（路径）」，value 仍存路径以兼容后端 `workspace` 字段
- 尚未配置任何项目目录时给出空态卡片 + 「快速新增项目目录」按钮
- 下拉旁附加 + 按钮：弹出快速新增弹窗，保存后自动选中新目录并刷新下拉

### 3. Todo 列表：新增「按项目分组」显示模式
- 头部新增切换图标（`UnorderedListOutlined` ↔ `FolderOpenOutlined`）
- 分组模式按 `workspace` 路径折叠为文件夹样式，标题用项目名称 + 数量徽标
- 未设置 `workspace` 的 todo 归入「未分组」区块

## 验证
- `cargo check --lib` ✅
- `cargo test --test db_feature_supplement_tests project_directory` 7/7 ✅
- `npx tsc --noEmit` ✅
- `npx vite build` ✅

## 关联 Issue
Closes #441