### PR TITLE
feat(workspace): 工作区布局重构 - 消息智能体数量badge + Loop配置平铺

### DIFF
--- a/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
+++ b/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react';
-import { Button, Popconfirm, Input, Space, Empty, Spin, Switch, message, Tooltip } from 'antd';
-import { PlusOutlined, FolderOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { Button, Popconfirm, Input, Space, Empty, Spin, Switch, message, Tooltip, Badge } from 'antd';
+import { PlusOutlined, FolderOutlined, QuestionCircleOutlined, RobotOutlined } from '@ant-design/icons';
 import { PageCard } from '@/components/common/PageCard';
 import * as db from '@/utils/database';
-import type { ProjectDirectory } from '@/utils/database';
-import { WorkspaceDetailPage } from './workspace';
+import type { ProjectDirectory, AgentBot } from '@/utils/database';
+import { WorkspaceDetailPage, BotDetailPage } from './workspace';
 
 export function ProjectDirectoriesPanel() {
   // 项目目录列表；按 path 升序，保持稳定可读
@@ -18,12 +18,19 @@ export function ProjectDirectoriesPanel() {
   const [editingDirName, setEditingDirName] = useState('');
   // 进入工作空间详情页
   const [selectedWorkspace, setSelectedWorkspace] = useState<ProjectDirectory | null>(null);
+  // 直接进入 Bot 详情页（消息智能体配置）
+  const [selectedBotForDetail, setSelectedBotForDetail] = useState<AgentBot | null>(null);
+  // 全部智能体列表（用于按 workspace 过滤显示数量）
+  const [allBots, setAllBots] = useState<AgentBot[]>([]);
 
   // 每次进入页面都重新拉取一次，确保用户在其他地方新增/删除后能立刻看到
   const loadProjectDirectories = () => {
     setProjectDirsLoading(true);
-    db.getProjectDirectories()
-      .then(setProjectDirectories)
+    Promise.all([db.getProjectDirectories(), db.getAgentBots()])
+      .then(([dirs, bots]) => {
+        setProjectDirectories(dirs);
+        setAllBots(bots);
+      })
       .catch((err: any) => message.error('加载项目目录失败: ' + (err?.message || String(err))))
       .finally(() => setProjectDirsLoading(false));
   };
@@ -128,7 +135,37 @@ export function ProjectDirectoriesPanel() {
     }
   };
 
-  // 选中工作空间，显示详情页
+  // 获取指定工作空间绑定的智能体数量
+  const getBotCount = (workspaceId: number) => allBots.filter(b => b.workspace_id === workspaceId).length;
+
+  // 点击智能体数量，进入该工作空间第一个智能体的详情页
+  const handleBotCountClick = (workspaceId: number) => {
+    const botsInWorkspace = allBots.filter(b => b.workspace_id === workspaceId);
+    if (botsInWorkspace.length > 0) {
+      setSelectedBotForDetail(botsInWorkspace[0]);
+    } else {
+      message.info('该工作空间暂无绑定的消息智能体');
+    }
+  };
+
+  // 选中 Bot，显示消息智能体配置页
+  if (selectedBotForDetail) {
+    return (
+      <BotDetailPage
+        bot={selectedBotForDetail}
+        onBack={() => {
+          setSelectedBotForDetail(null);
+          // 刷新一下 bot 列表，确保数量准确
+          db.getAgentBots().then(setAllBots).catch(() => {});
+        }}
+        onRefresh={() => {
+          db.getAgentBots().then(setAllBots).catch(() => {});
+        }}
+      />
+    );
+  }
+
+  // 选中工作空间，显示详情页（Loop 配置直接展示，不再有 tab 切换）
   if (selectedWorkspace) {
     return (
       <WorkspaceDetailPage
@@ -256,12 +293,24 @@ export function ProjectDirectoriesPanel() {
                           编辑
                         </Button>
                       )}
+                      {/* 消息智能体数量badge，点击进入配置页 */}
+                      <Tooltip title="点击进入消息智能体配置">
+                        <Badge count={getBotCount(dir.id)} size="small" offset={[-2, 0]}>
+                          <Button
+                            type="primary"
+                            size="small"
+                            icon={<RobotOutlined />}
+                            onClick={() => handleBotCountClick(dir.id)}
+                          >
+                            消息配置
+                          </Button>
+                        </Badge>
+                      </Tooltip>
                       <Button
-                        type="primary"
                         size="small"
                         onClick={() => setSelectedWorkspace(dir)}
                       >
-                        配置
+                        Loop配置
                       </Button>
                       <Popconfirm
                         title="删除工作空间"

--- a/frontend/src/components/settings/workspace/WorkspaceDetailPage.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceDetailPage.tsx
@@ -1,7 +1,5 @@
-import { useState } from 'react';
-import { Tabs, Select, Button } from 'antd';
-import { ArrowLeftOutlined, RobotOutlined, SettingOutlined, FolderOutlined } from '@ant-design/icons';
-import { useIsMobile } from '@/hooks/useIsMobile';
+import { Button } from 'antd';
+import { ArrowLeftOutlined, FolderOutlined } from '@ant-design/icons';
 import { PageCard } from '@/components/common/PageCard';
 import type { ProjectDirectory } from '@/utils/database';
 import { WorkspaceAgentPanel } from './WorkspaceAgentPanel';
@@ -14,37 +12,11 @@ interface WorkspaceDetailPageProps {
   onBack: () => void;
 }
 
-type TabKey = 'agents' | 'loop-settings';
-
-const TAB_OPTIONS = [
-  { value: 'agents' as TabKey, label: '智能体', icon: <RobotOutlined /> },
-  { value: 'loop-settings' as TabKey, label: 'Loop设置', icon: <SettingOutlined /> },
-];
-
+/**
+ * 工作空间详情页：展示智能体、斜杠命令、工作空间设置和 Loop 评审模板。
+ * 不再使用 Tab 切换，所有配置项平铺展示，一步交互完成。
+ */
 export function WorkspaceDetailPage({ workspace, onBack }: WorkspaceDetailPageProps) {
-  const [activeTab, setActiveTab] = useState<TabKey>('agents');
-  const isMobile = useIsMobile();
-
-  /**
-   * 渲染标签页内容
-   */
-  const renderTabContent = (key: TabKey) => {
-    if (key === 'agents') {
-      return (
-        <>
-          <WorkspaceAgentPanel workspaceId={workspace.id} />
-          <div style={{ marginTop: 24 }}>
-            <WorkspaceSlashCommandsPanel workspaceId={workspace.id} />
-          </div>
-          <div style={{ marginTop: 24 }}>
-            <WorkspaceSettingsPanel workspaceId={workspace.id} />
-          </div>
-        </>
-      );
-    }
-    return <ReviewTemplatesPanel workspaceId={workspace.id} />;
-  };
-
   return (
     <PageCard
       icon={
@@ -61,55 +33,15 @@ export function WorkspaceDetailPage({ workspace, onBack }: WorkspaceDetailPagePr
       }
       title={workspace.name}
     >
-      <div className="workspace-detail-page">
-        {/* 手机端：使用 Select 下拉切换 */}
-        {isMobile ? (
-          <div className="mobile-tabs-container">
-            <Select
-              value={activeTab}
-              onChange={(v) => setActiveTab(v)}
-              style={{ width: '100%', marginBottom: 12 }}
-              options={TAB_OPTIONS.map((opt) => ({
-                value: opt.value,
-                label: (
-                  <span>
-                    {opt.icon} {opt.label}
-                  </span>
-                ),
-              }))}
-            />
-            <div className="mobile-tab-content">
-              {renderTabContent(activeTab)}
-            </div>
-          </div>
-        ) : (
-          /* 桌面端：使用 Tabs */
-          <Tabs
-            activeKey={activeTab}
-            onChange={(v) => setActiveTab(v as TabKey)}
-            style={{ marginTop: 4 }}
-            items={[
-              {
-                key: 'agents',
-                label: (
-                  <span>
-                    <RobotOutlined /> 智能体
-                  </span>
-                ),
-                children: renderTabContent('agents'),
-              },
-              {
-                key: 'loop-settings',
-                label: (
-                  <span>
-                    <SettingOutlined /> Loop设置
-                  </span>
-                ),
-                children: renderTabContent('loop-settings'),
-              },
-            ]}
-          />
-        )}
+      <div className="workspace-detail-page" style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+        {/* 智能体面板 */}
+        <WorkspaceAgentPanel workspaceId={workspace.id} />
+        {/* 斜杠命令面板 */}
+        <WorkspaceSlashCommandsPanel workspaceId={workspace.id} />
+        {/* 工作空间设置面板 */}
+        <WorkspaceSettingsPanel workspaceId={workspace.id} />
+        {/* Loop 评审模板面板 */}
+        <ReviewTemplatesPanel workspaceId={workspace.id} />
       </div>
     </PageCard>
   );


### PR DESCRIPTION
## 改动概述

### 1. 工作区列表页面（ProjectDirectoriesPanel）
- 消息智能体数量以 **Badge** 形式显示在按钮上，点击进入  消息智能体配置页
- 右侧操作按钮调整为：
  - **消息配置**（带数量badge）→ 进入 Bot 配置
  - **Loop配置** → 进入工作空间详情页

### 2. 工作空间详情页（WorkspaceDetailPage）
- **移除 Tab 结构**，不再切换「智能体」/「Loop设置」
- 智能体面板、斜杠命令面板、工作空间设置、Loop评审模板 **平铺展示**
- 一步交互完成所有配置

### 3. 文件变更
- ：新增  状态、badge 显示、智能体数量点击跳转
- ：移除 Tabs/Mobile Select，改为单层垂直布局

## 测试建议
1. 在工作区列表页面，验证智能体数量badge显示正确
2. 点击badge进入消息智能体配置页，验证配置项完整
3. 点击"Loop配置"进入详情页，验证Loop评审模板正常展示