### PR TITLE
feat: 新增事项和环节的批量更换执行器专用接口

### DIFF
--- a/backend/src/db/step_.rs
+++ b/backend/src/db/step_.rs
@@ -188,4 +188,33 @@ impl Database {
         steps::Entity::delete_by_id(id).exec(&self.conn).await?;
         Ok(())
     }
+
+    /// 批量更新环节执行器（单条 SQL，原子语义）。
+    /// 只更新 executor 列和 updated_at，其他字段保持不变。
+    pub async fn batch_update_steps_executor(
+        &self,
+        ids: &[i64],
+        executor: &str,
+    ) -> Result<u64, sea_orm::DbErr> {
+        use sea_orm::Statement;
+        if ids.is_empty() {
+            return Ok(0);
+        }
+        let now = crate::models::utc_timestamp();
+        // 构建 IN 占位符：?1, ?2, ...
+        let placeholders: Vec<String> = (1..=ids.len()).map(|i| format!("?{}", i)).collect();
+        let in_clause = placeholders.join(",");
+        // executor 占位符在 ids 之后：?{ids.len()+1}，updated_at 占位符最后
+        let executor_idx = ids.len() + 1;
+        let now_idx = ids.len() + 2;
+        let sql = format!(
+            "UPDATE steps SET executor = ?{executor_idx}, updated_at = ?{now_idx} WHERE id IN ({in_clause})"
+        );
+        let mut vals: Vec<sea_orm::Value> = ids.iter().map(|id| (*id).into()).collect();
+        vals.push(executor.to_string().into());
+        vals.push(now.into());
+        let stmt = Statement::from_sql_and_values(sea_orm::DbBackend::Sqlite, sql, vals);
+        let rows_affected = self.conn.execute(stmt).await?.rows_affected();
+        Ok(rows_affected)
+    }
 }

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -213,6 +213,31 @@ impl Database {
         self.exec_update(am).await
     }
 
+    /// 批量更新事项执行器（单条 SQL，原子语义）。
+    pub async fn batch_update_todos_executor(
+        &self,
+        ids: &[i64],
+        executor: &str,
+    ) -> Result<u64, sea_orm::DbErr> {
+        if ids.is_empty() {
+            return Ok(0);
+        }
+        let now = crate::models::utc_timestamp();
+        let placeholders: Vec<String> = (1..=ids.len()).map(|i| format!("?{}", i)).collect();
+        let in_clause = placeholders.join(",");
+        let executor_idx = ids.len() + 1;
+        let now_idx = ids.len() + 2;
+        let sql = format!(
+            "UPDATE todos SET executor = ?{executor_idx}, updated_at = ?{now_idx} WHERE id IN ({in_clause})"
+        );
+        let mut vals: Vec<sea_orm::Value> = ids.iter().map(|id| (*id).into()).collect();
+        vals.push(executor.to_string().into());
+        vals.push(now.into());
+        let stmt = sea_orm::Statement::from_sql_and_values(sea_orm::DbBackend::Sqlite, sql, vals);
+        let rows_affected = self.conn.execute(stmt).await?.rows_affected();
+        Ok(rows_affected)
+    }
+
     /// Replace the inline hook list for a todo. The list is stored as a JSON
     /// array in the `hooks` column.
     pub async fn update_todo_hooks(

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1240,6 +1240,7 @@ fn todo_routes() -> Router<AppState> {
         .route("/api/todos/{id}/summary", get(execution::get_execution_summary))
         .route("/api/todos/{id}/scheduler", put(scheduler::update_scheduler))
         .route("/api/todos/recent-completed", get(todo::get_recent_completed_todos))
+        .route("/api/todos/batch-executor", put(todo::batch_update_todos_executor))
         // 环节相关：promote 复制到 steps 表,原 todo 保留
         .route("/api/todos/{id}/promote", post(todo::promote_todo_to_step))
         .route("/api/todos/{id}", get(todo::get_todo).put(todo::update_todo).delete(todo::delete_todo))
@@ -1253,6 +1254,7 @@ fn step_routes() -> Router<AppState> {
     Router::new()
         .route("/api/steps", get(step_::list_steps))
         .route("/api/steps/candidates", get(step_::list_step_candidates))
+        .route("/api/steps/batch-executor", put(step_::batch_update_steps_executor))
         .route("/api/steps/{id}", get(step_::get_step).put(step_::update_step).delete(step_::delete_step))
 }
 

--- a/backend/src/handlers/step_.rs
+++ b/backend/src/handlers/step_.rs
@@ -5,7 +5,7 @@
 use axum::extract::{Path, State};
 
 use crate::handlers::{ApiJson, AppError, AppState};
-use crate::models::{ApiResponse, StepDto, UpdateStepRequest};
+use crate::models::{ApiResponse, BatchUpdateStepExecutorRequest, BatchUpdateStepResult, StepDto, UpdateStepRequest};
 
 // ====== 环节管理（kind=step）======
 //
@@ -52,23 +52,31 @@ pub async fn get_step(
     Ok(ApiResponse::ok(StepDto::from(s).with_usage(used_by_loop_step_count)))
 }
 
-/// PUT /api/steps/:id — 更新环节基本信息
+/// PUT /api/steps/:id — 更新环节基本信息（部分更新，只传需要改的字段即可）
 pub async fn update_step(
     State(state): State<AppState>,
     Path(id): Path<i64>,
     ApiJson(req): ApiJson<UpdateStepRequest>,
 ) -> Result<ApiResponse<StepDto>, AppError> {
-    if req.title.trim().is_empty() {
+    // 校验环节存在，并取出当前值用于回填未传字段
+    let existing = state
+        .db
+        .get_step(id)
+        .await?
+        .ok_or(AppError::NotFound)?;
+
+    let title = req.title.unwrap_or_else(|| existing.title.clone());
+    if title.trim().is_empty() {
         return Err(AppError::BadRequest("title 不能为空".to_string()));
     }
-    // 校验环节存在
-    state.db.get_step(id).await?.ok_or(AppError::NotFound)?;
+    let prompt = req.prompt.unwrap_or_else(|| existing.prompt.clone());
+
     state
         .db
         .update_step(
             id,
-            req.title.trim(),
-            &req.prompt,
+            title.trim(),
+            &prompt,
             req.executor.as_deref(),
             req.acceptance_criteria.as_deref(),
             req.color.as_deref(),
@@ -89,4 +97,26 @@ pub async fn delete_step(
     // 被引用时后端返回外键冲突错误，前端会显示相应提示。
     state.db.delete_step(id).await?;
     Ok(ApiResponse::ok(()))
+}
+
+/// PUT /api/steps/batch-executor — 批量更新环节执行器
+pub async fn batch_update_steps_executor(
+    State(state): State<AppState>,
+    ApiJson(req): ApiJson<BatchUpdateStepExecutorRequest>,
+) -> Result<ApiResponse<BatchUpdateStepResult>, AppError> {
+    if req.ids.is_empty() {
+        return Err(AppError::BadRequest("ids 不能为空".to_string()));
+    }
+    if req.executor.trim().is_empty() {
+        return Err(AppError::BadRequest("executor 不能为空".to_string()));
+    }
+
+    let rows_affected = state
+        .db
+        .batch_update_steps_executor(&req.ids, req.executor.trim())
+        .await?;
+    Ok(ApiResponse::ok(BatchUpdateStepResult {
+        updated_count: rows_affected as i64,
+        total: req.ids.len() as i64,
+    }))
 }

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -7,8 +7,8 @@ use crate::db::TodoUpdate;
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::hooks::models::HookContext;
 use crate::models::{
-    utc_timestamp, ApiResponse, CreateTodoRequest, RecentCompletedTodo, StepDto, Todo,
-    UpdateTagsRequest, UpdateTodoRequest,
+    utc_timestamp, ApiResponse, BatchUpdateTodoExecutorRequest, BatchUpdateTodoResult,
+    CreateTodoRequest, RecentCompletedTodo, StepDto, Todo, UpdateTagsRequest, UpdateTodoRequest,
 };
 
 /// Validate cron expression, return helpful error for invalid ones
@@ -384,4 +384,25 @@ pub async fn promote_todo_to_step(
         )
         .await?;
     Ok(ApiResponse::ok(StepDto::from(step)))
+}
+
+/// PUT /api/todos/batch-executor — 批量更新事项执行器
+pub async fn batch_update_todos_executor(
+    State(state): State<AppState>,
+    ApiJson(req): ApiJson<BatchUpdateTodoExecutorRequest>,
+) -> Result<ApiResponse<BatchUpdateTodoResult>, AppError> {
+    if req.ids.is_empty() {
+        return Err(AppError::BadRequest("ids 不能为空".to_string()));
+    }
+    if req.executor.trim().is_empty() {
+        return Err(AppError::BadRequest("executor 不能为空".to_string()));
+    }
+    let rows_affected = state
+        .db
+        .batch_update_todos_executor(&req.ids, req.executor.trim())
+        .await?;
+    Ok(ApiResponse::ok(BatchUpdateTodoResult {
+        updated_count: rows_affected as i64,
+        total: req.ids.len() as i64,
+    }))
 }

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -444,6 +444,20 @@ pub struct TodoIdQuery {
     pub status: Option<String>,
 }
 
+/// 批量更新事项执行器请求体。
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchUpdateTodoExecutorRequest {
+    pub ids: Vec<i64>,
+    pub executor: String,
+}
+
+/// 批量更新事项执行器返回结果。
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchUpdateTodoResult {
+    pub updated_count: i64,
+    pub total: i64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunningBoardResponse {
     pub records: Vec<ExecutionRecord>,

--- a/backend/src/models/step_.rs
+++ b/backend/src/models/step_.rs
@@ -43,11 +43,28 @@ impl StepDto {
 }
 
 /// 更新环节请求体。
+///
+/// 所有字段均可选，实现"部分更新"语义 —— 只传需要变更的字段，
+/// 未传的字段从数据库保持原值。批量更换执行器时只需传 `executor`。
 #[derive(Debug, Clone, Deserialize)]
 pub struct UpdateStepRequest {
-    pub title: String,
-    pub prompt: String,
+    pub title: Option<String>,
+    pub prompt: Option<String>,
     pub executor: Option<String>,
     pub acceptance_criteria: Option<String>,
     pub color: Option<String>,
+}
+
+/// 批量更新环节执行器请求体。
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchUpdateStepExecutorRequest {
+    pub ids: Vec<i64>,
+    pub executor: String,
+}
+
+/// 批量更新环节执行器返回结果。
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchUpdateStepResult {
+    pub updated_count: i64,
+    pub total: i64,
 }

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -309,10 +309,8 @@ export function TodoList(props: TodoListProps) {
     setExecutorModalOpen(false);
     setPendingExecutorChangeIds([]);
     try {
-      // 事项模式：需要先 fetchOne 获取 title/prompt 再调 updateTodo；
-      // 这里直接传 fetchOne 闭包让 db 层内部处理
       const result = listMode === 'item'
-        ? await db.batchUpdateTodosExecutor(ids, executor, db.getTodo)
+        ? await db.batchUpdateTodosExecutor(ids, executor)
         : await dbSteps.batchUpdateStepsExecutor(ids, executor);
       if (result.failed.length === 0) {
         message.success(`已为 ${result.updated.length} 项更换执行器为「${executor}」`);
@@ -321,9 +319,9 @@ export function TodoList(props: TodoListProps) {
       }
       // 触发列表刷新：item 通过 stepUpdateCount 机制，step / loop 通过各自的 reload
       if (listMode === 'item') {
-        // item 模式依赖全局 todos 状态，由 useApp 拉取；增量更新单条避免全量重拉
-        for (const id of result.updated) {
-          const todo = await db.getTodo(id);
+        // item 模式依赖全局 todos 状态，由 useApp 拉取；全量表查一次避免 N 次单条 GET
+        const allItems = await db.getAllTodos('item');
+        for (const todo of allItems) {
           dispatch({ type: 'UPDATE_TODO', payload: todo });
         }
       } else if (listMode === 'step') {

--- a/frontend/src/utils/database/steps.ts
+++ b/frontend/src/utils/database/steps.ts
@@ -31,10 +31,10 @@ export async function promoteTodoToStep(id: number): Promise<StepSummary> {
   return unwrap(await api.post(`/api/todos/${id}/promote`, {}));
 }
 
-/** 更新环节基本信息。 */
+/** 更新环节基本信息（部分更新：只传需要变更的字段即可）。 */
 export async function updateStep(
   id: number,
-  data: { title: string; prompt?: string; executor?: string | null; acceptance_criteria?: string | null; color?: string },
+  data: { title?: string; prompt?: string; executor?: string | null; acceptance_criteria?: string | null; color?: string },
 ): Promise<StepSummary> {
   return unwrap(await api.put(`/api/steps/${id}`, data));
 }
@@ -44,26 +44,16 @@ export async function deleteStep(id: number): Promise<void> {
   await api.delete(`/api/steps/${id}`);
 }
 
-// 批量更新环节执行器：后端暂未提供 PUT /api/steps/batch-executor 接口，
-// 暂时逐条调 updateStep 实现批量语义。等后端就绪后只需替换函数体，
-// 外部签名保持不变。
+/** 批量更新环节执行器。后端提供专用接口，单次 SQL 完成。 */
 export async function batchUpdateStepsExecutor(
   ids: number[],
   executor: string,
 ): Promise<{ updated: number[]; failed: number[] }> {
-  const updated: number[] = [];
-  const failed: number[] = [];
-  // 串行执行：与 batchUpdateTodosExecutor 保持一致，避免瞬时并发压垮后端
-  for (const id of ids) {
-    try {
-      // updateStep 要求 title 必传，先 GET 一次拿原值再 PUT；
-      // 后端就绪后这层 GET 也能省掉。
-      const step = await getStep(id);
-      await updateStep(id, { title: step.title, executor });
-      updated.push(id);
-    } catch {
-      failed.push(id);
-    }
+  try {
+    const result = await unwrap(await api.put('/api/steps/batch-executor', { ids, executor }));
+    const body = result as { updated_count: number; total: number };
+    return { updated: ids.slice(0, body.updated_count), failed: ids.slice(body.updated_count) };
+  } catch {
+    return { updated: [], failed: ids };
   }
-  return { updated, failed };
 }

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -70,28 +70,18 @@ export async function updateTodoTags(todoId: number, tagIds: number[]): Promise<
   await api.put(`/api/todos/${todoId}/tags`, { tag_ids: tagIds });
 }
 
-// 批量更新执行器：后端暂未提供 PUT /api/todos/batch-executor 接口，
-// 暂时逐条调 updateTodo 实现批量语义，并在调用方提供「成功 / 失败」反馈。
-// 后端就绪后只需把这里换成单次 API 调用即可，外部签名保持不变。
+/** 批量更新事项执行器。后端提供专用接口，单次 SQL 完成。 */
 export async function batchUpdateTodosExecutor(
   ids: number[],
   executor: string,
-  fetchOne: (id: number) => Promise<Todo>,
 ): Promise<{ updated: number[]; failed: number[] }> {
-  const updated: number[] = [];
-  const failed: number[] = [];
-  // 串行而非 Promise.all：避免一次性打爆后端；同时后端对 todo 的 executor 更新
-  // 没有跨行事务要求，串行失败隔离足以满足「换执行器」的批量语义。
-  for (const id of ids) {
-    try {
-      const todo = await fetchOne(id);
-      await updateTodo(id, todo.title, todo.prompt, todo.status, executor);
-      updated.push(id);
-    } catch {
-      failed.push(id);
-    }
+  try {
+    const result = await unwrap(await api.put('/api/todos/batch-executor', { ids, executor }));
+    const body = result as { updated_count: number; total: number };
+    return { updated: ids.slice(0, body.updated_count), failed: ids.slice(body.updated_count) };
+  } catch {
+    return { updated: [], failed: ids };
   }
-  return { updated, failed };
 }
 
 // Tag APIs


### PR DESCRIPTION

## 变更内容

新增事项和环节的批量更换执行器专用接口，替代原来的逐条 GET+PUT 循环。

### 后端
- 新增 `PUT /api/steps/batch-executor` 和 `PUT /api/todos/batch-executor`，单条 SQL 原子更新
- DB 层新增 `batch_update_steps_executor` / `batch_update_todos_executor`
- Model 层新增请求/返回结构体
- 修复步骤路由中 `batch-executor` 在 `{id}` 之后注册的冲突问题

### 前端
- `batchUpdateStepsExecutor` / `batchUpdateTodosExecutor` 改为调批量接口
- `updateStep` 签名 `title` 改为可选，支持部分更新
- `TodoList` 事项刷新从 N 次单条 GET 改为 1 次全量 GET
- 修复批量响应 unwrap 取错字段的问题
