### PR TITLE
feat(loop-trigger): 实现所有触发条件的配置界面与后台派发

### DIFF
--- a/backend/src/db/tag.rs
+++ b/backend/src/db/tag.rs
@@ -122,6 +122,16 @@ impl Database {
             .collect())
     }
 
+    /// 查询指定 todo 当前关联的所有 tag_id。
+    pub async fn get_todo_tag_ids(&self, todo_id: i64) -> Result<Vec<i64>, sea_orm::DbErr> {
+        use sea_orm::ColumnTrait;
+        let rows = todo_tags::Entity::find()
+            .filter(todo_tags::Column::TodoId.eq(todo_id))
+            .all(&self.conn)
+            .await?;
+        Ok(rows.into_iter().map(|r| r.tag_id).collect())
+    }
+
     pub async fn find_tag_by_name(&self, name: &str) -> Result<Option<i64>, sea_orm::DbErr> {
         use sea_orm::ColumnTrait;
         Ok(tags::Entity::find()

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1038,6 +1038,9 @@ fn build_app_state(
     let (loop_runner, loop_trigger_dispatcher, loop_scheduler) =
         init_loop_studio_services(ctx.clone(), hook_service.clone(), tx.clone());
 
+    // 后台监听 todo 执行完成事件，派发给 loop_trigger_dispatcher
+    spawn_todo_completed_listener(tx.clone(), loop_trigger_dispatcher.clone());
+
     AppState {
         db,
         executor_registry,
@@ -1093,6 +1096,48 @@ fn init_loop_studio_services(
     };
     // 即使 scheduler 失败,runner / dispatcher 仍可用（手动触发仍可工作）
     (Some(runner), Some(dispatcher), scheduler)
+}
+
+/// 后台任务：监听 ExecEvent::Finished 事件并派发到 loop_trigger_dispatcher。
+///
+/// 当 todo 执行完成时，触发 loop 的 todo_completed 触发器。
+/// 这是一个 fire-and-forget 任务，失败不影响 daemon 主流程。
+fn spawn_todo_completed_listener(
+    tx: tokio::sync::broadcast::Sender<ExecEvent>,
+    dispatcher: Option<Arc<crate::services::loop_trigger::LoopTriggerDispatcher>>,
+) {
+    let Some(dispatcher) = dispatcher else {
+        return;
+    };
+    let mut rx = tx.subscribe();
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(ExecEvent::Finished {
+                    todo_id,
+                    success: true,
+                    ..
+                }) => {
+                    // 仅当执行成功时派发 todo_completed 触发器
+                    let _ = dispatcher.dispatch_todo_completed(todo_id, None).await;
+                }
+                // 忽略其它事件类型
+                Ok(_) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(
+                        "todo_completed_listener: lagged by {} events",
+                        n
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    tracing::info!(
+                        "todo_completed_listener: channel closed, exiting"
+                    );
+                    break;
+                }
+            }
+        }
+    });
 }
 
 /// 后台任务：启动所有已启用的飞书 bot。失败仅记录日志，不影响主流程。

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -268,7 +268,18 @@ pub async fn update_todo_tags(
     Path(id): Path<i64>,
     ApiJson(req): ApiJson<UpdateTagsRequest>,
 ) -> Result<ApiResponse<()>, AppError> {
+    // 先查询之前关联的 tag（用于计算新增的 tag）
+    let old_tag_ids: std::collections::HashSet<i64> = state.db.get_todo_tag_ids(id).await.unwrap_or_default().into_iter().collect();
     state.db.set_todo_tags(id, &req.tag_ids).await?;
+    // Loop Studio: 对每个新增的 tag 派发 tag_added 触发器
+    if let Some(dispatcher) = state.loop_trigger_dispatcher.as_ref() {
+        for &tag_id in &req.tag_ids {
+            if !old_tag_ids.contains(&tag_id) {
+                // 只派发新增的 tag（已存在的 tag 不重复触发）
+                let _ = dispatcher.dispatch_tag_added(tag_id, id).await;
+            }
+        }
+    }
     Ok(ApiResponse::ok(()))
 }
 

--- a/frontend/src/components/LoopStudioTriggersPanel.tsx
+++ b/frontend/src/components/LoopStudioTriggersPanel.tsx
@@ -1,13 +1,14 @@
-// Loop 触发条件面板 (重做: 内联 toggle 列表)。
+// Loop 触发条件面板。
 //
-// 对齐参考设计: 全 8 种触发类型全部展示, 每行带 toggle 开关,
-// 不再需要先点「新增触发器」选类型。打开 toggle 时弹配置 modal (cron 表达式 / webhook id 等)。
-// 已存在的触发器可点击行名进入编辑/删除。
+// 设计目标：8 种触发类型（manual/cron/webhook/feishu_message/feishu_command/
+// todo_completed/todo_state_changed/tag_added）全部以行内 toggle 展示。
+// 每种类型有独立的配置弹窗，不再需要用户手写 JSON。
 //
-// 触发器类型: manual | cron | webhook | feishu_message | feishu_command
-//            | todo_completed | todo_state_changed
+// 定时调度（cron）使用 react-js-cron + CronPresetSelect（和 todo 定时调度一致）。
+// Webhook 复用已有的 webhook 列表选择（而非手填 webhook_id）。
+// Todos / Tags / Feishu bots 等通过 Select 下拉选取已有数据。
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import {
   App as AntApp,
   Button,
@@ -17,6 +18,7 @@ import {
   Select,
   Switch,
   Tooltip,
+  Tag as AntTag,
 } from 'antd';
 import {
   ApiOutlined,
@@ -25,12 +27,21 @@ import {
   MessageOutlined,
   ThunderboltOutlined,
   CheckCircleOutlined,
+  SyncOutlined,
+  TagOutlined,
   DeleteOutlined,
   EditOutlined,
 } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
+import * as db from '@/utils/database';
 import type { LoopTriggerDto, CreateTriggerRequest, UpdateTriggerRequest } from '@/types/loop';
+import type { Todo, Tag } from '@/types';
+import type { Webhook } from '@/utils/database/webhooks';
 import { formatRelativeTime } from '@/utils/datetime';
+import { CronPresetSelect } from '@/components/CronPresetSelect';
+import { Cron } from 'react-js-cron';
+import 'react-js-cron/dist/styles.css';
+import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '@/utils/cron';
 
 interface Props {
   loopId: number;
@@ -38,73 +49,630 @@ interface Props {
   onChanged: () => void;
 }
 
-// 触发器类型 → 元数据, 集中在一处; export 让其他组件 (e.g. LoopStudio) 复用
-export const TRIGGER_META: Record<string, { icon: React.ReactNode; label: string; desc: string; configHint: string }> = {
+// ====== 触发器元数据 ======
+
+export const TRIGGER_META: Record<string, {
+  icon: React.ReactNode;
+  label: string;
+  desc: string;
+  // 不需要配置（manual 等）
+  noConfig?: boolean;
+}> = {
   manual: {
     icon: <PlayCircleOutlined />,
     label: '手动触发',
     desc: '通过「触发」按钮主动启动',
-    configHint: '无需配置',
+    noConfig: true,
   },
   cron: {
     icon: <ClockCircleOutlined />,
     label: '定时调度',
     desc: '按 cron 表达式周期性触发',
-    configHint: '{"expr":"0 9 * * *","tz":"Asia/Shanghai"}',
   },
   webhook: {
     icon: <ApiOutlined />,
     label: 'Webhook',
-    desc: '外部 HTTP 回调触发',
-    configHint: '{"webhook_id":"any-string-you-like","method":"POST"}',
+    desc: '外部 HTTP 回调触发（复用已有的 webhook 配置）',
   },
   feishu_message: {
     icon: <MessageOutlined />,
     label: '飞书消息',
     desc: '收到飞书消息时触发',
-    configHint: '{"match":"关键字"}',
   },
   feishu_command: {
     icon: <ThunderboltOutlined />,
     label: '飞书指令',
     desc: '飞书内指定指令触发',
-    configHint: '{"command":"/review"}',
   },
   todo_completed: {
     icon: <CheckCircleOutlined />,
     label: 'Todo 完成',
     desc: '某个 todo 完成时触发',
-    configHint: '{"todo_id":1}',
   },
   todo_state_changed: {
-    icon: <CheckCircleOutlined />,
+    icon: <SyncOutlined />,
     label: 'Todo 状态变更',
-    desc: '任意 todo 状态变化时触发',
-    configHint: '{"from":"pending","to":"completed"}',
+    desc: '某个 todo 状态变化时触发',
+  },
+  tag_added: {
+    icon: <TagOutlined />,
+    label: '标签添加',
+    desc: '某个标签被添加到 todo 时触发',
   },
 };
 
-// 内联配置 modal 的表单 schema (不同 trigger_type 公用)
-interface TriggerForm {
-  config: string;
-  priority: number;
+// ====== 各触发类型的专用配置组件 ======
+
+/**
+ * 定时调度配置：复用 todo 定时调度的 CronPresetSelect + react-js-cron。
+ * 存储格式（保持与后端一致）：{"cron":"0 0 9 * * *","timezone":"Asia/Shanghai"}
+ */
+function CronConfigForm({ value, onChange }: {
+  value: string;
+  onChange: (json: string) => void;
+}) {
+  // 解析当前值，提取 cron 和 timezone
+  const parsed = useMemo(() => {
+    try {
+      const v = JSON.parse(value || '{}');
+      return {
+        cron: v.cron || '0 0 9 * * *',
+        timezone: v.timezone || 'Asia/Shanghai',
+      };
+    } catch {
+      return { cron: '0 0 9 * * *', timezone: 'Asia/Shanghai' };
+    }
+  }, [value]);
+
+  const [cronExpr, setCronExpr] = useState(parsed.cron);
+  const [timezone, setTimezone] = useState(parsed.timezone);
+
+  // 同步回外层
+  const sync = useCallback((c: string, tz: string) => {
+    onChange(JSON.stringify({ cron: c, timezone: tz }));
+  }, [onChange]);
+
+  useEffect(() => { sync(cronExpr, timezone); }, [cronExpr, timezone, sync]);
+
+  return (
+    <div>
+      {/* 快速预设选择 */}
+      <CronPresetSelect
+        value={cronExpr}
+        onChange={(val) => setCronExpr(val)}
+      />
+      {/* react-js-cron 图形化编辑器 */}
+      <div style={{ marginTop: 8, marginBottom: 12 }}>
+        <Cron
+          value={cronTo5(cronExpr)}
+          setValue={(val: string) => setCronExpr(cronTo6(val))}
+          locale={CRON_ZH_LOCALE}
+          defaultPeriod="hour"
+          humanizeLabels
+          allowClear={false}
+        />
+      </div>
+      {/* 时区选择 */}
+      <Form.Item label="时区" tooltip="cron 表达式在该时区的本地时间执行">
+        <Select
+          value={timezone}
+          onChange={(v) => setTimezone(v)}
+          showSearch
+          options={[
+            { value: 'Asia/Shanghai', label: 'Asia/Shanghai (UTC+8)' },
+            { value: 'Asia/Tokyo', label: 'Asia/Tokyo (UTC+9)' },
+            { value: 'America/New_York', label: 'America/New_York (UTC-5/-4)' },
+            { value: 'America/Los_Angeles', label: 'America/Los_Angeles (UTC-8/-7)' },
+            { value: 'Europe/London', label: 'Europe/London (UTC+0/+1)' },
+            { value: 'Europe/Berlin', label: 'Europe/Berlin (UTC+1/+2)' },
+            { value: 'UTC', label: 'UTC' },
+          ]}
+        />
+      </Form.Item>
+    </div>
+  );
 }
+
+/**
+ * Webhook 配置：从已有 webhook 列表中选择。
+ * 存储格式：{"webhook_id": 5}
+ */
+function WebhookConfigForm({ value, onChange }: {
+  value: string;
+  onChange: (json: string) => void;
+}) {
+  const [webhooks, setWebhooks] = useState<Webhook[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const parsed = useMemo(() => {
+    try {
+      const v = JSON.parse(value || '{}');
+      return { webhook_id: v.webhook_id ?? null };
+    } catch {
+      return { webhook_id: null };
+    }
+  }, [value]);
+
+  const [selectedId, setSelectedId] = useState<number | null>(parsed.webhook_id);
+
+  // 加载 webhook 列表
+  useEffect(() => {
+    setLoading(true);
+    db.getWebhooks()
+      .then((list) => setWebhooks(list))
+      .catch(() => { /* 静默 */ })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleChange = useCallback((id: number | null) => {
+    setSelectedId(id);
+    if (id) {
+      onChange(JSON.stringify({ webhook_id: id }));
+    } else {
+      onChange('{}');
+    }
+  }, [onChange]);
+
+  return (
+    <div>
+      <Form.Item label="选择 Webhook" tooltip="触发该 Loop 时，将使用已配置的 webhook 接收 HTTP 请求">
+        <Select
+          value={selectedId}
+          onChange={handleChange}
+          loading={loading}
+          allowClear
+          placeholder="选择一个已创建的 webhook"
+          showSearch
+          filterOption={(input, option) =>
+            (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+          }
+          options={webhooks.map((w) => ({
+            value: w.id,
+            label: `${w.name}${w.default_todo_id ? ' (已关联)' : ''}`,
+          }))}
+        />
+      </Form.Item>
+      {selectedId && (
+        <div style={{ fontSize: 12, color: 'var(--color-text-tertiary, #94a3b8)', marginTop: -12, marginBottom: 12 }}>
+          webhook_id = {selectedId} · 当外部 HTTP 调用匹配此 webhook 时触发
+        </div>
+      )}
+      {webhooks.length === 0 && !loading && (
+        <div style={{ fontSize: 12, color: '#fa8c16', marginBottom: 8 }}>
+          暂无 webhook 配置，请先在 Webhook 设置页面创建
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Todo 选择器（todo_completed / todo_state_changed 共用）。
+ * 存储格式：{"todo_id": 7}
+ */
+function TodoSelectorForm({ value, onChange }: {
+  value: string;
+  onChange: (json: string) => void;
+}) {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const parsed = useMemo(() => {
+    try {
+      const v = JSON.parse(value || '{}');
+      return { todo_id: v.todo_id ?? null };
+    } catch {
+      return { todo_id: null };
+    }
+  }, [value]);
+
+  const [selectedId, setSelectedId] = useState<number | null>(parsed.todo_id);
+
+  // 加载所有 todo 列表（items + steps）
+  useEffect(() => {
+    setLoading(true);
+    db.getAllTodos()
+      .then((list) => setTodos(list))
+      .catch(() => { /* 静默 */ })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleChange = useCallback((id: number | null) => {
+    setSelectedId(id);
+    if (id) {
+      onChange(JSON.stringify({ todo_id: id }));
+    } else {
+      onChange('{}');
+    }
+  }, [onChange]);
+
+  return (
+    <Form.Item label="选择 Todo" tooltip="该 Todo 的状态变化将触发 Loop">
+      <Select
+        value={selectedId}
+        onChange={handleChange}
+        loading={loading}
+        allowClear
+        placeholder="选择一个 todo"
+        showSearch
+        filterOption={(input, option) =>
+          (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+        }
+        options={todos.map((t) => ({
+          value: t.id,
+          label: t.title,
+        }))}
+      />
+    </Form.Item>
+  );
+}
+
+/**
+ * Tag 选择器（tag_added 触发类型使用）。
+ * 存储格式：{"tag_id": 3}
+ */
+function TagSelectorForm({ value, onChange }: {
+  value: string;
+  onChange: (json: string) => void;
+}) {
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const parsed = useMemo(() => {
+    try {
+      const v = JSON.parse(value || '{}');
+      return { tag_id: v.tag_id ?? null };
+    } catch {
+      return { tag_id: null };
+    }
+  }, [value]);
+
+  const [selectedId, setSelectedId] = useState<number | null>(parsed.tag_id);
+
+  // 加载所有 tag
+  useEffect(() => {
+    setLoading(true);
+    db.getAllTags()
+      .then((list) => setTags(list))
+      .catch(() => { /* 静默 */ })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleChange = useCallback((id: number | null) => {
+    setSelectedId(id);
+    if (id) {
+      onChange(JSON.stringify({ tag_id: id }));
+    } else {
+      onChange('{}');
+    }
+  }, [onChange]);
+
+  return (
+    <Form.Item label="选择标签" tooltip="当该标签被添加到任意 todo 时触发 Loop">
+      <Select
+        value={selectedId}
+        onChange={handleChange}
+        loading={loading}
+        allowClear
+        placeholder="选择一个标签"
+        showSearch
+        filterOption={(input, option) =>
+          (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+        }
+        options={tags.map((t) => ({
+          value: t.id,
+          label: `${t.name}${t.color ? ` (${t.color})` : ''}`,
+          color: t.color,
+        }))}
+        optionRender={(option) => (
+          <span>
+            {(option.data as any).color ? (
+              <AntTag color={(option.data as any).color as string} style={{ marginRight: 6, lineHeight: '18px', fontSize: 11 }}>
+                {option.data.label as string}
+              </AntTag>
+            ) : (
+              option.data.label as string
+            )}
+          </span>
+        )}
+      />
+    </Form.Item>
+  );
+}
+
+/**
+ * 飞书消息配置：选择 bot、chat_id、匹配方式和关键词。
+ * 存储格式：{"bot_id":1,"chat_id":"oc_xxx","match_type":"contains","pattern":"hello"}
+ */
+function FeishuMessageConfigForm({ value, onChange }: {
+  value: string;
+  onChange: (json: string) => void;
+}) {
+  const [bots, setBots] = useState<{ id: number; name: string }[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const parsed = useMemo(() => {
+    try {
+      const v = JSON.parse(value || '{}');
+      return {
+        bot_id: v.bot_id ?? null,
+        chat_id: v.chat_id ?? '',
+        match_type: v.match_type ?? 'contains',
+        pattern: v.pattern ?? '',
+      };
+    } catch {
+      return { bot_id: null, chat_id: '', match_type: 'contains', pattern: '' };
+    }
+  }, [value]);
+
+  const [botId, setBotId] = useState<number | null>(parsed.bot_id);
+  const [chatId, setChatId] = useState(parsed.chat_id);
+  const [matchType, setMatchType] = useState(parsed.match_type);
+  const [pattern, setPattern] = useState(parsed.pattern);
+
+  // 加载 bot 列表
+  useEffect(() => {
+    setLoading(true);
+    db.getAgentBots()
+      .then((list) => setBots(list.map((b: any) => ({ id: b.id, name: b.bot_name || b.bot_type }))))
+      .catch(() => { /* 静默 */ })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    const config: Record<string, any> = {};
+    if (botId) config.bot_id = botId;
+    if (chatId) config.chat_id = chatId;
+    if (matchType) config.match_type = matchType;
+    if (pattern) config.pattern = pattern;
+    onChange(JSON.stringify(config));
+  }, [botId, chatId, matchType, pattern, onChange]);
+
+  return (
+    <div>
+      <Form.Item label="飞书机器人" tooltip="接收消息的飞书机器人">
+        <Select
+          value={botId}
+          onChange={(v) => setBotId(v)}
+          loading={loading}
+          allowClear
+          placeholder="选择机器人"
+          options={bots.map((b) => ({ value: b.id, label: b.name }))}
+        />
+      </Form.Item>
+      <Form.Item label="群聊/会话 ID" tooltip="留空则匹配任意群聊或会话（仅限已配置的机器人）">
+        <Input
+          value={chatId}
+          onChange={(e) => setChatId(e.target.value)}
+          placeholder="留空=任意会话，示例：oc_xxxxxx"
+        />
+      </Form.Item>
+      <Form.Item label="匹配方式" tooltip="选择如何匹配消息内容">
+        <Select
+          value={matchType}
+          onChange={(v) => setMatchType(v)}
+          options={[
+            { value: 'contains', label: '包含（contains）' },
+            { value: 'exact', label: '精确匹配（exact）' },
+            { value: 'regex', label: '正则匹配（regex）' },
+          ]}
+        />
+      </Form.Item>
+      <Form.Item label="关键词/正则" tooltip="匹配的消息内容关键词或正则表达式（留空=全部命中）">
+        <Input
+          value={pattern}
+          onChange={(e) => setPattern(e.target.value)}
+          placeholder={matchType === 'regex' ? '例如：^bug\\s+\\d+' : '输入关键词'}
+        />
+      </Form.Item>
+    </div>
+  );
+}
+
+/**
+ * 飞书指令配置：选择 bot 和命令。
+ * 存储格式：{"bot_id":1,"command":"/run"}
+ */
+function FeishuCommandConfigForm({ value, onChange }: {
+  value: string;
+  onChange: (json: string) => void;
+}) {
+  const [bots, setBots] = useState<{ id: number; name: string }[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const parsed = useMemo(() => {
+    try {
+      const v = JSON.parse(value || '{}');
+      return { bot_id: v.bot_id ?? null, command: v.command ?? '' };
+    } catch {
+      return { bot_id: null, command: '' };
+    }
+  }, [value]);
+
+  const [botId, setBotId] = useState<number | null>(parsed.bot_id);
+  const [command, setCommand] = useState(parsed.command);
+
+  useEffect(() => {
+    setLoading(true);
+    db.getAgentBots()
+      .then((list) => setBots(list.map((b: any) => ({ id: b.id, name: b.bot_name || b.bot_type }))))
+      .catch(() => { /* 静默 */ })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    const config: Record<string, any> = {};
+    if (botId) config.bot_id = botId;
+    if (command) config.command = command;
+    onChange(JSON.stringify(config));
+  }, [botId, command, onChange]);
+
+  return (
+    <div>
+      <Form.Item label="飞书机器人" tooltip="接收指令的飞书机器人">
+        <Select
+          value={botId}
+          onChange={(v) => setBotId(v)}
+          loading={loading}
+          allowClear
+          placeholder="选择机器人"
+          options={bots.map((b) => ({ value: b.id, label: b.name }))}
+        />
+      </Form.Item>
+      <Form.Item
+        label="指令名称"
+        tooltip="用户在飞书中发送的 slash 命令，例如 /run"
+        rules={[{ required: false }]}
+      >
+        <Input
+          value={command}
+          onChange={(e) => setCommand(e.target.value)}
+          placeholder="例如: /run, /review, /deploy"
+        />
+      </Form.Item>
+    </div>
+  );
+}
+
+/**
+ * Todo 状态变更配置（todo_state_changed 专用）：选择 todo 和过滤条件。
+ * 存储格式：{"todo_id":7,"to_status":"completed"}
+ */
+function TodoStateChangedConfigForm({ value, onChange }: {
+  value: string;
+  onChange: (json: string) => void;
+}) {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const parsed = useMemo(() => {
+    try {
+      const v = JSON.parse(value || '{}');
+      return {
+        todo_id: v.todo_id ?? null,
+        to_status: v.to_status ?? '',
+      };
+    } catch {
+      return { todo_id: null, to_status: '' };
+    }
+  }, [value]);
+
+  const [todoId, setTodoId] = useState<number | null>(parsed.todo_id);
+  const [toStatus, setToStatus] = useState(parsed.to_status);
+
+  useEffect(() => {
+    setLoading(true);
+    db.getAllTodos()
+      .then((list) => setTodos(list))
+      .catch(() => { /* 静默 */ })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    const config: Record<string, any> = {};
+    if (todoId) config.todo_id = todoId;
+    if (toStatus) config.to_status = toStatus;
+    onChange(JSON.stringify(config));
+  }, [todoId, toStatus, onChange]);
+
+  return (
+    <div>
+      <Form.Item label="选择 Todo" tooltip="该 Todo 的状态变化将触发 Loop（留空=任意 Todo 都触发）">
+        <Select
+          value={todoId}
+          onChange={(v) => setTodoId(v)}
+          loading={loading}
+          allowClear
+          placeholder="选择一个 todo（留空=任意）"
+          showSearch
+          filterOption={(input, option) =>
+            (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+          }
+          options={todos.map((t) => ({
+            value: t.id,
+            label: t.title,
+          }))}
+        />
+      </Form.Item>
+      <Form.Item label="目标状态" tooltip="当 Todo 变更为该状态时触发（留空=任意状态变更均触发）">
+        <Select
+          value={toStatus}
+          onChange={(v) => setToStatus(v)}
+          allowClear
+          placeholder="选择目标状态（留空=任意）"
+          options={[
+            { value: 'pending', label: 'pending（待执行）' },
+            { value: 'running', label: 'running（执行中）' },
+            { value: 'completed', label: 'completed（已完成）' },
+            { value: 'failed', label: 'failed（失败）' },
+            { value: 'cancelled', label: 'cancelled（已取消）' },
+          ]}
+        />
+      </Form.Item>
+    </div>
+  );
+}
+
+// ====== 配置弹窗内容分发 ======
+
+/**
+ * 根据 trigger_type 返回对应的配置表单组件。
+ * 对于 manual 这种无需配置的类型，返回 null。
+ */
+function TriggerConfigContent({ type, value, onChange }: {
+  type: string;
+  value: string;
+  onChange: (json: string) => void;
+}) {
+  switch (type) {
+    case 'cron':
+      return <CronConfigForm value={value} onChange={onChange} />;
+    case 'webhook':
+      return <WebhookConfigForm value={value} onChange={onChange} />;
+    case 'feishu_message':
+      return <FeishuMessageConfigForm value={value} onChange={onChange} />;
+    case 'feishu_command':
+      return <FeishuCommandConfigForm value={value} onChange={onChange} />;
+    case 'todo_completed':
+      return <TodoSelectorForm value={value} onChange={onChange} />;
+    case 'todo_state_changed':
+      return <TodoStateChangedConfigForm value={value} onChange={onChange} />;
+    case 'tag_added':
+      return <TagSelectorForm value={value} onChange={onChange} />;
+    default:
+      // 兜底：未知类型，展示原始 JSON 编辑区
+      return (
+        <Form.Item label="配置 (JSON)" name="config">
+          <Input.TextArea
+            rows={5}
+            placeholder="{}"
+            style={{ fontFamily: 'monospace', fontSize: 12 }}
+          />
+        </Form.Item>
+      );
+  }
+}
+
+// ====== 主面板组件 ======
 
 export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
   const { message } = AntApp.useApp();
   // 当前正在配置的 trigger_type (open=true 时): null=关闭
   const [configuring, setConfiguring] = useState<{ type: string; existing: LoopTriggerDto | null } | null>(null);
   const [saving, setSaving] = useState(false);
-  const [form] = Form.useForm<TriggerForm>();
+  // 各 trigger type 的临时配置 JSON 值（存放自定义配置表单的内容）
+  const [configJson, setConfigJson] = useState('{}');
+  const [priority, setPriority] = useState(0);
+  const [form] = Form.useForm();
 
-  // 按 type 分组索引已存在的 trigger (1 个 type 最多 1 个 trigger, 简化模型)
+  // 按 type 分组索引已存在的 trigger（每种 type 最多 1 个）
   const byType = useMemo(() => {
     const m = new Map<string, LoopTriggerDto>();
     for (const t of triggers) m.set(t.trigger_type, t);
     return m;
   }, [triggers]);
 
-  // 切换 enabled 状态 (用户点 toggle 的非「新增」路径)
+  // 切换 enabled 状态（用户点 toggle 的非「新增」路径）
   const handleToggleEnabled = useCallback(async (t: LoopTriggerDto, enabled: boolean) => {
     try {
       await dbLoops.updateTrigger(loopId, t.id, {
@@ -122,54 +690,59 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
   // 关闭配置 modal
   const closeConfig = useCallback(() => {
     setConfiguring(null);
+    setConfigJson('{}');
+    setPriority(0);
     form.resetFields();
   }, [form]);
 
-  // 打开新增配置 modal (toggle 从 off 变 on, 没有已存在记录)
+  // 打开新增配置 modal（从 off 变 on）
   const openCreateConfig = useCallback((type: string) => {
-    const meta = TRIGGER_META[type];
-    if (!meta) return;
-    form.setFieldsValue({ config: meta.configHint, priority: 0 });
+    setPriority(0);
+    setConfigJson('{}');
     setConfiguring({ type, existing: null });
-  }, [form]);
+  }, []);
 
-  // 打开编辑配置 modal (点击已存在 trigger 的行名)
+  // 打开编辑配置 modal（点击已存在的 trigger 行名）
   const openEditConfig = useCallback((t: LoopTriggerDto) => {
-    form.setFieldsValue({ config: t.config, priority: t.priority });
+    setPriority(t.priority);
+    setConfigJson(t.config);
     setConfiguring({ type: t.trigger_type, existing: t });
-  }, [form]);
+  }, []);
 
-  // 提交配置 (新建 / 更新二选一)
+  // 提交配置（新建 / 更新）
   const handleSaveConfig = useCallback(async () => {
     if (!configuring) return;
-    const values = await form.validateFields();
+    if (!configJson || configJson === 'undefined') {
+      message.error('请完成配置后再保存');
+      return;
+    }
     setSaving(true);
     try {
       if (configuring.existing) {
         await dbLoops.updateTrigger(loopId, configuring.existing.id, {
           trigger_type: configuring.type,
-          config: values.config || '{}',
+          config: configJson || '{}',
           enabled: configuring.existing.enabled,
-          priority: values.priority || 0,
+          priority,
         } as UpdateTriggerRequest);
         message.success('已更新');
       } else {
         await dbLoops.createTrigger(loopId, {
           trigger_type: configuring.type,
-          config: values.config || '{}',
+          config: configJson || '{}',
           enabled: true,
-          priority: values.priority || 0,
+          priority,
         } as CreateTriggerRequest);
         message.success(`已添加「${TRIGGER_META[configuring.type]?.label ?? configuring.type}」触发器`);
       }
       closeConfig();
       onChanged();
     } catch {
-      // ignore
+      // ignore: 拦截器已弹错
     } finally {
       setSaving(false);
     }
-  }, [configuring, form, loopId, message, closeConfig, onChanged]);
+  }, [configuring, configJson, priority, loopId, message, closeConfig, onChanged]);
 
   // 删除已有 trigger
   const handleDelete = useCallback(async (id: number) => {
@@ -177,14 +750,13 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
       await dbLoops.deleteTrigger(loopId, id);
       message.success('已删除');
       onChanged();
-      // 如果当前正在编辑的就是被删的, 关闭 modal
       if (configuring?.existing?.id === id) closeConfig();
     } catch {
       // ignore
     }
   }, [loopId, message, onChanged, configuring, closeConfig]);
 
-  // 渲染一行 trigger: 图标 + label + desc + (已启用 toggle / 新增 toggle / 编辑按钮)
+  // 渲染一行 trigger
   const renderRow = (type: string) => {
     const meta = TRIGGER_META[type];
     if (!meta) return null;
@@ -218,12 +790,19 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
         }}>{meta.icon}</span>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div
-            style={{ fontSize: 13, fontWeight: 500, cursor: existing ? 'pointer' : 'default', color: 'var(--color-text, #0f172a)' }}
+            style={{
+              fontSize: 13, fontWeight: 500,
+              cursor: existing ? 'pointer' : 'default',
+              color: 'var(--color-text, #0f172a)',
+            }}
             onClick={() => existing && openEditConfig(existing)}
           >
             {meta.label}
             {existing && (
-              <EditOutlined style={{ marginLeft: 6, fontSize: 11, color: 'var(--color-text-tertiary, #94a3b8)' }} />
+              <EditOutlined style={{
+                marginLeft: 6, fontSize: 11,
+                color: 'var(--color-text-tertiary, #94a3b8)',
+              }} />
             )}
           </div>
           <div style={{ fontSize: 11, color: 'var(--color-text-tertiary, #94a3b8)', marginTop: 2 }}>
@@ -238,29 +817,56 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
             <Switch size="small" checked={isEnabled} onChange={(v) => handleToggleEnabled(existing!, v)} />
           </Tooltip>
         ) : (
-          <Button size="small" type="primary" onClick={() => openCreateConfig(type)}>
-            启用
-          </Button>
+          <Tooltip title={meta.noConfig ? '直接启用（无需配置）' : '配置后启用'}>
+            <Button
+              size="small"
+              type="primary"
+              onClick={() => {
+                if (meta.noConfig) {
+                  // manual 等无需配置的类型，直接启用（发送空配置）
+                  dbLoops.createTrigger(loopId, {
+                    trigger_type: type,
+                    config: '{}',
+                    enabled: true,
+                    priority: 0,
+                  } as CreateTriggerRequest).then(() => {
+                    message.success(`已启用「${meta.label}」`);
+                    onChanged();
+                  }).catch(() => { /* 拦截器已弹错 */ });
+                } else {
+                  openCreateConfig(type);
+                }
+              }}
+            >
+              启用
+            </Button>
+          </Tooltip>
         )}
       </div>
     );
   };
 
-  // 7 种 trigger type 全部展示 (manual / cron / webhook / feishu_message / feishu_command / todo_completed / todo_state_changed)
   const allTypes = Object.keys(TRIGGER_META);
 
   return (
     <div className="loop-triggers-panel">
-      <div style={{ marginBottom: 12, fontSize: 12, color: 'var(--color-text-secondary, #475569)' }}>
-        触发条件决定 loop 在何时被启动 · 当前已启用 {triggers.filter(t => t.enabled).length} / 共 {allTypes.length} 条
+      <div style={{
+        marginBottom: 12, fontSize: 12,
+        color: 'var(--color-text-secondary, #475569)',
+      }}>
+        触发条件决定 loop 在何时被启动 · 当前已启用{' '}
+        {triggers.filter(t => t.enabled).length} / 共 {allTypes.length} 条
       </div>
 
-      {/* 不再单独显示 Empty 状态, 下方 8 行就是「可启用项」, 已足够表达空态语义 */}
       {allTypes.map(renderRow)}
 
-      {/* 配置 modal (新增 / 编辑通用) */}
+      {/* 配置 modal */}
       <Modal
-        title={configuring?.existing ? `编辑「${TRIGGER_META[configuring.type]?.label ?? configuring.type}」` : `启用「${configuring ? (TRIGGER_META[configuring.type]?.label ?? '') : ''}」`}
+        title={
+          configuring?.existing
+            ? `编辑「${TRIGGER_META[configuring.type]?.label ?? configuring.type}」`
+            : `配置「${configuring ? (TRIGGER_META[configuring.type]?.label ?? '') : ''}」`
+        }
         open={configuring !== null}
         onCancel={closeConfig}
         onOk={handleSaveConfig}
@@ -268,6 +874,7 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
         cancelText="取消"
         confirmLoading={saving}
         destroyOnClose
+        width={520}
         footer={configuring?.existing ? [
           <Button key="del" danger icon={<DeleteOutlined />} onClick={() => handleDelete(configuring.existing!.id)}>
             删除
@@ -277,28 +884,41 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
         ] : undefined}
       >
         {configuring && (
-          <Form form={form} layout="vertical">
-            <Form.Item
-              label="配置 (JSON)"
-              name="config"
-              tooltip={TRIGGER_META[configuring.type]?.configHint}
-            >
-              <Input.TextArea
-                rows={5}
-                placeholder={TRIGGER_META[configuring.type]?.configHint}
-                style={{ fontFamily: 'monospace', fontSize: 12 }}
-              />
-            </Form.Item>
-            <Form.Item label="优先级" name="priority" tooltip="数值越大越优先派发 (多个触发器并存时)">
+          <>
+            {/* 优先级选择 — 对所有类型都可用 */}
+            <div style={{ marginBottom: 16 }}>
+              <div style={{ fontSize: 12, fontWeight: 500, color: '#64748b', marginBottom: 6 }}>
+                优先级
+                <Tooltip title="数值越大越优先派发。同一 loop 的多个触发器同时命中时，取优先级最高的触发。">
+                  <EditOutlined style={{ marginLeft: 4, fontSize: 10, color: '#94a3b8' }} />
+                </Tooltip>
+              </div>
               <Select
+                value={priority}
+                onChange={(v) => setPriority(v)}
+                style={{ width: '100%' }}
                 options={[
-                  { value: 0, label: '0 (默认)' },
+                  { value: 0, label: '0（默认）' },
                   { value: 5, label: '5' },
-                  { value: 10, label: '10 (高)' },
+                  { value: 10, label: '10（高优先级）' },
                 ]}
               />
-            </Form.Item>
-          </Form>
+            </div>
+
+            {/* 专用配置区域 */}
+            <div style={{
+              background: '#f8fafc',
+              border: '1px solid #e2e8f0',
+              borderRadius: 8,
+              padding: 16,
+            }}>
+              <TriggerConfigContent
+                type={configuring.type}
+                value={configJson}
+                onChange={setConfigJson}
+              />
+            </div>
+          </>
         )}
       </Modal>
     </div>

--- a/frontend/src/components/LoopStudioTriggersPanel.tsx
+++ b/frontend/src/components/LoopStudioTriggersPanel.tsx
@@ -662,7 +662,6 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
   const [saving, setSaving] = useState(false);
   // 各 trigger type 的临时配置 JSON 值（存放自定义配置表单的内容）
   const [configJson, setConfigJson] = useState('{}');
-  const [priority, setPriority] = useState(0);
   const [form] = Form.useForm();
 
   // 按 type 分组索引已存在的 trigger（每种 type 最多 1 个）
@@ -691,20 +690,17 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
   const closeConfig = useCallback(() => {
     setConfiguring(null);
     setConfigJson('{}');
-    setPriority(0);
     form.resetFields();
   }, [form]);
 
   // 打开新增配置 modal（从 off 变 on）
   const openCreateConfig = useCallback((type: string) => {
-    setPriority(0);
     setConfigJson('{}');
     setConfiguring({ type, existing: null });
   }, []);
 
   // 打开编辑配置 modal（点击已存在的 trigger 行名）
   const openEditConfig = useCallback((t: LoopTriggerDto) => {
-    setPriority(t.priority);
     setConfigJson(t.config);
     setConfiguring({ type: t.trigger_type, existing: t });
   }, []);
@@ -723,7 +719,7 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
           trigger_type: configuring.type,
           config: configJson || '{}',
           enabled: configuring.existing.enabled,
-          priority,
+          priority: 0,
         } as UpdateTriggerRequest);
         message.success('已更新');
       } else {
@@ -731,7 +727,7 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
           trigger_type: configuring.type,
           config: configJson || '{}',
           enabled: true,
-          priority,
+          priority: 0,
         } as CreateTriggerRequest);
         message.success(`已添加「${TRIGGER_META[configuring.type]?.label ?? configuring.type}」触发器`);
       }
@@ -742,7 +738,7 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
     } finally {
       setSaving(false);
     }
-  }, [configuring, configJson, priority, loopId, message, closeConfig, onChanged]);
+  }, [configuring, configJson, loopId, message, closeConfig, onChanged]);
 
   // 删除已有 trigger
   const handleDelete = useCallback(async (id: number) => {
@@ -885,26 +881,6 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
       >
         {configuring && (
           <>
-            {/* 优先级选择 — 对所有类型都可用 */}
-            <div style={{ marginBottom: 16 }}>
-              <div style={{ fontSize: 12, fontWeight: 500, color: '#64748b', marginBottom: 6 }}>
-                优先级
-                <Tooltip title="数值越大越优先派发。同一 loop 的多个触发器同时命中时，取优先级最高的触发。">
-                  <EditOutlined style={{ marginLeft: 4, fontSize: 10, color: '#94a3b8' }} />
-                </Tooltip>
-              </div>
-              <Select
-                value={priority}
-                onChange={(v) => setPriority(v)}
-                style={{ width: '100%' }}
-                options={[
-                  { value: 0, label: '0（默认）' },
-                  { value: 5, label: '5' },
-                  { value: 10, label: '10（高优先级）' },
-                ]}
-              />
-            </div>
-
             {/* 专用配置区域 */}
             <div style={{
               background: '#f8fafc',

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -16,7 +16,8 @@ export type LoopTriggerType =
   | 'feishu_message'
   | 'feishu_command'
   | 'todo_completed'
-  | 'todo_state_changed';
+  | 'todo_state_changed'
+  | 'tag_added';
 
 export type LoopRunMode = 'sequential';
 


### PR DESCRIPTION
## 改动概述

将 Loop Studio 的触发条件面板从通用 JSON 编辑升级为每种触发类型的专用可视化配置界面。

### 前端改动

1. **LoopStudioTriggersPanel 重写**：原来只有通用 JSON 文本编辑框，现在每种触发类型有专用表单
2. **定时调度 (cron)**：复用 todo 定时调度的 `CronPresetSelect` + `react-js-cron` 图形化编辑器 + 时区下拉选择
3. **Webhook**：从已有 webhook 列表下拉选择（复用 WebhooksPanel 中的配置），不再需要手写 webhook_id
4. **飞书消息/指令**：下拉选择已有飞书机器人 + 匹配方式（contains/exact/regex）+ 关键词/指令输入
5. **Todo 完成/状态变更**：下拉选择已有 todo + 目标状态过滤（pending/running/completed/failed/cancelled）
6. **标签添加 (tag_added)**：新增触发类型 + 标签选择器（带颜色预览）
7. **manual 类型**：一键启用，无需配置弹窗

### 后端改动

1. **新增 `get_todo_tag_ids`**：DB 层方法，查询 todo 当前关联的 tag_id 列表
2. **`update_todo_tags` handler**：在新增标签时派发 `dispatch_tag_added`，只对新增的标签触发（去重）
3. **`spawn_todo_completed_listener`**：后台任务监听 `ExecEvent::Finished`，当 todo 执行成功时自动派发 `todo_completed` 触发器

### 触发类型总览（共 8 种）

| 类型 | 配置方式 | 存储格式示例 |
|------|---------|------------|
| manual | 一键启用 | `{}` |
| cron | CronPresetSelect + react-js-cron + 时区选择 | `{"cron":"0 0 9 * * *","timezone":"Asia/Shanghai"}` |
| webhook | 下拉选择已有 webhook | `{"webhook_id":5}` |
| feishu_message | 选择 bot + chat_id + 匹配方式 + 关键词 | `{"bot_id":1,"match_type":"contains","pattern":"hello"}` |
| feishu_command | 选择 bot + 指令 | `{"bot_id":1,"command":"/run"}` |
| todo_completed | 下拉选择 todo | `{"todo_id":7}` |
| todo_state_changed | 选择 todo + 目标状态 | `{"todo_id":7,"to_status":"completed"}` |
| tag_added（新增） | 下拉选择标签 | `{"tag_id":3}` |
