### PR TITLE
fix: 修复时间过滤 SQL 中 ISO 8601 格式与 SQLite datetime() 格式不匹配

### DIFF
--- a/backend/src/db/dashboard.rs
+++ b/backend/src/db/dashboard.rs
@@ -279,7 +279,7 @@ pub(super) async fn fetch_execution_overall(
         COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN json_extract(usage, '$.duration_ms') ELSE 0 END), 0) as total_duration, \
         COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN 1 ELSE 0 END), 0) as duration_count \
         FROM execution_records \
-        WHERE started_at >= {}",
+        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {}",
         ctx.time_filter
     );
 
@@ -341,7 +341,7 @@ pub(super) async fn fetch_executor_distribution(
         COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
         COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
         FROM execution_records \
-        WHERE started_at >= {} \
+        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} \
         GROUP BY COALESCE(executor, 'claudecode')",
         ctx.time_filter
     );
@@ -391,7 +391,7 @@ pub(super) async fn fetch_model_distribution(
         COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
         COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
         FROM execution_records \
-        WHERE started_at >= {} \
+        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} \
         GROUP BY COALESCE(model, 'unknown')",
         ctx.time_filter
     );
@@ -440,7 +440,7 @@ pub(super) async fn fetch_trigger_distribution(
         COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
         COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count \
         FROM execution_records \
-        WHERE started_at >= {} \
+        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} \
         GROUP BY COALESCE(trigger_type, 'manual')",
         ctx.time_filter
     );
@@ -476,7 +476,7 @@ pub(super) async fn fetch_executor_durations(
         ROUND(AVG(json_extract(usage, '$.duration_ms')), 0) as avg_duration, \
         COUNT(*) as execution_count \
         FROM execution_records \
-        WHERE started_at >= {} AND json_extract(usage, '$.duration_ms') IS NOT NULL \
+        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} AND json_extract(usage, '$.duration_ms') IS NOT NULL \
         GROUP BY COALESCE(executor, 'claudecode')",
         ctx.time_filter
     );
@@ -510,7 +510,7 @@ pub(super) async fn fetch_model_cache_stats(
         COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
         COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read \
         FROM execution_records \
-        WHERE started_at >= {} AND model IS NOT NULL \
+        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} AND model IS NOT NULL \
         GROUP BY COALESCE(model, 'unknown')",
         ctx.time_filter
     );
@@ -554,7 +554,7 @@ pub(super) async fn fetch_daily_stats(
         COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
         COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
         FROM execution_records \
-        WHERE started_at IS NOT NULL AND LENGTH(started_at) >= 10 AND started_at >= {} \
+        WHERE started_at IS NOT NULL AND LENGTH(started_at) >= 10 AND REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} \
         GROUP BY SUBSTR(started_at, 1, 10) \
         ORDER BY day DESC \
         LIMIT {}",
@@ -613,7 +613,7 @@ pub(super) async fn fetch_tag_distribution(
         COALESCE(SUM(COALESCE(json_extract(er.usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
         FROM execution_records er \
         INNER JOIN todo_tags tt ON tt.todo_id = er.todo_id \
-        WHERE er.todo_id IS NOT NULL AND er.started_at >= {} \
+        WHERE er.todo_id IS NOT NULL AND REPLACE(REPLACE(er.started_at, 'T', ' '), 'Z', '') >= {} \
         GROUP BY tt.tag_id",
         ctx.time_filter
     );
@@ -667,7 +667,7 @@ pub(super) async fn fetch_recent_executions(
 ) -> Result<Vec<ExecutionRecord>, sea_orm::DbErr> {
     let sql = format!(
         "SELECT id, todo_id, executor, trigger_type, status, started_at, finished_at, usage, task_id, session_id, result, resume_message FROM execution_records \
-        WHERE started_at >= {} \
+        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} \
         ORDER BY started_at DESC LIMIT 10",
         ctx.time_filter
     );

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -148,7 +148,7 @@ impl Database {
         use sea_orm::Condition;
         let filter = if let Some(h) = query.hours.filter(|&h| h > 0) {
             let time_expr = sea_orm::sea_query::Expr::cust(&format!(
-                "started_at >= datetime('now', '-{} hours')", h
+                "REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= datetime('now', '-{} hours')", h
             ));
             filter.add(time_expr)
         } else {

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -759,7 +759,7 @@ impl Database {
             .order_by_desc(loop_executions::Column::StartedAt);
         if let Some(h) = hours.filter(|&h| h > 0) {
             let time_expr = sea_orm::sea_query::Expr::cust(&format!(
-                "started_at >= datetime('now', '-{} hours')", h
+                "REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= datetime('now', '-{} hours')", h
             ));
             query = query.filter(time_expr);
         }

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -1033,7 +1033,7 @@ impl Database {
         let mut conditions = vec![
             "t.deleted_at IS NULL".to_string(),
             "t.status IN ('completed', 'failed')".to_string(),
-            format!("er.finished_at >= {}", time_filter),
+            format!("REPLACE(REPLACE(er.finished_at, 'T', ' '), 'Z', '') >= {}", time_filter),
         ];
         // 按 workspace_id 过滤：仅显示该工作空间下的事项
         if let Some(wid) = workspace_id {


### PR DESCRIPTION
## 问题描述

**结论视图**（Memorial Board）请求 `/api/todos/recent-completed?hours=6&workspace_id=1` 时，返回了 3 条数据，但最近 6 小时内实际只有 1 条。

## 根因

数据库中的 `started_at` / `finished_at` 以 ISO 8601 格式存储（`2026-06-27T14:45:33.235Z`，T 分隔符 + Z 后缀），而 SQLite 的 `datetime('now')` 返回空格分隔格式（`2026-06-27 17:53:00`）。字符串比较时 `T` (ASCII 84) > `空格` (ASCII 32)，导致所有记录都通过 `>=` 过滤条件，**时间范围过滤完全失效**。

## 修复

用 `REPLACE(REPLACE(col, 'T', ' '), 'Z', '')` 将存储的 ISO 8601 格式归一化为空格分隔格式后再比较。

## 影响范围（4 文件，12 处 SQL）

| 文件 | 修改处 | 影响 |
|---|---|---|
| `backend/src/db/todo.rs` | 1 | 结论视图（recent-completed API） |
| `backend/src/db/dashboard.rs` | 9 | 仪表盘全部统计 |
| `backend/src/db/execution.rs` | 1 | 执行记录按时间查询 |
| `backend/src/db/loop_.rs` | 1 | 环路执行按时间查询 |

## 验证

修复后 SQL 查询返回正确的 1 条（todo_id=1），而非之前的 3 条。