### PR TITLE
fix(step): 修复环节详情面板暗色模式下提示词/验收标准背景刺眼

### DIFF
--- a/frontend/src/components/StepDetailPanel.tsx
+++ b/frontend/src/components/StepDetailPanel.tsx
@@ -87,9 +87,11 @@ const sectionStyle: React.CSSProperties = {
 
 // Prompt 内容样式：预格式化文本、浅色背景、适中行高，
 // 与验收标准区段共用基础样式，仅追加 minHeight
+// 背景使用 --color-bg-hover：暗色下为 Catppuccin Mocha 的柔和深灰 #262637，
+// 亮色 fallback #f1f5f9 保持与白色底边的轻微层次，替代未定义的 --color-bg-secondary。
 const textDisplayStyle: React.CSSProperties = {
   fontSize: 13, color: 'var(--color-text-secondary, #475569)',
-  background: 'var(--color-bg-secondary, #f8fafc)',
+  background: 'var(--color-bg-hover, #f1f5f9)',
   padding: 12, borderRadius: 6, whiteSpace: 'pre-wrap',
   lineHeight: 1.6, minHeight: 40,
 };


### PR DESCRIPTION
## 问题

暗色模式下，点击环节列表中的某个环节后，右侧详情面板中的「提示词 (Prompt)」和「验收标准」两个文本区域背景为**白色/浅灰色**，非常刺眼。

## 根因

`StepDetailPanel.tsx` 中 `textDisplayStyle` 使用了 `background: var(--color-bg-secondary, #f8fafc)`，但 **`--color-bg-secondary` 这个 CSS 变量在 `App.css` 中从未定义**（亮色和暗色 theme 块中都没有）。因此无论在亮色还是暗色模式下，都回退到了 `#f8fafc`。

## 修复

改为 `var(--color-bg-hover, #f1f5f9)`，因为 `--color-bg-hover` 在 `App.css` 的暗色 theme 中已正确定义为 `#262637`（Catppuccin Mocha 柔和深灰），亮色下 `#f1f5f9` 保持与白色背景的轻微层次区别。

## 变更

仅修改 `frontend/src/components/StepDetailPanel.tsx`，1 行代码 + 注释说明。