### PR TITLE
fix(unify): 统一页面样式和交互风格

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { ConfigProvider, Layout, App as AntApp, Drawer, message, Form } from 'antd';
-import { PlusOutlined, ThunderboltOutlined, CloseOutlined, LeftOutlined, PlayCircleOutlined, LaptopOutlined, FolderOutlined, MenuOutlined } from '@ant-design/icons';
+import { PlusOutlined, ThunderboltOutlined, CloseOutlined, ArrowLeftOutlined, PlayCircleOutlined, LaptopOutlined, FolderOutlined, MenuOutlined } from '@ant-design/icons';
 import { AppProvider, useApp } from './hooks/useApp';
 import { useIsMobile } from './hooks/useIsMobile';
 import { useExecutionEvents } from './hooks/useExecutionEvents';
@@ -276,14 +276,14 @@ function AppContent() {
       {/* Mobile Header with Back Button + Hamburger Menu */}
       {isMobile && (
         <div className="mobile-header">
-          {selectedId !== null ? (
-            // 有选中项时显示返回按钮，回到列表视图
+          {activeView !== 'items' ? (
+            // 非事项视图时显示返回按钮，使用浏览器历史记录返回
             <button
               className="mobile-header-menu-btn"
-              onClick={backToList}
-              aria-label="返回列表"
+              onClick={() => window.history.back()}
+              aria-label="返回"
             >
-              <LeftOutlined />
+              <ArrowLeftOutlined />
             </button>
           ) : null}
           <button
@@ -430,22 +430,8 @@ function AppContent() {
               />
             ) : selectedLoopId !== null ? (
               // 从左侧环路列表选中某个 loop，右侧展示 LoopDetailPanel；
-              // 借用一个轻量容器提供 overflow:auto + 返回按钮。
+              // 借用一个轻量容器提供 overflow:auto。
               <div style={{ height: '100%', overflow: 'auto' }}>
-                {isMobile && (
-                  <div style={{ padding: '8px 12px', borderBottom: '1px solid var(--color-border, #e2e8f0)' }}>
-                    <button
-                      onClick={() => setSelectedLoopId(null)}
-                      style={{
-                        background: 'none', border: 'none', cursor: 'pointer',
-                        display: 'flex', alignItems: 'center', gap: 4,
-                        color: 'var(--color-text-secondary, #475569)', fontSize: 14,
-                      }}
-                    >
-                      <LeftOutlined /> 返回
-                    </button>
-                  </div>
-                )}
                 <LoopDetailPanel
                   loopId={selectedLoopId}
                   tags={state.tags}

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { Tabs, Form, message } from 'antd';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import {
   SettingOutlined,
   CodeOutlined,
@@ -28,6 +29,7 @@ import { DEFAULT_EXECUTION_TIMEOUT_SECS } from '@/constants';
 export function SettingsPage() {
   const { state, dispatch } = useApp();
   const { tags } = state;
+  const isMobile = useIsMobile();
 
   const [configForm] = Form.useForm();
   const [configLoading, setConfigLoading] = useState(false);
@@ -194,14 +196,14 @@ export function SettingsPage() {
   return (
     <PageCard
       icon={<SettingOutlined />}
-      title="配置管理"
+      title="设置"
     >
       <Tabs
         className="settings-tabs"
         items={tabItems}
         type="card"
         size="small"
-        tabPosition="left"
+        tabPosition={isMobile ? 'top' : 'left'}
         activeKey={resolvedTab}
         onChange={handleTabChange}
       />

--- a/frontend/src/components/SkillsPanel.tsx
+++ b/frontend/src/components/SkillsPanel.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
+import { Segmented } from 'antd';
 import {
   AppstoreOutlined, BarChartOutlined,
   SwapOutlined, ThunderboltOutlined,
 } from '@ant-design/icons';
 import type { ReactNode } from 'react';
+import { PageCard } from '@/components/common/PageCard';
 import { SkillsOverview } from './skills/SkillsOverview';
 import { SkillsComparison } from './skills/SkillsComparison';
 import { SkillSync } from './skills/SkillSync';
@@ -14,70 +16,30 @@ type SubView = 'overview' | 'compare' | 'sync' | 'tracking';
 export function SkillsPanel() {
   const [activeView, setActiveView] = useState<SubView>('overview');
 
-  const views: { key: SubView; label: string; icon: ReactNode }[] = [
-    { key: 'overview', label: '总览', icon: <AppstoreOutlined /> },
-    { key: 'compare', label: '对比分析', icon: <BarChartOutlined /> },
-    { key: 'sync', label: '同步管理', icon: <SwapOutlined /> },
-    { key: 'tracking', label: '调用追踪', icon: <ThunderboltOutlined /> },
+  const views: { label: ReactNode; value: SubView }[] = [
+    { label: <span><AppstoreOutlined /> 总览</span>, value: 'overview' },
+    { label: <span><BarChartOutlined /> 对比分析</span>, value: 'compare' },
+    { label: <span><SwapOutlined /> 同步管理</span>, value: 'sync' },
+    { label: <span><ThunderboltOutlined /> 调用追踪</span>, value: 'tracking' },
   ];
 
   return (
-    <div>
-      {/* Tab bar */}
-      <div
-        role="tablist"
-        aria-label="Skills 管理"
-        style={{
-          display: 'flex',
-          gap: 4,
-          marginBottom: 20,
-          borderBottom: '1px solid var(--color-border, #e2e8f0)',
-          paddingBottom: 0,
-        }}
-      >
-        {views.map(v => {
-          const isActive = activeView === v.key;
-          return (
-            <button
-              key={v.key}
-              role="tab"
-              aria-selected={isActive}
-              onClick={() => setActiveView(v.key)}
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 6,
-                padding: '10px 16px',
-                border: 'none',
-                borderBottom: `2px solid ${isActive ? 'var(--color-primary, #0891b2)' : 'transparent'}`,
-                background: 'transparent',
-                color: isActive
-                  ? 'var(--color-primary, #0891b2)'
-                  : 'var(--color-text-secondary, #a6adc8)',
-                cursor: 'pointer',
-                fontSize: 14,
-                fontWeight: isActive ? 500 : 400,
-                transition: 'all 0.2s',
-                marginBottom: -1,
-              }}
-              onMouseEnter={e => {
-                if (!isActive) e.currentTarget.style.color = 'var(--color-text, #cdd6f4)';
-              }}
-              onMouseLeave={e => {
-                if (!isActive) e.currentTarget.style.color = 'var(--color-text-secondary, #a6adc8)';
-              }}
-            >
-              {v.icon}
-              {v.label}
-            </button>
-          );
-        })}
-      </div>
-
+    <PageCard
+      icon={<ThunderboltOutlined />}
+      title="Skills"
+      extra={
+        <Segmented
+          size="small"
+          value={activeView}
+          onChange={value => setActiveView(value as SubView)}
+          options={views}
+        />
+      }
+    >
       {activeView === 'overview' && <SkillsOverview />}
       {activeView === 'compare' && <SkillsComparison />}
       {activeView === 'sync' && <SkillSync />}
       {activeView === 'tracking' && <SkillTracking />}
-    </div>
+    </PageCard>
   );
 }

--- a/frontend/src/components/settings/workspace/BotDetailPage.tsx
+++ b/frontend/src/components/settings/workspace/BotDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Card, Button, Switch, Input, Select, Tag, message, Modal, Typography, AutoComplete, Table } from 'antd';
-import { LeftOutlined, CopyOutlined } from '@ant-design/icons';
+import { ArrowLeftOutlined, CopyOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import type { AgentBot, FeishuPushStatus, WhitelistEntry, FeishuSenderItem } from '@/utils/database';
 import type { FeishuHistoryMessage, FeishuHistoryChat, ExecutionRecord } from '@/types';
@@ -189,7 +189,7 @@ export function BotDetailPage({ bot, onBack, onRefresh, autoShowHistory = false 
     <div className="bot-detail-page">
       {/* 头部：返回、名称、标签 */}
       <div className="detail-header" style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
-        <Button type="text" size="small" icon={<LeftOutlined />} onClick={onBack} className="back-btn" />
+        <Button type="text" size="small" icon={<ArrowLeftOutlined />} onClick={onBack} className="back-btn" />
         <h3 className="card-title" style={{ margin: 0 }}>{bot.bot_name}</h3>
         <Tag color={bot.enabled ? 'green' : 'default'}>
           {bot.enabled ? '已启用' : '已禁用'}

--- a/frontend/src/components/settings/workspace/WorkspaceDetailPage.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Tabs, Select, Button } from 'antd';
-import { LeftOutlined, RobotOutlined, SettingOutlined } from '@ant-design/icons';
+import { ArrowLeftOutlined, RobotOutlined, SettingOutlined } from '@ant-design/icons';
 import type { ProjectDirectory } from '@/utils/database';
 import { WorkspaceAgentPanel } from './WorkspaceAgentPanel';
 import { WorkspaceSlashCommandsPanel } from './WorkspaceSlashCommandsPanel';
@@ -39,7 +39,7 @@ export function WorkspaceDetailPage({ workspace, onBack }: WorkspaceDetailPagePr
         <Button
           type="text"
           size="small"
-          icon={<LeftOutlined />}
+          icon={<ArrowLeftOutlined />}
           onClick={onBack}
           className="back-btn"
         />


### PR DESCRIPTION
- SkillsPanel: 添加 PageCard 包装，使用 Segmented 替换自定义 tab bar
- 返回图标统一为 ArrowLeftOutlined（App.tsx, BotDetailPage, WorkspaceDetailPage）
- 手机端返回按钮逻辑改为 activeView !== 'items'，始终在非事项视图显示
- SettingsPage 标题从"配置管理"改为"设置"，与左侧导航一致
- SettingsPage Tabs 手机端改为 tabPosition='top' 适配
- 移除 LoopDetailPanel 内联返回按钮（顶部 Header 已统一处理）
- 所有 PageCard 包裹的页面现在风格统一
