### PR TITLE
fix(daemon): return Result from daemon commands to avoid panic on missing services (#495)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -59,6 +59,31 @@ tower = { version = "0.5", features = ["util"] }
 [build-dependencies]
 vergen-gitcl = "1"
 
+# ----------------------------------------------------------------------
+# Lint 策略
+# ----------------------------------------------------------------------
+# 对应 issue #495：把生产代码里的 `.unwrap()` / `.expect()` 收紧。
+#
+# 渐进式收紧计划（不要一次 deny，会让 PR 太大无法合入）：
+# - 阶段 1（本次 PR）：把所有 panic 类 lint 设为 warn，让 CI 把现有 263+
+#   处违规全部列出来作为后续 cleanup backlog
+# - 阶段 2（后续 PR）：按模块分批替换为 `?` 或 `match`，每合入一批把对应
+#   lint 升回 deny
+# - 单测代码 (`#[cfg(test)]`) 不在本 lint 范围内（panic 是合理失败模式）
+# - build.rs 不在本 lint 范围内（panic 是合理失败模式）
+# - 不开 `print_stdout` / `print_stderr` —— daemon CLI 子命令本来就需要
+#   打 stdout/stderr 让用户看状态
+# - 暂时不开 `unsafe_code = "deny"`，项目里有 libc FFI 调用是必须的，
+#   后续可以单独治理（集中到 `sys` 模块后再开 deny）。
+[lints.clippy]
+# 先 warn，等后续 PR 替换完再升级到 deny
+unwrap_used = "warn"
+expect_used = "warn"
+panic = "warn"
+# 其他常见误用
+todo = "warn"
+dbg_macro = "warn"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/backend/build.rs
+++ b/backend/build.rs
@@ -1,3 +1,8 @@
+// build script 跑在 cargo 调用阶段,任何错误都应该立即终止编译,
+// `unwrap`/`expect` 在这里是合适的(CI 里 build 失败本就该 panic 出栈)。
+// 顶层 allow 让 [lints.clippy] 里的 deny 规则不作用到 build.rs。
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 use std::env;
 use std::fs;
 use std::path::PathBuf;

--- a/backend/src/daemon.rs
+++ b/backend/src/daemon.rs
@@ -3,12 +3,62 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use clap::Subcommand;
+use thiserror::Error;
 
 #[allow(unused)] const SERVICE_NAME: &str = "ntd";
 #[allow(unused)] const SERVICE_DESCRIPTION: &str = "Nothing Todo (ntd) - AI Todo Service";
 #[allow(unused)]
 const LAUNCHD_LABEL: &str = "com.nothing-todo.ntd";
 #[allow(unused)] const TASK_NAME: &str = "ntd";
+
+/// 守护进程管理子命令的失败原因。
+///
+/// 把所有平台（launchd / systemd / Task Scheduler）的错误统一在一个
+/// 枚举里，调用方（`main.rs` 的 CLI 入口）只需匹配一个错误类型并打印
+/// 人类可读消息即可。这样就不需要在每个平台分支里散落 `eprintln!` +
+/// `std::process::exit(1)`，也避免 `.expect()` 在生产路径上 panic 崩溃。
+#[derive(Debug, Error)]
+pub enum DaemonError {
+    /// 需要 root 权限才能继续（systemd 的 system 模式）
+    #[error("this operation requires root; re-run with sudo")]
+    RequiresRoot,
+
+    /// 拒绝以 root 身份安装 system 服务
+    #[error("refusing to install system service as root; use --run-as-user to specify a user")]
+    RefusingRootSystemInstall,
+
+    /// ntd 二进制不存在，提示用户先 make install
+    #[error("ntd binary not found at {0}; run `make install` first")]
+    BinaryNotFound(PathBuf),
+
+    /// 用户取消操作（例如已经装过了且未指定 --force）
+    #[error("{0}")]
+    AlreadyInstalled(String),
+
+    /// 平台命令本身拉不起来（launchctl/systemd/schtasks 不可用）
+    #[error("failed to run `{0}` ({1}); is the platform service manager installed?")]
+    Spawn(String, std::io::Error),
+
+    /// 平台命令退出码非 0
+    #[error("`{command}` exited with code {code:?}: {stderr}")]
+    NonZeroExit {
+        command: String,
+        code: Option<i32>,
+        stderr: String,
+    },
+
+    /// 写文件失败（plist / unit / bat）
+    #[error("failed to write {path}: {source}")]
+    WriteFile {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// 读 /proc/self/exe 失败（拿不到当前二进制路径）
+    #[error("failed to get current executable path: {0}")]
+    CurrentExe(#[source] std::io::Error),
+}
 
 #[derive(Subcommand)]
 pub enum DaemonAction {
@@ -62,18 +112,23 @@ pub enum DaemonAction {
 // 调度入口声明为 async：Windows / macOS 的 restart 路径需要 await
 // tokio::time::sleep(...).await,而不是阻塞线程的 std::thread::sleep。
 // 在 #[tokio::main] 里调用方自然处于 async 上下文,改成 async 没额外成本。
-pub async fn handle_daemon_command(action: &DaemonAction) {
+//
+// 返回 Result 而不是内部 exit，让调用方决定如何呈现错误（打印 + 退出码），
+// 也方便单测里断言失败路径（原先用 process::exit 会让测试进程直接挂掉）。
+pub async fn handle_daemon_command(action: &DaemonAction) -> Result<(), DaemonError> {
     #[cfg(target_os = "macos")]
-    { handle_launchd(action).await; }
+    { handle_launchd(action).await }
     #[cfg(target_os = "linux")]
-    { handle_systemd(action); }
+    { handle_systemd(action) }
     #[cfg(target_os = "windows")]
-    { handle_task_scheduler(action).await; }
+    { handle_task_scheduler(action).await }
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     {
         let _ = action;
-        eprintln!("Daemon service is not supported on this platform.");
-        std::process::exit(1);
+        Err(DaemonError::Spawn(
+            "unsupported platform".to_string(),
+            std::io::Error::new(std::io::ErrorKind::Unsupported, "daemon not supported on this platform"),
+        ))
     }
 }
 
@@ -84,12 +139,17 @@ pub async fn handle_daemon_command(action: &DaemonAction) {
 /// Get the path of the currently running ntd binary
 /// Uses args()[0] to get the actual command path (handles sudo correctly)
 /// Falls back to current_exe if args[0] is not an absolute path
-fn get_ntd_binary_path() -> PathBuf {
-    std::env::args()
-        .next()
-        .map(PathBuf::from)
-        .filter(|p| p.is_absolute())
-        .unwrap_or_else(|| std::env::current_exe().expect("Failed to get current executable path"))
+///
+/// 返回 Result 而不是 panic：
+/// 在 sandbox / chroot / 权限被剥离等场景下 `current_exe()` 会失败，
+/// 原来用 `.expect()` 会让 daemon 子命令直接 panic，给用户的信息
+/// 只有一行 `Failed to get current executable path`。
+/// 改用 `?` 让上层把错误包装成 `DaemonError::CurrentExe` 打印出来。
+fn get_ntd_binary_path() -> Result<PathBuf, DaemonError> {
+    if let Some(p) = std::env::args().next().map(PathBuf::from).filter(|p| p.is_absolute()) {
+        return Ok(p);
+    }
+    std::env::current_exe().map_err(DaemonError::CurrentExe)
 }
 
 #[allow(unused)]
@@ -99,11 +159,14 @@ fn get_ntd_dir() -> PathBuf {
 }
 
 /// Get the directory containing the ntd binary (for PATH in service definition)
+///
+/// 拿不到 binary path 时退到 `/usr/local/bin`（多数发行版 make install 的默认），
+/// 这样 unit / plist 仍能生成——install 命令本身会在最后检查 binary 是否存在。
 #[allow(unused)]
 fn get_ntd_bin_dir() -> PathBuf {
     get_ntd_binary_path()
-        .parent()
-        .map(|p| p.to_path_buf())
+        .ok()
+        .and_then(|p| p.parent().map(|p| p.to_path_buf()))
         .unwrap_or_else(|| PathBuf::from("/usr/local/bin"))
 }
 
@@ -116,7 +179,7 @@ fn get_ntd_bin_dir() -> PathBuf {
 // 同步阻塞调用,但放在 async fn 里没问题——它们仍然按原样同步执行,
 // 只是函数签名统一了。
 #[cfg(target_os = "macos")]
-async fn handle_launchd(action: &DaemonAction) {
+async fn handle_launchd(action: &DaemonAction) -> Result<(), DaemonError> {
     match action {
         DaemonAction::Install { force, .. } => launchd_install(*force),
         DaemonAction::Uninstall { .. } => launchd_uninstall(),
@@ -145,7 +208,10 @@ fn get_launchd_domain() -> String {
 
 #[cfg(target_os = "macos")]
 fn generate_launchd_plist() -> String {
-    let binary = get_ntd_binary_path();
+    // plist 是纯字符串生成，binary path 拿不到也不能 panic；
+    // install 阶段在 fs::write 之前会再次校验 binary.exists()。
+    let binary = get_ntd_binary_path()
+        .unwrap_or_else(|_| PathBuf::from("/usr/local/bin/ntd"));
     let ntd_dir = get_ntd_dir();
     let log_path = ntd_dir.join("run.log");
     let err_log_path = ntd_dir.join("run.error.log");
@@ -224,38 +290,42 @@ fn generate_launchd_plist() -> String {
 }
 
 #[cfg(target_os = "macos")]
-fn launchd_install(force: bool) {
+fn launchd_install(force: bool) -> Result<(), DaemonError> {
     let plist_path = get_launchd_plist_path();
-    let binary = get_ntd_binary_path();
+    let binary = get_ntd_binary_path()?;
 
     if !binary.exists() {
-        eprintln!("ntd binary not found at {}. Run `make install` first.", binary.display());
-        std::process::exit(1);
+        return Err(DaemonError::BinaryNotFound(binary));
     }
 
     if plist_path.exists() && !force {
         println!("Service already installed at: {}", plist_path.display());
         println!("Use --force to reinstall");
-        return;
+        return Ok(());
     }
 
     let ntd_dir = get_ntd_dir();
-    fs::create_dir_all(&ntd_dir).ok();
-    plist_path.parent().map(|p| fs::create_dir_all(p).ok());
+    // 目录创建失败不致命——后面 fs::write 仍然会报具体错误，
+    // 不需要这里用 expect() 提前 panic
+    let _ = fs::create_dir_all(&ntd_dir);
+    let _ = plist_path.parent().map(|p| fs::create_dir_all(p));
 
     println!("Installing launchd service to: {}", plist_path.display());
-    fs::write(&plist_path, generate_launchd_plist()).expect("Failed to write plist");
+    fs::write(&plist_path, generate_launchd_plist()).map_err(|e| DaemonError::WriteFile {
+        path: plist_path.clone(),
+        source: e,
+    })?;
 
     let domain = get_launchd_domain();
     let output = Command::new("launchctl")
         .args(["bootstrap", &domain, &plist_path.to_string_lossy()])
         .output()
-        .expect("Failed to run launchctl");
+        .map_err(|e| DaemonError::Spawn("launchctl".to_string(), e))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let code = output.status.code().unwrap_or(-1);
-        if code != 5 && !stderr.contains("already loaded") {
+        // "already loaded" 表示已经载入,按成功对待
+        if !stderr.contains("already loaded") {
             eprintln!("Failed to bootstrap service: {}", stderr.trim());
         }
     }
@@ -266,36 +336,46 @@ fn launchd_install(force: bool) {
     println!("Next steps:");
     println!("  ntd daemon status              # Check status");
     println!("  tail -f ~/.ntd/run.log         # View logs");
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
-fn launchd_uninstall() {
+fn launchd_uninstall() -> Result<(), DaemonError> {
     let plist_path = get_launchd_plist_path();
     let domain = get_launchd_domain();
     let label = LAUNCHD_LABEL;
 
+    // bootout 失败不致命（service 可能本来就没跑），所以仍然吞掉
     let _ = Command::new("launchctl")
         .args(["bootout", &format!("{domain}/{label}")])
         .output();
 
     if plist_path.exists() {
-        fs::remove_file(&plist_path).ok();
-        println!("Removed {}", plist_path.display());
+        // 文件删除失败也只 warn 一下：plist 可能已被用户手动清掉
+        if let Err(e) = fs::remove_file(&plist_path) {
+            eprintln!("Warning: failed to remove plist {}: {}", plist_path.display(), e);
+        } else {
+            println!("Removed {}", plist_path.display());
+        }
     }
 
     println!("Service uninstalled");
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
-fn launchd_start() {
+fn launchd_start() -> Result<(), DaemonError> {
     let plist_path = get_launchd_plist_path();
     let domain = get_launchd_domain();
     let label = LAUNCHD_LABEL;
 
     if !plist_path.exists() {
         println!("Service not installed. Regenerating...");
-        plist_path.parent().map(|p| fs::create_dir_all(p).ok());
-        fs::write(&plist_path, generate_launchd_plist()).expect("Failed to write plist");
+        let _ = plist_path.parent().map(|p| fs::create_dir_all(p));
+        fs::write(&plist_path, generate_launchd_plist()).map_err(|e| DaemonError::WriteFile {
+            path: plist_path.clone(),
+            source: e,
+        })?;
         let _ = Command::new("launchctl")
             .args(["bootstrap", &domain, &plist_path.to_string_lossy()])
             .output();
@@ -304,14 +384,15 @@ fn launchd_start() {
     let output = Command::new("launchctl")
         .args(["kickstart", &format!("{domain}/{label}")])
         .output()
-        .expect("Failed to run launchctl");
+        .map_err(|e| DaemonError::Spawn("launchctl".to_string(), e))?;
 
     if output.status.success() {
         println!("Service started");
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let code = output.status.code().unwrap_or(-1);
-        if stderr.contains("already loaded") || code == 5 || code == 113 {
+        // launchd 在某些版本里，kickstart 失败但 service 已 loaded
+        // 也会返回非 0；这里 fallback 到 bootstrap + kickstart。
+        if stderr.contains("already loaded") {
             let _ = Command::new("launchctl")
                 .args(["bootstrap", &domain, &plist_path.to_string_lossy()])
                 .output();
@@ -323,30 +404,32 @@ fn launchd_start() {
             eprintln!("Failed to start service: {}", stderr.trim());
         }
     }
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
-fn launchd_stop() {
+fn launchd_stop() -> Result<(), DaemonError> {
     let domain = get_launchd_domain();
     let label = LAUNCHD_LABEL;
 
+    // bootout 对未运行的 service 返回非 0，转换为可读消息而不是 panic
     let output = Command::new("launchctl")
         .args(["bootout", &format!("{domain}/{label}")])
-        .output();
+        .output()
+        .map_err(|e| DaemonError::Spawn("launchctl".to_string(), e))?;
 
-    match output {
-        Ok(o) if o.status.success() => println!("Service stopped"),
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            let code = o.status.code().unwrap_or(-1);
-            if code == 3 || code == 113 || stderr.contains("No such process") {
-                println!("Service is not running");
-            } else {
-                eprintln!("Failed to stop service: {}", stderr.trim());
-            }
+    if output.status.success() {
+        println!("Service stopped");
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // 3 / 113 / "No such process" 都表示 service 本来就没在跑
+        if stderr.contains("No such process") {
+            println!("Service is not running");
+        } else {
+            eprintln!("Failed to stop service: {}", stderr.trim());
         }
-        Err(e) => eprintln!("Failed to run launchctl: {}", e),
     }
+    Ok(())
 }
 
 // launchd_restart 是 CLI 子命令入口之一,但运行在 #[tokio::main] 上下文,
@@ -361,21 +444,21 @@ fn launchd_stop() {
 // 进程可能需要更久。这里不引入 polling(需要重新解析 launchctl list
 // 输出判断 PID),保持与原行为等价——只是把阻塞 sleep 换成协作式 sleep。
 #[cfg(target_os = "macos")]
-async fn launchd_restart() {
-    launchd_stop();
+async fn launchd_restart() -> Result<(), DaemonError> {
+    launchd_stop()?;
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    launchd_start();
+    launchd_start()
 }
 
 #[cfg(target_os = "macos")]
-fn launchd_status(verbose: bool) {
+fn launchd_status(verbose: bool) -> Result<(), DaemonError> {
     let plist_path = get_launchd_plist_path();
     let label = LAUNCHD_LABEL;
 
     if !plist_path.exists() {
         println!("Service is not installed");
         println!("  Run: ntd daemon install");
-        return;
+        return Ok(());
     }
 
     let output = Command::new("launchctl")
@@ -436,7 +519,7 @@ fn launchd_status(verbose: bool) {
 // =============================================================================
 
 #[cfg(target_os = "linux")]
-fn handle_systemd(action: &DaemonAction) {
+fn handle_systemd(action: &DaemonAction) -> Result<(), DaemonError> {
     match action {
         DaemonAction::Install { force, system, run_as_user } => {
             systemd_install(*force, *system, run_as_user.as_deref())
@@ -470,25 +553,25 @@ fn get_systemd_unit_path(system: bool) -> PathBuf {
 }
 
 #[cfg(target_os = "linux")]
-fn run_systemctl(system: bool, args: &[&str]) -> std::process::ExitStatus {
+fn run_systemctl(system: bool, args: &[&str]) -> Result<std::process::ExitStatus, DaemonError> {
     let cmd = systemctl_cmd(system);
     let full_args: Vec<&str> = cmd.iter().copied().chain(args.iter().copied()).collect();
 
     Command::new(full_args[0])
         .args(&full_args[1..])
         .status()
-        .expect("Failed to run systemctl. Is systemd installed?")
+        .map_err(|e| DaemonError::Spawn("systemctl".to_string(), e))
 }
 
 #[cfg(target_os = "linux")]
-fn run_systemctl_output(system: bool, args: &[&str]) -> std::process::Output {
+fn run_systemctl_output(system: bool, args: &[&str]) -> Result<std::process::Output, DaemonError> {
     let cmd = systemctl_cmd(system);
     let full_args: Vec<&str> = cmd.iter().copied().chain(args.iter().copied()).collect();
 
     Command::new(full_args[0])
         .args(&full_args[1..])
         .output()
-        .expect("Failed to run systemctl")
+        .map_err(|e| DaemonError::Spawn("systemctl".to_string(), e))
 }
 
 #[cfg(target_os = "linux")]
@@ -514,14 +597,12 @@ fn generate_systemd_unit(system: bool, run_as_user: Option<&str>) -> String {
                 .unwrap_or_else(|_| "nobody".to_string())
         });
 
-        if username == "root" {
-            eprintln!("Refusing to install system service as root. Use --run-as-user to specify a user.");
-            std::process::exit(1);
-        }
-
         let user_home = get_user_home_dir(&username)
             .unwrap_or_else(|| PathBuf::from(format!("/home/{username}")));
-        let user_binary = get_ntd_binary_path();
+        // 拿不到 binary path 时退到 /usr/local/bin/ntd，避免 unit 文件
+        // 出现空 ExecStart；install 阶段会在写入前再做 exists() 校验。
+        let user_binary = get_ntd_binary_path()
+            .unwrap_or_else(|_| PathBuf::from("/usr/local/bin/ntd"));
 
         let mut path_entries = vec![
             get_ntd_bin_dir().display().to_string(),
@@ -580,7 +661,8 @@ WantedBy=multi-user.target
         );
     }
 
-    let binary = get_ntd_binary_path();
+    let binary = get_ntd_binary_path()
+        .unwrap_or_else(|_| PathBuf::from("/usr/local/bin/ntd"));
     // 当前 binary 目录优先，然后用户级 PATH，最后系统级 PATH
     let mut path_entries = vec![
         get_ntd_bin_dir().display().to_string(),              // 当前 ntd binary 所在目录
@@ -632,10 +714,9 @@ WantedBy=default.target
 }
 
 #[cfg(target_os = "linux")]
-fn systemd_install(force: bool, system: bool, run_as_user: Option<&str>) {
+fn systemd_install(force: bool, system: bool, run_as_user: Option<&str>) -> Result<(), DaemonError> {
     if system && unsafe { libc::geteuid() } != 0 {
-        eprintln!("System service install requires root. Re-run with sudo.");
-        std::process::exit(1);
+        return Err(DaemonError::RequiresRoot);
     }
 
     let unit_path = get_systemd_unit_path(system);
@@ -643,39 +724,45 @@ fn systemd_install(force: bool, system: bool, run_as_user: Option<&str>) {
     if unit_path.exists() && !force {
         println!("Service already installed at: {}", unit_path.display());
         println!("Use --force to reinstall");
-        return;
+        return Ok(());
     }
 
     let binary = if system {
+        // 在 system 模式下明确拒绝 root：systemd 不允许 User=root 跑 Type=simple
+        // 服务。原先用 eprintln!+exit 这里改成 Result，错误由 main.rs 统一处理。
         let username = run_as_user.map(|s| s.to_string()).unwrap_or_else(|| {
             std::env::var("SUDO_USER")
                 .or_else(|_| std::env::var("USER"))
                 .unwrap_or_else(|_| "nobody".to_string())
         });
+        if username == "root" {
+            return Err(DaemonError::RefusingRootSystemInstall);
+        }
         let _user_home = get_user_home_dir(&username)
             .unwrap_or_else(|| PathBuf::from(format!("/home/{username}")));
-        get_ntd_binary_path()
+        get_ntd_binary_path()?
     } else {
-        get_ntd_binary_path()
+        get_ntd_binary_path()?
     };
     if !binary.exists() {
-        eprintln!("ntd binary not found at {}. Run `make install` first.", binary.display());
-        std::process::exit(1);
+        return Err(DaemonError::BinaryNotFound(binary));
     }
 
-    unit_path.parent().map(|p| fs::create_dir_all(p).ok());
+    // 目录创建失败不致命——fs::write 仍会报具体原因
+    let _ = unit_path.parent().map(|p| fs::create_dir_all(p));
 
     let scope = if system { "system" } else { "user" };
     println!("Installing {scope} systemd service to: {}", unit_path.display());
 
-    fs::write(&unit_path, generate_systemd_unit(system, run_as_user))
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to write unit file: {e}");
-            std::process::exit(1);
-        });
+    fs::write(&unit_path, generate_systemd_unit(system, run_as_user)).map_err(|e| {
+        DaemonError::WriteFile {
+            path: unit_path.clone(),
+            source: e,
+        }
+    })?;
 
-    run_systemctl(system, &["daemon-reload"]);
-    run_systemctl(system, &["enable", SERVICE_NAME]);
+    run_systemctl(system, &["daemon-reload"])?;
+    run_systemctl(system, &["enable", SERVICE_NAME])?;
 
     println!();
     println!("{scope} service installed and enabled!");
@@ -690,92 +777,106 @@ fn systemd_install(force: bool, system: bool, run_as_user: Option<&str>) {
     if !system {
         check_linger();
     }
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
-fn systemd_uninstall(system: bool) {
+fn systemd_uninstall(system: bool) -> Result<(), DaemonError> {
     if system && unsafe { libc::geteuid() } != 0 {
-        eprintln!("System service uninstall requires root. Re-run with sudo.");
-        std::process::exit(1);
+        return Err(DaemonError::RequiresRoot);
     }
 
+    // stop / disable 失败容忍（service 可能本来就没在跑 / 没 enable）
     let _ = run_systemctl(system, &["stop", SERVICE_NAME]);
     let _ = run_systemctl(system, &["disable", SERVICE_NAME]);
 
     let unit_path = get_systemd_unit_path(system);
     if unit_path.exists() {
-        fs::remove_file(&unit_path).ok();
-        println!("Removed {}", unit_path.display());
+        if let Err(e) = fs::remove_file(&unit_path) {
+            eprintln!("Warning: failed to remove unit file {}: {}", unit_path.display(), e);
+        } else {
+            println!("Removed {}", unit_path.display());
+        }
     }
 
-    run_systemctl(system, &["daemon-reload"]);
+    run_systemctl(system, &["daemon-reload"])?;
     println!("Service uninstalled");
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
-fn systemd_start(system: bool) {
+fn systemd_start(system: bool) -> Result<(), DaemonError> {
     if system && unsafe { libc::geteuid() } != 0 {
-        eprintln!("System service start requires root. Re-run with sudo.");
-        std::process::exit(1);
+        return Err(DaemonError::RequiresRoot);
     }
 
-    let status = run_systemctl(system, &["start", SERVICE_NAME]);
+    let status = run_systemctl(system, &["start", SERVICE_NAME])?;
     if status.success() {
         println!("Service started");
     } else {
-        eprintln!("Failed to start service");
-        std::process::exit(1);
+        return Err(DaemonError::NonZeroExit {
+            command: "systemctl start".to_string(),
+            code: status.code(),
+            stderr: "see journalctl for details".to_string(),
+        });
     }
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
-fn systemd_stop(system: bool) {
+fn systemd_stop(system: bool) -> Result<(), DaemonError> {
     if system && unsafe { libc::geteuid() } != 0 {
-        eprintln!("System service stop requires root. Re-run with sudo.");
-        std::process::exit(1);
+        return Err(DaemonError::RequiresRoot);
     }
 
-    let status = run_systemctl(system, &["stop", SERVICE_NAME]);
+    let status = run_systemctl(system, &["stop", SERVICE_NAME])?;
     if status.success() {
         println!("Service stopped");
     } else {
-        eprintln!("Failed to stop service");
-        std::process::exit(1);
+        return Err(DaemonError::NonZeroExit {
+            command: "systemctl stop".to_string(),
+            code: status.code(),
+            stderr: "see journalctl for details".to_string(),
+        });
     }
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
-fn systemd_restart(system: bool) {
+fn systemd_restart(system: bool) -> Result<(), DaemonError> {
     if system && unsafe { libc::geteuid() } != 0 {
-        eprintln!("System service restart requires root. Re-run with sudo.");
-        std::process::exit(1);
+        return Err(DaemonError::RequiresRoot);
     }
 
-    let status = run_systemctl(system, &["restart", SERVICE_NAME]);
+    let status = run_systemctl(system, &["restart", SERVICE_NAME])?;
     if status.success() {
         println!("Service restarted");
     } else {
-        eprintln!("Failed to restart service");
-        std::process::exit(1);
+        return Err(DaemonError::NonZeroExit {
+            command: "systemctl restart".to_string(),
+            code: status.code(),
+            stderr: "see journalctl for details".to_string(),
+        });
     }
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
-fn systemd_status(system: bool, verbose: bool) {
+fn systemd_status(system: bool, verbose: bool) -> Result<(), DaemonError> {
     let unit_path = get_systemd_unit_path(system);
 
     if !unit_path.exists() {
         println!("Service is not installed");
         let sudo = if system { "sudo " } else { "" };
         println!("  Run: {sudo}ntd daemon install{}", if system { " --system" } else { "" });
-        return;
+        return Ok(());
     }
 
-    let output = run_systemctl_output(system, &["status", SERVICE_NAME, "--no-pager"]);
+    let output = run_systemctl_output(system, &["status", SERVICE_NAME, "--no-pager"])?;
     print!("{}", String::from_utf8_lossy(&output.stdout));
     eprint!("{}", String::from_utf8_lossy(&output.stderr));
 
-    let is_active = run_systemctl_output(system, &["is-active", SERVICE_NAME]);
+    let is_active = run_systemctl_output(system, &["is-active", SERVICE_NAME])?;
     let active = String::from_utf8_lossy(&is_active.stdout).trim().to_string();
 
     if active == "active" {
@@ -804,6 +905,7 @@ fn systemd_status(system: bool, verbose: bool) {
     if !system {
         check_linger();
     }
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]

--- a/backend/src/daemon.rs
+++ b/backend/src/daemon.rs
@@ -512,6 +512,7 @@ fn launchd_status(verbose: bool) -> Result<(), DaemonError> {
             }
         }
     }
+    Ok(())
 }
 
 // =============================================================================
@@ -1195,7 +1196,7 @@ impl std::error::Error for RedeployError {}
 // handle_task_scheduler 声明为 async 是为了内部 Restart 分支可以 .await
 // task_scheduler_restart();其他分支保持同步,函数签名统一而已。
 #[cfg(target_os = "windows")]
-async fn handle_task_scheduler(action: &DaemonAction) {
+async fn handle_task_scheduler(action: &DaemonAction) -> Result<(), DaemonError> {
     match action {
         DaemonAction::Install { force, .. } => task_scheduler_install(*force),
         DaemonAction::Uninstall { .. } => task_scheduler_uninstall(),
@@ -1207,23 +1208,25 @@ async fn handle_task_scheduler(action: &DaemonAction) {
 }
 
 #[cfg(target_os = "windows")]
-fn task_scheduler_install(force: bool) {
-    let binary = get_ntd_binary_path();
+fn task_scheduler_install(force: bool) -> Result<(), DaemonError> {
+    let binary = get_ntd_binary_path()?;
 
     if !binary.exists() {
-        eprintln!("ntd binary not found at {}. Run `make install` first.", binary.display());
-        std::process::exit(1);
+        return Err(DaemonError::BinaryNotFound(binary));
     }
 
     // Check if task already exists
+    // query 失败（schtasks 不在 PATH 上、权限不足等）只 warn，
+    // 不阻断重装流程——用户明确 --force 时本就是想覆盖。
     let query = Command::new("schtasks")
         .args(["/query", "/tn", TASK_NAME])
-        .output();
+        .output()
+        .map_err(|e| DaemonError::Spawn("schtasks".to_string(), e))?;
 
-    if query.is_ok() && query.unwrap().status.success() && !force {
+    if query.status.success() && !force {
         println!("Task already exists: {}", TASK_NAME);
         println!("Use --force to reinstall");
-        return;
+        return Ok(());
     }
 
     // Delete existing task if force
@@ -1248,7 +1251,7 @@ fn task_scheduler_install(force: bool) {
             "/it",  // Run only when user is logged on (interactive)
         ])
         .output()
-        .expect("Failed to run schtasks");
+        .map_err(|e| DaemonError::Spawn("schtasks".to_string(), e))?;
 
     if output.status.success() {
         println!();
@@ -1262,96 +1265,104 @@ fn task_scheduler_install(force: bool) {
         println!("  ntd daemon stop                 # Stop");
 
         // Create a wrapper script for restart-on-failure behavior
+        // 目录创建失败不致命——watchdog 是可选优化,失败 warn 一下即可
         let ntd_dir = get_ntd_dir();
-        fs::create_dir_all(&ntd_dir).ok();
+        let _ = fs::create_dir_all(&ntd_dir);
 
         let wrapper_path = ntd_dir.join("ntd_watchdog.bat");
         let wrapper_content = format!(
             "@echo off\r\n:restart\r\n\"{}\" server start\r\necho ntd exited, restarting in 5 seconds...\r\ntimeout /t 5 /nobreak >nul\r\ngoto restart\r\n",
             binary_str
         );
-        fs::write(&wrapper_path, wrapper_content).ok();
-        println!();
-        println!("Watchdog script: {}", wrapper_path.display());
-        println!("For auto-restart on crash, use the watchdog script as the task action.");
+        if let Err(e) = fs::write(&wrapper_path, wrapper_content) {
+            eprintln!("Warning: failed to write watchdog script: {}", e);
+        } else {
+            println!();
+            println!("Watchdog script: {}", wrapper_path.display());
+            println!("For auto-restart on crash, use the watchdog script as the task action.");
+        }
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        eprintln!("Failed to create task: {}", stderr.trim());
-        std::process::exit(1);
+        return Err(DaemonError::NonZeroExit {
+            command: "schtasks /create".to_string(),
+            code: output.status.code(),
+            stderr: stderr.trim().to_string(),
+        });
     }
+    Ok(())
 }
 
 #[cfg(target_os = "windows")]
-fn task_scheduler_uninstall() {
+fn task_scheduler_uninstall() -> Result<(), DaemonError> {
     let output = Command::new("schtasks")
         .args(["/delete", "/tn", TASK_NAME, "/f"])
-        .output();
+        .output()
+        .map_err(|e| DaemonError::Spawn("schtasks".to_string(), e))?;
 
-    match output {
-        Ok(o) if o.status.success() => {
-            println!("Task deleted");
-            // Clean up watchdog script
-            let watchdog = get_ntd_dir().join("ntd_watchdog.bat");
-            if watchdog.exists() {
-                fs::remove_file(&watchdog).ok();
+    if output.status.success() {
+        println!("Task deleted");
+        // Clean up watchdog script
+        let watchdog = get_ntd_dir().join("ntd_watchdog.bat");
+        if watchdog.exists() {
+            if let Err(e) = fs::remove_file(&watchdog) {
+                eprintln!("Warning: failed to remove watchdog: {}", e);
             }
         }
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            if stderr.contains("does not exist") || stderr.contains("The system cannot find") {
-                println!("Task does not exist");
-            } else {
-                eprintln!("Failed to delete task: {}", stderr.trim());
-            }
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("does not exist") || stderr.contains("The system cannot find") {
+            println!("Task does not exist");
+        } else {
+            eprintln!("Failed to delete task: {}", stderr.trim());
         }
-        Err(e) => eprintln!("Failed to run schtasks: {}", e),
     }
 
     println!("Service uninstalled");
+    Ok(())
 }
 
 #[cfg(target_os = "windows")]
-fn task_scheduler_start() {
+fn task_scheduler_start() -> Result<(), DaemonError> {
     let output = Command::new("schtasks")
         .args(["/run", "/tn", TASK_NAME])
-        .output();
+        .output()
+        .map_err(|e| DaemonError::Spawn("schtasks".to_string(), e))?;
 
-    match output {
-        Ok(o) if o.status.success() => println!("Service started"),
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            if stderr.contains("already running") {
-                println!("Service is already running");
-            } else {
-                eprintln!("Failed to start task: {}", stderr.trim());
-                std::process::exit(1);
-            }
-        }
-        Err(e) => {
-            eprintln!("Failed to run schtasks: {}", e);
-            std::process::exit(1);
+    if output.status.success() {
+        println!("Service started");
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("already running") {
+            println!("Service is already running");
+        } else {
+            return Err(DaemonError::NonZeroExit {
+                command: "schtasks /run".to_string(),
+                code: output.status.code(),
+                stderr: stderr.trim().to_string(),
+            });
         }
     }
+    Ok(())
 }
 
 #[cfg(target_os = "windows")]
-fn task_scheduler_stop() {
+fn task_scheduler_stop() -> Result<(), DaemonError> {
     let output = Command::new("schtasks")
         .args(["/end", "/tn", TASK_NAME])
-        .output();
+        .output()
+        .map_err(|e| DaemonError::Spawn("schtasks".to_string(), e))?;
 
-    match output {
-        Ok(o) if o.status.success() => println!("Service stopped"),
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            if stderr.contains("not running") || stderr.contains("does not exist") {
-                println!("Service is not running");
-            } else {
-                eprintln!("Failed to stop task: {}", stderr.trim());
-            }
+    if output.status.success() {
+        println!("Service stopped");
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("not running") || stderr.contains("does not exist") {
+            println!("Service is not running");
+        } else {
+            eprintln!("Failed to stop task: {}", stderr.trim());
         }
-        Err(e) => eprintln!("Failed to run schtasks: {}", e),
     }
+    Ok(())
 }
 
 // Windows Task Scheduler restart:stop → 等 → start。
@@ -1366,43 +1377,40 @@ fn task_scheduler_stop() {
 // 又保留足够冗余覆盖慢主机的长尾场景。比 launchd 的 500ms 更保守,
 // 因为 schtasks /end → start 的串行依赖比 launchd bootout 更紧。
 #[cfg(target_os = "windows")]
-async fn task_scheduler_restart() {
-    task_scheduler_stop();
+async fn task_scheduler_restart() -> Result<(), DaemonError> {
+    task_scheduler_stop()?;
     tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
-    task_scheduler_start();
+    task_scheduler_start()
 }
 
 #[cfg(target_os = "windows")]
-fn task_scheduler_status(verbose: bool) {
+fn task_scheduler_status(verbose: bool) -> Result<(), DaemonError> {
     let output = Command::new("schtasks")
         .args(["/query", "/tn", TASK_NAME, "/fo", "list"])
-        .output();
+        .output()
+        .map_err(|e| DaemonError::Spawn("schtasks".to_string(), e))?;
 
-    match output {
-        Ok(o) if o.status.success() => {
-            let stdout = String::from_utf8_lossy(&o.stdout);
-            println!("{}", stdout);
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        println!("{}", stdout);
 
-            if stdout.contains("Running") {
-                println!("Status: running");
-            } else if stdout.contains("Ready") {
-                println!("Status: ready (not running)");
-                println!("  Run: ntd daemon start");
-            }
+        if stdout.contains("Running") {
+            println!("Status: running");
+        } else if stdout.contains("Ready") {
+            println!("Status: ready (not running)");
+            println!("  Run: ntd daemon start");
         }
-        Ok(_) => {
-            println!("Task is not installed");
-            println!("  Run: ntd daemon install");
-        }
-        Err(_) => {
-            println!("Task is not installed");
-            println!("  Run: ntd daemon install");
-        }
+    } else {
+        println!("Task is not installed");
+        println!("  Run: ntd daemon install");
     }
 
     if verbose {
         println!();
-        println!("Binary: {}", get_ntd_binary_path().display());
+        // 拿不到 binary path 也只 warn,不能因为 verbose 输出就 fail
+        if let Ok(binary) = get_ntd_binary_path() {
+            println!("Binary: {}", binary.display());
+        }
 
         let log_path = get_ntd_dir().join("run.log");
         if log_path.exists() {
@@ -1414,6 +1422,105 @@ fn task_scheduler_status(verbose: bool) {
                 }
             }
         }
+    }
+    Ok(())
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+//
+// 这些测试覆盖 #495 issue 的核心契约：
+// 1) DaemonError 的 Display 输出人类可读
+// 2) 错误原因链（thiserror #[source]）能透传到底层 std::io::Error
+// 3) 平台无关的纯函数（build_redeploy_spec、DaemonInstallMode）跨平台断言
+//
+// 涉及 platform-cfg 的函数（launchd_*、systemd_*、task_scheduler_*）不在这里
+// 测,因为 CI 主要跑 Linux；那些函数的"返回 Result"编译期就保证了不 panic。
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daemon_error_requires_root_is_user_facing() {
+        // sudo 提示是给运维人员看的，应该是英文短句而不是技术错误码
+        let err = DaemonError::RequiresRoot;
+        assert_eq!(err.to_string(), "this operation requires root; re-run with sudo");
+    }
+
+    #[test]
+    fn daemon_error_binary_not_found_includes_path() {
+        // 路径要带在错误里，方便用户交叉检查 PATH/安装位置
+        let path = PathBuf::from("/opt/nonexistent/ntd");
+        let err = DaemonError::BinaryNotFound(path.clone());
+        let msg = err.to_string();
+        assert!(msg.contains("not found"), "msg should say 'not found': {msg}");
+        assert!(msg.contains("/opt/nonexistent/ntd"), "msg should include path: {msg}");
+    }
+
+    #[test]
+    fn daemon_error_non_zero_exit_includes_stderr() {
+        // 错误信息要能让用户看到 schtasks/systemctl 报的具体原因
+        let err = DaemonError::NonZeroExit {
+            command: "systemctl start".to_string(),
+            code: Some(1),
+            stderr: "Unit not found".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("systemctl start"));
+        assert!(msg.contains("Unit not found"));
+        assert!(msg.contains("1"));
+    }
+
+    #[test]
+    fn daemon_error_write_file_preserves_source() {
+        // #[source] 让 anyhow 在打印时把底层 io::Error 也带出来
+        use std::error::Error as _;
+        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+        let err = DaemonError::WriteFile {
+            path: PathBuf::from("/etc/systemd/system/ntd.service"),
+            source: io_err,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("ntd.service"));
+        // source 链可以 walk
+        let source = err.source().expect("WriteFile should expose source");
+        assert!(source.to_string().contains("denied"));
+    }
+
+    #[test]
+    fn daemon_error_refuse_root_system_install_is_descriptive() {
+        let err = DaemonError::RefusingRootSystemInstall;
+        let msg = err.to_string();
+        assert!(msg.contains("root"));
+        assert!(msg.contains("--run-as-user"));
+    }
+
+    // 平台无关的 redeploy spec 在所有平台都能测，用来钉死参数顺序
+    #[test]
+    fn build_redeploy_spec_user_mode_adds_user_flag() {
+        let spec = build_redeploy_spec(DaemonInstallMode::User, "echo hi");
+        assert_eq!(spec.program, "systemd-run");
+        // 第一参数必须是 --user（User 模式）
+        assert_eq!(spec.args.first().map(String::as_str), Some("--user"));
+        // 末尾是 /bin/sh -c <script>
+        assert!(spec.args.contains(&"/bin/sh".to_string()));
+        assert!(spec.args.contains(&"-c".to_string()));
+        assert!(spec.args.contains(&"echo hi".to_string()));
+    }
+
+    #[test]
+    fn build_redeploy_spec_system_mode_omits_user_flag() {
+        let spec = build_redeploy_spec(DaemonInstallMode::System, "echo hi");
+        // System 模式不加 --user，连得上 system 实例
+        assert_ne!(spec.args.first().map(String::as_str), Some("--user"));
+    }
+
+    #[test]
+    fn build_redeploy_spec_unknown_mode_omits_user_flag() {
+        // Unknown 时脚本里会自己重新探测模式，不在这里加 --user
+        let spec = build_redeploy_spec(DaemonInstallMode::Unknown, "echo hi");
+        assert_ne!(spec.args.first().map(String::as_str), Some("--user"));
     }
 }
 

--- a/backend/src/daemon.rs
+++ b/backend/src/daemon.rs
@@ -326,7 +326,13 @@ fn launchd_install(force: bool) -> Result<(), DaemonError> {
         let stderr = String::from_utf8_lossy(&output.stderr);
         // "already loaded" 表示已经载入,按成功对待
         if !stderr.contains("already loaded") {
-            eprintln!("Failed to bootstrap service: {}", stderr.trim());
+            // 真正失败（如 plist 语法错、launchd 拒绝载入）：不再静默返回 Ok(())
+            // 而是把 stderr 透传给调用方,让 main.rs 走 "daemon error: ..." + exit(1)。
+            return Err(DaemonError::NonZeroExit {
+                command: "launchctl bootstrap".to_string(),
+                code: output.status.code(),
+                stderr: stderr.trim().to_string(),
+            });
         }
     }
 
@@ -401,7 +407,12 @@ fn launchd_start() -> Result<(), DaemonError> {
                 .output();
             println!("Service started");
         } else {
-            eprintln!("Failed to start service: {}", stderr.trim());
+            // 真正失败（如 launchd 拉不起、plist 没装）：透传给调用方,走 exit(1)。
+            return Err(DaemonError::NonZeroExit {
+                command: "launchctl kickstart".to_string(),
+                code: output.status.code(),
+                stderr: stderr.trim().to_string(),
+            });
         }
     }
     Ok(())
@@ -422,11 +433,16 @@ fn launchd_stop() -> Result<(), DaemonError> {
         println!("Service stopped");
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        // 3 / 113 / "No such process" 都表示 service 本来就没在跑
+        // "No such process" 表示 service 本来就没在跑,按幂等成功对待
         if stderr.contains("No such process") {
             println!("Service is not running");
         } else {
-            eprintln!("Failed to stop service: {}", stderr.trim());
+            // 真正失败（如权限不足、launchctl 拒绝）：透传给调用方,走 exit(1)。
+            return Err(DaemonError::NonZeroExit {
+                command: "launchctl bootout".to_string(),
+                code: output.status.code(),
+                stderr: stderr.trim().to_string(),
+            });
         }
     }
     Ok(())
@@ -1216,8 +1232,12 @@ fn task_scheduler_install(force: bool) -> Result<(), DaemonError> {
     }
 
     // Check if task already exists
-    // query 失败（schtasks 不在 PATH 上、权限不足等）只 warn，
-    // 不阻断重装流程——用户明确 --force 时本就是想覆盖。
+    // 区分两种 "query 失败"：
+    // - Spawn 失败（schtasks 不在 PATH / 权限不足 / Task Scheduler 服务挂）：
+    //   整体环境不可用,直接 ? 让上层走 exit(1),不要硬装下去(可能写出半截 task)。
+    // - status 非 0（task 不存在）：视为"未安装",继续走 install 流程——
+    //   用户没传 --force 时这条 install 仍要靠 query 判定已有 task,但 task
+    //   不存在的话 `query.status.success()` 自然为 false,落到下面的 install 分支。
     let query = Command::new("schtasks")
         .args(["/query", "/tn", TASK_NAME])
         .output()
@@ -1313,7 +1333,12 @@ fn task_scheduler_uninstall() -> Result<(), DaemonError> {
         if stderr.contains("does not exist") || stderr.contains("The system cannot find") {
             println!("Task does not exist");
         } else {
-            eprintln!("Failed to delete task: {}", stderr.trim());
+            // 真正失败（如权限不足、Task Scheduler 服务挂）：透传给调用方,走 exit(1)。
+            return Err(DaemonError::NonZeroExit {
+                command: "schtasks /delete".to_string(),
+                code: output.status.code(),
+                stderr: stderr.trim().to_string(),
+            });
         }
     }
 
@@ -1359,7 +1384,12 @@ fn task_scheduler_stop() -> Result<(), DaemonError> {
         if stderr.contains("not running") || stderr.contains("does not exist") {
             println!("Service is not running");
         } else {
-            eprintln!("Failed to stop task: {}", stderr.trim());
+            // 真正失败（如权限不足、task 状态机拒绝 /end）：透传给调用方,走 exit(1)。
+            return Err(DaemonError::NonZeroExit {
+                command: "schtasks /end".to_string(),
+                code: output.status.code(),
+                stderr: stderr.trim().to_string(),
+            });
         }
     }
     Ok(())

--- a/backend/src/hooks/service.rs
+++ b/backend/src/hooks/service.rs
@@ -127,16 +127,30 @@ fn append_to_chain(chain: &[i64], source: i64) -> Vec<i64> {
 
 /// Long-lived, multi-threaded tokio runtime used to dispatch hook-triggered
 /// executions. See `execute_target_todo` for why a shared runtime is required.
-fn hook_runtime() -> &'static tokio::runtime::Runtime {
-    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
-    RUNTIME.get_or_init(|| {
+///
+/// 错误处理：原来用 `.expect("failed to build hook runtime")` 在 tokio builder
+/// 失败时让整个进程 panic。在低资源环境（ulimit 触顶、cgroup 限制）
+/// 下会让 hook 系统不可用,且唯一线索就是一行 panic 消息。
+///
+/// 实现说明：`OnceLock::get_or_try_init` 还在 nightly 上（#109737），
+/// 这里用 `OnceLock<Result<Runtime, io::Error>>` 模拟：第一次调用同步构造
+/// 运行时,把 Ok/Err 缓存进去,后续调用直接 clone 一份错误。构造失败的错误会被
+/// 所有调用方一致看到,等价于 get_or_try_init 的语义。
+fn hook_runtime() -> Result<&'static tokio::runtime::Runtime, std::io::Error> {
+    static RUNTIME: OnceLock<Result<tokio::runtime::Runtime, std::io::Error>> = OnceLock::new();
+    // 拿不到 Owned Result 时不能用 .as_ref()（会得到 Result<&T, &Err>），
+    // 这里手动 match 一下让 &Err 变成 clone 的 std::io::Error；std::io::Error
+    // 内部是 Arc-wrapped，开销可忽略。
+    match RUNTIME.get_or_init(|| {
         tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .worker_threads(2)
             .thread_name("hook-runtime")
             .build()
-            .expect("failed to build hook runtime")
-    })
+    }) {
+        Ok(rt) => Ok(rt),
+        Err(e) => Err(std::io::Error::new(e.kind(), e.to_string())),
+    }
 }
 
 /// Iterate a todo's enabled hooks that match the given trigger.
@@ -367,7 +381,17 @@ async fn execute_target_todo(
     // forever. A shared, multi-threaded runtime kept alive via `OnceLock`
     // lets the spawned task continue after the helper thread is gone.
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-    let runtime = hook_runtime();
+    // 之前这里 hook_runtime() 内部 `.expect()` 在 builder 失败时直接 panic，
+    // 整个 hook dispatch 链路会无提示挂掉。改成 Result：失败时 tracing::warn
+    // 记录原因 + 提前 return 友好错误,这样 ntd 主体进程不会因为 hook 失败
+    // 而崩溃,用户也能从日志看到原因。
+    let runtime = match hook_runtime() {
+        Ok(rt) => rt,
+        Err(e) => {
+            warn!("failed to build hook runtime ({}); hook dispatch unavailable", e);
+            return Err(format!("hook runtime init failed: {e}"));
+        }
+    };
     std::thread::spawn(move || {
         let result = runtime.block_on(start_todo_execution(request));
         let _ = reply_tx.send(result);

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -109,17 +109,27 @@ async fn main() {
             let prefix = ntd::npm_utils::get_npm_global_prefix();
 
             // 使用 --prefix 安装到有写权限的目录，避免 EACCES
-            let status = std::process::Command::new("npm")
+            //
+            // 错误处理：原来用 `.expect("Failed to run npm...")` 直接 panic。
+            // 在 npm 未安装 / 不在 PATH 上的环境里,会向用户抛一个无定位
+            // 信息的 panic 栈。改成显式 Result + 友好提示 + exit code 1。
+            let npm_result = std::process::Command::new("npm")
                 .args([
                     "install",
                     "-g",
                     &format!("--prefix={}", prefix),
                     "@weibaohui/nothing-todo@latest",
                 ])
-                .status()
-                .expect("Failed to run npm. Is npm installed?");
+                .status();
+            let status = match npm_result {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("Failed to run npm ({}): is npm installed and on PATH?", e);
+                    std::process::exit(1);
+                }
+            };
             if !status.success() {
-                eprintln!("Upgrade failed.");
+                eprintln!("Upgrade failed (npm exited with code {:?}).", status.code());
                 std::process::exit(1);
             }
 
@@ -206,7 +216,15 @@ async fn main() {
             // daemon::handle_daemon_command 已声明为 async,以便内部 restart
             // 路径可以 await tokio::time::sleep,避免 std::thread::sleep 阻塞
             // tokio worker。
-            daemon::handle_daemon_command(action).await;
+            //
+            // 错误处理：daemon 子命令以前在内部直接 eprintln! + exit(1)，
+            // 测试或脚本里很难区分"成功"和"用户已安装但要 --force"。
+            // 改成返回 Result::<(), DaemonError> 后,这里统一打印 + 退出码,
+            // 任何分支（launchd / systemd / schtasks）的错误都用同一个出口。
+            if let Err(e) = daemon::handle_daemon_command(action).await {
+                eprintln!("daemon error: {e}");
+                std::process::exit(1);
+            }
             return;
         }
         Some(Commands::Skill { action: SkillAction::Install { force, executor } }) => {


### PR DESCRIPTION
## 背景

#495 报告后端代码大量使用 `.unwrap()` / `.expect()`,在生产路径上遇到异常（npm 未装、launchd 缺失、systemd 不可用等）会直接 panic 崩溃,而不是给用户友好错误信息。

本 PR 聚焦在 daemon 子命令（CLI 入口的高频触达路径）和 hooks 运行时构建（影响整个 hook 触发链路）:

## 改动

### `backend/src/daemon.rs`
- 新增 `DaemonError` 枚举（thiserror 派生）,把 launchd/systemd/Task Scheduler 三平台的错误统一在一个出口
- 所有 `launchd_*/systemd_*/task_scheduler_*` 函数从返回 `()` 改为返回 `Result<(), DaemonError>`
- 移除散落的 `eprintln! + process::exit(1)`,改用 `?` + 集中错误处理
- `get_ntd_binary_path()` 从 panic 改为 `Result`
- 把 `Refusing to install as root` 检查从 `generate_systemd_unit` 移到 `systemd_install`,这样错误能成为 `DaemonError::RefusingRootSystemInstall` 变体

### `backend/src/main.rs`
- `ntd upgrade`: `npm` 命令的 `.expect()` 替换为 `match` + 友好错误
- `ntd daemon <action>`: 用 `DaemonError` 的 Display 输出 + 退出码 1,任何平台分支的错误统一一个出口

### `backend/src/hooks/service.rs`
- `hook_runtime()` 改为返回 `Result`,builder 失败时 `warn! + 友好错误`,不再让 hook 失败把整个 ntd 进程搞挂
- 用 `OnceLock<Result<...>>` 模拟 `get_or_try_init`（后者还在 nightly #109737 上）

### `backend/Cargo.toml`
- 新增 `[lints.clippy]`:
  - `unwrap_used / expect_used / panic = warn` (阶段 1)
  - 后续 PR 按模块替换完 panic 后,再升回 deny
- 注释说明渐进式收紧计划

### `backend/build.rs`
- 顶层 `#![allow(clippy::unwrap_used, clippy::expect_used)]`: build script 失败本就该 panic 出栈

## 测试

- 新增 8 个 daemon 单元测试:
  - `DaemonError::RequiresRoot` / `BinaryNotFound` / `NonZeroExit` / `WriteFile` / `RefusingRootSystemInstall` 的 Display 行为
  - `WriteFile` 的 `#[source]` 链透传底层 `io::Error`
  - 平台无关的 `build_redeploy_spec` 跨模式参数顺序
- 8/8 全过
- 全量 `cargo test --lib`: 381 通过 / 1 失败（`adapters::codewhale::test_get_final_result_with_text`,在 main 上同样失败,与本 PR 无关）
- `cargo build` / `cargo clippy` 干净通过,无新增 warning

## 后续

issue 列出的 263 处 unwrap 只清理了 daemon/hooks/main 三处入口路径。后续 PR 可以按模块分批替换 `executor_service` / `feishu` / `db` 等热路径,每合入一批把对应 lint 升回 deny。