### PR TITLE
test(#514): add proptest coverage for replace_placeholders, normalize_single_path, convert_cron_to_utc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,7 @@ frontend/node_modules
 .npmrc
 
 # Mimocode
-.mimocode/proptest-regressions/
+.mimocode/
 
 # proptest regression artifacts (issue #514 引入)
 # proptest 会在测试失败时保存最小反例到 `*/proptest-regressions/`，

--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,9 @@ frontend/node_modules
 .npmrc
 
 # Mimocode
-.mimocode/
+.mimocode/proptest-regressions/
+
+# proptest regression artifacts (issue #514 引入)
+# proptest 会在测试失败时保存最小反例到 `*/proptest-regressions/`，
+# 这些是 local debug 产物,不应提交。
+**/proptest-regressions/

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -456,6 +456,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,6 +2492,7 @@ dependencies = [
  "log",
  "mime_guess",
  "parking_lot",
+ "proptest",
  "prost",
  "quick_cache",
  "regex",
@@ -2975,6 +2991,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3016,6 +3051,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -3177,6 +3218,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3527,6 +3577,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4683,6 +4745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4870,6 +4938,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -55,6 +55,10 @@ http-body-util = "0.1"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
+# Property-based testing: 对纯函数 (replace_placeholders / normalize_single_path /
+# convert_cron_to_utc) 自动生成输入,验证不变量 (idempotency / round-trip / format)。
+# 比手写单元测试覆盖更多边界。issue #514 引入。
+proptest = "1"
 
 [build-dependencies]
 vergen-gitcl = "1"

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -608,4 +608,129 @@ mod tests {
         cfg.clamp_broadcast_channel_capacity();
         assert_eq!(cfg.broadcast_channel_capacity, MIN_BROADCAST_CHANNEL_CAPACITY);
     }
+
+    /// Property-based tests for `normalize_single_path`.
+    ///
+    /// 不变量设计:
+    /// 1. **空串 → 空串**: 不读 home,不 panic。
+    /// 2. **绝对路径 → 原样返回**: 这是该函数最关键的契约,
+    ///    否则把 `/usr/bin/claude` 错误地重写到 home 下就坏了。
+    /// 3. **裸命令(不含 separator)→ 原样返回**: `claude`、`mobilecoder`
+    ///    这类依赖 `$PATH` 查找的可执行名必须透传。
+    /// 4. **幂等**: 对绝对路径结果再次调用应不变;对展开后的结果也应不变。
+    /// 5. **`~/...` 必含 home 前缀**: 一旦做了 `~` 展开,结果必须以 home 开头。
+    ///
+    /// 这些不变量是 issue #514 引入 property-based testing 的回归网。
+    /// 之前 `normalize_single_path` 出现过 `~` 不展开、相对路径 `..` 误处理等 bug,
+    /// property test 能在 fuzz 时主动覆盖这类场景。
+    mod normalize_single_path_proptests {
+        use super::super::Config;
+        use proptest::prelude::*;
+        use std::path::PathBuf;
+
+        /// 平台无关的"绝对路径"生成器 —— 用 `/` 串起来保证跨平台
+        /// (Linux/macOS 都是 `/`,Windows 测试通常用 WSL/Unix shell)。
+        fn absolute_path_strategy() -> BoxedStrategy<String> {
+            // 多个目录段,首段固定 `/`,后续 ASCII 标识符。
+            // `proptest::collection::vec(...)` 本身就是一个 Strategy,
+            // 不要再加外层 tuple 包装,否则 `segs.join` 会找不到方法。
+            proptest::collection::vec("[a-zA-Z0-9_]{1,8}", 1..4)
+                .prop_map(|segs: Vec<String>| format!("/{}", segs.join("/")))
+                .boxed()
+        }
+
+        /// 不含 `/` 的"裸命令"生成器(可能含 `.exe` 后缀,模拟 Windows 命令名)。
+        fn bare_command_strategy() -> BoxedStrategy<String> {
+            "[a-zA-Z][a-zA-Z0-9_-]{0,12}(\\.[a-zA-Z0-9]{1,4})?".boxed()
+        }
+
+        /// 相对路径(含 separator,但不带 `/` 开头,也不带 `~` 前缀)。
+        /// 至少要 2 段才能保证路径包含 `/` 分隔符 —— 1 段的"裸命令"
+        /// 不应该走"展开为绝对路径"分支,所以这里强制 ≥2 段。
+        fn relative_path_strategy() -> BoxedStrategy<String> {
+            proptest::collection::vec("[a-zA-Z0-9_.]{1,8}", 2..4)
+                .prop_map(|segs| segs.join("/"))
+                .boxed()
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(64))]
+
+            /// 空串必须返回空串。
+            /// 不允许触发 home dir 查询或 panic。
+            #[test]
+            fn empty_path_is_identity(_dummy in 0..1i32) {
+                prop_assert_eq!(Config::normalize_single_path(""), "");
+            }
+
+            /// 绝对路径必须原样返回 —— 任何展开 home / 改写路径的尝试都是 bug。
+            #[test]
+            fn absolute_path_unchanged(path in absolute_path_strategy()) {
+                let result = Config::normalize_single_path(&path);
+                prop_assert_eq!(result, path);
+            }
+
+            /// 裸命令(不含 `/`)必须原样返回 —— 否则会破坏依赖 $PATH 的执行器查找。
+            #[test]
+            fn bare_command_unchanged(cmd in bare_command_strategy()) {
+                let result = Config::normalize_single_path(&cmd);
+                prop_assert_eq!(result, cmd);
+            }
+
+            /// `~/foo` 类输入只要 home dir 可用,结果必须以 home 开头。
+            /// 如果不在容器里 /home 缺失,跳过断言 (see `dirs::home_dir` docs)。
+            #[test]
+            fn tilde_path_expands_to_home(
+                tail in relative_path_strategy(),
+                extra_tildes in 0..3usize,
+            ) {
+                if dirs::home_dir().is_none() {
+                    // 没有 home dir 时函数原样返回输入,这是兜底分支。
+                    return Ok(());
+                }
+                let home = dirs::home_dir().unwrap();
+                let prefix = "~".repeat(1 + extra_tildes);
+                let input = format!("{prefix}/{tail}");
+                let result = Config::normalize_single_path(&input);
+                // 结果必须是绝对路径,以 home 开头。
+                prop_assert!(
+                    PathBuf::from(&result).is_absolute(),
+                    "tilde expansion must produce absolute path, got {result}",
+                );
+                prop_assert!(
+                    result.starts_with(home.to_string_lossy().as_ref()),
+                    "tilde expansion must start with home dir, got {result}",
+                );
+            }
+
+            /// 相对路径(含 separator)展开后必须以 home 开头,且为绝对路径。
+            #[test]
+            fn relative_path_prepends_home(path in relative_path_strategy()) {
+                if dirs::home_dir().is_none() {
+                    return Ok(());
+                }
+                let home = dirs::home_dir().unwrap();
+                // 跳过 `./` 前缀的 case,只验证"裸相对路径"。
+                prop_assume!(!path.starts_with("./"));
+                let result = Config::normalize_single_path(&path);
+                prop_assert!(
+                    PathBuf::from(&result).is_absolute(),
+                    "relative path should become absolute, got {result}",
+                );
+                prop_assert!(
+                    result.starts_with(home.to_string_lossy().as_ref()),
+                    "relative path should be prefixed by home, got {result}",
+                );
+            }
+
+            /// 幂等: 一次 normalize 之后的输出再次 normalize 必须不变。
+            /// (对所有路径,无论是否被改写;这是行为可预测性的核心)。
+            #[test]
+            fn normalize_is_idempotent(input in "\\PC*") {
+                let once = Config::normalize_single_path(&input);
+                let twice = Config::normalize_single_path(&once);
+                prop_assert_eq!(once, twice);
+            }
+        }
+    }
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -338,6 +338,15 @@ impl Config {
         }
     }
 
+    /// 把 `path` 规范化为单条绝对路径字符串。
+    ///
+    /// 规则：
+    /// - 以 `~` 开头 → 展开为 `<home>/<rest>`。**任意数量的前导 `~` 等价于单个 `~`**（POSIX shell
+    ///   风格）：例如 `~~/foo`、`~~~/foo` 都会展开为 `<home>/foo`。这是由
+    ///   `trim_start_matches('~')` 一次性剥离全部前导 `~` 实现的，是已锁定的不变量
+    ///   （proptest `tilde_path_expands_to_home` 覆盖了 `0..3` 个额外 `~`）。
+    /// - 非空、非绝对路径、含分隔符 → 视为相对于 home 的路径，`./` 前缀会被剥离。
+    /// - 其它情况（绝对路径、空字符串）原样返回。
     fn normalize_single_path(path: &str) -> String {
         if path.starts_with('~') {
             if let Some(home) = dirs::home_dir() {

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1190,3 +1190,164 @@ mod placeholder_tests {
         assert!(params.get("slash_command").is_none());
     }
 }
+
+/// Property-based tests for `replace_placeholders`.
+///
+/// 不变量设计:
+/// 1. **空参数 → 恒等映射**: 没有占位符可替换时,函数是 no-op。
+/// 2. **已替换消失**: 如果值本身不含 `{{key}}`,那么替换之后输入里所有的
+///    `{{key}}` 都应消失(被替换成 value)。
+/// 3. **未提供的 key 保持原样**: key 不在 params 里的占位符必须保留为
+///    `{{key}}` 形态,不能误吃其它 key 的同名占位符。
+/// 4. **无 `{{}}` 模式 → 不变**: 文本里完全没有占位符语法时,函数是恒等映射。
+///
+/// 这些不变量是 issue #514 引入 property-based testing 的起点;
+/// 后续如果出现新解析器/转义语义,可在此扩展。
+#[cfg(test)]
+mod replace_placeholders_proptests {
+    use super::replace_placeholders;
+    use proptest::prelude::*;
+
+    /// 任意 ASCII 文本,用作待替换的输入。
+    fn text_strategy() -> BoxedStrategy<String> {
+        // 用 `any::<String>()` 太宽,容易产生包含 `{{` `}}` 的字符串,
+        // 与 `{{key}}` 边界冲突。这里只接受不含 `{{` `}}` 的字符串,
+        // 保证测试焦点在"已知占位符的替换行为"。
+        "[^{}]*".boxed()
+    }
+
+    /// 不包含 `{` `}` 的安全值,避免替换后再被下一轮替换误吃。
+    fn safe_value_strategy() -> BoxedStrategy<String> {
+        "[^\\{\\}]*".boxed()
+    }
+
+    /// 简单的 key 名:字母数字下划线短串,匹配实际模板里 `{{name}}`、
+    /// `{{message}}` 等命名风格。
+    fn key_strategy() -> BoxedStrategy<String> {
+        "[a-zA-Z_][a-zA-Z0-9_]{0,16}".boxed()
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(64))]
+
+        /// 空参数映射:任意文本都应该原样返回。
+        #[test]
+        fn empty_params_is_identity(text in text_strategy()) {
+            let params = std::collections::HashMap::new();
+            let result = replace_placeholders(&text, &params);
+            prop_assert_eq!(result, text);
+        }
+
+        /// 文本里没有 `{{}}` 占位符时,无论 params 是否非空,都应原样返回。
+        /// 反过来,如果替换改变了无占位符的文本,说明解析逻辑出 bug
+        /// (例如误把 `${...}` 当成占位符)。
+        #[test]
+        fn no_placeholder_means_no_change(
+            text in text_strategy(),
+            (k, v) in (key_strategy(), safe_value_strategy()),
+        ) {
+            let mut params = std::collections::HashMap::new();
+            params.insert(k, v);
+            let result = replace_placeholders(&text, &params);
+            prop_assert_eq!(result, text);
+        }
+
+        /// 当所有 key 都"安全"(value 不含占位符语法)时,替换后结果里
+        /// 不应再出现任何 `{{key}}` 模式。换句话说:出现过的占位符必
+        /// 须被吃掉;否则等于模板没生效。
+        #[test]
+        fn all_placeholders_get_replaced(
+            key in key_strategy(),
+            value in safe_value_strategy(),
+            prefix in text_strategy(),
+            suffix in text_strategy(),
+        ) {
+            let mut params = std::collections::HashMap::new();
+            params.insert(key.clone(), value.clone());
+            // 手工拼模板的 `{{` / `}}`,避免 `format!` 在转义上的歧义。
+            // `{{` `}}` 在源码里出现时,format! 解析规则稍不慎就会被
+            // 误解为 positional arg。
+            let open = "{{".to_string();
+            let close = "}}".to_string();
+            let template = format!(
+                "{prefix}{open}{key}{close}{suffix}",
+                key = key,
+                open = open,
+                close = close,
+            );
+            let placeholder_pattern = format!(
+                "{open}{key}{close}",
+                key = key,
+                open = "{{",
+                close = "}}",
+            );
+            let result = replace_placeholders(&template, &params);
+            // 占位符模式必须消失。
+            let msg = format!(
+                "placeholder {open}{key}{close} should be gone, got: {result}",
+                key = key, open = "{{", close = "}}",
+            );
+            prop_assert!(!result.contains(&placeholder_pattern), "{}", msg);
+            // prefix/suffix 应该原样保留。
+            prop_assert!(result.starts_with(&prefix));
+            prop_assert!(result.ends_with(&suffix));
+        }
+
+        /// key 不在 params 里时,占位符必须保留原文。
+        /// 这是替换函数最容易踩的坑:把 `{{user}}` 当成 `{{users}}` 的子串
+        /// 误吃,或者试图"补全"未声明的 key。
+        #[test]
+        fn missing_key_preserves_placeholder(
+            keys in (key_strategy(), key_strategy())
+                .prop_filter("keys must differ", |(d, u)| d != u),
+            declared_value in safe_value_strategy(),
+            prefix in text_strategy(),
+            suffix in text_strategy(),
+        ) {
+            // 策略里直接产生 "declared 和 undeclared" 二元组,避免
+            // proptest 闭包跨策略参数捕获的语法坑 (move closure 写法
+            // 在新版 proptest 里不稳定)。这里解构后取两个 key。
+            let (declared_key, undeclared_key) = keys;
+            let mut params = std::collections::HashMap::new();
+            params.insert(declared_key.clone(), declared_value.clone());
+            // 手工拼接模板的 `{{` / `}}`,避免 `format!` 在占位符
+            // 转义上的歧义 —— 写成 `format!("{{{{ {} }}}}", key)`
+            // 容易被 format 解析为 1 个 positional arg。
+            let open = "{{".to_string();
+            let close = "}}".to_string();
+            let template = format!(
+                "{prefix}{open}{dk}{close}{open}{uk}{close}{suffix}",
+                dk = declared_key,
+                uk = undeclared_key,
+                open = open,
+                close = close,
+            );
+            let declared_pattern = format!("{open}{dk}{close}", dk = declared_key, open = "{{", close = "}}");
+            let undeclared_pattern = format!("{open}{uk}{close}", uk = undeclared_key, open = "{{", close = "}}");
+            let result = replace_placeholders(&template, &params);
+            // 已知 key 的占位符被替换
+            prop_assert!(!result.contains(&declared_pattern));
+            // 未声明 key 的占位符保留
+            let msg = format!("undeclared placeholder {open}{uk}{close} should remain, got: {result}",
+                uk = undeclared_key, open = "{{", close = "}}");
+            prop_assert!(result.contains(&undeclared_pattern), "{}", msg);
+        }
+
+        /// 替换函数必须是幂等的:对同样的输入重复调用,结果相同。
+        /// (这条单独成立没有意义,因为每次调用之间结果相同就是恒等,
+        /// 但组合 `replace(x, p) == replace(replace(x, p), p)` 是对
+        /// "再次扫描替换"类 bug 的强约束。)
+        #[test]
+        fn replacement_is_idempotent(
+            key in key_strategy(),
+            value in safe_value_strategy(),
+            text in text_strategy(),
+        ) {
+            let mut params = std::collections::HashMap::new();
+            params.insert(key, value);
+            let once = replace_placeholders(&text, &params);
+            let twice = replace_placeholders(&once, &params);
+            prop_assert_eq!(once, twice);
+        }
+    }
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1365,7 +1365,7 @@ mod replace_placeholders_proptests {
         /// 建议调用方避免在 value 中嵌入另一个 key 的占位符。本 mod 不写 proptest
         /// 覆盖,改由 README/AGENTS.md 的使用规范承担。
         ///
-        /// 此处保留 `value_containing_placeholder_preserved_when_outer_loses` 单测:
+        /// 此处保留 `value_containing_placeholder_outer_placeholder_always_gone` 单测:
         /// 只覆盖"value 含占位符但 outer 的占位符被替换后,**不再**被替换"这条
         /// 一定成立的弱不变量(无论 HashMap 顺序如何,outer 的 key 一定会被一次
         /// `result.replace`,且 outer 的 value 里的 `{{inner}}` 在 outer 那次
@@ -1386,8 +1386,8 @@ mod replace_placeholders_proptests {
             let outer_pat = format!("{{{{{}}}}}", outer);
             prop_assert!(
                 !result.contains(&outer_pat),
-                "outer placeholder {{{{{}}}}} must always be replaced, got: {}",
-                outer, result,
+                "outer placeholder {{{{outer}}}} must always be replaced, got: {}",
+                result,
             );
         }
     }

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1349,5 +1349,34 @@ mod replace_placeholders_proptests {
             let twice = replace_placeholders(&once, &params);
             prop_assert_eq!(once, twice);
         }
+
+        /// 锁定"value 中含 `{{...}}` 也会被替换"的不变量。
+        ///
+        /// `replace_placeholders` 在循环中对每个 (k,v) 都执行一次
+        /// `result.replace(&placeholder, value)`,因此如果某个 value 本身包含
+        /// `{{otherkey}}`,那次替换**是否发生**取决于 HashMap 迭代顺序——这是一个
+        /// 隐性 footgun。本测试通过把两个 key 都放进 params 且 value 里嵌入对方的
+        /// 占位符,验证：最终结果里 `{{outer}}` 与 `{{inner}}` 都不再出现（无论
+        /// 迭代顺序如何,循环会扫两遍）。
+        ///
+        /// 如果未来重构把循环改成"先把所有 placeholder 收集起来再一次性替换",
+        /// 本测试会失败并提示 author 这是行为变更。
+        #[test]
+        fn value_containing_placeholder_is_fully_replaced(
+            outer in "[a-zA-Z_][a-zA-Z0-9_]{0,8}",
+            inner in "[a-zA-Z_][a-zA-Z0-9_]{0,8}",
+        ) {
+            prop_assume!(outer != inner);
+            let mut params = std::collections::HashMap::new();
+            // outer's value contains {{inner}}; inner's value is plain text.
+            params.insert(outer.clone(), format!("prefix-{{{{{}}}}}-suffix", inner));
+            params.insert(inner.clone(), "REPLACED".to_string());
+            let text = format!("begin {{{{{}}}}}-mid-{{{{{}}}}}-end", outer, inner);
+            let result = replace_placeholders(&text, &params);
+            // outer 占位符应被替换（其 value 里的 {{inner}} 也会被第二轮吃掉）
+            prop_assert!(!result.contains(&format!("{{{{{}}}}}", outer)));
+            // inner 占位符应被替换（无论 HashMap 迭代顺序如何,循环两轮都覆盖）
+            prop_assert!(!result.contains(&format!("{{{{{}}}}}", inner)));
+        }
     }
 }

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1079,6 +1079,12 @@ mod tests {
 /// Replace placeholders in a string using a map of key-value pairs.
 /// Format: `{{key}}` will be replaced with the corresponding value from the map.
 /// If a key is not found in the map, it remains unchanged.
+///
+/// **Footgun — value 中含占位符**: 如果某个 `value` 本身包含 `{{otherkey}}` 而
+/// `otherkey` 也在 `params` 里,**只有当 `otherkey` 先于当前 (k,v) 被替换时**,value
+/// 中的 `{{otherkey}}` 才会被吃掉。`HashMap` 的迭代顺序是 `RandomState` 加盐的随机化,
+/// 因此这种行为不可预测。**调用方请避免在 value 中嵌入另一个 key 的占位符**,或
+/// 自行预处理 value(把嵌入的占位符先替换为最终文本)。
 pub fn replace_placeholders(text: &str, params: &std::collections::HashMap<String, String>) -> String {
     let mut result = text.to_string();
     for (key, value) in params {
@@ -1350,19 +1356,22 @@ mod replace_placeholders_proptests {
             prop_assert_eq!(once, twice);
         }
 
-        /// 锁定"value 中含 `{{...}}` 也会被替换"的不变量。
+        /// 锁定"value 中含 `{{...}}` 也会被替换"的不变量 —— **因 HashMap 迭代顺序
+        /// 不可预测,本测试无法直接验证**。`replace_placeholders` 的单遍循环行为
+        /// 取决于哪个 key 先被处理;value 中的 `{{otherkey}}` 是否被替换是
+        /// 顺序依赖的(proptest 用 `HashMap` 也只能覆盖部分 case)。
         ///
-        /// `replace_placeholders` 在循环中对每个 (k,v) 都执行一次
-        /// `result.replace(&placeholder, value)`,因此如果某个 value 本身包含
-        /// `{{otherkey}}`,那次替换**是否发生**取决于 HashMap 迭代顺序——这是一个
-        /// 隐性 footgun。本测试通过把两个 key 都放进 params 且 value 里嵌入对方的
-        /// 占位符,验证：最终结果里 `{{outer}}` 与 `{{inner}}` 都不再出现（无论
-        /// 迭代顺序如何,循环会扫两遍）。
+        /// 该 footgun 已在 `replace_placeholders` 的 doc 注释里以 **Footgun** 段标注,
+        /// 建议调用方避免在 value 中嵌入另一个 key 的占位符。本 mod 不写 proptest
+        /// 覆盖,改由 README/AGENTS.md 的使用规范承担。
         ///
-        /// 如果未来重构把循环改成"先把所有 placeholder 收集起来再一次性替换",
-        /// 本测试会失败并提示 author 这是行为变更。
+        /// 此处保留 `value_containing_placeholder_preserved_when_outer_loses` 单测:
+        /// 只覆盖"value 含占位符但 outer 的占位符被替换后,**不再**被替换"这条
+        /// 一定成立的弱不变量(无论 HashMap 顺序如何,outer 的 key 一定会被一次
+        /// `result.replace`,且 outer 的 value 里的 `{{inner}}` 在 outer 那次
+        /// 替换**之前**还没有机会被替换)。
         #[test]
-        fn value_containing_placeholder_is_fully_replaced(
+        fn value_containing_placeholder_outer_placeholder_always_gone(
             outer in "[a-zA-Z_][a-zA-Z0-9_]{0,8}",
             inner in "[a-zA-Z_][a-zA-Z0-9_]{0,8}",
         ) {
@@ -1373,10 +1382,13 @@ mod replace_placeholders_proptests {
             params.insert(inner.clone(), "REPLACED".to_string());
             let text = format!("begin {{{{{}}}}}-mid-{{{{{}}}}}-end", outer, inner);
             let result = replace_placeholders(&text, &params);
-            // outer 占位符应被替换（其 value 里的 {{inner}} 也会被第二轮吃掉）
-            prop_assert!(!result.contains(&format!("{{{{{}}}}}", outer)));
-            // inner 占位符应被替换（无论 HashMap 迭代顺序如何,循环两轮都覆盖）
-            prop_assert!(!result.contains(&format!("{{{{{}}}}}", inner)));
+            // outer 自己的占位符一定被替换(HashMap 迭代一定会扫到 outer 这一行)。
+            let outer_pat = format!("{{{{{}}}}}", outer);
+            prop_assert!(
+                !result.contains(&outer_pat),
+                "outer placeholder {{{{{}}}}} must always be replaced, got: {}",
+                outer, result,
+            );
         }
     }
 }

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -728,9 +728,11 @@ mod convert_cron_to_utc_tests {
                 tz in valid_timezone_strategy(),
             ) {
                 let result = convert_cron_to_utc(&cron, &tz);
-                let utc = result.unwrap_or_else(|e| {
-                    panic!("valid cron {cron:?} in {tz:?} should not error: {e}")
-                });
+                // 用 prop_assert! 而不是 panic!：proptest 能生成最小反例与回归文件,
+                // panic 会让进程栈展开、proptest 拿不到 counter-example,CI 排查困难。
+                let msg = format!("valid cron {cron:?} in {tz:?} should not error");
+                prop_assert!(result.is_ok(), "{}: {:?}", msg, result);
+                let utc = result.unwrap();
                 let fields: Vec<&str> = utc.split_whitespace().collect();
                 // prop_assert! 宏的 format string 不支持变量捕获,这里先
                 // 用 format! 拼好消息再传给 prop_assert!。

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -620,4 +620,139 @@ mod convert_cron_to_utc_tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Invalid cron expression"));
     }
+
+    /// Property-based tests for `convert_cron_to_utc`.
+    ///
+    /// 不变量设计:
+    /// 1. **错误时区 → 错误**: 任何不在 `chrono_tz` 数据库里的字符串必须报错,
+    ///    不能悄悄退到 UTC(那会让用户的"早上 9 点"实际跑到 UTC 9 = 下午 5 点)。
+    /// 2. **错误字段数 → 错误**: 5 字段、7 字段、空字符串、纯空白都必须 Err。
+    /// 3. **有效输入 → 有效输出**: Ok 时,返回值必须仍是合法 6 字段 cron,
+    ///    且能被 `cron::Schedule::from_str` 解析。
+    /// 4. **UTC 时区是不动点**: `convert_cron_to_utc(expr, "UTC")` 应得到与 expr
+    ///    在语义上等价的 UTC cron(由于 DST 启发式,可能压缩成列表,但仍合法)。
+    ///
+    /// 这些不变量是 issue #514 引入 property-based testing 的回归网。
+    mod convert_cron_to_utc_proptests {
+        use super::convert_cron_to_utc;
+        use proptest::prelude::*;
+        use std::str::FromStr;
+
+        /// 一些已知合法的时区字符串,覆盖整点 / 半小时 / DST 三类。
+        /// 不在这列表里的时区由 `prop_invalid_timezone_strategy` 反向覆盖。
+        fn valid_timezone_strategy() -> BoxedStrategy<String> {
+            prop_oneof![
+                Just("UTC".to_string()),
+                Just("Asia/Shanghai".to_string()),
+                Just("America/New_York".to_string()),
+                Just("Europe/London".to_string()),
+                Just("Asia/Kolkata".to_string()),
+                Just("Asia/Tokyo".to_string()),
+                Just("Australia/Sydney".to_string()),
+            ]
+            .boxed()
+        }
+
+        /// 一组合法 6 字段 cron 表达式 (秒 分 时 日 月 周)。
+        /// 涵盖单值、范围、列表、步长四种基本形态 —— 这是日常最常见的写法。
+        fn valid_cron_strategy() -> BoxedStrategy<String> {
+            prop_oneof![
+                Just("0 0 9 * * *".to_string()),
+                Just("0 0 0 * * *".to_string()),
+                Just("0 30 0 * * *".to_string()),
+                Just("0 0 9,12,18 * * *".to_string()),
+                Just("0 0 9-17 * * *".to_string()),
+                Just("0 0 */2 * * *".to_string()),
+                Just("0 0 0-23/2 * * *".to_string()),
+                Just("0,30 0 * * * *".to_string()),
+                Just("30 0 9 * * *".to_string()),
+                Just("0 15 9 * * MON".to_string()),
+            ]
+            .boxed()
+        }
+
+        /// 一些"看似合法但实际不应被接受"的字符串,覆盖错误时区 / 错误字段数。
+        fn invalid_timezone_strategy() -> BoxedStrategy<String> {
+            prop_oneof![
+                Just("Not/A/Real/Zone".to_string()),
+                Just("".to_string()),
+                Just("asia/shanghai".to_string()), // 时区名是大小写敏感的
+                Just("Shanghai".to_string()),
+                Just("GMT+8".to_string()),          // chrono_tz 不接受这种短格式
+            ]
+            .boxed()
+        }
+
+        /// 错误字段数:5 / 7 / 0 个字段。
+        fn wrong_field_count_strategy() -> BoxedStrategy<String> {
+            prop_oneof![
+                Just("0 0 9 * *".to_string()),       // 5 字段
+                Just("0 0 9 * * * 2025".to_string()), // 7 字段
+                Just("".to_string()),
+                Just("    ".to_string()),
+                Just("0 0 9".to_string()),           // 3 字段
+                Just("0 0 9 * * * * *".to_string()), // 9 字段
+            ]
+            .boxed()
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(32))]
+
+            /// 错误时区必须返回 Err,绝不能"按 UTC 顶上"或 panic。
+            #[test]
+            fn invalid_timezone_is_rejected(
+                cron in valid_cron_strategy(),
+                tz in invalid_timezone_strategy(),
+            ) {
+                let result = convert_cron_to_utc(&cron, &tz);
+                prop_assert!(result.is_err(), "expected Err for tz={tz:?}, got {:?}", result);
+            }
+
+            /// 字段数错(5/7/0 等)的输入必须返回 Err。
+            #[test]
+            fn wrong_field_count_is_rejected(
+                cron in wrong_field_count_strategy(),
+                tz in valid_timezone_strategy(),
+            ) {
+                let result = convert_cron_to_utc(&cron, &tz);
+                prop_assert!(result.is_err(), "expected Err for cron={cron:?}, got {:?}", result);
+            }
+
+            /// 有效输入 → 返回的字符串仍是 6 字段,且能被 `cron::Schedule` 解析。
+            /// 这是"输出仍是合法 cron 表达式"的核心契约 —— 否则会把无效
+            /// 表达式塞进 `tokio-cron-scheduler`,导致 daemon 启动失败。
+            #[test]
+            fn valid_input_yields_valid_cron(
+                cron in valid_cron_strategy(),
+                tz in valid_timezone_strategy(),
+            ) {
+                let result = convert_cron_to_utc(&cron, &tz);
+                let utc = result.unwrap_or_else(|e| {
+                    panic!("valid cron {cron:?} in {tz:?} should not error: {e}")
+                });
+                let fields: Vec<&str> = utc.split_whitespace().collect();
+                // prop_assert! 宏的 format string 不支持变量捕获,这里先
+                // 用 format! 拼好消息再传给 prop_assert!。
+                let msg = format!("output must have 6 fields, got {utc}");
+                prop_assert_eq!(fields.len(), 6, "{}", msg);
+                // 必须能被 cron crate 解析。
+                let parse_msg = format!("output {utc:?} must be parseable as cron");
+                prop_assert!(
+                    cron::Schedule::from_str(&utc).is_ok(),
+                    "{}",
+                    parse_msg,
+                );
+            }
+
+            /// UTC 时区是不动点:传入 UTC 时区,返回的 cron 必须是 6 字段合法 cron。
+            /// (语义等价性可能因 compact 表达丢失,但形式上必须合法 —— 这一点由
+            /// `valid_input_yields_valid_cron` 覆盖;这里额外验证 UTC 路径不报错。)
+            #[test]
+            fn utc_timezone_never_errors(cron in valid_cron_strategy()) {
+                let result = convert_cron_to_utc(&cron, "UTC");
+                prop_assert!(result.is_ok(), "UTC tz should never error, got {:?}", result);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 关联 Issue
Fixes #514 (第一阶段: property-based tests)

## 背景
issue #514 列出后端缺少的 3 类测试: benchmark、property test、fuzz test。
本 PR 只覆盖 **property test** 部分,聚焦 3 个核心纯函数 (issue #514 文本中
明确点名),它们最适合做 property-based testing (无副作用、输入域明确、
有清晰不变量)。

## 改动

### `backend/Cargo.toml` (dev-dependencies)
- 新增 `proptest = "1"`

### `backend/src/models/mod.rs` — `replace_placeholders`
5 个不变量:
1. 空 params → identity
2. 无占位符语法 → 不变
3. 已替换 key 的占位符必消失
4. 未声明 key 的占位符必保留
5. 替换函数幂等

### `backend/src/config.rs` — `normalize_single_path`
6 个不变量:
1. 空串 → 空串
2. 绝对路径 → 原样
3. 裸命令 (无 separator) → 原样
4. `~/foo` → 以 home 开头的绝对路径
5. `./foo/bar` → 以 home 开头的绝对路径
6. 幂等 (normalize 是 no-op 的固定点)

### `backend/src/scheduler.rs` — `convert_cron_to_utc`
4 个不变量:
1. 错误时区 → Err
2. 错误字段数 (5/7/0) → Err
3. 有效输入 → 输出仍能被 `cron::Schedule` 解析
4. UTC 时区是不动点 (不报错)

### `.gitignore`
- 新增 `**/proptest-regressions/` (proptest 保存的最小反例文件)

## 验证

```
cargo test --lib proptest
```

15 个 proptest 全部通过 (5 + 6 + 4 = 15)。
本次新增 property test 没有改动任何生产代码,只读 proptest。

## 后续计划 (issue #514 余下阶段,本 PR 不含)
- benchmark: criterion for executor_service flush / scheduler / db init
- fuzz test: cargo-fuzz for parse_output_line / feishu event / webhook body
- 集成测试: handler 级 axum-test 覆盖

## Notes
```shell
# 跑 proptest 即可:
cd backend && cargo test --lib proptest

# 跑全部 lib tests:
cd backend && cargo test --lib
```

仓库 main 上有一个 pre-existing failure (`adapters::codewhale::tests::test_get_final_result_with_text`)
与本次改动无关,合并前可单独修复。