### PR TITLE
fix: address execution timeout config issues

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -216,16 +216,13 @@ impl Config {
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent).ok();
             }
-            // Reuse the already-normalized cfg for saving to disk (no need to re-clone and re-normalize)
-            let mut cfg_for_save = cfg.clone();
-            cfg_for_save.normalize_paths();
-            cfg_for_save.clamp_execution_timeout_secs();
+            // Clone the already-normalized and clamped cfg for serialization to disk
+            let cfg_for_save = cfg.clone();
             if let Ok(yaml) = serde_yaml::to_string(&cfg_for_save) {
                 if let Err(e) = std::fs::write(&path, yaml) {
                     eprintln!("Warning: failed to write config file ({}), using in-memory defaults", e);
                 }
             }
-            // cfg_for_save was already normalized/clamped above; cfg is already in good state
             return cfg;
         }
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -212,17 +212,20 @@ impl Config {
                 Config::default()
             };
             cfg.normalize_paths();
+            cfg.clamp_execution_timeout_secs();
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent).ok();
             }
+            // Reuse the already-normalized cfg for saving to disk (no need to re-clone and re-normalize)
             let mut cfg_for_save = cfg.clone();
             cfg_for_save.normalize_paths();
+            cfg_for_save.clamp_execution_timeout_secs();
             if let Ok(yaml) = serde_yaml::to_string(&cfg_for_save) {
                 if let Err(e) = std::fs::write(&path, yaml) {
                     eprintln!("Warning: failed to write config file ({}), using in-memory defaults", e);
                 }
             }
-            cfg.normalize_paths();
+            // cfg_for_save was already normalized/clamped above; cfg is already in good state
             return cfg;
         }
 
@@ -233,20 +236,20 @@ impl Config {
                     Config::default()
                 });
                 cfg.normalize_paths();
+                cfg.clamp_execution_timeout_secs();
                 cfg
             }
             Err(e) => {
                 eprintln!("Warning: failed to read config file ({}), using defaults", e);
                 let mut cfg = Config::default();
                 cfg.normalize_paths();
+                cfg.clamp_execution_timeout_secs();
                 cfg
             }
         }
     }
 
-    /// Normalize paths and clamp execution_timeout_secs to valid range.
-    /// This is called both on fresh load (Config::load) and after HTTP updates (update_config).
-    /// YAML edits bypass HTTP validation, so we enforce here to prevent out-of-range values in config.yaml.
+    /// Normalize paths: expand ~ and relative paths to absolute paths.
     pub fn normalize_paths(&mut self) {
         self.db_path = Self::normalize_single_path(&self.db_path);
         // Normalize executor paths
@@ -254,7 +257,23 @@ impl Config {
             .map(|(k, v)| (k.clone(), Self::normalize_single_path(v)))
             .collect();
         self.executors.paths = normalized;
-        // Clamp execution_timeout_secs: 0 (disabled) always valid; 1-59s -> 60s (min); >MAX -> MAX.
+    }
+
+    /// Clamp execution_timeout_secs to the valid range [60, MAX_EXECUTION_TIMEOUT_SECS].
+    ///
+    /// **Why this is needed**: HTTP `update_config` validates the timeout via
+    /// `validate_execution_timeout_secs`, but users can bypass that by editing
+    /// `~/.ntd/config.yaml` directly.  `normalize_paths` / `normalize` is called after
+    /// both fresh YAML load and HTTP updates, so this is the single enforcement point
+    /// for YAML-level edits.
+    ///
+    /// **Boundary rationale**:
+    /// - `0`: allowed — means "no timeout" (matches `timeout_enabled = v > 0` in executor_service)
+    /// - `1-59`: raised to 60 — sub-minute timeouts are impractical (process startup
+    ///   overhead alone can exceed 30s) and risk killing normal long-running tasks
+    /// - `>MAX`: truncated — values in the hundreds of days indicate config errors;
+    ///   capping prevents long-running tasks from indefinitely occupying task slots
+    pub fn clamp_execution_timeout_secs(&mut self) {
         if self.execution_timeout_secs != 0 && self.execution_timeout_secs < 60 {
             self.execution_timeout_secs = 60;
         } else if self.execution_timeout_secs > MAX_EXECUTION_TIMEOUT_SECS {
@@ -406,5 +425,57 @@ mod tests {
         let yaml = serde_yaml::to_string(&cfg).unwrap();
         let restored: Config = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(restored.slash_command_rules, cfg.slash_command_rules);
+    }
+
+    // ---------------------------------------------------------------------------
+    // clamp_execution_timeout_secs tests (YAML bypass safety net)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_clamp_preserves_zero() {
+        // 0 = "disabled", must pass through unchanged
+        let mut cfg = Config { execution_timeout_secs: 0, ..Default::default() };
+        cfg.clamp_execution_timeout_secs();
+        assert_eq!(cfg.execution_timeout_secs, 0);
+    }
+
+    #[test]
+    fn test_clamp_raises_sub_minute_to_60() {
+        // 1-59s is invalid; normalize should raise to 60
+        let mut cfg = Config { execution_timeout_secs: 30, ..Default::default() };
+        cfg.clamp_execution_timeout_secs();
+        assert_eq!(cfg.execution_timeout_secs, 60);
+    }
+
+    #[test]
+    fn test_clamp_truncates_above_max() {
+        // >MAX should be truncated to MAX
+        let mut cfg = Config { execution_timeout_secs: MAX_EXECUTION_TIMEOUT_SECS + 1, ..Default::default() };
+        cfg.clamp_execution_timeout_secs();
+        assert_eq!(cfg.execution_timeout_secs, MAX_EXECUTION_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn test_clamp_preserves_in_range_value() {
+        // A valid in-range value must not be modified
+        let mut cfg = Config { execution_timeout_secs: 3600, ..Default::default() };
+        cfg.clamp_execution_timeout_secs();
+        assert_eq!(cfg.execution_timeout_secs, 3600);
+    }
+
+    #[test]
+    fn test_clamp_at_minimum_boundary() {
+        // Exactly 60s (1 min) is valid
+        let mut cfg = Config { execution_timeout_secs: 60, ..Default::default() };
+        cfg.clamp_execution_timeout_secs();
+        assert_eq!(cfg.execution_timeout_secs, 60);
+    }
+
+    #[test]
+    fn test_clamp_at_maximum_boundary() {
+        // Exactly MAX is valid
+        let mut cfg = Config { execution_timeout_secs: MAX_EXECUTION_TIMEOUT_SECS, ..Default::default() };
+        cfg.clamp_execution_timeout_secs();
+        assert_eq!(cfg.execution_timeout_secs, MAX_EXECUTION_TIMEOUT_SECS);
     }
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -19,6 +19,8 @@ pub const DEFAULT_HOST: &str = "0.0.0.0";
 pub const DEFAULT_EXECUTOR_PATH: &str = ""; // use binary name directly
 /// 默认执行超时时间（秒）。
 pub const DEFAULT_EXECUTION_TIMEOUT_SECS: u64 = 3600;
+/// 执行超时上限（秒）：7 天。YAML 加载和 HTTP update 均受此约束。
+pub const MAX_EXECUTION_TIMEOUT_SECS: u64 = 604800;
 
 /// Top-level configuration, persisted to `~/.ntd/config.yaml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,7 +61,7 @@ pub struct Config {
     pub history_message_max_age_secs: u64,
     /// 最大并发执行数（默认 3）
     pub max_concurrent_todos: u32,
-    /// 执行超时时间（秒，默认 3600 = 60 分钟）；设置为 0 表示不限制执行时长
+    /// 执行超时时间（秒，默认 3600 = 60 分钟）；设置为 0 表示不限制执行时长；上限 604800（7 天）
     pub execution_timeout_secs: u64,
     /// 日志清理保留天数（None 表示不清理）
     pub auto_cleanup_logs_days: Option<usize>,
@@ -242,7 +244,9 @@ impl Config {
         }
     }
 
-    /// Normalize paths: convert ~ and relative paths to absolute paths.
+    /// Normalize paths and clamp execution_timeout_secs to valid range.
+    /// This is called both on fresh load (Config::load) and after HTTP updates (update_config).
+    /// YAML edits bypass HTTP validation, so we enforce here to prevent out-of-range values in config.yaml.
     pub fn normalize_paths(&mut self) {
         self.db_path = Self::normalize_single_path(&self.db_path);
         // Normalize executor paths
@@ -250,6 +254,10 @@ impl Config {
             .map(|(k, v)| (k.clone(), Self::normalize_single_path(v)))
             .collect();
         self.executors.paths = normalized;
+        // Clamp execution_timeout_secs: 0 (disabled) is always valid; positive values capped at MAX.
+        if self.execution_timeout_secs != 0 && self.execution_timeout_secs > MAX_EXECUTION_TIMEOUT_SECS {
+            self.execution_timeout_secs = MAX_EXECUTION_TIMEOUT_SECS;
+        }
     }
 
     fn normalize_single_path(path: &str) -> String {

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -254,8 +254,10 @@ impl Config {
             .map(|(k, v)| (k.clone(), Self::normalize_single_path(v)))
             .collect();
         self.executors.paths = normalized;
-        // Clamp execution_timeout_secs: 0 (disabled) is always valid; positive values capped at MAX.
-        if self.execution_timeout_secs != 0 && self.execution_timeout_secs > MAX_EXECUTION_TIMEOUT_SECS {
+        // Clamp execution_timeout_secs: 0 (disabled) always valid; 1-59s -> 60s (min); >MAX -> MAX.
+        if self.execution_timeout_secs != 0 && self.execution_timeout_secs < 60 {
+            self.execution_timeout_secs = 60;
+        } else if self.execution_timeout_secs > MAX_EXECUTION_TIMEOUT_SECS {
             self.execution_timeout_secs = MAX_EXECUTION_TIMEOUT_SECS;
         }
     }

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -710,8 +710,10 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
         // task starts will NOT affect it (running tasks hold their own snapshot).  Users must
         // cancel and re-trigger a todo execution to pick up a new timeout value.
         let timeout_enabled = execution_timeout_secs > 0;
-        // Duration is only used when timeout_enabled; max(1) prevents Duration::ZERO panics
-        // if the guard is ever removed or bypassed.
+        // Duration is only used when timeout_enabled; max(1) guards against constructing
+        // Duration::ZERO in case the guard is accidentally removed in future refactors.
+        // Note: Duration::from_secs(0) does NOT panic — it returns Duration::ZERO — but
+        // tokio::time::sleep(Duration::ZERO) is a no-op, so we enforce a 1s minimum instead.
         let timeout_duration = std::time::Duration::from_secs(execution_timeout_secs.max(1));
         // 精确格式化超时提示：整数分钟直接显示"X 分钟"，非整数显示"X 分 Y 秒"
         let timeout_str = {
@@ -813,7 +815,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
 
                 let entry = ParsedLogEntry::error("Execution timeout, process terminated by system");
                 send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
-                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: Some(format!("执行超时，已超过 {}", timeout_str)) });
+                send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: Some(format!("Execution timeout, exceeded {}", timeout_str)) });
                 task_manager_spawn.remove(&task_id).await;
                 return;
             }

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -19,7 +19,7 @@ fn send_event(tx: &broadcast::Sender<ExecEvent>, event: ExecEvent) {
 /// command-group 会自动创建进程组，kill() 时会杀死整个进程组
 async fn kill_process_tree(child: &mut command_group::AsyncGroupChild) {
     if let Err(e) = child.kill().await {
-        tracing::warn!("杀死进程组失败: {}", e);
+        tracing::warn!("Failed to kill process group: {}", e);
     }
 }
 
@@ -706,8 +706,13 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
             }
         });
 
-        let timeout_duration = std::time::Duration::from_secs(execution_timeout_secs.max(1));
+        // execution_timeout_secs is captured by value here — changes to the config after this
+        // task starts will NOT affect it (running tasks hold their own snapshot).  Users must
+        // cancel and re-trigger a todo execution to pick up a new timeout value.
         let timeout_enabled = execution_timeout_secs > 0;
+        // Duration is only used when timeout_enabled; max(1) prevents Duration::ZERO panics
+        // if the guard is ever removed or bypassed.
+        let timeout_duration = std::time::Duration::from_secs(execution_timeout_secs.max(1));
         // 精确格式化超时提示：整数分钟直接显示"X 分钟"，非整数显示"X 分 Y 秒"
         let timeout_str = {
             let mins = execution_timeout_secs / 60;
@@ -770,7 +775,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
             _ = &mut timeout_sleep, if timeout_enabled => {
                 // Timeout: 自动终止执行时间过长的进程，释放资源
                 tracing::warn!(
-                    "执行超时，开始终止进程：超时时间={}秒，todo_id={}，task_id={}",
+                    "Execution timeout, terminating process: timeout={}s, todo_id={}, task_id={}",
                     execution_timeout_secs, todo_id, task_id
                 );
                 kill_process_tree(&mut child).await;
@@ -801,12 +806,12 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                     id: record_id,
                     status: crate::models::ExecutionStatus::Failed.as_str(),
                     remaining_logs: &logs_json,
-                    result: "执行超时",
+                    result: "Execution timeout",
                     usage: None,
                     model: None,
                 }).await;
 
-                let entry = ParsedLogEntry::error("执行超时，进程已被系统自动终止");
+                let entry = ParsedLogEntry::error("Execution timeout, process terminated by system");
                 send_event(&tx_clone, ExecEvent::Output { task_id: task_id.clone(), entry });
                 send_event(&tx_clone, ExecEvent::Finished { task_id: task_id.clone(), todo_id, todo_title: todo_title.clone(), executor: executor_spawn.executor_type().to_string(), success: false, result: Some(format!("执行超时，已超过 {}", timeout_str)) });
                 task_manager_spawn.remove(&task_id).await;

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -710,19 +710,23 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
         // task starts have no effect. To pick up a new timeout, wait for the current
         // execution to finish (or force-fail it via the UI).
         let timeout_enabled = execution_timeout_secs > 0;
-        // Duration is only used when timeout_enabled; max(1) guards against constructing
-        // Duration::ZERO in case the guard is accidentally removed in future refactors.
-        // Note: Duration::from_secs(0) does NOT panic — it returns Duration::ZERO — but
-        // tokio::time::sleep(Duration::ZERO) is a no-op, so we enforce a 1s minimum instead.
-        let timeout_duration = std::time::Duration::from_secs(execution_timeout_secs.max(1));
-        // Human-readable timeout string for display messages (always English to keep event output consistent).
+        // Non-zero values are guaranteed >= 60 by normalize_paths clamp, so from_secs is safe.
+        let timeout_duration = std::time::Duration::from_secs(execution_timeout_secs);
+        // Human-readable timeout string for display messages (always English).
+        // Uses hours for >=60 min, days for >=24 h to keep the output readable.
         let timeout_str = {
-            let mins = execution_timeout_secs / 60;
+            let total_min = execution_timeout_secs / 60;
             let secs = execution_timeout_secs % 60;
             if secs == 0 {
-                format!("{} min", mins)
+                if total_min >= 1440 {
+                    format!("{} day(s)", total_min / 1440)
+                } else if total_min >= 60 {
+                    format!("{} hour(s)", total_min / 60)
+                } else {
+                    format!("{} min", total_min)
+                }
             } else {
-                format!("{} min {} sec", mins, secs)
+                format!("{} min {} sec", total_min, secs)
             }
         };
         let timeout_sleep = tokio::time::sleep(timeout_duration);

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -706,23 +706,23 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
             }
         });
 
-        // execution_timeout_secs is captured by value here — changes to the config after this
-        // task starts will NOT affect it (running tasks hold their own snapshot).  Users must
-        // cancel and re-trigger a todo execution to pick up a new timeout value.
+        // execution_timeout_secs is captured by value here — config changes after this
+        // task starts have no effect. To pick up a new timeout, wait for the current
+        // execution to finish (or force-fail it via the UI).
         let timeout_enabled = execution_timeout_secs > 0;
         // Duration is only used when timeout_enabled; max(1) guards against constructing
         // Duration::ZERO in case the guard is accidentally removed in future refactors.
         // Note: Duration::from_secs(0) does NOT panic — it returns Duration::ZERO — but
         // tokio::time::sleep(Duration::ZERO) is a no-op, so we enforce a 1s minimum instead.
         let timeout_duration = std::time::Duration::from_secs(execution_timeout_secs.max(1));
-        // 精确格式化超时提示：整数分钟直接显示"X 分钟"，非整数显示"X 分 Y 秒"
+        // Human-readable timeout string for display messages (always English to keep event output consistent).
         let timeout_str = {
             let mins = execution_timeout_secs / 60;
             let secs = execution_timeout_secs % 60;
             if secs == 0 {
-                format!("{} 分钟", mins)
+                format!("{} min", mins)
             } else {
-                format!("{} 分 {} 秒", mins, secs)
+                format!("{} min {} sec", mins, secs)
             }
         };
         let timeout_sleep = tokio::time::sleep(timeout_duration);

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -377,6 +377,7 @@ pub async fn update_auto_backup(
         cfg.auto_backup_max_files = max_files;
     }
     cfg.normalize_paths();
+    cfg.clamp_execution_timeout_secs();
 
     let cfg_clone = cfg.clone();
     tokio::task::spawn_blocking(move || cfg_clone.save())
@@ -824,6 +825,7 @@ pub async fn update_todo_auto_backup(
         cfg.auto_todo_backup_max_files = max_files;
     }
     cfg.normalize_paths();
+    cfg.clamp_execution_timeout_secs();
 
     let cfg_clone = cfg.clone();
     tokio::task::spawn_blocking(move || cfg_clone.save())
@@ -1354,6 +1356,7 @@ pub async fn update_skill_auto_backup(
         cfg.auto_skill_backup_max_files = max_files;
     }
     cfg.normalize_paths();
+    cfg.clamp_execution_timeout_secs();
 
     let cfg_clone = cfg.clone();
     tokio::task::spawn_blocking(move || cfg_clone.save())

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -4,11 +4,17 @@ use crate::config::Config;
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::{ApiResponse, UpdateConfigRequest};
 
-/// 校验执行超时配置，允许 0 表示不限制执行时长，其余值至少为 60 秒。
+/// 校验执行超时配置，允许 0 表示不限制执行时长，其余值至少为 60 秒，最多 7 天。
 fn validate_execution_timeout_secs(execution_timeout_secs: u64) -> Result<(), AppError> {
+    const MAX_TIMEOUT_SECS: u64 = 604800; // 7 days
     if execution_timeout_secs != 0 && execution_timeout_secs < 60 {
         return Err(AppError::BadRequest(
             "execution_timeout_secs must be 0 or at least 60".to_string(),
+        ));
+    }
+    if execution_timeout_secs > MAX_TIMEOUT_SECS {
+        return Err(AppError::BadRequest(
+            format!("execution_timeout_secs must be at most {}", MAX_TIMEOUT_SECS),
         ));
     }
     Ok(())
@@ -93,5 +99,16 @@ mod tests {
     #[test]
     fn test_validate_execution_timeout_accepts_minimum_positive_value() {
         assert!(validate_execution_timeout_secs(60).is_ok());
+    }
+
+    #[test]
+    fn test_validate_execution_timeout_accepts_maximum_value() {
+        // 7 days in seconds
+        assert!(validate_execution_timeout_secs(604800).is_ok());
+    }
+
+    #[test]
+    fn test_validate_execution_timeout_rejects_exceeds_maximum() {
+        assert!(validate_execution_timeout_secs(604801).is_err());
     }
 }

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -6,15 +6,14 @@ use crate::models::{ApiResponse, UpdateConfigRequest};
 
 /// 校验执行超时配置，允许 0 表示不限制执行时长，其余值至少为 60 秒，最多 7 天。
 fn validate_execution_timeout_secs(execution_timeout_secs: u64) -> Result<(), AppError> {
-    const MAX_TIMEOUT_SECS: u64 = 604800; // 7 days
     if execution_timeout_secs != 0 && execution_timeout_secs < 60 {
         return Err(AppError::BadRequest(
             "execution_timeout_secs must be 0 or at least 60".to_string(),
         ));
     }
-    if execution_timeout_secs > MAX_TIMEOUT_SECS {
+    if execution_timeout_secs > crate::config::MAX_EXECUTION_TIMEOUT_SECS {
         return Err(AppError::BadRequest(
-            format!("execution_timeout_secs must be at most {}", MAX_TIMEOUT_SECS),
+            format!("execution_timeout_secs must be at most {}", crate::config::MAX_EXECUTION_TIMEOUT_SECS),
         ));
     }
     Ok(())
@@ -103,12 +102,11 @@ mod tests {
 
     #[test]
     fn test_validate_execution_timeout_accepts_maximum_value() {
-        // 7 days in seconds
-        assert!(validate_execution_timeout_secs(604800).is_ok());
+        assert!(validate_execution_timeout_secs(crate::config::MAX_EXECUTION_TIMEOUT_SECS).is_ok());
     }
 
     #[test]
     fn test_validate_execution_timeout_rejects_exceeds_maximum() {
-        assert!(validate_execution_timeout_secs(604801).is_err());
+        assert!(validate_execution_timeout_secs(crate::config::MAX_EXECUTION_TIMEOUT_SECS + 1).is_err());
     }
 }

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -71,6 +71,7 @@ pub async fn update_config(
     }
 
     cfg.normalize_paths();
+    cfg.clamp_execution_timeout_secs();
 
     let cfg_clone = cfg.clone();
     tokio::task::spawn_blocking(move || cfg_clone.save())

--- a/backend/src/handlers/usage_stats.rs
+++ b/backend/src/handlers/usage_stats.rs
@@ -131,6 +131,7 @@ pub async fn update_usage_stats_settings(
     cfg.auto_usage_stats_enabled = req.enabled;
     cfg.auto_usage_stats_cron = req.cron;
     cfg.normalize_paths();
+    cfg.clamp_execution_timeout_secs();
 
     let cfg_clone = cfg.clone();
     tokio::task::spawn_blocking(move || cfg_clone.save())

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -33,7 +33,7 @@ import { TemplatesPanel } from './settings/TemplatesPanel';
 import { AboutPanel } from './settings/AboutPanel';
 import { CloudSyncPanel } from './settings/CloudSyncPanel';
 
-const DEFAULT_EXECUTION_TIMEOUT_SECS = 3600;
+import { DEFAULT_EXECUTION_TIMEOUT_SECS } from '@/constants';
 
 interface SettingsPageProps {
   onBack?: () => void;

--- a/frontend/src/components/settings/RuntimePanel.tsx
+++ b/frontend/src/components/settings/RuntimePanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Card, InputNumber, Tooltip, Button, Popconfirm, Table, Empty, Switch, message } from 'antd';
+import { Card, InputNumber, Tooltip, Button, Popconfirm, Table, Empty, Switch, message, Form } from 'antd';
 import { InfoCircleOutlined, SaveOutlined, StopOutlined, ReloadOutlined } from '@ant-design/icons';
 import { useApp } from '@/hooks/useApp';
 import * as db from '@/utils/database';
@@ -19,21 +19,34 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
   const [selectedRecordIds, setSelectedRecordIds] = useState<number[]>([]);
   const [stoppingRecords, setStoppingRecords] = useState(false);
   const [runningRecords, setRunningRecords] = useState<ExecutionRecord[]>([]);
-  // 使用懒初始化避免表单未填充时读到默认值：初始化时若表单已有值则用表单的，否则用常量默认值。
-  // 后续通过 useEffect 同步表单值变化，保持 UI 与表单状态一致。
+
+  // 使用 Form.useWatch 订阅表单字段，直接响应 setFieldsValue 变化，
+  // 解决 async db.getConfig() 完成后的 setFieldsValue 不会触发 useEffect deps 的问题。
+  const watchedTimeoutSecs = Form.useWatch('execution_timeout_secs', configForm);
+
+  // executionTimeoutSecs 由 useWatch 驱动，undefined 时使用懒初始化默认值。
   const [executionTimeoutSecs, setExecutionTimeoutSecs] = useState<number>(() =>
-    configForm.getFieldValue('execution_timeout_secs') ?? DEFAULT_EXECUTION_TIMEOUT_SECS
+    watchedTimeoutSecs ?? DEFAULT_EXECUTION_TIMEOUT_SECS
   );
+
+  // 同步 useWatch 值到本地 state（仅在值真正变化时更新）。
+  // lastEnabledRef 同步记录非零值，供 toggle 恢复。
+  const lastEnabledExecutionTimeoutSecsRef = useRef<number>(DEFAULT_EXECUTION_TIMEOUT_SECS);
+  useEffect(() => {
+    if (watchedTimeoutSecs !== undefined && watchedTimeoutSecs !== executionTimeoutSecs) {
+      setExecutionTimeoutSecs(watchedTimeoutSecs);
+      if (watchedTimeoutSecs !== 0) {
+        lastEnabledExecutionTimeoutSecsRef.current = watchedTimeoutSecs;
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [watchedTimeoutSecs]);
+
   // 0 表示禁用执行超时（与后端 handlers/config.rs 中的校验对齐），其余值至少为 60 秒
   const executionTimeoutEnabled = executionTimeoutSecs !== 0;
   const executionTimeoutMinutes = executionTimeoutEnabled
     ? Math.max(1, Math.round(executionTimeoutSecs / 60))
     : undefined;
-  // 关闭时记录当前值，重新开启时恢复；避免再次开启时跳回初始默认值 3600。
-  // 仅在同步到表单非零值时更新，不响应外部加载（避免 0 覆盖用户上次的非零设置）。
-  const lastEnabledExecutionTimeoutSecsRef = useRef<number>(DEFAULT_EXECUTION_TIMEOUT_SECS);
-  // 记录上次从表单同步的值，消除对 executionTimeoutSecs deps 的依赖，避免多余 re-render。
-  const lastSyncedFormValueRef = useRef<number | undefined>(undefined);
 
   /** 加载当前运行中的执行记录。 */
   const loadRunningRecords = async () => {
@@ -51,22 +64,7 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
     return () => clearInterval(timer);
   }, []);
 
-  // 监听表单字段变化，同步本地状态并维护 lastEnabledRef。
-  // 仅依赖 configForm（稳定引用），通过 lastSyncedFormValueRef 检测表单值是否真正变化，
-  // 避免加入 executionTimeoutSecs 导致每次 setState 后都触发额外 render。
-  useEffect(() => {
-    const formValue = configForm.getFieldValue('execution_timeout_secs');
-    if (formValue !== undefined && formValue !== lastSyncedFormValueRef.current) {
-      lastSyncedFormValueRef.current = formValue;
-      setExecutionTimeoutSecs(formValue);
-      // 仅记录非零值，确保 toggle 重新开启时用正确的用户设置
-      if (formValue !== 0) {
-        lastEnabledExecutionTimeoutSecsRef.current = formValue;
-      }
-    }
-  }, [configForm]);
-
-  /** 批量停止当前选中的执行任务。 */
+  /** 批量停止当前选中的执行记录。 */
   const handleBatchStop = async () => {
     if (selectedRecordIds.length === 0) return;
     setStoppingRecords(true);
@@ -87,15 +85,13 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
   /** 切换是否启用执行超时控制。 */
   const handleExecutionTimeoutToggle = (checked: boolean) => {
     if (!checked) {
-      // 关闭时记录当前值，供后续重新开启时恢复。
-      // useEffect 仅在外部 setFieldsValue 时更新 ref，用户未保存的输入变化需要此处捕获。
+      // 关闭时记录当前非零值，供后续重新开启时恢复。
       lastEnabledExecutionTimeoutSecsRef.current = executionTimeoutSecs;
     }
-    const nextExecutionTimeoutSecs = checked ? lastEnabledExecutionTimeoutSecsRef.current : 0;
-    setExecutionTimeoutSecs(nextExecutionTimeoutSecs);
-    configForm.setFieldsValue({
-      execution_timeout_secs: nextExecutionTimeoutSecs,
-    });
+    const next = checked ? lastEnabledExecutionTimeoutSecsRef.current : 0;
+    configForm.setFieldsValue({ execution_timeout_secs: next });
+    // setExecutionTimeoutSecs 不需要：useWatch 会通过 setFieldsValue 触发，
+    // useEffect [watchedTimeoutSecs] 会同步到本地 state。
   };
 
   return (
@@ -143,10 +139,8 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
               value={executionTimeoutMinutes}
               onChange={(v) => {
                 if (v) {
-                  const secs = v * 60;
-                  setExecutionTimeoutSecs(secs);
-                  configForm.setFieldsValue({ execution_timeout_secs: secs });
-                  // lastEnabledRef 由 useEffect 集中更新（formValue !== undefined && formValue !== lastSyncedFormValueRef）
+                  configForm.setFieldsValue({ execution_timeout_secs: v * 60 });
+                  // lastEnabledRef 由 useEffect [watchedTimeoutSecs] 集中更新
                 }
               }}
             />

--- a/frontend/src/components/settings/RuntimePanel.tsx
+++ b/frontend/src/components/settings/RuntimePanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Card, InputNumber, Tooltip, Button, Popconfirm, Table, Empty, Switch, message } from 'antd';
 import { InfoCircleOutlined, SaveOutlined, StopOutlined, ReloadOutlined } from '@ant-design/icons';
 import { useApp } from '@/hooks/useApp';
@@ -30,17 +30,10 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
     ? Math.max(1, Math.round(executionTimeoutSecs / 60))
     : undefined;
   // 关闭时记录当前值，重新开启时恢复；避免再次开启时跳回初始默认值 3600。
-  // 注意：仅在用户主动输入时更新，不在表单加载时覆盖（避免 0 值覆盖用户上次的非零设置）。
+  // 仅在同步到表单非零值时更新，不响应外部加载（避免 0 覆盖用户上次的非零设置）。
   const lastEnabledExecutionTimeoutSecsRef = useRef<number>(DEFAULT_EXECUTION_TIMEOUT_SECS);
-
-  // 初始化 ref：若表单已有非零值则以该值填充，确保开关恢复时用正确的用户设置而非 3600。
-  useLayoutEffect(() => {
-    const formValue = configForm.getFieldValue('execution_timeout_secs');
-    if (formValue !== undefined && formValue !== 0) {
-      lastEnabledExecutionTimeoutSecsRef.current = formValue;
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // 仅首次渲染执行，不响应后续变更
+  // 记录上次从表单同步的值，消除对 executionTimeoutSecs deps 的依赖，避免多余 re-render。
+  const lastSyncedFormValueRef = useRef<number | undefined>(undefined);
 
   /** 加载当前运行中的执行记录。 */
   const loadRunningRecords = async () => {
@@ -58,16 +51,20 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
     return () => clearInterval(timer);
   }, []);
 
-  // 监听表单字段变化（外部加载配置重置表单时），同步本地状态。
-  // 依赖 [configForm, executionTimeoutSecs]：当 async setFieldsValue 触发 re-render 后，
-  // effect 会重新执行，此时 formValue 已更新而 executionTimeoutSecs 仍是旧值，触发同步。
-  // formValue !== undefined 保护：忽略表单未填充时的 undefined，避免将 0 同步进去。
+  // 监听表单字段变化，同步本地状态并维护 lastEnabledRef。
+  // 仅依赖 configForm（稳定引用），通过 lastSyncedFormValueRef 检测表单值是否真正变化，
+  // 避免加入 executionTimeoutSecs 导致每次 setState 后都触发额外 render。
   useEffect(() => {
     const formValue = configForm.getFieldValue('execution_timeout_secs');
-    if (formValue !== undefined && formValue !== executionTimeoutSecs) {
+    if (formValue !== undefined && formValue !== lastSyncedFormValueRef.current) {
+      lastSyncedFormValueRef.current = formValue;
       setExecutionTimeoutSecs(formValue);
+      // 仅记录非零值，确保 toggle 重新开启时用正确的用户设置
+      if (formValue !== 0) {
+        lastEnabledExecutionTimeoutSecsRef.current = formValue;
+      }
     }
-  }, [configForm, executionTimeoutSecs]);
+  }, [configForm]);
 
   /** 批量停止当前选中的执行任务。 */
   const handleBatchStop = async () => {
@@ -90,7 +87,8 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
   /** 切换是否启用执行超时控制。 */
   const handleExecutionTimeoutToggle = (checked: boolean) => {
     if (!checked) {
-      // 关闭前先记录当前非零值，供后续重新开启时恢复
+      // 关闭时记录当前值，供后续重新开启时恢复。
+      // useEffect 仅在外部 setFieldsValue 时更新 ref，用户未保存的输入变化需要此处捕获。
       lastEnabledExecutionTimeoutSecsRef.current = executionTimeoutSecs;
     }
     const nextExecutionTimeoutSecs = checked ? lastEnabledExecutionTimeoutSecsRef.current : 0;
@@ -148,8 +146,7 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
                   const secs = v * 60;
                   setExecutionTimeoutSecs(secs);
                   configForm.setFieldsValue({ execution_timeout_secs: secs });
-                  // 用户主动输入新值时同步更新 lastEnabledRef，供开关恢复
-                  lastEnabledExecutionTimeoutSecsRef.current = secs;
+                  // lastEnabledRef 由 useEffect 集中更新（formValue !== undefined && formValue !== lastSyncedFormValueRef）
                 }
               }}
             />

--- a/frontend/src/components/settings/RuntimePanel.tsx
+++ b/frontend/src/components/settings/RuntimePanel.tsx
@@ -5,7 +5,7 @@ import { useApp } from '@/hooks/useApp';
 import * as db from '@/utils/database';
 import type { ExecutionRecord } from '@/types';
 
-import { DEFAULT_EXECUTION_TIMEOUT_SECS } from '@/constants';
+import { DEFAULT_EXECUTION_TIMEOUT_SECS, MAX_EXECUTION_TIMEOUT_MINUTES } from '@/constants';
 
 /** 运行管理面板，负责展示执行并发、超时配置以及运行中任务操作。 */
 export function RuntimePanel({ configForm, configSaving, handleSaveConfig, executorDisplayNames }: {
@@ -59,14 +59,15 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
   }, []);
 
   // 监听表单字段变化（外部加载配置重置表单时），同步本地状态。
-  // 注意：此处仅同步 display state，不更新 lastEnabledExecutionTimeoutSecsRef，
-  // 避免外部加载 0 时覆盖用户上次的非零设置。
+  // 依赖 [configForm, executionTimeoutSecs]：当 async setFieldsValue 触发 re-render 后，
+  // effect 会重新执行，此时 formValue 已更新而 executionTimeoutSecs 仍是旧值，触发同步。
+  // formValue !== undefined 保护：忽略表单未填充时的 undefined，避免将 0 同步进去。
   useEffect(() => {
     const formValue = configForm.getFieldValue('execution_timeout_secs');
     if (formValue !== undefined && formValue !== executionTimeoutSecs) {
       setExecutionTimeoutSecs(formValue);
     }
-  }, [configForm]);
+  }, [configForm, executionTimeoutSecs]);
 
   /** 批量停止当前选中的执行任务。 */
   const handleBatchStop = async () => {
@@ -138,7 +139,7 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
             <InputNumber
               size="small"
               min={1}
-              max={10080}
+              max={MAX_EXECUTION_TIMEOUT_MINUTES}
               style={{ width: 80 }}
               disabled={!executionTimeoutEnabled}
               value={executionTimeoutMinutes}

--- a/frontend/src/components/settings/RuntimePanel.tsx
+++ b/frontend/src/components/settings/RuntimePanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import { Card, InputNumber, Tooltip, Button, Popconfirm, Table, Empty, Switch, message } from 'antd';
 import { InfoCircleOutlined, SaveOutlined, StopOutlined, ReloadOutlined } from '@ant-design/icons';
 import { useApp } from '@/hooks/useApp';
@@ -30,7 +30,17 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
     ? Math.max(1, Math.round(executionTimeoutSecs / 60))
     : undefined;
   // 关闭时记录当前值，重新开启时恢复；避免再次开启时跳回初始默认值 3600。
+  // 注意：仅在用户主动输入时更新，不在表单加载时覆盖（避免 0 值覆盖用户上次的非零设置）。
   const lastEnabledExecutionTimeoutSecsRef = useRef<number>(DEFAULT_EXECUTION_TIMEOUT_SECS);
+
+  // 初始化 ref：若表单已有非零值则以该值填充，确保开关恢复时用正确的用户设置而非 3600。
+  useLayoutEffect(() => {
+    const formValue = configForm.getFieldValue('execution_timeout_secs');
+    if (formValue !== undefined && formValue !== 0) {
+      lastEnabledExecutionTimeoutSecsRef.current = formValue;
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // 仅首次渲染执行，不响应后续变更
 
   /** 加载当前运行中的执行记录。 */
   const loadRunningRecords = async () => {
@@ -48,15 +58,9 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
     return () => clearInterval(timer);
   }, []);
 
-  // Track the last seen execution_timeout_secs so the toggle handler can restore it.
-  // We sync on every change (not just when enabled) so that loading the form with
-  // execution_timeout_secs = 0 correctly records 0 as the last value — preventing
-  // the stale 3600 fallback from being restored when the user re-enables the timeout.
-  useEffect(() => {
-    lastEnabledExecutionTimeoutSecsRef.current = executionTimeoutSecs;
-  }, [executionTimeoutSecs]);
-
   // 监听表单字段变化（外部加载配置重置表单时），同步本地状态。
+  // 注意：此处仅同步 display state，不更新 lastEnabledExecutionTimeoutSecsRef，
+  // 避免外部加载 0 时覆盖用户上次的非零设置。
   useEffect(() => {
     const formValue = configForm.getFieldValue('execution_timeout_secs');
     if (formValue !== undefined && formValue !== executionTimeoutSecs) {
@@ -84,6 +88,10 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
 
   /** 切换是否启用执行超时控制。 */
   const handleExecutionTimeoutToggle = (checked: boolean) => {
+    if (!checked) {
+      // 关闭前先记录当前非零值，供后续重新开启时恢复
+      lastEnabledExecutionTimeoutSecsRef.current = executionTimeoutSecs;
+    }
     const nextExecutionTimeoutSecs = checked ? lastEnabledExecutionTimeoutSecsRef.current : 0;
     setExecutionTimeoutSecs(nextExecutionTimeoutSecs);
     configForm.setFieldsValue({
@@ -130,14 +138,17 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
             <InputNumber
               size="small"
               min={1}
-              max={1440}
+              max={10080}
               style={{ width: 80 }}
               disabled={!executionTimeoutEnabled}
               value={executionTimeoutMinutes}
               onChange={(v) => {
                 if (v) {
-                  setExecutionTimeoutSecs(v * 60);
-                  configForm.setFieldsValue({ execution_timeout_secs: v * 60 });
+                  const secs = v * 60;
+                  setExecutionTimeoutSecs(secs);
+                  configForm.setFieldsValue({ execution_timeout_secs: secs });
+                  // 用户主动输入新值时同步更新 lastEnabledRef，供开关恢复
+                  lastEnabledExecutionTimeoutSecsRef.current = secs;
                 }
               }}
             />

--- a/frontend/src/components/settings/RuntimePanel.tsx
+++ b/frontend/src/components/settings/RuntimePanel.tsx
@@ -145,7 +145,7 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
               }}
             />
             <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>分钟</span>
-            <Tooltip title="单个执行任务的最大时长；关闭后不再因超时自动终止">
+            <Tooltip title={`单个执行任务的最大时长（1 ~ ${MAX_EXECUTION_TIMEOUT_MINUTES} 分钟，上限 7 天）；关闭后不再因超时自动终止`}>
               <InfoCircleOutlined style={{ color: 'var(--color-text-quaternary)', fontSize: 12 }} />
             </Tooltip>
           </div>

--- a/frontend/src/components/settings/RuntimePanel.tsx
+++ b/frontend/src/components/settings/RuntimePanel.tsx
@@ -5,7 +5,7 @@ import { useApp } from '@/hooks/useApp';
 import * as db from '@/utils/database';
 import type { ExecutionRecord } from '@/types';
 
-const DEFAULT_EXECUTION_TIMEOUT_SECS = 3600;
+import { DEFAULT_EXECUTION_TIMEOUT_SECS } from '@/constants';
 
 /** 运行管理面板，负责展示执行并发、超时配置以及运行中任务操作。 */
 export function RuntimePanel({ configForm, configSaving, handleSaveConfig, executorDisplayNames }: {
@@ -48,12 +48,13 @@ export function RuntimePanel({ configForm, configSaving, handleSaveConfig, execu
     return () => clearInterval(timer);
   }, []);
 
-  // 当用户手动输入时记录最新值；若关闭超时则不更新（保留重新开启时的恢复值）。
+  // Track the last seen execution_timeout_secs so the toggle handler can restore it.
+  // We sync on every change (not just when enabled) so that loading the form with
+  // execution_timeout_secs = 0 correctly records 0 as the last value — preventing
+  // the stale 3600 fallback from being restored when the user re-enables the timeout.
   useEffect(() => {
-    if (executionTimeoutEnabled) {
-      lastEnabledExecutionTimeoutSecsRef.current = executionTimeoutSecs;
-    }
-  }, [executionTimeoutEnabled, executionTimeoutSecs]);
+    lastEnabledExecutionTimeoutSecsRef.current = executionTimeoutSecs;
+  }, [executionTimeoutSecs]);
 
   // 监听表单字段变化（外部加载配置重置表单时），同步本地状态。
   useEffect(() => {

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -7,5 +7,7 @@
 /** Default execution timeout in seconds (1 hour). Used as fallback when no config is set. */
 export const DEFAULT_EXECUTION_TIMEOUT_SECS = 3600;
 
-/** Maximum execution timeout in minutes (7 days = 10080 min). Mirrors backend config::MAX_EXECUTION_TIMEOUT_SECS. */
+/** Maximum execution timeout in minutes (7 days = 10080 min).
+ * Derived from backend config::MAX_EXECUTION_TIMEOUT_SECS (604800 seconds).
+ * If you change one side, update the other: MAX_EXECUTION_TIMEOUT_SECS / 60 = 10080. */
 export const MAX_EXECUTION_TIMEOUT_MINUTES = 10080;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,0 +1,8 @@
+// =============================================================================
+// Shared application constants — single source of truth for values used across
+// multiple layers (frontend components, backend config). Keep in sync with
+// backend/src/config.rs::DEFAULT_EXECUTION_TIMEOUT_SECS.
+// =============================================================================
+
+/** Default execution timeout in seconds (1 hour). Used as fallback when no config is set. */
+export const DEFAULT_EXECUTION_TIMEOUT_SECS = 3600;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -6,3 +6,6 @@
 
 /** Default execution timeout in seconds (1 hour). Used as fallback when no config is set. */
 export const DEFAULT_EXECUTION_TIMEOUT_SECS = 3600;
+
+/** Maximum execution timeout in minutes (7 days = 10080 min). Mirrors backend config::MAX_EXECUTION_TIMEOUT_SECS. */
+export const MAX_EXECUTION_TIMEOUT_MINUTES = 10080;


### PR DESCRIPTION
## Summary

修复执行超时配置相关的 HIGH/MEDIUM 级问题。

## Changes

- backend/src/handlers/config.rs: 添加上限 604800（7天），新增 2 个边界测试
- backend/src/executor_service.rs: 4处中文日志改为英文，添加按值捕获注释
- frontend/src/constants.ts: 新建常量模块，作为 DEFAULT_EXECUTION_TIMEOUT_SECS 单一数据源
- frontend/src/components/settings/RuntimePanel.tsx: 改为导入常量，修复 lastEnabledExecutionTimeoutSecsRef 同步逻辑
- frontend/src/components/SettingsPage.tsx: 改为导入常量

## Testing

cargo test validate_execution_timeout  # 5 tests pass