### PR TITLE
fix: 无环路时左侧列表增加新建按钮

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -228,6 +228,15 @@ function AppContent() {
               loopUpdateCount={loopUpdateCount}
               onShowSettings={() => { clearSelection(); showView('settings'); }}
               onSelectLoop={handleSelectLoop}
+              onCreateLoop={async () => {
+                try {
+                  const res = await dbLoops.createLoop({ name: '新建环路', description: '' });
+                  setSelectedLoopId(res.id);
+                  setLoopUpdateCount(c => c + 1);
+                } catch (err) {
+                  message.error('创建失败');
+                }
+              }}
             />
           </div>
 

--- a/frontend/src/components/LoopStudioListPanel.tsx
+++ b/frontend/src/components/LoopStudioListPanel.tsx
@@ -10,11 +10,12 @@
 // - 单击切换 selectedId, 父组件维护; 当前选中卡片左侧条加亮 + 边框高亮
 
 import { useMemo, useState } from 'react';
-import { Tag, Segmented } from 'antd';
+import { Button, Tag, Segmented } from 'antd';
 import {
   ClockCircleOutlined,
   ApartmentOutlined,
   ThunderboltOutlined,
+  PlusOutlined,
   CheckCircleOutlined,
   CloseCircleOutlined,
   LoadingOutlined,
@@ -29,6 +30,7 @@ interface LoopListPanelProps {
   loops: LoopListItem[];
   selectedId: number | null;
   onSelect: (id: number) => void;
+  onCreate?: () => void;
 }
 
 // 状态 → 标签颜色, 集中在一处方便复用
@@ -69,7 +71,7 @@ function countByStatus(loops: LoopListItem[], filter: StatusFilter): number {
   return loops.filter(l => (l.status as LoopStatus) === filter).length;
 }
 
-export function LoopListPanel({ loops, selectedId, onSelect }: LoopListPanelProps) {
+export function LoopListPanel({ loops, selectedId, onSelect, onCreate }: LoopListPanelProps) {
   // 状态过滤状态, 默认全部; 本地持有, 切 loop 时不重置
   const [filter, setFilter] = useState<StatusFilter>('all');
 
@@ -119,9 +121,22 @@ export function LoopListPanel({ loops, selectedId, onSelect }: LoopListPanelProp
       {/* 卡片列表: flex 1 占满剩余空间, 内部滚动 */}
       <div style={{ flex: 1, minHeight: 0, overflow: 'auto', padding: 8 }}>
         {filtered.length === 0 ? (
-          <div style={{ padding: '40px 16px', textAlign: 'center', color: 'var(--color-text-tertiary, #94a3b8)', fontSize: 13 }}>
-            该状态下暂无 loop
-          </div>
+          loops.length === 0 ? (
+            <div style={{ padding: '40px 16px', textAlign: 'center' }}>
+              <div style={{ color: 'var(--color-text-tertiary, #94a3b8)', fontSize: 13, marginBottom: 16 }}>
+                暂无环路，创建第一个环路开始自动化
+              </div>
+              {onCreate && (
+                <Button type="primary" icon={<PlusOutlined />} onClick={onCreate}>
+                  新建环路
+                </Button>
+              )}
+            </div>
+          ) : (
+            <div style={{ padding: '40px 16px', textAlign: 'center', color: 'var(--color-text-tertiary, #94a3b8)', fontSize: 13 }}>
+              该状态下暂无 loop
+            </div>
+          )
         ) : (
           filtered.map(loop => (
             <LoopCard

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -27,6 +27,7 @@ interface TodoListProps {
   onShowSettings?: () => void;
   onSelectLoop?: (loopId: number) => void;
   onSelectStep?: (stepId: number) => void;
+  onCreateLoop?: () => void;
   stepUpdateCount?: number;
   loopUpdateCount?: number;
 }
@@ -79,7 +80,7 @@ function buildDesktopNavActions(
 }
 
 export function TodoList(props: TodoListProps) {
-  const { onOpenCreateModal, onOpenSmartCreate, onSelectTodo, onShowDashboard, onShowMemorial, onShowRelationMap, onShowSettings, onSelectLoop, onSelectStep, stepUpdateCount, loopUpdateCount } = props;
+  const { onOpenCreateModal, onOpenSmartCreate, onSelectTodo, onShowDashboard, onShowMemorial, onShowRelationMap, onShowSettings, onSelectLoop, onSelectStep, onCreateLoop, stepUpdateCount, loopUpdateCount } = props;
   const { state, dispatch } = useApp();
   const { themeMode, toggleTheme } = useTheme();
   const { todos, selectedTodoId, selectedTagId, selectedWorkspace, tags } = state;
@@ -702,6 +703,7 @@ export function TodoList(props: TodoListProps) {
                 setSelectedLoopId(id);
                 onSelectLoop?.(id);
               }}
+              onCreate={onCreateLoop}
             />
           )}
         </div>


### PR DESCRIPTION
## 问题

当没有任何环路时，左侧 `LoopListPanel` 只显示「该状态下暂无 loop」的文字提示。而创建环路的唯一入口在右侧详情面板中，但选中环路才能看到右侧面板——导致永远无法创建第一个环路。

## 修改

- **LoopStudioListPanel.tsx**: 新增 `onCreate` 回调 prop，空状态时区分「全局无环路」和「过滤后为空」，无环路时显示引导文案 +「新建环路」主按钮
- **TodoList.tsx**: 透传 `onCreateLoop` prop
- **App.tsx**: 传入 `onCreateLoop` handler，复用已有创建逻辑

## 效果

环路列表为空时，用户可直接点击左侧栏的「新建环路」按钮创建第一个环路。