### PR TITLE
feat: 集成 systemd-run --scope --no-block 到一键更新流程 (issue #569)

### DIFF
--- a/backend/src/daemon/mod.rs
+++ b/backend/src/daemon/mod.rs
@@ -34,7 +34,8 @@ mod redeploy;
 // 旧路径，避免外部调用方和单测改动。
 #[cfg(target_os = "linux")]
 pub use redeploy::{
-    build_redeploy_spec, spawn_detached_redeploy, spawn_detached_redeploy_nonblocking,
+    build_redeploy_spec, build_redeploy_spec_nonblocking, redeploy_log_path,
+    spawn_detached_redeploy, spawn_detached_redeploy_nonblocking,
     DaemonInstallMode, RedeployCommandSpec, RedeployError,
 };
 

--- a/backend/src/daemon/mod.rs
+++ b/backend/src/daemon/mod.rs
@@ -34,8 +34,8 @@ mod redeploy;
 // 旧路径，避免外部调用方和单测改动。
 #[cfg(target_os = "linux")]
 pub use redeploy::{
-    build_redeploy_spec, spawn_detached_redeploy, DaemonInstallMode, RedeployCommandSpec,
-    RedeployError,
+    build_redeploy_spec, spawn_detached_redeploy, spawn_detached_redeploy_nonblocking,
+    DaemonInstallMode, RedeployCommandSpec, RedeployError,
 };
 
 #[derive(Subcommand)]

--- a/backend/src/daemon/redeploy.rs
+++ b/backend/src/daemon/redeploy.rs
@@ -133,11 +133,14 @@ pub fn redeploy_log_path() -> std::path::PathBuf {
         .join("upgrade-redeploy.log")
 }
 
-/// 真正启动 detached redeploy。
+/// 真正启动 detached redeploy（阻塞版本，适合 CLI 使用）。
 ///
 /// - `script`：stop && uninstall && install --force && start 的 shell 片段
 /// - 返回：Ok(()) 表示 systemd-run 至少拉起了 sh（脚本本身的成败要看日志）
 /// - Err：探测/启动/IO 失败，带具体原因
+///
+/// 会等待 systemd-run 命令完成（即 systemd-run 启动 scope 后返回）。
+/// 对于 HTTP handler 场景需使用 [`spawn_detached_redeploy_nonblocking`]。
 ///
 /// **stdio 处理**：
 /// - stdin 重定向到 /dev/null：防止 sh 等 tty 输入
@@ -187,6 +190,77 @@ pub fn spawn_detached_redeploy(script: &str) -> Result<(), RedeployError> {
         Err(e) => {
             let msg = format!(
                 "failed to spawn systemd-run: {e}; log: {}",
+                log_path.display()
+            );
+            tracing::error!("{msg}");
+            Err(RedeployError::Spawn { source: e, log: log_path })
+        }
+    }
+}
+
+/// 非阻塞版 spawn_detached_redeploy，适合 HTTP handler 使用。
+///
+/// 与 [`spawn_detached_redeploy`] 的区别：
+/// - 使用 `.spawn()` 而非 `.status()`，不等待 systemd-run 完成
+/// - 在 systemd-run args 中追加 `--no-block`，让 systemd-run 启动 scope 后立即返回
+/// - 仅检查 systemd-run 能否成功启动（spawn 成功即视为成功），
+///   不等待命令执行完毕
+///
+/// 返回值含义：
+/// - `Ok(())`：systemd-run 进程已成功派生（scope 已提交给 systemd）
+/// - `Err(...)`：连 systemd-run 都启动失败（systemd 不可用 / PATH 找不到等）
+pub fn spawn_detached_redeploy_nonblocking(script: &str) -> Result<(), RedeployError> {
+    let mode = detect_install_mode();
+    let log_path = redeploy_log_path();
+    if let Some(parent) = log_path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    // 非阻塞版需要追加 --no-block，让 systemd-run 立即返回
+    // 因此不能直接复用 build_redeploy_spec，需要额外加一个参数
+    let mut spec = build_redeploy_spec(mode, script);
+    // 在 --collect 之后、sh 之前插入 --no-block。
+    // build_redeploy_spec 的 args 布局是：
+    //   [--user?] --scope --collect --property=... --property=... /bin/sh -c <script>
+    // --no-block 放在 --collect 之后、--property=Description 之前（任意位置均可，
+    // 只要不在 sh -c 后面即可）。这里插在 args 的 --collect 之后。
+    let collect_idx = spec.args.iter().position(|a| a == "--collect");
+    if let Some(idx) = collect_idx {
+        spec.args.insert(idx + 1, "--no-block".to_string());
+    } else {
+        // build_redeploy_spec 一定会加 --collect，但防御性兜底
+        spec.args.insert(2, "--no-block".to_string());
+    }
+
+    let log_file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|e| RedeployError::LogOpen {
+            path: log_path.clone(),
+            source: e,
+        })?;
+
+    let mut cmd = Command::new(&spec.program);
+    cmd.args(&spec.args);
+    cmd.stdin(std::process::Stdio::null());
+    if let Ok(f) = log_file.try_clone() {
+        cmd.stdout(f);
+    }
+    cmd.stderr(log_file);
+
+    // 使用 .spawn() 非阻塞启动，不等待 systemd-run 返回
+    match cmd.spawn() {
+        Ok(_) => {
+            tracing::info!(
+                "Non-blocking redeploy spawned via systemd-run (--no-block). script: {}",
+                script
+            );
+            Ok(())
+        }
+        Err(e) => {
+            let msg = format!(
+                "failed to spawn systemd-run (non-blocking): {e}; log: {}",
                 log_path.display()
             );
             tracing::error!("{msg}");

--- a/backend/src/daemon/redeploy.rs
+++ b/backend/src/daemon/redeploy.rs
@@ -52,7 +52,12 @@ pub enum DaemonInstallMode {
 pub fn detect_install_mode() -> DaemonInstallMode {
     // 先尝试通过 systemctl 探测 system 实例
     if let Ok(out) = Command::new("systemctl")
-        .args(["show", SERVICE_NAME, "--property=FragmentPath", "--property=LoadState"])
+        .args([
+            "show",
+            SERVICE_NAME,
+            "--property=FragmentPath",
+            "--property=LoadState",
+        ])
         .output()
     {
         let stdout = String::from_utf8_lossy(&out.stdout);
@@ -100,17 +105,48 @@ pub struct RedeployCommandSpec {
 }
 
 pub fn build_redeploy_spec(mode: DaemonInstallMode, script: &str) -> RedeployCommandSpec {
-    // User 模式必须加 --user 才能连到用户的 systemd 实例；
-    // System 模式和 Unknown 模式都不加，这样即使探测失败回退也能跑
-    // （Unknown 时连不上 ntd.service 的实例，但 redeploy 脚本里用的是
-    //  ntd 自己的 stop/uninstall/install 逻辑，会重新匹配实际模式）。
+    build_redeploy_spec_inner(mode, script, false)
+}
+
+/// 构造 nonblocking 版本的 redeploy spec（追加 `--no-block`）。
+///
+/// 与 [`build_redeploy_spec`] 的唯一区别是在 `--collect` 后插入 `--no-block`，
+/// 让 systemd-run 启动 scope 后立即返回而不等待脚本完成。
+/// 提取为公有函数，便于单测和 `spawn_detached_redeploy_nonblocking` 共同使用。
+pub fn build_redeploy_spec_nonblocking(
+    mode: DaemonInstallMode,
+    script: &str,
+) -> RedeployCommandSpec {
+    build_redeploy_spec_inner(mode, script, true)
+}
+
+/// build_redeploy_spec 的内部实现，通过 `nonblocking` 控制是否追加 `--no-block`。
+///
+/// 设计理由：
+/// - `--no-block` 作为纯数据参数集成到 spec 构造中，而非事后在 args Vec 中查找插入，
+///   消除了未来重构 args 顺序时插入点偏移的风险。
+/// - nonblocking 和非 nonblocking 版本共享同一份参数构造核心逻辑，确保一致性。
+/// - User 模式必须加 --user 才能连到用户的 systemd 实例；
+///   System 模式和 Unknown 模式都不加，这样即使探测失败回退也能跑
+///   （Unknown 时连不上 ntd.service 的实例，但 redeploy 脚本里用的是
+///    ntd 自己的 stop/uninstall/install 逻辑，会重新匹配实际模式）。
+fn build_redeploy_spec_inner(
+    mode: DaemonInstallMode,
+    script: &str,
+    nonblocking: bool,
+) -> RedeployCommandSpec {
     let mut args: Vec<String> = Vec::new();
     if mode == DaemonInstallMode::User {
         args.push("--user".to_string());
     }
+    args.push("--scope".to_string());
+    args.push("--collect".to_string());
+    // nonblocking 模式下在 --collect 之后插入 --no-block，
+    // 让 systemd-run 启动 scope 后立即返回，不等脚本执行完毕。
+    if nonblocking {
+        args.push("--no-block".to_string());
+    }
     args.extend([
-        "--scope".to_string(),
-        "--collect".to_string(),
         "--property=Description=ntd upgrade redeploy".to_string(),
         // 即使 scope 内被 kill，也只杀 systemd-run 自身，不杀 sh 链
         "--property=KillMode=process".to_string(),
@@ -185,7 +221,10 @@ pub fn spawn_detached_redeploy(script: &str) -> Result<(), RedeployError> {
                 log_path.display()
             );
             tracing::error!("{msg}");
-            Err(RedeployError::NonZeroExit { code: s.code(), log: log_path })
+            Err(RedeployError::NonZeroExit {
+                code: s.code(),
+                log: log_path,
+            })
         }
         Err(e) => {
             let msg = format!(
@@ -193,7 +232,10 @@ pub fn spawn_detached_redeploy(script: &str) -> Result<(), RedeployError> {
                 log_path.display()
             );
             tracing::error!("{msg}");
-            Err(RedeployError::Spawn { source: e, log: log_path })
+            Err(RedeployError::Spawn {
+                source: e,
+                log: log_path,
+            })
         }
     }
 }
@@ -216,21 +258,10 @@ pub fn spawn_detached_redeploy_nonblocking(script: &str) -> Result<(), RedeployE
         let _ = fs::create_dir_all(parent);
     }
 
-    // 非阻塞版需要追加 --no-block，让 systemd-run 立即返回
-    // 因此不能直接复用 build_redeploy_spec，需要额外加一个参数
-    let mut spec = build_redeploy_spec(mode, script);
-    // 在 --collect 之后、sh 之前插入 --no-block。
-    // build_redeploy_spec 的 args 布局是：
-    //   [--user?] --scope --collect --property=... --property=... /bin/sh -c <script>
-    // --no-block 放在 --collect 之后、--property=Description 之前（任意位置均可，
-    // 只要不在 sh -c 后面即可）。这里插在 args 的 --collect 之后。
-    let collect_idx = spec.args.iter().position(|a| a == "--collect");
-    if let Some(idx) = collect_idx {
-        spec.args.insert(idx + 1, "--no-block".to_string());
-    } else {
-        // build_redeploy_spec 一定会加 --collect，但防御性兜底
-        spec.args.insert(2, "--no-block".to_string());
-    }
+    // 非阻塞版：使用 build_redeploy_spec_nonblocking 直接构造带 --no-block 的 spec。
+    // --no-block 作为参数集成到 spec 构造中，无需事后在 args Vec 中查找插入，
+    // 消除了未来重构 args 顺序时插入点偏移的风险。
+    let spec = build_redeploy_spec_nonblocking(mode, script);
 
     let log_file = fs::OpenOptions::new()
         .create(true)
@@ -264,7 +295,10 @@ pub fn spawn_detached_redeploy_nonblocking(script: &str) -> Result<(), RedeployE
                 log_path.display()
             );
             tracing::error!("{msg}");
-            Err(RedeployError::Spawn { source: e, log: log_path })
+            Err(RedeployError::Spawn {
+                source: e,
+                log: log_path,
+            })
         }
     }
 }
@@ -277,10 +311,7 @@ pub enum RedeployError {
         source: std::io::Error,
     },
     /// systemd-run 启动了但脚本退出码非 0
-    NonZeroExit {
-        code: Option<i32>,
-        log: PathBuf,
-    },
+    NonZeroExit { code: Option<i32>, log: PathBuf },
     /// 连 systemd-run 都拉不起来（没装 systemd / PATH 里找不到）
     Spawn {
         source: std::io::Error,
@@ -292,7 +323,12 @@ impl std::fmt::Display for RedeployError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             RedeployError::LogOpen { path, source } => {
-                write!(f, "failed to open redeploy log {}: {}", path.display(), source)
+                write!(
+                    f,
+                    "failed to open redeploy log {}: {}",
+                    path.display(),
+                    source
+                )
             }
             RedeployError::NonZeroExit { code, log } => {
                 write!(

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -555,23 +555,29 @@ fn ntd_update_marker_cleanup_path() -> String {
 ///
 /// 使用 `(...) &` 语法让子进程在后台运行并脱离当前 shell 的 wait 链，
 /// 主进程 exit(0) 后子进程不会收到 SIGHUP，会被 reparent 到 init 进程。
-/// 输出重定向到 /tmp/ntd-upgrade.log 方便排查。
+/// 输出重定向到日志文件方便排查。
+///
+/// # 参数
+/// * `ntd_cmd` - ntd 可执行文件路径
+/// * `marker_cleanup_path` - 标记文件清理路径
+/// * `log_path` - 子进程 stdout/stderr 重定向的目标日志路径
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-fn spawn_redeploy_sh_fallback(ntd_cmd: &str, marker_cleanup_path: &str) {
+fn spawn_redeploy_sh_fallback(ntd_cmd: &str, marker_cleanup_path: &str, log_path: &str) {
     // 用单引号包裹 ntd 路径。调用方已通过 is_safe_ntd_path 校验，
     // 没有单引号/反斜杠等危险字符。单引号在 bash 里禁用所有 expansion。
     let quoted = crate::daemon::common::shell_quote_single(ntd_cmd);
 
     // stdin 设为 null 防止子进程意外读取父进程 stdin。
-    // stdout/stderr 在 shell 命令内部已通过 `>> /tmp/ntd-upgrade.log 2>&1`
+    // stdout/stderr 在 shell 命令内部已通过 `>> {log_path} 2>&1`
     // 重定向到日志文件，此处 .stdout/.stderr 设置被 shell 内部重定向覆盖。
     //
     // 使用 `;` 而非 `&&`：即使某步失败也继续后续步骤，保证标记被清理。
     std::process::Command::new("sh")
         .args(["-c", &format!(
-            "(sleep 3; {quoted} daemon install --force; {quoted} daemon start; rm -f {marker}) >> /tmp/ntd-upgrade.log 2>&1 &",
+            "(sleep 3; {quoted} daemon install --force; {quoted} daemon start; rm -f {marker}) >> {log} 2>&1 &",
             quoted = quoted,
             marker = marker_cleanup_path,
+            log = log_path,
         )])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
@@ -730,14 +736,16 @@ async fn version_upgrade_handler() -> impl IntoResponse {
                     "Self-update: systemd-run failed ({}), falling back to sh -c",
                     e,
                 );
-                spawn_redeploy_sh_fallback(&ntd_cmd, &marker_cleanup_path);
+                // systemd-run 失败时 fallback 到 sh -c，日志使用 redeploy_log_path 统一路径
+                let fallback_log = crate::daemon::redeploy_log_path().to_string_lossy().to_string();
+                spawn_redeploy_sh_fallback(&ntd_cmd, &marker_cleanup_path, &fallback_log);
             }
         }
     }
     #[cfg(not(target_os = "linux"))]
     {
         // macOS 或其他 Unix 使用 sh -c 方案，因为 launchd 不会按 cgroup 杀进程。
-        spawn_redeploy_sh_fallback(&ntd_cmd, &marker_cleanup_path);
+        spawn_redeploy_sh_fallback(&ntd_cmd, &marker_cleanup_path, "/tmp/ntd-upgrade.log");
     }
 
     // Windows 用 cmd /C 加 CREATE_NO_WINDOW 隐藏黑窗

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -551,6 +551,35 @@ fn ntd_update_marker_cleanup_path() -> String {
     }
 }
 
+/// sh -c 回退方案：在非 Linux 平台或 systemd-run 不可用时使用。
+///
+/// 使用 `(...) &` 语法让子进程在后台运行并脱离当前 shell 的 wait 链，
+/// 主进程 exit(0) 后子进程不会收到 SIGHUP，会被 reparent 到 init 进程。
+/// 输出重定向到 /tmp/ntd-upgrade.log 方便排查。
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn spawn_redeploy_sh_fallback(ntd_cmd: &str, marker_cleanup_path: &str) {
+    // 用单引号包裹 ntd 路径。调用方已通过 is_safe_ntd_path 校验，
+    // 没有单引号/反斜杠等危险字符。单引号在 bash 里禁用所有 expansion。
+    let quoted = crate::daemon::common::shell_quote_single(ntd_cmd);
+
+    // stdin 设为 null 防止子进程意外读取父进程 stdin。
+    // stdout/stderr 在 shell 命令内部已通过 `>> /tmp/ntd-upgrade.log 2>&1`
+    // 重定向到日志文件，此处 .stdout/.stderr 设置被 shell 内部重定向覆盖。
+    //
+    // 使用 `;` 而非 `&&`：即使某步失败也继续后续步骤，保证标记被清理。
+    std::process::Command::new("sh")
+        .args(["-c", &format!(
+            "(sleep 3; {quoted} daemon install --force; {quoted} daemon start; rm -f {marker}) >> /tmp/ntd-upgrade.log 2>&1 &",
+            quoted = quoted,
+            marker = marker_cleanup_path,
+        )])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok();
+}
+
 /// 执行 npm 升级并采用分离式自更新方案重新部署 daemon 服务。
 ///
 /// # 核心问题
@@ -659,53 +688,72 @@ async fn version_upgrade_handler() -> impl IntoResponse {
     // 与子进程里的清理路径保持一致。
     std::fs::write(ntd_update_marker_path(), "").ok();
 
-    // 用单引号包裹 ntd 路径。调用方已通过 is_safe_ntd_path 校验，
-    // 没有单引号/反斜杠等危险字符。单引号在 bash 里禁用所有 expansion。
-    let quoted = crate::daemon::common::shell_quote_single(&ntd_cmd);
-
     // 子进程清理标记文件时的路径，与 ntd_update_marker_path() 保持一致。
     let marker_cleanup_path = ntd_update_marker_cleanup_path();
 
-    // fork 独立子进程：用 sh -c 启动后台 shell，
-    // `(...) &` 语法让子进程在后台运行并脱离当前 shell 的 wait 链，
-    // 主进程 exit(0) 后子进程不会收到 SIGHUP，会被 reparent 到 init 进程。
+    // 分离式自更新方案 (issue #569)：fork 独立子进程在后台完成 install + start。
     //
-    // 步骤：
-    // 1. sleep 3s：等主进程完全退出 + OS 释放 socket fd，避免端口冲突。
-    //    使用整数 `3` 而非 `3.0`：macOS 和 Alpine/busybox 的 sleep
-    //    不支持浮点数参数，整型兼容所有平台。
-    // 2. install --force：用新 binary 重新注册服务
-    // 3. start：启动新版本服务
-    // 4. rm -f：清理更新标记
-    //
-    // 使用 `;` 而非 `&&`：即使某步失败也继续后续步骤，保证标记被清理。
-    #[cfg(unix)]
-    std::process::Command::new("sh")
-        .args(["-c", &format!(
-            "(sleep 3; {quoted} daemon install --force; {quoted} daemon start; rm -f {marker}) >> /tmp/ntd-upgrade.log 2>&1 &",
-            quoted = quoted,
-            marker = marker_cleanup_path,
-        )])
-        // stdin 设为 null 防止子进程意外读取父进程 stdin。
-        // stdout/stderr 在 shell 命令内部已通过 `>> /tmp/ntd-upgrade.log 2>&1`
-        // 重定向到日志文件，此处 .stdout/.stderr 设置被 shell 内部重定向覆盖。
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .ok();
+    // 不同平台采用不同策略：
+    // - Linux（systemd）：使用 systemd-run --scope --no-block 把脚本放在独立 cgroup，
+    //   即使主进程 exit(0) 后 systemd 清理 ntd.service 的 cgroup 也不会杀掉子进程。
+    // - macOS / 其他 Unix：使用 sh -c "(...) &" 语法让子进程脱离 shell wait 链，
+    //   主进程 exit 后子进程被 reparent 到 init 进程。
+    // - Windows：使用 cmd /C + CREATE_NO_WINDOW 隐藏黑窗。
+    #[cfg(target_os = "linux")]
+    {
+        // Linux 上使用 systemd-run --scope --no-block，
+        // 将 redeploy 脚本放入独立 cgroup，防止被 systemd 的 KillMode=mixed 牵连。
+        // 详见 backend/src/daemon/redeploy.rs 模块注释。
+        //
+        // 步骤：
+        // 1. sleep 3s：等主进程完全退出 + OS 释放 socket fd，避免端口冲突。
+        // 2. install --force：用新 binary 重新注册服务
+        // 3. start：启动新版本服务
+        // 4. rm -f：清理更新标记
+        let script = format!(
+            "sleep 3; {} daemon install --force; {} daemon start; rm -f {}",
+            ntd_cmd,
+            ntd_cmd,
+            marker_cleanup_path,
+        );
+        match crate::daemon::spawn_detached_redeploy_nonblocking(&script) {
+            Ok(()) => {
+                tracing::info!(
+                    "Self-update (Linux): systemd-run redeploy spawned. ntd path: {}",
+                    ntd_cmd,
+                );
+            }
+            Err(e) => {
+                // systemd-run 启动失败（可能是 Docker / WSL 没有 systemd），降级到 sh -c。
+                // 这样在无 systemd 的容器环境也能工作。
+                tracing::warn!(
+                    "Self-update: systemd-run failed ({}), falling back to sh -c",
+                    e,
+                );
+                spawn_redeploy_sh_fallback(&ntd_cmd, &marker_cleanup_path);
+            }
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        // macOS 或其他 Unix 使用 sh -c 方案，因为 launchd 不会按 cgroup 杀进程。
+        spawn_redeploy_sh_fallback(&ntd_cmd, &marker_cleanup_path);
+    }
 
     // Windows 用 cmd /C 加 CREATE_NO_WINDOW 隐藏黑窗
     #[cfg(windows)]
-    std::process::Command::new("cmd")
-        .args(["/C", &format!(
-            "timeout /t 3 /nobreak >nul && {quoted} daemon install --force && {quoted} daemon start && del /f /q {marker}",
-            quoted = quoted,
-            marker = marker_cleanup_path,
-        )])
-        .creation_flags(0x08000000) // CREATE_NO_WINDOW
-        .spawn()
-        .ok();
+    {
+        let quoted = crate::daemon::common::shell_quote_single(&ntd_cmd);
+        std::process::Command::new("cmd")
+            .args(["/C", &format!(
+                "timeout /t 3 /nobreak >nul && {quoted} daemon install --force && {quoted} daemon start && del /f /q {marker}",
+                quoted = quoted,
+                marker = marker_cleanup_path,
+            )])
+            .creation_flags(0x08000000) // CREATE_NO_WINDOW
+            .spawn()
+            .ok();
+    }
 
     // 记录 fork 成功，便于运维查日志确认升级进程已启动
     tracing::info!(
@@ -716,8 +764,8 @@ async fn version_upgrade_handler() -> impl IntoResponse {
     // 先返回成功响应给前端，让 Axum 完成 HTTP 响应的发送。
     // 然后通过 spawn 后台任务延迟 500ms 后 exit(0)，
     // 给当前 in-flight 响应足够时间写回客户端。
-    // 子进程（sleep 3s 后 install --force + start）通过 `(...) &`
-    // 已脱离当前 shell wait 链，主进程 exit 后子进程正常工作。
+    // 子进程已通过 systemd-run --scope（Linux）或 `(...) &`（其他 Unix）
+    // 脱离当前进程树，主进程 exit 后子进程正常工作。
     //
     // 异步 handler 返回响应与 spawn 后台任务：
     // Axum 在 handler 返回后完成响应 body 的写入和 flush，

--- a/backend/tests/daemon_redeploy_tests.rs
+++ b/backend/tests/daemon_redeploy_tests.rs
@@ -24,16 +24,15 @@ mod build_redeploy_spec_tests {
         assert!(
             spec.args
                 .iter()
-                .any(|a| a.starts_with("--property=Description=") && a.contains("ntd upgrade redeploy")),
+                .any(|a| a.starts_with("--property=Description=")
+                    && a.contains("ntd upgrade redeploy")),
             "missing Description property, args = {:?}",
             spec.args
         );
         // KillMode=process 是这次修复里多加的 belt-and-suspenders,
         // 即使 scope 被 kill 也只杀 systemd-run 自身,不杀 sh -c 链
         assert!(
-            spec.args
-                .iter()
-                .any(|a| a.contains("KillMode=process")),
+            spec.args.iter().any(|a| a.contains("KillMode=process")),
             "missing KillMode=process, args = {:?}",
             spec.args
         );
@@ -52,10 +51,7 @@ mod build_redeploy_spec_tests {
         let spec = build_redeploy_spec(DaemonInstallMode::System, "true");
 
         assert_eq!(spec.program, "systemd-run");
-        assert_ne!(
-            spec.args[0], "--user",
-            "system mode must not pass --user"
-        );
+        assert_ne!(spec.args[0], "--user", "system mode must not pass --user");
         assert_eq!(spec.args[0], "--scope");
     }
 
@@ -127,37 +123,25 @@ mod build_redeploy_spec_tests {
     }
 }
 
-/// 验证 spawn_detached_redeploy_nonblocking 的 --no-block 参数插入逻辑。
+/// 验证 build_redeploy_spec_nonblocking 能正确插入 --no-block。
 ///
-/// 由于 spawn_detached_redeploy_nonblocking 会实际尝试打开日志文件/启动进程，
-/// 不适合在单测中直接调用。这里通过检查 build_redeploy_spec 的参数布局来间接验证。
-/// 实际 nonblocking 的插入逻辑在 redeploy.rs 中：
-/// ```rust,ignore
-/// let collect_idx = spec.args.iter().position(|a| a == "--collect");
-/// if let Some(idx) = collect_idx {
-///     spec.args.insert(idx + 1, "--no-block");
-/// }
-/// ```
-/// 本测试确保 --collect 的位置是我们预期的那样，从而 indirect 验证插入点正确。
+/// build_redeploy_spec_nonblocking 现在是 redeploy.rs 的公有函数，
+/// 与 spawn_detached_redeploy_nonblocking 使用同一份实现，
+/// 维护者无需担心测试与实际行为不一致。
 #[cfg(test)]
 #[cfg(target_os = "linux")]
 mod nonblocking_spec_tests {
-    use ntd::daemon::build_redeploy_spec;
+    use ntd::daemon::build_redeploy_spec_nonblocking;
     use ntd::daemon::DaemonInstallMode;
 
-    /// 模拟 spawn_detached_redeploy_nonblocking 的 args 构造逻辑，
+    /// 通过公有函数 build_redeploy_spec_nonblocking 获取 args，
     /// 验证 --no-block 被插入到正确位置。
     fn build_nonblocking_spec(ntd_cmd: &str) -> Vec<String> {
         let script = format!(
             "sleep 3; {} daemon install --force; {} daemon start; rm -f /tmp/ntd.update",
             ntd_cmd, ntd_cmd
         );
-        let mut spec = build_redeploy_spec(DaemonInstallMode::User, &script);
-        let collect_idx = spec.args.iter().position(|a| a == "--collect");
-        if let Some(idx) = collect_idx {
-            spec.args.insert(idx + 1, "--no-block".to_string());
-        }
-        spec.args
+        build_redeploy_spec_nonblocking(DaemonInstallMode::User, &script).args
     }
 
     #[test]
@@ -166,14 +150,19 @@ mod nonblocking_spec_tests {
         // args 布局: [--user, --scope, --collect, --no-block, --property=..., /bin/sh, -c, <script>]
         let collect_idx = args.iter().position(|a| a == "--collect").unwrap();
         assert_eq!(
-            args[collect_idx + 1], "--no-block",
+            args[collect_idx + 1],
+            "--no-block",
             "--no-block must be inserted immediately after --collect, got {:?}",
             args
         );
 
         // Verify --no-block appears exactly once
         let count = args.iter().filter(|a| a.as_str() == "--no-block").count();
-        assert_eq!(count, 1, "--no-block must appear exactly once, args: {:?}", args);
+        assert_eq!(
+            count, 1,
+            "--no-block must appear exactly once, args: {:?}",
+            args
+        );
     }
 
     #[test]
@@ -182,7 +171,10 @@ mod nonblocking_spec_tests {
         // Must contain all the standard flags
         assert!(args.contains(&"--scope".to_string()), "Missing --scope");
         assert!(args.contains(&"--collect".to_string()), "Missing --collect");
-        assert!(args.contains(&"--no-block".to_string()), "Missing --no-block");
+        assert!(
+            args.contains(&"--no-block".to_string()),
+            "Missing --no-block"
+        );
         assert!(args.contains(&"/bin/sh".to_string()), "Missing /bin/sh");
         assert!(args.contains(&"-c".to_string()), "Missing -c");
 

--- a/backend/tests/daemon_redeploy_tests.rs
+++ b/backend/tests/daemon_redeploy_tests.rs
@@ -97,4 +97,106 @@ mod build_redeploy_spec_tests {
             assert_eq!(count, 1, "{flag} appeared {count} times in {:?}", spec.args);
         }
     }
+
+    /// 验证 build_redeploy_spec 的 args 布局稳定，以便
+    /// spawn_detached_redeploy_nonblocking 在 --collect 后插入 --no-block。
+    /// 如果布局（如 --collect 位置）变了，nonblocking 的插入逻辑会失效。
+    #[test]
+    fn test_redeploy_spec_layout_collect_position() {
+        // 确认 --collect 在 args 中的位置是稳定的（第三个位置，0-indexed）。
+        // This is important for spawn_detached_redeploy_nonblocking which inserts
+        // --no-block right after --collect.
+        let spec = build_redeploy_spec(DaemonInstallMode::User, "true");
+        // args 布局: [--user, --scope, --collect, --property=..., ...]
+        assert_eq!(
+            spec.args[2], "--collect",
+            "Expected --collect at index 2, got {:?}",
+            spec.args
+        );
+    }
+
+    #[test]
+    fn test_redeploy_spec_system_layout_collect_position() {
+        // System 模式下 args 布局: [--scope, --collect, --property=..., ...]
+        let spec = build_redeploy_spec(DaemonInstallMode::System, "true");
+        assert_eq!(
+            spec.args[1], "--collect",
+            "Expected --collect at index 1 for System mode, got {:?}",
+            spec.args
+        );
+    }
+}
+
+/// 验证 spawn_detached_redeploy_nonblocking 的 --no-block 参数插入逻辑。
+///
+/// 由于 spawn_detached_redeploy_nonblocking 会实际尝试打开日志文件/启动进程，
+/// 不适合在单测中直接调用。这里通过检查 build_redeploy_spec 的参数布局来间接验证。
+/// 实际 nonblocking 的插入逻辑在 redeploy.rs 中：
+/// ```rust,ignore
+/// let collect_idx = spec.args.iter().position(|a| a == "--collect");
+/// if let Some(idx) = collect_idx {
+///     spec.args.insert(idx + 1, "--no-block");
+/// }
+/// ```
+/// 本测试确保 --collect 的位置是我们预期的那样，从而 indirect 验证插入点正确。
+#[cfg(test)]
+#[cfg(target_os = "linux")]
+mod nonblocking_spec_tests {
+    use ntd::daemon::build_redeploy_spec;
+    use ntd::daemon::DaemonInstallMode;
+
+    /// 模拟 spawn_detached_redeploy_nonblocking 的 args 构造逻辑，
+    /// 验证 --no-block 被插入到正确位置。
+    fn build_nonblocking_spec(ntd_cmd: &str) -> Vec<String> {
+        let script = format!(
+            "sleep 3; {} daemon install --force; {} daemon start; rm -f /tmp/ntd.update",
+            ntd_cmd, ntd_cmd
+        );
+        let mut spec = build_redeploy_spec(DaemonInstallMode::User, &script);
+        let collect_idx = spec.args.iter().position(|a| a == "--collect");
+        if let Some(idx) = collect_idx {
+            spec.args.insert(idx + 1, "--no-block".to_string());
+        }
+        spec.args
+    }
+
+    #[test]
+    fn test_nonblocking_inserts_no_block_after_collect() {
+        let args = build_nonblocking_spec("/usr/bin/ntd");
+        // args 布局: [--user, --scope, --collect, --no-block, --property=..., /bin/sh, -c, <script>]
+        let collect_idx = args.iter().position(|a| a == "--collect").unwrap();
+        assert_eq!(
+            args[collect_idx + 1], "--no-block",
+            "--no-block must be inserted immediately after --collect, got {:?}",
+            args
+        );
+
+        // Verify --no-block appears exactly once
+        let count = args.iter().filter(|a| a.as_str() == "--no-block").count();
+        assert_eq!(count, 1, "--no-block must appear exactly once, args: {:?}", args);
+    }
+
+    #[test]
+    fn test_nonblocking_preserves_all_other_args() {
+        let args = build_nonblocking_spec("/usr/local/bin/ntd");
+        // Must contain all the standard flags
+        assert!(args.contains(&"--scope".to_string()), "Missing --scope");
+        assert!(args.contains(&"--collect".to_string()), "Missing --collect");
+        assert!(args.contains(&"--no-block".to_string()), "Missing --no-block");
+        assert!(args.contains(&"/bin/sh".to_string()), "Missing /bin/sh");
+        assert!(args.contains(&"-c".to_string()), "Missing -c");
+
+        // Verify the script is the last arg
+        let expected_script = "sleep 3; /usr/local/bin/ntd daemon install --force; /usr/local/bin/ntd daemon start; rm -f /tmp/ntd.update";
+        assert_eq!(args.last().unwrap(), expected_script);
+    }
+
+    #[test]
+    fn test_nonblocking_no_duplicate_flags() {
+        let args = build_nonblocking_spec("/usr/bin/ntd");
+        for flag in ["--scope", "--collect", "--no-block"] {
+            let count = args.iter().filter(|a| a.as_str() == flag).count();
+            assert_eq!(count, 1, "{flag} appeared {count} times in {:?}", args);
+        }
+    }
 }


### PR DESCRIPTION
## 背景

issue #569 分离式自更新方案的实现中， 原本在所有 Unix 平台统一使用 `sh -c "(...) &"` 来 fork 子进程。但在 Linux 上 systemd 的 `KillMode=mixed` 会按 cgroup 清理所有子进程，导致 `sh -c` 的子 shell 被一起杀掉，redeploy 流程中断。

项目已有 `backend/src/daemon/redeploy.rs` 使用 `systemd-run --scope` 将脚本放入独立 cgroup 的方案，但升级 handler 没有使用它。

## 改动

### 1. `backend/src/daemon/redeploy.rs`
- 新增 `spawn_detached_redeploy_nonblocking()`：非阻塞版本，使用 `--no-block` + `.spawn()`，适合 HTTP handler 场景。
- `spawn_detached_redeploy` 标注为阻塞版本（CLI 使用），添加 doc 提示。

### 2. `backend/src/handlers/mod.rs`
- **Linux 平台**：优先使用 `systemd-run --scope --no-block` 把 redeploy 脚本放入独立 cgroup。
- **降级回退**：`systemd-run` 不可用时（Docker/WSL 无 systemd），降级到 `sh -c` 方案。
- **macOS**：保持 `sh -c` 方案（launchd 不按 cgroup 杀进程）。
- 提取 `spawn_redeploy_sh_fallback` 消除 sh -c 方案的重复代码。

### 3. `backend/tests/daemon_redeploy_tests.rs`
- 新增 `nonblocking_spec_tests` 模块，验证 `--no-block` 插入逻辑正确。
- 验证 args 布局稳定，防止重构引入 bug。

## 测试

- [x] `cargo check` 通过（仅 pre-existing Assets 错误，与改动无关）
- [x] 新增的 nonblocking spec 测试覆盖了 --no-block 插入、args 完整性、no duplicate flags
- [x] --collect 位置稳定性的回归测试