### PR TITLE
feat: 评分不通过时允许跳转到自身（重试），需兜底限制

### DIFF
--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -358,6 +358,22 @@ pub async fn update_loop_step(
             .await?
             .ok_or_else(|| AppError::BadRequest(format!("step #{} 不存在", req.step_id)))?;
     }
+    // 评分不通过时跳转到自身（重试），需要 loop 有兜底限制
+    if req.on_rating_fail == "goto" && req.fail_goto_step_id == Some(sid) {
+        let loop_ = state.db.get_loop(loop_id).await?.ok_or(AppError::NotFound)?;
+        // 解析 limits_config，检查是否配置了步数或 Token 限制
+        #[derive(serde::Deserialize, Default)]
+        struct LimitsConfig {
+            max_step_executions: Option<i32>,
+            max_total_tokens: Option<i64>,
+        }
+        let limits: LimitsConfig = serde_json::from_str(&loop_.limits_config).unwrap_or_default();
+        if limits.max_step_executions.is_none() && limits.max_total_tokens.is_none() {
+            return Err(AppError::BadRequest(
+                "评分不通过时跳转到自身需要配置「最大执行步数」或「最大 Token 数」兜底".to_string(),
+            ));
+        }
+    }
     state
         .db
         .update_loop_step(

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -63,6 +63,9 @@ export function LoopDetailPanel({
   const [projectDirs, setProjectDirs] = useState<ProjectDirectory[]>([]);
   // 执行记录总数，由 LoopExecutionsPanel 通过回调更新
   const [executionTotal, setExecutionTotal] = useState(0);
+  // 从 loop.limits_config 解析出的限制值，传递给子面板做兜底校验
+  const [maxStepExecutions, setMaxStepExecutions] = useState<number | null>(null);
+  const [maxTotalTokens, setMaxTotalTokens] = useState<number | null>(null);
 
   // 加载完整 detail, 子面板变更后也要重新拉以保持最新
   const reload = useCallback(() => {
@@ -84,6 +87,9 @@ export function LoopDetailPanel({
             max_step_executions: lc.max_step_executions ?? null,
             max_total_tokens: lc.max_total_tokens ?? null,
           });
+          // 缓存限制值，传递给子面板做跳转自身时的兜底校验
+          setMaxStepExecutions(lc.max_step_executions ?? null);
+          setMaxTotalTokens(lc.max_total_tokens ?? null);
         } catch {
           // 忽略解析错误
         }
@@ -335,6 +341,8 @@ export function LoopDetailPanel({
           loopId={loopId}
           steps={detail.steps}
           onChanged={() => { reload(); onChanged(); }}
+          maxStepExecutions={maxStepExecutions}
+          maxTotalTokens={maxTotalTokens}
         />
       </DetailSection>
 

--- a/frontend/src/components/LoopStudioStepsPanel.tsx
+++ b/frontend/src/components/LoopStudioStepsPanel.tsx
@@ -17,9 +17,13 @@ interface StepsPanelProps {
   loopId: number;
   steps: LoopStepDto[];
   onChanged: () => void;
+  /** Loop 的最大执行步数限制，来自 loop.limits_config.max_step_executions */
+  maxStepExecutions?: number | null;
+  /** Loop 的最大 Token 数限制，来自 loop.limits_config.max_total_tokens */
+  maxTotalTokens?: number | null;
 }
 
-export function LoopStepsPanel({ loopId, steps, onChanged }: StepsPanelProps) {
+export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, maxTotalTokens }: StepsPanelProps) {
   const { message } = AntApp.useApp();
 
   // Modal 状态
@@ -70,6 +74,16 @@ export function LoopStepsPanel({ loopId, steps, onChanged }: StepsPanelProps) {
   // 保存
   const handleSave = useCallback(async () => {
     const values = await form.validateFields();
+    // 评分不通过时跳转到自身（重试），需要至少有一个兜底限制
+    if (
+      editingStep &&
+      values.on_rating_fail === 'goto' &&
+      values.fail_goto_step_id === editingStep.id &&
+      !maxStepExecutions && !maxTotalTokens
+    ) {
+      message.error('跳转到自身需要设置「最大执行步数」或「最大 Token 数」兜底，请在 Loop 基础信息中配置');
+      return;
+    }
     setSaving(true);
     try {
       if (editingStep) {
@@ -112,7 +126,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged }: StepsPanelProps) {
     } finally {
       setSaving(false);
     }
-  }, [form, loopId, editingStep, message, onChanged]);
+  }, [form, loopId, editingStep, message, onChanged, maxStepExecutions, maxTotalTokens]);
 
   // 删除环节
   const handleDelete = useCallback(async (stepId: number) => {
@@ -270,10 +284,9 @@ export function LoopStepsPanel({ loopId, steps, onChanged }: StepsPanelProps) {
             {on_rating_fail === 'goto' && (
               <Form.Item label="目标环节" name="fail_goto_step_id">
                 <Select
-                  placeholder="选择目标环节"
+                  placeholder="选择目标环节（选择自身=重试）"
                   options={steps
-                    .filter(s => s.id !== editingStep?.id)
-                    .map(s => ({ label: `${s.name} (#${s.id})`, value: s.id }))}
+                    .map(s => ({ label: s.id === editingStep?.id ? `${s.name} (#${s.id}) ⬅ 重试` : `${s.name} (#${s.id})`, value: s.id }))}
                 />
               </Form.Item>
             )}


### PR DESCRIPTION
## 背景

Loop 环节设置了评分门禁后，如果评分不通过，用户可以配置「跳转到指定环节」。之前不能选择自身，现在放开这个限制——选择自身等于「重试」。

## 风险 & 保护

重试可能形成死循环，所以要求 loop 必须配置至少一个兜底限制：
- **最大执行步数**（`max_step_executions`）
- **最大 Token 数**（`max_total_tokens`）

两者至少设一个才能保存评分不通过时跳转到自身。

## 双重校验

| 层 | 位置 | 行为 |
|----|------|------|
| 前端 | `LoopStudioStepsPanel.handleSave` | 如果 goto 自身且两个限制都没设，弹 error 阻止保存 |
| 后端 | `handlers/loop_.rs::update_loop_step` | 同样校验，返回 400 BadRequest |

## 运行时保护（已有）

`LoopRunner` 在主循环中已有：
1. `total_executed >= max_step_executions` → capped 终止
2. `total_tokens_used >= max_total_tokens` → capped 终止
3. 连续 5 次执行同一 step → 死循环检测终止