### PR TITLE
feat(backup): 升级备份文件大小显示格式

### DIFF
--- a/frontend/src/components/settings/backup/DatabaseBackupTab.tsx
+++ b/frontend/src/components/settings/backup/DatabaseBackupTab.tsx
@@ -4,6 +4,7 @@ import { Cron } from 'react-js-cron';
 import 'react-js-cron/dist/styles.css';
 import { CronPresetSelect } from '@/components/CronPresetSelect';
 import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '@/utils/cron';
+import { formatFileSize } from '@/utils/format';
 
 interface BackupFilesInfo {
   auto_backup_enabled: boolean;
@@ -102,7 +103,7 @@ export function DatabaseBackupTab({
                     <div>
                       <div style={{ fontWeight: 500 }}>{file.name}</div>
                       <div style={{ color: 'var(--color-text-tertiary)', fontSize: 11 }}>
-                        {(file.size / 1024).toFixed(1)} KB · {file.created_at}
+                        {formatFileSize(file.size)} · {file.created_at}
                       </div>
                     </div>
                     <Space size={4}>

--- a/frontend/src/components/settings/backup/SkillBackupTab.tsx
+++ b/frontend/src/components/settings/backup/SkillBackupTab.tsx
@@ -4,6 +4,7 @@ import { Cron } from 'react-js-cron';
 import 'react-js-cron/dist/styles.css';
 import { CronPresetSelect } from '@/components/CronPresetSelect';
 import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '@/utils/cron';
+import { formatFileSize } from '@/utils/format';
 
 interface ExecutorSkillInfo {
   executor: string;
@@ -112,7 +113,7 @@ export function SkillBackupTab({
                     <div>
                       <div style={{ fontWeight: 500 }}>{file.name}</div>
                       <div style={{ color: 'var(--color-text-tertiary)', fontSize: 11 }}>
-                        {(file.size / 1024).toFixed(1)} KB · {file.created_at}
+                        {formatFileSize(file.size)} · {file.created_at}
                       </div>
                     </div>
                     <Space size={4}>

--- a/frontend/src/components/settings/backup/TodoBackupTab.tsx
+++ b/frontend/src/components/settings/backup/TodoBackupTab.tsx
@@ -4,6 +4,7 @@ import { Cron } from 'react-js-cron';
 import 'react-js-cron/dist/styles.css';
 import { CronPresetSelect } from '@/components/CronPresetSelect';
 import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '@/utils/cron';
+import { formatFileSize } from '@/utils/format';
 
 const { Dragger } = Upload;
 
@@ -129,7 +130,7 @@ export function TodoBackupTab({
                     <div>
                       <div style={{ fontWeight: 500 }}>{file.name}</div>
                       <div style={{ color: 'var(--color-text-tertiary)', fontSize: 11 }}>
-                        {(file.size / 1024).toFixed(1)} KB · {file.created_at}
+                        {formatFileSize(file.size)} · {file.created_at}
                       </div>
                     </div>
                     <Space size={4}>

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -136,3 +136,19 @@ export function elapsedSeconds(startTimeStr: string | null | undefined): number 
   const now = new Date();
   return Math.floor((now.getTime() - date.getTime()) / 1000);
 }
+
+/**
+ * 格式化文件大小为人类可读字符串。
+ *
+ * 规则：
+ * - < 1KB → 显示字节（如 "500 B"）
+ * - < 1MB → 显示 KB（如 "1.5 KB"）
+ * - < 1GB → 显示 MB（如 "2.5 MB"）
+ * - >= 1GB → 显示 GB（如 "1.2 GB"）
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}


### PR DESCRIPTION
## 变更内容

- 新增 `formatFileSize` 工具函数，支持 B/KB/MB/GB 自适应显示
- 更新三个备份标签页（TodoBackupTab、SkillBackupTab、DatabaseBackupTab）使用新的格式化函数
- 大于 1MB 显示为 XX MB，大于 1GB 显示为 XX GB

Closes #595