### PR TITLE
fix: 修复 todo 搜索栏下方分隔线在暗色主题下颜色突兀的问题 (issue #602)

### DIFF
--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -496,7 +496,8 @@ export function TodoList({ onOpenCreateModal, onOpenSmartCreate, onSelectTodo, o
       </div>
 
       {/* Search box - 在 todo 列表上方，按标题或提示词关键字搜索 */}
-      <div style={{ padding: '8px 16px', borderBottom: '1px solid #f0f0f0' }}>
+      {/* 横线颜色用 --color-border-light 而不是硬编码：useTheme 通过切换 documentElement 的 data-theme 来驱动 CSS 变量；浅色=#f1f5f9、暗色=#262637，与仓库其他 7 处分隔线（TodoDrawer/HistoryList/SessionDetailDrawer 等）保持一致，避免暗色下出现一条突兀的浅线 (issue #602) */}
+      <div style={{ padding: '8px 16px', borderBottom: '1px solid var(--color-border-light)' }}>
         <Input
           placeholder="搜索标题或提示词..."
           prefix={<SearchOutlined style={{ color: '#bfbfbf' }} />}

--- a/frontend/tests/todo-search-divider-theme.spec.ts
+++ b/frontend/tests/todo-search-divider-theme.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * todo 搜索栏分隔线主题色测试
+ *
+ * 验证修复后的搜索栏下方横线在亮/暗主题下颜色都能跟随主题：
+ * - 亮色主题下颜色应明显浅于暗色主题（不再是固定白色 #f0f0f0）
+ * - 暗色主题下颜色应足够深，不再突兀
+ * - 同一会话切换主题时颜色发生变化
+ *
+ * 对应 Issue #602：todo 搜索框主题色修正
+ */
+
+import { test, expect, chromium, type Page } from '@playwright/test';
+
+const DEV_URL = process.env.E2E_BASE_URL || 'http://localhost:5173';
+
+// 解析 rgb()/rgba() 字符串为对象，便于做亮度判定
+function parseRgb(rgbStr: string): { r: number; g: number; b: number } | null {
+  const m = rgbStr.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  if (!m) return null;
+  return { r: parseInt(m[1], 10), g: parseInt(m[2], 10), b: parseInt(m[3], 10) };
+}
+
+// 在页面上定位 todo 搜索框所在的容器 div（带 border-bottom: 1px solid）并返回颜色
+async function getSearchDividerColor(page: Page): Promise<string | null> {
+  return await page.evaluate(() => {
+    // 通过 placeholder 文本定位搜索框；向上回溯到第一个有可见 border-bottom 的祖先
+    const inputs = Array.from(document.querySelectorAll('input'));
+    const searchInput = inputs.find(
+      (i) => i.placeholder && i.placeholder.includes('搜索标题'),
+    );
+    if (!searchInput) return null;
+    let el: HTMLElement | null = searchInput.parentElement;
+    while (el && el !== document.body) {
+      const style = getComputedStyle(el);
+      if (style.borderBottomStyle === 'solid' && style.borderBottomWidth !== '0px') {
+        return style.borderBottomColor;
+      }
+      el = el.parentElement;
+    }
+    return null;
+  });
+}
+
+test.describe('todo 搜索栏分隔线主题色 — Issue #602', () => {
+  test('亮色主题下分隔线颜色为浅色（非纯白）', async () => {
+    const browser = await chromium.launch();
+    // 强制 light colorScheme，避免系统暗色偏好影响 useTheme 初始判断
+    const context = await browser.newContext({ colorScheme: 'light' });
+    const page = await context.newPage();
+    await page.goto(DEV_URL);
+    // 显式写入 localStorage 锁定主题，刷新后由 ThemeProvider 接管
+    await page.evaluate(() => localStorage.setItem('app_theme', 'light'));
+    await page.reload();
+    // 等待页面布局稳定，给 useLayoutEffect 写入 data-theme 的时间
+    await page.waitForTimeout(1500);
+
+    const color = await getSearchDividerColor(page);
+    expect(color).not.toBeNull();
+    const rgb = parseRgb(color!);
+    expect(rgb).not.toBeNull();
+    // 修复前的硬编码 #f0f0f0 → rgb(240,240,240)，三通道和=720，过浅
+    // 修复后用 --color-border-light=#f1f5f9 → rgb(241,245,249)，同样浅
+    // 但关键是不能等于纯白 (255,255,255)；且比暗色应明显更浅
+    expect(rgb!.r + rgb!.g + rgb!.b).toBeLessThan(255 * 3);
+    expect(rgb!.r + rgb!.g + rgb!.b).toBeGreaterThan(600); // 至少是浅灰
+
+    await browser.close();
+  });
+
+  test('暗色主题下分隔线颜色为深色（不再突兀的浅线）', async () => {
+    const browser = await chromium.launch();
+    const context = await browser.newContext({ colorScheme: 'dark' });
+    const page = await context.newPage();
+    await page.goto(DEV_URL);
+    await page.evaluate(() => localStorage.setItem('app_theme', 'dark'));
+    await page.reload();
+    await page.waitForTimeout(1500);
+
+    const color = await getSearchDividerColor(page);
+    expect(color).not.toBeNull();
+    const rgb = parseRgb(color!);
+    expect(rgb).not.toBeNull();
+    // 修复后 --color-border-light=#262637 → rgb(38,38,55)，三通道和=131
+    // 修复前 #f0f0f0 仍是 720，所以三通道和应显著低于 720
+    expect(rgb!.r + rgb!.g + rgb!.b).toBeLessThan(300);
+
+    await browser.close();
+  });
+
+  test('同一会话切换主题时颜色发生变化', async () => {
+    const browser = await chromium.launch();
+    const context = await browser.newContext({ colorScheme: 'light' });
+    const page = await context.newPage();
+    await page.goto(DEV_URL);
+    await page.evaluate(() => localStorage.setItem('app_theme', 'light'));
+    await page.reload();
+    await page.waitForTimeout(1500);
+
+    const lightColor = await getSearchDividerColor(page);
+    expect(lightColor).not.toBeNull();
+
+    // 切换到暗色并刷新，让 ThemeProvider 重新读 localStorage
+    await page.evaluate(() => localStorage.setItem('app_theme', 'dark'));
+    await page.reload();
+    await page.waitForTimeout(1500);
+
+    const darkColor = await getSearchDividerColor(page);
+    expect(darkColor).not.toBeNull();
+
+    // 核心断言：颜色必须跟随主题变化；修复前两边都是 #f0f0f0 永远相等
+    expect(lightColor).not.toBe(darkColor);
+
+    // 暗色必须明显比亮色暗
+    const lr = parseRgb(lightColor!)!;
+    const dr = parseRgb(darkColor!)!;
+    expect(dr.r + dr.g + dr.b).toBeLessThan(lr.r + lr.g + lr.b);
+
+    await browser.close();
+  });
+});


### PR DESCRIPTION
## 背景
Issue #602 反馈：todo 搜索栏下方有一条白色横线，在亮色主题下没问题，但在暗色主题下没有变色，导致一条白线非常突兀。

## 根因
`frontend/src/components/TodoList.tsx` 中搜索栏容器 div 用了硬编码的 `borderBottom: '1px solid #f0f0f0'`，绕过了主题机制（useTheme 通过切换 documentElement 的 data-theme 来驱动 CSS 变量）。

## 修复
把硬编码的 `#f0f0f0` 替换为 CSS 变量 `var(--color-border-light)`：
- 亮色: `--color-border-light = #f1f5f9` (浅灰)
- 暗色: `--color-border-light = #262637` (深灰)

此写法与项目内其他 7 处分隔线（TodoDrawer/HistoryList/SessionDetailDrawer/RunningRecordDrawer/SkillsPanel/CompactRow/relation-map.css）完全一致。

## 验证
新增 `frontend/tests/todo-search-divider-theme.spec.ts`，通过 Playwright 实测：
1. 亮色主题下分隔线颜色为浅色、非纯白
2. 暗色主题下分隔线颜色为深色，不再突兀
3. 同一会话切换主题时颜色发生变化（核心断言：修复前两边都是 #f0f0f0 永远相等）

测试命令：
```bash
cd frontend && npx playwright test tests/todo-search-divider-theme.spec.ts --reporter=list
```
3 个用例全部通过。

## 变更范围
- `frontend/src/components/TodoList.tsx`: 1 行样式替换 + 注释说明
- `frontend/tests/todo-search-divider-theme.spec.ts`: 新增验证脚本（122 行）

未触及搜索框 prefix 颜色 (#bfbfbf)，那属于另一处暗色主题可读性优化，不在本 issue 范围内。