### PR TITLE
fix(LeftRail): 收缩状态菜单数量与展开状态一致

### DIFF
--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -187,9 +187,7 @@ export function LeftRail({
               </div>
             )}
             <div className={isDrawer ? 'ntd-left-rail-drawer-section-body' : 'ntd-left-rail-section-body'}>
-              {section.items
-                .filter(it => shouldShowLabels ? true : !String(it.key).startsWith('settings_'))
-                .map(renderNavButton)}
+              {section.items.map(renderNavButton)}
             </div>
           </div>
         ))}


### PR DESCRIPTION
## 问题

左侧菜单在收缩状态下，settings_ 开头的菜单项被错误过滤掉，导致菜单数量少于展开状态。

## 修复

移除 LeftRail.tsx 中错误的 filter 逻辑，所有菜单项在两种状态下均完整显示，仅标签文本的显示/隐藏由 shouldShowLabels 控制。