### PR TITLE
docs(readme): 删除「各执行器特点」章节 (issue #633)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,22 +169,6 @@ ntd 支持多种 AI CLI 工具，选择你已有的或最喜欢的即可：
 - **Worktree**：执行时自动创建 Git worktree，隔离分支操作，适合仓库内多任务并行
 - **后置 Todo 进度提取**：Hermes 特有功能，执行完成后从会话文件中提取内部 Todo 进度
 
-### 各执行器特点
-
-| 执行器 | 特点 | 安装方式 |
-|--------|------|----------|
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) | 官方 CLI，最完善的功能支持，NDJSON 流式输出 | `npm install -g @anthropic-ai/claude-code` |
-| [Codex](https://openai.com/codex) | OpenAI 代码助手，支持复杂推理 | 官方渠道 |
-| [CodeBuddy](https://codebuddy.com) | 与 Claude Code 协议兼容的工具调用展示 | 官方渠道 |
-| [Opencode](https://opencode.ai) | 开源代码助手，自定义事件流格式 | 官方渠道 |
-| [MobileCoder](https://github.com/nicheai/mobilecoder) | 移动端 AI 代码助手，支持事件流解析 | 官方渠道 |
-| [AtomCode](https://atomcode.dev) | 轻量级 AI 代码编辑器，stderr 解析 | 官方渠道 |
-| [Hermes](https://github.com/bhousai/hermes) | 支持 Todo 进度提取，适合任务分解场景 | 官方渠道 |
-| [Kimi](https://kimi.moonshot.cn) | 国产大模型 CLI，支持思考过程展示 | 官方渠道 |
-| [Pi](https://pi.ai) | 智能 AI 助手，支持 NDJSON 事件流，含思考过程展示 | 官方渠道 |
-| [CodeWhale](https://codewhale.cn) | AI 代码助手，适合中文场景 | 官方渠道 |
-| [MiMo](https://mimo.ai) | 多模态 AI 代码助手，支持思考过程与 Token 统计 | 官方渠道 |
-
 ---
 
 ## 功能概览


### PR DESCRIPTION
## 背景

Issue #633：readme.md 瘦身，删除「各执行器特点」章节。

## 变更

删除 README.md 中的「各执行器特点」小节（含 1 个二级小标题 + 1 个 11 行的执行器特点表），共 16 行。

## 删除理由

- 与正上方的「功能对比表」内容重复：两者都列举了 11 个执行器，且「特点」列描述的 NDJSON、事件流、Token 统计等信息已由「功能说明」段落覆盖。
- 安装方式信息已在「功能对比表」第 7 列与「安装」章节提供。

## 证据

### 1. Git diff

```diff
diff --git a/README.md b/README.md
index 90dfe11..e26a850 100644
--- a/README.md
+++ b/README.md
@@ -169,22 +169,6 @@ ntd 支持多种 AI CLI 工具，选择你已有的或最喜欢的即可：
 - **Worktree**：执行时自动创建 Git worktree，隔离分支操作，适合仓库内多任务并行
 - **后置 Todo 进度提取**：Hermes 特有功能，执行完成后从会话文件中提取内部 Todo 进度
 
-### 各执行器特点
-
-| 执行器 | 特点 | 安装方式 |
-|--------|------|----------|
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) | 官方 CLI，最完善的功能支持，NDJSON 流式输出 | `npm install -g @anthropic-ai/claude-code` |
-| [Codex](https://openai.com/codex) | OpenAI 代码助手，支持复杂推理 | 官方渠道 |
-| [CodeBuddy](https://codebuddy.com) | 与 Claude Code 协议兼容的工具调用展示 | 官方渠道 |
-| [Opencode](https://opencode.ai) | 开源代码助手，自定义事件流格式 | 官方渠道 |
-| [MobileCoder](https://github.com/nicheai/mobilecoder) | 移动端 AI 代码助手，支持事件流解析 | 官方渠道 |
-| [AtomCode](https://atomcode.dev) | 轻量级 AI 代码编辑器，stderr 解析 | 官方渠道 |
-| [Hermes](https://github.com/bhousai/hermes) | 支持 Todo 进度提取，适合任务分解场景 | 官方渠道 |
-| [Kimi](https://kimi.moonshot.cn) | 国产大模型 CLI，支持思考过程展示 | 官方渠道 |
-| [Pi](https://pi.ai) | 智能 AI 助手，支持 NDJSON 事件流，含思考过程展示 | 官方渠道 |
-| [CodeWhale](https://codewhale.cn) | AI 代码助手，适合中文场景 | 官方渠道 |
-| [MiMo](https://mimo.ai) | 多模态 AI 代码助手，支持思考过程与 Token 统计 | 官方渠道 |
-
 ---
 
 ## 功能概览
```

### 2. 验证

- 删除行数：16
- README 总行数：235 → 219
- `grep -rn "各执行器特点" --include="*.md"`：无任何匹配，确认全仓库无残留引用

### 3. 文档结构（删除后）

```
## 支持的 AI 执行器
  ### 功能对比表
  ### 功能说明
## 功能概览
  ### 智能任务管理
  ...
```

「功能对比表」+「功能说明」共同覆盖了原「各执行器特点」表格所承载的信息，未造成信息丢失。

Closes #633