### PR TITLE
fix: 修复 Windows 交叉编译时 spawn_redeploy_sh_fallback 未定义的错误 (issue #573)

### DIFF
--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -742,7 +742,7 @@ async fn version_upgrade_handler() -> impl IntoResponse {
             }
         }
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", windows)))]
     {
         // macOS 或其他 Unix 使用 sh -c 方案，因为 launchd 不会按 cgroup 杀进程。
         spawn_redeploy_sh_fallback(&ntd_cmd, &marker_cleanup_path, "/tmp/ntd-upgrade.log");


### PR DESCRIPTION
## 问题

PR #572 引入了  函数，其定义加了 `#[cfg(not(windows))]` 保护，
但 macOS/其他 Unix 路径的 cfg guard 是 `#[cfg(not(target_os = "linux"))]`，
这在 Windows 上也求值为 true，导致 Windows 交叉编译时找不到该函数。

## 修复

将 macOS/Unix 的 cfg guard 改为 `#[cfg(not(any(target_os = "linux", windows)))]`，
使 Windows 和 Linux 都不会走到这个路径：
- Windows 走自己的 cmd /C 路径
- Linux（systemd 环境）走 systemd-run 路径，fallback 到 sh -c 仅在 macOS/其他 Unix 上触发

Closes #573