### PR TITLE
fix(mobile): 修复手机端命令视图缺失问题 (fixes #657)

### DIFF
--- a/frontend/src/components/todo-detail/NarrowLogView.tsx
+++ b/frontend/src/components/todo-detail/NarrowLogView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ChatView } from '@/components/ChatView';
 import { LogViewHeader } from './LogViewHeader';
 import { formatLogTime } from './helpers';
@@ -28,10 +28,17 @@ export function NarrowLogView({ record, isRunning, displayLogs, liveLogs, viewMo
   // 用户主动切到「对话/命令」时直接展开，否则只对运行中的记录展开（更符合直觉）。
   const defaultOpen = isRunning || viewMode === 'chat' || viewMode === 'command';
   const [isExpanded, setIsExpanded] = useState(defaultOpen);
-  // PR #657 复查 C1 修复：useState 初始值只读一次，viewMode 后续变化不会触发展开。
-  // 显式同步「切到 chat/command 必展开」这条约束；用户后续手动 collapse 仍可生效。
+  // 修复 PR #658 复查 HIGH#2：用户主动折叠后，viewMode 切换不应再强制展开；
+  // 用 ref 记录用户手动折叠行为，让 useEffect 仅在 ref=false 时才 setIsExpanded(true)
+  const userCollapsedRef = useRef(false);
   useEffect(() => {
-    if (viewMode === 'chat' || viewMode === 'command') {
+    // 切回 log 视图时清零，让后续切换能继续自动展开
+    if (viewMode === 'log') {
+      userCollapsedRef.current = false;
+      return;
+    }
+    // 用户没手动折叠过 + 切到 chat/command → 自动展开
+    if ((viewMode === 'chat' || viewMode === 'command') && !userCollapsedRef.current) {
       setIsExpanded(true);
     }
   }, [viewMode]);
@@ -44,7 +51,16 @@ export function NarrowLogView({ record, isRunning, displayLogs, liveLogs, viewMo
   } as const;
   const title = `${titleMap[viewMode]}${liveTag}`;
   return (
-    <details style={{ marginTop: 8 }} open={isExpanded} onToggle={(e) => setIsExpanded((e.target as HTMLDetailsElement).open)}>
+    <details
+      style={{ marginTop: 8 }}
+      open={isExpanded}
+      onToggle={(e) => {
+        // 捕获用户主动折叠：之后切 viewMode 不会强制展开
+        const open = (e.target as HTMLDetailsElement).open;
+        if (!open) userCollapsedRef.current = true;
+        setIsExpanded(open);
+      }}
+    >
       <summary style={{ cursor: 'pointer', color: 'var(--color-primary)', fontSize: 12, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 8 }}>
         <span>{title}</span>
         <LogViewHeader

--- a/frontend/src/types/execution.tsx
+++ b/frontend/src/types/execution.tsx
@@ -38,9 +38,6 @@ export interface CommandEntry {
   timestamp: string;
 }
 
-/** issue #648: 执行历史记录页内的视图模式（Segmented 选项） */
-export type LogViewMode = 'log' | 'chat' | 'command';
-
 export interface ChatMessage {
   role: 'user' | 'assistant' | 'system' | 'tool' | 'thinking' | 'result';
   content: string;

--- a/frontend/tests/issue-657-mobile-command-view.spec.ts
+++ b/frontend/tests/issue-657-mobile-command-view.spec.ts
@@ -197,4 +197,58 @@ test.describe('issue #657 — 窄屏命令视图', () => {
     expect(cmdText).toContain('git pull origin main');
     expect(cmdText).toContain('共 2 条命令');
   });
+
+  // 修复 PR #658 复查 HIGH#2：用户主动折叠后切到「命令」视图应保持折叠。
+  // 修复前 useEffect 会无脑 setIsExpanded(true) 覆盖用户行为。
+  test('NarrowLogView 用户手动折叠后切到命令视图应保持折叠', async ({ page }) => {
+    await mountAndRead(page, {
+      component: 'NarrowLogView',
+      logs: SAMPLE_LOGS,
+      executor: 'claudecode',
+      viewMode: 'chat',
+      recordId: 43,
+    });
+
+    // 初始 chat 视图：useEffect 应自动展开
+    const chatOpen = await page.evaluate(() => {
+      const d = document.querySelector('#test-target details');
+      return d ? d.hasAttribute('open') : false;
+    });
+    expect(chatOpen).toBe(true);
+
+    // 模拟用户主动折叠 details
+    await page.evaluate(() => {
+      const d = document.querySelector('#test-target details') as HTMLDetailsElement | null;
+      if (d) {
+        d.open = false;
+        d.dispatchEvent(new Event('toggle'));
+      }
+    });
+    await page.waitForTimeout(150);
+    const afterCollapse = await page.evaluate(() => {
+      const d = document.querySelector('#test-target details');
+      return d ? d.hasAttribute('open') : false;
+    });
+    expect(afterCollapse).toBe(false);
+
+    // 切到「命令」视图：userCollapsedRef=true，应保持闭合
+    await page.locator('#test-target .ant-segmented-item:has-text("命令")').first().click();
+    await page.waitForTimeout(300);
+    const afterCommand = await page.evaluate(() => {
+      const d = document.querySelector('#test-target details');
+      return d ? d.hasAttribute('open') : false;
+    });
+    expect(afterCommand).toBe(false);
+
+    // 切回 log 视图后重置 ref，再切到 command 仍能自动展开
+    await page.locator('#test-target .ant-segmented-item:has-text("日志")').first().click();
+    await page.waitForTimeout(300);
+    await page.locator('#test-target .ant-segmented-item:has-text("命令")').first().click();
+    await page.waitForTimeout(300);
+    const afterReset = await page.evaluate(() => {
+      const d = document.querySelector('#test-target details');
+      return d ? d.hasAttribute('open') : false;
+    });
+    expect(afterReset).toBe(true);
+  });
 });


### PR DESCRIPTION
## 关联 Issue
Fixes #657

## 问题描述
手机端访问执行记录详情页时，对话模式后面没有「命令」模式切换按钮，且在某些情况下整个日志视图区域不显示。

## 改动点

### LogViewHeader
- 引入 `CodeOutlined` 图标
- Segmented 新增 `{ value: 'command', icon: <CodeOutlined />, label: '命令' }` 选项，与桌面端 `RecordDetailView` 对齐
- onChange 类型 cast 从 `'log' | 'chat'` 扩展为 `'log' | 'chat' | 'command'`，避免切到命令视图后状态错位

### NarrowLogView
- 抽取 `buildNarrowTitle` helper：按视图模式生成不同标题，统一管理 `实时` 标记
- 抽取 `renderNarrowBody` 子函数：按 viewMode 渲染对应 body（chat / command / log），便于单测覆盖
- 移除 `if (!isRunning && displayLogs.length === 0) return null;`：让视图区域始终渲染，避免手机端切到命令视图时整个日志区被吞掉
- 新增 `command` 模式分支，渲染 `CommandPanel` 并传入 `record.executor`
- 导出 `NarrowViewMode` 联合类型，与 LogViewHeader 共享避免漂移

### 测试
- `tests/issue-657-mobile-command-view.spec.ts`: 3 个 Playwright 用例
  1. `LogViewHeader` 渲染「日志 / 对话 / 命令」三个选项
  2. 点击「命令」触发 onViewModeChange 并切到命令视图，CommandPanel `data-testid` 出现
  3. 空日志场景（通过 URL hash 注入 logs: []）视图不再被吞；切到命令视图能正常显示「未捕获到」空态
- 配套 `tests/issue-657-mount.html` + `tests/issue-657-mount.ts` mount harness：复用 `issue-648-mount` 模式，Vite dev server 加载真实 React 组件

## 测试结果
```
✓ LogViewHeader 应渲染「日志/对话/命令」三个选项 (1.4s)
✓ 点击「命令」应触发 onViewModeChange 并切到命令视图 (1.9s)
✓ 空日志场景下视图区域不应被吞掉 (1.8s)
3 passed (6.9s)
```

回归测试（issue #648 命令视图 UI）：
```
✓ 应在浏览器中渲染「命令」视图并展示命令卡片
✓ hermes 执行器应显示「不支持」提示
✓ 空日志应显示「未捕获到」空态
3 passed (30.9s)
```

## 设计取舍
- **不导出 buildNarrowTitle**：属于组件内部逻辑，外部组件只需传入 props，导出反而增加 API 表面积。
- **不删除 NarrowLogView 的三元 title 表达式**：拆出 helper 后，可读性已经达标。
- **保留 defaultOpen 包含 command**：切到命令视图时用户期望立刻看到内容，与 chat 视图行为一致。
- **不直接 return null 当 logs 为空**：原行为会让手机端切到命令视图时整个区域被吞，体验上"无内容等于没这功能"。空态由 CommandPanel 内部的「未捕获到」卡片处理。

## 截图
- 修复前：无命令视图按钮，日志区在某些场景下消失
- 修复后：`tests/__screenshots__/mobile-command-view.png`、`mobile-narrow-rendered.png`