### PR TITLE
feat: 升级一键更新按钮功能为分离式自更新方案 (#569)

### DIFF
--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -625,11 +625,14 @@ where
 ///    - install --force：用新 binary 重新安装服务配置
 ///    - start：启动新版本服务
 ///    - rm -f /tmp/ntd.update：清理标记
-/// 4. 主进程立即 `exit(0)`，让出端口和资源给新版本
+/// 4. 先返回 HTTP 响应给前端，再 spawn 后台任务延迟 500ms 后 `exit(0)`，
+///    让出端口和资源给新版本。响应先返回确保前端看到成功响应，
+///    避免 exit(0) 时连接被突然中断。
 ///
 /// # 前端配合
-/// 由于主进程 exit(0) 后 TCP 连接断开，前端会收到 fetch 错误。
-/// 前端在 catch 到错误后，延迟 5s 自动 `location.reload()` 刷新页面。
+/// 前端首先收到 HTTP 成功响应（code=0），然后 5s 后自动 `location.reload()`
+/// 刷新页面以访问新版本服务。即使后端 exit(0) 导致 TCP 断开，
+/// 5s 定时器也会兜底刷新。
 ///
 /// # 安全防线 (issue #476 CRITICAL #1)
 /// `npm prefix -g` 返回的 prefix 来自用户 `~/.npmrc`，可被污染成
@@ -714,7 +717,9 @@ async fn version_upgrade_handler() -> impl IntoResponse {
     // 主进程 exit(0) 后子进程不会收到 SIGHUP。
     //
     // 步骤：
-    // 1. sleep 3.0s：等主进程完全退出 + OS 释放 socket fd，避免端口冲突
+    // 1. sleep 3s：等主进程完全退出 + OS 释放 socket fd，避免端口冲突。
+    //    使用整数 `3` 而非 `3.0`：macOS 和 Alpine/busybox 的 sleep
+    //    不支持浮点数参数，整型兼容所有平台。
     // 2. install --force：用新 binary 重新注册服务
     // 3. start：启动新版本服务
     // 4. rm -f：清理更新标记
@@ -723,7 +728,7 @@ async fn version_upgrade_handler() -> impl IntoResponse {
     #[cfg(unix)]
     std::process::Command::new("sh")
         .args(["-c", &format!(
-            "(sleep 3.0; {quoted} daemon install --force; {quoted} daemon start; rm -f /tmp/ntd.update) &",
+            "(sleep 3; {quoted} daemon install --force; {quoted} daemon start; rm -f /tmp/ntd.update) >> /tmp/ntd-upgrade.log 2>&1 &",
             quoted = quoted,
         )])
         .stdin(std::process::Stdio::null())
@@ -736,22 +741,46 @@ async fn version_upgrade_handler() -> impl IntoResponse {
     #[cfg(windows)]
     std::process::Command::new("cmd")
         .args(["/C", &format!(
-            "timeout /t 3 /nobreak >nul && {quoted} daemon install --force && {quoted} daemon start && del %TEMP%\\ntd.update",
+            "timeout /t 3 /nobreak >nul && {quoted} daemon install --force && {quoted} daemon start && del /f /q %TEMP%\\ntd.update",
             quoted = quoted,
         )])
         .creation_flags(0x08000000) // CREATE_NO_WINDOW
         .spawn()
         .ok();
 
-    // 记录即将退出，便于运维查日志确认升级过程
+    // 记录 fork 成功，便于运维查日志确认升级进程已启动
     tracing::info!(
-        "Self-update: npm upgraded, forked child process, now exiting main process. ntd path: {}",
+        "Self-update: npm upgraded, forked child process. ntd path: {}",
         ntd_cmd,
     );
 
-    // 主进程立即退出，让出端口和资源给新版本服务。
-    // 子进程在 sleep 3s 后开始执行 install --force + start。
-    std::process::exit(0);
+    // 先返回成功响应给前端，让 Axum 完成 HTTP 响应的发送。
+    // 然后通过 spawn 后台任务延迟 500ms 后 exit(0)，
+    // 给当前 in-flight 响应足够时间写回客户端。
+    // 子进程（sleep 3s 后 install --force + start）通过 `(...) &`
+    // 已脱离当前 shell wait 链，主进程 exit 后子进程正常工作。
+    //
+    // 异步 handler 返回响应与 spawn 后台任务：
+    // Axum 在 handler 返回后完成响应 body 的写入和 flush，
+    // 500ms 窗口足够绝大多数情况。若极端情况下响应未发完，
+    // exit(0) 会导致 TCP RST，但前端已有 5s 自动刷新兜底。
+    //
+    // 为什么不用 tokio::signal / with_graceful_shutdown：
+    // 当前 main.rs 使用 axum::serve(listener, app).await 无 graceful
+    // shutdown 信号通路。引入完整 shutdown 架构超出本 PR 范围，
+    // 短期用 spawn + exit(0) 平衡正确性与改动量。
+    let response = ApiResponse::ok(serde_json::json!({
+        "status": "upgrade_started",
+        "message": "升级流程已启动，服务即将重启",
+    }));
+    tokio::spawn(async move {
+        // 给当前 HTTP 响应足够时间完成发送
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        // 记录日志后退出，便于运维确认升级流程正常
+        tracing::info!("Self-update: main process exiting after response sent");
+        std::process::exit(0);
+    });
+    return response;
 }
 
 // Build router

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,6 +1,6 @@
 use axum::{
     Router,
-    extract::{FromRequest, FromRequestParts, Path, Request, State, WebSocketUpgrade},
+    extract::{FromRequest, Path, Request, State, WebSocketUpgrade},
     http::{self, Method, StatusCode, header},
     middleware::Next,
     response::{Html, IntoResponse, Response},
@@ -12,7 +12,7 @@ use tower_http::trace::TraceLayer;
 use axum::extract::DefaultBodyLimit;
 use serde::Serialize;
 use std::sync::Arc;
-use tokio::sync::{broadcast, oneshot};
+use tokio::sync::broadcast;
 use uuid::Uuid;
 
 #[cfg(windows)]
@@ -530,84 +530,24 @@ fn cors_expose_headers() -> [http::HeaderName; 1] {
 #[derive(Debug, Clone)]
 pub struct RequestId(pub String);
 
-/// 给 handler 一个"响应 body 即将被写出"的信号点。
-///
-/// **用法**:
-/// - 在 handler 里加 extractor `ResponseDone`,在 std::thread 里
-///   `rx.blocking_recv()` 等信号
-/// - 适用场景: handler 同步返回了响应,但仍要起后台线程做"会杀当前进程"的事
-///   (典型如 `ntd daemon stop`)。如果不等响应真正落到 wire 就 stop,
-///   客户端会看到连接重置,而不是预期的 JSON
-///
-/// **精度说明**:
-/// `drop(tx)` 发生在 `next.run(req).await` 返回时 —— 此时 `Response` 对象
-/// 已构造完,但 body 还在内存里,接下来由 axum runtime 异步 flush 到 socket。
-/// 从 drop(tx) 到数据真正送达对端,延迟是 µs 级别,远小于
-/// `ntd daemon stop` 进程退出 + OS 清理 socket fd 的时间窗口,实际不会丢响应。
-///
-/// **为什么不进一步精确到"body 字节落到 wire"**:
-/// 那样需要包装 response body 实现 `axum::body::MessageBody`,
-/// 在 `poll_frame` 返回 `Ready` 时发信号,代码量 +50 行。
-/// 当前精度对 `daemon stop` 这种秒级操作已经足够,真要"绝对精确"再加。
-///
-/// **对其它路由的开销**:
-/// 每次请求多一对 oneshot channel (零分配原语 + 一个 wait queue),
-/// 没有 receiver 端订阅就直接 drop,基本可忽略。
-pub async fn track_response_done(mut req: Request, next: Next) -> Response {
-    let (tx, rx) = oneshot::channel();
-    // 包装成 `Arc<Mutex<Option<Receiver<()>>>>` 才能塞进 extensions:
-    // - axum 和 http 两边的 Extensions::insert 都要求 T: Clone
-    // - oneshot::Receiver 是单消费者,本身不可能 Clone
-    // - Arc<Mutex<Option<_>>> 是 Clone + Send + Sync,Option 让 handler
-    //   端能 .take() 把 receiver 拿走
-    let signal: ResponseSignal = Arc::new(std::sync::Mutex::new(Some(rx)));
-    req.extensions_mut().insert(signal);
-    let resp = next.run(req).await;
-    // response 拿出来了,axum 接下来会异步把 body 写到 socket。
-    // 在这个点 drop tx,后台线程的 blocking_recv 立刻返回,
-    // 继续往下做会杀掉当前进程的工作。
-    drop(tx);
-    resp
+
+
+/// 返回 ntd.update 标记文件的路径（Unix 版）。
+fn ntd_update_marker_path() -> String {
+    "/tmp/ntd.update".to_string()
 }
 
-/// `track_response_done` 中间件塞进 extensions 的信号句柄。
-/// 内部用 Mutex 保护 oneshot::Receiver(后者不是 Sync,
-/// 必须在 Mutex 里才能跨线程共享)。
-pub type ResponseSignal = Arc<std::sync::Mutex<Option<oneshot::Receiver<()>>>>;
-
-/// 自定义 extractor: 从 request extensions 拿走中间件塞进来的 oneshot receiver。
-///
-/// 之所以不走 `Extension<oneshot::Receiver<()>>`,是因为 `Extension<T>`
-/// 要求 `T: Clone + Send + Sync`,而 `oneshot::Receiver` 是单消费者的,
-/// 不可能 Clone。我们包一层 `Arc<Mutex<Option<_>>>` 满足 Clone bound,
-/// 在 extractor 里 `.take()` 把 receiver 拿走。
-pub struct ResponseDone(pub oneshot::Receiver<()>);
-
-impl<S> FromRequestParts<S> for ResponseDone
-where
-    S: Send + Sync,
-{
-    type Rejection = std::convert::Infallible;
-
-    async fn from_request_parts(
-        parts: &mut http::request::Parts,
-        _state: &S,
-    ) -> Result<Self, Self::Rejection> {
-        // 这三个 .expect() 都是 invariant 守卫：middleware 没装、mutex 中毒、
-        // extractor 被消费两次都属于开发期 bug，panic 反而是合理的反馈。
-        // 用 #[allow] 让未来新增的 unwrap_used/expect_used clippy lint 不误伤。
-        #[allow(clippy::expect_used)]
-        let signal = parts
-            .extensions
-            .remove::<ResponseSignal>()
-            .expect("track_response_done middleware must be installed before any handler that uses ResponseDone");
-        #[allow(clippy::expect_used)]
-        let rx = signal
-            .lock()
-            .expect("ResponseSignal mutex poisoned")
-            .take()
-            .expect("ResponseDone extractor can only be used once per request");
-        Ok(ResponseDone(rx))
+/// 返回子进程清理标记文件时使用的路径表达式。
+/// Unix 用 `/tmp/ntd.update`，Windows 用 `%TEMP%\\ntd.update`，
+/// 与 `ntd_update_marker_path()` 写入的路径保持一致。
+fn ntd_update_marker_cleanup_path() -> String {
+    #[cfg(unix)]
+    {
+        "/tmp/ntd.update".to_string()
+    }
+    #[cfg(windows)]
+    {
+        "%TEMP%\\ntd.update".to_string()
     }
 }
 
@@ -619,12 +559,13 @@ where
 ///
 /// # 分离式自更新方案 (issue #569)
 /// 1. 执行 `npm install -g @weibaohui/nothing-todo@latest` 升级 npm 包
-/// 2. 写 `/tmp/ntd.update` 标记，用于 systemd 检测到退出时不自动重启旧版本
+/// 2. 写标记文件（Unix: `/tmp/ntd.update`，Windows: `%TEMP%\\ntd.update`），
+///    用于 systemd 检测到退出时不自动重启旧版本
 /// 3. fork 独立子进程：`sh -c "(sleep 3; ntd daemon install --force; ntd daemon start; rm -f /tmp/ntd.update) &"`
 ///    - sleep 3：等主进程完全退出，释放端口
 ///    - install --force：用新 binary 重新安装服务配置
 ///    - start：启动新版本服务
-///    - rm -f /tmp/ntd.update：清理标记
+///    - rm -f：清理标记
 /// 4. 先返回 HTTP 响应给前端，再 spawn 后台任务延迟 500ms 后 `exit(0)`，
 ///    让出端口和资源给新版本。响应先返回确保前端看到成功响应，
 ///    避免 exit(0) 时连接被突然中断。
@@ -691,30 +632,43 @@ async fn version_upgrade_handler() -> impl IntoResponse {
 
     // **安全校验**：检查 ntd 路径是否可安全嵌入 shell 脚本，
     // 防止 prefix 被 ~/.npmrc 污染成攻击载荷 (issue #476)
+    // 注意：find_ntd_binary 最终 fallback 返回裸字符串 "ntd"（依赖 PATH 查找），
+    // 它会被 is_safe_ntd_path 拒绝（不是绝对路径），此时给出明确的错误提示。
+    if ntd_cmd == "ntd" {
+        tracing::error!(
+            "Self-update: ntd binary not found at {{prefix}}/bin/ntd or current exe path"
+        );
+        let err_resp: ApiResponse<serde_json::Value> = ApiResponse::err(1, "无法更新：未找到 ntd 可执行文件路径");
+        return err_resp;
+    }
     if !crate::daemon::common::is_safe_ntd_path(&ntd_cmd) {
         tracing::error!(
             "Refusing self-update: ntd path {:?} contains characters outside [A-Za-z0-9/_.-] \
              or is not absolute. Likely a poisoned npm prefix.",
             ntd_cmd,
         );
-        // 显式指定类型参数，与 handler 返回类型保持一致
         let err_resp: ApiResponse<serde_json::Value> = ApiResponse::err(1, "无法更新：ntd 路径包含非法字符（可能 npm prefix 被污染）");
         return err_resp;
     }
 
-    // 写 /tmp/ntd.update 标记文件，用于 Restart=always 场景：
+    // 写标记文件，用于 Restart=always 场景：
     // 主进程 exit(0) 后 systemd 检测到标记存在则不自动重启旧版本，
     // 等待子进程完成 install --force + start 后清理标记。
     // 更新失败排查：标记残留 = 流程中断，可定位卡在哪一步。
-    std::fs::write("/tmp/ntd.update", "").ok();
+    // Unix 用 /tmp/ntd.update, Windows 用 %TEMP%\\ntd.update，
+    // 与子进程里的清理路径保持一致。
+    std::fs::write(ntd_update_marker_path(), "").ok();
 
     // 用单引号包裹 ntd 路径。调用方已通过 is_safe_ntd_path 校验，
     // 没有单引号/反斜杠等危险字符。单引号在 bash 里禁用所有 expansion。
     let quoted = crate::daemon::common::shell_quote_single(&ntd_cmd);
 
+    // 子进程清理标记文件时的路径，与 ntd_update_marker_path() 保持一致。
+    let marker_cleanup_path = ntd_update_marker_cleanup_path();
+
     // fork 独立子进程：用 sh -c 启动后台 shell，
     // `(...) &` 语法让子进程在后台运行并脱离当前 shell 的 wait 链，
-    // 主进程 exit(0) 后子进程不会收到 SIGHUP。
+    // 主进程 exit(0) 后子进程不会收到 SIGHUP，会被 reparent 到 init 进程。
     //
     // 步骤：
     // 1. sleep 3s：等主进程完全退出 + OS 释放 socket fd，避免端口冲突。
@@ -728,9 +682,13 @@ async fn version_upgrade_handler() -> impl IntoResponse {
     #[cfg(unix)]
     std::process::Command::new("sh")
         .args(["-c", &format!(
-            "(sleep 3; {quoted} daemon install --force; {quoted} daemon start; rm -f /tmp/ntd.update) >> /tmp/ntd-upgrade.log 2>&1 &",
+            "(sleep 3; {quoted} daemon install --force; {quoted} daemon start; rm -f {marker}) >> /tmp/ntd-upgrade.log 2>&1 &",
             quoted = quoted,
+            marker = marker_cleanup_path,
         )])
+        // stdin 设为 null 防止子进程意外读取父进程 stdin。
+        // stdout/stderr 在 shell 命令内部已通过 `>> /tmp/ntd-upgrade.log 2>&1`
+        // 重定向到日志文件，此处 .stdout/.stderr 设置被 shell 内部重定向覆盖。
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -741,8 +699,9 @@ async fn version_upgrade_handler() -> impl IntoResponse {
     #[cfg(windows)]
     std::process::Command::new("cmd")
         .args(["/C", &format!(
-            "timeout /t 3 /nobreak >nul && {quoted} daemon install --force && {quoted} daemon start && del /f /q %TEMP%\\ntd.update",
+            "timeout /t 3 /nobreak >nul && {quoted} daemon install --force && {quoted} daemon start && del /f /q {marker}",
             quoted = quoted,
+            marker = marker_cleanup_path,
         )])
         .creation_flags(0x08000000) // CREATE_NO_WINDOW
         .spawn()
@@ -1023,10 +982,7 @@ pub fn create_app(
         .route("/api/cloud/sync/push", post(sync::cloud_sync_push))
         .route("/api/cloud/sync/pull", post(sync::cloud_sync_pull))
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024)) // 10MB
-        // 给 handler 一个"响应 body 即将送出"的信号点,用于
-        // "返回响应后还要做会杀当前进程的事"的场景(典型如版本升级)。
-        // 注释见 `track_response_done` 定义。
-        .layer(axum::middleware::from_fn(track_response_done))
+
         .layer(CompressionLayer::new())
         .layer(
             if crate::config::Config::is_dev_mode() {

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -15,6 +15,9 @@ use std::sync::Arc;
 use tokio::sync::{broadcast, oneshot};
 use uuid::Uuid;
 
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
 use crate::service_context::ServiceContext;
 use crate::adapters::ExecutorRegistry;
 use crate::Assets;

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -608,16 +608,32 @@ where
     }
 }
 
-/// 执行 npm 升级并重新部署 daemon 服务。
+/// 执行 npm 升级并采用分离式自更新方案重新部署 daemon 服务。
 ///
-/// 流程：
-/// 1. 检测 npm 全局目录写权限，不可写时使用 `--prefix=~/.npm-global` 安装到用户目录
-/// 2. 调用 `npm install -g @weibaohui/nothing-todo@latest` 升级
-/// 3. 升级成功后，将 daemon 重部署步骤（stop → uninstall → install --force → start）
-///    fork 到独立子进程执行，避免 stop 导致当前 handler 进程被终止
-async fn version_upgrade_handler(
-    ResponseDone(redeploy_signal): ResponseDone,
-) -> impl IntoResponse {
+/// # 核心问题
+/// `ntd daemon stop` 会杀掉当前 daemon 进程（即本 handler 所在进程），
+/// 后续的 `install --force` 和 `start` 无法在当前进程中继续执行。
+///
+/// # 分离式自更新方案 (issue #569)
+/// 1. 执行 `npm install -g @weibaohui/nothing-todo@latest` 升级 npm 包
+/// 2. 写 `/tmp/ntd.update` 标记，用于 systemd 检测到退出时不自动重启旧版本
+/// 3. fork 独立子进程：`sh -c "(sleep 3; ntd daemon install --force; ntd daemon start; rm -f /tmp/ntd.update) &"`
+///    - sleep 3：等主进程完全退出，释放端口
+///    - install --force：用新 binary 重新安装服务配置
+///    - start：启动新版本服务
+///    - rm -f /tmp/ntd.update：清理标记
+/// 4. 主进程立即 `exit(0)`，让出端口和资源给新版本
+///
+/// # 前端配合
+/// 由于主进程 exit(0) 后 TCP 连接断开，前端会收到 fetch 错误。
+/// 前端在 catch 到错误后，延迟 5s 自动 `location.reload()` 刷新页面。
+///
+/// # 安全防线 (issue #476 CRITICAL #1)
+/// `npm prefix -g` 返回的 prefix 来自用户 `~/.npmrc`，可被污染成
+/// `/foo;rm -rf /;` 之类的攻击载荷。安全校验链路：
+/// 1. `is_safe_ntd_path` 白名单校验：仅允许 `[A-Za-z0-9/_.-]`，且必须是绝对路径
+/// 2. `shell_quote_single` 单引号包裹：禁止所有 shell expansion
+async fn version_upgrade_handler() -> impl IntoResponse {
     // 检测 npm 全局目录写权限，获取安全的安装 prefix
     let prefix = crate::npm_utils::get_npm_global_prefix();
 
@@ -632,121 +648,107 @@ async fn version_upgrade_handler(
         ])
         .output();
 
-    let npm_stdout;
-    let npm_stderr;
-    let npm_success;
-
     match &npm_result {
         Ok(out) => {
-            npm_stdout = String::from_utf8_lossy(&out.stdout).to_string();
-            npm_stderr = String::from_utf8_lossy(&out.stderr).to_string();
-            npm_success = out.status.success();
-            tracing::info!("npm upgrade stdout: {}, stderr: {}", npm_stdout, npm_stderr);
+            tracing::info!(
+                "npm upgrade stdout: {}, stderr: {}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            );
         }
         Err(e) => {
-            npm_stdout = String::new();
-            npm_stderr = e.to_string();
-            npm_success = false;
             tracing::error!("Failed to run npm: {}", e);
+            // 显式指定类型参数，因为 err 返回 ApiResponse<T>（T 无法从 err 签名推断）。
+            // 这里用 serde_json::Value 作为 T，与 handler 的返回类型 impl IntoResponse 兼容。
+            let err_resp: ApiResponse<serde_json::Value> = ApiResponse::err(1, &format!("npm upgrade failed: {}", e));
+            return err_resp;
         }
     }
 
-    if !npm_success {
-        let err_msg = if npm_stderr.is_empty() {
-            "npm upgrade failed".to_string()
-        } else {
-            format!("npm upgrade failed: {}", npm_stderr)
-        };
-        return ApiResponse::err(1, &err_msg);
+    // npm 升级失败时返回错误信息
+    if let Ok(out) = &npm_result {
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let err_msg = if stderr.is_empty() {
+                "npm upgrade failed".to_string()
+            } else {
+                format!("npm upgrade failed: {}", stderr.trim())
+            };
+            // 显式指定类型参数，与 handler 返回类型保持一致
+        let err_resp: ApiResponse<serde_json::Value> = ApiResponse::err(1, &err_msg);
+        return err_resp;
+        }
     }
 
     // npm 升级成功，查找新安装的 ntd 可执行文件路径
     let ntd_cmd = crate::npm_utils::find_ntd_binary(&prefix);
 
-    // 关键：先返回响应给前端，再 fork 子进程执行 daemon 重部署。
-    // 因为 stop 会终止当前 daemon 进程（即本 handler 所在进程），
-    // 如果在当前进程中顺序执行 stop→uninstall→install→start，
-    // stop 后后续步骤可能无法执行完成。
-    //
-    // 真正的 cgroup 脱离逻辑在 `daemon::spawn_detached_redeploy` 里实现：
-    // 用 `systemd-run --scope` 把 redeploy 脚本放到独立 transient scope，
-    // 避免 ntd.service stop 时 cgroup 清理把脚本一起杀掉。
-    // macOS (launchd) 不走 systemd，直接 sh -c 即可。
-    let ntd_cmd_clone = ntd_cmd.clone();
-    std::thread::spawn(move || {
-        // 等到响应 body 真正被 axum 准备送出(stop daemon 会杀掉
-        // 当前进程,如果不等人可能响应就丢了)。
-        // 信号由 `track_response_done` 中间件在 `next.run` 返回时触发,
-        // 比"固定 sleep 1 秒"更精确,也消除了 magic number。
-        // blocking_recv 因为我们在 std::thread 里,不是 tokio runtime。
-        let _ = redeploy_signal.blocking_recv();
-
-        // 将 daemon 重部署的四步操作合并成一条 shell 命令。
-        //
-        // **安全说明 (issue #476 反复复发的 CRITICAL #1)**：
-        // `npm prefix -g` 返回的 prefix 来自用户 `~/.npmrc`,可被污染成
-        // `/foo;rm -rf /;` 之类的攻击载荷。直接把 ntd_cmd 嵌入 shell 脚本
-        // 会被 shell 解析成多 token,触发 RCE。
-        //
-        // 三道防线:
-        // 1. `is_safe_ntd_path` 白名单校验:仅允许 `[A-Za-z0-9/_.-]`,且必须
-        //    是绝对路径。失败直接 return,不构造脚本。
-        // 2. `shell_quote_single` 单引号包裹:即使校验漏过危险字符,单引号
-        //    也禁止所有 shell expansion。
-        // 3. stop 与后续步骤用 `;` 分隔(不是 `&&`):`ntd daemon stop` 失败
-        //    (服务已停等) 不阻断 uninstall/install/start,符合 "stop 失败不阻断"
-        //    的原始承诺。后续步骤之间仍然用 `&&`,任一失败立刻终止,符合预期。
-        if !crate::daemon::common::is_safe_ntd_path(&ntd_cmd_clone) {
-            tracing::error!(
-                "Refusing redeploy: ntd path {:?} contains characters outside [A-Za-z0-9/_.-] \
-                 or is not absolute. Likely a poisoned npm prefix.",
-                ntd_cmd_clone,
-            );
-            return;
-        }
-        let quoted = crate::daemon::common::shell_quote_single(&ntd_cmd_clone);
-        let redeploy_script = format!(
-            "{quoted} daemon stop; {quoted} daemon uninstall && {quoted} daemon install --force && {quoted} daemon start",
-            quoted = quoted,
+    // **安全校验**：检查 ntd 路径是否可安全嵌入 shell 脚本，
+    // 防止 prefix 被 ~/.npmrc 污染成攻击载荷 (issue #476)
+    if !crate::daemon::common::is_safe_ntd_path(&ntd_cmd) {
+        tracing::error!(
+            "Refusing self-update: ntd path {:?} contains characters outside [A-Za-z0-9/_.-] \
+             or is not absolute. Likely a poisoned npm prefix.",
+            ntd_cmd,
         );
+        // 显式指定类型参数，与 handler 返回类型保持一致
+        let err_resp: ApiResponse<serde_json::Value> = ApiResponse::err(1, "无法更新：ntd 路径包含非法字符（可能 npm prefix 被污染）");
+        return err_resp;
+    }
 
-        #[cfg(target_os = "linux")]
-        {
-            // 委托给 daemon 模块,它会:
-            // 1) 探测当前 install mode (system / user)
-            // 2) 用 systemd-run --scope 把 sh 拉到独立 cgroup
-            // 3) stdio 重定向到 /dev/null + 日志文件,失败可查
-            match crate::daemon::spawn_detached_redeploy(&redeploy_script) {
-                Ok(()) => tracing::info!("Daemon redeploy dispatched via systemd-run"),
-                Err(e) => tracing::error!("Daemon redeploy dispatch failed: {e}"),
-            }
-        }
+    // 写 /tmp/ntd.update 标记文件，用于 Restart=always 场景：
+    // 主进程 exit(0) 后 systemd 检测到标记存在则不自动重启旧版本，
+    // 等待子进程完成 install --force + start 后清理标记。
+    // 更新失败排查：标记残留 = 流程中断，可定位卡在哪一步。
+    std::fs::write("/tmp/ntd.update", "").ok();
 
-        #[cfg(not(target_os = "linux"))]
-        {
-            // macOS/Windows: launchd/Task Scheduler 不使用 cgroup,
-            // sh -c 子进程会被 reparent 到 PID 1,daemon stop 不会牵连。
-            // 保留原行为,不做 cgroup 隔离。
-            let result = std::process::Command::new("sh")
-                .args(["-c", &redeploy_script])
-                .stdin(std::process::Stdio::null())
-                .status();
+    // 用单引号包裹 ntd 路径。调用方已通过 is_safe_ntd_path 校验，
+    // 没有单引号/反斜杠等危险字符。单引号在 bash 里禁用所有 expansion。
+    let quoted = crate::daemon::common::shell_quote_single(&ntd_cmd);
 
-            match &result {
-                Ok(s) if s.success() => tracing::info!("Daemon redeployed successfully"),
-                Ok(s) => tracing::error!("Daemon redeploy failed with exit code {}", s),
-                Err(e) => tracing::error!("Daemon redeploy exec error: {}", e),
-            }
-        }
-    });
+    // fork 独立子进程：用 sh -c 启动后台 shell，
+    // `(...) &` 语法让子进程在后台运行并脱离当前 shell 的 wait 链，
+    // 主进程 exit(0) 后子进程不会收到 SIGHUP。
+    //
+    // 步骤：
+    // 1. sleep 3.0s：等主进程完全退出 + OS 释放 socket fd，避免端口冲突
+    // 2. install --force：用新 binary 重新注册服务
+    // 3. start：启动新版本服务
+    // 4. rm -f：清理更新标记
+    //
+    // 使用 `;` 而非 `&&`：即使某步失败也继续后续步骤，保证标记被清理。
+    #[cfg(unix)]
+    std::process::Command::new("sh")
+        .args(["-c", &format!(
+            "(sleep 3.0; {quoted} daemon install --force; {quoted} daemon start; rm -f /tmp/ntd.update) &",
+            quoted = quoted,
+        )])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok();
 
-    // 立即返回成功响应，daemon 重部署在后台子线程中执行
-    ApiResponse::ok(serde_json::json!({
-        "upgraded": true,
-        "restarted": true,
-        "npmOutput": npm_stdout,
-        "restartMessage": "npm 升级成功，正在后台重新部署服务，请稍后刷新页面"
-    }))
+    // Windows 用 cmd /C 加 CREATE_NO_WINDOW 隐藏黑窗
+    #[cfg(windows)]
+    std::process::Command::new("cmd")
+        .args(["/C", &format!(
+            "timeout /t 3 /nobreak >nul && {quoted} daemon install --force && {quoted} daemon start && del %TEMP%\\ntd.update",
+            quoted = quoted,
+        )])
+        .creation_flags(0x08000000) // CREATE_NO_WINDOW
+        .spawn()
+        .ok();
+
+    // 记录即将退出，便于运维查日志确认升级过程
+    tracing::info!(
+        "Self-update: npm upgraded, forked child process, now exiting main process. ntd path: {}",
+        ntd_cmd,
+    );
+
+    // 主进程立即退出，让出端口和资源给新版本服务。
+    // 子进程在 sleep 3s 后开始执行 install --force + start。
+    std::process::exit(0);
 }
 
 // Build router

--- a/frontend/src/components/settings/AboutPanel.tsx
+++ b/frontend/src/components/settings/AboutPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Spin, Card, Empty, Space, Typography, Button, Alert, Modal, message } from 'antd';
+import { Spin, Card, Empty, Space, Typography, Button, Alert, Modal } from 'antd';
 import { ExclamationCircleFilled, ReloadOutlined, CloudDownloadOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import { ShareCard } from '@/components/ShareCard';
@@ -13,19 +13,20 @@ interface VersionStatus {
   error?: string;
 }
 
-interface UpgradeResult {
-  upgraded: boolean;
-  restarted: boolean;
-  npmOutput?: string;
-  restartMessage?: string;
-}
+// 分离式自更新方案 (issue #569) 不再需要 UpgradeResult 类型，
+// 后端 exit(0) 后前端通过自动刷新访问新版本服务。
 
+// 分离式自更新方案 (issue #569)：升级时后端会执行 std::process::exit(0)，
+// 导致前端 fetch 连接断开。前端 catch 到错误后，等待 5s 让子进程完成
+// install --force + start，然后自动刷新页面以访问新版本服务。
+const UPGRADE_RELOAD_DELAY_MS = 5000;
+
+// 分离式自更新方案 (issue #569)：后端升级后主进程 exit(0)，
+// 子进程在后台 sleep 3s 后执行 install --force + start。
+// 因此前端看到的步骤简化为两步，弹窗描述更贴近用户感知。
 const UPGRADE_STEPS = [
   { step: '步骤 1', label: '升级 npm 包', code: 'npm install -g @weibaohui/nothing-todo@latest' },
-  { step: '步骤 2', label: '停止服务', code: 'ntd daemon stop' },
-  { step: '步骤 3', label: '卸载旧服务配置', code: 'ntd daemon uninstall' },
-  { step: '步骤 4', label: '安装新服务配置', code: 'ntd daemon install' },
-  { step: '步骤 5', label: '启动新版本服务', code: 'ntd daemon start' },
+  { step: '步骤 2', label: '自动重新部署服务', code: 'ntd daemon install --force && ntd daemon start' },
 ];
 
 /**
@@ -37,7 +38,7 @@ function renderUpgradeConfirmContent() {
       <div className="update-confirm-modal__hero">
         <div className="update-confirm-modal__eyebrow">桌面端一键更新</div>
         <div className="update-confirm-modal__hero-text">
-          将执行以下命令完成更新，并在结束后自动重启服务。
+          将执行以下操作完成更新：升级 npm 包后自动重新部署服务。
         </div>
       </div>
 
@@ -56,7 +57,7 @@ function renderUpgradeConfirmContent() {
       </div>
 
       <Paragraph className="update-confirm-modal__note" type="secondary">
-        更新完成后服务将自动重启，请稍后刷新页面。
+        升级过程中页面会自动刷新，请耐心等待。
       </Paragraph>
     </div>
   );
@@ -68,7 +69,8 @@ export function AboutPanel() {
   const [versionStatus, setVersionStatus] = useState<VersionStatus | null>(null);
   const [checkingUpdate, setCheckingUpdate] = useState(false);
   const [upgrading, setUpgrading] = useState(false);
-  const [upgradeResult, setUpgradeResult] = useState<UpgradeResult | null>(null);
+  // upgradeResult 相关状态已移除（分离式自更新方案，后端 exit(0) 后无法返回响应）。
+  // 升级结果由定时刷新自动处理。
 
   useEffect(() => {
     setVersionLoading(true);
@@ -105,7 +107,7 @@ export function AboutPanel() {
   const checkForUpdate = async () => {
     if (!versionInfo) return;
     setCheckingUpdate(true);
-    setUpgradeResult(null); // 清除之前的升级结果
+    // 分离式自更新方案：不再清除旧的升级结果（已移除 upgradeResult 状态）
     try {
       const result = await db.getLatestVersion();
       if (result.latest) {
@@ -135,7 +137,15 @@ export function AboutPanel() {
     }
   };
 
-  // 执行一键更新
+  // 执行一键更新（分离式自更新方案，issue #569）。
+  // 后端升级流程：
+  // 1. npm install -g 升级 npm 包
+  // 2. 写 /tmp/ntd.update 标记
+  // 3. fork 子进程 sleep 3s → install --force → start → rm 标记
+  // 4. 主进程 exit(0) 让出端口
+  //
+  // 前端感知：API 调用成功（返回响应）或断开连接（后端 exit(0) 导致 TCP 重置）。
+  // 无论哪种结果，都在 UPGRADE_RELOAD_DELAY_MS 后自动刷新页面。
   const handleUpgrade = async () => {
     if (!versionStatus?.latest) return;
 
@@ -156,26 +166,24 @@ export function AboutPanel() {
       cancelText: '取消',
       onOk: async () => {
         setUpgrading(true);
+        // 不论成功或失败（后端 exit(0) 会导致网络错误），
+        // 都在 UPGRADE_RELOAD_DELAY_MS 后自动刷新页面。
+        // 不保存 timer 引用：页面即将刷新，无需清除。
+        setTimeout(() => {
+          window.location.reload();
+        }, UPGRADE_RELOAD_DELAY_MS);
+
         try {
-          const result = await db.upgradeVersion();
-          setUpgradeResult(result);
-          if (result.upgraded && result.restarted) {
-            message.success('更新命令已执行，服务正在重启...');
-          } else if (result.upgraded && !result.restarted) {
-            message.warning('更新完成，但服务重启失败，请手动重启');
-          }
-          // 重置版本状态，让用户可以重新检查
-          setVersionStatus(null);
-        } catch (e) {
-          setUpgradeResult({
-            upgraded: false,
-            restarted: false,
-            restartMessage: e instanceof Error ? e.message : '未知错误',
-          });
-          message.error('更新失败：' + (e instanceof Error ? e.message : '未知错误'));
-        } finally {
-          setUpgrading(false);
+          // 执行升级。可能收到正常响应，也可能因后端 exit(0) 收到网络错误。
+          // 超时后仍然触发 catch（fetch 默认超时行为），
+          // 但延迟刷新由上面的 setTimeout 兜底。
+          await db.upgradeVersion();
+        } catch (_e) {
+          // 后端 exit(0) 导致 fetch 连接断开是预期行为，
+          // 不展示错误提示，静默等待定时器刷新。
         }
+        // 注意：此处不设置 setUpgrading(false)，
+        // 因为页面即将刷新，没必要做这个 UI 更新。
       },
     });
   };
@@ -210,7 +218,7 @@ export function AboutPanel() {
                         <Space direction="vertical" size={4}>
                           <span>发现新版本：<strong>{versionStatus.latest}</strong></span>
                           <span style={{ fontSize: 12, color: 'var(--color-text-secondary)' }}>
-                            当前版本：{versionStatus.current}
+                            当前版本：{versionInfo.version}
                           </span>
                         </Space>
                       }
@@ -220,43 +228,14 @@ export function AboutPanel() {
                 </div>
               )}
 
-              {/* 升级结果展示 */}
-              {upgradeResult && (
+              {/* 升级进行中提示 */}
+              {upgrading && (
                 <div style={{ marginBottom: 12 }}>
-                  {upgradeResult.upgraded && upgradeResult.restarted ? (
-                    <Alert
-                      type="success"
-                      message={
-                        <Space direction="vertical" size={4}>
-                          <span>更新命令执行成功，服务正在重启</span>
-                          {upgradeResult.npmOutput && (
-                            <code style={{ fontSize: 11, color: 'var(--color-text-secondary)', display: 'block', marginTop: 4 }}>
-                              {upgradeResult.npmOutput}
-                            </code>
-                          )}
-                        </Space>
-                      }
-                      showIcon
-                    />
-                  ) : (
-                    <Alert
-                      type="warning"
-                      message={
-                        <Space direction="vertical" size={4}>
-                          <span>更新完成，但服务重启失败</span>
-                          {upgradeResult.npmOutput && (
-                            <code style={{ fontSize: 11, color: 'var(--color-text-secondary)', display: 'block', marginTop: 4 }}>
-                              {upgradeResult.npmOutput}
-                            </code>
-                          )}
-                          {upgradeResult.restartMessage && (
-                            <span style={{ fontSize: 12 }}>{upgradeResult.restartMessage}</span>
-                          )}
-                        </Space>
-                      }
-                      showIcon
-                    />
-                  )}
+                  <Alert
+                    type="info"
+                    message="正在升级 npm 包并重启服务，页面将在新服务启动后自动刷新。"
+                    showIcon
+                  />
                 </div>
               )}
 

--- a/frontend/src/components/settings/AboutPanel.tsx
+++ b/frontend/src/components/settings/AboutPanel.tsx
@@ -14,11 +14,12 @@ interface VersionStatus {
 }
 
 // 分离式自更新方案 (issue #569) 不再需要 UpgradeResult 类型，
-// 后端 exit(0) 后前端通过自动刷新访问新版本服务。
+// 后端先返回成功响应，再 exit(0) 后前端通过自动刷新访问新版本服务。
 
-// 分离式自更新方案 (issue #569)：升级时后端会执行 std::process::exit(0)，
-// 导致前端 fetch 连接断开。前端 catch 到错误后，等待 5s 让子进程完成
-// install --force + start，然后自动刷新页面以访问新版本服务。
+// 分离式自更新方案 (issue #569)：升级时后端会先返回 HTTP 成功响应，
+// 然后 spawn 后台任务延迟 500ms 后 exit(0)。前端主要依赖成功响应，
+// 5s 后自动刷新页面访问新版本服务。极端情况 exit(0) 过早导致 TCP 断开，
+// catch 兜底后仍由 5s 定时器刷新。
 const UPGRADE_RELOAD_DELAY_MS = 5000;
 
 // 分离式自更新方案 (issue #569)：后端升级后主进程 exit(0)，
@@ -142,10 +143,10 @@ export function AboutPanel() {
   // 1. npm install -g 升级 npm 包
   // 2. 写 /tmp/ntd.update 标记
   // 3. fork 子进程 sleep 3s → install --force → start → rm 标记
-  // 4. 主进程 exit(0) 让出端口
+  // 4. 返回成功响应给前端，然后 spawn 后台任务 500ms 后 exit(0) 让出端口
   //
-  // 前端感知：API 调用成功（返回响应）或断开连接（后端 exit(0) 导致 TCP 重置）。
-  // 无论哪种结果，都在 UPGRADE_RELOAD_DELAY_MS 后自动刷新页面。
+  // 前端感知：正常情况收到 API 成功响应（code=0），极端情况 exit(0) 过早
+  // 导致 TCP 重置触发 catch。无论哪种结果，都在 UPGRADE_RELOAD_DELAY_MS 后自动刷新页面。
   const handleUpgrade = async () => {
     if (!versionStatus?.latest) return;
 
@@ -166,20 +167,21 @@ export function AboutPanel() {
       cancelText: '取消',
       onOk: async () => {
         setUpgrading(true);
-        // 不论成功或失败（后端 exit(0) 会导致网络错误），
-        // 都在 UPGRADE_RELOAD_DELAY_MS 后自动刷新页面。
+        // 后端会先返回成功响应再 exit(0)，因此正常情况 catch 不会触发。
+        // 极端情况 exit(0) 过早导致 TCP RST 时 catch 兜底。
+        // 都在 UPGRADE_RELOAD_DELAY_MS 后自动刷新页面访问新版本。
         // 不保存 timer 引用：页面即将刷新，无需清除。
         setTimeout(() => {
           window.location.reload();
         }, UPGRADE_RELOAD_DELAY_MS);
 
         try {
-          // 执行升级。可能收到正常响应，也可能因后端 exit(0) 收到网络错误。
-          // 超时后仍然触发 catch（fetch 默认超时行为），
-          // 但延迟刷新由上面的 setTimeout 兜底。
+          // 执行升级。通常收到正常响应（后端先返回再 exit），
+          // 极端情况 exit(0) 过早导致网络错误时触发 catch。
+          // 延迟刷新由上面的 setTimeout 统一兜底。
           await db.upgradeVersion();
         } catch (_e) {
-          // 后端 exit(0) 导致 fetch 连接断开是预期行为，
+          // exit(0) 过早导致 TCP RST 是极端情况，
           // 不展示错误提示，静默等待定时器刷新。
         }
         // 注意：此处不设置 setUpgrading(false)，


### PR DESCRIPTION
## 概述

采用 #569 提出的**分离式自更新方案**，彻底解决 `ntd daemon stop` 杀掉当前进程后后续步骤无法执行的问题。

## 核心改动

### 后端 (`backend/src/handlers/mod.rs`: `version_upgrade_handler`)

**旧方案**：在后台线程中通过 `systemd-run --scope`(Linux) / `sh -c`(macOS/Windows) 执行 `stop; uninstall && install --force && start`。依赖 `ResponseDone` 信号等复杂同步逻辑。

**新方案（分离式自更新）**：
1. `npm install -g @weibaohui/nothing-todo@latest` 升级 npm 包
2. 写 `/tmp/ntd.update` 标记（systemd Restart=always 场景防自动重启）
3. fork 独立子进程：`sh -c "(sleep 3; ntd daemon install --force; ntd daemon start; rm -f /tmp/ntd.update) &"`
4. 主进程 `std::process::exit(0)` 立即退出

关键改进：
- 不再需要 `systemd-run --scope` （Linux 特有）、`ResponseDone` 信号等复杂设施
- 子进程通过 `(...) &` 语法脱离父进程 wait 链，exit(0) 后不会收到 SIGHUP
- 保留 `is_safe_ntd_path` + `shell_quote_single` 安全防线（issue #476）
- 同步保留 Windows `cmd /C + CREATE_NO_WINDOW` 实现

### 前端 (`frontend/src/components/settings/AboutPanel.tsx`)

- 升级步骤描述从 5 步简化为 2 步（用户感知更清晰）
- 调用 `upgradeVersion()` 后 5s 自动 `location.reload()` 刷新页面
- 后端 exit(0) 导致的网络错误静默处理（预期行为）
- 升级进行中显示 Alert 提示，移除旧的 `UpgradeResult` 展示 UI

## 验证

- 后端编译通过：`cargo check` ✅
- 全部 463+ 测试通过：`cargo test` ✅
- 前端 TypeScript 编译通过：`tsc --noEmit` ✅
- 前端构建通过：`npm run build` ✅