### PR TITLE
feat: loop 环节支持人工审批（human review）

### DIFF
--- a/backend/src/db/entity/loop_step_executions.rs
+++ b/backend/src/db/entity/loop_step_executions.rs
@@ -30,6 +30,10 @@ pub struct Model {
     pub sequence_index: i32,
     /// 本次步执行的核心结论摘要
     pub conclusion: Option<String>,
+    /// 人工审批状态: NULL | "pending" | "approved"（非人工审批环节为 NULL）
+    pub approval_status: Option<String>,
+    /// 审批人的备注/意见
+    pub approval_comment: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/entity/loop_steps.rs
+++ b/backend/src/db/entity/loop_steps.rs
@@ -38,6 +38,9 @@ pub struct Model {
     pub on_rating_fail: String,
     /// on_rating_fail="goto" 时的目标 step_id
     pub fail_goto_step_id: Option<i64>,
+    /// 评审类型: "ai" = AI 自动评审, "human" = 人工审批（默认 "ai"）
+    #[sea_orm(default_value = "ai")]
+    pub review_type: String,
     #[sea_orm(default_value = "1")]
     pub enabled: i32,
     pub created_at: Option<String>,

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -817,7 +817,10 @@ impl Database {
                           (SELECT le.status FROM loop_executions le \
                            WHERE le.loop_id = l.id ORDER BY le.started_at DESC LIMIT 1) as last_execution_status, \
                           (SELECT le.started_at FROM loop_executions le \
-                           WHERE le.loop_id = l.id ORDER BY le.started_at DESC LIMIT 1) as last_execution_at \
+                           WHERE le.loop_id = l.id ORDER BY le.started_at DESC LIMIT 1) as last_execution_at, \
+                          (SELECT COUNT(*) FROM loop_step_executions lse \
+                           INNER JOIN loop_executions le2 ON le2.id = lse.loop_execution_id \
+                           WHERE le2.loop_id = l.id AND lse.approval_status = 'pending') as pending_approval_count \
                    FROM loops l \
                    WHERE l.workspace = ?1 \
                    ORDER BY l.updated_at DESC",
@@ -828,7 +831,10 @@ impl Database {
                       (SELECT le.status FROM loop_executions le \
                        WHERE le.loop_id = l.id ORDER BY le.started_at DESC LIMIT 1) as last_execution_status, \
                       (SELECT le.started_at FROM loop_executions le \
-                       WHERE le.loop_id = l.id ORDER BY le.started_at DESC LIMIT 1) as last_execution_at \
+                       WHERE le.loop_id = l.id ORDER BY le.started_at DESC LIMIT 1) as last_execution_at, \
+                      (SELECT COUNT(*) FROM loop_step_executions lse \
+                       INNER JOIN loop_executions le2 ON le2.id = lse.loop_execution_id \
+                       WHERE le2.loop_id = l.id AND lse.approval_status = 'pending') as pending_approval_count \
                    FROM loops l \
                    ORDER BY l.updated_at DESC",
         };
@@ -866,6 +872,7 @@ impl Database {
                     .unwrap_or_default(),
                 last_execution_at: row
                     .try_get_by::<Option<String>, _>("last_execution_at")?,
+                pending_approval_count: row.try_get_by::<i32, _>("pending_approval_count").unwrap_or(0),
             });
         }
         Ok(out)
@@ -910,6 +917,8 @@ pub struct LoopListRow {
     pub step_count: i32,
     pub last_execution_status: String,
     pub last_execution_at: Option<String>,
+    /// 该 loop 下所有待人工审批的环节执行数
+    pub pending_approval_count: i32,
 }
 
 /// LoopStudio 详情页单次请求所需的完整数据。

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -11,7 +11,7 @@
 //! 不抽象 DAO trait，因为 codebase 其它 db 文件都这样做）。
 use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect,
-    Set,
+    Set, DbBackend, ConnectionTrait, Statement,
 };
 use std::collections::HashMap;
 
@@ -491,6 +491,61 @@ impl Database {
             .map(|c| c as i64)
     }
 
+    /// 统计该 loop 下所有待人工审批的环节执行数。
+    /// 条件：loop_step_executions 关联到该 loop 的运行中 execution，且 approval_status = 'pending'。
+    pub async fn count_pending_approvals_for_loop(
+        &self,
+        loop_id: i64,
+    ) -> Result<i32, sea_orm::DbErr> {
+        use sea_orm::{ConnectionTrait, Statement};
+        let sql = format!(
+            "SELECT COUNT(*) AS n FROM loop_step_executions lse \
+             INNER JOIN loop_executions le ON le.id = lse.loop_execution_id \
+             WHERE le.loop_id = {} AND lse.approval_status = 'pending'",
+            loop_id
+        );
+        let row = self
+            .conn
+            .query_one(Statement::from_string(DbBackend::Sqlite, sql))
+            .await?
+            .ok_or(sea_orm::DbErr::RecordNotFound("count query returned no rows".into()))?;
+        Ok(row.try_get_by::<i32, _>("n").unwrap_or(0))
+    }
+
+    /// 批量查询指定 loop_execution 列表的待审批数，返回 execution_id → count 映射。
+    pub async fn count_pending_approvals_by_execution_ids(
+        &self,
+        execution_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, i32>, sea_orm::DbErr> {
+        use sea_orm::{ConnectionTrait, Statement};
+        let mut map = std::collections::HashMap::new();
+        if execution_ids.is_empty() {
+            return Ok(map);
+        }
+        let ids_str: String = execution_ids
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT lse.loop_execution_id, COUNT(*) AS n \
+             FROM loop_step_executions lse \
+             WHERE lse.loop_execution_id IN ({}) AND lse.approval_status = 'pending' \
+             GROUP BY lse.loop_execution_id",
+            ids_str
+        );
+        let rows = self
+            .conn
+            .query_all(Statement::from_string(DbBackend::Sqlite, sql))
+            .await?;
+        for row in rows {
+            let exec_id: i64 = row.try_get_by("loop_execution_id")?;
+            let n: i32 = row.try_get_by("n").unwrap_or(0);
+            map.insert(exec_id, n);
+        }
+        Ok(map)
+    }
+
     /// 终态化 loop execution: 设置 status、finished_at 并按需累加 completed/failed 计数。
     ///
     /// 计数更新由调用方传入,因为 runner 在每个阶段结束时增量更新,效率更高。
@@ -834,12 +889,15 @@ impl Database {
         let todo_map: HashMap<i64, _> = todos.into_iter().map(|t| (t.id, t)).collect();
         let steps: Vec<loop_steps::Model> =
             steps_with_meta.iter().map(|(s, _, _, _)| s.clone()).collect();
+        // 统计该 loop 下待人工审批的环节执行数
+        let pending_approval_count = self.count_pending_approvals_for_loop(loop_id).await?;
         Ok(Some(LoopFullView {
             loop_,
             triggers,
             steps,
             steps_meta: steps_with_meta,
             todo_map,
+            pending_approval_count,
         }))
     }
 }
@@ -863,4 +921,6 @@ pub struct LoopFullView {
     /// (step, todo_title, todo_executor, todo_status)
     pub steps_meta: Vec<(loop_steps::Model, String, String, String)>,
     pub todo_map: HashMap<i64, crate::db::entity::todos::Model>,
+    /// 该 loop 下待人工审批的环节执行数
+    pub pending_approval_count: i32,
 }

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -168,6 +168,7 @@ impl Database {
                 s.success_goto_step_id,
                 &s.on_rating_fail,
                 s.fail_goto_step_id,
+                &s.review_type,
             )
             .await?;
         }
@@ -330,6 +331,7 @@ impl Database {
         success_goto_step_id: Option<i64>,
         on_rating_fail: &str,
         fail_goto_step_id: Option<i64>,
+        review_type: &str,
     ) -> Result<loop_steps::Model, sea_orm::DbErr> {
         // 自动分配 order_index: 当前最大 + 1
         let next_order = self
@@ -356,6 +358,7 @@ impl Database {
             success_goto_step_id: ActiveValue::Set(success_goto_step_id),
             on_rating_fail: ActiveValue::Set(on_rating_fail.to_string()),
             fail_goto_step_id: ActiveValue::Set(fail_goto_step_id),
+            review_type: ActiveValue::Set(review_type.to_string()),
             created_at: ActiveValue::Set(Some(now)),
             ..Default::default()
         };
@@ -377,6 +380,7 @@ impl Database {
         success_goto_step_id: Option<i64>,
         on_rating_fail: &str,
         fail_goto_step_id: Option<i64>,
+        review_type: &str,
     ) -> Result<(), sea_orm::DbErr> {
         let existing = loop_steps::Entity::find_by_id(id).one(&self.conn).await?;
         if let Some(c) = existing {
@@ -394,6 +398,7 @@ impl Database {
             am.success_goto_step_id = ActiveValue::Set(success_goto_step_id);
             am.on_rating_fail = ActiveValue::Set(on_rating_fail.to_string());
             am.fail_goto_step_id = ActiveValue::Set(fail_goto_step_id);
+            am.review_type = ActiveValue::Set(review_type.to_string());
             am.update(&self.conn).await?;
         }
         Ok(())
@@ -642,6 +647,42 @@ impl Database {
         Ok(())
     }
 
+    /// 设置环节执行记录的审批状态（人工审批流程专用）。
+    pub async fn set_step_execution_approval_status(
+        &self,
+        id: i64,
+        approval_status: &str,
+    ) -> Result<(), sea_orm::DbErr> {
+        let existing = loop_step_executions::Entity::find_by_id(id).one(&self.conn).await?;
+        if let Some(c) = existing {
+            let mut am: loop_step_executions::ActiveModel = c.into();
+            am.approval_status = ActiveValue::Set(Some(approval_status.to_string()));
+            am.update(&self.conn).await?;
+        }
+        Ok(())
+    }
+
+    /// 人工审批：写入评分、审批意见，更新状态。
+    /// 调用前由 handler 校验 approval_status = "pending"。
+    pub async fn approve_step_execution(
+        &self,
+        id: i64,
+        rating: i32,
+        status: &str,
+        comment: Option<&str>,
+    ) -> Result<(), sea_orm::DbErr> {
+        let existing = loop_step_executions::Entity::find_by_id(id).one(&self.conn).await?;
+        if let Some(c) = existing {
+            let mut am: loop_step_executions::ActiveModel = c.into();
+            am.rating = ActiveValue::Set(Some(rating));
+            am.status = ActiveValue::Set(status.to_string());
+            am.approval_status = ActiveValue::Set(Some("approved".to_string()));
+            am.approval_comment = ActiveValue::Set(comment.map(|s| s.to_string()));
+            am.update(&self.conn).await?;
+        }
+        Ok(())
+    }
+
     // ====== 辅助：批量取 step + todo 元信息 ======
 
     /// 一次 SQL 把 step + 关联 todo 的 title/executor/status 拉出来。
@@ -657,6 +698,7 @@ impl Database {
             "SELECT s.id, s.loop_id, s.name, s.description, s.order_index, s.step_id, \
                     s.run_mode, s.skip_on_source_failed, s.min_rating, s.unrated_policy, \
                     s.on_success, s.success_goto_step_id, s.on_rating_fail, s.fail_goto_step_id, \
+                    s.review_type, \
                     s.enabled, s.created_at, \
                     t.title as todo_title, st.executor as todo_executor, t.status as todo_status \
              FROM loop_steps s \
@@ -687,6 +729,7 @@ impl Database {
                 success_goto_step_id: row.try_get_by::<Option<i64>, _>("success_goto_step_id")?,
                 on_rating_fail: row.try_get_by::<String, _>("on_rating_fail")?,
                 fail_goto_step_id: row.try_get_by::<Option<i64>, _>("fail_goto_step_id")?,
+                review_type: row.try_get_by::<String, _>("review_type")?,
                 enabled: row.try_get_by::<i32, _>("enabled")?,
                 created_at: row.try_get_by::<Option<String>, _>("created_at")?,
             };

--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -54,6 +54,7 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V15ReviewTemplates),
         Box::new(V16LoopStepExecutionSnapshotColumns),
         Box::new(V17ConsolidateReviewInstanceTodos),
+        Box::new(V18LoopHumanReview),
     ]
 }
 
@@ -2994,5 +2995,55 @@ mod v17_consolidate_review_instance_todos_tests {
             .await.expect("q").expect("row");
         let n: i64 = row.try_get_by("n").unwrap_or(0i64);
         assert!(n >= 1, "at least one old review todo must be soft-deleted");
+    }
+}
+
+// ===== V18: loop 人工审批支持 =====
+//
+// 需求：loop 环节增加人工审批能力，评审类型分为 "ai" 和 "human" 两种。
+// - loop_steps 新增 review_type 列（默认 'ai' = 现有 AI 自动评审）
+// - loop_step_executions 新增 approval_status（审批状态）和 approval_comment（审批备注）
+//
+// 向后兼容：review_type 默认为 'ai'，所有旧数据行为不变。
+pub(super) struct V18LoopHumanReview;
+
+#[async_trait]
+impl Migration for V18LoopHumanReview {
+    fn version(&self) -> i64 {
+        18
+    }
+    fn name(&self) -> &'static str {
+        "loop_human_review"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // loop_steps.review_type: 'ai' = AI 自动评审, 'human' = 人工审批
+        add_column_if_missing(
+            db,
+            "loop_steps",
+            "review_type",
+            "ALTER TABLE loop_steps ADD COLUMN review_type TEXT NOT NULL DEFAULT 'ai'",
+        )
+        .await?;
+
+        // loop_step_executions.approval_status: NULL | 'pending' | 'approved'
+        add_column_if_missing(
+            db,
+            "loop_step_executions",
+            "approval_status",
+            "ALTER TABLE loop_step_executions ADD COLUMN approval_status TEXT",
+        )
+        .await?;
+
+        // loop_step_executions.approval_comment: 审批人的备注/意见
+        add_column_if_missing(
+            db,
+            "loop_step_executions",
+            "approval_comment",
+            "ALTER TABLE loop_step_executions ADD COLUMN approval_comment TEXT",
+        )
+        .await?;
+
+        Ok(())
     }
 }

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -514,7 +514,14 @@ pub async fn list_executions(
     let offset = (page - 1) * limit;
     let records = state.db.list_loop_executions(loop_id, limit, offset).await?;
     let total = state.db.count_loop_executions(loop_id).await?;
-    let items: Vec<LoopExecutionDto> = records.into_iter().map(Into::into).collect();
+    // 批量查询各执行记录的待审批数量
+    let exec_ids: Vec<i64> = records.iter().map(|r| r.id).collect();
+    let pending_counts = state.db.count_pending_approvals_by_execution_ids(&exec_ids).await?;
+    let mut items: Vec<LoopExecutionDto> = records.into_iter().map(Into::into).collect();
+    // 填充 pending_approval_count
+    for item in &mut items {
+        item.pending_approval_count = pending_counts.get(&item.id).copied().unwrap_or(0);
+    }
     Ok(ApiResponse::ok(serde_json::json!({
         "items": items,
         "total": total,

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -437,6 +437,19 @@ pub async fn approve_step_execution(
         .find(|se| se.id == step_execution_id)
         .ok_or_else(|| AppError::NotFound)?;
 
+    // 2.5. 校验 execution 归属于指定 loop_id，防止路径参数伪造
+    // 先获取 loop_execution 记录，确认其 loop_id 与 URL 路径中的 _loop_id 一致
+    let loop_exec = state
+        .db
+        .get_loop_execution(execution_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound)?;
+    if loop_exec.loop_id != _loop_id {
+        return Err(AppError::BadRequest(
+            "该 execution 不属于指定的 loop".to_string(),
+        ));
+    }
+
     // 3. 校验当前状态是 "pending_approval"
     if step_exec.status != "pending_approval" {
         return Err(AppError::BadRequest(

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -28,7 +28,7 @@ use crate::models::{
     LoopDetail, LoopDto, LoopExecutionDetail, LoopExecutionDto, LoopExecutionTokenSummary,
     LoopListItem, LoopStepDto, LoopStepExecutionDto, LoopTriggerDto, ReorderLoopStepsRequest,
     UpdateLoopRequest, UpdateLoopStatusRequest, UpdateLoopStepRequest,
-    UpdateTriggerRequest,
+    UpdateTriggerRequest, ApproveStepExecutionRequest,
 };
 
 const DEFAULT_PAGE_LIMIT: u64 = 20;
@@ -316,6 +316,7 @@ pub async fn create_loop_step(
             req.success_goto_step_id,
             &req.on_rating_fail,
             req.fail_goto_step_id,
+            &req.review_type,
         )
         .await?;
     let (_, todo_title, todo_executor, todo_status) = state
@@ -390,6 +391,7 @@ pub async fn update_loop_step(
             req.success_goto_step_id,
             &req.on_rating_fail,
             req.fail_goto_step_id,
+            &req.review_type,
         )
         .await?;
     let (_, todo_title, todo_executor, todo_status) = state
@@ -414,6 +416,61 @@ pub async fn delete_loop_step(
     state.db.get_loop_step(sid).await?.ok_or(AppError::NotFound)?;
     state.db.delete_loop_step(sid).await?;
     Ok(ApiResponse::ok(()))
+}
+
+/// POST /api/loops/{loop_id}/executions/{execution_id}/steps/{step_execution_id}/approve
+/// 人工审批：对等待审批的环节执行记录打分并继续 loop 执行。
+pub async fn approve_step_execution(
+    State(state): State<AppState>,
+    Path((_loop_id, execution_id, step_execution_id)): Path<(i64, i64, i64)>,
+    Json(req): Json<ApproveStepExecutionRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    // 1. 校验评分范围
+    if req.rating < 0 || req.rating > 100 {
+        return Err(AppError::BadRequest("评分必须在 0-100 之间".to_string()));
+    }
+
+    // 2. 查询 step_execution 记录
+    let step_execs = state.db.list_loop_step_executions(execution_id).await?;
+    let step_exec = step_execs
+        .iter()
+        .find(|se| se.id == step_execution_id)
+        .ok_or_else(|| AppError::NotFound)?;
+
+    // 3. 校验当前状态是 "pending_approval"
+    if step_exec.status != "pending_approval" {
+        return Err(AppError::BadRequest(
+            "该环节当前不需要审批".to_string(),
+        ));
+    }
+
+    // 4. 根据评分和阈值决定最终状态
+    let min_rating = step_exec.min_rating.unwrap_or(0);
+    let final_status = if req.rating >= min_rating { "success" } else { "failed" };
+
+    // 5. 写入审批结果
+    state
+        .db
+        .approve_step_execution(
+            step_execution_id,
+            req.rating,
+            final_status,
+            req.comment.as_deref(),
+        )
+        .await?;
+
+    // 6. 尝试恢复 loop 执行
+    let runner = state
+        .loop_runner
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("loop runner not ready".to_string()))?;
+    runner.resume_loop_execution(execution_id).await;
+
+    Ok(ApiResponse::ok(serde_json::json!({
+        "step_execution_id": step_execution_id,
+        "rating": req.rating,
+        "status": final_status,
+    })))
 }
 
 pub async fn reorder_loop_steps(
@@ -594,4 +651,5 @@ pub fn loop_routes() -> axum::Router<AppState> {
         )
         .route("/api/loops/{id}/executions", get(list_executions))
         .route("/api/loops/{id}/executions/{eid}", get(get_execution))
+        .route("/api/loops/{id}/executions/{eid}/steps/{seid}/approve", post(approve_step_execution))
 }

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -472,6 +472,13 @@ pub async fn approve_step_execution(
         )
         .await?;
 
+    // 5b. 发送 WebSocket 事件触发前端刷新
+    let _ = state.tx.send(crate::handlers::ExecEvent::ReviewStatusChanged {
+        record_id: step_exec.execution_record_id.unwrap_or(0),
+        todo_id: step_exec.todo_id,
+        review_status: final_status.to_string(),
+    });
+
     // 6. 尝试恢复 loop 执行
     let runner = state
         .loop_runner

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -21,6 +21,9 @@ pub struct LoopListItem {
     pub step_count: i32,
     pub last_execution_status: String,
     pub last_execution_at: Option<String>,
+    /// 该 loop 下所有待人工审批的环节执行数
+    #[serde(default)]
+    pub pending_approval_count: i32,
 }
 
 impl From<LoopListRow> for LoopListItem {
@@ -31,6 +34,7 @@ impl From<LoopListRow> for LoopListItem {
             step_count: row.step_count,
             last_execution_status: row.last_execution_status,
             last_execution_at: row.last_execution_at,
+            pending_approval_count: row.pending_approval_count,
         }
     }
 }

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -176,6 +176,8 @@ pub struct LoopStepRawDto {
     pub success_goto_step_id: Option<i64>,
     pub on_rating_fail: String,
     pub fail_goto_step_id: Option<i64>,
+    /// 评审类型: "ai" = AI 自动评审, "human" = 人工审批
+    pub review_type: String,
     pub enabled: bool,
     pub created_at: Option<String>,
 }
@@ -197,6 +199,7 @@ impl From<loop_steps::Model> for LoopStepRawDto {
             success_goto_step_id: m.success_goto_step_id,
             on_rating_fail: m.on_rating_fail,
             fail_goto_step_id: m.fail_goto_step_id,
+            review_type: m.review_type,
             enabled: m.enabled != 0,
             created_at: m.created_at,
         }
@@ -259,6 +262,10 @@ pub struct LoopStepExecutionDto {
     pub sequence_index: i32,
     /// 本次步执行的结论摘要
     pub conclusion: Option<String>,
+    /// 人工审批状态: NULL | "pending" | "approved"
+    pub approval_status: Option<String>,
+    /// 审批人的备注/意见
+    pub approval_comment: Option<String>,
     /// 本次环节执行消耗的 token（从 execution_record.usage JSON 解析）
     pub input_tokens: Option<i64>,
     pub output_tokens: Option<i64>,
@@ -285,6 +292,8 @@ impl From<loop_step_executions::Model> for LoopStepExecutionDto {
             step_name: None,
             sequence_index: m.sequence_index,
             conclusion: m.conclusion,
+            approval_status: m.approval_status,
+            approval_comment: m.approval_comment,
             input_tokens: None,
             output_tokens: None,
             cache_read_input_tokens: None,
@@ -408,12 +417,16 @@ pub struct CreateLoopStepRequest {
     pub on_rating_fail: String,
     #[serde(default)]
     pub fail_goto_step_id: Option<i64>,
+    /// 评审类型: "ai" | "human"（默认 "ai"）
+    #[serde(default = "default_review_type")]
+    pub review_type: String,
 }
 
 fn default_run_mode() -> String { "sequential".to_string() }
 fn default_unrated_policy() -> String { "skip".to_string() }
 fn default_on_success() -> String { "next".to_string() }
 fn default_on_rating_fail() -> String { "break".to_string() }
+fn default_review_type() -> String { "ai".to_string() }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct UpdateLoopStepRequest {
@@ -429,6 +442,18 @@ pub struct UpdateLoopStepRequest {
     pub success_goto_step_id: Option<i64>,
     pub on_rating_fail: String,
     pub fail_goto_step_id: Option<i64>,
+    /// 评审类型: "ai" | "human"（默认 "ai"）
+    #[serde(default = "default_review_type")]
+    pub review_type: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApproveStepExecutionRequest {
+    /// 审批人给出的评分 (0-100)
+    pub rating: i32,
+    /// 审批人的备注/意见（可选）
+    #[serde(default)]
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -480,6 +505,7 @@ pub fn loop_status_color(status: &str) -> &'static str {
 pub fn step_execution_color(status: &str) -> &'static str {
     match status {
         "pending" => "#bfbfbf",
+        "pending_approval" => "#fa8c16", // 等待人工审批
         "running" => "#1890ff",
         "success" => "#52c41a",
         "failed" => "#f5222d",

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -44,6 +44,9 @@ pub struct LoopDetail {
     pub steps: Vec<LoopStepDto>,
     /// todo_id -> TodoDto,前端展示 step 关联的 todo 信息时直接 lookup
     pub todo_map: std::collections::HashMap<i64, TodoSummary>,
+    /// 待人工审批的环节执行数（approval_status='pending' 的 loop_step_executions 数量）
+    #[serde(default)]
+    pub pending_approval_count: i32,
 }
 
 impl From<LoopFullView> for LoopDetail {
@@ -78,6 +81,7 @@ impl From<LoopFullView> for LoopDetail {
             triggers: view.triggers.into_iter().map(Into::into).collect(),
             steps,
             todo_map,
+            pending_approval_count: view.pending_approval_count,
         }
     }
 }
@@ -219,6 +223,9 @@ pub struct LoopExecutionDto {
     pub total_steps: i32,
     pub completed_steps: i32,
     pub failed_steps: i32,
+    /// 待人工审批的环节数（approval_status='pending' 的 loop_step_executions 数量）
+    #[serde(default)]
+    pub pending_approval_count: i32,
 }
 
 impl From<loop_executions::Model> for LoopExecutionDto {
@@ -235,6 +242,7 @@ impl From<loop_executions::Model> for LoopExecutionDto {
             total_steps: m.total_steps,
             completed_steps: m.completed_steps,
             failed_steps: m.failed_steps,
+            pending_approval_count: 0, // 由 handler 后续查询填充
         }
     }
 }

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::collections::HashMap;
 use tokio::sync::broadcast;
-use tokio::time::timeout;
 use tracing::{error, info, warn};
 
 use crate::executor_service::{run_todo_execution_with_params, RunTodoExecutionRequest};
@@ -125,12 +124,143 @@ impl LoopRunner {
         loop_execution_id
     }
 
+    /// 恢复被人工审批暂停的 loop 执行。
+    /// 由审批 API handler 调用。
+    /// 查找已审批的 step_execution，确定下一步，然后继续主循环。
+    pub async fn resume_loop_execution(
+        self: &Arc<Self>,
+        loop_execution_id: i64,
+    ) {
+        // 1. 加载 loop_execution，校验状态为 running
+        let loop_exec = match self.ctx.db.get_loop_execution(loop_execution_id).await {
+            Ok(Some(le)) => le,
+            _ => {
+                warn!("resume: loop_execution #{} not found", loop_execution_id);
+                return;
+            }
+        };
+        if loop_exec.status != "running" {
+            warn!("resume: loop_execution #{} status is {}, not running", loop_execution_id, loop_exec.status);
+            return;
+        }
+
+        // 2. 加载所有 step_executions，找到刚被审批的那条
+        let step_execs = match self.ctx.db.list_loop_step_executions(loop_execution_id).await {
+            Ok(se) => se,
+            Err(e) => {
+                warn!("resume: failed to list step_executions: {}", e);
+                return;
+            }
+        };
+
+        // 找 approval_status = "approved" 且原来状态是 pending_approval 的（已审批）
+        let approved_se = step_execs.iter().find(|se| {
+            se.approval_status.as_deref() == Some("approved") &&
+            (se.status == "success" || se.status == "failed")
+        });
+
+        let approved = match approved_se {
+            Some(se) => se,
+            None => {
+                warn!("resume: no approved step_execution found for loop_execution #{}", loop_execution_id);
+                return;
+            }
+        };
+
+        // 3. 加载 steps 以确定从哪个索引继续
+        let all_steps = match self.ctx.db.list_enabled_loop_steps_by_loop(loop_exec.loop_id).await {
+            Ok(steps) => steps,
+            Err(e) => {
+                warn!("resume: failed to load steps: {}", e);
+                return;
+            }
+        };
+
+        // 4. 找到被审批环节对应的 step，确定 gate_passed 和下一步索引
+        let step_id_to_idx: HashMap<i64, usize> = all_steps
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (s.id, i))
+            .collect();
+
+        let step_idx = match step_id_to_idx.get(&approved.step_id) {
+            Some(&idx) => idx,
+            None => {
+                warn!("resume: step #{} not found in current steps", approved.step_id);
+                return;
+            }
+        };
+
+        // 5. 根据审批评分和阈值决定下一步
+        let step = &all_steps[step_idx];
+        let rating = approved.rating.unwrap_or(0);
+        let min_rating = approved.min_rating.unwrap_or(0);
+        let gate_passed = rating >= min_rating;
+
+        // 6. 更新计数器（从已有 step_executions 推算）
+        let completed = step_execs.iter().filter(|se| se.status == "success").count() as i32;
+        let failed = step_execs.iter().filter(|se| se.status == "failed").count() as i32;
+        // 总额外步数 = 当前 sequence_index（最大序号即累计执行步数）
+        let _total_executed = step_execs.iter().map(|se| se.sequence_index).max().unwrap_or(0);
+        // 更新 loop_execution 中的计数器
+        let _ = self.ctx.db.increment_loop_execution_counters(
+            loop_execution_id,
+            if gate_passed { 1 } else { 0 },
+            if gate_passed { 0 } else { 1 },
+            0,
+        ).await;
+
+        // 7. 计算下一步索引
+        let next_policy = if gate_passed { &step.on_success } else { &step.on_rating_fail };
+        let next_idx = self.resolve_next(step, next_policy, &step_id_to_idx, step_idx);
+
+        info!(
+            "resume: loop_execution #{} step #{} rating={} min={} gate_passed={} next_idx={:?}",
+            loop_execution_id, approved.step_id, rating, min_rating, gate_passed, next_idx
+        );
+
+        // 8. 从下一步继续执行
+        if let Some(idx) = next_idx {
+            let self_clone = self.clone();
+            tokio::spawn(async move {
+                if let Err(e) = self_clone.run_inner_from(
+                    loop_exec.loop_id,
+                    loop_execution_id,
+                    loop_exec.trigger_type.clone(),
+                    Some(idx),
+                ).await {
+                    error!("resume: loop #{} continue failed: {}", loop_exec.loop_id, e);
+                }
+            });
+        } else {
+            // 没有下一步（end/break），结束 loop execution
+            let final_status = if completed > 0 { "success" } else { "failed" };
+            let _ = self.ctx.db.finish_loop_execution(
+                loop_execution_id, final_status, completed, failed,
+            ).await;
+            info!("resume: loop_execution #{} ended with status {}", loop_execution_id, final_status);
+        }
+    }
+
     /// DAG 执行引擎主循环。
+    /// resume_step_idx: None 表示全新执行，Some(idx) 表示从指定步骤继续（人工审批恢复）。
     async fn run_inner(
-        self: Arc<Self>,
+        self: &Arc<Self>,
         loop_id: i64,
         loop_execution_id: i64,
         trigger_type: String,
+    ) -> Result<(), String> {
+        self.run_inner_from(loop_id, loop_execution_id, trigger_type, None).await
+    }
+
+    /// DAG 执行引擎主循环（支持从指定步骤继续）。
+    /// resume_step_idx: None = 从头开始，Some(idx) = 从该步骤继续。
+    async fn run_inner_from(
+        self: &Arc<Self>,
+        loop_id: i64,
+        loop_execution_id: i64,
+        trigger_type: String,
+        resume_step_idx: Option<usize>,
     ) -> Result<(), String> {
         // 1. 校验 loop 状态
         let loop_ = self
@@ -160,26 +290,52 @@ impl LoopRunner {
             return Ok(());
         }
 
-        // 3. 初始化
-        self.ctx
-            .db
-            .finish_loop_execution(loop_execution_id, "running", 0, 0)
-            .await
-            .map_err(|e| e.to_string())?;
-        self.clear_finished_at(loop_execution_id).await?;
-        self.update_total_steps(loop_execution_id, all_steps.len() as i32)
-            .await?;
+        // 3. 初始化（全新执行）或恢复状态（续跑）
+        let is_resume = resume_step_idx.is_some();
+        if !is_resume {
+            // 全新执行：设置 loop execution 状态
+            self.ctx
+                .db
+                .finish_loop_execution(loop_execution_id, "running", 0, 0)
+                .await
+                .map_err(|e| e.to_string())?;
+            self.clear_finished_at(loop_execution_id).await?;
+            self.update_total_steps(loop_execution_id, all_steps.len() as i32)
+                .await?;
+        }
 
         let limits: LimitsConfig = serde_json::from_str(&loop_.limits_config).unwrap_or_default();
         let max_executions = limits.max_step_executions.unwrap_or(i32::MAX);
         let max_total_tokens = limits.max_total_tokens.unwrap_or(i64::MAX);
 
-        let mut current_idx: Option<usize> = Some(0);
-        let mut sequence_counter = 0i32;
-        let mut total_executed = 0i32;
+        // 恢复模式下从已有记录推算状态计数器
+        let (prev_completed, prev_failed, prev_total_executed, prev_max_sequence, prev_last_output, prev_last_conclusion, prev_last_step_name) =
+            if is_resume {
+                let execs = self.ctx.db.list_loop_step_executions(loop_execution_id).await
+                    .unwrap_or_default();
+                let completed = execs.iter().filter(|se| se.status == "success").count() as i32;
+                let failed = execs.iter().filter(|se| se.status == "failed").count() as i32;
+                let total_exec = execs.iter().map(|se| se.sequence_index).max().unwrap_or(0);
+                let max_seq = execs.iter().map(|se| se.sequence_index).max().unwrap_or(0);
+                // 找最后完成的 step 用于模板变量
+                let last_success = execs.iter()
+                    .filter(|se| se.status == "success" || se.status == "pending_approval")
+                    .max_by_key(|se| se.sequence_index);
+                let last_conclusion = last_success.and_then(|se| se.conclusion.clone());
+                let last_step_name = last_success.and_then(|se| {
+                    all_steps.iter().find(|s| s.id == se.step_id).map(|s| s.name.clone())
+                });
+                (completed, failed, total_exec, max_seq, None, last_conclusion, last_step_name)
+            } else {
+                (0, 0, 0, 0, None, None, None)
+            };
+
+        let mut current_idx: Option<usize> = resume_step_idx.or(Some(0));
+        let mut sequence_counter = if is_resume { prev_max_sequence } else { 0 };
+        let mut total_executed = prev_total_executed;
         let mut total_tokens_used: i64 = 0;
-        let mut completed: i32 = 0;
-        let mut failed: i32 = 0;
+        let mut completed = prev_completed;
+        let mut failed = prev_failed;
         let mut consecutive_retries: HashMap<i64, i32> = HashMap::new();
 
         let step_id_to_idx: HashMap<i64, usize> = all_steps
@@ -189,9 +345,9 @@ impl LoopRunner {
             .collect();
 
         // 上一环节的执行结果（用于注入模板变量）
-        let mut last_output: Option<String> = None;
-        let mut last_conclusion: Option<String> = None;
-        let mut last_step_name: Option<String> = None;
+        let mut last_output: Option<String> = prev_last_output;
+        let mut last_conclusion: Option<String> = prev_last_conclusion;
+        let mut last_step_name: Option<String> = prev_last_step_name;
 
         // 4. 主循环
         while let Some(idx) = current_idx {
@@ -315,6 +471,24 @@ impl LoopRunner {
 
             // 4h. 评分闸门
             let (gate_passed, step_rating) = if step_status == "success" && step.min_rating.is_some() {
+                // 人工审批类型：暂停等待，不自动评审
+                // 提取结论后写回 pending_approval 状态，然后退出主循环。
+                if step.review_type == "human" {
+                    let conclusion = self.extract_conclusion(record_id).await;
+                    self.ctx
+                        .db
+                        .finish_step_execution(
+                            step_exec.id, "pending_approval", Some(record_id), None, None, Some(&conclusion),
+                        )
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    // 标记审批状态为等待中
+                    let _ = self.ctx.db.set_step_execution_approval_status(step_exec.id, "pending").await;
+                    info!("loop #{} step #{} waiting for human approval", loop_id, step.id);
+                    // 暂停循环（不写最终状态，loop execution 保持 running）
+                    return Ok(());
+                }
+                // AI 自动评审：原有逻辑
                 self
                     .apply_rating_gate(
                         record_id,
@@ -452,73 +626,42 @@ impl LoopRunner {
             .ok_or_else(|| "executor returned no record_id".to_string())
     }
 
-    /// 订阅 broadcast 等待指定 record_id 的 Finished 事件。
+    /// 轮询数据库确认指定 record_id 的执行记录是否进入终态。
     /// timeout 24h 防止长跑任务永久挂住 loop。
+    ///
+    /// 改用轮询而非 broadcast 的原因：broadcast 的 Finished 事件不带 record_id，
+    /// 多 loop 并发时会错误收到其他 loop 的 Finished 事件，导致提前返回错误状态。
+    /// 原注释已承认"多 loop 并发时会有歧义；首版接受这个限制"，此处修复该问题。
     async fn wait_for_step_finish(&self, record_id: i64) -> Result<String, String> {
-        let mut rx = self.tx.subscribe();
         let wait_timeout = Duration::from_secs(24 * 60 * 60);
-        let result = timeout(wait_timeout, async {
-            loop {
-                match rx.recv().await {
-                    Ok(crate::handlers::ExecEvent::Finished {
-                        task_id: _,
-                        todo_id: _,
-                        todo_title: _,
-                        executor: _,
-                        success,
-                        result: _,
-                        feishu_bot_id: _,
-                        feishu_receive_id: _,
-                    }) => {
-                        // Finished 不带 record_id,需要靠 todo 状态二次查询确认
-                        // 这里简化为: 任意 Finished 事件都先接住,再用 record_id 反查
-                        // 但实际是 broadcast 只发 task_id 不发 record_id;
-                        // 所以我们用 fallback: 任意 Finished 来就直接退出,
-                        // 因为 loop 是顺序的,这时只有当前 step 在跑。
-                        // （多 loop 并发时会有歧义；首版接受这个限制,后期可扩展 event 加 record_id）
-                        return if success {
-                            Ok(ExecutionStatus::Success.as_str().to_string())
-                        } else {
-                            Ok(ExecutionStatus::Failed.as_str().to_string())
-                        };
-                    }
-                    Ok(crate::handlers::ExecEvent::Started { .. })
-                    | Ok(crate::handlers::ExecEvent::Output { .. })
-                    | Ok(crate::handlers::ExecEvent::TodoProgress { .. })
-                    | Ok(crate::handlers::ExecEvent::ExecutionStats { .. })
-                    | Ok(crate::handlers::ExecEvent::ReviewStatusChanged { .. })
-                    | Ok(crate::handlers::ExecEvent::Sync { .. }) => continue,
-                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
-                    Err(broadcast::error::RecvError::Closed) => {
-                        return Err("broadcast channel closed".to_string());
-                    }
-                }
-            }
-        })
-        .await;
+        let poll_interval = Duration::from_millis(500);
+        let start = std::time::Instant::now();
 
-        match result {
-            Ok(inner) => {
-                // inner 是 broadcast waiter 返回的 Result<String,String>
-                // 二次确认: 用 record_id 反查 execution_records 拿到实际 status
-                match inner {
-                    Ok(broadcast_status) => match self
-                        .ctx
-                        .db
-                        .get_execution_record(record_id)
-                        .await
-                    {
-                        Ok(Some(rec)) => Ok(rec.status.to_string()),
-                        Ok(None) => Ok(broadcast_status),
-                        Err(_) => Ok(broadcast_status),
-                    },
-                    Err(e) => Err(e),
+        loop {
+            if start.elapsed() > wait_timeout {
+                return Err(format!(
+                    "step execution (record #{}) timeout after 24h",
+                    record_id
+                ));
+            }
+
+            // 按 record_id 精确查询执行记录状态，避免 broadcast 竞态
+            match self.ctx.db.get_execution_record(record_id).await {
+                Ok(Some(rec)) => {
+                    let status_str = rec.status.to_string();
+                    if !matches!(rec.status, ExecutionStatus::Running) {
+                        return Ok(status_str);
+                    }
+                }
+                Ok(None) => {
+                    // 记录尚未创建（执行尚未开始或尚未提交），继续等待
+                }
+                Err(e) => {
+                    warn!("wait_for_step_finish: get_execution_record #{} error: {}", record_id, e);
                 }
             }
-            Err(_) => Err(format!(
-                "step execution (record #{}) timeout after 24h",
-                record_id
-            )),
+
+            tokio::time::sleep(poll_interval).await;
         }
     }
 

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -482,8 +482,11 @@ impl LoopRunner {
                         )
                         .await
                         .map_err(|e| e.to_string())?;
-                    // 标记审批状态为等待中
-                    let _ = self.ctx.db.set_step_execution_approval_status(step_exec.id, "pending").await;
+                    // 标记审批状态为等待中；失败仅记录日志，不中断 loop 暂停流程，
+                    // 因为 step_execution 已经写为 pending_approval 状态，前端可继续操作。
+                    if let Err(e) = self.ctx.db.set_step_execution_approval_status(step_exec.id, "pending").await {
+                        warn!("loop #{} step #{}: failed to set approval_status to pending: {}", loop_id, step.id, e);
+                    }
                     info!("loop #{} step #{} waiting for human approval", loop_id, step.id);
                     // 暂停循环（不写最终状态，loop execution 保持 running）
                     return Ok(());
@@ -636,6 +639,10 @@ impl LoopRunner {
         let wait_timeout = Duration::from_secs(24 * 60 * 60);
         let poll_interval = Duration::from_millis(500);
         let start = std::time::Instant::now();
+        // 连续错误计数器：防止数据库持续异常导致无限轮询；
+        // 单次成功查询或查询返回 None（记录尚未创建）时重置计数。
+        let mut consecutive_errors = 0;
+        let max_consecutive_errors = 5;
 
         loop {
             if start.elapsed() > wait_timeout {
@@ -648,16 +655,29 @@ impl LoopRunner {
             // 按 record_id 精确查询执行记录状态，避免 broadcast 竞态
             match self.ctx.db.get_execution_record(record_id).await {
                 Ok(Some(rec)) => {
+                    // 成功获取记录，重置错误计数
+                    consecutive_errors = 0;
                     let status_str = rec.status.to_string();
                     if !matches!(rec.status, ExecutionStatus::Running) {
                         return Ok(status_str);
                     }
                 }
                 Ok(None) => {
-                    // 记录尚未创建（执行尚未开始或尚未提交），继续等待
+                    // 记录尚未创建（执行尚未开始或尚未提交），继续等待；
+                    // 这是合法状态，重置错误计数。
+                    consecutive_errors = 0;
                 }
                 Err(e) => {
-                    warn!("wait_for_step_finish: get_execution_record #{} error: {}", record_id, e);
+                    consecutive_errors += 1;
+                    warn!("wait_for_step_finish: get_execution_record #{} error (consecutive: {}/{}): {}",
+                          record_id, consecutive_errors, max_consecutive_errors, e);
+                    // 达到连续错误阈值时停止轮询，防止数据库故障导致 loop 永久挂起
+                    if consecutive_errors >= max_consecutive_errors {
+                        return Err(format!(
+                            "step execution (record #{}) aborted after {} consecutive DB errors",
+                            record_id, max_consecutive_errors
+                        ));
+                    }
                 }
             }
 

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -488,6 +488,12 @@ impl LoopRunner {
                         warn!("loop #{} step #{}: failed to set approval_status to pending: {}", loop_id, step.id, e);
                     }
                     info!("loop #{} step #{} waiting for human approval", loop_id, step.id);
+                    // 发送 WebSocket 事件触发前端刷新（让执行历史列表显示"待审批"标记）
+                    let _ = self.tx.send(crate::handlers::ExecEvent::ReviewStatusChanged {
+                        record_id,
+                        todo_id: 0,
+                        review_status: "pending_approval".to_string(),
+                    });
                     // 暂停循环（不写最终状态，loop execution 保持 running）
                     return Ok(());
                 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2257,6 +2257,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2266,7 +2267,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -20,6 +20,7 @@ import {
   DeleteOutlined,
   EditOutlined,
   PlusOutlined,
+  ExclamationCircleOutlined,
 } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
 import * as dbReviewTemplates from '@/utils/database/reviewTemplates';
@@ -305,6 +306,21 @@ export function LoopDetailPanel({
               );
             })() : <EmptyValue />
           } />
+          {/* 待人工审批提示 */}
+          {detail.pending_approval_count > 0 && (
+            <DetailField label="待审批" value={
+              <span style={{
+                display: 'inline-flex', alignItems: 'center', gap: 4,
+                padding: '2px 10px', borderRadius: 12,
+                background: 'var(--color-error-bg, #fef2f2)',
+                color: 'var(--color-error, #ef4444)',
+                fontWeight: 700, fontSize: 14,
+              }}>
+                <ExclamationCircleOutlined />
+                {detail.pending_approval_count} 条待审批
+              </span>
+            } />
+          )}
         </div>
       </DetailSection>
 

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -402,7 +402,7 @@ export function LoopDetailPanel({
         />
       </div>
 
-      {/* 折叠区: 执行历史, 默认收起 */}
+      {/* 折叠区: 执行历史 */}
       <div style={{
         background: 'var(--color-bg-elevated, #ffffff)',
         border: '1px solid var(--color-border, #e2e8f0)',
@@ -413,7 +413,7 @@ export function LoopDetailPanel({
         <Collapse
           ghost
           expandIconPosition="end"
-          defaultActiveKey={[]}
+          defaultActiveKey={['executions']}
           items={[
             {
               key: 'executions',

--- a/frontend/src/components/LoopStudioExecutionsPanel.tsx
+++ b/frontend/src/components/LoopStudioExecutionsPanel.tsx
@@ -13,7 +13,6 @@ import {
   CloseCircleOutlined,
   LoadingOutlined,
   MinusCircleOutlined,
-  StarOutlined,
   ArrowRightOutlined,
   ReadOutlined,
   ExclamationCircleOutlined,
@@ -557,71 +556,29 @@ function StepExecList({ stepExecs, loopId, executionId, onApproved }: { stepExec
               </div>
 
               {/* 评分 / 阈值 */}
-              <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap', marginBottom: 4 }}>
-                {s.rating != null ? (
-                  <span style={{
-                    display: 'inline-flex', alignItems: 'center', gap: 2,
-                    padding: '1px 6px', borderRadius: 4, fontSize: 12,
-                    background: ratingPassed ? 'var(--color-success-bg, #f0fdf4)' : 'var(--color-error-bg, #fef2f2)',
-                    color: ratingPassed ? 'var(--color-success, #22c55e)' : 'var(--color-error, #ef4444)',
-                    fontWeight: 600,
-                  }}>
-                    <StarOutlined style={{ fontSize: 10 }} /> {s.rating}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', marginBottom: 4 }}>
+                {s.min_rating != null && (
+                  <span style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+                    阈值 {s.min_rating}
                   </span>
+                )}
+                {s.rating != null ? (
+                  <>
+                    <span style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
+                      评分 {s.rating}
+                    </span>
+                    <span style={{
+                      padding: '1px 6px', borderRadius: 4, fontSize: 11, fontWeight: 600,
+                      background: ratingPassed ? 'var(--color-success-bg, #f0fdf4)' : 'var(--color-error-bg, #fef2f2)',
+                      color: ratingPassed ? 'var(--color-success, #22c55e)' : 'var(--color-error, #ef4444)',
+                    }}>
+                      {ratingPassed ? '通过' : '不通过'}
+                    </span>
+                  </>
                 ) : (
                   <span style={{ fontSize: 11, color: 'var(--color-text-tertiary, #94a3b8)' }}>未评审</span>
                 )}
-                {s.min_rating != null && (
-                  <span style={{ fontSize: 11, color: s.rating != null && s.rating >= s.min_rating ? 'var(--color-success, #22c55e)' : 'var(--color-error, #ef4444)' }}>
-                    {s.rating != null && (s.rating >= s.min_rating ? '✅' : '❌')} {s.min_rating}
-                  </span>
-                )}
               </div>
-
-              {/* Token 消耗：从 execution_record.usage 解析 */}
-              {(s.input_tokens != null || s.output_tokens != null) && (
-                <div style={{
-                  display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap',
-                  marginTop: 4, marginBottom: 4,
-                }}>
-                  {s.input_tokens != null && (
-                    <span style={{
-                      padding: '1px 5px', borderRadius: 3,
-                      background: 'var(--color-info-bg)', fontSize: 10, color: 'var(--color-info)',
-                      fontWeight: 500, fontFamily: 'monospace',
-                    }}>
-                      i{formatToken(s.input_tokens)}
-                    </span>
-                  )}
-                  {s.output_tokens != null && (
-                    <span style={{
-                      padding: '1px 5px', borderRadius: 3,
-                      background: 'var(--color-success-bg)', fontSize: 10, color: 'var(--color-success)',
-                      fontWeight: 500, fontFamily: 'monospace',
-                    }}>
-                      o{formatToken(s.output_tokens)}
-                    </span>
-                  )}
-                  {s.cache_read_input_tokens != null && s.cache_read_input_tokens > 0 && (
-                    <span style={{
-                      padding: '1px 5px', borderRadius: 3,
-                      background: 'var(--color-info-bg)', fontSize: 10, color: 'var(--color-primary)',
-                      fontWeight: 500, fontFamily: 'monospace',
-                    }}>
-                      cr{formatToken(s.cache_read_input_tokens)}
-                    </span>
-                  )}
-                  {s.total_cost_usd != null && s.total_cost_usd > 0 && (
-                    <span style={{
-                      padding: '1px 5px', borderRadius: 3,
-                      background: 'var(--color-warning-bg)', fontSize: 10, color: 'var(--color-warning)',
-                      fontWeight: 500, fontFamily: 'monospace',
-                    }}>
-                      {formatCost(s.total_cost_usd)}
-                    </span>
-                  )}
-                </div>
-              )}
 
               {/* 结论（黑板） */}
               {s.conclusion && (
@@ -643,6 +600,24 @@ function StepExecList({ stepExecs, loopId, executionId, onApproved }: { stepExec
                 开始 {s.started_at ? new Date(s.started_at).toLocaleTimeString() : '-'}
                 · 结束 {s.finished_at ? new Date(s.finished_at).toLocaleTimeString() : '-'}
               </div>
+
+              {/* Token 消耗 */}
+              {(s.input_tokens != null || s.output_tokens != null) && (
+                <div style={{
+                  display: 'flex', flexWrap: 'wrap', gap: 4,
+                  marginTop: 4, fontSize: 10, color: 'var(--color-text-tertiary)',
+                }}>
+                  {s.input_tokens != null && (
+                    <span>输入 {formatToken(s.input_tokens)}</span>
+                  )}
+                  {s.output_tokens != null && (
+                    <span>输出 {formatToken(s.output_tokens)}</span>
+                  )}
+                  {s.cache_read_input_tokens != null && s.cache_read_input_tokens > 0 && (
+                    <span>缓存读 {formatToken(s.cache_read_input_tokens)}</span>
+                  )}
+                </div>
+              )}
 
               {/* 错误 */}
               {s.error_message && (

--- a/frontend/src/components/LoopStudioExecutionsPanel.tsx
+++ b/frontend/src/components/LoopStudioExecutionsPanel.tsx
@@ -267,9 +267,6 @@ export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange
                     <span style={{ fontWeight: 600, fontSize: 14 }}>#{e.id}</span>
                     <Tag color={view.color}>{view.label}</Tag>
                     <Tag>{e.trigger_type}</Tag>
-                    {e.failed_steps > 0 && (
-                      <Tag color="red">{e.failed_steps} 失败</Tag>
-                    )}
                     {e.pending_approval_count > 0 && (
                       <Tag color="red" style={{ fontWeight: 600 }}>
                         <ExclamationCircleOutlined /> {e.pending_approval_count} 待审批

--- a/frontend/src/components/LoopStudioExecutionsPanel.tsx
+++ b/frontend/src/components/LoopStudioExecutionsPanel.tsx
@@ -482,6 +482,10 @@ function StepExecList({ stepExecs, loopId, executionId, onApproved }: { stepExec
       const { approveStepExecution } = await import('@/utils/database/loops');
       await approveStepExecution(loopId, executionId, stepExecutionId, approveRating, approveComment || undefined);
       message.success('审批已提交');
+      // 重置审批表单状态为初始值，防止下一张待审卡片复用上次的评分与备注；
+      // 70 分是默认通过评分，空字符串确保备注框干净。
+      setApproveRating(70);
+      setApproveComment('');
       onApproved();
     } catch (e: any) {
       message.error(e?.message || '审批失败');

--- a/frontend/src/components/LoopStudioExecutionsPanel.tsx
+++ b/frontend/src/components/LoopStudioExecutionsPanel.tsx
@@ -16,6 +16,7 @@ import {
   StarOutlined,
   ArrowRightOutlined,
   ReadOutlined,
+  ExclamationCircleOutlined,
 } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
 import type { LoopExecutionDto, LoopExecutionDetail, LoopExecutionTokenSummary } from '@/types/loop';
@@ -43,6 +44,7 @@ function execStatusView(status: string): { color: string; icon: React.ReactNode;
     case 'capped':
     case 'capped_step': return { color: 'gold', icon: <MinusCircleOutlined />, label: '步数超限' };
     case 'capped_token': return { color: 'purple', icon: <MinusCircleOutlined />, label: 'Token 超限' };
+    case 'pending_approval': return { color: 'orange', icon: <ExclamationCircleOutlined />, label: '等待审批' };
     default: return { color: 'default', icon: <MinusCircleOutlined />, label: status };
   }
 }
@@ -308,7 +310,7 @@ export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange
                         {expandedDetail.token_summary && (
                           <TokenSummaryBar summary={expandedDetail.token_summary} />
                         )}
-                        <StepExecList stepExecs={expandedDetail.step_executions} />
+                        <StepExecList stepExecs={expandedDetail.step_executions} loopId={loopId} executionId={expandedDetail.id} onApproved={() => loadPage(page)} />
                       </>
                     ) : null}
                   </div>
@@ -450,9 +452,14 @@ function BlackboardDrawer({ open, stepExecs, onClose }: {
 }
 
 // 环节执行卡片：卡片式布局 + 箭头连接展示执行顺序，每张卡展示执行详情
-function StepExecList({ stepExecs }: { stepExecs: Record<string, any>[] }) {
+function StepExecList({ stepExecs, loopId, executionId, onApproved }: { stepExecs: Record<string, any>[]; loopId: number; executionId: number; onApproved: () => void }) {
+  const { message } = AntApp.useApp();
   const [drawerRecord, setDrawerRecord] = useState<any | null>(null);
   const [drawerLoading, setDrawerLoading] = useState(false);
+  // 人工审批状态
+  const [approvingId, setApprovingId] = useState<number | null>(null);
+  const [approveRating, setApproveRating] = useState<number>(70);
+  const [approveComment, setApproveComment] = useState<string>('');
 
   const handleCardClick = useCallback(async (s: any) => {
     if (!s.execution_record_id) return;
@@ -467,6 +474,21 @@ function StepExecList({ stepExecs }: { stepExecs: Record<string, any>[] }) {
       setDrawerLoading(false);
     }
   }, []);
+
+  // 人工审批提交
+  const handleApprove = useCallback(async (stepExecutionId: number) => {
+    setApprovingId(stepExecutionId);
+    try {
+      const { approveStepExecution } = await import('@/utils/database/loops');
+      await approveStepExecution(loopId, executionId, stepExecutionId, approveRating, approveComment || undefined);
+      message.success('审批已提交');
+      onApproved();
+    } catch (e: any) {
+      message.error(e?.message || '审批失败');
+    } finally {
+      setApprovingId(null);
+    }
+  }, [loopId, executionId, approveRating, approveComment, message, onApproved]);
 
   if (stepExecs.length === 0) {
     return <Empty description="无环节执行记录" />;
@@ -620,6 +642,60 @@ function StepExecList({ stepExecs }: { stepExecs: Record<string, any>[] }) {
               {s.error_message && (
                 <div style={{ marginTop: 4, fontSize: 11, color: 'var(--color-error, #ef4444)', lineHeight: 1.4 }}>
                   {s.error_message}
+                </div>
+              )}
+
+              {/* 人工审批操作区域：pending_approval 状态时显示 */}
+              {s.status === 'pending_approval' && (
+                <div
+                  onClick={(e) => e.stopPropagation()}
+                  style={{
+                    marginTop: 8,
+                    padding: '8px 10px',
+                    background: 'var(--color-warning-bg, #fffbeb)',
+                    border: '1px solid var(--color-warning, #f59e0b)',
+                    borderRadius: 8,
+                  }}
+                >
+                  <div style={{ fontSize: 11, fontWeight: 600, color: 'var(--color-warning, #f59e0b)', marginBottom: 6 }}>
+                    ⏳ 等待人工审批
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6, flexWrap: 'wrap' }}>
+                    <span style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>评分</span>
+                    <input
+                      type="range"
+                      min={0}
+                      max={100}
+                      value={approveRating}
+                      onChange={(e) => setApproveRating(Number(e.target.value))}
+                      style={{ flex: 1, minWidth: 60 }}
+                    />
+                    <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-text)', minWidth: 24, textAlign: 'right' }}>
+                      {approveRating}
+                    </span>
+                  </div>
+                  <input
+                    type="text"
+                    placeholder="审批意见（可选）"
+                    value={approveComment}
+                    onChange={(e) => setApproveComment(e.target.value)}
+                    style={{
+                      width: '100%', padding: '3px 6px', fontSize: 11,
+                      borderRadius: 4, border: '1px solid var(--color-border, #e2e8f0)',
+                      background: 'var(--color-bg-elevated, #fff)',
+                      color: 'var(--color-text)',
+                      marginBottom: 6, boxSizing: 'border-box',
+                    }}
+                  />
+                  <Button
+                    size="small"
+                    type="primary"
+                    loading={approvingId === s.id}
+                    onClick={() => handleApprove(s.id)}
+                    style={{ width: '100%', fontSize: 11 }}
+                  >
+                    提交审批
+                  </Button>
                 </div>
               )}
             </div>

--- a/frontend/src/components/LoopStudioExecutionsPanel.tsx
+++ b/frontend/src/components/LoopStudioExecutionsPanel.tsx
@@ -270,6 +270,11 @@ export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange
                     {e.failed_steps > 0 && (
                       <Tag color="red">{e.failed_steps} 失败</Tag>
                     )}
+                    {e.pending_approval_count > 0 && (
+                      <Tag color="red" style={{ fontWeight: 600 }}>
+                        <ExclamationCircleOutlined /> {e.pending_approval_count} 待审批
+                      </Tag>
+                    )}
                     <Button
                       size="small"
                       type="text"

--- a/frontend/src/components/LoopStudioListPanel.tsx
+++ b/frontend/src/components/LoopStudioListPanel.tsx
@@ -20,6 +20,7 @@ import {
   CloseCircleOutlined,
   LoadingOutlined,
   MinusCircleOutlined,
+  ExclamationCircleOutlined,
 } from '@ant-design/icons';
 import { formatRelativeTime } from '@/utils/datetime';
 import type { LoopListItem, LoopStatus } from '@/types/loop';
@@ -285,6 +286,17 @@ function LoopCard({ loop, selected, onClick, checked, onToggleCheck, projectDirs
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, fontSize: 11, color: 'var(--color-text-tertiary, #94a3b8)' }}>
         <span><ThunderboltOutlined /> {loop.trigger_count}</span>
         <span><ApartmentOutlined /> {loop.step_count}</span>
+        {loop.pending_approval_count > 0 && (
+          <span style={{
+            display: 'inline-flex', alignItems: 'center', gap: 2,
+            padding: '1px 6px', borderRadius: 8,
+            background: 'var(--color-error-bg, #fef2f2)',
+            color: 'var(--color-error, #ef4444)',
+            fontWeight: 600, fontSize: 11,
+          }}>
+            <ExclamationCircleOutlined style={{ fontSize: 10 }} /> {loop.pending_approval_count}
+          </span>
+        )}
         <span>{executionIcon(loop.last_execution_status)}</span>
         {loop.updated_at && (
           <span style={{ marginLeft: 'auto' }}>

--- a/frontend/src/components/LoopStudioStepsPanel.tsx
+++ b/frontend/src/components/LoopStudioStepsPanel.tsx
@@ -67,6 +67,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
       on_rating_fail: step.on_rating_fail,
       fail_goto_step_id: step.fail_goto_step_id,
       skip_on_source_failed: step.skip_on_source_failed,
+      review_type: step.review_type ?? 'ai',
     });
     setModalOpen(true);
   }, [form]);
@@ -100,6 +101,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
           success_goto_step_id: values.success_goto_step_id ?? null,
           on_rating_fail: values.on_rating_fail ?? 'break',
           fail_goto_step_id: values.fail_goto_step_id ?? null,
+          review_type: values.review_type ?? 'ai',
         });
         message.success('环节已更新');
       } else {
@@ -116,6 +118,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
           success_goto_step_id: values.success_goto_step_id ?? null,
           on_rating_fail: values.on_rating_fail ?? 'break',
           fail_goto_step_id: values.fail_goto_step_id ?? null,
+          review_type: values.review_type ?? 'ai',
         });
         message.success('环节已添加');
       }
@@ -233,7 +236,18 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
           <div style={{ fontWeight: 600, fontSize: 14, marginBottom: 12, color: 'var(--color-warning, #f97316)' }}>
             评分门禁
           </div>
-          <Form.Item label="评分阈值" name="min_rating" tooltip="启用后 AI 自动评分，低于此值视为不通过（0-100，留空=不启用）">
+          <Form.Item
+            label="评审类型"
+            name="review_type"
+            initialValue="ai"
+            tooltip="AI 自动评审：执行完后 AI 自动打分；人工审批：执行完后暂停等待人工打分"
+          >
+            <Select>
+              <Select.Option value="ai">🤖 AI 自动评审</Select.Option>
+              <Select.Option value="human">👤 人工审批</Select.Option>
+            </Select>
+          </Form.Item>
+          <Form.Item label="评分阈值" name="min_rating" tooltip="启用后根据评审类型进行评分，低于此值视为不通过（0-100，留空=不启用）">
             <InputNumber min={0} max={100} placeholder="留空=不启用" style={{ width: '100%' }} />
           </Form.Item>
 

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -66,6 +66,8 @@ export interface LoopExecutionDto {
   completed_steps: number;
   failed_steps: number;
   total_executed_steps: number;
+  /** 待人工审批的环节数 */
+  pending_approval_count: number;
 }
 
 export interface LoopStepExecutionDto {
@@ -211,6 +213,8 @@ export interface LoopDetail {
   triggers: LoopTriggerDto[];
   steps: LoopStepDto[];
   todo_map: Record<number, TodoSummaryForLoop>;
+  /** 待人工审批的环节执行数 */
+  pending_approval_count: number;
 }
 
 export interface LoopListItem {

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -231,6 +231,8 @@ export interface LoopListItem {
   step_count: number;
   last_execution_status: string;
   last_execution_at: string | null;
+  /** 待人工审批的环节执行数 */
+  pending_approval_count: number;
 }
 
 export interface LoopExecutionTokenSummary {

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -26,6 +26,8 @@ export type LoopUnratedPolicy = 'skip' | 'continue';
 export type LoopOnSuccessPolicy = 'next' | 'goto' | 'end';
 export type LoopOnRatingFailPolicy = 'break' | 'skip' | 'goto' | 'end';
 
+export type ReviewType = 'ai' | 'human';
+
 export type LoopExecutionStatus = 'running' | 'success' | 'partial' | 'failed' | 'cancelled' | 'capped_step' | 'capped_token';
 
 export interface LoopDto {
@@ -84,6 +86,10 @@ export interface LoopStepExecutionDto {
   conclusion: string | null;
   /** 该环节消耗的 token（从关联的 execution_record.usage 解析） */
   input_tokens: number | null;
+  /** 人工审批状态: null | 'pending' | 'approved' */
+  approval_status: string | null;
+  /** 审批人的备注/意见 */
+  approval_comment: string | null;
   output_tokens: number | null;
   cache_read_input_tokens: number | null;
   cache_creation_input_tokens: number | null;
@@ -113,6 +119,8 @@ export interface LoopStepRawDto {
   success_goto_step_id: number | null;
   on_rating_fail: string;
   fail_goto_step_id: number | null;
+  /** 评审类型: 'ai' = AI 自动评审, 'human' = 人工审批 */
+  review_type: string;
   enabled: boolean;
   created_at: string | null;
 }
@@ -133,6 +141,8 @@ export interface LoopStepDto {
   success_goto_step_id: number | null;
   on_rating_fail: string;
   fail_goto_step_id: number | null;
+  /** 评审类型: 'ai' = AI 自动评审, 'human' = 人工审批 */
+  review_type: string;
   enabled: boolean;
   created_at: string | null;
   todo_title: string;
@@ -154,6 +164,8 @@ export interface CreateLoopStepRequest {
   success_goto_step_id?: number | null;
   on_rating_fail?: string;
   fail_goto_step_id?: number | null;
+  /** 评审类型: 'ai' | 'human'，默认 'ai' */
+  review_type?: string;
 }
 
 export interface UpdateLoopStepRequest {
@@ -170,6 +182,13 @@ export interface UpdateLoopStepRequest {
   success_goto_step_id: number | null;
   on_rating_fail: string;
   fail_goto_step_id: number | null;
+  /** 评审类型: 'ai' | 'human'，默认 'ai' */
+  review_type?: string;
+}
+
+export interface ApproveStepExecutionRequest {
+  rating: number;
+  comment?: string;
 }
 
 export interface ReorderLoopStepsRequest {

--- a/frontend/src/utils/database/loops.ts
+++ b/frontend/src/utils/database/loops.ts
@@ -157,6 +157,23 @@ export async function getExecution(
   return unwrap(await api.get(`/api/loops/${loopId}/executions/${executionId}`));
 }
 
+/**
+ * 人工审批环节执行。
+ * POST /api/loops/{loopId}/executions/{executionId}/steps/{stepExecutionId}/approve
+ */
+export async function approveStepExecution(
+  loopId: number,
+  executionId: number,
+  stepExecutionId: number,
+  rating: number,
+  comment?: string,
+): Promise<{ step_execution_id: number; rating: number; status: string }> {
+  return unwrap(await api.post(
+    `/api/loops/${loopId}/executions/${executionId}/steps/${stepExecutionId}/approve`,
+    { rating, comment },
+  ));
+}
+
 // ─── 批量操作（占位实现） ────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary
- 新增 `review_type` 属性，支持 "ai"（AI 自动评审）和 "human"（人工审批）两种模式
- 人工审批模式下，环节执行完成后暂停等待人工打分，按相同的评分门禁逻辑继续流程
- 修复 `wait_for_step_finish` 多 loop 并发时 broadcast 事件串扰导致步骤错误标记为 failed 的问题

## 变更文件
| 层 | 文件 | 改动 |
|---|------|------|
| DB | `migration.rs` | V18 迁移: loop_steps 加 review_type，loop_step_executions 加 approval_status/approval_comment |
| 后端 | `entity/loop_steps.rs`, `entity/loop_step_executions.rs` | 实体新增字段 |
| 后端 | `models/loop_.rs` | DTO/Request 新增对应字段 |
| 后端 | `db/loop_.rs` | DAO 新增 approve_step_execution 等方法 |
| 后端 | `handlers/loop_.rs` | 新增 POST /api/loops/{id}/executions/{eid}/steps/{seid}/approve |
| 后端 | `services/loop_runner.rs` | 暂停/恢复机制，wait_for_step_finish 改为 DB 轮询 |
| 前端 | `types/loop.ts`, `utils/database/loops.ts` | 类型和 API 客户端 |
| 前端 | `LoopStudioStepsPanel.tsx` | 环节编辑增加评审类型选择器 |
| 前端 | `LoopStudioExecutionsPanel.tsx` | 执行历史增加人工审批入口 |

## Test plan
- [ ] 创建 loop，环节设置 review_type="human" + min_rating=80，触发执行，验证环节变为"等待审批"状态
- [ ] 在执行历史中打分并提交审批，验证评分生效且 loop 继续执行
- [ ] 多 loop 并发执行，验证不再出现步骤错误标记为 failed
- [ ] review_type="ai"（默认）的现有 loop 行为不受影响

🤖 Generated with [CodeBuddy Code]