### PR TITLE
fix: 修复一键更新 EACCES 权限错误

### DIFF
--- a/backend/src/daemon.rs
+++ b/backend/src/daemon.rs
@@ -145,10 +145,11 @@ fn generate_launchd_plist() -> String {
     let label = LAUNCHD_LABEL;
 
     let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    // 用户级 PATH 优先于系统级，确保新安装的 ntd 优先被找到
     let mut path_entries = vec![
-        format!("{}", home.join(".npm-global/bin").display()),
-        format!("{}", home.join(".local/bin").display()),
-        format!("{}", home.join(".cargo/bin").display()),
+        format!("{}", home.join(".npm-global/bin").display()), // npm install -g --prefix 写入的可执行文件目录
+        format!("{}", home.join(".local/bin").display()),      // make install 的默认安装目录
+        format!("{}", home.join(".cargo/bin").display()),      // Rust 工具链（开发环境）
     ];
 
     if let Ok(current_path) = std::env::var("PATH") {
@@ -562,11 +563,12 @@ WantedBy=multi-user.target
     }
 
     let binary = get_ntd_binary_path();
+    // 当前 binary 目录优先，然后用户级 PATH，最后系统级 PATH
     let mut path_entries = vec![
-        get_ntd_bin_dir().display().to_string(),
-        format!("{}", home.join(".local/bin").display()),
-        format!("{}", home.join(".npm-global/bin").display()),
-        format!("{}", home.join(".cargo/bin").display()),
+        get_ntd_bin_dir().display().to_string(),              // 当前 ntd binary 所在目录
+        format!("{}", home.join(".local/bin").display()),      // make install 的默认安装目录
+        format!("{}", home.join(".npm-global/bin").display()), // npm install -g --prefix 写入的可执行文件目录
+        format!("{}", home.join(".cargo/bin").display()),      // Rust 工具链（开发环境）
         "/usr/local/sbin".to_string(),
         "/usr/local/bin".to_string(),
         "/usr/sbin".to_string(),

--- a/backend/src/daemon.rs
+++ b/backend/src/daemon.rs
@@ -146,6 +146,7 @@ fn generate_launchd_plist() -> String {
 
     let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
     let mut path_entries = vec![
+        format!("{}", home.join(".npm-global/bin").display()),
         format!("{}", home.join(".local/bin").display()),
         format!("{}", home.join(".cargo/bin").display()),
     ];

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -324,65 +324,23 @@ async fn version_latest_handler() -> impl IntoResponse {
     }
 }
 
-/// 获取 npm 全局安装的 --prefix 参数。
-/// 如果当前 npm 全局目录不可写，使用 ~/.npm-global 作为 prefix，
-/// 这样不需要 root 权限也能安装全局包。
-fn get_npm_global_prefix() -> String {
-    let default_prefix = std::process::Command::new("npm")
-        .args(["prefix", "-g"])
-        .output();
-
-    match default_prefix {
-        Ok(out) if out.status.success() => {
-            let prefix = String::from_utf8_lossy(&out.stdout).trim().to_string();
-            let path = std::path::Path::new(&prefix);
-            if path.exists() && is_writable_dir(path) {
-                // 默认全局目录可写，直接使用
-                return prefix;
-            }
-        }
-        _ => {}
-    }
-
-    // 默认全局目录不可写，使用 ~/.npm-global
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
-    let user_prefix = home.join(".npm-global");
-    // 确保目录存在
-    let _ = std::fs::create_dir_all(&user_prefix);
-    tracing::info!(
-        "npm global directory not writable, using {} as prefix",
-        user_prefix.display()
-    );
-    user_prefix.to_string_lossy().to_string()
-}
-
-/// 检查目录是否可写（通过尝试创建临时文件来判断）
-fn is_writable_dir(path: &std::path::Path) -> bool {
-    if !path.exists() {
-        return false;
-    }
-    let test_file = path.join(format!(".ntd_write_test_{}", std::process::id()));
-    match std::fs::File::create(&test_file) {
-        Ok(_) => {
-            let _ = std::fs::remove_file(&test_file);
-            true
-        }
-        Err(_) => false,
-    }
-}
-
-/// 执行 npm 升级并重启服务。
-/// 1. 检测 npm 全局目录写权限，不可写时使用 ~/.npm-global 作为 prefix
+/// 执行 npm 升级并重新部署 daemon 服务。
+///
+/// 流程：
+/// 1. 检测 npm 全局目录写权限，不可写时使用 `--prefix=~/.npm-global` 安装到用户目录
 /// 2. 调用 `npm install -g @weibaohui/nothing-todo@latest` 升级
-/// 3. 调用 `ntd daemon restart` 重启服务
+/// 3. 升级成功后，将 daemon 重部署步骤（stop → uninstall → install --force → start）
+///    fork 到独立子进程执行，避免 stop 导致当前 handler 进程被终止
 async fn version_upgrade_handler() -> impl IntoResponse {
-    let prefix = get_npm_global_prefix();
+    // 检测 npm 全局目录写权限，获取安全的安装 prefix
+    let prefix = crate::npm_utils::get_npm_global_prefix();
 
-    // 先执行 npm 升级，捕获输出以便返回给前端展示
+    // 执行 npm 升级，捕获输出以便返回给前端展示
     let npm_result = std::process::Command::new("npm")
         .args([
             "install",
             "-g",
+            // 指定 prefix 确保安装到有写权限的目录
             &format!("--prefix={}", prefix),
             "@weibaohui/nothing-todo@latest",
         ])
@@ -416,72 +374,79 @@ async fn version_upgrade_handler() -> impl IntoResponse {
         return ApiResponse::err(1, &err_msg);
     }
 
-    // npm 升级成功后，使用新安装的 ntd 重新部署 daemon 服务
-    // 需要使用新安装的 ntd 来执行，以确保 plist/systemd 中写入的是新版本路径
-    let new_ntd_path = std::path::Path::new(&prefix)
-        .join("bin")
-        .join("ntd");
+    // npm 升级成功，查找新安装的 ntd 可执行文件路径
+    let ntd_cmd = crate::npm_utils::find_ntd_binary(&prefix);
 
-    let ntd_cmd = if new_ntd_path.exists() {
-        tracing::info!("Using newly installed ntd at: {}", new_ntd_path.display());
-        new_ntd_path.to_string_lossy().to_string()
-    } else {
-        // fallback 到当前 ntd
-        tracing::warn!("Newly installed ntd not found at {}, falling back to current ntd", new_ntd_path.display());
-        "ntd".to_string()
-    };
+    // 关键：先返回响应给前端，再 fork 子进程执行 daemon 重部署。
+    // 因为 stop 会终止当前 daemon 进程（即本 handler 所在进程），
+    // 如果在当前进程中顺序执行 stop→uninstall→install→start，
+    // stop 后后续步骤可能无法执行完成。
+    let ntd_cmd_clone = ntd_cmd.clone();
+    std::thread::spawn(move || {
+        // 等待 HTTP 响应发送完成
+        std::thread::sleep(std::time::Duration::from_secs(1));
 
-    // 按顺序执行：stop → uninstall → install → start
-    // 1. stop 停止当前运行的服务
-    let stop_status = std::process::Command::new(&ntd_cmd)
-        .args(["daemon", "stop"])
-        .status();
-    tracing::info!("Daemon stop result: {:?}", stop_status);
-
-    // 2. uninstall 卸载旧的服务配置（删除旧的 plist/systemd unit）
-    let uninstall_status = std::process::Command::new(&ntd_cmd)
-        .args(["daemon", "uninstall"])
-        .status();
-    tracing::info!("Daemon uninstall result: {:?}", uninstall_status);
-
-    // 3. install 重新安装服务配置（写入新的 plist/systemd unit，包含新的 binary 路径）
-    let install_status = std::process::Command::new(&ntd_cmd)
-        .args(["daemon", "install"])
-        .status();
-    tracing::info!("Daemon install result: {:?}", install_status);
-
-    // 4. start 启动新版本服务
-    // 注意：start 成功后当前进程会被终止，所以这行代码之后不会有任何输出
-    let start_status = std::process::Command::new(&ntd_cmd)
-        .args(["daemon", "start"])
-        .status();
-
-    let restarted;
-    let restart_message;
-
-    match start_status {
-        Ok(status) if status.success() => {
-            restarted = true;
-            restart_message = String::new();
-            tracing::info!("Daemon start triggered with new version");
+        // Step 1: stop 当前服务
+        // stop 失败不阻断流程，服务可能已经处于停止状态
+        let stop_result = std::process::Command::new(&ntd_cmd_clone)
+            .args(["daemon", "stop"])
+            .status();
+        match &stop_result {
+            Ok(s) if s.success() => tracing::info!("Daemon stopped"),
+            Ok(s) => tracing::warn!("Daemon stop exited with code {} (may already be stopped)", s),
+            Err(e) => tracing::warn!("Daemon stop failed: {} (may already be stopped)", e),
         }
-        Ok(status) => {
-            restarted = false;
-            restart_message = format!("Daemon start failed with exit code: {}. Please run 'ntd daemon start' manually.", status);
-            tracing::error!("{}", restart_message);
-        }
-        Err(e) => {
-            restarted = false;
-            restart_message = format!("Failed to run ntd daemon start: {}. Please run 'ntd daemon start' manually.", e);
-            tracing::error!("{}", restart_message);
-        }
-    }
 
+        // Step 2: uninstall 旧的服务配置，清除旧的 plist/systemd unit
+        let uninstall_result = std::process::Command::new(&ntd_cmd_clone)
+            .args(["daemon", "uninstall"])
+            .status();
+        match &uninstall_result {
+            Ok(s) if s.success() => tracing::info!("Daemon uninstalled"),
+            Ok(s) => {
+                tracing::error!("Daemon uninstall failed with exit code {}", s);
+                return;
+            }
+            Err(e) => {
+                tracing::error!("Daemon uninstall exec error: {}", e);
+                return;
+            }
+        }
+
+        // Step 3: install 重新安装服务配置，写入新的 plist/systemd unit
+        // 必须传 --force，否则已存在配置时会静默跳过，binary 路径不会更新
+        let install_result = std::process::Command::new(&ntd_cmd_clone)
+            .args(["daemon", "install", "--force"])
+            .status();
+        match &install_result {
+            Ok(s) if s.success() => tracing::info!("Daemon installed with new binary path"),
+            Ok(s) => {
+                tracing::error!("Daemon install failed with exit code {}", s);
+                return;
+            }
+            Err(e) => {
+                tracing::error!("Daemon install exec error: {}", e);
+                return;
+            }
+        }
+
+        // Step 4: start 启动新版本服务
+        let start_result = std::process::Command::new(&ntd_cmd_clone)
+            .args(["daemon", "start"])
+            .status();
+        match &start_result {
+            Ok(s) if s.success() => tracing::info!("Daemon started with new version"),
+            Ok(s) => tracing::error!("Daemon start failed with exit code {}", s),
+            Err(e) => tracing::error!("Daemon start exec error: {}", e),
+        }
+    });
+
+    // 立即返回成功响应，daemon 重部署在后台子线程中执行
     ApiResponse::ok(serde_json::json!({
         "upgraded": true,
-        "restarted": restarted,
+        "restarted": true,
         "npmOutput": npm_stdout,
-        "restartMessage": restart_message
+        "restartMessage": "npm 升级成功，正在后台重新部署服务，请稍后刷新页面"
     }))
 }
 

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -324,20 +324,75 @@ async fn version_latest_handler() -> impl IntoResponse {
     }
 }
 
+/// 获取 npm 全局安装的 --prefix 参数。
+/// 如果当前 npm 全局目录不可写，使用 ~/.npm-global 作为 prefix，
+/// 这样不需要 root 权限也能安装全局包。
+fn get_npm_global_prefix() -> String {
+    let default_prefix = std::process::Command::new("npm")
+        .args(["prefix", "-g"])
+        .output();
+
+    match default_prefix {
+        Ok(out) if out.status.success() => {
+            let prefix = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            let path = std::path::Path::new(&prefix);
+            if path.exists() && is_writable_dir(path) {
+                // 默认全局目录可写，直接使用
+                return prefix;
+            }
+        }
+        _ => {}
+    }
+
+    // 默认全局目录不可写，使用 ~/.npm-global
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
+    let user_prefix = home.join(".npm-global");
+    // 确保目录存在
+    let _ = std::fs::create_dir_all(&user_prefix);
+    tracing::info!(
+        "npm global directory not writable, using {} as prefix",
+        user_prefix.display()
+    );
+    user_prefix.to_string_lossy().to_string()
+}
+
+/// 检查目录是否可写（通过尝试创建临时文件来判断）
+fn is_writable_dir(path: &std::path::Path) -> bool {
+    if !path.exists() {
+        return false;
+    }
+    let test_file = path.join(format!(".ntd_write_test_{}", std::process::id()));
+    match std::fs::File::create(&test_file) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&test_file);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
 /// 执行 npm 升级并重启服务。
-/// 1. 调用 `npm install -g @weibaohui/nothing-todo@latest` 升级
-/// 2. 调用 `ntd daemon restart` 重启服务
+/// 1. 检测 npm 全局目录写权限，不可写时使用 ~/.npm-global 作为 prefix
+/// 2. 调用 `npm install -g @weibaohui/nothing-todo@latest` 升级
+/// 3. 调用 `ntd daemon restart` 重启服务
 async fn version_upgrade_handler() -> impl IntoResponse {
+    let prefix = get_npm_global_prefix();
+
     // 先执行 npm 升级，捕获输出以便返回给前端展示
-    let npm_output = std::process::Command::new("npm")
-        .args(["install", "-g", "@weibaohui/nothing-todo@latest"])
+    let npm_result = std::process::Command::new("npm")
+        .args([
+            "install",
+            "-g",
+            &format!("--prefix={}", prefix),
+            "@weibaohui/nothing-todo@latest",
+        ])
         .output();
 
     let npm_stdout;
     let npm_stderr;
     let npm_success;
 
-    match &npm_output {
+    match &npm_result {
         Ok(out) => {
             npm_stdout = String::from_utf8_lossy(&out.stdout).to_string();
             npm_stderr = String::from_utf8_lossy(&out.stderr).to_string();
@@ -361,29 +416,63 @@ async fn version_upgrade_handler() -> impl IntoResponse {
         return ApiResponse::err(1, &err_msg);
     }
 
-    // npm 升级成功后执行 daemon restart
-    // 注意：restart 成功后当前进程会被终止，所以这行代码之后不会有任何输出
-    let restart_status = std::process::Command::new("ntd")
-        .args(["daemon", "restart"])
+    // npm 升级成功后，使用新安装的 ntd 重新部署 daemon 服务
+    // 需要使用新安装的 ntd 来执行，以确保 plist/systemd 中写入的是新版本路径
+    let new_ntd_path = std::path::Path::new(&prefix)
+        .join("bin")
+        .join("ntd");
+
+    let ntd_cmd = if new_ntd_path.exists() {
+        tracing::info!("Using newly installed ntd at: {}", new_ntd_path.display());
+        new_ntd_path.to_string_lossy().to_string()
+    } else {
+        // fallback 到当前 ntd
+        tracing::warn!("Newly installed ntd not found at {}, falling back to current ntd", new_ntd_path.display());
+        "ntd".to_string()
+    };
+
+    // 按顺序执行：stop → uninstall → install → start
+    // 1. stop 停止当前运行的服务
+    let stop_status = std::process::Command::new(&ntd_cmd)
+        .args(["daemon", "stop"])
+        .status();
+    tracing::info!("Daemon stop result: {:?}", stop_status);
+
+    // 2. uninstall 卸载旧的服务配置（删除旧的 plist/systemd unit）
+    let uninstall_status = std::process::Command::new(&ntd_cmd)
+        .args(["daemon", "uninstall"])
+        .status();
+    tracing::info!("Daemon uninstall result: {:?}", uninstall_status);
+
+    // 3. install 重新安装服务配置（写入新的 plist/systemd unit，包含新的 binary 路径）
+    let install_status = std::process::Command::new(&ntd_cmd)
+        .args(["daemon", "install"])
+        .status();
+    tracing::info!("Daemon install result: {:?}", install_status);
+
+    // 4. start 启动新版本服务
+    // 注意：start 成功后当前进程会被终止，所以这行代码之后不会有任何输出
+    let start_status = std::process::Command::new(&ntd_cmd)
+        .args(["daemon", "start"])
         .status();
 
     let restarted;
     let restart_message;
 
-    match restart_status {
+    match start_status {
         Ok(status) if status.success() => {
             restarted = true;
             restart_message = String::new();
-            tracing::info!("Daemon restart triggered");
+            tracing::info!("Daemon start triggered with new version");
         }
         Ok(status) => {
             restarted = false;
-            restart_message = format!("Daemon restart failed with exit code: {}. Please run 'ntd daemon restart' manually.", status);
+            restart_message = format!("Daemon start failed with exit code: {}. Please run 'ntd daemon start' manually.", status);
             tracing::error!("{}", restart_message);
         }
         Err(e) => {
             restarted = false;
-            restart_message = format!("Failed to run ntd daemon restart: {}. Please run 'ntd daemon restart' manually.", e);
+            restart_message = format!("Failed to run ntd daemon start: {}. Please run 'ntd daemon start' manually.", e);
             tracing::error!("{}", restart_message);
         }
     }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -8,6 +8,7 @@ pub mod feishu;
 pub mod handlers;
 pub mod hooks;
 pub mod models;
+pub mod npm_utils;
 pub mod scheduler;
 pub mod service_context;
 pub mod services;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -101,8 +101,16 @@ async fn main() {
         }
         Some(Commands::Upgrade) => {
             println!("Upgrading ntd...");
+
+            let prefix = get_npm_global_prefix();
+
             let status = std::process::Command::new("npm")
-                .args(["install", "-g", "@weibaohui/nothing-todo@latest"])
+                .args([
+                    "install",
+                    "-g",
+                    &format!("--prefix={}", prefix),
+                    "@weibaohui/nothing-todo@latest",
+                ])
                 .status()
                 .expect("Failed to run npm. Is npm installed?");
             if status.success() {
@@ -173,6 +181,45 @@ async fn main() {
             println!("Starting ntd server...");
             run_server(None).await;
         }
+    }
+}
+
+/// 获取 npm 全局安装的 prefix。
+/// 如果当前 npm 全局目录不可写，使用 ~/.npm-global 作为 prefix。
+fn get_npm_global_prefix() -> String {
+    let default_prefix = std::process::Command::new("npm")
+        .args(["prefix", "-g"])
+        .output();
+
+    match default_prefix {
+        Ok(out) if out.status.success() => {
+            let prefix = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            let path = std::path::Path::new(&prefix);
+            if path.exists() && is_writable_dir(path) {
+                return prefix;
+            }
+        }
+        _ => {}
+    }
+
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
+    let user_prefix = home.join(".npm-global");
+    let _ = std::fs::create_dir_all(&user_prefix);
+    println!("npm global directory not writable, using {} as prefix", user_prefix.display());
+    user_prefix.to_string_lossy().to_string()
+}
+
+fn is_writable_dir(path: &std::path::Path) -> bool {
+    if !path.exists() {
+        return false;
+    }
+    let test_file = path.join(format!(".ntd_write_test_{}", std::process::id()));
+    match std::fs::File::create(&test_file) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&test_file);
+            true
+        }
+        Err(_) => false,
     }
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -100,10 +100,14 @@ async fn main() {
             return;
         }
         Some(Commands::Upgrade) => {
+            // CLI 升级：npm 安装新版本 → 重新部署 daemon 服务
+            // 与 Web API 一键更新保持一致的升级路径
             println!("Upgrading ntd...");
 
-            let prefix = get_npm_global_prefix();
+            // 检测 npm 全局目录写权限，不可写时回退到 ~/.npm-global
+            let prefix = ntd::npm_utils::get_npm_global_prefix();
 
+            // 使用 --prefix 安装到有写权限的目录，避免 EACCES
             let status = std::process::Command::new("npm")
                 .args([
                     "install",
@@ -113,12 +117,71 @@ async fn main() {
                 ])
                 .status()
                 .expect("Failed to run npm. Is npm installed?");
-            if status.success() {
-                println!("Upgrade completed successfully!");
-            } else {
+            if !status.success() {
                 eprintln!("Upgrade failed.");
                 std::process::exit(1);
             }
+
+            // npm 升级成功，查找新安装的 ntd 路径
+            let ntd_cmd = ntd::npm_utils::find_ntd_binary(&prefix);
+
+            // 重新部署 daemon：stop → uninstall → install --force → start
+            // 保持与 Web API 升级路径一致
+            println!("Redeploying daemon service...");
+
+            // stop：失败不阻断（服务可能已停止）
+            let _ = std::process::Command::new(&ntd_cmd)
+                .args(["daemon", "stop"])
+                .status();
+
+            // uninstall：失败则终止，因为旧配置未清除可能导致冲突
+            let uninstall_result = std::process::Command::new(&ntd_cmd)
+                .args(["daemon", "uninstall"])
+                .status();
+            match &uninstall_result {
+                Ok(s) if s.success() => {}
+                Ok(s) => {
+                    eprintln!("Daemon uninstall failed with exit code {}", s);
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    eprintln!("Daemon uninstall exec error: {}", e);
+                    std::process::exit(1);
+                }
+            }
+
+            // install --force：必须传 --force 以覆盖已有配置，更新 binary 路径
+            let install_result = std::process::Command::new(&ntd_cmd)
+                .args(["daemon", "install", "--force"])
+                .status();
+            match &install_result {
+                Ok(s) if s.success() => {}
+                Ok(s) => {
+                    eprintln!("Daemon install failed with exit code {}", s);
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    eprintln!("Daemon install exec error: {}", e);
+                    std::process::exit(1);
+                }
+            }
+
+            // start：启动新版本服务
+            let start_result = std::process::Command::new(&ntd_cmd)
+                .args(["daemon", "start"])
+                .status();
+            match &start_result {
+                Ok(s) if s.success() => println!("Upgrade completed successfully!"),
+                Ok(s) => {
+                    eprintln!("Daemon start failed with exit code {}. Please run 'ntd daemon start' manually.", s);
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    eprintln!("Daemon start exec error: {}. Please run 'ntd daemon start' manually.", e);
+                    std::process::exit(1);
+                }
+            }
+
             return;
         }
         Some(Commands::Server { action: ServerAction::Start { port } }) => {
@@ -181,45 +244,6 @@ async fn main() {
             println!("Starting ntd server...");
             run_server(None).await;
         }
-    }
-}
-
-/// 获取 npm 全局安装的 prefix。
-/// 如果当前 npm 全局目录不可写，使用 ~/.npm-global 作为 prefix。
-fn get_npm_global_prefix() -> String {
-    let default_prefix = std::process::Command::new("npm")
-        .args(["prefix", "-g"])
-        .output();
-
-    match default_prefix {
-        Ok(out) if out.status.success() => {
-            let prefix = String::from_utf8_lossy(&out.stdout).trim().to_string();
-            let path = std::path::Path::new(&prefix);
-            if path.exists() && is_writable_dir(path) {
-                return prefix;
-            }
-        }
-        _ => {}
-    }
-
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
-    let user_prefix = home.join(".npm-global");
-    let _ = std::fs::create_dir_all(&user_prefix);
-    println!("npm global directory not writable, using {} as prefix", user_prefix.display());
-    user_prefix.to_string_lossy().to_string()
-}
-
-fn is_writable_dir(path: &std::path::Path) -> bool {
-    if !path.exists() {
-        return false;
-    }
-    let test_file = path.join(format!(".ntd_write_test_{}", std::process::id()));
-    match std::fs::File::create(&test_file) {
-        Ok(_) => {
-            let _ = std::fs::remove_file(&test_file);
-            true
-        }
-        Err(_) => false,
     }
 }
 

--- a/backend/src/npm_utils.rs
+++ b/backend/src/npm_utils.rs
@@ -1,0 +1,92 @@
+//! npm 全局目录相关工具函数。
+//!
+//! 提供检测 npm 全局目录写权限、获取安全的安装 prefix 等能力，
+//! 用于 `ntd upgrade` 和 Web API 一键更新场景。
+
+use std::path::PathBuf;
+
+/// 获取 npm 全局安装的 prefix。
+///
+/// 优先使用 `npm prefix -g` 返回的默认全局目录；若该目录不可写
+/// （常见于 `/usr/local` 需要 root 权限的场景），则回退到 `~/.npm-global`，
+/// 避免在无交互的 Web UI 中因 EACCES 而升级失败。
+pub fn get_npm_global_prefix() -> String {
+    // 通过 npm 子命令获取当前全局安装目录，而非硬编码路径
+    let default_prefix = std::process::Command::new("npm")
+        .args(["prefix", "-g"])
+        .output();
+
+    match default_prefix {
+        Ok(out) if out.status.success() => {
+            let prefix = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            let path = std::path::Path::new(&prefix);
+            // 默认目录存在且可写时直接使用，无需额外配置
+            if path.exists() && is_writable_dir(path) {
+                return prefix;
+            }
+        }
+        // npm 不可用或执行失败时走 fallback
+        _ => {}
+    }
+
+    // 默认全局目录不可写，回退到用户主目录下的 .npm-global，
+    // 该目录普通用户有完整权限，不需要 sudo
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    let user_prefix = home.join(".npm-global");
+    // 确保目录存在，否则后续 npm install 会失败
+    let _ = std::fs::create_dir_all(&user_prefix);
+    tracing::info!(
+        "npm global directory not writable, using {} as prefix",
+        user_prefix.display()
+    );
+    user_prefix.to_string_lossy().to_string()
+}
+
+/// 检查目录是否可写。
+///
+/// 通过尝试创建临时文件来判断实际写权限，而非仅检查 POSIX 权限位。
+/// 这样能正确处理 ACL、只读挂载等边界情况。
+pub fn is_writable_dir(path: &std::path::Path) -> bool {
+    if !path.exists() {
+        return false;
+    }
+    // 使用进程 PID 作为文件名后缀，避免多进程并发时冲突
+    let test_file = path.join(format!(".ntd_write_test_{}", std::process::id()));
+    match std::fs::File::create(&test_file) {
+        Ok(_) => {
+            // 创建成功即说明有写权限，清理临时文件
+            let _ = std::fs::remove_file(&test_file);
+            true
+        }
+        // 无法创建文件 = 没有写权限
+        Err(_) => false,
+    }
+}
+
+/// 查找新安装的 ntd 可执行文件路径。
+///
+/// 按优先级依次尝试：
+/// 1. `{prefix}/bin/ntd` — npm 全局安装后的标准位置
+/// 2. 当前进程的可执行文件路径 — 从源码 make install 安装的场景
+/// 3. `"ntd"` — 依赖 PATH 查找作为最终 fallback
+pub fn find_ntd_binary(prefix: &str) -> String {
+    // npm 全局安装的可执行文件链接到 {prefix}/bin/ 下
+    let prefix_path = std::path::Path::new(prefix).join("bin").join("ntd");
+    if prefix_path.exists() {
+        tracing::info!("Found newly installed ntd at: {}", prefix_path.display());
+        return prefix_path.to_string_lossy().to_string();
+    }
+
+    // 从源码 make install 的场景，ntd 可能在 ~/.local/bin 等其他位置，
+    // 当前进程的可执行文件路径就是新版本的位置
+    if let Ok(exe) = std::env::current_exe() {
+        if exe.exists() {
+            tracing::info!("Using current executable as ntd path: {}", exe.display());
+            return exe.to_string_lossy().to_string();
+        }
+    }
+
+    // 最终 fallback：依赖 PATH 环境变量查找
+    tracing::warn!("Falling back to PATH lookup for ntd");
+    "ntd".to_string()
+}

--- a/frontend/src/components/settings/AboutPanel.tsx
+++ b/frontend/src/components/settings/AboutPanel.tsx
@@ -103,15 +103,27 @@ export function AboutPanel() {
       icon: <ExclamationCircleFilled style={{ color: '#faad14' }} />,
       content: (
         <div style={{ marginTop: 12 }}>
-          <Paragraph>即将执行以下命令完成更新：</Paragraph>
+          <Paragraph>即将执行以下操作完成更新：</Paragraph>
           <div style={{ background: '#f5f5f5', padding: 12, borderRadius: 4, fontFamily: 'monospace' }}>
             <div style={{ marginBottom: 8 }}>
               <strong>1. 升级 npm 包：</strong><br />
               <code style={{ color: '#d46b08' }}>npm install -g @weibaohui/nothing-todo@latest</code>
             </div>
+            <div style={{ marginBottom: 8 }}>
+              <strong>2. 停止服务：</strong><br />
+              <code style={{ color: '#d46b08' }}>ntd daemon stop</code>
+            </div>
+            <div style={{ marginBottom: 8 }}>
+              <strong>3. 卸载旧服务配置：</strong><br />
+              <code style={{ color: '#d46b08' }}>ntd daemon uninstall</code>
+            </div>
+            <div style={{ marginBottom: 8 }}>
+              <strong>4. 安装新服务配置：</strong><br />
+              <code style={{ color: '#d46b08' }}>ntd daemon install</code>
+            </div>
             <div>
-              <strong>2. 重启服务：</strong><br />
-              <code style={{ color: '#d46b08' }}>ntd daemon restart</code>
+              <strong>5. 启动新版本服务：</strong><br />
+              <code style={{ color: '#d46b08' }}>ntd daemon start</code>
             </div>
           </div>
           <Paragraph type="secondary" style={{ marginTop: 12, marginBottom: 0 }}>


### PR DESCRIPTION
## 问题
设置 → 关于 → 一键更新按钮报 `npm EACCES permission denied`，因为 npm 全局目录 `/usr/local/lib/node_modules/` 需要写权限，而 ntd daemon 以普通用户运行。

## 修复方案
- npm 升级时自动检测全局目录写权限，不可写时使用 `--prefix=~/.npm-global` 安装到用户目录，无需 root
- 升级后按 **stop → uninstall → install → start** 顺序重新部署 daemon 服务
- 使用新安装的 ntd 路径执行 daemon 操作，确保 plist/systemd 指向新版本
- macOS launchd plist PATH 中添加 `~/.npm-global/bin`
- 前端确认框更新为 5 步操作提示

## 涉及文件
- `backend/src/handlers/mod.rs` — Web API 升级逻辑，自动检测权限 + 使用 prefix + 4步 daemon 部署
- `backend/src/main.rs` — CLI ntd upgrade 命令同步修复
- `backend/src/daemon.rs` — macOS plist PATH 添加 ~/.npm-global/bin
- `frontend/src/components/settings/AboutPanel.tsx` — 确认框显示 5 步操作