### PR TITLE
feat: 在全局限制区域添加超限异常处理标记

### DIFF
--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -20,6 +20,8 @@ import {
   DeleteOutlined,
   EditOutlined,
   ExclamationCircleOutlined,
+  CheckCircleOutlined,
+  CloseCircleOutlined,
 } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
 import * as db from '@/utils/database';
@@ -271,6 +273,34 @@ export function LoopDetailPanel({
                   ? <span style={{ fontWeight: 500 }}>{lc.max_total_tokens.toLocaleString()}</span>
                   : <span style={{ color: '#94a3b8' }}>未限制</span>;
               } catch { return <EmptyValue />; }
+            })()
+          } />
+          <DetailField label="超限异常处理" value={
+            (() => {
+              const hasHandler = detail.abnormal_handler_todo_id != null;
+              const triggerOn = detail.abnormal_handler_trigger_on ? JSON.parse(detail.abnormal_handler_trigger_on) : [];
+              const hasCappedTrigger = Array.isArray(triggerOn) && (triggerOn.includes('capped_step') || triggerOn.includes('capped_token'));
+              const enabled = hasHandler && hasCappedTrigger;
+              return (
+                <span style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 6,
+                  padding: '2px 8px',
+                  borderRadius: 12,
+                  background: enabled ? '#dcfce7' : '#f1f5f9',
+                  color: enabled ? '#166534' : '#64748b',
+                  fontSize: 12,
+                  fontWeight: 500,
+                }}>
+                  {enabled ? (
+                    <CheckCircleOutlined style={{ fontSize: 12 }} />
+                  ) : (
+                    <CloseCircleOutlined style={{ fontSize: 12 }} />
+                  )}
+                  {enabled ? '已启用' : '未启用'}
+                </span>
+              );
             })()
           } />
         </div>


### PR DESCRIPTION
## Summary
- 在 Loop 详情页面的全局限制区域新增一个字段，显示是否启用了超限异常处理配置
- 当同时满足以下条件时显示为"已启用"：
  - 设置了异常处理 Todo (abnormal_handler_todo_id)
  - 触发条件包含超步数(capped_step)或超Token(capped_token)

## Test plan
- [ ] 验证 Loop 详情页正常显示
- [ ] 验证超限异常处理标记在满足条件时显示"已启用"
- [ ] 验证不满足条件时显示"未启用"