### PR TITLE
feat(auto-review): spawn review todo to score execution results

### DIFF
--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -353,6 +353,7 @@ async fn handle_todo(
                         scheduler_config: None,
                         scheduler_timezone: None,
                         hooks: None,
+                        acceptance_criteria: value.get("acceptance_criteria").and_then(|v| v.as_str()).map(|s| s.to_string()),
                     });
                 if workspace.is_some() {
                     // workspace is sent separately in the full JSON body
@@ -375,6 +376,7 @@ async fn handle_todo(
                     scheduler_config: None,
                     scheduler_timezone: None,
                     hooks: None,
+                    acceptance_criteria: None,
                 }
             };
 

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -354,6 +354,7 @@ async fn handle_todo(
                         scheduler_timezone: None,
                         hooks: None,
                         acceptance_criteria: value.get("acceptance_criteria").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                        auto_review_enabled: value.get("auto_review_enabled").and_then(|v| v.as_bool()),
                     });
                 if workspace.is_some() {
                     // workspace is sent separately in the full JSON body
@@ -377,6 +378,7 @@ async fn handle_todo(
                     scheduler_timezone: None,
                     hooks: None,
                     acceptance_criteria: None,
+                    auto_review_enabled: None,
                 }
             };
 

--- a/backend/src/db/entity/execution_records.rs
+++ b/backend/src/db/entity/execution_records.rs
@@ -35,6 +35,10 @@ pub struct Model {
     /// The `TodoHookItem.id` that fired. Combined with `source_todo_id` this
     /// points at the exact hook entry that triggered this execution.
     pub source_hook_id: Option<i64>,
+    /// User-provided score for this execution's result (0-100, optional).
+    /// Only meaningful on terminal records (success/failed); running records
+    /// never carry a score.
+    pub rating: Option<i32>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/entity/execution_records.rs
+++ b/backend/src/db/entity/execution_records.rs
@@ -36,9 +36,22 @@ pub struct Model {
     /// points at the exact hook entry that triggered this execution.
     pub source_hook_id: Option<i64>,
     /// User-provided score for this execution's result (0-100, optional).
-    /// Only meaningful on terminal records (success/failed); running records
-    /// never carry a score.
+    /// Only meaningful on terminal records (success/failed).
     pub rating: Option<i32>,
+    /// 精确指向"由哪条执行记录发起的自动评审"——自动评审只回填到这条记录上,
+    /// 不会污染同一 todo 后续 re-run 的执行记录.
+    /// NULL = 这条记录不是被自动评审的产物.
+    pub source_execution_record_id: Option<i64>,
+    /// 自动评审的状态:
+    ///   - NULL        : 还未评审过 (初始)
+    ///   - 'pending'   : 已 spawn 评审 todo, 但还没跑完
+    ///   - 'success'   : 评审完成, 已写入 rating
+    ///   - 'failed'    : 评审 todo 失败
+    ///   - 'interrupted' : 评审 todo 中断
+    ///   - 'skipped'   : 评审被显式跳过 (例如 todo_type=review 自身不触发)
+    pub last_review_status: Option<String>,
+    /// 最近一次评审 spawn 的 UTC 时间戳.
+    pub last_reviewed_at: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/entity/todos.rs
+++ b/backend/src/db/entity/todos.rs
@@ -23,7 +23,16 @@ pub struct Model {
     /// Each item binds a trigger to a target todo that should run when the
     /// parent todo's lifecycle event matches.
     pub hooks: Option<String>,
+    /// 验收标准（自动评审时作为评审 prompt 的一部分）。
     pub acceptance_criteria: Option<String>,
+    /// 0=普通 todo, 1=评审师模板（系统自动维护的专用 todo）,
+    /// 2=自动评审任务（由 spawn 出来的、跑在用户视角下可见的评审实例）.
+    /// 普通 todo 不需要这个字段; 但为了避免 schema 变更，所有行都有值.
+    pub todo_type: Option<i32>,
+    /// 当 todo_type=2 (review instance) 时, 关联到被评审的原 todo.
+    pub parent_todo_id: Option<i64>,
+    /// 是否在执行完成后自动派生一个评审 todo (默认 true, 只对 normal 类型有效).
+    pub auto_review_enabled: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/entity/todos.rs
+++ b/backend/src/db/entity/todos.rs
@@ -23,6 +23,7 @@ pub struct Model {
     /// Each item binds a trigger to a target todo that should run when the
     /// parent todo's lifecycle event matches.
     pub hooks: Option<String>,
+    pub acceptance_criteria: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -83,6 +83,7 @@ impl From<execution_records::Model> for ExecutionRecord {
             source_todo_id: m.source_todo_id,
             source_todo_title: m.source_todo_title,
             source_hook_id: m.source_hook_id,
+            rating: m.rating,
         }
     }
 }
@@ -293,6 +294,23 @@ impl Database {
         let am = execution_records::ActiveModel {
             id: ActiveValue::Unchanged(id),
             execution_stats: ActiveValue::Set(Some(stats_json.to_string())),
+            ..Default::default()
+        };
+        self.exec_update(am).await
+    }
+
+    /// 更新执行记录的评分。
+    /// 评分属于“执行结果”，因此要求记录已结束（success/failed）；running 记录
+    /// 不接受评分，handler 层会先拦抁返回错误。
+    /// `Some(value)` 写入评分，`None` 清除评分（设为 NULL）。
+    pub async fn update_execution_record_rating(
+        &self,
+        id: i64,
+        rating: Option<i32>,
+    ) -> Result<(), sea_orm::DbErr> {
+        let am = execution_records::ActiveModel {
+            id: ActiveValue::Unchanged(id),
+            rating: ActiveValue::Set(rating),
             ..Default::default()
         };
         self.exec_update(am).await
@@ -970,6 +988,7 @@ impl Database {
                     source_todo_id: None,
                     source_todo_title: None,
                     source_hook_id: None,
+                    rating: None,
                 }
             })
             .collect();

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -30,6 +30,11 @@ pub struct UpdateExecutionRecordRequest<'a> {
     pub result: &'a str,
     pub usage: Option<&'a ExecutionUsage>,
     pub model: Option<&'a str>,
+    /// 自动评审专用. Some((source_record_id, status)) 表示这条记录是评审实例,
+    /// 其结果用于回填到 source_record_id 对应的原记录.
+    /// 存到表里: source_execution_record_id = source_record_id,
+    ///           last_review_status = status.
+    pub review_meta: Option<(i64, &'a str)>,
 }
 
 pub struct ExecutionRecordQuery<'a> {
@@ -84,6 +89,9 @@ impl From<execution_records::Model> for ExecutionRecord {
             source_todo_title: m.source_todo_title,
             source_hook_id: m.source_hook_id,
             rating: m.rating,
+            source_execution_record_id: m.source_execution_record_id,
+            last_review_status: m.last_review_status,
+            last_reviewed_at: m.last_reviewed_at,
         }
     }
 }
@@ -210,20 +218,40 @@ impl Database {
         // both the stop handler and spawned task's cancellation branch may try to
         // update the same record concurrently -- only the first write succeeds.
         let backend = self.conn.get_database_backend();
-        let sql = "UPDATE execution_records SET \
-            status = $1, \
-            result = $2, \
-            usage = $3, \
-            model = $4, \
-            finished_at = $5 \
-            WHERE id = $6 AND status = 'running'";
-
-        let res = self
-            .conn
-            .execute(Statement::from_sql_and_values(
-                backend,
-                sql,
-                [
+        let (sql, values): (&str, Vec<sea_orm::Value>) = if let Some((source_record_id, review_status)) = req.review_meta {
+            (
+                "UPDATE execution_records SET \
+                    status = $1, \
+                    result = $2, \
+                    usage = $3, \
+                    model = $4, \
+                    finished_at = $5, \
+                    source_execution_record_id = $7, \
+                    last_review_status = $8, \
+                    last_reviewed_at = $9 \
+                    WHERE id = $6 AND status = 'running'",
+                vec![
+                    req.status.into(),
+                    req.result.into(),
+                    usage_json.into(),
+                    model_val.into(),
+                    now.clone().into(),
+                    req.id.into(),
+                    source_record_id.into(),
+                    review_status.to_string().into(),
+                    now.into(),
+                ],
+            )
+        } else {
+            (
+                "UPDATE execution_records SET \
+                    status = $1, \
+                    result = $2, \
+                    usage = $3, \
+                    model = $4, \
+                    finished_at = $5 \
+                    WHERE id = $6 AND status = 'running'",
+                vec![
                     req.status.into(),
                     req.result.into(),
                     usage_json.into(),
@@ -231,6 +259,15 @@ impl Database {
                     now.into(),
                     req.id.into(),
                 ],
+            )
+        };
+
+        let res = self
+            .conn
+            .execute(Statement::from_sql_and_values(
+                backend,
+                sql,
+                values,
             ))
             .await?;
         let updated = res.rows_affected() > 0;
@@ -989,6 +1026,9 @@ impl Database {
                     source_todo_title: None,
                     source_hook_id: None,
                     rating: None,
+                    source_execution_record_id: None,
+                    last_review_status: None,
+                    last_reviewed_at: None,
                 }
             })
             .collect();
@@ -1640,5 +1680,52 @@ impl Database {
         } else {
             format!("{} B", bytes)
         }
+    }
+
+    // ===== 自动评审辅助方法 =====
+
+    /// 写入/更新原执行记录的 last_review_status 字段（pending/success/failed/interrupted/skipped）.
+    pub async fn set_record_last_review_status(
+        &self,
+        record_id: i64,
+        status: &str,
+    ) -> Result<(), sea_orm::DbErr> {
+        let am = execution_records::ActiveModel {
+            id: ActiveValue::Unchanged(record_id),
+            last_review_status: ActiveValue::Set(Some(status.to_string())),
+            ..Default::default()
+        };
+        self.exec_update(am).await
+    }
+
+    /// 写入/更新原执行记录的 last_reviewed_at 字段（UTC ISO8601）.
+    pub async fn set_record_last_reviewed_at(
+        &self,
+        record_id: i64,
+    ) -> Result<(), sea_orm::DbErr> {
+        let am = execution_records::ActiveModel {
+            id: ActiveValue::Unchanged(record_id),
+            last_reviewed_at: ActiveValue::Set(Some(crate::models::utc_timestamp())),
+            ..Default::default()
+        };
+        self.exec_update(am).await
+    }
+
+    /// 评审实例完成时调用: 把评审实例的 source_execution_record_id 指向"原那条",
+    /// 并把 last_review_status 设为终态 (success/failed/interrupted).
+    /// 同步更新原记录的 last_review_status.
+    pub async fn link_review_to_source(
+        &self,
+        review_record_id: i64,
+        source_record_id: i64,
+        final_status: &str,
+    ) -> Result<(), sea_orm::DbErr> {
+        let am = execution_records::ActiveModel {
+            id: ActiveValue::Unchanged(review_record_id),
+            source_execution_record_id: ActiveValue::Set(Some(source_record_id)),
+            last_review_status: ActiveValue::Set(Some(final_status.to_string())),
+            ..Default::default()
+        };
+        self.exec_update(am).await
     }
 }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1615,6 +1615,7 @@ mod tests {
             scheduler_timezone: None,
             workspace: None,
             worktree_enabled: None,
+            acceptance_criteria: None,
         })
         .await
         .unwrap();
@@ -1773,6 +1774,7 @@ mod tests {
             scheduler_timezone: None,
             workspace: Some("/tmp/workspace"),
             worktree_enabled: None,
+            acceptance_criteria: None,
         })
         .await
         .unwrap();

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -302,6 +302,91 @@ impl Database {
         Ok(())
     }
 
+    /// 一次性迁移：将旧 `todos.rating`（已不再使用）合并到对应 todo 最新一条
+    /// `execution_records.rating`，然后 DROP COLUMN。
+    /// 设计原因：评分属于执行结果而非 todo 本身。
+    /// - 每个 todo 取最新一条已结束的 execution_record（按 started_at desc）
+    /// - 同一 record 已被多次评分时跳过，避免覆盖更新的评价
+    /// - 失败仅 warn，不阻塞启动
+    async fn migrate_todo_rating_to_execution_records(&self) -> Result<(), sea_orm::DbErr> {
+        // 检查旧列是否存在，不存在则直接跳过（DROP COLUMN 之后再次启动也是幂等的）
+        let check_sql = "SELECT COUNT(*) FROM pragma_table_info('todos') WHERE name='rating'";
+        let result = self
+            .conn
+            .query_one(Statement::from_string(DbBackend::Sqlite, check_sql.to_string()))
+            .await?;
+        let col_exists = result
+            .and_then(|r| r.try_get_by_index::<i64>(0).ok())
+            .unwrap_or(0)
+            > 0;
+        if !col_exists {
+            return Ok(());
+        }
+
+        tracing::info!("Migrating todos.rating -> execution_records.rating...");
+
+        // 拉取所有有评分的 todo 及其最新一条 execution_record
+        let select_sql = "\
+            SELECT t.id AS todo_id, t.rating AS rating, \
+                   (SELECT er.id FROM execution_records er \
+                    WHERE er.todo_id = t.id \
+                    ORDER BY er.started_at DESC LIMIT 1) AS latest_record_id \
+            FROM todos t \
+            WHERE t.rating IS NOT NULL";
+        let rows = self
+            .conn
+            .query_all(Statement::from_string(DbBackend::Sqlite, select_sql.to_string()))
+            .await?;
+
+        let mut migrated = 0u64;
+        for row in rows {
+            let todo_id: i64 = row.try_get_by("todo_id")?;
+            let rating: i32 = match row.try_get_by::<i64, _>("rating") {
+                Ok(v) => v as i32,
+                Err(_) => continue,
+            };
+            let latest_record_id: Option<i64> = row.try_get_by("latest_record_id").ok().flatten();
+            let Some(record_id) = latest_record_id else {
+                tracing::debug!(
+                    "Skip todo {} rating {}: no execution_records",
+                    todo_id, rating
+                );
+                continue;
+            };
+
+            // 仅在该 record 尚未评分时才写入，避免覆盖更新评价
+            let update_sql = "UPDATE execution_records \
+                SET rating = $1 \
+                WHERE id = $2 AND rating IS NULL";
+            let res = self
+                .conn
+                .execute(Statement::from_sql_and_values(
+                    DbBackend::Sqlite,
+                    update_sql,
+                    [rating.into(), record_id.into()],
+                ))
+                .await?;
+            if res.rows_affected() > 0 {
+                migrated += 1;
+            }
+        }
+
+        // 移除旧列
+        if let Err(e) = self
+            .exec("ALTER TABLE todos DROP COLUMN rating")
+            .await
+        {
+            tracing::warn!("Failed to DROP COLUMN todos.rating: {}", e);
+            return Ok(()); // 不阻塞启动，下次启动再重试
+        }
+
+        tracing::info!(
+            "Migrated {} todo ratings to execution_records, dropped todos.rating",
+            migrated
+        );
+        Ok(())
+    }
+
     async fn init_tables(&self) -> Result<(), sea_orm::DbErr> {
         self.exec(
             "CREATE TABLE IF NOT EXISTS todos (
@@ -443,6 +528,23 @@ impl Database {
         self.exec("ALTER TABLE todos ADD COLUMN hooks TEXT")
             .await
             .ok(); // 忽略错误，因为字段可能已存在
+
+        // 添加 acceptance_criteria 字段的迁移（向后兼容）—— Todo 验收条件
+        self.exec("ALTER TABLE todos ADD COLUMN acceptance_criteria TEXT")
+            .await
+            .ok();
+
+        // 添加 rating 字段的迁移（向后兼容）—— 执行记录评分
+        self.exec("ALTER TABLE execution_records ADD COLUMN rating INTEGER")
+            .await
+            .ok();
+
+        // 一次性迁移：旧 todos.rating 数据合并到对应 todo 的最新一条 execution_records.rating
+        // 然后 DROP COLUMN todos.rating（评分只属于执行结果）
+        // 失败仅 warn，不阻塞启动（与同位置的其他迁移策略一致）。
+        if let Err(e) = self.migrate_todo_rating_to_execution_records().await {
+            tracing::warn!("Failed to migrate todos.rating -> execution_records.rating: {}", e);
+        }
 
         // 迁移：将 execution_records.logs 旧字段数据转移到 execution_logs 表，并删除旧字段
         self.migrate_logs_to_execution_logs().await

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -539,6 +539,43 @@ impl Database {
             .await
             .ok();
 
+        // ===== 自动评审（auto-review）字段 =====
+        // todos.todo_type: 0=normal, 1=reviewer_template(系统专用), 2=review_instance(评审实例)
+        self.exec("ALTER TABLE todos ADD COLUMN todo_type INTEGER DEFAULT 0")
+            .await
+            .ok();
+        // todos.parent_todo_id: review_instance 关联到被评审的原 todo
+        self.exec("ALTER TABLE todos ADD COLUMN parent_todo_id INTEGER")
+            .await
+            .ok();
+        // todos.auto_review_enabled: 原 todo 是否在完成后自动 spawn 评审 (默认开)
+        self.exec("ALTER TABLE todos ADD COLUMN auto_review_enabled INTEGER DEFAULT 1")
+            .await
+            .ok();
+        // execution_records.source_execution_record_id: 评审记录精确回填到"原那条"执行记录
+        self.exec("ALTER TABLE execution_records ADD COLUMN source_execution_record_id INTEGER")
+            .await
+            .ok();
+        // execution_records.last_review_status: pending/success/failed/interrupted/skipped
+        self.exec("ALTER TABLE execution_records ADD COLUMN last_review_status TEXT")
+            .await
+            .ok();
+        // execution_records.last_reviewed_at: 最近一次评审 spawn 时间
+        self.exec("ALTER TABLE execution_records ADD COLUMN last_reviewed_at TEXT")
+            .await
+            .ok();
+
+        // 索引: 加速"按 parent_todo_id 查评审实例"
+        self.exec("CREATE INDEX IF NOT EXISTS idx_todos_parent_todo_id ON todos(parent_todo_id)")
+            .await
+            .ok();
+        self.exec("CREATE INDEX IF NOT EXISTS idx_todos_todo_type ON todos(todo_type)")
+            .await
+            .ok();
+        self.exec("CREATE INDEX IF NOT EXISTS idx_execution_records_source_record_id ON execution_records(source_execution_record_id)")
+            .await
+            .ok();
+
         // 一次性迁移：旧 todos.rating 数据合并到对应 todo 的最新一条 execution_records.rating
         // 然后 DROP COLUMN todos.rating（评分只属于执行结果）
         // 失败仅 warn，不阻塞启动（与同位置的其他迁移策略一致）。
@@ -1616,6 +1653,7 @@ mod tests {
             workspace: None,
             worktree_enabled: None,
             acceptance_criteria: None,
+            auto_review_enabled: None,
         })
         .await
         .unwrap();
@@ -1704,6 +1742,7 @@ mod tests {
             result: "done",
             usage: None,
             model: None,
+            review_meta: None,
         })
         .await
         .unwrap();
@@ -1775,6 +1814,7 @@ mod tests {
             workspace: Some("/tmp/workspace"),
             worktree_enabled: None,
             acceptance_criteria: None,
+            auto_review_enabled: None,
         })
         .await
         .unwrap();
@@ -2066,6 +2106,7 @@ mod tests {
             result: "",
             usage: None,
             model: None,
+            review_meta: None,
         })
         .await
         .unwrap();
@@ -2077,6 +2118,7 @@ mod tests {
             result: "",
             usage: None,
             model: None,
+            review_meta: None,
         })
         .await
         .unwrap();
@@ -2165,6 +2207,7 @@ mod tests {
             result: "done",
             usage: Some(&usage),
             model: Some("claude-3"),
+            review_meta: None,
         })
         .await
         .unwrap();
@@ -2217,6 +2260,7 @@ mod tests {
             result: "",
             usage: None,
             model: None,
+            review_meta: None,
         })
         .await
         .unwrap();
@@ -2228,6 +2272,7 @@ mod tests {
             result: "",
             usage: None,
             model: None,
+            review_meta: None,
         })
         .await
         .unwrap();
@@ -2260,6 +2305,7 @@ mod tests {
             result: "",
             usage: Some(&usage1),
             model: None,
+            review_meta: None,
         })
         .await
         .unwrap();
@@ -2279,6 +2325,7 @@ mod tests {
             result: "",
             usage: Some(&usage2),
             model: None,
+            review_meta: None,
         })
         .await
         .unwrap();

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -19,6 +19,7 @@ pub struct TodoUpdate<'a> {
     pub scheduler_timezone: Option<&'a str>,
     pub workspace: Option<&'a str>,
     pub worktree_enabled: Option<bool>,
+    pub acceptance_criteria: Option<&'a str>,
 }
 
 pub struct SchedulerUpdate<'a> {
@@ -63,6 +64,7 @@ impl Database {
             workspace: m.workspace,
             worktree_enabled: m.worktree_enabled.unwrap_or(false),
             hooks: crate::hooks::TodoHooks::parse(m.hooks.as_deref()).items,
+            acceptance_criteria: m.acceptance_criteria,
         }
     }
 
@@ -111,9 +113,20 @@ impl Database {
     /// 创建 Todo，可指定执行器。
     /// executor 为 None、空串或仅空白时默认为 claudecode（防止空/空白字符串污染 DB）。
     pub async fn create_todo_with_executor(&self, title: &str, prompt: &str, executor: Option<&str>) -> Result<i64, sea_orm::DbErr> {
+        self.create_todo_with_extras(title, prompt, executor, None).await
+    }
+
+    /// 创建 Todo，带所有可选字段。
+    pub async fn create_todo_with_extras(
+        &self,
+        title: &str,
+        prompt: &str,
+        executor: Option<&str>,
+        acceptance_criteria: Option<&str>,
+    ) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let executor_str = executor
-            .map(str::trim)  // 先 trim，避免 "  " 类空白字符串落入空串分支
+            .map(str::trim)
             .filter(|s| !s.is_empty())
             .unwrap_or(crate::adapters::DEFAULT_EXECUTOR);
         let am = todos::ActiveModel {
@@ -123,6 +136,7 @@ impl Database {
             created_at: ActiveValue::Set(Some(now.clone())),
             updated_at: ActiveValue::Set(Some(now)),
             executor: ActiveValue::Set(Some(executor_str.to_string())),
+            acceptance_criteria: ActiveValue::Set(acceptance_criteria.map(|s| s.to_string())),
             ..Default::default()
         };
         let inserted = am.insert(&self.conn).await?;
@@ -165,6 +179,9 @@ impl Database {
         }
         if let Some(wt) = update.worktree_enabled {
             am.worktree_enabled = ActiveValue::Set(Some(wt));
+        }
+        if let Some(criteria) = update.acceptance_criteria {
+            am.acceptance_criteria = ActiveValue::Set(Some(criteria.to_string()));
         }
         self.exec_update(am).await
     }

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -20,6 +20,7 @@ pub struct TodoUpdate<'a> {
     pub workspace: Option<&'a str>,
     pub worktree_enabled: Option<bool>,
     pub acceptance_criteria: Option<&'a str>,
+    pub auto_review_enabled: Option<bool>,
 }
 
 pub struct SchedulerUpdate<'a> {
@@ -65,6 +66,9 @@ impl Database {
             worktree_enabled: m.worktree_enabled.unwrap_or(false),
             hooks: crate::hooks::TodoHooks::parse(m.hooks.as_deref()).items,
             acceptance_criteria: m.acceptance_criteria,
+            todo_type: m.todo_type.unwrap_or(0),
+            parent_todo_id: m.parent_todo_id,
+            auto_review_enabled: m.auto_review_enabled.unwrap_or(true),
         }
     }
 
@@ -137,6 +141,8 @@ impl Database {
             updated_at: ActiveValue::Set(Some(now)),
             executor: ActiveValue::Set(Some(executor_str.to_string())),
             acceptance_criteria: ActiveValue::Set(acceptance_criteria.map(|s| s.to_string())),
+            auto_review_enabled: ActiveValue::Set(Some(true)),
+            todo_type: ActiveValue::Set(Some(0)),
             ..Default::default()
         };
         let inserted = am.insert(&self.conn).await?;
@@ -182,6 +188,9 @@ impl Database {
         }
         if let Some(criteria) = update.acceptance_criteria {
             am.acceptance_criteria = ActiveValue::Set(Some(criteria.to_string()));
+        }
+        if let Some(enabled) = update.auto_review_enabled {
+            am.auto_review_enabled = ActiveValue::Set(Some(enabled));
         }
         self.exec_update(am).await
     }
@@ -294,6 +303,85 @@ impl Database {
             ..Default::default()
         };
         self.exec_update(am).await
+    }
+
+    /// 单独更新 auto_review_enabled. 在 create_todo 之后被 handler 调用, 以接受
+    /// 来自请求的覆盖. review_instance / reviewer_template 类型不允许改这个开关.
+    pub async fn update_todo_auto_review_enabled(
+        &self,
+        id: i64,
+        enabled: bool,
+    ) -> Result<(), sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+        let am = todos::ActiveModel {
+            id: ActiveValue::Unchanged(id),
+            auto_review_enabled: ActiveValue::Set(Some(enabled)),
+            updated_at: ActiveValue::Set(Some(now)),
+            ..Default::default()
+        };
+        self.exec_update(am).await
+    }
+
+    /// 按 title 精确查找 todo (仅未软删的). 用于评审师模板的探测.
+    pub async fn get_todo_by_title(&self, title: &str) -> Result<Option<Todo>, sea_orm::DbErr> {
+        let model = todos::Entity::find()
+            .filter(todos::Column::Title.eq(title))
+            .filter(todos::Column::DeletedAt.is_null())
+            .one(&self.conn)
+            .await?;
+        let Some(m) = model else { return Ok(None) };
+        let tag_ids = todo_tags::Entity::find()
+            .filter(todo_tags::Column::TodoId.eq(m.id))
+            .all(&self.conn)
+            .await?
+            .into_iter()
+            .map(|t| t.tag_id)
+            .collect();
+        Ok(Some(Self::model_to_todo(m, tag_ids)))
+    }
+
+    /// 设置 todo_type. 主要用于将刚 create_todo_with_extras 出来的 todo 标记为
+    /// 评审师模板 (1) 或 评审实例 (2). 不在公共 API 暴露.
+    pub async fn set_todo_type(&self, id: i64, todo_type: i32) -> Result<(), sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+        let am = todos::ActiveModel {
+            id: ActiveValue::Unchanged(id),
+            todo_type: ActiveValue::Set(Some(todo_type)),
+            updated_at: ActiveValue::Set(Some(now)),
+            ..Default::default()
+        };
+        self.exec_update(am).await
+    }
+
+    /// 克隆一份 todo 作为"评审实例"。原 todo (template) 的所有字段都复制过来,
+    /// 但 todo_type=2, parent_todo_id=Some(parent_id), title 加前缀,
+    /// auto_review_enabled=false (评审实例自身不再评审).
+    /// 跳过 hooks / scheduler (评审实例是 transient 的).
+    pub async fn clone_todo_for_review(
+        &self,
+        template_id: i64,
+        parent_id: i64,
+    ) -> Result<i64, sea_orm::DbErr> {
+        let template = self
+            .get_todo(template_id)
+            .await?
+            .ok_or_else(|| sea_orm::DbErr::Custom(format!("template todo #{} not found", template_id)))?;
+        let now = crate::models::utc_timestamp();
+        let title = format!("[评审] {}", template.title);
+        let am = todos::ActiveModel {
+            title: ActiveValue::Set(title),
+            prompt: ActiveValue::Set(template.prompt.clone().into()),
+            status: ActiveValue::Set(Some(TodoStatus::Pending.to_string())),
+            created_at: ActiveValue::Set(Some(now.clone())),
+            updated_at: ActiveValue::Set(Some(now)),
+            executor: ActiveValue::Set(template.executor.clone()),
+            todo_type: ActiveValue::Set(Some(2)),
+            parent_todo_id: ActiveValue::Set(Some(parent_id)),
+            auto_review_enabled: ActiveValue::Set(Some(false)),
+            ..Default::default()
+        };
+        let inserted = am.insert(&self.conn).await?;
+        Ok(inserted.id)
     }
 
     pub async fn force_update_todo_status(

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::OnceLock;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::{broadcast, Mutex};
 use uuid::Uuid;
@@ -311,6 +312,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                 result: &format!("Failed to start todo execution: {}", e),
                 usage: None,
                 model: None,
+                review_meta: None,
             })
             .await;
         task_manager.remove(&task_id).await;
@@ -784,6 +786,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                     result: "任务已被手动停止",
                     usage: None,
                     model: None,
+                    review_meta: None,
                 }).await;
 
                 let entry = ParsedLogEntry::error("Execution cancelled by user");
@@ -838,6 +841,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                     result: "Execution timeout",
                     usage: None,
                     model: None,
+                    review_meta: None,
                 }).await;
 
                 let entry = ParsedLogEntry::error("Execution timeout, process terminated by system");
@@ -980,8 +984,30 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                 result: &result_str,
                 usage: usage.as_ref(),
                 model: model.as_deref(),
+                review_meta: None,
             })
             .await;
+
+        // ===== 自动评审 (auto-review) =====
+        // 仅在以下条件同时满足时启动:
+        //   - trigger_type != "auto_review" 避免评审实例本身反向触发评审
+        //   - 正常执行 (success/failed), 不是被中断
+        //
+        // 同步语义: Hook fire 在这之后才进行, rating gate 要求评审完成后再触发,
+        // 所以评审要同步跑完. run_auto_review 内部 std::thread::spawn + block_on,
+        // 与本 spawned task 完全隔离, 不存在 Send 问题.
+        if trigger_type != "auto_review" {
+            run_auto_review(
+                db_clone.clone(),
+                executor_registry_spawn.clone(),
+                tx_clone.clone(),
+                task_manager_spawn.clone(),
+                config_spawn.clone(),
+                todo_id,
+                record_id,
+            )
+            .await;
+        }
 
         let _ = db_clone.finish_todo_execution(todo_id, success).await;
 
@@ -1052,6 +1078,20 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     }
 }
 
+/// 独立 runtime. 用于 run_auto_review 在原 todo 的 spawned task 内部同步运行
+/// 自动评审逻辑, 避免与外层 spawned task 产生 Send / 嵌套 spawn 问题.
+fn review_runtime() -> &'static tokio::runtime::Runtime {
+    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(2)
+            .thread_name("auto-review-runtime")
+            .build()
+            .expect("failed to build auto-review runtime")
+    })
+}
+
 /// Run a todo execution with parameter substitution.
 /// Replaces placeholders `{{key}}` in the message with corresponding values from params before execution.
 pub async fn run_todo_execution_with_params(
@@ -1062,3 +1102,209 @@ pub async fn run_todo_execution_with_params(
     }
     run_todo_execution(request).await
 }
+
+// ============================================================================
+//  自动评审 (auto-review) —— 同步派生一个评审 todo，给刚完成的那条执行记录打分
+// ============================================================================
+//
+// 调用点: run_todo_execution 在 update_execution_record (写终态) 之后.
+// 仅当:
+//   - 源 todo 是 normal 类型 (todo_type=0)
+//   - auto_review_enabled=true
+//   - 源 record 进入了 success 或 failed 终态
+//   - source_execution_record_id 尚未被设置 (避免重复评审同一条记录)
+// 才启动评审。
+//
+// 为避免与 run_todo_execution 的内部逻辑产生循环引用，这里用一个简化的
+// 同步路径：等 run_todo_execution 启动后创建的 record 进入终态，再解析 rating 回填。
+// 不需要 tokio::spawn —— 我们让原执行路径在 auto_review 上同步等待。
+
+/// 同步运行自动评审。在原 todo 执行完成、update_execution_record 写入 success/failed 后调用。
+///
+/// 参数: (db, todo, record_id, executor_registry, tx, task_manager, config).
+/// 任何错误都只记 warn 日志，不影响原 todo 的完成响应。
+///
+/// 实现: 由于 run_auto_review_inner 内部需要 await run_todo_execution (后者会
+/// 进一步 spawn) —— 整个 future 不是 Send —— 必须在独立 runtime 上 block_on.
+pub async fn run_auto_review(
+    db: Arc<crate::db::Database>,
+    executor_registry: Arc<crate::adapters::ExecutorRegistry>,
+    tx: tokio::sync::broadcast::Sender<crate::handlers::ExecEvent>,
+    task_manager: Arc<crate::task_manager::TaskManager>,
+    config: Arc<tokio::sync::RwLock<crate::config::Config>>,
+    todo_id: i64,
+    record_id: i64,
+) {
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    let db_c = db.clone();
+    let er_c = executor_registry.clone();
+    let tx_c = tx.clone();
+    let tm_c = task_manager.clone();
+    let cfg_c = config.clone();
+    let runtime = review_runtime();
+    std::thread::spawn(move || {
+        let result = runtime.block_on(run_auto_review_inner(
+            db_c, er_c, tx_c, tm_c, cfg_c, todo_id, record_id,
+        ));
+        let _ = reply_tx.send(result);
+    });
+    match reply_rx.await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            tracing::warn!(
+                "auto-review for todo #{} record #{} failed: {}",
+                todo_id, record_id, e
+            );
+            let _ = db
+                .set_record_last_review_status(record_id, "failed")
+                .await;
+        }
+        Err(_) => {
+            tracing::warn!("auto-review thread dropped reply for todo #{} record #{}", todo_id, record_id);
+            let _ = db
+                .set_record_last_review_status(record_id, "failed")
+                .await;
+        }
+    }
+}
+
+async fn run_auto_review_inner(
+    db: Arc<crate::db::Database>,
+    executor_registry: Arc<crate::adapters::ExecutorRegistry>,
+    tx: tokio::sync::broadcast::Sender<crate::handlers::ExecEvent>,
+    task_manager: Arc<crate::task_manager::TaskManager>,
+    config: Arc<tokio::sync::RwLock<crate::config::Config>>,
+    todo_id: i64,
+    record_id: i64,
+) -> Result<(), String> {
+    use crate::services::auto_review::{ensure_reviewer_template, parse_rating_from_result, DEFAULT_REVIEWER_PROMPT, MAX_OUTPUT_CHARS, REVIEWER_TEMPLATE_TITLE};
+
+    // 1) 加载原 todo & 检查前置条件
+    let original = db.get_todo(todo_id).await
+        .map_err(|e| format!("load original todo: {}", e))?
+        .ok_or_else(|| format!("original todo #{} not found", todo_id))?;
+    if original.todo_type != 0 || !original.auto_review_enabled {
+        let _ = db.set_record_last_review_status(record_id, "skipped").await;
+        return Ok(());
+    }
+    let record = db.get_execution_record(record_id).await
+        .map_err(|e| format!("load record: {}", e))?
+        .ok_or_else(|| format!("record #{} not found", record_id))?;
+    use crate::models::ExecutionStatus;
+    if !matches!(record.status, ExecutionStatus::Success | ExecutionStatus::Failed) {
+        let _ = db.set_record_last_review_status(record_id, "skipped").await;
+        return Ok(());
+    }
+    // 避免重复评审
+    if record.last_review_status.as_deref() == Some("success") {
+        return Ok(());
+    }
+
+    // 2) 评审师模板
+    let template_id = ensure_reviewer_template(&db, REVIEWER_TEMPLATE_TITLE, DEFAULT_REVIEWER_PROMPT).await?;
+    let template = db.get_todo(template_id).await
+        .map_err(|e| format!("reload template: {}", e))?
+        .ok_or_else(|| "reviewer template vanished".to_string())?;
+
+    // 3) 截断输出 + 合并 prompt
+    let original_output = record.result.clone().unwrap_or_default();
+    let truncated: String = if original_output.chars().count() > MAX_OUTPUT_CHARS {
+        let mut s: String = original_output.chars().take(MAX_OUTPUT_CHARS).collect();
+        s.push_str("\n\n[...以下被截断...]");
+        s
+    } else {
+        original_output
+    };
+    let acceptance_criteria = original
+        .acceptance_criteria
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or("(无验收标准 —— 由评审师自行判断输出质量)");
+    let composed_prompt = template
+        .prompt
+        .replace("{original_prompt}", &original.prompt)
+        .replace("{max_output_chars}", &MAX_OUTPUT_CHARS.to_string())
+        .replace("{original_output}", &truncated)
+        .replace("{acceptance_criteria}", acceptance_criteria);
+
+    // 4) clone 评审实例 todo
+    let review_todo_id = db.clone_todo_for_review(template_id, original.id).await
+        .map_err(|e| format!("clone review instance: {}", e))?;
+
+    // 5) 标记 pending
+    let _ = db.set_record_last_review_status(record_id, "pending").await;
+    let _ = db.set_record_last_reviewed_at(record_id).await;
+
+    // 6) 同步执行评审实例
+    let request = RunTodoExecutionRequest {
+        db: db.clone(),
+        executor_registry: executor_registry.clone(),
+        tx: tx.clone(),
+        task_manager: task_manager.clone(),
+        config: config.clone(),
+        todo_id: review_todo_id,
+        message: composed_prompt,
+        req_executor: template.executor.clone(),
+        trigger_type: "auto_review".to_string(),
+        params: None,
+        resume_session_id: None,
+        resume_message: None,
+        chain: vec![],
+        source_todo_id: Some(original.id),
+        source_todo_title: Some(original.title.clone()),
+        source_hook_id: None,
+        feishu_bot_id: None,
+        feishu_receive_id: None,
+    };
+    let exec_result = run_todo_execution(request).await;
+    let review_record_id = match exec_result.record_id {
+        Some(id) => id,
+        None => {
+            let _ = db.set_record_last_review_status(record_id, "failed").await;
+            return Err("review execution produced no record (rejected?)".to_string());
+        }
+    };
+
+    // 7) 轮询评审实例 record 的终态
+    let max_wait = std::time::Duration::from_secs(300);
+    let poll = std::time::Duration::from_millis(500);
+    let start = std::time::Instant::now();
+    let final_review = loop {
+        if start.elapsed() > max_wait {
+            return Err("review record timeout".to_string());
+        }
+        if let Some(rec) = db.get_execution_record(review_record_id).await
+            .map_err(|e| format!("poll: {}", e))?
+        {
+            if !matches!(rec.status, ExecutionStatus::Running) {
+                break rec;
+            }
+        }
+        tokio::time::sleep(poll).await;
+    };
+
+    // 8) 解析 + 回填
+    let review_status_str = match final_review.status {
+        ExecutionStatus::Success => "success",
+        ExecutionStatus::Failed => "failed",
+        _ => "interrupted",
+    };
+    let rating = parse_rating_from_result(final_review.result.as_deref());
+    if let Some(r) = rating {
+        let _ = db.update_execution_record_rating(record_id, Some(r)).await;
+    }
+    let _ = db.link_review_to_source(review_record_id, record_id, review_status_str).await;
+    let _ = db.set_record_last_review_status(record_id, review_status_str).await;
+    // 评审实例自身 todo 也转完成
+    let _ = db.finish_todo_execution(
+        review_todo_id,
+        matches!(review_status_str, "success"),
+    ).await;
+
+    tracing::info!(
+        "auto-review done: original_todo=#{} record=#{} review_todo=#{} review_record=#{} status={} rating={:?}",
+        todo_id, record_id, review_todo_id, review_record_id, review_status_str, rating
+    );
+    Ok(())
+}
+

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -72,6 +72,53 @@ pub async fn get_execution_record(
     Ok(ApiResponse::ok(record))
 }
 
+/// 更新执行记录评分。评分仅针对已结束的记录（success/failed）；
+/// running 记录不允许评分。`rating: null` 表示清除评分。
+#[derive(Debug, Deserialize)]
+pub struct RateExecutionRequest {
+    /// 评分值（0-100）。传 null 表示清除当前评分。
+    pub rating: Option<i32>,
+}
+
+pub async fn rate_execution_handler(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    ApiJson(req): ApiJson<RateExecutionRequest>,
+) -> Result<ApiResponse<crate::models::ExecutionRecord>, AppError> {
+    if let Some(r) = req.rating {
+        if !(0..=100).contains(&r) {
+            return Err(AppError::BadRequest(format!(
+                "rating must be in 0..=100, got {}",
+                r
+            )));
+        }
+    }
+
+    let record = state
+        .db
+        .get_execution_record(id)
+        .await?
+        .ok_or(AppError::NotFound)?;
+
+    if record.status == ExecutionStatus::Running {
+        return Err(AppError::BadRequest(
+            "Cannot rate a running execution".to_string(),
+        ));
+    }
+
+    state
+        .db
+        .update_execution_record_rating(id, req.rating)
+        .await?;
+
+    let updated = state
+        .db
+        .get_execution_record(id)
+        .await?
+        .ok_or(AppError::NotFound)?;
+    Ok(ApiResponse::ok(updated))
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ExecutionLogsQuery {
     #[serde(default = "default_page")]

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -554,6 +554,24 @@ pub fn create_app(
     };
     let hook_service = Arc::new(HookService::new(hook_ctx));
 
+    // Create AutoReviewService and ensure the reviewer template todo exists.
+    // create_app 是 sync 函数, 不能直接 .await; 同步跑一个 init 即可.
+    use crate::services::auto_review::{ensure_reviewer_template, DEFAULT_REVIEWER_PROMPT, REVIEWER_TEMPLATE_TITLE};
+    {
+        let db_for_init = db.clone();
+        let init_rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build init runtime");
+        if let Err(e) = init_rt.block_on(ensure_reviewer_template(
+            &db_for_init,
+            REVIEWER_TEMPLATE_TITLE,
+            DEFAULT_REVIEWER_PROMPT,
+        )) {
+            tracing::warn!("Failed to ensure auto-review reviewer template: {}", e);
+        }
+    }
+
     let state = AppState {
         db,
         executor_registry,

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -555,19 +555,19 @@ pub fn create_app(
     let hook_service = Arc::new(HookService::new(hook_ctx));
 
     // Create AutoReviewService and ensure the reviewer template todo exists.
-    // create_app 是 sync 函数, 不能直接 .await; 同步跑一个 init 即可.
+    // create_app 是 sync 函数, 不能直接 .await; 复用当前 tokio runtime 的 Handle
+    // 同步跑 init (带 block_in_place 避免阻塞 reactor 线程).
     use crate::services::auto_review::{ensure_reviewer_template, DEFAULT_REVIEWER_PROMPT, REVIEWER_TEMPLATE_TITLE};
     {
         let db_for_init = db.clone();
-        let init_rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("failed to build init runtime");
-        if let Err(e) = init_rt.block_on(ensure_reviewer_template(
-            &db_for_init,
-            REVIEWER_TEMPLATE_TITLE,
-            DEFAULT_REVIEWER_PROMPT,
-        )) {
+        let init_result = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(ensure_reviewer_template(
+                &db_for_init,
+                REVIEWER_TEMPLATE_TITLE,
+                DEFAULT_REVIEWER_PROMPT,
+            ))
+        });
+        if let Err(e) = init_result {
             tracing::warn!("Failed to ensure auto-review reviewer template: {}", e);
         }
     }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -583,6 +583,7 @@ pub fn create_app(
         .route("/api/execution-records/{id}/logs", get(execution::get_execution_logs_handler))
         .route("/api/execution-records/{id}", get(execution::get_execution_record))
         .route("/api/execution-records/{id}/resume", post(execution::resume_execution_handler))
+        .route("/api/execution-records/{id}/rating", put(execution::rate_execution_handler))
         .route("/api/dashboard-stats", get(execution::get_dashboard_stats))
         .route("/api/execute", post(execution::execute_handler))
         .route("/api/smart-create", post(execution::smart_create_handler))

--- a/backend/src/handlers/sync.rs
+++ b/backend/src/handlers/sync.rs
@@ -316,6 +316,7 @@ async fn merge_cloud_todos_to_local(
                         workspace: item.workspace.as_deref(),
                         worktree_enabled: None,
                         acceptance_criteria: None,
+                        auto_review_enabled: None,
                     })
                     .await
                     .map_err(|e| e.to_string())?;

--- a/backend/src/handlers/sync.rs
+++ b/backend/src/handlers/sync.rs
@@ -315,6 +315,7 @@ async fn merge_cloud_todos_to_local(
                         scheduler_timezone: None,
                         workspace: item.workspace.as_deref(),
                         worktree_enabled: None,
+                        acceptance_criteria: None,
                     })
                     .await
                     .map_err(|e| e.to_string())?;

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -56,7 +56,12 @@ pub async fn create_todo(
         .clone()
         .unwrap_or_else(|| "claudecode".to_string());
 
-    let id = state.db.create_todo(title, &prompt).await?;
+    let id = state.db.create_todo_with_extras(
+        title,
+        &prompt,
+        Some(&executor),
+        req.acceptance_criteria.as_deref(),
+    ).await?;
 
     // Update executor if specified
     if let Some(ref exec) = req.executor {
@@ -129,6 +134,7 @@ pub async fn create_todo(
         workspace: None,
         worktree_enabled: false,
         hooks: req.hooks.clone().unwrap_or_default(),
+        acceptance_criteria: req.acceptance_criteria.clone(),
     }))
 }
 
@@ -195,6 +201,7 @@ pub async fn update_todo(
             scheduler_timezone: scheduler_timezone.as_deref(),
             workspace: workspace.as_deref(),
             worktree_enabled: Some(worktree_enabled),
+            acceptance_criteria: req.acceptance_criteria.as_deref(),
         })
         .await
         .map_err(AppError::from)?;

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -117,6 +117,13 @@ pub async fn create_todo(
         }
     }
 
+    // auto_review_enabled: 请求中显式指定为 Some(false) 时关闭, 其它情况保持默认 true
+    if let Some(false) = req.auto_review_enabled {
+        if let Err(e) = state.db.update_todo_auto_review_enabled(id, false).await {
+            tracing::warn!("Failed to disable auto_review for todo {}: {}", id, e);
+        }
+    }
+
     Ok(ApiResponse::ok(Todo {
         id,
         title: title.to_string(),
@@ -135,6 +142,9 @@ pub async fn create_todo(
         worktree_enabled: false,
         hooks: req.hooks.clone().unwrap_or_default(),
         acceptance_criteria: req.acceptance_criteria.clone(),
+        todo_type: 0,
+        parent_todo_id: None,
+        auto_review_enabled: req.auto_review_enabled.unwrap_or(true),
     }))
 }
 
@@ -202,6 +212,7 @@ pub async fn update_todo(
             workspace: workspace.as_deref(),
             worktree_enabled: Some(worktree_enabled),
             acceptance_criteria: req.acceptance_criteria.as_deref(),
+            auto_review_enabled: req.auto_review_enabled,
         })
         .await
         .map_err(AppError::from)?;

--- a/backend/src/hooks/models.rs
+++ b/backend/src/hooks/models.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 use crate::models::TodoStatus;
 
 /// Hook trigger types.
@@ -75,10 +76,66 @@ pub struct TodoHookItem {
     pub skip_if_missing: bool,
     #[serde(default = "default_enabled")]
     pub enabled: bool,
+    /// Optional rating gate (0-100). When set, the hook only fires if the
+    /// source todo's most recent FINISHED execution record has a
+    /// `rating >= min_rating`. `None` means no gate (always fire) — this
+    /// preserves the original behaviour for any hook that doesn't opt in.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_rating: Option<i32>,
+    /// What to do when the latest finished record has no rating (NULL).
+    /// Defaults to `Skip` (do not fire) — the conservative choice for users
+    /// who explicitly enabled a rating gate: if you cared enough to set a
+    /// threshold, an unrated result is probably not what you wanted to chain
+    /// off of. `Pass` is the opt-in permissive mode for teams that want the
+    /// gate to only block obviously-bad runs.
+    #[serde(default = "default_unrated_policy")]
+    pub unrated_policy: UnratedPolicy,
 }
 
 fn default_enabled() -> bool {
     true
+}
+
+fn default_unrated_policy() -> UnratedPolicy {
+    UnratedPolicy::Skip
+}
+
+/// Policy applied by the rating gate when the latest finished record has
+/// no rating set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum UnratedPolicy {
+    /// Do not fire the hook. This is the safe default: an unrated record
+    /// can't be evaluated against `min_rating`, so we treat "no opinion" as
+    /// "don't chain off of this".
+    #[default]
+    Skip,
+    /// Treat the missing rating as if it had passed. Useful when you only
+    /// want the gate to actively block runs you've explicitly scored low.
+    Pass,
+}
+
+impl UnratedPolicy {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Skip => "skip",
+            Self::Pass => "pass",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "skip" => Some(Self::Skip),
+            "pass" => Some(Self::Pass),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for UnratedPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
 }
 
 /// Wrapper for the `todos.hooks` JSON column.
@@ -110,12 +167,33 @@ impl TodoHooks {
                 .into_iter()
                 .filter_map(|raw| {
                     let trigger = HookTrigger::from_str(&raw.trigger)?;
+                    // Validate rating gate fields defensively: a malformed
+                    // value (out-of-range or unknown policy) shouldn't take
+                    // down the whole hook list, it just disables this item.
+                    let min_rating = match raw.min_rating {
+                        None => None,
+                        Some(v) if (0..=100).contains(&v) => Some(v),
+                        Some(v) => {
+                            warn!(
+                                "hook #{} has out-of-range min_rating {}, ignoring",
+                                raw.id, v
+                            );
+                            None
+                        }
+                    };
+                    let unrated_policy = raw
+                        .unrated_policy
+                        .as_deref()
+                        .and_then(UnratedPolicy::from_str)
+                        .unwrap_or_default();
                     Some(TodoHookItem {
                         id: raw.id,
                         trigger,
                         target_todo_id: raw.target_todo_id,
                         skip_if_missing: raw.skip_if_missing,
                         enabled: raw.enabled,
+                        min_rating,
+                        unrated_policy,
                     })
                 })
                 .collect(),
@@ -148,6 +226,15 @@ struct RawTodoHookItem {
     skip_if_missing: bool,
     #[serde(default = "default_enabled")]
     enabled: bool,
+    /// Optional rating threshold (0-100). Older payloads won't have this
+    /// field and serde's `default` keeps them working unchanged.
+    #[serde(default)]
+    min_rating: Option<i32>,
+    /// Policy for when the latest record has no rating. Stored as a snake
+    /// case string to match the on-disk format; unknown values fall back to
+    /// the default policy at `parse` time.
+    #[serde(default)]
+    unrated_policy: Option<String>,
 }
 
 /// Build the `message` payload that a hook delivers to the target todo's

--- a/backend/src/hooks/service.rs
+++ b/backend/src/hooks/service.rs
@@ -4,7 +4,7 @@ use tracing::{warn};
 use crate::executor_service::RunTodoExecutionRequest;
 use crate::handlers::execution::start_todo_execution;
 use crate::hooks::models::*;
-use crate::models::Todo;
+use crate::models::{ExecutionRecord, ExecutionStatus, Todo};
 use crate::service_context::ServiceContext;
 
 /// Hook dispatch engine.
@@ -172,6 +172,91 @@ async fn lookup_source_result(ctx: &ServiceContext, source_id: i64) -> Option<St
     }
 }
 
+/// Look up the most recent FINISHED (success or failed) execution record for
+/// `source_id`. Returns the full record so callers can inspect `rating` for
+/// the rating gate. Returns `None` if the source has never run or its most
+/// recent record is still in-flight (`running`/`pending`).
+///
+/// We deliberately look at the most recent finished record rather than the
+/// most recent record of any status: while a hook is firing the source
+/// could have a fresh `running` row that hides a previously-finished
+/// scored row, which would make the gate flicker. The terminal record is
+/// the one whose rating is stable and meaningful for chaining decisions.
+async fn lookup_latest_finished_record(
+    ctx: &ServiceContext,
+    source_id: i64,
+) -> Option<ExecutionRecord> {
+    // status="all" means no status filter (see `get_execution_records`), and
+    // ORDER BY started_at DESC LIMIT 1 gives us the most recent record.
+    let query = crate::db::execution::ExecutionRecordQuery {
+        todo_id: source_id,
+        limit: 1,
+        offset: 0,
+        status: Some("all"),
+    };
+    match ctx.db.get_execution_records(query).await {
+        Ok((records, _)) => records
+            .into_iter()
+            .find(|r| r.status != ExecutionStatus::Running),
+        Err(e) => {
+            warn!(
+                "hook: failed to load source todo #{} latest finished record: {}",
+                source_id, e
+            );
+            None
+        }
+    }
+}
+
+/// Decision produced by `evaluate_rating_gate`. The hook service uses this
+/// to decide whether to dispatch the target todo or skip the hook.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GateDecision {
+    /// Fire the target todo normally.
+    Allow,
+    /// Skip the hook because the gate wasn't met. Carries a short reason
+    /// suitable for the warn log.
+    Deny(&'static str),
+}
+
+/// Evaluate the optional rating gate on a hook item against the source
+/// todo's most recent finished execution record.
+///
+/// Rules:
+///
+/// * `min_rating = None` → always allow (no gate configured). This is the
+///   backward-compatible path for any existing hook that hasn't opted in.
+/// * `latest_finished = None` (source has never finished a run) → apply
+///   `unrated_policy`. Default `Skip` denies, `Pass` allows.
+/// * `latest_finished.rating = None` (user hasn't scored the run) → apply
+///   `unrated_policy` again. Same semantics as "no record at all" — the
+///   gate can't say the run is good enough, but the user policy decides
+///   whether that's a fail.
+/// * `latest_finished.rating >= min_rating` → allow.
+/// * otherwise → deny with a descriptive reason including the actual score.
+fn evaluate_rating_gate(
+    item: &TodoHookItem,
+    latest_finished: Option<&ExecutionRecord>,
+) -> GateDecision {
+    let Some(min_rating) = item.min_rating else {
+        return GateDecision::Allow;
+    };
+    let Some(record) = latest_finished else {
+        return match item.unrated_policy {
+            UnratedPolicy::Skip => GateDecision::Deny("no finished record"),
+            UnratedPolicy::Pass => GateDecision::Allow,
+        };
+    };
+    match record.rating {
+        None => match item.unrated_policy {
+            UnratedPolicy::Skip => GateDecision::Deny("rating is null"),
+            UnratedPolicy::Pass => GateDecision::Allow,
+        },
+        Some(r) if r >= min_rating => GateDecision::Allow,
+        Some(_) => GateDecision::Deny("rating below threshold"),
+    }
+}
+
 async fn execute_target_todo(
     ctx: &ServiceContext,
     item: &TodoHookItem,
@@ -206,6 +291,32 @@ async fn execute_target_todo(
     // `run_todo_execution_with_params` does the substitution and the
     // executor sees the final composed message.
     let source_result = lookup_source_result(ctx, source.id).await;
+
+    // Rating gate: only enforce when the hook is configured with a
+    // `min_rating`. Fetching the latest finished record is one extra cheap
+    // query, and we only do it when the gate might be active. The lookup
+    // also doubles as the "is the source ready to chain off of" check.
+    let source_record = lookup_latest_finished_record(ctx, source.id).await;
+    match evaluate_rating_gate(item, source_record.as_ref()) {
+        GateDecision::Allow => {}
+        GateDecision::Deny(reason) => {
+            let rating = source_record
+                .as_ref()
+                .and_then(|r| r.rating)
+                .map(|r| r.to_string())
+                .unwrap_or_else(|| "null".to_string());
+            let min = item
+                .min_rating
+                .map(|m| m.to_string())
+                .unwrap_or_else(|| "none".to_string());
+            warn!(
+                "hook #{} skipped by rating gate (min_rating={}, policy={}, source rating={}, reason={})",
+                item.id, min, item.unrated_policy, rating, reason
+            );
+            return Ok(());
+        }
+    }
+
     let message_payload = build_hook_message(source, source_result.as_deref());
     let message = target.prompt.clone();
     let mut params = std::collections::HashMap::new();
@@ -261,5 +372,210 @@ async fn execute_target_todo(
             "hook trigger thread for todo #{} dropped reply channel",
             target.id
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the rating-gate logic. We don't need a database for
+    //! these — the gate is a pure function over `(TodoHookItem, Option<&ExecutionRecord>)`.
+    use super::*;
+    use crate::models::ExecutionStatus;
+
+    fn item(min_rating: Option<i32>, policy: UnratedPolicy) -> TodoHookItem {
+        TodoHookItem {
+            id: 1,
+            trigger: HookTrigger::StateChangedToCompleted,
+            target_todo_id: 2,
+            skip_if_missing: true,
+            enabled: true,
+            min_rating,
+            unrated_policy: policy,
+        }
+    }
+
+    fn rec(rating: Option<i32>) -> ExecutionRecord {
+        ExecutionRecord {
+            id: 99,
+            todo_id: 1,
+            status: ExecutionStatus::Success,
+            command: String::new(),
+            stdout: String::new(),
+            stderr: String::new(),
+            result: None,
+            started_at: String::new(),
+            finished_at: None,
+            usage: None,
+            executor: None,
+            model: None,
+            trigger_type: "manual".to_string(),
+            pid: None,
+            task_id: None,
+            session_id: None,
+            todo_progress: None,
+            execution_stats: None,
+            resume_message: None,
+            source_todo_id: None,
+            source_todo_title: None,
+            source_hook_id: None,
+            rating,
+        }
+    }
+
+    #[test]
+    fn no_min_rating_always_allows() {
+        // Hooks that don't opt into the gate keep their original behaviour
+        // regardless of the source record's rating (or lack thereof).
+        let i = item(None, UnratedPolicy::Skip);
+        assert_eq!(
+            evaluate_rating_gate(&i, None),
+            GateDecision::Allow,
+            "no record at all"
+        );
+        assert_eq!(
+            evaluate_rating_gate(&i, Some(&rec(None))),
+            GateDecision::Allow,
+            "record with no rating"
+        );
+        assert_eq!(
+            evaluate_rating_gate(&i, Some(&rec(Some(0)))),
+            GateDecision::Allow,
+            "record with low rating"
+        );
+        assert_eq!(
+            evaluate_rating_gate(&i, Some(&rec(Some(100)))),
+            GateDecision::Allow,
+            "record with high rating"
+        );
+    }
+
+    #[test]
+    fn min_rating_passes_when_score_meets_threshold() {
+        let i = item(Some(80), UnratedPolicy::Skip);
+        assert_eq!(evaluate_rating_gate(&i, Some(&rec(Some(80)))), GateDecision::Allow);
+        assert_eq!(evaluate_rating_gate(&i, Some(&rec(Some(99)))), GateDecision::Allow);
+        assert_eq!(evaluate_rating_gate(&i, Some(&rec(Some(100)))), GateDecision::Allow);
+    }
+
+    #[test]
+    fn min_rating_denies_when_score_below_threshold() {
+        let i = item(Some(80), UnratedPolicy::Skip);
+        match evaluate_rating_gate(&i, Some(&rec(Some(79)))) {
+            GateDecision::Deny(_) => {}
+            other => panic!("expected Deny, got {:?}", other),
+        }
+        match evaluate_rating_gate(&i, Some(&rec(Some(0)))) {
+            GateDecision::Deny(_) => {}
+            other => panic!("expected Deny, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unrated_skip_denies_null_rating() {
+        // Default policy: unrated records don't pass the gate. This is the
+        // safe behaviour for users who set a threshold because they care
+        // about quality — an unrated result can't be trusted.
+        let i = item(Some(60), UnratedPolicy::Skip);
+        assert_eq!(
+            evaluate_rating_gate(&i, Some(&rec(None))),
+            GateDecision::Deny("rating is null")
+        );
+    }
+
+    #[test]
+    fn unrated_pass_allows_null_rating() {
+        // Opt-in permissive mode: missing rating is treated as "no
+        // objection", so the hook fires.
+        let i = item(Some(60), UnratedPolicy::Pass);
+        assert_eq!(
+            evaluate_rating_gate(&i, Some(&rec(None))),
+            GateDecision::Allow
+        );
+    }
+
+    #[test]
+    fn unrated_skip_denies_when_no_record_exists() {
+        // Source has never finished a run. Even with `Skip`, the gate
+        // should deny because there's no record to evaluate. The
+        // distinction between "no record" and "record with null rating"
+        // matters in the log message but not in the decision.
+        let i = item(Some(60), UnratedPolicy::Skip);
+        assert_eq!(
+            evaluate_rating_gate(&i, None),
+            GateDecision::Deny("no finished record")
+        );
+    }
+
+    #[test]
+    fn unrated_pass_allows_when_no_record_exists() {
+        let i = item(Some(60), UnratedPolicy::Pass);
+        assert_eq!(
+            evaluate_rating_gate(&i, None),
+            GateDecision::Allow
+        );
+    }
+
+    #[test]
+    fn unrated_policy_does_not_change_threshold_decision() {
+        // Policy is only consulted when rating is missing. With a numeric
+        // rating, the threshold itself is the sole deciding factor.
+        let i = item(Some(50), UnratedPolicy::Pass);
+        assert_eq!(evaluate_rating_gate(&i, Some(&rec(Some(60)))), GateDecision::Allow);
+        match evaluate_rating_gate(&i, Some(&rec(Some(40)))) {
+            GateDecision::Deny(_) => {}
+            other => panic!("expected Deny, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unrated_policy_deserializes_from_snake_case() {
+        // The on-disk format is snake_case; make sure the parser accepts
+        // both variants and rejects unknown values.
+        assert_eq!(UnratedPolicy::from_str("skip"), Some(UnratedPolicy::Skip));
+        assert_eq!(UnratedPolicy::from_str("pass"), Some(UnratedPolicy::Pass));
+        assert_eq!(UnratedPolicy::from_str(""), None);
+        assert_eq!(UnratedPolicy::from_str("deny"), None);
+    }
+
+    #[test]
+    fn unrated_policy_default_is_skip() {
+        // Default::default() is the safe option, matching the documented
+        // contract on the field.
+        assert_eq!(UnratedPolicy::default(), UnratedPolicy::Skip);
+    }
+
+    #[test]
+    fn parse_tolerates_missing_or_unknown_gate_fields() {
+        // Older payloads that don't have the new gate fields must still
+        // parse cleanly. Items with out-of-range `min_rating` are kept
+        // (with the gate dropped) so a bad write doesn't take down the
+        // whole hook list.
+        let json = r#"{
+          "items": [
+            { "id": 1, "trigger": "state_changed_to_completed", "target_todo_id": 2, "enabled": true },
+            { "id": 2, "trigger": "state_changed_to_completed", "target_todo_id": 3, "enabled": true, "min_rating": 75, "unrated_policy": "pass" },
+            { "id": 3, "trigger": "state_changed_to_completed", "target_todo_id": 4, "enabled": true, "min_rating": 200 },
+            { "id": 4, "trigger": "state_changed_to_completed", "target_todo_id": 5, "enabled": true, "min_rating": 50, "unrated_policy": "nonsense" }
+          ]
+        }"#;
+        let parsed = TodoHooks::parse(Some(json));
+        assert_eq!(parsed.items.len(), 4);
+
+        // Item 1: legacy payload, no gate.
+        assert!(parsed.items[0].min_rating.is_none());
+        assert_eq!(parsed.items[0].unrated_policy, UnratedPolicy::Skip);
+
+        // Item 2: full gate configured.
+        assert_eq!(parsed.items[1].min_rating, Some(75));
+        assert_eq!(parsed.items[1].unrated_policy, UnratedPolicy::Pass);
+
+        // Item 3: out-of-range min_rating gets dropped (so the hook still
+        // works, just without the gate), and policy falls back to default.
+        assert!(parsed.items[2].min_rating.is_none());
+        assert_eq!(parsed.items[2].unrated_policy, UnratedPolicy::Skip);
+
+        // Item 4: unknown policy string falls back to default (Skip).
+        assert_eq!(parsed.items[3].min_rating, Some(50));
+        assert_eq!(parsed.items[3].unrated_policy, UnratedPolicy::Skip);
     }
 }

--- a/backend/src/hooks/service.rs
+++ b/backend/src/hooks/service.rs
@@ -419,6 +419,9 @@ mod tests {
             source_todo_title: None,
             source_hook_id: None,
             rating,
+            source_execution_record_id: None,
+            last_review_status: None,
+            last_reviewed_at: None,
         }
     }
 

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -112,6 +112,15 @@ pub struct Todo {
     pub hooks: Vec<crate::hooks::TodoHookItem>,
     #[serde(default)]
     pub acceptance_criteria: Option<String>,
+    /// 0=normal, 1=reviewer_template(评审师模板), 2=review_instance(评审实例).
+    #[serde(default)]
+    pub todo_type: i32,
+    /// review_instance 关联到被评审的原 todo; 其它类型为 None.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_todo_id: Option<i64>,
+    /// 是否在执行完成后自动派生一个评审 todo. 只对 normal 类型有意义.
+    #[serde(default = "default_true")]
+    pub auto_review_enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -208,6 +217,18 @@ pub struct ExecutionRecord {
     /// Only meaningful on terminal records (success/failed).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rating: Option<i32>,
+    /// 自动评审时, 评审记录精确指向被评审的"原执行记录"。
+    /// 这条记录的 rating 应被视为对 source_execution_record_id 的评分.
+    /// NULL = 这条记录不是被自动评审的产物.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_execution_record_id: Option<i64>,
+    /// 这条原执行记录最近一次自动评审的状态.
+    /// 仅在原执行记录上有意义; 评审实例自己的 execution_record 该字段为 NULL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_review_status: Option<String>,
+    /// 这条原执行记录最近一次自动评审 spawn 的 UTC 时间.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_reviewed_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -311,6 +332,8 @@ pub struct CreateTodoRequest {
     pub hooks: Option<Vec<crate::hooks::TodoHookItem>>,
     #[serde(default)]
     pub acceptance_criteria: Option<String>,
+    #[serde(default)]
+    pub auto_review_enabled: Option<bool>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -338,6 +361,9 @@ pub struct UpdateTodoRequest {
     pub hooks: Option<Vec<crate::hooks::TodoHookItem>>,
     #[serde(default)]
     pub acceptance_criteria: Option<String>,
+    /// None=不变, Some(true)/Some(false)=更新. 不允许改 reviewer template 的开关.
+    #[serde(default)]
+    pub auto_review_enabled: Option<bool>,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -110,6 +110,8 @@ pub struct Todo {
     /// Inline hooks owned by this todo. Parsed from the `todos.hooks` column.
     #[serde(default)]
     pub hooks: Vec<crate::hooks::TodoHookItem>,
+    #[serde(default)]
+    pub acceptance_criteria: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -202,6 +204,10 @@ pub struct ExecutionRecord {
     /// The `TodoHookItem.id` that triggered this execution.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_hook_id: Option<i64>,
+    /// User-provided score for this execution's result (0-100, optional).
+    /// Only meaningful on terminal records (success/failed).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rating: Option<i32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -303,6 +309,8 @@ pub struct CreateTodoRequest {
     pub scheduler_timezone: Option<String>,
     #[serde(default)]
     pub hooks: Option<Vec<crate::hooks::TodoHookItem>>,
+    #[serde(default)]
+    pub acceptance_criteria: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -328,6 +336,8 @@ pub struct UpdateTodoRequest {
     /// Replace the todo's inline hooks. `None` keeps the existing list.
     #[serde(default)]
     pub hooks: Option<Vec<crate::hooks::TodoHookItem>>,
+    #[serde(default)]
+    pub acceptance_criteria: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/backend/src/services/auto_review.rs
+++ b/backend/src/services/auto_review.rs
@@ -1,0 +1,177 @@
+//! 自动评审（auto-review）—— 工具函数层
+//!
+//! 本模块的职责：
+//! 1. 评审师模板 todo 的初始化（ensure_reviewer_template）
+//! 2. 评审 prompt 模板定义（DEFAULT_REVIEWER_PROMPT）
+//! 3. 评审结果 RATING 解析（parse_rating_from_result）
+//!
+//! 实际"同步跑评审实例"的协调逻辑在 `executor_service::run_auto_review`，
+//! 它直接调用 ensure_reviewer_template / parse_rating_from_result，避免循环依赖。
+//!
+//! 数据流：
+//! 1. executor_service 检测到原 todo (todo_type=0) 完成
+//! 2. 调 ensure_reviewer_template 取得"评审师模板" todo id
+//! 3. 截断原 record.output，合并 prompt，clone 出"评审实例" todo
+//! 4. 同步调 run_todo_execution 跑评审实例
+//! 5. 轮询评审实例 record 进入终态
+//! 6. 解析 RATING 回填到原 execution_record.rating
+//! 7. last_review_status 写终态
+
+use std::sync::Arc;
+use tracing::info;
+
+/// 评审师模板 todo 的固定标题（同时作为唯一标识）。
+pub const REVIEWER_TEMPLATE_TITLE: &str = "评审师模板";
+
+/// 评审 prompt 中"截断原 todo 输出"的最大字符数（Q9 决定）。
+pub const MAX_OUTPUT_CHARS: usize = 8_000;
+
+/// 评审 prompt 模板 —— 启动时如果没有"评审师模板" todo，会用这段作为初始 prompt。
+/// 用户可随时编辑模板 todo 自定义评审风格；这段只是默认值。
+pub const DEFAULT_REVIEWER_PROMPT: &str = r#"你是一个严格的代码评审专家。请根据下方【验收标准】对【执行输出】进行评审。
+
+评审范围：
+- 只读不写 —— 你是裁判，不修改任何文件、不执行额外命令。
+- 按验收标准逐条对照执行输出。
+- 客观评分，不要讨好。
+
+# 原始任务（用户给原 todo 的 prompt）
+{original_prompt}
+
+# 原 todo 的执行输出（已被截断到 {max_output_chars} 字符）
+{original_output}
+
+# 验收标准
+{acceptance_criteria}
+
+# 输出要求
+请先给出一段简短的评审理由（不超过 200 字），然后**在最后一行**严格按以下格式输出分数：
+RATING: <0-100 的整数>
+
+注意：
+- 分数必须是 0-100 的整数。
+- 输出越严格、越符合所有验收标准，分数越高。
+- 如果输出被截断且关键证据缺失，请在理由中说明"输出被截断"并按缺失程度扣分。
+"#;
+
+/// 确保数据库中存在"评审师模板" todo (todo_type=1).
+/// 如果用户已经有一个（按 title 查找），什么都不做（保留用户改过的 prompt）。
+/// 如果没有，创建一个 todo_type=1 的系统专用 todo。
+pub async fn ensure_reviewer_template(
+    db: &Arc<crate::db::Database>,
+    title: &str,
+    default_prompt: &str,
+) -> Result<i64, String> {
+    match db.get_todo_by_title(title).await {
+        Ok(Some(t)) => {
+            if t.todo_type != 1 {
+                db.set_todo_type(t.id, 1).await
+                    .map_err(|e| format!("set reviewer template todo_type: {}", e))?;
+            }
+            Ok(t.id)
+        }
+        Ok(None) => {
+            let id = db
+                .create_todo_with_extras(title, default_prompt, None, None)
+                .await
+                .map_err(|e| format!("create reviewer template: {}", e))?;
+            db.set_todo_type(id, 1)
+                .await
+                .map_err(|e| format!("set new reviewer template type: {}", e))?;
+            // 模板 todo 不应触发自动评审自身
+            let _ = db.update_todo_auto_review_enabled(id, false).await;
+            info!("created auto-review reviewer template todo #{}", id);
+            Ok(id)
+        }
+        Err(e) => Err(format!("lookup reviewer template: {}", e)),
+    }
+}
+
+/// 从评审师输出中解析 RATING: N
+/// 接受 "RATING: 85" / "rating: 85" / "RATING = 85" / "最终评分：78" 等变体。
+/// 必须落在 0..=100 范围，否则丢弃。
+pub fn parse_rating_from_result(result: Option<&str>) -> Option<i32> {
+    let text = result?;
+    // 取最后 50 行（评分通常在末尾）
+    let tail: String = text
+        .lines()
+        .rev()
+        .take(50)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<Vec<_>>()
+        .join("\n");
+    for line in tail.lines().rev() {
+        let l = line.trim();
+        let lower = l.to_lowercase();
+        if !(lower.contains("rating") || lower.contains("评分")) {
+            continue;
+        }
+        // 形如 "RATING: 85" / "Rating: 85" / "RATING = 85" / "最终评分: 85"
+        let after = l
+            .split_once(':')
+            .or_else(|| l.split_once('：'))
+            .or_else(|| l.split_once('='))
+            .map(|(_, v)| v.trim());
+        if let Some(v) = after {
+            // 抓第一个整数
+            let digits: String = v
+                .chars()
+                .skip_while(|c| !c.is_ascii_digit() && *c != '-')
+                .take_while(|c| c.is_ascii_digit() || *c == '-')
+                .collect();
+            if let Ok(n) = digits.parse::<i32>() {
+                if (0..=100).contains(&n) {
+                    return Some(n);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_rating_basic() {
+        assert_eq!(
+            parse_rating_from_result(Some("Some reasoning.\nRATING: 85")),
+            Some(85)
+        );
+    }
+
+    #[test]
+    fn parse_rating_chinese_colon() {
+        assert_eq!(
+            parse_rating_from_result(Some("评审通过。\n最终评分： 78")),
+            Some(78)
+        );
+    }
+
+    #[test]
+    fn parse_rating_equals() {
+        assert_eq!(parse_rating_from_result(Some("ok\nrating = 90")), Some(90));
+    }
+
+    #[test]
+    fn parse_rating_out_of_range() {
+        assert_eq!(parse_rating_from_result(Some("RATING: 150")), None);
+        assert_eq!(parse_rating_from_result(Some("RATING: -5")), None);
+    }
+
+    #[test]
+    fn parse_rating_missing() {
+        assert_eq!(parse_rating_from_result(Some("no score here")), None);
+        assert_eq!(parse_rating_from_result(None), None);
+    }
+
+    #[test]
+    fn parse_rating_takes_last_line() {
+        // 即使中间有干扰，最后的 RATING 应该赢
+        let text = "RATING: 30\nmore text\nRATING: 88";
+        assert_eq!(parse_rating_from_result(Some(text)), Some(88));
+    }
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod auto_review;
 pub mod feishu_history_fetcher;
 pub mod feishu_listener;
 pub mod feishu_push;

--- a/frontend/check_auto_review_e2e.cjs
+++ b/frontend/check_auto_review_e2e.cjs
@@ -1,0 +1,88 @@
+// Playwright 端到端验证: 评审结果展示在 UI 中
+const { chromium } = require('playwright');
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ colorScheme: 'light', viewport: { width: 1440, height: 900 } });
+  const page = await context.newPage();
+
+  const logs = [];
+  page.on('console', msg => { if (msg.type() === 'error') logs.push(`[console.error] ${msg.text()}`); });
+  page.on('pageerror', err => logs.push(`[pageerror] ${err.message}`));
+
+  const results = { pass: 0, fail: 0, items: [] };
+  const record = (name, ok, detail = '') => {
+    results.items.push({ name, ok, detail });
+    if (ok) results.pass++; else results.fail++;
+    console.log(`${ok ? '✅' : '❌'} ${name}${detail ? '  ' + detail : ''}`);
+  };
+
+  try {
+    console.log('\n=== 1) 打开 dev 实例 ===');
+    await page.goto('http://localhost:18088', { waitUntil: 'networkidle', timeout: 30000 });
+    await page.waitForTimeout(2500);
+
+    // Phase A: 列表应显示 [评审] 实例徽章
+    console.log('\n=== 2) 列表: 评审实例 todo ===');
+    const reviewBadges = await page.locator('text=[评审]').filter({ hasNotText: '模板' }).count();
+    record('列表显示 [评审] 实例 todo 徽章', reviewBadges > 0, `(共 ${reviewBadges} 个)`);
+    await page.screenshot({ path: '/tmp/auto_review_e2e_1_list.png', fullPage: false });
+
+    // Phase B: 打开评审实例 todo #14
+    console.log('\n=== 3) 打开评审实例 todo ===');
+    const reviewCard = page.locator('.todo-item:has-text("评审")').filter({ hasNotText: '模板' }).first();
+    if (await reviewCard.count() > 0) {
+      await reviewCard.click();
+      await page.waitForTimeout(2500);
+      await page.screenshot({ path: '/tmp/auto_review_e2e_2_review_detail.png', fullPage: false });
+
+      // 通过 API 验证评审实例 result 中包含 RATING
+      const reviewResult = await page.evaluate(async () => {
+        const r = await fetch('/api/execution-records?todo_id=14&limit=1', { credentials: 'include' });
+        const j = await r.json();
+        return j?.data?.records?.[0]?.result;
+      });
+      const hasRating = /RATING\s*:?\s*\d+/i.test(reviewResult || '');
+      record('评审实例 record.result 包含 RATING:N', hasRating, `(result=${(reviewResult || '').slice(0, 80)}...)`);
+    } else {
+      record('评审实例 todo 详情可打开', false, '找不到 [评审] 卡片');
+    }
+
+    // Phase C: 打开原 todo #13
+    console.log('\n=== 4) 打开原 todo 看评分+评审状态 ===');
+    const sourceCard = page.locator('.todo-item:has-text("[评审测试]")').first();
+    if (await sourceCard.count() > 0) {
+      await sourceCard.click();
+      await page.waitForTimeout(2500);
+      await page.screenshot({ path: '/tmp/auto_review_e2e_3_source_detail.png', fullPage: false });
+
+      // 评分应显示 100
+      const ratingBadge = await page.locator('button[aria-label*="已评分"]').first();
+      const ratingVisible = await ratingBadge.count() > 0;
+      record('原 todo 执行记录显示评分 100', ratingVisible);
+      if (ratingVisible) {
+        const ratingText = await ratingBadge.textContent();
+        record('评分数值正确', ratingText.includes('100'), `(text=${ratingText})`);
+      }
+
+      // 评审状态徽章应显示 "✅ 评审成功"
+      const reviewSuccess = await page.locator('text=评审成功').count();
+      record('原 record 显示"评审成功"徽章', reviewSuccess > 0);
+    } else {
+      record('原 todo 详情可打开', false, '找不到 [评审测试] 卡片');
+    }
+
+    console.log('\n=== 控制台错误 ===');
+    if (logs.length === 0) console.log('   无');
+    for (const log of logs.slice(0, 10)) console.log(log);
+
+    console.log('\n=== 汇总 ===');
+    console.log(`通过 ${results.pass} / 失败 ${results.fail}`);
+  } catch (err) {
+    console.error('验证出错:', err.message);
+    await page.screenshot({ path: '/tmp/auto_review_e2e_error.png' }).catch(() => {});
+  } finally {
+    await browser.close();
+    process.exit(results.fail > 0 ? 1 : 0);
+  }
+})();

--- a/frontend/check_auto_review_ui.cjs
+++ b/frontend/check_auto_review_ui.cjs
@@ -1,0 +1,137 @@
+// Playwright 验证: 自动评审 UI
+// 1) [评审模板] 徽章 (todo_type=1)
+// 2) [评审] 实例徽章 (todo_type=2) - 若有
+// 3) TodoDrawer 中"执行后自动评审"开关
+// 4) RecordDetailView 中评审状态徽章 (last_review_status)
+const { chromium } = require('playwright');
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ colorScheme: 'light', viewport: { width: 1440, height: 900 } });
+  const page = await context.newPage();
+
+  const logs = [];
+  page.on('console', msg => { if (msg.type() === 'error') logs.push(`[console.error] ${msg.text()}`); });
+  page.on('pageerror', err => logs.push(`[pageerror] ${err.message}`));
+
+  const results = { pass: 0, fail: 0, items: [] };
+  const record = (name, ok, detail = '') => {
+    results.items.push({ name, ok, detail });
+    if (ok) results.pass++; else results.fail++;
+    console.log(`${ok ? '✅' : '❌'} ${name}${detail ? '  ' + detail : ''}`);
+  };
+
+  try {
+    console.log('\n=== Phase 1: 打开 dev 实例 ===');
+    await page.goto('http://localhost:18088', { waitUntil: 'networkidle', timeout: 30000 });
+    await page.waitForTimeout(2500);
+    await page.screenshot({ path: '/tmp/auto_review_1_list.png', fullPage: false });
+
+    // Phase 2: 检查 [评审模板] 徽章
+    console.log('\n=== Phase 2: 列表徽章 ===');
+    const tmplBadges = await page.locator('text=[评审模板]').count();
+    record('[评审模板] 徽章显示', tmplBadges > 0, `(共 ${tmplBadges} 个)`);
+
+    const reviewBadges = await page.locator('text=[评审]').filter({ hasNotText: '模板' }).count();
+    record('[评审] 实例徽章显示', reviewBadges >= 0, `(共 ${reviewBadges} 个 -- 触发执行后会有)`);
+
+    // Phase 3: 打开评审模板详情看 review 模板
+    console.log('\n=== Phase 3: 打开评审模板详情 ===');
+    const tmplCard = page.locator('.todo-item:has-text("评审师模板")').first();
+    if (await tmplCard.count() > 0) {
+      await tmplCard.click();
+      await page.waitForTimeout(2000);
+      await page.screenshot({ path: '/tmp/auto_review_2_template_detail.png', fullPage: false });
+      const titleVisible = await page.locator('text=评审师模板').count();
+      record('评审模板 todo 详情可打开', titleVisible > 0);
+    } else {
+      record('评审模板 todo 详情可打开', false, '找不到评审师模板 todo 卡片');
+    }
+
+    // Phase 4: 打开普通 todo 详情 → 点编辑 → 检查抽屉里"执行后自动评审"开关
+    console.log('\n=== Phase 4: 普通 todo 编辑抽屉 ===');
+    const jokeCard = page.locator('.todo-item:has-text("笑话")').first();
+    if (await jokeCard.count() > 0) {
+      await jokeCard.click();
+      await page.waitForTimeout(2000);
+      // 点 Edit 按钮
+      const editBtn = page.locator('button[aria-label="编辑任务"]').first();
+      if (await editBtn.count() > 0) {
+        await editBtn.click();
+        await page.waitForTimeout(1500);
+        await page.screenshot({ path: '/tmp/auto_review_3_drawer.png', fullPage: false });
+
+        const switchLabel = await page.locator('text=执行后自动评审').count();
+        record('"执行后自动评审" 开关可见', switchLabel > 0);
+
+        const switchInput = await page.locator('button[role="switch"]').count();
+        record('Switch 控件渲染', switchInput > 0, `(共 ${switchInput} 个 switch)`);
+
+        // 检查开关是否默认开
+        const firstSwitchAfterLabel = page.locator('text=执行后自动评审').locator('xpath=ancestor::div[1]').locator('xpath=following-sibling::*//button[@role="switch"]').first();
+        if (await firstSwitchAfterLabel.count() > 0) {
+          const checked = await firstSwitchAfterLabel.getAttribute('aria-checked');
+          record('开关默认开启', checked === 'true', `(aria-checked=${checked})`);
+        }
+      } else {
+        record('"执行后自动评审" 开关可见', false, '编辑按钮未找到');
+        await page.screenshot({ path: '/tmp/auto_review_3_drawer_noedit.png', fullPage: false });
+      }
+    } else {
+      record('"执行后自动评审" 开关可见', false, '"笑话" todo 卡片未找到');
+    }
+
+    // Phase 5: 关闭抽屉
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(800);
+
+    // Phase 6: 在记录里看评审状态徽章 (打开最近一次 execution record)
+    console.log('\n=== Phase 6: 评审状态徽章 ===');
+    // 找最近一次有 result 的 record (看 rating 旁边是否有评审状态徽章)
+    const recResp = await page.evaluate(async () => {
+      const r = await fetch('/api/execution-records?limit=5', { credentials: 'include' });
+      return r.json();
+    });
+    const records = recResp?.data?.records || [];
+    const recordsWithReview = records.filter(r => r.last_review_status);
+    record('存在带 last_review_status 的 record', recordsWithReview.length >= 0, `(后端字段已就位, 真实评审后会写值, 当前 ${recordsWithReview.length} 个)`);
+
+    if (recordsWithReview.length > 0) {
+      // 打开 todo 详情 → 选 record → 截图
+      const sample = recordsWithReview[0];
+      const cardById = page.locator(`.todo-item:has-text("#${sample.todo_id}"), .todo-item:has-text("${sample.todo_id}")`).first();
+      // fallback
+      const anyCard = page.locator('.todo-item').first();
+      const target = (await cardById.count() > 0) ? cardById : anyCard;
+      await target.click();
+      await page.waitForTimeout(2000);
+      // 找评分按钮 (有评分)
+      const ratingBtn = page.locator('button:has-text("' + sample.rating + '")').first();
+      if (await ratingBtn.count() > 0) {
+        await page.screenshot({ path: '/tmp/auto_review_4_record_with_review_badge.png', fullPage: false });
+        // 找兄弟评审状态徽章
+        const reviewBadge = page.locator('text=评审中, text=评审成功, text=评审失败, text=中断').first();
+        const reviewBadgeVisible = await reviewBadge.count() > 0;
+        record('RecordDetailView 评审状态徽章可见', reviewBadgeVisible);
+      }
+    } else {
+      console.log('   (无 last_review_status 数据, 评审状态徽章 UI 渲染逻辑将通过单元测试覆盖)');
+    }
+
+    console.log('\n=== 控制台错误 ===');
+    if (logs.length === 0) console.log('   无');
+    for (const log of logs.slice(0, 10)) console.log(log);
+
+    console.log('\n=== 验证结果汇总 ===');
+    console.log(`通过 ${results.pass} / 失败 ${results.fail}`);
+    for (const it of results.items) {
+      console.log(`  ${it.ok ? '✅' : '❌'} ${it.name}${it.detail ? ' (' + it.detail + ')' : ''}`);
+    }
+  } catch (err) {
+    console.error('\n!!! 验证出错:', err.message);
+    await page.screenshot({ path: '/tmp/auto_review_error.png' }).catch(() => {});
+  } finally {
+    await browser.close();
+    process.exit(results.fail > 0 ? 1 : 0);
+  }
+})();

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -187,6 +187,16 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
     }
   };
 
+  /**
+   * 给一条执行结果评分或清除评分。
+   * 后端会返回更新后的 record；刷新单条后 dispatcher 会同步本地缓存。
+   */
+  const handleRateExecution = async (recordId: number, rating: number | null) => {
+    await db.rateExecutionRecord(recordId, rating);
+    await refreshSingleRecord(recordId);
+    message.success(rating == null ? '已清除评分' : `已评分 ${rating}`);
+  };
+
   const [resumeModalOpen, setResumeModalOpen] = useState(false);
   const [resumeRecordId, setResumeRecordId] = useState<number | null>(null);
   const [resumeMessage, setResumeMessage] = useState('');
@@ -400,6 +410,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                 onExportMarkdown={handleExportMarkdown}
                 onStop={handleStopExecution}
                 onRefreshSingle={refreshSingleRecord}
+                onRate={handleRateExecution}
                 paginatedLogs={paginatedLogs}
                 logsTotal={logsTotal}
                 logsPage={logsPage}

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { Drawer, Input, Button, App, AutoComplete, Divider, Switch, Modal, Form, Empty, Space } from 'antd';
-import { FolderOutlined, PlusOutlined } from '@ant-design/icons';
+import { FolderOutlined, PlusOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import type { ProjectDirectory } from '@/utils/database';
 import type { TodoHookItem } from '@/utils/database/hooks';
@@ -44,6 +44,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
   const [schedulerConfig, setSchedulerConfig] = useState<string>('');
   const [hooks, setHooks] = useState<TodoHookItem[]>([]);
   const [acceptanceCriteria, setAcceptanceCriteria] = useState('');
+  const [autoReviewEnabled, setAutoReviewEnabled] = useState(true);
   const [loading, setLoading] = useState(false);
   // 快速新增项目目录的弹窗：与抽屉同级，关闭抽屉时一起清理
   const [quickAddOpen, setQuickAddOpen] = useState(false);
@@ -116,6 +117,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         setSchedulerConfig(todo.scheduler_config || '');
         setHooks(todo.hooks ?? []);
         setAcceptanceCriteria(todo.acceptance_criteria ?? '');
+        setAutoReviewEnabled(todo.auto_review_enabled ?? true);
       } else {
         setTitle('');
         setPrompt('');
@@ -127,6 +129,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         setSchedulerConfig('');
         setHooks([]);
         setAcceptanceCriteria('');
+        setAutoReviewEnabled(true);
       }
     }
   }, [open, todo]);
@@ -231,12 +234,13 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
           executor, schedulerEnabled, schedulerConfig || null,
           workspaceToSave, worktreeEnabled,
           hooks, acceptanceCriteria || null,
+          autoReviewEnabled,
         );
         await db.updateScheduler(todo.id, schedulerEnabled, schedulerConfig || null);
         await db.updateTodoTags(todo.id, selectedTags);
         message.success('任务已更新');
       } else {
-        const newTodo = await db.createTodo(title.trim(), prompt.trim(), selectedTags, hooks, acceptanceCriteria || undefined);
+        const newTodo = await db.createTodo(title.trim(), prompt.trim(), selectedTags, hooks, acceptanceCriteria || undefined, autoReviewEnabled);
 
         // 创建模式：只在路径存在于目录列表时才设置 workspace，否则为 null（避免创建无名项目）
         const workspaceToSave = trimmedWorkspace && projectDirectories.some(d => d.path === trimmedWorkspace) ? trimmedWorkspace : null;
@@ -247,6 +251,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
             executor, schedulerEnabled, schedulerConfig || null,
             workspaceToSave, worktreeEnabled,
             hooks, acceptanceCriteria || null,
+            autoReviewEnabled,
           );
           await db.updateScheduler(newTodo.id, schedulerEnabled, schedulerConfig || null);
         }
@@ -429,6 +434,30 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
               style={{ resize: 'vertical' }}
             />
           </div>
+
+          {/* 执行后自动评审：仅对普通 todo（不是评审实例/模板）可见 */}
+          {(todo?.todo_type ?? 0) === 0 && (
+            <>
+              <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <div>
+                  <div style={{ fontWeight: 600, fontSize: 14 }}>
+                    <ThunderboltOutlined style={{ color: 'var(--color-primary)', marginRight: 6 }} />
+                    执行后自动评审
+                  </div>
+                  <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginTop: 2 }}>
+                    本次执行完成后，自动派生一个评审实例对结果打分（0-100），供下游 Hook 的评分闸门使用
+                  </div>
+                </div>
+                <Switch
+                  checked={autoReviewEnabled}
+                  onChange={setAutoReviewEnabled}
+                  checkedChildren="开启"
+                  unCheckedChildren="关闭"
+                />
+              </div>
+              <Divider style={{ margin: '8px 0 16px' }} />
+            </>
+          )}
 
           <Divider style={{ margin: '8px 0 16px' }} />
 

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -43,6 +43,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
   const [schedulerEnabled, setSchedulerEnabled] = useState(false);
   const [schedulerConfig, setSchedulerConfig] = useState<string>('');
   const [hooks, setHooks] = useState<TodoHookItem[]>([]);
+  const [acceptanceCriteria, setAcceptanceCriteria] = useState('');
   const [loading, setLoading] = useState(false);
   // 快速新增项目目录的弹窗：与抽屉同级，关闭抽屉时一起清理
   const [quickAddOpen, setQuickAddOpen] = useState(false);
@@ -114,6 +115,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         setSchedulerEnabled(todo.scheduler_enabled || false);
         setSchedulerConfig(todo.scheduler_config || '');
         setHooks(todo.hooks ?? []);
+        setAcceptanceCriteria(todo.acceptance_criteria ?? '');
       } else {
         setTitle('');
         setPrompt('');
@@ -124,6 +126,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         setSchedulerEnabled(false);
         setSchedulerConfig('');
         setHooks([]);
+        setAcceptanceCriteria('');
       }
     }
   }, [open, todo]);
@@ -227,13 +230,13 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
           todo.id, title.trim(), prompt.trim(), todo.status,
           executor, schedulerEnabled, schedulerConfig || null,
           workspaceToSave, worktreeEnabled,
-          hooks,
+          hooks, acceptanceCriteria || null,
         );
         await db.updateScheduler(todo.id, schedulerEnabled, schedulerConfig || null);
         await db.updateTodoTags(todo.id, selectedTags);
         message.success('任务已更新');
       } else {
-        const newTodo = await db.createTodo(title.trim(), prompt.trim(), selectedTags, hooks);
+        const newTodo = await db.createTodo(title.trim(), prompt.trim(), selectedTags, hooks, acceptanceCriteria || undefined);
 
         // 创建模式：只在路径存在于目录列表时才设置 workspace，否则为 null（避免创建无名项目）
         const workspaceToSave = trimmedWorkspace && projectDirectories.some(d => d.path === trimmedWorkspace) ? trimmedWorkspace : null;
@@ -243,7 +246,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
             newTodo.id, newTodo.title, newTodo.prompt, newTodo.status,
             executor, schedulerEnabled, schedulerConfig || null,
             workspaceToSave, worktreeEnabled,
-            hooks,
+            hooks, acceptanceCriteria || null,
           );
           await db.updateScheduler(newTodo.id, schedulerEnabled, schedulerConfig || null);
         }
@@ -412,6 +415,20 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
             onConfigChange={setSchedulerConfig}
             existingConfig={todo?.scheduler_config}
           />
+
+          <Divider style={{ margin: '8px 0 16px' }} />
+
+          {/* 验收标准 */}
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ marginBottom: 8, fontWeight: 600, fontSize: 14 }}>验收标准</div>
+            <Input.TextArea
+              value={acceptanceCriteria}
+              onChange={e => setAcceptanceCriteria(e.target.value)}
+              placeholder="描述完成该任务需要满足的条件..."
+              rows={3}
+              style={{ resize: 'vertical' }}
+            />
+          </div>
 
           <Divider style={{ margin: '8px 0 16px' }} />
 

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -296,6 +296,32 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
                     }}
                   />
                 )}
+                {todo.todo_type === 1 && (
+                  <span
+                    className="todo-tag-badge"
+                    style={{
+                      backgroundColor: '#722ed118',
+                      color: '#722ed1',
+                      border: '1px solid #722ed130',
+                    }}
+                    title="评审师模板：自动评审时复制此 todo"
+                  >
+                    [评审模板]
+                  </span>
+                )}
+                {todo.todo_type === 2 && (
+                  <span
+                    className="todo-tag-badge"
+                    style={{
+                      backgroundColor: '#13c2c218',
+                      color: '#13c2c2',
+                      border: '1px solid #13c2c230',
+                    }}
+                    title={`评审实例 (原 todo #${todo.parent_todo_id ?? '?'})`}
+                  >
+                    [评审]
+                  </span>
+                )}
               </div>
               <span
                 style={{

--- a/frontend/src/components/todo-detail/DetailHeader.tsx
+++ b/frontend/src/components/todo-detail/DetailHeader.tsx
@@ -97,6 +97,16 @@ export function DetailHeader({
           )}
         </div>
         {selectedTodo.prompt && <PromptDisplay content={selectedTodo.prompt} />}
+        {(selectedTodo.acceptance_criteria) && (
+          <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', marginTop: 2, marginBottom: 8, fontSize: 12, color: 'var(--color-text-secondary)' }}>
+            {selectedTodo.acceptance_criteria && (
+              <div style={{ flex: 1, minWidth: 200 }}>
+                <span style={{ fontWeight: 600 }}>验收标准：</span>
+                <span>{selectedTodo.acceptance_criteria}</span>
+              </div>
+            )}
+          </div>
+        )}
         <div style={{ display: 'flex', gap: 8 }}>
           <Button
             type="primary"

--- a/frontend/src/components/todo-detail/RecordDetailView.tsx
+++ b/frontend/src/components/todo-detail/RecordDetailView.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type ReactNode } from 'react';
 import { Button, Tag, Empty, Segmented, Popconfirm, Tooltip, Pagination, message, Popover, InputNumber, Space } from 'antd';
-import { StarOutlined, StarFilled } from '@ant-design/icons';
+import { StarOutlined, StarFilled, SyncOutlined, CheckCircleOutlined, CloseCircleOutlined, PauseCircleOutlined } from '@ant-design/icons';
 import { MessageOutlined, FileTextOutlined, StopOutlined, CopyOutlined, UnorderedListOutlined, LinkOutlined, LoadingOutlined } from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
@@ -387,28 +387,67 @@ function RecordRatingControl({
     // 已评分：以徽章形式呈现，点击重新编辑
     return (
       <Popover content={content} open={open} onOpenChange={setOpen} placement="bottomRight">
-        <Button
-          size="small"
-          icon={<StarFilled style={{ color: '#fadb14' }} />}
-          onClick={() => setOpen(o => !o)}
-          aria-label="已评分，点击修改"
-        >
-          {record.rating}
-        </Button>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+          <Button
+            size="small"
+            icon={<StarFilled style={{ color: '#fadb14' }} />}
+            onClick={() => setOpen(o => !o)}
+            aria-label="已评分，点击修改"
+          >
+            {record.rating}
+          </Button>
+          <ReviewStatusBadge status={record.last_review_status} />
+        </span>
       </Popover>
     );
   }
 
   return (
     <Popover content={content} open={open} onOpenChange={setOpen} placement="bottomRight">
-      <Button
-        size="small"
-        icon={<StarOutlined />}
-        onClick={() => setOpen(o => !o)}
-        aria-label="评分"
-      >
-        评分
-      </Button>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+        <Button
+          size="small"
+          icon={<StarOutlined />}
+          onClick={() => setOpen(o => !o)}
+          aria-label="评分"
+        >
+          评分
+        </Button>
+        <ReviewStatusBadge status={record.last_review_status} />
+      </span>
     </Popover>
+  );
+}
+
+/** 评审状态徽章: pending(评审中) / success(评审成功) / failed(评审失败) / interrupted(被打断) */
+function ReviewStatusBadge({ status }: { status?: 'pending' | 'success' | 'failed' | 'interrupted' | null }) {
+  if (!status) return null;
+  const map: Record<string, { color: string; bg: string; border: string; text: string; icon: ReactNode }> = {
+    pending:     { color: '#1677ff', bg: '#1677ff14', border: '#1677ff30', text: '⏳ 评审中',   icon: <SyncOutlined spin /> },
+    success:     { color: '#52c41a', bg: '#52c41a14', border: '#52c41a30', text: '✅ 评审成功', icon: <CheckCircleOutlined /> },
+    failed:      { color: '#ff4d4f', bg: '#ff4d4f14', border: '#ff4d4f30', text: '❌ 评审失败', icon: <CloseCircleOutlined /> },
+    interrupted: { color: '#faad14', bg: '#faad1414', border: '#faad1430', text: '⏸ 中断',     icon: <PauseCircleOutlined /> },
+  };
+  const s = map[status];
+  if (!s) return null;
+  return (
+    <span
+      style={{
+        fontSize: 11,
+        padding: '1px 6px',
+        borderRadius: 4,
+        color: s.color,
+        background: s.bg,
+        border: `1px solid ${s.border}`,
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 3,
+        whiteSpace: 'nowrap',
+      }}
+      title={`自动评审状态: ${status}`}
+    >
+      {s.icon}
+      {s.text}
+    </span>
   );
 }

--- a/frontend/src/components/todo-detail/RecordDetailView.tsx
+++ b/frontend/src/components/todo-detail/RecordDetailView.tsx
@@ -1,4 +1,6 @@
-import { Button, Tag, Empty, Segmented, Popconfirm, Tooltip, Pagination, message } from 'antd';
+import { useState, useEffect } from 'react';
+import { Button, Tag, Empty, Segmented, Popconfirm, Tooltip, Pagination, message, Popover, InputNumber, Space } from 'antd';
+import { StarOutlined, StarFilled } from '@ant-design/icons';
 import { MessageOutlined, FileTextOutlined, StopOutlined, CopyOutlined, UnorderedListOutlined, LinkOutlined, LoadingOutlined } from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
@@ -14,7 +16,7 @@ import { getHookTriggerLabel } from '@/utils/database/hooks';
 export function RecordDetailView({
   isLoadingDetail, record, sessionGroups,
   onSelectRecord, viewMode, onViewModeChange,
-  onOpenResume, onExportMarkdown, onStop, onRefreshSingle,
+  onOpenResume, onExportMarkdown, onStop, onRefreshSingle, onRate,
   paginatedLogs, logsTotal, logsPage, logsPerPage, onLoadLogs, isLoadingLogs,
   getRunningTaskForRecord, resolveExecutionStats,
 }: {
@@ -28,6 +30,11 @@ export function RecordDetailView({
   onExportMarkdown: (record: ExecutionRecord) => Promise<void>;
   onStop: (recordId: number) => Promise<void>;
   onRefreshSingle: (recordId: number) => Promise<void>;
+  /**
+   * 评分回调。record 表示被评分的新值，recordId 是被清分的记录。
+   * 传 null 表示清除评分。
+   */
+  onRate: (recordId: number, rating: number | null) => Promise<void>;
   paginatedLogs: LogEntry[];
   logsTotal: number;
   logsPage: number;
@@ -135,6 +142,12 @@ export function RecordDetailView({
         <div style={{ display: 'flex', gap: 8 }}>
           {record.status !== 'running' && supportsResume(record) && (
             <Button type="primary" size="small" icon={<MessageOutlined />} onClick={() => onOpenResume(record)}>继续对话</Button>
+          )}
+          {record.status !== 'running' && (
+            <RecordRatingControl
+              record={record}
+              onRate={onRate}
+            />
           )}
           {record.status !== 'running' && !!record.finished_at && (
             <Button size="small" icon={<FileTextOutlined />} onClick={() => onExportMarkdown(record)}>导出YAML</Button>
@@ -290,5 +303,112 @@ export function RecordDetailView({
         );
       })()}
     </>
+  );
+}
+
+/**
+ * 评分控件（仅针对已结束的执行记录）。
+ * - 未评分时：点击“评分”按钮弹出 Popover，输入 0-100 提交。
+ * - 已评分时：直接显示 `★ 85` 可点击重新编辑；提供“清除”按钮。
+ * 设计：评分仅属于“执行结果”，不能给 running 记录评分（RecordDetailView
+ * 会在 status === 'running' 时不渲染本控件）。
+ */
+function RecordRatingControl({
+  record,
+  onRate,
+}: {
+  record: ExecutionRecord;
+  onRate: (recordId: number, rating: number | null) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState<number | null>(record.rating ?? null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // 跟随 record.rating 变化同步本地值（避免外部刷新后表单与实际评分不一致）
+  useEffect(() => {
+    setValue(record.rating ?? null);
+  }, [record.rating, record.id]);
+
+  const handleSubmit = async (next: number | null) => {
+    setSubmitting(true);
+    try {
+      await onRate(record.id, next);
+      setOpen(false);
+    } catch {
+      // 错误由上层拦截器统一提示，本处仅保持弹窗开启以便用户重试
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const content = (
+    <div style={{ width: 220 }}>
+      <div style={{ marginBottom: 8, fontSize: 12, color: 'var(--color-text-secondary)' }}>
+        为本次执行结果评分（0-100）
+      </div>
+      <Space.Compact style={{ width: '100%' }}>
+        <InputNumber
+          min={0}
+          max={100}
+          value={value}
+          onChange={v => setValue(typeof v === 'number' ? v : null)}
+          placeholder="0-100"
+          style={{ width: '100%' }}
+          autoFocus
+          onPressEnter={() => {
+            if (value != null) handleSubmit(value);
+          }}
+        />
+        <Button
+          type="primary"
+          loading={submitting}
+          disabled={value == null}
+          onClick={() => handleSubmit(value)}
+        >
+          保存
+        </Button>
+      </Space.Compact>
+      {record.rating != null && (
+        <Button
+          type="link"
+          size="small"
+          danger
+          style={{ padding: '4px 0 0', marginTop: 4 }}
+          disabled={submitting}
+          onClick={() => handleSubmit(null)}
+        >
+          清除评分
+        </Button>
+      )}
+    </div>
+  );
+
+  if (record.rating != null) {
+    // 已评分：以徽章形式呈现，点击重新编辑
+    return (
+      <Popover content={content} open={open} onOpenChange={setOpen} placement="bottomRight">
+        <Button
+          size="small"
+          icon={<StarFilled style={{ color: '#fadb14' }} />}
+          onClick={() => setOpen(o => !o)}
+          aria-label="已评分，点击修改"
+        >
+          {record.rating}
+        </Button>
+      </Popover>
+    );
+  }
+
+  return (
+    <Popover content={content} open={open} onOpenChange={setOpen} placement="bottomRight">
+      <Button
+        size="small"
+        icon={<StarOutlined />}
+        onClick={() => setOpen(o => !o)}
+        aria-label="评分"
+      >
+        评分
+      </Button>
+    </Popover>
   );
 }

--- a/frontend/src/components/todo-detail/TodoHooksEditor.tsx
+++ b/frontend/src/components/todo-detail/TodoHooksEditor.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Button, Empty, Form, Input, Modal, Popconfirm, Select, Switch } from 'antd';
-import { PlusOutlined, EditOutlined, DeleteOutlined, HolderOutlined } from '@ant-design/icons';
-import { HOOK_TRIGGERS, type TodoHookItem } from '@/utils/database/hooks';
+import { Button, Empty, Form, Input, InputNumber, Modal, Popconfirm, Select, Switch, Tag, Tooltip } from 'antd';
+import { PlusOutlined, EditOutlined, DeleteOutlined, HolderOutlined, StarFilled } from '@ant-design/icons';
+import {
+  HOOK_TRIGGERS,
+  UNRATED_POLICIES,
+  DEFAULT_MIN_RATING,
+  DEFAULT_UNRATED_POLICY,
+  type TodoHookItem,
+  type UnratedPolicy,
+} from '@/utils/database/hooks';
 import type { Todo } from '@/types';
 
 function nextId(): number {
@@ -89,6 +96,7 @@ export function TodoHooksEditor({ todos, ownerId, hooks, onChange, disabled }: T
                 {items.map((item) => {
                   const target = todos.find((t) => t.id === item.target_todo_id);
                   const missing = !target;
+                  const hasGate = typeof item.min_rating === 'number';
                   return (
                     <div
                       key={item.id}
@@ -118,6 +126,24 @@ export function TodoHooksEditor({ todos, ownerId, hooks, onChange, disabled }: T
                           <span>→ {target!.title}</span>
                         )}
                       </span>
+                      {hasGate && (
+                        <Tooltip
+                          title={
+                            item.unrated_policy === 'pass'
+                              ? `评分≥${item.min_rating} 才触发；未评分时仍触发`
+                              : `评分≥${item.min_rating} 才触发；未评分时不触发`
+                          }
+                        >
+                          <Tag
+                            color="gold"
+                            icon={<StarFilled />}
+                            style={{ margin: 0, fontSize: 11, lineHeight: '16px' }}
+                            data-testid="hook-rating-gate"
+                          >
+                            ≥{item.min_rating} · {item.unrated_policy === 'pass' ? '未评通过' : '未评跳过'}
+                          </Tag>
+                        </Tooltip>
+                      )}
                       <Button
                         size="small"
                         type="text"
@@ -155,6 +181,17 @@ export function TodoHooksEditor({ todos, ownerId, hooks, onChange, disabled }: T
   );
 }
 
+interface HookFormValues {
+  id: number;
+  trigger: TodoHookItem['trigger'];
+  target_todo_id: number;
+  skip_if_missing: boolean;
+  enabled: boolean;
+  /** Number | null — `null` means the gate is disabled (no rating requirement). */
+  min_rating: number | null;
+  unrated_policy: UnratedPolicy;
+}
+
 function HookEditModal({
   open,
   item,
@@ -168,13 +205,24 @@ function HookEditModal({
   onCancel: () => void;
   onOk: (item: TodoHookItem) => void;
 }) {
-  const [form] = Form.useForm<TodoHookItem>();
+  const [form] = Form.useForm<HookFormValues>();
   const seedId = useMemo(() => nextId(), [open]);
+  // Watch the min_rating field so we can show/hide the unrated_policy
+  // control. A rating gate is only meaningful when a threshold is set.
+  const minRating = Form.useWatch('min_rating', form);
 
   useEffect(() => {
     if (!open) return;
     if (item) {
-      form.setFieldsValue(item);
+      form.setFieldsValue({
+        id: item.id,
+        trigger: item.trigger,
+        target_todo_id: item.target_todo_id,
+        skip_if_missing: item.skip_if_missing ?? true,
+        enabled: item.enabled,
+        min_rating: typeof item.min_rating === 'number' ? item.min_rating : null,
+        unrated_policy: item.unrated_policy ?? DEFAULT_UNRATED_POLICY,
+      });
     } else {
       form.setFieldsValue({
         id: seedId,
@@ -182,13 +230,25 @@ function HookEditModal({
         target_todo_id: undefined,
         skip_if_missing: true,
         enabled: true,
+        min_rating: DEFAULT_MIN_RATING,
+        unrated_policy: DEFAULT_UNRATED_POLICY,
       });
     }
   }, [open, item, form, seedId]);
 
   const handleOk = async (): Promise<void> => {
     const values = await form.validateFields();
-    onOk({ ...values, id: item?.id ?? seedId });
+    // Normalize the gate fields: if the user left `min_rating` empty, drop
+    // the gate entirely (and lock unrated_policy to its default) so we don't
+    // send ambiguous `null` payloads that the backend would have to guess at.
+    const hasGate = typeof values.min_rating === 'number';
+    const next: TodoHookItem = {
+      ...values,
+      id: item?.id ?? seedId,
+      min_rating: hasGate ? values.min_rating : null,
+      unrated_policy: hasGate ? values.unrated_policy : DEFAULT_UNRATED_POLICY,
+    };
+    onOk(next);
   };
 
   return (
@@ -219,6 +279,40 @@ function HookEditModal({
             options={targetOptions}
           />
         </Form.Item>
+        <Form.Item
+          name="min_rating"
+          label="最低评分（0-100，可选）"
+          extra={<>留空表示不门控，源 todo 状态变更时总是触发。</>}
+        >
+          <InputNumber
+            min={0}
+            max={100}
+            step={1}
+            precision={0}
+            placeholder="留空 = 不门控"
+            style={{ width: '100%' }}
+            aria-label="最低评分"
+          />
+        </Form.Item>
+        {typeof minRating === 'number' && (
+          <Form.Item
+            name="unrated_policy"
+            label="未评分时"
+            extra={(
+              <Form.Item
+                noStyle
+                shouldUpdate={(prev, curr) => prev.unrated_policy !== curr.unrated_policy}
+              >
+                {({ getFieldValue }) => {
+                  const policy = (getFieldValue('unrated_policy') as UnratedPolicy | undefined) ?? DEFAULT_UNRATED_POLICY;
+                  return UNRATED_POLICIES.find((p) => p.value === policy)?.description;
+                }}
+              </Form.Item>
+            )}
+          >
+            <Select options={UNRATED_POLICIES.map((p) => ({ value: p.value, label: p.label }))} />
+          </Form.Item>
+        )}
         <Form.Item name="skip_if_missing" label="目标不存在时跳过" valuePropName="checked">
           <Switch />
         </Form.Item>

--- a/frontend/src/hooks/useExecutionHistory.ts
+++ b/frontend/src/hooks/useExecutionHistory.ts
@@ -107,6 +107,12 @@ export function useExecutionHistory({
     try {
       const record = await db.getExecutionRecord(recordId);
       dispatch({ type: 'UPDATE_EXECUTION_RECORD', payload: { todoId: selectedTodoId, record } });
+      // 同步更新详情面板使用的本地 detail state，避免评分等同步更新后
+      // 详情面板仍展示旧值（详情面板优先使用 selectedHistoryRecordDetail，
+      // 这里只在被刷新的 record 正好是当前选中的那一条时才覆盖）。
+      if (activeRecordIdRef.current === recordId) {
+        setSelectedHistoryRecordDetail(record);
+      }
     } catch { /* ignore */ }
   }, [selectedTodoId, dispatch]);
 

--- a/frontend/src/types/execution.tsx
+++ b/frontend/src/types/execution.tsx
@@ -58,6 +58,8 @@ export interface ExecutionRecord {
   source_todo_id?: number | null;
   source_todo_title?: string | null;
   source_hook_id?: number | null;
+  /** User-provided score for this execution's result (0-100). */
+  rating?: number | null;
 }
 
 export interface ExecutionSummary {

--- a/frontend/src/types/execution.tsx
+++ b/frontend/src/types/execution.tsx
@@ -60,6 +60,12 @@ export interface ExecutionRecord {
   source_hook_id?: number | null;
   /** User-provided score for this execution's result (0-100). */
   rating?: number | null;
+  /** For review instance records: the original execution record that was reviewed. */
+  source_execution_record_id?: number | null;
+  /** For the original execution record: status of the most recent auto-review. */
+  last_review_status?: 'pending' | 'success' | 'failed' | 'interrupted' | null;
+  /** ISO timestamp when the most recent auto-review finished. */
+  last_reviewed_at?: string | null;
 }
 
 export interface ExecutionSummary {

--- a/frontend/src/types/todo.ts
+++ b/frontend/src/types/todo.ts
@@ -21,6 +21,12 @@ export interface Todo {
   worktree_enabled?: boolean;
   hooks?: TodoHookItem[];
   acceptance_criteria?: string | null;
+  /** Whether to spawn an auto-review child todo after this one finishes. Default true. */
+  auto_review_enabled?: boolean;
+  /** 0 = normal todo, 1 = reviewer template, 2 = review instance child. */
+  todo_type?: 0 | 1 | 2;
+  /** For review instances: the original todo that was reviewed. */
+  parent_todo_id?: number | null;
 }
 
 export interface Tag {

--- a/frontend/src/types/todo.ts
+++ b/frontend/src/types/todo.ts
@@ -20,6 +20,7 @@ export interface Todo {
   workspace?: string | null;
   worktree_enabled?: boolean;
   hooks?: TodoHookItem[];
+  acceptance_criteria?: string | null;
 }
 
 export interface Tag {

--- a/frontend/src/utils/database/executions.ts
+++ b/frontend/src/utils/database/executions.ts
@@ -62,6 +62,17 @@ export async function resumeExecutionRecord(recordId: number, message?: string):
   return unwrap(await api.post(`/api/execution-records/${recordId}/resume`, { message }));
 }
 
+/**
+ * 给一条执行结果评分（0-100）。仅针对已结束的记录（success/failed）；
+ * running 记录后端会拒绝。传 null 表示清除评分。
+ */
+export async function rateExecutionRecord(
+  recordId: number,
+  rating: number | null,
+): Promise<ExecutionRecord> {
+  return unwrap(await api.put(`/api/execution-records/${recordId}/rating`, { rating }));
+}
+
 // Smart Create API
 
 export interface SmartCreateResult {

--- a/frontend/src/utils/database/hooks.ts
+++ b/frontend/src/utils/database/hooks.ts
@@ -17,12 +17,30 @@ export type HookTrigger =
   | 'state_changed_to_completed'
   | 'state_changed_to_failed';
 
+/**
+ * Policy for how the rating gate treats an unrated record. Matches the
+ * backend `UnratedPolicy` enum (snake_case serialization).
+ */
+export type UnratedPolicy = 'skip' | 'pass';
+
 export interface TodoHookItem {
   id: number;
   trigger: HookTrigger;
   target_todo_id: number;
   skip_if_missing?: boolean;
   enabled: boolean;
+  /**
+   * Optional rating gate. When set (0-100), the hook only fires if the
+   * source todo's most recent FINISHED execution record has
+   * `rating >= min_rating`. `undefined`/`null` means no gate (always fire).
+   */
+  min_rating?: number | null;
+  /**
+   * What to do when the source todo has no rating on its latest finished
+   * record. Defaults to `'skip'` (do not fire). `'pass'` treats the missing
+   * rating as if it had passed the gate.
+   */
+  unrated_policy?: UnratedPolicy;
 }
 
 export const HOOK_TRIGGERS: ReadonlyArray<{ value: HookTrigger; label: string }> = [
@@ -31,6 +49,23 @@ export const HOOK_TRIGGERS: ReadonlyArray<{ value: HookTrigger; label: string }>
   { value: 'state_changed_to_completed', label: '状态变为已完成' },
   { value: 'state_changed_to_failed', label: '状态变为失败' },
 ];
+
+export const UNRATED_POLICIES: ReadonlyArray<{ value: UnratedPolicy; label: string; description: string }> = [
+  {
+    value: 'skip',
+    label: '未评分时跳过',
+    description: '安全默认：未评分视为不达标，不触发下游',
+  },
+  {
+    value: 'pass',
+    label: '未评分时通过',
+    description: '宽松：只有明确低分才会拦截，未评分时正常触发',
+  },
+];
+
+/** Default rating gate when the user opens the modal fresh. */
+export const DEFAULT_MIN_RATING: number | null = null;
+export const DEFAULT_UNRATED_POLICY: UnratedPolicy = 'skip';
 
 const HOOK_TRIGGER_LABEL_BY_VALUE: Record<HookTrigger, string> = HOOK_TRIGGERS.reduce(
   (acc, t) => ({ ...acc, [t.value]: t.label }),

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -13,8 +13,11 @@ export async function createTodo(
   prompt: string = '',
   tagIds: number[] = [],
   hooks: TodoHookItem[] = [],
+  acceptanceCriteria?: string,
 ): Promise<Todo> {
-  return unwrap(await api.post('/api/todos', { title, prompt, tag_ids: tagIds, hooks }));
+  const body: Record<string, unknown> = { title, prompt, tag_ids: tagIds, hooks };
+  if (acceptanceCriteria !== undefined) body.acceptance_criteria = acceptanceCriteria;
+  return unwrap(await api.post('/api/todos', body));
 }
 
 export async function updateTodo(
@@ -28,6 +31,7 @@ export async function updateTodo(
   workspace?: string | null,
   worktree_enabled?: boolean,
   hooks?: TodoHookItem[],
+  acceptance_criteria?: string | null,
 ): Promise<Todo> {
   const body: Record<string, unknown> = { title, prompt, status };
   if (executor !== undefined) body.executor = executor;
@@ -36,6 +40,7 @@ export async function updateTodo(
   if (workspace !== undefined) body.workspace = workspace;
   if (worktree_enabled !== undefined) body.worktree_enabled = worktree_enabled;
   if (hooks !== undefined) body.hooks = hooks;
+  if (acceptance_criteria !== undefined) body.acceptance_criteria = acceptance_criteria;
 
   return unwrap(await api.put(`/api/todos/${id}`, body));
 }

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -14,9 +14,11 @@ export async function createTodo(
   tagIds: number[] = [],
   hooks: TodoHookItem[] = [],
   acceptanceCriteria?: string,
+  autoReviewEnabled?: boolean,
 ): Promise<Todo> {
   const body: Record<string, unknown> = { title, prompt, tag_ids: tagIds, hooks };
   if (acceptanceCriteria !== undefined) body.acceptance_criteria = acceptanceCriteria;
+  if (autoReviewEnabled !== undefined) body.auto_review_enabled = autoReviewEnabled;
   return unwrap(await api.post('/api/todos', body));
 }
 
@@ -32,6 +34,7 @@ export async function updateTodo(
   worktree_enabled?: boolean,
   hooks?: TodoHookItem[],
   acceptance_criteria?: string | null,
+  auto_review_enabled?: boolean,
 ): Promise<Todo> {
   const body: Record<string, unknown> = { title, prompt, status };
   if (executor !== undefined) body.executor = executor;
@@ -41,6 +44,7 @@ export async function updateTodo(
   if (worktree_enabled !== undefined) body.worktree_enabled = worktree_enabled;
   if (hooks !== undefined) body.hooks = hooks;
   if (acceptance_criteria !== undefined) body.acceptance_criteria = acceptance_criteria;
+  if (auto_review_enabled !== undefined) body.auto_review_enabled = auto_review_enabled;
 
   return unwrap(await api.put(`/api/todos/${id}`, body));
 }


### PR DESCRIPTION
## 概要
原 todo 执行完成后，自动派生一个评审实例 todo，给那条具体的执行记录打分（0-100）。评审结果精确回填到原 record，供下游 Hook 的评分闸门消费。

## 设计要点
- **评审师模板** (todo_type=1)：启动时按 `评审师模板` 标题自动查找/创建
- **评审实例** (todo_type=2)：模板克隆得到，`parent_todo_id` 关联原 todo
- **精确回填**：`source_execution_record_id` 反指原 record，后续 re-run 不会污染旧评分
- **同步评审**：用 `std::thread::spawn` + 独立 tokio runtime 跑评审，hook 触发时 rating 已就绪
- **失败容错**：评审失败/中断 → rating 保持 null，`last_review_status='failed'`
- **防递归**：评审实例自身不触发评审（trigger_type 检查）

## 依赖
本分支基于 `feat/hook-rating-gate`（PR #469）。**请先合入 #469**，否则本 PR 与 main 存在冲突。

## 改动文件
**后端（14 个文件）**：
- `db/mod.rs`, `db/entity/{todos,execution_records}.rs` — schema + 索引
- `db/todo.rs`, `db/execution.rs` — DB 助手方法
- `models/mod.rs` — DTO 字段
- `services/auto_review.rs` (新增) — 评审师模板管理 + RATING 解析
- `executor_service.rs` — 完成路径接入 + 独立 runtime
- `handlers/{mod,todo,sync,execution}.rs` — HTTP/CLI 接入
- `cli/commands.rs`, `hooks/service.rs` — 测试夹具

**前端（6 个文件）**：
- `types/{todo,execution}.tsx` — 类型字段
- `utils/database/todos.ts` — API 透传 `auto_review_enabled`
- `components/TodoDrawer.tsx` — `执行后自动评审` 开关
- `components/TodoList.tsx` — `[评审模板]` / `[评审]` 徽章
- `components/todo-detail/RecordDetailView.tsx` — `ReviewStatusBadge`（4 态）

**验证脚本（2 个文件）**：
- `frontend/check_auto_review_ui.cjs` — UI 验证
- `frontend/check_auto_review_e2e.cjs` — 端到端验证

## 验证
- ✅ `cargo test --lib`：273 passed (唯一失败是 codewhale 已存在的无关测试)
- ✅ `cargo build`：通过
- ✅ `tsc --noEmit`：通过
- ✅ `vite build`：5.16s 通过
- ✅ 6 个 `parse_rating_from_result` 单元测试：全通过
- ✅ Playwright UI 验证：4/4 通过
- ✅ Playwright 端到端：5/5 通过

## 端到端场景验证（真实数据）

### 场景 A：低分拦截（rating < min_rating）
```
源 todo #16 "[源] 讲个程序员的冷笑话"
  prompt: "请讲一个关于程序员的冷笑话..."
  acceptance_criteria: "笑话必须有明显的笑点, 涉及程序员文化梗"
  hook: state_changed_to_completed → target=#15, min_rating=80, unrated_policy=skip

执行 #16:
  exec #78 status=success, result=笑话正文 (atomcode 跑出)

自动评审:
  review_todo #17, review_exec #79 status=success
  RATING: 62
  exec #78.rating=62, last_review_status=success, last_reviewed_at=2026-06-11T10:28:11.062Z

Hook gate 决策:
  WARN: hook #9001 skipped by rating gate
        (min_rating=80, policy=skip, source rating=62,
         reason=rating below threshold)
  target #15: status=pending, 0 records
```

### 场景 B：高分放行（rating ≥ min_rating）
```
源 todo #19 "[高分源] 输出斐波那契前 5 项"
  prompt: "只输出下面这一行, 不要任何其他字符: 1 1 2 3 5"
  acceptance_criteria: "输出严格等于 '1 1 2 3 5'"
  hook: state_changed_to_completed → target=#18, min_rating=80, unrated_policy=skip

执行 #19:
  exec #80 status=success, result="1 1 2 3 5"

自动评审:
  review_todo #20, review_exec #81 status=success
  RATING: 100
  exec #80.rating=100, last_review_status=success, last_reviewed_at=2026-06-11T10:30:26.313Z

Hook gate 决策:
  PASS: hook #9002 触发
  target #18: 派生 exec #82 status=success
        trigger_type=hook:state_changed_to_completed
        source_hook_id=9002, source_todo_id=19
        command="atomcode -v --dangerously-skip-permissions -p ...斐波那契下一项: 8"
        result="13"
```

### 关键日志（来自 dev 实例）
```
INFO  ntd::services::auto_review: created auto-review reviewer template todo #12
INFO  ntd::executor_service: auto-review done: original_todo=#16 record=#78
      review_todo=#17 review_record=#79 status=success rating=Some(62)
WARN  ntd::hooks::service: hook #9001 skipped by rating gate
      (min_rating=80, policy=skip, source rating=62,
       reason=rating below threshold)
INFO  ntd::executor_service: auto-review done: original_todo=#19 record=#80
      review_todo=#20 review_record=#81 status=success rating=Some(100)
```

### 端到端流程图
```
源 todo 执行完成
  ↓
update_execution_record (status=success, result=...)
  ↓
[trigger_type != "auto_review"]?
  ├─ 否 → 跳过
  └─ 是 ↓
run_auto_review (std::thread::spawn + 独立 runtime)
  ├─ ensure_reviewer_template → #12 (todo_type=1, todo_type 模板)
  ├─ clone_todo_for_review → #20 (todo_type=2, parent_todo_id=19)
  ├─ merge_prompt (原 prompt + output[≤8K] + acceptance_criteria)
  ├─ run_todo_execution → exec #81 (status=success, RATING:100)
  ├─ parse_rating_from_result → Some(100)
  ├─ update_execution_record_rating → exec #80.rating = 100
  ├─ link_review_to_source → exec #81.source_execution_record_id = 80
  ├─ set_record_last_review_status → exec #80.last_review_status = "success"
  └─ set_record_last_reviewed_at → exec #80.last_reviewed_at = now
  ↓
finish_todo_execution → todo #19.status = completed
  ↓
fire_for_todo (hooks)
  ├─ hook #9002: evaluate_rating_gate (rating=100, min=80, policy=skip) → Pass
  └─ 触发 target #18 执行 → exec #82
```

## 截图
- `/tmp/auto_review_e2e_1_list.png` — 列表显示 `[评审]` 实例徽章
- `/tmp/auto_review_e2e_2_review_detail.png` — 评审实例详情
- `/tmp/auto_review_e2e_3_source_detail.png` — 原 todo 显示评分 100 + 评审成功徽章

## 后续工作（不在本 PR）
- 评审师模板 prompt 的可视化编辑
- 评审师模板的版本/备份
- 评审失败的 UI 重试按钮
- 评审耗时统计