### PR TITLE
feat: 评审模板按 workspace_id 隔离 + 移除设置页入口

### DIFF
--- a/backend/src/db/entity/review_templates.rs
+++ b/backend/src/db/entity/review_templates.rs
@@ -24,8 +24,8 @@ pub struct Model {
     pub name: String,
     pub description: Option<String>,
     pub prompt: String,
-    /// 所属工作空间（目录路径）。None = 全局模板（不限制工作空间）。
-    pub workspace: Option<String>,
+    /// 所属工作空间 ID（project_directories.id）。None = 全局模板。
+    pub workspace_id: Option<i64>,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }

--- a/backend/src/db/entity/review_templates.rs
+++ b/backend/src/db/entity/review_templates.rs
@@ -24,6 +24,8 @@ pub struct Model {
     pub name: String,
     pub description: Option<String>,
     pub prompt: String,
+    /// 所属工作空间（目录路径）。None = 全局模板（不限制工作空间）。
+    pub workspace: Option<String>,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }

--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -65,6 +65,7 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V30WorkspaceRefactor),
         Box::new(V31AddTodosWorkspaceId),
         Box::new(V32ReviewTemplatesWorkspaceId),
+        Box::new(V33ReviewTemplatesEnsureWorkspaceId),
     ]
 }
 
@@ -3553,6 +3554,27 @@ impl Migration for V32ReviewTemplatesWorkspaceId {
         }
         db.exec("ALTER TABLE review_templates ADD COLUMN workspace_id INTEGER").await?;
         tracing::info!("V32: added review_templates.workspace_id column");
+        Ok(())
+    }
+}
+
+/// V33 迁移：确保 review_templates 表存在 workspace_id 列。
+///
+/// 背景：V32 最初添加的是 workspace TEXT 列，后修正为 workspace_id INTEGER。
+/// 但由于 V32 已在部分环境中执行过（workspace TEXT），版本号无法覆写，
+/// 故新增 V33 作为补救：跳过已存在 workspace_id 的环境，不存在则补加。
+pub(super) struct V33ReviewTemplatesEnsureWorkspaceId;
+#[async_trait::async_trait]
+impl Migration for V33ReviewTemplatesEnsureWorkspaceId {
+    fn version(&self) -> i64 { 33 }
+    fn name(&self) -> &'static str { "ensure_review_templates_workspace_id" }
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        if table_has_column(db, "review_templates", "workspace_id").await? {
+            tracing::info!("review_templates.workspace_id already exists, skip V33");
+            return Ok(());
+        }
+        db.exec("ALTER TABLE review_templates ADD COLUMN workspace_id INTEGER").await?;
+        tracing::info!("V33: added review_templates.workspace_id column");
         Ok(())
     }
 }

--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -64,7 +64,7 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V29WebhookEnabledFields),
         Box::new(V30WorkspaceRefactor),
         Box::new(V31AddTodosWorkspaceId),
-        Box::new(V32ReviewTemplatesWorkspace),
+        Box::new(V32ReviewTemplatesWorkspaceId),
     ]
 }
 
@@ -3539,20 +3539,20 @@ impl Migration for V31AddTodosWorkspaceId {
     }
 }
 
-/// V32 迁移：为 review_templates 表添加 workspace 列，实现按工作空间隔离。
-pub(super) struct V32ReviewTemplatesWorkspace;
+/// V32 迁移：为 review_templates 表添加 workspace_id 列，实现按工作空间隔离。
+pub(super) struct V32ReviewTemplatesWorkspaceId;
 #[async_trait::async_trait]
-impl Migration for V32ReviewTemplatesWorkspace {
+impl Migration for V32ReviewTemplatesWorkspaceId {
     fn version(&self) -> i64 { 32 }
-    fn name(&self) -> &'static str { "add_review_templates_workspace" }
+    fn name(&self) -> &'static str { "add_review_templates_workspace_id" }
     async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
         // 幂等：列已存在时跳过 ALTER
-        if table_has_column(db, "review_templates", "workspace").await? {
-            tracing::info!("review_templates.workspace already exists, skip V32");
+        if table_has_column(db, "review_templates", "workspace_id").await? {
+            tracing::info!("review_templates.workspace_id already exists, skip V32");
             return Ok(());
         }
-        db.exec("ALTER TABLE review_templates ADD COLUMN workspace TEXT").await?;
-        tracing::info!("V32: added review_templates.workspace column");
+        db.exec("ALTER TABLE review_templates ADD COLUMN workspace_id INTEGER").await?;
+        tracing::info!("V32: added review_templates.workspace_id column");
         Ok(())
     }
 }

--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -64,6 +64,7 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V29WebhookEnabledFields),
         Box::new(V30WorkspaceRefactor),
         Box::new(V31AddTodosWorkspaceId),
+        Box::new(V32ReviewTemplatesWorkspace),
     ]
 }
 
@@ -3534,6 +3535,24 @@ impl Migration for V31AddTodosWorkspaceId {
         )
         .await?;
 
+        Ok(())
+    }
+}
+
+/// V32 迁移：为 review_templates 表添加 workspace 列，实现按工作空间隔离。
+pub(super) struct V32ReviewTemplatesWorkspace;
+#[async_trait::async_trait]
+impl Migration for V32ReviewTemplatesWorkspace {
+    fn version(&self) -> i64 { 32 }
+    fn name(&self) -> &'static str { "add_review_templates_workspace" }
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 幂等：列已存在时跳过 ALTER
+        if table_has_column(db, "review_templates", "workspace").await? {
+            tracing::info!("review_templates.workspace already exists, skip V32");
+            return Ok(());
+        }
+        db.exec("ALTER TABLE review_templates ADD COLUMN workspace TEXT").await?;
+        tracing::info!("V32: added review_templates.workspace column");
         Ok(())
     }
 }

--- a/backend/src/db/review_template.rs
+++ b/backend/src/db/review_template.rs
@@ -28,7 +28,7 @@ pub struct ReviewTemplateInput {
     pub name: String,
     pub description: Option<String>,
     pub prompt: String,
-    pub workspace: Option<String>,
+    pub workspace_id: Option<i64>,
 }
 
 impl From<&CreateReviewTemplateRequest> for ReviewTemplateInput {
@@ -37,7 +37,7 @@ impl From<&CreateReviewTemplateRequest> for ReviewTemplateInput {
             name: r.name.clone(),
             description: r.description.clone(),
             prompt: r.prompt.clone(),
-            workspace: r.workspace.clone(),
+            workspace_id: r.workspace_id,
         }
     }
 }
@@ -48,7 +48,7 @@ impl From<&UpdateReviewTemplateRequest> for ReviewTemplateInput {
             name: r.name.clone(),
             description: r.description.clone(),
             prompt: r.prompt.clone(),
-            workspace: None, // 更新时不修改 workspace
+            workspace_id: None, // 更新时不修改 workspace_id
         }
     }
 }
@@ -61,7 +61,7 @@ fn to_domain(m: review_templates::Model) -> ReviewTemplate {
         name: m.name,
         description: m.description,
         prompt: m.prompt,
-        workspace: m.workspace,
+        workspace_id: m.workspace_id,
         created_at: m.created_at,
         updated_at: m.updated_at,
     }
@@ -72,23 +72,23 @@ fn to_option(m: review_templates::Model) -> ReviewTemplateOption {
         id: m.id,
         name: m.name,
         description: m.description,
-        workspace: m.workspace,
+        workspace_id: m.workspace_id,
     }
 }
 
 impl Database {
     /// 列出全部评审模板，按 id 升序。返回完整模型（含 prompt）。
-    /// 可选按 workspace 过滤（None 或空字符串 = 不过滤）。
+    /// 可选按 workspace_id 过滤（None = 不过滤）。
     /// 设计原因：管理面板需要看 prompt；选项下拉请用 `list_review_template_options`。
     pub async fn list_review_templates(
         &self,
-        workspace: Option<&str>,
+        workspace_id: Option<i64>,
     ) -> Result<Vec<ReviewTemplate>, sea_orm::DbErr> {
         let mut query = review_templates::Entity::find()
             .order_by_asc(review_templates::Column::Id);
 
-        if let Some(ws) = workspace.filter(|s| !s.is_empty()) {
-            query = query.filter(review_templates::Column::Workspace.eq(ws.to_string()));
+        if let Some(ws_id) = workspace_id {
+            query = query.filter(review_templates::Column::WorkspaceId.eq(ws_id));
         }
 
         let models = query.all(&self.conn).await?;
@@ -96,16 +96,16 @@ impl Database {
     }
 
     /// 列出评审模板的轻量选项（不含 prompt），用于 loop 编辑器下拉。
-    /// 可选按 workspace 过滤（None 或空字符串 = 不过滤）。
+    /// 可选按 workspace_id 过滤（None = 不过滤）。
     pub async fn list_review_template_options(
         &self,
-        workspace: Option<&str>,
+        workspace_id: Option<i64>,
     ) -> Result<Vec<ReviewTemplateOption>, sea_orm::DbErr> {
         let mut query = review_templates::Entity::find()
             .order_by_asc(review_templates::Column::Id);
 
-        if let Some(ws) = workspace.filter(|s| !s.is_empty()) {
-            query = query.filter(review_templates::Column::Workspace.eq(ws.to_string()));
+        if let Some(ws_id) = workspace_id {
+            query = query.filter(review_templates::Column::WorkspaceId.eq(ws_id));
         }
 
         let models = query.all(&self.conn).await?;
@@ -140,7 +140,7 @@ impl Database {
             name: ActiveValue::Set(input.name.clone()),
             description: ActiveValue::Set(input.description.clone()),
             prompt: ActiveValue::Set(input.prompt.clone()),
-            workspace: ActiveValue::Set(input.workspace.clone()),
+            workspace_id: ActiveValue::Set(input.workspace_id),
             created_at: ActiveValue::Set(Some(now.clone())),
             updated_at: ActiveValue::Set(Some(now)),
             ..Default::default()
@@ -238,7 +238,7 @@ mod tests {
             name: name.to_string(),
             description: Some(format!("{name} 描述")),
             prompt: prompt.to_string(),
-            workspace: None,
+            workspace_id: None,
         }
     }
 
@@ -419,8 +419,8 @@ mod tests {
         let row = db.get_review_template(id).await.expect("get").expect("some");
         assert_eq!(row.name, "默认评审任务");
         assert!(row.prompt.contains("评审") && row.prompt.contains("RATING"));
-        // 默认模板的 workspace 应为 None（全局模板）
-        assert!(row.workspace.is_none(), "default template must be global (no workspace)");
+        // 默认模板的 workspace_id 应为 None（全局模板）
+        assert!(row.workspace_id.is_none(), "default template must be global (no workspace_id)");
     }
 
     #[tokio::test]

--- a/backend/src/db/review_template.rs
+++ b/backend/src/db/review_template.rs
@@ -28,6 +28,7 @@ pub struct ReviewTemplateInput {
     pub name: String,
     pub description: Option<String>,
     pub prompt: String,
+    pub workspace: Option<String>,
 }
 
 impl From<&CreateReviewTemplateRequest> for ReviewTemplateInput {
@@ -36,6 +37,7 @@ impl From<&CreateReviewTemplateRequest> for ReviewTemplateInput {
             name: r.name.clone(),
             description: r.description.clone(),
             prompt: r.prompt.clone(),
+            workspace: r.workspace.clone(),
         }
     }
 }
@@ -46,6 +48,7 @@ impl From<&UpdateReviewTemplateRequest> for ReviewTemplateInput {
             name: r.name.clone(),
             description: r.description.clone(),
             prompt: r.prompt.clone(),
+            workspace: None, // 更新时不修改 workspace
         }
     }
 }
@@ -58,6 +61,7 @@ fn to_domain(m: review_templates::Model) -> ReviewTemplate {
         name: m.name,
         description: m.description,
         prompt: m.prompt,
+        workspace: m.workspace,
         created_at: m.created_at,
         updated_at: m.updated_at,
     }
@@ -68,26 +72,43 @@ fn to_option(m: review_templates::Model) -> ReviewTemplateOption {
         id: m.id,
         name: m.name,
         description: m.description,
+        workspace: m.workspace,
     }
 }
 
 impl Database {
     /// 列出全部评审模板，按 id 升序。返回完整模型（含 prompt）。
+    /// 可选按 workspace 过滤（None 或空字符串 = 不过滤）。
     /// 设计原因：管理面板需要看 prompt；选项下拉请用 `list_review_template_options`。
-    pub async fn list_review_templates(&self) -> Result<Vec<ReviewTemplate>, sea_orm::DbErr> {
-        let models = review_templates::Entity::find()
-            .order_by_asc(review_templates::Column::Id)
-            .all(&self.conn)
-            .await?;
+    pub async fn list_review_templates(
+        &self,
+        workspace: Option<&str>,
+    ) -> Result<Vec<ReviewTemplate>, sea_orm::DbErr> {
+        let mut query = review_templates::Entity::find()
+            .order_by_asc(review_templates::Column::Id);
+
+        if let Some(ws) = workspace.filter(|s| !s.is_empty()) {
+            query = query.filter(review_templates::Column::Workspace.eq(ws.to_string()));
+        }
+
+        let models = query.all(&self.conn).await?;
         Ok(models.into_iter().map(to_domain).collect())
     }
 
     /// 列出评审模板的轻量选项（不含 prompt），用于 loop 编辑器下拉。
-    pub async fn list_review_template_options(&self) -> Result<Vec<ReviewTemplateOption>, sea_orm::DbErr> {
-        let models = review_templates::Entity::find()
-            .order_by_asc(review_templates::Column::Id)
-            .all(&self.conn)
-            .await?;
+    /// 可选按 workspace 过滤（None 或空字符串 = 不过滤）。
+    pub async fn list_review_template_options(
+        &self,
+        workspace: Option<&str>,
+    ) -> Result<Vec<ReviewTemplateOption>, sea_orm::DbErr> {
+        let mut query = review_templates::Entity::find()
+            .order_by_asc(review_templates::Column::Id);
+
+        if let Some(ws) = workspace.filter(|s| !s.is_empty()) {
+            query = query.filter(review_templates::Column::Workspace.eq(ws.to_string()));
+        }
+
+        let models = query.all(&self.conn).await?;
         Ok(models.into_iter().map(to_option).collect())
     }
 
@@ -119,6 +140,7 @@ impl Database {
             name: ActiveValue::Set(input.name.clone()),
             description: ActiveValue::Set(input.description.clone()),
             prompt: ActiveValue::Set(input.prompt.clone()),
+            workspace: ActiveValue::Set(input.workspace.clone()),
             created_at: ActiveValue::Set(Some(now.clone())),
             updated_at: ActiveValue::Set(Some(now)),
             ..Default::default()
@@ -216,6 +238,7 @@ mod tests {
             name: name.to_string(),
             description: Some(format!("{name} 描述")),
             prompt: prompt.to_string(),
+            workspace: None,
         }
     }
 
@@ -225,7 +248,7 @@ mod tests {
     async fn list_returns_only_seeded_default_on_fresh_db() {
         // V15 迁移在 fresh DB 上自动 seed 一条默认模板, list 不该空着。
         let db = fresh_db().await;
-        let list = db.list_review_templates().await.expect("list must succeed");
+        let list = db.list_review_templates(None).await.expect("list must succeed");
         assert_eq!(list.len(), 1, "V15 seeds exactly one default template");
         assert_eq!(list[0].name, "默认评审任务");
     }
@@ -238,7 +261,7 @@ mod tests {
         db.delete_review_template(default_id).await.expect("del default");
         db.create_review_template(&sample_input("B", "p-b")).await.expect("create B");
         db.create_review_template(&sample_input("A", "p-a")).await.expect("create A");
-        let list = db.list_review_templates().await.expect("list");
+        let list = db.list_review_templates(None).await.expect("list");
         assert_eq!(list.len(), 2);
         assert_eq!(list[0].name, "B", "first by id ascending");
         assert_eq!(list[1].name, "A");
@@ -255,7 +278,7 @@ mod tests {
         db.create_review_template(&sample_input("代码评审", "敏感 prompt 内含 RATING 占位符"))
             .await
             .expect("create");
-        let opts = db.list_review_template_options().await.expect("opts");
+        let opts = db.list_review_template_options(None).await.expect("opts");
         assert_eq!(opts.len(), 2, "default + created = 2");
         // 第二条是「代码评审」, 验证其字段且不带 prompt (编译期由 ReviewTemplateOption 字段保证)
         let code_review = opts.iter().find(|o| o.name == "代码评审").expect("must find");
@@ -396,6 +419,8 @@ mod tests {
         let row = db.get_review_template(id).await.expect("get").expect("some");
         assert_eq!(row.name, "默认评审任务");
         assert!(row.prompt.contains("评审") && row.prompt.contains("RATING"));
+        // 默认模板的 workspace 应为 None（全局模板）
+        assert!(row.workspace.is_none(), "default template must be global (no workspace)");
     }
 
     #[tokio::test]
@@ -439,7 +464,7 @@ mod tests {
         let id_b = id_b.expect("ensure B");
         assert_eq!(id_a, id_b, "concurrent ensure must converge on same id");
         // 必须恰好一行（不会重复插入）
-        let list = db.list_review_templates().await.expect("list");
+        let list = db.list_review_templates(None).await.expect("list");
         assert_eq!(list.len(), 1, "concurrent ensure must not duplicate");
     }
 }

--- a/backend/src/handlers/review_template.rs
+++ b/backend/src/handlers/review_template.rs
@@ -1,8 +1,8 @@
 //! 评审模板 HTTP handler。
 //!
 //! 端点（与 `db/review_template.rs` DAO 一一对应）：
-//! - `GET    /api/review-templates`          列出全部（含 prompt，用于管理面板）
-//! - `GET    /api/review-templates/options`  轻量选项（不含 prompt，用于 loop 选择器）
+//! - `GET    /api/review-templates?workspace=`   列出（含 prompt，可选按 workspace 过滤）
+//! - `GET    /api/review-templates/options?workspace=`  轻量选项（可选按 workspace 过滤）
 //! - `GET    /api/review-templates/{id}`     取单条
 //! - `POST   /api/review-templates`          创建
 //! - `PUT    /api/review-templates/{id}`     更新（PUT 全字段语义）
@@ -10,8 +10,9 @@
 //!
 //! 路由构建函数 `review_template_routes()` 在 `handlers/mod.rs` 内组装。
 
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::Json;
+use serde::Deserialize;
 
 use crate::db::ReviewTemplateInput;
 use crate::handlers::{ApiJson, AppError, AppState};
@@ -20,19 +21,27 @@ use crate::models::{
     UpdateReviewTemplateRequest,
 };
 
+/// 查询参数：可选的 workspace 过滤。
+#[derive(Debug, Default, Deserialize)]
+pub struct ReviewTemplateQuery {
+    pub workspace: Option<String>,
+}
+
 /// 列表（完整模型，含 prompt）。
 pub async fn list_review_templates(
     State(state): State<AppState>,
+    Query(query): Query<ReviewTemplateQuery>,
 ) -> Result<Json<ApiResponse<Vec<ReviewTemplate>>>, AppError> {
-    let templates = state.db.list_review_templates().await?;
+    let templates = state.db.list_review_templates(query.workspace.as_deref()).await?;
     Ok(Json(ApiResponse::ok(templates)))
 }
 
 /// 选项列表（轻量，不含 prompt）。
 pub async fn list_review_template_options(
     State(state): State<AppState>,
+    Query(query): Query<ReviewTemplateQuery>,
 ) -> Result<Json<ApiResponse<Vec<ReviewTemplateOption>>>, AppError> {
-    let opts = state.db.list_review_template_options().await?;
+    let opts = state.db.list_review_template_options(query.workspace.as_deref()).await?;
     Ok(Json(ApiResponse::ok(opts)))
 }
 
@@ -66,6 +75,7 @@ pub async fn create_review_template(
         name: name.to_string(),
         description: req.description.as_ref().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()),
         prompt: prompt.to_string(),
+        workspace: req.workspace.as_ref().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()),
     };
     let id = state.db.create_review_template(&input).await?;
     let t = state
@@ -94,6 +104,7 @@ pub async fn update_review_template(
         name: name.to_string(),
         description: req.description.as_ref().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()),
         prompt: prompt.to_string(),
+        workspace: None, // 更新时不修改 workspace
     };
     state.db.update_review_template(id, &input).await?;
     let t = state

--- a/backend/src/handlers/review_template.rs
+++ b/backend/src/handlers/review_template.rs
@@ -21,10 +21,10 @@ use crate::models::{
     UpdateReviewTemplateRequest,
 };
 
-/// 查询参数：可选的 workspace 过滤。
+/// 查询参数：可选的 workspace_id 过滤。
 #[derive(Debug, Default, Deserialize)]
 pub struct ReviewTemplateQuery {
-    pub workspace: Option<String>,
+    pub workspace_id: Option<i64>,
 }
 
 /// 列表（完整模型，含 prompt）。
@@ -32,7 +32,7 @@ pub async fn list_review_templates(
     State(state): State<AppState>,
     Query(query): Query<ReviewTemplateQuery>,
 ) -> Result<Json<ApiResponse<Vec<ReviewTemplate>>>, AppError> {
-    let templates = state.db.list_review_templates(query.workspace.as_deref()).await?;
+    let templates = state.db.list_review_templates(query.workspace_id).await?;
     Ok(Json(ApiResponse::ok(templates)))
 }
 
@@ -41,7 +41,7 @@ pub async fn list_review_template_options(
     State(state): State<AppState>,
     Query(query): Query<ReviewTemplateQuery>,
 ) -> Result<Json<ApiResponse<Vec<ReviewTemplateOption>>>, AppError> {
-    let opts = state.db.list_review_template_options(query.workspace.as_deref()).await?;
+    let opts = state.db.list_review_template_options(query.workspace_id).await?;
     Ok(Json(ApiResponse::ok(opts)))
 }
 
@@ -75,7 +75,7 @@ pub async fn create_review_template(
         name: name.to_string(),
         description: req.description.as_ref().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()),
         prompt: prompt.to_string(),
-        workspace: req.workspace.as_ref().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()),
+        workspace_id: req.workspace_id,
     };
     let id = state.db.create_review_template(&input).await?;
     let t = state
@@ -104,7 +104,7 @@ pub async fn update_review_template(
         name: name.to_string(),
         description: req.description.as_ref().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()),
         prompt: prompt.to_string(),
-        workspace: None, // 更新时不修改 workspace
+        workspace_id: None, // 更新时不修改 workspace_id
     };
     state.db.update_review_template(id, &input).await?;
     let t = state

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -868,6 +868,8 @@ pub struct ReviewTemplate {
     pub name: String,
     pub description: Option<String>,
     pub prompt: String,
+    /// 所属工作空间（目录路径）。None = 全局模板。
+    pub workspace: Option<String>,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }
@@ -881,6 +883,8 @@ pub struct ReviewTemplateOption {
     pub id: i64,
     pub name: String,
     pub description: Option<String>,
+    /// 所属工作空间（目录路径）。None = 全局模板。
+    pub workspace: Option<String>,
 }
 
 /// 评审模板创建请求。
@@ -890,6 +894,9 @@ pub struct CreateReviewTemplateRequest {
     #[serde(default)]
     pub description: Option<String>,
     pub prompt: String,
+    /// 所属工作空间（目录路径）。None = 全局模板。
+    #[serde(default)]
+    pub workspace: Option<String>,
 }
 
 /// 评审模板更新请求（name/prompt 必传，description 可选）。

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -868,8 +868,8 @@ pub struct ReviewTemplate {
     pub name: String,
     pub description: Option<String>,
     pub prompt: String,
-    /// 所属工作空间（目录路径）。None = 全局模板。
-    pub workspace: Option<String>,
+    /// 所属工作空间 ID（project_directories.id）。null = 全局模板。
+    pub workspace_id: Option<i64>,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }
@@ -883,8 +883,8 @@ pub struct ReviewTemplateOption {
     pub id: i64,
     pub name: String,
     pub description: Option<String>,
-    /// 所属工作空间（目录路径）。None = 全局模板。
-    pub workspace: Option<String>,
+    /// 所属工作空间 ID（project_directories.id）。null = 全局模板。
+    pub workspace_id: Option<i64>,
 }
 
 /// 评审模板创建请求。
@@ -894,9 +894,9 @@ pub struct CreateReviewTemplateRequest {
     #[serde(default)]
     pub description: Option<String>,
     pub prompt: String,
-    /// 所属工作空间（目录路径）。None = 全局模板。
+    /// 所属工作空间 ID（project_directories.id）。null = 全局模板。
     #[serde(default)]
-    pub workspace: Option<String>,
+    pub workspace_id: Option<i64>,
 }
 
 /// 评审模板更新请求（name/prompt 必传，description 可选）。

--- a/frontend/src/components/LoopFormModal.tsx
+++ b/frontend/src/components/LoopFormModal.tsx
@@ -5,6 +5,7 @@
 // - mode="edit"：编辑已有环路，需传 loopId + initialData 预填
 // - 工作空间为必填项（创建模式强制，编辑模式 allowClear 但保存时校验不通过)
 // - 评审模板 inline 创建逻辑一并迁入，避免用户切到设置页
+// - 工作空间与评审模板联动：选择工作空间后过滤可选的评审模板
 //
 // 被 LoopStudioDetailPanel（编辑）和 App.tsx（新建）共用。
 
@@ -77,12 +78,17 @@ export function LoopFormModal({
   // 异常处理 Todo
   const [abnormalHandlerTodoOptions, setAbnormalHandlerTodoOptions] = useState<Todo[]>([]);
 
-  // 打开时加载评审模板选项和异常处理 Todo 选项
+  // 打开时 + workspace 变化时重新加载评审模板选项（按 workspace 过滤）
   useEffect(() => {
     if (!open) return;
-    dbReviewTemplates.listReviewTemplateOptions()
+    dbReviewTemplates.listReviewTemplateOptions(workspaceValue ?? undefined)
       .then(setReviewTemplateOptions)
       .catch(() => { /* 静默 */ });
+  }, [open, workspaceValue]);
+
+  // 打开时加载异常处理 Todo 选项
+  useEffect(() => {
+    if (!open) return;
     dbTodos.getAllTodos()
       .then(setAbnormalHandlerTodoOptions)
       .catch(() => { /* 静默 */ });
@@ -126,14 +132,14 @@ export function LoopFormModal({
     }
   }, [open, mode, initialData, form]);
 
-  // 刷新评审模板并选中新建的模板
+  // 刷新评审模板（按当前 workspace 过滤）并选中新建的模板
   const reloadTemplatesAndSelect = useCallback(async (selectedId: number) => {
-    const opts = await dbReviewTemplates.listReviewTemplateOptions();
+    const opts = await dbReviewTemplates.listReviewTemplateOptions(workspaceValue ?? undefined);
     setReviewTemplateOptions(opts);
     form.setFieldsValue({ review_template_id: selectedId });
-  }, [form]);
+  }, [form, workspaceValue]);
 
-  // inline 创建评审模板
+  // inline 创建评审模板（归属当前选中的工作空间）
   const handleCreateTemplate = useCallback(async () => {
     const values = await newTemplateForm.validateFields();
     setCreatingTemplateSaving(true);
@@ -142,6 +148,7 @@ export function LoopFormModal({
         name: values.name.trim(),
         description: values.description?.trim() || null,
         prompt: values.prompt,
+        workspace: workspaceValue ?? null,
       });
       message.success(`已创建模板「${created.name}」`);
       await reloadTemplatesAndSelect(created.id);
@@ -152,7 +159,7 @@ export function LoopFormModal({
     } finally {
       setCreatingTemplateSaving(false);
     }
-  }, [newTemplateForm, message, reloadTemplatesAndSelect]);
+  }, [newTemplateForm, workspaceValue, message, reloadTemplatesAndSelect]);
 
   // 保存（创建 / 编辑共用）
   const handleSave = useCallback(async () => {
@@ -244,22 +251,60 @@ export function LoopFormModal({
           <Form.Item label="描述" name="description">
             <Input.TextArea rows={2} maxLength={500} />
           </Form.Item>
-          {/* 工作空间：创建模式必填，编辑模式可选 */}
-          <Form.Item
-            label={<>工作空间 {mode === 'create' && <span style={{ color: '#ff4d4f' }}>*</span>}</>
-          }
-            tooltip="此 loop 所属的工作空间"
-            rules={mode === 'create' ? [{ required: true, message: '请选择工作空间' }] : []}
-          >
-            <WorkspaceSelect
-              value={workspaceValue}
-              onChange={(v) => {
-                setWorkspaceValue(v);
-                form.setFieldsValue({ workspace: v });
-              }}
-              required={mode === 'create'}
-            />
-          </Form.Item>
+
+          {/* 工作空间 + 评审模板联动区 */}
+          <div style={{ fontWeight: 600, fontSize: 14, marginTop: 16, marginBottom: 8, color: 'var(--color-text-secondary, #64748b)' }}>
+            工作空间与评审模板
+          </div>
+          <div style={{ background: 'var(--color-bg-elevated, #f8fafc)', padding: 12, borderRadius: 8 }}>
+            {/* 工作空间：创建模式必填，编辑模式可选 */}
+            <Form.Item
+              label={<>工作空间 {mode === 'create' && <span style={{ color: '#ff4d4f' }}>*</span>}</>
+            }
+              tooltip="此 loop 所属的工作空间，切换后评审模板自动过滤"
+              rules={mode === 'create' ? [{ required: true, message: '请选择工作空间' }] : []}
+            >
+              <WorkspaceSelect
+                value={workspaceValue}
+                onChange={(v) => {
+                  setWorkspaceValue(v);
+                  form.setFieldsValue({ workspace: v, review_template_id: null });
+                }}
+                required={mode === 'create'}
+              />
+            </Form.Item>
+            {/* 评审模板（随 workspace 联动过滤） */}
+            <Form.Item
+              label="评审模板"
+              name="review_template_id"
+              tooltip="选择用于自动评审的模板（不选则使用默认模板）。切换工作空间后自动过滤。"
+              extra={
+                <Button
+                  type="link"
+                  size="small"
+                  icon={<PlusOutlined />}
+                  style={{ padding: 0, marginTop: 4 }}
+                  onClick={() => setCreatingTemplate(true)}
+                >
+                  新建模板
+                </Button>
+              }
+            >
+              <Select
+                allowClear
+                placeholder="使用默认评审模板"
+                showSearch
+                optionFilterProp="label"
+                options={
+                  workspaceValue
+                    ? reviewTemplateOptions.map(t => ({ value: t.id, label: t.name }))
+                    : reviewTemplateOptions.map(t => ({ value: t.id, label: t.name }))
+                }
+                notFoundContent={workspaceValue ? '暂无模板，可点击"新建模板"' : '请先选择工作空间'}
+              />
+            </Form.Item>
+          </div>
+
           <Form.Item label="Webhook" name="webhook_enabled" valuePropName="checked" tooltip="启用后可通过固定 URL 触发该 Loop 执行">
             <Switch />
           </Form.Item>
@@ -275,31 +320,7 @@ export function LoopFormModal({
           <Form.Item label="图标" name="icon" tooltip="预留字段, 当前仅展示">
             <Input placeholder="loop" maxLength={50} />
           </Form.Item>
-          {/* 评审模板 */}
-          <Form.Item
-            label="评审模板"
-            name="review_template_id"
-            tooltip="选择用于自动评审的模板（来自设置 → 评审模板管理）。不选则使用默认模板。"
-            extra={
-              <Button
-                type="link"
-                size="small"
-                icon={<PlusOutlined />}
-                style={{ padding: 0, marginTop: 4 }}
-                onClick={() => setCreatingTemplate(true)}
-              >
-                新建模板
-              </Button>
-            }
-          >
-            <Select
-              allowClear
-              placeholder="使用默认评审模板"
-              showSearch
-              optionFilterProp="label"
-              options={reviewTemplateOptions.map(t => ({ value: t.id, label: t.name }))}
-            />
-          </Form.Item>
+
           {/* 全局限制 */}
           <div style={{ fontWeight: 600, fontSize: 14, marginTop: 16, marginBottom: 12, color: 'var(--color-text-secondary, #64748b)' }}>
             全局限制
@@ -379,6 +400,11 @@ export function LoopFormModal({
           >
             <Input.TextArea rows={8} placeholder="你是一个评审师…" />
           </Form.Item>
+          <div style={{ fontSize: 12, color: 'var(--color-text-tertiary, #94a3b8)', marginTop: -8 }}>
+            {workspaceValue
+              ? `新建模板将归属于当前工作空间「${workspaceValue}」`
+              : '不选择工作空间则新建全局模板'}
+          </div>
         </Form>
       </Modal>
     </>

--- a/frontend/src/components/LoopFormModal.tsx
+++ b/frontend/src/components/LoopFormModal.tsx
@@ -15,6 +15,7 @@ import { PlusOutlined } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
 import * as dbReviewTemplates from '@/utils/database/reviewTemplates';
 import * as dbTodos from '@/utils/database/todos';
+import { getProjectDirectories } from '@/utils/database/todos';
 import type { UpdateLoopRequest } from '@/types/loop';
 import type { ReviewTemplateOption } from '@/types/reviewTemplate';
 import type { Todo } from '@/types/todo';
@@ -77,14 +78,31 @@ export function LoopFormModal({
   const [newTemplateForm] = Form.useForm<{ name: string; description?: string; prompt: string }>();
   // 异常处理 Todo
   const [abnormalHandlerTodoOptions, setAbnormalHandlerTodoOptions] = useState<Todo[]>([]);
+  // 工作空间路径→ID 映射（用于评审模板 API，其过滤/新建需 workspace_id 而非路径字符串）
+  const [pathToWorkspaceId, setPathToWorkspaceId] = useState<Record<string, number>>({});
 
-  // 打开时 + workspace 变化时重新加载评审模板选项（按 workspace 过滤）
+  // 打开时加载工作空间目录列表（建立路径→ID 映射）
   useEffect(() => {
     if (!open) return;
-    dbReviewTemplates.listReviewTemplateOptions(workspaceValue ?? undefined)
+    getProjectDirectories().then((dirs) => {
+      const map: Record<string, number> = {};
+      for (const d of dirs) {
+        if (d.path) map[d.path] = d.id;
+      }
+      setPathToWorkspaceId(map);
+    }).catch(() => { /* 静默 */ });
+  }, [open]);
+
+  /** 根据当前 workspaceValue（路径）推导对应的 workspace_id，用于评审模板 API */
+  const workspaceIdForReview: number | undefined = workspaceValue ? pathToWorkspaceId[workspaceValue] : undefined;
+
+  // 打开时 + workspace 变化时重新加载评审模板选项（按 workspace_id 过滤）
+  useEffect(() => {
+    if (!open) return;
+    dbReviewTemplates.listReviewTemplateOptions(workspaceIdForReview)
       .then(setReviewTemplateOptions)
       .catch(() => { /* 静默 */ });
-  }, [open, workspaceValue]);
+  }, [open, workspaceIdForReview]);
 
   // 打开时加载异常处理 Todo 选项
   useEffect(() => {
@@ -132,12 +150,12 @@ export function LoopFormModal({
     }
   }, [open, mode, initialData, form]);
 
-  // 刷新评审模板（按当前 workspace 过滤）并选中新建的模板
+  // 刷新评审模板（按当前 workspace_id 过滤）并选中新建的模板
   const reloadTemplatesAndSelect = useCallback(async (selectedId: number) => {
-    const opts = await dbReviewTemplates.listReviewTemplateOptions(workspaceValue ?? undefined);
+    const opts = await dbReviewTemplates.listReviewTemplateOptions(workspaceIdForReview);
     setReviewTemplateOptions(opts);
     form.setFieldsValue({ review_template_id: selectedId });
-  }, [form, workspaceValue]);
+  }, [form, workspaceIdForReview]);
 
   // inline 创建评审模板（归属当前选中的工作空间）
   const handleCreateTemplate = useCallback(async () => {
@@ -148,7 +166,7 @@ export function LoopFormModal({
         name: values.name.trim(),
         description: values.description?.trim() || null,
         prompt: values.prompt,
-        workspace: workspaceValue ?? null,
+        workspace_id: workspaceIdForReview ?? null,
       });
       message.success(`已创建模板「${created.name}」`);
       await reloadTemplatesAndSelect(created.id);

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -13,7 +13,6 @@ import {
   FileTextOutlined,
   LeftOutlined,
   CloudOutlined,
-  AuditOutlined,
 } from '@ant-design/icons';
 import { useApp } from '@/hooks/useApp';
 import * as db from '@/utils/database';
@@ -29,7 +28,6 @@ import { RuntimePanel } from './settings/RuntimePanel';
 import { TemplatesPanel } from './settings/TemplatesPanel';
 import { AboutPanel } from './settings/AboutPanel';
 import { CloudSyncPanel } from './settings/CloudSyncPanel';
-import { ReviewTemplatesPanel } from './settings/ReviewTemplatesPanel';
 
 import { DEFAULT_EXECUTION_TIMEOUT_SECS } from '@/constants';
 
@@ -193,11 +191,6 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       key: 'templates',
       label: <span><FileTextOutlined style={{ marginRight: 6 }} />模板管理</span>,
       children: <TemplatesPanel />,
-    },
-    {
-      key: 'reviewTemplates',
-      label: <span><AuditOutlined style={{ marginRight: 6 }} />评审模板</span>,
-      children: <ReviewTemplatesPanel />,
     },
     {
       key: 'backup',

--- a/frontend/src/components/settings/ReviewTemplatesPanel.tsx
+++ b/frontend/src/components/settings/ReviewTemplatesPanel.tsx
@@ -1,4 +1,4 @@
-// 评审模板管理面板（设置 → 评审模板）。
+// 评审模板管理面板。
 //
 // 表格 + 编辑弹窗 + 删除确认。模板独立于 todo, 评审时由 executor/loop_runner
 // 在 review_templates 表里查; 删除模板不级联清 loop 引用 (loops.review_template_id
@@ -9,6 +9,7 @@ import { Table, Button, Space, Modal, Form, Input, Popconfirm, Empty, Select, Ap
 import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import * as dbReviewTemplates from '@/utils/database/reviewTemplates';
 import type { ReviewTemplate } from '@/types/reviewTemplate';
+import { getProjectDirectories } from '@/utils/database/todos';
 
 interface FormValues {
   name: string;
@@ -17,11 +18,11 @@ interface FormValues {
 }
 
 interface ReviewTemplatesPanelProps {
-  /** 可选：在某个工作空间上下文中使用时传入，隐藏过滤框且只显示该工作空间下的模板 */
-  workspace?: string;
+  /** 可选：在工作空间上下文中使用时传入 workspace_id，隐藏过滤框且只显示该工作空间下的模板 */
+  workspaceId?: number;
 }
 
-export function ReviewTemplatesPanel({ workspace }: ReviewTemplatesPanelProps) {
+export function ReviewTemplatesPanel({ workspaceId }: ReviewTemplatesPanelProps) {
   const { message } = AntApp.useApp();
   const [templates, setTemplates] = useState<ReviewTemplate[]>([]);
   const [loading, setLoading] = useState(false);
@@ -29,41 +30,33 @@ export function ReviewTemplatesPanel({ workspace }: ReviewTemplatesPanelProps) {
   const [formOpen, setFormOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [form] = Form.useForm<FormValues>();
-  // 工作空间过滤（仅非 workspace 上下文时展示）
-  const [workspaceFilter, setWorkspaceFilter] = useState<string | undefined>(undefined);
-  const [workspaceOptions, setWorkspaceOptions] = useState<{ label: string; value: string }[]>([]);
+  // 工作空间过滤（仅在非 workspaceId 上下文时展示）
+  const [workspaceIdFilter, setWorkspaceIdFilter] = useState<number | undefined>(undefined);
+  const [workspaceIdOptions, setWorkspaceIdOptions] = useState<{ label: string; value: number }[]>([]);
 
-  /** 实际用于 API 请求的 workspace 参数 */
-  const effectiveWorkspace = workspace ?? workspaceFilter;
+  /** 实际用于 API 请求的 workspace_id 参数 */
+  const effectiveWorkspaceId = workspaceId ?? workspaceIdFilter;
+
+  /** 加载全量工作空间列表作为过滤选项 */
+  const loadWorkspaceOptions = () => {
+    getProjectDirectories()
+      .then((dirs) => {
+        setWorkspaceIdOptions(dirs.map(d => ({ label: d.name ? `${d.name}（${d.path}）` : d.path, value: d.id })));
+      })
+      .catch(() => { /* 静默 */ });
+  };
 
   /** 拉一次列表, 供 mount 与增删改后刷新用。 */
   const reload = () => {
     setLoading(true);
-    dbReviewTemplates.listReviewTemplates(effectiveWorkspace)
-      .then((list) => {
-        setTemplates(list);
-        // 仅在非 workspace 上下文时维护过滤选项
-        if (!workspace) {
-          dbReviewTemplates.listReviewTemplates()
-            .then((all) => {
-              const allWs = Array.from(
-                new Set(all.filter(t => t.workspace).map(t => t.workspace!))
-              );
-              setWorkspaceOptions(allWs.map(w => ({ label: w, value: w })));
-            })
-            .catch(() => {
-              const uniqueWorkspaces = Array.from(
-                new Set(list.filter(t => t.workspace).map(t => t.workspace!))
-              );
-              setWorkspaceOptions(uniqueWorkspaces.map(w => ({ label: w, value: w })));
-            });
-        }
-      })
+    dbReviewTemplates.listReviewTemplates(effectiveWorkspaceId)
+      .then(setTemplates)
       .catch((err) => message.error(`加载失败: ${err?.message || err}`))
       .finally(() => setLoading(false));
   };
 
-  useEffect(reload, [effectiveWorkspace]);
+  useEffect(reload, [effectiveWorkspaceId]);
+  useEffect(() => { if (!workspaceId) loadWorkspaceOptions(); }, [workspaceId]);
 
   /** 打开表单: editing 存在则进入编辑模式, 不存在则新建。 */
   const openForm = (template?: ReviewTemplate) => {
@@ -89,7 +82,6 @@ export function ReviewTemplatesPanel({ workspace }: ReviewTemplatesPanelProps) {
     try {
       values = await form.validateFields();
     } catch {
-      // antd 已在控件上展示错误, 不弹全局
       return;
     }
     setSaving(true);
@@ -103,10 +95,10 @@ export function ReviewTemplatesPanel({ workspace }: ReviewTemplatesPanelProps) {
         await dbReviewTemplates.updateReviewTemplate(editing.id, payload);
         message.success('已更新');
       } else {
-        // 新建时使用当前 workspace 上下文或过滤值作为模板所属 workspace
+        // 新建时绑定当前 workspace_id（工作空间上下文优先，否则用过滤值）
         await dbReviewTemplates.createReviewTemplate({
           ...payload,
-          workspace: effectiveWorkspace ?? null,
+          workspace_id: effectiveWorkspaceId ?? null,
         });
         message.success('已创建');
       }
@@ -141,13 +133,13 @@ export function ReviewTemplatesPanel({ workspace }: ReviewTemplatesPanelProps) {
           新建模板
         </Button>
         <Button onClick={reload}>刷新</Button>
-        {!workspace && (
+        {workspaceId === undefined && (
           <Select
             allowClear
             placeholder="按工作空间过滤"
-            value={workspaceFilter}
-            onChange={(v) => setWorkspaceFilter(v ?? undefined)}
-            options={workspaceOptions}
+            value={workspaceIdFilter}
+            onChange={(v) => setWorkspaceIdFilter(v ?? undefined)}
+            options={workspaceIdOptions}
             showSearch
             style={{ minWidth: 200 }}
             optionFilterProp="label"
@@ -175,11 +167,15 @@ export function ReviewTemplatesPanel({ workspace }: ReviewTemplatesPanelProps) {
             render: (text: string | null) => text || <span style={{ color: 'var(--color-text-tertiary)' }}>—</span>,
           },
           {
-            title: '工作空间',
-            dataIndex: 'workspace',
+            title: '所属工作空间',
+            dataIndex: 'workspace_id',
             width: 180,
             ellipsis: true,
-            render: (text: string | null) => text || <span style={{ color: 'var(--color-text-tertiary)' }}>全局</span>,
+            render: (id: number | null) => {
+              if (id == null) return <span style={{ color: 'var(--color-text-tertiary)' }}>全局</span>;
+              const match = workspaceIdOptions.find(o => o.value === id);
+              return match ? match.label : `#${id}`;
+            },
           },
           {
             title: 'Prompt 预览',

--- a/frontend/src/components/settings/ReviewTemplatesPanel.tsx
+++ b/frontend/src/components/settings/ReviewTemplatesPanel.tsx
@@ -5,7 +5,7 @@
 // 业务层决定是否置 NULL)。
 
 import { useState, useEffect } from 'react';
-import { Table, Button, Space, Modal, Form, Input, Popconfirm, Empty, App as AntApp } from 'antd';
+import { Table, Button, Space, Modal, Form, Input, Popconfirm, Empty, Select, App as AntApp } from 'antd';
 import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import * as dbReviewTemplates from '@/utils/database/reviewTemplates';
 import type { ReviewTemplate } from '@/types/reviewTemplate';
@@ -16,7 +16,12 @@ interface FormValues {
   prompt: string;
 }
 
-export function ReviewTemplatesPanel() {
+interface ReviewTemplatesPanelProps {
+  /** 可选：在某个工作空间上下文中使用时传入，隐藏过滤框且只显示该工作空间下的模板 */
+  workspace?: string;
+}
+
+export function ReviewTemplatesPanel({ workspace }: ReviewTemplatesPanelProps) {
   const { message } = AntApp.useApp();
   const [templates, setTemplates] = useState<ReviewTemplate[]>([]);
   const [loading, setLoading] = useState(false);
@@ -24,17 +29,41 @@ export function ReviewTemplatesPanel() {
   const [formOpen, setFormOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [form] = Form.useForm<FormValues>();
+  // 工作空间过滤（仅非 workspace 上下文时展示）
+  const [workspaceFilter, setWorkspaceFilter] = useState<string | undefined>(undefined);
+  const [workspaceOptions, setWorkspaceOptions] = useState<{ label: string; value: string }[]>([]);
+
+  /** 实际用于 API 请求的 workspace 参数 */
+  const effectiveWorkspace = workspace ?? workspaceFilter;
 
   /** 拉一次列表, 供 mount 与增删改后刷新用。 */
   const reload = () => {
     setLoading(true);
-    dbReviewTemplates.listReviewTemplates()
-      .then(setTemplates)
+    dbReviewTemplates.listReviewTemplates(effectiveWorkspace)
+      .then((list) => {
+        setTemplates(list);
+        // 仅在非 workspace 上下文时维护过滤选项
+        if (!workspace) {
+          dbReviewTemplates.listReviewTemplates()
+            .then((all) => {
+              const allWs = Array.from(
+                new Set(all.filter(t => t.workspace).map(t => t.workspace!))
+              );
+              setWorkspaceOptions(allWs.map(w => ({ label: w, value: w })));
+            })
+            .catch(() => {
+              const uniqueWorkspaces = Array.from(
+                new Set(list.filter(t => t.workspace).map(t => t.workspace!))
+              );
+              setWorkspaceOptions(uniqueWorkspaces.map(w => ({ label: w, value: w })));
+            });
+        }
+      })
       .catch((err) => message.error(`加载失败: ${err?.message || err}`))
       .finally(() => setLoading(false));
   };
 
-  useEffect(reload, []);
+  useEffect(reload, [effectiveWorkspace]);
 
   /** 打开表单: editing 存在则进入编辑模式, 不存在则新建。 */
   const openForm = (template?: ReviewTemplate) => {
@@ -74,7 +103,11 @@ export function ReviewTemplatesPanel() {
         await dbReviewTemplates.updateReviewTemplate(editing.id, payload);
         message.success('已更新');
       } else {
-        await dbReviewTemplates.createReviewTemplate(payload);
+        // 新建时使用当前 workspace 上下文或过滤值作为模板所属 workspace
+        await dbReviewTemplates.createReviewTemplate({
+          ...payload,
+          workspace: effectiveWorkspace ?? null,
+        });
         message.success('已创建');
       }
       closeForm();
@@ -103,11 +136,23 @@ export function ReviewTemplatesPanel() {
 
   return (
     <div style={{ maxWidth: 1000 }}>
-      <Space style={{ marginBottom: 16 }}>
+      <Space style={{ marginBottom: 16 }} wrap>
         <Button type="primary" icon={<PlusOutlined />} onClick={() => openForm()}>
           新建模板
         </Button>
         <Button onClick={reload}>刷新</Button>
+        {!workspace && (
+          <Select
+            allowClear
+            placeholder="按工作空间过滤"
+            value={workspaceFilter}
+            onChange={(v) => setWorkspaceFilter(v ?? undefined)}
+            options={workspaceOptions}
+            showSearch
+            style={{ minWidth: 200 }}
+            optionFilterProp="label"
+          />
+        )}
       </Space>
 
       <Table<ReviewTemplate>
@@ -128,6 +173,13 @@ export function ReviewTemplatesPanel() {
             dataIndex: 'description',
             ellipsis: true,
             render: (text: string | null) => text || <span style={{ color: 'var(--color-text-tertiary)' }}>—</span>,
+          },
+          {
+            title: '工作空间',
+            dataIndex: 'workspace',
+            width: 180,
+            ellipsis: true,
+            render: (text: string | null) => text || <span style={{ color: 'var(--color-text-tertiary)' }}>全局</span>,
           },
           {
             title: 'Prompt 预览',

--- a/frontend/src/components/settings/workspace/WorkspaceDetailPage.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceDetailPage.tsx
@@ -78,7 +78,7 @@ export function WorkspaceDetailPage({ workspace, onBack }: WorkspaceDetailPagePr
                 </div>
               </>
             )}
-            {activeTab === 'loop-settings' && <ReviewTemplatesPanel workspace={workspace.path} />}
+            {activeTab === 'loop-settings' && <ReviewTemplatesPanel workspaceId={workspace.id} />}
           </div>
         </div>
       ) : (
@@ -114,7 +114,7 @@ export function WorkspaceDetailPage({ workspace, onBack }: WorkspaceDetailPagePr
                   <SettingOutlined /> Loop设置
                 </span>
               ),
-              children: <ReviewTemplatesPanel workspace={workspace.path} />,
+              children: <ReviewTemplatesPanel workspaceId={workspace.id} />,
             },
           ]}
         />

--- a/frontend/src/components/settings/workspace/WorkspaceDetailPage.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceDetailPage.tsx
@@ -78,7 +78,7 @@ export function WorkspaceDetailPage({ workspace, onBack }: WorkspaceDetailPagePr
                 </div>
               </>
             )}
-            {activeTab === 'loop-settings' && <ReviewTemplatesPanel />}
+            {activeTab === 'loop-settings' && <ReviewTemplatesPanel workspace={workspace.path} />}
           </div>
         </div>
       ) : (
@@ -114,7 +114,7 @@ export function WorkspaceDetailPage({ workspace, onBack }: WorkspaceDetailPagePr
                   <SettingOutlined /> Loop设置
                 </span>
               ),
-              children: <ReviewTemplatesPanel />,
+              children: <ReviewTemplatesPanel workspace={workspace.path} />,
             },
           ]}
         />

--- a/frontend/src/types/reviewTemplate.ts
+++ b/frontend/src/types/reviewTemplate.ts
@@ -13,6 +13,8 @@ export interface ReviewTemplate {
   name: string;
   description: string | null;
   prompt: string;
+  /** 所属工作空间（目录路径）。null=全局模板。 */
+  workspace: string | null;
   created_at: string | null;
   updated_at: string | null;
 }
@@ -22,6 +24,8 @@ export interface ReviewTemplateOption {
   id: number;
   name: string;
   description: string | null;
+  /** 所属工作空间（目录路径）。null=全局模板。 */
+  workspace: string | null;
 }
 
 /** 创建评审模板请求体。 */
@@ -29,6 +33,8 @@ export interface CreateReviewTemplateRequest {
   name: string;
   description?: string | null;
   prompt: string;
+  /** 所属工作空间（目录路径）。不传=全局模板。 */
+  workspace?: string | null;
 }
 
 /** 全量更新评审模板请求体（PUT 语义）。 */

--- a/frontend/src/types/reviewTemplate.ts
+++ b/frontend/src/types/reviewTemplate.ts
@@ -13,8 +13,8 @@ export interface ReviewTemplate {
   name: string;
   description: string | null;
   prompt: string;
-  /** 所属工作空间（目录路径）。null=全局模板。 */
-  workspace: string | null;
+  /** 所属工作空间 ID（project_directories.id）。null=全局模板。 */
+  workspace_id: number | null;
   created_at: string | null;
   updated_at: string | null;
 }
@@ -24,8 +24,8 @@ export interface ReviewTemplateOption {
   id: number;
   name: string;
   description: string | null;
-  /** 所属工作空间（目录路径）。null=全局模板。 */
-  workspace: string | null;
+  /** 所属工作空间 ID（project_directories.id）。null=全局模板。 */
+  workspace_id: number | null;
 }
 
 /** 创建评审模板请求体。 */
@@ -33,8 +33,8 @@ export interface CreateReviewTemplateRequest {
   name: string;
   description?: string | null;
   prompt: string;
-  /** 所属工作空间（目录路径）。不传=全局模板。 */
-  workspace?: string | null;
+  /** 所属工作空间 ID（project_directories.id）。不传=全局模板。 */
+  workspace_id?: number | null;
 }
 
 /** 全量更新评审模板请求体（PUT 语义）。 */

--- a/frontend/src/utils/database/reviewTemplates.ts
+++ b/frontend/src/utils/database/reviewTemplates.ts
@@ -16,15 +16,15 @@ import type {
   UpdateReviewTemplateRequest,
 } from '@/types/reviewTemplate';
 
-/** 列出全部评审模板（含 prompt）。管理面板用。可选按 workspace 过滤。 */
-export async function listReviewTemplates(workspace?: string): Promise<ReviewTemplate[]> {
-  const params = workspace ? { workspace } : undefined;
+/** 列出全部评审模板（含 prompt）。管理面板用。可选按 workspace_id 过滤。 */
+export async function listReviewTemplates(workspaceId?: number): Promise<ReviewTemplate[]> {
+  const params = workspaceId !== undefined ? { workspace_id: workspaceId } : undefined;
   return unwrap(await api.get('/api/review-templates', { params }));
 }
 
-/** 列出评审模板的轻量选项（不含 prompt）。loop 编辑器选择器用。可选按 workspace 过滤。 */
-export async function listReviewTemplateOptions(workspace?: string): Promise<ReviewTemplateOption[]> {
-  const params = workspace ? { workspace } : undefined;
+/** 列出评审模板的轻量选项（不含 prompt）。loop 编辑器选择器用。可选按 workspace_id 过滤。 */
+export async function listReviewTemplateOptions(workspaceId?: number): Promise<ReviewTemplateOption[]> {
+  const params = workspaceId !== undefined ? { workspace_id: workspaceId } : undefined;
   return unwrap(await api.get('/api/review-templates/options', { params }));
 }
 

--- a/frontend/src/utils/database/reviewTemplates.ts
+++ b/frontend/src/utils/database/reviewTemplates.ts
@@ -16,14 +16,16 @@ import type {
   UpdateReviewTemplateRequest,
 } from '@/types/reviewTemplate';
 
-/** 列出全部评审模板（含 prompt）。管理面板用。 */
-export async function listReviewTemplates(): Promise<ReviewTemplate[]> {
-  return unwrap(await api.get('/api/review-templates'));
+/** 列出全部评审模板（含 prompt）。管理面板用。可选按 workspace 过滤。 */
+export async function listReviewTemplates(workspace?: string): Promise<ReviewTemplate[]> {
+  const params = workspace ? { workspace } : undefined;
+  return unwrap(await api.get('/api/review-templates', { params }));
 }
 
-/** 列出评审模板的轻量选项（不含 prompt）。loop 编辑器选择器用。 */
-export async function listReviewTemplateOptions(): Promise<ReviewTemplateOption[]> {
-  return unwrap(await api.get('/api/review-templates/options'));
+/** 列出评审模板的轻量选项（不含 prompt）。loop 编辑器选择器用。可选按 workspace 过滤。 */
+export async function listReviewTemplateOptions(workspace?: string): Promise<ReviewTemplateOption[]> {
+  const params = workspace ? { workspace } : undefined;
+  return unwrap(await api.get('/api/review-templates/options', { params }));
 }
 
 /** 取单条模板。 */


### PR DESCRIPTION

## 变更内容

1. **移除** 设置页「评审模板」tab 入口（已迁至工作空间下）
2. **后端隔离** — review_templates 表新增 workspace_id 列（V32/V33 迁移），列表/选项 API 支持 ?workspace_id= 过滤
3. **前端联动** — ReviewTemplatesPanel 在工作空间上下文中隐藏过滤框且只显示该工作空间下的模板
4. **Loop 编辑器** — 工作空间与评审模板联动过滤，布局合并为「工作空间与评审模板」分组卡片
5. **命名精确** — 全量统一为 workspace_id（整数 PK），消除 workspace 歧义
