### PR TITLE
fix(execution-logs): 终态分支不再重复插入日志 (fixes #653)

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -273,6 +273,15 @@ impl Database {
         let updated = res.rows_affected() > 0;
 
         // Only insert logs if the status update succeeded (prevent duplicate logs on concurrent writes)
+        //
+        // 注：截至当前（fix #653 之后）已无内部 caller 触发此分支 —— 所有生产 caller（终态 cancel /
+        // timeout / 正常完成 / 启动失败 共 4 处）均传 `remaining_logs: "[]"`，日志全部交给
+        // `LogFlusher` 在 `finalize()` 阶段 drain 入库。本分支保留的原因：
+        // 1. `UpdateExecutionRecord` 是公共 API surface，外部集成方可能仍依赖此行为；
+        // 2. `backend/src/db/mod.rs::test_update_execution_record_does_not_duplicate_logs_issue_653`
+        //    故意传全量 JSON 来回归 issue #653（5/10/5 断言）。
+        // 后续若 release window 有空档，建议把此分支抽成 `append_logs_only` 单独方法并删除，
+        // 让 `update_execution_record` 只负责 status / stats / usage 字段。
         if updated && !req.remaining_logs.is_empty() && req.remaining_logs != "[]" {
             self.insert_execution_logs(req.id, req.remaining_logs).await?;
         }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1372,6 +1372,82 @@ mod tests {
         assert_eq!(logs[0].log_type, "info");
     }
 
+    /// Issue #653 回归：执行期间 LogFlusher 已经按批次把日志写库，终态分支
+    /// （Completed / Cancelled / TimedOut）调用 `update_execution_record` 时
+    /// `remaining_logs` 必须传 `"[]"`，不能再传全量日志，否则每条日志都会被插两次。
+    ///
+    /// 用例分两步：
+    /// 1. 旧 buggy 路径：`append_execution_record_logs` 写 5 条，再以全量 JSON
+    ///    调 `update_execution_record`，断言出现 10 条重复日志（确认 bug 可复现）。
+    /// 2. 修复后路径：同样 append 5 条，再以 `"[]"` 调 `update_execution_record`，
+    ///    断言最终仍是 5 条（确认修复生效）。
+    #[tokio::test]
+    async fn test_update_execution_record_does_not_duplicate_logs_issue_653() {
+        let db = setup_db().await;
+        let todo_id = db.create_todo("DupLogs", "Prompt").await.unwrap();
+        let record_id = create_test_execution_record(&db, todo_id, "echo hi").await;
+
+        // 模拟 LogFlusher 期间已经把 5 条日志写到 execution_logs。
+        let logs_json = r#"[
+            {"timestamp":"2026-01-01T00:00:00.000Z","type":"info","content":"log 1"},
+            {"timestamp":"2026-01-01T00:00:01.000Z","type":"info","content":"log 2"},
+            {"timestamp":"2026-01-01T00:00:02.000Z","type":"info","content":"log 3"},
+            {"timestamp":"2026-01-01T00:00:03.000Z","type":"info","content":"log 4"},
+            {"timestamp":"2026-01-01T00:00:04.000Z","type":"info","content":"log 5"}
+        ]"#;
+        db.append_execution_record_logs(record_id, logs_json)
+            .await
+            .unwrap();
+        let (logs, total) = db.get_execution_logs(record_id, 1, 100).await.unwrap();
+        assert_eq!(total, 5, "append 阶段：5 条日志写库");
+        assert_eq!(logs.len(), 5);
+
+        // 1) 旧 buggy 路径：remaining_logs 传全量 JSON → 再次插入，验证 bug 可复现。
+        db.update_execution_record(crate::db::execution::UpdateExecutionRecordRequest {
+            id: record_id,
+            status: crate::models::ExecutionStatus::Success.as_str(),
+            remaining_logs: logs_json,
+            result: "done",
+            usage: None,
+            model: None,
+            review_meta: None,
+        })
+        .await
+        .unwrap();
+        let (_, total_after_dup) = db.get_execution_logs(record_id, 1, 100).await.unwrap();
+        assert_eq!(
+            total_after_dup, 10,
+            "旧 buggy 路径：传全量日志会导致 5+5=10 条重复日志（issue #653）"
+        );
+
+        // 2) 修复后路径：另起一条记录，传 "[]"，验证日志条数保持不变。
+        let record_id2 = create_test_execution_record(&db, todo_id, "echo hi").await;
+        db.append_execution_record_logs(record_id2, logs_json)
+            .await
+            .unwrap();
+        db.update_execution_record(crate::db::execution::UpdateExecutionRecordRequest {
+            id: record_id2,
+            status: crate::models::ExecutionStatus::Success.as_str(),
+            // 修复点：remaining_logs 传 "[]"，避免重复插入。
+            remaining_logs: "[]",
+            result: "done",
+            usage: None,
+            model: None,
+            review_meta: None,
+        })
+        .await
+        .unwrap();
+        let (logs2, total2) = db.get_execution_logs(record_id2, 1, 100).await.unwrap();
+        assert_eq!(
+            total2, 5,
+            "修复后路径：传 \"[]\" 时日志条数保持 5 条，无重复"
+        );
+        assert_eq!(logs2.len(), 5);
+        // 内容应当与原始 append 的一致
+        assert_eq!(logs2[0].content, "log 1");
+        assert_eq!(logs2[4].content, "log 5");
+    }
+
     #[tokio::test]
     async fn test_get_execution_summary_empty() {
         let db = setup_db().await;

--- a/backend/src/executor_service.rs
+++ b/backend/src/executor_service.rs
@@ -866,20 +866,14 @@ async fn drain_readers_and_flush(
     let _ = flush_timer.await;
 }
 
-/// 读全部 execution_logs 序列化为 JSON 字符串。
-///
-/// 失败一律回落到 `"[]"`，避免外部 IO 错误把 cancel / timeout 流程带崩。
-async fn fetch_remaining_logs_json(db: &Database, record_id: i64) -> String {
-    db.get_all_execution_logs(record_id)
-        .await
-        .map(|v| serde_json::to_string(&v).unwrap_or_else(|_| "[]".to_string()))
-        .unwrap_or_else(|_| "[]".to_string())
-}
-
 /// cancel 分支末段：写 DB（cancelled/failed + 空 result） + 发 Output/Finished 事件 + remove task。
 ///
 /// 抽出来让 cancel 分支的 select! 臂保持 ≤ 30 行：杀进程 + drain 已经抽到
 /// `drain_readers_and_flush`，剩下的就是"DB + 事件 + cleanup"。
+///
+/// 日志写入不再走 `remaining_logs`：进入本函数前 `drain_readers_and_flush` 已经调用
+/// `log_flusher.finalize()` 把残余 buffer 一次性入库；再传全量日志会触发
+/// `update_execution_record` 的 `insert_execution_logs` 分支重复插入（issue #653）。
 async fn handle_cancellation_branch(
     db: &Database,
     tx: &broadcast::Sender<ExecEvent>,
@@ -894,11 +888,11 @@ async fn handle_cancellation_branch(
 ) {
     let _ = db.update_todo_status(todo_id, crate::models::TodoStatus::Cancelled).await;
     let _ = db.update_todo_task_id(todo_id, None).await;
-    let remaining_logs = fetch_remaining_logs_json(db, record_id).await;
     let _ = db.update_execution_record(crate::db::execution::UpdateExecutionRecordRequest {
         id: record_id,
         status: crate::models::ExecutionStatus::Failed.as_str(),
-        remaining_logs: &remaining_logs,
+        // 日志已由 LogFlusher 全部入库；传 "[]" 避免重复插入。
+        remaining_logs: "[]",
         result: "任务已被手动停止",
         usage: None,
         model: None,
@@ -920,6 +914,9 @@ async fn handle_cancellation_branch(
 }
 
 /// timeout 分支末段：写 DB（failed + 包含超时常量文案） + 发 Output/Finished 事件 + remove task。
+///
+/// 日志写入策略与 [`handle_cancellation_branch`] 一致：进入本函数前 `LogFlusher::finalize`
+/// 已 drain 全部日志到 DB，`remaining_logs` 传 `"[]"` 避免重复插入（issue #653）。
 async fn handle_timeout_branch(
     db: &Database,
     tx: &broadcast::Sender<ExecEvent>,
@@ -938,11 +935,11 @@ async fn handle_timeout_branch(
         "Execution timeout, terminating process: timeout={}s, todo_id={}, task_id={}",
         execution_timeout_secs, todo_id, task_id
     );
-    let remaining_logs = fetch_remaining_logs_json(db, record_id).await;
     let _ = db.update_execution_record(crate::db::execution::UpdateExecutionRecordRequest {
         id: record_id,
         status: crate::models::ExecutionStatus::Failed.as_str(),
-        remaining_logs: &remaining_logs,
+        // 日志已由 LogFlusher 全部入库；传 "[]" 避免重复插入。
+        remaining_logs: "[]",
         result: "Execution timeout",
         usage: None,
         model: None,
@@ -963,7 +960,13 @@ async fn handle_timeout_branch(
     task_manager.remove(task_id).await;
 }
 
-/// 正常完成分支：把全量日志、stats、usage、model 写库。
+/// 正常完成分支：把 stats、usage、model 写库；status 更新交给 `update_execution_record`。
+///
+/// 日志写入不在这条路径上：执行过程中 [`crate::log_flusher::LogFlusher`] 已经按阈值 / timer
+/// 批量写库，进入本函数前 [`LogFlusher::finalize`] 也已 drain 残余 buffer（详见
+/// `run_todo_execution` 的 `RunOutcome::Completed` 分支）。这里再把"全量日志"以
+/// `remaining_logs` 传入会触发 [`crate::db::Database::update_execution_record`] 的
+/// `insert_execution_logs` 分支，导致每条日志被插两次（issue #653）。因此固定传 `"[]"`。
 ///
 /// `executor_spawn` 是 executor 的共享引用（stdout reader 里持有的是同一份），
 /// 这里再调用 `get_final_result` / `get_usage` / `get_model` 不会产生竞争——
@@ -973,7 +976,6 @@ async fn persist_completion_record(
     executor: &dyn crate::adapters::CodeExecutor,
     record_id: i64,
     all_logs: &[crate::models::ParsedLogEntry],
-    all_logs_json: &str,
     success: bool,
     execution_start: std::time::Instant,
 ) {
@@ -992,10 +994,11 @@ async fn persist_completion_record(
     // wall-clock duration 覆盖交给 helper 集中处理，避免三个终态分支各自维护。
     let usage = apply_wall_clock_duration(executor.get_usage(all_logs), execution_start);
     let model = executor.get_model();
+    // remaining_logs 故意传 "[]"：日志已由 LogFlusher 全部入库，再传全量会导致重复插入。
     let _ = db.update_execution_record(crate::db::execution::UpdateExecutionRecordRequest {
         id: record_id,
         status: final_status,
-        remaining_logs: all_logs_json,
+        remaining_logs: "[]",
         result: &result_str,
         usage: usage.as_ref(),
         model: model.as_deref(),
@@ -1523,11 +1526,6 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                     .get_all_execution_logs(record_id)
                     .await
                     .unwrap_or_default();
-                let all_logs_json =
-                    serde_json::to_string(&all_logs_snapshot).unwrap_or_else(|e| {
-                        tracing::error!("Failed to serialize all logs: {}", e);
-                        "[]".to_string()
-                    });
                 let result_str = executor_spawn
                     .get_final_result(&all_logs_snapshot)
                     .unwrap_or_default();
@@ -1537,7 +1535,6 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
                     executor_spawn.as_ref(),
                     record_id,
                     &all_logs_snapshot,
-                    &all_logs_json,
                     success,
                     execution_start,
                 )


### PR DESCRIPTION
# fix(execution-logs): 终态分支不再重复插入日志 (fixes #653)

## Issue
[weibaohui/nothing-todo#653](https://github.com/weibaohui/nothing-todo/issues/653) —— todo 执行历史区域中的日志出现重复。

## 根因

执行期间 [`crate::log_flusher::LogFlusher`] 已经按阈值（默认 5 条）/ timer（3s 兜底）把日志批量写入 `execution_logs` 表；进入终态分支时 [`LogFlusher::finalize`] 又会把残余 buffer 一次性 drain 入库。

然而三个终态分支同时把"全量日志 JSON"作为 `remaining_logs` 传给 [`Database::update_execution_record`]，触发 `insert_execution_logs` 再次插入，导致每条日志在执行历史区域出现两次。

具体位置：
- `persist_completion_record`（Completed 分支）—— `remaining_logs: all_logs_json`
- `handle_cancellation_branch`（Cancelled 分支）—— `remaining_logs: &fetch_remaining_logs_json(...)`
- `handle_timeout_branch`（TimedOut 分支）—— 同上

## 修复

三处 `remaining_logs` 统一改为 `"[]"`，由 `LogFlusher::finalize` 接管末尾日志写入：

```rust
let _ = db.update_execution_record(UpdateExecutionRecordRequest {
    id: record_id,
    status: final_status,
    remaining_logs: "[]",  // 修复：日志已由 LogFlusher 全部入库
    ...
});
```

附带清理：
- 删除已无引用的 `fetch_remaining_logs_json` helper
- `persist_completion_record` 移除冗余的 `all_logs_json` 参数（`all_logs_snapshot` 仍保留，因为 `executor.get_final_result` / `extract_execution_stats` / `executor.get_usage` 都要用它）

## 回归测试

新增 `test_update_execution_record_does_not_duplicate_logs_issue_653`，一次跑完"复现 bug + 验证修复"两组断言：

```text
test db::tests::test_update_execution_record_does_not_duplicate_logs_issue_653 ... ok
```

测试逻辑：
1. 模拟 LogFlusher 写 5 条日志（`append_execution_record_logs`）
2. **旧 buggy 路径**：以全量 JSON 调 `update_execution_record` —— 断言出现 10 条（5+5 重复），确认 bug 真实存在
3. **修复路径**：另开 record，以 `"[]"` 调 `update_execution_record` —— 断言保持 5 条，确认修复生效

## 全量测试

```text
cargo test --lib
test result: ok. 621 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
```

相关模块均通过：
- `db::tests::test_update_execution_record ... ok`
- `db::tests::test_update_execution_record_does_not_duplicate_logs_issue_653 ... ok`
- `log_flusher::tests::trigger_flush_when_threshold_reached ... ok`
- `log_flusher::tests::flush_failure_restores_snapshot_and_counter ... ok`
- `log_flusher::tests::no_data_lost_with_concurrent_writer_during_finalize ... ok`
- `log_flusher::tests::finalize_drains_remaining_buffer ... ok`
- `log_flusher::tests::pending_flag_prevents_concurrent_flushes ... ok`
- `log_flusher::tests::timer_periodically_flushes_buffer ... ok`
- `log_flusher::tests::timer_exits_on_shutdown ... ok`
- `executor_service::tests::*`（14 个）全部通过

## 设计取舍

为什么不动 `Database::update_execution_record` 的语义？
- `remaining_logs` 参数的历史语义是"在 status 更新时顺便把 buffer 中尚未入库的日志一起写入"，issue #496 的 LogFlusher 重构后这层语义已经被 LogFlusher 替代，但 `update_execution_record` 的"如果传了非空 remaining_logs 就插一遍"行为是公开 API 行为，外部可能存在调用方依赖，因此这次只改调用点。
- 如果后续确认不再需要 `remaining_logs` 入库路径，可以再单独提一个 refactor 把这个分支从 `update_execution_record` 中删除。

为什么不删 `all_logs_json` 之外的 `all_logs_snapshot`？
- `persist_completion_record` 内部仍然要 `executor.get_final_result(all_logs_snapshot)` / `extract_execution_stats(all_logs_snapshot, ...)` / `executor.get_usage(all_logs_snapshot)`，这些方法只读 executor 内部 state，需要全量日志才能算 final result / usage / stats。仅 `all_logs_json` 是冗余的。