### PR TITLE
fix(unify): 统一交互细节

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,7 +33,7 @@ const { Content } = Layout;
 
 function AppContent() {
   const { state, dispatch, clearSelection } = useApp();
-  const { activeView, selectedId, selectedPanel, showView, backToList, pushUrl } = useViewState();
+  const { activeView, selectedId, selectedPanel, showView, pushUrl } = useViewState();
   const { themeMode, toggleTheme } = useTheme();
 
   const [todoModalOpen, setTodoModalOpen] = useState(false);
@@ -426,9 +426,7 @@ function AppContent() {
             }}
           >
             {state.selectedTodoId ? (
-              <TodoDetail
-                onBack={isMobile ? backToList : undefined}
-              />
+              <TodoDetail />
             ) : selectedLoopId !== null ? (
               // 从左侧环路列表选中某个 loop，右侧展示 LoopDetailPanel；
               // 借用一个轻量容器提供 overflow:auto。

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -70,6 +70,11 @@ function AppContent() {
     ? 'detail'
     : selectedPanel;
 
+  // 切换视图或面板时收起 FAB，避免遗留
+  useEffect(() => {
+    setFabExpanded(false);
+  }, [effectiveMobilePanel]);
+
   const [panelCollapsed, setPanelCollapsed] = useState(() => {
     try {
       return localStorage.getItem('execution_panel_collapsed') === 'true';
@@ -174,11 +179,10 @@ function AppContent() {
   // 从左侧环路列表选中一个 loop，在右侧展示 LoopDetailPanel
   const handleSelectLoop = useCallback((loopId: number) => {
     // 清除 todo 选择，避免 state.selectedTodoId 抢占右侧面板
-    dispatch({ type: 'SELECT_TODO', payload: null });
     clearSelection();
     setSelectedLoopId(loopId);
     pushUrl('loops', { id: loopId });
-  }, [dispatch, clearSelection, pushUrl]);
+  }, [clearSelection, pushUrl]);
 
   const handleSmartCreateSubmitted = () => {
     db.getAllTodos().then(todos => {
@@ -198,10 +202,9 @@ function AppContent() {
 
   const showSettings = useCallback((tab: string | null) => {
     setSelectedLoopId(null);
-    dispatch({ type: 'SELECT_TODO', payload: null });
     clearSelection();
     showView('settings', { tab });
-  }, [clearSelection, dispatch, showView]);
+  }, [clearSelection, showView]);
 
   /**
    * 切换到独立的配置管理页面（运行管理 / Skills / 工作空间 / 会话）。
@@ -209,10 +212,9 @@ function AppContent() {
    */
   const showStandaloneSettingsPanel = useCallback((view: View) => {
     setSelectedLoopId(null);
-    dispatch({ type: 'SELECT_TODO', payload: null });
     clearSelection();
     pushUrl(view);
-  }, [clearSelection, dispatch, pushUrl]);
+  }, [clearSelection, pushUrl]);
 
   /**
    * 切换到“事项/环路”这类列表型入口。
@@ -222,11 +224,10 @@ function AppContent() {
   const showListSection = useCallback((mode: 'item' | 'loop') => {
     // 先清除旧选择，再设置新的列表模式
     setSelectedLoopId(null);
-    dispatch({ type: 'SELECT_TODO', payload: null });
     clearSelection();
     setForcedListMode(mode);
     pushUrl(mode === 'loop' ? 'loops' : 'items');
-  }, [pushUrl, clearSelection, dispatch]);
+  }, [pushUrl, clearSelection]);
 
   /**
    * 左侧主导航点击处理（桌面侧栏/移动抽屉共用）。

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -18,11 +18,10 @@ import { DetailHeader } from './todo-detail/DetailHeader';
 import { HistoryList } from './todo-detail/HistoryList';
 import { RecordDetailView } from './todo-detail/RecordDetailView';
 
-export function TodoDetail({ onBack }: { onBack?: () => void }) {
+export function TodoDetail() {
   const { state, dispatch } = useApp();
   const { message } = App.useApp();
   const { todos, selectedTodoId, executionRecords, runningTasks } = state;
-  const isMobile = useIsMobile();
   const isWide = !useIsMobile(BREAKPOINTS.wide);
   const [viewMode, setViewMode] = useState<'log' | 'chat' | 'command'>('log');
   const selectedTodo = todos.find(t => t.id === selectedTodoId);
@@ -286,14 +285,6 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
     }
   };
 
-  const handleMobileBack = () => {
-    if (onBack) {
-      onBack();
-    } else {
-      dispatch({ type: 'SELECT_TODO', payload: null });
-    }
-  };
-
   if (!selectedTodo) {
     return (
       <div className="detail-panel" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -340,11 +331,9 @@ export function TodoDetail({ onBack }: { onBack?: () => void }) {
         selectedTodo={selectedTodo}
         executor={executor}
         isExecuting={isExecuting}
-        isMobile={isMobile}
         summary={summary}
         currentTodoProgress={currentTodoProgress}
         records={records}
-        onMobileBack={handleMobileBack}
         onDelete={handleDelete}
         onTodoDrawerOpen={() => setTodoDrawerOpen(true)}
         onOpenExecuteWithArgs={handleOpenExecuteWithArgs}

--- a/frontend/src/components/settings/workspace/WorkspaceDetailPage.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceDetailPage.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Tabs, Select, Button } from 'antd';
 import { ArrowLeftOutlined, RobotOutlined, SettingOutlined } from '@ant-design/icons';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import type { ProjectDirectory } from '@/utils/database';
 import { WorkspaceAgentPanel } from './WorkspaceAgentPanel';
 import { WorkspaceSlashCommandsPanel } from './WorkspaceSlashCommandsPanel';
@@ -21,17 +22,7 @@ const TAB_OPTIONS = [
 
 export function WorkspaceDetailPage({ workspace, onBack }: WorkspaceDetailPageProps) {
   const [activeTab, setActiveTab] = useState<TabKey>('agents');
-  const [isMobile, setIsMobile] = useState(false);
-
-  // 检测手机端：屏幕宽度 < 768px
-  useEffect(() => {
-    const checkMobile = () => {
-      setIsMobile(window.innerWidth < 768);
-    };
-    checkMobile();
-    window.addEventListener('resize', checkMobile);
-    return () => window.removeEventListener('resize', checkMobile);
-  }, []);
+  const isMobile = useIsMobile();
 
   return (
     <div className="workspace-detail-page">

--- a/frontend/src/components/todo-detail/DetailHeader.tsx
+++ b/frontend/src/components/todo-detail/DetailHeader.tsx
@@ -1,5 +1,5 @@
 import { Button, Tag, Badge, Popconfirm, App } from 'antd';
-import { PlayCircleOutlined, ThunderboltOutlined, EditOutlined, DeleteOutlined, ArrowLeftOutlined, CopyOutlined } from '@ant-design/icons';
+import { PlayCircleOutlined, ThunderboltOutlined, EditOutlined, DeleteOutlined, CopyOutlined } from '@ant-design/icons';
 import { StatusPicker } from '@/components/StatusPicker';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { PromptDisplay } from './PromptDisplay';
@@ -11,17 +11,15 @@ import type { ExecutionSummary, ExecutionRecord } from '@/types';
 import type { Todo } from '@/types';
 
 export function DetailHeader({
-  selectedTodo, executor, isExecuting, isMobile, summary, currentTodoProgress,
-  records, onMobileBack, onDelete, onTodoDrawerOpen, onOpenExecuteWithArgs, onExecute, onStatusChange,
+  selectedTodo, executor, isExecuting, summary, currentTodoProgress,
+  records, onDelete, onTodoDrawerOpen, onOpenExecuteWithArgs, onExecute, onStatusChange,
 }: {
   selectedTodo: Todo;
   executor: string;
   isExecuting: boolean;
-  isMobile: boolean;
   summary: ExecutionSummary | null;
   currentTodoProgress: any;
   records: ExecutionRecord[];
-  onMobileBack: () => void;
   onDelete: () => Promise<void>;
   onTodoDrawerOpen: () => void;
   onOpenExecuteWithArgs: () => void;
@@ -33,16 +31,6 @@ export function DetailHeader({
 
   return (
     <>
-      {isMobile && (
-        <Button
-          type="text"
-          icon={<ArrowLeftOutlined />}
-          onClick={onMobileBack}
-          style={{ marginBottom: 8, marginLeft: -4 }}
-        >
-          返回
-        </Button>
-      )}
       <div className="detail-card header-card">
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
           <StatusPicker value={selectedTodo.status} onChange={onStatusChange} disabled={isExecuting} />


### PR DESCRIPTION
- Issue #7: WorkspaceDetailPage 手机检测改用 useIsMobile hook，移除手写 resize 逻辑
- Issue #12: 移除导航 helper 中与 clearSelection 重复的 dispatch 调用，简化代码
- Issue #17: FAB 切换视图后自动收起，避免界面遗留
