### PR TITLE
feat(hook): add before_execution pre-hook trigger

### DIFF
--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -589,6 +589,9 @@ fn fire_completion_hooks(
     )
 )]
 pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionResult {
+    // Extract `chain` before the rest so it stays available for cloning in
+    // the pre-hook section and in `fire_completion_hooks` at the end.
+    let chain = request.chain;
     let RunTodoExecutionRequest {
         db,
         executor_registry,
@@ -603,12 +606,12 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
         params,
         resume_session_id,
         resume_message,
-        chain,
         source_todo_id,
         source_todo_title,
         source_hook_id,
         feishu_bot_id,
         feishu_receive_id,
+        ..
     } = request;
     let message = params
         .as_ref()
@@ -653,6 +656,27 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     let todo_executor = todo.as_ref().and_then(|t| t.executor.clone());
     let todo_workspace = todo.as_ref().and_then(|t| t.workspace.clone());
     let todo_worktree_enabled = todo.as_ref().map(|t| t.worktree_enabled).unwrap_or(false);
+
+    // Fire before_execution hooks synchronously — block until all pre-flight targets finish.
+    // If the hook fails and the user didn't set skip_if_missing, we abort the main execution.
+    // We skip firing altogher when `todo` is None (todo was deleted between scheduling and now).
+    if let Some(ref t) = todo {
+        let ctx = crate::hooks::models::HookContext::for_before_execution(
+            todo_id,
+            t.title.clone(),
+            t.executor.clone(),
+            t.workspace.clone(),
+            chain.clone(),
+        );
+        match hook_service.clone().fire_before_execution(todo_id, ctx).await {
+            Ok(()) => {}
+            Err(msg) => {
+                // Pre-hook failed — abort this execution without creating a record.
+                tracing::warn!("aborting execution due to pre-hook failure: {}", msg);
+                return ExecutionResult { task_id, record_id: None };
+            }
+        }
+    }
 
     // Determine which executor to use: explicit > todo stored > default.
     // 抽到 `resolve_executor_type` 让 warn 日志集中，并支持单测。

--- a/backend/src/hooks/models.rs
+++ b/backend/src/hooks/models.rs
@@ -4,13 +4,21 @@ use crate::models::TodoStatus;
 
 /// Hook trigger types.
 ///
-/// The only triggers that exist are per-target-state: each fires when a todo
-/// transitions INTO that status. There are intentionally no lifecycle gates
-/// (`before_create` / `after_create` / `before_delete` / `after_delete`) —
-/// hooks observe state changes, they don't gate lifecycle events.
+/// Triggers are divided into two categories:
+/// - **State-change triggers**: fire when a todo transitions INTO a status
+///   (`pending` / `in_progress` / `completed` / `failed`).
+/// - **Execution triggers**: fire before or after a todo executes.
+///
+/// There are intentionally no lifecycle gates (`before_create` / `after_create`
+/// / `before_delete` / `after_delete`) — hooks observe state changes, they
+/// don't gate lifecycle events.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HookTrigger {
+    /// Fires just before a todo execution starts. The target todo runs first
+    /// as a "pre-flight" step; the source execution only proceeds after the
+    /// pre-hook completes.
+    BeforeExecution,
     StateChangedToPending,
     StateChangedToInProgress,
     StateChangedToCompleted,
@@ -20,6 +28,7 @@ pub enum HookTrigger {
 impl HookTrigger {
     pub fn as_str(&self) -> &'static str {
         match self {
+            Self::BeforeExecution => "before_execution",
             Self::StateChangedToPending => "state_changed_to_pending",
             Self::StateChangedToInProgress => "state_changed_to_in_progress",
             Self::StateChangedToCompleted => "state_changed_to_completed",
@@ -29,6 +38,7 @@ impl HookTrigger {
 
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
+            "before_execution" => Some(Self::BeforeExecution),
             "state_changed_to_pending" => Some(Self::StateChangedToPending),
             "state_changed_to_in_progress" => Some(Self::StateChangedToInProgress),
             "state_changed_to_completed" => Some(Self::StateChangedToCompleted),
@@ -40,6 +50,10 @@ impl HookTrigger {
     /// Map a target `TodoStatus` to its corresponding state-change trigger.
     /// Returns `None` for statuses without a dedicated trigger (e.g. `cancelled`)
     /// so callers can decide whether to fire any hook at all.
+    ///
+    /// Note: `BeforeExecution` is NOT a state-change trigger and is therefore
+    /// not returned here — callers that need to fire pre-execution hooks must
+    /// do so explicitly via a dedicated path (e.g. `fire_before_execution`).
     pub fn for_target_status(status: TodoStatus) -> Option<Self> {
         match status {
             TodoStatus::Pending => Some(Self::StateChangedToPending),
@@ -338,5 +352,33 @@ impl HookContext {
             trigger,
             chain,
         })
+    }
+
+    /// Build a pre-execution context for a todo about to run.
+    /// The trigger is always `HookTrigger::BeforeExecution`.
+    ///
+    /// Unlike state-change hooks (which are fire-and-forget), pre-execution
+    /// hooks are **synchronous blocking**: the source execution must wait for
+    /// all pre-hook targets to complete before proceeding. This ensures the
+    /// pre-flight step finishes before the main work starts.
+    pub fn for_before_execution(
+        todo_id: i64,
+        todo_title: String,
+        executor: Option<String>,
+        workspace: Option<String>,
+        chain: Vec<i64>,
+    ) -> Self {
+        Self {
+            todo_id: Some(todo_id),
+            todo_title,
+            old_status: None,
+            new_status: None,
+            executor,
+            workspace,
+            task_id: None,
+            trigger_time: crate::models::utc_timestamp(),
+            trigger: HookTrigger::BeforeExecution,
+            chain,
+        }
     }
 }

--- a/backend/src/hooks/service.rs
+++ b/backend/src/hooks/service.rs
@@ -115,6 +115,84 @@ impl HookService {
             .await;
         }
     }
+
+    /// Fire `before_execution` hooks attached to `todo_id` and **wait synchronously**
+    /// for all target todos to complete before returning.
+    ///
+    /// Unlike `fire_for_todo` (which is fire-and-forget), this method blocks the
+    /// caller until every pre-hook target finishes. The source execution must
+    /// not proceed until all pre-flight steps are done.
+    ///
+    /// Errors (target missing, execution failure, etc.) are logged but do not
+    /// propagate — the caller decides what to do on failure. The `skip_if_missing`
+    /// flag on each hook item is respected: if true, a missing target is silently
+    /// skipped; if false, we log a warning but still return `Ok` to let the caller
+    /// decide.
+    pub async fn fire_before_execution(
+        self: Arc<Self>,
+        todo_id: i64,
+        ctx: HookContext,
+    ) -> Result<(), String> {
+        let this = self.clone();
+
+        let todo = match this.ctx.db.get_todo(todo_id).await {
+            Ok(Some(t)) => t,
+            Ok(None) => {
+                warn!("pre-hook fire skipped: todo #{} not found", todo_id);
+                return Err(format!("todo #{} not found", todo_id));
+            }
+            Err(e) => {
+                warn!("pre-hook fire skipped: failed to load todo #{}: {}", todo_id, e);
+                return Err(format!("failed to load todo #{}: {}", todo_id, e));
+            }
+        };
+
+        let hooks: Vec<_> = matching_items(&todo, ctx.trigger);
+
+        // No pre-hooks registered — nothing to wait for.
+        if hooks.is_empty() {
+            return Ok(());
+        }
+
+        // Execute each pre-hook target sequentially, collecting errors.
+        // We don't use `futures::future::join_all` because we want the first
+        // failure to potentially short-circuit (though we continue all to
+        // give every hook a chance to run), and we want deterministic logging order.
+        let mut errors: Vec<String> = Vec::new();
+        for item in hooks {
+            let next_chain = append_to_chain(&ctx.chain, todo_id);
+            if next_chain.contains(&item.target_todo_id) {
+                warn!(
+                    "pre-hook #{} skipped: target todo #{} already in chain {:?}",
+                    item.id, item.target_todo_id, next_chain
+                );
+                continue;
+            }
+
+            // `execute_target_todo` spawns a helper thread and waits for the
+            // result via a oneshot channel — this blocks until the target
+            // execution finishes, which is exactly what we want for a
+            // synchronous pre-flight step.
+            match execute_target_todo(&this.ctx, &this, item, &todo, next_chain).await {
+                Ok(()) => {}
+                Err(msg) => {
+                    if !item.skip_if_missing {
+                        // Non-missing target that failed — log and record.
+                        warn!("pre-hook #{} failed: {}", item.id, msg);
+                        errors.push(msg);
+                    } else {
+                        warn!("pre-hook #{} skipped (skip_if_missing): {}", item.id, msg);
+                    }
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors.join("; "))
+        }
+    }
 }
 
 fn append_to_chain(chain: &[i64], source: i64) -> Vec<i64> {

--- a/backend/tests/hook_tests.rs
+++ b/backend/tests/hook_tests.rs
@@ -10,6 +10,7 @@ mod hook_trigger_tests {
 
     #[test]
     fn as_str_covers_all_variants() {
+        assert_eq!(HookTrigger::BeforeExecution.as_str(), "before_execution");
         assert_eq!(HookTrigger::StateChangedToPending.as_str(), "state_changed_to_pending");
         assert_eq!(HookTrigger::StateChangedToInProgress.as_str(), "state_changed_to_in_progress");
         assert_eq!(HookTrigger::StateChangedToCompleted.as_str(), "state_changed_to_completed");
@@ -19,6 +20,7 @@ mod hook_trigger_tests {
     #[test]
     fn from_str_round_trips_and_is_case_sensitive() {
         for t in [
+            HookTrigger::BeforeExecution,
             HookTrigger::StateChangedToPending,
             HookTrigger::StateChangedToInProgress,
             HookTrigger::StateChangedToCompleted,
@@ -29,6 +31,7 @@ mod hook_trigger_tests {
         assert_eq!(HookTrigger::from_str("invalid"), None);
         assert_eq!(HookTrigger::from_str(""), None);
         assert_eq!(HookTrigger::from_str("BEFORE_CREATE"), None);
+        assert_eq!(HookTrigger::from_str("before_execution"), Some(HookTrigger::BeforeExecution));
     }
 
     #[test]
@@ -53,11 +56,10 @@ mod hook_trigger_tests {
 
     #[test]
     fn is_sync_only_for_before_lifecycle() {
-        // Lifecycle gates were removed — all remaining triggers observe state
-        // changes asynchronously. This test is a placeholder reminding future
-        // maintainers that the sync/async distinction no longer applies to
-        // HookTrigger itself.
-        let _all: [HookTrigger; 4] = [
+        // All 5 hook trigger variants — including BeforeExecution (the only
+        // execution-phase trigger alongside the 4 state-change triggers).
+        let _all: [HookTrigger; 5] = [
+            HookTrigger::BeforeExecution,
             HookTrigger::StateChangedToPending,
             HookTrigger::StateChangedToInProgress,
             HookTrigger::StateChangedToCompleted,

--- a/frontend/src/utils/database/hooks.ts
+++ b/frontend/src/utils/database/hooks.ts
@@ -12,6 +12,7 @@
  *  `{{message}}` value automatically. */
 
 export type HookTrigger =
+  | 'before_execution'
   | 'state_changed_to_pending'
   | 'state_changed_to_in_progress'
   | 'state_changed_to_completed'
@@ -44,6 +45,7 @@ export interface TodoHookItem {
 }
 
 export const HOOK_TRIGGERS: ReadonlyArray<{ value: HookTrigger; label: string }> = [
+  { value: 'before_execution', label: '执行前' },
   { value: 'state_changed_to_pending', label: '状态变为待执行' },
   { value: 'state_changed_to_in_progress', label: '状态变为执行中' },
   { value: 'state_changed_to_completed', label: '状态变为已完成' },


### PR DESCRIPTION
## Motivation

Users want to run a "pre-flight" step before a todo executes — e.g. notifying a downstream system, running a prerequisite check, or pre-loading data. This requires a **synchronous blocking** hook that waits for the target to finish before the main execution proceeds.

## Changes

### Backend
- **HookTrigger::BeforeExecution**: new trigger variant, distinct from the 4 state-change triggers
- **HookContext::for_before_execution()**: new constructor building a pre-execution context
- **HookService::fire_before_execution()**: synchronous blocking dispatch — unlike state-change hooks which are fire-and-forget, this waits for all pre-hook targets to complete
- **run_todo_execution()**: call pre-hook after todo loads, before executor starts; abort main execution if any pre-hook fails with skip_if_missing=false

### Frontend
- Add `before_execution` to `HookTrigger` type and `HOOK_TRIGGERS` list (label: "执行前")

## Behavior

| | Post-hook (existing) | Pre-hook (new) |
|---|---|---|
| Fires | after todo completes | before todo starts |
| Dispatch | async, fire-and-forget | sync, blocks until done |
| Failure impact | none | aborts main execution |

## Tests
- All 567 lib tests pass
- All 26 hook_tests pass
- All 27 API integration tests pass