### PR TITLE
fix: 评分闸门失败原因未写入 error_message，用户看不到错误提示

### DIFF
--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -468,7 +468,7 @@ impl LoopRunner {
             };
 
             // 4h. 评分闸门
-            let (gate_passed, step_rating) = if step_status == "success" && step.min_rating.is_some() {
+            let (gate_passed, step_rating, error_msg) = if step_status == "success" && step.min_rating.is_some() {
                 // 人工审批类型：暂停等待，不自动评审
                 // 提取结论后写回 pending_approval 状态，然后退出主循环。
                 if step.review_type == "human" {
@@ -507,7 +507,7 @@ impl LoopRunner {
                     .await
                     .map_err(|e| e.to_string())?
             } else {
-                (step_status == "success", None)
+                (step_status == "success", None, None)
             };
 
             let final_step_status = if gate_passed { "success" } else { "failed" };
@@ -515,10 +515,10 @@ impl LoopRunner {
             // 4i. 提取结论
             let conclusion = self.extract_conclusion(record_id).await;
 
-            // 4j. 写回 step execution
+            // 4j. 写回 step execution（携 error_msg 让前端展示失败原因）
             self.ctx
                 .db
-                .finish_step_execution(step_exec.id, final_step_status, Some(record_id), None, step_rating, Some(&conclusion))
+                .finish_step_execution(step_exec.id, final_step_status, Some(record_id), error_msg.as_deref(), step_rating, Some(&conclusion))
                 .await
                 .map_err(|e| e.to_string())?;
 
@@ -872,7 +872,7 @@ impl LoopRunner {
     /// 评分闸门：检查 execution_record 的 rating 与阈值比较。
     /// 若未评分且环节有验收标准，自动发起评审。
     /// 无评分 = 0 分（不通过，除非 min_rating ≤ 0）。
-    /// 返回 (是否通过, 评分)。
+    /// 返回 (是否通过, 评分, 失败原因说明).
     async fn apply_rating_gate(
         &self,
         record_id: i64,
@@ -880,7 +880,7 @@ impl LoopRunner {
         step_prompt: &str,
         step_acceptance_criteria: Option<&str>,
         review_template_id: Option<i64>,
-    ) -> Result<(bool, Option<i32>), String> {
+    ) -> Result<(bool, Option<i32>, Option<String>), String> {
         // 先检查是否已有评分
         let rec = self
             .ctx
@@ -894,7 +894,7 @@ impl LoopRunner {
             let passed = rating >= min_rating;
             info!("rating gate: record #{} rating={} min_rating={} {}",
                 record_id, rating, min_rating, if passed { "PASS" } else { "FAIL" });
-            return Ok((passed, Some(rating)));
+            return Ok((passed, Some(rating), None));
         }
 
         // 无评分但有验收标准：发起自动评审
@@ -906,7 +906,7 @@ impl LoopRunner {
                 Ok(t) => t,
                 Err(e) => {
                     warn!("rating gate: failed to get review template: {}", e);
-                    return Ok((false, None));
+                    return Ok((false, None, Some(format!("获取评审模板失败: {}", e))));
                 }
             };
 
@@ -956,7 +956,7 @@ impl LoopRunner {
                 Err(e) => {
                     warn!("rating gate: failed to reuse/create review instance todo: {}", e);
                     let _ = self.ctx.db.set_record_last_review_status(record_id, "failed").await;
-                    return Ok((false, None));
+                    return Ok((false, None, Some(format!("创建评审实例失败: {}", e))));
                 }
             };
 
@@ -988,7 +988,7 @@ impl LoopRunner {
                 None => {
                     warn!("rating gate: review execution returned no record_id");
                     let _ = self.ctx.db.set_record_last_review_status(record_id, "failed").await;
-                    return Ok((false, None));
+                    return Ok((false, None, Some("评审执行未返回记录ID".to_string())));
                 }
             };
 
@@ -1004,7 +1004,7 @@ impl LoopRunner {
                         record_id, todo_id: 0,
                         review_status: "failed".to_string(),
                     });
-                    return Ok((false, None));
+                    return Ok((false, None, Some("评审超时".to_string())));
                 }
                 if let Ok(Some(r)) = self.ctx.db.get_execution_record(review_record_id).await {
                     use crate::models::ExecutionStatus;
@@ -1043,13 +1043,13 @@ impl LoopRunner {
                 let passed = r >= min_rating;
                 info!("rating gate: record #{} final rating={} min_rating={} {}",
                     record_id, r, min_rating, if passed { "PASS" } else { "FAIL" });
-                return Ok((passed, Some(r)));
+                return Ok((passed, Some(r), None));
             }
         }
 
         // 无评分且无验收标准 = 视为 0 分，不通过
         info!("rating gate: record #{} no rating and no criteria, treating as FAIL", record_id);
-        Ok((false, None))
+        Ok((false, None, Some("环节未设置验收标准，无法触发自动评审".to_string())))
     }
 
     /// 获取评审模板：优先使用 loop 配置的 id，否则用默认模板。

--- a/frontend/src/components/todo-detail/RecordDetailView.tsx
+++ b/frontend/src/components/todo-detail/RecordDetailView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, type ReactNode } from 'react';
 import { Button, Tag, Empty, Segmented, Popconfirm, Tooltip, Pagination, message, Popover, InputNumber, Space } from 'antd';
-import { StarOutlined, StarFilled, SyncOutlined, CheckCircleOutlined, CloseCircleOutlined, PauseCircleOutlined } from '@ant-design/icons';
+import { StarOutlined, StarFilled, SyncOutlined, CheckCircleOutlined, CloseCircleOutlined, PauseCircleOutlined, MinusCircleOutlined } from '@ant-design/icons';
 import { MessageOutlined, FileTextOutlined, StopOutlined, UnorderedListOutlined, LinkOutlined, LoadingOutlined, BranchesOutlined, CodeOutlined } from '@ant-design/icons';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { ChatView } from '@/components/ChatView';
@@ -424,14 +424,15 @@ function RecordRatingControl({
   );
 }
 
-/** 评审状态徽章: pending(评审中) / success(评审成功) / failed(评审失败) / interrupted(被打断) */
-export function ReviewStatusBadge({ status }: { status?: 'pending' | 'success' | 'failed' | 'interrupted' | null }) {
+/** 评审状态徽章: pending(评审中) / success(评审成功) / failed(评审失败) / interrupted(被打断) / skipped(跳过) */
+export function ReviewStatusBadge({ status }: { status?: 'pending' | 'success' | 'failed' | 'interrupted' | 'skipped' | null }) {
   if (!status) return null;
   const map: Record<string, { color: string; bg: string; border: string; text: string; icon: ReactNode }> = {
     pending:     { color: '#1677ff', bg: '#1677ff14', border: '#1677ff30', text: '⏳ 评审中',   icon: <SyncOutlined spin /> },
     success:     { color: '#52c41a', bg: '#52c41a14', border: '#52c41a30', text: '✅ 评审成功', icon: <CheckCircleOutlined /> },
     failed:      { color: '#ff4d4f', bg: '#ff4d4f14', border: '#ff4d4f30', text: '❌ 评审失败', icon: <CloseCircleOutlined /> },
     interrupted: { color: '#faad14', bg: '#faad1414', border: '#faad1430', text: '⏸ 中断',     icon: <PauseCircleOutlined /> },
+    skipped:     { color: '#6b7280', bg: '#6b728014', border: '#6b728030', text: '⏭ 跳过',     icon: <MinusCircleOutlined /> },
   };
   const s = map[status];
   if (!s) return null;


### PR DESCRIPTION
## 问题

Loop 环节执行时，评分闸门（`apply_rating_gate`）在以下场景仅写 tracing 日志，未将失败原因写入 `loop_step_executions.error_message` 字段，导致前端仅显示「失败」而不知具体原因：

- 未设置验收标准 → 无法触发自动评审
- 获取评审模板失败
- 创建评审实例失败
- 评审执行未返回记录ID
- 评审超时

## 改动

### `backend/src/services/loop_runner.rs`

- `apply_rating_gate` 返回值从 `(bool, Option<i32>)` 扩展为 `(bool, Option<i32>, Option<String>)`，第三元为失败原因说明
- 所有 `return Ok(…)` 点均已补充中文错误信息
- 调用处将 `error_msg` 传入 `finish_step_execution`，该字段已在前端 `LoopStudioExecutionsPanel.tsx` 中以红色错误色展示

### `frontend/src/components/todo-detail/RecordDetailView.tsx`

- `ReviewStatusBadge` 补充 `skipped` 状态展示（灰色 `⏭ 跳过`），之前 `skipped` 在该组件中不可见（功能降级为 null）

## 验证

- `cargo check` 通过
- `tsc --noEmit` 通过
- `cargo test --lib` 731 passed, 5 failed（5 个预存 migration 测试问题，与本次改动无关）