### PR TITLE
fix: clipboard copy fallback for HTTP environments (#590)

### DIFF
--- a/frontend/src/components/RunningRecordDrawer.tsx
+++ b/frontend/src/components/RunningRecordDrawer.tsx
@@ -8,6 +8,7 @@ import {
   LinkOutlined,
   RightOutlined,
 } from '@ant-design/icons';
+import { copyToClipboard } from '@/utils/clipboard';
 import XMarkdown from '@ant-design/x-markdown';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { useApp } from '@/hooks/useApp';
@@ -162,9 +163,10 @@ export function RunningRecordDrawer({ record, open, onClose, onRefresh }: Runnin
     onRefresh?.();
   }, [onRefresh]);
 
-  const handleCopyResult = useCallback(() => {
+  const handleCopyResult = useCallback(async () => {
     if (record?.result) {
-      navigator.clipboard.writeText(record.result);
+      // 使用统一的复制工具（兼容 HTTP 环境）
+      await copyToClipboard(record.result);
     }
   }, [record]);
 

--- a/frontend/src/components/ShareCard.tsx
+++ b/frontend/src/components/ShareCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Card, Button, App } from 'antd';
 import { ShareAltOutlined, CopyOutlined, CheckOutlined } from '@ant-design/icons';
+import { copyToClipboard } from '@/utils/clipboard';
 
 const getSharePrompt = () => {
   return `全局安装 ntd：npm install -g @weibaohui/nothing-todo，然后执行 ntd daemon install && ntd daemon start，可选安装 skills：ntd skills install，访问 8088 端口`;
@@ -12,10 +13,15 @@ export function ShareCard() {
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(getSharePrompt());
-      setCopied(true);
-      message.success('安装提示词已复制到剪贴板');
-      setTimeout(() => setCopied(false), 2000);
+      // 使用统一的复制工具（兼容 HTTP 环境）
+      const ok = await copyToClipboard(getSharePrompt());
+      if (ok) {
+        setCopied(true);
+        message.success('安装提示词已复制到剪贴板');
+        setTimeout(() => setCopied(false), 2000);
+      } else {
+        message.error('复制失败，请手动复制');
+      }
     } catch {
       message.error('复制失败，请手动复制');
     }

--- a/frontend/src/components/TodoCard.tsx
+++ b/frontend/src/components/TodoCard.tsx
@@ -12,6 +12,7 @@ import {
 import XMarkdown from '@ant-design/x-markdown';
 import { ExecutorBadge } from './ExecutorBadge';
 import { formatTokens, formatDuration } from '@/utils/format';
+import { copyToClipboard } from '@/utils/clipboard';
 
 /* ─── Types ─── */
 
@@ -182,9 +183,11 @@ export const TodoCard = memo(function TodoCard({
               {prompt && (
                 <button
                   className="kanban-copy-btn"
-                  onClick={e => {
+                  onClick={async e => {
                     e.stopPropagation();
-                    navigator.clipboard.writeText(prompt).then(() => message.success('已复制'));
+                    // 使用统一的复制工具（兼容 HTTP 环境）
+                    const ok = await copyToClipboard(prompt);
+                    if (ok) message.success('已复制');
                   }}
                   title="复制 Prompt"
                 >
@@ -240,9 +243,11 @@ export const TodoCard = memo(function TodoCard({
               {resultText && (
                 <button
                   className="kanban-copy-btn"
-                  onClick={e => {
+                  onClick={async e => {
                     e.stopPropagation();
-                    navigator.clipboard.writeText(resultText).then(() => message.success('已复制'));
+                    // 使用统一的复制工具（兼容 HTTP 环境）
+                    const ok = await copyToClipboard(resultText);
+                    if (ok) message.success('已复制');
                   }}
                   title="复制结论"
                 >

--- a/frontend/src/components/WebhooksPanel.tsx
+++ b/frontend/src/components/WebhooksPanel.tsx
@@ -28,6 +28,7 @@ import {
 } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import type { Webhook, WebhookRecord } from '@/utils/database';
+import { copyToClipboard } from '@/utils/clipboard';
 import type { Todo } from '@/types';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
@@ -61,14 +62,11 @@ function CopyableUrl({ url, compact }: { url: string; compact: boolean }) {
         size="small"
         icon={<LinkOutlined />}
         onClick={async () => {
-          if (!navigator.clipboard?.writeText) {
-            message.error('当前环境不支持复制');
-            return;
-          }
-          try {
-            await navigator.clipboard.writeText(url);
+          // 使用统一的复制工具（兼容 HTTP 环境）
+          const ok = await copyToClipboard(url);
+          if (ok) {
             message.success('已复制 URL');
-          } catch {
+          } else {
             message.error('复制失败，请手动复制');
           }
         }}

--- a/frontend/src/components/settings/AboutPanel.tsx
+++ b/frontend/src/components/settings/AboutPanel.tsx
@@ -3,6 +3,7 @@ import { Spin, Card, Empty, Space, Typography, Button, Alert, Modal, Collapse, m
 import { ExclamationCircleFilled, ReloadOutlined, CloudDownloadOutlined, CopyOutlined, CodeOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import { ShareCard } from '@/components/ShareCard';
+import { copyToClipboard } from '@/utils/clipboard';
 
 const { Paragraph } = Typography;
 
@@ -352,9 +353,14 @@ export function AboutPanel() {
                                   type="text"
                                   size="small"
                                   icon={<CopyOutlined />}
-                                  onClick={() => {
-                                    navigator.clipboard.writeText(step.code);
-                                    message.success(`已复制：${step.label}`);
+                                  onClick={async () => {
+                                    // 使用统一的复制工具（兼容 HTTP 环境）
+                                    const ok = await copyToClipboard(step.code);
+                                    if (ok) {
+                                      message.success(`已复制：${step.label}`);
+                                    } else {
+                                      message.error('复制失败');
+                                    }
                                   }}
                                 />
                               </div>
@@ -372,9 +378,14 @@ export function AboutPanel() {
                               <Button
                                 size="small"
                                 icon={<CopyOutlined />}
-                                onClick={() => {
-                                  navigator.clipboard.writeText(MANUAL_UPGRADE_SCRIPT);
-                                  message.success('已复制全部升级命令');
+                                onClick={async () => {
+                                  // 使用统一的复制工具（兼容 HTTP 环境）
+                                  const ok = await copyToClipboard(MANUAL_UPGRADE_SCRIPT);
+                                  if (ok) {
+                                    message.success('已复制全部升级命令');
+                                  } else {
+                                    message.error('复制失败');
+                                  }
                                 }}
                               >
                                 复制全部命令

--- a/frontend/src/components/settings/messages/BindTab.tsx
+++ b/frontend/src/components/settings/messages/BindTab.tsx
@@ -3,6 +3,7 @@ import { QrcodeOutlined, DeleteOutlined, CopyOutlined, PlusOutlined, MinusCircle
 import * as db from '@/utils/database';
 import type { FeishuPushStatus, WhitelistEntry, FeishuSenderItem } from '@/utils/database';
 import type { Todo } from '@/types';
+import { copyToClipboard } from '@/utils/clipboard';
 
 const { Paragraph } = Typography;
 
@@ -117,12 +118,14 @@ export function BindTab({
                     message.error('更新响应开关失败: ' + (e.message || '未知错误'));
                   }
                 };
-                const copyToClipboard = (text: string, label: string) => {
-                  navigator.clipboard.writeText(text).then(() => {
+                const doCopyText = async (text: string, label: string) => {
+                  // 使用统一的复制工具（兼容 HTTP 环境）
+                  const ok = await copyToClipboard(text);
+                  if (ok) {
                     message.success(`${label} 已复制`);
-                  }).catch(() => {
+                  } else {
                     message.error('复制失败');
-                  });
+                  }
                 };
 
                 return (
@@ -191,12 +194,12 @@ export function BindTab({
                               <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                                 <span style={{ fontSize: 11, width: 80, color: 'var(--color-text-tertiary)' }}>单聊ID:</span>
                                 <Input size="small" value={botPushStatus.p2p_receive_id} onChange={(e) => handlePushTargetUpdate('p2p_receive_id', e.target.value)} style={{ flex: 1, fontSize: 11 }} />
-                                <Button size="small" icon={<CopyOutlined />} onClick={() => copyToClipboard(botPushStatus.p2p_receive_id, 'p2p_receive_id')} />
+                                <Button size="small" icon={<CopyOutlined />} onClick={() => doCopyText(botPushStatus.p2p_receive_id, 'p2p_receive_id')} />
                               </div>
                               <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                                 <span style={{ fontSize: 11, width: 80, color: 'var(--color-text-tertiary)' }}>群ID:</span>
                                 <Input size="small" value={botPushStatus.group_chat_id || ''} onChange={(e) => handlePushTargetUpdate('group_chat_id', e.target.value)} style={{ flex: 1, fontSize: 11 }} />
-                                <Button size="small" icon={<CopyOutlined />} onClick={() => copyToClipboard(botPushStatus.group_chat_id || '', 'group_chat_id')} />
+                                <Button size="small" icon={<CopyOutlined />} onClick={() => doCopyText(botPushStatus.group_chat_id || '', 'group_chat_id')} />
                               </div>
                               <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                                 <span style={{ fontSize: 11, width: 80, color: 'var(--color-text-tertiary)' }}>发送类型:</span>

--- a/frontend/src/components/settings/messages/RecordTab.tsx
+++ b/frontend/src/components/settings/messages/RecordTab.tsx
@@ -2,6 +2,7 @@ import { Button, Select, Table, Tag, Typography, Modal, Form, Input, Space, Tool
 import { ReloadOutlined, PlusOutlined, HistoryOutlined, QuestionCircleOutlined, CopyOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import type { FeishuHistoryMessage, FeishuHistoryChat } from '@/types';
+import { copyToClipboard } from '@/utils/clipboard';
 
 const { Option } = Select;
 
@@ -173,9 +174,14 @@ export function RecordTab({
                       type="link"
                       icon={<CopyOutlined />}
                       style={{ fontSize: 10, padding: 0 }}
-                      onClick={() => {
-                        navigator.clipboard.writeText(record.sender_open_id);
-                        message.success('已复制 Open ID');
+                      onClick={async () => {
+                        // 使用统一的复制工具（兼容 HTTP 环境）
+                        const ok = await copyToClipboard(record.sender_open_id);
+                        if (ok) {
+                          message.success('已复制 Open ID');
+                        } else {
+                          message.error('复制失败');
+                        }
                       }}
                     />
                   )}

--- a/frontend/src/components/todo-detail/ChainGroupCard.tsx
+++ b/frontend/src/components/todo-detail/ChainGroupCard.tsx
@@ -13,6 +13,7 @@ import { ContinuationLogsLoader } from './ContinuationLogsLoader';
 import { getHookTriggerLabel } from '@/utils/database/hooks';
 import type { SessionGroup } from './helpers';
 import type { ExecutionRecord, ExecutionStats, LogEntry } from '@/types';
+import { copyToClipboard } from '@/utils/clipboard';
 
 function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, viewMode, parseLogs, onRefresh, resolveStats, onViewModeChange }: {
   group: SessionGroup;
@@ -97,19 +98,20 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
           </div>
         </div>
         {/* 点击命令文本即可复制，不需要额外的复制按钮 */}
-        {/* 复制逻辑三步走：①检查 clipboard API 可用性 → ②写入剪贴板 → ③反馈结果 */}
-        {/* 使用 navigator.clipboard?.writeText 可选链：HTTP 环境或旧浏览器中该 API 为 undefined，直接调用会报 TypeError */}
+        {/* 使用 copyToClipboard 统一处理，兼容 HTTP 环境（通过 fallback 到 execCommand） */}
         {mainRecord.command && (
           <Tooltip title="点击复制命令">
             <div
               onClick={async () => {
                 try {
-                  if (!navigator.clipboard?.writeText) {
-                    messageApi.error('当前环境不支持复制');
-                    return;
+                  // 调用统一的复制工具（内置 fallback，兼容 HTTP 环境）
+                  const ok = await copyToClipboard(mainRecord.command || '');
+                  // 根据返回结果提示用户
+                  if (ok) {
+                    messageApi.success('已复制');
+                  } else {
+                    messageApi.error('复制失败');
                   }
-                  await navigator.clipboard.writeText(mainRecord.command || '');
-                  messageApi.success('已复制');
                 } catch {
                   messageApi.error('复制失败');
                 }
@@ -123,15 +125,17 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
         {mainRecord.result && (
           <div className={`history-result ${mainRecord.status === 'success' ? 'history-result-success' : 'history-result-failed'}`}>
             <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
-              {/* 复制结论文本：先检查 clipboard API 可用性，防止在不支持的浏览器中崩溃 */}
+              {/* 复制结论文本：使用 copyToClipboard 统一处理，兼容 HTTP 环境 */}
               <Button type="text" size="small" icon={<CopyOutlined />} onClick={async () => {
                 try {
-                  if (!navigator.clipboard?.writeText) {
-                    messageApi.error('当前环境不支持复制');
-                    return;
+                  // 调用统一的复制工具（内置 fallback，兼容 HTTP 环境）
+                  const ok = await copyToClipboard(mainRecord.result || '');
+                  // 根据返回结果提示用户
+                  if (ok) {
+                    messageApi.success('已复制到剪贴板');
+                  } else {
+                    messageApi.error('复制失败');
                   }
-                  await navigator.clipboard.writeText(mainRecord.result || '');
-                  messageApi.success('已复制到剪贴板');
                 } catch {
                   messageApi.error('复制失败');
                 }
@@ -232,15 +236,17 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                 {record.result && (
                   <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`} style={{ marginBottom: 6 }}>
                     <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
-                      {/* 复制续轮结论文本：先检查 clipboard API 可用性 */}
+                      {/* 复制续轮结论文本：使用 copyToClipboard 统一处理，兼容 HTTP 环境 */}
                       <Button type="text" size="small" icon={<CopyOutlined />} onClick={async () => {
                         try {
-                          if (!navigator.clipboard?.writeText) {
-                            messageApi.error('当前环境不支持复制');
-                            return;
+                          // 调用统一的复制工具（内置 fallback，兼容 HTTP 环境）
+                          const ok = await copyToClipboard(record.result || '');
+                          // 根据返回结果提示用户
+                          if (ok) {
+                            messageApi.success('已复制');
+                          } else {
+                            messageApi.error('复制失败');
                           }
-                          await navigator.clipboard.writeText(record.result || '');
-                          messageApi.success('已复制');
                         } catch {
                           messageApi.error('复制失败');
                         }

--- a/frontend/src/components/todo-detail/NarrowHistoryCard.tsx
+++ b/frontend/src/components/todo-detail/NarrowHistoryCard.tsx
@@ -11,6 +11,7 @@ import { NarrowLogView } from './NarrowLogView';
 import { getHookTriggerLabel } from '@/utils/database/hooks';
 import { ReviewStatusBadge } from './RecordDetailView';
 import type { ExecutionRecord, ExecutionStats, LogEntry } from '@/types';
+import { copyToClipboard } from '@/utils/clipboard';
 
 /** Narrow mode: single history card */
 export function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, onStop, onRefresh, onRate, getRunningTask, resolveStats, parseLogs, messageApi, onViewModeChange }: {
@@ -102,19 +103,20 @@ export function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, on
         </div>
       </div>
       {/* 点击命令文本即可复制，不需要额外的复制按钮 */}
-      {/* 复制逻辑三步走：①检查 clipboard API 可用性 → ②写入剪贴板 → ③反馈结果 */}
-      {/* 使用 navigator.clipboard?.writeText 可选链：HTTP 环境或旧浏览器中该 API 为 undefined，直接调用会报 TypeError */}
+      {/* 使用 copyToClipboard 统一处理，兼容 HTTP 环境（通过 fallback 到 execCommand） */}
       {record.command && (
         <Tooltip title="点击复制命令">
           <div
             onClick={async () => {
               try {
-                if (!navigator.clipboard?.writeText) {
-                  messageApi.error('当前环境不支持复制');
-                  return;
+                // 调用统一的复制工具（内置 fallback，兼容 HTTP 环境）
+                const ok = await copyToClipboard(record.command || '');
+                // 根据返回结果提示用户
+                if (ok) {
+                  messageApi.success('已复制');
+                } else {
+                  messageApi.error('复制失败');
                 }
-                await navigator.clipboard.writeText(record.command || '');
-                messageApi.success('已复制');
               } catch {
                 messageApi.error('复制失败');
               }
@@ -128,15 +130,17 @@ export function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, on
       {record.result !== null && record.result !== '' && (
         <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`}>
           <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
-            {/* 复制结论文本：先检查 clipboard API 可用性，防止在不支持的浏览器中崩溃 */}
+            {/* 复制结论文本：使用 copyToClipboard 统一处理，兼容 HTTP 环境 */}
             <Button type="text" size="small" icon={<CopyOutlined />} onClick={async () => {
               try {
-                if (!navigator.clipboard?.writeText) {
-                  messageApi.error('当前环境不支持复制');
-                  return;
+                // 调用统一的复制工具（内置 fallback，兼容 HTTP 环境）
+                const ok = await copyToClipboard(record.result || '');
+                // 根据返回结果提示用户
+                if (ok) {
+                  messageApi.success('已复制到剪贴板');
+                } else {
+                  messageApi.error('复制失败');
                 }
-                await navigator.clipboard.writeText(record.result || '');
-                messageApi.success('已复制到剪贴板');
               } catch {
                 messageApi.error('复制失败');
               }

--- a/frontend/src/components/todo-detail/RecordDetailView.tsx
+++ b/frontend/src/components/todo-detail/RecordDetailView.tsx
@@ -13,6 +13,7 @@ import type { SessionGroup } from './helpers';
 import { supportsResume } from '@/types';
 import type { ExecutionRecord, LogEntry } from '@/types';
 import { getHookTriggerLabel } from '@/utils/database/hooks';
+import { copyToClipboard } from '@/utils/clipboard';
 
 export function RecordDetailView({
   isLoadingDetail, record, sessionGroups,
@@ -166,19 +167,20 @@ export function RecordDetailView({
         </div>
       </div>
       {/* 点击命令文本即可复制，不需要额外的复制按钮 */}
-      {/* 复制逻辑三步走：①检查 clipboard API 可用性 → ②写入剪贴板 → ③反馈结果 */}
-      {/* 使用 navigator.clipboard?.writeText 可选链：HTTP 环境或旧浏览器中该 API 为 undefined，直接调用会报 TypeError */}
+      {/* 使用 copyToClipboard 工具函数统一处理剪贴板写入，支持 HTTP 环境（通过 fallback 到 execCommand） */}
       {record.command && (
         <Tooltip title="点击复制命令">
           <div
             onClick={async () => {
               try {
-                if (!navigator.clipboard?.writeText) {
-                  message.error('当前环境不支持复制');
-                  return;
+                // 调用统一的复制工具（内置 fallback，兼容 HTTP 环境）
+                const ok = await copyToClipboard(record.command || '');
+                // 根据返回结果提示用户
+                if (ok) {
+                  message.success('已复制');
+                } else {
+                  message.error('复制失败');
                 }
-                await navigator.clipboard.writeText(record.command || '');
-                message.success('已复制');
               } catch {
                 message.error('复制失败');
               }
@@ -193,19 +195,21 @@ export function RecordDetailView({
         <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`} style={{ marginBottom: 12 }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
             <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-text)' }}>结论</span>
-            {/* 复制结论文本：先检查 clipboard API 可用性，防止在不支持的浏览器中崩溃 */}
+            {/* 复制结论文本：使用 copyToClipboard 统一处理，兼容 HTTP 环境 */}
             <Button
               type="text"
               size="small"
               icon={<CopyOutlined />}
               onClick={async () => {
                 try {
-                  if (!navigator.clipboard?.writeText) {
-                    message.error('当前环境不支持复制');
-                    return;
+                  // 调用统一的复制工具（内置 fallback，兼容 HTTP 环境）
+                  const ok = await copyToClipboard(record.result || '');
+                  // 根据返回结果提示用户
+                  if (ok) {
+                    message.success('已复制到剪贴板');
+                  } else {
+                    message.error('复制失败');
                   }
-                  await navigator.clipboard.writeText(record.result || '');
-                  message.success('已复制到剪贴板');
                 } catch {
                   message.error('复制失败');
                 }

--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -1,0 +1,71 @@
+/**
+ * Clipboard utility with fallback for non-secure contexts (HTTP)
+ * 
+ * The modern Clipboard API (navigator.clipboard.writeText) only works in secure contexts:
+ * - HTTPS
+ * - localhost
+ * 
+ * When accessing via HTTP (e.g., http://192.168.1.100:18088), the API is undefined.
+ * This utility provides a fallback using document.execCommand('copy') with a textarea.
+ */
+
+/**
+ * Copy text to clipboard with fallback for non-secure HTTP environments
+ * @param text - The text to copy to clipboard
+ * @returns Promise<boolean> - true if successful, false otherwise
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  // 优先使用现代 Clipboard API（HTTPS/localhost 环境）
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Clipboard API 失败，继续尝试 fallback
+    }
+  }
+
+  // Fallback: 使用 textarea + execCommand（HTTP 环境）
+  return fallbackCopyText(text);
+}
+
+/**
+ * Fallback copy method using textarea and execCommand
+ * 在 HTTP 环境中，Clipboard API 不可用，需要通过创建临时 textarea 元素并选中内容来复制
+ * @param text - The text to copy
+ * @returns boolean - true if successful, false otherwise
+ */
+function fallbackCopyText(text: string): boolean {
+  // 创建临时 textarea 元素（不可见）
+  const textarea = document.createElement('textarea');
+  
+  // 设置样式使其不可见但可交互（display:none 会导致 select() 失效）
+  textarea.style.position = 'fixed';
+  textarea.style.top = '0';
+  textarea.style.left = '0';
+  textarea.style.width = '2em';
+  textarea.style.height = '2em';
+  textarea.style.padding = '0';
+  textarea.style.border = 'none';
+  textarea.style.outline = 'none';
+  textarea.style.boxShadow = 'none';
+  textarea.style.background = 'transparent';
+  textarea.style.opacity = '0';
+  
+  // 设置值并添加到 DOM
+  textarea.value = text;
+  document.body.appendChild(textarea);
+  
+  try {
+    // 选中内容并执行复制命令
+    textarea.select();
+    textarea.setSelectionRange(0, text.length); // iOS 需要
+    const successful = document.execCommand('copy');
+    return successful;
+  } catch (err) {
+    return false;
+  } finally {
+    // 清理：移除临时元素
+    document.body.removeChild(textarea);
+  }
+}


### PR DESCRIPTION
## 问题描述

Issue #590: todo执行结论复制功能报错

navigator.clipboard.writeText 仅在安全上下文（HTTPS/localhost）中可用。通过 HTTP 访问（例如 http://192.168.1.100:18088）时，该 API 为 undefined，导致当前环境不支持复制错误。

## 解决方案

### 新增统一的剪贴板工具函数

创建 `frontend/src/utils/clipboard.ts`，提供 `copyToClipboard` 函数：
- **优先使用现代 Clipboard API**（HTTPS/localhost 环境）
- **自动降级到 execCommand 方案**（HTTP 环境）：
  - 创建临时 textarea 元素
  - 设置值并选中
  - 调用 document.execCommand('copy')
  - 清理临时元素

### 统一所有剪贴板调用

更新 10 个组件，统一使用新的工具函数：

**Todo 详情相关：**
- RecordDetailView.tsx - 命令和结论复制
- NarrowHistoryCard.tsx - 命令和结论复制
- ChainGroupCard.tsx - 命令、结论和续轮结论复制
- RunningRecordDrawer.tsx - 结论复制

**Todo 列表：**
- TodoCard.tsx - Prompt 和结论复制

**设置页面：**
- AboutPanel.tsx - 安装命令和升级脚本复制
- BindTab.tsx - ID 复制
- RecordTab.tsx - Open ID 复制

**其他：**
- WebhooksPanel.tsx - URL 复制
- ShareCard.tsx - 分享提示词复制

## 测试验证

- [x] TypeScript 编译通过
- [x] 生产构建成功
- [ ] HTTP 环境下复制功能正常
- [ ] HTTPS/localhost 环境下复制功能正常
- [ ] 所有复制场景的 UI 反馈正确