### PR TITLE
refactor: 将运行管理/会话合并到执行器页面为Tab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,9 +15,7 @@ import { Dashboard } from './components/Dashboard';
 import { MemorialBoard } from './components/MemorialBoard';
 import { SettingsPage } from './components/SettingsPage';
 import { SkillsPanel } from './components/SkillsPanel';
-import { SessionManager } from './components/SessionManager';
 import { ProjectDirectoriesPanel } from './components/settings/ProjectDirectoriesPanel';
-import { RuntimePanel } from './components/settings/RuntimePanel';
 import { ExecutorsPanel } from './components/settings/ExecutorsPanel';
 import { ExecutionPanel } from './components/ExecutionPanel';
 import { TodoDrawer } from './components/TodoDrawer';
@@ -27,7 +25,7 @@ import { LeftRail, type LeftRailKey } from './components/shell/LeftRail';
 
 import { EXECUTION_PANEL, LEFT_RAIL_WIDTH } from './constants';
 import * as db from './utils/database';
-import type { Config, ExecutorConfig } from './types';
+import type { Config } from './types';
 import zhCN from 'antd/locale/zh_CN';
 import './App.css';
 
@@ -99,20 +97,6 @@ function AppContent() {
     db.getConfig().then(setAppConfig).catch(() => {});
   }, []);
 
-  // 执行器列表供 RuntimePanel 的 executorDisplayNames 使用
-  const [runtimeExecutors, setRuntimeExecutors] = useState<ExecutorConfig[]>([]);
-
-  useEffect(() => {
-    db.getExecutors().then(setRuntimeExecutors).catch(() => {});
-  }, []);
-
-  const runtimeExecutorDisplayNames = useMemo(() => {
-    const map: Record<string, string> = {};
-    for (const ec of runtimeExecutors) {
-      map[ec.name] = ec.display_name;
-    }
-    return map;
-  }, [runtimeExecutors]);
 
   // URL → React state 恢复（首次加载完成后执行）
   useEffect(() => {
@@ -250,10 +234,6 @@ function AppContent() {
       showStandaloneSettingsPanel('projectDirectories');
       return;
     }
-    if (key === 'settings_sessions') {
-      showStandaloneSettingsPanel('sessions');
-      return;
-    }
     if (key === 'settings_skills') {
       showStandaloneSettingsPanel('skills');
       return;
@@ -262,7 +242,6 @@ function AppContent() {
       showStandaloneSettingsPanel('executors');
       return;
     }
-    showStandaloneSettingsPanel('runtime');
   }, [handleShowView, showListSection, showSettings, showStandaloneSettingsPanel]);
 
   // FAB backdrop click to collapse
@@ -473,16 +452,10 @@ function AppContent() {
                 overflow: 'hidden',
               }}
             >
-              {activeView === 'runtime' ? (
-                <RuntimePanel
-                  executorDisplayNames={runtimeExecutorDisplayNames}
-                />
-              ) : activeView === 'skills' ? (
+              {activeView === 'skills' ? (
                 <SkillsPanel />
               ) : activeView === 'projectDirectories' ? (
                 <ProjectDirectoriesPanel />
-              ) : activeView === 'sessions' ? (
-                <SessionManager />
               ) : activeView === 'executors' ? (
                 <ExecutorsPanel />
               ) : activeView === 'settings' ? (

--- a/frontend/src/components/SessionManager.tsx
+++ b/frontend/src/components/SessionManager.tsx
@@ -14,7 +14,12 @@ import { sourceTag, formatTokens, formatTime, shortId, sourceConfig } from './se
 
 const { Text } = Typography;
 
-export function SessionManager() {
+interface SessionManagerProps {
+  /** 为 true 时不渲染 PageCard 外层包装，用于嵌入到其他页面中 */
+  embedded?: boolean;
+}
+
+export function SessionManager({ embedded }: SessionManagerProps) {
   const [sessions, setSessions] = useState<SessionInfo[]>([]);
   const [stats, setStats] = useState<SessionStats | null>(null);
   const [loading, setLoading] = useState(false);
@@ -101,10 +106,9 @@ export function SessionManager() {
     )},
   ];
 
-  return (
-    <PageCard icon={<LaptopOutlined />} title="会话">
-      <div>
-        <StatsCards stats={stats} />
+  const content = (
+    <div>
+      <StatsCards stats={stats} />
 
       <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
         <Input placeholder="搜索 Prompt 内容..." prefix={<SearchOutlined />} value={searchText} onChange={(e) => { setSearchText(e.target.value); setPage(1); }} style={{ width: 220 }} allowClear />
@@ -125,7 +129,16 @@ export function SessionManager() {
       />
 
       <SessionDetailDrawer sessionId={selectedSessionId} open={drawerOpen} onClose={() => { setDrawerOpen(false); setSelectedSessionId(null); }} />
-        </div>
-      </PageCard>
+    </div>
+  );
+
+  if (embedded) {
+    return content;
+  }
+
+  return (
+    <PageCard icon={<LaptopOutlined />} title="会话">
+      {content}
+    </PageCard>
     );
 }

--- a/frontend/src/components/settings/ExecutorsPanel.tsx
+++ b/frontend/src/components/settings/ExecutorsPanel.tsx
@@ -1,13 +1,15 @@
-import { useState, useEffect, useRef } from 'react';
-import { Button, Card, Input, Switch, Spin, Tooltip, Modal, message, Typography, InputNumber, Form, Table, Space, Empty } from 'antd';
-import { SearchOutlined, PlayCircleOutlined, ClockCircleOutlined, BugOutlined, CodeOutlined, InfoCircleOutlined, SaveOutlined } from '@ant-design/icons';
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { Button, Card, Input, Switch, Spin, Tooltip, Modal, message, Typography, InputNumber, Form, Table, Space, Empty, Tabs, Popconfirm } from 'antd';
+import { SearchOutlined, PlayCircleOutlined, ClockCircleOutlined, BugOutlined, CodeOutlined, InfoCircleOutlined, SaveOutlined, StopOutlined, ReloadOutlined } from '@ant-design/icons';
 import { Cron } from 'react-js-cron';
 import 'react-js-cron/dist/styles.css';
 import { CronPresetSelect } from '@/components/CronPresetSelect';
 import { CRON_ZH_LOCALE, cronTo5, cronTo6 } from '@/utils/cron';
 import { PageCard } from '@/components/common/PageCard';
 import * as db from '@/utils/database';
-import type { ExecutorConfig } from '@/types';
+import type { ExecutorConfig, ExecutionRecord } from '@/types';
+import { useApp } from '@/hooks/useApp';
+import { SessionManager } from '@/components/SessionManager';
 
 import { DEFAULT_EXECUTION_TIMEOUT_SECS, MAX_EXECUTION_TIMEOUT_MINUTES } from '@/constants';
 
@@ -57,11 +59,64 @@ export function ExecutorsPanel() {
   const [usageStatsLoading, setUsageStatsLoading] = useState(false);
   const [usageStatsSaving, setUsageStatsSaving] = useState(false);
 
+  // 正在运行 tab 相关状态
+  const { state } = useApp();
+  const { todos } = state;
+  const [runningTab, setRunningTab] = useState<'executors' | 'running' | 'sessions'>('executors');
+  const [selectedRecordIds, setSelectedRecordIds] = useState<number[]>([]);
+  const [stoppingRecords, setStoppingRecords] = useState(false);
+  const [runningRecords, setRunningRecords] = useState<ExecutionRecord[]>([]);
+
   useEffect(() => {
     loadExecutors();
     loadConfig();
     loadUsageStatsSettings();
   }, []);
+
+  // 正在运行 tab：加载运行中记录
+  const loadRunningRecords = async () => {
+    try {
+      const records = await db.getRunningExecutionRecords();
+      setRunningRecords(records);
+    } catch (err) {
+      console.error('加载运行中任务失败:', err);
+    }
+  };
+
+  useEffect(() => {
+    if (runningTab === 'running') {
+      loadRunningRecords();
+      const timer = setInterval(loadRunningRecords, 10000);
+      return () => clearInterval(timer);
+    }
+  }, [runningTab]);
+
+  // 正在运行 tab：批量停止
+  const handleBatchStop = async () => {
+    if (selectedRecordIds.length === 0) return;
+    setStoppingRecords(true);
+    const results = await Promise.allSettled(
+      selectedRecordIds.map(async (recordId) => {
+        await db.forceFailExecution(recordId);
+      })
+    );
+    const successCount = results.filter(r => r.status === 'fulfilled').length;
+    const failCount = results.filter(r => r.status === 'rejected').length;
+    setSelectedRecordIds([]);
+    setStoppingRecords(false);
+    if (successCount > 0) message.success(`已停止 ${successCount} 个任务`);
+    if (failCount > 0) message.error(`${failCount} 个任务停止失败`);
+    loadRunningRecords();
+  };
+
+  // 执行器 display_name 映射（供正在运行 tab 使用）
+  const executorDisplayNames = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const ec of executors) {
+      map[ec.name] = ec.display_name;
+    }
+    return map;
+  }, [executors]);
 
   /** 加载应用配置（并发数、超时等）。 */
   const loadConfig = async () => {
@@ -145,8 +200,16 @@ export function ExecutorsPanel() {
 
   return (
     <PageCard icon={<CodeOutlined />} title="执行器">
-      <Spin spinning={executorsLoading}>
-        <div style={{ maxWidth: 1000 }}>
+      <Tabs
+        activeKey={runningTab}
+        onChange={(key) => setRunningTab(key as 'executors' | 'running')}
+        items={[
+          {
+            key: 'executors',
+            label: '执行器',
+            children: (
+              <Spin spinning={executorsLoading}>
+                <div style={{ maxWidth: 1000 }}>
         <Paragraph type="secondary" style={{ marginBottom: 16 }}>
           管理执行器的路径、开关状态，并检测二进制是否可用。关闭开关的执行器不会出现在 Todo 的执行器选择列表中。
         </Paragraph>
@@ -526,45 +589,151 @@ export function ExecutorsPanel() {
             </div>
           )}
         </Card>
-      </div>
-      <Modal
-        title={testModalData ? `测试结果 - ${executors.find(e => e.name === testModalData.name)?.display_name || testModalData.name}` : '测试结果'}
-        open={testModalVisible}
-        onCancel={() => setTestModalVisible(false)}
-        footer={<Button onClick={() => setTestModalVisible(false)}>关闭</Button>}
-        width={500}
-      >
-        {testModalData && (
-          <div>
-            <p>
-              状态：{testModalData.result.test_passed
-                ? <span style={{ color: '#52c41a', fontWeight: 600 }}>通过</span>
-                : <span style={{ color: '#ff4d4f', fontWeight: 600 }}>失败</span>
-              }
-            </p>
-            {testModalData.result.error && (
-              <p style={{ color: '#ff4d4f' }}>错误：{testModalData.result.error}</p>
-            )}
-            {testModalData.result.output && (
-              <div>
-                <Paragraph type="secondary">输出：</Paragraph>
-                <pre style={{
-                  background: '#f5f5f5',
-                  padding: 12,
-                  borderRadius: 6,
-                  fontSize: 12,
-                  maxHeight: 300,
-                  overflow: 'auto',
-                  whiteSpace: 'pre-wrap',
-                }}>
-                  {testModalData.result.output}
-                </pre>
+            {/* 执行器检测/修复结果 Modal */}
+            <Modal
+              title={testModalData ? `测试结果 - ${executors.find(e => e.name === testModalData.name)?.display_name || testModalData.name}` : '测试结果'}
+              open={testModalVisible}
+              onCancel={() => setTestModalVisible(false)}
+              footer={<Button onClick={() => setTestModalVisible(false)}>关闭</Button>}
+              width={500}
+            >
+              {testModalData && (
+                <div>
+                  <p>
+                    状态：{testModalData.result.test_passed
+                      ? <span style={{ color: '#52c41a', fontWeight: 600 }}>通过</span>
+                      : <span style={{ color: '#ff4d4f', fontWeight: 600 }}>失败</span>
+                    }
+                  </p>
+                  {testModalData.result.error && (
+                    <p style={{ color: '#ff4d4f' }}>错误：{testModalData.result.error}</p>
+                  )}
+                  {testModalData.result.output && (
+                    <div>
+                      <Paragraph type="secondary">输出：</Paragraph>
+                      <pre style={{
+                        background: '#f5f5f5',
+                        padding: 12,
+                        borderRadius: 6,
+                        fontSize: 12,
+                        maxHeight: 300,
+                        overflow: 'auto',
+                        whiteSpace: 'pre-wrap',
+                      }}>
+                        {testModalData.result.output}
+                      </pre>
+                    </div>
+                  )}
+                </div>
+              )}
+            </Modal>
               </div>
-            )}
-          </div>
-        )}
-      </Modal>
-      </Spin>
+            </Spin>
+          ),
+        },
+        {
+          key: 'running',
+          label: '正在运行',
+          children: (
+            <div style={{ padding: '8px 0' }}>
+              <div style={{ marginBottom: 12, display: 'flex', alignItems: 'center', gap: 8 }}>
+                <Button
+                  danger
+                  size="small"
+                  icon={<StopOutlined />}
+                  disabled={selectedRecordIds.length === 0}
+                  loading={stoppingRecords}
+                  onClick={handleBatchStop}
+                >
+                  批量停止 ({selectedRecordIds.length})
+                </Button>
+                <Button
+                  size="small"
+                  icon={<ReloadOutlined />}
+                  onClick={loadRunningRecords}
+                >
+                  刷新
+                </Button>
+                <span style={{ color: 'var(--color-text-secondary)', fontSize: 12 }}>
+                  共 {runningRecords.length} 个运行中任务
+                </span>
+              </div>
+              <Table
+                size="small"
+                rowKey="id"
+                dataSource={runningRecords}
+                rowSelection={{
+                  selectedRowKeys: selectedRecordIds,
+                  onChange: (keys) => setSelectedRecordIds(keys as number[]),
+                }}
+                pagination={false}
+                columns={[
+                  {
+                    title: 'Todo',
+                    key: 'todo_title',
+                    ellipsis: true,
+                    render: (_: unknown, record: ExecutionRecord) => {
+                      const todo = todos.find(t => t.id === record.todo_id);
+                      return todo ? todo.title : `#${record.todo_id}`;
+                    },
+                  },
+                  {
+                    title: '执行器',
+                    dataIndex: 'executor',
+                    key: 'executor',
+                    width: 110,
+                    render: (v: string | null) => {
+                      return executorDisplayNames[v || ''] || v || '-';
+                    },
+                  },
+                  {
+                    title: '触发方式',
+                    dataIndex: 'trigger_type',
+                    key: 'trigger_type',
+                    width: 100,
+                    render: (v: string) => {
+                      const map: Record<string, string> = { manual: '手动', slash_command: '斜杠命令', default_response: '默认响应', scheduler: '定时' };
+                      return map[v] || v;
+                    },
+                  },
+                  {
+                    title: '开始时间',
+                    dataIndex: 'started_at',
+                    key: 'started_at',
+                    width: 170,
+                    render: (v: string) => v ? new Date(v).toLocaleString() : '-',
+                  },
+                  {
+                    title: '操作',
+                    key: 'action',
+                    width: 80,
+                    render: (_: unknown, record: ExecutionRecord) => (
+                      <Popconfirm title="确认停止此任务？" onConfirm={async () => {
+                        try {
+                          await db.forceFailExecution(record.id);
+                          message.success('已停止');
+                          loadRunningRecords();
+                        } catch (err) { message.error(`停止失败: ${err instanceof Error ? err.message : String(err)}`); }
+                      }}>
+                        <Button type="text" size="small" icon={<StopOutlined />} />
+                      </Popconfirm>
+                    ),
+                  },
+                ]}
+                locale={{ emptyText: <Empty description="暂无运行中任务" image={Empty.PRESENTED_IMAGE_SIMPLE} /> }}
+              />
+            </div>
+          ),
+        },
+        {
+          key: 'sessions',
+          label: '会话',
+          children: (
+            <SessionManager embedded />
+          ),
+        },
+      ]}
+      />
     </PageCard>
   );
 }

--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -8,9 +8,7 @@ import {
   DashboardOutlined,
   ReadOutlined,
   SettingOutlined,
-  LaptopOutlined,
   ThunderboltOutlined,
-  PlayCircleOutlined,
   FolderOutlined,
   CodeOutlined,
   DoubleRightOutlined,
@@ -29,7 +27,6 @@ export type LeftRailKey =
   | 'settings_projectDirectories'
   | 'settings_sessions'
   | 'settings_skills'
-  | 'settings_runtime'
   | 'settings_executors';
 
 interface LeftRailItem {
@@ -83,11 +80,9 @@ export function LeftRail({
     {
       title: '配置',
       items: [
-        { key: 'settings_runtime', label: '运行管理', icon: <PlayCircleOutlined />, ariaLabel: '运行管理' },
         { key: 'settings_executors', label: '执行器', icon: <CodeOutlined />, ariaLabel: '执行器' },
         { key: 'settings_skills', label: 'Skills', icon: <ThunderboltOutlined />, ariaLabel: 'Skills' },
         { key: 'settings_projectDirectories', label: '工作空间', icon: <FolderOutlined />, ariaLabel: '工作空间' },
-        { key: 'settings_sessions', label: '会话', icon: <LaptopOutlined />, ariaLabel: '会话' },
         { key: 'settings', label: '设置', icon: <SettingOutlined />, ariaLabel: '设置' },
       ] satisfies LeftRailItem[],
     },

--- a/frontend/tests/verify_executor_tabs.spec.ts
+++ b/frontend/tests/verify_executor_tabs.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * 验证执行器页面改造：
+ * 1. 执行器页面有三个 tab：执行器 / 正在运行 / 会话
+ * 2. 左侧菜单已移除"运行管理"和"会话"菜单项
+ */
+test('执行器页面有执行器/正在运行/会话三个tab', async ({ page }) => {
+  await page.goto('http://localhost:18088');
+  await page.waitForLoadState('networkidle');
+
+  // 点击左侧"执行器"菜单
+  await page.click('[data-testid="left-rail-settings_executors"]');
+  await page.waitForTimeout(800);
+
+  // 验证有三个 tab
+  const tabExecutors = page.locator('.ant-tabs-tab').filter({ hasText: '执行器' });
+  const tabRunning = page.locator('.ant-tabs-tab').filter({ hasText: '正在运行' });
+  const tabSessions = page.locator('.ant-tabs-tab').filter({ hasText: '会话' });
+
+  await expect(tabExecutors).toBeVisible();
+  await expect(tabRunning).toBeVisible();
+  await expect(tabSessions).toBeVisible();
+
+  // 点击"正在运行" tab
+  await tabRunning.click();
+  await page.waitForTimeout(500);
+  await expect(page.locator('text=刷新')).toBeVisible();
+  await expect(page.locator('text=批量停止')).toBeVisible();
+
+  // 点击"会话" tab
+  await tabSessions.click();
+  await page.waitForTimeout(500);
+  // 会话 tab 有 StatsCards 和搜索框
+  await expect(page.locator('input[placeholder*="搜索"]')).toBeVisible();
+
+  console.log('✓ 执行器页面 Tab 切换正常');
+});
+
+test('左侧菜单已移除运行管理和会话', async ({ page }) => {
+  await page.goto('http://localhost:18088');
+  await page.waitForLoadState('networkidle');
+
+  // 展开左侧菜单
+  const toggleBtn = page.locator('[data-testid="left-rail-toggle"]');
+  if (await toggleBtn.isVisible()) {
+    await toggleBtn.click();
+    await page.waitForTimeout(300);
+  }
+
+  // 确认"运行管理"菜单项不存在
+  const runtimeMenu = page.locator('[data-testid="left-rail-settings_runtime"]');
+  await expect(runtimeMenu).toHaveCount(0);
+
+  // 确认"会话"菜单项不存在
+  const sessionsMenu = page.locator('[data-testid="left-rail-settings_sessions"]');
+  await expect(sessionsMenu).toHaveCount(0);
+
+  // 确认"执行器"菜单项仍然存在
+  const executorMenu = page.locator('[data-testid="left-rail-settings_executors"]');
+  await expect(executorMenu).toBeVisible();
+
+  console.log('✓ 运行管理和会话菜单已移除，执行器菜单保留');
+});


### PR DESCRIPTION
## 改动内容

- 左侧菜单移除"运行管理"和"会话"两个菜单项
- 执行器页面增加三个 Tab：**执行器** / **正在运行** / **会话**
- RuntimePanel 内容合并为"正在运行" Tab
- SessionManager 增加  模式用于嵌入，移除重复的 PageCard 外壳
- 清理 App.tsx 中不再需要的 RuntimePanel 相关代码

## 验证

- [x] 编译通过
- [x] Playwright 自动化测试通过（执行器三 Tab 切换、左侧菜单验证）

## 影响范围

-  - 移除 RuntimePanel 渲染逻辑
-  - 增加 embedded 模式
-  - 增加 Tab 承载运行时和会话
-  - 移除两个菜单项
-  - 新增自动化测试