### PR TITLE
feat: 关联图hook连线上显示评分闸门

### DIFF
--- a/frontend/src/components/relation-map/Edges.tsx
+++ b/frontend/src/components/relation-map/Edges.tsx
@@ -6,7 +6,7 @@ import {
   EdgeLabelRenderer,
 } from '@xyflow/react';
 
-/** Hook 边：带触发条件标签 */
+/** Hook 边：带触发条件标签和评分闸门 */
 export function HookEdge({
   id,
   sourceX,
@@ -17,7 +17,7 @@ export function HookEdge({
   targetPosition,
   data,
   selected,
-}: EdgeProps & { data?: { trigger?: string; hookId?: number; enabled?: boolean } }) {
+}: EdgeProps & { data?: { trigger?: string; hookId?: number; enabled?: boolean; minRating?: number | null; unratedPolicy?: string } }) {
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
     sourceY,
@@ -28,6 +28,10 @@ export function HookEdge({
   });
 
   const trigger = data?.trigger || '';
+  const minRating = data?.minRating;
+  const unratedPolicy = data?.unratedPolicy;
+  const hasRatingGate = minRating != null && minRating > 0;
+
   const getTriggerColor = useCallback((t: string) => {
     switch (t) {
       case 'state_changed_to_completed': return '#52c41a';
@@ -49,6 +53,11 @@ export function HookEdge({
   }, []);
 
   const color = getTriggerColor(trigger);
+
+  // 构建闸门标签
+  const gateLabel = hasRatingGate
+    ? `≥${minRating}${unratedPolicy === 'pass' ? '·未评过' : '·未评跳'}`
+    : null;
 
   return (
     <>
@@ -78,7 +87,7 @@ export function HookEdge({
             }}
             className="nodrag nopan"
           >
-            {getTriggerLabel(trigger)} →
+            {getTriggerLabel(trigger)} → {gateLabel || ''}
           </div>
         </EdgeLabelRenderer>
       )}

--- a/frontend/src/components/relation-map/GraphBuilder.ts
+++ b/frontend/src/components/relation-map/GraphBuilder.ts
@@ -36,6 +36,10 @@ export interface HookEdgeData extends Record<string, unknown> {
   trigger: string;
   hookId: number;
   enabled: boolean;
+  /** 评分闸门阈值（0-100），undefined/null 表示无闸门 */
+  minRating?: number | null;
+  /** 未评分时的策略：'skip' | 'pass' */
+  unratedPolicy?: string;
 }
 
 export interface WebhookEdgeData extends Record<string, unknown> {
@@ -104,6 +108,8 @@ function buildHookRelations(
           trigger: h.trigger,
           hookId: h.id,
           enabled: h.enabled,
+          minRating: h.min_rating,
+          unratedPolicy: h.unrated_policy,
         },
         animated: false,
       });

--- a/frontend/src/components/relation-map/RelationMap.tsx
+++ b/frontend/src/components/relation-map/RelationMap.tsx
@@ -163,7 +163,6 @@ export function RelationMap({ onBack }: RelationMapProps) {
             }
           }}
           maskColor={isDark ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.6)'}
-          style={{ borderRadius: 8, width: 100, height: 60 }}
         />
 
         {/* 右侧过滤面板 */}

--- a/frontend/src/components/relation-map/RelationMap.tsx
+++ b/frontend/src/components/relation-map/RelationMap.tsx
@@ -163,7 +163,7 @@ export function RelationMap({ onBack }: RelationMapProps) {
             }
           }}
           maskColor={isDark ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.6)'}
-          style={{ borderRadius: 8 }}
+          style={{ borderRadius: 8, width: 100, height: 60 }}
         />
 
         {/* 右侧过滤面板 */}

--- a/frontend/src/components/relation-map/relation-map.css
+++ b/frontend/src/components/relation-map/relation-map.css
@@ -382,4 +382,6 @@
   border-radius: 8px;
   border: 1px solid var(--color-border-secondary, #334155);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  width: 100px;
+  height: 60px;
 }


### PR DESCRIPTION
## 改动

在关联图的hook连线上显示评分闸门信息：
- 有评分闸门时显示 `≥N` 格式（如 ≥85）
- 未评分策略显示 `·未评跳` 或 `·未评过`

示例：`已完成 → ≥85·未评跳`