### PR TITLE
fix: 修复 Loop 编辑页面全局限制区域暗色模式背景色刺眼问题

### DIFF
--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -410,10 +410,10 @@ export function LoopDetailPanel({
             />
           </Form.Item>
           {/* ── 全局限制 ── */}
-          <div style={{ fontWeight: 600, fontSize: 14, marginTop: 16, marginBottom: 12, color: '#64748b' }}>
+          <div style={{ fontWeight: 600, fontSize: 14, marginTop: 16, marginBottom: 12, color: 'var(--color-text-secondary, #64748b)' }}>
             全局限制
           </div>
-          <div style={{ background: '#f8fafc', padding: 12, borderRadius: 8 }}>
+          <div style={{ background: 'var(--color-bg-elevated, #f8fafc)', padding: 12, borderRadius: 8 }}>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
               <Form.Item label="最大执行步数" name={['max_step_executions']} tooltip="超出后自动终止 Loop（留空=不限制）">
                 <InputNumber min={1} max={9999} placeholder="不限" style={{ width: '100%' }} />


### PR DESCRIPTION
## 问题

Loop 编辑弹窗中的 `全局限制` 区域使用了硬编码颜色：
- `background: '#f8fafc'` — 亮色背景，暗色模式下刺眼
- `color: '#64748b'` — 标题颜色，暗色模式下无适配

## 修改

替换为 CSS 变量（与项目中 `DetailSection` 等其他组件保持一致）：
- `background: 'var(--color-bg-elevated, #f8fafc)'`
- `color: 'var(--color-text-secondary, #64748b)'`

## 效果

暗色模式下 `--color-bg-elevated` 自动映射为深色背景值，不再显示刺眼的亮色块。