### PR TITLE
fix: feishu_messages建表补全processed_id/processed_type/workspace_id列

### DIFF
--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -375,6 +375,10 @@ async fn create_feishu_messages(db: &Database) -> Result<(), sea_orm::DbErr> {
             is_history INTEGER DEFAULT 0,
             fetch_time TEXT,
             created_at TEXT,
+            execution_record_id INTEGER,
+            workspace_id INTEGER,
+            processed_id INTEGER,
+            processed_type TEXT,
             FOREIGN KEY (bot_id) REFERENCES agent_bots(id) ON DELETE CASCADE
         )",
     )


### PR DESCRIPTION
## 概述

V1 建表  缺少 、、 列，导致：

- 消息历史记录加载失败
-  字段无法写入

## 修复

在  建表语句中补全这三列。

## 验证

- 飞书机器人连接正常
- 消息历史记录加载正常