### PR TITLE
fix(#509): 复用 AppState 共享的 HookService 单例

### DIFF
--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -9,6 +9,7 @@ use command_group::AsyncCommandGroup;
 use crate::adapters::{parse_executor_type, ExecutorRegistry};
 use crate::db::{Database, NewExecutionRecord};
 use crate::handlers::ExecEvent;
+use crate::hooks::HookService;
 use crate::models::{ExecutorType, ParsedLogEntry};
 use crate::task_manager::TaskManager;
 
@@ -36,6 +37,18 @@ pub struct RunTodoExecutionRequest {
     pub tx: broadcast::Sender<ExecEvent>,
     pub task_manager: Arc<TaskManager>,
     pub config: Arc<tokio::sync::RwLock<crate::config::Config>>,
+    /// 共享的 hook 触发器（来自 AppState 单例）。
+    ///
+    /// 之所以放在 request 里而不是在 `run_todo_execution` 内重新 `Arc::new(HookService::new(...))`，
+    /// 是因为：
+    /// 1. `HookService` 本身持有 `ServiceContext`（5 个 Arc + tokio::RwLock），每次执行末
+    ///    段 fire 钩子时重新 clone 5 个 Arc 是无意义的开销。
+    /// 2. AppState 里已经维护了一个长生命周期的 `Arc<HookService>`（handlers/mod.rs 中创建），
+    ///    handler 路径（handlers/todo.rs::update_todo 状态变更）已经在复用它，executor
+    ///    路径保持一致能避免出现两套 `HookService` 实例可能造成的不一致。
+    /// 3. `HookService::fire_for_todo` 内部会 `tokio::spawn` 子任务发新执行记录，
+    ///    复用同一个 service 能让所有 hook 触发的执行共享同一份内存状态。
+    pub hook_service: Arc<HookService>,
     pub todo_id: i64,
     pub message: String,
     pub req_executor: Option<String>,
@@ -65,6 +78,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
         tx,
         task_manager,
         config,
+        hook_service,
         todo_id,
         message,
         req_executor,
@@ -329,6 +343,9 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     let task_manager_spawn = task_manager.clone();
     let executor_registry_spawn = executor_registry.clone();
     let config_spawn = config.clone();
+    // 共享 AppState 的 hook_service：避免在执行末段 fire 钩子时再 Arc::new 一份 HookService
+    // （参见 RunTodoExecutionRequest::hook_service 字段注释）。
+    let hook_service_spawn = hook_service.clone();
 
     let todo_title = todo.as_ref().map(|t| t.title.clone()).unwrap_or_default();
     let execution_timeout_secs = timeout_secs;
@@ -1003,6 +1020,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                 tx_clone.clone(),
                 task_manager_spawn.clone(),
                 config_spawn.clone(),
+                hook_service_spawn.clone(),
                 todo_id,
                 record_id,
             )
@@ -1029,15 +1047,22 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                 t.workspace.clone(),
                 chain.clone(),
             ) {
-                let svc_ctx = crate::service_context::ServiceContext {
-                    db: db_clone.clone(),
-                    executor_registry: executor_registry_spawn.clone(),
-                    tx: tx_clone.clone(),
-                    task_manager: task_manager_spawn.clone(),
-                    config: config_spawn.clone(),
-                };
-                let svc = std::sync::Arc::new(crate::hooks::HookService::new(svc_ctx));
-                svc.fire_for_todo(todo_id, ctx);
+                // 复用 AppState 里共享的 HookService，而不是再 Arc::new 一份。
+                //
+                // 之前这里每次执行末段都重新构造 HookService + 重新 clone 5 个
+                // ServiceContext 字段 (db/executor_registry/tx/task_manager/config)，
+                // 造成 (1) 重复的 Arc 引用计数抖动，(2) 出现两份 HookService 实例
+                // 各自管自己内部状态的不一致 (例如后续想加共享缓存会立刻踩坑)。
+                // 现在与 handlers/todo.rs 走的是同一个 Arc<HookService> 单例。
+                //
+                // fire_for_todo 内部是 tokio::spawn 子任务 + fire-and-forget，
+                // 这里只追加一行 debug 日志方便排查"是否走到了 fire 路径"。
+                tracing::debug!(
+                    "firing state-change hook for todo #{} -> {:?}",
+                    todo_id,
+                    new_status
+                );
+                hook_service_spawn.clone().fire_for_todo(todo_id, ctx);
             }
         }
 
@@ -1121,7 +1146,7 @@ pub async fn run_todo_execution_with_params(
 
 /// 同步运行自动评审。在原 todo 执行完成、update_execution_record 写入 success/failed 后调用。
 ///
-/// 参数: (db, todo, record_id, executor_registry, tx, task_manager, config).
+/// 参数: (db, todo, record_id, executor_registry, tx, task_manager, config, hook_service).
 /// 任何错误都只记 warn 日志，不影响原 todo 的完成响应。
 ///
 /// 实现: 由于 run_auto_review_inner 内部需要 await run_todo_execution (后者会
@@ -1132,6 +1157,7 @@ pub async fn run_auto_review(
     tx: tokio::sync::broadcast::Sender<crate::handlers::ExecEvent>,
     task_manager: Arc<crate::task_manager::TaskManager>,
     config: Arc<tokio::sync::RwLock<crate::config::Config>>,
+    hook_service: Arc<HookService>,
     todo_id: i64,
     record_id: i64,
 ) {
@@ -1142,10 +1168,11 @@ pub async fn run_auto_review(
     let tx_outer = tx.clone();
     let tm_c = task_manager.clone();
     let cfg_c = config.clone();
+    let hs_c = hook_service.clone();
     let runtime = review_runtime();
     std::thread::spawn(move || {
         let result = runtime.block_on(run_auto_review_inner(
-            db_c, er_c, tx_c, tm_c, cfg_c, todo_id, record_id,
+            db_c, er_c, tx_c, tm_c, cfg_c, hs_c, todo_id, record_id,
         ));
         let _ = reply_tx.send(result);
     });
@@ -1185,6 +1212,7 @@ async fn run_auto_review_inner(
     tx: tokio::sync::broadcast::Sender<crate::handlers::ExecEvent>,
     task_manager: Arc<crate::task_manager::TaskManager>,
     config: Arc<tokio::sync::RwLock<crate::config::Config>>,
+    hook_service: Arc<HookService>,
     todo_id: i64,
     record_id: i64,
 ) -> Result<(), String> {
@@ -1263,6 +1291,9 @@ async fn run_auto_review_inner(
         tx: tx.clone(),
         task_manager: task_manager.clone(),
         config: config.clone(),
+        // 评审实例同样要复用同一个 HookService，确保评审触发的钩子与其他执行路径
+        // 共享状态；如果评审触发链上又产生新的执行，hook_service 不会再被重复构造。
+        hook_service: hook_service.clone(),
         todo_id: review_todo_id,
         message: composed_prompt,
         req_executor: template.executor.clone(),
@@ -1332,3 +1363,32 @@ async fn run_auto_review_inner(
     Ok(())
 }
 
+
+#[cfg(test)]
+mod run_todo_execution_request_tests {
+    //! 验证 `RunTodoExecutionRequest::hook_service` 字段被正确暴露，
+    //! 防止后续重构无意中把它移除/改名、导致 executor_service 末段又
+    //! 回退到 `Arc::new(HookService::new(...))` 重复构造 (issue #509)。
+    use super::*;
+
+    /// 编译期断言：把 `RunTodoExecutionRequest` 的 `hook_service` 字段
+    /// 投影成 `&Arc<HookService>`，相当于把字段的类型和名字"钉死"。
+    /// 如果字段被删除/改名/换类型，下面这一行会直接编译失败，提示
+    /// 重构者违反了 #509 的设计意图（所有 fire 钩子入口必须共享一个
+    /// HookService 单例）。
+    fn _hook_service_field_is_arc_hook_service(r: &RunTodoExecutionRequest) -> &Arc<HookService> {
+        &r.hook_service
+    }
+
+    /// 真正的单元测试：调用上面的投影函数并断言返回值类型。
+    /// 即便实际未运行过实际 fire，类型系统也保证 hook_service 字段
+    /// 的形状没有被破坏。
+    #[test]
+    fn hook_service_field_shape_is_preserved() {
+        let f: fn(&RunTodoExecutionRequest) -> &Arc<HookService> =
+            _hook_service_field_is_arc_hook_service;
+        // 触达 `_hook_service_field_is_arc_hook_service` 避免 dead_code
+        // 警告把它当未使用函数优化掉。
+        let _: fn(&RunTodoExecutionRequest) -> &Arc<HookService> = f;
+    }
+}

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -212,6 +212,9 @@ pub async fn execute_handler(
         tx: state.tx.clone(),
         task_manager: state.task_manager.clone(),
         config: state.config.clone(),
+        // 复用 AppState 单例：执行末段 fire state-change 钩子时直接用这份
+        // hook_service，避免再 Arc::new 一份 (见 #509)。
+        hook_service: state.hook_service.clone(),
         todo_id: req.todo_id,
         message,
         req_executor: req.executor,
@@ -483,6 +486,7 @@ pub async fn resume_execution_handler(
         tx: state.tx.clone(),
         task_manager: state.task_manager.clone(),
         config: state.config.clone(),
+        hook_service: state.hook_service.clone(),
         todo_id,
         message,
         req_executor: record.executor.clone(),
@@ -640,6 +644,7 @@ pub async fn smart_create_handler(
         tx: state.tx.clone(),
         task_manager: state.task_manager.clone(),
         config: state.config.clone(),
+        hook_service: state.hook_service.clone(),
         todo_id,
         message,
         req_executor: None,

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -626,6 +626,9 @@ async fn version_upgrade_handler(
 pub fn create_app(
     ctx: ServiceContext,
     scheduler: Arc<TodoScheduler>,
+    // 由 main.rs 构造好透传进来的 hook_service 单例。create_app 不再自行 Arc::new，
+    // 避免出现两份 HookService 各自管自己内部状态、彼此观察不到对方 (见 issue #509)。
+    hook_service: Arc<HookService>,
 ) -> Router {
     let db = ctx.db.clone();
     let executor_registry = ctx.executor_registry.clone();
@@ -635,7 +638,7 @@ pub fn create_app(
 
     // Create message debounce service (shared between listener and history fetcher)
     use crate::services::message_debounce::MessageDebounce;
-    let debounce = Arc::new(MessageDebounce::new(ctx.clone()));
+    let debounce = Arc::new(MessageDebounce::new(ctx.clone(), hook_service.clone()));
 
     let feishu_listener = Arc::new(FeishuListener::new(
         ctx.clone(),
@@ -710,16 +713,9 @@ pub fn create_app(
         fetcher.start(bots_for_fetcher);
     });
 
-    // Create HookService with a ServiceContext so it can trigger target todos.
-    // Reuse the live ServiceContext values rather than re-cloning its fields.
-    let hook_ctx = ServiceContext {
-        db: db.clone(),
-        executor_registry: executor_registry.clone(),
-        tx: tx.clone(),
-        task_manager: task_manager.clone(),
-        config: config.clone(),
-    };
-    let hook_service = Arc::new(HookService::new(hook_ctx));
+    // hook_service 由调用方（main.rs）构造后透传进来，这里不再重复创建。
+    // 这样 cron 触发的执行、手动 handler 触发的执行、自动评审触发的执行
+    // 全部复用同一份 HookService 单例 (见 issue #509)。
 
     // Create AutoReviewService and ensure the reviewer template todo exists.
     // create_app 是 sync 函数, 不能直接 .await; 复用当前 tokio runtime 的 Handle

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -299,6 +299,9 @@ async fn trigger_webhook_internal(
             tx: state.tx.clone(),
             task_manager: state.task_manager.clone(),
             config: state.config.clone(),
+            // Webhook 触发的执行同样复用 AppState 里的 hook_service 单例，
+            // 与手动/智能创建/恢复对话等入口走同一份实例 (见 #509)。
+            hook_service: state.hook_service.clone(),
             todo_id: req.todo_id,
             message: todo.prompt.clone(),
             req_executor: todo.executor.clone(),

--- a/backend/src/hooks/service.rs
+++ b/backend/src/hooks/service.rs
@@ -60,6 +60,7 @@ impl HookService {
 
                 let _ = execute_target_todo(
                     &this.ctx,
+                    &this,
                     item,
                     &todo,
                     next_chain,
@@ -106,6 +107,7 @@ impl HookService {
 
             let _ = execute_target_todo(
                 &this.ctx,
+                &this,
                 item,
                 &todo,
                 next_chain,
@@ -259,6 +261,9 @@ fn evaluate_rating_gate(
 
 async fn execute_target_todo(
     ctx: &ServiceContext,
+    // 复用调用方传进来的 hook_service 单例：target todo 执行末段还要 fire 它的钩子，
+    // 必须继续走同一份实例，否则又会出现多份 HookService (issue #509)。
+    hook_service: &Arc<HookService>,
     item: &TodoHookItem,
     source: &Todo,
     chain: Vec<i64>,
@@ -329,6 +334,8 @@ async fn execute_target_todo(
         tx: ctx.tx.clone(),
         task_manager: ctx.task_manager.clone(),
         config: ctx.config.clone(),
+        // target 执行末段 fire 钩子要继续走同一份 hook_service 单例 (issue #509)。
+        hook_service: hook_service.clone(),
         todo_id: target.id,
         message,
         req_executor: target.executor.clone(),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,6 +4,7 @@ use tokio::sync::broadcast;
 use tracing::info;
 
 use std::path::PathBuf;
+use ntd::hooks::HookService;
 use ntd::service_context::ServiceContext;
 use ntd::{adapters, cli, daemon, db, handlers, scheduler::TodoScheduler, task_manager::TaskManager};
 use ntd::NtdSkills;
@@ -460,8 +461,23 @@ async fn run_server(cli_port: Option<u16>) {
     let task_manager = Arc::new(TaskManager::new());
     let config = Arc::new(tokio::sync::RwLock::new(cfg.clone()));
 
+    // 在 TodoScheduler 之前构造一份共享的 HookService 单例：scheduler 的 cron 回调
+    // 以及 create_app 内的 handler 路径都要用同一份 Arc<HookService>，避免 executor
+    // 末段 fire 钩子时再 Arc::new 一份 (见 issue #509)。这里先准备 ServiceContext，
+    // 后续在 sched 创建之前完成 hook_service 构造。
+    let shared_ctx = ServiceContext {
+        db: db.clone(),
+        executor_registry: executor_registry.clone(),
+        tx: tx.clone(),
+        task_manager: task_manager.clone(),
+        config: config.clone(),
+    };
+    let hook_service = Arc::new(HookService::new(shared_ctx));
+
     let scheduler = Arc::new({
-        let sched = TodoScheduler::new().await.unwrap_or_else(|e| {
+        // 把 hook_service.clone() 传给 TodoScheduler，让 cron 触发的执行末段
+        // 也能复用同一份 HookService 单例 (issue #509)。
+        let sched = TodoScheduler::new(hook_service.clone()).await.unwrap_or_else(|e| {
             tracing::error!("Failed to create scheduler: {}. Exiting.", e);
             std::process::exit(1);
         });
@@ -532,6 +548,9 @@ async fn run_server(cli_port: Option<u16>) {
             config: config.clone(),
         },
         scheduler,
+        // 把已经构造好的 hook_service 透传给 create_app，create_app 内部
+        // 不再自己 Arc::new 一份。所有 fire 钩子的入口都走同一份单例。
+        hook_service,
     );
 
     let port = cli_port.unwrap_or(cfg.port);

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeSet, HashMap};
 use std::str::FromStr;
+use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio_cron_scheduler::{Job, JobScheduler};
 use tracing::{error, info, warn};
@@ -7,6 +8,7 @@ use tracing::{error, info, warn};
 use chrono::{TimeZone, Timelike};
 
 use crate::executor_service::{run_todo_execution, RunTodoExecutionRequest};
+use crate::hooks::HookService;
 use crate::service_context::ServiceContext;
 
 /// 把一个去重整数集合格式化成 cron 字段值。
@@ -232,14 +234,22 @@ fn convert_cron_to_utc(cron_expr: &str, timezone: &str) -> Result<String, String
 pub struct TodoScheduler {
     sched: Mutex<JobScheduler>,
     job_map: Mutex<HashMap<i64, uuid::Uuid>>,
+    /// 共享的 HookService 单例（来自 AppState）。
+    ///
+    /// cron 触发的执行在到达 run_todo_execution 末段时也要 fire 状态变更钩子，
+    /// 通过在 TodoScheduler 里直接持有 Arc<HookService> 避免再在 cron 回调里
+    /// Arc::new 一份（见 issue #509）。调用方（main.rs / handlers/mod.rs）
+    /// 在 TodoScheduler::new 时把 AppState.hook_service 传进来。
+    hook_service: Arc<HookService>,
 }
 
 impl TodoScheduler {
-    pub async fn new() -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn new(hook_service: Arc<HookService>) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let sched = JobScheduler::new().await?;
         Ok(Self {
             sched: Mutex::new(sched),
             job_map: Mutex::new(HashMap::new()),
+            hook_service,
         })
     }
 
@@ -329,6 +339,9 @@ impl TodoScheduler {
         let tx_clone = ctx.tx.clone();
         let tm_clone = ctx.task_manager.clone();
         let config_clone = ctx.config.clone();
+        // 闭包要 'static: 把 self.hook_service clone 一份进闭包，cron 触发时直接
+        // 复用这份 Arc，避免再在回调里 Arc::new 新的 HookService。
+        let hs_clone = self.hook_service.clone();
 
         info!("Creating job for todo {} with cron: {} (original: {:?})", todo_id, cron_expr_utc, timezone);
         let job = Job::new_async(&cron_expr_utc, move |_uuid, _l| {
@@ -337,6 +350,7 @@ impl TodoScheduler {
             let tx = tx_clone.clone();
             let tm = tm_clone.clone();
             let cfg = config_clone.clone();
+            let hs = hs_clone.clone();
 
             Box::pin(async move {
                 match db.get_todo(todo_id).await {
@@ -354,6 +368,9 @@ impl TodoScheduler {
                             tx,
                             task_manager: tm,
                             config: cfg,
+                            // cron 触发的执行末段也要 fire state-change 钩子，
+                            // 复用 TodoScheduler 里持有的单例 (issue #509)。
+                            hook_service: hs,
                             todo_id,
                             message,
                             req_executor: executor,

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -6,6 +6,7 @@ use tokio::task::JoinHandle;
 
 use crate::executor_service::RunTodoExecutionRequest;
 use crate::handlers::execution::start_todo_execution;
+use crate::hooks::HookService;
 use crate::service_context::ServiceContext;
 
 #[derive(Debug, Clone)]
@@ -37,13 +38,21 @@ struct DebounceEntry {
 pub struct MessageDebounce {
     entries: Arc<DashMap<(i64, String), DebounceEntry>>,
     ctx: ServiceContext,
+    /// 共享的 HookService 单例（来自 AppState）。
+    ///
+    /// debounce 触发的执行末段也要 fire 状态变更钩子。如果 debounce 在每次
+    /// `new()` 时都重新 `Arc::new(HookService::new(...))` 会出现多份实例，
+    /// 造成 hook 链路彼此看不见的问题（见 issue #509）。直接透传 AppState
+    /// 里的单例即可。
+    hook_service: Arc<HookService>,
 }
 
 impl MessageDebounce {
-    pub fn new(ctx: ServiceContext) -> Self {
+    pub fn new(ctx: ServiceContext, hook_service: Arc<HookService>) -> Self {
         Self {
             entries: Arc::new(DashMap::new()),
             ctx,
+            hook_service,
         }
     }
 
@@ -70,6 +79,9 @@ impl MessageDebounce {
             let tx = self.ctx.tx.clone();
             let task_manager = self.ctx.task_manager.clone();
             let config = self.ctx.config.clone();
+            // 把 self.hook_service clone 一份进闭包，timer 触发时直接复用
+            // AppState 里的单例 (见 issue #509)。
+            let hook_service = self.hook_service.clone();
             let bot_id = key.0;
             let chat_id = key.1.clone();
             let target_type = all_msgs
@@ -141,6 +153,8 @@ impl MessageDebounce {
                         tx,
                         task_manager,
                         config,
+                        // debounce 触发的执行末段也要复用同一份 hook_service 单例 (issue #509)。
+                        hook_service,
                         todo_id: last.todo_id,
                         message: exec_message,
                         req_executor: last.executor.clone(),


### PR DESCRIPTION
fixes #509

修复内容：
- `RunTodoExecutionRequest` 新增 `hook_service: Arc<HookService>` 字段
- `run_auto_review` 接受 `hook_service` 参数并透传
- `TodoScheduler` / `MessageDebounce` 构造时接收 `hook_service` 并在闭包里 clone
- `HookService::execute_target_todo` 接受 `&Arc<HookService>` 参数
- `handlers/mod.rs::create_app` 接受 `hook_service` 参数，main.rs 提前构造并透传

附带：
- executor_service 末段 fire 钩子前追加 tracing::debug! 日志
- 新增 executor_service::run_todo_execution_request_tests 编译期断言 hook_service 字段形状

验证：cargo build 通过；cargo test --lib 343 passed (1 pre-existing codewhale 失败与本改动无关)；hook_tests 26 passed；scheduler_tests 4 passed。