### PR TITLE
refactor(adapters): 11 个 executor 改为 #[derive(Clone)] (#611)

### DIFF
--- a/backend/src/adapters/atomcode.rs
+++ b/backend/src/adapters/atomcode.rs
@@ -9,6 +9,9 @@ use crate::models::utc_timestamp;
 ///
 /// `BaseExecutor` 持有 path + model + usage，
 /// 额外保留 `has_done` 状态字段用于在 stderr 中检测到 "done" 事件。
+// `BaseExecutor` 已经 derive Clone；`Arc<Mutex<...>>` 也派生 Clone（共享内部状态），
+// 因此组合结构体可直接 derive Clone，与原手写 impl 语义等价。
+#[derive(Clone)]
 pub struct AtomcodeExecutor {
     base: BaseExecutor,
     /// 标记是否已收到 done 事件，用于 stderr 流处理
@@ -20,15 +23,6 @@ impl AtomcodeExecutor {
         Self {
             base: BaseExecutor::new(path),
             has_done: Arc::new(Mutex::new(false)),
-        }
-    }
-}
-
-impl Clone for AtomcodeExecutor {
-    fn clone(&self) -> Self {
-        Self {
-            base: self.base.clone(),
-            has_done: self.has_done.clone(),
         }
     }
 }

--- a/backend/src/adapters/claude_code.rs
+++ b/backend/src/adapters/claude_code.rs
@@ -9,6 +9,8 @@ use crate::models::utc_timestamp;
 /// `usage` 字段虽然未被本 executor 直接使用（claude_code 的 usage 走
 /// `super::get_usage_from_logs` 从 result 事件提取），但 BaseExecutor 仍然保留这个
 /// `Arc<Mutex<Option<ExecutionUsage>>>` 字段，方便与其他 executor 行为保持一致。
+// `BaseExecutor` 已经 `#[derive(Clone)]`，组合字段无需手写 Clone impl。
+#[derive(Clone)]
 pub struct ClaudeCodeExecutor {
     base: BaseExecutor,
 }
@@ -16,12 +18,6 @@ pub struct ClaudeCodeExecutor {
 impl ClaudeCodeExecutor {
     pub fn new(path: String) -> Self {
         Self { base: BaseExecutor::new(path) }
-    }
-}
-
-impl Clone for ClaudeCodeExecutor {
-    fn clone(&self) -> Self {
-        Self { base: self.base.clone() }
     }
 }
 

--- a/backend/src/adapters/codebuddy.rs
+++ b/backend/src/adapters/codebuddy.rs
@@ -6,6 +6,8 @@ use crate::models::utc_timestamp;
 /// Codebuddy executor。
 ///
 /// 与 ClaudeCode 结构对称（path + model），统一通过 `BaseExecutor` 共享状态。
+// `BaseExecutor` 已经 `#[derive(Clone)]`，组合字段无需手写 Clone impl。
+#[derive(Clone)]
 pub struct CodebuddyExecutor {
     base: BaseExecutor,
 }
@@ -13,12 +15,6 @@ pub struct CodebuddyExecutor {
 impl CodebuddyExecutor {
     pub fn new(path: String) -> Self {
         Self { base: BaseExecutor::new(path) }
-    }
-}
-
-impl Clone for CodebuddyExecutor {
-    fn clone(&self) -> Self {
-        Self { base: self.base.clone() }
     }
 }
 

--- a/backend/src/adapters/codewhale.rs
+++ b/backend/src/adapters/codewhale.rs
@@ -17,7 +17,10 @@ use super::{BaseExecutor, CodeExecutor, ExecutorType, ParsedLogEntry};
 use crate::adapters::ExecutionUsage;
 use crate::models::utc_timestamp;
 
-/// Codewhale executor implementation.
+/// Codewhale executor implementation。
+///
+/// `#[derive(Clone)]` 由 `BaseExecutor`（已经 derive Clone）和自身所有 Arc<Mutex<...>> 字段共同保证安全。
+#[derive(Clone)]
 pub struct CodewhaleExecutor {
     /// 共享状态：path + model + usage。
     base: BaseExecutor,
@@ -26,12 +29,6 @@ pub struct CodewhaleExecutor {
 impl CodewhaleExecutor {
     pub fn new(path: String) -> Self {
         Self { base: BaseExecutor::new(path) }
-    }
-}
-
-impl Clone for CodewhaleExecutor {
-    fn clone(&self) -> Self {
-        Self { base: self.base.clone() }
     }
 }
 

--- a/backend/src/adapters/codex.rs
+++ b/backend/src/adapters/codex.rs
@@ -11,6 +11,8 @@ use crate::models::utc_timestamp;
 ///   - Codex：error 关键字 → "stderr" log_type；其他 → "info"
 ///
 /// 这种反向分类是历史行为，必须保留 override，不能直接删除该方法。
+// `BaseExecutor` 已经 `#[derive(Clone)]`，组合字段无需手写 Clone impl。
+#[derive(Clone)]
 pub struct CodexExecutor {
     base: BaseExecutor,
 }
@@ -18,12 +20,6 @@ pub struct CodexExecutor {
 impl CodexExecutor {
     pub fn new(path: String) -> Self {
         Self { base: BaseExecutor::new(path) }
-    }
-}
-
-impl Clone for CodexExecutor {
-    fn clone(&self) -> Self {
-        Self { base: self.base.clone() }
     }
 }
 

--- a/backend/src/adapters/hermes.rs
+++ b/backend/src/adapters/hermes.rs
@@ -10,6 +10,9 @@ use crate::models::{utc_timestamp, TodoItem};
 /// `BaseExecutor` 持有 path + model + usage 三件套，
 /// Hermes 还有 4 个执行期专用状态：`has_done`、`session_id`、`tool_calls_count`，
 /// 以及一个自定义的 `get_tool_calls_count()` override。
+// `BaseExecutor` 已经 derive Clone；`Arc<Mutex<...>>` 也派生 Clone（共享内部状态），
+// 因此组合结构体可直接 derive Clone，与原手写 impl 语义等价。
+#[derive(Clone)]
 pub struct HermesExecutor {
     base: BaseExecutor,
     has_done: Arc<Mutex<bool>>,
@@ -24,17 +27,6 @@ impl HermesExecutor {
             has_done: Arc::new(Mutex::new(false)),
             session_id: Arc::new(Mutex::new(None)),
             tool_calls_count: Arc::new(Mutex::new(0)),
-        }
-    }
-}
-
-impl Clone for HermesExecutor {
-    fn clone(&self) -> Self {
-        Self {
-            base: self.base.clone(),
-            has_done: self.has_done.clone(),
-            session_id: self.session_id.clone(),
-            tool_calls_count: self.tool_calls_count.clone(),
         }
     }
 }

--- a/backend/src/adapters/kimi.rs
+++ b/backend/src/adapters/kimi.rs
@@ -5,6 +5,8 @@ use crate::models::utc_timestamp;
 ///
 /// 内部使用 `BaseExecutor` 持有共享状态（path + model + usage），
 /// Kimi 自身不维护额外的执行期状态，因此 `BaseExecutor` 的所有字段默认即可。
+// `BaseExecutor` 已经 `#[derive(Clone)]`，组合字段无需手写 Clone impl。
+#[derive(Clone)]
 pub struct KimiExecutor {
     base: BaseExecutor,
 }
@@ -12,14 +14,6 @@ pub struct KimiExecutor {
 impl KimiExecutor {
     pub fn new(path: String) -> Self {
         Self { base: BaseExecutor::new(path) }
-    }
-}
-
-// `BaseExecutor` 已经 `#[derive(Clone)]`，
-// 通过结构体组合自动获得 Clone 能力，无需手写 impl Clone。
-impl Clone for KimiExecutor {
-    fn clone(&self) -> Self {
-        Self { base: self.base.clone() }
     }
 }
 

--- a/backend/src/adapters/mimo.rs
+++ b/backend/src/adapters/mimo.rs
@@ -29,6 +29,9 @@ use crate::models::utc_timestamp;
 ///
 /// `BaseExecutor` 持有 path + model + usage 三件套，
 /// MiMo 还有自己额外的 `has_successful_finish` 状态用于「非零退出码但有 step_finish 就算成功」的语义。
+// `BaseExecutor` 已经 derive Clone；`Arc<Mutex<...>>` 也派生 Clone（共享内部状态），
+// 因此组合结构体可直接 derive Clone，与原手写 impl 语义等价。
+#[derive(Clone)]
 pub struct MimoExecutor {
     /// 共享基础状态
     base: BaseExecutor,
@@ -42,15 +45,6 @@ impl MimoExecutor {
         Self {
             base: BaseExecutor::new(path),
             has_successful_finish: Arc::new(Mutex::new(false)),
-        }
-    }
-}
-
-impl Clone for MimoExecutor {
-    fn clone(&self) -> Self {
-        Self {
-            base: self.base.clone(),
-            has_successful_finish: self.has_successful_finish.clone(),
         }
     }
 }

--- a/backend/src/adapters/mobilecoder.rs
+++ b/backend/src/adapters/mobilecoder.rs
@@ -6,6 +6,8 @@ use crate::models::utc_timestamp;
 /// MobileCoder executor。
 ///
 /// MobileCoder 不使用 model 字段，但保留在 `BaseExecutor` 中以保持接口一致。
+// `BaseExecutor` 已经 `#[derive(Clone)]`，组合字段无需手写 Clone impl。
+#[derive(Clone)]
 pub struct MobilecoderExecutor {
     base: BaseExecutor,
 }
@@ -13,12 +15,6 @@ pub struct MobilecoderExecutor {
 impl MobilecoderExecutor {
     pub fn new(path: String) -> Self {
         Self { base: BaseExecutor::new(path) }
-    }
-}
-
-impl Clone for MobilecoderExecutor {
-    fn clone(&self) -> Self {
-        Self { base: self.base.clone() }
     }
 }
 

--- a/backend/src/adapters/opencode.rs
+++ b/backend/src/adapters/opencode.rs
@@ -10,6 +10,9 @@ use crate::models::utc_timestamp;
 ///
 /// `BaseExecutor` 持有 path + model + usage 三件套，
 /// Opencode 额外的 `has_successful_finish` 用于「非零退出码但有 finish 事件就算成功」语义。
+// `BaseExecutor` 已经 derive Clone；`Arc<Mutex<...>>` 也派生 Clone（共享内部状态），
+// 因此组合结构体可直接 derive Clone，与原手写 impl 语义等价。
+#[derive(Clone)]
 pub struct OpencodeExecutor {
     base: BaseExecutor,
     has_successful_finish: Arc<Mutex<bool>>,
@@ -20,15 +23,6 @@ impl OpencodeExecutor {
         Self {
             base: BaseExecutor::new(path),
             has_successful_finish: Arc::new(Mutex::new(false)),
-        }
-    }
-}
-
-impl Clone for OpencodeExecutor {
-    fn clone(&self) -> Self {
-        Self {
-            base: self.base.clone(),
-            has_successful_finish: self.has_successful_finish.clone(),
         }
     }
 }

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -29,6 +29,9 @@ use crate::models::utc_timestamp;
 /// `BaseExecutor` 持有 path + model + usage，
 /// pi 还维护一个独立的 `session_id` 字段，因为它的 session id 来源
 /// 与 `BaseExecutor::model` 等其他字段的生命周期不一致。
+// `BaseExecutor` 已经 derive Clone；`Arc<Mutex<...>>` 也派生 Clone（共享内部状态），
+// 因此组合结构体可直接 derive Clone，与原手写 impl 语义等价。
+#[derive(Clone)]
 pub struct PiExecutor {
     base: BaseExecutor,
     /// 从 session 事件中提取的 session id
@@ -123,17 +126,6 @@ impl PiExecutor {
             || buf.ends_with('！')
             || buf.ends_with('？')
             || buf.len() > 200
-    }
-}
-
-impl Clone for PiExecutor {
-    fn clone(&self) -> Self {
-        Self {
-            base: self.base.clone(),
-            session_id: self.session_id.clone(),
-            pending_text: self.pending_text.clone(),
-            full_text: self.full_text.clone(),
-        }
     }
 }
 


### PR DESCRIPTION
## 概述
Issue #611 — 纯样板清理。把 `backend/src/adapters/` 下 11 个 executor 适配器的手写 `impl Clone` 块改为 `#[derive(Clone)]`，因为它们都是 `BaseExecutor`（已 derive Clone）+ `Arc<Mutex<...>>` 字段（自身 Clone）的组合，derive 与手写语义完全等价。

## 改动
- 11 个结构体（claude_code, codex, hermes, kimi, atomcode, opencode, codebuddy, codewhale, mobilecoder, pi, mimo）顶部加 `#[derive(Clone)]`
- 删除各文件中的 `impl Clone for XxxExecutor { ... }` 块
- 每个结构体上方加 2-3 行注释，说明 derive 安全的依据（Arc<Mutex<...>> 共享内部状态，与原手写 impl 语义一致）

## 关键不变量
- `Arc<Mutex<...>>` clone 后共享同一份内部状态（这是 BaseExecutor 设计的核心）
- `test_base_executor_clone_shares_arc_state` 测试仍通过
- 公开 API、字段、行为均不变

## 证据

### 1. 编译通过
```
cargo build
warning: field `has_done` is never read
  --> src/adapters/hermes.rs:18:5
  ...
warning: `ntd` (lib) generated 1 warning
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 15s
```
唯一的 warning 是 pre-existing 的 dead-code 警告（`hermes.has_done`），与本次重构无关。

### 2. 单元测试通过
```
cargo test --lib
test result: ok. 474 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
```

### 3. 关键 Arc 共享状态不变量测试
```
cargo test --lib base
test adapters::tests::test_base_executor_clone_shares_arc_state ... ok
test adapters::tests::test_base_wrap_executor_default_check_success_via_trait ... ok
test adapters::tests::test_base_wrap_executor_executable_path_uses_base ... ok
test adapters::tests::test_base_wrap_executor_default_parse_stderr_via_trait ... ok
test adapters::tests::test_base_wrap_executor_get_usage_and_model_through_base ... ok
...
test result: ok. 16 passed; 0 failed
```

### 4. diff stats
```
 backend/src/adapters/atomcode.rs    | 12 +++---------
 backend/src/adapters/claude_code.rs |  8 ++------
 backend/src/adapters/codebuddy.rs   |  8 ++------
 backend/src/adapters/codewhale.rs   | 11 ++++-------
 backend/src/adapters/codex.rs       |  8 ++------
 backend/src/adapters/hermes.rs      | 14 +++-----------
 backend/src/adapters/kimi.rs        | 10 ++--------
 backend/src/adapters/mimo.rs        | 12 +++---------
 backend/src/adapters/mobilecoder.rs |  8 ++------
 backend/src/adapters/opencode.rs    | 12 +++---------
 backend/src/adapters/pi.rs          | 14 +++-----------
 11 files changed, 29 insertions(+), 88 deletions(-)
```
净减约 59 行样板代码。

## 验收对照（来自 Issue #611）
- [x] `cargo build` 通过
- [x] `cargo test` 通过（lib 全绿）
- [x] 11 个 executor 行为不变
- [x] `CodeExecutor::clone_box` 不受影响（本 refactor 不涉及该方法）
- [x] `BaseExecutor` 上保留的 `#[derive(Clone)]` 不变

## 备注
集成测试 `response_done_signal_tests` 编译失败是 main 分支已存在的问题（`ResponseDone` 在 handlers 中不存在），与本次重构无关 —— 在 main 上同样复现。

Closes #611