### PR TITLE
refactor: 提取 dispatch_subcommand 和 fail_on 辅助函数以减少 main.rs 重复代码

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -190,42 +190,15 @@ async fn main() {
             return;
         }
         Some(Commands::Todo { action }) => {
-            let cli = cli::Cli {
-                server: cli.server.clone(),
-                output: cli.output,
-                fields: cli.fields.clone(),
-                command: cli::Commands::Todo { action: action.clone() },
-            };
-            if let Err(e) = cli::run_command(&cli).await {
-                print_structured_error(&e);
-                std::process::exit(1);
-            }
+            dispatch_subcommand(&cli, cli::Commands::Todo { action: action.clone() }).await;
             return;
         }
         Some(Commands::Tag { action }) => {
-            let cli = cli::Cli {
-                server: cli.server.clone(),
-                output: cli.output,
-                fields: cli.fields.clone(),
-                command: cli::Commands::Tag { action: action.clone() },
-            };
-            if let Err(e) = cli::run_command(&cli).await {
-                print_structured_error(&e);
-                std::process::exit(1);
-            }
+            dispatch_subcommand(&cli, cli::Commands::Tag { action: action.clone() }).await;
             return;
         }
         Some(Commands::Stats) => {
-            let cli = cli::Cli {
-                server: cli.server.clone(),
-                output: cli.output,
-                fields: cli.fields.clone(),
-                command: cli::Commands::Stats,
-            };
-            if let Err(e) = cli::run_command(&cli).await {
-                print_structured_error(&e);
-                std::process::exit(1);
-            }
+            dispatch_subcommand(&cli, cli::Commands::Stats).await;
             return;
         }
         Some(Commands::Daemon { action }) => {
@@ -256,6 +229,28 @@ fn print_structured_error(e: &anyhow::Error) {
         "message": e.to_string(),
     });
     eprintln!("{}", serde_json::to_string(&err).unwrap_or_else(|_| r#"{"error":true,"message":"unknown"}"#.to_string()));
+}
+
+/// Print a structured error and exit the process.
+fn fail_on<T>(result: anyhow::Result<T>) -> T {
+    match result {
+        Ok(v) => v,
+        Err(e) => {
+            print_structured_error(&e);
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Dispatch a CLI subcommand (Todo/Tag/Stats) with unified error handling.
+async fn dispatch_subcommand(cli: &Cli, command: cli::Commands) {
+    let sub_cli = cli::Cli {
+        server: cli.server.clone(),
+        output: cli.output,
+        fields: cli.fields.clone(),
+        command,
+    };
+    fail_on(cli::run_command(&sub_cli).await);
 }
 
 /// Executor type → skill directory mapping (delegated to shared module).


### PR DESCRIPTION
## 修改内容

根据 Issue #515 的建议，从 main.rs 提取辅助函数减少重复代码：

### 1. `dispatch_subcommand` 辅助函数
合并 Todo、Tag、Stats 三个子命令的重复调用模式（构造 `cli::Cli` + `run_command` + 错误处理），每个分支从 ~10 行减少到 ~4 行。

### 2. `fail_on` 错误处理函数
统一的 `print_structured_error` + `std::process::exit(1)` 模式封装，避免重复。

### 变更统计
- 1 个文件变更
- +25 / -30 行（净减 5 行，同时新增了可复用的辅助函数）

## 测试
`cargo check` 通过，无新增 warning。

Closes #515