### PR TITLE
fix(mobile): 统一手机端返回按钮到顶部菜单栏

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -273,9 +273,19 @@ function AppContent() {
 
   return (
     <Layout style={{ height: '100vh', flexDirection: isMobile ? 'column' : 'row' }}>
-      {/* Mobile Header with Hamburger Menu */}
+      {/* Mobile Header with Back Button + Hamburger Menu */}
       {isMobile && (
         <div className="mobile-header">
+          {selectedId !== null ? (
+            // 有选中项时显示返回按钮，回到列表视图
+            <button
+              className="mobile-header-menu-btn"
+              onClick={backToList}
+              aria-label="返回列表"
+            >
+              <LeftOutlined />
+            </button>
+          ) : null}
           <button
             className="mobile-header-menu-btn"
             onClick={() => setNavDrawerOpen(true)}
@@ -507,9 +517,9 @@ function AppContent() {
                 <SessionManager />
               </PageCard>
             ) : activeView === 'settings' ? (
-              <SettingsPage onBack={isMobile ? backToList : undefined} />
+              <SettingsPage />
             ) : activeView === 'memorial' ? (
-              <MemorialBoard onBack={isMobile ? backToList : undefined} />
+              <MemorialBoard />
             ) : activeView === 'items' ? (
               // 事项视图但未选中具体条目：展示空白区域
               <div />
@@ -533,7 +543,7 @@ function AppContent() {
                 }}
               />
             ) : (
-              <Dashboard onBack={isMobile ? backToList : undefined} />
+              <Dashboard />
             )}
           </div>
         </Content>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Card, Table, Badge, Tag, Empty, Masonry, App, Button } from 'antd';
+import { Card, Table, Badge, Tag, Empty, Masonry, App } from 'antd';
 import {
-  LeftOutlined,
   ThunderboltOutlined,
   DashboardOutlined,
 } from '@ant-design/icons';
@@ -27,7 +26,7 @@ import {
 } from './dashboard/ChartCards';
 import { ActiveTasksCard, LeaderboardCard, ShareCardPanel, TimeRangeSelector } from './dashboard/SpecialCards';
 
-export function Dashboard({ onBack }: { onBack?: () => void }) {
+export function Dashboard() {
   const { state } = useApp();
   const { message } = App.useApp();
   const { todos, tags, runningTasks } = state;
@@ -198,11 +197,6 @@ export function Dashboard({ onBack }: { onBack?: () => void }) {
     <PageCard
       icon={<DashboardOutlined />}
       title="仪表盘"
-      extra={
-        onBack ? (
-          <Button type="text" size="small" icon={<LeftOutlined />} onClick={onBack} aria-label="返回" />
-        ) : undefined
-      }
     >
       <div style={{ padding: '16px 20px', background: 'var(--color-bg-layout)' }}>
         <style>{`

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useState, useMemo } from 'react';
-import { Card, Segmented, Skeleton, Empty, Button, Input, Select } from 'antd';
+import { Card, Segmented, Skeleton, Empty, Input, Select } from 'antd';
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
-  LeftOutlined,
   AppstoreOutlined,
   ProfileOutlined,
   SearchOutlined,
@@ -32,16 +31,12 @@ const TIME_OPTIONS: { label: string; value: number }[] = [
   { label: '7d', value: 168 },
 ];
 
-interface MemorialBoardProps {
-  onBack?: () => void;
-}
-
 // 看板模式类型：支持四种视图切换。
 // 为什么新增 loop_kanban：环路执行历史需要独立视图，与 todo 维度的看板互补。
 // 设计取舍：复用同一个 Segmented 切换，避免多入口导航混乱。
 type BoardMode = 'memorial' | 'kanban' | 'running' | 'loop_kanban';
 
-export function MemorialBoard({ onBack }: MemorialBoardProps) {
+export function MemorialBoard() {
   const { state, dispatch } = useApp();
   const [boardMode, setBoardMode] = useState<BoardMode>('memorial');
   const [items, setItems] = useState<RecentCompletedTodo[]>([]);
@@ -366,15 +361,6 @@ export function MemorialBoard({ onBack }: MemorialBoardProps) {
       title="看板"
       extra={
         <>
-          {onBack && (
-            <Button
-              type="text"
-              size="small"
-              icon={<LeftOutlined />}
-              onClick={onBack}
-              aria-label="返回"
-            />
-          )}
           {/* 视图模式切换：四种视图平铺展示。
               为什么新增"环路看板"选项：
               - memorial：按完成时间聚合 todo 的执行结论，适合快速回顾成果

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import { Tabs, Form, Button, message } from 'antd';
+import { Tabs, Form, message } from 'antd';
 import {
   SettingOutlined,
   CodeOutlined,
@@ -7,7 +7,6 @@ import {
   SaveOutlined,
   FileTextOutlined,
   InfoCircleOutlined,
-  LeftOutlined,
   CloudOutlined,
 } from '@ant-design/icons';
 import { useApp } from '@/hooks/useApp';
@@ -24,12 +23,8 @@ import { CloudSyncPanel } from './settings/CloudSyncPanel';
 
 import { DEFAULT_EXECUTION_TIMEOUT_SECS } from '@/constants';
 
-interface SettingsPageProps {
-  onBack?: () => void;
-}
-
 /** 设置页，负责加载并保存系统配置以及各类管理面板。 */
-export function SettingsPage({ onBack }: SettingsPageProps) {
+export function SettingsPage() {
   const { state, dispatch } = useApp();
   const { tags } = state;
 
@@ -204,16 +199,6 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       }}
     >
       <div className="settings-header-card detail-card header-card">
-        {onBack && (
-          <Button
-            type="text"
-            size="small"
-            icon={<LeftOutlined />}
-            onClick={onBack}
-            className="settings-back-btn"
-            aria-label="返回"
-          />
-        )}
         <div style={{ minWidth: 0 }}>
           <h2 className="card-title">配置管理</h2>
         </div>

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -9,6 +9,7 @@ import {
   InfoCircleOutlined,
   CloudOutlined,
 } from '@ant-design/icons';
+import { PageCard } from '@/components/common/PageCard';
 import { useApp } from '@/hooks/useApp';
 import { useViewState } from '@/hooks/useViewState';
 import * as db from '@/utils/database';
@@ -191,18 +192,10 @@ export function SettingsPage() {
   }, [pushUrl]);
 
   return (
-    <div
-      className="settings-page-root detail-panel"
-      style={{
-        height: '100%',
-        overflowY: 'auto',
-      }}
+    <PageCard
+      icon={<SettingOutlined />}
+      title="配置管理"
     >
-      <div className="settings-header-card detail-card header-card">
-        <div style={{ minWidth: 0 }}>
-          <h2 className="card-title">配置管理</h2>
-        </div>
-      </div>
       <Tabs
         className="settings-tabs"
         items={tabItems}
@@ -212,6 +205,6 @@ export function SettingsPage() {
         activeKey={resolvedTab}
         onChange={handleTabChange}
       />
-    </div>
+    </PageCard>
   );
 }


### PR DESCRIPTION
## 改动说明

- 手机端顶部 Header 始终显示返回按钮（选中 id 时显示），位于汉堡菜单旁边
- 删除 Dashboard、SettingsPage、MemorialBoard 各自的 onBack prop 及页面内返回按钮
- SettingsPage 改为使用 PageCard 统一框架，与其他页面保持一致
- 返回逻辑由全局 mobile-header 统一处理，不占用页面内容区空间