### PR TITLE
fix(loop): 修复 loop 步骤标题错配 + 恢复 loop 自动评审

### DIFF
--- a/backend/src/db/entity/todos.rs
+++ b/backend/src/db/entity/todos.rs
@@ -18,7 +18,6 @@ pub struct Model {
     pub scheduler_timezone: Option<String>,
     pub task_id: Option<String>,
     pub workspace: Option<String>,
-    pub worktree_enabled: Option<bool>,
     /// 验收标准（自动评审时作为评审 prompt 的一部分）。
     pub acceptance_criteria: Option<String>,
     /// 0=普通 todo, 1=评审任务（系统自动维护的专用 todo）,

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -13,7 +13,6 @@ use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect,
     Set, DbBackend,
 };
-use std::collections::HashMap;
 
 use crate::db::entity::{
     loop_executions, loop_step_executions, loop_steps, loop_triggers, loops,
@@ -735,14 +734,24 @@ impl Database {
 
     // ====== 辅助：批量取 step + todo 元信息 ======
 
-    /// 一次 SQL 把 step + 关联 todo 的 title/executor/status 拉出来。
+    /// 一次 SQL 把 loop_step + 关联 steps 模板的 title/executor 拉出来。
     /// 供前端 LoopStudio 详情页直接渲染(避免 N+1)。
+    ///
+    /// 历史注记：早期 `loop_steps.step_id` 指向 `todos.id`，后来重构为指向 `steps.id`
+    /// （环节成为可复用模板）。本 SQL 必须 INNER JOIN `steps`，不能再 JOIN `todos`。
+    /// 否则会把同名 ID 的 todo title 错配到 step 上，例如 loop 绑定 steps.id=3 时
+    /// 拿到的是 todos.id=3 的 title。前端 LoopFlowGraph / LoopStudioStepsPanel 第二列
+    /// 都依赖这个字段，错配会直接展示错误标题。
     pub async fn list_loop_steps_with_todo_meta(
         &self,
         loop_id: i64,
-    ) -> Result<Vec<(loop_steps::Model, String, String, String)>, sea_orm::DbErr> {
+    ) -> Result<Vec<(loop_steps::Model, String, String)>, sea_orm::DbErr> {
         // 用 raw SQL JOIN; SeaORM 的 join API 对 has-many/belongs-to 支持有限,
         // 一次写清晰且类型稳定。
+        //
+        // 仅返回 (loop_step, template_title, template_executor) 三元组。
+        // 原 tuple 还包含 `todo_status`，但 `steps` 表没有 status 列（环节是模板不是任务），
+        // 且前端从不消费该字段，所以一并移除。
         use sea_orm::{ConnectionTrait, Statement};
         let sql = format!(
             "SELECT s.id, s.loop_id, s.name, s.description, s.order_index, s.step_id, \
@@ -750,10 +759,9 @@ impl Database {
                     s.on_success, s.success_goto_step_id, s.on_rating_fail, s.fail_goto_step_id, \
                     s.review_type, \
                     s.enabled, s.created_at, \
-                    t.title as todo_title, st.executor as todo_executor, t.status as todo_status \
+                    st.title as todo_title, st.executor as todo_executor \
              FROM loop_steps s \
-             INNER JOIN todos t ON t.id = s.step_id \
-             LEFT JOIN steps st ON st.id = s.step_id \
+             INNER JOIN steps st ON st.id = s.step_id \
              WHERE s.loop_id = {} \
              ORDER BY s.order_index ASC, s.id ASC",
             loop_id
@@ -787,10 +795,7 @@ impl Database {
             let todo_executor: String = row
                 .try_get_by::<Option<String>, _>("todo_executor")?
                 .unwrap_or_default();
-            let todo_status: String = row
-                .try_get_by::<Option<String>, _>("todo_status")?
-                .unwrap_or_default();
-            out.push((model, todo_title, todo_executor, todo_status));
+            out.push((model, todo_title, todo_executor));
         }
         Ok(out)
     }
@@ -875,6 +880,11 @@ impl Database {
 
     /// 加载 loop 详情(基本+所有子项)给前端 LoopStudio 详情面板用。
     /// 单次返回所有必要数据,前端无需多次请求。
+    ///
+    /// 历史注记：早期实现还会 JOIN `todos` 表构建 `todo_map`，但 `loop_steps.step_id`
+    /// 重构后指向 `steps` 表（reusable 环节模板），且 todo_map 字段在前端从未被消费。
+    /// 本方法现在直接返回 `(loop_step, template_title, template_executor)` 三元组，
+    /// 不再做多余的 todos 拼装。
     pub async fn load_loop_full(
         &self,
         loop_id: i64,
@@ -884,13 +894,8 @@ impl Database {
         };
         let triggers = self.list_triggers_by_loop(loop_id).await?;
         let steps_with_meta = self.list_loop_steps_with_todo_meta(loop_id).await?;
-        let mut todo_ids: Vec<i64> = steps_with_meta.iter().map(|(s, _, _, _)| s.step_id).collect();
-        todo_ids.sort_unstable();
-        todo_ids.dedup();
-        let todos = self.get_todos_by_ids(&todo_ids).await?;
-        let todo_map: HashMap<i64, _> = todos.into_iter().map(|t| (t.id, t)).collect();
         let steps: Vec<loop_steps::Model> =
-            steps_with_meta.iter().map(|(s, _, _, _)| s.clone()).collect();
+            steps_with_meta.iter().map(|(s, _, _)| s.clone()).collect();
         // 统计该 loop 下待人工审批的环节执行数
         let pending_approval_count = self.count_pending_approvals_for_loop(loop_id).await?;
         Ok(Some(LoopFullView {
@@ -898,7 +903,6 @@ impl Database {
             triggers,
             steps,
             steps_meta: steps_with_meta,
-            todo_map,
             pending_approval_count,
         }))
     }
@@ -922,9 +926,9 @@ pub struct LoopFullView {
     pub loop_: loops::Model,
     pub triggers: Vec<loop_triggers::Model>,
     pub steps: Vec<loop_steps::Model>,
-    /// (step, todo_title, todo_executor, todo_status)
-    pub steps_meta: Vec<(loop_steps::Model, String, String, String)>,
-    pub todo_map: HashMap<i64, crate::db::entity::todos::Model>,
+    /// (step, template_title, template_executor)
+    /// template_* 字段从 steps 表读（不是 todos），见 list_loop_steps_with_todo_meta。
+    pub steps_meta: Vec<(loop_steps::Model, String, String)>,
     /// 该 loop 下待人工审批的环节执行数
     pub pending_approval_count: i32,
 }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -813,7 +813,6 @@ mod tests {
             scheduler_config: None,
             scheduler_timezone: None,
             workspace: None,
-            worktree_enabled: None,
             acceptance_criteria: None,
             auto_review_enabled: None,
         })
@@ -976,7 +975,6 @@ mod tests {
             scheduler_config: Some("0 0 * * *"),
             scheduler_timezone: None,
             workspace: Some("/tmp/workspace"),
-            worktree_enabled: None,
             acceptance_criteria: None,
             auto_review_enabled: None,
         })

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -18,7 +18,6 @@ pub struct TodoUpdate<'a> {
     pub scheduler_config: Option<&'a str>,
     pub scheduler_timezone: Option<&'a str>,
     pub workspace: Option<&'a str>,
-    pub worktree_enabled: Option<bool>,
     pub acceptance_criteria: Option<&'a str>,
     pub auto_review_enabled: Option<bool>,
 }
@@ -63,7 +62,6 @@ impl Database {
             scheduler_next_run_at,
             task_id: m.task_id,
             workspace: m.workspace,
-            worktree_enabled: m.worktree_enabled.unwrap_or(false),
             acceptance_criteria: m.acceptance_criteria,
             todo_type: m.todo_type.unwrap_or(0),
             parent_todo_id: m.parent_todo_id,
@@ -186,9 +184,6 @@ impl Database {
                 am.workspace = ActiveValue::Set(Some(ws.to_string()));
             }
         }
-        if let Some(wt) = update.worktree_enabled {
-            am.worktree_enabled = ActiveValue::Set(Some(wt));
-        }
         if let Some(criteria) = update.acceptance_criteria {
             am.acceptance_criteria = ActiveValue::Set(Some(criteria.to_string()));
         }
@@ -292,21 +287,6 @@ impl Database {
         let am = todos::ActiveModel {
             id: ActiveValue::Unchanged(id),
             workspace: ActiveValue::Set(ws),
-            updated_at: ActiveValue::Set(Some(now)),
-            ..Default::default()
-        };
-        self.exec_update(am).await
-    }
-
-    pub async fn update_todo_worktree_enabled(
-        &self,
-        id: i64,
-        enabled: bool,
-    ) -> Result<(), sea_orm::DbErr> {
-        let now = crate::models::utc_timestamp();
-        let am = todos::ActiveModel {
-            id: ActiveValue::Unchanged(id),
-            worktree_enabled: ActiveValue::Set(Some(enabled)),
             updated_at: ActiveValue::Set(Some(now)),
             ..Default::default()
         };
@@ -633,11 +613,7 @@ impl Database {
                     scheduler_config: m.scheduler_config,
                     tag_names,
                     workspace: m.workspace.clone(),
-                    worktree: if m.worktree_enabled.unwrap_or(false) {
-                        m.workspace.clone()
-                    } else {
-                        None
-                    },
+                    worktree: None,
                 }
             })
             .collect::<Vec<_>>())
@@ -688,11 +664,7 @@ impl Database {
                     scheduler_config: m.scheduler_config,
                     tag_names,
                     workspace: m.workspace.clone(),
-                    worktree: if m.worktree_enabled.unwrap_or(false) {
-                        m.workspace.clone()
-                    } else {
-                        None
-                    },
+                    worktree: None,
                 }
             })
             .collect())
@@ -749,8 +721,7 @@ impl Database {
         // 导入 todo
         for todo in todos_in {
             let now = crate::models::utc_timestamp();
-            let workspace = todo.worktree.clone().or(todo.workspace.clone());
-            let worktree_enabled = todo.worktree.is_some();
+            let workspace = todo.workspace.clone();
             let am = todos::ActiveModel {
                 title: ActiveValue::Set(todo.title.clone()),
                 prompt: ActiveValue::Set(Some(todo.prompt.clone())),
@@ -759,7 +730,6 @@ impl Database {
                 scheduler_enabled: ActiveValue::Set(Some(todo.scheduler_enabled)),
                 scheduler_config: ActiveValue::Set(todo.scheduler_config.clone()),
                 workspace: ActiveValue::Set(workspace),
-                worktree_enabled: ActiveValue::Set(Some(worktree_enabled)),
                 created_at: ActiveValue::Set(Some(now.clone())),
                 updated_at: ActiveValue::Set(Some(now)),
                 ..Default::default()
@@ -848,8 +818,7 @@ impl Database {
                 am.executor = ActiveValue::Set(todo.executor.clone());
                 am.scheduler_enabled = ActiveValue::Set(Some(todo.scheduler_enabled));
                 am.scheduler_config = ActiveValue::Set(todo.scheduler_config.clone());
-                am.workspace = ActiveValue::Set(todo.worktree.clone().or(todo.workspace.clone()));
-                am.worktree_enabled = ActiveValue::Set(Some(todo.worktree.is_some()));
+                am.workspace = ActiveValue::Set(todo.workspace.clone());
                 am.updated_at = ActiveValue::Set(Some(crate::models::utc_timestamp()));
                 let saved = am.update(&txn).await?;
 
@@ -881,8 +850,7 @@ impl Database {
             } else {
                 // 新建
                 let now = crate::models::utc_timestamp();
-                let workspace = todo.worktree.clone().or(todo.workspace.clone());
-                let worktree_enabled = todo.worktree.is_some();
+                let workspace = todo.workspace.clone();
                 let am = todos::ActiveModel {
                     title: ActiveValue::Set(todo.title.clone()),
                     prompt: ActiveValue::Set(Some(todo.prompt.clone())),
@@ -891,7 +859,6 @@ impl Database {
                     scheduler_enabled: ActiveValue::Set(Some(todo.scheduler_enabled)),
                     scheduler_config: ActiveValue::Set(todo.scheduler_config.clone()),
                     workspace: ActiveValue::Set(workspace),
-                    worktree_enabled: ActiveValue::Set(Some(worktree_enabled)),
                     created_at: ActiveValue::Set(Some(now.clone())),
                     updated_at: ActiveValue::Set(Some(now)),
                     ..Default::default()

--- a/backend/src/executor_service/pre_spawn.rs
+++ b/backend/src/executor_service/pre_spawn.rs
@@ -22,7 +22,6 @@ use crate::task_manager::TaskManager;
 use super::ExecutionResult;
 use super::RunTodoExecutionRequest;
 use super::log_capture::send_event;
-use super::worktree::apply_worktree_flag;
 
 /// 选择执行器类型。优先级：调用方显式 `req_executor` > todo 存储的 `todo_executor` > 默认值。
 ///
@@ -235,8 +234,7 @@ pub(crate) async fn reject_start_todo_failure(
 /// Stage 1 步骤 5 产物：executor 选择 + command 构造。
 ///
 /// 决策顺序：显式 req_executor > todo.executor > registry default。命令构造
-/// 用 `command_args_with_session` 处理 resume / 非 resume 分支，再用
-/// [`apply_worktree_flag`] 给 claude_code / hermes 加 worktree 参数。
+/// 用 `command_args_with_session` 处理 resume / 非 resume 分支。
 #[allow(dead_code)]
 pub(crate) struct SelectedExecutor {
     pub executor: Arc<dyn CodeExecutor>,
@@ -255,14 +253,14 @@ pub(crate) async fn select_executor_and_build_command(
     todo: &Option<crate::models::Todo>,
     message: &str,
 ) -> Result<SelectedExecutor, ExecutionResult> {
-    let (todo_workspace, todo_worktree_enabled, todo_executor) = extract_todo_executor_fields(todo);
+    let (todo_workspace, todo_executor) = extract_todo_executor_fields(todo);
     let executor_type =
         resolve_executor_type(request.req_executor.as_deref(), todo_executor.as_deref());
     let executor =
         resolve_executor_instance(request, todo, executor_type).await?;
     let executable_path = executor.executable_path().to_string();
     let command_args =
-        build_executor_command_args(&executor, message, request.resume_session_id.as_deref(), todo_worktree_enabled);
+        build_executor_command_args(&executor, message, request.resume_session_id.as_deref());
     let executor_str = executor.executor_type().to_string();
     persist_executor_choice(&request.db, request.todo_id, &executor_str).await;
     Ok(SelectedExecutor {
@@ -275,13 +273,12 @@ pub(crate) async fn select_executor_and_build_command(
     })
 }
 
-/// 从 `Option<Todo>` 提取 (workspace, worktree_enabled, executor_str) 三元组。
+/// 从 `Option<Todo>` 提取 (workspace, executor_str) 二元组。
 fn extract_todo_executor_fields(
     todo: &Option<crate::models::Todo>,
-) -> (Option<String>, bool, Option<String>) {
+) -> (Option<String>, Option<String>) {
     (
         todo.as_ref().and_then(|t| t.workspace.clone()),
-        todo.as_ref().map(|t| t.worktree_enabled).unwrap_or(false),
         todo.as_ref().and_then(|t| t.executor.clone()),
     )
 }
@@ -310,20 +307,17 @@ async fn resolve_executor_instance(
     .await)
 }
 
-/// 构造 argv：先按 executor 规则拼 + 再插入 --worktree flag（如果需要）。
+/// 构造 argv：直接按 executor 规则拼。
 fn build_executor_command_args(
     executor: &Arc<dyn CodeExecutor>,
     message: &str,
     resume_session_id: Option<&str>,
-    todo_worktree_enabled: bool,
 ) -> Vec<String> {
-    let mut args = executor.command_args_with_session(
+    executor.command_args_with_session(
         message,
         resume_session_id,
         resume_session_id.is_some(),
-    );
-    apply_worktree_flag(&mut args, executor.executor_type(), todo_worktree_enabled);
-    args
+    )
 }
 
 /// Update todo's executor to the one being used. 失败仅记日志，不阻断执行。

--- a/backend/src/executor_service/worktree.rs
+++ b/backend/src/executor_service/worktree.rs
@@ -5,11 +5,10 @@
 //!   1. 根据 todo.workspace 决定是否开 worktree（`resolve_worktree_context`）
 //!   2. 把 worktree 路径回写到 execution_records（`record_worktree_path`）
 //!   3. 执行结束后清理 worktree（`cleanup_worktree_if_needed`）
-//!   4. 给 claude_code / hermes 注入 `--worktree` 开关（`apply_worktree_flag`）
-//!   5. 杀进程组（`kill_process_tree`，command-group 集成）
+//!   4. 杀进程组（`kill_process_tree`，command-group 集成）
 
 use crate::db::Database;
-use crate::models::{ExecutorType, Todo};
+use crate::models::Todo;
 use crate::services::worktree::WorktreeService;
 
 /// issue #643: 单次执行使用的 worktree 上下文。
@@ -103,36 +102,6 @@ pub(crate) fn cleanup_worktree_if_needed(ctx: &WorktreeContext) {
     }
 }
 
-/// 给 `command_args` 插入 `--worktree` 开关。
-///
-/// - 仅当 `worktree_enabled == true` 且 executor 是 `Claudecode` 或 `Hermes` 时生效；
-///   其他 executor 即使 todo 开启了 worktree，也会被静默忽略。
-/// - 位置约束：必须放在 `--session-id` / `--resume` 之前，否则 Claude Code / Hermes
-///   在 resume session 时不会触发 worktree 初始化。
-///   没找到这些开关时 append 到末尾，依然能让 Claude Code 自动管理 worktree。
-pub(crate) fn apply_worktree_flag(
-    command_args: &mut Vec<String>,
-    exec_type: ExecutorType,
-    worktree_enabled: bool,
-) {
-    if !worktree_enabled {
-        return;
-    }
-    match exec_type {
-        ExecutorType::Claudecode | ExecutorType::Hermes => {
-            // 找 `--session-id` 或 `--resume` 的位置；找不到就 append 到末尾。
-            let insert_pos = command_args
-                .iter()
-                .position(|s| s == "--session-id" || s == "--resume")
-                .unwrap_or(command_args.len());
-            command_args.insert(insert_pos, "--worktree".to_string());
-        }
-        // 其他 executor 不支持 worktree flag，todo 配置的 `worktree_enabled`
-        // 对它们而言无意义；显式忽略避免误把 flag 透传给不识别的二进制。
-        _ => {}
-    }
-}
-
 /// 使用 command-group 安全地杀死进程树
 /// command-group 会自动创建进程组，kill() 时会杀死整个进程组
 pub(crate) async fn kill_process_tree(child: &mut command_group::AsyncGroupChild) {
@@ -144,36 +113,6 @@ pub(crate) async fn kill_process_tree(child: &mut command_group::AsyncGroupChild
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_apply_worktree_flag_inserts_before_session_id() {
-        // Claude Code：插入到 --session-id 之前。
-        let mut args = vec!["--print".to_string(), "--session-id".to_string(), "abc".to_string()];
-        apply_worktree_flag(&mut args, ExecutorType::Claudecode, true);
-        assert_eq!(args, vec!["--print", "--worktree", "--session-id", "abc"]);
-
-        // Hermes：插入到 --resume 之前。
-        let mut args = vec!["-p".to_string(), "--resume".to_string(), "xyz".to_string()];
-        apply_worktree_flag(&mut args, ExecutorType::Hermes, true);
-        assert_eq!(args, vec!["-p", "--worktree", "--resume", "xyz"]);
-
-        // 找不到 --session-id / --resume 时 append 到末尾。
-        let mut args = vec!["-p".to_string()];
-        apply_worktree_flag(&mut args, ExecutorType::Claudecode, true);
-        assert_eq!(args, vec!["-p", "--worktree"]);
-
-        // worktree_enabled = false 时不插入。
-        let mut args = vec!["--print".to_string()];
-        apply_worktree_flag(&mut args, ExecutorType::Claudecode, false);
-        assert_eq!(args, vec!["--print"]);
-
-        // 其他 executor 即使 worktree_enabled = true 也不插入。
-        let mut args = vec!["--print".to_string()];
-        apply_worktree_flag(&mut args, ExecutorType::Codex, true);
-        assert_eq!(args, vec!["--print"]);
-        apply_worktree_flag(&mut args, ExecutorType::Pi, true);
-        assert_eq!(args, vec!["--print"]);
-    }
 
     #[test]
     fn test_cleanup_worktree_if_needed_disabled() {

--- a/backend/src/handlers/feishu_binding.rs
+++ b/backend/src/handlers/feishu_binding.rs
@@ -145,10 +145,6 @@ pub async fn create_binding(
         if let Err(e) = state.db.update_todo_workspace(tid, Some(&dir.path)).await {
             tracing::warn!("[binding] failed to update todo {} workspace: {e}", tid);
         }
-        // 被飞书绑定使用的 Todo 必须关闭 worktree，避免 worktree 路径与 workspace 不一致。
-        if let Err(e) = state.db.update_todo_worktree_enabled(tid, false).await {
-            tracing::warn!("[binding] failed to set worktree_enabled for todo {}: {e}", tid);
-        }
         tid
     } else {
         // 新建 Todo，title/prompt 模板与 feishu_listener.rs 保持一致。
@@ -169,9 +165,6 @@ pub async fn create_binding(
         ).await?;
         if let Err(e) = state.db.update_todo_workspace(new_todo_id, Some(&dir.path)).await {
             tracing::warn!("[binding] failed to set todo workspace: {e}");
-        }
-        if let Err(e) = state.db.update_todo_worktree_enabled(new_todo_id, false).await {
-            tracing::warn!("[binding] failed to set worktree_enabled: {e}");
         }
         new_todo_id
     };

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -324,11 +324,10 @@ pub async fn list_loop_steps(
     let rows = state.db.list_loop_steps_with_todo_meta(loop_id).await?;
     let dtos: Vec<LoopStepDto> = rows
         .into_iter()
-        .map(|(s, todo_title, todo_executor, todo_status)| LoopStepDto {
+        .map(|(s, todo_title, todo_executor)| LoopStepDto {
             step: s.into(),
             todo_title,
             todo_executor,
-            todo_status,
         })
         .collect();
     Ok(ApiResponse::ok(dtos))
@@ -368,12 +367,12 @@ pub async fn create_loop_step(
             &req.review_type,
         )
         .await?;
-    let (_, todo_title, todo_executor, todo_status) = state
+    let (_, todo_title, todo_executor) = state
         .db
         .list_loop_steps_with_todo_meta(loop_id)
         .await?
         .into_iter()
-        .find(|(s, _, _, _)| s.id == created.id)
+        .find(|(s, _, _)| s.id == created.id)
         .ok_or_else(|| AppError::Internal("created step missing".to_string()))?;
     Ok((
         StatusCode::CREATED,
@@ -381,7 +380,6 @@ pub async fn create_loop_step(
             step: created.into(),
             todo_title,
             todo_executor,
-            todo_status,
         }),
     ))
 }
@@ -443,18 +441,17 @@ pub async fn update_loop_step(
             &req.review_type,
         )
         .await?;
-    let (_, todo_title, todo_executor, todo_status) = state
+    let (_, todo_title, todo_executor) = state
         .db
         .list_loop_steps_with_todo_meta(loop_id)
         .await?
         .into_iter()
-        .find(|(s, _, _, _)| s.id == sid)
+        .find(|(s, _, _)| s.id == sid)
         .ok_or_else(|| AppError::Internal("updated step missing".to_string()))?;
     Ok(ApiResponse::ok(LoopStepDto {
         step: state.db.get_loop_step(sid).await?.ok_or(AppError::Internal("step missing".to_string()))?.into(),
         todo_title,
         todo_executor,
-        todo_status,
     }))
 }
 

--- a/backend/src/handlers/sync.rs
+++ b/backend/src/handlers/sync.rs
@@ -314,7 +314,6 @@ async fn merge_cloud_todos_to_local(
                         scheduler_config: None,
                         scheduler_timezone: None,
                         workspace: item.workspace.as_deref(),
-                        worktree_enabled: None,
                         acceptance_criteria: None,
                         auto_review_enabled: None,
                     })
@@ -370,7 +369,7 @@ fn local_todos_to_cloud(todos: Vec<Todo>, tag_map: HashMap<i64, String>) -> Clou
                 scheduler_config: t.scheduler_config,
                 tag_names,
                 workspace: t.workspace,
-                worktree: t.worktree_enabled.then(|| "auto".to_string()),
+                worktree: None,
             }
         })
         .collect();

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -149,7 +149,6 @@ pub async fn create_todo(
         scheduler_next_run_at: None,
         task_id: None,
         workspace: None,
-        worktree_enabled: false,
         acceptance_criteria: req.acceptance_criteria.clone(),
         todo_type: 0,
         parent_todo_id: None,
@@ -184,7 +183,6 @@ pub async fn update_todo(
     let new_status = req.status.unwrap_or(current.status);
     let executor = req.executor.or(current.executor);
     let workspace = req.workspace.or(current.workspace);
-    let worktree_enabled = req.worktree_enabled.unwrap_or(current.worktree_enabled);
 
     let scheduler_config = req
         .scheduler_config
@@ -219,7 +217,6 @@ pub async fn update_todo(
             scheduler_config: scheduler_config.as_deref(),
             scheduler_timezone: scheduler_timezone.as_deref(),
             workspace: workspace.as_deref(),
-            worktree_enabled: Some(worktree_enabled),
             acceptance_criteria: req.acceptance_criteria.as_deref(),
             auto_review_enabled: req.auto_review_enabled,
         })

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -56,8 +56,6 @@ pub struct LoopDetail {
     pub loop_: LoopDto,
     pub triggers: Vec<LoopTriggerDto>,
     pub steps: Vec<LoopStepDto>,
-    /// todo_id -> TodoDto,前端展示 step 关联的 todo 信息时直接 lookup
-    pub todo_map: std::collections::HashMap<i64, TodoSummary>,
     /// 待人工审批的环节执行数（approval_status='pending' 的 loop_step_executions 数量）
     #[serde(default)]
     pub pending_approval_count: i32,
@@ -65,48 +63,22 @@ pub struct LoopDetail {
 
 impl From<LoopFullView> for LoopDetail {
     fn from(view: LoopFullView) -> Self {
-        let todo_map = view
-            .todo_map
-            .into_iter()
-            .map(|(id, t)| {
-                (
-                    id,
-                    TodoSummary {
-                        id: t.id,
-                        title: t.title,
-                        status: t.status.unwrap_or_default(),
-                        executor: t.executor.unwrap_or_default(),
-                    },
-                )
-            })
-            .collect();
         let steps = view
             .steps_meta
             .into_iter()
-            .map(|(s, todo_title, todo_executor, todo_status): (loop_steps::Model, String, String, String)| LoopStepDto {
+            .map(|(s, todo_title, todo_executor): (loop_steps::Model, String, String)| LoopStepDto {
                 step: s.into(),
                 todo_title,
                 todo_executor,
-                todo_status,
             })
             .collect();
         Self {
             loop_: view.loop_.into(),
             triggers: view.triggers.into_iter().map(Into::into).collect(),
             steps,
-            todo_map,
             pending_approval_count: view.pending_approval_count,
         }
     }
-}
-
-/// 极简的 todo 摘要(嵌在 loop detail 里),不暴露 prompt 等敏感字段。
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TodoSummary {
-    pub id: i64,
-    pub title: String,
-    pub status: String,
-    pub executor: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -183,10 +155,10 @@ impl From<loop_triggers::Model> for LoopTriggerDto {
 pub struct LoopStepDto {
     #[serde(flatten)]
     pub step: LoopStepRawDto,
-    /// 冗余字段,JOIN 时一并查出来,避免前端再请求 todo 详情
+    /// 冗余字段,JOIN 时一并查出来,避免前端再请求 step 模板详情。
+    /// 修复 JOIN 误用 todos 表后：todo_title/todo_executor 现在都从 steps 表读。
     pub todo_title: String,
     pub todo_executor: String,
-    pub todo_status: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -112,8 +112,6 @@ pub struct Todo {
     #[serde(default)]
     pub workspace: Option<String>,
     #[serde(default)]
-    pub worktree_enabled: bool,
-    #[serde(default)]
     pub acceptance_criteria: Option<String>,
     /// 0=normal, 1=reviewer_template（已废弃：评审模板已迁出至 review_templates 表）,
     /// 2=review_instance（评审实例）.
@@ -390,8 +388,6 @@ pub struct UpdateTodoRequest {
     pub scheduler_timezone: Option<String>,
     #[serde(default)]
     pub workspace: Option<String>,
-    #[serde(default)]
-    pub worktree_enabled: Option<bool>,
     #[serde(default)]
     pub acceptance_criteria: Option<String>,
     /// None=不变, Some(true)/Some(false)=更新. 不允许改 reviewer template 的开关.

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -1126,7 +1126,6 @@ impl FeishuListener {
                     match db.create_todo(&todo_title, &todo_prompt).await {
                         Ok(todo_id) => {
                             let _ = db.update_todo_workspace(todo_id, Some(&dir.path)).await;
-                            let _ = db.update_todo_worktree_enabled(todo_id, false).await;
                             match db.create_feishu_project_binding(bot_id, channel, chat_type, dir.id, todo_id).await {
                                 Ok(binding_id) => {
                                     let dir_name = dir.name.as_deref().unwrap_or("unknown");
@@ -1931,7 +1930,6 @@ mod tests {
             scheduler_next_run_at: None,
             task_id: None,
             workspace: None,
-            worktree_enabled: false,
             acceptance_criteria: None,
             todo_type: 0,
             parent_todo_id: None,

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -50,7 +50,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
 
   // 从 formState 中解构出常用的字段
   const {
-    title, prompt, selectedTags, executor, workspace, worktreeEnabled,
+    title, prompt, selectedTags, executor, workspace,
     schedulerEnabled, schedulerConfig, acceptanceCriteria, autoReviewEnabled,
   } = formState;
 
@@ -239,7 +239,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         await db.updateTodo(
           todo.id, title.trim(), prompt.trim(), todo.status,
           executor, schedulerEnabled, schedulerConfig || null,
-          workspaceToSave, worktreeEnabled,
+          workspaceToSave,
           acceptanceCriteria || null,
           autoReviewEnabled,
         );
@@ -252,11 +252,11 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         // 创建模式：只在路径存在于目录列表时才设置 workspace，否则为 null（避免创建无名项目）
         const workspaceToSave = trimmedWorkspace && projectDirectories.some(d => d.path === trimmedWorkspace) ? trimmedWorkspace : null;
 
-        if (workspaceToSave || schedulerEnabled || executor !== DEFAULT_EXECUTOR || worktreeEnabled) {
+        if (workspaceToSave || schedulerEnabled || executor !== DEFAULT_EXECUTOR) {
           await db.updateTodo(
             newTodo.id, newTodo.title, newTodo.prompt, newTodo.status,
             executor, schedulerEnabled, schedulerConfig || null,
-            workspaceToSave, worktreeEnabled,
+            workspaceToSave,
             acceptanceCriteria || null,
             autoReviewEnabled,
           );
@@ -409,14 +409,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
             )}
           </div>
 
-          {(executor === DEFAULT_EXECUTOR || executor === 'claude_code' || executor === 'hermes') && (
-            <div style={{ marginBottom: 16 }}>
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                <div style={{ fontWeight: 600, fontSize: 14 }}>Git Worktree</div>
-                <Switch checked={worktreeEnabled} onChange={(checked) => setField('worktreeEnabled', checked)} />
-              </div>
-            </div>
-          )}
+
 
           <Divider style={{ margin: '8px 0 16px' }} />
 

--- a/frontend/src/components/todo-drawer/reducer.ts
+++ b/frontend/src/components/todo-drawer/reducer.ts
@@ -24,8 +24,6 @@ export interface TodoFormState {
   executor: string;
   /** 工作目录路径 */
   workspace: string;
-  /** 是否启用 worktree */
-  worktreeEnabled: boolean;
   /** 是否启用调度器 */
   schedulerEnabled: boolean;
   /** 调度器 cron 表达式 */
@@ -51,7 +49,6 @@ export const initialFormState: TodoFormState = {
   selectedTags: [],
   executor: DEFAULT_EXECUTOR,
   workspace: '',
-  worktreeEnabled: false,
   schedulerEnabled: false,
   schedulerConfig: '',
   acceptanceCriteria: '',
@@ -80,7 +77,6 @@ export function todoFormReducer(state: TodoFormState, action: TodoFormAction): T
           selectedTags: action.todo.tag_ids || [],
           executor: action.todo.executor || DEFAULT_EXECUTOR,
           workspace: action.todo.workspace || '',
-          worktreeEnabled: action.todo.worktree_enabled || false,
           schedulerEnabled: action.todo.scheduler_enabled || false,
           schedulerConfig: action.todo.scheduler_config || '',
           acceptanceCriteria: action.todo.acceptance_criteria ?? '',

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -101,13 +101,6 @@ export interface LoopStepExecutionDto {
   total_cost_usd: number | null;
 }
 
-export interface TodoSummaryForLoop {
-  id: number;
-  title: string;
-  status: string;
-  executor: string;
-}
-
 export interface LoopStepRawDto {
   id: number;
   loop_id: number;
@@ -150,9 +143,10 @@ export interface LoopStepDto {
   review_type: string;
   enabled: boolean;
   created_at: string | null;
+  /** 关联 step 模板的 title（来自 steps 表） */
   todo_title: string;
+  /** 关联 step 模板的执行器 */
   todo_executor: string;
-  todo_status: string;
 }
 
 export interface CreateLoopStepRequest {
@@ -216,7 +210,6 @@ export interface LoopDetail {
   updated_at: string | null;
   triggers: LoopTriggerDto[];
   steps: LoopStepDto[];
-  todo_map: Record<number, TodoSummaryForLoop>;
   /** 待人工审批的环节执行数 */
   pending_approval_count: number;
 }

--- a/frontend/src/types/todo.ts
+++ b/frontend/src/types/todo.ts
@@ -16,7 +16,6 @@ export interface Todo {
   scheduler_next_run_at?: string | null;
   task_id?: string | null;
   workspace?: string | null;
-  worktree_enabled?: boolean;
   acceptance_criteria?: string | null;
   /** Whether to spawn an auto-review child todo after this one finishes. Default true. */
   auto_review_enabled?: boolean;

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -34,7 +34,6 @@ export async function updateTodo(
   scheduler_enabled?: boolean,
   scheduler_config?: string | null,
   workspace?: string | null,
-  worktree_enabled?: boolean,
   acceptance_criteria?: string | null,
   auto_review_enabled?: boolean,
 ): Promise<Todo> {
@@ -43,7 +42,6 @@ export async function updateTodo(
   if (scheduler_enabled !== undefined) body.scheduler_enabled = scheduler_enabled;
   if (scheduler_config !== undefined) body.scheduler_config = scheduler_config;
   if (workspace !== undefined) body.workspace = workspace;
-  if (worktree_enabled !== undefined) body.worktree_enabled = worktree_enabled;
   if (acceptance_criteria !== undefined) body.acceptance_criteria = acceptance_criteria;
   if (auto_review_enabled !== undefined) body.auto_review_enabled = auto_review_enabled;
 


### PR DESCRIPTION
## 背景

loop 详情页和执行历史里发现两个 bug：
1. **步骤标题错配**：loop 详情里 step 的 `todo_title`（前端用作"关联模板标题"展示）全部错位 —— loop 绑定 `steps.id=3` 时显示的却是 `todos.id=3` 的 title。
2. **loop 自动评审没触发**：loop 执行后 5 张 step_executions 卡片全部显示"未评审"，但日志显示 `apply_rating_gate` 实际跑了，评分也回写了 execution_records，但 `loop_step_executions.rating` 一直是 NULL。

## 根因

### Bug 1：SQL JOIN 错位

`db/loop_.rs::list_loop_steps_with_todo_meta` 历史上 `INNER JOIN todos` 取 title。

`d9780ce` 把 `loop_steps.step_id` 的 FK 从 `todos.id` 改到了 `steps.id`（环节成为可复用模板），但**这条 SQL 没跟着改**，仍然 JOIN `todos`：

```sql
-- 之前 (错)：
INNER JOIN todos t ON t.id = s.step_id
LEFT JOIN steps st ON st.id = s.step_id

-- 现在 (修)：
INNER JOIN steps st ON st.id = s.step_id
```

结果按错位 id 拉到错标题，例如 `loop_steps.step_id=2`（指向 `steps.id=2`="翻译笑话"）JOIN `todos` 时取到 `todos.id=2` 的 "[评审] 默认评审任务"。

### Bug 2：评审 todo 实例创建失败

dev 库 `schema_version` 跑到了 v24，其中历史 V 迁移已经 drop 掉了 `todos.worktree_enabled` 列（不在 `all_migrations()` 列表里 —— V20-V24 是幽灵迁移）。

但代码侧多处仍引用这个列：
- `db::entity::todos::Model` 仍然把 `worktree_enabled` 列在 `ActiveModel`
- `db/todo.rs` 的 `TodoUpdate` / `Todo` 构造 / 备份构造
- `models/mod.rs` 的 `Todo` / `UpdateTodoRequest` / `TodoBackup`
- `handlers/todo.rs` / `handlers/sync.rs` / `handlers/feishu_binding.rs`
- `services/feishu_listener.rs`
- `executor_service/worktree.rs::apply_worktree_flag`（执行器级 `--worktree` 开关）
- `executor_service/pre_spawn.rs::build_executor_command_args` 最后一参
- `frontend/src/types/todo.ts` / `utils/database/todos.ts` / `components/TodoDrawer.tsx` / `components/todo-drawer/reducer.ts`

最致命的是 `reuse_or_create_review_instance`：

```
rating gate: record #1314 triggering auto-review
rating gate: failed to reuse/create review instance todo: 
  Query Error: error returned from database: (code: 1) no such column: todos.worktree_enabled
```

评审 todo 实例 INSERT 失败 → `apply_rating_gate` 走 `return Ok((false, None))` → loop_runner 写 `loop_step_executions.rating = None` → 前端 `s.rating != null` 为 false → 显示"未评审"。

执行器级 worktree 开关（`todo.worktree_enabled` + `apply_worktree_flag`）原本是工作空间级 worktree（`project_directories.git_worktree_enabled`）的前置方案，覆盖面更窄（只 claudecode/hermes），且 `executor_service/worktree.rs::resolve_worktree_context` + `WorktreeService` 已经替代了它的功能，删干净。

## 改动

### Commit 1: `786a93c` — SQL JOIN 修复

- `db/loop_.rs::list_loop_steps_with_todo_meta` INNER JOIN 改为 `steps` 表
- 返回类型从 `(Model, String, String, String)` 简化到 `(Model, String, String)`（移除 `todo_status`，`steps` 表无 status 列）
- `LoopDetail` / `LoopStepDto` 删 `todo_status` / `todo_map` / `TodoSummary` 死字段
- `handlers/loop_.rs` 三处解构改三元组
- `frontend/src/types/loop.ts` 同步删 `todo_status` / `TodoSummaryForLoop` 死类型

### Commit 2: `1da5f2f` — 清理 worktree_enabled 残留

后端：
- `db/entity/todos.rs` 删 `pub worktree_enabled: Option<bool>`
- `db/todo.rs` 删 entity 转换 / `TodoUpdate` / `update_todo_worktree_enabled` 函数 / 三处 test fixture
- `db/mod.rs` test fixture 同步
- `models/mod.rs` 删 `Todo` / `UpdateTodoRequest` 字段
- `handlers/todo.rs` 删 `create_todo` / `update_todo` 中 worktree_enabled 写入
- `handlers/sync.rs` 删 sync payload worktree 字段
- `handlers/feishu_binding.rs` 删两次 `update_todo_worktree_enabled` 调用
- `services/feishu_listener.rs` 删一处调用 + test fixture 字段
- `executor_service/pre_spawn.rs` 删 `extract_todo_executor_fields` 第三位 + `build_executor_command_args` 最后一参 + import
- `executor_service/worktree.rs` 删 `apply_worktree_flag` 函数 + 5 条单测 + 文档注释

前端：
- `types/todo.ts` 删 `worktree_enabled?` 字段
- `utils/database/todos.ts` 删请求参数（保留 `git_worktree_enabled` 项目目录级）
- `components/TodoDrawer.tsx` 删 Git Worktree Switch 区块 + formState 字段 + save 调用
- `components/todo-drawer/reducer.ts` 删 `worktreeEnabled` state + initial + RESET_FORM

## 验证

```bash
cd backend && cargo build && cargo test
# 1148 个测试全过
```

```bash
cd frontend && npx tsc --noEmit
# 干净
```

端到端（dev 服务，loop #2 执行 #257）：

```
#1 step=讲个笑话      status=failed   rating=None
#2 step=讲个笑话      status=success  rating=75     (75 ≥ min_rating=40 PASS)
#3 step=是否科技笑话  status=success  rating=95     (95 ≥ min_rating=80 PASS)
#4 step=翻译笑话      status=success  rating=None   (无阈值, 不评审)
```

4 张卡片三个不同 step_name，rating 正常回写，loop 不再卡死在 step 1 自重试。

## 已知遗留

- `db/migration.rs:858` 历史 V 迁移里的 `ALTER TABLE todos ADD COLUMN worktree_enabled` 不可改（migration 不可变），保留作为历史记录
- dev 库 `schema_version` 表里 V20-V24 是幽灵迁移（reverted 分支残留），代码 `all_migrations()` 不列，运行时不会重新跑 —— 与本次清理互不影响

## Checklist

- [x] 单元测试 + 集成测试通过
- [x] TS 编译干净
- [x] 端到端触发 loop，评审跑通，rating 写入 DB
- [x] `git_worktree_enabled`（项目目录级）未被误删