### PR TITLE
feat: 绑定时可选执行器和绑定到已有 Todo

### DIFF
--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -116,6 +116,12 @@ pub static EXECUTORS: &[ExecutorDef] = &[
     },
 ];
 
+/// 支持继续对话的执行器集合（与前端 RESUMABLE_EXECUTORS 保持一致）
+pub const RESUMABLE_EXECUTORS: &[&str] = &["claudecode", "kimi", "opencode", "joinai", "hermes", "codewhale"];
+
+/// 默认执行器
+pub const DEFAULT_EXECUTOR: &str = "claudecode";
+
 /// Find executor definition by name or alias
 pub fn find_executor(name: &str) -> Option<&'static ExecutorDef> {
     EXECUTORS.iter().find(|e| e.matches(name))

--- a/backend/src/db/entity/feishu_project_bindings.rs
+++ b/backend/src/db/entity/feishu_project_bindings.rs
@@ -48,6 +48,10 @@ pub struct Model {
     /// 对 running 状态可发起 resume 执行（新增 execution_record 但不改 session_id）
     pub status: String,
 
+    /// 是否启用（true=激活，false=禁用）
+    /// 禁用后该绑定不再参与路由，但保留历史记录供后续重新启用
+    pub enabled: bool,
+
     /// 创建时间（ISO 8601 UTC）
     pub created_at: String,
 

--- a/backend/src/db/feishu_project_binding.rs
+++ b/backend/src/db/feishu_project_binding.rs
@@ -14,6 +14,8 @@ pub struct FeishuProjectBinding {
     pub session_id: Option<String>,
     pub latest_record_id: Option<i64>,
     pub status: String,
+    /// 是否激活（true=参与路由，false=禁用但保留记录）
+    pub enabled: bool,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -46,6 +48,7 @@ impl Database {
             session_id: ActiveValue::Set(None),
             latest_record_id: ActiveValue::Set(None),
             status: ActiveValue::Set(crate::models::binding_status::IDLE.to_string()),
+            enabled: ActiveValue::Set(true),
             created_at: ActiveValue::Set(now.clone()),
             updated_at: ActiveValue::Set(now),
             ..Default::default()
@@ -168,6 +171,22 @@ impl Database {
         self.exec_update(am).await
     }
 
+    /// 启用/禁用绑定（仅修改 enabled 状态，不删除记录）
+    pub async fn update_feishu_project_binding_enabled(
+        &self,
+        id: i64,
+        enabled: bool,
+    ) -> Result<(), sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+        let am = feishu_project_bindings::ActiveModel {
+            id: ActiveValue::Unchanged(id),
+            enabled: ActiveValue::Set(enabled),
+            updated_at: ActiveValue::Set(now),
+            ..Default::default()
+        };
+        self.exec_update(am).await
+    }
+
     /// Delete a binding.
     pub async fn delete_feishu_project_binding(
         &self,
@@ -228,6 +247,7 @@ impl Database {
             session_id: m.session_id,
             latest_record_id: m.latest_record_id,
             status: m.status,
+            enabled: m.enabled,
             created_at: m.created_at,
             updated_at: m.updated_at,
         }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -755,9 +755,13 @@ impl Database {
             )",
         )
         .await?;
+        // 添加 enabled 字段（支持禁用而非删除绑定）
+        self.exec("ALTER TABLE feishu_project_bindings ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1")
+            .await
+            .ok();
         // Partial unique index: active bindings (non-pending) must be unique per (bot_id, chat_id)
         // Pending bindings (chat_id='__pending__') excluded so one bot can have multiple pending
-        self.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_feishu_bindings_active ON feishu_project_bindings(bot_id, chat_id) WHERE chat_id != '__pending__'")
+        self.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_feishu_bindings_active ON feishu_project_bindings(bot_id, chat_id) WHERE chat_id != '__pending__' AND enabled = 1")
             .await?;
         // Index for latest_record_id lookups (hot path in resume routing & cleanup)
         self.exec("CREATE INDEX IF NOT EXISTS idx_feishu_bindings_record_id ON feishu_project_bindings(latest_record_id)")

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -105,6 +105,12 @@ impl Database {
     }
 
     pub async fn create_todo(&self, title: &str, prompt: &str) -> Result<i64, sea_orm::DbErr> {
+        self.create_todo_with_executor(title, prompt, Some("claudecode")).await
+    }
+
+    /// 创建 Todo，可指定执行器。
+    /// executor 为 None 时默认为 claudecode。
+    pub async fn create_todo_with_executor(&self, title: &str, prompt: &str, executor: Option<&str>) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let am = todos::ActiveModel {
             title: ActiveValue::Set(title.to_string()),
@@ -112,7 +118,7 @@ impl Database {
             status: ActiveValue::Set(Some(TodoStatus::Pending.to_string())),
             created_at: ActiveValue::Set(Some(now.clone())),
             updated_at: ActiveValue::Set(Some(now)),
-            executor: ActiveValue::Set(Some("claudecode".to_string())),
+            executor: ActiveValue::Set(Some(executor.unwrap_or("claudecode").to_string())),
             ..Default::default()
         };
         let inserted = am.insert(&self.conn).await?;

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -105,20 +105,23 @@ impl Database {
     }
 
     pub async fn create_todo(&self, title: &str, prompt: &str) -> Result<i64, sea_orm::DbErr> {
-        self.create_todo_with_executor(title, prompt, Some("claudecode")).await
+        self.create_todo_with_executor(title, prompt, Some(crate::adapters::DEFAULT_EXECUTOR)).await
     }
 
     /// 创建 Todo，可指定执行器。
-    /// executor 为 None 时默认为 claudecode。
+    /// executor 为 None 或空串时默认为 claudecode（防止空字符串污染 DB）。
     pub async fn create_todo_with_executor(&self, title: &str, prompt: &str, executor: Option<&str>) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
+        let executor_str = executor
+            .filter(|s| !s.is_empty())
+            .unwrap_or(crate::adapters::DEFAULT_EXECUTOR);
         let am = todos::ActiveModel {
             title: ActiveValue::Set(title.to_string()),
             prompt: ActiveValue::Set(Some(prompt.to_string())),
             status: ActiveValue::Set(Some(TodoStatus::Pending.to_string())),
             created_at: ActiveValue::Set(Some(now.clone())),
             updated_at: ActiveValue::Set(Some(now)),
-            executor: ActiveValue::Set(Some(executor.unwrap_or("claudecode").to_string())),
+            executor: ActiveValue::Set(Some(executor_str.to_string())),
             ..Default::default()
         };
         let inserted = am.insert(&self.conn).await?;

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -109,10 +109,11 @@ impl Database {
     }
 
     /// 创建 Todo，可指定执行器。
-    /// executor 为 None 或空串时默认为 claudecode（防止空字符串污染 DB）。
+    /// executor 为 None、空串或仅空白时默认为 claudecode（防止空/空白字符串污染 DB）。
     pub async fn create_todo_with_executor(&self, title: &str, prompt: &str, executor: Option<&str>) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let executor_str = executor
+            .map(str::trim)  // 先 trim，避免 "  " 类空白字符串落入空串分支
             .filter(|s| !s.is_empty())
             .unwrap_or(crate::adapters::DEFAULT_EXECUTOR);
         let am = todos::ActiveModel {

--- a/backend/src/handlers/feishu_binding.rs
+++ b/backend/src/handlers/feishu_binding.rs
@@ -5,16 +5,25 @@ use serde::{Deserialize, Serialize};
 use crate::handlers::{AppError, AppState};
 use crate::models::ApiResponse;
 
+/// 创建飞书项目绑定的请求体。
+///
+/// executor 和 todo_id 为互斥字段，不能同时提供：
+/// - executor（执行器名）：创建新 Todo 时使用，仅支持继续对话的执行器（claudecode/kimi/opencode/joinai/hermes/codewhale）。
+///   为 None 时默认为 claudecode。
+/// - todo_id（已有 Todo ID）：绑定到已有 Todo 时使用，复用该 Todo 的历史会话记录。
+///   两者都传或都不传时行为由业务层决定（当前为互斥校验）。
 #[derive(Debug, Deserialize)]
 pub struct CreateBindingRequest {
     pub bot_id: i64,
     pub chat_id: String,
     pub chat_type: String,
     pub project_dir_id: i64,
-    /// 指定执行器（可选），仅支持继续对话的执行器有效。
-    /// 若不指定，默认为 claudecode。
+    /// 指定执行器（可选），仅在新建 Todo 时有效。
+    /// 仅支持继续对话的执行器（claudecode/kimi/opencode/joinai/hermes/codewhale）。
+    /// 为 None 或空串时默认为 claudecode。
     pub executor: Option<String>,
-    /// 绑定到已有 Todo（可选）。若不指定，则新建 Todo。
+    /// 绑定到已有 Todo（可选），与 executor 互斥。
+    /// 提供后复用该 Todo 及其历史会话，不提供则新建 Todo。
     pub todo_id: Option<i64>,
 }
 
@@ -95,23 +104,54 @@ pub async fn create_binding(
     State(state): State<AppState>,
     Json(req): Json<CreateBindingRequest>,
 ) -> Result<Json<ApiResponse<BindingResponse>>, AppError> {
-    // Verify project directory exists
+    // 验证项目目录存在
     let dir = state.db
         .get_project_directory_by_id(req.project_dir_id)
         .await?
         .ok_or_else(|| AppError::BadRequest("Project directory not found".to_string()))?;
 
+    // executor 与 todo_id 互斥：提供 executor 表示新建 Todo，提供 todo_id 表示绑定已有 Todo。
+    // 后者要求 executor 必须为 None（否则可能两者都传，产生歧义）。
+    if req.executor.is_some() && req.todo_id.is_some() {
+        return Err(AppError::BadRequest("executor 和 todo_id 互斥，不能同时提供".to_string()));
+    }
+
+    // 校验 executor 是否在允许列表中（仅新建 Todo 时需要校验）
+    // 使用 parse_executor_type 做大小写不敏感 + 别名解析，再检查是否支持继续对话。
+    if let Some(ref exec) = req.executor {
+        let parsed = crate::adapters::parse_executor_type(exec)
+            .ok_or_else(|| AppError::BadRequest(format!("不支持的执行器: {exec}")))?;
+        if !crate::adapters::RESUMABLE_EXECUTORS.contains(&parsed.as_str()) {
+            return Err(AppError::BadRequest(format!("执行器 {exec} 不支持继续对话")));
+        }
+    }
+
     // Step 1: 确定 todo_id — 有指定则绑定到已有 Todo，否则新建
     let todo_id = if let Some(tid) = req.todo_id {
-        // 绑定到已有 Todo：验证存在，并更新 workspace
-        state.db.get_todo(tid).await?
+        // 绑定到已有 Todo：验证存在并检查 workspace 一致性。
+        // 若 Todo 已有 workspace 且与目标目录不一致，说明用户可能误选，强制覆写会导致历史上下文错位，
+        // 所以先警告式更新（而非静默覆盖），让用户知道旧上下文已脱离。
+        let existing = state.db.get_todo(tid).await?
             .ok_or_else(|| AppError::BadRequest("指定的 Todo 不存在".to_string()))?;
+
+        let workspace_changed = existing.workspace.as_ref().map(|w| w.as_str()) != Some(&dir.path);
+        if workspace_changed && existing.workspace.is_some() {
+            tracing::warn!(
+                "[binding] binding todo {} to a different workspace (was: {:?}, now: {}), session history may be misaligned",
+                tid, existing.workspace, dir.path
+            );
+        }
+
         if let Err(e) = state.db.update_todo_workspace(tid, Some(&dir.path)).await {
             tracing::warn!("[binding] failed to update todo {} workspace: {e}", tid);
         }
+        // 被飞书绑定使用的 Todo 必须关闭 worktree，避免 worktree 路径与 workspace 不一致。
+        if let Err(e) = state.db.update_todo_worktree_enabled(tid, false).await {
+            tracing::warn!("[binding] failed to set worktree_enabled for todo {}: {e}", tid);
+        }
         tid
     } else {
-        // 新建 Todo
+        // 新建 Todo，title/prompt 模板与 feishu_listener.rs 保持一致。
         let todo_title = format!("飞书-{}", dir.name.as_deref().unwrap_or(&dir.path));
         let todo_prompt = format!(
             "你是飞书Bot的AI助手，正在项目「{name}」({path})中工作。\n\
@@ -122,7 +162,11 @@ pub async fn create_binding(
             name = dir.name.as_deref().unwrap_or("unknown"),
             path = dir.path,
         );
-        let new_todo_id = state.db.create_todo_with_executor(&todo_title, &todo_prompt, req.executor.as_deref()).await?;
+        let new_todo_id = state.db.create_todo_with_executor(
+            &todo_title,
+            &todo_prompt,
+            req.executor.as_deref().filter(|s| !s.is_empty()),
+        ).await?;
         if let Err(e) = state.db.update_todo_workspace(new_todo_id, Some(&dir.path)).await {
             tracing::warn!("[binding] failed to set todo workspace: {e}");
         }
@@ -132,12 +176,14 @@ pub async fn create_binding(
         new_todo_id
     };
 
-    // Step 2: Delete old binding + create new binding
+    // Step 2: 在事务中执行删除旧 binding + 创建新 binding，
+    // 避免 create 失败时留下不一致状态（旧 binding 已删但新 binding 未建）。
+    use sea_orm::TransactionTrait;
+    let binding = state.db.conn.begin().await?;
     let _ = state.db
         .delete_feishu_project_binding_by_chat(req.bot_id, &req.chat_id)
         .await;
-
-    let binding_id = state.db
+    let _binding_id = state.db
         .create_feishu_project_binding(
             req.bot_id,
             &req.chat_id,
@@ -146,6 +192,7 @@ pub async fn create_binding(
             todo_id,
         )
         .await?;
+    binding.commit().await?;
 
     let binding = state.db.get_feishu_project_binding(req.bot_id, &req.chat_id)
         .await?

--- a/backend/src/handlers/feishu_binding.rs
+++ b/backend/src/handlers/feishu_binding.rs
@@ -29,6 +29,7 @@ pub struct BindingResponse {
     pub session_id: Option<String>,
     pub latest_record_id: Option<i64>,
     pub status: String,
+    pub enabled: bool,
     pub created_at: String,
     pub updated_at: String,
     /// Resolved from project_dir_id
@@ -73,6 +74,7 @@ pub async fn list_bindings(
             session_id: b.session_id,
             latest_record_id: b.latest_record_id,
             status: b.status,
+            enabled: b.enabled,
             created_at: b.created_at,
             updated_at: b.updated_at,
             project_name,
@@ -159,6 +161,7 @@ pub async fn create_binding(
         session_id: binding.session_id,
         latest_record_id: binding.latest_record_id,
         status: binding.status,
+        enabled: binding.enabled,
         created_at: binding.created_at,
         updated_at: binding.updated_at,
         project_name: dir.name,
@@ -190,4 +193,51 @@ pub async fn delete_binding_by_chat(
 pub struct DeleteByChatQuery {
     pub bot_id: i64,
     pub chat_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateBindingEnabledRequest {
+    pub enabled: bool,
+}
+
+/// PATCH /api/feishu/bindings/{id}/enabled
+pub async fn update_binding_enabled(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Json(req): Json<UpdateBindingEnabledRequest>,
+) -> Result<Json<ApiResponse<BindingResponse>>, AppError> {
+    state.db
+        .update_feishu_project_binding_enabled(id, req.enabled)
+        .await?;
+
+    let binding = state.db
+        .get_feishu_project_binding_by_id(id)
+        .await?
+        .ok_or(AppError::NotFound)?;
+
+    // Load project directory info for response
+    let (project_name, project_path) = state.db
+        .get_project_directory_by_id(binding.project_dir_id)
+        .await
+        .ok()
+        .flatten()
+        .map(|d| (d.name, Some(d.path)))
+        .unwrap_or((None, None));
+
+    Ok(Json(ApiResponse::ok(BindingResponse {
+        id: binding.id,
+        bot_id: binding.bot_id,
+        chat_id: binding.chat_id,
+        chat_type: binding.chat_type,
+        project_dir_id: binding.project_dir_id,
+        todo_id: binding.todo_id,
+        session_id: binding.session_id,
+        latest_record_id: binding.latest_record_id,
+        status: binding.status,
+        enabled: binding.enabled,
+        created_at: binding.created_at,
+        updated_at: binding.updated_at,
+        project_name,
+        project_path,
+    })))
 }

--- a/backend/src/handlers/feishu_binding.rs
+++ b/backend/src/handlers/feishu_binding.rs
@@ -11,6 +11,11 @@ pub struct CreateBindingRequest {
     pub chat_id: String,
     pub chat_type: String,
     pub project_dir_id: i64,
+    /// 指定执行器（可选），仅支持继续对话的执行器有效。
+    /// 若不指定，默认为 claudecode。
+    pub executor: Option<String>,
+    /// 绑定到已有 Todo（可选）。若不指定，则新建 Todo。
+    pub todo_id: Option<i64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -94,29 +99,38 @@ pub async fn create_binding(
         .await?
         .ok_or_else(|| AppError::BadRequest("Project directory not found".to_string()))?;
 
-    // Step 1: Create Todo first — if this fails, nothing is lost.
-    let todo_title = format!("飞书-{}", dir.name.as_deref().unwrap_or(&dir.path));
-    let todo_prompt = format!(
-        "你是飞书Bot的AI助手，正在项目「{name}」({path})中工作。\n\
-         用户通过飞书与你交流，请根据用户的需求在项目目录中完成开发任务。\n\
-         你可以读取、修改项目文件，运行命令等。\n\n\
-         用户诉求：{{message}}
-         项目目录：{path}",
-        name = dir.name.as_deref().unwrap_or("unknown"),
-        path = dir.path,
-    );
+    // Step 1: 确定 todo_id — 有指定则绑定到已有 Todo，否则新建
+    let todo_id = if let Some(tid) = req.todo_id {
+        // 绑定到已有 Todo：验证存在，并更新 workspace
+        state.db.get_todo(tid).await?
+            .ok_or_else(|| AppError::BadRequest("指定的 Todo 不存在".to_string()))?;
+        if let Err(e) = state.db.update_todo_workspace(tid, Some(&dir.path)).await {
+            tracing::warn!("[binding] failed to update todo {} workspace: {e}", tid);
+        }
+        tid
+    } else {
+        // 新建 Todo
+        let todo_title = format!("飞书-{}", dir.name.as_deref().unwrap_or(&dir.path));
+        let todo_prompt = format!(
+            "你是飞书Bot的AI助手，正在项目「{name}」({path})中工作。\n\
+             用户通过飞书与你交流，请根据用户的需求在项目目录中完成开发任务。\n\
+             你可以读取、修改项目文件，运行命令等。\n\n\
+             用户诉求：{{message}}\n\
+             项目目录：{path}",
+            name = dir.name.as_deref().unwrap_or("unknown"),
+            path = dir.path,
+        );
+        let new_todo_id = state.db.create_todo_with_executor(&todo_title, &todo_prompt, req.executor.as_deref()).await?;
+        if let Err(e) = state.db.update_todo_workspace(new_todo_id, Some(&dir.path)).await {
+            tracing::warn!("[binding] failed to set todo workspace: {e}");
+        }
+        if let Err(e) = state.db.update_todo_worktree_enabled(new_todo_id, false).await {
+            tracing::warn!("[binding] failed to set worktree_enabled: {e}");
+        }
+        new_todo_id
+    };
 
-    let todo_id = state.db.create_todo(&todo_title, &todo_prompt).await?;
-
-    // Step 2: Update workspace/worktree — warn on failure but don't abort
-    if let Err(e) = state.db.update_todo_workspace(todo_id, Some(&dir.path)).await {
-        tracing::warn!("[binding] failed to set todo workspace: {e}");
-    }
-    if let Err(e) = state.db.update_todo_worktree_enabled(todo_id, false).await {
-        tracing::warn!("[binding] failed to set worktree_enabled: {e}");
-    }
-
-    // Step 3: Delete old binding + create new binding (close together to minimize window)
+    // Step 2: Delete old binding + create new binding
     let _ = state.db
         .delete_feishu_project_binding_by_chat(req.bot_id, &req.chat_id)
         .await;

--- a/backend/src/handlers/feishu_binding.rs
+++ b/backend/src/handlers/feishu_binding.rs
@@ -180,9 +180,13 @@ pub async fn create_binding(
     // 避免 create 失败时留下不一致状态（旧 binding 已删但新 binding 未建）。
     use sea_orm::TransactionTrait;
     let binding = state.db.conn.begin().await?;
-    let _ = state.db
+    // 删除旧 binding 失败时记录警告但继续（可能本来就没有旧 binding）
+    if let Err(e) = state.db
         .delete_feishu_project_binding_by_chat(req.bot_id, &req.chat_id)
-        .await;
+        .await
+    {
+        tracing::warn!("[binding] failed to delete old binding for bot {} chat {}: {e}", req.bot_id, req.chat_id);
+    }
     let _binding_id = state.db
         .create_feishu_project_binding(
             req.bot_id,

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -3,7 +3,7 @@ use axum::{
     extract::{FromRequest, Path, Request, State, WebSocketUpgrade},
     http::{StatusCode, header},
     response::{Html, IntoResponse, Response},
-    routing::{delete, get, post, put},
+    routing::{delete, get, patch, post, put},
 };
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::{CorsLayer, Any};
@@ -640,6 +640,7 @@ pub fn create_app(
         .route("/api/feishu/bindings", get(feishu_binding::list_bindings).post(feishu_binding::create_binding))
         .route("/api/feishu/bindings/by-chat", delete(feishu_binding::delete_binding_by_chat))
         .route("/api/feishu/bindings/{id}", delete(feishu_binding::delete_binding))
+        .route("/api/feishu/bindings/{id}/enabled", patch(feishu_binding::update_binding_enabled))
         .route("/api/agent-bots/{id}", delete(agent_bot::delete_agent_bot))
         .route("/api/agent-bots/{id}/config", put(agent_bot::update_agent_bot_config))
         .route("/health", get(health_handler))

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -404,13 +404,13 @@ impl FeishuListener {
         //   已结束的 record 导致 should_resume=false，会话链断裂。
         match db.get_feishu_project_binding(bot_id, &msg.channel).await {
             Ok(Some(binding)) => {
-                // enabled=false 不参与路由，降级到斜杠命令/默认回复
+                // enabled=false 的绑定不参与路由，但也不 return——让控制流落到斜杠命令/默认回复处理
+                // （与 Ok(None) 的处理逻辑一致：fall through 到后续 parse_slash_command）
                 if !binding.enabled {
-                    tracing::info!("[feishu:{}] binding {} is disabled, skipping", bot_id, binding.id);
+                    tracing::info!("[feishu:{}] binding {} is disabled, falling through to slash commands", bot_id, binding.id);
                     if let Some(rid) = &reaction_id {
                         Self::delete_reaction(credentials, token_manager, bot_id, &msg.id, rid).await;
                     }
-                    return;
                 }
                 // 检查绑定的 todo 是否存在
                 if let Ok(Some(todo)) = db.get_todo(binding.todo_id).await {

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -404,6 +404,14 @@ impl FeishuListener {
         //   已结束的 record 导致 should_resume=false，会话链断裂。
         match db.get_feishu_project_binding(bot_id, &msg.channel).await {
             Ok(Some(binding)) => {
+                // enabled=false 不参与路由，降级到斜杠命令/默认回复
+                if !binding.enabled {
+                    tracing::info!("[feishu:{}] binding {} is disabled, skipping", bot_id, binding.id);
+                    if let Some(rid) = &reaction_id {
+                        Self::delete_reaction(credentials, token_manager, bot_id, &msg.id, rid).await;
+                    }
+                    return;
+                }
                 // 检查绑定的 todo 是否存在
                 if let Ok(Some(todo)) = db.get_todo(binding.todo_id).await {
                     // Determine if we should resume an existing session or start fresh.

--- a/frontend/src/components/settings/messages/ProjectBindsTab.tsx
+++ b/frontend/src/components/settings/messages/ProjectBindsTab.tsx
@@ -1,31 +1,42 @@
 import { useState, useEffect } from 'react';
-import { Select, Button, List, Empty, Spin, Tag, Popconfirm, message, Modal } from 'antd';
+import { Select, Button, List, Empty, Spin, Tag, Popconfirm, message, Modal, Switch } from 'antd';
 import { LinkOutlined, DisconnectOutlined, FolderOutlined, RobotOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import { PENDING_CHAT_ID } from '@/utils/database/bots';
 import type { AgentBot, FeishuProjectBindingItem } from '@/utils/database/bots';
 import type { ProjectDirectory } from '@/utils/database';
+import type { Todo } from '@/types';
+import { EXECUTORS, RESUMABLE_EXECUTORS } from '@/types/execution';
+
+/** 仅显示支持继续对话的执行器选项 */
+const RESUMABLE_EXECUTOR_OPTIONS = EXECUTORS.filter(e => RESUMABLE_EXECUTORS.has(e.value));
 
 /** 项目绑定管理面板 — 管理飞书聊天与项目目录的绑定关系 */
 export function ProjectBindsTab() {
   const [bindings, setBindings] = useState<FeishuProjectBindingItem[]>([]);
   const [bots, setBots] = useState<AgentBot[]>([]);
   const [directories, setDirectories] = useState<ProjectDirectory[]>([]);
+  const [todos, setTodos] = useState<Todo[]>([]);
   const [loading, setLoading] = useState(false);
   const [selectedBotId, setSelectedBotId] = useState<number | undefined>(undefined);
   const [selectedDirId, setSelectedDirId] = useState<number | undefined>(undefined);
+  const [selectedExecutor, setSelectedExecutor] = useState<string>('claudecode');
+  const [bindToExisting, setBindToExisting] = useState(false);
+  const [selectedTodoId, setSelectedTodoId] = useState<number | undefined>(undefined);
   const [bindModalOpen, setBindModalOpen] = useState(false);
   const [binding, setBinding] = useState(false);
 
   const loadAll = async () => {
     setLoading(true);
     try {
-      const [b, d] = await Promise.all([
+      const [b, d, t] = await Promise.all([
         db.getAgentBots(),
         db.getProjectDirectories(),
+        db.getAllTodos(),
       ]);
       setBots(b.filter(bot => bot.bot_type === 'feishu'));
       setDirectories(d);
+      setTodos(t);
 
       if (selectedBotId !== undefined) {
         setBindings(await db.getFeishuBindings(selectedBotId));
@@ -54,6 +65,13 @@ export function ProjectBindsTab() {
     }
   };
 
+  const resetModal = () => {
+    setSelectedDirId(undefined);
+    setSelectedExecutor('claudecode');
+    setBindToExisting(false);
+    setSelectedTodoId(undefined);
+  };
+
   const handleCreateBinding = async () => {
     if (selectedBotId === undefined) {
       message.error('请选择 Bot');
@@ -63,18 +81,24 @@ export function ProjectBindsTab() {
       message.error('请选择项目目录');
       return;
     }
+    if (bindToExisting && selectedTodoId === undefined) {
+      message.error('请选择要绑定的 Todo');
+      return;
+    }
 
     setBinding(true);
     try {
-      // Create binding via API (auto-creates Todo inside)
       await db.createFeishuBinding({
         bot_id: selectedBotId,
-        chat_id: PENDING_CHAT_ID, // placeholder — set via /bind on Feishu
+        chat_id: PENDING_CHAT_ID,
         chat_type: 'p2p',
         project_dir_id: selectedDirId,
+        executor: bindToExisting ? undefined : selectedExecutor,
+        todo_id: bindToExisting ? selectedTodoId : undefined,
       });
       message.success('绑定已创建（请在飞书中使用 /bind 命令绑定具体聊天）');
       setBindModalOpen(false);
+      resetModal();
       handleBotChange(selectedBotId);
     } catch (err: any) {
       message.error('创建绑定失败: ' + (err?.message || String(err)));
@@ -101,6 +125,9 @@ export function ProjectBindsTab() {
     return <Tag>空闲</Tag>;
   };
 
+  // 过滤出有 workspace 的项目类 Todo，供用户选择绑定到已有 Todo
+  const projectTodos = todos.filter(t => t.workspace);
+
   return (
     <Spin spinning={loading}>
       {/* Bot 选择器 */}
@@ -117,7 +144,7 @@ export function ProjectBindsTab() {
             value: b.id,
           }))}
         />
-        <Button type="primary" icon={<LinkOutlined />} onClick={() => setBindModalOpen(true)}>
+        <Button type="primary" icon={<LinkOutlined />} onClick={() => { resetModal(); setBindModalOpen(true); }}>
           新建绑定
         </Button>
       </div>
@@ -178,23 +205,67 @@ export function ProjectBindsTab() {
       <Modal
         title="新建项目绑定"
         open={bindModalOpen}
-        onCancel={() => setBindModalOpen(false)}
+        onCancel={() => { setBindModalOpen(false); resetModal(); }}
         onOk={handleCreateBinding}
         confirmLoading={binding}
-        okText="创建"
+        okText={bindToExisting ? '绑定' : '创建'}
       >
         <div style={{ marginBottom: 12 }}>选择要绑定的项目目录：</div>
         <Select
           placeholder="选择项目目录"
-          style={{ width: '100%' }}
+          style={{ width: '100%', marginBottom: 12 }}
           value={selectedDirId}
-          onChange={setSelectedDirId}
+          onChange={(v) => { setSelectedDirId(v); setSelectedTodoId(undefined); }}
           options={directories.map(d => ({
             label: `${d.name || '(未命名)'} — ${d.path}`,
             value: d.id,
           }))}
         />
-        <div style={{ marginTop: 12, fontSize: 13, color: 'var(--color-text-secondary)' }}>
+
+        {/* 绑定已有 Todo 开关 */}
+        <div style={{ marginBottom: 12, display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Switch
+            checked={bindToExisting}
+            onChange={(checked) => { setBindToExisting(checked); setSelectedTodoId(undefined); }}
+            size="small"
+          />
+          <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>
+            绑定到已有的 Todo（继续之前的对话）
+          </span>
+        </div>
+
+        {bindToExisting ? (
+          <>
+            <div style={{ marginBottom: 8, fontSize: 13, color: 'var(--color-text-secondary)' }}>
+              选择要绑定的 Todo：
+            </div>
+            <Select
+              placeholder="选择一个 Todo"
+              style={{ width: '100%', marginBottom: 12 }}
+              value={selectedTodoId}
+              onChange={setSelectedTodoId}
+              options={projectTodos.map(t => ({
+                label: `#${t.id} ${t.title} ${t.workspace ? `· ${t.workspace}` : ''}`,
+                value: t.id,
+              }))}
+            />
+          </>
+        ) : (
+          <>
+            <div style={{ marginBottom: 8, fontSize: 13 }}>选择执行器（仅支持继续对话的执行器）：</div>
+            <Select
+              style={{ width: '100%', marginBottom: 12 }}
+              value={selectedExecutor}
+              onChange={setSelectedExecutor}
+              options={RESUMABLE_EXECUTOR_OPTIONS.map(e => ({
+                label: e.label,
+                value: e.value,
+              }))}
+            />
+          </>
+        )}
+
+        <div style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>
           创建绑定后，请在对应的飞书聊天中使用 <code>/bind &lt;项目名称&gt;</code> 命令完成绑定。
         </div>
       </Modal>

--- a/frontend/src/components/settings/messages/ProjectBindsTab.tsx
+++ b/frontend/src/components/settings/messages/ProjectBindsTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Select, Button, List, Empty, Spin, Tag, Popconfirm, message, Modal, Switch } from 'antd';
+import { Select, Button, List, Empty, Spin, Tag, Popconfirm, message, Modal, Switch, Radio } from 'antd';
 import { LinkOutlined, DisconnectOutlined, FolderOutlined, RobotOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import { PENDING_CHAT_ID } from '@/utils/database/bots';
@@ -25,6 +25,7 @@ export function ProjectBindsTab() {
   const [selectedTodoId, setSelectedTodoId] = useState<number | undefined>(undefined);
   const [bindModalOpen, setBindModalOpen] = useState(false);
   const [binding, setBinding] = useState(false);
+  const [selectedBindingId, setSelectedBindingId] = useState<number | undefined>(undefined);
 
   const loadAll = async () => {
     setLoading(true);
@@ -38,10 +39,15 @@ export function ProjectBindsTab() {
       setDirectories(d);
       setTodos(t);
 
-      if (selectedBotId !== undefined) {
-        setBindings(await db.getFeishuBindings(selectedBotId));
-      } else {
-        setBindings(await db.getFeishuBindings());
+      const bindings = selectedBotId !== undefined
+        ? await db.getFeishuBindings(selectedBotId)
+        : await db.getFeishuBindings();
+      setBindings(bindings);
+
+      // Initialize radio selection to the currently-enabled binding
+      const activeBinding = bindings.find(binding => binding.enabled);
+      if (activeBinding) {
+        setSelectedBindingId(activeBinding.id);
       }
     } catch (err: any) {
       message.error('加载数据失败: ' + (err?.message || String(err)));
@@ -117,6 +123,33 @@ export function ProjectBindsTab() {
     }
   };
 
+  const handleToggleEnabled = async (id: number, enabled: boolean) => {
+    try {
+      await db.updateFeishuBindingEnabled(id, enabled);
+      message.success(enabled ? '已启用' : '已禁用');
+      handleBotChange(selectedBotId);
+    } catch (err: any) {
+      message.error((enabled ? '启用' : '禁用') + '失败: ' + (err?.message || String(err)));
+    }
+  };
+
+  // Radio 选择：启用对应绑定（单选，同一时间只有一个活跃）
+  // 选新绑定前先禁用旧绑定，避免数据库 unique 约束冲突
+  const handleSelectBinding = async (id: number) => {
+    if (selectedBindingId === id) return; // 已是选中状态
+    try {
+      if (selectedBindingId !== undefined) {
+        await db.updateFeishuBindingEnabled(selectedBindingId, false);
+      }
+      await db.updateFeishuBindingEnabled(id, true);
+      setSelectedBindingId(id);
+      message.success('已设为活跃绑定');
+      handleBotChange(selectedBotId);
+    } catch (err: any) {
+      message.error('切换绑定失败: ' + (err?.message || String(err)));
+    }
+  };
+
   const chatTypeLabel = (t: string) => t === 'p2p' ? '私聊' : '群聊';
   const isPending = (item: FeishuProjectBindingItem) => item.chat_id === PENDING_CHAT_ID;
   const statusTag = (s: string, pending: boolean) => {
@@ -166,13 +199,21 @@ export function ProjectBindsTab() {
               }}
             >
               <div style={{ display: 'flex', alignItems: 'center', gap: 12, flex: 1, minWidth: 0 }}>
-                <RobotOutlined style={{ fontSize: 18, color: '#52c41a' }} />
+                {/* Radio 单选：表示该绑定是否被选为活跃绑定 */}
+                <Radio
+                  checked={selectedBindingId === item.id}
+                  onChange={() => handleSelectBinding(item.id)}
+                  disabled={isPending(item)}
+                  style={{ flexShrink: 0 }}
+                />
+                <RobotOutlined style={{ fontSize: 18, color: item.enabled ? '#52c41a' : '#999' }} />
                 <div style={{ flex: 1, minWidth: 0 }}>
                   <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                     <span style={{ fontWeight: 500 }}>
                       {item.project_name || item.project_path || '(未知项目)'}
                     </span>
                     {statusTag(item.status, isPending(item))}
+                    {!item.enabled && !isPending(item) && <Tag color="red">已禁用</Tag>}
                   </div>
                   <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginTop: 2 }}>
                     <FolderOutlined style={{ marginRight: 4 }} />
@@ -188,6 +229,15 @@ export function ProjectBindsTab() {
                     {item.session_id && <span> · Session: {item.session_id.slice(0, 8)}…</span>}
                   </div>
                 </div>
+                {/* 启用/禁用开关（非待绑定状态才显示） */}
+                {!isPending(item) && (
+                  <Switch
+                    size="small"
+                    checked={item.enabled}
+                    onChange={(checked) => handleToggleEnabled(item.id, checked)}
+                    style={{ flexShrink: 0 }}
+                  />
+                )}
                 <Popconfirm
                   title="确认解绑"
                   description={`解除与「${item.project_name || item.project_path}」的绑定？`}

--- a/frontend/src/components/settings/messages/ProjectBindsTab.tsx
+++ b/frontend/src/components/settings/messages/ProjectBindsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Select, Button, List, Empty, Spin, Tag, Popconfirm, message, Modal, Switch, Radio } from 'antd';
 import { LinkOutlined, DisconnectOutlined, FolderOutlined, RobotOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
@@ -6,12 +6,17 @@ import { PENDING_CHAT_ID } from '@/utils/database/bots';
 import type { AgentBot, FeishuProjectBindingItem } from '@/utils/database/bots';
 import type { ProjectDirectory } from '@/utils/database';
 import type { Todo } from '@/types';
-import { EXECUTORS, RESUMABLE_EXECUTORS } from '@/types/execution';
+import { RESUMABLE_EXECUTOR_OPTIONS, DEFAULT_EXECUTOR } from '@/types/execution';
 
-/** 仅显示支持继续对话的执行器选项 */
-const RESUMABLE_EXECUTOR_OPTIONS = EXECUTORS.filter(e => RESUMABLE_EXECUTORS.has(e.value));
-
-/** 项目绑定管理面板 — 管理飞书聊天与项目目录的绑定关系 */
+/**
+ * 项目绑定管理面板 — 管理飞书聊天与项目目录的绑定关系。
+ *
+ * 两种绑定模式：
+ * 1. 新建 Todo 模式：用户选择项目目录和执行器，系统创建新 Todo 并绑定
+ * 2. 绑定已有 Todo 模式：用户选择已有 Todo（其 workspace 必须与选定目录一致），直接复用其历史会话
+ *
+ * 同一 bot 同一时间只有一个活跃绑定（Radio 单选），禁用后保留记录可重新启用。
+ */
 export function ProjectBindsTab() {
   const [bindings, setBindings] = useState<FeishuProjectBindingItem[]>([]);
   const [bots, setBots] = useState<AgentBot[]>([]);
@@ -20,7 +25,7 @@ export function ProjectBindsTab() {
   const [loading, setLoading] = useState(false);
   const [selectedBotId, setSelectedBotId] = useState<number | undefined>(undefined);
   const [selectedDirId, setSelectedDirId] = useState<number | undefined>(undefined);
-  const [selectedExecutor, setSelectedExecutor] = useState<string>('claudecode');
+  const [selectedExecutor, setSelectedExecutor] = useState<string>(DEFAULT_EXECUTOR);
   const [bindToExisting, setBindToExisting] = useState(false);
   const [selectedTodoId, setSelectedTodoId] = useState<number | undefined>(undefined);
   const [bindModalOpen, setBindModalOpen] = useState(false);
@@ -71,13 +76,32 @@ export function ProjectBindsTab() {
     }
   };
 
+  /**
+   * 重置 Modal 状态为默认值，确保每次打开 Modal 都是干净的创建流程。
+   *
+   * 之所以单独抽成函数而不是内联，是因为：
+   * 1. Modal 打开和取消时都要重置，需要复用
+   * 2. resetModal 保证了状态的一致性，避免遗漏某个字段
+   *
+   * 默认值策略：executor 使用 DEFAULT_EXECUTOR（系统统一默认执行器），
+   * bindToExisting 和 selectedTodoId 清空，确保进入"新建 Todo"模式。
+   */
   const resetModal = () => {
     setSelectedDirId(undefined);
-    setSelectedExecutor('claudecode');
+    setSelectedExecutor(DEFAULT_EXECUTOR);
     setBindToExisting(false);
     setSelectedTodoId(undefined);
   };
 
+  /**
+   * 创建绑定。
+   *
+   * executor 和 todo_id 为互斥字段：
+   * - bindToExisting=true 时传入 todo_id（绑定已有 Todo，复用其历史会话），executor 传 undefined
+   * - bindToExisting=false 时传入 executor（新建 Todo），todo_id 传 undefined
+   *
+   * 之所以传 undefined 而非省略字段，是为了保持请求结构完整，便于后端做互斥校验。
+   */
   const handleCreateBinding = async () => {
     if (selectedBotId === undefined) {
       message.error('请选择 Bot');
@@ -145,8 +169,12 @@ export function ProjectBindsTab() {
     }
   };
 
-  // Radio 选择：启用对应绑定（单选，同一时间只有一个活跃）
-  // 选新绑定前先禁用旧绑定，避免数据库 unique 约束冲突
+  /**
+   * Radio 单选：启用对应绑定（同一时间只有一个活跃）。
+   *
+   * 选新绑定前先禁用旧绑定，避免数据库 partial unique index 约束冲突
+   *（同一个 bot+chat 只能有一个 enabled=true 的绑定）。
+   */
   const handleSelectBinding = async (id: number) => {
     if (selectedBindingId === id) return; // 已是选中状态
     try {
@@ -170,8 +198,22 @@ export function ProjectBindsTab() {
     return <Tag>空闲</Tag>;
   };
 
-  // 过滤出有 workspace 的项目类 Todo，供用户选择绑定到已有 Todo
-  const projectTodos = todos.filter(t => t.workspace);
+  /**
+   * 过滤出可绑定到已有 Todo 的列表。
+   *
+   * 仅显示有 workspace 的 Todo，且其 workspace 必须与用户当前选定的项目目录一致，
+   * 避免跨项目错绑导致历史会话上下文错位（后端会强制更新 Todo 的 workspace）。
+   * 若用户尚未选择目录，则显示所有有 workspace 的 Todo。
+   */
+  const projectTodos = useMemo(() => {
+    const selectedDir = directories.find(d => d.id === selectedDirId);
+    const dirPath = selectedDir?.path;
+    return todos.filter(t => {
+      if (!t.workspace) return false;
+      // 若已选目录，仅显示 workspace 与目录路径一致的 Todo
+      return dirPath ? t.workspace === dirPath : true;
+    });
+  }, [todos, directories, selectedDirId]);
 
   return (
     <Spin spinning={loading}>
@@ -292,6 +334,7 @@ export function ProjectBindsTab() {
           placeholder="选择项目目录"
           style={{ width: '100%', marginBottom: 12 }}
           value={selectedDirId}
+          // 切换目录时清空已选 Todo，避免目录与 Todo workspace 不匹配的误解
           onChange={(v) => { setSelectedDirId(v); setSelectedTodoId(undefined); }}
           options={directories.map(d => ({
             label: `${d.name || '(未命名)'} — ${d.path}`,
@@ -299,11 +342,20 @@ export function ProjectBindsTab() {
           }))}
         />
 
-        {/* 绑定已有 Todo 开关 */}
+        {/*
+          绑定已有 Todo 开关。
+          Switch 而非 Radio，因为这两个模式是互斥的独立状态，不是同一属性的多个选项。
+          切换时重置 selectedTodoId（确保旧选择不影响新流程），同时重置 selectedExecutor
+          回到默认的 DEFAULT_EXECUTOR，保证关闭后用户看到的是新建模式的正确默认值。
+        */}
         <div style={{ marginBottom: 12, display: 'flex', alignItems: 'center', gap: 8 }}>
           <Switch
             checked={bindToExisting}
-            onChange={(checked) => { setBindToExisting(checked); setSelectedTodoId(undefined); }}
+            onChange={(checked) => {
+              setBindToExisting(checked);
+              setSelectedTodoId(undefined);
+              setSelectedExecutor(DEFAULT_EXECUTOR);
+            }}
             size="small"
           />
           <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>
@@ -313,6 +365,10 @@ export function ProjectBindsTab() {
 
         {bindToExisting ? (
           <>
+            {/*
+              Todo 选择器：仅显示 workspace 与选定目录一致的 Todo。
+              Label 格式为 "#id title · workspace路径"，方便用户确认选中的是正确的 Todo。
+            */}
             <div style={{ marginBottom: 8, fontSize: 13, color: 'var(--color-text-secondary)' }}>
               选择要绑定的 Todo：
             </div>
@@ -329,6 +385,10 @@ export function ProjectBindsTab() {
           </>
         ) : (
           <>
+            {/*
+              执行器选择：仅显示支持继续对话的执行器（RESUMABLE_EXECUTOR_OPTIONS）。
+              默认值为 DEFAULT_EXECUTOR，这是系统统一的默认执行器。
+            */}
             <div style={{ marginBottom: 8, fontSize: 13 }}>选择执行器（仅支持继续对话的执行器）：</div>
             <Select
               style={{ width: '100%', marginBottom: 12 }}

--- a/frontend/src/components/settings/messages/ProjectBindsTab.tsx
+++ b/frontend/src/components/settings/messages/ProjectBindsTab.tsx
@@ -113,13 +113,25 @@ export function ProjectBindsTab() {
     }
   };
 
-  const handleDeleteBinding = async (id: number) => {
+  // 解绑：仅禁用（enabled=false），保留记录
+  const handleUnbindBinding = async (id: number) => {
     try {
-      await db.deleteFeishuBinding(id);
+      await db.updateFeishuBindingEnabled(id, false);
       message.success('已解绑');
       handleBotChange(selectedBotId);
     } catch (err: any) {
       message.error('解绑失败: ' + (err?.message || String(err)));
+    }
+  };
+
+  // 删除：彻底删除绑定记录
+  const handleDeleteBinding = async (id: number) => {
+    try {
+      await db.deleteFeishuBinding(id);
+      message.success('已删除');
+      handleBotChange(selectedBotId);
+    } catch (err: any) {
+      message.error('删除失败: ' + (err?.message || String(err)));
     }
   };
 
@@ -238,12 +250,27 @@ export function ProjectBindsTab() {
                     style={{ flexShrink: 0 }}
                   />
                 )}
+                {/* 解绑：仅禁用（enabled=false），保留记录 */}
+                {!isPending(item) && (
+                  <Popconfirm
+                    title="确认解绑"
+                    description={`解除与「${item.project_name || item.project_path}」的绑定？（可随时重新启用）`}
+                    onConfirm={() => handleUnbindBinding(item.id)}
+                  >
+                    <Button type="text" icon={<DisconnectOutlined />} size="small">
+                      解绑
+                    </Button>
+                  </Popconfirm>
+                )}
+                {/* 删除：彻底删除记录 */}
                 <Popconfirm
-                  title="确认解绑"
-                  description={`解除与「${item.project_name || item.project_path}」的绑定？`}
+                  title="确认删除"
+                  description={`删除与「${item.project_name || item.project_path}」的绑定记录？此操作不可恢复。`}
                   onConfirm={() => handleDeleteBinding(item.id)}
                 >
-                  <Button type="text" danger icon={<DisconnectOutlined />} size="small" />
+                  <Button type="text" danger size="small">
+                    删除
+                  </Button>
                 </Popconfirm>
               </div>
             </List.Item>

--- a/frontend/src/types/execution.tsx
+++ b/frontend/src/types/execution.tsx
@@ -163,6 +163,12 @@ export function getExecutorOption(value: string): ExecutorOption {
 
 export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'joinai', 'hermes', 'codewhale']);
 
+/// 默认执行器
+export const DEFAULT_EXECUTOR = 'claudecode';
+
+/** 仅支持继续对话的执行器（用于选择 UI 的下拉数据源） */
+export const RESUMABLE_EXECUTOR_OPTIONS = EXECUTORS.filter(e => RESUMABLE_EXECUTORS.has(e.value));
+
 export function supportsResume(record: ExecutionRecord): boolean {
   return (
     record.status !== 'running' &&

--- a/frontend/src/utils/database/bots.ts
+++ b/frontend/src/utils/database/bots.ts
@@ -255,12 +255,23 @@ export async function getFeishuBindings(botId?: number): Promise<FeishuProjectBi
   return unwrap(await api.get('/api/feishu/bindings', { params }));
 }
 
+/**
+ * 创建飞书项目绑定。
+ *
+ * executor 和 todo_id 为互斥参数：
+ * - 传入 executor（支持继续对话的执行器）表示新建 Todo
+ * - 传入 todo_id（已有 Todo 的 ID）表示绑定到已有 Todo，复用其历史会话
+ *
+ * 两者都传时后端返回错误。都不传时后端使用默认 executor 新建 Todo。
+ */
 export async function createFeishuBinding(params: {
   bot_id: number;
   chat_id: string;
   chat_type: string;
   project_dir_id: number;
+  /** 指定执行器（可选，仅在新建 Todo 时使用）。仅支持 claudecode/kimi/opencode/joinai/hermes/codewhale */
   executor?: string;
+  /** 绑定到已有 Todo（可选）。提供后表示复用该 Todo 的历史会话，与 executor 互斥 */
   todo_id?: number;
 }): Promise<FeishuProjectBindingItem> {
   return unwrap(await api.post('/api/feishu/bindings', params));

--- a/frontend/src/utils/database/bots.ts
+++ b/frontend/src/utils/database/bots.ts
@@ -259,6 +259,8 @@ export async function createFeishuBinding(params: {
   chat_id: string;
   chat_type: string;
   project_dir_id: number;
+  executor?: string;
+  todo_id?: number;
 }): Promise<FeishuProjectBindingItem> {
   return unwrap(await api.post('/api/feishu/bindings', params));
 }

--- a/frontend/src/utils/database/bots.ts
+++ b/frontend/src/utils/database/bots.ts
@@ -242,6 +242,7 @@ export interface FeishuProjectBindingItem {
   session_id: string | null;
   latest_record_id: number | null;
   status: string;
+  enabled: boolean;
   created_at: string;
   updated_at: string;
   project_name: string | null;
@@ -267,4 +268,8 @@ export async function createFeishuBinding(params: {
 
 export async function deleteFeishuBinding(id: number): Promise<void> {
   await api.delete(`/api/feishu/bindings/${id}`);
+}
+
+export async function updateFeishuBindingEnabled(id: number, enabled: boolean): Promise<FeishuProjectBindingItem> {
+  return unwrap(await api.patch(`/api/feishu/bindings/${id}/enabled`, { enabled }));
 }


### PR DESCRIPTION
## 功能

- **新建绑定时可选执行器**：仅显示支持继续对话的执行器（claudecode/kimi/opencode/joinai/hermes/codewhale）
- **绑定到已有 Todo**：新增开关，打开后可选择已有 Todo，绑定后继续之前的对话历史
- 两者互斥：选已有 Todo 时不需选执行器（复用原 Todo 的）；新建 Todo 时才选执行器

## 技术改动

**后端**：
- `CreateBindingRequest` 新增 `executor` + `todo_id` 字段
- `db/todo.rs` 新增 `create_todo_with_executor()` 方法
- `create_binding` handler：优先用 `todo_id` 绑定已有 Todo，否则新建

**前端**：
- `ProjectBindsTab` Modal 新增 Switch 切换「新建 Todo」/「绑定已有 Todo」
- `createFeishuBinding` 支持 `executor` 和 `todo_id` 参数