### PR TITLE
feat(loop-kanban): 优化环路看板，新增 Token 展示、环节设计图、黑板按钮，移除重复搜索栏

### DIFF
--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -11,7 +11,7 @@
 //! 不抽象 DAO trait，因为 codebase 其它 db 文件都这样做）。
 use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect,
-    Set, DbBackend, ConnectionTrait, Statement,
+    Set, DbBackend,
 };
 use std::collections::HashMap;
 

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -525,9 +525,19 @@ pub async fn list_executions(
     let exec_ids: Vec<i64> = records.iter().map(|r| r.id).collect();
     let pending_counts = state.db.count_pending_approvals_by_execution_ids(&exec_ids).await?;
     let mut items: Vec<LoopExecutionDto> = records.into_iter().map(Into::into).collect();
-    // 填充 pending_approval_count
+    // 填充 pending_approval_count 和 token_summary
     for item in &mut items {
         item.pending_approval_count = pending_counts.get(&item.id).copied().unwrap_or(0);
+        // 加载 step_executions 并聚合 Token 消耗汇总
+        let step_execs = state.db.list_loop_step_executions(item.id).await.unwrap_or_default();
+        let mut enriched: Vec<LoopStepExecutionDto> = step_execs.into_iter().map(|se| {
+            se.into()
+        }).collect();
+        // 同步 enrich token usage（从 DB 读取 usage JSON 填充到 DTO）
+        for dto in &mut enriched {
+            enrich_step_execution_with_usage(&state.db, dto).await;
+        }
+        item.token_summary = Some(aggregate_step_execution_tokens(&state.db, &enriched).await);
     }
     Ok(ApiResponse::ok(serde_json::json!({
         "items": items,

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -529,15 +529,16 @@ pub async fn list_executions(
     for item in &mut items {
         item.pending_approval_count = pending_counts.get(&item.id).copied().unwrap_or(0);
         // 加载 step_executions 并聚合 Token 消耗汇总
-        let step_execs = state.db.list_loop_step_executions(item.id).await.unwrap_or_default();
+        let step_execs = state.db.list_loop_step_executions(item.id).await?;
         let mut enriched: Vec<LoopStepExecutionDto> = step_execs.into_iter().map(|se| {
             se.into()
         }).collect();
-        // 同步 enrich token usage（从 DB 读取 usage JSON 填充到 DTO）
+        // 从 execution_record.usage 填充 token 字段到 DTO
         for dto in &mut enriched {
             enrich_step_execution_with_usage(&state.db, dto).await;
         }
-        item.token_summary = Some(aggregate_step_execution_tokens(&state.db, &enriched).await);
+        // 直接从已 enrich 的 DTO 字段聚合，避免重复查询数据库
+        item.token_summary = Some(aggregate_tokens_from_step_dtos(&enriched));
     }
     Ok(ApiResponse::ok(serde_json::json!({
         "items": items,
@@ -575,39 +576,30 @@ async fn enrich_step_execution_with_usage(
     dto.total_cost_usd = usage.total_cost_usd;
 }
 
-/// 遍历 step_executions，从每个环节关联的 execution_record.usage 聚合出总 Token 用量。
-async fn aggregate_step_execution_tokens(
-    db: &crate::db::Database,
-    step_execs: &[LoopStepExecutionDto],
-) -> LoopExecutionTokenSummary {
+/// 从已 enrich 的 LoopStepExecutionDto 字段直接聚合 Token 消耗汇总，
+/// 不再重复查询数据库（原有的 aggregate_step_execution_tokens 存在 N+1 问题）。
+/// 前置条件：调用方必须先通过 enrich_step_execution_with_usage 填充 DTO token 字段。
+fn aggregate_tokens_from_step_dtos(step_execs: &[LoopStepExecutionDto]) -> LoopExecutionTokenSummary {
     let mut total_input_tokens: i64 = 0;
     let mut total_output_tokens: i64 = 0;
     let mut total_cache_read_input_tokens: i64 = 0;
     let mut total_cache_creation_input_tokens: i64 = 0;
     let mut total_cost_usd: f64 = 0.0;
     for se in step_execs {
-        let record_id = match se.execution_record_id {
-            Some(id) => id,
-            None => continue,
-        };
-        let record = match db.get_execution_record(record_id).await {
-            Ok(Some(r)) => r,
-            _ => continue,
-        };
-        let usage = match record.usage {
-            Some(u) => u,
-            None => continue,
-        };
-        total_input_tokens += usage.input_tokens as i64;
-        total_output_tokens += usage.output_tokens as i64;
-        if let Some(cr) = usage.cache_read_input_tokens {
-            total_cache_read_input_tokens += cr as i64;
+        if let Some(v) = se.input_tokens {
+            total_input_tokens += v;
         }
-        if let Some(cc) = usage.cache_creation_input_tokens {
-            total_cache_creation_input_tokens += cc as i64;
+        if let Some(v) = se.output_tokens {
+            total_output_tokens += v;
         }
-        if let Some(cost) = usage.total_cost_usd {
-            total_cost_usd += cost;
+        if let Some(v) = se.cache_read_input_tokens {
+            total_cache_read_input_tokens += v;
+        }
+        if let Some(v) = se.cache_creation_input_tokens {
+            total_cache_creation_input_tokens += v;
+        }
+        if let Some(v) = se.total_cost_usd {
+            total_cost_usd += v;
         }
     }
     LoopExecutionTokenSummary {
@@ -655,8 +647,8 @@ pub async fn get_execution(
         enrich_step_execution_with_usage(&state.db, &mut dto).await;
         enriched.push(dto);
     }
-    // 聚合 token 汇总
-    let token_summary = aggregate_step_execution_tokens(&state.db, &enriched).await;
+    // 聚合 token 汇总：直接从已 enrich 的 DTO 字段聚合，避免重复查询数据库
+    let token_summary = aggregate_tokens_from_step_dtos(&enriched);
     Ok(ApiResponse::ok(LoopExecutionDetail {
         execution: exec.into(),
         step_executions: enriched,

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -230,6 +230,10 @@ pub struct LoopExecutionDto {
     /// 待人工审批的环节数（approval_status='pending' 的 loop_step_executions 数量）
     #[serde(default)]
     pub pending_approval_count: i32,
+    /// 该次执行的 Token 消耗汇总（从 step_executions 的 usage 聚合计算）
+    /// 仅在 list_executions 响应中由 handler 填充，从 Model 转换时默认为空。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_summary: Option<LoopExecutionTokenSummary>,
 }
 
 impl From<loop_executions::Model> for LoopExecutionDto {
@@ -247,6 +251,7 @@ impl From<loop_executions::Model> for LoopExecutionDto {
             completed_steps: m.completed_steps,
             failed_steps: m.failed_steps,
             pending_approval_count: 0, // 由 handler 后续查询填充
+            token_summary: None,       // 由 handler 后续加载 step_executions 后聚合填充
         }
     }
 }

--- a/frontend/src/components/LoopKanban.tsx
+++ b/frontend/src/components/LoopKanban.tsx
@@ -3,37 +3,41 @@
 // 将所有环路的执行历史以看板形式展示，参考 KanbanBoard 的列布局风格：
 // - 列：运行中 / 待审批 / 成功 / 部分 / 失败 / 已取消 / 超限
 // - 每列按时间倒序展示 execution 卡片
-// - 支持时间范围过滤和环路名称搜索
+// - 搜索与时间过滤由父组件 MemorialBoard 统一管理，本组件不再重复渲染工具栏
+//
+// 交互说明：
+// - 点击卡片：打开侧边栏，上方展示该环路的环节设计流程图（LoopFlowGraph），
+//   下方展示该次执行的环节轨迹（StepExecList），实现「设计 vs 实际」对照。
+// - 黑板按钮：打开黑板抽屉，展示该次执行中所有环节的结论摘要（复用 BlackboardDrawer 组件）
 //
 // 数据来源：遍历所有 loop，对每个 loop 调用 listExecutions 聚合结果。
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { Input, Segmented, Spin, Empty, Tag, Tooltip } from 'antd';
+import { Button, Drawer, Spin, Empty, Tag, Tooltip, Divider, App as AntApp } from 'antd';
 import {
-  SearchOutlined,
+  ReadOutlined,
   CheckCircleOutlined,
   CloseCircleOutlined,
   LoadingOutlined,
   MinusCircleOutlined,
   ExclamationCircleOutlined,
+  ApartmentOutlined,
+  HistoryOutlined,
 } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
-import type { LoopExecutionDto, LoopListItem } from '@/types/loop';
+import type { LoopExecutionDto, LoopListItem, LoopExecutionDetail, LoopDetail } from '@/types/loop';
 import { formatRelativeTime } from '@/utils/datetime';
+// 复用 LoopStudioExecutionsPanel 中的执行轨迹卡片列表与黑板抽屉组件，
+// 确保环路执行历史在不同视图下的展示形态一致。
+import { StepExecList, BlackboardDrawer, formatToken } from './LoopStudioExecutionsPanel';
+// 复用环路流程设计图组件，在上方展示环节设计布局。
+import { LoopFlowGraph } from '@/components/loop-flow/LoopFlowGraph';
 
 // 环路执行记录增强类型：增加 loop_name 方便在卡片中直接显示环路名称，
 // 避免在渲染时反复回查 loop 列表
 interface LoopExecutionWithLoopName extends LoopExecutionDto {
   loop_name: string;
 }
-
-const TIME_OPTIONS: { label: string; value: number }[] = [
-  { label: '6h',  value: 6 },
-  { label: '12h', value: 12 },
-  { label: '24h', value: 24 },
-  { label: '3d',  value: 72 },
-  { label: '7d',  value: 168 },
-];
 
 // 状态 → 颜色 + 图标
 function execStatusView(status: string): { color: string; icon: React.ReactNode; label: string } {
@@ -83,9 +87,11 @@ const COLUMNS: ColumnDef[] = [
 interface ExecutionCardProps {
   exec: LoopExecutionWithLoopName;
   view: ReturnType<typeof execStatusView>;
+  onClick?: (exec: LoopExecutionWithLoopName) => void;
+  onBlackboard?: (exec: LoopExecutionWithLoopName) => void;
 }
 
-function ExecutionCard({ exec, view }: ExecutionCardProps) {
+function ExecutionCard({ exec, view, onClick, onBlackboard }: ExecutionCardProps) {
   return (
     <div
       className="loop-kanban-card"
@@ -96,13 +102,34 @@ function ExecutionCard({ exec, view }: ExecutionCardProps) {
         borderRadius: 8,
         padding: '10px 12px',
         marginBottom: 8,
-        cursor: 'default',
+        cursor: 'pointer',
+        transition: 'box-shadow 200ms',
       }}
+      onClick={() => onClick?.(exec)}
     >
       <CardHeader exec={exec} view={view} />
       <CardTrigger exec={exec} />
       <CardProgress exec={exec} />
+      {/* Token 消耗汇总：从执行历史 Token 消耗聚合数据中提取，
+          展示输入/输出/缓存读取的 token 数量，让用户快速了解资源消耗情况 */}
+      <CardTokenSummary exec={exec} />
       {exec.pending_approval_count > 0 && <CardApprovalBadge count={exec.pending_approval_count} />}
+      {/* 黑板按钮：点击后查看该次执行所有环节的结论摘要 */}
+      <div style={{ marginTop: 6, display: 'flex', justifyContent: 'flex-end' }}>
+        <Button
+          type="link"
+          size="small"
+          icon={<ReadOutlined />}
+          onClick={(e) => {
+            // 阻止冒泡到卡片的点击事件，避免同时打开轨迹侧边栏
+            e.stopPropagation();
+            onBlackboard?.(exec);
+          }}
+          style={{ fontSize: 11, padding: 0, height: 'auto', lineHeight: '20px' }}
+        >
+          黑板
+        </Button>
+      </div>
     </div>
   );
 }
@@ -143,6 +170,30 @@ function CardProgress({ exec }: { exec: LoopExecutionWithLoopName }) {
       <span style={{ fontFamily: 'monospace', color: 'var(--color-text-tertiary)' }}>
         {durationLabel(exec.started_at, exec.finished_at)}
       </span>
+    </div>
+  );
+}
+
+// Token 消耗汇总行：展示该次执行的输入/输出/缓存读取 token 数量。
+// 为什么独立成组件：条件渲染逻辑独立（只有 token_summary 存在且有消耗时才展示），
+// 且数据来自后端聚合计算，与卡片其他信息解耦。
+// 样式紧凑以适配看板卡片尺寸，颜色区分不同类型便于快速识别。
+function CardTokenSummary({ exec }: { exec: LoopExecutionWithLoopName }) {
+  const ts = exec.token_summary;
+  if (!ts) return null;
+  const hasTokens = ts.total_input_tokens > 0 || ts.total_output_tokens > 0 || (ts.total_cache_read_input_tokens ?? 0) > 0;
+  if (!hasTokens) return null;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap', fontSize: 10, marginTop: 4, color: 'var(--color-text-tertiary)' }}>
+      <span style={{ color: '#1677ff', fontWeight: 600 }}>输入 {formatToken(ts.total_input_tokens)}</span>
+      <span style={{ color: 'var(--color-text-tertiary)' }}>/</span>
+      <span style={{ color: '#52c41a', fontWeight: 600 }}>输出 {formatToken(ts.total_output_tokens)}</span>
+      {ts.total_cache_read_input_tokens > 0 && (
+        <>
+          <span style={{ color: 'var(--color-text-tertiary)' }}>/</span>
+          <span style={{ color: '#722ed1', fontWeight: 600 }}>缓存 {formatToken(ts.total_cache_read_input_tokens)}</span>
+        </>
+      )}
     </div>
   );
 }
@@ -302,19 +353,71 @@ interface Props {
   onHoursChange?: (h: number) => void;
 }
 
-export function LoopKanban({ searchText: externalSearch, hours: externalHours, onSearchChange, onHoursChange }: Props = {}) {
+export function LoopKanban({ searchText: externalSearch, hours: externalHours, onSearchChange: _onSearchChange, onHoursChange: _onHoursChange }: Props = {}) {
   // 为什么区分 internal/external：支持受控/非受控两种模式，
   // 外部传入时作为受控组件（MemorialBoard 统一管理 searchText/hours），
   // 未传入时作为非受控组件（独立状态）。
-  const [internalSearch, setInternalSearch] = useState('');
-  const [internalHours, setInternalHours] = useState(24);
+  // 注意：搜索与时间过滤的 UI 控件由父组件 MemorialBoard 渲染，
+  // 本组件不再渲染工具栏，但保留受控 props 透传能力，
+  // 使得 MemoriaBoard 的搜索/过滤对 LoopKanban 依然生效。
+  const [internalSearch] = useState('');
+  const [internalHours] = useState(24);
   const searchText = externalSearch ?? internalSearch;
   const hours = externalHours ?? internalHours;
-  const handleSearchChange = (v: string) => { if (onSearchChange) onSearchChange(v); else setInternalSearch(v); };
-  const handleHoursChange = (h: number) => { if (onHoursChange) onHoursChange(h); else setInternalHours(h); };
+
+  const { message } = AntApp.useApp();
 
   // 使用自定义 Hook 加载数据，逻辑抽离后函数体长度可控
   const { executions, loading } = useLoopExecutions();
+
+  // ── 轨迹侧边栏状态 ────────────────────────────────────
+  const [selectedExec, setSelectedExec] = useState<LoopExecutionWithLoopName | null>(null);
+  const [execDetail, setExecDetail] = useState<LoopExecutionDetail | null>(null);
+  // 环路设计信息：包含步骤定义，供 LoopFlowGraph 渲染环节设计图
+  const [loopDetail, setLoopDetail] = useState<LoopDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // 打开执行轨迹侧边栏：点击卡片时触发，加载该次执行的环节详情 与 环路的设计步骤。
+  // 为什么同时加载 loopDetail：在侧边栏上方展示环节设计流程图（LoopFlowGraph），
+  // 下方展示实际执行轨迹（StepExecList），实现「设计 vs 实际」对照。
+  // 为什么用 Promise.all：两个接口无依赖关系，可以并发请求减少总等待耗时。
+  // 为什么用 try/catch 静默失败：个别加载失败不应影响看板整体使用。
+  const handleCardClick = useCallback(async (exec: LoopExecutionWithLoopName) => {
+    setSelectedExec(exec);
+    setDrawerOpen(true);
+    setDetailLoading(true);
+    setExecDetail(null);
+    setLoopDetail(null);
+    try {
+      const [detail, loop] = await Promise.all([
+        dbLoops.getExecution(exec.loop_id, exec.id),
+        dbLoops.getLoop(exec.loop_id),
+      ]);
+      setExecDetail(detail);
+      setLoopDetail(loop);
+    } catch {
+      message.error('加载执行轨迹失败');
+    } finally {
+      setDetailLoading(false);
+    }
+  }, [message]);
+
+  // ── 黑板抽屉状态 ────────────────────────────────────
+  const [blackboardOpen, setBlackboardOpen] = useState(false);
+  const [blackboardExecs, setBlackboardExecs] = useState<Record<string, any>[]>([]);
+
+  // 打开黑板抽屉：点击卡片上的「黑板」按钮时触发。
+  // 每次打开都重新加载最新的执行详情，确保黑板数据是最新的。
+  const handleOpenBlackboard = useCallback(async (exec: LoopExecutionWithLoopName) => {
+    try {
+      const detail = await dbLoops.getExecution(exec.loop_id, exec.id);
+      setBlackboardExecs(detail.step_executions);
+      setBlackboardOpen(true);
+    } catch {
+      message.error('加载黑板数据失败');
+    }
+  }, [message]);
 
   // 按时间窗口过滤执行记录。
   // 为什么要独立 memo：hours 变化频繁（用户切换 Segmented），避免重复计算 cutoff 和遍历。
@@ -358,14 +461,6 @@ export function LoopKanban({ searchText: externalSearch, hours: externalHours, o
     return map;
   }, [filtered]);
 
-  // 统计各列数量，供工具栏右侧汇总展示。
-  // 为什么依赖 grouped 而非 filtered：grouped 已完成分组，直接读取长度更高效。
-  const stats = useMemo(() => {
-    const result: Record<string, number> = {};
-    for (const col of COLUMNS) result[col.label] = grouped[col.status]?.length ?? 0;
-    return result;
-  }, [grouped]);
-
   // 渲染单个执行卡片。
   // 为什么抽成独立组件：原 renderCard 函数超过 30 行，拆分后主体逻辑更清晰。
   // 为什么用 useCallback：避免每次渲染都重新创建函数，减少子组件不必要的 re-render。
@@ -376,9 +471,11 @@ export function LoopKanban({ searchText: externalSearch, hours: externalHours, o
         key={`${exec.loop_id}-${exec.id}`}
         exec={exec}
         view={view}
+        onClick={handleCardClick}
+        onBlackboard={handleOpenBlackboard}
       />
     );
-  }, []);
+  }, [handleCardClick, handleOpenBlackboard]);
 
   // 渲染看板列。
   // 为什么提取成组件：原函数超过 30 行，拆分后符合规范且便于测试列渲染逻辑。
@@ -389,45 +486,7 @@ export function LoopKanban({ searchText: externalSearch, hours: externalHours, o
 
   return (
     <div className="loop-kanban-board">
-      {/* 工具栏 */}
-      <div
-        className="loop-kanban-toolbar"
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 8,
-          padding: '8px 16px',
-          borderBottom: '1px solid var(--color-border)',
-          flexWrap: 'wrap',
-        }}
-      >
-        <Input
-          placeholder="搜索环路名称或触发类型…"
-          prefix={<SearchOutlined style={{ color: 'var(--color-text-tertiary)' }} />}
-          value={searchText}
-          onChange={e => handleSearchChange(e.target.value)}
-          allowClear
-          size="small"
-          style={{ width: 220 }}
-        />
-        <Segmented
-          size="small"
-          options={TIME_OPTIONS.map(o => ({ label: o.label, value: o.label }))}
-          value={TIME_OPTIONS.find(o => o.value === hours)?.label || '24h'}
-          onChange={label => {
-            const opt = TIME_OPTIONS.find(o => o.label === label);
-            if (opt) handleHoursChange(opt.value);
-          }}
-        />
-        {/* 统计 */}
-        <div style={{ marginLeft: 'auto', display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-          {COLUMNS.map(col => (
-            <span key={col.status} style={{ fontSize: 12, color: col.color }}>
-              {col.label} <strong>{stats[col.label]}</strong>
-            </span>
-          ))}
-        </div>
-      </div>
+      {/* 搜索与时间过滤由父组件 MemorialBoard 统一管理，此处不再重复渲染工具栏 */}
 
       {/* 看板列 */}
       {loading ? (
@@ -449,6 +508,102 @@ export function LoopKanban({ searchText: externalSearch, hours: externalHours, o
           {COLUMNS.map(renderColumn)}
         </div>
       )}
+
+      {/* 执行轨迹侧边栏：点击卡片时打开，上方展示该环路的环节设计流程图，
+          下方展示该次执行的环节轨迹，实现「设计 vs 实际」对照。
+          复用 LoopFlowGraph（环节设计图）和 StepExecList（实际执行轨迹）。 */}
+      <Drawer
+        title={
+          selectedExec ? (
+            <span>
+              <ReadOutlined style={{ marginRight: 8 }} />
+              执行轨迹 · {selectedExec.loop_name}
+              <span style={{ marginLeft: 8, fontSize: 12, color: 'var(--color-text-tertiary)', fontWeight: 400 }}>
+                #{selectedExec.id}
+              </span>
+            </span>
+          ) : '执行轨迹'
+        }
+        placement="right"
+        width={640}
+        open={drawerOpen}
+        onClose={() => {
+          setDrawerOpen(false);
+          setSelectedExec(null);
+          setExecDetail(null);
+          setLoopDetail(null);
+        }}
+        destroyOnClose
+      >
+        {detailLoading ? (
+          <div style={{ textAlign: 'center', padding: 40 }}>
+            <Spin tip="加载执行轨迹…" />
+          </div>
+        ) : execDetail && selectedExec && loopDetail ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            {/* 上方：环节设计流程图 — 展示该环路的标准步骤设计图，
+                让用户对照「预期设计」与「实际执行」。 */}
+            <div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+                <ApartmentOutlined style={{ color: 'var(--color-primary, #0891b2)' }} />
+                <span style={{ fontWeight: 600, fontSize: 14, color: 'var(--color-text, #0f172a)' }}>
+                  环节设计
+                </span>
+                <span style={{ fontSize: 11, color: 'var(--color-text-tertiary, #94a3b8)' }}>
+                  {loopDetail.steps.length} 个环节
+                </span>
+              </div>
+              <div style={{
+                background: 'var(--color-bg-elevated, #ffffff)',
+                border: '1px solid var(--color-border, #e2e8f0)',
+                borderRadius: 8,
+                padding: '8px 12px',
+              }}>
+                <LoopFlowGraph
+                  steps={loopDetail.steps}
+                  selectedStepId={null}
+                  onSelectStep={() => {}}
+                  onAddStep={() => {}}
+                />
+              </div>
+            </div>
+
+            <Divider style={{ margin: '4px 0' }} />
+
+            {/* 下方：实际执行轨迹 — 展示该次执行中各环节的真实运行情况。 */}
+            <div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+                <HistoryOutlined style={{ color: 'var(--color-primary, #0891b2)' }} />
+                <span style={{ fontWeight: 600, fontSize: 14, color: 'var(--color-text, #0f172a)' }}>
+                  执行轨迹
+                </span>
+              </div>
+              <StepExecList
+                stepExecs={execDetail.step_executions}
+                loopId={execDetail.loop_id}
+                executionId={execDetail.id}
+                onApproved={() => {
+                  // 审批通过后重新加载执行详情，保证环节状态与后端一致
+                  dbLoops.getExecution(selectedExec.loop_id, selectedExec.id)
+                    .then(setExecDetail)
+                    .catch(() => {});
+                }}
+              />
+            </div>
+          </div>
+        ) : (
+          <Empty description="无执行轨迹数据" />
+        )}
+      </Drawer>
+
+      {/* 黑板抽屉：按顺序展示该次执行中所有环节的结论，
+          让用户一次性纵览整条执行链路的输出摘要，
+          无需逐个展开每个环节的卡片查看 conclusion。 */}
+      <BlackboardDrawer
+        open={blackboardOpen}
+        stepExecs={blackboardExecs}
+        onClose={() => setBlackboardOpen(false)}
+      />
     </div>
   );
 }

--- a/frontend/src/components/LoopStudioExecutionsPanel.tsx
+++ b/frontend/src/components/LoopStudioExecutionsPanel.tsx
@@ -58,7 +58,7 @@ function durationLabel(start: string, end: string | null): string {
 }
 
 // Token 格式化：千位分隔
-function formatToken(n: number): string {
+export function formatToken(n: number): string {
   return n.toLocaleString();
 }
 
@@ -351,7 +351,7 @@ export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange
 // - 标题行：序号 + 环节名称
 // - 结论内容（markdown 区域）
 // 没有结论的环节展示「-无结论-」占位。
-function BlackboardDrawer({ open, stepExecs, onClose }: {
+export function BlackboardDrawer({ open, stepExecs, onClose }: {
   open: boolean;
   stepExecs: Record<string, any>[];
   onClose: () => void;
@@ -453,7 +453,7 @@ function BlackboardDrawer({ open, stepExecs, onClose }: {
 }
 
 // 环节执行卡片：卡片式布局 + 箭头连接展示执行顺序，每张卡展示执行详情
-function StepExecList({ stepExecs, loopId, executionId, onApproved }: { stepExecs: Record<string, any>[]; loopId: number; executionId: number; onApproved: () => void }) {
+export function StepExecList({ stepExecs, loopId, executionId, onApproved }: { stepExecs: Record<string, any>[]; loopId: number; executionId: number; onApproved: () => void }) {
   const { message } = AntApp.useApp();
   const [drawerRecord, setDrawerRecord] = useState<any | null>(null);
   const [drawerLoading, setDrawerLoading] = useState(false);

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -68,6 +68,8 @@ export interface LoopExecutionDto {
   total_executed_steps: number;
   /** 待人工审批的环节数 */
   pending_approval_count: number;
+  /** 该次执行的 Token 消耗汇总（从 step_executions 的 usage 聚合计算） */
+  token_summary?: LoopExecutionTokenSummary;
 }
 
 export interface LoopStepExecutionDto {


### PR DESCRIPTION
### 变更内容

1. **移除重复搜索/过滤控件**
   - 删除 LoopKanban 内部独立的搜索框、时间 Segmented 和状态统计栏
   - 保留受控 props 透传，搜索与时间过滤统一由父组件 MemorialBoard 管理

2. **卡片点击 → 执行轨迹侧边栏（设计 vs 实际对照）**
   - 点击卡片后并发加载执行详情（getExecution）和环路定义（getLoop）
   - 侧边栏上方展示环节设计图（LoopFlowGraph），下方展示实际执行轨迹（StepExecList）
   - 复用 StepExecList 组件的审批操作和展开详情功能

3. **每张卡片新增黑板按钮**
   - 卡片底部新增「黑板」按钮，点击打开 BlackboardDrawer
   - 使用 stopPropagation 防止与卡片点击事件冲突

4. **每张卡片新增 Token 消耗汇总行**
   - 后端 list_executions 接口新增 token_summary 聚合字段
   - 卡片上紧凑展示「输入 / 输出 / 缓存读取」的 token 数量

5. **导出复用组件**
   - StepExecList、BlackboardDrawer、formatToken 从 LoopStudioExecutionsPanel 导出

### 涉及文件
| 文件 | 改动 |
|------|------|
| `frontend/src/components/LoopKanban.tsx` | 移除重复工具栏，新增卡片点击轨迹侧边栏、黑板按钮、Token 展示 |
| `frontend/src/components/LoopStudioExecutionsPanel.tsx` | 导出 StepExecList、BlackboardDrawer、formatToken |
| `frontend/src/types/loop.ts` | LoopExecutionDto 新增 token_summary 可选字段 |
| `backend/src/handlers/loop_.rs` | list_executions 新增 token_summary 聚合计算 |
| `backend/src/models/loop_.rs` | LoopExecutionDto 新增 token_summary 字段 |
| `backend/src/db/loop_.rs` | 移除无用 import |