### PR TITLE
refactor: 环路详情头部按钮改为纯图标 + 汉字 tooltip

### DIFF
--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -235,22 +235,26 @@ export function LoopDetailPanel({
               icon={<ThunderboltOutlined />}
               onClick={onTrigger}
               disabled={detail.status !== 'enabled'}
-            >
-              触发
-            </Button>
+            />
           </Tooltip>
           <Tooltip title="复制">
             <Button size="small" icon={<CopyOutlined />} onClick={onDuplicate} />
           </Tooltip>
-          <Button size="small" icon={<EditOutlined />} onClick={handleOpenEdit}>编辑</Button>
-          <Button size="small" icon={<PlusOutlined />} onClick={onCreate}>新建</Button>
+          <Tooltip title="编辑">
+            <Button size="small" icon={<EditOutlined />} onClick={handleOpenEdit} />
+          </Tooltip>
+          <Tooltip title="新建">
+            <Button size="small" icon={<PlusOutlined />} onClick={onCreate} />
+          </Tooltip>
           <Popconfirm
             title="删除 loop"
             description="将级联删除 triggers/steps,无法恢复"
             okType="danger"
             onConfirm={onDelete}
           >
-            <Button size="small" danger icon={<DeleteOutlined />} />
+            <Tooltip title="删除">
+              <Button size="small" danger icon={<DeleteOutlined />} />
+            </Tooltip>
           </Popconfirm>
         </Space>
       </div>


### PR DESCRIPTION
将环路右上角的「触发」「编辑」「新建」「删除」按钮由图标+文字改为纯图标，鼠标悬停时通过 Tooltip 显示中文提示。

改动：
- 触发：去掉子文本，保留已有 Tooltip
- 复制：已有纯图标+Tooltip，无变化
- 编辑：增加 Tooltip 包裹，去掉子文本
- 新建：增加 Tooltip 包裹，去掉子文本
- 删除：在 Popconfirm 内增加 Tooltip 包裹，去掉子文本