### PR TITLE
fix(execution): 禁止用 task_id 作为 resume session_id

### DIFF
--- a/backend/src/adapters/claude_code.rs
+++ b/backend/src/adapters/claude_code.rs
@@ -1,3 +1,7 @@
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
 use super::helpers;
 use super::{BaseExecutor, CodeExecutor, ExecutorType, ParsedLogEntry};
 use super::claude_protocol::{ClaudeMessage, ClaudeContentBlock};
@@ -10,21 +14,33 @@ use crate::models::utc_timestamp;
 /// `usage` 字段虽然未被本 executor 直接使用（claude_code 的 usage 走
 /// `super::get_usage_from_logs` 从 result 事件提取），但 BaseExecutor 仍然保留这个
 /// `Arc<Mutex<Option<ExecutionUsage>>>` 字段，方便与其他 executor 行为保持一致。
-// `BaseExecutor` 已经 `#[derive(Clone)]`，组合字段无需手写 Clone impl。
+/// `session_id` 单独维护：来自 Claude Code system 事件，与 model/usage 生命周期不同，
+/// 避免污染 BaseExecutor 共享字段的语义。
+// `BaseExecutor` 已经 `#[derive(Clone)]`，组合字段无需手写 Clone impl；
+// `Arc<Mutex<...>>` 也派生 Clone（共享内部状态），与原手写 impl 语义等价。
 #[derive(Clone)]
 pub struct ClaudeCodeExecutor {
     base: BaseExecutor,
+    /// 从 system 事件中提取的 session id，供 extract_session_id 读取
+    session_id: Arc<Mutex<Option<String>>>,
 }
 
 impl ClaudeCodeExecutor {
     pub fn new(path: String) -> Self {
-        Self { base: BaseExecutor::new(path) }
+        Self {
+            base: BaseExecutor::new(path),
+            session_id: Arc::new(Mutex::new(None)),
+        }
     }
 
-    /// 处理 system 事件：把 model 写入 base.state，content 显示 session init 摘要。
+    /// 处理 system 事件：把 model 写入 base.state，session_id 写入独立字段，
+    /// content 显示 session init 摘要。
     fn handle_system(&self, model: Option<&String>, session_id: Option<&String>, subtype: Option<&String>) -> Option<ParsedLogEntry> {
         if let Some(m) = model {
             *self.base.model.lock() = Some(m.clone());
+        }
+        if let Some(sid) = session_id {
+            *self.session_id.lock() = Some(sid.clone());
         }
         Some(helpers::entry(
             "system",
@@ -198,6 +214,16 @@ impl CodeExecutor for ClaudeCodeExecutor {
         true
     }
 
+    /// 从 stdout 行提取 session_id。
+    ///
+    /// Claude Code 的 system 事件在对话开始时就会带 `session_id` 字段；
+    /// `handle_system` 解析时已写入 `self.session_id`，本方法直接读取并返回。
+    /// 一旦写过一次就不再变（system 事件在同一次执行里只触发一次），
+    /// 与 executor_service 中"只回写一次 DB"的语义一致。
+    fn extract_session_id(&self, _line: &str) -> Option<String> {
+        self.session_id.lock().clone()
+    }
+
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
         if line.is_empty() {
             return None;
@@ -346,5 +372,55 @@ mod tests {
     fn test_get_model_before_system() {
         let executor = ClaudeCodeExecutor::new("claude".to_string());
         assert!(executor.get_model().is_none());
+    }
+
+    #[test]
+    fn test_extract_session_id_before_system() {
+        // system 事件未到达时返回 None
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}"#;
+        assert_eq!(executor.extract_session_id(line), None);
+    }
+
+    #[test]
+    fn test_extract_session_id_from_system() {
+        // system 事件携带 session_id，handle_system 写入后 extract_session_id 能拿到
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
+        let line = r#"{"type":"system","session_id":"sess_abc123","model":"claude-3-5-sonnet"}"#;
+        // 走 parse_output_line 触发 handle_system 写入
+        let _ = executor.parse_output_line(line);
+        assert_eq!(
+            executor.extract_session_id(""),
+            Some("sess_abc123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_session_id_system_without_sid() {
+        // system 事件没有 session_id 字段时保持 None
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
+        let line = r#"{"type":"system","model":"claude-3-5-sonnet"}"#;
+        let _ = executor.parse_output_line(line);
+        assert_eq!(executor.extract_session_id(""), None);
+    }
+
+    #[test]
+    fn test_extract_session_id_empty_line() {
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
+        assert_eq!(executor.extract_session_id(""), None);
+    }
+
+    #[test]
+    fn test_extract_session_id_is_stable_across_lines() {
+        // 第一次解析到 system 写入 sid 后，后续任意行（哪怕是 assistant）继续返回同一 sid
+        let executor = ClaudeCodeExecutor::new("claude".to_string());
+        let sys = r#"{"type":"system","session_id":"sess_xyz","model":"m"}"#;
+        let _ = executor.parse_output_line(sys);
+        let assistant = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}"#;
+        let _ = executor.parse_output_line(assistant);
+        assert_eq!(
+            executor.extract_session_id(assistant),
+            Some("sess_xyz".to_string())
+        );
     }
 }

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -476,8 +476,11 @@ pub async fn resume_execution_handler(
         .filter(|m| !m.is_empty())
         .map(|m| m.to_string());
 
-    let resume_session_id = record.session_id.or(record.task_id).ok_or_else(|| {
-        AppError::BadRequest("No session_id found for this execution record".to_string())
+    // 只能从 session_id resume。task_id 是执行启动时的随机 UUID，
+    // 不是 Claude Code 的真实 session ID，不能作为 resume 的凭据。
+    // 如果 session_id 还未回写（首次执行刚结束），用户应等待或发起新的执行。
+    let resume_session_id = record.session_id.ok_or_else(|| {
+        AppError::BadRequest("Session not yet established. Please wait for the execution to finalize or start a new execution.".to_string())
     })?;
 
     let result = start_todo_execution(RunTodoExecutionRequest {

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -476,12 +476,12 @@ pub async fn resume_execution_handler(
         .filter(|m| !m.is_empty())
         .map(|m| m.to_string());
 
-    // 只能从 session_id resume。task_id 是执行启动时的随机 UUID，
+    // 只能从 session_id resume。task_id 是执行启动时生成的随机 UUID，
     // 不是 Claude Code 的真实 session ID，不能作为 resume 的凭据。
-    // 如果 session_id 还未回写（首次执行刚结束），用户应等待或发起新的执行。
-    let resume_session_id = record.session_id.ok_or_else(|| {
-        AppError::BadRequest("Session not yet established. Please wait for the execution to finalize or start a new execution.".to_string())
-    })?;
+    // session_id 由 executor 在解析 stdout 的 system 事件时异步回写 DB；
+    // 若执行异常退出或 extractor 未实现，DB 里的 session_id 仍为 NULL，
+    // 此时调用 resume 需等待或重试。
+    let resume_session_id = resolve_resume_session_id(&record)?;
 
     let result = start_todo_execution(RunTodoExecutionRequest {
         db: state.db.clone(),
@@ -673,4 +673,102 @@ pub async fn smart_create_handler(
         "todo_id": todo_id,
         "todo_title": todo.title,
     })))
+}
+
+/// 从执行记录中解析出可用的 resume session_id。
+///
+/// 严格化策略：只接受 DB 里的 `session_id`（由 executor 在解析 stdout 的
+/// system 事件时异步回写），不再回退到 `task_id`。
+/// `task_id` 是后端生成的随机 UUID，不能作为 Claude Code / Kimi 等
+/// 执行器的真实会话凭据，传给 `--resume` / `-S` 会导致 CLI 报错。
+///
+/// 该函数独立于 AppState / DB，方便单测覆盖核心拒绝逻辑。
+fn resolve_resume_session_id(
+    record: &crate::models::ExecutionRecord,
+) -> Result<String, AppError> {
+    record.session_id.clone().ok_or_else(|| {
+        AppError::BadRequest("No session_id available for resume".to_string())
+    })
+}
+
+#[cfg(test)]
+mod resume_session_id_tests {
+    use super::*;
+    use crate::models::{ExecutionRecord, ExecutionStatus};
+
+    /// 构造一个最小可用的测试 ExecutionRecord，固定关键字段。
+    fn make_record(session_id: Option<&str>, task_id: Option<&str>) -> ExecutionRecord {
+        ExecutionRecord {
+            id: 1,
+            todo_id: 1,
+            status: ExecutionStatus::Success,
+            command: String::new(),
+            stdout: String::new(),
+            stderr: String::new(),
+            result: None,
+            started_at: String::new(),
+            finished_at: None,
+            usage: None,
+            executor: None,
+            model: None,
+            trigger_type: "manual".to_string(),
+            pid: None,
+            task_id: task_id.map(|s| s.to_string()),
+            session_id: session_id.map(|s| s.to_string()),
+            todo_progress: None,
+            execution_stats: None,
+            resume_message: None,
+            source_todo_id: None,
+            source_todo_title: None,
+            source_hook_id: None,
+            rating: None,
+            source_execution_record_id: None,
+            last_review_status: None,
+            last_reviewed_at: None,
+            worktree_path: None,
+        }
+    }
+
+    #[test]
+    fn test_resolve_resume_session_id_none_returns_err() {
+        // session_id 为 None：必须返回 400，绝不能放行
+        let record = make_record(None, Some("task-uuid-123"));
+        let err = resolve_resume_session_id(&record).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+        if let AppError::BadRequest(msg) = err {
+            assert!(msg.contains("No session_id available for resume"));
+        }
+    }
+
+    #[test]
+    fn test_resolve_resume_session_id_both_none_returns_err() {
+        // session_id 与 task_id 都为 None：仍然返回 400
+        let record = make_record(None, None);
+        let err = resolve_resume_session_id(&record).unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn test_resolve_resume_session_id_with_sid_returns_sid() {
+        // session_id 有值：直接返回 session_id
+        let record = make_record(Some("real-claude-sid-abc"), Some("task-uuid-123"));
+        let sid = resolve_resume_session_id(&record).unwrap();
+        assert_eq!(sid, "real-claude-sid-abc");
+    }
+
+    #[test]
+    fn test_resolve_resume_session_id_ignores_task_id() {
+        // 即便 task_id 有值、session_id 为 None，也必须拒绝（不能 fallback）
+        let record = make_record(None, Some("task-uuid-123"));
+        assert!(resolve_resume_session_id(&record).is_err());
+    }
+
+    #[test]
+    fn test_resolve_resume_session_id_sid_takes_precedence() {
+        // 两者都有时返回 session_id，绝不会把 task_id 当作 sid
+        let record = make_record(Some("real-sid"), Some("random-task-uuid"));
+        let sid = resolve_resume_session_id(&record).unwrap();
+        assert_eq!(sid, "real-sid");
+        assert_ne!(sid, "random-task-uuid");
+    }
 }


### PR DESCRIPTION
## 修复内容

**问题**：手工 Resume 端点（execution.rs:479）在  时会 fallback 到 。但  是执行启动时生成的随机 UUID，**不是** Claude Code 的真实 session ID，会导致  错误。

**修复**：当  时，直接拒绝 resume，而不是 fallback 到 。



## 测试

请验证：
- [ ] 当执行记录的 session_id 为空时，点击 Resume 按钮返回明确错误信息
- [ ] 当执行记录的 session_id 存在时，Resume 正常工作