### PR TITLE
refactor: 统一工作空间选择组件

### DIFF
--- a/frontend/src/components/LoopFormModal.tsx
+++ b/frontend/src/components/LoopFormModal.tsx
@@ -13,10 +13,10 @@ import { App as AntApp, Modal, Form, Input, InputNumber, Select, Button } from '
 import { PlusOutlined } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
 import * as dbReviewTemplates from '@/utils/database/reviewTemplates';
-import * as db from '@/utils/database';
 import type { UpdateLoopRequest } from '@/types/loop';
 import type { ReviewTemplateOption } from '@/types/reviewTemplate';
 import { TagCheckCardGroup } from './TagCheckCard';
+import { WorkspaceSelect } from './common/WorkspaceSelect';
 
 // ---------- props ----------
 
@@ -60,22 +60,17 @@ export function LoopFormModal({
   const [form] = Form.useForm<FormValues>();
   // 标签选中态（单选）
   const [editingTag, setEditingTag] = useState<number | null>(null);
-  // 工作空间下拉选项
-  const [workspaceOptions, setWorkspaceOptions] = useState<{ label: string; value: string }[]>([]);
+  // 工作空间受控值（与 form.setFieldsValue 配合，避免直接操作 form 内部状态）
+  const [workspaceValue, setWorkspaceValue] = useState<string | null>(null);
   // 评审模板
   const [reviewTemplateOptions, setReviewTemplateOptions] = useState<ReviewTemplateOption[]>([]);
   const [creatingTemplate, setCreatingTemplate] = useState(false);
   const [creatingTemplateSaving, setCreatingTemplateSaving] = useState(false);
   const [newTemplateForm] = Form.useForm<{ name: string; description?: string; prompt: string }>();
 
-  // 打开时加载工作空间列表 + 评审模板选项
+  // 打开时加载评审模板选项
   useEffect(() => {
     if (!open) return;
-    // 加载项目目录用于工作空间下拉
-    db.getProjectDirectories()
-      .then(dirs => setWorkspaceOptions(dirs.map(d => ({ label: d.name || d.path, value: d.path }))))
-      .catch(() => { /* 静默 */ });
-    // 加载评审模板选项
     dbReviewTemplates.listReviewTemplateOptions()
       .then(setReviewTemplateOptions)
       .catch(() => { /* 静默 */ });
@@ -88,10 +83,10 @@ export function LoopFormModal({
       form.setFieldsValue({
         name: initialData.name,
         description: initialData.description,
-        workspace: initialData.workspace ?? null,
         icon: initialData.icon,
         review_template_id: initialData.review_template_id ?? null,
       });
+      setWorkspaceValue(initialData.workspace ?? null);
       // 解析 limits_config
       try {
         const lc = JSON.parse(initialData.limits_config || '{}');
@@ -105,6 +100,7 @@ export function LoopFormModal({
       // 创建模式：清空表单
       form.resetFields();
       setEditingTag(null);
+      setWorkspaceValue(null);
     }
   }, [open, mode, initialData, form]);
 
@@ -149,7 +145,7 @@ export function LoopFormModal({
       const basePayload = {
         name: values.name.trim(),
         description: values.description ?? '',
-        workspace: values.workspace ?? null,
+        workspace: workspaceValue ?? null,
         icon: values.icon ?? 'loop',
         review_template_id: values.review_template_id ?? null,
         limits_config: Object.keys(limitsConfig).length > 0 ? JSON.stringify(limitsConfig) : null,
@@ -158,7 +154,7 @@ export function LoopFormModal({
 
       if (mode === 'create') {
         // 创建模式：工作空间必填
-        if (!values.workspace?.trim()) {
+        if (!workspaceValue?.trim()) {
           message.error('请选择工作空间');
           setSaving(false);
           return;
@@ -166,7 +162,7 @@ export function LoopFormModal({
         const res = await dbLoops.createLoop({
           name: basePayload.name,
           description: basePayload.description,
-          workspace: values.workspace.trim(),
+          workspace: workspaceValue.trim(),
           tag_ids: basePayload.tag_ids,
           icon: basePayload.icon,
           review_template_id: basePayload.review_template_id,
@@ -186,7 +182,7 @@ export function LoopFormModal({
     } finally {
       setSaving(false);
     }
-  }, [form, editingTag, mode, loopId, message, onSaved, onClose]);
+  }, [form, editingTag, workspaceValue, mode, loopId, message, onSaved, onClose]);
 
   return (
     <>
@@ -214,16 +210,16 @@ export function LoopFormModal({
           <Form.Item
             label={<>工作空间 {mode === 'create' && <span style={{ color: '#ff4d4f' }}>*</span>}</>
           }
-            name="workspace"
             tooltip="此 loop 所属的工作空间"
             rules={mode === 'create' ? [{ required: true, message: '请选择工作空间' }] : []}
           >
-            <Select
-              allowClear
-              placeholder="选择工作空间"
-              options={workspaceOptions}
-              showSearch
-              optionFilterProp="label"
+            <WorkspaceSelect
+              value={workspaceValue}
+              onChange={(v) => {
+                setWorkspaceValue(v);
+                form.setFieldsValue({ workspace: v });
+              }}
+              required={mode === 'create'}
             />
           </Form.Item>
           {tags.length > 0 && (

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useMemo, useRef, useCallback, useReducer } from 'react';
-import { Drawer, Input, Button, App, AutoComplete, Divider, Switch, Modal, Form, Empty, Space } from 'antd';
-import { FolderOutlined, PlusOutlined, ThunderboltOutlined } from '@ant-design/icons';
+import { Drawer, Input, Button, App, Divider, Switch } from 'antd';
+import { FolderOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
-import type { ProjectDirectory } from '@/utils/database';
+import { WorkspaceSelect } from './common/WorkspaceSelect';
 
 import type { Todo, ExecutorConfig, ExecutorOption, SkillMeta, ExecutorSkills, TodoTemplate } from '@/types';
 import { EXECUTORS, executorConfigToOption, getExecutorColor, DEFAULT_EXECUTOR } from '@/types';
@@ -36,15 +36,11 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
 
   // UI 相关的状态（不属于表单数据）
   const [executorOptions, setExecutorOptions] = useState<ExecutorOption[]>(EXECUTORS);
-  const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
   const [allExecutorSkills, setAllExecutorSkills] = useState<ExecutorSkills[]>([]);
   const [skillsLoading, setSkillsLoading] = useState(false);
   const [skillsExpanded, setSkillsExpanded] = useState(false);
   const [skillSearchText, setSkillSearchText] = useState('');
   const [loading, setLoading] = useState(false);
-  const [quickAddOpen, setQuickAddOpen] = useState(false);
-  const [quickAddForm] = Form.useForm<{ name: string; path: string }>();
-  const [quickAddSubmitting, setQuickAddSubmitting] = useState(false);
   const editorRef = useRef<any>(null);
   // 旧版 hook 编辑器消费 useApp 的 todos，todo hook 已整块移除后该 hook 不再需要。
 
@@ -104,15 +100,11 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
 
   useEffect(() => {
     if (open) {
-      Promise.all([
-        db.getExecutors(),
-        db.getProjectDirectories(),
-      ]).then(([executorConfigs, directories]) => {
+      db.getExecutors().then((executorConfigs) => {
         const enabled = (executorConfigs as ExecutorConfig[]).filter((ec) => ec.enabled);
         if (enabled.length > 0) {
           setExecutorOptions(enabled.map(executorConfigToOption));
         }
-        setProjectDirectories(directories);
       }).catch(() => {});
 
       setSkillsLoading(true);
@@ -174,43 +166,6 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
     setTemplateModalOpen(false);
   }, [formState.prompt, insertTextAtCursor, message]);
 
-  // 快速新增项目目录：
-  // 用户在工作目录区域点"+"即可补一个项目，无需跳到设置页。
-  // 流程：校验表单 → 调用后端创建 → 更新本地目录列表 + 自动选中 → 通知其他组件刷新。
-  // 注意：name 必填由 antd Form rules 保证，这里额外 trim 后判空做兜底。
-  const handleQuickAddProjectDirectory = async () => {
-    let values: { name: string; path: string };
-    try {
-      values = await quickAddForm.validateFields(); // 触发 antd 必填校验
-    } catch {
-      // antd 校验失败时会自行提示，这里直接返回
-      return;
-    }
-    const name = values.name.trim(); // 去前后空格，与后端 trim 策略一致
-    const path = values.path.trim();
-    if (!name || !path) { // 兜底：防止 trim 后为空
-      message.error('项目名称与目录路径均为必填');
-      return;
-    }
-    setQuickAddSubmitting(true); // 防止重复提交
-    try {
-      const dir = await db.createProjectDirectory(path, name); // 调用后端创建目录
-      setProjectDirectories(prev =>
-        [...prev.filter(d => d.id !== dir.id), dir].sort((a, b) => a.path.localeCompare(b.path)) // 去重+按路径排序
-      );
-      // 保存后立即把新目录选中并写入工作目录，减少二次操作
-      setField('workspace', dir.path); // 自动选中新目录，减少用户二次操作
-      setQuickAddOpen(false); // 关闭弹窗
-      message.success(`已添加项目"${dir.name}"`);
-      // 通知其他组件（如 TodoList 分组视图）项目目录已更新
-      window.dispatchEvent(new CustomEvent('projectDirectoryAdded', { detail: dir })); // 通知 TodoList/KanbanBoard 等刷新
-    } catch (err: any) {
-      message.error('添加项目目录失败: ' + (err?.message || String(err)));
-    } finally {
-      setQuickAddSubmitting(false); // 无论成功失败都恢复按钮状态
-    }
-  };
-
   const handleSave = async () => {
     if (!title.trim()) {
       message.error('请输入任务标题');
@@ -219,7 +174,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
 
     // 创建模式：工作空间为必填项
     if (!isEditMode && !workspace.trim()) {
-      message.error('请选择项目目录（工作空间）');
+      message.error('请选择工作空间');
       return;
     }
 
@@ -228,24 +183,11 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
       const trimmedWorkspace = workspace.trim() || null;
 
       if (isEditMode && todo) {
-        // workspace 保存逻辑：
-        // 1. 用户主动清空 workspace → 保存 null
-        // 2. 输入了路径且在目录列表中命中 → 保存该路径
-        // 3. 输入了路径但目录列表为空/未命中，且编辑模式下原值与当前一致 → 保留原值（避免目录加载失败时误清空）
-        // 4. 其他情况（新建时输入了不存在的路径）→ 保存 null
-        // 如果用户输入了路径但不在下拉列表中，不自动创建（name 必填约束），让用户使用快速新增功能
-        const originalWorkspace = (todo.workspace || '').trim();
-        const isKnownWorkspace = !!trimmedWorkspace && projectDirectories.some(d => d.path === trimmedWorkspace);
-        const workspaceToSave = !trimmedWorkspace
-          ? null
-          : isKnownWorkspace || (isEditMode && trimmedWorkspace === originalWorkspace)
-            ? trimmedWorkspace
-            : null;
-
+        // WorkspaceSelect 只允许从下拉列表选择有效路径，无需二次校验
         await db.updateTodo(
           todo.id, title.trim(), prompt.trim(), todo.status,
           executor, schedulerEnabled, schedulerConfig || null,
-          workspaceToSave,
+          trimmedWorkspace,
           acceptanceCriteria || null,
           autoReviewEnabled,
         );
@@ -255,8 +197,8 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
       } else {
         const newTodo = await db.createTodo(title.trim(), prompt.trim(), selectedTags, acceptanceCriteria || undefined, autoReviewEnabled);
 
-        // 创建模式：只在路径存在于目录列表时才设置 workspace，否则为 null（避免创建无名项目）
-        const workspaceToSave = trimmedWorkspace && projectDirectories.some(d => d.path === trimmedWorkspace) ? trimmedWorkspace : null;
+        // WorkspaceSelect 只允许从下拉列表选择，无需二次校验
+        const workspaceToSave = trimmedWorkspace;
 
         if (workspaceToSave || schedulerEnabled || executor !== DEFAULT_EXECUTOR) {
           await db.updateTodo(
@@ -282,17 +224,6 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
   };
 
   const executorColor = getExecutorColor(executor);
-
-  // 把项目目录拍平成 AutoComplete 的可选项：value 仍存路径（与后端 workspace 字段兼容），
-  // label 同时展示"项目名称（路径）"，保证用户能看到项目维度的名字
-  const workspaceOptions = useMemo(
-    () =>
-      projectDirectories.map(d => ({
-        value: d.path,
-        label: d.name ? `${d.name}（${d.path}）` : d.path,
-      })),
-    [projectDirectories]
-  );
 
   return (
     <Drawer
@@ -362,57 +293,13 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
           <div style={{ marginBottom: 16 }}>
             <div style={{ marginBottom: 10, fontWeight: 600, fontSize: 14 }}>
               <FolderOutlined style={{ color: 'var(--color-primary)', marginRight: 6 }} />
-              项目目录 <span style={{ color: '#ff4d4f' }}>*</span>
+              工作空间 <span style={{ color: '#ff4d4f' }}>*</span>
             </div>
-            {projectDirectories.length === 0 ? (
-              // 没有可用项目目录时给出空态提示，避免用户面对一个无选项的下拉茫然
-              <div
-                style={{
-                  padding: 16,
-                  border: '1px dashed var(--color-border)',
-                  borderRadius: 6,
-                  background: 'var(--color-bg)',
-                }}
-              >
-                <Empty
-                  image={Empty.PRESENTED_IMAGE_SIMPLE}
-                  description={
-                    <div style={{ color: 'var(--color-text-secondary)' }}>
-                      尚未配置任何项目目录，请先创建后再选择
-                    </div>
-                  }
-                  style={{ margin: 0 }}
-                >
-                  <Button
-                    type="primary"
-                    icon={<PlusOutlined />}
-                    onClick={() => setQuickAddOpen(true)}
-                  >
-                    快速新增项目目录
-                  </Button>
-                </Empty>
-              </div>
-            ) : (
-              // 有项目目录时，下拉里展示的是项目名称（value 仍是路径，与后端模型兼容）
-              <Space.Compact style={{ width: '100%' }}>
-                <AutoComplete
-                  value={workspace}
-                  onChange={(value) => setField('workspace', value)}
-                  options={workspaceOptions}
-                  placeholder="选择项目目录或手动输入路径"
-                  style={{ flex: 1 }}
-                  filterOption={(input, option) =>
-                    (option?.label as string)?.toLowerCase().includes(input.toLowerCase())
-                  }
-                />
-                <Button
-                  icon={<PlusOutlined />}
-                  onClick={() => setQuickAddOpen(true)}
-                  title="快速新增项目目录"
-                  aria-label="快速新增项目目录"
-                />
-              </Space.Compact>
-            )}
+            <WorkspaceSelect
+              value={workspace}
+              onChange={(v) => setField('workspace', v ?? '')}
+              required
+            />
           </div>
 
 
@@ -479,40 +366,6 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         onSelect={handleSelectTemplate}
       />
 
-      {/* 快速新增项目目录：与抽屉同期挂载，避免切走 drawer 后弹窗无法关闭 */}
-      <Modal
-        title="快速新增项目目录"
-        open={quickAddOpen}
-        onCancel={() => {
-          if (quickAddSubmitting) return;
-          setQuickAddOpen(false);
-          quickAddForm.resetFields();
-        }}
-        onOk={handleQuickAddProjectDirectory}
-        confirmLoading={quickAddSubmitting}
-        okText="保存并使用"
-        cancelText="取消"
-        destroyOnClose
-        maskClosable={!quickAddSubmitting}
-      >
-        <Form form={quickAddForm} layout="vertical" preserve={false}>
-          <Form.Item
-            label="项目名称"
-            name="name"
-            // 名称必填：在 Todo 列表分组展示时是主标识
-            rules={[{ required: true, message: '请输入项目名称' }]}
-          >
-            <Input placeholder="例如：ntd 官网重构" autoFocus />
-          </Form.Item>
-          <Form.Item
-            label="目录路径"
-            name="path"
-            rules={[{ required: true, message: '请输入目录路径' }]}
-          >
-            <Input placeholder="例如：/Users/me/projects/ntd-site" />
-          </Form.Item>
-        </Form>
-      </Modal>
     </Drawer>
   );
 }

--- a/frontend/src/components/common/WorkspaceSelect.tsx
+++ b/frontend/src/components/common/WorkspaceSelect.tsx
@@ -1,0 +1,157 @@
+// 工作空间选择器：统一「选择已有目录」和「快捷新建」于一身。
+//
+// 复用场景：
+// - TodoDrawer：替换原有的 AutoComplete + Button 组合
+// - LoopFormModal：替换原有的 Select（添加快捷新建能力）
+//
+// 交互逻辑：
+// 1. Select 下拉展示目录列表，支持搜索过滤
+// 2. 旁边的「+」按钮打开新建 Modal
+// 3. 填写名称 + 路径后「保存并使用」，自动选中新建项并通知父组件
+// 4. 新建失败时保留表单内容，允许用户修正后重试
+
+import { useState, useEffect, useCallback } from 'react';
+import { Select, Form, Input, Button, Modal, Space, App } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
+import { getProjectDirectories, createProjectDirectory } from '@/utils/database/todos';
+
+interface WorkspaceSelectProps {
+  /** 当前选中的工作空间路径 */
+  value?: string | null;
+  /** 变更回调 */
+  onChange?: (workspace: string | null) => void;
+  /** 是否必填（影响 Select 的 allowClear） */
+  required?: boolean;
+  /** antd Select 原生 props 透传 */
+  selectProps?: Record<string, unknown>;
+}
+
+interface QuickAddFormValues {
+  name: string;
+  path: string;
+}
+
+export function WorkspaceSelect({ value, onChange, required, selectProps }: WorkspaceSelectProps) {
+  const { message } = App.useApp();
+  const [options, setOptions] = useState<{ label: string; value: string }[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [quickAddOpen, setQuickAddOpen] = useState(false);
+  const [quickAddSaving, setQuickAddSaving] = useState(false);
+  const [quickAddForm] = Form.useForm<QuickAddFormValues>();
+
+  // 加载目录列表
+  const loadDirs = useCallback(async () => {
+    setLoading(true);
+    try {
+      const dirs = await getProjectDirectories();
+      setOptions(dirs.map(d => ({
+        label: d.name ? `${d.name}（${d.path}）` : d.path,
+        value: d.path,
+      })));
+    } catch {
+      message.error('加载工作空间列表失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [message]);
+
+  useEffect(() => { loadDirs(); }, [loadDirs]);
+
+  // 监听外部 directory 新增事件，刷新列表并自动选中新目录
+  useEffect(() => {
+    const handleDirAdded = (event: Event) => {
+      const customEvent = event as CustomEvent<{ path: string }>;
+      loadDirs().then(() => {
+        if (customEvent.detail?.path) {
+          onChange?.(customEvent.detail.path);
+        }
+      });
+    };
+    window.addEventListener('projectDirectoryAdded', handleDirAdded);
+    return () => window.removeEventListener('projectDirectoryAdded', handleDirAdded);
+  }, [loadDirs, onChange]);
+
+  // 快捷新建：保存并使用
+  const handleQuickAdd = useCallback(async () => {
+    const values = await quickAddForm.validateFields();
+    setQuickAddSaving(true);
+    try {
+      // createProjectDirectory(path, name) — 路径在前，名称在后
+      await createProjectDirectory(values.path.trim(), values.name.trim());
+      message.success('工作空间已创建');
+      quickAddForm.resetFields();
+      setQuickAddOpen(false);
+      // 刷新列表后选中新建项
+      const dirs = await getProjectDirectories();
+      setOptions(dirs.map(d => ({
+        label: d.name ? `${d.name}（${d.path}）` : d.path,
+        value: d.path,
+      })));
+      onChange?.(values.path.trim());
+      // 广播新增事件，供 TodoList 等组件刷新分组数据
+      window.dispatchEvent(new CustomEvent('projectDirectoryAdded', { detail: { path: values.path.trim() } }));
+    } catch (e) {
+      message.error(`创建失败：${(e as Error).message}`);
+    } finally {
+      setQuickAddSaving(false);
+    }
+  }, [quickAddForm, message, onChange]);
+
+  return (
+    <>
+      <Space.Compact style={{ width: '100%' }}>
+        <Select
+          value={value}
+          onChange={onChange}
+          options={options}
+          loading={loading}
+          placeholder="选择工作空间"
+          showSearch
+          allowClear={!required}
+          optionFilterProp="label"
+          style={{ flex: 1 }}
+          {...selectProps}
+        />
+        <Button
+          icon={<PlusOutlined />}
+          onClick={() => setQuickAddOpen(true)}
+          title="新建工作空间"
+          aria-label="新建工作空间"
+        />
+      </Space.Compact>
+
+      <Modal
+        title="新建工作空间"
+        open={quickAddOpen}
+        onCancel={() => {
+          if (quickAddSaving) return;
+          quickAddForm.resetFields();
+          setQuickAddOpen(false);
+        }}
+        onOk={handleQuickAdd}
+        confirmLoading={quickAddSaving}
+        okText="保存并使用"
+        cancelText="取消"
+        destroyOnClose
+        maskClosable={!quickAddSaving}
+      >
+        <Form form={quickAddForm} layout="vertical" preserve={false}>
+          <Form.Item
+            label="工作空间名称"
+            name="name"
+            rules={[{ required: true, message: '请输入工作空间名称' }]}
+          >
+            <Input placeholder="例如：ntd 官网" autoFocus />
+          </Form.Item>
+          <Form.Item
+            label="目录路径"
+            name="path"
+            rules={[{ required: true, message: '请输入目录路径' }]}
+          >
+            <Input placeholder="例如：/Users/me/projects/ntd-site" />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+}


### PR DESCRIPTION
## 改动概述

- **新增  组件** ()
  - 下拉选择已有工作空间（目录列表）
  - 附带「+」按钮打开新建 Modal，支持快捷创建并自动选中
  - 两端（TodoDrawer / LoopFormModal）共用，消除了重复代码

- **TodoDrawer 改造**
  - 移除原有的  组合和独立的 QuickAddModal
  - 改用 ，代码行数从 ~520 行减至 ~340 行
  - 前端文案统一： → 

- **LoopFormModal 改造**
  - 原有 Select 替换为 ，获得快捷新建工作空间能力

## 改动量

| 文件 | 变更 |
|------|------|
|  | 新增 |
|  | -183 行 |
|  | ±38 行 |

后端已是  字段，无需改动。