### PR TITLE
fix(loop): 触发条件配置弹窗暗色主题适配

### DIFF
--- a/frontend/src/components/LoopStudioTriggersPanel.tsx
+++ b/frontend/src/components/LoopStudioTriggersPanel.tsx
@@ -883,8 +883,8 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
           <>
             {/* 专用配置区域 */}
             <div style={{
-              background: '#f8fafc',
-              border: '1px solid #e2e8f0',
+              background: 'var(--color-bg-hover, #f1f5f9)',
+              border: '1px solid var(--color-border, #e2e8f0)',
               borderRadius: 8,
               padding: 16,
             }}>


### PR DESCRIPTION
## 修复内容

将 Loop 触发条件点击启用后弹出的配置 Modal 中的硬编码背景色和边框色替换为 CSS 变量，使其在暗色主题下自动适配。

### 改动

`LoopStudioTriggersPanel.tsx`

| 原值 | 新值 |
|------|------|
| `background: '#f8fafc'` | `background: 'var(--color-bg-hover, #f1f5f9)'` |
| `border: '1px solid #e2e8f0'` | `border: '1px solid var(--color-border, #e2e8f0)'` |

### 效果
- 明亮主题：保持原有浅灰色背景
- 暗色主题：自动适配 Catppuccin Mocha 色板，不再显示白色刺眼背景