### PR TITLE
通用操作工具栏（事项 / 环节 / 环路 共用）+ 环节/环路搜索框

### DIFF
--- a/backend/src/db/step_.rs
+++ b/backend/src/db/step_.rs
@@ -90,28 +90,30 @@ impl Database {
             .collect();
         let in_clause = placeholders.join(",");
         
-        // 单次聚合查询：GROUP BY todo_id 一次性获取所有引用计数
+        // 单次聚合查询：GROUP BY step_id 一次性获取所有引用计数
+        // 注意：DB 列名是 step_id（commit 9590e63 把 stage→step 重命名后），
+        // 但 sea_orm entity 字段仍叫 todo_id，raw SQL 必须用真实列名 step_id。
         let sql = format!(
-            "SELECT todo_id, COUNT(*) as cnt FROM loop_steps WHERE todo_id IN ({}) GROUP BY todo_id",
+            "SELECT step_id, COUNT(*) as cnt FROM loop_steps WHERE step_id IN ({}) GROUP BY step_id",
             in_clause
         );
-        
+
         let values: Vec<sea_orm::Value> = step_ids
             .iter()
             .map(|id| (*id).into())
             .collect();
-        
+
         let stmt = Statement::from_sql_and_values(sea_orm::DbBackend::Sqlite, sql, values);
         let rows = self.conn.query_all(stmt).await?;
-        
+
         // 从查询结果构建 HashMap
         let mut map = std::collections::HashMap::new();
         for row in rows {
-            let todo_id: i64 = row.try_get("", "todo_id")?;
+            let step_id: i64 = row.try_get("", "step_id")?;
             let cnt: i64 = row.try_get("", "cnt")?;
-            map.insert(todo_id, cnt);
+            map.insert(step_id, cnt);
         }
-        
+
         Ok(map)
     }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2257,6 +2257,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2266,7 +2267,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"

--- a/frontend/src/components/LoopStudioListPanel.tsx
+++ b/frontend/src/components/LoopStudioListPanel.tsx
@@ -10,7 +10,7 @@
 // - 单击切换 selectedId, 父组件维护; 当前选中卡片左侧条加亮 + 边框高亮
 
 import { useMemo, useState } from 'react';
-import { Button, Tag, Segmented } from 'antd';
+import { Button, Tag, Segmented, Checkbox } from 'antd';
 import {
   ClockCircleOutlined,
   ApartmentOutlined,
@@ -31,6 +31,9 @@ interface LoopListPanelProps {
   selectedId: number | null;
   onSelect: (id: number) => void;
   onCreate?: () => void;
+  // —— 多选支持（ActionToolbar 工具栏选中态）——
+  selectedIds?: number[];
+  onToggleSelect?: (id: number) => void;
 }
 
 // 状态 → 标签颜色, 集中在一处方便复用
@@ -71,7 +74,10 @@ function countByStatus(loops: LoopListItem[], filter: StatusFilter): number {
   return loops.filter(l => (l.status as LoopStatus) === filter).length;
 }
 
-export function LoopListPanel({ loops, selectedId, onSelect, onCreate }: LoopListPanelProps) {
+export function LoopListPanel({
+  loops, selectedId, onSelect, onCreate,
+  selectedIds, onToggleSelect,
+}: LoopListPanelProps) {
   // 状态过滤状态, 默认全部; 本地持有, 切 loop 时不重置
   const [filter, setFilter] = useState<StatusFilter>('all');
 
@@ -144,6 +150,8 @@ export function LoopListPanel({ loops, selectedId, onSelect, onCreate }: LoopLis
               loop={loop}
               selected={loop.id === selectedId}
               onClick={() => onSelect(loop.id)}
+              checked={selectedIds?.includes(loop.id) ?? false}
+              onToggleCheck={onToggleSelect ? () => onToggleSelect(loop.id) : undefined}
             />
           ))
         )}
@@ -153,10 +161,12 @@ export function LoopListPanel({ loops, selectedId, onSelect, onCreate }: LoopLis
 }
 
 // 单张 loop 卡片: 颜色条 + 标题区 + meta + 底部进度条
-function LoopCard({ loop, selected, onClick }: {
+function LoopCard({ loop, selected, onClick, checked, onToggleCheck }: {
   loop: LoopListItem;
   selected: boolean;
   onClick: () => void;
+  checked?: boolean;
+  onToggleCheck?: () => void;
 }) {
   const status: LoopStatus = (loop.status as LoopStatus) ?? 'paused';
   // 副标题优先用 workspace, 缺则降级到 description
@@ -216,8 +226,25 @@ function LoopCard({ loop, selected, onClick }: {
         }}
       />
 
-      {/* 标题行: #id + 名称 + 状态徽章 */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+      {/* 多选复选框: 仅在父组件提供 onToggleCheck 时渲染；stopPropagation 避免触发卡片选中 */}
+      {onToggleCheck && (
+        <Checkbox
+          checked={checked ?? false}
+          onChange={(e) => {
+            e.stopPropagation();
+            onToggleCheck();
+          }}
+          onClick={(e) => e.stopPropagation()}
+          data-testid={`loop-row-checkbox-${loop.id}`}
+          style={{ position: 'absolute', top: 14, left: 12, zIndex: 1 }}
+        />
+      )}
+
+      {/* 标题行: #id + 名称 + 状态徽章。多选模式下左侧留出复选框空间 */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4,
+        paddingLeft: onToggleCheck ? 28 : 0,
+      }}>
         <span style={{ color: 'var(--color-text-tertiary, #94a3b8)', fontSize: 11, fontFamily: 'monospace' }}>#{loop.id}</span>
         <span style={{
           fontWeight: 600, fontSize: 14, flex: 1, minWidth: 0,

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useApp } from '@/hooks/useApp';
 import { useIsMobile } from '@/hooks/useIsMobile';
-import { Button, Dropdown, Empty, Tooltip, Input, Segmented, Skeleton } from 'antd';
+import { Button, Dropdown, Empty, Tooltip, Input, Segmented, Skeleton, Checkbox, Modal, App as AntApp, Form, Select } from 'antd';
 import type { MenuProps } from 'antd';
-import { PlusOutlined, ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, ApartmentOutlined, FolderOpenOutlined, MoreOutlined, SearchOutlined, DownOutlined } from '@ant-design/icons';
+import { ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, ApartmentOutlined, FolderOpenOutlined, MoreOutlined, SearchOutlined, DownOutlined, SwapOutlined, StopOutlined } from '@ant-design/icons';
 import { useTheme } from '@/hooks/useTheme';
 import { StatusPicker } from './StatusPicker';
 import * as db from '@/utils/database';
@@ -14,6 +14,9 @@ import type { LoopListItem } from '@/types/loop';
 import * as dbLoops from '@/utils/database/loops';
 import * as dbSteps from '@/utils/database/steps';
 import type { StepSummary } from '@/types';
+import { EXECUTORS_FOR_PICKER } from '@/types/execution';
+import { ExecutorPicker } from './todo-drawer/ExecutorPicker';
+import { ActionToolbar, type BatchActionItem } from './common/ActionToolbar';
 import { formatRelativeTime } from '@/utils/datetime';
 
 interface TodoListProps {
@@ -84,6 +87,7 @@ export function TodoList(props: TodoListProps) {
   const { state, dispatch } = useApp();
   const { themeMode, toggleTheme } = useTheme();
   const { todos, selectedTodoId, selectedTagId, selectedWorkspace, tags } = state;
+  const { message } = AntApp.useApp();
   const isMobile = useIsMobile();
   const [isLoading, setIsLoading] = useState(true);
   // 搜索关键字状态，用于按标题或提示词过滤 todo 列表
@@ -106,6 +110,51 @@ export function TodoList(props: TodoListProps) {
   const [selectedLoopId, setSelectedLoopId] = useState<number | null>(null);
   // 项目目录：工作空间选择器需要目录列表
   const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
+  // —— 通用工具栏：跨模式的多选 id 列表 ——
+  // 切换 listMode 时清空，避免不同模式 id 串台（todo/step/loop 都是 number id）
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  // 批量更换执行器 Modal（事项 / 环节共用）
+  const [executorModalOpen, setExecutorModalOpen] = useState(false);
+  const [pendingExecutorChangeIds, setPendingExecutorChangeIds] = useState<number[]>([]);
+  // 强停确认 Modal（环路）
+  const [forceStopModalOpen, setForceStopModalOpen] = useState(false);
+  const [pendingForceStopIds, setPendingForceStopIds] = useState<number[]>([]);
+  // 新建环节 Modal（环节模式「新建」入口）
+  const [stepCreateOpen, setStepCreateOpen] = useState(false);
+  const [stepCreateForm] = Form.useForm<{ title: string; prompt: string; executor?: string }>();
+  const [stepCreating, setStepCreating] = useState(false);
+
+  /**
+   * 新建环节：复用历史 StepList 实现的「先 createTodo 再 promoteTodoToStep」流程。
+   * 环节是独立实体，但历史 promote 接口要求从 todo 起步，这里保持一致。
+   */
+  const handleCreateStep = useCallback(async (values: { title: string; prompt: string; executor?: string }) => {
+    if (!values.title.trim()) { message.error('标题必填'); return; }
+    setStepCreating(true);
+    try {
+      const created = await db.createTodo(
+        values.title.trim(), values.prompt?.trim() ?? '', [], [], undefined, undefined,
+      );
+      await dbSteps.promoteTodoToStep(created.id);
+      // 把新环节的 executor 设回去（createTodo 不会保留 executor，promote 后再更新）
+      if (values.executor) {
+        await dbSteps.updateStep(created.id, { title: values.title, executor: values.executor });
+      }
+      message.success(`环节「${created.title}」已创建`);
+      setStepCreateOpen(false);
+      stepCreateForm.resetFields();
+      // 刷新环节列表
+      const fresh = await dbSteps.listSteps();
+      setStepList(fresh);
+      // 创建后自动选中，让用户能立即在右侧面板编辑详情
+      setSelectedStepId(created.id);
+      onSelectStep?.(created.id);
+    } catch {
+      // axios 拦截器已弹错
+    } finally {
+      setStepCreating(false);
+    }
+  }, [message, stepCreateForm, onSelectStep]);
 
   useEffect(() => {
     setIsLoading(false);
@@ -154,6 +203,17 @@ export function TodoList(props: TodoListProps) {
     localStorage.setItem('ntd_list_mode', listMode);
   }, [listMode]);
 
+  // 切换 listMode 时清空选择：todo/step/loop 虽然 id 都是 number，
+  // 但语义不同（同一数字可能指向不同实体），跨模式保留选择会让用户困惑。
+  useEffect(() => {
+    setSelectedIds([]);
+  }, [listMode]);
+
+  // 切换单条 id 的选中态（toggle 语义，工具栏的「全选」用 onSelectionChange 全量覆盖）
+  const toggleSelect = useCallback((id: number) => {
+    setSelectedIds(prev => prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]);
+  }, []);
+
   const filteredTodos = useMemo(() => {
     // 步骤模式下不需要过滤 todo（左侧渲染步骤列表）
     if (listMode === 'step') return [];
@@ -193,6 +253,15 @@ export function TodoList(props: TodoListProps) {
     return result;
   }, [todos, selectedTagId, selectedWorkspace, searchKeyword, listMode]);
 
+  // 当前 listMode 下"可见可选"的 id 列表，传给 ActionToolbar 用于「全选」/计数。
+  // 环路模式下 LoopStudioListPanel 内部还有状态过滤，selectableIds 实际是
+  // 未过滤的全量；用户可手动点击复选框缩窄选择，V1 不做"全选仅选可见"。
+  const visibleIds = useMemo<number[]>(() => {
+    if (listMode === 'item') return filteredTodos.map(t => t.id);
+    if (listMode === 'step') return stepList.map(s => s.id);
+    return loopList.map(l => l.id);
+  }, [listMode, filteredTodos, stepList, loopList]);
+
   const handleStatusChange = useCallback(async (todoId: number, title: string, prompt: string, newStatus: string) => {
     try {
       const updated = await db.updateTodo(todoId, title, prompt, newStatus);
@@ -201,6 +270,121 @@ export function TodoList(props: TodoListProps) {
       // ignore: interceptor already shows error
     }
   }, [dispatch]);
+
+  // —— 批量操作：事项模式 ——
+  // 「更换执行器」打开 Modal，Modal 内确认后调 db.batchUpdateTodosExecutor
+  const openItemChangeExecutor = useCallback((ids: number[]) => {
+    setPendingExecutorChangeIds(ids);
+    setExecutorModalOpen(true);
+  }, []);
+
+  // —— 批量操作：环节模式 ——
+  const openStepChangeExecutor = useCallback((ids: number[]) => {
+    setPendingExecutorChangeIds(ids);
+    setExecutorModalOpen(true);
+  }, []);
+
+  // —— 批量操作：环路模式 ——
+  const openLoopForceStop = useCallback((ids: number[]) => {
+    setPendingForceStopIds(ids);
+    setForceStopModalOpen(true);
+  }, []);
+
+  // 确认更换执行器（事项 / 环节共用，根据 listMode 路由到不同的 db 函数）
+  const handleConfirmChangeExecutor = useCallback(async (executor: string) => {
+    const ids = pendingExecutorChangeIds;
+    if (ids.length === 0) return;
+    setExecutorModalOpen(false);
+    setPendingExecutorChangeIds([]);
+    try {
+      // 事项模式：需要先 fetchOne 获取 title/prompt 再调 updateTodo；
+      // 这里直接传 fetchOne 闭包让 db 层内部处理
+      const result = listMode === 'item'
+        ? await db.batchUpdateTodosExecutor(ids, executor, db.getTodo)
+        : await dbSteps.batchUpdateStepsExecutor(ids, executor);
+      if (result.failed.length === 0) {
+        message.success(`已为 ${result.updated.length} 项更换执行器为「${executor}」`);
+      } else {
+        message.warning(`成功 ${result.updated.length} 条，失败 ${result.failed.length} 条`);
+      }
+      // 触发列表刷新：item 通过 stepUpdateCount 机制，step / loop 通过各自的 reload
+      if (listMode === 'item') {
+        // item 模式依赖全局 todos 状态，由 useApp 拉取；增量更新单条避免全量重拉
+        for (const id of result.updated) {
+          const todo = await db.getTodo(id);
+          dispatch({ type: 'UPDATE_TODO', payload: todo });
+        }
+      } else if (listMode === 'step') {
+        // step 模式独立拉取：手动刷新一次
+        const fresh = await dbSteps.listSteps();
+        setStepList(fresh);
+      }
+    } catch {
+      // axios 拦截器已弹错
+    } finally {
+      setSelectedIds([]);
+    }
+  }, [pendingExecutorChangeIds, listMode, message, dispatch]);
+
+  // 确认强停（环路占位实现）
+  const handleConfirmForceStop = useCallback(async () => {
+    const ids = pendingForceStopIds;
+    if (ids.length === 0) return;
+    setForceStopModalOpen(false);
+    setPendingForceStopIds([]);
+    try {
+      const result = await dbLoops.forceStopLoops(ids);
+      if (result.stopped.length > 0) {
+        message.success(`已强停 ${result.stopped.length} 个环路`);
+      } else {
+        // 占位实现会全部走失败分支，统一提示"开发中"
+        message.warning(`环路强停功能开发中（已选 ${ids.length} 个）`);
+      }
+    } finally {
+      setSelectedIds([]);
+    }
+  }, [pendingForceStopIds, message]);
+
+  // 工具栏配置：按 listMode 切换 createLabel / batchActions。
+  // 「新建」按钮统一显示为「新建」2 字（用户能从当前 listMode 知道新建的是什么）；
+  // 批量菜单项按模式差异。
+  const toolbarConfig = useMemo<{
+    createLabel: string;
+    batchActions: BatchActionItem<number>[];
+  }>(() => {
+    if (listMode === 'item') {
+      return {
+        createLabel: '新建',
+        batchActions: [{
+          key: 'change-executor',
+          label: '更换执行器',
+          icon: <SwapOutlined />,
+          onClick: openItemChangeExecutor,
+        }],
+      };
+    }
+    if (listMode === 'step') {
+      return {
+        createLabel: '新建',
+        batchActions: [{
+          key: 'change-executor',
+          label: '更换执行器',
+          icon: <SwapOutlined />,
+          onClick: openStepChangeExecutor,
+        }],
+      };
+    }
+    return {
+      createLabel: '新建',
+      batchActions: [{
+        key: 'force-stop',
+        label: '强停',
+        icon: <StopOutlined />,
+        danger: true,
+        onClick: openLoopForceStop,
+      }],
+    };
+  }, [listMode, openItemChangeExecutor, openStepChangeExecutor, openLoopForceStop]);
 
   const desktopNavActions = useMemo(
     () => buildDesktopNavActions(onShowDashboard, onShowMemorial, onShowRelationMap),
@@ -257,6 +441,7 @@ export function TodoList(props: TodoListProps) {
     const primaryTag = todoTags[0];
     const isCompleted = todo.status === 'completed';
     const relativeTime = formatRelativeTime(todo.updated_at);
+    const isChecked = selectedIds.includes(todo.id);
 
     return (
       <div
@@ -282,7 +467,16 @@ export function TodoList(props: TodoListProps) {
           }
         }}
       >
-        <div className="todo-item-content">
+        {/* 多选复选框：position absolute 浮在卡片左上，避免打乱原本的 layout。
+            stopPropagation 阻止冒泡到卡片的 onClick（不会触发详情选中）。 */}
+        <Checkbox
+          checked={isChecked}
+          onChange={(e) => { e.stopPropagation(); toggleSelect(todo.id); }}
+          onClick={(e) => e.stopPropagation()}
+          data-testid={`todo-row-checkbox-${todo.id}`}
+          style={{ position: 'absolute', top: 12, left: 12, zIndex: 1 }}
+        />
+        <div className="todo-item-content" style={{ paddingLeft: 28 }}>
           <div className="todo-item-main">
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
               <div
@@ -427,6 +621,8 @@ export function TodoList(props: TodoListProps) {
 
           {!isMobile && (
             <div className="header-quick-actions">
+              {/* header 只保留「智能新建」（AI 一句话生成）。普通新建入口已迁到
+                  ActionToolbar 的「新建事项 / 新建环节 / 新建环路」按钮，避免两处入口混淆。 */}
               <Tooltip title="智能新建">
                 <Button
                   type="text"
@@ -435,16 +631,6 @@ export function TodoList(props: TodoListProps) {
                   className="header-primary-action header-primary-action-smart"
                   onClick={onOpenSmartCreate}
                   aria-label="智能新建"
-                />
-              </Tooltip>
-              <Tooltip title="新建任务">
-                <Button
-                  type="text"
-                  size="small"
-                  icon={<PlusOutlined />}
-                  className="header-primary-action header-primary-action-create"
-                  onClick={onOpenCreateModal}
-                  aria-label="新建任务"
                 />
               </Tooltip>
             </div>
@@ -567,6 +753,26 @@ export function TodoList(props: TodoListProps) {
         />
       </div>
 
+      {/* 通用操作工具栏：跨模式的「全选 / 批量 / 新建」入口。
+          createLabel / batchActions 按 listMode 在 toolbarConfig 中切换。 */}
+      <ActionToolbar
+        selectableIds={visibleIds}
+        selectedIds={selectedIds}
+        onSelectionChange={setSelectedIds}
+        createLabel={toolbarConfig.createLabel}
+        onCreate={
+          listMode === 'item' ? onOpenCreateModal
+          : listMode === 'step' ? () => setStepCreateOpen(true)
+          : onCreateLoop
+        }
+        batchActions={toolbarConfig.batchActions}
+        totalCount={
+          listMode === 'item' ? todos.length
+          : listMode === 'step' ? stepList.length
+          : loopList.length
+        }
+      />
+
       {/* 标签过滤：环路模式下不显示，loop 不按 tag 过滤 */}
       {listMode === 'item' && tags.length > 0 && (
         <div className="tag-filter-bar">
@@ -652,6 +858,14 @@ export function TodoList(props: TodoListProps) {
                     }
                   }}
                 >
+                  {/* 多选复选框：与 todo 卡片一致，绝对定位浮在卡片左上 */}
+                  <Checkbox
+                    checked={selectedIds.includes(step.id)}
+                    onChange={(e) => { e.stopPropagation(); toggleSelect(step.id); }}
+                    onClick={(e) => e.stopPropagation()}
+                    data-testid={`step-row-checkbox-${step.id}`}
+                    style={{ position: 'absolute', top: 14, left: 12, zIndex: 1 }}
+                  />
                   {/* 左侧 3px 颜色条 */}
                   <span style={{
                     position: 'absolute', left: 0, top: 0, bottom: 0, width: 3,
@@ -659,8 +873,8 @@ export function TodoList(props: TodoListProps) {
                     borderRadius: '10px 0 0 10px',
                   }} />
 
-                  {/* 标题行: #id + 名称 */}
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+                  {/* 标题行: #id + 名称，多选模式左侧留出复选框空间 */}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4, paddingLeft: 28 }}>
                     <span style={{ color: 'var(--color-text-tertiary, #94a3b8)', fontSize: 11, fontFamily: 'monospace' }}>#{step.id}</span>
                     <span style={{
                       fontWeight: 600, fontSize: 14, flex: 1, minWidth: 0,
@@ -704,6 +918,8 @@ export function TodoList(props: TodoListProps) {
                 onSelectLoop?.(id);
               }}
               onCreate={onCreateLoop}
+              selectedIds={selectedIds}
+              onToggleSelect={toggleSelect}
             />
           )}
         </div>
@@ -732,6 +948,72 @@ export function TodoList(props: TodoListProps) {
           )}
         </div>
       )}
+
+      {/* 批量更换执行器 Modal：事项 / 环节共用。
+          关闭即作废，不会触发回调（避免半路取消导致 selectedIds 与 Modal 状态不一致）。 */}
+      <Modal
+        title={`更换执行器（${pendingExecutorChangeIds.length} 项）`}
+        open={executorModalOpen}
+        onCancel={() => { setExecutorModalOpen(false); setPendingExecutorChangeIds([]); }}
+        footer={null}
+        destroyOnClose
+      >
+        <ExecutorPicker
+          executor=""
+          executorOptions={EXECUTORS_FOR_PICKER}
+          onChange={(v) => handleConfirmChangeExecutor(v)}
+        />
+      </Modal>
+
+      {/* 强停环路确认 Modal：占位实现，最终会调真实接口 */}
+      <Modal
+        title="强停环路"
+        open={forceStopModalOpen}
+        onOk={handleConfirmForceStop}
+        onCancel={() => { setForceStopModalOpen(false); setPendingForceStopIds([]); }}
+        okText="强停"
+        cancelText="取消"
+        okButtonProps={{ danger: true }}
+        destroyOnClose
+      >
+        <p>将停止 <strong>{pendingForceStopIds.length}</strong> 个环路关联的所有正在运行的执行。</p>
+        <p style={{ color: 'var(--color-text-tertiary)', fontSize: 12 }}>
+          （强停功能开发中，详见 utils/database/loops.ts 的 forceStopLoops 注释。）
+        </p>
+      </Modal>
+
+      {/* 新建环节 Modal：工具栏「新建环节」触发。
+          字段：标题（必填）/ 提示词 / 执行器，复用 StepList 的 createTodo + promote 流程。 */}
+      <Modal
+        title="新建环节"
+        open={stepCreateOpen}
+        onCancel={() => { setStepCreateOpen(false); stepCreateForm.resetFields(); }}
+        onOk={() => stepCreateForm.submit()}
+        confirmLoading={stepCreating}
+        okText="创建"
+        cancelText="取消"
+        destroyOnClose
+      >
+        <Form
+          form={stepCreateForm}
+          layout="vertical"
+          onFinish={handleCreateStep}
+          initialValues={{ executor: 'claudecode' }}
+        >
+          <Form.Item label="标题" name="title" rules={[{ required: true, message: '标题必填' }]}>
+            <Input placeholder="例如：代码审查环节" maxLength={100} />
+          </Form.Item>
+          <Form.Item label="提示词 (Prompt)" name="prompt" tooltip="描述这个环节能做什么">
+            <Input.TextArea rows={5} placeholder="例如：你是资深代码审查员..." maxLength={4000} />
+          </Form.Item>
+          <Form.Item label="执行器" name="executor">
+            <Select
+              options={EXECUTORS_FOR_PICKER.map(e => ({ label: e.label, value: e.value }))}
+              placeholder="选择执行器"
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -253,14 +253,26 @@ export function TodoList(props: TodoListProps) {
     return result;
   }, [todos, selectedTagId, selectedWorkspace, searchKeyword, listMode]);
 
+  // 通用关键字过滤：环节 / 环路模式也按标题搜索（用户反馈：避免切换时跳界面）
+  const filteredStepList = useMemo(() => {
+    const keyword = searchKeyword.trim().toLowerCase();
+    if (!keyword) return stepList;
+    return stepList.filter(s => (s.title || '').toLowerCase().includes(keyword));
+  }, [stepList, searchKeyword]);
+
+  const filteredLoopList = useMemo(() => {
+    const keyword = searchKeyword.trim().toLowerCase();
+    if (!keyword) return loopList;
+    return loopList.filter(l => (l.name || '').toLowerCase().includes(keyword));
+  }, [loopList, searchKeyword]);
+
   // 当前 listMode 下"可见可选"的 id 列表，传给 ActionToolbar 用于「全选」/计数。
-  // 环路模式下 LoopStudioListPanel 内部还有状态过滤，selectableIds 实际是
-  // 未过滤的全量；用户可手动点击复选框缩窄选择，V1 不做"全选仅选可见"。
+  // 三种模式都按当前 searchKeyword 过滤后的列表计算，避免「全选」选中隐藏项。
   const visibleIds = useMemo<number[]>(() => {
     if (listMode === 'item') return filteredTodos.map(t => t.id);
-    if (listMode === 'step') return stepList.map(s => s.id);
-    return loopList.map(l => l.id);
-  }, [listMode, filteredTodos, stepList, loopList]);
+    if (listMode === 'step') return filteredStepList.map(s => s.id);
+    return filteredLoopList.map(l => l.id);
+  }, [listMode, filteredTodos, filteredStepList, filteredLoopList]);
 
   const handleStatusChange = useCallback(async (todoId: number, title: string, prompt: string, newStatus: string) => {
     try {
@@ -456,6 +468,10 @@ export function TodoList(props: TodoListProps) {
           borderLeftColor: primaryTag?.color || '#cbd5e1',
           borderLeftWidth: 4,
           borderLeftStyle: 'solid',
+          // 工具栏的多选复选框用 position: absolute 浮在卡片左上；
+          // 若 .todo-item 不设 position: relative，复选框会逃逸到上层容器，
+          // 所有卡片的复选框都叠在同一个屏幕坐标，点击会命中最后渲染的那个。
+          position: 'relative',
         }}
         role="button"
         tabIndex={0}
@@ -724,19 +740,22 @@ export function TodoList(props: TodoListProps) {
         </Dropdown>
       </div>
 
-      {/* 搜索框：环路模式下隐藏，loop 列表有自己的过滤 */}
-      {listMode === 'item' && (
-        <div style={{ padding: '8px 16px', borderBottom: '1px solid var(--color-border-light)' }}>
-          <Input
-            placeholder="搜索标题或提示词..."
-            prefix={<SearchOutlined style={{ color: '#bfbfbf' }} />}
-            value={searchKeyword}
-            onChange={(e) => setSearchKeyword(e.target.value)}
-            allowClear
-            size="small"
-          />
-        </div>
-      )}
+      {/* 搜索框：三种模式都展示（用户反馈：环节/环路原本没有，切换时会跳界面）。
+          placeholder 按 listMode 切换，关键词同时匹配事项标题/提示词、环节标题、环路名称。 */}
+      <div style={{ padding: '8px 16px', borderBottom: '1px solid var(--color-border-light)' }}>
+        <Input
+          placeholder={
+            listMode === 'item' ? '搜索标题或提示词...'
+            : listMode === 'step' ? '搜索环节标题...'
+            : '搜索环路名称...'
+          }
+          prefix={<SearchOutlined style={{ color: '#bfbfbf' }} />}
+          value={searchKeyword}
+          onChange={(e) => setSearchKeyword(e.target.value)}
+          allowClear
+          size="small"
+        />
+      </div>
 
       {/* 列表选择：事项 / 环节 / 环路 */}
       <div style={{ padding: '8px 16px', borderBottom: '1px solid var(--color-border-light)' }}>
@@ -766,11 +785,6 @@ export function TodoList(props: TodoListProps) {
           : onCreateLoop
         }
         batchActions={toolbarConfig.batchActions}
-        totalCount={
-          listMode === 'item' ? todos.length
-          : listMode === 'step' ? stepList.length
-          : loopList.length
-        }
       />
 
       {/* 标签过滤：环路模式下不显示，loop 不按 tag 过滤 */}
@@ -801,7 +815,7 @@ export function TodoList(props: TodoListProps) {
         <div style={{ flex: 1, minHeight: 0, overflow: 'auto', padding: 8 }}>
           {stepLoading ? (
             <Skeleton active style={{ padding: 16 }} />
-          ) : stepList.length === 0 ? (
+          ) : filteredStepList.length === 0 ? (
             <Empty
               image={Empty.PRESENTED_IMAGE_SIMPLE}
               description={
@@ -816,7 +830,7 @@ export function TodoList(props: TodoListProps) {
             />
           ) : (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-              {stepList.map(step => (
+              {filteredStepList.map(step => (
                 <div
                   key={step.id}
                   onClick={() => {
@@ -911,7 +925,7 @@ export function TodoList(props: TodoListProps) {
             <Skeleton active style={{ padding: 16 }} />
           ) : (
             <LoopListPanel
-              loops={loopList}
+              loops={filteredLoopList}
               selectedId={selectedLoopId}
               onSelect={(id) => {
                 setSelectedLoopId(id);

--- a/frontend/src/components/common/ActionToolbar.tsx
+++ b/frontend/src/components/common/ActionToolbar.tsx
@@ -9,7 +9,9 @@
 //    不去查后端的全量数据 — 过滤后选中是用户能直接感知的范围。
 // 4. **批量按钮空选时禁用**：菜单项仍渲染（让用户知道有哪些可做的操作），
 //    但 trigger 按钮 disabled，避免误导。
-// 5. **拆分内部子组件**：SelectAll / BatchDropdown / CreateButton 各自 < 30 行，
+// 5. **节省空间**：仅渲染三按钮（checkbox + 批量 + 新建），不显示「已选 N 项 / 共 N 项」文案，
+//    选中数 / 总数靠全选复选框三态视觉隐式表达。
+// 6. **拆分内部子组件**：SelectAll / BatchDropdown / CreateButton 各自 < 30 行，
 //    方便后续单测 + 维护。
 
 import { Checkbox, Dropdown, Button } from 'antd';
@@ -49,8 +51,6 @@ export interface ActionToolbarProps<TId extends Key = number> {
   batchLabel?: string;
 
   // —— 可选展示 ——
-  /** 总数（仅用于显示 "共 N 项"），无过滤时与 selectableIds.length 相等。 */
-  totalCount?: number;
   /** 整体隐藏（如列表为空）。 */
   hidden?: boolean;
   className?: string;
@@ -163,15 +163,13 @@ export function ActionToolbar<TId extends Key = number>(props: ActionToolbarProp
     selectableIds, selectedIds, onSelectionChange,
     createLabel, createIcon, onCreate,
     batchActions, batchLabel = '批量',
-    totalCount, hidden, className,
+    hidden, className,
   } = props;
 
   if (hidden) return null;
 
-  // "已选 N 项" 提示：有选择时显示，无选择时隐藏
-  const showSelectedCount = selectedIds.length > 0;
-  // "共 N 项" 总数提示：totalCount 与 selectableIds 长度不同时（如有搜索过滤）显示
-  const showTotal = totalCount !== undefined && totalCount !== selectableIds.length;
+  // 节省空间：用户反馈不再显示「已选 N 项」「共 N 项」文案。
+  // 选中数 / 总数由全选复选框的三态视觉（indeterminate / checked）隐式表达。
 
   return (
     <div
@@ -180,8 +178,8 @@ export function ActionToolbar<TId extends Key = number>(props: ActionToolbarProp
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: 12,
-        padding: '8px 16px',
+        gap: 8,
+        padding: '6px 12px',
         borderBottom: '1px solid var(--color-border-light)',
         background: 'var(--color-bg-elevated, #ffffff)',
         flexShrink: 0,
@@ -192,19 +190,6 @@ export function ActionToolbar<TId extends Key = number>(props: ActionToolbarProp
         selectedIds={selectedIds}
         onChange={onSelectionChange}
       />
-      {showSelectedCount && (
-        <span
-          data-testid="action-toolbar-selected-count"
-          style={{ fontSize: 12, color: 'var(--color-primary)' }}
-        >
-          已选 {selectedIds.length} 项
-        </span>
-      )}
-      {showTotal && (
-        <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
-          共 {totalCount} 项
-        </span>
-      )}
       <div style={{ flex: 1 }} />
       <BatchDropdown
         selectedIds={selectedIds}

--- a/frontend/src/components/common/ActionToolbar.tsx
+++ b/frontend/src/components/common/ActionToolbar.tsx
@@ -1,0 +1,217 @@
+// 通用列表操作工具栏：用于事项 / 环节 / 环路等任意「可批量管理」列表的头部。
+//
+// 设计要点：
+// 1. **受控组件**：所有选择态由父组件持有，本组件只负责渲染 + 回传变更事件，
+//    让三种模式（事项/环节/环路）能各自扩展差异点（createLabel / batchActions）。
+// 2. **三态全选**：用 antd `Checkbox` 的 indeterminate 区分「空选 / 部分选 / 全选」，
+//    符合用户对批量操作工具栏的常规预期。
+// 3. **「全选」语义**：只选当前过滤后的可见项（selectableIds），
+//    不去查后端的全量数据 — 过滤后选中是用户能直接感知的范围。
+// 4. **批量按钮空选时禁用**：菜单项仍渲染（让用户知道有哪些可做的操作），
+//    但 trigger 按钮 disabled，避免误导。
+// 5. **拆分内部子组件**：SelectAll / BatchDropdown / CreateButton 各自 < 30 行，
+//    方便后续单测 + 维护。
+
+import { Checkbox, Dropdown, Button } from 'antd';
+import type { MenuProps } from 'antd';
+import { DownOutlined, PlusOutlined } from '@ant-design/icons';
+import type { Key, ReactNode } from 'react';
+
+// ─── 类型导出 ────────────────────────────────────────────────
+
+/** 单个批量操作菜单项。组件不感知业务语义，只负责点击时回传当前已选 id 列表。 */
+export interface BatchActionItem<TId extends Key = number> {
+  key: string;
+  label: string;
+  icon?: ReactNode;
+  danger?: boolean;
+  /** 收到当前 selectedIds，由父组件决定如何执行（弹 Modal / 调 API 等）。 */
+  onClick: (selectedIds: TId[]) => void;
+}
+
+export interface ActionToolbarProps<TId extends Key = number> {
+  // —— 选择态 ——
+  /** 当前过滤后可见、可选的 id 列表。点「全选」会全选这批。 */
+  selectableIds: TId[];
+  /** 已选 id 列表（受控）。 */
+  selectedIds: TId[];
+  /** 选择变化回传。组件只透传，逻辑由父组件决定（合并 / 替换 / 移除）。 */
+  onSelectionChange: (next: TId[]) => void;
+
+  // —— 新建按钮（差异点 #1：每种模式不同） ——
+  createLabel: string;
+  createIcon?: ReactNode;
+  onCreate?: () => void;
+
+  // —— 批量菜单（差异点 #2：每种模式不同） ——
+  batchActions: BatchActionItem<TId>[];
+  /** 批量按钮的 trigger 文案，默认 "批量"（2 字紧凑）；菜单项 label 由 batchActions 决定。 */
+  batchLabel?: string;
+
+  // —— 可选展示 ——
+  /** 总数（仅用于显示 "共 N 项"），无过滤时与 selectableIds.length 相等。 */
+  totalCount?: number;
+  /** 整体隐藏（如列表为空）。 */
+  hidden?: boolean;
+  className?: string;
+}
+
+// ─── 内部子组件：SelectAll ───────────────────────────────────
+
+interface SelectAllProps<TId extends Key> {
+  selectableIds: TId[];
+  selectedIds: TId[];
+  onChange: (next: TId[]) => void;
+}
+
+function SelectAll<TId extends Key>({ selectableIds, selectedIds, onChange }: SelectAllProps<TId>) {
+  // 三态判定：与 antd `Checkbox` 的 indeterminate 协议对齐
+  // indeterminate 时 input.checked 为 false，aria-checked='mixed' 反映部分选
+  const allCount = selectableIds.length;
+  const selectedSet = new Set<TId>(selectedIds);
+  const isAll = allCount > 0 && selectableIds.every(id => selectedSet.has(id));
+  const isPartial = !isAll && selectedIds.some(id => selectedSet.has(id));
+
+  // 点击行为：未全选 → 全选；已全选 → 清空
+  const handleToggle = () => {
+    if (isAll || isPartial) {
+      onChange([]); // 任何非空状态点击都清空
+    } else {
+      onChange([...selectableIds]); // 全选当前可见项
+    }
+  };
+
+  return (
+    <Checkbox
+      checked={isAll}
+      indeterminate={isPartial}
+      onChange={handleToggle}
+      data-testid="action-toolbar-select-all"
+    >
+      全选
+    </Checkbox>
+  );
+}
+
+// ─── 内部子组件：BatchDropdown ──────────────────────────────
+
+interface BatchDropdownProps<TId extends Key> {
+  selectedIds: TId[];
+  batchActions: BatchActionItem<TId>[];
+  batchLabel: string;
+}
+
+function BatchDropdown<TId extends Key>({ selectedIds, batchActions, batchLabel }: BatchDropdownProps<TId>) {
+  // 空选时禁用 trigger，但菜单项照常渲染（让用户能预览能力）
+  const disabled = selectedIds.length === 0;
+
+  // 把 BatchActionItem 数组翻译成 antd MenuProps.items
+  const items: MenuProps['items'] = batchActions.map(action => ({
+    key: action.key,
+    label: action.label,
+    icon: action.icon,
+    danger: action.danger,
+    // antd 的 Menu onClick 只回传 key，selectedIds 需闭包捕获
+    onClick: () => action.onClick(selectedIds),
+    disabled: disabled,
+  }));
+
+  return (
+    <Dropdown
+      menu={{ items }}
+      trigger={['click']}
+      disabled={disabled}
+    >
+      <Button
+        size="small"
+        data-testid="action-toolbar-batch-trigger"
+        disabled={disabled}
+      >
+        {batchLabel} <DownOutlined style={{ fontSize: 10 }} />
+      </Button>
+    </Dropdown>
+  );
+}
+
+// ─── 内部子组件：CreateButton ────────────────────────────────
+
+interface CreateButtonProps {
+  label: string;
+  icon?: ReactNode;
+  onClick?: () => void;
+}
+
+function CreateButton({ label, icon, onClick }: CreateButtonProps) {
+  if (!onClick) return null; // 父组件未提供时不渲染
+  return (
+    <Button
+      type="primary"
+      size="small"
+      icon={icon ?? <PlusOutlined />}
+      onClick={onClick}
+      data-testid="action-toolbar-create"
+    >
+      {label}
+    </Button>
+  );
+}
+
+// ─── 主组件 ────────────────────────────────────────────────
+
+export function ActionToolbar<TId extends Key = number>(props: ActionToolbarProps<TId>) {
+  const {
+    selectableIds, selectedIds, onSelectionChange,
+    createLabel, createIcon, onCreate,
+    batchActions, batchLabel = '批量',
+    totalCount, hidden, className,
+  } = props;
+
+  if (hidden) return null;
+
+  // "已选 N 项" 提示：有选择时显示，无选择时隐藏
+  const showSelectedCount = selectedIds.length > 0;
+  // "共 N 项" 总数提示：totalCount 与 selectableIds 长度不同时（如有搜索过滤）显示
+  const showTotal = totalCount !== undefined && totalCount !== selectableIds.length;
+
+  return (
+    <div
+      className={className}
+      data-testid="action-toolbar"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '8px 16px',
+        borderBottom: '1px solid var(--color-border-light)',
+        background: 'var(--color-bg-elevated, #ffffff)',
+        flexShrink: 0,
+      }}
+    >
+      <SelectAll
+        selectableIds={selectableIds}
+        selectedIds={selectedIds}
+        onChange={onSelectionChange}
+      />
+      {showSelectedCount && (
+        <span
+          data-testid="action-toolbar-selected-count"
+          style={{ fontSize: 12, color: 'var(--color-primary)' }}
+        >
+          已选 {selectedIds.length} 项
+        </span>
+      )}
+      {showTotal && (
+        <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+          共 {totalCount} 项
+        </span>
+      )}
+      <div style={{ flex: 1 }} />
+      <BatchDropdown
+        selectedIds={selectedIds}
+        batchActions={batchActions}
+        batchLabel={batchLabel}
+      />
+      <CreateButton label={createLabel} icon={createIcon} onClick={onCreate} />
+    </div>
+  );
+}

--- a/frontend/src/utils/database/loops.ts
+++ b/frontend/src/utils/database/loops.ts
@@ -156,3 +156,25 @@ export async function getExecution(
 ): Promise<LoopExecutionDetail> {
   return unwrap(await api.get(`/api/loops/${loopId}/executions/${executionId}`));
 }
+
+// ─── 批量操作（占位实现） ────────────────────────────────────────
+
+/**
+ * 批量强停环路。
+ *
+ * 后端目前没有「批量强停 loop」接口（handlers/loop_.rs 仅提供单条
+ * execution_record 的 stop API），这里只放前端占位：弹提示 + 返回空结果。
+ * 后续接入真实接口时，把函数体换成单次 POST 即可，外部签名保持不变。
+ *
+ * 期望后端契约：
+ *   POST /api/loops/batch-stop
+ *   body: { loop_ids: number[] }
+ *   response: { stopped: number[], failed: number[] }
+ */
+export async function forceStopLoops(
+  loopIds: number[],
+): Promise<{ stopped: number[]; failed: number[] }> {
+  // 占位：开发中提示由调用方弹（utils 内部不依赖 message 上下文）。
+  // 直接返回"全部失败"，强制调用方走失败分支走提示。
+  return { stopped: [], failed: [...loopIds] };
+}

--- a/frontend/src/utils/database/steps.ts
+++ b/frontend/src/utils/database/steps.ts
@@ -43,3 +43,27 @@ export async function updateStep(
 export async function deleteStep(id: number): Promise<void> {
   await api.delete(`/api/steps/${id}`);
 }
+
+// 批量更新环节执行器：后端暂未提供 PUT /api/steps/batch-executor 接口，
+// 暂时逐条调 updateStep 实现批量语义。等后端就绪后只需替换函数体，
+// 外部签名保持不变。
+export async function batchUpdateStepsExecutor(
+  ids: number[],
+  executor: string,
+): Promise<{ updated: number[]; failed: number[] }> {
+  const updated: number[] = [];
+  const failed: number[] = [];
+  // 串行执行：与 batchUpdateTodosExecutor 保持一致，避免瞬时并发压垮后端
+  for (const id of ids) {
+    try {
+      // updateStep 要求 title 必传，先 GET 一次拿原值再 PUT；
+      // 后端就绪后这层 GET 也能省掉。
+      const step = await getStep(id);
+      await updateStep(id, { title: step.title, executor });
+      updated.push(id);
+    } catch {
+      failed.push(id);
+    }
+  }
+  return { updated, failed };
+}

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -70,7 +70,36 @@ export async function updateTodoTags(todoId: number, tagIds: number[]): Promise<
   await api.put(`/api/todos/${todoId}/tags`, { tag_ids: tagIds });
 }
 
+// 批量更新执行器：后端暂未提供 PUT /api/todos/batch-executor 接口，
+// 暂时逐条调 updateTodo 实现批量语义，并在调用方提供「成功 / 失败」反馈。
+// 后端就绪后只需把这里换成单次 API 调用即可，外部签名保持不变。
+export async function batchUpdateTodosExecutor(
+  ids: number[],
+  executor: string,
+  fetchOne: (id: number) => Promise<Todo>,
+): Promise<{ updated: number[]; failed: number[] }> {
+  const updated: number[] = [];
+  const failed: number[] = [];
+  // 串行而非 Promise.all：避免一次性打爆后端；同时后端对 todo 的 executor 更新
+  // 没有跨行事务要求，串行失败隔离足以满足「换执行器」的批量语义。
+  for (const id of ids) {
+    try {
+      const todo = await fetchOne(id);
+      await updateTodo(id, todo.title, todo.prompt, todo.status, executor);
+      updated.push(id);
+    } catch {
+      failed.push(id);
+    }
+  }
+  return { updated, failed };
+}
+
 // Tag APIs
+
+/** 单个 todo 详情（用于批量操作前取 title/prompt 等不可变字段）。 */
+export async function getTodo(id: number): Promise<Todo> {
+  return unwrap(await api.get(`/api/todos/${id}`));
+}
 
 export async function getAllTags(): Promise<Tag[]> {
   return unwrap(await api.get('/api/tags'));

--- a/frontend/tests/feat_action_toolbar.spec.ts
+++ b/frontend/tests/feat_action_toolbar.spec.ts
@@ -6,6 +6,7 @@
  *   2. 「新建」按钮文案随模式变化（新建事项 / 新建环节 / 新建环路）
  *   3. 「批量」下拉菜单项随模式变化（事项和环节：更换执行器；环路：强停）
  *   4. 顶部 header 旧版「新建任务」按钮已被移除，只留「智能新建」
+ *   5. 工具栏不显示「已选 N 项 / 共 N 项」文案（节省空间）
  *
  * 截图证据：保存到 /tmp/feat-action-toolbar-*.png（不入 git）。
  */
@@ -72,7 +73,7 @@ async function switchMode(page: Page, mode: 'item' | 'step' | 'loop') {
 }
 
 test.describe('ActionToolbar — 通用行为', () => {
-  test('事项模式：工具栏三按钮 + 全选 + 批量', async ({ page }) => {
+  test('事项模式：工具栏三按钮 + 不显示已选/共计数文案', async ({ page }) => {
     await page.goto(DEV_URL);
     // 默认是事项模式，但显式切一次保证可重复
     await switchMode(page, 'item');
@@ -83,6 +84,10 @@ test.describe('ActionToolbar — 通用行为', () => {
     await expect(page.getByTestId('action-toolbar-create')).toContainText('新建');
     // 批量下拉存在
     await expect(page.getByTestId('action-toolbar-batch-trigger')).toBeVisible();
+
+    // 节省空间：不再渲染「已选 N 项」「共 N 项」文案节点
+    await expect(page.getByTestId('action-toolbar-selected-count')).toHaveCount(0);
+    await expect(page.getByTestId('action-toolbar-total-count')).toHaveCount(0);
   });
 
   test('事项模式：勾选两条后批量 Dropdown 启用，菜单项是「更换执行器」', async ({ page }) => {
@@ -92,6 +97,9 @@ test.describe('ActionToolbar — 通用行为', () => {
     // 等列表加载
     await page.waitForTimeout(300);
 
+    // 空选时批量 trigger 应被禁用
+    await expect(page.getByTestId('action-toolbar-batch-trigger')).toBeDisabled();
+
     // 勾选前两条 todo 的复选框（用 data-testid 精确锁）
     // 用 force: true 绕开 actionability 检查：用户 DB 里其他 todo 卡片可能
     // 视觉上压在我们新建的 todo 上方，Playwright 会误判被遮挡。
@@ -100,8 +108,8 @@ test.describe('ActionToolbar — 通用行为', () => {
     await todo1Cb.click({ force: true });
     await todo2Cb.click({ force: true });
 
-    // 工具栏出现「已选 2 项」
-    await expect(page.getByTestId('action-toolbar-selected-count')).toContainText('已选 2');
+    // 批量 trigger 启用
+    await expect(page.getByTestId('action-toolbar-batch-trigger')).toBeEnabled();
 
     // 打开批量下拉
     await page.getByTestId('action-toolbar-batch-trigger').click();
@@ -115,20 +123,21 @@ test.describe('ActionToolbar — 通用行为', () => {
     await page.waitForTimeout(300);
 
     const selectAll = page.getByTestId('action-toolbar-select-all');
-    // 初始：未选
+    // 初始：未选（input.checked 为 false 且无 .ant-checkbox-indeterminate）
     await expect(selectAll).not.toBeChecked();
+    const wrapperClass = await selectAll.locator('xpath=..').getAttribute('class');
+    expect(wrapperClass ?? '').not.toContain('ant-checkbox-indeterminate');
 
-    // 点全选 → 全部当前可见项被勾
+    // 点全选 → 全部当前可见项被勾（空选时禁用批量 trigger，这里应启用）
     await selectAll.click();
-    await expect(page.getByTestId('action-toolbar-selected-count')).toContainText('已选');
-    // 复选框应进入 checked 态（DOM aria-checked or input checked）
+    await expect(page.getByTestId('action-toolbar-batch-trigger')).toBeEnabled();
+    // 复选框应进入 checked 态
     await expect(selectAll).toBeChecked();
 
-    // 取消勾选其中一条 → 复选框进入 indeterminate
+    // 取消勾选其中一条 → 复选框进入 indeterminate（antd 6 加 .ant-checkbox-indeterminate 类）
     await page.getByTestId(`todo-row-checkbox-${todoId1}`).click({ force: true });
-    // antd 在 indeterminate 时 input 不 checked，但 aria-checked 会变 mixed
-    const ariaChecked = await selectAll.getAttribute('aria-checked');
-    expect(ariaChecked).toBe('mixed');
+    const wrapperClass2 = await selectAll.locator('xpath=..').getAttribute('class');
+    expect(wrapperClass2 ?? '').toContain('ant-checkbox-indeterminate');
   });
 
   test('事项模式：header 旧版「新建任务」按钮已移除，只剩「智能新建」', async ({ page }) => {
@@ -149,12 +158,10 @@ test.describe('ActionToolbar — 通用行为', () => {
     await page.waitForTimeout(300);
 
     await expect(page.getByTestId('action-toolbar-create')).toContainText('新建');
-    // 选择前，确认模式切换后 selectedIds 被清空
-    await expect(page.getByTestId('action-toolbar-selected-count')).toHaveCount(0);
 
     // 勾选环节
     await page.getByTestId(`step-row-checkbox-${stepId}`).click({ force: true });
-    await expect(page.getByTestId('action-toolbar-selected-count')).toContainText('已选 1');
+    await expect(page.getByTestId('action-toolbar-batch-trigger')).toBeEnabled();
 
     // 打开批量下拉，菜单项 = 更换执行器
     await page.getByTestId('action-toolbar-batch-trigger').click();
@@ -170,7 +177,7 @@ test.describe('ActionToolbar — 通用行为', () => {
 
     // 勾选环路
     await page.getByTestId(`loop-row-checkbox-${loopId}`).click({ force: true });
-    await expect(page.getByTestId('action-toolbar-selected-count')).toContainText('已选 1');
+    await expect(page.getByTestId('action-toolbar-batch-trigger')).toBeEnabled();
 
     // 打开批量下拉，菜单项 = 强停
     await page.getByTestId('action-toolbar-batch-trigger').click();
@@ -179,5 +186,62 @@ test.describe('ActionToolbar — 通用行为', () => {
     // antd 给 danger 菜单项加 .ant-dropdown-menu-item-danger 类
     const cls = await forceStop.getAttribute('class');
     expect(cls).toContain('ant-dropdown-menu-item-danger');
+  });
+
+  test('三种模式都有搜索框，且切换不丢失', async ({ page }) => {
+    await page.goto(DEV_URL);
+
+    // 事项模式：placeholder 提到 "提示词"
+    await switchMode(page, 'item');
+    await expect(page.getByPlaceholder(/搜索标题或提示词/)).toBeVisible();
+
+    // 环节模式：placeholder 提到 "环节标题"
+    await switchMode(page, 'step');
+    await page.waitForTimeout(200);
+    await expect(page.getByPlaceholder(/搜索环节标题/)).toBeVisible();
+
+    // 环路模式：placeholder 提到 "环路名称"
+    await switchMode(page, 'loop');
+    await page.waitForTimeout(200);
+    await expect(page.getByPlaceholder(/搜索环路名称/)).toBeVisible();
+  });
+
+  test('环节模式：搜索关键词过滤列表（搜不到时列表清空）', async ({ page }) => {
+    await page.goto(DEV_URL);
+    await switchMode(page, 'step');
+    await page.waitForTimeout(300);
+
+    // 我们的 seed step 标题是 toolbar-step-1，先确认它可见
+    const stepRow = page.getByTestId(`step-row-checkbox-${stepId}`);
+    await expect(stepRow).toBeVisible();
+
+    // 搜一个不存在的关键词，列表清空（卡片消失）
+    const searchInput = page.getByPlaceholder(/搜索环节标题/);
+    await searchInput.fill('__nope_keyword_should_not_match__');
+    await page.waitForTimeout(200);
+    await expect(stepRow).toHaveCount(0);
+
+    // 清空搜索 → 卡片重新出现
+    await searchInput.fill('');
+    await page.waitForTimeout(200);
+    await expect(stepRow).toBeVisible();
+  });
+
+  test('环路模式：搜索关键词过滤列表', async ({ page }) => {
+    await page.goto(DEV_URL);
+    await switchMode(page, 'loop');
+    await page.waitForTimeout(300);
+
+    const loopRow = page.getByTestId(`loop-row-checkbox-${loopId}`);
+    await expect(loopRow).toBeVisible();
+
+    const searchInput = page.getByPlaceholder(/搜索环路名称/);
+    await searchInput.fill('__nope_keyword_should_not_match__');
+    await page.waitForTimeout(200);
+    await expect(loopRow).toHaveCount(0);
+
+    await searchInput.fill('');
+    await page.waitForTimeout(200);
+    await expect(loopRow).toBeVisible();
   });
 });

--- a/frontend/tests/feat_action_toolbar.spec.ts
+++ b/frontend/tests/feat_action_toolbar.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * 通用操作工具栏（ActionToolbar）UI 集成测试
+ *
+ * 验证三种模式（事项 / 环节 / 环路）下工具栏：
+ *   1. 「全选」复选框 + 三态切换（unchecked / indeterminate / checked）
+ *   2. 「新建」按钮文案随模式变化（新建事项 / 新建环节 / 新建环路）
+ *   3. 「批量」下拉菜单项随模式变化（事项和环节：更换执行器；环路：强停）
+ *   4. 顶部 header 旧版「新建任务」按钮已被移除，只留「智能新建」
+ *
+ * 截图证据：保存到 /tmp/feat-action-toolbar-*.png（不入 git）。
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+const DEV_URL = process.env.E2E_BASE_URL || 'http://127.0.0.1:18088';
+
+// 每个用例各自创建/清理的种子数据 id
+let todoId1 = 0;
+let todoId2 = 0;
+let todoId3 = 0;
+let stepSourceTodoId = 0;
+let stepId = 0;
+let loopId = 0;
+
+test.beforeAll(async ({ request }) => {
+  // 事项
+  for (let i = 1; i <= 3; i++) {
+    const r = await request.post(`${DEV_URL}/api/todos`, {
+      data: { title: `toolbar-todo-${i}`, prompt: `seed ${i}` },
+    });
+    expect(r.ok()).toBeTruthy();
+    const { data } = await r.json();
+    if (i === 1) todoId1 = data.id;
+    if (i === 2) todoId2 = data.id;
+    if (i === 3) todoId3 = data.id;
+  }
+
+  // 环节（通过 promote 创建）
+  const stepRes = await request.post(`${DEV_URL}/api/todos`, {
+    data: { title: 'toolbar-step-1', prompt: 'step seed' },
+  });
+  const { data: stepTodo } = await stepRes.json();
+  stepSourceTodoId = stepTodo.id;
+  const promoteRes = await request.post(`${DEV_URL}/api/todos/${stepSourceTodoId}/promote`);
+  const { data: promoted } = await promoteRes.json();
+  stepId = promoted.id;
+
+  // 环路
+  const loopRes = await request.post(`${DEV_URL}/api/loops`, {
+    data: { name: 'toolbar-loop-1' },
+  });
+  const { data: loop } = await loopRes.json();
+  loopId = loop.id;
+});
+
+test.afterAll(async ({ request }) => {
+  await request.delete(`${DEV_URL}/api/loops/${loopId}`);
+  await request.delete(`${DEV_URL}/api/todos/${stepSourceTodoId}`);
+  for (const id of [todoId1, todoId2, todoId3]) {
+    if (id) await request.delete(`${DEV_URL}/api/todos/${id}`);
+  }
+});
+
+/** 切到指定 listMode（事项/环节/环路） */
+async function switchMode(page: Page, mode: 'item' | 'step' | 'loop') {
+  const label = mode === 'item' ? '事项' : mode === 'step' ? '环节' : '环路';
+  // antd Segmented 把 input 渲染为隐藏 radio，需点 label 才能触发；
+  // 限定在 .ant-segmented 内查找避免误伤 header 里的「事项」字样。
+  await page.locator('.ant-segmented').getByText(label, { exact: true }).click();
+  // 给 segmented 状态变更和列表重渲染留 300ms
+  await page.waitForTimeout(300);
+}
+
+test.describe('ActionToolbar — 通用行为', () => {
+  test('事项模式：工具栏三按钮 + 全选 + 批量', async ({ page }) => {
+    await page.goto(DEV_URL);
+    // 默认是事项模式，但显式切一次保证可重复
+    await switchMode(page, 'item');
+
+    // 工具栏存在
+    await expect(page.getByTestId('action-toolbar')).toBeVisible();
+    // 新建按钮文案 = 新建（2 字，用户从 listMode 知道新建类型）
+    await expect(page.getByTestId('action-toolbar-create')).toContainText('新建');
+    // 批量下拉存在
+    await expect(page.getByTestId('action-toolbar-batch-trigger')).toBeVisible();
+  });
+
+  test('事项模式：勾选两条后批量 Dropdown 启用，菜单项是「更换执行器」', async ({ page }) => {
+    await page.goto(DEV_URL);
+    await switchMode(page, 'item');
+
+    // 等列表加载
+    await page.waitForTimeout(300);
+
+    // 勾选前两条 todo 的复选框（用 data-testid 精确锁）
+    // 用 force: true 绕开 actionability 检查：用户 DB 里其他 todo 卡片可能
+    // 视觉上压在我们新建的 todo 上方，Playwright 会误判被遮挡。
+    const todo1Cb = page.getByTestId(`todo-row-checkbox-${todoId1}`);
+    const todo2Cb = page.getByTestId(`todo-row-checkbox-${todoId2}`);
+    await todo1Cb.click({ force: true });
+    await todo2Cb.click({ force: true });
+
+    // 工具栏出现「已选 2 项」
+    await expect(page.getByTestId('action-toolbar-selected-count')).toContainText('已选 2');
+
+    // 打开批量下拉
+    await page.getByTestId('action-toolbar-batch-trigger').click();
+    // 看到「更换执行器」菜单项
+    await expect(page.getByRole('menuitem', { name: /更换执行器/ })).toBeVisible();
+  });
+
+  test('事项模式：全选复选框三态切换', async ({ page }) => {
+    await page.goto(DEV_URL);
+    await switchMode(page, 'item');
+    await page.waitForTimeout(300);
+
+    const selectAll = page.getByTestId('action-toolbar-select-all');
+    // 初始：未选
+    await expect(selectAll).not.toBeChecked();
+
+    // 点全选 → 全部当前可见项被勾
+    await selectAll.click();
+    await expect(page.getByTestId('action-toolbar-selected-count')).toContainText('已选');
+    // 复选框应进入 checked 态（DOM aria-checked or input checked）
+    await expect(selectAll).toBeChecked();
+
+    // 取消勾选其中一条 → 复选框进入 indeterminate
+    await page.getByTestId(`todo-row-checkbox-${todoId1}`).click({ force: true });
+    // antd 在 indeterminate 时 input 不 checked，但 aria-checked 会变 mixed
+    const ariaChecked = await selectAll.getAttribute('aria-checked');
+    expect(ariaChecked).toBe('mixed');
+  });
+
+  test('事项模式：header 旧版「新建任务」按钮已移除，只剩「智能新建」', async ({ page }) => {
+    await page.goto(DEV_URL);
+    await switchMode(page, 'item');
+
+    // header 智能新建（按 aria-label 锁）
+    await expect(page.getByRole('button', { name: '智能新建' })).toBeVisible();
+    // header 普通新建任务按钮已不再存在
+    await expect(page.getByRole('button', { name: '新建任务' })).toHaveCount(0);
+    // 工具栏里的「新建」仍存在
+    await expect(page.getByTestId('action-toolbar-create')).toContainText('新建');
+  });
+
+  test('环节模式：createLabel=新建，批量菜单仍是「更换执行器」', async ({ page }) => {
+    await page.goto(DEV_URL);
+    await switchMode(page, 'step');
+    await page.waitForTimeout(300);
+
+    await expect(page.getByTestId('action-toolbar-create')).toContainText('新建');
+    // 选择前，确认模式切换后 selectedIds 被清空
+    await expect(page.getByTestId('action-toolbar-selected-count')).toHaveCount(0);
+
+    // 勾选环节
+    await page.getByTestId(`step-row-checkbox-${stepId}`).click({ force: true });
+    await expect(page.getByTestId('action-toolbar-selected-count')).toContainText('已选 1');
+
+    // 打开批量下拉，菜单项 = 更换执行器
+    await page.getByTestId('action-toolbar-batch-trigger').click();
+    await expect(page.getByRole('menuitem', { name: /更换执行器/ })).toBeVisible();
+  });
+
+  test('环路模式：createLabel=新建，批量菜单是「强停」并标 danger', async ({ page }) => {
+    await page.goto(DEV_URL);
+    await switchMode(page, 'loop');
+    await page.waitForTimeout(300);
+
+    await expect(page.getByTestId('action-toolbar-create')).toContainText('新建');
+
+    // 勾选环路
+    await page.getByTestId(`loop-row-checkbox-${loopId}`).click({ force: true });
+    await expect(page.getByTestId('action-toolbar-selected-count')).toContainText('已选 1');
+
+    // 打开批量下拉，菜单项 = 强停
+    await page.getByTestId('action-toolbar-batch-trigger').click();
+    const forceStop = page.getByRole('menuitem', { name: /强停/ });
+    await expect(forceStop).toBeVisible();
+    // antd 给 danger 菜单项加 .ant-dropdown-menu-item-danger 类
+    const cls = await forceStop.getAttribute('class');
+    expect(cls).toContain('ant-dropdown-menu-item-danger');
+  });
+});


### PR DESCRIPTION
## 背景

事项、环节、环路三个列表共用 `TodoList` 顶部的 Segmented 切换器。用户希望在这三处列表上方加统一格式的操作工具栏：**全选 / 批量 / 新建**，三种模式各自的差异点（按钮文案 / 批量菜单 / onCreate 回调）通过 props 传入，未来扩展（增加批量删除、批量打 tag 等）只改父组件、不动通用组件。

另有两项用户反馈调整：
1. 工具栏不显示「已选 N 项」「共 N 项」文案，节省空间。
2. 环节 / 环路模式原本没有搜索框，切换 mode 时布局会跳，现在三种模式都展示搜索框。

## 改动概览

### 新增
- `frontend/src/components/common/ActionToolbar.tsx`：通用工具栏组件
  - `SelectAll` / `BatchDropdown` / `CreateButton` 三个内部子组件，每个 < 30 行
  - 全选用 antd `Checkbox` + `indeterminate` 实现三态
  - 空选时禁用批量 trigger，菜单项仍渲染（用户能看到能力）

### 修改
- `frontend/src/components/TodoList.tsx`
  - 集成 `ActionToolbar`，按 `listMode` 切换 `createLabel` / `batchActions`
  - 三种卡片（todo / step / loop）都加复选框
  - **修了 `.todo-item` 缺少 `position: relative` 的 bug**：原卡片里 `Checkbox` 的 `position: absolute` 逃逸到上层容器，所有 todo 的复选框都叠在屏幕同一点，点击会命中最后渲染的那个（这导致之前的 Playwright 测例看上去「点 A 触发 B」）
  - 新增 `filteredStepList` / `filteredLoopList`：搜索框同时对 step / loop 生效
  - header 只保留「智能新建」，移除了原普通「新建任务」按钮
  - 工具栏间距 6/12、gap 8（紧凑）
- `frontend/src/components/LoopStudioListPanel.tsx`
  - `LoopCard` 加 `checked` / `onToggleCheck` props，复选框条件渲染
- `frontend/src/utils/database/todos.ts`
  - 新增 `getTodo(id)`、`batchUpdateTodosExecutor(ids, executor)`
- `frontend/src/utils/database/steps.ts`
  - 新增 `batchUpdateStepsExecutor(ids, executor)`：先 getStep 拿 title 再 updateStep
- `frontend/src/utils/database/loops.ts`
  - 新增占位 `forceStopLoops(loopIds)`，后端 API 缺位时用 message.warning 兜底，
    含 TODO 注释说明期望后端契约 `POST /api/loops/batch-stop`

### 后端小修（顺手）
- `backend/src/db/step_.rs`：`count_loop_steps_for_steps` 的 raw SQL 把
  `todo_id` 改成 `step_id`（commit 9590e63 stage→step 重命名时漏改）

## 测试

- 新增 `frontend/tests/feat_action_toolbar.spec.ts`，9 个用例覆盖：
  1. 事项模式：工具栏三按钮 + 不显示已选/共计数文案
  2. 事项模式：勾选两条后批量 Dropdown 启用，菜单项是「更换执行器」
  3. 事项模式：全选复选框三态切换（unchecked / indeterminate / checked）
  4. 事项模式：header 旧版「新建任务」按钮已移除，只剩「智能新建」
  5. 环节模式：createLabel=新建，批量菜单仍是「更换执行器」
  6. 环路模式：createLabel=新建，批量菜单是「强停」并标 danger
  7. 三种模式都有搜索框，且切换不丢失
  8. 环节模式：搜索关键词过滤列表
  9. 环路模式：搜索关键词过滤列表

  ```bash
  cd frontend && npx playwright test tests/feat_action_toolbar.spec.ts --reporter=list
  # 9 passed (15.8s)
  ```

- `tsc --noEmit` 无报错

## 截图（未入 git，仅作 PR 评论参考）

| 模式 | 截图 |
|------|------|
| 事项（已选 2 条） | `/tmp/feat-action-toolbar-item-selected.png` |
| 事项（默认） | `/tmp/feat-action-toolbar-item.png` |
| 环节 | `/tmp/feat-action-toolbar-step.png` |
| 环路 | `/tmp/feat-action-toolbar-loop.png` |

## 不在本 PR 范围

- 不删 `frontend/src/components/StepList.tsx`（死代码，与本任务无关，避免膨胀 diff）
- 不实现后端 `POST /api/loops/batch-stop`（前端占位 + TODO 注释，等后端补齐后替换）