### PR TITLE
fix: constrain loop view overflow

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2642,6 +2642,7 @@ code {
   height: 100%;
   display: flex;
   flex-direction: column;
+  min-width: 0;
   overflow: hidden;
 }
 
@@ -2705,11 +2706,54 @@ code {
 /* ——— Masonry Layout ——— */
 .memorial-grid {
   flex: 1;
+  min-width: 0;
   overflow-y: auto;
   padding: var(--space-md) var(--space-lg);
   display: flex;
   gap: var(--space-md);
   align-items: start;
+}
+
+.loop-kanban-board {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.loop-kanban-columns-container {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  gap: 12px;
+  padding: 12px 16px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  align-items: flex-start;
+}
+
+.loop-kanban-columns-container::-webkit-scrollbar {
+  height: 6px;
+}
+
+.loop-kanban-columns-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.loop-kanban-columns-container::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: 3px;
+}
+
+.loop-kanban-column {
+  min-height: 0;
+}
+
+.loop-kanban-column-body {
+  min-height: 0;
 }
 
 /* ——— Column ——— */
@@ -4342,6 +4386,7 @@ code {
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-width: 0;
   overflow: hidden;
 }
 
@@ -4349,15 +4394,18 @@ code {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
   padding: 16px 20px;
   min-height: 56px;
   flex-shrink: 0;
+  min-width: 0;
 }
 
 .ntd-page-card-title {
   display: flex;
   align-items: center;
   gap: 10px;
+  min-width: 0;
 }
 
 .ntd-page-card-icon {
@@ -4371,12 +4419,16 @@ code {
   font-size: 16px;
   font-weight: 600;
   color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ntd-page-card-extra {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
 }
 
 .ntd-page-card-divider {
@@ -4387,6 +4439,8 @@ code {
 
 .ntd-page-card-content {
   flex: 1;
+  min-width: 0;
+  min-height: 0;
   overflow: auto;
   padding: 0;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -368,9 +368,20 @@ function AppContent() {
         </div>
       )}
 
-      <Layout>
+      <Layout
+        style={{
+          // 右侧主区域在外层横向布局里必须允许收缩，
+          // 否则内部超宽内容会把这一整列 Layout 撑宽到视口外。
+          flex: 1,
+          minWidth: 0,
+        }}
+      >
         <Content
           style={{
+            // Content 也要显式参与剩余空间分配，
+            // 避免按内容宽度自适应时把整个页面主区域撑宽。
+            flex: 1,
+            minWidth: 0,
             display: 'flex',
             flexDirection: isMobile ? 'column' : 'row',
             padding: isMobile ? 0 : 12,
@@ -419,6 +430,9 @@ function AppContent() {
             className={(!isMobile || effectiveMobilePanel === 'detail') ? 'animate-slide-in-right' : ''}
             style={{
               flex: 1,
+              // 允许右侧工作区在 flex 布局中收缩到可视区宽度内，
+              // 避免内部横向内容把整个页面主容器反向撑宽。
+              minWidth: 0,
               height: '100%',
               overflow: 'hidden',
               display: !isMobile || effectiveMobilePanel === 'detail' ? 'block' : 'none',

--- a/frontend/src/components/LoopKanban.tsx
+++ b/frontend/src/components/LoopKanban.tsx
@@ -229,6 +229,7 @@ function KanbanColumn({ col, items, renderCard }: KanbanColumnProps) {
         flex: 1,
         display: 'flex',
         flexDirection: 'column',
+        minHeight: 0,
       }}
     >
       <ColumnHeader col={col} count={items.length} />
@@ -277,7 +278,7 @@ function ColumnHeader({ col, count }: { col: ColumnDef; count: number }) {
 // 为什么独立：body 的滚动容器逻辑与 header 独立，方便后续增加虚拟滚动优化。
 function ColumnBody({ items, renderCard }: { items: LoopExecutionWithLoopName[]; renderCard: (exec: LoopExecutionWithLoopName) => React.ReactNode }) {
   return (
-    <div className="loop-kanban-column-body" style={{ flex: 1, overflowY: 'auto', padding: '0 4px' }}>
+    <div className="loop-kanban-column-body" style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '0 4px' }}>
       {items.length === 0 ? (
         <div style={{ textAlign: 'center', padding: '20px 0', color: 'var(--color-text-tertiary)', fontSize: 12 }}>
           暂无
@@ -496,17 +497,13 @@ export function LoopKanban({ searchText: externalSearch, hours: externalHours, o
       ) : filtered.length === 0 ? (
         <Empty description="暂无环路执行记录" style={{ padding: 60 }} />
       ) : (
-        <div
-          style={{
-            display: 'flex',
-            gap: 12,
-            padding: '12px 16px',
-            overflowX: 'auto',
-            alignItems: 'flex-start',
-          }}
-        >
+        <>
+          {/* 让超宽只发生在看板内部，而不是把外层 PageCard / App 主视图撑宽。
+              这样切换到环路视图时，顶部视图切换按钮仍然留在屏幕内。 */}
+          <div className="loop-kanban-columns-container">
           {COLUMNS.map(renderColumn)}
-        </div>
+          </div>
+        </>
       )}
 
       {/* 执行轨迹侧边栏：点击卡片时打开，上方展示该环路的环节设计流程图，

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -15,7 +15,7 @@ import { PageCard } from '@/components/common/PageCard';
 import { useApp } from '@/hooks/useApp';
 import { KanbanBoard } from './KanbanBoard';
 import { RunningBoard } from './RunningBoard';
-// 引入环路看板组件：与 KanbanBoard（todo 看板）、RunningBoard（运行视图）并列，
+// 引入环路视图组件：与 KanbanBoard（todo 看板）、RunningBoard（运行视图）并列，
 // 为什么需要：提供环路维度的执行历史聚合视图，补齐 todo 维度之外的监控缺口。
 import { LoopKanban } from './LoopKanban';
 import { TodoCard } from './TodoCard';
@@ -362,7 +362,7 @@ export function MemorialBoard() {
       extra={
         <>
           {/* 视图模式切换：四种视图平铺展示。
-              为什么新增"环路看板"选项：
+              为什么新增"环路视图"选项：
               - memorial：按完成时间聚合 todo 的执行结论，适合快速回顾成果
               - kanban：todo 维度的状态流转看板（待办/进行中/已完成/失败）
               - running：实时运行状态监控
@@ -377,7 +377,7 @@ export function MemorialBoard() {
               { label: <span><ProfileOutlined /> 结论视图</span>, value: 'memorial' },
               { label: <span><AppstoreOutlined /> 看板视图</span>, value: 'kanban' },
               { label: <span><ThunderboltOutlined /> 运行视图</span>, value: 'running' },
-              { label: <span><SyncOutlined /> 环路看板</span>, value: 'loop_kanban' },
+              { label: <span><SyncOutlined /> 环路视图</span>, value: 'loop_kanban' },
             ]}
           />
         </>

--- a/frontend/tests/check_loop_kanban_layout.spec.ts
+++ b/frontend/tests/check_loop_kanban_layout.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * 验证环路视图的超宽内容只在卡片内部横向滚动。
+ *
+ * 这个用例专门防回归以下问题：
+ * - 切到“环路视图”后，整页被看板列撑宽，导致页面主视图横向跳动
+ * - 顶部四个视图切换按钮被整体挤出屏幕外
+ * - 期望行为是页面主容器保持在视口内，只有看板列区域自己横向滚动
+ */
+test('环路视图仅在内容区横向滚动', async ({ page }) => {
+  await page.goto('http://localhost:18088');
+  await page.waitForLoadState('networkidle');
+
+  const boardNav = page.locator('[aria-label="看板"]');
+  await expect(boardNav).toBeVisible({ timeout: 5000 });
+  await boardNav.click();
+
+  const boardTitle = page.getByText('看板').first();
+  await expect(boardTitle).toBeVisible({ timeout: 5000 });
+
+  const loopKanbanOption = page.getByText('环路视图');
+  await expect(loopKanbanOption).toBeVisible({ timeout: 5000 });
+  await loopKanbanOption.click();
+
+  await page.waitForLoadState('networkidle');
+
+  const layoutMetrics = await page.evaluate(() => {
+    const html = document.documentElement;
+    const body = document.body;
+    const pageCard = document.querySelector('.ntd-page-card') as HTMLElement | null;
+    const pageCardExtra = document.querySelector('.ntd-page-card-extra') as HTMLElement | null;
+    const columnsContainer = document.querySelector('.loop-kanban-columns-container') as HTMLElement | null;
+
+    return {
+      viewportWidth: window.innerWidth,
+      htmlScrollWidth: html.scrollWidth,
+      bodyScrollWidth: body.scrollWidth,
+      pageCardScrollWidth: pageCard?.scrollWidth ?? 0,
+      pageCardExtraRight: pageCardExtra?.getBoundingClientRect().right ?? 0,
+      hasColumnsContainer: Boolean(columnsContainer),
+      columnsClientWidth: columnsContainer?.clientWidth ?? 0,
+      columnsScrollWidth: columnsContainer?.scrollWidth ?? 0,
+      columnsRight: columnsContainer?.getBoundingClientRect().right ?? 0,
+    };
+  });
+
+  expect(layoutMetrics.htmlScrollWidth).toBeLessThanOrEqual(layoutMetrics.viewportWidth + 2);
+  expect(layoutMetrics.bodyScrollWidth).toBeLessThanOrEqual(layoutMetrics.viewportWidth + 2);
+  expect(layoutMetrics.pageCardScrollWidth).toBeLessThanOrEqual(layoutMetrics.viewportWidth + 2);
+  expect(layoutMetrics.pageCardExtraRight).toBeLessThanOrEqual(layoutMetrics.viewportWidth + 2);
+
+  if (layoutMetrics.hasColumnsContainer) {
+    expect(layoutMetrics.columnsRight).toBeLessThanOrEqual(layoutMetrics.viewportWidth + 2);
+    expect(layoutMetrics.columnsScrollWidth).toBeGreaterThanOrEqual(layoutMetrics.columnsClientWidth);
+  }
+});

--- a/frontend/tests/loop-kanban.spec.ts
+++ b/frontend/tests/loop-kanban.spec.ts
@@ -1,8 +1,8 @@
-// 环路看板功能测试。
+// 环路视图功能测试。
 //
-// 设计意图：验证环路看板的视图切换、工具栏渲染、搜索与时间过滤等核心功能。
+// 设计意图：验证环路视图的视图切换、工具栏渲染、搜索与时间过滤等核心功能。
 // 为什么需要这套测试：
-// - 环路看板是新增视图，需要确保与已有 memorial/kanban/running 视图的切换链路正常
+// - 环路视图是新增视图，需要确保与已有 memorial/kanban/running 视图的切换链路正常
 // - 搜索和时间过滤是跨视图共享状态，需要验证受控组件模式下的数据流正确性
 // - 看板组件的加载、空状态、列渲染有多条分支，需要覆盖边界条件避免回归
 // 边界条件：
@@ -12,7 +12,7 @@
 
 import { test, expect } from '@playwright/test';
 
-test.describe('环路看板功能测试', () => {
+test.describe('环路视图功能测试', () => {
 
   // 为什么在 beforeEach 中导航到看板页：
   // - 所有测试用例的前置条件是进入 MemorialBoard，抽成 hook 避免重复代码
@@ -46,12 +46,12 @@ test.describe('环路看板功能测试', () => {
     await expect(options).toHaveCount(4);
   });
 
-  // 测试切换到环路看板视图的交互流程（核心功能路径）。
-  // 为什么需要：环路看板是新增功能，必须验证从 memorial 切换过去的完整链路。
+  // 测试切换到环路视图的交互流程（核心功能路径）。
+  // 为什么需要：环路视图是新增功能，必须验证从 memorial 切换过去的完整链路。
   test('test_switch_to_loop_kanban_view', async ({ page }) => {
-    // 为什么用 getByText 定位"环路看板"：文本内容比 nth(3) 更明确表达意图，
+    // 为什么用文本定位"环路视图"：文本内容比 nth(3) 更明确表达意图，
     // 且当选项顺序调整时不会误点到其他视图。
-    const loopKanbanOption = page.getByRole('radio', { name: /环路看板/ });
+    const loopKanbanOption = page.getByText('环路视图');
     await expect(loopKanbanOption).toBeVisible({ timeout: 5000 });
     await loopKanbanOption.click();
 
@@ -61,11 +61,11 @@ test.describe('环路看板功能测试', () => {
     await expect(searchInput).toBeVisible({ timeout: 5000 });
   });
 
-  // 测试环路看板的核心 UI 元素渲染（工具栏 + 看板主体或空状态）。
+  // 测试环路视图的核心 UI 元素渲染（工具栏 + 看板主体或空状态）。
   // 为什么需要：覆盖加载态、空态、正常态三种分支，确保 UI 不会白屏或卡死。
   test('test_loop_kanban_renders_board_or_empty_state', async ({ page }) => {
     // 为什么先切换视图：前置条件，确保测试的是 loop_kanban 模式
-    const loopKanbanOption = page.getByRole('radio', { name: /环路看板/ });
+    const loopKanbanOption = page.getByText('环路视图');
     await loopKanbanOption.click();
 
     // 为什么验证工具栏：工具栏是 LoopKanban 的固定部分，无论有无数据都应渲染
@@ -90,7 +90,7 @@ test.describe('环路看板功能测试', () => {
   // 测试时间过滤功能（边界条件：切换选项后数据重新过滤）。
   // 为什么需要：时间过滤是跨视图共享状态，loop_kanban 需验证 onHoursChange 回调正确触发。
   test('test_loop_kanban_time_filter', async ({ page }) => {
-    const loopKanbanOption = page.getByRole('radio', { name: /环路看板/ });
+    const loopKanbanOption = page.getByText('环路视图');
     await loopKanbanOption.click();
 
     // 为什么先等工具栏可见：确保组件已挂载，避免点击时元素未渲染
@@ -111,7 +111,7 @@ test.describe('环路看板功能测试', () => {
   // 测试搜索功能（边界条件：输入 -> 清空 -> 数据恢复）。
   // 为什么需要：搜索框是受控组件，需验证 onChange 回调正确触发且清空后状态重置。
   test('test_loop_kanban_search', async ({ page }) => {
-    const loopKanbanOption = page.getByRole('radio', { name: /环路看板/ });
+    const loopKanbanOption = page.getByText('环路视图');
     await loopKanbanOption.click();
 
     // 为什么用 getByPlaceholder：搜索框的语义化定位，比 class 或 nth() 更明确


### PR DESCRIPTION
## 变更说明
- 修复环路视图内容把整个页面撑宽的问题
- 将横向滚动限制在环路视图内容区内
- 将界面文案“环路看板”改为“环路视图”
- 补充对应的 Playwright 回归测试

## 验证
- cd frontend && npx playwright test tests/check_loop_kanban_layout.spec.ts --reporter=list