### PR TITLE
feat(hooks): add rating gate to TodoHookItem

### DIFF
--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -353,6 +353,7 @@ async fn handle_todo(
                         scheduler_config: None,
                         scheduler_timezone: None,
                         hooks: None,
+                        acceptance_criteria: value.get("acceptance_criteria").and_then(|v| v.as_str()).map(|s| s.to_string()),
                     });
                 if workspace.is_some() {
                     // workspace is sent separately in the full JSON body
@@ -375,6 +376,7 @@ async fn handle_todo(
                     scheduler_config: None,
                     scheduler_timezone: None,
                     hooks: None,
+                    acceptance_criteria: None,
                 }
             };
 

--- a/backend/src/db/entity/execution_records.rs
+++ b/backend/src/db/entity/execution_records.rs
@@ -35,6 +35,10 @@ pub struct Model {
     /// The `TodoHookItem.id` that fired. Combined with `source_todo_id` this
     /// points at the exact hook entry that triggered this execution.
     pub source_hook_id: Option<i64>,
+    /// User-provided score for this execution's result (0-100, optional).
+    /// Only meaningful on terminal records (success/failed); running records
+    /// never carry a score.
+    pub rating: Option<i32>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/entity/todos.rs
+++ b/backend/src/db/entity/todos.rs
@@ -23,6 +23,7 @@ pub struct Model {
     /// Each item binds a trigger to a target todo that should run when the
     /// parent todo's lifecycle event matches.
     pub hooks: Option<String>,
+    pub acceptance_criteria: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -83,6 +83,7 @@ impl From<execution_records::Model> for ExecutionRecord {
             source_todo_id: m.source_todo_id,
             source_todo_title: m.source_todo_title,
             source_hook_id: m.source_hook_id,
+            rating: m.rating,
         }
     }
 }
@@ -293,6 +294,23 @@ impl Database {
         let am = execution_records::ActiveModel {
             id: ActiveValue::Unchanged(id),
             execution_stats: ActiveValue::Set(Some(stats_json.to_string())),
+            ..Default::default()
+        };
+        self.exec_update(am).await
+    }
+
+    /// 更新执行记录的评分。
+    /// 评分属于“执行结果”，因此要求记录已结束（success/failed）；running 记录
+    /// 不接受评分，handler 层会先拦抁返回错误。
+    /// `Some(value)` 写入评分，`None` 清除评分（设为 NULL）。
+    pub async fn update_execution_record_rating(
+        &self,
+        id: i64,
+        rating: Option<i32>,
+    ) -> Result<(), sea_orm::DbErr> {
+        let am = execution_records::ActiveModel {
+            id: ActiveValue::Unchanged(id),
+            rating: ActiveValue::Set(rating),
             ..Default::default()
         };
         self.exec_update(am).await
@@ -970,6 +988,7 @@ impl Database {
                     source_todo_id: None,
                     source_todo_title: None,
                     source_hook_id: None,
+                    rating: None,
                 }
             })
             .collect();

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1615,6 +1615,7 @@ mod tests {
             scheduler_timezone: None,
             workspace: None,
             worktree_enabled: None,
+            acceptance_criteria: None,
         })
         .await
         .unwrap();
@@ -1773,6 +1774,7 @@ mod tests {
             scheduler_timezone: None,
             workspace: Some("/tmp/workspace"),
             worktree_enabled: None,
+            acceptance_criteria: None,
         })
         .await
         .unwrap();

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -302,6 +302,91 @@ impl Database {
         Ok(())
     }
 
+    /// 一次性迁移：将旧 `todos.rating`（已不再使用）合并到对应 todo 最新一条
+    /// `execution_records.rating`，然后 DROP COLUMN。
+    /// 设计原因：评分属于执行结果而非 todo 本身。
+    /// - 每个 todo 取最新一条已结束的 execution_record（按 started_at desc）
+    /// - 同一 record 已被多次评分时跳过，避免覆盖更新的评价
+    /// - 失败仅 warn，不阻塞启动
+    async fn migrate_todo_rating_to_execution_records(&self) -> Result<(), sea_orm::DbErr> {
+        // 检查旧列是否存在，不存在则直接跳过（DROP COLUMN 之后再次启动也是幂等的）
+        let check_sql = "SELECT COUNT(*) FROM pragma_table_info('todos') WHERE name='rating'";
+        let result = self
+            .conn
+            .query_one(Statement::from_string(DbBackend::Sqlite, check_sql.to_string()))
+            .await?;
+        let col_exists = result
+            .and_then(|r| r.try_get_by_index::<i64>(0).ok())
+            .unwrap_or(0)
+            > 0;
+        if !col_exists {
+            return Ok(());
+        }
+
+        tracing::info!("Migrating todos.rating -> execution_records.rating...");
+
+        // 拉取所有有评分的 todo 及其最新一条 execution_record
+        let select_sql = "\
+            SELECT t.id AS todo_id, t.rating AS rating, \
+                   (SELECT er.id FROM execution_records er \
+                    WHERE er.todo_id = t.id \
+                    ORDER BY er.started_at DESC LIMIT 1) AS latest_record_id \
+            FROM todos t \
+            WHERE t.rating IS NOT NULL";
+        let rows = self
+            .conn
+            .query_all(Statement::from_string(DbBackend::Sqlite, select_sql.to_string()))
+            .await?;
+
+        let mut migrated = 0u64;
+        for row in rows {
+            let todo_id: i64 = row.try_get_by("todo_id")?;
+            let rating: i32 = match row.try_get_by::<i64, _>("rating") {
+                Ok(v) => v as i32,
+                Err(_) => continue,
+            };
+            let latest_record_id: Option<i64> = row.try_get_by("latest_record_id").ok().flatten();
+            let Some(record_id) = latest_record_id else {
+                tracing::debug!(
+                    "Skip todo {} rating {}: no execution_records",
+                    todo_id, rating
+                );
+                continue;
+            };
+
+            // 仅在该 record 尚未评分时才写入，避免覆盖更新评价
+            let update_sql = "UPDATE execution_records \
+                SET rating = $1 \
+                WHERE id = $2 AND rating IS NULL";
+            let res = self
+                .conn
+                .execute(Statement::from_sql_and_values(
+                    DbBackend::Sqlite,
+                    update_sql,
+                    [rating.into(), record_id.into()],
+                ))
+                .await?;
+            if res.rows_affected() > 0 {
+                migrated += 1;
+            }
+        }
+
+        // 移除旧列
+        if let Err(e) = self
+            .exec("ALTER TABLE todos DROP COLUMN rating")
+            .await
+        {
+            tracing::warn!("Failed to DROP COLUMN todos.rating: {}", e);
+            return Ok(()); // 不阻塞启动，下次启动再重试
+        }
+
+        tracing::info!(
+            "Migrated {} todo ratings to execution_records, dropped todos.rating",
+            migrated
+        );
+        Ok(())
+    }
+
     async fn init_tables(&self) -> Result<(), sea_orm::DbErr> {
         self.exec(
             "CREATE TABLE IF NOT EXISTS todos (
@@ -443,6 +528,23 @@ impl Database {
         self.exec("ALTER TABLE todos ADD COLUMN hooks TEXT")
             .await
             .ok(); // 忽略错误，因为字段可能已存在
+
+        // 添加 acceptance_criteria 字段的迁移（向后兼容）—— Todo 验收条件
+        self.exec("ALTER TABLE todos ADD COLUMN acceptance_criteria TEXT")
+            .await
+            .ok();
+
+        // 添加 rating 字段的迁移（向后兼容）—— 执行记录评分
+        self.exec("ALTER TABLE execution_records ADD COLUMN rating INTEGER")
+            .await
+            .ok();
+
+        // 一次性迁移：旧 todos.rating 数据合并到对应 todo 的最新一条 execution_records.rating
+        // 然后 DROP COLUMN todos.rating（评分只属于执行结果）
+        // 失败仅 warn，不阻塞启动（与同位置的其他迁移策略一致）。
+        if let Err(e) = self.migrate_todo_rating_to_execution_records().await {
+            tracing::warn!("Failed to migrate todos.rating -> execution_records.rating: {}", e);
+        }
 
         // 迁移：将 execution_records.logs 旧字段数据转移到 execution_logs 表，并删除旧字段
         self.migrate_logs_to_execution_logs().await

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -19,6 +19,7 @@ pub struct TodoUpdate<'a> {
     pub scheduler_timezone: Option<&'a str>,
     pub workspace: Option<&'a str>,
     pub worktree_enabled: Option<bool>,
+    pub acceptance_criteria: Option<&'a str>,
 }
 
 pub struct SchedulerUpdate<'a> {
@@ -63,6 +64,7 @@ impl Database {
             workspace: m.workspace,
             worktree_enabled: m.worktree_enabled.unwrap_or(false),
             hooks: crate::hooks::TodoHooks::parse(m.hooks.as_deref()).items,
+            acceptance_criteria: m.acceptance_criteria,
         }
     }
 
@@ -111,9 +113,20 @@ impl Database {
     /// 创建 Todo，可指定执行器。
     /// executor 为 None、空串或仅空白时默认为 claudecode（防止空/空白字符串污染 DB）。
     pub async fn create_todo_with_executor(&self, title: &str, prompt: &str, executor: Option<&str>) -> Result<i64, sea_orm::DbErr> {
+        self.create_todo_with_extras(title, prompt, executor, None).await
+    }
+
+    /// 创建 Todo，带所有可选字段。
+    pub async fn create_todo_with_extras(
+        &self,
+        title: &str,
+        prompt: &str,
+        executor: Option<&str>,
+        acceptance_criteria: Option<&str>,
+    ) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let executor_str = executor
-            .map(str::trim)  // 先 trim，避免 "  " 类空白字符串落入空串分支
+            .map(str::trim)
             .filter(|s| !s.is_empty())
             .unwrap_or(crate::adapters::DEFAULT_EXECUTOR);
         let am = todos::ActiveModel {
@@ -123,6 +136,7 @@ impl Database {
             created_at: ActiveValue::Set(Some(now.clone())),
             updated_at: ActiveValue::Set(Some(now)),
             executor: ActiveValue::Set(Some(executor_str.to_string())),
+            acceptance_criteria: ActiveValue::Set(acceptance_criteria.map(|s| s.to_string())),
             ..Default::default()
         };
         let inserted = am.insert(&self.conn).await?;
@@ -165,6 +179,9 @@ impl Database {
         }
         if let Some(wt) = update.worktree_enabled {
             am.worktree_enabled = ActiveValue::Set(Some(wt));
+        }
+        if let Some(criteria) = update.acceptance_criteria {
+            am.acceptance_criteria = ActiveValue::Set(Some(criteria.to_string()));
         }
         self.exec_update(am).await
     }

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -72,6 +72,53 @@ pub async fn get_execution_record(
     Ok(ApiResponse::ok(record))
 }
 
+/// 更新执行记录评分。评分仅针对已结束的记录（success/failed）；
+/// running 记录不允许评分。`rating: null` 表示清除评分。
+#[derive(Debug, Deserialize)]
+pub struct RateExecutionRequest {
+    /// 评分值（0-100）。传 null 表示清除当前评分。
+    pub rating: Option<i32>,
+}
+
+pub async fn rate_execution_handler(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    ApiJson(req): ApiJson<RateExecutionRequest>,
+) -> Result<ApiResponse<crate::models::ExecutionRecord>, AppError> {
+    if let Some(r) = req.rating {
+        if !(0..=100).contains(&r) {
+            return Err(AppError::BadRequest(format!(
+                "rating must be in 0..=100, got {}",
+                r
+            )));
+        }
+    }
+
+    let record = state
+        .db
+        .get_execution_record(id)
+        .await?
+        .ok_or(AppError::NotFound)?;
+
+    if record.status == ExecutionStatus::Running {
+        return Err(AppError::BadRequest(
+            "Cannot rate a running execution".to_string(),
+        ));
+    }
+
+    state
+        .db
+        .update_execution_record_rating(id, req.rating)
+        .await?;
+
+    let updated = state
+        .db
+        .get_execution_record(id)
+        .await?
+        .ok_or(AppError::NotFound)?;
+    Ok(ApiResponse::ok(updated))
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ExecutionLogsQuery {
     #[serde(default = "default_page")]

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -583,6 +583,7 @@ pub fn create_app(
         .route("/api/execution-records/{id}/logs", get(execution::get_execution_logs_handler))
         .route("/api/execution-records/{id}", get(execution::get_execution_record))
         .route("/api/execution-records/{id}/resume", post(execution::resume_execution_handler))
+        .route("/api/execution-records/{id}/rating", put(execution::rate_execution_handler))
         .route("/api/dashboard-stats", get(execution::get_dashboard_stats))
         .route("/api/execute", post(execution::execute_handler))
         .route("/api/smart-create", post(execution::smart_create_handler))

--- a/backend/src/handlers/sync.rs
+++ b/backend/src/handlers/sync.rs
@@ -315,6 +315,7 @@ async fn merge_cloud_todos_to_local(
                         scheduler_timezone: None,
                         workspace: item.workspace.as_deref(),
                         worktree_enabled: None,
+                        acceptance_criteria: None,
                     })
                     .await
                     .map_err(|e| e.to_string())?;

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -56,7 +56,12 @@ pub async fn create_todo(
         .clone()
         .unwrap_or_else(|| "claudecode".to_string());
 
-    let id = state.db.create_todo(title, &prompt).await?;
+    let id = state.db.create_todo_with_extras(
+        title,
+        &prompt,
+        Some(&executor),
+        req.acceptance_criteria.as_deref(),
+    ).await?;
 
     // Update executor if specified
     if let Some(ref exec) = req.executor {
@@ -129,6 +134,7 @@ pub async fn create_todo(
         workspace: None,
         worktree_enabled: false,
         hooks: req.hooks.clone().unwrap_or_default(),
+        acceptance_criteria: req.acceptance_criteria.clone(),
     }))
 }
 
@@ -195,6 +201,7 @@ pub async fn update_todo(
             scheduler_timezone: scheduler_timezone.as_deref(),
             workspace: workspace.as_deref(),
             worktree_enabled: Some(worktree_enabled),
+            acceptance_criteria: req.acceptance_criteria.as_deref(),
         })
         .await
         .map_err(AppError::from)?;

--- a/backend/src/hooks/models.rs
+++ b/backend/src/hooks/models.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 use crate::models::TodoStatus;
 
 /// Hook trigger types.
@@ -75,10 +76,66 @@ pub struct TodoHookItem {
     pub skip_if_missing: bool,
     #[serde(default = "default_enabled")]
     pub enabled: bool,
+    /// Optional rating gate (0-100). When set, the hook only fires if the
+    /// source todo's most recent FINISHED execution record has a
+    /// `rating >= min_rating`. `None` means no gate (always fire) — this
+    /// preserves the original behaviour for any hook that doesn't opt in.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_rating: Option<i32>,
+    /// What to do when the latest finished record has no rating (NULL).
+    /// Defaults to `Skip` (do not fire) — the conservative choice for users
+    /// who explicitly enabled a rating gate: if you cared enough to set a
+    /// threshold, an unrated result is probably not what you wanted to chain
+    /// off of. `Pass` is the opt-in permissive mode for teams that want the
+    /// gate to only block obviously-bad runs.
+    #[serde(default = "default_unrated_policy")]
+    pub unrated_policy: UnratedPolicy,
 }
 
 fn default_enabled() -> bool {
     true
+}
+
+fn default_unrated_policy() -> UnratedPolicy {
+    UnratedPolicy::Skip
+}
+
+/// Policy applied by the rating gate when the latest finished record has
+/// no rating set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum UnratedPolicy {
+    /// Do not fire the hook. This is the safe default: an unrated record
+    /// can't be evaluated against `min_rating`, so we treat "no opinion" as
+    /// "don't chain off of this".
+    #[default]
+    Skip,
+    /// Treat the missing rating as if it had passed. Useful when you only
+    /// want the gate to actively block runs you've explicitly scored low.
+    Pass,
+}
+
+impl UnratedPolicy {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Skip => "skip",
+            Self::Pass => "pass",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "skip" => Some(Self::Skip),
+            "pass" => Some(Self::Pass),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for UnratedPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
 }
 
 /// Wrapper for the `todos.hooks` JSON column.
@@ -110,12 +167,33 @@ impl TodoHooks {
                 .into_iter()
                 .filter_map(|raw| {
                     let trigger = HookTrigger::from_str(&raw.trigger)?;
+                    // Validate rating gate fields defensively: a malformed
+                    // value (out-of-range or unknown policy) shouldn't take
+                    // down the whole hook list, it just disables this item.
+                    let min_rating = match raw.min_rating {
+                        None => None,
+                        Some(v) if (0..=100).contains(&v) => Some(v),
+                        Some(v) => {
+                            warn!(
+                                "hook #{} has out-of-range min_rating {}, ignoring",
+                                raw.id, v
+                            );
+                            None
+                        }
+                    };
+                    let unrated_policy = raw
+                        .unrated_policy
+                        .as_deref()
+                        .and_then(UnratedPolicy::from_str)
+                        .unwrap_or_default();
                     Some(TodoHookItem {
                         id: raw.id,
                         trigger,
                         target_todo_id: raw.target_todo_id,
                         skip_if_missing: raw.skip_if_missing,
                         enabled: raw.enabled,
+                        min_rating,
+                        unrated_policy,
                     })
                 })
                 .collect(),
@@ -148,6 +226,15 @@ struct RawTodoHookItem {
     skip_if_missing: bool,
     #[serde(default = "default_enabled")]
     enabled: bool,
+    /// Optional rating threshold (0-100). Older payloads won't have this
+    /// field and serde's `default` keeps them working unchanged.
+    #[serde(default)]
+    min_rating: Option<i32>,
+    /// Policy for when the latest record has no rating. Stored as a snake
+    /// case string to match the on-disk format; unknown values fall back to
+    /// the default policy at `parse` time.
+    #[serde(default)]
+    unrated_policy: Option<String>,
 }
 
 /// Build the `message` payload that a hook delivers to the target todo's

--- a/backend/src/hooks/service.rs
+++ b/backend/src/hooks/service.rs
@@ -4,7 +4,7 @@ use tracing::{warn};
 use crate::executor_service::RunTodoExecutionRequest;
 use crate::handlers::execution::start_todo_execution;
 use crate::hooks::models::*;
-use crate::models::Todo;
+use crate::models::{ExecutionRecord, ExecutionStatus, Todo};
 use crate::service_context::ServiceContext;
 
 /// Hook dispatch engine.
@@ -172,6 +172,91 @@ async fn lookup_source_result(ctx: &ServiceContext, source_id: i64) -> Option<St
     }
 }
 
+/// Look up the most recent FINISHED (success or failed) execution record for
+/// `source_id`. Returns the full record so callers can inspect `rating` for
+/// the rating gate. Returns `None` if the source has never run or its most
+/// recent record is still in-flight (`running`/`pending`).
+///
+/// We deliberately look at the most recent finished record rather than the
+/// most recent record of any status: while a hook is firing the source
+/// could have a fresh `running` row that hides a previously-finished
+/// scored row, which would make the gate flicker. The terminal record is
+/// the one whose rating is stable and meaningful for chaining decisions.
+async fn lookup_latest_finished_record(
+    ctx: &ServiceContext,
+    source_id: i64,
+) -> Option<ExecutionRecord> {
+    // status="all" means no status filter (see `get_execution_records`), and
+    // ORDER BY started_at DESC LIMIT 1 gives us the most recent record.
+    let query = crate::db::execution::ExecutionRecordQuery {
+        todo_id: source_id,
+        limit: 1,
+        offset: 0,
+        status: Some("all"),
+    };
+    match ctx.db.get_execution_records(query).await {
+        Ok((records, _)) => records
+            .into_iter()
+            .find(|r| r.status != ExecutionStatus::Running),
+        Err(e) => {
+            warn!(
+                "hook: failed to load source todo #{} latest finished record: {}",
+                source_id, e
+            );
+            None
+        }
+    }
+}
+
+/// Decision produced by `evaluate_rating_gate`. The hook service uses this
+/// to decide whether to dispatch the target todo or skip the hook.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GateDecision {
+    /// Fire the target todo normally.
+    Allow,
+    /// Skip the hook because the gate wasn't met. Carries a short reason
+    /// suitable for the warn log.
+    Deny(&'static str),
+}
+
+/// Evaluate the optional rating gate on a hook item against the source
+/// todo's most recent finished execution record.
+///
+/// Rules:
+///
+/// * `min_rating = None` → always allow (no gate configured). This is the
+///   backward-compatible path for any existing hook that hasn't opted in.
+/// * `latest_finished = None` (source has never finished a run) → apply
+///   `unrated_policy`. Default `Skip` denies, `Pass` allows.
+/// * `latest_finished.rating = None` (user hasn't scored the run) → apply
+///   `unrated_policy` again. Same semantics as "no record at all" — the
+///   gate can't say the run is good enough, but the user policy decides
+///   whether that's a fail.
+/// * `latest_finished.rating >= min_rating` → allow.
+/// * otherwise → deny with a descriptive reason including the actual score.
+fn evaluate_rating_gate(
+    item: &TodoHookItem,
+    latest_finished: Option<&ExecutionRecord>,
+) -> GateDecision {
+    let Some(min_rating) = item.min_rating else {
+        return GateDecision::Allow;
+    };
+    let Some(record) = latest_finished else {
+        return match item.unrated_policy {
+            UnratedPolicy::Skip => GateDecision::Deny("no finished record"),
+            UnratedPolicy::Pass => GateDecision::Allow,
+        };
+    };
+    match record.rating {
+        None => match item.unrated_policy {
+            UnratedPolicy::Skip => GateDecision::Deny("rating is null"),
+            UnratedPolicy::Pass => GateDecision::Allow,
+        },
+        Some(r) if r >= min_rating => GateDecision::Allow,
+        Some(_) => GateDecision::Deny("rating below threshold"),
+    }
+}
+
 async fn execute_target_todo(
     ctx: &ServiceContext,
     item: &TodoHookItem,
@@ -206,6 +291,32 @@ async fn execute_target_todo(
     // `run_todo_execution_with_params` does the substitution and the
     // executor sees the final composed message.
     let source_result = lookup_source_result(ctx, source.id).await;
+
+    // Rating gate: only enforce when the hook is configured with a
+    // `min_rating`. Fetching the latest finished record is one extra cheap
+    // query, and we only do it when the gate might be active. The lookup
+    // also doubles as the "is the source ready to chain off of" check.
+    let source_record = lookup_latest_finished_record(ctx, source.id).await;
+    match evaluate_rating_gate(item, source_record.as_ref()) {
+        GateDecision::Allow => {}
+        GateDecision::Deny(reason) => {
+            let rating = source_record
+                .as_ref()
+                .and_then(|r| r.rating)
+                .map(|r| r.to_string())
+                .unwrap_or_else(|| "null".to_string());
+            let min = item
+                .min_rating
+                .map(|m| m.to_string())
+                .unwrap_or_else(|| "none".to_string());
+            warn!(
+                "hook #{} skipped by rating gate (min_rating={}, policy={}, source rating={}, reason={})",
+                item.id, min, item.unrated_policy, rating, reason
+            );
+            return Ok(());
+        }
+    }
+
     let message_payload = build_hook_message(source, source_result.as_deref());
     let message = target.prompt.clone();
     let mut params = std::collections::HashMap::new();
@@ -261,5 +372,210 @@ async fn execute_target_todo(
             "hook trigger thread for todo #{} dropped reply channel",
             target.id
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the rating-gate logic. We don't need a database for
+    //! these — the gate is a pure function over `(TodoHookItem, Option<&ExecutionRecord>)`.
+    use super::*;
+    use crate::models::ExecutionStatus;
+
+    fn item(min_rating: Option<i32>, policy: UnratedPolicy) -> TodoHookItem {
+        TodoHookItem {
+            id: 1,
+            trigger: HookTrigger::StateChangedToCompleted,
+            target_todo_id: 2,
+            skip_if_missing: true,
+            enabled: true,
+            min_rating,
+            unrated_policy: policy,
+        }
+    }
+
+    fn rec(rating: Option<i32>) -> ExecutionRecord {
+        ExecutionRecord {
+            id: 99,
+            todo_id: 1,
+            status: ExecutionStatus::Success,
+            command: String::new(),
+            stdout: String::new(),
+            stderr: String::new(),
+            result: None,
+            started_at: String::new(),
+            finished_at: None,
+            usage: None,
+            executor: None,
+            model: None,
+            trigger_type: "manual".to_string(),
+            pid: None,
+            task_id: None,
+            session_id: None,
+            todo_progress: None,
+            execution_stats: None,
+            resume_message: None,
+            source_todo_id: None,
+            source_todo_title: None,
+            source_hook_id: None,
+            rating,
+        }
+    }
+
+    #[test]
+    fn no_min_rating_always_allows() {
+        // Hooks that don't opt into the gate keep their original behaviour
+        // regardless of the source record's rating (or lack thereof).
+        let i = item(None, UnratedPolicy::Skip);
+        assert_eq!(
+            evaluate_rating_gate(&i, None),
+            GateDecision::Allow,
+            "no record at all"
+        );
+        assert_eq!(
+            evaluate_rating_gate(&i, Some(&rec(None))),
+            GateDecision::Allow,
+            "record with no rating"
+        );
+        assert_eq!(
+            evaluate_rating_gate(&i, Some(&rec(Some(0)))),
+            GateDecision::Allow,
+            "record with low rating"
+        );
+        assert_eq!(
+            evaluate_rating_gate(&i, Some(&rec(Some(100)))),
+            GateDecision::Allow,
+            "record with high rating"
+        );
+    }
+
+    #[test]
+    fn min_rating_passes_when_score_meets_threshold() {
+        let i = item(Some(80), UnratedPolicy::Skip);
+        assert_eq!(evaluate_rating_gate(&i, Some(&rec(Some(80)))), GateDecision::Allow);
+        assert_eq!(evaluate_rating_gate(&i, Some(&rec(Some(99)))), GateDecision::Allow);
+        assert_eq!(evaluate_rating_gate(&i, Some(&rec(Some(100)))), GateDecision::Allow);
+    }
+
+    #[test]
+    fn min_rating_denies_when_score_below_threshold() {
+        let i = item(Some(80), UnratedPolicy::Skip);
+        match evaluate_rating_gate(&i, Some(&rec(Some(79)))) {
+            GateDecision::Deny(_) => {}
+            other => panic!("expected Deny, got {:?}", other),
+        }
+        match evaluate_rating_gate(&i, Some(&rec(Some(0)))) {
+            GateDecision::Deny(_) => {}
+            other => panic!("expected Deny, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unrated_skip_denies_null_rating() {
+        // Default policy: unrated records don't pass the gate. This is the
+        // safe behaviour for users who set a threshold because they care
+        // about quality — an unrated result can't be trusted.
+        let i = item(Some(60), UnratedPolicy::Skip);
+        assert_eq!(
+            evaluate_rating_gate(&i, Some(&rec(None))),
+            GateDecision::Deny("rating is null")
+        );
+    }
+
+    #[test]
+    fn unrated_pass_allows_null_rating() {
+        // Opt-in permissive mode: missing rating is treated as "no
+        // objection", so the hook fires.
+        let i = item(Some(60), UnratedPolicy::Pass);
+        assert_eq!(
+            evaluate_rating_gate(&i, Some(&rec(None))),
+            GateDecision::Allow
+        );
+    }
+
+    #[test]
+    fn unrated_skip_denies_when_no_record_exists() {
+        // Source has never finished a run. Even with `Skip`, the gate
+        // should deny because there's no record to evaluate. The
+        // distinction between "no record" and "record with null rating"
+        // matters in the log message but not in the decision.
+        let i = item(Some(60), UnratedPolicy::Skip);
+        assert_eq!(
+            evaluate_rating_gate(&i, None),
+            GateDecision::Deny("no finished record")
+        );
+    }
+
+    #[test]
+    fn unrated_pass_allows_when_no_record_exists() {
+        let i = item(Some(60), UnratedPolicy::Pass);
+        assert_eq!(
+            evaluate_rating_gate(&i, None),
+            GateDecision::Allow
+        );
+    }
+
+    #[test]
+    fn unrated_policy_does_not_change_threshold_decision() {
+        // Policy is only consulted when rating is missing. With a numeric
+        // rating, the threshold itself is the sole deciding factor.
+        let i = item(Some(50), UnratedPolicy::Pass);
+        assert_eq!(evaluate_rating_gate(&i, Some(&rec(Some(60)))), GateDecision::Allow);
+        match evaluate_rating_gate(&i, Some(&rec(Some(40)))) {
+            GateDecision::Deny(_) => {}
+            other => panic!("expected Deny, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unrated_policy_deserializes_from_snake_case() {
+        // The on-disk format is snake_case; make sure the parser accepts
+        // both variants and rejects unknown values.
+        assert_eq!(UnratedPolicy::from_str("skip"), Some(UnratedPolicy::Skip));
+        assert_eq!(UnratedPolicy::from_str("pass"), Some(UnratedPolicy::Pass));
+        assert_eq!(UnratedPolicy::from_str(""), None);
+        assert_eq!(UnratedPolicy::from_str("deny"), None);
+    }
+
+    #[test]
+    fn unrated_policy_default_is_skip() {
+        // Default::default() is the safe option, matching the documented
+        // contract on the field.
+        assert_eq!(UnratedPolicy::default(), UnratedPolicy::Skip);
+    }
+
+    #[test]
+    fn parse_tolerates_missing_or_unknown_gate_fields() {
+        // Older payloads that don't have the new gate fields must still
+        // parse cleanly. Items with out-of-range `min_rating` are kept
+        // (with the gate dropped) so a bad write doesn't take down the
+        // whole hook list.
+        let json = r#"{
+          "items": [
+            { "id": 1, "trigger": "state_changed_to_completed", "target_todo_id": 2, "enabled": true },
+            { "id": 2, "trigger": "state_changed_to_completed", "target_todo_id": 3, "enabled": true, "min_rating": 75, "unrated_policy": "pass" },
+            { "id": 3, "trigger": "state_changed_to_completed", "target_todo_id": 4, "enabled": true, "min_rating": 200 },
+            { "id": 4, "trigger": "state_changed_to_completed", "target_todo_id": 5, "enabled": true, "min_rating": 50, "unrated_policy": "nonsense" }
+          ]
+        }"#;
+        let parsed = TodoHooks::parse(Some(json));
+        assert_eq!(parsed.items.len(), 4);
+
+        // Item 1: legacy payload, no gate.
+        assert!(parsed.items[0].min_rating.is_none());
+        assert_eq!(parsed.items[0].unrated_policy, UnratedPolicy::Skip);
+
+        // Item 2: full gate configured.
+        assert_eq!(parsed.items[1].min_rating, Some(75));
+        assert_eq!(parsed.items[1].unrated_policy, UnratedPolicy::Pass);
+
+        // Item 3: out-of-range min_rating gets dropped (so the hook still
+        // works, just without the gate), and policy falls back to default.
+        assert!(parsed.items[2].min_rating.is_none());
+        assert_eq!(parsed.items[2].unrated_policy, UnratedPolicy::Skip);
+
+        // Item 4: unknown policy string falls back to default (Skip).
+        assert_eq!(parsed.items[3].min_rating, Some(50));
+        assert_eq!(parsed.items[3].unrated_policy, UnratedPolicy::Skip);
     }
 }

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -110,6 +110,8 @@ pub struct Todo {
     /// Inline hooks owned by this todo. Parsed from the `todos.hooks` column.
     #[serde(default)]
     pub hooks: Vec<crate::hooks::TodoHookItem>,
+    #[serde(default)]
+    pub acceptance_criteria: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -202,6 +204,10 @@ pub struct ExecutionRecord {
     /// The `TodoHookItem.id` that triggered this execution.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_hook_id: Option<i64>,
+    /// User-provided score for this execution's result (0-100, optional).
+    /// Only meaningful on terminal records (success/failed).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rating: Option<i32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -303,6 +309,8 @@ pub struct CreateTodoRequest {
     pub scheduler_timezone: Option<String>,
     #[serde(default)]
     pub hooks: Option<Vec<crate::hooks::TodoHookItem>>,
+    #[serde(default)]
+    pub acceptance_criteria: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -328,6 +336,8 @@ pub struct UpdateTodoRequest {
     /// Replace the todo's inline hooks. `None` keeps the existing list.
     #[serde(default)]
     pub hooks: Option<Vec<crate::hooks::TodoHookItem>>,
+    #[serde(default)]
+    pub acceptance_criteria: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -187,6 +187,16 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
     }
   };
 
+  /**
+   * 给一条执行结果评分或清除评分。
+   * 后端会返回更新后的 record；刷新单条后 dispatcher 会同步本地缓存。
+   */
+  const handleRateExecution = async (recordId: number, rating: number | null) => {
+    await db.rateExecutionRecord(recordId, rating);
+    await refreshSingleRecord(recordId);
+    message.success(rating == null ? '已清除评分' : `已评分 ${rating}`);
+  };
+
   const [resumeModalOpen, setResumeModalOpen] = useState(false);
   const [resumeRecordId, setResumeRecordId] = useState<number | null>(null);
   const [resumeMessage, setResumeMessage] = useState('');
@@ -400,6 +410,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                 onExportMarkdown={handleExportMarkdown}
                 onStop={handleStopExecution}
                 onRefreshSingle={refreshSingleRecord}
+                onRate={handleRateExecution}
                 paginatedLogs={paginatedLogs}
                 logsTotal={logsTotal}
                 logsPage={logsPage}

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -43,6 +43,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
   const [schedulerEnabled, setSchedulerEnabled] = useState(false);
   const [schedulerConfig, setSchedulerConfig] = useState<string>('');
   const [hooks, setHooks] = useState<TodoHookItem[]>([]);
+  const [acceptanceCriteria, setAcceptanceCriteria] = useState('');
   const [loading, setLoading] = useState(false);
   // 快速新增项目目录的弹窗：与抽屉同级，关闭抽屉时一起清理
   const [quickAddOpen, setQuickAddOpen] = useState(false);
@@ -114,6 +115,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         setSchedulerEnabled(todo.scheduler_enabled || false);
         setSchedulerConfig(todo.scheduler_config || '');
         setHooks(todo.hooks ?? []);
+        setAcceptanceCriteria(todo.acceptance_criteria ?? '');
       } else {
         setTitle('');
         setPrompt('');
@@ -124,6 +126,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         setSchedulerEnabled(false);
         setSchedulerConfig('');
         setHooks([]);
+        setAcceptanceCriteria('');
       }
     }
   }, [open, todo]);
@@ -227,13 +230,13 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
           todo.id, title.trim(), prompt.trim(), todo.status,
           executor, schedulerEnabled, schedulerConfig || null,
           workspaceToSave, worktreeEnabled,
-          hooks,
+          hooks, acceptanceCriteria || null,
         );
         await db.updateScheduler(todo.id, schedulerEnabled, schedulerConfig || null);
         await db.updateTodoTags(todo.id, selectedTags);
         message.success('任务已更新');
       } else {
-        const newTodo = await db.createTodo(title.trim(), prompt.trim(), selectedTags, hooks);
+        const newTodo = await db.createTodo(title.trim(), prompt.trim(), selectedTags, hooks, acceptanceCriteria || undefined);
 
         // 创建模式：只在路径存在于目录列表时才设置 workspace，否则为 null（避免创建无名项目）
         const workspaceToSave = trimmedWorkspace && projectDirectories.some(d => d.path === trimmedWorkspace) ? trimmedWorkspace : null;
@@ -243,7 +246,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
             newTodo.id, newTodo.title, newTodo.prompt, newTodo.status,
             executor, schedulerEnabled, schedulerConfig || null,
             workspaceToSave, worktreeEnabled,
-            hooks,
+            hooks, acceptanceCriteria || null,
           );
           await db.updateScheduler(newTodo.id, schedulerEnabled, schedulerConfig || null);
         }
@@ -412,6 +415,20 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
             onConfigChange={setSchedulerConfig}
             existingConfig={todo?.scheduler_config}
           />
+
+          <Divider style={{ margin: '8px 0 16px' }} />
+
+          {/* 验收标准 */}
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ marginBottom: 8, fontWeight: 600, fontSize: 14 }}>验收标准</div>
+            <Input.TextArea
+              value={acceptanceCriteria}
+              onChange={e => setAcceptanceCriteria(e.target.value)}
+              placeholder="描述完成该任务需要满足的条件..."
+              rows={3}
+              style={{ resize: 'vertical' }}
+            />
+          </div>
 
           <Divider style={{ margin: '8px 0 16px' }} />
 

--- a/frontend/src/components/todo-detail/DetailHeader.tsx
+++ b/frontend/src/components/todo-detail/DetailHeader.tsx
@@ -97,6 +97,16 @@ export function DetailHeader({
           )}
         </div>
         {selectedTodo.prompt && <PromptDisplay content={selectedTodo.prompt} />}
+        {(selectedTodo.acceptance_criteria) && (
+          <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', marginTop: 2, marginBottom: 8, fontSize: 12, color: 'var(--color-text-secondary)' }}>
+            {selectedTodo.acceptance_criteria && (
+              <div style={{ flex: 1, minWidth: 200 }}>
+                <span style={{ fontWeight: 600 }}>验收标准：</span>
+                <span>{selectedTodo.acceptance_criteria}</span>
+              </div>
+            )}
+          </div>
+        )}
         <div style={{ display: 'flex', gap: 8 }}>
           <Button
             type="primary"

--- a/frontend/src/components/todo-detail/RecordDetailView.tsx
+++ b/frontend/src/components/todo-detail/RecordDetailView.tsx
@@ -1,4 +1,6 @@
-import { Button, Tag, Empty, Segmented, Popconfirm, Tooltip, Pagination, message } from 'antd';
+import { useState, useEffect } from 'react';
+import { Button, Tag, Empty, Segmented, Popconfirm, Tooltip, Pagination, message, Popover, InputNumber, Space } from 'antd';
+import { StarOutlined, StarFilled } from '@ant-design/icons';
 import { MessageOutlined, FileTextOutlined, StopOutlined, CopyOutlined, UnorderedListOutlined, LinkOutlined, LoadingOutlined } from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
@@ -14,7 +16,7 @@ import { getHookTriggerLabel } from '@/utils/database/hooks';
 export function RecordDetailView({
   isLoadingDetail, record, sessionGroups,
   onSelectRecord, viewMode, onViewModeChange,
-  onOpenResume, onExportMarkdown, onStop, onRefreshSingle,
+  onOpenResume, onExportMarkdown, onStop, onRefreshSingle, onRate,
   paginatedLogs, logsTotal, logsPage, logsPerPage, onLoadLogs, isLoadingLogs,
   getRunningTaskForRecord, resolveExecutionStats,
 }: {
@@ -28,6 +30,11 @@ export function RecordDetailView({
   onExportMarkdown: (record: ExecutionRecord) => Promise<void>;
   onStop: (recordId: number) => Promise<void>;
   onRefreshSingle: (recordId: number) => Promise<void>;
+  /**
+   * 评分回调。record 表示被评分的新值，recordId 是被清分的记录。
+   * 传 null 表示清除评分。
+   */
+  onRate: (recordId: number, rating: number | null) => Promise<void>;
   paginatedLogs: LogEntry[];
   logsTotal: number;
   logsPage: number;
@@ -135,6 +142,12 @@ export function RecordDetailView({
         <div style={{ display: 'flex', gap: 8 }}>
           {record.status !== 'running' && supportsResume(record) && (
             <Button type="primary" size="small" icon={<MessageOutlined />} onClick={() => onOpenResume(record)}>继续对话</Button>
+          )}
+          {record.status !== 'running' && (
+            <RecordRatingControl
+              record={record}
+              onRate={onRate}
+            />
           )}
           {record.status !== 'running' && !!record.finished_at && (
             <Button size="small" icon={<FileTextOutlined />} onClick={() => onExportMarkdown(record)}>导出YAML</Button>
@@ -290,5 +303,112 @@ export function RecordDetailView({
         );
       })()}
     </>
+  );
+}
+
+/**
+ * 评分控件（仅针对已结束的执行记录）。
+ * - 未评分时：点击“评分”按钮弹出 Popover，输入 0-100 提交。
+ * - 已评分时：直接显示 `★ 85` 可点击重新编辑；提供“清除”按钮。
+ * 设计：评分仅属于“执行结果”，不能给 running 记录评分（RecordDetailView
+ * 会在 status === 'running' 时不渲染本控件）。
+ */
+function RecordRatingControl({
+  record,
+  onRate,
+}: {
+  record: ExecutionRecord;
+  onRate: (recordId: number, rating: number | null) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState<number | null>(record.rating ?? null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // 跟随 record.rating 变化同步本地值（避免外部刷新后表单与实际评分不一致）
+  useEffect(() => {
+    setValue(record.rating ?? null);
+  }, [record.rating, record.id]);
+
+  const handleSubmit = async (next: number | null) => {
+    setSubmitting(true);
+    try {
+      await onRate(record.id, next);
+      setOpen(false);
+    } catch {
+      // 错误由上层拦截器统一提示，本处仅保持弹窗开启以便用户重试
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const content = (
+    <div style={{ width: 220 }}>
+      <div style={{ marginBottom: 8, fontSize: 12, color: 'var(--color-text-secondary)' }}>
+        为本次执行结果评分（0-100）
+      </div>
+      <Space.Compact style={{ width: '100%' }}>
+        <InputNumber
+          min={0}
+          max={100}
+          value={value}
+          onChange={v => setValue(typeof v === 'number' ? v : null)}
+          placeholder="0-100"
+          style={{ width: '100%' }}
+          autoFocus
+          onPressEnter={() => {
+            if (value != null) handleSubmit(value);
+          }}
+        />
+        <Button
+          type="primary"
+          loading={submitting}
+          disabled={value == null}
+          onClick={() => handleSubmit(value)}
+        >
+          保存
+        </Button>
+      </Space.Compact>
+      {record.rating != null && (
+        <Button
+          type="link"
+          size="small"
+          danger
+          style={{ padding: '4px 0 0', marginTop: 4 }}
+          disabled={submitting}
+          onClick={() => handleSubmit(null)}
+        >
+          清除评分
+        </Button>
+      )}
+    </div>
+  );
+
+  if (record.rating != null) {
+    // 已评分：以徽章形式呈现，点击重新编辑
+    return (
+      <Popover content={content} open={open} onOpenChange={setOpen} placement="bottomRight">
+        <Button
+          size="small"
+          icon={<StarFilled style={{ color: '#fadb14' }} />}
+          onClick={() => setOpen(o => !o)}
+          aria-label="已评分，点击修改"
+        >
+          {record.rating}
+        </Button>
+      </Popover>
+    );
+  }
+
+  return (
+    <Popover content={content} open={open} onOpenChange={setOpen} placement="bottomRight">
+      <Button
+        size="small"
+        icon={<StarOutlined />}
+        onClick={() => setOpen(o => !o)}
+        aria-label="评分"
+      >
+        评分
+      </Button>
+    </Popover>
   );
 }

--- a/frontend/src/components/todo-detail/TodoHooksEditor.tsx
+++ b/frontend/src/components/todo-detail/TodoHooksEditor.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Button, Empty, Form, Input, Modal, Popconfirm, Select, Switch } from 'antd';
-import { PlusOutlined, EditOutlined, DeleteOutlined, HolderOutlined } from '@ant-design/icons';
-import { HOOK_TRIGGERS, type TodoHookItem } from '@/utils/database/hooks';
+import { Button, Empty, Form, Input, InputNumber, Modal, Popconfirm, Select, Switch, Tag, Tooltip } from 'antd';
+import { PlusOutlined, EditOutlined, DeleteOutlined, HolderOutlined, StarFilled } from '@ant-design/icons';
+import {
+  HOOK_TRIGGERS,
+  UNRATED_POLICIES,
+  DEFAULT_MIN_RATING,
+  DEFAULT_UNRATED_POLICY,
+  type TodoHookItem,
+  type UnratedPolicy,
+} from '@/utils/database/hooks';
 import type { Todo } from '@/types';
 
 function nextId(): number {
@@ -89,6 +96,7 @@ export function TodoHooksEditor({ todos, ownerId, hooks, onChange, disabled }: T
                 {items.map((item) => {
                   const target = todos.find((t) => t.id === item.target_todo_id);
                   const missing = !target;
+                  const hasGate = typeof item.min_rating === 'number';
                   return (
                     <div
                       key={item.id}
@@ -118,6 +126,24 @@ export function TodoHooksEditor({ todos, ownerId, hooks, onChange, disabled }: T
                           <span>→ {target!.title}</span>
                         )}
                       </span>
+                      {hasGate && (
+                        <Tooltip
+                          title={
+                            item.unrated_policy === 'pass'
+                              ? `评分≥${item.min_rating} 才触发；未评分时仍触发`
+                              : `评分≥${item.min_rating} 才触发；未评分时不触发`
+                          }
+                        >
+                          <Tag
+                            color="gold"
+                            icon={<StarFilled />}
+                            style={{ margin: 0, fontSize: 11, lineHeight: '16px' }}
+                            data-testid="hook-rating-gate"
+                          >
+                            ≥{item.min_rating} · {item.unrated_policy === 'pass' ? '未评通过' : '未评跳过'}
+                          </Tag>
+                        </Tooltip>
+                      )}
                       <Button
                         size="small"
                         type="text"
@@ -155,6 +181,17 @@ export function TodoHooksEditor({ todos, ownerId, hooks, onChange, disabled }: T
   );
 }
 
+interface HookFormValues {
+  id: number;
+  trigger: TodoHookItem['trigger'];
+  target_todo_id: number;
+  skip_if_missing: boolean;
+  enabled: boolean;
+  /** Number | null — `null` means the gate is disabled (no rating requirement). */
+  min_rating: number | null;
+  unrated_policy: UnratedPolicy;
+}
+
 function HookEditModal({
   open,
   item,
@@ -168,13 +205,24 @@ function HookEditModal({
   onCancel: () => void;
   onOk: (item: TodoHookItem) => void;
 }) {
-  const [form] = Form.useForm<TodoHookItem>();
+  const [form] = Form.useForm<HookFormValues>();
   const seedId = useMemo(() => nextId(), [open]);
+  // Watch the min_rating field so we can show/hide the unrated_policy
+  // control. A rating gate is only meaningful when a threshold is set.
+  const minRating = Form.useWatch('min_rating', form);
 
   useEffect(() => {
     if (!open) return;
     if (item) {
-      form.setFieldsValue(item);
+      form.setFieldsValue({
+        id: item.id,
+        trigger: item.trigger,
+        target_todo_id: item.target_todo_id,
+        skip_if_missing: item.skip_if_missing ?? true,
+        enabled: item.enabled,
+        min_rating: typeof item.min_rating === 'number' ? item.min_rating : null,
+        unrated_policy: item.unrated_policy ?? DEFAULT_UNRATED_POLICY,
+      });
     } else {
       form.setFieldsValue({
         id: seedId,
@@ -182,13 +230,25 @@ function HookEditModal({
         target_todo_id: undefined,
         skip_if_missing: true,
         enabled: true,
+        min_rating: DEFAULT_MIN_RATING,
+        unrated_policy: DEFAULT_UNRATED_POLICY,
       });
     }
   }, [open, item, form, seedId]);
 
   const handleOk = async (): Promise<void> => {
     const values = await form.validateFields();
-    onOk({ ...values, id: item?.id ?? seedId });
+    // Normalize the gate fields: if the user left `min_rating` empty, drop
+    // the gate entirely (and lock unrated_policy to its default) so we don't
+    // send ambiguous `null` payloads that the backend would have to guess at.
+    const hasGate = typeof values.min_rating === 'number';
+    const next: TodoHookItem = {
+      ...values,
+      id: item?.id ?? seedId,
+      min_rating: hasGate ? values.min_rating : null,
+      unrated_policy: hasGate ? values.unrated_policy : DEFAULT_UNRATED_POLICY,
+    };
+    onOk(next);
   };
 
   return (
@@ -219,6 +279,40 @@ function HookEditModal({
             options={targetOptions}
           />
         </Form.Item>
+        <Form.Item
+          name="min_rating"
+          label="最低评分（0-100，可选）"
+          extra={<>留空表示不门控，源 todo 状态变更时总是触发。</>}
+        >
+          <InputNumber
+            min={0}
+            max={100}
+            step={1}
+            precision={0}
+            placeholder="留空 = 不门控"
+            style={{ width: '100%' }}
+            aria-label="最低评分"
+          />
+        </Form.Item>
+        {typeof minRating === 'number' && (
+          <Form.Item
+            name="unrated_policy"
+            label="未评分时"
+            extra={(
+              <Form.Item
+                noStyle
+                shouldUpdate={(prev, curr) => prev.unrated_policy !== curr.unrated_policy}
+              >
+                {({ getFieldValue }) => {
+                  const policy = (getFieldValue('unrated_policy') as UnratedPolicy | undefined) ?? DEFAULT_UNRATED_POLICY;
+                  return UNRATED_POLICIES.find((p) => p.value === policy)?.description;
+                }}
+              </Form.Item>
+            )}
+          >
+            <Select options={UNRATED_POLICIES.map((p) => ({ value: p.value, label: p.label }))} />
+          </Form.Item>
+        )}
         <Form.Item name="skip_if_missing" label="目标不存在时跳过" valuePropName="checked">
           <Switch />
         </Form.Item>

--- a/frontend/src/hooks/useExecutionHistory.ts
+++ b/frontend/src/hooks/useExecutionHistory.ts
@@ -107,6 +107,12 @@ export function useExecutionHistory({
     try {
       const record = await db.getExecutionRecord(recordId);
       dispatch({ type: 'UPDATE_EXECUTION_RECORD', payload: { todoId: selectedTodoId, record } });
+      // 同步更新详情面板使用的本地 detail state，避免评分等同步更新后
+      // 详情面板仍展示旧值（详情面板优先使用 selectedHistoryRecordDetail，
+      // 这里只在被刷新的 record 正好是当前选中的那一条时才覆盖）。
+      if (activeRecordIdRef.current === recordId) {
+        setSelectedHistoryRecordDetail(record);
+      }
     } catch { /* ignore */ }
   }, [selectedTodoId, dispatch]);
 

--- a/frontend/src/types/execution.tsx
+++ b/frontend/src/types/execution.tsx
@@ -58,6 +58,8 @@ export interface ExecutionRecord {
   source_todo_id?: number | null;
   source_todo_title?: string | null;
   source_hook_id?: number | null;
+  /** User-provided score for this execution's result (0-100). */
+  rating?: number | null;
 }
 
 export interface ExecutionSummary {

--- a/frontend/src/types/todo.ts
+++ b/frontend/src/types/todo.ts
@@ -20,6 +20,7 @@ export interface Todo {
   workspace?: string | null;
   worktree_enabled?: boolean;
   hooks?: TodoHookItem[];
+  acceptance_criteria?: string | null;
 }
 
 export interface Tag {

--- a/frontend/src/utils/database/executions.ts
+++ b/frontend/src/utils/database/executions.ts
@@ -62,6 +62,17 @@ export async function resumeExecutionRecord(recordId: number, message?: string):
   return unwrap(await api.post(`/api/execution-records/${recordId}/resume`, { message }));
 }
 
+/**
+ * 给一条执行结果评分（0-100）。仅针对已结束的记录（success/failed）；
+ * running 记录后端会拒绝。传 null 表示清除评分。
+ */
+export async function rateExecutionRecord(
+  recordId: number,
+  rating: number | null,
+): Promise<ExecutionRecord> {
+  return unwrap(await api.put(`/api/execution-records/${recordId}/rating`, { rating }));
+}
+
 // Smart Create API
 
 export interface SmartCreateResult {

--- a/frontend/src/utils/database/hooks.ts
+++ b/frontend/src/utils/database/hooks.ts
@@ -17,12 +17,30 @@ export type HookTrigger =
   | 'state_changed_to_completed'
   | 'state_changed_to_failed';
 
+/**
+ * Policy for how the rating gate treats an unrated record. Matches the
+ * backend `UnratedPolicy` enum (snake_case serialization).
+ */
+export type UnratedPolicy = 'skip' | 'pass';
+
 export interface TodoHookItem {
   id: number;
   trigger: HookTrigger;
   target_todo_id: number;
   skip_if_missing?: boolean;
   enabled: boolean;
+  /**
+   * Optional rating gate. When set (0-100), the hook only fires if the
+   * source todo's most recent FINISHED execution record has
+   * `rating >= min_rating`. `undefined`/`null` means no gate (always fire).
+   */
+  min_rating?: number | null;
+  /**
+   * What to do when the source todo has no rating on its latest finished
+   * record. Defaults to `'skip'` (do not fire). `'pass'` treats the missing
+   * rating as if it had passed the gate.
+   */
+  unrated_policy?: UnratedPolicy;
 }
 
 export const HOOK_TRIGGERS: ReadonlyArray<{ value: HookTrigger; label: string }> = [
@@ -31,6 +49,23 @@ export const HOOK_TRIGGERS: ReadonlyArray<{ value: HookTrigger; label: string }>
   { value: 'state_changed_to_completed', label: '状态变为已完成' },
   { value: 'state_changed_to_failed', label: '状态变为失败' },
 ];
+
+export const UNRATED_POLICIES: ReadonlyArray<{ value: UnratedPolicy; label: string; description: string }> = [
+  {
+    value: 'skip',
+    label: '未评分时跳过',
+    description: '安全默认：未评分视为不达标，不触发下游',
+  },
+  {
+    value: 'pass',
+    label: '未评分时通过',
+    description: '宽松：只有明确低分才会拦截，未评分时正常触发',
+  },
+];
+
+/** Default rating gate when the user opens the modal fresh. */
+export const DEFAULT_MIN_RATING: number | null = null;
+export const DEFAULT_UNRATED_POLICY: UnratedPolicy = 'skip';
 
 const HOOK_TRIGGER_LABEL_BY_VALUE: Record<HookTrigger, string> = HOOK_TRIGGERS.reduce(
   (acc, t) => ({ ...acc, [t.value]: t.label }),

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -13,8 +13,11 @@ export async function createTodo(
   prompt: string = '',
   tagIds: number[] = [],
   hooks: TodoHookItem[] = [],
+  acceptanceCriteria?: string,
 ): Promise<Todo> {
-  return unwrap(await api.post('/api/todos', { title, prompt, tag_ids: tagIds, hooks }));
+  const body: Record<string, unknown> = { title, prompt, tag_ids: tagIds, hooks };
+  if (acceptanceCriteria !== undefined) body.acceptance_criteria = acceptanceCriteria;
+  return unwrap(await api.post('/api/todos', body));
 }
 
 export async function updateTodo(
@@ -28,6 +31,7 @@ export async function updateTodo(
   workspace?: string | null,
   worktree_enabled?: boolean,
   hooks?: TodoHookItem[],
+  acceptance_criteria?: string | null,
 ): Promise<Todo> {
   const body: Record<string, unknown> = { title, prompt, status };
   if (executor !== undefined) body.executor = executor;
@@ -36,6 +40,7 @@ export async function updateTodo(
   if (workspace !== undefined) body.workspace = workspace;
   if (worktree_enabled !== undefined) body.worktree_enabled = worktree_enabled;
   if (hooks !== undefined) body.hooks = hooks;
+  if (acceptance_criteria !== undefined) body.acceptance_criteria = acceptance_criteria;
 
   return unwrap(await api.put(`/api/todos/${id}`, body));
 }


### PR DESCRIPTION
## 背景

之前 `TodoHookItem` 的触发逻辑是"源 todo 状态变更就 fire"，没有"前置条件"概念。当源 todo 的执行结果是低分、甚至是失败但仍要往下游链式触发时，用户没有任何手段在 hook 这一层做"质量门控"。

本次新增一个可选的**评分门控**：
- 在 hook 触发前，先看源 todo 最新一条 finished execution record 的 rating 是否 ≥ 阈值
- 阈值未达 → 跳过触发，并输出 warn 日志
- 整个特性是**纯加项**：`min_rating` 为空时表现与改动前完全一致

## 字段

`TodoHookItem` 新增两个字段：

| 字段 | 类型 | 含义 |
|---|---|---|
| `min_rating` | `Option<i32>` (0-100) | 触发所需最低评分。`null` = 不门控（向后兼容） |
| `unrated_policy` | `UnratedPolicy` | rating 缺失时策略：`skip`（默认）/ `pass` |

## 规则矩阵

| 条件 | min_rating=None | min_rating=80, skip | min_rating=80, pass |
|---|---|---|---|
| 无 record | Allow | Deny (no finished record) | Allow |
| record.rating=null | Allow | **Deny (rating is null)** | Allow |
| record.rating=70 | Allow | **Deny (rating below threshold)** | Deny |
| record.rating=90 | Allow | Allow | Allow |

## 实现要点

- **后端** (`backend/src/hooks/`)
 - `models.rs`：`UnratedPolicy` enum（snake_case 序列化）、`TodoHookItem` 字段、`TodoHooks::parse` 防御性解析（越界/未知值降级）
 - `service.rs`：
 - `lookup_latest_finished_record`：查最新非 running record（避免 running 抖动）
 - `evaluate_rating_gate`：纯函数，配套 11 个单元测试覆盖全部分支
 - 拒绝时 `warn!` 输出完整上下文（min_rating、policy、actual rating、reason）
- **前端** (`frontend/src/`)
 - `utils/database/hooks.ts`：`UnratedPolicy` 类型 + `UNRATED_POLICIES` 选项
 - `TodoHooksEditor.tsx`：
 - 编辑 modal 动态显示"最低评分" InputNumber（min=0/max=100）
 - 填了数字才出现"未评分时" Select（避免视觉噪音）
 - 列表中**金色 Tag** `≥85 · 未评跳过` / `≥85 · 未评通过`，hover 显示详细说明
- `db/mod.rs` 顺手补两个旧测试缺失的 `acceptance_criteria` 字段，让 `cargo test --lib` 编译通过

## 验证

### 单元测试

`cargo test --lib hooks::service::tests` —— **11/11 通过**：
- `no_min_rating_always_allows` —— 无门控时无论评分如何都通过
- `min_rating_passes_when_score_meets_threshold` —— ≥ 阈值放行
- `min_rating_denies_when_score_below_threshold` —— < 阈值拒绝
- `unrated_skip_denies_null_rating` —— 默认 skip 拒绝 null
- `unrated_pass_allows_null_rating` —— pass 模式放行 null
- `unrated_skip_denies_when_no_record_exists` —— 无 record + skip 拒绝
- `unrated_pass_allows_when_no_record_exists` —— 无 record + pass 放行
- `unrated_policy_does_not_change_threshold_decision` —— policy 只影响 null 分支
- `unrated_policy_deserializes_from_snake_case` —— 序列化格式
- `unrated_policy_default_is_skip` —— 默认值
- `parse_tolerates_missing_or_unknown_gate_fields` —— JSON 解析容错（老 payload、无效越界、未知 policy）

### 端到端 API 验证

使用现有 todo#9 → #10 链路强制触发 `state_changed_to_completed`：

| 场景 | 结果 |
|---|---|
| min_rating=85, rating=70, skip | ✅ `skipped by rating gate (min_rating=85, policy=skip, source rating=70, reason=rating below threshold)` |
| min_rating=85, rating=90, skip | ✅ target todo#10 新增 record 74，hook 触发 |
| min_rating=85, rating=null, pass | ✅ target todo#10 新增 record 75，hook 触发 |
| min_rating=85, rating=null, skip | ✅ `skipped by rating gate (min_rating=85, policy=skip, source rating=null, reason=rating is null)` |

### Playwright UI 验证

- Hook 编辑 modal 显示"最低评分 (0-100, 可选)"标签
- 填入 85 后动态显示"未评分时" Select
- 保存后列表中显示金色 `≥85 · 未评跳过` Tag
- 重开编辑 modal 字段正确回填

## 向后兼容

- 旧 payload 没有 `min_rating` 字段 → 解析为 `None` → 不门控 → 行为不变
- 旧 payload 没有 `unrated_policy` 字段 → 解析为默认 `Skip`
- 前端没设过门控的 todo 列表不会有 Tag，UI 不变

## 分支

`feat/hook-rating-gate`，基于 `main` 的 1 个 commit (`35e1f62`)。