### PR TITLE
feat: redesign Skills tab with card grid layout

### DIFF
--- a/frontend/src/components/SkillsPanel.tsx
+++ b/frontend/src/components/SkillsPanel.tsx
@@ -24,18 +24,24 @@ export function SkillsPanel() {
   return (
     <div>
       {/* Tab bar */}
-      <div style={{
-        display: 'flex',
-        gap: 4,
-        marginBottom: 20,
-        borderBottom: '1px solid var(--color-border, #313244)',
-        paddingBottom: 0,
-      }}>
+      <div
+        role="tablist"
+        aria-label="Skills 管理"
+        style={{
+          display: 'flex',
+          gap: 4,
+          marginBottom: 20,
+          borderBottom: '1px solid var(--color-border, #e2e8f0)',
+          paddingBottom: 0,
+        }}
+      >
         {views.map(v => {
           const isActive = activeView === v.key;
           return (
             <button
               key={v.key}
+              role="tab"
+              aria-selected={isActive}
               onClick={() => setActiveView(v.key)}
               style={{
                 display: 'inline-flex',

--- a/frontend/src/components/SkillsPanel.tsx
+++ b/frontend/src/components/SkillsPanel.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Button } from 'antd';
 import {
   AppstoreOutlined, BarChartOutlined,
   SwapOutlined, ThunderboltOutlined,
@@ -16,7 +15,7 @@ export function SkillsPanel() {
   const [activeView, setActiveView] = useState<SubView>('overview');
 
   const views: { key: SubView; label: string; icon: ReactNode }[] = [
-    { key: 'overview', label: 'Skills 总览', icon: <AppstoreOutlined /> },
+    { key: 'overview', label: '总览', icon: <AppstoreOutlined /> },
     { key: 'compare', label: '对比分析', icon: <BarChartOutlined /> },
     { key: 'sync', label: '同步管理', icon: <SwapOutlined /> },
     { key: 'tracking', label: '调用追踪', icon: <ThunderboltOutlined /> },
@@ -24,25 +23,49 @@ export function SkillsPanel() {
 
   return (
     <div>
+      {/* Tab bar */}
       <div style={{
         display: 'flex',
-        flexWrap: 'wrap',
-        gap: 8,
+        gap: 4,
         marginBottom: 20,
-        borderBottom: '1px solid var(--color-border-light, #f0f0f0)',
-        paddingBottom: 12,
+        borderBottom: '1px solid var(--color-border, #313244)',
+        paddingBottom: 0,
       }}>
-        {views.map(v => (
-          <Button
-            key={v.key}
-            type={activeView === v.key ? 'primary' : 'default'}
-            icon={v.icon}
-            onClick={() => setActiveView(v.key)}
-            style={{ borderRadius: 8, fontSize: 13, padding: '4px 10px' }}
-          >
-            {v.label}
-          </Button>
-        ))}
+        {views.map(v => {
+          const isActive = activeView === v.key;
+          return (
+            <button
+              key={v.key}
+              onClick={() => setActiveView(v.key)}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '10px 16px',
+                border: 'none',
+                borderBottom: `2px solid ${isActive ? 'var(--color-primary, #0891b2)' : 'transparent'}`,
+                background: 'transparent',
+                color: isActive
+                  ? 'var(--color-primary, #0891b2)'
+                  : 'var(--color-text-secondary, #a6adc8)',
+                cursor: 'pointer',
+                fontSize: 14,
+                fontWeight: isActive ? 500 : 400,
+                transition: 'all 0.2s',
+                marginBottom: -1,
+              }}
+              onMouseEnter={e => {
+                if (!isActive) e.currentTarget.style.color = 'var(--color-text, #cdd6f4)';
+              }}
+              onMouseLeave={e => {
+                if (!isActive) e.currentTarget.style.color = 'var(--color-text-secondary, #a6adc8)';
+              }}
+            >
+              {v.icon}
+              {v.label}
+            </button>
+          );
+        })}
       </div>
 
       {activeView === 'overview' && <SkillsOverview />}

--- a/frontend/src/components/skills/SkillsOverview.tsx
+++ b/frontend/src/components/skills/SkillsOverview.tsx
@@ -1,15 +1,15 @@
 import { useState, useEffect, useMemo } from 'react';
-import { Spin, Row, Col, Card, Statistic, Input, Space, Button, Tooltip, Dropdown, message } from 'antd';
+import { Spin, Input, Space, Button, Tag, Dropdown, message } from 'antd';
 import type { MenuProps } from 'antd';
 import {
-  ThunderboltOutlined, AppstoreOutlined, BarChartOutlined,
-  SearchOutlined, FolderOpenOutlined, FileOutlined,
+  ThunderboltOutlined, SearchOutlined,
   DownloadOutlined, ExportOutlined, ImportOutlined,
+  AppstoreOutlined, SettingOutlined,
 } from '@ant-design/icons';
 import { EXECUTORS } from '@/types';
 import type { SkillMeta, ExecutorSkills } from '@/types';
 import * as db from '@/utils/database';
-import { SkillTree } from './SkillTree';
+import { EXECUTOR_COLORS, formatSize } from './helpers';
 import { SkillDetailDrawer } from './SkillDetailDrawer';
 import { ImportExportModal } from './ImportExportModal';
 
@@ -17,7 +17,7 @@ export function SkillsOverview() {
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<ExecutorSkills[]>([]);
   const [searchText, setSearchText] = useState('');
-  const [showCategory, setShowCategory] = useState(true);
+  const [filterExecutor, setFilterExecutor] = useState<string>('all');
   const [selectedSkill, setSelectedSkill] = useState<SkillMeta | null>(null);
   const [selectedExecutor, setSelectedExecutor] = useState('');
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -51,7 +51,38 @@ export function SkillsOverview() {
   };
 
   const totalSkills = useMemo(() => data.reduce((sum, e) => sum + e.skills.length, 0), [data]);
-  const executorsWithSkills = useMemo(() => data.filter(e => e.skills.length > 0).length, [data]);
+
+  const allSkills = useMemo(() => {
+    const skills: { skill: SkillMeta; executor: string }[] = [];
+    data.forEach(e => {
+      e.skills.forEach(s => {
+        if (filterExecutor === 'all' || filterExecutor === e.executor) {
+          skills.push({ skill: s, executor: e.executor });
+        }
+      });
+    });
+    return skills;
+  }, [data, filterExecutor]);
+
+  const filteredSkills = useMemo(() => {
+    if (!searchText) return allSkills;
+    const lower = searchText.toLowerCase();
+    return allSkills.filter(
+      ({ skill }) =>
+        skill.name.toLowerCase().includes(lower) ||
+        skill.description?.toLowerCase().includes(lower) ||
+        skill.keywords?.some(k => k.toLowerCase().includes(lower))
+    );
+  }, [allSkills, searchText]);
+
+  const executorTabs = useMemo(() => {
+    const tabs = [{ key: 'all', label: '全部', count: totalSkills }];
+    data.forEach(e => {
+      const label = EXECUTORS.find(x => x.value === e.executor)?.label || e.executor;
+      tabs.push({ key: e.executor, label, count: e.skills.length });
+    });
+    return tabs;
+  }, [data, totalSkills]);
 
   const exportMenuItems: MenuProps['items'] = [
     { key: 'export', icon: <ExportOutlined />, label: '导出选中' },
@@ -78,103 +109,147 @@ export function SkillsOverview() {
     setExportModalOpen(true);
   };
 
-  const handleImport = (executor: string) => {
-    setSelectedExecutor(executor);
-    setExportMode('import');
-    setInitialSelectedSkills(undefined);
-    setExportModalOpen(true);
-  };
-
-  const handleExport = (executor: string, selectAll?: boolean) => {
-    setSelectedExecutor(executor);
-    setExportMode('export');
-    if (selectAll) {
-      const executorData = data.find(e => e.executor === executor);
-      if (executorData) {
-        setInitialSelectedSkills(executorData.skills.map(s => s.name));
-      }
-    } else {
-      setInitialSelectedSkills(undefined);
-    }
-    setExportModalOpen(true);
-  };
-
   if (loading) {
     return <div style={{ textAlign: 'center', padding: 48 }}><Spin size="large" /></div>;
   }
 
   return (
     <div>
-      <Row gutter={16} style={{ marginBottom: 16 }}>
-        <Col xs={24} sm={8}>
-          <Card size="small">
-            <Statistic
-              title="Skill 总数"
-              value={totalSkills}
-              prefix={<ThunderboltOutlined style={{ color: '#7C3AED' }} />}
-              valueStyle={{ color: '#7C3AED' }}
-            />
-          </Card>
-        </Col>
-        <Col xs={24} sm={8}>
-          <Card size="small">
-            <Statistic
-              title="有 Skills 的执行器"
-              value={executorsWithSkills}
-              suffix={`/ ${data.length}`}
-              prefix={<AppstoreOutlined style={{ color: '#10B981' }} />}
-              valueStyle={{ color: '#10B981' }}
-            />
-          </Card>
-        </Col>
-        <Col xs={24} sm={8}>
-          <Card size="small">
-            <Statistic
-              title="执行器总数"
-              value={data.length}
-              prefix={<BarChartOutlined style={{ color: '#F97316' }} />}
-              valueStyle={{ color: '#F97316' }}
-            />
-          </Card>
-        </Col>
-      </Row>
+      {/* Stats row */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, 1fr)',
+        gap: 12,
+        marginBottom: 20,
+      }}>
+        <StatCard
+          icon={<ThunderboltOutlined />}
+          iconColor="#0891b2"
+          label="Skill 总数"
+          value={totalSkills}
+        />
+        <StatCard
+          icon={<AppstoreOutlined />}
+          iconColor="#10b981"
+          label="执行器"
+          value={data.filter(e => e.skills.length > 0).length}
+          suffix={`/ ${data.length}`}
+        />
+        <StatCard
+          icon={<SettingOutlined />}
+          iconColor="#f59e0b"
+          label="文件总数"
+          value={allSkills.reduce((sum, { skill }) => sum + skill.file_count, 0)}
+        />
+      </div>
 
-      <Card size="small" style={{ marginBottom: 16 }}>
-        <Space wrap style={{ width: '100%', justifyContent: 'space-between' }}>
-          <Space wrap>
-            <Input
-              placeholder="搜索 Skills..."
-              prefix={<SearchOutlined />}
-              value={searchText}
-              onChange={e => setSearchText(e.target.value)}
-              style={{ width: 200 }}
-              allowClear
-            />
-            <Tooltip title={showCategory ? '显示扁平结构' : '显示目录结构'}>
-              <Button
-                icon={showCategory ? <FolderOpenOutlined /> : <FileOutlined />}
-                onClick={() => setShowCategory(!showCategory)}
+      {/* Filter & Search bar */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        marginBottom: 16,
+        gap: 12,
+        flexWrap: 'wrap',
+      }}>
+        {/* Executor filter pills */}
+        <div style={{
+          display: 'flex',
+          gap: 6,
+          flexWrap: 'wrap',
+          flex: 1,
+        }}>
+          {executorTabs.map(tab => {
+            const isActive = filterExecutor === tab.key;
+            const color = tab.key === 'all' ? '#0891b2' : (EXECUTOR_COLORS[tab.key] || '#6c7086');
+            return (
+              <button
+                key={tab.key}
+                onClick={() => setFilterExecutor(tab.key)}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  padding: '4px 12px',
+                  borderRadius: 20,
+                  border: `1px solid ${isActive ? color : 'var(--color-border, #313244)'}`,
+                  background: isActive ? `${color}20` : 'transparent',
+                  color: isActive ? color : 'var(--color-text-secondary, #a6adc8)',
+                  cursor: 'pointer',
+                  fontSize: 13,
+                  fontWeight: isActive ? 500 : 400,
+                  transition: 'all 0.2s',
+                  whiteSpace: 'nowrap',
+                }}
               >
-                {showCategory ? '目录视图' : '扁平视图'}
-              </Button>
-            </Tooltip>
-          </Space>
+                {tab.label}
+                <span style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  minWidth: 18,
+                  height: 18,
+                  borderRadius: 9,
+                  background: isActive ? color : 'var(--color-fill, #45475a)',
+                  color: isActive ? '#fff' : 'var(--color-text-secondary, #a6adc8)',
+                  fontSize: 11,
+                  lineHeight: 1,
+                  padding: '0 4px',
+                }}>
+                  {tab.count}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <Space size={8}>
+          <Input
+            placeholder="搜索 Skills..."
+            prefix={<SearchOutlined style={{ color: 'var(--color-text-quaternary, #6c7086)' }} />}
+            value={searchText}
+            onChange={e => setSearchText(e.target.value)}
+            style={{ width: 200, borderRadius: 20 }}
+            allowClear
+          />
           <Dropdown menu={{ items: exportMenuItems, onClick: handleExportMenuClick }} trigger={['click']}>
-            <Button type="primary" icon={<DownloadOutlined />}>
+            <Button
+              type="primary"
+              icon={<DownloadOutlined />}
+              style={{ borderRadius: 20 }}
+            >
               导入/导出
             </Button>
           </Dropdown>
         </Space>
-      </Card>
+      </div>
 
-      <SkillTree
-        data={data}
-        onSkillClick={handleSkillClick}
-        onImport={handleImport}
-        onExport={handleExport}
-        searchText={searchText}
-        showCategory={showCategory}
-      />
+      {/* Skill card grid */}
+      {filteredSkills.length === 0 ? (
+        <div style={{
+          textAlign: 'center',
+          padding: '60px 20px',
+          color: 'var(--color-text-secondary, #a6adc8)',
+        }}>
+          <AppstoreOutlined style={{ fontSize: 48, marginBottom: 16, opacity: 0.3 }} />
+          <div style={{ fontSize: 16 }}>{searchText ? '无匹配结果' : '暂无 Skills'}</div>
+        </div>
+      ) : (
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+          gap: 12,
+        }}>
+          {filteredSkills.map(({ skill, executor }) => (
+            <SkillCard
+              key={`${executor}-${skill.name}`}
+              skill={skill}
+              executor={executor}
+              onClick={() => handleSkillClick(skill, executor)}
+            />
+          ))}
+        </div>
+      )}
 
       <SkillDetailDrawer
         skill={selectedSkill}
@@ -197,6 +272,208 @@ export function SkillsOverview() {
           setInitialSelectedSkills(undefined);
         }}
       />
+    </div>
+  );
+}
+
+function StatCard({ icon, iconColor, label, value, suffix }: {
+  icon: React.ReactNode;
+  iconColor: string;
+  label: string;
+  value: number;
+  suffix?: string;
+}) {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 12,
+      padding: '14px 16px',
+      borderRadius: 12,
+      background: 'var(--color-bg-container, #1e1e2e)',
+      border: '1px solid var(--color-border, #313244)',
+      transition: 'border-color 0.2s',
+    }}
+      onMouseEnter={e => {
+        e.currentTarget.style.borderColor = iconColor;
+      }}
+      onMouseLeave={e => {
+        e.currentTarget.style.borderColor = 'var(--color-border, #313244)';
+      }}
+    >
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 36,
+        height: 36,
+        borderRadius: 10,
+        background: `${iconColor}18`,
+        color: iconColor,
+        fontSize: 16,
+      }}>
+        {icon}
+      </div>
+      <div>
+        <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #a6adc8)' }}>{label}</div>
+        <div style={{ fontSize: 20, fontWeight: 600, lineHeight: 1.2, color: 'var(--color-text, #cdd6f4)' }}>
+          {value}{suffix && <span style={{ fontSize: 13, fontWeight: 400, marginLeft: 2 }}>{suffix}</span>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SkillCard({ skill, executor, onClick }: {
+  skill: SkillMeta;
+  executor: string;
+  onClick: () => void;
+}) {
+  const color = EXECUTOR_COLORS[executor] || '#0891b2';
+  const initial = skill.name.replace(/.*\//, '').charAt(0).toUpperCase();
+  const executorLabel = EXECUTORS.find(e => e.value === executor)?.label || executor;
+  const shortName = skill.name.includes('/') ? skill.name.split('/').pop()! : skill.name;
+  const category = skill.name.includes('/') ? skill.name.split('/')[0] : null;
+
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12,
+        padding: 16,
+        borderRadius: 12,
+        background: 'var(--color-bg-container, #1e1e2e)',
+        border: '1px solid var(--color-border, #313244)',
+        cursor: 'pointer',
+        transition: 'all 0.2s',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+      onMouseEnter={e => {
+        e.currentTarget.style.borderColor = color;
+        e.currentTarget.style.boxShadow = `0 4px 12px ${color}20`;
+        e.currentTarget.style.transform = 'translateY(-2px)';
+      }}
+      onMouseLeave={e => {
+        e.currentTarget.style.borderColor = 'var(--color-border, #313244)';
+        e.currentTarget.style.boxShadow = 'none';
+        e.currentTarget.style.transform = 'translateY(0)';
+      }}
+    >
+      {/* Top accent line */}
+      <div style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        height: 2,
+        background: `linear-gradient(90deg, ${color}, ${color}60)`,
+        opacity: 0.6,
+      }} />
+
+      {/* Header: icon + name + executor tag */}
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+        <div style={{
+          width: 36,
+          height: 36,
+          borderRadius: 10,
+          background: `${color}18`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color,
+          fontSize: 15,
+          fontWeight: 600,
+          flexShrink: 0,
+        }}>
+          {initial}
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{
+            fontSize: 14,
+            fontWeight: 500,
+            color: 'var(--color-text, #cdd6f4)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}>
+            {shortName}
+          </div>
+          <div style={{
+            fontSize: 11,
+            color: 'var(--color-text-tertiary, #6c7086)',
+            marginTop: 2,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}>
+            {executorLabel}
+          </div>
+        </div>
+      </div>
+
+      {/* Description */}
+      {skill.description && (
+        <div style={{
+          fontSize: 12,
+          color: 'var(--color-text-secondary, #a6adc8)',
+          lineHeight: 1.5,
+          display: '-webkit-box',
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: 'vertical',
+          overflow: 'hidden',
+          minHeight: 36,
+        }}>
+          {skill.description}
+        </div>
+      )}
+
+      {/* Footer: tags */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        marginTop: 'auto',
+        flexWrap: 'wrap',
+      }}>
+        {category && (
+          <Tag style={{
+            margin: 0,
+            fontSize: 11,
+            lineHeight: '18px',
+            padding: '0 6px',
+            borderRadius: 4,
+            background: 'var(--color-fill, #45475a)',
+            border: 'none',
+            color: 'var(--color-text-secondary, #a6adc8)',
+          }}>
+            {category}
+          </Tag>
+        )}
+        {skill.version && (
+          <Tag style={{
+            margin: 0,
+            fontSize: 11,
+            lineHeight: '18px',
+            padding: '0 6px',
+            borderRadius: 4,
+            background: `${color}18`,
+            border: 'none',
+            color,
+          }}>
+            v{skill.version}
+          </Tag>
+        )}
+        <span style={{
+          marginLeft: 'auto',
+          fontSize: 11,
+          color: 'var(--color-text-quaternary, #585b70)',
+        }}>
+          {formatSize(skill.total_size)}
+        </span>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/skills/SkillsOverview.tsx
+++ b/frontend/src/components/skills/SkillsOverview.tsx
@@ -4,12 +4,12 @@ import type { MenuProps } from 'antd';
 import {
   ThunderboltOutlined, SearchOutlined,
   DownloadOutlined, ExportOutlined, ImportOutlined,
-  AppstoreOutlined, SettingOutlined,
+  AppstoreOutlined, FileTextOutlined,
 } from '@ant-design/icons';
 import { EXECUTORS } from '@/types';
 import type { SkillMeta, ExecutorSkills } from '@/types';
 import * as db from '@/utils/database';
-import { EXECUTOR_COLORS, formatSize } from './helpers';
+import { EXECUTOR_COLORS, formatSize, splitSkillName } from './helpers';
 import { SkillDetailDrawer } from './SkillDetailDrawer';
 import { ImportExportModal } from './ImportExportModal';
 
@@ -50,8 +50,15 @@ export function SkillsOverview() {
     setDrawerOpen(true);
   };
 
-  const totalSkills = useMemo(() => data.reduce((sum, e) => sum + e.skills.length, 0), [data]);
+  // Stats computed from unfiltered data (total counts, not affected by filter)
+  const stats = useMemo(() => {
+    const totalSkills = data.reduce((sum, e) => sum + e.skills.length, 0);
+    const totalFiles = data.reduce((sum, e) => sum + e.skills.reduce((s, sk) => s + sk.file_count, 0), 0);
+    const executorsWithSkills = data.filter(e => e.skills.length > 0).length;
+    return { totalSkills, totalFiles, executorsWithSkills };
+  }, [data]);
 
+  // All skills flattened (filtered by executor, but not by search)
   const allSkills = useMemo(() => {
     const skills: { skill: SkillMeta; executor: string }[] = [];
     data.forEach(e => {
@@ -64,6 +71,7 @@ export function SkillsOverview() {
     return skills;
   }, [data, filterExecutor]);
 
+  // Skills filtered by both executor and search text
   const filteredSkills = useMemo(() => {
     if (!searchText) return allSkills;
     const lower = searchText.toLowerCase();
@@ -75,14 +83,28 @@ export function SkillsOverview() {
     );
   }, [allSkills, searchText]);
 
+  // Executor filter tabs with counts synced to search
   const executorTabs = useMemo(() => {
-    const tabs = [{ key: 'all', label: '全部', count: totalSkills }];
+    const filterMatch = (skills: SkillMeta[]) => {
+      if (!searchText) return skills.length;
+      const lower = searchText.toLowerCase();
+      return skills.filter(s =>
+        s.name.toLowerCase().includes(lower) ||
+        s.description?.toLowerCase().includes(lower) ||
+        s.keywords?.some(k => k.toLowerCase().includes(lower))
+      ).length;
+    };
+
+    const tabs = [{ key: 'all', label: '全部', count: filterMatch(allSkills.map(s => s.skill)) }];
     data.forEach(e => {
       const label = EXECUTORS.find(x => x.value === e.executor)?.label || e.executor;
-      tabs.push({ key: e.executor, label, count: e.skills.length });
+      const count = filterExecutor === 'all' || filterExecutor === e.executor
+        ? filterMatch(e.skills)
+        : 0;
+      tabs.push({ key: e.executor, label, count });
     });
     return tabs;
-  }, [data, totalSkills]);
+  }, [data, filterExecutor, searchText, allSkills]);
 
   const exportMenuItems: MenuProps['items'] = [
     { key: 'export', icon: <ExportOutlined />, label: '导出选中' },
@@ -98,7 +120,9 @@ export function SkillsOverview() {
     } else {
       setExportMode('export');
       if (key === 'export-all') {
-        const executorData = data.find(e => e.executor === selectedExecutor);
+        // Export from current filter scope, not stale selectedExecutor
+        const scopeExecutor = filterExecutor !== 'all' ? filterExecutor : selectedExecutor;
+        const executorData = data.find(e => e.executor === scopeExecutor);
         if (executorData) {
           setInitialSelectedSkills(executorData.skills.map(s => s.name));
         }
@@ -140,7 +164,7 @@ export function SkillsOverview() {
             <div>
               <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #475569)' }}>Skill 总数</div>
               <div style={{ fontSize: 20, fontWeight: 600, lineHeight: 1.2, color: 'var(--color-text, #0f172a)' }}>
-                {totalSkills}
+                {stats.totalSkills}
               </div>
             </div>
           </div>
@@ -163,7 +187,7 @@ export function SkillsOverview() {
             <div>
               <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #475569)' }}>执行器</div>
               <div style={{ fontSize: 20, fontWeight: 600, lineHeight: 1.2, color: 'var(--color-text, #0f172a)' }}>
-                {data.filter(e => e.skills.length > 0).length}
+                {stats.executorsWithSkills}
                 <span style={{ fontSize: 13, fontWeight: 400, marginLeft: 2 }}>/ {data.length}</span>
               </div>
             </div>
@@ -182,12 +206,12 @@ export function SkillsOverview() {
               color: '#f59e0b',
               fontSize: 16,
             }}>
-              <SettingOutlined />
+              <FileTextOutlined />
             </div>
             <div>
               <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #475569)' }}>文件总数</div>
               <div style={{ fontSize: 20, fontWeight: 600, lineHeight: 1.2, color: 'var(--color-text, #0f172a)' }}>
-                {allSkills.reduce((sum, { skill }) => sum + skill.file_count, 0)}
+                {stats.totalFiles}
               </div>
             </div>
           </div>
@@ -204,20 +228,25 @@ export function SkillsOverview() {
         flexWrap: 'wrap',
       }}>
         {/* Executor filter pills */}
-        <div style={{
-          display: 'flex',
-          gap: 6,
-          flexWrap: 'wrap',
-          flex: 1,
-        }}>
+        <div
+          role="tablist"
+          aria-label="按执行器筛选"
+          style={{
+            display: 'flex',
+            gap: 6,
+            flexWrap: 'wrap',
+            flex: 1,
+          }}
+        >
           {executorTabs.map(tab => {
             const isActive = filterExecutor === tab.key;
             const color = tab.key === 'all' ? '#0891b2' : (EXECUTOR_COLORS[tab.key] || '#64748b');
             return (
               <button
                 key={tab.key}
+                role="tab"
+                aria-selected={isActive}
                 onClick={() => setFilterExecutor(tab.key)}
-                className="skill-filter-pill"
                 style={{
                   display: 'inline-flex',
                   alignItems: 'center',
@@ -316,7 +345,7 @@ export function SkillsOverview() {
       <ImportExportModal
         open={exportModalOpen}
         mode={exportMode}
-        executor={selectedExecutor}
+        executor={filterExecutor !== 'all' ? filterExecutor : selectedExecutor}
         data={data}
         initialSelectedSkills={initialSelectedSkills}
         onClose={() => {
@@ -334,16 +363,23 @@ function SkillCard({ skill, executor, onClick }: {
   onClick: () => void;
 }) {
   const color = EXECUTOR_COLORS[executor] || '#0891b2';
-  const initial = skill.name.replace(/.*\//, '').charAt(0).toUpperCase();
+  const { category, shortName } = splitSkillName(skill.name);
   const executorLabel = EXECUTORS.find(e => e.value === executor)?.label || executor;
-  const shortName = skill.name.includes('/') ? skill.name.split('/').pop()! : skill.name;
-  const category = skill.name.includes('/') ? skill.name.split('/')[0] : null;
 
   return (
     <Card
       size="small"
       hoverable
       onClick={onClick}
+      tabIndex={0}
+      role="button"
+      aria-label={`${shortName} - ${executorLabel}`}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
       className="skill-card"
       style={{
         borderRadius: 12,
@@ -383,7 +419,7 @@ function SkillCard({ skill, executor, onClick }: {
           fontWeight: 600,
           flexShrink: 0,
         }}>
-          {initial}
+          {shortName.charAt(0).toUpperCase()}
         </div>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{

--- a/frontend/src/components/skills/SkillsOverview.tsx
+++ b/frontend/src/components/skills/SkillsOverview.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { Spin, Input, Space, Button, Tag, Dropdown, message } from 'antd';
+import { Spin, Input, Space, Button, Tag, Dropdown, Card, message } from 'antd';
 import type { MenuProps } from 'antd';
 import {
   ThunderboltOutlined, SearchOutlined,
@@ -122,25 +122,76 @@ export function SkillsOverview() {
         gap: 12,
         marginBottom: 20,
       }}>
-        <StatCard
-          icon={<ThunderboltOutlined />}
-          iconColor="#0891b2"
-          label="Skill 总数"
-          value={totalSkills}
-        />
-        <StatCard
-          icon={<AppstoreOutlined />}
-          iconColor="#10b981"
-          label="执行器"
-          value={data.filter(e => e.skills.length > 0).length}
-          suffix={`/ ${data.length}`}
-        />
-        <StatCard
-          icon={<SettingOutlined />}
-          iconColor="#f59e0b"
-          label="文件总数"
-          value={allSkills.reduce((sum, { skill }) => sum + skill.file_count, 0)}
-        />
+        <Card size="small" style={{ borderRadius: 12 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 36,
+              height: 36,
+              borderRadius: 10,
+              background: 'rgba(8, 145, 178, 0.12)',
+              color: '#0891b2',
+              fontSize: 16,
+            }}>
+              <ThunderboltOutlined />
+            </div>
+            <div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #475569)' }}>Skill 总数</div>
+              <div style={{ fontSize: 20, fontWeight: 600, lineHeight: 1.2, color: 'var(--color-text, #0f172a)' }}>
+                {totalSkills}
+              </div>
+            </div>
+          </div>
+        </Card>
+        <Card size="small" style={{ borderRadius: 12 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 36,
+              height: 36,
+              borderRadius: 10,
+              background: 'rgba(16, 185, 129, 0.12)',
+              color: '#10b981',
+              fontSize: 16,
+            }}>
+              <AppstoreOutlined />
+            </div>
+            <div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #475569)' }}>执行器</div>
+              <div style={{ fontSize: 20, fontWeight: 600, lineHeight: 1.2, color: 'var(--color-text, #0f172a)' }}>
+                {data.filter(e => e.skills.length > 0).length}
+                <span style={{ fontSize: 13, fontWeight: 400, marginLeft: 2 }}>/ {data.length}</span>
+              </div>
+            </div>
+          </div>
+        </Card>
+        <Card size="small" style={{ borderRadius: 12 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 36,
+              height: 36,
+              borderRadius: 10,
+              background: 'rgba(245, 158, 11, 0.12)',
+              color: '#f59e0b',
+              fontSize: 16,
+            }}>
+              <SettingOutlined />
+            </div>
+            <div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #475569)' }}>文件总数</div>
+              <div style={{ fontSize: 20, fontWeight: 600, lineHeight: 1.2, color: 'var(--color-text, #0f172a)' }}>
+                {allSkills.reduce((sum, { skill }) => sum + skill.file_count, 0)}
+              </div>
+            </div>
+          </div>
+        </Card>
       </div>
 
       {/* Filter & Search bar */}
@@ -161,20 +212,21 @@ export function SkillsOverview() {
         }}>
           {executorTabs.map(tab => {
             const isActive = filterExecutor === tab.key;
-            const color = tab.key === 'all' ? '#0891b2' : (EXECUTOR_COLORS[tab.key] || '#6c7086');
+            const color = tab.key === 'all' ? '#0891b2' : (EXECUTOR_COLORS[tab.key] || '#64748b');
             return (
               <button
                 key={tab.key}
                 onClick={() => setFilterExecutor(tab.key)}
+                className="skill-filter-pill"
                 style={{
                   display: 'inline-flex',
                   alignItems: 'center',
                   gap: 4,
                   padding: '4px 12px',
                   borderRadius: 20,
-                  border: `1px solid ${isActive ? color : 'var(--color-border, #313244)'}`,
-                  background: isActive ? `${color}20` : 'transparent',
-                  color: isActive ? color : 'var(--color-text-secondary, #a6adc8)',
+                  border: `1px solid ${isActive ? color : 'var(--color-border, #e2e8f0)'}`,
+                  background: isActive ? `${color}15` : 'transparent',
+                  color: isActive ? color : 'var(--color-text-secondary, #475569)',
                   cursor: 'pointer',
                   fontSize: 13,
                   fontWeight: isActive ? 500 : 400,
@@ -190,8 +242,8 @@ export function SkillsOverview() {
                   minWidth: 18,
                   height: 18,
                   borderRadius: 9,
-                  background: isActive ? color : 'var(--color-fill, #45475a)',
-                  color: isActive ? '#fff' : 'var(--color-text-secondary, #a6adc8)',
+                  background: isActive ? color : 'var(--color-fill, #e2e8f0)',
+                  color: isActive ? '#fff' : 'var(--color-text-secondary, #475569)',
                   fontSize: 11,
                   lineHeight: 1,
                   padding: '0 4px',
@@ -206,7 +258,7 @@ export function SkillsOverview() {
         <Space size={8}>
           <Input
             placeholder="搜索 Skills..."
-            prefix={<SearchOutlined style={{ color: 'var(--color-text-quaternary, #6c7086)' }} />}
+            prefix={<SearchOutlined style={{ color: 'var(--color-text-quaternary, #94a3b8)' }} />}
             value={searchText}
             onChange={e => setSearchText(e.target.value)}
             style={{ width: 200, borderRadius: 20 }}
@@ -229,7 +281,7 @@ export function SkillsOverview() {
         <div style={{
           textAlign: 'center',
           padding: '60px 20px',
-          color: 'var(--color-text-secondary, #a6adc8)',
+          color: 'var(--color-text-secondary, #475569)',
         }}>
           <AppstoreOutlined style={{ fontSize: 48, marginBottom: 16, opacity: 0.3 }} />
           <div style={{ fontSize: 16 }}>{searchText ? '无匹配结果' : '暂无 Skills'}</div>
@@ -276,54 +328,6 @@ export function SkillsOverview() {
   );
 }
 
-function StatCard({ icon, iconColor, label, value, suffix }: {
-  icon: React.ReactNode;
-  iconColor: string;
-  label: string;
-  value: number;
-  suffix?: string;
-}) {
-  return (
-    <div style={{
-      display: 'flex',
-      alignItems: 'center',
-      gap: 12,
-      padding: '14px 16px',
-      borderRadius: 12,
-      background: 'var(--color-bg-container, #1e1e2e)',
-      border: '1px solid var(--color-border, #313244)',
-      transition: 'border-color 0.2s',
-    }}
-      onMouseEnter={e => {
-        e.currentTarget.style.borderColor = iconColor;
-      }}
-      onMouseLeave={e => {
-        e.currentTarget.style.borderColor = 'var(--color-border, #313244)';
-      }}
-    >
-      <div style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: 36,
-        height: 36,
-        borderRadius: 10,
-        background: `${iconColor}18`,
-        color: iconColor,
-        fontSize: 16,
-      }}>
-        {icon}
-      </div>
-      <div>
-        <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #a6adc8)' }}>{label}</div>
-        <div style={{ fontSize: 20, fontWeight: 600, lineHeight: 1.2, color: 'var(--color-text, #cdd6f4)' }}>
-          {value}{suffix && <span style={{ fontSize: 13, fontWeight: 400, marginLeft: 2 }}>{suffix}</span>}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function SkillCard({ skill, executor, onClick }: {
   skill: SkillMeta;
   executor: string;
@@ -336,30 +340,21 @@ function SkillCard({ skill, executor, onClick }: {
   const category = skill.name.includes('/') ? skill.name.split('/')[0] : null;
 
   return (
-    <div
+    <Card
+      size="small"
+      hoverable
       onClick={onClick}
+      className="skill-card"
       style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 12,
-        padding: 16,
         borderRadius: 12,
-        background: 'var(--color-bg-container, #1e1e2e)',
-        border: '1px solid var(--color-border, #313244)',
         cursor: 'pointer',
         transition: 'all 0.2s',
         position: 'relative',
         overflow: 'hidden',
+        borderColor: 'var(--color-border, #e2e8f0)',
       }}
-      onMouseEnter={e => {
-        e.currentTarget.style.borderColor = color;
-        e.currentTarget.style.boxShadow = `0 4px 12px ${color}20`;
-        e.currentTarget.style.transform = 'translateY(-2px)';
-      }}
-      onMouseLeave={e => {
-        e.currentTarget.style.borderColor = 'var(--color-border, #313244)';
-        e.currentTarget.style.boxShadow = 'none';
-        e.currentTarget.style.transform = 'translateY(0)';
+      styles={{
+        body: { padding: 16 },
       }}
     >
       {/* Top accent line */}
@@ -379,7 +374,7 @@ function SkillCard({ skill, executor, onClick }: {
           width: 36,
           height: 36,
           borderRadius: 10,
-          background: `${color}18`,
+          background: `${color}15`,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -394,7 +389,7 @@ function SkillCard({ skill, executor, onClick }: {
           <div style={{
             fontSize: 14,
             fontWeight: 500,
-            color: 'var(--color-text, #cdd6f4)',
+            color: 'var(--color-text, #0f172a)',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
@@ -403,7 +398,7 @@ function SkillCard({ skill, executor, onClick }: {
           </div>
           <div style={{
             fontSize: 11,
-            color: 'var(--color-text-tertiary, #6c7086)',
+            color: 'var(--color-text-tertiary, #94a3b8)',
             marginTop: 2,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
@@ -418,13 +413,14 @@ function SkillCard({ skill, executor, onClick }: {
       {skill.description && (
         <div style={{
           fontSize: 12,
-          color: 'var(--color-text-secondary, #a6adc8)',
+          color: 'var(--color-text-secondary, #475569)',
           lineHeight: 1.5,
           display: '-webkit-box',
           WebkitLineClamp: 2,
           WebkitBoxOrient: 'vertical',
           overflow: 'hidden',
           minHeight: 36,
+          marginTop: 12,
         }}>
           {skill.description}
         </div>
@@ -435,7 +431,7 @@ function SkillCard({ skill, executor, onClick }: {
         display: 'flex',
         alignItems: 'center',
         gap: 6,
-        marginTop: 'auto',
+        marginTop: 12,
         flexWrap: 'wrap',
       }}>
         {category && (
@@ -445,9 +441,9 @@ function SkillCard({ skill, executor, onClick }: {
             lineHeight: '18px',
             padding: '0 6px',
             borderRadius: 4,
-            background: 'var(--color-fill, #45475a)',
+            background: 'var(--color-fill, #e2e8f0)',
             border: 'none',
-            color: 'var(--color-text-secondary, #a6adc8)',
+            color: 'var(--color-text-secondary, #475569)',
           }}>
             {category}
           </Tag>
@@ -459,7 +455,7 @@ function SkillCard({ skill, executor, onClick }: {
             lineHeight: '18px',
             padding: '0 6px',
             borderRadius: 4,
-            background: `${color}18`,
+            background: `${color}15`,
             border: 'none',
             color,
           }}>
@@ -469,11 +465,11 @@ function SkillCard({ skill, executor, onClick }: {
         <span style={{
           marginLeft: 'auto',
           fontSize: 11,
-          color: 'var(--color-text-quaternary, #585b70)',
+          color: 'var(--color-text-quaternary, #94a3b8)',
         }}>
           {formatSize(skill.total_size)}
         </span>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/skills/helpers.ts
+++ b/frontend/src/components/skills/helpers.ts
@@ -1,14 +1,10 @@
-import { EXECUTORS } from '@/types';
+import { EXECUTOR_COLORS, getExecutorColor } from '@/types';
 import type { SkillMeta } from '@/types';
 
-export const EXECUTOR_COLORS: Record<string, string> = {};
-EXECUTORS.forEach(e => { EXECUTOR_COLORS[e.value] = e.color; });
-EXECUTOR_COLORS['claude_code'] = EXECUTOR_COLORS['claudecode'];
-EXECUTOR_COLORS['claude'] = EXECUTOR_COLORS['claudecode'];
-EXECUTOR_COLORS['cbc'] = EXECUTOR_COLORS['codebuddy'];
-EXECUTOR_COLORS['atom'] = EXECUTOR_COLORS['atomcode'];
+export { EXECUTOR_COLORS, getExecutorColor };
 
 export function formatSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '-';
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
@@ -26,6 +22,12 @@ export function formatTime(iso: string | null): string {
 
 export function normalizeExecutor(name: string): string {
   return name.toLowerCase().replace(/[_\s-]/g, '');
+}
+
+export function splitSkillName(name: string): { category: string | null; shortName: string } {
+  if (!name.includes('/')) return { category: null, shortName: name };
+  const parts = name.split('/');
+  return { category: parts[0], shortName: parts.slice(1).join('/') };
 }
 
 export interface SkillTreeNode {


### PR DESCRIPTION
## Summary
- Redesign Skills tab with modern card grid layout inspired by WorkBuddy
- Add executor filter pills with count badges for easy filtering
- Each skill card shows: colored initial icon, name, description, version, file size
- Clean tab bar with underline indicator style

## Changes
- `SkillsPanel.tsx`: Cleaner tab bar with underline indicator
- `SkillsOverview.tsx`: New card grid layout with:
  - Stats cards (Skill总数, 执行器, 文件总数)
  - Responsive 3-column grid
  - Theme-aware colors (works in both light/dark mode)

## Testing
- TypeScript compiles without errors
- UI verified in both light and dark themes via Playwright screenshots