### PR TITLE
feat(loop): 环路执行前校验工作空间一致性，失败时在前端展示错误原因

### DIFF
--- a/backend/src/db/entity/loop_executions.rs
+++ b/backend/src/db/entity/loop_executions.rs
@@ -29,6 +29,8 @@ pub struct Model {
     /// 累计执行过的 step 次数（含循环重走）
     #[sea_orm(default_value = "0")]
     pub total_executed_steps: i32,
+    /// 执行失败时的错误说明（如工作空间不一致）。仅在 status=failed 时有值。
+    pub error_message: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -840,6 +840,7 @@ impl Database {
         status: &str,
         completed_steps: i32,
         failed_steps: i32,
+        error_message: Option<&str>,
     ) -> Result<(), sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let existing = loop_executions::Entity::find_by_id(id).one(&self.conn).await?;
@@ -849,6 +850,12 @@ impl Database {
             am.finished_at = ActiveValue::Set(Some(now));
             am.completed_steps = ActiveValue::Set(completed_steps);
             am.failed_steps = ActiveValue::Set(failed_steps);
+            // error_message 有值时写入 / 为 None 时保持数据库已有值不变。
+            // 这意味着后续可以覆盖但不主动清空。如果将来需要显式清空，
+            // 可改为 am.error_message = ActiveValue::Set(error_message.map(|s| s.to_string()));
+            if let Some(msg) = error_message {
+                am.error_message = ActiveValue::Set(Some(msg.to_string()));
+            }
             am.update(&self.conn).await?;
         }
         Ok(())

--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -68,7 +68,29 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V33ReviewTemplatesEnsureWorkspaceId),
         Box::new(V34MigrateOrphansToTempWorkspace),
         Box::new(V35RenameWorkspaceToWorkspacePath),
+        Box::new(V36LoopExecutionsErrorMessage),
     ]
+}
+
+/// V36 迁移：给 loop_executions 表添加 error_message 列，用于存储执行失败的原因。
+///
+/// 当 loop 因工作空间不一致等原因在启动步骤前失败时，error_message 会记录具体原因，
+/// 供前端在失败记录上展示，避免用户只能通过后台日志排查。
+pub(super) struct V36LoopExecutionsErrorMessage;
+#[async_trait::async_trait]
+impl Migration for V36LoopExecutionsErrorMessage {
+    fn version(&self) -> i64 { 36 }
+    fn name(&self) -> &'static str { "add_loop_executions_error_message" }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 幂等：列已存在时跳过
+        if !table_has_column(db, "loop_executions", "error_message").await? {
+            db.exec("ALTER TABLE loop_executions ADD COLUMN error_message TEXT DEFAULT NULL")
+                .await?;
+            tracing::info!("V36: loop_executions.error_message column added");
+        }
+        Ok(())
+    }
 }
 
 /// v13 迁移：将 loop_steps.todo_id 重命名为 step_id，消除列名误导。

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -880,6 +880,7 @@ mod tests {
             limit: 100,
             offset: 0,
             status: None,
+            hours: None,
         })
         .await
         .unwrap();
@@ -917,6 +918,7 @@ mod tests {
             limit: 100,
             offset: 0,
             status: None,
+            hours: None,
         })
         .await
         .unwrap();
@@ -1208,6 +1210,7 @@ mod tests {
             limit: 100,
             offset: 0,
             status: None,
+            hours: None,
         })
         .await
         .unwrap();
@@ -1233,6 +1236,7 @@ mod tests {
             limit: 2,
             offset: 0,
             status: None,
+            hours: None,
         })
         .await
         .unwrap();
@@ -1253,6 +1257,7 @@ mod tests {
             limit: 10,
             offset: 2,
             status: None,
+            hours: None,
         })
         .await
         .unwrap();
@@ -1298,6 +1303,7 @@ mod tests {
                 limit: 10,
                 offset: 0,
                 status: Some("running"),
+                hours: None,
             })
             .await
             .unwrap();
@@ -1312,6 +1318,7 @@ mod tests {
                 limit: 10,
                 offset: 0,
                 status: Some("success"),
+                hours: None,
             })
             .await
             .unwrap();
@@ -1326,6 +1333,7 @@ mod tests {
                 limit: 10,
                 offset: 0,
                 status: Some("failed"),
+                hours: None,
             })
             .await
             .unwrap();
@@ -1339,6 +1347,7 @@ mod tests {
             limit: 10,
             offset: 0,
             status: None,
+            hours: None,
         })
         .await
         .unwrap();
@@ -1353,6 +1362,7 @@ mod tests {
                 limit: 10,
                 offset: 0,
                 status: Some("all"),
+                hours: None,
             })
             .await
                 .unwrap();
@@ -1390,6 +1400,7 @@ mod tests {
             limit: 100,
             offset: 0,
             status: None,
+            hours: None,
         })
         .await
         .unwrap();

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -48,14 +48,8 @@ pub async fn get_todos(
         let cutoff = chrono::Utc::now() - chrono::Duration::hours(h as i64);
         let cutoff_str = cutoff.format("%Y-%m-%dT%H:%M:%S").to_string();
         todos.into_iter().filter(|t| {
-            // completed/failed 的 todo 按 finished_at 过滤，其他按 updated_at
-            let time_field = match t.status {
-                crate::models::TodoStatus::Completed | crate::models::TodoStatus::Failed => {
-                    t.finished_at.as_deref().unwrap_or(&t.updated_at)
-                }
-                _ => &t.updated_at,
-            };
-            time_field >= &cutoff_str
+            // 按 updated_at 过滤（finished_at 字段未在模型上实现，暂统一用 updated_at）
+            t.updated_at >= cutoff_str
         }).collect()
     } else {
         todos

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -239,6 +239,9 @@ pub struct LoopExecutionDto {
     /// 仅在 list_executions 响应中由 handler 填充，从 Model 转换时默认为空。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_summary: Option<LoopExecutionTokenSummary>,
+    /// 执行失败时的错误说明（仅在 status=failed 时有值）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
 }
 
 impl From<loop_executions::Model> for LoopExecutionDto {
@@ -257,6 +260,7 @@ impl From<loop_executions::Model> for LoopExecutionDto {
             failed_steps: m.failed_steps,
             pending_approval_count: 0, // 由 handler 后续查询填充
             token_summary: None,       // 由 handler 后续加载 step_executions 后聚合填充
+            error_message: m.error_message, // 直接透传 DB 中的错误说明
         }
     }
 }

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -60,6 +60,69 @@ impl LoopRunner {
         &self.ctx
     }
 
+    /// 校验 loop 所有步骤的 todo 是否都归属同一工作空间。
+    /// 环路运行时要求所有环节在同一工作空间下，否则 cwd / worktree 无法统一，
+    /// 且跨工作空间的数据流会导致不可预期的行为。
+    /// 返回 Err 时附带具体哪些步骤不在同一工作空间。
+    async fn check_workspace_consistency(
+        &self,
+        loop_: &crate::db::entity::loops::Model,
+        all_steps: &[loop_steps::Model],
+    ) -> Result<(), String> {
+        // 收集所有属于 loop 的步骤的 todo_id 的去重列表
+        // 使用 indexmap 保留顺序同时去重，避免同一个 todo 被多个 step 引用时重复检查
+        let mut seen = std::collections::HashSet::new();
+        let mut todo_ids = Vec::new();
+        for step in all_steps {
+            if seen.insert(step.todo_id) {
+                todo_ids.push(step.todo_id);
+            }
+        }
+
+        // 加载每个 todo 并校验 workspace_id 是否与 loop 一致
+        let mut mismatches: Vec<String> = Vec::new();
+        for &tid in &todo_ids {
+            let todo = self
+                .ctx
+                .db
+                .get_todo(tid)
+                .await
+                .map_err(|e| e.to_string())?
+                .ok_or_else(|| format!("todo #{} (引用于 loop #{}) 已被删除", tid, loop_.id))?;
+
+            // 比较双方 workspace_id 是否一致。
+            // 特殊处理：Some(0)（todos 默认值，未分配工作空间）与 None（loop 默认值）语义等价，
+            // 都表示"未分配工作空间"，视为同一空间。
+            let loop_ws = loop_.workspace_id.filter(|&id| id != 0);
+            let todo_ws = todo.workspace_id.filter(|&id| id != 0);
+            if loop_ws != todo_ws {
+                let step_names: Vec<&str> = all_steps
+                    .iter()
+                    .filter(|s| s.todo_id == tid)
+                    .map(|s| s.name.as_str())
+                    .collect();
+                mismatches.push(format!(
+                    "环节「{}」(todo #{}) 所属工作空间 (id={:?}) 与 loop (id={:?}) 不一致",
+                    step_names.join("、"),
+                    tid,
+                    todo.workspace_id,
+                    loop_.workspace_id,
+                ));
+            }
+        }
+
+        if mismatches.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "loop #{}「{}」的环节不在同一工作空间下，无法执行：\n{}",
+                loop_.id,
+                loop_.name,
+                mismatches.join("\n"),
+            ))
+        }
+    }
+
     /// Spawn 一条 loop 执行（fire-and-forget）。返回 loop_execution_id 给调用方。
     pub fn spawn_run(
         self: Arc<Self>,
@@ -114,12 +177,23 @@ impl LoopRunner {
                         "failed",
                         0,
                         0,
+                        Some(&e),
                     )
                     .await;
                 // 触发异常处理 Todo（传入 0 作为步数/Token 统计）
                 let _ = this2_for_err
                     .trigger_abnormal_handler(loop_id, loop_execution_id, "failed", 0, 0)
                     .await;
+                // 发送 WebSocket 事件，触发前端刷新执行历史列表。
+                // 没有这步的话，前端 LoopExecutionsPanel 收不到事件通知，
+                // 用户无法在界面上看到这条 failed 记录，只能从后台日志中排查。
+                let _ = this2_for_err
+                    .tx
+                    .send(crate::handlers::ExecEvent::ReviewStatusChanged {
+                        record_id: 0,
+                        todo_id: 0,
+                        review_status: "failed".to_string(),
+                    });
             }
         });
 
@@ -238,7 +312,7 @@ impl LoopRunner {
             // 没有下一步（end/break），结束 loop execution
             let final_status = if completed > 0 { "success" } else { "failed" };
             let _ = self.ctx.db.finish_loop_execution(
-                loop_execution_id, final_status, completed, failed,
+                loop_execution_id, final_status, completed, failed, None,
             ).await;
             info!("resume: loop_execution #{} ended with status {}", loop_execution_id, final_status);
         }
@@ -286,19 +360,24 @@ impl LoopRunner {
         if all_steps.is_empty() {
             self.ctx
                 .db
-                .finish_loop_execution(loop_execution_id, "success", 0, 0)
+                .finish_loop_execution(loop_execution_id, "success", 0, 0, None)
                 .await
                 .map_err(|e| e.to_string())?;
             return Ok(());
         }
 
-        // 3. 初始化（全新执行）或恢复状态（续跑）
+        // 3. 校验所有步骤的 todo 是否都在同一工作空间下
+        // 环路运行时要求所有环节（step.todo）与 loop 属于同一 workspace，
+        // 否则 cwd/worktree 无法统一，跨空间数据流会导致不可预期的行为。
+        self.check_workspace_consistency(&loop_, &all_steps).await?;
+
+        // 4. 初始化（全新执行）或恢复状态（续跑）
         let is_resume = resume_step_idx.is_some();
         if !is_resume {
             // 全新执行：设置 loop execution 状态
             self.ctx
                 .db
-                .finish_loop_execution(loop_execution_id, "running", 0, 0)
+                .finish_loop_execution(loop_execution_id, "running", 0, 0, None)
                 .await
                 .map_err(|e| e.to_string())?;
             self.clear_finished_at(loop_execution_id).await?;
@@ -363,7 +442,7 @@ impl LoopRunner {
                 info!("loop #{} capped: total_executed={} >= max={}", loop_id, total_executed, max_executions);
                 self.ctx
                     .db
-                    .finish_loop_execution(loop_execution_id, "capped_step", completed, failed)
+                    .finish_loop_execution(loop_execution_id, "capped_step", completed, failed, None)
                     .await
                     .map_err(|e| e.to_string())?;
                 // 触发异常处理 Todo
@@ -379,7 +458,7 @@ impl LoopRunner {
                 );
                 self.ctx
                     .db
-                    .finish_loop_execution(loop_execution_id, "capped_token", completed, failed)
+                    .finish_loop_execution(loop_execution_id, "capped_token", completed, failed, None)
                     .await
                     .map_err(|e| e.to_string())?;
                 // 触发异常处理 Todo
@@ -590,7 +669,7 @@ impl LoopRunner {
         };
         self.ctx
             .db
-            .finish_loop_execution(loop_execution_id, final_status, completed, failed)
+            .finish_loop_execution(loop_execution_id, final_status, completed, failed, None)
             .await
             .map_err(|e| e.to_string())?;
 
@@ -1477,5 +1556,187 @@ mod tests {
         assert!(trigger_on.contains(&"capped_step".to_string()));
         assert!(trigger_on.contains(&"capped_token".to_string()));
         assert!(trigger_on.contains(&"failed".to_string()));
+    }
+
+    // ── 工作空间一致性校验测试 ──
+    // 使用真实 DB 验证 check_workspace_consistency 方法的行为。
+
+    /// 构造最小 LoopRunner 供测试使用。
+    /// 用 `:memory:` 模式创建独立 SQLite 数据库，避免对外部文件依赖。
+    async fn make_test_runner() -> (LoopRunner, Arc<crate::db::Database>) {
+        use crate::adapters::ExecutorRegistry;
+        use crate::config::Config;
+        use crate::service_context::ServiceContext;
+        use crate::task_manager::TaskManager;
+        use std::sync::RwLock;
+        use tokio::sync::broadcast;
+
+        let db = Arc::new(crate::db::Database::new(":memory:").await.unwrap());
+        let (tx, _rx) = broadcast::channel(1);
+        let ctx = ServiceContext {
+            db: db.clone(),
+            executor_registry: Arc::new(ExecutorRegistry::default()),
+            tx,
+            task_manager: Arc::new(TaskManager::default()),
+            config: Arc::new(RwLock::new(Config::default())),
+        };
+        let runner = LoopRunner::new(ctx, broadcast::channel(1).0);
+        (runner, db)
+    }
+
+    /// 辅助：快速创建一个 workspace（project_directory），返回其 id。
+    async fn create_workspace(db: &crate::db::Database, id_suffix: i64) -> i64 {
+        db.create_project_directory(
+            &format!("/tmp/test-workspace-{}", id_suffix),
+            Some(&format!("test-ws-{}", id_suffix)),
+            false,
+            false,
+        )
+        .await
+        .unwrap()
+    }
+
+    /// 校验：所有 step 的 todo 与 loop 在同一工作空间 → 通过。
+    #[tokio::test]
+    async fn test_check_workspace_consistency_all_match() {
+        let (runner, db) = make_test_runner().await;
+        // 创建工作空间
+        let ws_id = create_workspace(&db, 1).await;
+        // 创建两个 todo 都在同一工作空间
+        let todo_a = db.create_todo_with_extras("task A", "do A", None, None, false, ws_id, "/tmp/ws").await.unwrap();
+        let todo_b = db.create_todo_with_extras("task B", "do B", None, None, false, ws_id, "/tmp/ws").await.unwrap();
+        // 创建 loop 属于同一工作空间
+        let loop_model = db.create_loop("test-loop", "", Some(ws_id), Some("/tmp/ws"), false, "loop", None, None, None, "[]").await.unwrap();
+        // 构造步骤列表（使用真实的 step model 但手动构建，无需写入 DB，因为
+        // check_workspace_consistency 只通过 todo_id 查 DB，不查 step 表本身）
+        let steps = vec![
+            loop_steps::Model {
+                id: 1, loop_id: loop_model.id, name: "步骤A".to_string(),
+                description: String::new(), order_index: 0, todo_id: todo_a,
+                run_mode: "sequential".to_string(), skip_on_source_failed: 0,
+                min_rating: None, unrated_policy: "skip".to_string(),
+                on_success: "next".to_string(), success_goto_step_id: None,
+                on_rating_fail: "break".to_string(), fail_goto_step_id: None,
+                review_type: "ai".to_string(), enabled: 1, created_at: None,
+            },
+            loop_steps::Model {
+                id: 2, loop_id: loop_model.id, name: "步骤B".to_string(),
+                description: String::new(), order_index: 1, todo_id: todo_b,
+                run_mode: "sequential".to_string(), skip_on_source_failed: 0,
+                min_rating: None, unrated_policy: "skip".to_string(),
+                on_success: "next".to_string(), success_goto_step_id: None,
+                on_rating_fail: "break".to_string(), fail_goto_step_id: None,
+                review_type: "ai".to_string(), enabled: 1, created_at: None,
+            },
+        ];
+        let result = runner.check_workspace_consistency(&loop_model, &steps).await;
+        assert!(result.is_ok(), "同一工作空间下应通过：{:?}", result.err());
+    }
+
+    /// 校验：step 的 todo 在另一工作空间 → 报错。
+    #[tokio::test]
+    async fn test_check_workspace_consistency_mismatch() {
+        let (runner, db) = make_test_runner().await;
+        let ws1 = create_workspace(&db, 1).await;
+        let ws2 = create_workspace(&db, 2).await;
+        // todo_a 在 ws1，todo_b 在 ws2
+        let todo_a = db.create_todo_with_extras("task A", "do A", None, None, false, ws1, "/tmp/ws1").await.unwrap();
+        let todo_b = db.create_todo_with_extras("task B", "do B", None, None, false, ws2, "/tmp/ws2").await.unwrap();
+        // loop 属于 ws1
+        let loop_model = db.create_loop("test-loop", "", Some(ws1), Some("/tmp/ws1"), false, "loop", None, None, None, "[]").await.unwrap();
+        let steps = vec![
+            loop_steps::Model {
+                id: 1, loop_id: loop_model.id, name: "步骤A".to_string(),
+                description: String::new(), order_index: 0, todo_id: todo_a,
+                run_mode: "sequential".to_string(), skip_on_source_failed: 0,
+                min_rating: None, unrated_policy: "skip".to_string(),
+                on_success: "next".to_string(), success_goto_step_id: None,
+                on_rating_fail: "break".to_string(), fail_goto_step_id: None,
+                review_type: "ai".to_string(), enabled: 1, created_at: None,
+            },
+            loop_steps::Model {
+                id: 2, loop_id: loop_model.id, name: "步骤B".to_string(),
+                description: String::new(), order_index: 1, todo_id: todo_b,
+                run_mode: "sequential".to_string(), skip_on_source_failed: 0,
+                min_rating: None, unrated_policy: "skip".to_string(),
+                on_success: "next".to_string(), success_goto_step_id: None,
+                on_rating_fail: "break".to_string(), fail_goto_step_id: None,
+                review_type: "ai".to_string(), enabled: 1, created_at: None,
+            },
+        ];
+        let result = runner.check_workspace_consistency(&loop_model, &steps).await;
+        assert!(result.is_err(), "跨工作空间应报错");
+        let err_msg = result.unwrap_err();
+        assert!(err_msg.contains("步骤B"), "错误信息应包含跨空间的步骤名");
+        assert!(err_msg.contains("不一致"), "错误信息应提示工作空间不一致");
+    }
+
+    /// 校验：loop 和 todos 都未设置工作空间（workspace_id=0/None）→ 通过。
+    /// 注：todos.workspace_id 列定义 NOT NULL DEFAULT 0，未分配工作空间时为 0；
+    /// loop.workspace_id 可选，未分配时为 None。两者应视为"均未设置"。
+    #[tokio::test]
+    async fn test_check_workspace_consistency_both_unset() {
+        let (runner, db) = make_test_runner().await;
+        // todo_a, todo_b: workspace_id=0（默认值，表示未分配工作空间）
+        let todo_a = db.create_todo_with_executor("task A", "do A", None).await.unwrap();
+        let todo_b = db.create_todo_with_executor("task B", "do B", None).await.unwrap();
+        // loop: workspace_id=None（也视为未分配）
+        let loop_model = db.create_loop("test-loop", "", None, None, false, "loop", None, None, None, "[]").await.unwrap();
+        let steps = vec![
+            loop_steps::Model {
+                id: 1, loop_id: loop_model.id, name: "步骤A".to_string(),
+                description: String::new(), order_index: 0, todo_id: todo_a,
+                run_mode: "sequential".to_string(), skip_on_source_failed: 0,
+                min_rating: None, unrated_policy: "skip".to_string(),
+                on_success: "next".to_string(), success_goto_step_id: None,
+                on_rating_fail: "break".to_string(), fail_goto_step_id: None,
+                review_type: "ai".to_string(), enabled: 1, created_at: None,
+            },
+            loop_steps::Model {
+                id: 2, loop_id: loop_model.id, name: "步骤B".to_string(),
+                description: String::new(), order_index: 1, todo_id: todo_b,
+                run_mode: "sequential".to_string(), skip_on_source_failed: 0,
+                min_rating: None, unrated_policy: "skip".to_string(),
+                on_success: "next".to_string(), success_goto_step_id: None,
+                on_rating_fail: "break".to_string(), fail_goto_step_id: None,
+                review_type: "ai".to_string(), enabled: 1, created_at: None,
+            },
+        ];
+        let result = runner.check_workspace_consistency(&loop_model, &steps).await;
+        // todo.workspace_id=Some(0) vs loop.workspace_id=None 在数据库中分别表示"未分配"，
+        // check_workspace_consistency 会将 0 和 None 统一视为"未设置"，二者等价，应通过。
+        assert!(result.is_ok(), "Some(0) 与 None 均表示未分配工作空间，应视为一致：{:?}", result.err());
+    }
+
+    /// 校验：同一 todo 被多个 step 引用时不会重复检查 → 仍通过。
+    #[tokio::test]
+    async fn test_check_workspace_consistency_duplicate_todo() {
+        let (runner, db) = make_test_runner().await;
+        let ws_id = create_workspace(&db, 1).await;
+        let todo_a = db.create_todo_with_extras("task A", "do A", None, None, false, ws_id, "/tmp/ws").await.unwrap();
+        let loop_model = db.create_loop("test-loop", "", Some(ws_id), Some("/tmp/ws"), false, "loop", None, None, None, "[]").await.unwrap();
+        // 两个 step 引用同一个 todo
+        let steps = vec![
+            loop_steps::Model {
+                id: 1, loop_id: loop_model.id, name: "步骤A-1".to_string(),
+                description: String::new(), order_index: 0, todo_id: todo_a,
+                run_mode: "sequential".to_string(), skip_on_source_failed: 0,
+                min_rating: None, unrated_policy: "skip".to_string(),
+                on_success: "next".to_string(), success_goto_step_id: None,
+                on_rating_fail: "break".to_string(), fail_goto_step_id: None,
+                review_type: "ai".to_string(), enabled: 1, created_at: None,
+            },
+            loop_steps::Model {
+                id: 2, loop_id: loop_model.id, name: "步骤A-2".to_string(),
+                description: String::new(), order_index: 1, todo_id: todo_a,
+                run_mode: "sequential".to_string(), skip_on_source_failed: 0,
+                min_rating: None, unrated_policy: "skip".to_string(),
+                on_success: "next".to_string(), success_goto_step_id: None,
+                on_rating_fail: "break".to_string(), fail_goto_step_id: None,
+                review_type: "ai".to_string(), enabled: 1, created_at: None,
+            },
+        ];
+        let result = runner.check_workspace_consistency(&loop_model, &steps).await;
+        assert!(result.is_ok(), "重复引用同一 todo 应通过：{:?}", result.err());
     }
 }

--- a/frontend/src/components/LoopStudioExecutionsPanel.tsx
+++ b/frontend/src/components/LoopStudioExecutionsPanel.tsx
@@ -295,6 +295,19 @@ export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange
                       耗时 {durationLabel(e.started_at, e.finished_at)}
                     </span>
                   </div>
+                  {/* 第三行：错误说明（仅在 status=failed 且有 error_message 时显示） */}
+                  {e.status === 'failed' && e.error_message && (
+                    <div style={{
+                      marginTop: 6, padding: '4px 8px',
+                      background: 'var(--color-error-bg, #fff1f0)',
+                      border: '1px solid var(--color-error-border, #ffccc7)',
+                      borderRadius: 4,
+                      fontSize: 12, color: 'var(--color-error-text, #cf1322)',
+                      lineHeight: 1.5, whiteSpace: 'pre-wrap',
+                    }}>
+                      {e.error_message}
+                    </div>
+                  )}
                 </div>
                 {expanded && (
                   <div className="loop-exec-row-detail" style={{

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -79,6 +79,8 @@ export interface LoopExecutionDto {
   pending_approval_count: number;
   /** 该次执行的 Token 消耗汇总（从 step_executions 的 usage 聚合计算） */
   token_summary?: LoopExecutionTokenSummary;
+  /** 执行失败时的错误说明（仅在 status=failed 时有值） */
+  error_message?: string | null;
 }
 
 export interface LoopStepExecutionDto {


### PR DESCRIPTION
## 背景

环路运行时要求所有环节（step.todo）与 loop 属于同一 workspace，否则 cwd/worktree 无法统一，跨空间数据流会导致不可预期的行为。

## 改动

### 工作空间校验（核心逻辑）

在 `run_inner_from` 的步骤 2（加载步骤列表）之后、步骤 3（初始化）之前，新增工作空间一致性校验：

- 加载每个 step.todo 的 `workspace_id`
- 与 loop 的 `workspace_id` 比较
- 特殊处理：`Some(0)`（todos 的 NOT NULL DEFAULT）与 `None`（loop 可选字段）均视为未分配，语义等价
- 发现不一致时返回错误，指出具体哪些环节不匹配

### 错误信息可见性

之前校验失败只在后台日志有记录，前端看不到任何信息。本次做了完整链路：

| 改动 | 文件 |
|------|------|
| V36 迁移：`error_message TEXT` 列 | `backend/src/db/migration.rs` |
| 实体模型新增字段 | `backend/src/db/entity/loop_executions.rs` |
| `finish_loop_execution` 增加 error_message 参数 | `backend/src/db/loop_.rs` |
| 错误处理器透传错误信息 + 补发 WebSocket 事件 | `backend/src/services/loop_runner.rs` |
| DTO 透传 error_message | `backend/src/models/loop_.rs` |
| 前端类型定义 | `frontend/src/types/loop.ts` |
| 前端红色错误提示框 | `frontend/src/components/LoopStudioExecutionsPanel.tsx` |

### 单元测试（4 个）

| 测试 | 场景 |
|------|------|
| `test_check_workspace_consistency_all_match` | 所有 todo 与 loop 同工作空间 → 通过 |
| `test_check_workspace_consistency_mismatch` | 某 todo 在不同工作空间 → 报错 |
| `test_check_workspace_consistency_both_unset` | 双方均未分配（`Some(0)` vs `None`）→ 视为一致 |
| `test_check_workspace_consistency_duplicate_todo` | 同一 todo 被多个 step 引用 → 去重检查，通过 |

### 其他修复

- `backend/src/handlers/todo.rs`：`finished_at` 字段不存在导致的编译错误（预存）
- `backend/src/db/mod.rs`：`ExecutionRecordQuery` 缺少 `hours` 字段导致的编译错误（预存）

Closes #(issue)