### PR TITLE
refactor: 清理重复代码，提升代码质量

### DIFF
--- a/backend/src/adapters/codewhale.rs
+++ b/backend/src/adapters/codewhale.rs
@@ -199,7 +199,13 @@ impl CodeExecutor for CodewhaleExecutor {
         }
     }
 
-    // parse_stderr_line / check_success 走 CodeExecutor 默认实现（委托给 BaseExecutor），
+    // parse_stderr_line 委托给 BaseExecutor 的默认关键字分类逻辑，
+    // 根据是否包含 "error" 决定 log_type（error / stderr）。
+    fn parse_stderr_line(&self, line: &str) -> Option<ParsedLogEntry> {
+        BaseExecutor::default_parse_stderr_line(line)
+    }
+
+    // check_success 走 CodeExecutor 默认实现（委托给 BaseExecutor），
     // 与本文件以前的 in-class 实现完全等价。去掉重复 override 是 PR #536 的核心目标。
 
     fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
@@ -221,10 +227,13 @@ impl CodeExecutor for CodewhaleExecutor {
             let concatenated = raw_chunks.join("");
             // Strip think tags from the full text (this also trims outer whitespace)
             let cleaned = super::strip_think_tags(&concatenated);
-            // Normalize multiple newlines to single newline for readability
+            // Normalize whitespace:
+            // - Split by newlines to preserve multi-line structure
+            // - collapse all whitespace within each line to single spaces (split_whitespace + join)
+            // - filter empty lines after trimming
             let normalized = cleaned
                 .split('\n')
-                .map(|s| s.trim())
+                .map(|s| s.split_whitespace().collect::<Vec<_>>().join(" "))
                 .filter(|s| !s.is_empty())
                 .collect::<Vec<_>>()
                 .join("\n");

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -286,6 +286,11 @@ impl CodeExecutor for PiExecutor {
                     None
                 },
                 "tool_execution_start" => {
+                    // 先刷出缓冲的 text_delta，避免工具调用前的内容丢失
+                    let flushed = self.flush_pending_text();
+                    if flushed.is_some() {
+                        return flushed;
+                    }
                     if let Some(te) = event.tool_execution {
                         let name = te.tool_name.unwrap_or_else(|| "unknown".to_string());
                         let input_str = te.args.as_ref().map(|i| serde_json::to_string(i).unwrap_or_default()).unwrap_or_default();
@@ -302,6 +307,11 @@ impl CodeExecutor for PiExecutor {
                     }
                 }
                 "tool_execution_end" => {
+                    // 先刷出缓冲的 text_delta，避免工具结果前的内容丢失
+                    let flushed = self.flush_pending_text();
+                    if flushed.is_some() {
+                        return flushed;
+                    }
                     if let Some(te) = event.tool_execution {
                         let name = te.tool_name.unwrap_or_else(|| "unknown".to_string());
                         let output = te.output.unwrap_or_default();
@@ -367,13 +377,18 @@ impl CodeExecutor for PiExecutor {
     // check_success 走 CodeExecutor 默认实现（委托给 BaseExecutor::default_check_success），
     // 与原 `exit_code == 0` 实现完全等价。去掉重复 override 是 PR #536 的核心目标。
 
-    fn get_final_result(&self, _logs: &[ParsedLogEntry]) -> Option<String> {
+    fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
         // 优先使用 message_end 中提取的完整文本（无换行、无碎片）
         if let Some(full) = self.full_text.lock().clone() {
             return Some(full);
         }
-        // fallback 到最后一条 text
-        None
+        // full_text 不可用时（message_end 未到达/进程被 kill/session 交接）
+        // fallback 到日志中的最后一条 assistant 条目，避免 RunningBoard
+        // "Last reply" 面板和 execution_records.result 为空
+        logs.iter()
+            .rev()
+            .find(|l| l.log_type == "assistant")
+            .map(|l| l.content.clone())
     }
 
     fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
@@ -545,15 +560,15 @@ mod tests {
     }
 
     #[test]
-    fn test_get_final_result_joins_assistant() {
+    fn test_get_final_result_fallback_to_last_assistant() {
         let executor = PiExecutor::new("pi".to_string());
-        // 没有 full_text 时应返回 None
+        // 没有 full_text 时 fallback 到最后一条 assistant 日志
         let logs = vec![
             ParsedLogEntry::new("assistant", "hello"),
             ParsedLogEntry::new("assistant", "world"),
         ];
         let result = executor.get_final_result(&logs);
-        assert_eq!(result, None, "without full_text should return None");
+        assert_eq!(result, Some("world".to_string()));
     }
 
     #[test]

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -19,6 +19,8 @@ pub struct PiExecutor {
     base: BaseExecutor,
     /// 从 session 事件中提取的 session id
     session_id: Arc<Mutex<Option<String>>>,
+    /// text_delta 缓冲：合并连续的增量文本，避免每字符单独成行
+    pending_text: Arc<Mutex<String>>,
 }
 
 impl PiExecutor {
@@ -26,7 +28,44 @@ impl PiExecutor {
         Self {
             base: BaseExecutor::new(path),
             session_id: Arc::new(Mutex::new(None)),
+            pending_text: Arc::new(Mutex::new(String::new())),
         }
+    }
+
+    /// 将缓冲的 text_delta 内容作为一个 assistant 日志条目刷出。
+    /// 返回 `Some(entry)` 表示有缓冲内容被刷出，`None` 表示缓冲为空。
+    fn flush_pending_text(&self) -> Option<ParsedLogEntry> {
+        let mut buf = self.pending_text.lock();
+        let content = std::mem::take(&mut *buf);
+        drop(buf);
+        if content.is_empty() {
+            return None;
+        }
+        Some(ParsedLogEntry {
+            timestamp: utc_timestamp(),
+            log_type: "assistant".to_string(),
+            content,
+            usage: None,
+            tool_name: None,
+            tool_input_json: None,
+        })
+    }
+
+    /// 判断缓冲文本是否到达自然边界，可以刷出。
+    /// 条件：以句子结束标点结尾、包含换行符，或超过阈值长度。
+    fn is_text_boundary(buf: &str) -> bool {
+        // 以句子结束标点结尾
+        buf.ends_with('.')
+            || buf.ends_with('!')
+            || buf.ends_with('?')
+            || buf.ends_with('。')
+            || buf.ends_with('！')
+            || buf.ends_with('？')
+            || buf.ends_with('\n')
+            // 包含换行符
+            || buf.contains('\n')
+            // 超过 200 字符强制刷出
+            || buf.len() > 200
     }
 }
 
@@ -35,6 +74,7 @@ impl Clone for PiExecutor {
         Self {
             base: self.base.clone(),
             session_id: self.session_id.clone(),
+            pending_text: self.pending_text.clone(),
         }
     }
 }
@@ -121,6 +161,8 @@ impl CodeExecutor for PiExecutor {
                     })
                 }
                 "message_end" => {
+                    // message_end 前先刷出残留的 text_delta 缓冲
+                    let flushed = self.flush_pending_text();
                     // message_end 包含完整消息内容
                     // 对于 assistant 消息，内容已经在 message_update 时通过 text_delta 实时发送了
                     // message_end 这里只处理工具结果等非 assistant 消息
@@ -133,7 +175,7 @@ impl CodeExecutor for PiExecutor {
                                     *self.base.model.lock() = Some(model.clone());
                                 }
                             }
-                            return None;
+                            return flushed;
                         }
                         // 其他角色（user 等）的消息内容
                         let mut text_parts = Vec::new();
@@ -159,7 +201,7 @@ impl CodeExecutor for PiExecutor {
                             });
                         }
                     }
-                    None
+                    flushed
                 }
                 "message_update" => {
                     // message_update 包含增量内容，只从 assistantMessageEvent 提取
@@ -179,23 +221,32 @@ impl CodeExecutor for PiExecutor {
                         }
                         match ame.event_type.as_deref() {
                             Some("text_delta") => {
-                                // text_delta 是实际回复的增量内容
-                                // 移除尾部换行符，避免 PI 输出每字符一行时在最终结果中引入多余换行
+                                // text_delta 是实际回复的增量内容——缓冲合并，不立即发出
                                 if let Some(delta) = &ame.delta {
                                     let trimmed = delta.trim_end();
                                     if !trimmed.is_empty() {
-                                        return Some(ParsedLogEntry {
-                                            timestamp: utc_timestamp(),
-                                            log_type: "assistant".to_string(),
-                                            content: trimmed.to_string(),
-                                            usage: None,
-                                            tool_name: None,
-                                            tool_input_json: None,
-                                        });
+                                        let mut buf = self.pending_text.lock();
+                                        buf.push_str(trimmed);
+                                        // 在自然边界处刷出：标点符号或足够长的文本
+                                        if Self::is_text_boundary(&buf) {
+                                            let content = std::mem::take(&mut *buf);
+                                            drop(buf);
+                                            return Some(ParsedLogEntry {
+                                                timestamp: utc_timestamp(),
+                                                log_type: "assistant".to_string(),
+                                                content,
+                                                usage: None,
+                                                tool_name: None,
+                                                tool_input_json: None,
+                                            });
+                                        }
                                     }
                                 }
+                                None
                             }
                             Some("thinking_delta") => {
+                                // thinking_delta 前先刷出残留的 text_delta 缓冲
+                                let flushed = self.flush_pending_text();
                                 // thinking_delta 是 thinking 的增量内容
                                 // 移除尾部换行符，避免多余换行
                                 if let Some(delta) = &ame.delta {
@@ -211,11 +262,13 @@ impl CodeExecutor for PiExecutor {
                                         });
                                     }
                                 }
+                                flushed
                             }
-                            _ => {}
+                            _ => None,
                         }
+                    } else {
+                        None
                     }
-                    None
                 }
                 "message_start" => {
                     // message_start 事件（通常只有 role 信息，不返回具体内容）
@@ -416,9 +469,13 @@ mod tests {
     fn test_parse_output_line_text_delta() {
         let executor = PiExecutor::new("pi".to_string());
         let line = r#"{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"hello world"}}"#;
+        // text_delta 内容被缓冲，不立即发出
         let entry = executor.parse_output_line(line);
-        assert!(entry.is_some());
-        let e = entry.unwrap();
+        assert!(entry.is_none(), "text_delta without boundary should buffer, not emit");
+        // 显式刷出应得到缓冲的内容
+        let flushed = executor.flush_pending_text();
+        assert!(flushed.is_some());
+        let e = flushed.unwrap();
         assert_eq!(e.log_type, "assistant");
         assert_eq!(e.content, "hello world");
     }

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -25,6 +25,10 @@ pub struct PiExecutor {
     base: BaseExecutor,
     /// 从 session 事件中提取的 session id
     session_id: Arc<Mutex<Option<String>>>,
+    /// text_delta 缓冲：合并连续的增量文本，避免碎片化
+    pending_text: Arc<Mutex<String>>,
+    /// 从 message_end 中提取的完整文本，供 get_final_result 使用
+    full_text: Arc<Mutex<Option<String>>>,
 }
 
 impl PiExecutor {
@@ -32,7 +36,27 @@ impl PiExecutor {
         Self {
             base: BaseExecutor::new(path),
             session_id: Arc::new(Mutex::new(None)),
+            pending_text: Arc::new(Mutex::new(String::new())),
+            full_text: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// 将缓冲的 text_delta 内容作为一个 assistant 日志条目刷出。
+    fn flush_pending_text(&self) -> Option<ParsedLogEntry> {
+        let mut buf = self.pending_text.lock();
+        let content = std::mem::take(&mut *buf);
+        drop(buf);
+        if content.is_empty() {
+            return None;
+        }
+        Some(ParsedLogEntry {
+            timestamp: utc_timestamp(),
+            log_type: "assistant".to_string(),
+            content,
+            usage: None,
+            tool_name: None,
+            tool_input_json: None,
+        })
     }
 
     /// 从 message_end 的 content 块中提取纯文本，去掉换行，合并为单条字符串。
@@ -54,6 +78,18 @@ impl PiExecutor {
             Some(parts.join(""))
         }
     }
+
+    /// 判断缓冲文本是否到达自然边界，可以刷出。
+    /// 条件：以句子结束标点结尾，或超过阈值长度。
+    fn is_text_boundary(buf: &str) -> bool {
+        buf.ends_with('.')
+            || buf.ends_with('!')
+            || buf.ends_with('?')
+            || buf.ends_with('。')
+            || buf.ends_with('！')
+            || buf.ends_with('？')
+            || buf.len() > 200
+    }
 }
 
 impl Clone for PiExecutor {
@@ -61,6 +97,8 @@ impl Clone for PiExecutor {
         Self {
             base: self.base.clone(),
             session_id: self.session_id.clone(),
+            pending_text: self.pending_text.clone(),
+            full_text: self.full_text.clone(),
         }
     }
 }
@@ -146,8 +184,7 @@ impl CodeExecutor for PiExecutor {
                     })
                 }
                 "message_end" => {
-                    // message_end 包含完整文本，是 assistant 输出的唯一来源。
-                    // text_delta 被跳过（见下方），避免碎片化。
+                    let flushed = self.flush_pending_text();
                     if let Some(msg) = event.message {
                         // 提取 model
                         if let Some(model) = &msg.model {
@@ -155,23 +192,15 @@ impl CodeExecutor for PiExecutor {
                                 *self.base.model.lock() = Some(model.clone());
                             }
                         }
-                        // 提取完整文本（去掉换行）
-                        return self.extract_full_text(&msg).map(|content| ParsedLogEntry {
-                            timestamp: utc_timestamp(),
-                            log_type: "assistant".to_string(),
-                            content,
-                            usage: None,
-                            tool_name: None,
-                            tool_input_json: None,
-                        });
+                        // 存储完整文本供 get_final_result 使用
+                        if let Some(full) = self.extract_full_text(&msg) {
+                            *self.full_text.lock() = Some(full);
+                        }
                     }
-                    None
+                    flushed
                 }
                 "message_update" => {
-                    // 只处理 thinking_delta（实时思考过程）；text_delta 跳过，
-                    // 等 message_end 一次输出完整文本，避免碎片化。
                     if let Some(ame) = event.assistant_message_event {
-                        // 提取 model 信息
                         if let Some(model) = &ame.model {
                             if !model.is_empty() {
                                 *self.base.model.lock() = Some(model.clone());
@@ -184,24 +213,54 @@ impl CodeExecutor for PiExecutor {
                                 }
                             }
                         }
-                        if ame.event_type.as_deref() == Some("thinking_delta") {
-                            if let Some(delta) = &ame.delta {
-                                let trimmed = delta.trim_end();
-                                if !trimmed.is_empty() {
-                                    return Some(ParsedLogEntry {
-                                        timestamp: utc_timestamp(),
-                                        log_type: "thinking".to_string(),
-                                        content: trimmed.chars().take(500).collect(),
-                                        usage: None,
-                                        tool_name: None,
-                                        tool_input_json: None,
-                                    });
+                        match ame.event_type.as_deref() {
+                            Some("text_delta") => {
+                                // 实时流式输出：缓冲 text_delta，在自然边界刷出
+                                // 去掉 delta 中的换行，避免输出碎片化
+                                if let Some(delta) = &ame.delta {
+                                    let cleaned = delta.replace('\n', "").trim_end().to_string();
+                                    if !cleaned.is_empty() {
+                                        let mut buf = self.pending_text.lock();
+                                        buf.push_str(&cleaned);
+                                        // 在句子结束标点处刷出
+                                        if Self::is_text_boundary(&buf) {
+                                            let content = std::mem::take(&mut *buf);
+                                            drop(buf);
+                                            return Some(ParsedLogEntry {
+                                                timestamp: utc_timestamp(),
+                                                log_type: "assistant".to_string(),
+                                                content,
+                                                usage: None,
+                                                tool_name: None,
+                                                tool_input_json: None,
+                                            });
+                                        }
+                                    }
                                 }
+                                None
                             }
+                            Some("thinking_delta") => {
+                                let flushed = self.flush_pending_text();
+                                if let Some(delta) = &ame.delta {
+                                    let trimmed = delta.trim_end();
+                                    if !trimmed.is_empty() {
+                                        return Some(ParsedLogEntry {
+                                            timestamp: utc_timestamp(),
+                                            log_type: "thinking".to_string(),
+                                            content: trimmed.chars().take(500).collect(),
+                                            usage: None,
+                                            tool_name: None,
+                                            tool_input_json: None,
+                                        });
+                                    }
+                                }
+                                flushed
+                            }
+                            _ => None,
                         }
-                        // text_delta / text_start / text_end 等跳过
+                    } else {
+                        None
                     }
-                    None
                 }
                 "message_start" => None,
                 "tool_execution_start" => {
@@ -286,23 +345,13 @@ impl CodeExecutor for PiExecutor {
     // check_success 走 CodeExecutor 默认实现（委托给 BaseExecutor::default_check_success），
     // 与原 `exit_code == 0` 实现完全等价。去掉重复 override 是 PR #536 的核心目标。
 
-    fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
-        // 收集所有 assistant 类型的文本
-        let texts: Vec<String> = logs.iter()
-            .filter(|l| l.log_type == "assistant")
-            .map(|l| l.content.clone())
-            .filter(|t| !t.trim().is_empty())
-            .collect();
-
-        if !texts.is_empty() {
-            Some(texts.join("\n\n"))
-        } else {
-            // fallback 到最后一条文本
-            logs.iter()
-                .rev()
-                .find(|l| l.log_type == "text")
-                .map(|l| l.content.clone())
+    fn get_final_result(&self, _logs: &[ParsedLogEntry]) -> Option<String> {
+        // 优先使用 message_end 中提取的完整文本（无换行、无碎片）
+        if let Some(full) = self.full_text.lock().clone() {
+            return Some(full);
         }
+        // fallback 到最后一条 text
+        None
     }
 
     fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
@@ -409,11 +458,12 @@ mod tests {
     fn test_parse_output_line_message_end_assistant() {
         let executor = PiExecutor::new("pi".to_string());
         let line = r#"{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"你好！有什么我可以帮你的吗？"}],"model":"deepseek-v4"}}"#;
+        // message_end 不直接返回内容（实时文本已通过 text_delta 输出），
+        // 而是将完整文本存储到 full_text 供 get_final_result 使用
         let entry = executor.parse_output_line(line);
-        assert!(entry.is_some());
-        let e = entry.unwrap();
-        assert_eq!(e.log_type, "assistant");
-        assert_eq!(e.content, "你好！有什么我可以帮你的吗？");
+        assert!(entry.is_none(), "assistant message_end returns flushed (None)");
+        assert_eq!(executor.get_model(), Some("deepseek-v4".to_string()));
+        assert_eq!(executor.get_final_result(&[]), Some("你好！有什么我可以帮你的吗？".to_string()));
     }
 
     #[test]
@@ -422,10 +472,8 @@ mod tests {
         // 内容中的换行应被清除
         let line = r#"{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"从前\n\n，在一片\n深蓝色的\n森林里"}]}}"#;
         let entry = executor.parse_output_line(line);
-        assert!(entry.is_some());
-        let e = entry.unwrap();
-        assert_eq!(e.log_type, "assistant");
-        assert_eq!(e.content, "从前，在一片深蓝色的森林里");
+        assert!(entry.is_none());
+        assert_eq!(executor.get_final_result(&[]), Some("从前，在一片深蓝色的森林里".to_string()));
     }
 
     #[test]
@@ -477,20 +525,32 @@ mod tests {
     #[test]
     fn test_get_final_result_joins_assistant() {
         let executor = PiExecutor::new("pi".to_string());
+        // 没有 full_text 时应返回 None
         let logs = vec![
             ParsedLogEntry::new("assistant", "hello"),
             ParsedLogEntry::new("assistant", "world"),
         ];
         let result = executor.get_final_result(&logs);
-        assert_eq!(result, Some("hello\n\nworld".to_string()));
+        assert_eq!(result, None, "without full_text should return None");
     }
 
     #[test]
     fn test_get_final_result_fallback_to_text() {
         let executor = PiExecutor::new("pi".to_string());
         let logs = vec![ParsedLogEntry { timestamp: String::new(), log_type: "text".to_string(), content: "plain text".to_string(), usage: None, tool_name: None, tool_input_json: None }];
+        // 没有 full_text 时返回 None
         let result = executor.get_final_result(&logs);
-        assert_eq!(result, Some("plain text".to_string()));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_get_final_result_from_full_text() {
+        let executor = PiExecutor::new("pi".to_string());
+        // 模拟 parse_output_line 通过 message_end 设置了 full_text
+        let line = r#"{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"你好！有什么我可以帮你的吗？"}],"model":"deepseek-v4"}}"#;
+        executor.parse_output_line(line);
+        let result = executor.get_final_result(&[]);
+        assert_eq!(result, Some("你好！有什么我可以帮你的吗？".to_string()));
     }
 
     #[test]

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -83,8 +83,8 @@ impl PiExecutor {
         if parts.is_empty() {
             None
         } else {
-            // 用空格连接多个 text block，避免 "Hello" + "World" → "HelloWorld"
-            Some(parts.join(" "))
+            // 用空串连接多个 text block（避免在 code fence 边界插入多余空格，块间空白由模型负责）。
+            Some(parts.join(""))
         }
     }
 

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -52,7 +52,7 @@ impl PiExecutor {
     }
 
     /// 判断缓冲文本是否到达自然边界，可以刷出。
-    /// 条件：以句子结束标点结尾、包含换行符，或超过阈值长度。
+    /// 条件：以句子结束标点结尾，或超过阈值长度。
     fn is_text_boundary(buf: &str) -> bool {
         // 以句子结束标点结尾
         buf.ends_with('.')
@@ -61,9 +61,6 @@ impl PiExecutor {
             || buf.ends_with('。')
             || buf.ends_with('！')
             || buf.ends_with('？')
-            || buf.ends_with('\n')
-            // 包含换行符
-            || buf.contains('\n')
             // 超过 200 字符强制刷出
             || buf.len() > 200
     }
@@ -222,11 +219,12 @@ impl CodeExecutor for PiExecutor {
                         match ame.event_type.as_deref() {
                             Some("text_delta") => {
                                 // text_delta 是实际回复的增量内容——缓冲合并，不立即发出
+                                // 去掉 delta 中的所有换行，避免 pi 输出中的换行导致碎片化
                                 if let Some(delta) = &ame.delta {
-                                    let trimmed = delta.trim_end();
-                                    if !trimmed.is_empty() {
+                                    let cleaned = delta.replace('\n', "").trim_end().to_string();
+                                    if !cleaned.is_empty() {
                                         let mut buf = self.pending_text.lock();
-                                        buf.push_str(trimmed);
+                                        buf.push_str(&cleaned);
                                         // 在自然边界处刷出：标点符号或足够长的文本
                                         if Self::is_text_boundary(&buf) {
                                             let content = std::mem::take(&mut *buf);

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -446,7 +446,7 @@ mod tests {
     fn test_parse_output_line_tool_execution_start() {
         // 通过实际 pi 输出验证 tool_execution_start 解析
         // 注意：需要完整 JSON 格式才能被 PiEvent 解析
-        let executor = PiExecutor::new("pi".to_string());
+        let _executor = PiExecutor::new("pi".to_string());
         // 跳过这个复杂结构的解析测试，因为它需要完整的 PiEvent 结构
         // tool_execution_start 的解析逻辑已通过集成测试验证
         assert!(true);

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -3,9 +3,17 @@
 //! 支持 --continue 恢复会话、--session 指定 session-id、--mode json JSONL 输出
 //!
 //! ## 输出策略
-//! pi 的 JSONL 流包含 text_delta（逐字增量）和 message_end（完整文本）。
-//! 为避免 text_delta 碎片化导致前端输出断裂，**跳过所有 text_delta**，
-//! 只在 message_end 事件中提取完整的 assistant 文本一次输出。
+//! pi 的 JSONL 流包含 text_delta（逐字增量）、message_end（完整文本）和
+//! thinking_delta（思考过程增量）。为兼顾实时性与完整性：
+//!
+//! - **text_delta**：缓冲连续增量文本，在标点边界刷出为 assistant 条目，
+//!   保证前端实时显示流畅。`flush_pending_text()` 是唯一的刷出口，确保
+//!   在任何事件切换（thinking_delta / message_end / 流程结束）之前
+//!   缓冲区都被清空。
+//! - **message_end**：提取完整的 assistant 文本存入 `full_text`，
+//!   供 `get_final_result` 返回最终结果（去掉换行），避免拼接碎片。
+//! - **thinking_delta**：作为 thinking 日志条目直接输出，不进入 text_delta 缓冲。
+//!
 //! 适用于 pi --mode json 输出。
 
 use std::sync::Arc;
@@ -65,7 +73,7 @@ impl PiExecutor {
         for block in &msg.content {
             if let super::pi_event::PiContentBlock::Text { text } = block {
                 if let Some(t) = text {
-                    let cleaned = t.replace('\n', "").trim().to_string();
+                    let cleaned = t.replace('\n', "").trim_end().to_string();
                     if !cleaned.is_empty() {
                         parts.push(cleaned);
                     }
@@ -75,7 +83,8 @@ impl PiExecutor {
         if parts.is_empty() {
             None
         } else {
-            Some(parts.join(""))
+            // 用空格连接多个 text block，避免 "Hello" + "World" → "HelloWorld"
+            Some(parts.join(" "))
         }
     }
 
@@ -186,6 +195,11 @@ impl CodeExecutor for PiExecutor {
                 "message_end" => {
                     let flushed = self.flush_pending_text();
                     if let Some(msg) = event.message {
+                        // 仅处理 assistant 的 message_end；user 等其他角色的
+                        // message_end 不提取内容（避免用户输入被误判为输出）
+                        if msg.role.as_deref() != Some("assistant") {
+                            return flushed;
+                        }
                         // 提取 model
                         if let Some(model) = &msg.model {
                             if !model.is_empty() {
@@ -240,7 +254,11 @@ impl CodeExecutor for PiExecutor {
                                 None
                             }
                             Some("thinking_delta") => {
+                                // 先刷出缓冲的 text_delta，确保 thinking 之前文本已输出
                                 let flushed = self.flush_pending_text();
+                                if flushed.is_some() {
+                                    return flushed;
+                                }
                                 if let Some(delta) = &ame.delta {
                                     let trimmed = delta.trim_end();
                                     if !trimmed.is_empty() {
@@ -254,7 +272,7 @@ impl CodeExecutor for PiExecutor {
                                         });
                                     }
                                 }
-                                flushed
+                                None
                             }
                             _ => None,
                         }
@@ -262,7 +280,11 @@ impl CodeExecutor for PiExecutor {
                         None
                     }
                 }
-                "message_start" => None,
+                "message_start" => {
+                    // 新的消息开始，重置 full_text，避免上次执行的状态泄漏
+                    *self.full_text.lock() = None;
+                    None
+                },
                 "tool_execution_start" => {
                     if let Some(te) = event.tool_execution {
                         let name = te.tool_name.unwrap_or_else(|| "unknown".to_string());
@@ -535,10 +557,10 @@ mod tests {
     }
 
     #[test]
-    fn test_get_final_result_fallback_to_text() {
+    fn test_get_final_result_returns_none_without_full_text() {
         let executor = PiExecutor::new("pi".to_string());
         let logs = vec![ParsedLogEntry { timestamp: String::new(), log_type: "text".to_string(), content: "plain text".to_string(), usage: None, tool_name: None, tool_input_json: None }];
-        // 没有 full_text 时返回 None
+        // 没有 full_text 时返回 None（不再从日志 fallback）
         let result = executor.get_final_result(&logs);
         assert_eq!(result, None);
     }

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -1,6 +1,12 @@
 //! pi 执行器 adapter
 //!
 //! 支持 --continue 恢复会话、--session 指定 session-id、--mode json JSONL 输出
+//!
+//! ## 输出策略
+//! pi 的 JSONL 流包含 text_delta（逐字增量）和 message_end（完整文本）。
+//! 为避免 text_delta 碎片化导致前端输出断裂，**跳过所有 text_delta**，
+//! 只在 message_end 事件中提取完整的 assistant 文本一次输出。
+//! 适用于 pi --mode json 输出。
 
 use std::sync::Arc;
 use parking_lot::Mutex;
@@ -19,8 +25,6 @@ pub struct PiExecutor {
     base: BaseExecutor,
     /// 从 session 事件中提取的 session id
     session_id: Arc<Mutex<Option<String>>>,
-    /// text_delta 缓冲：合并连续的增量文本，避免每字符单独成行
-    pending_text: Arc<Mutex<String>>,
 }
 
 impl PiExecutor {
@@ -28,41 +32,27 @@ impl PiExecutor {
         Self {
             base: BaseExecutor::new(path),
             session_id: Arc::new(Mutex::new(None)),
-            pending_text: Arc::new(Mutex::new(String::new())),
         }
     }
 
-    /// 将缓冲的 text_delta 内容作为一个 assistant 日志条目刷出。
-    /// 返回 `Some(entry)` 表示有缓冲内容被刷出，`None` 表示缓冲为空。
-    fn flush_pending_text(&self) -> Option<ParsedLogEntry> {
-        let mut buf = self.pending_text.lock();
-        let content = std::mem::take(&mut *buf);
-        drop(buf);
-        if content.is_empty() {
-            return None;
+    /// 从 message_end 的 content 块中提取纯文本，去掉换行，合并为单条字符串。
+    fn extract_full_text(&self, msg: &super::pi_event::PiMessage) -> Option<String> {
+        let mut parts = Vec::new();
+        for block in &msg.content {
+            if let super::pi_event::PiContentBlock::Text { text } = block {
+                if let Some(t) = text {
+                    let cleaned = t.replace('\n', "").trim().to_string();
+                    if !cleaned.is_empty() {
+                        parts.push(cleaned);
+                    }
+                }
+            }
         }
-        Some(ParsedLogEntry {
-            timestamp: utc_timestamp(),
-            log_type: "assistant".to_string(),
-            content,
-            usage: None,
-            tool_name: None,
-            tool_input_json: None,
-        })
-    }
-
-    /// 判断缓冲文本是否到达自然边界，可以刷出。
-    /// 条件：以句子结束标点结尾，或超过阈值长度。
-    fn is_text_boundary(buf: &str) -> bool {
-        // 以句子结束标点结尾
-        buf.ends_with('.')
-            || buf.ends_with('!')
-            || buf.ends_with('?')
-            || buf.ends_with('。')
-            || buf.ends_with('！')
-            || buf.ends_with('？')
-            // 超过 200 字符强制刷出
-            || buf.len() > 200
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join(""))
+        }
     }
 }
 
@@ -71,7 +61,6 @@ impl Clone for PiExecutor {
         Self {
             base: self.base.clone(),
             session_id: self.session_id.clone(),
-            pending_text: self.pending_text.clone(),
         }
     }
 }
@@ -144,7 +133,6 @@ impl CodeExecutor for PiExecutor {
             tracing::debug!("[pi] parse_output_line: event_type={}", event.event_type);
             return match event.event_type.as_str() {
                 "session" => {
-                    // Session 初始化事件
                     if let Some(id) = &event.id {
                         *self.session_id.lock() = Some(id.clone());
                     }
@@ -158,50 +146,30 @@ impl CodeExecutor for PiExecutor {
                     })
                 }
                 "message_end" => {
-                    // message_end 前先刷出残留的 text_delta 缓冲
-                    let flushed = self.flush_pending_text();
-                    // message_end 包含完整消息内容
-                    // 对于 assistant 消息，内容已经在 message_update 时通过 text_delta 实时发送了
-                    // message_end 这里只处理工具结果等非 assistant 消息
+                    // message_end 包含完整文本，是 assistant 输出的唯一来源。
+                    // text_delta 被跳过（见下方），避免碎片化。
                     if let Some(msg) = event.message {
-                        if msg.role.as_deref() == Some("assistant") {
-                            // assistant 内容已在 message_update 时发送，这里跳过避免重复
-                            // 但仍需提取 model 信息
-                            if let Some(model) = &msg.model {
-                                if !model.is_empty() {
-                                    *self.base.model.lock() = Some(model.clone());
-                                }
-                            }
-                            return flushed;
-                        }
-                        // 其他角色（user 等）的消息内容
-                        let mut text_parts = Vec::new();
-                        for block in &msg.content {
-                            if let super::pi_event::PiContentBlock::Text { text } = block {
-                                if let Some(t) = text {
-                                    let trimmed = t.trim();
-                                    if !trimmed.is_empty() {
-                                        text_parts.push(trimmed.to_string());
-                                    }
-                                }
+                        // 提取 model
+                        if let Some(model) = &msg.model {
+                            if !model.is_empty() {
+                                *self.base.model.lock() = Some(model.clone());
                             }
                         }
-                        if !text_parts.is_empty() {
-                            let content = text_parts.join("\n");
-                            return Some(ParsedLogEntry {
-                                timestamp: utc_timestamp(),
-                                log_type: "assistant".to_string(),
-                                content: content.clone(),
-                                usage: None,
-                                tool_name: None,
-                                tool_input_json: None,
-                            });
-                        }
+                        // 提取完整文本（去掉换行）
+                        return self.extract_full_text(&msg).map(|content| ParsedLogEntry {
+                            timestamp: utc_timestamp(),
+                            log_type: "assistant".to_string(),
+                            content,
+                            usage: None,
+                            tool_name: None,
+                            tool_input_json: None,
+                        });
                     }
-                    flushed
+                    None
                 }
                 "message_update" => {
-                    // message_update 包含增量内容，只从 assistantMessageEvent 提取
+                    // 只处理 thinking_delta（实时思考过程）；text_delta 跳过，
+                    // 等 message_end 一次输出完整文本，避免碎片化。
                     if let Some(ame) = event.assistant_message_event {
                         // 提取 model 信息
                         if let Some(model) = &ame.model {
@@ -216,91 +184,57 @@ impl CodeExecutor for PiExecutor {
                                 }
                             }
                         }
-                        match ame.event_type.as_deref() {
-                            Some("text_delta") => {
-                                // text_delta 是实际回复的增量内容——缓冲合并，不立即发出
-                                // 去掉 delta 中的所有换行，避免 pi 输出中的换行导致碎片化
-                                if let Some(delta) = &ame.delta {
-                                    let cleaned = delta.replace('\n', "").trim_end().to_string();
-                                    if !cleaned.is_empty() {
-                                        let mut buf = self.pending_text.lock();
-                                        buf.push_str(&cleaned);
-                                        // 在自然边界处刷出：标点符号或足够长的文本
-                                        if Self::is_text_boundary(&buf) {
-                                            let content = std::mem::take(&mut *buf);
-                                            drop(buf);
-                                            return Some(ParsedLogEntry {
-                                                timestamp: utc_timestamp(),
-                                                log_type: "assistant".to_string(),
-                                                content,
-                                                usage: None,
-                                                tool_name: None,
-                                                tool_input_json: None,
-                                            });
-                                        }
-                                    }
+                        if ame.event_type.as_deref() == Some("thinking_delta") {
+                            if let Some(delta) = &ame.delta {
+                                let trimmed = delta.trim_end();
+                                if !trimmed.is_empty() {
+                                    return Some(ParsedLogEntry {
+                                        timestamp: utc_timestamp(),
+                                        log_type: "thinking".to_string(),
+                                        content: trimmed.chars().take(500).collect(),
+                                        usage: None,
+                                        tool_name: None,
+                                        tool_input_json: None,
+                                    });
                                 }
-                                None
                             }
-                            Some("thinking_delta") => {
-                                // thinking_delta 前先刷出残留的 text_delta 缓冲
-                                let flushed = self.flush_pending_text();
-                                // thinking_delta 是 thinking 的增量内容
-                                // 移除尾部换行符，避免多余换行
-                                if let Some(delta) = &ame.delta {
-                                    let trimmed = delta.trim_end();
-                                    if !trimmed.is_empty() {
-                                        return Some(ParsedLogEntry {
-                                            timestamp: utc_timestamp(),
-                                            log_type: "thinking".to_string(),
-                                            content: trimmed.chars().take(500).collect(),
-                                            usage: None,
-                                            tool_name: None,
-                                            tool_input_json: None,
-                                        });
-                                    }
-                                }
-                                flushed
-                            }
-                            _ => None,
                         }
-                    } else {
-                        None
+                        // text_delta / text_start / text_end 等跳过
                     }
-                }
-                "message_start" => {
-                    // message_start 事件（通常只有 role 信息，不返回具体内容）
                     None
                 }
+                "message_start" => None,
                 "tool_execution_start" => {
                     if let Some(te) = event.tool_execution {
                         let name = te.tool_name.unwrap_or_else(|| "unknown".to_string());
                         let input_str = te.args.as_ref().map(|i| serde_json::to_string(i).unwrap_or_default()).unwrap_or_default();
-                        return Some(ParsedLogEntry {
+                        Some(ParsedLogEntry {
                             timestamp: utc_timestamp(),
                             log_type: "tool_use".to_string(),
                             content: format!("开始工具: {}", name),
                             usage: None,
                             tool_name: Some(name),
                             tool_input_json: Some(input_str),
-                        });
+                        })
+                    } else {
+                        None
                     }
-                    None
                 }
                 "tool_execution_end" => {
                     if let Some(te) = event.tool_execution {
                         let name = te.tool_name.unwrap_or_else(|| "unknown".to_string());
                         let output = te.output.unwrap_or_default();
-                        return Some(ParsedLogEntry {
+                        Some(ParsedLogEntry {
                             timestamp: utc_timestamp(),
                             log_type: "tool_result".to_string(),
                             content: format!("{}: {}", name, output.chars().take(300).collect::<String>()),
                             usage: None,
                             tool_name: Some(name),
                             tool_input_json: None,
-                        });
+                        })
+                    } else {
+                        None
                     }
-                    None
                 }
                 "agent_start" => Some(ParsedLogEntry {
                     timestamp: utc_timestamp(),
@@ -334,7 +268,6 @@ impl CodeExecutor for PiExecutor {
                     tool_name: None,
                     tool_input_json: None,
                 }),
-                // 忽略其他事件类型
                 _ => None,
             };
         }
@@ -467,15 +400,32 @@ mod tests {
     fn test_parse_output_line_text_delta() {
         let executor = PiExecutor::new("pi".to_string());
         let line = r#"{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"hello world"}}"#;
-        // text_delta 内容被缓冲，不立即发出
+        // text_delta 被跳过，等 message_end 输出完整文本
         let entry = executor.parse_output_line(line);
-        assert!(entry.is_none(), "text_delta without boundary should buffer, not emit");
-        // 显式刷出应得到缓冲的内容
-        let flushed = executor.flush_pending_text();
-        assert!(flushed.is_some());
-        let e = flushed.unwrap();
+        assert!(entry.is_none(), "text_delta should be skipped");
+    }
+
+    #[test]
+    fn test_parse_output_line_message_end_assistant() {
+        let executor = PiExecutor::new("pi".to_string());
+        let line = r#"{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"你好！有什么我可以帮你的吗？"}],"model":"deepseek-v4"}}"#;
+        let entry = executor.parse_output_line(line);
+        assert!(entry.is_some());
+        let e = entry.unwrap();
         assert_eq!(e.log_type, "assistant");
-        assert_eq!(e.content, "hello world");
+        assert_eq!(e.content, "你好！有什么我可以帮你的吗？");
+    }
+
+    #[test]
+    fn test_parse_output_line_message_end_assistant_with_newlines() {
+        let executor = PiExecutor::new("pi".to_string());
+        // 内容中的换行应被清除
+        let line = r#"{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"从前\n\n，在一片\n深蓝色的\n森林里"}]}}"#;
+        let entry = executor.parse_output_line(line);
+        assert!(entry.is_some());
+        let e = entry.unwrap();
+        assert_eq!(e.log_type, "assistant");
+        assert_eq!(e.content, "从前，在一片深蓝色的森林里");
     }
 
     #[test]

--- a/backend/src/db/dashboard.rs
+++ b/backend/src/db/dashboard.rs
@@ -4,7 +4,8 @@
 //! 将各个独立的 SQL 查询和结果解析拆分为独立的异步函数。
 //!
 //! 每个函数职责单一：执行一条 SQL 查询、解析结果、返回领域结构体。
-//! `get_dashboard_stats` 作为协调者依次调用它们，组装最终的 `DashboardStats`。
+//! `get_dashboard_stats` 作为协调者，使用 `tokio::try_join!` 并行调用所有
+//! 独立查询函数，组装最终的 `DashboardStats`。
 
 use std::collections::HashMap;
 use sea_orm::{ConnectionTrait, DbBackend, Statement};
@@ -482,11 +483,9 @@ pub(super) async fn fetch_recent_executions(
                 session_id: row.try_get_by("session_id").ok(),
                 result: row.try_get_by("result").ok(),
                 resume_message: row.try_get_by("resume_message").ok(),
-                command: None, stdout: None, stderr: None, model: None,
-                pid: None, todo_progress: None, execution_stats: None,
-                source_todo_id: None, source_todo_title: None, source_hook_id: None,
-                rating: None, source_execution_record_id: None,
-                last_review_status: None, last_reviewed_at: None,
+                // 其余未 SELECT 的字段使用 Default（Option 字段为 None，id 为 0）
+                // 未来新增字段会自动得到 Default 值，无需手动维护 None 列表
+                ..execution_records::Model::default()
             }
         })
         .map(Into::into)

--- a/backend/src/db/dashboard.rs
+++ b/backend/src/db/dashboard.rs
@@ -1,0 +1,643 @@
+//! Dashboard statistics query helpers.
+//!
+//! 提取自 `execution.rs` 中的 `get_dashboard_stats` 函数（705 行），
+//! 将各个独立的 SQL 查询和结果解析拆分为独立的异步函数。
+//!
+//! 每个函数职责单一：执行一条 SQL 查询、解析结果、返回领域结构体。
+//! `get_dashboard_stats` 作为协调者依次调用它们，组装最终的 `DashboardStats`。
+
+use std::collections::HashMap;
+use sea_orm::{ConnectionTrait, DbBackend, Statement};
+
+use crate::models::{
+    DailyExecution, DailyTokenStats, ExecutionRecord,
+    ExecutorCount, ExecutorDuration, ModelCacheStat, ModelCount, TagCount,
+    TriggerTypeCount, LeaderboardItem,
+};
+
+/// 辅助结构体：携带数据库连接和时间过滤条件，避免在每个函数中重复传递。
+pub(super) struct DashboardQueryContext<'a> {
+    pub conn: &'a dyn ConnectionTrait,
+    pub backend: DbBackend,
+    pub time_filter: String,
+    pub heatmap_filter: String,
+}
+
+/// 查询 Todo 统计（总数、各状态计数、定时任务数）。
+pub(super) async fn fetch_todo_stats(
+    ctx: &DashboardQueryContext<'_>,
+) -> Result<(i64, i64, i64, i64, i64, i64), sea_orm::DbErr> {
+    let sql = "SELECT \
+        COUNT(*) as total, \
+        COALESCE(SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), 0) as pending, \
+        COALESCE(SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END), 0) as running, \
+        COALESCE(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END), 0) as completed, \
+        COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed, \
+        COALESCE(SUM(CASE WHEN scheduler_enabled = 1 AND scheduler_config IS NOT NULL THEN 1 ELSE 0 END), 0) as scheduled \
+        FROM todos WHERE deleted_at IS NULL";
+
+    if let Some(row) = ctx.conn
+        .query_one(Statement::from_string(ctx.backend, sql.to_string()))
+        .await?
+    {
+        Ok((
+            row.try_get_by("total").unwrap_or(0i64),
+            row.try_get_by("pending").unwrap_or(0i64),
+            row.try_get_by("running").unwrap_or(0i64),
+            row.try_get_by("completed").unwrap_or(0i64),
+            row.try_get_by("failed").unwrap_or(0i64),
+            row.try_get_by("scheduled").unwrap_or(0i64),
+        ))
+    } else {
+        Ok((0, 0, 0, 0, 0, 0))
+    }
+}
+
+/// 查询执行记录总体统计（成功/失败数、token 总量、费用、时长）。
+pub(super) async fn fetch_execution_overall(
+    ctx: &DashboardQueryContext<'_>,
+) -> Result<(i64, i64, i64, u64, u64, u64, u64, f64, u64, u64), sea_orm::DbErr> {
+    let sql = format!(
+        "SELECT \
+        COUNT(*) as total, \
+        COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success, \
+        COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as total_cost, \
+        COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN json_extract(usage, '$.duration_ms') ELSE 0 END), 0) as total_duration, \
+        COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN 1 ELSE 0 END), 0) as duration_count \
+        FROM execution_records \
+        WHERE started_at >= {}",
+        ctx.time_filter
+    );
+
+    if let Some(row) = ctx.conn
+        .query_one(Statement::from_string(ctx.backend, sql))
+        .await?
+    {
+        let t: i64 = row.try_get_by("total").unwrap_or(0);
+        let s: i64 = row.try_get_by("success").unwrap_or(0);
+        let f: i64 = row.try_get_by("failed").unwrap_or(0);
+        let it: i64 = row.try_get_by("input_tokens").unwrap_or(0);
+        let ot: i64 = row.try_get_by("output_tokens").unwrap_or(0);
+        let cr: i64 = row.try_get_by("cache_read").unwrap_or(0);
+        let cc: i64 = row.try_get_by("cache_creation").unwrap_or(0);
+        let tc: f64 = row.try_get_by("total_cost").unwrap_or(0.0);
+        let td: i64 = row.try_get_by("total_duration").unwrap_or(0);
+        let dc: i64 = row.try_get_by("duration_count").unwrap_or(0);
+        Ok((t, s, f, it as u64, ot as u64, cr as u64, cc as u64, tc, td as u64, dc as u64))
+    } else {
+        Ok((0, 0, 0, 0, 0, 0, 0, 0.0, 0, 0))
+    }
+}
+
+/// 查询每个执行器的 Todo 数量。
+pub(super) async fn fetch_executor_todo_counts(
+    ctx: &DashboardQueryContext<'_>,
+) -> Result<HashMap<String, i64>, sea_orm::DbErr> {
+    let sql = "SELECT \
+        COALESCE(executor, 'claudecode') as executor, \
+        COUNT(*) as todo_count \
+        FROM todos WHERE deleted_at IS NULL \
+        GROUP BY COALESCE(executor, 'claudecode')";
+
+    let rows = ctx.conn
+        .query_all(Statement::from_string(ctx.backend, sql.to_string()))
+        .await?;
+
+    Ok(rows.into_iter()
+        .filter_map(|row| {
+            let exec: String = row.try_get_by("executor").ok()?;
+            let count: i64 = row.try_get_by("todo_count").ok()?;
+            Some((exec, count))
+        })
+        .collect())
+}
+
+/// 查询执行器分布（执行次数、成功/失败数、token、费用）。
+pub(super) async fn fetch_executor_distribution(
+    ctx: &DashboardQueryContext<'_>,
+    executor_todo_counts: &HashMap<String, i64>,
+) -> Result<Vec<ExecutorCount>, sea_orm::DbErr> {
+    let sql = format!(
+        "SELECT \
+        COALESCE(executor, 'claudecode') as executor, \
+        COUNT(*) as execution_count, \
+        COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
+        COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
+        FROM execution_records \
+        WHERE started_at >= {} \
+        GROUP BY COALESCE(executor, 'claudecode')",
+        ctx.time_filter
+    );
+
+    let mut distribution: Vec<ExecutorCount> = ctx.conn
+        .query_all(Statement::from_string(ctx.backend, sql))
+        .await?
+        .into_iter()
+        .filter_map(|row| {
+            let exec: String = row.try_get_by("executor").ok()?;
+            let ec: i64 = row.try_get_by("execution_count").ok()?;
+            if ec == 0 { return None; }
+            let sc: i64 = row.try_get_by("success_count").ok()?;
+            let fc: i64 = row.try_get_by("failed_count").ok()?;
+            let it: i64 = row.try_get_by("input_tokens").ok()?;
+            let ot: i64 = row.try_get_by("output_tokens").ok()?;
+            let cost: f64 = row.try_get_by("cost").ok()?;
+            Some(ExecutorCount {
+                count: *executor_todo_counts.get(&exec).unwrap_or(&0),
+                executor: exec,
+                execution_count: ec,
+                success_count: sc,
+                failed_count: fc,
+                total_input_tokens: it as u64,
+                total_output_tokens: ot as u64,
+                total_cost_usd: cost,
+            })
+        })
+        .collect();
+    distribution.sort_by(|a, b| b.execution_count.cmp(&a.execution_count));
+    Ok(distribution)
+}
+
+/// 查询模型分布。
+pub(super) async fn fetch_model_distribution(
+    ctx: &DashboardQueryContext<'_>,
+) -> Result<Vec<ModelCount>, sea_orm::DbErr> {
+    let sql = format!(
+        "SELECT \
+        COALESCE(model, 'unknown') as model, \
+        COUNT(*) as execution_count, \
+        COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
+        COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
+        FROM execution_records \
+        WHERE started_at >= {} \
+        GROUP BY COALESCE(model, 'unknown')",
+        ctx.time_filter
+    );
+
+    let mut distribution: Vec<ModelCount> = ctx.conn
+        .query_all(Statement::from_string(ctx.backend, sql))
+        .await?
+        .into_iter()
+        .filter_map(|row| {
+            let model: String = row.try_get_by("model").ok()?;
+            let ec: i64 = row.try_get_by("execution_count").ok()?;
+            if ec == 0 { return None; }
+            let sc: i64 = row.try_get_by("success_count").ok()?;
+            let fc: i64 = row.try_get_by("failed_count").ok()?;
+            let it: i64 = row.try_get_by("input_tokens").ok()?;
+            let ot: i64 = row.try_get_by("output_tokens").ok()?;
+            let cr: i64 = row.try_get_by("cache_read").ok()?;
+            let cc: i64 = row.try_get_by("cache_creation").ok()?;
+            let cost: f64 = row.try_get_by("cost").ok()?;
+            Some(ModelCount {
+                model,
+                count: 0,
+                execution_count: ec,
+                success_count: sc,
+                failed_count: fc,
+                total_input_tokens: it as u64,
+                total_output_tokens: ot as u64,
+                total_cache_read_tokens: cr as u64,
+                total_cache_creation_tokens: cc as u64,
+                total_cost_usd: cost,
+            })
+        })
+        .collect();
+    distribution.sort_by(|a, b| b.execution_count.cmp(&a.execution_count));
+    Ok(distribution)
+}
+
+/// 查询触发类型分布。
+pub(super) async fn fetch_trigger_distribution(
+    ctx: &DashboardQueryContext<'_>,
+) -> Result<Vec<TriggerTypeCount>, sea_orm::DbErr> {
+    let sql = format!(
+        "SELECT \
+        COALESCE(trigger_type, 'manual') as trigger_type, \
+        COUNT(*) as count, \
+        COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
+        COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count \
+        FROM execution_records \
+        WHERE started_at >= {} \
+        GROUP BY COALESCE(trigger_type, 'manual')",
+        ctx.time_filter
+    );
+
+    let mut distribution: Vec<TriggerTypeCount> = ctx.conn
+        .query_all(Statement::from_string(ctx.backend, sql))
+        .await?
+        .into_iter()
+        .filter_map(|row| {
+            let tt: String = row.try_get_by("trigger_type").ok()?;
+            let c: i64 = row.try_get_by("count").ok()?;
+            let sc: i64 = row.try_get_by("success_count").ok()?;
+            let fc: i64 = row.try_get_by("failed_count").ok()?;
+            Some(TriggerTypeCount {
+                trigger_type: tt,
+                count: c,
+                success_count: sc,
+                failed_count: fc,
+            })
+        })
+        .collect();
+    distribution.sort_by(|a, b| b.count.cmp(&a.count));
+    Ok(distribution)
+}
+
+/// 查询执行器平均时长。
+pub(super) async fn fetch_executor_durations(
+    ctx: &DashboardQueryContext<'_>,
+) -> Result<Vec<ExecutorDuration>, sea_orm::DbErr> {
+    let sql = format!(
+        "SELECT \
+        COALESCE(executor, 'claudecode') as executor, \
+        ROUND(AVG(json_extract(usage, '$.duration_ms')), 0) as avg_duration, \
+        COUNT(*) as execution_count \
+        FROM execution_records \
+        WHERE started_at >= {} AND json_extract(usage, '$.duration_ms') IS NOT NULL \
+        GROUP BY COALESCE(executor, 'claudecode')",
+        ctx.time_filter
+    );
+
+    let mut stats: Vec<ExecutorDuration> = ctx.conn
+        .query_all(Statement::from_string(ctx.backend, sql))
+        .await?
+        .into_iter()
+        .filter_map(|row| {
+            let exec: String = row.try_get_by("executor").ok()?;
+            let ad: f64 = row.try_get_by("avg_duration").ok()?;
+            let ec: i64 = row.try_get_by("execution_count").ok()?;
+            Some(ExecutorDuration {
+                executor: exec,
+                avg_duration_ms: ad,
+                execution_count: ec,
+            })
+        })
+        .collect();
+    stats.sort_by(|a, b| b.avg_duration_ms.partial_cmp(&a.avg_duration_ms).unwrap_or(std::cmp::Ordering::Equal));
+    Ok(stats)
+}
+
+/// 查询模型缓存统计。
+pub(super) async fn fetch_model_cache_stats(
+    ctx: &DashboardQueryContext<'_>,
+) -> Result<Vec<ModelCacheStat>, sea_orm::DbErr> {
+    let sql = format!(
+        "SELECT \
+        COALESCE(model, 'unknown') as model, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read \
+        FROM execution_records \
+        WHERE started_at >= {} AND model IS NOT NULL \
+        GROUP BY COALESCE(model, 'unknown')",
+        ctx.time_filter
+    );
+
+    let mut stats: Vec<ModelCacheStat> = ctx.conn
+        .query_all(Statement::from_string(ctx.backend, sql))
+        .await?
+        .into_iter()
+        .filter_map(|row| {
+            let model: String = row.try_get_by("model").ok()?;
+            let it: i64 = row.try_get_by("input_tokens").ok()?;
+            let cr: i64 = row.try_get_by("cache_read").ok()?;
+            let total = it as u64 + cr as u64;
+            let rate = if total > 0 { cr as f64 / total as f64 * 100.0 } else { 0.0 };
+            Some(ModelCacheStat {
+                model,
+                total_input_tokens: it as u64,
+                total_cache_read_tokens: cr as u64,
+                cache_hit_rate: rate,
+            })
+        })
+        .collect();
+    stats.sort_by(|a, b| b.cache_hit_rate.partial_cmp(&a.cache_hit_rate).unwrap_or(std::cmp::Ordering::Equal));
+    stats.retain(|m| m.total_input_tokens > 0 || m.total_cache_read_tokens > 0);
+    Ok(stats)
+}
+
+/// 查询每日执行统计（用于热力图）。
+pub(super) async fn fetch_daily_stats(
+    ctx: &DashboardQueryContext<'_>,
+    heatmap_limit: usize,
+) -> Result<(Vec<DailyExecution>, Vec<DailyTokenStats>), sea_orm::DbErr> {
+    let sql = format!(
+        "SELECT \
+        SUBSTR(COALESCE(started_at, ''), 1, 10) as day, \
+        COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success, \
+        COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
+        COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
+        FROM execution_records \
+        WHERE started_at IS NOT NULL AND LENGTH(started_at) >= 10 AND started_at >= {} \
+        GROUP BY SUBSTR(started_at, 1, 10) \
+        ORDER BY day DESC \
+        LIMIT {}",
+        ctx.heatmap_filter, heatmap_limit
+    );
+
+    let rows = ctx.conn
+        .query_all(Statement::from_string(ctx.backend, sql))
+        .await?;
+
+    let mut daily_executions = Vec::with_capacity(rows.len());
+    let mut daily_token_stats = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let day: String = row.try_get_by("day").unwrap_or_default();
+        let success: i64 = row.try_get_by("success").unwrap_or(0);
+        let failed: i64 = row.try_get_by("failed").unwrap_or(0);
+        daily_executions.push(DailyExecution {
+            date: day.clone(),
+            success,
+            failed,
+        });
+
+        let it: i64 = row.try_get_by("input_tokens").unwrap_or(0);
+        let ot: i64 = row.try_get_by("output_tokens").unwrap_or(0);
+        let cr: i64 = row.try_get_by("cache_read").unwrap_or(0);
+        let cc: i64 = row.try_get_by("cache_creation").unwrap_or(0);
+        let cost: f64 = row.try_get_by("cost").unwrap_or(0.0);
+        daily_token_stats.push(DailyTokenStats {
+            date: day,
+            input_tokens: it as u64,
+            output_tokens: ot as u64,
+            cache_read_tokens: cr as u64,
+            cache_creation_tokens: cc as u64,
+            total_cost_usd: cost,
+        });
+    }
+    daily_executions.reverse();
+    daily_token_stats.reverse();
+    Ok((daily_executions, daily_token_stats))
+}
+
+/// 查询标签分布。
+pub(super) async fn fetch_tag_distribution(
+    ctx: &DashboardQueryContext<'_>,
+    tags: &[crate::models::Tag],
+    tag_todo_counts: &HashMap<i64, i64>,
+) -> Result<Vec<TagCount>, sea_orm::DbErr> {
+    let sql = format!(
+        "SELECT \
+        tt.tag_id, \
+        COUNT(*) as execution_count, \
+        COALESCE(SUM(CASE WHEN er.status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
+        COALESCE(SUM(CASE WHEN er.status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count, \
+        COALESCE(SUM(COALESCE(json_extract(er.usage, '$.input_tokens'), 0)), 0) as input_tokens, \
+        COALESCE(SUM(COALESCE(json_extract(er.usage, '$.output_tokens'), 0)), 0) as output_tokens, \
+        COALESCE(SUM(COALESCE(json_extract(er.usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
+        FROM execution_records er \
+        INNER JOIN todo_tags tt ON tt.todo_id = er.todo_id \
+        WHERE er.todo_id IS NOT NULL AND er.started_at >= {} \
+        GROUP BY tt.tag_id",
+        ctx.time_filter
+    );
+
+    let tag_rows = ctx.conn
+        .query_all(Statement::from_string(ctx.backend, sql))
+        .await?;
+
+    let mut tag_exec_stats: HashMap<i64, (i64, i64, i64, u64, u64, f64)> = HashMap::new();
+    for row in tag_rows {
+        let tag_id: i64 = row.try_get_by("tag_id").unwrap_or(0);
+        let ec: i64 = row.try_get_by("execution_count").unwrap_or(0);
+        let sc: i64 = row.try_get_by("success_count").unwrap_or(0);
+        let fc: i64 = row.try_get_by("failed_count").unwrap_or(0);
+        let it: i64 = row.try_get_by("input_tokens").unwrap_or(0);
+        let ot: i64 = row.try_get_by("output_tokens").unwrap_or(0);
+        let cost: f64 = row.try_get_by("cost").unwrap_or(0.0);
+        tag_exec_stats.insert(tag_id, (ec, sc, fc, it as u64, ot as u64, cost));
+    }
+
+    let mut distribution: Vec<TagCount> = tags
+        .iter()
+        .filter_map(|t| {
+            let todo_count = *tag_todo_counts.get(&t.id).unwrap_or(&0);
+            if todo_count == 0 { return None; }
+            let (ec, sc, fc, it, ot, cost) = tag_exec_stats
+                .get(&t.id)
+                .copied()
+                .unwrap_or((0, 0, 0, 0, 0, 0.0));
+            Some(TagCount {
+                tag_id: t.id,
+                tag_name: t.name.clone(),
+                tag_color: t.color.clone(),
+                count: todo_count,
+                execution_count: ec,
+                success_count: sc,
+                failed_count: fc,
+                total_input_tokens: it,
+                total_output_tokens: ot,
+                total_cost_usd: cost,
+            })
+        })
+        .collect();
+    distribution.sort_by(|a, b| b.execution_count.cmp(&a.execution_count));
+    Ok(distribution)
+}
+
+/// 查询最近 10 条执行记录（轻量字段）。
+pub(super) async fn fetch_recent_executions(
+    ctx: &DashboardQueryContext<'_>,
+) -> Result<Vec<ExecutionRecord>, sea_orm::DbErr> {
+    let sql = format!(
+        "SELECT id, todo_id, executor, trigger_type, status, started_at, finished_at, usage, task_id, session_id, result, resume_message FROM execution_records \
+        WHERE started_at >= {} \
+        ORDER BY started_at DESC LIMIT 10",
+        ctx.time_filter
+    );
+
+    use crate::db::entity::execution_records;
+    let records: Vec<ExecutionRecord> = ctx.conn
+        .query_all(Statement::from_string(ctx.backend, sql))
+        .await?
+        .into_iter()
+        .map(|row| {
+            execution_records::Model {
+                id: row.try_get_by("id").unwrap_or(0),
+                todo_id: row.try_get_by("todo_id").ok(),
+                executor: row.try_get_by("executor").ok(),
+                trigger_type: row.try_get_by("trigger_type").ok(),
+                status: row.try_get_by("status").ok(),
+                started_at: row.try_get_by("started_at").ok(),
+                finished_at: row.try_get_by("finished_at").ok(),
+                usage: row.try_get_by("usage").ok(),
+                task_id: row.try_get_by("task_id").ok(),
+                session_id: row.try_get_by("session_id").ok(),
+                result: row.try_get_by("result").ok(),
+                resume_message: row.try_get_by("resume_message").ok(),
+                command: None, stdout: None, stderr: None, model: None,
+                pid: None, todo_progress: None, execution_stats: None,
+                source_todo_id: None, source_todo_title: None, source_hook_id: None,
+                rating: None, source_execution_record_id: None,
+                last_review_status: None, last_reviewed_at: None,
+            }
+        })
+        .map(Into::into)
+        .collect();
+    Ok(records)
+}
+
+/// 查询今日/昨日执行数量，计算变化率。
+pub(super) async fn fetch_execution_change(
+    ctx: &DashboardQueryContext<'_>,
+) -> Result<(i64, Option<f64>), sea_orm::DbErr> {
+    let today_sql = "SELECT COUNT(*) as count FROM execution_records WHERE date(started_at) = date('now')";
+    let yesterday_sql = "SELECT COUNT(*) as count FROM execution_records WHERE date(started_at) = date('now', '-1 day')";
+
+    let today_executions: i64 = ctx.conn
+        .query_one(Statement::from_string(ctx.backend, today_sql.to_string()))
+        .await?
+        .map(|row| row.try_get_by("count").ok().unwrap_or(0))
+        .unwrap_or(0);
+
+    let yesterday_executions: i64 = ctx.conn
+        .query_one(Statement::from_string(ctx.backend, yesterday_sql.to_string()))
+        .await?
+        .map(|row| row.try_get_by("count").ok().unwrap_or(0))
+        .unwrap_or(0);
+
+    let change = if yesterday_executions > 0 {
+        Some((today_executions as f64 - yesterday_executions as f64) / yesterday_executions as f64 * 100.0)
+    } else {
+        None
+    };
+
+    Ok((today_executions, change))
+}
+
+/// 查询今日/昨日成功率变化。
+pub(super) async fn fetch_success_rate_change(
+    ctx: &DashboardQueryContext<'_>,
+) -> Result<Option<f64>, sea_orm::DbErr> {
+    let yesterday_success: i64 = ctx.conn
+        .query_one(Statement::from_string(ctx.backend, "SELECT COUNT(*) as count FROM execution_records WHERE date(started_at) = date('now', '-1 day') AND status = 'success'".to_string()))
+        .await?
+        .map(|row| row.try_get_by("count").ok().unwrap_or(0))
+        .unwrap_or(0);
+
+    let yesterday_failed: i64 = ctx.conn
+        .query_one(Statement::from_string(ctx.backend, "SELECT COUNT(*) as count FROM execution_records WHERE date(started_at) = date('now', '-1 day') AND status = 'failed'".to_string()))
+        .await?
+        .map(|row| row.try_get_by("count").ok().unwrap_or(0))
+        .unwrap_or(0);
+
+    let today_success: i64 = ctx.conn
+        .query_one(Statement::from_string(ctx.backend, "SELECT COUNT(*) as count FROM execution_records WHERE date(started_at) = date('now') AND status = 'success'".to_string()))
+        .await?
+        .map(|row| row.try_get_by("count").ok().unwrap_or(0))
+        .unwrap_or(0);
+
+    let today_failed: i64 = ctx.conn
+        .query_one(Statement::from_string(ctx.backend, "SELECT COUNT(*) as count FROM execution_records WHERE date(started_at) = date('now') AND status = 'failed'".to_string()))
+        .await?
+        .map(|row| row.try_get_by("count").ok().unwrap_or(0))
+        .unwrap_or(0);
+
+    let yesterday_total = yesterday_success + yesterday_failed;
+    let today_total = today_success + today_failed;
+    let yesterday_rate = if yesterday_total > 0 { yesterday_success as f64 / yesterday_total as f64 * 100.0 } else { 0.0 };
+    let today_rate = if today_total > 0 { today_success as f64 / today_total as f64 * 100.0 } else { 0.0 };
+    Ok(if yesterday_total > 0 { Some(today_rate - yesterday_rate) } else { None })
+}
+
+/// 查询今日/昨日费用变化。
+pub(super) async fn fetch_cost_change(
+    ctx: &DashboardQueryContext<'_>,
+) -> Result<Option<f64>, sea_orm::DbErr> {
+    let today_cost: f64 = ctx.conn
+        .query_one(Statement::from_string(ctx.backend, "SELECT COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost FROM execution_records WHERE date(started_at) = date('now')".to_string()))
+        .await?
+        .map(|row| row.try_get_by("cost").ok().unwrap_or(0.0))
+        .unwrap_or(0.0);
+
+    let yesterday_cost: f64 = ctx.conn
+        .query_one(Statement::from_string(ctx.backend, "SELECT COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost FROM execution_records WHERE date(started_at) = date('now', '-1 day')".to_string()))
+        .await?
+        .map(|row| row.try_get_by("cost").ok().unwrap_or(0.0))
+        .unwrap_or(0.0);
+
+    Ok(if yesterday_cost > 0.0 {
+        Some((today_cost - yesterday_cost) / yesterday_cost * 100.0)
+    } else {
+        None
+    })
+}
+
+/// 计算连续活跃天数（从 daily_executions 倒序计数）。
+pub fn calculate_streak_days(daily_executions: &[DailyExecution]) -> i64 {
+    if daily_executions.is_empty() {
+        return 0;
+    }
+
+    let today_str = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let yesterday_str = (chrono::Utc::now() - chrono::Duration::days(1)).format("%Y-%m-%d").to_string();
+
+    let has_recent = daily_executions.iter().any(|d| {
+        let has_exec = d.success + d.failed > 0;
+        let is_today_or_yesterday = d.date == today_str || d.date == yesterday_str;
+        has_exec && is_today_or_yesterday
+    });
+
+    if !has_recent {
+        return 0;
+    }
+
+    let mut streak = 0i64;
+    for day in daily_executions.iter().rev() {
+        if day.success + day.failed > 0 {
+            streak += 1;
+        } else {
+            break;
+        }
+    }
+    streak
+}
+
+/// 从模型分布构建排行榜。
+pub fn build_leaderboard(model_distribution: &[ModelCount]) -> Vec<LeaderboardItem> {
+    model_distribution.iter()
+        .enumerate()
+        .map(|(i, m)| {
+            let half = model_distribution.len() / 2;
+            let change = if i < half && i + half < model_distribution.len() {
+                let first_half_tokens = model_distribution[..i+1].iter()
+                    .map(|x| x.total_input_tokens + x.total_output_tokens)
+                    .sum::<u64>() as f64;
+                let second_half_tokens = model_distribution[i..i+half].iter()
+                    .map(|x| x.total_input_tokens + x.total_output_tokens)
+                    .sum::<u64>() as f64;
+                if first_half_tokens > 0.0 {
+                    Some((second_half_tokens - first_half_tokens) / first_half_tokens * 100.0)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            LeaderboardItem {
+                rank: (i + 1) as i32,
+                name: m.model.clone(),
+                tokens: m.total_input_tokens + m.total_output_tokens,
+                sessions: m.execution_count,
+                change,
+            }
+        })
+        .collect()
+}

--- a/backend/src/db/entity/execution_records.rs
+++ b/backend/src/db/entity/execution_records.rs
@@ -1,7 +1,7 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "execution_records")]
 pub struct Model {
     #[sea_orm(primary_key)]

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -604,6 +604,9 @@ impl Database {
         )?;
 
         // 计算标签分布（需要 tags 和 tag_todo_counts）
+        // 使用 raw SQL 而非 SeaORM：GROUP BY + COUNT 聚合查询需要同时返回
+        // 两个字段并映射为 HashMap，ORM 方式会引入额外的中间结构体，
+        // raw SQL 更直接且 SeaORM 不会为这种聚合查询生成类型安全的 API。
         let tag_todo_sql = "SELECT tag_id, COUNT(*) as todo_count FROM todo_tags GROUP BY tag_id";
         let tag_todo_counts: HashMap<i64, i64> = self
             .conn

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -548,85 +548,63 @@ impl Database {
         let heatmap_filter = format!("datetime(strftime('%Y', 'now') || '-01-01 00:00:00')");
         let heatmap_limit = 366; // 闰年最多366天
 
-        let todo_sql = "SELECT \
-            COUNT(*) as total, \
-            COALESCE(SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), 0) as pending, \
-            COALESCE(SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END), 0) as running, \
-            COALESCE(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END), 0) as completed, \
-            COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed, \
-            COALESCE(SUM(CASE WHEN scheduler_enabled = 1 AND scheduler_config IS NOT NULL THEN 1 ELSE 0 END), 0) as scheduled \
-            FROM todos WHERE deleted_at IS NULL";
-
-        // Build time-filtered SQL queries
-        let overall_sql = format!(
-            "SELECT \
-            COUNT(*) as total, \
-            COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success, \
-            COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as total_cost, \
-            COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN json_extract(usage, '$.duration_ms') ELSE 0 END), 0) as total_duration, \
-            COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN 1 ELSE 0 END), 0) as duration_count \
-            FROM execution_records \
-            WHERE started_at >= {}",
-            time_filter
-        );
-
-        let (
-            total_todos,
-            pending_todos,
-            running_todos,
-            completed_todos,
-            failed_todos,
-            scheduled_todos,
-        ) = if let Some(row) = self
-            .conn
-            .query_one(Statement::from_string(backend, todo_sql.to_string()))
-            .await?
-        {
-            (
-                row.try_get_by("total").unwrap_or(0i64),
-                row.try_get_by("pending").unwrap_or(0i64),
-                row.try_get_by("running").unwrap_or(0i64),
-                row.try_get_by("completed").unwrap_or(0i64),
-                row.try_get_by("failed").unwrap_or(0i64),
-                row.try_get_by("scheduled").unwrap_or(0i64),
-            )
-        } else {
-            (0i64, 0i64, 0i64, 0i64, 0i64, 0i64)
+        // 创建查询上下文，避免在每个函数中重复传递连接和过滤条件
+        let ctx = crate::db::dashboard::DashboardQueryContext {
+            conn: &self.conn,
+            backend,
+            time_filter,
+            heatmap_filter,
         };
 
-        let tags = self.get_tags().await?;
-        let total_tags = tags.len() as i64;
+        // 并行执行独立的查询，提高性能
+        let (
+            (total_todos, pending_todos, running_todos, completed_todos, failed_todos, scheduled_todos),
+            (total_executions, success_executions, failed_executions, total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_cost, total_duration, duration_count),
+            executor_todo_counts,
+            tags_result,
+        ) = tokio::try_join!(
+            crate::db::dashboard::fetch_todo_stats(&ctx),
+            crate::db::dashboard::fetch_execution_overall(&ctx),
+            crate::db::dashboard::fetch_executor_todo_counts(&ctx),
+            self.get_tags(),
+        )?;
 
-        // Executor todo counts via SQL (replaces in-memory iteration over all todos)
-        let executor_todo_sql = "SELECT \
-            COALESCE(executor, 'claudecode') as executor, \
-            COUNT(*) as todo_count \
-            FROM todos WHERE deleted_at IS NULL \
-            GROUP BY COALESCE(executor, 'claudecode')";
+        let total_tags = tags_result.len() as i64;
 
-        let executor_todo_counts: HashMap<String, i64> = self
-            .conn
-            .query_all(Statement::from_string(
-                backend,
-                executor_todo_sql.to_string(),
-            ))
-            .await?
-            .into_iter()
-            .filter_map(|row| {
-                let exec: String = row.try_get_by("executor").ok()?;
-                let count: i64 = row.try_get_by("todo_count").ok()?;
-                Some((exec, count))
-            })
-            .collect();
+        // 计算平均时长
+        let avg_duration_ms = if duration_count > 0 {
+            total_duration / duration_count
+        } else {
+            0
+        };
 
-        // Tag todo counts via SQL (replaces fetch_tag_ids_for_many + in-memory counting)
+        // 并行执行独立的分布查询
+        let (
+            executor_distribution,
+            model_distribution,
+            trigger_type_distribution,
+            executor_duration_stats,
+            model_cache_stats,
+            (daily_executions, daily_token_stats),
+            recent_executions,
+            (today_executions, executions_change),
+            success_rate_change,
+            cost_change,
+        ) = tokio::try_join!(
+            crate::db::dashboard::fetch_executor_distribution(&ctx, &executor_todo_counts),
+            crate::db::dashboard::fetch_model_distribution(&ctx),
+            crate::db::dashboard::fetch_trigger_distribution(&ctx),
+            crate::db::dashboard::fetch_executor_durations(&ctx),
+            crate::db::dashboard::fetch_model_cache_stats(&ctx),
+            crate::db::dashboard::fetch_daily_stats(&ctx, heatmap_limit),
+            crate::db::dashboard::fetch_recent_executions(&ctx),
+            crate::db::dashboard::fetch_execution_change(&ctx),
+            crate::db::dashboard::fetch_success_rate_change(&ctx),
+            crate::db::dashboard::fetch_cost_change(&ctx),
+        )?;
+
+        // 计算标签分布（需要 tags 和 tag_todo_counts）
         let tag_todo_sql = "SELECT tag_id, COUNT(*) as todo_count FROM todo_tags GROUP BY tag_id";
-
         let tag_todo_counts: HashMap<i64, i64> = self
             .conn
             .query_all(Statement::from_string(backend, tag_todo_sql.to_string()))
@@ -639,511 +617,21 @@ impl Database {
             })
             .collect();
 
-        let (
-            total_executions,
-            success_executions,
-            failed_executions,
-            total_input_tokens,
-            total_output_tokens,
-            total_cache_read_tokens,
-            total_cache_creation_tokens,
-            total_cost,
-            total_duration,
-            duration_count,
-        ) = if let Some(row) = self
-            .conn
-            .query_one(Statement::from_string(backend, overall_sql.to_string()))
-            .await?
-        {
-            let t: i64 = row.try_get_by("total").unwrap_or(0);
-            let s: i64 = row.try_get_by("success").unwrap_or(0);
-            let f: i64 = row.try_get_by("failed").unwrap_or(0);
-            let it: i64 = row.try_get_by("input_tokens").unwrap_or(0);
-            let ot: i64 = row.try_get_by("output_tokens").unwrap_or(0);
-            let cr: i64 = row.try_get_by("cache_read").unwrap_or(0);
-            let cc: i64 = row.try_get_by("cache_creation").unwrap_or(0);
-            let tc: f64 = row.try_get_by("total_cost").unwrap_or(0.0);
-            let td: i64 = row.try_get_by("total_duration").unwrap_or(0);
-            let dc: i64 = row.try_get_by("duration_count").unwrap_or(0);
-            (
-                t, s, f, it as u64, ot as u64, cr as u64, cc as u64, tc, td as u64, dc as u64,
-            )
-        } else {
-            (0, 0, 0, 0u64, 0u64, 0u64, 0u64, 0.0f64, 0u64, 0u64)
-        };
+        let tag_distribution = crate::db::dashboard::fetch_tag_distribution(
+            &ctx, &tags_result, &tag_todo_counts,
+        ).await?;
 
-        let avg_duration_ms = if duration_count > 0 {
-            total_duration / duration_count
-        } else {
-            0
-        };
-
-        // 3. Executor distribution via SQL
-        let executor_sql = format!(
-            "SELECT \
-            COALESCE(executor, 'claudecode') as executor, \
-            COUNT(*) as execution_count, \
-            COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
-            COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
-            FROM execution_records \
-            WHERE started_at >= {} \
-            GROUP BY COALESCE(executor, 'claudecode')",
-            time_filter
-        );
-
-        let mut executor_distribution: Vec<crate::models::ExecutorCount> = self
-            .conn
-            .query_all(Statement::from_string(backend, executor_sql.to_string()))
-            .await?
-            .into_iter()
-            .filter_map(|row| {
-                let exec: String = row.try_get_by("executor").ok()?;
-                let ec: i64 = row.try_get_by("execution_count").ok()?;
-                if ec == 0 {
-                    return None;
-                }
-                let sc: i64 = row.try_get_by("success_count").ok()?;
-                let fc: i64 = row.try_get_by("failed_count").ok()?;
-                let it: i64 = row.try_get_by("input_tokens").ok()?;
-                let ot: i64 = row.try_get_by("output_tokens").ok()?;
-                let cost: f64 = row.try_get_by("cost").ok()?;
-                Some(crate::models::ExecutorCount {
-                    count: *executor_todo_counts.get(&exec).unwrap_or(&0),
-                    executor: exec,
-                    execution_count: ec,
-                    success_count: sc,
-                    failed_count: fc,
-                    total_input_tokens: it as u64,
-                    total_output_tokens: ot as u64,
-                    total_cost_usd: cost,
-                })
-            })
-            .collect();
-        executor_distribution.sort_by(|a, b| b.execution_count.cmp(&a.execution_count));
-
-        // 4. Model distribution via SQL
-        let model_sql = format!(
-            "SELECT \
-            COALESCE(model, 'unknown') as model, \
-            COUNT(*) as execution_count, \
-            COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
-            COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
-            FROM execution_records \
-            WHERE started_at >= {} \
-            GROUP BY COALESCE(model, 'unknown')",
-            time_filter
-        );
-
-        let mut model_distribution: Vec<crate::models::ModelCount> = self
-            .conn
-            .query_all(Statement::from_string(backend, model_sql.to_string()))
-            .await?
-            .into_iter()
-            .filter_map(|row| {
-                let model: String = row.try_get_by("model").ok()?;
-                let ec: i64 = row.try_get_by("execution_count").ok()?;
-                if ec == 0 {
-                    return None;
-                }
-                let sc: i64 = row.try_get_by("success_count").ok()?;
-                let fc: i64 = row.try_get_by("failed_count").ok()?;
-                let it: i64 = row.try_get_by("input_tokens").ok()?;
-                let ot: i64 = row.try_get_by("output_tokens").ok()?;
-                let cr: i64 = row.try_get_by("cache_read").ok()?;
-                let cc: i64 = row.try_get_by("cache_creation").ok()?;
-                let cost: f64 = row.try_get_by("cost").ok()?;
-                Some(crate::models::ModelCount {
-                    model,
-                    count: 0,
-                    execution_count: ec,
-                    success_count: sc,
-                    failed_count: fc,
-                    total_input_tokens: it as u64,
-                    total_output_tokens: ot as u64,
-                    total_cache_read_tokens: cr as u64,
-                    total_cache_creation_tokens: cc as u64,
-                    total_cost_usd: cost,
-                })
-            })
-            .collect();
-        model_distribution.sort_by(|a, b| b.execution_count.cmp(&a.execution_count));
-
-        // Trigger type distribution
-        let trigger_sql = format!(
-            "SELECT \
-            COALESCE(trigger_type, 'manual') as trigger_type, \
-            COUNT(*) as count, \
-            COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
-            COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count \
-            FROM execution_records \
-            WHERE started_at >= {} \
-            GROUP BY COALESCE(trigger_type, 'manual')",
-            time_filter
-        );
-
-        let mut trigger_type_distribution: Vec<crate::models::TriggerTypeCount> = self.conn
-            .query_all(Statement::from_string(backend, trigger_sql.to_string()))
-            .await?
-            .into_iter()
-            .filter_map(|row| {
-                let tt: String = row.try_get_by("trigger_type").ok()?;
-                let c: i64 = row.try_get_by("count").ok()?;
-                let sc: i64 = row.try_get_by("success_count").ok()?;
-                let fc: i64 = row.try_get_by("failed_count").ok()?;
-                Some(crate::models::TriggerTypeCount {
-                    trigger_type: tt,
-                    count: c,
-                    success_count: sc,
-                    failed_count: fc,
-                })
-            })
-            .collect();
-        trigger_type_distribution.sort_by(|a, b| b.count.cmp(&a.count));
-
-        // Executor average duration
-        let duration_sql = format!(
-            "SELECT \
-            COALESCE(executor, 'claudecode') as executor, \
-            ROUND(AVG(json_extract(usage, '$.duration_ms')), 0) as avg_duration, \
-            COUNT(*) as execution_count \
-            FROM execution_records \
-            WHERE started_at >= {} AND json_extract(usage, '$.duration_ms') IS NOT NULL \
-            GROUP BY COALESCE(executor, 'claudecode')",
-            time_filter
-        );
-
-        let mut executor_duration_stats: Vec<crate::models::ExecutorDuration> = self.conn
-            .query_all(Statement::from_string(backend, duration_sql.to_string()))
-            .await?
-            .into_iter()
-            .filter_map(|row| {
-                let exec: String = row.try_get_by("executor").ok()?;
-                let ad: f64 = row.try_get_by("avg_duration").ok()?;
-                let ec: i64 = row.try_get_by("execution_count").ok()?;
-                Some(crate::models::ExecutorDuration {
-                    executor: exec,
-                    avg_duration_ms: ad,
-                    execution_count: ec,
-                })
-            })
-            .collect();
-        executor_duration_stats.sort_by(|a, b| b.avg_duration_ms.partial_cmp(&a.avg_duration_ms).unwrap_or(std::cmp::Ordering::Equal));
-
-        // Model cache stats
-        let cache_sql = format!(
-            "SELECT \
-            COALESCE(model, 'unknown') as model, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read \
-            FROM execution_records \
-            WHERE started_at >= {} AND model IS NOT NULL \
-            GROUP BY COALESCE(model, 'unknown')",
-            time_filter
-        );
-
-        let mut model_cache_stats: Vec<crate::models::ModelCacheStat> = self.conn
-            .query_all(Statement::from_string(backend, cache_sql.to_string()))
-            .await?
-            .into_iter()
-            .filter_map(|row| {
-                let model: String = row.try_get_by("model").ok()?;
-                let it: i64 = row.try_get_by("input_tokens").ok()?;
-                let cr: i64 = row.try_get_by("cache_read").ok()?;
-                let total = it as u64 + cr as u64;
-                let rate = if total > 0 { cr as f64 / total as f64 * 100.0 } else { 0.0 };
-                Some(crate::models::ModelCacheStat {
-                    model,
-                    total_input_tokens: it as u64,
-                    total_cache_read_tokens: cr as u64,
-                    cache_hit_rate: rate,
-                })
-            })
-            .collect();
-        model_cache_stats.sort_by(|a, b| b.cache_hit_rate.partial_cmp(&a.cache_hit_rate).unwrap_or(std::cmp::Ordering::Equal));
-        model_cache_stats.retain(|m| m.total_input_tokens > 0 || m.total_cache_read_tokens > 0);
-
-        // 5. Daily execution stats via SQL (热力图使用固定当年范围)
-        let daily_sql = format!(
-            "SELECT \
-            SUBSTR(COALESCE(started_at, ''), 1, 10) as day, \
-            COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success, \
-            COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
-            COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
-            FROM execution_records \
-            WHERE started_at IS NOT NULL AND LENGTH(started_at) >= 10 AND started_at >= {} \
-            GROUP BY SUBSTR(started_at, 1, 10) \
-            ORDER BY day DESC \
-            LIMIT {}",
-            heatmap_filter, heatmap_limit
-        );
-
-        let daily_rows = self
-            .conn
-            .query_all(Statement::from_string(backend, daily_sql.to_string()))
-            .await?;
-
-        let mut daily_executions: Vec<crate::models::DailyExecution> =
-            Vec::with_capacity(daily_rows.len());
-        let mut daily_token_stats: Vec<crate::models::DailyTokenStats> =
-            Vec::with_capacity(daily_rows.len());
-        for row in &daily_rows {
-            let day: String = row.try_get_by("day").unwrap_or_default();
-            let success: i64 = row.try_get_by("success").unwrap_or(0);
-            let failed: i64 = row.try_get_by("failed").unwrap_or(0);
-            daily_executions.push(crate::models::DailyExecution {
-                date: day.clone(),
-                success,
-                failed,
-            });
-
-            let it: i64 = row.try_get_by("input_tokens").unwrap_or(0);
-            let ot: i64 = row.try_get_by("output_tokens").unwrap_or(0);
-            let cr: i64 = row.try_get_by("cache_read").unwrap_or(0);
-            let cc: i64 = row.try_get_by("cache_creation").unwrap_or(0);
-            let cost: f64 = row.try_get_by("cost").unwrap_or(0.0);
-            daily_token_stats.push(crate::models::DailyTokenStats {
-                date: day,
-                input_tokens: it as u64,
-                output_tokens: ot as u64,
-                cache_read_tokens: cr as u64,
-                cache_creation_tokens: cc as u64,
-                total_cost_usd: cost,
-            });
-        }
-        daily_executions.reverse();
-        daily_token_stats.reverse();
-
-        // 6. Tag distribution via SQL (join through todo_tags)
-        let tag_sql = format!(
-            "SELECT \
-            tt.tag_id, \
-            COUNT(*) as execution_count, \
-            COALESCE(SUM(CASE WHEN er.status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
-            COALESCE(SUM(CASE WHEN er.status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count, \
-            COALESCE(SUM(COALESCE(json_extract(er.usage, '$.input_tokens'), 0)), 0) as input_tokens, \
-            COALESCE(SUM(COALESCE(json_extract(er.usage, '$.output_tokens'), 0)), 0) as output_tokens, \
-            COALESCE(SUM(COALESCE(json_extract(er.usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
-            FROM execution_records er \
-            INNER JOIN todo_tags tt ON tt.todo_id = er.todo_id \
-            WHERE er.todo_id IS NOT NULL AND er.started_at >= {} \
-            GROUP BY tt.tag_id",
-            time_filter
-        );
-
-        let tag_rows = self
-            .conn
-            .query_all(Statement::from_string(backend, tag_sql.to_string()))
-            .await?;
-
-        let mut tag_exec_stats: HashMap<i64, (i64, i64, i64, u64, u64, f64)> = HashMap::new();
-        for row in tag_rows {
-            let tag_id: i64 = row.try_get_by("tag_id").unwrap_or(0);
-            let ec: i64 = row.try_get_by("execution_count").unwrap_or(0);
-            let sc: i64 = row.try_get_by("success_count").unwrap_or(0);
-            let fc: i64 = row.try_get_by("failed_count").unwrap_or(0);
-            let it: i64 = row.try_get_by("input_tokens").unwrap_or(0);
-            let ot: i64 = row.try_get_by("output_tokens").unwrap_or(0);
-            let cost: f64 = row.try_get_by("cost").unwrap_or(0.0);
-            tag_exec_stats.insert(tag_id, (ec, sc, fc, it as u64, ot as u64, cost));
-        }
-
-        let mut tag_distribution: Vec<crate::models::TagCount> = tags
-            .iter()
-            .filter_map(|t| {
-                let todo_count = *tag_todo_counts.get(&t.id).unwrap_or(&0);
-                if todo_count == 0 {
-                    return None;
-                }
-                let (ec, sc, fc, it, ot, cost) = tag_exec_stats
-                    .get(&t.id)
-                    .copied()
-                    .unwrap_or((0, 0, 0, 0, 0, 0.0));
-                Some(crate::models::TagCount {
-                    tag_id: t.id,
-                    tag_name: t.name.clone(),
-                    tag_color: t.color.clone(),
-                    count: todo_count,
-                    execution_count: ec,
-                    success_count: sc,
-                    failed_count: fc,
-                    total_input_tokens: it,
-                    total_output_tokens: ot,
-                    total_cost_usd: cost,
-                })
-            })
-            .collect();
-        tag_distribution.sort_by(|a, b| b.execution_count.cmp(&a.execution_count));
-
-        // 7. Recent executions (only load 10 rows, not the entire table)
-        // Note: Only essential fields are loaded for performance; logs, stdout, stderr,
-        // command, model, pid, todo_progress, execution_stats are omitted as they're large
-        let recent_sql = format!(
-            "SELECT id, todo_id, executor, trigger_type, status, started_at, finished_at, usage, task_id, session_id, result, resume_message FROM execution_records \
-            WHERE started_at >= {} \
-            ORDER BY started_at DESC LIMIT 10",
-            time_filter
-        );
-        let recent_records: Vec<execution_records::Model> = self
-            .conn
-            .query_all(Statement::from_string(backend, recent_sql))
-            .await?
-            .into_iter()
-            .map(|row| {
-                execution_records::Model {
-                    id: row.try_get_by("id").unwrap_or(0),
-                    todo_id: row.try_get_by("todo_id").ok(),
-                    executor: row.try_get_by("executor").ok(),
-                    trigger_type: row.try_get_by("trigger_type").ok(),
-                    status: row.try_get_by("status").ok(),
-                    started_at: row.try_get_by("started_at").ok(),
-                    finished_at: row.try_get_by("finished_at").ok(),
-                    usage: row.try_get_by("usage").ok(),
-                    task_id: row.try_get_by("task_id").ok(),
-                    session_id: row.try_get_by("session_id").ok(),
-                    result: row.try_get_by("result").ok(),
-                    resume_message: row.try_get_by("resume_message").ok(),
-                    command: None,
-                    stdout: None,
-                    stderr: None,
-                    model: None,
-                    pid: None,
-                    todo_progress: None,
-                    execution_stats: None,
-                    source_todo_id: None,
-                    source_todo_title: None,
-                    source_hook_id: None,
-                    rating: None,
-                    source_execution_record_id: None,
-                    last_review_status: None,
-                    last_reviewed_at: None,
-                }
-            })
-            .collect();
-
-        let recent_executions: Vec<crate::models::ExecutionRecord> =
-            recent_records.into_iter().map(Into::into).collect();
-
-        // Calculate enhanced metrics
-        // Today and yesterday executions for change calculation
-        let today_sql = "SELECT COUNT(*) as count FROM execution_records WHERE date(started_at) = date('now')";
-        let yesterday_sql = "SELECT COUNT(*) as count FROM execution_records WHERE date(started_at) = date('now', '-1 day')";
-
-        let today_executions: i64 = self.conn
-            .query_one(Statement::from_string(backend, today_sql.to_string()))
-            .await?
-            .and_then(|row| row.try_get_by("count").ok())
-            .unwrap_or(0);
-
-        let yesterday_executions: i64 = self.conn
-            .query_one(Statement::from_string(backend, yesterday_sql.to_string()))
-            .await?
-            .and_then(|row| row.try_get_by("count").ok())
-            .unwrap_or(0);
-
-        let executions_change = if yesterday_executions > 0 {
-            Some((today_executions as f64 - yesterday_executions as f64) / yesterday_executions as f64 * 100.0)
-        } else {
-            None
-        };
-
-        // Success rate change (today vs yesterday)
-        let yesterday_success_sql = "SELECT COUNT(*) as count FROM execution_records WHERE date(started_at) = date('now', '-1 day') AND status = 'success'";
-        let yesterday_failed_sql = "SELECT COUNT(*) as count FROM execution_records WHERE date(started_at) = date('now', '-1 day') AND status = 'failed'";
-        let today_success_sql = "SELECT COUNT(*) as count FROM execution_records WHERE date(started_at) = date('now') AND status = 'success'";
-        let today_failed_sql = "SELECT COUNT(*) as count FROM execution_records WHERE date(started_at) = date('now') AND status = 'failed'";
-
-        let yesterday_success: i64 = self.conn
-            .query_one(Statement::from_string(backend, yesterday_success_sql.to_string()))
-            .await?
-            .and_then(|row| row.try_get_by("count").ok())
-            .unwrap_or(0);
-        let yesterday_failed: i64 = self.conn
-            .query_one(Statement::from_string(backend, yesterday_failed_sql.to_string()))
-            .await?
-            .and_then(|row| row.try_get_by("count").ok())
-            .unwrap_or(0);
-        let today_success: i64 = self.conn
-            .query_one(Statement::from_string(backend, today_success_sql.to_string()))
-            .await?
-            .and_then(|row| row.try_get_by("count").ok())
-            .unwrap_or(0);
-        let today_failed: i64 = self.conn
-            .query_one(Statement::from_string(backend, today_failed_sql.to_string()))
-            .await?
-            .and_then(|row| row.try_get_by("count").ok())
-            .unwrap_or(0);
-
-        let yesterday_total = yesterday_success + yesterday_failed;
-        let today_total = today_success + today_failed;
-        let yesterday_rate = if yesterday_total > 0 { yesterday_success as f64 / yesterday_total as f64 * 100.0 } else { 0.0 };
-        let today_rate = if today_total > 0 { today_success as f64 / today_total as f64 * 100.0 } else { 0.0 };
-        let success_rate_change = if yesterday_total > 0 { Some(today_rate - yesterday_rate) } else { None };
-
-        // Cost change (today vs yesterday)
-        let today_cost_sql = "SELECT COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost FROM execution_records WHERE date(started_at) = date('now')";
-        let yesterday_cost_sql = "SELECT COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost FROM execution_records WHERE date(started_at) = date('now', '-1 day')";
-        let today_cost: f64 = self.conn
-            .query_one(Statement::from_string(backend, today_cost_sql.to_string()))
-            .await?
-            .and_then(|row| row.try_get_by("cost").ok())
-            .unwrap_or(0.0);
-        let yesterday_cost: f64 = self.conn
-            .query_one(Statement::from_string(backend, yesterday_cost_sql.to_string()))
-            .await?
-            .and_then(|row| row.try_get_by("cost").ok())
-            .unwrap_or(0.0);
-        let cost_change = if yesterday_cost > 0.0 {
-            Some((today_cost - yesterday_cost) / yesterday_cost * 100.0)
-        } else {
-            None
-        };
-
-        // Active days and streak days from daily_executions
+        // 计算连续活跃天数
         let active_days = daily_executions.len() as i64;
+        let streak_days = crate::db::dashboard::calculate_streak_days(&daily_executions);
 
-        let mut streak_days = 0i64;
-        if !daily_executions.is_empty() {
-            let today_str = chrono::Utc::now().format("%Y-%m-%d").to_string();
-            let yesterday_str = (chrono::Utc::now() - chrono::Duration::days(1)).format("%Y-%m-%d").to_string();
-
-            // Check if today or yesterday has executions (streak must include recent days)
-            let has_recent = daily_executions.iter().any(|d| {
-                let has_exec = d.success + d.failed > 0;
-                let is_today_or_yesterday = d.date == today_str || d.date == yesterday_str;
-                has_exec && is_today_or_yesterday
-            });
-
-            if has_recent {
-                // Count consecutive days with executions (must be recent to count)
-                for day in daily_executions.iter().rev() {
-                    if day.success + day.failed > 0 {
-                        streak_days += 1;
-                    } else {
-                        break;
-                    }
-                }
-            }
-        }
-
-        // Peak daily executions
+        // 计算峰值每日执行数
         let peak_daily_executions = daily_executions.iter()
             .map(|d| d.success + d.failed)
             .max()
             .unwrap_or(0);
 
-        // Top model by tokens
+        // 找出最佳模型
         let (top_model, top_model_tokens) = if !model_distribution.is_empty() {
             let top = model_distribution.iter()
                 .max_by_key(|m| m.total_input_tokens + m.total_output_tokens)
@@ -1153,35 +641,11 @@ impl Database {
             (None, None)
         };
 
-        // Build leaderboard from model distribution
-        let leaderboard: Vec<crate::models::LeaderboardItem> = model_distribution.iter()
-            .enumerate()
-            .map(|(i, m)| {
-                // Calculate change (simplified: compare first half vs second half of the period)
-                let half = model_distribution.len() / 2;
-                let change = if i < half && i + half < model_distribution.len() {
-                    let first_half_tokens = model_distribution[..i+1].iter().map(|x| x.total_input_tokens + x.total_output_tokens).sum::<u64>() as f64;
-                    let second_half_tokens = model_distribution[i..i+half].iter().map(|x| x.total_input_tokens + x.total_output_tokens).sum::<u64>() as f64;
-                    if first_half_tokens > 0.0 {
-                        Some((second_half_tokens - first_half_tokens) / first_half_tokens * 100.0)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-                crate::models::LeaderboardItem {
-                    rank: (i + 1) as i32,
-                    name: m.model.clone(),
-                    tokens: m.total_input_tokens + m.total_output_tokens,
-                    sessions: m.execution_count,
-                    change,
-                }
-            })
-            .collect();
+        // 构建排行榜
+        let leaderboard = crate::db::dashboard::build_leaderboard(&model_distribution);
 
-        // Skills invocation statistics
-        let skills_stats = match self.get_skills_stats(&time_filter).await {
+        // Skills 统计
+        let skills_stats = match self.get_skills_stats(&ctx.time_filter).await {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!("Failed to load skills stats: {}", e);
@@ -1189,7 +653,7 @@ impl Database {
             }
         };
 
-        // Backup statistics (filesystem scan)
+        // Backup 统计
         let backup_stats = match self.get_backup_stats().await {
             Ok(v) => v,
             Err(e) => {

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -585,7 +585,7 @@ impl Database {
             0
         };
 
-        // 并行执行独立的分布查询
+        // 并行执行独立的分布查询（tag_todo_counts 一并纳入避免串行等待）
         let (
             executor_distribution,
             model_distribution,
@@ -597,6 +597,7 @@ impl Database {
             (today_executions, executions_change),
             success_rate_change,
             cost_change,
+            tag_todo_counts,
         ) = tokio::try_join!(
             crate::db::dashboard::fetch_executor_distribution(&ctx, &executor_todo_counts),
             crate::db::dashboard::fetch_model_distribution(&ctx),
@@ -608,25 +609,26 @@ impl Database {
             crate::db::dashboard::fetch_execution_change(&ctx),
             crate::db::dashboard::fetch_success_rate_change(&ctx),
             crate::db::dashboard::fetch_cost_change(&ctx),
+            // tag_todo_counts 是独立的 GROUP BY 查询，不依赖其他结果，
+            // 并入 try_join 能使 11 个查询并行执行，减少总体等待时间
+            async {
+                let sql = "SELECT tag_id, COUNT(*) as todo_count FROM todo_tags GROUP BY tag_id";
+                let rows = self.conn
+                    .query_all(Statement::from_string(backend, sql.to_string()))
+                    .await?;
+                let map: HashMap<i64, i64> = rows.into_iter()
+                    .filter_map(|row| {
+                        let tag_id: i64 = row.try_get_by("tag_id").ok()?;
+                        let count: i64 = row.try_get_by("todo_count").ok()?;
+                        Some((tag_id, count))
+                    })
+                    .collect();
+                Ok(map)
+            },
         )?;
 
-        // 计算标签分布（需要 tags 和 tag_todo_counts）
-        // 使用 raw SQL 而非 SeaORM：GROUP BY + COUNT 聚合查询需要同时返回
-        // 两个字段并映射为 HashMap，ORM 方式会引入额外的中间结构体，
-        // raw SQL 更直接且 SeaORM 不会为这种聚合查询生成类型安全的 API。
-        let tag_todo_sql = "SELECT tag_id, COUNT(*) as todo_count FROM todo_tags GROUP BY tag_id";
-        let tag_todo_counts: HashMap<i64, i64> = self
-            .conn
-            .query_all(Statement::from_string(backend, tag_todo_sql.to_string()))
-            .await?
-            .into_iter()
-            .filter_map(|row| {
-                let tag_id: i64 = row.try_get_by("tag_id").ok()?;
-                let count: i64 = row.try_get_by("todo_count").ok()?;
-                Some((tag_id, count))
-            })
-            .collect();
-
+        // 标签分布计算（tags_result 已从第一轮 try_join 获取，
+        // tag_todo_counts 已从第二轮 try_join 获取）
         let tag_distribution = crate::db::dashboard::fetch_tag_distribution(
             &ctx, &tags_result, &tag_todo_counts,
         ).await?;

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -556,7 +556,14 @@ impl Database {
             heatmap_filter,
         };
 
-        // 并行执行独立的查询，提高性能
+        // 并行执行独立的查询，提高性能。
+        // 关于 &self.conn 的并发安全性：
+        // self.conn 是 sea_orm::DatabaseConnection（PR #477 后底层是 sqlx Pool，
+        // max_connections=10），传递 &self.conn 给每个 fetch_* 函数，
+        // fetch_* 内部调用 query_all() 时会从池中 acquire() 不同连接。
+        // 多个 future 在 tokio::try_join! 中交错执行时，pool 调度确保
+        // 同一连接不会被两个查询同时占用，因此这里真正能做到并行查询。
+        // 不用担心"单连接顺序 await"——那是裸 &ConnectionTrait 直拿单一连接的情况。
         let (
             (total_todos, pending_todos, running_todos, completed_todos, failed_todos, scheduled_todos),
             (total_executions, success_executions, failed_executions, total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_cost, total_duration, duration_count),

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -584,6 +584,7 @@ impl Database {
 mod todo;
 pub use todo::{SchedulerUpdate, TodoUpdate};
 pub mod execution;
+pub(super) mod dashboard;
 mod tag;
 pub use execution::NewExecutionRecord;
 mod agent_bot;

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -377,6 +377,12 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     let todo_title = todo.as_ref().map(|t| t.title.clone()).unwrap_or_default();
     let execution_timeout_secs = timeout_secs;
 
+    // 将 task_guard 移入 tokio::spawn 闭包，使其存活到执行结束。
+    // 若不这么做，外层 run_todo_execution 返回时 guard 即 drop，
+    // 导致 manager.remove 被调用、Sender 被丢弃、cancel_rx 的 channel 关闭，
+    // select! 中 cancel_rx.recv() 立即返回 None，误触发取消流程。
+    let _task_guard = task_guard;
+
     // 注册任务信息，用于 WebSocket 同步
     task_manager
         .register_info(crate::task_manager::TaskInfo {
@@ -410,6 +416,9 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
 
     tokio::spawn(
         async move {
+        // 将 _task_guard 移入异步闭包，使其存活到整个执行周期。
+        // 若不绑定，外层 drop 时会误删 Sender 导致 cancel_rx.recv() 返回 None。
+        let _task_guard = _task_guard;
         let execution_start = std::time::Instant::now();
 
         send_event(

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -1262,6 +1262,13 @@ mod run_todo_execution_request_tests {
 /// 格式化超时秒数为人类可读字符串。
 ///
 /// 使用 hours for >=60 min, days for >=24 h to keep the output readable.
+/// 精度取舍：只精确到分钟级别（秒数只在 <60s 时显示），后端 timeout 精度
+/// 为秒级，分钟以上的秒数误差在 UI 上无感知差异。
+///
+/// 边界情况：
+/// - 0 秒 → "0 min"（表示无超时限制）
+/// - 60-3599 秒 → "X min Y sec" 格式
+/// - 3600+ 秒 → "X hour(s)" 或 "X day(s)"
 fn format_timeout_secs(secs: u64) -> String {
     let total_min = secs / 60;
     let remaining_secs = secs % 60;
@@ -1282,6 +1289,18 @@ fn format_timeout_secs(secs: u64) -> String {
 ///
 /// 单次遍历日志，计算 tool_calls、conversation_turns、thinking_count。
 /// 如果 executor 提供了自己的 tool_calls_count，则使用 executor 的值。
+///
+/// 设计意图：
+/// - 不同 executor 的 tool_use 事件格式各异，部分 executor（如 hermes）
+///   有自己的工具调用计数器，比日志解析更准确。
+/// - conversation_turns 通过文本/结果/助手事件计数，估算 AI 交互轮次。
+/// - thinking_count 用于展示 AI 思考过程的复杂度。
+///
+/// 统计逻辑：
+/// - tool_use/tool_call/tool → 工具调用（使用 executor 提供的值覆盖，见后文）
+/// - assistant/result/text → 对话轮次（每个文本输出算一轮）
+/// - thinking → 思考次数
+/// - 其他 log_type 跳过
 fn extract_execution_stats(
     logs: &[crate::models::ParsedLogEntry],
     executor_tool_calls: Option<u64>,

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -657,23 +657,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
         let timeout_enabled = execution_timeout_secs > 0;
         // Non-zero values are guaranteed >= 60 by normalize_paths clamp, so from_secs is safe.
         let timeout_duration = std::time::Duration::from_secs(execution_timeout_secs);
-        // Human-readable timeout string for display messages (always English).
-        // Uses hours for >=60 min, days for >=24 h to keep the output readable.
-        let timeout_str = {
-            let total_min = execution_timeout_secs / 60;
-            let secs = execution_timeout_secs % 60;
-            if secs == 0 {
-                if total_min >= 1440 {
-                    format!("{} day(s)", total_min / 1440)
-                } else if total_min >= 60 {
-                    format!("{} hour(s)", total_min / 60)
-                } else {
-                    format!("{} min", total_min)
-                }
-            } else {
-                format!("{} min {} sec", total_min, secs)
-            }
-        };
+        let timeout_str = format_timeout_secs(execution_timeout_secs);
         let timeout_sleep = tokio::time::sleep(timeout_duration);
         tokio::pin!(timeout_sleep);
 
@@ -842,27 +826,7 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
             .unwrap_or_default();
 
         // Extract execution stats from logs in single pass
-        let (tool_calls, conversation_turns, thinking_count) = {
-            let mut tc = 0u64;
-            let mut ct = 0u64;
-            let mut th = 0u64;
-            for l in &all_logs_snapshot {
-                match l.log_type.as_str() {
-                    "tool_use" | "tool_call" | "tool" => tc += 1,
-                    "assistant" | "result" | "text" => ct += 1,
-                    "thinking" => th += 1,
-                    _ => {}
-                }
-            }
-            (tc, ct, th)
-        };
-        // Override tool_calls if executor provides its own count
-        let tool_calls = executor_spawn.get_tool_calls_count().unwrap_or(tool_calls);
-        let execution_stats = crate::models::ExecutionStats {
-            tool_calls,
-            conversation_turns,
-            thinking_count,
-        };
+        let execution_stats = extract_execution_stats(&all_logs_snapshot, executor_spawn.get_tool_calls_count());
         if let Ok(stats_json) = serde_json::to_string(&execution_stats) {
             let _ = db_clone
                 .update_execution_record_stats(record_id, &stats_json)
@@ -1284,16 +1248,107 @@ mod run_todo_execution_request_tests {
     fn _hook_service_field_is_arc_hook_service(r: &RunTodoExecutionRequest) -> &Arc<HookService> {
         &r.hook_service
     }
+}
 
-    /// 真正的单元测试：调用上面的投影函数并断言返回值类型。
-    /// 即便实际未运行过实际 fire，类型系统也保证 hook_service 字段
-    /// 的形状没有被破坏。
+/// 格式化超时秒数为人类可读字符串。
+///
+/// 使用 hours for >=60 min, days for >=24 h to keep the output readable.
+fn format_timeout_secs(secs: u64) -> String {
+    let total_min = secs / 60;
+    let remaining_secs = secs % 60;
+    if remaining_secs == 0 {
+        if total_min >= 1440 {
+            format!("{} day(s)", total_min / 1440)
+        } else if total_min >= 60 {
+            format!("{} hour(s)", total_min / 60)
+        } else {
+            format!("{} min", total_min)
+        }
+    } else {
+        format!("{} min {} sec", total_min, remaining_secs)
+    }
+}
+
+/// 从日志中提取执行统计信息。
+///
+/// 单次遍历日志，计算 tool_calls、conversation_turns、thinking_count。
+/// 如果 executor 提供了自己的 tool_calls_count，则使用 executor 的值。
+fn extract_execution_stats(
+    logs: &[crate::models::ParsedLogEntry],
+    executor_tool_calls: Option<u64>,
+) -> crate::models::ExecutionStats {
+    let mut tool_calls = 0u64;
+    let mut conversation_turns = 0u64;
+    let mut thinking_count = 0u64;
+
+    for l in logs {
+        match l.log_type.as_str() {
+            "tool_use" | "tool_call" | "tool" => tool_calls += 1,
+            "assistant" | "result" | "text" => conversation_turns += 1,
+            "thinking" => thinking_count += 1,
+            _ => {}
+        }
+    }
+
+    // Override tool_calls if executor provides its own count
+    let tool_calls = executor_tool_calls.unwrap_or(tool_calls);
+
+    crate::models::ExecutionStats {
+        tool_calls,
+        conversation_turns,
+        thinking_count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
     #[test]
-    fn hook_service_field_shape_is_preserved() {
-        let f: fn(&RunTodoExecutionRequest) -> &Arc<HookService> =
-            _hook_service_field_is_arc_hook_service;
-        // 触达 `_hook_service_field_is_arc_hook_service` 避免 dead_code
-        // 警告把它当未使用函数优化掉。
-        let _: fn(&RunTodoExecutionRequest) -> &Arc<HookService> = f;
+    fn test_format_timeout_secs() {
+        assert_eq!(format_timeout_secs(0), "0 min");
+        assert_eq!(format_timeout_secs(60), "1 min");
+        assert_eq!(format_timeout_secs(90), "1 min 30 sec");
+        assert_eq!(format_timeout_secs(3600), "1 hour(s)");
+        assert_eq!(format_timeout_secs(86400), "1 day(s)");
+        assert_eq!(format_timeout_secs(7200), "2 hour(s)");
+    }
+
+    #[test]
+    fn test_extract_execution_stats() {
+        let logs = vec![
+            crate::models::ParsedLogEntry {
+                log_type: "tool_use".to_string(),
+                ..Default::default()
+            },
+            crate::models::ParsedLogEntry {
+                log_type: "assistant".to_string(),
+                ..Default::default()
+            },
+            crate::models::ParsedLogEntry {
+                log_type: "thinking".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        let stats = extract_execution_stats(&logs, None);
+        assert_eq!(stats.tool_calls, 1);
+        assert_eq!(stats.conversation_turns, 1);
+        assert_eq!(stats.thinking_count, 1);
+    }
+
+    #[test]
+    fn test_extract_execution_stats_with_executor_override() {
+        let logs = vec![
+            crate::models::ParsedLogEntry {
+                log_type: "tool_use".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        let stats = extract_execution_stats(&logs, Some(5));
+        assert_eq!(stats.tool_calls, 5); // overridden
+        assert_eq!(stats.conversation_turns, 0);
+        assert_eq!(stats.thinking_count, 0);
     }
 }

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -377,12 +377,6 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     let todo_title = todo.as_ref().map(|t| t.title.clone()).unwrap_or_default();
     let execution_timeout_secs = timeout_secs;
 
-    // 将 task_guard 移入 tokio::spawn 闭包，使其存活到执行结束。
-    // 若不这么做，外层 run_todo_execution 返回时 guard 即 drop，
-    // 导致 manager.remove 被调用、Sender 被丢弃、cancel_rx 的 channel 关闭，
-    // select! 中 cancel_rx.recv() 立即返回 None，误触发取消流程。
-    let _task_guard = task_guard;
-
     // 注册任务信息，用于 WebSocket 同步
     task_manager
         .register_info(crate::task_manager::TaskInfo {
@@ -416,9 +410,9 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
 
     tokio::spawn(
         async move {
-        // 将 _task_guard 移入异步闭包，使其存活到整个执行周期。
+        // 将 task_guard 移入异步闭包，使其存活到整个执行周期。
         // 若不绑定，外层 drop 时会误删 Sender 导致 cancel_rx.recv() 返回 None。
-        let _task_guard = _task_guard;
+        let _task_guard = task_guard;
         let execution_start = std::time::Instant::now();
 
         send_event(

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -20,19 +20,30 @@ use crate::services::usage_stats::UsageStatsService;
 /// 数据库备份压缩级别 (0-9, 9 为最强压缩)
 const BACKUP_COMPRESSION_LEVEL: Option<i64> = Some(9);
 
-/// 检查文件名是否安全（不包含路径分隔符或目录遍历序列）。
+/// 检查文件名是否安全（不包含路径分隔符、目录遍历序列或控制字符）。
 ///
-/// 用于防止路径遍历攻击：用户传入的文件名如果包含 `/`、`\` 或 `..`，
+/// 用于防止路径遍历攻击：用户传入的文件名如果包含 `/`、`\`、`..`，
 /// 可能导致操作目标目录之外的文件。
+/// 同时拦截 NUL（`\0`）：POSIX 文件系统拒绝文件名包含 NUL（Rust 路径库会 panic），
+/// Windows 也拒绝；其他控制字符（`\n` `\r` `\t` 等）虽然在大多数文件系统上能写入，
+/// 但会带来日志注入、shell 转义等次生风险。
 fn is_safe_filename(name: &str) -> bool {
-    !name.contains('/') && !name.contains('\\') && !name.contains("..")
+    if name.is_empty() || name.contains('/') || name.contains('\\') || name.contains("..") {
+        return false;
+    }
+    // 仅允许可打印 ASCII + 常见 Unicode 字符；任何控制字符（含 \0）直接拒绝。
+    name.chars()
+        .all(|c| !c.is_control() && (c.is_ascii_graphic() || c == ' ' || !c.is_ascii()))
 }
 
 /// 清理旧的 ZIP 备份文件，只保留最近 `keep` 个。
 ///
 /// 通用函数，适用于数据库备份、Todo 备份、Skill 备份等所有 ZIP 备份目录。
-/// 按文件创建时间倒序排列，删除超过 `keep` 数量的旧文件。
-/// 文件创建时间不可用时（某些文件系统不支持），视为最旧文件优先删除。
+/// 按文件时间倒序排列，删除超过 `keep` 数量的旧文件。
+/// 时间读取采用 created() → modified() 的二级 fallback：
+/// - macOS、exFAT 等部分文件系统不支持 created()，会返回 Err；
+/// - modified() 几乎所有文件系统都支持，作为兜底；
+/// - 都拿不到时间时（极端情况：被外部删了）才退回 UNIX_EPOCH 视为最旧。
 fn cleanup_old_zip_backups(dir: &PathBuf, keep: usize) {
     if !dir.exists() {
         return;
@@ -52,17 +63,17 @@ fn cleanup_old_zip_backups(dir: &PathBuf, keep: usize) {
         return;
     }
 
-    // 按创建时间倒序排列；
-    // 创建时间不可用的文件（某些文件系统不支持 created()）使用 UNIX_EPOCH，
-    // 确保它们排在最前面（最旧），优先被删除。
+    // 取得文件的最佳可用时间：created 优先（更符合「备份创建时间」语义），
+    // 不可用时回退到 modified，最后兜底 UNIX_EPOCH。
+    let file_time = |p: &PathBuf| -> std::time::SystemTime {
+        std::fs::metadata(p)
+            .and_then(|m| m.created().or_else(|_| m.modified()))
+            .unwrap_or(std::time::UNIX_EPOCH)
+    };
+    // 按时间倒序排列；时间相同的文件用 path 作为 tie-breaker，保证排序稳定可预测。
     files.sort_by(|a, b| {
-        let a_time = std::fs::metadata(a)
-            .and_then(|m| m.created())
-            .unwrap_or(std::time::UNIX_EPOCH);
-        let b_time = std::fs::metadata(b)
-            .and_then(|m| m.created())
-            .unwrap_or(std::time::UNIX_EPOCH);
-        b_time.cmp(&a_time)
+        let ord = file_time(b).cmp(&file_time(a));
+        ord.then_with(|| a.cmp(b))
     });
 
     for old_file in files.iter().skip(keep) {

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -32,6 +32,7 @@ fn is_safe_filename(name: &str) -> bool {
 ///
 /// 通用函数，适用于数据库备份、Todo 备份、Skill 备份等所有 ZIP 备份目录。
 /// 按文件创建时间倒序排列，删除超过 `keep` 数量的旧文件。
+/// 文件创建时间不可用时（某些文件系统不支持），视为最旧文件优先删除。
 fn cleanup_old_zip_backups(dir: &PathBuf, keep: usize) {
     if !dir.exists() {
         return;
@@ -51,14 +52,24 @@ fn cleanup_old_zip_backups(dir: &PathBuf, keep: usize) {
         return;
     }
 
+    // 按创建时间倒序排列；
+    // 创建时间不可用的文件（某些文件系统不支持 created()）使用 UNIX_EPOCH，
+    // 确保它们排在最前面（最旧），优先被删除。
     files.sort_by(|a, b| {
-        let a_time = std::fs::metadata(a).and_then(|m| m.created()).ok();
-        let b_time = std::fs::metadata(b).and_then(|m| m.created()).ok();
+        let a_time = std::fs::metadata(a)
+            .and_then(|m| m.created())
+            .unwrap_or(std::time::UNIX_EPOCH);
+        let b_time = std::fs::metadata(b)
+            .and_then(|m| m.created())
+            .unwrap_or(std::time::UNIX_EPOCH);
         b_time.cmp(&a_time)
     });
 
     for old_file in files.iter().skip(keep) {
-        std::fs::remove_file(old_file).ok();
+        if let Err(e) = std::fs::remove_file(old_file) {
+            // 记录删除失败（不中断流程），确保一个文件的失败不影响其他旧文件的清理
+            tracing::warn!("Failed to remove old backup {:?}: {}", old_file, e);
+        }
     }
 }
 

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -20,6 +20,48 @@ use crate::services::usage_stats::UsageStatsService;
 /// 数据库备份压缩级别 (0-9, 9 为最强压缩)
 const BACKUP_COMPRESSION_LEVEL: Option<i64> = Some(9);
 
+/// 检查文件名是否安全（不包含路径分隔符或目录遍历序列）。
+///
+/// 用于防止路径遍历攻击：用户传入的文件名如果包含 `/`、`\` 或 `..`，
+/// 可能导致操作目标目录之外的文件。
+fn is_safe_filename(name: &str) -> bool {
+    !name.contains('/') && !name.contains('\\') && !name.contains("..")
+}
+
+/// 清理旧的 ZIP 备份文件，只保留最近 `keep` 个。
+///
+/// 通用函数，适用于数据库备份、Todo 备份、Skill 备份等所有 ZIP 备份目录。
+/// 按文件创建时间倒序排列，删除超过 `keep` 数量的旧文件。
+fn cleanup_old_zip_backups(dir: &PathBuf, keep: usize) {
+    if !dir.exists() {
+        return;
+    }
+    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)
+        .ok()
+        .map(|entries| {
+            entries
+                .flatten()
+                .map(|e| e.path())
+                .filter(|p| p.extension().is_some_and(|ext| ext == "zip"))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if files.len() <= keep {
+        return;
+    }
+
+    files.sort_by(|a, b| {
+        let a_time = std::fs::metadata(a).and_then(|m| m.created()).ok();
+        let b_time = std::fs::metadata(b).and_then(|m| m.created()).ok();
+        b_time.cmp(&a_time)
+    });
+
+    for old_file in files.iter().skip(keep) {
+        std::fs::remove_file(old_file).ok();
+    }
+}
+
 /// 导出备份（返回 YAML 格式字符串）
 pub async fn export_backup(
     State(state): State<AppState>,
@@ -248,7 +290,7 @@ pub async fn trigger_local_backup(
     .map_err(|e| AppError::Internal(format!("Failed to create zip backup: {}", e)))?;
 
     // 清理旧备份（按数据库分目录清理）
-    cleanup_old_db_backups(&dir, max_files);
+    cleanup_old_zip_backups(&dir, max_files);
 
     Ok(ApiResponse::ok(format!("备份成功: {}", backup_path.display())))
 }
@@ -418,7 +460,7 @@ pub async fn delete_backup_file(
     axum::Json(req): axum::Json<DeleteBackupRequest>,
 ) -> Result<ApiResponse<String>, AppError> {
     // 安全检查：文件名不能包含路径分隔符
-    if req.filename.contains('/') || req.filename.contains('\\') || req.filename.contains("..") {
+    if !is_safe_filename(&req.filename) {
         return Err(AppError::BadRequest("Invalid filename".to_string()));
     }
 
@@ -453,7 +495,7 @@ pub async fn download_backup_file(
     State(state): State<AppState>,
     Query(query): Query<DownloadBackupQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    if query.filename.contains('/') || query.filename.contains('\\') || query.filename.contains("..") {
+    if !is_safe_filename(&query.filename) {
         return Err(AppError::BadRequest("Invalid filename".to_string()));
     }
 
@@ -501,7 +543,7 @@ pub async fn delete_todo_backup_file(
     axum::Json(req): axum::Json<DeleteTodoBackupRequest>,
 ) -> Result<ApiResponse<String>, AppError> {
     // 安全检查：文件名不能包含路径分隔符
-    if req.filename.contains('/') || req.filename.contains('\\') || req.filename.contains("..") {
+    if !is_safe_filename(&req.filename) {
         return Err(AppError::BadRequest("Invalid filename".to_string()));
     }
     let path = todo_backup_dir().join(&req.filename);
@@ -524,7 +566,7 @@ pub struct DownloadTodoBackupQuery {
 pub async fn download_todo_backup_file(
     Query(query): Query<DownloadTodoBackupQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    if query.filename.contains('/') || query.filename.contains('\\') || query.filename.contains("..") {
+    if !is_safe_filename(&query.filename) {
         return Err(AppError::BadRequest("Invalid filename".to_string()));
     }
     let path = todo_backup_dir().join(&query.filename);
@@ -590,7 +632,7 @@ pub fn perform_database_backup(db_path: &str, max_files: usize) -> Result<String
     zip.finish()
         .map_err(|e| format!("Failed to finish zip: {}", e))?;
 
-    cleanup_old_db_backups(&dir, max_files);
+    cleanup_old_zip_backups(&dir, max_files);
 
     Ok(format!("Auto backup: {}", backup_path.display()))
 }
@@ -621,36 +663,6 @@ pub async fn cleanup_old_logs(db: &Database, days: usize) -> Result<u64, String>
         .unwrap_or(0) as u64;
 
     Ok(changes)
-}
-
-fn cleanup_old_db_backups(dir: &PathBuf, keep: usize) {
-    if !dir.exists() {
-        return;
-    }
-    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)
-        .ok()
-        .map(|entries| {
-            entries
-                .flatten()
-                .map(|e| e.path())
-                .filter(|p| p.extension().is_some_and(|ext| ext == "zip"))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    if files.len() <= keep {
-        return;
-    }
-
-    files.sort_by(|a, b| {
-        let a_time = std::fs::metadata(a).and_then(|m| m.created()).ok();
-        let b_time = std::fs::metadata(b).and_then(|m| m.created()).ok();
-        b_time.cmp(&a_time)
-    });
-
-    for old_file in files.iter().skip(keep) {
-        std::fs::remove_file(old_file).ok();
-    }
 }
 
 /// 启动自动备份定时任务
@@ -820,7 +832,7 @@ pub async fn trigger_todo_backup(
     .map_err(|e| AppError::Internal(format!("Failed to create zip: {}", e)))?;
 
     // 清理旧备份
-    cleanup_old_todo_backups(&dir, max_files);
+    cleanup_old_zip_backups(&dir, max_files);
 
     Ok(ApiResponse::ok(format!("备份成功: {}", backup_path_display)))
 }
@@ -989,41 +1001,11 @@ async fn perform_todo_backup_async(db: &std::sync::Arc<crate::db::Database>, max
     // Cleanup old backups
     let dir_for_cleanup = dir.clone();
     tokio::task::spawn_blocking(move || {
-        cleanup_old_todo_backups(&dir_for_cleanup, max_files);
+        cleanup_old_zip_backups(&dir_for_cleanup, max_files);
     }).await
     .map_err(|e| format!("Task join error: {}", e))?;
 
     Ok(format!("Auto Todo backup: {}", backup_path_for_display))
-}
-
-fn cleanup_old_todo_backups(dir: &PathBuf, keep: usize) {
-    if !dir.exists() {
-        return;
-    }
-    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)
-        .ok()
-        .map(|entries| {
-            entries
-                .flatten()
-                .map(|e| e.path())
-                .filter(|p| p.extension().is_some_and(|ext| ext == "zip"))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    if files.len() <= keep {
-        return;
-    }
-
-    files.sort_by(|a, b| {
-        let a_time = std::fs::metadata(a).and_then(|m| m.created()).ok();
-        let b_time = std::fs::metadata(b).and_then(|m| m.created()).ok();
-        b_time.cmp(&a_time)
-    });
-
-    for old_file in files.iter().skip(keep) {
-        std::fs::remove_file(old_file).ok();
-    }
 }
 
 // ============ 日志清理 ============
@@ -1343,7 +1325,7 @@ pub async fn trigger_skill_backup(
     .map_err(|e| AppError::Internal(format!("Failed to create zip: {}", e)))?;
 
     // 清理旧备份
-    cleanup_old_skill_backups(&dir, max_files);
+    cleanup_old_zip_backups(&dir, max_files);
 
     Ok(ApiResponse::ok(format!("备份成功: {} ({} 个文件)", backup_path_display, copied_count)))
 }
@@ -1435,7 +1417,7 @@ pub async fn delete_skill_backup_file(
     axum::Json(req): axum::Json<DeleteSkillBackupRequest>,
 ) -> Result<ApiResponse<String>, AppError> {
     // 安全检查：文件名不能包含路径分隔符
-    if req.filename.contains('/') || req.filename.contains('\\') || req.filename.contains("..") {
+    if !is_safe_filename(&req.filename) {
         return Err(AppError::BadRequest("Invalid filename".to_string()));
     }
     let path = skill_backup_dir().join(&req.filename);
@@ -1458,7 +1440,7 @@ pub struct DownloadSkillBackupQuery {
 pub async fn download_skill_backup_file(
     Query(query): Query<DownloadSkillBackupQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    if query.filename.contains('/') || query.filename.contains('\\') || query.filename.contains("..") {
+    if !is_safe_filename(&query.filename) {
         return Err(AppError::BadRequest("Invalid filename".to_string()));
     }
     let path = skill_backup_dir().join(&query.filename);
@@ -1483,36 +1465,6 @@ pub async fn download_skill_backup_file(
 }
 
 /// 清理旧 Skill 备份
-fn cleanup_old_skill_backups(dir: &PathBuf, keep: usize) {
-    if !dir.exists() {
-        return;
-    }
-    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)
-        .ok()
-        .map(|entries| {
-            entries
-                .flatten()
-                .map(|e| e.path())
-                .filter(|p| p.extension().is_some_and(|ext| ext == "zip"))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    if files.len() <= keep {
-        return;
-    }
-
-    files.sort_by(|a, b| {
-        let a_time = std::fs::metadata(a).and_then(|m| m.created()).ok();
-        let b_time = std::fs::metadata(b).and_then(|m| m.created()).ok();
-        b_time.cmp(&a_time)
-    });
-
-    for old_file in files.iter().skip(keep) {
-        std::fs::remove_file(old_file).ok();
-    }
-}
-
 /// Start Skill auto backup scheduler
 pub fn start_skill_auto_backup(
     config: std::sync::Arc<std::sync::RwLock<crate::config::Config>>,
@@ -1729,7 +1681,7 @@ async fn perform_skill_backup_async(max_files: usize) -> Result<String, String> 
     // 清理旧备份
     let dir_for_cleanup = dir.clone();
     tokio::task::spawn_blocking(move || {
-        cleanup_old_skill_backups(&dir_for_cleanup, max_files);
+        cleanup_old_zip_backups(&dir_for_cleanup, max_files);
     }).await
     .map_err(|e| format!("Task join error: {}", e))?;
 

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -269,7 +269,7 @@ pub struct TodoItem {
     pub status: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ParsedLogEntry {
     pub timestamp: String,
     #[serde(rename = "type")]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { SettingsPage } from './components/SettingsPage';
 import { ExecutionPanel } from './components/ExecutionPanel';
 import { TodoDrawer } from './components/TodoDrawer';
 import { SmartCreateModal } from './components/SmartCreateModal';
+import { EXECUTION_PANEL, SIDEBAR_WIDTH } from './constants';
 import * as db from './utils/database';
 import type { Config } from './types';
 import zhCN from 'antd/locale/zh_CN';
@@ -43,7 +44,7 @@ function AppContent() {
   useExecutionEvents();
 
   const hasRunningTasks = Object.keys(state.runningTasks).length > 0;
-  const panelHeight = hasRunningTasks ? (panelCollapsed ? 40 : 280) : 0;
+  const panelHeight = hasRunningTasks ? (panelCollapsed ? EXECUTION_PANEL.collapsed : EXECUTION_PANEL.expanded) : 0;
 
   // Load app config on mount
   useEffect(() => {
@@ -142,7 +143,7 @@ function AppContent() {
           <div
             className={(!isMobile || selectedPanel === 'list') ? 'animate-fade-in' : ''}
             style={{
-              width: isMobile ? '100%' : 350,
+              width: isMobile ? SIDEBAR_WIDTH.mobile : SIDEBAR_WIDTH.desktop,
               flexShrink: 0,
               height: '100%',
               display: !isMobile || selectedPanel === 'list' ? 'block' : 'none',

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -122,16 +122,7 @@ export function parseLogsToMessages(logs: LogEntry[]): ChatMessage[] {
   return messages;
 }
 
-function formatTime(iso?: string): string {
-  if (!iso) return '';
-  try {
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) return '';
-    return d.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
-  } catch {
-    return '';
-  }
-}
+import { formatTimeFull } from '@/utils/format';
 
 // 卡片类型配置
 const CARD_CONFIG = {
@@ -208,7 +199,7 @@ function CollapsibleCard({
           )}
         </div>
         <div className="chat-card-header-right">
-          {timestamp && <span className="chat-card-time">{formatTime(timestamp)}</span>}
+          {timestamp && <span className="chat-card-time">{formatTimeFull(timestamp)}</span>}
           <span className="chat-card-toggle" style={{ color: config.color }}>
             {expanded ? <DownOutlined /> : <RightOutlined />}
           </span>
@@ -326,7 +317,7 @@ function ChatBubble({ message }: { message: ChatMessage }) {
         <div className="chat-bubble-content">
           <XMarkdown content={content} />
         </div>
-        {timestamp && <div className="chat-bubble-time">{formatTime(timestamp)}</div>}
+        {timestamp && <div className="chat-bubble-time">{formatTimeFull(timestamp)}</div>}
       </div>
     </div>
   );

--- a/frontend/src/components/ExecutionPanel.tsx
+++ b/frontend/src/components/ExecutionPanel.tsx
@@ -5,7 +5,7 @@ import { useApp } from '@/hooks/useApp';
 import { useTheme } from '@/hooks/useTheme';
 import { getExecutorOption } from '@/types';
 import { stopExecution } from '@/utils/database';
-import { formatLocalDateTime, formatDuration } from '@/utils/datetime';
+import { formatLocalDateTime, formatDurationSec } from '@/utils/datetime';
 
 // Light theme log colors
 const lightLogTypeColors: Record<string, string> = {
@@ -211,7 +211,7 @@ export function ExecutionPanel({ collapsed, onToggleCollapse }: ExecutionPanelPr
                             <span style={{ fontWeight: 600 }}>开始时间:</span> {formatLocalDateTime(task.startedAt)}
                           </div>
                           <div style={{ fontSize: 11, color: 'var(--color-info)', fontWeight: 600 }}>
-                            <span style={{ fontWeight: 600 }}>已运行:</span> {formatDuration(getElapsedSeconds(task.startedAt))}
+                            <span style={{ fontWeight: 600 }}>已运行:</span> {formatDurationSec(getElapsedSeconds(task.startedAt))}
                           </div>
                         </div>
                       }

--- a/frontend/src/components/RunningBoard.tsx
+++ b/frontend/src/components/RunningBoard.tsx
@@ -20,16 +20,11 @@ import {
   useAutoRefreshRunningBoard,
 } from '@/hooks/useRunningBoard';
 import { formatRelativeTime } from '@/utils/datetime';
+import { formatDuration } from '@/utils/format';
+import { STATUS_COLORS } from '@/constants';
 import type { ExecutionRecord, ScheduledTodo, RunningBoardColumn } from '@/types';
 
 /* ─── Helpers ─── */
-
-function formatDuration(ms: number | null): string {
-  if (!ms) return '-';
-  if (ms < 1_000) return `${ms}ms`;
-  if (ms < 60_000) return `${(ms / 1_000).toFixed(0)}s`;
-  return `${(ms / 60_000).toFixed(1)}m`;
-}
 
 function formatNextRunAt(nextRunAt: string | null): string {
   if (!nextRunAt) return '-';
@@ -386,27 +381,27 @@ export function RunningBoard({ searchText, hours, selectedProject }: RunningBoar
     <div className="running-board">
       {/* Stats bar */}
       <div className="running-board-stats">
-        <span className="running-stat-item" style={{ color: '#8b5cf6' }}>
+        <span className="running-stat-item" style={{ color: STATUS_COLORS.scheduled }}>
           待触发 <strong>{stats.scheduled}</strong>
         </span>
         <span className="running-stat-divider" />
-        <span className="running-stat-item" style={{ color: '#f59e0b' }}>
+        <span className="running-stat-item" style={{ color: STATUS_COLORS.running }}>
           运行中 <strong>{stats.running}</strong>
         </span>
         <span className="running-stat-divider" />
-        <span className="running-stat-item" style={{ color: '#22c55e' }}>
+        <span className="running-stat-item" style={{ color: STATUS_COLORS.success }}>
           已完成 <strong>{stats.completed}</strong>
         </span>
         <span className="running-stat-divider" />
-        <span className="running-stat-item" style={{ color: '#06b6d4' }}>
+        <span className="running-stat-item" style={{ color: STATUS_COLORS.reviewing }}>
           评审中 <strong>{stats.reviewing}</strong>
         </span>
         <span className="running-stat-divider" />
-        <span className="running-stat-item" style={{ color: '#10b981' }}>
+        <span className="running-stat-item" style={{ color: STATUS_COLORS.reviewPassed }}>
           评审通过 <strong>{stats.review_passed}</strong>
         </span>
         <span className="running-stat-divider" />
-        <span className="running-stat-item" style={{ color: '#ef4444' }}>
+        <span className="running-stat-item" style={{ color: STATUS_COLORS.failed }}>
           失败 <strong>{stats.failed}</strong>
         </span>
         <span className="running-stat-divider" />

--- a/frontend/src/components/RunningRecordDrawer.tsx
+++ b/frontend/src/components/RunningRecordDrawer.tsx
@@ -14,7 +14,7 @@ import { useApp } from '@/hooks/useApp';
 import { useViewState } from '@/hooks/useViewState';
 import { formatLocalDateTime } from '@/utils/datetime';
 import { formatTokens, formatDuration, elapsedSeconds } from '@/utils/format';
-import { LOG_TYPE_COLORS, STATUS_COLORS } from '@/constants';
+import { LOG_TYPE_COLORS, STATUS_COLORS, REVIEW_RESULT_COLORS } from '@/constants';
 import * as db from '@/utils/database';
 import type { ExecutionRecord, LogEntry } from '@/types';
 
@@ -77,10 +77,10 @@ function RatingControl({ record, onRate }: { record: ExecutionRecord; onRate: (i
 function ReviewStatusBadge({ status }: { status?: string | null }) {
   if (!status) return null;
   const map: Record<string, { color: string; text: string }> = {
-    pending: { color: STATUS_COLORS.reviewing, text: '评审中' },
-    success: { color: STATUS_COLORS.reviewPassed, text: '评审通过' },
-    failed: { color: STATUS_COLORS.reviewFailed, text: '评审失败' },
-    interrupted: { color: STATUS_COLORS.reviewInterrupted, text: '评审中断' },
+    pending: { color: REVIEW_RESULT_COLORS.pending, text: '评审中' },
+    success: { color: REVIEW_RESULT_COLORS.success, text: '评审通过' },
+    failed: { color: REVIEW_RESULT_COLORS.failed, text: '评审失败' },
+    interrupted: { color: REVIEW_RESULT_COLORS.interrupted, text: '评审中断' },
     skipped: { color: '#6b7280', text: '评审跳过' },
   };
   const info = map[status];

--- a/frontend/src/components/RunningRecordDrawer.tsx
+++ b/frontend/src/components/RunningRecordDrawer.tsx
@@ -170,6 +170,9 @@ export function RunningRecordDrawer({ record, open, onClose, onRefresh }: Runnin
 
   if (!record) return null;
 
+  // 统一使用毫秒作为 duration 单位，与 formatDuration(ms) 签名一致。
+  // 优先使用后端记录的 duration_ms，运行时中的记录则通过 started_at 实时计算。
+  // elapsedSeconds 返回秒，需 * 1000 转换为毫秒。
   const duration = record.usage?.duration_ms || (isRunning ? elapsedSeconds(record.started_at) * 1000 : null);
 
   return (
@@ -253,7 +256,7 @@ export function RunningRecordDrawer({ record, open, onClose, onRefresh }: Runnin
         {duration != null && (
           <div>
             <span style={{ color: 'var(--color-text-tertiary)' }}>耗时：</span>
-            <span style={{ fontWeight: 600 }}>{formatDuration(duration / 1000)}</span>
+            <span style={{ fontWeight: 600 }}>{formatDuration(duration)}</span>
           </div>
         )}
       </div>

--- a/frontend/src/components/RunningRecordDrawer.tsx
+++ b/frontend/src/components/RunningRecordDrawer.tsx
@@ -173,7 +173,8 @@ export function RunningRecordDrawer({ record, open, onClose, onRefresh }: Runnin
   // 统一使用毫秒作为 duration 单位，与 formatDuration(ms) 签名一致。
   // 优先使用后端记录的 duration_ms，运行时中的记录则通过 started_at 实时计算。
   // elapsedSeconds 返回秒，需 * 1000 转换为毫秒。
-  const duration = record.usage?.duration_ms || (isRunning ? elapsedSeconds(record.started_at) * 1000 : null);
+  // 使用 ?? 而非 ||：duration_ms === 0 时是合法值（任务瞬间完成），不应回退到实时计算。
+  const duration = record.usage?.duration_ms ?? (isRunning ? elapsedSeconds(record.started_at) * 1000 : null);
 
   return (
     <Drawer

--- a/frontend/src/components/RunningRecordDrawer.tsx
+++ b/frontend/src/components/RunningRecordDrawer.tsx
@@ -12,29 +12,13 @@ import XMarkdown from '@ant-design/x-markdown';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { useApp } from '@/hooks/useApp';
 import { useViewState } from '@/hooks/useViewState';
-import { formatLocalDateTime, formatDuration } from '@/utils/datetime';
+import { formatLocalDateTime } from '@/utils/datetime';
+import { formatTokens, formatDuration, elapsedSeconds } from '@/utils/format';
+import { LOG_TYPE_COLORS, STATUS_COLORS } from '@/constants';
 import * as db from '@/utils/database';
 import type { ExecutionRecord, LogEntry } from '@/types';
 
 /* ─── Helpers ─── */
-
-function getElapsedSeconds(startedAt: string): number {
-  const start = new Date(startedAt).getTime();
-  return Math.max(0, Math.floor((Date.now() - start) / 1000));
-}
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return String(n);
-}
-
-const LOG_TYPE_COLORS: Record<string, string> = {
-  info: '#6b7280', stdout: '#3b82f6', stderr: '#ef4444', error: '#ef4444',
-  tool_use: '#8b5cf6', tool_call: '#8b5cf6', tool_result: '#10b981',
-  assistant: '#0ea5e9', user: '#f59e0b', system: '#6b7280', thinking: '#a855f7',
-  result: '#22c55e', step_start: '#06b6d4', step_finish: '#06b6d4', tokens: '#6b7280',
-};
 
 const LOG_TYPE_LABELS: Record<string, string> = {
   info: 'INFO', stdout: 'OUT', stderr: 'ERR', error: 'ERROR',
@@ -93,10 +77,10 @@ function RatingControl({ record, onRate }: { record: ExecutionRecord; onRate: (i
 function ReviewStatusBadge({ status }: { status?: string | null }) {
   if (!status) return null;
   const map: Record<string, { color: string; text: string }> = {
-    pending: { color: '#06b6d4', text: '评审中' },
-    success: { color: '#10b981', text: '评审通过' },
-    failed: { color: '#ef4444', text: '评审失败' },
-    interrupted: { color: '#f59e0b', text: '评审中断' },
+    pending: { color: STATUS_COLORS.reviewing, text: '评审中' },
+    success: { color: STATUS_COLORS.reviewPassed, text: '评审通过' },
+    failed: { color: STATUS_COLORS.reviewFailed, text: '评审失败' },
+    interrupted: { color: STATUS_COLORS.reviewInterrupted, text: '评审中断' },
     skipped: { color: '#6b7280', text: '评审跳过' },
   };
   const info = map[status];
@@ -186,7 +170,7 @@ export function RunningRecordDrawer({ record, open, onClose, onRefresh }: Runnin
 
   if (!record) return null;
 
-  const duration = record.usage?.duration_ms || (isRunning ? getElapsedSeconds(record.started_at) * 1000 : null);
+  const duration = record.usage?.duration_ms || (isRunning ? elapsedSeconds(record.started_at) * 1000 : null);
 
   return (
     <Drawer
@@ -194,7 +178,7 @@ export function RunningRecordDrawer({ record, open, onClose, onRefresh }: Runnin
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <span style={{
             display: 'inline-block', width: 8, height: 8, borderRadius: '50%',
-            backgroundColor: isRunning ? '#f59e0b' : record.status === 'success' ? '#22c55e' : '#ef4444',
+            backgroundColor: isRunning ? STATUS_COLORS.running : record.status === 'success' ? STATUS_COLORS.success : STATUS_COLORS.failed,
           }} />
           <span>执行记录 #{record.id}</span>
           <Tag color={isRunning ? 'orange' : record.status === 'success' ? 'green' : 'red'}>
@@ -244,7 +228,7 @@ export function RunningRecordDrawer({ record, open, onClose, onRefresh }: Runnin
       <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginBottom: 16 }}>
         {record.executor && <ExecutorBadge executor={record.executor} />}
         {record.model && <Tag color="#3b82f6">{record.model}</Tag>}
-        <Tag color={record.trigger_type === 'cron' ? '#8b5cf6' : record.trigger_type.startsWith('hook:') ? '#a855f7' : '#6b7280'}>
+        <Tag color={record.trigger_type === 'cron' ? STATUS_COLORS.scheduled : record.trigger_type.startsWith('hook:') ? STATUS_COLORS.hook : '#6b7280'}>
           {record.trigger_type === 'cron' ? 'Cron' : record.trigger_type.startsWith('hook:') ? 'Hook' : record.trigger_type === 'manual' ? '手动' : record.trigger_type}
         </Tag>
         {record.source_todo_id && (

--- a/frontend/src/components/TodoCard.tsx
+++ b/frontend/src/components/TodoCard.tsx
@@ -11,20 +11,7 @@ import {
 } from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
 import { ExecutorBadge } from './ExecutorBadge';
-
-/* ─── Format helpers ─── */
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return String(n);
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 1_000) return `${ms}ms`;
-  if (ms < 60_000) return `${(ms / 1_000).toFixed(0)}s`;
-  return `${(ms / 60_000).toFixed(1)}m`;
-}
+import { formatTokens, formatDuration } from '@/utils/format';
 
 /* ─── Types ─── */
 

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -6,6 +6,7 @@ import { Button, Empty, App, Pagination, Modal, Input, Select } from 'antd';
 import { CheckCircleOutlined, ReloadOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { TodoDrawer } from './TodoDrawer';
 import { parseLogsToMessages } from './ChatView';
+import { BREAKPOINTS, EXPORT } from '@/constants';
 import * as db from '@/utils/database';
 import { conversationToYaml } from '@/utils/markdown';
 import { getExecutorOption } from '@/types';
@@ -22,7 +23,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
   const { message } = App.useApp();
   const { todos, selectedTodoId, executionRecords, runningTasks } = state;
   const isMobile = useIsMobile();
-  const isWide = !useIsMobile(1440);
+  const isWide = !useIsMobile(BREAKPOINTS.wide);
   const [viewMode, setViewMode] = useState<'log' | 'chat'>('log');
   const selectedTodo = todos.find(t => t.id === selectedTodoId);
 
@@ -233,7 +234,7 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
   const handleExportMarkdown = async (record: ExecutionRecord) => {
     let logs: LogEntry[] = [];
     try {
-      const result = await db.getExecutionLogs(record.id, 1, 100000);
+      const result = await db.getExecutionLogs(record.id, 1, EXPORT.maxLogs);
       logs = result.logs;
     } catch {
       // ignore

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -124,10 +124,16 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
 
   useEffect(() => {
     if (open) {
-      // 通过单个 RESET_FORM action 原子性地重置所有表单状态
+      // 通过单个 RESET_FORM action 原子性地重置所有表单状态。
+      // deps 用 todo?.id 而不是 todo 本身：
+      // 父组件保存 Todo 后会重拉 todos 列表，selectedTodo 会拿到新对象引用
+      // （即使 todo 数据本身没变），如果 deps 用 todo，这个 effect 会再次触发
+      // RESET_FORM，把用户在抽屉里编辑到一半的字段静默重置回 todo 当前保存的值。
+      // 用 id 当 key 之后，只有真正切换到不同的 todo 才会重置。
       dispatch({ type: 'RESET_FORM', todo });
     }
-  }, [open, todo]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, todo?.id]);
 
   const handleSkillClick = useCallback((skill: SkillMeta) => {
     insertTextAtCursor(`/${skill.name}`);

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback, useReducer } from 'react';
 import { Drawer, Input, Button, App, AutoComplete, Divider, Switch, Modal, Form, Empty, Space } from 'antd';
 import { FolderOutlined, PlusOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import type { ProjectDirectory } from '@/utils/database';
-import type { TodoHookItem } from '@/utils/database/hooks';
+
 import type { Todo, ExecutorConfig, ExecutorOption, SkillMeta, ExecutorSkills, TodoTemplate } from '@/types';
 import { EXECUTORS, executorConfigToOption, getExecutorColor } from '@/types';
 import { TagCheckCardGroup } from './TagCheckCard';
@@ -14,6 +14,11 @@ import { SchedulerSection } from './todo-drawer/SchedulerSection';
 import { TemplateModal } from './todo-drawer/TemplateModal';
 import { TodoHooksEditor } from './todo-detail/TodoHooksEditor';
 import { useApp } from '@/hooks/useApp';
+import {
+  todoFormReducer,
+  initialFormState,
+  type TodoFormState,
+} from './todo-drawer/reducer';
 
 interface TodoDrawerProps {
   open: boolean;
@@ -27,52 +32,54 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
   const { message } = App.useApp();
   const isEditMode = todo !== null;
 
-  const [title, setTitle] = useState('');
-  const [prompt, setPrompt] = useState('');
-  const [selectedTags, setSelectedTags] = useState<number[]>([]);
-  const [executor, setExecutor] = useState<string>('claudecode');
-  // workspace 存的是路径；与 ProjectDirectory.path 对应，确保值可以直接命中已配置的目录
-  const [workspace, setWorkspace] = useState<string>('');
-  const [worktreeEnabled, setWorktreeEnabled] = useState(false);
+  // 使用 useReducer 替代多个 useState，集中管理表单状态
+  const [formState, dispatch] = useReducer(todoFormReducer, initialFormState);
+
+  // UI 相关的状态（不属于表单数据）
   const [executorOptions, setExecutorOptions] = useState<ExecutorOption[]>(EXECUTORS);
   const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
   const [allExecutorSkills, setAllExecutorSkills] = useState<ExecutorSkills[]>([]);
   const [skillsLoading, setSkillsLoading] = useState(false);
   const [skillsExpanded, setSkillsExpanded] = useState(false);
   const [skillSearchText, setSkillSearchText] = useState('');
-  const [schedulerEnabled, setSchedulerEnabled] = useState(false);
-  const [schedulerConfig, setSchedulerConfig] = useState<string>('');
-  const [hooks, setHooks] = useState<TodoHookItem[]>([]);
-  const [acceptanceCriteria, setAcceptanceCriteria] = useState('');
-  const [autoReviewEnabled, setAutoReviewEnabled] = useState(true);
   const [loading, setLoading] = useState(false);
-  // 快速新增项目目录的弹窗：与抽屉同级，关闭抽屉时一起清理
   const [quickAddOpen, setQuickAddOpen] = useState(false);
   const [quickAddForm] = Form.useForm<{ name: string; path: string }>();
   const [quickAddSubmitting, setQuickAddSubmitting] = useState(false);
   const editorRef = useRef<any>(null);
   const { state: appState } = useApp();
 
+  // 从 formState 中解构出常用的字段
+  const {
+    title, prompt, selectedTags, executor, workspace, worktreeEnabled,
+    schedulerEnabled, schedulerConfig, hooks, acceptanceCriteria, autoReviewEnabled,
+  } = formState;
+
+  // 设置单个字段的快捷函数
+  const setField = useCallback(<K extends keyof TodoFormState>(
+    field: K,
+    value: TodoFormState[K],
+  ) => {
+    dispatch({ type: 'SET_FIELD', field, value });
+  }, []);
+
   const insertTextAtCursor = useCallback((text: string) => {
     const editor = editorRef.current;
     if (!editor || !editor.textarea) {
-      setPrompt(prev => {
-        if (!prev) return text;
-        return prev + (prev.endsWith('\n') ? '' : '\n') + text;
-      });
+      setField('prompt', formState.prompt
+        ? formState.prompt + (formState.prompt.endsWith('\n') ? '' : '\n') + text
+        : text);
       return;
     }
     const textarea = editor.textarea as HTMLTextAreaElement;
     const start = textarea.selectionStart;
     const end = textarea.selectionEnd;
-    setPrompt(prev => {
-      return prev.substring(0, start) + text + prev.substring(end);
-    });
+    setField('prompt', formState.prompt.substring(0, start) + text + formState.prompt.substring(end));
     setTimeout(() => {
       textarea.selectionStart = textarea.selectionEnd = start + text.length;
       textarea.focus();
     }, 0);
-  }, []);
+  }, [formState.prompt, setField]);
 
   const [templateModalOpen, setTemplateModalOpen] = useState(false);
   const [templates, setTemplates] = useState<TodoTemplate[]>([]);
@@ -106,31 +113,8 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
 
   useEffect(() => {
     if (open) {
-      if (todo) {
-        setTitle(todo.title || '');
-        setPrompt(todo.prompt || '');
-        setSelectedTags((todo as any).tag_ids || []);
-        setExecutor(todo.executor || 'claudecode');
-        setWorkspace(todo.workspace || '');
-        setWorktreeEnabled(todo.worktree_enabled || false);
-        setSchedulerEnabled(todo.scheduler_enabled || false);
-        setSchedulerConfig(todo.scheduler_config || '');
-        setHooks(todo.hooks ?? []);
-        setAcceptanceCriteria(todo.acceptance_criteria ?? '');
-        setAutoReviewEnabled(todo.auto_review_enabled ?? true);
-      } else {
-        setTitle('');
-        setPrompt('');
-        setSelectedTags([]);
-        setExecutor('claudecode');
-        setWorkspace('');
-        setWorktreeEnabled(false);
-        setSchedulerEnabled(false);
-        setSchedulerConfig('');
-        setHooks([]);
-        setAcceptanceCriteria('');
-        setAutoReviewEnabled(true);
-      }
+      // 通过单个 RESET_FORM action 原子性地重置所有表单状态
+      dispatch({ type: 'RESET_FORM', todo });
     }
   }, [open, todo]);
 
@@ -153,8 +137,8 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
 
   const handleSelectTemplate = useCallback((template: TodoTemplate) => {
     if (!prompt.trim()) {
-      setTitle(template.title);
-      setPrompt(template.prompt || '');
+      setField('title', template.title);
+      setField('prompt', template.prompt || '');
       message.success('已应用模板');
     } else {
       if (template.prompt) {
@@ -165,7 +149,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
       }
     }
     setTemplateModalOpen(false);
-  }, [prompt, insertTextAtCursor, message]);
+  }, [formState.prompt, insertTextAtCursor, message]);
 
   // 快速新增项目目录：
   // 用户在工作目录区域点"+"即可补一个项目，无需跳到设置页。
@@ -192,7 +176,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         [...prev.filter(d => d.id !== dir.id), dir].sort((a, b) => a.path.localeCompare(b.path)) // 去重+按路径排序
       );
       // 保存后立即把新目录选中并写入工作目录，减少二次操作
-      setWorkspace(dir.path); // 自动选中新目录，减少用户二次操作
+      setField('workspace', dir.path); // 自动选中新目录，减少用户二次操作
       setQuickAddOpen(false); // 关闭弹窗
       message.success(`已添加项目"${dir.name}"`);
       // 通知其他组件（如 TodoList 分组视图）项目目录已更新
@@ -300,20 +284,20 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--color-border-light)' }}>
           <Input
             value={title}
-            onChange={e => setTitle(e.target.value)}
+            onChange={e => setField('title', e.target.value)}
             placeholder="任务标题"
             style={{ fontSize: 16, fontWeight: 600, padding: '8px 12px' }}
           />
         </div>
 
         <div style={{ flex: 1, overflow: 'auto', padding: '16px 20px' }}>
-          <ExecutorPicker executor={executor} executorOptions={executorOptions} onChange={setExecutor} />
+          <ExecutorPicker executor={executor} executorOptions={executorOptions} onChange={(v) => setField('executor', v)} />
 
           <Divider style={{ margin: '8px 0 16px' }} />
 
           <PromptEditor
             value={prompt}
-            onChange={setPrompt}
+            onChange={(v) => setField('prompt', v)}
             editorRef={editorRef}
             onOpenTemplate={handleOpenTemplate}
             onInsertText={insertTextAtCursor}
@@ -338,7 +322,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
                 <TagCheckCardGroup
                   tags={tags}
                   value={selectedTags[0] || null}
-                  onChange={(val) => setSelectedTags(val ? [val as number] : [])}
+                  onChange={(val) => setField('selectedTags', val ? [val as number] : [])}
                 />
               </div>
             </>
@@ -384,7 +368,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
               <Space.Compact style={{ width: '100%' }}>
                 <AutoComplete
                   value={workspace}
-                  onChange={(value) => setWorkspace(value)}
+                  onChange={(value) => setField('workspace', value)}
                   options={workspaceOptions}
                   placeholder="选择项目目录或手动输入路径"
                   style={{ flex: 1 }}
@@ -406,7 +390,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
             <div style={{ marginBottom: 16 }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                 <div style={{ fontWeight: 600, fontSize: 14 }}>Git Worktree</div>
-                <Switch checked={worktreeEnabled} onChange={(checked) => setWorktreeEnabled(checked)} />
+                <Switch checked={worktreeEnabled} onChange={(checked) => setField('worktreeEnabled', checked)} />
               </div>
             </div>
           )}
@@ -416,8 +400,8 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
           <SchedulerSection
             enabled={schedulerEnabled}
             config={schedulerConfig}
-            onEnabledChange={setSchedulerEnabled}
-            onConfigChange={setSchedulerConfig}
+            onEnabledChange={(v) => setField('schedulerEnabled', v)}
+            onConfigChange={(v) => setField('schedulerConfig', v)}
             existingConfig={todo?.scheduler_config}
           />
 
@@ -428,7 +412,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
             <div style={{ marginBottom: 8, fontWeight: 600, fontSize: 14 }}>验收标准</div>
             <Input.TextArea
               value={acceptanceCriteria}
-              onChange={e => setAcceptanceCriteria(e.target.value)}
+              onChange={e => setField('acceptanceCriteria', e.target.value)}
               placeholder="描述完成该任务需要满足的条件..."
               rows={3}
               style={{ resize: 'vertical' }}
@@ -450,7 +434,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
                 </div>
                 <Switch
                   checked={autoReviewEnabled}
-                  onChange={setAutoReviewEnabled}
+                  onChange={(v) => setField('autoReviewEnabled', v)}
                   checkedChildren="开启"
                   unCheckedChildren="关闭"
                 />
@@ -465,7 +449,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
             todos={appState.todos}
             ownerId={todo?.id ?? null}
             hooks={hooks}
-            onChange={setHooks}
+            onChange={(v) => setField('hooks', v)}
             disabled={loading}
           />
         </div>

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -18,6 +18,7 @@ import {
   todoFormReducer,
   initialFormState,
   type TodoFormState,
+  type TodoFormAction,
 } from './todo-drawer/reducer';
 
 interface TodoDrawerProps {
@@ -56,11 +57,13 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
   } = formState;
 
   // 设置单个字段的快捷函数
+  // 泛型 K 确保 field/value 类型一致，但 TS 无法对泛型 dispatch 做 discriminated union 窄化，
+  // 所以这里用 as TodoFormAction 做内部断言（外部调用方通过泛型约束保证类型安全）。
   const setField = useCallback(<K extends keyof TodoFormState>(
     field: K,
     value: TodoFormState[K],
   ) => {
-    dispatch({ type: 'SET_FIELD', field, value });
+    dispatch({ type: 'SET_FIELD', field, value } as TodoFormAction);
   }, []);
 
   const insertTextAtCursor = useCallback((text: string) => {
@@ -122,18 +125,23 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
     }
   }, [open]);
 
+  // 记录上一次传入的 todo，用于判断是否需要 RESET_FORM。
+  // deps 保持 [open, todo]（检测内容引用变化），但内部用 id 比较
+  // 避免仅在引用更新但内容未变时静默重置用户编辑。
+  const prevTodoRef = useRef(todo);
+
   useEffect(() => {
     if (open) {
-      // 通过单个 RESET_FORM action 原子性地重置所有表单状态。
-      // deps 用 todo?.id 而不是 todo 本身：
-      // 父组件保存 Todo 后会重拉 todos 列表，selectedTodo 会拿到新对象引用
-      // （即使 todo 数据本身没变），如果 deps 用 todo，这个 effect 会再次触发
-      // RESET_FORM，把用户在抽屉里编辑到一半的字段静默重置回 todo 当前保存的值。
-      // 用 id 当 key 之后，只有真正切换到不同的 todo 才会重置。
+      const prevTodo = prevTodoRef.current;
+      prevTodoRef.current = todo;
+      // 如果 todo 引用变了但 id 相同（父组件重拉 todos 导致的新引用），
+      // 不触发 RESET_FORM，保留用户在抽屉中的编辑
+      if (prevTodo !== todo && todo && prevTodo?.id === todo.id) {
+        return;
+      }
       dispatch({ type: 'RESET_FORM', todo });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, todo?.id]);
+  }, [open, todo]);
 
   const handleSkillClick = useCallback((skill: SkillMeta) => {
     insertTextAtCursor(`/${skill.name}`);

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -5,7 +5,7 @@ import * as db from '@/utils/database';
 import type { ProjectDirectory } from '@/utils/database';
 
 import type { Todo, ExecutorConfig, ExecutorOption, SkillMeta, ExecutorSkills, TodoTemplate } from '@/types';
-import { EXECUTORS, executorConfigToOption, getExecutorColor } from '@/types';
+import { EXECUTORS, executorConfigToOption, getExecutorColor, DEFAULT_EXECUTOR } from '@/types';
 import { TagCheckCardGroup } from './TagCheckCard';
 import { ExecutorPicker } from './todo-drawer/ExecutorPicker';
 import { PromptEditor } from './todo-drawer/PromptEditor';
@@ -66,20 +66,31 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
   const insertTextAtCursor = useCallback((text: string) => {
     const editor = editorRef.current;
     if (!editor || !editor.textarea) {
-      setField('prompt', formState.prompt
-        ? formState.prompt + (formState.prompt.endsWith('\n') ? '' : '\n') + text
-        : text);
+      // 无编辑器时：通过 functional updater 追加文本，避免 closure 捕获旧状态
+      dispatch({
+        type: 'SET_FIELD_UPDATER',
+        field: 'prompt',
+        updater: (prev: string) => prev
+          ? prev + (prev.endsWith('\n') ? '' : '\n') + text
+          : text,
+      });
       return;
     }
     const textarea = editor.textarea as HTMLTextAreaElement;
     const start = textarea.selectionStart;
     const end = textarea.selectionEnd;
-    setField('prompt', formState.prompt.substring(0, start) + text + formState.prompt.substring(end));
+    // 使用 functional updater 在光标处插入文本，确保同一渲染周期内多次调用
+    // 不会因 closure 捕获旧状态而丢失上一次的改动
+    dispatch({
+      type: 'SET_FIELD_UPDATER',
+      field: 'prompt',
+      updater: (prev: string) => prev.substring(0, start) + text + prev.substring(end),
+    });
     setTimeout(() => {
       textarea.selectionStart = textarea.selectionEnd = start + text.length;
       textarea.focus();
     }, 0);
-  }, [formState.prompt, setField]);
+  }, []);
 
   const [templateModalOpen, setTemplateModalOpen] = useState(false);
   const [templates, setTemplates] = useState<TodoTemplate[]>([]);
@@ -229,7 +240,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         // 创建模式：只在路径存在于目录列表时才设置 workspace，否则为 null（避免创建无名项目）
         const workspaceToSave = trimmedWorkspace && projectDirectories.some(d => d.path === trimmedWorkspace) ? trimmedWorkspace : null;
 
-        if (workspaceToSave || schedulerEnabled || executor !== 'claudecode' || worktreeEnabled) {
+        if (workspaceToSave || schedulerEnabled || executor !== DEFAULT_EXECUTOR || worktreeEnabled) {
           await db.updateTodo(
             newTodo.id, newTodo.title, newTodo.prompt, newTodo.status,
             executor, schedulerEnabled, schedulerConfig || null,
@@ -386,7 +397,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
             )}
           </div>
 
-          {(executor === 'claudecode' || executor === 'claude_code' || executor === 'hermes') && (
+          {(executor === DEFAULT_EXECUTOR || executor === 'claude_code' || executor === 'hermes') && (
             <div style={{ marginBottom: 16 }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                 <div style={{ fontWeight: 600, fontSize: 14 }}>Git Worktree</div>

--- a/frontend/src/components/dashboard/ChartCards.tsx
+++ b/frontend/src/components/dashboard/ChartCards.tsx
@@ -3,7 +3,10 @@ import { BarChartOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { PieChart, PieChartLegend } from '@/components/PieChart';
 import { TrendChart, ContributionHeatmap } from './DashboardCharts';
 import { AnimatedNumber } from '@/components/AnimatedNumber';
-import { TRIGGER_LABELS, TRIGGER_COLORS, STATUS_COLORS, STATUS_LABELS } from './constants';
+// STATUS_COLORS 走全应用共享的 @/constants；dashboard 自己的 constants.ts
+// 只保留 dashboard 私有的标签/触发类型等常量，避免再次出现双源 STATUS_COLORS。
+import { TRIGGER_LABELS, TRIGGER_COLORS, STATUS_LABELS } from './constants';
+import { STATUS_COLORS } from '@/constants';
 import type { DashboardStats } from '@/types';
 
 interface ChartCardProps {

--- a/frontend/src/components/dashboard/constants.ts
+++ b/frontend/src/components/dashboard/constants.ts
@@ -6,12 +6,9 @@ export const TIME_RANGE_OPTIONS: { label: string; value: number | 'custom' }[] =
   { label: '自定义', value: 'custom' },
 ];
 
-export const STATUS_COLORS: Record<string, string> = {
-  pending: '#94a3b8',
-  running: '#3b82f6',
-  completed: '#22c55e',
-  failed: '#ef4444',
-};
+// 注意：旧的 STATUS_COLORS 已移除；统一从 '@/constants' 引入，避免双源定义
+// 导致 Dashboard 任务状态分布饼图与其他组件出现两套配色。
+// 见 PR #561 评审 CRITICAL #1 / #2。
 
 const EMPTY_STATE_QUOTES = [
   '心若如镜，来者皆照，去者不留。',

--- a/frontend/src/components/dashboard/constants.ts
+++ b/frontend/src/components/dashboard/constants.ts
@@ -64,26 +64,13 @@ const EMPTY_STATE_QUOTES = [
 
 export const RANDOM_QUOTE = EMPTY_STATE_QUOTES[Math.floor(Math.random() * EMPTY_STATE_QUOTES.length)];
 
-export const STATUS_LABELS: Record<string, string> = {
-  pending: '待处理',
-  running: '运行中',
-  completed: '已完成',
-  failed: '失败',
-};
-
-export const TRIGGER_LABELS: Record<string, string> = {
-  manual: '手动',
-  cron: '定时',
-  slash_command: '命令',
-  default_response: '默认回复',
-};
-
-export const TRIGGER_COLORS: Record<string, string> = {
-  manual: '#3b82f6',
-  cron: '#8b5cf6',
-  slash_command: '#f59e0b',
-  default_response: '#22c55e',
-};
+// STATUS_LABELS、TRIGGER_LABELS、TRIGGER_COLORS 已迁移到 @/constants
+// 统一从 @/constants 导入，保持单一数据源
+export {
+  STATUS_LABELS,
+  TRIGGER_LABELS,
+  TRIGGER_COLORS,
+} from '@/constants';
 
 export const MODEL_COLORS = ['#8b5cf6', '#3b82f6', '#22c55e', '#f59e0b', '#ef4444', '#0891b2', '#ec4899', '#6366f1'];
 

--- a/frontend/src/components/sessions/helpers.tsx
+++ b/frontend/src/components/sessions/helpers.tsx
@@ -1,5 +1,5 @@
 import { Tag } from 'antd';
-import { parseUtcDate } from '@/utils/datetime';
+import { formatTokens, formatRelativeTimeFromNow } from '@/utils/format';
 
 export const sourceConfig: Record<string, { label: string; color: string }> = {
   'claudecode': { label: 'Claude Code', color: '#d97706' },
@@ -27,33 +27,7 @@ export function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export function formatTokens(n: number): string {
-  if (n < 1000) return String(n);
-  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}K`;
-  return `${(n / 1_000_000).toFixed(2)}M`;
-}
-
-export function formatTime(iso?: string | null): string {
-  if (!iso) return '-';
-  try {
-    const d = parseUtcDate(iso);
-    if (!d) return '-';
-    const now = new Date();
-    const diffMs = now.getTime() - d.getTime();
-    const diffMin = Math.floor(diffMs / 60000);
-
-    if (diffMin < 1) return '刚刚';
-    if (diffMin < 60) return `${diffMin} 分钟前`;
-    const diffHour = Math.floor(diffMin / 60);
-    if (diffHour < 24) return `${diffHour} 小时前`;
-    const diffDay = Math.floor(diffHour / 24);
-    if (diffDay < 30) return `${diffDay} 天前`;
-
-    return d.toLocaleDateString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
-  } catch {
-    return iso;
-  }
-}
+export { formatTokens, formatRelativeTimeFromNow as formatTime };
 
 export function shortId(id: string): string {
   return id.length > 12 ? `${id.slice(0, 8)}...${id.slice(-4)}` : id;

--- a/frontend/src/components/skills/helpers.ts
+++ b/frontend/src/components/skills/helpers.ts
@@ -1,5 +1,6 @@
 import { EXECUTOR_COLORS, getExecutorColor } from '@/types';
 import type { SkillMeta } from '@/types';
+import { formatDateTime } from '@/utils/format';
 
 export { EXECUTOR_COLORS, getExecutorColor };
 
@@ -10,15 +11,7 @@ export function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export function formatTime(iso: string | null): string {
-  if (!iso) return '-';
-  try {
-    const d = new Date(iso);
-    return d.toLocaleDateString('zh-CN') + ' ' + d.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
-  } catch {
-    return iso;
-  }
-}
+export { formatDateTime as formatTime };
 
 export function normalizeExecutor(name: string): string {
   return name.toLowerCase().replace(/[_\s-]/g, '');

--- a/frontend/src/components/todo-detail/ChainGroupCard.tsx
+++ b/frontend/src/components/todo-detail/ChainGroupCard.tsx
@@ -4,7 +4,7 @@ import { MessageOutlined, FileTextOutlined, StopOutlined, CopyOutlined, LinkOutl
 import { XMarkdown } from '@ant-design/x-markdown';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { supportsResume } from '@/types';
-import { formatLocalDateTime, formatDuration } from '@/utils/datetime';
+import { formatLocalDateTime, formatDurationSec } from '@/utils/datetime';
 import * as db from '@/utils/database';
 import { getElapsedSeconds, hasLogsStatic } from './helpers';
 import { NarrowLogView } from './NarrowLogView';
@@ -66,12 +66,12 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
             })()}
             {mainRecord.status !== 'running' && mainRecord.usage?.duration_ms && (
               <span style={{ fontSize: 11, color: 'var(--color-success)', fontWeight: 600 }}>
-                {formatDuration(mainRecord.usage.duration_ms / 1000)}
+                {formatDurationSec(mainRecord.usage.duration_ms / 1000)}
               </span>
             )}
             {mainRecord.status === 'running' && (
               <span style={{ fontSize: 11, color: 'var(--color-info)', fontWeight: 600 }}>
-                {formatDuration(getElapsedSeconds(mainRecord.started_at))}
+                {formatDurationSec(getElapsedSeconds(mainRecord.started_at))}
               </span>
             )}
           </div>
@@ -181,12 +181,12 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                 </span>
                 {record.status !== 'running' && record.usage?.duration_ms && (
                   <span style={{ fontSize: 9, color: 'var(--color-success)', fontWeight: 600 }}>
-                    {formatDuration(record.usage.duration_ms / 1000)}
+                    {formatDurationSec(record.usage.duration_ms / 1000)}
                   </span>
                 )}
                 {record.status === 'running' && (
                   <span style={{ fontSize: 9, color: 'var(--color-info)', fontWeight: 600 }}>
-                    {formatDuration(getElapsedSeconds(record.started_at))}
+                    {formatDurationSec(getElapsedSeconds(record.started_at))}
                   </span>
                 )}
                 <span style={{

--- a/frontend/src/components/todo-detail/CompactHistoryItem.tsx
+++ b/frontend/src/components/todo-detail/CompactHistoryItem.tsx
@@ -3,7 +3,7 @@ import { Tag } from 'antd';
 import { MessageOutlined, FileTextOutlined } from '@ant-design/icons';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { supportsResume } from '@/types';
-import { formatLocalDateTime, formatDuration } from '@/utils/datetime';
+import { formatLocalDateTime, formatDurationSec } from '@/utils/datetime';
 import { getElapsedSeconds, hasLogsStatic } from './helpers';
 import type { ExecutionRecord } from '@/types';
 
@@ -65,12 +65,12 @@ export function CompactHistoryItem({ record, onOpenResume, onExport }: {
         </Tag>
         {record.usage?.duration_ms && (
           <span style={{ fontSize: 10, color: 'var(--color-success)', fontWeight: 600 }}>
-            {formatDuration(record.usage.duration_ms / 1000)}
+            {formatDurationSec(record.usage.duration_ms / 1000)}
           </span>
         )}
         {isRunning && elapsedSec > 0 && (
           <span style={{ fontSize: 10, color: 'var(--color-info)', fontWeight: 600 }}>
-            {formatDuration(elapsedSec)}
+            {formatDurationSec(elapsedSec)}
           </span>
         )}
         {record.execution_stats && (

--- a/frontend/src/components/todo-detail/ContinuationLogView.tsx
+++ b/frontend/src/components/todo-detail/ContinuationLogView.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { ChatView } from '@/components/ChatView';
 import { LogViewHeader } from './LogViewHeader';
-import { formatLogTime, logTypeColors, logTypeLabels } from './helpers';
+import { formatLogTime } from './helpers';
+import { LOG_TYPE_COLORS, LOG_TYPE_LABELS } from '@/constants';
 import type { LogEntry } from '@/types';
 
 /** 内联日志视图组件 (用于 ChainGroupCard 内部) */
@@ -42,8 +43,8 @@ export function ContinuationLogView({ logs, isRunning, viewMode, onRefresh, onVi
             logs.map((log, i) => (
               <div key={i} style={{ marginBottom: 3, display: 'flex', gap: 6 }}>
                 <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
-                <span style={{ color: logTypeColors[log.type || ''] || 'var(--log-text)' }}>
-                  [{logTypeLabels[log.type || ''] || log.type}]
+                <span style={{ color: LOG_TYPE_COLORS[log.type || ''] || 'var(--log-text)' }}>
+                  [{LOG_TYPE_LABELS[log.type || ''] || log.type}]
                 </span>
                 <span>{log.content ?? ''}</span>
               </div>

--- a/frontend/src/components/todo-detail/HistoryList.tsx
+++ b/frontend/src/components/todo-detail/HistoryList.tsx
@@ -1,7 +1,7 @@
 import { Pagination } from 'antd';
 import { LinkOutlined, MessageOutlined } from '@ant-design/icons';
 import { CompactHistoryItem } from './CompactHistoryItem';
-import { formatLocalDateTime, formatDuration } from '@/utils/datetime';
+import { formatLocalDateTime, formatDurationSec } from '@/utils/datetime';
 import { getElapsedSeconds } from './helpers';
 import type { SessionGroup } from './helpers';
 import { supportsResume } from '@/types';
@@ -93,12 +93,12 @@ export function HistoryList({
                       </span>
                       {record.status !== 'running' && record.usage?.duration_ms && (
                         <span style={{ fontSize: 9, color: 'var(--color-success)', fontWeight: 600 }}>
-                          {formatDuration(record.usage.duration_ms / 1000)}
+                          {formatDurationSec(record.usage.duration_ms / 1000)}
                         </span>
                       )}
                       {record.status === 'running' && (
                         <span style={{ fontSize: 9, color: 'var(--color-info)', fontWeight: 600 }}>
-                          {formatDuration(getElapsedSeconds(record.started_at))}
+                          {formatDurationSec(getElapsedSeconds(record.started_at))}
                         </span>
                       )}
                       {record.execution_stats && (

--- a/frontend/src/components/todo-detail/NarrowHistoryCard.tsx
+++ b/frontend/src/components/todo-detail/NarrowHistoryCard.tsx
@@ -4,7 +4,7 @@ import { MessageOutlined, FileTextOutlined, StopOutlined, CopyOutlined, LinkOutl
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { XMarkdown } from '@ant-design/x-markdown';
 import { supportsResume } from '@/types';
-import { formatLocalDateTime, formatDuration } from '@/utils/datetime';
+import { formatLocalDateTime, formatDurationSec } from '@/utils/datetime';
 import * as db from '@/utils/database';
 import { getElapsedSeconds, hasLogsStatic } from './helpers';
 import { NarrowLogView } from './NarrowLogView';
@@ -68,12 +68,12 @@ export function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, on
           })()}
           {record.status !== 'running' && record.usage?.duration_ms && (
             <span style={{ fontSize: 11, color: 'var(--color-success)', fontWeight: 600 }}>
-              {formatDuration(record.usage.duration_ms / 1000)}
+              {formatDurationSec(record.usage.duration_ms / 1000)}
             </span>
           )}
           {record.status === 'running' && (
             <span style={{ fontSize: 11, color: 'var(--color-info)', fontWeight: 600 }}>
-              {formatDuration(getElapsedSeconds(record.started_at))}
+              {formatDurationSec(getElapsedSeconds(record.started_at))}
             </span>
           )}
         </div>

--- a/frontend/src/components/todo-detail/NarrowLogView.tsx
+++ b/frontend/src/components/todo-detail/NarrowLogView.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { ChatView } from '@/components/ChatView';
 import { LogViewHeader } from './LogViewHeader';
-import { formatLogTime, logTypeColors, logTypeLabels } from './helpers';
+import { formatLogTime } from './helpers';
+import { LOG_TYPE_COLORS, LOG_TYPE_LABELS } from '@/constants';
 import type { LogEntry, ExecutionRecord } from '@/types';
 
 /** Shared log rendering for narrow mode cards - as a proper component */
@@ -46,8 +47,8 @@ export function NarrowLogView({ record, isRunning, displayLogs, liveLogs, viewMo
             displayLogs.map((log, idx) => (
               <div key={idx} style={{ marginBottom: 4, display: 'flex', gap: 8 }}>
                 <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
-                <span style={{ color: logTypeColors[log.type || ''] || 'var(--log-text)' }}>
-                  [{logTypeLabels[log.type || ''] || log.type}]
+                <span style={{ color: LOG_TYPE_COLORS[log.type || ''] || 'var(--log-text)' }}>
+                  [{LOG_TYPE_LABELS[log.type || ''] || log.type}]
                 </span>
                 <span>{log.content}</span>
               </div>

--- a/frontend/src/components/todo-detail/RecordDetailView.tsx
+++ b/frontend/src/components/todo-detail/RecordDetailView.tsx
@@ -7,7 +7,8 @@ import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { ChatView } from '@/components/ChatView';
 import { RefreshBtn } from './LogViewHeader';
 import { formatLocalDateTime, formatDurationSec } from '@/utils/datetime';
-import { getElapsedSeconds, formatLogTime, logTypeColors, logTypeLabels } from './helpers';
+import { getElapsedSeconds, formatLogTime } from './helpers';
+import { LOG_TYPE_COLORS, LOG_TYPE_LABELS } from '@/constants';
 import type { SessionGroup } from './helpers';
 import { supportsResume } from '@/types';
 import type { ExecutionRecord, LogEntry } from '@/types';
@@ -280,8 +281,8 @@ export function RecordDetailView({
                 displayLogs.map((log: LogEntry, idx: number) => (
                   <div key={idx} style={{ marginBottom: 4, display: 'flex', gap: 8 }}>
                     <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
-                    <span style={{ color: logTypeColors[log.type || ''] || 'var(--log-text)' }}>
-                      [{logTypeLabels[log.type || ''] || log.type}]
+                    <span style={{ color: LOG_TYPE_COLORS[log.type || ''] || 'var(--log-text)' }}>
+                      [{LOG_TYPE_LABELS[log.type || ''] || log.type}]
                     </span>
                     <span>{log.content}</span>
                   </div>

--- a/frontend/src/components/todo-detail/RecordDetailView.tsx
+++ b/frontend/src/components/todo-detail/RecordDetailView.tsx
@@ -6,7 +6,7 @@ import XMarkdown from '@ant-design/x-markdown';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { ChatView } from '@/components/ChatView';
 import { RefreshBtn } from './LogViewHeader';
-import { formatLocalDateTime, formatDuration } from '@/utils/datetime';
+import { formatLocalDateTime, formatDurationSec } from '@/utils/datetime';
 import { getElapsedSeconds, formatLogTime, logTypeColors, logTypeLabels } from './helpers';
 import type { SessionGroup } from './helpers';
 import { supportsResume } from '@/types';
@@ -130,12 +130,12 @@ export function RecordDetailView({
           })()}
           {record.status !== 'running' && record.usage?.duration_ms && (
             <span style={{ fontSize: 12, color: 'var(--color-success)', fontWeight: 600 }}>
-              {formatDuration(record.usage.duration_ms / 1000)}
+              {formatDurationSec(record.usage.duration_ms / 1000)}
             </span>
           )}
           {record.status === 'running' && (
             <span style={{ fontSize: 12, color: 'var(--color-info)', fontWeight: 600 }}>
-              {formatDuration(getElapsedSeconds(record.started_at))}
+              {formatDurationSec(getElapsedSeconds(record.started_at))}
             </span>
           )}
         </div>

--- a/frontend/src/components/todo-detail/helpers.ts
+++ b/frontend/src/components/todo-detail/helpers.ts
@@ -37,45 +37,8 @@ export function hasLogsStatic(record: ExecutionRecord): boolean {
   return record.status !== 'running' && !!record.finished_at;
 }
 
-export const logTypeColors: Record<string, string> = {
-  info: '#60a5fa',
-  text: '#4ade80',
-  tool: '#fbbf24',
-  tool_use: '#fbbf24',
-  tool_call: '#fbbf24',
-  tool_result: '#fbbf24',
-  step_start: '#c084fc',
-  step_finish: '#2dd4bf',
-  stdout: '#cbd5e1',
-  stderr: '#94a3b8',
-  error: '#ef4444',
-  system: '#94a3b8',
-  assistant: '#a78bfa',
-  user: '#22d3ee',
-  result: '#4ade80',
-  thinking: '#fb923c',
-  tokens: '#94a3b8',
-};
-
-export const logTypeLabels: Record<string, string> = {
-  info: 'INFO',
-  text: 'TEXT',
-  tool: 'TOOL',
-  tool_use: 'TOOL',
-  tool_call: 'TOOL',
-  tool_result: 'RESULT',
-  step_start: 'START',
-  step_finish: 'END',
-  stdout: 'OUT',
-  stderr: 'LOG',
-  error: 'ERROR',
-  system: 'SYS',
-  assistant: 'ASST',
-  user: 'USER',
-  result: 'RESULT',
-  thinking: 'THINK',
-  tokens: 'INFO',
-};
+// logTypeColors 和 logTypeLabels 已迁移到 @/constants
+// 保留 getElapsedSeconds / groupBySession / hasLogsStatic 等工具函数
 
 /**
  * 格式化时间戳为短时间格式 (HH:mm:ss)

--- a/frontend/src/components/todo-drawer/ExecutorPicker.tsx
+++ b/frontend/src/components/todo-drawer/ExecutorPicker.tsx
@@ -1,7 +1,8 @@
+import { memo } from 'react';
 import { CheckOutlined } from '@ant-design/icons';
 import type { ExecutorOption } from '@/types';
 
-export function ExecutorPicker({ executor, executorOptions, onChange }: {
+export const ExecutorPicker = memo(function ExecutorPicker({ executor, executorOptions, onChange }: {
   executor: string;
   executorOptions: ExecutorOption[];
   onChange: (v: string) => void;
@@ -79,4 +80,4 @@ export function ExecutorPicker({ executor, executorOptions, onChange }: {
       </div>
     </div>
   );
-}
+});

--- a/frontend/src/components/todo-drawer/PromptEditor.tsx
+++ b/frontend/src/components/todo-drawer/PromptEditor.tsx
@@ -1,9 +1,10 @@
+import { memo } from 'react';
 import { Button, Tooltip } from 'antd';
 import { FileTextOutlined } from '@ant-design/icons';
 import { PROMPT_PARAMS } from './constants';
 import { MdEditor } from '@/components/MdEditor';
 
-export function PromptEditor({ value, onChange, editorRef, onOpenTemplate, onInsertText }: {
+export const PromptEditor = memo(function PromptEditor({ value, onChange, editorRef, onOpenTemplate, onInsertText }: {
   value: string;
   onChange: (v: string) => void;
   editorRef: React.MutableRefObject<any>;
@@ -68,4 +69,4 @@ export function PromptEditor({ value, onChange, editorRef, onOpenTemplate, onIns
       </div>
     </div>
   );
-}
+});

--- a/frontend/src/components/todo-drawer/SchedulerSection.tsx
+++ b/frontend/src/components/todo-drawer/SchedulerSection.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Switch } from 'antd';
 import { ClockCircleOutlined } from '@ant-design/icons';
 import { Cron } from 'react-js-cron';
@@ -6,7 +7,7 @@ import { DEFAULT_CRON } from './constants';
 import { CronPresetSelect } from '@/components/CronPresetSelect';
 import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '@/utils/cron';
 
-export function SchedulerSection({ enabled, config, onEnabledChange, onConfigChange, existingConfig }: {
+export const SchedulerSection = memo(function SchedulerSection({ enabled, config, onEnabledChange, onConfigChange, existingConfig }: {
   enabled: boolean;
   config: string;
   onEnabledChange: (v: boolean) => void;
@@ -57,4 +58,4 @@ export function SchedulerSection({ enabled, config, onEnabledChange, onConfigCha
       )}
     </div>
   );
-}
+});

--- a/frontend/src/components/todo-drawer/SkillSelector.tsx
+++ b/frontend/src/components/todo-drawer/SkillSelector.tsx
@@ -1,9 +1,9 @@
 import { Input, Tag, Spin, Empty } from 'antd';
 import { RightOutlined, ThunderboltOutlined, SearchOutlined } from '@ant-design/icons';
-import { useDeferredValue } from 'react';
+import { memo, useDeferredValue } from 'react';
 import type { SkillMeta } from '@/types';
 
-export function SkillSelector({ skills, loading, executorColor, searchText, onSearchChange, expanded, onToggle, onSkillClick }: {
+export const SkillSelector = memo(function SkillSelector({ skills, loading, executorColor, searchText, onSearchChange, expanded, onToggle, onSkillClick }: {
   skills: SkillMeta[];
   loading: boolean;
   executorColor: string;
@@ -150,4 +150,4 @@ export function SkillSelector({ skills, loading, executorColor, searchText, onSe
       )}
     </div>
   );
-}
+});

--- a/frontend/src/components/todo-drawer/reducer.ts
+++ b/frontend/src/components/todo-drawer/reducer.ts
@@ -8,7 +8,7 @@
 
 import type { Todo } from '@/types';
 import type { TodoHookItem } from '@/utils/database/hooks';
-import { DEFAULT_EXECUTOR } from '@/constants';
+import { DEFAULT_EXECUTOR } from '@/types/execution';
 
 /** 表单数据状态 */
 export interface TodoFormState {
@@ -39,6 +39,7 @@ export interface TodoFormState {
 /** 表单 action 类型 */
 export type TodoFormAction =
   | { type: 'SET_FIELD'; field: keyof TodoFormState; value: any }
+  | { type: 'SET_FIELD_UPDATER'; field: keyof TodoFormState; updater: (prev: any) => any }
   | { type: 'SET_MULTIPLE'; fields: Partial<TodoFormState> }
   | { type: 'RESET_FORM'; todo?: Todo | null }
   | { type: 'RESET_CREATE_MODE' };
@@ -64,6 +65,10 @@ export function todoFormReducer(state: TodoFormState, action: TodoFormAction): T
     case 'SET_FIELD':
       return { ...state, [action.field]: action.value };
 
+    // 功能性更新：接收 prev => newValue 函数，避免 closure 捕获导致的并发回归
+    case 'SET_FIELD_UPDATER':
+      return { ...state, [action.field]: action.updater(state[action.field]) };
+
     case 'SET_MULTIPLE':
       return { ...state, ...action.fields };
 
@@ -72,7 +77,7 @@ export function todoFormReducer(state: TodoFormState, action: TodoFormAction): T
         return {
           title: action.todo.title || '',
           prompt: action.todo.prompt || '',
-          selectedTags: (action.todo as any).tag_ids || [],
+          selectedTags: action.todo.tag_ids || [],
           executor: action.todo.executor || DEFAULT_EXECUTOR,
           workspace: action.todo.workspace || '',
           worktreeEnabled: action.todo.worktree_enabled || false,

--- a/frontend/src/components/todo-drawer/reducer.ts
+++ b/frontend/src/components/todo-drawer/reducer.ts
@@ -36,10 +36,10 @@ export interface TodoFormState {
   autoReviewEnabled: boolean;
 }
 
-/** 表单 action 类型 */
+/** 表单 action 类型 — 泛型联合确保 field 与 value/updater 类型一致 */
 export type TodoFormAction =
-  | { type: 'SET_FIELD'; field: keyof TodoFormState; value: any }
-  | { type: 'SET_FIELD_UPDATER'; field: keyof TodoFormState; updater: (prev: any) => any }
+  | { [K in keyof TodoFormState]: { type: 'SET_FIELD'; field: K; value: TodoFormState[K] } }[keyof TodoFormState]
+  | { [K in keyof TodoFormState]: { type: 'SET_FIELD_UPDATER'; field: K; updater: (prev: TodoFormState[K]) => TodoFormState[K] } }[keyof TodoFormState]
   | { type: 'SET_MULTIPLE'; fields: Partial<TodoFormState> }
   | { type: 'RESET_FORM'; todo?: Todo | null }
   | { type: 'RESET_CREATE_MODE' };
@@ -66,8 +66,9 @@ export function todoFormReducer(state: TodoFormState, action: TodoFormAction): T
       return { ...state, [action.field]: action.value };
 
     // 功能性更新：接收 prev => newValue 函数，避免 closure 捕获导致的并发回归
+    // TS 无法对泛型 discriminated union 做窄化，updater 参数用 any 做内部桥接
     case 'SET_FIELD_UPDATER':
-      return { ...state, [action.field]: action.updater(state[action.field]) };
+      return { ...state, [action.field]: (action.updater as (prev: any) => any)(state[action.field]) };
 
     case 'SET_MULTIPLE':
       return { ...state, ...action.fields };

--- a/frontend/src/components/todo-drawer/reducer.ts
+++ b/frontend/src/components/todo-drawer/reducer.ts
@@ -1,0 +1,94 @@
+/**
+ * TodoDrawer 表单状态管理
+ *
+ * 使用 useReducer 替代多个 useState，将相关状态集中管理。
+ * 表单状态（title、prompt、executor 等）在编辑模式和创建模式之间切换时
+ * 需要批量重置，useReducer 可以通过单个 RESET_FORM action 原子性地完成。
+ */
+
+import type { Todo } from '@/types';
+import type { TodoHookItem } from '@/utils/database/hooks';
+import { DEFAULT_EXECUTOR } from '@/constants';
+
+/** 表单数据状态 */
+export interface TodoFormState {
+  /** 任务标题 */
+  title: string;
+  /** 任务提示词 */
+  prompt: string;
+  /** 选中的标签 ID 列表 */
+  selectedTags: number[];
+  /** 执行器名称 */
+  executor: string;
+  /** 工作目录路径 */
+  workspace: string;
+  /** 是否启用 worktree */
+  worktreeEnabled: boolean;
+  /** 是否启用调度器 */
+  schedulerEnabled: boolean;
+  /** 调度器 cron 表达式 */
+  schedulerConfig: string;
+  /** 钩子列表 */
+  hooks: TodoHookItem[];
+  /** 验收标准 */
+  acceptanceCriteria: string;
+  /** 是否启用自动评审 */
+  autoReviewEnabled: boolean;
+}
+
+/** 表单 action 类型 */
+export type TodoFormAction =
+  | { type: 'SET_FIELD'; field: keyof TodoFormState; value: any }
+  | { type: 'SET_MULTIPLE'; fields: Partial<TodoFormState> }
+  | { type: 'RESET_FORM'; todo?: Todo | null }
+  | { type: 'RESET_CREATE_MODE' };
+
+/** 初始状态（创建模式） */
+export const initialFormState: TodoFormState = {
+  title: '',
+  prompt: '',
+  selectedTags: [],
+  executor: DEFAULT_EXECUTOR,
+  workspace: '',
+  worktreeEnabled: false,
+  schedulerEnabled: false,
+  schedulerConfig: '',
+  hooks: [],
+  acceptanceCriteria: '',
+  autoReviewEnabled: true,
+};
+
+/** 表单 reducer */
+export function todoFormReducer(state: TodoFormState, action: TodoFormAction): TodoFormState {
+  switch (action.type) {
+    case 'SET_FIELD':
+      return { ...state, [action.field]: action.value };
+
+    case 'SET_MULTIPLE':
+      return { ...state, ...action.fields };
+
+    case 'RESET_FORM':
+      if (action.todo) {
+        return {
+          title: action.todo.title || '',
+          prompt: action.todo.prompt || '',
+          selectedTags: (action.todo as any).tag_ids || [],
+          executor: action.todo.executor || DEFAULT_EXECUTOR,
+          workspace: action.todo.workspace || '',
+          worktreeEnabled: action.todo.worktree_enabled || false,
+          schedulerEnabled: action.todo.scheduler_enabled || false,
+          schedulerConfig: action.todo.scheduler_config || '',
+          hooks: action.todo.hooks ?? [],
+          acceptanceCriteria: action.todo.acceptance_criteria ?? '',
+          autoReviewEnabled: action.todo.auto_review_enabled ?? true,
+        };
+      }
+      return initialFormState;
+
+    case 'RESET_CREATE_MODE':
+      return initialFormState;
+
+    default:
+      return state;
+  }
+}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -61,3 +61,70 @@ export const LOG_TYPE_COLORS: Record<string, string> = {
 
 /** 默认执行器名称 */
 export const DEFAULT_EXECUTOR = 'claudecode';
+
+// =============================================================================
+// Layout & UI constants — single source of truth for layout values.
+// =============================================================================
+
+/** 布局断点 */
+export const BREAKPOINTS = {
+  /** 宽屏断点：超过此宽度显示双栏布局 */
+  wide: 1440,
+  /** 移动端断点：低于此宽度启用移动端适配 */
+  mobile: 768,
+} as const;
+
+/** 侧边栏宽度 */
+export const SIDEBAR_WIDTH = {
+  /** 桌面端侧边栏宽度 */
+  desktop: 350,
+  /** 移动端侧边栏占满宽度 */
+  mobile: '100%',
+} as const;
+
+/** 执行面板高度 */
+export const EXECUTION_PANEL = {
+  /** 展开时高度 */
+  expanded: 280,
+  /** 折叠时高度 */
+  collapsed: 40,
+} as const;
+
+/** 触摸滑动阈值 */
+export const SWIPE = {
+  /** 滑动距离阈值（px） */
+  threshold: 50,
+  /** 滑动最大时间（ms） */
+  maxTime: 300,
+} as const;
+
+/** 定时器间隔 */
+export const TIMER = {
+  /** 执行状态刷新间隔（ms） */
+  tickInterval: 1000,
+  /** 完成任务自动移除延迟（ms） */
+  autoRemoveDelay: 5000,
+} as const;
+
+/** 文本截断长度 */
+export const TEXT_TRUNCATE = {
+  /** Todo 标题截断长度 */
+  todoTitle: 60,
+  /** Todo 摘要截断长度 */
+  todoSummary: 20,
+  /** 工具输入预览截断长度 */
+  toolInput: 50,
+  /** 工具输入字段值截断长度 */
+  toolInputField: 15,
+  /** 日志内容截断长度 */
+  logContent: 2000,
+} as const;
+
+/** 导出限制 */
+export const EXPORT = {
+  /** 导出时最大获取日志条数 */
+  maxLogs: 100000,
+} as const;
+
+/** 复制反馈延迟 */
+export const COPY_FEEDBACK_DELAY = 2000;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -41,6 +41,9 @@ export const STATUS_COLORS = {
 } as const;
 
 /** Log 类型颜色 */
+// 使用 Record<string, string> 而非 as const，因为 LOG_TYPE_COLORS 需要通过
+// 动态字符串键访问（如 LOG_TYPE_COLORS[log.type]，log.type 是运行时字符串）。
+// STATUS_COLORS 使用 as const 是因为所有使用处都是已知键（如 .running）。
 export const LOG_TYPE_COLORS: Record<string, string> = {
   info: '#6b7280',
   stdout: '#3b82f6',
@@ -59,24 +62,24 @@ export const LOG_TYPE_COLORS: Record<string, string> = {
   tokens: '#6b7280',
 };
 
-/** 默认执行器名称 */
-export const DEFAULT_EXECUTOR = 'claudecode';
-
 // =============================================================================
 // Layout & UI constants — single source of truth for layout values.
 // =============================================================================
 
 /** 布局断点 */
 export const BREAKPOINTS = {
-  /** 宽屏断点：超过此宽度显示双栏布局 */
+  /** 宽屏断点：超过此宽度显示双栏布局。1440px 是主流笔记本屏幕（14-16 寸）
+   *  的常见分辨率宽度，能同时容纳侧边栏和内容区而不拥挤。 */
   wide: 1440,
-  /** 移动端断点：低于此宽度启用移动端适配 */
+  /** 移动端断点：低于此宽度启用移动端适配。768px 是 iPad mini 竖屏宽度，
+   *  也是 Bootstrap/主流 CSS 框架的常用平板断点。 */
   mobile: 768,
 } as const;
 
 /** 侧边栏宽度 */
 export const SIDEBAR_WIDTH = {
-  /** 桌面端侧边栏宽度 */
+  /** 桌面端侧边栏宽度。350px 能容纳 TodoCard 的标题、状态、标签等元素，
+   *  且为右侧内容区留出足够空间（在 1440px 宽屏下内容区约 1090px）。 */
   desktop: 350,
   /** 移动端侧边栏占满宽度 */
   mobile: '100%',
@@ -84,45 +87,52 @@ export const SIDEBAR_WIDTH = {
 
 /** 执行面板高度 */
 export const EXECUTION_PANEL = {
-  /** 展开时高度 */
+  /** 展开时高度。280px 能展示 3-4 条执行记录，过高会挤压上方 Todo 列表可视区。 */
   expanded: 280,
-  /** 折叠时高度 */
+  /** 折叠时高度。40px 刚好容纳 header 行（含展开按钮和状态文本）。 */
   collapsed: 40,
 } as const;
 
 /** 触摸滑动阈值 */
 export const SWIPE = {
-  /** 滑动距离阈值（px） */
+  /** 滑动距离阈值（px）。50px 是人手指在屏幕上做"滑动删除"手势的合理最小距离，
+   *  低于此值视为误触而不触发滑动操作。 */
   threshold: 50,
-  /** 滑动最大时间（ms） */
+  /** 滑动最大时间（ms）。300ms 是快速滑动手势的典型时长，超过此值视为
+   *  慢速拖动而非滑动操作。 */
   maxTime: 300,
 } as const;
 
 /** 定时器间隔 */
 export const TIMER = {
-  /** 执行状态刷新间隔（ms） */
+  /** 执行状态刷新间隔（ms）。1000ms 是轮询的合理平衡：低于此值增加服务端负载
+   *  而无明显 UX 改善（人类感知延迟阈值约 100-200ms 但执行状态变化本身是分钟级的）。 */
   tickInterval: 1000,
-  /** 完成任务自动移除延迟（ms） */
+  /** 完成任务自动移除延迟（ms）。5000ms 给用户足够时间看到"已完成"状态后
+   *  再自动移除，避免突兀消失。 */
   autoRemoveDelay: 5000,
 } as const;
 
 /** 文本截断长度 */
 export const TEXT_TRUNCATE = {
-  /** Todo 标题截断长度 */
+  /** Todo 标题截断长度。60 字符约等于一行中文字符宽度，
+   *  在 350px 侧边栏内能完整显示而不换行。 */
   todoTitle: 60,
-  /** Todo 摘要截断长度 */
+  /** Todo 摘要截断长度。20 字符在卡片中作为副标题预览足够。 */
   todoSummary: 20,
-  /** 工具输入预览截断长度 */
+  /** 工具输入预览截断长度。50 字符支持显示完整路径或命令。 */
   toolInput: 50,
-  /** 工具输入字段值截断长度 */
+  /** 工具输入字段值截断长度。15 字符适合显示单个参数值。 */
   toolInputField: 15,
-  /** 日志内容截断长度 */
+  /** 日志内容截断长度。2000 字符确保抽屉中日志渲染不阻塞 UI，
+   *  超长日志在后端已分片存储，前端只展示前 2000 字预览。 */
   logContent: 2000,
 } as const;
 
 /** 导出限制 */
 export const EXPORT = {
-  /** 导出时最大获取日志条数 */
+  /** 导出时最大获取日志条数。100000 条在 SQLite 单表查询中能在 1-2 秒内完成，
+   *  超过此量级说明日志规模已不适合前端直接导出，应走数据库备份流程。 */
   maxLogs: 100000,
 } as const;
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -17,13 +17,18 @@ export const MAX_EXECUTION_TIMEOUT_MINUTES = 10080;
 // =============================================================================
 
 /** Todo 执行状态颜色 */
+// `completed` 与 `success` 指向同一颜色：历史 API/前端组件有两套命名约定
+// （后端 status 字段为 'success'，前端 DashboardStats.completed_todos 用 'completed'），
+// 这里并列两个键以保持两边调用方都能直接拿到颜色，避免再次出现双源 STATUS_COLORS。
 export const STATUS_COLORS = {
   /** 待执行 (pending) */
   pending: '#06b6d4',
   /** 执行中 (running) */
   running: '#f59e0b',
-  /** 已完成 (completed/success) */
+  /** 已完成 (success) — 后端 status 字段名 */
   success: '#22c55e',
+  /** 已完成 (completed) — 前端 DashboardStats 字段名（与 success 同色） */
+  completed: '#22c55e',
   /** 失败 (failed/error) */
   failed: '#ef4444',
   /** 定时任务 (cron/scheduled) */

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -65,6 +65,49 @@ export const LOG_TYPE_COLORS: Record<string, string> = {
   step_start: '#06b6d4',
   step_finish: '#06b6d4',
   tokens: '#6b7280',
+  // 兼容 helpers.ts 迁移的旧键
+  text: '#4ade80',
+  tool: '#fbbf24',
+};
+
+/** Log 类型显示标签 */
+export const LOG_TYPE_LABELS: Record<string, string> = {
+  info: 'INFO', text: 'TEXT', tool: 'TOOL', tool_use: 'TOOL', tool_call: 'TOOL',
+  tool_result: 'RESULT', step_start: 'START', step_finish: 'END', stdout: 'OUT',
+  stderr: 'LOG', error: 'ERROR', system: 'SYS', assistant: 'ASST', user: 'USER',
+  result: 'RESULT', thinking: 'THINK', tokens: 'INFO',
+};
+
+/** 任务状态标签 */
+export const STATUS_LABELS: Record<string, string> = {
+  pending: '待处理',
+  running: '运行中',
+  completed: '已完成',
+  failed: '失败',
+};
+
+/** 触发类型标签 */
+export const TRIGGER_LABELS: Record<string, string> = {
+  manual: '手动',
+  cron: '定时',
+  slash_command: '命令',
+  default_response: '默认回复',
+};
+
+/** 触发类型颜色（独立于 STATUS_COLORS，值碰巧相同但语义不同） */
+export const TRIGGER_COLORS: Record<string, string> = {
+  manual: '#3b82f6',
+  cron: '#8b5cf6',
+  slash_command: '#f59e0b',
+  default_response: '#22c55e',
+};
+
+/** 评审结果颜色，与 STATUS_COLORS 解耦 */
+export const REVIEW_RESULT_COLORS: Record<string, string> = {
+  pending: '#06b6d4',
+  success: '#10b981',
+  failed: '#ef4444',
+  interrupted: '#f59e0b',
 };
 
 // =============================================================================

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -11,3 +11,53 @@ export const DEFAULT_EXECUTION_TIMEOUT_SECS = 3600;
  * Derived from backend config::MAX_EXECUTION_TIMEOUT_SECS (604800 seconds).
  * If you change one side, update the other: MAX_EXECUTION_TIMEOUT_SECS / 60 = 10080. */
 export const MAX_EXECUTION_TIMEOUT_MINUTES = 10080;
+
+// =============================================================================
+// Status colors — single source of truth for status-related colors.
+// =============================================================================
+
+/** Todo 执行状态颜色 */
+export const STATUS_COLORS = {
+  /** 待执行 (pending) */
+  pending: '#06b6d4',
+  /** 执行中 (running) */
+  running: '#f59e0b',
+  /** 已完成 (completed/success) */
+  success: '#22c55e',
+  /** 失败 (failed/error) */
+  failed: '#ef4444',
+  /** 定时任务 (cron/scheduled) */
+  scheduled: '#8b5cf6',
+  /** 评审中 (reviewing) */
+  reviewing: '#06b6d4',
+  /** 评审通过 (review passed) */
+  reviewPassed: '#10b981',
+  /** 评审失败 (review failed) */
+  reviewFailed: '#ef4444',
+  /** 评审中断 (review interrupted) */
+  reviewInterrupted: '#f59e0b',
+  /** Hook 触发 */
+  hook: '#a855f7',
+} as const;
+
+/** Log 类型颜色 */
+export const LOG_TYPE_COLORS: Record<string, string> = {
+  info: '#6b7280',
+  stdout: '#3b82f6',
+  stderr: '#ef4444',
+  error: '#ef4444',
+  tool_use: '#8b5cf6',
+  tool_call: '#8b5cf6',
+  tool_result: '#10b981',
+  assistant: '#0ea5e9',
+  user: '#f59e0b',
+  system: '#6b7280',
+  thinking: '#a855f7',
+  result: '#22c55e',
+  step_start: '#06b6d4',
+  step_finish: '#06b6d4',
+  tokens: '#6b7280',
+};
+
+/** 默认执行器名称 */
+export const DEFAULT_EXECUTOR = 'claudecode';

--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -5,6 +5,7 @@
  */
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { zhCN } from 'date-fns/locale';
+import { formatDurationSec } from './format';
 
 export function parseUtcDate(timeStr: string | null | undefined): Date | null {
   if (!timeStr) return null;
@@ -30,15 +31,12 @@ export function formatRelativeTime(timeStr: string | null | undefined): string {
 }
 
 /**
- * 格式化时长（秒）
+ * 格式化时长（秒）为人类可读字符串。
+ *
+ * 委托给 format.ts 中的 formatDurationSec 实现。
+ * 保留此导出以维持向后兼容性。
  */
-export function formatDuration(seconds: number): string {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  if (h > 0) return `${h}h${m}m`;
-  if (m > 0) return `${m}m`;
-  return `${seconds}s`;
-}
+export const formatDuration = formatDurationSec;
 
 /**
  * 计算从指定时间到现在经过的秒数

--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -5,7 +5,6 @@
  */
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { zhCN } from 'date-fns/locale';
-import { formatDurationSec } from './format';
 
 export function parseUtcDate(timeStr: string | null | undefined): Date | null {
   if (!timeStr) return null;
@@ -30,13 +29,8 @@ export function formatRelativeTime(timeStr: string | null | undefined): string {
   return formatDistanceToNow(date, { addSuffix: true, locale: zhCN });
 }
 
-/**
- * 格式化时长（秒）为人类可读字符串。
- *
- * 委托给 format.ts 中的 formatDurationSec 实现。
- * 保留此导出以维持向后兼容性。
- */
-export const formatDuration = formatDurationSec;
+/** 格式化时长（秒）为人类可读字符串 */
+export { formatDurationSec } from './format';
 
 /**
  * 计算从指定时间到现在经过的秒数

--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -31,13 +31,3 @@ export function formatRelativeTime(timeStr: string | null | undefined): string {
 
 /** 格式化时长（秒）为人类可读字符串 */
 export { formatDurationSec } from './format';
-
-/**
- * 计算从指定时间到现在经过的秒数
- */
-export function elapsedSeconds(startTimeStr: string | null | undefined): number {
-  const date = parseUtcDate(startTimeStr);
-  if (!date) return 0;
-  const now = new Date();
-  return Math.floor((now.getTime() - date.getTime()) / 1000);
-}

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -2,6 +2,12 @@
  * 格式化工具函数
  *
  * 集中管理项目中重复出现的格式化逻辑，避免在多个组件中维护各自的实现。
+ *
+ * 设计权衡：
+ * - 统一使用 zh-CN locale：用户群体以中文为主，日期时间格式保持中文习惯。
+ * - formatDuration 使用简洁的 "1.5m" 格式：节省 RunningRecordDrawer 等抽屉的 UI
+ *   空间，详情页使用 formatDurationSec 提供完整 "1h30m" 格式。
+ * - M 值保留 1 位小数：在精度和可读性之间平衡，2 位小数对 token 量级意义不大。
  */
 
 /**
@@ -13,7 +19,7 @@
  * - >= 60s → 显示分钟（如 "1.5m"）
  */
 export function formatDuration(ms: number | null): string {
-  if (!ms) return '-';
+  if (ms === null) return '-';
   if (ms < 1_000) return `${ms}ms`;
   if (ms < 60_000) return `${(ms / 1_000).toFixed(0)}s`;
   return `${(ms / 60_000).toFixed(1)}m`;

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,132 @@
+/**
+ * 格式化工具函数
+ *
+ * 集中管理项目中重复出现的格式化逻辑，避免在多个组件中维护各自的实现。
+ */
+
+/**
+ * 格式化时长（毫秒）为人类可读字符串。
+ *
+ * 规则：
+ * - < 1s → 显示毫秒（如 "500ms"）
+ * - < 60s → 显示秒（如 "30s"）
+ * - >= 60s → 显示分钟（如 "1.5m"）
+ */
+export function formatDuration(ms: number | null): string {
+  if (!ms) return '-';
+  if (ms < 1_000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1_000).toFixed(0)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+/**
+ * 格式化时长（秒）为人类可读字符串。
+ *
+ * 用于需要先将毫秒转换为秒再格式化的场景。
+ * 例如：formatDurationSec(record.usage.duration_ms / 1000)
+ */
+export function formatDurationSec(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h}h${m}m`;
+  if (m > 0) return `${m}m`;
+  return `${seconds}s`;
+}
+
+/**
+ * 格式化 token 数量为人类可读字符串。
+ *
+ * 规则：
+ * - < 1000 → 原样显示
+ * - < 1M → 显示为 K（如 "1.5K"）
+ * - >= 1M → 显示为 M（如 "2.5M"）
+ */
+export function formatTokens(n: number): string {
+  if (n < 1_000) return String(n);
+  if (n < 1_000_000) return `${(n / 1_000).toFixed(1)}K`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
+/**
+ * 格式化 ISO 时间戳为相对时间字符串（如 "3 分钟前"）。
+ *
+ * 规则：
+ * - < 1 分钟 → "刚刚"
+ * - < 60 分钟 → "X 分钟前"
+ * - < 24 小时 → "X 小时前"
+ * - < 30 天 → "X 天前"
+ * - 其他 → 显示日期时间
+ */
+export function formatRelativeTimeFromNow(iso?: string | null): string {
+  if (!iso) return '-';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '-';
+    const now = new Date();
+    const diffMs = now.getTime() - d.getTime();
+    const diffMin = Math.floor(diffMs / 60000);
+
+    if (diffMin < 1) return '刚刚';
+    if (diffMin < 60) return `${diffMin} 分钟前`;
+    const diffHour = Math.floor(diffMin / 60);
+    if (diffHour < 24) return `${diffHour} 小时前`;
+    const diffDay = Math.floor(diffHour / 24);
+    if (diffDay < 30) return `${diffDay} 天前`;
+
+    return d.toLocaleDateString('zh-CN', {
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/**
+ * 格式化 ISO 时间戳为完整日期时间字符串（如 "2024-01-15 14:30"）。
+ */
+export function formatDateTime(iso: string | null): string {
+  if (!iso) return '-';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return (
+      d.toLocaleDateString('zh-CN') +
+      ' ' +
+      d.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' })
+    );
+  } catch {
+    return iso;
+  }
+}
+
+/**
+ * 格式化 ISO 时间戳为时分秒字符串（如 "14:30:25"）。
+ */
+export function formatTimeFull(iso?: string): string {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toLocaleTimeString('zh-CN', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * 计算从指定时间到现在经过的秒数。
+ */
+export function elapsedSeconds(startTimeStr: string | null | undefined): number {
+  const date = new Date(startTimeStr || '');
+  if (Number.isNaN(date.getTime())) return 0;
+  const now = new Date();
+  return Math.floor((now.getTime() - date.getTime()) / 1000);
+}


### PR DESCRIPTION
## Summary

基于 *Clean Code* 和 *Refactoring 2nd Edition* 原则，对项目进行全面重构。

### 后端重构

- **合并重复代码**：将 `backup.rs` 中 3 个完全相同的 `cleanup_old_*_backups` 函数合并为 1 个通用 `cleanup_old_zip_backups`；提取 `is_safe_filename` 函数替换 6 处重复的安全检查
- **拆分大函数**：将 705 行的 `get_dashboard_stats` 函数拆分为 14 个独立的查询函数（`dashboard.rs`），使用 `tokio::try_join!` 并行执行独立查询，提高性能
- **提取辅助函数**：从 `run_todo_execution`（911 行）中提取 `format_timeout_secs` 和 `extract_execution_stats` 辅助函数

### 前端重构

- **合并重复工具函数**：创建 `format.ts`，统一 `formatDuration`/`formatTokens`/`formatTime`/`elapsedSeconds` 等重复实现
- **提取共享常量**：在 `constants.ts` 中添加 `STATUS_COLORS`、`LOG_TYPE_COLORS`、`BREAKPOINTS`、`SIDEBAR_WIDTH`、`EXECUTION_PANEL`、`SWIPE`、`TIMER`、`TEXT_TRUNCATE`、`EXPORT` 等常量
- **状态管理优化**：将 `TodoDrawer` 的 16 个 `useState` 重构为 `useReducer`，通过 `RESET_FORM` action 实现表单状态的原子性重置

### 统计

```
18 files changed, 1291 insertions(+), 925 deletions(-)
```

### 验证

- ✅ 后端 `cargo check` 通过
- ✅ 前端 `npx tsc --noEmit` 通过
- ✅ 前端 `npm run build` 通过