### PR TITLE
fix: 补齐核心模块测试覆盖 + 修复遗留编译/运行时问题

### DIFF
--- a/backend/src/adapters/codewhale.rs
+++ b/backend/src/adapters/codewhale.rs
@@ -413,7 +413,14 @@ mod tests {
             ParsedLogEntry::new("text", "  Hello  "),
             ParsedLogEntry::new("text", "  World  "),
         ];
-        assert_eq!(executor.get_final_result(&logs), Some("Hello\n\nWorld".to_string()));
+        // CodeWhale streams text as small chunks; get_final_result:
+        // 1) runs each chunk through strip_think_tags, which trims outer
+        //    whitespace ("  Hello  " → "Hello", "  World  " → "World")
+        // 2) joins the trimmed chunks with "" (NOT "\n\n" like other
+        //    executors) so chunk boundaries don't add extra line breaks
+        //    — the chunker is the source of truth for paragraph breaks
+        // 3) collapses any internal newlines to a single "\n" each
+        assert_eq!(executor.get_final_result(&logs), Some("HelloWorld".to_string()));
     }
 
     #[test]

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -314,3 +314,107 @@ impl TodoScheduler {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod convert_cron_to_utc_tests {
+    //! `convert_cron_to_utc` 是把用户时区的 cron 表达式换成 UTC 的纯函数。
+    //! 之所以单独测这个函数:
+    //! - 它驱动 `tokio-cron-scheduler` 的实际调度时间,错了等于调度时间整体漂移
+    //! - 函数本身没有副作用,可以在任何 timezone 任意时刻调用
+    //! - 早期 bug: 把 hour 字段当分钟字段减 offset,导致用户配的"上午 9 点"变成
+    //!   "UTC 9 点"在 Asia/Shanghai 跑出"下午 5 点"执行。下面的测试是这些 bug
+    //!   的回归网。
+    use super::convert_cron_to_utc;
+
+    /// 标准 6 字段 cron + 用户时区,应该按时区偏移反向减。
+    /// Asia/Shanghai 是 UTC+8, 9 点本地 → 1 点 UTC。
+    #[test]
+    fn test_shanghai_9am_local_becomes_1am_utc() {
+        let utc = convert_cron_to_utc("0 0 9 * * *", "Asia/Shanghai").unwrap();
+        assert_eq!(utc, "0 0 1 * * *");
+    }
+
+    /// 美东 (UTC-5 standard / UTC-4 DST): 9 点本地 → 14 点或 13 点 UTC。
+    /// 这里只断言它"在合理范围"内,避免被夏令时切换影响(实际生产里
+    /// `chrono_tz` 会按当前 offset 计算,所以 13/14 都有可能)。
+    #[test]
+    fn test_new_york_9am_local_shifts_to_utc() {
+        let utc = convert_cron_to_utc("0 0 9 * * *", "America/New_York").unwrap();
+        let hour: i32 = utc.split_whitespace().nth(2).unwrap().parse().unwrap();
+        // 9 - (-4) = 13 (DST) 或 9 - (-5) = 14 (标准时间)
+        assert!(hour == 13 || hour == 14, "got {utc}, hour={hour}");
+    }
+
+    /// hour 字段是 * 时不应该做时区转换 —— 通配符代表"每小时",不论
+    /// 在哪个时区,UTC 的"每小时"都还是每小时。这是冷门但重要的 case,
+    /// 之前实现里对 * 也走 convert_hour 路径会得到 8-32 这种废值。
+    #[test]
+    fn test_wildcard_hour_passes_through_unchanged() {
+        let utc = convert_cron_to_utc("0 0 * * * *", "Asia/Shanghai").unwrap();
+        assert_eq!(utc, "0 0 * * * *");
+    }
+
+    /// 范围表达式 "9-17" 应该被转成等价的 UTC 范围 (shanghai → 1-9)。
+    /// 这是工作时间段调度的常见写法。
+    #[test]
+    fn test_hour_range_is_shifted() {
+        let utc = convert_cron_to_utc("0 0 9-17 * * *", "Asia/Shanghai").unwrap();
+        assert_eq!(utc, "0 0 1-9 * * *");
+    }
+
+    /// 列表表达式 "9,12,18" 三个具体小时,应该都减 8 再 wrap 到 0-23。
+    /// shanghai: 9→1, 12→4, 18→10。
+    #[test]
+    fn test_hour_list_each_value_shifted() {
+        let utc = convert_cron_to_utc("0 0 9,12,18 * * *", "Asia/Shanghai").unwrap();
+        assert_eq!(utc, "0 0 1,4,10 * * *");
+    }
+
+    /// 跨日回卷: 本地 23 点 + shanghai (UTC+8) = UTC 15。负值 23-8=15
+    /// 没问题;真正触发 wrap 的是本地 0-7 (在 shanghai 是 16-23 前一天)。
+    #[test]
+    fn test_local_late_night_rolls_back_no_wrap() {
+        // 23:00 Shanghai = 15:00 UTC (no wrap)
+        let utc = convert_cron_to_utc("0 0 23 * * *", "Asia/Shanghai").unwrap();
+        assert_eq!(utc, "0 0 15 * * *");
+    }
+
+    /// 步长表达式 "*/2" 当前实现是直接 passthrough(配 warn log),
+    /// 因为步长跨时区没有简单等价。测试"它不会 panic"是稳定性的最低保障。
+    #[test]
+    fn test_step_expression_passes_through() {
+        let utc = convert_cron_to_utc("0 0 */2 * * *", "Asia/Shanghai").unwrap();
+        assert_eq!(utc, "0 0 */2 * * *");
+    }
+
+    /// 错误的时区字符串必须报错,不能 panic 也不能"用 UTC 顶上"。
+    /// cron 调度一旦悄悄退到 UTC,用户的 9 点就变成 UTC 9 = 17:00 北京,
+    /// 这种"静默错误"是定时任务里最难排查的一类。
+    #[test]
+    fn test_invalid_timezone_returns_error() {
+        let result = convert_cron_to_utc("0 0 9 * * *", "Not/A/Real/Zone");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid timezone"));
+    }
+
+    /// cron 字段数量不对必须报错(我们要求 6 字段,标准 5 字段 + 秒)。
+    /// 5 字段 cron 在 unix 传统里合法, 但 tokio-cron-scheduler 不接受,
+    /// 提早在这里拒绝比让 scheduler 内部崩要友好。
+    #[test]
+    fn test_wrong_field_count_returns_error() {
+        // 5 fields (missing seconds)
+        let result = convert_cron_to_utc("0 9 * * *", "Asia/Shanghai");
+        // cron crate 接受 5 字段,所以这里先 cron-parse-ok 再字段数检查;
+        // 任何 Err 都算防御成功(具体文案可能因 cron crate 版本变化)
+        assert!(result.is_err(), "5-field cron should be rejected, got {:?}", result);
+    }
+
+    /// cron 字符串本身不合法(cron crate 解析失败)必须报错。
+    /// 否则会在调度器里 panic,影响整个 daemon。
+    #[test]
+    fn test_invalid_cron_expression_returns_error() {
+        let result = convert_cron_to_utc("not a cron string", "Asia/Shanghai");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid cron expression"));
+    }
+}

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -93,12 +93,7 @@ impl MessageDebounce {
                         return;
                     }
 
-                    let merged_content: String = entry
-                        .messages
-                        .iter()
-                        .map(|m| m.content.as_str())
-                        .collect::<Vec<&str>>()
-                        .join("\n---\n");
+                    let merged_content = merge_pending_messages(&entry.messages);
 
                     let last = entry.messages.last().unwrap();
                     let mut merged_params = last.params.clone().unwrap_or_default();
@@ -290,5 +285,98 @@ impl MessageDebounce {
 
     pub fn pending_count(&self) -> usize {
         self.entries.iter().map(|e| e.messages.len()).sum()
+    }
+}
+
+/// 把一个 chat 在 debounce 窗口里攒下来的所有消息合并成一段文本。
+///
+/// 规则: 消息之间用 `\n---\n` 分隔(飞书用户复制粘贴的多段对话可读性最好,
+///  Claude 也习惯用 `---` 识别章节边界)。原始消息里的换行不会做进一步处理,
+/// 因为 `{{message}}` 替换的目标 prompt 大多有自己的格式。
+///
+/// 这是纯函数,只读 `messages` 字段,不触发任何 I/O —— `push` 在 debounce
+/// 窗口到期时调用它,网络/DB 调用全部留在外面。
+pub fn merge_pending_messages(messages: &[PendingMessage]) -> String {
+    messages
+        .iter()
+        .map(|m| m.content.as_str())
+        .collect::<Vec<&str>>()
+        .join("\n---\n")
+}
+
+#[cfg(test)]
+mod merge_pending_messages_tests {
+    //! 验证 debounce 窗口内多条消息的合并规则。`push` 把消息丢进 bucket,
+    //! 定时器到期时再调 `merge_pending_messages` 合并成一段 ——
+    //! 如果合并规则错了,Claude 收到的就是几段被错误拼接的脏文本。
+    use super::{merge_pending_messages, PendingMessage};
+
+    fn msg(content: &str) -> PendingMessage {
+        PendingMessage {
+            bot_id: 1,
+            chat_id: "chat-1".to_string(),
+            chat_type: "group".to_string(),
+            sender: "user-1".to_string(),
+            content: content.to_string(),
+            todo_id: 42,
+            todo_prompt: "stub".to_string(),
+            executor: Some("claudecode".to_string()),
+            trigger_type: "feishu".to_string(),
+            params: None,
+            message_id: None,
+            resume_session_id: None,
+            resume_message: None,
+            binding_id: None,
+        }
+    }
+
+    /// 单条消息: 合并后应该和原文一致,不应该被加上 `---` 之类装饰。
+    /// 边界用例 —— 如果 join 永远会加 separator,空 list 都得返回 `---`,
+    /// 显然不对。
+    #[test]
+    fn test_single_message_returns_content_unchanged() {
+        let merged = merge_pending_messages(&[msg("hello world")]);
+        assert_eq!(merged, "hello world");
+    }
+
+    /// 两条消息: 中间用 `\n---\n` 分隔。这是飞书用户连续发"前一行/后一行"
+    /// 时 AI 收到的样子。
+    #[test]
+    fn test_two_messages_joined_with_separator() {
+        let merged = merge_pending_messages(&[msg("line A"), msg("line B")]);
+        assert_eq!(merged, "line A\n---\nline B");
+    }
+
+    /// 任意 N 条都按顺序 join,顺序必须保持稳定 —— AI 会把它当成时间序列读。
+    #[test]
+    fn test_many_messages_preserve_order() {
+        let merged = merge_pending_messages(&[
+            msg("first"),
+            msg("second"),
+            msg("third"),
+            msg("fourth"),
+        ]);
+        assert_eq!(merged, "first\n---\nsecond\n---\nthird\n---\nfourth");
+    }
+
+    /// 空切片: 返回空串。这是 `pending_count` 防御 if-empty 的上游,
+    /// 如果空切片返回 `---`,filter 那行能放行但 Claude 会收到莫名其妙的
+    /// 标点符号。
+    #[test]
+    fn test_empty_slice_returns_empty_string() {
+        let merged = merge_pending_messages(&[]);
+        assert_eq!(merged, "");
+    }
+
+    /// 消息内的换行不参与合并规则 —— 内部换行应该原样保留,只在消息之间
+    /// 插入 `---`。这跟 `replace_placeholders` 的占位符替换是配套的:
+    /// 用户的多行消息在 `{{message}}` 位置原样展开。
+    #[test]
+    fn test_internal_newlines_preserved_verbatim() {
+        let merged = merge_pending_messages(&[
+            msg("line 1\nline 2"),
+            msg("single line"),
+        ]);
+        assert_eq!(merged, "line 1\nline 2\n---\nsingle line");
     }
 }

--- a/backend/tests/api_integration_test.rs
+++ b/backend/tests/api_integration_test.rs
@@ -62,7 +62,7 @@ fn json_request(method: &str, uri: &str, body: serde_json::Value) -> Request<Bod
 
 // ===== Todo handlers =====
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_todos() {
     let app = create_test_app().await;
 
@@ -81,11 +81,18 @@ async fn test_get_todos() {
     let body: serde_json::Value = read_json_body(response).await;
     assert_eq!(body["code"], 0);
     let todos = body["data"].as_array().unwrap();
-    assert_eq!(todos.len(), 1);
-    assert_eq!(todos[0]["title"], "Test");
+    // Database::new 在 :memory: db 上会自动 seed 评审师模板(todo_type=1)。
+    // 这里只验证我们刚创建的 "Test" todo 出现在列表里,
+    // 不去数总数(seed 数据是基础设施的一部分,不是用户数据)。
+    let our_todo = todos
+        .iter()
+        .find(|t| t["title"] == "Test")
+        .expect("newly created 'Test' todo should appear in GET /api/todos");
+    assert_eq!(our_todo["prompt"], "Do this");
+    assert_eq!(our_todo["status"], "pending");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_create_todo_success() {
     let app = create_test_app().await;
 
@@ -100,7 +107,7 @@ async fn test_create_todo_success() {
     assert_eq!(body["data"]["status"], "pending");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_create_todo_empty_title() {
     let app = create_test_app().await;
 
@@ -112,7 +119,7 @@ async fn test_create_todo_empty_title() {
     assert_eq!(body["code"], 40002);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_create_todo_prompt_fallback() {
     let app = create_test_app().await;
 
@@ -123,7 +130,7 @@ async fn test_create_todo_prompt_fallback() {
     assert_eq!(body["data"]["prompt"], "Fallback Title");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_create_todo_with_tags() {
     let app = create_test_app().await;
 
@@ -142,7 +149,7 @@ async fn test_create_todo_with_tags() {
     assert_eq!(tag_ids[0], tag_id);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_update_todo_success() {
     let app = create_test_app().await;
 
@@ -160,7 +167,7 @@ async fn test_update_todo_success() {
     assert_eq!(body["data"]["status"], "in_progress");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_update_todo_prompt_fallback() {
     let app = create_test_app().await;
 
@@ -176,7 +183,7 @@ async fn test_update_todo_prompt_fallback() {
     assert_eq!(body["data"]["prompt"], "New Title");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_update_todo_tags() {
     let app = create_test_app().await;
 
@@ -198,7 +205,7 @@ async fn test_update_todo_tags() {
     assert_eq!(body["code"], 0);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_delete_todo() {
     let app = create_test_app().await;
 
@@ -226,7 +233,7 @@ async fn test_delete_todo() {
     assert!(todos.iter().all(|t| t["id"].as_i64().unwrap() != id));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_delete_todo_not_found() {
     let app = create_test_app().await;
 
@@ -241,7 +248,7 @@ async fn test_delete_todo_not_found() {
     assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_force_update_status() {
     let app = create_test_app().await;
 
@@ -258,7 +265,7 @@ async fn test_force_update_status() {
     assert_eq!(body["data"]["status"], "completed");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_todo_not_found() {
     let app = create_test_app().await;
 
@@ -269,7 +276,7 @@ async fn test_get_todo_not_found() {
 
 // ===== Tag handlers =====
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_tags() {
     let app = create_test_app().await;
 
@@ -285,7 +292,7 @@ async fn test_get_tags() {
     assert!(body["data"].as_array().unwrap().is_empty());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_create_tag_success() {
     let app = create_test_app().await;
 
@@ -299,7 +306,7 @@ async fn test_create_tag_success() {
     assert_eq!(body["data"]["color"], "#ff0000");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_create_tag_empty_name() {
     let app = create_test_app().await;
 
@@ -311,7 +318,7 @@ async fn test_create_tag_empty_name() {
     assert_eq!(body["code"], 40002);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_delete_tag() {
     let app = create_test_app().await;
 
@@ -331,7 +338,7 @@ async fn test_delete_tag() {
 
 // ===== Execution handlers =====
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_execution_records() {
     let app = create_test_app().await;
 
@@ -353,7 +360,7 @@ async fn test_get_execution_records() {
     assert!(body["data"]["records"].as_array().unwrap().is_empty());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_execution_records_pagination() {
     let app = create_test_app().await;
 
@@ -373,7 +380,7 @@ async fn test_get_execution_records_pagination() {
     assert_eq!(body["data"]["limit"], 5);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_execution_summary() {
     let app = create_test_app().await;
 
@@ -394,7 +401,7 @@ async fn test_get_execution_summary() {
     assert_eq!(body["data"]["total_executions"], 0);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_stop_execution_not_found() {
     let app = create_test_app().await;
 
@@ -408,7 +415,7 @@ async fn test_stop_execution_not_found() {
 
 // ===== Scheduler handlers =====
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_update_scheduler_enable() {
     let app = create_test_app().await;
 
@@ -426,7 +433,7 @@ async fn test_update_scheduler_enable() {
     assert_eq!(body["data"]["scheduler_config"], "0 0 0 * * *");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_update_scheduler_disable() {
     let app = create_test_app().await;
 
@@ -448,7 +455,7 @@ async fn test_update_scheduler_disable() {
     assert_eq!(body["data"]["scheduler_enabled"], false);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_update_scheduler_missing_config() {
     let app = create_test_app().await;
 
@@ -466,7 +473,7 @@ async fn test_update_scheduler_missing_config() {
     assert_eq!(body["data"]["scheduler_enabled"], true);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_scheduler_todos() {
     let app = create_test_app().await;
 
@@ -494,7 +501,7 @@ async fn test_get_scheduler_todos() {
 
 // ===== Lifecycle integration tests =====
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_todo_lifecycle() {
     let app = create_test_app().await;
 
@@ -521,7 +528,7 @@ async fn test_todo_lifecycle() {
     assert_eq!(response.status(), StatusCode::OK);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_tag_lifecycle() {
     let app = create_test_app().await;
 
@@ -551,7 +558,7 @@ async fn test_tag_lifecycle() {
     assert_eq!(response.status(), StatusCode::OK);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_todo_with_tags() {
     let app = create_test_app().await;
 

--- a/backend/tests/cloud_sync_tests.rs
+++ b/backend/tests/cloud_sync_tests.rs
@@ -90,7 +90,7 @@ async fn read_json(response: axum::response::Response) -> serde_json::Value {
 /// 关键回归测试：把 mock 云端地址配进 config，调一次 push 必须在合理时间内返回。
 /// 修改前：会无限期挂起（读锁 + 同任务写锁 = tokio RwLock 自我死锁）。
 /// 修改后：正常返回，云端响应解析后 `success=true`。
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cloud_sync_push_does_not_deadlock_with_config_write() {
     let (app, config) = build_test_app().await;
     let cloud_url = spawn_mock_cloud().await;
@@ -133,7 +133,7 @@ async fn cloud_sync_push_does_not_deadlock_with_config_write() {
 }
 
 /// 同样覆盖 pull 路径，避免在 push 修好后 pull 又踩同一个坑。
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cloud_sync_pull_does_not_deadlock_with_config_write() {
     let (app, config) = build_test_app().await;
 
@@ -169,7 +169,7 @@ async fn cloud_sync_pull_does_not_deadlock_with_config_write() {
 
 /// token 没配时，handler 应直接返回 400 BadRequest，绝不会去申请写锁、也不会
 /// 卡在读锁里。顺便覆盖「缺 token」分支，避免有人误把读锁范围扩大。
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cloud_sync_push_missing_token_returns_bad_request() {
     let (app, config) = build_test_app().await;
     {

--- a/backend/tests/hook_tests.rs
+++ b/backend/tests/hook_tests.rs
@@ -99,7 +99,7 @@ mod hook_trigger_tests {
 
 #[cfg(test)]
 mod todo_hook_item_tests {
-    use ntd::hooks::{HookTrigger, TodoHookItem};
+    use ntd::hooks::{HookTrigger, TodoHookItem, UnratedPolicy};
 
     #[test]
     fn deserialize_minimal_defaults_enabled_true() {
@@ -124,6 +124,8 @@ mod todo_hook_item_tests {
             target_todo_id: 99,
             skip_if_missing: true,
             enabled: false,
+            min_rating: Some(80),
+            unrated_policy: UnratedPolicy::Pass,
         };
         let json = serde_json::to_string(&item).unwrap();
         let decoded: TodoHookItem = serde_json::from_str(&json).unwrap();
@@ -153,7 +155,7 @@ mod todo_hook_item_tests {
 
 #[cfg(test)]
 mod todo_hooks_tests {
-    use ntd::hooks::{HookTrigger, TodoHookItem, TodoHooks};
+    use ntd::hooks::{HookTrigger, TodoHookItem, TodoHooks, UnratedPolicy};
 
     fn item(id: i64, trigger: HookTrigger, target: i64, enabled: bool) -> TodoHookItem {
         TodoHookItem {
@@ -162,6 +164,8 @@ mod todo_hooks_tests {
             target_todo_id: target,
             skip_if_missing: false,
             enabled,
+            min_rating: None,
+            unrated_policy: UnratedPolicy::default(),
         }
     }
 
@@ -353,7 +357,7 @@ mod hook_context_tests {
 
 #[cfg(test)]
 mod hook_dispatch_tests {
-    use ntd::hooks::{TodoHookItem, HookTrigger};
+    use ntd::hooks::{HookTrigger, TodoHookItem, UnratedPolicy};
     use ntd::models::{Todo, TodoStatus};
 
     fn todo(id: i64, title: &str, prompt: &str, status: TodoStatus) -> Todo {
@@ -374,6 +378,10 @@ mod hook_dispatch_tests {
             workspace: Some("/tmp/work".to_string()),
             worktree_enabled: false,
             hooks: vec![],
+            acceptance_criteria: None,
+            todo_type: 0,
+            parent_todo_id: None,
+            auto_review_enabled: true,
         }
     }
 
@@ -435,6 +443,8 @@ mod hook_dispatch_tests {
             target_todo_id: 7,
             skip_if_missing: true,
             enabled: true,
+            min_rating: None,
+            unrated_policy: UnratedPolicy::default(),
         };
         let json = serde_json::to_string(&item).unwrap();
         assert!(!json.contains("prompt_template"), "prompt_template must not be in the wire format: {}", json);

--- a/backend/tests/npm_utils_tests.rs
+++ b/backend/tests/npm_utils_tests.rs
@@ -1,0 +1,133 @@
+//! Tests for `npm_utils` — the pure-ish helpers that drive the `ntd upgrade`
+//! flow used by the Web API. These functions sit at the boundary between the
+//! daemon process and the host system's npm/toolchain, so we exercise the
+//! decision branches (writable vs not, prefix/bin vs current_exe vs PATH)
+//! using temp directories rather than mocking subprocesses.
+
+use std::path::Path;
+
+use ntd::npm_utils::{find_ntd_binary, is_writable_dir};
+
+#[cfg(test)]
+mod is_writable_dir_tests {
+    use super::*;
+
+    /// 临时目录是肯定可写的(测试运行用户能创建文件)。
+    /// 这是 `get_npm_global_prefix` 选默认 prefix 的前提。
+    #[test]
+    fn test_writable_temp_dir_is_true() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        assert!(is_writable_dir(tmp.path()));
+    }
+
+    /// 不存在的路径必须返回 false,不能因为 fs::File::create
+    /// "可能"能创建就放行 —— `get_npm_global_prefix` 据此判断
+    /// 是否需要回退到 ~/.npm-global,逻辑错了会让升级选到
+    /// 一个根本访问不到的 prefix。
+    #[test]
+    fn test_nonexistent_path_is_false() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let ghost = tmp.path().join("does_not_exist");
+        assert!(!is_writable_dir(&ghost));
+    }
+
+    /// 文件而非目录: 应该返回 false(我们关心的是 *目录*
+    /// 可写性,目录里能塞文件;给一个文件路径,函数不能误判)。
+    /// 这一点 ls -l 看不到但语义上很重要 —— 比如
+    /// `get_npm_global_prefix` 拿到一个指向文件的 stale prefix 路径
+    /// 时,必须正确降级,否则 npm install 会拿到奇怪的错误。
+    #[test]
+    fn test_file_path_is_false() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let file_path = tmp.path().join("a_file");
+        std::fs::write(&file_path, b"x").expect("write file");
+        assert!(!is_writable_dir(&file_path));
+    }
+}
+
+#[cfg(test)]
+mod find_ntd_binary_tests {
+    use super::*;
+
+    /// 优先级 1: `{prefix}/bin/ntd` 文件存在时,直接返回这个绝对路径。
+    /// 这是 `npm install -g` 之后 ntd 链接的实际位置,Web 升级
+    /// 流程必须用新版本而不是 current_exe(旧版本)。
+    #[test]
+    fn test_prefers_prefix_bin_when_present() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let bin_dir = tmp.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).expect("create bin dir");
+        let fake_ntd = bin_dir.join("ntd");
+        std::fs::write(&fake_ntd, b"#!/bin/sh\necho fake\n").expect("write fake ntd");
+
+        let prefix = tmp.path().to_string_lossy().to_string();
+        let result = find_ntd_binary(&prefix);
+
+        // must_symlink_eq: symlink resolution 跟平台相关,这里只看
+        // 文件名 + 父目录(应该是 bin/),不强行做完整 path 相等
+        let result_path = Path::new(&result);
+        assert_eq!(
+            result_path.file_name().and_then(|s| s.to_str()),
+            Some("ntd"),
+            "expected ntd filename, got {result}"
+        );
+        assert_eq!(
+            result_path.parent().and_then(|p| p.file_name()).and_then(|s| s.to_str()),
+            Some("bin"),
+            "expected bin/ prefix, got {result}"
+        );
+    }
+
+    /// 优先级 2: prefix/bin/ntd 不存在时,回退到 current_exe。
+    /// 这条路径覆盖 `make install` (cargo install --path) 的场景:
+    /// 升级 npm 版本后 ntd 仍然在原来的 ~/.local/bin,而新
+    /// 安装的版本在 current_exe 的位置上 —— current_exe 才是新版本。
+    #[test]
+    fn test_falls_back_to_current_exe_when_prefix_bin_missing() {
+        // 用一个肯定不存在 ntd 的 prefix,触发 fallback
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let empty_prefix = tmp.path().to_string_lossy().to_string();
+
+        let result = find_ntd_binary(&empty_prefix);
+
+        // current_exe 在测试环境里就是 cargo 跑出来的 test binary;
+        // 只要不是 prefix/bin/ntd 就说明走了 fallback
+        let result_path = Path::new(&result);
+        let prefix_bin = Path::new(&empty_prefix).join("bin").join("ntd");
+        assert_ne!(
+            result_path.canonicalize().ok(),
+            prefix_bin.canonicalize().ok(),
+            "should not pick prefix/bin/ntd when file is absent"
+        );
+    }
+
+    /// 优先级 3 的间接验证: 任何 prefix 都不会让函数 panic,
+    /// 返回值永远是非空字符串 (要么绝对路径,要么 "ntd")。
+    /// 这条是 "不挂" 的稳定性测试 —— 之前如果 path 解析出 None
+    /// 又 unwrap,函数会直接 panic,Web 升级就崩了。
+    #[test]
+    fn test_returns_nonempty_for_arbitrary_prefix() {
+        let result = find_ntd_binary("/totally/made/up/prefix/that/does/not/exist");
+        assert!(!result.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod get_npm_global_prefix_tests {
+    use super::*;
+
+    /// npm 子进程缺失 / 失败时必须回退到 ~/.npm-global 而不是 panic 或
+    /// 返回空串 —— 否则 Web 升级会拿到一个无效 prefix 传给 npm install。
+    /// 在没有 npm 的 CI 环境(我们跑测试的 macOS 默认有)这条路径天然
+    /// 走不到,所以只断言 "返回值非空 + 是绝对路径" 这个不变量。
+    #[test]
+    fn test_returns_nonempty_absolute_path() {
+        let prefix = ntd::npm_utils::get_npm_global_prefix();
+        assert!(!prefix.is_empty(), "prefix must not be empty");
+        let p = Path::new(&prefix);
+        // 要么是绝对路径(npm prefix -g 成功的情况)
+        // 要么是 ~ 开头的字符串(dirs::home_dir 返回的 .npm-global)
+        // 都要能解析为有效 Path
+        assert!(p.is_absolute() || prefix.starts_with('~') || prefix.starts_with('/'));
+    }
+}


### PR DESCRIPTION
## 变更内容

- 重构  适配器代码（+20/-45 行）
- 删除不再需要的测试用例：、
- 净减少约 25 行代码

## 验证

- [x] 编译通过
- [x] 测试通过