### PR TITLE
refactor: 全栈 workspace_id 破坏式改造 + 多项 fix/chore

### DIFF
--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -373,6 +373,19 @@ pub trait CodeExecutor: Send + Sync {
     fn get_tool_calls_count(&self) -> Option<u64> {
         None
     }
+
+    /// 子进程启动后、关闭 stdin 之前要写入的内容。
+    ///
+    /// 用途：等价于 `echo "<content>" | <executor> ...` 的管道输入。
+    /// 默认 `None`（直接关闭 stdin，与重构前一致）；个别执行器需要在 stdin 上预置
+    /// 自动应答（例如 pi 在启用 Worktree 切目录后会在交互式 prompt 卡住，
+    /// 通过预写 "y" 自动确认目录切换）时可 override 返回 `Some(...)`。
+    ///
+    /// 实现要求：内容应一次性写入并立刻 flush；写入失败由调用方记录 warning 但不视为致命错误，
+    /// 因为 stdin 关闭本身仍能保证子进程正常退出。
+    fn stdin_payload(&self) -> Option<String> {
+        None
+    }
 }
 
 /// 代码执行器注册表

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -309,6 +309,17 @@ impl CodeExecutor for PiExecutor {
         &self.base.path
     }
 
+    /// pi 在启用 Worktree 并切换工作目录时会卡在交互式确认 prompt 上（"directory changed, continue? [y/N]"）。
+    /// 通过 stdin 预写一个 "y\n" 自动应答，相当于在 shell 里 `echo "y" | pi -p ...`。
+    /// 等价于 `echo y | pi ...`：预写一行 y 后关闭 stdin，pi 读到 y 后继续后续执行，
+    /// 不会再向 stdin 请求输入。
+    ///
+    /// 仅在 pi 启动时（-p 模式）需要这一次应答；非交互模式（-p 下 pi 也走 stdin 询问）
+    /// 下也安全：多写一个 y 不会让 pi 异常。
+    fn stdin_payload(&self) -> Option<String> {
+        Some("y\n".to_string())
+    }
+
     fn command_args(&self, message: &str) -> Vec<String> {
         vec![
             "-p".to_string(),
@@ -451,6 +462,14 @@ mod tests {
         let executor = PiExecutor::new("pi".to_string());
         assert_eq!(executor.extract_session_id(""), None);
         assert_eq!(executor.extract_session_id("not json"), None);
+    }
+
+    /// stdin_payload 应返回 "y\n" —— 等价于 `echo "y" | pi -p ...`，
+    /// 用来自动应答 pi 启用 Worktree 切目录后的交互式确认 prompt。
+    #[test]
+    fn test_stdin_payload_returns_y() {
+        let executor = PiExecutor::new("pi".to_string());
+        assert_eq!(executor.stdin_payload(), Some("y\n".to_string()));
     }
 
     #[test]

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -90,9 +90,9 @@ pub enum TodoAction {
         #[arg(short, long)]
         executor: Option<String>,
 
-        /// Working directory
-        #[arg(short, long)]
-        workspace: Option<String>,
+        /// Working directory (workspace path)
+        #[arg(short = 'w', long = "workspace-path")]
+        workspace_path: Option<String>,
 
         /// Tag IDs (comma-separated)
         #[arg(long)]
@@ -154,9 +154,9 @@ pub enum TodoAction {
         #[arg(long)]
         executor: Option<String>,
 
-        /// New working directory
-        #[arg(long)]
-        workspace: Option<String>,
+        /// New working directory (workspace path)
+        #[arg(long = "workspace-path")]
+        workspace_path: Option<String>,
 
         /// New tag IDs (comma-separated)
         #[arg(long)]
@@ -268,9 +268,10 @@ pub enum TagAction {
 pub enum LoopAction {
     /// List all loops
     List {
-        /// Filter by workspace
-        #[arg(long)]
-        workspace: Option<String>,
+        /// Filter by workspace ID (unique key; use --workspace-id instead of path
+        /// since path is not unique across project_directories).
+        #[arg(long = "workspace-id")]
+        workspace_id: Option<i64>,
     },
     /// Get loop details
     Get {
@@ -393,7 +394,7 @@ async fn handle_todo(
     fields: &Option<String>,
 ) -> Result<()> {
     match action {
-        TodoAction::Create { title, prompt, file, stdin, executor, workspace, tags, schedule } => {
+        TodoAction::Create { title, prompt, file, stdin, executor, workspace_path, tags, schedule } => {
             let mut req = if *stdin {
                 // Read from stdin
                 let value = read_stdin_json()?;
@@ -413,8 +414,8 @@ async fn handle_todo(
                         auto_review_enabled: value.get("auto_review_enabled").and_then(|v| v.as_bool()),
                         webhook_enabled: None,
                     });
-                    if workspace.is_some() {
-                        // workspace is sent separately in the full JSON body
+                    if workspace_path.is_some() {
+                        // workspace_path is sent separately in the full JSON body
                     }
                     req
             } else {
@@ -496,7 +497,7 @@ async fn handle_todo(
             let resp: ClientResponse<Todo> = client.get(&format!("/todos/{}", id)).await?;
             print_response(resp, output, fields)?;
         }
-        TodoAction::Update { id, title, prompt, file, stdin, status, executor, workspace, tags, schedule } => {
+        TodoAction::Update { id, title, prompt, file, stdin, status, executor, workspace_path, tags, schedule } => {
             let mut req = if *stdin {
                 read_stdin_json()?
             } else {
@@ -510,7 +511,7 @@ async fn handle_todo(
                     "prompt": prompt_content,
                     "status": status,
                     "executor": executor,
-                    "workspace": workspace,
+                    "workspace_path": workspace_path,
                 })
             };
 
@@ -519,7 +520,7 @@ async fn handle_todo(
             if let Some(p) = prompt { req["prompt"] = p.clone().into(); }
             if let Some(s) = status { req["status"] = s.clone().into(); }
             if let Some(e) = executor { req["executor"] = e.clone().into(); }
-            if let Some(w) = workspace { req["workspace"] = w.clone().into(); }
+            if let Some(w) = workspace_path { req["workspace_path"] = w.clone().into(); }
             if let Some(t) = tags {
                 let tag_ids: Vec<i64> = t.split(',').filter_map(|s| s.trim().parse().ok()).collect();
                 req["tag_ids"] = tag_ids.into();
@@ -646,9 +647,9 @@ async fn handle_loop(
     fields: &Option<String>,
 ) -> Result<()> {
     match action {
-        LoopAction::List { workspace } => {
-            let path = if let Some(w) = workspace {
-                format!("/loops?workspace={}", w)
+        LoopAction::List { workspace_id } => {
+            let path = if let Some(wid) = workspace_id {
+                format!("/loops?workspace_id={}", wid)
             } else {
                 "/loops".to_string()
             };

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -90,9 +90,9 @@ pub enum TodoAction {
         #[arg(short, long)]
         executor: Option<String>,
 
-        /// Working directory (workspace path)
-        #[arg(short = 'w', long = "workspace-path")]
-        workspace_path: Option<String>,
+        /// Working directory ID (project_directories.id). 唯一键，CLI 不再支持 path。
+        #[arg(short = 'w', long = "workspace-id")]
+        workspace_id: Option<i64>,
 
         /// Tag IDs (comma-separated)
         #[arg(long)]
@@ -154,9 +154,9 @@ pub enum TodoAction {
         #[arg(long)]
         executor: Option<String>,
 
-        /// New working directory (workspace path)
-        #[arg(long = "workspace-path")]
-        workspace_path: Option<String>,
+        /// New working directory ID (project_directories.id)
+        #[arg(long = "workspace-id")]
+        workspace_id: Option<i64>,
 
         /// New tag IDs (comma-separated)
         #[arg(long)]
@@ -394,7 +394,7 @@ async fn handle_todo(
     fields: &Option<String>,
 ) -> Result<()> {
     match action {
-        TodoAction::Create { title, prompt, file, stdin, executor, workspace_path, tags, schedule } => {
+        TodoAction::Create { title, prompt, file, stdin, executor, workspace_id, tags, schedule } => {
             let mut req = if *stdin {
                 // Read from stdin
                 let value = read_stdin_json()?;
@@ -413,10 +413,12 @@ async fn handle_todo(
                         acceptance_criteria: value.get("acceptance_criteria").and_then(|v| v.as_str()).map(|s| s.to_string()),
                         auto_review_enabled: value.get("auto_review_enabled").and_then(|v| v.as_bool()),
                         webhook_enabled: None,
+                        // stdin 路径下 workspace_id 由 JSON body 提供；若 body 没传则 fallback 到 CLI 参数；
+                        // 闭包内部不能 `?`，因此取不到时填 0，由下面 outer 检查 fail-fast。
+                        workspace_id: value.get("workspace_id").and_then(|v| v.as_i64())
+                            .or(*workspace_id)
+                            .unwrap_or(0),
                     });
-                    if workspace_path.is_some() {
-                        // workspace_path is sent separately in the full JSON body
-                    }
                     req
             } else {
                 let title = title.clone().ok_or_else(|| anyhow::anyhow!("Title is required. Use --stdin to read from stdin."))?;
@@ -437,6 +439,8 @@ async fn handle_todo(
                     acceptance_criteria: None,
                     webhook_enabled: None,
                     auto_review_enabled: None,
+                    // 非 stdin 模式下 workspace_id 必填：CLI 唯一标识符是 id 而非 path
+                    workspace_id: workspace_id.ok_or_else(|| anyhow::anyhow!("--workspace-id is required"))?,
                 }
             };
 
@@ -446,6 +450,11 @@ async fn handle_todo(
                     req.scheduler_enabled = Some(true);
                     req.scheduler_config = Some(s.clone());
                 }
+            }
+
+            // stdin 闭包不能 `?`，这里做统一的 fail-fast：workspace_id=0 表示上游未传
+            if req.workspace_id == 0 {
+                return Err(anyhow::anyhow!("workspace_id is required (pass --workspace-id or include in stdin JSON)").into());
             }
 
             let resp: ClientResponse<Todo> = client.post("/todos", &req).await?;
@@ -497,7 +506,7 @@ async fn handle_todo(
             let resp: ClientResponse<Todo> = client.get(&format!("/todos/{}", id)).await?;
             print_response(resp, output, fields)?;
         }
-        TodoAction::Update { id, title, prompt, file, stdin, status, executor, workspace_path, tags, schedule } => {
+        TodoAction::Update { id, title, prompt, file, stdin, status, executor, workspace_id, tags, schedule } => {
             let mut req = if *stdin {
                 read_stdin_json()?
             } else {
@@ -511,7 +520,7 @@ async fn handle_todo(
                     "prompt": prompt_content,
                     "status": status,
                     "executor": executor,
-                    "workspace_path": workspace_path,
+                    "workspace_id": workspace_id,
                 })
             };
 
@@ -520,7 +529,7 @@ async fn handle_todo(
             if let Some(p) = prompt { req["prompt"] = p.clone().into(); }
             if let Some(s) = status { req["status"] = s.clone().into(); }
             if let Some(e) = executor { req["executor"] = e.clone().into(); }
-            if let Some(w) = workspace_path { req["workspace_path"] = w.clone().into(); }
+            if let Some(w) = workspace_id { req["workspace_id"] = Value::from(*w as i64); }
             if let Some(t) = tags {
                 let tag_ids: Vec<i64> = t.split(',').filter_map(|s| s.trim().parse().ok()).collect();
                 req["tag_ids"] = tag_ids.into();

--- a/backend/src/db/entity/loops.rs
+++ b/backend/src/db/entity/loops.rs
@@ -12,7 +12,11 @@ pub struct Model {
     pub name: String,
     #[sea_orm(default_value = "")]
     pub description: String,
-    pub workspace: Option<String>,
+    /// Loop 所属的工作空间目录路径（对应 project_directories.path）。
+    /// path 不唯一，筛选只用 workspace_id；path 只用于 cwd/worktree。
+    pub workspace_path: Option<String>,
+    /// Loop 所属的工作空间 ID（关联 project_directories.id）。
+    pub workspace_id: Option<i64>,
     #[sea_orm(default_value = false)]
     pub webhook_enabled: bool,
     /// enabled | paused

--- a/backend/src/db/entity/todos.rs
+++ b/backend/src/db/entity/todos.rs
@@ -17,7 +17,9 @@ pub struct Model {
     pub scheduler_config: Option<String>,
     pub scheduler_timezone: Option<String>,
     pub task_id: Option<String>,
-    pub workspace: Option<String>,
+    /// 该 todo 所属的工作空间目录路径（对应 project_directories.path）。
+    /// 注意：path 不唯一，筛选与外键只用 workspace_id；path 只用于 cwd/worktree。
+    pub workspace_path: Option<String>,
     /// 该 todo 所属的工作空间 ID（关联 project_directories.id）
     pub workspace_id: Option<i64>,
     pub webhook_enabled: Option<bool>,

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -11,7 +11,7 @@
 //! 不抽象 DAO trait，因为 codebase 其它 db 文件都这样做）。
 use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter,
-    QueryOrder, QuerySelect, Set, Statement, DbBackend,
+    QueryOrder, QuerySelect, Set, DbBackend,
 };
 
 use crate::db::entity::{
@@ -288,12 +288,12 @@ impl Database {
 
             // 第二遍：更新有 goto 引用的步骤，把旧 step_id 换成新 step_id
             let old_to_new: std::collections::HashMap<i64, i64> = step_map.iter().map(|(old, new, _, _)| (*old, *new)).collect();
-            for (old_id, new_id, old_success_goto, old_fail_goto) in &step_map {
+            for (_old_id, new_id, old_success_goto, old_fail_goto) in &step_map {
                 let new_success_goto = old_success_goto.and_then(|g| old_to_new.get(&g).copied());
                 let new_fail_goto = old_fail_goto.and_then(|g| old_to_new.get(&g).copied());
 
                 if new_success_goto.is_some() || new_fail_goto.is_some() {
-                    let now = crate::models::utc_timestamp();
+                    let _now = crate::models::utc_timestamp();
                     let existing = loop_steps::Entity::find_by_id(*new_id).one(&self.conn).await?;
                     if let Some(c) = existing {
                         let mut am: loop_steps::ActiveModel = c.into();

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -10,8 +10,8 @@
 //! 与现有 webhook/tag 等模块风格保持一致（直接用 sea_orm::DatabaseConnection，
 //! 不抽象 DAO trait，因为 codebase 其它 db 文件都这样做）。
 use sea_orm::{
-    ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect,
-    Set, DbBackend,
+    ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter,
+    QueryOrder, QuerySelect, Set, Statement, DbBackend,
 };
 
 use crate::db::entity::{
@@ -49,7 +49,7 @@ impl Database {
         let am = loops::ActiveModel {
             name: ActiveValue::Set(name.to_string()),
             description: ActiveValue::Set(description.to_string()),
-            workspace: ActiveValue::Set(workspace.map(|s| s.to_string())),
+            workspace_path: ActiveValue::Set(workspace.map(|s| s.to_string())),
             webhook_enabled: ActiveValue::Set(webhook_enabled),
             icon: ActiveValue::Set(icon.to_string()),
             review_template_id: ActiveValue::Set(review_template_id),
@@ -83,7 +83,7 @@ impl Database {
             let mut am: loops::ActiveModel = c.into();
             am.name = ActiveValue::Set(name.to_string());
             am.description = ActiveValue::Set(description.to_string());
-            am.workspace = ActiveValue::Set(workspace.map(|s| s.to_string()));
+            am.workspace_path = ActiveValue::Set(workspace.map(|s| s.to_string()));
             am.webhook_enabled = ActiveValue::Set(webhook_enabled);
             am.icon = ActiveValue::Set(icon.to_string());
             am.review_template_id = ActiveValue::Set(review_template_id);
@@ -123,6 +123,246 @@ impl Database {
         Ok(())
     }
 
+    /// 批量更新环路工作空间（移动到其他工作空间）。
+    /// 连带移动步骤关联的所有 todo 到同一目标工作空间。
+    pub async fn batch_update_loops_workspace(
+        &self,
+        ids: &[i64],
+        workspace: &str,
+    ) -> Result<u64, sea_orm::DbErr> {
+        if ids.is_empty() || workspace.trim().is_empty() {
+            return Ok(0);
+        }
+        let now = crate::models::utc_timestamp();
+        let ws = workspace.trim();
+
+        // 1. 更新 loops 表
+        let placeholders: Vec<String> = (1..=ids.len()).map(|i| format!("?{}", i)).collect();
+        let in_clause = placeholders.join(",");
+        let ws_idx = ids.len() + 1;
+        let now_idx = ids.len() + 2;
+        let sql = format!(
+            "UPDATE loops SET workspace_path = ?{ws_idx}, updated_at = ?{now_idx} WHERE id IN ({in_clause})"
+        );
+        let mut vals: Vec<sea_orm::Value> = ids.iter().map(|id| (*id).into()).collect();
+        vals.push(ws.to_string().into());
+        vals.push(now.clone().into());
+        let stmt = sea_orm::Statement::from_sql_and_values(sea_orm::DbBackend::Sqlite, sql, vals);
+        self.conn.execute(stmt).await?.rows_affected();
+
+        // 2. 收集所有步骤关联的 todo_id 并批量迁移
+        let todo_ids = self.collect_todo_ids_from_loops(ids).await?;
+        if !todo_ids.is_empty() {
+            let t_placeholders: Vec<String> = (1..=todo_ids.len()).map(|i| format!("?{}", i)).collect();
+            let t_in_clause = t_placeholders.join(",");
+            let t_ws_idx = todo_ids.len() + 1;
+            let t_now_idx = todo_ids.len() + 2;
+            let t_sql = format!(
+                "UPDATE todos SET workspace_path = ?{t_ws_idx}, updated_at = ?{t_now_idx} WHERE id IN ({t_in_clause})"
+            );
+            let mut t_vals: Vec<sea_orm::Value> = todo_ids.iter().map(|id| (*id).into()).collect();
+            t_vals.push(ws.to_string().into());
+            t_vals.push(now.into());
+            let t_stmt = sea_orm::Statement::from_sql_and_values(sea_orm::DbBackend::Sqlite, t_sql, t_vals);
+            self.conn.execute(t_stmt).await?;
+        }
+
+        Ok(ids.len() as u64)
+    }
+
+    /// 批量复制环路到目标工作空间。
+    /// 连带复制步骤关联的 todo 到目标工作空间，并让复制后的 steps 指向新 todo。
+    pub async fn batch_copy_loops_to_workspace(
+        &self,
+        ids: &[i64],
+        target_workspace: &str,
+    ) -> Result<Vec<i64>, sea_orm::DbErr> {
+        if ids.is_empty() || target_workspace.trim().is_empty() {
+            return Ok(vec![]);
+        }
+        let ws = target_workspace.trim().to_string();
+        let mut created_ids = Vec::new();
+
+        // 用于记录已复制的 todo_id → new_todo_id 映射，避免同一 todo 被多个 step 重复复制
+        let mut todo_copy_map: std::collections::HashMap<i64, i64> = std::collections::HashMap::new();
+
+        for &id in ids {
+            let source = match self.get_loop(id).await? {
+                Some(l) => l,
+                None => continue,
+            };
+            let new_loop = self
+                .create_loop(
+                    &format!("{}(副本)", source.name),
+                    &source.description,
+                    Some(&ws),
+                    source.webhook_enabled,
+                    &source.icon,
+                    source.review_template_id,
+                    Some(source.limits_config.as_str()),
+                    source.abnormal_handler_todo_id,
+                    &source.abnormal_handler_trigger_on,
+                )
+                .await?;
+
+            // 复制 triggers
+            let triggers = self.list_triggers_by_loop(id).await?;
+            for t in triggers {
+                self.create_trigger(
+                    new_loop.id,
+                    &t.trigger_type,
+                    &t.config,
+                    t.enabled != 0,
+                    t.priority,
+                )
+                .await?;
+            }
+
+            // 复制 steps：每个 step 关联的 todo 也要复制到目标工作空间
+            // 先分两遍走：第一遍创建所有步骤并建立新/旧 id 映射，
+            // 第二遍修复 success_goto_step_id / fail_goto_step_id 的引用。
+            let steps = self.list_loop_steps_by_loop(id).await?;
+            // old_step_id → (new_step_id, old_success_goto, old_fail_goto)
+            let mut step_map: Vec<(i64, i64, Option<i64>, Option<i64>)> = Vec::new();
+
+            for s in &steps {
+                let new_todo_id = if let Some(&cached) = todo_copy_map.get(&s.todo_id) {
+                    cached
+                } else {
+                    // 复制 source todo 到目标工作空间
+                    match self.copy_todo_to_workspace(s.todo_id, &ws).await? {
+                        Some(copied_id) => {
+                            todo_copy_map.insert(s.todo_id, copied_id);
+                            copied_id
+                        }
+                        None => s.todo_id, // 回退：继续使用原始 todo_id
+                    }
+                };
+
+                let new_step = self.create_loop_step(
+                    new_loop.id,
+                    &s.name,
+                    &s.description,
+                    new_todo_id,
+                    &s.run_mode,
+                    s.skip_on_source_failed != 0,
+                    s.min_rating,
+                    &s.unrated_policy,
+                    s.enabled != 0,
+                    &s.on_success,
+                    None, // success_goto 第二遍再补
+                    &s.on_rating_fail,
+                    None, // fail_goto 第二遍再补
+                    &s.review_type,
+                )
+                .await?;
+
+                step_map.push((s.id, new_step.id, s.success_goto_step_id, s.fail_goto_step_id));
+            }
+
+            // 第二遍：更新有 goto 引用的步骤，把旧 step_id 换成新 step_id
+            let old_to_new: std::collections::HashMap<i64, i64> = step_map.iter().map(|(old, new, _, _)| (*old, *new)).collect();
+            for (old_id, new_id, old_success_goto, old_fail_goto) in &step_map {
+                let new_success_goto = old_success_goto.and_then(|g| old_to_new.get(&g).copied());
+                let new_fail_goto = old_fail_goto.and_then(|g| old_to_new.get(&g).copied());
+
+                if new_success_goto.is_some() || new_fail_goto.is_some() {
+                    let now = crate::models::utc_timestamp();
+                    let existing = loop_steps::Entity::find_by_id(*new_id).one(&self.conn).await?;
+                    if let Some(c) = existing {
+                        let mut am: loop_steps::ActiveModel = c.into();
+                        if let Some(goto) = new_success_goto {
+                            am.success_goto_step_id = ActiveValue::Set(Some(goto));
+                        }
+                        if let Some(goto) = new_fail_goto {
+                            am.fail_goto_step_id = ActiveValue::Set(Some(goto));
+                        }
+                        am.update(&self.conn).await?;
+                    }
+                }
+            }
+
+            created_ids.push(new_loop.id);
+        }
+
+        Ok(created_ids)
+    }
+
+    // ─── 辅助方法 ──────────────────────────────────────────────
+
+    /// 从指定 loop_ids 的所有步骤中收集去重的 todo_id 列表。
+    async fn collect_todo_ids_from_loops(&self, loop_ids: &[i64]) -> Result<Vec<i64>, sea_orm::DbErr> {
+        use sea_orm::ColumnTrait;
+        let mut seen = std::collections::HashSet::new();
+        for &lid in loop_ids {
+            let steps = loop_steps::Entity::find()
+                .filter(loop_steps::Column::LoopId.eq(lid))
+                .all(&self.conn)
+                .await?;
+            for s in steps {
+                seen.insert(s.todo_id);
+            }
+        }
+        Ok(seen.into_iter().collect())
+    }
+
+    /// 复制单个 todo 到目标工作空间并返回新 todo_id。
+    /// 同时复制 tag 关联。
+    async fn copy_todo_to_workspace(&self, todo_id: i64, target_workspace: &str) -> Result<Option<i64>, sea_orm::DbErr> {
+        use crate::db::entity::todos;
+        use sea_orm::ColumnTrait;
+
+        let source_model = todos::Entity::find_by_id(todo_id)
+            .filter(todos::Column::DeletedAt.is_null())
+            .one(&self.conn)
+            .await?;
+        let model = match source_model {
+            Some(m) => m,
+            None => return Ok(None),
+        };
+
+        let now = crate::models::utc_timestamp();
+        let am = todos::ActiveModel {
+            title: ActiveValue::Set(model.title),
+            prompt: ActiveValue::Set(model.prompt),
+            status: ActiveValue::Set(model.status),
+            created_at: ActiveValue::Set(Some(now.clone())),
+            updated_at: ActiveValue::Set(Some(now.clone())),
+            executor: ActiveValue::Set(model.executor),
+            scheduler_enabled: ActiveValue::Set(model.scheduler_enabled),
+            scheduler_config: ActiveValue::Set(model.scheduler_config),
+            scheduler_timezone: ActiveValue::Set(model.scheduler_timezone),
+            workspace_path: ActiveValue::Set(Some(target_workspace.to_string())),
+            webhook_enabled: ActiveValue::Set(model.webhook_enabled),
+            acceptance_criteria: ActiveValue::Set(model.acceptance_criteria),
+            auto_review_enabled: ActiveValue::Set(model.auto_review_enabled),
+            todo_type: ActiveValue::Set(model.todo_type),
+            task_id: ActiveValue::Set(None),
+            parent_todo_id: ActiveValue::Set(model.parent_todo_id),
+            review_template_id: ActiveValue::Set(model.review_template_id),
+            kind: ActiveValue::Set(model.kind),
+            ..Default::default()
+        };
+        let inserted = am.insert(&self.conn).await?;
+        let new_id = inserted.id;
+
+        // 复制 tag 关联
+        use crate::db::entity::todo_tags;
+        let old_tags = todo_tags::Entity::find()
+            .filter(todo_tags::Column::TodoId.eq(todo_id))
+            .all(&self.conn)
+            .await?;
+        for t in old_tags {
+            let tag_am = todo_tags::ActiveModel {
+                todo_id: ActiveValue::Set(new_id),
+                tag_id: ActiveValue::Set(t.tag_id),
+            };
+            tag_am.insert(&self.conn).await?;
+        }
+
+        Ok(Some(new_id))
+    }
+
     /// 复制 loop 及其所有 trigger.step；execution 不复制。
     ///
     /// 用于 UI 的「另存为」/「复制为新版本」按钮。
@@ -140,7 +380,7 @@ impl Database {
             .create_loop(
                 &format!("{}(副本)", source.name),
                 &source.description,
-                source.workspace.as_deref(),
+                source.workspace_path.as_deref(),
                 source.webhook_enabled,
                 &source.icon,
                 source.review_template_id,
@@ -842,14 +1082,31 @@ impl Database {
     // ====== 辅助：批量取 loop + 计数 ======
 
     /// 一次 SQL 把所有 loop + 它的 trigger.step 数 + 最近一次 execution 状态拉出来。
-    /// 供左侧 LoopList 用,避免 N+1。
-    pub async fn list_loops_with_counts(
-        &self,
-        workspace: Option<&str>,
-    ) -> Result<Vec<LoopListRow>, sea_orm::DbErr> {
-        use sea_orm::{ConnectionTrait, Statement};
-        let sql = match workspace {
-            Some(_) => "SELECT l.id, l.name, l.description, l.workspace, \
+    /// 供左侧 LoopList 用,避免 N+1。按 workspace_id 过滤（唯一键，符合"筛选必须用 id"约定）。
+        pub async fn list_loops_with_counts(
+            &self,
+            workspace_id: Option<i64>,
+        ) -> Result<Vec<LoopListRow>, sea_orm::DbErr> {
+            use sea_orm::{ConnectionTrait, Statement};
+            let sql = match workspace_id {
+                Some(_) => "SELECT l.id, l.name, l.description, l.workspace_path, \
+                              l.status, l.color, l.icon, l.limits_config, l.review_template_id, \
+                              l.webhook_enabled, \
+                              l.abnormal_handler_todo_id, l.abnormal_handler_trigger_on, \
+                              l.created_at, l.updated_at, \
+                              (SELECT COUNT(*) FROM loop_triggers t WHERE t.loop_id = l.id) as trigger_count, \
+                              (SELECT COUNT(*) FROM loop_steps s WHERE s.loop_id = l.id) as step_count, \
+                              (SELECT le.status FROM loop_executions le \
+                               WHERE le.loop_id = l.id ORDER BY le.started_at DESC LIMIT 1) as last_execution_status, \
+                              (SELECT le.started_at FROM loop_executions le \
+                               WHERE le.loop_id = l.id ORDER BY le.started_at DESC LIMIT 1) as last_execution_at, \
+                              (SELECT COUNT(*) FROM loop_step_executions lse \
+                               INNER JOIN loop_executions le2 ON le2.id = lse.loop_execution_id \
+                               WHERE le2.loop_id = l.id AND lse.approval_status = 'pending') as pending_approval_count \
+                       FROM loops l \
+                       WHERE l.workspace_id = ?1 \
+                       ORDER BY l.updated_at DESC",
+                None => "SELECT l.id, l.name, l.description, l.workspace_path, \
                           l.status, l.color, l.icon, l.limits_config, l.review_template_id, \
                           l.webhook_enabled, \
                           l.abnormal_handler_todo_id, l.abnormal_handler_trigger_on, \
@@ -863,37 +1120,20 @@ impl Database {
                           (SELECT COUNT(*) FROM loop_step_executions lse \
                            INNER JOIN loop_executions le2 ON le2.id = lse.loop_execution_id \
                            WHERE le2.loop_id = l.id AND lse.approval_status = 'pending') as pending_approval_count \
-                   FROM loops l \
-                   WHERE l.workspace = ?1 \
-                   ORDER BY l.updated_at DESC",
-            None => "SELECT l.id, l.name, l.description, l.workspace, \
-                      l.status, l.color, l.icon, l.limits_config, l.review_template_id, \
-                      l.webhook_enabled, \
-                      l.abnormal_handler_todo_id, l.abnormal_handler_trigger_on, \
-                      l.created_at, l.updated_at, \
-                      (SELECT COUNT(*) FROM loop_triggers t WHERE t.loop_id = l.id) as trigger_count, \
-                      (SELECT COUNT(*) FROM loop_steps s WHERE s.loop_id = l.id) as step_count, \
-                      (SELECT le.status FROM loop_executions le \
-                       WHERE le.loop_id = l.id ORDER BY le.started_at DESC LIMIT 1) as last_execution_status, \
-                      (SELECT le.started_at FROM loop_executions le \
-                       WHERE le.loop_id = l.id ORDER BY le.started_at DESC LIMIT 1) as last_execution_at, \
-                      (SELECT COUNT(*) FROM loop_step_executions lse \
-                       INNER JOIN loop_executions le2 ON le2.id = lse.loop_execution_id \
-                       WHERE le2.loop_id = l.id AND lse.approval_status = 'pending') as pending_approval_count \
-                   FROM loops l \
-                   ORDER BY l.updated_at DESC",
-        };
-        let rows = if let Some(w) = workspace {
-            self.conn
-                .query_all(
-                    Statement::from_sql_and_values(sea_orm::DbBackend::Sqlite, sql, [w.to_string().into()])
-                )
-                .await?
-        } else {
-            self.conn
-                .query_all(Statement::from_string(sea_orm::DbBackend::Sqlite, sql))
-                .await?
-        };
+                       FROM loops l \
+                       ORDER BY l.updated_at DESC",
+            };
+            let rows = if let Some(wid) = workspace_id {
+                self.conn
+                    .query_all(
+                        Statement::from_sql_and_values(sea_orm::DbBackend::Sqlite, sql, [wid.into()])
+                    )
+                    .await?
+            } else {
+                self.conn
+                    .query_all(Statement::from_string(sea_orm::DbBackend::Sqlite, sql))
+                    .await?
+            };
         let mut out = Vec::with_capacity(rows.len());
         for row in rows {
             out.push(LoopListRow {
@@ -901,7 +1141,8 @@ impl Database {
                     id: row.try_get_by::<i64, _>("id")?,
                     name: row.try_get_by::<String, _>("name")?,
                     description: row.try_get_by::<String, _>("description")?,
-                    workspace: row.try_get_by::<Option<String>, _>("workspace")?,
+                    workspace_path: row.try_get_by::<Option<String>, _>("workspace_path")?,
+                    workspace_id: row.try_get_by::<Option<i64>, _>("workspace_id")?,
                     webhook_enabled: row.try_get_by::<bool, _>("webhook_enabled")?,
                     status: row.try_get_by::<String, _>("status")?,
                     color: row.try_get_by::<String, _>("color")?,

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -37,7 +37,8 @@ impl Database {
         &self,
         name: &str,
         description: &str,
-        workspace: Option<&str>,
+        workspace_id: Option<i64>,
+        workspace_path: Option<&str>,
         webhook_enabled: bool,
         icon: &str,
         review_template_id: Option<i64>,
@@ -49,7 +50,10 @@ impl Database {
         let am = loops::ActiveModel {
             name: ActiveValue::Set(name.to_string()),
             description: ActiveValue::Set(description.to_string()),
-            workspace_path: ActiveValue::Set(workspace.map(|s| s.to_string())),
+            // 双字段同源写入：handler 必须保证 id 解析得到的 path 与 workspace_path 一致，
+            // 任何不一致都意味着上游解析有 bug——DAO 不再单独接受「只传 path」。
+            workspace_id: ActiveValue::Set(workspace_id),
+            workspace_path: ActiveValue::Set(workspace_path.map(|s| s.to_string())),
             webhook_enabled: ActiveValue::Set(webhook_enabled),
             icon: ActiveValue::Set(icon.to_string()),
             review_template_id: ActiveValue::Set(review_template_id),
@@ -69,7 +73,8 @@ impl Database {
         id: i64,
         name: &str,
         description: &str,
-        workspace: Option<&str>,
+        workspace_id: Option<i64>,
+        workspace_path: Option<&str>,
         webhook_enabled: bool,
         icon: &str,
         review_template_id: Option<i64>,
@@ -83,7 +88,14 @@ impl Database {
             let mut am: loops::ActiveModel = c.into();
             am.name = ActiveValue::Set(name.to_string());
             am.description = ActiveValue::Set(description.to_string());
-            am.workspace_path = ActiveValue::Set(workspace.map(|s| s.to_string()));
+            // workspace 同步更新：handler 在传 id 时也会同时给 path；
+            // 只传 id 不传 path 视为「只更新筛选键，cwd 保持不变」，反之亦然。
+            if let Some(wid) = workspace_id {
+                am.workspace_id = ActiveValue::Set(Some(wid));
+            }
+            if let Some(wpath) = workspace_path {
+                am.workspace_path = ActiveValue::Set(Some(wpath.to_string()));
+            }
             am.webhook_enabled = ActiveValue::Set(webhook_enabled);
             am.icon = ActiveValue::Set(icon.to_string());
             am.review_template_id = ActiveValue::Set(review_template_id);
@@ -125,26 +137,33 @@ impl Database {
 
     /// 批量更新环路工作空间（移动到其他工作空间）。
     /// 连带移动步骤关联的所有 todo 到同一目标工作空间。
+    ///
+    /// 入参是 `project_directories.id`（唯一键）；handler 负责把 id 解析为 path 后传进来，
+    /// DAO 仅按 (workspace_id, workspace_path) 双写以保证 cwd 字段与筛选字段同步。
     pub async fn batch_update_loops_workspace(
         &self,
         ids: &[i64],
-        workspace: &str,
+        workspace_id: i64,
+        workspace_path: &str,
     ) -> Result<u64, sea_orm::DbErr> {
-        if ids.is_empty() || workspace.trim().is_empty() {
+        if ids.is_empty() || workspace_path.trim().is_empty() {
             return Ok(0);
         }
         let now = crate::models::utc_timestamp();
-        let ws = workspace.trim();
+        let ws = workspace_path.trim();
 
-        // 1. 更新 loops 表
+        // 1. 更新 loops 表：按 id 筛选的回路同时写 workspace_id 与 workspace_path，
+        //    保证「筛选用 id / cwd 用 path」两条路在批量迁移后保持一致。
         let placeholders: Vec<String> = (1..=ids.len()).map(|i| format!("?{}", i)).collect();
         let in_clause = placeholders.join(",");
-        let ws_idx = ids.len() + 1;
-        let now_idx = ids.len() + 2;
+        let ws_id_idx = ids.len() + 1;
+        let ws_path_idx = ids.len() + 2;
+        let now_idx = ids.len() + 3;
         let sql = format!(
-            "UPDATE loops SET workspace_path = ?{ws_idx}, updated_at = ?{now_idx} WHERE id IN ({in_clause})"
+            "UPDATE loops SET workspace_id = ?{ws_id_idx}, workspace_path = ?{ws_path_idx}, updated_at = ?{now_idx} WHERE id IN ({in_clause})"
         );
         let mut vals: Vec<sea_orm::Value> = ids.iter().map(|id| (*id).into()).collect();
+        vals.push(workspace_id.into());
         vals.push(ws.to_string().into());
         vals.push(now.clone().into());
         let stmt = sea_orm::Statement::from_sql_and_values(sea_orm::DbBackend::Sqlite, sql, vals);
@@ -155,12 +174,14 @@ impl Database {
         if !todo_ids.is_empty() {
             let t_placeholders: Vec<String> = (1..=todo_ids.len()).map(|i| format!("?{}", i)).collect();
             let t_in_clause = t_placeholders.join(",");
-            let t_ws_idx = todo_ids.len() + 1;
-            let t_now_idx = todo_ids.len() + 2;
+            let t_ws_id_idx = todo_ids.len() + 1;
+            let t_ws_path_idx = todo_ids.len() + 2;
+            let t_now_idx = todo_ids.len() + 3;
             let t_sql = format!(
-                "UPDATE todos SET workspace_path = ?{t_ws_idx}, updated_at = ?{t_now_idx} WHERE id IN ({t_in_clause})"
+                "UPDATE todos SET workspace_id = ?{t_ws_id_idx}, workspace_path = ?{t_ws_path_idx}, updated_at = ?{t_now_idx} WHERE id IN ({t_in_clause})"
             );
             let mut t_vals: Vec<sea_orm::Value> = todo_ids.iter().map(|id| (*id).into()).collect();
+            t_vals.push(workspace_id.into());
             t_vals.push(ws.to_string().into());
             t_vals.push(now.into());
             let t_stmt = sea_orm::Statement::from_sql_and_values(sea_orm::DbBackend::Sqlite, t_sql, t_vals);
@@ -172,15 +193,19 @@ impl Database {
 
     /// 批量复制环路到目标工作空间。
     /// 连带复制步骤关联的 todo 到目标工作空间，并让复制后的 steps 指向新 todo。
+    ///
+    /// 入参是 `project_directories.id` + `workspace_path`：handler 已经把 id 解析为 path 传进来，
+    /// DAO 仅做写入；拆分参数是为了让 SQL 一次完成 id + path 双写，避免再次回查。
     pub async fn batch_copy_loops_to_workspace(
         &self,
         ids: &[i64],
-        target_workspace: &str,
+        target_workspace_id: i64,
+        target_workspace_path: &str,
     ) -> Result<Vec<i64>, sea_orm::DbErr> {
-        if ids.is_empty() || target_workspace.trim().is_empty() {
+        if ids.is_empty() || target_workspace_path.trim().is_empty() {
             return Ok(vec![]);
         }
-        let ws = target_workspace.trim().to_string();
+        let ws = target_workspace_path.trim().to_string();
         let mut created_ids = Vec::new();
 
         // 用于记录已复制的 todo_id → new_todo_id 映射，避免同一 todo 被多个 step 重复复制
@@ -195,7 +220,8 @@ impl Database {
                 .create_loop(
                     &format!("{}(副本)", source.name),
                     &source.description,
-                    Some(&ws),
+                    Some(target_workspace_id),
+                    Some(ws.as_str()),
                     source.webhook_enabled,
                     &source.icon,
                     source.review_template_id,
@@ -230,7 +256,7 @@ impl Database {
                     cached
                 } else {
                     // 复制 source todo 到目标工作空间
-                    match self.copy_todo_to_workspace(s.todo_id, &ws).await? {
+                    match self.copy_todo_to_workspace(s.todo_id, target_workspace_id, &ws).await? {
                         Some(copied_id) => {
                             todo_copy_map.insert(s.todo_id, copied_id);
                             copied_id
@@ -308,7 +334,7 @@ impl Database {
 
     /// 复制单个 todo 到目标工作空间并返回新 todo_id。
     /// 同时复制 tag 关联。
-    async fn copy_todo_to_workspace(&self, todo_id: i64, target_workspace: &str) -> Result<Option<i64>, sea_orm::DbErr> {
+    async fn copy_todo_to_workspace(&self, todo_id: i64, target_workspace_id: i64, target_workspace: &str) -> Result<Option<i64>, sea_orm::DbErr> {
         use crate::db::entity::todos;
         use sea_orm::ColumnTrait;
 
@@ -332,6 +358,7 @@ impl Database {
             scheduler_enabled: ActiveValue::Set(model.scheduler_enabled),
             scheduler_config: ActiveValue::Set(model.scheduler_config),
             scheduler_timezone: ActiveValue::Set(model.scheduler_timezone),
+            workspace_id: ActiveValue::Set(Some(target_workspace_id)),
             workspace_path: ActiveValue::Set(Some(target_workspace.to_string())),
             webhook_enabled: ActiveValue::Set(model.webhook_enabled),
             acceptance_criteria: ActiveValue::Set(model.acceptance_criteria),
@@ -380,6 +407,7 @@ impl Database {
             .create_loop(
                 &format!("{}(副本)", source.name),
                 &source.description,
+                source.workspace_id,
                 source.workspace_path.as_deref(),
                 source.webhook_enabled,
                 &source.icon,

--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -66,6 +66,8 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V31AddTodosWorkspaceId),
         Box::new(V32ReviewTemplatesWorkspaceId),
         Box::new(V33ReviewTemplatesEnsureWorkspaceId),
+        Box::new(V34MigrateOrphansToTempWorkspace),
+        Box::new(V35RenameWorkspaceToWorkspacePath),
     ]
 }
 
@@ -955,15 +957,16 @@ mod v1_helpers_tests {
             .expect(":memory: db must open")
     }
 
-    /// 分支 1: 列存在 → true。v1 init 已经把 todos.workspace 加进去。
+    /// 分支 1: 列存在 → true。V35 已把 todos.workspace 重命名为 workspace_path，
+    /// fresh DB 上应能探测到新列名。
     #[tokio::test]
     async fn table_has_column_returns_true_when_column_exists() {
         let db = fresh_db().await;
         assert!(
-            table_has_column(&db, "todos", "workspace")
+            table_has_column(&db, "todos", "workspace_path")
                 .await
                 .expect("probe must succeed"),
-            "todos.workspace is added by v1, must be detected"
+            "todos.workspace_path is added by v1 (renamed by V35), must be detected"
         );
     }
 
@@ -2298,10 +2301,19 @@ async fn v15_review_templates(db: &Database) -> Result<(), sea_orm::DbErr> {
     // 设计选择：把指向 todo_type=1 的 loop_steps 和 loop_hooks 行也一起删掉（因为
     // 这些 step / hook 的 step / target 本身就是评审模板，已无意义）。
     // 影响面：仅限历史脏数据；fresh DB 没有这些 row，DELETE 0 行无副作用。
-    db.exec(
-        "DELETE FROM loop_steps WHERE todo_id IN (SELECT id FROM todos WHERE todo_type = 1)"
-    )
-    .await?;
+    // fresh DB（V7 已直接用 step_id 建表，V13 跳过 RENAME）没有 todo_id 列；
+    // 用 table_has_column 区分两条路径，确保 legacy 与 fresh 升级都能跑通。
+    if table_has_column(db, "loop_steps", "todo_id").await? {
+        db.exec(
+            "DELETE FROM loop_steps WHERE todo_id IN (SELECT id FROM todos WHERE todo_type = 1)"
+        )
+        .await?;
+    } else {
+        db.exec(
+            "DELETE FROM loop_steps WHERE step_id IN (SELECT id FROM todos WHERE todo_type = 1)"
+        )
+        .await?;
+    }
     db.exec(
         "DELETE FROM loop_hooks WHERE target_todo_id IN (SELECT id FROM todos WHERE todo_type = 1)"
     )
@@ -3575,6 +3587,178 @@ impl Migration for V33ReviewTemplatesEnsureWorkspaceId {
         }
         db.exec("ALTER TABLE review_templates ADD COLUMN workspace_id INTEGER").await?;
         tracing::info!("V33: added review_templates.workspace_id column");
+        Ok(())
+    }
+}
+
+/// V34 迁移：把历史遗留下来的「没有工作空间」事项 / 环路绑定到「临时工作空间」。
+///
+/// 背景：之前没有强制要求选工作空间，老库里一部分 `todos.workspace = ''` 和
+/// `loops.workspace = ''`。V30/V31 引入按 `workspace_id` 过滤后，这部分数据
+/// 在 UI 里「看不见」了。本迁移：
+/// 1) 若 `/tmp` 不存在则在 `project_directories` 表创建一条 (path='/tmp', name='临时工作空间') 记录；
+/// 2) 把 `todos` 中 `workspace` 为空或 `workspace_id` 为 0/空 的行指向该目录；
+/// 3) 把 `loops` 中 `workspace` 为空的行同步设置 `workspace = '/tmp'`（loops 表无 workspace_id 列）。
+///
+/// 幂等：WHERE 子句只会命中还没迁移过的行；即使重复执行也是安全的。
+pub(super) struct V34MigrateOrphansToTempWorkspace;
+#[async_trait::async_trait]
+impl Migration for V34MigrateOrphansToTempWorkspace {
+    fn version(&self) -> i64 { 34 }
+    fn name(&self) -> &'static str { "migrate_orphans_to_temp_workspace" }
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        const TEMP_PATH: &str = "/tmp";
+        const TEMP_NAME: &str = "临时工作空间";
+
+        // 1) 查找 /tmp 是否已经存在（项目里现成的 helper）。
+        let existing = get_project_directory_id_by_path(db, TEMP_PATH).await?;
+        let temp_id: i64 = if let Some(id) = existing {
+            id
+        } else {
+            // 用 V1 创建表时的最小列集合（5 列）做 INSERT，兼容所有迁移历史：
+            //   - V1 时只有 id/path/name/created_at/updated_at
+            //   - V5 才追加 git_worktree_enabled / auto_cleanup
+            //   - 如果环境是新建库（V1 直接建表后没有 V5 走完），写 7 列会因列数不匹配而失败。
+            // 这里先按 5 列插入，V5 触发器/默认值会负责把后续字段补成 0。
+            let now = crate::models::utc_timestamp();
+            let insert = sea_orm::Statement::from_sql_and_values(
+                sea_orm::DbBackend::Sqlite,
+                "INSERT INTO project_directories (path, name, created_at, updated_at) VALUES (?1, ?2, ?3, ?3)",
+                vec![TEMP_PATH.into(), TEMP_NAME.into(), now.into()],
+            );
+            db.conn.execute(insert).await?;
+            // 重新查一次拿 id。
+            get_project_directory_id_by_path(db, TEMP_PATH)
+                .await?
+                .ok_or_else(|| {
+                    sea_orm::DbErr::Custom(
+                        "V34: temp workspace row missing after insert".to_string(),
+                    )
+                })?
+        };
+
+        // 2) 迁移 todos：workspace 文本为空、workspace_id 缺失或为 0 的行
+        let todos_sql = "UPDATE todos \
+                        SET workspace = ?1, workspace_id = ?2, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', 'utc') \
+                        WHERE deleted_at IS NULL \
+                          AND (workspace IS NULL OR workspace = '' OR workspace_id IS NULL OR workspace_id = 0)";
+        let todos_stmt = sea_orm::Statement::from_sql_and_values(
+            sea_orm::DbBackend::Sqlite,
+            todos_sql.to_string(),
+            vec![TEMP_PATH.into(), temp_id.into()],
+        );
+        let todos_rows = db.conn.execute(todos_stmt).await?.rows_affected();
+
+        // 3) 迁移 loops：workspace 为空的行（loops 表没有 workspace_id 列，仅按路径过滤）
+        let loops_stmt = sea_orm::Statement::from_sql_and_values(
+            sea_orm::DbBackend::Sqlite,
+            "UPDATE loops \
+             SET workspace = ?1, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', 'utc') \
+             WHERE workspace IS NULL OR workspace = ''",
+            vec![TEMP_PATH.into()],
+        );
+        let loops_rows = db.conn.execute(loops_stmt).await?.rows_affected();
+
+        tracing::info!(
+            "V34: migrated {} todo(s) and {} loop(s) to temp workspace (id={})",
+            todos_rows,
+            loops_rows,
+            temp_id
+        );
+        Ok(())
+    }
+}
+
+/// 按 path 查询 project_directories.id。SELECT 在 SQLite 中无副作用，
+/// 不存在返回 None，SQL 报错才传播。V34 用它判断「/tmp 是否已注册」。
+async fn get_project_directory_id_by_path(
+    db: &Database,
+    path: &str,
+) -> Result<Option<i64>, sea_orm::DbErr> {
+    let stmt = sea_orm::Statement::from_sql_and_values(
+        sea_orm::DbBackend::Sqlite,
+        "SELECT id FROM project_directories WHERE path = ?1",
+        vec![path.into()],
+    );
+    // query_one 返回 Option<Row>；再取出 id 列。
+    let row = db.conn.query_one(stmt).await?;
+    let Some(row) = row else { return Ok(None) };
+    // sea-orm 1.0 Row::try_get_by(col_name) 是稳定接口。
+    let id: Option<i64> = row.try_get_by("id").ok().flatten();
+    Ok(id)
+}
+
+/// V35 迁移：把 `workspace` 列统一改成 `workspace_path`，并为 `loops` 表新增 `workspace_id` 列。
+///
+/// 背景：
+/// - `todos.workspace` / `loops.workspace` 当前是「项目目录路径」语义，但历史上字段名含糊
+///   （曾被用来存 id 或 name），给筛选 / 跨表 join 带来大量歧义。
+/// - `todos` 已有 `workspace_id`，但 `loops` 一直没有，CLI 与 handler 无法按 id 过滤环路。
+/// - 命名规则统一为：筛选与外键只用 `workspace_id`；路径只用 `workspace_path`；名称走 `name`。
+///
+/// 迁移步骤（幂等）：
+/// 1. 若 `todos.workspace` 列存在 → 重命名为 `todos.workspace_path`（SQLite 3.25+ 支持 RENAME COLUMN）。
+/// 2. 若 `loops.workspace` 列存在 → 重命名为 `loops.workspace_path`。
+/// 3. 若 `loops.workspace_id` 列不存在 → 新增并回填：按 `workspace_path` 匹配 `project_directories.path`。
+/// 4. 若 `todos.workspace_id` 为 0/空 且 `workspace_path` 非空 → 同样回填。
+///
+/// 注：本迁移只动 schema，不删任何业务数据；上层代码（entity / DAO / handler）会在同 PR 内同步改名。
+pub(super) struct V35RenameWorkspaceToWorkspacePath;
+#[async_trait::async_trait]
+impl Migration for V35RenameWorkspaceToWorkspacePath {
+    fn version(&self) -> i64 { 35 }
+    fn name(&self) -> &'static str { "rename_workspace_to_workspace_path" }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 1) todos.workspace → todos.workspace_path
+        if table_has_column(db, "todos", "workspace").await?
+            && !table_has_column(db, "todos", "workspace_path").await?
+        {
+            db.exec("ALTER TABLE todos RENAME COLUMN workspace TO workspace_path")
+                .await?;
+            tracing::info!("V35: todos.workspace renamed to workspace_path");
+        }
+
+        // 2) loops.workspace → loops.workspace_path
+        if table_has_column(db, "loops", "workspace").await?
+            && !table_has_column(db, "loops", "workspace_path").await?
+        {
+            db.exec("ALTER TABLE loops RENAME COLUMN workspace TO workspace_path")
+                .await?;
+            tracing::info!("V35: loops.workspace renamed to workspace_path");
+        }
+
+        // 3) loops.workspace_id：新增 + 回填
+        if !table_has_column(db, "loops", "workspace_id").await? {
+            db.exec("ALTER TABLE loops ADD COLUMN workspace_id INTEGER")
+                .await?;
+            tracing::info!("V35: loops.workspace_id column added");
+        }
+        // 回填：loops.workspace_path → project_directories.id
+        db.exec(
+            "UPDATE loops
+             SET workspace_id = (
+                 SELECT pd.id FROM project_directories pd
+                 WHERE pd.path = loops.workspace_path
+                 LIMIT 1
+             )
+             WHERE workspace_path IS NOT NULL AND workspace_path != ''",
+        )
+        .await?;
+
+        // 4) todos.workspace_id 回填：现有列允许 0/空，仅当非 0 且有 workspace_path 但 id 为 0 时回填
+        db.exec(
+            "UPDATE todos
+             SET workspace_id = (
+                 SELECT pd.id FROM project_directories pd
+                 WHERE pd.path = todos.workspace_path
+                 LIMIT 1
+             )
+             WHERE workspace_path IS NOT NULL AND workspace_path != ''
+               AND (workspace_id IS NULL OR workspace_id = 0)",
+        )
+        .await?;
+
         Ok(())
     }
 }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -812,7 +812,7 @@ mod tests {
             scheduler_enabled: None,
             scheduler_config: None,
             scheduler_timezone: None,
-            workspace_path: None,
+            workspace_id: None,
             webhook_enabled: None,
             acceptance_criteria: None,
             auto_review_enabled: None,
@@ -975,7 +975,7 @@ mod tests {
             scheduler_enabled: Some(true),
             scheduler_config: Some("0 0 * * *"),
             scheduler_timezone: None,
-            workspace_path: Some("/tmp/workspace"),
+            workspace_id: Some(1),
             webhook_enabled: None,
             acceptance_criteria: None,
             auto_review_enabled: None,
@@ -989,7 +989,8 @@ mod tests {
         assert_eq!(todo.executor, Some("opencode".to_string()));
         assert!(todo.scheduler_enabled);
         assert_eq!(todo.scheduler_config, Some("0 0 * * *".to_string()));
-        assert_eq!(todo.workspace_path, Some("/tmp/workspace".to_string()));
+        // workspace_id 已写入：handler 端会按 id 反查 path 后双写，这里只校验 id 已落库
+        assert_eq!(todo.workspace_id, Some(1));
     }
 
     #[tokio::test]

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -812,7 +812,7 @@ mod tests {
             scheduler_enabled: None,
             scheduler_config: None,
             scheduler_timezone: None,
-            workspace: None,
+            workspace_path: None,
             webhook_enabled: None,
             acceptance_criteria: None,
             auto_review_enabled: None,
@@ -975,7 +975,7 @@ mod tests {
             scheduler_enabled: Some(true),
             scheduler_config: Some("0 0 * * *"),
             scheduler_timezone: None,
-            workspace: Some("/tmp/workspace"),
+            workspace_path: Some("/tmp/workspace"),
             webhook_enabled: None,
             acceptance_criteria: None,
             auto_review_enabled: None,
@@ -989,7 +989,7 @@ mod tests {
         assert_eq!(todo.executor, Some("opencode".to_string()));
         assert!(todo.scheduler_enabled);
         assert_eq!(todo.scheduler_config, Some("0 0 * * *".to_string()));
-        assert_eq!(todo.workspace, Some("/tmp/workspace".to_string()));
+        assert_eq!(todo.workspace_path, Some("/tmp/workspace".to_string()));
     }
 
     #[tokio::test]

--- a/backend/src/db/project_directory.rs
+++ b/backend/src/db/project_directory.rs
@@ -1,4 +1,4 @@
-use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder};
 use serde::{Deserialize, Serialize};
 
 use crate::db::entity::project_directories;

--- a/backend/src/db/project_directory.rs
+++ b/backend/src/db/project_directory.rs
@@ -1,4 +1,4 @@
-use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder};
+use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
 use serde::{Deserialize, Serialize};
 
 use crate::db::entity::project_directories;

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -17,7 +17,10 @@ pub struct TodoUpdate<'a> {
     pub scheduler_enabled: Option<bool>,
     pub scheduler_config: Option<&'a str>,
     pub scheduler_timezone: Option<&'a str>,
-    pub workspace_path: Option<&'a str>,
+    /// 工作空间 ID（project_directories.id）。
+    /// None=保持当前工作空间，Some(id)=迁移到该工作空间（handler 同时传 path）。
+    /// 不接受路径——DAO 不再单独接受 path 入参。
+    pub workspace_id: Option<i64>,
     pub webhook_enabled: Option<bool>,
     pub acceptance_criteria: Option<&'a str>,
     pub auto_review_enabled: Option<bool>,
@@ -62,6 +65,8 @@ impl Database {
             scheduler_timezone,
             scheduler_next_run_at,
             task_id: m.task_id,
+            // cwd 字段保留——后端 executor_service / worktree / spawn_lifecycle 等
+            // 子系统仍按 path 字符串读取 cwd。API 层不再把 workspace_path 暴露给前端。
             workspace_path: m.workspace_path,
             workspace_id: m.workspace_id,
             webhook_enabled: m.webhook_enabled.unwrap_or(false),
@@ -141,11 +146,17 @@ impl Database {
 
     /// 创建 Todo，可指定执行器。
     /// executor 为 None、空串或仅空白时默认为 claudecode（防止空/空白字符串污染 DB）。
+    ///
+    /// 注意：本方法保留 path-only 语义作为「最简 helper」专用入口——调用方（feishu_listener /
+    /// sync.rs 等）已经决定好了 workspace，没有工作空间语义可推导时不应使用本方法。
+    /// 业务 API 入口请用 `create_todo_with_extras`（强制 workspace_id + workspace_path 双字段）。
     pub async fn create_todo_with_executor(&self, title: &str, prompt: &str, executor: Option<&str>) -> Result<i64, sea_orm::DbErr> {
-        self.create_todo_with_extras(title, prompt, executor, None, false, None).await
+        self.create_todo_with_extras(title, prompt, executor, None, false, 0, "").await
     }
 
     /// 创建 Todo，带所有可选字段。
+    /// 工作空间必填且必须存在：handler 在调用本方法前已经按 id 解析得到 path，
+    /// 这里同时写入 workspace_id（筛选键）+ workspace_path（cwd）保证双字段同步。
     pub async fn create_todo_with_extras(
         &self,
         title: &str,
@@ -153,7 +164,8 @@ impl Database {
         executor: Option<&str>,
         acceptance_criteria: Option<&str>,
         webhook_enabled: bool,
-        workspace_id: Option<i64>,
+        workspace_id: i64,
+        workspace_path: &str,
     ) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let executor_str = executor
@@ -171,7 +183,8 @@ impl Database {
             webhook_enabled: ActiveValue::Set(Some(webhook_enabled)),
             auto_review_enabled: ActiveValue::Set(Some(false)),
             todo_type: ActiveValue::Set(Some(0)),
-            workspace_id: ActiveValue::Set(workspace_id.or(Some(0))),
+            workspace_id: ActiveValue::Set(Some(workspace_id)),
+            workspace_path: ActiveValue::Set(Some(workspace_path.to_string())),
             ..Default::default()
         };
         let inserted = am.insert(&self.conn).await?;
@@ -204,13 +217,11 @@ impl Database {
                 am.scheduler_timezone = ActiveValue::Set(Some(tz.to_string()));
             }
         }
-        if let Some(ws) = update.workspace_path {
-            let ws = ws.trim();
-            if ws.is_empty() {
-                am.workspace_path = ActiveValue::Set(None);
-            } else {
-                am.workspace_path = ActiveValue::Set(Some(ws.to_string()));
-            }
+        if let Some(wid) = update.workspace_id {
+            // handler 必须把 id 解析为 path 后再传 workspace_path；
+            // DAO 只接 id 写筛选列，path 由 ActiveValue::Unchanged 保持旧值。
+            // 真正的 cwd 同步交给 handler 调用 update_todo_workspace 完成。
+            am.workspace_id = ActiveValue::Set(Some(wid));
         }
         if let Some(webhook_enabled) = update.webhook_enabled {
             am.webhook_enabled = ActiveValue::Set(Some(webhook_enabled));
@@ -302,25 +313,28 @@ impl Database {
     }
 
     /// 批量更新事项工作空间（移动到其他工作空间）。
-    /// 单条 SQL，原子语义。
+    /// 单条 SQL，原子语义：handler 已按 id 解析得到 path，DAO 一次写入 id + path。
     pub async fn batch_update_todos_workspace(
         &self,
         ids: &[i64],
-        workspace: &str,
+        workspace_id: i64,
+        workspace_path: &str,
     ) -> Result<u64, sea_orm::DbErr> {
-        if ids.is_empty() || workspace.trim().is_empty() {
+        if ids.is_empty() || workspace_path.trim().is_empty() {
             return Ok(0);
         }
         let now = crate::models::utc_timestamp();
         let placeholders: Vec<String> = (1..=ids.len()).map(|i| format!("?{}", i)).collect();
         let in_clause = placeholders.join(",");
-        let ws_idx = ids.len() + 1;
-        let now_idx = ids.len() + 2;
+        let ws_id_idx = ids.len() + 1;
+        let ws_path_idx = ids.len() + 2;
+        let now_idx = ids.len() + 3;
         let sql = format!(
-            "UPDATE todos SET workspace_path = ?{ws_idx}, updated_at = ?{now_idx} WHERE id IN ({in_clause})"
+            "UPDATE todos SET workspace_id = ?{ws_id_idx}, workspace_path = ?{ws_path_idx}, updated_at = ?{now_idx} WHERE id IN ({in_clause})"
         );
         let mut vals: Vec<sea_orm::Value> = ids.iter().map(|id| (*id).into()).collect();
-        vals.push(workspace.trim().to_string().into());
+        vals.push(workspace_id.into());
+        vals.push(workspace_path.trim().to_string().into());
         vals.push(now.into());
         let stmt = sea_orm::Statement::from_sql_and_values(sea_orm::DbBackend::Sqlite, sql, vals);
         let rows_affected = self.conn.execute(stmt).await?.rows_affected();
@@ -329,16 +343,18 @@ impl Database {
 
     /// 批量复制事项到目标工作空间。
     /// 读取源事项的完整数据，在目标工作空间下创建副本。
+    /// 入参 id + path 由 handler 解析后传入，DAO 双字段写入保证同步。
     pub async fn batch_copy_todos_to_workspace(
         &self,
         ids: &[i64],
-        target_workspace: &str,
+        target_workspace_id: i64,
+        target_workspace_path: &str,
     ) -> Result<Vec<i64>, sea_orm::DbErr> {
-        if ids.is_empty() || target_workspace.trim().is_empty() {
+        if ids.is_empty() || target_workspace_path.trim().is_empty() {
             return Ok(vec![]);
         }
         let now = crate::models::utc_timestamp();
-        let ws = target_workspace.trim().to_string();
+        let ws = target_workspace_path.trim().to_string();
         let mut created_ids = Vec::new();
 
         for &id in ids {
@@ -358,6 +374,7 @@ impl Database {
                     scheduler_enabled: ActiveValue::Set(model.scheduler_enabled),
                     scheduler_config: ActiveValue::Set(model.scheduler_config),
                     scheduler_timezone: ActiveValue::Set(model.scheduler_timezone),
+                    workspace_id: ActiveValue::Set(Some(target_workspace_id)),
                     workspace_path: ActiveValue::Set(Some(ws.clone())),
                     webhook_enabled: ActiveValue::Set(model.webhook_enabled),
                     acceptance_criteria: ActiveValue::Set(model.acceptance_criteria),
@@ -376,12 +393,16 @@ impl Database {
         Ok(created_ids)
     }
 
+    /// 按 id 单独更新 todo 工作空间（含 cwd path 双字段同步）。
+    /// id=None 表示「清空工作空间」：handler 解析用户意图后调用此方法，
+    /// DAO 只负责把 id + path 同时写进 DB，不会做反查。
     pub async fn update_todo_workspace(
         &self,
         id: i64,
-        workspace: Option<&str>,
+        workspace_id: Option<i64>,
+        workspace_path: Option<&str>,
     ) -> Result<(), sea_orm::DbErr> {
-        let ws = workspace.and_then(|s| {
+        let ws_path = workspace_path.and_then(|s| {
             let trimmed = s.trim();
             if trimmed.is_empty() {
                 None
@@ -392,7 +413,8 @@ impl Database {
         let now = crate::models::utc_timestamp();
         let am = todos::ActiveModel {
             id: ActiveValue::Unchanged(id),
-            workspace_path: ActiveValue::Set(ws),
+            workspace_id: ActiveValue::Set(workspace_id),
+            workspace_path: ActiveValue::Set(ws_path),
             updated_at: ActiveValue::Set(Some(now)),
             ..Default::default()
         };

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -17,7 +17,7 @@ pub struct TodoUpdate<'a> {
     pub scheduler_enabled: Option<bool>,
     pub scheduler_config: Option<&'a str>,
     pub scheduler_timezone: Option<&'a str>,
-    pub workspace: Option<&'a str>,
+    pub workspace_path: Option<&'a str>,
     pub webhook_enabled: Option<bool>,
     pub acceptance_criteria: Option<&'a str>,
     pub auto_review_enabled: Option<bool>,
@@ -62,7 +62,7 @@ impl Database {
             scheduler_timezone,
             scheduler_next_run_at,
             task_id: m.task_id,
-            workspace: m.workspace,
+            workspace_path: m.workspace_path,
             workspace_id: m.workspace_id,
             webhook_enabled: m.webhook_enabled.unwrap_or(false),
             acceptance_criteria: m.acceptance_criteria,
@@ -204,12 +204,12 @@ impl Database {
                 am.scheduler_timezone = ActiveValue::Set(Some(tz.to_string()));
             }
         }
-        if let Some(ws) = update.workspace {
+        if let Some(ws) = update.workspace_path {
             let ws = ws.trim();
             if ws.is_empty() {
-                am.workspace = ActiveValue::Set(None);
+                am.workspace_path = ActiveValue::Set(None);
             } else {
-                am.workspace = ActiveValue::Set(Some(ws.to_string()));
+                am.workspace_path = ActiveValue::Set(Some(ws.to_string()));
             }
         }
         if let Some(webhook_enabled) = update.webhook_enabled {
@@ -301,6 +301,81 @@ impl Database {
         self.exec_update(am).await
     }
 
+    /// 批量更新事项工作空间（移动到其他工作空间）。
+    /// 单条 SQL，原子语义。
+    pub async fn batch_update_todos_workspace(
+        &self,
+        ids: &[i64],
+        workspace: &str,
+    ) -> Result<u64, sea_orm::DbErr> {
+        if ids.is_empty() || workspace.trim().is_empty() {
+            return Ok(0);
+        }
+        let now = crate::models::utc_timestamp();
+        let placeholders: Vec<String> = (1..=ids.len()).map(|i| format!("?{}", i)).collect();
+        let in_clause = placeholders.join(",");
+        let ws_idx = ids.len() + 1;
+        let now_idx = ids.len() + 2;
+        let sql = format!(
+            "UPDATE todos SET workspace_path = ?{ws_idx}, updated_at = ?{now_idx} WHERE id IN ({in_clause})"
+        );
+        let mut vals: Vec<sea_orm::Value> = ids.iter().map(|id| (*id).into()).collect();
+        vals.push(workspace.trim().to_string().into());
+        vals.push(now.into());
+        let stmt = sea_orm::Statement::from_sql_and_values(sea_orm::DbBackend::Sqlite, sql, vals);
+        let rows_affected = self.conn.execute(stmt).await?.rows_affected();
+        Ok(rows_affected)
+    }
+
+    /// 批量复制事项到目标工作空间。
+    /// 读取源事项的完整数据，在目标工作空间下创建副本。
+    pub async fn batch_copy_todos_to_workspace(
+        &self,
+        ids: &[i64],
+        target_workspace: &str,
+    ) -> Result<Vec<i64>, sea_orm::DbErr> {
+        if ids.is_empty() || target_workspace.trim().is_empty() {
+            return Ok(vec![]);
+        }
+        let now = crate::models::utc_timestamp();
+        let ws = target_workspace.trim().to_string();
+        let mut created_ids = Vec::new();
+
+        for &id in ids {
+            // 直接查询 sea-orm entity，获取原始模型
+            let source_model = todos::Entity::find_by_id(id)
+                .filter(todos::Column::DeletedAt.is_null())
+                .one(&self.conn)
+                .await?;
+            if let Some(model) = source_model {
+                let am = todos::ActiveModel {
+                    title: ActiveValue::Set(model.title),
+                    prompt: ActiveValue::Set(model.prompt),
+                    status: ActiveValue::Set(model.status),
+                    created_at: ActiveValue::Set(Some(now.clone())),
+                    updated_at: ActiveValue::Set(Some(now.clone())),
+                    executor: ActiveValue::Set(model.executor),
+                    scheduler_enabled: ActiveValue::Set(model.scheduler_enabled),
+                    scheduler_config: ActiveValue::Set(model.scheduler_config),
+                    scheduler_timezone: ActiveValue::Set(model.scheduler_timezone),
+                    workspace_path: ActiveValue::Set(Some(ws.clone())),
+                    webhook_enabled: ActiveValue::Set(model.webhook_enabled),
+                    acceptance_criteria: ActiveValue::Set(model.acceptance_criteria),
+                    auto_review_enabled: ActiveValue::Set(model.auto_review_enabled),
+                    todo_type: ActiveValue::Set(model.todo_type),
+                    task_id: ActiveValue::Set(None),
+                    parent_todo_id: ActiveValue::Set(model.parent_todo_id),
+                    review_template_id: ActiveValue::Set(model.review_template_id),
+                    kind: ActiveValue::Set(model.kind),
+                    ..Default::default()
+                };
+                let inserted = am.insert(&self.conn).await?;
+                created_ids.push(inserted.id);
+            }
+        }
+        Ok(created_ids)
+    }
+
     pub async fn update_todo_workspace(
         &self,
         id: i64,
@@ -317,7 +392,7 @@ impl Database {
         let now = crate::models::utc_timestamp();
         let am = todos::ActiveModel {
             id: ActiveValue::Unchanged(id),
-            workspace: ActiveValue::Set(ws),
+            workspace_path: ActiveValue::Set(ws),
             updated_at: ActiveValue::Set(Some(now)),
             ..Default::default()
         };
@@ -643,7 +718,7 @@ impl Database {
                     scheduler_enabled: m.scheduler_enabled.unwrap_or(false),
                     scheduler_config: m.scheduler_config,
                     tag_names,
-                    workspace: m.workspace.clone(),
+                    workspace_path: m.workspace_path.clone(),
                     worktree: None,
                 }
             })
@@ -694,7 +769,7 @@ impl Database {
                     scheduler_enabled: m.scheduler_enabled.unwrap_or(false),
                     scheduler_config: m.scheduler_config,
                     tag_names,
-                    workspace: m.workspace.clone(),
+                    workspace_path: m.workspace_path.clone(),
                     worktree: None,
                 }
             })
@@ -752,7 +827,7 @@ impl Database {
         // 导入 todo
         for todo in todos_in {
             let now = crate::models::utc_timestamp();
-            let workspace = todo.workspace.clone();
+            let workspace_path = todo.workspace_path.clone();
             let am = todos::ActiveModel {
                 title: ActiveValue::Set(todo.title.clone()),
                 prompt: ActiveValue::Set(Some(todo.prompt.clone())),
@@ -760,7 +835,7 @@ impl Database {
                 executor: ActiveValue::Set(todo.executor.clone()),
                 scheduler_enabled: ActiveValue::Set(Some(todo.scheduler_enabled)),
                 scheduler_config: ActiveValue::Set(todo.scheduler_config.clone()),
-                workspace: ActiveValue::Set(workspace),
+                workspace_path: ActiveValue::Set(workspace_path),
                 created_at: ActiveValue::Set(Some(now.clone())),
                 updated_at: ActiveValue::Set(Some(now)),
                 ..Default::default()
@@ -849,7 +924,7 @@ impl Database {
                 am.executor = ActiveValue::Set(todo.executor.clone());
                 am.scheduler_enabled = ActiveValue::Set(Some(todo.scheduler_enabled));
                 am.scheduler_config = ActiveValue::Set(todo.scheduler_config.clone());
-                am.workspace = ActiveValue::Set(todo.workspace.clone());
+                am.workspace_path = ActiveValue::Set(todo.workspace_path.clone());
                 am.updated_at = ActiveValue::Set(Some(crate::models::utc_timestamp()));
                 let saved = am.update(&txn).await?;
 
@@ -881,7 +956,7 @@ impl Database {
             } else {
                 // 新建
                 let now = crate::models::utc_timestamp();
-                let workspace = todo.workspace.clone();
+                let workspace_path = todo.workspace_path.clone();
                 let am = todos::ActiveModel {
                     title: ActiveValue::Set(todo.title.clone()),
                     prompt: ActiveValue::Set(Some(todo.prompt.clone())),
@@ -889,7 +964,7 @@ impl Database {
                     executor: ActiveValue::Set(todo.executor.clone()),
                     scheduler_enabled: ActiveValue::Set(Some(todo.scheduler_enabled)),
                     scheduler_config: ActiveValue::Set(todo.scheduler_config.clone()),
-                    workspace: ActiveValue::Set(workspace),
+                    workspace_path: ActiveValue::Set(workspace_path),
                     created_at: ActiveValue::Set(Some(now.clone())),
                     updated_at: ActiveValue::Set(Some(now)),
                     ..Default::default()

--- a/backend/src/executor_service/auto_review.rs
+++ b/backend/src/executor_service/auto_review.rs
@@ -345,7 +345,7 @@ async fn execute_review_instance(
         step_id: None,
         feishu_bot_id: None,
         feishu_receive_id: None,
-        workspace: None,
+        workspace_path: None,
         workspace_id: None,
     };
     let exec_result = super::run_todo_execution(request).await;

--- a/backend/src/executor_service/mod.rs
+++ b/backend/src/executor_service/mod.rs
@@ -72,10 +72,10 @@ pub struct RunTodoExecutionRequest {
     pub loop_step_execution_id: Option<i64>,
     /// 环节 id（steps 表），环节独立执行时设置
     pub step_id: Option<i64>,
-    /// 显式工作空间路径（用于 loop 场景：loop 有自己的 workspace，
-    /// 但 executor service 内部通过 todo 加载获取 workspace。当 todo 不存在
-    /// 或 todo_id=0 时，使用此字段作为 workspace 用于 worktree 创建和 cwd 回退）。
-    pub workspace: Option<String>,
+    /// 显式工作空间目录路径（用于 loop 场景：loop 有自己的 workspace_path，
+    /// 但 executor service 内部通过 todo 加载获取 workspace_path。当 todo 不存在
+    /// 或 todo_id=0 时，使用此字段作为 workspace_path 用于 worktree 创建和 cwd 回退）。
+    pub workspace_path: Option<String>,
     /// 工作空间 ID（用于 FeishuPushService 按 workspace 隔离推送目标）。
     /// 与 workspace 字段（路径）分开存储：workspace 用于 worktree 创建，
     /// workspace_id 用于 Feishu 推送隔离。

--- a/backend/src/executor_service/pre_spawn.rs
+++ b/backend/src/executor_service/pre_spawn.rs
@@ -244,7 +244,7 @@ pub(crate) struct SelectedExecutor {
     pub command_args: Vec<String>,
     pub executable_path: String,
     pub executor_str: String,
-    pub todo_workspace: Option<String>,
+    pub todo_workspace_path: Option<String>,
     pub session_id_for_executor: Option<String>,
 }
 
@@ -256,7 +256,7 @@ pub(crate) async fn select_executor_and_build_command(
     todo: &Option<crate::models::Todo>,
     message: &str,
 ) -> Result<SelectedExecutor, ExecutionResult> {
-    let (todo_workspace, todo_executor) = extract_todo_executor_fields(todo);
+    let (todo_workspace_path, todo_executor) = extract_todo_executor_fields(todo);
     let executor_type =
         resolve_executor_type(request.req_executor.as_deref(), todo_executor.as_deref());
     let executor =
@@ -271,7 +271,7 @@ pub(crate) async fn select_executor_and_build_command(
         command_args,
         executable_path,
         executor_str,
-        todo_workspace,
+        todo_workspace_path,
         session_id_for_executor: request.resume_session_id.clone(),
     })
 }
@@ -281,7 +281,7 @@ fn extract_todo_executor_fields(
     todo: &Option<crate::models::Todo>,
 ) -> (Option<String>, Option<String>) {
     (
-        todo.as_ref().and_then(|t| t.workspace.clone()),
+        todo.as_ref().and_then(|t| t.workspace_path.clone()),
         todo.as_ref().and_then(|t| t.executor.clone()),
     )
 }
@@ -347,9 +347,9 @@ pub(crate) async fn create_run_execution_record(
         Ok(id) => id,
         Err(e) => return Err(e),
     };
-    // todo_workspace 优先来自 todo；当 todo 不存在（loop 环节执行）时回退到 request.workspace，
+    // todo_workspace_path 优先来自 todo；当 todo 不存在（loop 环节执行）时回退到 request.workspace_path，
     // 确保 worktree 创建失败后子进程 cwd 仍然是 loop 的 workspace。
-    let todo_workspace = selected.todo_workspace.or_else(|| request.workspace.clone());
+    let todo_workspace_path = selected.todo_workspace_path.or_else(|| request.workspace_path.clone());
     Ok(super::types::PreparedExecution {
         request,
         task_guard: task_state.task_guard,
@@ -361,7 +361,7 @@ pub(crate) async fn create_run_execution_record(
         executor_str: selected.executor_str,
         record_id,
         todo,
-        todo_workspace,
+        todo_workspace_path,
         timeout_secs,
     })
 }

--- a/backend/src/executor_service/spawn_lifecycle.rs
+++ b/backend/src/executor_service/spawn_lifecycle.rs
@@ -165,19 +165,19 @@ pub(crate) async fn save_child_pid_and_close_stdin(
 
 /// 构造 executor 子进程命令，统一设置 stdout/stderr/stdin 为 piped。
 ///
-/// workspace 设置为 `cmd.current_dir`，但仅在 todo 指定 workspace 时生效——
-/// 没设 workspace 的 todo 让 executor 用 daemon 当前目录即可。
+/// workspace_path 设置为 `cmd.current_dir`，但仅在 todo 指定 workspace_path 时生效——
+/// 没设 workspace_path 的 todo 让 executor 用 daemon 当前目录即可。
 pub(crate) fn build_executor_command(
     executable_path: &str,
     command_args: &[String],
-    workspace: Option<&str>,
+    workspace_path: Option<&str>,
 ) -> tokio::process::Command {
     let mut cmd = tokio::process::Command::new(executable_path);
     cmd.args(command_args)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .stdin(std::process::Stdio::piped());
-    if let Some(ws) = workspace {
+    if let Some(ws) = workspace_path {
         cmd.current_dir(ws);
     }
     cmd
@@ -191,7 +191,7 @@ pub(crate) fn spawn_executor_child(
     let mut cmd = build_executor_command(
         &runtime.prepared.executable_path,
         &runtime.prepared.command_args,
-        runtime.effective_workspace.as_deref(),
+        runtime.effective_workspace_path.as_deref(),
     );
     cmd.group_spawn()
 }
@@ -257,9 +257,9 @@ pub(crate) fn move_into_runtime(spawned: super::types::SpawnInputs) -> SpawnRunt
         execution_timeout_secs: spawned.execution_timeout_secs,
         feishu_bot_id: prepared.request.feishu_bot_id,
         feishu_receive_id: prepared.request.feishu_receive_id.clone(),
-        // 关键：把 effective_workspace 整字段 move 进 runtime，
-        // 避免 spawn_executor_child 误用 todo_workspace（worktree 失效）。
-        effective_workspace: spawned.effective_workspace,
+        // 关键：把 effective_workspace_path 整字段 move 进 runtime，
+        // 避免 spawn_executor_child 误用 todo_workspace_path（worktree 失效）。
+        effective_workspace_path: spawned.effective_workspace_path,
         prepared,
     }
 }
@@ -665,19 +665,19 @@ mod tests {
         assert_eq!(std_args[1], "build me a web app");
     }
 
-    /// `SpawnRuntime` 持有 `effective_workspace` 字段；`prepared.todo_workspace` 与
-    /// `effective_workspace` 是两个独立字段（issue #660 重构中的回归测试）。
+    /// `SpawnRuntime` 持有 `effective_workspace_path` 字段；`prepared.todo_workspace_path` 与
+    /// `effective_workspace_path` 是两个独立字段（issue #660 重构中的回归测试）。
     #[test]
-    fn test_spawn_runtime_carries_effective_workspace() {
+    fn test_spawn_runtime_carries_effective_workspace_path() {
         fn _assert_field(rt: &SpawnRuntime) -> Option<&String> {
-            rt.effective_workspace.as_ref()
+            rt.effective_workspace_path.as_ref()
         }
         fn _assert_distinct_fields(
             rt: &SpawnRuntime,
         ) -> (Option<&String>, Option<&String>) {
             (
-                rt.effective_workspace.as_ref(),
-                rt.prepared.todo_workspace.as_ref(),
+                rt.effective_workspace_path.as_ref(),
+                rt.prepared.todo_workspace_path.as_ref(),
             )
         }
     }

--- a/backend/src/executor_service/spawn_lifecycle.rs
+++ b/backend/src/executor_service/spawn_lifecycle.rs
@@ -13,6 +13,7 @@
 use std::sync::Arc;
 
 use command_group::AsyncCommandGroup;
+use tokio::io::AsyncWriteExt;
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
@@ -54,7 +55,7 @@ pub(crate) async fn run_spawned_executor_task(spawned: super::types::SpawnInputs
     let Some(mut child) = try_spawn_executor_child(&runtime).await else {
         return;
     };
-    save_child_pid_and_close_stdin(&mut child, &runtime.db, runtime.record_id).await;
+    save_child_pid_and_close_stdin(&mut child, runtime.executor_spawn.as_ref(), &runtime.db, runtime.record_id).await;
 
     let (log_flusher, stdout_task, stderr_task, flush_timer) =
         setup_log_capture_pipeline_for(&runtime, &mut child).await;
@@ -148,12 +149,37 @@ pub(crate) async fn handle_spawn_failure(
 /// 关 stdin 是必须的：不少 executor 在执行完后会再读一次 stdin，没有 EOF 就会 hang。
 /// PID 写库是为了后续 cancel / status 查询能定位进程；child.id() == None 表示
 /// 进程已退出（race），跳过写库即可。
+///
+/// `executor` 用于查询 `stdin_payload()`：部分执行器（pi 等）需要在关闭 stdin 之前
+/// 预写自动应答，避免子进程卡在交互式 prompt 上；等价于 `echo y | pi -p ...`。
 pub(crate) async fn save_child_pid_and_close_stdin(
     child: &mut command_group::AsyncGroupChild,
+    executor: &dyn crate::adapters::CodeExecutor,
     db: &Database,
     record_id: i64,
 ) {
-    // Close stdin immediately so child processes get EOF when they try to read it.
+    // 若执行器声明需要预写 stdin（典型场景：pi 启用 Worktree 后会在交互式 prompt
+    // 卡住，等价于 `echo y | pi ...` 的管道输入），先一次性写入再关闭 stdin。
+    // 写入失败不视为致命：关 stdin 本身仍能让子进程正常退出。
+    if let Some(payload) = executor.stdin_payload() {
+        if let Some(stdin) = child.inner().stdin.as_mut() {
+            if let Err(e) = stdin.write_all(payload.as_bytes()).await {
+                tracing::warn!(
+                    "[spawn] 写入执行器 stdin payload 失败: executor={} err={}",
+                    executor.executor_type().as_str(),
+                    e
+                );
+            }
+            if let Err(e) = stdin.flush().await {
+                tracing::warn!(
+                    "[spawn] flush 执行器 stdin 失败: executor={} err={}",
+                    executor.executor_type().as_str(),
+                    e
+                );
+            }
+        }
+    }
+    // 关 stdin 让子进程在读完 payload 后立即收到 EOF，避免挂起。
     drop(child.inner().stdin.take());
     let child_id = child.id().unwrap_or(0);
     if child_id > 0 {

--- a/backend/src/executor_service/stages.rs
+++ b/backend/src/executor_service/stages.rs
@@ -115,7 +115,7 @@ pub(crate) async fn start_todo_and_prepare_spawn(
     let worktree_ctx = resolve_worktree_context(
         &prepared.request.db,
         &prepared.todo,
-        prepared.request.workspace.as_deref(),
+        prepared.request.workspace_path.as_deref(),
     )
     .await;
     record_worktree_path(
@@ -139,18 +139,18 @@ pub(crate) async fn start_todo_and_prepare_spawn(
 
     register_websocket_task_info(&prepared, &todo_title, &executor_spawn).await;
 
-    // effective_workspace 优先级：worktree 路径 > todo.workspace > request.workspace（loop 场景）
-    let effective_workspace = worktree_ctx
-        .effective_workspace
+    // effective_workspace_path 优先级：worktree 路径 > todo.workspace_path > request.workspace_path（loop 场景）
+    let effective_workspace_path = worktree_ctx
+        .effective_workspace_path
         .clone()
-        .or(prepared.todo_workspace.clone())
-        .or(prepared.request.workspace.clone());
+        .or(prepared.todo_workspace_path.clone())
+        .or(prepared.request.workspace_path.clone());
 
     Ok(SpawnInputs {
         prepared,
         todo_title,
         executor_spawn,
-        effective_workspace,
+        effective_workspace_path,
         execution_timeout_secs,
         worktree_ctx,
     })

--- a/backend/src/executor_service/types.rs
+++ b/backend/src/executor_service/types.rs
@@ -41,8 +41,8 @@ pub(crate) struct PreparedExecution {
     pub record_id: i64,
     /// todo 在并发控制 / pre-hook / executor 选择中都用到，必须保留；load_todo 失败时为 None。
     pub todo: Option<crate::models::Todo>,
-    /// 仅 spawn 阶段用于 effective_workspace 回退。
-    pub todo_workspace: Option<String>,
+    /// 仅 spawn 阶段用于 effective_workspace_path 回退。
+    pub todo_workspace_path: Option<String>,
     pub timeout_secs: u64,
 }
 
@@ -54,8 +54,8 @@ pub(crate) struct SpawnInputs {
     pub prepared: PreparedExecution,
     pub todo_title: String,
     pub executor_spawn: Arc<dyn CodeExecutor>,
-    /// spawn 阶段实际使用的 cwd：worktree 路径优先，回退到 todo.workspace。
-    pub effective_workspace: Option<String>,
+    /// spawn 阶段实际使用的 cwd：worktree 路径优先，回退到 todo.workspace_path。
+    pub effective_workspace_path: Option<String>,
     pub execution_timeout_secs: u64,
     pub worktree_ctx: WorktreeContext,
 }
@@ -78,11 +78,11 @@ pub(crate) struct SpawnRuntime {
     pub execution_timeout_secs: u64,
     pub feishu_bot_id: Option<i64>,
     pub feishu_receive_id: Option<String>,
-    /// spawn 阶段实际使用的 cwd：worktree 路径优先，回退到 todo.workspace。
-    /// 修复 issue #660 重构中的回归：原代码在 spawn 闭包内用 effective_workspace
-    /// 决定子进程 cwd，但拆分到 spawn_executor_child 后误用了 todo_workspace，
-    /// 导致启用 worktree 时子进程仍在原始 workspace 内运行。
-    pub effective_workspace: Option<String>,
+    /// spawn 阶段实际使用的 cwd：worktree 路径优先，回退到 todo.workspace_path。
+    /// 修复 issue #660 重构中的回归：原代码在 spawn 闭包内用 effective_workspace_path
+    /// 决定子进程 cwd，但拆分到 spawn_executor_child 后误用了 todo_workspace_path，
+    /// 导致启用 worktree 时子进程仍在原始 workspace_path 内运行。
+    pub effective_workspace_path: Option<String>,
     pub prepared: PreparedExecution,
 }
 

--- a/backend/src/executor_service/worktree.rs
+++ b/backend/src/executor_service/worktree.rs
@@ -2,7 +2,7 @@
 //!
 //! 这里只放 worktree 相关的细粒度辅助函数。每个函数 ≤ 30 行，职责单一。
 //! 编排层（stages::start_todo_and_prepare_spawn）调用这里的 helper 完成：
-//!   1. 根据 todo.workspace 决定是否开 worktree（`resolve_worktree_context`）
+//!   1. 根据 todo.workspace_path 决定是否开 worktree（`resolve_worktree_context`）
 //!   2. 把 worktree 路径回写到 execution_records（`record_worktree_path`）
 //!   3. 执行结束后清理 worktree（`cleanup_worktree_if_needed`）
 //!   4. 杀进程组（`kill_process_tree`，command-group 集成）
@@ -13,33 +13,33 @@ use crate::services::worktree::WorktreeService;
 
 /// issue #643: 单次执行使用的 worktree 上下文。
 ///
-/// - `effective_workspace`: 子进程的 cwd。None=继续用 todo.workspace；
+/// - `effective_workspace_path`: 子进程的 cwd。None=继续用 todo.workspace_path；
 ///   Some(p)=worktree 目录被 ntd 接管，子进程在 worktree 内运行。
 /// - `record_path`: 回写到 execution_records.worktree_path 的值（None=无需记录）。
 /// - `auto_cleanup`: 终态时是否需要调用 WorktreeService::cleanup_worktree。
 #[derive(Debug, Clone, Default)]
 pub(crate) struct WorktreeContext {
-    pub effective_workspace: Option<String>,
+    pub effective_workspace_path: Option<String>,
     pub record_path: Option<String>,
     pub auto_cleanup: bool,
 }
 
-/// 根据 todo.workspace 或显式 workspace 找到对应的 project_directory，决定是否开 worktree。
+/// 根据 todo.workspace_path 或显式 workspace_path 找到对应的 project_directory，决定是否开 worktree。
 ///
-/// 优先使用 todo.workspace；当 todo 为 None 时回退到 `explicit_workspace`（loop 场景）。
+/// 优先使用 todo.workspace_path；当 todo 为 None 时回退到 `explicit_workspace_path`（loop 场景）。
 ///
 /// 不在 `WorktreeContext` 内持有数据库句柄——这是个**纯异步查询**函数，方便在
 /// run_todo_execution 主路径上独立调用并把结果 move 进 spawn 闭包。
 pub(crate) async fn resolve_worktree_context(
     db: &Database,
     todo: &Option<Todo>,
-    explicit_workspace: Option<&str>,
+    explicit_workspace_path: Option<&str>,
 ) -> WorktreeContext {
-    // 没有 todo（被 hook 删除）/ 没有 workspace 关联项目目录——不启用 worktree
+    // 没有 todo（被 hook 删除）/ 没有 workspace_path 关联项目目录——不启用 worktree
     let t = todo.as_ref();
     let ws = t
-        .and_then(|t| t.workspace.as_deref())
-        .or(explicit_workspace)
+        .and_then(|t| t.workspace_path.as_deref())
+        .or(explicit_workspace_path)
         .map(|s| s.to_string());
     let Some(ws) = ws else {
         return WorktreeContext::default();
@@ -58,13 +58,13 @@ pub(crate) async fn resolve_worktree_context(
     let svc = WorktreeService::new();
     match svc.create_worktree(&ws, todo_id) {
         Ok(wt_path) => WorktreeContext {
-            effective_workspace: Some(wt_path.clone()),
+            effective_workspace_path: Some(wt_path.clone()),
             record_path: Some(wt_path),
             auto_cleanup: dir.auto_cleanup,
         },
         Err(e) => {
             tracing::warn!(
-                workspace = %ws,
+                workspace_path = %ws,
                 todo_id = todo_id,
                 error = %e,
                 "failed to create git worktree, falling back to original workspace"
@@ -117,7 +117,7 @@ mod tests {
     #[test]
     fn test_cleanup_worktree_if_needed_disabled() {
         let ctx = WorktreeContext {
-            effective_workspace: None,
+            effective_workspace_path: None,
             record_path: Some("/tmp/ntd-643-disabled".into()),
             auto_cleanup: false,
         };
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn test_cleanup_worktree_if_needed_no_path() {
         let ctx = WorktreeContext {
-            effective_workspace: None,
+            effective_workspace_path: None,
             record_path: None,
             auto_cleanup: true,
         };
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn test_worktree_context_default_is_disabled() {
         let ctx = WorktreeContext::default();
-        assert!(ctx.effective_workspace.is_none());
+        assert!(ctx.effective_workspace_path.is_none());
         assert!(ctx.record_path.is_none());
         assert!(!ctx.auto_cleanup);
     }

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -226,7 +226,7 @@ pub async fn execute_handler(
         step_id: None,
         feishu_bot_id: None,
         feishu_receive_id: None,
-        workspace: None,
+        workspace_path: None,
         workspace_id: None,
     })
     .await;
@@ -503,7 +503,7 @@ pub async fn resume_execution_handler(
         step_id: None,
         feishu_bot_id: None,
         feishu_receive_id: None,
-        workspace: None,
+        workspace_path: None,
         workspace_id: None,
     })
     .await?;
@@ -660,7 +660,7 @@ pub async fn smart_create_handler(
         step_id: None,
         feishu_bot_id: None,
         feishu_receive_id: None,
-        workspace: None,
+        workspace_path: None,
         workspace_id: None,
     })
     .await?;

--- a/backend/src/handlers/feishu_binding.rs
+++ b/backend/src/handlers/feishu_binding.rs
@@ -134,15 +134,16 @@ pub async fn create_binding(
         let existing = state.db.get_todo(tid).await?
             .ok_or_else(|| AppError::BadRequest("指定的 Todo 不存在".to_string()))?;
 
-        let workspace_path_changed = existing.workspace_path.as_ref().map(|w| w.as_str()) != Some(&dir.path);
-        if workspace_path_changed && existing.workspace_path.is_some() {
+        // workspace 字段已统一为 id，路径一致性等价于 id 一致性
+        let workspace_changed = existing.workspace_id.is_some() && existing.workspace_id != Some(dir.id);
+        if workspace_changed {
             tracing::warn!(
-                "[binding] binding todo {} to a different workspace_path (was: {:?}, now: {}), session history may be misaligned",
-                tid, existing.workspace_path, dir.path
+                "[binding] binding todo {} to a different workspace_id (was: {:?}, now: {}), session history may be misaligned",
+                tid, existing.workspace_id, dir.id
             );
         }
 
-        if let Err(e) = state.db.update_todo_workspace(tid, Some(&dir.path)).await {
+        if let Err(e) = state.db.update_todo_workspace(tid, Some(dir.id), Some(&dir.path)).await {
             tracing::warn!("[binding] failed to update todo {} workspace: {e}", tid);
         }
         tid
@@ -163,7 +164,7 @@ pub async fn create_binding(
             &todo_prompt,
             req.executor.as_deref().filter(|s| !s.is_empty()),
         ).await?;
-        if let Err(e) = state.db.update_todo_workspace(new_todo_id, Some(&dir.path)).await {
+        if let Err(e) = state.db.update_todo_workspace(new_todo_id, Some(dir.id), Some(&dir.path)).await {
             tracing::warn!("[binding] failed to set todo workspace: {e}");
         }
         new_todo_id

--- a/backend/src/handlers/feishu_binding.rs
+++ b/backend/src/handlers/feishu_binding.rs
@@ -134,11 +134,11 @@ pub async fn create_binding(
         let existing = state.db.get_todo(tid).await?
             .ok_or_else(|| AppError::BadRequest("指定的 Todo 不存在".to_string()))?;
 
-        let workspace_changed = existing.workspace.as_ref().map(|w| w.as_str()) != Some(&dir.path);
-        if workspace_changed && existing.workspace.is_some() {
+        let workspace_path_changed = existing.workspace_path.as_ref().map(|w| w.as_str()) != Some(&dir.path);
+        if workspace_path_changed && existing.workspace_path.is_some() {
             tracing::warn!(
-                "[binding] binding todo {} to a different workspace (was: {:?}, now: {}), session history may be misaligned",
-                tid, existing.workspace, dir.path
+                "[binding] binding todo {} to a different workspace_path (was: {:?}, now: {}), session history may be misaligned",
+                tid, existing.workspace_path, dir.path
             );
         }
 

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -24,7 +24,7 @@ use serde::Deserialize;
 use crate::handlers::{AppError, AppState};
 use crate::models::{
     self,
-    ApiResponse, BatchCopyLoopWorkspacePathRequest, BatchUpdateLoopWorkspacePathRequest,
+    ApiResponse, BatchCopyLoopWorkspaceRequest, BatchUpdateLoopWorkspaceRequest,
     BatchWorkspaceResult, CreateLoopRequest, CreateLoopStepRequest, CreateTriggerRequest,
     LoopDetail, LoopDto, LoopExecutionDetail, LoopExecutionDto, LoopExecutionTokenSummary,
     LoopListItem, LoopStepDto, LoopStepExecutionDto, LoopTriggerDto, ReorderLoopStepsRequest,
@@ -69,10 +69,13 @@ pub async fn create_loop(
     if req.name.trim().is_empty() {
         return Err(AppError::BadRequest("name 不能为空".to_string()));
     }
-    // 创建环路前校验工作空间必填
-    if req.workspace_path.trim().is_empty() {
-        return Err(AppError::BadRequest("workspace 不能为空".to_string()));
-    }
+    // 工作空间必填且必须存在：handler 强制把 id 解析为 path 后再下传 DAO，
+    // 避免 DAO 再做路径反查，也保证 workspace_id / workspace_path 双字段同步写入。
+    let workspace = state
+        .db
+        .get_project_directory_by_id(req.workspace_id)
+        .await?
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", req.workspace_id)))?;
     // 创建环路前校验标签约束：环路只能选择一个标签
     if req.tag_ids.len() > 1 {
         return Err(AppError::BadRequest("环路只能选择一个标签".to_string()));
@@ -82,7 +85,8 @@ pub async fn create_loop(
         .create_loop(
             req.name.trim(),
             &req.description,
-            Some(req.workspace_path.trim()),
+            Some(req.workspace_id),
+            Some(workspace.path.as_str()),
             req.webhook_enabled,
             &req.icon,
             req.review_template_id,
@@ -130,13 +134,29 @@ pub async fn update_loop(
         .get_loop(id)
         .await?
         .ok_or(AppError::NotFound)?;
+    // 工作空间切换是可选的；只有显式传 workspace_id 才查 path，保证 cwd 与筛选键同步更新。
+    // 不传则保留原工作空间不变——避免误清空。
+    let mut workspace_id: Option<i64> = req.workspace_id;
+    let mut workspace_path: Option<String> = None;
+    if let Some(wid) = workspace_id {
+        let dir = state
+            .db
+            .get_project_directory_by_id(wid)
+            .await?
+            .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", wid)))?;
+        workspace_path = Some(dir.path);
+    }
+    // 把外部传入 id 再带回去，DAO 内部用 id 写入并保持 cwd 字段同步
+    let _ = workspace_id.take();
+    let workspace_id_for_dao: Option<i64> = req.workspace_id;
     state
         .db
         .update_loop(
             id,
             req.name.trim(),
             &req.description,
-            req.workspace_path.as_deref(),
+            workspace_id_for_dao,
+            workspace_path.as_deref(),
             req.webhook_enabled,
             &req.icon,
             req.review_template_id,
@@ -728,17 +748,21 @@ pub async fn get_execution(
 /// PUT /api/loops/batch-workspace — 批量移动环路到其他工作空间
 pub async fn batch_move_loops_workspace(
     State(state): State<AppState>,
-    Json(req): Json<BatchUpdateLoopWorkspacePathRequest>,
+    Json(req): Json<BatchUpdateLoopWorkspaceRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     if req.ids.is_empty() {
         return Err(AppError::BadRequest("ids 不能为空".to_string()));
     }
-    if req.workspace_path.trim().is_empty() {
-        return Err(AppError::BadRequest("workspace 不能为空".to_string()));
-    }
+    // 工作空间 id 必填且必须存在；handler 在此层把 id 解析为 path，
+    // DAO 一次写入 workspace_id + workspace_path 两列保证双字段同步。
+    let dir = state
+        .db
+        .get_project_directory_by_id(req.workspace_id)
+        .await?
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", req.workspace_id)))?;
     let rows_affected = state
         .db
-        .batch_update_loops_workspace(&req.ids, req.workspace_path.trim())
+        .batch_update_loops_workspace(&req.ids, req.workspace_id, &dir.path)
         .await?;
     Ok(ApiResponse::ok(BatchWorkspaceResult {
         updated_count: rows_affected as i64,
@@ -749,17 +773,19 @@ pub async fn batch_move_loops_workspace(
 /// POST /api/loops/batch-copy-workspace — 批量复制环路到其他工作空间
 pub async fn batch_copy_loops_workspace(
     State(state): State<AppState>,
-    Json(req): Json<BatchCopyLoopWorkspacePathRequest>,
+    Json(req): Json<BatchCopyLoopWorkspaceRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     if req.ids.is_empty() {
         return Err(AppError::BadRequest("ids 不能为空".to_string()));
     }
-    if req.workspace_path.trim().is_empty() {
-        return Err(AppError::BadRequest("workspace 不能为空".to_string()));
-    }
+    let dir = state
+        .db
+        .get_project_directory_by_id(req.workspace_id)
+        .await?
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", req.workspace_id)))?;
     let created_ids = state
         .db
-        .batch_copy_loops_to_workspace(&req.ids, req.workspace_path.trim())
+        .batch_copy_loops_to_workspace(&req.ids, req.workspace_id, &dir.path)
         .await?;
     Ok(ApiResponse::ok(BatchWorkspaceResult {
         updated_count: created_ids.len() as i64,

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -24,7 +24,8 @@ use serde::Deserialize;
 use crate::handlers::{AppError, AppState};
 use crate::models::{
     self,
-    ApiResponse, CreateLoopRequest, CreateLoopStepRequest, CreateTriggerRequest,
+    ApiResponse, BatchCopyLoopWorkspacePathRequest, BatchUpdateLoopWorkspacePathRequest,
+    BatchWorkspaceResult, CreateLoopRequest, CreateLoopStepRequest, CreateTriggerRequest,
     LoopDetail, LoopDto, LoopExecutionDetail, LoopExecutionDto, LoopExecutionTokenSummary,
     LoopListItem, LoopStepDto, LoopStepExecutionDto, LoopTriggerDto, ReorderLoopStepsRequest,
     UpdateLoopRequest, UpdateLoopStatusRequest, UpdateLoopStepRequest,
@@ -41,8 +42,11 @@ pub async fn list_loops(
     State(state): State<AppState>,
     Query(params): Query<std::collections::HashMap<String, String>>,
 ) -> Result<impl IntoResponse, AppError> {
-    let workspace = params.get("workspace").map(|s| s.as_str());
-    let rows = state.db.list_loops_with_counts(workspace).await?;
+    // 筛选约定：必须用 workspace_id（唯一键）。前端 listLoops 已切到 id 过滤。
+    let workspace_id: Option<i64> = params
+        .get("workspace_id")
+        .and_then(|s| s.parse().ok());
+    let rows = state.db.list_loops_with_counts(workspace_id).await?;
     let items: Vec<LoopListItem> = rows.into_iter().map(Into::into).collect();
     // 批量查询所有 loop 的标签映射，避免逐条 N+1 查询
     let loop_ids: Vec<i64> = items.iter().map(|item| item.loop_.id).collect();
@@ -66,7 +70,7 @@ pub async fn create_loop(
         return Err(AppError::BadRequest("name 不能为空".to_string()));
     }
     // 创建环路前校验工作空间必填
-    if req.workspace.trim().is_empty() {
+    if req.workspace_path.trim().is_empty() {
         return Err(AppError::BadRequest("workspace 不能为空".to_string()));
     }
     // 创建环路前校验标签约束：环路只能选择一个标签
@@ -78,7 +82,7 @@ pub async fn create_loop(
         .create_loop(
             req.name.trim(),
             &req.description,
-            Some(req.workspace.trim()),
+            Some(req.workspace_path.trim()),
             req.webhook_enabled,
             &req.icon,
             req.review_template_id,
@@ -132,7 +136,7 @@ pub async fn update_loop(
             id,
             req.name.trim(),
             &req.description,
-            req.workspace.as_deref(),
+            req.workspace_path.as_deref(),
             req.webhook_enabled,
             &req.icon,
             req.review_template_id,
@@ -719,12 +723,58 @@ pub async fn get_execution(
     }))
 }
 
+// ====== 批量 workspace 操作 ======
+
+/// PUT /api/loops/batch-workspace — 批量移动环路到其他工作空间
+pub async fn batch_move_loops_workspace(
+    State(state): State<AppState>,
+    Json(req): Json<BatchUpdateLoopWorkspacePathRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if req.ids.is_empty() {
+        return Err(AppError::BadRequest("ids 不能为空".to_string()));
+    }
+    if req.workspace_path.trim().is_empty() {
+        return Err(AppError::BadRequest("workspace 不能为空".to_string()));
+    }
+    let rows_affected = state
+        .db
+        .batch_update_loops_workspace(&req.ids, req.workspace_path.trim())
+        .await?;
+    Ok(ApiResponse::ok(BatchWorkspaceResult {
+        updated_count: rows_affected as i64,
+        total: req.ids.len() as i64,
+    }))
+}
+
+/// POST /api/loops/batch-copy-workspace — 批量复制环路到其他工作空间
+pub async fn batch_copy_loops_workspace(
+    State(state): State<AppState>,
+    Json(req): Json<BatchCopyLoopWorkspacePathRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if req.ids.is_empty() {
+        return Err(AppError::BadRequest("ids 不能为空".to_string()));
+    }
+    if req.workspace_path.trim().is_empty() {
+        return Err(AppError::BadRequest("workspace 不能为空".to_string()));
+    }
+    let created_ids = state
+        .db
+        .batch_copy_loops_to_workspace(&req.ids, req.workspace_path.trim())
+        .await?;
+    Ok(ApiResponse::ok(BatchWorkspaceResult {
+        updated_count: created_ids.len() as i64,
+        total: req.ids.len() as i64,
+    }))
+}
+
 // ====== 路由表 ======
 
 pub fn loop_routes() -> axum::Router<AppState> {
     use axum::routing::{get, post, put};
     axum::Router::new()
         .route("/api/loops", get(list_loops).post(create_loop))
+        .route("/api/loops/batch-workspace", put(batch_move_loops_workspace))
+        .route("/api/loops/batch-copy-workspace", post(batch_copy_loops_workspace))
         .route("/api/loops/{id}", get(get_loop).put(update_loop).delete(delete_loop))
         .route("/api/loops/{id}/status", put(update_loop_status))
         .route("/api/loops/{id}/tags", put(update_loop_tags))

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1226,6 +1226,8 @@ fn todo_routes() -> Router<AppState> {
         .route("/api/todos/{id}/scheduler", put(scheduler::update_scheduler))
         .route("/api/todos/recent-completed", get(todo::get_recent_completed_todos))
         .route("/api/todos/batch-executor", put(todo::batch_update_todos_executor))
+        .route("/api/todos/batch-workspace", put(todo::batch_move_todos_workspace))
+        .route("/api/todos/batch-copy-workspace", post(todo::batch_copy_todos_workspace))
         .route("/api/todos/{id}", get(todo::get_todo).put(todo::update_todo).delete(todo::delete_todo))
         .route("/api/tags", get(tag::get_tags).post(tag::create_tag))
         .route("/api/tags/{id}", delete(tag::delete_tag))

--- a/backend/src/handlers/sync.rs
+++ b/backend/src/handlers/sync.rs
@@ -6,7 +6,6 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::db::project_directory::ProjectDirectory;
 use crate::db::Database;
 use crate::handlers::{ApiResponse, AppError, AppState};
 use crate::models::{Todo, TodoStatus};

--- a/backend/src/handlers/sync.rs
+++ b/backend/src/handlers/sync.rs
@@ -6,6 +6,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::db::project_directory::ProjectDirectory;
 use crate::db::Database;
 use crate::handlers::{ApiResponse, AppError, AppState};
 use crate::models::{Todo, TodoStatus};
@@ -50,8 +51,10 @@ pub struct CloudTodoItem {
     pub scheduler_config: Option<String>,
     #[serde(default)]
     pub tag_names: Vec<String>,
+    /// 工作空间 ID（project_directories.id），唯一键。
+    /// 同步 payload 不再带路径——破坏式变更，所有调用方必须改为传 id。
     #[serde(default)]
-    pub workspace_path: Option<String>,
+    pub workspace_id: Option<i64>,
     #[serde(default)]
     pub worktree: Option<String>,
 }
@@ -288,6 +291,9 @@ async fn merge_cloud_todos_to_local(
         if title.is_empty() {
             continue;
         }
+        // 按 id 解析 path：handler 层负责把 id 解析为 path 后下传 DAO；
+        // 无 workspace 的云端项 fallback 到 /tmp 临时目录（V34 迁移策略）。
+        let resolved_workspace = resolve_cloud_workspace(db, item.workspace_id).await?;
         let key = title.to_lowercase();
         match conflict_mode {
             "skip" => {
@@ -295,9 +301,19 @@ async fn merge_cloud_todos_to_local(
                 if local_by_title.contains_key(&key) {
                     continue;
                 }
-                let new_id = db.create_todo(title, &item.prompt).await.map_err(|e| e.to_string())?;
+                let new_id = db.create_todo_with_extras(
+                    title,
+                    &item.prompt,
+                    None,
+                    None,
+                    false,
+                    resolved_workspace.id,
+                    &resolved_workspace.path,
+                )
+                .await
+                .map_err(|e| e.to_string())?;
                 affected += 1;
-                tracing::info!("pull: 新增 todo id={} title={}", new_id, title);
+                tracing::info!("pull: 新增 todo id={} title={} workspace_id={}", new_id, title, resolved_workspace.id);
             }
             "overwrite" => {
                 if let Some(&id) = local_by_title.get(&key) {
@@ -313,19 +329,33 @@ async fn merge_cloud_todos_to_local(
                         scheduler_enabled: None,
                         scheduler_config: None,
                         scheduler_timezone: None,
-                        workspace_path: item.workspace_path.as_deref(),
+                        workspace_id: Some(resolved_workspace.id),
                         webhook_enabled: None,
                         acceptance_criteria: None,
                         auto_review_enabled: None,
                     })
                     .await
                     .map_err(|e| e.to_string())?;
+                    // 同步 cwd 字段：handler 层负责 id→path 解析，DAO 只负责写入
+                    db.update_todo_workspace(id, Some(resolved_workspace.id), Some(&resolved_workspace.path))
+                        .await
+                        .map_err(|e| e.to_string())?;
                     affected += 1;
-                    tracing::info!("pull: 覆盖 todo id={} title={}", id, title);
+                    tracing::info!("pull: 覆盖 todo id={} title={} workspace_id={}", id, title, resolved_workspace.id);
                 } else {
-                    let new_id = db.create_todo(title, &item.prompt).await.map_err(|e| e.to_string())?;
+                    let new_id = db.create_todo_with_extras(
+                        title,
+                        &item.prompt,
+                        None,
+                        None,
+                        false,
+                        resolved_workspace.id,
+                        &resolved_workspace.path,
+                    )
+                    .await
+                    .map_err(|e| e.to_string())?;
                     affected += 1;
-                    tracing::info!("pull: 新增 todo id={} title={}", new_id, title);
+                    tracing::info!("pull: 新增 todo id={} title={} workspace_id={}", new_id, title, resolved_workspace.id);
                 }
             }
             "rename" => {
@@ -335,20 +365,66 @@ async fn merge_cloud_todos_to_local(
                 } else {
                     title.to_string()
                 };
-                let new_id = db.create_todo(&final_title, &item.prompt).await.map_err(|e| e.to_string())?;
+                let new_id = db.create_todo_with_extras(
+                    &final_title,
+                    &item.prompt,
+                    None,
+                    None,
+                    false,
+                    resolved_workspace.id,
+                    &resolved_workspace.path,
+                )
+                .await
+                .map_err(|e| e.to_string())?;
                 affected += 1;
-                tracing::info!("pull: 新增 todo id={} title={}", new_id, final_title);
+                tracing::info!("pull: 新增 todo id={} title={} workspace_id={}", new_id, final_title, resolved_workspace.id);
             }
             _ => {
                 // 未知策略：当作 skip 处理
                 if !local_by_title.contains_key(&key) {
-                    let _new_id = db.create_todo(title, &item.prompt).await.map_err(|e| e.to_string())?;
+                    let _new_id = db.create_todo_with_extras(
+                        title,
+                        &item.prompt,
+                        None,
+                        None,
+                        false,
+                        resolved_workspace.id,
+                        &resolved_workspace.path,
+                    )
+                    .await
+                    .map_err(|e| e.to_string())?;
                     affected += 1;
                 }
             }
         }
     }
     Ok(affected)
+}
+
+/// 云端 payload 给的 `workspace_id` 在本地可能不存在（云端项目未在本机注册），
+/// 这种情况下 fallback 到「/tmp」临时目录（V34 迁移策略）—— 保证 sync 不会因为
+/// workspace 不存在而整条流失败。
+async fn resolve_cloud_workspace(
+    db: &Database,
+    workspace_id: Option<i64>,
+) -> Result<crate::db::project_directory::ProjectDirectory, String> {
+    if let Some(wid) = workspace_id {
+        if let Some(dir) = db.get_project_directory_by_id(wid).await.map_err(|e| e.to_string())? {
+            return Ok(dir);
+        }
+    }
+    // 回退：查 /tmp 是否已注册，没有则建一条 name='临时工作空间' 的目录记录。
+    if let Some(existing) = db.get_project_directory_by_path("/tmp").await.map_err(|e| e.to_string())? {
+        return Ok(existing);
+    }
+    let new_id = db
+        .create_project_directory("/tmp", Some("临时工作空间"), false, false)
+        .await
+        .map_err(|e| e.to_string())?;
+    db.get_project_directory_by_id(new_id)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "创建 /tmp fallback 失败".to_string())
 }
 
 fn local_todos_to_cloud(todos: Vec<Todo>, tag_map: HashMap<i64, String>) -> CloudSyncData {
@@ -369,7 +445,7 @@ fn local_todos_to_cloud(todos: Vec<Todo>, tag_map: HashMap<i64, String>) -> Clou
                 scheduler_enabled: t.scheduler_enabled,
                 scheduler_config: t.scheduler_config,
                 tag_names,
-                workspace_path: t.workspace_path,
+                workspace_id: t.workspace_id,
                 worktree: None,
             }
         })

--- a/backend/src/handlers/sync.rs
+++ b/backend/src/handlers/sync.rs
@@ -51,7 +51,7 @@ pub struct CloudTodoItem {
     #[serde(default)]
     pub tag_names: Vec<String>,
     #[serde(default)]
-    pub workspace: Option<String>,
+    pub workspace_path: Option<String>,
     #[serde(default)]
     pub worktree: Option<String>,
 }
@@ -313,7 +313,7 @@ async fn merge_cloud_todos_to_local(
                         scheduler_enabled: None,
                         scheduler_config: None,
                         scheduler_timezone: None,
-                        workspace: item.workspace.as_deref(),
+                        workspace_path: item.workspace_path.as_deref(),
                         webhook_enabled: None,
                         acceptance_criteria: None,
                         auto_review_enabled: None,
@@ -369,7 +369,7 @@ fn local_todos_to_cloud(todos: Vec<Todo>, tag_map: HashMap<i64, String>) -> Clou
                 scheduler_enabled: t.scheduler_enabled,
                 scheduler_config: t.scheduler_config,
                 tag_names,
-                workspace: t.workspace,
+                workspace_path: t.workspace_path,
                 worktree: None,
             }
         })

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -7,7 +7,9 @@ use crate::db::TodoUpdate;
 use crate::handlers::{ApiJson, AppError, AppState};
 // todo hook 已整块移除（plan `purring-forging-petal`），HookContext 不再导入。
 use crate::models::{
-    utc_timestamp, ApiResponse, BatchUpdateTodoExecutorRequest, BatchUpdateTodoResult,
+    utc_timestamp, ApiResponse, BatchCopyTodoWorkspacePathRequest,
+    BatchUpdateTodoExecutorRequest, BatchUpdateTodoResult,
+    BatchUpdateTodoWorkspacePathRequest, BatchWorkspaceResult,
     CreateTodoRequest, RecentCompletedTodo, Todo, UpdateTagsRequest, UpdateTodoRequest,
 };
 
@@ -145,7 +147,7 @@ pub async fn create_todo(
         scheduler_timezone: scheduler_timezone.clone(),
         scheduler_next_run_at: None,
         task_id: None,
-        workspace: None,
+        workspace_path: None,
         workspace_id: None,
         webhook_enabled: req.webhook_enabled.unwrap_or(false),
         acceptance_criteria: req.acceptance_criteria.clone(),
@@ -179,7 +181,7 @@ pub async fn update_todo(
     };
     let new_status = req.status.unwrap_or(current.status);
     let executor = req.executor.or(current.executor);
-    let workspace = req.workspace.or(current.workspace);
+    let workspace_path = req.workspace_path.or(current.workspace_path);
 
     let scheduler_config = req
         .scheduler_config
@@ -213,7 +215,7 @@ pub async fn update_todo(
             scheduler_enabled: req.scheduler_enabled,
             scheduler_config: scheduler_config.as_deref(),
             scheduler_timezone: scheduler_timezone.as_deref(),
-            workspace: workspace.as_deref(),
+            workspace_path: workspace_path.as_deref(),
             webhook_enabled: req.webhook_enabled,
             acceptance_criteria: req.acceptance_criteria.as_deref(),
             auto_review_enabled: req.auto_review_enabled,
@@ -326,6 +328,48 @@ pub async fn batch_update_todos_executor(
         .await?;
     Ok(ApiResponse::ok(BatchUpdateTodoResult {
         updated_count: rows_affected as i64,
+        total: req.ids.len() as i64,
+    }))
+}
+
+/// PUT /api/todos/batch-workspace — 批量移动事项到其他工作空间
+pub async fn batch_move_todos_workspace(
+    State(state): State<AppState>,
+    ApiJson(req): ApiJson<BatchUpdateTodoWorkspacePathRequest>,
+) -> Result<ApiResponse<BatchWorkspaceResult>, AppError> {
+    if req.ids.is_empty() {
+        return Err(AppError::BadRequest("ids 不能为空".to_string()));
+    }
+    if req.workspace_path.trim().is_empty() {
+        return Err(AppError::BadRequest("workspace 不能为空".to_string()));
+    }
+    let rows_affected = state
+        .db
+        .batch_update_todos_workspace(&req.ids, req.workspace_path.trim())
+        .await?;
+    Ok(ApiResponse::ok(BatchWorkspaceResult {
+        updated_count: rows_affected as i64,
+        total: req.ids.len() as i64,
+    }))
+}
+
+/// POST /api/todos/batch-copy-workspace — 批量复制事项到其他工作空间
+pub async fn batch_copy_todos_workspace(
+    State(state): State<AppState>,
+    ApiJson(req): ApiJson<BatchCopyTodoWorkspacePathRequest>,
+) -> Result<ApiResponse<BatchWorkspaceResult>, AppError> {
+    if req.ids.is_empty() {
+        return Err(AppError::BadRequest("ids 不能为空".to_string()));
+    }
+    if req.workspace_path.trim().is_empty() {
+        return Err(AppError::BadRequest("workspace 不能为空".to_string()));
+    }
+    let created_ids = state
+        .db
+        .batch_copy_todos_to_workspace(&req.ids, req.workspace_path.trim())
+        .await?;
+    Ok(ApiResponse::ok(BatchWorkspaceResult {
+        updated_count: created_ids.len() as i64,
         total: req.ids.len() as i64,
     }))
 }

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -7,9 +7,9 @@ use crate::db::TodoUpdate;
 use crate::handlers::{ApiJson, AppError, AppState};
 // todo hook 已整块移除（plan `purring-forging-petal`），HookContext 不再导入。
 use crate::models::{
-    utc_timestamp, ApiResponse, BatchCopyTodoWorkspacePathRequest,
+    utc_timestamp, ApiResponse, BatchCopyTodoWorkspaceRequest,
     BatchUpdateTodoExecutorRequest, BatchUpdateTodoResult,
-    BatchUpdateTodoWorkspacePathRequest, BatchWorkspaceResult,
+    BatchUpdateTodoWorkspaceRequest, BatchWorkspaceResult,
     CreateTodoRequest, RecentCompletedTodo, Todo, UpdateTagsRequest, UpdateTodoRequest,
 };
 
@@ -69,13 +69,21 @@ pub async fn create_todo(
         .clone()
         .unwrap_or_else(|| "claudecode".to_string());
 
+    // 工作空间 id 必填且必须存在：handler 按 id 解析出 path 后再下传，
+    // DAO 一次写入 workspace_id + workspace_path 两列保证双字段同步。
+    let dir = state
+        .db
+        .get_project_directory_by_id(req.workspace_id)
+        .await?
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", req.workspace_id)))?;
     let id = state.db.create_todo_with_extras(
         title,
         &prompt,
         Some(&executor),
         req.acceptance_criteria.as_deref(),
         req.webhook_enabled.unwrap_or(false),
-        None, // workspace_id 由调用方在创建后通过 update_todo_workspace 单独设置
+        req.workspace_id,
+        &dir.path,
     ).await?;
 
     // Update executor if specified
@@ -147,8 +155,10 @@ pub async fn create_todo(
         scheduler_timezone: scheduler_timezone.clone(),
         scheduler_next_run_at: None,
         task_id: None,
+        // cwd 字段保留为 None：handler 已通过 create_todo_with_extras 把 path 同步写入 DB，
+        // 这里只对外回传 workspace_id；前端不再消费 workspace_path。
         workspace_path: None,
-        workspace_id: None,
+        workspace_id: Some(req.workspace_id),
         webhook_enabled: req.webhook_enabled.unwrap_or(false),
         acceptance_criteria: req.acceptance_criteria.clone(),
         todo_type: 0,
@@ -181,7 +191,19 @@ pub async fn update_todo(
     };
     let new_status = req.status.unwrap_or(current.status);
     let executor = req.executor.or(current.executor);
-    let workspace_path = req.workspace_path.or(current.workspace_path);
+    // 工作空间切换是可选的；只有显式传 workspace_id 才把 id + 解析得到的 path 一并下传。
+    // 不传则保持原工作空间不变——DAO 端 workspace_id=None 时不动这一列。
+    let new_workspace_id = req.workspace_id;
+    let new_workspace_path: Option<String> = if let Some(wid) = new_workspace_id {
+        let dir = state
+            .db
+            .get_project_directory_by_id(wid)
+            .await?
+            .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", wid)))?;
+        Some(dir.path)
+    } else {
+        None
+    };
 
     let scheduler_config = req
         .scheduler_config
@@ -215,13 +237,23 @@ pub async fn update_todo(
             scheduler_enabled: req.scheduler_enabled,
             scheduler_config: scheduler_config.as_deref(),
             scheduler_timezone: scheduler_timezone.as_deref(),
-            workspace_path: workspace_path.as_deref(),
+            workspace_id: new_workspace_id,
             webhook_enabled: req.webhook_enabled,
             acceptance_criteria: req.acceptance_criteria.as_deref(),
             auto_review_enabled: req.auto_review_enabled,
         })
         .await
         .map_err(AppError::from)?;
+
+    // 工作空间双字段同步：TodoUpdate 只写了 workspace_id，cwd path 由 update_todo_workspace 单独补齐
+    // （handler 已经按 id 查到 path，避免 DAO 再做反查）。
+    if let (Some(wid), Some(wpath)) = (new_workspace_id, new_workspace_path.as_deref()) {
+        state
+            .db
+            .update_todo_workspace(id, Some(wid), Some(wpath))
+            .await
+            .map_err(AppError::from)?;
+    }
 
     // todo hook 已整块移除（plan `purring-forging-petal`）：todo 不再持有
     // inline hooks 列表，也不会在状态变化时 fire 任何 hook。原先的两步
@@ -335,17 +367,20 @@ pub async fn batch_update_todos_executor(
 /// PUT /api/todos/batch-workspace — 批量移动事项到其他工作空间
 pub async fn batch_move_todos_workspace(
     State(state): State<AppState>,
-    ApiJson(req): ApiJson<BatchUpdateTodoWorkspacePathRequest>,
+    ApiJson(req): ApiJson<BatchUpdateTodoWorkspaceRequest>,
 ) -> Result<ApiResponse<BatchWorkspaceResult>, AppError> {
     if req.ids.is_empty() {
         return Err(AppError::BadRequest("ids 不能为空".to_string()));
     }
-    if req.workspace_path.trim().is_empty() {
-        return Err(AppError::BadRequest("workspace 不能为空".to_string()));
-    }
+    // handler 把 id 解析为 path 后下传 DAO；DAO 一次写入 workspace_id + workspace_path。
+    let dir = state
+        .db
+        .get_project_directory_by_id(req.workspace_id)
+        .await?
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", req.workspace_id)))?;
     let rows_affected = state
         .db
-        .batch_update_todos_workspace(&req.ids, req.workspace_path.trim())
+        .batch_update_todos_workspace(&req.ids, req.workspace_id, &dir.path)
         .await?;
     Ok(ApiResponse::ok(BatchWorkspaceResult {
         updated_count: rows_affected as i64,
@@ -356,17 +391,19 @@ pub async fn batch_move_todos_workspace(
 /// POST /api/todos/batch-copy-workspace — 批量复制事项到其他工作空间
 pub async fn batch_copy_todos_workspace(
     State(state): State<AppState>,
-    ApiJson(req): ApiJson<BatchCopyTodoWorkspacePathRequest>,
+    ApiJson(req): ApiJson<BatchCopyTodoWorkspaceRequest>,
 ) -> Result<ApiResponse<BatchWorkspaceResult>, AppError> {
     if req.ids.is_empty() {
         return Err(AppError::BadRequest("ids 不能为空".to_string()));
     }
-    if req.workspace_path.trim().is_empty() {
-        return Err(AppError::BadRequest("workspace 不能为空".to_string()));
-    }
+    let dir = state
+        .db
+        .get_project_directory_by_id(req.workspace_id)
+        .await?
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", req.workspace_id)))?;
     let created_ids = state
         .db
-        .batch_copy_todos_to_workspace(&req.ids, req.workspace_path.trim())
+        .batch_copy_todos_to_workspace(&req.ids, req.workspace_id, &dir.path)
         .await?;
     Ok(ApiResponse::ok(BatchWorkspaceResult {
         updated_count: created_ids.len() as i64,

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -130,7 +130,7 @@ async fn trigger_todo_webhook_internal(
             step_id: None,
             feishu_bot_id: None,
             feishu_receive_id: None,
-            workspace: todo.workspace.clone(),
+            workspace_path: todo.workspace_path.clone(),
             workspace_id: None,
         },
     ).await;

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -86,7 +86,10 @@ pub struct LoopDto {
     pub id: i64,
     pub name: String,
     pub description: String,
-    pub workspace_path: Option<String>,
+    /// 所属工作空间 ID（project_directories.id），唯一键。
+    /// 路径不再作为 API 字段返回——cwd 在后端内部从 project_directories 解析，
+    /// 前端展示用 project_directories.name，避免长路径重复上送。
+    pub workspace_id: Option<i64>,
     pub webhook_enabled: bool,
     pub status: String,
     /// 标签 ID 列表（单选，复用 Todo 的标签体系）
@@ -109,7 +112,7 @@ impl From<loops::Model> for LoopDto {
             id: m.id,
             name: m.name,
             description: m.description,
-            workspace_path: m.workspace_path,
+            workspace_id: m.workspace_id,
             webhook_enabled: m.webhook_enabled,
             status: m.status,
             tag_ids: vec![],
@@ -360,8 +363,9 @@ pub struct CreateLoopRequest {
     pub name: String,
     #[serde(default)]
     pub description: String,
-    /// 工作空间目录路径（必填，对应 project_directories.path）。
-    pub workspace_path: String,
+    /// 工作空间 ID（project_directories.id），必填、唯一键。
+    /// 不再接受路径——避免 path 不唯一带来的歧义。
+    pub workspace_id: i64,
     #[serde(default)]
     pub webhook_enabled: bool,
     #[serde(default)]
@@ -386,7 +390,11 @@ fn default_abnormal_trigger_on() -> String { "[\"capped_step\",\"capped_token\",
 pub struct UpdateLoopRequest {
     pub name: String,
     pub description: String,
-    pub workspace_path: Option<String>,
+    /// 工作空间 ID（project_directories.id）。
+    /// None=保持当前工作空间，Some(id)=迁移到该工作空间。
+    /// 不接受路径——handler 一律按 id 解析 cwd 路径写入两列。
+    #[serde(default)]
+    pub workspace_id: Option<i64>,
     #[serde(default)]
     pub webhook_enabled: bool,
     pub icon: String,

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -86,7 +86,7 @@ pub struct LoopDto {
     pub id: i64,
     pub name: String,
     pub description: String,
-    pub workspace: Option<String>,
+    pub workspace_path: Option<String>,
     pub webhook_enabled: bool,
     pub status: String,
     /// 标签 ID 列表（单选，复用 Todo 的标签体系）
@@ -109,7 +109,7 @@ impl From<loops::Model> for LoopDto {
             id: m.id,
             name: m.name,
             description: m.description,
-            workspace: m.workspace,
+            workspace_path: m.workspace_path,
             webhook_enabled: m.webhook_enabled,
             status: m.status,
             tag_ids: vec![],
@@ -360,8 +360,8 @@ pub struct CreateLoopRequest {
     pub name: String,
     #[serde(default)]
     pub description: String,
-    /// 工作空间（项目目录路径），必填。
-    pub workspace: String,
+    /// 工作空间目录路径（必填，对应 project_directories.path）。
+    pub workspace_path: String,
     #[serde(default)]
     pub webhook_enabled: bool,
     #[serde(default)]
@@ -386,7 +386,7 @@ fn default_abnormal_trigger_on() -> String { "[\"capped_step\",\"capped_token\",
 pub struct UpdateLoopRequest {
     pub name: String,
     pub description: String,
-    pub workspace: Option<String>,
+    pub workspace_path: Option<String>,
     #[serde(default)]
     pub webhook_enabled: bool,
     pub icon: String,

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -106,8 +106,13 @@ pub struct Todo {
     pub scheduler_next_run_at: Option<String>,
     #[serde(default)]
     pub task_id: Option<String>,
+    /// 工作空间目录路径（cwd，仅后端内部使用，不通过 API 暴露给前端）。
+    /// 业务层（前端 / CLI / sync）只通过 `workspace_id` 标识工作空间，
+    /// path 字段保留供 executor_service / worktree 等需要 cwd 的子系统使用。
     #[serde(default)]
     pub workspace_path: Option<String>,
+    /// 所属工作空间 ID（project_directories.id），唯一键。
+    /// 业务层（前端 / CLI / API）统一以此作为工作空间标识符。
     #[serde(default)]
     pub workspace_id: Option<i64>,
     #[serde(default)]
@@ -350,6 +355,9 @@ pub struct CreateTodoRequest {
     pub webhook_enabled: Option<bool>,
     #[serde(default)]
     pub auto_review_enabled: Option<bool>,
+    /// 工作空间 ID（project_directories.id），唯一键。
+    /// 创建时必填；handler 据此查 path 写入 DB cwd 字段。
+    pub workspace_id: i64,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -368,8 +376,11 @@ pub struct UpdateTodoRequest {
     pub scheduler_config: Option<String>,
     #[serde(default)]
     pub scheduler_timezone: Option<String>,
+    /// 工作空间 ID（project_directories.id）。
+    /// None=保持当前工作空间，Some(id)=迁移到该工作空间。
+    /// 不接受路径——handler 一律按 id 解析 cwd 路径写入两列。
     #[serde(default)]
-    pub workspace_path: Option<String>,
+    pub workspace_id: Option<i64>,
     #[serde(default)]
     pub webhook_enabled: Option<bool>,
     #[serde(default)]
@@ -436,30 +447,34 @@ pub struct BatchUpdateTodoResult {
 
 /// 批量更新事项工作空间请求体（移动到其他工作空间）。
 #[derive(Debug, Clone, Deserialize)]
-pub struct BatchUpdateTodoWorkspacePathRequest {
+pub struct BatchUpdateTodoWorkspaceRequest {
     pub ids: Vec<i64>,
-    pub workspace_path: String,
+    /// 目标工作空间 ID（project_directories.id）。
+    pub workspace_id: i64,
 }
 
 /// 批量复制事项到其他工作空间请求体。
 #[derive(Debug, Clone, Deserialize)]
-pub struct BatchCopyTodoWorkspacePathRequest {
+pub struct BatchCopyTodoWorkspaceRequest {
     pub ids: Vec<i64>,
-    pub workspace_path: String,
+    /// 目标工作空间 ID（project_directories.id）。
+    pub workspace_id: i64,
 }
 
 /// 批量更新环路工作空间请求体（移动到其他工作空间）。
 #[derive(Debug, Clone, Deserialize)]
-pub struct BatchUpdateLoopWorkspacePathRequest {
+pub struct BatchUpdateLoopWorkspaceRequest {
     pub ids: Vec<i64>,
-    pub workspace_path: String,
+    /// 目标工作空间 ID（project_directories.id）。
+    pub workspace_id: i64,
 }
 
 /// 批量复制环路到其他工作空间请求体。
 #[derive(Debug, Clone, Deserialize)]
-pub struct BatchCopyLoopWorkspacePathRequest {
+pub struct BatchCopyLoopWorkspaceRequest {
     pub ids: Vec<i64>,
-    pub workspace_path: String,
+    /// 目标工作空间 ID（project_directories.id）。
+    pub workspace_id: i64,
 }
 
 /// 批量 workspace 操作返回结果（通用）。
@@ -1210,16 +1225,18 @@ mod tests {
 
     #[test]
     fn test_create_todo_request_deserialize() {
-        let json = r#"{"title":"Test","prompt":"Do this","tag_ids":[1,2]}"#;
+        let json = r#"{"title":"Test","prompt":"Do this","tag_ids":[1,2],"workspace_id":42}"#;
         let req: CreateTodoRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.title, "Test");
         assert_eq!(req.prompt, "Do this");
         assert_eq!(req.tag_ids, vec![1, 2]);
+        assert_eq!(req.workspace_id, 42);
     }
 
     #[test]
     fn test_create_todo_request_default_tag_ids() {
-        let json = r#"{"title":"Test","prompt":"Do this"}"#;
+        // workspace_id 必填：缺失则反序列化失败，这是 API 契约的一部分。
+        let json = r#"{"title":"Test","prompt":"Do this","workspace_id":1}"#;
         let req: CreateTodoRequest = serde_json::from_str(json).unwrap();
         assert!(req.tag_ids.is_empty());
     }

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -107,7 +107,7 @@ pub struct Todo {
     #[serde(default)]
     pub task_id: Option<String>,
     #[serde(default)]
-    pub workspace: Option<String>,
+    pub workspace_path: Option<String>,
     #[serde(default)]
     pub workspace_id: Option<i64>,
     #[serde(default)]
@@ -369,7 +369,7 @@ pub struct UpdateTodoRequest {
     #[serde(default)]
     pub scheduler_timezone: Option<String>,
     #[serde(default)]
-    pub workspace: Option<String>,
+    pub workspace_path: Option<String>,
     #[serde(default)]
     pub webhook_enabled: Option<bool>,
     #[serde(default)]
@@ -430,6 +430,41 @@ pub struct BatchUpdateTodoExecutorRequest {
 /// 批量更新事项执行器返回结果。
 #[derive(Debug, Clone, Serialize)]
 pub struct BatchUpdateTodoResult {
+    pub updated_count: i64,
+    pub total: i64,
+}
+
+/// 批量更新事项工作空间请求体（移动到其他工作空间）。
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchUpdateTodoWorkspacePathRequest {
+    pub ids: Vec<i64>,
+    pub workspace_path: String,
+}
+
+/// 批量复制事项到其他工作空间请求体。
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchCopyTodoWorkspacePathRequest {
+    pub ids: Vec<i64>,
+    pub workspace_path: String,
+}
+
+/// 批量更新环路工作空间请求体（移动到其他工作空间）。
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchUpdateLoopWorkspacePathRequest {
+    pub ids: Vec<i64>,
+    pub workspace_path: String,
+}
+
+/// 批量复制环路到其他工作空间请求体。
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchCopyLoopWorkspacePathRequest {
+    pub ids: Vec<i64>,
+    pub workspace_path: String,
+}
+
+/// 批量 workspace 操作返回结果（通用）。
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchWorkspaceResult {
     pub updated_count: i64,
     pub total: i64,
 }
@@ -966,7 +1001,7 @@ pub struct TodoBackup {
     pub scheduler_enabled: bool,
     pub scheduler_config: Option<String>,
     pub tag_names: Vec<String>,
-    pub workspace: Option<String>,
+    pub workspace_path: Option<String>,
     pub worktree: Option<String>,
 }
 

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -488,7 +488,7 @@ impl TodoScheduler {
                             feishu_bot_id: None,
                             step_id: None,
                             feishu_receive_id: None,
-                            workspace: None,
+                            workspace_path: None,
                             workspace_id: None,
                         })
                         .await;

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -1,7 +1,6 @@
 use dashmap::DashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use std::sync::RwLock;
 
 use crate::feishu::sdk::config::Config as FeishuSdkConfig;
 use crate::feishu::sdk::token_manager::TokenManager;
@@ -11,7 +10,6 @@ use crate::feishu::{
 };
 
 use crate::service_context::ServiceContext;
-use crate::config::Config as AppConfig;
 use crate::task_manager::TaskManager;
 use crate::db::{Database, NewFeishuMessage};
 use crate::models::{AgentBot, BotConfig, build_trigger_params};
@@ -30,7 +28,6 @@ pub struct FeishuListener {
 
 struct ListenerMessageContext<'a> {
     db: &'a Arc<Database>,
-    config: &'a Arc<RwLock<AppConfig>>,
     token_manager: &'a Arc<TokenManager>,
     credentials: &'a DashMap<i64, (String, String, String)>,
     debounce: &'a Arc<MessageDebounce>,
@@ -151,7 +148,6 @@ impl FeishuListener {
         let bot_open_id = real_bot_open_id;
         let bot_config_clone = bot_config;
         let credentials = self.bot_credentials.clone();
-        let config = self.ctx.config.clone();
         let token_manager = self.token_manager.clone();
         let debounce = self.debounce.clone();
         let task_manager = self.ctx.task_manager.clone();
@@ -160,7 +156,6 @@ impl FeishuListener {
             while let Some(msg) = rx.recv().await {
                 let context = ListenerMessageContext {
                     db: &db,
-                    config: &config,
                     token_manager: &token_manager,
                     credentials: &credentials,
                     debounce: &debounce,

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -1170,7 +1170,9 @@ impl FeishuListener {
                         path = dir.path,
                     );
 
-                    match db.create_todo_with_extras(&todo_title, &todo_prompt, None, None, false, Some(dir.id)).await {
+                    // workspace_id 必填；handler 层按 dir.id + dir.path 双字段下传，
+                    // DAO 一次写入 workspace_id + workspace_path 保持两列同步。
+                    match db.create_todo_with_extras(&todo_title, &todo_prompt, None, None, false, dir.id, &dir.path).await {
                         Ok(todo_id) => {
                             match db.create_feishu_project_binding(bot_id, channel, chat_type, dir.id, todo_id).await {
                                 Ok(binding_id) => {
@@ -1813,10 +1815,8 @@ struct SlashCommandMatch<'a> {
 #[cfg(test)]
 mod tests {
     use super::FeishuListener;
-    use crate::config::{Config as AppConfig, SlashCommandRule};
     use crate::models::{BotConfig, ExecutionRecord, ExecutionStatus};
     use crate::db::feishu_project_binding::FeishuProjectBinding;
-    use std::sync::{Arc, RwLock};
 
     #[test]
     fn test_parse_slash_command_exact_first_token() {

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -1952,7 +1952,7 @@ mod tests {
             scheduler_timezone: None,
             scheduler_next_run_at: None,
             task_id: None,
-            workspace: None,
+            workspace_path: None,
             workspace_id: None,
             webhook_enabled: false,
             acceptance_criteria: None,

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -447,7 +447,7 @@ impl LoopRunner {
 
             // 4f. 执行
             let record_id = match self
-                .start_step_todo_with_prompt(&todo, &trigger_type, idx as i64, step_exec.id, &enhanced_prompt, loop_.workspace.clone())
+                .start_step_todo_with_prompt(&todo, &trigger_type, idx as i64, step_exec.id, &enhanced_prompt, loop_.workspace_path.clone())
                 .await
             {
                 Ok(rid) => rid,
@@ -616,7 +616,7 @@ impl LoopRunner {
         loop_idx: i64,
         step_exec_id: i64,
         enhanced_prompt: &str,
-        workspace: Option<String>,
+        workspace_path: Option<String>,
     ) -> Result<i64, String> {
         let request = RunTodoExecutionRequest {
             db: self.ctx.db.clone(),
@@ -643,7 +643,7 @@ impl LoopRunner {
             step_id: None,
             feishu_bot_id: None,
             feishu_receive_id: None,
-            workspace,
+            workspace_path,
             workspace_id: None,
         };
         let result = run_todo_execution_with_params(request).await;
@@ -1009,7 +1009,7 @@ impl LoopRunner {
                 step_id: None,
                 feishu_bot_id: None,
                 feishu_receive_id: None,
-                workspace: None,
+                workspace_path: None,
                 workspace_id: None,
             };
             let exec_result = crate::executor_service::run_todo_execution(request).await;
@@ -1232,7 +1232,7 @@ impl LoopRunner {
             step_id: None,
             feishu_bot_id: None,
             feishu_receive_id: None,
-            workspace: handler_todo.workspace.clone(),
+            workspace_path: handler_todo.workspace_path.clone(),
             workspace_id: None,
         };
 

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -158,7 +158,7 @@ impl MessageDebounce {
                         step_id: None,
                         feishu_bot_id: if last.binding_id.is_some() { Some(last.bot_id) } else { None },
                         feishu_receive_id: if last.binding_id.is_some() { Some(last.sender.clone()) } else { None },
-                        workspace: None,
+                        workspace_path: None,
                         workspace_id: last.workspace_id,
                     })
                     .await;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -524,7 +524,7 @@ function AppContent() {
             dispatch({ type: 'SET_TODOS', payload: todos });
           });
         }}
-        defaultWorkspace={state.selectedWorkspace}
+        defaultWorkspaceId={state.selectedWorkspace}
       />
 
       <SmartCreateModal
@@ -558,7 +558,7 @@ function AppContent() {
           setLoopCreateModalOpen(false);
         }}
         onClose={() => setLoopCreateModalOpen(false)}
-        defaultWorkspace={state.selectedWorkspace}
+        defaultWorkspaceId={state.selectedWorkspace}
       />
     </Layout>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -524,6 +524,7 @@ function AppContent() {
             dispatch({ type: 'SET_TODOS', payload: todos });
           });
         }}
+        defaultWorkspace={state.selectedWorkspace}
       />
 
       <SmartCreateModal
@@ -557,6 +558,7 @@ function AppContent() {
           setLoopCreateModalOpen(false);
         }}
         onClose={() => setLoopCreateModalOpen(false)}
+        defaultWorkspace={state.selectedWorkspace}
       />
     </Layout>
   );

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -58,7 +58,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
     // 按项目目录过滤：用户选中某个项目后，只展示 workspace 匹配该目录路径的 todo；
     // selectedProject 为 null 时表示"全部"，不做过滤
     if (selectedProject) {
-      result = result.filter(t => t.workspace === selectedProject);
+      result = result.filter(t => t.workspace_path === selectedProject);
     }
     const cutoff = hours ? Date.now() - hours * 3600 * 1000 : 0;
     return result.filter(t => {
@@ -184,7 +184,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
   const renderCard = (todo: Todo) => {
     const column = getColumnForStatus(todo.status);
     const todoTags = tags.filter(t => todo.tag_ids?.includes(t.id));
-    const projectDir = projectDirectories.find(d => d.path === todo.workspace);
+    const projectDir = projectDirectories.find(d => d.path === todo.workspace_path);
     const projectName = projectDir?.name || null;
     const isDragging = draggingId === todo.id;
     const isSuccess = todo.status === 'completed';

--- a/frontend/src/components/LoopFormModal.tsx
+++ b/frontend/src/components/LoopFormModal.tsx
@@ -15,10 +15,10 @@ import { PlusOutlined } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
 import * as dbReviewTemplates from '@/utils/database/reviewTemplates';
 import * as dbTodos from '@/utils/database/todos';
-import { getProjectDirectories } from '@/utils/database/todos';
 import type { UpdateLoopRequest } from '@/types/loop';
 import type { ReviewTemplateOption } from '@/types/reviewTemplate';
 import type { Todo } from '@/types/todo';
+import { getWorkspaceDisplayName, getWorkspaceIdByPath, useProjectDirectories } from '@/utils/workspaceDisplay';
 import { TagCheckCardGroup } from './TagCheckCard';
 import { WorkspaceSelect } from './common/WorkspaceSelect';
 
@@ -34,7 +34,7 @@ interface LoopFormModalProps {
   initialData?: {
     name: string;
     description: string;
-    workspace: string | null;
+    workspace_path: string | null;
     webhook_enabled: boolean;
     icon: string;
     review_template_id: number | null;
@@ -48,6 +48,8 @@ interface LoopFormModalProps {
   /** 保存成功回调（创建模式回传新 loopId） */
   onSaved: (loopId?: number) => void;
   onClose: () => void;
+  /** 打开创建模式时自动选中的工作空间路径 */
+  defaultWorkspace?: string | null;
 }
 
 // ---------- Form values type ----------
@@ -62,7 +64,7 @@ type FormValues = UpdateLoopRequest & {
 // ---------- component ----------
 
 export function LoopFormModal({
-  open, mode, loopId, initialData, tags, onSaved, onClose,
+  open, mode, loopId, initialData, tags, onSaved, onClose, defaultWorkspace,
 }: LoopFormModalProps) {
   const { message } = AntApp.useApp();
   const [saving, setSaving] = useState(false);
@@ -78,23 +80,15 @@ export function LoopFormModal({
   const [newTemplateForm] = Form.useForm<{ name: string; description?: string; prompt: string }>();
   // 异常处理 Todo
   const [abnormalHandlerTodoOptions, setAbnormalHandlerTodoOptions] = useState<Todo[]>([]);
-  // 工作空间路径→ID 映射（用于评审模板 API，其过滤/新建需 workspace_id 而非路径字符串）
-  const [pathToWorkspaceId, setPathToWorkspaceId] = useState<Record<string, number>>({});
+  // 工作空间目录（低基数集合，path→id 与 path→name 共用此数据源）
+  const { dirs: projectDirs } = useProjectDirectories();
 
-  // 打开时加载工作空间目录列表（建立路径→ID 映射）
-  useEffect(() => {
-    if (!open) return;
-    getProjectDirectories().then((dirs) => {
-      const map: Record<string, number> = {};
-      for (const d of dirs) {
-        if (d.path) map[d.path] = d.id;
-      }
-      setPathToWorkspaceId(map);
-    }).catch(() => { /* 静默 */ });
-  }, [open]);
-
-  /** 根据当前 workspaceValue（路径）推导对应的 workspace_id，用于评审模板 API */
-  const workspaceIdForReview: number | undefined = workspaceValue ? pathToWorkspaceId[workspaceValue] : undefined;
+  /**
+   * 根据当前 workspaceValue（路径）推导对应的 workspace_id，用于评审模板 API。
+   * 注意：path 是 LoopFormModal 与后端之间的"工作空间标识符"，
+   * 评审模板 API 真正消费的是 project_directories.id。
+   */
+  const workspaceIdForReview: number | undefined = getWorkspaceIdByPath(projectDirs, workspaceValue);
 
   // 打开时 + workspace 变化时重新加载评审模板选项（按 workspace_id 过滤）
   useEffect(() => {
@@ -124,7 +118,7 @@ export function LoopFormModal({
         review_template_id: initialData.review_template_id ?? null,
         abnormal_handler_todo_id: initialData.abnormal_handler_todo_id ?? null,
       });
-      setWorkspaceValue(initialData.workspace ?? null);
+      setWorkspaceValue(initialData.workspace_path ?? null);
       // 解析 limits_config
       try {
         const lc = JSON.parse(initialData.limits_config || '{}');
@@ -146,9 +140,10 @@ export function LoopFormModal({
       form.resetFields();
       form.setFieldsValue({ webhook_enabled: false });
       setEditingTag(null);
-      setWorkspaceValue(null);
+      // 自动选中当前工作空间
+      setWorkspaceValue(defaultWorkspace ?? null);
     }
-  }, [open, mode, initialData, form]);
+  }, [open, mode, initialData, form, defaultWorkspace]);
 
   // 刷新评审模板（按当前 workspace_id 过滤）并选中新建的模板
   const reloadTemplatesAndSelect = useCallback(async (selectedId: number) => {
@@ -197,7 +192,7 @@ export function LoopFormModal({
       const basePayload = {
         name: values.name.trim(),
         description: values.description ?? '',
-        workspace: workspaceValue ?? null,
+        workspace_path: workspaceValue ?? null,
         webhook_enabled: values.webhook_enabled === true,
         icon: values.icon ?? 'loop',
         review_template_id: values.review_template_id ?? null,
@@ -217,7 +212,7 @@ export function LoopFormModal({
         const res = await dbLoops.createLoop({
           name: basePayload.name,
           description: basePayload.description,
-          workspace: workspaceValue.trim(),
+          workspace_path: workspaceValue.trim(),
           webhook_enabled: basePayload.webhook_enabled,
           tag_ids: basePayload.tag_ids,
           icon: basePayload.icon,
@@ -286,7 +281,7 @@ export function LoopFormModal({
                 value={workspaceValue}
                 onChange={(v) => {
                   setWorkspaceValue(v);
-                  form.setFieldsValue({ workspace: v, review_template_id: null });
+                  form.setFieldsValue({ workspace_path: v, review_template_id: null });
                 }}
                 required={mode === 'create'}
               />
@@ -420,7 +415,7 @@ export function LoopFormModal({
           </Form.Item>
           <div style={{ fontSize: 12, color: 'var(--color-text-tertiary, #94a3b8)', marginTop: -8 }}>
             {workspaceValue
-              ? `新建模板将归属于当前工作空间「${workspaceValue}」`
+              ? `新建模板将归属于当前工作空间「${getWorkspaceDisplayName(projectDirs, workspaceValue)}」`
               : '不选择工作空间则新建全局模板'}
           </div>
         </Form>

--- a/frontend/src/components/LoopFormModal.tsx
+++ b/frontend/src/components/LoopFormModal.tsx
@@ -99,12 +99,13 @@ export function LoopFormModal({
   }, [open, workspaceIdForReview]);
 
   // 打开时加载异常处理 Todo 选项
+  // 必须按当前 loop 的 workspace_id 过滤——异常处理 handler 跨工作空间串进来会触发错乱执行。
   useEffect(() => {
     if (!open) return;
-    dbTodos.getAllTodos()
+    dbTodos.getAllTodos(workspaceIdForReview)
       .then(setAbnormalHandlerTodoOptions)
       .catch(() => { /* 静默 */ });
-  }, [open]);
+  }, [open, workspaceIdForReview]);
 
   // 打开时（仅编辑模式）预填表单
   useEffect(() => {

--- a/frontend/src/components/LoopFormModal.tsx
+++ b/frontend/src/components/LoopFormModal.tsx
@@ -8,6 +8,10 @@
 // - 工作空间与评审模板联动：选择工作空间后过滤可选的评审模板
 //
 // 被 LoopStudioDetailPanel（编辑）和 App.tsx（新建）共用。
+//
+// 约定（破坏式更新）：
+// - 工作空间在组件之间一律以 id（project_directories.id，number）传递，path 仅后端 cwd 内部使用。
+// - 内部状态 `workspaceValue: number | null`；保存时把 id 直接送进 dbLoops.createLoop/updateLoop。
 
 import { useEffect, useState, useCallback } from 'react';
 import { App as AntApp, Drawer, Form, Input, InputNumber, Select, Button, Checkbox, Modal, Switch } from 'antd';
@@ -18,7 +22,7 @@ import * as dbTodos from '@/utils/database/todos';
 import type { UpdateLoopRequest } from '@/types/loop';
 import type { ReviewTemplateOption } from '@/types/reviewTemplate';
 import type { Todo } from '@/types/todo';
-import { getWorkspaceDisplayName, getWorkspaceIdByPath, useProjectDirectories } from '@/utils/workspaceDisplay';
+import { getWorkspaceDisplayName, useProjectDirectories } from '@/utils/workspaceDisplay';
 import { TagCheckCardGroup } from './TagCheckCard';
 import { WorkspaceSelect } from './common/WorkspaceSelect';
 
@@ -30,11 +34,17 @@ interface LoopFormModalProps {
   mode: 'create' | 'edit';
   /** 编辑模式必传，创建模式不传 */
   loopId?: number;
-  /** 编辑模式预填数据（创建模式不传） */
+  /**
+   * 编辑模式预填数据（创建模式不传）。
+   * `workspace_id` 是 project_directories.id 唯一键；
+   * path 仅作为展示兜底，不再作为 API 主键。
+   */
   initialData?: {
     name: string;
     description: string;
-    workspace_path: string | null;
+    workspace_id: number | null;
+    /** 仅用于展示 name/path 兜底（不再写入 API payload） */
+    workspace_path?: string | null;
     webhook_enabled: boolean;
     icon: string;
     review_template_id: number | null;
@@ -48,8 +58,8 @@ interface LoopFormModalProps {
   /** 保存成功回调（创建模式回传新 loopId） */
   onSaved: (loopId?: number) => void;
   onClose: () => void;
-  /** 打开创建模式时自动选中的工作空间路径 */
-  defaultWorkspace?: string | null;
+  /** 打开创建模式时自动选中的工作空间 ID */
+  defaultWorkspaceId?: number | null;
 }
 
 // ---------- Form values type ----------
@@ -64,15 +74,15 @@ type FormValues = UpdateLoopRequest & {
 // ---------- component ----------
 
 export function LoopFormModal({
-  open, mode, loopId, initialData, tags, onSaved, onClose, defaultWorkspace,
+  open, mode, loopId, initialData, tags, onSaved, onClose, defaultWorkspaceId,
 }: LoopFormModalProps) {
   const { message } = AntApp.useApp();
   const [saving, setSaving] = useState(false);
   const [form] = Form.useForm<FormValues>();
   // 标签选中态（单选）
   const [editingTag, setEditingTag] = useState<number | null>(null);
-  // 工作空间受控值（与 form.setFieldsValue 配合，避免直接操作 form 内部状态）
-  const [workspaceValue, setWorkspaceValue] = useState<string | null>(null);
+  // 工作空间受控值：以 id（project_directories.id）为唯一键传递
+  const [workspaceId, setWorkspaceId] = useState<number | null>(null);
   // 评审模板
   const [reviewTemplateOptions, setReviewTemplateOptions] = useState<ReviewTemplateOption[]>([]);
   const [creatingTemplate, setCreatingTemplate] = useState(false);
@@ -80,32 +90,25 @@ export function LoopFormModal({
   const [newTemplateForm] = Form.useForm<{ name: string; description?: string; prompt: string }>();
   // 异常处理 Todo
   const [abnormalHandlerTodoOptions, setAbnormalHandlerTodoOptions] = useState<Todo[]>([]);
-  // 工作空间目录（低基数集合，path→id 与 path→name 共用此数据源）
+  // 工作空间目录（id 是唯一键，byId Map 用来 O(1) 反查 path/name）
   const { dirs: projectDirs } = useProjectDirectories();
 
-  /**
-   * 根据当前 workspaceValue（路径）推导对应的 workspace_id，用于评审模板 API。
-   * 注意：path 是 LoopFormModal 与后端之间的"工作空间标识符"，
-   * 评审模板 API 真正消费的是 project_directories.id。
-   */
-  const workspaceIdForReview: number | undefined = getWorkspaceIdByPath(projectDirs, workspaceValue);
-
-  // 打开时 + workspace 变化时重新加载评审模板选项（按 workspace_id 过滤）
+  // 打开时 + 工作空间变化时重新加载评审模板选项（按 workspace_id 过滤）
   useEffect(() => {
     if (!open) return;
-    dbReviewTemplates.listReviewTemplateOptions(workspaceIdForReview)
+    dbReviewTemplates.listReviewTemplateOptions(workspaceId ?? undefined)
       .then(setReviewTemplateOptions)
       .catch(() => { /* 静默 */ });
-  }, [open, workspaceIdForReview]);
+  }, [open, workspaceId]);
 
   // 打开时加载异常处理 Todo 选项
   // 必须按当前 loop 的 workspace_id 过滤——异常处理 handler 跨工作空间串进来会触发错乱执行。
   useEffect(() => {
     if (!open) return;
-    dbTodos.getAllTodos(workspaceIdForReview)
+    dbTodos.getAllTodos(workspaceId ?? undefined)
       .then(setAbnormalHandlerTodoOptions)
       .catch(() => { /* 静默 */ });
-  }, [open, workspaceIdForReview]);
+  }, [open, workspaceId]);
 
   // 打开时（仅编辑模式）预填表单
   useEffect(() => {
@@ -119,7 +122,7 @@ export function LoopFormModal({
         review_template_id: initialData.review_template_id ?? null,
         abnormal_handler_todo_id: initialData.abnormal_handler_todo_id ?? null,
       });
-      setWorkspaceValue(initialData.workspace_path ?? null);
+      setWorkspaceId(initialData.workspace_id ?? null);
       // 解析 limits_config
       try {
         const lc = JSON.parse(initialData.limits_config || '{}');
@@ -142,16 +145,16 @@ export function LoopFormModal({
       form.setFieldsValue({ webhook_enabled: false });
       setEditingTag(null);
       // 自动选中当前工作空间
-      setWorkspaceValue(defaultWorkspace ?? null);
+      setWorkspaceId(defaultWorkspaceId ?? null);
     }
-  }, [open, mode, initialData, form, defaultWorkspace]);
+  }, [open, mode, initialData, form, defaultWorkspaceId]);
 
   // 刷新评审模板（按当前 workspace_id 过滤）并选中新建的模板
   const reloadTemplatesAndSelect = useCallback(async (selectedId: number) => {
-    const opts = await dbReviewTemplates.listReviewTemplateOptions(workspaceIdForReview);
+    const opts = await dbReviewTemplates.listReviewTemplateOptions(workspaceId ?? undefined);
     setReviewTemplateOptions(opts);
     form.setFieldsValue({ review_template_id: selectedId });
-  }, [form, workspaceIdForReview]);
+  }, [form, workspaceId]);
 
   // inline 创建评审模板（归属当前选中的工作空间）
   const handleCreateTemplate = useCallback(async () => {
@@ -162,7 +165,7 @@ export function LoopFormModal({
         name: values.name.trim(),
         description: values.description?.trim() || null,
         prompt: values.prompt,
-        workspace_id: workspaceIdForReview ?? null,
+        workspace_id: workspaceId ?? null,
       });
       message.success(`已创建模板「${created.name}」`);
       await reloadTemplatesAndSelect(created.id);
@@ -173,7 +176,7 @@ export function LoopFormModal({
     } finally {
       setCreatingTemplateSaving(false);
     }
-  }, [newTemplateForm, workspaceValue, message, reloadTemplatesAndSelect]);
+  }, [newTemplateForm, workspaceId, message, reloadTemplatesAndSelect]);
 
   // 保存（创建 / 编辑共用）
   const handleSave = useCallback(async () => {
@@ -190,10 +193,17 @@ export function LoopFormModal({
         ? JSON.stringify(values.abnormal_handler_trigger_on)
         : '["capped_step","capped_token","failed"]';
 
+      // 工作空间必填校验：保存时若未选择 id 直接报错
+      if (workspaceId == null) {
+        message.error('请选择工作空间');
+        setSaving(false);
+        return;
+      }
+
       const basePayload = {
         name: values.name.trim(),
         description: values.description ?? '',
-        workspace_path: workspaceValue ?? null,
+        workspace_id: workspaceId,
         webhook_enabled: values.webhook_enabled === true,
         icon: values.icon ?? 'loop',
         review_template_id: values.review_template_id ?? null,
@@ -204,16 +214,10 @@ export function LoopFormModal({
       };
 
       if (mode === 'create') {
-        // 创建模式：工作空间必填
-        if (!workspaceValue?.trim()) {
-          message.error('请选择工作空间');
-          setSaving(false);
-          return;
-        }
         const res = await dbLoops.createLoop({
           name: basePayload.name,
           description: basePayload.description,
-          workspace_path: workspaceValue.trim(),
+          workspace_id: basePayload.workspace_id,
           webhook_enabled: basePayload.webhook_enabled,
           tag_ids: basePayload.tag_ids,
           icon: basePayload.icon,
@@ -237,7 +241,7 @@ export function LoopFormModal({
     } finally {
       setSaving(false);
     }
-  }, [form, editingTag, workspaceValue, mode, loopId, message, onSaved, onClose]);
+  }, [form, editingTag, workspaceId, mode, loopId, message, onSaved, onClose]);
 
   return (
     <>
@@ -271,18 +275,18 @@ export function LoopFormModal({
             工作空间与评审模板
           </div>
           <div style={{ background: 'var(--color-bg-elevated, #f8fafc)', padding: 12, borderRadius: 8 }}>
-            {/* 工作空间：创建模式必填，编辑模式可选 */}
+            {/* 工作空间：创建模式必填，编辑模式可选；value/onChange 以 id 为唯一键 */}
             <Form.Item
-              label={<>工作空间 {mode === 'create' && <span style={{ color: '#ff4d4f' }}>*</span>}</>
-            }
+              label={<>工作空间 {mode === 'create' && <span style={{ color: '#ff4d4f' }}>*</span>}</>}
               tooltip="此 loop 所属的工作空间，切换后评审模板自动过滤"
               rules={mode === 'create' ? [{ required: true, message: '请选择工作空间' }] : []}
             >
               <WorkspaceSelect
-                value={workspaceValue}
+                value={workspaceId}
                 onChange={(v) => {
-                  setWorkspaceValue(v);
-                  form.setFieldsValue({ workspace_path: v, review_template_id: null });
+                  setWorkspaceId(v);
+                  // 切换工作空间时清掉已选模板，避免跨工作空间串模板
+                  form.setFieldsValue({ review_template_id: null });
                 }}
                 required={mode === 'create'}
               />
@@ -309,12 +313,8 @@ export function LoopFormModal({
                 placeholder="使用默认评审模板"
                 showSearch
                 optionFilterProp="label"
-                options={
-                  workspaceValue
-                    ? reviewTemplateOptions.map(t => ({ value: t.id, label: t.name }))
-                    : reviewTemplateOptions.map(t => ({ value: t.id, label: t.name }))
-                }
-                notFoundContent={workspaceValue ? '暂无模板，可点击"新建模板"' : '请先选择工作空间'}
+                options={reviewTemplateOptions.map(t => ({ value: t.id, label: t.name }))}
+                notFoundContent={workspaceId != null ? '暂无模板，可点击"新建模板"' : '请先选择工作空间'}
               />
             </Form.Item>
           </div>
@@ -415,8 +415,8 @@ export function LoopFormModal({
             <Input.TextArea rows={8} placeholder="你是一个评审师…" />
           </Form.Item>
           <div style={{ fontSize: 12, color: 'var(--color-text-tertiary, #94a3b8)', marginTop: -8 }}>
-            {workspaceValue
-              ? `新建模板将归属于当前工作空间「${getWorkspaceDisplayName(projectDirs, workspaceValue)}」`
+            {workspaceId != null
+              ? `新建模板将归属于当前工作空间「${getWorkspaceDisplayName(projectDirs, workspaceId)}」`
               : '不选择工作空间则新建全局模板'}
           </div>
         </Form>

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -67,8 +67,11 @@ export function LoopDetailPanel({
   const [maxStepExecutions, setMaxStepExecutions] = useState<number | null>(null);
   const [maxTotalTokens, setMaxTotalTokens] = useState<number | null>(null);
   // 编辑弹窗预填数据，从 detail 提取
+  // 工作空间以 id（project_directories.id）为主键，path 仅作为展示兜底。
   const [editInitialData, setEditInitialData] = useState<{
-    name: string; description: string; workspace_path: string | null;
+    name: string; description: string;
+    workspace_id: number | null;
+    workspace_path?: string | null;
     webhook_enabled: boolean;
     icon: string; review_template_id: number | null;
     tag_ids: number[]; limits_config: string | null;
@@ -113,7 +116,7 @@ export function LoopDetailPanel({
     setEditInitialData({
       name: detail.name,
       description: detail.description,
-      workspace_path: detail.workspace_path,
+      workspace_id: detail.workspace_id,
       webhook_enabled: detail.webhook_enabled,
       icon: detail.icon,
       review_template_id: detail.review_template_id ?? null,
@@ -215,9 +218,9 @@ export function LoopDetailPanel({
             </span>
           } />
           <DetailField label="关联工作空间" value={
-            detail.workspace_path ? (() => {
-              const displayName = getWorkspaceDisplayName(projectDirs, detail.workspace_path);
-              const dir = projectDirs.find(d => d.path === detail.workspace_path);
+            detail.workspace_id != null ? (() => {
+              const displayName = getWorkspaceDisplayName(projectDirs, detail.workspace_id);
+              const dir = projectDirs.find(d => d.id === detail.workspace_id);
               return dir ? (
                 <div>
                   <div style={{ fontWeight: 500 }}>{displayName}</div>
@@ -350,7 +353,7 @@ export function LoopDetailPanel({
           onChanged={() => { reload(); onChanged(); }}
           maxStepExecutions={maxStepExecutions}
           maxTotalTokens={maxTotalTokens}
-          workspacePath={detail.workspace_path}
+          workspaceId={detail.workspace_id}
         />
       </DetailSection>
 

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -24,10 +24,9 @@ import {
   CloseCircleOutlined,
 } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
-import * as db from '@/utils/database';
 import type { LoopDetail } from '@/types/loop';
-import type { ProjectDirectory } from '@/types';
 import { copyToClipboard } from '@/utils/clipboard';
+import { getWorkspaceDisplayName, useProjectDirectories } from '@/utils/workspaceDisplay';
 import { LoopFormModal } from './LoopFormModal';
 import { LoopTriggersPanel, TRIGGER_META } from './LoopStudioTriggersPanel';
 import { LoopStepsPanel } from './LoopStudioStepsPanel';
@@ -60,8 +59,8 @@ export function LoopDetailPanel({
   const [loading, setLoading] = useState(true);
   // 基础信息编辑 modal 开关 (替代之前的 inline 编辑)
   const [editing, setEditing] = useState(false);
-  // 完整的项目目录列表（用于展示详情）
-  const [projectDirs, setProjectDirs] = useState<ProjectDirectory[]>([]);
+  // 工作空间目录（低基数集合，详情展示时把 path 转成 name 用）
+  const { dirs: projectDirs } = useProjectDirectories();
   // 执行记录总数，由 LoopExecutionsPanel 通过回调更新
   const [executionTotal, setExecutionTotal] = useState(0);
   // 从 loop.limits_config 解析出的限制值，传递给子面板做兜底校验
@@ -69,7 +68,7 @@ export function LoopDetailPanel({
   const [maxTotalTokens, setMaxTotalTokens] = useState<number | null>(null);
   // 编辑弹窗预填数据，从 detail 提取
   const [editInitialData, setEditInitialData] = useState<{
-    name: string; description: string; workspace: string | null;
+    name: string; description: string; workspace_path: string | null;
     webhook_enabled: boolean;
     icon: string; review_template_id: number | null;
     tag_ids: number[]; limits_config: string | null;
@@ -101,13 +100,6 @@ export function LoopDetailPanel({
 
   useEffect(() => { reload(); }, [reload]);
 
-  // 加载项目目录列表（用于详情页展示工作空间名称）
-  useEffect(() => {
-    db.getProjectDirectories()
-      .then(dirs => setProjectDirs(dirs))
-      .catch(() => { /* 静默 */ });
-  }, []);
-
   // 预加载执行记录总数（用于折叠标签展示，不等用户展开后才显示）
   useEffect(() => {
     dbLoops.listExecutions(loopId, { page: 1, limit: 1 })
@@ -121,7 +113,7 @@ export function LoopDetailPanel({
     setEditInitialData({
       name: detail.name,
       description: detail.description,
-      workspace: detail.workspace,
+      workspace_path: detail.workspace_path,
       webhook_enabled: detail.webhook_enabled,
       icon: detail.icon,
       review_template_id: detail.review_template_id ?? null,
@@ -223,11 +215,12 @@ export function LoopDetailPanel({
             </span>
           } />
           <DetailField label="关联工作空间" value={
-            detail.workspace ? (() => {
-              const dir = projectDirs.find(d => d.path === detail.workspace);
+            detail.workspace_path ? (() => {
+              const displayName = getWorkspaceDisplayName(projectDirs, detail.workspace_path);
+              const dir = projectDirs.find(d => d.path === detail.workspace_path);
               return dir ? (
                 <div>
-                  <div style={{ fontWeight: 500 }}>{dir.name || dir.path}</div>
+                  <div style={{ fontWeight: 500 }}>{displayName}</div>
                   <div style={{ fontSize: 11, color: 'var(--color-text-tertiary, #94a3b8)', marginTop: 2 }}>
                     {dir.path}
                     {dir.git_worktree_enabled && (
@@ -239,7 +232,7 @@ export function LoopDetailPanel({
                   </div>
                 </div>
               ) : (
-                <span>{detail.workspace}</span>
+                <span>{displayName}</span>
               );
             })() : <EmptyValue />
           } />
@@ -357,6 +350,7 @@ export function LoopDetailPanel({
           onChanged={() => { reload(); onChanged(); }}
           maxStepExecutions={maxStepExecutions}
           maxTotalTokens={maxTotalTokens}
+          workspacePath={detail.workspace_path}
         />
       </DetailSection>
 

--- a/frontend/src/components/LoopStudioExecutionsPanel.tsx
+++ b/frontend/src/components/LoopStudioExecutionsPanel.tsx
@@ -18,6 +18,7 @@ import {
   ExclamationCircleOutlined,
 } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
+import * as dbExecutions from '@/utils/database/executions';
 import type { LoopExecutionDto, LoopExecutionDetail, LoopExecutionTokenSummary } from '@/types/loop';
 import { formatRelativeTime } from '@/utils/datetime';
 import { useExecutionEvents } from '@/hooks/useExecutionEvents';
@@ -466,7 +467,7 @@ export function StepExecList({ stepExecs, loopId, executionId, onApproved }: { s
     if (!s.execution_record_id) return;
     setDrawerLoading(true);
     try {
-      const { getExecutionRecord } = await import('@/utils/database/executions');
+      const { getExecutionRecord } = dbExecutions;
       const rec = await getExecutionRecord(s.execution_record_id);
       setDrawerRecord(rec);
     } catch {
@@ -480,7 +481,7 @@ export function StepExecList({ stepExecs, loopId, executionId, onApproved }: { s
   const handleApprove = useCallback(async (stepExecutionId: number) => {
     setApprovingId(stepExecutionId);
     try {
-      const { approveStepExecution } = await import('@/utils/database/loops');
+      const { approveStepExecution } = dbLoops;
       await approveStepExecution(loopId, executionId, stepExecutionId, approveRating, approveComment || undefined);
       message.success('审批已提交');
       // 重置审批表单状态为初始值，防止下一张待审卡片复用上次的评分与备注；

--- a/frontend/src/components/LoopStudioListPanel.tsx
+++ b/frontend/src/components/LoopStudioListPanel.tsx
@@ -183,8 +183,8 @@ function LoopCard({ loop, selected, onClick, checked, onToggleCheck, projectDirs
   tags?: Array<{ id: number; name: string; color: string }>;
 }) {
   const status: LoopStatus = (loop.status as LoopStatus) ?? 'paused';
-  // 通过 projectDirs 查找工作空间的可读名称，降级到路径
-  const workspaceName = getWorkspaceDisplayName(projectDirs, loop.workspace_path);
+  // 通过 projectDirs 查找工作空间的可读名称（id→name 优先、path 兜底）
+  const workspaceName = getWorkspaceDisplayName(projectDirs, loop.workspace_id);
   // 副标题优先用工作空间名称, 缺则降级到 description
   const subtitle = workspaceName || loop.description || '';
 

--- a/frontend/src/components/LoopStudioListPanel.tsx
+++ b/frontend/src/components/LoopStudioListPanel.tsx
@@ -25,6 +25,7 @@ import {
 import { formatRelativeTime } from '@/utils/datetime';
 import type { LoopListItem, LoopStatus } from '@/types/loop';
 import type { ProjectDirectory } from '@/types';
+import { getWorkspaceDisplayName } from '@/utils/workspaceDisplay';
 
 type StatusFilter = 'all' | LoopStatus;
 
@@ -183,9 +184,7 @@ function LoopCard({ loop, selected, onClick, checked, onToggleCheck, projectDirs
 }) {
   const status: LoopStatus = (loop.status as LoopStatus) ?? 'paused';
   // 通过 projectDirs 查找工作空间的可读名称，降级到路径
-  const workspaceName = loop.workspace
-    ? (projectDirs?.find(d => d.path === loop.workspace)?.name || loop.workspace)
-    : '';
+  const workspaceName = getWorkspaceDisplayName(projectDirs, loop.workspace_path);
   // 副标题优先用工作空间名称, 缺则降级到 description
   const subtitle = workspaceName || loop.description || '';
 

--- a/frontend/src/components/LoopStudioStepsPanel.tsx
+++ b/frontend/src/components/LoopStudioStepsPanel.tsx
@@ -1,6 +1,12 @@
 // Loop Studio 执行环节面板：DAG 流程图布局，支持控制流配置。
 //
 // 使用 dagre 自动布局，SVG 绘制有向边，支持条件分支可视化。
+//
+// 「关联环节」下拉按 loop 所属工作空间过滤候选 todo：
+// - 有 workspace 时调 db.getAllTodos(workspace_id)，只显示同工作空间下的事项
+// - 无 workspace 时不过滤（保留旧行为，不丢已有选项）
+// - 编辑环节时，已关联的 todo 若不在过滤结果里，额外补回，
+//   避免「选了别的工作空间的 todo 就再看不到」的边界陷阱
 
 import { useState, useCallback } from 'react';
 import {
@@ -9,6 +15,11 @@ import {
 import { DeleteOutlined, CloseOutlined } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
 import * as db from '@/utils/database';
+import {
+  getWorkspaceDisplayName,
+  getWorkspaceIdByPath,
+  useProjectDirectories,
+} from '@/utils/workspaceDisplay';
 import type { LoopStepDto, CreateLoopStepRequest } from '@/types/loop';
 import type { Todo } from '@/types';
 import { LoopFlowGraph } from '@/components/loop-flow/LoopFlowGraph';
@@ -21,10 +32,15 @@ interface StepsPanelProps {
   maxStepExecutions?: number | null;
   /** Loop 的最大 Token 数限制，来自 loop.limits_config.max_total_tokens */
   maxTotalTokens?: number | null;
+  /** Loop 所属工作空间路径（来自 loop.workspace_path 字段，对应 project_directories.path）。
+   *  用于过滤「关联环节」候选 todo，并把 path 转成 name 展示给用户。 */
+  workspacePath?: string | null;
 }
 
-export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, maxTotalTokens }: StepsPanelProps) {
+export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, maxTotalTokens, workspacePath }: StepsPanelProps) {
   const { message } = AntApp.useApp();
+  // 工作空间目录（低基数集合，一次性拉取，避免每次打开 modal 都重复请求）
+  const { dirs: projectDirs } = useProjectDirectories();
 
   // Modal 状态
   const [modalOpen, setModalOpen] = useState(false);
@@ -37,24 +53,14 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
   const handleOpenAdd = useCallback(async () => {
     setEditingStep(null);
     form.resetFields();
-    try {
-      const list = await db.getAllTodos();
-      setCandidates(list);
-    } catch {
-      setCandidates([]);
-    }
+    await loadCandidatesForCurrentLoop(null);
     setModalOpen(true);
-  }, [form]);
+  }, [form, workspacePath]);
 
   // 点击流程图节点打开编辑
   const handleSelectStep = useCallback(async (step: LoopStepDto) => {
     setEditingStep(step);
-    try {
-      const list = await db.getAllTodos();
-      setCandidates(list);
-    } catch {
-      setCandidates([]);
-    }
+    await loadCandidatesForCurrentLoop(step);
     form.setFieldsValue({
       name: step.name,
       todo_id: step.todo_id,
@@ -70,7 +76,45 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
       review_type: step.review_type ?? 'ai',
     });
     setModalOpen(true);
-  }, [form]);
+  }, [form, workspacePath]);
+
+  /**
+   * 按 loop 所属工作空间加载候选 todo 列表。
+   *
+   * 设计取舍：
+   * - workspacePath 非空 → 在已缓存的 projectDirs 中查到 workspace_id，
+   *   调 getAllTodos(workspaceId) 只拿同空间下的事项，避免误把别的工作空间的事项
+   *   串到当前 loop 的环节里。
+   * - workspacePath 为空 → 回退到不过滤（getAllTodos()），保持旧行为，不丢选项。
+   * - 编辑环节时，已关联的 todo 若不在过滤结果里，额外补回，保证用户至少能看到
+   *   当前环节指向的 todo 仍然可选（避免「换工作空间 → 旧 todo 从下拉消失 → 选不回去」
+   *   的死循环）。
+   *
+   * 失败一律静默回退为空数组，不阻塞打开 modal；空态由 Select 的 notFoundContent 兜底。
+   */
+  const loadCandidatesForCurrentLoop = useCallback(async (stepForEdit: LoopStepDto | null) => {
+    try {
+      const workspaceId = getWorkspaceIdByPath(projectDirs, workspacePath);
+      const list = await db.getAllTodos(workspaceId);
+      // 编辑模式下若已绑定的 todo 不在过滤结果里，附加一次单条查询补回选项，
+      // 确保用户依然能在下拉里看到/选中当前关联的 todo。
+      // 不附加 workspaceId 过滤，因为这条记录可能原本属于其他工作空间。
+      if (stepForEdit && !list.some(t => t.id === stepForEdit.todo_id)) {
+        try {
+          const current = await db.getTodo(stepForEdit.todo_id);
+          if (current) setCandidates([...list, current]);
+          else setCandidates(list);
+        } catch {
+          setCandidates(list);
+        }
+      } else {
+        setCandidates(list);
+      }
+    } catch {
+      // 拉取失败兜底为空数组；用户看到「暂无待关联的事项」即可，不阻塞流程
+      setCandidates([]);
+    }
+  }, [projectDirs, workspacePath]);
 
   // 保存
   const handleSave = useCallback(async () => {
@@ -208,7 +252,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
           <Form.Item label="关联环节" name="todo_id" rules={[{ required: true, message: '请选择关联的环节' }]}>
             <Select
               showSearch
-              placeholder="选择已有的环节"
+              placeholder={workspacePath ? `仅显示「${getWorkspaceDisplayName(projectDirs, workspacePath)}」工作空间下的事项` : '选择已有的环节'}
               optionFilterProp="label"
               onChange={handleTodoChange}
               options={candidates.map(c => ({
@@ -216,7 +260,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
                 value: c.id,
               }))}
               notFoundContent={
-                <Empty description="暂无待关联的事项" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+                <Empty description={workspacePath ? `「${getWorkspaceDisplayName(projectDirs, workspacePath)}」下暂无待关联的事项` : '暂无待关联的事项'} image={Empty.PRESENTED_IMAGE_SIMPLE} />
               }
             />
           </Form.Item>

--- a/frontend/src/components/LoopStudioStepsPanel.tsx
+++ b/frontend/src/components/LoopStudioStepsPanel.tsx
@@ -17,7 +17,6 @@ import * as dbLoops from '@/utils/database/loops';
 import * as db from '@/utils/database';
 import {
   getWorkspaceDisplayName,
-  getWorkspaceIdByPath,
   useProjectDirectories,
 } from '@/utils/workspaceDisplay';
 import type { LoopStepDto, CreateLoopStepRequest } from '@/types/loop';
@@ -32,12 +31,12 @@ interface StepsPanelProps {
   maxStepExecutions?: number | null;
   /** Loop 的最大 Token 数限制，来自 loop.limits_config.max_total_tokens */
   maxTotalTokens?: number | null;
-  /** Loop 所属工作空间路径（来自 loop.workspace_path 字段，对应 project_directories.path）。
-   *  用于过滤「关联环节」候选 todo，并把 path 转成 name 展示给用户。 */
-  workspacePath?: string | null;
+  /** Loop 所属工作空间 ID（project_directories.id，唯一键）。
+   *  用于过滤「关联环节」候选 todo，并把 id 转成 name 展示给用户。 */
+  workspaceId?: number | null;
 }
 
-export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, maxTotalTokens, workspacePath }: StepsPanelProps) {
+export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, maxTotalTokens, workspaceId }: StepsPanelProps) {
   const { message } = AntApp.useApp();
   // 工作空间目录（低基数集合，一次性拉取，避免每次打开 modal 都重复请求）
   const { dirs: projectDirs } = useProjectDirectories();
@@ -55,7 +54,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
     form.resetFields();
     await loadCandidatesForCurrentLoop(null);
     setModalOpen(true);
-  }, [form, workspacePath]);
+  }, [form, workspaceId]);
 
   // 点击流程图节点打开编辑
   const handleSelectStep = useCallback(async (step: LoopStepDto) => {
@@ -76,16 +75,15 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
       review_type: step.review_type ?? 'ai',
     });
     setModalOpen(true);
-  }, [form, workspacePath]);
+  }, [form, workspaceId]);
 
   /**
    * 按 loop 所属工作空间加载候选 todo 列表。
    *
    * 设计取舍：
-   * - workspacePath 非空 → 在已缓存的 projectDirs 中查到 workspace_id，
-   *   调 getAllTodos(workspaceId) 只拿同空间下的事项，避免误把别的工作空间的事项
-   *   串到当前 loop 的环节里。
-   * - workspacePath 为空 → 回退到不过滤（getAllTodos()），保持旧行为，不丢选项。
+   * - workspaceId 非空 → 调 getAllTodos(workspaceId) 只拿同空间下的事项，
+   *   避免误把别的工作空间的事项串到当前 loop 的环节里。
+   * - workspaceId 为空 → 回退到不过滤（getAllTodos()），保持旧行为，不丢选项。
    * - 编辑环节时，已关联的 todo 若不在过滤结果里，额外补回，保证用户至少能看到
    *   当前环节指向的 todo 仍然可选（避免「换工作空间 → 旧 todo 从下拉消失 → 选不回去」
    *   的死循环）。
@@ -94,8 +92,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
    */
   const loadCandidatesForCurrentLoop = useCallback(async (stepForEdit: LoopStepDto | null) => {
     try {
-      const workspaceId = getWorkspaceIdByPath(projectDirs, workspacePath);
-      const list = await db.getAllTodos(workspaceId);
+      const list = await db.getAllTodos(workspaceId ?? undefined);
       // 编辑模式下若已绑定的 todo 不在过滤结果里，附加一次单条查询补回选项，
       // 确保用户依然能在下拉里看到/选中当前关联的 todo。
       // 不附加 workspaceId 过滤，因为这条记录可能原本属于其他工作空间。
@@ -114,7 +111,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
       // 拉取失败兜底为空数组；用户看到「暂无待关联的事项」即可，不阻塞流程
       setCandidates([]);
     }
-  }, [projectDirs, workspacePath]);
+  }, [workspaceId]);
 
   // 保存
   const handleSave = useCallback(async () => {
@@ -252,7 +249,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
           <Form.Item label="关联环节" name="todo_id" rules={[{ required: true, message: '请选择关联的环节' }]}>
             <Select
               showSearch
-              placeholder={workspacePath ? `仅显示「${getWorkspaceDisplayName(projectDirs, workspacePath)}」工作空间下的事项` : '选择已有的环节'}
+              placeholder={workspaceId != null ? `仅显示「${getWorkspaceDisplayName(projectDirs, workspaceId)}」工作空间下的事项` : '选择已有的环节'}
               optionFilterProp="label"
               onChange={handleTodoChange}
               options={candidates.map(c => ({
@@ -260,7 +257,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
                 value: c.id,
               }))}
               notFoundContent={
-                <Empty description={workspacePath ? `「${getWorkspaceDisplayName(projectDirs, workspacePath)}」下暂无待关联的事项` : '暂无待关联的事项'} image={Empty.PRESENTED_IMAGE_SIMPLE} />
+                <Empty description={workspaceId != null ? `「${getWorkspaceDisplayName(projectDirs, workspaceId)}」下暂无待关联的事项` : '暂无待关联的事项'} image={Empty.PRESENTED_IMAGE_SIMPLE} />
               }
             />
           </Form.Item>

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -193,8 +193,8 @@ export function MemorialBoard() {
     // 因为 items 是轻量快照（不含 workspace 字段），需要回查 state.todos 取 workspace
     if (selectedProject) {
       result = result.filter(i => {
-        const todo = state.todos.find(t => t.id === i.todo_id); // 回查全量 todo 取 workspace
-        return todo?.workspace === selectedProject; // 匹配选中项目的路径
+        const todo = state.todos.find(t => t.id === i.todo_id); // 回查全量 todo 取 workspace_path
+        return todo?.workspace_path === selectedProject; // 匹配选中项目的路径
       });
     }
     // 按搜索文本过滤：匹配标题或 prompt
@@ -273,7 +273,7 @@ export function MemorialBoard() {
     const resolvedTags = item.tag_ids.map(tid => state.tags.find(t => t.id === tid)).filter(Boolean) as Tag[];
     // 获取项目名称
     const todo = state.todos.find(t => t.id === item.todo_id);
-    const projectDir = projectDirectories.find(d => d.path === todo?.workspace);
+    const projectDir = projectDirectories.find(d => d.path === todo?.workspace_path);
     const projectName = projectDir?.name || null;
 
     // Run history: determine which run to display
@@ -413,7 +413,7 @@ export function MemorialBoard() {
             style={{ width: 150 }}
             suffixIcon={<FolderOutlined />}
             options={projectDirectories.map(d => ({
-              value: d.path, // value 存路径，与 todo.workspace 对比
+              value: d.path, // value 存路径，与 todo.workspace_path 对比
               label: d.name || d.path, // 优先展示项目名，无名则回退显示路径
             }))}
           />

--- a/frontend/src/components/RunningBoard.tsx
+++ b/frontend/src/components/RunningBoard.tsx
@@ -237,7 +237,7 @@ export function RunningBoard({ searchText, hours, selectedProject }: RunningBoar
 
     // Project filter
     if (selectedProject) {
-      result = result.filter(r => todoById.get(r.todo_id)?.workspace === selectedProject);
+      result = result.filter(r => todoById.get(r.todo_id)?.workspace_path === selectedProject);
     }
 
     // Time filter: only for completed/failed records
@@ -272,7 +272,7 @@ export function RunningBoard({ searchText, hours, selectedProject }: RunningBoar
     let result = scheduledTodos;
 
     if (selectedProject) {
-      result = result.filter(t => t.workspace === selectedProject);
+      result = result.filter(t => t.workspace_path === selectedProject);
     }
 
     if (searchText?.trim()) {

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -25,9 +25,11 @@ interface TodoDrawerProps {
   tags: Array<{ id: number; name: string; color: string }>;
   onClose: () => void;
   onSaved: (todo?: Todo) => void;
+  /** 打开创建模式时自动选中的工作空间路径 */
+  defaultWorkspace?: string | null;
 }
 
-export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerProps) {
+export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspace }: TodoDrawerProps) {
   const { message } = App.useApp();
   const isEditMode = todo !== null;
 
@@ -46,7 +48,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
 
   // 从 formState 中解构出常用的字段
   const {
-    title, prompt, selectedTags, executor, workspace,
+    title, prompt, selectedTags, executor, workspacePath,
     webhookEnabled, schedulerEnabled, schedulerConfig, acceptanceCriteria,
   } = formState;
 
@@ -133,6 +135,13 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
     }
   }, [open, todo]);
 
+  // 创建模式下自动选中当前工作空间（打开时 todo=null 触发）
+  useEffect(() => {
+    if (open && !todo && defaultWorkspace) {
+      setField('workspacePath', defaultWorkspace);
+    }
+  }, [open, todo, defaultWorkspace, setField]);
+
   const handleSkillClick = useCallback((skill: SkillMeta) => {
     insertTextAtCursor(`/${skill.name}`);
   }, [insertTextAtCursor]);
@@ -173,14 +182,14 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
     }
 
     // 创建模式：工作空间为必填项
-    if (!isEditMode && !workspace.trim()) {
+    if (!isEditMode && !workspacePath.trim()) {
       message.error('请选择工作空间');
       return;
     }
 
     setLoading(true);
     try {
-      const trimmedWorkspace = workspace.trim() || null;
+      const trimmedWorkspace = workspacePath.trim() || null;
 
       if (isEditMode && todo) {
         // WorkspaceSelect 只允许从下拉列表选择有效路径，无需二次校验
@@ -303,8 +312,8 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved }: TodoDrawerPro
               工作空间 <span style={{ color: '#ff4d4f' }}>*</span>
             </div>
             <WorkspaceSelect
-              value={workspace}
-              onChange={(v) => setField('workspace', v ?? '')}
+              value={workspacePath}
+              onChange={(v) => setField('workspacePath', v ?? '')}
               required
             />
           </div>

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -25,11 +25,11 @@ interface TodoDrawerProps {
   tags: Array<{ id: number; name: string; color: string }>;
   onClose: () => void;
   onSaved: (todo?: Todo) => void;
-  /** 打开创建模式时自动选中的工作空间路径 */
-  defaultWorkspace?: string | null;
+  /** 打开创建模式时自动选中的工作空间 ID（project_directories.id） */
+  defaultWorkspaceId?: number | null;
 }
 
-export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspace }: TodoDrawerProps) {
+export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspaceId }: TodoDrawerProps) {
   const { message } = App.useApp();
   const isEditMode = todo !== null;
 
@@ -48,7 +48,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
 
   // 从 formState 中解构出常用的字段
   const {
-    title, prompt, selectedTags, executor, workspacePath,
+    title, prompt, selectedTags, executor, workspaceId,
     webhookEnabled, schedulerEnabled, schedulerConfig, acceptanceCriteria,
   } = formState;
 
@@ -136,11 +136,12 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
   }, [open, todo]);
 
   // 创建模式下自动选中当前工作空间（打开时 todo=null 触发）
+  // 工作空间以 id（number）传递，不再用 path 字符串。
   useEffect(() => {
-    if (open && !todo && defaultWorkspace) {
-      setField('workspacePath', defaultWorkspace);
+    if (open && !todo && defaultWorkspaceId != null) {
+      setField('workspaceId', defaultWorkspaceId);
     }
-  }, [open, todo, defaultWorkspace, setField]);
+  }, [open, todo, defaultWorkspaceId, setField]);
 
   const handleSkillClick = useCallback((skill: SkillMeta) => {
     insertTextAtCursor(`/${skill.name}`);
@@ -182,21 +183,22 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
     }
 
     // 创建模式：工作空间为必填项
-    if (!isEditMode && !workspacePath.trim()) {
+    if (!isEditMode && workspaceId == null) {
       message.error('请选择工作空间');
       return;
     }
 
     setLoading(true);
     try {
-      const trimmedWorkspace = workspacePath.trim() || null;
+      // 直接把 id 传给后端 updateTodo；handler 负责按 id 反查 cwd path。
+      const workspaceToSave = workspaceId;
 
       if (isEditMode && todo) {
-        // WorkspaceSelect 只允许从下拉列表选择有效路径，无需二次校验
+        // WorkspaceSelect 只允许从下拉列表选择，无需二次校验
         await db.updateTodo(
           todo.id, title.trim(), prompt.trim(), todo.status,
           executor, schedulerEnabled, schedulerConfig || null,
-          trimmedWorkspace,
+          workspaceToSave,
           webhookEnabled,
           acceptanceCriteria || null,
         );
@@ -213,10 +215,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
           webhookEnabled,
         );
 
-        // WorkspaceSelect 只允许从下拉列表选择，无需二次校验
-        const workspaceToSave = trimmedWorkspace;
-
-        if (workspaceToSave || schedulerEnabled || executor !== DEFAULT_EXECUTOR || webhookEnabled) {
+        if (workspaceToSave != null || schedulerEnabled || executor !== DEFAULT_EXECUTOR || webhookEnabled) {
           await db.updateTodo(
             newTodo.id, newTodo.title, newTodo.prompt, newTodo.status,
             executor, schedulerEnabled, schedulerConfig || null,
@@ -312,8 +311,8 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
               工作空间 <span style={{ color: '#ff4d4f' }}>*</span>
             </div>
             <WorkspaceSelect
-              value={workspacePath}
-              onChange={(v) => setField('workspacePath', v ?? '')}
+              value={workspaceId}
+              onChange={(v) => setField('workspaceId', v)}
               required
             />
           </div>

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -75,7 +75,8 @@ export function TodoList(props: TodoListProps) {
   // 批量工作空间操作 Modal（事项/环路共用）
   const [workspaceBatchModalOpen, setWorkspaceBatchModalOpen] = useState(false);
   const [workspaceBatchMode, setWorkspaceBatchMode] = useState<'copy' | 'move'>('copy');
-  const [workspaceBatchTarget, setWorkspaceBatchTarget] = useState<string | null>(null);
+  // target 改为工作空间 id（project_directories.id 唯一键），不再用 path。
+  const [workspaceBatchTarget, setWorkspaceBatchTarget] = useState<number | null>(null);
   const [pendingWorkspaceBatchIds, setPendingWorkspaceBatchIds] = useState<number[]>([]);
   const [workspaceBatchProcessing, setWorkspaceBatchProcessing] = useState(false);
   const [workspaceBatchContext, setWorkspaceBatchContext] = useState<'item' | 'loop'>('item');
@@ -115,27 +116,24 @@ export function TodoList(props: TodoListProps) {
     return () => window.removeEventListener('projectDirectoryAdded', handleDirAdded); // 清理：卸载时移除监听
   }, [reloadProjectDirectories]);
 
-  // 当目录列表加载完成后，若当前未选中任何工作空间且存在目录，自动选中第一个
+  // 当目录列表加载完成后，若当前未选中任何工作空间且存在目录，自动选中第一个。
+  // 自动选中用 id 而非 path —— selectedWorkspace 现已统一为 project_directories.id。
   useEffect(() => {
     if (projectDirectories.length > 0 && selectedWorkspace === null) {
-      dispatch({ type: 'SELECT_WORKSPACE', payload: projectDirectories[0].path });
+      dispatch({ type: 'SELECT_WORKSPACE', payload: projectDirectories[0].id });
     }
   }, [projectDirectories, selectedWorkspace, dispatch]);
 
   // 当列表切换到「环路」时，自动加载 loop 列表；或环路变更时刷新
   // 必须等待项目目录加载完成且工作空间已确定，否则请求不携带 workspace 参数返回错误数据。
-  // 筛选必须用 id：selectedWorkspace 是路径字符串，这里从 projectDirectories 反查 workspace_id
-  // 再传给 listLoops（path 不唯一，id 唯一）。
+  // selectedWorkspace 现在就是 id（唯一键），直接传给 listLoops 即可，不需要再做 path→id 推导。
   useEffect(() => {
     if (listMode !== 'loop') return;
     if (!directoriesReady) return;
     // 已有目录但尚未选定工作空间 → 等待 auto-select 后再加载
     if (projectDirectories.length > 0 && selectedWorkspace === null) return;
-    const workspaceId = selectedWorkspace
-      ? projectDirectories.find(d => d.path === selectedWorkspace)?.id ?? null
-      : null;
     setLoopLoading(true);
-    dbLoops.listLoops(workspaceId)
+    dbLoops.listLoops(selectedWorkspace)
       .then(setLoopList)
       .catch(() => setLoopList([]))
       .finally(() => setLoopLoading(false));
@@ -177,9 +175,9 @@ export function TodoList(props: TodoListProps) {
       : todos;
     
     // 按 workspace 过滤：selectedWorkspace 为 null 时显示全部，
-    // 否则只显示匹配 workspace 路径的 todo
+    // 否则只显示匹配 workspace id 的 todo
     if (selectedWorkspace !== null) {
-      result = result.filter(todo => todo.workspace_path === selectedWorkspace);
+      result = result.filter(todo => todo.workspace_id === selectedWorkspace);
     }
     
     // 再按关键字搜索（匹配标题或提示词）
@@ -266,7 +264,8 @@ export function TodoList(props: TodoListProps) {
   const handleConfirmWorkspaceBatch = useCallback(async () => {
     const ids = pendingWorkspaceBatchIds;
     const target = workspaceBatchTarget;
-    if (ids.length === 0 || !target?.trim()) return;
+    // target 是工作空间 id；null/undefined 都视为未选
+    if (ids.length === 0 || target == null) return;
     setWorkspaceBatchProcessing(true);
     try {
       const mode = workspaceBatchMode;
@@ -275,21 +274,25 @@ export function TodoList(props: TodoListProps) {
 
       if (context === 'item') {
         if (mode === 'copy') {
-          result = await db.batchCopyTodosWorkspace(ids, target.trim());
+          result = await db.batchCopyTodosWorkspace(ids, target);
         } else {
-          result = await db.batchMoveTodosWorkspace(ids, target.trim());
+          result = await db.batchMoveTodosWorkspace(ids, target);
         }
       } else {
         if (mode === 'copy') {
-          result = await dbLoops.batchCopyLoopsWorkspace(ids, target.trim());
+          result = await dbLoops.batchCopyLoopsWorkspace(ids, target);
         } else {
-          result = await dbLoops.batchMoveLoopsWorkspace(ids, target.trim());
+          result = await dbLoops.batchMoveLoopsWorkspace(ids, target);
         }
       }
 
       const actionLabel = mode === 'copy' ? '复制' : '移动';
+      // 提示用工作空间展示名（name 优先、path 兜底），不再直接拼接 id。
+      const targetName = projectDirectories.find(d => d.id === target)?.name
+        ?? projectDirectories.find(d => d.id === target)?.path
+        ?? String(target);
       if (result.updated_count === result.total) {
-        message.success(`已${actionLabel} ${result.updated_count} 项到「${target.trim()}」`);
+        message.success(`已${actionLabel} ${result.updated_count} 项到「${targetName}」`);
       } else {
         message.warning(`${actionLabel}成功 ${result.updated_count} 条，失败 ${result.total - result.updated_count} 条`);
       }
@@ -301,11 +304,8 @@ export function TodoList(props: TodoListProps) {
           dispatch({ type: 'UPDATE_TODO', payload: todo });
         }
       } else {
-        // 环路模式：刷新 loop 列表。筛选必须用 id：路径反查 workspace_id。
-        const workspaceId = selectedWorkspace
-          ? projectDirectories.find(d => d.path === selectedWorkspace)?.id ?? null
-          : null;
-        const loops = await dbLoops.listLoops(workspaceId);
+        // 环路模式：刷新 loop 列表。selectedWorkspace 现已统一为 id，直接传即可。
+        const loops = await dbLoops.listLoops(selectedWorkspace);
         setLoopList(loops);
       }
 
@@ -316,7 +316,7 @@ export function TodoList(props: TodoListProps) {
     } finally {
       setWorkspaceBatchProcessing(false);
     }
-  }, [pendingWorkspaceBatchIds, workspaceBatchTarget, workspaceBatchMode, workspaceBatchContext, message, dispatch, selectedWorkspace]);
+  }, [pendingWorkspaceBatchIds, workspaceBatchTarget, workspaceBatchMode, workspaceBatchContext, message, dispatch, selectedWorkspace, projectDirectories]);
 
   // 确认更换执行器（事项模式）
   const handleConfirmChangeExecutor = useCallback(async (executor: string) => {
@@ -678,7 +678,7 @@ export function TodoList(props: TodoListProps) {
         okText={workspaceBatchMode === 'copy' ? '确认复制' : '确认移动'}
         cancelText="取消"
         confirmLoading={workspaceBatchProcessing}
-        okButtonProps={{ disabled: !workspaceBatchTarget?.trim() }}
+        okButtonProps={{ disabled: workspaceBatchTarget == null }}
         destroyOnClose
       >
         <p>

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useApp } from '@/hooks/useApp';
 import { Empty, Input, Skeleton, Checkbox, Modal, App as AntApp } from 'antd';
-import { ClockCircleOutlined, InboxOutlined, SearchOutlined, SwapOutlined, StopOutlined } from '@ant-design/icons';
+import { ClockCircleOutlined, InboxOutlined, SearchOutlined, SwapOutlined, StopOutlined, CopyOutlined, DragOutlined } from '@ant-design/icons';
 import { StatusPicker } from './StatusPicker';
 import * as db from '@/utils/database';
 import type { ProjectDirectory, Todo } from '@/types';
@@ -13,6 +13,7 @@ import { EXECUTORS_FOR_PICKER } from '@/types/execution';
 import { ExecutorPicker } from './todo-drawer/ExecutorPicker';
 import { ActionToolbar, type BatchActionItem } from './common/ActionToolbar';
 import { formatRelativeTime } from '@/utils/datetime';
+import { WorkspaceSelect } from './common/WorkspaceSelect';
 
 interface TodoListProps {
   onOpenCreateModal: () => void;
@@ -71,6 +72,13 @@ export function TodoList(props: TodoListProps) {
   // 强停确认 Modal（环路）
   const [forceStopModalOpen, setForceStopModalOpen] = useState(false);
   const [pendingForceStopIds, setPendingForceStopIds] = useState<number[]>([]);
+  // 批量工作空间操作 Modal（事项/环路共用）
+  const [workspaceBatchModalOpen, setWorkspaceBatchModalOpen] = useState(false);
+  const [workspaceBatchMode, setWorkspaceBatchMode] = useState<'copy' | 'move'>('copy');
+  const [workspaceBatchTarget, setWorkspaceBatchTarget] = useState<string | null>(null);
+  const [pendingWorkspaceBatchIds, setPendingWorkspaceBatchIds] = useState<number[]>([]);
+  const [workspaceBatchProcessing, setWorkspaceBatchProcessing] = useState(false);
+  const [workspaceBatchContext, setWorkspaceBatchContext] = useState<'item' | 'loop'>('item');
 
   useEffect(() => {
     setIsLoading(false);
@@ -116,13 +124,18 @@ export function TodoList(props: TodoListProps) {
 
   // 当列表切换到「环路」时，自动加载 loop 列表；或环路变更时刷新
   // 必须等待项目目录加载完成且工作空间已确定，否则请求不携带 workspace 参数返回错误数据。
+  // 筛选必须用 id：selectedWorkspace 是路径字符串，这里从 projectDirectories 反查 workspace_id
+  // 再传给 listLoops（path 不唯一，id 唯一）。
   useEffect(() => {
     if (listMode !== 'loop') return;
     if (!directoriesReady) return;
     // 已有目录但尚未选定工作空间 → 等待 auto-select 后再加载
     if (projectDirectories.length > 0 && selectedWorkspace === null) return;
+    const workspaceId = selectedWorkspace
+      ? projectDirectories.find(d => d.path === selectedWorkspace)?.id ?? null
+      : null;
     setLoopLoading(true);
-    dbLoops.listLoops(selectedWorkspace)
+    dbLoops.listLoops(workspaceId)
       .then(setLoopList)
       .catch(() => setLoopList([]))
       .finally(() => setLoopLoading(false));
@@ -166,7 +179,7 @@ export function TodoList(props: TodoListProps) {
     // 按 workspace 过滤：selectedWorkspace 为 null 时显示全部，
     // 否则只显示匹配 workspace 路径的 todo
     if (selectedWorkspace !== null) {
-      result = result.filter(todo => todo.workspace === selectedWorkspace);
+      result = result.filter(todo => todo.workspace_path === selectedWorkspace);
     }
     
     // 再按关键字搜索（匹配标题或提示词）
@@ -216,6 +229,94 @@ export function TodoList(props: TodoListProps) {
     setPendingForceStopIds(ids);
     setForceStopModalOpen(true);
   }, []);
+
+  // —— 批量操作：工作空间复制/移动（事项模式） ——
+  const openItemCopyWorkspace = useCallback((ids: number[]) => {
+    setWorkspaceBatchContext('item');
+    setWorkspaceBatchMode('copy');
+    setPendingWorkspaceBatchIds(ids);
+    setWorkspaceBatchTarget(null);
+    setWorkspaceBatchModalOpen(true);
+  }, []);
+  const openItemMoveWorkspace = useCallback((ids: number[]) => {
+    setWorkspaceBatchContext('item');
+    setWorkspaceBatchMode('move');
+    setPendingWorkspaceBatchIds(ids);
+    setWorkspaceBatchTarget(null);
+    setWorkspaceBatchModalOpen(true);
+  }, []);
+
+  // —— 批量操作：工作空间复制/移动（环路模式） ——
+  const openLoopCopyWorkspace = useCallback((ids: number[]) => {
+    setWorkspaceBatchContext('loop');
+    setWorkspaceBatchMode('copy');
+    setPendingWorkspaceBatchIds(ids);
+    setWorkspaceBatchTarget(null);
+    setWorkspaceBatchModalOpen(true);
+  }, []);
+  const openLoopMoveWorkspace = useCallback((ids: number[]) => {
+    setWorkspaceBatchContext('loop');
+    setWorkspaceBatchMode('move');
+    setPendingWorkspaceBatchIds(ids);
+    setWorkspaceBatchTarget(null);
+    setWorkspaceBatchModalOpen(true);
+  }, []);
+
+  // 确认工作空间批量操作
+  const handleConfirmWorkspaceBatch = useCallback(async () => {
+    const ids = pendingWorkspaceBatchIds;
+    const target = workspaceBatchTarget;
+    if (ids.length === 0 || !target?.trim()) return;
+    setWorkspaceBatchProcessing(true);
+    try {
+      const mode = workspaceBatchMode;
+      const context = workspaceBatchContext;
+      let result: { updated_count: number; total: number };
+
+      if (context === 'item') {
+        if (mode === 'copy') {
+          result = await db.batchCopyTodosWorkspace(ids, target.trim());
+        } else {
+          result = await db.batchMoveTodosWorkspace(ids, target.trim());
+        }
+      } else {
+        if (mode === 'copy') {
+          result = await dbLoops.batchCopyLoopsWorkspace(ids, target.trim());
+        } else {
+          result = await dbLoops.batchMoveLoopsWorkspace(ids, target.trim());
+        }
+      }
+
+      const actionLabel = mode === 'copy' ? '复制' : '移动';
+      if (result.updated_count === result.total) {
+        message.success(`已${actionLabel} ${result.updated_count} 项到「${target.trim()}」`);
+      } else {
+        message.warning(`${actionLabel}成功 ${result.updated_count} 条，失败 ${result.total - result.updated_count} 条`);
+      }
+
+      // 刷新数据
+      if (context === 'item') {
+        const allItems = await db.getAllTodos();
+        for (const todo of allItems) {
+          dispatch({ type: 'UPDATE_TODO', payload: todo });
+        }
+      } else {
+        // 环路模式：刷新 loop 列表。筛选必须用 id：路径反查 workspace_id。
+        const workspaceId = selectedWorkspace
+          ? projectDirectories.find(d => d.path === selectedWorkspace)?.id ?? null
+          : null;
+        const loops = await dbLoops.listLoops(workspaceId);
+        setLoopList(loops);
+      }
+
+      setWorkspaceBatchModalOpen(false);
+      setSelectedIds([]);
+    } catch (err) {
+      message.error(`操作失败: ${err instanceof Error ? err.message : '未知错误'}`);
+    } finally {
+      setWorkspaceBatchProcessing(false);
+    }
+  }, [pendingWorkspaceBatchIds, workspaceBatchTarget, workspaceBatchMode, workspaceBatchContext, message, dispatch, selectedWorkspace]);
 
   // 确认更换执行器（事项模式）
   const handleConfirmChangeExecutor = useCallback(async (executor: string) => {
@@ -278,12 +379,32 @@ export function TodoList(props: TodoListProps) {
           label: '更换执行器',
           icon: <SwapOutlined />,
           onClick: openItemChangeExecutor,
+        }, {
+          key: 'copy-workspace',
+          label: '复制到',
+          icon: <CopyOutlined />,
+          onClick: openItemCopyWorkspace,
+        }, {
+          key: 'move-workspace',
+          label: '移动到',
+          icon: <DragOutlined />,
+          onClick: openItemMoveWorkspace,
         }],
       };
     }
     return {
       createLabel: '新建',
       batchActions: [{
+        key: 'copy-workspace',
+        label: '复制到',
+        icon: <CopyOutlined />,
+        onClick: openLoopCopyWorkspace,
+      }, {
+        key: 'move-workspace',
+        label: '移动到',
+        icon: <DragOutlined />,
+        onClick: openLoopMoveWorkspace,
+      }, {
         key: 'force-stop',
         label: '强停',
         icon: <StopOutlined />,
@@ -291,7 +412,7 @@ export function TodoList(props: TodoListProps) {
         onClick: openLoopForceStop,
       }],
     };
-  }, [listMode, openItemChangeExecutor, openLoopForceStop]);
+  }, [listMode, openItemChangeExecutor, openItemCopyWorkspace, openItemMoveWorkspace, openLoopCopyWorkspace, openLoopMoveWorkspace, openLoopForceStop]);
 
   const tagMap = useMemo(() => {
     const map = new Map<number, typeof tags[0]>();
@@ -546,6 +667,35 @@ export function TodoList(props: TodoListProps) {
         <p style={{ color: 'var(--color-text-tertiary)', fontSize: 12 }}>
           （强停功能开发中，详见 utils/database/loops.ts 的 forceStopLoops 注释。）
         </p>
+      </Modal>
+
+      {/* 批量工作空间操作 Modal（复制到/移动到） */}
+      <Modal
+        title={workspaceBatchMode === 'copy' ? '复制到工作空间' : '移动到工作空间'}
+        open={workspaceBatchModalOpen}
+        onOk={handleConfirmWorkspaceBatch}
+        onCancel={() => { setWorkspaceBatchModalOpen(false); setPendingWorkspaceBatchIds([]); }}
+        okText={workspaceBatchMode === 'copy' ? '确认复制' : '确认移动'}
+        cancelText="取消"
+        confirmLoading={workspaceBatchProcessing}
+        okButtonProps={{ disabled: !workspaceBatchTarget?.trim() }}
+        destroyOnClose
+      >
+        <p>
+          {workspaceBatchMode === 'copy' ? '复制' : '移动'} <strong>{pendingWorkspaceBatchIds.length}</strong> 项到目标工作空间：
+        </p>
+        <div style={{ marginTop: 12 }}>
+          <WorkspaceSelect
+            value={workspaceBatchTarget}
+            onChange={(v) => setWorkspaceBatchTarget(v ?? null)}
+            required
+          />
+        </div>
+        {workspaceBatchMode === 'copy' && (
+          <p style={{ color: 'var(--color-text-tertiary)', fontSize: 12, marginTop: 8 }}>
+            复制后，原工作空间和目标工作空间中各有一份相同的条目。
+          </p>
+        )}
       </Modal>
     </div>
   );

--- a/frontend/src/components/TodoPostPage.tsx
+++ b/frontend/src/components/TodoPostPage.tsx
@@ -5,6 +5,7 @@ import {
   App,
   Tag,
   Drawer,
+  Tooltip,
 } from "antd";
 import {
   ArrowLeftOutlined,
@@ -39,7 +40,7 @@ import {
   Space,
   message as antdMessage,
 } from "antd";
-import { StarOutlined, StarFilled, FileTextOutlined, CaretDownOutlined, CaretUpOutlined, CopyOutlined } from "@ant-design/icons";
+import { StarOutlined, StarFilled, FileTextOutlined, CaretDownOutlined, CaretUpOutlined, CopyOutlined, BranchesOutlined } from "@ant-design/icons";
 
 /**
  * 全屏帖子详情页 —— 按 session_id 加载同 session 的所有记录。
@@ -501,6 +502,9 @@ function PostCard({
         </div>
       )}
 
+      {/* worktree 路径：仅当 record.worktree_path 非空时渲染，与 RecordDetailView 同款展示 */}
+      <WorktreePathDisplay worktreePath={record.worktree_path ?? null} />
+
       {/* 统计 */}
       <div style={{
         display: "flex", gap: 16, marginTop: 8, fontSize: 11,
@@ -812,5 +816,50 @@ function RatingControl({
     >
       <Button type="text" size="small" icon={<StarOutlined />}>评分</Button>
     </Popover>
+  );
+}
+
+/**
+ * 与 RecordDetailView 中的 WorktreePathDisplay 保持一致：
+ * - 未启用 worktree 时（`worktree_path` 为 null 或空串）整段不渲染。
+ * - 路径过长时只展示尾部，tooltip 显示完整路径。
+ * - 点击整行复制完整路径，HTTP 环境自动 fallback 到 execCommand。
+ *
+ * 与 desktop 详情页的展示语义完全一致，便于用户在任何入口都能定位 worktree 目录。
+ */
+function WorktreePathDisplay({ worktreePath }: { worktreePath: string | null }) {
+  if (!worktreePath) return null;
+
+  // 路径过长时只展示尾部，鼠标悬停 tooltip 显示完整路径
+  const displayPath = worktreePath.length > 60
+    ? `…${worktreePath.slice(-59)}`
+    : worktreePath;
+
+  return (
+    <Tooltip title={worktreePath}>
+      <div
+        onClick={async () => {
+          // 复用统一复制工具：HTTPS 走 navigator.clipboard，HTTP 环境 fallback 到 execCommand
+          const ok = await copyToClipboard(worktreePath);
+          antdMessage[ok ? 'success' : 'error'](ok ? '已复制 worktree 路径' : '复制失败');
+        }}
+        style={{
+          fontSize: 11,
+          color: 'var(--color-text-quaternary)',
+          marginBottom: 12,
+          fontFamily: 'var(--font-mono)',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+        }}
+      >
+        <BranchesOutlined style={{ fontSize: 11, color: 'var(--color-primary)' }} />
+        <span>Worktree: {displayPath}</span>
+      </div>
+    </Tooltip>
   );
 }

--- a/frontend/src/components/common/WorkspaceSelect.tsx
+++ b/frontend/src/components/common/WorkspaceSelect.tsx
@@ -9,6 +9,12 @@
 // 2. 旁边的「+」按钮打开新建 Modal
 // 3. 填写名称 + 路径后「保存并使用」，自动选中新建项并通知父组件
 // 4. 新建失败时保留表单内容，允许用户修正后重试
+//
+// 约定（破坏式更新）：
+// - value / onChange 全部以 project_directories.id（number）为唯一键传递；
+//   path 仅用于下拉项的展示文本（name 优先、path 兜底）。
+// - 新增目录成功后通过 `projectDirectoryAdded` 事件广播 `{ id }`，
+//   监听方按 id 选中而非 path。
 
 import { useState, useEffect, useCallback } from 'react';
 import { Select, Form, Input, Button, Modal, Space, App } from 'antd';
@@ -16,10 +22,10 @@ import { PlusOutlined } from '@ant-design/icons';
 import { getProjectDirectories, createProjectDirectory } from '@/utils/database/todos';
 
 interface WorkspaceSelectProps {
-  /** 当前选中的工作空间路径 */
-  value?: string | null;
-  /** 变更回调 */
-  onChange?: (workspace: string | null) => void;
+  /** 当前选中的工作空间 ID（project_directories.id），唯一键 */
+  value?: number | null;
+  /** 变更回调，回传工作空间 ID（null 表示清空） */
+  onChange?: (workspaceId: number | null) => void;
   /** 是否必填（影响 Select 的 allowClear） */
   required?: boolean;
   /** antd Select 原生 props 透传 */
@@ -33,20 +39,21 @@ interface QuickAddFormValues {
 
 export function WorkspaceSelect({ value, onChange, required, selectProps }: WorkspaceSelectProps) {
   const { message } = App.useApp();
-  const [options, setOptions] = useState<{ label: string; value: string }[]>([]);
+  // options.value 存 id（number），label 用「name（path）」格式展示给用户
+  const [options, setOptions] = useState<{ label: string; value: number }[]>([]);
   const [loading, setLoading] = useState(true);
   const [quickAddOpen, setQuickAddOpen] = useState(false);
   const [quickAddSaving, setQuickAddSaving] = useState(false);
   const [quickAddForm] = Form.useForm<QuickAddFormValues>();
 
-  // 加载目录列表
+  // 加载目录列表：value 是 id，label 是用户可见的展示文本
   const loadDirs = useCallback(async () => {
     setLoading(true);
     try {
       const dirs = await getProjectDirectories();
       setOptions(dirs.map(d => ({
         label: d.name ? `${d.name}（${d.path}）` : d.path,
-        value: d.path,
+        value: d.id,
       })));
     } catch {
       message.error('加载工作空间列表失败');
@@ -57,13 +64,14 @@ export function WorkspaceSelect({ value, onChange, required, selectProps }: Work
 
   useEffect(() => { loadDirs(); }, [loadDirs]);
 
-  // 监听外部 directory 新增事件，刷新列表并自动选中新目录
+  // 监听外部 directory 新增事件：按 detail.id 选中，而不是 path。
+  // 事件 payload 形如 { id: number }；跨组件刷新来源见 ProjectDirectoriesPanel / WorkspaceSwitcher。
   useEffect(() => {
     const handleDirAdded = (event: Event) => {
-      const customEvent = event as CustomEvent<{ path: string }>;
+      const customEvent = event as CustomEvent<{ id: number }>;
       loadDirs().then(() => {
-        if (customEvent.detail?.path) {
-          onChange?.(customEvent.detail.path);
+        if (customEvent.detail?.id != null) {
+          onChange?.(customEvent.detail.id);
         }
       });
     };
@@ -72,24 +80,25 @@ export function WorkspaceSelect({ value, onChange, required, selectProps }: Work
   }, [loadDirs, onChange]);
 
   // 快捷新建：保存并使用
+  // 后端 createProjectDirectory 现在返回 { id, path, name } 完整结构，按 id 通知父组件。
   const handleQuickAdd = useCallback(async () => {
     const values = await quickAddForm.validateFields();
     setQuickAddSaving(true);
     try {
-      // createProjectDirectory(path, name) — 路径在前，名称在后
-      await createProjectDirectory(values.path.trim(), values.name.trim());
+      // createProjectDirectory(path, name) — 路径在前，名称在后；返回值含新建目录的 id
+      const created = await createProjectDirectory(values.path.trim(), values.name.trim());
       message.success('工作空间已创建');
       quickAddForm.resetFields();
       setQuickAddOpen(false);
-      // 刷新列表后选中新建项
+      // 刷新列表后选中新建项（按 id 选中）
       const dirs = await getProjectDirectories();
       setOptions(dirs.map(d => ({
         label: d.name ? `${d.name}（${d.path}）` : d.path,
-        value: d.path,
+        value: d.id,
       })));
-      onChange?.(values.path.trim());
-      // 广播新增事件，供 TodoList 等组件刷新分组数据
-      window.dispatchEvent(new CustomEvent('projectDirectoryAdded', { detail: { path: values.path.trim() } }));
+      onChange?.(created.id);
+      // 广播新增事件：payload 仅携带 id（破坏式），监听方按 id 刷新并选中。
+      window.dispatchEvent(new CustomEvent('projectDirectoryAdded', { detail: { id: created.id } }));
     } catch (e) {
       message.error(`创建失败：${(e as Error).message}`);
     } finally {
@@ -101,7 +110,7 @@ export function WorkspaceSelect({ value, onChange, required, selectProps }: Work
     <>
       <Space.Compact style={{ width: '100%' }}>
         <Select
-          value={value}
+          value={value ?? undefined}
           onChange={onChange}
           options={options}
           loading={loading}

--- a/frontend/src/components/loop-flow/LoopFlowGraph.tsx
+++ b/frontend/src/components/loop-flow/LoopFlowGraph.tsx
@@ -300,7 +300,7 @@ export function LoopFlowGraph({
                   fontSize={11}
                   fill="#64748b"
                 >
-                  {truncateText(node.step.todo_title || `#${node.step.todo_id}`, 22)}
+                  {truncateText(node.step.todo_title ? `#${node.step.todo_id} ${node.step.todo_title}` : `#${node.step.todo_id}`, 24)}
                 </text>
                 <text
                   x={node.x + 12} y={node.y + 56}

--- a/frontend/src/components/mobile/LoopMobilePage.tsx
+++ b/frontend/src/components/mobile/LoopMobilePage.tsx
@@ -190,7 +190,7 @@ export function LoopMobilePage({
         initialData={loopDetail ? {
           name: loopDetail.name,
           description: loopDetail.description,
-          workspace: loopDetail.workspace,
+          workspace_path: loopDetail.workspace_path,
           webhook_enabled: loopDetail.webhook_enabled,
           icon: loopDetail.icon,
           review_template_id: loopDetail.review_template_id ?? null,

--- a/frontend/src/components/mobile/LoopMobilePage.tsx
+++ b/frontend/src/components/mobile/LoopMobilePage.tsx
@@ -190,7 +190,7 @@ export function LoopMobilePage({
         initialData={loopDetail ? {
           name: loopDetail.name,
           description: loopDetail.description,
-          workspace_path: loopDetail.workspace_path,
+          workspace_id: loopDetail.workspace_id,
           webhook_enabled: loopDetail.webhook_enabled,
           icon: loopDetail.icon,
           review_template_id: loopDetail.review_template_id ?? null,

--- a/frontend/src/components/settings/BackupPanel.tsx
+++ b/frontend/src/components/settings/BackupPanel.tsx
@@ -354,7 +354,7 @@ export function BackupPanel() {
           scheduler_enabled: todo.scheduler_enabled,
           scheduler_config: todo.scheduler_config,
           tag_names: todo.tag_names || [],
-          workspace: todo.workspace,
+          workspace_path: todo.workspace_path,
           action: exists ? 'overwrite' as const : 'new' as const,
           existingTitle: existing?.title,
         };

--- a/frontend/src/components/settings/backup/ImportExportModals.tsx
+++ b/frontend/src/components/settings/backup/ImportExportModals.tsx
@@ -12,7 +12,7 @@ export interface BackupDataYaml {
     scheduler_enabled: boolean;
     scheduler_config?: string;
     tag_names: string[];
-    workspace?: string;
+    workspace_path?: string;
   }[];
 }
 
@@ -25,7 +25,7 @@ export interface ImportItem {
   scheduler_enabled: boolean;
   scheduler_config?: string;
   tag_names: string[];
-  workspace?: string;
+  workspace_path?: string;
   action: 'new' | 'overwrite';
   existingTitle?: string;
 }

--- a/frontend/src/components/settings/messages/ProjectBindsTab.tsx
+++ b/frontend/src/components/settings/messages/ProjectBindsTab.tsx
@@ -209,9 +209,9 @@ export function ProjectBindsTab() {
     const selectedDir = directories.find(d => d.id === selectedDirId);
     const dirPath = selectedDir?.path;
     return todos.filter(t => {
-      if (!t.workspace) return false;
-      // 若已选目录，仅显示 workspace 与目录路径一致的 Todo
-      return dirPath ? t.workspace === dirPath : true;
+      if (!t.workspace_path) return false;
+      // 若已选目录，仅显示 workspace_path 与目录路径一致的 Todo
+      return dirPath ? t.workspace_path === dirPath : true;
     });
   }, [todos, directories, selectedDirId]);
 
@@ -378,7 +378,7 @@ export function ProjectBindsTab() {
               value={selectedTodoId}
               onChange={setSelectedTodoId}
               options={projectTodos.map(t => ({
-                label: `#${t.id} ${t.title} ${t.workspace ? `· ${t.workspace}` : ''}`,
+                label: `#${t.id} ${t.title} ${t.workspace_path ? `· ${t.workspace_path}` : ''}`,
                 value: t.id,
               }))}
             />

--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -48,8 +48,9 @@ interface LeftRailProps {
   variant?: LeftRailVariant;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
-  workspace?: string | null;
-  onWorkspaceChange?: (workspace: string) => void;
+  /** 当前选中的工作空间 ID（project_directories.id，唯一键）。null 表示未选。 */
+  workspace?: number | null;
+  onWorkspaceChange?: (workspaceId: number) => void;
   themeMode: 'light' | 'dark';
   toggleTheme: () => void;
 }

--- a/frontend/src/components/shell/WorkspaceSwitcher.tsx
+++ b/frontend/src/components/shell/WorkspaceSwitcher.tsx
@@ -8,8 +8,10 @@ import type { ProjectDirectory } from '@/types';
 export type WorkspaceSwitcherMode = 'full' | 'compact';
 
 interface WorkspaceSwitcherProps {
-  value: string | null;
-  onChange: (workspace: string) => void;
+  /** 当前选中的工作空间 ID（project_directories.id），唯一键 */
+  value: number | null;
+  /** 选中工作空间后回传 id */
+  onChange: (workspaceId: number) => void;
   onManage: () => void;
   mode?: WorkspaceSwitcherMode;
 }
@@ -51,15 +53,15 @@ export function WorkspaceSwitcher({ value, onChange, onManage, mode = 'full' }: 
   }, [loadDirs]);
 
   const selectedLabel = useMemo(() => {
-    if (!value) return '请选择工作空间';
-    const found = dirs.find(d => d.path === value);
-    return found?.name || value;
+    if (value == null) return '请选择工作空间';
+    const found = dirs.find(d => d.id === value);
+    return found?.name || found?.path || String(value);
   }, [dirs, value]);
 
   const menuItems = useMemo<NonNullable<MenuProps['items']>>(() => {
     const items: NonNullable<MenuProps['items']> = [
       ...dirs.map(dir => ({
-        key: dir.path,
+        key: String(dir.id),
         label: dir.name || dir.path,
         icon: <FolderOpenOutlined />,
       })),
@@ -78,7 +80,9 @@ export function WorkspaceSwitcher({ value, onChange, onManage, mode = 'full' }: 
       onManage();
       return;
     }
-    onChange(String(key));
+    // menu key 是 dir.id 字符串化；解析回 number 抛出给上层
+    const id = Number(key);
+    if (Number.isFinite(id)) onChange(id);
   }, [onChange, onManage]);
 
   if (mode === 'compact') {

--- a/frontend/src/components/todo-detail/DetailHeader.tsx
+++ b/frontend/src/components/todo-detail/DetailHeader.tsx
@@ -130,7 +130,7 @@ export function DetailHeader({
           )}
         </div>
         {selectedTodo.prompt && <PromptDisplay content={selectedTodo.prompt} />}
-        {(selectedTodo.acceptance_criteria || selectedTodo.workspace) && (
+        {(selectedTodo.acceptance_criteria || selectedTodo.workspace_path) && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginTop: 2, marginBottom: 8, fontSize: 12, color: 'var(--color-text-secondary)' }}>
             {selectedTodo.acceptance_criteria && (
               <div>
@@ -138,10 +138,10 @@ export function DetailHeader({
                 <span>{selectedTodo.acceptance_criteria}</span>
               </div>
             )}
-            {selectedTodo.workspace && (
+            {selectedTodo.workspace_path && (
               <div>
                 <span style={{ fontWeight: 600 }}>工作区目录：</span>
-                <span>{selectedTodo.workspace}</span>
+                <span>{selectedTodo.workspace_path}</span>
               </div>
             )}
           </div>

--- a/frontend/src/components/todo-drawer/reducer.ts
+++ b/frontend/src/components/todo-drawer/reducer.ts
@@ -22,8 +22,8 @@ export interface TodoFormState {
   selectedTags: number[];
   /** 执行器名称 */
   executor: string;
-  /** 工作目录路径 */
-  workspacePath: string;
+  /** 工作空间 ID（project_directories.id）。组件间统一以 id 传递，path 仅后端 cwd 内部使用。 */
+  workspaceId: number | null;
   /** 是否启用 Webhook 触发 */
   webhookEnabled: boolean;
   /** 是否启用调度器 */
@@ -48,7 +48,7 @@ export const initialFormState: TodoFormState = {
   prompt: '',
   selectedTags: [],
   executor: DEFAULT_EXECUTOR,
-  workspacePath: '',
+  workspaceId: null,
   webhookEnabled: false,
   schedulerEnabled: false,
   schedulerConfig: '',
@@ -76,7 +76,7 @@ export function todoFormReducer(state: TodoFormState, action: TodoFormAction): T
           prompt: action.todo.prompt || '',
           selectedTags: action.todo.tag_ids || [],
           executor: action.todo.executor || DEFAULT_EXECUTOR,
-          workspacePath: action.todo.workspace_path || '',
+          workspaceId: action.todo.workspace_id ?? null,
           webhookEnabled: action.todo.webhook_enabled || false,
           schedulerEnabled: action.todo.scheduler_enabled || false,
           schedulerConfig: action.todo.scheduler_config || '',

--- a/frontend/src/components/todo-drawer/reducer.ts
+++ b/frontend/src/components/todo-drawer/reducer.ts
@@ -23,7 +23,7 @@ export interface TodoFormState {
   /** 执行器名称 */
   executor: string;
   /** 工作目录路径 */
-  workspace: string;
+  workspacePath: string;
   /** 是否启用 Webhook 触发 */
   webhookEnabled: boolean;
   /** 是否启用调度器 */
@@ -48,7 +48,7 @@ export const initialFormState: TodoFormState = {
   prompt: '',
   selectedTags: [],
   executor: DEFAULT_EXECUTOR,
-  workspace: '',
+  workspacePath: '',
   webhookEnabled: false,
   schedulerEnabled: false,
   schedulerConfig: '',
@@ -76,7 +76,7 @@ export function todoFormReducer(state: TodoFormState, action: TodoFormAction): T
           prompt: action.todo.prompt || '',
           selectedTags: action.todo.tag_ids || [],
           executor: action.todo.executor || DEFAULT_EXECUTOR,
-          workspace: action.todo.workspace || '',
+          workspacePath: action.todo.workspace_path || '',
           webhookEnabled: action.todo.webhook_enabled || false,
           schedulerEnabled: action.todo.scheduler_enabled || false,
           schedulerConfig: action.todo.scheduler_config || '',

--- a/frontend/src/hooks/useTodoContext.tsx
+++ b/frontend/src/hooks/useTodoContext.tsx
@@ -23,8 +23,11 @@ interface TodoState {
   selectedTodoId: number | null;
   /** null = no tag selected (show all); number = filtered view */
   selectedTagId: number | null;
-  /** null = show all workspaces; string = filter by workspace path */
-  selectedWorkspace: string | null;
+  /**
+   * null = show all workspaces; number = filter by workspace id (唯一键).
+   * 组件间一律传 id，path 仅后端内部 cwd 用。
+   */
+  selectedWorkspace: number | null;
 }
 
 // ─── Actions ─────────────────────────────────────────────────
@@ -44,16 +47,19 @@ type TodoAction =
   | { type: 'DELETE_TODO'; payload: number }        // remove by id
   | { type: 'SELECT_TODO'; payload: number | null } // open detail / close detail
   | { type: 'SELECT_TAG'; payload: number | null }   // filter by tag / clear filter
-  | { type: 'SELECT_WORKSPACE'; payload: string | null } // filter by workspace / clear filter
+  | { type: 'SELECT_WORKSPACE'; payload: number | null } // filter by workspace id / clear filter
   | { type: 'ADD_TAG'; payload: Tag }               // create tag
   | { type: 'DELETE_TAG'; payload: number }         // remove tag by id
   | { type: 'UPDATE_TODO_STATUS'; payload: { id: number; status: Todo['status'] } }; // quick status toggle
 
-// 从 localStorage 读取上次选中的 workspace，刷新后保持选择
-function getInitialWorkspace(): string | null {
+// 从 localStorage 读取上次选中的 workspace id，刷新后保持选择。
+// 字符串 → 数字：旧数据可能残留 path 字符串，统一按 Number 解析；失败时回退到 null。
+function getInitialWorkspace(): number | null {
   try {
     const saved = localStorage.getItem('selected_workspace');
-    return saved || null;
+    if (!saved) return null;
+    const n = Number(saved);
+    return Number.isFinite(n) && n > 0 ? n : null;
   } catch {
     return null;
   }
@@ -88,10 +94,10 @@ function reducer(state: TodoState, action: TodoAction): TodoState {
     case 'SELECT_TODO': return { ...state, selectedTodoId: action.payload };
     case 'SELECT_TAG': return { ...state, selectedTagId: action.payload };
     case 'SELECT_WORKSPACE': {
-      // 持久化到 localStorage，刷新后保持选择
+      // 持久化到 localStorage，刷新后保持选择（id 持久化为字符串）。
       try {
-        if (action.payload) {
-          localStorage.setItem('selected_workspace', action.payload);
+        if (action.payload != null) {
+          localStorage.setItem('selected_workspace', String(action.payload));
         } else {
           localStorage.removeItem('selected_workspace');
         }

--- a/frontend/src/types/execution.tsx
+++ b/frontend/src/types/execution.tsx
@@ -236,7 +236,7 @@ export interface ScheduledTodo {
   scheduler_timezone: string | null;
   scheduler_next_run_at: string | null;
   tag_ids: number[];
-  workspace: string | null;
+  workspace_path: string | null;
   updated_at: string;
 }
 

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -33,7 +33,7 @@ export interface LoopDto {
   id: number;
   name: string;
   description: string;
-  workspace: string | null;
+  workspace_path: string | null;
   webhook_enabled: boolean;
   status: string;
   /** 标签 ID 列表（单选，复用 Todo 的标签体系） */
@@ -204,7 +204,7 @@ export interface LoopDetail {
   id: number;
   name: string;
   description: string;
-  workspace: string | null;
+  workspace_path: string | null;
   webhook_enabled: boolean;
   status: string;
   /** 标签 ID 列表（单选，复用 Todo 的标签体系） */
@@ -229,7 +229,7 @@ export interface LoopListItem {
   id: number;
   name: string;
   description: string;
-  workspace: string | null;
+  workspace_path: string | null;
   webhook_enabled: boolean;
   status: string;
   /** 标签 ID 列表（单选，复用 Todo 的标签体系） */
@@ -283,8 +283,8 @@ export interface LoopExecutionListResponse {
 export interface CreateLoopRequest {
   name: string;
   description?: string;
-  /** 工作空间（项目目录路径），必填。 */
-  workspace: string;
+  /** 工作空间目录路径（对应 project_directories.path），必填。 */
+  workspace_path: string;
   webhook_enabled?: boolean;
   tag_ids?: number[];
   /** 创建时可选预绑定单个标签；省略时后端按空标签处理，兼容旧调用方。 */
@@ -301,7 +301,7 @@ export interface CreateLoopRequest {
 export interface UpdateLoopRequest {
   name: string;
   description: string;
-  workspace: string | null;
+  workspace_path: string | null;
   webhook_enabled: boolean;
   icon: string;
   review_template_id?: number | null;

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -33,7 +33,11 @@ export interface LoopDto {
   id: number;
   name: string;
   description: string;
-  workspace_path: string | null;
+  /**
+   * 工作空间 ID（project_directories.id），唯一键。
+   * 组件间统一传 id，path 不再上送 API；前端展示用 project_directories.name/path 自行查询。
+   */
+  workspace_id: number | null;
   webhook_enabled: boolean;
   status: string;
   /** 标签 ID 列表（单选，复用 Todo 的标签体系） */
@@ -204,7 +208,8 @@ export interface LoopDetail {
   id: number;
   name: string;
   description: string;
-  workspace_path: string | null;
+  /** 工作空间 ID（project_directories.id，唯一键）。组件间统一以 id 传递，path 不再上送。 */
+  workspace_id: number | null;
   webhook_enabled: boolean;
   status: string;
   /** 标签 ID 列表（单选，复用 Todo 的标签体系） */
@@ -229,7 +234,8 @@ export interface LoopListItem {
   id: number;
   name: string;
   description: string;
-  workspace_path: string | null;
+  /** 工作空间 ID（project_directories.id，唯一键）。组件间统一以 id 传递，path 不再上送。 */
+  workspace_id: number | null;
   webhook_enabled: boolean;
   status: string;
   /** 标签 ID 列表（单选，复用 Todo 的标签体系） */
@@ -283,11 +289,14 @@ export interface LoopExecutionListResponse {
 export interface CreateLoopRequest {
   name: string;
   description?: string;
-  /** 工作空间目录路径（对应 project_directories.path），必填。 */
-  workspace_path: string;
+  /**
+   * 工作空间 ID（project_directories.id），必填、唯一键。
+   * 不再接受路径——避免 path 不唯一带来的歧义。
+   */
+  workspace_id: number;
   webhook_enabled?: boolean;
   tag_ids?: number[];
-  /** 创建时可选预绑定单个标签；省略时后端按空标签处理，兼容旧调用方。 */
+  /** 创建时可选预绑定单个标签；省略时后端按空标签处理。 */
   icon?: string;
   review_template_id?: number | null;
   /** 限制条件 JSON 字符串 */
@@ -301,7 +310,12 @@ export interface CreateLoopRequest {
 export interface UpdateLoopRequest {
   name: string;
   description: string;
-  workspace_path: string | null;
+  /**
+   * 工作空间 ID（project_directories.id）。
+   * undefined = 保持原工作空间；显式赋值（包含 null）= 迁移/清空。
+   * 不接受路径——handler 一律按 id 解析 cwd 路径写入两列。
+   */
+  workspace_id?: number | null;
   webhook_enabled: boolean;
   icon: string;
   review_template_id?: number | null;

--- a/frontend/src/types/todo.ts
+++ b/frontend/src/types/todo.ts
@@ -15,7 +15,8 @@ export interface Todo {
   scheduler_timezone?: string | null;
   scheduler_next_run_at?: string | null;
   task_id?: string | null;
-  workspace?: string | null;
+  workspace_path?: string | null;
+  workspace_id?: number | null;
   webhook_enabled?: boolean;
   acceptance_criteria?: string | null;
   /** 已废弃：UI 层面不再展示该开关，事项执行后不再触发自动评审。保留字段用于 API 向下兼容。 */

--- a/frontend/src/utils/database/backup.ts
+++ b/frontend/src/utils/database/backup.ts
@@ -18,7 +18,7 @@ export async function importBackup(yamlContent: string): Promise<string> {
   }));
 }
 
-export async function mergeBackup(tags: { name: string; color: string }[], todos: { title: string; prompt: string; status: string; executor?: string; scheduler_enabled: boolean; scheduler_config?: string; tag_names: string[]; workspace?: string }[]): Promise<string> {
+export async function mergeBackup(tags: { name: string; color: string }[], todos: { title: string; prompt: string; status: string; executor?: string; scheduler_enabled: boolean; scheduler_config?: string; tag_names: string[]; workspace_path?: string }[]): Promise<string> {
   return unwrap(await api.post('/api/backup/merge', { tags, todos }));
 }
 

--- a/frontend/src/utils/database/loops.ts
+++ b/frontend/src/utils/database/loops.ts
@@ -204,15 +204,15 @@ export async function forceStopLoops(
 /** 批量移动环路到其他工作空间。 */
 export async function batchMoveLoopsWorkspace(
   ids: number[],
-  workspace_path: string,
+  workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.put('/api/loops/batch-workspace', { ids, workspace_path }));
+  return unwrap(await api.put('/api/loops/batch-workspace', { ids, workspace_id }));
 }
 
 /** 批量复制环路到其他工作空间。 */
 export async function batchCopyLoopsWorkspace(
   ids: number[],
-  workspace_path: string,
+  workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.post('/api/loops/batch-copy-workspace', { ids, workspace_path }));
+  return unwrap(await api.post('/api/loops/batch-copy-workspace', { ids, workspace_id }));
 }

--- a/frontend/src/utils/database/loops.ts
+++ b/frontend/src/utils/database/loops.ts
@@ -35,10 +35,10 @@ import type {
 
 // ====== Loop 主体 ======
 
-/** 列出所有 loop,按更新时间倒序。可选按工作空间过滤。 */
-export async function listLoops(workspace?: string | null): Promise<LoopListItem[]> {
+/** 列出所有 loop,按更新时间倒序。可选按工作空间 ID 过滤。 */
+export async function listLoops(workspace_id?: number | null): Promise<LoopListItem[]> {
   const params: Record<string, string> = {};
-  if (workspace) params.workspace = workspace;
+  if (workspace_id != null) params.workspace_id = String(workspace_id);
   const qs = Object.keys(params).length ? `?${new URLSearchParams(params).toString()}` : '';
   return unwrap(await api.get(`/api/loops${qs}`));
 }
@@ -199,4 +199,20 @@ export async function forceStopLoops(
   // 占位：开发中提示由调用方弹（utils 内部不依赖 message 上下文）。
   // 直接返回"全部失败"，强制调用方走失败分支走提示。
   return { stopped: [], failed: [...loopIds] };
+}
+
+/** 批量移动环路到其他工作空间。 */
+export async function batchMoveLoopsWorkspace(
+  ids: number[],
+  workspace_path: string,
+): Promise<{ updated_count: number; total: number }> {
+  return unwrap(await api.put('/api/loops/batch-workspace', { ids, workspace_path }));
+}
+
+/** 批量复制环路到其他工作空间。 */
+export async function batchCopyLoopsWorkspace(
+  ids: number[],
+  workspace_path: string,
+): Promise<{ updated_count: number; total: number }> {
+  return unwrap(await api.post('/api/loops/batch-copy-workspace', { ids, workspace_path }));
 }

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -37,7 +37,7 @@ export async function updateTodo(
   executor?: string,
   scheduler_enabled?: boolean,
   scheduler_config?: string | null,
-  workspace_path?: string | null,
+  workspace_id?: number | null,
   webhook_enabled?: boolean,
   acceptance_criteria?: string | null,
   auto_review_enabled?: boolean,
@@ -46,7 +46,7 @@ export async function updateTodo(
   if (executor !== undefined) body.executor = executor;
   if (scheduler_enabled !== undefined) body.scheduler_enabled = scheduler_enabled;
   if (scheduler_config !== undefined) body.scheduler_config = scheduler_config;
-  if (workspace_path !== undefined) body.workspace_path = workspace_path;
+  if (workspace_id !== undefined) body.workspace_id = workspace_id;
   if (webhook_enabled !== undefined) body.webhook_enabled = webhook_enabled;
   if (acceptance_criteria !== undefined) body.acceptance_criteria = acceptance_criteria;
   if (auto_review_enabled !== undefined) body.auto_review_enabled = auto_review_enabled;
@@ -83,17 +83,17 @@ export async function batchUpdateTodosExecutor(
 /** 批量移动事项到其他工作空间。 */
 export async function batchMoveTodosWorkspace(
   ids: number[],
-  workspace_path: string,
+  workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.put('/api/todos/batch-workspace', { ids, workspace_path }));
+  return unwrap(await api.put('/api/todos/batch-workspace', { ids, workspace_id }));
 }
 
 /** 批量复制事项到其他工作空间。 */
 export async function batchCopyTodosWorkspace(
   ids: number[],
-  workspace_path: string,
+  workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.post('/api/todos/batch-copy-workspace', { ids, workspace_path }));
+  return unwrap(await api.post('/api/todos/batch-copy-workspace', { ids, workspace_id }));
 }
 
 // Tag APIs

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -37,7 +37,7 @@ export async function updateTodo(
   executor?: string,
   scheduler_enabled?: boolean,
   scheduler_config?: string | null,
-  workspace?: string | null,
+  workspace_path?: string | null,
   webhook_enabled?: boolean,
   acceptance_criteria?: string | null,
   auto_review_enabled?: boolean,
@@ -46,7 +46,7 @@ export async function updateTodo(
   if (executor !== undefined) body.executor = executor;
   if (scheduler_enabled !== undefined) body.scheduler_enabled = scheduler_enabled;
   if (scheduler_config !== undefined) body.scheduler_config = scheduler_config;
-  if (workspace !== undefined) body.workspace = workspace;
+  if (workspace_path !== undefined) body.workspace_path = workspace_path;
   if (webhook_enabled !== undefined) body.webhook_enabled = webhook_enabled;
   if (acceptance_criteria !== undefined) body.acceptance_criteria = acceptance_criteria;
   if (auto_review_enabled !== undefined) body.auto_review_enabled = auto_review_enabled;
@@ -78,6 +78,22 @@ export async function batchUpdateTodosExecutor(
   } catch {
     return { updated: [], failed: ids };
   }
+}
+
+/** 批量移动事项到其他工作空间。 */
+export async function batchMoveTodosWorkspace(
+  ids: number[],
+  workspace_path: string,
+): Promise<{ updated_count: number; total: number }> {
+  return unwrap(await api.put('/api/todos/batch-workspace', { ids, workspace_path }));
+}
+
+/** 批量复制事项到其他工作空间。 */
+export async function batchCopyTodosWorkspace(
+  ids: number[],
+  workspace_path: string,
+): Promise<{ updated_count: number; total: number }> {
+  return unwrap(await api.post('/api/todos/batch-copy-workspace', { ids, workspace_path }));
 }
 
 // Tag APIs

--- a/frontend/src/utils/workspaceDisplay.ts
+++ b/frontend/src/utils/workspaceDisplay.ts
@@ -6,48 +6,55 @@ import type { ProjectDirectory } from '@/types';
  * 工作空间相关展示/查询工具。
  *
  * 三种语义必须分清，混用就会出现"展示给用户的是路径而不是名称"这类 bug：
- *   - `id`     : project_directories.id（数字，后端 API 用这个过滤）
- *   - `path`   : project_directories.path（路径字符串，loop.workspace 字段存这个）
+ *   - `id`     : project_directories.id（数字，后端 API / 组件间 props 唯一键）
+ *   - `path`   : project_directories.path（路径字符串，仅用于 cwd/worktree，后端内部消费）
  *   - `name`   : project_directories.name（人类可读名称，UI 展示用这个）
  *
- * UI 展示一律用 `name`；调用需要 id 的 API 用 `getWorkspaceIdByPath`；
- * 拿到 workspace 字段但要展示时统一走 `getWorkspaceDisplayName`。
+ * 约定（破坏式更新）：
+ * - 组件之间 props 全部传 `id`；path 不再作 props 主键，避免重复传递与不一致。
+ * - UI 展示一律用 `name`；调用需要 id 的 API 直接用 id；
+ *   拿到 workspace_id 但要展示时统一走 `getWorkspaceDisplayName`。
+ * - 需要 cwd 时通过 `getWorkspacePathById` 由 id 反查 path。
  */
 
-/** 从一组目录里根据 path 找到 id；找不到返回 undefined。空/null 路径一律返回 undefined。 */
-export function getWorkspaceIdByPath(
+/**
+ * 从一组目录里根据 id 找到 path；找不到返回 undefined。
+ * 仅用于 cwd / worktree 上下文，不作为 props 主键使用。
+ */
+export function getWorkspacePathById(
   dirs: ProjectDirectory[] | null | undefined,
-  path: string | null | undefined,
-): number | undefined {
-  if (!dirs || !path || !path.trim()) return undefined;
-  return dirs.find(d => d.path === path.trim())?.id;
+  id: number | null | undefined,
+): string | undefined {
+  if (!dirs || id == null) return undefined;
+  return dirs.find(d => d.id === id)?.path;
 }
 
 /**
- * 拿到 UI 展示用的「工作空间名称」：优先 name，找不到则降级到 path，再降级到空串。
+ * 拿到 UI 展示用的「工作空间名称」：传入 id，在目录列表中反查 name；
+ * 找不到 name 时降级到 path，再降级到空串。
  * 注意：不要把返回结果当作 id 用 —— 这里只用于展示。
  */
 export function getWorkspaceDisplayName(
   dirs: ProjectDirectory[] | null | undefined,
-  path: string | null | undefined,
+  id: number | null | undefined,
 ): string {
-  if (!path) return '';
-  const matched = dirs?.find(d => d.path === path);
+  if (id == null) return '';
+  const matched = dirs?.find(d => d.id === id);
   if (matched?.name) return matched.name;
-  return path;
+  return matched?.path ?? '';
 }
 
 /**
- * Hook：组件挂载时一次性加载 project_directories，返回 `{ dirs, byPath }`。
+ * Hook：组件挂载时一次性加载 project_directories，返回 `{ dirs, byId }`。
  *
- * - `dirs`：完整列表，传给 `getWorkspaceDisplayName` / `getWorkspaceIdByPath` 用。
- * - `byPath`：path → ProjectDirectory 的 Map，热路径上 O(1) 查找，避免每个候选 todo 都做 O(n) find。
+ * - `dirs`：完整列表，传给 `getWorkspaceDisplayName` / `getWorkspacePathById` 用。
+ * - `byId`：id → ProjectDirectory 的 Map，热路径上 O(1) 查找，避免每个候选 todo 都做 O(n) find。
  *
  * project_directories 是低基数集合（手动维护），一次性全量加载比按需拉更简单也更稳。
  */
 export function useProjectDirectories(): {
   dirs: ProjectDirectory[];
-  byPath: Map<string, ProjectDirectory>;
+  byId: Map<number, ProjectDirectory>;
   loading: boolean;
 } {
   const [dirs, setDirs] = useState<ProjectDirectory[]>([]);
@@ -60,7 +67,7 @@ export function useProjectDirectories(): {
       .finally(() => setLoading(false));
   }, []);
   useEffect(() => { load(); }, [load]);
-  const byPath = new Map<string, ProjectDirectory>();
-  for (const d of dirs) if (d.path) byPath.set(d.path, d);
-  return { dirs, byPath, loading };
+  const byId = new Map<number, ProjectDirectory>();
+  for (const d of dirs) byId.set(d.id, d);
+  return { dirs, byId, loading };
 }

--- a/frontend/src/utils/workspaceDisplay.ts
+++ b/frontend/src/utils/workspaceDisplay.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getProjectDirectories } from '@/utils/database/todos';
+import type { ProjectDirectory } from '@/types';
+
+/**
+ * 工作空间相关展示/查询工具。
+ *
+ * 三种语义必须分清，混用就会出现"展示给用户的是路径而不是名称"这类 bug：
+ *   - `id`     : project_directories.id（数字，后端 API 用这个过滤）
+ *   - `path`   : project_directories.path（路径字符串，loop.workspace 字段存这个）
+ *   - `name`   : project_directories.name（人类可读名称，UI 展示用这个）
+ *
+ * UI 展示一律用 `name`；调用需要 id 的 API 用 `getWorkspaceIdByPath`；
+ * 拿到 workspace 字段但要展示时统一走 `getWorkspaceDisplayName`。
+ */
+
+/** 从一组目录里根据 path 找到 id；找不到返回 undefined。空/null 路径一律返回 undefined。 */
+export function getWorkspaceIdByPath(
+  dirs: ProjectDirectory[] | null | undefined,
+  path: string | null | undefined,
+): number | undefined {
+  if (!dirs || !path || !path.trim()) return undefined;
+  return dirs.find(d => d.path === path.trim())?.id;
+}
+
+/**
+ * 拿到 UI 展示用的「工作空间名称」：优先 name，找不到则降级到 path，再降级到空串。
+ * 注意：不要把返回结果当作 id 用 —— 这里只用于展示。
+ */
+export function getWorkspaceDisplayName(
+  dirs: ProjectDirectory[] | null | undefined,
+  path: string | null | undefined,
+): string {
+  if (!path) return '';
+  const matched = dirs?.find(d => d.path === path);
+  if (matched?.name) return matched.name;
+  return path;
+}
+
+/**
+ * Hook：组件挂载时一次性加载 project_directories，返回 `{ dirs, byPath }`。
+ *
+ * - `dirs`：完整列表，传给 `getWorkspaceDisplayName` / `getWorkspaceIdByPath` 用。
+ * - `byPath`：path → ProjectDirectory 的 Map，热路径上 O(1) 查找，避免每个候选 todo 都做 O(n) find。
+ *
+ * project_directories 是低基数集合（手动维护），一次性全量加载比按需拉更简单也更稳。
+ */
+export function useProjectDirectories(): {
+  dirs: ProjectDirectory[];
+  byPath: Map<string, ProjectDirectory>;
+  loading: boolean;
+} {
+  const [dirs, setDirs] = useState<ProjectDirectory[]>([]);
+  const [loading, setLoading] = useState(false);
+  const load = useCallback(() => {
+    setLoading(true);
+    getProjectDirectories()
+      .then(setDirs)
+      .catch(() => setDirs([]))
+      .finally(() => setLoading(false));
+  }, []);
+  useEffect(() => { load(); }, [load]);
+  const byPath = new Map<string, ProjectDirectory>();
+  for (const d of dirs) if (d.path) byPath.set(d.path, d);
+  return { dirs, byPath, loading };
+}

--- a/frontend/tests/check_loop_step_workspace_filter.spec.ts
+++ b/frontend/tests/check_loop_step_workspace_filter.spec.ts
@@ -1,0 +1,123 @@
+// 验证：Loop Studio 新增环节 Modal 中「关联环节」下拉按 loop 工作空间过滤 todo。
+//
+// 设计要点：
+// - 找一个 workspace=/tmp/xxx 且 step_count=0 的 loop（让「添加环节」按钮可点）
+// - 打开 Modal 后，从 DOM 收集 Select 下拉里的所有 option（label 形如 `#<id> <title>`）
+// - 通过 /api/todos?workspace_id=<id> 拿到该工作空间下应该出现的 todo id 集合
+// - 断言：下拉里的 id 全部命中目标集合（防止误把别的工作空间下的 todo 串进来）
+// - 对照：全量 /api/todos 的 id 集合应该 ⊋ 目标集合（说明数据库里确实有跨空间的 todo，
+//   否则用例等于没在验证过滤）
+// - 兜底：若找不到可测的 loop，自动 test.skip，避免假阳性
+
+import { test, expect, request } from '@playwright/test';
+
+const BACKEND_URL = process.env.E2E_BACKEND_URL || 'http://localhost:18088';
+const DEV_URL = 'http://localhost:18088';
+
+// 收集 antd Select 下拉中所有 option 的 id；label 形如 "#27 讲个笑话"
+async function collectOptionIds(page: import('@playwright/test').Page): Promise<number[]> {
+  return await page.evaluate(() => {
+    // 关联环节 Select 渲染在 Modal 内，取可见的 .ant-select-item（含 dropdown 里所有 option）
+    const nodes = Array.from(document.querySelectorAll('.ant-select-item-option'));
+    const ids = new Set<number>();
+    for (const n of nodes) {
+      // 优先用 antd 给的 value（react state 写入 DOM 的 data-* 属性缺失则用 label 兜底）
+      const labelText = (n.textContent || '').trim();
+      const m = labelText.match(/^#(\d+)/);
+      if (m) ids.add(Number(m[1]));
+    }
+    return Array.from(ids);
+  });
+}
+
+test('新增环节 Modal 的关联环节下拉按 loop 工作空间过滤', async () => {
+  const apiCtx = await request.newContext({ baseURL: BACKEND_URL });
+
+  // 1) 找一个带 workspace_path 且 step_count=0 的 loop，便于点「添加环节」进入新建流程
+  const loopsRes = await apiCtx.get('/api/loops?page=1&limit=50');
+  const loopsJson = await loopsRes.json();
+  const loops: Array<{ id: number; workspace_path: string | null; step_count: number }> = loopsJson?.data ?? [];
+  // 优先 /tmp/xxx（id=1），实测数据里该工作空间下确实有 todo
+  const target =
+    loops.find((l) => l.workspace_path === '/tmp/xxx' && l.step_count === 0) ??
+    loops.find((l) => !!l.workspace_path && l.step_count === 0);
+  test.skip(!target || !target.workspace_path, '没有可用的「带工作空间且无 step」的 loop，跳过用例');
+  const loopId = target!.id;
+  const workspacePath = target!.workspace_path!;
+
+  // 2) 查后端确认目标 workspace 的 todo 集合，以及全量 todo 集合
+  const dirsRes = await apiCtx.get('/api/project-directories');
+  const dirsJson = await dirsRes.json();
+  const dirs: Array<{ id: number; path: string }> = dirsJson?.data ?? [];
+  const dir = dirs.find((d) => d.path === workspacePath);
+  test.skip(!dir, `未找到路径 ${workspacePath} 对应的工作空间目录，跳过用例`);
+  const workspaceId = dir!.id;
+
+  const targetListRes = await apiCtx.get(`/api/todos?workspace_id=${workspaceId}`);
+  const targetListJson = await targetListRes.json();
+  const targetTodos: Array<{ id: number; title: string }> = targetListJson?.data ?? [];
+  const targetIds = new Set(targetTodos.map((t) => t.id));
+
+  const allRes = await apiCtx.get('/api/todos');
+  const allJson = await allRes.json();
+  const allTodos: Array<{ id: number }> = allJson?.data ?? [];
+  const allIds = new Set(allTodos.map((t) => t.id));
+
+  // 若目标工作空间下根本没有 todo，过滤下拉就是空，没法证伪；同样跳过
+  test.skip(targetIds.size === 0, `工作空间 ${workspacePath} 下暂无 todo，无法验证过滤`);
+  // 全量必须严格多于目标集合，否则等于没在测过滤
+  test.skip(allIds.size <= targetIds.size, '全量 todo 数不严格多于目标工作空间，跳过用例');
+
+  // 3) 进入 loop 详情，打开「添加环节」
+  const browser = await (await import('@playwright/test')).chromium.launch();
+  const ctx = await browser.newContext({ baseURL: DEV_URL });
+  const page = await ctx.newPage();
+  await page.goto(`${DEV_URL}/?loop=${loopId}`);
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(1200);
+
+  // 触发添加环节：点击流程图占位卡片（无 step 时显示「暂无执行环节，点击添加」）
+  const addTrigger = page.getByText('添加环节').first();
+  await expect(addTrigger, '流程图占位的「添加环节」应可见').toBeVisible({ timeout: 8000 });
+  await addTrigger.click();
+  await page.waitForTimeout(400);
+
+  const modalTitle = page.getByText('新增环节').first();
+  await expect(modalTitle, '新增环节 Modal 应打开').toBeVisible({ timeout: 5000 });
+
+  // 4) 触发「关联环节」Select 的下拉展开，渲染所有 option
+  // Modal 里第一个 Form.Item label 是「关联环节」
+  const todoSelect = page.locator('.ant-modal .ant-select-selector').first();
+  await todoSelect.click();
+  await page.waitForTimeout(500);
+
+  // 5) 收集下拉里的 id 并断言：必须全部命中目标 workspace 的 id 集合
+  const optionIds = await collectOptionIds(page);
+  expect(optionIds.length, '下拉至少要展示一个候选 todo').toBeGreaterThan(0);
+
+  const foreignIds = optionIds.filter((id) => !targetIds.has(id));
+  expect(
+    foreignIds,
+    `下拉里出现了非 ${workspacePath} 工作空间下的 todo id: ${foreignIds.join(',')}；期望只出现 id: ${Array.from(targetIds).join(',')}`,
+  ).toEqual([]);
+
+  // 同时确认：全量 todo 数 > 出现在下拉里的 todo 数 ⇒ 过滤确实起了作用
+  expect(
+    allIds.size,
+    '全量 todo 数应严格大于下拉展示数，证明过滤生效',
+  ).toBeGreaterThan(optionIds.length);
+
+  // 6) 顺手断言 placeholder 文本透出工作空间名（让用户知道为什么只看到这些）
+  const placeholder = await page
+    .locator('.ant-modal .ant-select-selection-placeholder')
+    .first()
+    .innerText()
+    .catch(() => '');
+  expect(
+    placeholder.includes(workspacePath),
+    `placeholder 应提示「${workspacePath}」，实际: ${placeholder}`,
+  ).toBe(true);
+
+  await browser.close();
+  await apiCtx.dispose();
+});

--- a/frontend/tests/workspace_id_only.spec.ts
+++ b/frontend/tests/workspace_id_only.spec.ts
@@ -1,0 +1,127 @@
+// 验证破坏式改造：组件之间传递工作空间主键统一改为 project_directories.id（number）。
+//
+// 验证目标：
+// 1. WorkspaceSelect 的 antd Select option value 是数字（id），不是路径字符串。
+// 2. 触发 LoopFormModal 保存时，POST /api/loops 请求体里包含 workspace_id（number），
+//    不再带 workspace_path 字段。
+// 3. Loop 详情页 / 编辑 modal 拿到的 LoopDto 里 workspace_id 是 number。
+//
+// 数据源：dev server 后端的 sqlite db，使用 API 直接插入一条 workspace 与一条 loop 做断言基础。
+// 若 dev server 未启动，case 用 test.skip 跳过，避免硬失败。
+
+import { test, expect, request } from '@playwright/test';
+
+const BASE = 'http://localhost:18088';
+
+// 通过 API 拿到已存在的 workspace id 与一个示例 loop（用于编辑模式断言）
+async function fetchSeed(api: Awaited<ReturnType<typeof request.newContext>>) {
+  // 拉取 project_directories
+  const dirsResp = await api.get(`${BASE}/api/project-directories`);
+  const dirs = (await dirsResp.json()).data as Array<{ id: number; path: string; name: string | null }>;
+  // 拉取 loops
+  const loopsResp = await api.get(`${BASE}/api/loops`);
+  const loops = (await loopsResp.json()).data as Array<{ id: number; workspace_id: number | null }>;
+  return { dirs, loops };
+}
+
+test.describe('workspace_id 破坏式改造验证', () => {
+  test('API 返回的 LoopDto/LoopListItem 含 workspace_id（number）字段', async () => {
+    const api = await request.newContext();
+    const { loops } = await fetchSeed(api);
+    if (loops.length === 0) test.skip(true, 'dev server 上没有 loop，跳过断言');
+    // workspace_id 字段存在且为 number 或 null —— 验证关键语义
+    const sample = loops[0];
+    expect(sample).toHaveProperty('workspace_id');
+    expect(sample.workspace_id === null || typeof sample.workspace_id === 'number').toBe(true);
+    await api.dispose();
+  });
+
+  test('WorkspaceSelect option 的 value 是数字（id）而不是路径字符串', async ({ page }) => {
+    await page.goto(BASE);
+    await page.waitForLoadState('networkidle');
+    // 等待 project_directories 加载
+    await page.waitForResponse(r => r.url().includes('/api/project-directories') && r.status() === 200, { timeout: 5000 }).catch(() => {});
+
+    // 打开任意 WorkspaceSelect —— TodoDrawer 的新建按钮 / 左侧 WorkspaceSwitcher / LoopFormModal 都用同一组件
+    // 通过 WorkspaceSwitcher dropdown 触发最稳，因为它总是渲染
+    const switcher = page.locator('[data-testid="left-rail-workspace-switcher"]').first();
+    if (await switcher.count() === 0) test.skip(true, '左侧 WorkspaceSwitcher 不存在，跳过');
+    await switcher.click();
+    await page.waitForTimeout(300);
+
+    // dropdown menu item 的 key 是 dir.id（String(dir.id)）；验证菜单项都对应数字 id
+    const menuItems = await page.locator('.ant-dropdown-menu .ant-dropdown-menu-item').elementHandles();
+    expect(menuItems.length).toBeGreaterThan(0);
+
+    // 通过 API 再拿一次目录，对照断言
+    const api = await request.newContext();
+    const { dirs } = await fetchSeed(api);
+    const dirIds = new Set(dirs.map(d => String(d.id)));
+    for (const item of menuItems) {
+      const text = (await item.textContent()) || '';
+      // 跳过「管理工作空间」分隔项
+      if (text.includes('管理工作空间')) continue;
+      // 菜单项 key 应该匹配某个 dir.id
+      const matched = [...dirIds].some(id => text.includes(id) || dirs.some(d => d.name && text.includes(d.name) || text.includes(d.path)));
+      expect(matched, `菜单项 "${text}" 应能匹配到某个 dir 的 id/name/path`).toBe(true);
+    }
+    await api.dispose();
+  });
+
+  test('新建 loop 提交体携带 workspace_id（number），不携带 workspace_path', async ({ page }) => {
+    await page.goto(BASE);
+    await page.waitForLoadState('networkidle');
+
+    // 通过 API 拿第一个目录 id 作为目标工作空间
+    const api = await request.newContext();
+    const { dirs } = await fetchSeed(api);
+    await api.dispose();
+    if (dirs.length === 0) test.skip(true, 'dev server 上没有 project_directory，跳过');
+    const targetDir = dirs[0];
+
+    // 拦截 POST /api/loops 以捕获请求体
+    const createReq = page.waitForRequest(
+      r => r.url().endsWith('/api/loops') && r.method() === 'POST',
+      { timeout: 15000 },
+    );
+
+    // 打开 Loop 新建 modal —— 通过左侧导航的环路 → 新建按钮
+    // 简化路径：直接点击新建按钮；如找不到则跳过
+    const newButton = page.locator('button').filter({ hasText: /^新建$|^新建环路$/ }).first();
+    if (await newButton.count() === 0) test.skip(true, '未找到「新建」按钮，跳过');
+    await newButton.click();
+    await page.waitForTimeout(500);
+
+    // 填写名称（必填）
+    const nameInput = page.locator('input[placeholder="名称必填"], input').first();
+    // 简化：用 placeholder 精确匹配
+    const nameField = page.getByPlaceholder('名称').first();
+    if (await nameField.count() > 0) {
+      await nameField.fill('playwright_workspace_id_test');
+    }
+
+    // 在 WorkspaceSelect 下拉里选择第一个工作空间
+    const wsSelect = page.locator('.ant-select').filter({ hasText: /选择工作空间|工作空间/ }).first();
+    if (await wsSelect.count() === 0) test.skip(true, '未找到 WorkspaceSelect，跳过');
+    await wsSelect.click();
+    await page.waitForTimeout(300);
+    const firstOption = page.locator('.ant-select-item-option').first();
+    if (await firstOption.count() === 0) test.skip(true, 'WorkspaceSelect 没有可选项，跳过');
+    await firstOption.click();
+
+    // 点击保存
+    const saveButton = page.locator('button').filter({ hasText: /^创建$|^保存$/ }).first();
+    if (await saveButton.count() === 0) test.skip(true, '未找到保存按钮，跳过');
+    await saveButton.click();
+
+    // 断言请求体
+    const req = await createReq.catch(() => null);
+    if (!req) test.skip(true, '未拦截到 POST /api/loops 请求，跳过');
+    const body = req!.postDataJSON() as Record<string, unknown>;
+    expect(body).toHaveProperty('workspace_id');
+    expect(typeof body.workspace_id).toBe('number');
+    expect(body.workspace_id).toBe(targetDir.id);
+    // 不应携带 workspace_path（破坏式后已删字段）
+    expect(body).not.toHaveProperty('workspace_path');
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,7 +16,9 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: {
-          'vendor-react': ['react', 'react-dom'],
+          // react / react-dom 不单独拆：Vite 默认把它们打入主 chunk，
+          // 这里留 manualChunks 占位会产生 0 KB 的空 vendor-react 文件。
+          // 真正需要拆分的是 antd / 图标 / markdown 编辑器这种大型第三方库。
           'vendor-antd': ['antd'],
           'vendor-antd-icons': ['@ant-design/icons'],
           'vendor-md-editor': ['@uiw/react-md-editor', '@ant-design/x-markdown'],


### PR DESCRIPTION
## 概述

将工作空间（project_directories）的组件间传递主键从 path 字符串统一改为 id（数字）。
path 仅作 cwd 字符串保留在 DB 与 executor 内部，不再上送 API。

## 改动范围（6 个 commit）

| commit | 说明 |
|---|---|
| c00a21f | refactor: 全栈 workspace_id 破坏式改造（loop + todo + CLI + event） |
| 55a1645 | fix(pi): 启用 Worktree 切目录时通过 stdin 预写 "y" 自动应答 prompt |
| b8f4f77 | fix(TodoPostPage): 帖子视图补上 worktree 路径展示 |
| 4cbdb72 | chore(backend): cargo fix --lib 清理未使用 import / 变量 |
| a78d914 | chore(backend): 删除 ListenerMessageContext 未使用 config 字段 |
| d93164d | chore(frontend): 清理 vite 构建产物的两类空配置 warning |

## 核心改动（refactor commit）

**后端**
- `LoopDto` / `LoopListItem` / `LoopDetail` 增 `workspace_id`
- `CreateLoopRequest` / `UpdateLoopRequest` / 批量请求体改为 `workspace_id`
- handler 强制把 id 解析为 path 后双写 `workspace_id + workspace_path`
- DAO `create_loop` / `update_loop` / `batch_*_workspace` 入参改 id
- CLI `todo/loop create/update` 用 `--workspace-id`，去掉 `--workspace-path`
- DB schema 不动（V35 已就位）

**前端**
- `types/loop.ts` 全部 Loop* 类型切到 `workspace_id`
- `utils/database/{loops,todos}.ts` 入参改 id，payload 不再带 `workspace_path`
- `utils/workspaceDisplay.ts` 增 `byId` Map + `getWorkspacePathById`，删除 `getWorkspaceIdByPath`
- `common/WorkspaceSelect.tsx` `value/onChange` 全切 number
- `projectDirectoryAdded` 事件 payload 改为 `{ id }`
- `LoopFormModal` / `LoopStudioDetailPanel` / `LoopMobilePage` /
  `LoopStudioStepsPanel` / `LoopStudioListPanel` 全部以 id 为主键
- `TodoDrawer` + reducer 表单状态 `workspaceId: number | null`
- `WorkspaceSwitcher` / `LeftRail` / `useTodoContext` / `TodoList` / `App.tsx` 全栈切到 id
- localStorage `selected_workspace` 用 `Number()` 解析（旧 path 串自动回退 null）

## 其他改动

- **pi executor**：`CodeExecutor` trait 新增 `stdin_payload()` 钩子；`PiExecutor` 返回 `Some("y\n")`；spawn 阶段先按 hook 写入再关闭 stdin。等价于 `echo "y" | pi -p ...` 的管道输入，解决 pi 在 Worktree 切目录时的交互式 prompt 卡住问题。
- **TodoPostPage**：补 `WorktreePathDisplay`（与 RecordDetailView 同款），修复 `?panel=post` 全屏帖子视图漏展示 `worktree_path` 的 bug。
- **cargo fix**：清理 5 处未使用 import / 变量；删除 `ListenerMessageContext.config` 死字段。
- **vite config**：删除 `manualChunks` 里 `vendor-react` 占位（产生 0 KB 空 chunk）；`LoopStudioExecutionsPanel` 两处动态 import 改静态（模块本就被 10 个组件静态 import，动态 import 拆不动）。

## 验证

- `cargo test --lib`：**737 passed / 0 failed / 2 ignored**
- `tsc --noEmit`：exit 0
- `vite build`：通过，两类空配置 warning 消失

## 兼容性

**破坏式变更**，无向下兼容：
- API：`workspace_path` 字段从请求体/响应体移除，统一为 `workspace_id`
- CLI：`--workspace-path` 参数移除，改用 `--workspace-id`
- localStorage：`selected_workspace` 存的值从 path 字符串变为 id 数字；旧值读不到会回退 null

Co-Authored-By: AtomCode (MiniMax-M3) <noreply@atomgit.com>