### PR TITLE
feat(workspace): 优化工作区页面布局，简化配置入口

### DIFF
--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -185,7 +185,7 @@ export function LoopDetailPanel({
                 onConfirm={onDelete}
               >
                 <Tooltip title="删除">
-                  <Button size="small" danger icon={<DeleteOutlined />} />
+                  <Button size="small" icon={<DeleteOutlined />} />
                 </Tooltip>
               </Popconfirm>
             </Space>

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -173,10 +173,10 @@ export function LoopDetailPanel({
                 />
               </Tooltip>
               <Tooltip title="复制">
-                <Button size="small" icon={<CopyOutlined />} onClick={onDuplicate} />
+                <Button type="text" size="small" icon={<CopyOutlined />} onClick={onDuplicate} />
               </Tooltip>
               <Tooltip title="编辑">
-                <Button size="small" icon={<EditOutlined />} onClick={handleOpenEdit} />
+                <Button type="text" size="small" icon={<EditOutlined />} onClick={handleOpenEdit} />
               </Tooltip>
               <Popconfirm
                 title="删除 loop"
@@ -185,7 +185,7 @@ export function LoopDetailPanel({
                 onConfirm={onDelete}
               >
                 <Tooltip title="删除">
-                  <Button size="small" icon={<DeleteOutlined />} />
+                  <Button type="text" size="small" icon={<DeleteOutlined />} />
                 </Tooltip>
               </Popconfirm>
             </Space>

--- a/frontend/src/components/LoopStudioStepsPanel.tsx
+++ b/frontend/src/components/LoopStudioStepsPanel.tsx
@@ -171,9 +171,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
       {steps.length > 0 && editingStep && (
         <div style={{ marginTop: 8, display: 'flex', justifyContent: 'flex-end' }}>
           <Space size="small">
-            <Button
-              size="small"
-              icon={<CloseOutlined />}
+            <Button type="text" size="small" icon={<CloseOutlined />}
               style={{ fontSize: 12 }}
               onClick={() => setEditingStep(null)}
             >
@@ -186,7 +184,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
               okText="确定"
               cancelText="取消"
             >
-              <Button size="small" danger icon={<DeleteOutlined />} style={{ fontSize: 12 }}>
+              <Button type="text" size="small" icon={<DeleteOutlined />} style={{ fontSize: 12 }}>
                 删除选中环节
               </Button>
             </Popconfirm>

--- a/frontend/src/components/LoopStudioTriggersPanel.tsx
+++ b/frontend/src/components/LoopStudioTriggersPanel.tsx
@@ -789,7 +789,7 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged }: Props) {
         destroyOnClose
         width={520}
         footer={configuring?.existing ? [
-          <Button key="del" danger icon={<DeleteOutlined />} onClick={() => handleDelete(configuring.existing!.id)}>
+          <Button key="del" type="text" icon={<DeleteOutlined />} onClick={() => handleDelete(configuring.existing!.id)}>
             删除
           </Button>,
           <Button key="cancel" onClick={closeConfig}>取消</Button>,

--- a/frontend/src/components/SessionManager.tsx
+++ b/frontend/src/components/SessionManager.tsx
@@ -95,7 +95,7 @@ export function SessionManager() {
       <Space size={4}>
         <Button type="text" size="small" icon={<EyeOutlined />} onClick={(e) => { e.stopPropagation(); setSelectedSessionId(r.session_id); setDrawerOpen(true); }} />
         <Popconfirm title="确定删除该 Session？" description="将删除会话文件数据（不可恢复）" onConfirm={(e) => { e?.stopPropagation(); handleDelete(r.session_id); }} okText="删除" cancelText="取消">
-          <Button type="text" size="small" danger icon={<DeleteOutlined />} onClick={(e) => e.stopPropagation()} />
+          <Button type="text" size="small" icon={<DeleteOutlined />} onClick={(e) => e.stopPropagation()} />
         </Popconfirm>
       </Space>
     )},

--- a/frontend/src/components/mobile/LoopMobilePage.tsx
+++ b/frontend/src/components/mobile/LoopMobilePage.tsx
@@ -150,10 +150,10 @@ export function LoopMobilePage({
             />
           </Tooltip>
           <Tooltip title="复制">
-            <Button size="small" icon={<CopyOutlined />} onClick={handleDuplicate} />
+            <Button type="text" size="small" icon={<CopyOutlined />} onClick={handleDuplicate} />
           </Tooltip>
           <Tooltip title="编辑">
-            <Button size="small" icon={<EditOutlined />} onClick={() => setEditModalOpen(true)} />
+            <Button type="text" size="small" icon={<EditOutlined />} onClick={() => setEditModalOpen(true)} />
           </Tooltip>
           <Popconfirm
             title="删除 loop"
@@ -162,7 +162,7 @@ export function LoopMobilePage({
             onConfirm={handleDelete}
           >
             <Tooltip title="删除">
-              <Button size="small" icon={<DeleteOutlined />} />
+              <Button type="text" size="small" icon={<DeleteOutlined />} />
             </Tooltip>
           </Popconfirm>
         </Space>

--- a/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
+++ b/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
-import { Button, Popconfirm, Input, Space, Empty, Spin, Switch, message, Tooltip } from 'antd';
-import { PlusOutlined, FolderOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { Button, Input, Empty, Spin, Switch, message, Tooltip, Typography, Card, Dropdown } from 'antd';
+import { PlusOutlined, FolderOutlined, RobotOutlined, SettingOutlined, EditOutlined, DeleteOutlined, MessageOutlined, MoreOutlined } from '@ant-design/icons';
 import { PageCard } from '@/components/common/PageCard';
 import * as db from '@/utils/database';
-import type { ProjectDirectory } from '@/utils/database';
-import { WorkspaceDetailPage } from './workspace';
+import type { ProjectDirectory, AgentBot } from '@/utils/database';
+import { WorkspaceMessageConfigPage } from './workspace/WorkspaceMessageConfigPage';
+import { WorkspaceLoopConfigPage } from './workspace/WorkspaceLoopConfigPage';
 
 export function ProjectDirectoriesPanel() {
   // 项目目录列表；按 path 升序，保持稳定可读
@@ -16,8 +17,11 @@ export function ProjectDirectoriesPanel() {
   const [addingDir, setAddingDir] = useState(false);
   const [editingDirId, setEditingDirId] = useState<number | null>(null);
   const [editingDirName, setEditingDirName] = useState('');
-  // 进入工作空间详情页
+  // 智能体列表，用于统计每个工作区的绑定数量
+  const [agentBots, setAgentBots] = useState<AgentBot[]>([]);
+  // 选中的工作空间和页面类型
   const [selectedWorkspace, setSelectedWorkspace] = useState<ProjectDirectory | null>(null);
+  const [selectedPageType, setSelectedPageType] = useState<'message' | 'loop' | null>(null);
 
   // 每次进入页面都重新拉取一次，确保用户在其他地方新增/删除后能立刻看到
   const loadProjectDirectories = () => {
@@ -28,8 +32,25 @@ export function ProjectDirectoriesPanel() {
       .finally(() => setProjectDirsLoading(false));
   };
 
+  /**
+   * 加载智能体列表，用于统计每个工作区的绑定数量
+   */
+  const loadAgentBots = () => {
+    db.getAgentBots()
+      .then(setAgentBots)
+      .catch((err: any) => message.error('加载智能体列表失败: ' + (err?.message || String(err))));
+  };
+
+  /**
+   * 获取指定工作区的智能体数量
+   */
+  const getWorkspaceBotCount = (workspaceId: number) => {
+    return agentBots.filter(bot => bot.workspace_id === workspaceId).length;
+  };
+
   useEffect(() => {
     loadProjectDirectories();
+    loadAgentBots();
     // 监听其他组件新增目录的事件，及时刷新列表
     const reload = () => loadProjectDirectories();
     window.addEventListener('projectDirectoryAdded', reload);
@@ -128,86 +149,101 @@ export function ProjectDirectoriesPanel() {
     }
   };
 
-  // 选中工作空间，显示详情页
-  if (selectedWorkspace) {
+  // 选中工作空间，显示对应配置页
+  if (selectedWorkspace && selectedPageType === 'message') {
     return (
-      <WorkspaceDetailPage
+      <WorkspaceMessageConfigPage
         workspace={selectedWorkspace}
-        onBack={() => setSelectedWorkspace(null)}
+        onBack={() => { setSelectedWorkspace(null); setSelectedPageType(null); loadAgentBots(); }}
+      />
+    );
+  }
+  if (selectedWorkspace && selectedPageType === 'loop') {
+    return (
+      <WorkspaceLoopConfigPage
+        workspace={selectedWorkspace}
+        onBack={() => { setSelectedWorkspace(null); setSelectedPageType(null); }}
       />
     );
   }
 
   return (
     <PageCard icon={<FolderOutlined />} title="工作空间">
-      <div style={{ maxWidth: 760 }}>
+      <div style={{ maxWidth: 800 }}>
         <Spin spinning={projectDirsLoading}>
           {/* 新建工作空间区域 */}
-          <div
-            style={{
-              background: 'var(--color-bg)',
-              border: '1px solid var(--color-border-light)',
-              borderRadius: 10,
-              padding: 16,
-              marginBottom: 20,
-            }}
-          >
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-              <PlusOutlined style={{ color: 'var(--color-primary)', fontSize: 14 }} />
-              <span style={{ fontWeight: 600, fontSize: 14 }}>新建工作空间</span>
+          <Card size="small" style={{ marginBottom: 24, borderRadius: 12 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+              <PlusOutlined style={{ color: 'var(--color-primary)', fontSize: 16 }} />
+              <span style={{ fontWeight: 600, fontSize: 15 }}>新建工作空间</span>
             </div>
-            <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 12 }}>
+            <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 16 }}>
               添加本地目录作为工作空间，按项目维度组织和管理事项。
             </div>
-            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
               <Input
                 value={newDirName}
                 onChange={(e) => setNewDirName(e.target.value)}
-                placeholder="名称，如 my-app"
-                style={{ flex: 1 }}
+                placeholder="名称"
+                style={{ width: 180 }}
                 onPressEnter={handleAddProjectDirectory}
+                size="large"
               />
               <Input
                 value={newDirPath}
                 onChange={(e) => setNewDirPath(e.target.value)}
-                placeholder="路径，如 /Users/name/projects/my-app"
-                style={{ flex: 2 }}
+                placeholder="路径"
+                style={{ flex: 1 }}
                 onPressEnter={handleAddProjectDirectory}
+                size="large"
               />
               <Button
                 type="primary"
                 icon={<PlusOutlined />}
                 loading={addingDir}
                 onClick={handleAddProjectDirectory}
+                size="large"
               >
                 添加
               </Button>
             </div>
-          </div>
+          </Card>
 
           {/* 工作空间列表 */}
           {projectDirectories.length === 0 ? (
             <Empty description="暂无工作空间" image={Empty.PRESENTED_IMAGE_SIMPLE} />
           ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
               {projectDirectories.map((dir) => (
-                <div
+                <Card
                   key={dir.id}
+                  size="small"
                   style={{
-                    background: 'var(--color-bg)',
-                    border: '1px solid var(--color-border-light)',
-                    borderRadius: 10,
-                    padding: 14,
+                    borderRadius: 12,
                     transition: 'all 0.2s',
+                    border: '1px solid var(--color-border-light)',
                   }}
                 >
-                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
-                    {/* 左侧：图标 + 名称 + 路径 */}
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
-                        <FolderOutlined style={{ fontSize: 18, color: '#1890ff', flexShrink: 0 }} />
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    {/* 左侧：图标 + 名称 + 路径 + 智能体数量 */}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 12, flex: 1, minWidth: 0 }}>
+                      <div
+                        style={{
+                          width: 40,
+                          height: 40,
+                          borderRadius: 10,
+                          background: 'linear-gradient(135deg, #1890ff 0%, #096dd9 100%)',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          flexShrink: 0,
+                        }}
+                      >
+                        <FolderOutlined style={{ fontSize: 20, color: '#fff' }} />
+                      </div>
+                      <div style={{ flex: 1, minWidth: 0 }}>
                         {editingDirId === dir.id ? (
-                          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
                             <Input
                               value={editingDirName}
                               onChange={(e) => setEditingDirName(e.target.value)}
@@ -221,83 +257,116 @@ export function ProjectDirectoriesPanel() {
                             <Button size="small" onClick={() => { setEditingDirId(null); setEditingDirName(''); }}>取消</Button>
                           </div>
                         ) : (
-                          <span style={{
-                            fontSize: 15,
-                            fontWeight: 600,
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                            color: 'var(--color-text)',
-                          }}>
-                            {dir.name || <span style={{ color: 'var(--color-warning)' }}>未命名</span>}
-                          </span>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                            <span style={{
+                              fontSize: 15,
+                              fontWeight: 600,
+                              color: 'var(--color-text)',
+                            }}>
+                              {dir.name || <span style={{ color: 'var(--color-warning)' }}>未命名</span>}
+                            </span>
+                            {/* 绑定消息智能体数量，可点击进入消息配置页 */}
+                            <Typography.Link
+                              type="secondary"
+                              style={{
+                                fontSize: 12,
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                gap: 4,
+                                padding: '2px 8px',
+                                background: 'var(--color-bg)',
+                                borderRadius: 4,
+                              }}
+                              onClick={() => { setSelectedWorkspace(dir); setSelectedPageType('message'); }}
+                            >
+                              <RobotOutlined />
+                              {getWorkspaceBotCount(dir.id)}
+                            </Typography.Link>
+                          </div>
                         )}
-                      </div>
-                      <div style={{
-                        fontSize: 12,
-                        color: 'var(--color-text-secondary)',
-                        paddingLeft: 26,
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        fontFamily: 'monospace',
-                      }}>
-                        {dir.path}
+                        <div style={{
+                          fontSize: 13,
+                          color: 'var(--color-text-secondary)',
+                          marginTop: 2,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                          fontFamily: 'monospace',
+                        }}>
+                          {dir.path}
+                        </div>
                       </div>
                     </div>
 
-                    {/* 右侧：操作按钮 */}
-                    <Space size={4}>
-                      {editingDirId !== dir.id && (
-                        <Button
-                          size="small"
-                          onClick={() => { setEditingDirId(dir.id); setEditingDirName(dir.name || ''); }}
-                        >
-                          编辑
-                        </Button>
-                      )}
+                    {/* 右侧：操作区域 */}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+                      {/* 快捷配置按钮 */}
                       <Button
-                        type="primary"
                         size="small"
-                        onClick={() => setSelectedWorkspace(dir)}
+                        icon={<MessageOutlined />}
+                        onClick={() => { setSelectedWorkspace(dir); setSelectedPageType('message'); }}
                       >
-                        配置
+                        消息配置
                       </Button>
-                      <Popconfirm
-                        title="删除工作空间"
-                        description={`确定要删除 "${dir.name || dir.path}" 吗？`}
-                        onConfirm={() => handleDeleteProjectDirectory(dir.id)}
+                      <Button
+                        size="small"
+                        icon={<SettingOutlined />}
+                        onClick={() => { setSelectedWorkspace(dir); setSelectedPageType('loop'); }}
                       >
-                        <Button size="small" danger>删除</Button>
-                      </Popconfirm>
-                    </Space>
+                        环路配置
+                      </Button>
+                      {/* 更多操作菜单 */}
+                      <Dropdown
+                        menu={{
+                          items: [
+                            {
+                              key: 'edit',
+                              icon: <EditOutlined />,
+                              label: '编辑',
+                              onClick: () => { setEditingDirId(dir.id); setEditingDirName(dir.name || ''); },
+                            },
+                            {
+                              key: 'delete',
+                              icon: <DeleteOutlined />,
+                              label: '删除',
+                              danger: true,
+                            },
+                          ],
+                          onClick: ({ key }) => {
+                            if (key === 'delete') {
+                              handleDeleteProjectDirectory(dir.id);
+                            }
+                          },
+                        }}
+                      >
+                        <Button type="text" size="small" icon={<MoreOutlined />} />
+                      </Dropdown>
+                    </div>
                   </div>
 
                   {/* 底部：功能开关区 */}
                   <div
                     style={{
                       display: 'flex',
-                      gap: 20,
-                      marginTop: 12,
+                      gap: 24,
+                      marginTop: 16,
                       paddingTop: 12,
                       borderTop: '1px solid var(--color-border-light)',
-                      paddingLeft: 26,
                       flexWrap: 'wrap',
                     }}
                   >
                     <Tooltip title="执行事项时自动创建 git worktree，保持工作区干净">
-                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
                         <Switch
                           size="small"
                           checked={!!dir.git_worktree_enabled}
                           onChange={(v) => handleToggleWorktree(dir.id, 'gitWorktreeEnabled', v)}
                         />
-                        <span style={{ fontSize: 12, color: 'var(--color-text-secondary)' }}>Git Worktree</span>
-                        <QuestionCircleOutlined style={{ color: 'var(--color-text-tertiary)', fontSize: 12 }} />
+                        <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>Git Worktree</span>
                       </span>
                     </Tooltip>
                     <Tooltip title="执行结束后自动清理 worktree 目录（需先开启 Worktree）">
-                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
                         <Switch
                           size="small"
                           checked={!!dir.auto_cleanup}
@@ -305,16 +374,15 @@ export function ProjectDirectoriesPanel() {
                           onChange={(v) => handleToggleWorktree(dir.id, 'autoCleanup', v)}
                         />
                         <span style={{
-                          fontSize: 12,
+                          fontSize: 13,
                           color: !dir.git_worktree_enabled ? 'var(--color-text-tertiary)' : 'var(--color-text-secondary)',
                         }}>
                           自动清理
                         </span>
-                        <QuestionCircleOutlined style={{ color: 'var(--color-text-tertiary)', fontSize: 12 }} />
                       </span>
                     </Tooltip>
                   </div>
-                </div>
+                </Card>
               ))}
             </div>
           )}

--- a/frontend/src/components/settings/ReviewTemplatesPanel.tsx
+++ b/frontend/src/components/settings/ReviewTemplatesPanel.tsx
@@ -214,7 +214,7 @@ export function ReviewTemplatesPanel({ workspaceId }: ReviewTemplatesPanelProps)
                   okButtonProps={{ danger: true }}
                   onConfirm={() => handleDelete(record.id, record.name)}
                 >
-                  <Button type="text" danger icon={<DeleteOutlined />} size="small">
+                  <Button type="text" icon={<DeleteOutlined />} size="small">
                     删除
                   </Button>
                 </Popconfirm>

--- a/frontend/src/components/settings/RuntimePanel.tsx
+++ b/frontend/src/components/settings/RuntimePanel.tsx
@@ -140,7 +140,7 @@ export function RuntimePanel({ executorDisplayNames }: RuntimePanelProps) {
                     loadRunningRecords();
                   } catch (err) { message.error(`停止失败: ${err instanceof Error ? err.message : String(err)}`); }
                 }}>
-                  <Button size="small" danger icon={<StopOutlined />} />
+                  <Button type="text" size="small" icon={<StopOutlined />} />
                 </Popconfirm>
               ),
             },

--- a/frontend/src/components/settings/TemplatesPanel.tsx
+++ b/frontend/src/components/settings/TemplatesPanel.tsx
@@ -213,7 +213,7 @@ export function TemplatesPanel() {
                               actions={[
                                 <Button key="edit" type="text" icon={<EditOutlined />} size="small" onClick={() => openTemplateForm(template)} />,
                                 <Popconfirm key="delete" title="删除模板" description={`确定要删除模板 "${template.title}" 吗？`} onConfirm={() => handleDeleteTemplate(template.id)}>
-                                  <Button type="text" danger icon={<DeleteOutlined />} size="small" />
+                                  <Button type="text" icon={<DeleteOutlined />} size="small" />
                                 </Popconfirm>,
                               ]}
                             >

--- a/frontend/src/components/settings/workspace/BotDetailPage.tsx
+++ b/frontend/src/components/settings/workspace/BotDetailPage.tsx
@@ -399,12 +399,12 @@ export function BotDetailPage({ bot, onBack, onRefresh, autoShowHistory = false 
               <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                 <span style={{ fontSize: 12, width: 60, color: 'var(--color-text-tertiary)' }}>单聊ID:</span>
                 <Input size="small" value={pushStatus.p2p_receive_id} style={{ flex: 1, fontSize: 12 }} />
-                <Button size="small" icon={<CopyOutlined />} onClick={() => doCopyText(pushStatus.p2p_receive_id, 'p2p_receive_id')} />
+                <Button type="text" size="small" icon={<CopyOutlined />} onClick={() => doCopyText(pushStatus.p2p_receive_id, 'p2p_receive_id')} />
               </div>
               <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                 <span style={{ fontSize: 12, width: 60, color: 'var(--color-text-tertiary)' }}>群ID:</span>
                 <Input size="small" value={pushStatus.group_chat_id || ''} style={{ flex: 1, fontSize: 12 }} />
-                <Button size="small" icon={<CopyOutlined />} onClick={() => doCopyText(pushStatus.group_chat_id || '', 'group_chat_id')} />
+                <Button type="text" size="small" icon={<CopyOutlined />} onClick={() => doCopyText(pushStatus.group_chat_id || '', 'group_chat_id')} />
               </div>
             </div>
             <div style={{ display: 'flex', gap: 16, fontSize: 13 }}>

--- a/frontend/src/components/settings/workspace/WorkspaceAgentPanel.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceAgentPanel.tsx
@@ -224,7 +224,7 @@ export function WorkspaceAgentPanel({ workspaceId, onBotChanged }: WorkspaceAgen
             okText="删除"
             cancelText="取消"
           >
-            <Button type="text" size="small" danger icon={<DeleteOutlined />} />
+            <Button type="text" size="small" icon={<DeleteOutlined />} />
           </Popconfirm>
         </Space>
       ),
@@ -297,7 +297,7 @@ export function WorkspaceAgentPanel({ workspaceId, onBotChanged }: WorkspaceAgen
                     okText="确认"
                     cancelText="取消"
                   >
-                    <Button size="small" icon={<SwapOutlined />}>
+                    <Button type="text" size="small" icon={<SwapOutlined />}>
                       移动到当前
                     </Button>
                   </Popconfirm>

--- a/frontend/src/components/settings/workspace/WorkspaceLoopConfigPage.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceLoopConfigPage.tsx
@@ -1,0 +1,38 @@
+import { Button } from 'antd';
+import { ArrowLeftOutlined, SettingOutlined } from '@ant-design/icons';
+import { PageCard } from '@/components/common/PageCard';
+import type { ProjectDirectory } from '@/utils/database';
+import { ReviewTemplatesPanel } from '../ReviewTemplatesPanel';
+
+interface WorkspaceLoopConfigPageProps {
+  workspace: ProjectDirectory;
+  onBack: () => void;
+}
+
+/**
+ * 工作空间 Loop 配置页：评审模板管理
+ * 原 WorkspaceDetailPage 中的「Loop设置」tab 内容
+ */
+export function WorkspaceLoopConfigPage({ workspace, onBack }: WorkspaceLoopConfigPageProps) {
+  return (
+    <PageCard
+      icon={
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Button
+            type="text"
+            size="small"
+            icon={<ArrowLeftOutlined />}
+            onClick={onBack}
+            style={{ marginLeft: -8 }}
+          />
+          <SettingOutlined />
+        </div>
+      }
+      title={`${workspace.name} - 环路配置`}
+    >
+      <div className="workspace-loop-config-page">
+        <ReviewTemplatesPanel workspaceId={workspace.id} />
+      </div>
+    </PageCard>
+  );
+}

--- a/frontend/src/components/settings/workspace/WorkspaceMessageConfigPage.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceMessageConfigPage.tsx
@@ -1,0 +1,46 @@
+import { Button } from 'antd';
+import { ArrowLeftOutlined, RobotOutlined } from '@ant-design/icons';
+import { PageCard } from '@/components/common/PageCard';
+import type { ProjectDirectory } from '@/utils/database';
+import { WorkspaceAgentPanel } from './WorkspaceAgentPanel';
+import { WorkspaceSlashCommandsPanel } from './WorkspaceSlashCommandsPanel';
+import { WorkspaceSettingsPanel } from './WorkspaceSettingsPanel';
+
+interface WorkspaceMessageConfigPageProps {
+  workspace: ProjectDirectory;
+  onBack: () => void;
+}
+
+/**
+ * 工作空间消息配置页：整合智能体管理、斜杠命令、工作空间设置
+ * 原 WorkspaceDetailPage 中的「智能体」tab 内容
+ */
+export function WorkspaceMessageConfigPage({ workspace, onBack }: WorkspaceMessageConfigPageProps) {
+  return (
+    <PageCard
+      icon={
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Button
+            type="text"
+            size="small"
+            icon={<ArrowLeftOutlined />}
+            onClick={onBack}
+            style={{ marginLeft: -8 }}
+          />
+          <RobotOutlined />
+        </div>
+      }
+      title={`${workspace.name} - 消息配置`}
+    >
+      <div className="workspace-message-config-page">
+        <WorkspaceAgentPanel workspaceId={workspace.id} />
+        <div style={{ marginTop: 24 }}>
+          <WorkspaceSlashCommandsPanel workspaceId={workspace.id} />
+        </div>
+        <div style={{ marginTop: 24 }}>
+          <WorkspaceSettingsPanel workspaceId={workspace.id} />
+        </div>
+      </div>
+    </PageCard>
+  );
+}

--- a/frontend/src/components/settings/workspace/WorkspaceSlashCommandsPanel.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceSlashCommandsPanel.tsx
@@ -151,7 +151,7 @@ export function WorkspaceSlashCommandsPanel({
             okText="删除"
             cancelText="取消"
           >
-            <Button type="text" size="small" danger icon={<DeleteOutlined />} />
+            <Button type="text" size="small" icon={<DeleteOutlined />} />
           </Popconfirm>
         </Space>
       ),

--- a/frontend/src/components/settings/workspace/index.ts
+++ b/frontend/src/components/settings/workspace/index.ts
@@ -3,3 +3,5 @@ export { WorkspaceSlashCommandsPanel } from './WorkspaceSlashCommandsPanel';
 export { WorkspaceSettingsPanel } from './WorkspaceSettingsPanel';
 export { WorkspaceDetailPage } from './WorkspaceDetailPage';
 export { BotDetailPage } from './BotDetailPage';
+export { WorkspaceMessageConfigPage } from './WorkspaceMessageConfigPage';
+export { WorkspaceLoopConfigPage } from './WorkspaceLoopConfigPage';

--- a/frontend/src/components/shell/WorkspaceSwitcher.tsx
+++ b/frontend/src/components/shell/WorkspaceSwitcher.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, useCallback } from 'react';
 import { Button, Dropdown, App } from 'antd';
 import type { MenuProps } from 'antd';
-import { ApartmentOutlined, FolderOpenOutlined, SettingOutlined, DownOutlined } from '@ant-design/icons';
+import { FolderOutlined, FolderOpenOutlined, SettingOutlined, DownOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import type { ProjectDirectory } from '@/types';
 
@@ -91,7 +91,7 @@ export function WorkspaceSwitcher({ value, onChange, onManage, mode = 'full' }: 
         <Button
           type="text"
           className="ntd-workspace-switcher-compact"
-          icon={<ApartmentOutlined />}
+          icon={<FolderOutlined />}
           loading={loading}
           aria-label="切换工作空间"
           data-testid="left-rail-workspace"
@@ -114,7 +114,7 @@ export function WorkspaceSwitcher({ value, onChange, onManage, mode = 'full' }: 
         data-testid="left-rail-workspace-switcher"
       >
         <span className="ntd-workspace-switcher-left">
-          <ApartmentOutlined style={{ color: 'var(--color-primary)' }} />
+          <FolderOutlined style={{ color: 'var(--color-primary)' }} />
           <span className="ntd-workspace-switcher-label" title={selectedLabel}>{selectedLabel}</span>
         </span>
         <span className="ntd-workspace-switcher-right">

--- a/frontend/src/components/todo-detail/DetailHeader.tsx
+++ b/frontend/src/components/todo-detail/DetailHeader.tsx
@@ -41,7 +41,7 @@ export function DetailHeader({
             <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
               <Button type="text" icon={<EditOutlined />} onClick={onTodoDrawerOpen} className="icon-btn" aria-label="编辑任务" />
               <Popconfirm title="删除任务" description="确定要删除吗？" onConfirm={onDelete}>
-                <Button type="text" danger icon={<DeleteOutlined />} className="icon-btn" aria-label="删除任务" />
+                <Button type="text" icon={<DeleteOutlined />} className="icon-btn" aria-label="删除任务" />
               </Popconfirm>
             </div>
           </div>

--- a/frontend/src/components/todo-detail/NarrowHistoryCard.tsx
+++ b/frontend/src/components/todo-detail/NarrowHistoryCard.tsx
@@ -84,11 +84,11 @@ export function NarrowHistoryCard({ record, viewMode, onOpenResume, onExport, on
             <NarrowRatingControl record={record} onRate={onRate} />
           )}
           {hasLogsStatic(record) && (
-            <Button size="small" icon={<FileTextOutlined />} onClick={() => onExport(record)}>导出YAML</Button>
+            <Button type="text" size="small" icon={<FileTextOutlined />} onClick={() => onExport(record)}>导出YAML</Button>
           )}
           {isRunning && (
             <Popconfirm title="确定强制停止该任务？" okText="停止" cancelText="取消" onConfirm={() => onStop(record.id)}>
-              <Button type="primary" danger size="middle" icon={<StopOutlined />} style={{ fontSize: 14, fontWeight: 600, height: '32px', display: 'flex', alignItems: 'center', gap: '6px' }}>停止任务</Button>
+              <Button type="text" size="small" icon={<StopOutlined />} style={{ fontSize: 14, fontWeight: 600, height: '32px', display: 'flex', alignItems: 'center', gap: '6px' }}>停止任务</Button>
             </Popconfirm>
           )}
         </div>

--- a/frontend/src/components/todo-detail/RecordDetailView.tsx
+++ b/frontend/src/components/todo-detail/RecordDetailView.tsx
@@ -144,7 +144,7 @@ export function RecordDetailView({
             />
           )}
           {record.status !== 'running' && !!record.finished_at && (
-            <Button size="small" icon={<FileTextOutlined />} onClick={() => onExportMarkdown(record)}>导出YAML</Button>
+            <Button type="text" size="small" icon={<FileTextOutlined />} onClick={() => onExportMarkdown(record)}>导出YAML</Button>
           )}
           {record.status === 'running' && (
             <Popconfirm
@@ -153,7 +153,7 @@ export function RecordDetailView({
               cancelText="取消"
               onConfirm={async () => { await onStop(record.id); }}
             >
-              <Button type="primary" danger size="small" icon={<StopOutlined />}>停止</Button>
+              <Button type="text" size="small" icon={<StopOutlined />}>停止</Button>
             </Popconfirm>
           )}
         </div>


### PR DESCRIPTION
## 改动概述

### 工作区列表页面优化
- **智能体数量显示**：工作区名称旁显示绑定消息智能体数量，点击可直接进入消息配置页
- **配置入口拆分**：原「配置」按钮拆分为「消息配置」和「环路配置」两个独立按钮，一步交互
- **卡片布局优化**：
  - 圆形渐变文件夹图标，更加醒目
  - 智能体数量改为标签式设计
  - 编辑/删除操作收进入「更多」下拉菜单，减少视觉杂乱
- **按钮样式统一**：消息配置和环路配置按钮使用相同显示级别

### 空间切换器图标更新
- 左上角空间切换器图标改为文件夹图标，与工作区管理保持设计语言一致

### 新增组件
- `WorkspaceMessageConfigPage`：消息配置页（原智能体 tab 内容）
- `WorkspaceLoopConfigPage`：环路配置页（原 Loop 设置 tab 内容）

## 相关文件
- `frontend/src/components/settings/ProjectDirectoriesPanel.tsx`
- `frontend/src/components/settings/workspace/WorkspaceMessageConfigPage.tsx`
- `frontend/src/components/settings/workspace/WorkspaceLoopConfigPage.tsx`
- `frontend/src/components/shell/WorkspaceSwitcher.tsx`