### PR TITLE
fix(db): 扩大连接池大小避免高并发时请求超时

### DIFF
--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -66,7 +66,7 @@ impl Database {
         };
 
         let mut opt = ConnectOptions::new(url);
-        opt.max_connections(1)
+        opt.max_connections(10)
             .min_connections(1)
             .connect_timeout(Duration::from_secs(5))
             .sqlx_logging(false);


### PR DESCRIPTION
## 修改内容

`max_connections` 从 1 改为 10。

## 问题

SQLite 连接池只有 1 个连接，当后台任务（飞书历史抓取、定时调度等）占用连接时，绑定等操作会因无法获取连接而报 `Connection pool timed out`。

## 影响范围

- `backend/src/db/mod.rs` — 连接池配置