### PR TITLE
将 Token 用量统计卡片从动态 Masonry 布局移至固定位置

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -188,10 +188,7 @@ export function Dashboard({ onBack }: { onBack?: () => void }) {
     { key: 'message-stats', render: () => <MessageStatsCard msgStats={msgStats} msgStatsError={msgStatsError} processingRate={processingRate} /> },
     { key: 'skills-stats', render: () => <SkillsStatsCard stats={stats} loading={loading} /> },
     { key: 'backup-stats', render: () => <BackupStatsCard stats={stats} loading={loading} /> },
-    {
-      key: 'usage-stats',
-      render: () => <UsageStatsCard since={usageStatsRange.since} until={usageStatsRange.until} />,
-    },
+    // usage-stats 卡片已移至 Masonry 下方固定显示，见下方独立渲染
     { key: 'share-card', render: () => <ShareCardPanel /> },
   ];
 
@@ -224,6 +221,10 @@ export function Dashboard({ onBack }: { onBack?: () => void }) {
         itemRender={(item) => item.data.render()}
         fresh
       />
+      {/* Token 用量统计 — 数据较多，固定置于最近执行记录上方 */}
+      <div style={{ marginTop: 16 }}>
+        <UsageStatsCard since={usageStatsRange.since} until={usageStatsRange.until} />
+      </div>
       <Card
         title={<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><ThunderboltOutlined /><span>最近执行记录</span></div>}
         style={{ borderRadius: 12, marginTop: 16 }}


### PR DESCRIPTION
## 变更说明

Token 用量统计卡片数据较多（包含日/周/月维度的表格和模型细分），
在 Masonry 瀑布流中占据较大高度，影响整体浏览体验。

## 改动内容

- 从 `panels` 数组中移除 `UsageStatsCard`，不再参与 Masonry 动态布局
- 将 `UsageStatsCard` 固定渲染在 Masonry 下方、最近执行记录卡片上方

布局顺序：
```
Masonry 动态瀑布流（其余所有卡片）
[固定] Token 用量统计
[固定] 最近执行记录
```