### PR TITLE
fix(mimo): 修复命令视图工具命令状态判定始终为失败

### DIFF
--- a/backend/src/adapters/claude_code.rs
+++ b/backend/src/adapters/claude_code.rs
@@ -216,19 +216,19 @@ impl CodeExecutor for ClaudeCodeExecutor {
     /// 从 stdout 中提取 session_id。
     /// Claude Code 的 session_id 在 system 事件的 session_id 字段中输出。
     /// 提取成功后保存到 executor 状态，供后续回写 DB 使用。
+    /// 若 line 为空或不含 session_id，则返回之前已缓存的值（handle_system 写入的）。
     fn extract_session_id(&self, line: &str) -> Option<String> {
-        if line.is_empty() {
-            return None;
-        }
-        // 解析 JSON，提取 system 事件中的 session_id
-        if let Ok(msg) = serde_json::from_str::<ClaudeMessage>(line) {
-            if let ClaudeMessage::System { session_id: Some(sid), .. } = msg {
-                // 保存到 executor 状态
-                *self.session_id.lock() = Some(sid.clone());
-                return Some(sid);
+        // 尝试从当前行解析新的 session_id
+        if !line.is_empty() {
+            if let Ok(msg) = serde_json::from_str::<ClaudeMessage>(line) {
+                if let ClaudeMessage::System { session_id: Some(sid), .. } = msg {
+                    *self.session_id.lock() = Some(sid.clone());
+                    return Some(sid);
+                }
             }
         }
-        None
+        // 回退：返回之前缓存的 session_id（由 handle_system 写入）
+        self.session_id.lock().clone()
     }
 
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {

--- a/backend/src/adapters/mimo.rs
+++ b/backend/src/adapters/mimo.rs
@@ -64,6 +64,8 @@ impl MimoExecutor {
     }
 
     /// tool_use: bash 工具显示 description + output，其它工具显示 tool + description。
+    /// tool_input_json 序列化完整的 part.state（含 status / input / output），
+    /// 前端 extractAgentCommands 依赖 state.status 判定命令成功/失败。
     fn handle_tool_use(
         &self,
         part: &super::mimo_event::MimoPart,
@@ -75,9 +77,10 @@ impl MimoExecutor {
         let description = part.state.as_ref()
             .and_then(|s| s.input.as_ref()?.description.clone())
             .unwrap_or_default();
-        let input_json = part.state.as_ref()
-            .and_then(|s| s.input.as_ref())
-            .map(|i| i.to_full_json());
+        // 序列化完整的 part.state（含 status / input / output），
+        // 而非仅 input；前端 extractAgentCommands 需要 state.status 判定成功/失败。
+        let state_json = part.state.as_ref()
+            .map(|s| serde_json::to_string(s).unwrap_or_default());
 
         // bash 特殊渲染：把命令输出也带上
         let content = if tool == "bash" {
@@ -90,7 +93,7 @@ impl MimoExecutor {
         };
 
         Some(helpers::with_timestamp(
-            helpers::entry_with_optional_tool("tool", content, Some(tool), input_json),
+            helpers::entry_with_optional_tool("tool", content, Some(tool), state_json),
             timestamp,
         ))
     }

--- a/backend/src/adapters/mimo_event.rs
+++ b/backend/src/adapters/mimo_event.rs
@@ -4,7 +4,7 @@
 //! with underscore-separated type names (e.g., step_start, tool_use).
 
 use std::collections::HashMap;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// MiMo agent event with underscore-separated type names (same as OpenCode)
 #[derive(Debug, Clone, Deserialize)]
@@ -47,7 +47,7 @@ pub struct MimoPart {
     pub snapshot: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MimoToolState {
     #[serde(default)]
     pub status: Option<String>,
@@ -57,7 +57,7 @@ pub struct MimoToolState {
     pub output: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MimoToolInput {
     #[serde(default)]
     pub command: Option<String>,


### PR DESCRIPTION
## 问题

mimo 执行器的命令视图中，工具命令（如 bash）显示为"失败"，但实际命令执行成功。

## 根因

`mimo.rs` 的 `handle_tool_use` 只序列化了 `part.state.input` 到 `tool_input_json`：
```json
{"command":"echo hello","description":"Print hello"}
```

但前端 `extractAgentCommands` 期望 `tool_input_json` 包含完整的 `state` 对象：
```json
{"status":"completed","input":{"command":"echo hello","description":"Print hello"},"output":"hello\n"}
```

解析链断裂：`state.status` → `undefined` → `''` → `success = false`

## 修复

- `mimo_event.rs`: `MimoToolState`/`MimoToolInput` 添加 `Serialize`
- `mimo.rs`: `handle_tool_use` 序列化完整 `part.state`（含 status/input/output）
- `claude_code.rs`: `extract_session_id` 合并行解析与缓存回退逻辑（修复 rebase 引入的测试失败）

## 测试

- [x] 全部 648 个库测试通过