### PR TITLE
feat(kanban): show per-run score badge on board cards

### DIFF
--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -877,7 +877,7 @@ impl Database {
         let sql = format!(
             "SELECT t.id as todo_id, t.title, t.prompt, t.executor, \
              er.status as execution_status, er.finished_at, er.result, er.model, er.usage, \
-             er.trigger_type, er.id as record_id \
+             er.trigger_type, er.id as record_id, er.rating \
              FROM todos t \
              JOIN execution_records er ON er.id = ( \
                  SELECT er2.id FROM execution_records er2 \
@@ -936,6 +936,7 @@ impl Database {
                     execution_status,
                     trigger_type,
                     record_id,
+                    rating: row.try_get_by("rating").ok().flatten(),
                 })
             })
             .collect())

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -542,6 +542,10 @@ pub struct RecentCompletedTodo {
     pub execution_status: String,
     pub trigger_type: String,
     pub record_id: i64,
+    /// User-provided score for the most recent execution record (0-100).
+    /// Mirrors `ExecutionRecord::rating` so that the conclusion/memorial view
+    /// can render the score badge without an extra round-trip per card.
+    pub rating: Option<i32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3397,6 +3397,26 @@ code {
   color: #fff !important;
 }
 
+/* Rating badge shown in the conclusion header of each run.
+   The inline style sets the background color based on score band;
+   here we only handle sizing, spacing, and shape so the badge looks
+   consistent with the other meta chips on the card. */
+.kanban-rating-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 4px;
+  padding: 0 6px;
+  height: 18px;
+  border-radius: 9px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  flex-shrink: 0;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
 .kanban-card-section-toggle {
   font-size: 11px;
   color: var(--color-text-tertiary);

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -218,6 +218,17 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
       displayUsage = null;
     }
 
+    // Rating belongs to the ExecutionRecord, so we must surface the rating
+    // for the currently selected run — not just run 0. Each historical run
+    // lives in runDataCache; the latest run may also be cached under
+    // todoExecutionRecord when available from the store.
+    let displayRating: number | null | undefined;
+    if (runIdx === 0) {
+      displayRating = todoExecutionRecord?.rating;
+    } else if (cachedRun) {
+      displayRating = cachedRun.rating;
+    }
+
     const isLoadingResult = cache.loadingResults.has(todo.id);
     const isLoadingRun = cache.loadingRunIndex[todo.id] != null && cache.loadingRunIndex[todo.id] === runIdx && runIdx > 0;
     const runCount = cache.totalRunsCache[todo.id] ?? (isFinished ? 1 : 0);
@@ -254,6 +265,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
           selectedRun={runIdx}
           onSelectRun={(index) => cache.handleSelectRun(todo.id, index)}
           isLoadingRun={isLoadingRun}
+          rating={displayRating}
         />
       </div>
     );

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -291,6 +291,18 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
       displayUsage = null;
     }
 
+    // Rating belongs to the ExecutionRecord, so each historical run lives in
+    // runDataCache with its own score. For the latest run we fall back to the
+    // `item.rating` field that the recent-completed endpoint now returns.
+    let displayRating: number | null | undefined;
+    if (runIdx === 0) {
+      displayRating = item.rating;
+    } else if (cachedRun) {
+      displayRating = cachedRun.rating;
+    } else {
+      displayRating = null;
+    }
+
     const isLoadingRun = loadingRunIndex[item.todo_id] != null && loadingRunIndex[item.todo_id] === runIdx && runIdx > 0;
     const runCount = totalRunsCache[item.todo_id] ?? 1;
 
@@ -328,6 +340,7 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
           selectedRun={runIdx}
           onSelectRun={(index) => handleSelectRun(item.todo_id, index)}
           isLoadingRun={isLoadingRun}
+          rating={displayRating}
         />
       </Card>
     );

--- a/frontend/src/components/TodoCard.tsx
+++ b/frontend/src/components/TodoCard.tsx
@@ -78,6 +78,26 @@ export interface TodoCardProps {
   selectedRun?: number; // 0-based, default 0 (most recent)
   onSelectRun?: (index: number) => void;
   isLoadingRun?: boolean;
+
+  /** Score (0-100) for the currently displayed run. Null/undefined = no rating yet. */
+  rating?: number | null;
+}
+
+/* ─── Rating helpers ─── */
+
+/**
+ * Map a 0-100 score to a semantic color used for the rating badge.
+ * Bands:
+ *   >= 80 → green (good)
+ *   >= 60 → blue (ok)
+ *   >= 40 → orange (warn)
+ *   <  40 → red (bad)
+ */
+function ratingColor(score: number): string {
+  if (score >= 80) return '#22c55e';
+  if (score >= 60) return '#3b82f6';
+  if (score >= 40) return '#f59e0b';
+  return '#ef4444';
 }
 
 /* ─── Component ─── */
@@ -106,6 +126,7 @@ export const TodoCard = memo(function TodoCard({
   selectedRun = 0,
   onSelectRun,
   isLoadingRun,
+  rating,
 }: TodoCardProps) {
   return (
     <>
@@ -206,6 +227,16 @@ export const TodoCard = memo(function TodoCard({
               onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); onToggleResult(); } }}
             >
               <span className="kanban-card-section-label"><FileProtectOutlined /> 结论</span>
+              {rating != null && (
+                <span
+                  className="kanban-rating-badge"
+                  style={{ backgroundColor: ratingColor(rating), color: '#fff' }}
+                  title={`评分 ${rating}/100`}
+                  onClick={e => e.stopPropagation()}
+                >
+                  ★ {rating}
+                </span>
+              )}
               {runCount != null && runCount > 1 && (
                 <span className="kanban-run-tags" onClick={e => e.stopPropagation()}>
                   {Array.from({ length: Math.min(runCount, 5) }, (_, i) => (

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -329,4 +329,6 @@ export interface RecentCompletedTodo {
   execution_status: string;
   trigger_type: string;
   record_id: number;
+  /** User-provided score for the most recent execution record (0-100). */
+  rating?: number | null;
 }


### PR DESCRIPTION
## 背景

看板卡片（KanbanBoard）目前在每个卡片的"结论"区只显示结论文本、使用量（token/cost/duration）和触发器徽章，但不显示评分。评分（rating）字段已在 `ExecutionRecord` 上存在，并被 hook 的评分门（rating gate）等下游功能使用，但在前端看板中完全不可见，导致用户难以直观比较不同任务或同一任务多次重跑（run）的质量。

## 变更

- **`TodoCard.tsx`**
  - 新增 `rating?: number | null` 入参。
  - 在"结论"区 header 渲染一个胶囊状徽章：`★ <score>`。
  - 新增 `ratingColor(score)` 工具函数，按分数段返回颜色：
    - ≥80 → 绿（好）
    - ≥60 → 蓝（一般）
    - ≥40 → 橙（警告）
    - <40 → 红（差）
  - `rating === null/undefined` 时不渲染徽章，避免噪音。

- **`KanbanBoard.tsx`**
  - 在 render 路径中提取 `displayRating`：当前 runIdx 对应 ExecutionRecord 的 rating 字段（最新 run 来自 `todoExecutionRecord`，历史 run 来自 `runDataCache[runIdx]`），确保切换 run 时展示对应 run 的评分。
  - 把 `displayRating` 透传给 `TodoCard`。

- **`App.css`**
  - 新增 `.kanban-rating-badge` 样式（高度 18px，圆角胶囊，字号 11，加粗，颜色由内联 style 提供以便按分数段着色）。

## 验证

通过 Playwright 端到端校验：

| 检查项 | 结果 |
|---|---|
| 评分徽章渲染 | ✅ 4/19 张卡片显示（其余未评分） |
| 颜色映射 | ✅ 30→红、62→蓝、100→绿，全部命中 |
| 位置（紧邻"结论"标签） | ✅ |
| 切换 run 时评分同步 | ✅ 同卡 run 1 显示 ★30，run 2 显示 ★35 |
| 深色模式 | ✅ 颜色一致 |
| TS 类型检查 | ✅ 无错误 |
| 运行时报错 | 0 |

## 风险

- 仅前端新增展示，无后端/数据契约变更。
- 徽章使用内联 background-color，避免主题变量在多色场景下维护负担。
- 未评分卡片保持原样，向后兼容。

---

## 后续提交：结论视图同步

把看板视图的评分徽章能力扩展到 MemorialBoard 的"结论视图"，确保两个视图行为一致。

### 变更

- **后端**
  - `models::RecentCompletedTodo`：新增 `rating: Option<i32>` 字段。
  - `db::todo::get_recent_completed_todos`：SQL 增加 `SELECT er.rating`，并在结果映射中填充新字段。这样无需为每张卡片额外请求执行记录详情，前端就能直接拿到最近一次运行的评分。

- **前端**
  - `types/stats.ts`：`RecentCompletedTodo` 增加可选 `rating`。
  - `components/MemorialBoard.tsx`：按当前 run 提取 `displayRating`（run 0 走 `item.rating`，历史 run 走 `runDataCache[runIdx].rating`），并透传给 `TodoCard`。逻辑与 `KanbanBoard` 完全对称。

### 验证（Playwright on dev:18088）

| 检查项 | 结果 |
|---|---|
| 纪念板卡片数 | 14 |
| 评分徽章数 | 4（其余未评分正确隐藏） |
| 颜色映射 | ✅ 25→红、62→蓝、100→绿 |
| 位置（"结论"标签旁） | ✅ |
| 深色模式 | ✅ 4 枚徽章，无运行时报错 |
| TS 类型检查 | ✅ 无错误 |
| 后端 `cargo check` | ✅ 通过（仅有与本次无关的既有 warning） |
