### PR TITLE
feat(backend+frontend): 实现 Loop Token 数量限制，capped 状态区分步数超限和 Token 超限

### DIFF
--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -454,6 +454,8 @@ pub fn validate_loop_status(s: &str) -> Result<(), String> {
 }
 
 /// 把 loop_execution.status 归类为前端展示用的颜色。
+/// 注意区分「步数超限」和「Token 超限」两种 capped 场景，
+/// 分别用不同的颜色让用户一目了然。
 pub fn loop_execution_color(status: &str) -> &'static str {
     match status {
         "running" => "#1890ff",
@@ -461,6 +463,8 @@ pub fn loop_execution_color(status: &str) -> &'static str {
         "failed" => "#f5222d",
         "partial" => "#fa8c16",
         "cancelled" => "#8c8c8c",
+        "capped_step" => "#d4b106",   // 步数超限：黄色
+        "capped_token" => "#722ed1",  // Token 超限：紫色
         _ => "#bfbfbf",
     }
 }

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -27,10 +27,18 @@ use crate::service_context::ServiceContext;
 use crate::db::entity::{loop_steps, steps};
 
 /// 全局限制配置，从 loop.limits_config JSON 解析。
+///
+/// 支持两种限制方式：
+/// - max_step_executions：最大执行步数（已有）
+/// - max_total_tokens：最大消耗 Token 数（新增，input_tokens + output_tokens 之和）
 #[derive(Debug, Default, Clone, serde::Deserialize)]
 struct LimitsConfig {
     #[serde(default)]
     max_step_executions: Option<i32>,
+    /// 最大消耗 Token 数（input_tokens + output_tokens），超过后 Loop 被 capped 终止。
+    /// None 表示不限制。
+    #[serde(default)]
+    max_total_tokens: Option<i64>,
 }
 
 /// LoopRunner 依赖：与现有 HookService 共享一个 spawn-friendly 结构。
@@ -164,10 +172,12 @@ impl LoopRunner {
 
         let limits: LimitsConfig = serde_json::from_str(&loop_.limits_config).unwrap_or_default();
         let max_executions = limits.max_step_executions.unwrap_or(i32::MAX);
+        let max_total_tokens = limits.max_total_tokens.unwrap_or(i64::MAX);
 
         let mut current_idx: Option<usize> = Some(0);
         let mut sequence_counter = 0i32;
         let mut total_executed = 0i32;
+        let mut total_tokens_used: i64 = 0;
         let mut completed: i32 = 0;
         let mut failed: i32 = 0;
         let mut consecutive_retries: HashMap<i64, i32> = HashMap::new();
@@ -190,12 +200,24 @@ impl LoopRunner {
             }
             let step = &all_steps[idx];
 
-            // 4a. 全局限制检查
+            // 4a. 全局限制检查：步数限制 + Token 限制
             if total_executed >= max_executions {
                 info!("loop #{} capped: total_executed={} >= max={}", loop_id, total_executed, max_executions);
                 self.ctx
                     .db
-                    .finish_loop_execution(loop_execution_id, "capped", completed, failed)
+                    .finish_loop_execution(loop_execution_id, "capped_step", completed, failed)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                return Ok(());
+            }
+            if total_tokens_used >= max_total_tokens {
+                info!(
+                    "loop #{} capped by token: total_tokens_used={} >= max={}",
+                    loop_id, total_tokens_used, max_total_tokens
+                );
+                self.ctx
+                    .db
+                    .finish_loop_execution(loop_execution_id, "capped_token", completed, failed)
                     .await
                     .map_err(|e| e.to_string())?;
                 return Ok(());
@@ -345,10 +367,17 @@ impl LoopRunner {
             }
 
             // 记录上一环节的输出（供下一环节的 {last_output}/{message} 模板变量使用）
+            // 同时从 execution_record.usage 中提取 token 用量，累加到 total_tokens_used，
+            // 用于下一轮循环 4a 的 token 上限检查。
             let exec_record = self.ctx.db.get_execution_record(record_id).await.ok().flatten();
             last_output = exec_record.as_ref().and_then(|r| r.result.clone());
             last_conclusion = Some(conclusion.clone());
             last_step_name = Some(step.name.clone());
+            // 从 usage JSON 中取出 input_tokens + output_tokens 作为本次消耗的 token 数
+            if let Some(ref usage) = exec_record.and_then(|r| r.usage) {
+                let step_tokens = (usage.input_tokens + usage.output_tokens) as i64;
+                total_tokens_used += step_tokens;
+            }
 
             // 4l. 确定下一步
             current_idx = if gate_passed {
@@ -961,5 +990,33 @@ mod tests {
     fn limits_config_parses_max_step_executions() {
         let config: LimitsConfig = serde_json::from_str(r#"{"max_step_executions": 20}"#).unwrap();
         assert_eq!(config.max_step_executions, Some(20));
+    }
+
+    #[test]
+    fn limits_config_max_total_tokens_defaults_to_none() {
+        let config: LimitsConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(config.max_total_tokens, None);
+    }
+
+    #[test]
+    fn limits_config_parses_max_total_tokens() {
+        let config: LimitsConfig = serde_json::from_str(r#"{"max_total_tokens": 100000}"#).unwrap();
+        assert_eq!(config.max_total_tokens, Some(100000));
+    }
+
+    #[test]
+    fn limits_config_parses_both_limits() {
+        let config: LimitsConfig =
+            serde_json::from_str(r#"{"max_step_executions": 10, "max_total_tokens": 50000}"#).unwrap();
+        assert_eq!(config.max_step_executions, Some(10));
+        assert_eq!(config.max_total_tokens, Some(50000));
+    }
+
+    #[test]
+    fn limits_config_parses_partial_limits() {
+        // 只设 max_total_tokens，不设 max_step_executions
+        let config: LimitsConfig = serde_json::from_str(r#"{"max_total_tokens": 99999}"#).unwrap();
+        assert_eq!(config.max_step_executions, None);
+        assert_eq!(config.max_total_tokens, Some(99999));
     }
 }

--- a/frontend/src/components/LoopStudioExecutionsPanel.tsx
+++ b/frontend/src/components/LoopStudioExecutionsPanel.tsx
@@ -32,6 +32,7 @@ interface Props {
 const DEFAULT_PAGE_LIMIT = 5;
 
 // 状态 → 颜色 + 图标, 与 LoopListPanel.executionIcon 保持一致
+// 兼容旧记录：旧版只支持步数限制，status = "capped" 视为步数超限。
 function execStatusView(status: string): { color: string; icon: React.ReactNode; label: string } {
   switch (status) {
     case 'success': return { color: 'green', icon: <CheckCircleOutlined />, label: '成功' };
@@ -39,6 +40,9 @@ function execStatusView(status: string): { color: string; icon: React.ReactNode;
     case 'partial': return { color: 'orange', icon: <CloseCircleOutlined />, label: '部分' };
     case 'running': return { color: 'blue', icon: <LoadingOutlined />, label: '运行中' };
     case 'cancelled': return { color: 'default', icon: <MinusCircleOutlined />, label: '已取消' };
+    case 'capped':
+    case 'capped_step': return { color: 'gold', icon: <MinusCircleOutlined />, label: '步数超限' };
+    case 'capped_token': return { color: 'purple', icon: <MinusCircleOutlined />, label: 'Token 超限' };
     default: return { color: 'default', icon: <MinusCircleOutlined />, label: status };
   }
 }

--- a/frontend/src/components/LoopStudioListPanel.tsx
+++ b/frontend/src/components/LoopStudioListPanel.tsx
@@ -60,11 +60,14 @@ function progressBarColor(status: string): string {
 }
 
 // 最近执行状态 → 图标, 使用主题变量, 暗色下也保持对比度
+// 兼容旧记录：旧版只支持步数限制，status = "capped" 视为步数超限。
 function executionIcon(status: string) {
   if (status === 'success') return <CheckCircleOutlined style={{ color: 'var(--color-success, #22c55e)' }} />;
   if (status === 'failed') return <CloseCircleOutlined style={{ color: 'var(--color-error, #ef4444)' }} />;
   if (status === 'partial') return <CloseCircleOutlined style={{ color: 'var(--color-warning, #f59e0b)' }} />;
   if (status === 'running') return <LoadingOutlined style={{ color: 'var(--color-info, #3b82f6)' }} />;
+  if (status === 'capped' || status === 'capped_step') return <MinusCircleOutlined style={{ color: '#d4b106' }} />;
+  if (status === 'capped_token') return <MinusCircleOutlined style={{ color: '#722ed1' }} />;
   return <MinusCircleOutlined style={{ color: 'var(--color-text-tertiary, #94a3b8)' }} />;
 }
 

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -26,7 +26,7 @@ export type LoopUnratedPolicy = 'skip' | 'continue';
 export type LoopOnSuccessPolicy = 'next' | 'goto' | 'end';
 export type LoopOnRatingFailPolicy = 'break' | 'skip' | 'goto' | 'end';
 
-export type LoopExecutionStatus = 'running' | 'success' | 'partial' | 'failed' | 'cancelled' | 'capped';
+export type LoopExecutionStatus = 'running' | 'success' | 'partial' | 'failed' | 'cancelled' | 'capped_step' | 'capped_token';
 
 export interface LoopDto {
   id: number;


### PR DESCRIPTION
## 改动内容

### Loop Token 数量限制（后端）
- `LimitsConfig` 中新增 `max_total_tokens: Option<i64>` 字段
- Loop 执行过程中实时累加各环节消耗的 token（`input_tokens + output_tokens`）
- 主循环中增加 token 上限检查，超过后以 `capped_token` 状态终止

### capped 状态中文翻译（前端）
- `capped_step` → **步数超限** 🟡
- `capped_token` → **Token 超限** 🟣
- 兼容旧记录：`capped` 视为步数超限

### 改动文件
| 文件 | 改动 |
|---|---|
| `backend/src/services/loop_runner.rs` | LimitsConfig 新增 max_total_tokens；主循环 token cap 检查；累加策略 |
| `backend/src/models/loop_.rs` | loop_execution_color 新增两种 capped 颜色 |
| `frontend/src/types/loop.ts` | LoopExecutionStatus 拆分为 capped_step / capped_token |
| `frontend/src/components/LoopStudioExecutionsPanel.tsx` | execStatusView 新增中文标签 |
| `frontend/src/components/LoopStudioListPanel.tsx` | executionIcon 新增两种 capped 图标 |