### PR TITLE
fix: loop step execution records missing from todo execution history

### DIFF
--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -605,7 +605,9 @@ impl LoopRunner {
             tx: self.ctx.tx.clone(),
             task_manager: self.ctx.task_manager.clone(),
             config: self.ctx.config.clone(),
-            todo_id: 0,
+            // 使用 todo.id 而非 0，确保 execution_record 能关联到正确的 todo，
+            // 使 todo 执行历史界面能看到 loop 环节的执行记录。
+            todo_id: todo.id,
             message: enhanced_prompt.to_string(),
             req_executor: todo.executor.clone(),
             trigger_type: format!("loop_stage:{}", trigger_type),


### PR DESCRIPTION
## 问题

当前 loop 执行后，todo 运行产生的历史记录在 todo 的执行历史界面看不到。

## 根因

在 `start_step_todo_with_prompt` 中，`RunTodoExecutionRequest` 使用了 `todo_id: 0`。`create_record_or_reject` 会把 `todo_id == 0` 转换为 `NULL` 写入 `execution_records` 表：

```rust
todo_id: if request.todo_id == 0 { None } else { Some(request.todo_id) },
```

这导致 loop 环节的执行记录 `todo_id` 为 NULL，前端按 `todo_id` 查询时找不到这些记录。

## 修复

将 `todo_id: 0` 改为 `todo_id: todo.id`，直接使用已加载的 todo 的实际 ID，使 execution_record 能正确关联到源 todo。

```diff
- todo_id: 0,
+ // 使用 todo.id 而非 0，确保 execution_record 能关联到正确的 todo，
+ // 使 todo 执行历史界面能看到 loop 环节的执行记录。
+ todo_id: todo.id,
```

## 测试

- 731 个后端测试全部通过（5 个失败的迁移测试为 main 已存在的预存问题）
- execution 相关测试全部通过