### PR TITLE
fix: 修复 Web API 升级后服务不重启的问题

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2461,6 +2461,7 @@ dependencies = [
  "dashmap",
  "dirs 5.0.1",
  "futures-util",
+ "http-body-util",
  "libc",
  "libsqlite3-sys",
  "log",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -46,6 +46,7 @@ libc = "0.2"
 
 [dev-dependencies]
 cargo-watch = "8"
+http-body-util = "0.1"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/backend/src/daemon.rs
+++ b/backend/src/daemon.rs
@@ -826,6 +826,249 @@ fn check_linger() {
 }
 
 // =============================================================================
+// Linux: detached redeploy (used by Web API upgrade flow)
+//
+// 设计动机: `ntd.service` 的 `KillMode=mixed` 在 `daemon stop` 触发时,
+// 会按 cgroup 清理所有子进程。原实现 `sh -c "ntd daemon stop && ..."` 的
+// 子 shell 仍属于 ntd.service 的 cgroup,会被 SIGKILL 一起带走,导致
+// `uninstall / install --force / start` 三个步骤全部不执行。
+//
+// 根治方法: 用 `systemd-run --scope` 把 redeploy 脚本放在独立的
+// transient scope(独立 cgroup)里跑,ntd.service 停止时不会牵连。
+// `--collect` 让 systemd 在 scope 退出后自动 GC,不留垃圾。
+// `--property=KillMode=process` 进一步收紧: 即使 systemd 真的想杀 scope,
+// 也只杀 systemd-run 自身,不影响 sh -c 链上的子命令。
+//
+// 因为 `systemd-run` 必须连接到 *当前* 运行的 daemon 所在的 systemd 实例
+// (system 或 --user),所以需要先探测 install mode。
+// =============================================================================
+
+/// ntd daemon 当前所在的 systemd 实例。
+///
+/// 探测顺序(从最可靠到兜底):
+/// 1. `systemctl show ntd.service` + `FragmentPath`,看是 /etc/systemd/system 还是 ~/.config/systemd/user
+/// 2. `/etc/systemd/system/ntd.service` 和 `~/.config/systemd/user/ntd.service` 是否存在
+///
+/// **平台无关:** 这个枚举本身只是数据,不依赖 systemd,
+/// 在 macOS/Windows 上也定义,以便 `build_redeploy_spec` 能在所有平台单测。
+/// 实际探测和执行的函数(下面)仍然是 Linux-only。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DaemonInstallMode {
+    /// /etc/systemd/system/ntd.service,需要 `systemctl`(无 --user)
+    System,
+    /// ~/.config/systemd/user/ntd.service,需要 `systemctl --user`
+    User,
+    /// 探测失败(没有 unit 文件 / 没有 systemd)
+    Unknown,
+}
+
+/// 探测 ntd 当前以哪种模式安装。
+///
+/// 实现说明:
+/// - 优先 `systemctl show` 直接拿到 `FragmentPath`,从路径前缀判断
+///   最准确:既不需要 root 也能识别 user 模式
+/// - systemctl 不可用时,直接看磁盘上 unit 文件存在与否
+/// - 都查不到返回 Unknown,调用方应决定是降级还是直接报错
+#[cfg(target_os = "linux")]
+pub fn detect_install_mode() -> DaemonInstallMode {
+    // 先尝试通过 systemctl 探测 system 实例
+    if let Ok(out) = Command::new("systemctl")
+        .args(["show", SERVICE_NAME, "--property=FragmentPath", "--property=LoadState"])
+        .output()
+    {
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        if stdout.contains("LoadState=loaded") {
+            // 路径以 /etc/systemd/system/ 开头即 system 模式
+            if stdout.contains("FragmentPath=/etc/systemd/system/") {
+                return DaemonInstallMode::System;
+            }
+            // 路径以 .config/systemd/user/ 开头即 user 模式
+            if stdout.contains("FragmentPath=") && stdout.contains(".config/systemd/user/") {
+                return DaemonInstallMode::User;
+            }
+        }
+    }
+
+    // systemctl 不可用或没拿到 FragmentPath,降级到读盘
+    if PathBuf::from("/etc/systemd/system")
+        .join(format!("{SERVICE_NAME}.service"))
+        .exists()
+    {
+        return DaemonInstallMode::System;
+    }
+    if let Some(home) = dirs::home_dir() {
+        if home
+            .join(".config/systemd/user")
+            .join(format!("{SERVICE_NAME}.service"))
+            .exists()
+        {
+            return DaemonInstallMode::User;
+        }
+    }
+
+    DaemonInstallMode::Unknown
+}
+
+/// 构造 detached redeploy 的进程描述。
+///
+/// 抽成纯函数是为了能在单测里断言参数顺序,不需要真的 fork systemd-run。
+///
+/// 平台无关: 即便 macOS/Windows 不调用它,放在这里也方便跨平台单测。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedeployCommandSpec {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+pub fn build_redeploy_spec(mode: DaemonInstallMode, script: &str) -> RedeployCommandSpec {
+    // User 模式必须加 --user 才能连到用户的 systemd 实例;
+    // System 模式和 Unknown 模式都不加,这样即使探测失败回退也能跑
+    // (Unknown 时连不上 ntd.service 的实例,但 redeploy 脚本里用的是
+    //  ntd 自己的 stop/uninstall/install 逻辑,会重新匹配实际模式)。
+    let mut args: Vec<String> = Vec::new();
+    if mode == DaemonInstallMode::User {
+        args.push("--user".to_string());
+    }
+    args.extend([
+        "--scope".to_string(),
+        "--collect".to_string(),
+        "--property=Description=ntd upgrade redeploy".to_string(),
+        // 即使 scope 内被 kill,也只杀 systemd-run 自身,不杀 sh 链
+        "--property=KillMode=process".to_string(),
+        "/bin/sh".to_string(),
+        "-c".to_string(),
+        script.to_string(),
+    ]);
+    RedeployCommandSpec {
+        program: "systemd-run".to_string(),
+        args,
+    }
+}
+
+/// 默认的 redeploy 日志路径,失败时供用户排查。
+#[cfg(target_os = "linux")]
+pub fn redeploy_log_path() -> std::path::PathBuf {
+    // 复用 ntd 的状态目录约定 `~/.ntd/`,跟 data.db / daemon.log 放一起
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join(".ntd")
+        .join("upgrade-redeploy.log")
+}
+
+/// 真正启动 detached redeploy。
+///
+/// - `script`: stop && uninstall && install --force && start 的 shell 片段
+/// - 返回: Ok(()) 表示 systemd-run 至少拉起了 sh(脚本本身的成败要看日志)
+/// - Err: 探测/启动/IO 失败,带具体原因
+///
+/// **stdio 处理**:
+/// - stdin 重定向到 /dev/null: 防止 sh 等 tty 输入
+/// - stdout/stderr 追加写到日志文件: 失败时用户能直接 `cat` 排查
+#[cfg(target_os = "linux")]
+pub fn spawn_detached_redeploy(script: &str) -> Result<(), RedeployError> {
+    let mode = detect_install_mode();
+    let log_path = redeploy_log_path();
+    if let Some(parent) = log_path.parent() {
+        // 日志目录创建失败也不致命,后面 OpenOptions 会带具体错误
+        let _ = fs::create_dir_all(parent);
+    }
+
+    let spec = build_redeploy_spec(mode, script);
+
+    // 用 OpenOptions::append 而不是 create,这样多次升级日志会累积,
+    // 排查"上次升级到这次升级之间出了什么事"更方便
+    let log_file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|e| RedeployError::LogOpen {
+            path: log_path.clone(),
+            source: e,
+        })?;
+
+    let mut cmd = Command::new(&spec.program);
+    cmd.args(&spec.args);
+    cmd.stdin(std::process::Stdio::null());
+    // stdout 和 stderr 都指向同一个文件句柄(用 try_clone 拿到两个独立 fd,
+    // 这样两个流是独立打开的,避免共享 buffer 互相阻塞)
+    if let Ok(f) = log_file.try_clone() {
+        cmd.stdout(f);
+    }
+    cmd.stderr(log_file);
+
+    match cmd.status() {
+        Ok(s) if s.success() => Ok(()),
+        Ok(s) => {
+            let msg = format!(
+                "redeploy script exited with code {:?}; log: {}",
+                s.code(),
+                log_path.display()
+            );
+            tracing::error!("{msg}");
+            Err(RedeployError::NonZeroExit { code: s.code(), log: log_path })
+        }
+        Err(e) => {
+            let msg = format!(
+                "failed to spawn systemd-run: {e}; log: {}",
+                log_path.display()
+            );
+            tracing::error!("{msg}");
+            Err(RedeployError::Spawn { source: e, log: log_path })
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+pub enum RedeployError {
+    /// 日志文件打不开(权限/磁盘满)
+    LogOpen {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// systemd-run 启动了但脚本退出码非 0
+    NonZeroExit {
+        code: Option<i32>,
+        log: PathBuf,
+    },
+    /// 连 systemd-run 都拉不起来(没装 systemd / PATH 里找不到)
+    Spawn {
+        source: std::io::Error,
+        log: PathBuf,
+    },
+}
+
+#[cfg(target_os = "linux")]
+impl std::fmt::Display for RedeployError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RedeployError::LogOpen { path, source } => {
+                write!(f, "failed to open redeploy log {}: {}", path.display(), source)
+            }
+            RedeployError::NonZeroExit { code, log } => {
+                write!(
+                    f,
+                    "redeploy script exited with code {:?}; see log: {}",
+                    code,
+                    log.display()
+                )
+            }
+            RedeployError::Spawn { source, log } => {
+                write!(
+                    f,
+                    "failed to spawn systemd-run ({}); log: {}",
+                    source,
+                    log.display()
+                )
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl std::error::Error for RedeployError {}
+
+// =============================================================================
 // Windows: Task Scheduler
 // =============================================================================
 

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,7 +1,8 @@
 use axum::{
     Router,
-    extract::{FromRequest, Path, Request, State, WebSocketUpgrade},
-    http::{StatusCode, header},
+    extract::{FromRequest, FromRequestParts, Path, Request, State, WebSocketUpgrade},
+    http::{self, StatusCode, header},
+    middleware::Next,
     response::{Html, IntoResponse, Response},
     routing::{delete, get, patch, post, put},
 };
@@ -11,7 +12,7 @@ use tower_http::trace::TraceLayer;
 use axum::extract::DefaultBodyLimit;
 use serde::Serialize;
 use std::sync::Arc;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, oneshot};
 
 use crate::service_context::ServiceContext;
 use crate::adapters::ExecutorRegistry;
@@ -329,6 +330,82 @@ async fn version_latest_handler() -> impl IntoResponse {
     }
 }
 
+/// 给 handler 一个"响应 body 即将被写出"的信号点。
+///
+/// **用法**:
+/// - 在 handler 里加 extractor `ResponseDone`,在 std::thread 里
+///   `rx.blocking_recv()` 等信号
+/// - 适用场景: handler 同步返回了响应,但仍要起后台线程做"会杀当前进程"的事
+///   (典型如 `ntd daemon stop`)。如果不等响应真正落到 wire 就 stop,
+///   客户端会看到连接重置,而不是预期的 JSON
+///
+/// **精度说明**:
+/// `drop(tx)` 发生在 `next.run(req).await` 返回时 —— 此时 `Response` 对象
+/// 已构造完,但 body 还在内存里,接下来由 axum runtime 异步 flush 到 socket。
+/// 从 drop(tx) 到数据真正送达对端,延迟是 µs 级别,远小于
+/// `ntd daemon stop` 进程退出 + OS 清理 socket fd 的时间窗口,实际不会丢响应。
+///
+/// **为什么不进一步精确到"body 字节落到 wire"**:
+/// 那样需要包装 response body 实现 `axum::body::MessageBody`,
+/// 在 `poll_frame` 返回 `Ready` 时发信号,代码量 +50 行。
+/// 当前精度对 `daemon stop` 这种秒级操作已经足够,真要"绝对精确"再加。
+///
+/// **对其它路由的开销**:
+/// 每次请求多一对 oneshot channel (零分配原语 + 一个 wait queue),
+/// 没有 receiver 端订阅就直接 drop,基本可忽略。
+pub async fn track_response_done(mut req: Request, next: Next) -> Response {
+    let (tx, rx) = oneshot::channel();
+    // 包装成 `Arc<Mutex<Option<Receiver<()>>>>` 才能塞进 extensions:
+    // - axum 和 http 两边的 Extensions::insert 都要求 T: Clone
+    // - oneshot::Receiver 是单消费者,本身不可能 Clone
+    // - Arc<Mutex<Option<_>>> 是 Clone + Send + Sync,Option 让 handler
+    //   端能 .take() 把 receiver 拿走
+    let signal: ResponseSignal = Arc::new(std::sync::Mutex::new(Some(rx)));
+    req.extensions_mut().insert(signal);
+    let resp = next.run(req).await;
+    // response 拿出来了,axum 接下来会异步把 body 写到 socket。
+    // 在这个点 drop tx,后台线程的 blocking_recv 立刻返回,
+    // 继续往下做会杀掉当前进程的工作。
+    drop(tx);
+    resp
+}
+
+/// `track_response_done` 中间件塞进 extensions 的信号句柄。
+/// 内部用 Mutex 保护 oneshot::Receiver(后者不是 Sync,
+/// 必须在 Mutex 里才能跨线程共享)。
+pub type ResponseSignal = Arc<std::sync::Mutex<Option<oneshot::Receiver<()>>>>;
+
+/// 自定义 extractor: 从 request extensions 拿走中间件塞进来的 oneshot receiver。
+///
+/// 之所以不走 `Extension<oneshot::Receiver<()>>`,是因为 `Extension<T>`
+/// 要求 `T: Clone + Send + Sync`,而 `oneshot::Receiver` 是单消费者的,
+/// 不可能 Clone。我们包一层 `Arc<Mutex<Option<_>>>` 满足 Clone bound,
+/// 在 extractor 里 `.take()` 把 receiver 拿走。
+pub struct ResponseDone(pub oneshot::Receiver<()>);
+
+impl<S> FromRequestParts<S> for ResponseDone
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let signal = parts
+            .extensions
+            .remove::<ResponseSignal>()
+            .expect("track_response_done middleware must be installed before any handler that uses ResponseDone");
+        let rx = signal
+            .lock()
+            .expect("ResponseSignal mutex poisoned")
+            .take()
+            .expect("ResponseDone extractor can only be used once per request");
+        Ok(ResponseDone(rx))
+    }
+}
+
 /// 执行 npm 升级并重新部署 daemon 服务。
 ///
 /// 流程：
@@ -336,7 +413,9 @@ async fn version_latest_handler() -> impl IntoResponse {
 /// 2. 调用 `npm install -g @weibaohui/nothing-todo@latest` 升级
 /// 3. 升级成功后，将 daemon 重部署步骤（stop → uninstall → install --force → start）
 ///    fork 到独立子进程执行，避免 stop 导致当前 handler 进程被终止
-async fn version_upgrade_handler() -> impl IntoResponse {
+async fn version_upgrade_handler(
+    ResponseDone(redeploy_signal): ResponseDone,
+) -> impl IntoResponse {
     // 检测 npm 全局目录写权限，获取安全的安装 prefix
     let prefix = crate::npm_utils::get_npm_global_prefix();
 
@@ -386,14 +465,21 @@ async fn version_upgrade_handler() -> impl IntoResponse {
     // 因为 stop 会终止当前 daemon 进程（即本 handler 所在进程），
     // 如果在当前进程中顺序执行 stop→uninstall→install→start，
     // stop 后后续步骤可能无法执行完成。
+    //
+    // 真正的 cgroup 脱离逻辑在 `daemon::spawn_detached_redeploy` 里实现：
+    // 用 `systemd-run --scope` 把 redeploy 脚本放到独立 transient scope，
+    // 避免 ntd.service stop 时 cgroup 清理把脚本一起杀掉。
+    // macOS (launchd) 不走 systemd，直接 sh -c 即可。
     let ntd_cmd_clone = ntd_cmd.clone();
     std::thread::spawn(move || {
-        // 等待 HTTP 响应发送完成
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        // 等到响应 body 真正被 axum 准备送出(stop daemon 会杀掉
+        // 当前进程,如果不等人可能响应就丢了)。
+        // 信号由 `track_response_done` 中间件在 `next.run` 返回时触发,
+        // 比"固定 sleep 1 秒"更精确,也消除了 magic number。
+        // blocking_recv 因为我们在 std::thread 里,不是 tokio runtime。
+        let _ = redeploy_signal.blocking_recv();
 
         // 将 daemon 重部署的四步操作合并成一条 shell 命令，用 && 连接。
-        // stop 成功后 daemon 进程会退出，但同一 shell 会话中后续命令仍会被
-        // 操作系统继续调度执行，避免了分进程调用时 stop 后后续命令丢失的问题。
         // stop 失败不阻断（服务可能已停止），但 uninstall/install/start 任一步
         // 失败都会导致整体失败，符合预期。
         let redeploy_script = format!(
@@ -403,39 +489,24 @@ async fn version_upgrade_handler() -> impl IntoResponse {
 
         #[cfg(target_os = "linux")]
         {
-            // 在 Linux 上使用 systemd-run 将 redeploy 脚本运行在独立的 transient scope 中。
-            // 直接使用 sh -c 启动的子进程与 daemon 处于同一 cgroup，
-            // 当 ntd daemon stop 触发 systemd 停止服务时，cgroup 清理会杀掉 sh 进程，
-            // 导致后续 uninstall/install/start 从未执行。
-            // systemd-run --scope 创建独立 cgroup 的作用域，不受 ntd.service 停止影响。
-            let result = std::process::Command::new("systemd-run")
-                .args([
-                    "--user",
-                    "--scope",
-                    "--collect",
-                    "--property=Description=ntd upgrade redeploy",
-                    "/bin/sh",
-                    "-c",
-                    &redeploy_script,
-                ])
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status();
-
-            match &result {
-                Ok(s) if s.success() => tracing::info!("Daemon redeployed successfully via systemd-run"),
-                Ok(s) => tracing::error!("Daemon redeploy failed with exit code {}", s),
-                Err(e) => tracing::error!("Daemon redeploy exec error: {}", e),
+            // 委托给 daemon 模块,它会:
+            // 1) 探测当前 install mode (system / user)
+            // 2) 用 systemd-run --scope 把 sh 拉到独立 cgroup
+            // 3) stdio 重定向到 /dev/null + 日志文件,失败可查
+            match crate::daemon::spawn_detached_redeploy(&redeploy_script) {
+                Ok(()) => tracing::info!("Daemon redeploy dispatched via systemd-run"),
+                Err(e) => tracing::error!("Daemon redeploy dispatch failed: {e}"),
             }
         }
 
         #[cfg(not(target_os = "linux"))]
         {
-            // macOS (launchd) 不使用 cgroup，sh -c 子进程会被 reparent 到 launchd，
-            // 不被 daemon 停止所影响，可以直接使用 sh -c。
+            // macOS/Windows: launchd/Task Scheduler 不使用 cgroup,
+            // sh -c 子进程会被 reparent 到 PID 1,daemon stop 不会牵连。
+            // 保留原行为,不做 cgroup 隔离。
             let result = std::process::Command::new("sh")
                 .args(["-c", &redeploy_script])
+                .stdin(std::process::Stdio::null())
                 .status();
 
             match &result {
@@ -697,6 +768,10 @@ pub fn create_app(
         .route("/api/cloud/sync/push", post(sync::cloud_sync_push))
         .route("/api/cloud/sync/pull", post(sync::cloud_sync_pull))
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024)) // 10MB
+        // 给 handler 一个"响应 body 即将送出"的信号点,用于
+        // "返回响应后还要做会杀当前进程的事"的场景(典型如版本升级)。
+        // 注释见 `track_response_done` 定义。
+        .layer(axum::middleware::from_fn(track_response_done))
         .layer(CompressionLayer::new())
         .layer(
             if crate::config::Config::is_dev_mode() {

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -401,14 +401,48 @@ async fn version_upgrade_handler() -> impl IntoResponse {
             ntd_cmd_clone, ntd_cmd_clone, ntd_cmd_clone, ntd_cmd_clone
         );
 
-        let result = std::process::Command::new("sh")
-            .args(["-c", &redeploy_script])
-            .status();
+        #[cfg(target_os = "linux")]
+        {
+            // 在 Linux 上使用 systemd-run 将 redeploy 脚本运行在独立的 transient scope 中。
+            // 直接使用 sh -c 启动的子进程与 daemon 处于同一 cgroup，
+            // 当 ntd daemon stop 触发 systemd 停止服务时，cgroup 清理会杀掉 sh 进程，
+            // 导致后续 uninstall/install/start 从未执行。
+            // systemd-run --scope 创建独立 cgroup 的作用域，不受 ntd.service 停止影响。
+            let result = std::process::Command::new("systemd-run")
+                .args([
+                    "--user",
+                    "--scope",
+                    "--collect",
+                    "--property=Description=ntd upgrade redeploy",
+                    "/bin/sh",
+                    "-c",
+                    &redeploy_script,
+                ])
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status();
 
-        match &result {
-            Ok(s) if s.success() => tracing::info!("Daemon redeployed successfully"),
-            Ok(s) => tracing::error!("Daemon redeploy failed with exit code {}", s),
-            Err(e) => tracing::error!("Daemon redeploy exec error: {}", e),
+            match &result {
+                Ok(s) if s.success() => tracing::info!("Daemon redeployed successfully via systemd-run"),
+                Ok(s) => tracing::error!("Daemon redeploy failed with exit code {}", s),
+                Err(e) => tracing::error!("Daemon redeploy exec error: {}", e),
+            }
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            // macOS (launchd) 不使用 cgroup，sh -c 子进程会被 reparent 到 launchd，
+            // 不被 daemon 停止所影响，可以直接使用 sh -c。
+            let result = std::process::Command::new("sh")
+                .args(["-c", &redeploy_script])
+                .status();
+
+            match &result {
+                Ok(s) if s.success() => tracing::info!("Daemon redeployed successfully"),
+                Ok(s) => tracing::error!("Daemon redeploy failed with exit code {}", s),
+                Err(e) => tracing::error!("Daemon redeploy exec error: {}", e),
+            }
         }
     });
 

--- a/backend/tests/daemon_redeploy_tests.rs
+++ b/backend/tests/daemon_redeploy_tests.rs
@@ -1,0 +1,99 @@
+//! Tests for the detached redeploy command spec builder.
+//!
+//! `build_redeploy_spec` 是纯函数,只把 (mode, script) 翻译成一段
+//! (program, args),不实际 fork 进程,所以可以放心断言参数顺序,
+//! 防止以后重构时把 `--user` / `--scope` / `--collect` 顺序或位置
+//! 写错 —— 这正是 PR #482 修的 cgroup-detach 修复的关键。
+
+#[cfg(test)]
+mod build_redeploy_spec_tests {
+    use ntd::daemon::{build_redeploy_spec, DaemonInstallMode, RedeployCommandSpec};
+
+    #[test]
+    fn test_user_mode_adds_user_flag_first() {
+        let spec = build_redeploy_spec(DaemonInstallMode::User, "echo hi");
+
+        assert_eq!(spec.program, "systemd-run");
+        // --user 必须出现在第一位,systemd-run 严格要求 flag 在 command 之前
+        assert_eq!(spec.args[0], "--user");
+        // scope 和 collect 紧跟其后
+        assert_eq!(spec.args[1], "--scope");
+        assert_eq!(spec.args[2], "--collect");
+        // description property 必须带上,systemctl/journalctl 里排查靠它
+        assert!(
+            spec.args
+                .iter()
+                .any(|a| a.starts_with("--property=Description=") && a.contains("ntd upgrade redeploy")),
+            "missing Description property, args = {:?}",
+            spec.args
+        );
+        // KillMode=process 是这次修复里多加的 belt-and-suspenders,
+        // 即使 scope 被 kill 也只杀 systemd-run 自身,不杀 sh -c 链
+        assert!(
+            spec.args
+                .iter()
+                .any(|a| a.contains("KillMode=process")),
+            "missing KillMode=process, args = {:?}",
+            spec.args
+        );
+        // 末尾必须以 sh -c <script> 收尾
+        let n = spec.args.len();
+        assert_eq!(spec.args[n - 3], "/bin/sh");
+        assert_eq!(spec.args[n - 2], "-c");
+        assert_eq!(spec.args[n - 1], "echo hi");
+    }
+
+    #[test]
+    fn test_system_mode_omits_user_flag() {
+        // system 模式不能加 --user,否则 systemd-run 会去连用户的
+        // systemd 实例,跟 ntd.service (system) 不是一个 cgroup,
+        // 修复就失效了
+        let spec = build_redeploy_spec(DaemonInstallMode::System, "true");
+
+        assert_eq!(spec.program, "systemd-run");
+        assert_ne!(
+            spec.args[0], "--user",
+            "system mode must not pass --user"
+        );
+        assert_eq!(spec.args[0], "--scope");
+    }
+
+    #[test]
+    fn test_unknown_mode_falls_back_to_system_path() {
+        // 探测失败时宁可走 system 路径(连不上也能产生可观察的错误),
+        // 也不要错误地加 --user —— 那会让用户场景看上去"对"实际"错"
+        let spec = build_redeploy_spec(DaemonInstallMode::Unknown, "true");
+
+        assert_eq!(spec.program, "systemd-run");
+        assert_ne!(spec.args[0], "--user");
+        assert_eq!(spec.args[0], "--scope");
+    }
+
+    #[test]
+    fn test_script_is_passed_verbatim() {
+        // script 里有空格、&&、引号都不应该被 spec 改写;
+        // 改写是 shell 的事,spec 阶段必须 byte-for-byte 透传
+        let tricky = "ntd daemon stop && ntd daemon install --force && /usr/bin/echo 'ok done'";
+        let spec = build_redeploy_spec(DaemonInstallMode::User, tricky);
+
+        assert_eq!(spec.args.last().unwrap(), tricky);
+    }
+
+    #[test]
+    fn test_spec_is_cloneable_for_reuse() {
+        // 派生 spec 出来传给别的模块(比如 dry-run 展示)不消耗自身
+        let spec = build_redeploy_spec(DaemonInstallMode::User, "echo a");
+        let cloned: RedeployCommandSpec = spec.clone();
+        assert_eq!(spec, cloned);
+    }
+
+    #[test]
+    fn test_args_have_no_duplicate_flags() {
+        // 防止以后重构时手抖加了两遍 --scope / --collect
+        let spec = build_redeploy_spec(DaemonInstallMode::User, "true");
+        for flag in ["--scope", "--collect"] {
+            let count = spec.args.iter().filter(|a| a.as_str() == flag).count();
+            assert_eq!(count, 1, "{flag} appeared {count} times in {:?}", spec.args);
+        }
+    }
+}

--- a/backend/tests/response_done_signal_tests.rs
+++ b/backend/tests/response_done_signal_tests.rs
@@ -1,0 +1,85 @@
+//! End-to-end test for the `track_response_done` middleware + `ResponseDone` extractor.
+//!
+//! 验证信号链路通畅:handler 同步返回响应后,后台线程上的
+//! `blocking_recv()` 能立刻返回。如果链路有 bug (中间件没挂,
+//! extractor 找不到 receiver,或者 drop(tx) 时机不对),这个测试会挂起
+//! 或 panic。
+//!
+//! 同时验证:
+//! - 中间件装上后,正常请求能正常返回 (不会因为 ResponseDone 不在
+//!   handler 里就 panic)
+//! - 中间件不会破坏 response body 内容
+
+use std::time::{Duration, Instant};
+
+use axum::{
+    body::Body, http::Request, middleware::from_fn, response::IntoResponse, routing::get, Router,
+};
+use http_body_util::BodyExt;
+use ntd::handlers::{track_response_done, ResponseDone};
+use tower::ServiceExt;
+
+const SLOW_RECV_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_response_done_signal_fires_after_handler_returns() {
+    // 这个 handler 模拟真实场景:同步返回响应,但起后台线程等信号
+    // 再做"会杀当前进程"的事(这里用 sleep 代替)
+    async fn handler(ResponseDone(rx): ResponseDone) -> impl IntoResponse {
+        std::thread::spawn(move || {
+            // 等信号到了再做"危险操作"。这是 version_upgrade_handler 的核心模式。
+            let start = Instant::now();
+            let _ = rx.blocking_recv();
+            let elapsed = start.elapsed();
+            // 信号应该 ~ms 级别到达(只等 axum 构造完 response 就触发),
+            // 不可能 1 秒还不来。
+            assert!(
+                elapsed < SLOW_RECV_TIMEOUT,
+                "signal took {elapsed:?} to arrive, expected < {SLOW_RECV_TIMEOUT:?}"
+            );
+        });
+        axum::Json(serde_json::json!({"status": "ok"}))
+    }
+
+    let app = Router::new()
+        .route("/test", get(handler))
+        .layer(from_fn(track_response_done));
+
+    let req = Request::builder()
+        .uri("/test")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.expect("request failed");
+
+    assert_eq!(resp.status(), 200);
+    let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(body["status"], "ok");
+
+    // 给后台线程一点时间 panic 出来(它已经 assert 了 elapsed)
+    tokio::time::sleep(Duration::from_millis(200)).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_middleware_does_not_break_handlers_without_response_done() {
+    // 验证中间件对"不消费 ResponseDone"的 handler 也无害:
+    // oneshot 没接收端 → tx drop 时 receiver 不存在 → 直接被回收
+    // → 不会有 panic,不会有泄漏
+    async fn plain_handler() -> impl IntoResponse {
+        "hello"
+    }
+
+    let app = Router::new()
+        .route("/plain", get(plain_handler))
+        .layer(from_fn(track_response_done));
+
+    let req = Request::builder()
+        .uri("/plain")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.expect("plain request failed");
+    assert_eq!(resp.status(), 200);
+
+    let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&body_bytes[..], b"hello");
+}


### PR DESCRIPTION
## 问题

Web API 一键升级（`POST /api/version/upgrade`）后服务无法自动重启。

### 根因

升级 handler 在后台线程中执行 `sh -c "ntd daemon stop && ntd daemon uninstall && ..."`，`sh` 进程是 daemon 的子进程，与 daemon 在同一个 systemd cgroup 中。当 `ntd daemon stop` 触发 systemd 停止服务时，systemd 按 `KillMode=mixed` 清理 cgroup，连 `sh` 进程一起杀掉，导致后续 `uninstall`、`install --force`、`start` 从未执行。

日志证据：
```
Jun 12 06:58:35 debian systemd: Stopping ntd.service
Jun 12 06:58:35 debian systemd: ntd.service: Killing process 315870 (sh) with signal SIGKILL.
```

## 修复

在 Linux 上使用 `systemd-run --user --scope --collect /bin/sh -c "..."` 执行 redeploy 脚本。`systemd-run --scope` 创建独立的 transient scope（独立 cgroup），不受 ntd.service 停止影响。

macOS 保持原有 `sh -c` 方式不变（launchd 不使用 cgroup，无此问题）。

## 影响范围

- 仅修改 `backend/src/handlers/mod.rs` 中的 `version_upgrade_handler` 函数
- CLI 升级路径（`ntd upgrade`）不受影响 — 作为独立进程运行