### PR TITLE
refactor(routing): 统一 URL 路由体系，view 覆盖所有导航入口

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1,0 +1,557 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Nothing Todo — 技术架构</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&family=Inter:wght@400;600;700;900&display=swap" rel="stylesheet">
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0a0e1a;--bg2:#111827;--bg3:#1a2035;--card:#151d30;
+  --border:#1e2a45;--text:#c8d6e5;--text2:#8899aa;--accent:#6c5ce7;
+  --accent2:#a29bfe;--green:#00cec9;--orange:#fdcb6e;--red:#ff7675;
+  --blue:#74b9ff;--pink:#fd79a8;--cyan:#81ecec;
+  --mono:'JetBrains Mono',monospace;--sans:'Inter',system-ui,sans-serif;
+}
+html{scroll-behavior:smooth;font-size:15px}
+body{background:var(--bg);color:var(--text);font-family:var(--sans);line-height:1.7;min-height:100vh}
+body::before{content:'';position:fixed;inset:0;z-index:-1;
+  background:radial-gradient(ellipse at 20% 50%,rgba(108,92,231,.08) 0%,transparent 50%),
+             radial-gradient(ellipse at 80% 20%,rgba(0,206,201,.06) 0%,transparent 50%),
+             radial-gradient(ellipse at 50% 90%,rgba(253,203,110,.04) 0%,transparent 50%)}
+body::after{content:'';position:fixed;inset:0;z-index:-1;opacity:.03;
+  background-image:linear-gradient(var(--accent) 1px,transparent 1px),linear-gradient(90deg,var(--accent) 1px,transparent 1px);
+  background-size:60px 60px}
+nav{position:fixed;top:0;left:0;right:0;z-index:100;
+  background:rgba(10,14,26,.85);backdrop-filter:blur(16px);border-bottom:1px solid var(--border);padding:0 2rem;height:56px;display:flex;align-items:center;justify-content:space-between}
+nav .logo{font-weight:900;font-size:1.1rem;color:var(--accent2);letter-spacing:-.5px}
+nav .logo span{color:var(--green)}
+nav ul{list-style:none;display:flex;gap:1.5rem;flex-wrap:wrap}
+nav a{color:var(--text2);text-decoration:none;font-size:.82rem;font-weight:600;transition:.2s}
+nav a:hover{color:var(--accent2)}
+main{max-width:1200px;margin:0 auto;padding:80px 2rem 4rem}
+section{margin-bottom:4rem;scroll-margin-top:70px}
+h1{font-size:2.8rem;font-weight:900;line-height:1.15;margin-bottom:.5rem;
+  background:linear-gradient(135deg,var(--accent2),var(--green),var(--orange));
+  -webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+h1 .sub{display:block;font-size:.45em;font-weight:600;-webkit-text-fill-color:var(--text2);margin-top:.3rem;letter-spacing:.5px}
+h2{font-size:1.6rem;font-weight:700;margin-bottom:1.2rem;color:#e2e8f0;
+  padding-left:1rem;border-left:4px solid var(--accent)}
+h3{font-size:1.15rem;font-weight:700;margin:1.5rem 0 .6rem;color:var(--accent2)}
+h4{font-size:1rem;font-weight:600;margin:1rem 0 .4rem;color:var(--cyan)}
+p{margin-bottom:.8rem}
+.card-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:1.2rem;margin:1.5rem 0}
+.card{background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.4rem;transition:.3s;position:relative;overflow:hidden}
+.card:hover{border-color:var(--accent);transform:translateY(-3px);box-shadow:0 8px 30px rgba(108,92,231,.15)}
+.card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;
+  background:linear-gradient(90deg,var(--accent),var(--green));opacity:0;transition:.3s}
+.card:hover::before{opacity:1}
+.card h4{margin:0 0 .5rem;color:var(--accent2)}
+.card p,.card li{font-size:.88rem;color:var(--text2)}
+.card ul{list-style:none;padding:0}
+.card li{padding:.2rem 0;padding-left:1.2rem;position:relative}
+.card li::before{content:'›';position:absolute;left:0;color:var(--accent)}
+.badge{display:inline-block;padding:.15rem .6rem;border-radius:20px;font-size:.72rem;font-weight:700;
+  font-family:var(--mono);margin:.15rem}
+.badge-rust{background:rgba(222,190,122,.15);color:#dec07a}
+.badge-react{background:rgba(97,218,251,.12);color:#61dafb}
+.badge-axum{background:rgba(108,92,231,.15);color:var(--accent2)}
+.badge-sqlite{background:rgba(0,206,201,.12);color:var(--green)}
+.badge-vite{background:rgba(253,203,110,.12);color:var(--orange)}
+.badge-antd{background:rgba(255,118,117,.12);color:var(--red)}
+table{width:100%;border-collapse:collapse;margin:1rem 0;font-size:.88rem}
+th{text-align:left;padding:.7rem 1rem;background:var(--bg3);color:var(--accent2);font-weight:700;border-bottom:2px solid var(--accent)}
+td{padding:.6rem 1rem;border-bottom:1px solid var(--border);color:var(--text)}
+tr:hover td{background:rgba(108,92,231,.04)}
+.flow{display:flex;flex-direction:column;align-items:center;gap:.5rem;margin:1.5rem 0}
+.flow-row{display:flex;align-items:center;gap:.8rem;flex-wrap:wrap;justify-content:center}
+.flow-step{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:.7rem 1.2rem;text-align:center;min-width:140px;transition:.3s}
+.flow-step:hover{border-color:var(--green);box-shadow:0 0 20px rgba(0,206,201,.1)}
+.flow-step .step-num{font-family:var(--mono);font-size:.7rem;color:var(--green);font-weight:700;display:block;margin-bottom:.2rem}
+.flow-step .step-label{font-weight:600;font-size:.85rem}
+.flow-arrow{color:var(--accent);font-size:1.2rem;font-weight:900}
+.ascii{background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:1.2rem;
+  font-family:var(--mono);font-size:.72rem;line-height:1.5;overflow-x:auto;color:var(--text2);margin:1rem 0;white-space:pre}
+.pattern{background:var(--card);border-left:3px solid var(--accent);border-radius:0 10px 10px 0;
+  padding:1.2rem 1.5rem;margin:1rem 0}
+.pattern h4{color:var(--orange);margin-top:0}
+.pattern code{background:var(--bg3);padding:.15rem .5rem;border-radius:4px;font-family:var(--mono);font-size:.82rem;color:var(--cyan)}
+.module-list{columns:2;column-gap:2rem}
+.module-list li{break-inside:avoid;margin-bottom:.4rem;font-size:.88rem;color:var(--text2)}
+.module-list li strong{color:var(--accent2)}
+footer{text-align:center;padding:3rem 0 1rem;color:var(--text2);font-size:.78rem;border-top:1px solid var(--border);margin-top:3rem}
+footer a{color:var(--accent2)}
+@media(max-width:768px){
+  h1{font-size:2rem}
+  nav ul{display:none}
+  .module-list{columns:1}
+  .card-grid{grid-template-columns:1fr}
+  .flow-row{flex-direction:column}
+  .flow-arrow{transform:rotate(90deg)}
+}
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="logo">ntd<span>.</span>arch</div>
+  <ul>
+    <li><a href="#stack">技术栈</a></li>
+    <li><a href="#backend">后端</a></li>
+    <li><a href="#frontend">前端</a></li>
+    <li><a href="#dataflow">数据流</a></li>
+    <li><a href="#patterns">设计模式</a></li>
+    <li><a href="#database">数据库</a></li>
+    <li><a href="#build">构建与部署</a></li>
+  </ul>
+</nav>
+
+<main>
+<h1>Nothing Todo 技术架构<span class="sub">全栈 AI 任务自动化平台 · 技术参考文档</span></h1>
+
+<p><strong>Nothing Todo（ntd）</strong> 是一个全栈应用程序，允许用户创建 AI 驱动的待办事项，将其分配给各种代码执行 AI 代理（Claude Code、Codex、Pi 等），并通过 WebSocket 实时监控执行过程。该平台支持定时循环任务、飞书集成和云端同步。</p>
+
+<div style="margin:1rem 0">
+  <span class="badge badge-rust">Rust 1.81+</span>
+  <span class="badge badge-axum">Axum 0.8</span>
+  <span class="badge badge-react">React 19</span>
+  <span class="badge badge-vite">Vite 7</span>
+  <span class="badge badge-antd">Ant Design 6</span>
+  <span class="badge badge-sqlite">SQLite</span>
+  <span class="badge badge-rust">Tokio</span>
+  <span class="badge badge-rust">SeaORM 1</span>
+  <span class="badge badge-react">TypeScript 5.8</span>
+  <span class="badge badge-rust">rustls</span>
+</div>
+
+<!-- ===== TECH STACK OVERVIEW ===== -->
+<section id="stack">
+<h2>📦 技术栈总览</h2>
+<div class="card-grid">
+  <div class="card">
+    <h4>🔧 后端</h4>
+    <ul>
+      <li><strong>Rust 2021</strong>（MSRV 1.81）</li>
+      <li><strong>Axum 0.8</strong> — HTTP/WebSocket 服务器</li>
+      <li><strong>Tokio</strong> — 异步运行时（full features）</li>
+      <li><strong>SeaORM 1</strong> + SQLx 0.7 — ORM 层</li>
+      <li><strong>Rusqlite</strong> — 内置 SQLite 驱动</li>
+      <li><strong>tracing</strong> + tracing-subscriber — 结构化日志</li>
+      <li><strong>clap 4</strong> — CLI 框架</li>
+      <li><strong>command-group 5</strong> — 层级子命令</li>
+      <li><strong>tower-http</strong> — 中间件（CORS、trace、压缩）</li>
+      <li><strong>tokio-cron-scheduler</strong> — 定时调度</li>
+      <li><strong>rust-embed 8</strong> — 嵌入前端资源</li>
+      <li><strong>proptest</strong> — 属性驱动测试</li>
+    </ul>
+  </div>
+  <div class="card">
+    <h4>🎨 前端</h4>
+    <ul>
+      <li><strong>React 19</strong> + TypeScript 5.8</li>
+      <li><strong>Vite 7</strong> — 构建工具（HMR 热更新）</li>
+      <li><strong>Ant Design 6</strong> — UI 组件库</li>
+      <li><strong>@xyflow/react</strong> — 流程图/关系图可视化</li>
+      <li><strong>@uiw/react-md-editor</strong> — Markdown 编辑器</li>
+      <li><strong>dagre</strong> — DAG 布局引擎</li>
+      <li><strong>date-fns 4</strong> — 日期工具库</li>
+      <li><strong>axios</strong> — HTTP 客户端</li>
+      <li><strong>react-countup</strong> — 数字动画</li>
+      <li><strong>react-js-cron</strong> — Cron 表达式构建器</li>
+      <li><strong>Playwright</strong> — E2E 端到端测试</li>
+    </ul>
+  </div>
+  <div class="card">
+    <h4>🤖 AI 执行器</h4>
+    <ul>
+      <li>Claude Code、Codex、CodeBuddy、Opencode</li>
+      <li>AtomCode、Hermes、Kimi、MobileCoder</li>
+      <li>CodeWhale、Pi、Mimo、ZhanLu</li>
+      <li>每种执行器均通过适配器模式 + 事件流接入</li>
+    </ul>
+  </div>
+  <div class="card">
+    <h4>💾 数据层</h4>
+    <ul>
+      <li>SQLite（内置，无需系统依赖）</li>
+      <li>约 35 个实体，覆盖 8 个业务域</li>
+      <li>SeaORM 迁移系统</li>
+      <li>自动备份（数据库、待办、技能、用量统计）</li>
+    </ul>
+  </div>
+</div>
+</section>
+
+<!-- ===== BACKEND ARCHITECTURE ===== -->
+<section id="backend">
+<h2>🏗️ 后端架构</h2>
+
+<h3>五层架构</h3>
+<div class="ascii">┌─────────────────────────────────────────────────────────────┐
+│  CLI 层（clap 4）                                           │
+│  ─────────────────────────────────────────────────────────  │
+│  ntd server | ntd todo | ntd loop | ntd tag | ntd daemon    │
+│  ntd skill install | ntd upgrade | ntd stats | ntd version   │
+└────────────────────────┬────────────────────────────────────┘
+                         │ HTTP / WebSocket / CLI 分发
+┌────────────────────────▼────────────────────────────────────┐
+│  处理器层（Axum 0.8）                                       │
+│  ─────────────────────────────────────────────────────────  │
+│  todo | loop | tag | scheduler | execution | feishu_binding  │
+│  feishu_history | project_directory | review_template         │
+│  custom_template | agent_bot | session | skills | sync       │
+│  usage_stats | config | webhook | backup                     │
+└────────────────────────┬────────────────────────────────────┘
+                         │ ServiceContext（db、registry、tx、tm、cfg）
+┌────────────────────────▼────────────────────────────────────┐
+│  服务层                                                    │
+│  ─────────────────────────────────────────────────────────  │
+│  loop_runner | loop_scheduler | loop_trigger                │
+│  feishu_listener | feishu_push | feishu_history_fetcher     │
+│  auto_review | usage_stats | worktree | message_debounce     │
+└────────────────────────┬────────────────────────────────────┘
+                         │ ExecutorRegistry + TaskManager
+┌────────────────────────▼────────────────────────────────────┐
+│  执行器服务（编排器）                                       │
+│  ─────────────────────────────────────────────────────────  │
+│  stages::prepare_execution_state()                          │
+│  stages::start_todo_and_prepare_spawn()                     │
+│  stages::dispatch_spawned_executor_task()                   │
+│  ├── pre_spawn  （并发门控、执行器选择）                      │
+│  ├── worktree   （git worktree 创建/清理）                    │
+│  ├── log_capture  （stdout/stderr 读取 + LogFlusher）         │
+│  ├── auto_review （独立运行时 + std::thread 执行评审）         │
+│  └── completion （终态处理、钩子、事件广播）                  │
+└────────────────────────┬────────────────────────────────────┘
+                         │ 适配器 trait
+┌────────────────────────▼────────────────────────────────────┐
+│  适配器层（12+ 执行器）                                     │
+│  ─────────────────────────────────────────────────────────  │
+│  ClaudeCodeAdapter | CodexAdapter | CodeBuddyAdapter        │
+│  OpencodeAdapter | AtomCodeAdapter | HermesAdapter          │
+│  KimiAdapter | MobileCoderAdapter | CodeWhaleAdapter        │
+│  PiAdapter | MimoAdapter | ZhanLuAdapter                    │
+│  + *_event 变体（流式事件协议）                              │
+└────────────────────────┬────────────────────────────────────┘
+                         │ 进程启动 + IPC
+┌────────────────────────▼────────────────────────────────────┐
+│  数据库（SQLite / SeaORM）                                  │
+│  ─────────────────────────────────────────────────────────  │
+│  todos | tags | loops | loop_steps | loop_executions        │
+│  execution_records | execution_logs | executors             │
+│  feishu_* | agent_bots | sync_records | usage_stats         │
+│  workspace_settings | review_templates | skills             │
+└─────────────────────────────────────────────────────────────┘</div>
+
+<h3>核心模块（16 个）</h3>
+<ul class="module-list">
+  <li><strong>main.rs</strong> — 程序入口、CLI 解析、服务器启动、升级流程</li>
+  <li><strong>lib.rs</strong> — 模块声明，<code>Assets</code> + <code>NtdSkills</code> 嵌入（rust-embed）</li>
+  <li><strong>service_context.rs</strong> — 共享依赖容器（db、registry、tx、task_mgr、config）</li>
+  <li><strong>config.rs</strong> — YAML 配置（<code>~/.ntd/config.yaml</code>）、校验、默认值、安全限制</li>
+  <li><strong>handlers/</strong> — HTTP 路由处理器（Axum 提取器 + AppState）</li>
+  <li><strong>services/</strong> — 业务逻辑（loop_runner、feishu_listener、message_debounce 等）</li>
+  <li><strong>executor_service/</strong> — 执行编排（pre-spawn → stages → completion）</li>
+  <li><strong>adapters/</strong> — AI 执行器接入（<code>CodeExecutor</code> trait，12+ 适配器）</li>
+  <li><strong>db/</strong> — 数据访问层（实体、迁移、查询构建器、辅助函数）</li>
+  <li><strong>scheduler.rs</strong> — Cron 定时任务调度（<code>tokio-cron-scheduler</code>）</li>
+  <li><strong>task_manager.rs</strong> — 运行中任务注册表 + 取消控制（RAII 守卫）</li>
+  <li><strong>cli/</strong> — CLI 客户端库（供 <code>ntd</code> npm 包消费者调用）</li>
+  <li><strong>daemon/</strong> — 系统服务管理（launchd/systemd/TaskScheduler）</li>
+  <li><strong>feishu/</strong> — 飞书/Lark 集成（SDK、WebSocket、消息编解码）</li>
+  <li><strong>log_flusher.rs</strong> — 异步日志刷盘（定期写入磁盘）</li>
+  <li><strong>sys.rs</strong> — FFI 边界层（<code>SO_REUSEADDR</code>、Unix 专属 libc 调用）</li>
+</ul>
+</section>
+
+<!-- ===== FRONTEND ARCHITECTURE ===== -->
+<section id="frontend">
+<h2>🎨 前端架构</h2>
+
+<h3>技术概览</h3>
+<div class="card-grid">
+  <div class="card">
+    <h4>框架与工具</h4>
+    <p>React 19 + TypeScript 5.8 + Vite 7</p>
+    <p>ESM 模块，路径别名 <code>@</code> → <code>src/</code></p>
+    <p>Rollup manual chunks 分包策略</p>
+    <p>开发代理：<code>/api</code> → <code>localhost:8088</code></p>
+  </div>
+  <div class="card">
+    <h4>UI 组件</h4>
+    <p>Ant Design 6（Table、Drawer、Modal、Tree 等）</p>
+    <p><code>@ant-design/icons</code> 6</p>
+    <p><code>@uiw/react-md-editor</code>（提示词编辑）</p>
+    <p><code>ErrorBoundary</code>（JSX 错误捕获）</p>
+  </div>
+  <div class="card">
+    <h4>可视化</h4>
+    <p><code>@xyflow/react</code> + dagre — Loop Studio 流程图</p>
+    <p>RelationMap — 实体关系图</p>
+    <p>PieChart — 用量统计图表</p>
+    <p>AnimatedNumber / CountUp — 指标动画</p>
+  </div>
+  <div class="card">
+    <h4>状态管理</h4>
+    <p>React Hooks（useState、useReducer、useContext）</p>
+    <p>自定义 Hooks：<code>useApp</code>、<code>useTodoContext</code>、<code>useExecutionEvents</code></p>
+    <p>看板执行缓存（<code>useKanbanExecutionCache</code>）</p>
+  </div>
+  <div class="card">
+    <h4>本地存储</h4>
+    <p>IndexedDB 通过 <code>utils/database/client.ts</code></p>
+    <p>会话持久化、待办缓存、技能同步</p>
+    <p>数据库备份/恢复工具</p>
+  </div>
+  <div class="card">
+    <h4>测试</h4>
+    <p>Playwright E2E 端到端测试</p>
+    <p>组件级快照测试</p>
+    <p>Mock API 响应的集成测试</p>
+  </div>
+</div>
+
+<h3>核心组件树</h3>
+<div class="ascii">App.tsx
+├── Dashboard（统计、图表、紧凑行）
+│   ├── ChartCards / StatsGridCards / DistributionCards
+│   ├── MiniStat / SpecialCards / UsageStatsCard
+│   └── EnhancedCards
+├── KanbanBoard（拖拽待办看板）
+├── RunningBoard（活跃执行概览）
+├── TodoList + TodoCard + TodoDrawer
+│   └── TodoDetail（历史记录、日志、续执行）
+├── LoopStudio
+│   ├── LoopKanban / LoopFormModal
+│   ├── LoopStudioListPanel
+│   ├── LoopStudioStepsPanel
+│   ├── LoopStudioTriggersPanel
+│   ├── LoopStudioExecutionsPanel
+│   ├── LoopStudioDetailPanel
+│   └── LoopFlowGraph（xyflow + dagre）
+├── SessionManager + sessions/*
+├── SkillsPanel + skills/*
+├── SettingsPage
+│   ├── RuntimePanel / ExecutorsPanel
+│   ├── TemplatesPanel / ReviewTemplatesPanel
+│   ├── TagsPanel / MessagesPanel
+│   ├── ProjectDirectoriesPanel
+│   ├── CloudSyncPanel / BackupPanel
+│   ├── AboutPanel / SystemSettingsPanel
+│   └── messages/ 与 backup/ 子标签页
+├── CommandPanel + CommandCard
+├── MemorialBoard
+├── ShareCard
+└── ChatView + ExecutionPanel</div>
+</section>
+
+<!-- ===== DATA FLOW ===== -->
+<section id="dataflow">
+<h2>🔄 数据流</h2>
+
+<h3>待办执行流水线</h3>
+<div class="flow">
+  <div class="flow-row">
+    <div class="flow-step"><span class="step-num">第一步</span><span class="step-label">用户创建待办</span></div>
+    <span class="flow-arrow">→</span>
+    <div class="flow-step"><span class="step-num">第二步</span><span class="step-label">API → 处理器</span></div>
+    <span class="flow-arrow">→</span>
+    <div class="flow-step"><span class="step-num">第三步</span><span class="step-label">定时调度 / 手动触发</span></div>
+  </div>
+  <div class="flow-row">
+    <span class="flow-arrow">↓</span>
+  </div>
+  <div class="flow-row">
+    <div class="flow-step"><span class="step-num">第四步</span><span class="step-label">ExecutorService::run_todo_execution()</span></div>
+    <span class="flow-arrow">→</span>
+    <div class="flow-step"><span class="step-num">第五步</span><span class="step-label">预启动 → Worktree → 进程启动</span></div>
+    <span class="flow-arrow">→</span>
+    <div class="flow-step"><span class="step-num">第六步</span><span class="step-label">日志捕获 + 广播（WebSocket）</span></div>
+  </div>
+  <div class="flow-row">
+    <span class="flow-arrow">↓</span>
+  </div>
+  <div class="flow-row">
+    <div class="flow-step"><span class="step-num">第七步</span><span class="step-label">自动评审（如已启用）</span></div>
+    <span class="flow-arrow">→</span>
+    <div class="flow-step"><span class="step-num">第八步</span><span class="step-label">完成钩子 → 数据库记录</span></div>
+    <span class="flow-arrow">→</span>
+    <div class="flow-step"><span class="step-num">第九步</span><span class="step-label">前端实时更新</span></div>
+  </div>
+</div>
+
+<h3>WebSocket 事件流</h3>
+<div class="ascii">┌──────────┐   broadcast::Sender   ┌──────────────┐
+│ 执行器    │ ───────────────────►  │  TaskManager  │
+│ 适配器    │   ExecEvent           │  + WebSocket   │
+└──────────┘                       └──────┬───────┘
+                                          │
+                                    ┌─────▼─────┐
+                                    │  前端       │
+                                    │  ChatView   │
+                                    │  (SSE/WSS)  │
+                                    └─────────────┘</div>
+
+<h3>Loop Studio 流程</h3>
+<div class="ascii">LoopTrigger（定时/Webhook/手动）
+    │
+    ▼
+LoopScheduler（Cron 循环管理）
+    │
+    ▼
+LoopTriggerDispatcher → LoopRunner
+    │
+    ├──► 加载循环步骤
+    ├──► 执行每个步骤（通过 ExecutorService）
+    ├──► 自动评审步骤结果
+    └──► 持久化 LoopExecutions + LoopStepExecutions</div>
+</section>
+
+<!-- ===== DESIGN PATTERNS ===== -->
+<section id="patterns">
+<h2>🧩 设计模式</h2>
+
+<div class="pattern">
+  <h4>1. 适配器模式 — AI 执行器接入</h4>
+  <p>统一的 <code>CodeExecutor</code> trait 抽象了 12+ 种不同的 AI 编程代理。每种适配器实现相同的接口，无论底层协议是 stdio、事件流还是自定义协议。</p>
+  <p><code>adapters/mod.rs</code> 定义了 <code>EXECUTORS</code> 静态数组，包含 <code>ExecutorDef</code> 元数据。<code>ExecutorRegistry</code> 通过名称/路径动态注册和解析执行器。</p>
+</div>
+
+<div class="pattern">
+  <h4>2. 广播频道 — 实时事件分发</h4>
+  <p><code>tokio::sync::broadcast</code> 容量可配（默认 10,000），将执行事件广播给所有连接的 WebSocket 客户端。环形缓冲区防止突发流量下的消息丢失。</p>
+  <p>通过 <code>config.yaml</code> 配置，带有安全限制：最小 100，软上限 1M，超过 100M 时崩溃拒绝。</p>
+</div>
+
+<div class="pattern">
+  <h4>3. 进程组管理 — 守护进程服务</h4>
+  <p>跨平台守护进程管理：<code>launchd</code>（macOS）、<code>systemd</code>（Linux）、<code>Task Scheduler</code>（Windows）。共享路径解析在 <code>daemon/common.rs</code>，平台特定实现在子模块中。</p>
+  <p>Linux 支持分离式重新部署，实现零停机升级。</p>
+</div>
+
+<div class="pattern">
+  <h4>4. 日志刷写器 — 异步持久化</h4>
+  <p><code>log_flusher.rs</code> 实现定期的异步日志刷盘，将写入 I/O 与热执行路径解耦。使用 <code>quick_cache</code> 进行内存缓冲。</p>
+</div>
+
+<div class="pattern">
+  <h4>5. 服务上下文 — 依赖注入</h4>
+  <p><code>ServiceContext</code> 将 5 个 <code>Arc&lt;T&gt;</code> 依赖聚合为一个可克隆的结构体，贯穿整个应用，减少样板代码并确保一致的依赖共享。</p>
+  <p>字段：<code>db</code>、<code>executor_registry</code>、<code>tx</code>（广播）、<code>task_manager</code>、<code>config</code>（RwLock）。</p>
+</div>
+
+<div class="pattern">
+  <h4>6. 嵌入式资源 — RustEmbed</h4>
+  <p>前端构建产物和 ntd-usage 技能文件通过 <code>rust-embed</code> 编译进二进制文件。实现单二进制分发，无需外部资源依赖。</p>
+  <p><code>Assets</code> 结构体嵌入 <code>../frontend/dist/</code>；<code>NtdSkills</code> 嵌入 <code>../ntd-skills/</code>。</p>
+</div>
+</section>
+
+<!-- ===== DATABASE DESIGN ===== -->
+<section id="database">
+<h2>🗄️ 数据库设计</h2>
+
+<h3>核心实体（约 35 张表，SeaORM 管理）</h3>
+<table>
+<thead><tr><th>业务域</th><th>实体</th><th>用途</th></tr></thead>
+<tbody>
+<tr><td><strong>待办</strong></td><td><code>todos</code>、<code>tags</code>、<code>todo_tags</code>、<code>todo_templates</code></td><td>核心任务项、标签、模板</td></tr>
+<tr><td><strong>执行</strong></td><td><code>execution_records</code>、<code>execution_logs</code>、<code>executors</code></td><td>执行历史、日志行、执行器配置</td></tr>
+<tr><td><strong>Loop Studio</strong></td><td><code>loops</code>、<code>loop_steps</code>、<code>loop_step_executions</code>、<code>loop_executions</code>、<code>loop_triggers</code>、<code>loop_tags</code></td><td>自动化多步 AI 工作流</td></tr>
+<tr><td><strong>飞书</strong></td><td><code>feishu_homes</code>、<code>feishu_messages</code>、<code>feishu_history_chats</code>、<code>feishu_push_targets</code>、<code>feishu_response_config</code>、<code>feishu_project_bindings</code>、<code>feishu_group_whitelist</code></td><td>飞书机器人集成与消息推送</td></tr>
+<tr><td><strong>用量统计</strong></td><td><code>usage_stats</code>、<code>usage_model_breakdown</code>、<code>usage_executor_daily</code></td><td>AI 模型用量分析与计费</td></tr>
+<tr><td><strong>设置</strong></td><td><code>workspace_settings</code>、<code>workspace_slash_commands</code>、<code>agent_bots</code>、<code>project_directories</code>、<code>review_templates</code></td><td>配置、斜杠命令、机器人</td></tr>
+<tr><td><strong>同步</strong></td><td><code>sync_records</code></td><td>云端同步状态跟踪</td></tr>
+<tr><td><strong>技能</strong></td><td><code>skills</code>（处理器级）</td><td>AI 执行器技能定义</td></tr>
+</tbody>
+</table>
+
+<h3>核心关系</h3>
+<div class="ascii">todos ──┬── todo_tags ── tags
+        ├── execution_records（触发）
+        ├── todo_templates（引用）
+        └── loop_step_executions（来源）
+
+executors ──► CodeExecutor 适配器（注册表）
+
+loops ──► loop_steps ──► loop_step_executions
+    ├── loop_triggers（定时触发）
+    └── loop_executions（总体运行）
+
+feishu_messages ──► feishu_history_chats
+    ──► feishu_push_targets（路由）
+    ──► feishu_response_config（自动回复）</div>
+</section>
+
+<!-- ===== BUILD & DEPLOY ===== -->
+<section id="build">
+<h2>🚀 构建与部署</h2>
+
+<div class="card-grid">
+  <div class="card">
+    <h4>开发模式</h4>
+    <p><code>npm run dev</code> — Vite HMR 监听 :5173，代理 /api → localhost:8088</p>
+    <p><code>cargo run</code> — 后端服务器，端口可配（默认 8088）</p>
+    <p><code>NTD_MODE=dev</code> — 加载 <code>config.dev.yaml</code></p>
+  </div>
+  <div class="card">
+    <h4>生产构建</h4>
+    <p><code>npm run build</code> — TypeScript + Vite 压缩打包</p>
+    <p><code>cargo build --release</code> — LTO、单 codegen 单元、剥离符号</p>
+    <p>前端资源通过 rust-embed 嵌入二进制</p>
+  </div>
+  <div class="card">
+    <h4>交叉编译</h4>
+    <p>musl 目标用于 Linux 静态构建</p>
+    <p>平台专属守护进程安装器（launchd/systemd/TaskScheduler）</p>
+    <p>条件编译：<code>#[cfg(unix)]</code>、<code>#[cfg(windows)]</code></p>
+  </div>
+  <div class="card">
+    <h4>NPM 分发</h4>
+    <p>发布为 <code>@weibaohui/nothing-todo</code></p>
+    <p>包含 CLI 二进制 + npm_utils 路径解析</p>
+    <p><code>ntd upgrade</code> — 通过 npm + 守护进程重新部署自我升级</p>
+  </div>
+  <div class="card">
+    <h4>守护进程服务</h4>
+    <p><code>ntd daemon install/start/stop/restart/status/uninstall</code></p>
+    <p>macOS：~/Library/LaunchAgents 中的 launchd plist</p>
+    <p>Linux：systemd 服务单元</p>
+    <p>Windows：任务计划程序注册</p>
+  </div>
+  <div class="card">
+    <h4>自动升级</h4>
+    <p><code>ntd upgrade</code>：npm install → 查找二进制 → daemon stop → uninstall → install --force → start</p>
+    <p>每次服务器启动时运行数据库迁移</p>
+    <p>执行器路径从 config.yaml 迁移至数据库</p>
+  </div>
+</div>
+
+<h3>发布配置与优化</h3>
+<div class="ascii">[profile.release]
+  lto = true              # 链接时优化（显著减小体积并提升性能）
+  codegen-units = 1       # 单一 codegen 单元以获得更好优化
+  strip = true            # 剥离二进制调试符号
+
+[lints.clippy]
+  unwrap_used = "warn"    # 渐进式减少 panic（issue #495）
+  expect_used = "warn"
+  panic = "warn"
+  too_many_arguments = "warn"
+  needless_collect = "warn"
+
+[lints.rust]
+  unsafe_code = "deny"    # 仅 sys.rs 可通过 #![allow(unsafe_code)] 放行</div>
+</section>
+
+<footer>
+  <p>Nothing Todo 技术架构文档 — 生成于 2026-06-26</p>
+  <p>后端：Rust 1.81+ · Axum 0.8 · SeaORM 1 · SQLite &nbsp;|&nbsp; 前端：React 19 · Vite 7 · Ant Design 6</p>
+  <p>12+ AI 执行器适配器 · WebSocket 实时流式传输 · 基于 Cron 的定时调度 · 飞书集成</p>
+</footer>
+
+</main>
+</body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2257,6 +2257,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2266,7 +2267,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4211,11 +4211,34 @@ code {
   width: 100%;
   display: flex;
   justify-content: center;
+  gap: 4px;
   padding-top: 10px;
 }
 
 .ntd-left-rail.expanded .ntd-left-rail-bottom {
   justify-content: flex-end;
+}
+
+/* 亮/暗色主题切换按钮 — 与折叠按钮同款样式，保持底部操作一致性 */
+.ntd-left-rail-theme-toggle {
+  width: 44px !important;
+  height: 44px !important;
+  border-radius: 14px !important;
+  color: var(--color-text-tertiary) !important;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.ntd-left-rail-theme-toggle:hover {
+  background: var(--color-bg-hover) !important;
+  color: var(--color-text) !important;
+}
+
+/* 移动端抽屉底部区域 — 放置主题切换按钮，撑满剩余空间 */
+.ntd-left-rail-drawer-bottom {
+  margin-top: auto;
+  width: 100%;
+  padding: 10px 10px 0;
+  border-top: 1px solid var(--color-border-light);
 }
 
 .ntd-left-rail-toggle {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3984,3 +3984,96 @@ code {
     min-width: 600px;
   }
 }
+
+/* ============================================================
+   Left Rail Shell — 左侧主导航（桌面/移动抽屉）
+   ============================================================ */
+
+.ntd-left-rail {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px 8px;
+  background: color-mix(in srgb, var(--color-bg-elevated) 92%, var(--color-bg) 8%);
+  border-right: 1px solid var(--color-border-light);
+}
+
+.ntd-left-rail-top {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  align-items: center;
+}
+
+.ntd-left-rail-btn {
+  width: 44px !important;
+  height: 44px !important;
+  border-radius: 14px !important;
+  color: var(--color-text-secondary) !important;
+  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
+}
+
+.ntd-left-rail-btn:hover {
+  background: var(--color-bg-hover) !important;
+  color: var(--color-text) !important;
+  transform: translateY(-1px);
+}
+
+.ntd-left-rail-btn.active {
+  background: var(--color-primary-bg) !important;
+  color: var(--color-primary) !important;
+  box-shadow: var(--shadow-sm);
+}
+
+.ntd-left-rail-drawer {
+  width: 100%;
+  height: 100%;
+  padding: 10px 10px;
+  background: var(--color-bg-elevated);
+}
+
+.ntd-left-rail-drawer-top {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ntd-left-rail-drawer-btn {
+  height: 44px !important;
+  border-radius: 14px !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: flex-start !important;
+  padding: 0 12px !important;
+  gap: 10px !important;
+  color: var(--color-text-secondary) !important;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.ntd-left-rail-drawer-btn:hover {
+  background: var(--color-bg-hover) !important;
+  color: var(--color-text) !important;
+}
+
+.ntd-left-rail-drawer-btn.active {
+  background: var(--color-primary-bg) !important;
+  color: var(--color-primary) !important;
+}
+
+.ntd-left-rail-drawer-label {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.ntd-logo-button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.ntd-nav-drawer .ant-drawer-header {
+  display: none;
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4064,7 +4064,50 @@ code {
   border-bottom: 1px solid var(--color-border-light);
 }
 
-.ntd-left-rail-workspace-chip {
+.ntd-workspace-switcher {
+  width: 100% !important;
+  height: 36px !important;
+  border-radius: 12px !important;
+  padding: 0 10px !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: space-between !important;
+  gap: 10px !important;
+  background: var(--color-bg-elevated) !important;
+  border: 1px solid var(--color-border) !important;
+  color: var(--color-text-secondary) !important;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.ntd-workspace-switcher:hover {
+  background: var(--color-bg-hover) !important;
+  border-color: color-mix(in srgb, var(--color-primary) 22%, var(--color-border)) !important;
+}
+
+.ntd-workspace-switcher-left {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.ntd-workspace-switcher-label {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 160px;
+}
+
+.ntd-workspace-switcher-right {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
+.ntd-workspace-switcher-compact {
   width: 44px !important;
   height: 44px !important;
   border-radius: 14px !important;
@@ -4072,7 +4115,7 @@ code {
   transition: background var(--transition-fast), color var(--transition-fast);
 }
 
-.ntd-left-rail-workspace-chip:hover {
+.ntd-workspace-switcher-compact:hover {
   background: var(--color-bg-hover) !important;
   color: var(--color-text) !important;
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3989,6 +3989,11 @@ code {
    Left Rail Shell — 左侧主导航（桌面/移动抽屉）
    ============================================================ */
 
+.ntd-left-rail-slot {
+  flex-shrink: 0;
+  transition: width var(--transition-slow);
+}
+
 .ntd-left-rail {
   height: 100%;
   display: flex;
@@ -3999,12 +4004,21 @@ code {
   border-right: 1px solid var(--color-border-light);
 }
 
+.ntd-left-rail.expanded {
+  align-items: stretch;
+  padding: 10px 10px;
+}
+
 .ntd-left-rail-top {
   display: flex;
   flex-direction: column;
   gap: 6px;
   width: 100%;
   align-items: center;
+}
+
+.ntd-left-rail.expanded .ntd-left-rail-top {
+  align-items: stretch;
 }
 
 .ntd-left-rail-btn {
@@ -4025,6 +4039,59 @@ code {
   background: var(--color-primary-bg) !important;
   color: var(--color-primary) !important;
   box-shadow: var(--shadow-sm);
+}
+
+.ntd-left-rail-expanded-btn {
+  height: 44px !important;
+  border-radius: 14px !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: flex-start !important;
+  padding: 0 12px !important;
+  gap: 10px !important;
+  color: var(--color-text-secondary) !important;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.ntd-left-rail-expanded-btn:hover {
+  background: var(--color-bg-hover) !important;
+  color: var(--color-text) !important;
+}
+
+.ntd-left-rail-expanded-btn.active {
+  background: var(--color-primary-bg) !important;
+  color: var(--color-primary) !important;
+  box-shadow: var(--shadow-sm);
+}
+
+.ntd-left-rail-expanded-label {
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.ntd-left-rail-bottom {
+  margin-top: auto;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding-top: 10px;
+}
+
+.ntd-left-rail.expanded .ntd-left-rail-bottom {
+  justify-content: flex-end;
+}
+
+.ntd-left-rail-toggle {
+  width: 44px !important;
+  height: 44px !important;
+  border-radius: 14px !important;
+  color: var(--color-text-tertiary) !important;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.ntd-left-rail-toggle:hover {
+  background: var(--color-bg-hover) !important;
+  color: var(--color-text) !important;
 }
 
 .ntd-left-rail-drawer {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4021,6 +4021,100 @@ code {
   align-items: stretch;
 }
 
+.ntd-left-rail-workspace {
+  width: 100%;
+  padding: 6px 6px 10px;
+  border-bottom: 1px solid var(--color-border-light);
+  margin-bottom: 8px;
+}
+
+.ntd-left-rail-drawer-workspace {
+  width: 100%;
+  padding: 12px 12px 10px;
+  border-bottom: 1px solid var(--color-border-light);
+  margin-bottom: 8px;
+}
+
+.ntd-left-rail-workspace-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  letter-spacing: 0.02em;
+  margin: 0 0 8px;
+}
+
+.ntd-left-rail-workspace-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.ntd-left-rail-workspace-actions .ant-btn {
+  padding: 0 8px !important;
+  height: 28px !important;
+  border-radius: 10px !important;
+}
+
+.ntd-left-rail-workspace-collapsed {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 2px 0 10px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.ntd-left-rail-workspace-chip {
+  width: 44px !important;
+  height: 44px !important;
+  border-radius: 14px !important;
+  color: var(--color-text-secondary) !important;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.ntd-left-rail-workspace-chip:hover {
+  background: var(--color-bg-hover) !important;
+  color: var(--color-text) !important;
+}
+
+.ntd-left-rail-section {
+  width: 100%;
+}
+
+.ntd-left-rail-section-title {
+  padding: 10px 10px 6px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-tertiary);
+  letter-spacing: 0.06em;
+}
+
+.ntd-left-rail-section-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 6px;
+}
+
+.ntd-left-rail-drawer-section {
+  width: 100%;
+}
+
+.ntd-left-rail-drawer-section-title {
+  padding: 10px 12px 6px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-tertiary);
+  letter-spacing: 0.06em;
+}
+
+.ntd-left-rail-drawer-section-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 10px;
+}
+
 .ntd-left-rail-btn {
   width: 44px !important;
   height: 44px !important;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { ConfigProvider, Layout, App as AntApp, Drawer, message } from 'antd';
 import { PlusOutlined, ThunderboltOutlined, CloseOutlined, LeftOutlined } from '@ant-design/icons';
 import { AppProvider, useApp } from './hooks/useApp';
@@ -52,8 +52,21 @@ function AppContent() {
   // 环路变更计数，驱动左侧 loop 列表刷新
   const [loopUpdateCount, setLoopUpdateCount] = useState(0);
   const [forcedListMode, setForcedListMode] = useState<'item' | 'loop' | undefined>(undefined);
-  const [railFocus, setRailFocus] = useState<LeftRailKey>(() => {
+  const [activeNavKey, setActiveNavKey] = useState<LeftRailKey>(() => {
     try {
+      const params = new URLSearchParams(window.location.search);
+      const view = params.get('view');
+      const tab = params.get('tab');
+      if (view === 'settings' && tab) {
+        if (tab === 'projectDirectories') return 'settings_projectDirectories';
+        if (tab === 'sessions') return 'settings_sessions';
+        if (tab === 'skills') return 'settings_skills';
+        if (tab === 'runtime') return 'settings_runtime';
+        return 'settings';
+      }
+      if (view === 'memorial') return 'memorial';
+      if (view === 'settings') return 'settings';
+      if (view === 'dashboard') return 'dashboard';
       const saved = localStorage.getItem('ntd_list_mode');
       return saved === 'loop' ? 'loops' : 'inbox';
     } catch {
@@ -71,6 +84,20 @@ function AppContent() {
   });
 
   useExecutionEvents();
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const custom = event as CustomEvent<{ tab?: string }>;
+      const tab = custom.detail?.tab;
+      if (tab === 'projectDirectories') setActiveNavKey('settings_projectDirectories');
+      else if (tab === 'sessions') setActiveNavKey('settings_sessions');
+      else if (tab === 'skills') setActiveNavKey('settings_skills');
+      else if (tab === 'runtime') setActiveNavKey('settings_runtime');
+      else setActiveNavKey('settings');
+    };
+    window.addEventListener('settingsTabChanged', handler);
+    return () => window.removeEventListener('settingsTabChanged', handler);
+  }, []);
 
   const hasRunningTasks = Object.keys(state.runningTasks).length > 0;
   const panelHeight = hasRunningTasks ? (panelCollapsed ? EXECUTION_PANEL.collapsed : EXECUTION_PANEL.expanded) : 0;
@@ -150,10 +177,18 @@ function AppContent() {
     setSelectedLoopId(null);
     clearSelection();
     showView(view);
-    setRailFocus(view === 'settings' ? 'settings' : view === 'memorial' ? 'memorial' : 'dashboard');
+    setActiveNavKey(view === 'settings' ? 'settings' : view === 'memorial' ? 'memorial' : 'dashboard');
   }, [clearSelection, showView]);
 
   const handleGoToSettings = () => handleShowView('settings');
+
+  const showSettings = useCallback((tab: string | null, navKey: LeftRailKey) => {
+    setSelectedLoopId(null);
+    dispatch({ type: 'SELECT_TODO', payload: null });
+    clearSelection();
+    setActiveNavKey(navKey);
+    showView('settings', { tab });
+  }, [clearSelection, dispatch, showView]);
 
   /**
    * 切换到“收件箱/环路”这类列表型入口。
@@ -164,7 +199,7 @@ function AppContent() {
     dispatch({ type: 'SELECT_TODO', payload: null });
     clearSelection();
     setForcedListMode(mode);
-    setRailFocus(mode === 'loop' ? 'loops' : 'inbox');
+    setActiveNavKey(mode === 'loop' ? 'loops' : 'inbox');
     backToList();
   }, [backToList, clearSelection, dispatch]);
 
@@ -181,22 +216,34 @@ function AppContent() {
       showListSection('loop');
       return;
     }
-    if (key === 'settings') {
-      handleShowView('settings');
+    if (key === 'dashboard') {
+      setActiveNavKey('dashboard');
+      handleShowView('dashboard');
       return;
     }
     if (key === 'memorial') {
+      setActiveNavKey('memorial');
       handleShowView('memorial');
       return;
     }
-    handleShowView('dashboard');
-  }, [handleShowView, showListSection]);
-
-  const activeRailKey = useMemo<LeftRailKey>(() => {
-    if (activeView === 'settings') return 'settings';
-    if (activeView === 'memorial') return 'memorial';
-    return railFocus;
-  }, [activeView, railFocus]);
+    if (key === 'settings') {
+      showSettings(null, 'settings');
+      return;
+    }
+    if (key === 'settings_projectDirectories') {
+      showSettings('projectDirectories', 'settings_projectDirectories');
+      return;
+    }
+    if (key === 'settings_sessions') {
+      showSettings('sessions', 'settings_sessions');
+      return;
+    }
+    if (key === 'settings_skills') {
+      showSettings('skills', 'settings_skills');
+      return;
+    }
+    showSettings('runtime', 'settings_runtime');
+  }, [handleShowView, showListSection, showSettings]);
 
   // FAB backdrop click to collapse
   const handleFabBackdropClick = () => setFabExpanded(false);
@@ -256,7 +303,7 @@ function AppContent() {
           }}
         >
           <LeftRail
-            activeKey={activeRailKey}
+            activeKey={activeNavKey}
             onSelect={handleRailSelect}
             collapsed={railCollapsed}
             onToggleCollapsed={() => {
@@ -265,6 +312,10 @@ function AppContent() {
               try {
                 localStorage.setItem('ntd_left_rail_collapsed', String(next));
               } catch {}
+            }}
+            workspace={state.selectedWorkspace}
+            onWorkspaceChange={(workspace) => {
+              dispatch({ type: 'SELECT_WORKSPACE', payload: workspace });
             }}
           />
         </div>
@@ -298,7 +349,7 @@ function AppContent() {
               onOpenSmartCreate={() => setSmartCreateOpen(true)}
               onOpenNav={() => setNavDrawerOpen(true)}
               onSelectTodo={(todoId) => {
-                setRailFocus('inbox');
+                setActiveNavKey('inbox');
                 handleSelectTodo(todoId);
               }}
               onShowDashboard={() => handleRailSelect('dashboard')}
@@ -306,7 +357,7 @@ function AppContent() {
               loopUpdateCount={loopUpdateCount}
               onShowSettings={() => handleRailSelect('settings')}
               onSelectLoop={(loopId) => {
-                setRailFocus('loops');
+                setActiveNavKey('loops');
                 handleSelectLoop(loopId);
               }}
               onCreateLoop={() => {
@@ -316,8 +367,8 @@ function AppContent() {
               forcedListMode={forcedListMode}
               onListModeChange={(mode) => {
                 setForcedListMode(undefined);
-                if (railFocus === 'inbox' || railFocus === 'loops') {
-                  setRailFocus(mode === 'loop' ? 'loops' : 'inbox');
+                if (activeNavKey === 'inbox' || activeNavKey === 'loops') {
+                  setActiveNavKey(mode === 'loop' ? 'loops' : 'inbox');
                 }
               }}
             />
@@ -422,7 +473,15 @@ function AppContent() {
         rootClassName="ntd-nav-drawer"
         styles={{ body: { padding: 0 } }}
       >
-        <LeftRail activeKey={activeRailKey} onSelect={handleRailSelect} variant="drawer" />
+        <LeftRail
+          activeKey={activeNavKey}
+          onSelect={handleRailSelect}
+          variant="drawer"
+          workspace={state.selectedWorkspace}
+          onWorkspaceChange={(workspace) => {
+            dispatch({ type: 'SELECT_WORKSPACE', payload: workspace });
+          }}
+        />
       </Drawer>
 
       <TodoDrawer

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
-import { ConfigProvider, Layout, App as AntApp, message } from 'antd';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { ConfigProvider, Layout, App as AntApp, Drawer, message } from 'antd';
 import { PlusOutlined, ThunderboltOutlined, CloseOutlined, LeftOutlined } from '@ant-design/icons';
 import { AppProvider, useApp } from './hooks/useApp';
 import { useIsMobile } from './hooks/useIsMobile';
@@ -16,8 +16,9 @@ import { TodoDrawer } from './components/TodoDrawer';
 import { SmartCreateModal } from './components/SmartCreateModal';
 import { LoopDetailPanel } from './components/LoopStudioDetailPanel';
 import { LoopFormModal } from './components/LoopFormModal';
+import { LeftRail, type LeftRailKey } from './components/shell/LeftRail';
 import * as dbLoops from './utils/database/loops';
-import { EXECUTION_PANEL, SIDEBAR_WIDTH } from './constants';
+import { EXECUTION_PANEL, LEFT_RAIL_WIDTH, SIDEBAR_WIDTH } from './constants';
 import * as db from './utils/database';
 import type { Config } from './types';
 import zhCN from 'antd/locale/zh_CN';
@@ -32,6 +33,7 @@ function AppContent() {
   const [todoModalOpen, setTodoModalOpen] = useState(false);
   const [smartCreateOpen, setSmartCreateOpen] = useState(false);
   const [fabExpanded, setFabExpanded] = useState(false);
+  const [navDrawerOpen, setNavDrawerOpen] = useState(false);
   const [appConfig, setAppConfig] = useState<Config | null>(null);
   // 新建环路弹窗（使用 LoopFormModal create 模式）
   const [loopCreateModalOpen, setLoopCreateModalOpen] = useState(false);
@@ -39,6 +41,15 @@ function AppContent() {
   const [selectedLoopId, setSelectedLoopId] = useState<number | null>(null);
   // 环路变更计数，驱动左侧 loop 列表刷新
   const [loopUpdateCount, setLoopUpdateCount] = useState(0);
+  const [forcedListMode, setForcedListMode] = useState<'item' | 'loop' | undefined>(undefined);
+  const [railFocus, setRailFocus] = useState<LeftRailKey>(() => {
+    try {
+      const saved = localStorage.getItem('ntd_list_mode');
+      return saved === 'loop' ? 'loops' : 'inbox';
+    } catch {
+      return 'inbox';
+    }
+  });
   const isMobile = useIsMobile();
 
   const [panelCollapsed, setPanelCollapsed] = useState(() => {
@@ -129,15 +140,59 @@ function AppContent() {
     setSelectedLoopId(null);
     clearSelection();
     showView(view);
+    setRailFocus(view === 'settings' ? 'settings' : view === 'memorial' ? 'memorial' : 'dashboard');
   }, [clearSelection, showView]);
 
   const handleGoToSettings = () => handleShowView('settings');
+
+  /**
+   * 切换到“收件箱/环路”这类列表型入口。
+   * 目标：在桌面端保持三栏结构（左主导航 + 中间列表 + 右工作区），移动端回到列表面板。
+   */
+  const showListSection = useCallback((mode: 'item' | 'loop') => {
+    setSelectedLoopId(null);
+    dispatch({ type: 'SELECT_TODO', payload: null });
+    clearSelection();
+    setForcedListMode(mode);
+    setRailFocus(mode === 'loop' ? 'loops' : 'inbox');
+    backToList();
+  }, [backToList, clearSelection, dispatch]);
+
+  /**
+   * 左侧主导航点击处理（桌面侧栏/移动抽屉共用）。
+   */
+  const handleRailSelect = useCallback((key: LeftRailKey) => {
+    setNavDrawerOpen(false);
+    if (key === 'inbox') {
+      showListSection('item');
+      return;
+    }
+    if (key === 'loops') {
+      showListSection('loop');
+      return;
+    }
+    if (key === 'settings') {
+      handleShowView('settings');
+      return;
+    }
+    if (key === 'memorial') {
+      handleShowView('memorial');
+      return;
+    }
+    handleShowView('dashboard');
+  }, [handleShowView, showListSection]);
+
+  const activeRailKey = useMemo<LeftRailKey>(() => {
+    if (activeView === 'settings') return 'settings';
+    if (activeView === 'memorial') return 'memorial';
+    return railFocus;
+  }, [activeView, railFocus]);
 
   // FAB backdrop click to collapse
   const handleFabBackdropClick = () => setFabExpanded(false);
 
   return (
-    <Layout style={{ height: '100vh' }}>
+    <Layout style={{ height: '100vh', flexDirection: isMobile ? 'column' : 'row' }}>
       {/* Mobile FAB Group */}
       {isMobile && selectedPanel === 'list' && (
         <>
@@ -182,20 +237,26 @@ function AppContent() {
         </>
       )}
 
+      {!isMobile && (
+        <div style={{ width: LEFT_RAIL_WIDTH, height: `calc(100vh - ${panelHeight}px)` }}>
+          <LeftRail activeKey={activeRailKey} onSelect={handleRailSelect} />
+        </div>
+      )}
+
       <Layout>
         <Content
           style={{
             display: 'flex',
             flexDirection: isMobile ? 'column' : 'row',
-            padding: isMobile ? 0 : 16,
-            paddingBottom: isMobile ? 0 : 16 + panelHeight,
-            gap: isMobile ? 0 : 16,
+            padding: isMobile ? 0 : 12,
+            paddingBottom: isMobile ? 0 : 12 + panelHeight,
+            gap: isMobile ? 0 : 12,
             height: `calc(100vh - ${panelHeight}px)`,
             overflow: 'hidden',
             transition: 'height 0.3s ease, padding-bottom 0.3s ease',
           }}
         >
-          {/* Todo List Panel */}
+          {/* Middle List Panel */}
           <div
             className={(!isMobile || selectedPanel === 'list') ? 'animate-fade-in' : ''}
             style={{
@@ -208,20 +269,34 @@ function AppContent() {
             <TodoList
               onOpenCreateModal={() => setTodoModalOpen(true)}
               onOpenSmartCreate={() => setSmartCreateOpen(true)}
-              onSelectTodo={handleSelectTodo}
-              onShowDashboard={() => handleShowView('dashboard')}
-              onShowMemorial={() => handleShowView('memorial')}
+              onOpenNav={() => setNavDrawerOpen(true)}
+              onSelectTodo={(todoId) => {
+                setRailFocus('inbox');
+                handleSelectTodo(todoId);
+              }}
+              onShowDashboard={() => handleRailSelect('dashboard')}
+              onShowMemorial={() => handleRailSelect('memorial')}
               loopUpdateCount={loopUpdateCount}
-              onShowSettings={() => handleShowView('settings')}
-              onSelectLoop={handleSelectLoop}
+              onShowSettings={() => handleRailSelect('settings')}
+              onSelectLoop={(loopId) => {
+                setRailFocus('loops');
+                handleSelectLoop(loopId);
+              }}
               onCreateLoop={() => {
                 // 打开 LoopFormModal 创建模式，用户填写完整信息后创建环路
                 setLoopCreateModalOpen(true);
               }}
+              forcedListMode={forcedListMode}
+              onListModeChange={(mode) => {
+                setForcedListMode(undefined);
+                if (railFocus === 'inbox' || railFocus === 'loops') {
+                  setRailFocus(mode === 'loop' ? 'loops' : 'inbox');
+                }
+              }}
             />
           </div>
 
-          {/* Detail Panel */}
+          {/* Right Workspace */}
           <div
             className={(!isMobile || selectedPanel === 'detail') ? 'animate-slide-in-right' : ''}
             style={{
@@ -311,6 +386,17 @@ function AppContent() {
           </div>
         </Content>
       </Layout>
+
+      <Drawer
+        open={navDrawerOpen}
+        onClose={() => setNavDrawerOpen(false)}
+        placement="left"
+        width={280}
+        rootClassName="ntd-nav-drawer"
+        styles={{ body: { padding: 0 } }}
+      >
+        <LeftRail activeKey={activeRailKey} onSelect={handleRailSelect} variant="drawer" />
+      </Drawer>
 
       <TodoDrawer
         open={todoModalOpen}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -250,15 +250,27 @@ function AppContent() {
   /**
    * 切换到“事项/环路”这类列表型入口。
    * 目标：在桌面端保持三栏结构（左主导航 + 中间列表 + 右工作区），移动端回到列表面板。
+   * 进入后自动选中第一项，让右侧直接展示详情，避免显示空白仪表盘页。
    */
   const showListSection = useCallback((mode: 'item' | 'loop') => {
+    // 先清除旧选择，再设置新的列表模式
     setSelectedLoopId(null);
     dispatch({ type: 'SELECT_TODO', payload: null });
     clearSelection();
     setForcedListMode(mode);
     setActiveNavKey(mode === 'loop' ? 'loops' : 'items');
     backToList();
-  }, [backToList, clearSelection, dispatch]);
+
+    // 自动选中第一项：事项模式选中第一个 todo，环路模式由 TodoList 加载后自动选中第一项
+    if (mode === 'item') {
+      const todos = state.todos;
+      if (todos.length > 0) {
+        const firstId = todos[0].id;
+        dispatch({ type: 'SELECT_TODO', payload: firstId });
+        selectTodo(firstId);
+      }
+    }
+  }, [backToList, clearSelection, dispatch, state.todos, selectTodo]);
 
   /**
    * 左侧主导航点击处理（桌面侧栏/移动抽屉共用）。

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
-import { ConfigProvider, Layout, App as AntApp, Drawer, message } from 'antd';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { ConfigProvider, Layout, App as AntApp, Drawer, message, Form } from 'antd';
 import { PlusOutlined, ThunderboltOutlined, CloseOutlined, LeftOutlined } from '@ant-design/icons';
 import { AppProvider, useApp } from './hooks/useApp';
 import { useIsMobile } from './hooks/useIsMobile';
@@ -11,6 +11,10 @@ import { TodoDetail } from './components/TodoDetail';
 import { Dashboard } from './components/Dashboard';
 import { MemorialBoard } from './components/MemorialBoard';
 import { SettingsPage } from './components/SettingsPage';
+import { SkillsPanel } from './components/SkillsPanel';
+import { SessionManager } from './components/SessionManager';
+import { ProjectDirectoriesPanel } from './components/settings/ProjectDirectoriesPanel';
+import { RuntimePanel } from './components/settings/RuntimePanel';
 import { ExecutionPanel } from './components/ExecutionPanel';
 import { TodoDrawer } from './components/TodoDrawer';
 import { SmartCreateModal } from './components/SmartCreateModal';
@@ -20,7 +24,7 @@ import { LeftRail, type LeftRailKey } from './components/shell/LeftRail';
 import * as dbLoops from './utils/database/loops';
 import { EXECUTION_PANEL, LEFT_RAIL_WIDTH, SIDEBAR_WIDTH } from './constants';
 import * as db from './utils/database';
-import type { Config } from './types';
+import type { Config, ExecutorConfig } from './types';
 import zhCN from 'antd/locale/zh_CN';
 import './App.css';
 
@@ -108,6 +112,45 @@ function AppContent() {
     db.getConfig().then(setAppConfig).catch(() => {});
   }, []);
 
+  // —— 独立页面：「运行管理」与「设置页」共享的配置表单状态 —
+  // RuntimePanel 从设置标签页剥离成独立页面后，需要自己的 Form 实例 + 配置加载/保存逻辑。
+  const [runtimeConfigForm] = Form.useForm();
+  const [runtimeConfigSaving, setRuntimeConfigSaving] = useState(false);
+  // 执行器列表供 executorDisplayNames 使用
+  const [runtimeExecutors, setRuntimeExecutors] = useState<ExecutorConfig[]>([]);
+
+  useEffect(() => {
+    db.getConfig().then((cfg) => {
+      runtimeConfigForm.setFieldsValue(cfg);
+    }).catch(() => {});
+  }, [runtimeConfigForm]);
+
+  useEffect(() => {
+    db.getExecutors().then(setRuntimeExecutors).catch(() => {});
+  }, []);
+
+  const runtimeExecutorDisplayNames = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const ec of runtimeExecutors) {
+      map[ec.name] = ec.display_name;
+    }
+    return map;
+  }, [runtimeExecutors]);
+
+  const handleRuntimeSaveConfig = useCallback(async () => {
+    try {
+      const values = await runtimeConfigForm.validateFields();
+      setRuntimeConfigSaving(true);
+      await db.updateConfig(values);
+      message.success('配置已保存');
+    } catch (err: any) {
+      if (err?.errorFields) return;
+      message.error('保存失败: ' + (err?.message || String(err)));
+    } finally {
+      setRuntimeConfigSaving(false);
+    }
+  }, [runtimeConfigForm]);
+
   // On initial load, restore todo/loop selection from URL (only when loading finishes)
   useEffect(() => {
     if (state.loading) return;
@@ -192,6 +235,19 @@ function AppContent() {
   }, [clearSelection, dispatch, showView]);
 
   /**
+   * 切换到独立的配置管理页面（运行管理 / Skills / 工作空间 / 会话）。
+   * 这些页面已从设置页标签页中剥离，独立为左侧导航菜单项。
+   */
+  const showStandaloneSettingsPanel = useCallback((navKey: LeftRailKey) => {
+    setSelectedLoopId(null);
+    dispatch({ type: 'SELECT_TODO', payload: null });
+    clearSelection();
+    setActiveNavKey(navKey);
+    // 保持 activeView 不变（应为 'dashboard'），不触发视图切换，
+    // 让右侧面板根据 activeNavKey 渲染对应的独立页面。
+  }, [clearSelection, dispatch]);
+
+  /**
    * 切换到“事项/环路”这类列表型入口。
    * 目标：在桌面端保持三栏结构（左主导航 + 中间列表 + 右工作区），移动端回到列表面板。
    */
@@ -232,19 +288,19 @@ function AppContent() {
       return;
     }
     if (key === 'settings_projectDirectories') {
-      showSettings('projectDirectories', 'settings_projectDirectories');
+      showStandaloneSettingsPanel('settings_projectDirectories');
       return;
     }
     if (key === 'settings_sessions') {
-      showSettings('sessions', 'settings_sessions');
+      showStandaloneSettingsPanel('settings_sessions');
       return;
     }
     if (key === 'settings_skills') {
-      showSettings('skills', 'settings_skills');
+      showStandaloneSettingsPanel('settings_skills');
       return;
     }
-    showSettings('runtime', 'settings_runtime');
-  }, [handleShowView, showListSection, showSettings]);
+    showStandaloneSettingsPanel('settings_runtime');
+  }, [handleShowView, showListSection, showSettings, showStandaloneSettingsPanel]);
 
   // FAB backdrop click to collapse
   const handleFabBackdropClick = () => setFabExpanded(false);
@@ -454,6 +510,28 @@ function AppContent() {
                     setLoopUpdateCount(c => c + 1);
                   }}
                 />
+              </div>
+            ) : activeNavKey === 'settings_runtime' ? (
+              // 运行管理 — 独立页面（非设置内嵌标签页）
+              <div className="detail-panel" style={{ height: '100%', overflowY: 'auto', padding: 16 }}>
+                <RuntimePanel
+                  configForm={runtimeConfigForm}
+                  configSaving={runtimeConfigSaving}
+                  handleSaveConfig={handleRuntimeSaveConfig}
+                  executorDisplayNames={runtimeExecutorDisplayNames}
+                />
+              </div>
+            ) : activeNavKey === 'settings_skills' ? (
+              <div className="detail-panel" style={{ height: '100%', overflowY: 'auto', padding: 16 }}>
+                <SkillsPanel />
+              </div>
+            ) : activeNavKey === 'settings_projectDirectories' ? (
+              <div className="detail-panel" style={{ height: '100%', overflowY: 'auto', padding: 16 }}>
+                <ProjectDirectoriesPanel />
+              </div>
+            ) : activeNavKey === 'settings_sessions' ? (
+              <div className="detail-panel" style={{ height: '100%', overflowY: 'auto', padding: 16 }}>
+                <SessionManager />
               </div>
             ) : activeView === 'settings' ? (
               <SettingsPage onBack={isMobile ? backToList : undefined} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -349,16 +349,11 @@ function AppContent() {
           >
             <TodoList
               onOpenCreateModal={() => setTodoModalOpen(true)}
-              onOpenSmartCreate={() => setSmartCreateOpen(true)}
-              onOpenNav={() => setNavDrawerOpen(true)}
               onSelectTodo={(todoId) => {
                 setActiveNavKey('items');
                 handleSelectTodo(todoId);
               }}
-              onShowDashboard={() => handleRailSelect('dashboard')}
-              onShowMemorial={() => handleRailSelect('memorial')}
               loopUpdateCount={loopUpdateCount}
-              onShowSettings={() => handleRailSelect('settings')}
               onSelectLoop={(loopId) => {
                 setActiveNavKey('loops');
                 handleSelectLoop(loopId);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,16 @@ function AppContent() {
   const [smartCreateOpen, setSmartCreateOpen] = useState(false);
   const [fabExpanded, setFabExpanded] = useState(false);
   const [navDrawerOpen, setNavDrawerOpen] = useState(false);
+  const [railCollapsed, setRailCollapsed] = useState(() => {
+    try {
+      const saved = localStorage.getItem('ntd_left_rail_collapsed');
+      if (saved === 'true') return true;
+      if (saved === 'false') return false;
+      return true;
+    } catch {
+      return true;
+    }
+  });
   const [appConfig, setAppConfig] = useState<Config | null>(null);
   // 新建环路弹窗（使用 LoopFormModal create 模式）
   const [loopCreateModalOpen, setLoopCreateModalOpen] = useState(false);
@@ -238,8 +248,25 @@ function AppContent() {
       )}
 
       {!isMobile && (
-        <div style={{ width: LEFT_RAIL_WIDTH, height: `calc(100vh - ${panelHeight}px)` }}>
-          <LeftRail activeKey={activeRailKey} onSelect={handleRailSelect} />
+        <div
+          className="ntd-left-rail-slot"
+          style={{
+            width: railCollapsed ? LEFT_RAIL_WIDTH.collapsed : LEFT_RAIL_WIDTH.expanded,
+            height: `calc(100vh - ${panelHeight}px)`,
+          }}
+        >
+          <LeftRail
+            activeKey={activeRailKey}
+            onSelect={handleRailSelect}
+            collapsed={railCollapsed}
+            onToggleCollapsed={() => {
+              const next = !railCollapsed;
+              setRailCollapsed(next);
+              try {
+                localStorage.setItem('ntd_left_rail_collapsed', String(next));
+              } catch {}
+            }}
+          />
         </div>
       )}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,9 +68,9 @@ function AppContent() {
       if (view === 'settings') return 'settings';
       if (view === 'dashboard') return 'dashboard';
       const saved = localStorage.getItem('ntd_list_mode');
-      return saved === 'loop' ? 'loops' : 'inbox';
+      return saved === 'loop' ? 'loops' : 'items';
     } catch {
-      return 'inbox';
+      return 'items';
     }
   });
   const isMobile = useIsMobile();
@@ -191,7 +191,7 @@ function AppContent() {
   }, [clearSelection, dispatch, showView]);
 
   /**
-   * 切换到“收件箱/环路”这类列表型入口。
+   * 切换到“事项/环路”这类列表型入口。
    * 目标：在桌面端保持三栏结构（左主导航 + 中间列表 + 右工作区），移动端回到列表面板。
    */
   const showListSection = useCallback((mode: 'item' | 'loop') => {
@@ -199,7 +199,7 @@ function AppContent() {
     dispatch({ type: 'SELECT_TODO', payload: null });
     clearSelection();
     setForcedListMode(mode);
-    setActiveNavKey(mode === 'loop' ? 'loops' : 'inbox');
+    setActiveNavKey(mode === 'loop' ? 'loops' : 'items');
     backToList();
   }, [backToList, clearSelection, dispatch]);
 
@@ -208,7 +208,7 @@ function AppContent() {
    */
   const handleRailSelect = useCallback((key: LeftRailKey) => {
     setNavDrawerOpen(false);
-    if (key === 'inbox') {
+    if (key === 'items') {
       showListSection('item');
       return;
     }
@@ -349,7 +349,7 @@ function AppContent() {
               onOpenSmartCreate={() => setSmartCreateOpen(true)}
               onOpenNav={() => setNavDrawerOpen(true)}
               onSelectTodo={(todoId) => {
-                setActiveNavKey('inbox');
+                setActiveNavKey('items');
                 handleSelectTodo(todoId);
               }}
               onShowDashboard={() => handleRailSelect('dashboard')}
@@ -367,8 +367,8 @@ function AppContent() {
               forcedListMode={forcedListMode}
               onListModeChange={(mode) => {
                 setForcedListMode(undefined);
-                if (activeNavKey === 'inbox' || activeNavKey === 'loops') {
-                  setActiveNavKey(mode === 'loop' ? 'loops' : 'inbox');
+                if (activeNavKey === 'items' || activeNavKey === 'loops') {
+                  setActiveNavKey(mode === 'loop' ? 'loops' : 'items');
                 }
               }}
             />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -381,6 +381,7 @@ function AppContent() {
               onListModeChange={() => {
                 setForcedListMode(undefined);
               }}
+              activeView={activeView}
             />
           </div>
 
@@ -490,6 +491,9 @@ function AppContent() {
               <SettingsPage onBack={isMobile ? backToList : undefined} />
             ) : activeView === 'memorial' ? (
               <MemorialBoard onBack={isMobile ? backToList : undefined} />
+            ) : activeView === 'items' || activeView === 'loops' ? (
+              // 事项/环路视图但未选中具体条目：展示空白区域，绝不回退到 Dashboard
+              <div />
             ) : (
               <Dashboard onBack={isMobile ? backToList : undefined} />
             )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ const { Content } = Layout;
 function AppContent() {
   const { state, dispatch, clearSelection } = useApp();
   const { activeView, selectedPanel, setSelectedPanel, showView, selectTodo, backToList } = useViewState();
+  const { themeMode, toggleTheme } = useTheme();
 
   const [todoModalOpen, setTodoModalOpen] = useState(false);
   const [smartCreateOpen, setSmartCreateOpen] = useState(false);
@@ -317,6 +318,8 @@ function AppContent() {
             onWorkspaceChange={(workspace) => {
               dispatch({ type: 'SELECT_WORKSPACE', payload: workspace });
             }}
+            themeMode={themeMode}
+            toggleTheme={toggleTheme}
           />
         </div>
       )}
@@ -481,6 +484,8 @@ function AppContent() {
           onWorkspaceChange={(workspace) => {
             dispatch({ type: 'SELECT_WORKSPACE', payload: workspace });
           }}
+          themeMode={themeMode}
+          toggleTheme={toggleTheme}
         />
       </Drawer>
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -337,14 +337,17 @@ function AppContent() {
             transition: 'height 0.3s ease, padding-bottom 0.3s ease',
           }}
         >
-          {/* Middle List Panel */}
+          {/* 中间列表面板：仅在「事项」或「环路」导航选中时显示；
+              仪表盘/看板/配置等页面由右侧面板独占，不需要中间列表 */}
           <div
             className={(!isMobile || selectedPanel === 'list') ? 'animate-fade-in' : ''}
             style={{
               width: isMobile ? SIDEBAR_WIDTH.mobile : SIDEBAR_WIDTH.desktop,
               flexShrink: 0,
               height: '100%',
-              display: !isMobile || selectedPanel === 'list' ? 'block' : 'none',
+              display: isMobile
+                ? (selectedPanel === 'list' ? 'block' : 'none')
+                : (activeNavKey === 'items' || activeNavKey === 'loops' ? 'block' : 'none'),
             }}
           >
             <TodoList

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import { PlusOutlined, ThunderboltOutlined, CloseOutlined, LeftOutlined } from '
 import { AppProvider, useApp } from './hooks/useApp';
 import { useIsMobile } from './hooks/useIsMobile';
 import { useExecutionEvents } from './hooks/useExecutionEvents';
-import { useViewState, type View } from './hooks/useViewState';
+import { useViewState, viewToNavKey, type View } from './hooks/useViewState';
 import { ThemeProvider, useTheme } from './hooks/useTheme';
 import { TodoList } from './components/TodoList';
 import { TodoDetail } from './components/TodoDetail';
@@ -32,7 +32,7 @@ const { Content } = Layout;
 
 function AppContent() {
   const { state, dispatch, clearSelection } = useApp();
-  const { activeView, selectedPanel, setSelectedPanel, showView, selectTodo, backToList } = useViewState();
+  const { activeView, selectedId, selectedPanel, showView, backToList, pushUrl } = useViewState();
   const { themeMode, toggleTheme } = useTheme();
 
   const [todoModalOpen, setTodoModalOpen] = useState(false);
@@ -57,27 +57,10 @@ function AppContent() {
   // 环路变更计数，驱动左侧 loop 列表刷新
   const [loopUpdateCount, setLoopUpdateCount] = useState(0);
   const [forcedListMode, setForcedListMode] = useState<'item' | 'loop' | undefined>(undefined);
-  const [activeNavKey, setActiveNavKey] = useState<LeftRailKey>(() => {
-    try {
-      const params = new URLSearchParams(window.location.search);
-      const view = params.get('view');
-      const tab = params.get('tab');
-      if (view === 'settings' && tab) {
-        if (tab === 'projectDirectories') return 'settings_projectDirectories';
-        if (tab === 'sessions') return 'settings_sessions';
-        if (tab === 'skills') return 'settings_skills';
-        if (tab === 'runtime') return 'settings_runtime';
-        return 'settings';
-      }
-      if (view === 'memorial') return 'memorial';
-      if (view === 'settings') return 'settings';
-      if (view === 'dashboard') return 'dashboard';
-      const saved = localStorage.getItem('ntd_list_mode');
-      return saved === 'loop' ? 'loops' : 'items';
-    } catch {
-      return 'items';
-    }
-  });
+  // 从 activeView 派生出 LeftRailKey，去除独立的状态源
+  const navKey = useMemo<LeftRailKey>(() => {
+    return viewToNavKey(activeView) as LeftRailKey;
+  }, [activeView]);
   const isMobile = useIsMobile();
 
   const [panelCollapsed, setPanelCollapsed] = useState(() => {
@@ -90,19 +73,7 @@ function AppContent() {
 
   useExecutionEvents();
 
-  useEffect(() => {
-    const handler = (event: Event) => {
-      const custom = event as CustomEvent<{ tab?: string }>;
-      const tab = custom.detail?.tab;
-      if (tab === 'projectDirectories') setActiveNavKey('settings_projectDirectories');
-      else if (tab === 'sessions') setActiveNavKey('settings_sessions');
-      else if (tab === 'skills') setActiveNavKey('settings_skills');
-      else if (tab === 'runtime') setActiveNavKey('settings_runtime');
-      else setActiveNavKey('settings');
-    };
-    window.addEventListener('settingsTabChanged', handler);
-    return () => window.removeEventListener('settingsTabChanged', handler);
-  }, []);
+  // settingsTabChanged 事件不再需要 — activeView + activeTab 由 useViewState 统一管理
 
   const hasRunningTasks = Object.keys(state.runningTasks).length > 0;
   const panelHeight = hasRunningTasks ? (panelCollapsed ? EXECUTION_PANEL.collapsed : EXECUTION_PANEL.expanded) : 0;
@@ -151,49 +122,45 @@ function AppContent() {
     }
   }, [runtimeConfigForm]);
 
-  // On initial load, restore todo/loop selection from URL (only when loading finishes)
+  // URL → React state 恢复（首次加载完成后执行）
   useEffect(() => {
     if (state.loading) return;
-    const params = new URLSearchParams(window.location.search);
-    const todoId = params.get('todo');
-    const loopId = params.get('loop');
-    if (todoId && state.todos.some(t => String(t.id) === todoId)) {
-      dispatch({ type: 'SELECT_TODO', payload: Number(todoId) });
-      setSelectedPanel('detail');
-    } else if (loopId) {
-      setSelectedLoopId(Number(loopId));
-      setSelectedPanel('detail');
+    if (activeView === 'items' && selectedId != null && state.todos.some(t => t.id === selectedId)) {
+      dispatch({ type: 'SELECT_TODO', payload: selectedId });
+      setSelectedLoopId(null);
+    } else if (activeView === 'loops' && selectedId != null) {
+      setSelectedLoopId(selectedId);
+      dispatch({ type: 'SELECT_TODO', payload: null });
+      clearSelection();
+    } else if (activeView !== 'items' && activeView !== 'loops') {
+      // 非列表视图时清除选择
+      setSelectedLoopId(null);
+      dispatch({ type: 'SELECT_TODO', payload: null });
     }
-  }, [state.loading, state.todos, dispatch, setSelectedPanel]);
+  }, [state.loading, state.todos, dispatch, clearSelection, activeView, selectedId]);
 
-  // Browser back/forward: restore loop selection from URL
+  // popstate 由 useViewState 统一处理；这里监听 view/id 变化来同步 React 状态
   useEffect(() => {
-    const onPopState = () => {
-      const params = new URLSearchParams(window.location.search);
-      const todoId = params.get('todo');
-      const loopId = params.get('loop');
-      if (todoId) {
-        // useViewState handles todo selection; just clear loop
-        setSelectedLoopId(null);
-      } else if (loopId) {
-        setSelectedLoopId(Number(loopId));
-        setSelectedPanel('detail');
-        dispatch({ type: 'SELECT_TODO', payload: null });
-        clearSelection();
-      } else {
-        setSelectedLoopId(null);
+    if (activeView === 'items' && selectedId != null) {
+      setSelectedLoopId(null);
+      if (!state.loading) {
+        dispatch({ type: 'SELECT_TODO', payload: selectedId });
       }
-    };
-    window.addEventListener('popstate', onPopState);
-    return () => window.removeEventListener('popstate', onPopState);
-  }, [dispatch, clearSelection, setSelectedPanel]);
+    } else if (activeView === 'loops' && selectedId != null) {
+      setSelectedLoopId(selectedId);
+      dispatch({ type: 'SELECT_TODO', payload: null });
+      clearSelection();
+    } else {
+      setSelectedLoopId(null);
+    }
+  }, [activeView, selectedId, dispatch, clearSelection, state.loading]);
 
   const handleSelectTodo = (todoId: string | number | null) => {
     if (todoId != null) {
       // 选中 todo 时清除 loop 选择，避免右侧面板显示冲突
       setSelectedLoopId(null);
       dispatch({ type: 'SELECT_TODO', payload: Number(todoId) });
-      selectTodo(Number(todoId));
+      pushUrl('items', { id: Number(todoId) });
     }
   };
 
@@ -203,12 +170,8 @@ function AppContent() {
     dispatch({ type: 'SELECT_TODO', payload: null });
     clearSelection();
     setSelectedLoopId(loopId);
-    setSelectedPanel('detail');
-    // 更新 URL，支持浏览器前进/后退导航
-    const params = new URLSearchParams();
-    params.set('loop', String(loopId));
-    window.history.pushState(null, '', `/?${params.toString()}`);
-  }, [dispatch, clearSelection, setSelectedPanel]);
+    pushUrl('loops', { id: loopId });
+  }, [dispatch, clearSelection, pushUrl]);
 
   const handleSmartCreateSubmitted = () => {
     db.getAllTodos().then(todos => {
@@ -221,16 +184,14 @@ function AppContent() {
     setSelectedLoopId(null);
     clearSelection();
     showView(view);
-    setActiveNavKey(view === 'settings' ? 'settings' : view === 'memorial' ? 'memorial' : 'dashboard');
   }, [clearSelection, showView]);
 
   const handleGoToSettings = () => handleShowView('settings');
 
-  const showSettings = useCallback((tab: string | null, navKey: LeftRailKey) => {
+  const showSettings = useCallback((tab: string | null) => {
     setSelectedLoopId(null);
     dispatch({ type: 'SELECT_TODO', payload: null });
     clearSelection();
-    setActiveNavKey(navKey);
     showView('settings', { tab });
   }, [clearSelection, dispatch, showView]);
 
@@ -238,19 +199,17 @@ function AppContent() {
    * 切换到独立的配置管理页面（运行管理 / Skills / 工作空间 / 会话）。
    * 这些页面已从设置页标签页中剥离，独立为左侧导航菜单项。
    */
-  const showStandaloneSettingsPanel = useCallback((navKey: LeftRailKey) => {
+  const showStandaloneSettingsPanel = useCallback((view: View) => {
     setSelectedLoopId(null);
     dispatch({ type: 'SELECT_TODO', payload: null });
     clearSelection();
-    setActiveNavKey(navKey);
-    // 保持 activeView 不变（应为 'dashboard'），不触发视图切换，
-    // 让右侧面板根据 activeNavKey 渲染对应的独立页面。
-  }, [clearSelection, dispatch]);
+    pushUrl(view);
+  }, [clearSelection, dispatch, pushUrl]);
 
   /**
    * 切换到“事项/环路”这类列表型入口。
    * 目标：在桌面端保持三栏结构（左主导航 + 中间列表 + 右工作区），移动端回到列表面板。
-   * 进入后自动选中第一项，让右侧直接展示详情，避免显示空白仪表盘页。
+   * 进入后自动选中第一项的工作交由 TodoList 统一处理（需等目录加载 → 工作空间确定）。
    */
   const showListSection = useCallback((mode: 'item' | 'loop') => {
     // 先清除旧选择，再设置新的列表模式
@@ -258,19 +217,8 @@ function AppContent() {
     dispatch({ type: 'SELECT_TODO', payload: null });
     clearSelection();
     setForcedListMode(mode);
-    setActiveNavKey(mode === 'loop' ? 'loops' : 'items');
-    backToList();
-
-    // 自动选中第一项：事项模式选中第一个 todo，环路模式由 TodoList 加载后自动选中第一项
-    if (mode === 'item') {
-      const todos = state.todos;
-      if (todos.length > 0) {
-        const firstId = todos[0].id;
-        dispatch({ type: 'SELECT_TODO', payload: firstId });
-        selectTodo(firstId);
-      }
-    }
-  }, [backToList, clearSelection, dispatch, state.todos, selectTodo]);
+    pushUrl(mode === 'loop' ? 'loops' : 'items');
+  }, [pushUrl, clearSelection, dispatch]);
 
   /**
    * 左侧主导航点击处理（桌面侧栏/移动抽屉共用）。
@@ -286,32 +234,30 @@ function AppContent() {
       return;
     }
     if (key === 'dashboard') {
-      setActiveNavKey('dashboard');
       handleShowView('dashboard');
       return;
     }
     if (key === 'memorial') {
-      setActiveNavKey('memorial');
       handleShowView('memorial');
       return;
     }
     if (key === 'settings') {
-      showSettings(null, 'settings');
+      showSettings(null);
       return;
     }
     if (key === 'settings_projectDirectories') {
-      showStandaloneSettingsPanel('settings_projectDirectories');
+      showStandaloneSettingsPanel('projectDirectories');
       return;
     }
     if (key === 'settings_sessions') {
-      showStandaloneSettingsPanel('settings_sessions');
+      showStandaloneSettingsPanel('sessions');
       return;
     }
     if (key === 'settings_skills') {
-      showStandaloneSettingsPanel('settings_skills');
+      showStandaloneSettingsPanel('skills');
       return;
     }
-    showStandaloneSettingsPanel('settings_runtime');
+    showStandaloneSettingsPanel('runtime');
   }, [handleShowView, showListSection, showSettings, showStandaloneSettingsPanel]);
 
   // FAB backdrop click to collapse
@@ -372,7 +318,7 @@ function AppContent() {
           }}
         >
           <LeftRail
-            activeKey={activeNavKey}
+            activeKey={navKey}
             onSelect={handleRailSelect}
             collapsed={railCollapsed}
             onToggleCollapsed={() => {
@@ -415,18 +361,16 @@ function AppContent() {
               height: '100%',
               display: isMobile
                 ? (selectedPanel === 'list' ? 'block' : 'none')
-                : (activeNavKey === 'items' || activeNavKey === 'loops' ? 'block' : 'none'),
+                : (activeView === 'items' || activeView === 'loops' ? 'block' : 'none'),
             }}
           >
             <TodoList
               onOpenCreateModal={() => setTodoModalOpen(true)}
               onSelectTodo={(todoId) => {
-                setActiveNavKey('items');
                 handleSelectTodo(todoId);
               }}
               loopUpdateCount={loopUpdateCount}
               onSelectLoop={(loopId) => {
-                setActiveNavKey('loops');
                 handleSelectLoop(loopId);
               }}
               onCreateLoop={() => {
@@ -434,11 +378,8 @@ function AppContent() {
                 setLoopCreateModalOpen(true);
               }}
               forcedListMode={forcedListMode}
-              onListModeChange={(mode) => {
+              onListModeChange={() => {
                 setForcedListMode(undefined);
-                if (activeNavKey === 'items' || activeNavKey === 'loops') {
-                  setActiveNavKey(mode === 'loop' ? 'loops' : 'items');
-                }
               }}
             />
           </div>
@@ -523,7 +464,7 @@ function AppContent() {
                   }}
                 />
               </div>
-            ) : activeNavKey === 'settings_runtime' ? (
+            ) : activeView === 'runtime' ? (
               // 运行管理 — 独立页面（非设置内嵌标签页）
               <div className="detail-panel" style={{ height: '100%', overflowY: 'auto', padding: 16 }}>
                 <RuntimePanel
@@ -533,15 +474,15 @@ function AppContent() {
                   executorDisplayNames={runtimeExecutorDisplayNames}
                 />
               </div>
-            ) : activeNavKey === 'settings_skills' ? (
+            ) : activeView === 'skills' ? (
               <div className="detail-panel" style={{ height: '100%', overflowY: 'auto', padding: 16 }}>
                 <SkillsPanel />
               </div>
-            ) : activeNavKey === 'settings_projectDirectories' ? (
+            ) : activeView === 'projectDirectories' ? (
               <div className="detail-panel" style={{ height: '100%', overflowY: 'auto', padding: 16 }}>
                 <ProjectDirectoriesPanel />
               </div>
-            ) : activeNavKey === 'settings_sessions' ? (
+            ) : activeView === 'sessions' ? (
               <div className="detail-panel" style={{ height: '100%', overflowY: 'auto', padding: 16 }}>
                 <SessionManager />
               </div>
@@ -565,7 +506,7 @@ function AppContent() {
         styles={{ body: { padding: 0 } }}
       >
         <LeftRail
-          activeKey={activeNavKey}
+          activeKey={navKey}
           onSelect={handleRailSelect}
           variant="drawer"
           workspace={state.selectedWorkspace}

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -243,6 +243,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
         items={tabItems}
         type="card"
         size="small"
+        tabPosition="left"
         activeKey={activeTab}
         onChange={handleTabChange}
       />

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -5,26 +5,18 @@ import {
   CodeOutlined,
   TagOutlined,
   SaveOutlined,
-  FolderOutlined,
-  ThunderboltOutlined,
-  InfoCircleOutlined,
-  PlayCircleOutlined,
-  LaptopOutlined,
   FileTextOutlined,
+  InfoCircleOutlined,
   LeftOutlined,
   CloudOutlined,
 } from '@ant-design/icons';
 import { useApp } from '@/hooks/useApp';
 import * as db from '@/utils/database';
 import type { Config, ExecutorConfig, SlashCommandRule } from '@/types';
-import { SkillsPanel } from './SkillsPanel';
-import { SessionManager } from './SessionManager';
 import { SystemSettingsPanel } from './settings/SystemSettingsPanel';
 import { ExecutorsPanel } from './settings/ExecutorsPanel';
 import { TagsPanel } from './settings/TagsPanel';
-import { ProjectDirectoriesPanel } from './settings/ProjectDirectoriesPanel';
 import { BackupPanel } from './settings/BackupPanel';
-import { RuntimePanel } from './settings/RuntimePanel';
 import { TemplatesPanel } from './settings/TemplatesPanel';
 import { AboutPanel } from './settings/AboutPanel';
 import { CloudSyncPanel } from './settings/CloudSyncPanel';
@@ -44,17 +36,9 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
   const [configLoading, setConfigLoading] = useState(false);
   const [configSaving, setConfigSaving] = useState(false);
 
-  // Executors state (shared between ExecutorsPanel and RuntimePanel)
+  // Executors state
   const [executors, setExecutors] = useState<ExecutorConfig[]>([]);
   const [executorsLoading, setExecutorsLoading] = useState(false);
-
-  const executorDisplayNames = useMemo(() => {
-    const map: Record<string, string> = {};
-    for (const ec of executors) {
-      map[ec.name] = ec.display_name;
-    }
-    return map;
-  }, [executors]);
 
   // Load config on mount
   useEffect(() => {
@@ -142,12 +126,13 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
 
   // Tab 顺序说明：
   // 1. 系统设置、执行器管理、标签管理 → 基础配置优先
-  // 2. 消息、Session 管理 → 用户个性化配置紧随其后
-  // 3. 项目目录、模板管理 → 项目相关
-  // 4. 备份与恢复 → 数据安全（用户配置完毕后最后考虑）
-  // 5. Skills 管理、运行管理 → 高级功能放中间层
-  // 6. 云端同步 → 外部集成邻近放置
-  // 7. 关于 → 信息页末位
+  // 2. 模板管理 → 项目相关
+  // 3. 备份与恢复 → 数据安全
+  // 4. 云端同步 → 外部集成
+  // 5. 关于 → 信息页末位
+  //
+  // 会话管理、工作空间、Skills 管理、运行管理已独立为左侧导航菜单项，
+  // 不再嵌套在设置页的标签页中。
   const tabItems = [
     {
       key: 'system',
@@ -178,16 +163,6 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       children: <TagsPanel tags={tags} dispatch={dispatch} />,
     },
     {
-      key: 'sessions',
-      label: <span><LaptopOutlined style={{ marginRight: 6 }} />Session 管理</span>,
-      children: <SessionManager />,
-    },
-    {
-      key: 'projectDirectories',
-      label: <span><FolderOutlined style={{ marginRight: 6 }} />工作空间</span>,
-      children: <ProjectDirectoriesPanel />,
-    },
-    {
       key: 'templates',
       label: <span><FileTextOutlined style={{ marginRight: 6 }} />模板管理</span>,
       children: <TemplatesPanel />,
@@ -196,23 +171,6 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       key: 'backup',
       label: <span><SaveOutlined style={{ marginRight: 6 }} />备份与恢复</span>,
       children: <BackupPanel />,
-    },
-    {
-      key: 'skills',
-      label: <span><ThunderboltOutlined style={{ marginRight: 6 }} />Skills 管理</span>,
-      children: <SkillsPanel />,
-    },
-    {
-      key: 'runtime',
-      label: <span><PlayCircleOutlined style={{ marginRight: 6 }} />运行管理</span>,
-      children: (
-        <RuntimePanel
-          configForm={configForm}
-          configSaving={configSaving}
-          handleSaveConfig={handleSaveConfig}
-          executorDisplayNames={executorDisplayNames}
-        />
-      ),
     },
     {
       key: 'cloudSync',

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -11,6 +11,7 @@ import {
   CloudOutlined,
 } from '@ant-design/icons';
 import { useApp } from '@/hooks/useApp';
+import { useViewState } from '@/hooks/useViewState';
 import * as db from '@/utils/database';
 import type { Config, ExecutorConfig, SlashCommandRule } from '@/types';
 import { SystemSettingsPanel } from './settings/SystemSettingsPanel';
@@ -186,34 +187,13 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
 
   const knownTabs = useMemo(() => tabItems.map(t => t.key), [tabItems]);
 
-  const getInitialTab = useCallback(() => {
-    const tab = new URLSearchParams(window.location.search).get('tab');
-    if (tab && knownTabs.includes(tab)) return tab;
-    return 'system';
-  }, [knownTabs]);
-
-  const [activeTab, setActiveTab] = useState<string>(getInitialTab);
-
-  useEffect(() => {
-    setActiveTab(getInitialTab());
-  }, [getInitialTab]);
-
-  useEffect(() => {
-    const onPopState = () => {
-      setActiveTab(getInitialTab());
-    };
-    window.addEventListener('popstate', onPopState);
-    return () => window.removeEventListener('popstate', onPopState);
-  }, [getInitialTab]);
+  // 从 useViewState 获取当前 tab，popstate 由它统一处理
+  const { activeTab, pushUrl } = useViewState();
+  const resolvedTab = activeTab && knownTabs.includes(activeTab) ? activeTab : 'system';
 
   const handleTabChange = useCallback((key: string) => {
-    setActiveTab(key);
-    const params = new URLSearchParams(window.location.search);
-    params.set('view', 'settings');
-    params.set('tab', key);
-    window.history.pushState(null, '', `/?${params.toString()}`);
-    window.dispatchEvent(new CustomEvent('settingsTabChanged', { detail: { tab: key } }));
-  }, []);
+    pushUrl('settings', { tab: key });
+  }, [pushUrl]);
 
   return (
     <div
@@ -244,7 +224,7 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
         type="card"
         size="small"
         tabPosition="left"
-        activeKey={activeTab}
+        activeKey={resolvedTab}
         onChange={handleTabChange}
       />
     </div>

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { Tabs, Form, Button, message } from 'antd';
 import {
   SettingOutlined,
@@ -226,6 +226,37 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
     },
   ];
 
+  const knownTabs = useMemo(() => tabItems.map(t => t.key), [tabItems]);
+
+  const getInitialTab = useCallback(() => {
+    const tab = new URLSearchParams(window.location.search).get('tab');
+    if (tab && knownTabs.includes(tab)) return tab;
+    return 'system';
+  }, [knownTabs]);
+
+  const [activeTab, setActiveTab] = useState<string>(getInitialTab);
+
+  useEffect(() => {
+    setActiveTab(getInitialTab());
+  }, [getInitialTab]);
+
+  useEffect(() => {
+    const onPopState = () => {
+      setActiveTab(getInitialTab());
+    };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, [getInitialTab]);
+
+  const handleTabChange = useCallback((key: string) => {
+    setActiveTab(key);
+    const params = new URLSearchParams(window.location.search);
+    params.set('view', 'settings');
+    params.set('tab', key);
+    window.history.pushState(null, '', `/?${params.toString()}`);
+    window.dispatchEvent(new CustomEvent('settingsTabChanged', { detail: { tab: key } }));
+  }, []);
+
   return (
     <div
       className="settings-page-root detail-panel"
@@ -249,7 +280,14 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
           <h2 className="card-title">配置管理</h2>
         </div>
       </div>
-      <Tabs className="settings-tabs" items={tabItems} type="card" size="small" />
+      <Tabs
+        className="settings-tabs"
+        items={tabItems}
+        type="card"
+        size="small"
+        activeKey={activeTab}
+        onChange={handleTabChange}
+      />
     </div>
   );
 }

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -3,7 +3,7 @@ import { useApp } from '@/hooks/useApp';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { Button, Dropdown, Empty, Tooltip, Input, Segmented, Skeleton, Checkbox, Modal, App as AntApp } from 'antd';
 import type { MenuProps } from 'antd';
-import { ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, ApartmentOutlined, FolderOpenOutlined, MoreOutlined, SearchOutlined, DownOutlined, SwapOutlined, StopOutlined } from '@ant-design/icons';
+import { ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, MoreOutlined, SearchOutlined, SwapOutlined, StopOutlined } from '@ant-design/icons';
 import { useTheme } from '@/hooks/useTheme';
 import { StatusPicker } from './StatusPicker';
 import * as db from '@/utils/database';
@@ -596,62 +596,6 @@ export function TodoList(props: TodoListProps) {
           )}
           </div>
         </div>
-      </div>
-
-      {/* Workspace selector - 在搜索框上方，用于切换不同工作空间。
-          已移除"全部工作空间"选项，强制用户必须选择一个工作空间。 */}
-      <div style={{ padding: '8px 16px', borderBottom: '1px solid var(--color-border-light)' }}>
-        <Dropdown
-          menu={{
-            items: [
-              ...projectDirectories.map(dir => ({
-                key: dir.path,
-                label: dir.name || dir.path,
-                icon: <FolderOpenOutlined />,
-              })),
-              { type: 'divider' as const },
-              {
-                key: '__manage__',
-                label: '管理工作空间',
-                icon: <SettingOutlined />,
-              },
-            ],
-            onClick: ({ key }) => {
-              if (key === '__manage__') {
-                onShowSettings?.();
-              } else {
-                dispatch({ type: 'SELECT_WORKSPACE', payload: key });
-              }
-            },
-          }}
-          trigger={['click']}
-        >
-          <Button
-            type="text"
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              width: '100%',
-              justifyContent: 'space-between',
-              padding: '8px 12px',
-              borderRadius: 'var(--radius-md)',
-              background: 'var(--color-bg-elevated)',
-              border: '1px solid var(--color-border)',
-            }}
-          >
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <ApartmentOutlined style={{ color: 'var(--color-primary)' }} />
-              <span style={{ fontWeight: 500 }}>
-                {selectedWorkspace
-                  ? projectDirectories.find(d => d.path === selectedWorkspace)?.name || selectedWorkspace
-                  : '请选择工作空间'
-                }
-              </span>
-            </div>
-            <DownOutlined style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }} />
-          </Button>
-        </Dropdown>
       </div>
 
       {/* 搜索框：两种模式都展示（用户反馈：环路原本没有，切换时会跳界面）。

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useApp } from '@/hooks/useApp';
+import { useViewState } from '@/hooks/useViewState';
 import { Empty, Input, Skeleton, Checkbox, Modal, App as AntApp } from 'antd';
 import { ClockCircleOutlined, InboxOutlined, SearchOutlined, SwapOutlined, StopOutlined } from '@ant-design/icons';
 import { StatusPicker } from './StatusPicker';
@@ -42,6 +43,7 @@ export function TodoList(props: TodoListProps) {
   const { onOpenCreateModal, onSelectTodo, onSelectLoop, onCreateLoop, loopUpdateCount, forcedListMode, onListModeChange } = props;
   const { state, dispatch } = useApp();
   const { todos, selectedTodoId, selectedTagId, selectedWorkspace, tags } = state;
+  const { activeView } = useViewState();
   const { message } = AntApp.useApp();
   const [isLoading, setIsLoading] = useState(true);
   // 搜索关键字状态，用于按标题或提示词过滤 todo 列表
@@ -59,6 +61,8 @@ export function TodoList(props: TodoListProps) {
   const [selectedLoopId, setSelectedLoopId] = useState<number | null>(null);
   // 项目目录：工作空间选择器需要目录列表
   const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
+  // 标记项目目录初始加载是否已完成（无论成功与否），用于守卫环路加载等工作空间确定后再发起请求
+  const [directoriesReady, setDirectoriesReady] = useState(false);
   // —— 通用工具栏：跨模式的多选 id 列表 ——
   // 切换 listMode 时清空，避免不同模式 id 串台（todo/loop 都是 number id）
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
@@ -85,9 +89,12 @@ export function TodoList(props: TodoListProps) {
   // 失败时静默处理：分组视图退化为只显示路径即可，不阻塞主流程。
   const reloadProjectDirectories = useCallback(() => {
     db.getProjectDirectories() // 从后端拉取全量目录列表
-      .then(setProjectDirectories) // 更新本地状态，触发分组重新计算
+      .then(dirs => {
+        setProjectDirectories(dirs);
+        setDirectoriesReady(true);
+      })
       .catch(() => {
-        // 静默失败：分组视图退化为只显示路径即可，不阻塞主流程
+        setDirectoriesReady(true); // 失败也标记为 ready，避免阻塞环路加载
       });
   }, []);
 
@@ -109,31 +116,23 @@ export function TodoList(props: TodoListProps) {
   }, [projectDirectories, selectedWorkspace, dispatch]);
 
   // 当列表切换到「环路」时，自动加载 loop 列表；或环路变更时刷新
+  // 必须等待项目目录加载完成且工作空间已确定，否则请求不携带 workspace 参数返回错误数据。
   useEffect(() => {
     if (listMode !== 'loop') return;
+    if (!directoriesReady) return;
+    // 已有目录但尚未选定工作空间 → 等待 auto-select 后再加载
+    if (projectDirectories.length > 0 && selectedWorkspace === null) return;
     setLoopLoading(true);
     dbLoops.listLoops(selectedWorkspace)
       .then(setLoopList)
       .catch(() => setLoopList([]))
       .finally(() => setLoopLoading(false));
-  }, [listMode, loopUpdateCount, selectedWorkspace]);
+  }, [listMode, loopUpdateCount, selectedWorkspace, projectDirectories, directoriesReady]);
 
   // 持久化列表模式到 localStorage
   useEffect(() => {
     localStorage.setItem('ntd_list_mode', listMode);
   }, [listMode]);
-
-  // 进入环路列表且加载完成后，若未选中任何 loop，自动选中第一个。
-  // 目的是让右侧直接展示环路详情而不显示空白仪表盘。
-  useEffect(() => {
-    if (listMode !== 'loop') return;
-    if (loopLoading) return;
-    if (selectedLoopId !== null) return;
-    if (loopList.length === 0) return;
-    const firstId = loopList[0].id;
-    setSelectedLoopId(firstId);
-    onSelectLoop?.(firstId);
-  }, [listMode, loopLoading, loopList, selectedLoopId, onSelectLoop]);
 
   // 向壳层同步当前列表模式，便于左侧主导航高亮与全局路由状态保持一致。
   useEffect(() => {
@@ -189,6 +188,38 @@ export function TodoList(props: TodoListProps) {
     if (!keyword) return loopList;
     return loopList.filter(l => (l.name || '').toLowerCase().includes(keyword));
   }, [loopList, searchKeyword]);
+
+  // 事项/环路模式：等目录加载完成 → 工作空间确定后 → 自动选中第一项。
+  // 目的是让右侧直接展示详情，避免显示空白仪表盘页。
+  // 注意：必须检查 activeView 匹配，防止用户已导航离开后 auto-select 又把视图弹回。
+  useEffect(() => {
+    // 等目录加载完成
+    if (!directoriesReady) return;
+    // 有目录但尚未选定工作空间 → 等待 auto-select
+    if (projectDirectories.length > 0 && selectedWorkspace === null) return;
+
+    if (listMode === 'item') {
+      if (activeView !== 'items') return;
+      if (selectedTodoId !== null) return;
+      if (filteredTodos.length === 0) return;
+      const firstId = filteredTodos[0].id;
+      dispatch({ type: 'SELECT_TODO', payload: firstId });
+      onSelectTodo?.(firstId);
+    } else if (listMode === 'loop') {
+      if (activeView !== 'loops') return;
+      if (selectedLoopId !== null) return;
+      if (loopLoading) return;
+      if (loopList.length === 0) return;
+      const firstId = loopList[0].id;
+      setSelectedLoopId(firstId);
+      onSelectLoop?.(firstId);
+    }
+  }, [
+    directoriesReady, projectDirectories, selectedWorkspace,
+    listMode, activeView,
+    selectedTodoId, filteredTodos, dispatch, onSelectTodo,
+    selectedLoopId, loopLoading, loopList, onSelectLoop,
+  ]);
 
   // 当前 listMode 下"可见可选"的 id 列表，传给 ActionToolbar 用于「全选」/计数。
   // 两种模式都按当前 searchKeyword 过滤后的列表计算，避免「全选」选中隐藏项。

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -20,6 +20,7 @@ import { formatRelativeTime } from '@/utils/datetime';
 interface TodoListProps {
   onOpenCreateModal: () => void;
   onOpenSmartCreate: () => void;
+  onOpenNav?: () => void;
   onSelectTodo?: (todoId: string | number) => void;
   onShowDashboard?: () => void;
   onShowMemorial?: () => void;
@@ -27,6 +28,8 @@ interface TodoListProps {
   onSelectLoop?: (loopId: number) => void;
   onCreateLoop?: () => void;
   loopUpdateCount?: number;
+  forcedListMode?: 'item' | 'loop';
+  onListModeChange?: (mode: 'item' | 'loop') => void;
 }
 
 function SkeletonRow() {
@@ -69,7 +72,7 @@ function buildDesktopNavActions(
 }
 
 export function TodoList(props: TodoListProps) {
-  const { onOpenCreateModal, onOpenSmartCreate, onSelectTodo, onShowDashboard, onShowMemorial, onShowSettings, onSelectLoop, onCreateLoop, loopUpdateCount } = props;
+  const { onOpenCreateModal, onOpenSmartCreate, onOpenNav, onSelectTodo, onShowDashboard, onShowMemorial, onShowSettings, onSelectLoop, onCreateLoop, loopUpdateCount, forcedListMode, onListModeChange } = props;
   const { state, dispatch } = useApp();
   const { themeMode, toggleTheme } = useTheme();
   const { todos, selectedTodoId, selectedTagId, selectedWorkspace, tags } = state;
@@ -104,6 +107,14 @@ export function TodoList(props: TodoListProps) {
   useEffect(() => {
     setIsLoading(false);
   }, []);
+
+  // 外部导航强制指定 listMode 时（例如左侧主导航点击“收件箱/环路”），
+  // 需要让内部状态跟随，否则中间列表会停留在用户上次切换的模式。
+  useEffect(() => {
+    if (!forcedListMode) return;
+    if (forcedListMode === listMode) return;
+    setListMode(forcedListMode);
+  }, [forcedListMode, listMode]);
 
   // 进入页面时拉取项目目录；后续 Todo 抽屉新增/删除目录时也会主动重拉，确保分组始终准确。
   // 失败时静默处理：分组视图退化为只显示路径即可，不阻塞主流程。
@@ -146,6 +157,11 @@ export function TodoList(props: TodoListProps) {
   useEffect(() => {
     localStorage.setItem('ntd_list_mode', listMode);
   }, [listMode]);
+
+  // 向壳层同步当前列表模式，便于左侧主导航高亮与全局路由状态保持一致。
+  useEffect(() => {
+    onListModeChange?.(listMode);
+  }, [listMode, onListModeChange]);
 
   // 切换 listMode 时清空选择：todo/loop 虽然 id 都是 number，
   // 但语义不同（同一数字可能指向不同实体），跨模式保留选择会让用户困惑。
@@ -490,7 +506,18 @@ export function TodoList(props: TodoListProps) {
       {/* Header */}
       <div className="todo-list-header">
         {/* NTD Logo */}
-        <div className="ntd-logo" aria-label="NTD Logo">NTD</div>
+        {onOpenNav ? (
+          <button
+            type="button"
+            className="ntd-logo ntd-logo-button"
+            onClick={onOpenNav}
+            aria-label="打开导航"
+          >
+            NTD
+          </button>
+        ) : (
+          <div className="ntd-logo" aria-label="NTD Logo">NTD</div>
+        )}
         <div className="header-actions">
           <div className="header-toolbar">
             {desktopNavActions.length > 0 && (

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -3,8 +3,7 @@ import { useApp } from '@/hooks/useApp';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { Button, Dropdown, Empty, Tooltip, Input, Segmented, Skeleton, Checkbox, Modal, App as AntApp } from 'antd';
 import type { MenuProps } from 'antd';
-import { ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, SunOutlined, MoonOutlined, MoreOutlined, SearchOutlined, SwapOutlined, StopOutlined } from '@ant-design/icons';
-import { useTheme } from '@/hooks/useTheme';
+import { ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, MoreOutlined, SearchOutlined, SwapOutlined, StopOutlined } from '@ant-design/icons';
 import { StatusPicker } from './StatusPicker';
 import * as db from '@/utils/database';
 import type { ProjectDirectory, Todo } from '@/types';
@@ -74,7 +73,6 @@ function buildDesktopNavActions(
 export function TodoList(props: TodoListProps) {
   const { onOpenCreateModal, onOpenSmartCreate, onOpenNav, onSelectTodo, onShowDashboard, onShowMemorial, onShowSettings, onSelectLoop, onCreateLoop, loopUpdateCount, forcedListMode, onListModeChange } = props;
   const { state, dispatch } = useApp();
-  const { themeMode, toggleTheme } = useTheme();
   const { todos, selectedTodoId, selectedTagId, selectedWorkspace, tags } = state;
   const { message } = AntApp.useApp();
   const isMobile = useIsMobile();
@@ -326,23 +324,13 @@ export function TodoList(props: TodoListProps) {
    * 处理桌面端头部"更多"菜单点击。
    */
   const handleHeaderMenuClick = useCallback<NonNullable<MenuProps['onClick']>>(({ key }) => {
-    if (key === 'theme') {
-      toggleTheme();
-      return;
-    }
     if (key === 'settings') {
       onShowSettings?.();
     }
-  }, [onShowSettings, toggleTheme]);
+  }, [onShowSettings]);
 
   const headerMenuItems = useMemo<MenuProps['items']>(() => {
-    const items: NonNullable<MenuProps['items']> = [
-      {
-        key: 'theme',
-        icon: themeMode === 'light' ? <MoonOutlined /> : <SunOutlined />,
-        label: themeMode === 'light' ? '暗色' : '亮色',
-      },
-    ];
+    const items: NonNullable<MenuProps['items']> = [];
 
     if (onShowSettings) {
       items.push(
@@ -356,7 +344,7 @@ export function TodoList(props: TodoListProps) {
     }
 
     return items;
-  }, [themeMode, onShowSettings]);
+  }, [onShowSettings]);
 
   const tagMap = useMemo(() => {
     const map = new Map<number, typeof tags[0]>();
@@ -572,16 +560,6 @@ export function TodoList(props: TodoListProps) {
 
           {isMobile && (
             <div className="header-nav-cluster" aria-label="移动端操作">
-              <Tooltip title={themeMode === 'light' ? '暗色' : '亮色'}>
-                <Button
-                  type="text"
-                  size="small"
-                  icon={themeMode === 'light' ? <MoonOutlined /> : <SunOutlined />}
-                  onClick={toggleTheme}
-                  className="header-nav-btn"
-                  aria-label={themeMode === 'light' ? '暗色' : '亮色'}
-                />
-              </Tooltip>
               <Tooltip title="设置">
                 <Button
                   type="text"

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -108,7 +108,7 @@ export function TodoList(props: TodoListProps) {
     setIsLoading(false);
   }, []);
 
-  // 外部导航强制指定 listMode 时（例如左侧主导航点击“收件箱/环路”），
+  // 外部导航强制指定 listMode 时（例如左侧主导航点击“事项/环路”），
   // 需要让内部状态跟随，否则中间列表会停留在用户上次切换的模式。
   useEffect(() => {
     if (!forcedListMode) return;

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useApp } from '@/hooks/useApp';
-import { useViewState } from '@/hooks/useViewState';
 import { Empty, Input, Skeleton, Checkbox, Modal, App as AntApp } from 'antd';
 import { ClockCircleOutlined, InboxOutlined, SearchOutlined, SwapOutlined, StopOutlined } from '@ant-design/icons';
 import { StatusPicker } from './StatusPicker';
@@ -23,6 +22,7 @@ interface TodoListProps {
   loopUpdateCount?: number;
   forcedListMode?: 'item' | 'loop';
   onListModeChange?: (mode: 'item' | 'loop') => void;
+  activeView: string;
 }
 
 function SkeletonRow() {
@@ -40,10 +40,9 @@ function SkeletonList() {
 }
 
 export function TodoList(props: TodoListProps) {
-  const { onOpenCreateModal, onSelectTodo, onSelectLoop, onCreateLoop, loopUpdateCount, forcedListMode, onListModeChange } = props;
+  const { onOpenCreateModal, onSelectTodo, onSelectLoop, onCreateLoop, loopUpdateCount, forcedListMode, onListModeChange, activeView } = props;
   const { state, dispatch } = useApp();
   const { todos, selectedTodoId, selectedTagId, selectedWorkspace, tags } = state;
-  const { activeView } = useViewState();
   const { message } = AntApp.useApp();
   const [isLoading, setIsLoading] = useState(true);
   // 搜索关键字状态，用于按标题或提示词过滤 todo 列表

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,9 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useApp } from '@/hooks/useApp';
-import { useIsMobile } from '@/hooks/useIsMobile';
-import { Button, Dropdown, Empty, Tooltip, Input, Segmented, Skeleton, Checkbox, Modal, App as AntApp } from 'antd';
-import type { MenuProps } from 'antd';
-import { ThunderboltOutlined, ClockCircleOutlined, InboxOutlined, DashboardOutlined, ReadOutlined, SettingOutlined, MoreOutlined, SearchOutlined, SwapOutlined, StopOutlined } from '@ant-design/icons';
+import { Empty, Input, Segmented, Skeleton, Checkbox, Modal, App as AntApp } from 'antd';
+import { ClockCircleOutlined, InboxOutlined, SearchOutlined, SwapOutlined, StopOutlined } from '@ant-design/icons';
 import { StatusPicker } from './StatusPicker';
 import * as db from '@/utils/database';
 import type { ProjectDirectory, Todo } from '@/types';
@@ -18,12 +16,7 @@ import { formatRelativeTime } from '@/utils/datetime';
 
 interface TodoListProps {
   onOpenCreateModal: () => void;
-  onOpenSmartCreate: () => void;
-  onOpenNav?: () => void;
   onSelectTodo?: (todoId: string | number) => void;
-  onShowDashboard?: () => void;
-  onShowMemorial?: () => void;
-  onShowSettings?: () => void;
   onSelectLoop?: (loopId: number) => void;
   onCreateLoop?: () => void;
   loopUpdateCount?: number;
@@ -45,37 +38,11 @@ function SkeletonList() {
   );
 }
 
-/**
- * 构建桌面端头部高频导航按钮。
- */
-function buildDesktopNavActions(
-  onShowDashboard: TodoListProps['onShowDashboard'],
-  onShowMemorial: TodoListProps['onShowMemorial'],
-) {
-  return [
-    {
-      key: 'dashboard',
-      title: '仪表盘',
-      icon: <DashboardOutlined />,
-      onClick: onShowDashboard ? () => onShowDashboard() : undefined,
-      ariaLabel: '仪表盘',
-    },
-    {
-      key: 'memorial',
-      title: '看板',
-      icon: <ReadOutlined />,
-      onClick: onShowMemorial ? () => onShowMemorial() : undefined,
-      ariaLabel: '看板',
-    },
-  ].filter(action => typeof action.onClick === 'function');
-}
-
 export function TodoList(props: TodoListProps) {
-  const { onOpenCreateModal, onOpenSmartCreate, onOpenNav, onSelectTodo, onShowDashboard, onShowMemorial, onShowSettings, onSelectLoop, onCreateLoop, loopUpdateCount, forcedListMode, onListModeChange } = props;
+  const { onOpenCreateModal, onSelectTodo, onSelectLoop, onCreateLoop, loopUpdateCount, forcedListMode, onListModeChange } = props;
   const { state, dispatch } = useApp();
   const { todos, selectedTodoId, selectedTagId, selectedWorkspace, tags } = state;
   const { message } = AntApp.useApp();
-  const isMobile = useIsMobile();
   const [isLoading, setIsLoading] = useState(true);
   // 搜索关键字状态，用于按标题或提示词过滤 todo 列表
   const [searchKeyword, setSearchKeyword] = useState('');
@@ -315,37 +282,6 @@ export function TodoList(props: TodoListProps) {
     };
   }, [listMode, openItemChangeExecutor, openLoopForceStop]);
 
-  const desktopNavActions = useMemo(
-    () => buildDesktopNavActions(onShowDashboard, onShowMemorial),
-    [onShowDashboard, onShowMemorial],
-  );
-
-  /**
-   * 处理桌面端头部"更多"菜单点击。
-   */
-  const handleHeaderMenuClick = useCallback<NonNullable<MenuProps['onClick']>>(({ key }) => {
-    if (key === 'settings') {
-      onShowSettings?.();
-    }
-  }, [onShowSettings]);
-
-  const headerMenuItems = useMemo<MenuProps['items']>(() => {
-    const items: NonNullable<MenuProps['items']> = [];
-
-    if (onShowSettings) {
-      items.push(
-        { type: 'divider' },
-        {
-          key: 'settings',
-          icon: <SettingOutlined />,
-          label: '设置',
-        },
-      );
-    }
-
-    return items;
-  }, [onShowSettings]);
-
   const tagMap = useMemo(() => {
     const map = new Map<number, typeof tags[0]>();
     for (const tag of tags) map.set(tag.id, tag);
@@ -491,91 +427,6 @@ export function TodoList(props: TodoListProps) {
 
   return (
     <div className="todo-list-container">
-      {/* Header */}
-      <div className="todo-list-header">
-        {/* NTD Logo */}
-        {onOpenNav ? (
-          <button
-            type="button"
-            className="ntd-logo ntd-logo-button"
-            onClick={onOpenNav}
-            aria-label="打开导航"
-          >
-            NTD
-          </button>
-        ) : (
-          <div className="ntd-logo" aria-label="NTD Logo">NTD</div>
-        )}
-        <div className="header-actions">
-          <div className="header-toolbar">
-            {desktopNavActions.length > 0 && (
-              <div className="header-nav-cluster" aria-label="主导航">
-                {desktopNavActions.map(action => (
-                  <Tooltip key={action.key} title={action.title}>
-                    <Button
-                      type="text"
-                      size="small"
-                      icon={action.icon}
-                      onClick={action.onClick}
-                      className="header-nav-btn"
-                      aria-label={action.ariaLabel}
-                    />
-                  </Tooltip>
-                ))}
-              </div>
-            )}
-
-            {!isMobile && (
-              <Dropdown
-                menu={{ items: headerMenuItems, onClick: handleHeaderMenuClick }}
-                trigger={['click']}
-                placement="bottomRight"
-              >
-                <Button
-                  type="text"
-                  size="small"
-                  icon={<MoreOutlined />}
-                  className="header-overflow-btn"
-                  aria-label="更多操作"
-                />
-              </Dropdown>
-            )}
-
-          {!isMobile && (
-            <div className="header-quick-actions">
-              {/* header 只保留「智能新建」（AI 一句话生成）。普通新建入口已迁到
-                  ActionToolbar 的「新建事项 / 新建环路」按钮，避免两处入口混淆。 */}
-              <Tooltip title="智能新建">
-                <Button
-                  type="text"
-                  size="small"
-                  icon={<ThunderboltOutlined />}
-                  className="header-primary-action header-primary-action-smart"
-                  onClick={onOpenSmartCreate}
-                  aria-label="智能新建"
-                />
-              </Tooltip>
-            </div>
-          )}
-
-          {isMobile && (
-            <div className="header-nav-cluster" aria-label="移动端操作">
-              <Tooltip title="设置">
-                <Button
-                  type="text"
-                  size="small"
-                  icon={<SettingOutlined />}
-                  onClick={() => onShowSettings?.()}
-                  className="header-nav-btn"
-                  aria-label="设置"
-                />
-              </Tooltip>
-            </div>
-          )}
-          </div>
-        </div>
-      </div>
-
       {/* 搜索框：两种模式都展示（用户反馈：环路原本没有，切换时会跳界面）。
           placeholder 按 listMode 切换，关键词同时匹配事项标题/提示词、环路名称。 */}
       <div style={{ padding: '8px 16px', borderBottom: '1px solid var(--color-border-light)' }}>

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -123,6 +123,18 @@ export function TodoList(props: TodoListProps) {
     localStorage.setItem('ntd_list_mode', listMode);
   }, [listMode]);
 
+  // 进入环路列表且加载完成后，若未选中任何 loop，自动选中第一个。
+  // 目的是让右侧直接展示环路详情而不显示空白仪表盘。
+  useEffect(() => {
+    if (listMode !== 'loop') return;
+    if (loopLoading) return;
+    if (selectedLoopId !== null) return;
+    if (loopList.length === 0) return;
+    const firstId = loopList[0].id;
+    setSelectedLoopId(firstId);
+    onSelectLoop?.(firstId);
+  }, [listMode, loopLoading, loopList, selectedLoopId, onSelectLoop]);
+
   // 向壳层同步当前列表模式，便于左侧主导航高亮与全局路由状态保持一致。
   useEffect(() => {
     onListModeChange?.(listMode);
@@ -132,6 +144,7 @@ export function TodoList(props: TodoListProps) {
   // 但语义不同（同一数字可能指向不同实体），跨模式保留选择会让用户困惑。
   useEffect(() => {
     setSelectedIds([]);
+    setSelectedLoopId(null);
   }, [listMode]);
 
   // 切换单条 id 的选中态（toggle 语义，工具栏的「全选」用 onSelectionChange 全量覆盖）

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useApp } from '@/hooks/useApp';
-import { Empty, Input, Segmented, Skeleton, Checkbox, Modal, App as AntApp } from 'antd';
+import { Empty, Input, Skeleton, Checkbox, Modal, App as AntApp } from 'antd';
 import { ClockCircleOutlined, InboxOutlined, SearchOutlined, SwapOutlined, StopOutlined } from '@ant-design/icons';
 import { StatusPicker } from './StatusPicker';
 import * as db from '@/utils/database';
@@ -440,20 +440,6 @@ export function TodoList(props: TodoListProps) {
           onChange={(e) => setSearchKeyword(e.target.value)}
           allowClear
           size="small"
-        />
-      </div>
-
-      {/* 列表选择：事项 / 环路 */}
-      <div style={{ padding: '8px 16px', borderBottom: '1px solid var(--color-border-light)' }}>
-        <Segmented
-          block
-          size="small"
-          value={listMode}
-          onChange={(v) => setListMode(v as 'item' | 'loop')}
-          options={[
-            { label: '事项', value: 'item' },
-            { label: '环路', value: 'loop' },
-          ]}
         />
       </div>
 

--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -18,7 +18,7 @@ import {
 import { WorkspaceSwitcher } from './WorkspaceSwitcher';
 
 export type LeftRailKey =
-  | 'inbox'
+  | 'items'
   | 'loops'
   | 'dashboard'
   | 'memorial'
@@ -63,9 +63,9 @@ export function LeftRail({
 }: LeftRailProps) {
   const sections = useMemo(() => ([
     {
-      title: '收件箱',
+      title: '事项',
       items: [
-        { key: 'inbox', label: '收件箱', icon: <InboxOutlined />, ariaLabel: '收件箱' },
+        { key: 'items', label: '事项', icon: <InboxOutlined />, ariaLabel: '事项' },
         { key: 'loops', label: '环路', icon: <ApartmentOutlined />, ariaLabel: '环路' },
       ] satisfies LeftRailItem[],
     },

--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -69,15 +69,10 @@ export function LeftRail({
 }: LeftRailProps) {
   const sections = useMemo(() => ([
     {
-      title: '事项',
+      title: '工作区',
       items: [
         { key: 'items', label: '事项', icon: <InboxOutlined />, ariaLabel: '事项' },
         { key: 'loops', label: '环路', icon: <ApartmentOutlined />, ariaLabel: '环路' },
-      ] satisfies LeftRailItem[],
-    },
-    {
-      title: '工作区',
-      items: [
         { key: 'dashboard', label: '仪表盘', icon: <DashboardOutlined />, ariaLabel: '仪表盘' },
         { key: 'memorial', label: '看板', icon: <ReadOutlined />, ariaLabel: '看板' },
       ] satisfies LeftRailItem[],

--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -1,0 +1,119 @@
+import { useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { Button, Tooltip } from 'antd';
+import type { ButtonProps } from 'antd';
+import {
+  InboxOutlined,
+  ApartmentOutlined,
+  DashboardOutlined,
+  ReadOutlined,
+  SettingOutlined,
+} from '@ant-design/icons';
+
+export type LeftRailKey = 'inbox' | 'loops' | 'dashboard' | 'memorial' | 'settings';
+
+interface LeftRailItem {
+  key: LeftRailKey;
+  label: string;
+  icon: ReactNode;
+  ariaLabel: string;
+  danger?: boolean;
+}
+
+export type LeftRailVariant = 'rail' | 'drawer';
+
+interface LeftRailProps {
+  activeKey: LeftRailKey;
+  onSelect: (key: LeftRailKey) => void;
+  variant?: LeftRailVariant;
+}
+
+/**
+ * 左侧主导航栏。
+ * 目标：为“中间列表 + 右侧工作区”补上一层全局导航，让用户能用更低成本在核心区域间切换。
+ */
+export function LeftRail({ activeKey, onSelect, variant = 'rail' }: LeftRailProps) {
+  const items = useMemo<LeftRailItem[]>(() => ([
+    {
+      key: 'inbox',
+      label: '收件箱',
+      icon: <InboxOutlined />,
+      ariaLabel: '收件箱',
+    },
+    {
+      key: 'loops',
+      label: '环路',
+      icon: <ApartmentOutlined />,
+      ariaLabel: '环路',
+    },
+    {
+      key: 'dashboard',
+      label: '仪表盘',
+      icon: <DashboardOutlined />,
+      ariaLabel: '仪表盘',
+    },
+    {
+      key: 'memorial',
+      label: '看板',
+      icon: <ReadOutlined />,
+      ariaLabel: '看板',
+    },
+    {
+      key: 'settings',
+      label: '设置',
+      icon: <SettingOutlined />,
+      ariaLabel: '设置',
+    },
+  ]), []);
+
+  const isDrawer = variant === 'drawer';
+
+  /**
+   * 渲染单个导航按钮。
+   * rail：只展示图标（靠 Tooltip 告知含义）；drawer：展示图标 + 文本，适配移动端。
+   */
+  const renderNavButton = (item: LeftRailItem) => {
+    const isActive = item.key === activeKey;
+    const commonProps: ButtonProps = {
+      type: 'text',
+      icon: item.icon,
+      onClick: () => onSelect(item.key),
+      className: isDrawer ? 'ntd-left-rail-drawer-btn' : 'ntd-left-rail-btn',
+      'aria-label': item.ariaLabel,
+      'data-testid': `left-rail-${item.key}`,
+      danger: item.danger,
+    };
+
+    if (isDrawer) {
+      return (
+        <Button
+          key={item.key}
+          {...commonProps}
+          className={`${commonProps.className} ${isActive ? 'active' : ''}`}
+        >
+          <span className="ntd-left-rail-drawer-label">{item.label}</span>
+        </Button>
+      );
+    }
+
+    return (
+      <Tooltip key={item.key} title={item.label} placement="right">
+        <Button
+          {...commonProps}
+          className={`${commonProps.className} ${isActive ? 'active' : ''}`}
+        />
+      </Tooltip>
+    );
+  };
+
+  return (
+    <div
+      className={isDrawer ? 'ntd-left-rail-drawer' : 'ntd-left-rail'}
+      data-testid="left-rail"
+    >
+      <div className={isDrawer ? 'ntd-left-rail-drawer-top' : 'ntd-left-rail-top'}>
+        {items.map(renderNavButton)}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { ReactNode } from 'react';
-import { Button, Tooltip, Popover } from 'antd';
+import { Button, Tooltip } from 'antd';
 import type { ButtonProps } from 'antd';
 import {
   InboxOutlined,
@@ -15,7 +15,7 @@ import {
   DoubleRightOutlined,
   DoubleLeftOutlined,
 } from '@ant-design/icons';
-import { WorkspaceSelect } from '@/components/common/WorkspaceSelect';
+import { WorkspaceSwitcher } from './WorkspaceSwitcher';
 
 export type LeftRailKey =
   | 'inbox'
@@ -145,71 +145,24 @@ export function LeftRail({
     if (isDrawer || shouldShowLabels) {
       return (
         <div className={isDrawer ? 'ntd-left-rail-drawer-workspace' : 'ntd-left-rail-workspace'}>
-          <div className="ntd-left-rail-workspace-label">工作空间</div>
-          <WorkspaceSelect
+          <WorkspaceSwitcher
             value={workspace ?? null}
-            required
-            onChange={(next) => {
-              if (!next) return;
-              onWorkspaceChange?.(next);
-            }}
-            selectProps={{ size: 'small' }}
+            onChange={(next) => onWorkspaceChange?.(next)}
+            onManage={() => onSelect('settings_projectDirectories')}
+            mode="full"
           />
-          <div className="ntd-left-rail-workspace-actions">
-            <Button
-              type="text"
-              size="small"
-              icon={<SettingOutlined />}
-              onClick={() => onSelect('settings_projectDirectories')}
-              aria-label="管理工作空间"
-              data-testid="left-rail-manage-workspaces"
-            >
-              管理
-            </Button>
-          </div>
         </div>
       );
     }
 
     return (
       <div className="ntd-left-rail-workspace-collapsed">
-        <Popover
-          placement="rightTop"
-          trigger="click"
-          content={
-            <div style={{ width: 260, padding: 10 }}>
-              <div style={{ fontWeight: 600, marginBottom: 8 }}>工作空间</div>
-              <WorkspaceSelect
-                value={workspace ?? null}
-                required
-                onChange={(next) => {
-                  if (!next) return;
-                  onWorkspaceChange?.(next);
-                }}
-                selectProps={{ size: 'small' }}
-              />
-              <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 10 }}>
-                <Button
-                  type="text"
-                  size="small"
-                  icon={<SettingOutlined />}
-                  onClick={() => onSelect('settings_projectDirectories')}
-                  aria-label="管理工作空间"
-                >
-                  管理
-                </Button>
-              </div>
-            </div>
-          }
-        >
-          <Button
-            type="text"
-            className="ntd-left-rail-workspace-chip"
-            icon={<ApartmentOutlined />}
-            aria-label="切换工作空间"
-            data-testid="left-rail-workspace"
-          />
-        </Popover>
+        <WorkspaceSwitcher
+          value={workspace ?? null}
+          onChange={(next) => onWorkspaceChange?.(next)}
+          onManage={() => onSelect('settings_projectDirectories')}
+          mode="compact"
+        />
       </div>
     );
   };

--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { ReactNode } from 'react';
-import { Button, Tooltip } from 'antd';
+import { Button, Tooltip, Popover } from 'antd';
 import type { ButtonProps } from 'antd';
 import {
   InboxOutlined,
@@ -8,11 +8,25 @@ import {
   DashboardOutlined,
   ReadOutlined,
   SettingOutlined,
+  LaptopOutlined,
+  ThunderboltOutlined,
+  PlayCircleOutlined,
+  FolderOutlined,
   DoubleRightOutlined,
   DoubleLeftOutlined,
 } from '@ant-design/icons';
+import { WorkspaceSelect } from '@/components/common/WorkspaceSelect';
 
-export type LeftRailKey = 'inbox' | 'loops' | 'dashboard' | 'memorial' | 'settings';
+export type LeftRailKey =
+  | 'inbox'
+  | 'loops'
+  | 'dashboard'
+  | 'memorial'
+  | 'settings'
+  | 'settings_projectDirectories'
+  | 'settings_sessions'
+  | 'settings_skills'
+  | 'settings_runtime';
 
 interface LeftRailItem {
   key: LeftRailKey;
@@ -30,43 +44,47 @@ interface LeftRailProps {
   variant?: LeftRailVariant;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
+  workspace?: string | null;
+  onWorkspaceChange?: (workspace: string) => void;
 }
 
 /**
  * 左侧主导航栏。
  * 目标：为“中间列表 + 右侧工作区”补上一层全局导航，让用户能用更低成本在核心区域间切换。
  */
-export function LeftRail({ activeKey, onSelect, variant = 'rail', collapsed = true, onToggleCollapsed }: LeftRailProps) {
-  const items = useMemo<LeftRailItem[]>(() => ([
+export function LeftRail({
+  activeKey,
+  onSelect,
+  variant = 'rail',
+  collapsed = true,
+  onToggleCollapsed,
+  workspace,
+  onWorkspaceChange,
+}: LeftRailProps) {
+  const sections = useMemo(() => ([
     {
-      key: 'inbox',
-      label: '收件箱',
-      icon: <InboxOutlined />,
-      ariaLabel: '收件箱',
+      title: '收件箱',
+      items: [
+        { key: 'inbox', label: '收件箱', icon: <InboxOutlined />, ariaLabel: '收件箱' },
+        { key: 'loops', label: '环路', icon: <ApartmentOutlined />, ariaLabel: '环路' },
+      ] satisfies LeftRailItem[],
     },
     {
-      key: 'loops',
-      label: '环路',
-      icon: <ApartmentOutlined />,
-      ariaLabel: '环路',
+      title: '工作区',
+      items: [
+        { key: 'dashboard', label: '仪表盘', icon: <DashboardOutlined />, ariaLabel: '仪表盘' },
+        { key: 'memorial', label: '看板', icon: <ReadOutlined />, ariaLabel: '看板' },
+      ] satisfies LeftRailItem[],
     },
     {
-      key: 'dashboard',
-      label: '仪表盘',
-      icon: <DashboardOutlined />,
-      ariaLabel: '仪表盘',
-    },
-    {
-      key: 'memorial',
-      label: '看板',
-      icon: <ReadOutlined />,
-      ariaLabel: '看板',
-    },
-    {
-      key: 'settings',
-      label: '设置',
-      icon: <SettingOutlined />,
-      ariaLabel: '设置',
+      title: '配置',
+      items: [
+        { key: 'settings_runtime', label: '运行管理', icon: <PlayCircleOutlined />, ariaLabel: '运行管理' },
+        { key: 'settings_skills', label: 'Skills', icon: <ThunderboltOutlined />, ariaLabel: 'Skills' },
+        { key: 'settings_projectDirectories', label: '工作空间', icon: <FolderOutlined />, ariaLabel: '工作空间' },
+        { key: 'settings_sessions', label: '会话', icon: <LaptopOutlined />, ariaLabel: '会话' },
+        { key: 'settings', label: '设置', icon: <SettingOutlined />, ariaLabel: '设置' },
+      ] satisfies LeftRailItem[],
     },
   ]), []);
 
@@ -123,13 +141,101 @@ export function LeftRail({ activeKey, onSelect, variant = 'rail', collapsed = tr
     );
   };
 
+  const renderWorkspaceArea = () => {
+    if (isDrawer || shouldShowLabels) {
+      return (
+        <div className={isDrawer ? 'ntd-left-rail-drawer-workspace' : 'ntd-left-rail-workspace'}>
+          <div className="ntd-left-rail-workspace-label">工作空间</div>
+          <WorkspaceSelect
+            value={workspace ?? null}
+            required
+            onChange={(next) => {
+              if (!next) return;
+              onWorkspaceChange?.(next);
+            }}
+            selectProps={{ size: 'small' }}
+          />
+          <div className="ntd-left-rail-workspace-actions">
+            <Button
+              type="text"
+              size="small"
+              icon={<SettingOutlined />}
+              onClick={() => onSelect('settings_projectDirectories')}
+              aria-label="管理工作空间"
+              data-testid="left-rail-manage-workspaces"
+            >
+              管理
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="ntd-left-rail-workspace-collapsed">
+        <Popover
+          placement="rightTop"
+          trigger="click"
+          content={
+            <div style={{ width: 260, padding: 10 }}>
+              <div style={{ fontWeight: 600, marginBottom: 8 }}>工作空间</div>
+              <WorkspaceSelect
+                value={workspace ?? null}
+                required
+                onChange={(next) => {
+                  if (!next) return;
+                  onWorkspaceChange?.(next);
+                }}
+                selectProps={{ size: 'small' }}
+              />
+              <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 10 }}>
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<SettingOutlined />}
+                  onClick={() => onSelect('settings_projectDirectories')}
+                  aria-label="管理工作空间"
+                >
+                  管理
+                </Button>
+              </div>
+            </div>
+          }
+        >
+          <Button
+            type="text"
+            className="ntd-left-rail-workspace-chip"
+            icon={<ApartmentOutlined />}
+            aria-label="切换工作空间"
+            data-testid="left-rail-workspace"
+          />
+        </Popover>
+      </div>
+    );
+  };
+
   return (
     <div
       className={isDrawer ? 'ntd-left-rail-drawer' : `ntd-left-rail ${shouldShowLabels ? 'expanded' : 'collapsed'}`}
       data-testid="left-rail"
     >
+      {renderWorkspaceArea()}
+
       <div className={isDrawer ? 'ntd-left-rail-drawer-top' : 'ntd-left-rail-top'}>
-        {items.map(renderNavButton)}
+        {sections.map(section => (
+          <div key={section.title} className={isDrawer ? 'ntd-left-rail-drawer-section' : 'ntd-left-rail-section'}>
+            {shouldShowLabels && (
+              <div className={isDrawer ? 'ntd-left-rail-drawer-section-title' : 'ntd-left-rail-section-title'}>
+                {section.title}
+              </div>
+            )}
+            <div className={isDrawer ? 'ntd-left-rail-drawer-section-body' : 'ntd-left-rail-section-body'}>
+              {section.items
+                .filter(it => shouldShowLabels ? true : !String(it.key).startsWith('settings_'))
+                .map(renderNavButton)}
+            </div>
+          </div>
+        ))}
       </div>
 
       {!isDrawer && (

--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -8,6 +8,8 @@ import {
   DashboardOutlined,
   ReadOutlined,
   SettingOutlined,
+  DoubleRightOutlined,
+  DoubleLeftOutlined,
 } from '@ant-design/icons';
 
 export type LeftRailKey = 'inbox' | 'loops' | 'dashboard' | 'memorial' | 'settings';
@@ -26,13 +28,15 @@ interface LeftRailProps {
   activeKey: LeftRailKey;
   onSelect: (key: LeftRailKey) => void;
   variant?: LeftRailVariant;
+  collapsed?: boolean;
+  onToggleCollapsed?: () => void;
 }
 
 /**
  * 左侧主导航栏。
  * 目标：为“中间列表 + 右侧工作区”补上一层全局导航，让用户能用更低成本在核心区域间切换。
  */
-export function LeftRail({ activeKey, onSelect, variant = 'rail' }: LeftRailProps) {
+export function LeftRail({ activeKey, onSelect, variant = 'rail', collapsed = true, onToggleCollapsed }: LeftRailProps) {
   const items = useMemo<LeftRailItem[]>(() => ([
     {
       key: 'inbox',
@@ -67,6 +71,7 @@ export function LeftRail({ activeKey, onSelect, variant = 'rail' }: LeftRailProp
   ]), []);
 
   const isDrawer = variant === 'drawer';
+  const shouldShowLabels = isDrawer || !collapsed;
 
   /**
    * 渲染单个导航按钮。
@@ -91,29 +96,56 @@ export function LeftRail({ activeKey, onSelect, variant = 'rail' }: LeftRailProp
           {...commonProps}
           className={`${commonProps.className} ${isActive ? 'active' : ''}`}
         >
-          <span className="ntd-left-rail-drawer-label">{item.label}</span>
+          <span className="ntd-left-rail-drawer-label" data-testid={`left-rail-label-${item.key}`}>{item.label}</span>
         </Button>
       );
     }
 
+    if (!shouldShowLabels) {
+      return (
+        <Tooltip key={item.key} title={item.label} placement="right">
+          <Button
+            {...commonProps}
+            className={`${commonProps.className} ${isActive ? 'active' : ''}`}
+          />
+        </Tooltip>
+      );
+    }
+
     return (
-      <Tooltip key={item.key} title={item.label} placement="right">
-        <Button
-          {...commonProps}
-          className={`${commonProps.className} ${isActive ? 'active' : ''}`}
-        />
-      </Tooltip>
+      <Button
+        key={item.key}
+        {...commonProps}
+        className={`ntd-left-rail-expanded-btn ${isActive ? 'active' : ''}`}
+      >
+        <span className="ntd-left-rail-expanded-label" data-testid={`left-rail-label-${item.key}`}>{item.label}</span>
+      </Button>
     );
   };
 
   return (
     <div
-      className={isDrawer ? 'ntd-left-rail-drawer' : 'ntd-left-rail'}
+      className={isDrawer ? 'ntd-left-rail-drawer' : `ntd-left-rail ${shouldShowLabels ? 'expanded' : 'collapsed'}`}
       data-testid="left-rail"
     >
       <div className={isDrawer ? 'ntd-left-rail-drawer-top' : 'ntd-left-rail-top'}>
         {items.map(renderNavButton)}
       </div>
+
+      {!isDrawer && (
+        <div className="ntd-left-rail-bottom">
+          <Tooltip title={shouldShowLabels ? '收起导航' : '展开导航'} placement="right">
+            <Button
+              type="text"
+              className="ntd-left-rail-toggle"
+              icon={shouldShowLabels ? <DoubleLeftOutlined /> : <DoubleRightOutlined />}
+              onClick={onToggleCollapsed}
+              aria-label={shouldShowLabels ? '收起导航' : '展开导航'}
+              data-testid="left-rail-toggle"
+            />
+          </Tooltip>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -14,6 +14,8 @@ import {
   FolderOutlined,
   DoubleRightOutlined,
   DoubleLeftOutlined,
+  SunOutlined,
+  MoonOutlined,
 } from '@ant-design/icons';
 import { WorkspaceSwitcher } from './WorkspaceSwitcher';
 
@@ -46,6 +48,8 @@ interface LeftRailProps {
   onToggleCollapsed?: () => void;
   workspace?: string | null;
   onWorkspaceChange?: (workspace: string) => void;
+  themeMode: 'light' | 'dark';
+  toggleTheme: () => void;
 }
 
 /**
@@ -60,6 +64,8 @@ export function LeftRail({
   onToggleCollapsed,
   workspace,
   onWorkspaceChange,
+  themeMode,
+  toggleTheme,
 }: LeftRailProps) {
   const sections = useMemo(() => ([
     {
@@ -191,8 +197,37 @@ export function LeftRail({
         ))}
       </div>
 
+      {isDrawer && (
+        <div className="ntd-left-rail-drawer-bottom">
+          {/* 移动端抽屉底部：亮/暗色主题切换按钮 */}
+          <Button
+            type="text"
+            block
+            icon={themeMode === 'light' ? <MoonOutlined /> : <SunOutlined />}
+            onClick={toggleTheme}
+            className="ntd-left-rail-drawer-btn"
+            data-testid="left-rail-theme-toggle"
+          >
+            <span className="ntd-left-rail-drawer-label">
+              {themeMode === 'light' ? '暗色模式' : '亮色模式'}
+            </span>
+          </Button>
+        </div>
+      )}
+
       {!isDrawer && (
         <div className="ntd-left-rail-bottom">
+          {/* 亮/暗色主题切换按钮 — 当前为亮色显示太阳，暗色显示月亮，点击切换 */}
+          <Tooltip title={themeMode === 'light' ? '切换暗色' : '切换亮色'} placement="right">
+            <Button
+              type="text"
+              className="ntd-left-rail-theme-toggle"
+              icon={themeMode === 'light' ? <SunOutlined /> : <MoonOutlined />}
+              onClick={toggleTheme}
+              aria-label={themeMode === 'light' ? '切换暗色' : '切换亮色'}
+              data-testid="left-rail-theme-toggle"
+            />
+          </Tooltip>
           <Tooltip title={shouldShowLabels ? '收起导航' : '展开导航'} placement="right">
             <Button
               type="text"

--- a/frontend/src/components/shell/WorkspaceSwitcher.tsx
+++ b/frontend/src/components/shell/WorkspaceSwitcher.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useMemo, useState, useCallback } from 'react';
+import { Button, Dropdown, App } from 'antd';
+import type { MenuProps } from 'antd';
+import { ApartmentOutlined, FolderOpenOutlined, SettingOutlined, DownOutlined } from '@ant-design/icons';
+import * as db from '@/utils/database';
+import type { ProjectDirectory } from '@/types';
+
+export type WorkspaceSwitcherMode = 'full' | 'compact';
+
+interface WorkspaceSwitcherProps {
+  value: string | null;
+  onChange: (workspace: string) => void;
+  onManage: () => void;
+  mode?: WorkspaceSwitcherMode;
+}
+
+/**
+ * 工作空间切换器（旧版交互：Dropdown 列表 + “管理工作空间”）。
+ * 目标：保留你原来觉得“顺手”的选择方式，同时把入口搬到左侧导航顶部。
+ */
+export function WorkspaceSwitcher({ value, onChange, onManage, mode = 'full' }: WorkspaceSwitcherProps) {
+  const { message } = App.useApp();
+  const [dirs, setDirs] = useState<ProjectDirectory[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  /**
+   * 拉取工作空间目录列表。
+   * 失败时不阻塞页面，只给出轻提示，避免影响用户继续操作。
+   */
+  const loadDirs = useCallback(async () => {
+    setLoading(true);
+    try {
+      const list = await db.getProjectDirectories();
+      setDirs(list);
+    } catch (err) {
+      message.error(`加载工作空间失败: ${err instanceof Error ? err.message : '未知错误'}`);
+      setDirs([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [message]);
+
+  useEffect(() => {
+    loadDirs();
+  }, [loadDirs]);
+
+  useEffect(() => {
+    const handler = () => loadDirs();
+    window.addEventListener('projectDirectoryAdded', handler);
+    return () => window.removeEventListener('projectDirectoryAdded', handler);
+  }, [loadDirs]);
+
+  const selectedLabel = useMemo(() => {
+    if (!value) return '请选择工作空间';
+    const found = dirs.find(d => d.path === value);
+    return found?.name || value;
+  }, [dirs, value]);
+
+  const menuItems = useMemo<NonNullable<MenuProps['items']>>(() => {
+    const items: NonNullable<MenuProps['items']> = [
+      ...dirs.map(dir => ({
+        key: dir.path,
+        label: dir.name || dir.path,
+        icon: <FolderOpenOutlined />,
+      })),
+      { type: 'divider' as const },
+      {
+        key: '__manage__',
+        label: '管理工作空间',
+        icon: <SettingOutlined />,
+      },
+    ];
+    return items;
+  }, [dirs]);
+
+  const onMenuClick = useCallback<NonNullable<MenuProps['onClick']>>(({ key }) => {
+    if (key === '__manage__') {
+      onManage();
+      return;
+    }
+    onChange(String(key));
+  }, [onChange, onManage]);
+
+  if (mode === 'compact') {
+    return (
+      <Dropdown
+        menu={{ items: menuItems, onClick: onMenuClick }}
+        trigger={['click']}
+        placement="bottomLeft"
+      >
+        <Button
+          type="text"
+          className="ntd-workspace-switcher-compact"
+          icon={<ApartmentOutlined />}
+          loading={loading}
+          aria-label="切换工作空间"
+          data-testid="left-rail-workspace"
+        />
+      </Dropdown>
+    );
+  }
+
+  return (
+    <Dropdown
+      menu={{ items: menuItems, onClick: onMenuClick }}
+      trigger={['click']}
+      placement="bottomLeft"
+    >
+      <Button
+        type="text"
+        className="ntd-workspace-switcher"
+        loading={loading}
+        aria-label="切换工作空间"
+        data-testid="left-rail-workspace-switcher"
+      >
+        <span className="ntd-workspace-switcher-left">
+          <ApartmentOutlined style={{ color: 'var(--color-primary)' }} />
+          <span className="ntd-workspace-switcher-label" title={selectedLabel}>{selectedLabel}</span>
+        </span>
+        <span className="ntd-workspace-switcher-right">
+          <DownOutlined style={{ fontSize: 10, color: 'var(--color-text-tertiary)' }} />
+        </span>
+      </Button>
+    </Dropdown>
+  );
+}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -134,7 +134,10 @@ export const SIDEBAR_WIDTH = {
 } as const;
 
 /** 左侧主导航栏宽度（桌面端）。 */
-export const LEFT_RAIL_WIDTH = 72;
+export const LEFT_RAIL_WIDTH = {
+  collapsed: 72,
+  expanded: 240,
+} as const;
 
 /** 执行面板高度 */
 export const EXECUTION_PANEL = {

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -133,6 +133,9 @@ export const SIDEBAR_WIDTH = {
   mobile: '100%',
 } as const;
 
+/** 左侧主导航栏宽度（桌面端）。 */
+export const LEFT_RAIL_WIDTH = 72;
+
 /** 执行面板高度 */
 export const EXECUTION_PANEL = {
   /** 展开时高度。280px 能展示 3-4 条执行记录，过高会挤压上方 Todo 列表可视区。 */

--- a/frontend/src/hooks/useViewState.ts
+++ b/frontend/src/hooks/useViewState.ts
@@ -41,12 +41,15 @@ export function useViewState() {
   }, [activeView]);
 
   // Push URL helper — updates history without triggering popstate
-  const pushUrl = useCallback((view: string, todoId?: string | number | null) => {
+  const pushUrl = useCallback((view: string, todoId?: string | number | null, tab?: string | null) => {
     const params = new URLSearchParams();
     if (todoId) {
       params.set('todo', String(todoId));
     } else if (view !== 'dashboard') {
       params.set('view', view);
+      if (typeof tab === 'string' && tab.trim()) {
+        params.set('tab', tab);
+      }
     }
     const qs = params.toString();
     window.history.pushState(null, '', qs ? `/?${qs}` : '/');
@@ -76,12 +79,12 @@ export function useViewState() {
   }, []);
 
   // Navigate to a different view (clears todo selection)
-  const showView = useCallback((view: View) => {
+  const showView = useCallback((view: View, opts?: { tab?: string | null }) => {
     setActiveView(view);
     // On mobile, dashboard renders in the detail panel, so always show it
     const panel: Panel = view === 'dashboard' ? 'detail' : viewToPanel(view);
     setSelectedPanel(panel);
-    pushUrl(view);
+    pushUrl(view, null, opts?.tab ?? null);
   }, [pushUrl]);
 
   // Select a todo (opens detail panel, preserves current view)

--- a/frontend/src/hooks/useViewState.ts
+++ b/frontend/src/hooks/useViewState.ts
@@ -1,112 +1,150 @@
 /**
- * useViewState — URL-driven view navigation state.
+ * useViewState — 统一的 URL-driven 视图导航状态管理。
  *
- * Manages activeView (dashboard | settings | memorial | steps),
- * selectedPanel (list | detail), and browser history (pushState / popstate).
- * Decoupled from TodoContext so it can be tested / reused independently.
+ * URL 方案：
+ *   /?view=items&id=20        事项详情 #20
+ *   /?view=items               事项列表（默认，可省略 "?view=items" 以 / 表示）
+ *   /?view=loops&id=5         环路详情 #5
+ *   /?view=loops               环路列表
+ *   /?view=dashboard           仪表盘
+ *   /?view=settings&tab=system 设置-系统标签
+ *   /?view=memorial            看板
+ *   /?view=runtime             运行管理
+ *   /?view=skills              Skills
+ *   /?view=projectDirectories  工作空间
+ *   /?view=sessions            会话
+ *
+ * 只管理 URL + 派生的 React 状态，不持有 Todo/Loop 的 app 数据。
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 
-// 'steps' view 已移除（StepList 组件已删除），
-// 环节管理由 TodoList 的 step mode（listMode === 'step'）承担。
-// 'relation' view 已移除（关联图组件已删除）。
-export type View = 'dashboard' | 'settings' | 'memorial';
+export type View =
+  | 'items'
+  | 'loops'
+  | 'dashboard'
+  | 'settings'
+  | 'memorial'
+  | 'runtime'
+  | 'skills'
+  | 'projectDirectories'
+  | 'sessions';
+
 export type Panel = 'list' | 'detail';
 
-// 哪些 view 是合法的 URL 参数(popstate / 直接改 URL 都需要校验)
-const KNOWN_VIEWS: View[] = ['dashboard', 'settings', 'memorial'];
+const ALL_VIEWS: View[] = [
+  'items', 'loops',
+  'dashboard', 'settings', 'memorial',
+  'runtime', 'skills', 'projectDirectories', 'sessions',
+];
 
-// ─── Helpers ─────────────────────────────────────────────────
+// ─── URL 解析/构建 ─────────────────────────────────────────
 
 function getInitialView(): View {
-  const view = new URLSearchParams(window.location.search).get('view');
-  if (view && (KNOWN_VIEWS as string[]).includes(view)) return view as View;
-  return 'dashboard';
+  const view = new URLSearchParams(window.location.search).get('view') as View | null;
+  if (view && ALL_VIEWS.includes(view)) return view;
+  return 'items';
 }
 
-function viewToPanel(v: View): Panel {
-  return v === 'dashboard' ? 'list' : 'detail';
+function getInitialId(): number | null {
+  const id = new URLSearchParams(window.location.search).get('id');
+  if (!id) return null;
+  const n = Number(id);
+  return Number.isFinite(n) ? n : null;
 }
 
-// ─── Hook ────────────────────────────────────────────────────
+function getInitialTab(): string | null {
+  const tab = new URLSearchParams(window.location.search).get('tab');
+  return tab || null;
+}
+
+function buildUrl(view: View, opts?: { id?: number | null; tab?: string | null }): string {
+  const params = new URLSearchParams();
+  params.set('view', view);
+  if (opts?.id != null) params.set('id', String(opts.id));
+  if (typeof opts?.tab === 'string' && opts.tab.trim()) params.set('tab', opts.tab);
+  const qs = params.toString();
+  return qs ? `/?${qs}` : '/';
+}
+
+// ─── 左铁路键 ←→ View 映射 ───────────────────────────────
+// useViewState 不依赖 LeftRailKey，但提供映射方便 App.tsx 使用。
+
+const VIEW_TO_NAV_KEY: Record<View, string> = {
+  items: 'items',
+  loops: 'loops',
+  dashboard: 'dashboard',
+  memorial: 'memorial',
+  settings: 'settings',
+  runtime: 'settings_runtime',
+  skills: 'settings_skills',
+  projectDirectories: 'settings_projectDirectories',
+  sessions: 'settings_sessions',
+};
+
+export function viewToNavKey(view: View): string {
+  return VIEW_TO_NAV_KEY[view];
+}
+
+// ─── Hook ────────────────────────────────────────────────
 
 export function useViewState() {
   const [activeView, setActiveView] = useState<View>(getInitialView);
-  const [selectedPanel, setSelectedPanel] = useState<Panel>(() => viewToPanel(getInitialView()));
+  const [selectedId, setSelectedId] = useState<number | null>(getInitialId);
+  // tab 只用于 settings view，暴露给 SettingsPage 使用
+  const [activeTab, setActiveTab] = useState<string | null>(getInitialTab);
 
-  // Sync view → panel (when view changes externally e.g. popstate)
-  useEffect(() => {
-    setSelectedPanel(viewToPanel(activeView));
-  }, [activeView]);
-
-  // Push URL helper — updates history without triggering popstate
-  const pushUrl = useCallback((view: string, todoId?: string | number | null, tab?: string | null) => {
-    const params = new URLSearchParams();
-    if (todoId) {
-      params.set('todo', String(todoId));
-    } else if (view !== 'dashboard') {
-      params.set('view', view);
-      if (typeof tab === 'string' && tab.trim()) {
-        params.set('tab', tab);
-      }
-    }
-    const qs = params.toString();
-    window.history.pushState(null, '', qs ? `/?${qs}` : '/');
+  // 统一 push URL + React state
+  const pushUrl = useCallback((view: View, opts?: { id?: number | null; tab?: string | null }) => {
+    const url = buildUrl(view, opts);
+    window.history.pushState(null, '', url);
+    setActiveView(view);
+    setSelectedId(opts?.id ?? null);
+    setActiveTab(opts?.tab ?? null);
   }, []);
 
-  // Browser back/forward handler
+  // 统一 popstate 处理 — 替代了之前分散在 App.tsx / SettingsPage 的三个监听器
   useEffect(() => {
     const onPopState = () => {
       const params = new URLSearchParams(window.location.search);
-      const todoId = params.get('todo');
       const view = params.get('view') as View | null;
-
-      if (todoId) {
-        // Selecting a todo always opens detail panel
-        setSelectedPanel('detail');
-        if (view) setActiveView(view);
-      } else if (view && (KNOWN_VIEWS as string[]).includes(view)) {
-        setActiveView(view);
-        setSelectedPanel('detail');
-      } else {
-        setActiveView('dashboard');
-        setSelectedPanel('list');
-      }
+      const idStr = params.get('id');
+      const tab = params.get('tab');
+      const resolvedView = view && ALL_VIEWS.includes(view) ? view : 'items';
+      const resolvedId = idStr ? (Number.isFinite(Number(idStr)) ? Number(idStr) : null) : null;
+      setActiveView(resolvedView);
+      setSelectedId(resolvedId);
+      setActiveTab(tab || null);
     };
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
 
-  // Navigate to a different view (clears todo selection)
+  // showView: 导航到页面型视图（dashboard/settings/memorial），清空 id
   const showView = useCallback((view: View, opts?: { tab?: string | null }) => {
-    setActiveView(view);
-    // On mobile, dashboard renders in the detail panel, so always show it
-    const panel: Panel = view === 'dashboard' ? 'detail' : viewToPanel(view);
-    setSelectedPanel(panel);
-    pushUrl(view, null, opts?.tab ?? null);
+    pushUrl(view, { tab: opts?.tab ?? null });
   }, [pushUrl]);
 
-  // Select a todo (opens detail panel, preserves current view)
-  // Guard: callers pass Number(todoId) which returns NaN for invalid strings like "";
-  // we silently ignore NaN to avoid dispatching a SELECT_TODO with NaN.
+  // selectTodo: 向后兼容 RunningBoard / RunningRecordDrawer
+  // 导航到 items 视图 + 选中 todo
   const selectTodo = useCallback((todoId: number) => {
     if (!Number.isFinite(todoId)) return;
-    setSelectedPanel('detail');
-    pushUrl(activeView, todoId);
+    pushUrl('items', { id: todoId });
+  }, [pushUrl]);
+
+  // backToList: 回到当前视图的概览（清空 id），用于移动端返回按钮
+  const backToList = useCallback(() => {
+    pushUrl(activeView);
   }, [activeView, pushUrl]);
 
-  // Go back to the list panel (dashboard view)
-  const backToList = useCallback(() => {
-    setActiveView('dashboard');
-    setSelectedPanel('list');
-    pushUrl('dashboard');
-  }, [pushUrl]);
+  // selectedPanel 从 URL 派生：有 id 表示「详情」，否则为「列表」
+  const selectedPanel = useMemo<Panel>(() => (selectedId !== null ? 'detail' : 'list'), [selectedId]);
 
   return {
     activeView,
+    selectedId,
+    activeTab,
     selectedPanel,
-    setSelectedPanel,
     showView,
     selectTodo,
     backToList,

--- a/frontend/tests/left-rail-shell.spec.ts
+++ b/frontend/tests/left-rail-shell.spec.ts
@@ -10,10 +10,10 @@ test('左侧主导航渲染并支持切换到设置', async ({ page }) => {
   const rail = page.getByTestId('left-rail');
   await expect(rail).toBeVisible();
   await expect(page.getByTestId('left-rail-toggle')).toBeVisible();
-  await expect(page.getByTestId('left-rail-label-inbox')).toHaveCount(0);
+  await expect(page.getByTestId('left-rail-label-items')).toHaveCount(0);
 
   await page.getByTestId('left-rail-toggle').click();
-  await expect(page.getByTestId('left-rail-label-inbox')).toBeVisible();
+  await expect(page.getByTestId('left-rail-label-items')).toBeVisible();
 
   await page.getByTestId('left-rail-workspace-switcher').click();
   await page.getByText('管理工作空间').click();

--- a/frontend/tests/left-rail-shell.spec.ts
+++ b/frontend/tests/left-rail-shell.spec.ts
@@ -15,6 +15,6 @@ test('左侧主导航渲染并支持切换到设置', async ({ page }) => {
   await page.getByTestId('left-rail-toggle').click();
   await expect(page.getByTestId('left-rail-label-inbox')).toBeVisible();
 
-  await page.getByTestId('left-rail-settings').click();
-  await expect(page.getByText('系统设置')).toBeVisible();
+  await page.getByTestId('left-rail-manage-workspaces').click();
+  await expect(page.getByText('添加项目目录')).toBeVisible();
 });

--- a/frontend/tests/left-rail-shell.spec.ts
+++ b/frontend/tests/left-rail-shell.spec.ts
@@ -15,6 +15,7 @@ test('左侧主导航渲染并支持切换到设置', async ({ page }) => {
   await page.getByTestId('left-rail-toggle').click();
   await expect(page.getByTestId('left-rail-label-inbox')).toBeVisible();
 
-  await page.getByTestId('left-rail-manage-workspaces').click();
+  await page.getByTestId('left-rail-workspace-switcher').click();
+  await page.getByText('管理工作空间').click();
   await expect(page.getByText('添加项目目录')).toBeVisible();
 });

--- a/frontend/tests/left-rail-shell.spec.ts
+++ b/frontend/tests/left-rail-shell.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test('左侧主导航渲染并支持切换到设置', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto('/');
+
+  await expect(page.getByTestId('left-rail')).toBeVisible();
+
+  await page.getByTestId('left-rail-settings').click();
+  await expect(page.getByText('系统设置')).toBeVisible();
+});
+

--- a/frontend/tests/left-rail-shell.spec.ts
+++ b/frontend/tests/left-rail-shell.spec.ts
@@ -1,12 +1,20 @@
 import { test, expect } from '@playwright/test';
 
 test('左侧主导航渲染并支持切换到设置', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('ntd_left_rail_collapsed', 'true');
+  });
   await page.setViewportSize({ width: 1280, height: 720 });
   await page.goto('/');
 
-  await expect(page.getByTestId('left-rail')).toBeVisible();
+  const rail = page.getByTestId('left-rail');
+  await expect(rail).toBeVisible();
+  await expect(page.getByTestId('left-rail-toggle')).toBeVisible();
+  await expect(page.getByTestId('left-rail-label-inbox')).toHaveCount(0);
+
+  await page.getByTestId('left-rail-toggle').click();
+  await expect(page.getByTestId('left-rail-label-inbox')).toBeVisible();
 
   await page.getByTestId('left-rail-settings').click();
   await expect(page.getByText('系统设置')).toBeVisible();
 });
-


### PR DESCRIPTION
## 变更概要

### URL 方案统一为 `view` + `id` + `tab`

| URL | 含义 |
|---|---|
| `/?view=items&id=20` | 事项详情 #20 |
| `/?view=items` | 事项列表（默认）|
| `/?view=loops&id=5` | 环路详情 #5 |
| `/?view=loops` | 环路列表 |
| `/?view=dashboard` | 仪表盘 |
| `/?view=settings&tab=system` | 设置-系统标签 |
| `/?view=memorial` | 看板 |
| `/?view=runtime` | 运行管理 |
| `/?view=skills` | Skills |
| `/?view=projectDirectories` | 工作空间 |
| `/?view=sessions` | 会话 |

### 核心改动

1. **useViewState** — View 类型从 3 个值扩展到 9 个；`id` 统一取代 `todo` 和 `loop` 两个独立参数；三处 popstate 监听合并为一处；提供 `viewToNavKey` 映射

2. **App.tsx** — 移除 `activeNavKey` 状态（从 activeView 派生）；移除独立的 loop popstate 和 `settingsTabChanged` 监听；所有 pushState 调用改用统一的 `pushUrl`

3. **SettingsPage** — 移除独立 popstate 监听，改用 useViewState 的 activeTab

4. **TodoList** — auto-select 增加 `activeView` 守卫，防止用户导航离开后 auto-select 又把视图弹回（竞态修复）