### PR TITLE
chore(todo): 执行后自动评审默认关闭

### DIFF
--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -435,7 +435,9 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
             />
           </div>
 
-          {/* 执行后自动评审：仅对普通 todo（不是评审实例/模板）可见 */}
+          {/* 执行后自动评审：仅对普通 todo（不是评审实例/模板）可见。
+              业务上默认关闭（reducer 初始态为 false），仅在用户手动开启时启用；
+              loop 通过后端 API 创建 step todo，仍走 DB 默认 true，不受影响。 */}
           {(todo?.todo_type ?? 0) === 0 && (
             <>
               <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/frontend/src/components/todo-drawer/reducer.ts
+++ b/frontend/src/components/todo-drawer/reducer.ts
@@ -52,7 +52,10 @@ export const initialFormState: TodoFormState = {
   schedulerEnabled: false,
   schedulerConfig: '',
   acceptanceCriteria: '',
-  autoReviewEnabled: true,
+  // 默认关闭执行后自动评审：业务上不再需要该能力；
+  // loop 仍依赖自动评审，但其 step todo 由后端 API 创建，
+  // 走后端默认 true 的路径，不受此处默认值影响。
+  autoReviewEnabled: false,
 };
 
 /** 表单 reducer */
@@ -80,7 +83,9 @@ export function todoFormReducer(state: TodoFormState, action: TodoFormAction): T
           schedulerEnabled: action.todo.scheduler_enabled || false,
           schedulerConfig: action.todo.scheduler_config || '',
           acceptanceCriteria: action.todo.acceptance_criteria ?? '',
-          autoReviewEnabled: action.todo.auto_review_enabled ?? true,
+          // 编辑既有 todo 时若 DB 中未显式存值，默认关闭，
+          // 与创建模式默认值保持一致；老数据若显式开启则如实回填。
+          autoReviewEnabled: action.todo.auto_review_enabled ?? false,
         };
       }
       return initialFormState;


### PR DESCRIPTION
## 背景

业务上不再需要 todo 「执行后自动评审」能力。新建 / 编辑 todo 时，默认应处于关闭状态，避免误触发评审实例。

## 改动

- `frontend/src/components/todo-drawer/reducer.ts`
  - `initialFormState.autoReviewEnabled` 由 `true` 改为 `false`（新建模式默认值）。
  - `RESET_FORM` 编辑既有 todo 时回填默认值由 `?? true` 改为 `?? false`，与创建模式保持一致；DB 中显式开启的 todo 仍如实回填。
- `frontend/src/components/TodoDrawer.tsx`
  - 「执行后自动评审」区块上方注释补充默认关闭说明。

## 关于 loop 的依赖

loop 仍依赖自动评审，但其 step todo 由后端 API 创建，走 DB 默认值 `true` 的路径，不受本次 UI 默认值改动影响。后端 `create_todo` handler、migration 默认值均保持原状。

## 验证

- `npx tsc --noEmit` 通过（EXIT=0）。
- 改动文件：`src/components/TodoDrawer.tsx`、`src/components/todo-drawer/reducer.ts`，合计 2 个文件 +10/-3。

🤖 Generated with [Claude Code](https://claude.com/claude-code)