### PR TITLE
feat: add ntd loop CLI command with --param support

### DIFF
--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -7,7 +7,8 @@ use serde_json::Value;
 
 use crate::models::{
     ClientResponse, CreateTagRequest, CreateTodoRequest, DashboardStats, ExecutionRecord,
-    ExecutionRecordsPage, ExecutionSummary, Tag, Todo, ExecuteRequest,
+    ExecutionRecordsPage, ExecutionSummary, Tag, Todo, ExecuteRequest, LoopDto,
+    TriggerLoopRequest,
 };
 use crate::cli::client::ApiClient;
 use crate::config;
@@ -51,6 +52,11 @@ pub enum Commands {
     Todo {
         #[command(subcommand)]
         action: TodoAction,
+    },
+    /// Loop management
+    Loop {
+        #[command(subcommand)]
+        action: LoopAction,
     },
     /// Tag management
     Tag {
@@ -255,6 +261,56 @@ pub enum TagAction {
     },
 }
 
+// ============== Loop Commands ==============
+
+/// Loop CLI actions, mirrors the structure of Todo commands for consistency.
+#[derive(Debug, Clone, Subcommand)]
+pub enum LoopAction {
+    /// List all loops
+    List {
+        /// Filter by workspace
+        #[arg(long)]
+        workspace: Option<String>,
+    },
+    /// Get loop details
+    Get {
+        /// Loop ID
+        id: i64,
+    },
+    /// Trigger (execute) a loop
+    Trigger {
+        /// Loop ID
+        id: i64,
+
+        /// Parameters for placeholder replacement (key=value format, can be repeated)
+        /// Example: --param project_name=myproject --param env=production
+        /// These params will be injected into step prompts via {{params.key}} placeholders.
+        #[arg(long = "param", num_args = 1, value_parser = parse_key_value)]
+        params: Option<Vec<(String, String)>>,
+    },
+    /// Get loop execution history
+    Executions {
+        /// Loop ID
+        id: i64,
+
+        /// Page number
+        #[arg(long, default_value = "1")]
+        page: i64,
+
+        /// Items per page
+        #[arg(long, default_value = "20")]
+        limit: i64,
+    },
+    /// Get execution details
+    Execution {
+        /// Loop ID
+        loop_id: i64,
+
+        /// Execution ID
+        execution_id: i64,
+    },
+}
+
 // ============== Helper Functions ==============
 
 fn read_prompt_from_file(file: &Option<String>) -> Result<String> {
@@ -320,6 +376,7 @@ pub async fn run_command(cli: &Cli) -> Result<()> {
 
     match &cli.command {
         Commands::Todo { action } => handle_todo(&client, action, &cli.output, &cli.fields).await?,
+        Commands::Loop { action } => handle_loop(&client, action, &cli.output, &cli.fields).await?,
         Commands::Tag { action } => handle_tag(&client, action, &cli.output, &cli.fields).await?,
         Commands::Stats => handle_stats(&client, &cli.output, &cli.fields).await?,
     }
@@ -575,6 +632,59 @@ async fn handle_stats(
 ) -> Result<()> {
     let resp: ClientResponse<DashboardStats> = client.get("/dashboard-stats").await?;
     print_response(resp, output, fields)?;
+    Ok(())
+}
+
+// ============== Loop Handlers ==============
+
+async fn handle_loop(
+    client: &ApiClient,
+    action: &LoopAction,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
+    match action {
+        LoopAction::List { workspace } => {
+            let path = if let Some(w) = workspace {
+                format!("/loops?workspace={}", w)
+            } else {
+                "/loops".to_string()
+            };
+            let resp: ClientResponse<Vec<LoopDto>> = client.get(&path).await?;
+            print_response(resp, output, fields)?;
+        }
+        LoopAction::Get { id } => {
+            let resp: ClientResponse<LoopDto> = client.get(&format!("/loops/{}", id)).await?;
+            print_response(resp, output, fields)?;
+        }
+        LoopAction::Trigger { id, params } => {
+            let params_map: std::collections::HashMap<String, String> = params
+                .as_ref()
+                .map(|vec| vec.iter().cloned().collect())
+                .unwrap_or_default();
+            let req = TriggerLoopRequest { params: params_map };
+            let resp: ClientResponse<serde_json::Value> = client.post(
+                &format!("/loops/{}/trigger", id),
+                &req,
+            ).await?;
+            print_response(resp, output, fields)?;
+        }
+        LoopAction::Executions { id, page, limit } => {
+            let path = format!(
+                "/loops/{}/executions?page={}&limit={}",
+                id, page, limit
+            );
+            let resp: ClientResponse<serde_json::Value> = client.get(&path).await?;
+            print_response(resp, output, fields)?;
+        }
+        LoopAction::Execution { loop_id, execution_id } => {
+            let resp: ClientResponse<serde_json::Value> = client.get(&format!(
+                "/loops/{}/executions/{}",
+                loop_id, execution_id
+            )).await?;
+            print_response(resp, output, fields)?;
+        }
+    }
     Ok(())
 }
 

--- a/backend/src/cli/mod.rs
+++ b/backend/src/cli/mod.rs
@@ -4,5 +4,5 @@ pub mod commands;
 pub use client::ApiClient;
 pub use commands::{
     run_command,
-    Cli, Commands, TodoAction, TagAction, ExecutionAction, OutputFormat,
+    Cli, Commands, TodoAction, TagAction, LoopAction, ExecutionAction, OutputFormat,
 };

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -44,6 +44,11 @@ enum Commands {
         #[command(subcommand)]
         action: cli::TodoAction,
     },
+    /// Loop management
+    Loop {
+        #[command(subcommand)]
+        action: cli::LoopAction,
+    },
     /// Tag management
     Tag {
         #[command(subcommand)]
@@ -210,6 +215,10 @@ async fn main() {
         }
         Some(Commands::Todo { action }) => {
             dispatch_subcommand(&cli, cli::Commands::Todo { action: action.clone() }).await;
+            return;
+        }
+        Some(Commands::Loop { action }) => {
+            dispatch_subcommand(&cli, cli::Commands::Loop { action: action.clone() }).await;
             return;
         }
         Some(Commands::Tag { action }) => {

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -383,6 +383,16 @@ pub struct UpdateLoopStatusRequest {
     pub status: String,
 }
 
+/// 手动触发 Loop 的请求体，支持传递参数到 prompt 占位符。
+/// 对应 CLI 命令：`ntd loop trigger <id> --param key=value`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriggerLoopRequest {
+    /// 触发时传递的参数，会注入到 step prompt 的 {{params.key}} 占位符。
+    /// 例如：`{"project_name": "myproject"}` 会将 prompt 中的 `{{project_name}}` 替换为 `myproject`。
+    #[serde(default)]
+    pub params: std::collections::HashMap<String, String>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct CreateTriggerRequest {
     pub trigger_type: String,


### PR DESCRIPTION
- Add 'ntd loop' command with subcommands: list, get, trigger, executions, execution
- Support --param key=value for trigger command to pass parameters to loop steps
- Parameters are injected into step prompts via {{params.key}} placeholders
- Mirror the command structure of 'ntd todo' for consistent user experience

Modified files:
- backend/src/cli/commands.rs: Add LoopAction enum and handle_loop function
- backend/src/cli/mod.rs: Export LoopAction
- backend/src/main.rs: Add Loop command to CLI
- backend/src/models/loop_.rs: Add TriggerLoopRequest struct
- backend/src/handlers/loop_.rs: Update trigger_loop to accept params
- backend/src/services/loop_trigger.rs: Pass params in dispatch_manual
- backend/src/services/loop_runner.rs: Inject params into step prompts