### PR TITLE
feat: 增加运行视图 — 6 列看板展示全部执行记录流水线

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -38,7 +38,7 @@ pub struct UpdateExecutionRecordRequest<'a> {
 }
 
 pub struct ExecutionRecordQuery<'a> {
-    pub todo_id: i64,
+    pub todo_id: Option<i64>,
     pub limit: i64,
     pub offset: i64,
     pub status: Option<&'a str>,
@@ -101,15 +101,14 @@ impl Database {
         &self,
         query: ExecutionRecordQuery<'_>,
     ) -> Result<(Vec<ExecutionRecord>, i64), sea_orm::DbErr> {
-        let base_filter = execution_records::Column::TodoId.eq(query.todo_id);
-        let filter = if let Some(s) = query.status {
-            if s == "all" {
-                base_filter // "all" 等同于不传过滤条件
-            } else {
-                base_filter.and(execution_records::Column::Status.eq(s))
-            }
+        let base_filter = if let Some(todo_id) = query.todo_id {
+            execution_records::Column::TodoId.eq(todo_id)
         } else {
-            base_filter
+            execution_records::Column::TodoId.is_not_null()
+        };
+        let filter = match query.status {
+            Some("all") | None => base_filter,
+            Some(s) => base_filter.and(execution_records::Column::Status.eq(s)),
         };
 
         let total: i64 = execution_records::Entity::find()

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1588,7 +1588,7 @@ mod tests {
 
     async fn create_test_execution_record(db: &Database, todo_id: i64, command: &str) -> i64 {
         db.create_execution_record(NewExecutionRecord {
-            todo_id,
+            todo_id: Some(todo_id),
             command,
             executor: "claudecode",
             trigger_type: "manual",
@@ -1713,7 +1713,7 @@ mod tests {
         let after = truncate_seconds(Utc::now());
 
         let (records, _) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
-            todo_id,
+            todo_id: Some(todo_id),
             limit: 100,
             offset: 0,
             status: None,
@@ -1749,7 +1749,7 @@ mod tests {
         let after = truncate_seconds(Utc::now());
 
         let (records, _) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
-            todo_id,
+            todo_id: Some(todo_id),
             limit: 100,
             offset: 0,
             status: None,
@@ -2038,7 +2038,7 @@ mod tests {
         let todo_id = db.create_todo("Test", "Prompt").await.unwrap();
         let record_id = create_test_execution_record(&db, todo_id, "echo hi").await;
         let (records, total) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
-            todo_id,
+            todo_id: Some(todo_id),
             limit: 100,
             offset: 0,
             status: None,
@@ -2062,7 +2062,7 @@ mod tests {
             create_test_execution_record(&db, todo_id, &format!("cmd{}", i)).await;
         }
         let (records, total) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
-            todo_id,
+            todo_id: Some(todo_id),
             limit: 2,
             offset: 0,
             status: None,
@@ -2081,7 +2081,7 @@ mod tests {
             create_test_execution_record(&db, todo_id, &format!("cmd{}", i)).await;
         }
         let (records, total) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
-            todo_id,
+            todo_id: Some(todo_id),
             limit: 10,
             offset: 2,
             status: None,
@@ -2125,7 +2125,7 @@ mod tests {
 
         let (running, total_running) =
             db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
-                todo_id,
+                todo_id: Some(todo_id),
                 limit: 10,
                 offset: 0,
                 status: Some("running"),
@@ -2138,7 +2138,7 @@ mod tests {
 
         let (success, total_success) =
             db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
-                todo_id,
+                todo_id: Some(todo_id),
                 limit: 10,
                 offset: 0,
                 status: Some("success"),
@@ -2151,7 +2151,7 @@ mod tests {
 
         let (failed, total_failed) =
             db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
-                todo_id,
+                todo_id: Some(todo_id),
                 limit: 10,
                 offset: 0,
                 status: Some("failed"),
@@ -2163,7 +2163,7 @@ mod tests {
         assert_eq!(failed[0].id, failed_id);
 
         let (all, total_all) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
-            todo_id,
+            todo_id: Some(todo_id),
             limit: 10,
             offset: 0,
             status: None,
@@ -2176,7 +2176,7 @@ mod tests {
         // Test Some("all") returns all records (db layer should treat "all" as no filter)
         let (all_filter, total_all_filter) =
             db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
-                todo_id,
+                todo_id: Some(todo_id),
                 limit: 10,
                 offset: 0,
                 status: Some("all"),
@@ -2212,7 +2212,7 @@ mod tests {
         .await
         .unwrap();
         let (records, _) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
-            todo_id,
+            todo_id: Some(todo_id),
             limit: 100,
             offset: 0,
             status: None,

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -1139,6 +1139,7 @@ pub async fn run_auto_review(
     let db_c = db.clone();
     let er_c = executor_registry.clone();
     let tx_c = tx.clone();
+    let tx_outer = tx.clone();
     let tm_c = task_manager.clone();
     let cfg_c = config.clone();
     let runtime = review_runtime();
@@ -1158,12 +1159,22 @@ pub async fn run_auto_review(
             let _ = db
                 .set_record_last_review_status(record_id, "failed")
                 .await;
+            let _ = tx_outer.send(crate::handlers::ExecEvent::ReviewStatusChanged {
+                record_id,
+                todo_id,
+                review_status: "failed".to_string(),
+            });
         }
         Err(_) => {
             tracing::warn!("auto-review thread dropped reply for todo #{} record #{}", todo_id, record_id);
             let _ = db
                 .set_record_last_review_status(record_id, "failed")
                 .await;
+            let _ = tx_outer.send(crate::handlers::ExecEvent::ReviewStatusChanged {
+                record_id,
+                todo_id,
+                review_status: "failed".to_string(),
+            });
         }
     }
 }
@@ -1185,6 +1196,9 @@ async fn run_auto_review_inner(
         .ok_or_else(|| format!("original todo #{} not found", todo_id))?;
     if original.todo_type != 0 || !original.auto_review_enabled {
         let _ = db.set_record_last_review_status(record_id, "skipped").await;
+        let _ = tx.send(crate::handlers::ExecEvent::ReviewStatusChanged {
+            record_id, todo_id, review_status: "skipped".to_string(),
+        });
         return Ok(());
     }
     let record = db.get_execution_record(record_id).await
@@ -1193,6 +1207,9 @@ async fn run_auto_review_inner(
     use crate::models::ExecutionStatus;
     if !matches!(record.status, ExecutionStatus::Success | ExecutionStatus::Failed) {
         let _ = db.set_record_last_review_status(record_id, "skipped").await;
+        let _ = tx.send(crate::handlers::ExecEvent::ReviewStatusChanged {
+            record_id, todo_id, review_status: "skipped".to_string(),
+        });
         return Ok(());
     }
     // 避免重复评审
@@ -1265,6 +1282,9 @@ async fn run_auto_review_inner(
         Some(id) => id,
         None => {
             let _ = db.set_record_last_review_status(record_id, "failed").await;
+            let _ = tx.send(crate::handlers::ExecEvent::ReviewStatusChanged {
+                record_id, todo_id, review_status: "failed".to_string(),
+            });
             return Err("review execution produced no record (rejected?)".to_string());
         }
     };

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -1233,6 +1233,11 @@ async fn run_auto_review_inner(
     // 5) 标记 pending
     let _ = db.set_record_last_review_status(record_id, "pending").await;
     let _ = db.set_record_last_reviewed_at(record_id).await;
+    let _ = tx.send(crate::handlers::ExecEvent::ReviewStatusChanged {
+        record_id,
+        todo_id,
+        review_status: "pending".to_string(),
+    });
 
     // 6) 同步执行评审实例
     let request = RunTodoExecutionRequest {
@@ -1294,6 +1299,11 @@ async fn run_auto_review_inner(
     }
     let _ = db.link_review_to_source(review_record_id, record_id, review_status_str).await;
     let _ = db.set_record_last_review_status(record_id, review_status_str).await;
+    let _ = tx.send(crate::handlers::ExecEvent::ReviewStatusChanged {
+        record_id,
+        todo_id,
+        review_status: review_status_str.to_string(),
+    });
 
     tracing::info!(
         "auto-review done: original_todo=#{} record=#{} review_todo=#{} review_record=#{} status={} rating={:?}",

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -316,6 +316,43 @@ pub async fn get_running_execution_records_handler(
 }
 
 #[derive(Debug, Deserialize)]
+pub struct RunningBoardQuery {
+    #[serde(default)]
+    pub page: Option<i64>,
+    #[serde(default)]
+    pub limit: Option<i64>,
+}
+
+pub async fn get_running_board(
+    State(state): State<AppState>,
+    Query(query): Query<RunningBoardQuery>,
+) -> Result<ApiResponse<crate::models::RunningBoardResponse>, AppError> {
+    let page = query.page.unwrap_or(1).max(1);
+    let limit = query.limit.unwrap_or(50).clamp(1, 200);
+    let offset = (page - 1) * limit;
+
+    let (records, total) = state
+        .db
+        .get_execution_records(crate::db::execution::ExecutionRecordQuery {
+            todo_id: None,
+            limit,
+            offset,
+            status: None,
+        })
+        .await?;
+
+    let scheduled_todos = state.db.get_scheduler_todos().await?;
+
+    Ok(ApiResponse::ok(crate::models::RunningBoardResponse {
+        records,
+        scheduled_todos,
+        total,
+        page,
+        limit,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
 pub struct ForceFailRequest {
     pub record_id: i64,
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -83,6 +83,11 @@ pub enum ExecEvent {
         task_id: String,
         stats: crate::models::ExecutionStats,
     },
+    ReviewStatusChanged {
+        record_id: i64,
+        todo_id: i64,
+        review_status: String,
+    },
 }
 
 #[derive(Debug)]
@@ -668,6 +673,7 @@ pub fn create_app(
         .route("/api/tags/{id}", delete(tag::delete_tag))
         .route("/api/execution-records", get(execution::get_execution_records))
         .route("/api/execution-records/running", get(execution::get_running_execution_records_handler))
+        .route("/api/running-board", get(execution::get_running_board))
         .route("/api/execution-records/session/{session_id}", get(execution::get_execution_records_by_session))
         .route("/api/execution-records/{id}/logs", get(execution::get_execution_logs_handler))
         .route("/api/execution-records/{id}", get(execution::get_execution_record))

--- a/backend/src/hooks/service.rs
+++ b/backend/src/hooks/service.rs
@@ -155,7 +155,7 @@ fn matching_items(todo: &Todo, trigger: HookTrigger) -> Vec<&TodoHookItem> {
 /// enough; we don't need the full history.
 async fn lookup_source_result(ctx: &ServiceContext, source_id: i64) -> Option<String> {
     let query = crate::db::execution::ExecutionRecordQuery {
-        todo_id: source_id,
+        todo_id: Some(source_id),
         limit: 1,
         offset: 0,
         status: Some("success"),
@@ -189,7 +189,7 @@ async fn lookup_latest_finished_record(
     // status="all" means no status filter (see `get_execution_records`), and
     // ORDER BY started_at DESC LIMIT 1 gives us the most recent record.
     let query = crate::db::execution::ExecutionRecordQuery {
-        todo_id: source_id,
+        todo_id: Some(source_id),
         limit: 1,
         offset: 0,
         status: Some("all"),

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -393,13 +393,23 @@ pub struct SmartCreateRequest {
 
 #[derive(Deserialize)]
 pub struct TodoIdQuery {
-    pub todo_id: i64,
+    #[serde(default)]
+    pub todo_id: Option<i64>,
     #[serde(default)]
     pub page: Option<i64>,
     #[serde(default)]
     pub limit: Option<i64>,
     #[serde(default)]
     pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunningBoardResponse {
+    pub records: Vec<ExecutionRecord>,
+    pub scheduled_todos: Vec<Todo>,
+    pub total: i64,
+    pub page: i64,
+    pub limit: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -200,6 +200,7 @@ impl FeishuPushService {
                 ))
             }
             ExecEvent::Sync { .. } => None,
+            ExecEvent::ReviewStatusChanged { .. } => None,
         }
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ntd",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@ant-design/icons": "^6.1.1",
         "@ant-design/x-markdown": "^2.5.0",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3714,3 +3714,259 @@ code {
     cursor: default;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Running Board
+   ═══════════════════════════════════════════════════════════════ */
+
+.running-board {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.running-board-loading {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  height: 100%;
+}
+
+.running-columns-container {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+.running-column {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--color-border);
+  overflow: hidden;
+}
+
+.running-column:last-child {
+  border-right: none;
+}
+
+.running-column-header {
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 2px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.running-column-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.running-column-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.running-column-icon {
+  font-size: 14px;
+}
+
+.running-column-count {
+  margin-left: auto;
+  background: var(--color-bg);
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 10px;
+}
+
+.running-column-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-xs);
+}
+
+.running-column-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 80px;
+  color: var(--color-text-tertiary);
+  font-size: 12px;
+}
+
+/* ─── Running Card ─── */
+
+.running-card {
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm) var(--space-md);
+  margin-bottom: var(--space-xs);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.running-card:hover {
+  box-shadow: var(--shadow-sm);
+  border-color: var(--color-primary);
+}
+
+.running-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.running-card-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text);
+  line-height: 1.4;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.running-card-title:hover {
+  color: var(--color-primary);
+}
+
+.running-card-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.running-card-time {
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  margin-bottom: 2px;
+}
+
+.running-card-duration {
+  color: var(--color-text-secondary);
+}
+
+.running-card-stats {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.running-card-cost {
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+}
+
+.running-card-footer {
+  margin-top: 4px;
+}
+
+.running-card-next-run {
+  font-size: 11px;
+  color: #8b5cf6;
+  font-weight: 500;
+}
+
+/* ─── Scheduled Card ─── */
+
+.scheduled-card {
+  border-left: 3px solid #8b5cf6;
+}
+
+/* ─── Execution Card status borders ─── */
+
+.execution-card.status-running {
+  border-left: 3px solid #f59e0b;
+}
+
+.execution-card.status-success {
+  border-left: 3px solid #22c55e;
+}
+
+.execution-card.status-failed {
+  border-left: 3px solid #ef4444;
+}
+
+/* ─── Running Board Stats Bar ─── */
+
+.running-board-stats {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px var(--space-md);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-elevated);
+  flex-shrink: 0;
+  font-size: 12px;
+  overflow-x: auto;
+}
+
+.running-stat-item {
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.running-stat-item strong {
+  font-weight: 600;
+}
+
+.running-stat-divider {
+  width: 1px;
+  height: 12px;
+  background: var(--color-border);
+  flex-shrink: 0;
+}
+
+/* ─── Running Board Pagination ─── */
+
+.running-board-pagination {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-sm);
+  border-top: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+/* ─── Mobile ─── */
+
+.running-mobile-list {
+  padding: var(--space-sm);
+}
+
+.running-mobile-list .running-card {
+  margin-bottom: var(--space-sm);
+  cursor: default;
+}
+
+.running-mobile-tabs {
+  padding: 0;
+}
+
+.running-mobile-tabs .ant-tabs-nav {
+  margin-bottom: 0;
+}
+
+.running-mobile-tabs .ant-tabs-tab {
+  font-size: 13px;
+}

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -8,9 +8,11 @@ import {
   ProfileOutlined,
   SearchOutlined,
   FolderOutlined,
+  ThunderboltOutlined,
 } from '@ant-design/icons';
 import { useApp } from '@/hooks/useApp';
 import { KanbanBoard } from './KanbanBoard';
+import { RunningBoard } from './RunningBoard';
 import { TodoCard } from './TodoCard';
 import * as db from '@/utils/database';
 import { formatRelativeTime } from '@/utils/datetime';
@@ -28,7 +30,7 @@ interface MemorialBoardProps {
   onBack?: () => void;
 }
 
-type BoardMode = 'memorial' | 'kanban';
+type BoardMode = 'memorial' | 'kanban' | 'running';
 
 export function MemorialBoard({ onBack }: MemorialBoardProps) {
   const { state, dispatch } = useApp();
@@ -368,6 +370,7 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
             options={[
               { label: <span><ProfileOutlined /> 结论视图</span>, value: 'memorial' },
               { label: <span><AppstoreOutlined /> 看板视图</span>, value: 'kanban' },
+              { label: <span><ThunderboltOutlined /> 运行视图</span>, value: 'running' },
             ]}
           />
         </div>
@@ -414,7 +417,7 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
                 <CloseCircleOutlined /> <strong>{failedCount}</strong> 失败
               </span>
             </div>
-          ) : (
+          ) : boardMode === 'kanban' ? (
             <div className="memorial-summary">
               <span className="memorial-stat-dot memorial-stat-all">共 <strong>{kanbanStats.length}</strong> 条</span>
               <span className="memorial-stat-dot" style={{ color: '#3b82f6' }}>待办 <strong>{kanbanStatsCount.pending}</strong></span>
@@ -422,11 +425,13 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
               <span className="memorial-stat-dot" style={{ color: '#22c55e' }}>已完成 <strong>{kanbanStatsCount.completed}</strong></span>
               <span className="memorial-stat-dot" style={{ color: '#ef4444' }}>失败 <strong>{kanbanStatsCount.failed}</strong></span>
             </div>
-          )}
+          ) : null}
         </div>
       </div>
 
-      {boardMode === 'kanban' ? (
+      {boardMode === 'running' ? (
+        <RunningBoard searchText={searchText} hours={hours} selectedProject={selectedProject} />
+      ) : boardMode === 'kanban' ? (
         <KanbanBoard searchText={searchText} hours={hours} onSearchChange={setSearchText} onHoursChange={setHours} />
       ) : loading ? (
         <div className="memorial-grid">

--- a/frontend/src/components/RunningBoard.tsx
+++ b/frontend/src/components/RunningBoard.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
-import { Tabs, Tag, Skeleton, Card, Pagination } from 'antd';
+import { useState, useMemo, useCallback, useRef } from 'react';
+import { Tabs, Tag, Skeleton, Card } from 'antd';
 import {
   ClockCircleOutlined,
   CheckCircleOutlined,
@@ -54,8 +54,7 @@ const COLUMN_ICONS: Record<RunningBoardColumn, React.ReactNode> = {
 /* ─── Scheduled Todo Card ─── */
 
 function ScheduledTodoCard({ todo, onSelectTodo }: { todo: ScheduledTodo; onSelectTodo?: (id: number) => void }) {
-  const handleClick = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
+  const handleClick = useCallback(() => {
     onSelectTodo?.(todo.id);
   }, [todo.id, onSelectTodo]);
 
@@ -161,6 +160,7 @@ function RunningBoardColumnView({
   scheduledTodos,
   onSelectTodo,
   onCardClick,
+  getTodoTitle,
 }: {
   columnKey: RunningBoardColumn;
   label: string;
@@ -169,6 +169,7 @@ function RunningBoardColumnView({
   scheduledTodos: ScheduledTodo[];
   onSelectTodo?: (id: number) => void;
   onCardClick?: (record: ExecutionRecord) => void;
+  getTodoTitle?: (id: number) => string | undefined;
 }) {
   const count = records.length + scheduledTodos.length;
 
@@ -194,6 +195,7 @@ function RunningBoardColumnView({
               <ExecutionRecordCard
                 key={`record-${record.id}`}
                 record={record}
+                todoTitle={getTodoTitle?.(record.todo_id)}
                 onSelectTodo={onSelectTodo}
                 onCardClick={onCardClick}
               />
@@ -220,7 +222,7 @@ export function RunningBoard({ searchText, hours, selectedProject }: RunningBoar
   const [activeKey, setActiveKey] = useState<RunningBoardColumn>('running');
   const [drawerRecord, setDrawerRecord] = useState<ExecutionRecord | null>(null);
 
-  const { records, scheduledTodos, loading, total, page, limit, refresh, setPage } = useRunningBoard();
+  const { records, scheduledTodos, loading, refresh } = useRunningBoard();
   useAutoRefreshRunningBoard(refresh);
 
   const handleCardClick = useCallback((record: ExecutionRecord) => {
@@ -231,17 +233,8 @@ export function RunningBoard({ searchText, hours, selectedProject }: RunningBoar
     setDrawerRecord(null);
   }, []);
 
-  // Also refresh when WebSocket events come in
-  useEffect(() => {
-    const handleStarted = () => refresh();
-    const handleFinished = () => setTimeout(refresh, 1000);
-    window.addEventListener('executionStarted', handleStarted);
-    window.addEventListener('executionFinished', handleFinished);
-    return () => {
-      window.removeEventListener('executionStarted', handleStarted);
-      window.removeEventListener('executionFinished', handleFinished);
-    };
-  }, [refresh]);
+  // O(1) todo lookup map
+  const todoById = useMemo(() => new Map(state.todos.map(t => [t.id, t])), [state.todos]);
 
   // Apply filters from toolbar
   const filteredRecords = useMemo(() => {
@@ -249,10 +242,7 @@ export function RunningBoard({ searchText, hours, selectedProject }: RunningBoar
 
     // Project filter
     if (selectedProject) {
-      result = result.filter(r => {
-        const todo = state.todos.find(t => t.id === r.todo_id);
-        return todo?.workspace === selectedProject;
-      });
+      result = result.filter(r => todoById.get(r.todo_id)?.workspace === selectedProject);
     }
 
     // Time filter: only for completed/failed records
@@ -270,7 +260,7 @@ export function RunningBoard({ searchText, hours, selectedProject }: RunningBoar
     if (searchText?.trim()) {
       const q = searchText.toLowerCase();
       result = result.filter(r => {
-        const todo = state.todos.find(t => t.id === r.todo_id);
+        const todo = todoById.get(r.todo_id);
         return (
           (todo?.title?.toLowerCase().includes(q)) ||
           (todo?.prompt?.toLowerCase().includes(q)) ||
@@ -281,7 +271,7 @@ export function RunningBoard({ searchText, hours, selectedProject }: RunningBoar
     }
 
     return result;
-  }, [records, searchText, hours, selectedProject, state.todos]);
+  }, [records, searchText, hours, selectedProject, todoById]);
 
   const filteredScheduledTodos = useMemo(() => {
     let result = scheduledTodos;
@@ -316,19 +306,9 @@ export function RunningBoard({ searchText, hours, selectedProject }: RunningBoar
     selectTodo(todoId);
   }, [selectTodo]);
 
-  // Build todo title map from records
-  const todoTitleMap = useMemo(() => {
-    const map = new Map<number, string>();
-    // From scheduled todos
-    for (const t of scheduledTodos) {
-      map.set(t.id, t.title);
-    }
-    return map;
-  }, [scheduledTodos]);
-
   const getTodoTitle = useCallback((todoId: number): string | undefined => {
-    return todoTitleMap.get(todoId) || state.todos.find(t => t.id === todoId)?.title;
-  }, [todoTitleMap, state.todos]);
+    return todoById.get(todoId)?.title;
+  }, [todoById]);
 
   // Mobile tab items
   const mobileTabItems = RUNNING_BOARD_COLUMNS.map(col => {
@@ -448,6 +428,7 @@ export function RunningBoard({ searchText, hours, selectedProject }: RunningBoar
               scheduledTodos={grouped[col.key].scheduledTodos}
               onSelectTodo={handleSelectTodo}
               onCardClick={handleCardClick}
+              getTodoTitle={getTodoTitle}
             />
           ))}
         </div>
@@ -461,20 +442,6 @@ export function RunningBoard({ searchText, hours, selectedProject }: RunningBoar
             activeKey={activeKey}
             onChange={(key) => setActiveKey(key as RunningBoardColumn)}
             items={mobileTabItems}
-          />
-        </div>
-      )}
-
-      {/* Pagination */}
-      {total > limit && (
-        <div className="running-board-pagination">
-          <Pagination
-            current={page}
-            total={total}
-            pageSize={limit}
-            onChange={setPage}
-            size="small"
-            showSizeChanger={false}
           />
         </div>
       )}

--- a/frontend/src/components/RunningBoard.tsx
+++ b/frontend/src/components/RunningBoard.tsx
@@ -1,0 +1,491 @@
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import { Tabs, Tag, Skeleton, Card, Pagination } from 'antd';
+import {
+  ClockCircleOutlined,
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  LoadingOutlined,
+  EyeOutlined,
+  TrophyOutlined,
+} from '@ant-design/icons';
+import { useApp } from '@/hooks/useApp';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { useViewState } from '@/hooks/useViewState';
+import { ExecutorBadge } from './ExecutorBadge';
+import { RunningRecordDrawer } from './RunningRecordDrawer';
+import {
+  useRunningBoard,
+  classifyRecords,
+  RUNNING_BOARD_COLUMNS,
+  useAutoRefreshRunningBoard,
+} from '@/hooks/useRunningBoard';
+import { formatRelativeTime } from '@/utils/datetime';
+import type { ExecutionRecord, ScheduledTodo, RunningBoardColumn } from '@/types';
+
+/* ─── Helpers ─── */
+
+function formatDuration(ms: number | null): string {
+  if (!ms) return '-';
+  if (ms < 1_000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1_000).toFixed(0)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+function formatNextRunAt(nextRunAt: string | null): string {
+  if (!nextRunAt) return '-';
+  const now = Date.now();
+  const target = new Date(nextRunAt).getTime();
+  const diff = target - now;
+  if (diff < 0) return '即将触发';
+  if (diff < 60_000) return `${Math.floor(diff / 1000)}s 后`;
+  if (diff < 3600_000) return `${Math.floor(diff / 60_000)}m 后`;
+  return `${(diff / 3600_000).toFixed(1)}h 后`;
+}
+
+const COLUMN_ICONS: Record<RunningBoardColumn, React.ReactNode> = {
+  scheduled: <ClockCircleOutlined />,
+  running: <LoadingOutlined />,
+  completed: <CheckCircleOutlined />,
+  reviewing: <EyeOutlined />,
+  review_passed: <TrophyOutlined />,
+  failed: <CloseCircleOutlined />,
+};
+
+/* ─── Scheduled Todo Card ─── */
+
+function ScheduledTodoCard({ todo, onSelectTodo }: { todo: ScheduledTodo; onSelectTodo?: (id: number) => void }) {
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    onSelectTodo?.(todo.id);
+  }, [todo.id, onSelectTodo]);
+
+  return (
+    <div className="running-card scheduled-card">
+      <div className="running-card-header">
+        <span className="running-card-title" onClick={handleClick}>{todo.title}</span>
+      </div>
+      <div className="running-card-meta">
+        {todo.executor && <ExecutorBadge executor={todo.executor} />}
+        <Tag color="purple" style={{ marginLeft: 4 }}>
+          {todo.scheduler_config || 'cron'}
+        </Tag>
+        {todo.scheduler_timezone && (
+          <Tag style={{ marginLeft: 4 }}>{todo.scheduler_timezone}</Tag>
+        )}
+      </div>
+      <div className="running-card-footer">
+        <span className="running-card-next-run">
+          下次: {formatNextRunAt(todo.scheduler_next_run_at)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ─── Execution Record Card ─── */
+
+function ExecutionRecordCard({
+  record,
+  todoTitle,
+  onSelectTodo,
+  onCardClick,
+}: {
+  record: ExecutionRecord;
+  todoTitle?: string;
+  onSelectTodo?: (id: number) => void;
+  onCardClick?: (record: ExecutionRecord) => void;
+}) {
+  const duration = record.usage?.duration_ms || null;
+  const cost = record.usage?.total_cost_usd;
+
+  const handleTitleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    onSelectTodo?.(record.todo_id);
+  }, [record.todo_id, onSelectTodo]);
+
+  const handleCardClick = useCallback(() => {
+    onCardClick?.(record);
+  }, [record, onCardClick]);
+
+  const statusTag = useMemo(() => {
+    if (record.status === 'running') return <Tag color="orange">运行中</Tag>;
+    if (record.status === 'failed') return <Tag color="red">失败</Tag>;
+    if (record.last_review_status === 'pending') return <Tag color="cyan">评审中</Tag>;
+    if (record.last_review_status === 'success') return <Tag color="green">评审通过</Tag>;
+    if (record.last_review_status === 'failed') return <Tag color="red">评审失败</Tag>;
+    return <Tag color="green">成功</Tag>;
+  }, [record.status, record.last_review_status]);
+
+  return (
+    <div className={`running-card execution-card status-${record.status}`} onClick={handleCardClick}>
+      <div className="running-card-header">
+        <span className="running-card-title" onClick={handleTitleClick}>
+          {todoTitle || `Todo #${record.todo_id}`}
+        </span>
+        {statusTag}
+      </div>
+      <div className="running-card-meta">
+        {record.executor && <ExecutorBadge executor={record.executor} />}
+        {record.model && <Tag style={{ marginLeft: 4 }}>{record.model}</Tag>}
+        {record.trigger_type && record.trigger_type !== 'manual' && (
+          <Tag color="blue" style={{ marginLeft: 4 }}>{record.trigger_type}</Tag>
+        )}
+      </div>
+      <div className="running-card-time">
+        {formatRelativeTime(record.started_at)}
+        {duration != null && <span className="running-card-duration"> · {formatDuration(duration)}</span>}
+      </div>
+      {(record.rating != null || cost != null) && (
+        <div className="running-card-stats">
+          {record.rating != null && (
+            <Tag color={record.rating >= 80 ? 'green' : record.rating >= 50 ? 'orange' : 'red'}>
+              {record.rating}分
+            </Tag>
+          )}
+          {cost != null && cost > 0 && (
+            <span className="running-card-cost">${cost.toFixed(4)}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ─── Column Component ─── */
+
+function RunningBoardColumnView({
+  columnKey,
+  label,
+  color,
+  records,
+  scheduledTodos,
+  onSelectTodo,
+  onCardClick,
+}: {
+  columnKey: RunningBoardColumn;
+  label: string;
+  color: string;
+  records: ExecutionRecord[];
+  scheduledTodos: ScheduledTodo[];
+  onSelectTodo?: (id: number) => void;
+  onCardClick?: (record: ExecutionRecord) => void;
+}) {
+  const count = records.length + scheduledTodos.length;
+
+  return (
+    <div className="running-column">
+      <div className="running-column-header" style={{ borderBottomColor: color }}>
+        <div className="running-column-title">
+          <div className="running-column-dot" style={{ backgroundColor: color }} />
+          <span className="running-column-icon" style={{ color }}>{COLUMN_ICONS[columnKey]}</span>
+          <span>{label}</span>
+          <span className="running-column-count">{count}</span>
+        </div>
+      </div>
+      <div className="running-column-body">
+        {count === 0 ? (
+          <div className="running-column-empty">暂无</div>
+        ) : (
+          <>
+            {scheduledTodos.map(todo => (
+              <ScheduledTodoCard key={`scheduled-${todo.id}`} todo={todo} onSelectTodo={onSelectTodo} />
+            ))}
+            {records.map(record => (
+              <ExecutionRecordCard
+                key={`record-${record.id}`}
+                record={record}
+                onSelectTodo={onSelectTodo}
+                onCardClick={onCardClick}
+              />
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Main Component ─── */
+
+export interface RunningBoardProps {
+  searchText?: string;
+  hours?: number;
+  selectedProject?: string | null;
+}
+
+export function RunningBoard({ searchText, hours, selectedProject }: RunningBoardProps = {}) {
+  const { state } = useApp();
+  const { selectTodo } = useViewState();
+  const isMobile = useIsMobile();
+  const [activeKey, setActiveKey] = useState<RunningBoardColumn>('running');
+  const [drawerRecord, setDrawerRecord] = useState<ExecutionRecord | null>(null);
+
+  const { records, scheduledTodos, loading, total, page, limit, refresh, setPage } = useRunningBoard();
+  useAutoRefreshRunningBoard(refresh);
+
+  const handleCardClick = useCallback((record: ExecutionRecord) => {
+    setDrawerRecord(record);
+  }, []);
+
+  const handleDrawerClose = useCallback(() => {
+    setDrawerRecord(null);
+  }, []);
+
+  // Also refresh when WebSocket events come in
+  useEffect(() => {
+    const handleStarted = () => refresh();
+    const handleFinished = () => setTimeout(refresh, 1000);
+    window.addEventListener('executionStarted', handleStarted);
+    window.addEventListener('executionFinished', handleFinished);
+    return () => {
+      window.removeEventListener('executionStarted', handleStarted);
+      window.removeEventListener('executionFinished', handleFinished);
+    };
+  }, [refresh]);
+
+  // Apply filters from toolbar
+  const filteredRecords = useMemo(() => {
+    let result = records;
+
+    // Project filter
+    if (selectedProject) {
+      result = result.filter(r => {
+        const todo = state.todos.find(t => t.id === r.todo_id);
+        return todo?.workspace === selectedProject;
+      });
+    }
+
+    // Time filter: only for completed/failed records
+    if (hours && hours > 0) {
+      const cutoff = Date.now() - hours * 3600 * 1000;
+      result = result.filter(r => {
+        if (r.status === 'running') return true;
+        const finished = r.finished_at ? new Date(r.finished_at).getTime() : 0;
+        const started = new Date(r.started_at).getTime();
+        return (finished > cutoff) || (started > cutoff);
+      });
+    }
+
+    // Search filter
+    if (searchText?.trim()) {
+      const q = searchText.toLowerCase();
+      result = result.filter(r => {
+        const todo = state.todos.find(t => t.id === r.todo_id);
+        return (
+          (todo?.title?.toLowerCase().includes(q)) ||
+          (todo?.prompt?.toLowerCase().includes(q)) ||
+          (r.model?.toLowerCase().includes(q)) ||
+          (r.executor?.toLowerCase().includes(q))
+        );
+      });
+    }
+
+    return result;
+  }, [records, searchText, hours, selectedProject, state.todos]);
+
+  const filteredScheduledTodos = useMemo(() => {
+    let result = scheduledTodos;
+
+    if (selectedProject) {
+      result = result.filter(t => t.workspace === selectedProject);
+    }
+
+    if (searchText?.trim()) {
+      const q = searchText.toLowerCase();
+      result = result.filter(t =>
+        t.title.toLowerCase().includes(q) || t.prompt?.toLowerCase().includes(q)
+      );
+    }
+
+    return result;
+  }, [scheduledTodos, searchText, selectedProject]);
+
+  const grouped = useMemo(() => classifyRecords(filteredRecords, filteredScheduledTodos), [filteredRecords, filteredScheduledTodos]);
+
+  const stats = useMemo(() => ({
+    total: filteredRecords.length + filteredScheduledTodos.length,
+    scheduled: grouped.scheduled.scheduledTodos.length,
+    running: grouped.running.records.length,
+    completed: grouped.completed.records.length,
+    reviewing: grouped.reviewing.records.length,
+    review_passed: grouped.review_passed.records.length,
+    failed: grouped.failed.records.length,
+  }), [filteredRecords, filteredScheduledTodos, grouped]);
+
+  const handleSelectTodo = useCallback((todoId: number) => {
+    selectTodo(todoId);
+  }, [selectTodo]);
+
+  // Build todo title map from records
+  const todoTitleMap = useMemo(() => {
+    const map = new Map<number, string>();
+    // From scheduled todos
+    for (const t of scheduledTodos) {
+      map.set(t.id, t.title);
+    }
+    return map;
+  }, [scheduledTodos]);
+
+  const getTodoTitle = useCallback((todoId: number): string | undefined => {
+    return todoTitleMap.get(todoId) || state.todos.find(t => t.id === todoId)?.title;
+  }, [todoTitleMap, state.todos]);
+
+  // Mobile tab items
+  const mobileTabItems = RUNNING_BOARD_COLUMNS.map(col => {
+    const data = grouped[col.key];
+    const count = data.records.length + data.scheduledTodos.length;
+    return {
+      key: col.key,
+      label: `${col.label} (${count})`,
+      children: (
+        <div className="running-mobile-list">
+          {count === 0 ? (
+            <div className="running-column-empty">暂无</div>
+          ) : (
+            <>
+              {data.scheduledTodos.map(todo => (
+                <ScheduledTodoCard key={`scheduled-${todo.id}`} todo={todo} onSelectTodo={handleSelectTodo} />
+              ))}
+              {data.records.map(record => (
+                <ExecutionRecordCard
+                  key={`record-${record.id}`}
+                  record={record}
+                  todoTitle={getTodoTitle(record.todo_id)}
+                  onSelectTodo={handleSelectTodo}
+                  onCardClick={handleCardClick}
+                />
+              ))}
+            </>
+          )}
+        </div>
+      ),
+    };
+  });
+
+  // Touch swipe for mobile
+  const touchStartRef = useRef<{ x: number; y: number; time: number } | null>(null);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    touchStartRef.current = { x: touch.clientX, y: touch.clientY, time: Date.now() };
+  }, []);
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (!touchStartRef.current) return;
+    const touch = e.changedTouches[0];
+    const deltaX = touch.clientX - touchStartRef.current.x;
+    const deltaY = touch.clientY - touchStartRef.current.y;
+    const deltaTime = Date.now() - touchStartRef.current.time;
+    if (Math.abs(deltaX) > 50 && deltaTime < 300 && Math.abs(deltaX) > Math.abs(deltaY)) {
+      const currentIndex = RUNNING_BOARD_COLUMNS.findIndex(c => c.key === activeKey);
+      let nextIndex = currentIndex;
+      if (deltaX > 0 && currentIndex > 0) nextIndex = currentIndex - 1;
+      else if (deltaX < 0 && currentIndex < RUNNING_BOARD_COLUMNS.length - 1) nextIndex = currentIndex + 1;
+      if (nextIndex !== currentIndex) setActiveKey(RUNNING_BOARD_COLUMNS[nextIndex].key);
+    }
+    touchStartRef.current = null;
+  }, [activeKey]);
+
+  if (loading && records.length === 0 && scheduledTodos.length === 0) {
+    return (
+      <div className="running-board">
+        <div className="running-board-loading">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="running-column">
+              <Card size="small" bodyStyle={{ padding: 12 }}>
+                <Skeleton active paragraph={{ rows: 3 }} />
+              </Card>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="running-board">
+      {/* Stats bar */}
+      <div className="running-board-stats">
+        <span className="running-stat-item" style={{ color: '#8b5cf6' }}>
+          待触发 <strong>{stats.scheduled}</strong>
+        </span>
+        <span className="running-stat-divider" />
+        <span className="running-stat-item" style={{ color: '#f59e0b' }}>
+          运行中 <strong>{stats.running}</strong>
+        </span>
+        <span className="running-stat-divider" />
+        <span className="running-stat-item" style={{ color: '#22c55e' }}>
+          已完成 <strong>{stats.completed}</strong>
+        </span>
+        <span className="running-stat-divider" />
+        <span className="running-stat-item" style={{ color: '#06b6d4' }}>
+          评审中 <strong>{stats.reviewing}</strong>
+        </span>
+        <span className="running-stat-divider" />
+        <span className="running-stat-item" style={{ color: '#10b981' }}>
+          评审通过 <strong>{stats.review_passed}</strong>
+        </span>
+        <span className="running-stat-divider" />
+        <span className="running-stat-item" style={{ color: '#ef4444' }}>
+          失败 <strong>{stats.failed}</strong>
+        </span>
+        <span className="running-stat-divider" />
+        <span className="running-stat-item" style={{ color: 'var(--color-text-secondary)' }}>
+          共 <strong>{stats.total}</strong> 条
+        </span>
+      </div>
+
+      {/* Desktop: 6 columns */}
+      {!isMobile && (
+        <div className="running-columns-container">
+          {RUNNING_BOARD_COLUMNS.map(col => (
+            <RunningBoardColumnView
+              key={col.key}
+              columnKey={col.key}
+              label={col.label}
+              color={col.color}
+              records={grouped[col.key].records}
+              scheduledTodos={grouped[col.key].scheduledTodos}
+              onSelectTodo={handleSelectTodo}
+              onCardClick={handleCardClick}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Mobile: Swipeable Tabs */}
+      {isMobile && (
+        <div onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+          <Tabs
+            className="running-mobile-tabs"
+            activeKey={activeKey}
+            onChange={(key) => setActiveKey(key as RunningBoardColumn)}
+            items={mobileTabItems}
+          />
+        </div>
+      )}
+
+      {/* Pagination */}
+      {total > limit && (
+        <div className="running-board-pagination">
+          <Pagination
+            current={page}
+            total={total}
+            pageSize={limit}
+            onChange={setPage}
+            size="small"
+            showSizeChanger={false}
+          />
+        </div>
+      )}
+
+      {/* Record Detail Drawer */}
+      <RunningRecordDrawer
+        record={drawerRecord}
+        open={!!drawerRecord}
+        onClose={handleDrawerClose}
+        onRefresh={refresh}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/RunningRecordDrawer.tsx
+++ b/frontend/src/components/RunningRecordDrawer.tsx
@@ -1,0 +1,339 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Drawer, Tag, Button, Popconfirm, Space, Popover, InputNumber, Collapse, Spin } from 'antd';
+import {
+  StarOutlined,
+  StarFilled,
+  StopOutlined,
+  CopyOutlined,
+  LinkOutlined,
+  RightOutlined,
+} from '@ant-design/icons';
+import XMarkdown from '@ant-design/x-markdown';
+import { ExecutorBadge } from '@/components/ExecutorBadge';
+import { useApp } from '@/hooks/useApp';
+import { useViewState } from '@/hooks/useViewState';
+import { formatLocalDateTime, formatDuration } from '@/utils/datetime';
+import * as db from '@/utils/database';
+import type { ExecutionRecord, LogEntry } from '@/types';
+
+/* ─── Helpers ─── */
+
+function getElapsedSeconds(startedAt: string): number {
+  const start = new Date(startedAt).getTime();
+  return Math.max(0, Math.floor((Date.now() - start) / 1000));
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+const LOG_TYPE_COLORS: Record<string, string> = {
+  info: '#6b7280', stdout: '#3b82f6', stderr: '#ef4444', error: '#ef4444',
+  tool_use: '#8b5cf6', tool_call: '#8b5cf6', tool_result: '#10b981',
+  assistant: '#0ea5e9', user: '#f59e0b', system: '#6b7280', thinking: '#a855f7',
+  result: '#22c55e', step_start: '#06b6d4', step_finish: '#06b6d4', tokens: '#6b7280',
+};
+
+const LOG_TYPE_LABELS: Record<string, string> = {
+  info: 'INFO', stdout: 'OUT', stderr: 'ERR', error: 'ERROR',
+  tool_use: 'TOOL', tool_call: 'CALL', tool_result: 'RESULT',
+  assistant: 'AI', user: 'USER', system: 'SYS', thinking: 'THINK',
+  result: 'RESULT', step_start: 'STEP', step_finish: 'STEP', tokens: 'TOKENS',
+};
+
+/* ─── Rating Control ─── */
+
+function RatingControl({ record, onRate }: { record: ExecutionRecord; onRate: (id: number, r: number | null) => Promise<void> }) {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState<number | null>(record.rating ?? null);
+  useEffect(() => { setValue(record.rating ?? null); }, [record.rating, record.id]);
+
+  const handleSubmit = async (next: number | null) => {
+    try { await onRate(record.id, next); setOpen(false); } catch {}
+  };
+
+  if (record.rating != null) {
+    return (
+      <Popover content={
+        <div style={{ width: 200 }}>
+          <div style={{ marginBottom: 8, fontSize: 12 }}>评分：{record.rating}</div>
+          <Space.Compact style={{ width: '100%' }}>
+            <InputNumber min={0} max={100} value={value ?? 0} onChange={v => setValue(typeof v === 'number' ? v : null)} style={{ width: '100%' }} />
+            <Button onClick={() => handleSubmit(value)}>改</Button>
+          </Space.Compact>
+          <Button type="link" danger size="small" style={{ padding: '4px 0 0' }} onClick={() => handleSubmit(null)}>清除</Button>
+        </div>
+      } open={open} onOpenChange={setOpen} placement="bottomRight">
+        <Button size="small" icon={<StarFilled style={{ color: '#fadb14' }} />} onClick={() => setOpen(o => !o)}>
+          {record.rating}
+        </Button>
+      </Popover>
+    );
+  }
+
+  return (
+    <Popover content={
+      <div style={{ width: 200 }}>
+        <div style={{ marginBottom: 8, fontSize: 12 }}>评分（0-100）</div>
+        <Space.Compact style={{ width: '100%' }}>
+          <InputNumber min={0} max={100} value={value} onChange={v => setValue(typeof v === 'number' ? v : null)} placeholder="0-100" style={{ width: '100%' }} />
+          <Button type="primary" onClick={() => handleSubmit(value)}>评分</Button>
+        </Space.Compact>
+      </div>
+    } open={open} onOpenChange={setOpen} placement="bottomRight">
+      <Button size="small" icon={<StarOutlined />} onClick={() => setOpen(o => !o)}>评分</Button>
+    </Popover>
+  );
+}
+
+/* ─── Review Status Badge ─── */
+
+function ReviewStatusBadge({ status }: { status?: string | null }) {
+  if (!status) return null;
+  const map: Record<string, { color: string; text: string }> = {
+    pending: { color: '#06b6d4', text: '评审中' },
+    success: { color: '#10b981', text: '评审通过' },
+    failed: { color: '#ef4444', text: '评审失败' },
+    interrupted: { color: '#f59e0b', text: '评审中断' },
+    skipped: { color: '#6b7280', text: '评审跳过' },
+  };
+  const info = map[status];
+  if (!info) return null;
+  return <Tag color={info.color}>{info.text}</Tag>;
+}
+
+/* ─── Log View ─── */
+
+function LogView({ record }: { record: ExecutionRecord }) {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (record.status === 'running') return;
+    setLoading(true);
+    db.getExecutionLogs(record.id, 1, 500)
+      .then(r => setLogs(r.logs))
+      .catch(() => setLogs([]))
+      .finally(() => setLoading(false));
+  }, [record.id, record.status]);
+
+  if (loading) return <Spin size="small" style={{ display: 'block', margin: '16px auto' }} />;
+  if (logs.length === 0) return <div style={{ color: 'var(--color-text-tertiary)', fontSize: 12, padding: 16 }}>暂无日志</div>;
+
+  return (
+    <div style={{ maxHeight: 400, overflow: 'auto', fontSize: 12, fontFamily: 'var(--font-mono)' }}>
+      {logs.map((log, i) => (
+        <div key={i} style={{ display: 'flex', gap: 8, padding: '2px 0', borderBottom: '1px solid var(--color-border-light)' }}>
+          <span style={{ color: LOG_TYPE_COLORS[log.type] || '#6b7280', minWidth: 52, textAlign: 'right', flexShrink: 0 }}>
+            {LOG_TYPE_LABELS[log.type] || log.type}
+          </span>
+          <span style={{ color: 'var(--color-text-secondary)', whiteSpace: 'pre-wrap', wordBreak: 'break-all', flex: 1 }}>
+            {log.content?.slice(0, 2000)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ─── Main Drawer ─── */
+
+export interface RunningRecordDrawerProps {
+  record: ExecutionRecord | null;
+  open: boolean;
+  onClose: () => void;
+  onRefresh?: () => void;
+}
+
+export function RunningRecordDrawer({ record, open, onClose, onRefresh }: RunningRecordDrawerProps) {
+  const { state } = useApp();
+  const { selectTodo } = useViewState();
+  const [stopping, setStopping] = useState(false);
+
+  const todo = record ? state.todos.find(t => t.id === record.todo_id) : null;
+  const isRunning = record?.status === 'running';
+
+  const handleNavigateTodo = useCallback(() => {
+    if (record) {
+      selectTodo(record.todo_id);
+      onClose();
+    }
+  }, [record, selectTodo, onClose]);
+
+  const handleStop = useCallback(async () => {
+    if (!record) return;
+    setStopping(true);
+    try {
+      await db.stopExecution(record.id);
+      onRefresh?.();
+    } catch {} finally {
+      setStopping(false);
+    }
+  }, [record, onRefresh]);
+
+  const handleRate = useCallback(async (id: number, rating: number | null) => {
+    await db.rateExecutionRecord(id, rating);
+    onRefresh?.();
+  }, [onRefresh]);
+
+  const handleCopyResult = useCallback(() => {
+    if (record?.result) {
+      navigator.clipboard.writeText(record.result);
+    }
+  }, [record]);
+
+  if (!record) return null;
+
+  const duration = record.usage?.duration_ms || (isRunning ? getElapsedSeconds(record.started_at) * 1000 : null);
+
+  return (
+    <Drawer
+      title={
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{
+            display: 'inline-block', width: 8, height: 8, borderRadius: '50%',
+            backgroundColor: isRunning ? '#f59e0b' : record.status === 'success' ? '#22c55e' : '#ef4444',
+          }} />
+          <span>执行记录 #{record.id}</span>
+          <Tag color={isRunning ? 'orange' : record.status === 'success' ? 'green' : 'red'}>
+            {isRunning ? '运行中' : record.status === 'success' ? '成功' : '失败'}
+          </Tag>
+          <ReviewStatusBadge status={record.last_review_status} />
+        </div>
+      }
+      open={open}
+      onClose={onClose}
+      width={560}
+      extra={
+        <div style={{ display: 'flex', gap: 8 }}>
+          {todo && (
+            <Button size="small" icon={<RightOutlined />} onClick={handleNavigateTodo}>
+              查看任务
+            </Button>
+          )}
+          {isRunning && (
+            <Popconfirm title="确定停止该任务？" onConfirm={handleStop} okText="停止" cancelText="取消">
+              <Button size="small" danger icon={<StopOutlined />} loading={stopping}>停止</Button>
+            </Popconfirm>
+          )}
+        </div>
+      }
+    >
+      {/* Todo Info */}
+      {todo && (
+        <div
+          onClick={handleNavigateTodo}
+          style={{
+            padding: '10px 12px', marginBottom: 16, borderRadius: 8,
+            background: 'var(--color-fill-quaternary)', cursor: 'pointer',
+            border: '1px solid var(--color-border-light)',
+          }}
+        >
+          <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>{todo.title}</div>
+          {todo.prompt && (
+            <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {todo.prompt}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Meta */}
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 16 }}>
+        {record.executor && <ExecutorBadge executor={record.executor} />}
+        {record.model && <Tag color="#3b82f6">{record.model}</Tag>}
+        <Tag color={record.trigger_type === 'cron' ? '#8b5cf6' : record.trigger_type.startsWith('hook:') ? '#a855f7' : '#6b7280'}>
+          {record.trigger_type === 'cron' ? 'Cron' : record.trigger_type.startsWith('hook:') ? 'Hook' : record.trigger_type === 'manual' ? '手动' : record.trigger_type}
+        </Tag>
+        {record.source_todo_id && (
+          <Tag color="purple" icon={<LinkOutlined />}>
+            来自 #{record.source_todo_id} {record.source_todo_title ?? ''}
+          </Tag>
+        )}
+      </div>
+
+      {/* Times */}
+      <div style={{ display: 'flex', gap: 16, marginBottom: 16, fontSize: 13 }}>
+        <div>
+          <span style={{ color: 'var(--color-text-tertiary)' }}>开始：</span>
+          {formatLocalDateTime(record.started_at)}
+        </div>
+        {record.finished_at && (
+          <div>
+            <span style={{ color: 'var(--color-text-tertiary)' }}>结束：</span>
+            {formatLocalDateTime(record.finished_at)}
+          </div>
+        )}
+        {duration != null && (
+          <div>
+            <span style={{ color: 'var(--color-text-tertiary)' }}>耗时：</span>
+            <span style={{ fontWeight: 600 }}>{formatDuration(duration / 1000)}</span>
+          </div>
+        )}
+      </div>
+
+      {/* Usage */}
+      {record.usage && (
+        <div style={{ display: 'flex', gap: 16, marginBottom: 16, fontSize: 12, color: 'var(--color-text-secondary)' }}>
+          <div>Input: <b>{formatTokens(record.usage.input_tokens)}</b></div>
+          <div>Output: <b>{formatTokens(record.usage.output_tokens)}</b></div>
+          {record.usage.total_cost_usd != null && (
+            <div style={{ color: 'var(--color-warning)', fontWeight: 600 }}>${record.usage.total_cost_usd.toFixed(4)}</div>
+          )}
+        </div>
+      )}
+
+      {/* Execution Stats */}
+      {record.execution_stats && (
+        <div style={{ display: 'flex', gap: 16, marginBottom: 16, fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+          <div>工具调用: <b style={{ color: 'var(--color-primary)' }}>{record.execution_stats.tool_calls}</b></div>
+          <div>对话轮次: <b style={{ color: 'var(--color-primary)' }}>{record.execution_stats.conversation_turns}</b></div>
+          {record.execution_stats.thinking_count > 0 && (
+            <div>思考: <b style={{ color: 'var(--color-primary)' }}>{record.execution_stats.thinking_count}</b></div>
+          )}
+        </div>
+      )}
+
+      {/* Rating + Review */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+        <RatingControl record={record} onRate={handleRate} />
+        <ReviewStatusBadge status={record.last_review_status} />
+      </div>
+
+      {/* Result */}
+      {record.result && (
+        <Collapse
+          defaultActiveKey={['result']}
+          size="small"
+          style={{ marginBottom: 16 }}
+          items={[{
+            key: 'result',
+            label: (
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
+                <span>执行结果</span>
+                <Button type="text" size="small" icon={<CopyOutlined />} onClick={e => { e.stopPropagation(); handleCopyResult(); }} />
+              </div>
+            ),
+            children: (
+              <div style={{ maxHeight: 300, overflow: 'auto' }}>
+                <XMarkdown content={record.result} />
+              </div>
+            ),
+          }]}
+        />
+      )}
+
+      {/* Logs */}
+      <Collapse
+        size="small"
+        items={[{
+          key: 'logs',
+          label: '执行日志',
+          children: <LogView record={record} />,
+        }]}
+      />
+    </Drawer>
+  );
+}

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -47,7 +47,14 @@ interface ExecEventExecutionStats {
   stats: ExecutionStats;
 }
 
-type ExecEvent = ExecEventStarted | ExecEventOutput | ExecEventFinished | ExecEventSync | ExecEventTodoProgress | ExecEventExecutionStats;
+interface ExecEventReviewStatusChanged {
+  type: 'ReviewStatusChanged';
+  record_id: number;
+  todo_id: number;
+  review_status: string;
+}
+
+type ExecEvent = ExecEventStarted | ExecEventOutput | ExecEventFinished | ExecEventSync | ExecEventTodoProgress | ExecEventExecutionStats | ExecEventReviewStatusChanged;
 
 export function useExecutionEvents() {
   const { dispatch } = useApp();
@@ -136,6 +143,7 @@ export function useExecutionEvents() {
                 type: 'UPDATE_TODO_STATUS',
                 payload: { id: data.todo_id, status: 'running' },
               });
+              window.dispatchEvent(new CustomEvent('executionStarted', { detail: { todoId: data.todo_id } }));
               break;
             }
             case 'Output': {
@@ -179,6 +187,13 @@ export function useExecutionEvents() {
                 dispatch({ type: 'REMOVE_RUNNING_TASK', payload: data.task_id });
               }, 3000);
               removeTaskTimersRef.current.add(timer);
+              window.dispatchEvent(new CustomEvent('executionFinished', { detail: { todoId: data.todo_id, success: data.success } }));
+              break;
+            }
+            case 'ReviewStatusChanged': {
+              window.dispatchEvent(new CustomEvent('reviewStatusChanged', {
+                detail: { recordId: data.record_id, todoId: data.todo_id, reviewStatus: data.review_status },
+              }));
               break;
             }
           }

--- a/frontend/src/hooks/useRunningBoard.ts
+++ b/frontend/src/hooks/useRunningBoard.ts
@@ -37,7 +37,7 @@ function classifyRecord(record: ExecutionRecord): RunningBoardColumn {
   if (record.last_review_status === 'success') return 'review_passed';
   if (record.last_review_status === 'failed' || record.last_review_status === 'interrupted') return 'failed';
   if (record.status === 'success') return 'completed';
-  // interrupted / skipped review + non-success status
+  // 防御性兜底：理论上不可达（status 只有 running/success/failed 三种合法值）
   return 'failed';
 }
 
@@ -47,7 +47,7 @@ export function useRunningBoard(): RunningBoardState {
   const [loading, setLoading] = useState(true);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
-  const limit = 100;
+  const limit = 100; // 后端上限 200，取 100 平衡首屏加载性能与翻页频率
   const mountedRef = useRef(true);
 
   const refresh = useCallback(async () => {

--- a/frontend/src/hooks/useRunningBoard.ts
+++ b/frontend/src/hooks/useRunningBoard.ts
@@ -1,0 +1,115 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import * as db from '@/utils/database';
+import type { ExecutionRecord, ScheduledTodo, RunningBoardColumn } from '@/types';
+
+export interface RunningBoardState {
+  records: ExecutionRecord[];
+  scheduledTodos: ScheduledTodo[];
+  loading: boolean;
+  total: number;
+  page: number;
+  limit: number;
+  refresh: () => Promise<void>;
+  setPage: (page: number) => void;
+}
+
+export interface ColumnData {
+  key: RunningBoardColumn;
+  label: string;
+  color: string;
+  records: ExecutionRecord[];
+  scheduledTodos: ScheduledTodo[];
+}
+
+export const RUNNING_BOARD_COLUMNS: { key: RunningBoardColumn; label: string; color: string }[] = [
+  { key: 'scheduled', label: '待触发', color: '#8b5cf6' },
+  { key: 'running', label: '运行中', color: '#f59e0b' },
+  { key: 'completed', label: '已完成', color: '#22c55e' },
+  { key: 'reviewing', label: '评审中', color: '#06b6d4' },
+  { key: 'review_passed', label: '评审通过', color: '#10b981' },
+  { key: 'failed', label: '失败', color: '#ef4444' },
+];
+
+function classifyRecord(record: ExecutionRecord): RunningBoardColumn {
+  if (record.status === 'running') return 'running';
+  if (record.status === 'failed') return 'failed';
+  if (record.last_review_status === 'pending') return 'reviewing';
+  if (record.last_review_status === 'success') return 'review_passed';
+  if (record.last_review_status === 'failed') return 'failed';
+  if (record.status === 'success') return 'completed';
+  return 'completed';
+}
+
+export function useRunningBoard(): RunningBoardState {
+  const [records, setRecords] = useState<ExecutionRecord[]>([]);
+  const [scheduledTodos, setScheduledTodos] = useState<ScheduledTodo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const limit = 100;
+  const mountedRef = useRef(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await db.getRunningBoardData(page, limit);
+      if (mountedRef.current) {
+        setRecords(data.records);
+        setScheduledTodos(data.scheduled_todos);
+        setTotal(data.total);
+      }
+    } catch {
+      if (mountedRef.current) {
+        setRecords([]);
+        setScheduledTodos([]);
+      }
+    } finally {
+      if (mountedRef.current) setLoading(false);
+    }
+  }, [page, limit]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    refresh();
+    return () => { mountedRef.current = false; };
+  }, [refresh]);
+
+  return { records, scheduledTodos, loading, total, page, limit, refresh, setPage };
+}
+
+export function classifyRecords(
+  records: ExecutionRecord[],
+  scheduledTodos: ScheduledTodo[],
+): Record<RunningBoardColumn, { records: ExecutionRecord[]; scheduledTodos: ScheduledTodo[] }> {
+  const groups: Record<RunningBoardColumn, { records: ExecutionRecord[]; scheduledTodos: ScheduledTodo[] }> = {
+    scheduled: { records: [], scheduledTodos: [] },
+    running: { records: [], scheduledTodos: [] },
+    completed: { records: [], scheduledTodos: [] },
+    reviewing: { records: [], scheduledTodos: [] },
+    review_passed: { records: [], scheduledTodos: [] },
+    failed: { records: [], scheduledTodos: [] },
+  };
+
+  groups.scheduled.scheduledTodos = scheduledTodos;
+
+  for (const record of records) {
+    const col = classifyRecord(record);
+    groups[col].records.push(record);
+  }
+
+  return groups;
+}
+
+export function useAutoRefreshRunningBoard(refresh: () => Promise<void>): void {
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
+
+  useEffect(() => {
+    const handleReviewStatusChanged = () => {
+      refreshRef.current();
+    };
+
+    window.addEventListener('reviewStatusChanged', handleReviewStatusChanged);
+    return () => window.removeEventListener('reviewStatusChanged', handleReviewStatusChanged);
+  }, []);
+}

--- a/frontend/src/hooks/useRunningBoard.ts
+++ b/frontend/src/hooks/useRunningBoard.ts
@@ -35,9 +35,10 @@ function classifyRecord(record: ExecutionRecord): RunningBoardColumn {
   if (record.status === 'failed') return 'failed';
   if (record.last_review_status === 'pending') return 'reviewing';
   if (record.last_review_status === 'success') return 'review_passed';
-  if (record.last_review_status === 'failed') return 'failed';
+  if (record.last_review_status === 'failed' || record.last_review_status === 'interrupted') return 'failed';
   if (record.status === 'success') return 'completed';
-  return 'completed';
+  // interrupted / skipped review + non-success status
+  return 'failed';
 }
 
 export function useRunningBoard(): RunningBoardState {
@@ -105,11 +106,16 @@ export function useAutoRefreshRunningBoard(refresh: () => Promise<void>): void {
   refreshRef.current = refresh;
 
   useEffect(() => {
-    const handleReviewStatusChanged = () => {
-      refreshRef.current();
-    };
+    const handleRefresh = () => { refreshRef.current(); };
+    const handleFinished = () => { setTimeout(() => refreshRef.current(), 1000); };
 
-    window.addEventListener('reviewStatusChanged', handleReviewStatusChanged);
-    return () => window.removeEventListener('reviewStatusChanged', handleReviewStatusChanged);
+    window.addEventListener('reviewStatusChanged', handleRefresh);
+    window.addEventListener('executionStarted', handleRefresh);
+    window.addEventListener('executionFinished', handleFinished);
+    return () => {
+      window.removeEventListener('reviewStatusChanged', handleRefresh);
+      window.removeEventListener('executionStarted', handleRefresh);
+      window.removeEventListener('executionFinished', handleFinished);
+    };
   }, []);
 }

--- a/frontend/src/types/execution.tsx
+++ b/frontend/src/types/execution.tsx
@@ -179,6 +179,33 @@ export const DEFAULT_EXECUTOR = 'claudecode';
 /** 仅支持继续对话的执行器（用于选择 UI 的下拉数据源） */
 export const RESUMABLE_EXECUTOR_OPTIONS = EXECUTORS.filter(e => RESUMABLE_EXECUTORS.has(e.value));
 
+// ─── Running Board types ────────────────────────────────────
+
+export interface ScheduledTodo {
+  id: number;
+  title: string;
+  prompt: string;
+  status: string;
+  executor: string | null;
+  scheduler_enabled: boolean;
+  scheduler_config: string | null;
+  scheduler_timezone: string | null;
+  scheduler_next_run_at: string | null;
+  tag_ids: number[];
+  workspace: string | null;
+  updated_at: string;
+}
+
+export interface RunningBoardData {
+  records: ExecutionRecord[];
+  scheduled_todos: ScheduledTodo[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export type RunningBoardColumn = 'scheduled' | 'running' | 'completed' | 'reviewing' | 'review_passed' | 'failed';
+
 export function supportsResume(record: ExecutionRecord): boolean {
   return (
     record.status !== 'running' &&

--- a/frontend/src/utils/database/executions.ts
+++ b/frontend/src/utils/database/executions.ts
@@ -1,5 +1,5 @@
 import { api, unwrap } from './client';
-import type { ExecutionRecord, ExecutionSummary, ExecutionRecordsPage, ExecutionLogsPage } from '@/types';
+import type { ExecutionRecord, ExecutionSummary, ExecutionRecordsPage, ExecutionLogsPage, RunningBoardData } from '@/types';
 
 export async function getExecutionRecords(todoId: number, page?: number, limit?: number, status?: string): Promise<ExecutionRecordsPage> {
   const params: Record<string, unknown> = { todo_id: todoId };
@@ -84,4 +84,11 @@ export interface SmartCreateResult {
 
 export async function smartCreate(content: string): Promise<SmartCreateResult> {
   return unwrap(await api.post('/api/smart-create', { content }));
+}
+
+export async function getRunningBoardData(page?: number, limit?: number): Promise<RunningBoardData> {
+  const params: Record<string, unknown> = {};
+  if (page !== undefined) params.page = page;
+  if (limit !== undefined) params.limit = limit;
+  return unwrap(await api.get('/api/running-board', { params }));
 }


### PR DESCRIPTION
## Summary
- 在 MemorialBoard 中新增第三个模式「运行视图」，以 ExecutionRecord 为粒度展示全部执行记录流水线
- 6 列布局：待触发 / 运行中 / 已完成 / 评审中 / 评审通过 / 失败
- 点击卡片弹出 Drawer 查看详情（状态、元信息、评分、结果、日志）
- 支持 toolbar 搜索、时间、项目过滤条件
- WebSocket 实时更新（ReviewStatusChanged 事件）

## Changes

### 后端
- `TodoIdQuery`/`ExecutionRecordQuery.todo_id` 改为 `Option<i64>`，支持无 todo_id 查询
- 新增 `GET /api/running-board` 端点，一次性返回全部执行记录 + 待触发调度 todo
- 新增 `ReviewStatusChanged` WebSocket 事件，评审状态变化时推送到前端

### 前端
- 新增 `RunningBoard` 组件（6 列看板）
- 新增 `RunningRecordDrawer` 组件（卡片详情抽屉）
- 新增 `useRunningBoard` hook（数据获取、分组、实时刷新）
- MemorialBoard Segmented 增加「运行视图」选项
- 运行视图内置 stats bar 动态显示各列计数