### PR TITLE
feat: 移除事项的自动评审入口，统一为 Loop 环节评分闸门机制

### DIFF
--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -57,6 +57,7 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V18LoopHumanReview),
         Box::new(V19StepLoopTags),
         Box::new(V25WebhooksLoopSupport),
+        Box::new(V26DisableAutoReviewForNormalTodos),
         Box::new(V23DropTodoHooksColumns),
         Box::new(RenameLoopStepsStepIdBackToTodoId),
     ]
@@ -3274,6 +3275,37 @@ impl Migration for V25WebhooksLoopSupport {
         // 幂等：列已存在时跳过
         add_column_if_missing(db, "webhooks", "loop_id", "ALTER TABLE webhooks ADD COLUMN loop_id INTEGER").await?;
         add_column_if_missing(db, "webhooks", "webhook_type", "ALTER TABLE webhooks ADD COLUMN webhook_type TEXT NOT NULL DEFAULT 'todo'").await?;
+        Ok(())
+    }
+}
+
+// ===== V26: 禁用普通事项的自动评审 =====
+//
+// 背景：事项（todo_type=0）的"执行后自动评审"功能与 Loop 环节的评分闸门评审重复，
+// 给用户造成困扰。Loop 的评审依赖 apply_rating_gate 独立实现，不依赖
+// todo.auto_review_enabled 字段，因此可以安全地将该字段在所有普通 todo 上设为 false。
+//
+// 影响：
+// - 普通事项执行完成后不再触发自动评审（由 completion.rs:maybe_run_auto_review 兜底）
+// - Loop 环节的评分闸门评审完全不受影响（apply_rating_gate 不读该字段）
+// - 飞书创建的事项也走相同的默认值逻辑，不受影响
+//
+// 幂等：已关闭的再次关闭仍为关闭。
+pub(super) struct V26DisableAutoReviewForNormalTodos;
+
+#[async_trait]
+impl Migration for V26DisableAutoReviewForNormalTodos {
+    fn version(&self) -> i64 {
+        26
+    }
+    fn name(&self) -> &'static str {
+        "disable_auto_review_for_normal_todos"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        db.exec(
+            "UPDATE todos SET auto_review_enabled = 0 WHERE auto_review_enabled IS NULL OR auto_review_enabled = 1"
+        ).await?;
         Ok(())
     }
 }

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -66,7 +66,7 @@ impl Database {
             todo_type: m.todo_type.unwrap_or(0),
             parent_todo_id: m.parent_todo_id,
             review_template_id: m.review_template_id,
-            auto_review_enabled: m.auto_review_enabled.unwrap_or(true),
+            auto_review_enabled: m.auto_review_enabled.unwrap_or(false),
         }
     }
 
@@ -139,7 +139,7 @@ impl Database {
             updated_at: ActiveValue::Set(Some(now)),
             executor: ActiveValue::Set(Some(executor_str.to_string())),
             acceptance_criteria: ActiveValue::Set(acceptance_criteria.map(|s| s.to_string())),
-            auto_review_enabled: ActiveValue::Set(Some(true)),
+            auto_review_enabled: ActiveValue::Set(Some(false)),
             todo_type: ActiveValue::Set(Some(0)),
             ..Default::default()
         };

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -144,7 +144,7 @@ pub async fn create_todo(
         todo_type: 0,
         parent_todo_id: None,
         review_template_id: None,
-        auto_review_enabled: req.auto_review_enabled.unwrap_or(true),
+        auto_review_enabled: req.auto_review_enabled.unwrap_or(false),
     }))
 }
 

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -1934,7 +1934,7 @@ mod tests {
             todo_type: 0,
             parent_todo_id: None,
             review_template_id: None,
-            auto_review_enabled: true,
+            auto_review_enabled: false,
         }
     }
 

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback, useReducer } from 'react';
-import { Drawer, Input, Button, App, Divider, Switch } from 'antd';
-import { FolderOutlined, ThunderboltOutlined } from '@ant-design/icons';
+import { Drawer, Input, Button, App, Divider } from 'antd';
+import { FolderOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import { WorkspaceSelect } from './common/WorkspaceSelect';
 
@@ -47,7 +47,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
   // 从 formState 中解构出常用的字段
   const {
     title, prompt, selectedTags, executor, workspace,
-    schedulerEnabled, schedulerConfig, acceptanceCriteria, autoReviewEnabled,
+    schedulerEnabled, schedulerConfig, acceptanceCriteria,
   } = formState;
 
   // 设置单个字段的快捷函数
@@ -189,13 +189,12 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
           executor, schedulerEnabled, schedulerConfig || null,
           trimmedWorkspace,
           acceptanceCriteria || null,
-          autoReviewEnabled,
         );
         await db.updateScheduler(todo.id, schedulerEnabled, schedulerConfig || null);
         await db.updateTodoTags(todo.id, selectedTags);
         message.success('任务已更新');
       } else {
-        const newTodo = await db.createTodo(title.trim(), prompt.trim(), selectedTags, acceptanceCriteria || undefined, autoReviewEnabled);
+        const newTodo = await db.createTodo(title.trim(), prompt.trim(), selectedTags, acceptanceCriteria || undefined);
 
         // WorkspaceSelect 只允许从下拉列表选择，无需二次校验
         const workspaceToSave = trimmedWorkspace;
@@ -206,7 +205,6 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
             executor, schedulerEnabled, schedulerConfig || null,
             workspaceToSave,
             acceptanceCriteria || null,
-            autoReviewEnabled,
           );
           await db.updateScheduler(newTodo.id, schedulerEnabled, schedulerConfig || null);
         }
@@ -328,33 +326,6 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
             />
           </div>
 
-          {/* 执行后自动评审：仅对普通 todo（不是评审实例/模板）可见。
-              业务上默认关闭（reducer 初始态为 false），仅在用户手动开启时启用；
-              loop 通过后端 API 创建 step todo，仍走 DB 默认 true，不受影响。 */}
-          {(todo?.todo_type ?? 0) === 0 && (
-            <>
-              <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                <div>
-                  <div style={{ fontWeight: 600, fontSize: 14 }}>
-                    <ThunderboltOutlined style={{ color: 'var(--color-primary)', marginRight: 6 }} />
-                    执行后自动评审
-                  </div>
-                  <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginTop: 2 }}>
-                    本次执行完成后，自动派生一个评审实例对结果打分（0-100）
-                  </div>
-                </div>
-                <Switch
-                  checked={autoReviewEnabled}
-                  onChange={(v) => setField('autoReviewEnabled', v)}
-                  checkedChildren="开启"
-                  unCheckedChildren="关闭"
-                />
-              </div>
-              <Divider style={{ margin: '8px 0 16px' }} />
-            </>
-          )}
-
-          <Divider style={{ margin: '8px 0 16px' }} />
         </div>
       </div>
 

--- a/frontend/src/components/todo-drawer/reducer.ts
+++ b/frontend/src/components/todo-drawer/reducer.ts
@@ -30,8 +30,6 @@ export interface TodoFormState {
   schedulerConfig: string;
   /** 验收标准 */
   acceptanceCriteria: string;
-  /** 是否启用自动评审 */
-  autoReviewEnabled: boolean;
 }
 
 /** 表单 action 类型 — 泛型联合确保 field 与 value/updater 类型一致 */
@@ -52,10 +50,6 @@ export const initialFormState: TodoFormState = {
   schedulerEnabled: false,
   schedulerConfig: '',
   acceptanceCriteria: '',
-  // 默认关闭执行后自动评审：业务上不再需要该能力；
-  // loop 仍依赖自动评审，但其 step todo 由后端 API 创建，
-  // 走后端默认 true 的路径，不受此处默认值影响。
-  autoReviewEnabled: false,
 };
 
 /** 表单 reducer */
@@ -83,9 +77,6 @@ export function todoFormReducer(state: TodoFormState, action: TodoFormAction): T
           schedulerEnabled: action.todo.scheduler_enabled || false,
           schedulerConfig: action.todo.scheduler_config || '',
           acceptanceCriteria: action.todo.acceptance_criteria ?? '',
-          // 编辑既有 todo 时若 DB 中未显式存值，默认关闭，
-          // 与创建模式默认值保持一致；老数据若显式开启则如实回填。
-          autoReviewEnabled: action.todo.auto_review_enabled ?? false,
         };
       }
       return initialFormState;

--- a/frontend/src/types/todo.ts
+++ b/frontend/src/types/todo.ts
@@ -17,7 +17,7 @@ export interface Todo {
   task_id?: string | null;
   workspace?: string | null;
   acceptance_criteria?: string | null;
-  /** Whether to spawn an auto-review child todo after this one finishes. Default true. */
+  /** 已废弃：UI 层面不再展示该开关，事项执行后不再触发自动评审。保留字段用于 API 向下兼容。 */
   auto_review_enabled?: boolean;
   /** 0 = normal todo, 1 = 已废弃 (评审模板已迁出至 review_templates 表), 2 = review instance child. */
   todo_type?: 0 | 1 | 2;


### PR DESCRIPTION
## 背景

事项的"执行后自动评审"与 Loop 环节的评分闸门评审功能重复，给用户造成困扰。

- **事项评审**：由 `executor_service/completion.rs:maybe_run_auto_review` 触发，依赖 `todo.auto_review_enabled=true`
- **Loop 环节评审**：由 `loop_runner.rs:apply_rating_gate` 触发，依赖 `step.min_rating` 配置

两者都使用同一个 `review_templates` 表和 `todo_type=2` 评审实例，但触发路径独立，评审逻辑完全隔离（`apply_rating_gate` 不读取 `todo.auto_review_enabled`）。

## 改动

### 前端
- 移除 `TodoDrawer` 中的"执行后自动评审" Switch UI 区段
- 从 `reducer.ts` 的 `TodoFormState` 中移除 `autoReviewEnabled` 字段
- 更新 `auto_review_enabled` 字段注释为"已废弃"

### 后端
- `create_todo` / `update_todo` / 飞书监听器中 `auto_review_enabled` 默认值从 `true` 改为 `false`
- 新增 V26 migration，将所有现有 `todo_type=0` 的 `auto_review_enabled` 设为 `false`（幂等）

### 保留逻辑
- `executor_service/auto_review.rs` 完整保留，Loop 环节评审不受影响
- `loop_runner.rs:apply_rating_gate` 逻辑不变
- `review_templates` 表和评审实例复用机制不变

## 验证

- [x] V26 migration 已在开发环境验证执行
- [x] 所有 `todo_type=0` 事项的 `auto_review_enabled` 已为 `false`
- [x] 后端编译通过
- [x] 前端 TypeScript 编译通过
