### PR TITLE
refactor: rename joinai executor to mobilecoder

### DIFF
--- a/backend/src/adapters/mobilecoder.rs
+++ b/backend/src/adapters/mobilecoder.rs
@@ -2,29 +2,29 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
-use super::joinai_event::JoinaiAgentEvent;
+use super::mobilecoder_event::MobilecoderAgentEvent;
 use crate::models::utc_timestamp;
 
-pub struct JoinaiExecutor {
+pub struct MobilecoderExecutor {
     path: String,
     usage: Arc<Mutex<Option<ExecutionUsage>>>,
 }
 
-impl JoinaiExecutor {
+impl MobilecoderExecutor {
     pub fn new(path: String) -> Self {
         Self { path, usage: Arc::new(Mutex::new(None)) }
     }
 }
 
-impl Clone for JoinaiExecutor {
+impl Clone for MobilecoderExecutor {
     fn clone(&self) -> Self {
         Self { path: self.path.clone(), usage: self.usage.clone() }
     }
 }
 
-impl CodeExecutor for JoinaiExecutor {
+impl CodeExecutor for MobilecoderExecutor {
     fn executor_type(&self) -> ExecutorType {
-        ExecutorType::Joinai
+        ExecutorType::Mobilecoder
     }
 
     fn executable_path(&self) -> &str {
@@ -65,12 +65,12 @@ impl CodeExecutor for JoinaiExecutor {
     }
 
     fn extract_session_id(&self, line: &str) -> Option<String> {
-        let event: JoinaiAgentEvent = serde_json::from_str(line).ok()?;
+        let event: MobilecoderAgentEvent = serde_json::from_str(line).ok()?;
         event.session_id.or_else(|| event.part.as_ref()?.session_id.clone())
     }
 
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
-        let event: JoinaiAgentEvent = serde_json::from_str(line).ok()?;
+        let event: MobilecoderAgentEvent = serde_json::from_str(line).ok()?;
 
         let timestamp = event.timestamp
             .map(|ts| {
@@ -189,7 +189,7 @@ impl CodeExecutor for JoinaiExecutor {
     }
 
     fn get_model(&self) -> Option<String> {
-        // Joinai doesn't provide model info
+        // MobileCoder doesn't provide model info
         None
     }
 }
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_step_start() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let line = r#"{"type":"step_start","timestamp":1700000000000}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "step_start");
@@ -210,7 +210,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_tool_use_bash() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let line = r#"{"type":"tool_use","timestamp":1700000000000,"part":{"type":"tool_use","tool":"bash","state":{"status":"success","input":{"description":"list files"},"output":"file.txt"}}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "tool");
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_text() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let line = r#"{"type":"text","timestamp":1700000000000,"part":{"type":"text","text":"hello world"}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "text");
@@ -230,7 +230,7 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_step_finish_stores_usage() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let line = r#"{"type":"step_finish","timestamp":1700000000000,"part":{"type":"step_finish","tokens":{"total":100,"input":50,"output":50,"cache":{"read":10,"write":5}},"cost":0.001}}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "step_finish");
@@ -246,28 +246,28 @@ mod tests {
 
     #[test]
     fn test_parse_output_line_unknown_type() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let line = r#"{"type":"unknown","timestamp":1700000000000}"#;
         assert!(executor.parse_output_line(line).is_none());
     }
 
     #[test]
     fn test_parse_output_line_invalid_json() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let line = "not json";
         assert!(executor.parse_output_line(line).is_none());
     }
 
     #[test]
     fn test_parse_output_line_empty_text() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let line = r#"{"type":"text","timestamp":1700000000000,"part":{"type":"text","text":""}}"#;
         assert!(executor.parse_output_line(line).is_none());
     }
 
     #[test]
     fn test_get_final_result_with_text() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let logs = vec![
             ParsedLogEntry::new("text", "  hello world  "),
         ];
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn test_get_final_result_fallback_to_stderr() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let logs = vec![
             ParsedLogEntry::new("stderr", "error output"),
         ];
@@ -285,27 +285,27 @@ mod tests {
 
     #[test]
     fn test_get_final_result_empty_logs() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let logs: Vec<ParsedLogEntry> = vec![];
         assert!(executor.get_final_result(&logs).is_none());
     }
 
     #[test]
     fn test_get_usage_before_step_finish() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         assert!(executor.get_usage(&[]).is_none());
     }
 
     #[test]
     fn test_get_model_always_none() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         assert!(executor.get_model().is_none());
     }
 
     #[test]
     fn test_parse_output_line_with_iso_timestamp() {
         // New version: ISO 8601 string timestamp
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let line = r#"{"type":"step_start","timestamp":"2026-05-12T06:08:58.721Z","content":"Step started"}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "step_start");
@@ -316,7 +316,7 @@ mod tests {
     #[test]
     fn test_parse_output_line_with_number_timestamp_milliseconds() {
         // Milliseconds format (13+ digits) should still work
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let line = r#"{"type":"step_start","timestamp":1700000000000,"content":"Step started"}"#;
         let entry = executor.parse_output_line(line).unwrap();
         assert_eq!(entry.log_type, "step_start");

--- a/backend/src/adapters/mobilecoder_event.rs
+++ b/backend/src/adapters/mobilecoder_event.rs
@@ -1,6 +1,6 @@
-//! JoinAI-specific event parsing.
+//! MobileCoder-specific event parsing.
 //!
-//! JoinAI uses underscore-separated event types (e.g., step_start, tool_use) and
+//! MobileCoder uses underscore-separated event types (e.g., step_start, tool_use) and
 //! follows a different naming convention.
 
 use std::collections::HashMap;
@@ -8,56 +8,56 @@ use serde::Deserialize;
 
 /// Flexible timestamp that can be deserialized from both numbers and strings.
 #[derive(Debug, Clone)]
-pub struct JoinAITimestamp(pub String);
+pub struct MobilecoderTimestamp(pub String);
 
-impl<'de> Deserialize<'de> for JoinAITimestamp {
+impl<'de> Deserialize<'de> for MobilecoderTimestamp {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        struct JoinAITimestampVisitor;
-        impl<'de> serde::de::Visitor<'de> for JoinAITimestampVisitor {
-            type Value = JoinAITimestamp;
+        struct MobilecoderTimestampVisitor;
+        impl<'de> serde::de::Visitor<'de> for MobilecoderTimestampVisitor {
+            type Value = MobilecoderTimestamp;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("a number (u64) or a string")
             }
 
-            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<JoinAITimestamp, E> {
-                Ok(JoinAITimestamp(v.to_string()))
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<MobilecoderTimestamp, E> {
+                Ok(MobilecoderTimestamp(v.to_string()))
             }
 
-            fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<JoinAITimestamp, E> {
-                Ok(JoinAITimestamp(v.to_string()))
+            fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<MobilecoderTimestamp, E> {
+                Ok(MobilecoderTimestamp(v.to_string()))
             }
 
-            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<JoinAITimestamp, E> {
-                Ok(JoinAITimestamp(v.to_string()))
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<MobilecoderTimestamp, E> {
+                Ok(MobilecoderTimestamp(v.to_string()))
             }
 
-            fn visit_string<E: serde::de::Error>(self, v: String) -> Result<JoinAITimestamp, E> {
-                Ok(JoinAITimestamp(v))
+            fn visit_string<E: serde::de::Error>(self, v: String) -> Result<MobilecoderTimestamp, E> {
+                Ok(MobilecoderTimestamp(v))
             }
         }
-        deserializer.deserialize_any(JoinAITimestampVisitor)
+        deserializer.deserialize_any(MobilecoderTimestampVisitor)
     }
 }
 
-/// JoinAI agent event with underscore-separated type names
+/// MobileCoder agent event with underscore-separated type names
 #[derive(Debug, Clone, Deserialize)]
-pub struct JoinaiAgentEvent {
+pub struct MobilecoderAgentEvent {
     #[serde(rename = "type")]
     pub event_type: String,
     #[serde(default)]
-    pub timestamp: Option<JoinAITimestamp>,
+    pub timestamp: Option<MobilecoderTimestamp>,
     #[serde(default, rename = "sessionID")]
     pub session_id: Option<String>,
     #[serde(default)]
-    pub part: Option<JoinaiAgentPart>,
+    pub part: Option<MobilecoderAgentPart>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct JoinaiAgentPart {
+pub struct MobilecoderAgentPart {
     #[serde(rename = "type")]
     pub part_type: Option<String>,
     #[serde(default)]
@@ -69,13 +69,13 @@ pub struct JoinaiAgentPart {
     #[serde(default)]
     pub call_id: Option<String>,
     #[serde(default)]
-    pub state: Option<JoinaiAgentToolState>,
+    pub state: Option<MobilecoderAgentToolState>,
     #[serde(default)]
     pub message_id: Option<String>,
     #[serde(default, rename = "sessionID")]
     pub session_id: Option<String>,
     #[serde(default)]
-    pub tokens: Option<JoinaiAgentTokens>,
+    pub tokens: Option<MobilecoderAgentTokens>,
     #[serde(default)]
     pub cost: Option<f64>,
     #[serde(default)]
@@ -83,17 +83,17 @@ pub struct JoinaiAgentPart {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct JoinaiAgentToolState {
+pub struct MobilecoderAgentToolState {
     #[serde(default)]
     pub status: Option<String>,
     #[serde(default)]
-    pub input: Option<JoinaiAgentToolInput>,
+    pub input: Option<MobilecoderAgentToolInput>,
     #[serde(default)]
     pub output: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct JoinaiAgentToolInput {
+pub struct MobilecoderAgentToolInput {
     #[serde(default)]
     pub command: Option<String>,
     #[serde(default)]
@@ -102,7 +102,7 @@ pub struct JoinaiAgentToolInput {
     pub extra: HashMap<String, serde_json::Value>,
 }
 
-impl JoinaiAgentToolInput {
+impl MobilecoderAgentToolInput {
     pub fn to_full_json(&self) -> String {
         let mut map = serde_json::Map::new();
         if let Some(ref cmd) = self.command {
@@ -119,18 +119,18 @@ impl JoinaiAgentToolInput {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct JoinaiAgentTokens {
+pub struct MobilecoderAgentTokens {
     pub total: u64,
     pub input: u64,
     pub output: u64,
     #[serde(default)]
     pub reasoning: u64,
     #[serde(default)]
-    pub cache: JoinaiAgentCacheTokens,
+    pub cache: MobilecoderAgentCacheTokens,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
-pub struct JoinaiAgentCacheTokens {
+pub struct MobilecoderAgentCacheTokens {
     #[serde(default)]
     pub read: u64,
     #[serde(default)]

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -88,12 +88,12 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         aliases: &[],
     },
     ExecutorDef {
-        name: "joinai",
-        executor_type: ExecutorType::Joinai,
-        binary_name: "joinai",
-        display_name: "JoinAI",
-        default_path: "joinai",
-        session_dir: "",
+        name: "mobilecoder",
+        executor_type: ExecutorType::Mobilecoder,
+        binary_name: "mobile",
+        display_name: "MobileCoder",
+        default_path: "mobile",
+        session_dir: "~/.mobile-coder",
         aliases: &[],
     },
     ExecutorDef {
@@ -117,7 +117,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
 ];
 
 /// 支持继续对话的执行器集合（与前端 RESUMABLE_EXECUTORS 保持一致）
-pub const RESUMABLE_EXECUTORS: &[&str] = &["claudecode", "kimi", "opencode", "joinai", "hermes", "codewhale"];
+pub const RESUMABLE_EXECUTORS: &[&str] = &["claudecode", "kimi", "opencode", "mobilecoder", "hermes", "codewhale"];
 
 /// 默认执行器
 pub const DEFAULT_EXECUTOR: &str = "claudecode";
@@ -167,8 +167,8 @@ pub fn get_usage_from_logs(logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
     logs.iter().rev().find(|l| l.log_type == "result")?.usage.clone()
 }
 
-pub mod joinai;
-pub mod joinai_event;
+pub mod mobilecoder;
+pub mod mobilecoder_event;
 pub mod claude_protocol;
 pub mod agent_event;
 pub mod claude_code;
@@ -282,7 +282,7 @@ impl ExecutorRegistry {
         let exec = find_executor(name)?;
         let executor: Arc<dyn CodeExecutor> = match exec.name {
             "claudecode" => Arc::new(claude_code::ClaudeCodeExecutor::new(path.to_string())),
-            "joinai" => Arc::new(joinai::JoinaiExecutor::new(path.to_string())),
+            "mobilecoder" => Arc::new(mobilecoder::MobilecoderExecutor::new(path.to_string())),
             "codebuddy" => Arc::new(codebuddy::CodebuddyExecutor::new(path.to_string())),
             "opencode" => Arc::new(opencode::OpencodeExecutor::new(path.to_string())),
             "atomcode" => Arc::new(atomcode::AtomcodeExecutor::new(path.to_string())),
@@ -343,8 +343,8 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_executor_type_joinai() {
-        assert_eq!(parse_executor_type("joinai"), Some(ExecutorType::Joinai));
+    fn test_parse_executor_type_mobilecoder() {
+        assert_eq!(parse_executor_type("mobilecoder"), Some(ExecutorType::Mobilecoder));
     }
 
     #[test]
@@ -410,8 +410,8 @@ mod tests {
     #[tokio::test]
     async fn test_executor_registry_register_and_get() {
         let reg = ExecutorRegistry::new();
-        reg.register(joinai::JoinaiExecutor::new("joinai".to_string())).await;
-        assert!(reg.get(ExecutorType::Joinai).await.is_some());
+        reg.register(mobilecoder::MobilecoderExecutor::new("mobile".to_string())).await;
+        assert!(reg.get(ExecutorType::Mobilecoder).await.is_some());
     }
 
     #[tokio::test]
@@ -430,11 +430,11 @@ mod tests {
     #[tokio::test]
     async fn test_executor_registry_list_executors() {
         let reg = ExecutorRegistry::new();
-        reg.register(joinai::JoinaiExecutor::new("joinai".to_string())).await;
+        reg.register(mobilecoder::MobilecoderExecutor::new("mobile".to_string())).await;
         reg.register(claude_code::ClaudeCodeExecutor::new("claude".to_string())).await;
         let list = reg.list_executors().await;
         assert_eq!(list.len(), 2);
-        assert!(list.contains(&ExecutorType::Joinai));
+        assert!(list.contains(&ExecutorType::Mobilecoder));
         assert!(list.contains(&ExecutorType::Claudecode));
     }
 
@@ -443,7 +443,7 @@ mod tests {
 
     #[async_trait]
     impl CodeExecutor for MockExecutor {
-        fn executor_type(&self) -> ExecutorType { ExecutorType::Joinai }
+        fn executor_type(&self) -> ExecutorType { ExecutorType::Mobilecoder }
         fn executable_path(&self) -> &str { "mock" }
         fn command_args(&self, _message: &str) -> Vec<String> { vec![] }
         fn parse_output_line(&self, _line: &str) -> Option<ParsedLogEntry> { None }

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -80,7 +80,7 @@ pub enum TodoAction {
         #[arg(long)]
         stdin: bool,
 
-        /// Executor type (claudecode, joinai, codebuddy, opencode, atomcode, hermes, kimi, codex, codewhale)
+        /// Executor type (claudecode, mobilecoder, codebuddy, opencode, atomcode, hermes, kimi, codex, codewhale)
         #[arg(short, long)]
         executor: Option<String>,
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -371,8 +371,11 @@ mod tests {
 
     #[test]
     fn test_normalize_single_path_tilde_expansion() {
+        // 测试路径归一化能正确展开 ~ 为用户 home 目录，
+        // 验证 path_concat 在处理带 ~ 前缀路径时的正确性。
         let home = dirs::home_dir().expect("need home dir for test");
         let result = Config::normalize_single_path("~/bin/mobile");
+        // 归一化后的路径应将 ~ 展开为 home_join("bin").join("mobile")
         let expected = home.join("bin").join("mobile").to_string_lossy().to_string();
         assert_eq!(result, expected, "~ should expand to home directory");
     }
@@ -390,9 +393,11 @@ mod tests {
 
     #[test]
     fn test_normalize_single_path_bare_command() {
+        // 裸命令名（无路径斜杠）应原样保留，让系统在 $PATH 中查找
         let result = Config::normalize_single_path("opencode");
         assert_eq!(result, "opencode", "bare command name should be left untouched for PATH lookup");
 
+        // 同上，验证 mobilecoder 作为裸命令名时也能正确透传
         let result = Config::normalize_single_path("mobilecoder");
         assert_eq!(result, "mobilecoder", "bare command name should be left untouched for PATH lookup");
     }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -372,8 +372,8 @@ mod tests {
     #[test]
     fn test_normalize_single_path_tilde_expansion() {
         let home = dirs::home_dir().expect("need home dir for test");
-        let result = Config::normalize_single_path("~/bin/joinai");
-        let expected = home.join("bin").join("joinai").to_string_lossy().to_string();
+        let result = Config::normalize_single_path("~/bin/mobile");
+        let expected = home.join("bin").join("mobile").to_string_lossy().to_string();
         assert_eq!(result, expected, "~ should expand to home directory");
     }
 
@@ -393,8 +393,8 @@ mod tests {
         let result = Config::normalize_single_path("opencode");
         assert_eq!(result, "opencode", "bare command name should be left untouched for PATH lookup");
 
-        let result = Config::normalize_single_path("joinai");
-        assert_eq!(result, "joinai", "bare command name should be left untouched for PATH lookup");
+        let result = Config::normalize_single_path("mobilecoder");
+        assert_eq!(result, "mobilecoder", "bare command name should be left untouched for PATH lookup");
     }
 
     #[test]

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1688,9 +1688,9 @@ mod tests {
     async fn test_update_todo_executor() {
         let db = setup_db().await;
         let id = db.create_todo("Test", "Prompt").await.unwrap();
-        db.update_todo_executor(id, "joinai").await.unwrap();
+        db.update_todo_executor(id, "mobilecoder").await.unwrap();
         let todo = db.get_todo(id).await.unwrap().unwrap();
-        assert_eq!(todo.executor, Some("joinai".to_string()));
+        assert_eq!(todo.executor, Some("mobilecoder".to_string()));
     }
 
     #[tokio::test]

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -1063,7 +1063,7 @@ fn all_executor_skills_dirs() -> Vec<(&'static str, PathBuf)> {
         ("opencode", home.join(".opencode").join("skills")),
         ("atomcode", home.join(".atomcode").join("skills")),
         ("kimi", home.join(".kimi").join("skills")),
-        ("joinai", home.join(".joinai").join("skills")),
+        ("mobilecoder", home.join(".mobile-coder").join("skills")),
     ]
 }
 

--- a/backend/src/handlers/feishu_binding.rs
+++ b/backend/src/handlers/feishu_binding.rs
@@ -8,7 +8,7 @@ use crate::models::ApiResponse;
 /// 创建飞书项目绑定的请求体。
 ///
 /// executor 和 todo_id 为互斥字段，不能同时提供：
-/// - executor（执行器名）：创建新 Todo 时使用，仅支持继续对话的执行器（claudecode/kimi/opencode/joinai/hermes/codewhale）。
+/// - executor（执行器名）：创建新 Todo 时使用，仅支持继续对话的执行器（claudecode/kimi/opencode/mobilecoder/hermes/codewhale）。
 ///   为 None 时默认为 claudecode。
 /// - todo_id（已有 Todo ID）：绑定到已有 Todo 时使用，复用该 Todo 的历史会话记录。
 ///   两者都传或都不传时行为由业务层决定（当前为互斥校验）。
@@ -19,7 +19,7 @@ pub struct CreateBindingRequest {
     pub chat_type: String,
     pub project_dir_id: i64,
     /// 指定执行器（可选），仅在新建 Todo 时有效。
-    /// 仅支持继续对话的执行器（claudecode/kimi/opencode/joinai/hermes/codewhale）。
+    /// 仅支持继续对话的执行器（claudecode/kimi/opencode/mobilecoder/hermes/codewhale）。
     /// 为 None 或空串时默认为 claudecode。
     pub executor: Option<String>,
     /// 绑定到已有 Todo（可选），与 executor 互斥。

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -626,7 +626,7 @@ fn get_scanner(name: &str) -> Option<fn(&mut Vec<SessionInfo>)> {
         "hermes" => Some(scan_hermes),
         "kimi" => Some(scan_kimi),
         "atomcode" => Some(scan_atomcode),
-        "codebuddy" | "opencode" | "joinai" => None, // no session storage found
+        "codebuddy" | "opencode" | "mobilecoder" => None, // no session storage found
         _ => None,
     }
 }

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -33,7 +33,7 @@ pub fn executor_skills_dir_str(et: &str) -> Option<PathBuf> {
         "opencode" => Some(home.join(".opencode").join("skills")),
         "atomcode" => Some(home.join(".atomcode").join("skills")),
         "kimi" => Some(home.join(".kimi").join("skills")),
-        "joinai" => Some(home.join(".joinai").join("skills")),
+        "mobilecoder" => Some(home.join(".mobile-coder").join("skills")),
         // agents 是只读 skill 来源：扫描但不参与执行器管理/Todo 执行
         "agents" => Some(home.join(".agents").join("skills")),
         _ => None,
@@ -119,7 +119,7 @@ fn executor_label(et: ExecutorType) -> &'static str {
         ExecutorType::Opencode => "Opencode",
         ExecutorType::Atomcode => "AtomCode",
         ExecutorType::Kimi => "Kimi",
-        ExecutorType::Joinai => "JoinAI",
+        ExecutorType::Mobilecoder => "MobileCoder",
         ExecutorType::Codewhale => "CodeWhale",
     }
 }
@@ -134,7 +134,7 @@ const ALL_EXECUTORS: [ExecutorType; 9] = [
     ExecutorType::Opencode,
     ExecutorType::Atomcode,
     ExecutorType::Kimi,
-    ExecutorType::Joinai,
+    ExecutorType::Mobilecoder,
     ExecutorType::Codewhale,
 ];
 
@@ -485,7 +485,7 @@ fn discover_skills_for_executor(et: ExecutorType) -> ExecutorSkills {
 /// 3. 如果不是 ExecutorType，在 `executor_label_for_source` 加显示名
 const ALL_SKILL_SOURCES: &[&str] = &[
     "claudecode", "codebuddy", "opencode", "atomcode",
-    "hermes", "kimi", "joinai", "codex",
+    "hermes", "kimi", "mobilecoder", "codex",
     "agents",
 ];
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -262,7 +262,7 @@ fn executor_skills_dir(et: &str) -> Option<PathBuf> {
 
 const ALL_EXECUTORS: &[&str] = &[
     "claudecode", "hermes", "codex", "codebuddy",
-    "opencode", "atomcode", "kimi", "joinai", "codewhale",
+    "opencode", "atomcode", "kimi", "mobilecoder", "codewhale",
 ];
 
 /// Install embedded ntd-usage skill to executor skill directories.

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -690,7 +690,7 @@ pub struct ExecutorDetectInfo {
 #[serde(rename_all = "lowercase")]
 #[derive(Default)]
 pub enum ExecutorType {
-    Joinai,
+    Mobilecoder,
     #[default]
     Claudecode,
     Codebuddy,
@@ -706,7 +706,7 @@ pub enum ExecutorType {
 impl ExecutorType {
     pub fn as_str(&self) -> &'static str {
         match self {
-            ExecutorType::Joinai => "joinai",
+            ExecutorType::Mobilecoder => "mobilecoder",
             ExecutorType::Claudecode => "claudecode",
             ExecutorType::Codebuddy => "codebuddy",
             ExecutorType::Opencode => "opencode",
@@ -881,7 +881,7 @@ mod tests {
 
     #[test]
     fn test_executor_type_as_str() {
-        assert_eq!(ExecutorType::Joinai.as_str(), "joinai");
+        assert_eq!(ExecutorType::Mobilecoder.as_str(), "mobilecoder");
         assert_eq!(ExecutorType::Claudecode.as_str(), "claudecode");
         assert_eq!(ExecutorType::Codebuddy.as_str(), "codebuddy");
         assert_eq!(ExecutorType::Opencode.as_str(), "opencode");

--- a/backend/tests/adapter_extended_tests.rs
+++ b/backend/tests/adapter_extended_tests.rs
@@ -451,13 +451,13 @@ mod kimi_executor_extended_tests {
 }
 
 #[cfg(test)]
-mod joinai_executor_extended_tests {
-    use ntd::adapters::joinai::JoinaiExecutor;
+mod mobilecoder_executor_extended_tests {
+    use ntd::adapters::mobilecoder::MobilecoderExecutor;
     use ntd::adapters::CodeExecutor;
 
     #[test]
     fn test_extract_session_id_from_event() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let line = r#"{"type":"step_start","sessionID":"ses_abc123"}"#;
         let session = executor.extract_session_id(line);
         assert_eq!(session, Some("ses_abc123".to_string()));
@@ -465,7 +465,7 @@ mod joinai_executor_extended_tests {
 
     #[test]
     fn test_extract_session_id_from_part() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let line = r#"{"type":"text","part":{"sessionID":"ses_xyz789"},"text":"hello"}"#;
         let session = executor.extract_session_id(line);
         assert_eq!(session, Some("ses_xyz789".to_string()));
@@ -473,7 +473,7 @@ mod joinai_executor_extended_tests {
 
     #[test]
     fn test_extract_session_id_not_found() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let line = r#"{"type":"text","text":"hello"}"#;
         let session = executor.extract_session_id(line);
         assert!(session.is_none());
@@ -481,20 +481,20 @@ mod joinai_executor_extended_tests {
 
     #[test]
     fn test_extract_session_id_invalid_json() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let session = executor.extract_session_id("not json");
         assert!(session.is_none());
     }
 
     #[test]
     fn test_supports_resume() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         assert!(executor.supports_resume());
     }
 
     #[test]
     fn test_extract_session_id_from_real_api_response() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let line = r#"{"type":"step_start","timestamp":1779069382034,"sessionID":"ses_1c73b5ee0ffef5UHX2DuxZj9uF","part":{"id":"prt_e38cc6d8f001nXvt3aI6D6IfT7","sessionID":"ses_1c73b5ee0ffef5UHX2DuxZj9uF","messageID":"msg_e38cb2991001z0vtz9Wng3siRh","type":"step-start","snapshot":"1779069382030"}}"#;
         let session = executor.extract_session_id(line);
         assert_eq!(session, Some("ses_1c73b5ee0ffef5UHX2DuxZj9uF".to_string()));
@@ -502,7 +502,7 @@ mod joinai_executor_extended_tests {
 
     #[test]
     fn test_command_args_with_session() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let args = executor.command_args_with_session("continue", Some("ses_abc123"), true);
         assert!(args.contains(&"-s".to_string()));
         assert!(args.contains(&"ses_abc123".to_string()));
@@ -517,7 +517,7 @@ mod joinai_executor_extended_tests {
 
     #[test]
     fn test_command_args() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let args = executor.command_args("讲个笑话");
         assert_eq!(args[0], "run");
         assert_eq!(args[1], "--agent");

--- a/backend/tests/business_logic_tests.rs
+++ b/backend/tests/business_logic_tests.rs
@@ -120,7 +120,7 @@ mod executor_type_tests {
         assert_eq!(ExecutorType::Hermes.to_string(), "hermes");
         assert_eq!(ExecutorType::Opencode.to_string(), "opencode");
         assert_eq!(ExecutorType::Atomcode.to_string(), "atomcode");
-        assert_eq!(ExecutorType::Joinai.to_string(), "joinai");
+        assert_eq!(ExecutorType::Mobilecoder.to_string(), "mobilecoder");
         assert_eq!(ExecutorType::Codebuddy.to_string(), "codebuddy");
         assert_eq!(ExecutorType::Codex.to_string(), "codex");
     }
@@ -134,7 +134,7 @@ mod executor_type_tests {
         assert_eq!(parse_executor_type("hermes"), Some(ExecutorType::Hermes));
         assert_eq!(parse_executor_type("opencode"), Some(ExecutorType::Opencode));
         assert_eq!(parse_executor_type("atomcode"), Some(ExecutorType::Atomcode));
-        assert_eq!(parse_executor_type("joinai"), Some(ExecutorType::Joinai));
+        assert_eq!(parse_executor_type("mobilecoder"), Some(ExecutorType::Mobilecoder));
         assert_eq!(parse_executor_type("codebuddy"), Some(ExecutorType::Codebuddy));
         assert_eq!(parse_executor_type("codex"), Some(ExecutorType::Codex));
     }

--- a/backend/tests/executor_tests.rs
+++ b/backend/tests/executor_tests.rs
@@ -4,7 +4,7 @@ use ntd::adapters::claude_code::ClaudeCodeExecutor;
 use ntd::adapters::hermes::HermesExecutor;
 use ntd::adapters::opencode::OpencodeExecutor;
 use ntd::adapters::atomcode::AtomcodeExecutor;
-use ntd::adapters::joinai::JoinaiExecutor;
+use ntd::adapters::mobilecoder::MobilecoderExecutor;
 use ntd::adapters::codex::CodexExecutor;
 use ntd::models::{ParsedLogEntry, ExecutorType};
 
@@ -418,20 +418,20 @@ mod atomcode_executor_tests {
 }
 
 #[cfg(test)]
-mod joinai_executor_tests {
+mod mobilecoder_executor_tests {
     use super::*;
 
     #[test]
-    fn test_joinai_executor_type() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
-        assert_eq!(executor.executor_type(), ExecutorType::Joinai);
+    fn test_mobilecoder_executor_type() {
+        let executor = MobilecoderExecutor::new("mobile".to_string());
+        assert_eq!(executor.executor_type(), ExecutorType::Mobilecoder);
     }
 
     #[test]
-    fn test_joinai_command_args() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+    fn test_mobilecoder_command_args() {
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         let args = executor.command_args("say hello");
-        // joinai uses: run --format json <message>
+        // mobilecoder uses: run --format json <message>
         assert!(args.contains(&"run".to_string()));
         assert!(args.contains(&"--format".to_string()));
         assert!(args.contains(&"json".to_string()));
@@ -439,8 +439,8 @@ mod joinai_executor_tests {
     }
 
     #[test]
-    fn test_joinai_check_success() {
-        let executor = JoinaiExecutor::new("joinai".to_string());
+    fn test_mobilecoder_check_success() {
+        let executor = MobilecoderExecutor::new("mobile".to_string());
         assert!(executor.check_success(0));
         assert!(!executor.check_success(1));
     }

--- a/backend/tests/services_tests.rs
+++ b/backend/tests/services_tests.rs
@@ -397,6 +397,8 @@ mod feishu_push_service_tests {
             executor: "kimi".to_string(),
             success,
             result,
+            feishu_bot_id: None,
+            feishu_receive_id: None,
         }
     }
 }

--- a/frontend/src/components/sessions/helpers.tsx
+++ b/frontend/src/components/sessions/helpers.tsx
@@ -9,7 +9,7 @@ export const sourceConfig: Record<string, { label: string; color: string }> = {
   'atomcode': { label: 'AtomCode', color: '#ef4444' },
   'codebuddy': { label: 'CodeBuddy', color: '#f59e0b' },
   'opencode': { label: 'OpenCode', color: '#22c55e' },
-  'joinai': { label: 'JoinAI', color: '#6366f1' },
+  'mobilecoder': { label: 'MobileCoder', color: '#6366f1' },
 };
 
 export function sourceTag(source: string) {

--- a/frontend/src/components/settings/AboutPanel.tsx
+++ b/frontend/src/components/settings/AboutPanel.tsx
@@ -298,7 +298,7 @@ export function AboutPanel() {
             </div>
             <div style={{ borderTop: '1px solid var(--color-border-light)', paddingTop: 16 }}>
               <Paragraph type="secondary" style={{ margin: 0 }}>
-                NTD (Nothing Todo) 是一个 AI Todo 应用，支持 Claude Code 和 JoinAI 等多种执行器。
+                NTD (Nothing Todo) 是一个 AI Todo 应用，支持 Claude Code 和 MobileCoder 等多种执行器。
               </Paragraph>
             </div>
           </div>

--- a/frontend/src/types/execution.tsx
+++ b/frontend/src/types/execution.tsx
@@ -122,7 +122,7 @@ export const EXECUTORS: ExecutorOption[] = [
   { value: 'claudecode', label: 'Claude',    color: '#e17055', icon: <FaSquare color="#e17055" size={14} /> },
   { value: 'codebuddy',  label: 'CodeBuddy', color: '#00b894', icon: <FaSquare color="#00b894" size={14} /> },
   { value: 'opencode',   label: 'Opencode',  color: '#fdcb6e', icon: <FaSquare color="#fdcb6e" size={14} /> },
-  { value: 'joinai',     label: 'JoinAI',    color: '#6c5ce7', icon: <FaSquare color="#6c5ce7" size={14} /> },
+  { value: 'mobilecoder', label: 'MobileCoder', color: '#6c5ce7', icon: <FaSquare color="#6c5ce7" size={14} /> },
   { value: 'atomcode',   label: 'AtomCode',  color: '#e84393', icon: <FaSquare color="#e84393" size={14} /> },
   { value: 'hermes',     label: 'Hermes',    color: '#0984e3', icon: <FaSquare color="#0984e3" size={14} /> },
   { value: 'kimi',       label: 'Kimi',      color: '#d63031', icon: <FaSquare color="#d63031" size={14} /> },
@@ -137,7 +137,7 @@ export const EXECUTOR_COLORS: Record<string, string> = {
   claudecode: '#e17055',
   codebuddy: '#00b894',
   opencode: '#fdcb6e',
-  joinai: '#6c5ce7',
+  mobilecoder: '#6c5ce7',
   atomcode: '#e84393',
   hermes: '#0984e3',
   kimi: '#d63031',
@@ -161,7 +161,7 @@ export function getExecutorOption(value: string): ExecutorOption {
   return EXECUTORS.find(e => e.value === value.toLowerCase()) || EXECUTORS[0];
 }
 
-export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'joinai', 'hermes', 'codewhale']);
+export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'mobilecoder', 'hermes', 'codewhale']);
 
 /// 默认执行器
 export const DEFAULT_EXECUTOR = 'claudecode';

--- a/frontend/src/utils/database/bots.ts
+++ b/frontend/src/utils/database/bots.ts
@@ -269,7 +269,7 @@ export async function createFeishuBinding(params: {
   chat_id: string;
   chat_type: string;
   project_dir_id: number;
-  /** 指定执行器（可选，仅在新建 Todo 时使用）。仅支持 claudecode/kimi/opencode/joinai/hermes/codewhale */
+  /** 指定执行器（可选，仅在新建 Todo 时使用）。仅支持 claudecode/kimi/opencode/mobilecoder/hermes/codewhale */
   executor?: string;
   /** 绑定到已有 Todo（可选）。提供后表示复用该 Todo 的历史会话，与 executor 互斥 */
   todo_id?: number;


### PR DESCRIPTION
## Summary

Rename the joinai executor to mobilecoder with updated binary name and paths.

**Changes:**
- Executor name: joinai → mobilecoder
- Binary name: joinai → mobile  
- Default path: joinai → mobile
- Session dir: (none) → ~/.mobile-coder
- Skills dir: ~/.joinai → ~/.mobile-coder

**Files renamed:**
- adapters/joinai.rs → adapters/mobilecoder.rs
- adapters/joinai_event.rs → adapters/mobilecoder_event.rs

**Backend updates:** adapters/mod.rs, models/mod.rs, handlers/skills.rs, handlers/session.rs, handlers/backup.rs, handlers/feishu_binding.rs, main.rs, cli/commands.rs, config.rs, all test files

**Frontend updates:** types/execution.tsx, components/sessions/helpers.tsx, components/settings/AboutPanel.tsx, utils/database/bots.ts

**Also fixed:** unrelated missing fields error in services_tests.rs