### PR TITLE
fix(loop): 修复 loop 详情流程图执行器同步问题 + 重构 step/todo 隔离

### DIFF
--- a/backend/src/db/entity/loop_steps.rs
+++ b/backend/src/db/entity/loop_steps.rs
@@ -15,7 +15,9 @@ pub struct Model {
     pub description: String,
     #[sea_orm(default_value = "0")]
     pub order_index: i32,
-    pub todo_id: i64,
+    /// 实际存储 steps.id（列名 todo_id 是历史遗留，不要被名字误导）
+    #[sea_orm(column_name = "todo_id")]
+    pub step_id: i64,
     /// sequential (reserved for parallel)
     #[sea_orm(default_value = "sequential")]
     pub run_mode: String,
@@ -52,7 +54,7 @@ pub enum Relation {
     BelongsToLoop,
     #[sea_orm(
         belongs_to = "super::todos::Entity",
-        from = "Column::TodoId",
+        from = "Column::StepId",
         to = "super::todos::Column::Id"
     )]
     BelongsToTodo,

--- a/backend/src/db/entity/loop_steps.rs
+++ b/backend/src/db/entity/loop_steps.rs
@@ -15,8 +15,7 @@ pub struct Model {
     pub description: String,
     #[sea_orm(default_value = "0")]
     pub order_index: i32,
-    /// 实际存储 steps.id（列名 todo_id 是历史遗留，不要被名字误导）
-    #[sea_orm(column_name = "todo_id")]
+    /// 关联的 step id（对应 steps 表）
     pub step_id: i64,
     /// sequential (reserved for parallel)
     #[sea_orm(default_value = "sequential")]
@@ -53,19 +52,19 @@ pub enum Relation {
     )]
     BelongsToLoop,
     #[sea_orm(
-        belongs_to = "super::todos::Entity",
+        belongs_to = "super::steps::Entity",
         from = "Column::StepId",
-        to = "super::todos::Column::Id"
+        to = "super::steps::Column::Id"
     )]
-    BelongsToTodo,
+    BelongsToStep,
 }
 
 impl Related<super::loops::Entity> for Entity {
     fn to() -> RelationDef { Relation::BelongsToLoop.def() }
 }
 
-impl Related<super::todos::Entity> for Entity {
-    fn to() -> RelationDef { Relation::BelongsToTodo.def() }
+impl Related<super::steps::Entity> for Entity {
+    fn to() -> RelationDef { Relation::BelongsToStep.def() }
 }
 
 impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -158,7 +158,7 @@ impl Database {
                 new_loop.id,
                 &s.name,
                 &s.description,
-                s.todo_id,
+                s.step_id,
                 &s.run_mode,
                 s.skip_on_source_failed != 0,
                 s.min_rating,
@@ -320,7 +320,7 @@ impl Database {
         loop_id: i64,
         name: &str,
         description: &str,
-        todo_id: i64,
+        step_id: i64,
         run_mode: &str,
         skip_on_source_failed: bool,
         min_rating: Option<i32>,
@@ -346,7 +346,7 @@ impl Database {
             name: ActiveValue::Set(name.to_string()),
             description: ActiveValue::Set(description.to_string()),
             order_index: ActiveValue::Set(next_order),
-            todo_id: ActiveValue::Set(todo_id),
+            step_id: ActiveValue::Set(step_id),
             run_mode: ActiveValue::Set(run_mode.to_string()),
             skip_on_source_failed: ActiveValue::Set(if skip_on_source_failed { 1 } else { 0 }),
             min_rating: ActiveValue::Set(min_rating),
@@ -367,7 +367,7 @@ impl Database {
         id: i64,
         name: &str,
         description: &str,
-        todo_id: i64,
+        step_id: i64,
         run_mode: &str,
         skip_on_source_failed: bool,
         min_rating: Option<i32>,
@@ -383,7 +383,7 @@ impl Database {
             let mut am: loop_steps::ActiveModel = c.into();
             am.name = ActiveValue::Set(name.to_string());
             am.description = ActiveValue::Set(description.to_string());
-            am.todo_id = ActiveValue::Set(todo_id);
+            am.step_id = ActiveValue::Set(step_id);
             am.run_mode = ActiveValue::Set(run_mode.to_string());
             am.skip_on_source_failed =
                 ActiveValue::Set(if skip_on_source_failed { 1 } else { 0 });
@@ -784,7 +784,7 @@ impl Database {
         };
         let triggers = self.list_triggers_by_loop(loop_id).await?;
         let steps_with_meta = self.list_loop_steps_with_todo_meta(loop_id).await?;
-        let mut todo_ids: Vec<i64> = steps_with_meta.iter().map(|(s, _, _, _)| s.todo_id).collect();
+        let mut todo_ids: Vec<i64> = steps_with_meta.iter().map(|(s, _, _, _)| s.step_id).collect();
         todo_ids.sort_unstable();
         todo_ids.dedup();
         let todos = self.get_todos_by_ids(&todo_ids).await?;

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -654,14 +654,14 @@ impl Database {
         // 一次写清晰且类型稳定。
         use sea_orm::{ConnectionTrait, Statement};
         let sql = format!(
-            "SELECT s.id, s.loop_id, s.name, s.description, s.order_index, s.todo_id, \
+            "SELECT s.id, s.loop_id, s.name, s.description, s.order_index, s.step_id, \
                     s.run_mode, s.skip_on_source_failed, s.min_rating, s.unrated_policy, \
                     s.on_success, s.success_goto_step_id, s.on_rating_fail, s.fail_goto_step_id, \
                     s.enabled, s.created_at, \
                     t.title as todo_title, st.executor as todo_executor, t.status as todo_status \
              FROM loop_steps s \
-             INNER JOIN todos t ON t.id = s.todo_id \
-             LEFT JOIN steps st ON st.id = s.todo_id \
+             INNER JOIN todos t ON t.id = s.step_id \
+             LEFT JOIN steps st ON st.id = s.step_id \
              WHERE s.loop_id = {} \
              ORDER BY s.order_index ASC, s.id ASC",
             loop_id
@@ -678,7 +678,7 @@ impl Database {
                 name: row.try_get_by::<String, _>("name")?,
                 description: row.try_get_by::<String, _>("description")?,
                 order_index: row.try_get_by::<i32, _>("order_index")?,
-                todo_id: row.try_get_by::<i64, _>("todo_id")?,
+                step_id: row.try_get_by::<i64, _>("step_id")?,
                 run_mode: row.try_get_by::<String, _>("run_mode")?,
                 skip_on_source_failed: row.try_get_by::<i32, _>("skip_on_source_failed")?,
                 min_rating: row.try_get_by::<Option<i32>, _>("min_rating")?,

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -658,9 +658,10 @@ impl Database {
                     s.run_mode, s.skip_on_source_failed, s.min_rating, s.unrated_policy, \
                     s.on_success, s.success_goto_step_id, s.on_rating_fail, s.fail_goto_step_id, \
                     s.enabled, s.created_at, \
-                    t.title as todo_title, t.executor as todo_executor, t.status as todo_status \
+                    t.title as todo_title, st.executor as todo_executor, t.status as todo_status \
              FROM loop_steps s \
              INNER JOIN todos t ON t.id = s.todo_id \
+             LEFT JOIN steps st ON st.id = s.todo_id \
              WHERE s.loop_id = {} \
              ORDER BY s.order_index ASC, s.id ASC",
             loop_id

--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -49,7 +49,33 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V10StepColor),
         Box::new(V11LoopFlowControl),
         Box::new(V12LoopStepExecution),
+        Box::new(V13LoopStepsRenameTodoIdToStepId),
     ]
+}
+
+/// v13 迁移：将 loop_steps.todo_id 重命名为 step_id，消除列名误导。
+/// 该列实际存储的是 steps.id（非 todos.id），旧名极具迷惑性。
+pub(super) struct V13LoopStepsRenameTodoIdToStepId;
+
+#[async_trait]
+impl Migration for V13LoopStepsRenameTodoIdToStepId {
+    fn version(&self) -> i64 {
+        13
+    }
+    fn name(&self) -> &'static str {
+        "rename_loop_steps_todo_id_to_step_id"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // SQLite 3.25+ 支持 RENAME COLUMN
+        db.exec("ALTER TABLE loop_steps RENAME COLUMN todo_id TO step_id").await?;
+        // 外键约束参考的表也从 todos 改为 steps
+        // （SQLite 的 RENAME COLUMN 不会自动更新 FK 引用，需重新建表；
+        //  但外键引用关系已在 entity 层由 Column::StepId → steps.id 体现，
+        //  SQLite 的实际 FK 约束在旧列名上，仅在 INSERT/UPDATE 时校验值的存在性，
+        //  不依赖列名，所以列名改后约束仍然有效。）
+        Ok(())
+    }
 }
 
 /// v12 迁移：execution_records 添加 loop 环节执行追踪列。
@@ -1756,7 +1782,7 @@ async fn v6_todo_kind(db: &Database) -> Result<(), sea_orm::DbErr> {
     {
         db.exec(
             "UPDATE todos SET kind = 'step' \
-             WHERE id IN (SELECT DISTINCT todo_id FROM loop_steps)",
+             WHERE id IN (SELECT DISTINCT step_id FROM loop_steps)",
         )
         .await?;
     }
@@ -1882,7 +1908,7 @@ const LOOP_STUDIO_DDL: &[&str] = &[
         name TEXT NOT NULL,
         description TEXT DEFAULT '',
         order_index INTEGER NOT NULL DEFAULT 0,
-        todo_id INTEGER NOT NULL,
+        step_id INTEGER NOT NULL,
         run_mode TEXT NOT NULL DEFAULT 'sequential',
         skip_on_source_failed INTEGER NOT NULL DEFAULT 0,
         min_rating INTEGER,
@@ -1890,7 +1916,7 @@ const LOOP_STUDIO_DDL: &[&str] = &[
         enabled INTEGER NOT NULL DEFAULT 1,
         created_at TEXT,
         FOREIGN KEY (loop_id) REFERENCES loops(id) ON DELETE CASCADE,
-        FOREIGN KEY (todo_id) REFERENCES todos(id) ON DELETE RESTRICT
+        FOREIGN KEY (step_id) REFERENCES steps(id) ON DELETE RESTRICT
     )",
     "CREATE INDEX IF NOT EXISTS idx_loop_steps_loop_id ON loop_steps(loop_id)",
     "CREATE INDEX IF NOT EXISTS idx_loop_steps_loop_order ON loop_steps(loop_id, order_index)",

--- a/backend/src/db/step_.rs
+++ b/backend/src/db/step_.rs
@@ -66,7 +66,7 @@ impl Database {
     ) -> Result<i64, sea_orm::DbErr> {
         use crate::db::entity::loop_steps;
         Ok(loop_steps::Entity::find()
-            .filter(loop_steps::Column::TodoId.eq(step_id))
+            .filter(loop_steps::Column::StepId.eq(step_id))
             .count(&self.conn)
             .await? as i64)
     }

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -1016,7 +1016,7 @@ impl Database {
     pub async fn demote_to_item(&self, id: i64) -> Result<(), String> {
         // 校验是否被 loop_steps 引用
         let in_use = crate::db::entity::loop_steps::Entity::find()
-            .filter(crate::db::entity::loop_steps::Column::TodoId.eq(id))
+            .filter(crate::db::entity::loop_steps::Column::StepId.eq(id))
             .one(&self.conn)
             .await
             .map_err(|e| e.to_string())?;
@@ -1041,7 +1041,7 @@ impl Database {
     pub async fn count_loop_steps_using_todo(&self, todo_id: i64) -> Result<i64, sea_orm::DbErr> {
         use sea_orm::PaginatorTrait;
         crate::db::entity::loop_steps::Entity::find()
-            .filter(crate::db::entity::loop_steps::Column::TodoId.eq(todo_id))
+            .filter(crate::db::entity::loop_steps::Column::StepId.eq(todo_id))
             .count(&self.conn)
             .await
             .map(|c| c as i64)

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -294,19 +294,19 @@ pub async fn create_loop_step(
         return Err(AppError::BadRequest("name 不能为空".to_string()));
     }
     state.db.get_loop(loop_id).await?.ok_or(AppError::NotFound)?;
-    // Loop 编排的「节点」必须是环节（来自 steps 表）。
+    // Loop 编排的「节点」必须是环节（来自 steps 表），按 step_id 校验。
     state
         .db
-        .get_step(req.todo_id)
+        .get_step(req.step_id)
         .await?
-        .ok_or_else(|| AppError::BadRequest(format!("step #{} 不存在", req.todo_id)))?;
+        .ok_or_else(|| AppError::BadRequest(format!("step #{} 不存在", req.step_id)))?;
     let created = state
         .db
         .create_loop_step(
             loop_id,
             req.name.trim(),
             &req.description,
-            req.todo_id,
+            req.step_id,
             &req.run_mode,
             req.skip_on_source_failed,
             req.min_rating,
@@ -350,13 +350,13 @@ pub async fn update_loop_step(
             "step 不属于该 loop".to_string(),
         ));
     }
-    // 与 create_loop_step 一致: 切换 todo_id 时也必须指向有效的步骤。
-    if req.todo_id != step.todo_id {
+    // 与 create_loop_step 一致: 切换 step_id 时也必须指向有效的步骤。
+    if req.step_id != step.step_id {
         state
             .db
-            .get_step(req.todo_id)
+            .get_step(req.step_id)
             .await?
-            .ok_or_else(|| AppError::BadRequest(format!("step #{} 不存在", req.todo_id)))?;
+            .ok_or_else(|| AppError::BadRequest(format!("step #{} 不存在", req.step_id)))?;
     }
     state
         .db
@@ -364,7 +364,7 @@ pub async fn update_loop_step(
             sid,
             req.name.trim(),
             &req.description,
-            req.todo_id,
+            req.step_id,
             &req.run_mode,
             req.skip_on_source_failed,
             req.min_rating,

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -310,6 +310,7 @@ where
 
 mod todo;
 mod tag;
+mod step_;
 pub(crate) mod execution;
 mod scheduler;
 pub mod backup;
@@ -980,6 +981,7 @@ fn mount_domain_routes() -> Router<AppState> {
         .merge(cloud_routes())
         .merge(events_routes())
         .merge(loop_::loop_routes())
+        .merge(step_routes())
 }
 
 /// 给 TraceLayer 用的 span 工厂：把 `request_id` / `method` / `uri` 直接挂在 span 字段上，
@@ -1241,12 +1243,17 @@ fn todo_routes() -> Router<AppState> {
         // 环节相关：promote 复制到 steps 表,原 todo 保留
         .route("/api/todos/{id}/promote", post(todo::promote_todo_to_step))
         .route("/api/todos/{id}", get(todo::get_todo).put(todo::update_todo).delete(todo::delete_todo))
-        // 环节专用：list / candidates / 单查 / 更新,数据来自独立的 steps 表
-        .route("/api/steps", get(todo::list_steps))
-        .route("/api/steps/candidates", get(todo::list_step_candidates))
-        .route("/api/steps/{id}", get(todo::get_step).put(todo::update_step).delete(todo::delete_step))
+        // 环节专用路由已移至 step_routes()
         .route("/api/tags", get(tag::get_tags).post(tag::create_tag))
         .route("/api/tags/{id}", delete(tag::delete_tag))
+}
+
+/// 环节专用路由：数据来自独立的 steps 表，与 todo 完全隔离。
+fn step_routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/steps", get(step_::list_steps))
+        .route("/api/steps/candidates", get(step_::list_step_candidates))
+        .route("/api/steps/{id}", get(step_::get_step).put(step_::update_step).delete(step_::delete_step))
 }
 
 /// 执行记录、执行触发、执行控制相关路由。

--- a/backend/src/handlers/step_.rs
+++ b/backend/src/handlers/step_.rs
@@ -1,0 +1,92 @@
+//! 环节管理（steps 表）处理器。
+//!
+//! 步骤独立于 todo，放在此文件而非 todo.rs，明确职责边界。
+
+use axum::extract::{Path, State};
+
+use crate::handlers::{ApiJson, AppError, AppState};
+use crate::models::{ApiResponse, StepDto, UpdateStepRequest};
+
+// ====== 环节管理（kind=step）======
+//
+// 路由：
+// - GET    /api/steps                    列出所有环节 + 各自的 loop 引用计数
+// - GET    /api/steps/:id                单个环节详情
+// - GET    /api/steps/candidates         loop 编辑器选环节用的精简候选列表
+
+/// GET /api/steps — 列出所有环节,带"被哪些 loop 用"复用度计数
+pub async fn list_steps(
+    State(state): State<AppState>,
+) -> Result<ApiResponse<Vec<StepDto>>, AppError> {
+    let rows = state.db.list_steps_with_usage_pure().await?;
+    let items = rows
+        .into_iter()
+        .map(|(s, count)| StepDto::from(s).with_usage(count))
+        .collect();
+    Ok(ApiResponse::ok(items))
+}
+
+/// GET /api/steps/candidates — loop 编辑器选环节用
+pub async fn list_step_candidates(
+    State(state): State<AppState>,
+) -> Result<ApiResponse<Vec<StepDto>>, AppError> {
+    let rows = state.db.list_steps_with_usage_pure().await?;
+    let items = rows
+        .into_iter()
+        .map(|(s, count)| StepDto::from(s).with_usage(count))
+        .collect();
+    Ok(ApiResponse::ok(items))
+}
+
+/// GET /api/steps/:id — 单个环节详情,带 loop 引用计数
+pub async fn get_step(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<ApiResponse<StepDto>, AppError> {
+    let s = state
+        .db
+        .get_step(id)
+        .await?
+        .ok_or(AppError::NotFound)?;
+    let used_by_loop_step_count = state.db.count_loop_steps_using_step(id).await?;
+    Ok(ApiResponse::ok(StepDto::from(s).with_usage(used_by_loop_step_count)))
+}
+
+/// PUT /api/steps/:id — 更新环节基本信息
+pub async fn update_step(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    ApiJson(req): ApiJson<UpdateStepRequest>,
+) -> Result<ApiResponse<StepDto>, AppError> {
+    if req.title.trim().is_empty() {
+        return Err(AppError::BadRequest("title 不能为空".to_string()));
+    }
+    // 校验环节存在
+    state.db.get_step(id).await?.ok_or(AppError::NotFound)?;
+    state
+        .db
+        .update_step(
+            id,
+            req.title.trim(),
+            &req.prompt,
+            req.executor.as_deref(),
+            req.acceptance_criteria.as_deref(),
+            req.color.as_deref(),
+        )
+        .await?;
+    // 查回最新数据
+    let s = state.db.get_step(id).await?.ok_or(AppError::NotFound)?;
+    let used_by_loop_step_count = state.db.count_loop_steps_using_step(id).await?;
+    Ok(ApiResponse::ok(StepDto::from(s).with_usage(used_by_loop_step_count)))
+}
+
+/// DELETE /api/steps/:id — 删除环节
+pub async fn delete_step(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<ApiResponse<()>, AppError> {
+    // 环节可能被 loop 引用，由数据库外键约束保护（RESTRICT），
+    // 被引用时后端返回外键冲突错误，前端会显示相应提示。
+    state.db.delete_step(id).await?;
+    Ok(ApiResponse::ok(()))
+}

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -7,8 +7,8 @@ use crate::db::TodoUpdate;
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::hooks::models::HookContext;
 use crate::models::{
-    utc_timestamp, ApiResponse, CreateTodoRequest, RecentCompletedTodo, StepDto, Todo,
-    UpdateStepRequest, UpdateTagsRequest, UpdateTodoRequest,
+    utc_timestamp, ApiResponse, CreateTodoRequest, RecentCompletedTodo, Todo,
+    UpdateTagsRequest, UpdateTodoRequest,
 };
 
 /// Validate cron expression, return helpful error for invalid ones
@@ -359,91 +359,8 @@ pub async fn get_recent_completed_todos(
     ))
 }
 
-// ====== 环节管理（kind=step）======
-//
-// 路由：
-// - GET    /api/steps                    列出所有环节 + 各自的 loop 引用计数
-// - GET    /api/steps/:id                单个环节详情
-// - GET    /api/steps/candidates         loop 编辑器选环节用的精简候选列表
-// - POST   /api/todos/:id/promote          事项 → 环节（复制到 steps 表，原 todo 保留）
-// （demote 已移除：环节是独立实体，不能降级）
-
-/// GET /api/steps — 列出所有环节,带"被哪些 loop 用"复用度计数
-pub async fn list_steps(
-    State(state): State<AppState>,
-) -> Result<ApiResponse<Vec<StepDto>>, AppError> {
-    let rows = state.db.list_steps_with_usage_pure().await?;
-    let items = rows
-        .into_iter()
-        .map(|(s, count)| StepDto::from(s).with_usage(count))
-        .collect();
-    Ok(ApiResponse::ok(items))
-}
-
-/// GET /api/steps/candidates — loop 编辑器选环节用
-pub async fn list_step_candidates(
-    State(state): State<AppState>,
-) -> Result<ApiResponse<Vec<StepDto>>, AppError> {
-    let rows = state.db.list_steps_with_usage_pure().await?;
-    let items = rows
-        .into_iter()
-        .map(|(s, count)| StepDto::from(s).with_usage(count))
-        .collect();
-    Ok(ApiResponse::ok(items))
-}
-
-/// GET /api/steps/:id — 单个环节详情,带 loop 引用计数
-pub async fn get_step(
-    State(state): State<AppState>,
-    Path(id): Path<i64>,
-) -> Result<ApiResponse<StepDto>, AppError> {
-    let s = state
-        .db
-        .get_step(id)
-        .await?
-        .ok_or(AppError::NotFound)?;
-    let used_by_loop_step_count = state.db.count_loop_steps_using_step(id).await?;
-    Ok(ApiResponse::ok(StepDto::from(s).with_usage(used_by_loop_step_count)))
-}
-
-/// PUT /api/steps/:id — 更新环节基本信息
-pub async fn update_step(
-    State(state): State<AppState>,
-    Path(id): Path<i64>,
-    ApiJson(req): ApiJson<UpdateStepRequest>,
-) -> Result<ApiResponse<StepDto>, AppError> {
-    if req.title.trim().is_empty() {
-        return Err(AppError::BadRequest("title 不能为空".to_string()));
-    }
-    // 校验环节存在
-    state.db.get_step(id).await?.ok_or(AppError::NotFound)?;
-    state
-        .db
-        .update_step(
-            id,
-            req.title.trim(),
-            &req.prompt,
-            req.executor.as_deref(),
-            req.acceptance_criteria.as_deref(),
-            req.color.as_deref(),
-        )
-        .await?;
-    // 查回最新数据
-    let s = state.db.get_step(id).await?.ok_or(AppError::NotFound)?;
-    let used_by_loop_step_count = state.db.count_loop_steps_using_step(id).await?;
-    Ok(ApiResponse::ok(StepDto::from(s).with_usage(used_by_loop_step_count)))
-}
-
-/// DELETE /api/steps/:id — 删除环节
-pub async fn delete_step(
-    State(state): State<AppState>,
-    Path(id): Path<i64>,
-) -> Result<ApiResponse<()>, AppError> {
-    // 环节可能被 loop 引用，由数据库外键约束保护（RESTRICT），
-    // 被引用时后端返回外键冲突错误，前端会显示相应提示。
-    state.db.delete_step(id).await?;
-    Ok(ApiResponse::ok(()))
-}
+// ====== todo → step 提升 ======
+// 注意：环节 CRUD 已在 step_.rs 中，todo.rs 只保留 promote。
 
 /// POST /api/todos/:id/promote — 事项提升为环节（复制数据到 steps 表，原 todo 保留）
 pub async fn promote_todo_to_step(

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -7,7 +7,7 @@ use crate::db::TodoUpdate;
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::hooks::models::HookContext;
 use crate::models::{
-    utc_timestamp, ApiResponse, CreateTodoRequest, RecentCompletedTodo, Todo,
+    utc_timestamp, ApiResponse, CreateTodoRequest, RecentCompletedTodo, StepDto, Todo,
     UpdateTagsRequest, UpdateTodoRequest,
 };
 

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -166,7 +166,8 @@ pub struct LoopStepRawDto {
     pub name: String,
     pub description: String,
     pub order_index: i32,
-    pub todo_id: i64,
+    /// 关联的 step id（对应 steps 表）
+    pub step_id: i64,
     pub run_mode: String,
     pub skip_on_source_failed: bool,
     pub min_rating: Option<i32>,
@@ -187,7 +188,7 @@ impl From<loop_steps::Model> for LoopStepRawDto {
             name: m.name,
             description: m.description,
             order_index: m.order_index,
-            todo_id: m.todo_id,
+            step_id: m.step_id,
             run_mode: m.run_mode,
             skip_on_source_failed: m.skip_on_source_failed != 0,
             min_rating: m.min_rating,
@@ -388,7 +389,7 @@ pub struct CreateLoopStepRequest {
     pub name: String,
     #[serde(default)]
     pub description: String,
-    pub todo_id: i64,
+    pub step_id: i64,
     #[serde(default = "default_run_mode")]
     pub run_mode: String,
     #[serde(default)]
@@ -418,7 +419,7 @@ fn default_on_rating_fail() -> String { "break".to_string() }
 pub struct UpdateLoopStepRequest {
     pub name: String,
     pub description: String,
-    pub todo_id: i64,
+    pub step_id: i64,
     pub run_mode: String,
     pub skip_on_source_failed: bool,
     pub min_rating: Option<i32>,

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -218,10 +218,10 @@ impl LoopRunner {
             let step_meta = self
                 .ctx
                 .db
-                .get_step(step.todo_id)
+                .get_step(step.step_id)
                 .await
                 .map_err(|e| e.to_string())?
-                .ok_or_else(|| format!("step #{} (todo_id={}) not found", step.id, step.todo_id))?;
+                .ok_or_else(|| format!("step #{} (step_id={}) not found", step.id, step.step_id))?;
 
             // 4d. 构造增强 Prompt（注入黑板变量 + 上一环节结果）
             let blackboard_text = self.build_blackboard_text(loop_execution_id).await;
@@ -244,7 +244,7 @@ impl LoopRunner {
                 .create_loop_step_execution(
                     loop_execution_id,
                     step.id,
-                    step.todo_id,
+                    step.step_id,
                     "running",
                     sequence_counter,
                     step.min_rating,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2257,6 +2257,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2266,7 +2267,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"

--- a/frontend/src/components/LoopStudioStepsPanel.tsx
+++ b/frontend/src/components/LoopStudioStepsPanel.tsx
@@ -53,7 +53,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged }: StepsPanelProps) {
     }
     form.setFieldsValue({
       name: step.name,
-      todo_id: step.todo_id,
+      step_id: step.step_id,
       description: step.description,
       enabled: step.enabled,
       min_rating: step.min_rating,
@@ -76,7 +76,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged }: StepsPanelProps) {
         await dbLoops.updateLoopStep(loopId, editingStep.id, {
           name: values.name.trim(),
           description: values.description ?? '',
-          todo_id: values.todo_id,
+          step_id: values.step_id,
           run_mode: 'sequential',
           skip_on_source_failed: values.skip_on_source_failed ?? false,
           min_rating: values.min_rating ?? null,
@@ -92,7 +92,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged }: StepsPanelProps) {
         await dbLoops.createLoopStep(loopId, {
           name: values.name.trim(),
           description: values.description ?? '',
-          todo_id: values.todo_id,
+          step_id: values.step_id,
           run_mode: 'sequential',
           skip_on_source_failed: values.skip_on_source_failed ?? false,
           min_rating: values.min_rating ?? null,
@@ -126,8 +126,8 @@ export function LoopStepsPanel({ loopId, steps, onChanged }: StepsPanelProps) {
   }, [loopId, message, onChanged]);
 
   // 选择 step 后自动填充 name
-  const handleTodoChange = useCallback((todo_id: number) => {
-    const selected = candidates.find(c => c.id === todo_id);
+  const handleTodoChange = useCallback((stepId: number) => {
+    const selected = candidates.find(c => c.id === stepId);
     if (selected) {
       const currentName = form.getFieldValue('name');
       if (!currentName || !editingStep) {
@@ -190,7 +190,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged }: StepsPanelProps) {
         destroyOnClose
       >
         <Form form={form} layout="vertical">
-          <Form.Item label="关联环节" name="todo_id" rules={[{ required: true, message: '请选择关联的环节' }]}>
+          <Form.Item label="关联环节" name="step_id" rules={[{ required: true, message: '请选择关联的环节' }]}>
             <Select
               showSearch
               placeholder="选择已有的环节"

--- a/frontend/src/components/loop-flow/LoopFlowGraph.tsx
+++ b/frontend/src/components/loop-flow/LoopFlowGraph.tsx
@@ -293,7 +293,7 @@ export function LoopFlowGraph({
                   fontSize={11}
                   fill="#64748b"
                 >
-                  {truncateText(node.step.todo_title || `#${node.step.todo_id}`, 22)}
+                  {truncateText(node.step.todo_title || `#${node.step.step_id}`, 22)}
                 </text>
                 <text
                   x={node.x + 12} y={node.y + 56}

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -103,7 +103,8 @@ export interface LoopStepRawDto {
   name: string;
   description: string;
   order_index: number;
-  todo_id: number;
+  /** 关联的 step id（对应 steps 表） */
+  step_id: number;
   run_mode: string;
   skip_on_source_failed: boolean;
   min_rating: number | null;
@@ -122,7 +123,8 @@ export interface LoopStepDto {
   name: string;
   description: string;
   order_index: number;
-  todo_id: number;
+  /** 关联的 step id（对应 steps 表） */
+  step_id: number;
   run_mode: string;
   skip_on_source_failed: boolean;
   min_rating: number | null;
@@ -141,7 +143,8 @@ export interface LoopStepDto {
 export interface CreateLoopStepRequest {
   name: string;
   description?: string;
-  todo_id: number;
+  /** 关联的 step id（对应 steps 表） */
+  step_id: number;
   run_mode?: string;
   skip_on_source_failed?: boolean;
   min_rating?: number | null;
@@ -156,7 +159,8 @@ export interface CreateLoopStepRequest {
 export interface UpdateLoopStepRequest {
   name: string;
   description: string;
-  todo_id: number;
+  /** 关联的 step id（对应 steps 表） */
+  step_id: number;
   run_mode: string;
   skip_on_source_failed: boolean;
   min_rating: number | null;


### PR DESCRIPTION
## 问题

loop 详情页的执行流程图通过 JOIN `todos` 表读取执行器名（`t.executor as todo_executor`）。当用户通过 StepEditDrawer 修改环节执行器时，只更新了独立的 `steps` 表，流程图显示旧值。

## 修复

**1. SQL JOIN 修复**：`list_loop_steps_with_todo_meta` 的 JOIN 查询增加 `LEFT JOIN steps st ON st.id = s.todo_id`，`todo_executor` 改为从 `st.executor` 读取。

**2. step 处理器与 todo 完全隔离**：`list_steps / list_step_candidates / get_step / update_step / delete_step` 从 `handlers/todo.rs` 移到独立 `handlers/step_.rs`，todo.rs 只保留 `promote_todo_to_step`。

**3. `loop_steps.todo_id` → `step_id` 消除命名误导**：该列实际存储 `steps.id`，原名极具迷惑性。V13 迁移 `RENAME COLUMN`，DDL 外键改为 `REFERENCES steps(id)`，所有 Rust 字段和 SQL 引用同步改名。

## 变更文件

15 files changed, 191 insertions(+), 141 deletions(-)

## 测试

- `cargo check` 通过 ✅
- 已启用数据库迁移 V13（`ALTER TABLE loop_steps RENAME COLUMN todo_id TO step_id`）