### PR TITLE
feat(issue-652): 执行历史「结论」区支持折叠/展开

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -718,6 +718,26 @@ body {
   color: var(--color-error);
 }
 
+/* issue #652: 折叠态下压缩到只剩一行头部，展开态保留正常内边距与过渡 */
+.history-result-collapsed {
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.history-result-expanded {
+  transition: padding 0.15s ease;
+}
+
+/* Markdown 内容区域加一个轻量的出现动画，避免切换时生硬 */
+.conclusion-content {
+  animation: conclusion-fade-in 0.15s ease;
+}
+
+@keyframes conclusion-fade-in {
+  from { opacity: 0; transform: translateY(-2px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 /* ---------- Chat View ---------- */
 .chat-container {
   flex: 1;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -706,6 +706,9 @@ body {
   border-radius: var(--radius-sm);
   font-size: 13px;
   word-break: break-all;
+  /* padding 过渡提到基础类上，折叠/展开两个方向都能平滑切换；
+     之前 transition 只挂在 .history-result-expanded 上，折叠方向会"啪"一下跳变。 */
+  transition: padding 0.15s ease;
 }
 
 .history-result-success {
@@ -718,14 +721,11 @@ body {
   color: var(--color-error);
 }
 
-/* issue #652: 折叠态下压缩到只剩一行头部，展开态保留正常内边距与过渡 */
+/* issue #652: 折叠态下压缩到只剩一行头部，展开态保留正常内边距。
+   transition 已上移至 .history-result 基础类，折叠/展开两个方向都能平滑切换。 */
 .history-result-collapsed {
   padding-top: 6px;
   padding-bottom: 6px;
-}
-
-.history-result-expanded {
-  transition: padding 0.15s ease;
 }
 
 /* Markdown 内容区域加一个轻量的出现动画，避免切换时生硬 */

--- a/frontend/src/components/todo-detail/ChainGroupCard.tsx
+++ b/frontend/src/components/todo-detail/ChainGroupCard.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
 import { Button, Popconfirm, Tag, Tooltip } from 'antd';
-import { MessageOutlined, FileTextOutlined, StopOutlined, CopyOutlined, LinkOutlined, UpOutlined, DownOutlined } from '@ant-design/icons';
-import { XMarkdown } from '@ant-design/x-markdown';
+import { MessageOutlined, FileTextOutlined, StopOutlined, LinkOutlined, UpOutlined, DownOutlined } from '@ant-design/icons';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
+import { CollapsibleConclusion } from './CollapsibleConclusion';
 import { supportsResume } from '@/types';
 import { formatLocalDateTime, formatDurationSec } from '@/utils/datetime';
 import * as db from '@/utils/database';
@@ -123,26 +123,14 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
           </Tooltip>
         )}
         {mainRecord.result && (
-          <div className={`history-result ${mainRecord.status === 'success' ? 'history-result-success' : 'history-result-failed'}`}>
-            <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
-              {/* 复制结论文本：使用 copyToClipboard 统一处理，兼容 HTTP 环境 */}
-              <Button type="text" size="small" icon={<CopyOutlined />} onClick={async () => {
-                try {
-                  // 调用统一的复制工具（内置 fallback，兼容 HTTP 环境）
-                  const ok = await copyToClipboard(mainRecord.result || '');
-                  // 根据返回结果提示用户
-                  if (ok) {
-                    messageApi.success('已复制到剪贴板');
-                  } else {
-                    messageApi.error('复制失败');
-                  }
-                } catch {
-                  messageApi.error('复制失败');
-                }
-              }} />
-            </div>
-            <XMarkdown content={mainRecord.result} />
-          </div>
+          // 折叠/展开控制由 CollapsibleConclusion 内部状态管理；
+          // 传 recordId 让折叠状态按记录持久化。
+          <CollapsibleConclusion
+            result={mainRecord.result}
+            status={mainRecord.status}
+            messageApi={messageApi}
+            recordId={mainRecord.id}
+          />
         )}
         {(() => {
           const stats = resolveStats(mainRecord, mainRecord.status === 'running');
@@ -234,26 +222,14 @@ function ChainGroupCard({ group, onOpenResume, onExport, onStop, messageApi, vie
                 border: '1px solid var(--color-border-light)',
               }}>
                 {record.result && (
-                  <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`} style={{ marginBottom: 6 }}>
-                    <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
-                      {/* 复制续轮结论文本：使用 copyToClipboard 统一处理，兼容 HTTP 环境 */}
-                      <Button type="text" size="small" icon={<CopyOutlined />} onClick={async () => {
-                        try {
-                          // 调用统一的复制工具（内置 fallback，兼容 HTTP 环境）
-                          const ok = await copyToClipboard(record.result || '');
-                          // 根据返回结果提示用户
-                          if (ok) {
-                            messageApi.success('已复制');
-                          } else {
-                            messageApi.error('复制失败');
-                          }
-                        } catch {
-                          messageApi.error('复制失败');
-                        }
-                      }} />
-                    </div>
-                    <XMarkdown content={record.result} />
-                  </div>
+                  // 续轮结论同样接入 CollapsibleConclusion；
+                  // 不带 showTitle，因为 ChainGroupCard 在头部已有标识。
+                  <CollapsibleConclusion
+                    result={record.result}
+                    status={record.status}
+                    messageApi={messageApi}
+                    recordId={record.id}
+                  />
                 )}
                 {record.usage && (
                   <div style={{ fontSize: 10, color: 'var(--color-text-tertiary)', marginBottom: 4, display: 'flex', gap: 8 }}>

--- a/frontend/src/components/todo-detail/CollapsibleConclusion.tsx
+++ b/frontend/src/components/todo-detail/CollapsibleConclusion.tsx
@@ -32,6 +32,9 @@ const HEADER_GAP = 8;
 // 折叠态下，整块被压缩到只剩一行头部；展开态保留 marginBottom 与内层 Markdown 容器
 const CONTAINER_MARGIN_BOTTOM = 12;
 
+// toggle 按钮与正文内容区的 id 关联前缀；拼上 recordId 防止同一页多条记录冲突
+const CONTENT_ID_PREFIX = 'conclusion-content-';
+
 export interface CollapsibleConclusionProps {
   /** Markdown 文本，来自 ExecutionRecord.result */
   result: string;
@@ -105,13 +108,13 @@ export function CollapsibleConclusion({
     setCollapsed(stored ?? false);
   }, [storageKey]);
 
-  // 切换折叠态：写本地状态 + 持久化到 localStorage
+  // 切换折叠态：写本地状态 + 持久化到 localStorage。
+  // 不把副作用塞进 setState updater：React 18 StrictMode / 并发模式下
+  // updater 会被多次调用，副作用写在 updater 内会重复写 localStorage。
   const toggle = () => {
-    setCollapsed(prev => {
-      const next = !prev;
-      writeCollapsedState(storageKey, next);
-      return next;
-    });
+    const next = !collapsed;
+    setCollapsed(next);
+    writeCollapsedState(storageKey, next);
   };
 
   // 复制 Markdown 源文到剪贴板；统一走 copyToClipboard，兼容 HTTP 环境
@@ -131,6 +134,10 @@ export function CollapsibleConclusion({
   const statusClass = status === 'success'
     ? 'history-result-success'
     : 'history-result-failed';
+
+  // 内容区域 id，供 toggle 按钮 aria-controls 关联（WAI-ARIA disclosure pattern）。
+  // 未提供 recordId 时用 'default'，避免出现在多记录场景下 id 冲突。
+  const contentId = `${CONTENT_ID_PREFIX}${recordId ?? 'default'}`;
 
   return (
     <div
@@ -154,6 +161,7 @@ export function CollapsibleConclusion({
           onClick={toggle}
           icon={collapsed ? <CaretDownOutlined /> : <CaretUpOutlined />}
           aria-expanded={!collapsed}
+          aria-controls={contentId}
           aria-label={collapsed ? '展开结论' : '折叠结论'}
           data-testid="conclusion-toggle"
           style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '0 8px' }}
@@ -192,7 +200,11 @@ export function CollapsibleConclusion({
         />
       </div>
       {!collapsed && (
-        <div className="conclusion-content" data-testid="conclusion-content">
+        <div
+          id={contentId}
+          className="conclusion-content"
+          data-testid="conclusion-content"
+        >
           <XMarkdown content={result} />
         </div>
       )}

--- a/frontend/src/components/todo-detail/CollapsibleConclusion.tsx
+++ b/frontend/src/components/todo-detail/CollapsibleConclusion.tsx
@@ -1,0 +1,190 @@
+/**
+ * 共享的「可折叠结论」组件
+ *
+ * 取代 RecordDetailView / ChainGroupCard / NarrowHistoryCard 中重复出现的
+ * 结论展示区（带 XMarkdown 渲染 + 复制按钮）。
+ *
+ * 设计要点：
+ * 1. 默认展开 — 保持与历史行为一致；用户折叠后用 localStorage 记住偏好。
+ * 2. 折叠态只保留头部（标题 / 字数 / 复制 / 切换按钮），Markdown 内容
+ *    整体不渲染，避免大段内容占据屏幕，符合 issue #652 的诉求。
+ * 3. 切换按钮带 ARIA 属性，便于无障碍与 Playwright 选择器定位。
+ * 4. messageApi 是可选的：调用方（如 RecordDetailView）若想用动态 message
+ *    实例，传入即可；否则回落到 antd 的静态 message。
+ *
+ * 对应 issue：#652 「todo执行历史页面 结论 显示区做成可折叠的效果」
+ */
+
+import { useEffect, useState } from 'react';
+import { Button, message as antdMessage } from 'antd';
+import { CaretDownOutlined, CaretUpOutlined, CopyOutlined } from '@ant-design/icons';
+import XMarkdown from '@ant-design/x-markdown';
+import { copyToClipboard } from '@/utils/clipboard';
+
+// 折叠状态在 localStorage 中的 key 前缀；按 recordId 区分避免互相串扰
+const STORAGE_KEY_PREFIX = 'ntd:conclusion-collapsed:';
+
+// 切换按钮与正文之间的间距，避免切换后边框贴在一起
+const HEADER_MARGIN = 4;
+const HEADER_GAP = 8;
+
+// 折叠态下，整块被压缩到只剩一行头部；展开态保留 marginBottom 与内层 Markdown 容器
+const CONTAINER_MARGIN_BOTTOM = 12;
+
+export interface CollapsibleConclusionProps {
+  /** Markdown 文本，来自 ExecutionRecord.result */
+  result: string;
+  /** 执行状态，仅用于切换 success / failed 背景色 */
+  status: string;
+  /** 动态 message 实例；不传则使用 antd 静态 message */
+  messageApi?: { success: (msg: string) => void; error: (msg: string) => void };
+  /** 是否在头部显示「结论」二字标题；目前仅 RecordDetailView 启用 */
+  showTitle?: boolean;
+  /** 记录 ID；提供时折叠状态会按 ID 持久化到 localStorage */
+  recordId?: number | string;
+}
+
+/**
+ * 从 localStorage 读取折叠状态；无值时返回 undefined，由调用方决定默认值。
+ * 把读取单独抽出来以便在 effect 中复用。
+ */
+function readCollapsedState(key: string | null): boolean | undefined {
+  if (!key) return undefined;
+  try {
+    const stored = window.localStorage.getItem(key);
+    if (stored === null) return undefined;
+    return stored === 'true';
+  } catch {
+    // 隐私模式或 storage 配额耗尽时 read 可能抛错，按"未持久化"处理
+    return undefined;
+  }
+}
+
+/**
+ * 写入折叠状态；同样吞掉异常，避免破坏 UI 交互。
+ */
+function writeCollapsedState(key: string | null, collapsed: boolean): void {
+  if (!key) return;
+  try {
+    window.localStorage.setItem(key, String(collapsed));
+  } catch {
+    // 写入失败（隐私模式 / 配额）静默吞掉；下次刷新会回到默认展开
+  }
+}
+
+export function CollapsibleConclusion({
+  result,
+  status,
+  messageApi,
+  showTitle = false,
+  recordId,
+}: CollapsibleConclusionProps) {
+  // 按 recordId 派生 storage key；recordId 缺失则不持久化
+  const storageKey = recordId !== undefined && recordId !== null
+    ? `${STORAGE_KEY_PREFIX}${recordId}`
+    : null;
+
+  // 初始状态：未持久化时默认展开（向后兼容）；有持久化值时尊重用户选择
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    const stored = readCollapsedState(storageKey);
+    return stored ?? false;
+  });
+
+  // recordId 变化时（如切换到另一条执行记录）重新读取持久化值，
+  // 让每条记录各自的折叠状态独立保持。
+  useEffect(() => {
+    const stored = readCollapsedState(storageKey);
+    // 显式区分 "未持久化" 与 "持久化为 false"：前者用默认 false，后者用持久化值
+    setCollapsed(stored ?? false);
+  }, [storageKey]);
+
+  // 切换折叠态：写本地状态 + 持久化到 localStorage
+  const toggle = () => {
+    setCollapsed(prev => {
+      const next = !prev;
+      writeCollapsedState(storageKey, next);
+      return next;
+    });
+  };
+
+  // 复制 Markdown 源文到剪贴板；统一走 copyToClipboard，兼容 HTTP 环境
+  const handleCopy = async () => {
+    const api = messageApi ?? antdMessage;
+    try {
+      const ok = await copyToClipboard(result || '');
+      api[ok ? 'success' : 'error'](ok ? '已复制到剪贴板' : '复制失败');
+    } catch {
+      api.error('复制失败');
+    }
+  };
+
+  // 与原实现保持一致：成功用绿底，失败用红底，其他状态（如 running）暂走 failed 视觉
+  const statusClass = status === 'success'
+    ? 'history-result-success'
+    : 'history-result-failed';
+
+  return (
+    <div
+      className={`history-result ${statusClass} ${collapsed ? 'history-result-collapsed' : 'history-result-expanded'}`}
+      style={{ marginBottom: CONTAINER_MARGIN_BOTTOM }}
+      data-testid="collapsible-conclusion"
+      data-collapsed={collapsed ? 'true' : 'false'}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: collapsed ? 0 : HEADER_MARGIN,
+          gap: HEADER_GAP,
+        }}
+      >
+        <Button
+          type="text"
+          size="small"
+          onClick={toggle}
+          icon={collapsed ? <CaretDownOutlined /> : <CaretUpOutlined />}
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? '展开结论' : '折叠结论'}
+          data-testid="conclusion-toggle"
+          style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '0 8px' }}
+        >
+          {showTitle && (
+            <span
+              style={{
+                fontSize: 13,
+                fontWeight: 600,
+                color: 'var(--color-text)',
+                marginRight: 4,
+              }}
+            >
+              结论
+            </span>
+          )}
+          <span
+            style={{
+              fontSize: 11,
+              color: 'var(--color-text-tertiary)',
+              fontWeight: 500,
+            }}
+          >
+            {result.length} 字
+          </span>
+        </Button>
+        <Button
+          type="text"
+          size="small"
+          icon={<CopyOutlined />}
+          onClick={handleCopy}
+          aria-label="复制结论"
+          data-testid="conclusion-copy"
+        />
+      </div>
+      {!collapsed && (
+        <div className="conclusion-content" data-testid="conclusion-content">
+          <XMarkdown content={result} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/todo-detail/CollapsibleConclusion.tsx
+++ b/frontend/src/components/todo-detail/CollapsibleConclusion.tsx
@@ -15,8 +15,9 @@
  * 对应 issue：#652 「todo执行历史页面 结论 显示区做成可折叠的效果」
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button, message as antdMessage } from 'antd';
+import type { MessageInstance } from 'antd/es/message/interface';
 import { CaretDownOutlined, CaretUpOutlined, CopyOutlined } from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
 import { copyToClipboard } from '@/utils/clipboard';
@@ -37,7 +38,7 @@ export interface CollapsibleConclusionProps {
   /** 执行状态，仅用于切换 success / failed 背景色 */
   status: string;
   /** 动态 message 实例；不传则使用 antd 静态 message */
-  messageApi?: { success: (msg: string) => void; error: (msg: string) => void };
+  messageApi?: MessageInstance;
   /** 是否在头部显示「结论」二字标题；目前仅 RecordDetailView 启用 */
   showTitle?: boolean;
   /** 记录 ID；提供时折叠状态会按 ID 持久化到 localStorage */
@@ -91,8 +92,14 @@ export function CollapsibleConclusion({
   });
 
   // recordId 变化时（如切换到另一条执行记录）重新读取持久化值，
-  // 让每条记录各自的折叠状态独立保持。
+  // 让每条记录各自的折叠状态独立保持。首次挂载由 useState lazy init 处理，
+  // 用 isFirst 跳过首次 effect 调用避免一次多余的 no-op 重渲染。
+  const isFirstMountRef = useRef(true);
   useEffect(() => {
+    if (isFirstMountRef.current) {
+      isFirstMountRef.current = false;
+      return;
+    }
     const stored = readCollapsedState(storageKey);
     // 显式区分 "未持久化" 与 "持久化为 false"：前者用默认 false，后者用持久化值
     setCollapsed(stored ?? false);
@@ -118,7 +125,9 @@ export function CollapsibleConclusion({
     }
   };
 
-  // 与原实现保持一致：成功用绿底，失败用红底，其他状态（如 running）暂走 failed 视觉
+  // 与原实现保持一致：成功用绿底，失败用红底。
+  // 保留旧行为：running / pending / cancelled 等非 success 状态
+  // 暂走 failed 视觉（历史包袱，未在本次 PR 中调整）。
   const statusClass = status === 'success'
     ? 'history-result-success'
     : 'history-result-failed';
@@ -168,7 +177,9 @@ export function CollapsibleConclusion({
               fontWeight: 500,
             }}
           >
-            {result.length} 字
+            {/* 用 spread 数 code points 而非 UTF-16 code units，
+                避免一个 emoji 被算成 2 字让字数虚高。 */}
+            {[...result].length} 字
           </span>
         </Button>
         <Button

--- a/frontend/src/components/todo-detail/NarrowHistoryCard.tsx
+++ b/frontend/src/components/todo-detail/NarrowHistoryCard.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Button, Popconfirm, Tag, Tooltip, Popover, InputNumber, Space } from 'antd';
-import { MessageOutlined, FileTextOutlined, StopOutlined, CopyOutlined, LinkOutlined, StarOutlined, StarFilled } from '@ant-design/icons';
+import { MessageOutlined, FileTextOutlined, StopOutlined, LinkOutlined, StarOutlined, StarFilled } from '@ant-design/icons';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
-import { XMarkdown } from '@ant-design/x-markdown';
 import { supportsResume } from '@/types';
 import { formatLocalDateTime, formatDurationSec } from '@/utils/datetime';
 import * as db from '@/utils/database';
@@ -10,6 +9,7 @@ import { getElapsedSeconds, hasLogsStatic } from './helpers';
 import { NarrowLogView } from './NarrowLogView';
 import { getHookTriggerLabel } from '@/utils/database/hooks';
 import { ReviewStatusBadge } from './RecordDetailView';
+import { CollapsibleConclusion } from './CollapsibleConclusion';
 import type { ExecutionRecord, ExecutionStats, LogEntry } from '@/types';
 import { copyToClipboard } from '@/utils/clipboard';
 
@@ -128,26 +128,14 @@ export function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, on
         </Tooltip>
       )}
       {record.result !== null && record.result !== '' && (
-        <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`}>
-          <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 4 }}>
-            {/* 复制结论文本：使用 copyToClipboard 统一处理，兼容 HTTP 环境 */}
-            <Button type="text" size="small" icon={<CopyOutlined />} onClick={async () => {
-              try {
-                // 调用统一的复制工具（内置 fallback，兼容 HTTP 环境）
-                const ok = await copyToClipboard(record.result || '');
-                // 根据返回结果提示用户
-                if (ok) {
-                  messageApi.success('已复制到剪贴板');
-                } else {
-                  messageApi.error('复制失败');
-                }
-              } catch {
-                messageApi.error('复制失败');
-              }
-            }} />
-          </div>
-          <XMarkdown content={record.result} />
-        </div>
+        // 窄屏/手机版的结论区与桌面端共用同一 CollapsibleConclusion，
+        // 折叠状态按 recordId 持久化，长结论在窄屏下尤其友好。
+        <CollapsibleConclusion
+          result={record.result}
+          status={record.status}
+          messageApi={messageApi}
+          recordId={record.id}
+        />
       )}
       {record.usage && (
         <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 8, display: 'flex', gap: 12, flexWrap: 'wrap' }}>

--- a/frontend/src/components/todo-detail/RecordDetailView.tsx
+++ b/frontend/src/components/todo-detail/RecordDetailView.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, type ReactNode } from 'react';
 import { Button, Tag, Empty, Segmented, Popconfirm, Tooltip, Pagination, message, Popover, InputNumber, Space } from 'antd';
 import { StarOutlined, StarFilled, SyncOutlined, CheckCircleOutlined, CloseCircleOutlined, PauseCircleOutlined } from '@ant-design/icons';
-import { MessageOutlined, FileTextOutlined, StopOutlined, CopyOutlined, UnorderedListOutlined, LinkOutlined, LoadingOutlined, BranchesOutlined, CodeOutlined } from '@ant-design/icons';
-import XMarkdown from '@ant-design/x-markdown';
+import { MessageOutlined, FileTextOutlined, StopOutlined, UnorderedListOutlined, LinkOutlined, LoadingOutlined, BranchesOutlined, CodeOutlined } from '@ant-design/icons';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { ChatView } from '@/components/ChatView';
 import { RefreshBtn } from './LogViewHeader';
@@ -15,6 +14,7 @@ import type { ExecutionRecord, LogEntry } from '@/types';
 import { getHookTriggerLabel } from '@/utils/database/hooks';
 import { copyToClipboard } from '@/utils/clipboard';
 import { CommandPanel } from '@/components/CommandPanel';
+import { CollapsibleConclusion } from './CollapsibleConclusion';
 
 export function RecordDetailView({
   isLoadingDetail, record, sessionGroups,
@@ -195,32 +195,15 @@ export function RecordDetailView({
       {/* issue #645: 展示本次执行使用的 git worktree 目录路径；目录可能已被清理，但仍保留在记录里便于排查 */}
       <WorktreePathDisplay worktreePath={record.worktree_path ?? null} />
       {record.result !== null && record.result !== '' && (
-        <div className={`history-result ${record.status === 'success' ? 'history-result-success' : 'history-result-failed'}`} style={{ marginBottom: 12 }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
-            <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-text)' }}>结论</span>
-            {/* 复制结论文本：使用 copyToClipboard 统一处理，兼容 HTTP 环境 */}
-            <Button
-              type="text"
-              size="small"
-              icon={<CopyOutlined />}
-              onClick={async () => {
-                try {
-                  // 调用统一的复制工具（内置 fallback，兼容 HTTP 环境）
-                  const ok = await copyToClipboard(record.result || '');
-                  // 根据返回结果提示用户
-                  if (ok) {
-                    message.success('已复制到剪贴板');
-                  } else {
-                    message.error('复制失败');
-                  }
-                } catch {
-                  message.error('复制失败');
-                }
-              }}
-            />
-          </div>
-          <XMarkdown content={record.result} />
-        </div>
+        // 折叠/展开控制由 CollapsibleConclusion 内部状态管理；
+        // 传 recordId 让折叠状态按记录持久化，避免每次重渲染都重新展开长结论。
+        <CollapsibleConclusion
+          result={record.result}
+          status={record.status}
+          messageApi={message}
+          showTitle
+          recordId={record.id}
+        />
       )}
       {record.usage && (
         <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginBottom: 12, display: 'flex', gap: 12, flexWrap: 'wrap' }}>

--- a/frontend/tests/issue-652-collapsible-conclusion.spec.ts
+++ b/frontend/tests/issue-652-collapsible-conclusion.spec.ts
@@ -87,6 +87,8 @@ test.describe('可折叠结论 — Issue #652', () => {
     const toggle = page.locator('[data-testid="conclusion-toggle"]');
     await expect(toggle).toContainText('字');
     await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    // aria-controls 指向内容区域 id（WAI-ARIA disclosure pattern）
+    await expect(toggle).toHaveAttribute('aria-controls', 'conclusion-content-default');
 
     // 截图：默认展开
     await container.screenshot({
@@ -200,10 +202,9 @@ test.describe('可折叠结论 — Issue #652', () => {
     // 拦截 clipboard 写入（在浏览器里通过 permissions 提前允许）
     await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
     await page.locator('[data-testid="conclusion-copy"]').click();
-    // 不验证 messageApi 的具体内容（mock 化），只确保点击不报错
-    const errors: string[] = [];
-    page.on('pageerror', e => errors.push(e.message));
-    await page.waitForTimeout(200);
-    expect(errors).toEqual([]);
+    // 真正读剪贴板断言内容一致，比单纯"无报错"更严格。
+    // 防止 copyToClipboard 静默吞错时用例仍能通过（PR #475 的同类教训）。
+    const copied = await page.evaluate(() => navigator.clipboard.readText());
+    expect(copied).toBe('需要复制的结论内容');
   });
 });

--- a/frontend/tests/issue-652-collapsible-conclusion.spec.ts
+++ b/frontend/tests/issue-652-collapsible-conclusion.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * issue #652 — 「可折叠结论」组件 UI 集成测试
+ *
+ * 启动 Vite dev server，把 CollapsibleConclusion 在浏览器里跑起来，
+ * 验证：
+ *   1. 默认展开：能看到 Markdown 内容、字数统计
+ *   2. 点击 toggle 后折叠：内容消失、aria-expanded=false、容器高度变小
+ *   3. 再次点击 toggle 后恢复展开：内容出现
+ *   4. localStorage 持久化：刷新后保持折叠/展开态
+ *   5. showTitle=true 时显示「结论」标题
+ *   6. 失败状态时容器 class 含 history-result-failed
+ *
+ * 截图：保留给 PR 评论作为视觉证据。
+ */
+
+import { test, expect } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEV_URL = process.env.E2E_BASE_URL || 'http://127.0.0.1:18089';
+const HARNESS_URL = `${DEV_URL}/tests/issue-652-mount.html`;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SCREENSHOT_DIR = resolve(__dirname, '__screenshots__');
+mkdirSync(SCREENSHOT_DIR, { recursive: true });
+
+// 长结论样本：包含代码块、列表、段落，模拟真实执行结果
+const LONG_RESULT = `# 完成情况
+
+1. 实现 CollapsibleConclusion 组件
+2. 替换 3 个文件中的内联结论区
+3. 添加折叠态 CSS
+
+\`\`\`ts
+const ok = await copyToClipboard(result);
+\`\`\`
+
+- [x] 默认展开
+- [x] 折叠/展开切换
+- [x] localStorage 持久化
+`;
+
+/** 把数据塞到 URL hash 里，harness 端会读出来 */
+async function mount(
+  page: any,
+  data: { result: string; status?: string; recordId?: number | string | null; showTitle?: boolean },
+) {
+  await page.goto('about:blank');
+  const hash = encodeURIComponent(JSON.stringify({
+    result: data.result,
+    status: data.status ?? 'success',
+    recordId: data.recordId ?? null,
+    showTitle: data.showTitle ?? false,
+  }));
+  await page.goto(`${HARNESS_URL}#${hash}`);
+  await page.waitForFunction(() => (window as any).__renderDone === true, { timeout: 10000 });
+  const err = await page.evaluate(() => (window as any).__renderError);
+  if (err) throw new Error(`Mount 失败: ${err}`);
+}
+
+test.describe('可折叠结论 — Issue #652', () => {
+  test('默认展开：应显示 Markdown 内容与字数统计', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', e => errors.push(e.message));
+    page.on('console', m => {
+      if (m.type() === 'error') errors.push(`console.error: ${m.text()}`);
+    });
+
+    await page.goto(DEV_URL);
+    await page.waitForSelector('#root', { state: 'attached' });
+    await page.waitForTimeout(1500);
+
+    await mount(page, { result: LONG_RESULT, recordId: null });
+
+    const container = page.locator('[data-testid="collapsible-conclusion"]');
+    await expect(container).toBeVisible();
+    await expect(container).toHaveAttribute('data-collapsed', 'false');
+
+    // 内容区域可见
+    const content = page.locator('[data-testid="conclusion-content"]');
+    await expect(content).toBeVisible();
+    await expect(content).toContainText('完成情况');
+
+    // 字数统计（字符数会包含 markdown 符号，按大致范围断言）
+    const toggle = page.locator('[data-testid="conclusion-toggle"]');
+    await expect(toggle).toContainText('字');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    // 截图：默认展开
+    await container.screenshot({
+      path: resolve(SCREENSHOT_DIR, 'issue-652-expanded.png'),
+      fullPage: true,
+    });
+
+    // 无 console error（antd deprecation 与 403 /api/* 是已有噪音，跳过）
+    const realErrors = errors.filter(e =>
+      !e.includes('[antd:') && !e.includes('Failed to load resource'),
+    );
+    expect(realErrors).toEqual([]);
+  });
+
+  test('点击 toggle 后折叠：内容消失、aria-expanded=false', async ({ page }) => {
+    await page.goto(DEV_URL);
+    await page.waitForSelector('#root', { state: 'attached' });
+    await page.waitForTimeout(1500);
+
+    await mount(page, { result: LONG_RESULT, recordId: 1001 });
+
+    const container = page.locator('[data-testid="collapsible-conclusion"]');
+    await expect(container).toHaveAttribute('data-collapsed', 'false');
+
+    // 点击 toggle 折叠
+    await page.locator('[data-testid="conclusion-toggle"]').click();
+    await expect(container).toHaveAttribute('data-collapsed', 'true');
+    await expect(page.locator('[data-testid="conclusion-toggle"]')).toHaveAttribute('aria-expanded', 'false');
+
+    // 内容区域消失
+    await expect(page.locator('[data-testid="conclusion-content"]')).toHaveCount(0);
+
+    // 截图：折叠态
+    await container.screenshot({
+      path: resolve(SCREENSHOT_DIR, 'issue-652-collapsed.png'),
+      fullPage: true,
+    });
+
+    // 折叠态下容器高度应明显小于展开态
+    const collapsedBox = await container.boundingBox();
+    expect(collapsedBox?.height ?? 0).toBeLessThan(80);
+  });
+
+  test('再次点击 toggle：恢复展开', async ({ page }) => {
+    await page.goto(DEV_URL);
+    await page.waitForSelector('#root', { state: 'attached' });
+    await page.waitForTimeout(1500);
+
+    await mount(page, { result: LONG_RESULT, recordId: 1002 });
+
+    const container = page.locator('[data-testid="collapsible-conclusion"]');
+    const toggle = page.locator('[data-testid="conclusion-toggle"]');
+
+    await toggle.click();
+    await expect(container).toHaveAttribute('data-collapsed', 'true');
+
+    await toggle.click();
+    await expect(container).toHaveAttribute('data-collapsed', 'false');
+    await expect(page.locator('[data-testid="conclusion-content"]')).toBeVisible();
+  });
+
+  test('localStorage 持久化：刷新后保持折叠态', async ({ page }) => {
+    await page.goto(DEV_URL);
+    await page.waitForSelector('#root', { state: 'attached' });
+    await page.waitForTimeout(1500);
+
+    // 用固定 recordId 让 localStorage 生效
+    await mount(page, { result: LONG_RESULT, recordId: 9999 });
+
+    // 折叠一次
+    await page.locator('[data-testid="conclusion-toggle"]').click();
+    await expect(page.locator('[data-testid="collapsible-conclusion"]')).toHaveAttribute('data-collapsed', 'true');
+
+    // 重新挂载同一 recordId，模拟刷新
+    await mount(page, { result: LONG_RESULT, recordId: 9999 });
+
+    // 应该是折叠的（持久化生效）
+    await expect(page.locator('[data-testid="collapsible-conclusion"]')).toHaveAttribute('data-collapsed', 'true');
+    await expect(page.locator('[data-testid="conclusion-content"]')).toHaveCount(0);
+  });
+
+  test('showTitle=true：显示「结论」标题', async ({ page }) => {
+    await page.goto(DEV_URL);
+    await page.waitForSelector('#root', { state: 'attached' });
+    await page.waitForTimeout(1500);
+
+    await mount(page, { result: LONG_RESULT, recordId: 2001, showTitle: true });
+
+    const toggle = page.locator('[data-testid="conclusion-toggle"]');
+    await expect(toggle).toContainText('结论');
+  });
+
+  test('失败状态：容器带 history-result-failed 类', async ({ page }) => {
+    await page.goto(DEV_URL);
+    await page.waitForSelector('#root', { state: 'attached' });
+    await page.waitForTimeout(1500);
+
+    await mount(page, { result: '执行失败原因...', status: 'failed', recordId: 3001 });
+
+    const container = page.locator('[data-testid="collapsible-conclusion"]');
+    await expect(container).toHaveClass(/history-result-failed/);
+  });
+
+  test('复制按钮：点击后调用 copyToClipboard', async ({ page }) => {
+    await page.goto(DEV_URL);
+    await page.waitForSelector('#root', { state: 'attached' });
+    await page.waitForTimeout(1500);
+
+    await mount(page, { result: '需要复制的结论内容', recordId: 4001 });
+
+    // 拦截 clipboard 写入（在浏览器里通过 permissions 提前允许）
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+    await page.locator('[data-testid="conclusion-copy"]').click();
+    // 不验证 messageApi 的具体内容（mock 化），只确保点击不报错
+    const errors: string[] = [];
+    page.on('pageerror', e => errors.push(e.message));
+    await page.waitForTimeout(200);
+    expect(errors).toEqual([]);
+  });
+});

--- a/frontend/tests/issue-652-mount.html
+++ b/frontend/tests/issue-652-mount.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <title>issue #652 mount harness</title>
+</head>
+<body>
+  <div id="harness-root"></div>
+  <script type="module" src="/tests/issue-652-mount.ts"></script>
+</body>
+</html>

--- a/frontend/tests/issue-652-mount.ts
+++ b/frontend/tests/issue-652-mount.ts
@@ -1,0 +1,70 @@
+/**
+ * issue #652 — 浏览器侧 mount 脚本
+ *
+ * Playwright 加载 issue-652-mount.html，Vite dev server 把这个 .ts 文件
+ * 当成 module 解析，import map / bare specifier 自动注入。
+ *
+ * 流程：
+ * 1) 从 URL hash 读 result / status / recordId / showTitle（测试代码通过 hash 注入）
+ * 2) createRoot 挂 CollapsibleConclusion 到 #test-collapsible-conclusion
+ * 3) 写 window.__renderDone = true，让 Playwright 收尾
+ */
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { CollapsibleConclusion } from '../src/components/todo-detail/CollapsibleConclusion.tsx';
+
+interface MountData {
+  result: string;
+  status: string;
+  recordId: number | string | null;
+  showTitle: boolean;
+}
+
+interface MountWindow extends Window {
+  __renderDone?: boolean;
+  __renderError?: string;
+}
+
+const w = window as MountWindow;
+
+function readDataFromHash(): MountData {
+  const h = window.location.hash.replace(/^#/, '');
+  if (!h) {
+    return { result: '默认结果文本', status: 'success', recordId: null, showTitle: false };
+  }
+  try {
+    return JSON.parse(decodeURIComponent(h)) as MountData;
+  } catch {
+    return { result: '默认结果文本', status: 'success', recordId: null, showTitle: false };
+  }
+}
+
+const data = readDataFromHash();
+
+try {
+  const container = document.createElement('div');
+  container.id = 'test-collapsible-conclusion';
+  container.style.padding = '20px';
+  container.style.background = '#f5f5f5';
+  container.style.maxWidth = '900px';
+  container.style.margin = '0 auto';
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+  // 构造一个空的 messageApi，避免在 Playwright headless 环境下 antd 静态 message 实例冲突
+  const messageApi = {
+    success: (msg: string) => console.log('[mock message success]', msg),
+    error: (msg: string) => console.log('[mock message error]', msg),
+  };
+  root.render(React.createElement(CollapsibleConclusion, {
+    result: data.result,
+    status: data.status,
+    messageApi,
+    showTitle: data.showTitle,
+    recordId: data.recordId ?? undefined,
+  }));
+  setTimeout(() => { w.__renderDone = true; }, 500);
+} catch (e) {
+  w.__renderError = (e as Error).message;
+  w.__renderDone = true;
+}


### PR DESCRIPTION
## 背景
关闭 #652

Issue 描述：todo 执行历史页面结论显示区做成可折叠的效果。有些 todo 执行完成后，结论非常长，占用大片显示区域。希望增加一个折叠的框架功能，点击后，可以把结论区域收起来，需要的时候再展开看。

## 改动概览

### 1. 抽取共享组件 `CollapsibleConclusion`
新增 `frontend/src/components/todo-detail/CollapsibleConclusion.tsx`：
- 渲染头部条：折叠/展开切换按钮（带 caret 图标 + 字数统计 + 可选「结论」标题）
- 复制按钮：复用 `copyToClipboard` 工具，与原有 HTTP fallback 行为一致
- 折叠态：仅显示头部条；展开态：头部 + `XMarkdown` 渲染的 Markdown 内容
- 折叠状态按 `recordId` 持久化到 `localStorage`（`ntd:conclusion-collapsed:<id>`），切换记录时互不干扰
- 完整 ARIA 属性（`aria-expanded`、`aria-label`）+ `data-testid` 便于无障碍与测试
- 默认展开（向后兼容），用户可显式折叠

### 2. 替换 3 个文件中的内联结论区
- `RecordDetailView.tsx:197-224`（桌面端详情面板）
- `ChainGroupCard.tsx:125-146`（主记录）
- `ChainGroupCard.tsx:236-257`（续轮展开）
- `NarrowHistoryCard.tsx:130-151`（窄屏/手机版）

统一通过 `<CollapsibleConclusion result=... status=... recordId=...>` 渲染。删除冗余的 `CopyOutlined` / `XMarkdown` 导入。

### 3. CSS 折叠态
`frontend/src/App.css` 新增：
- `.history-result-collapsed`：压缩 padding 到 6px
- `.history-result-expanded`：平滑过渡
- `.conclusion-content` + `conclusion-fade-in` keyframes：展开时轻量淡入

### 4. Playwright 集成测试
`frontend/tests/issue-652-collapsible-conclusion.spec.ts`（含 `mount.html` + `mount.ts`），**7/7 用例通过**：
- 默认展开：内容 + 字数 + 截图
- 点击 toggle 折叠：内容消失、`aria-expanded=false`、高度 < 80px
- 再次点击恢复展开
- `localStorage` 持久化：折叠后刷新保持
- `showTitle=true` 时显示「结论」标题
- `status='failed'` 时容器带 `history-result-failed` 类
- 复制按钮点击不报错（grantPermissions clipboard）

## 验证

### Playwright 7/7 通过

```
✓  默认展开：应显示 Markdown 内容与字数统计 (10.4s)
✓  点击 toggle 后折叠：内容消失、aria-expanded=false (9.7s)
✓  再次点击 toggle：恢复展开 (11.1s)
✓  localStorage 持久化：刷新后保持折叠态 (24.7s)
✓  showTitle=true：显示「结论」标题 (25.5s)
✓  失败状态：容器带 history-result-failed 类 (25.8s)
✓  复制按钮：点击后调用 copyToClipboard (23.4s)
```

### TypeScript 编译
`npx tsc --noEmit` 退出码 0，无类型错误。

## 截图证据

下方 PR 评论中附两张截图：
- `issue-652-expanded.png`：展开态（带完整 Markdown 内容）
- `issue-652-collapsed.png`：折叠态（仅头部 + 173 字 + 复制按钮）

（截图存放在 `frontend/tests/__screenshots__/`，该目录已在 `.gitignore` 中忽略）