### PR TITLE
feat(loop-flow): loop 环节执行继承工作空间 git worktree 配置

### DIFF
--- a/backend/src/executor_service/auto_review.rs
+++ b/backend/src/executor_service/auto_review.rs
@@ -319,6 +319,7 @@ async fn execute_review_instance(
         loop_step_execution_id: None,
             step_id: None,        feishu_bot_id: None,
         feishu_receive_id: None,
+        workspace: None,
     };
     let exec_result = super::run_todo_execution(request).await;
     exec_result

--- a/backend/src/executor_service/mod.rs
+++ b/backend/src/executor_service/mod.rs
@@ -80,6 +80,10 @@ pub struct RunTodoExecutionRequest {
     pub loop_step_execution_id: Option<i64>,
     /// 环节 id（steps 表），环节独立执行时设置
     pub step_id: Option<i64>,
+    /// 显式工作空间路径（用于 loop 场景：loop 有自己的 workspace，
+    /// 但 executor service 内部通过 todo 加载获取 workspace。当 todo 不存在
+    /// 或 todo_id=0 时，使用此字段作为 workspace 用于 worktree 创建和 cwd 回退）。
+    pub workspace: Option<String>,
 }
 
 /// Run a todo execution. Priority: explicit executor > todo stored executor > default.

--- a/backend/src/executor_service/pre_spawn.rs
+++ b/backend/src/executor_service/pre_spawn.rs
@@ -350,6 +350,9 @@ pub(crate) async fn create_run_execution_record(
         Ok(id) => id,
         Err(e) => return Err(e),
     };
+    // todo_workspace 优先来自 todo；当 todo 不存在（loop 环节执行）时回退到 request.workspace，
+    // 确保 worktree 创建失败后子进程 cwd 仍然是 loop 的 workspace。
+    let todo_workspace = selected.todo_workspace.or_else(|| request.workspace.clone());
     Ok(super::types::PreparedExecution {
         request,
         task_guard: task_state.task_guard,
@@ -361,7 +364,7 @@ pub(crate) async fn create_run_execution_record(
         executor_str: selected.executor_str,
         record_id,
         todo,
-        todo_workspace: selected.todo_workspace,
+        todo_workspace,
         timeout_secs,
     })
 }

--- a/backend/src/executor_service/stages.rs
+++ b/backend/src/executor_service/stages.rs
@@ -113,7 +113,12 @@ pub(crate) fn read_runtime_config(request: &RunTodoExecutionRequest) -> (u32, u6
 pub(crate) async fn start_todo_and_prepare_spawn(
     prepared: PreparedExecution,
 ) -> Result<SpawnInputs, ExecutionResult> {
-    let worktree_ctx = resolve_worktree_context(&prepared.request.db, &prepared.todo).await;
+    let worktree_ctx = resolve_worktree_context(
+        &prepared.request.db,
+        &prepared.todo,
+        prepared.request.workspace.as_deref(),
+    )
+    .await;
     record_worktree_path(
         &prepared.request.db,
         prepared.record_id,
@@ -135,12 +140,12 @@ pub(crate) async fn start_todo_and_prepare_spawn(
 
     register_websocket_task_info(&prepared, &todo_title, &executor_spawn).await;
 
-    // effective_workspace 在 worktree 失败回退 + todo.workspace 回退 之后确定，
-    // 后续 move 进 spawn 闭包作为 cwd。
+    // effective_workspace 优先级：worktree 路径 > todo.workspace > request.workspace（loop 场景）
     let effective_workspace = worktree_ctx
         .effective_workspace
         .clone()
-        .or(prepared.todo_workspace.clone());
+        .or(prepared.todo_workspace.clone())
+        .or(prepared.request.workspace.clone());
 
     Ok(SpawnInputs {
         prepared,

--- a/backend/src/executor_service/worktree.rs
+++ b/backend/src/executor_service/worktree.rs
@@ -25,20 +25,28 @@ pub(crate) struct WorktreeContext {
     pub auto_cleanup: bool,
 }
 
-/// 根据 todo.workspace 找到对应的 project_directory，决定是否开 worktree。
+/// 根据 todo.workspace 或显式 workspace 找到对应的 project_directory，决定是否开 worktree。
+///
+/// 优先使用 todo.workspace；当 todo 为 None 时回退到 `explicit_workspace`（loop 场景）。
 ///
 /// 不在 `WorktreeContext` 内持有数据库句柄——这是个**纯异步查询**函数，方便在
 /// run_todo_execution 主路径上独立调用并把结果 move 进 spawn 闭包。
-pub(crate) async fn resolve_worktree_context(db: &Database, todo: &Option<Todo>) -> WorktreeContext {
+pub(crate) async fn resolve_worktree_context(
+    db: &Database,
+    todo: &Option<Todo>,
+    explicit_workspace: Option<&str>,
+) -> WorktreeContext {
     // 没有 todo（被 hook 删除）/ 没有 workspace 关联项目目录——不启用 worktree
-    let Some(t) = todo.as_ref() else {
-        return WorktreeContext::default();
-    };
-    let Some(ws) = t.workspace.as_deref() else {
+    let t = todo.as_ref();
+    let ws = t
+        .and_then(|t| t.workspace.as_deref())
+        .or(explicit_workspace)
+        .map(|s| s.to_string());
+    let Some(ws) = ws else {
         return WorktreeContext::default();
     };
     // 目录在 project_directories 表里没登记——同样不启用（避免给任意 workspace 路径做 worktree）
-    let Ok(Some(dir)) = db.get_project_directory_by_path(ws).await else {
+    let Ok(Some(dir)) = db.get_project_directory_by_path(&ws).await else {
         return WorktreeContext::default();
     };
     if !dir.git_worktree_enabled {
@@ -47,8 +55,9 @@ pub(crate) async fn resolve_worktree_context(db: &Database, todo: &Option<Todo>)
 
     // 走到这里说明用户在该目录下开启了 worktree 自动管理。
     // 创建失败时不阻塞执行——回退到原始 workspace，子进程仍然能跑通。
+    let todo_id = t.as_ref().map(|t| t.id).unwrap_or(0);
     let svc = WorktreeService::new();
-    match svc.create_worktree(ws, t.id) {
+    match svc.create_worktree(&ws, todo_id) {
         Ok(wt_path) => WorktreeContext {
             effective_workspace: Some(wt_path.clone()),
             record_path: Some(wt_path),
@@ -57,7 +66,7 @@ pub(crate) async fn resolve_worktree_context(db: &Database, todo: &Option<Todo>)
         Err(e) => {
             tracing::warn!(
                 workspace = %ws,
-                todo_id = t.id,
+                todo_id = todo_id,
                 error = %e,
                 "failed to create git worktree, falling back to original workspace"
             );

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -231,6 +231,7 @@ pub async fn execute_handler(
             step_id: None,
             feishu_bot_id: None,
         feishu_receive_id: None,
+        workspace: None,
     })
     .await;
     let result = result?;
@@ -509,6 +510,7 @@ pub async fn resume_execution_handler(
             step_id: None,
             feishu_bot_id: None,
         feishu_receive_id: None,
+        workspace: None,
     })
     .await?;
     let record_id = result.record_id
@@ -669,6 +671,7 @@ pub async fn smart_create_handler(
             step_id: None,
             feishu_bot_id: None,
         feishu_receive_id: None,
+        workspace: None,
     })
     .await?;
 

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -320,6 +320,7 @@ async fn trigger_webhook_internal(
             source_hook_id: None,
             loop_step_execution_id: None,            feishu_bot_id: None,
             step_id: None,            feishu_receive_id: None,
+            workspace: None,
         },
     ).await;
 

--- a/backend/src/hooks/service.rs
+++ b/backend/src/hooks/service.rs
@@ -438,6 +438,7 @@ async fn execute_target_todo(
             step_id: None,
             feishu_bot_id: None,
         feishu_receive_id: None,
+        workspace: None,
     };
 
     // Dispatch on a dedicated hook runtime. A `std::thread::spawn` is needed

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -505,6 +505,7 @@ impl TodoScheduler {
                             source_hook_id: None,
             loop_step_execution_id: None,                            feishu_bot_id: None,
             step_id: None,                            feishu_receive_id: None,
+                            workspace: None,
                         })
                         .await;
                     }

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -261,7 +261,7 @@ impl LoopRunner {
 
             // 4f. 执行
             let record_id = match self
-                .start_step_todo_with_prompt(&step_meta, &trigger_type, idx as i64, step_exec.id, &enhanced_prompt)
+                .start_step_todo_with_prompt(&step_meta, &trigger_type, idx as i64, step_exec.id, &enhanced_prompt, loop_.workspace.clone())
                 .await
             {
                 Ok(rid) => rid,
@@ -389,6 +389,7 @@ impl LoopRunner {
         loop_idx: i64,
         step_exec_id: i64,
         enhanced_prompt: &str,
+        workspace: Option<String>,
     ) -> Result<i64, String> {
         let request = RunTodoExecutionRequest {
             db: self.ctx.db.clone(),
@@ -416,6 +417,7 @@ impl LoopRunner {
             step_id: Some(step_meta.id),
             feishu_bot_id: None,
             feishu_receive_id: None,
+            workspace,
         };
         let result = run_todo_execution_with_params(request).await;
         result
@@ -724,6 +726,7 @@ impl LoopRunner {
                 step_id: None,
                 feishu_bot_id: None,
                 feishu_receive_id: None,
+                workspace: None,
             };
             let exec_result = crate::executor_service::run_todo_execution(request).await;
             let review_record_id = match exec_result.record_id {

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -611,7 +611,10 @@ impl LoopRunner {
                 for marker in &["## 结论", "## Conclusion", "Conclusion:", "结论："] {
                     if let Some(pos) = output.find(marker) {
                         let after = &output[pos + marker.len()..].trim();
-                        let end = after.find('\n').unwrap_or(after.len().min(300));
+                        let end = after.find('\n').unwrap_or_else(|| {
+                            // 使用 char_indices 确保切片在字符边界上，避免切到多字节字符中间
+                            after.char_indices().nth(300).map(|(i, _)| i).unwrap_or(after.len())
+                        });
                         let slice = &after[..end].trim();
                         if !slice.is_empty() {
                             return slice.to_string();

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -168,6 +168,7 @@ impl MessageDebounce {
                         source_hook_id: None,
             loop_step_execution_id: None,                        feishu_bot_id: if last.binding_id.is_some() { Some(last.bot_id) } else { None },
             step_id: None,                        feishu_receive_id: if last.binding_id.is_some() { Some(last.sender.clone()) } else { None },
+                            workspace: None,
                     })
                     .await;
 

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -292,7 +292,6 @@ export function LoopDetailPanel({
         <LoopStepsPanel
           loopId={loopId}
           steps={detail.steps}
-          triggers={detail.triggers}
           tracedStepIds={tracedStepIds}
           tracedSequenceMap={tracedSequenceMap}
           onChanged={() => { reload(); onChanged(); }}

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -292,6 +292,7 @@ export function LoopDetailPanel({
         <LoopStepsPanel
           loopId={loopId}
           steps={detail.steps}
+          triggers={detail.triggers}
           tracedStepIds={tracedStepIds}
           tracedSequenceMap={tracedSequenceMap}
           onChanged={() => { reload(); onChanged(); }}

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -61,9 +61,6 @@ export function LoopDetailPanel({
   const [projectDirs, setProjectDirs] = useState<ProjectDirectory[]>([]);
   // 执行记录总数，由 LoopExecutionsPanel 通过回调更新
   const [executionTotal, setExecutionTotal] = useState(0);
-  // 执行轨迹：选中的执行展开时高亮流程图
-  const [tracedStepIds, setTracedStepIds] = useState<number[]>([]);
-  const [tracedSequenceMap, setTracedSequenceMap] = useState<Record<number, number>>({});
 
   // 加载完整 detail, 子面板变更后也要重新拉以保持最新
   const reload = useCallback(() => {
@@ -292,8 +289,6 @@ export function LoopDetailPanel({
         <LoopStepsPanel
           loopId={loopId}
           steps={detail.steps}
-          tracedStepIds={tracedStepIds}
-          tracedSequenceMap={tracedSequenceMap}
           onChanged={() => { reload(); onChanged(); }}
         />
       </DetailSection>
@@ -362,7 +357,7 @@ export function LoopDetailPanel({
               ),
               children: (
                 <div style={{ paddingTop: 4 }}>
-                  <LoopExecutionsPanel loopId={loopId} loopName={detail.name} onTotalChange={setExecutionTotal} onExecutionTrace={(ids, seqMap) => { setTracedStepIds(ids); setTracedSequenceMap(seqMap); }} />
+                  <LoopExecutionsPanel loopId={loopId} loopName={detail.name} onTotalChange={setExecutionTotal} />
                 </div>
               ),
             },

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -54,9 +54,7 @@ export function LoopDetailPanel({
   // 基础信息编辑 modal 开关 (替代之前的 inline 编辑)
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [form] = Form.useForm<UpdateLoopRequest>();
-  // 全局限制编辑
-  const [limitsForm] = Form.useForm();
+  const [form] = Form.useForm<UpdateLoopRequest & { max_step_executions?: number; max_total_tokens?: number }>();
   // 工作空间下拉选项
   const [workspaceOptions, setWorkspaceOptions] = useState<{ label: string; value: string }[]>([]);
   // 完整的项目目录列表（用于展示详情）
@@ -80,15 +78,15 @@ export function LoopDetailPanel({
           color: d.color,
           icon: d.icon,
         });
-        // 解析 limits_config
+        // 解析 limits_config 到同一 form
         try {
           const lc = JSON.parse(d.limits_config || '{}');
-          limitsForm.setFieldsValue({
+          form.setFieldsValue({
             max_step_executions: lc.max_step_executions ?? null,
             max_total_tokens: lc.max_total_tokens ?? null,
           });
         } catch {
-          limitsForm.resetFields();
+          // 忽略解析错误
         }
       })
       .catch(() => {
@@ -138,11 +136,10 @@ export function LoopDetailPanel({
     setSaving(true);
     try {
       const colorHex = String(values.color || 'var(--color-primary, #0891b2)');
-      // 构建 limits_config
-      const limitsVals = limitsForm.getFieldsValue();
+      // 构建 limits_config（从主 form 读取）
       const limitsConfig: Record<string, any> = {};
-      if (limitsVals.max_step_executions != null) limitsConfig.max_step_executions = limitsVals.max_step_executions;
-      if (limitsVals.max_total_tokens != null) limitsConfig.max_total_tokens = limitsVals.max_total_tokens;
+      if (values.max_step_executions != null) limitsConfig.max_step_executions = values.max_step_executions;
+      if (values.max_total_tokens != null) limitsConfig.max_total_tokens = values.max_total_tokens;
 
       await dbLoops.updateLoop(loopId, {
         name: values.name.trim(),
@@ -161,7 +158,7 @@ export function LoopDetailPanel({
     } finally {
       setSaving(false);
     }
-  }, [form, limitsForm, loopId, message, reload, onChanged]);
+  }, [form, loopId, message, reload, onChanged]);
 
   if (loading && !detail) {
     return <Skeleton active style={{ padding: 24 }} />;

--- a/frontend/src/components/LoopStudioStepsPanel.tsx
+++ b/frontend/src/components/LoopStudioStepsPanel.tsx
@@ -9,20 +9,19 @@ import {
 import { DeleteOutlined } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
 import * as dbSteps from '@/utils/database/steps';
-import type { LoopStepDto, LoopTriggerDto, CreateLoopStepRequest } from '@/types/loop';
+import type { LoopStepDto, CreateLoopStepRequest } from '@/types/loop';
 import type { StepSummary } from '@/types';
 import { LoopFlowGraph } from '@/components/loop-flow/LoopFlowGraph';
 
 interface StepsPanelProps {
   loopId: number;
   steps: LoopStepDto[];
-  triggers: LoopTriggerDto[];
   tracedStepIds?: number[];
   tracedSequenceMap?: Record<number, number>;
   onChanged: () => void;
 }
 
-export function LoopStepsPanel({ loopId, steps, triggers, tracedStepIds, tracedSequenceMap, onChanged }: StepsPanelProps) {
+export function LoopStepsPanel({ loopId, steps, tracedStepIds, tracedSequenceMap, onChanged }: StepsPanelProps) {
   const { message } = AntApp.useApp();
 
   // Modal 状态
@@ -147,7 +146,6 @@ export function LoopStepsPanel({ loopId, steps, triggers, tracedStepIds, tracedS
       {/* 流程图 */}
       <LoopFlowGraph
         steps={steps}
-        triggers={triggers}
         selectedStepId={editingStep?.id ?? null}
         tracedStepIds={tracedStepIds}
         tracedSequenceMap={tracedSequenceMap}

--- a/frontend/src/components/LoopStudioStepsPanel.tsx
+++ b/frontend/src/components/LoopStudioStepsPanel.tsx
@@ -16,12 +16,10 @@ import { LoopFlowGraph } from '@/components/loop-flow/LoopFlowGraph';
 interface StepsPanelProps {
   loopId: number;
   steps: LoopStepDto[];
-  tracedStepIds?: number[];
-  tracedSequenceMap?: Record<number, number>;
   onChanged: () => void;
 }
 
-export function LoopStepsPanel({ loopId, steps, tracedStepIds, tracedSequenceMap, onChanged }: StepsPanelProps) {
+export function LoopStepsPanel({ loopId, steps, onChanged }: StepsPanelProps) {
   const { message } = AntApp.useApp();
 
   // Modal 状态
@@ -147,8 +145,6 @@ export function LoopStepsPanel({ loopId, steps, tracedStepIds, tracedSequenceMap
       <LoopFlowGraph
         steps={steps}
         selectedStepId={editingStep?.id ?? null}
-        tracedStepIds={tracedStepIds}
-        tracedSequenceMap={tracedSequenceMap}
         onSelectStep={handleSelectStep}
         onAddStep={handleOpenAdd}
       />

--- a/frontend/src/components/LoopStudioStepsPanel.tsx
+++ b/frontend/src/components/LoopStudioStepsPanel.tsx
@@ -9,19 +9,20 @@ import {
 import { DeleteOutlined } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
 import * as dbSteps from '@/utils/database/steps';
-import type { LoopStepDto, CreateLoopStepRequest } from '@/types/loop';
+import type { LoopStepDto, LoopTriggerDto, CreateLoopStepRequest } from '@/types/loop';
 import type { StepSummary } from '@/types';
 import { LoopFlowGraph } from '@/components/loop-flow/LoopFlowGraph';
 
 interface StepsPanelProps {
   loopId: number;
   steps: LoopStepDto[];
+  triggers: LoopTriggerDto[];
   tracedStepIds?: number[];
   tracedSequenceMap?: Record<number, number>;
   onChanged: () => void;
 }
 
-export function LoopStepsPanel({ loopId, steps, tracedStepIds, tracedSequenceMap, onChanged }: StepsPanelProps) {
+export function LoopStepsPanel({ loopId, steps, triggers, tracedStepIds, tracedSequenceMap, onChanged }: StepsPanelProps) {
   const { message } = AntApp.useApp();
 
   // Modal 状态
@@ -146,6 +147,7 @@ export function LoopStepsPanel({ loopId, steps, tracedStepIds, tracedSequenceMap
       {/* 流程图 */}
       <LoopFlowGraph
         steps={steps}
+        triggers={triggers}
         selectedStepId={editingStep?.id ?? null}
         tracedStepIds={tracedStepIds}
         tracedSequenceMap={tracedSequenceMap}

--- a/frontend/src/components/LoopStudioStepsPanel.tsx
+++ b/frontend/src/components/LoopStudioStepsPanel.tsx
@@ -4,9 +4,9 @@
 
 import { useState, useCallback } from 'react';
 import {
-  App as AntApp, Button, Modal, Form, Input, InputNumber, Select, Switch, Popconfirm, Empty,
+  App as AntApp, Button, Modal, Form, Input, InputNumber, Select, Switch, Popconfirm, Empty, Space,
 } from 'antd';
-import { DeleteOutlined } from '@ant-design/icons';
+import { DeleteOutlined, CloseOutlined } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
 import * as dbSteps from '@/utils/database/steps';
 import type { LoopStepDto, CreateLoopStepRequest } from '@/types/loop';
@@ -153,20 +153,31 @@ export function LoopStepsPanel({ loopId, steps, tracedStepIds, tracedSequenceMap
         onAddStep={handleOpenAdd}
       />
 
-      {/* 删除按钮（仅在有步骤时显示在左下角） */}
+      {/* 操作区：仅在选中环节时显示。提供「取消选择」回到未选中态，
+          避免只能通过 modal 关闭或点空白来退出。删除用 Popconfirm 防误触。 */}
       {steps.length > 0 && editingStep && (
         <div style={{ marginTop: 8, display: 'flex', justifyContent: 'flex-end' }}>
-          <Popconfirm
-            title="删除环节"
-            description={`确定删除「${editingStep.name}」？`}
-            onConfirm={() => { handleDelete(editingStep.id); setEditingStep(null); }}
-            okText="确定"
-            cancelText="取消"
-          >
-            <Button size="small" danger icon={<DeleteOutlined />} style={{ fontSize: 12 }}>
-              删除选中环节
+          <Space size="small">
+            <Button
+              size="small"
+              icon={<CloseOutlined />}
+              style={{ fontSize: 12 }}
+              onClick={() => setEditingStep(null)}
+            >
+              取消选择
             </Button>
-          </Popconfirm>
+            <Popconfirm
+              title="删除环节"
+              description={`确定删除「${editingStep.name}」？`}
+              onConfirm={() => { handleDelete(editingStep.id); setEditingStep(null); }}
+              okText="确定"
+              cancelText="取消"
+            >
+              <Button size="small" danger icon={<DeleteOutlined />} style={{ fontSize: 12 }}>
+                删除选中环节
+              </Button>
+            </Popconfirm>
+          </Space>
         </div>
       )}
 

--- a/frontend/src/components/loop-flow/FlowEdge.tsx
+++ b/frontend/src/components/loop-flow/FlowEdge.tsx
@@ -1,0 +1,263 @@
+// Loop 流程图边渲染 + 路径/中点计算。
+//
+// 边分两类：
+// 1) 普通前向边（success-next / success-goto / fail-skip / fail-goto / fail-break / end）：
+//    横向 S 形贝塞尔曲线，按 EDGE_STYLES 着色。
+// 2) 回环边（isLoopBack=true）：目标 step 排在源 step 之前的 goto。
+//    用 U 形向上拱的曲线 + 加重样式 + 白底加粗标签，从普通边里跳出来。
+//
+// 之所以独立成文件：让 LoopFlowGraph 主文件保持在 500 行硬限内，
+// 边相关的样式/路径/标签测量都是独立关注点。
+
+import type { LoopStepDto } from '@/types/loop';
+import {
+  START_NODE_ID, END_NODE_ID, VIRTUAL_NODE_RADIUS,
+  NODE_WIDTH, NODE_HEIGHT, LOOP_BACK_TOP_PADDING,
+} from '@/components/loop-flow/flowConstants';
+import type { LayoutNode, LayoutEdge, EdgeType } from '@/components/loop-flow/flowTypes';
+
+const EDGE_STYLES: Record<EdgeType, { color: string; dash: string; labelColor: string }> = {
+  'start-first':  { color: '#94a3b8', dash: '', labelColor: '#94a3b8' },
+  'success-next': { color: '#94a3b8', dash: '', labelColor: '#94a3b8' },
+  'success-goto': { color: '#22c55e', dash: '', labelColor: '#16a34a' },
+  'fail-skip':    { color: '#f97316', dash: '5,3', labelColor: '#ea580c' },
+  'fail-goto':    { color: '#ef4444', dash: '', labelColor: '#dc2626' },
+  'fail-break':   { color: '#ef4444', dash: '', labelColor: '#dc2626' },
+  'end':          { color: '#94a3b8', dash: '', labelColor: '#94a3b8' },
+};
+
+export function classifyEdge(
+  _step: LoopStepDto,
+  _allSteps: LoopStepDto[],
+  policy: string,
+  _gotoId: number | null,
+  isSuccess: boolean,
+): EdgeType {
+  if (policy === 'end') return 'end';
+  if (isSuccess) {
+    if (policy === 'goto') return 'success-goto';
+    return 'success-next';
+  }
+  // failure edges
+  switch (policy) {
+    case 'skip': return 'fail-skip';
+    case 'goto': return 'fail-goto';
+    case 'break': return 'fail-break';
+    default: return 'fail-break';
+  }
+}
+
+export function resolveTargetStep(
+  step: LoopStepDto,
+  allSteps: LoopStepDto[],
+  policy: string,
+  gotoId: number | null,
+): number | undefined {
+  if (policy === 'next' || policy === 'skip') {
+    const idx = allSteps.findIndex(s => s.id === step.id);
+    if (idx >= 0 && idx < allSteps.length - 1) {
+      return allSteps[idx + 1].id;
+    }
+    return undefined;
+  }
+  if (policy === 'goto' && gotoId != null) {
+    return gotoId;
+  }
+  return undefined;
+}
+
+// 边的一端锚点：真实环节用矩形边的中点；虚拟节点用圆周上的对应方向点。
+// 真实环节的左/右中点与圆节点的水平切点对齐，让 Start→first / last→End
+// 这两条边的起止点在视觉上和「同高度的中间」自然衔接。
+// side='top' 只用于回环边：起止都在环节顶边中点，正交折线从顶边出来
+// 视觉上更顺（不与环节卡片的左右中线争夺起止点）。
+function getEdgeAnchor(
+  nodeId: number, nodes: LayoutNode[],
+  startX: number, startY: number, endX: number, endY: number,
+  side: 'left' | 'right' | 'top',
+): { x: number; y: number } | null {
+  if (nodeId === START_NODE_ID) {
+    if (side === 'top') return null;
+    return { x: startX + (side === 'right' ? VIRTUAL_NODE_RADIUS : -VIRTUAL_NODE_RADIUS), y: startY };
+  }
+  if (nodeId === END_NODE_ID) {
+    if (side === 'top') return null;
+    return { x: endX + (side === 'right' ? VIRTUAL_NODE_RADIUS : -VIRTUAL_NODE_RADIUS), y: endY };
+  }
+  const node = nodes.find(n => n.id === nodeId);
+  if (!node) return null;
+  if (side === 'top') {
+    return { x: node.x + NODE_WIDTH / 2, y: node.y };
+  }
+  return {
+    x: side === 'right' ? node.x + NODE_WIDTH : node.x,
+    y: node.y + NODE_HEIGHT / 2,
+  };
+}
+
+export function buildEdgePath(
+  edge: LayoutEdge, nodes: LayoutNode[],
+  startX: number, startY: number, endX: number, endY: number,
+): string {
+  const from = getEdgeAnchor(edge.fromId, nodes, startX, startY, endX, endY, 'right');
+  const to = getEdgeAnchor(edge.toId, nodes, startX, startY, endX, endY, 'left');
+  if (!from || !to) return '';
+
+  if (edge.isLoopBack) {
+    // 回环：3 段正交折线（up → left → down），从源 step 顶边中点出发，
+    // 上升到 baseY - H 后水平走到目标 step 顶边中点上方，再下到 to。
+    // 起点/终点都在顶边而不是 right/left 中线，跟用户期望的「从顶部出、
+    // 从顶部入」一致；虚拟节点没有顶边概念，自动回退到 right/left 旧路径。
+    const fromTop = getEdgeAnchor(edge.fromId, nodes, startX, startY, endX, endY, 'top');
+    const toTop = getEdgeAnchor(edge.toId, nodes, startX, startY, endX, endY, 'top');
+    if (fromTop && toTop) {
+      const H = LOOP_BACK_TOP_PADDING;
+      const baseY = Math.min(fromTop.y, toTop.y);
+      return `M ${fromTop.x} ${fromTop.y} V ${baseY - H} H ${toTop.x} V ${toTop.y}`;
+    }
+    // 起点或终点是虚拟节点（START/END），回退到 right/left 锚点的旧版本。
+    const H = LOOP_BACK_TOP_PADDING;
+    const baseY = Math.min(from.y, to.y);
+    return `M ${from.x} ${from.y} V ${baseY - H} H ${to.x} V ${to.y}`;
+  }
+
+  const dx = Math.abs(to.x - from.x);
+  const cx1 = from.x + dx * 0.4;
+  const cx2 = to.x - dx * 0.4;
+
+  return `M ${from.x} ${from.y} C ${cx1} ${from.y}, ${cx2} ${to.y}, ${to.x} ${to.y}`;
+}
+
+export function getEdgeMidX(
+  edge: LayoutEdge, nodes: LayoutNode[],
+  startX: number, endX: number,
+): number {
+  // 回环用 top 锚点的 x（顶边中点），跟路径的水平段两端对齐。
+  if (edge.isLoopBack) {
+    const fromTop = getEdgeAnchor(edge.fromId, nodes, startX, 0, endX, 0, 'top');
+    const toTop = getEdgeAnchor(edge.toId, nodes, startX, 0, endX, 0, 'top');
+    if (fromTop && toTop) return (fromTop.x + toTop.x) / 2;
+  }
+  const from = getEdgeAnchor(edge.fromId, nodes, startX, 0, endX, 0, 'right');
+  const to = getEdgeAnchor(edge.toId, nodes, startX, 0, endX, 0, 'left');
+  if (!from || !to) return 0;
+  return (from.x + to.x) / 2;
+}
+
+export function getEdgeMidY(
+  edge: LayoutEdge, nodes: LayoutNode[],
+  startY: number, endY: number,
+): number {
+  const from = getEdgeAnchor(edge.fromId, nodes, 0, startY, 0, endY, 'right');
+  const to = getEdgeAnchor(edge.toId, nodes, 0, startY, 0, endY, 'left');
+  if (!from || !to) return 0;
+  // 回环标签：水平折线段在 y=baseY-H，标签 y 设为 baseY-H-11 让白底矩形
+  // 底边离折线 4px（rect 高度 16，y=midY-9 → 底边=midY+7），不会盖住折线。
+  // 用 top 锚点的 y（节点顶边）而不是 right 锚点的 y（垂直中点），因为
+  // 回环的水平段在两个 step 顶边之上的 baseY-H 高度。
+  if (edge.isLoopBack) {
+    const fromTop = getEdgeAnchor(edge.fromId, nodes, 0, startY, 0, endY, 'top');
+    const toTop = getEdgeAnchor(edge.toId, nodes, 0, startY, 0, endY, 'top');
+    const baseY = Math.min(fromTop?.y ?? from.y, toTop?.y ?? to.y);
+    return baseY - LOOP_BACK_TOP_PADDING - 11;
+  }
+  return (from.y + to.y) / 2;
+}
+
+// 按可视宽度粗略估算标签宽度（中文字符 10px，ASCII 字符 6px，加 1px 字间距），
+// 用于给回环标签加白底。SVG 文本测量在 React 里成本较高，这里用近似。
+function getLabelWidth(text: string): number {
+  let w = 0;
+  for (const ch of text) {
+    w += ch.charCodeAt(0) > 0x7F ? 10 : 6;
+  }
+  return w;
+}
+
+interface FlowEdgeProps {
+  edge: LayoutEdge;
+  index: number;
+  nodes: LayoutNode[];
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+  tracedStepIds: number[];
+  isEdgeTraced: (fromId: number, toId: number) => boolean;
+}
+
+// 单条边的渲染：箭头线 + 标签。回环边用白底圆角矩形包标签，
+// 让弧顶处的文字跟红色加粗虚线一起成为「回头重做」的强信号。
+export function FlowEdge({
+  edge, index, nodes, startX, startY, endX, endY,
+  tracedStepIds, isEdgeTraced,
+}: FlowEdgeProps) {
+  const traced = isEdgeTraced(edge.fromId, edge.toId);
+  const hasTrace = tracedStepIds.length > 0;
+  const baseStyle = EDGE_STYLES[edge.type] || EDGE_STYLES['success-next'];
+  // 回环边用更显眼的样式：颜色加深、虚线步长更大、stroke 加粗，
+  // 即便被 trace 高亮压一层也能让回环一眼从其它边里跳出来。
+  const style = edge.isLoopBack ? {
+    color: edge.type === 'success-goto' ? '#15803d' : '#b91c1c',
+    dash: '7,4',
+    labelColor: edge.type === 'success-goto' ? '#15803d' : '#b91c1c',
+  } : baseStyle;
+  const strokeWidth = edge.isLoopBack
+    ? (hasTrace && traced ? 3.5 : 2.5)
+    : (hasTrace && traced ? 3 : 1.5);
+  const opacity = hasTrace ? (traced ? 1 : 0.15) : 1;
+  const markerSize = edge.isLoopBack ? 8 : 6;
+  const labelW = edge.label ? getLabelWidth(edge.label) : 0;
+  const midX = getEdgeMidX(edge, nodes, startX, endX);
+  const midY = getEdgeMidY(edge, nodes, startY, endY);
+
+  return (
+    <g opacity={opacity}>
+      <defs>
+        <marker
+          id={`arrow-${index}`}
+          viewBox="0 0 10 10" refX="10" refY="5"
+          markerWidth={markerSize} markerHeight={markerSize} orient="auto"
+        >
+          <path d="M 0 0 L 10 5 L 0 10 z" fill={style.color} />
+        </marker>
+      </defs>
+      <path
+        d={buildEdgePath(edge, nodes, startX, startY, endX, endY)}
+        fill="none"
+        stroke={style.color}
+        strokeWidth={strokeWidth}
+        strokeDasharray={style.dash || undefined}
+        markerEnd={`url(#arrow-${index})`}
+      />
+      {edge.label && (
+        edge.isLoopBack ? (
+          <g>
+            <rect
+              x={midX - labelW / 2 - 4} y={midY - 9}
+              width={labelW + 8} height={16} rx={4}
+              fill="#ffffff" stroke={style.color} strokeWidth={1}
+            />
+            <text
+              x={midX} y={midY + 2}
+              textAnchor="middle" fontSize={10} fontWeight={700}
+              fill={style.labelColor}
+              style={{ fontFamily: 'system-ui' }}
+            >
+              {edge.label}
+            </text>
+          </g>
+        ) : (
+          <text
+            x={midX} y={midY - 6}
+            textAnchor="middle" fontSize={10}
+            fill={style.labelColor}
+            style={{ fontFamily: 'monospace' }}
+          >
+            {edge.label}
+          </text>
+        )
+      )}
+    </g>
+  );
+}

--- a/frontend/src/components/loop-flow/FlowEdge.tsx
+++ b/frontend/src/components/loop-flow/FlowEdge.tsx
@@ -199,14 +199,16 @@ export function FlowEdge({
   // 即便被 trace 高亮压一层也能让回环一眼从其它边里跳出来。
   const style = edge.isLoopBack ? {
     color: edge.type === 'success-goto' ? '#15803d' : '#b91c1c',
-    dash: '7,4',
+    dash: '6,3',
     labelColor: edge.type === 'success-goto' ? '#15803d' : '#b91c1c',
   } : baseStyle;
+  // 回环边：stroke 比普通边略粗但不要喧宾夺主。1.8（默认）/ 2.5（被 trace 高亮），
+  // 配合深色 + 虚线足以区分；箭头也小一档，避免抢走步骤卡片视觉。
   const strokeWidth = edge.isLoopBack
-    ? (hasTrace && traced ? 3.5 : 2.5)
+    ? (hasTrace && traced ? 2.5 : 1.8)
     : (hasTrace && traced ? 3 : 1.5);
   const opacity = hasTrace ? (traced ? 1 : 0.15) : 1;
-  const markerSize = edge.isLoopBack ? 8 : 6;
+  const markerSize = edge.isLoopBack ? 6 : 6;
   const labelW = edge.label ? getLabelWidth(edge.label) : 0;
   const midX = getEdgeMidX(edge, nodes, startX, endX);
   const midY = getEdgeMidY(edge, nodes, startY, endY);

--- a/frontend/src/components/loop-flow/FlowEdge.tsx
+++ b/frontend/src/components/loop-flow/FlowEdge.tsx
@@ -195,15 +195,14 @@ export function FlowEdge({
   const traced = isEdgeTraced(edge.fromId, edge.toId);
   const hasTrace = tracedStepIds.length > 0;
   const baseStyle = EDGE_STYLES[edge.type] || EDGE_STYLES['success-next'];
-  // 回环边用更显眼的样式：颜色加深、虚线步长更大、stroke 加粗，
-  // 即便被 trace 高亮压一层也能让回环一眼从其它边里跳出来。
+  // 回环是带条件的执行路径，与普通跳转同属主路径，不该用虚线暗示「次要」。
+  // 区分度只靠颜色加深（success 深绿、fail 深红）和更粗的 stroke 即可。
   const style = edge.isLoopBack ? {
     color: edge.type === 'success-goto' ? '#15803d' : '#b91c1c',
-    dash: '6,3',
+    dash: '',
     labelColor: edge.type === 'success-goto' ? '#15803d' : '#b91c1c',
   } : baseStyle;
-  // 回环边：stroke 比普通边略粗但不要喧宾夺主。1.8（默认）/ 2.5（被 trace 高亮），
-  // 配合深色 + 虚线足以区分；箭头也小一档，避免抢走步骤卡片视觉。
+  // 回环边：stroke 比普通边略粗（1.8 vs 1.5）即可，颜色已经够深无需再叠粗细差。
   const strokeWidth = edge.isLoopBack
     ? (hasTrace && traced ? 2.5 : 1.8)
     : (hasTrace && traced ? 3 : 1.5);

--- a/frontend/src/components/loop-flow/FlowEdge.tsx
+++ b/frontend/src/components/loop-flow/FlowEdge.tsx
@@ -182,18 +182,13 @@ interface FlowEdgeProps {
   startY: number;
   endX: number;
   endY: number;
-  tracedStepIds: number[];
-  isEdgeTraced: (fromId: number, toId: number) => boolean;
 }
 
 // 单条边的渲染：箭头线 + 标签。回环边用白底圆角矩形包标签，
 // 让弧顶处的文字跟红色加粗虚线一起成为「回头重做」的强信号。
 export function FlowEdge({
   edge, index, nodes, startX, startY, endX, endY,
-  tracedStepIds, isEdgeTraced,
 }: FlowEdgeProps) {
-  const traced = isEdgeTraced(edge.fromId, edge.toId);
-  const hasTrace = tracedStepIds.length > 0;
   const baseStyle = EDGE_STYLES[edge.type] || EDGE_STYLES['success-next'];
   // 回环是带条件的执行路径，与普通跳转同属主路径，不该用虚线暗示「次要」。
   // 区分度只靠颜色加深（success 深绿、fail 深红）和更粗的 stroke 即可。
@@ -203,17 +198,14 @@ export function FlowEdge({
     labelColor: edge.type === 'success-goto' ? '#15803d' : '#b91c1c',
   } : baseStyle;
   // 回环边：stroke 比普通边略粗（1.8 vs 1.5）即可，颜色已经够深无需再叠粗细差。
-  const strokeWidth = edge.isLoopBack
-    ? (hasTrace && traced ? 2.5 : 1.8)
-    : (hasTrace && traced ? 3 : 1.5);
-  const opacity = hasTrace ? (traced ? 1 : 0.15) : 1;
-  const markerSize = edge.isLoopBack ? 6 : 6;
+  const strokeWidth = edge.isLoopBack ? 1.8 : 1.5;
+  const markerSize = 6;
   const labelW = edge.label ? getLabelWidth(edge.label) : 0;
   const midX = getEdgeMidX(edge, nodes, startX, endX);
   const midY = getEdgeMidY(edge, nodes, startY, endY);
 
   return (
-    <g opacity={opacity}>
+    <g>
       <defs>
         <marker
           id={`arrow-${index}`}

--- a/frontend/src/components/loop-flow/FlowVirtualNodes.tsx
+++ b/frontend/src/components/loop-flow/FlowVirtualNodes.tsx
@@ -1,26 +1,10 @@
-// Loop 流程图虚拟节点 (Start / End) 与触发条件徽章。
+// Loop 流程图虚拟节点 (Start / End)。
 //
 // Start/End 是 dagre 布局时插入的虚拟节点，不渲染真实的环节卡片，但需要
-// 视觉提示给用户「这里是一切的起点/终点」。Start 节点旁还会并排显示一组
-// 触发条件徽章 (来自该 loop 已启用的 triggers)，让用户一眼看出「哪些方式
-// 能让这个 loop 跑起来」。
-//
-// 之所以独立成文件：让主文件 LoopFlowGraph 保持在 500 行硬限内，
-// 虚拟节点视觉与触发条件展示是独立的关注点。
-
-import type { LoopTriggerDto } from '@/types/loop';
+// 视觉提示给用户「这里是一切的起点/终点」。之所以独立成文件：让主文件
+// LoopFlowGraph 保持在 500 行硬限内，虚拟节点视觉是独立的关注点。
 
 export const VIRTUAL_NODE_RADIUS = 20;
-
-export const TRIGGER_SHORT_LABELS: Record<string, string> = {
-  manual: '手动触发',
-  cron: '定时调度',
-  webhook: 'Webhook',
-  feishu_message: '飞书消息',
-  feishu_command: '飞书指令',
-  todo_completed: 'Todo 完成',
-  todo_state_changed: 'Todo 状态变更',
-};
 
 interface VirtualNodeProps {
   x: number;
@@ -83,102 +67,4 @@ export function EndNode({ x, y }: VirtualNodeProps) {
       </text>
     </g>
   );
-}
-
-interface TriggerBadgesProps {
-  triggers: LoopTriggerDto[];
-  startX: number;
-  startY: number;
-  badgeWidth?: number;
-  badgeHeight?: number;
-  gap?: number;
-  maxVisible?: number;
-}
-
-// 触发条件徽章：堆叠在 Start 节点左侧，垂直居中对齐 startY。
-//
-// 全部用纯文本标签（不依赖 emoji 字体），保证 SVG 在不同环境下渲染一致。
-// 当启用触发器超过 maxVisible 时折叠成「+N 更多」，避免流程图整体高度被撑高。
-export function TriggerBadges({
-  triggers, startX, startY,
-  badgeWidth = 110, badgeHeight = 22, gap = 4, maxVisible = 4,
-}: TriggerBadgesProps) {
-  // 只展示当前已启用的触发器，未启用的视觉上等价于「不支持」——它们
-  // 不会让 loop 真正运行起来，不应让用户产生「这个 loop 有这条触发路径」的错觉。
-  const enabled = triggers.filter(t => t.enabled);
-  if (enabled.length === 0) return null;
-
-  const visible = enabled.slice(0, maxVisible);
-  const hidden = enabled.length - visible.length;
-
-  // 让徽章组的几何中心落在 startY 上，而不是从 startY 向下铺开——
-  // 这样视觉上与 Start 节点是「一组」，不会显得失衡。
-  const totalHeight = visible.length * badgeHeight + (visible.length - 1) * gap
-    + (hidden > 0 ? badgeHeight + gap : 0);
-  const firstY = startY - totalHeight / 2;
-
-  // 徽章右边缘距离 Start 节点左边缘 6px，留一点呼吸空间。
-  const groupRight = startX - VIRTUAL_NODE_RADIUS - 6;
-  const groupX = groupRight - badgeWidth;
-
-  return (
-    <g>
-      {visible.map((t, i) => {
-        const y = firstY + i * (badgeHeight + gap);
-        const label = TRIGGER_SHORT_LABELS[t.trigger_type] || t.trigger_type;
-        return (
-          <g key={t.id} transform={`translate(${groupX}, ${y})`}>
-            <rect
-              width={badgeWidth} height={badgeHeight} rx={11}
-              fill="#f0f9ff" stroke="#0891b2" strokeWidth={1}
-            />
-            {/* 在徽章内展示 trigger_type 的简短文字；超过宽度时用 SVG title
-                把完整类型暴露给 hover，与主面板的标签保持一致。 */}
-            <text
-              x={10} y={badgeHeight / 2 + 4}
-              fontSize={11} fill="#0f172a"
-              style={{ fontFamily: 'system-ui' }}
-            >
-              {truncateLabel(label, badgeWidth - 20)}
-            </text>
-            <title>{TRIGGER_SHORT_LABELS[t.trigger_type] || t.trigger_type}</title>
-          </g>
-        );
-      })}
-      {hidden > 0 && (
-        <g
-          transform={`translate(${groupX}, ${firstY + visible.length * (badgeHeight + gap)})`}
-        >
-          <rect
-            width={badgeWidth} height={badgeHeight} rx={11}
-            fill="#f1f5f9" stroke="#94a3b8" strokeWidth={1} strokeDasharray="3,2"
-          />
-          <text
-            x={badgeWidth / 2} y={badgeHeight / 2 + 4}
-            textAnchor="middle" fontSize={11} fill="#64748b"
-            style={{ fontFamily: 'system-ui' }}
-          >
-            +{hidden} 个未展开
-          </text>
-        </g>
-      )}
-    </g>
-  );
-}
-
-// 按可视宽度粗略截断触发器标签，避免文字溢出徽章。
-// 这里用「字符数 / 中文字宽」近似代替精确测量，比 SVG 文本测量 API 更轻。
-function truncateLabel(text: string, maxPx: number): string {
-  // 中文字符按 11px 算，ASCII 按 6px 算，留 4px 余量。
-  let used = 0;
-  let result = '';
-  for (const ch of text) {
-    const w = ch.charCodeAt(0) > 0x7F ? 11 : 6;
-    if (used + w > maxPx - 4) {
-      return result + '…';
-    }
-    used += w;
-    result += ch;
-  }
-  return result;
 }

--- a/frontend/src/components/loop-flow/FlowVirtualNodes.tsx
+++ b/frontend/src/components/loop-flow/FlowVirtualNodes.tsx
@@ -1,0 +1,184 @@
+// Loop 流程图虚拟节点 (Start / End) 与触发条件徽章。
+//
+// Start/End 是 dagre 布局时插入的虚拟节点，不渲染真实的环节卡片，但需要
+// 视觉提示给用户「这里是一切的起点/终点」。Start 节点旁还会并排显示一组
+// 触发条件徽章 (来自该 loop 已启用的 triggers)，让用户一眼看出「哪些方式
+// 能让这个 loop 跑起来」。
+//
+// 之所以独立成文件：让主文件 LoopFlowGraph 保持在 500 行硬限内，
+// 虚拟节点视觉与触发条件展示是独立的关注点。
+
+import type { LoopTriggerDto } from '@/types/loop';
+
+export const VIRTUAL_NODE_RADIUS = 20;
+
+export const TRIGGER_SHORT_LABELS: Record<string, string> = {
+  manual: '手动触发',
+  cron: '定时调度',
+  webhook: 'Webhook',
+  feishu_message: '飞书消息',
+  feishu_command: '飞书指令',
+  todo_completed: 'Todo 完成',
+  todo_state_changed: 'Todo 状态变更',
+};
+
+interface VirtualNodeProps {
+  x: number;
+  y: number;
+  selected?: boolean;
+}
+
+// 入口节点：绿色实心圆 + ▶ 符号，下方标 "开始"。
+// 选中态改为更深的青色，呼应真实环节的选中样式。
+export function StartNode({ x, y, selected = false }: VirtualNodeProps) {
+  return (
+    <g>
+      <circle
+        cx={x} cy={y} r={VIRTUAL_NODE_RADIUS}
+        fill={selected ? '#0891b2' : '#22c55e'}
+        stroke={selected ? '#0e7490' : '#16a34a'}
+        strokeWidth={2}
+      />
+      <text
+        x={x} y={y + 5} textAnchor="middle"
+        fontSize={15} fontWeight={700} fill="#ffffff"
+        style={{ fontFamily: 'system-ui' }}
+      >
+        ▶
+      </text>
+      <text
+        x={x} y={y + VIRTUAL_NODE_RADIUS + 13} textAnchor="middle"
+        fontSize={10} fontWeight={600}
+        fill={selected ? '#0e7490' : '#16a34a'}
+        style={{ fontFamily: 'system-ui' }}
+      >
+        开始
+      </text>
+    </g>
+  );
+}
+
+// 出口节点：深灰色实心圆 + ■ 符号，下方标 "结束"。
+// 故意用低饱和灰色，避免抢走入口节点的视觉重点。
+export function EndNode({ x, y }: VirtualNodeProps) {
+  return (
+    <g>
+      <circle
+        cx={x} cy={y} r={VIRTUAL_NODE_RADIUS}
+        fill="#475569" stroke="#334155" strokeWidth={2}
+      />
+      <text
+        x={x} y={y + 5} textAnchor="middle"
+        fontSize={15} fontWeight={700} fill="#ffffff"
+        style={{ fontFamily: 'system-ui' }}
+      >
+        ■
+      </text>
+      <text
+        x={x} y={y + VIRTUAL_NODE_RADIUS + 13} textAnchor="middle"
+        fontSize={10} fontWeight={600} fill="#475569"
+        style={{ fontFamily: 'system-ui' }}
+      >
+        结束
+      </text>
+    </g>
+  );
+}
+
+interface TriggerBadgesProps {
+  triggers: LoopTriggerDto[];
+  startX: number;
+  startY: number;
+  badgeWidth?: number;
+  badgeHeight?: number;
+  gap?: number;
+  maxVisible?: number;
+}
+
+// 触发条件徽章：堆叠在 Start 节点左侧，垂直居中对齐 startY。
+//
+// 全部用纯文本标签（不依赖 emoji 字体），保证 SVG 在不同环境下渲染一致。
+// 当启用触发器超过 maxVisible 时折叠成「+N 更多」，避免流程图整体高度被撑高。
+export function TriggerBadges({
+  triggers, startX, startY,
+  badgeWidth = 110, badgeHeight = 22, gap = 4, maxVisible = 4,
+}: TriggerBadgesProps) {
+  // 只展示当前已启用的触发器，未启用的视觉上等价于「不支持」——它们
+  // 不会让 loop 真正运行起来，不应让用户产生「这个 loop 有这条触发路径」的错觉。
+  const enabled = triggers.filter(t => t.enabled);
+  if (enabled.length === 0) return null;
+
+  const visible = enabled.slice(0, maxVisible);
+  const hidden = enabled.length - visible.length;
+
+  // 让徽章组的几何中心落在 startY 上，而不是从 startY 向下铺开——
+  // 这样视觉上与 Start 节点是「一组」，不会显得失衡。
+  const totalHeight = visible.length * badgeHeight + (visible.length - 1) * gap
+    + (hidden > 0 ? badgeHeight + gap : 0);
+  const firstY = startY - totalHeight / 2;
+
+  // 徽章右边缘距离 Start 节点左边缘 6px，留一点呼吸空间。
+  const groupRight = startX - VIRTUAL_NODE_RADIUS - 6;
+  const groupX = groupRight - badgeWidth;
+
+  return (
+    <g>
+      {visible.map((t, i) => {
+        const y = firstY + i * (badgeHeight + gap);
+        const label = TRIGGER_SHORT_LABELS[t.trigger_type] || t.trigger_type;
+        return (
+          <g key={t.id} transform={`translate(${groupX}, ${y})`}>
+            <rect
+              width={badgeWidth} height={badgeHeight} rx={11}
+              fill="#f0f9ff" stroke="#0891b2" strokeWidth={1}
+            />
+            {/* 在徽章内展示 trigger_type 的简短文字；超过宽度时用 SVG title
+                把完整类型暴露给 hover，与主面板的标签保持一致。 */}
+            <text
+              x={10} y={badgeHeight / 2 + 4}
+              fontSize={11} fill="#0f172a"
+              style={{ fontFamily: 'system-ui' }}
+            >
+              {truncateLabel(label, badgeWidth - 20)}
+            </text>
+            <title>{TRIGGER_SHORT_LABELS[t.trigger_type] || t.trigger_type}</title>
+          </g>
+        );
+      })}
+      {hidden > 0 && (
+        <g
+          transform={`translate(${groupX}, ${firstY + visible.length * (badgeHeight + gap)})`}
+        >
+          <rect
+            width={badgeWidth} height={badgeHeight} rx={11}
+            fill="#f1f5f9" stroke="#94a3b8" strokeWidth={1} strokeDasharray="3,2"
+          />
+          <text
+            x={badgeWidth / 2} y={badgeHeight / 2 + 4}
+            textAnchor="middle" fontSize={11} fill="#64748b"
+            style={{ fontFamily: 'system-ui' }}
+          >
+            +{hidden} 个未展开
+          </text>
+        </g>
+      )}
+    </g>
+  );
+}
+
+// 按可视宽度粗略截断触发器标签，避免文字溢出徽章。
+// 这里用「字符数 / 中文字宽」近似代替精确测量，比 SVG 文本测量 API 更轻。
+function truncateLabel(text: string, maxPx: number): string {
+  // 中文字符按 11px 算，ASCII 按 6px 算，留 4px 余量。
+  let used = 0;
+  let result = '';
+  for (const ch of text) {
+    const w = ch.charCodeAt(0) > 0x7F ? 11 : 6;
+    if (used + w > maxPx - 4) {
+      return result + '…';
+    }
+    used += w;
+    result += ch;
+  }
+  return result;
+}

--- a/frontend/src/components/loop-flow/LoopFlowGraph.tsx
+++ b/frontend/src/components/loop-flow/LoopFlowGraph.tsx
@@ -89,7 +89,7 @@ function useFlowLayout(steps: LoopStepDto[]) {
         layoutEdges.push({
           from: String(step.id), to: String(successTarget),
           label: isLoopBack
-            ? `↻ 跳回 ${name}`
+            ? `跳回 ${name}`
             : step.on_success === 'goto' ? `✅→${name}` : '',
           type: successType, fromId: step.id, toId: successTarget,
           isLoopBack,
@@ -105,14 +105,14 @@ function useFlowLayout(steps: LoopStepDto[]) {
           const targetIdx = stepIndexById.get(failTarget);
           const isLoopBack = failType === 'fail-goto'
             && targetIdx != null && targetIdx < sourceIdx;
-          // 回环边：标签写「↻ <阈值分」，阈值取自源 step 的 min_rating。
-          // 比「↻ 重试 笑话」更准——用户一眼看出「评分低于 X 就回退到上一步」，
-          // 目标 step 名出现在连线箭头上，标签聚焦在条件本身。
+          // 回环边：标签只写阈值条件（<90分），不加 ↻ 之类的前缀符号。
+          // 路径已经是向上拱的正交折线 + 红色虚线，「回环」语义靠视觉传达，
+          // 文字聚焦在「什么情况下」这一核心信息上。
           const name = targetNameOf(failTarget);
           layoutEdges.push({
             from: String(step.id), to: String(failTarget),
             label: isLoopBack
-              ? `↻ <${step.min_rating}分`
+              ? `<${step.min_rating}分`
               : step.on_rating_fail === 'goto' ? `❌→${name}`
               : step.on_rating_fail === 'skip' ? '失败→继续' : '',
             type: failType, fromId: step.id, toId: failTarget,

--- a/frontend/src/components/loop-flow/LoopFlowGraph.tsx
+++ b/frontend/src/components/loop-flow/LoopFlowGraph.tsx
@@ -105,11 +105,14 @@ function useFlowLayout(steps: LoopStepDto[]) {
           const targetIdx = stepIndexById.get(failTarget);
           const isLoopBack = failType === 'fail-goto'
             && targetIdx != null && targetIdx < sourceIdx;
+          // 回环边：标签写「↻ <阈值分」，阈值取自源 step 的 min_rating。
+          // 比「↻ 重试 笑话」更准——用户一眼看出「评分低于 X 就回退到上一步」，
+          // 目标 step 名出现在连线箭头上，标签聚焦在条件本身。
           const name = targetNameOf(failTarget);
           layoutEdges.push({
             from: String(step.id), to: String(failTarget),
             label: isLoopBack
-              ? `↻ 重试 ${name}`
+              ? `↻ <${step.min_rating}分`
               : step.on_rating_fail === 'goto' ? `❌→${name}`
               : step.on_rating_fail === 'skip' ? '失败→继续' : '',
             type: failType, fromId: step.id, toId: failTarget,

--- a/frontend/src/components/loop-flow/LoopFlowGraph.tsx
+++ b/frontend/src/components/loop-flow/LoopFlowGraph.tsx
@@ -298,13 +298,17 @@ export function LoopFlowGraph({
                   cx={node.x + NODE_WIDTH - 10} cy={node.y + 10} r={4}
                   fill={node.step.enabled ? '#22c55e' : '#94a3b8'}
                 />
+                {/* Index badge 放在 step 左上角（探出卡片外），
+                    不再放在 left-middle——那里正好是入边箭头落点，
+                    圆形 badge 会把箭头完全遮住。移到 top-left 后箭头在
+                    left-middle 自由落下，跟右上角的状态 dot 视觉对角呼应。 */}
                 <rect
-                  x={node.x - 12} y={node.y + NODE_HEIGHT / 2 - 10}
+                  x={node.x - 10} y={node.y - 10}
                   width={20} height={20} rx={10}
                   fill={isSelected ? '#0891b2' : '#f1f5f9'}
                 />
                 <text
-                  x={node.x - 2} y={node.y + NODE_HEIGHT / 2 + 4}
+                  x={node.x} y={node.y + 4}
                   textAnchor="middle" fontSize={11} fontWeight={700}
                   fill={isSelected ? '#ffffff' : '#64748b'}
                   style={{ fontFamily: 'monospace' }}

--- a/frontend/src/components/loop-flow/LoopFlowGraph.tsx
+++ b/frontend/src/components/loop-flow/LoopFlowGraph.tsx
@@ -1,9 +1,33 @@
+// Loop Studio 执行环节流程图。
+//
+// 布局：dagre 自动排列虚拟 Start/End + 真实 step 节点。
+// 渲染：边（FlowEdge） + 真实环节卡片 + Start/End 虚拟节点（FlowVirtualNodes）。
+// 回环：当某环节失败要回到前面重做（fail-goto 目标 step index < 源 step index），
+//       用 U 形向上拱的弧线 + 加粗红色虚线 + 白底「↻ 重试」标签，跟普通跳转区分。
+//
+// 文件按 500 行硬限拆为：
+// - LoopFlowGraph.tsx（本文件）：布局 + 主组装
+// - FlowEdge.tsx：单条边渲染与路径计算
+// - FlowVirtualNodes.tsx：Start/End 节点 + 触发条件徽章
+// - flowConstants.ts / flowTypes.ts：共享常量与类型
+
 import { useMemo } from 'react';
 import dagre from 'dagre';
-import type { LoopStepDto } from '@/types/loop';
+import type { LoopStepDto, LoopTriggerDto } from '@/types/loop';
+import {
+  StartNode, EndNode, TriggerBadges,
+} from '@/components/loop-flow/FlowVirtualNodes';
+import { FlowEdge, classifyEdge, resolveTargetStep } from '@/components/loop-flow/FlowEdge';
+import {
+  NODE_WIDTH, NODE_HEIGHT, RANK_SEP, NODE_SEP,
+  TRIGGER_AREA_WIDTH, LOOP_BACK_TOP_PADDING,
+  VIRTUAL_NODE_RADIUS, START_NODE_ID, END_NODE_ID,
+} from '@/components/loop-flow/flowConstants';
+import type { LayoutNode, LayoutEdge } from '@/components/loop-flow/flowTypes';
 
 interface FlowGraphProps {
   steps: LoopStepDto[];
+  triggers?: LoopTriggerDto[];
   selectedStepId: number | null;
   tracedStepIds?: number[];
   tracedSequenceMap?: Record<number, number>;
@@ -11,120 +35,110 @@ interface FlowGraphProps {
   onAddStep: () => void;
 }
 
-const NODE_WIDTH = 180;
-const NODE_HEIGHT = 80;
-const RANK_SEP = 60;
-const NODE_SEP = 30;
-
-type EdgeType = 'success-next' | 'success-goto' | 'fail-skip' | 'fail-goto' | 'fail-break' | 'end';
-
-interface LayoutEdge {
-  from: string;
-  to: string;
-  label: string;
-  type: EdgeType;
-  fromId: number;
-  toId: number;
-}
-
-interface LayoutNode {
-  id: number;
-  x: number;
-  y: number;
-  step: LoopStepDto;
-}
-
-const EDGE_STYLES: Record<EdgeType, { color: string; dash: string; labelColor: string }> = {
-  'success-next': { color: '#94a3b8', dash: '', labelColor: '#94a3b8' },
-  'success-goto': { color: '#22c55e', dash: '', labelColor: '#16a34a' },
-  'fail-skip':    { color: '#f97316', dash: '5,3', labelColor: '#ea580c' },
-  'fail-goto':    { color: '#ef4444', dash: '', labelColor: '#dc2626' },
-  'fail-break':   { color: '#ef4444', dash: '', labelColor: '#dc2626' },
-  'end':          { color: '#94a3b8', dash: '', labelColor: '#94a3b8' },
-};
-
-function classifyEdge(
-  _step: LoopStepDto,
-  _allSteps: LoopStepDto[],
-  policy: string,
-  _gotoId: number | null,
-  isSuccess: boolean,
-): EdgeType {
-  if (policy === 'end') return 'end';
-  if (isSuccess) {
-    if (policy === 'goto') return 'success-goto';
-    return 'success-next';
-  }
-  // failure edges
-  switch (policy) {
-    case 'skip': return 'fail-skip';
-    case 'goto': return 'fail-goto';
-    case 'break': return 'fail-break';
-    default: return 'fail-break';
-  }
-}
-
-function resolveTargetStep(
-  step: LoopStepDto,
-  allSteps: LoopStepDto[],
-  policy: string,
-  gotoId: number | null,
-): number | undefined {
-  if (policy === 'next' || policy === 'skip') {
-    const idx = allSteps.findIndex(s => s.id === step.id);
-    if (idx >= 0 && idx < allSteps.length - 1) {
-      return allSteps[idx + 1].id;
-    }
-    return undefined;
-  }
-  if (policy === 'goto' && gotoId != null) {
-    return gotoId;
-  }
-  return undefined;
-}
-
-function useFlowLayout(steps: LoopStepDto[]) {
+function useFlowLayout(steps: LoopStepDto[], triggerCount: number) {
   return useMemo(() => {
-    if (steps.length === 0) return { nodes: [], edges: [] as LayoutEdge[], width: 0, height: 0 };
+    if (steps.length === 0) return {
+      nodes: [] as LayoutNode[], edges: [] as LayoutEdge[], width: 0, height: 0,
+      startX: 0, startY: 0, endX: 0, endY: 0,
+      triggerAreaWidth: 0, hasLoopBack: false,
+    };
 
     const g = new dagre.graphlib.Graph();
     g.setGraph({ rankdir: 'LR', ranksep: RANK_SEP, nodesep: NODE_SEP, marginx: 20, marginy: 20 });
     g.setDefaultEdgeLabel(() => ({}));
 
-    // Add nodes
+    // 虚拟 Start / End 节点（dagre 用 width/height 计算位置，半径由 VIRTUAL_NODE_RADIUS 决定）
+    const VIRTUAL_NODE_SIZE = VIRTUAL_NODE_RADIUS * 2;
+    g.setNode(String(START_NODE_ID), { width: VIRTUAL_NODE_SIZE, height: VIRTUAL_NODE_SIZE });
+    g.setNode(String(END_NODE_ID),   { width: VIRTUAL_NODE_SIZE, height: VIRTUAL_NODE_SIZE });
+
+    // 真实 step 节点
     for (const step of steps) {
       g.setNode(String(step.id), { width: NODE_WIDTH, height: NODE_HEIGHT });
     }
 
-    // Build edges
+    // 边集合：Start→first、step↔step（含回环识别）、step→end 都会 push 进来。
+    // dagre 知道这些边用于布局，前端按 layoutEdges 渲染。
     const layoutEdges: LayoutEdge[] = [];
+    const stepIndexById = new Map<number, number>();
+    steps.forEach((s, i) => stepIndexById.set(s.id, i));
+
+    // Start → 第一个 step：dagre 用这条边把首节点排到 Start 右侧，
+    // layoutEdges 也得 push 同款边，否则前端不会画这条连线。
+    if (steps.length > 0) {
+      g.setEdge(String(START_NODE_ID), String(steps[0].id));
+      layoutEdges.push({
+        from: String(START_NODE_ID), to: String(steps[0].id),
+        label: '',
+        type: 'start-first', fromId: START_NODE_ID, toId: steps[0].id,
+      });
+    }
+
     for (const step of steps) {
-      // Success edge
+      const sourceIdx = stepIndexById.get(step.id) ?? 0;
+      const targetNameOf = (id: number) => steps.find(s => s.id === id)?.name || String(id);
+
+      // 成功边
       const successType = classifyEdge(step, steps, step.on_success, step.success_goto_step_id, true);
       const successTarget = resolveTargetStep(step, steps, step.on_success, step.success_goto_step_id);
       if (successTarget != null) {
         g.setEdge(String(step.id), String(successTarget));
+        const targetIdx = stepIndexById.get(successTarget);
+        const isLoopBack = successType === 'success-goto'
+          && targetIdx != null && targetIdx < sourceIdx;
+        const name = targetNameOf(successTarget);
         layoutEdges.push({
           from: String(step.id), to: String(successTarget),
-          label: step.on_success === 'goto' ? `✅→${steps.find(s => s.id === successTarget)?.name || successTarget}` : '',
+          label: isLoopBack
+            ? `↻ 跳回 ${name}`
+            : step.on_success === 'goto' ? `✅→${name}` : '',
           type: successType, fromId: step.id, toId: successTarget,
+          isLoopBack,
         });
       }
 
-      // Failure edge (only if different from success edge)
+      // 失败边（仅当策略与成功策略不同时绘制，避免双线重叠）
       if (step.min_rating != null && step.on_rating_fail !== step.on_success) {
         const failType = classifyEdge(step, steps, step.on_rating_fail, step.fail_goto_step_id, false);
         const failTarget = resolveTargetStep(step, steps, step.on_rating_fail, step.fail_goto_step_id);
         if (failTarget != null) {
           g.setEdge(String(step.id), String(failTarget));
+          const targetIdx = stepIndexById.get(failTarget);
+          const isLoopBack = failType === 'fail-goto'
+            && targetIdx != null && targetIdx < sourceIdx;
+          const name = targetNameOf(failTarget);
           layoutEdges.push({
             from: String(step.id), to: String(failTarget),
-            label: step.on_rating_fail === 'goto' ? `❌→${steps.find(s => s.id === failTarget)?.name || failTarget}` : 
-                    step.on_rating_fail === 'skip' ? '失败→继续' : '',
+            label: isLoopBack
+              ? `↻ 重试 ${name}`
+              : step.on_rating_fail === 'goto' ? `❌→${name}`
+              : step.on_rating_fail === 'skip' ? '失败→继续' : '',
             type: failType, fromId: step.id, toId: failTarget,
+            isLoopBack,
           });
         }
       }
+    }
+
+    // 任何带 end 策略的环节连到 End 节点
+    for (const step of steps) {
+      if (step.on_success === 'end' || step.on_rating_fail === 'end') {
+        g.setEdge(String(step.id), String(END_NODE_ID));
+        layoutEdges.push({
+          from: String(step.id), to: String(END_NODE_ID),
+          label: '',
+          type: 'end', fromId: step.id, toId: END_NODE_ID,
+        });
+      }
+    }
+    // 兜底：所有环节都跑通后没显式 end 策略，就把最后一个 step 连到 End
+    if (!layoutEdges.some(e => e.toId === END_NODE_ID) && steps.length > 0) {
+      const lastId = steps[steps.length - 1].id;
+      g.setEdge(String(lastId), String(END_NODE_ID));
+      layoutEdges.push({
+        from: String(lastId), to: String(END_NODE_ID),
+        label: '', type: 'end', fromId: lastId, toId: END_NODE_ID,
+      });
     }
 
     dagre.layout(g);
@@ -139,21 +153,52 @@ function useFlowLayout(steps: LoopStepDto[]) {
       };
     });
 
+    const startPos = g.node(String(START_NODE_ID));
+    const endPos = g.node(String(END_NODE_ID));
+
     const graphWidth = g.graph().width || 0;
     const graphHeight = g.graph().height || 0;
 
-    return { nodes, edges: layoutEdges, width: graphWidth + 40, height: graphHeight + 40 };
-  }, [steps]);
+    // 顶部留白：任一连线是回环（弧线向上），给 SVG 顶部加 padding，
+    // 否则弧线会裁切。dagre 内容整体下移以让出顶部空间。
+    const hasLoopBack = layoutEdges.some(e => e.isLoopBack);
+    const loopBackPad = hasLoopBack ? LOOP_BACK_TOP_PADDING : 0;
+
+    return {
+      nodes,
+      edges: layoutEdges,
+      width: graphWidth + 40 + (triggerCount > 0 ? TRIGGER_AREA_WIDTH : 0),
+      height: graphHeight + 40 + loopBackPad,
+      startX: startPos?.x ?? 40,
+      startY: startPos?.y ?? 40,
+      endX: endPos?.x ?? graphWidth - 40,
+      endY: endPos?.y ?? graphHeight - 40,
+      triggerAreaWidth: triggerCount > 0 ? TRIGGER_AREA_WIDTH : 0,
+      hasLoopBack,
+    };
+  }, [steps, triggerCount]);
 }
 
-export function LoopFlowGraph({ steps, selectedStepId, tracedStepIds = [], tracedSequenceMap: _tracedSequenceMap = {}, onSelectStep, onAddStep }: FlowGraphProps) {
-  const { nodes, edges, width, height } = useFlowLayout(steps);
+export function LoopFlowGraph({
+  steps, triggers = [],
+  selectedStepId, tracedStepIds = [], tracedSequenceMap: _tracedSequenceMap = {},
+  onSelectStep, onAddStep,
+}: FlowGraphProps) {
+  const enabledTriggerCount = useMemo(
+    () => triggers.filter(t => t.enabled).length, [triggers],
+  );
+  const {
+    nodes, edges, width, height,
+    startX, startY, endX, endY, triggerAreaWidth,
+    hasLoopBack,
+  } = useFlowLayout(steps, enabledTriggerCount);
+  // 有回环时把 dagre 内容整体下移，让 U 形弧线在顶部有画布。
+  const dagreOffsetY = hasLoopBack ? LOOP_BACK_TOP_PADDING : 0;
 
-  // 判断节点是否在轨迹中
+  // 判断节点/边是否在执行轨迹中。轨迹为空表示全亮。
   const isTraced = (id: number) => tracedStepIds.length === 0 || tracedStepIds.includes(id);
   const traceIndex = (id: number) => tracedStepIds.indexOf(id);
-
-  // 判断边是否在轨迹中（源和目标都在 tracedStepIds 中且连续）
+  // 边在轨迹中：源和目标都出现且目标在源的下一个位置
   const isEdgeTraced = (fromId: number, toId: number) => {
     if (tracedStepIds.length === 0) return true;
     const fi = tracedStepIds.indexOf(fromId);
@@ -191,147 +236,128 @@ export function LoopFlowGraph({ steps, selectedStepId, tracedStepIds = [], trace
   return (
     <div style={{ overflowX: 'auto', overflowY: 'hidden', padding: '12px 0', minHeight: 160 }}>
       <svg width={width} height={height} style={{ display: 'block' }}>
-        {/* Edges */}
-        {edges.map((edge, i) => {
-          const style = EDGE_STYLES[edge.type] || EDGE_STYLES['success-next'];
-          const traced = isEdgeTraced(edge.fromId, edge.toId);
-          const hasTrace = tracedStepIds.length > 0;
-          const opacity = hasTrace ? (traced ? 1 : 0.15) : 1;
-          return (
-            <g key={`edge-${i}`} opacity={opacity}>
-              {/* Arrow line */}
-              <defs>
-                <marker
-                  id={`arrow-${i}`}
-                  viewBox="0 0 10 10" refX="10" refY="5"
-                  markerWidth="6" markerHeight="6" orient="auto"
-                >
-                  <path d="M 0 0 L 10 5 L 0 10 z" fill={style.color} />
-                </marker>
-              </defs>
-              <path
-                d={buildEdgePath(edge, nodes)}
-                fill="none"
-                stroke={style.color}
-                strokeWidth={hasTrace && traced ? 3 : 1.5}
-                strokeDasharray={style.dash || undefined}
-                markerEnd={`url(#arrow-${i})`}
-              />
-              {/* Label */}
-              {edge.label && (
+        {/* 触发条件徽章：放在 SVG 绝对坐标系的左侧，不参与 dagre 平移。
+            这样徽章的几何中心能与右侧 dagre 内容的 Start 节点垂直对齐。 */}
+        <TriggerBadges
+          triggers={triggers}
+          startX={triggerAreaWidth + startX}
+          startY={startY}
+        />
+
+        {/* dagre 布局的所有内容（边、真实环节、Start/End 节点）整体右移
+            triggerAreaWidth，让出左侧徽章区域；如有回环则再下移 dagreOffsetY
+            腾出顶部空间画 U 形弧线。 */}
+        <g transform={`translate(${triggerAreaWidth}, ${dagreOffsetY})`}>
+          {/* 边 */}
+          {edges.map((edge, i) => (
+            <FlowEdge
+              key={`edge-${i}`}
+              edge={edge}
+              index={i}
+              nodes={nodes}
+              startX={startX}
+              startY={startY}
+              endX={endX}
+              endY={endY}
+              tracedStepIds={tracedStepIds}
+              isEdgeTraced={isEdgeTraced}
+            />
+          ))}
+
+          {/* Start / End 虚拟节点 */}
+          <StartNode x={startX} y={startY} />
+          <EndNode x={endX} y={endY} />
+
+          {/* 真实环节节点 */}
+          {nodes.map((node) => {
+            const traced = isTraced(node.id);
+            const hasTrace = tracedStepIds.length > 0;
+            const opacity = hasTrace ? (traced ? 1 : 0.3) : 1;
+            const ti = traceIndex(node.id);
+            const isSelected = selectedStepId === node.id;
+            return (
+              <g
+                key={`node-${node.id}`}
+                onClick={() => onSelectStep(node.step)}
+                style={{ cursor: 'pointer' }}
+                opacity={opacity}
+              >
+                <rect
+                  x={node.x} y={node.y}
+                  width={NODE_WIDTH} height={NODE_HEIGHT}
+                  rx={8} ry={8}
+                  fill={isSelected ? '#f0f9ff' : '#ffffff'}
+                  stroke={isSelected ? '#0891b2' : (hasTrace && traced ? '#22c55e' : '#e2e8f0')}
+                  strokeWidth={isSelected ? 2 : (hasTrace && traced ? 2 : 1)}
+                />
+                {hasTrace && traced && ti >= 0 && (
+                  <rect
+                    x={node.x + NODE_WIDTH - 28} y={node.y + NODE_HEIGHT - 18}
+                    width={22} height={14} rx={4} fill="#22c55e"
+                  />
+                )}
+                {hasTrace && traced && ti >= 0 && (
+                  <text
+                    x={node.x + NODE_WIDTH - 17} y={node.y + NODE_HEIGHT - 7}
+                    textAnchor="middle" fontSize={8} fontWeight={700} fill="#ffffff"
+                    style={{ fontFamily: 'monospace' }}
+                  >
+                    {ti + 1}
+                  </text>
+                )}
+                <circle
+                  cx={node.x + NODE_WIDTH - 10} cy={node.y + 10} r={4}
+                  fill={node.step.enabled ? '#22c55e' : '#94a3b8'}
+                />
+                <rect
+                  x={node.x - 12} y={node.y + NODE_HEIGHT / 2 - 10}
+                  width={20} height={20} rx={10}
+                  fill={isSelected ? '#0891b2' : '#f1f5f9'}
+                />
                 <text
-                  x={getEdgeMidX(edge, nodes)}
-                  y={getEdgeMidY(edge, nodes) - 6}
-                  textAnchor="middle"
-                  fontSize={10}
-                  fill={style.labelColor}
+                  x={node.x - 2} y={node.y + NODE_HEIGHT / 2 + 4}
+                  textAnchor="middle" fontSize={11} fontWeight={700}
+                  fill={isSelected ? '#ffffff' : '#64748b'}
                   style={{ fontFamily: 'monospace' }}
                 >
-                  {edge.label}
+                  {String(nodes.indexOf(node) + 1).padStart(2, '0')}
                 </text>
-              )}
-            </g>
-          );
-        })}
-
-        {/* Nodes */}
-        {nodes.map(node => {
-          const traced = isTraced(node.id);
-          const hasTrace = tracedStepIds.length > 0;
-          const opacity = hasTrace ? (traced ? 1 : 0.3) : 1;
-          const ti = traceIndex(node.id);
-          const isSelected = selectedStepId === node.id;
-          return (
-          <g
-            key={`node-${node.id}`}
-            onClick={() => onSelectStep(node.step)}
-            style={{ cursor: 'pointer' }}
-            opacity={opacity}
-          >
-            <rect
-              x={node.x} y={node.y}
-              width={NODE_WIDTH} height={NODE_HEIGHT}
-              rx={8} ry={8}
-              fill={isSelected ? '#f0f9ff' : '#ffffff'}
-              stroke={isSelected ? '#0891b2' : (hasTrace && traced ? '#22c55e' : '#e2e8f0')}
-              strokeWidth={isSelected ? 2 : (hasTrace && traced ? 2 : 1)}
-            />
-            {/* Traced step index badge */}
-            {hasTrace && traced && ti >= 0 && (
-              <rect
-                x={node.x + NODE_WIDTH - 28} y={node.y + NODE_HEIGHT - 18}
-                width={22} height={14} rx={4}
-                fill="#22c55e"
-              />
-            )}
-            {hasTrace && traced && ti >= 0 && (
-              <text
-                x={node.x + NODE_WIDTH - 17} y={node.y + NODE_HEIGHT - 7}
-                textAnchor="middle" fontSize={8} fontWeight={700}
-                fill="#ffffff"
-                style={{ fontFamily: 'monospace' }}
-              >
-                {ti + 1}
-              </text>
-            )}
-            {/* Status dot */}
-            <circle
-              cx={node.x + NODE_WIDTH - 10} cy={node.y + 10} r={4}
-              fill={node.step.enabled ? '#22c55e' : '#94a3b8'}
-            />
-            {/* Index badge */}
-            <rect
-              x={node.x - 12} y={node.y + NODE_HEIGHT / 2 - 10}
-              width={20} height={20} rx={10}
-              fill={isSelected ? '#0891b2' : '#f1f5f9'}
-            />
-            <text
-              x={node.x - 2} y={node.y + NODE_HEIGHT / 2 + 4}
-              textAnchor="middle" fontSize={11} fontWeight={700}
-              fill={isSelected ? '#ffffff' : '#64748b'}
-              style={{ fontFamily: 'monospace' }}
-            >
-              {String(nodes.indexOf(node) + 1).padStart(2, '0')}
-            </text>
-            {/* Name */}
-            <text
-              x={node.x + 12} y={node.y + 22}
-              fontSize={13} fontWeight={600}
-              fill={hasTrace && !traced ? '#cbd5e1' : '#0f172a'}
-              style={{ fontFamily: 'system-ui' }}
-            >
-              {truncateText(node.step.name, 18)}
-            </text>
-            {/* Todo title */}
-            <text
-              x={node.x + 12} y={node.y + 40}
-              fontSize={11}
-              fill={hasTrace && !traced ? '#cbd5e1' : '#64748b'}
-            >
-              {truncateText(node.step.todo_title || `#${node.step.todo_id}`, 22)}
-            </text>
-            {/* Executor */}
-            <text
-              x={node.x + 12} y={node.y + 56}
-              fontSize={10}
-              fill={hasTrace && !traced ? '#e2e8f0' : '#94a3b8'}
-            >
-              {node.step.todo_executor || '未指派'}
-            </text>
-            {/* Gate indicator */}
-            {node.step.min_rating != null && (
-              <text
-                x={node.x + NODE_WIDTH - 8} y={node.y + NODE_HEIGHT - 6}
-                textAnchor="end" fontSize={9}
-                fill={hasTrace && !traced ? '#e2e8f0' : '#f97316'}
-                style={{ fontFamily: 'monospace' }}
-              >
-                闸门:{node.step.min_rating}
-              </text>
-            )}
-          </g>
-          );
-        })}
+                <text
+                  x={node.x + 12} y={node.y + 22}
+                  fontSize={13} fontWeight={600}
+                  fill={hasTrace && !traced ? '#cbd5e1' : '#0f172a'}
+                  style={{ fontFamily: 'system-ui' }}
+                >
+                  {truncateText(node.step.name, 18)}
+                </text>
+                <text
+                  x={node.x + 12} y={node.y + 40}
+                  fontSize={11}
+                  fill={hasTrace && !traced ? '#cbd5e1' : '#64748b'}
+                >
+                  {truncateText(node.step.todo_title || `#${node.step.todo_id}`, 22)}
+                </text>
+                <text
+                  x={node.x + 12} y={node.y + 56}
+                  fontSize={10}
+                  fill={hasTrace && !traced ? '#e2e8f0' : '#94a3b8'}
+                >
+                  {node.step.todo_executor || '未指派'}
+                </text>
+                {node.step.min_rating != null && (
+                  <text
+                    x={node.x + NODE_WIDTH - 8} y={node.y + NODE_HEIGHT - 6}
+                    textAnchor="end" fontSize={9}
+                    fill={hasTrace && !traced ? '#e2e8f0' : '#f97316'}
+                    style={{ fontFamily: 'monospace' }}
+                  >
+                    闸门:{node.step.min_rating}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+        </g>
       </svg>
 
       {/* Add button */}
@@ -362,38 +388,7 @@ export function LoopFlowGraph({ steps, selectedStepId, tracedStepIds = [], trace
   );
 }
 
-// ─── Helpers ───
-
+// 按字符数粗截断，避免环节名过长溢出卡片。
 function truncateText(text: string, maxLen: number): string {
   return text.length > maxLen ? text.slice(0, maxLen - 1) + '…' : text;
-}
-
-function buildEdgePath(edge: LayoutEdge, nodes: LayoutNode[]): string {
-  const from = nodes.find(n => n.id === edge.fromId);
-  const to = nodes.find(n => n.id === edge.toId);
-  if (!from || !to) return '';
-
-  const x1 = from.x + NODE_WIDTH;
-  const y1 = from.y + NODE_HEIGHT / 2;
-  const x2 = to.x;
-  const y2 = to.y + NODE_HEIGHT / 2;
-
-  const dx = Math.abs(x2 - x1);
-  const cx = x1 + dx * 0.4;
-
-  return `M ${x1} ${y1} C ${cx} ${y1}, ${x2 - dx * 0.4} ${y2}, ${x2} ${y2}`;
-}
-
-function getEdgeMidX(edge: LayoutEdge, nodes: LayoutNode[]): number {
-  const from = nodes.find(n => n.id === edge.fromId);
-  const to = nodes.find(n => n.id === edge.toId);
-  if (!from || !to) return 0;
-  return (from.x + NODE_WIDTH + to.x) / 2;
-}
-
-function getEdgeMidY(edge: LayoutEdge, nodes: LayoutNode[]): number {
-  const from = nodes.find(n => n.id === edge.fromId);
-  const to = nodes.find(n => n.id === edge.toId);
-  if (!from || !to) return 0;
-  return (from.y + NODE_HEIGHT / 2 + to.y + NODE_HEIGHT / 2) / 2;
 }

--- a/frontend/src/components/loop-flow/LoopFlowGraph.tsx
+++ b/frontend/src/components/loop-flow/LoopFlowGraph.tsx
@@ -3,31 +3,30 @@
 // 布局：dagre 自动排列虚拟 Start/End + 真实 step 节点。
 // 渲染：边（FlowEdge） + 真实环节卡片 + Start/End 虚拟节点（FlowVirtualNodes）。
 // 回环：当某环节失败要回到前面重做（fail-goto 目标 step index < 源 step index），
-//       用 U 形向上拱的弧线 + 加粗红色虚线 + 白底「↻ 重试」标签，跟普通跳转区分。
+//       用正交折线（顶边出 + 顶边入）+ 加粗红色虚线 + 白底「↻ 重试」标签。
 //
 // 文件按 500 行硬限拆为：
 // - LoopFlowGraph.tsx（本文件）：布局 + 主组装
 // - FlowEdge.tsx：单条边渲染与路径计算
-// - FlowVirtualNodes.tsx：Start/End 节点 + 触发条件徽章
+// - FlowVirtualNodes.tsx：Start/End 节点
 // - flowConstants.ts / flowTypes.ts：共享常量与类型
 
 import { useMemo } from 'react';
 import dagre from 'dagre';
-import type { LoopStepDto, LoopTriggerDto } from '@/types/loop';
+import type { LoopStepDto } from '@/types/loop';
 import {
-  StartNode, EndNode, TriggerBadges,
+  StartNode, EndNode,
 } from '@/components/loop-flow/FlowVirtualNodes';
 import { FlowEdge, classifyEdge, resolveTargetStep } from '@/components/loop-flow/FlowEdge';
 import {
   NODE_WIDTH, NODE_HEIGHT, RANK_SEP, NODE_SEP,
-  TRIGGER_AREA_WIDTH, LOOP_BACK_TOP_PADDING,
+  LOOP_BACK_TOP_PADDING,
   VIRTUAL_NODE_RADIUS, START_NODE_ID, END_NODE_ID,
 } from '@/components/loop-flow/flowConstants';
 import type { LayoutNode, LayoutEdge } from '@/components/loop-flow/flowTypes';
 
 interface FlowGraphProps {
   steps: LoopStepDto[];
-  triggers?: LoopTriggerDto[];
   selectedStepId: number | null;
   tracedStepIds?: number[];
   tracedSequenceMap?: Record<number, number>;
@@ -35,12 +34,12 @@ interface FlowGraphProps {
   onAddStep: () => void;
 }
 
-function useFlowLayout(steps: LoopStepDto[], triggerCount: number) {
+function useFlowLayout(steps: LoopStepDto[]) {
   return useMemo(() => {
     if (steps.length === 0) return {
       nodes: [] as LayoutNode[], edges: [] as LayoutEdge[], width: 0, height: 0,
       startX: 0, startY: 0, endX: 0, endY: 0,
-      triggerAreaWidth: 0, hasLoopBack: false,
+      hasLoopBack: false,
     };
 
     const g = new dagre.graphlib.Graph();
@@ -167,32 +166,28 @@ function useFlowLayout(steps: LoopStepDto[], triggerCount: number) {
     return {
       nodes,
       edges: layoutEdges,
-      width: graphWidth + 40 + (triggerCount > 0 ? TRIGGER_AREA_WIDTH : 0),
+      width: graphWidth + 40,
       height: graphHeight + 40 + loopBackPad,
       startX: startPos?.x ?? 40,
       startY: startPos?.y ?? 40,
       endX: endPos?.x ?? graphWidth - 40,
       endY: endPos?.y ?? graphHeight - 40,
-      triggerAreaWidth: triggerCount > 0 ? TRIGGER_AREA_WIDTH : 0,
       hasLoopBack,
     };
-  }, [steps, triggerCount]);
+  }, [steps]);
 }
 
 export function LoopFlowGraph({
-  steps, triggers = [],
+  steps,
   selectedStepId, tracedStepIds = [], tracedSequenceMap: _tracedSequenceMap = {},
   onSelectStep, onAddStep,
 }: FlowGraphProps) {
-  const enabledTriggerCount = useMemo(
-    () => triggers.filter(t => t.enabled).length, [triggers],
-  );
   const {
     nodes, edges, width, height,
-    startX, startY, endX, endY, triggerAreaWidth,
+    startX, startY, endX, endY,
     hasLoopBack,
-  } = useFlowLayout(steps, enabledTriggerCount);
-  // 有回环时把 dagre 内容整体下移，让 U 形弧线在顶部有画布。
+  } = useFlowLayout(steps);
+  // 有回环时把 dagre 内容整体下移，让顶部正交折线有画布。
   const dagreOffsetY = hasLoopBack ? LOOP_BACK_TOP_PADDING : 0;
 
   // 判断节点/边是否在执行轨迹中。轨迹为空表示全亮。
@@ -236,18 +231,9 @@ export function LoopFlowGraph({
   return (
     <div style={{ overflowX: 'auto', overflowY: 'hidden', padding: '12px 0', minHeight: 160 }}>
       <svg width={width} height={height} style={{ display: 'block' }}>
-        {/* 触发条件徽章：放在 SVG 绝对坐标系的左侧，不参与 dagre 平移。
-            这样徽章的几何中心能与右侧 dagre 内容的 Start 节点垂直对齐。 */}
-        <TriggerBadges
-          triggers={triggers}
-          startX={triggerAreaWidth + startX}
-          startY={startY}
-        />
-
-        {/* dagre 布局的所有内容（边、真实环节、Start/End 节点）整体右移
-            triggerAreaWidth，让出左侧徽章区域；如有回环则再下移 dagreOffsetY
-            腾出顶部空间画 U 形弧线。 */}
-        <g transform={`translate(${triggerAreaWidth}, ${dagreOffsetY})`}>
+        {/* dagre 布局的所有内容（边、真实环节、Start/End 节点）。
+            有回环时下移 dagreOffsetY 腾出顶部空间画正交折线。 */}
+        <g transform={`translate(0, ${dagreOffsetY})`}>
           {/* 边 */}
           {edges.map((edge, i) => (
             <FlowEdge

--- a/frontend/src/components/loop-flow/LoopFlowGraph.tsx
+++ b/frontend/src/components/loop-flow/LoopFlowGraph.tsx
@@ -28,8 +28,6 @@ import type { LayoutNode, LayoutEdge } from '@/components/loop-flow/flowTypes';
 interface FlowGraphProps {
   steps: LoopStepDto[];
   selectedStepId: number | null;
-  tracedStepIds?: number[];
-  tracedSequenceMap?: Record<number, number>;
   onSelectStep: (step: LoopStepDto) => void;
   onAddStep: () => void;
 }
@@ -182,7 +180,7 @@ function useFlowLayout(steps: LoopStepDto[]) {
 
 export function LoopFlowGraph({
   steps,
-  selectedStepId, tracedStepIds = [], tracedSequenceMap: _tracedSequenceMap = {},
+  selectedStepId,
   onSelectStep, onAddStep,
 }: FlowGraphProps) {
   const {
@@ -192,17 +190,6 @@ export function LoopFlowGraph({
   } = useFlowLayout(steps);
   // 有回环时把 dagre 内容整体下移，让顶部正交折线有画布。
   const dagreOffsetY = hasLoopBack ? LOOP_BACK_TOP_PADDING : 0;
-
-  // 判断节点/边是否在执行轨迹中。轨迹为空表示全亮。
-  const isTraced = (id: number) => tracedStepIds.length === 0 || tracedStepIds.includes(id);
-  const traceIndex = (id: number) => tracedStepIds.indexOf(id);
-  // 边在轨迹中：源和目标都出现且目标在源的下一个位置
-  const isEdgeTraced = (fromId: number, toId: number) => {
-    if (tracedStepIds.length === 0) return true;
-    const fi = tracedStepIds.indexOf(fromId);
-    const ti = tracedStepIds.indexOf(toId);
-    return fi >= 0 && ti >= 0 && ti === fi + 1;
-  };
 
   if (steps.length === 0) {
     return (
@@ -248,8 +235,6 @@ export function LoopFlowGraph({
               startY={startY}
               endX={endX}
               endY={endY}
-              tracedStepIds={tracedStepIds}
-              isEdgeTraced={isEdgeTraced}
             />
           ))}
 
@@ -259,41 +244,21 @@ export function LoopFlowGraph({
 
           {/* 真实环节节点 */}
           {nodes.map((node) => {
-            const traced = isTraced(node.id);
-            const hasTrace = tracedStepIds.length > 0;
-            const opacity = hasTrace ? (traced ? 1 : 0.3) : 1;
-            const ti = traceIndex(node.id);
             const isSelected = selectedStepId === node.id;
             return (
               <g
                 key={`node-${node.id}`}
                 onClick={() => onSelectStep(node.step)}
                 style={{ cursor: 'pointer' }}
-                opacity={opacity}
               >
                 <rect
                   x={node.x} y={node.y}
                   width={NODE_WIDTH} height={NODE_HEIGHT}
                   rx={8} ry={8}
                   fill={isSelected ? '#f0f9ff' : '#ffffff'}
-                  stroke={isSelected ? '#0891b2' : (hasTrace && traced ? '#22c55e' : '#e2e8f0')}
-                  strokeWidth={isSelected ? 2 : (hasTrace && traced ? 2 : 1)}
+                  stroke={isSelected ? '#0891b2' : '#e2e8f0'}
+                  strokeWidth={isSelected ? 2 : 1}
                 />
-                {hasTrace && traced && ti >= 0 && (
-                  <rect
-                    x={node.x + NODE_WIDTH - 28} y={node.y + NODE_HEIGHT - 18}
-                    width={22} height={14} rx={4} fill="#22c55e"
-                  />
-                )}
-                {hasTrace && traced && ti >= 0 && (
-                  <text
-                    x={node.x + NODE_WIDTH - 17} y={node.y + NODE_HEIGHT - 7}
-                    textAnchor="middle" fontSize={8} fontWeight={700} fill="#ffffff"
-                    style={{ fontFamily: 'monospace' }}
-                  >
-                    {ti + 1}
-                  </text>
-                )}
                 <circle
                   cx={node.x + NODE_WIDTH - 10} cy={node.y + 10} r={4}
                   fill={node.step.enabled ? '#22c55e' : '#94a3b8'}
@@ -318,7 +283,7 @@ export function LoopFlowGraph({
                 <text
                   x={node.x + 12} y={node.y + 22}
                   fontSize={13} fontWeight={600}
-                  fill={hasTrace && !traced ? '#cbd5e1' : '#0f172a'}
+                  fill="#0f172a"
                   style={{ fontFamily: 'system-ui' }}
                 >
                   {truncateText(node.step.name, 18)}
@@ -326,14 +291,14 @@ export function LoopFlowGraph({
                 <text
                   x={node.x + 12} y={node.y + 40}
                   fontSize={11}
-                  fill={hasTrace && !traced ? '#cbd5e1' : '#64748b'}
+                  fill="#64748b"
                 >
                   {truncateText(node.step.todo_title || `#${node.step.todo_id}`, 22)}
                 </text>
                 <text
                   x={node.x + 12} y={node.y + 56}
                   fontSize={10}
-                  fill={hasTrace && !traced ? '#e2e8f0' : '#94a3b8'}
+                  fill="#94a3b8"
                 >
                   {node.step.todo_executor || '未指派'}
                 </text>
@@ -341,7 +306,7 @@ export function LoopFlowGraph({
                   <text
                     x={node.x + NODE_WIDTH - 8} y={node.y + NODE_HEIGHT - 6}
                     textAnchor="end" fontSize={9}
-                    fill={hasTrace && !traced ? '#e2e8f0' : '#f97316'}
+                    fill="#f97316"
                     style={{ fontFamily: 'monospace' }}
                   >
                     闸门:{node.step.min_rating}

--- a/frontend/src/components/loop-flow/flowConstants.ts
+++ b/frontend/src/components/loop-flow/flowConstants.ts
@@ -1,0 +1,23 @@
+// Loop 流程图共享常量与虚拟节点 ID。
+//
+// 同时被 LoopFlowGraph、FlowEdge、FlowVirtualNodes 引用，集中在一处
+// 避免修改时漏改导致尺寸对不上。
+
+export const NODE_WIDTH = 180;
+export const NODE_HEIGHT = 80;
+export const RANK_SEP = 60;
+export const NODE_SEP = 30;
+
+export const VIRTUAL_NODE_RADIUS = 20;
+export const VIRTUAL_NODE_SIZE = VIRTUAL_NODE_RADIUS * 2;
+
+// 触发条件徽章占用区：放在 Start 节点左侧。
+// 140 = 8 左内边距 + 110 徽章 + 22 间距 + dagre marginx(20) 的预留
+export const TRIGGER_AREA_WIDTH = 140;
+
+// 回环边弧顶距 dagre 内容顶部的距离。决定 SVG 顶部留白大小，
+// 同时也是 buildEdgePath 中回环控制点的 Y 偏移（绝对值）。
+export const LOOP_BACK_TOP_PADDING = 100;
+
+export const START_NODE_ID = -1;
+export const END_NODE_ID = -2;

--- a/frontend/src/components/loop-flow/flowConstants.ts
+++ b/frontend/src/components/loop-flow/flowConstants.ts
@@ -11,10 +11,6 @@ export const NODE_SEP = 30;
 export const VIRTUAL_NODE_RADIUS = 20;
 export const VIRTUAL_NODE_SIZE = VIRTUAL_NODE_RADIUS * 2;
 
-// 触发条件徽章占用区：放在 Start 节点左侧。
-// 140 = 8 左内边距 + 110 徽章 + 22 间距 + dagre marginx(20) 的预留
-export const TRIGGER_AREA_WIDTH = 140;
-
 // 回环边弧顶距 dagre 内容顶部的距离。决定 SVG 顶部留白大小，
 // 同时也是 buildEdgePath 中回环控制点的 Y 偏移（绝对值）。
 export const LOOP_BACK_TOP_PADDING = 100;

--- a/frontend/src/components/loop-flow/flowTypes.ts
+++ b/frontend/src/components/loop-flow/flowTypes.ts
@@ -1,0 +1,30 @@
+// Loop 流程图共享类型。
+import type { LoopStepDto } from '@/types/loop';
+
+export type EdgeType =
+  | 'start-first'
+  | 'success-next'
+  | 'success-goto'
+  | 'fail-skip'
+  | 'fail-goto'
+  | 'fail-break'
+  | 'end';
+
+export interface LayoutEdge {
+  from: string;
+  to: string;
+  label: string;
+  type: EdgeType;
+  fromId: number;
+  toId: number;
+  // 是否跳回到排在前面的环节（goto 的目标 step index < 源 step index）。
+  // 这种「回环」用拱形弧线 + 加粗虚线 + 重试图标标识，跟普通跳转明显区分。
+  isLoopBack?: boolean;
+}
+
+export interface LayoutNode {
+  id: number;
+  x: number;
+  y: number;
+  step: LoopStepDto;
+}

--- a/frontend/tests/check-loop-flow-no-trace-link.spec.ts
+++ b/frontend/tests/check-loop-flow-no-trace-link.spec.ts
@@ -1,0 +1,52 @@
+// 验证：展开「执行历史」不应再让上方流程图的高亮/淡出变化（trace 联动已移除）。
+// 通过 API 找一个有 steps 的 loop，从 ?loop=<id> 路由直接进入详情，对比展开执行历史前后的 SVG 透明度。
+import { test, expect } from '@playwright/test';
+
+const BACKEND_URL = process.env.E2E_BACKEND_URL || 'http://localhost:18088';
+const DEV_URL = 'http://localhost:18088';
+
+test('展开执行历史不应影响流程图渲染', async ({ page }) => {
+  // 找一个至少有 1 个 step 的 loop（通过 API 直接筛选）
+  const listRes = await page.request.get(`${BACKEND_URL}/api/loops?page=1&limit=50`);
+  const listJson = await listRes.json();
+  const loops: Array<{ id: number; step_count: number }> = listJson?.data ?? [];
+  const candidate = loops.find((l) => l.step_count > 0);
+  test.skip(!candidate, '没有可用的带 step 的 loop，跳过用例');
+  const loopId = candidate!.id;
+
+  // 直接从 URL 进入 loop 详情
+  await page.goto(`${DEV_URL}/?loop=${loopId}`);
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(800);
+
+  // 流程图整体在一个 svg 节点里
+  const svg = page.locator('svg').first();
+  await expect(svg).toBeVisible();
+
+  // 采样展开前 SVG 内部各 <g opacity> 的值；移除 trace 后应全为 1。
+  const sampleOpacity = async () => svg.evaluate((root) =>
+    Array.from(root.querySelectorAll('g[opacity]')).map((g) =>
+      parseFloat(g.getAttribute('opacity') || '1'),
+    ),
+  );
+
+  const before = await sampleOpacity();
+
+  // 展开「执行历史」折叠面板
+  const historyHeader = page.getByText(/执行历史/).first();
+  if (await historyHeader.count() > 0) {
+    await historyHeader.click();
+    await page.waitForTimeout(800);
+  }
+
+  const after = await sampleOpacity();
+
+  // 流程图内不应再出现半透明节点/边 —— 全部应保持 1
+  const dimmed = after.filter((o) => o < 1);
+  expect(dimmed, `发现 ${dimmed.length} 个被淡化的 g：${JSON.stringify(after)}`).toEqual([]);
+  // 展开前后 g 数量应当一致（不再因 trace 触发额外的重渲染分支）
+  expect(after.length).toBe(before.length);
+
+  // 截图留档，便于人工核对（不入 git，输出在 test-results/）
+  await page.screenshot({ path: `test-results/loop-flow-no-trace-link-${loopId}.png`, fullPage: false });
+});


### PR DESCRIPTION
## 背景

loop 关联工作空间后，每个环节的执行没有使用工作空间的 git worktree 配置。原因是 `loop_runner` 调用 `run_todo_execution_with_params` 时传 `todo_id=0`，导致 executor service 内部加载不到 todo → worktree 不会被创建，子进程也没有正确的 cwd。

## 改动

### `RunTodoExecutionRequest` 新增 `workspace` 字段
loop runner 能把 loop 的 workspace 显式传递给 executor service，绕过 todo 加载的限制。

### `resolve_worktree_context` 支持显式 workspace 参数
当 todo 为 `None`（loop 场景）时，使用显式 workspace 进行 project_directory 查询和 worktree 创建。

### `start_todo_and_prepare_spawn` / `create_run_execution_record` 透传回退链
`effective_workspace` 优先级：worktree 路径 → todo.workspace → request.workspace（新增），确保 loop 的 workspace 最终成为子进程 cwd。

### 修改文件（5 个核心 + 6 个调用方适配）

| 文件 | 改动 |
|------|------|
| `executor_service/mod.rs` | 新增 `workspace` 字段 |
| `executor_service/worktree.rs` | `resolve_worktree_context` 新增 `explicit_workspace` 参数 |
| `executor_service/stages.rs` | 透传 request.workspace 给 worktree 解析 + 回退链 |
| `executor_service/pre_spawn.rs` | todo_workspace 回退到 request.workspace |
| `services/loop_runner.rs` | 传递 loop.workspace 到 step 执行 |
| 其余 6 个调用方 | 添加 `workspace: None` 保持原行为 |

## 执行流程

```
loop.workspace=/path/to/proj + project_directory.git_worktree_enabled=true
  → run_inner → start_step_todo_with_prompt(..., workspace=Some(path))
  → RunTodoExecutionRequest { todo_id:0, workspace: Some(path) }
  → resolve_worktree_context(db, &None, Some(path))
  → WorktreeService::create_worktree(path, 0)
  → WorktreeContext { effective_workspace: worktree_path }
  → spawn_executor_child → cmd.current_dir(worktree_path)
  → cleanup_worktree_if_needed (执行结束后)
```