### PR TITLE
refactor: 统一工作空间选择组件 & 修复环路环节创建和限制条件保存

### DIFF
--- a/backend/src/db/entity/loop_steps.rs
+++ b/backend/src/db/entity/loop_steps.rs
@@ -1,9 +1,7 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-/// 环路阶段：loop 的一个有序步骤，绑定一个 todo。
-///
-/// 首版仅支持 sequential 执行；run_mode 字段预留扩展。
+/// 环路阶段：loop 的一个有序步骤，关联一个 todo。
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "loop_steps")]
 pub struct Model {

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -40,6 +40,7 @@ impl Database {
         workspace: Option<&str>,
         icon: &str,
         review_template_id: Option<i64>,
+        limits_config: Option<&str>,
     ) -> Result<loops::Model, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let am = loops::ActiveModel {
@@ -48,6 +49,7 @@ impl Database {
             workspace: ActiveValue::Set(workspace.map(|s| s.to_string())),
             icon: ActiveValue::Set(icon.to_string()),
             review_template_id: ActiveValue::Set(review_template_id),
+            limits_config: ActiveValue::Set(limits_config.unwrap_or("{}").to_string()),
             status: ActiveValue::Set("paused".to_string()),
             created_at: ActiveValue::Set(Some(now.clone())),
             updated_at: ActiveValue::Set(Some(now)),
@@ -129,6 +131,7 @@ impl Database {
                 source.workspace.as_deref(),
                 &source.icon,
                 source.review_template_id,
+                Some(source.limits_config.as_str()),
             )
             .await?;
 

--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -57,6 +57,7 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V18LoopHumanReview),
         Box::new(V19StepLoopTags),
         Box::new(V23DropTodoHooksColumns),
+        Box::new(RenameLoopStepsStepIdBackToTodoId),
     ]
 }
 
@@ -3125,6 +3126,103 @@ impl Migration for V23DropTodoHooksColumns {
     async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
         drop_column_if_exists(db, "todos", "hooks").await?;
         drop_column_if_exists(db, "execution_records", "source_hook_id").await?;
+        Ok(())
+    }
+}
+
+/// v24 迁移：将 loop_steps.step_id 改回 todo_id。
+///
+/// v13 把列重命名为 step_id 并企图让 FK 指向 steps 表，
+/// 但 steps 表从未创建（Step 中间层已被移除），导致 FK 实际失效。
+/// 本次迁移重建 loop_steps 表：
+///   - 列名改回 todo_id（与 Rust entity 对齐，无须 column_name attribute）
+///   - FK 改为正确指向 todos(id)
+///   - 保留所有历史数据
+struct RenameLoopStepsStepIdBackToTodoId;
+
+#[async_trait]
+impl Migration for RenameLoopStepsStepIdBackToTodoId {
+    fn version(&self) -> i64 { 24 }
+    fn name(&self) -> &'static str { "rename_loop_steps_step_id_to_todo_id" }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 1. 如果 loop_steps 表不存在（迁移中途失败，只剩 loop_steps_new），直接 rename 恢复
+        if !table_exists(db, "loop_steps").await? && table_exists(db, "loop_steps_new").await? {
+            tracing::info!("loop_steps missing but loop_steps_new exists, renaming to restore");
+            db.exec("ALTER TABLE loop_steps_new RENAME TO loop_steps").await?;
+            db.exec("CREATE INDEX IF NOT EXISTS idx_loop_steps_loop_id ON loop_steps(loop_id)").await?;
+            db.exec("CREATE INDEX IF NOT EXISTS idx_loop_steps_loop_order ON loop_steps(loop_id, order_index)").await?;
+            return Ok(());
+        }
+
+        // 2. 如果列已是 todo_id（fresh DB 场景），跳过
+        if !table_has_column(db, "loop_steps", "step_id").await? {
+            tracing::info!("loop_steps.step_id not present, skip rename");
+            return Ok(());
+        }
+
+        // 3. 禁用外键约束（SQLite 不允许在有 FK 引用时 DROP TABLE）
+        db.exec("PRAGMA foreign_keys = OFF").await?;
+
+        // 4. 删除旧残留（如果有）
+        db.exec("DROP TABLE IF EXISTS loop_steps_new").await?;
+
+        // 5. 创建新表（列名改回 todo_id，FK 指向 todos.id）
+        db.exec(
+            "CREATE TABLE loop_steps_new (
+                id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                loop_id BIGINT NOT NULL,
+                name TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                order_index INTEGER NOT NULL DEFAULT 0,
+                todo_id BIGINT NOT NULL,
+                run_mode TEXT NOT NULL DEFAULT 'sequential',
+                skip_on_source_failed INTEGER NOT NULL DEFAULT 0,
+                min_rating BIGINT,
+                unrated_policy TEXT NOT NULL DEFAULT 'skip',
+                on_success TEXT NOT NULL DEFAULT 'next',
+                success_goto_step_id BIGINT,
+                on_rating_fail TEXT NOT NULL DEFAULT 'break',
+                fail_goto_step_id BIGINT,
+                review_type TEXT NOT NULL DEFAULT 'ai',
+                enabled INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT,
+                FOREIGN KEY (loop_id) REFERENCES loops(id) ON DELETE CASCADE,
+                FOREIGN KEY (todo_id) REFERENCES todos(id) ON DELETE RESTRICT
+            )",
+        )
+        .await?;
+
+        // 6. 复制数据（step_id → todo_id）
+        db.exec(
+            "INSERT INTO loop_steps_new (id, loop_id, name, description, order_index,
+                todo_id, run_mode, skip_on_source_failed, min_rating, unrated_policy,
+                on_success, success_goto_step_id, on_rating_fail, fail_goto_step_id,
+                review_type, enabled, created_at)
+             SELECT id, loop_id, name, description, order_index,
+                step_id, run_mode, skip_on_source_failed, min_rating, unrated_policy,
+                on_success, success_goto_step_id, on_rating_fail, fail_goto_step_id,
+                review_type, enabled, created_at
+             FROM loop_steps",
+        )
+        .await?;
+
+        // 7. 删除旧表
+        db.exec("DROP TABLE loop_steps").await?;
+
+        // 8. 重命名新表
+        db.exec("ALTER TABLE loop_steps_new RENAME TO loop_steps").await?;
+
+        // 9. 重建索引
+        db.exec("CREATE INDEX IF NOT EXISTS idx_loop_steps_loop_id ON loop_steps(loop_id)")
+            .await?;
+        db.exec("CREATE INDEX IF NOT EXISTS idx_loop_steps_loop_order ON loop_steps(loop_id, order_index)")
+            .await?;
+
+        // 10. 恢复外键约束
+        db.exec("PRAGMA foreign_keys = ON").await?;
+
+        tracing::info!("loop_steps.step_id renamed back to todo_id");
         Ok(())
     }
 }

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -81,6 +81,7 @@ pub async fn create_loop(
             Some(req.workspace.trim()),
             &req.icon,
             req.review_template_id,
+            req.limits_config.as_deref(),
         )
         .await?;
     // 如果创建请求携带了 tag_ids，则持久化标签关联；否则新建环路从空标签开始

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -359,6 +359,8 @@ pub struct CreateLoopRequest {
     #[serde(default = "default_icon")]
     pub icon: String,
     pub review_template_id: Option<i64>,
+    #[serde(default)]
+    pub limits_config: Option<String>,
 }
 
 fn default_icon() -> String { "loop".to_string() }

--- a/frontend/src/components/LoopFormModal.tsx
+++ b/frontend/src/components/LoopFormModal.tsx
@@ -13,10 +13,10 @@ import { App as AntApp, Modal, Form, Input, InputNumber, Select, Button } from '
 import { PlusOutlined } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
 import * as dbReviewTemplates from '@/utils/database/reviewTemplates';
-import * as db from '@/utils/database';
 import type { UpdateLoopRequest } from '@/types/loop';
 import type { ReviewTemplateOption } from '@/types/reviewTemplate';
 import { TagCheckCardGroup } from './TagCheckCard';
+import { WorkspaceSelect } from './common/WorkspaceSelect';
 
 // ---------- props ----------
 
@@ -60,22 +60,17 @@ export function LoopFormModal({
   const [form] = Form.useForm<FormValues>();
   // 标签选中态（单选）
   const [editingTag, setEditingTag] = useState<number | null>(null);
-  // 工作空间下拉选项
-  const [workspaceOptions, setWorkspaceOptions] = useState<{ label: string; value: string }[]>([]);
+  // 工作空间受控值（与 form.setFieldsValue 配合，避免直接操作 form 内部状态）
+  const [workspaceValue, setWorkspaceValue] = useState<string | null>(null);
   // 评审模板
   const [reviewTemplateOptions, setReviewTemplateOptions] = useState<ReviewTemplateOption[]>([]);
   const [creatingTemplate, setCreatingTemplate] = useState(false);
   const [creatingTemplateSaving, setCreatingTemplateSaving] = useState(false);
   const [newTemplateForm] = Form.useForm<{ name: string; description?: string; prompt: string }>();
 
-  // 打开时加载工作空间列表 + 评审模板选项
+  // 打开时加载评审模板选项
   useEffect(() => {
     if (!open) return;
-    // 加载项目目录用于工作空间下拉
-    db.getProjectDirectories()
-      .then(dirs => setWorkspaceOptions(dirs.map(d => ({ label: d.name || d.path, value: d.path }))))
-      .catch(() => { /* 静默 */ });
-    // 加载评审模板选项
     dbReviewTemplates.listReviewTemplateOptions()
       .then(setReviewTemplateOptions)
       .catch(() => { /* 静默 */ });
@@ -88,10 +83,10 @@ export function LoopFormModal({
       form.setFieldsValue({
         name: initialData.name,
         description: initialData.description,
-        workspace: initialData.workspace ?? null,
         icon: initialData.icon,
         review_template_id: initialData.review_template_id ?? null,
       });
+      setWorkspaceValue(initialData.workspace ?? null);
       // 解析 limits_config
       try {
         const lc = JSON.parse(initialData.limits_config || '{}');
@@ -105,6 +100,7 @@ export function LoopFormModal({
       // 创建模式：清空表单
       form.resetFields();
       setEditingTag(null);
+      setWorkspaceValue(null);
     }
   }, [open, mode, initialData, form]);
 
@@ -149,7 +145,7 @@ export function LoopFormModal({
       const basePayload = {
         name: values.name.trim(),
         description: values.description ?? '',
-        workspace: values.workspace ?? null,
+        workspace: workspaceValue ?? null,
         icon: values.icon ?? 'loop',
         review_template_id: values.review_template_id ?? null,
         limits_config: Object.keys(limitsConfig).length > 0 ? JSON.stringify(limitsConfig) : null,
@@ -158,7 +154,7 @@ export function LoopFormModal({
 
       if (mode === 'create') {
         // 创建模式：工作空间必填
-        if (!values.workspace?.trim()) {
+        if (!workspaceValue?.trim()) {
           message.error('请选择工作空间');
           setSaving(false);
           return;
@@ -166,7 +162,7 @@ export function LoopFormModal({
         const res = await dbLoops.createLoop({
           name: basePayload.name,
           description: basePayload.description,
-          workspace: values.workspace.trim(),
+          workspace: workspaceValue.trim(),
           tag_ids: basePayload.tag_ids,
           icon: basePayload.icon,
           review_template_id: basePayload.review_template_id,
@@ -186,7 +182,7 @@ export function LoopFormModal({
     } finally {
       setSaving(false);
     }
-  }, [form, editingTag, mode, loopId, message, onSaved, onClose]);
+  }, [form, editingTag, workspaceValue, mode, loopId, message, onSaved, onClose]);
 
   return (
     <>
@@ -214,16 +210,16 @@ export function LoopFormModal({
           <Form.Item
             label={<>工作空间 {mode === 'create' && <span style={{ color: '#ff4d4f' }}>*</span>}</>
           }
-            name="workspace"
             tooltip="此 loop 所属的工作空间"
             rules={mode === 'create' ? [{ required: true, message: '请选择工作空间' }] : []}
           >
-            <Select
-              allowClear
-              placeholder="选择工作空间"
-              options={workspaceOptions}
-              showSearch
-              optionFilterProp="label"
+            <WorkspaceSelect
+              value={workspaceValue}
+              onChange={(v) => {
+                setWorkspaceValue(v);
+                form.setFieldsValue({ workspace: v });
+              }}
+              required={mode === 'create'}
             />
           </Form.Item>
           {tags.length > 0 && (

--- a/frontend/src/components/LoopFormModal.tsx
+++ b/frontend/src/components/LoopFormModal.tsx
@@ -166,6 +166,7 @@ export function LoopFormModal({
           tag_ids: basePayload.tag_ids,
           icon: basePayload.icon,
           review_template_id: basePayload.review_template_id,
+          limits_config: basePayload.limits_config,
         });
         message.success('环路已创建');
         onSaved(res.id);

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useMemo, useRef, useCallback, useReducer } from 'react';
-import { Drawer, Input, Button, App, AutoComplete, Divider, Switch, Modal, Form, Empty, Space } from 'antd';
-import { FolderOutlined, PlusOutlined, ThunderboltOutlined } from '@ant-design/icons';
+import { Drawer, Input, Button, App, Divider, Switch } from 'antd';
+import { FolderOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
-import type { ProjectDirectory } from '@/utils/database';
+import { WorkspaceSelect } from './common/WorkspaceSelect';
 
 import type { Todo, ExecutorConfig, ExecutorOption, SkillMeta, ExecutorSkills, TodoTemplate } from '@/types';
 import { EXECUTORS, executorConfigToOption, getExecutorColor, DEFAULT_EXECUTOR } from '@/types';
@@ -36,15 +36,11 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
 
   // UI 相关的状态（不属于表单数据）
   const [executorOptions, setExecutorOptions] = useState<ExecutorOption[]>(EXECUTORS);
-  const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
   const [allExecutorSkills, setAllExecutorSkills] = useState<ExecutorSkills[]>([]);
   const [skillsLoading, setSkillsLoading] = useState(false);
   const [skillsExpanded, setSkillsExpanded] = useState(false);
   const [skillSearchText, setSkillSearchText] = useState('');
   const [loading, setLoading] = useState(false);
-  const [quickAddOpen, setQuickAddOpen] = useState(false);
-  const [quickAddForm] = Form.useForm<{ name: string; path: string }>();
-  const [quickAddSubmitting, setQuickAddSubmitting] = useState(false);
   const editorRef = useRef<any>(null);
   // 旧版 hook 编辑器消费 useApp 的 todos，todo hook 已整块移除后该 hook 不再需要。
 
@@ -104,15 +100,11 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
 
   useEffect(() => {
     if (open) {
-      Promise.all([
-        db.getExecutors(),
-        db.getProjectDirectories(),
-      ]).then(([executorConfigs, directories]) => {
+      db.getExecutors().then((executorConfigs) => {
         const enabled = (executorConfigs as ExecutorConfig[]).filter((ec) => ec.enabled);
         if (enabled.length > 0) {
           setExecutorOptions(enabled.map(executorConfigToOption));
         }
-        setProjectDirectories(directories);
       }).catch(() => {});
 
       setSkillsLoading(true);
@@ -174,43 +166,6 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
     setTemplateModalOpen(false);
   }, [formState.prompt, insertTextAtCursor, message]);
 
-  // 快速新增项目目录：
-  // 用户在工作目录区域点"+"即可补一个项目，无需跳到设置页。
-  // 流程：校验表单 → 调用后端创建 → 更新本地目录列表 + 自动选中 → 通知其他组件刷新。
-  // 注意：name 必填由 antd Form rules 保证，这里额外 trim 后判空做兜底。
-  const handleQuickAddProjectDirectory = async () => {
-    let values: { name: string; path: string };
-    try {
-      values = await quickAddForm.validateFields(); // 触发 antd 必填校验
-    } catch {
-      // antd 校验失败时会自行提示，这里直接返回
-      return;
-    }
-    const name = values.name.trim(); // 去前后空格，与后端 trim 策略一致
-    const path = values.path.trim();
-    if (!name || !path) { // 兜底：防止 trim 后为空
-      message.error('项目名称与目录路径均为必填');
-      return;
-    }
-    setQuickAddSubmitting(true); // 防止重复提交
-    try {
-      const dir = await db.createProjectDirectory(path, name); // 调用后端创建目录
-      setProjectDirectories(prev =>
-        [...prev.filter(d => d.id !== dir.id), dir].sort((a, b) => a.path.localeCompare(b.path)) // 去重+按路径排序
-      );
-      // 保存后立即把新目录选中并写入工作目录，减少二次操作
-      setField('workspace', dir.path); // 自动选中新目录，减少用户二次操作
-      setQuickAddOpen(false); // 关闭弹窗
-      message.success(`已添加项目"${dir.name}"`);
-      // 通知其他组件（如 TodoList 分组视图）项目目录已更新
-      window.dispatchEvent(new CustomEvent('projectDirectoryAdded', { detail: dir })); // 通知 TodoList/KanbanBoard 等刷新
-    } catch (err: any) {
-      message.error('添加项目目录失败: ' + (err?.message || String(err)));
-    } finally {
-      setQuickAddSubmitting(false); // 无论成功失败都恢复按钮状态
-    }
-  };
-
   const handleSave = async () => {
     if (!title.trim()) {
       message.error('请输入任务标题');
@@ -219,7 +174,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
 
     // 创建模式：工作空间为必填项
     if (!isEditMode && !workspace.trim()) {
-      message.error('请选择项目目录（工作空间）');
+      message.error('请选择工作空间');
       return;
     }
 
@@ -228,24 +183,11 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
       const trimmedWorkspace = workspace.trim() || null;
 
       if (isEditMode && todo) {
-        // workspace 保存逻辑：
-        // 1. 用户主动清空 workspace → 保存 null
-        // 2. 输入了路径且在目录列表中命中 → 保存该路径
-        // 3. 输入了路径但目录列表为空/未命中，且编辑模式下原值与当前一致 → 保留原值（避免目录加载失败时误清空）
-        // 4. 其他情况（新建时输入了不存在的路径）→ 保存 null
-        // 如果用户输入了路径但不在下拉列表中，不自动创建（name 必填约束），让用户使用快速新增功能
-        const originalWorkspace = (todo.workspace || '').trim();
-        const isKnownWorkspace = !!trimmedWorkspace && projectDirectories.some(d => d.path === trimmedWorkspace);
-        const workspaceToSave = !trimmedWorkspace
-          ? null
-          : isKnownWorkspace || (isEditMode && trimmedWorkspace === originalWorkspace)
-            ? trimmedWorkspace
-            : null;
-
+        // WorkspaceSelect 只允许从下拉列表选择有效路径，无需二次校验
         await db.updateTodo(
           todo.id, title.trim(), prompt.trim(), todo.status,
           executor, schedulerEnabled, schedulerConfig || null,
-          workspaceToSave,
+          trimmedWorkspace,
           acceptanceCriteria || null,
           autoReviewEnabled,
         );
@@ -255,8 +197,8 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
       } else {
         const newTodo = await db.createTodo(title.trim(), prompt.trim(), selectedTags, acceptanceCriteria || undefined, autoReviewEnabled);
 
-        // 创建模式：只在路径存在于目录列表时才设置 workspace，否则为 null（避免创建无名项目）
-        const workspaceToSave = trimmedWorkspace && projectDirectories.some(d => d.path === trimmedWorkspace) ? trimmedWorkspace : null;
+        // WorkspaceSelect 只允许从下拉列表选择，无需二次校验
+        const workspaceToSave = trimmedWorkspace;
 
         if (workspaceToSave || schedulerEnabled || executor !== DEFAULT_EXECUTOR) {
           await db.updateTodo(
@@ -282,17 +224,6 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
   };
 
   const executorColor = getExecutorColor(executor);
-
-  // 把项目目录拍平成 AutoComplete 的可选项：value 仍存路径（与后端 workspace 字段兼容），
-  // label 同时展示"项目名称（路径）"，保证用户能看到项目维度的名字
-  const workspaceOptions = useMemo(
-    () =>
-      projectDirectories.map(d => ({
-        value: d.path,
-        label: d.name ? `${d.name}（${d.path}）` : d.path,
-      })),
-    [projectDirectories]
-  );
 
   return (
     <Drawer
@@ -362,57 +293,13 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
           <div style={{ marginBottom: 16 }}>
             <div style={{ marginBottom: 10, fontWeight: 600, fontSize: 14 }}>
               <FolderOutlined style={{ color: 'var(--color-primary)', marginRight: 6 }} />
-              项目目录 <span style={{ color: '#ff4d4f' }}>*</span>
+              工作空间 <span style={{ color: '#ff4d4f' }}>*</span>
             </div>
-            {projectDirectories.length === 0 ? (
-              // 没有可用项目目录时给出空态提示，避免用户面对一个无选项的下拉茫然
-              <div
-                style={{
-                  padding: 16,
-                  border: '1px dashed var(--color-border)',
-                  borderRadius: 6,
-                  background: 'var(--color-bg)',
-                }}
-              >
-                <Empty
-                  image={Empty.PRESENTED_IMAGE_SIMPLE}
-                  description={
-                    <div style={{ color: 'var(--color-text-secondary)' }}>
-                      尚未配置任何项目目录，请先创建后再选择
-                    </div>
-                  }
-                  style={{ margin: 0 }}
-                >
-                  <Button
-                    type="primary"
-                    icon={<PlusOutlined />}
-                    onClick={() => setQuickAddOpen(true)}
-                  >
-                    快速新增项目目录
-                  </Button>
-                </Empty>
-              </div>
-            ) : (
-              // 有项目目录时，下拉里展示的是项目名称（value 仍是路径，与后端模型兼容）
-              <Space.Compact style={{ width: '100%' }}>
-                <AutoComplete
-                  value={workspace}
-                  onChange={(value) => setField('workspace', value)}
-                  options={workspaceOptions}
-                  placeholder="选择项目目录或手动输入路径"
-                  style={{ flex: 1 }}
-                  filterOption={(input, option) =>
-                    (option?.label as string)?.toLowerCase().includes(input.toLowerCase())
-                  }
-                />
-                <Button
-                  icon={<PlusOutlined />}
-                  onClick={() => setQuickAddOpen(true)}
-                  title="快速新增项目目录"
-                  aria-label="快速新增项目目录"
-                />
-              </Space.Compact>
-            )}
+            <WorkspaceSelect
+              value={workspace}
+              onChange={(v) => setField('workspace', v ?? '')}
+              required
+            />
           </div>
 
 
@@ -479,40 +366,6 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
         onSelect={handleSelectTemplate}
       />
 
-      {/* 快速新增项目目录：与抽屉同期挂载，避免切走 drawer 后弹窗无法关闭 */}
-      <Modal
-        title="快速新增项目目录"
-        open={quickAddOpen}
-        onCancel={() => {
-          if (quickAddSubmitting) return;
-          setQuickAddOpen(false);
-          quickAddForm.resetFields();
-        }}
-        onOk={handleQuickAddProjectDirectory}
-        confirmLoading={quickAddSubmitting}
-        okText="保存并使用"
-        cancelText="取消"
-        destroyOnClose
-        maskClosable={!quickAddSubmitting}
-      >
-        <Form form={quickAddForm} layout="vertical" preserve={false}>
-          <Form.Item
-            label="项目名称"
-            name="name"
-            // 名称必填：在 Todo 列表分组展示时是主标识
-            rules={[{ required: true, message: '请输入项目名称' }]}
-          >
-            <Input placeholder="例如：ntd 官网重构" autoFocus />
-          </Form.Item>
-          <Form.Item
-            label="目录路径"
-            name="path"
-            rules={[{ required: true, message: '请输入目录路径' }]}
-          >
-            <Input placeholder="例如：/Users/me/projects/ntd-site" />
-          </Form.Item>
-        </Form>
-      </Modal>
     </Drawer>
   );
 }

--- a/frontend/src/components/common/WorkspaceSelect.tsx
+++ b/frontend/src/components/common/WorkspaceSelect.tsx
@@ -1,0 +1,157 @@
+// 工作空间选择器：统一「选择已有目录」和「快捷新建」于一身。
+//
+// 复用场景：
+// - TodoDrawer：替换原有的 AutoComplete + Button 组合
+// - LoopFormModal：替换原有的 Select（添加快捷新建能力）
+//
+// 交互逻辑：
+// 1. Select 下拉展示目录列表，支持搜索过滤
+// 2. 旁边的「+」按钮打开新建 Modal
+// 3. 填写名称 + 路径后「保存并使用」，自动选中新建项并通知父组件
+// 4. 新建失败时保留表单内容，允许用户修正后重试
+
+import { useState, useEffect, useCallback } from 'react';
+import { Select, Form, Input, Button, Modal, Space, App } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
+import { getProjectDirectories, createProjectDirectory } from '@/utils/database/todos';
+
+interface WorkspaceSelectProps {
+  /** 当前选中的工作空间路径 */
+  value?: string | null;
+  /** 变更回调 */
+  onChange?: (workspace: string | null) => void;
+  /** 是否必填（影响 Select 的 allowClear） */
+  required?: boolean;
+  /** antd Select 原生 props 透传 */
+  selectProps?: Record<string, unknown>;
+}
+
+interface QuickAddFormValues {
+  name: string;
+  path: string;
+}
+
+export function WorkspaceSelect({ value, onChange, required, selectProps }: WorkspaceSelectProps) {
+  const { message } = App.useApp();
+  const [options, setOptions] = useState<{ label: string; value: string }[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [quickAddOpen, setQuickAddOpen] = useState(false);
+  const [quickAddSaving, setQuickAddSaving] = useState(false);
+  const [quickAddForm] = Form.useForm<QuickAddFormValues>();
+
+  // 加载目录列表
+  const loadDirs = useCallback(async () => {
+    setLoading(true);
+    try {
+      const dirs = await getProjectDirectories();
+      setOptions(dirs.map(d => ({
+        label: d.name ? `${d.name}（${d.path}）` : d.path,
+        value: d.path,
+      })));
+    } catch {
+      message.error('加载工作空间列表失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [message]);
+
+  useEffect(() => { loadDirs(); }, [loadDirs]);
+
+  // 监听外部 directory 新增事件，刷新列表并自动选中新目录
+  useEffect(() => {
+    const handleDirAdded = (event: Event) => {
+      const customEvent = event as CustomEvent<{ path: string }>;
+      loadDirs().then(() => {
+        if (customEvent.detail?.path) {
+          onChange?.(customEvent.detail.path);
+        }
+      });
+    };
+    window.addEventListener('projectDirectoryAdded', handleDirAdded);
+    return () => window.removeEventListener('projectDirectoryAdded', handleDirAdded);
+  }, [loadDirs, onChange]);
+
+  // 快捷新建：保存并使用
+  const handleQuickAdd = useCallback(async () => {
+    const values = await quickAddForm.validateFields();
+    setQuickAddSaving(true);
+    try {
+      // createProjectDirectory(path, name) — 路径在前，名称在后
+      await createProjectDirectory(values.path.trim(), values.name.trim());
+      message.success('工作空间已创建');
+      quickAddForm.resetFields();
+      setQuickAddOpen(false);
+      // 刷新列表后选中新建项
+      const dirs = await getProjectDirectories();
+      setOptions(dirs.map(d => ({
+        label: d.name ? `${d.name}（${d.path}）` : d.path,
+        value: d.path,
+      })));
+      onChange?.(values.path.trim());
+      // 广播新增事件，供 TodoList 等组件刷新分组数据
+      window.dispatchEvent(new CustomEvent('projectDirectoryAdded', { detail: { path: values.path.trim() } }));
+    } catch (e) {
+      message.error(`创建失败：${(e as Error).message}`);
+    } finally {
+      setQuickAddSaving(false);
+    }
+  }, [quickAddForm, message, onChange]);
+
+  return (
+    <>
+      <Space.Compact style={{ width: '100%' }}>
+        <Select
+          value={value}
+          onChange={onChange}
+          options={options}
+          loading={loading}
+          placeholder="选择工作空间"
+          showSearch
+          allowClear={!required}
+          optionFilterProp="label"
+          style={{ flex: 1 }}
+          {...selectProps}
+        />
+        <Button
+          icon={<PlusOutlined />}
+          onClick={() => setQuickAddOpen(true)}
+          title="新建工作空间"
+          aria-label="新建工作空间"
+        />
+      </Space.Compact>
+
+      <Modal
+        title="新建工作空间"
+        open={quickAddOpen}
+        onCancel={() => {
+          if (quickAddSaving) return;
+          quickAddForm.resetFields();
+          setQuickAddOpen(false);
+        }}
+        onOk={handleQuickAdd}
+        confirmLoading={quickAddSaving}
+        okText="保存并使用"
+        cancelText="取消"
+        destroyOnClose
+        maskClosable={!quickAddSaving}
+      >
+        <Form form={quickAddForm} layout="vertical" preserve={false}>
+          <Form.Item
+            label="工作空间名称"
+            name="name"
+            rules={[{ required: true, message: '请输入工作空间名称' }]}
+          >
+            <Input placeholder="例如：ntd 官网" autoFocus />
+          </Form.Item>
+          <Form.Item
+            label="目录路径"
+            name="path"
+            rules={[{ required: true, message: '请输入目录路径' }]}
+          >
+            <Input placeholder="例如：/Users/me/projects/ntd-site" />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
+  );
+}

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -279,6 +279,8 @@ export interface CreateLoopRequest {
   /** 创建时可选预绑定单个标签；省略时后端按空标签处理，兼容旧调用方。 */
   icon?: string;
   review_template_id?: number | null;
+  /** 限制条件 JSON 字符串 */
+  limits_config?: string | null;
 }
 
 export interface UpdateLoopRequest {

--- a/frontend/tests/verify_loop_limits.spec.ts
+++ b/frontend/tests/verify_loop_limits.spec.ts
@@ -1,0 +1,58 @@
+// 验证环路创建时 limits_config（最大步数/Token数）能正确保存。
+import { test, expect } from '@playwright/test';
+
+test('环路创建 - 最大步数和Token数限制能正确保存', async ({ page }) => {
+  await page.goto('http://localhost:18088');
+  await page.waitForTimeout(2000);
+
+  // 切换到环路模式
+  const loopTab = page.locator('.ant-segmented-item', { hasText: '环路' });
+  if (await loopTab.isVisible()) {
+    await loopTab.click();
+    await page.waitForTimeout(1000);
+  }
+
+  // 点击新建按钮
+  const createBtn = page.locator('button:has-text("新建"), .ant-btn:has-text("新建")').first();
+  if (await createBtn.isVisible({ timeout: 3000 })) {
+    await createBtn.click();
+    await page.waitForTimeout(1000);
+  }
+
+  const modal = page.locator('.ant-modal');
+  if (await modal.isVisible({ timeout: 3000 })) {
+    // 填写名称
+    const nameInput = page.locator('.ant-modal input').first();
+    if (await nameInput.isVisible()) {
+      await nameInput.fill('测试限制条件');
+    }
+
+    // 选择工作空间
+    const wsSelect = page.locator('.ant-modal .ant-select').first();
+    if (await wsSelect.isVisible()) {
+      await wsSelect.click();
+      await page.waitForTimeout(500);
+      const wsOption = page.locator('.ant-select-dropdown .ant-select-item').first();
+      if (await wsOption.isVisible({ timeout: 2000 })) {
+        await wsOption.click();
+        await page.waitForTimeout(300);
+      }
+    }
+
+    // 找到最大步数输入框（表单中包含"最大执行步数"）
+    const maxStepInput = page.locator('.ant-modal input.ant-input-number').first();
+    if (await maxStepInput.isVisible({ timeout: 2000 })) {
+      await maxStepInput.fill('10');
+    }
+
+    // 点击确定
+    const okBtn = page.locator('.ant-modal .ant-btn-primary').first();
+    if (await okBtn.isVisible()) {
+      await okBtn.click();
+      await page.waitForTimeout(2000);
+      console.log('创建按钮已点击');
+    }
+  }
+
+  await page.screenshot({ path: 'frontend/tests/__screenshots__/verify_loop_limits.png' });
+});

--- a/frontend/tests/verify_loop_step_add.spec.ts
+++ b/frontend/tests/verify_loop_step_add.spec.ts
@@ -1,0 +1,69 @@
+// 验证环路添加环节功能：选择工作空间后能正常添加 step。
+import { test, expect } from '@playwright/test';
+
+test('环路添加环节 - 工作空间选择后正常添加 step', async ({ page }) => {
+  // 1. 打开应用，进入事项列表
+  await page.goto('http://localhost:18088');
+  await page.waitForTimeout(2000);
+
+  // 2. 切换到环路模式
+  const loopTab = page.locator('.ant-segmented-item', { hasText: '环路' });
+  if (await loopTab.isVisible()) {
+    await loopTab.click();
+    await page.waitForTimeout(1000);
+  }
+
+  // 3. 点击第一个环路进入详情
+  const firstLoop = page.locator('.loop-item, [class*="loop-item"], [class*="loop-card"]').first();
+  if (await firstLoop.isVisible({ timeout: 3000 })) {
+    await firstLoop.click();
+    await page.waitForTimeout(2000);
+
+    // 4. 查找添加环节按钮
+    const addStepBtn = page.locator('text=添加环节, text=添加').first();
+    if (await addStepBtn.isVisible({ timeout: 3000 })) {
+      await addStepBtn.click();
+      await page.waitForTimeout(1000);
+
+      // 5. 检查 Modal 是否出现
+      const modal = page.locator('.ant-modal');
+      const modalVisible = await modal.isVisible({ timeout: 3000 }).catch(() => false);
+      console.log('Modal visible:', modalVisible);
+
+      if (modalVisible) {
+        // 6. 检查表单元素是否存在
+        const todoSelect = page.locator('.ant-select').first();
+        const todoVisible = await todoSelect.isVisible({ timeout: 2000 }).catch(() => false);
+        console.log('Todo select visible:', todoVisible);
+
+        // 7. 选择一个 todo
+        if (todoVisible) {
+          await todoSelect.click();
+          await page.waitForTimeout(500);
+          const option = page.locator('.ant-select-item').first();
+          if (await option.isVisible({ timeout: 2000 })) {
+            await option.click();
+            await page.waitForTimeout(300);
+          }
+        }
+
+        // 8. 填写名称
+        const nameInput = page.locator('input[placeholder*="环节"], input[placeholder*="名称"]');
+        if (await nameInput.isVisible({ timeout: 2000 })) {
+          await nameInput.fill('自动化测试环节');
+        }
+
+        // 9. 点击确定/添加按钮
+        const okBtn = page.locator('.ant-modal-footer .ant-btn-primary, .ant-modal .ant-btn-primary').first();
+        if (await okBtn.isVisible({ timeout: 2000 })) {
+          await okBtn.click();
+          await page.waitForTimeout(2000);
+          console.log('添加按钮已点击');
+        }
+      }
+    }
+  }
+
+  // 截图留档
+  await page.screenshot({ path: 'frontend/tests/__screenshots__/verify_loop_step_add.png' });
+});


### PR DESCRIPTION
## 改动概述

### 1. WorkspaceSelect 组件统一（refactor）
- **新增  组件** ()
  - 下拉选择已有工作空间 + 快捷新建 Modal，两端共用
- **TodoDrawer**：移除原有的 AutoComplete + Button 组合，改用 WorkspaceSelect（-183 行）
- **LoopFormModal**：替换原有 Select，获得快捷新建能力
- 前端文案统一： → 

### 2. Bug 修复

#### 修复 1：环路详情页 500 错误（v24 迁移）
- **根因**：v13 把  改名为 ，但  表从未创建，导致 SQL JOIN 失败
- **修复**：v24 把列名改回 ，支持迁移中途失败的恢复
- **同时**：修正 v24 迁移 DDL 为 （SQLite 自增要求）

#### 修复 2：添加环节点确定无反应
- **根因**：v24 迁移 DDL 写错， 不支持 SQLite 自增，导致  返回 
- **修复**：数据库重建表使用正确的 

#### 修复 3：环路创建时 limits_config 未保存
- **根因**： 缺少  字段，handler 也未传递
- **修复**：后端  增加  字段；handler 传递参数；前端类型和调用补全

## 改动量
| 文件 | 变更 |
|------|------|
|  | 新增 |
|  | -183 行 |
|  | ±38 行 |
|  | 注释更新 |
|  |  参数 + SQL 列名 |
|  | v24 新增 |
|  |  传参 |
|  |  增加  |
|  | 同上 |