### PR TITLE
fix(frontend): 去掉最大 Token 数后面的（预留）标签

### DIFF
--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -267,7 +267,7 @@ export function LoopDetailPanel({
               } catch { return <EmptyValue />; }
             })()
           } />
-          <DetailField label="最大 Token 数（预留）" value={
+          <DetailField label="最大 Token 数" value={
             (() => {
               try {
                 const lc = JSON.parse(detail.limits_config || '{}');


### PR DESCRIPTION
Token 限制功能已实现，无需再标注「预留」