### PR TITLE
fix: 限制生产环境 CORS 方法/header 白名单，新增配置化 cors_allowed_origins

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -94,6 +94,11 @@ pub struct Config {
     pub broadcast_channel_capacity: usize,
     /// 云端同步配置
     pub cloud_sync: CloudSyncConfig,
+    /// CORS 允许的来源域名白名单（仅生产模式生效）。
+    /// 空列表 = 仅同源请求（不发送 Access-Control-Allow-Origin header）。
+    /// 可配置多个域名，如 ["https://app.example.com", "https://admin.example.com"]。
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cors_allowed_origins: Vec<String>,
 }
 
 /// Paths for each supported executor binary.
@@ -206,6 +211,7 @@ impl Default for Config {
             auto_usage_stats_cron: "0 0 1 * * *".to_string(),
             broadcast_channel_capacity: DEFAULT_BROADCAST_CHANNEL_CAPACITY,
             cloud_sync: CloudSyncConfig::default(),
+            cors_allowed_origins: Vec::new(),
         }
     }
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,7 +1,7 @@
 use axum::{
     Router,
     extract::{FromRequest, FromRequestParts, Path, Request, State, WebSocketUpgrade},
-    http::{self, StatusCode, header},
+    http::{self, Method, StatusCode, header},
     middleware::Next,
     response::{Html, IntoResponse, Response},
     routing::{delete, get, patch, post, put},
@@ -878,10 +878,33 @@ pub fn create_app(
                     .allow_methods(Any)
                     .allow_headers(Any)
             } else {
-                CorsLayer::new()
-                    .allow_methods(Any)
-                    .allow_headers(Any)
-                    // Production: same-origin only (no explicit allow_origin)
+                // Production: restrict to methods and headers actually used by the API,
+                // with configurable origin whitelist (empty = same-origin only).
+                let methods = [
+                    Method::GET,
+                    Method::POST,
+                    Method::PUT,
+                    Method::DELETE,
+                    Method::PATCH,
+                ];
+                let headers = [header::CONTENT_TYPE, header::AUTHORIZATION];
+
+                let origins: Vec<_> = Config::load()
+                    .cors_allowed_origins
+                    .iter()
+                    .filter_map(|o| o.parse::<axum::http::HeaderValue>().ok())
+                    .collect();
+
+                let cors = CorsLayer::new()
+                    .allow_methods(methods)
+                    .allow_headers(headers);
+
+                if origins.is_empty() {
+                    // No explicit origins = same-origin only (no allow_origin sent)
+                    cors
+                } else {
+                    cors.allow_origin(origins)
+                }
             },
         )
         .layer(TraceLayer::new_for_http())


### PR DESCRIPTION
## 修改内容

根据 #507 修复建议：

1. **生产模式限制 HTTP 方法**： 限制为 GET/POST/PUT/DELETE/PATCH（与实际路由一致）
2. **生产模式限制 Header**： 限制为 Content-Type / Authorization
3. **新增配置化 origin 白名单**：Config 结构体增加 ，默认空列表 = 仅同源
4. **开发模式不变**：仍保持 Any 宽松策略

## 测试

- `cargo check` 通过
- 27 个 config 单元测试全部通过（含 round_trip 序列化测试）

Closes #507