### PR TITLE
fix(ui): 统一左侧菜单与页面card的图标

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,7 +32,7 @@ const { Content } = Layout;
 
 function AppContent() {
   const { state, dispatch, clearSelection } = useApp();
-  const { activeView, selectedId, selectedPanel, showView, pushUrl } = useViewState();
+  const { activeView, selectedId, activePanel, showView, pushUrl, replaceUrl, backToList } = useViewState();
   const { themeMode, toggleTheme } = useTheme();
 
   const [todoModalOpen, setTodoModalOpen] = useState(false);
@@ -63,11 +63,12 @@ function AppContent() {
   }, [activeView]);
   const isMobile = useIsMobile();
 
-  // 手机端有效面板：items/loops 视图使用 selectedPanel（基于 id 判断），
-  // 其他视图（dashboard/memorial/settings 等）始终显示 detail 面板
+  // 手机端有效面板：
+  // - items/loops 视图：使用 activePanel（来自 URL，支持 list/detail 独立页面）
+  // - 其他视图（dashboard/memorial/settings 等）：始终显示 detail（全屏页面）
   const effectiveMobilePanel = isMobile && activeView !== 'items' && activeView !== 'loops'
     ? 'detail'
-    : selectedPanel;
+    : activePanel;
 
   // 切换视图或面板时收起 FAB，避免遗留
   useEffect(() => {
@@ -147,7 +148,8 @@ function AppContent() {
       // 选中 todo 时清除 loop 选择，避免右侧面板显示冲突
       setSelectedLoopId(null);
       dispatch({ type: 'SELECT_TODO', payload: Number(todoId) });
-      pushUrl('items', { id: Number(todoId) });
+      // 使用 replaceUrl + panel=detail：移动端 list→detail 切换不产生历史记录
+      replaceUrl('items', { id: Number(todoId), panel: 'detail' });
     }
   };
 
@@ -156,8 +158,9 @@ function AppContent() {
     // 清除 todo 选择，避免 state.selectedTodoId 抢占右侧面板
     clearSelection();
     setSelectedLoopId(loopId);
-    pushUrl('loops', { id: loopId });
-  }, [clearSelection, pushUrl]);
+    // 使用 replaceUrl + panel=detail：移动端 list→detail 切换不产生历史记录
+    replaceUrl('loops', { id: loopId, panel: 'detail' });
+  }, [clearSelection, replaceUrl]);
 
   const handleSmartCreateSubmitted = () => {
     db.getAllTodos().then(todos => {
@@ -256,11 +259,19 @@ function AppContent() {
       {/* Mobile Header with Back Button + Hamburger Menu */}
       {isMobile && (
         <div className="mobile-header">
-          {activeView !== 'items' ? (
-            // 非事项视图时显示返回按钮，使用浏览器历史记录返回
+          {(activePanel === 'detail' || (activeView !== 'items' && activeView !== 'loops')) ? (
+            // 返回按钮显示条件：
+            // 1. items/loops 视图处于 detail panel → backToList（回到列表页）
+            // 2. 其他视图（dashboard/memorial/settings 等）→ 回到首页 items
             <button
               className="mobile-header-menu-btn"
-              onClick={() => window.history.back()}
+              onClick={() => {
+                if (activeView === 'items' || activeView === 'loops') {
+                  backToList();
+                } else {
+                  showView('items');
+                }
+              }}
               aria-label="返回"
             >
               <ArrowLeftOutlined />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -257,27 +257,21 @@ function AppContent() {
 
   return (
     <Layout style={{ height: '100vh', flexDirection: isMobile ? 'column' : 'row' }}>
-      {/* Mobile Header with Back Button + Hamburger Menu */}
+      {/* Mobile Header — 返回按钮仅在 items/loops 详情页显示，菜单按钮始终在右侧 */}
       {isMobile && (
         <div className="mobile-header">
-          {(activePanel === 'detail' || (activeView !== 'items' && activeView !== 'loops')) ? (
-            // 返回按钮显示条件：
-            // 1. items/loops 视图处于 detail panel → backToList（回到列表页）
-            // 2. 其他视图（dashboard/memorial/settings 等）→ 回到首页 items
+          {/* items/loops 详情页显示返回按钮，否则空占位保持菜单按钮位置一致 */}
+          {(activeView === 'items' || activeView === 'loops') && activePanel === 'detail' ? (
             <button
               className="mobile-header-menu-btn"
-              onClick={() => {
-                if (activeView === 'items' || activeView === 'loops') {
-                  backToList();
-                } else {
-                  showView('items');
-                }
-              }}
-              aria-label="返回"
+              onClick={backToList}
+              aria-label="返回列表"
             >
               <ArrowLeftOutlined />
             </button>
-          ) : null}
+          ) : (
+            <div style={{ width: 40 }} />
+          )}
           <button
             className="mobile-header-menu-btn"
             onClick={() => setNavDrawerOpen(true)}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -204,8 +204,9 @@ function AppContent() {
     setSelectedLoopId(null);
     clearSelection();
     setForcedListMode(mode);
-    pushUrl(mode === 'loop' ? 'loops' : 'items');
-  }, [pushUrl, clearSelection]);
+    // 使用 replaceUrl + panel=list：切回 items/loops 时定位到列表页，不污染历史
+    replaceUrl(mode === 'loop' ? 'loops' : 'items', { panel: 'list' });
+  }, [replaceUrl, clearSelection]);
 
   /**
    * 左侧主导航点击处理（桌面侧栏/移动抽屉共用）。

--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -3,8 +3,8 @@ import type { ReactNode } from 'react';
 import { Button, Tooltip } from 'antd';
 import type { ButtonProps } from 'antd';
 import {
-  InboxOutlined,
-  ApartmentOutlined,
+  UnorderedListOutlined,
+  RetweetOutlined,
   DashboardOutlined,
   ReadOutlined,
   SettingOutlined,
@@ -73,8 +73,8 @@ export function LeftRail({
     {
       title: '工作区',
       items: [
-        { key: 'items', label: '事项', icon: <InboxOutlined />, ariaLabel: '事项' },
-        { key: 'loops', label: '环路', icon: <ApartmentOutlined />, ariaLabel: '环路' },
+        { key: 'items', label: '事项', icon: <UnorderedListOutlined />, ariaLabel: '事项' },
+        { key: 'loops', label: '环路', icon: <RetweetOutlined />, ariaLabel: '环路' },
         { key: 'dashboard', label: '仪表盘', icon: <DashboardOutlined />, ariaLabel: '仪表盘' },
         { key: 'memorial', label: '看板', icon: <ReadOutlined />, ariaLabel: '看板' },
       ] satisfies LeftRailItem[],

--- a/frontend/src/hooks/useViewState.ts
+++ b/frontend/src/hooks/useViewState.ts
@@ -15,6 +15,10 @@
  *   /?view=sessions            会话
  *   /?view=executors           执行器
  *
+ * 移动端 panel 参数（用于 list/detail 独立页面）：
+ *   /?view=items&panel=list        事项列表（全屏）
+ *   /?view=items&panel=detail&id=123  事项详情（全屏）
+ *
  * 只管理 URL + 派生的 React 状态，不持有 Todo/Loop 的 app 数据。
  */
 
@@ -60,11 +64,20 @@ function getInitialTab(): string | null {
   return tab || null;
 }
 
-function buildUrl(view: View, opts?: { id?: number | null; tab?: string | null }): string {
+function getInitialPanel(): Panel {
+  // 移动端使用 panel 参数区分列表/详情页面
+  // 桌面端忽略此参数，始终显示 list+detail 双栏布局
+  const panel = new URLSearchParams(window.location.search).get('panel') as Panel | null;
+  return panel === 'detail' ? 'detail' : 'list';
+}
+
+function buildUrl(view: View, opts?: { id?: number | null; tab?: string | null; panel?: Panel }): string {
   const params = new URLSearchParams();
   params.set('view', view);
   if (opts?.id != null) params.set('id', String(opts.id));
   if (typeof opts?.tab === 'string' && opts.tab.trim()) params.set('tab', opts.tab);
+  // 只有移动端需要 panel 参数，桌面端不需要（双栏布局始终显示）
+  if (opts?.panel === 'detail') params.set('panel', 'detail');
   const qs = params.toString();
   return qs ? `/?${qs}` : '/';
 }
@@ -96,14 +109,29 @@ export function useViewState() {
   const [selectedId, setSelectedId] = useState<number | null>(getInitialId);
   // tab 只用于 settings view，暴露给 SettingsPage 使用
   const [activeTab, setActiveTab] = useState<string | null>(getInitialTab);
+  // panel 只用于移动端 list/detail 独立页面，桌面端忽略（始终显示双栏）
+  const [activePanel, setActivePanel] = useState<Panel>(getInitialPanel);
 
-  // 统一 push URL + React state
-  const pushUrl = useCallback((view: View, opts?: { id?: number | null; tab?: string | null }) => {
+  // 统一 push URL + React state — 用于视图间导航（首页 → 各视图）
+  const pushUrl = useCallback((view: View, opts?: { id?: number | null; tab?: string | null; panel?: Panel }) => {
     const url = buildUrl(view, opts);
     window.history.pushState(null, '', url);
     setActiveView(view);
     setSelectedId(opts?.id ?? null);
     setActiveTab(opts?.tab ?? null);
+    // panel 仅在移动端有意义，桌面端始终为 list
+    setActivePanel(opts?.panel ?? 'list');
+  }, []);
+
+  // replaceUrl — 用于移动端 list/detail 内部切换，不污染浏览器历史
+  // 桌面端也可以用，保持行为一致
+  const replaceUrl = useCallback((view: View, opts?: { id?: number | null; tab?: string | null; panel?: Panel }) => {
+    const url = buildUrl(view, opts);
+    window.history.replaceState(null, '', url);
+    setActiveView(view);
+    setSelectedId(opts?.id ?? null);
+    setActiveTab(opts?.tab ?? null);
+    setActivePanel(opts?.panel ?? 'list');
   }, []);
 
   // 统一 popstate 处理 — 替代了之前分散在 App.tsx / SettingsPage 的三个监听器
@@ -113,11 +141,14 @@ export function useViewState() {
       const view = params.get('view') as View | null;
       const idStr = params.get('id');
       const tab = params.get('tab');
+      const panel = params.get('panel') as Panel | null;
       const resolvedView = view && ALL_VIEWS.includes(view) ? view : 'items';
       const resolvedId = idStr ? (Number.isFinite(Number(idStr)) ? Number(idStr) : null) : null;
       setActiveView(resolvedView);
       setSelectedId(resolvedId);
       setActiveTab(tab || null);
+      // panel 只在移动端使用，桌面端始终为 list
+      setActivePanel(panel === 'detail' ? 'detail' : 'list');
     };
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
@@ -135,22 +166,26 @@ export function useViewState() {
     pushUrl('items', { id: todoId });
   }, [pushUrl]);
 
-  // backToList: 回到当前视图的概览（清空 id），用于移动端返回按钮
+  // backToList: 回到当前视图的概览（清空 id，切到 list panel），用于移动端返回按钮
+  // 使用 replaceUrl 避免污染浏览器历史（list/detail 切换不应产生历史记录）
   const backToList = useCallback(() => {
-    pushUrl(activeView);
-  }, [activeView, pushUrl]);
+    replaceUrl(activeView, { panel: 'list' });
+  }, [activeView, replaceUrl]);
 
-  // selectedPanel 从 URL 派生：有 id 表示「详情」，否则为「列表」
+  // selectedPanel 从 URL 派生：移动端使用 activePanel，桌面端始终为 list+detail 双栏
+  // 桌面端不需要区分 list/detail panel（双栏同时显示），移动端才需要
   const selectedPanel = useMemo<Panel>(() => (selectedId !== null ? 'detail' : 'list'), [selectedId]);
 
   return {
     activeView,
     selectedId,
     activeTab,
+    activePanel,
     selectedPanel,
     showView,
     selectTodo,
     backToList,
     pushUrl,
+    replaceUrl,
   };
 }


### PR DESCRIPTION
## 修改内容

- **事项**：左侧菜单和页面均使用 （☰）
- **环路**：左侧菜单和页面均使用 （🔄）

## 修改文件

-  — 菜单图标
-  — 页面图标（保持不变，确保与菜单一致）
-  — 页面图标（保持不变，确保与菜单一致）