### PR TITLE
fix(backend): 评审实例 todo 按 review_template 全局复用

### DIFF
--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -53,6 +53,7 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V14LoopsReviewTemplateId),
         Box::new(V15ReviewTemplates),
         Box::new(V16LoopStepExecutionSnapshotColumns),
+        Box::new(V17ConsolidateReviewInstanceTodos),
     ]
 }
 
@@ -2748,5 +2749,250 @@ mod v16_loop_step_execution_snapshot_columns_tests {
         assert!(table_has_column(&db, "loop_step_executions", "min_rating").await);
         assert!(table_has_column(&db, "loop_step_executions", "unrated_policy").await);
         assert!(table_has_column(&db, "loop_step_executions", "rating").await);
+    }
+}
+
+// ====== V17: 评审实例 todo 收敛 ======
+//
+// 历史背景:评审实例 todo (todo_type=2) 历史上每次评审执行都新建一条 todo,
+// 同 review_template 的评审会留下 N 条「[评审] X」重复 todo 把 todos 表刷屏。
+// 本次改动 (commit 跟随 fix/reuse-review-instance-by-template) 把
+// `find_review_instance_by_template` + `reset_review_instance_for_reuse`
+// 引入 DAO,新建评审前先复用,不再无脑 INSERT。
+//
+// V17 的职责是「数据兜底」:对升级到 V17 的已有库,把同一 review_template_id
+// 对应的多个评审实例 todo 软删除(deleted_at=now),只保留 id 最大那条最新 todo。
+// execution_records 表不动 —— 历史评审执行记录照旧保留,前端/查询仍能 join 到
+// 那条「最新」的 todo 看到最新评分。
+//
+// 幂等:V17 跑完后所有 todo_type=2 行的 review_template_id 在 (review_template_id,
+// deleted_at IS NULL) 上天然 unique。再跑一次只会再软删除同一批已经被标记的
+// 行(条件 deleted_at IS NULL 不命中),不会动已被软删的行。
+pub(super) struct V17ConsolidateReviewInstanceTodos;
+
+#[async_trait]
+impl Migration for V17ConsolidateReviewInstanceTodos {
+    fn version(&self) -> i64 {
+        17
+    }
+    fn name(&self) -> &'static str {
+        "consolidate_review_instance_todos"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        consolidate_review_instance_todos(db).await
+    }
+}
+
+/// 数据迁移本体:每个 review_template_id 只保留一条未被软删的
+/// todo_type=2 评审实例 todo,其余软删除。
+///
+/// 实现选择 SQLite 友好的"两步走":
+/// 1) 用一条 UPDATE 把"每个 (review_template_id) 组里 id 不是最大"且"未软删"
+///    的 todo_type=2 行打上 deleted_at;
+/// 2) 已软删(deleted_at IS NOT NULL)的行不进 WHERE,所以幂等再跑无副作用。
+///
+/// SQLite 不支持 UPDATE ... FROM,但支持子查询,所以可以用
+/// `UPDATE todos SET deleted_at = ? WHERE id IN (SELECT id FROM ... WHERE ...)`。
+/// 用 `from_sql_and_values` 配合 `?` 占位参数化 timestamp,避免字符串拼接注入风险。
+async fn consolidate_review_instance_todos(db: &Database) -> Result<(), sea_orm::DbErr> {
+    let now = crate::models::utc_timestamp();
+    let sql = r#"
+        UPDATE todos
+        SET deleted_at = ?
+        WHERE todo_type = 2
+          AND deleted_at IS NULL
+          AND review_template_id IS NOT NULL
+          AND id NOT IN (
+            SELECT MAX(id) FROM todos
+            WHERE todo_type = 2
+              AND deleted_at IS NULL
+              AND review_template_id IS NOT NULL
+            GROUP BY review_template_id
+          )
+    "#;
+    db.conn
+        .execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            sql,
+            [now.into()],
+        ))
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod v17_consolidate_review_instance_todos_tests {
+    //! V17 迁移的回归测试。
+    //!
+    //! 覆盖:
+    //! 1) 同一 review_template_id 3 条 todo_type=2 → 软删 2 条,留 1 条最新;
+    //! 2) 不同 review_template_id 互不影响;
+    //! 3) 幂等:再跑一次不抛错、保留行不变;
+    //! 4) 已软删行不会被再次"打戳"。
+    //!
+    //! 注意:V17 是数据迁移,没有 schema 变更,所以不需要 add_column_if_missing。
+    //! 直接 INSERT + 调用迁移函数验证即可。
+
+    use super::*;
+    use sea_orm::{ActiveModelTrait, Set};
+    use crate::db::entity::todos;
+
+    async fn fresh_db() -> Database {
+        Database::new(":memory:").await.expect("memory db must open")
+    }
+
+    /// 注入一条 review_template 行,返回 id。V15 已自动 seed 默认模板,
+    /// 测试需要独立 id 以避免与默认行冲突,所以走 ActiveModel 自插。
+    async fn insert_review_template(db: &Database, name: &str) -> i64 {
+        let now = crate::models::utc_timestamp();
+        let am = crate::db::entity::review_templates::ActiveModel {
+            name: Set(name.to_string()),
+            description: Set(None),
+            prompt: Set(format!("{name} prompt")),
+            created_at: Set(Some(now.clone())),
+            updated_at: Set(Some(now)),
+            ..Default::default()
+        };
+        am.insert(&db.conn).await.expect("insert template").id
+    }
+
+    /// 注入一条 todo_type=2 评审实例 todo。
+    async fn insert_review_todo(
+        db: &Database,
+        template_id: i64,
+        title: &str,
+    ) -> i64 {
+        let now = crate::models::utc_timestamp();
+        let am = todos::ActiveModel {
+            title: Set(title.to_string()),
+            prompt: Set(Some("p".to_string())),
+            status: Set(Some("success".to_string())),
+            created_at: Set(Some(now.clone())),
+            updated_at: Set(Some(now)),
+            todo_type: Set(Some(2)),
+            review_template_id: Set(Some(template_id)),
+            auto_review_enabled: Set(Some(false)),
+            ..Default::default()
+        };
+        am.insert(&db.conn).await.expect("insert review todo").id
+    }
+
+    async fn count_active_review_todos(
+        db: &Database,
+        template_id: i64,
+    ) -> i64 {
+        let sql = format!(
+            "SELECT COUNT(*) AS n FROM todos WHERE todo_type = 2 \
+             AND review_template_id = {} AND deleted_at IS NULL",
+            template_id
+        );
+        let row = db
+            .conn
+            .query_one(Statement::from_string(DbBackend::Sqlite, sql))
+            .await
+            .expect("count")
+            .expect("row");
+        let n: i64 = row.try_get_by("n").unwrap_or(0i64);
+        n
+    }
+
+    #[tokio::test]
+    async fn v17_keeps_only_newest_per_template_and_soft_deletes_rest() {
+        let db = fresh_db().await;
+        let template_id = insert_review_template(&db, "T1").await;
+        let id1 = insert_review_todo(&db, template_id, "[评审] T1 v1").await;
+        let id2 = insert_review_todo(&db, template_id, "[评审] T1 v2").await;
+        let id3 = insert_review_todo(&db, template_id, "[评审] T1 v3").await;
+
+        consolidate_review_instance_todos(&db).await.expect("v17 up");
+
+        assert_eq!(count_active_review_todos(&db, template_id).await, 1,
+            "exactly one active review todo per template after V17");
+        // 最新 id (id3) 必须保留
+        let active = db
+            .find_review_instance_by_template(template_id)
+            .await
+            .expect("find")
+            .expect("newest todo must be findable");
+        assert_eq!(active.id, id3, "max id kept");
+        assert_ne!(id1, id3);
+        assert_ne!(id2, id3);
+    }
+
+    #[tokio::test]
+    async fn v17_isolates_templates() {
+        let db = fresh_db().await;
+        let t1 = insert_review_template(&db, "T1").await;
+        let t2 = insert_review_template(&db, "T2").await;
+        // T1: 2 条, T2: 3 条
+        insert_review_todo(&db, t1, "a").await;
+        insert_review_todo(&db, t1, "b").await;
+        insert_review_todo(&db, t2, "c").await;
+        insert_review_todo(&db, t2, "d").await;
+        insert_review_todo(&db, t2, "e").await;
+
+        consolidate_review_instance_todos(&db).await.expect("v17");
+
+        assert_eq!(count_active_review_todos(&db, t1).await, 1);
+        assert_eq!(count_active_review_todos(&db, t2).await, 1);
+    }
+
+    #[tokio::test]
+    async fn v17_is_idempotent() {
+        let db = fresh_db().await;
+        let template_id = insert_review_template(&db, "T").await;
+        insert_review_todo(&db, template_id, "v1").await;
+        insert_review_todo(&db, template_id, "v2").await;
+        insert_review_todo(&db, template_id, "v3").await;
+
+        consolidate_review_instance_todos(&db).await.expect("v17 first run");
+        consolidate_review_instance_todos(&db).await.expect("v17 second run (idempotent)");
+
+        assert_eq!(count_active_review_todos(&db, template_id).await, 1,
+            "idempotent — still exactly 1 active after re-run");
+    }
+
+    #[tokio::test]
+    async fn v17_does_not_touch_other_todo_types() {
+        // 普通 todo (todo_type=0) 不应被 V17 软删
+        let db = fresh_db().await;
+        let template_id = insert_review_template(&db, "T").await;
+        let review_id = insert_review_todo(&db, template_id, "r1").await;
+        let review_id2 = insert_review_todo(&db, template_id, "r2").await;
+        // 插一条普通 todo
+        let now = crate::models::utc_timestamp();
+        let normal_id = todos::ActiveModel {
+            title: Set("normal".to_string()),
+            prompt: Set(None),
+            created_at: Set(Some(now.clone())),
+            updated_at: Set(Some(now)),
+            todo_type: Set(Some(0)),
+            ..Default::default()
+        }
+        .insert(&db.conn)
+        .await
+        .expect("insert normal")
+        .id;
+
+        consolidate_review_instance_todos(&db).await.expect("v17");
+
+        // 普通 todo 仍存活
+        let sql = format!("SELECT deleted_at FROM todos WHERE id = {}", normal_id);
+        let row = db
+            .conn
+            .query_one(Statement::from_string(DbBackend::Sqlite, sql))
+            .await
+            .expect("q")
+            .expect("row");
+        let deleted_at: Option<String> = row.try_get_by("deleted_at").unwrap_or(None);
+        assert!(deleted_at.is_none(), "todo_type=0 must not be touched by V17");
+        // review 行里有一条被软删
+        let sql = format!("SELECT COUNT(*) AS n FROM todos WHERE id IN ({}, {}) AND deleted_at IS NOT NULL",
+            review_id, review_id2);
+        let row = db.conn.query_one(Statement::from_string(DbBackend::Sqlite, sql))
+            .await.expect("q").expect("row");
+        let n: i64 = row.try_get_by("n").unwrap_or(0i64);
+        assert!(n >= 1, "at least one old review todo must be soft-deleted");
     }
 }

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -420,6 +420,48 @@ impl Database {
         Ok(inserted.id)
     }
 
+    /// 根据 review_template_id 查找一条未删除的评审实例 todo (todo_type=2)。
+    ///
+    /// 复用语义：同一评审模板的所有评审执行共享同一条评审实例 todo,
+    /// 避免 todos 表被「同一模板 N 次评审 → N 条 todo」刷屏。
+    /// 多条匹配时返回 id 最大（最新创建）的那条，
+    /// 保证 V17 数据清理前老数据也能被定位到。
+    pub async fn find_review_instance_by_template(
+        &self,
+        review_template_id: i64,
+    ) -> Result<Option<todos::Model>, sea_orm::DbErr> {
+        todos::Entity::find()
+            .filter(todos::Column::TodoType.eq(2_i32))
+            .filter(todos::Column::ReviewTemplateId.eq(review_template_id))
+            .filter(todos::Column::DeletedAt.is_null())
+            .order_by_desc(todos::Column::Id)
+            .one(&self.conn)
+            .await
+    }
+
+    /// 复用现有评审实例 todo:重置 prompt/executor/status/updated_at,
+    /// 保留 todo id 和 execution_records 关联(历史 record 仍可见)。
+    ///
+    /// 调用方负责先调 `find_review_instance_by_template` 拿到 id;
+    /// 找不到时不要调本方法,应改走 `create_review_instance_todo`。
+    pub async fn reset_review_instance_for_reuse(
+        &self,
+        id: i64,
+        new_prompt: &str,
+        new_executor: Option<&str>,
+    ) -> Result<(), sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+        let am = todos::ActiveModel {
+            id: ActiveValue::Unchanged(id),
+            prompt: ActiveValue::Set(Some(new_prompt.to_string())),
+            executor: ActiveValue::Set(new_executor.map(|s| s.to_string())),
+            status: ActiveValue::Set(Some(TodoStatus::Pending.to_string())),
+            updated_at: ActiveValue::Set(Some(now)),
+            ..Default::default()
+        };
+        self.exec_update(am).await
+    }
+
     pub async fn force_update_todo_status(
         &self,
         id: i64,
@@ -1158,5 +1200,154 @@ impl Database {
                 todo,
             })
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod review_instance_reuse_tests {
+    //! 评审实例 todo 复用逻辑的单元测试。
+    //!
+    //! 关注三个新方法:`create_review_instance_todo` /
+    //! `find_review_instance_by_template` / `reset_review_instance_for_reuse`。
+    //! 每次评审运行共享同一条 todo(todo_type=2, review_template_id=N),
+    //! 避免 todos 表被「同模板 N 次评审 → N 条 todo」刷屏。
+
+    use super::*;
+    use crate::db::Database;
+
+    async fn fresh_db() -> Database {
+        Database::new(":memory:").await.expect("memory db must open")
+    }
+
+    async fn seed_template(db: &Database, name: &str) -> i64 {
+        // review_templates 表有 review_template_id, 直接插一条确保模板存在
+        use sea_orm::{ActiveModelTrait, Set};
+        let now = crate::models::utc_timestamp();
+        let am = crate::db::entity::review_templates::ActiveModel {
+            name: Set(name.to_string()),
+            description: Set(None),
+            prompt: Set(format!("{name} prompt")),
+            created_at: Set(Some(now.clone())),
+            updated_at: Set(Some(now)),
+            ..Default::default()
+        };
+        let inserted = am.insert(&db.conn).await.expect("insert template");
+        inserted.id
+    }
+
+    // -------- find_review_instance_by_template --------
+
+    #[tokio::test]
+    async fn find_review_instance_by_template_returns_existing() {
+        let db = fresh_db().await;
+        let template_id = seed_template(&db, "默认评审").await;
+        let first_id = db
+            .create_review_instance_todo(0, template_id, "默认评审", "p1".into(), None)
+            .await
+            .expect("create first");
+        let second_id = db
+            .create_review_instance_todo(0, template_id, "默认评审", "p2".into(), None)
+            .await
+            .expect("create second");
+        // 多条匹配 → 返回最新 (id 大的那条)
+        let found = db
+            .find_review_instance_by_template(template_id)
+            .await
+            .expect("find");
+        assert!(found.is_some(), "must find a review instance");
+        let found = found.unwrap();
+        assert_eq!(found.id, second_id, "newest by id wins");
+        assert_ne!(first_id, second_id);
+        assert_eq!(found.review_template_id, Some(template_id));
+        assert_eq!(found.todo_type, Some(2));
+    }
+
+    #[tokio::test]
+    async fn find_review_instance_by_template_returns_none_when_absent() {
+        let db = fresh_db().await;
+        let template_id = seed_template(&db, "未使用").await;
+        let found = db
+            .find_review_instance_by_template(template_id)
+            .await
+            .expect("find");
+        assert!(found.is_none(), "no review instance yet");
+    }
+
+    #[tokio::test]
+    async fn find_review_instance_by_template_excludes_deleted() {
+        let db = fresh_db().await;
+        let template_id = seed_template(&db, "X").await;
+        let id = db
+            .create_review_instance_todo(0, template_id, "X", "p".into(), None)
+            .await
+            .expect("create");
+        // 软删除
+        use sea_orm::{ActiveModelTrait, Set};
+        let now = crate::models::utc_timestamp();
+        let am = todos::ActiveModel {
+            id: Set(id),
+            deleted_at: Set(Some(now)),
+            ..Default::default()
+        };
+        am.update(&db.conn).await.expect("soft delete");
+        let found = db
+            .find_review_instance_by_template(template_id)
+            .await
+            .expect("find");
+        assert!(found.is_none(), "soft-deleted must be excluded");
+    }
+
+    #[tokio::test]
+    async fn find_review_instance_by_template_isolates_by_template_id() {
+        let db = fresh_db().await;
+        let t1 = seed_template(&db, "T1").await;
+        let t2 = seed_template(&db, "T2").await;
+        db.create_review_instance_todo(0, t1, "T1", "p".into(), None).await.expect("c1");
+        db.create_review_instance_todo(0, t2, "T2", "p".into(), None).await.expect("c2");
+        let f1 = db.find_review_instance_by_template(t1).await.expect("f1");
+        let f2 = db.find_review_instance_by_template(t2).await.expect("f2");
+        assert_eq!(f1.unwrap().review_template_id, Some(t1));
+        assert_eq!(f2.unwrap().review_template_id, Some(t2));
+    }
+
+    // -------- reset_review_instance_for_reuse --------
+
+    #[tokio::test]
+    async fn reset_review_instance_for_reuse_updates_prompt_status_executor() {
+        let db = fresh_db().await;
+        let template_id = seed_template(&db, "R").await;
+        let id = db
+            .create_review_instance_todo(0, template_id, "R", "old-prompt".into(), Some("claude".to_string()))
+            .await
+            .expect("create");
+        db.reset_review_instance_for_reuse(id, "new-prompt", Some("pi"))
+            .await
+            .expect("reset");
+        let found = db
+            .find_review_instance_by_template(template_id)
+            .await
+            .expect("find")
+            .expect("must exist");
+        assert_eq!(found.id, id, "id preserved");
+        assert_eq!(found.prompt.as_deref(), Some("new-prompt"));
+        assert_eq!(found.executor.as_deref(), Some("pi"));
+        assert_eq!(found.status.as_deref(), Some("pending"), "reset to pending");
+        assert_eq!(found.review_template_id, Some(template_id));
+        assert_eq!(found.todo_type, Some(2));
+    }
+
+    #[tokio::test]
+    async fn reset_review_instance_for_reuse_allows_executor_to_become_none() {
+        let db = fresh_db().await;
+        let template_id = seed_template(&db, "N").await;
+        let id = db
+            .create_review_instance_todo(0, template_id, "N", "p".into(), Some("claude".to_string()))
+            .await
+            .expect("create");
+        db.reset_review_instance_for_reuse(id, "p2", None)
+            .await
+            .expect("reset");
+        let found = db.find_review_instance_by_template(template_id).await.expect("find").unwrap();
+        assert!(found.executor.is_none(), "executor must clear to None");
     }
 }

--- a/backend/src/executor_service/auto_review.rs
+++ b/backend/src/executor_service/auto_review.rs
@@ -301,18 +301,36 @@ async fn execute_review_instance(
     template: &crate::models::ReviewTemplate,
     composed_prompt: String,
 ) -> Result<i64, String> {
-    // 创建一个评审实例 todo (todo_type=2), prompt 已是 caller 合成的最终 prompt。
-    // executor 从源 todo 继承 (review_template 表没有 executor 字段)。
-    let review_todo_id = db
-        .create_review_instance_todo(
-            original.id,
-            template.id,
-            &template.name,
-            composed_prompt.clone(),
-            original.executor.clone(),
-        )
+    // 复用策略:同一 review_template 全局共享一条评审实例 todo,
+    // 避免「每次评审都新建 todo」把 todos 表刷成同一评审 N 份。
+    // - 已有 → 重置 prompt/executor/status(保留 id 和 execution_records 关联)
+    // - 没有 → 新建
+    let review_todo_id = match db
+        .find_review_instance_by_template(template.id)
         .await
-        .map_err(|e| format!("create review instance todo: {}", e))?;
+        .map_err(|e| format!("find review instance: {}", e))?
+    {
+        Some(existing) => {
+            db.reset_review_instance_for_reuse(
+                existing.id,
+                &composed_prompt,
+                original.executor.as_deref(),
+            )
+            .await
+            .map_err(|e| format!("reset review instance: {}", e))?;
+            existing.id
+        }
+        None => db
+            .create_review_instance_todo(
+                original.id,
+                template.id,
+                &template.name,
+                composed_prompt.clone(),
+                original.executor.clone(),
+            )
+            .await
+            .map_err(|e| format!("create review instance todo: {}", e))?,
+    };
 
     let request = RunTodoExecutionRequest {
         db: db.clone(),

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -661,6 +661,48 @@ impl LoopRunner {
         }
     }
 
+    /// 复用或新建评审实例 todo。
+    ///
+    /// 设计：同一 `review_template_id` 全局共享一条评审实例 todo,
+    /// 避免「每次 loop 执行都新建评审 todo」把 todos 表刷屏。
+    /// 已有 → `reset_review_instance_for_reuse`(保留 id + execution_records 关联)
+    /// 没有 → `create_review_instance_todo`(parent_todo_id=0,loop step 没有单一源 todo)
+    /// 抽成单独方法便于 loop_runner.rs 内复用,且控制函数行数 ≤ 30。
+    async fn reuse_or_create_review_instance(
+        &self,
+        template_id: i64,
+        template_name: &str,
+        review_prompt: &str,
+        review_executor: Option<&str>,
+    ) -> Result<i64, sea_orm::DbErr> {
+        match self
+            .ctx
+            .db
+            .find_review_instance_by_template(template_id)
+            .await?
+        {
+            Some(existing) => {
+                self.ctx
+                    .db
+                    .reset_review_instance_for_reuse(existing.id, review_prompt, review_executor)
+                    .await?;
+                Ok(existing.id)
+            }
+            None => {
+                self.ctx
+                    .db
+                    .create_review_instance_todo(
+                        0,
+                        template_id,
+                        template_name,
+                        review_prompt.to_string(),
+                        review_executor.map(|s| s.to_string()),
+                    )
+                    .await
+            }
+        }
+    }
+
     /// 评分闸门：检查 execution_record 的 rating 与阈值比较。
     /// 若未评分且环节有验收标准，自动发起评审。
     /// 无评分 = 0 分（不通过，除非 min_rating ≤ 0）。
@@ -732,19 +774,21 @@ impl LoopRunner {
                 review_status: "pending".to_string(),
             });
 
-            // 5) 创建一个 todo_type=2 的评审实例 todo (V15 之后 review_template 不再是 todo)。
-            //    parent_todo_id=0: loop step 没有单一 source todo, 用 0 表达。
+            // 5) 评审实例 todo 复用策略:同一 review_template 全局共享一条 todo,
+            //    避免「每次 loop 执行都新建评审 todo」把 todos 表刷屏。
+            //    parent_todo_id=0: loop step 没有单一 source todo。
             //    executor 继承自被评审的 record。
-            let review_todo_id = match self.ctx.db.create_review_instance_todo(
-                0,
+            //    - 已有 → reset prompt/executor/status,保留 id 和 execution_records 关联
+            //    - 没有 → 新建
+            let review_todo_id = match self.reuse_or_create_review_instance(
                 template.id,
                 &template.name,
-                review_prompt.clone(),
-                review_executor.clone(),
+                &review_prompt,
+                review_executor.as_deref(),
             ).await {
                 Ok(id) => id,
                 Err(e) => {
-                    warn!("rating gate: failed to create review instance todo: {}", e);
+                    warn!("rating gate: failed to reuse/create review instance todo: {}", e);
                     let _ = self.ctx.db.set_record_last_review_status(record_id, "failed").await;
                     return Ok((false, None));
                 }


### PR DESCRIPTION
## Bug

每次评审执行(单 todo 自动评审 + loop 评分闸门)都新建一条 `todo_type=2` 评审实例 todo。同 review_template 的评审会留下 N 份「[评审] X」重复 todo 把 todos 表刷屏。

dev DB 实测:5 条评审 todo 标题全部相同 (`[评审] 默认评审任务`),`review_template_id` 都是 1,只有 id 和 created_at 不同。

## 修复

评审实例 todo 改为按 `review_template_id` 全局复用:

1. **DAO 新方法** (`backend/src/db/todo.rs`):
   - `find_review_instance_by_template(template_id) -> Option<Model>` — 复用查询
   - `reset_review_instance_for_reuse(id, prompt, executor)` — 重置 prompt/executor/status/updated_at,保留 id

2. **两处调用点改用复用**:
   - `executor_service/auto_review.rs::execute_review_instance` — 单 todo 自动评审
   - `services/loop_runner.rs::apply_rating_gate` (经新抽 `reuse_or_create_review_instance` 子函数) — loop 评分闸门

3. **execution_records 每次仍新建一条** — 历史评审执行轨迹完整保留。

4. **V17 数据迁移** (`backend/src/db/migration.rs`):
   - 对升级到 V17 的库,每个 `review_template_id` 只保留最新 (`id` 最大) 一条 `todo_type=2` 评审 todo,其余 soft-delete (`deleted_at=now`)。
   - SQLite-friendly `UPDATE ... WHERE id NOT IN (SELECT MAX(id) ... GROUP BY review_template_id)`,带 `deleted_at IS NULL` 条件保证幂等。

## Test Plan

- [x] DAO 单测 (`review_instance_reuse_tests`): 6 个 — 查找存在/不存在/排除软删/按 template 隔离/reset 行为/允许 executor 清空
- [x] V17 迁移测试 (`v17_consolidate_review_instance_todos_tests`): 4 个 — 保留最新/按 template 隔离/幂等/不动其他 todo_type
- [x] 全量 `cargo test`: 748 unit + 所有集成测试通过,0 failed
- [x] dev DB 端到端:升级前 5 条评审 todo → V17 跑完剩 1 条 (id=18)
- [x] 触发 loop#2 一次:todo_type=2 未软删总数仍为 1,未新增 todo

## 不在范围内

- 不改 single-todo vs loop 的来源区分 (`parent_todo_id` 字段不动)
- 不动 `execution_records` 表结构,只新增数据
- V17 不写日志表,操作可审计(执行时间戳通过 `deleted_at` 体现)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>