### PR TITLE
feat: 在左侧todo列表上方增加关键字搜索框 (issue #585)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3970,3 +3970,46 @@ code {
 .running-mobile-tabs .ant-tabs-tab {
   font-size: 13px;
 }
+
+/* ---------- Todo Search Bar ---------- */
+/* 搜索框容器：放在标签筛选条和列表之间，提供标题/提示词模糊搜索 */
+.todo-search-bar {
+  padding: var(--space-sm) var(--space-lg);
+  border-bottom: 1px solid var(--color-border-light);
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-shrink: 0;
+}
+
+/* 搜索输入框：占满剩余宽度，圆角与标签条保持一致 */
+.todo-search-bar .todo-search-input {
+  flex: 1;
+  border-radius: var(--radius-sm);
+}
+
+/* 搜索输入框内部样式覆盖：让前缀图标和清空按钮垂直居中 */
+.todo-search-bar .todo-search-input .ant-input-prefix {
+  margin-right: var(--space-sm);
+  display: flex;
+  align-items: center;
+}
+
+/* 搜索结果计数：有搜索关键字时显示，帮助用户确认筛选范围 */
+.todo-search-count {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* 暗色主题下搜索框适配 */
+[data-theme="dark"] .todo-search-bar .todo-search-input {
+  background: var(--color-bg);
+  border-color: var(--color-border);
+}
+
+[data-theme="dark"] .todo-search-bar .todo-search-input:hover,
+[data-theme="dark"] .todo-search-bar .todo-search-input-focused {
+  border-color: var(--color-primary);
+}

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -545,7 +545,11 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
             <Empty
               description={
                 <div style={{ color: 'var(--color-text-tertiary)', fontSize: 14 }}>
-                  {selectedTagId ? '该标签下暂无任务' : '暂无任务'}
+                  {searchKeyword 
+                    ? `未找到匹配 "${searchKeyword}" 的任务`
+                    : selectedTagId 
+                      ? '该标签下暂无任务' 
+                      : '暂无任务'}
                   <br />
                   <span style={{ fontSize: 13, marginTop: 4, display: 'inline-block' }}>
                     点击右上角新建按钮创建第一个任务

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useApp } from '@/hooks/useApp';
 import { useIsMobile } from '@/hooks/useIsMobile';
-import { Button, Dropdown, Empty, Tooltip } from 'antd';
+import { Button, Dropdown, Empty, Input, Tooltip } from 'antd';
 import type { MenuProps } from 'antd';
-import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, ApartmentOutlined, UnorderedListOutlined, FolderOpenOutlined, RightOutlined, MoreOutlined } from '@ant-design/icons';
+import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, ApartmentOutlined, UnorderedListOutlined, FolderOpenOutlined, RightOutlined, MoreOutlined, SearchOutlined } from '@ant-design/icons';
 import { useTheme } from '@/hooks/useTheme';
 import { StatusPicker } from './StatusPicker';
 import * as db from '@/utils/database';
@@ -95,6 +95,9 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
   const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
   // 记录每个分组的折叠状态，key 为 workspace 路径
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  // 搜索关键字：用于按标题或提示词过滤 todo 列表；
+  // 用户输入后实时筛选，空字符串表示不过滤
+  const [searchKeyword, setSearchKeyword] = useState('');
 
   useEffect(() => {
     setIsLoading(false);
@@ -118,12 +121,23 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
     return () => window.removeEventListener('projectDirectoryAdded', handleDirAdded); // 清理：卸载时移除监听
   }, [reloadProjectDirectories]);
 
-  const filteredTodos = useMemo(() =>
-    selectedTagId
+  // 先按标签筛选，再按搜索关键字筛选；
+  // 搜索匹配标题（title）和提示词（prompt），任一包含关键字即命中
+  const filteredTodos = useMemo(() => {
+    // 第一步：标签筛选，selectedTagId 为 null 时不过滤
+    const tagFiltered = selectedTagId
       ? todos.filter(t => (t as any).tag_ids?.includes(selectedTagId))
-      : todos,
-    [todos, selectedTagId]
-  );
+      : todos;
+    // 第二步：关键字筛选，空字符串时不过滤；
+    // 统一转小写比较，实现不区分大小写的模糊匹配
+    const keyword = searchKeyword.trim().toLowerCase();
+    if (!keyword) return tagFiltered;
+    return tagFiltered.filter(t => {
+      const titleMatch = (t.title || '').toLowerCase().includes(keyword);
+      const promptMatch = (t.prompt || '').toLowerCase().includes(keyword);
+      return titleMatch || promptMatch;
+    });
+  }, [todos, selectedTagId, searchKeyword]);
 
   // 按 workspace 路径分组；workspace 为空或 null 的归入"未分组"虚拟分组，
   // 保证游离 todo 不会消失，只是放到列表底部
@@ -503,6 +517,23 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
           ))}
         </div>
       )}
+
+      {/* Search input - filter todos by title or prompt */}
+      <div className="todo-search-bar">
+        <Input
+          placeholder="搜索任务标题或提示词..."
+          prefix={<SearchOutlined style={{ color: 'var(--color-text-tertiary)' }} />}
+          allowClear
+          value={searchKeyword}
+          onChange={(e) => setSearchKeyword(e.target.value)}
+          className="todo-search-input"
+        />
+        {searchKeyword && (
+          <div className="todo-search-count">
+            找到 {filteredTodos.length} 个任务
+          </div>
+        )}
+      </div>
 
       {/* Todo list */}
       <div className="todo-list-content">


### PR DESCRIPTION
## 变更内容

为左侧 todo 列表添加关键字搜索功能：

### 功能特性
- 搜索框位于标签筛选栏下方，todo 列表上方
- 支持按标题（title）或提示词（prompt）进行模糊搜索
- 实时过滤，输入即搜索
- 搜索时显示匹配结果数量
- 支持一键清空搜索内容
- 适配暗色主题

### 技术实现
- 使用 React useState 管理搜索关键字状态
- 使用 useMemo 优化过滤性能，与标签筛选组合使用
- 不区分大小写的模糊匹配
- 使用 Ant Design Input 组件，带搜索图标前缀和清空按钮

### 修改文件
- `frontend/src/components/TodoList.tsx` - 添加搜索状态和 UI
- `frontend/src/App.css` - 添加搜索框样式

关闭 #585