### PR TITLE
优化暗黑更新弹窗与首页头部导航

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -248,9 +248,85 @@ body {
 
 .header-actions {
   display: flex;
-  gap: 4px;
   align-items: center;
-  flex-shrink: 0;
+  justify-content: flex-end;
+  flex: 1;
+  min-width: 0;
+}
+
+.header-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: 0;
+  width: 100%;
+}
+
+.header-nav-cluster {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  border: 1px solid var(--color-border-light);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-bg-elevated) 84%, var(--color-bg) 16%);
+  box-shadow: var(--shadow-sm);
+}
+
+.header-nav-btn,
+.header-overflow-btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 999px !important;
+  color: var(--color-text-secondary) !important;
+  transition: all var(--transition-fast);
+}
+
+.header-nav-btn:hover,
+.header-overflow-btn:hover {
+  background: var(--color-primary-bg) !important;
+  color: var(--color-primary) !important;
+}
+
+.header-quick-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: 2px;
+}
+
+.header-primary-action {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px !important;
+  border: 1px solid transparent !important;
+  box-shadow: var(--shadow-sm);
+  transition: all var(--transition-base, 0.2s ease);
+}
+
+.header-primary-action-smart {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.14), rgba(139, 92, 246, 0.12)) !important;
+  color: #2563eb !important;
+  border-color: rgba(59, 130, 246, 0.18) !important;
+}
+
+.header-primary-action-smart:hover {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(139, 92, 246, 0.18)) !important;
+  color: #1d4ed8 !important;
+  transform: translateY(-1px);
+}
+
+.header-primary-action-create {
+  background: var(--color-primary-bg) !important;
+  color: var(--color-primary) !important;
+  border-color: color-mix(in srgb, var(--color-primary) 22%, transparent) !important;
+}
+
+.header-primary-action-create:hover {
+  background: var(--color-primary-light) !important;
+  color: var(--color-primary-hover) !important;
+  transform: translateY(-1px);
 }
 
 /* Tag Filter Bar */
@@ -1289,6 +1365,46 @@ body {
   color: #60a5fa !important;
 }
 
+[data-theme="dark"] .header-nav-cluster {
+  border-color: rgba(166, 173, 200, 0.12);
+  background: linear-gradient(180deg, rgba(49, 50, 68, 0.82), rgba(30, 30, 46, 0.96));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+[data-theme="dark"] .header-nav-btn,
+[data-theme="dark"] .header-overflow-btn {
+  color: var(--color-text-secondary) !important;
+}
+
+[data-theme="dark"] .header-nav-btn:hover,
+[data-theme="dark"] .header-overflow-btn:hover {
+  background: rgba(8, 145, 178, 0.16) !important;
+  color: #89dceb !important;
+}
+
+[data-theme="dark"] .header-primary-action-smart {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.22), rgba(139, 92, 246, 0.18)) !important;
+  color: #93c5fd !important;
+  border-color: rgba(96, 165, 250, 0.18) !important;
+  box-shadow: 0 10px 24px rgba(17, 24, 39, 0.28);
+}
+
+[data-theme="dark"] .header-primary-action-smart:hover {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.3), rgba(139, 92, 246, 0.24)) !important;
+  color: #bfdbfe !important;
+}
+
+[data-theme="dark"] .header-primary-action-create {
+  background: rgba(8, 145, 178, 0.16) !important;
+  color: #67e8f9 !important;
+  border-color: rgba(34, 211, 238, 0.16) !important;
+}
+
+[data-theme="dark"] .header-primary-action-create:hover {
+  background: rgba(8, 145, 178, 0.24) !important;
+  color: #a5f3fc !important;
+}
+
 [data-theme="dark"] .smart-create-btn:hover {
   background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(139, 92, 246, 0.15)) !important;
   color: #93bbfd !important;
@@ -2011,6 +2127,238 @@ code {
 
 [data-theme="dark"] .ant-modal-close:hover {
   color: var(--color-text);
+}
+
+/* ---------- Update Confirm Modal ---------- */
+.update-confirm-modal.ant-modal {
+  overflow: hidden;
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  box-shadow: var(--shadow-lg);
+}
+
+.update-confirm-modal .ant-modal-body {
+  padding: 0;
+  background: transparent;
+}
+
+.update-confirm-modal .ant-modal-confirm-body-wrapper {
+  overflow: hidden;
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  box-shadow: var(--shadow-lg);
+}
+
+.update-confirm-modal .ant-modal-confirm-body {
+  padding: 20px 20px 0;
+}
+
+.update-confirm-modal .ant-modal-content {
+  overflow: hidden;
+  border: 1px solid var(--color-border-light);
+  box-shadow: var(--shadow-lg);
+}
+
+.update-confirm-modal .ant-modal-confirm-body {
+  align-items: flex-start;
+}
+
+.update-confirm-modal .ant-modal-confirm-paragraph {
+  max-width: 100%;
+}
+
+.update-confirm-modal .ant-modal-confirm-title {
+  display: block;
+  margin-bottom: 0;
+}
+
+.update-confirm-modal .ant-modal-confirm-content {
+  margin-top: 16px !important;
+  margin-inline-start: 0 !important;
+  max-width: 100% !important;
+}
+
+.update-confirm-modal .ant-modal-confirm-btns {
+  margin-top: 20px !important;
+  padding-top: 14px;
+  border-top: 1px solid var(--color-border-light);
+}
+
+.update-confirm-modal__icon {
+  margin-top: 2px;
+  color: #f59e0b !important;
+  font-size: 22px !important;
+}
+
+.update-confirm-modal__title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.update-confirm-modal__title {
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.35;
+  color: var(--color-text);
+}
+
+.update-confirm-modal__subtitle {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+}
+
+.update-confirm-modal__content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.update-confirm-modal__hero {
+  position: relative;
+  padding: 16px 18px;
+  border-radius: 14px;
+  border: 1px solid rgba(8, 145, 178, 0.18);
+  background:
+    radial-gradient(circle at top right, rgba(8, 145, 178, 0.14), transparent 42%),
+    linear-gradient(135deg, rgba(8, 145, 178, 0.08), rgba(59, 130, 246, 0.04));
+}
+
+.update-confirm-modal__eyebrow {
+  margin-bottom: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+}
+
+.update-confirm-modal__hero-text {
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--color-text);
+}
+
+.update-confirm-modal__command-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.update-confirm-modal__command-card {
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--color-border-light);
+  background: color-mix(in srgb, var(--color-bg-elevated) 88%, var(--color-primary-bg) 12%);
+}
+
+.update-confirm-modal__command-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.update-confirm-modal__command-step {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 52px;
+  height: 24px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: var(--color-primary-bg);
+  color: var(--color-primary);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.update-confirm-modal__command-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.update-confirm-modal__command-code {
+  display: block;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: #d97706;
+  font-size: 13px;
+  line-height: 1.7;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.update-confirm-modal__note.ant-typography {
+  margin-bottom: 0;
+  padding-left: 12px;
+  border-left: 2px solid var(--color-border);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+[data-theme="dark"] .update-confirm-modal .ant-modal-content {
+  border-color: rgba(166, 173, 200, 0.14);
+  background:
+    radial-gradient(circle at top right, rgba(137, 220, 235, 0.08), transparent 28%),
+    linear-gradient(180deg, rgba(49, 50, 68, 0.92), rgba(30, 30, 46, 0.98));
+}
+
+[data-theme="dark"] .update-confirm-modal.ant-modal {
+  border-color: rgba(166, 173, 200, 0.14);
+  background:
+    radial-gradient(circle at top right, rgba(137, 220, 235, 0.08), transparent 28%),
+    linear-gradient(180deg, rgba(49, 50, 68, 0.92), rgba(30, 30, 46, 0.98));
+}
+
+[data-theme="dark"] .update-confirm-modal .ant-modal-confirm-body-wrapper {
+  border-color: rgba(166, 173, 200, 0.14);
+  background:
+    radial-gradient(circle at top right, rgba(137, 220, 235, 0.08), transparent 28%),
+    linear-gradient(180deg, rgba(49, 50, 68, 0.92), rgba(30, 30, 46, 0.98));
+}
+
+[data-theme="dark"] .update-confirm-modal .ant-modal-confirm-btns {
+  border-top-color: rgba(166, 173, 200, 0.12);
+}
+
+[data-theme="dark"] .update-confirm-modal__hero {
+  border-color: rgba(137, 220, 235, 0.18);
+  background:
+    radial-gradient(circle at top right, rgba(137, 220, 235, 0.14), transparent 40%),
+    linear-gradient(135deg, rgba(17, 27, 43, 0.96), rgba(12, 74, 94, 0.32));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+[data-theme="dark"] .update-confirm-modal__command-card {
+  border-color: rgba(166, 173, 200, 0.12);
+  background:
+    linear-gradient(180deg, rgba(49, 50, 68, 0.84), rgba(30, 30, 46, 0.92));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+[data-theme="dark"] .update-confirm-modal__command-step {
+  background: rgba(8, 145, 178, 0.18);
+  color: #89dceb;
+}
+
+[data-theme="dark"] .update-confirm-modal__command-code {
+  border-color: rgba(166, 173, 200, 0.12);
+  background: rgba(10, 10, 15, 0.92);
+  color: #f9e2af;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+[data-theme="dark"] .update-confirm-modal__note.ant-typography {
+  border-left-color: rgba(166, 173, 200, 0.2);
+  color: var(--color-text-secondary);
 }
 
 /* ---------- Select Dropdown Dark Mode ---------- */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1245,32 +1245,6 @@ body {
 }
 
 /* ---------- Smart Create Styles ---------- */
-.header-actions-divider {
-  width: 1px;
-  height: 16px;
-  background: var(--color-border-light, #e5e7eb);
-  flex-shrink: 0;
-}
-
-.smart-create-btn {
-  color: #3b82f6 !important;
-  transition: all var(--transition-base, 0.2s ease);
-}
-
-.smart-create-btn:hover {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(139, 92, 246, 0.1)) !important;
-  color: #2563eb !important;
-}
-
-.create-btn {
-  color: var(--color-primary) !important;
-  transition: all var(--transition-base, 0.2s ease);
-}
-
-.create-btn:hover {
-  background: var(--color-primary-light) !important;
-  color: var(--color-primary-hover) !important;
-}
 
 .smart-create-content {
   display: flex;
@@ -1361,9 +1335,6 @@ body {
 }
 
 /* Dark theme smart create adjustments */
-[data-theme="dark"] .smart-create-btn {
-  color: #60a5fa !important;
-}
 
 [data-theme="dark"] .header-nav-cluster {
   border-color: rgba(166, 173, 200, 0.12);
@@ -1403,20 +1374,6 @@ body {
 [data-theme="dark"] .header-primary-action-create:hover {
   background: rgba(8, 145, 178, 0.24) !important;
   color: #a5f3fc !important;
-}
-
-[data-theme="dark"] .smart-create-btn:hover {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(139, 92, 246, 0.15)) !important;
-  color: #93bbfd !important;
-}
-
-[data-theme="dark"] .create-btn {
-  color: #22d3ee !important;
-}
-
-[data-theme="dark"] .create-btn:hover {
-  background: rgba(8, 145, 178, 0.15) !important;
-  color: #67e8f9 !important;
 }
 
 [data-theme="dark"] .smart-create-config-info {
@@ -2130,7 +2087,7 @@ code {
 }
 
 /* ---------- Update Confirm Modal ---------- */
-.update-confirm-modal.ant-modal {
+.update-confirm-modal .ant-modal-content {
   overflow: hidden;
   border: 1px solid var(--color-border-light);
   border-radius: var(--radius-lg);
@@ -2145,23 +2102,10 @@ code {
 
 .update-confirm-modal .ant-modal-confirm-body-wrapper {
   overflow: hidden;
-  border: 1px solid var(--color-border-light);
-  border-radius: var(--radius-lg);
-  background: var(--color-bg-elevated);
-  box-shadow: var(--shadow-lg);
 }
 
 .update-confirm-modal .ant-modal-confirm-body {
   padding: 20px 20px 0;
-}
-
-.update-confirm-modal .ant-modal-content {
-  overflow: hidden;
-  border: 1px solid var(--color-border-light);
-  box-shadow: var(--shadow-lg);
-}
-
-.update-confirm-modal .ant-modal-confirm-body {
   align-items: flex-start;
 }
 
@@ -2188,7 +2132,7 @@ code {
 
 .update-confirm-modal__icon {
   margin-top: 2px;
-  color: #f59e0b !important;
+  color: var(--color-warning) !important;
   font-size: 22px !important;
 }
 
@@ -2289,6 +2233,7 @@ code {
   border: 1px solid var(--color-border);
   background: var(--color-bg);
   color: #d97706;
+  font-family: var(--font-mono);
   font-size: 13px;
   line-height: 1.7;
   overflow-x: auto;
@@ -2305,20 +2250,6 @@ code {
 }
 
 [data-theme="dark"] .update-confirm-modal .ant-modal-content {
-  border-color: rgba(166, 173, 200, 0.14);
-  background:
-    radial-gradient(circle at top right, rgba(137, 220, 235, 0.08), transparent 28%),
-    linear-gradient(180deg, rgba(49, 50, 68, 0.92), rgba(30, 30, 46, 0.98));
-}
-
-[data-theme="dark"] .update-confirm-modal.ant-modal {
-  border-color: rgba(166, 173, 200, 0.14);
-  background:
-    radial-gradient(circle at top right, rgba(137, 220, 235, 0.08), transparent 28%),
-    linear-gradient(180deg, rgba(49, 50, 68, 0.92), rgba(30, 30, 46, 0.98));
-}
-
-[data-theme="dark"] .update-confirm-modal .ant-modal-confirm-body-wrapper {
   border-color: rgba(166, 173, 200, 0.14);
   background:
     radial-gradient(circle at top right, rgba(137, 220, 235, 0.08), transparent 28%),

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -191,8 +191,11 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
       {
         key: 'display-mode',
         icon: displayMode === 'flat' ? <FolderOpenOutlined /> : <UnorderedListOutlined />,
-        label: displayMode === 'flat' ? '切换为按项目分组' : '切换为平铺列表',
-        'aria-pressed': displayMode === 'grouped',
+        label: (
+          <span aria-pressed={displayMode === 'grouped'}>
+            {displayMode === 'flat' ? '切换为按项目分组' : '切换为平铺列表'}
+          </span>
+        ),
       },
       {
         key: 'theme',

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -51,21 +51,21 @@ function buildDesktopNavActions(
       key: 'dashboard',
       title: '仪表盘',
       icon: <DashboardOutlined />,
-      onClick: onShowDashboard,
+      onClick: onShowDashboard ? () => onShowDashboard() : undefined,
       ariaLabel: '查看仪表盘',
     },
     {
       key: 'memorial',
       title: '看板',
       icon: <ReadOutlined />,
-      onClick: () => onShowMemorial?.(),
+      onClick: onShowMemorial ? () => onShowMemorial() : undefined,
       ariaLabel: '看板',
     },
     {
       key: 'relation-map',
       title: '关联图',
       icon: <ApartmentOutlined />,
-      onClick: () => onShowRelationMap?.(),
+      onClick: onShowRelationMap ? () => onShowRelationMap() : undefined,
       ariaLabel: '关联图',
     },
   ].filter(action => typeof action.onClick === 'function');
@@ -157,6 +157,18 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
     [onShowDashboard, onShowMemorial, onShowRelationMap],
   );
 
+  const toggleGroupCollapse = useCallback((key: string) => {
+    setCollapsedGroups(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
+
   /**
    * 处理桌面端头部“更多”菜单点击。
    */
@@ -174,26 +186,34 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
     }
   }, [onShowSettings, toggleTheme]);
 
-  const headerMenuItems = useMemo<MenuProps['items']>(() => ([
-    {
-      key: 'display-mode',
-      icon: displayMode === 'flat' ? <FolderOpenOutlined /> : <UnorderedListOutlined />,
-      label: displayMode === 'flat' ? '切换为按项目分组' : '切换为平铺列表',
-    },
-    {
-      key: 'theme',
-      icon: themeMode === 'light' ? <MoonOutlined /> : <SunOutlined />,
-      label: themeMode === 'light' ? '切换暗色主题' : '切换亮色主题',
-    },
-    {
-      type: 'divider',
-    },
-    {
-      key: 'settings',
-      icon: <SettingOutlined />,
-      label: '配置管理',
-    },
-  ]), [displayMode, themeMode]);
+  const headerMenuItems = useMemo<MenuProps['items']>(() => {
+    const items: NonNullable<MenuProps['items']> = [
+      {
+        key: 'display-mode',
+        icon: displayMode === 'flat' ? <FolderOpenOutlined /> : <UnorderedListOutlined />,
+        label: displayMode === 'flat' ? '切换为按项目分组' : '切换为平铺列表',
+        'aria-pressed': displayMode === 'grouped',
+      },
+      {
+        key: 'theme',
+        icon: themeMode === 'light' ? <MoonOutlined /> : <SunOutlined />,
+        label: themeMode === 'light' ? '切换暗色主题' : '切换亮色主题',
+      },
+    ];
+
+    if (onShowSettings) {
+      items.push(
+        { type: 'divider' },
+        {
+          key: 'settings',
+          icon: <SettingOutlined />,
+          label: '配置管理',
+        },
+      );
+    }
+
+    return items;
+  }, [displayMode, themeMode, onShowSettings]);
 
   const tagMap = useMemo(() => {
     const map = new Map<number, typeof tags[0]>();
@@ -206,6 +226,7 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
     const todoTags = ((todo as any).tag_ids as number[] | undefined)?.map(id => tagMap.get(id)).filter((t): t is typeof tags[0] => !!t) ?? [];
     const primaryTag = todoTags[0];
     const isCompleted = todo.status === 'completed';
+    const relativeTime = formatRelativeTime(todo.updated_at);
 
     return (
       <div
@@ -279,9 +300,9 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
                   flexShrink: 0,
                   marginLeft: 8,
                 }}
-                title={formatRelativeTime(todo.updated_at)}
+                title={relativeTime}
               >
-                {formatRelativeTime(todo.updated_at)}
+                {relativeTime}
               </span>
             </div>
           </div>
@@ -400,7 +421,7 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
                 type="text"
                 size="small"
                 icon={<SettingOutlined />}
-                onClick={onShowSettings}
+                onClick={() => onShowSettings?.()}
                 className="header-nav-btn"
                 aria-label="配置管理"
               />
@@ -463,32 +484,14 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
                 <div key={key} className="todo-group">
                   <div
                     className="todo-group-header"
-                    onClick={() => {
-                      setCollapsedGroups(prev => {
-                        const next = new Set(prev);
-                        if (isCollapsed) {
-                          next.delete(key);
-                        } else {
-                          next.add(key);
-                        }
-                        return next;
-                      });
-                    }}
+                    onClick={() => toggleGroupCollapse(key)}
                     style={{ cursor: 'pointer' }}
                     role="button"
                     tabIndex={0}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault();
-                        setCollapsedGroups(prev => {
-                          const next = new Set(prev);
-                          if (isCollapsed) {
-                            next.delete(key);
-                          } else {
-                            next.add(key);
-                          }
-                          return next;
-                        });
+                        toggleGroupCollapse(key);
                       }
                     }}
                     aria-expanded={!isCollapsed}

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useApp } from '../hooks/useApp';
 import { useIsMobile } from '../hooks/useIsMobile';
-import { Button, Empty, Tooltip } from 'antd';
-import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, ApartmentOutlined, UnorderedListOutlined, FolderOpenOutlined, RightOutlined } from '@ant-design/icons';
+import { Button, Dropdown, Empty, Tooltip } from 'antd';
+import type { MenuProps } from 'antd';
+import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, ApartmentOutlined, UnorderedListOutlined, FolderOpenOutlined, RightOutlined, MoreOutlined } from '@ant-design/icons';
 import { useTheme } from '../hooks/useTheme';
 import { StatusPicker } from './StatusPicker';
 import * as db from '../utils/database';
@@ -36,6 +37,39 @@ function SkeletonList() {
 
 // 列表显示模式：flat 是当前的平铺模式；grouped 按项目目录把 todo 折叠成"文件夹"分组
 type ListDisplayMode = 'flat' | 'grouped';
+
+/**
+ * 构建桌面端头部高频导航按钮。
+ */
+function buildDesktopNavActions(
+  onShowDashboard: TodoListProps['onShowDashboard'],
+  onShowMemorial: TodoListProps['onShowMemorial'],
+  onShowRelationMap: TodoListProps['onShowRelationMap'],
+) {
+  return [
+    {
+      key: 'dashboard',
+      title: '仪表盘',
+      icon: <DashboardOutlined />,
+      onClick: onShowDashboard,
+      ariaLabel: '查看仪表盘',
+    },
+    {
+      key: 'memorial',
+      title: '看板',
+      icon: <ReadOutlined />,
+      onClick: () => onShowMemorial?.(),
+      ariaLabel: '看板',
+    },
+    {
+      key: 'relation-map',
+      title: '关联图',
+      icon: <ApartmentOutlined />,
+      onClick: () => onShowRelationMap?.(),
+      ariaLabel: '关联图',
+    },
+  ].filter(action => typeof action.onClick === 'function');
+}
 
 export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, onShowDashboard, onShowMemorial, onShowRelationMap, onShowSettings }: TodoListProps) {
   const { state, dispatch } = useApp();
@@ -117,6 +151,49 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
       // ignore: interceptor already shows error
     }
   }, [dispatch]);
+
+  const desktopNavActions = useMemo(
+    () => buildDesktopNavActions(onShowDashboard, onShowMemorial, onShowRelationMap),
+    [onShowDashboard, onShowMemorial, onShowRelationMap],
+  );
+
+  /**
+   * 处理桌面端头部“更多”菜单点击。
+   */
+  const handleHeaderMenuClick = useCallback<NonNullable<MenuProps['onClick']>>(({ key }) => {
+    if (key === 'display-mode') {
+      setDisplayMode(prev => (prev === 'flat' ? 'grouped' : 'flat'));
+      return;
+    }
+    if (key === 'theme') {
+      toggleTheme();
+      return;
+    }
+    if (key === 'settings') {
+      onShowSettings?.();
+    }
+  }, [onShowSettings, toggleTheme]);
+
+  const headerMenuItems = useMemo<MenuProps['items']>(() => ([
+    {
+      key: 'display-mode',
+      icon: displayMode === 'flat' ? <FolderOpenOutlined /> : <UnorderedListOutlined />,
+      label: displayMode === 'flat' ? '切换为按项目分组' : '切换为平铺列表',
+    },
+    {
+      key: 'theme',
+      icon: themeMode === 'light' ? <MoonOutlined /> : <SunOutlined />,
+      label: themeMode === 'light' ? '切换暗色主题' : '切换亮色主题',
+    },
+    {
+      type: 'divider',
+    },
+    {
+      key: 'settings',
+      icon: <SettingOutlined />,
+      label: '配置管理',
+    },
+  ]), [displayMode, themeMode]);
 
   const tagMap = useMemo(() => {
     const map = new Map<number, typeof tags[0]>();
@@ -237,73 +314,48 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
         {/* NTD Logo */}
         <div className="ntd-logo" aria-label="NTD Logo">NTD</div>
         <div className="header-actions">
-          <Button
-            type="text"
-            size="small"
-            icon={<DashboardOutlined />}
-            onClick={onShowDashboard}
-            className="tag-btn"
-            aria-label="查看仪表盘"
-          />
-          <Tooltip title="看板">
-            <Button
-              type="text"
-              size="small"
-              icon={<ReadOutlined />}
-              onClick={() => onShowMemorial?.()}
-              className="tag-btn"
-              aria-label="看板"
-            />
-          </Tooltip>
-          <Tooltip title="关联图">
-            <Button
-              type="text"
-              size="small"
-              icon={<ApartmentOutlined />}
-              onClick={() => onShowRelationMap?.()}
-              className="tag-btn"
-              aria-label="关联图"
-            />
-          </Tooltip>
-          {/* 列表显示模式切换：图标上区分平铺 vs 项目分组；选中态给个浅色高亮 */}
-          <Tooltip title={displayMode === 'flat' ? '切换为按项目分组' : '切换为平铺列表'}>
-            <Button
-              type="text"
-              size="small"
-              icon={displayMode === 'flat' ? <UnorderedListOutlined /> : <FolderOpenOutlined />}
-              onClick={() => setDisplayMode(prev => (prev === 'flat' ? 'grouped' : 'flat'))}
-              className={`tag-btn ${displayMode === 'grouped' ? 'active' : ''}`}
-              aria-label="切换列表显示模式"
-              aria-pressed={displayMode === 'grouped'}
-            />
-          </Tooltip>
-          <Tooltip title={themeMode === 'light' ? '切换暗色主题' : '切换亮色主题'}>
-            <Button
-              type="text"
-              size="small"
-              icon={themeMode === 'light' ? <MoonOutlined /> : <SunOutlined />}
-              onClick={toggleTheme}
-              className="tag-btn"
-              aria-label="切换主题"
-            />
-          </Tooltip>
-          <Button
-            type="text"
-            size="small"
-            icon={<SettingOutlined />}
-            onClick={onShowSettings}
-            className="tag-btn"
-            aria-label="配置管理"
-          />
+          <div className="header-toolbar">
+            {!isMobile && desktopNavActions.length > 0 && (
+              <div className="header-nav-cluster" aria-label="主导航">
+                {desktopNavActions.map(action => (
+                  <Tooltip key={action.key} title={action.title}>
+                    <Button
+                      type="text"
+                      size="small"
+                      icon={action.icon}
+                      onClick={action.onClick}
+                      className="header-nav-btn"
+                      aria-label={action.ariaLabel}
+                    />
+                  </Tooltip>
+                ))}
+              </div>
+            )}
+
+            {!isMobile && (
+              <Dropdown
+                menu={{ items: headerMenuItems, onClick: handleHeaderMenuClick }}
+                trigger={['click']}
+                placement="bottomRight"
+              >
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<MoreOutlined />}
+                  className="header-overflow-btn"
+                  aria-label="更多操作"
+                />
+              </Dropdown>
+            )}
+
           {!isMobile && (
-            <>
-              <span className="header-actions-divider" />
+            <div className="header-quick-actions">
               <Tooltip title="智能新建">
                 <Button
                   type="text"
                   size="small"
                   icon={<ThunderboltOutlined />}
-                  className="smart-create-btn"
+                  className="header-primary-action header-primary-action-smart"
                   onClick={onOpenSmartCreate}
                   aria-label="智能新建"
                 />
@@ -313,13 +365,48 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
                   type="text"
                   size="small"
                   icon={<PlusOutlined />}
-                  className="create-btn"
+                  className="header-primary-action header-primary-action-create"
                   onClick={onOpenCreateModal}
                   aria-label="新建任务"
                 />
               </Tooltip>
+            </div>
+          )}
+
+          {isMobile && (
+            <>
+              <Tooltip title={displayMode === 'flat' ? '切换为按项目分组' : '切换为平铺列表'}>
+                <Button
+                  type="text"
+                  size="small"
+                  icon={displayMode === 'flat' ? <UnorderedListOutlined /> : <FolderOpenOutlined />}
+                  onClick={() => setDisplayMode(prev => (prev === 'flat' ? 'grouped' : 'flat'))}
+                  className="header-nav-btn"
+                  aria-label="切换列表显示模式"
+                  aria-pressed={displayMode === 'grouped'}
+                />
+              </Tooltip>
+              <Tooltip title={themeMode === 'light' ? '切换暗色主题' : '切换亮色主题'}>
+                <Button
+                  type="text"
+                  size="small"
+                  icon={themeMode === 'light' ? <MoonOutlined /> : <SunOutlined />}
+                  onClick={toggleTheme}
+                  className="header-nav-btn"
+                  aria-label="切换主题"
+                />
+              </Tooltip>
+              <Button
+                type="text"
+                size="small"
+                icon={<SettingOutlined />}
+                onClick={onShowSettings}
+                className="header-nav-btn"
+                aria-label="配置管理"
+              />
             </>
           )}
+          </div>
         </div>
       </div>
 

--- a/frontend/src/components/settings/AboutPanel.tsx
+++ b/frontend/src/components/settings/AboutPanel.tsx
@@ -20,6 +20,11 @@ interface UpgradeResult {
   restartMessage?: string;
 }
 
+const UPGRADE_STEPS = [
+  { step: '步骤 1', label: '升级 npm 包', code: 'npm install -g @weibaohui/nothing-todo@latest' },
+  { step: '步骤 2', label: '重启服务', code: 'ntd daemon restart' },
+];
+
 /**
  * 渲染更新确认弹窗的内容区域。
  */
@@ -34,25 +39,17 @@ function renderUpgradeConfirmContent() {
       </div>
 
       <div className="update-confirm-modal__command-list">
-        <div className="update-confirm-modal__command-card">
-          <div className="update-confirm-modal__command-header">
-            <span className="update-confirm-modal__command-step">步骤 1</span>
-            <span className="update-confirm-modal__command-label">升级 npm 包</span>
+        {UPGRADE_STEPS.map(({ step, label, code }) => (
+          <div key={step} className="update-confirm-modal__command-card">
+            <div className="update-confirm-modal__command-header">
+              <span className="update-confirm-modal__command-step">{step}</span>
+              <span className="update-confirm-modal__command-label">{label}</span>
+            </div>
+            <code className="update-confirm-modal__command-code">
+              {code}
+            </code>
           </div>
-          <code className="update-confirm-modal__command-code">
-            npm install -g @weibaohui/nothing-todo@latest
-          </code>
-        </div>
-
-        <div className="update-confirm-modal__command-card">
-          <div className="update-confirm-modal__command-header">
-            <span className="update-confirm-modal__command-step">步骤 2</span>
-            <span className="update-confirm-modal__command-label">重启服务</span>
-          </div>
-          <code className="update-confirm-modal__command-code">
-            ntd daemon restart
-          </code>
-        </div>
+        ))}
       </div>
 
       <Paragraph className="update-confirm-modal__note" type="secondary">

--- a/frontend/src/components/settings/AboutPanel.tsx
+++ b/frontend/src/components/settings/AboutPanel.tsx
@@ -20,6 +20,48 @@ interface UpgradeResult {
   restartMessage?: string;
 }
 
+/**
+ * 渲染更新确认弹窗的内容区域。
+ */
+function renderUpgradeConfirmContent() {
+  return (
+    <div className="update-confirm-modal__content">
+      <div className="update-confirm-modal__hero">
+        <div className="update-confirm-modal__eyebrow">桌面端一键更新</div>
+        <div className="update-confirm-modal__hero-text">
+          将执行以下命令完成更新，并在结束后自动重启服务。
+        </div>
+      </div>
+
+      <div className="update-confirm-modal__command-list">
+        <div className="update-confirm-modal__command-card">
+          <div className="update-confirm-modal__command-header">
+            <span className="update-confirm-modal__command-step">步骤 1</span>
+            <span className="update-confirm-modal__command-label">升级 npm 包</span>
+          </div>
+          <code className="update-confirm-modal__command-code">
+            npm install -g @weibaohui/nothing-todo@latest
+          </code>
+        </div>
+
+        <div className="update-confirm-modal__command-card">
+          <div className="update-confirm-modal__command-header">
+            <span className="update-confirm-modal__command-step">步骤 2</span>
+            <span className="update-confirm-modal__command-label">重启服务</span>
+          </div>
+          <code className="update-confirm-modal__command-code">
+            ntd daemon restart
+          </code>
+        </div>
+      </div>
+
+      <Paragraph className="update-confirm-modal__note" type="secondary">
+        更新完成后服务将自动重启，请稍后刷新页面。
+      </Paragraph>
+    </div>
+  );
+}
+
 export function AboutPanel() {
   const [versionInfo, setVersionInfo] = useState<{ version: string; git_sha: string; git_describe: string } | null>(null);
   const [versionLoading, setVersionLoading] = useState(false);
@@ -99,26 +141,17 @@ export function AboutPanel() {
 
     // 弹出确认框，显示将要执行的命令
     Modal.confirm({
-      title: '确认执行以下命令',
-      icon: <ExclamationCircleFilled style={{ color: '#faad14' }} />,
-      content: (
-        <div style={{ marginTop: 12 }}>
-          <Paragraph>即将执行以下命令完成更新：</Paragraph>
-          <div style={{ background: '#f5f5f5', padding: 12, borderRadius: 4, fontFamily: 'monospace' }}>
-            <div style={{ marginBottom: 8 }}>
-              <strong>1. 升级 npm 包：</strong><br />
-              <code style={{ color: '#d46b08' }}>npm install -g @weibaohui/nothing-todo@latest</code>
-            </div>
-            <div>
-              <strong>2. 重启服务：</strong><br />
-              <code style={{ color: '#d46b08' }}>ntd daemon restart</code>
-            </div>
-          </div>
-          <Paragraph type="secondary" style={{ marginTop: 12, marginBottom: 0 }}>
-            更新完成后服务将自动重启，请稍后刷新页面。
-          </Paragraph>
+      className: 'update-confirm-modal',
+      rootClassName: 'update-confirm-modal',
+      width: 560,
+      title: (
+        <div className="update-confirm-modal__title-group">
+          <div className="update-confirm-modal__title">确认执行更新</div>
+          <div className="update-confirm-modal__subtitle">将按以下步骤升级当前 NTD 服务</div>
         </div>
       ),
+      icon: <ExclamationCircleFilled className="update-confirm-modal__icon" />,
+      content: renderUpgradeConfirmContent(),
       okText: '执行更新',
       cancelText: '取消',
       onOk: async () => {


### PR DESCRIPTION
## 变更内容
- 优化 PC 端暗黑主题下的更新确认弹窗样式，重构命令展示与操作层次
- 重构首页左上角头部导航，改为高频入口直达 + 更多菜单收纳，缓解按钮过多导致的排版拥挤
- 为头部主操作补充更清晰的视觉层级，保留智能新建与新建任务的主按钮识别度

## 验证
- 使用 Playwright 验证暗黑主题下更新确认弹窗可以正常打开并应用新样式
- 使用 Playwright 验证首页头部导航在桌面端不再横向溢出，布局收纳生效
- 使用 GetDiagnostics 检查本次修改文件，无新增 TS 报错
