### PR TITLE
feat: add pi executor adapter

### DIFF
--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -114,10 +114,19 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         session_dir: "~/.codewhale",
         aliases: &[],
     },
+    ExecutorDef {
+        name: "pi",
+        executor_type: ExecutorType::Pi,
+        binary_name: "pi",
+        display_name: "Pi",
+        default_path: "pi",
+        session_dir: "~/.pi",
+        aliases: &[],
+    },
 ];
 
 /// 支持继续对话的执行器集合（与前端 RESUMABLE_EXECUTORS 保持一致）
-pub const RESUMABLE_EXECUTORS: &[&str] = &["claudecode", "kimi", "opencode", "mobilecoder", "hermes", "codewhale"];
+pub const RESUMABLE_EXECUTORS: &[&str] = &["claudecode", "kimi", "opencode", "mobilecoder", "hermes", "codewhale", "pi"];
 
 /// 默认执行器
 pub const DEFAULT_EXECUTOR: &str = "claudecode";
@@ -180,6 +189,8 @@ pub mod hermes;
 pub mod kimi;
 pub mod codex;
 pub mod codewhale;
+pub mod pi;
+pub mod pi_event;
 
 #[async_trait]
 pub trait CodeExecutor: Send + Sync {
@@ -290,6 +301,7 @@ impl ExecutorRegistry {
             "kimi" => Arc::new(kimi::KimiExecutor::new(path.to_string())),
             "codex" => Arc::new(codex::CodexExecutor::new(path.to_string())),
             "codewhale" => Arc::new(codewhale::CodewhaleExecutor::new(path.to_string())),
+            "pi" => Arc::new(pi::PiExecutor::new(path.to_string())),
             _ => return None,
         };
         Some(executor)

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -119,8 +119,11 @@ impl CodeExecutor for PiExecutor {
                 }
                 "message_end" => {
                     // message_end 包含完整的消息内容
-                    // 提取最终的 text 回复（忽略 thinking），用于 get_final_result
+                    // 只有 assistant 消息才包含 AI 回复内容，user 消息不需要处理
                     if let Some(msg) = event.message {
+                        if msg.role.as_deref() != Some("assistant") {
+                            return None;
+                        }
                         let mut text_parts = Vec::new();
                         for block in &msg.content {
                             if let super::pi_event::PiContentBlock::Text { text } = block {

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -118,12 +118,15 @@ impl CodeExecutor for PiExecutor {
                     })
                 }
                 "message_end" => {
-                    // message_end 包含完整的消息内容
-                    // 提取 assistant 消息的 text 内容
+                    // message_end 包含完整消息内容
+                    // 对于 assistant 消息，内容已经在 message_update 时通过 text_delta 实时发送了
+                    // message_end 这里只处理工具结果等非 assistant 消息
                     if let Some(msg) = event.message {
-                        if msg.role.as_deref() != Some("assistant") {
+                        if msg.role.as_deref() == Some("assistant") {
+                            // assistant 内容已在 message_update 时发送，这里跳过避免重复
                             return None;
                         }
+                        // 其他角色（user 等）的消息内容
                         let mut text_parts = Vec::new();
                         for block in &msg.content {
                             if let super::pi_event::PiContentBlock::Text { text } = block {
@@ -150,71 +153,29 @@ impl CodeExecutor for PiExecutor {
                     None
                 }
                 "message_update" => {
-                    // message_update 包含增量内容
-                    // 优先从 assistantMessageEvent 提取 text delta（实际回复内容）
+                    // message_update 包含增量内容，只从 assistantMessageEvent 提取
                     if let Some(ame) = event.assistant_message_event {
-                        // 处理 text_delta - 这是实际的回复文本
-                        if ame.event_type.as_deref() == Some("text_delta") {
-                            if let Some(delta) = &ame.delta {
-                                let trimmed = delta.trim();
-                                if !trimmed.is_empty() {
-                                    return Some(ParsedLogEntry {
-                                        timestamp: utc_timestamp(),
-                                        log_type: "assistant".to_string(),
-                                        content: trimmed.to_string(),
-                                        usage: None,
-                                        tool_name: None,
-                                        tool_input_json: None,
-                                    });
-                                }
-                            }
-                        }
-                        // 处理 thinking_delta - 这是 thinking 内容的增量
-                        if ame.event_type.as_deref() == Some("thinking_delta") {
-                            if let Some(delta) = &ame.delta {
-                                let trimmed = delta.trim();
-                                if !trimmed.is_empty() {
-                                    return Some(ParsedLogEntry {
-                                        timestamp: utc_timestamp(),
-                                        log_type: "thinking".to_string(),
-                                        content: trimmed.chars().take(500).collect(),
-                                        usage: None,
-                                        tool_name: None,
-                                        tool_input_json: None,
-                                    });
-                                }
-                            }
-                        }
-                        // 处理 thinking_start / thinking_end - 完整的 thinking 内容
-                        if ame.event_type.as_deref() == Some("thinking_start") ||
-                           ame.event_type.as_deref() == Some("thinking_end") {
-                            if let Some(partial) = &ame.partial {
-                                for block in &partial.content {
-                                    if let super::pi_event::PiContentBlock::Thinking { thinking } = block {
-                                        if let Some(t) = thinking {
-                                            let trimmed = t.trim();
-                                            if !trimmed.is_empty() {
-                                                return Some(ParsedLogEntry {
-                                                    timestamp: utc_timestamp(),
-                                                    log_type: "thinking".to_string(),
-                                                    content: trimmed.chars().take(500).collect(),
-                                                    usage: None,
-                                                    tool_name: None,
-                                                    tool_input_json: None,
-                                                });
-                                            }
-                                        }
+                        match ame.event_type.as_deref() {
+                            Some("text_delta") => {
+                                // text_delta 是实际回复的增量内容
+                                if let Some(delta) = &ame.delta {
+                                    let trimmed = delta.trim();
+                                    if !trimmed.is_empty() {
+                                        return Some(ParsedLogEntry {
+                                            timestamp: utc_timestamp(),
+                                            log_type: "assistant".to_string(),
+                                            content: trimmed.to_string(),
+                                            usage: None,
+                                            tool_name: None,
+                                            tool_input_json: None,
+                                        });
                                     }
                                 }
                             }
-                        }
-                    }
-                    // 备用：从 message.content 解析（处理非 assistant 消息或无 assistantMessageEvent 的情况）
-                    if let Some(msg) = event.message {
-                        for block in &msg.content {
-                            if let super::pi_event::PiContentBlock::Thinking { thinking } = block {
-                                if let Some(t) = thinking {
-                                    let trimmed = t.trim();
+                            Some("thinking_delta") => {
+                                // thinking_delta 是 thinking 的增量内容
+                                if let Some(delta) = &ame.delta {
+                                    let trimmed = delta.trim();
                                     if !trimmed.is_empty() {
                                         return Some(ParsedLogEntry {
                                             timestamp: utc_timestamp(),
@@ -227,6 +188,7 @@ impl CodeExecutor for PiExecutor {
                                     }
                                 }
                             }
+                            _ => {}
                         }
                     }
                     None

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -117,49 +117,40 @@ impl CodeExecutor for PiExecutor {
                         tool_input_json: None,
                     })
                 }
-                "message_start" | "message_update" | "message_end" => {
-                    // 解析消息内容
+                "message_end" => {
+                    // message_end 包含完整的消息内容
+                    // 提取最终的 text 回复（忽略 thinking），用于 get_final_result
                     if let Some(msg) = event.message {
-                        for block in msg.content {
-                            match block {
-                                super::pi_event::PiContentBlock::Text { text } => {
-                                    if let Some(t) = text {
-                                        let trimmed = t.trim();
-                                        if !trimmed.is_empty() {
-                                            return Some(ParsedLogEntry {
-                                                timestamp: utc_timestamp(),
-                                                log_type: "assistant".to_string(),
-                                                content: trimmed.to_string(),
-                                                usage: None,
-                                                tool_name: None,
-                                                tool_input_json: None,
-                                            });
-                                        }
+                        let mut text_parts = Vec::new();
+                        for block in &msg.content {
+                            if let super::pi_event::PiContentBlock::Text { text } = block {
+                                if let Some(t) = text {
+                                    let trimmed = t.trim();
+                                    if !trimmed.is_empty() {
+                                        text_parts.push(trimmed.to_string());
                                     }
                                 }
-                                super::pi_event::PiContentBlock::ToolCall { id: _, name, input } => {
-                                    let name_str = name.unwrap_or_else(|| "unknown".to_string());
-                                    let input_str = serde_json::to_string(&input).unwrap_or_default();
-                                    return Some(ParsedLogEntry {
-                                        timestamp: utc_timestamp(),
-                                        log_type: "tool_use".to_string(),
-                                        content: format!("调用工具: {} - {}", name_str, input_str.chars().take(300).collect::<String>()),
-                                        usage: None,
-                                        tool_name: Some(name_str),
-                                        tool_input_json: Some(input_str),
-                                    });
-                                }
-                                super::pi_event::PiContentBlock::ToolResult { tool_call_id: _, content, is_error } => {
-                                    let err_str = if is_error.unwrap_or(false) { "[错误] " } else { "" };
-                                    return Some(ParsedLogEntry {
-                                        timestamp: utc_timestamp(),
-                                        log_type: "tool_result".to_string(),
-                                        content: format!("{}{}", err_str, content.unwrap_or_default().chars().take(300).collect::<String>()),
-                                        usage: None,
-                                        tool_name: None,
-                                        tool_input_json: None,
-                                    });
-                                }
+                            }
+                        }
+                        if !text_parts.is_empty() {
+                            let content = text_parts.join("\n");
+                            return Some(ParsedLogEntry {
+                                timestamp: utc_timestamp(),
+                                log_type: "assistant".to_string(),
+                                content: content.clone(),
+                                usage: None,
+                                tool_name: None,
+                                tool_input_json: None,
+                            });
+                        }
+                    }
+                    None
+                }
+                "message_update" => {
+                    // message_update 包含增量内容，处理 thinking 和 text delta
+                    if let Some(msg) = event.message {
+                        for block in &msg.content {
+                            match block {
                                 super::pi_event::PiContentBlock::Thinking { thinking } => {
                                     if let Some(t) = thinking {
                                         let trimmed = t.trim();
@@ -175,19 +166,14 @@ impl CodeExecutor for PiExecutor {
                                         }
                                     }
                                 }
-                                super::pi_event::PiContentBlock::Redacted { redacted } => {
-                                    return Some(ParsedLogEntry {
-                                        timestamp: utc_timestamp(),
-                                        log_type: "assistant".to_string(),
-                                        content: format!("[redacted] {}", redacted.unwrap_or_default()),
-                                        usage: None,
-                                        tool_name: None,
-                                        tool_input_json: None,
-                                    });
-                                }
+                                _ => {}
                             }
                         }
                     }
+                    None
+                }
+                "message_start" => {
+                    // message_start 事件（通常只有 role 信息，不返回具体内容）
                     None
                 }
                 "tool_execution_start" => {

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -119,7 +119,7 @@ impl CodeExecutor for PiExecutor {
                 }
                 "message_end" => {
                     // message_end 包含完整的消息内容
-                    // 只有 assistant 消息才包含 AI 回复内容，user 消息不需要处理
+                    // 提取 assistant 消息的 text 内容
                     if let Some(msg) = event.message {
                         if msg.role.as_deref() != Some("assistant") {
                             return None;
@@ -150,26 +150,82 @@ impl CodeExecutor for PiExecutor {
                     None
                 }
                 "message_update" => {
-                    // message_update 包含增量内容，处理 thinking 和 text delta
-                    if let Some(msg) = event.message {
-                        for block in &msg.content {
-                            match block {
-                                super::pi_event::PiContentBlock::Thinking { thinking } => {
-                                    if let Some(t) = thinking {
-                                        let trimmed = t.trim();
-                                        if !trimmed.is_empty() {
-                                            return Some(ParsedLogEntry {
-                                                timestamp: utc_timestamp(),
-                                                log_type: "thinking".to_string(),
-                                                content: trimmed.chars().take(500).collect(),
-                                                usage: None,
-                                                tool_name: None,
-                                                tool_input_json: None,
-                                            });
+                    // message_update 包含增量内容
+                    // 优先从 assistantMessageEvent 提取 text delta（实际回复内容）
+                    if let Some(ame) = event.assistant_message_event {
+                        // 处理 text_delta - 这是实际的回复文本
+                        if ame.event_type.as_deref() == Some("text_delta") {
+                            if let Some(delta) = &ame.delta {
+                                let trimmed = delta.trim();
+                                if !trimmed.is_empty() {
+                                    return Some(ParsedLogEntry {
+                                        timestamp: utc_timestamp(),
+                                        log_type: "assistant".to_string(),
+                                        content: trimmed.to_string(),
+                                        usage: None,
+                                        tool_name: None,
+                                        tool_input_json: None,
+                                    });
+                                }
+                            }
+                        }
+                        // 处理 thinking_delta - 这是 thinking 内容的增量
+                        if ame.event_type.as_deref() == Some("thinking_delta") {
+                            if let Some(delta) = &ame.delta {
+                                let trimmed = delta.trim();
+                                if !trimmed.is_empty() {
+                                    return Some(ParsedLogEntry {
+                                        timestamp: utc_timestamp(),
+                                        log_type: "thinking".to_string(),
+                                        content: trimmed.chars().take(500).collect(),
+                                        usage: None,
+                                        tool_name: None,
+                                        tool_input_json: None,
+                                    });
+                                }
+                            }
+                        }
+                        // 处理 thinking_start / thinking_end - 完整的 thinking 内容
+                        if ame.event_type.as_deref() == Some("thinking_start") ||
+                           ame.event_type.as_deref() == Some("thinking_end") {
+                            if let Some(partial) = &ame.partial {
+                                for block in &partial.content {
+                                    if let super::pi_event::PiContentBlock::Thinking { thinking } = block {
+                                        if let Some(t) = thinking {
+                                            let trimmed = t.trim();
+                                            if !trimmed.is_empty() {
+                                                return Some(ParsedLogEntry {
+                                                    timestamp: utc_timestamp(),
+                                                    log_type: "thinking".to_string(),
+                                                    content: trimmed.chars().take(500).collect(),
+                                                    usage: None,
+                                                    tool_name: None,
+                                                    tool_input_json: None,
+                                                });
+                                            }
                                         }
                                     }
                                 }
-                                _ => {}
+                            }
+                        }
+                    }
+                    // 备用：从 message.content 解析（处理非 assistant 消息或无 assistantMessageEvent 的情况）
+                    if let Some(msg) = event.message {
+                        for block in &msg.content {
+                            if let super::pi_event::PiContentBlock::Thinking { thinking } = block {
+                                if let Some(t) = thinking {
+                                    let trimmed = t.trim();
+                                    if !trimmed.is_empty() {
+                                        return Some(ParsedLogEntry {
+                                            timestamp: utc_timestamp(),
+                                            log_type: "thinking".to_string(),
+                                            content: trimmed.chars().take(500).collect(),
+                                            usage: None,
+                                            tool_name: None,
+                                            tool_input_json: None,
+                                        });
+                                    }
+                                }
                             }
                         }
                     }

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -1,0 +1,305 @@
+//! pi 执行器 adapter
+//!
+//! 支持 --continue 恢复会话、--session 指定 session-id、--mode json JSONL 输出
+
+use std::sync::Arc;
+use parking_lot::Mutex;
+
+use super::{CodeExecutor, ExecutorType, ParsedLogEntry, ExecutionUsage};
+use super::pi_event::PiEvent;
+use crate::models::utc_timestamp;
+
+pub struct PiExecutor {
+    path: String,
+    model: Arc<Mutex<Option<String>>>,
+    /// 从 session 事件中提取的 session id
+    session_id: Arc<Mutex<Option<String>>>,
+}
+
+impl PiExecutor {
+    pub fn new(path: String) -> Self {
+        Self {
+            path,
+            model: Arc::new(Mutex::new(None)),
+            session_id: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl Clone for PiExecutor {
+    fn clone(&self) -> Self {
+        Self {
+            path: self.path.clone(),
+            model: self.model.clone(),
+            session_id: self.session_id.clone(),
+        }
+    }
+}
+
+impl CodeExecutor for PiExecutor {
+    fn executor_type(&self) -> ExecutorType {
+        ExecutorType::Pi
+    }
+
+    fn executable_path(&self) -> &str {
+        &self.path
+    }
+
+    fn command_args(&self, message: &str) -> Vec<String> {
+        vec![
+            "-p".to_string(),
+            "--mode".to_string(),
+            "json".to_string(),
+            message.to_string(),
+        ]
+    }
+
+    /// 支持 session 的命令参数
+    /// pi 使用 --continue 恢复，--session <id> 指定已有 session
+    fn command_args_with_session(&self, message: &str, session_id: Option<&str>, is_resume: bool) -> Vec<String> {
+        let mut args = vec![
+            "-p".to_string(),
+            "--mode".to_string(),
+            "json".to_string(),
+        ];
+        if let Some(sid) = session_id {
+            if is_resume {
+                // 恢复模式：继续之前的 session
+                args.push("--continue".to_string());
+                args.push(format!("--session {}", sid));
+            } else {
+                // 新 session 但指定 id（目前 pi 不支持创建指定 id 的 session，
+                // 只能用 --continue 恢复，这里 fallback 到 --continue）
+                args.push("--continue".to_string());
+                args.push(format!("--session {}", sid));
+            }
+        }
+        args.push(message.to_string());
+        args
+    }
+
+    fn supports_resume(&self) -> bool {
+        true
+    }
+
+    /// 从 session 事件中提取 session id
+    fn extract_session_id(&self, line: &str) -> Option<String> {
+        if line.is_empty() {
+            return None;
+        }
+        if let Ok(event) = serde_json::from_str::<PiEvent>(line) {
+            if event.event_type == "session" {
+                if let Some(id) = event.id {
+                    *self.session_id.lock() = Some(id.clone());
+                    return Some(id);
+                }
+            }
+        }
+        None
+    }
+
+    fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
+        if line.is_empty() {
+            return None;
+        }
+
+        // 尝试解析为 pi JSONL 事件
+        if let Ok(event) = serde_json::from_str::<PiEvent>(line) {
+            return match event.event_type.as_str() {
+                "session" => {
+                    // Session 初始化事件
+                    if let Some(id) = &event.id {
+                        *self.session_id.lock() = Some(id.clone());
+                    }
+                    Some(ParsedLogEntry {
+                        timestamp: utc_timestamp(),
+                        log_type: "system".to_string(),
+                        content: format!("Session: {:?}", event.id),
+                        usage: None,
+                        tool_name: None,
+                        tool_input_json: None,
+                    })
+                }
+                "message_start" | "message_update" | "message_end" => {
+                    // 解析消息内容
+                    if let Some(msg) = event.message {
+                        for block in msg.content {
+                            match block {
+                                super::pi_event::PiContentBlock::Text { text } => {
+                                    if let Some(t) = text {
+                                        let trimmed = t.trim();
+                                        if !trimmed.is_empty() {
+                                            return Some(ParsedLogEntry {
+                                                timestamp: utc_timestamp(),
+                                                log_type: "assistant".to_string(),
+                                                content: trimmed.to_string(),
+                                                usage: None,
+                                                tool_name: None,
+                                                tool_input_json: None,
+                                            });
+                                        }
+                                    }
+                                }
+                                super::pi_event::PiContentBlock::ToolCall { id: _, name, input } => {
+                                    let name_str = name.unwrap_or_else(|| "unknown".to_string());
+                                    let input_str = serde_json::to_string(&input).unwrap_or_default();
+                                    return Some(ParsedLogEntry {
+                                        timestamp: utc_timestamp(),
+                                        log_type: "tool_use".to_string(),
+                                        content: format!("调用工具: {} - {}", name_str, input_str.chars().take(300).collect::<String>()),
+                                        usage: None,
+                                        tool_name: Some(name_str),
+                                        tool_input_json: Some(input_str),
+                                    });
+                                }
+                                super::pi_event::PiContentBlock::ToolResult { tool_call_id: _, content, is_error } => {
+                                    let err_str = if is_error.unwrap_or(false) { "[错误] " } else { "" };
+                                    return Some(ParsedLogEntry {
+                                        timestamp: utc_timestamp(),
+                                        log_type: "tool_result".to_string(),
+                                        content: format!("{}{}", err_str, content.unwrap_or_default().chars().take(300).collect::<String>()),
+                                        usage: None,
+                                        tool_name: None,
+                                        tool_input_json: None,
+                                    });
+                                }
+                                super::pi_event::PiContentBlock::Thinking { thinking } => {
+                                    if let Some(t) = thinking {
+                                        let trimmed = t.trim();
+                                        if !trimmed.is_empty() {
+                                            return Some(ParsedLogEntry {
+                                                timestamp: utc_timestamp(),
+                                                log_type: "thinking".to_string(),
+                                                content: trimmed.chars().take(500).collect(),
+                                                usage: None,
+                                                tool_name: None,
+                                                tool_input_json: None,
+                                            });
+                                        }
+                                    }
+                                }
+                                super::pi_event::PiContentBlock::Redacted { redacted } => {
+                                    return Some(ParsedLogEntry {
+                                        timestamp: utc_timestamp(),
+                                        log_type: "assistant".to_string(),
+                                        content: format!("[redacted] {}", redacted.unwrap_or_default()),
+                                        usage: None,
+                                        tool_name: None,
+                                        tool_input_json: None,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    None
+                }
+                "tool_execution_start" => {
+                    if let Some(te) = event.tool_execution {
+                        let name = te.name.unwrap_or_else(|| "unknown".to_string());
+                        let input_str = te.input.as_ref().map(|i| serde_json::to_string(i).unwrap_or_default()).unwrap_or_default();
+                        return Some(ParsedLogEntry {
+                            timestamp: utc_timestamp(),
+                            log_type: "tool_use".to_string(),
+                            content: format!("开始工具: {}", name),
+                            usage: None,
+                            tool_name: Some(name),
+                            tool_input_json: Some(input_str),
+                        });
+                    }
+                    None
+                }
+                "tool_execution_end" => {
+                    if let Some(te) = event.tool_execution {
+                        let name = te.name.unwrap_or_else(|| "unknown".to_string());
+                        let output = te.output.unwrap_or_default();
+                        return Some(ParsedLogEntry {
+                            timestamp: utc_timestamp(),
+                            log_type: "tool_result".to_string(),
+                            content: format!("{}: {}", name, output.chars().take(300).collect::<String>()),
+                            usage: None,
+                            tool_name: Some(name),
+                            tool_input_json: None,
+                        });
+                    }
+                    None
+                }
+                "agent_start" => Some(ParsedLogEntry {
+                    timestamp: utc_timestamp(),
+                    log_type: "system".to_string(),
+                    content: "Agent started".to_string(),
+                    usage: None,
+                    tool_name: None,
+                    tool_input_json: None,
+                }),
+                "agent_end" => Some(ParsedLogEntry {
+                    timestamp: utc_timestamp(),
+                    log_type: "system".to_string(),
+                    content: "Agent finished".to_string(),
+                    usage: None,
+                    tool_name: None,
+                    tool_input_json: None,
+                }),
+                "compaction_start" => Some(ParsedLogEntry {
+                    timestamp: utc_timestamp(),
+                    log_type: "system".to_string(),
+                    content: "Compacting session...".to_string(),
+                    usage: None,
+                    tool_name: None,
+                    tool_input_json: None,
+                }),
+                "compaction_end" => Some(ParsedLogEntry {
+                    timestamp: utc_timestamp(),
+                    log_type: "system".to_string(),
+                    content: "Compaction finished".to_string(),
+                    usage: None,
+                    tool_name: None,
+                    tool_input_json: None,
+                }),
+                // 忽略其他事件类型
+                _ => None,
+            };
+        }
+
+        // 非 JSON 行当作普通文本处理
+        Some(ParsedLogEntry {
+            timestamp: utc_timestamp(),
+            log_type: "text".to_string(),
+            content: line.to_string(),
+            usage: None,
+            tool_name: None,
+            tool_input_json: None,
+        })
+    }
+
+    fn check_success(&self, exit_code: i32) -> bool {
+        exit_code == 0
+    }
+
+    fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
+        // 收集所有 assistant 类型的文本
+        let texts: Vec<String> = logs.iter()
+            .filter(|l| l.log_type == "assistant")
+            .map(|l| l.content.clone())
+            .filter(|t| !t.trim().is_empty())
+            .collect();
+
+        if !texts.is_empty() {
+            Some(texts.join("\n\n"))
+        } else {
+            // fallback 到最后一条文本
+            logs.iter()
+                .rev()
+                .find(|l| l.log_type == "text")
+                .map(|l| l.content.clone())
+        }
+    }
+
+    fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
+        // pi 目前不在 JSONL 中输出 usage 信息
+        None
+    }
+
+    fn get_model(&self) -> Option<String> {
+        self.model.lock().clone()
+    }
+}

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -55,24 +55,17 @@ impl CodeExecutor for PiExecutor {
     }
 
     /// 支持 session 的命令参数
-    /// pi 使用 --continue 恢复，--session <id> 指定已有 session
-    fn command_args_with_session(&self, message: &str, session_id: Option<&str>, is_resume: bool) -> Vec<String> {
+    /// pi 使用 --continue 恢复（不需要指定 session id，pi 会自动找当前目录最近的 session）
+    fn command_args_with_session(&self, message: &str, _session_id: Option<&str>, is_resume: bool) -> Vec<String> {
         let mut args = vec![
             "-p".to_string(),
             "--mode".to_string(),
             "json".to_string(),
         ];
-        if let Some(sid) = session_id {
-            if is_resume {
-                // 恢复模式：继续之前的 session
-                args.push("--continue".to_string());
-                args.push(format!("--session {}", sid));
-            } else {
-                // 新 session 但指定 id（目前 pi 不支持创建指定 id 的 session，
-                // 只能用 --continue 恢复，这里 fallback 到 --continue）
-                args.push("--continue".to_string());
-                args.push(format!("--session {}", sid));
-            }
+        if is_resume {
+            // 恢复模式：只用 --continue，让 pi 自动找最近 session
+            // 注意：pi 的 session 按项目目录存储，必须确保 cwd 与原 session 创建时一致
+            args.push("--continue".to_string());
         }
         args.push(message.to_string());
         args
@@ -87,9 +80,12 @@ impl CodeExecutor for PiExecutor {
         if line.is_empty() {
             return None;
         }
+        tracing::debug!("[pi] extract_session_id: trying line={}", line.chars().take(100).collect::<String>());
         if let Ok(event) = serde_json::from_str::<PiEvent>(line) {
+            tracing::debug!("[pi] parsed event type={}", event.event_type);
             if event.event_type == "session" {
                 if let Some(id) = event.id {
+                    tracing::info!("[pi] extracted session_id={}", id);
                     *self.session_id.lock() = Some(id.clone());
                     return Some(id);
                 }
@@ -105,6 +101,7 @@ impl CodeExecutor for PiExecutor {
 
         // 尝试解析为 pi JSONL 事件
         if let Ok(event) = serde_json::from_str::<PiEvent>(line) {
+            tracing::debug!("[pi] parse_output_line: event_type={}", event.event_type);
             return match event.event_type.as_str() {
                 "session" => {
                     // Session 初始化事件
@@ -301,5 +298,26 @@ impl CodeExecutor for PiExecutor {
 
     fn get_model(&self) -> Option<String> {
         self.model.lock().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_session_id() {
+        let executor = PiExecutor::new("pi".to_string());
+        let line = r#"{"type":"session","version":3,"id":"019eb655-b65a-750d-b774-9bfad4b0c51b","timestamp":"2026-06-11T10:58:51.098Z","cwd":"/Users/mac/projects/rust/nothing-todo"}"#;
+        let sid = executor.extract_session_id(line);
+        assert_eq!(sid, Some("019eb655-b65a-750d-b774-9bfad4b0c51b".to_string()));
+    }
+
+    #[test]
+    fn test_extract_session_id_not_session() {
+        let executor = PiExecutor::new("pi".to_string());
+        let line = r#"{"type":"message_start","message":{"role":"user"}}"#;
+        let sid = executor.extract_session_id(line);
+        assert_eq!(sid, None);
     }
 }

--- a/backend/src/adapters/pi_event.rs
+++ b/backend/src/adapters/pi_event.rs
@@ -22,6 +22,9 @@ pub struct PiEvent {
     // message 事件
     #[serde(default)]
     pub message: Option<PiMessage>,
+    // message_update 中的 assistant 事件（包含 thinking_delta / text_delta）
+    #[serde(default, rename = "assistantMessageEvent")]
+    pub assistant_message_event: Option<PiAssistantMessageEvent>,
     // tool_execution 事件
     #[serde(default)]
     pub tool_execution: Option<PiToolExecution>,
@@ -66,6 +69,28 @@ pub enum PiContentBlock {
     Thinking { thinking: Option<String> },
     #[serde(rename = "redacted")]
     Redacted { redacted: Option<String> },
+}
+
+/// assistantMessageEvent 中的内容（message_update 时包含 thinking_delta / text_delta）
+#[derive(Debug, Clone, Deserialize)]
+pub struct PiAssistantMessageEvent {
+    #[serde(rename = "type")]
+    pub event_type: Option<String>,
+    #[serde(default)]
+    pub content_index: Option<u32>,
+    #[serde(default)]
+    pub delta: Option<String>,
+    #[serde(default)]
+    pub partial: Option<PiAssistantMessagePartial>,
+}
+
+/// partial 内容（包含完整的 thinking 或 text）
+#[derive(Debug, Clone, Deserialize)]
+pub struct PiAssistantMessagePartial {
+    #[serde(default)]
+    pub role: Option<String>,
+    #[serde(default)]
+    pub content: Vec<PiContentBlock>,
 }
 
 /// 工具执行事件（tool_execution_start / tool_execution_update / tool_execution_end）

--- a/backend/src/adapters/pi_event.rs
+++ b/backend/src/adapters/pi_event.rs
@@ -1,0 +1,105 @@
+//! pi JSONL 事件类型定义
+//!
+//! pi 在 `--mode json` 时输出的 JSONL 事件格式
+
+use serde::Deserialize;
+
+/// pi JSONL 输出的事件信封，所有事件都有 type 字段
+#[derive(Debug, Clone, Deserialize)]
+pub struct PiEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    #[serde(default)]
+    pub session: Option<String>,
+    #[serde(default)]
+    pub version: Option<u32>,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub timestamp: Option<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    // message 事件
+    #[serde(default)]
+    pub message: Option<PiMessage>,
+    // tool_execution 事件
+    #[serde(default)]
+    pub tool_execution: Option<PiToolExecution>,
+    // agent 事件
+    #[serde(default)]
+    pub agent: Option<PiAgent>,
+    // turn 事件
+    #[serde(default)]
+    pub turn: Option<PiTurn>,
+    // queue_update 事件
+    #[serde(default)]
+    pub queue_update: Option<PiQueueUpdate>,
+    // compaction 事件
+    #[serde(default)]
+    pub compaction: Option<PiCompaction>,
+}
+
+/// 消息内容（message_start / message_update / message_end）
+#[derive(Debug, Clone, Deserialize)]
+pub struct PiMessage {
+    #[serde(rename = "type")]
+    pub message_type: Option<String>,
+    #[serde(default)]
+    pub role: Option<String>,
+    #[serde(default)]
+    pub content: Vec<PiContentBlock>,
+    #[serde(default)]
+    pub id: Option<String>,
+}
+
+/// 内容块（text / tool_call / tool_result / thinking）
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum PiContentBlock {
+    #[serde(rename = "text")]
+    Text { text: Option<String> },
+    #[serde(rename = "tool_call")]
+    ToolCall { id: Option<String>, name: Option<String>, input: serde_json::Value },
+    #[serde(rename = "tool_result")]
+    ToolResult { tool_call_id: Option<String>, content: Option<String>, is_error: Option<bool> },
+    #[serde(rename = "thinking")]
+    Thinking { thinking: Option<String> },
+    #[serde(rename = "redacted")]
+    Redacted { redacted: Option<String> },
+}
+
+/// 工具执行事件（tool_execution_start / tool_execution_update / tool_execution_end）
+#[derive(Debug, Clone, Deserialize)]
+pub struct PiToolExecution {
+    pub id: Option<String>,
+    #[serde(rename = "type")]
+    pub tool_type: Option<String>,
+    pub name: Option<String>,
+    pub input: Option<serde_json::Value>,
+    pub output: Option<String>,
+    pub status: Option<String>,
+}
+
+/// agent 事件（agent_start / agent_end）
+#[derive(Debug, Clone, Deserialize)]
+pub struct PiAgent {
+    pub name: Option<String>,
+}
+
+/// turn 事件（turn_start / turn_end）
+#[derive(Debug, Clone, Deserialize)]
+pub struct PiTurn {
+    pub turn_number: Option<u32>,
+}
+
+/// queue_update 事件
+#[derive(Debug, Clone, Deserialize)]
+pub struct PiQueueUpdate {
+    pub messages_queued: Option<u32>,
+}
+
+/// compaction 事件（compaction_start / compaction_end）
+#[derive(Debug, Clone, Deserialize)]
+pub struct PiCompaction {
+    pub reason: Option<String>,
+}

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -121,12 +121,13 @@ fn executor_label(et: ExecutorType) -> &'static str {
         ExecutorType::Kimi => "Kimi",
         ExecutorType::Mobilecoder => "MobileCoder",
         ExecutorType::Codewhale => "CodeWhale",
+        ExecutorType::Pi => "Pi",
     }
 }
 
 // 保留 ALL_EXECUTORS 供其他可能用到的代码；新代码请用 ALL_SKILL_SOURCES
 #[allow(dead_code)]
-const ALL_EXECUTORS: [ExecutorType; 9] = [
+const ALL_EXECUTORS: [ExecutorType; 10] = [
     ExecutorType::Claudecode,
     ExecutorType::Hermes,
     ExecutorType::Codex,
@@ -136,6 +137,7 @@ const ALL_EXECUTORS: [ExecutorType; 9] = [
     ExecutorType::Kimi,
     ExecutorType::Mobilecoder,
     ExecutorType::Codewhale,
+    ExecutorType::Pi,
 ];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -700,6 +700,7 @@ pub enum ExecutorType {
     Kimi,
     Codex,
     Codewhale,
+    Pi,
 }
 
 
@@ -715,6 +716,7 @@ impl ExecutorType {
             ExecutorType::Kimi => "kimi",
             ExecutorType::Codex => "codex",
             ExecutorType::Codewhale => "codewhale",
+            ExecutorType::Pi => "pi",
         }
     }
 }

--- a/frontend/src/types/execution.tsx
+++ b/frontend/src/types/execution.tsx
@@ -128,6 +128,7 @@ export const EXECUTORS: ExecutorOption[] = [
   { value: 'kimi',       label: 'Kimi',      color: '#d63031', icon: <FaSquare color="#d63031" size={14} /> },
   { value: 'codex',      label: 'Codex',     color: '#488597', icon: <FaSquare color="#488597" size={14} /> },
   { value: 'codewhale',  label: 'CodeWhale', color: '#00cec9', icon: <FaSquare color="#00cec9" size={14} /> },
+  { value: 'pi',        label: 'Pi',        color: '#8e44ad', icon: <FaSquare color="#8e44ad" size={14} /> },
   // `agents` is read-only skill source (`~/.agents/skills`), not shown in executor management.
   // Included here so it appears in Skills overview/sync tabs.
   { value: 'agents',     label: 'Agents',    color: '#2d3436', icon: <FaSquare color="#2d3436" size={14} /> },
@@ -143,6 +144,7 @@ export const EXECUTOR_COLORS: Record<string, string> = {
   kimi: '#d63031',
   codex: '#488597',
   codewhale: '#00cec9',
+  pi: '#8e44ad',
   agents: '#2d3436',
   // Aliases for backward compatibility with database names
   'claude_code': '#e17055',
@@ -161,7 +163,7 @@ export function getExecutorOption(value: string): ExecutorOption {
   return EXECUTORS.find(e => e.value === value.toLowerCase()) || EXECUTORS[0];
 }
 
-export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'mobilecoder', 'hermes', 'codewhale']);
+export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'mobilecoder', 'hermes', 'codewhale', 'pi']);
 
 /// 默认执行器
 export const DEFAULT_EXECUTOR = 'claudecode';


### PR DESCRIPTION
## 功能说明

新增 pi 执行器 adapter，支持在平台上使用 pi 作为 AI 编程执行器。

### 功能支持

| 功能 | 状态 |
|------|------|
| session 继续对话 | ✅  /  |
| JSONL 输出解析 | ✅  |
| 工具调用展示 | ✅  /  |
| thinking 解析 | ✅ |
| 模型信息 | ✅ 从事件中提取 |
| usage 统计 | ❌ pi 未输出此信息 |

### 改动文件

-  - 新增 
-  - pi 执行器 adapter 实现
-  - pi JSONL 事件类型定义
-  - 注册 pi executor
-  - 处理 Pi executor 类型