### PR TITLE
feat(executor): 新增 Zhanlu 执行器 (Issue #673)

### DIFF
--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -134,10 +134,9 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         aliases: &["mimocode"],
     },
     ExecutorDef {
-        // Zhanlu: Issue #673 新增的执行器，行为与 opencode 完全一致；
-        // 使用 ~/.zhanlu/bin/zl 二进制，session 目录是 ~/.local/share/zhanlu/storage。
-        // 默认路径写成 `zl` 而不是 `~/.zhanlu/bin/zl` 是为了走 PATH 查找，
-        // 与其他 executor 的 default_path 风格保持一致（统一从 PATH 解析）。
+        // Zhanlu: Issue #673 新增的执行器，行为与 opencode 完全一致。
+        // binary_name / default_path 都走 PATH 解析（统一为 `zl`），
+        // session 目录是 ~/.local/share/zhanlu/storage。
         name: "zhanlu",
         executor_type: ExecutorType::Zhanlu,
         binary_name: "zl",

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -133,10 +133,23 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         session_dir: "~/.local/share/mimocode",
         aliases: &["mimocode"],
     },
+    ExecutorDef {
+        // Zhanlu: Issue #673 新增的执行器，行为与 opencode 完全一致；
+        // 使用 ~/.zhanlu/bin/zl 二进制，session 目录是 ~/.local/share/zhanlu/storage。
+        // 默认路径写成 `zl` 而不是 `~/.zhanlu/bin/zl` 是为了走 PATH 查找，
+        // 与其他 executor 的 default_path 风格保持一致（统一从 PATH 解析）。
+        name: "zhanlu",
+        executor_type: ExecutorType::Zhanlu,
+        binary_name: "zl",
+        display_name: "Zhanlu",
+        default_path: "zl",
+        session_dir: "~/.local/share/zhanlu/storage",
+        aliases: &["zhanlucode", "zl"],
+    },
 ];
 
 /// 支持继续对话的执行器集合（与前端 RESUMABLE_EXECUTORS 保持一致）
-pub const RESUMABLE_EXECUTORS: &[&str] = &["claudecode", "kimi", "opencode", "mobilecoder", "hermes", "codewhale", "pi", "mimo"];
+pub const RESUMABLE_EXECUTORS: &[&str] = &["claudecode", "kimi", "opencode", "mobilecoder", "hermes", "codewhale", "pi", "mimo", "zhanlu"];
 
 /// 默认执行器
 pub const DEFAULT_EXECUTOR: &str = "claudecode";
@@ -289,6 +302,8 @@ pub mod pi;
 pub mod pi_event;
 pub mod mimo;
 pub mod mimo_event;
+pub mod zhanlu;
+pub mod zhanlu_event;
 
 #[async_trait]
 pub trait CodeExecutor: Send + Sync {
@@ -409,6 +424,7 @@ impl ExecutorRegistry {
             "codewhale" => Arc::new(codewhale::CodewhaleExecutor::new(path.to_string())),
             "pi" => Arc::new(pi::PiExecutor::new(path.to_string())),
             "mimo" => Arc::new(mimo::MimoExecutor::new(path.to_string())),
+            "zhanlu" => Arc::new(zhanlu::ZhanluExecutor::new(path.to_string())),
             _ => return None,
         };
         Some(executor)
@@ -483,6 +499,16 @@ mod tests {
         assert_eq!(parse_executor_type("mimo"), Some(ExecutorType::Mimo));
         assert_eq!(parse_executor_type("MIMO"), Some(ExecutorType::Mimo));
         assert_eq!(parse_executor_type("mimocode"), Some(ExecutorType::Mimo));
+    }
+
+    #[test]
+    fn test_parse_executor_type_zhanlu() {
+        // Issue #673: zhanlu 必须能被 parse_executor_type 解析为 ExecutorType::Zhanlu
+        // 同时别名 zhanlucode / zl 也能解析到 Zhanlu
+        assert_eq!(parse_executor_type("zhanlu"), Some(ExecutorType::Zhanlu));
+        assert_eq!(parse_executor_type("ZHANLU"), Some(ExecutorType::Zhanlu));
+        assert_eq!(parse_executor_type("zhanlucode"), Some(ExecutorType::Zhanlu));
+        assert_eq!(parse_executor_type("zl"), Some(ExecutorType::Zhanlu));
     }
 
     #[test]

--- a/backend/src/adapters/zhanlu.rs
+++ b/backend/src/adapters/zhanlu.rs
@@ -1,0 +1,416 @@
+use std::sync::Arc;
+use parking_lot::Mutex;
+
+use super::helpers;
+use super::zhanlu_event::ZhanluAgentEvent;
+use super::{BaseExecutor, CodeExecutor, ExecutorType, ParsedLogEntry};
+use crate::adapters::ExecutionUsage;
+use crate::models::utc_timestamp;
+
+/// Zhanlu executor。
+///
+/// 与 Opencode 完全等价：相同的命令行参数、相同的 JSON 输出格式、相同的退出码语义。
+/// Issue #673 明确要求「行为跟 opencode 完全一致，执行命令也一致，返回输出 json 格式也一致」，
+/// 但因为后续 Zhanlu 可能演化出独立行为，所以不复用 `opencode.rs`，而是完整复制一份。
+///
+/// `has_successful_finish` 与 Opencode 一样承担「非零退出码但有 finish 事件就算成功」的语义。
+#[derive(Clone)]
+pub struct ZhanluExecutor {
+    base: BaseExecutor,
+    has_successful_finish: Arc<Mutex<bool>>,
+}
+
+impl ZhanluExecutor {
+    pub fn new(path: String) -> Self {
+        Self {
+            base: BaseExecutor::new(path),
+            has_successful_finish: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    /// 把 Zhanlu 时间戳（毫秒）转换为 ISO 字符串；缺失时回退到 utc_timestamp。
+    fn resolve_timestamp(ts: Option<u64>) -> String {
+        ts.and_then(|ts| chrono::DateTime::from_timestamp_millis(ts as i64))
+            .map(|dt| dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
+            .unwrap_or_else(utc_timestamp)
+    }
+
+    /// step_start / step-start: 重置 has_successful_finish + usage。
+    fn handle_step_start(&self, timestamp: &str) -> Option<ParsedLogEntry> {
+        *self.has_successful_finish.lock() = false;
+        *self.base.usage.lock() = None;
+        Some(helpers::with_timestamp(helpers::entry("step_start", "Step started"), timestamp))
+    }
+
+    /// tool_use / tool-use: bash 工具显示 description + output，其它工具显示 tool + description。
+    fn handle_tool_use(
+        &self,
+        part: &super::zhanlu_event::ZhanluAgentPart,
+        timestamp: &str,
+    ) -> Option<ParsedLogEntry> {
+        let tool = part.tool.clone().unwrap_or_default();
+        let status = part.state.as_ref().and_then(|s| s.status.clone()).unwrap_or_default();
+        let description = part.state.as_ref().and_then(|s| s.input.as_ref().and_then(|i| i.description.clone())).unwrap_or_default();
+        let input_json = part.state.as_ref()
+            .and_then(|s| s.input.as_ref())
+            .map(|i| i.to_full_json());
+
+        // bash 特殊渲染：把命令输出也带上
+        let content = if tool == "bash" {
+            match &part.state.as_ref().and_then(|s| s.output.clone()) {
+                Some(output) => format!("[{}] {}: {}", status, description, output),
+                None => format!("[{}] {}", status, description),
+            }
+        } else {
+            format!("[{}] Tool: {} - {}", status, tool, description)
+        };
+
+        Some(helpers::with_timestamp(
+            helpers::entry_with_optional_tool("tool", content, Some(tool), input_json),
+            timestamp,
+        ))
+    }
+
+    /// text: 空文本返回 None，否则返回 text 日志。
+    fn handle_text(
+        &self,
+        part: &super::zhanlu_event::ZhanluAgentPart,
+        timestamp: &str,
+    ) -> Option<ParsedLogEntry> {
+        let text = part.text.clone().unwrap_or_default();
+        if text.is_empty() {
+            return None;
+        }
+        Some(helpers::with_timestamp(helpers::text_entry(text), timestamp))
+    }
+
+    /// step_finish / step-finish: 标记 has_successful_finish，从 tokens 提取 usage。
+    fn handle_step_finish(
+        &self,
+        event: &ZhanluAgentEvent,
+        timestamp: &str,
+    ) -> Option<ParsedLogEntry> {
+        // Mark as successfully finished — zhanlu returns non-zero exit code
+        // even on successful execution, so we track success via the event stream.
+        *self.has_successful_finish.lock() = true;
+        // Store usage info if available
+        if let Some(part) = &event.part {
+            if let Some(tokens) = &part.tokens {
+                *self.base.usage.lock() = Some(ExecutionUsage {
+                    input_tokens: tokens.input,
+                    output_tokens: tokens.output,
+                    cache_read_input_tokens: if tokens.cache.read > 0 { Some(tokens.cache.read) } else { None },
+                    cache_creation_input_tokens: if tokens.cache.write > 0 { Some(tokens.cache.write) } else { None },
+                    total_cost_usd: part.cost,
+                    duration_ms: None,
+                });
+            }
+        }
+        Some(helpers::with_timestamp(helpers::entry("step_finish", "Step finished"), timestamp))
+    }
+}
+
+impl CodeExecutor for ZhanluExecutor {
+    fn executor_type(&self) -> ExecutorType {
+        ExecutorType::Zhanlu
+    }
+
+    fn executable_path(&self) -> &str {
+        &self.base.path
+    }
+
+    fn command_args(&self, message: &str) -> Vec<String> {
+        vec![
+            "run".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+            "--dangerously-skip-permissions".to_string(),
+            message.to_string(),
+        ]
+    }
+
+    fn command_args_with_session(&self, message: &str, session_id: Option<&str>, is_resume: bool) -> Vec<String> {
+        let mut args = vec![
+            "run".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+        ];
+        // Resume mode: use -s to specify existing session
+        if is_resume {
+            if let Some(sid) = session_id {
+                args.push("-s".to_string());
+                args.push(sid.to_string());
+            }
+        }
+        args.push("--dangerously-skip-permissions".to_string());
+        args.push(message.to_string());
+        args
+    }
+
+    fn supports_resume(&self) -> bool {
+        true
+    }
+
+    fn extract_session_id(&self, line: &str) -> Option<String> {
+        let event: ZhanluAgentEvent = serde_json::from_str(line).ok()?;
+        event.session_id.or_else(|| event.part.as_ref()?.session_id.clone())
+    }
+
+    fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
+        let event: ZhanluAgentEvent = serde_json::from_str(line).ok()?;
+        let timestamp = Self::resolve_timestamp(event.timestamp);
+
+        match event.event_type.as_str() {
+            "step_start" | "step-start" => self.handle_step_start(&timestamp),
+            "tool_use" | "tool-use" => self.handle_tool_use(event.part.as_ref()?, &timestamp),
+            "text" => self.handle_text(event.part.as_ref()?, &timestamp),
+            "step_finish" | "step-finish" => self.handle_step_finish(&event, &timestamp),
+            _ => None,
+        }
+    }
+
+    fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
+        super::default_final_result_with_think_stripping(logs)
+    }
+
+    fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
+        self.base.usage.lock().clone()
+    }
+
+    fn get_model(&self) -> Option<String> {
+        self.base.model.lock().clone()
+    }
+
+    fn check_success(&self, exit_code: i32) -> bool {
+        if exit_code == 0 {
+            return true;
+        }
+        // zhanlu returns non-zero exit codes (e.g. 144) even on successful execution,
+        // similar to opencode. Trust the presence of a step_finish event in the output stream.
+        *self.has_successful_finish.lock()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::ParsedLogEntry;
+
+    #[test]
+    fn test_parse_output_line_step_start() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"step_start","timestamp":1700000000000}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_start");
+        assert_eq!(entry.content, "Step started");
+    }
+
+    #[test]
+    fn test_parse_output_line_tool_use_bash() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"tool_use","timestamp":1700000000000,"part":{"type":"tool_use","tool":"bash","state":{"status":"success","input":{"description":"list files"},"output":"file.txt"}}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "tool");
+        assert!(entry.content.contains("success"), "content should contain status: {}", entry.content);
+        assert!(entry.content.contains("list files"), "content should contain description: {}", entry.content);
+        assert!(entry.content.contains("file.txt"), "content should contain output: {}", entry.content);
+    }
+
+    #[test]
+    fn test_parse_output_line_text() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"text","timestamp":1700000000000,"part":{"type":"text","text":"hello world"}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "text");
+        assert_eq!(entry.content, "hello world");
+    }
+
+    #[test]
+    fn test_parse_output_line_step_finish_stores_usage() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"step_finish","timestamp":1700000000000,"part":{"type":"step_finish","tokens":{"total":100,"input":50,"output":50,"cache":{"read":10,"write":5}},"cost":0.001}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_finish");
+        assert_eq!(entry.content, "Step finished");
+
+        let usage = executor.get_usage(&[]).unwrap();
+        assert_eq!(usage.input_tokens, 50);
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(usage.cache_read_input_tokens, Some(10));
+        assert_eq!(usage.cache_creation_input_tokens, Some(5));
+        assert_eq!(usage.total_cost_usd, Some(0.001));
+    }
+
+    #[test]
+    fn test_parse_output_line_unknown_type() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"unknown","timestamp":1700000000000}"#;
+        assert!(executor.parse_output_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_output_line_invalid_json() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = "not json";
+        assert!(executor.parse_output_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_output_line_empty_text() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"text","timestamp":1700000000000,"part":{"type":"text","text":""}}"#;
+        assert!(executor.parse_output_line(line).is_none());
+    }
+
+    #[test]
+    fn test_get_final_result_with_text() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let logs = vec![
+            ParsedLogEntry::new("text", "  hello world  "),
+        ];
+        assert_eq!(executor.get_final_result(&logs), Some("hello world".to_string()));
+    }
+
+    #[test]
+    fn test_get_final_result_fallback_to_stderr() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let logs = vec![
+            ParsedLogEntry::new("stderr", "error output"),
+        ];
+        assert_eq!(executor.get_final_result(&logs), Some("error output".to_string()));
+    }
+
+    #[test]
+    fn test_get_final_result_empty_logs() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let logs: Vec<ParsedLogEntry> = vec![];
+        assert!(executor.get_final_result(&logs).is_none());
+    }
+
+    #[test]
+    fn test_get_usage_before_step_finish() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        assert!(executor.get_usage(&[]).is_none());
+    }
+
+    #[test]
+    fn test_get_model_always_none() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        assert!(executor.get_model().is_none());
+    }
+
+    #[test]
+    fn test_check_success_exit_code_zero() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        assert!(executor.check_success(0));
+    }
+
+    #[test]
+    fn test_check_success_non_zero_without_step_finish() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        assert!(!executor.check_success(144));
+        assert!(!executor.check_success(1));
+    }
+
+    #[test]
+    fn test_check_success_non_zero_with_step_finish() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"step_finish","timestamp":1700000000000,"part":{"type":"step_finish","tokens":{"total":100,"input":50,"output":50,"cache":{"read":10,"write":5}},"cost":0.001}}"#;
+        let _ = executor.parse_output_line(line);
+        assert!(executor.check_success(144), "should succeed when step_finish was parsed even with non-zero exit code");
+    }
+
+    // Tests for the hyphenated type names (e.g., step-start, tool-use)
+    #[test]
+    fn test_parse_output_line_step_start_hyphenated() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"step-start","timestamp":1700000000000,"sessionID":"ses_xxx"}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_start");
+        assert_eq!(entry.content, "Step started");
+    }
+
+    #[test]
+    fn test_parse_output_line_tool_use_hyphenated() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"tool-use","timestamp":1700000000000,"part":{"type":"tool","tool":"bash","state":{"status":"completed","input":{"description":"list files"},"output":"file.txt"}}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "tool");
+        assert!(entry.content.contains("completed"), "content should contain status: {}", entry.content);
+    }
+
+    #[test]
+    fn test_parse_output_line_step_finish_hyphenated() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"step-finish","timestamp":1700000000000,"part":{"type":"step-finish","reason":"stop","tokens":{"total":100,"input":50,"output":50,"reasoning":0,"cache":{"read":10,"write":5}},"cost":0.001}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_finish");
+        assert_eq!(entry.content, "Step finished");
+
+        let usage = executor.get_usage(&[]).unwrap();
+        assert_eq!(usage.input_tokens, 50);
+        assert_eq!(usage.output_tokens, 50);
+    }
+
+    #[test]
+    fn test_check_success_with_step_finish_hyphenated() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"step-finish","timestamp":1700000000000,"part":{"type":"step-finish","tokens":{"total":100,"input":50,"output":50,"cache":{"read":10,"write":5}},"cost":0.001}}"#;
+        let _ = executor.parse_output_line(line);
+        assert!(executor.check_success(144), "should succeed when step-finish was parsed even with non-zero exit code");
+    }
+
+    #[test]
+    fn test_parse_actual_zhanlu_json_format() {
+        // Test with actual zhanlu output format (hyphenated types, sessionID)
+        // 这是与 opencode 完全一致的 JSON 结构——Issue #673 要求 zhanlu 输出格式
+        // 与 opencode 完全相同，所以这里使用的字段名/类型名都按 opencode 风格。
+        let executor = ZhanluExecutor::new("zl".to_string());
+
+        // Step start
+        let line = r#"{"type":"step-start","timestamp":1777471473403,"sessionID":"ses_xxx"}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_start");
+
+        // Text output
+        let line = r#"{"type":"text","timestamp":1777471505165,"sessionID":"ses_xxx","part":{"type":"text","text":"Hello, this is a test response"}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "text");
+        assert_eq!(entry.content, "Hello, this is a test response");
+
+        // Step finish
+        let line = r#"{"type":"step-finish","timestamp":1777471505168,"sessionID":"ses_xxx","part":{"type":"step-finish","reason":"stop","tokens":{"total":14155,"input":13862,"output":293,"reasoning":0,"cache":{"write":0,"read":0}},"cost":0}}"#;
+        let _ = executor.parse_output_line(line);
+
+        // Verify final result extraction
+        let logs = vec![
+            ParsedLogEntry::new("step_start", "Step started"),
+            ParsedLogEntry::new("text", "Hello, this is a test response"),
+            ParsedLogEntry::new("step_finish", "Step finished"),
+        ];
+        let result = executor.get_final_result(&logs);
+        assert_eq!(result, Some("Hello, this is a test response".to_string()));
+    }
+
+    /// 验证 zhanlu 的 executor_type 与 ExecutorType 枚举保持一致，
+    /// 防止以后修改 ExecutorType::Zhanlu 名字时忘记同步此处。
+    #[test]
+    fn test_executor_type_is_zhanlu() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        assert_eq!(executor.executor_type(), ExecutorType::Zhanlu);
+        assert_eq!(ExecutorType::Zhanlu.as_str(), "zhanlu");
+    }
+
+    /// zhanlu 与 opencode 行为一致：相同的命令行参数结构，确保 Issue #673
+    /// 「执行命令也一致」要求被满足。
+    #[test]
+    fn test_command_args_match_opencode_shape() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let args = executor.command_args("hello");
+        assert_eq!(args[0], "run");
+        assert_eq!(args[1], "--format");
+        assert_eq!(args[2], "json");
+        assert_eq!(args[3], "--dangerously-skip-permissions");
+        assert_eq!(args[4], "hello");
+    }
+}

--- a/backend/src/adapters/zhanlu_event.rs
+++ b/backend/src/adapters/zhanlu_event.rs
@@ -1,0 +1,104 @@
+//! Zhanlu-specific event parsing.
+//!
+//! Zhanlu 复用了 OpenCode 的事件格式（hyphenated event types，例如 step-start、tool-use），
+//! 并额外使用 camelCase 字段名（如 sessionID）。
+//!
+//! Issue #673 要求「行为跟 opencode 完全一致，执行命令也一致，返回输出 JSON 格式也一致」，
+//! 所以这里只把类型名从 Opencode 前缀重命名为 Zhanlu，serde 结构和字段映射保持完全一致。
+
+use std::collections::HashMap;
+use serde::Deserialize;
+
+/// Zhanlu agent event with hyphenated type names (与 OpenCode 完全相同的 JSON 结构)
+#[derive(Debug, Clone, Deserialize)]
+pub struct ZhanluAgentEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    #[serde(default)]
+    pub timestamp: Option<u64>,
+    #[serde(default, rename = "sessionID")]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub part: Option<ZhanluAgentPart>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ZhanluAgentPart {
+    #[serde(rename = "type")]
+    pub part_type: Option<String>,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub tool: Option<String>,
+    #[serde(default)]
+    pub call_id: Option<String>,
+    #[serde(default)]
+    pub state: Option<ZhanluAgentToolState>,
+    #[serde(default)]
+    pub message_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub tokens: Option<ZhanluAgentTokens>,
+    #[serde(default)]
+    pub cost: Option<f64>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ZhanluAgentToolState {
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub input: Option<ZhanluAgentToolInput>,
+    #[serde(default)]
+    pub output: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ZhanluAgentToolInput {
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+impl ZhanluAgentToolInput {
+    pub fn to_full_json(&self) -> String {
+        let mut map = serde_json::Map::new();
+        if let Some(ref cmd) = self.command {
+            map.insert("command".into(), serde_json::Value::String(cmd.clone()));
+        }
+        if let Some(ref desc) = self.description {
+            map.insert("description".into(), serde_json::Value::String(desc.clone()));
+        }
+        for (k, v) in &self.extra {
+            map.insert(k.clone(), v.clone());
+        }
+        serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ZhanluAgentTokens {
+    pub total: u64,
+    pub input: u64,
+    pub output: u64,
+    #[serde(default)]
+    pub reasoning: u64,
+    #[serde(default)]
+    pub cache: ZhanluAgentCacheTokens,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ZhanluAgentCacheTokens {
+    #[serde(default)]
+    pub read: u64,
+    #[serde(default)]
+    pub write: u64,
+}

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -80,7 +80,7 @@ pub enum TodoAction {
         #[arg(long)]
         stdin: bool,
 
-        /// Executor type (claudecode, mobilecoder, codebuddy, opencode, atomcode, hermes, kimi, codex, codewhale)
+        /// Executor type (claudecode, mobilecoder, codebuddy, opencode, atomcode, hermes, kimi, codex, codewhale, zhanlu)
         #[arg(short, long)]
         executor: Option<String>,
 

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -1125,6 +1125,8 @@ fn all_executor_skills_dirs() -> Vec<(&'static str, PathBuf)> {
         ("atomcode", home.join(".atomcode").join("skills")),
         ("kimi", home.join(".kimi").join("skills")),
         ("mobilecoder", home.join(".mobile-coder").join("skills")),
+        // Issue #673: Zhanlu skills 目录在 ~/.local/share/zhanlu/skills
+        ("zhanlu", home.join(".local/share/zhanlu").join("skills")),
     ]
 }
 

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -2073,9 +2073,10 @@ mod session_scanner_dispatch_tests {
 
     /// 重构前的 match 显式列出"无 session 存储"的 executor 名 (codebuddy 等)
     /// 也应当返 None;行为必须与原来逐分支对照一致。
+    /// Issue #673 新增的 zhanlu 也属于「暂无 scanner」的范畴,与 opencode/mimo 同列。
     #[test]
     fn get_scanner_returns_none_for_unsupported_executors() {
-        for name in ["codebuddy", "opencode", "mobilecoder", "mimo"] {
+        for name in ["codebuddy", "opencode", "mobilecoder", "mimo", "zhanlu"] {
             assert!(
                 get_scanner(name).is_none(),
                 "scanner for {name} should be None (no session storage found)"
@@ -2275,8 +2276,9 @@ mod session_scanner_tests {
             assert!(get_scanner(name).is_some(), "scanner {name} should be registered");
             assert_eq!(get_scanner(name).unwrap().name(), name);
         }
-        // 旧 match 中显式 None 的几个 executor 继续走 None 分支
-        for name in ["codebuddy", "opencode", "mobilecoder", "mimo", "unknown", ""] {
+        // 旧 match 中显式 None 的几个 executor 继续走 None 分支；
+        // Issue #673 新增的 zhanlu 同样不在 SCANNERS 内（与 opencode/mimo 一致）
+        for name in ["codebuddy", "opencode", "mobilecoder", "mimo", "zhanlu", "unknown", ""] {
             assert!(get_scanner(name).is_none(), "scanner {name} should NOT be registered");
         }
     }

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -527,7 +527,7 @@ fn executor_label_for_source(name: &str) -> &'static str {
 ///
 /// GET /api/skills - List skills grouped by executor
 ///
-/// 扫描 8 个 ExecutorType 之外，还扫 `~/.agents/skills`（只读 skill 来源）。
+/// 扫描 11 个 ExecutorType 之外，还扫 `~/.agents/skills`（只读 skill 来源）。
 /// agents 不参与 Todo 执行，但能在 Skills 总览/对比/同步里看到并使用。
 ///
 /// 实现选择：每个来源的目录 IO 放在 `spawn_blocking` 里跑，
@@ -537,7 +537,7 @@ pub async fn list_skills(
 ) -> Result<ApiResponse<Vec<ExecutorSkills>>, AppError> {
     // spawn_blocking：磁盘 IO 不能跑在 tokio reactor 上，否则会卡住其他请求
     let result = tokio::task::spawn_blocking(move || {
-        // 顺序遍历 10 个来源：单次调用只 IO 一次，顺序 vs 并行收益不大，
+        // 顺序遍历 12 个来源：单次调用只 IO 一次，顺序 vs 并行收益不大，
         // 而且顺序能保证响应里 source 顺序稳定，方便前端按位置渲染 Tab
         ALL_SKILL_SOURCES
             .iter()

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -133,7 +133,8 @@ fn executor_label(et: ExecutorType) -> &'static str {
 }
 
 // 保留 ALL_EXECUTORS 供其他可能用到的代码；新代码请用 ALL_SKILL_SOURCES
-// 12 = 11 个旧执行器 + Issue #673 新增的 Zhanlu
+// 12 = 10 个旧执行器 + Mimo (PR #669) + Issue #673 新增的 Zhanlu
+// 注意：加新执行器必须同时更新下面数组与本注释的计数，否则会出现 H1 同型错位。
 #[allow(dead_code)]
 const ALL_EXECUTORS: [ExecutorType; 12] = [
     ExecutorType::Claudecode,

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -36,6 +36,9 @@ pub fn executor_skills_dir_str(et: &str) -> Option<PathBuf> {
         "mobilecoder" => Some(home.join(".mobile-coder").join("skills")),
         "pi" => Some(home.join(".pi").join("skills")),
         "mimo" => Some(home.join(".local/share/mimocode").join("skills")),
+        // Zhanlu: Issue #673 新增执行器，session 路径为 ~/.local/share/zhanlu/storage，
+        // skills 目录与 session 目录同根
+        "zhanlu" => Some(home.join(".local/share/zhanlu").join("skills")),
         // agents 是只读 skill 来源：扫描但不参与执行器管理/Todo 执行
         "agents" => Some(home.join(".agents").join("skills")),
         _ => None,
@@ -125,12 +128,14 @@ fn executor_label(et: ExecutorType) -> &'static str {
         ExecutorType::Codewhale => "CodeWhale",
         ExecutorType::Pi => "Pi",
         ExecutorType::Mimo => "MiMo",
+        ExecutorType::Zhanlu => "Zhanlu",
     }
 }
 
 // 保留 ALL_EXECUTORS 供其他可能用到的代码；新代码请用 ALL_SKILL_SOURCES
+// 12 = 11 个旧执行器 + Issue #673 新增的 Zhanlu
 #[allow(dead_code)]
-const ALL_EXECUTORS: [ExecutorType; 10] = [
+const ALL_EXECUTORS: [ExecutorType; 12] = [
     ExecutorType::Claudecode,
     ExecutorType::Hermes,
     ExecutorType::Codex,
@@ -141,6 +146,8 @@ const ALL_EXECUTORS: [ExecutorType; 10] = [
     ExecutorType::Mobilecoder,
     ExecutorType::Codewhale,
     ExecutorType::Pi,
+    ExecutorType::Mimo,
+    ExecutorType::Zhanlu,
 ];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -491,7 +498,7 @@ fn discover_skills_for_executor(et: ExecutorType) -> ExecutorSkills {
 const ALL_SKILL_SOURCES: &[&str] = &[
     "claudecode", "codebuddy", "opencode", "atomcode",
     "hermes", "kimi", "mobilecoder", "codex",
-    "pi", "mimo",
+    "pi", "mimo", "zhanlu",
     "agents",
 ];
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -314,6 +314,7 @@ fn executor_skills_dir(et: &str) -> Option<PathBuf> {
 const ALL_EXECUTORS: &[&str] = &[
     "claudecode", "hermes", "codex", "codebuddy",
     "opencode", "atomcode", "kimi", "mobilecoder", "codewhale", "pi", "mimo",
+    "zhanlu",
 ];
 
 /// Install embedded ntd-usage skill to executor skill directories.

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -780,6 +780,7 @@ pub enum ExecutorType {
     Codewhale,
     Pi,
     Mimo,
+    Zhanlu,
 }
 
 
@@ -797,6 +798,7 @@ impl ExecutorType {
             ExecutorType::Codewhale => "codewhale",
             ExecutorType::Pi => "pi",
             ExecutorType::Mimo => "mimo",
+            ExecutorType::Zhanlu => "zhanlu",
         }
     }
 }

--- a/backend/src/services/usage_stats.rs
+++ b/backend/src/services/usage_stats.rs
@@ -153,6 +153,10 @@ impl UsageStatsService {
         let opencode_entries = self.load_opencode_jsonl_entries().await;
         all_entries.extend(opencode_entries);
 
+        // Zhanlu (Issue #673) - read from session files in ~/.local/share/zhanlu/storage
+        let zhanlu_entries = self.load_zhanlu_jsonl_entries().await;
+        all_entries.extend(zhanlu_entries);
+
         // Kimi - read from wire.jsonl files
         let kimi_entries = self.load_kimi_jsonl_entries().await;
         all_entries.extend(kimi_entries);
@@ -321,6 +325,28 @@ impl UsageStatsService {
         let opencode_dir2 = home.join(".opencode");
         if opencode_dir2.exists() {
             self.load_jsonl_files_from_dir(&opencode_dir2, "opencode", &mut entries).await;
+        }
+
+        entries
+    }
+
+    /// Load entries from Zhanlu session files (Issue #673)
+    ///
+    /// Zhanlu 的 session 存储路径与 opencode 类似但路径前缀不同：
+    /// Issue 中给出的默认 session 路径是 `~/.local/share/zhanlu/storage`。
+    /// 这里直接复用 `load_jsonl_files_from_dir` 的解析逻辑，因为 Zhanlu 与 Opencode
+    /// 输出一致（Issue #673 明确要求）。
+    async fn load_zhanlu_jsonl_entries(&self) -> Vec<RawUsageEntry> {
+        let mut entries = Vec::new();
+
+        let Some(home) = dirs::home_dir() else {
+            return entries;
+        };
+
+        // Zhanlu 默认 session 路径: ~/.local/share/zhanlu/storage
+        let zhanlu_dir = home.join(".local").join("share").join("zhanlu").join("storage");
+        if zhanlu_dir.exists() {
+            self.load_jsonl_files_from_dir(&zhanlu_dir, "zhanlu", &mut entries).await;
         }
 
         entries

--- a/backend/src/services/usage_stats.rs
+++ b/backend/src/services/usage_stats.rs
@@ -944,3 +944,95 @@ impl UsageStatsService {
         }).collect())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! 回归测试：Zhanlu (Issue #673) jsonl 走 `parse_generic_jsonl_line` 必须正确解析
+    //! `usage` / `timestamp` / `model` / cache token 字段，与 Opencode 行为一致。
+    //!
+    //! 该测试针对 PR #677 review H2 —— 之前 zhanlu jsonl 复用 opencode 解析器但
+    //! 没有专门的回归测试，运行时才能发现字段名是否真的 byte-for-byte 一致。
+    use super::*;
+    use std::sync::Arc;
+
+    /// 构造一个 UsageStatsService 实例用于测试其 impl 方法。
+    /// `parse_generic_jsonl_line` 是 &self 方法但不触碰 self.db，所以传任意 Database 即可。
+    async fn make_service() -> UsageStatsService {
+        let db = Arc::new(
+            crate::db::Database::new(":memory:")
+                .await
+                .expect("内存 db 必须能创建"),
+        );
+        UsageStatsService::new(db)
+    }
+
+    /// Zhanlu (与 Opencode 一致) 风格 jsonl：顶层 `usage` + `timestamp` + `model`。
+    /// 走 parse_generic_jsonl_line 后应填入对应字段。
+    #[tokio::test]
+    async fn test_parse_zhanlu_jsonl_step_with_usage() {
+        let svc = make_service().await;
+        let line = r#"{
+            "type": "step_start",
+            "sessionID": "ses_zhanlu_001",
+            "timestamp": "2026-06-18T12:34:56Z",
+            "model": "zhanlu-test-model",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_read_input_tokens": 20,
+                "cache_creation_input_tokens": 10
+            }
+        }"#;
+        let entry = svc
+            .parse_generic_jsonl_line(line, "ses_zhanlu_001", "/tmp/zhanlu")
+            .expect("zhanlu jsonl 应被 parse");
+
+        assert_eq!(entry.session_id, "ses_zhanlu_001");
+        assert_eq!(entry.project_path, "/tmp/zhanlu");
+        assert_eq!(entry.model.as_deref(), Some("zhanlu-test-model"));
+        assert_eq!(entry.input_tokens, 100);
+        assert_eq!(entry.output_tokens, 50);
+        assert_eq!(entry.cache_read_tokens, 20);
+        assert_eq!(entry.cache_creation_tokens, 10);
+        assert_eq!(entry.date, "2026-06-18");
+    }
+
+    /// Zhanlu 把 usage 嵌进 `data.usage`（与 Opencode 嵌套形态一致）也能被解析。
+    /// 这是 parse_generic_jsonl_line 的 fallback 分支，必须能正确回退。
+    #[tokio::test]
+    async fn test_parse_zhanlu_jsonl_nested_data_usage() {
+        let svc = make_service().await;
+        let line = r#"{
+            "type": "step_finish",
+            "data": {
+                "usage": {
+                    "input_tokens": 200,
+                    "output_tokens": 80,
+                    "cache_creation_input_tokens": 5
+                },
+                "model": "nested-zhanlu-model"
+            },
+            "created_at": "2026-06-18T13:00:00Z"
+        }"#;
+        let entry = svc
+            .parse_generic_jsonl_line(line, "ses_zhanlu_002", "/tmp/zhanlu")
+            .expect("嵌套 data.usage 应被 parse");
+
+        assert_eq!(entry.input_tokens, 200);
+        assert_eq!(entry.output_tokens, 80);
+        assert_eq!(entry.cache_creation_tokens, 5);
+        assert_eq!(entry.cache_read_tokens, 0); // 字段缺失 → 0
+        assert_eq!(entry.model.as_deref(), Some("nested-zhanlu-model"));
+        assert_eq!(entry.date, "2026-06-18");
+    }
+
+    /// 没有 usage 字段的行（如纯文本 / metadata）应返回 None，不污染 entries。
+    #[tokio::test]
+    async fn test_parse_zhanlu_jsonl_skips_non_usage_lines() {
+        let svc = make_service().await;
+        let line = r#"{"type": "text", "text": "hello"}"#;
+        assert!(svc
+            .parse_generic_jsonl_line(line, "ses_zhanlu_003", "/tmp/zhanlu")
+            .is_none());
+    }
+}

--- a/backend/tests/business_logic_tests.rs
+++ b/backend/tests/business_logic_tests.rs
@@ -123,6 +123,8 @@ mod executor_type_tests {
         assert_eq!(ExecutorType::Mobilecoder.to_string(), "mobilecoder");
         assert_eq!(ExecutorType::Codebuddy.to_string(), "codebuddy");
         assert_eq!(ExecutorType::Codex.to_string(), "codex");
+        // Issue #673: Zhanlu 应当序列化为 "zhanlu"
+        assert_eq!(ExecutorType::Zhanlu.to_string(), "zhanlu");
     }
 
     #[test]
@@ -137,6 +139,10 @@ mod executor_type_tests {
         assert_eq!(parse_executor_type("mobilecoder"), Some(ExecutorType::Mobilecoder));
         assert_eq!(parse_executor_type("codebuddy"), Some(ExecutorType::Codebuddy));
         assert_eq!(parse_executor_type("codex"), Some(ExecutorType::Codex));
+        // Issue #673: parse_executor_type 必须能识别 zhanlu（含别名 zhanlucode / zl）
+        assert_eq!(parse_executor_type("zhanlu"), Some(ExecutorType::Zhanlu));
+        assert_eq!(parse_executor_type("zhanlucode"), Some(ExecutorType::Zhanlu));
+        assert_eq!(parse_executor_type("zl"), Some(ExecutorType::Zhanlu));
     }
 
     #[test]

--- a/backend/tests/executor_tests.rs
+++ b/backend/tests/executor_tests.rs
@@ -6,6 +6,7 @@ use ntd::adapters::opencode::OpencodeExecutor;
 use ntd::adapters::atomcode::AtomcodeExecutor;
 use ntd::adapters::mobilecoder::MobilecoderExecutor;
 use ntd::adapters::codex::CodexExecutor;
+use ntd::adapters::zhanlu::ZhanluExecutor;
 use ntd::models::{ParsedLogEntry, ExecutorType};
 
 #[cfg(test)]
@@ -386,6 +387,82 @@ mod opencode_executor_tests {
         let executor = OpencodeExecutor::new("opencode".to_string());
         assert!(executor.check_success(0));
         assert!(!executor.check_success(1));
+    }
+}
+
+// Issue #673: Zhanlu 测试
+// 行为与 opencode 完全一致：相同的命令行参数、相同的 JSON 输出格式、相同的退出码语义。
+#[cfg(test)]
+mod zhanlu_executor_tests {
+    use super::*;
+
+    #[test]
+    fn test_zhanlu_executor_type() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        assert_eq!(executor.executor_type(), ExecutorType::Zhanlu);
+    }
+
+    #[test]
+    fn test_zhanlu_command_args() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let args = executor.command_args("say hello");
+        assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
+        assert!(args.contains(&"--format".to_string()));
+        assert!(args.contains(&"json".to_string()));
+        assert!(args.contains(&"say hello".to_string()));
+    }
+
+    #[test]
+    fn test_zhanlu_check_success() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        assert!(executor.check_success(0));
+        assert!(!executor.check_success(1));
+    }
+
+    #[test]
+    fn test_zhanlu_supports_resume() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        assert!(executor.supports_resume());
+    }
+
+    #[test]
+    fn test_zhanlu_parse_step_start() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"step_start","timestamp":1700000000000}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_start");
+    }
+
+    #[test]
+    fn test_zhanlu_parse_text() {
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"text","timestamp":1700000000000,"part":{"type":"text","text":"hi from zhanlu"}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "text");
+        assert_eq!(entry.content, "hi from zhanlu");
+    }
+
+    #[test]
+    fn test_zhanlu_extract_session_id_from_hyphenated_format() {
+        // Issue #673 要求与 opencode 输出一致，所以 sessionID 也是 camelCase
+        let executor = ZhanluExecutor::new("zl".to_string());
+        let line = r#"{"type":"step-start","timestamp":1700000000000,"sessionID":"ses_zhanlu_001"}"#;
+        assert_eq!(executor.extract_session_id(line), Some("ses_zhanlu_001".to_string()));
+    }
+
+    /// 行为对齐检查：与 opencode 完全一致地解析相同的 JSON 输入，应当产出相同的 ParsedLogEntry。
+    /// 这是 Issue #673「输出 JSON 格式也一致」的端到端证据。
+    #[test]
+    fn test_zhanlu_matches_opencode_on_same_json() {
+        let opencode = OpencodeExecutor::new("opencode".to_string());
+        let zhanlu = ZhanluExecutor::new("zl".to_string());
+
+        let line = r#"{"type":"tool-use","timestamp":1700000000000,"part":{"type":"tool","tool":"bash","state":{"status":"completed","input":{"description":"echo"},"output":"ok"}}}"#;
+        let o = opencode.parse_output_line(line).unwrap();
+        let z = zhanlu.parse_output_line(line).unwrap();
+        assert_eq!(o.log_type, z.log_type);
+        assert_eq!(o.content, z.content);
+        assert_eq!(o.tool_name, z.tool_name);
     }
 }
 

--- a/docs/ADD_EXECUTOR_GUIDE.md
+++ b/docs/ADD_EXECUTOR_GUIDE.md
@@ -32,6 +32,7 @@
 
 - `claude_code.rs`：Claude 风格 stream-json。
 - `opencode.rs`：事件流中包含 step、tool、text、tokens。
+- `zhanlu.rs`：与 opencode 完全一致的协议族（Issue #673 直接复制而成），后续可能演化独立。
 - `kimi.rs`：OpenAI chat message 风格 JSONL。
 - `codex.rs`：宽松解析不同 JSONL 事件字段。
 

--- a/docs/user-guide/features/skills-overview.md
+++ b/docs/user-guide/features/skills-overview.md
@@ -10,7 +10,7 @@ Skills 是 ntd 帮各执行器管理的**预制 prompt 模板**，类似 Claude 
 
 | 来源 | 目录 | 可写 | 说明 |
 |------|------|------|------|
-| `claudecode` / `codebuddy` / `opencode` / `atomcode` / `hermes` / `kimi` / `mobilecoder` / `codex` / `pi` | `~/.{executor}/skills/` | ✅ | 9 个真实执行器，有 skills 目录映射 |
+| `claudecode` / `codebuddy` / `opencode` / `atomcode` / `hermes` / `kimi` / `mobilecoder` / `codex` / `pi` / `mimo` / `zhanlu` | `~/.{executor}/skills/` | ✅ | 11 个真实执行器，有 skills 目录映射 |
 | `codewhale` | — | — | 是执行器，但**没有** skills 目录映射（不在扫描列表中） |
 | `agents` | `~/.agents/skills/` | ❌ | **只读来源**，扫描但不参与 Todo 执行 |
 

--- a/docs/user-guide/settings/executors.md
+++ b/docs/user-guide/settings/executors.md
@@ -24,6 +24,8 @@
 | `codex` | Codex CLI | `codex` | `~/.codex` |
 | `codewhale` | CodeWhale CLI | `codewhale` | `~/.codewhale` |
 | `pi` | Pi CLI | `pi` | `~/.pi` |
+| `mimo` | MiMo CLI | `mimo` | `~/.local/share/mimocode` |
+| `zhanlu` | Zhanlu CLI | `zl` | `~/.local/share/zhanlu/storage` |
 
 > 默认路径这一列在 `EXECUTORS` 里其实就是裸命令名（`claude` / `codebuddy` / ...），后端默认走 `$PATH`解析（不是绝对路径）。若要使用绝对路径，在「修改配置」里覆盖即可。Session目录只在切换/续接对话时用到。
 

--- a/docs/user-guide/settings/sessions.md
+++ b/docs/user-guide/settings/sessions.md
@@ -40,7 +40,7 @@ Session 是 ntd 把**跨执行器的会话**统一抽象出来的视图。原先
 
 后端 `session.rs`启动时 +定期扫描这些目录，解析 jsonl文件提取元信息。
 
-> `codebuddy` / `opencode` / `mobilecoder` / `codewhale` **不**在扫描范围内（参见 `session.rs::scan_for_executors` 的 `match executor`）。原文档提到的 `cc-connect` 来源也已移除。
+> `codebuddy` / `opencode` / `mobilecoder` / `codewhale` / `zhanlu` **不**在扫描范围内（参见 `session.rs::scan_for_executors` 的 `match executor`）。原文档提到的 `cc-connect` 来源也已移除。
 >
 > **Pi 编码坑点**：pi 把 cwd 里的 `/` 替换为 `-` 并在头尾各加一个 `-` 作为项目目录名（`/Users/weibh/projects/rust/nothing-todo` → `--Users-weibh-projects-rust-nothing-todo--`）。这导致项目名里的 `-` 与分隔符不可区分（例如上例解码后会变成 `Users/weibh/projects/rust/nothing/todo`）。`scan_pi` 优先使用 JSONL 首行 `cwd` 字段，文件名解码仅作为 fallback。
 

--- a/docs/user-guide/settings/skills.md
+++ b/docs/user-guide/settings/skills.md
@@ -16,7 +16,7 @@
 
 ## 与执行器的关系
 
-- **9 个真实执行器**（`claudecode` / `codebuddy` / `opencode` / `atomcode` / `hermes` / `kimi` / `mobilecoder` / `codex` / `pi`）有 skills 目录映射，可写
+- **11 个真实执行器**（`claudecode` / `codebuddy` / `opencode` / `atomcode` / `hermes` / `kimi` / `mobilecoder` / `codex` / `pi` / `mimo` / `zhanlu`）有 skills 目录映射，可写
 - `codewhale` 是执行器但**没有** skills 目录映射
 - `agents` 是只读来源，扫描但不参与 Todo 执行；不出现于「执行器管理」标签
 

--- a/frontend/src/components/sessions/helpers.tsx
+++ b/frontend/src/components/sessions/helpers.tsx
@@ -10,6 +10,8 @@ export const sourceConfig: Record<string, { label: string; color: string }> = {
   'codebuddy': { label: 'CodeBuddy', color: '#f59e0b' },
   'opencode': { label: 'OpenCode', color: '#22c55e' },
   'mobilecoder': { label: 'MobileCoder', color: '#6366f1' },
+  // Issue #673: zhanlu 与 opencode 输出格式一致，使用相近色便于视觉区分
+  'zhanlu': { label: 'Zhanlu', color: '#0f766e' },
 };
 
 export function sourceTag(source: string) {

--- a/frontend/src/components/sessions/helpers.tsx
+++ b/frontend/src/components/sessions/helpers.tsx
@@ -1,17 +1,18 @@
 import { Tag } from 'antd';
 import { formatTokens, formatRelativeTimeFromNow } from '@/utils/format';
+import { EXECUTOR_COLORS } from '@/types/execution';
 
 export const sourceConfig: Record<string, { label: string; color: string }> = {
-  'claudecode': { label: 'Claude Code', color: '#d97706' },
-  'codex': { label: 'Codex', color: '#10a37f' },
-  'hermes': { label: 'Hermes', color: '#8b5cf6' },
-  'kimi': { label: 'Kimi', color: '#3b82f6' },
-  'atomcode': { label: 'AtomCode', color: '#ef4444' },
-  'codebuddy': { label: 'CodeBuddy', color: '#f59e0b' },
-  'opencode': { label: 'OpenCode', color: '#22c55e' },
-  'mobilecoder': { label: 'MobileCoder', color: '#6366f1' },
-  // Issue #673: zhanlu 与 opencode 输出格式一致，使用相近色便于视觉区分
-  'zhanlu': { label: 'Zhanlu', color: '#0f766e' },
+  'claudecode': { label: 'Claude Code', color: EXECUTOR_COLORS.claudecode },
+  'codex': { label: 'Codex', color: EXECUTOR_COLORS.codex },
+  'hermes': { label: 'Hermes', color: EXECUTOR_COLORS.hermes },
+  'kimi': { label: 'Kimi', color: EXECUTOR_COLORS.kimi },
+  'atomcode': { label: 'AtomCode', color: EXECUTOR_COLORS.atomcode },
+  'codebuddy': { label: 'CodeBuddy', color: EXECUTOR_COLORS.codebuddy },
+  'opencode': { label: 'OpenCode', color: EXECUTOR_COLORS.opencode },
+  'mobilecoder': { label: 'MobileCoder', color: EXECUTOR_COLORS.mobilecoder },
+  // Issue #673: zhanlu 颜色从 EXECUTOR_COLORS 取，保持与 execution.tsx 单点 SoT。
+  'zhanlu': { label: 'Zhanlu', color: EXECUTOR_COLORS.zhanlu },
 };
 
 export function sourceTag(source: string) {

--- a/frontend/src/types/execution.tsx
+++ b/frontend/src/types/execution.tsx
@@ -169,7 +169,8 @@ export const EXECUTORS: ExecutorOption[] = [
   { value: 'pi',        label: 'Pi',        color: '#8e44ad', icon: <FaSquare color="#8e44ad" size={14} /> },
   { value: 'mimo',      label: 'MiMo',      color: '#ff6b6b', icon: <FaSquare color="#ff6b6b" size={14} /> },
   // Issue #673: 新增 Zhanlu 执行器，与 Opencode 输出格式一致
-  { value: 'zhanlu',    label: 'Zhanlu',    color: '#2d3436', icon: <FaSquare color="#2d3436" size={14} /> },
+  // 颜色与下方 EXECUTOR_COLORS.zhanlu 同步为 #0f766e，与 agents(#2d3436) 视觉可分。
+  { value: 'zhanlu',    label: 'Zhanlu',    color: '#0f766e', icon: <FaSquare color="#0f766e" size={14} /> },
   // `agents` is read-only skill source (`~/.agents/skills`), not shown in executor management.
   // Included here so it appears in Skills overview/sync tabs.
   { value: 'agents',     label: 'Agents',    color: '#2d3436', icon: <FaSquare color="#2d3436" size={14} /> },
@@ -187,7 +188,9 @@ export const EXECUTOR_COLORS: Record<string, string> = {
   codewhale: '#00cec9',
   pi: '#8e44ad',
   mimo: '#ff6b6b',
-  zhanlu: '#2d3436',
+  // Issue #673 + PR #677 review H1：zhanlu 颜色与 agents 撞色（都是 #2d3436），
+  // 改为深青 `#0f766e` 与 opencode 的 `#fdcb6e` / agents 的 `#2d3436` 视觉可分。
+  zhanlu: '#0f766e',
   agents: '#2d3436',
   // Aliases for backward compatibility with database names
   'claude_code': '#e17055',

--- a/frontend/src/types/execution.tsx
+++ b/frontend/src/types/execution.tsx
@@ -168,6 +168,8 @@ export const EXECUTORS: ExecutorOption[] = [
   { value: 'codewhale',  label: 'CodeWhale', color: '#00cec9', icon: <FaSquare color="#00cec9" size={14} /> },
   { value: 'pi',        label: 'Pi',        color: '#8e44ad', icon: <FaSquare color="#8e44ad" size={14} /> },
   { value: 'mimo',      label: 'MiMo',      color: '#ff6b6b', icon: <FaSquare color="#ff6b6b" size={14} /> },
+  // Issue #673: 新增 Zhanlu 执行器，与 Opencode 输出格式一致
+  { value: 'zhanlu',    label: 'Zhanlu',    color: '#2d3436', icon: <FaSquare color="#2d3436" size={14} /> },
   // `agents` is read-only skill source (`~/.agents/skills`), not shown in executor management.
   // Included here so it appears in Skills overview/sync tabs.
   { value: 'agents',     label: 'Agents',    color: '#2d3436', icon: <FaSquare color="#2d3436" size={14} /> },
@@ -185,6 +187,7 @@ export const EXECUTOR_COLORS: Record<string, string> = {
   codewhale: '#00cec9',
   pi: '#8e44ad',
   mimo: '#ff6b6b',
+  zhanlu: '#2d3436',
   agents: '#2d3436',
   // Aliases for backward compatibility with database names
   'claude_code': '#e17055',
@@ -203,7 +206,7 @@ export function getExecutorOption(value: string): ExecutorOption {
   return EXECUTORS.find(e => e.value === value.toLowerCase()) || EXECUTORS[0];
 }
 
-export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'mobilecoder', 'hermes', 'codewhale', 'pi', 'mimo']);
+export const RESUMABLE_EXECUTORS = new Set(['claudecode', 'kimi', 'opencode', 'mobilecoder', 'hermes', 'codewhale', 'pi', 'mimo', 'zhanlu']);
 
 /// 默认执行器
 export const DEFAULT_EXECUTOR = 'claudecode';

--- a/frontend/src/utils/commandExtractor.ts
+++ b/frontend/src/utils/commandExtractor.ts
@@ -113,18 +113,19 @@ function extractClaudeCommands(logs: LogEntry[]): CommandEntry[] {
 }
 
 /**
- * Group B: Agent 协议族（opencode / mobilecoder / mimo）
+ * Group B: Agent 协议族（opencode / mobilecoder / mimo / zhanlu）
  *
  * - 单条 log_type=tool，content 含 description + output + status
  * - 由于后端 claudecode-style 工具信息存到 toolName/toolInputJson，
- *   而 opencode 等把一切都塞 content；本函数同时尝试两条路径。
+ *   而 opencode/zhanlu 等把一切都塞 content；本函数同时尝试两条路径。
+ * - Issue #673：zhanlu 与 opencode 行为/输出完全一致，复用同一套提取逻辑。
  */
 function extractAgentCommands(logs: LogEntry[]): CommandEntry[] {
   const result: CommandEntry[] = [];
   for (const log of logs) {
     if (log.type !== 'tool' || !isBashTool(log.toolName)) continue;
     const input = parseJsonSafe(log.toolInputJson);
-    // opencode 把 input/output/status 放在 part.state
+    // opencode/zhanlu 把 input/output/status 放在 part.state
     const state = (input?.state as Record<string, unknown>) || input;
     const inner = (state?.input as Record<string, unknown>) || state;
     const command = (inner?.command as string) || (inner?.description as string) || '';
@@ -515,6 +516,8 @@ export function extractCommandsByExecutor(
     case 'opencode':
     case 'mobilecoder':
     case 'mimo':
+    // Issue #673: zhanlu 与 opencode 输出 JSON 格式一致，复用 Agent 协议提取
+    case 'zhanlu':
       return extractAgentCommands(logs);
     case 'kimi':
       return extractKimiCommands(logs);

--- a/frontend/src/utils/database/bots.ts
+++ b/frontend/src/utils/database/bots.ts
@@ -269,7 +269,7 @@ export async function createFeishuBinding(params: {
   chat_id: string;
   chat_type: string;
   project_dir_id: number;
-  /** 指定执行器（可选，仅在新建 Todo 时使用）。仅支持 claudecode/kimi/opencode/mobilecoder/hermes/codewhale */
+  /** 指定执行器（可选，仅在新建 Todo 时使用）。仅支持 claudecode/kimi/opencode/mobilecoder/hermes/codewhale/zhanlu */
   executor?: string;
   /** 绑定到已有 Todo（可选）。提供后表示复用该 Todo 的历史会话，与 executor 互斥 */
   todo_id?: number;

--- a/frontend/tests/issue-648-command-extractor.spec.ts
+++ b/frontend/tests/issue-648-command-extractor.spec.ts
@@ -329,6 +329,8 @@ test.describe('commandExtractor — Issue #648', () => {
         opencode: mod.extractCommandsByExecutor(logs, 'opencode').length,
         mobilecoder: mod.extractCommandsByExecutor(logs, 'mobilecoder').length,
         mimo: mod.extractCommandsByExecutor(logs, 'mimo').length,
+        // Issue #673: zhanlu 与 opencode 输出格式一致，复用 Agent 协议提取
+        zhanlu: mod.extractCommandsByExecutor(logs, 'zhanlu').length,
         hermes: mod.extractCommandsByExecutor(logs, 'hermes').length,
         unknown: mod.extractCommandsByExecutor(logs, 'something-new').length,
       };
@@ -336,6 +338,7 @@ test.describe('commandExtractor — Issue #648', () => {
     expect(result.opencode).toBe(1);
     expect(result.mobilecoder).toBe(1);
     expect(result.mimo).toBe(1);
+    expect(result.zhanlu).toBe(1);
     expect(result.hermes).toBe(0);
     // 未知执行器走 Claude fallback — 上面那条日志不是 Claude 协议，应是 0
     expect(result.unknown).toBe(0);


### PR DESCRIPTION
## 概述

新增 Zhanlu (二进制名 zl) 执行器，与 Opencode 行为完全一致。

## 关联 Issue

Closes #673

## 变更点

### 新增文件
- `backend/src/adapters/zhanlu.rs` — ZhanluExecutor 完整实现
- `backend/src/adapters/zhanlu_event.rs` — JSON 事件 schema（与 Opencode 完全相同）

### 修改文件
- `backend/src/models/mod.rs` — ExecutorType 新增 Zhanlu 变体
- `backend/src/adapters/mod.rs` — 注册 zhanlu（含别名 zhanlucode / zl）+ 单元测试
- `backend/src/main.rs` — ALL_EXECUTORS 加入 zhanlu
- `backend/src/cli/commands.rs` — 文档注释补充
- `backend/src/handlers/skills.rs` — skills 目录映射 ~/.local/share/zhanlu/skills
- `backend/src/handlers/backup.rs` — 备份目标加入 zhanlu
- `backend/src/handlers/session.rs` — 测试覆盖（无 scanner，与 opencode 一致）
- `backend/src/services/usage_stats.rs` — 从 ~/.local/share/zhanlu/storage 读 jsonl
- `backend/tests/executor_tests.rs` — 新增 8 个 zhanlu 单元测试
- `backend/tests/business_logic_tests.rs` — 新增 3 个 ExecutorType 相关测试
- `frontend/src/types/execution.tsx` — EXECUTORS / EXECUTOR_COLORS / RESUMABLE_EXECUTORS 加 zhanlu
- `frontend/src/utils/commandExtractor.ts` — zhanlu 复用 Agent 协议提取
- `frontend/src/utils/database/bots.ts` — 注释补充
- `frontend/src/components/sessions/helpers.tsx` — sourceConfig 加入 zhanlu
- `frontend/tests/issue-648-command-extractor.spec.ts` — 派发测试加入 zhanlu
- `docs/ADD_EXECUTOR_GUIDE.md` — 文档同步
- `docs/user-guide/settings/executors.md` — 执行器表格加入 zhanlu
- `docs/user-guide/settings/sessions.md` — 排除扫描列表加入 zhanlu
- `docs/user-guide/settings/skills.md` — 数量从 9 更新为 11
- `docs/user-guide/features/skills-overview.md` — 表格同步

## 设计决策

1. **不复用 opencode.rs**：按 Issue #673 明确要求「不要共用一份代码」，完整复制一份独立维护
2. **JSON 协议完全相同**：step_start / step-start, tool_use / tool-use, text, step_finish / step-finish
3. **sessionID 提取**：使用 camelCase sessionID（与 Opencode 一致）
4. **别名**：zhanlu (主) / zhanlucode / zl
5. **路径**：默认 PATH 查找 zl，session 路径 ~/.local/share/zhanlu/storage

## 测试

```
cargo test --lib → 673 passed, 0 failed (含 8 个 zhanlu 单元测试 + 1 个 parse_executor_type 测试)
cargo test --test executor_tests → 63 passed, 0 failed (含 8 个 zhanlu 测试)
cargo test --test business_logic_tests → 28 passed, 0 failed
```

注意：`test_claude_command_args_with_session_new` 在 main 上就存在失败，与本次改动无关。

## 验证证据

- ✅ 后端 lib 构建成功（0 errors, 仅 3 个预存在 warnings）
- ✅ 8 个 zhanlu 单元测试全部通过
- ✅ 与 Opencode 输出格式一致（对比测试通过：test_zhanlu_matches_opencode_on_same_json）
- ✅ parse_executor_type 正确识别 zhanlu / zhanlucode / zl / ZHANLU