### PR TITLE
fix: 改进 skills 同步错误提示，修复 NotFound 不友好问题 (#564)

### DIFF
--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -1028,7 +1028,20 @@ pub async fn sync_skill(
         .ok_or_else(|| AppError::BadRequest(format!("Unknown source executor: {}", req.source_executor)))?;
 
     // 统一 containment 校验
-    let skill_dir = resolve_skill_path_under(&source_dir, &req.skill_name)?;
+    // 404（NotFound）在这里对用户不友好，转化为带上下文的 BadRequest
+    let skill_dir = resolve_skill_path_under(&source_dir, &req.skill_name)
+        .map_err(|e| {
+            if matches!(e, AppError::NotFound) {
+                AppError::BadRequest(format!(
+                    "Skill '{}' not found in executor '{}' (directory: {})",
+                    req.skill_name,
+                    req.source_executor,
+                    source_dir.display()
+                ))
+            } else {
+                e
+            }
+        })?;
 
     let mut synced = Vec::new();
     let mut errors = Vec::new();
@@ -1114,7 +1127,7 @@ pub async fn sync_skill(
     }
 
     if synced.is_empty() && !errors.is_empty() {
-        return Err(AppError::Internal(errors.join("; ")));
+        return Err(AppError::BadRequest(errors.join("; ")));
     }
 
     let mut msg = format!("Synced '{}' (flattened) to: {}", req.skill_name, synced.join(", "));

--- a/frontend/src/components/skills/SkillSync.tsx
+++ b/frontend/src/components/skills/SkillSync.tsx
@@ -44,7 +44,9 @@ export function SkillSync() {
       setSyncResult(result);
       message.success('同步完成');
     } catch (err: any) {
-      message.error('同步失败: ' + (err?.message || String(err)));
+      const errMsg = err?.message || String(err);
+      setSyncResult('❌ 同步失败: ' + errMsg);
+      message.error('同步失败');
     } finally {
       setSyncing(false);
     }
@@ -155,7 +157,7 @@ export function SkillSync() {
           {syncResult && (
             <Alert
               message={syncResult}
-              type="success"
+              type={syncResult.includes('❌') ? 'error' : syncResult.includes('Error') || syncResult.includes('Errors') ? 'warning' : 'success'}
               showIcon
             />
           )}


### PR DESCRIPTION
## 问题描述

Issue #564: skills 同步失败时提示 `同步失败NotFound`，错误信息不清晰，且未能成功同步 skill。

## 根因分析

1. `sync_skill` 中调用 `resolve_skill_path_under` 时，如果源 skill 路径不存在（`canonicalize` 失败），返回 `AppError::NotFound`，其消息为硬编码 `"Not found"`，用户无法理解
2. 当所有目标执行器都同步失败时，错误使用 `AppError::Internal`（HTTP 500），实际上这是用户操作问题而非服务器内部错误
3. 前端 catch 块仅弹出短暂 `message.error`，用户来不及查看详细错误

## 修改内容

### 后端
- `sync_skill`: 将 `resolve_skill_path_under` 返回的 `NotFound` 转化为带上下文的 `BadRequest`，显示具体的 executor 名称和目录路径
- `sync_skill`: 全部同步失败时改用 `BadRequest`（HTTP 400）而非 `Internal`（HTTP 500）

### 前端  
- catch 块将在页面上（Alert 组件）持久显示详细的错误信息
- Alert 类型根据内容动态切换（error/warning/success）

## 测试

（后续由 Playwright 自动化验证）
