### PR TITLE
feat(loop): loop 执行历史中展示 Token 消耗统计

### DIFF
--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -48,7 +48,31 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V9IndependentSteps),
         Box::new(V10StepColor),
         Box::new(V11LoopFlowControl),
+        Box::new(V12LoopStepExecution),
     ]
+}
+
+/// v12 迁移：execution_records 添加 loop 环节执行追踪列。
+///
+/// loop_step_execution_id 指向 loop_step_executions 表的 id，
+/// step_id 指向 steps 表的 id，用于追踪 loop 环节的执行记录。
+pub(super) struct V12LoopStepExecution;
+
+#[async_trait]
+impl Migration for V12LoopStepExecution {
+    fn version(&self) -> i64 {
+        12
+    }
+    fn name(&self) -> &'static str {
+        "loop_step_execution_columns"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 为已有的 execution_records 添加 loop 环节执行追踪字段
+        add_column_warn(db, "ALTER TABLE execution_records ADD COLUMN loop_step_execution_id BIGINT").await;
+        add_column_warn(db, "ALTER TABLE execution_records ADD COLUMN step_id BIGINT").await;
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -25,8 +25,8 @@ use crate::handlers::{AppError, AppState};
 use crate::models::{
     self,
     ApiResponse, CreateLoopRequest, CreateLoopStepRequest, CreateTriggerRequest,
-    LoopDetail, LoopDto, LoopExecutionDetail, LoopExecutionDto, LoopListItem,
-    LoopStepDto, LoopTriggerDto, ReorderLoopStepsRequest,
+    LoopDetail, LoopDto, LoopExecutionDetail, LoopExecutionDto, LoopExecutionTokenSummary,
+    LoopListItem, LoopStepDto, LoopStepExecutionDto, LoopTriggerDto, ReorderLoopStepsRequest,
     UpdateLoopRequest, UpdateLoopStatusRequest, UpdateLoopStepRequest,
     UpdateTriggerRequest,
 };
@@ -437,6 +437,78 @@ pub async fn list_executions(
     })))
 }
 
+/// 从 execution_record_id 读取 usage JSON 并解析为 LoopStepExecutionDto 的 token 字段。
+/// usage 是 JSON 字符串，格式见 ExecutionUsage。
+async fn enrich_step_execution_with_usage(
+    db: &crate::db::Database,
+    dto: &mut LoopStepExecutionDto,
+) {
+    // 只有关联了 execution_record 的 step 才有 usage 数据
+    let record_id = match dto.execution_record_id {
+        Some(id) => id,
+        None => return,
+    };
+    let record = match db.get_execution_record(record_id).await {
+        Ok(Some(r)) => r,
+        _ => return,
+    };
+    // 从 execution_record.usage 字段解析 token 用量
+    let usage = match record.usage {
+        Some(u) => u,
+        None => return,
+    };
+    // 转为 i64 送入 DTO（usage 字段是 u64），避免前端处理大数字溢出
+    dto.input_tokens = Some(usage.input_tokens as i64);
+    dto.output_tokens = Some(usage.output_tokens as i64);
+    dto.cache_read_input_tokens = usage.cache_read_input_tokens.map(|v| v as i64);
+    dto.cache_creation_input_tokens = usage.cache_creation_input_tokens.map(|v| v as i64);
+    dto.total_cost_usd = usage.total_cost_usd;
+}
+
+/// 遍历 step_executions，从每个环节关联的 execution_record.usage 聚合出总 Token 用量。
+async fn aggregate_step_execution_tokens(
+    db: &crate::db::Database,
+    step_execs: &[LoopStepExecutionDto],
+) -> LoopExecutionTokenSummary {
+    let mut total_input_tokens: i64 = 0;
+    let mut total_output_tokens: i64 = 0;
+    let mut total_cache_read_input_tokens: i64 = 0;
+    let mut total_cache_creation_input_tokens: i64 = 0;
+    let mut total_cost_usd: f64 = 0.0;
+    for se in step_execs {
+        let record_id = match se.execution_record_id {
+            Some(id) => id,
+            None => continue,
+        };
+        let record = match db.get_execution_record(record_id).await {
+            Ok(Some(r)) => r,
+            _ => continue,
+        };
+        let usage = match record.usage {
+            Some(u) => u,
+            None => continue,
+        };
+        total_input_tokens += usage.input_tokens as i64;
+        total_output_tokens += usage.output_tokens as i64;
+        if let Some(cr) = usage.cache_read_input_tokens {
+            total_cache_read_input_tokens += cr as i64;
+        }
+        if let Some(cc) = usage.cache_creation_input_tokens {
+            total_cache_creation_input_tokens += cc as i64;
+        }
+        if let Some(cost) = usage.total_cost_usd {
+            total_cost_usd += cost;
+        }
+    }
+    LoopExecutionTokenSummary {
+        total_input_tokens,
+        total_output_tokens,
+        total_cache_read_input_tokens,
+        total_cache_creation_input_tokens,
+        total_cost_usd,
+    }
+}
+
 pub async fn get_execution(
     State(state): State<AppState>,
     Path((loop_id, eid)): Path<(i64, i64)>,
@@ -461,20 +533,25 @@ pub async fn get_execution(
         .await?
         .map(|l| l.name)
         .unwrap_or_default();
-    // 为每个 step execution 补充 step_name（来自 loop_steps 表）
-    let mut enriched: Vec<crate::models::LoopStepExecutionDto> = vec![];
+    // 为每个 step execution 补充 step_name（来自 loop_steps 表）和 token 用量
+    let mut enriched: Vec<LoopStepExecutionDto> = vec![];
     for se in step_execs {
-        let mut dto: crate::models::LoopStepExecutionDto = se.into();
+        let mut dto: LoopStepExecutionDto = se.into();
         // 读取 loop_step 的名称（仅用于显示）
         if let Ok(Some(ls)) = state.db.get_loop_step(dto.step_id).await {
             dto.step_name = Some(ls.name);
         }
+        // 从关联的 execution_record 读取 token 用量
+        enrich_step_execution_with_usage(&state.db, &mut dto).await;
         enriched.push(dto);
     }
+    // 聚合 token 汇总
+    let token_summary = aggregate_step_execution_tokens(&state.db, &enriched).await;
     Ok(ApiResponse::ok(LoopExecutionDetail {
         execution: exec.into(),
         step_executions: enriched,
         loop_name,
+        token_summary,
     }))
 }
 

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -258,6 +258,12 @@ pub struct LoopStepExecutionDto {
     pub sequence_index: i32,
     /// 本次步执行的结论摘要
     pub conclusion: Option<String>,
+    /// 本次环节执行消耗的 token（从 execution_record.usage JSON 解析）
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub cache_read_input_tokens: Option<i64>,
+    pub cache_creation_input_tokens: Option<i64>,
+    pub total_cost_usd: Option<f64>,
 }
 
 impl From<loop_step_executions::Model> for LoopStepExecutionDto {
@@ -278,6 +284,11 @@ impl From<loop_step_executions::Model> for LoopStepExecutionDto {
             step_name: None,
             sequence_index: m.sequence_index,
             conclusion: m.conclusion,
+            input_tokens: None,
+            output_tokens: None,
+            cache_read_input_tokens: None,
+            cache_creation_input_tokens: None,
+            total_cost_usd: None,
         }
     }
 }
@@ -292,12 +303,25 @@ impl LoopStepExecutionDto {
     }
 }
 
+/// Loop Execution 附加的 token 汇总统计,
+/// 由后端在 get_execution 时从 execution_records.usage JSON 聚合计算。
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LoopExecutionTokenSummary {
+    pub total_input_tokens: i64,
+    pub total_output_tokens: i64,
+    pub total_cache_read_input_tokens: i64,
+    pub total_cache_creation_input_tokens: i64,
+    pub total_cost_usd: f64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoopExecutionDetail {
     #[serde(flatten)]
     pub execution: LoopExecutionDto,
     pub step_executions: Vec<LoopStepExecutionDto>,
     pub loop_name: String,
+    /// 本次 loop execution 的 token 汇总统计
+    pub token_summary: LoopExecutionTokenSummary,
 }
 
 // ====== 请求体（创建/更新）======

--- a/backend/tests/hook_tests.rs
+++ b/backend/tests/hook_tests.rs
@@ -485,7 +485,7 @@ mod hook_source_provenance_tests {
 
         let record_id = db
             .create_execution_record(NewExecutionRecord {
-                todo_id: target_id,
+                todo_id: Some(target_id),
                 command: "echo test",
                 executor: "claudecode",
                 trigger_type: "hook:state_changed_to_completed",
@@ -495,6 +495,8 @@ mod hook_source_provenance_tests {
                 source_todo_id: Some(42),
                 source_todo_title: Some("joke source"),
                 source_hook_id: Some(999001),
+                loop_step_execution_id: None,
+                step_id: None,
             })
             .await
             .unwrap();
@@ -514,7 +516,7 @@ mod hook_source_provenance_tests {
 
         let record_id = db
             .create_execution_record(NewExecutionRecord {
-                todo_id: target_id,
+                todo_id: Some(target_id),
                 command: "echo manual",
                 executor: "claudecode",
                 trigger_type: "manual",
@@ -524,6 +526,8 @@ mod hook_source_provenance_tests {
                 source_todo_id: None,
                 source_todo_title: None,
                 source_hook_id: None,
+                loop_step_execution_id: None,
+                step_id: None,
             })
             .await
             .unwrap();

--- a/backend/tests/loop_step_tests.rs
+++ b/backend/tests/loop_step_tests.rs
@@ -25,7 +25,7 @@ async fn create_todo(db: &Database, title: &str) -> i64 {
 
 // 工具: 构造一个 loop, 返回 loop_id
 async fn create_loop(db: &Database, name: &str) -> i64 {
-    db.create_loop(name, "", None, "#722ed1", "loop")
+    db.create_loop(name, "", None, "#722ed1", "loop", None)
         .await
         .unwrap()
         .id
@@ -51,7 +51,7 @@ async fn v6_migration_backfills_step_for_loop_referenced_todos() {
     let db = setup_db().await;
     let todo_id = create_todo(&db, "被 loop 引用的 todo").await;
     let loop_id = create_loop(&db, "测试 loop").await;
-    db.create_loop_step(loop_id, "阶段 1", "", todo_id, "sequential", false, None, "skip", true)
+    db.create_loop_step(loop_id, "阶段 1", "", todo_id, "sequential", false, None, "skip", true, "next", None, "break", None)
         .await
         .unwrap();
 
@@ -94,7 +94,7 @@ async fn demote_step_blocked_when_loop_references_it() {
     let todo_id = create_todo(&db, "被引用的环节").await;
     db.promote_to_step(todo_id).await.unwrap();
     let loop_id = create_loop(&db, "引用 loop").await;
-    db.create_loop_step(loop_id, "阶段", "", todo_id, "sequential", false, None, "skip", true)
+    db.create_loop_step(loop_id, "阶段", "", todo_id, "sequential", false, None, "skip", true, "next", None, "break", None)
         .await
         .unwrap();
     // demote 应该失败 (返回 AppError::BadRequest 或 DbErr)
@@ -115,7 +115,7 @@ async fn demote_succeeds_after_stage_deleted() {
     db.promote_to_step(todo_id).await.unwrap();
     let loop_id = create_loop(&db, "loop").await;
     let step_id = db
-        .create_loop_step(loop_id, "阶段", "", todo_id, "sequential", false, None, "skip", true)
+        .create_loop_step(loop_id, "阶段", "", todo_id, "sequential", false, None, "skip", true, "next", None, "break", None)
         .await
         .unwrap()
         .id;
@@ -152,7 +152,7 @@ async fn list_steps_with_usage_includes_count() {
     db.promote_to_step(e2).await.unwrap();
     // 1 个 step 引用 e2
     let loop_id = create_loop(&db, "loop").await;
-    db.create_loop_step(loop_id, "阶段", "", e2, "sequential", false, None, "skip", true)
+    db.create_loop_step(loop_id, "阶段", "", e2, "sequential", false, None, "skip", true, "next", None, "break", None)
         .await
         .unwrap();
     let list = db.list_steps_with_usage().await.unwrap();
@@ -178,14 +178,14 @@ async fn count_loop_steps_reflects_stage_changes() {
 
     // 加一个 step → 1
     let s1 = db
-        .create_loop_step(loop_id, "s1", "", todo_id, "sequential", false, None, "skip", true)
+        .create_loop_step(loop_id, "s1", "", todo_id, "sequential", false, None, "skip", true, "next", None, "break", None)
         .await
         .unwrap()
         .id;
     assert_eq!(db.count_loop_steps_using_todo(todo_id).await.unwrap(), 1);
 
     // 加第二个 step → 2
-    db.create_loop_step(loop_id, "s2", "", todo_id, "sequential", false, None, "skip", true)
+    db.create_loop_step(loop_id, "s2", "", todo_id, "sequential", false, None, "skip", true, "next", None, "break", None)
         .await
         .unwrap();
     assert_eq!(db.count_loop_steps_using_todo(todo_id).await.unwrap(), 2);

--- a/frontend/src/components/LoopStudioExecutionsPanel.tsx
+++ b/frontend/src/components/LoopStudioExecutionsPanel.tsx
@@ -17,7 +17,7 @@ import {
   ArrowRightOutlined,
 } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
-import type { LoopExecutionDto, LoopExecutionDetail } from '@/types/loop';
+import type { LoopExecutionDto, LoopExecutionDetail, LoopExecutionTokenSummary } from '@/types/loop';
 import { formatRelativeTime } from '@/utils/datetime';
 import { useExecutionEvents } from '@/hooks/useExecutionEvents';
 
@@ -49,6 +49,70 @@ function durationLabel(start: string, end: string | null): string {
   if (ms < 1000) return `${ms}ms`;
   if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
   return `${Math.floor(ms / 60_000)}m ${Math.floor((ms % 60_000) / 1000)}s`;
+}
+
+// Token 格式化：千位分隔
+function formatToken(n: number): string {
+  return n.toLocaleString();
+}
+
+// Cost 格式化：美元小数
+function formatCost(cost: number): string {
+  if (cost < 0.01) return '$<0.01';
+  return `$${cost.toFixed(4)}`;
+}
+
+// Token 汇总条组件：展示本次 loop execution 的 token 总消耗
+function TokenSummaryBar({ summary }: { summary: LoopExecutionTokenSummary }) {
+  // 只在有实际消耗时才显示
+  const hasTokens = summary.total_input_tokens > 0 || summary.total_output_tokens > 0;
+  if (!hasTokens && summary.total_cost_usd <= 0) return null;
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 8, flexWrap: 'wrap',
+      padding: '8px 12px',
+      marginBottom: 8,
+      background: 'var(--color-bg-hover)',
+      borderRadius: 8,
+      border: '1px solid var(--color-border)',
+      fontSize: 12,
+    }}>
+      <span style={{ fontWeight: 600, color: 'var(--color-text)' }}>Token 消耗汇总</span>
+      <TokenBadge label="输入" value={`${formatToken(summary.total_input_tokens)}`} color="#1677ff" />
+      <TokenBadge label="输出" value={`${formatToken(summary.total_output_tokens)}`} color="#52c41a" />
+      {summary.total_cache_read_input_tokens > 0 && (
+        <TokenBadge label="缓存读取" value={`${formatToken(summary.total_cache_read_input_tokens)}`} color="#722ed1" />
+      )}
+      {summary.total_cache_creation_input_tokens > 0 && (
+        <TokenBadge label="缓存创建" value={`${formatToken(summary.total_cache_creation_input_tokens)}`} color="#eb2f96" />
+      )}
+      {summary.total_cost_usd > 0 && (
+        <span style={{
+          padding: '2px 6px', borderRadius: 4,
+          background: 'var(--color-warning-bg)', color: 'var(--color-warning)',
+          fontWeight: 600, fontSize: 12,
+        }}>
+          费用 {formatCost(summary.total_cost_usd)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// Token 徽章组件
+function TokenBadge({ label, value, color }: { label: string; value: string; color: string }) {
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 3,
+      padding: '1px 6px', borderRadius: 4,
+      background: `${color}0f`,
+      fontSize: 11, fontWeight: 500, color,
+    }}>
+      {label}: {value}
+    </span>
+  );
 }
 
 export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange, onExecutionTrace }: Props) {
@@ -203,7 +267,13 @@ export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange
                     {expandedLoading ? (
                       <Skeleton active />
                     ) : expandedDetail && expandedDetail.id === e.id ? (
-                      <StepExecList stepExecs={expandedDetail.step_executions} />
+                      <>
+                        {/* Token 汇总条：展示本次 loop 执行的所有 token 消耗 */}
+                        {expandedDetail.token_summary && (
+                          <TokenSummaryBar summary={expandedDetail.token_summary} />
+                        )}
+                        <StepExecList stepExecs={expandedDetail.step_executions} />
+                      </>
                     ) : null}
                   </div>
                 )}
@@ -264,7 +334,7 @@ function StepExecList({ stepExecs }: { stepExecs: Record<string, any>[] }) {
               <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '0 2px' }}>
                 <ArrowRightOutlined style={{ color: 'var(--color-text-tertiary, #94a3b8)', fontSize: 16 }} />
                 {s.sequence_index != null && (
-                  <span style={{ fontSize: 9, color: '#94a3b8', fontFamily: 'monospace', lineHeight: 1 }}>
+                  <span style={{ fontSize: 9, color: 'var(--color-text-tertiary)', fontFamily: 'monospace', lineHeight: 1 }}>
                     #{s.sequence_index}
                   </span>
                 )}
@@ -289,7 +359,7 @@ function StepExecList({ stepExecs }: { stepExecs: Record<string, any>[] }) {
               {/* 黑板序号 + 执行序号 */}
               <div style={{ position: 'absolute', top: 6, left: 10, fontSize: 11, fontWeight: 600, color: 'var(--color-text-tertiary, #94a3b8)', display: 'flex', gap: 6 }}>
                 {s.sequence_index != null && <span style={{ fontFamily: 'monospace' }}>#{s.sequence_index}</span>}
-                <span style={{ fontFamily: 'monospace', color: '#cbd5e1' }}>/#{idx + 1}</span>
+                <span style={{ fontFamily: 'monospace', color: 'var(--color-text-tertiary)' }}>/#{idx + 1}</span>
               </div>
 
               {/* 状态指示圆点 */}
@@ -329,17 +399,62 @@ function StepExecList({ stepExecs }: { stepExecs: Record<string, any>[] }) {
                 )}
               </div>
 
+              {/* Token 消耗：从 execution_record.usage 解析 */}
+              {(s.input_tokens != null || s.output_tokens != null) && (
+                <div style={{
+                  display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap',
+                  marginTop: 4, marginBottom: 4,
+                }}>
+                  {s.input_tokens != null && (
+                    <span style={{
+                      padding: '1px 5px', borderRadius: 3,
+                      background: 'var(--color-info-bg)', fontSize: 10, color: 'var(--color-info)',
+                      fontWeight: 500, fontFamily: 'monospace',
+                    }}>
+                      i{formatToken(s.input_tokens)}
+                    </span>
+                  )}
+                  {s.output_tokens != null && (
+                    <span style={{
+                      padding: '1px 5px', borderRadius: 3,
+                      background: 'var(--color-success-bg)', fontSize: 10, color: 'var(--color-success)',
+                      fontWeight: 500, fontFamily: 'monospace',
+                    }}>
+                      o{formatToken(s.output_tokens)}
+                    </span>
+                  )}
+                  {s.cache_read_input_tokens != null && s.cache_read_input_tokens > 0 && (
+                    <span style={{
+                      padding: '1px 5px', borderRadius: 3,
+                      background: 'var(--color-info-bg)', fontSize: 10, color: 'var(--color-primary)',
+                      fontWeight: 500, fontFamily: 'monospace',
+                    }}>
+                      cr{formatToken(s.cache_read_input_tokens)}
+                    </span>
+                  )}
+                  {s.total_cost_usd != null && s.total_cost_usd > 0 && (
+                    <span style={{
+                      padding: '1px 5px', borderRadius: 3,
+                      background: 'var(--color-warning-bg)', fontSize: 10, color: 'var(--color-warning)',
+                      fontWeight: 500, fontFamily: 'monospace',
+                    }}>
+                      {formatCost(s.total_cost_usd)}
+                    </span>
+                  )}
+                </div>
+              )}
+
               {/* 结论（黑板） */}
               {s.conclusion && (
                 <div style={{
                   marginTop: 6, padding: '6px 8px',
-                  background: '#f8fafc', borderRadius: 6,
-                  fontSize: 12, color: '#475569',
+                  background: 'var(--color-bg-hover)', borderRadius: 6,
+                  fontSize: 12, color: 'var(--color-text-secondary)',
                   lineHeight: 1.5, maxHeight: 60, overflow: 'hidden',
                   textOverflow: 'ellipsis',
-                  borderLeft: '3px solid #0891b2',
+                  borderLeft: '3px solid var(--color-primary)',
                 }}>
-                  <div style={{ fontSize: 10, fontWeight: 600, color: '#0891b2', marginBottom: 2 }}>结论</div>
+                  <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-primary)', marginBottom: 2 }}>结论</div>
                   {s.conclusion.length > 120 ? s.conclusion.slice(0, 120) + '…' : s.conclusion}
                 </div>
               )}
@@ -392,7 +507,7 @@ function StepExecList({ stepExecs }: { stepExecs: Record<string, any>[] }) {
         <div>
           <div style={{ fontWeight: 600, marginBottom: 8, fontSize: 14 }}>执行结果</div>
           <div style={{
-            background: 'var(--color-bg-secondary, #f8fafc)',
+            background: 'var(--color-bg-hover)',
             padding: 12, borderRadius: 6, fontSize: 13,
             whiteSpace: 'pre-wrap', lineHeight: 1.6, maxHeight: 400, overflow: 'auto',
           }}>

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -82,6 +82,12 @@ export interface LoopStepExecutionDto {
   step_name: string | null;
   sequence_index: number;
   conclusion: string | null;
+  /** 该环节消耗的 token（从关联的 execution_record.usage 解析） */
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cache_read_input_tokens: number | null;
+  cache_creation_input_tokens: number | null;
+  total_cost_usd: number | null;
 }
 
 export interface TodoSummaryForLoop {
@@ -198,6 +204,14 @@ export interface LoopListItem {
   last_execution_at: string | null;
 }
 
+export interface LoopExecutionTokenSummary {
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cache_read_input_tokens: number;
+  total_cache_creation_input_tokens: number;
+  total_cost_usd: number;
+}
+
 export interface LoopExecutionDetail {
   id: number;
   loop_id: number;
@@ -213,6 +227,7 @@ export interface LoopExecutionDetail {
   total_executed_steps: number;
   step_executions: Record<string, any>[];
   loop_name: string;
+  token_summary: LoopExecutionTokenSummary;
 }
 
 export interface LoopExecutionListResponse {


### PR DESCRIPTION
## 功能说明

Loop 执行历史中展示 Token 消耗统计。

### 后端变更

- `LoopStepExecutionDto` 增加 `input_tokens`、`output_tokens`、`cache_read_input_tokens`、`cache_creation_input_tokens`、`total_cost_usd` 字段
- 新增 `LoopExecutionTokenSummary` 结构体，`LoopExecutionDetail` 增加 `token_summary` 字段
- `get_execution` 处理函数：按环节从 `execution_record.usage` 解析 token 消耗，并聚合计算汇总
- 新增 v12 迁移：为 `execution_records` 添加 `loop_step_execution_id` 和 `step_id` 列（实体已定义但缺 DDL）

### 前端变更

- 新增 `TokenSummaryBar` 组件：在展开的执行详情顶部展示总 Token 消耗（输入、输出、缓存读取、缓存创建、费用）
- 每张环节执行卡片展示 Token 徽章：`i`（输入）`o`（输出）`cr`（缓存读取）和费用
- 所有硬编码 hex 颜色替换为 CSS 变量，暗色模式下自动适配 Catppuccin Mocha 主题

### Token 数据来源

Token 数据来自 `execution_records.usage` 字段（JSON），该字段由各执行器（Claude Code、Codex 等）写入。