### PR TITLE
feat: make executor timeout configurable

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -17,6 +17,8 @@ pub const DEFAULT_DEV_PORT: u16 = 18088;
 pub const DEFAULT_HOST: &str = "0.0.0.0";
 /// Default executor paths (binary names).
 pub const DEFAULT_EXECUTOR_PATH: &str = ""; // use binary name directly
+/// 默认执行超时时间（秒）。
+pub const DEFAULT_EXECUTION_TIMEOUT_SECS: u64 = 3600;
 
 /// Top-level configuration, persisted to `~/.ntd/config.yaml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -57,7 +59,7 @@ pub struct Config {
     pub history_message_max_age_secs: u64,
     /// 最大并发执行数（默认 3）
     pub max_concurrent_todos: u32,
-    /// 执行超时时间（秒，默认 3600 = 60 分钟），超过此时间将自动终止进程
+    /// 执行超时时间（秒，默认 3600 = 60 分钟）；设置为 0 表示不限制执行时长
     pub execution_timeout_secs: u64,
     /// 日志清理保留天数（None 表示不清理）
     pub auto_cleanup_logs_days: Option<usize>,
@@ -177,7 +179,7 @@ impl Default for Config {
             default_response_todo_id: None,
             history_message_max_age_secs: 600,
             max_concurrent_todos: 3,
-            execution_timeout_secs: 3600,
+            execution_timeout_secs: DEFAULT_EXECUTION_TIMEOUT_SECS,
             auto_cleanup_logs_days: Some(30),
             auto_skill_backup_enabled: false,
             auto_skill_backup_cron: "0 0 5 * * *".to_string(),
@@ -320,6 +322,12 @@ mod tests {
     fn test_server_url() {
         let cfg = Config { port: 9090, ..Default::default() };
         assert_eq!(cfg.server_url(), "http://localhost:9090");
+    }
+
+    #[test]
+    fn test_default_execution_timeout() {
+        let cfg = Config::default();
+        assert_eq!(cfg.execution_timeout_secs, DEFAULT_EXECUTION_TIMEOUT_SECS);
     }
 
     #[test]

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -706,6 +706,12 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
             }
         });
 
+        let timeout_duration = std::time::Duration::from_secs(execution_timeout_secs.max(1));
+        let timeout_enabled = execution_timeout_secs > 0;
+        let timeout_mins = execution_timeout_secs / 60;
+        let timeout_sleep = tokio::time::sleep(timeout_duration);
+        tokio::pin!(timeout_sleep);
+
         let status = tokio::select! {
             biased;
             _ = cancel_rx.recv() => {
@@ -752,10 +758,10 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                 task_manager_spawn.remove(&task_id).await;
                 return;
             }
-            _ = tokio::time::sleep(std::time::Duration::from_secs(execution_timeout_secs)) => {
+            _ = &mut timeout_sleep, if timeout_enabled => {
                 // Timeout: 自动终止执行时间过长的进程，释放资源
                 tracing::warn!(
-                    "Execution timeout reached ({}s) for todo {} (task {}), killing process",
+                    "执行超时，开始终止进程：超时时间={}秒，todo_id={}，task_id={}",
                     execution_timeout_secs, todo_id, task_id
                 );
                 kill_process_tree(&mut child).await;
@@ -791,10 +797,9 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                     model: None,
                 }).await;
 
-                let entry = ParsedLogEntry::error("Execution timeout - process was automatically terminated");
+                let entry = ParsedLogEntry::error("执行超时，进程已被系统自动终止");
                 send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
-                let timeout_mins = execution_timeout_secs / 60;
-                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: Some(format!("Execution timed out after {} minutes", timeout_mins)) });
+                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: Some(format!("执行超时，已超过 {} 分钟", timeout_mins)) });
                 task_manager_spawn.remove(&task_id).await;
                 return;
             }

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -4,6 +4,16 @@ use crate::config::Config;
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::{ApiResponse, UpdateConfigRequest};
 
+/// 校验执行超时配置，允许 0 表示不限制执行时长，其余值至少为 60 秒。
+fn validate_execution_timeout_secs(execution_timeout_secs: u64) -> Result<(), AppError> {
+    if execution_timeout_secs != 0 && execution_timeout_secs < 60 {
+        return Err(AppError::BadRequest(
+            "execution_timeout_secs must be 0 or at least 60".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 pub async fn get_config(State(state): State<AppState>) -> Result<ApiResponse<Config>, AppError> {
     let cfg = state.config.read().await.clone();
     Ok(ApiResponse::ok(cfg))
@@ -43,9 +53,7 @@ pub async fn update_config(
         cfg.max_concurrent_todos = max_concurrent_todos;
     }
     if let Some(execution_timeout_secs) = req.execution_timeout_secs {
-        if execution_timeout_secs < 60 {
-            return Err(AppError::BadRequest("execution_timeout_secs must be at least 60".to_string()));
-        }
+        validate_execution_timeout_secs(execution_timeout_secs)?;
         cfg.execution_timeout_secs = execution_timeout_secs;
     }
     if let Some(scheduler_default_timezone) = req.scheduler_default_timezone {
@@ -66,4 +74,24 @@ pub async fn update_config(
         .map_err(|e| AppError::Internal(format!("Failed to save config: {}", e)))?;
 
     Ok(ApiResponse::ok(cfg.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_execution_timeout_secs;
+
+    #[test]
+    fn test_validate_execution_timeout_accepts_zero() {
+        assert!(validate_execution_timeout_secs(0).is_ok());
+    }
+
+    #[test]
+    fn test_validate_execution_timeout_rejects_small_positive_value() {
+        assert!(validate_execution_timeout_secs(59).is_err());
+    }
+
+    #[test]
+    fn test_validate_execution_timeout_accepts_minimum_positive_value() {
+        assert!(validate_execution_timeout_secs(60).is_ok());
+    }
 }

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -33,10 +33,13 @@ import { TemplatesPanel } from './settings/TemplatesPanel';
 import { AboutPanel } from './settings/AboutPanel';
 import { CloudSyncPanel } from './settings/CloudSyncPanel';
 
+const DEFAULT_EXECUTION_TIMEOUT_SECS = 3600;
+
 interface SettingsPageProps {
   onBack?: () => void;
 }
 
+/** 设置页，负责加载并保存系统配置以及各类管理面板。 */
 export function SettingsPage({ onBack }: SettingsPageProps) {
   const { state, dispatch } = useApp();
   const { tags } = state;
@@ -86,6 +89,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       .finally(() => setExecutorsLoading(false));
   }, []);
 
+  /** 汇总表单值并保存当前系统配置。 */
   const handleSaveConfig = async () => {
     try {
       const values = await configForm.validateFields();
@@ -122,7 +126,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
         ...currentConfig,
         ...(values as Partial<Config>),
         max_concurrent_todos: configForm.getFieldValue('max_concurrent_todos') ?? currentConfig.max_concurrent_todos ?? 3,
-        execution_timeout_secs: configForm.getFieldValue('execution_timeout_secs') ?? currentConfig.execution_timeout_secs ?? 1800,
+        execution_timeout_secs: configForm.getFieldValue('execution_timeout_secs') ?? currentConfig.execution_timeout_secs ?? DEFAULT_EXECUTION_TIMEOUT_SECS,
         slash_command_rules: hasSlashRulesField
           ? normalizedRules
           : (currentConfig.slash_command_rules ?? []),

--- a/frontend/src/components/settings/RuntimePanel.tsx
+++ b/frontend/src/components/settings/RuntimePanel.tsx
@@ -1,10 +1,13 @@
-import { useState, useEffect } from 'react';
-import { Card, InputNumber, Tooltip, Button, Popconfirm, Table, Empty, message } from 'antd';
+import { useState, useEffect, useRef } from 'react';
+import { Card, InputNumber, Tooltip, Button, Popconfirm, Table, Empty, Switch, message } from 'antd';
 import { InfoCircleOutlined, SaveOutlined, StopOutlined, ReloadOutlined } from '@ant-design/icons';
 import { useApp } from '@/hooks/useApp';
 import * as db from '@/utils/database';
 import type { ExecutionRecord } from '@/types';
 
+const DEFAULT_EXECUTION_TIMEOUT_SECS = 3600;
+
+/** 运行管理面板，负责展示执行并发、超时配置以及运行中任务操作。 */
 export function RuntimePanel({ configForm, configSaving, handleSaveConfig, executorDisplayNames }: {
   configForm: any;
   configSaving: boolean;
@@ -16,13 +19,21 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
   const [selectedRecordIds, setSelectedRecordIds] = useState<number[]>([]);
   const [stoppingRecords, setStoppingRecords] = useState(false);
   const [runningRecords, setRunningRecords] = useState<ExecutionRecord[]>([]);
+  const lastEnabledExecutionTimeoutSecsRef = useRef(DEFAULT_EXECUTION_TIMEOUT_SECS);
+  const formExecutionTimeoutSecs = configForm.getFieldValue('execution_timeout_secs') ?? DEFAULT_EXECUTION_TIMEOUT_SECS;
+  const [executionTimeoutSecs, setExecutionTimeoutSecs] = useState<number>(formExecutionTimeoutSecs);
+  const executionTimeoutEnabled = executionTimeoutSecs !== 0;
+  const executionTimeoutMinutes = executionTimeoutEnabled
+    ? Math.max(1, Math.round(executionTimeoutSecs / 60))
+    : undefined;
 
+  /** 加载当前运行中的执行记录。 */
   const loadRunningRecords = async () => {
     try {
       const records = await db.getRunningExecutionRecords();
       setRunningRecords(records);
     } catch (err) {
-      console.error('Failed to load running records:', err);
+      console.error('加载运行中任务失败:', err);
     }
   };
 
@@ -32,6 +43,17 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
     return () => clearInterval(timer);
   }, []);
 
+  useEffect(() => {
+    if (executionTimeoutEnabled) {
+      lastEnabledExecutionTimeoutSecsRef.current = executionTimeoutSecs;
+    }
+  }, [executionTimeoutEnabled, executionTimeoutSecs]);
+
+  useEffect(() => {
+    setExecutionTimeoutSecs(formExecutionTimeoutSecs);
+  }, [formExecutionTimeoutSecs]);
+
+  /** 批量停止当前选中的执行任务。 */
   const handleBatchStop = async () => {
     if (selectedRecordIds.length === 0) return;
     setStoppingRecords(true);
@@ -47,6 +69,15 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
     if (successCount > 0) message.success(`已停止 ${successCount} 个任务`);
     if (failCount > 0) message.error(`${failCount} 个任务停止失败`);
     loadRunningRecords();
+  };
+
+  /** 切换是否启用执行超时控制。 */
+  const handleExecutionTimeoutToggle = (checked: boolean) => {
+    const nextExecutionTimeoutSecs = checked ? lastEnabledExecutionTimeoutSecsRef.current : 0;
+    setExecutionTimeoutSecs(nextExecutionTimeoutSecs);
+    configForm.setFieldsValue({
+      execution_timeout_secs: nextExecutionTimeoutSecs,
+    });
   };
 
   return (
@@ -76,20 +107,30 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
             </Tooltip>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>超时时间(分钟)</span>
+            <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>执行超时</span>
+            <Switch
+              size="small"
+              checked={executionTimeoutEnabled}
+              checkedChildren="开启"
+              unCheckedChildren="关闭"
+              onChange={handleExecutionTimeoutToggle}
+            />
             <InputNumber
               size="small"
               min={1}
               max={1440}
               style={{ width: 80 }}
-              value={Math.round((configForm.getFieldValue('execution_timeout_secs') ?? 1800) / 60)}
+              disabled={!executionTimeoutEnabled}
+              value={executionTimeoutMinutes}
               onChange={(v) => {
                 if (v) {
+                  setExecutionTimeoutSecs(v * 60);
                   configForm.setFieldsValue({ execution_timeout_secs: v * 60 });
                 }
               }}
             />
-            <Tooltip title="单个对话执行的最大时长，超时将自动终止">
+            <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>分钟</span>
+            <Tooltip title="单个执行任务的最大时长；关闭后不再因超时自动终止">
               <InfoCircleOutlined style={{ color: 'var(--color-text-quaternary)', fontSize: 12 }} />
             </Tooltip>
           </div>


### PR DESCRIPTION
## 背景
- 执行器存在 60 分钟超时限制，需要确认来源并提供可配置选项
- 运行管理页原有超时配置默认值与后端不一致，且新增开关后存在前端状态刷新延迟

## 变更
- 后端支持将 `execution_timeout_secs=0` 作为关闭超时限制
- 统一执行超时默认值为 3600 秒，并补充相关校验与测试
- 运行管理页将超时配置改为开关 + 分钟输入
- 修复执行超时开关点击后 UI 不立即刷新的问题
- 调整执行超时相关日志与提示文案为中文

## 验证
- `cd frontend && npm run build`
- `cd backend && cargo test execution_timeout`
