### PR TITLE
refactor: 移动端事项/环路页面独立，使用PageCard统一样式

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ import { useViewState, viewToNavKey, type View } from './hooks/useViewState';
 import { ThemeProvider, useTheme } from './hooks/useTheme';
 import { TodoPage } from './components/TodoPage';
 import { LoopPage } from './components/LoopPage';
+import { TodoMobilePage } from './components/mobile/TodoMobilePage';
+import { LoopMobilePage } from './components/mobile/LoopMobilePage';
 import { Dashboard } from './components/Dashboard';
 import { MemorialBoard } from './components/MemorialBoard';
 import { SettingsPage } from './components/SettingsPage';
@@ -378,36 +380,66 @@ function AppContent() {
             transition: 'height 0.3s ease, padding-bottom 0.3s ease',
           }}
         >
-          {/* 事项页面 */}
+          {/* 事项页面：移动端与桌面端独立组件 */}
           {activeView === 'items' && (
-            <TodoPage
-              selectedTodoId={state.selectedTodoId}
-              onOpenCreateModal={() => setTodoModalOpen(true)}
-              onSelectTodo={handleSelectTodo}
-              loopUpdateCount={loopUpdateCount}
-              onSelectLoop={handleSelectLoop}
-              onCreateLoop={() => setLoopCreateModalOpen(true)}
-              forcedListMode={forcedListMode}
-              onListModeChange={() => setForcedListMode(undefined)}
-              effectiveMobilePanel={effectiveMobilePanel}
-            />
+            isMobile ? (
+              <TodoMobilePage
+                selectedTodoId={state.selectedTodoId}
+                onOpenCreateModal={() => setTodoModalOpen(true)}
+                onSelectTodo={handleSelectTodo}
+                loopUpdateCount={loopUpdateCount}
+                onSelectLoop={handleSelectLoop}
+                onCreateLoop={() => setLoopCreateModalOpen(true)}
+                forcedListMode={forcedListMode}
+                onListModeChange={() => setForcedListMode(undefined)}
+                effectiveMobilePanel={effectiveMobilePanel}
+              />
+            ) : (
+              <TodoPage
+                selectedTodoId={state.selectedTodoId}
+                onOpenCreateModal={() => setTodoModalOpen(true)}
+                onSelectTodo={handleSelectTodo}
+                loopUpdateCount={loopUpdateCount}
+                onSelectLoop={handleSelectLoop}
+                onCreateLoop={() => setLoopCreateModalOpen(true)}
+                forcedListMode={forcedListMode}
+                onListModeChange={() => setForcedListMode(undefined)}
+                effectiveMobilePanel={effectiveMobilePanel}
+              />
+            )
           )}
 
-          {/* 环路页面 */}
+          {/* 环路页面：移动端与桌面端独立组件 */}
           {activeView === 'loops' && (
-            <LoopPage
-              selectedLoopId={selectedLoopId}
-              tags={state.tags}
-              onOpenCreateModal={() => setTodoModalOpen(true)}
-              onSelectTodo={handleSelectTodo}
-              loopUpdateCount={loopUpdateCount}
-              onSelectLoop={handleSelectLoop}
-              onCreateLoop={() => setLoopCreateModalOpen(true)}
-              forcedListMode={forcedListMode}
-              onListModeChange={() => setForcedListMode(undefined)}
-              onLoopChanged={() => setLoopUpdateCount(c => c + 1)}
-              effectiveMobilePanel={effectiveMobilePanel}
-            />
+            isMobile ? (
+              <LoopMobilePage
+                selectedLoopId={selectedLoopId}
+                tags={state.tags}
+                onOpenCreateModal={() => setTodoModalOpen(true)}
+                onSelectTodo={handleSelectTodo}
+                loopUpdateCount={loopUpdateCount}
+                onSelectLoop={handleSelectLoop}
+                onCreateLoop={() => setLoopCreateModalOpen(true)}
+                forcedListMode={forcedListMode}
+                onListModeChange={() => setForcedListMode(undefined)}
+                onLoopChanged={() => setLoopUpdateCount(c => c + 1)}
+                effectiveMobilePanel={effectiveMobilePanel}
+              />
+            ) : (
+              <LoopPage
+                selectedLoopId={selectedLoopId}
+                tags={state.tags}
+                onOpenCreateModal={() => setTodoModalOpen(true)}
+                onSelectTodo={handleSelectTodo}
+                loopUpdateCount={loopUpdateCount}
+                onSelectLoop={handleSelectLoop}
+                onCreateLoop={() => setLoopCreateModalOpen(true)}
+                forcedListMode={forcedListMode}
+                onListModeChange={() => setForcedListMode(undefined)}
+                onLoopChanged={() => setLoopUpdateCount(c => c + 1)}
+                effectiveMobilePanel={effectiveMobilePanel}
+              />
+            )
           )}
 
           {/* 非事项/环路视图：右侧独占 */}

--- a/frontend/src/components/ListDetailPage.tsx
+++ b/frontend/src/components/ListDetailPage.tsx
@@ -4,7 +4,6 @@ import { Button } from 'antd';
 import { MenuFoldOutlined, MenuUnfoldOutlined } from '@ant-design/icons';
 import { PageCard } from './common/PageCard';
 import { EmptyDetailPlaceholder } from './EmptyDetailPlaceholder';
-import { useIsMobile } from '@/hooks/useIsMobile';
 import { SIDEBAR_WIDTH } from '@/constants';
 
 interface ListDetailPageProps {
@@ -16,6 +15,11 @@ interface ListDetailPageProps {
   storageKey?: string;
 }
 
+/**
+ * 桌面端列表-详情双栏布局组件
+ * 左侧为可折叠的列表侧边栏，右侧为详情内容区
+ * 移动端逻辑已独立到 mobile/TodoMobilePage 和 mobile/LoopMobilePage
+ */
 export function ListDetailPage({
   icon,
   title,
@@ -24,12 +28,11 @@ export function ListDetailPage({
   detailPanel,
   storageKey = 'list_detail_sidebar_collapsed',
 }: ListDetailPageProps) {
-  const isMobile = useIsMobile();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
     try {
       return localStorage.getItem(storageKey) === 'true';
     } catch {
-      return true; // 默认展开
+      return true;
     }
   });
 
@@ -42,19 +45,6 @@ export function ListDetailPage({
   const toggleSidebar = () => {
     setSidebarCollapsed(v => !v);
   };
-
-  if (isMobile) {
-    return (
-      <>
-        <div style={{ width: SIDEBAR_WIDTH.mobile, flexShrink: 0, height: '100%' }}>
-          {listPanel}
-        </div>
-        <div style={{ flex: 1, minWidth: 0, height: '100%', overflow: 'hidden' }}>
-          {detailPanel ?? <EmptyDetailPlaceholder />}
-        </div>
-      </>
-    );
-  }
 
   const headerExtra = (
     <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>

--- a/frontend/src/components/LoopPage.tsx
+++ b/frontend/src/components/LoopPage.tsx
@@ -3,9 +3,6 @@ import { Button, message } from 'antd';
 import { ListDetailPage } from './ListDetailPage';
 import { TodoList } from './TodoList';
 import { LoopDetailPanel } from './LoopStudioDetailPanel';
-import { EmptyDetailPlaceholder } from './EmptyDetailPlaceholder';
-import { useIsMobile } from '@/hooks/useIsMobile';
-import { SIDEBAR_WIDTH } from '@/constants';
 import * as dbLoops from '@/utils/database/loops';
 
 interface LoopPageProps {
@@ -22,6 +19,11 @@ interface LoopPageProps {
   effectiveMobilePanel: 'list' | 'detail';
 }
 
+/**
+ * 桌面端环路页面组件
+ * 使用 ListDetailPage 实现左侧列表 + 右侧详情的双栏布局
+ * 移动端逻辑已独立到 LoopMobilePage 组件
+ */
 export function LoopPage({
   selectedLoopId,
   tags,
@@ -33,10 +35,7 @@ export function LoopPage({
   forcedListMode,
   onListModeChange,
   onLoopChanged,
-  effectiveMobilePanel,
 }: LoopPageProps) {
-  const isMobile = useIsMobile();
-
   const listPanel = (
     <TodoList
       onOpenCreateModal={onOpenCreateModal}
@@ -75,7 +74,7 @@ export function LoopPage({
           await dbLoops.deleteLoop(selectedLoopId);
           message.success('已删除');
           onLoopChanged();
-        } catch (err) {
+        } catch {
           message.error('删除失败，环路可能正在被引用');
         }
       }}
@@ -94,36 +93,6 @@ export function LoopPage({
       onChanged={onLoopChanged}
     />
   ) : null;
-
-  if (isMobile) {
-    return (
-      <>
-        <div
-          className={effectiveMobilePanel === 'list' ? 'animate-fade-in' : ''}
-          style={{
-            width: SIDEBAR_WIDTH.mobile,
-            flexShrink: 0,
-            height: '100%',
-            display: effectiveMobilePanel === 'list' ? 'block' : 'none',
-          }}
-        >
-          {listPanel}
-        </div>
-        <div
-          className={effectiveMobilePanel === 'detail' ? 'animate-slide-in-right' : ''}
-          style={{
-            flex: 1,
-            minWidth: 0,
-            height: '100%',
-            overflow: 'hidden',
-            display: effectiveMobilePanel === 'detail' ? 'block' : 'none',
-          }}
-        >
-          {detailPanel ?? <EmptyDetailPlaceholder />}
-        </div>
-      </>
-    );
-  }
 
   return (
     <ListDetailPage

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -42,6 +42,7 @@ interface LoopDetailPanelProps {
   onDelete: () => void;
   onToggleStatus: () => void;
   onChanged: () => void;
+  hideTitleRow?: boolean;
 }
 
 export function LoopDetailPanel({
@@ -52,6 +53,7 @@ export function LoopDetailPanel({
   onDelete,
   onToggleStatus,
   onChanged,
+  hideTitleRow = false,
 }: LoopDetailPanelProps) {
   const { message } = AntApp.useApp();
   const [detail, setDetail] = useState<LoopDetail | null>(null);
@@ -149,43 +151,47 @@ export function LoopDetailPanel({
   return (
     // 父容器已 overflow:auto, 这里只负责垂直 padding, 不再 height:100%
     <div className="loop-detail-panel detail-panel" style={{ padding: 'var(--space-xl)' }}>
-      {/* Header: 标签色条 + 标题 + 操作按钮 */}
-      <div className="loop-detail-header" style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
-        {(() => {
-          const tag = tags.find(t => detail.tag_ids?.includes(t.id));
-          return <span style={{ width: 4, height: 24, background: tag?.color || '#722ed1', borderRadius: 2 }} />;
-        })()}
-        <h2 style={{ margin: 0, fontSize: 18, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--color-text, #0f172a)' }}>
-          {detail.name}
-        </h2>
-        <span style={{ color: 'var(--color-text-tertiary, #94a3b8)', fontSize: 12 }}>#{detail.id}</span>
-        <Space size={4}>
-          <Tooltip title="手动触发">
-            <Button
-              size="small" type="primary"
-              icon={<ThunderboltOutlined />}
-              onClick={onTrigger}
-              disabled={detail.status !== 'enabled'}
-            />
-          </Tooltip>
-          <Tooltip title="复制">
-            <Button size="small" icon={<CopyOutlined />} onClick={onDuplicate} />
-          </Tooltip>
-          <Tooltip title="编辑">
-            <Button size="small" icon={<EditOutlined />} onClick={handleOpenEdit} />
-          </Tooltip>
-          <Popconfirm
-            title="删除 loop"
-            description="将级联删除 triggers/steps,无法恢复"
-            okType="danger"
-            onConfirm={onDelete}
-          >
-            <Tooltip title="删除">
-              <Button size="small" danger icon={<DeleteOutlined />} />
-            </Tooltip>
-          </Popconfirm>
-        </Space>
-      </div>
+      {!hideTitleRow && (
+        <>
+          {/* Header: 标签色条 + 标题 + 操作按钮 */}
+          <div className="loop-detail-header" style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
+            {(() => {
+              const tag = tags.find(t => detail.tag_ids?.includes(t.id));
+              return <span style={{ width: 4, height: 24, background: tag?.color || '#722ed1', borderRadius: 2 }} />;
+            })()}
+            <h2 style={{ margin: 0, fontSize: 18, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--color-text, #0f172a)' }}>
+              {detail.name}
+            </h2>
+            <span style={{ color: 'var(--color-text-tertiary, #94a3b8)', fontSize: 12 }}>#{detail.id}</span>
+            <Space size={4}>
+              <Tooltip title="手动触发">
+                <Button
+                  size="small" type="primary"
+                  icon={<ThunderboltOutlined />}
+                  onClick={onTrigger}
+                  disabled={detail.status !== 'enabled'}
+                />
+              </Tooltip>
+              <Tooltip title="复制">
+                <Button size="small" icon={<CopyOutlined />} onClick={onDuplicate} />
+              </Tooltip>
+              <Tooltip title="编辑">
+                <Button size="small" icon={<EditOutlined />} onClick={handleOpenEdit} />
+              </Tooltip>
+              <Popconfirm
+                title="删除 loop"
+                description="将级联删除 triggers/steps,无法恢复"
+                okType="danger"
+                onConfirm={onDelete}
+              >
+                <Tooltip title="删除">
+                  <Button size="small" danger icon={<DeleteOutlined />} />
+                </Tooltip>
+              </Popconfirm>
+            </Space>
+          </div>
+        </>
+      )}
 
       {detail.description && (
         <div style={{ color: 'var(--color-text-secondary, #475569)', fontSize: 13, marginBottom: 16 }}>{detail.description}</div>

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -18,7 +18,11 @@ import { DetailHeader } from './todo-detail/DetailHeader';
 import { HistoryList } from './todo-detail/HistoryList';
 import { RecordDetailView } from './todo-detail/RecordDetailView';
 
-export function TodoDetail() {
+interface TodoDetailProps {
+  hideTitleRow?: boolean;
+}
+
+export function TodoDetail({ hideTitleRow = false }: TodoDetailProps) {
   const { state, dispatch } = useApp();
   const { message } = App.useApp();
   const { todos, selectedTodoId, executionRecords, runningTasks } = state;
@@ -340,6 +344,7 @@ export function TodoDetail() {
         onOpenExecuteWithArgs={handleOpenExecuteWithArgs}
         onExecute={handleExecute}
         onStatusChange={handleStatusChange}
+        hideTitleRow={hideTitleRow}
       />
 
       {/* Execution History */}

--- a/frontend/src/components/TodoPage.tsx
+++ b/frontend/src/components/TodoPage.tsx
@@ -3,9 +3,6 @@ import { Button } from 'antd';
 import { ListDetailPage } from './ListDetailPage';
 import { TodoList } from './TodoList';
 import { TodoDetail } from './TodoDetail';
-import { EmptyDetailPlaceholder } from './EmptyDetailPlaceholder';
-import { useIsMobile } from '@/hooks/useIsMobile';
-import { SIDEBAR_WIDTH } from '@/constants';
 
 interface TodoPageProps {
   selectedTodoId: string | number | null;
@@ -19,8 +16,12 @@ interface TodoPageProps {
   effectiveMobilePanel: 'list' | 'detail';
 }
 
+/**
+ * 桌面端事项页面组件
+ * 使用 ListDetailPage 实现左侧列表 + 右侧详情的双栏布局
+ * 移动端逻辑已独立到 TodoMobilePage 组件
+ */
 export function TodoPage({
-  selectedTodoId,
   onOpenCreateModal,
   onSelectTodo,
   loopUpdateCount,
@@ -28,10 +29,8 @@ export function TodoPage({
   onCreateLoop,
   forcedListMode,
   onListModeChange,
-  effectiveMobilePanel,
+  selectedTodoId,
 }: TodoPageProps) {
-  const isMobile = useIsMobile();
-
   const listPanel = (
     <TodoList
       onOpenCreateModal={onOpenCreateModal}
@@ -44,38 +43,6 @@ export function TodoPage({
       hideCreateButton={true}
     />
   );
-
-  const detailPanel = selectedTodoId ? <TodoDetail /> : <EmptyDetailPlaceholder />;
-
-  if (isMobile) {
-    return (
-      <>
-        <div
-          className={effectiveMobilePanel === 'list' ? 'animate-fade-in' : ''}
-          style={{
-            width: SIDEBAR_WIDTH.mobile,
-            flexShrink: 0,
-            height: '100%',
-            display: effectiveMobilePanel === 'list' ? 'block' : 'none',
-          }}
-        >
-          {listPanel}
-        </div>
-        <div
-          className={effectiveMobilePanel === 'detail' ? 'animate-slide-in-right' : ''}
-          style={{
-            flex: 1,
-            minWidth: 0,
-            height: '100%',
-            overflow: 'hidden',
-            display: effectiveMobilePanel === 'detail' ? 'block' : 'none',
-          }}
-        >
-          {detailPanel}
-        </div>
-      </>
-    );
-  }
 
   return (
     <ListDetailPage

--- a/frontend/src/components/common/PageCard.tsx
+++ b/frontend/src/components/common/PageCard.tsx
@@ -13,6 +13,7 @@ import type { ReactNode, CSSProperties } from 'react';
  * @param title    - 页面标题文本
  * @param extra    - 标题栏右侧的操作按钮区域
  * @param children - 页面内容（渲染在横线下方）
+ * @param showHeader - 是否显示顶部标题栏，默认为 true
  * @param className - 自定义类名
  * @param style - 自定义样式
  * @param contentClassName - 内容区域自定义类名
@@ -23,6 +24,7 @@ export function PageCard({
   title,
   extra,
   children,
+  showHeader = true,
   className,
   style,
   contentClassName,
@@ -32,6 +34,7 @@ export function PageCard({
   title?: ReactNode;
   extra?: ReactNode;
   children: ReactNode;
+  showHeader?: boolean;
   className?: string;
   style?: CSSProperties;
   contentClassName?: string;
@@ -39,16 +42,20 @@ export function PageCard({
 }) {
   return (
     <div className={`ntd-page-card ${className || ''}`} style={style}>
-      {/* 顶部标题栏：图标 + 标题 + 操作按钮 */}
-      <div className="ntd-page-card-header">
-        <div className="ntd-page-card-title">
-          {icon && <span className="ntd-page-card-icon">{icon}</span>}
-          {title && <span className="ntd-page-card-title-text">{title}</span>}
-        </div>
-        {extra && <div className="ntd-page-card-extra">{extra}</div>}
-      </div>
-      {/* 横线分隔 */}
-      <div className="ntd-page-card-divider" />
+      {showHeader && (
+        <>
+          {/* 顶部标题栏：图标 + 标题 + 操作按钮 */}
+          <div className="ntd-page-card-header">
+            <div className="ntd-page-card-title">
+              {icon && <span className="ntd-page-card-icon">{icon}</span>}
+              {title && <span className="ntd-page-card-title-text">{title}</span>}
+            </div>
+            {extra && <div className="ntd-page-card-extra">{extra}</div>}
+          </div>
+          {/* 横线分隔 */}
+          <div className="ntd-page-card-divider" />
+        </>
+      )}
       {/* 内容区域 */}
       <div className={`ntd-page-card-content ${contentClassName || ''}`} style={contentStyle}>
         {children}

--- a/frontend/src/components/mobile/LoopMobilePage.tsx
+++ b/frontend/src/components/mobile/LoopMobilePage.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useState, useCallback } from 'react';
+import { RetweetOutlined, PlusOutlined, ThunderboltOutlined, CopyOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
+import { Button, Space, Tooltip, Popconfirm, message } from 'antd';
+import { PageCard } from '../common/PageCard';
+import { TodoList } from '../TodoList';
+import { LoopDetailPanel } from '../LoopStudioDetailPanel';
+import { LoopFormModal } from '../LoopFormModal';
+import { EmptyDetailPlaceholder } from '../EmptyDetailPlaceholder';
+import { SIDEBAR_WIDTH } from '@/constants';
+import * as dbLoops from '@/utils/database/loops';
+import type { LoopDetail } from '@/types/loop';
+
+interface LoopMobilePageProps {
+  selectedLoopId: number | null;
+  tags: Array<{ id: number; name: string; color: string }>;
+  onOpenCreateModal: () => void;
+  onSelectTodo: (todoId: string | number | null) => void;
+  loopUpdateCount: number;
+  onSelectLoop: (loopId: number) => void;
+  onCreateLoop: () => void;
+  forcedListMode?: 'item' | 'loop';
+  onListModeChange: () => void;
+  onLoopChanged: () => void;
+  effectiveMobilePanel: 'list' | 'detail';
+}
+
+/**
+ * 移动端环路页面组件
+ * 列表页和详情页为两个独立的 PageCard 页面，各自有完整的标题栏
+ * 列表页：PageCard 标题为"环路"
+ * 详情页：PageCard 标题为具体环路标题，操作按钮在标题栏右侧
+ */
+export function LoopMobilePage({
+  selectedLoopId,
+  tags,
+  onOpenCreateModal,
+  onSelectTodo,
+  loopUpdateCount,
+  onSelectLoop,
+  onCreateLoop,
+  forcedListMode,
+  onListModeChange,
+  onLoopChanged,
+  effectiveMobilePanel,
+}: LoopMobilePageProps) {
+  const [loopDetail, setLoopDetail] = useState<LoopDetail | null>(null);
+  const [editModalOpen, setEditModalOpen] = useState(false);
+
+  const loadLoopDetail = useCallback(() => {
+    if (selectedLoopId === null) {
+      setLoopDetail(null);
+      return;
+    }
+    dbLoops.getLoop(selectedLoopId)
+      .then(d => setLoopDetail(d))
+      .catch(() => setLoopDetail(null));
+  }, [selectedLoopId]);
+
+  useEffect(() => {
+    loadLoopDetail();
+  }, [loadLoopDetail, loopUpdateCount]);
+
+  const handleTrigger = useCallback(async () => {
+    if (selectedLoopId === null) return;
+    try {
+      const res = await dbLoops.triggerLoop(selectedLoopId);
+      message.success(`已触发 (execution #${res.execution_id})`);
+    } catch (err) {
+      message.error(`触发失败: ${err instanceof Error ? err.message : '未知错误'}`);
+    }
+  }, [selectedLoopId]);
+
+  const handleDuplicate = useCallback(async () => {
+    if (selectedLoopId === null) return;
+    try {
+      await dbLoops.duplicateLoop(selectedLoopId);
+      message.success('已复制');
+      onLoopChanged();
+    } catch (err) {
+      message.error(`复制失败: ${err instanceof Error ? err.message : '未知错误'}`);
+    }
+  }, [selectedLoopId, onLoopChanged]);
+
+  const handleDelete = useCallback(async () => {
+    if (selectedLoopId === null) return;
+    try {
+      await dbLoops.deleteLoop(selectedLoopId);
+      message.success('已删除');
+      onLoopChanged();
+    } catch {
+      message.error('删除失败，环路可能正在被引用');
+    }
+  }, [selectedLoopId, onLoopChanged]);
+
+  const handleToggleStatus = useCallback(async () => {
+    if (selectedLoopId === null || !loopDetail) return;
+    try {
+      const next = loopDetail.status === 'enabled' ? 'paused' : 'enabled';
+      await dbLoops.updateLoopStatus(selectedLoopId, { status: next } as any);
+      message.success(`已${next === 'enabled' ? '启用' : '暂停'}`);
+      loadLoopDetail();
+      onLoopChanged();
+    } catch (err) {
+      message.error(`状态切换失败: ${err instanceof Error ? err.message : '未知错误'}`);
+    }
+  }, [selectedLoopId, loopDetail, loadLoopDetail, onLoopChanged]);
+
+  const listPage = (
+    <PageCard
+      icon={<RetweetOutlined />}
+      title="环路"
+      extra={
+        <Button
+          type="primary"
+          size="small"
+          icon={<PlusOutlined />}
+          onClick={onCreateLoop}
+        >
+          新建
+        </Button>
+      }
+      style={{ height: '100%' }}
+      contentStyle={{ padding: 0, height: 'calc(100% - 43px)' }}
+    >
+      <TodoList
+        onOpenCreateModal={onOpenCreateModal}
+        onSelectTodo={onSelectTodo}
+        loopUpdateCount={loopUpdateCount}
+        onSelectLoop={onSelectLoop}
+        onCreateLoop={onCreateLoop}
+        forcedListMode={forcedListMode}
+        onListModeChange={onListModeChange}
+        hideCreateButton={true}
+      />
+    </PageCard>
+  );
+
+  const detailPage = selectedLoopId !== null ? (
+    <PageCard
+      title={loopDetail?.name ?? '加载中...'}
+      extra={
+        <Space size={4}>
+          <Tooltip title="手动触发">
+            <Button
+              type="primary"
+              size="small"
+              icon={<ThunderboltOutlined />}
+              onClick={handleTrigger}
+              disabled={loopDetail?.status !== 'enabled'}
+            />
+          </Tooltip>
+          <Tooltip title="复制">
+            <Button size="small" icon={<CopyOutlined />} onClick={handleDuplicate} />
+          </Tooltip>
+          <Tooltip title="编辑">
+            <Button size="small" icon={<EditOutlined />} onClick={() => setEditModalOpen(true)} />
+          </Tooltip>
+          <Popconfirm
+            title="删除 loop"
+            description="将级联删除 triggers/steps,无法恢复"
+            okType="danger"
+            onConfirm={handleDelete}
+          >
+            <Tooltip title="删除">
+              <Button size="small" icon={<DeleteOutlined />} />
+            </Tooltip>
+          </Popconfirm>
+        </Space>
+      }
+      style={{ height: '100%' }}
+      contentStyle={{ padding: 0, height: 'calc(100% - 43px)' }}
+    >
+      <LoopDetailPanel
+        loopId={selectedLoopId}
+        tags={tags}
+        onTrigger={handleTrigger}
+        onDuplicate={handleDuplicate}
+        onDelete={handleDelete}
+        onToggleStatus={handleToggleStatus}
+        onChanged={() => {
+          loadLoopDetail();
+          onLoopChanged();
+        }}
+        hideTitleRow={true}
+      />
+      <LoopFormModal
+        open={editModalOpen}
+        mode="edit"
+        loopId={selectedLoopId ?? undefined}
+        initialData={loopDetail ? {
+          name: loopDetail.name,
+          description: loopDetail.description,
+          workspace: loopDetail.workspace,
+          webhook_enabled: loopDetail.webhook_enabled,
+          icon: loopDetail.icon,
+          review_template_id: loopDetail.review_template_id ?? null,
+          tag_ids: loopDetail.tag_ids ?? [],
+          limits_config: loopDetail.limits_config,
+          abnormal_handler_todo_id: loopDetail.abnormal_handler_todo_id ?? null,
+          abnormal_handler_trigger_on: loopDetail.abnormal_handler_trigger_on ?? '["capped_step","capped_token","failed"]',
+        } : undefined}
+        tags={tags}
+        onSaved={() => {
+          setEditModalOpen(false);
+          loadLoopDetail();
+          onLoopChanged();
+        }}
+        onClose={() => setEditModalOpen(false)}
+      />
+    </PageCard>
+  ) : (
+    <PageCard
+      style={{ height: '100%' }}
+      contentStyle={{ padding: 0, height: 'calc(100% - 43px)' }}
+    >
+      <EmptyDetailPlaceholder />
+    </PageCard>
+  );
+
+  return (
+    <>
+      <div
+        className={effectiveMobilePanel === 'list' ? 'animate-fade-in' : ''}
+        style={{
+          width: SIDEBAR_WIDTH.mobile,
+          flexShrink: 0,
+          height: '100%',
+          display: effectiveMobilePanel === 'list' ? 'block' : 'none',
+        }}
+      >
+        {listPage}
+      </div>
+      <div
+        className={effectiveMobilePanel === 'detail' ? 'animate-slide-in-right' : ''}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          height: '100%',
+          overflow: 'hidden',
+          display: effectiveMobilePanel === 'detail' ? 'block' : 'none',
+        }}
+      >
+        {detailPage}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/mobile/TodoMobilePage.tsx
+++ b/frontend/src/components/mobile/TodoMobilePage.tsx
@@ -1,0 +1,158 @@
+import { useState, useCallback } from 'react';
+import { UnorderedListOutlined, PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
+import { Button, Popconfirm, App } from 'antd';
+import { PageCard } from '../common/PageCard';
+import { TodoList } from '../TodoList';
+import { TodoDetail } from '../TodoDetail';
+import { TodoDrawer } from '../TodoDrawer';
+import { EmptyDetailPlaceholder } from '../EmptyDetailPlaceholder';
+import { SIDEBAR_WIDTH } from '@/constants';
+import { useApp } from '@/hooks/useApp';
+import * as db from '@/utils/database';
+
+interface TodoMobilePageProps {
+  selectedTodoId: string | number | null;
+  onOpenCreateModal: () => void;
+  onSelectTodo: (todoId: string | number | null) => void;
+  loopUpdateCount: number;
+  onSelectLoop: (loopId: number) => void;
+  onCreateLoop: () => void;
+  forcedListMode?: 'item' | 'loop';
+  onListModeChange: () => void;
+  effectiveMobilePanel: 'list' | 'detail';
+}
+
+/**
+ * 移动端事项页面组件
+ * 列表页和详情页为两个独立的 PageCard 页面，各自有完整的标题栏
+ * 列表页：PageCard 标题为"事项"
+ * 详情页：PageCard 标题为具体事项标题，操作按钮在标题栏右侧
+ */
+export function TodoMobilePage({
+  selectedTodoId,
+  onOpenCreateModal,
+  onSelectTodo,
+  loopUpdateCount,
+  onSelectLoop,
+  onCreateLoop,
+  forcedListMode,
+  onListModeChange,
+  effectiveMobilePanel,
+}: TodoMobilePageProps) {
+  const { state, dispatch } = useApp();
+  const { message } = App.useApp();
+  const { todos } = state;
+  const selectedTodo = todos.find(t => t.id === selectedTodoId);
+  const [todoDrawerOpen, setTodoDrawerOpen] = useState(false);
+
+  const handleDelete = useCallback(async () => {
+    if (!selectedTodo) return;
+    try {
+      await db.deleteTodo(selectedTodo.id);
+      dispatch({ type: 'DELETE_TODO', payload: selectedTodo.id });
+      dispatch({ type: 'SELECT_TODO', payload: null });
+      message.success('删除成功');
+    } catch {
+      // ignore: interceptor already shows error
+    }
+  }, [selectedTodo, dispatch, message]);
+
+  const listPage = (
+    <PageCard
+      icon={<UnorderedListOutlined />}
+      title="事项"
+      extra={
+        <Button
+          type="primary"
+          size="small"
+          icon={<PlusOutlined />}
+          onClick={onOpenCreateModal}
+        >
+          新建
+        </Button>
+      }
+      style={{ height: '100%' }}
+      contentStyle={{ padding: 0, height: 'calc(100% - 43px)' }}
+    >
+      <TodoList
+        onOpenCreateModal={onOpenCreateModal}
+        onSelectTodo={onSelectTodo}
+        loopUpdateCount={loopUpdateCount}
+        onSelectLoop={onSelectLoop}
+        onCreateLoop={onCreateLoop}
+        forcedListMode={forcedListMode}
+        onListModeChange={onListModeChange}
+        hideCreateButton={true}
+      />
+    </PageCard>
+  );
+
+  const detailPage = selectedTodo ? (
+    <PageCard
+      title={selectedTodo.title}
+      extra={
+        <div style={{ display: 'flex', gap: 4 }}>
+          <Button
+            type="text"
+            size="small"
+            icon={<EditOutlined />}
+            onClick={() => setTodoDrawerOpen(true)}
+          />
+          <Popconfirm title="删除任务" description="确定要删除吗？" onConfirm={handleDelete}>
+            <Button type="text" size="small" icon={<DeleteOutlined />} />
+          </Popconfirm>
+        </div>
+      }
+      style={{ height: '100%' }}
+      contentStyle={{ padding: 0, height: 'calc(100% - 43px)' }}
+    >
+      <TodoDetail hideTitleRow={true} />
+      <TodoDrawer
+        open={todoDrawerOpen}
+        todo={selectedTodo}
+        tags={state.tags}
+        onClose={() => setTodoDrawerOpen(false)}
+        onSaved={() => {
+          db.getAllTodos().then(todos => {
+            dispatch({ type: 'SET_TODOS', payload: todos });
+          });
+        }}
+      />
+    </PageCard>
+  ) : (
+    <PageCard
+      style={{ height: '100%' }}
+      contentStyle={{ padding: 0, height: 'calc(100% - 43px)' }}
+    >
+      <EmptyDetailPlaceholder />
+    </PageCard>
+  );
+
+  return (
+    <>
+      <div
+        className={effectiveMobilePanel === 'list' ? 'animate-fade-in' : ''}
+        style={{
+          width: SIDEBAR_WIDTH.mobile,
+          flexShrink: 0,
+          height: '100%',
+          display: effectiveMobilePanel === 'list' ? 'block' : 'none',
+        }}
+      >
+        {listPage}
+      </div>
+      <div
+        className={effectiveMobilePanel === 'detail' ? 'animate-slide-in-right' : ''}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          height: '100%',
+          overflow: 'hidden',
+          display: effectiveMobilePanel === 'detail' ? 'block' : 'none',
+        }}
+      >
+        {detailPage}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/todo-detail/DetailHeader.tsx
+++ b/frontend/src/components/todo-detail/DetailHeader.tsx
@@ -13,6 +13,7 @@ import type { Todo } from '@/types';
 export function DetailHeader({
   selectedTodo, executor, isExecuting, summary, currentTodoProgress,
   records, onDelete, onTodoDrawerOpen, onOpenExecuteWithArgs, onExecute, onStatusChange,
+  hideTitleRow = false,
 }: {
   selectedTodo: Todo;
   executor: string;
@@ -25,6 +26,7 @@ export function DetailHeader({
   onOpenExecuteWithArgs: () => void;
   onExecute: () => Promise<void>;
   onStatusChange: (status: string) => Promise<void>;
+  hideTitleRow?: boolean;
 }) {
   const { message } = App.useApp();
   const webhookUrl = `${window.location.origin}/webhook/trigger/todo/${selectedTodo.id}`;
@@ -32,16 +34,18 @@ export function DetailHeader({
   return (
     <>
       <div className="detail-card header-card">
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
-          <StatusPicker value={selectedTodo.status} onChange={onStatusChange} disabled={isExecuting} />
-          <h2 className="card-title" style={{ margin: 0, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{selectedTodo.title}</h2>
-          <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
-            <Button type="text" icon={<EditOutlined />} onClick={onTodoDrawerOpen} className="icon-btn" aria-label="编辑任务" />
-            <Popconfirm title="删除任务" description="确定要删除吗？" onConfirm={onDelete}>
-              <Button type="text" danger icon={<DeleteOutlined />} className="icon-btn" aria-label="删除任务" />
-            </Popconfirm>
+        {!hideTitleRow && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+            <StatusPicker value={selectedTodo.status} onChange={onStatusChange} disabled={isExecuting} />
+            <h2 className="card-title" style={{ margin: 0, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{selectedTodo.title}</h2>
+            <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
+              <Button type="text" icon={<EditOutlined />} onClick={onTodoDrawerOpen} className="icon-btn" aria-label="编辑任务" />
+              <Popconfirm title="删除任务" description="确定要删除吗？" onConfirm={onDelete}>
+                <Button type="text" danger icon={<DeleteOutlined />} className="icon-btn" aria-label="删除任务" />
+              </Popconfirm>
+            </div>
           </div>
-        </div>
+        )}
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, flexWrap: 'wrap' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
             <ExecutorBadge executor={executor} />


### PR DESCRIPTION
- 移动端页面独立：TodoMobilePage / LoopMobilePage
- 列表页和详情页各为独立PageCard，标题和操作按钮放在标题栏
- 详情组件新增hideTitleRow属性，只隐藏标题行，保留基本信息
- 删除按钮移除红色danger样式，与其他图标按钮保持一致