### PR TITLE
fix: make WebSocket broadcast channel capacity configurable (#503)

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -21,6 +21,15 @@ pub const DEFAULT_EXECUTOR_PATH: &str = ""; // use binary name directly
 pub const DEFAULT_EXECUTION_TIMEOUT_SECS: u64 = 3600;
 /// 执行超时上限（秒）：7 天。YAML 加载和 HTTP update 均受此约束。
 pub const MAX_EXECUTION_TIMEOUT_SECS: u64 = 604800;
+/// WebSocket broadcast channel 默认容量。
+///
+/// 原先硬编码为 100，但 AI 执行器（如 claude_code）的 `Output` 事件频率可达每秒数十条，
+/// 100 的容量在 1~2 秒延迟下就会因 ring buffer 覆盖而丢消息，导致前端日志断断续续、
+/// `Finished` 等关键事件丢失。10000 大约能覆盖 200s@50msg/s 或 100s@100msg/s 的 burst，
+/// 对绝大多数使用场景足够；同时 broadcast 是 ring buffer，内存开销仅 O(capacity)。
+pub const DEFAULT_BROADCAST_CHANNEL_CAPACITY: usize = 10000;
+/// WebSocket broadcast channel 最小容量。低于此值视为配置错误，自动抬升以避免退化到丢消息。
+pub const MIN_BROADCAST_CHANNEL_CAPACITY: usize = 100;
 
 /// Top-level configuration, persisted to `~/.ntd/config.yaml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -77,6 +86,12 @@ pub struct Config {
     pub auto_usage_stats_enabled: bool,
     /// AI 使用统计自动归档 cron 表达式（6 字段，含秒），默认每天凌晨 1 点执行
     pub auto_usage_stats_cron: String,
+    /// WebSocket broadcast channel 容量（ring buffer 大小）。
+    ///
+    /// 影响所有 `/events` WebSocket 订阅者能缓存的最大事件数。当慢消费者
+    /// （如刚连上的客户端、暂停的标签页）落后超过此容量时，最旧事件将被覆盖丢弃。
+    /// 仅在启动时生效，运行时调整需要重启服务。最小值见 `MIN_BROADCAST_CHANNEL_CAPACITY`。
+    pub broadcast_channel_capacity: usize,
     /// 云端同步配置
     pub cloud_sync: CloudSyncConfig,
 }
@@ -189,6 +204,7 @@ impl Default for Config {
             scheduler_default_timezone: None,
             auto_usage_stats_enabled: false,
             auto_usage_stats_cron: "0 0 1 * * *".to_string(),
+            broadcast_channel_capacity: DEFAULT_BROADCAST_CHANNEL_CAPACITY,
             cloud_sync: CloudSyncConfig::default(),
         }
     }
@@ -213,6 +229,7 @@ impl Config {
             };
             cfg.normalize_paths();
             cfg.clamp_execution_timeout_secs();
+            cfg.clamp_broadcast_channel_capacity();
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent).ok();
             }
@@ -234,6 +251,7 @@ impl Config {
                 });
                 cfg.normalize_paths();
                 cfg.clamp_execution_timeout_secs();
+                cfg.clamp_broadcast_channel_capacity();
                 cfg
             }
             Err(e) => {
@@ -241,6 +259,7 @@ impl Config {
                 let mut cfg = Config::default();
                 cfg.normalize_paths();
                 cfg.clamp_execution_timeout_secs();
+                cfg.clamp_broadcast_channel_capacity();
                 cfg
             }
         }
@@ -275,6 +294,20 @@ impl Config {
             self.execution_timeout_secs = 60;
         } else if self.execution_timeout_secs > MAX_EXECUTION_TIMEOUT_SECS {
             self.execution_timeout_secs = MAX_EXECUTION_TIMEOUT_SECS;
+        }
+    }
+
+    /// 把 broadcast_channel_capacity 抬升到最小值 `MIN_BROADCAST_CHANNEL_CAPACITY`。
+    ///
+    /// **为什么需要**：YAML 直接编辑可绕过 HTTP 校验把 capacity 写成 0/1/50 等无意义值，
+    /// 这种配置等同于「关闭事件流」，会让慢消费者立刻丢失 Finished 等关键事件。
+    /// 这里强制把任意小于阈值的值抬升到 `MIN_BROADCAST_CHANNEL_CAPACITY`，保持行为可观察。
+    ///
+    /// **为什么不在这里设置上限**：broadcast 是 ring buffer，capacity 与每条事件大小相关，
+    /// 但每条 ExecEvent 序列化后通常 < 1KB，100000 条也只占约 100MB，运维需要时可自行调大。
+    pub fn clamp_broadcast_channel_capacity(&mut self) {
+        if self.broadcast_channel_capacity < MIN_BROADCAST_CHANNEL_CAPACITY {
+            self.broadcast_channel_capacity = MIN_BROADCAST_CHANNEL_CAPACITY;
         }
     }
 
@@ -479,5 +512,73 @@ mod tests {
         let mut cfg = Config { execution_timeout_secs: MAX_EXECUTION_TIMEOUT_SECS, ..Default::default() };
         cfg.clamp_execution_timeout_secs();
         assert_eq!(cfg.execution_timeout_secs, MAX_EXECUTION_TIMEOUT_SECS);
+    }
+
+    // ---------------------------------------------------------------------------
+    // broadcast_channel_capacity tests (YAML bypass safety net + round-trip)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn test_default_broadcast_channel_capacity_is_10000() {
+        // 默认值是 10000，比硬编码 100 大两个数量级，避免高频输出场景下 ring buffer 覆盖
+        let cfg = Config::default();
+        assert_eq!(cfg.broadcast_channel_capacity, DEFAULT_BROADCAST_CHANNEL_CAPACITY);
+        assert_eq!(cfg.broadcast_channel_capacity, 10000);
+    }
+
+    #[test]
+    fn test_broadcast_channel_capacity_round_trip() {
+        // 自定义值能在 YAML 序列化/反序列化后保留
+        let cfg = Config {
+            broadcast_channel_capacity: 50000,
+            ..Default::default()
+        };
+        let yaml = serde_yaml::to_string(&cfg).unwrap();
+        let restored: Config = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(restored.broadcast_channel_capacity, 50000);
+    }
+
+    #[test]
+    fn test_clamp_broadcast_channel_raises_zero_to_min() {
+        // 0 = 等同于关闭事件流，必须抬升到最小值
+        let mut cfg = Config {
+            broadcast_channel_capacity: 0,
+            ..Default::default()
+        };
+        cfg.clamp_broadcast_channel_capacity();
+        assert_eq!(cfg.broadcast_channel_capacity, MIN_BROADCAST_CHANNEL_CAPACITY);
+    }
+
+    #[test]
+    fn test_clamp_broadcast_channel_raises_small_value() {
+        // 任何小于 MIN 的值都被抬升
+        let mut cfg = Config {
+            broadcast_channel_capacity: 50,
+            ..Default::default()
+        };
+        cfg.clamp_broadcast_channel_capacity();
+        assert_eq!(cfg.broadcast_channel_capacity, MIN_BROADCAST_CHANNEL_CAPACITY);
+    }
+
+    #[test]
+    fn test_clamp_broadcast_channel_preserves_in_range_value() {
+        // 在 [MIN, ∞) 范围内的值不应被修改
+        let mut cfg = Config {
+            broadcast_channel_capacity: 5000,
+            ..Default::default()
+        };
+        cfg.clamp_broadcast_channel_capacity();
+        assert_eq!(cfg.broadcast_channel_capacity, 5000);
+    }
+
+    #[test]
+    fn test_clamp_broadcast_channel_preserves_minimum_boundary() {
+        // 恰好等于 MIN 的值不应被修改
+        let mut cfg = Config {
+            broadcast_channel_capacity: MIN_BROADCAST_CHANNEL_CAPACITY,
+            ..Default::default()
+        };
+        cfg.clamp_broadcast_channel_capacity();
+        assert_eq!(cfg.broadcast_channel_capacity, MIN_BROADCAST_CHANNEL_CAPACITY);
     }
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -307,6 +307,11 @@ impl Config {
     /// 但每条 ExecEvent 序列化后通常 < 1KB，100000 条也只占约 100MB，运维需要时可自行调大。
     pub fn clamp_broadcast_channel_capacity(&mut self) {
         if self.broadcast_channel_capacity < MIN_BROADCAST_CHANNEL_CAPACITY {
+            tracing::warn!(
+                "broadcast_channel_capacity {} below minimum {}, raising to minimum",
+                self.broadcast_channel_capacity,
+                MIN_BROADCAST_CHANNEL_CAPACITY
+            );
             self.broadcast_channel_capacity = MIN_BROADCAST_CHANNEL_CAPACITY;
         }
     }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1588,8 +1588,7 @@ mod tests {
 
     async fn create_test_execution_record(db: &Database, todo_id: i64, command: &str) -> i64 {
         db.create_execution_record(NewExecutionRecord {
-            // NewExecutionRecord.todo_id is `i64` (non-optional) in current schema，
-            // 直接传值而不是包成 Some；旧 API 用 `Some(todo_id)` 已不再兼容
+            // `NewExecutionRecord.todo_id` is now `i64` (was `Option<i64>`); pass directly.
             todo_id,
             command,
             executor: "claudecode",

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1588,7 +1588,9 @@ mod tests {
 
     async fn create_test_execution_record(db: &Database, todo_id: i64, command: &str) -> i64 {
         db.create_execution_record(NewExecutionRecord {
-            todo_id: Some(todo_id),
+            // NewExecutionRecord.todo_id is `i64` (non-optional) in current schema，
+            // 直接传值而不是包成 Some；旧 API 用 `Some(todo_id)` 已不再兼容
+            todo_id,
             command,
             executor: "claudecode",
             trigger_type: "manual",

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -69,9 +69,21 @@ pub async fn update_config(
             Some(tz.to_string())
         };
     }
+    if let Some(capacity) = req.broadcast_channel_capacity {
+        // 与 YAML 加载路径保持一致的最小值校验，避免配成 0 让 ring buffer 立刻被覆盖丢消息。
+        // 注：运行时修改后只持久化配置，重启服务才会在新连接上生效（broadcast channel 启动时建）。
+        if capacity < crate::config::MIN_BROADCAST_CHANNEL_CAPACITY {
+            return Err(AppError::BadRequest(format!(
+                "broadcast_channel_capacity must be at least {}",
+                crate::config::MIN_BROADCAST_CHANNEL_CAPACITY
+            )));
+        }
+        cfg.broadcast_channel_capacity = capacity;
+    }
 
     cfg.normalize_paths();
     cfg.clamp_execution_timeout_secs();
+    cfg.clamp_broadcast_channel_capacity();
 
     let cfg_clone = cfg.clone();
     tokio::task::spawn_blocking(move || cfg_clone.save())

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -203,17 +203,42 @@ pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade)
                 .await;
         }
 
-        while let Ok(event) = rx.recv().await {
-            let json = serde_json::to_string(&event).unwrap_or_default();
-            if json.is_empty() {
-                continue;
-            }
-            if ws
-                .send(axum::extract::ws::Message::Text(json.into()))
-                .await
-                .is_err()
-            {
-                break;
+        // 循环从 broadcast channel 读取事件并推到 WebSocket。
+        //
+        // 注意 `rx.recv()` 在 channel 容量耗尽时返回 `RecvError::Lagged(n)`:
+        // ring buffer 已被覆盖,n 条旧事件丢失(包括可能错过的 Finished 等
+        // 关键事件)。这里选择 **重新订阅** —— `subscribe()` 拿到的 rx 指向
+        // channel 当前 head,自然跳过被覆盖的积压;前端只会看到日志断流
+        // 不会断开连接。如果不处理 Lagged,原 `while let Ok(...)` 会立刻
+        // 退出 → WS 断开 → 前端误判任务仍在执行。
+        //
+        // 对比 `services/feishu_push.rs:91-93` 的同模式实现。
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    let json = serde_json::to_string(&event).unwrap_or_default();
+                    if json.is_empty() {
+                        continue;
+                    }
+                    if ws
+                        .send(axum::extract::ws::Message::Text(json.into()))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(
+                        "[ws-events] client lagged, skipped {} events; resubscribing to skip backlog",
+                        n
+                    );
+                    rx = state.tx.subscribe();
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    tracing::info!("[ws-events] broadcast channel closed, closing WebSocket");
+                    break;
+                }
             }
         }
     })

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -451,7 +451,9 @@ async fn run_server(cli_port: Option<u16>) {
     let executors = executor_registry.list_executors().await;
     info!("Available executors: {:?}", executors);
 
-    let (tx, _rx) = broadcast::channel(100);
+    // WebSocket 事件 broadcast channel 容量从配置读取，避免硬编码 100 在高频输出场景下
+    // 因 ring buffer 覆盖而丢失 Finished 等关键事件。Config::load 已经做过最小值 clamp。
+    let (tx, _rx) = broadcast::channel(cfg.broadcast_channel_capacity);
     let task_manager = Arc::new(TaskManager::new());
     let config = Arc::new(tokio::sync::RwLock::new(cfg.clone()));
 

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -664,6 +664,8 @@ pub struct UpdateConfigRequest {
     pub max_concurrent_todos: Option<u32>,
     pub execution_timeout_secs: Option<u64>,
     pub scheduler_default_timezone: Option<String>,
+    /// WebSocket broadcast channel 容量。修改后需要重启服务才会在新连接上生效。
+    pub broadcast_channel_capacity: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/docs/user-guide/settings/system-settings.md
+++ b/docs/user-guide/settings/system-settings.md
@@ -30,6 +30,7 @@ ntd 的核心运行时配置都在这里。改完点「**保存**」→ `PUT /ap
 |------|------|------|--------|
 | `max_concurrent_todos` | `3` | 同时跑的最大 Todo数 | ❌ |
 | `execution_timeout_secs` | `3600` |单个 Todo最长执行时间 | ❌ |
+| `broadcast_channel_capacity` | `10000` |WebSocket `/events` 频道 ring buffer 大小；高频输出执行器(50 msg/s × 200s)的 burst 上限 | ✅（启动时建 channel）|
 
 >超出 `execution_timeout_secs` 的执行会被强制失败（走 `execution::force_fail_execution_handler`）。
 


### PR DESCRIPTION
Closes #503

## 问题
`backend/src/main.rs:454` 中 `broadcast::channel(100)` 硬编码为 100。在 AI 执行器（如 claude_code）的高频输出场景下，stdout 每秒可达数十条 `Output` 事件，1~2 秒延迟的 WebSocket 客户端就会因 ring buffer 覆盖而丢消息，导致前端日志断断续续，且 `Finished` 等关键事件丢失会让前端误判任务仍在执行。

## 修复
- **Config 新增字段** `broadcast_channel_capacity: usize`（默认 10000，最小 100）
- **新增 `clamp_broadcast_channel_capacity`**，与 `clamp_execution_timeout_secs` 同样的「YAML 绕过安全网」模式，避免配成 0/1 等无意义值
- **main.rs** 使用 `cfg.broadcast_channel_capacity` 替代硬编码
- **HTTP `update_config`** 暴露该字段供运行时调整（重启生效，因为 broadcast channel 在启动时建）
- **测试**: 6 个新单测覆盖默认值、YAML 往返、clamp 三种分支

## 为什么是 10000
10000 大约能覆盖 200s@50msg/s 或 100s@100msg/s 的 burst，对绝大多数使用场景足够；broadcast 是 ring buffer，10000 条 ExecEvent（每条 < 1KB）约 10MB 内存开销。

## 验证
- `cargo check`: 通过
- `cargo test --lib config::`: 27/27 通过（含 6 个新增）
- `cargo test --lib`: 339 通过，1 个失败 (`adapters::codewhale::tests::test_get_final_result_with_text`) 是 main 上预先存在的、与本 PR 无关的 whitespace 测试问题

## 附带修复
- `db/mod.rs:1591`: 修正预先存在的测试 helper 类型不匹配 (`Some(todo_id)` → `todo_id`，因 `NewExecutionRecord.todo_id` 已从 `Option<i64>` 改为 `i64`)，让 `cargo test --lib` 整体可编译