### PR TITLE
fix(frontend): 编辑表单「最大 Token 数」也去掉（预留）标签

### DIFF
--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -483,7 +483,7 @@ export function LoopDetailPanel({
               <Form.Item label="最大执行步数" name={['max_step_executions']} tooltip="超出后自动终止 Loop（留空=不限制）">
                 <InputNumber min={1} max={9999} placeholder="不限" style={{ width: '100%' }} />
               </Form.Item>
-              <Form.Item label="最大 Token 数（预留）" name={['max_total_tokens']} tooltip="超出后自动终止（留空=不限制）">
+              <Form.Item label="最大 Token 数" name={['max_total_tokens']} tooltip="超出后自动终止（留空=不限制）">
                 <InputNumber min={1} max={9999999999} placeholder="不限" style={{ width: '100%' }} step={1000000} />
               </Form.Item>
             </div>


### PR DESCRIPTION
## Summary

PR #715 (`f48bbc3`) 只改了详情面板的 label,编辑表单 `Form.Item` 的 label 漏改,与显示侧文案不一致。

## 改动

`frontend/src/components/LoopStudioDetailPanel.tsx:486`

```diff
- <Form.Item label="最大 Token 数（预留）" name={['max_total_tokens']} tooltip="超出后自动终止（留空=不限制）">
+ <Form.Item label="最大 Token 数" name={['max_total_tokens']} tooltip="超出后自动终止（留空=不限制）">
```

两处 label 现在统一为「最大 Token 数」。

## 为什么改

PR #715 的提交者没有 grep 整个仓库搜「预留」字样,只改了当时看到的那一行。表单 tooltip 已经明确说明「超出后自动终止(留空=不限制)」,功能不是预留状态,「预留」二字反而误导用户。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>