### PR TITLE
fix: 评审模板复用、PI换行修复、手机端评分组件

### DIFF
--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -177,8 +177,9 @@ impl CodeExecutor for PiExecutor {
                         match ame.event_type.as_deref() {
                             Some("text_delta") => {
                                 // text_delta 是实际回复的增量内容
+                                // 移除尾部换行符，避免 PI 输出每字符一行时在最终结果中引入多余换行
                                 if let Some(delta) = &ame.delta {
-                                    let trimmed = delta.trim();
+                                    let trimmed = delta.trim_end();
                                     if !trimmed.is_empty() {
                                         return Some(ParsedLogEntry {
                                             timestamp: utc_timestamp(),
@@ -193,8 +194,9 @@ impl CodeExecutor for PiExecutor {
                             }
                             Some("thinking_delta") => {
                                 // thinking_delta 是 thinking 的增量内容
+                                // 移除尾部换行符，避免多余换行
                                 if let Some(delta) = &ame.delta {
-                                    let trimmed = delta.trim();
+                                    let trimmed = delta.trim_end();
                                     if !trimmed.is_empty() {
                                         return Some(ParsedLogEntry {
                                             timestamp: utc_timestamp(),

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -1227,9 +1227,8 @@ async fn run_auto_review_inner(
         .replace("{original_output}", &truncated)
         .replace("{acceptance_criteria}", acceptance_criteria);
 
-    // 4) clone 评审实例 todo
-    let review_todo_id = db.clone_todo_for_review(template_id, original.id).await
-        .map_err(|e| format!("clone review instance: {}", e))?;
+    // 4) 复用评审师模板 todo，直接执行（不 clone 新实例）
+    let review_todo_id = template_id;
 
     // 5) 标记 pending
     let _ = db.set_record_last_review_status(record_id, "pending").await;
@@ -1295,11 +1294,6 @@ async fn run_auto_review_inner(
     }
     let _ = db.link_review_to_source(review_record_id, record_id, review_status_str).await;
     let _ = db.set_record_last_review_status(record_id, review_status_str).await;
-    // 评审实例自身 todo 也转完成
-    let _ = db.finish_todo_execution(
-        review_todo_id,
-        matches!(review_status_str, "success"),
-    ).await;
 
     tracing::info!(
         "auto-review done: original_todo=#{} record=#{} review_todo=#{} review_record=#{} status={} rating={:?}",

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -436,6 +436,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
                     onExport={handleExportMarkdown}
                     onStop={handleStopExecution}
                     onRefresh={refreshSingleRecord}
+                    onRate={handleRateExecution}
                     getRunningTask={getRunningTaskForRecord}
                     resolveStats={resolveExecutionStats}
                     parseLogs={parseRecordLogs}

--- a/frontend/src/components/todo-detail/NarrowHistoryCard.tsx
+++ b/frontend/src/components/todo-detail/NarrowHistoryCard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import { Button, Popconfirm, Tag, Tooltip } from 'antd';
-import { MessageOutlined, FileTextOutlined, StopOutlined, CopyOutlined, LinkOutlined } from '@ant-design/icons';
+import { Button, Popconfirm, Tag, Tooltip, Popover, InputNumber, Space } from 'antd';
+import { MessageOutlined, FileTextOutlined, StopOutlined, CopyOutlined, LinkOutlined, StarOutlined, StarFilled } from '@ant-design/icons';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { XMarkdown } from '@ant-design/x-markdown';
 import { supportsResume } from '@/types';
@@ -9,16 +9,18 @@ import * as db from '@/utils/database';
 import { getElapsedSeconds, hasLogsStatic } from './helpers';
 import { NarrowLogView } from './NarrowLogView';
 import { getHookTriggerLabel } from '@/utils/database/hooks';
+import { ReviewStatusBadge } from './RecordDetailView';
 import type { ExecutionRecord, ExecutionStats, LogEntry } from '@/types';
 
 /** Narrow mode: single history card */
-export function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, onRefresh, getRunningTask, resolveStats, parseLogs, messageApi, onViewModeChange }: {
+export function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, onRefresh, onRate, getRunningTask, resolveStats, parseLogs, messageApi, onViewModeChange }: {
   record: ExecutionRecord;
   viewMode: 'log' | 'chat';
   onOpenResume: (r: ExecutionRecord) => void;
   onExport: (r: ExecutionRecord) => void;
   onStop: (id: number) => Promise<void>;
   onRefresh: (id: number) => Promise<void>;
+  onRate: (recordId: number, rating: number | null) => Promise<void>;
   getRunningTask: (r: ExecutionRecord) => any;
   resolveStats: (r: ExecutionRecord, running: boolean) => ExecutionStats | null | undefined;
   parseLogs: (r: ExecutionRecord) => LogEntry[];
@@ -86,6 +88,9 @@ export function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, on
           {!isRunning && supportsResume(record) && (
             <Button type="primary" size="small" icon={<MessageOutlined />} onClick={() => onOpenResume(record)}>继续对话</Button>
           )}
+          {!isRunning && (
+            <NarrowRatingControl record={record} onRate={onRate} />
+          )}
           {hasLogsStatic(record) && (
             <Button size="small" icon={<FileTextOutlined />} onClick={() => onExport(record)}>导出YAML</Button>
           )}
@@ -139,6 +144,11 @@ export function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, on
           </div>
         );
       })()}
+      {/* 评分与评审状态 */}
+      <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <NarrowRatingControl record={record} onRate={onRate} />
+        <ReviewStatusBadge status={record.last_review_status} />
+      </div>
       <NarrowLogView
         record={record}
         isRunning={isRunning}
@@ -149,5 +159,63 @@ export function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, on
         onViewModeChange={onViewModeChange}
       />
     </div>
+  );
+}
+
+/** 手机版评分控件（简化版） */
+function NarrowRatingControl({
+  record,
+  onRate,
+}: {
+  record: ExecutionRecord;
+  onRate: (recordId: number, rating: number | null) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState<number | null>(record.rating ?? null);
+
+  useEffect(() => {
+    setValue(record.rating ?? null);
+  }, [record.rating, record.id]);
+
+  const handleSubmit = async (next: number | null) => {
+    try {
+      await onRate(record.id, next);
+      setOpen(false);
+    } catch {
+      // 错误由上层拦截器统一提示
+    }
+  };
+
+  if (record.rating != null) {
+    return (
+      <Popover content={
+        <div style={{ width: 200 }}>
+          <div style={{ marginBottom: 8, fontSize: 12, color: 'var(--color-text-secondary)' }}>评分：{record.rating}</div>
+          <Space.Compact style={{ width: '100%' }}>
+            <InputNumber min={0} max={100} value={value ?? 0} onChange={v => setValue(typeof v === 'number' ? v : null)} style={{ width: '100%' }} />
+            <Button onClick={() => handleSubmit(value)}>改</Button>
+          </Space.Compact>
+          <Button type="link" danger size="small" style={{ padding: '4px 0 0' }} onClick={() => handleSubmit(null)}>清除</Button>
+        </div>
+      } open={open} onOpenChange={setOpen} placement="bottomRight">
+        <Button size="small" icon={<StarFilled style={{ color: '#fadb14' }} />} onClick={() => setOpen(o => !o)}>
+          {record.rating}
+        </Button>
+      </Popover>
+    );
+  }
+
+  return (
+    <Popover content={
+      <div style={{ width: 200 }}>
+        <div style={{ marginBottom: 8, fontSize: 12, color: 'var(--color-text-secondary)' }}>为本次执行结果评分（0-100）</div>
+        <Space.Compact style={{ width: '100%' }}>
+          <InputNumber min={0} max={100} value={value} onChange={v => setValue(typeof v === 'number' ? v : null)} placeholder="0-100" style={{ width: '100%' }} />
+          <Button type="primary" onClick={() => handleSubmit(value)}>评分</Button>
+        </Space.Compact>
+      </div>
+    } open={open} onOpenChange={setOpen} placement="bottomRight">
+      <Button size="small" icon={<StarOutlined />} onClick={() => setOpen(o => !o)}>评分</Button>
+    </Popover>
   );
 }

--- a/frontend/src/components/todo-detail/RecordDetailView.tsx
+++ b/frontend/src/components/todo-detail/RecordDetailView.tsx
@@ -420,7 +420,7 @@ function RecordRatingControl({
 }
 
 /** 评审状态徽章: pending(评审中) / success(评审成功) / failed(评审失败) / interrupted(被打断) */
-function ReviewStatusBadge({ status }: { status?: 'pending' | 'success' | 'failed' | 'interrupted' | null }) {
+export function ReviewStatusBadge({ status }: { status?: 'pending' | 'success' | 'failed' | 'interrupted' | null }) {
   if (!status) return null;
   const map: Record<string, { color: string; bg: string; border: string; text: string; icon: ReactNode }> = {
     pending:     { color: '#1677ff', bg: '#1677ff14', border: '#1677ff30', text: '⏳ 评审中',   icon: <SyncOutlined spin /> },


### PR DESCRIPTION
## 改动

### 1. 评审模板复用
- 不再每次clone评审实例，直接复用评审师模板(todo_type=1)执行评审
- 避免创建大量一次性评审todo

### 2. PI执行器换行问题修复
- text_delta/think_delta使用trim_end()替代trim()
- 修复PI执行器输出每字符一行导致的换行问题

### 3. 手机端评分组件
- NarrowHistoryCard添加评分控件(NarrowRatingControl)
- 添加评审状态徽章(ReviewStatusBadge)
- 修复手机端执行记录页面看不到评分的问题