### PR TITLE
fix: address PR #521 post-merge review findings

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -30,6 +30,9 @@ pub const MAX_EXECUTION_TIMEOUT_SECS: u64 = 604800;
 pub const DEFAULT_BROADCAST_CHANNEL_CAPACITY: usize = 10000;
 /// WebSocket broadcast channel 最小容量。低于此值视为配置错误，自动抬升以避免退化到丢消息。
 pub const MIN_BROADCAST_CHANNEL_CAPACITY: usize = 100;
+/// WebSocket broadcast channel 软上限。超过此值时记录 warn 但不强制截断，
+/// 保留运维人员根据实际负载调大的自主权。约 1M events × <1KB ≈ 1GB ceiling。
+pub const SOFT_MAX_BROADCAST_CHANNEL_CAPACITY: usize = 1_000_000;
 
 /// Top-level configuration, persisted to `~/.ntd/config.yaml`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -297,14 +300,20 @@ impl Config {
         }
     }
 
-    /// 把 broadcast_channel_capacity 抬升到最小值 `MIN_BROADCAST_CHANNEL_CAPACITY`。
+    /// 把 broadcast_channel_capacity 抬升到最小值 `MIN_BROADCAST_CHANNEL_CAPACITY`；
+    /// 超过 `SOFT_MAX_BROADCAST_CHANNEL_CAPACITY` 时发出 warn 但不截断。
     ///
     /// **为什么需要**：YAML 直接编辑可绕过 HTTP 校验把 capacity 写成 0/1/50 等无意义值，
     /// 这种配置等同于「关闭事件流」，会让慢消费者立刻丢失 Finished 等关键事件。
     /// 这里强制把任意小于阈值的值抬升到 `MIN_BROADCAST_CHANNEL_CAPACITY`，保持行为可观察。
     ///
-    /// **为什么不在这里设置上限**：broadcast 是 ring buffer，capacity 与每条事件大小相关，
-    /// 但每条 ExecEvent 序列化后通常 < 1KB，100000 条也只占约 100MB，运维需要时可自行调大。
+    /// **为什么是软上限**：broadcast 是 ring buffer，capacity 与每条事件大小相关，
+    /// 每条 ExecEvent 序列化后通常 < 1KB，100000 条也只占约 100MB。
+    /// `SOFT_MAX_BROADCAST_CHANNEL_CAPACITY`(1_000_000) 约对应 1-4GB 内存，
+    /// 超过此值记录 warn 提示，但不强制截断，保留运维人员的自主权。
+    ///
+    /// **调用场景**：YAML/默认值加载路径（真 clamp）和 HTTP `update_config` 路径
+    /// （HTTP 路径已显式 reject < MIN，此处为冗余防御）。
     pub fn clamp_broadcast_channel_capacity(&mut self) {
         if self.broadcast_channel_capacity < MIN_BROADCAST_CHANNEL_CAPACITY {
             tracing::warn!(
@@ -313,6 +322,13 @@ impl Config {
                 MIN_BROADCAST_CHANNEL_CAPACITY
             );
             self.broadcast_channel_capacity = MIN_BROADCAST_CHANNEL_CAPACITY;
+        }
+        if self.broadcast_channel_capacity > SOFT_MAX_BROADCAST_CHANNEL_CAPACITY {
+            tracing::warn!(
+                "broadcast_channel_capacity {} exceeds soft limit {}; this may allocate significant memory",
+                self.broadcast_channel_capacity,
+                SOFT_MAX_BROADCAST_CHANNEL_CAPACITY
+            );
         }
     }
 

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -83,7 +83,7 @@ pub async fn update_config(
 
     cfg.normalize_paths();
     cfg.clamp_execution_timeout_secs();
-    cfg.clamp_broadcast_channel_capacity();
+
 
     let cfg_clone = cfg.clone();
     tokio::task::spawn_blocking(move || cfg_clone.save())

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -207,12 +207,14 @@ pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade)
         //
         // 注意 `rx.recv()` 在 channel 容量耗尽时返回 `RecvError::Lagged(n)`:
         // ring buffer 已被覆盖,n 条旧事件丢失(包括可能错过的 Finished 等
-        // 关键事件)。这里选择 **重新订阅** —— `subscribe()` 拿到的 rx 指向
-        // channel 当前 head,自然跳过被覆盖的积压;前端只会看到日志断流
+        // channel 当前 head,自然跳过被覆盖的积压。虽然 receiver 在 Lagged 后
+        // 本身可以继续收新事件（tokio broadcast 语义），但 resubscribe 能从最新
+        // head 开始，完全跳过积压，避免旧日志涌入前端。
         // 不会断开连接。如果不处理 Lagged,原 `while let Ok(...)` 会立刻
         // 退出 → WS 断开 → 前端误判任务仍在执行。
         //
-        // 对比 `services/feishu_push.rs:91-93` 的同模式实现。
+        // 对比 `services/feishu_push.rs:91-93`（warn-only，不重新订阅）；
+        // 这里额外 resubscribe 以跳过 lag 期间的积压事件。
         loop {
             match rx.recv().await {
                 Ok(event) => {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -456,6 +456,14 @@ async fn run_server(cli_port: Option<u16>) {
 
     // WebSocket 事件 broadcast channel 容量从配置读取，避免硬编码 100 在高频输出场景下
     // 因 ring buffer 覆盖而丢失 Finished 等关键事件。Config::load 已经做过最小值 clamp。
+    // Safety guard: values > 100_000_000 would request >100GB for ring buffer;
+    // treat as fatal rather than silently OOM.
+    if cfg.broadcast_channel_capacity > 100_000_000 {
+        panic!(
+            "broadcast_channel_capacity {} exceeds hard safety limit (100_000_000); refusing to start",
+            cfg.broadcast_channel_capacity
+        );
+    }
     let (tx, _rx) = broadcast::channel(cfg.broadcast_channel_capacity);
     let task_manager = Arc::new(TaskManager::new());
     let config = Arc::new(tokio::sync::RwLock::new(cfg.clone()));

--- a/docs/user-guide/settings/system-settings.md
+++ b/docs/user-guide/settings/system-settings.md
@@ -30,7 +30,7 @@ ntd 的核心运行时配置都在这里。改完点「**保存**」→ `PUT /ap
 |------|------|------|--------|
 | `max_concurrent_todos` | `3` | 同时跑的最大 Todo数 | ❌ |
 | `execution_timeout_secs` | `3600` |单个 Todo最长执行时间 | ❌ |
-| `broadcast_channel_capacity` | `10000` |WebSocket `/events` 频道 ring buffer 大小；高频输出执行器(50 msg/s × 200s)的 burst 上限 | ✅（启动时建 channel）|
+| `broadcast_channel_capacity` | `10000` |WebSocket `/events` 频道 ring buffer 大小；高频输出执行器(50 msg/s × 200s)的 burst 上限 | ❌（启动时建 channel）|
 
 >超出 `execution_timeout_secs` 的执行会被强制失败（走 `execution::force_fail_execution_handler`）。
 


### PR DESCRIPTION
## 变更内容

解决 PR #521 post-merge audit 中发现的遗留问题：

### 修复项

| # | 级别 | 描述 | 修复 |
|---|------|------|------|
| 1 | MEDIUM | docs 表行 `✅` 与代码语义相反 | `system-settings.md:33` ✅ → ❌ |
| 2 | MEDIUM | `clamp_broadcast_channel_capacity` 缺 MAX 上限 | 加 `SOFT_MAX_BROADCAST_CHANNEL_CAPACITY = 1_000_000` + warn |
| 3 | LOW | feishu_push 注释不准确 | 改为 `（warn-only，不重新订阅）` |
| 4 | LOW | HTTP 路径死调用 | 删除 `config.rs:86` 冗余 `clamp_broadcast_channel_capacity()` |
| 5 | LOW | clamp 注释没说 HTTP 路径 | 注明 `YAML/默认值加载路径（真 clamp）和 HTTP update_config 路径（冗余防御）` |
| 6 | NEW | main.rs OOM 风险 | 加 panic guard: `capacity > 100_000_000` |

### 验证

- `cargo check`: ✅
- `cargo test --lib config::`: 27/27 ✅