### PR TITLE
feat: 工作空间改为必填项，移除环路详情页新建按钮

### DIFF
--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -65,6 +65,10 @@ pub async fn create_loop(
     if req.name.trim().is_empty() {
         return Err(AppError::BadRequest("name 不能为空".to_string()));
     }
+    // 创建环路前校验工作空间必填
+    if req.workspace.trim().is_empty() {
+        return Err(AppError::BadRequest("workspace 不能为空".to_string()));
+    }
     // 创建环路前校验标签约束：环路只能选择一个标签
     if req.tag_ids.len() > 1 {
         return Err(AppError::BadRequest("环路只能选择一个标签".to_string()));
@@ -74,7 +78,7 @@ pub async fn create_loop(
         .create_loop(
             req.name.trim(),
             &req.description,
-            req.workspace.as_deref(),
+            Some(req.workspace.trim()),
             &req.icon,
             req.review_template_id,
         )

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -352,8 +352,8 @@ pub struct CreateLoopRequest {
     pub name: String,
     #[serde(default)]
     pub description: String,
-    #[serde(default)]
-    pub workspace: Option<String>,
+    /// 工作空间（项目目录路径），必填。
+    pub workspace: String,
     #[serde(default)]
     pub tag_ids: Vec<i64>,
     #[serde(default = "default_icon")]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { ConfigProvider, Layout, App as AntApp, message } from 'antd';
+import { ConfigProvider, Layout, App as AntApp, Modal, Select, message } from 'antd';
 import { PlusOutlined, ThunderboltOutlined, CloseOutlined, LeftOutlined } from '@ant-design/icons';
 import { AppProvider, useApp } from './hooks/useApp';
 import { useIsMobile } from './hooks/useIsMobile';
@@ -20,7 +20,7 @@ import { LoopDetailPanel } from './components/LoopStudioDetailPanel';
 import * as dbLoops from './utils/database/loops';
 import { EXECUTION_PANEL, SIDEBAR_WIDTH } from './constants';
 import * as db from './utils/database';
-import type { Config } from './types';
+import type { Config, ProjectDirectory } from './types';
 import zhCN from 'antd/locale/zh_CN';
 import './App.css';
 
@@ -34,6 +34,11 @@ function AppContent() {
   const [smartCreateOpen, setSmartCreateOpen] = useState(false);
   const [fabExpanded, setFabExpanded] = useState(false);
   const [appConfig, setAppConfig] = useState<Config | null>(null);
+  // 新建环路时的工作空间选择弹窗
+  const [loopCreateModalOpen, setLoopCreateModalOpen] = useState(false);
+  const [loopCreateWorkspace, setLoopCreateWorkspace] = useState<string | undefined>(undefined);
+  const [loopCreateCreating, setLoopCreateCreating] = useState(false);
+  const [loopCreateDirs, setLoopCreateDirs] = useState<ProjectDirectory[]>([]);
   // 从左侧环路列表选中某个 loop 时记录其 id，右侧面板展示 LoopDetailPanel
   const [selectedLoopId, setSelectedLoopId] = useState<number | null>(null);
   // ���左侧环节列表选中某个 step 时记录其 id，右侧面板展示 StepDetailPanel
@@ -234,14 +239,13 @@ function AppContent() {
               loopUpdateCount={loopUpdateCount}
               onShowSettings={() => handleShowView('settings')}
               onSelectLoop={handleSelectLoop}
-              onCreateLoop={async () => {
-                try {
-                  const res = await dbLoops.createLoop({ name: '新建环路', description: '' });
-                  setSelectedLoopId(res.id);
-                  setLoopUpdateCount(c => c + 1);
-                } catch (err) {
-                  message.error('创建失败');
-                }
+              onCreateLoop={() => {
+                // 打开工作空间选择弹窗，用户选定后创建环路
+                db.getProjectDirectories().then(dirs => {
+                  setLoopCreateDirs(dirs);
+                  setLoopCreateWorkspace(undefined);
+                  setLoopCreateModalOpen(true);
+                }).catch(() => message.error('加载项目目录失败'));
               }}
             />
           </div>
@@ -326,15 +330,6 @@ function AppContent() {
                       message.error('删除失败，环路可能正在被引用');
                     }
                   }}
-                  onCreate={async () => {
-                    try {
-                      const res = await dbLoops.createLoop({ name: '新建环路', description: '' });
-                      setSelectedLoopId(res.id);
-                      setLoopUpdateCount(c => c + 1);
-                    } catch (err) {
-                      message.error('创建失败');
-                    }
-                  }}
                   onToggleStatus={async () => {
                     try {
                       const loops = await dbLoops.listLoops();
@@ -397,6 +392,45 @@ function AppContent() {
           } catch {}
         }}
       />
+
+      {/* 新建环路工作空间选择弹窗：工作空间为必填项，选定后才创建环路 */}
+      <Modal
+        title="新建环路"
+        open={loopCreateModalOpen}
+        onCancel={() => setLoopCreateModalOpen(false)}
+        onOk={async () => {
+          if (!loopCreateWorkspace) {
+            message.error('请选择工作空间');
+            return;
+          }
+          setLoopCreateCreating(true);
+          try {
+            const res = await dbLoops.createLoop({ name: '新建环路', description: '', workspace: loopCreateWorkspace });
+            setSelectedLoopId(res.id);
+            setLoopUpdateCount(c => c + 1);
+            setLoopCreateModalOpen(false);
+          } catch (err) {
+            message.error('创建失败');
+          } finally {
+            setLoopCreateCreating(false);
+          }
+        }}
+        confirmLoading={loopCreateCreating}
+        okText="创建"
+        cancelText="取消"
+      >
+        <div style={{ marginTop: 16 }}>
+          {/* 工作空间下拉选择器：从项目目录列表中选取 */}
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>工作空间 <span style={{ color: '#ff4d4f' }}>*</span></div>
+          <Select
+            style={{ width: '100%' }}
+            placeholder="请选择工作空间"
+            value={loopCreateWorkspace}
+            onChange={setLoopCreateWorkspace}
+            options={loopCreateDirs.map(d => ({ label: d.name || d.path, value: d.path }))}
+          />
+        </div>
+      </Modal>
     </Layout>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { ConfigProvider, Layout, App as AntApp, Modal, Select, message } from 'antd';
+import { ConfigProvider, Layout, App as AntApp, message } from 'antd';
 import { PlusOutlined, ThunderboltOutlined, CloseOutlined, LeftOutlined } from '@ant-design/icons';
 import { AppProvider, useApp } from './hooks/useApp';
 import { useIsMobile } from './hooks/useIsMobile';
@@ -17,10 +17,11 @@ import { TodoDrawer } from './components/TodoDrawer';
 import { SmartCreateModal } from './components/SmartCreateModal';
 import { StepDetailPanel } from '@/components/StepDetailPanel';
 import { LoopDetailPanel } from './components/LoopStudioDetailPanel';
+import { LoopFormModal } from './components/LoopFormModal';
 import * as dbLoops from './utils/database/loops';
 import { EXECUTION_PANEL, SIDEBAR_WIDTH } from './constants';
 import * as db from './utils/database';
-import type { Config, ProjectDirectory } from './types';
+import type { Config } from './types';
 import zhCN from 'antd/locale/zh_CN';
 import './App.css';
 
@@ -34,11 +35,8 @@ function AppContent() {
   const [smartCreateOpen, setSmartCreateOpen] = useState(false);
   const [fabExpanded, setFabExpanded] = useState(false);
   const [appConfig, setAppConfig] = useState<Config | null>(null);
-  // 新建环路时的工作空间选择弹窗
+  // 新建环路弹窗（使用 LoopFormModal create 模式）
   const [loopCreateModalOpen, setLoopCreateModalOpen] = useState(false);
-  const [loopCreateWorkspace, setLoopCreateWorkspace] = useState<string | undefined>(undefined);
-  const [loopCreateCreating, setLoopCreateCreating] = useState(false);
-  const [loopCreateDirs, setLoopCreateDirs] = useState<ProjectDirectory[]>([]);
   // 从左侧环路列表选中某个 loop 时记录其 id，右侧面板展示 LoopDetailPanel
   const [selectedLoopId, setSelectedLoopId] = useState<number | null>(null);
   // ���左侧环节列表选中某个 step 时记录其 id，右侧面板展示 StepDetailPanel
@@ -240,12 +238,8 @@ function AppContent() {
               onShowSettings={() => handleShowView('settings')}
               onSelectLoop={handleSelectLoop}
               onCreateLoop={() => {
-                // 打开工作空间选择弹窗，用户选定后创建环路
-                db.getProjectDirectories().then(dirs => {
-                  setLoopCreateDirs(dirs);
-                  setLoopCreateWorkspace(undefined);
-                  setLoopCreateModalOpen(true);
-                }).catch(() => message.error('加载项目目录失败'));
+                // 打开 LoopFormModal 创建模式，用户填写完整信息后创建环路
+                setLoopCreateModalOpen(true);
               }}
             />
           </div>
@@ -393,44 +387,18 @@ function AppContent() {
         }}
       />
 
-      {/* 新建环路工作空间选择弹窗：工作空间为必填项，选定后才创建环路 */}
-      <Modal
-        title="新建环路"
+      {/* 新建环路弹窗 — 复用 LoopFormModal create 模式，用户填写完整信息后创建 */}
+      <LoopFormModal
         open={loopCreateModalOpen}
-        onCancel={() => setLoopCreateModalOpen(false)}
-        onOk={async () => {
-          if (!loopCreateWorkspace) {
-            message.error('请选择工作空间');
-            return;
-          }
-          setLoopCreateCreating(true);
-          try {
-            const res = await dbLoops.createLoop({ name: '新建环路', description: '', workspace: loopCreateWorkspace });
-            setSelectedLoopId(res.id);
-            setLoopUpdateCount(c => c + 1);
-            setLoopCreateModalOpen(false);
-          } catch (err) {
-            message.error('创建失败');
-          } finally {
-            setLoopCreateCreating(false);
-          }
+        mode="create"
+        tags={state.tags}
+        onSaved={(newLoopId) => {
+          if (newLoopId) setSelectedLoopId(newLoopId);
+          setLoopUpdateCount(c => c + 1);
+          setLoopCreateModalOpen(false);
         }}
-        confirmLoading={loopCreateCreating}
-        okText="创建"
-        cancelText="取消"
-      >
-        <div style={{ marginTop: 16 }}>
-          {/* 工作空间下拉选择器：从项目目录列表中选取 */}
-          <div style={{ marginBottom: 8, fontWeight: 500 }}>工作空间 <span style={{ color: '#ff4d4f' }}>*</span></div>
-          <Select
-            style={{ width: '100%' }}
-            placeholder="请选择工作空间"
-            value={loopCreateWorkspace}
-            onChange={setLoopCreateWorkspace}
-            options={loopCreateDirs.map(d => ({ label: d.name || d.path, value: d.path }))}
-          />
-        </div>
-      </Modal>
+        onClose={() => setLoopCreateModalOpen(false)}
+      />
     </Layout>
   );
 }

--- a/frontend/src/components/LoopFormModal.tsx
+++ b/frontend/src/components/LoopFormModal.tsx
@@ -1,0 +1,314 @@
+// 环路创建/编辑共用的 Form Modal。
+//
+// 设计要点：
+// - mode="create"：新建环路，保存后回传新 loopId
+// - mode="edit"：编辑已有环路，需传 loopId + initialData 预填
+// - 工作空间为必填项（创建模式强制，编辑模式 allowClear 但保存时校验不通过)
+// - 评审模板 inline 创建逻辑一并迁入，避免用户切到设置页
+//
+// 被 LoopStudioDetailPanel（编辑）和 App.tsx（新建）共用。
+
+import { useEffect, useState, useCallback } from 'react';
+import { App as AntApp, Modal, Form, Input, InputNumber, Select, Button } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
+import * as dbLoops from '@/utils/database/loops';
+import * as dbReviewTemplates from '@/utils/database/reviewTemplates';
+import * as db from '@/utils/database';
+import type { UpdateLoopRequest } from '@/types/loop';
+import type { ReviewTemplateOption } from '@/types/reviewTemplate';
+import { TagCheckCardGroup } from './TagCheckCard';
+
+// ---------- props ----------
+
+interface LoopFormModalProps {
+  open: boolean;
+  /** 'create' = 新建, 'edit' = 编辑 */
+  mode: 'create' | 'edit';
+  /** 编辑模式必传，创建模式不传 */
+  loopId?: number;
+  /** 编辑模式预填数据（创建模式不传） */
+  initialData?: {
+    name: string;
+    description: string;
+    workspace: string | null;
+    icon: string;
+    review_template_id: number | null;
+    tag_ids: number[];
+    limits_config: string | null;
+  };
+  /** 可用标签列表 */
+  tags: Array<{ id: number; name: string; color: string }>;
+  /** 保存成功回调（创建模式回传新 loopId） */
+  onSaved: (loopId?: number) => void;
+  onClose: () => void;
+}
+
+// ---------- Form values type ----------
+
+type FormValues = UpdateLoopRequest & {
+  max_step_executions?: number;
+  max_total_tokens?: number;
+};
+
+// ---------- component ----------
+
+export function LoopFormModal({
+  open, mode, loopId, initialData, tags, onSaved, onClose,
+}: LoopFormModalProps) {
+  const { message } = AntApp.useApp();
+  const [saving, setSaving] = useState(false);
+  const [form] = Form.useForm<FormValues>();
+  // 标签选中态（单选）
+  const [editingTag, setEditingTag] = useState<number | null>(null);
+  // 工作空间下拉选项
+  const [workspaceOptions, setWorkspaceOptions] = useState<{ label: string; value: string }[]>([]);
+  // 评审模板
+  const [reviewTemplateOptions, setReviewTemplateOptions] = useState<ReviewTemplateOption[]>([]);
+  const [creatingTemplate, setCreatingTemplate] = useState(false);
+  const [creatingTemplateSaving, setCreatingTemplateSaving] = useState(false);
+  const [newTemplateForm] = Form.useForm<{ name: string; description?: string; prompt: string }>();
+
+  // 打开时加载工作空间列表 + 评审模板选项
+  useEffect(() => {
+    if (!open) return;
+    // 加载项目目录用于工作空间下拉
+    db.getProjectDirectories()
+      .then(dirs => setWorkspaceOptions(dirs.map(d => ({ label: d.name || d.path, value: d.path }))))
+      .catch(() => { /* 静默 */ });
+    // 加载评审模板选项
+    dbReviewTemplates.listReviewTemplateOptions()
+      .then(setReviewTemplateOptions)
+      .catch(() => { /* 静默 */ });
+  }, [open]);
+
+  // 打开时（仅编辑模式）预填表单
+  useEffect(() => {
+    if (!open) return;
+    if (mode === 'edit' && initialData) {
+      form.setFieldsValue({
+        name: initialData.name,
+        description: initialData.description,
+        workspace: initialData.workspace ?? null,
+        icon: initialData.icon,
+        review_template_id: initialData.review_template_id ?? null,
+      });
+      // 解析 limits_config
+      try {
+        const lc = JSON.parse(initialData.limits_config || '{}');
+        form.setFieldsValue({
+          max_step_executions: lc.max_step_executions ?? null,
+          max_total_tokens: lc.max_total_tokens ?? null,
+        });
+      } catch { /* 忽略解析错误 */ }
+      setEditingTag(initialData.tag_ids?.[0] ?? null);
+    } else if (mode === 'create') {
+      // 创建模式：清空表单
+      form.resetFields();
+      setEditingTag(null);
+    }
+  }, [open, mode, initialData, form]);
+
+  // 刷新评审模板并选中新建的模板
+  const reloadTemplatesAndSelect = useCallback(async (selectedId: number) => {
+    const opts = await dbReviewTemplates.listReviewTemplateOptions();
+    setReviewTemplateOptions(opts);
+    form.setFieldsValue({ review_template_id: selectedId });
+  }, [form]);
+
+  // inline 创建评审模板
+  const handleCreateTemplate = useCallback(async () => {
+    const values = await newTemplateForm.validateFields();
+    setCreatingTemplateSaving(true);
+    try {
+      const created = await dbReviewTemplates.createReviewTemplate({
+        name: values.name.trim(),
+        description: values.description?.trim() || null,
+        prompt: values.prompt,
+      });
+      message.success(`已创建模板「${created.name}」`);
+      await reloadTemplatesAndSelect(created.id);
+      newTemplateForm.resetFields();
+      setCreatingTemplate(false);
+    } catch (e) {
+      message.error(`创建失败：${(e as Error).message}`);
+    } finally {
+      setCreatingTemplateSaving(false);
+    }
+  }, [newTemplateForm, message, reloadTemplatesAndSelect]);
+
+  // 保存（创建 / 编辑共用）
+  const handleSave = useCallback(async () => {
+    const values = await form.validateFields();
+    setSaving(true);
+    try {
+      // 构建 limits_config
+      const limitsConfig: Record<string, any> = {};
+      if (values.max_step_executions != null) limitsConfig.max_step_executions = values.max_step_executions;
+      if (values.max_total_tokens != null) limitsConfig.max_total_tokens = values.max_total_tokens;
+
+      const basePayload = {
+        name: values.name.trim(),
+        description: values.description ?? '',
+        workspace: values.workspace ?? null,
+        icon: values.icon ?? 'loop',
+        review_template_id: values.review_template_id ?? null,
+        limits_config: Object.keys(limitsConfig).length > 0 ? JSON.stringify(limitsConfig) : null,
+        tag_ids: editingTag != null ? [editingTag] : [],
+      };
+
+      if (mode === 'create') {
+        // 创建模式：工作空间必填
+        if (!values.workspace?.trim()) {
+          message.error('请选择工作空间');
+          setSaving(false);
+          return;
+        }
+        const res = await dbLoops.createLoop({
+          name: basePayload.name,
+          description: basePayload.description,
+          workspace: values.workspace.trim(),
+          tag_ids: basePayload.tag_ids,
+          icon: basePayload.icon,
+          review_template_id: basePayload.review_template_id,
+        });
+        message.success('环路已创建');
+        onSaved(res.id);
+      } else {
+        // 编辑模式
+        if (!loopId) return;
+        await dbLoops.updateLoop(loopId, basePayload);
+        message.success('已保存');
+        onSaved();
+      }
+      onClose();
+    } catch (e) {
+      message.error(mode === 'create' ? '创建失败' : '保存失败，请重试');
+    } finally {
+      setSaving(false);
+    }
+  }, [form, editingTag, mode, loopId, message, onSaved, onClose]);
+
+  return (
+    <>
+      {/* 主表单 Modal */}
+      <Modal
+        title={mode === 'create' ? '新建环路' : '编辑 loop'}
+        open={open}
+        onCancel={onClose}
+        onOk={handleSave}
+        okText={mode === 'create' ? '创建' : '保存'}
+        cancelText="取消"
+        confirmLoading={saving}
+        width={560}
+        destroyOnClose
+      >
+        <Form form={form} layout="vertical">
+          {/* 名称：必填 */}
+          <Form.Item label="名称" name="name" rules={[{ required: true, message: '名称必填' }]}>
+            <Input maxLength={100} />
+          </Form.Item>
+          <Form.Item label="描述" name="description">
+            <Input.TextArea rows={2} maxLength={500} />
+          </Form.Item>
+          {/* 工作空间：创建模式必填，编辑模式可选 */}
+          <Form.Item
+            label={<>工作空间 {mode === 'create' && <span style={{ color: '#ff4d4f' }}>*</span>}</>
+          }
+            name="workspace"
+            tooltip="此 loop 所属的工作空间"
+            rules={mode === 'create' ? [{ required: true, message: '请选择工作空间' }] : []}
+          >
+            <Select
+              allowClear
+              placeholder="选择工作空间"
+              options={workspaceOptions}
+              showSearch
+              optionFilterProp="label"
+            />
+          </Form.Item>
+          {tags.length > 0 && (
+            <Form.Item label="标签">
+              <TagCheckCardGroup
+                tags={tags}
+                value={editingTag}
+                onChange={(val) => setEditingTag(val as number | null)}
+              />
+            </Form.Item>
+          )}
+          <Form.Item label="图标" name="icon" tooltip="预留字段, 当前仅展示">
+            <Input placeholder="loop" maxLength={50} />
+          </Form.Item>
+          {/* 评审模板 */}
+          <Form.Item
+            label="评审模板"
+            name="review_template_id"
+            tooltip="选择用于自动评审的模板（来自设置 → 评审模板管理）。不选则使用默认模板。"
+            extra={
+              <Button
+                type="link"
+                size="small"
+                icon={<PlusOutlined />}
+                style={{ padding: 0, marginTop: 4 }}
+                onClick={() => setCreatingTemplate(true)}
+              >
+                新建模板
+              </Button>
+            }
+          >
+            <Select
+              allowClear
+              placeholder="使用默认评审模板"
+              showSearch
+              optionFilterProp="label"
+              options={reviewTemplateOptions.map(t => ({ value: t.id, label: t.name }))}
+            />
+          </Form.Item>
+          {/* 全局限制 */}
+          <div style={{ fontWeight: 600, fontSize: 14, marginTop: 16, marginBottom: 12, color: 'var(--color-text-secondary, #64748b)' }}>
+            全局限制
+          </div>
+          <div style={{ background: 'var(--color-bg-elevated, #f8fafc)', padding: 12, borderRadius: 8 }}>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+              <Form.Item label="最大执行步数" name={['max_step_executions']} tooltip="超出后自动终止 Loop（留空=不限制）">
+                <InputNumber min={1} max={9999} placeholder="不限" style={{ width: '100%' }} />
+              </Form.Item>
+              <Form.Item label="最大 Token 数" name={['max_total_tokens']} tooltip="超出后自动终止（留空=不限制）">
+                <InputNumber min={1} max={9999999999} placeholder="不限" style={{ width: '100%' }} step={1000000} />
+              </Form.Item>
+            </div>
+          </div>
+        </Form>
+      </Modal>
+
+      {/* inline 新建评审模板的 Modal */}
+      <Modal
+        title="新建评审模板"
+        open={creatingTemplate}
+        onCancel={() => {
+          newTemplateForm.resetFields();
+          setCreatingTemplate(false);
+        }}
+        onOk={handleCreateTemplate}
+        confirmLoading={creatingTemplateSaving}
+        destroyOnClose
+      >
+        <Form form={newTemplateForm} layout="vertical" preserve={false}>
+          <Form.Item label="名称" name="name" rules={[{ required: true, message: '请输入名称' }]}>
+            <Input placeholder="如：代码评审 / 文档评审" maxLength={128} />
+          </Form.Item>
+          <Form.Item label="描述" name="description">
+            <Input placeholder="（可选）简短说明这个模板的用途" maxLength={512} />
+          </Form.Item>
+          <Form.Item
+            label="Prompt 模板"
+            name="prompt"
+            rules={[{ required: true, message: '请输入 prompt 模板' }]}
+            tooltip="支持占位符 {original_prompt} {original_output} {acceptance_criteria} {max_output_chars}"
+          >
+            <Input.TextArea rows={8} placeholder="你是一个评审师…" />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+}

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -40,7 +40,6 @@ interface LoopDetailPanelProps {
   onTrigger: () => void;
   onDuplicate: () => void;
   onDelete: () => void;
-  onCreate: () => void;
   onToggleStatus: () => void;
   onChanged: () => void;
 }
@@ -51,7 +50,6 @@ export function LoopDetailPanel({
   onTrigger,
   onDuplicate,
   onDelete,
-  onCreate,
   onToggleStatus,
   onChanged,
 }: LoopDetailPanelProps) {
@@ -253,9 +251,6 @@ export function LoopDetailPanel({
           </Tooltip>
           <Tooltip title="编辑">
             <Button size="small" icon={<EditOutlined />} onClick={handleOpenEdit} />
-          </Tooltip>
-          <Tooltip title="新建">
-            <Button size="small" icon={<PlusOutlined />} onClick={onCreate} />
           </Tooltip>
           <Popconfirm
             title="删除 loop"

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -12,23 +12,20 @@
 import { useEffect, useState, useCallback } from 'react';
 import {
   Skeleton, App as AntApp, Button, Space, Tooltip, Popconfirm, Empty,
-  Modal, Form, Input, InputNumber, Collapse, Select, Switch,
+  Collapse, Switch,
 } from 'antd';
 import {
   ThunderboltOutlined,
   CopyOutlined,
   DeleteOutlined,
   EditOutlined,
-  PlusOutlined,
   ExclamationCircleOutlined,
 } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
-import * as dbReviewTemplates from '@/utils/database/reviewTemplates';
 import * as db from '@/utils/database';
-import type { LoopDetail, UpdateLoopRequest } from '@/types/loop';
-import type { ReviewTemplateOption } from '@/types/reviewTemplate';
+import type { LoopDetail } from '@/types/loop';
 import type { ProjectDirectory } from '@/types';
-import { TagCheckCardGroup } from './TagCheckCard';
+import { LoopFormModal } from './LoopFormModal';
 import { LoopTriggersPanel, TRIGGER_META } from './LoopStudioTriggersPanel';
 import { LoopStepsPanel } from './LoopStudioStepsPanel';
 import { LoopExecutionsPanel } from './LoopStudioExecutionsPanel';
@@ -58,10 +55,6 @@ export function LoopDetailPanel({
   const [loading, setLoading] = useState(true);
   // 基础信息编辑 modal 开关 (替代之前的 inline 编辑)
   const [editing, setEditing] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [form] = Form.useForm<UpdateLoopRequest & { max_step_executions?: number; max_total_tokens?: number }>();
-  // 工作空间下拉选项
-  const [workspaceOptions, setWorkspaceOptions] = useState<{ label: string; value: string }[]>([]);
   // 完整的项目目录列表（用于展示详情）
   const [projectDirs, setProjectDirs] = useState<ProjectDirectory[]>([]);
   // 执行记录总数，由 LoopExecutionsPanel 通过回调更新
@@ -69,8 +62,12 @@ export function LoopDetailPanel({
   // 从 loop.limits_config 解析出的限制值，传递给子面板做兜底校验
   const [maxStepExecutions, setMaxStepExecutions] = useState<number | null>(null);
   const [maxTotalTokens, setMaxTotalTokens] = useState<number | null>(null);
-  // 编辑时选中的标签（单选）
-  const [editingTag, setEditingTag] = useState<number | null>(null);
+  // 编辑弹窗预填数据，从 detail 提取
+  const [editInitialData, setEditInitialData] = useState<{
+    name: string; description: string; workspace: string | null;
+    icon: string; review_template_id: number | null;
+    tag_ids: number[]; limits_config: string | null;
+  } | null>(null);
 
   // 加载完整 detail, 子面板变更后也要重新拉以保持最新
   const reload = useCallback(() => {
@@ -78,20 +75,9 @@ export function LoopDetailPanel({
     dbLoops.getLoop(loopId)
       .then((d) => {
         setDetail(d);
-        form.setFieldsValue({
-          name: d.name,
-          description: d.description,
-          workspace: d.workspace,
-          icon: d.icon,
-        });
-        // 解析 limits_config 到同一 form
+        // 解析 limits_config 缓存限制值，传递给子面板做跳转自身时的兜底校验
         try {
           const lc = JSON.parse(d.limits_config || '{}');
-          form.setFieldsValue({
-            max_step_executions: lc.max_step_executions ?? null,
-            max_total_tokens: lc.max_total_tokens ?? null,
-          });
-          // 缓存限制值，传递给子面板做跳转自身时的兜底校验
           setMaxStepExecutions(lc.max_step_executions ?? null);
           setMaxTotalTokens(lc.max_total_tokens ?? null);
         } catch {
@@ -103,64 +89,16 @@ export function LoopDetailPanel({
         setDetail(null);
       })
       .finally(() => setLoading(false));
-  }, [loopId, form, message]);
+  }, [loopId, message]);
 
   useEffect(() => { reload(); }, [reload]);
 
-  // 加载工作空间列表供下拉选择
+  // 加载项目目录列表（用于详情页展示工作空间名称）
   useEffect(() => {
     db.getProjectDirectories()
-      .then(dirs => {
-        setProjectDirs(dirs);
-        setWorkspaceOptions(
-          dirs.map(d => ({ label: d.name || d.path, value: d.path }))
-        );
-      })
+      .then(dirs => setProjectDirs(dirs))
       .catch(() => { /* 静默 */ });
   }, []);
-
-  // 评审模板下拉选项 (含 inline 「+ 新建模板」流程所需)
-  const [reviewTemplateOptions, setReviewTemplateOptions] = useState<ReviewTemplateOption[]>([]);
-  const [creatingTemplate, setCreatingTemplate] = useState(false);
-  const [creatingTemplateSaving, setCreatingTemplateSaving] = useState(false);
-  const [newTemplateForm] = Form.useForm<{ name: string; description?: string; prompt: string }>();
-
-  // 加载评审模板选项；保存/创建后也要重新拉以保持最新
-  const reloadTemplateOptions = useCallback(() => {
-    dbReviewTemplates.listReviewTemplateOptions()
-      .then(setReviewTemplateOptions)
-      .catch(() => { /* 静默：模板加载失败不影响 loop 编辑 */ });
-  }, []);
-
-  useEffect(() => { reloadTemplateOptions(); }, [reloadTemplateOptions]);
-
-  /**
-   * Inline 创建评审模板：弹一个小 Modal，输入 name + prompt，保存后
-   * 1) 把新模板写回 reviewTemplateOptions  2) 把 Select 当前值置为新 id
-   * 避免用户先关掉 loop 编辑器去设置里建模板再回来。
-   */
-  const handleCreateTemplate = useCallback(async () => {
-    const values = await newTemplateForm.validateFields();
-    setCreatingTemplateSaving(true);
-    try {
-      const created = await dbReviewTemplates.createReviewTemplate({
-        name: values.name.trim(),
-        description: values.description?.trim() || null,
-        prompt: values.prompt,
-      });
-      message.success(`已创建模板「${created.name}」`);
-      // 刷新下拉 + 立即选中新建的
-      const opts = await dbReviewTemplates.listReviewTemplateOptions();
-      setReviewTemplateOptions(opts);
-      form.setFieldsValue({ review_template_id: created.id });
-      newTemplateForm.resetFields();
-      setCreatingTemplateSaving(false);
-      setCreatingTemplate(false);
-    } catch (e) {
-      message.error(`创建失败：${(e as Error).message}`);
-      setCreatingTemplateSaving(false);
-    }
-  }, [form, message, newTemplateForm]);
 
   // 预加载执行记录总数（用于折叠标签展示，不等用户展开后才显示）
   useEffect(() => {
@@ -169,53 +107,28 @@ export function LoopDetailPanel({
       .catch(() => { /* 静默 */ });
   }, [loopId]);
 
-  // 打开编辑 modal
+  // 打开编辑 modal：从 detail 提取预填数据
   const handleOpenEdit = useCallback(() => {
     if (!detail) return;
-    form.setFieldsValue({
+    setEditInitialData({
       name: detail.name,
       description: detail.description,
       workspace: detail.workspace,
       icon: detail.icon,
-      // review_template_id 是 Option<i64>，null 也要能透传
       review_template_id: detail.review_template_id ?? null,
+      tag_ids: detail.tag_ids ?? [],
+      limits_config: detail.limits_config,
     });
-    // 初始化标签（单选）
-    setEditingTag(detail.tag_ids?.[0] ?? null);
     setEditing(true);
-  }, [detail, form]);
+  }, [detail]);
 
-  // 保存基础信息 (后端要求全量)
-  const handleSave = useCallback(async () => {
-    const values = await form.validateFields();
-    setSaving(true);
-    try {
-      // 构建 limits_config（从主 form 读取）
-      const limitsConfig: Record<string, any> = {};
-      if (values.max_step_executions != null) limitsConfig.max_step_executions = values.max_step_executions;
-      if (values.max_total_tokens != null) limitsConfig.max_total_tokens = values.max_total_tokens;
-
-      // 一次性保存基础信息+标签，避免分两次 API 调用导致部分提交风险
-      await dbLoops.updateLoop(loopId, {
-        name: values.name.trim(),
-        description: values.description ?? '',
-        workspace: values.workspace ?? null,
-        icon: values.icon ?? 'loop',
-        review_template_id: values.review_template_id ?? null,
-        limits_config: Object.keys(limitsConfig).length > 0 ? JSON.stringify(limitsConfig) : null,
-        // 标签合并到同一请求体中，后端 handler 在更新基本信息后一并持久化标签关联
-        tag_ids: editingTag != null ? [editingTag] : [],
-      });
-      message.success('已保存');
-      setEditing(false);
-      reload();
-      onChanged();
-    } catch (e) {
-      message.error('保存失败，请重试');
-    } finally {
-      setSaving(false);
-    }
-  }, [form, loopId, editingTag, message, reload, onChanged]);
+  // 编辑保存后的回调：刷新详情 + 通知父组件
+  const handleEditSaved = useCallback(() => {
+    setEditing(false);
+    setEditInitialData(null);
+    reload();
+    onChanged();
+  }, [reload, onChanged]);
 
   if (loading && !detail) {
     return <Skeleton active style={{ padding: 24 }} />;
@@ -446,127 +359,19 @@ export function LoopDetailPanel({
         />
       </div>
 
-      {/* 编辑基础信息 modal — 替代之前的 inline 编辑 */}
-      <Modal
-        title="编辑 loop"
+      {/* 编辑基础信息 modal — 复用 LoopFormModal 组件 */}
+      <LoopFormModal
         open={editing}
-        onCancel={() => setEditing(false)}
-        onOk={handleSave}
-        okText="保存"
-        cancelText="取消"
-        confirmLoading={saving}
-        width={560}
-        destroyOnClose
-      >
-        <Form form={form} layout="vertical">
-          <Form.Item label="名称" name="name" rules={[{ required: true, message: '名称必填' }]}>
-            <Input maxLength={100} />
-          </Form.Item>
-          <Form.Item label="描述" name="description">
-            <Input.TextArea rows={2} maxLength={500} />
-          </Form.Item>
-          <Form.Item label="关联工作空间" name="workspace" tooltip="此 loop 所属的工作空间">
-            <Select
-              allowClear
-              placeholder="选择工作空间"
-              options={workspaceOptions}
-              showSearch
-              optionFilterProp="label"
-            />
-          </Form.Item>
-          {tags.length > 0 && (
-            <Form.Item label="标签">
-              <TagCheckCardGroup
-                tags={tags}
-                value={editingTag}
-                onChange={(val) => setEditingTag(val as number | null)}
-              />
-            </Form.Item>
-          )}
-          <Form.Item label="图标" name="icon" tooltip="预留字段, 当前仅展示">
-            <Input placeholder="loop" maxLength={50} />
-          </Form.Item>
-          <Form.Item
-            label="评审模板"
-            name="review_template_id"
-            tooltip="选择用于自动评审的模板（来自设置 → 评审模板管理）。不选则使用默认模板。"
-            extra={
-              <Button
-                type="link"
-                size="small"
-                icon={<PlusOutlined />}
-                style={{ padding: 0, marginTop: 4 }}
-                onClick={() => setCreatingTemplate(true)}
-              >
-                新建模板
-              </Button>
-            }
-          >
-            <Select
-              allowClear
-              placeholder="使用默认评审模板"
-              showSearch
-              optionFilterProp="label"
-              // 不传 options 会被 antd 当成"自定义模板字符串"模式（与 value 是 number 冲突）。
-              options={reviewTemplateOptions.map((t) => ({
-                value: t.id,
-                label: t.name,
-              }))}
-            />
-          </Form.Item>
-          {/* ── 全局限制 ── */}
-          <div style={{ fontWeight: 600, fontSize: 14, marginTop: 16, marginBottom: 12, color: 'var(--color-text-secondary, #64748b)' }}>
-            全局限制
-          </div>
-          <div style={{ background: 'var(--color-bg-elevated, #f8fafc)', padding: 12, borderRadius: 8 }}>
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-              <Form.Item label="最大执行步数" name={['max_step_executions']} tooltip="超出后自动终止 Loop（留空=不限制）">
-                <InputNumber min={1} max={9999} placeholder="不限" style={{ width: '100%' }} />
-              </Form.Item>
-              <Form.Item label="最大 Token 数" name={['max_total_tokens']} tooltip="超出后自动终止（留空=不限制）">
-                <InputNumber min={1} max={9999999999} placeholder="不限" style={{ width: '100%' }} step={1000000} />
-              </Form.Item>
-            </div>
-          </div>
-        </Form>
-      </Modal>
-
-      {/* Inline 新建评审模板的 Modal：在 loop 编辑器内就能创建并立即选中。 */}
-      <Modal
-        title="新建评审模板"
-        open={creatingTemplate}
-        onCancel={() => {
-          newTemplateForm.resetFields();
-          setCreatingTemplate(false);
+        mode="edit"
+        loopId={loopId}
+        initialData={editInitialData ?? undefined}
+        tags={tags}
+        onSaved={handleEditSaved}
+        onClose={() => {
+          setEditing(false);
+          setEditInitialData(null);
         }}
-        onOk={handleCreateTemplate}
-        confirmLoading={creatingTemplateSaving}
-        destroyOnClose
-      >
-        <Form form={newTemplateForm} layout="vertical" preserve={false}>
-          <Form.Item
-            label="名称"
-            name="name"
-            rules={[{ required: true, message: '请输入名称' }]}
-          >
-            <Input placeholder="如：代码评审 / 文档评审" maxLength={128} />
-          </Form.Item>
-          <Form.Item label="描述" name="description">
-            <Input placeholder="（可选）简短说明这个模板的用途" maxLength={512} />
-          </Form.Item>
-          <Form.Item
-            label="Prompt 模板"
-            name="prompt"
-            rules={[{ required: true, message: '请输入 prompt 模板' }]}
-            tooltip="支持占位符 {original_prompt} {original_output} {acceptance_criteria} {max_output_chars}"
-          >
-            <Input.TextArea
-              rows={8}
-              placeholder="你是一个评审师…"
-            />
-          </Form.Item>
-        </Form>
-      </Modal>
+      />
     </div>
   );
 }

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -217,6 +217,12 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
       return;
     }
 
+    // 创建模式：工作空间为必填项
+    if (!isEditMode && !workspace.trim()) {
+      message.error('请选择项目目录（工作空间）');
+      return;
+    }
+
     setLoading(true);
     try {
       const trimmedWorkspace = workspace.trim() || null;
@@ -356,7 +362,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
           <div style={{ marginBottom: 16 }}>
             <div style={{ marginBottom: 10, fontWeight: 600, fontSize: 14 }}>
               <FolderOutlined style={{ color: 'var(--color-primary)', marginRight: 6 }} />
-              项目目录
+              项目目录 <span style={{ color: '#ff4d4f' }}>*</span>
             </div>
             {projectDirectories.length === 0 ? (
               // 没有可用项目目录时给出空态提示，避免用户面对一个无选项的下拉茫然

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -271,7 +271,8 @@ export interface LoopExecutionListResponse {
 export interface CreateLoopRequest {
   name: string;
   description?: string;
-  workspace?: string | null;
+  /** 工作空间（项目目录路径），必填。 */
+  workspace: string;
   tag_ids?: number[];
   /** 创建时可选预绑定单个标签；省略时后端按空标签处理，兼容旧调用方。 */
   icon?: string;


### PR DESCRIPTION
## 变更内容

### 工作空间(workspace)改为必填
- 创建**事项**时，必须选择项目目录（工作空间），未选时阻止提交，UI 加红色 `*` 标记
- 创建**环路**时，侧边栏「新建」改为弹出工作空间选择弹窗，选定后才创建

### 移除环路详情页右上角「新建」入口
- 删除 `LoopStudioDetailPanel` 顶部的「新建」按钮及 `onCreate` prop
- 保留左侧侧边栏「事项/环节/环路」下方的「新建」按钮（唯一入口）

### 后端 API
- `CreateLoopRequest.workspace` 由可选改为必填（`Option<String>` → `String`）
- 空 workspace 返回 400 BadRequest

## 验证
- [x] TypeScript 编译通过（`npx tsc --noEmit` 零错误）
- [x] 开发服务启动正常（`make dev`），API 返回 200
