### PR TITLE
fix(skills-sync): 修复 SKILL.md YAML name 与目录名不一致时同步失败

### DIFF
--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -1029,17 +1029,55 @@ pub async fn sync_skill(
 
     // 统一 containment 校验
     // 404（NotFound）在这里对用户不友好，转化为带上下文的 BadRequest
+    //
+    // 注意：SKILL.md 中 YAML front matter 定义的 name 可能与磁盘目录名不一致。
+    // 例如 SKILL.md 中写 `name: r2-backup` 但目录名是 `imported-skill`。
+    // `resolve_skill_path_under` 是按磁盘路径查找的，如果按 name 找不到，
+    // 需要 fallback 到扫描所有子目录，匹配 YAML 中定义的 name。
     let skill_dir = resolve_skill_path_under(&source_dir, &req.skill_name)
-        .map_err(|e| {
+        .or_else(|e| {
+            // 按 name 直接 join 找不到时，尝试扫描所有子目录匹配 YAML front matter 中的 name
             if matches!(e, AppError::NotFound) {
-                AppError::BadRequest(format!(
-                    "Skill '{}' not found in executor '{}' (directory: {})",
-                    req.skill_name,
-                    req.source_executor,
-                    source_dir.display()
-                ))
+                // 扫描 source_dir 下所有 skill 子目录，匹配 SKILL.md 的 YAML name
+                let mut found: Option<PathBuf> = None;
+                if let Ok(entries) = std::fs::read_dir(&source_dir) {
+                    for entry in entries.flatten() {
+                        let path = entry.path();
+                        if !path.is_dir() {
+                            continue;
+                        }
+                        let skill_md = path.join("SKILL.md");
+                        if skill_md.exists() {
+                            if let Ok(content) = std::fs::read_to_string(&skill_md) {
+                                if let Some(yaml) = extract_yaml_front_matter(&content) {
+                                    for line in yaml.lines() {
+                                        if let Some(val) = line.strip_prefix("name:") {
+                                            let yaml_name = val.trim().trim_matches('"').to_string();
+                                            if yaml_name == req.skill_name {
+                                                found = Some(path);
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        if found.is_some() {
+                            break;
+                        }
+                    }
+                }
+                match found {
+                    Some(path) => Ok(path),
+                    None => Err(AppError::BadRequest(format!(
+                        "Skill '{}' not found in executor '{}' (directory: {})",
+                        req.skill_name,
+                        req.source_executor,
+                        source_dir.display()
+                    ))),
+                }
             } else {
-                e
+                Err(e)
             }
         })?;
 

--- a/frontend/src/components/skills/SkillDetailDrawer.tsx
+++ b/frontend/src/components/skills/SkillDetailDrawer.tsx
@@ -220,15 +220,18 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
               const exists = executorsData.find(ex => ex.executor === exec.value);
               const targetName = skill?.name?.split('/').pop() || skill?.name;
               const alreadyHas = exists?.skills.find(s => s.name === targetName);
+              // agents 是只读来源，不能作为同步目标
+              const isReadonly = exec.value === 'agents';
               return (
                 <Col span={12} key={exec.value}>
-                  <Checkbox value={exec.value}>
+                  <Checkbox value={exec.value} disabled={isReadonly}>
                     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
                       <span style={{
                         width: 6, height: 6, borderRadius: '50%',
                         backgroundColor: exec.color,
                       }} />
                       {exec.label}
+                      {isReadonly && <Tag color="default" style={{ fontSize: 10 }}>只读</Tag>}
                       {alreadyHas && <Tag color="orange" style={{ fontSize: 10 }}>已存在</Tag>}
                     </span>
                   </Checkbox>


### PR DESCRIPTION
## 问题
当 SKILL.md 中 YAML front matter 定义的 `name` 与磁盘目录名不一致时（例如 YAML 中 `name: r2-backup` 但目录名是 `imported-skill`），`sync_skill` 直接按 name join 路径会找不到目录，导致同步返回 NotFound 错误，功能报错。

## 修复
1. **后端 `sync_skill`**：增加 fallback 逻辑。当按 name 直接找不到目录时，扫描源 skills 目录下所有子目录，读取 SKILL.md 的 YAML front matter，匹配 `name` 字段来找到正确的磁盘路径。
2. **前端 `SkillDetailDrawer`**：同步弹窗中 `agents` 执行器增加 `disabled` 只读标记，与 `SkillSync` 页面行为保持一致。

## 测试
- [x] 同步 YAML name != 目录名的 skill (r2-backup) ✓
- [x] 同步嵌套路径 skill (devops/webhook-subscriptions) ✓
- [x] 同步不存在的 skill 正确返回错误 ✓
- [x] agents 作为目标被正确拒绝 ✓
- [x] 同步普通 skill (目录名 == YAML name) ✓
- [x] 验证同步后文件列表与源一致 ✓

Closes #566