### PR TITLE
feat(webhook): support loop webhooks with separate trigger paths

### DIFF
--- a/backend/src/db/entity/webhooks.rs
+++ b/backend/src/db/entity/webhooks.rs
@@ -1,6 +1,21 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
+/// Webhook 类型：区分是绑定 todo 还是绑定 loop。
+/// - "todo": 通过 /webhook/trigger/{id}/todo 触发，执行对应 todo
+/// - "loop": 通过 /webhook/trigger/{id}/loop 触发，触发对应 loop 的 webhook 触发器
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WebhookType {
+    #[serde(rename = "todo")]
+    Todo,
+    #[serde(rename = "loop")]
+    Loop,
+}
+
+impl Default for WebhookType {
+    fn default() -> Self { WebhookType::Todo }
+}
+
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "webhooks")]
 pub struct Model {
@@ -8,7 +23,13 @@ pub struct Model {
     pub id: i64,
     pub name: String,
     pub enabled: bool,
+    /// 绑定的默认 todo（仅 webhook_type = "todo" 时有效）
     pub default_todo_id: Option<i64>,
+    /// 绑定的 loop（仅 webhook_type = "loop" 时有效）
+    pub loop_id: Option<i64>,
+    /// 类型：todo | loop
+    #[sea_orm(default_value = "todo")]
+    pub webhook_type: String,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }

--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -212,6 +212,9 @@ async fn v1_initial_schema(db: &Database) -> Result<(), sea_orm::DbErr> {
     create_project_directories_table(db).await?;
     create_todo_templates_table(db).await?;
     create_webhooks_table(db).await?;
+    // 为 webhooks 表添加 loop_id 和 webhook_type 列（v8 Loop Webhook 支持）
+    add_column_if_missing(db, "webhooks", "loop_id", "ALTER TABLE webhooks ADD COLUMN loop_id INTEGER").await?;
+    add_column_if_missing(db, "webhooks", "webhook_type", "ALTER TABLE webhooks ADD COLUMN webhook_type TEXT NOT NULL DEFAULT 'todo'").await?;
     create_webhook_records_table(db).await?;
     create_usage_daily_stats_table(db).await?;
     create_usage_daily_stats_trigger(db).await?;

--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -56,6 +56,7 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V17ConsolidateReviewInstanceTodos),
         Box::new(V18LoopHumanReview),
         Box::new(V19StepLoopTags),
+        Box::new(V25WebhooksLoopSupport),
         Box::new(V23DropTodoHooksColumns),
         Box::new(RenameLoopStepsStepIdBackToTodoId),
     ]
@@ -212,9 +213,6 @@ async fn v1_initial_schema(db: &Database) -> Result<(), sea_orm::DbErr> {
     create_project_directories_table(db).await?;
     create_todo_templates_table(db).await?;
     create_webhooks_table(db).await?;
-    // 为 webhooks 表添加 loop_id 和 webhook_type 列（v8 Loop Webhook 支持）
-    add_column_if_missing(db, "webhooks", "loop_id", "ALTER TABLE webhooks ADD COLUMN loop_id INTEGER").await?;
-    add_column_if_missing(db, "webhooks", "webhook_type", "ALTER TABLE webhooks ADD COLUMN webhook_type TEXT NOT NULL DEFAULT 'todo'").await?;
     create_webhook_records_table(db).await?;
     create_usage_daily_stats_table(db).await?;
     create_usage_daily_stats_trigger(db).await?;
@@ -3258,4 +3256,24 @@ async fn drop_column_if_exists(
     let drop_sql = format!("ALTER TABLE {} DROP COLUMN {}", table, column);
     tracing::info!("Dropping {}.{} ...", table, column);
     db.exec(&drop_sql).await
+}
+
+/// v25 迁移：为 webhooks 表添加 loop_id 和 webhook_type 列，支持 loop webhook 类型。
+pub(super) struct V25WebhooksLoopSupport;
+
+#[async_trait]
+impl Migration for V25WebhooksLoopSupport {
+    fn version(&self) -> i64 {
+        25
+    }
+    fn name(&self) -> &'static str {
+        "webhooks_loop_support"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 幂等：列已存在时跳过
+        add_column_if_missing(db, "webhooks", "loop_id", "ALTER TABLE webhooks ADD COLUMN loop_id INTEGER").await?;
+        add_column_if_missing(db, "webhooks", "webhook_type", "ALTER TABLE webhooks ADD COLUMN webhook_type TEXT NOT NULL DEFAULT 'todo'").await?;
+        Ok(())
+    }
 }

--- a/backend/src/db/webhook.rs
+++ b/backend/src/db/webhook.rs
@@ -59,6 +59,17 @@ impl Database {
         webhooks::Entity::find()
             .filter(webhooks::Column::Enabled.eq(true))
             .filter(webhooks::Column::DefaultTodoId.eq(todo_id))
+            .filter(webhooks::Column::WebhookType.eq("todo"))
+            .one(&self.conn)
+            .await
+    }
+
+    /// Get an enabled webhook that has the given loop_id (webhook_type = "loop").
+    pub async fn get_webhook_by_loop(&self, loop_id: i64) -> Result<Option<webhooks::Model>, sea_orm::DbErr> {
+        webhooks::Entity::find()
+            .filter(webhooks::Column::Enabled.eq(true))
+            .filter(webhooks::Column::LoopId.eq(loop_id))
+            .filter(webhooks::Column::WebhookType.eq("loop"))
             .one(&self.conn)
             .await
     }
@@ -69,12 +80,16 @@ impl Database {
         name: &str,
         enabled: bool,
         default_todo_id: Option<i64>,
+        loop_id: Option<i64>,
+        webhook_type: &str,
     ) -> Result<webhooks::Model, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let am = webhooks::ActiveModel {
             name: ActiveValue::Set(name.to_string()),
             enabled: ActiveValue::Set(enabled),
             default_todo_id: ActiveValue::Set(default_todo_id),
+            loop_id: ActiveValue::Set(loop_id),
+            webhook_type: ActiveValue::Set(webhook_type.to_string()),
             created_at: ActiveValue::Set(Some(now.clone())),
             updated_at: ActiveValue::Set(Some(now)),
             ..Default::default()
@@ -89,6 +104,8 @@ impl Database {
         name: &str,
         enabled: bool,
         default_todo_id: Option<i64>,
+        loop_id: Option<i64>,
+        webhook_type: &str,
     ) -> Result<(), sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let existing = webhooks::Entity::find_by_id(id)
@@ -100,6 +117,8 @@ impl Database {
             am.name = ActiveValue::Set(name.to_string());
             am.enabled = ActiveValue::Set(enabled);
             am.default_todo_id = ActiveValue::Set(default_todo_id);
+            am.loop_id = ActiveValue::Set(loop_id);
+            am.webhook_type = ActiveValue::Set(webhook_type.to_string());
             am.updated_at = ActiveValue::Set(Some(now));
             am.update(&self.conn).await?;
         }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1335,10 +1335,10 @@ fn feishu_routes() -> Router<AppState> {
 /// Webhook 路由：外部触发端点（无 /api 前缀）+ Webhook 管理 API + 调用记录。
 fn webhook_routes() -> Router<AppState> {
     Router::new()
-        // Todo webhook: /webhook/trigger/{todo_id}/todo
-        .route("/webhook/trigger/{todo_id}/todo", get(webhook::trigger_webhook_with_todo).post(webhook::trigger_webhook_with_todo_post_json))
-        // Loop webhook: /webhook/trigger/{webhook_id}/loop
-        .route("/webhook/trigger/{webhook_id}/loop", get(webhook::trigger_webhook_with_loop_get).post(webhook::trigger_webhook_with_loop_post))
+        // Todo webhook: /webhook/trigger/todo/{todo_id}
+        .route("/webhook/trigger/todo/:todo_id", get(webhook::trigger_webhook_with_todo).post(webhook::trigger_webhook_with_todo_post_json))
+        // Loop webhook: /webhook/trigger/loop/{loop_id}
+        .route("/webhook/trigger/loop/:loop_id", get(webhook::trigger_webhook_with_loop_get).post(webhook::trigger_webhook_with_loop_post))
         .route("/api/webhooks", get(webhook::list_webhooks).post(webhook::create_webhook))
         .route("/api/webhooks/{id}", get(webhook::get_webhook).put(webhook::update_webhook).delete(webhook::delete_webhook))
         .route("/api/webhook-records", get(webhook::get_webhook_records))

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1336,9 +1336,9 @@ fn feishu_routes() -> Router<AppState> {
 fn webhook_routes() -> Router<AppState> {
     Router::new()
         // Todo webhook: /webhook/trigger/todo/{todo_id}
-        .route("/webhook/trigger/todo/:todo_id", get(webhook::trigger_webhook_with_todo).post(webhook::trigger_webhook_with_todo_post_json))
+        .route("/webhook/trigger/todo/{todo_id}", get(webhook::trigger_webhook_with_todo).post(webhook::trigger_webhook_with_todo_post_json))
         // Loop webhook: /webhook/trigger/loop/{loop_id}
-        .route("/webhook/trigger/loop/:loop_id", get(webhook::trigger_webhook_with_loop_get).post(webhook::trigger_webhook_with_loop_post))
+        .route("/webhook/trigger/loop/{loop_id}", get(webhook::trigger_webhook_with_loop_get).post(webhook::trigger_webhook_with_loop_post))
         .route("/api/webhooks", get(webhook::list_webhooks).post(webhook::create_webhook))
         .route("/api/webhooks/{id}", get(webhook::get_webhook).put(webhook::update_webhook).delete(webhook::delete_webhook))
         .route("/api/webhook-records", get(webhook::get_webhook_records))

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1335,8 +1335,10 @@ fn feishu_routes() -> Router<AppState> {
 /// Webhook 路由：外部触发端点（无 /api 前缀）+ Webhook 管理 API + 调用记录。
 fn webhook_routes() -> Router<AppState> {
     Router::new()
-        // todo_id 必填：显式、确定性，避免"最近一个 enabled todo"的竞态
-        .route("/webhook/trigger/{todo_id}", get(webhook::trigger_webhook_with_todo).post(webhook::trigger_webhook_with_todo_post_json))
+        // Todo webhook: /webhook/trigger/{todo_id}/todo
+        .route("/webhook/trigger/{todo_id}/todo", get(webhook::trigger_webhook_with_todo).post(webhook::trigger_webhook_with_todo_post_json))
+        // Loop webhook: /webhook/trigger/{webhook_id}/loop
+        .route("/webhook/trigger/{webhook_id}/loop", get(webhook::trigger_webhook_with_loop_get).post(webhook::trigger_webhook_with_loop_post))
         .route("/api/webhooks", get(webhook::list_webhooks).post(webhook::create_webhook))
         .route("/api/webhooks/{id}", get(webhook::get_webhook).put(webhook::update_webhook).delete(webhook::delete_webhook))
         .route("/api/webhook-records", get(webhook::get_webhook_records))

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -268,7 +268,7 @@ pub async fn trigger_webhook_with_todo(
             todo_id,
             webhook_id: Some(webhook.id),
             method: "GET".to_string(),
-            path: format!("/webhook/trigger/{}/todo", todo_id),
+            path: format!("/webhook/trigger/todo/{}", todo_id),
             query_params: params,
             content_type: None,
             body: None,
@@ -298,7 +298,7 @@ pub async fn trigger_webhook_with_todo_post_json(
             todo_id,
             webhook_id: Some(webhook.id),
             method: "POST".to_string(),
-            path: format!("/webhook/trigger/{}/todo", todo_id),
+            path: format!("/webhook/trigger/todo/{}", todo_id),
             query_params: params,
             content_type: Some("application/json".to_string()),
             body: Some(body_str),
@@ -306,52 +306,48 @@ pub async fn trigger_webhook_with_todo_post_json(
     ).await
 }
 
-/// Trigger endpoint for loop webhook (with webhook_id) - GET
+/// Trigger endpoint for loop webhook (with loop_id) - GET
 pub async fn trigger_webhook_with_loop_get(
     State(state): State<AppState>,
-    Path(webhook_id): Path<i64>,
+    Path(loop_id): Path<i64>,
     axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
 ) -> Result<impl IntoResponse, AppError> {
-    trigger_webhook_loop_internal(Arc::new(state), webhook_id, "GET", params, None, None).await
+    trigger_webhook_loop_internal(Arc::new(state), loop_id, "GET", params, None, None).await
 }
 
-/// Trigger endpoint for loop webhook (with webhook_id) - POST with JSON body
+/// Trigger endpoint for loop webhook (with loop_id) - POST with JSON body
 pub async fn trigger_webhook_with_loop_post(
     State(state): State<AppState>,
-    Path(webhook_id): Path<i64>,
+    Path(loop_id): Path<i64>,
     axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
     Json(body): Json<serde_json::Value>,
 ) -> Result<impl IntoResponse, AppError> {
     let body_str = serde_json::to_string(&body).ok();
     let content_type = Some("application/json".to_string());
-    trigger_webhook_loop_internal(Arc::new(state), webhook_id, "POST", params, content_type, body_str).await
+    trigger_webhook_loop_internal(Arc::new(state), loop_id, "POST", params, content_type, body_str).await
 }
 
 /// Internal loop webhook trigger implementation
 async fn trigger_webhook_loop_internal(
     state: Arc<AppState>,
-    webhook_id: i64,
+    loop_id: i64,
     method: &str,
     query_params: HashMap<String, String>,
     content_type: Option<String>,
     body: Option<String>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Verify webhook exists and is enabled, then dispatch to loop_trigger_dispatcher
-    let webhook = state.db.get_webhook(webhook_id).await?
+    // Find enabled loop webhook for this loop_id
+    let webhook = state.db.get_webhook_by_loop(loop_id).await?
         .ok_or_else(|| AppError::NotFound)?;
 
     if !webhook.enabled {
         return Err(AppError::BadRequest("Webhook is disabled".to_string()));
     }
 
-    if webhook.webhook_type != "loop" {
-        return Err(AppError::BadRequest("This webhook is not configured for loops".to_string()));
-    }
-
     // Record the webhook call
     let response_body = if let Some(dispatcher) = state.loop_trigger_dispatcher.as_ref() {
         // Dispatch to loop trigger - this triggers all loop triggers that reference this webhook
-        let started = dispatcher.dispatch_webhook(webhook_id, body.as_deref()).await;
+        let started = dispatcher.dispatch_webhook(webhook.id, body.as_deref()).await;
         serde_json::json!({ "success": true, "dispatched": true, "started_runs": started }).to_string()
     } else {
         serde_json::json!({ "success": false, "error": "Loop trigger dispatcher not available" }).to_string()
@@ -364,9 +360,9 @@ async fn trigger_webhook_loop_internal(
     };
 
     if let Err(e) = state.db.create_webhook_record(NewWebhookRecord {
-        webhook_id: Some(webhook_id),
+        webhook_id: Some(webhook.id),
         method: method.to_string(),
-        path: format!("/webhook/trigger/{}/loop", webhook_id),
+        path: format!("/webhook/trigger/loop/{}", loop_id),
         query_params: query_params_json,
         body: body.clone(),
         content_type: content_type.clone(),

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -17,6 +17,15 @@ pub struct CreateWebhookRequest {
     pub name: String,
     pub enabled: bool,
     pub default_todo_id: Option<i64>,
+    /// 仅 webhook_type = "loop" 时使用
+    pub loop_id: Option<i64>,
+    /// "todo" | "loop"，默认为 "todo"
+    #[serde(default = "default_webhook_type")]
+    pub webhook_type: String,
+}
+
+fn default_webhook_type() -> String {
+    "todo".to_string()
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -24,6 +33,11 @@ pub struct UpdateWebhookRequest {
     pub name: String,
     pub enabled: bool,
     pub default_todo_id: Option<i64>,
+    /// 仅 webhook_type = "loop" 时使用
+    pub loop_id: Option<i64>,
+    /// "todo" | "loop"
+    #[serde(default = "default_webhook_type")]
+    pub webhook_type: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -93,7 +107,13 @@ pub async fn create_webhook(
     State(state): State<AppState>,
     Json(req): Json<CreateWebhookRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    let webhook = state.db.create_webhook(&req.name, req.enabled, req.default_todo_id).await?;
+    let webhook = state.db.create_webhook(
+        &req.name,
+        req.enabled,
+        req.default_todo_id,
+        req.loop_id,
+        &req.webhook_type,
+    ).await?;
     Ok(ApiResponse::ok(webhook))
 }
 
@@ -103,7 +123,14 @@ pub async fn update_webhook(
     Path(id): Path<i64>,
     Json(req): Json<UpdateWebhookRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    state.db.update_webhook(id, &req.name, req.enabled, req.default_todo_id).await?;
+    state.db.update_webhook(
+        id,
+        &req.name,
+        req.enabled,
+        req.default_todo_id,
+        req.loop_id,
+        &req.webhook_type,
+    ).await?;
     let webhook = state.db.get_webhook(id).await?;
     Ok(ApiResponse::ok(webhook))
 }
@@ -241,7 +268,7 @@ pub async fn trigger_webhook_with_todo(
             todo_id,
             webhook_id: Some(webhook.id),
             method: "GET".to_string(),
-            path: format!("/webhook/trigger/{}", todo_id),
+            path: format!("/webhook/trigger/{}/todo", todo_id),
             query_params: params,
             content_type: None,
             body: None,
@@ -271,12 +298,86 @@ pub async fn trigger_webhook_with_todo_post_json(
             todo_id,
             webhook_id: Some(webhook.id),
             method: "POST".to_string(),
-            path: format!("/webhook/trigger/{}", todo_id),
+            path: format!("/webhook/trigger/{}/todo", todo_id),
             query_params: params,
             content_type: Some("application/json".to_string()),
             body: Some(body_str),
         },
     ).await
+}
+
+/// Trigger endpoint for loop webhook (with webhook_id) - GET
+pub async fn trigger_webhook_with_loop_get(
+    State(state): State<AppState>,
+    Path(webhook_id): Path<i64>,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+) -> Result<impl IntoResponse, AppError> {
+    trigger_webhook_loop_internal(Arc::new(state), webhook_id, "GET", params, None, None).await
+}
+
+/// Trigger endpoint for loop webhook (with webhook_id) - POST with JSON body
+pub async fn trigger_webhook_with_loop_post(
+    State(state): State<AppState>,
+    Path(webhook_id): Path<i64>,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
+    Json(body): Json<serde_json::Value>,
+) -> Result<impl IntoResponse, AppError> {
+    let body_str = serde_json::to_string(&body).ok();
+    let content_type = Some("application/json".to_string());
+    trigger_webhook_loop_internal(Arc::new(state), webhook_id, "POST", params, content_type, body_str).await
+}
+
+/// Internal loop webhook trigger implementation
+async fn trigger_webhook_loop_internal(
+    state: Arc<AppState>,
+    webhook_id: i64,
+    method: &str,
+    query_params: HashMap<String, String>,
+    content_type: Option<String>,
+    body: Option<String>,
+) -> Result<impl IntoResponse, AppError> {
+    // Verify webhook exists and is enabled, then dispatch to loop_trigger_dispatcher
+    let webhook = state.db.get_webhook(webhook_id).await?
+        .ok_or_else(|| AppError::NotFound)?;
+
+    if !webhook.enabled {
+        return Err(AppError::BadRequest("Webhook is disabled".to_string()));
+    }
+
+    if webhook.webhook_type != "loop" {
+        return Err(AppError::BadRequest("This webhook is not configured for loops".to_string()));
+    }
+
+    // Record the webhook call
+    let response_body = if let Some(dispatcher) = state.loop_trigger_dispatcher.as_ref() {
+        // Dispatch to loop trigger - this triggers all loop triggers that reference this webhook
+        let started = dispatcher.dispatch_webhook(webhook_id, body.as_deref()).await;
+        serde_json::json!({ "success": true, "dispatched": true, "started_runs": started }).to_string()
+    } else {
+        serde_json::json!({ "success": false, "error": "Loop trigger dispatcher not available" }).to_string()
+    };
+
+    let query_params_json = if query_params.is_empty() {
+        None
+    } else {
+        serde_json::to_string(&query_params).ok()
+    };
+
+    if let Err(e) = state.db.create_webhook_record(NewWebhookRecord {
+        webhook_id: Some(webhook_id),
+        method: method.to_string(),
+        path: format!("/webhook/trigger/{}/loop", webhook_id),
+        query_params: query_params_json,
+        body: body.clone(),
+        content_type: content_type.clone(),
+        triggered_todo_id: None, // loop webhook 不关联具体 todo
+        status_code: Some(200),
+        response_body: Some(response_body.clone()),
+    }).await {
+        tracing::warn!("Failed to create webhook record: {:?}", e);
+    }
+
+    Ok((StatusCode::OK, axum::Json(serde_json::json!({ "success": true }))).into_response())
 }
 
 /// Internal trigger implementation

--- a/backend/tests/db_feature_supplement_tests.rs
+++ b/backend/tests/db_feature_supplement_tests.rs
@@ -500,7 +500,7 @@ async fn test_webhook_create_and_get() {
     let db = setup_db().await;
     let todo_id = db.create_todo("test", "").await.unwrap();
     let w = db
-        .create_webhook("hook-1", true, Some(todo_id))
+        .create_webhook("hook-1", true, Some(todo_id), None, "todo")
         .await
         .unwrap();
     assert_eq!(w.name, "hook-1");
@@ -518,11 +518,11 @@ async fn test_webhook_update_partial_fields() {
     // update_webhook 会刷新 updated_at，并把 name/enabled/default_todo_id 一起覆盖。
     let db = setup_db().await;
     let todo_id = db.create_todo("t1", "").await.unwrap();
-    let w = db.create_webhook("orig", true, None).await.unwrap();
+    let w = db.create_webhook("orig", true, None, None, "todo").await.unwrap();
     let before_updated_at = w.updated_at.clone();
 
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    db.update_webhook(w.id, "renamed", false, Some(todo_id))
+    db.update_webhook(w.id, "renamed", false, Some(todo_id), None, "todo")
         .await
         .unwrap();
     let after = db.get_webhook(w.id).await.unwrap().unwrap();
@@ -535,7 +535,7 @@ async fn test_webhook_update_partial_fields() {
 #[tokio::test]
 async fn test_webhook_delete() {
     let db = setup_db().await;
-    let w = db.create_webhook("to-del", true, None).await.unwrap();
+    let w = db.create_webhook("to-del", true, None, None, "todo").await.unwrap();
     db.delete_webhook(w.id).await.unwrap();
     assert!(db.get_webhook(w.id).await.unwrap().is_none());
 }
@@ -552,9 +552,9 @@ async fn test_webhook_get_by_ids_empty_input() {
 async fn test_webhook_get_by_ids_filters() {
     // 只返回 ids 列表内的 webhook，其他记录不应混入。
     let db = setup_db().await;
-    let w1 = db.create_webhook("a", true, None).await.unwrap();
-    let w2 = db.create_webhook("b", true, None).await.unwrap();
-    let w3 = db.create_webhook("c", true, None).await.unwrap();
+    let w1 = db.create_webhook("a", true, None, None, "todo").await.unwrap();
+    let w2 = db.create_webhook("b", true, None, None, "todo").await.unwrap();
+    let w3 = db.create_webhook("c", true, None, None, "todo").await.unwrap();
     let picked = db.get_webhooks_by_ids(&[w1.id, w3.id]).await.unwrap();
     let picked_ids: Vec<i64> = picked.iter().map(|w| w.id).collect();
     assert_eq!(picked_ids.len(), 2);
@@ -569,7 +569,7 @@ async fn test_webhook_get_by_default_todo_respects_enabled_flag() {
     let db = setup_db().await;
     let todo_id = db.create_todo("t", "").await.unwrap();
     let w = db
-        .create_webhook("by-default", true, Some(todo_id))
+        .create_webhook("by-default", true, Some(todo_id), None, "todo")
         .await
         .unwrap();
 
@@ -581,7 +581,7 @@ async fn test_webhook_get_by_default_todo_respects_enabled_flag() {
     assert_eq!(hit.id, w.id);
 
     // 关闭后再查，应返回 None
-    db.update_webhook(w.id, "by-default", false, Some(todo_id))
+    db.update_webhook(w.id, "by-default", false, Some(todo_id), None, "todo")
         .await
         .unwrap();
     assert!(db
@@ -595,7 +595,7 @@ async fn test_webhook_get_by_default_todo_respects_enabled_flag() {
 async fn test_webhook_record_create_and_paginate() {
     // 写入多条记录，按 id 倒序、分页参数 limit/offset 正确生效。
     let db = setup_db().await;
-    let w = db.create_webhook("rec", true, None).await.unwrap();
+    let w = db.create_webhook("rec", true, None, None, "todo").await.unwrap();
     for i in 0..5 {
         db.create_webhook_record(ntd::db::webhook::NewWebhookRecord {
             webhook_id: Some(w.id),
@@ -632,7 +632,7 @@ async fn test_webhook_record_cleanup_old_returns_zero_for_recent() {
     // 这里不依赖底层 SQL 直写（db.exec 是 pub(super)，外部测试不可见），
     // 只通过公开 API 写入并验证函数在常见参数下行为稳定。
     let db = setup_db().await;
-    let w = db.create_webhook("clean", true, None).await.unwrap();
+    let w = db.create_webhook("clean", true, None, None, "todo").await.unwrap();
     db.create_webhook_record(ntd::db::webhook::NewWebhookRecord {
         webhook_id: Some(w.id),
         method: "POST".into(),
@@ -658,7 +658,7 @@ async fn test_webhook_record_cleanup_old_returns_zero_for_recent() {
 async fn test_webhook_record_get_by_id() {
     // get_webhook_record 应能按主键精确取回。
     let db = setup_db().await;
-    let w = db.create_webhook("find", true, None).await.unwrap();
+    let w = db.create_webhook("find", true, None, None, "todo").await.unwrap();
     let rec = db
         .create_webhook_record(ntd::db::webhook::NewWebhookRecord {
             webhook_id: Some(w.id),

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -314,6 +314,7 @@ export function LoopDetailPanel({
                 <div style={{ paddingTop: 4 }}>
                   <LoopTriggersPanel
                     loopId={loopId}
+                    loopName={detail.name}
                     triggers={detail.triggers}
                     onChanged={() => { reload(); onChanged(); }}
                   />

--- a/frontend/src/components/LoopStudioTriggersPanel.tsx
+++ b/frontend/src/components/LoopStudioTriggersPanel.tsx
@@ -45,6 +45,7 @@ import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '@/utils/cron';
 
 interface Props {
   loopId: number;
+  loopName: string;
   triggers: LoopTriggerDto[];
   onChanged: () => void;
 }
@@ -655,7 +656,7 @@ function TriggerConfigContent({ type, value, onChange }: {
 
 // ====== 主面板组件 ======
 
-export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
+export function LoopTriggersPanel({ loopId, loopName, triggers, onChanged }: Props) {
   const { message } = AntApp.useApp();
   // 当前正在配置的 trigger_type (open=true 时): null=关闭
   const [configuring, setConfiguring] = useState<{ type: string; existing: LoopTriggerDto | null } | null>(null);
@@ -811,6 +812,39 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
         {isOn ? (
           <Tooltip title={isEnabled ? '点击禁用' : '点击启用'}>
             <Switch size="small" checked={isEnabled} onChange={(v) => handleToggleEnabled(existing!, v)} />
+          </Tooltip>
+        ) : type === 'webhook' ? (
+          // Webhook 快速启用：一键创建 webhook 并启用触发器
+          <Tooltip title="一键创建 Webhook 并启用触发器">
+            <Button
+              size="small"
+              type="primary"
+              onClick={async () => {
+                try {
+                  // 用 loop 名称作为 webhook 名称，创建 loop 类型 webhook
+                  const wh = await db.createWebhook(
+                    `${loopName} Webhook`,
+                    true,
+                    'loop',
+                    undefined, // defaultTodoId
+                    loopId,   // loopId
+                  );
+                  // 同时创建 webhook 触发器，config 中引用该 webhook
+                  await dbLoops.createTrigger(loopId, {
+                    trigger_type: 'webhook',
+                    config: JSON.stringify({ webhook_id: wh.id }),
+                    enabled: true,
+                    priority: 0,
+                  } as CreateTriggerRequest);
+                  message.success(`已为「${loopName}」创建 Webhook 并启用触发器`);
+                  onChanged();
+                } catch {
+                  // 拦截器已弹错
+                }
+              }}
+            >
+              快速启用
+            </Button>
           </Tooltip>
         ) : (
           <Tooltip title={meta.noConfig ? '直接启用（无需配置）' : '配置后启用'}>

--- a/frontend/src/components/WebhooksPanel.tsx
+++ b/frontend/src/components/WebhooksPanel.tsx
@@ -114,9 +114,9 @@ function WebhookCard({
 }) {
   // 根据类型生成触发 URL
   const triggerUrl = webhook.webhook_type === 'todo' && webhook.default_todo_id
-    ? `${baseUrl}/webhook/trigger/${webhook.default_todo_id}/todo`
-    : webhook.webhook_type === 'loop' && webhook.id
-    ? `${baseUrl}/webhook/trigger/${webhook.id}/loop`
+    ? `${baseUrl}/webhook/trigger/todo/${webhook.default_todo_id}`
+    : webhook.webhook_type === 'loop' && webhook.loop_id
+    ? `${baseUrl}/webhook/trigger/loop/${webhook.loop_id}`
     : null;
 
   return (
@@ -418,10 +418,10 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
       key: 'urls',
       width: 320,
       render: (_: any, record: Webhook) => {
-        const url = record.webhook_type === 'loop' && record.id
-          ? `${baseUrl}/webhook/trigger/${record.id}/loop`
+        const url = record.webhook_type === 'loop' && record.loop_id
+          ? `${baseUrl}/webhook/trigger/loop/${record.loop_id}`
           : record.default_todo_id
-          ? `${baseUrl}/webhook/trigger/${record.default_todo_id}/todo`
+          ? `${baseUrl}/webhook/trigger/todo/${record.default_todo_id}`
           : null;
         if (!url) {
           return (

--- a/frontend/src/components/WebhooksPanel.tsx
+++ b/frontend/src/components/WebhooksPanel.tsx
@@ -112,13 +112,20 @@ function WebhookCard({
   onDelete: () => void;
   onToggle: () => void;
 }) {
+  // 根据类型生成触发 URL
+  const triggerUrl = webhook.webhook_type === 'todo' && webhook.default_todo_id
+    ? `${baseUrl}/webhook/trigger/${webhook.default_todo_id}/todo`
+    : webhook.webhook_type === 'loop' && webhook.id
+    ? `${baseUrl}/webhook/trigger/${webhook.id}/loop`
+    : null;
+
   return (
     <Card
       size="small"
       style={{ marginBottom: 12 }}
       styles={{ body: { padding: 12 } }}
     >
-      {/* 顶部：名称 + 启用开关 + 操作 */}
+      {/* 顶部：名称 + 类型标签 + 启用开关 + 操作 */}
       <div
         style={{
           display: 'flex',
@@ -141,6 +148,12 @@ function WebhookCard({
           title={webhook.name}
         >
           {webhook.name}
+          <Tag
+            color={webhook.webhook_type === 'loop' ? 'purple' : 'blue'}
+            style={{ marginLeft: 6, fontSize: 10, lineHeight: '16px' }}
+          >
+            {webhook.webhook_type === 'loop' ? 'Loop' : 'Todo'}
+          </Tag>
         </div>
         <Space size={4} style={{ flexShrink: 0 }}>
           <Switch
@@ -171,7 +184,7 @@ function WebhookCard({
         </Space>
       </div>
 
-      {/* 默认触发 Todo */}
+      {/* 关联目标 */}
       <div
         style={{
           fontSize: 12,
@@ -181,7 +194,9 @@ function WebhookCard({
           gap: 4,
         }}
       >
-        <span style={{ flexShrink: 0 }}>默认 Todo：</span>
+        <span style={{ flexShrink: 0 }}>
+          {webhook.webhook_type === 'loop' ? '关联 Loop：' : '默认 Todo：'}
+        </span>
         <span
           style={{
             flex: 1,
@@ -190,21 +205,22 @@ function WebhookCard({
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
           }}
-          title={todo?.title || (webhook.default_todo_id ? `Todo #${webhook.default_todo_id}` : '')}
+          title={webhook.webhook_type === 'loop'
+            ? (webhook.loop_id ? `Loop #${webhook.loop_id}` : '')
+            : (todo?.title || (webhook.default_todo_id ? `Todo #${webhook.default_todo_id}` : ''))}
         >
-          {webhook.default_todo_id
-            ? (todo?.title || `Todo #${webhook.default_todo_id}`)
-            : <span style={{ opacity: 0.5 }}>未设置</span>}
+          {webhook.webhook_type === 'loop'
+            ? (webhook.loop_id ? `Loop #${webhook.loop_id}` : <span style={{ opacity: 0.5 }}>未设置</span>)
+            : (webhook.default_todo_id
+              ? (todo?.title || `Todo #${webhook.default_todo_id}`)
+              : <span style={{ opacity: 0.5 }}>未设置</span>)}
         </span>
       </div>
 
-      {/* URL 区域 —— 仅在配置了默认 Todo 时显示触发 URL */}
-      {webhook.default_todo_id ? (
+      {/* URL 区域 */}
+      {triggerUrl ? (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginBottom: 6 }}>
-          <CopyableUrl
-            url={`${baseUrl}/webhook/trigger/${webhook.default_todo_id}`}
-            compact
-          />
+          <CopyableUrl url={triggerUrl} compact />
         </div>
       ) : (
         <div
@@ -215,7 +231,7 @@ function WebhookCard({
             padding: '4px 0',
           }}
         >
-          未配置默认 Todo，无法生成触发 URL
+          未配置目标，无法生成触发 URL
         </div>
       )}
 
@@ -285,7 +301,9 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
     webhookForm.setFieldsValue({
       name: webhook.name,
       enabled: webhook.enabled,
+      webhook_type: webhook.webhook_type,
       default_todo_id: webhook.default_todo_id,
+      loop_id: webhook.loop_id,
     });
     setWebhookFormOpen(true);
   }, [webhookForm]);
@@ -296,10 +314,23 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
       setWebhookFormSaving(true);
 
       if (editingWebhook) {
-        await db.updateWebhook(editingWebhook.id, values.name, values.enabled, values.default_todo_id);
+        await db.updateWebhook(
+          editingWebhook.id,
+          values.name,
+          values.enabled,
+          values.webhook_type,
+          values.webhook_type === 'todo' ? values.default_todo_id : undefined,
+          values.webhook_type === 'loop' ? values.loop_id : undefined,
+        );
         message.success('Webhook 已更新');
       } else {
-        await db.createWebhook(values.name, values.enabled, values.default_todo_id);
+        await db.createWebhook(
+          values.name,
+          values.enabled,
+          values.webhook_type,
+          values.webhook_type === 'todo' ? values.default_todo_id : undefined,
+          values.webhook_type === 'loop' ? values.loop_id : undefined,
+        );
         message.success('Webhook 已创建');
       }
 
@@ -325,7 +356,14 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
 
   const handleToggleEnabled = useCallback(async (webhook: Webhook) => {
     try {
-      await db.updateWebhook(webhook.id, webhook.name, !webhook.enabled, webhook.default_todo_id ?? undefined);
+      await db.updateWebhook(
+        webhook.id,
+        webhook.name,
+        !webhook.enabled,
+        webhook.webhook_type,
+        webhook.default_todo_id ?? undefined,
+        webhook.loop_id ?? undefined,
+      );
       loadWebhooks();
     } catch (e: any) {
       message.error('更新失败: ' + (e?.message || String(e)));
@@ -342,6 +380,17 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
       width: 150,
     },
     {
+      title: '类型',
+      dataIndex: 'webhook_type',
+      key: 'webhook_type',
+      width: 80,
+      render: (type: 'todo' | 'loop') => (
+        <Tag color={type === 'loop' ? 'purple' : 'blue'}>
+          {type === 'loop' ? 'Loop' : 'Todo'}
+        </Tag>
+      ),
+    },
+    {
       title: '状态',
       dataIndex: 'enabled',
       key: 'enabled',
@@ -351,14 +400,17 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
       ),
     },
     {
-      title: '默认触发 Todo',
+      title: '关联目标',
       dataIndex: 'default_todo_id',
-      key: 'default_todo_id',
+      key: 'target',
       width: 200,
-      render: (todoId: number | null) => {
-        if (!todoId) return <span style={{ color: 'var(--color-text-tertiary)' }}>未设置</span>;
-        const todo = todos.find(t => t.id === todoId);
-        return todo ? todo.title : `Todo #${todoId}`;
+      render: (_: any, record: Webhook) => {
+        if (record.webhook_type === 'loop') {
+          return record.loop_id ? `Loop #${record.loop_id}` : <span style={{ color: 'var(--color-text-tertiary)' }}>未设置</span>;
+        }
+        if (!record.default_todo_id) return <span style={{ color: 'var(--color-text-tertiary)' }}>未设置</span>;
+        const todo = todos.find(t => t.id === record.default_todo_id);
+        return todo ? todo.title : `Todo #${record.default_todo_id}`;
       },
     },
     {
@@ -366,19 +418,19 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
       key: 'urls',
       width: 320,
       render: (_: any, record: Webhook) => {
-        if (!record.default_todo_id) {
+        const url = record.webhook_type === 'loop' && record.id
+          ? `${baseUrl}/webhook/trigger/${record.id}/loop`
+          : record.default_todo_id
+          ? `${baseUrl}/webhook/trigger/${record.default_todo_id}/todo`
+          : null;
+        if (!url) {
           return (
             <span style={{ color: 'var(--color-text-tertiary)', fontSize: 12 }}>
-              请先配置默认 Todo
+              请先配置目标
             </span>
           );
         }
-        return (
-          <CopyableUrl
-            url={`${baseUrl}/webhook/trigger/${record.default_todo_id}`}
-            compact={false}
-          />
-        );
+        return <CopyableUrl url={url} compact={false} />;
       },
     },
     {
@@ -598,30 +650,58 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
             <Input placeholder="例如: 默认 Webhook" />
           </Form.Item>
           <Form.Item
+            name="webhook_type"
+            label="类型"
+            tooltip="Todo 类型通过 /webhook/trigger/{todo_id}/todo 触发；Loop 类型通过 /webhook/trigger/{webhook_id}/loop 触发"
+            rules={[{ required: true, message: '请选择类型' }]}
+          >
+            <Select
+              placeholder="选择 webhook 类型"
+              options={[
+                { value: 'todo', label: 'Todo - 触发指定 Todo 执行' },
+                { value: 'loop', label: 'Loop - 触发 Loop 的 webhook 触发器' },
+              ]}
+            />
+          </Form.Item>
+          <Form.Item noStyle shouldUpdate={(prev, curr) => prev.webhook_type !== curr.webhook_type}>
+            {({ getFieldValue }) =>
+              getFieldValue('webhook_type') === 'todo' ? (
+                <Form.Item
+                  name="default_todo_id"
+                  label="默认触发 Todo"
+                  tooltip="配置后可通过 /webhook/trigger/{todo_id}/todo 显式触发；必须设置才能生成触发 URL"
+                >
+                  <Select
+                    allowClear
+                    placeholder="选择默认触发的 Todo"
+                    showSearch
+                    filterOption={(input, option) =>
+                      (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                    }
+                    options={todos.map(t => ({
+                      value: t.id,
+                      label: t.title,
+                    }))}
+                  />
+                </Form.Item>
+              ) : (
+                <Form.Item
+                  name="loop_id"
+                  label="关联 Loop"
+                  tooltip="配置后可通过 /webhook/trigger/{webhook_id}/loop 触发此 Loop；必须设置才能生成触发 URL"
+                >
+                  <Input type="number" placeholder="输入 Loop ID" />
+                </Form.Item>
+              )
+            }
+          </Form.Item>
+          <Form.Item
             name="enabled"
             label="启用状态"
             valuePropName="checked"
             initialValue={true}
           >
             <Switch />
-          </Form.Item>
-          <Form.Item
-            name="default_todo_id"
-            label="默认触发 Todo"
-            tooltip="配置后可通过 /webhook/trigger/{todo_id} 显式触发；必须设置才能生成触发 URL"
-          >
-            <Select
-              allowClear
-              placeholder="选择默认触发的 Todo"
-              showSearch
-              filterOption={(input, option) =>
-                (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
-              }
-              options={todos.map(t => ({
-                value: t.id,
-                label: t.title,
-              }))}
-            />
           </Form.Item>
         </Form>
       </Modal>

--- a/frontend/src/components/WebhooksPanel.tsx
+++ b/frontend/src/components/WebhooksPanel.tsx
@@ -27,9 +27,11 @@ import {
   CopyOutlined,
 } from '@ant-design/icons';
 import * as db from '@/utils/database';
+import * as dbLoops from '@/utils/database/loops';
 import type { Webhook, WebhookRecord } from '@/utils/database';
 import { copyToClipboard } from '@/utils/clipboard';
 import type { Todo } from '@/types';
+import type { LoopListItem } from '@/types/loop';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
 interface WebhooksPanelProps {
@@ -254,6 +256,9 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
 
   // Records state
   const [records, setRecords] = useState<WebhookRecord[]>([]);
+  // Loops list for webhook form (loop type)
+  const [loops, setLoops] = useState<LoopListItem[]>([]);
+  const [loopsLoading, setLoopsLoading] = useState(false);
   const [recordsLoading, setRecordsLoading] = useState(false);
   const [recordsTotal, setRecordsTotal] = useState(0);
   const [recordsPage, setRecordsPage] = useState(1);
@@ -285,6 +290,18 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
     }
   };
 
+  const loadLoops = async () => {
+    setLoopsLoading(true);
+    try {
+      const data = await dbLoops.listLoops();
+      setLoops(data);
+    } catch {
+      // 静默失败
+    } finally {
+      setLoopsLoading(false);
+    }
+  };
+
   useEffect(() => {
     loadWebhooks();
     loadRecords(1, recordsPageSize);
@@ -293,6 +310,7 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
   const handleCreateWebhook = useCallback(() => {
     setEditingWebhook(null);
     webhookForm.resetFields();
+    loadLoops();
     setWebhookFormOpen(true);
   }, [webhookForm]);
 
@@ -305,6 +323,7 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
       default_todo_id: webhook.default_todo_id,
       loop_id: webhook.loop_id,
     });
+    loadLoops();
     setWebhookFormOpen(true);
   }, [webhookForm]);
 
@@ -688,9 +707,21 @@ export function WebhooksPanel({ todos }: WebhooksPanelProps) {
                 <Form.Item
                   name="loop_id"
                   label="关联 Loop"
-                  tooltip="配置后可通过 /webhook/trigger/{webhook_id}/loop 触发此 Loop；必须设置才能生成触发 URL"
+                  tooltip="配置后可通过 /webhook/trigger/loop/{loop_id} 触发此 Loop；必须设置才能生成触发 URL"
                 >
-                  <Input type="number" placeholder="输入 Loop ID" />
+                  <Select
+                    allowClear
+                    placeholder="选择关联的 Loop"
+                    showSearch
+                    loading={loopsLoading}
+                    filterOption={(input, option) =>
+                      (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                    }
+                    options={loops.map(l => ({
+                      value: l.id,
+                      label: l.name,
+                    }))}
+                  />
                 </Form.Item>
               )
             }

--- a/frontend/src/utils/database/webhooks.ts
+++ b/frontend/src/utils/database/webhooks.ts
@@ -4,7 +4,12 @@ export interface Webhook {
   id: number;
   name: string;
   enabled: boolean;
+  /** 绑定的默认 todo（仅 webhook_type = "todo" 时有效） */
   default_todo_id: number | null;
+  /** 绑定的 loop（仅 webhook_type = "loop" 时有效） */
+  loop_id: number | null;
+  /** 类型: "todo" | "loop" */
+  webhook_type: 'todo' | 'loop';
   created_at: string;
   updated_at: string;
 }
@@ -40,19 +45,44 @@ export async function getWebhook(id: number): Promise<Webhook> {
   return unwrap(await api.get(`/api/webhooks/${id}`));
 }
 
-export async function createWebhook(name: string, enabled: boolean, defaultTodoId?: number): Promise<Webhook> {
+/**
+ * 创建 webhook。
+ * webhookType = "loop" 时需要传 loopId，defaultTodoId 留空；
+ * webhookType = "todo" 时需要传 defaultTodoId，loopId 留空。
+ */
+export async function createWebhook(
+  name: string,
+  enabled: boolean,
+  webhookType: 'todo' | 'loop' = 'todo',
+  defaultTodoId?: number,
+  loopId?: number,
+): Promise<Webhook> {
   return unwrap(await api.post('/api/webhooks', {
     name,
     enabled,
-    default_todo_id: defaultTodoId ?? null,
+    webhook_type: webhookType,
+    default_todo_id: webhookType === 'todo' ? (defaultTodoId ?? null) : null,
+    loop_id: webhookType === 'loop' ? (loopId ?? null) : null,
   }));
 }
 
-export async function updateWebhook(id: number, name: string, enabled: boolean, defaultTodoId?: number): Promise<Webhook> {
+/**
+ * 更新 webhook。
+ */
+export async function updateWebhook(
+  id: number,
+  name: string,
+  enabled: boolean,
+  webhookType: 'todo' | 'loop' = 'todo',
+  defaultTodoId?: number,
+  loopId?: number,
+): Promise<Webhook> {
   return unwrap(await api.put(`/api/webhooks/${id}`, {
     name,
     enabled,
-    default_todo_id: defaultTodoId ?? null,
+    webhook_type: webhookType,
+    default_todo_id: webhookType === 'todo' ? (defaultTodoId ?? null) : null,
+    loop_id: webhookType === 'loop' ? (loopId ?? null) : null,
   }));
 }
 


### PR DESCRIPTION
## 改动内容

### Backend
- webhook entity 新增 （`todo`|`loop`）和  字段
- 新触发路径：
  - `/webhook/trigger/todo/{todo_id}` — 触发 Todo 类型 webhook
  - `/webhook/trigger/loop/{loop_id}` — 触发 Loop 类型 webhook
- Loop webhook 触发时调用 `loop_trigger_dispatcher.dispatch_webhook()` 匹配并启动 loop
- 数据库迁移 v25：为 `webhooks` 表添加 `loop_id` 和 `webhook_type` 列

### Frontend
- **设置 > Webhook**：统一管理所有 webhook
  - 创建/编辑时选择类型（Todo / Loop）
  - Loop 类型使用下拉框选择关联的 Loop
  - 表格和卡片中显示类型标签
  - 根据类型生成正确的触发 URL
- **Loop Studio > 触发条件 > Webhook**：
  - 快速启用按钮：一点就自动创建 webhook（用 loop 名称命名）并启用触发器

### 测试
- 更新了 db_feature_supplement_tests 中的 webhook 测试签名