### PR TITLE
fix(pi): 跳过 stderr 中的 JSONL 行，避免日志重复

### DIFF
--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -409,6 +409,20 @@ impl CodeExecutor for PiExecutor {
     fn get_model(&self) -> Option<String> {
         self.base.model.lock().clone()
     }
+
+    /// 重写 parse_stderr_line：跳过 JSONL 行（pi --mode json 会同时输出 JSONL
+    /// 到 stdout 和 stderr）。JSONL 行已在 stdout reader 中被正确解析，
+    /// 若 stderr 再处理一次，每条日志会重复出现两次。
+    /// 非 JSON 的 stderr 行按默认关键字分类处理。
+    fn parse_stderr_line(&self, line: &str) -> Option<ParsedLogEntry> {
+        let trimmed = line.trim();
+        // 跳过空行，跳过 JSONL（以 { 或 [ 开头的行）
+        if trimmed.is_empty() || trimmed.starts_with('{') || trimmed.starts_with('[') {
+            return None;
+        }
+        // 非 JSON 的 stderr 行委托给默认关键字分类
+        BaseExecutor::default_parse_stderr_line(line)
+    }
 }
 
 #[cfg(test)]
@@ -660,4 +674,51 @@ mod tests {
         executor.parse_output_line(line);
         assert_eq!(executor.get_model(), Some("claude-opus-4-7".to_string()));
     }
+
+    // —— parse_stderr_line ——
+
+    #[test]
+    fn test_parse_stderr_line_skips_jsonl() {
+        // JSONL 行（pi --mode json 同时输出到 stdout 和 stderr）应被跳过，
+        // 避免与 stdout reader 的解析结果重复。
+        let executor = PiExecutor::new("pi".to_string());
+        let line = r#"{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"hello"}}"#;
+        assert!(executor.parse_stderr_line(line).is_none(), "JSONL 行应被跳过");
+    }
+
+    #[test]
+    fn test_parse_stderr_line_skips_jsonl_array() {
+        // JSON 数组开头的 stderr 行也应被跳过。
+        let executor = PiExecutor::new("pi".to_string());
+        let line = r#"[{"key":"value"},{"key":"value2"}]
+"#;
+        assert!(executor.parse_stderr_line(line).is_none(), "JSON 数组行应被跳过");
+    }
+
+    #[test]
+    fn test_parse_stderr_line_skips_empty() {
+        // 空行应被跳过。
+        let executor = PiExecutor::new("pi".to_string());
+        assert!(executor.parse_stderr_line("").is_none());
+        assert!(executor.parse_stderr_line("   ").is_none());
+    }
+
+    #[test]
+    fn test_parse_stderr_line_passes_non_json() {
+        // 非 JSON 的 stderr 行（pi 真正的错误/警告信息）应按默认关键字分类处理。
+        let executor = PiExecutor::new("pi".to_string());
+        let entry = executor.parse_stderr_line("ERROR: something failed").unwrap();
+        assert_eq!(entry.log_type, "error", "含 error 的行应标记为 error");
+        assert!(entry.content.contains("ERROR"));
+    }
+
+    #[test]
+    fn test_parse_stderr_line_info() {
+        // 非 JSON、不含 error 关键字的 stderr 行应作为普通 stderr。
+        let executor = PiExecutor::new("pi".to_string());
+        let entry = executor.parse_stderr_line("loading config ...").unwrap();
+        assert_eq!(entry.log_type, "stderr");
+        assert_eq!(entry.content, "loading config ...");
+    }
+
 }


### PR DESCRIPTION
## 问题描述

使用 pi 作为执行器时，前端看到的所有日志（assistant 回复、thinking、tool_use 等）都是**两份重复**的。

## 根因分析

pi 的 `--mode json` 会将完整的 JSONL 事件流**同时输出到 stdout 和 stderr**（这是 pi 的行为特性）。

而原来的代码中：

1. **stdout reader**（`spawn_stdout_reader`）：读取 stdout → `parse_output_line` 正确解析 JSONL → 产生正确的 assistant/thinking/tool_use 日志 → 推入 LogFlusher + 发事件
2. **stderr reader**（`spawn_stderr_reader`）：读取 stderr → `parse_stderr_line`（PiExecutor 未 override，走 trait 默认返回 `None`）→ `unwrap_or_else(|| ParsedLogEntry::stderr(line.clone()))` → 又把同一行 JSONL 推入 LogFlusher + 发事件

结果：**每条 JSONL 行产生两条日志**——一条来自 stdout 的正确解析结果，一条来自 stderr 的 raw 文本兜底。

## 修复方案

实现 `PiExecutor::parse_stderr_line`，识别并跳过 JSONL 行（以 `{` 或 `[` 开头的行），非 JSON 的 stderr 行（如真正的错误/警告信息）才委托给 `BaseExecutor::default_parse_stderr_line` 处理。

## 测试

新增 5 个单元测试覆盖：

| 测试 | 验证内容 |
|------|---------|
| `test_parse_stderr_line_skips_jsonl` | JSONL 对象行被跳过 |
| `test_parse_stderr_line_skips_jsonl_array` | JSON 数组行被跳过 |
| `test_parse_stderr_line_skips_empty` | 空行被跳过 |
| `test_parse_stderr_line_passes_non_json` | 含 error 的非 JSON 行正常标记为 error |
| `test_parse_stderr_line_info` | 非 JSON 普通行标记为 stderr |

```
cargo test --lib -- adapters::pi::tests
```
→ 29 passed, 1 ignored（仅已有的忽略项）