### PR TITLE
fix: replace inline unsafe blocks with crate::sys::require_root_or_exit in daemon/linux.rs

### DIFF
--- a/backend/src/daemon/linux.rs
+++ b/backend/src/daemon/linux.rs
@@ -225,9 +225,8 @@ WantedBy=default.target
 }
 
 fn install(force: bool, system: bool, run_as_user: Option<&str>) {
-    if system && unsafe { libc::geteuid() } != 0 {
-        eprintln!("System service install requires root. Re-run with sudo.");
-        std::process::exit(1);
+    if system {
+        crate::sys::require_root_or_exit("install");
     }
 
     let unit_path = unit_path(system);
@@ -291,9 +290,8 @@ fn install(force: bool, system: bool, run_as_user: Option<&str>) {
 }
 
 fn uninstall(system: bool) {
-    if system && unsafe { libc::geteuid() } != 0 {
-        eprintln!("System service uninstall requires root. Re-run with sudo.");
-        std::process::exit(1);
+    if system {
+        crate::sys::require_root_or_exit("uninstall");
     }
 
     // stop / disable 都允许失败：service 没起来或没 enable 是正常状态
@@ -311,9 +309,8 @@ fn uninstall(system: bool) {
 }
 
 fn start(system: bool) {
-    if system && unsafe { libc::geteuid() } != 0 {
-        eprintln!("System service start requires root. Re-run with sudo.");
-        std::process::exit(1);
+    if system {
+        crate::sys::require_root_or_exit("start");
     }
 
     let status = run_systemctl(system, &["start", SERVICE_NAME]);
@@ -326,9 +323,8 @@ fn start(system: bool) {
 }
 
 fn stop(system: bool) {
-    if system && unsafe { libc::geteuid() } != 0 {
-        eprintln!("System service stop requires root. Re-run with sudo.");
-        std::process::exit(1);
+    if system {
+        crate::sys::require_root_or_exit("stop");
     }
 
     let status = run_systemctl(system, &["stop", SERVICE_NAME]);
@@ -341,9 +337,8 @@ fn stop(system: bool) {
 }
 
 fn restart(system: bool) {
-    if system && unsafe { libc::geteuid() } != 0 {
-        eprintln!("System service restart requires root. Re-run with sudo.");
-        std::process::exit(1);
+    if system {
+        crate::sys::require_root_or_exit("restart");
     }
 
     let status = run_systemctl(system, &["restart", SERVICE_NAME]);


### PR DESCRIPTION
## 问题

Commit `42d3cb9` (PR #551) 为保障 unsafe 边界安全，在 `src/lib.rs` 添加了 `#![deny(unsafe_code)]`，并将所有 unsafe FFI 集中到 `src/sys.rs` 提供安全包装。但由于 `daemon.rs` → `daemon/linux.rs` 的模块拆分发生在两个独立 PR 中的合并顺序问题，`daemon/linux.rs` 中的 5 处裸 `unsafe { libc::geteuid() }` 调用未被替换，导致 CI (Build and Release #1354, #1356) 编译失败。

## 修复

将 `daemon/linux.rs` 中 5 个函数的根权限检查替换为集中式 `crate::sys::require_root_or_exit()`：

| 函数 | 行号 | 替换前 | 替换后 |
|------|------|--------|--------|
| `install` | 228 | `unsafe { libc::geteuid() } != 0` | `crate::sys::require_root_or_exit"install")` |
| `uninstall` | 294 | 同上 | 同上 |
| `start` | 314 | 同上 | 同上 |
| `stop` | 329 | 同上 | 同上 |
| `restart` | 344 | 同上 | 同上 |

## 验证

- `cargo check --target x86_64-unknown-linux-gnu` ✅ 通过（0 errors, 仅 warnings）
- 保持了与 `sys.rs` 已有 API 一致

Fixes CI build failure on main branch.