### PR TITLE
feat: 事项详情页论坛式重设计

### DIFF
--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -319,17 +319,18 @@ impl CodeExecutor for PiExecutor {
     }
 
     /// 支持 session 的命令参数
-    /// pi 使用 --continue 恢复（不需要指定 session id，pi 会自动找当前目录最近的 session）
-    fn command_args_with_session(&self, message: &str, _session_id: Option<&str>, is_resume: bool) -> Vec<String> {
+    /// pi 使用 --session <session_id> 恢复会话
+    fn command_args_with_session(&self, message: &str, session_id: Option<&str>, is_resume: bool) -> Vec<String> {
         let mut args = vec![
             "-p".to_string(),
             "--mode".to_string(),
             "json".to_string(),
         ];
         if is_resume {
-            // 恢复模式：只用 --continue，让 pi 自动找最近 session
-            // 注意：pi 的 session 按项目目录存储，必须确保 cwd 与原 session 创建时一致
-            args.push("--continue".to_string());
+            if let Some(sid) = session_id {
+                args.push("--session".to_string());
+                args.push(sid.to_string());
+            }
         }
         args.push(message.to_string());
         args
@@ -463,18 +464,25 @@ mod tests {
     fn test_command_args_with_session_resume() {
         let executor = PiExecutor::new("pi".to_string());
         let args = executor.command_args_with_session("hello", Some("session123"), true);
-        // pi resume 只用 --continue，session 按目录自动管理，不需要传 session_id
-        assert!(args.contains(&"--continue".to_string()));
-        // session_id 参数被忽略
-        assert!(!args.contains(&"session123".to_string()));
+        // pi resume 使用 --session <session_id>
+        assert!(args.contains(&"--session".to_string()));
+        assert!(args.contains(&"session123".to_string()));
     }
 
     #[test]
     fn test_command_args_with_session_no_resume() {
         let executor = PiExecutor::new("pi".to_string());
         let args = executor.command_args_with_session("hello", Some("session123"), false);
-        // 不使用 --continue，只在新 session 执行
-        assert!(!args.contains(&"--continue".to_string()));
+        // 非 resume 模式不使用 --session
+        assert!(!args.contains(&"--session".to_string()));
+    }
+
+    #[test]
+    fn test_command_args_with_session_resume_no_id() {
+        let executor = PiExecutor::new("pi".to_string());
+        let args = executor.command_args_with_session("hello", None, true);
+        // resume 模式但没有 session_id 时，不加 --session（降级为新 session）
+        assert!(!args.contains(&"--session".to_string()));
     }
 
     #[test]

--- a/backend/src/db/review_template.rs
+++ b/backend/src/db/review_template.rs
@@ -336,6 +336,7 @@ mod tests {
             name: "新模板".to_string(),
             description: Some("描述".to_string()),
             prompt: "你是一个评审师".to_string(),
+            workspace_id: None,
         };
         let id = db.create_review_template(&input).await.expect("create");
         let row = db.get_review_template(id).await.expect("get").expect("some");
@@ -351,6 +352,7 @@ mod tests {
             name: "no-desc".to_string(),
             description: None,
             prompt: "p".to_string(),
+            workspace_id: None,
         };
         let id = db.create_review_template(&input).await.expect("create");
         let row = db.get_review_template(id).await.expect("get").expect("some");
@@ -372,6 +374,7 @@ mod tests {
             name: "new".to_string(),
             description: Some("new-desc".to_string()),
             prompt: "new-prompt".to_string(),
+            workspace_id: None,
         };
         db.update_review_template(id, &input).await.expect("update");
         let after = db.get_review_template(id).await.expect("get").expect("some");
@@ -445,6 +448,7 @@ mod tests {
             name: "默认评审任务".to_string(),
             description: None,
             prompt: "user-customized prompt".to_string(),
+            workspace_id: None,
         }).await.expect("update");
         let id2 = db.ensure_default_review_template().await.expect("ensure 2");
         assert_eq!(id, id2);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { useExecutionEvents } from './hooks/useExecutionEvents';
 import { useViewState, viewToNavKey, type View } from './hooks/useViewState';
 import { ThemeProvider, useTheme } from './hooks/useTheme';
 import { TodoPage } from './components/TodoPage';
+import { TodoPostPage } from './components/TodoPostPage';
 import { LoopPage } from './components/LoopPage';
 import { TodoMobilePage } from './components/mobile/TodoMobilePage';
 import { LoopMobilePage } from './components/mobile/LoopMobilePage';
@@ -34,7 +35,7 @@ const { Content } = Layout;
 
 function AppContent() {
   const { state, dispatch, clearSelection } = useApp();
-  const { activeView, selectedId, activePanel, showView, pushUrl, replaceUrl, backToList } = useViewState();
+  const { activeView, selectedId, activePanel, selectedRecordId, showView, pushUrl, replaceUrl, backToList } = useViewState();
   const { themeMode, toggleTheme } = useTheme();
 
   const [todoModalOpen, setTodoModalOpen] = useState(false);
@@ -68,9 +69,10 @@ function AppContent() {
   // 手机端有效面板：
   // - items/loops 视图：使用 activePanel（来自 URL，支持 list/detail 独立页面）
   // - 其他视图（dashboard/memorial/settings 等）：始终显示 detail（全屏页面）
+  // - post 面板仅桌面端使用，移动端降级为 list
   const effectiveMobilePanel = isMobile && activeView !== 'items' && activeView !== 'loops'
     ? 'detail'
-    : activePanel;
+    : activePanel === 'post' ? 'list' : activePanel;
 
   // 切换视图或面板时收起 FAB，避免遗留
   useEffect(() => {
@@ -154,6 +156,11 @@ function AppContent() {
       replaceUrl('items', { id: Number(todoId), panel: 'detail' });
     }
   };
+
+  /** 点击帖子时跳转到全屏帖子详情页 */
+  const handleOpenPost = useCallback((todoId: number, recordId: number) => {
+    pushUrl('items', { id: todoId, panel: 'post', record: recordId });
+  }, [pushUrl]);
 
   // 从左侧环路列表选中一个 loop，在右侧展示 LoopDetailPanel
   const handleSelectLoop = useCallback((loopId: number) => {
@@ -380,8 +387,17 @@ function AppContent() {
             transition: 'height 0.3s ease, padding-bottom 0.3s ease',
           }}
         >
+          {/* 帖子详情页：panel=post 时全屏显示帖子内容 */}
+          {activeView === 'items' && activePanel === 'post' && selectedId != null && selectedRecordId != null && (
+            <TodoPostPage
+              todoId={selectedId}
+              recordId={selectedRecordId}
+              onBack={() => replaceUrl('items', { id: selectedId, panel: 'list' })}
+            />
+          )}
+
           {/* 事项页面：移动端与桌面端独立组件 */}
-          {activeView === 'items' && (
+          {activeView === 'items' && activePanel !== 'post' && (
             isMobile ? (
               <TodoMobilePage
                 selectedTodoId={state.selectedTodoId}
@@ -405,6 +421,7 @@ function AppContent() {
                 forcedListMode={forcedListMode}
                 onListModeChange={() => setForcedListMode(undefined)}
                 effectiveMobilePanel={effectiveMobilePanel}
+                onOpenPost={handleOpenPost}
               />
             )
           )}

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -3,7 +3,7 @@ import { useApp } from '@/hooks/useApp';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useExecutionHistory } from '@/hooks/useExecutionHistory';
 import { Button, Empty, App, Pagination, Modal, Input, Select } from 'antd';
-import { CheckCircleOutlined, ReloadOutlined, ThunderboltOutlined, FullscreenOutlined, FullscreenExitOutlined } from '@ant-design/icons';
+import { CheckCircleOutlined, ReloadOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { TodoDrawer } from './TodoDrawer';
 import { parseLogsToMessages } from './ChatView';
 import { BREAKPOINTS, EXPORT } from '@/constants';
@@ -30,7 +30,6 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
   const selectedTodo = todos.find(t => t.id === selectedTodoId);
 
   const [todoDrawerOpen, setTodoDrawerOpen] = useState(false);
-  const [isHistoryFullscreen, setIsHistoryFullscreen] = useState(false);
   // viewMode 仅窄屏模式使用（PostDetailDrawer 内部自己管理）
   const [viewMode, setViewMode] = useState<'log' | 'chat' | 'command'>('log');
 
@@ -366,14 +365,6 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
             >
               刷新
             </Button>
-            <Button
-              type="text"
-              size="small"
-              icon={<FullscreenOutlined />}
-              onClick={() => setIsHistoryFullscreen(true)}
-            >
-              放大
-            </Button>
           </div>
         </div>
         {records.length === 0 ? (
@@ -465,79 +456,6 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
           }
         }}
       />
-
-      <Modal
-        title={
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 4px' }}>
-            <span style={{ fontWeight: 600 }}>执行历史</span>
-            <Button
-              type="text"
-              size="small"
-              icon={<FullscreenExitOutlined />}
-              onClick={() => setIsHistoryFullscreen(false)}
-            >
-              退出全屏
-            </Button>
-          </div>
-        }
-        open={isHistoryFullscreen}
-        onCancel={() => setIsHistoryFullscreen(false)}
-        footer={null}
-        width="100%"
-        style={{ top: 0, height: '100vh' }}
-        bodyStyle={{ padding: 0, height: 'calc(100vh - 55px)', overflow: 'hidden' }}
-        closable={false}
-        maskClosable
-        destroyOnClose={false}
-      >
-        {records.length === 0 ? (
-          <Empty description="暂无执行记录" image={Empty.PRESENTED_IMAGE_SIMPLE} />
-        ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', height: '100%', padding: '16px 20px' }}>
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12, flexShrink: 0 }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                <Select
-                  size="small"
-                  value={historyStatusFilter}
-                  onChange={setHistoryStatusFilter}
-                  style={{ width: 100 }}
-                  options={[
-                    { value: 'all', label: '全部' },
-                    { value: 'running', label: '进行中' },
-                    { value: 'success', label: '成功' },
-                    { value: 'failed', label: '失败' },
-                  ]}
-                />
-                <Button
-                  type="text"
-                  size="small"
-                  icon={<ReloadOutlined />}
-                  onClick={() => loadExecutionRecords(historyPage, historyLimit)}
-                  loading={isExecuting}
-                >
-                  刷新
-                </Button>
-              </div>
-            </div>
-            <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minHeight: 0 }}>
-              <ForumPostList
-                sessionGroups={sessionGroups}
-                selectedRecordId={selectedHistoryRecordId}
-                onSelectRecord={(id) => {
-                  setSelectedHistoryRecordId(id);
-                  if (selectedTodoId && onOpenPost) {
-                    onOpenPost(selectedTodoId, id);
-                  }
-                }}
-                historyTotal={historyTotal}
-                historyLimit={historyLimit}
-                historyPage={historyPage}
-                onPageChange={handleHistoryPageChange}
-              />
-            </div>
-          </div>
-        )}
-      </Modal>
 
       <Modal
         title={<><ThunderboltOutlined style={{ marginRight: 8 }} />带参执行</>}

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -15,23 +15,24 @@ import { groupBySession } from './todo-detail/helpers';
 import { NarrowHistoryCard } from './todo-detail/NarrowHistoryCard';
 import { ChainGroupCard } from './todo-detail/ChainGroupCard';
 import { DetailHeader } from './todo-detail/DetailHeader';
-import { HistoryList } from './todo-detail/HistoryList';
-import { RecordDetailView } from './todo-detail/RecordDetailView';
+import { ForumPostList } from './todo-detail/ForumPostList';
 
 interface TodoDetailProps {
   hideTitleRow?: boolean;
+  onOpenPost?: (todoId: number, recordId: number) => void;
 }
 
-export function TodoDetail({ hideTitleRow = false }: TodoDetailProps) {
+export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps) {
   const { state, dispatch } = useApp();
   const { message } = App.useApp();
   const { todos, selectedTodoId, executionRecords, runningTasks } = state;
   const isWide = !useIsMobile(BREAKPOINTS.wide);
-  const [viewMode, setViewMode] = useState<'log' | 'chat' | 'command'>('log');
   const selectedTodo = todos.find(t => t.id === selectedTodoId);
 
   const [todoDrawerOpen, setTodoDrawerOpen] = useState(false);
   const [isHistoryFullscreen, setIsHistoryFullscreen] = useState(false);
+  // viewMode 仅窄屏模式使用（PostDetailDrawer 内部自己管理）
+  const [viewMode, setViewMode] = useState<'log' | 'chat' | 'command'>('log');
 
   // 使用 useExecutionHistory hook 获取执行历史相关的状态和操作
   const {
@@ -45,12 +46,6 @@ export function TodoDetail({ hideTitleRow = false }: TodoDetailProps) {
     setHistoryStatusFilter,
     summary,
     selectedHistoryRecord,
-    isLoadingDetail,
-    paginatedLogs,
-    logsTotal,
-    logsPage,
-    logsPerPage,
-    isLoadingLogs,
     loadExecutionRecords,
     loadLogs,
     refreshSingleRecord,
@@ -202,32 +197,25 @@ export function TodoDetail({ hideTitleRow = false }: TodoDetailProps) {
     message.success(rating == null ? '已清除评分' : `已评分 ${rating}`);
   };
 
-  const [resumeModalOpen, setResumeModalOpen] = useState(false);
-  const [resumeRecordId, setResumeRecordId] = useState<number | null>(null);
-  const [resumeMessage, setResumeMessage] = useState('');
-  const [resumeLoading, setResumeLoading] = useState(false);
-
   const sessionGroups = useMemo(() => groupBySession(records), [records]);
 
-  const handleOpenResume = (record: ExecutionRecord) => {
-    setResumeRecordId(record.id);
-    setResumeMessage('');
-    setResumeModalOpen(true);
-  };
-
-  const handleResumeConfirm = async () => {
-    if (!resumeRecordId) return;
-    setResumeLoading(true);
+  const handleReply = async (record: ExecutionRecord, replyMessage: string) => {
+    if (!replyMessage.trim()) return;
     try {
-      await db.resumeExecutionRecord(resumeRecordId, resumeMessage);
-      message.success('已继续对话，任务开始执行');
-      setResumeModalOpen(false);
-      setResumeMessage('');
+      await db.resumeExecutionRecord(record.id, replyMessage);
+      message.success('回复成功，开始执行');
       await loadExecutionRecords(historyPage, historyLimit);
     } catch (error) {
-      message.error('继续对话失败: ' + (error instanceof Error ? error.message : String(error)));
-    } finally {
-      setResumeLoading(false);
+      message.error('回复失败: ' + (error instanceof Error ? error.message : String(error)));
+    }
+  };
+
+  // 窄屏模式兼容：NarrowHistoryCard / ChainGroupCard 仍期望 onOpenResume 回调。
+  // 窄屏暂不做论坛式改造，保留简单 prompt 交互。
+  const handleOpenResume = (record: ExecutionRecord) => {
+    const input = prompt('输入要继续发送的消息：');
+    if (input && input.trim()) {
+      handleReply(record, input.trim());
     }
   };
 
@@ -391,42 +379,21 @@ export function TodoDetail({ hideTitleRow = false }: TodoDetailProps) {
         {records.length === 0 ? (
           <Empty description="暂无执行记录" image={Empty.PRESENTED_IMAGE_SIMPLE} />
         ) : isWide ? (
-          <div style={{ flex: 1, display: 'flex', gap: 16, overflow: 'hidden', minHeight: 0 }}>
-            <HistoryList
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minHeight: 0 }}>
+            <ForumPostList
               sessionGroups={sessionGroups}
-              selectedHistoryRecordId={selectedHistoryRecordId}
-              onSelectRecord={(id) => setSelectedHistoryRecordId(id)}
+              selectedRecordId={selectedHistoryRecordId}
+              onSelectRecord={(id) => {
+                setSelectedHistoryRecordId(id);
+                if (selectedTodoId && onOpenPost) {
+                  onOpenPost(selectedTodoId, id);
+                }
+              }}
               historyTotal={historyTotal}
               historyLimit={historyLimit}
               historyPage={historyPage}
               onPageChange={handleHistoryPageChange}
-              onOpenResume={handleOpenResume}
-              onExportMarkdown={handleExportMarkdown}
             />
-            <div style={{ width: 1, background: 'var(--color-border-light)', flexShrink: 0 }} />
-            <div className="history-detail-column">
-              <RecordDetailView
-                isLoadingDetail={isLoadingDetail}
-                record={selectedHistoryRecord}
-                sessionGroups={sessionGroups}
-                onSelectRecord={(id) => setSelectedHistoryRecordId(id)}
-                viewMode={viewMode}
-                onViewModeChange={setViewMode}
-                onOpenResume={handleOpenResume}
-                onExportMarkdown={handleExportMarkdown}
-                onStop={handleStopExecution}
-                onRefreshSingle={refreshSingleRecord}
-                onRate={handleRateExecution}
-                paginatedLogs={paginatedLogs}
-                logsTotal={logsTotal}
-                logsPage={logsPage}
-                logsPerPage={logsPerPage}
-                onLoadLogs={loadLogs}
-                isLoadingLogs={isLoadingLogs}
-                getRunningTaskForRecord={getRunningTaskForRecord}
-                resolveExecutionStats={resolveExecutionStats}
-              />
-            </div>
           </div>
         ) : (
           <>
@@ -552,68 +519,24 @@ export function TodoDetail({ hideTitleRow = false }: TodoDetailProps) {
                 </Button>
               </div>
             </div>
-            <div style={{ flex: 1, display: 'flex', gap: 16, overflow: 'hidden', minHeight: 0 }}>
-              <HistoryList
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minHeight: 0 }}>
+              <ForumPostList
                 sessionGroups={sessionGroups}
-                selectedHistoryRecordId={selectedHistoryRecordId}
-                onSelectRecord={(id) => setSelectedHistoryRecordId(id)}
+                selectedRecordId={selectedHistoryRecordId}
+                onSelectRecord={(id) => {
+                  setSelectedHistoryRecordId(id);
+                  if (selectedTodoId && onOpenPost) {
+                    onOpenPost(selectedTodoId, id);
+                  }
+                }}
                 historyTotal={historyTotal}
                 historyLimit={historyLimit}
                 historyPage={historyPage}
                 onPageChange={handleHistoryPageChange}
-                onOpenResume={handleOpenResume}
-                onExportMarkdown={handleExportMarkdown}
               />
-              <div style={{ width: 1, background: 'var(--color-border-light)', flexShrink: 0 }} />
-              <div className="history-detail-column" style={{ flex: 1, minWidth: 0 }}>
-                <RecordDetailView
-                  isLoadingDetail={isLoadingDetail}
-                  record={selectedHistoryRecord}
-                  sessionGroups={sessionGroups}
-                  onSelectRecord={(id) => setSelectedHistoryRecordId(id)}
-                  viewMode={viewMode}
-                  onViewModeChange={setViewMode}
-                  onOpenResume={handleOpenResume}
-                  onExportMarkdown={handleExportMarkdown}
-                  onStop={handleStopExecution}
-                  onRefreshSingle={refreshSingleRecord}
-                  onRate={handleRateExecution}
-                  paginatedLogs={paginatedLogs}
-                  logsTotal={logsTotal}
-                  logsPage={logsPage}
-                  logsPerPage={logsPerPage}
-                  onLoadLogs={loadLogs}
-                  isLoadingLogs={isLoadingLogs}
-                  getRunningTaskForRecord={getRunningTaskForRecord}
-                  resolveExecutionStats={resolveExecutionStats}
-                />
-              </div>
             </div>
           </div>
         )}
-      </Modal>
-
-      <Modal
-        title="继续对话"
-        open={resumeModalOpen}
-        onOk={handleResumeConfirm}
-        onCancel={() => {
-          setResumeModalOpen(false);
-          setResumeMessage('');
-        }}
-        confirmLoading={resumeLoading}
-        okText="开始执行"
-        cancelText="取消"
-      >
-        <p style={{ marginBottom: 12, color: 'var(--color-text-secondary)' }}>
-          将复用之前的会话上下文继续对话，你可以修改下方消息：
-        </p>
-        <Input.TextArea
-          value={resumeMessage}
-          onChange={(e) => setResumeMessage(e.target.value)}
-          rows={4}
-          placeholder="输入要继续发送的消息..."
-        />
       </Modal>
 
       <Modal

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -469,29 +469,6 @@ export function TodoList(props: TodoListProps) {
         hideCreate={hideCreateButton}
       />
 
-      {/* 标签过滤：环路模式下不显示，loop 不按 tag 过滤 */}
-      {listMode === 'item' && tags.length > 0 && (
-        <div className="tag-filter-bar">
-          <button
-            className={`tag-chip ${selectedTagId === null ? 'active' : ''}`}
-            onClick={() => dispatch({ type: 'SELECT_TAG', payload: null })}
-          >
-            全部
-          </button>
-          {tags.map(tag => (
-            <button
-              key={tag.id}
-              className={`tag-chip ${selectedTagId === tag.id ? 'active' : ''}`}
-              style={{ '--tag-color': tag.color } as React.CSSProperties}
-              onClick={() => dispatch({ type: 'SELECT_TAG', payload: tag.id })}
-            >
-              <span className="tag-dot" style={{ backgroundColor: tag.color }} />
-              {tag.name}
-            </button>
-          ))}
-        </div>
-      )}
-
       {listMode === 'loop' ? (
         <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
           {loopLoading ? (

--- a/frontend/src/components/TodoPage.tsx
+++ b/frontend/src/components/TodoPage.tsx
@@ -14,6 +14,7 @@ interface TodoPageProps {
   forcedListMode?: 'item' | 'loop';
   onListModeChange: () => void;
   effectiveMobilePanel: 'list' | 'detail';
+  onOpenPost?: (todoId: number, recordId: number) => void;
 }
 
 /**
@@ -30,6 +31,7 @@ export function TodoPage({
   forcedListMode,
   onListModeChange,
   selectedTodoId,
+  onOpenPost,
 }: TodoPageProps) {
   const listPanel = (
     <TodoList
@@ -60,7 +62,7 @@ export function TodoPage({
         </Button>
       }
       listPanel={listPanel}
-      detailPanel={selectedTodoId ? <TodoDetail /> : null}
+      detailPanel={selectedTodoId ? <TodoDetail onOpenPost={onOpenPost} /> : null}
     />
   );
 }

--- a/frontend/src/components/TodoPostPage.tsx
+++ b/frontend/src/components/TodoPostPage.tsx
@@ -21,9 +21,9 @@ import { CommandPanel } from "@/components/CommandPanel";
 import { CollapsibleConclusion } from "./todo-detail/CollapsibleConclusion";
 import { ReplyInput } from "./todo-detail/ReplyInput";
 import { RefreshBtn } from "./todo-detail/LogViewHeader";
-import { groupBySession } from "./todo-detail/helpers";
+import { LOG_TYPE_COLORS, LOG_TYPE_LABELS } from "@/constants";
+import { groupBySession, formatLogTime, getElapsedSeconds } from "./todo-detail/helpers";
 import { formatLocalDateTime, formatDurationSec } from "@/utils/datetime";
-import { getElapsedSeconds } from "./todo-detail/helpers";
 import { supportsResume } from "@/types";
 import { parseLogsToMessages } from "./ChatView";
 import { conversationToYaml } from "@/utils/markdown";
@@ -37,10 +37,9 @@ import {
   Popover,
   InputNumber,
   Space,
-  Tooltip,
   message as antdMessage,
 } from "antd";
-import { StarOutlined, StarFilled, FileTextOutlined } from "@ant-design/icons";
+import { StarOutlined, StarFilled, FileTextOutlined, CaretDownOutlined, CaretUpOutlined, CopyOutlined } from "@ant-design/icons";
 
 /**
  * 全屏帖子详情页 —— 按 session_id 加载同 session 的所有记录。
@@ -594,28 +593,8 @@ function LogDrawer({
       width="60%"
       styles={{ body: { padding: "12px 16px", display: "flex", flexDirection: "column" } }}
     >
-      {/* 执行命令 */}
-      {record?.command && (
-        <Tooltip title="点击复制命令">
-          <div
-            onClick={async () => {
-              try {
-                const ok = await copyToClipboard(record.command || "");
-                antdMessage[ok ? "success" : "error"](ok ? "已复制" : "复制失败");
-              } catch { antdMessage.error("复制失败"); }
-            }}
-            style={{
-              fontSize: 11, color: "var(--color-text-quaternary)", marginBottom: 12,
-              fontFamily: "var(--font-mono)", overflow: "hidden",
-              textOverflow: "ellipsis", whiteSpace: "nowrap", cursor: "pointer",
-              padding: "6px 10px", background: "var(--color-bg-elevated)", borderRadius: 6,
-              border: "1px solid var(--color-border-light)",
-            }}
-          >
-            {record.command}
-          </div>
-        </Tooltip>
-      )}
+      {/* 执行命令 —— 可折叠，默认收缩 */}
+      {record?.command && <CollapsibleCommand command={record.command} />}
 
       {/* 元信息行：评分 + 导出 */}
       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
@@ -658,20 +637,103 @@ function LogDrawer({
         ) : (
           <div
             style={{
-              background: "var(--log-bg)", color: "var(--log-text)",
-              padding: 12, borderRadius: 8, fontFamily: "var(--font-mono)",
-              fontSize: 11, whiteSpace: "pre-wrap", wordBreak: "break-all",
+              background: "var(--log-bg)",
+              color: "var(--log-text)",
+              padding: 12,
+              borderRadius: 8,
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
             }}
           >
-            {displayLogs.map((log: LogEntry, i: number) => (
-              <div key={i}>
-                [{log.type}] {log.content}
+            {displayLogs.length === 0 ? (
+              <div style={{ color: "var(--log-text-muted)" }}>
+                {isLoadingLogs ? "加载中..." : "暂无日志"}
               </div>
-            ))}
+            ) : (
+              displayLogs.map((log: LogEntry, idx: number) => (
+                <div key={idx} style={{ marginBottom: 4, display: "flex", gap: 8 }}>
+                  <span style={{ color: "var(--log-text-muted)", flexShrink: 0 }}>
+                    {formatLogTime(log.timestamp || "")}
+                  </span>
+                  <span style={{ color: LOG_TYPE_COLORS[log.type || ""] || "var(--log-text)", fontWeight: 500 }}>
+                    [{LOG_TYPE_LABELS[log.type || ""] || log.type}]
+                  </span>
+                  <span>{log.content}</span>
+                </div>
+              ))
+            )}
           </div>
         )}
       </div>
     </Drawer>
+  );
+}
+
+// ─── 可折叠命令 ────────────────────────────────────────────
+
+/**
+ * 可折叠的命令展示，默认收缩。
+ * 折叠态显示命令前 60 字 + 复制按钮；
+ * 展开态显示完整命令文本。
+ */
+function CollapsibleCommand({ command }: { command: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      const ok = await copyToClipboard(command);
+      antdMessage[ok ? "success" : "error"](ok ? "已复制" : "复制失败");
+    } catch {
+      antdMessage.error("复制失败");
+    }
+  };
+
+  const truncated = command.length > 60 ? command.substring(0, 60) + "..." : command;
+
+  return (
+    <div
+      style={{
+        marginBottom: 12,
+        padding: "8px 12px",
+        background: "var(--log-bg)",
+        borderRadius: 6,
+        border: "1px solid var(--color-border-light)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <Button
+          type="text"
+          size="small"
+          icon={expanded ? <CaretUpOutlined /> : <CaretDownOutlined />}
+          onClick={() => setExpanded(!expanded)}
+          style={{ flexShrink: 0, padding: "0 4px" }}
+        />
+        <span
+          style={{
+            flex: 1,
+            minWidth: 0,
+            fontSize: 11,
+            fontFamily: "var(--font-mono)",
+            color: "var(--log-text)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: expanded ? "pre-wrap" : "nowrap",
+            wordBreak: "break-all",
+            cursor: "pointer",
+          }}
+          onClick={() => setExpanded(!expanded)}
+        >
+          {expanded ? command : truncated}
+        </span>
+        <Button
+          type="text"
+          size="small"
+          icon={<CopyOutlined />}
+          onClick={handleCopy}
+          style={{ flexShrink: 0 }}
+        />
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/components/TodoPostPage.tsx
+++ b/frontend/src/components/TodoPostPage.tsx
@@ -38,9 +38,9 @@ import {
   InputNumber,
   Space,
   Tooltip,
-  Popconfirm,
+  message as antdMessage,
 } from "antd";
-import { StarOutlined, StarFilled, FileTextOutlined, MessageOutlined } from "@ant-design/icons";
+import { StarOutlined, StarFilled, FileTextOutlined } from "@ant-design/icons";
 
 /**
  * 全屏帖子详情页 —— 按 session_id 加载同 session 的所有记录。
@@ -576,10 +576,10 @@ function LogDrawer({
   const [viewMode, setViewMode] = useState<"chat" | "command" | "log">("chat");
 
   const liveLogs = (() => {
-    if (!recordId) return null;
+    if (!record) return null;
     const allTasks = Object.values(runningTasks);
     for (const t of allTasks) {
-      if (t.recordId === recordId) return t.logs || null;
+      if (t.recordId === record.id) return t.logs || null;
     }
     return null;
   })();
@@ -588,21 +588,51 @@ function LogDrawer({
 
   return (
     <Drawer
-      title={
-        viewMode === "chat"
-          ? `对话视图 #${recordId || ""}`
-          : viewMode === "command"
-          ? `命令视图 #${recordId || ""}`
-          : `执行日志 #${recordId || ""}`
-      }
+      title={`执行详情 #${record?.id || ""}`}
       open={open}
       onClose={onClose}
       width="60%"
-      styles={{ body: { padding: "12px 16px" } }}
+      styles={{ body: { padding: "12px 16px", display: "flex", flexDirection: "column" } }}
     >
-      <div style={{ marginBottom: 12, display: "flex", alignItems: "center", gap: 8 }}>
-        <RefreshBtn onClick={() => { if (recordId) onLoadLogs(recordId, logsPage); }} />
+      {/* 执行命令 */}
+      {record?.command && (
+        <Tooltip title="点击复制命令">
+          <div
+            onClick={async () => {
+              try {
+                const ok = await copyToClipboard(record.command || "");
+                antdMessage[ok ? "success" : "error"](ok ? "已复制" : "复制失败");
+              } catch { antdMessage.error("复制失败"); }
+            }}
+            style={{
+              fontSize: 11, color: "var(--color-text-quaternary)", marginBottom: 12,
+              fontFamily: "var(--font-mono)", overflow: "hidden",
+              textOverflow: "ellipsis", whiteSpace: "nowrap", cursor: "pointer",
+              padding: "6px 10px", background: "var(--color-bg-elevated)", borderRadius: 6,
+              border: "1px solid var(--color-border-light)",
+            }}
+          >
+            {record.command}
+          </div>
+        </Tooltip>
+      )}
+
+      {/* 元信息行：评分 + 导出 */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+        {record && record.status !== "running" && (
+          <RatingControl record={record} onRate={onRate} />
+        )}
+        {record && record.status !== "running" && !!record.finished_at && (
+          <Button type="text" size="small" icon={<FileTextOutlined />} onClick={() => onExport(record)}>
+            导出YAML
+          </Button>
+        )}
         <div style={{ flex: 1 }} />
+        <RefreshBtn onClick={() => { if (record) onLoadLogs(record.id, logsPage); }} />
+      </div>
+
+      {/* 视图切换 */}
+      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
         <Button type={viewMode === "chat" ? "primary" : "default"} size="small" onClick={() => setViewMode("chat")}>
           对话
         </Button>
@@ -642,5 +672,83 @@ function LogDrawer({
         )}
       </div>
     </Drawer>
+  );
+}
+
+// ─── 评分控件 ──────────────────────────────────────────────
+
+function RatingControl({
+  record,
+  onRate,
+}: {
+  record: ExecutionRecord;
+  onRate: (recordId: number, rating: number | null) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState<number | null>(record.rating ?? null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    setValue(record.rating ?? null);
+  }, [record.rating, record.id]);
+
+  const handleSubmit = async (next: number | null) => {
+    setSubmitting(true);
+    try {
+      await onRate(record.id, next);
+      setOpen(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (record.rating != null) {
+    return (
+      <Popover
+        open={open}
+        onOpenChange={setOpen}
+        trigger="click"
+        content={
+          <Space.Compact style={{ width: 200 }}>
+            <InputNumber
+              min={0} max={100} value={value}
+              onChange={v => setValue(typeof v === "number" ? v : null)}
+              placeholder="0-100" style={{ width: "100%" }}
+              onPressEnter={() => { if (value != null) handleSubmit(value); }}
+            />
+            <Button type="primary" loading={submitting} onClick={() => { if (value != null) handleSubmit(value); }}>
+              更新
+            </Button>
+          </Space.Compact>
+        }
+      >
+        <Button type="text" size="small" icon={<StarFilled style={{ color: "#faad14" }} />}>
+          {record.rating}
+        </Button>
+      </Popover>
+    );
+  }
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+      trigger="click"
+      content={
+        <Space.Compact style={{ width: 200 }}>
+          <InputNumber
+            min={0} max={100} value={value}
+            onChange={v => setValue(typeof v === "number" ? v : null)}
+            placeholder="0-100" style={{ width: "100%" }}
+            onPressEnter={() => { if (value != null) handleSubmit(value); }}
+          />
+          <Button type="primary" loading={submitting} onClick={() => { if (value != null) handleSubmit(value); }}>
+            评分
+          </Button>
+        </Space.Compact>
+      }
+    >
+      <Button type="text" size="small" icon={<StarOutlined />}>评分</Button>
+    </Popover>
   );
 }

--- a/frontend/src/components/TodoPostPage.tsx
+++ b/frontend/src/components/TodoPostPage.tsx
@@ -1,0 +1,646 @@
+import { useState, useRef, useEffect, useMemo } from "react";
+import {
+  Button,
+  Empty,
+  App,
+  Tag,
+  Drawer,
+} from "antd";
+import {
+  ArrowLeftOutlined,
+  StopOutlined,
+  LinkOutlined,
+  InfoCircleOutlined,
+} from "@ant-design/icons";
+import { useApp } from "@/hooks/useApp";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { PageCard } from "@/components/common/PageCard";
+import { ExecutorBadge } from "@/components/ExecutorBadge";
+import { ChatView } from "@/components/ChatView";
+import { CommandPanel } from "@/components/CommandPanel";
+import { CollapsibleConclusion } from "./todo-detail/CollapsibleConclusion";
+import { ReplyInput } from "./todo-detail/ReplyInput";
+import { RefreshBtn } from "./todo-detail/LogViewHeader";
+import { groupBySession } from "./todo-detail/helpers";
+import { formatLocalDateTime, formatDurationSec } from "@/utils/datetime";
+import { getElapsedSeconds } from "./todo-detail/helpers";
+import { supportsResume } from "@/types";
+import { parseLogsToMessages } from "./ChatView";
+import { conversationToYaml } from "@/utils/markdown";
+import { getExecutorOption } from "@/types";
+import { copyToClipboard } from "@/utils/clipboard";
+import { EXPORT } from "@/constants";
+import * as db from "@/utils/database";
+import type { ExecutionRecord, LogEntry } from "@/types";
+import type { SessionGroup } from "./todo-detail/helpers";
+import {
+  Popover,
+  InputNumber,
+  Space,
+  Tooltip,
+  Popconfirm,
+} from "antd";
+import { StarOutlined, StarFilled, FileTextOutlined, MessageOutlined } from "@ant-design/icons";
+
+/**
+ * 全屏帖子详情页 —— 按 session_id 加载同 session 的所有记录。
+ * 进入页面后获取目标记录 → 取 session_id → 调后端接口拉取同 session 记录。
+ */
+export function TodoPostPage({
+  todoId,
+  recordId,
+  onBack,
+}: {
+  todoId: number;
+  recordId: number;
+  onBack: () => void;
+}) {
+  const { state } = useApp();
+  const isMobile = useIsMobile();
+  const { message } = App.useApp();
+  const { runningTasks } = state;
+
+  const [records, setRecords] = useState<ExecutionRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [replyLoading, setReplyLoading] = useState(false);
+
+  // 日志抽屉状态
+  const [logDrawerOpen, setLogDrawerOpen] = useState(false);
+  const [logDrawerRecordId, setLogDrawerRecordId] = useState<number | null>(null);
+  const [paginatedLogs, setPaginatedLogs] = useState<LogEntry[]>([]);
+  const [logsPage, setLogsPage] = useState(1);
+  const logsPerPage = 200;
+  const [isLoadingLogs, setIsLoadingLogs] = useState(false);
+
+  // 加载 session 记录
+  const loadSessionRecords = async () => {
+    setLoading(true);
+    try {
+      // 1. 获取目标记录
+      const targetRecord = await db.getExecutionRecord(recordId);
+      // 2. 如果有 session_id，拉取同 session 的所有记录
+      if (targetRecord.session_id) {
+        const sessionRecords = await db.getExecutionRecordsBySession(targetRecord.session_id);
+        // 按 started_at 排序
+        sessionRecords.sort((a, b) =>
+          (a.started_at || "").localeCompare(b.started_at || "")
+        );
+        setRecords(sessionRecords);
+      } else {
+        // 无 session_id，只显示这一条
+        setRecords([targetRecord]);
+      }
+    } catch (error) {
+      message.error("加载执行记录失败: " + (error instanceof Error ? error.message : String(error)));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadSessionRecords();
+  }, [recordId]);
+
+  // 加载日志
+  const loadLogsForRecord = async (rId: number, page: number) => {
+    setIsLoadingLogs(true);
+    try {
+      const result = await db.getExecutionLogs(rId, page, logsPerPage);
+      setPaginatedLogs(result.logs);
+      setLogsPage(page);
+    } catch {
+      // ignore
+    } finally {
+      setIsLoadingLogs(false);
+    }
+  };
+
+  const isExecuting = Object.values(runningTasks).some(
+    (t) => t.todoId === todoId && t.status === "running"
+  );
+
+  // 定时器 —— 实时计时
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!isExecuting) return;
+    const interval = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(interval);
+  }, [isExecuting]);
+
+  // 执行结束时刷新
+  const prevIsExecutingRef = useRef(isExecuting);
+  useEffect(() => {
+    const prev = prevIsExecutingRef.current;
+    if (prev && !isExecuting) {
+      loadSessionRecords();
+    }
+    prevIsExecutingRef.current = isExecuting;
+  }, [isExecuting]);
+
+  const getRunningTaskForRecord = (r: ExecutionRecord) => {
+    if (r.task_id) return runningTasks[r.task_id] || null;
+    return Object.values(runningTasks).find((t) => t.todoId === r.todo_id) || null;
+  };
+
+  const resolveExecutionStats = (r: ExecutionRecord, running: boolean) => {
+    if (running) {
+      const task = getRunningTaskForRecord(r);
+      if (task?.executionStats) return task.executionStats;
+    }
+    return r.execution_stats;
+  };
+
+  const sessionGroups = useMemo(() => groupBySession(records), [records]);
+
+  const handleStopExecution = async (rId: number) => {
+    try {
+      await db.stopExecution(rId);
+      message.info("已发送停止指令");
+      await loadSessionRecords();
+    } catch (error) {
+      message.error("停止失败: " + (error instanceof Error ? error.message : String(error)));
+    }
+  };
+
+  const handleReply = async (r: ExecutionRecord, replyMessage: string) => {
+    if (!replyMessage.trim()) return;
+    setReplyLoading(true);
+    try {
+      await db.resumeExecutionRecord(r.id, replyMessage);
+      message.success("回复成功，开始执行");
+      await loadSessionRecords();
+    } catch (error) {
+      message.error("回复失败: " + (error instanceof Error ? error.message : String(error)));
+    } finally {
+      setReplyLoading(false);
+    }
+  };
+
+  const handleRateExecution = async (rId: number, rating: number | null) => {
+    try {
+      await db.rateExecutionRecord(rId, rating);
+      // 刷新当前记录
+      const updated = await db.getExecutionRecord(rId);
+      setRecords(prev => prev.map(r => (r.id === rId ? updated : r)));
+      message.success(rating == null ? "已清除评分" : `已评分 ${rating}`);
+    } catch (error) {
+      message.error("评分失败: " + (error instanceof Error ? error.message : String(error)));
+    }
+  };
+
+  const handleExportMarkdown = async (r: ExecutionRecord) => {
+    let logs: LogEntry[] = [];
+    try {
+      const result = await db.getExecutionLogs(r.id, 1, EXPORT.maxLogs);
+      logs = result.logs;
+    } catch { /* ignore */ }
+    const msgs = parseLogsToMessages(logs);
+    const executorLabel = r.executor ? getExecutorOption(r.executor).label : undefined;
+    const content = conversationToYaml(msgs, {
+      title: todo?.title,
+      executor: executorLabel,
+      model: r.model || undefined,
+      startedAt: r.started_at,
+      status: r.status,
+    });
+    const blob = new Blob([content], { type: "application/x-yaml;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+    a.download = `exec-${r.id}-${ts}.yaml`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    message.success("导出成功");
+  };
+
+  const handleSelectRecord = (rId: number) => {
+    const url = new URL(window.location.href);
+    url.searchParams.set("record", String(rId));
+    window.history.replaceState(null, "", url.toString());
+  };
+
+  const openLogDrawer = (rId: number) => {
+    setLogDrawerRecordId(rId);
+    loadLogsForRecord(rId, 1);
+    setLogDrawerOpen(true);
+  };
+
+  const todo = state.todos.find((t) => t.id === todoId);
+  const todoTitle = todo?.title || `事项 #${todoId}`;
+
+  // 全局楼层号
+  let floorCounter = 0;
+  const getNextFloor = () => {
+    floorCounter++;
+    return floorCounter;
+  };
+
+  return (
+    <PageCard
+      icon={<InfoCircleOutlined />}
+      title={todoTitle}
+      extra={
+        <Button type="text" icon={<ArrowLeftOutlined />} onClick={onBack}>
+          返回
+        </Button>
+      }
+      contentStyle={{ padding: isMobile ? 8 : "16px 24px 40px", overflow: "auto" }}
+      style={{ flex: 1, width: "100%", minHeight: 0 }}
+      contentClassName="todo-post-content"
+    >
+      {loading ? (
+        <div style={{ textAlign: "center", padding: 40, color: "var(--color-text-tertiary)" }}>
+          加载中...
+        </div>
+      ) : records.length === 0 ? (
+        <Empty description="暂无执行记录" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+      ) : (
+        sessionGroups.map((group) => (
+          <ThreadGroup
+            key={group.sessionId}
+            group={group}
+            getNextFloor={getNextFloor}
+            onSelectRecord={handleSelectRecord}
+            onStop={handleStopExecution}
+            onReply={handleReply}
+            replyLoading={replyLoading}
+            onOpenLogDrawer={openLogDrawer}
+            resolveExecutionStats={resolveExecutionStats}
+          />
+        ))
+      )}
+
+      {/* 日志/对话抽屉 */}
+      <LogDrawer
+        open={logDrawerOpen}
+        record={records.find(r => r.id === logDrawerRecordId) || null}
+        paginatedLogs={paginatedLogs}
+        logsPage={logsPage}
+        isLoadingLogs={isLoadingLogs}
+        onLoadLogs={loadLogsForRecord}
+        onClose={() => setLogDrawerOpen(false)}
+        runningTasks={runningTasks}
+        onRate={handleRateExecution}
+        onExport={handleExportMarkdown}
+      />
+    </PageCard>
+  );
+}
+
+// ─── 帖子组（所有记录平铺为连续楼层） ─────────────────────────
+
+function ThreadGroup({
+  group,
+  getNextFloor,
+  onSelectRecord,
+  onStop,
+  onReply,
+  replyLoading,
+  onOpenLogDrawer,
+  resolveExecutionStats,
+}: {
+  group: SessionGroup;
+  getNextFloor: () => number;
+  onSelectRecord: (id: number) => void;
+  onStop: (id: number) => Promise<void>;
+  onReply: (r: ExecutionRecord, msg: string) => Promise<void>;
+  replyLoading: boolean;
+  onOpenLogDrawer: (id: number) => void;
+  resolveExecutionStats: (r: ExecutionRecord, running: boolean) => any;
+}) {
+  const allRecords = group.records;
+  const lastRecord = allRecords[allRecords.length - 1];
+
+  return (
+    <div style={{ marginBottom: 24 }}>
+      {allRecords.map((record, idx) => (
+        <PostCard
+          key={record.id}
+          record={record}
+          floor={getNextFloor()}
+          isContinuation={idx > 0}
+          onSelect={() => onSelectRecord(record.id)}
+          onStop={onStop}
+          onOpenLogDrawer={onOpenLogDrawer}
+          resolveExecutionStats={resolveExecutionStats}
+        />
+      ))}
+      <ReplyRow record={lastRecord} onReply={onReply} loading={replyLoading} />
+    </div>
+  );
+}
+
+// ─── 主帖卡片 ──────────────────────────────────────────────
+
+function PostCard({
+  record,
+  floor,
+  isContinuation = false,
+  onSelect,
+  onStop,
+  onOpenLogDrawer,
+  resolveExecutionStats,
+}: {
+  record: ExecutionRecord;
+  floor: number;
+  isContinuation?: boolean;
+  onSelect: () => void;
+  onStop: (id: number) => Promise<void>;
+  onOpenLogDrawer: (id: number) => void;
+  resolveExecutionStats: (r: ExecutionRecord, running: boolean) => any;
+}) {
+  const isRunning = record.status === "running";
+  const [elapsedSec, setElapsedSec] = useState(
+    isRunning ? getElapsedSeconds(record.started_at) : 0
+  );
+
+  useEffect(() => {
+    if (!isRunning) return;
+    const tick = () => setElapsedSec(getElapsedSeconds(record.started_at));
+    tick();
+    const timer = setInterval(tick, 1000);
+    return () => clearInterval(timer);
+  }, [isRunning, record.started_at]);
+
+  const stats = resolveExecutionStats(record, isRunning);
+
+  return (
+    <div
+      onClick={onSelect}
+      style={{
+        background: "var(--color-bg-elevated)",
+        border: "1px solid var(--color-border-light)",
+        borderRadius: 8,
+        padding: "16px 20px",
+        cursor: "pointer",
+        marginBottom: 2,
+      }}
+    >
+      {/* 帖子头 */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 10,
+          paddingBottom: 8,
+          borderBottom: "1px dashed var(--color-border-light)",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <span style={{ fontSize: 14, fontWeight: 700, color: "var(--color-primary)" }}>
+            #{floor}
+          </span>
+          {isContinuation && (
+            <>
+              <LinkOutlined style={{ fontSize: 12, color: "var(--color-primary)" }} />
+              {record.resume_message ? (
+                <span style={{
+                  fontSize: 12,
+                  color: "var(--color-text-secondary)",
+                  fontStyle: "italic",
+                  maxWidth: 300,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}>
+                  {String(record.resume_message).length > 40
+                    ? String(record.resume_message).substring(0, 40) + "..."
+                    : record.resume_message}
+                </span>
+              ) : (
+                <span style={{ fontSize: 12, color: "var(--color-text-tertiary)" }}>
+                  继续对话
+                </span>
+              )}
+            </>
+          )}
+          {record.executor && !isContinuation && <ExecutorBadge executor={record.executor} />}
+          {record.model && (
+            <Tag color="#3b82f6" style={{ margin: 0, fontSize: 11 }}>
+              {record.model}
+            </Tag>
+          )}
+          <span style={{ fontSize: 12, color: "var(--color-text-tertiary)" }}>
+            {formatLocalDateTime(record.started_at)}
+          </span>
+          <Tag
+            color={
+              record.trigger_type === "cron"
+                ? "#8b5cf6"
+                : record.trigger_type?.startsWith("hook:")
+                ? "#a855f7"
+                : "#6b7280"
+            }
+            style={{ margin: 0, fontSize: 11 }}
+          >
+            {record.trigger_type === "cron"
+              ? "Cron"
+              : record.trigger_type?.startsWith("hook:")
+              ? "Hook"
+              : "手动"}
+          </Tag>
+          {!isRunning && record.usage?.duration_ms && (
+            <span style={{ fontSize: 12, color: "var(--color-success)", fontWeight: 600 }}>
+              {formatDurationSec(record.usage.duration_ms / 1000)}
+            </span>
+          )}
+          {isRunning && elapsedSec > 0 && (
+            <span style={{ fontSize: 12, color: "var(--color-info)", fontWeight: 600 }}>
+              {formatDurationSec(elapsedSec)}
+            </span>
+          )}
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span
+            style={{
+              fontSize: 11,
+              padding: "2px 10px",
+              borderRadius: 12,
+              backgroundColor:
+                record.status === "success"
+                  ? "var(--color-success)"
+                  : record.status === "failed"
+                  ? "var(--color-error)"
+                  : "var(--color-info)",
+              color: "#fff",
+              fontWeight: 600,
+            }}
+          >
+            {record.status === "success" ? "成功" : record.status === "failed" ? "失败" : "进行中"}
+          </span>
+          {isRunning && (
+            <Button
+              type="text" size="small" danger icon={<StopOutlined />}
+              onClick={(e) => { e.stopPropagation(); onStop(record.id); }}
+            >
+              停止
+            </Button>
+          )}
+          <Button
+            type="text" size="small" icon={<InfoCircleOutlined />}
+            onClick={(e) => { e.stopPropagation(); onOpenLogDrawer(record.id); }}
+          >
+            详情
+          </Button>
+        </div>
+      </div>
+
+      {/* 帖子内容 —— 结论 */}
+      {record.result ? (
+        <CollapsibleConclusion result={record.result} status={record.status} recordId={record.id} />
+      ) : isRunning ? (
+        <div style={{ color: "var(--color-text-tertiary)", fontSize: 13, padding: "8px 0" }}>
+          执行中...
+        </div>
+      ) : (
+        <div style={{ color: "var(--color-text-tertiary)", fontSize: 13, padding: "8px 0" }}>
+          暂无结论
+        </div>
+      )}
+
+      {/* 统计 */}
+      <div style={{
+        display: "flex", gap: 16, marginTop: 8, fontSize: 11,
+        color: "var(--color-text-tertiary)", flexWrap: "wrap",
+      }}>
+        {record.usage && (
+          <>
+            <span>Input: <b>{record.usage.input_tokens.toLocaleString()}</b></span>
+            <span>Output: <b>{record.usage.output_tokens.toLocaleString()}</b></span>
+            {record.usage.total_cost_usd != null && (
+              <span style={{ color: "var(--color-warning)" }}>
+                ${record.usage.total_cost_usd.toFixed(6)}
+              </span>
+            )}
+          </>
+        )}
+        {stats && (
+          <>
+            <span>工具调用: <b style={{ color: "var(--color-primary)" }}>{stats.tool_calls}</b></span>
+            <span>对话轮次: <b style={{ color: "var(--color-primary)" }}>{stats.conversation_turns}</b></span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── 回复输入行 ────────────────────────────────────────────
+
+function ReplyRow({
+  record,
+  onReply,
+  loading,
+}: {
+  record: ExecutionRecord;
+  onReply: (r: ExecutionRecord, msg: string) => Promise<void>;
+  loading: boolean;
+}) {
+  if (record.status === "running" || !supportsResume(record)) return null;
+  return (
+    <div style={{ padding: "4px 0" }}>
+      <ReplyInput record={record} onReply={onReply} loading={loading} />
+    </div>
+  );
+}
+
+// ─── 日志/对话/命令抽屉 ────────────────────────────────────
+
+function LogDrawer({
+  open,
+  record,
+  paginatedLogs,
+  logsPage,
+  isLoadingLogs,
+  onLoadLogs,
+  onClose,
+  runningTasks,
+  onRate,
+  onExport,
+}: {
+  open: boolean;
+  record: ExecutionRecord | null;
+  paginatedLogs: LogEntry[];
+  logsPage: number;
+  isLoadingLogs: boolean;
+  onLoadLogs: (recordId: number, page: number) => Promise<void>;
+  onClose: () => void;
+  runningTasks: Record<string, any>;
+  onRate: (recordId: number, rating: number | null) => Promise<void>;
+  onExport: (record: ExecutionRecord) => void;
+}) {
+  const [viewMode, setViewMode] = useState<"chat" | "command" | "log">("chat");
+
+  const liveLogs = (() => {
+    if (!recordId) return null;
+    const allTasks = Object.values(runningTasks);
+    for (const t of allTasks) {
+      if (t.recordId === recordId) return t.logs || null;
+    }
+    return null;
+  })();
+
+  const displayLogs = liveLogs && liveLogs.length > 0 ? liveLogs : paginatedLogs;
+
+  return (
+    <Drawer
+      title={
+        viewMode === "chat"
+          ? `对话视图 #${recordId || ""}`
+          : viewMode === "command"
+          ? `命令视图 #${recordId || ""}`
+          : `执行日志 #${recordId || ""}`
+      }
+      open={open}
+      onClose={onClose}
+      width="60%"
+      styles={{ body: { padding: "12px 16px" } }}
+    >
+      <div style={{ marginBottom: 12, display: "flex", alignItems: "center", gap: 8 }}>
+        <RefreshBtn onClick={() => { if (recordId) onLoadLogs(recordId, logsPage); }} />
+        <div style={{ flex: 1 }} />
+        <Button type={viewMode === "chat" ? "primary" : "default"} size="small" onClick={() => setViewMode("chat")}>
+          对话
+        </Button>
+        <Button type={viewMode === "command" ? "primary" : "default"} size="small" onClick={() => setViewMode("command")}>
+          命令
+        </Button>
+        <Button type={viewMode === "log" ? "primary" : "default"} size="small" onClick={() => setViewMode("log")}>
+          日志
+        </Button>
+      </div>
+
+      <div style={{ overflow: "auto", flex: 1 }}>
+        {isLoadingLogs ? (
+          <div style={{ textAlign: "center", padding: 40, color: "var(--color-text-tertiary)" }}>
+            加载中...
+          </div>
+        ) : displayLogs.length === 0 ? (
+          <Empty description="暂无日志" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+        ) : viewMode === "chat" ? (
+          <ChatView logs={displayLogs} isRunning={false} />
+        ) : viewMode === "command" ? (
+          <CommandPanel logs={displayLogs} executor={undefined} />
+        ) : (
+          <div
+            style={{
+              background: "var(--log-bg)", color: "var(--log-text)",
+              padding: 12, borderRadius: 8, fontFamily: "var(--font-mono)",
+              fontSize: 11, whiteSpace: "pre-wrap", wordBreak: "break-all",
+            }}
+          >
+            {displayLogs.map((log: LogEntry, i: number) => (
+              <div key={i}>
+                [{log.type}] {log.content}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Drawer>
+  );
+}

--- a/frontend/src/components/todo-detail/ForumPostCard.tsx
+++ b/frontend/src/components/todo-detail/ForumPostCard.tsx
@@ -1,4 +1,5 @@
 import { Tag, Badge } from 'antd';
+import { StarFilled } from '@ant-design/icons';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { formatLocalDateTime, formatDurationSec } from '@/utils/datetime';
 import { getElapsedSeconds } from './helpers';
@@ -104,6 +105,12 @@ export function ForumPostCard({
         </span>
         {record.executor && <ExecutorBadge executor={record.executor} />}
         {record.model && <Tag color="#3b82f6" style={{ fontSize: 10, padding: '0 6px', lineHeight: '18px', margin: 0 }}>{record.model}</Tag>}
+        {record.rating != null && (
+          <span style={{ color: '#faad14', fontWeight: 600, display: 'flex', alignItems: 'center', gap: 2 }}>
+            <StarFilled style={{ fontSize: 10 }} />
+            {record.rating}
+          </span>
+        )}
         <Tag color={record.trigger_type === 'cron' ? '#8b5cf6' : record.trigger_type?.startsWith('hook:') ? '#a855f7' : '#6b7280'} style={{ fontSize: 10, padding: '0 6px', lineHeight: '18px', margin: 0 }}>
           {record.trigger_type === 'cron' ? 'Cron' : record.trigger_type?.startsWith('hook:') ? 'Hook' : '手动'}
         </Tag>

--- a/frontend/src/components/todo-detail/ForumPostCard.tsx
+++ b/frontend/src/components/todo-detail/ForumPostCard.tsx
@@ -1,0 +1,128 @@
+import { Tag, Badge } from 'antd';
+import { ExecutorBadge } from '@/components/ExecutorBadge';
+import { formatLocalDateTime, formatDurationSec } from '@/utils/datetime';
+import { getElapsedSeconds } from './helpers';
+import { useState, useEffect } from 'react';
+import type { ExecutionRecord } from '@/types';
+
+/**
+ * 提取帖子标题：取 result 第一行（去除 markdown 标记），
+ * 截取前 40 字。无 result 时返回 "执行中"。
+ */
+function extractPostTitle(result: string | null | undefined): string {
+  if (!result || result.trim() === '') return '执行中';
+  const firstLine = result.split('\n')[0];
+  const cleaned = firstLine.replace(/^[#*>+\-\s]+/, '').trim();
+  if (!cleaned) return '执行中';
+  if (cleaned.length > 40) return cleaned.substring(0, 40) + '...';
+  return cleaned;
+}
+
+/**
+ * 论坛帖子卡片 —— 一行一条执行记录。
+ */
+export function ForumPostCard({
+  record,
+  isSelected,
+  onSelect,
+  replyCount,
+}: {
+  record: ExecutionRecord;
+  isSelected: boolean;
+  onSelect: () => void;
+  /** 追问数量，>0 时显示 badge */
+  replyCount?: number;
+}) {
+  const isRunning = record.status === 'running';
+  const [elapsedSec, setElapsedSec] = useState(isRunning ? getElapsedSeconds(record.started_at) : 0);
+
+  useEffect(() => {
+    if (!isRunning) return;
+    const tick = () => setElapsedSec(getElapsedSeconds(record.started_at));
+    tick();
+    const timer = setInterval(tick, 1000);
+    return () => clearInterval(timer);
+  }, [isRunning, record.started_at]);
+
+  const title = extractPostTitle(record.result);
+  const statusColor =
+    record.status === 'success' ? 'var(--color-success)' :
+    record.status === 'failed' ? 'var(--color-error)' :
+    'var(--color-info)';
+
+  const statusText =
+    record.status === 'success' ? '成功' :
+    record.status === 'failed' ? '失败' :
+    '进行中';
+
+  return (
+    <div
+      onClick={onSelect}
+      style={{
+        padding: '10px 14px',
+        marginBottom: 2,
+        borderRadius: 6,
+        cursor: 'pointer',
+        background: isSelected ? 'var(--color-primary-bg)' : 'var(--color-bg-elevated)',
+        border: `1px solid ${isSelected ? 'var(--color-primary)' : 'var(--color-border-light)'}`,
+        transition: 'background 0.15s, border-color 0.15s',
+      }}
+    >
+      {/* 第一行：状态 + 标题 + 追问 badge */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+        <span style={{
+          flexShrink: 0,
+          fontSize: 10,
+          padding: '1px 8px',
+          borderRadius: 10,
+          backgroundColor: statusColor,
+          color: '#fff',
+          fontWeight: 600,
+          lineHeight: '18px',
+        }}>
+          {statusText}
+        </span>
+        <span style={{
+          fontSize: 13,
+          fontWeight: 600,
+          color: isRunning ? 'var(--color-info)' : 'var(--color-text)',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}>
+          {title}
+        </span>
+        {replyCount != null && replyCount > 0 && (
+          <Badge count={replyCount} size="small" style={{ backgroundColor: 'var(--color-primary)' }} />
+        )}
+      </div>
+
+      {/* 第二行：元信息 */}
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', fontSize: 11 }}>
+        <span style={{ color: 'var(--color-text-tertiary)' }}>
+          {formatLocalDateTime(record.started_at)}
+        </span>
+        {record.executor && <ExecutorBadge executor={record.executor} />}
+        {record.model && <Tag color="#3b82f6" style={{ fontSize: 10, padding: '0 6px', lineHeight: '18px', margin: 0 }}>{record.model}</Tag>}
+        <Tag color={record.trigger_type === 'cron' ? '#8b5cf6' : record.trigger_type?.startsWith('hook:') ? '#a855f7' : '#6b7280'} style={{ fontSize: 10, padding: '0 6px', lineHeight: '18px', margin: 0 }}>
+          {record.trigger_type === 'cron' ? 'Cron' : record.trigger_type?.startsWith('hook:') ? 'Hook' : '手动'}
+        </Tag>
+        {!isRunning && record.usage?.duration_ms && (
+          <span style={{ color: 'var(--color-success)', fontWeight: 600 }}>
+            {formatDurationSec(record.usage.duration_ms / 1000)}
+          </span>
+        )}
+        {isRunning && elapsedSec > 0 && (
+          <span style={{ color: 'var(--color-info)', fontWeight: 600 }}>
+            {formatDurationSec(elapsedSec)}
+          </span>
+        )}
+        {record.execution_stats && (
+          <span style={{ color: 'var(--color-text-tertiary)' }}>
+            🔧{record.execution_stats.tool_calls} 💬{record.execution_stats.conversation_turns}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/todo-detail/ForumPostList.tsx
+++ b/frontend/src/components/todo-detail/ForumPostList.tsx
@@ -1,0 +1,59 @@
+import { Pagination } from 'antd';
+import { ForumPostCard } from './ForumPostCard';
+import type { SessionGroup } from './helpers';
+
+/**
+ * 论坛帖子列表 —— 只显示主帖（每个 session 的第一条记录）。
+ * 追问数量以 badge 展示，点击主帖进入详情页查看完整帖子流。
+ */
+export function ForumPostList({
+  sessionGroups,
+  selectedRecordId,
+  onSelectRecord,
+  historyTotal,
+  historyLimit,
+  historyPage,
+  onPageChange,
+}: {
+  sessionGroups: SessionGroup[];
+  selectedRecordId: number | null;
+  onSelectRecord: (id: number) => void;
+  historyTotal: number;
+  historyLimit: number;
+  historyPage: number;
+  onPageChange: (page: number, pageSize: number) => void;
+}) {
+  return (
+    <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+      {sessionGroups.map(group => {
+        const mainRecord = group.records[0];
+        const replyCount = group.records.length > 1 ? group.records.length - 1 : 0;
+
+        return (
+          <div key={group.sessionId}>
+            <ForumPostCard
+              record={mainRecord}
+              isSelected={selectedRecordId === mainRecord.id}
+              onSelect={() => onSelectRecord(mainRecord.id)}
+              replyCount={replyCount}
+            />
+          </div>
+        );
+      })}
+
+      {/* 分页 */}
+      {historyTotal > historyLimit && (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '12px 0' }}>
+          <Pagination
+            simple
+            current={historyPage}
+            pageSize={historyLimit}
+            total={historyTotal}
+            onChange={onPageChange}
+            size="small"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/todo-detail/ForumReplyCard.tsx
+++ b/frontend/src/components/todo-detail/ForumReplyCard.tsx
@@ -1,0 +1,129 @@
+import { LinkOutlined } from '@ant-design/icons';
+import { formatLocalDateTime, formatDurationSec } from '@/utils/datetime';
+import { getElapsedSeconds } from './helpers';
+import { useState, useEffect } from 'react';
+import type { ExecutionRecord } from '@/types';
+
+/**
+ * 提取帖子标题：取 result 第一行（去除 markdown 标记），
+ * 截取前 40 字。无 result 时返回 "执行中"。
+ */
+function extractPostTitle(result: string | null | undefined): string {
+  if (!result || result.trim() === '') return '执行中';
+  const firstLine = result.split('\n')[0];
+  const cleaned = firstLine.replace(/^[#*>+\-\s]+/, '').trim();
+  if (!cleaned) return '执行中';
+  if (cleaned.length > 40) return cleaned.substring(0, 40) + '...';
+  return cleaned;
+}
+
+/**
+ * 论坛跟帖/回复卡片 —— 同 session 的后续执行记录。
+ * 缩进 + 左边框连线，视觉上表示主帖的回复。
+ */
+export function ForumReplyCard({
+  record,
+  resumeMessage,
+  isSelected,
+  onSelect,
+}: {
+  record: ExecutionRecord;
+  resumeMessage?: string | null;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  const isRunning = record.status === 'running';
+  const [elapsedSec, setElapsedSec] = useState(isRunning ? getElapsedSeconds(record.started_at) : 0);
+
+  useEffect(() => {
+    if (!isRunning) return;
+    const tick = () => setElapsedSec(getElapsedSeconds(record.started_at));
+    tick();
+    const timer = setInterval(tick, 1000);
+    return () => clearInterval(timer);
+  }, [isRunning, record.started_at]);
+
+  const title = extractPostTitle(record.result);
+  const msg = resumeMessage
+    ? (resumeMessage.length > 30 ? resumeMessage.substring(0, 30) + '...' : resumeMessage)
+    : '继续对话';
+
+  const statusColor =
+    record.status === 'success' ? 'var(--color-success)' :
+    record.status === 'failed' ? 'var(--color-error)' :
+    'var(--color-info)';
+
+  return (
+    <div
+      onClick={onSelect}
+      style={{
+        marginLeft: 24,
+        padding: '6px 10px',
+        borderLeft: '2px solid var(--color-primary)',
+        borderBottom: '1px solid var(--color-border-light)',
+        cursor: 'pointer',
+        background: isSelected ? 'var(--color-primary-bg)' : 'var(--color-bg-elevated)',
+        transition: 'background 0.15s',
+        marginBottom: 1,
+      }}
+    >
+      {/* 第一行：图标 + resume_message + 状态 */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 3 }}>
+        <span style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 11, color: 'var(--color-primary)', fontWeight: 500 }}>
+          <LinkOutlined style={{ fontSize: 10 }} />
+          <span style={{ color: 'var(--color-text-secondary)', fontWeight: 400 }}>
+            {msg}
+          </span>
+        </span>
+        <span style={{
+          flexShrink: 0,
+          fontSize: 9,
+          padding: '1px 6px',
+          borderRadius: 8,
+          backgroundColor: statusColor,
+          color: '#fff',
+          fontWeight: 600,
+          lineHeight: '16px',
+        }}>
+          {record.status === 'success' ? '成功' : record.status === 'failed' ? '失败' : '进行中'}
+        </span>
+      </div>
+
+      {/* 第二行：标题 */}
+      <div style={{
+        fontSize: 12,
+        fontWeight: 500,
+        color: isRunning ? 'var(--color-info)' : 'var(--color-text)',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        marginBottom: 3,
+        paddingLeft: 14,
+      }}>
+        {title}
+      </div>
+
+      {/* 第三行：元信息 */}
+      <div style={{ display: 'flex', gap: 4, alignItems: 'center', flexWrap: 'wrap', fontSize: 10, paddingLeft: 14 }}>
+        <span style={{ color: 'var(--color-text-tertiary)' }}>
+          {formatLocalDateTime(record.started_at)}
+        </span>
+        {!isRunning && record.usage?.duration_ms && (
+          <span style={{ color: 'var(--color-success)', fontWeight: 600 }}>
+            {formatDurationSec(record.usage.duration_ms / 1000)}
+          </span>
+        )}
+        {isRunning && elapsedSec > 0 && (
+          <span style={{ color: 'var(--color-info)', fontWeight: 600 }}>
+            {formatDurationSec(elapsedSec)}
+          </span>
+        )}
+        {record.execution_stats && (
+          <span style={{ color: 'var(--color-text-tertiary)' }}>
+            🔧{record.execution_stats.tool_calls}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/todo-detail/PostDetailDrawer.tsx
+++ b/frontend/src/components/todo-detail/PostDetailDrawer.tsx
@@ -1,0 +1,401 @@
+import { useState, useEffect } from 'react';
+import { Drawer, Button, Tag, Empty, Segmented, Popconfirm, Tooltip, Pagination, message, Popover, InputNumber, Space } from 'antd';
+import { StarOutlined, StarFilled, LinkOutlined, UnorderedListOutlined, CodeOutlined } from '@ant-design/icons';
+import { MessageOutlined, FileTextOutlined, StopOutlined } from '@ant-design/icons';
+import { ExecutorBadge } from '@/components/ExecutorBadge';
+import { ChatView } from '@/components/ChatView';
+import { CommandPanel } from '@/components/CommandPanel';
+import { RefreshBtn } from './LogViewHeader';
+import { formatLocalDateTime, formatDurationSec } from '@/utils/datetime';
+import { getElapsedSeconds, formatLogTime } from './helpers';
+import { LOG_TYPE_COLORS, LOG_TYPE_LABELS } from '@/constants';
+import { CollapsibleConclusion } from './CollapsibleConclusion';
+import { ReplyInput } from './ReplyInput';
+import { copyToClipboard } from '@/utils/clipboard';
+import { supportsResume } from '@/types';
+import type { SessionGroup } from './helpers';
+import type { ExecutionRecord, LogEntry, ExecutionStats } from '@/types';
+
+export interface PostDetailProps {
+  record: ExecutionRecord;
+  sessionGroups: SessionGroup[];
+  onSelectRecord: (id: number) => void;
+  onStop: (recordId: number) => Promise<void>;
+  onRefreshSingle: (recordId: number) => Promise<void>;
+  onRate: (recordId: number, rating: number | null) => Promise<void>;
+  onExportMarkdown: (record: ExecutionRecord) => Promise<void>;
+  onReply: (record: ExecutionRecord, message: string) => Promise<void>;
+  replyLoading: boolean;
+  paginatedLogs: LogEntry[];
+  logsTotal: number;
+  logsPage: number;
+  logsPerPage: number;
+  onLoadLogs: (recordId: number, page: number) => Promise<void>;
+  isLoadingLogs: boolean;
+  getRunningTaskForRecord: (record: ExecutionRecord) => any;
+  resolveExecutionStats: (record: ExecutionRecord, isRunning: boolean) => ExecutionStats | null | undefined;
+}
+
+/**
+ * 帖子详情内容（无外壳）—— 供 PostDetailDrawer 和 TodoPostPage 共用。
+ */
+export function PostDetailContent(props: PostDetailProps) {
+  const { record } = props;
+  const [viewMode, setViewMode] = useState<'log' | 'chat' | 'command'>('log');
+  const isRunning = record.status === 'running';
+  const runningTask = isRunning ? props.getRunningTaskForRecord(record) : null;
+  const liveLogs = runningTask ? runningTask.logs : null;
+  const displayLogs = liveLogs && liveLogs.length > 0 ? liveLogs : props.paginatedLogs;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+        {/* Continuation breadcrumb */}
+        {(() => {
+          const group = props.sessionGroups.find(g => g.records.some(r => r.id === record.id));
+          if (!group || group.records.length <= 1 || !group.records[0].session_id) return null;
+          const idx = group.records.findIndex(r => r.id === record.id);
+          if (idx <= 0) return null;
+          return (
+            <div style={{
+              display: 'flex', alignItems: 'center', gap: 6,
+              marginBottom: 10, padding: '4px 10px', borderRadius: 6,
+              background: 'var(--color-bg-elevated)', border: '1px solid var(--color-border-light)',
+              fontSize: 11, color: 'var(--color-text-tertiary)',
+            }}>
+              <LinkOutlined style={{ color: 'var(--color-primary)', fontSize: 11 }} />
+              <span>继续自</span>
+              <span
+                onClick={() => props.onSelectRecord(group.records[0].id)}
+                style={{ cursor: 'pointer', color: 'var(--color-primary)', fontWeight: 500 }}
+              >
+                {formatLocalDateTime(group.records[0].started_at)}
+              </span>
+              {record.resume_message && (
+                <>
+                  <span style={{ color: 'var(--color-border)' }}>·</span>
+                  <span style={{ color: 'var(--color-text-secondary)', fontStyle: 'italic' }}>
+                    &quot;{String(record.resume_message).length > 40 ? String(record.resume_message).substring(0, 40) + '...' : record.resume_message}&quot;
+                  </span>
+                </>
+              )}
+              <span style={{ marginLeft: 'auto', color: 'var(--color-text-quaternary)' }}>
+                第{idx + 1}轮 / 共{group.records.length}轮
+              </span>
+            </div>
+          );
+        })()}
+
+        {/* Header row */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12, flexWrap: 'wrap', gap: 8 }}>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+            {record.executor && <ExecutorBadge executor={record.executor} />}
+            {record.model && <Tag color="#3b82f6">{record.model}</Tag>}
+            <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', fontWeight: 500 }}>
+              {formatLocalDateTime(record.started_at)}
+            </span>
+            <span style={{
+              fontSize: 11, padding: '3px 12px', borderRadius: 12,
+              backgroundColor: record.status === 'success' ? 'var(--color-success)' : record.status === 'failed' ? 'var(--color-error)' : 'var(--color-info)',
+              color: '#fff', fontWeight: 600,
+            }}>
+              {record.status === 'success' ? '成功' : record.status === 'failed' ? '失败' : '进行中'}
+            </span>
+            {!isRunning && record.usage?.duration_ms && (
+              <span style={{ fontSize: 12, color: 'var(--color-success)', fontWeight: 600 }}>
+                {formatDurationSec(record.usage.duration_ms / 1000)}
+              </span>
+            )}
+            {isRunning && (
+              <span style={{ fontSize: 12, color: 'var(--color-info)', fontWeight: 600 }}>
+                {formatDurationSec(getElapsedSeconds(record.started_at))}
+              </span>
+            )}
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            {!isRunning && supportsResume(record) && (
+              <Button type="primary" size="small" icon={<MessageOutlined />} onClick={() => props.onReply(record, '')}>继续对话</Button>
+            )}
+            {!isRunning && (
+              <RatingControl record={record} onRate={props.onRate} />
+            )}
+            {!isRunning && !!record.finished_at && (
+              <Button type="text" size="small" icon={<FileTextOutlined />} onClick={() => props.onExportMarkdown(record)}>导出YAML</Button>
+            )}
+            {isRunning && (
+              <Popconfirm title="确定强制停止该任务？" okText="停止" cancelText="取消" onConfirm={async () => { await props.onStop(record.id); }}>
+                <Button type="text" size="small" icon={<StopOutlined />}>停止</Button>
+              </Popconfirm>
+            )}
+          </div>
+        </div>
+
+        {/* Command */}
+        {record.command && (
+          <Tooltip title="点击复制命令">
+            <div
+              onClick={async () => {
+                try {
+                  const ok = await copyToClipboard(record.command || '');
+                  message[ok ? 'success' : 'error'](ok ? '已复制' : '复制失败');
+                } catch { message.error('复制失败'); }
+              }}
+              style={{ fontSize: 11, color: 'var(--color-text-quaternary)', marginBottom: 12, fontFamily: 'var(--font-mono)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', cursor: 'pointer' }}
+            >
+              {record.command}
+            </div>
+          </Tooltip>
+        )}
+
+        {/* Worktree path */}
+        {record.worktree_path && (
+          <div style={{ fontSize: 11, color: 'var(--color-text-quaternary)', marginBottom: 12 }}>
+            worktree: {record.worktree_path}
+          </div>
+        )}
+
+        {/* Conclusion */}
+        {record.result !== null && record.result !== '' && (
+          <CollapsibleConclusion
+            result={record.result}
+            status={record.status}
+            messageApi={message}
+            showTitle
+            recordId={record.id}
+          />
+        )}
+
+        {/* Usage stats */}
+        {record.usage && (
+          <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginBottom: 12, display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+            <span>Input: {record.usage.input_tokens.toLocaleString()}</span>
+            <span>Output: {record.usage.output_tokens.toLocaleString()}</span>
+            {record.usage.total_cost_usd !== null && (
+              <span style={{ color: 'var(--color-warning)', fontWeight: 600 }}>${record.usage.total_cost_usd.toFixed(6)}</span>
+            )}
+          </div>
+        )}
+
+        {/* Execution stats */}
+        {(() => {
+          const stats = props.resolveExecutionStats(record, isRunning);
+          if (!stats) return null;
+          return (
+            <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginBottom: 12, display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+              <span>工具调用: <b style={{ color: 'var(--color-primary)' }}>{stats.tool_calls}</b></span>
+              <span>对话轮次: <b style={{ color: 'var(--color-primary)' }}>{stats.conversation_turns}</b></span>
+              {stats.thinking_count > 0 && (
+                <span>思考次数: <b style={{ color: 'var(--color-primary)' }}>{stats.thinking_count}</b></span>
+              )}
+            </div>
+          );
+        })()}
+
+        {/* Log view header + content */}
+        {(() => {
+          if (!isRunning && displayLogs.length === 0) return null;
+          return (
+            <div>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-primary)' }}>
+                    {viewMode === 'command'
+                      ? `命令视图 (${displayLogs.length} 条${isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''})`
+                      : viewMode === 'chat'
+                        ? `对话视图 (${displayLogs.length} 条${isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''})`
+                        : `执行过程 (${isRunning ? displayLogs.length : props.logsTotal} 条${isRunning && liveLogs && liveLogs.length > 0 ? ' · 实时' : ''})`}
+                  </span>
+                  <RefreshBtn onClick={() => { props.onRefreshSingle(record.id); props.onLoadLogs(record.id, props.logsPage); }} />
+                </div>
+                <Segmented
+                  size="small"
+                  value={viewMode}
+                  onChange={(value) => setViewMode(value as 'log' | 'chat' | 'command')}
+                  options={[
+                    { value: 'log', icon: <UnorderedListOutlined />, label: '日志' },
+                    { value: 'chat', icon: <MessageOutlined />, label: '对话' },
+                    { value: 'command', icon: <CodeOutlined />, label: '命令' },
+                  ]}
+                />
+              </div>
+
+              {viewMode === 'chat' ? (
+                <ChatView logs={displayLogs as LogEntry[]} isRunning={isRunning} />
+              ) : viewMode === 'command' ? (
+                <div style={{ overflow: 'auto', padding: 4 }}>
+                  <CommandPanel logs={displayLogs} executor={record.executor} />
+                </div>
+              ) : (
+                <div style={{
+                  background: 'var(--log-bg)', color: 'var(--log-text)',
+                  padding: 12, borderRadius: 8, fontFamily: 'var(--font-mono)', fontSize: 11, overflow: 'auto',
+                }}>
+                  {displayLogs.length === 0 ? (
+                    <div style={{ color: 'var(--log-text-muted)' }}>{isRunning ? '等待输出...' : (props.isLoadingLogs ? '加载中...' : '暂无日志')}</div>
+                  ) : (
+                    displayLogs.map((log: LogEntry, idx: number) => (
+                      <div key={idx} style={{ marginBottom: 4, display: 'flex', gap: 8 }}>
+                        <span style={{ color: 'var(--log-text-muted)', flexShrink: 0 }}>{formatLogTime(log.timestamp || '')}</span>
+                        <span style={{ color: LOG_TYPE_COLORS[log.type || ''] || 'var(--log-text)' }}>
+                          [{LOG_TYPE_LABELS[log.type || ''] || log.type}]
+                        </span>
+                        <span>{log.content}</span>
+                      </div>
+                    ))
+                  )}
+                </div>
+              )}
+
+              {!isRunning && props.logsTotal > props.logsPerPage && (
+                <Pagination
+                  simple
+                  current={props.logsPage}
+                  pageSize={props.logsPerPage}
+                  total={props.logsTotal}
+                  onChange={(page) => props.onLoadLogs(record.id, page)}
+                  size="small"
+                  style={{ marginTop: 8, textAlign: 'center' }}
+                />
+              )}
+            </div>
+          );
+        })()}
+      </div>
+
+      {/* Reply input at the bottom */}
+      {!isRunning && supportsResume(record) && (
+        <div style={{ flexShrink: 0, paddingTop: 12, borderTop: '1px solid var(--color-border-light)' }}>
+          <ReplyInput record={record} onReply={props.onReply} loading={props.replyLoading} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * 帖子详情抽屉 —— 点击帖子后从右侧滑出。
+ */
+export function PostDetailDrawer({
+  open,
+  record,
+  onClose,
+  ...contentProps
+}: {
+  open: boolean;
+  record: ExecutionRecord | null;
+  onClose: () => void;
+} & PostDetailProps) {
+  if (!record) {
+    return (
+      <Drawer
+        title="帖子详情"
+        open={open}
+        onClose={onClose}
+        width="65%"
+        styles={{ body: { padding: 0 } }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+          <Empty description="请选择一条执行记录" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+        </div>
+      </Drawer>
+    );
+  }
+
+  return (
+    <Drawer
+      title={
+        <span style={{ fontSize: 14, fontWeight: 600 }}>
+          {record.result
+            ? (record.result.split('\n')[0]?.replace(/^[#*>+\-\s]+/, '').trim().substring(0, 50) || '执行记录')
+            : '执行记录'}
+          {record.result && record.result.split('\n')[0]?.length > 50 ? '...' : ''}
+        </span>
+      }
+      open={open}
+      onClose={onClose}
+      width="65%"
+      styles={{ body: { padding: '16px 20px', display: 'flex', flexDirection: 'column' } }}
+    >
+      <PostDetailContent record={record} {...contentProps} />
+    </Drawer>
+  );
+}
+
+/**
+ * 评分控件，与 RecordDetailView 内部的 RecordRatingControl 功能一致。
+ */
+function RatingControl({
+  record,
+  onRate,
+}: {
+  record: ExecutionRecord;
+  onRate: (recordId: number, rating: number | null) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState<number | null>(record.rating ?? null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    setValue(record.rating ?? null);
+  }, [record.rating, record.id]);
+
+  const handleSubmit = async (next: number | null) => {
+    setSubmitting(true);
+    try {
+      await onRate(record.id, next);
+      setOpen(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (record.rating != null) {
+    return (
+      <Popover
+        open={open}
+        onOpenChange={setOpen}
+        trigger="click"
+        content={
+          <Space.Compact style={{ width: 200 }}>
+            <InputNumber
+              min={0} max={100} value={value}
+              onChange={v => setValue(typeof v === 'number' ? v : null)}
+              placeholder="0-100" style={{ width: '100%' }}
+              onPressEnter={() => { if (value != null) handleSubmit(value); }}
+            />
+            <Button type="primary" loading={submitting} onClick={() => { if (value != null) handleSubmit(value); }}>
+              更新
+            </Button>
+          </Space.Compact>
+        }
+      >
+        <Button type="text" size="small" icon={<StarFilled style={{ color: '#faad14' }} />}>
+          {record.rating}
+        </Button>
+      </Popover>
+    );
+  }
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+      trigger="click"
+      content={
+        <Space.Compact style={{ width: 200 }}>
+          <InputNumber
+            min={0} max={100} value={value}
+            onChange={v => setValue(typeof v === 'number' ? v : null)}
+            placeholder="0-100" style={{ width: '100%' }}
+            onPressEnter={() => { if (value != null) handleSubmit(value); }}
+          />
+          <Button type="primary" loading={submitting} onClick={() => { if (value != null) handleSubmit(value); }}>
+            评分
+          </Button>
+        </Space.Compact>
+      }
+    >
+      <Button type="text" size="small" icon={<StarOutlined />}>评分</Button>
+    </Popover>
+  );
+}

--- a/frontend/src/components/todo-detail/ReplyInput.tsx
+++ b/frontend/src/components/todo-detail/ReplyInput.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { Input, Button } from 'antd';
+import { SendOutlined } from '@ant-design/icons';
+import type { ExecutionRecord } from '@/types';
+
+/**
+ * 论坛式内联回复框 —— 替代原来的 Modal "继续对话"。
+ * 输入框 + 回复按钮，紧凑布局。
+ */
+export function ReplyInput({
+  record,
+  onReply,
+  loading,
+}: {
+  record: ExecutionRecord;
+  onReply: (record: ExecutionRecord, message: string) => Promise<void>;
+  loading?: boolean;
+}) {
+  const [message, setMessage] = useState('');
+
+  const handleReply = async () => {
+    const trimmed = message.trim();
+    if (!trimmed || loading) return;
+    await onReply(record, trimmed);
+    setMessage('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleReply();
+    }
+  };
+
+  return (
+    <div style={{
+      marginLeft: 24,
+      marginTop: 4,
+      marginBottom: 8,
+      display: 'flex',
+      gap: 8,
+      alignItems: 'center',
+    }}>
+      <Input
+        size="small"
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="输入回复内容..."
+        disabled={loading}
+        style={{
+          flex: 1,
+          borderRadius: 16,
+          fontSize: 12,
+        }}
+      />
+      <Button
+        type="primary"
+        size="small"
+        icon={<SendOutlined />}
+        onClick={handleReply}
+        loading={loading}
+        disabled={!message.trim()}
+        style={{ borderRadius: 16 }}
+      >
+        回复
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useViewState.ts
+++ b/frontend/src/hooks/useViewState.ts
@@ -36,7 +36,7 @@ export type View =
   | 'sessions'
   | 'executors';
 
-export type Panel = 'list' | 'detail';
+export type Panel = 'list' | 'detail' | 'post';
 
 const ALL_VIEWS: View[] = [
   'items', 'loops',
@@ -65,19 +65,27 @@ function getInitialTab(): string | null {
 }
 
 function getInitialPanel(): Panel {
-  // 移动端使用 panel 参数区分列表/详情页面
-  // 桌面端忽略此参数，始终显示 list+detail 双栏布局
+  // 桌面端使用 panel 参数区分列表/帖子详情页面
   const panel = new URLSearchParams(window.location.search).get('panel') as Panel | null;
-  return panel === 'detail' ? 'detail' : 'list';
+  if (panel === 'detail' || panel === 'post') return panel;
+  return 'list';
 }
 
-function buildUrl(view: View, opts?: { id?: number | null; tab?: string | null; panel?: Panel }): string {
+function getInitialRecordId(): number | null {
+  const record = new URLSearchParams(window.location.search).get('record');
+  if (!record) return null;
+  const n = Number(record);
+  return Number.isFinite(n) ? n : null;
+}
+
+function buildUrl(view: View, opts?: { id?: number | null; tab?: string | null; panel?: Panel; record?: number | null }): string {
   const params = new URLSearchParams();
   params.set('view', view);
   if (opts?.id != null) params.set('id', String(opts.id));
   if (typeof opts?.tab === 'string' && opts.tab.trim()) params.set('tab', opts.tab);
-  // 只有移动端需要 panel 参数，桌面端不需要（双栏布局始终显示）
-  if (opts?.panel === 'detail') params.set('panel', 'detail');
+  // panel 参数：detail 用于移动端，post 用于帖子详情页
+  if (opts?.panel === 'detail' || opts?.panel === 'post') params.set('panel', opts.panel);
+  if (opts?.record != null) params.set('record', String(opts.record));
   const qs = params.toString();
   return qs ? `/?${qs}` : '/';
 }
@@ -109,32 +117,34 @@ export function useViewState() {
   const [selectedId, setSelectedId] = useState<number | null>(getInitialId);
   // tab 只用于 settings view，暴露给 SettingsPage 使用
   const [activeTab, setActiveTab] = useState<string | null>(getInitialTab);
-  // panel 只用于移动端 list/detail 独立页面，桌面端忽略（始终显示双栏）
+  // panel：list=列表，detail=移动端详情，post=帖子详情（桌面端全屏）
   const [activePanel, setActivePanel] = useState<Panel>(getInitialPanel);
+  // record：帖子详情页中选中的执行记录 ID
+  const [selectedRecordId, setSelectedRecordId] = useState<number | null>(getInitialRecordId);
 
   // 统一 push URL + React state — 用于视图间导航（首页 → 各视图）
-  const pushUrl = useCallback((view: View, opts?: { id?: number | null; tab?: string | null; panel?: Panel }) => {
+  const pushUrl = useCallback((view: View, opts?: { id?: number | null; tab?: string | null; panel?: Panel; record?: number | null }) => {
     const url = buildUrl(view, opts);
     window.history.pushState(null, '', url);
     setActiveView(view);
     setSelectedId(opts?.id ?? null);
     setActiveTab(opts?.tab ?? null);
-    // panel 仅在移动端有意义，桌面端始终为 list
     setActivePanel(opts?.panel ?? 'list');
+    setSelectedRecordId(opts?.record ?? null);
   }, []);
 
-  // replaceUrl — 用于移动端 list/detail 内部切换，不污染浏览器历史
-  // 桌面端也可以用，保持行为一致
-  const replaceUrl = useCallback((view: View, opts?: { id?: number | null; tab?: string | null; panel?: Panel }) => {
+  // replaceUrl — 用于切换不污染浏览器历史
+  const replaceUrl = useCallback((view: View, opts?: { id?: number | null; tab?: string | null; panel?: Panel; record?: number | null }) => {
     const url = buildUrl(view, opts);
     window.history.replaceState(null, '', url);
     setActiveView(view);
     setSelectedId(opts?.id ?? null);
     setActiveTab(opts?.tab ?? null);
     setActivePanel(opts?.panel ?? 'list');
+    setSelectedRecordId(opts?.record ?? null);
   }, []);
 
-  // 统一 popstate 处理 — 替代了之前分散在 App.tsx / SettingsPage 的三个监听器
+  // 统一 popstate 处理
   useEffect(() => {
     const onPopState = () => {
       const params = new URLSearchParams(window.location.search);
@@ -142,13 +152,15 @@ export function useViewState() {
       const idStr = params.get('id');
       const tab = params.get('tab');
       const panel = params.get('panel') as Panel | null;
+      const recordStr = params.get('record');
       const resolvedView = view && ALL_VIEWS.includes(view) ? view : 'items';
       const resolvedId = idStr ? (Number.isFinite(Number(idStr)) ? Number(idStr) : null) : null;
+      const resolvedRecord = recordStr ? (Number.isFinite(Number(recordStr)) ? Number(recordStr) : null) : null;
       setActiveView(resolvedView);
       setSelectedId(resolvedId);
       setActiveTab(tab || null);
-      // panel 只在移动端使用，桌面端始终为 list
-      setActivePanel(panel === 'detail' ? 'detail' : 'list');
+      setActivePanel(panel === 'detail' || panel === 'post' ? panel : 'list');
+      setSelectedRecordId(resolvedRecord);
     };
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
@@ -182,6 +194,7 @@ export function useViewState() {
     activeTab,
     activePanel,
     selectedPanel,
+    selectedRecordId,
     showView,
     selectTodo,
     backToList,


### PR DESCRIPTION
## 概述

将事项详情页从复杂的双栏布局（执行历史列表 + 日志/对话详情）重构为论坛帖子式交互。

### 核心变更

**1. 论坛帖子列表**
- 每条执行记录 = 一条帖子卡片（一行一条）
- 同 session 的追问以 badge 数字展示（`2` 表示有 2 个追问）
- 帖子标题取 result 结论前 40 字（或"执行中"）
- 评分有值时展示 `★ 85`

**2. 论坛帖子详情页**（`?view=items&id=27&panel=post&record=2094`）
- 全屏论坛楼层式布局（#1 主帖、#2 追问、#3 追问...）
- 按 session_id 请求后端，只加载同 session 记录
- 每条帖子完整展示结论内容（XMarkdown 渲染）
- 追问楼层显示 resume_message + 结论
- 底部内联回复框（替代原来的 Modal "继续对话"）
- PageCard 包裹，宽度自适应

**3. 详情抽屉**
- 点击楼层 `详情` 按钮 → 右侧抽屉
- 默认展示对话视图（可切换日志/命令）
- 执行命令区：深色终端风格 + 可折叠 + 复制按钮
- 评分控件 + 导出 YAML

**4. 已删除**
- 标签筛选器
- "放大"全屏按钮 + 全屏 Modal

### 文件变更
| 操作 | 文件 |
|------|------|
| 新建 | `ForumPostCard.tsx`, `ForumPostList.tsx`, `ForumReplyCard.tsx`, `ReplyInput.tsx`, `TodoPostPage.tsx` |
| 修改 | `TodoDetail.tsx`, `TodoPage.tsx`, `App.tsx`, `useViewState.ts`, `PostDetailDrawer.tsx` |
| 后端 | `pi.rs` 命令格式从 `--continue` 改为 `--session <id>` |

### 技术决策
- 不改后端 API（新增 session 查询接口前端已存在,直接调用）
- 帖子列表纯前端渲染，帖子详情页按 session_id 请求后端
- URL 路由：`pushUrl` 统一管理（App.tsx → TodoPage → TodoDetail 逐层传递回调）