### PR TITLE
fix: 切换到仪表盘/看板/关联图/设置时自动切换视图

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import { PlusOutlined, ThunderboltOutlined, CloseOutlined, LeftOutlined } from '
 import { AppProvider, useApp } from './hooks/useApp';
 import { useIsMobile } from './hooks/useIsMobile';
 import { useExecutionEvents } from './hooks/useExecutionEvents';
-import { useViewState } from './hooks/useViewState';
+import { useViewState, type View } from './hooks/useViewState';
 import { ThemeProvider, useTheme } from './hooks/useTheme';
 import { TodoList } from './components/TodoList';
 import { TodoDetail } from './components/TodoDetail';
@@ -141,7 +141,15 @@ function AppContent() {
     });
   };
 
-  const handleGoToSettings = () => showView('settings');
+  // 统一导航处理：切换 view 时清空 step/loop 选择，避免旧选择抢占右侧面板
+  const handleShowView = useCallback((view: View) => {
+    setSelectedStepId(null);
+    setSelectedLoopId(null);
+    clearSelection();
+    showView(view);
+  }, [clearSelection, showView]);
+
+  const handleGoToSettings = () => handleShowView('settings');
 
   // FAB backdrop click to collapse
   const handleFabBackdropClick = () => setFabExpanded(false);
@@ -219,14 +227,14 @@ function AppContent() {
               onOpenCreateModal={() => setTodoModalOpen(true)}
               onOpenSmartCreate={() => setSmartCreateOpen(true)}
               onSelectTodo={handleSelectTodo}
-              onShowDashboard={() => { clearSelection(); showView('dashboard'); }}
-              onShowMemorial={() => { clearSelection(); showView('memorial'); }}
-              onShowRelationMap={() => { clearSelection(); showView('relation'); }}
-              onShowSteps={() => { clearSelection(); showView('steps'); }}
+              onShowDashboard={() => handleShowView('dashboard')}
+              onShowMemorial={() => handleShowView('memorial')}
+              onShowRelationMap={() => handleShowView('relation')}
+              onShowSteps={() => handleShowView('steps')}
               onSelectStep={handleSelectStep}
               stepUpdateCount={stepUpdateCount}
               loopUpdateCount={loopUpdateCount}
-              onShowSettings={() => { clearSelection(); showView('settings'); }}
+              onShowSettings={() => handleShowView('settings')}
               onSelectLoop={handleSelectLoop}
               onCreateLoop={async () => {
                 try {


### PR DESCRIPTION
## 修复

点击导航按钮切换到仪表盘、看板、关联图、设置时，视图不会自动切换，需要刷新页面才能生效。

## 根因

在环节/环路页面时 `selectedStepId`/`selectedLoopId` 非空，detail panel 渲染按条件优先顺序判断：
1. `selectedTodoId` → TodoDetail
2. `selectedStepId !== null` → StepDetailPanel（环节）
3. `selectedLoopId !== null` → LoopDetailPanel（环路）
4. `activeView` → settings/memorial/relation/steps/dashboard

点击导航时 `showView()` 只更新了 `activeView`，但没有清空 step/loop 选择状态，渲染在第2/3步就被截获。刷新后状态初始化为 null 才正确。

## 修复

新增统一的 `handleShowView` 函数，在调用 `showView()` 前先清空 `selectedStepId` 和 `selectedLoopId`，所有 5 个导航回调都改用此函数。