### PR TITLE
docs: 补齐 backend onboarding 文档（README/ARCHITECTURE/SEQUENCE/CONFIG）

### DIFF
--- a/backend/ARCHITECTURE.md
+++ b/backend/ARCHITECTURE.md
@@ -1,0 +1,423 @@
+# ntd Backend 架构
+
+> 配套文档：[README.md](./README.md) · [SEQUENCE.md](./SEQUENCE.md) · [CONFIG.md](./CONFIG.md)
+
+本文档面向需要快速理解后端全貌的工程师：模块依赖、关键流程、数据模型、跨切关注点。
+关键流程的 step-by-step 时序图见 [SEQUENCE.md](./SEQUENCE.md)。
+
+---
+
+## 1. 总览
+
+ntd 后端是一个单进程 async 应用：
+
+- HTTP/WebSocket 服务（Axum）+ CLI 子命令（Clap）
+- SQLite（WAL + 外键）
+- Cron 调度器（tokio-cron-scheduler）
+- 多路飞书长连接（每 bot 一条 WebSocket）
+- 多执行器子进程池（Claude Code / Codex / OpenCode / Hermes / Kimi / Mimo / MobileCoder / CodeWhale / Pi / CodeBuddy / AtomCode）
+
+**核心思想**：所有"用户视角的工作单元"都是 Todo；执行时把 Todo 的 `prompt` 喂给一个 AI CLI 子进程，解析 stdout/stderr，把进度、产物、统计通过 broadcast 通道实时推到前端。
+
+---
+
+## 2. 模块依赖图
+
+```mermaid
+flowchart TB
+    main[main.rs] --> cli[cli/]
+    main --> handlers[handlers/]
+    main --> daemon[daemon.rs]
+    main --> scheduler[scheduler.rs]
+    main --> npm_utils[npm_utils.rs]
+    main --> service_context[service_context.rs]
+    main --> lib[lib.rs embeds frontend dist + ntd-skills]
+
+    handlers --> service_context
+    handlers --> adapters[adapters/]
+    handlers --> db[db/]
+    handlers --> executor_service[executor_service.rs]
+    handlers --> task_manager[task_manager.rs]
+    handlers --> hooks[hooks/]
+    handlers --> scheduler
+    handlers --> feishu[feishu/]
+    handlers --> services[services/]
+    handlers --> models[models/]
+    handlers --> config[config.rs]
+    handlers --> todo_progress[todo_progress.rs]
+
+    executor_service --> adapters
+    executor_service --> db
+    executor_service --> task_manager
+    executor_service --> models
+    executor_service --> config
+
+    scheduler --> executor_service
+    scheduler --> service_context
+
+    services --> executor_service
+    services --> service_context
+    services --> config
+
+    hooks --> executor_service
+    hooks --> service_context
+    hooks --> models
+
+    adapters --> models
+    db --> models
+
+    feishu --> config
+    feishu --> db
+
+    daemon --> config
+    cli --> handlers
+    cli --> config
+
+    service_context --> db
+    service_context --> adapters
+    service_context --> task_manager
+    service_context --> config
+```
+
+> **`service_context`** 是依赖容器：db、executor_registry、tx（broadcast::Sender<ExecEvent>）、task_manager、config。所有需要这些依赖的模块都通过它获取，避免显式传 5+ 参数。
+
+---
+
+## 3. 数据模型 ER
+
+```mermaid
+erDiagram
+    todos ||--o{ execution_records : "has many"
+    todos ||--o{ todo_tags : "labeled"
+    tags ||--o{ todo_tags : "applied to"
+    todos ||--o{ webhooks : "triggered by"
+    webhooks ||--o{ webhook_records : "deliveries"
+    execution_records ||--o{ execution_logs : "stdout/stderr lines"
+    execution_records ||--o| execution_records : "auto review (source_execution_record_id)"
+    executors ||..|| todos : "executor column (loose FK)"
+    project_directories ||--o{ todos : "workspace"
+    todo_templates ||..o{ todos : "spawned from"
+
+    agent_bots ||--o{ feishu_homes : "p2p chats"
+    agent_bots ||--o{ feishu_messages : "received"
+    agent_bots ||--o{ feishu_history_chats : "polled groups"
+    agent_bots ||--o{ feishu_project_bindings : "chat→project"
+    agent_bots ||--o{ feishu_push_targets : "push level config"
+    agent_bots ||--o{ feishu_response_config : "per-target debounce"
+    agent_bots ||--o{ feishu_group_whitelist : "sender allowlist"
+
+    sync_records }|..|| todos : "cloud sync delta"
+    sync_records }|..|| tags : "cloud sync delta"
+    sync_records }|..|| todo_templates : "cloud sync delta"
+    sync_records }|..|| project_directories : "cloud sync delta"
+
+    usage_stats ||--o{ usage_executor_daily : "per executor per day"
+    usage_stats ||--o{ usage_model_breakdown : "per model per day"
+
+    todos {
+        i64 id PK
+        string title
+        string prompt
+        string status
+        string executor
+        bool scheduler_enabled
+        string scheduler_config
+        string scheduler_timezone
+        string task_id
+        string workspace
+        bool worktree_enabled
+        string hooks
+        string acceptance_criteria
+        int todo_type
+        i64 parent_todo_id
+        bool auto_review_enabled
+    }
+
+    execution_records {
+        i64 id PK
+        i64 todo_id FK
+        string status
+        string command
+        string stdout
+        string stderr
+        string result
+        string usage
+        string executor
+        string model
+        string started_at
+        string finished_at
+        string trigger_type
+        int pid
+        string task_id
+        string session_id
+        string todo_progress
+        string execution_stats
+        i64 source_todo_id
+        string source_todo_title
+        i64 source_hook_id
+        int rating
+        i64 source_execution_record_id
+        string last_review_status
+        string last_reviewed_at
+    }
+
+    execution_logs {
+        i64 id PK
+        i64 record_id FK
+        string stream
+        string content
+        int64 ts_ms
+    }
+
+    executors {
+        i64 id PK
+        string name UK
+        string display_name
+        string path
+        string session_dir
+        bool enabled
+    }
+
+    tags {
+        i64 id PK
+        string name UK
+    }
+
+    todo_tags {
+        i64 id PK
+        i64 todo_id FK
+        i64 tag_id FK
+    }
+
+    webhooks {
+        i64 id PK
+        i64 todo_id FK
+        string url
+        string secret
+        bool enabled
+    }
+
+    webhook_records {
+        i64 id PK
+        i64 webhook_id FK
+        string payload
+        int http_status
+        string response_body
+        string delivered_at
+    }
+
+    agent_bots {
+        i64 id PK
+        string app_id
+        string app_secret
+        string domain
+        string name
+    }
+
+    feishu_messages {
+        i64 id PK
+        i64 bot_id FK
+        string message_id UK
+        string chat_id
+        string sender_open_id
+        string content
+        bool processed
+        i64 processed_todo_id
+        i64 execution_record_id
+    }
+
+    project_directories {
+        i64 id PK
+        string name UK
+        string path
+        string description
+    }
+
+    sync_records {
+        i64 id PK
+        string entity_type
+        i64 entity_id
+        string operation
+        string payload
+        string synced_at
+    }
+
+    todo_templates {
+        i64 id PK
+        string title
+        string prompt
+        string category
+        string source_url
+        bool is_custom
+    }
+```
+
+### 3.1 关键表说明
+
+- **`todos.hooks`**：JSON 数组，每项是一条 `TodoHookItem`（id / trigger / target_todo_id / enabled）。父 todo 完成时按 trigger 匹配并启动子 todo。
+- **`todos.todo_type`**：0=normal / 1=review template（系统内置）/ 2=auto review instance（运行时派生）。1 和 2 都属于评审链路，不参与普通 UI。
+- **`execution_records.source_*`**：hook 触发的执行会快照 source_todo_id / source_todo_title / source_hook_id，便于事后排查；source 改了名字 UI 仍能显示当时的内容。
+- **`execution_records.last_review_status`**：自动评审链路状态机，pending → success/failed/interrupted/skipped。
+- **`executors.path`**：可执行器二进制路径；空字符串表示直接用 `binary_name`（让 `$PATH` 解析）。
+- **`feishu_messages.processed`**：消息是否已被某个 todo 消费；与 `processed_todo_id` 配合做幂等。
+- **`sync_records`**：云端同步的 delta 日志；按 entity_type + entity_id 去重。
+
+---
+
+## 4. 关键流程一览
+
+### 4.1 Todo 执行链路（HTTP 触发）
+
+```
+HTTP POST /api/execute
+  → handlers/execution.rs::start_todo_execution
+  → executor_service::run_todo_execution
+      ├─ task_manager.register(uuid)              // 申请 cancel 通道
+      ├─ 并发上限检查 (max_concurrent_todos)
+      ├─ adapters::ExecutorRegistry::get_or_default  // 选执行器
+      ├─ db.create_execution_record               // 落 status=Running
+      ├─ tx.send(Started)                         // 推 WebSocket
+      ├─ spawn child process via command-group    // setpgid
+      ├─ async BufReader 读 stdout/stderr         // 解析日志
+      ├─ tx.send(Output) per line                 // 实时推 UI
+      ├─ db.update_execution_record(status=ok/failed)
+      ├─ tx.send(Finished)
+      ├─ hooks.fire_for_todo(todo_id, ctx)        // 父→子级联
+      └─ task_manager.remove(uuid)
+```
+
+详细时序见 [SEQUENCE.md §1](./SEQUENCE.md#1-执行-todo-的端到端流程)。
+
+### 4.2 Cron 调度链路
+
+```
+config.yaml 启动 → scheduler.load_from_db(&ctx)
+  → 遍历 todos WHERE scheduler_enabled=1
+  → for each: convert_cron_to_utc(cron, tz)
+  → JobScheduler::new(Job::new_async)
+  → sched.start()
+  → 每 tick: Job 回调 executor_service::run_todo_execution(trigger_type="cron")
+```
+
+### 4.3 飞书消息链路
+
+```
+飞书 WS 接收事件
+  → feishu/channel.rs codec 解码
+  → services::feishu_listener::on_message
+  → feishu_project_bindings 查找 chat_id → project_dir
+  → todo 解析（按 slash command 匹配 / 落到 default_response_todo_id / 走绑定）
+  → MessageDebounce.push(PendingMessage)
+      ├─ 同 (bot_id, chat_id) 已有 buffer → abort 旧 timer、合并消息
+      └─ 新 key → 注册 timer (debounce_secs 后 flush)
+  → flush: executor_service::run_todo_execution(trigger_type="feishu")
+```
+
+### 4.4 Hook 触发链路
+
+```
+子 task Finished(success=true)
+  → hooks/service.rs::fire_for_todo(parent_id, ctx)
+  → 读 parent.hooks JSON → 解析 TodoHookItem[]
+  → 过滤 trigger 匹配项
+  → chain 检测（含 target_todo_id 即跳过，防环）
+  → executor_service::run_todo_execution(source_todo_id=parent.id, trigger_type="hook:...")
+```
+
+### 4.5 自动评审链路
+
+```
+子 task Finished
+  → 若 parent.auto_review_enabled=true 且 todo_type=normal
+  → services::auto_review::spawn_review(parent_id, record_id)
+  → 在 system_review_todo (todo_type=1) 模板上 spawn todo_type=2 实例
+  → executor_service::run_todo_execution(trigger_type="auto_review")
+  → 评审完成 → execution_records.rating + last_review_status="success"
+```
+
+---
+
+## 5. 跨切关注点
+
+### 5.1 并发与取消
+
+- **单 todo 并发上限**：`max_concurrent_todos`，按 todo_id 计数（全局默认 3，可通过 HTTP `/api/config` 调）。
+- **全局执行上限**：通过 `TaskManager` 已注册任务数间接控制；DB 里 `status='running'` 记录数与 `TaskManager.tasks` 大致对齐。
+- **取消**：`TaskManager.cancel(task_id)` 通过 `mpsc::UnboundedSender<()>` 发送信号；`executor_service` 收到后调用 `child.kill()`（command-group 自动 kill 整个进程组）。
+- **孤儿清理**：启动时 `cleanup_orphan_execution_records` 把 status=running 但进程已退出的记录标为 failed。
+
+### 5.2 超时
+
+- `Config.execution_timeout_secs`：默认 3600 秒；设 0 表示不限制；上限 604800（7 天）。
+- 超时由 `executor_service` 中 `tokio::time::timeout` 包裹的 future 实现；超时会 kill 子进程并写 `status='timeout'`。
+- YAML 直接编辑时 `clamp_execution_timeout_secs()` 是统一 enforcement 点。
+
+### 5.3 事件总线
+
+- 类型：`broadcast::Sender<ExecEvent>`（容量 100，详见 issue #503）。
+- 事件：`Started` / `Output` / `Finished` / `Sync` / `TodoProgress` / `ExecutionStats` / `ReviewStatusChanged`。
+- 前端 WebSocket 收到 `Sync` 时清空当前列表并用服务端推的 `TaskInfo[]` 重建。
+- 高负载下容量可能不足，需要按需调大。
+
+### 5.4 路径与配置归一化
+
+- `Config::normalize_paths()`：展开 `~`、相对路径转绝对；裸命令名（无 `/`）原样保留供 `$PATH` 解析。
+- `Config::clamp_execution_timeout_secs()`：YAML 级别的兜底校验，防止用户绕过 HTTP 验证。
+- 配置文件写入走 `temp + rename` 原子写，崩溃时不损坏。
+
+### 5.5 飞书去抖
+
+- `MessageDebounce`：按 `(bot_id, chat_id)` 聚合；新消息到达时 abort 旧 timer，新 timer 在 `debounce_secs` 后 flush。
+- 设计目的：用户在群里连发多条只触发一次 todo 执行；保留最后一条消息 + 历史摘要。
+
+### 5.6 Hook chain 防环
+
+- `RunTodoExecutionRequest.chain`：当前路径上所有 todo_id。
+- hook fire 时若 `target_todo_id ∈ chain` 直接跳过；避免 A→B→A 死循环。
+
+---
+
+## 6. 进程模型
+
+### 6.1 子进程组
+
+- 所有 AI CLI 通过 `command-group::AsyncGroupChild` 启动，自动 `setpgid`。
+- 取消时 `kill()` 会 kill 整个进程组，避免留下孤儿孙子进程。
+- Unix only；macOS / Linux 行为一致。
+
+### 6.2 Daemon 管理
+
+- macOS：launchd plist，标签 `com.weibaohui.ntd`。
+- Linux：systemd user unit，文件 `~/.config/systemd/user/ntd.service`。
+- `ntd daemon install` 写对应描述文件；`start` 调用 `launchctl bootstrap` / `systemctl --user start`。
+
+### 6.3 升级路径
+
+- `ntd upgrade`：当前实现是 `npm install -g @weibaohui/nothing-todo@latest` + 重新部署 daemon。
+- 已知耦合问题（issue #517）：硬编码 npm 包名；非 npm 安装（cargo install / deb / 手动下载二进制）走不通。
+
+---
+
+## 7. 测试策略
+
+| 层 | 类型 | 工具 |
+|----|------|------|
+| 单元 | 配置归一化 / 时区换算 / 占位符替换 | `#[cfg(test)] mod tests` |
+| 集成 | HTTP 路由 / DB CRUD | `tests/` + `tempfile` |
+| 异步 | 并发上限 / 取消 / 超时 | `#[tokio::test]` |
+| 端到端 | Playwright（前端） | `frontend/tests` |
+
+新增模块请至少覆盖：
+- 公共 API 正常路径
+- 边界（空 / max / 非法输入）
+- 异步时序（race / cancel / timeout）
+
+---
+
+## 8. 已知技术债（部分）
+
+- `db/mod.rs` 单文件约 2150 行，可拆 entity repository。
+- `daemon.rs` 单文件约 1044 行，可拆 platform-specific launchd / systemd。
+- `executor_service.rs` 单文件约 1031 行，可拆 process spawn / log parser / timeout。
+- `CodeExecutor` 适配器 boilerplate 重复 11 次，可考虑宏生成（issue #504）。
+- 详见 issue 列表。

--- a/backend/CONFIG.md
+++ b/backend/CONFIG.md
@@ -1,0 +1,245 @@
+# ntd 配置项说明
+
+> 配套文档：[README.md](./README.md) · [ARCHITECTURE.md](./ARCHITECTURE.md) · [SEQUENCE.md](./SEQUENCE.md)
+
+配置文件位置：
+- 生产：`~/.ntd/config.yaml`
+- 开发（`NTD_MODE=dev`）：`~/.ntd/config.dev.yaml`
+
+首次启动若文件不存在，ntd 会用默认值创建一份 YAML（已归一化路径、clamp 后的超时）。
+HTTP `PUT /api/config` 会走同样的归一化 + clamp 流程再原子写回磁盘。
+
+---
+
+## 顶层字段一览
+
+```yaml
+# 示例（生产默认）
+port: 8088
+host: 0.0.0.0
+db_path: ~/.ntd/data.db
+log_level: INFO
+
+auto_backup_enabled: false
+auto_backup_cron: "0 0 3 * * *"
+auto_backup_max_files: 30
+
+auto_todo_backup_enabled: false
+auto_todo_backup_cron: "0 0 4 * * *"
+auto_todo_backup_max_files: 30
+
+auto_sync_custom_templates_enabled: false
+auto_sync_custom_templates_cron: "0 0 4 * * *"
+
+auto_skill_backup_enabled: false
+auto_skill_backup_cron: "0 0 5 * * *"
+auto_skill_backup_max_files: 30
+
+auto_usage_stats_enabled: false
+auto_usage_stats_cron: "0 0 1 * * *"
+
+slash_command_rules: []           # 全局斜杠命令路由
+default_response_todo_id: null    # 没匹配 slash 时的兜底 todo
+
+history_message_max_age_secs: 600 # 飞书历史消息最大处理年龄
+max_concurrent_todos: 3           # 单 todo 并发上限
+execution_timeout_secs: 3600      # 单次执行超时，0=不限
+
+auto_cleanup_logs_days: 30        # 日志清理保留天数，null=不清理
+
+scheduler_default_timezone: null  # cron 默认时区（如 "Asia/Shanghai"）
+
+cloud_sync:
+  server_url: ""
+  sync_token: null
+  last_sync_at: null
+  default_conflict_mode: "overwrite"
+```
+
+---
+
+## 字段详细说明
+
+### 服务
+
+| 字段 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `port` | u16 | 8088（开发 18088） | HTTP 服务监听端口 |
+| `host` | string | `0.0.0.0` | 监听地址；建议生产改成具体 IP 或反代 |
+| `db_path` | string | `~/.ntd/data.db` | SQLite 文件路径；`~` 会展开为 `$HOME`；`./relative` 也会展开 |
+| `log_level` | string | `INFO` | `RUST_LOG` 覆盖；tracing-subscriber EnvFilter 用 |
+| `max_concurrent_todos` | u32 | 3 | 同一 todo 并发执行上限 |
+| `execution_timeout_secs` | u64 | 3600 | 单次执行超时（秒）。0 = 不限制。上限 604800（7 天）。YAML 加载时 clamp |
+
+### 备份（数据库 / Todo / Skill）
+
+| 字段 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `auto_backup_enabled` | bool | false | 是否开启 `~/.ntd/data.db` 周期备份 |
+| `auto_backup_cron` | string (6 字段) | `0 0 3 * * *` | 数据库备份 cron（每天凌晨 3 点） |
+| `auto_backup_max_files` | usize | 30 | 最多保留的备份文件数，超出按 mtime 删除 |
+| `auto_todo_backup_enabled` | bool | false | 是否开启 Todo 列表备份 |
+| `auto_todo_backup_cron` | string (6 字段) | `0 0 4 * * *` | Todo 备份 cron（每天凌晨 4 点） |
+| `auto_todo_backup_max_files` | usize | 30 | 同上 |
+| `auto_skill_backup_enabled` | bool | false | 是否开启 Skill 备份 |
+| `auto_skill_backup_cron` | string (6 字段) | `0 0 5 * * *` | Skill 备份 cron（每天凌晨 5 点） |
+| `auto_skill_backup_max_files` | usize | 30 | 同上 |
+
+> **Cron 字段**：`秒 分 时 日 月 周`，6 字段。`tokio-cron-scheduler` 要求 6 字段；若时区不是 UTC，会按 `scheduler_default_timezone` 转换。
+
+### 自定义模板 / 统计归档
+
+| 字段 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `auto_sync_custom_templates_enabled` | bool | false | 是否开启自定义模板（todo_templates 表）远程拉取 |
+| `auto_sync_custom_templates_cron` | string (6 字段) | `0 0 4 * * *` | 同步 cron |
+| `auto_usage_stats_enabled` | bool | false | 是否开启 AI 使用统计自动归档 |
+| `auto_usage_stats_cron` | string (6 字段) | `0 0 1 * * *` | 归档 cron（每天凌晨 1 点） |
+
+### 飞书斜杠命令路由
+
+```yaml
+slash_command_rules:
+  - slash_command: "/joke"
+    todo_id: 8
+    enabled: true
+  - slash_command: "/review-pr"
+    todo_id: 12
+    enabled: false
+```
+
+| 字段 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `slash_command` | string | `/todo` | 斜杠命令字符串；匹配时大小写敏感、前缀匹配 |
+| `todo_id` | i64 | 0 | 触发后启动的 todo id |
+| `enabled` | bool | true | 是否启用；false 时这条规则被跳过 |
+
+| 全局字段 | 类型 | 默认 | 说明 |
+|---------|------|------|------|
+| `default_response_todo_id` | i64? | null | 当消息不匹配任何 slash_command 时启动的兜底 todo；null = 不兜底 |
+
+### 飞书历史消息
+
+| 字段 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `history_message_max_age_secs` | u64 | 600（10 分钟） | 历史拉取（`feishu_history_chats` 轮询）时，超出此时间窗口的消息被标记为 `is_history=1` 且不处理 |
+
+### 调度器
+
+| 字段 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `scheduler_default_timezone` | string? | null | 默认时区（IANA 名，如 `Asia/Shanghai`、`America/New_York`）。todo 自身 `scheduler_timezone` 优先 |
+
+### 日志清理
+
+| 字段 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `auto_cleanup_logs_days` | usize? | 30 | `execution_logs` 表保留天数；null = 不清理 |
+
+### 云端同步
+
+```yaml
+cloud_sync:
+  server_url: "https://ntd.example.com"
+  sync_token: "ntd_xxxxxxxxxxxx"   # 可选
+  last_sync_at: "2026-06-01T00:00:00Z"
+  default_conflict_mode: "overwrite" # 或 "skip"
+```
+
+| 字段 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `server_url` | string | `""` | 云端 ntd 服务地址；空 = 不启用 |
+| `sync_token` | string? | null | 鉴权 token，`ntd_` 前缀 |
+| `last_sync_at` | string? | null | 最后一次成功同步时间（ISO8601）；首次同步时为 null |
+| `default_conflict_mode` | string | `overwrite` | 冲突解决模式：`overwrite`（本地覆盖云端）/ `skip`（跳过冲突） |
+
+---
+
+## 历史兼容性字段
+
+### `executors`（已弃用，仅用于一次性迁移）
+
+```yaml
+# 旧版本：执行器路径直接写在 config 里
+executors:
+  paths:
+    claudecode: /usr/local/bin/claude
+    codex: codex           # 裸命令名（让 $PATH 解析）
+
+# 新版本：执行器存在 DB 的 executors 表里
+# 通过 ntd UI / API 配置，配置文件中不再写
+```
+
+- ntd 启动时 `migrate_from_config(&cfg.executors)` 会把上面的 `paths` 一次性迁到 `executors` 表。
+- 迁移完成后该字段不再读；写回时也不会序列化（`#[serde(skip_serializing)]`）。
+- 建议：迁移完成后从 YAML 中删除 `executors` 块。
+
+### 嵌套结构兼容
+
+`ExecutorPaths` 反序列化时同时接受两种 schema：
+
+```yaml
+# 新格式
+executors:
+  paths:
+    claudecode: claude
+
+# 旧格式（兼容）
+executors:
+  claudecode: claude
+```
+
+旧格式用户升级 ntd 不会失败；首次保存时统一成新格式。
+
+---
+
+## 配置修改建议
+
+### 时区敏感
+
+- 改 `scheduler_default_timezone` 后，**已注册的 cron job 不会自动重新转换**；需要重启 ntd。
+- 改 `max_concurrent_todos` 后，正在执行的 task 不受影响；新发起的执行才生效。
+
+### 备份路径
+
+- 备份文件默认写到 `~/.ntd/backups/`；当前版本暂不开放自定义路径。
+- 建议 `auto_backup_max_files` ≥ 7，留一周历史方便回滚。
+
+### 飞书
+
+- `history_message_max_age_secs` 设太大会被飞书 API 限流；建议保持 600。
+- `slash_command_rules` 顺序不重要，匹配按消息前缀。
+
+### 升级时注意
+
+- 新增字段：ntd 不会自动写默认值到 YAML，下次保存时才补。可手动加上去。
+- 删除字段：保留在 YAML 里也没事，会被 `#[serde(default)]` 忽略。
+- 字段重命名：需要写迁移或在 release notes 里明确。
+
+---
+
+## HTTP 动态修改
+
+`PUT /api/config`（handlers/config.rs）允许运行时修改以下字段（白名单，其他字段返回 400）：
+
+- `port` / `host` / `log_level`
+- `max_concurrent_todos` / `execution_timeout_secs`
+- `auto_backup_*` / `auto_todo_backup_*` / `auto_skill_backup_*`
+- `auto_usage_stats_*` / `auto_sync_custom_templates_*`
+- `slash_command_rules` / `default_response_todo_id`
+- `history_message_max_age_secs`
+- `auto_cleanup_logs_days`
+- `scheduler_default_timezone`
+- `cloud_sync.*`
+
+修改后立即生效（除 cron 任务需重启 scheduler）。
+
+---
+
+## 相关代码
+
+- 配置定义：`backend/src/config.rs::Config`
+- 加载 / 保存 / 归一化：`Config::load` / `Config::save` / `normalize_paths` / `clamp_execution_timeout_secs`
+- HTTP 修改：`backend/src/handlers/config.rs`
+- 周期任务注册：`backend/src/handlers/backup.rs`、`backend/src/handlers/custom_template.rs`
+- 运行时校验：`backend/src/handlers/config.rs::validate_execution_timeout_secs`

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,167 @@
+# ntd Backend
+
+Rust + Axum 后端，为 Nothing Todo (ntd) 提供 HTTP API、Cron 调度、飞书消息桥接、SQLite 持久化等能力。
+前端构建产物通过 `rust-embed` 嵌入二进制，分发一个可执行文件即可运行整套应用。
+
+> 配套文档：[ARCHITECTURE.md](./ARCHITECTURE.md) · [SEQUENCE.md](./SEQUENCE.md) · [CONFIG.md](./CONFIG.md)
+
+---
+
+## 1. 模块概览
+
+`backend/src` 下的主要模块与职责：
+
+| 模块 | 职责 |
+|------|------|
+| `main.rs` | CLI 入口（version / upgrade / server / todo / tag / daemon / skill），启动时调用 `run_server` 装配 HTTP 服务 |
+| `config.rs` | 统一配置（`~/.ntd/config.yaml` 或 `~/.ntd/config.dev.yaml`），所有组件都从这里读，不直接读环境变量 |
+| `daemon.rs` | `ntd daemon install/uninstall/start/stop/restart/status` 子命令，基于 launchd (macOS) / systemd (Linux) |
+| `cli/` | 子命令级别的客户端（`ntd todo add`、`ntd tag list` 等），通过 HTTP 调用本机 API |
+| `service_context.rs` | 跨模块共享的运行时依赖容器（db、executor_registry、tx、task_manager、config） |
+| `adapters/` | AI 执行器适配层。统一 `CodeExecutor` trait + `ExecutorRegistry`，每个 CLI 工具（Claude Code / Codex / OpenCode / Hermes / Kimi / Mimo / MobileCoder / CodeWhale / Pi / CodeBuddy / AtomCode）一个子模块 |
+| `executor_service.rs` | 启动 AI CLI 子进程、解析 stdout/stderr、调度并发上限、超时控制、子进程组级联终止 |
+| `task_manager.rs` | 任务生命周期管理：基于 `mpsc::UnboundedSender` 广播取消信号；`TaskInfo` 用于 WebSocket 同步当前运行列表 |
+| `scheduler.rs` | 基于 `tokio-cron-scheduler` 的 Cron 调度；启动时从 DB 加载；时区换算到 UTC |
+| `handlers/` | Axum HTTP 路由。按业务域拆分（todo / tag / scheduler / session / config / execution / webhook / feishu_* / skills / agent_bot / sync / backup / usage_stats / executor_config / project_directory / todo_template / custom_template） |
+| `hooks/` | Hook 触发引擎：父 Todo 完成事件可级联启动子 Todo；带 chain 检测避免循环 |
+| `models/` | 与 DB / API 共用的数据结构（Todo、ExecutionRecord、ParsedLogEntry 等）+ 占位符替换等工具 |
+| `db/` | SeaORM 数据访问层。所有公开方法 async；SQLite WAL + 外键开启 |
+| `db/entity/` | SeaORM 实体（todos / execution_records / execution_logs / webhooks / webhook_records / tags / todo_tags / executors / agent_bots / feishu_* / project_directories / sync_records / todo_templates / skills / usage_* 等） |
+| `feishu/` | 飞书长连接通道、消息编解码、配置、SDK 封装 |
+| `services/` | 飞书消息监听、消息去抖、自动 review、推送、用量统计等业务服务 |
+| `todo_progress.rs` | Todo 进度解析与展示 |
+| `npm_utils.rs` | 与 npm 全局安装交互的工具（探测 prefix、定位 ntd 二进制路径） |
+| `lib.rs` | 把以上模块 `pub mod` 出去，并嵌入前端 dist 与 ntd-skills 资源 |
+
+---
+
+## 2. 本地开发
+
+### 2.1 前置依赖
+
+- Rust 1.85+
+- Node.js 20+（仅在改前端或跑 `make build` 时需要）
+- Make
+
+### 2.2 常用命令
+
+在仓库根目录执行：
+
+| 命令 | 说明 |
+|------|------|
+| `make setup` | 一次性安装 Rust / Node / cross 等依赖 |
+| `make dev` | 启动开发模式（端口 18088，前后端分离，热重载） |
+| `make stop` | 停止开发实例 |
+| `make build` | 仅构建生产版本（编译前端 → 嵌入 → cargo build --release） |
+| `make clean` | 清理构建产物 |
+| `make install` | 构建并安装到 `~/.local/bin/ntd` |
+| `make cross-build` | 交叉编译 win / mac / linux x86+arm |
+
+### 2.3 端口区分
+
+| 环境 | 端口 | 配置文件 | 数据库 |
+|------|------|---------|--------|
+| 生产 | 8088 | `~/.ntd/config.yaml` | `~/.ntd/data.db` |
+| 开发 (`NTD_MODE=dev`) | 18088 | `~/.ntd/config.dev.yaml` | `~/.ntd/data.dev.db` |
+
+> 通过设置 `NTD_MODE=dev` 环境变量切换开发/生产模式；`config.rs` 会据此选择配置文件路径和默认端口。
+
+### 2.4 单独运行后端测试
+
+```bash
+cd backend
+cargo test
+```
+
+---
+
+## 3. 数据库迁移与初始化
+
+数据库文件位置由 `Config.db_path` 决定，默认 `~/.ntd/data.db`。
+
+### 3.1 启动流程（按顺序执行）
+
+1. `Database::new(path)` → SeaORM 连接 + 设置 PRAGMA (`busy_timeout=5000` / `foreign_keys=ON` / `journal_mode=WAL`)
+2. `init_tables()` — 通过 SeaORM `create_table_from_entity` 同步创建所有表（幂等）
+3. `seed_default_templates()` — 首次启动写入内置 Todo 模板
+4. `migrate_feishu_fk_cascade()` — 给飞书子表补 `ON DELETE CASCADE`（SQLite 不支持 ALTER 外键，需要新建 → 拷贝 → 删除 → 重命名）
+5. `migrate_logs_to_execution_logs()` — 老的 `logs` 表拆到 `execution_logs`（按 `record_id` 关联）
+6. `migrate_from_config(&cfg.executors)` — 老的 `config.yaml` 里 `executors.paths` 一次性迁到 `executors` 表
+7. `seed_default_executors()` — 如果 `executors` 表为空，写入内置执行器列表
+8. `sync_new_executors()` — 比对代码中 `EXECUTORS` 常量与 DB，添加新增的、删除内置已移除的
+9. `backfill_session_dir()` — 给历史执行器补 `session_dir`
+10. `cleanup_orphan_execution_records()` — 启动时清理 status=running 但进程已退出的孤儿
+11. `cleanup_old_webhook_records(30)` — 删除超过 30 天的 webhook 投递记录
+
+### 3.2 新增字段 / 表的标准做法
+
+- 优先改 `db/entity/*.rs` 实体定义，`init_tables()` 会自动建表（缺失列不会自动补，需要写迁移）
+- 如需新增列：写一个类似 `migrate_feishu_fk_cascade()` 的函数，在 `Database::new` 末尾调用，包裹在事务中
+- 删除字段：直接删实体 + 同步删 handler + 测试；旧数据保留但不再读写
+
+### 3.3 开发环境数据库
+
+首次启动会自动创建 `~/.ntd/data.dev.db`。如果 schema 改了想从零开始：
+
+```bash
+rm ~/.ntd/data.dev.db
+make dev
+```
+
+---
+
+## 4. CLI 命令速查
+
+| 命令 | 说明 |
+|------|------|
+| `ntd` | 无子命令时直接启动服务（默认端口读取 config） |
+| `ntd version` | 打印版本与 git SHA |
+| `ntd upgrade` | 通过 npm 拉取最新版并重启 daemon |
+| `ntd server start [--port 8088]` | 显式启动服务 |
+| `ntd todo ...` | Todo CRUD、子命令见 `cli/commands.rs` |
+| `ntd tag ...` | 标签管理 |
+| `ntd stats` | 全局统计 |
+| `ntd daemon install\|uninstall\|start\|stop\|restart\|status` | 服务管理 |
+| `ntd skill install [--force] [--executor claudecode,...]` | 把内置的 `ntd-usage` 技能安装到各执行器技能目录 |
+
+---
+
+## 5. 故障排查
+
+| 症状 | 检查点 |
+|------|-------|
+| 启动报 `Failed to bind to port` | `~/.ntd/config.yaml` 里 `port` 是否被占用；`make stop` 清掉残留进程 |
+| DB 报 `database is locked` | SQLite WAL 模式已被强制开启；通常 5 秒 `busy_timeout` 后自愈；若持续，检查是否有别的进程在写同一个 db 文件 |
+| Todo 执行后立刻 Finished 无日志 | 检查 executor 二进制是否在 `$PATH`；`Executors` 表 `enabled=1` 且 `path` 正确 |
+| WebSocket 连不上 | 浏览器代理拦截了 upgrade；生产模式下 `Host` 是否能从外部访问 |
+| 飞书无响应 | `agent_bots` 表里 `app_id/app_secret` 是否填写；`feishu_project_bindings` 是否启用 |
+
+---
+
+## 6. 测试
+
+```bash
+# 全部测试
+cd backend && cargo test
+
+# 仅某个模块
+cd backend && cargo test --lib config::
+
+# 集成测试（需要 tempfile）
+cd backend && cargo test --test '*'
+```
+
+CI 期望所有 `cargo test` 通过后再合并；新增模块请同步加单元测试，至少覆盖：
+- 公共 API 的正常路径
+- 配置/路径归一化
+- 时区/并发上限等边界条件
+
+---
+
+## 7. 相关文档
+
+- [ARCHITECTURE.md](./ARCHITECTURE.md) — 模块依赖图、关键流程、数据模型、配置项
+- [SEQUENCE.md](./SEQUENCE.md) — 5 个关键流程的 mermaid sequenceDiagram
+- [CONFIG.md](./CONFIG.md) — `~/.ntd/config.yaml` 全部字段说明
+- 仓库根 `DEVELOPMENT.md` — 跨前后端的开发指南
+- 仓库根 `CLAUDE.md` — Claude Code 协作约定（注释规范、分支策略等）

--- a/backend/SEQUENCE.md
+++ b/backend/SEQUENCE.md
@@ -1,0 +1,342 @@
+# ntd Backend 关键流程时序图
+
+> 配套文档：[README.md](./README.md) · [ARCHITECTURE.md](./ARCHITECTURE.md) · [CONFIG.md](./CONFIG.md)
+
+本文档用 mermaid `sequenceDiagram` 描述 5 个最关键的业务流程。每个图都标注了：
+- 涉及模块
+- 关键边界（超时 / 并发上限 / 取消 / 失败兜底）
+- 与其他流程的衔接点
+
+---
+
+## 1. 执行 Todo 的端到端流程
+
+**触发方式**：HTTP `POST /api/execute` 或 CLI `ntd todo execute`，亦可由 cron / webhook / 飞书 / hook 派生。
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Client as 前端 / CLI
+    participant H as handlers/execution.rs<br/>start_todo_execution
+    participant ES as executor_service<br/>run_todo_execution
+    participant TM as task_manager<br/>TaskManager
+    participant REG as adapters<br/>ExecutorRegistry
+    participant DB as db::Database
+    participant TX as broadcast::Sender<br/>ExecEvent
+    participant CG as command-group<br/>AsyncGroupChild
+    participant Hook as hooks<br/>HookService
+    participant WS as WebSocket<br/>前端
+
+    Client->>H: POST /api/execute {todo_id, message, executor?}
+    H->>ES: RunTodoExecutionRequest { ... }
+
+    ES->>TM: register(task_id)
+    TM-->>ES: cancel_rx (mpsc::Receiver)
+
+    ES->>DB: get_todo(todo_id)
+    DB-->>ES: Todo { executor?, ... }
+
+    Note over ES: 并发上限检查<br/>count(running records for todo_id)<br/>&lt; max_concurrent_todos
+
+    ES->>REG: get_or_default(executor_req | todo.executor | default)
+    REG-->>ES: Arc<dyn CodeExecutor>
+
+    ES->>DB: create_execution_record(status=Running)
+    DB-->>ES: record_id
+
+    ES->>TX: send(Started {task_id, todo_id, executor})
+    TX-->>WS: 推前端
+
+    par 子进程 + 日志解析
+        ES->>CG: spawn(cli binary + args)
+        CG-->>ES: child (pgid set)
+
+        loop 每行 stdout/stderr
+            CG-->>ES: BufReader line
+            ES->>ES: parse → ParsedLogEntry
+            ES->>DB: append execution_log
+            ES->>TX: send(Output {entry})
+            TX-->>WS: 推前端
+        end
+
+        ES->>CG: wait_with_output + timeout(execution_timeout_secs)
+    and 取消监听
+        TM->>ES: cancel_rx.recv() (用户取消)
+        ES->>CG: kill() (整个进程组)
+    end
+
+    alt 正常完成
+        CG-->>ES: ExitStatus::success()
+        ES->>DB: update_execution_record(status=Success)
+        ES->>TX: send(Finished {success=true})
+    else 超时
+        Note over ES: tokio timeout 触发
+        ES->>CG: kill()
+        ES->>DB: update_execution_record(status=Timeout)
+        ES->>TX: send(Finished {success=false, "timeout"})
+    else 取消
+        ES->>DB: update_execution_record(status=Cancelled)
+        ES->>TX: send(Finished {success=false, "cancelled by user"})
+    else 进程失败
+        CG-->>ES: ExitStatus::failure / spawn error
+        ES->>DB: update_execution_record(status=Failed, stderr)
+        ES->>TX: send(Finished {success=false})
+    end
+
+    ES->>Hook: fire_for_todo(todo_id, Finished)
+    Note over Hook: 异步 tokio::spawn，<br/>读 parent.hooks 触发子 todo
+
+    ES->>TM: remove(task_id)
+    TX-->>WS: Finished 事件
+```
+
+**关键边界**：
+- 并发上限检查用 `task_manager.get_all_task_infos()` 过滤掉僵尸记录（status=running 但 task_manager 不存在）。
+- 取消信号通过 `mpsc` 通道送达；不要在阻塞 future 中 `recv`，要 `tokio::select!` 与子进程等待并列。
+- 失败兜底：进程崩溃 / spawn 失败 / BufReader EOF 都要把 status 写到 DB；否则前端永远看到 Running。
+
+---
+
+## 2. Cron 调度工作流程
+
+**触发方式**：`make dev` / `make install` 后由 ntd daemon 启动 ntd 服务，scheduler 随之初始化。
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Main as main.rs::run_server
+    participant Cfg as config::Config
+    participant Sched as scheduler<br/>TodoScheduler
+    participant DB as db::Database
+    participant TZ as chrono_tz
+    participant JSC as tokio_cron_scheduler<br/>JobScheduler
+    participant ES as executor_service
+    participant Hook as hooks<br/>HookService
+
+    Main->>Cfg: Config::load() (含 scheduler_default_timezone)
+    Cfg-->>Main: Config
+
+    Main->>Sched: TodoScheduler::new()
+    Main->>Sched: load_from_db(&ctx)
+
+    loop 每个 todo WHERE scheduler_enabled=true
+        Sched->>DB: get_todo(id)
+        DB-->>Sched: Todo { scheduler_config, scheduler_timezone }
+        Sched->>TZ: parse tz (e.g. "Asia/Shanghai")
+        Sched->>Sched: convert_cron_to_utc(cron, tz)
+        Note over Sched: 把用户本地时间转换为 UTC<br/>因为 tokio-cron-scheduler 总是 UTC
+        Sched->>JSC: add(Job::new_async(cron_utc, callback))
+    end
+
+    Main->>Sched: start()
+    Sched->>JSC: start()
+
+    loop 每个 tick
+        JSC->>Sched: 回调 fn(todo_id, cron)
+        Sched->>ES: run_todo_execution(trigger_type="cron")
+        ES->>Hook: fire_for_todo (Finished 后)
+    end
+
+    Note over Main: 周期任务：<br/>auto_backup / auto_todo_backup /<br/>auto_skill_backup / auto_usage_stats /<br/>auto_sync_custom_templates<br/>也走相同 JobScheduler 路径
+```
+
+**关键边界**：
+- `convert_cron_to_utc` 仅处理 hours 字段；`*` / 单值 / `9-17` / `*/2` 中除 `*/2` 外都正确换算。
+- 调度器重启时 JobScheduler 不会保留跨进程状态，必须重新从 DB 加载。
+- `tz=None` 视为 UTC。
+
+---
+
+## 3. 飞书消息处理流程
+
+**触发方式**：某个 `agent_bots.app_id` 配置开启后，ntd 启动时建立 WebSocket 长连接。
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant FS as Feishu Server
+    participant Ch as feishu/channel.rs<br/>FeishuChannelService
+    participant L as services/feishu_listener
+    participant TM as TokenManager
+    participant DB as db::Database
+    participant Bind as feishu_project_bindings
+    participant Debounce as MessageDebounce
+    participant ES as executor_service
+    participant TX as broadcast::Sender
+
+    Note over Ch: 启动时为每个 bot_id<br/>创建独立 WS 连接
+
+    loop 心跳 / 重连
+        FS->>Ch: ping / pong
+    end
+
+    FS->>Ch: 消息事件 (message_id, chat_id, sender, content)
+    Ch->>Ch: codec 解码 → ChannelMessage
+    Ch->>L: dispatch
+
+    L->>TM: get_token(bot_id)
+    TM-->>L: access_token
+
+    L->>DB: feishu_messages::insert(bot_id, msg)
+    Note over L: message_id UK，幂等
+
+    L->>Bind: get_by_chat_id(bot_id, chat_id)
+    alt 命中绑定
+        Bind-->>L: project_dir + resume_session_id?
+        L->>L: 解析 slash command 或 default_response_todo
+    else 未绑定
+        L->>L: 走 slash command / default_response
+    end
+
+    L->>Debounce: push(PendingMessage {bot_id, chat_id, ...})
+    Note over Debounce: 同 (bot_id, chat_id) 已存在 →<br/>abort 旧 timer + 合并<br/>否则注册新 timer (debounce_secs)
+
+    Note over Debounce: 等 debounce_secs 或新消息打断
+
+    Debounce->>ES: run_todo_execution(trigger_type="feishu",<br/>resume_session_id?, resume_message?,<br/>binding_id?)
+    ES->>DB: create_execution_record
+    ES->>TX: send(Started)
+
+    Note over ES: 正常执行链路<br/>(见 §1)
+
+    ES->>TX: send(Finished)
+    TX-->>L: 收到 Finished
+    L->>FS: 调 send_message API 回复结果<br/>(绑定 chat_id)
+    L->>DB: update feishu_messages.processed=1,<br/>processed_todo_id, execution_record_id
+```
+
+**关键边界**：
+- 同 `(bot_id, chat_id)` 短时间内多消息只触发一次执行；合并逻辑保留最后一条 + 历史摘要。
+- `feishu_messages.message_id` 是 unique，重复投递走幂等分支不重复执行。
+- `history_message_max_age_secs`（默认 600）控制历史回溯多久的消息还会被处理；超过的标 `is_history=1` 跳过。
+- Token 由 `TokenManager` 缓存，过期前自动刷新；冷启动时同步获取。
+
+---
+
+## 4. 配置加载流程
+
+**触发方式**：每次 `ntd` 启动时 `Config::load()`。
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Main as main.rs::run_server
+    participant Cfg as config::Config
+    participant FS as std::fs
+    participant Yaml as serde_yaml
+    participant Env as std::env
+
+    Main->>Cfg: Config::load()
+    Cfg->>Env: NTD_MODE ?
+    alt NTD_MODE=dev
+        Cfg->>FS: path = ~/.ntd/config.dev.yaml
+    else 生产
+        Cfg->>FS: path = ~/.ntd/config.yaml
+    end
+
+    alt 文件不存在
+        Cfg->>Cfg: Config::default() + dev 覆盖 (port, db_path)
+        Cfg->>Cfg: normalize_paths()
+        Cfg->>Cfg: clamp_execution_timeout_secs()
+        Cfg->>FS: create_dir_all(parent)
+        Cfg->>Yaml: to_string(&cfg)
+        Cfg->>FS: write(path, yaml)
+        Cfg-->>Main: cfg (in-memory, 已 normalize)
+    else 文件存在
+        Cfg->>FS: read_to_string(path)
+        FS-->>Cfg: yaml content
+        Cfg->>Yaml: from_str::<Config>(content)
+        alt 解析失败
+            Cfg->>Cfg: warn + Config::default()
+        else 解析成功
+            Cfg->>Cfg: cfg (含 ExecutorPaths 反序列化兜底)
+        end
+        Cfg->>Cfg: normalize_paths()
+        Note over Cfg: db_path: ~ → home 展开<br/>executors.paths: ~ / 相对路径展开<br/>裸命令名（无 /）原样保留
+        Cfg->>Cfg: clamp_execution_timeout_secs()
+        Note over Cfg: 0 保留<br/>1-59 → 60<br/>> MAX_EXECUTION_TIMEOUT_SECS → MAX
+        Cfg-->>Main: cfg
+    end
+
+    Note over Main: HTTP PUT /api/config → 同样的<br/>normalize + clamp 流程（去重避免跳过兜底）
+```
+
+**关键边界**：
+- 用户直接编辑 `~/.ntd/config.yaml` 时 `clamp_execution_timeout_secs` 是唯一兜底（HTTP 路径用 `validate_execution_timeout_secs`）。
+- `ExecutorPaths` 反序列化兼容两种 schema：`{paths: {...}}` 和老版本直接 `{...}`，避免历史配置文件升级失败。
+- 配置文件写入用 `temp + rename` 原子替换；崩溃时不会留下半截 YAML。
+
+---
+
+## 5. 数据库初始化流程
+
+**触发方式**：`Database::new(path)`。
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Main as main.rs::run_server
+    participant DB as db::Database
+    participant SO as sea_orm<br/>ConnectOptions
+    participant SQL as SQLite
+    participant Migrate as db::Database<br/>(migrations)
+
+    Main->>DB: Database::new(db_path)
+    DB->>SO: ConnectOptions::new("sqlite://...?mode=rwc")
+    SO->>SO: max_connections(10)<br/>min_connections(1)<br/>connect_timeout(5s)<br/>sqlx_logging(false)
+    DB->>SQL: connect()
+
+    DB->>SQL: PRAGMA busy_timeout=5000
+    DB->>SQL: PRAGMA foreign_keys=ON
+    DB->>SQL: PRAGMA journal_mode=WAL
+    DB->>SQL: query("SELECT journal_mode")
+    SQL-->>DB: mode (期望 "wal")
+
+    DB->>SQL: init_tables()
+    Note over DB,SQL: 遍历 entity/*.rs<br/>CREATE TABLE IF NOT EXISTS
+
+    DB->>DB: seed_default_templates()
+    Note over DB: 内置 todo_templates 写入
+
+    DB->>DB: migrate_feishu_fk_cascade()
+    Note over DB: 检查 sqlite_master.sql<br/>缺 ON DELETE CASCADE 的表<br/>→ 重建 (新表→copy→drop→rename)
+
+    DB->>DB: migrate_logs_to_execution_logs()
+    Note over DB: 老 logs 表数据迁到 execution_logs
+
+    DB->>DB: migrate_from_config(&cfg.executors)
+    Note over DB: 一次迁移：<br/>config.yaml.executors.paths →<br/>executors 表
+
+    DB->>DB: seed_default_executors()
+    Note over DB: 表为空时写入 11 个内置执行器
+
+    DB->>DB: sync_new_executors()
+    Note over DB: 增量：代码 EXECUTORS 常量 vs DB<br/>补新增、删内置已移除
+
+    DB->>DB: backfill_session_dir()
+    Note over DB: 给历史 executors 补 session_dir
+
+    DB->>DB: cleanup_orphan_execution_records()
+    Note over DB: status='running' 但进程已退出<br/>→ status='failed' + finished_at=now
+
+    DB->>DB: cleanup_old_webhook_records(30 days)
+    DB-->>Main: Database ready
+```
+
+**关键边界**：
+- `PRAGMA foreign_keys=ON` 必须显式开，SQLite 默认 OFF。
+- WAL 模式下允许多读单写；`max_connections=10` 是 SQLite + SeaORM 的安全上限。
+- `migrate_feishu_fk_cascade` 用事务包住整个重建过程；失败回滚不留半截表。
+- 增量迁移（`sync_new_executors`）让代码升级时自动同步 DB，不会让新 executor 缺失。
+
+---
+
+## 附录：模块路径速查
+
+| 流程 | 入口模块 | 关键函数 |
+|------|---------|---------|
+| Todo 执行 | `handlers::execution::start_todo_execution` | `executor_service::run_todo_execution` |
+| Cron 调度 | `scheduler::TodoScheduler::load_from_db` | `scheduler::convert_cron_to_utc` |
+| 飞书消息 | `services::feishu_listener::on_message` | `services::message_debounce::push` |
+| 配置加载 | `config::Config::load` | `normalize_paths` / `clamp_execution_timeout_secs` |
+| DB 初始化 | `db::Database::new` | `migrate_feishu_fk_cascade` / `sync_new_executors` |


### PR DESCRIPTION
## 背景

关闭 issue #518。backend/ 目录此前没有任何 README/架构图，新人 onboarding 只能通过 main.rs + CLAUDE.md + 代码注释理解。本 PR 添加 4 个文档，覆盖 Diátaxis 框架中 explanation + reference 两类。

## 改动

新增 4 个文档文件，不修改任何既有代码：

- **backend/README.md**：模块概览 + 本地开发命令 + DB 迁移说明 + 故障排查 + 测试策略
- **backend/ARCHITECTURE.md**：
  - 模块依赖图（mermaid flowchart，标注 service_context 依赖容器作用）
  - ER 图（todos / execution_records / executors / feishu_* / sync / usage 等）
  - 5 个关键流程概述 + 跨切关注点（并发、取消、超时、事件总线、飞书去抖、Hook 防环）
  - 进程模型 / 已知技术债
- **backend/SEQUENCE.md**：5 个关键流程的 mermaid sequenceDiagram
  - 执行 Todo 的端到端流程
  - Cron 调度工作流程
  - 飞书消息处理流程
  - 配置加载流程
  - 数据库初始化流程
- **backend/CONFIG.md**：~20 个配置项逐项说明（服务 / 备份 / 飞书 / 调度器 / 云端同步）+ 兼容性字段 + HTTP 动态修改白名单

## 验证

- 4 个 markdown 文件均通过 mermaid 语法解析（架构图 / ER 图 / 时序图用 mermaid 块）
- 内容来源：直接读 backend/src/ 现有代码（config.rs / executor_service.rs / scheduler.rs / task_manager.rs / db/mod.rs / hooks/service.rs / services/feishu_listener.rs / services/message_debounce.rs / adapters/mod.rs 等）
- 所有流程描述都标注了与 issue 相关的边界条件（如 #503 broadcast 容量、#510 RwLock 类型、#495 unwrap 风险）

## 影响

- 新人 onboarding 速度提升
- 后续 PR 评审有 ARCHITECTURE.md 做基准
- 不修改任何 Rust 代码，无运行时行为变更