### PR TITLE
feat: add Kilo as a new executor (similar to Opencode/Zhanlu)

### DIFF
--- a/backend/src/adapters/kilo.rs
+++ b/backend/src/adapters/kilo.rs
@@ -1,0 +1,399 @@
+use std::sync::Arc;
+use parking_lot::Mutex;
+
+use super::helpers;
+use super::kilo_event::KiloAgentEvent;
+use super::{BaseExecutor, CodeExecutor, ExecutorType, ParsedLogEntry};
+use crate::adapters::ExecutionUsage;
+use crate::models::utc_timestamp;
+
+/// Kilo executor。
+///
+/// 与 Opencode/Zhanlu 完全等价：相同的命令行参数、相同的 JSON 输出格式、相同的退出码语义。
+/// Kilo 作为另一个开源 AI 编程执行器，通过 `BaseExecutor` 持有 path + model + usage 三件套，
+/// 额外的 `has_successful_finish` 用于「非零退出码但有 finish 事件就算成功」语义。
+#[derive(Clone)]
+pub struct KiloExecutor {
+    base: BaseExecutor,
+    has_successful_finish: Arc<Mutex<bool>>,
+}
+
+impl KiloExecutor {
+    pub fn new(path: String) -> Self {
+        Self {
+            base: BaseExecutor::new(path),
+            has_successful_finish: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    /// 把 Kilo 时间戳（毫秒）转换为 ISO 字符串；缺失时回退到 utc_timestamp。
+    fn resolve_timestamp(ts: Option<u64>) -> String {
+        ts.and_then(|ts| chrono::DateTime::from_timestamp_millis(ts as i64))
+            .map(|dt| dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
+            .unwrap_or_else(utc_timestamp)
+    }
+
+    /// step_start / step-start: 重置 has_successful_finish + usage。
+    fn handle_step_start(&self, timestamp: &str) -> Option<ParsedLogEntry> {
+        *self.has_successful_finish.lock() = false;
+        *self.base.usage.lock() = None;
+        Some(helpers::with_timestamp(helpers::entry("step_start", "Step started"), timestamp))
+    }
+
+    /// tool_use / tool-use: bash 工具显示 description + output，其它工具显示 tool + description。
+    fn handle_tool_use(
+        &self,
+        part: &super::kilo_event::KiloAgentPart,
+        timestamp: &str,
+    ) -> Option<ParsedLogEntry> {
+        let tool = part.tool.clone().unwrap_or_default();
+        let status = part.state.as_ref().and_then(|s| s.status.clone()).unwrap_or_default();
+        let description = part.state.as_ref().and_then(|s| s.input.as_ref().and_then(|i| i.description.clone())).unwrap_or_default();
+        let input_json = part.state.as_ref()
+            .and_then(|s| s.input.as_ref())
+            .map(|i| i.to_full_json());
+
+        let content = if tool == "bash" {
+            match &part.state.as_ref().and_then(|s| s.output.clone()) {
+                Some(output) => format!("[{}] {}: {}", status, description, output),
+                None => format!("[{}] {}", status, description),
+            }
+        } else {
+            format!("[{}] Tool: {} - {}", status, tool, description)
+        };
+
+        Some(helpers::with_timestamp(
+            helpers::entry_with_optional_tool("tool", content, Some(tool), input_json),
+            timestamp,
+        ))
+    }
+
+    /// text: 空文本返回 None，否则返回 text 日志。
+    fn handle_text(
+        &self,
+        part: &super::kilo_event::KiloAgentPart,
+        timestamp: &str,
+    ) -> Option<ParsedLogEntry> {
+        let text = part.text.clone().unwrap_or_default();
+        if text.is_empty() {
+            return None;
+        }
+        Some(helpers::with_timestamp(helpers::text_entry(text), timestamp))
+    }
+
+    /// step_finish / step-finish: 标记 has_successful_finish，从 tokens 提取 usage。
+    fn handle_step_finish(
+        &self,
+        event: &KiloAgentEvent,
+        timestamp: &str,
+    ) -> Option<ParsedLogEntry> {
+        *self.has_successful_finish.lock() = true;
+        if let Some(part) = &event.part {
+            if let Some(tokens) = &part.tokens {
+                *self.base.usage.lock() = Some(ExecutionUsage {
+                    input_tokens: tokens.input,
+                    output_tokens: tokens.output,
+                    cache_read_input_tokens: if tokens.cache.read > 0 { Some(tokens.cache.read) } else { None },
+                    cache_creation_input_tokens: if tokens.cache.write > 0 { Some(tokens.cache.write) } else { None },
+                    total_cost_usd: part.cost,
+                    duration_ms: None,
+                });
+            }
+        }
+        Some(helpers::with_timestamp(helpers::entry("step_finish", "Step finished"), timestamp))
+    }
+}
+
+impl CodeExecutor for KiloExecutor {
+    fn executor_type(&self) -> ExecutorType {
+        ExecutorType::Kilo
+    }
+
+    fn executable_path(&self) -> &str {
+        &self.base.path
+    }
+
+    fn command_args(&self, message: &str) -> Vec<String> {
+        vec![
+            "run".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+            "--dangerously-skip-permissions".to_string(),
+            message.to_string(),
+        ]
+    }
+
+    fn command_args_with_session(&self, message: &str, session_id: Option<&str>, is_resume: bool) -> Vec<String> {
+        let mut args = vec![
+            "run".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+        ];
+        if is_resume {
+            if let Some(sid) = session_id {
+                args.push("-s".to_string());
+                args.push(sid.to_string());
+            }
+        }
+        args.push("--dangerously-skip-permissions".to_string());
+        args.push(message.to_string());
+        args
+    }
+
+    fn supports_resume(&self) -> bool {
+        true
+    }
+
+    fn extract_session_id(&self, line: &str) -> Option<String> {
+        let event: KiloAgentEvent = serde_json::from_str(line).ok()?;
+        event.session_id.or_else(|| event.part.as_ref()?.session_id.clone())
+    }
+
+    fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
+        let event: KiloAgentEvent = serde_json::from_str(line).ok()?;
+        let timestamp = Self::resolve_timestamp(event.timestamp);
+
+        match event.event_type.as_str() {
+            "step_start" | "step-start" => self.handle_step_start(&timestamp),
+            "tool_use" | "tool-use" => self.handle_tool_use(event.part.as_ref()?, &timestamp),
+            "text" => self.handle_text(event.part.as_ref()?, &timestamp),
+            "step_finish" | "step-finish" => self.handle_step_finish(&event, &timestamp),
+            _ => None,
+        }
+    }
+
+    fn get_final_result(&self, logs: &[ParsedLogEntry]) -> Option<String> {
+        super::default_final_result_with_think_stripping(logs)
+    }
+
+    fn get_usage(&self, _logs: &[ParsedLogEntry]) -> Option<ExecutionUsage> {
+        self.base.usage.lock().clone()
+    }
+
+    fn get_model(&self) -> Option<String> {
+        self.base.model.lock().clone()
+    }
+
+    fn check_success(&self, exit_code: i32) -> bool {
+        if exit_code == 0 {
+            return true;
+        }
+        // kilo 返回非零退出码（如 144）即使执行成功，通过 step_finish 事件判断成功。
+        *self.has_successful_finish.lock()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::ParsedLogEntry;
+
+    #[test]
+    fn test_parse_output_line_step_start() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"step_start","timestamp":1700000000000}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_start");
+        assert_eq!(entry.content, "Step started");
+    }
+
+    #[test]
+    fn test_parse_output_line_tool_use_bash() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"tool_use","timestamp":1700000000000,"part":{"type":"tool_use","tool":"bash","state":{"status":"success","input":{"description":"list files"},"output":"file.txt"}}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "tool");
+        assert!(entry.content.contains("success"), "content should contain status: {}", entry.content);
+        assert!(entry.content.contains("list files"), "content should contain description: {}", entry.content);
+        assert!(entry.content.contains("file.txt"), "content should contain output: {}", entry.content);
+    }
+
+    #[test]
+    fn test_parse_output_line_text() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"text","timestamp":1700000000000,"part":{"type":"text","text":"hello world"}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "text");
+        assert_eq!(entry.content, "hello world");
+    }
+
+    #[test]
+    fn test_parse_output_line_step_finish_stores_usage() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"step_finish","timestamp":1700000000000,"part":{"type":"step_finish","tokens":{"total":100,"input":50,"output":50,"cache":{"read":10,"write":5}},"cost":0.001}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_finish");
+        assert_eq!(entry.content, "Step finished");
+
+        let usage = executor.get_usage(&[]).unwrap();
+        assert_eq!(usage.input_tokens, 50);
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(usage.cache_read_input_tokens, Some(10));
+        assert_eq!(usage.cache_creation_input_tokens, Some(5));
+        assert_eq!(usage.total_cost_usd, Some(0.001));
+    }
+
+    #[test]
+    fn test_parse_output_line_unknown_type() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"unknown","timestamp":1700000000000}"#;
+        assert!(executor.parse_output_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_output_line_invalid_json() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = "not json";
+        assert!(executor.parse_output_line(line).is_none());
+    }
+
+    #[test]
+    fn test_parse_output_line_empty_text() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"text","timestamp":1700000000000,"part":{"type":"text","text":""}}"#;
+        assert!(executor.parse_output_line(line).is_none());
+    }
+
+    #[test]
+    fn test_get_final_result_with_text() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let logs = vec![
+            ParsedLogEntry::new("text", "  hello world  "),
+        ];
+        assert_eq!(executor.get_final_result(&logs), Some("hello world".to_string()));
+    }
+
+    #[test]
+    fn test_get_final_result_fallback_to_stderr() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let logs = vec![
+            ParsedLogEntry::new("stderr", "error output"),
+        ];
+        assert_eq!(executor.get_final_result(&logs), Some("error output".to_string()));
+    }
+
+    #[test]
+    fn test_get_final_result_empty_logs() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let logs: Vec<ParsedLogEntry> = vec![];
+        assert!(executor.get_final_result(&logs).is_none());
+    }
+
+    #[test]
+    fn test_get_usage_before_step_finish() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        assert!(executor.get_usage(&[]).is_none());
+    }
+
+    #[test]
+    fn test_get_model_always_none() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        assert!(executor.get_model().is_none());
+    }
+
+    #[test]
+    fn test_check_success_exit_code_zero() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        assert!(executor.check_success(0));
+    }
+
+    #[test]
+    fn test_check_success_non_zero_without_step_finish() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        assert!(!executor.check_success(144));
+        assert!(!executor.check_success(1));
+    }
+
+    #[test]
+    fn test_check_success_non_zero_with_step_finish() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"step_finish","timestamp":1700000000000,"part":{"type":"step_finish","tokens":{"total":100,"input":50,"output":50,"cache":{"read":10,"write":5}},"cost":0.001}}"#;
+        let _ = executor.parse_output_line(line);
+        assert!(executor.check_success(144), "应该成功：非零退出码但 step_finish 已收到");
+    }
+
+    #[test]
+    fn test_parse_output_line_step_start_hyphenated() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"step-start","timestamp":1700000000000,"sessionID":"ses_xxx"}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_start");
+        assert_eq!(entry.content, "Step started");
+    }
+
+    #[test]
+    fn test_parse_output_line_tool_use_hyphenated() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"tool-use","timestamp":1700000000000,"part":{"type":"tool","tool":"bash","state":{"status":"completed","input":{"description":"list files"},"output":"file.txt"}}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "tool");
+        assert!(entry.content.contains("completed"), "content should contain status: {}", entry.content);
+    }
+
+    #[test]
+    fn test_parse_output_line_step_finish_hyphenated() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"step-finish","timestamp":1700000000000,"part":{"type":"step-finish","reason":"stop","tokens":{"total":100,"input":50,"output":50,"reasoning":0,"cache":{"read":10,"write":5}},"cost":0.001}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_finish");
+        assert_eq!(entry.content, "Step finished");
+
+        let usage = executor.get_usage(&[]).unwrap();
+        assert_eq!(usage.input_tokens, 50);
+        assert_eq!(usage.output_tokens, 50);
+    }
+
+    #[test]
+    fn test_check_success_with_step_finish_hyphenated() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"step-finish","timestamp":1700000000000,"part":{"type":"step-finish","tokens":{"total":100,"input":50,"output":50,"cache":{"read":10,"write":5}},"cost":0.001}}"#;
+        let _ = executor.parse_output_line(line);
+        assert!(executor.check_success(144), "应该成功：非零退出码但 step-finish 已收到");
+    }
+
+    #[test]
+    fn test_parse_actual_kilo_json_format() {
+        let executor = KiloExecutor::new("kilo".to_string());
+
+        // Step start
+        let line = r#"{"type":"step-start","timestamp":1777471473403,"sessionID":"ses_xxx"}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_start");
+
+        // Text output
+        let line = r#"{"type":"text","timestamp":1777471505165,"sessionID":"ses_xxx","part":{"type":"text","text":"Hello, this is a test response"}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "text");
+        assert_eq!(entry.content, "Hello, this is a test response");
+
+        // Step finish
+        let line = r#"{"type":"step-finish","timestamp":1777471505168,"sessionID":"ses_xxx","part":{"type":"step-finish","reason":"stop","tokens":{"total":14155,"input":13862,"output":293,"reasoning":0,"cache":{"write":0,"read":0}},"cost":0}}"#;
+        let _ = executor.parse_output_line(line);
+
+        let logs = vec![
+            ParsedLogEntry::new("step_start", "Step started"),
+            ParsedLogEntry::new("text", "Hello, this is a test response"),
+            ParsedLogEntry::new("step_finish", "Step finished"),
+        ];
+        let result = executor.get_final_result(&logs);
+        assert_eq!(result, Some("Hello, this is a test response".to_string()));
+    }
+
+    #[test]
+    fn test_executor_type_is_kilo() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        assert_eq!(executor.executor_type(), ExecutorType::Kilo);
+        assert_eq!(ExecutorType::Kilo.as_str(), "kilo");
+    }
+
+    #[test]
+    fn test_command_args_shape() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let args = executor.command_args("hello");
+        assert_eq!(args[0], "run");
+        assert_eq!(args[1], "--format");
+        assert_eq!(args[2], "json");
+        assert_eq!(args[3], "--dangerously-skip-permissions");
+        assert_eq!(args[4], "hello");
+    }
+}

--- a/backend/src/adapters/kilo_event.rs
+++ b/backend/src/adapters/kilo_event.rs
@@ -103,3 +103,278 @@ pub struct KiloAgentCacheTokens {
     #[serde(default)]
     pub write: u64,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── KiloAgentEvent deserialization ──────────────────────────────────
+
+    #[test]
+    fn test_kilo_agent_event_basic_step_start() {
+        let json = r#"{"type":"step_start","timestamp":1700000000000}"#;
+        let event: KiloAgentEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type, "step_start");
+        assert_eq!(event.timestamp, Some(1700000000000u64));
+        assert!(event.session_id.is_none());
+        assert!(event.part.is_none());
+    }
+
+    #[test]
+    fn test_kilo_agent_event_hyphenated_step_start() {
+        let json = r#"{"type":"step-start","timestamp":1777471473403,"sessionID":"ses_abc123"}"#;
+        let event: KiloAgentEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type, "step-start");
+        assert_eq!(event.timestamp, Some(1777471473403u64));
+        assert_eq!(event.session_id, Some("ses_abc123".to_string()));
+        assert!(event.part.is_none());
+    }
+
+    #[test]
+    fn test_kilo_agent_event_missing_timestamp_defaults_to_none() {
+        // timestamp is #[serde(default)] so missing → None
+        let json = r#"{"type":"unknown"}"#;
+        let event: KiloAgentEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type, "unknown");
+        assert!(event.timestamp.is_none());
+    }
+
+    #[test]
+    fn test_kilo_agent_event_with_text_part() {
+        let json = r#"{"type":"text","timestamp":1700000000001,"sessionID":"ses_xyz","part":{"type":"text","text":"hello kilo"}}"#;
+        let event: KiloAgentEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type, "text");
+        assert_eq!(event.session_id, Some("ses_xyz".to_string()));
+        let part = event.part.unwrap();
+        assert_eq!(part.text, Some("hello kilo".to_string()));
+        assert_eq!(part.part_type, Some("text".to_string()));
+    }
+
+    #[test]
+    fn test_kilo_agent_event_with_step_finish_part() {
+        let json = r#"{"type":"step-finish","timestamp":1700000000002,"part":{"type":"step-finish","reason":"stop","tokens":{"total":200,"input":150,"output":50,"reasoning":0,"cache":{"read":10,"write":5}},"cost":0.0025}}"#;
+        let event: KiloAgentEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type, "step-finish");
+        let part = event.part.unwrap();
+        assert_eq!(part.reason, Some("stop".to_string()));
+        assert_eq!(part.cost, Some(0.0025));
+        let tokens = part.tokens.unwrap();
+        assert_eq!(tokens.total, 200);
+        assert_eq!(tokens.input, 150);
+        assert_eq!(tokens.output, 50);
+        assert_eq!(tokens.reasoning, 0);
+        assert_eq!(tokens.cache.read, 10);
+        assert_eq!(tokens.cache.write, 5);
+    }
+
+    #[test]
+    fn test_kilo_agent_event_with_tool_use_part() {
+        let json = r#"{"type":"tool-use","timestamp":1700000000003,"part":{"type":"tool_use","tool":"bash","state":{"status":"running","input":{"description":"list files","command":"ls -la"},"output":null}}}"#;
+        let event: KiloAgentEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type, "tool-use");
+        let part = event.part.unwrap();
+        assert_eq!(part.tool, Some("bash".to_string()));
+        let state = part.state.unwrap();
+        assert_eq!(state.status, Some("running".to_string()));
+        assert!(state.output.is_none());
+        let input = state.input.unwrap();
+        assert_eq!(input.description, Some("list files".to_string()));
+        assert_eq!(input.command, Some("ls -la".to_string()));
+    }
+
+    #[test]
+    fn test_kilo_agent_event_invalid_json_fails() {
+        let result: Result<KiloAgentEvent, _> = serde_json::from_str("not json at all");
+        assert!(result.is_err());
+    }
+
+    // ── KiloAgentPart deserialization ────────────────────────────────────
+
+    #[test]
+    fn test_kilo_agent_part_all_optional_fields_default_to_none() {
+        // Only type field is required (but actually part_type is Option<String>)
+        let json = r#"{"type":"text"}"#;
+        let part: KiloAgentPart = serde_json::from_str(json).unwrap();
+        assert_eq!(part.part_type, Some("text".to_string()));
+        assert!(part.id.is_none());
+        assert!(part.text.is_none());
+        assert!(part.tool.is_none());
+        assert!(part.call_id.is_none());
+        assert!(part.state.is_none());
+        assert!(part.message_id.is_none());
+        assert!(part.session_id.is_none());
+        assert!(part.tokens.is_none());
+        assert!(part.cost.is_none());
+        assert!(part.reason.is_none());
+    }
+
+    #[test]
+    fn test_kilo_agent_part_with_session_id_in_part() {
+        let json = r#"{"type":"step-finish","session_id":"ses_from_part"}"#;
+        let part: KiloAgentPart = serde_json::from_str(json).unwrap();
+        assert_eq!(part.session_id, Some("ses_from_part".to_string()));
+    }
+
+    // ── KiloAgentToolState deserialization ───────────────────────────────
+
+    #[test]
+    fn test_kilo_agent_tool_state_complete() {
+        let json = r#"{"status":"completed","input":{"description":"echo test","command":"echo test"},"output":"test\n"}"#;
+        let state: KiloAgentToolState = serde_json::from_str(json).unwrap();
+        assert_eq!(state.status, Some("completed".to_string()));
+        assert_eq!(state.output, Some("test\n".to_string()));
+        let input = state.input.unwrap();
+        assert_eq!(input.description, Some("echo test".to_string()));
+        assert_eq!(input.command, Some("echo test".to_string()));
+    }
+
+    #[test]
+    fn test_kilo_agent_tool_state_all_optional() {
+        let json = r#"{}"#;
+        let state: KiloAgentToolState = serde_json::from_str(json).unwrap();
+        assert!(state.status.is_none());
+        assert!(state.input.is_none());
+        assert!(state.output.is_none());
+    }
+
+    // ── KiloAgentToolInput.to_full_json() ────────────────────────────────
+
+    #[test]
+    fn test_kilo_agent_tool_input_to_full_json_with_command_and_description() {
+        let json = r#"{"command":"ls -la","description":"list all files"}"#;
+        let input: KiloAgentToolInput = serde_json::from_str(json).unwrap();
+        let result = input.to_full_json();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["command"], "ls -la");
+        assert_eq!(parsed["description"], "list all files");
+    }
+
+    #[test]
+    fn test_kilo_agent_tool_input_to_full_json_with_extra_fields() {
+        let json = r#"{"description":"write file","path":"/tmp/test.txt","content":"hello"}"#;
+        let input: KiloAgentToolInput = serde_json::from_str(json).unwrap();
+        let result = input.to_full_json();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["description"], "write file");
+        // Extra fields are included via flatten
+        assert_eq!(parsed["path"], "/tmp/test.txt");
+        assert_eq!(parsed["content"], "hello");
+    }
+
+    #[test]
+    fn test_kilo_agent_tool_input_to_full_json_empty_input() {
+        // No command, no description, no extra fields
+        let json = r#"{}"#;
+        let input: KiloAgentToolInput = serde_json::from_str(json).unwrap();
+        let result = input.to_full_json();
+        // Should produce a valid (possibly empty) JSON object
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed.is_object());
+    }
+
+    #[test]
+    fn test_kilo_agent_tool_input_to_full_json_only_command() {
+        let json = r#"{"command":"git status"}"#;
+        let input: KiloAgentToolInput = serde_json::from_str(json).unwrap();
+        let result = input.to_full_json();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["command"], "git status");
+        assert!(parsed.get("description").is_none() || parsed["description"].is_null());
+    }
+
+    #[test]
+    fn test_kilo_agent_tool_input_to_full_json_returns_valid_json_string() {
+        let json = r#"{"description":"test","command":"pwd"}"#;
+        let input: KiloAgentToolInput = serde_json::from_str(json).unwrap();
+        let result = input.to_full_json();
+        // Must be non-empty and parseable
+        assert!(!result.is_empty());
+        assert!(serde_json::from_str::<serde_json::Value>(&result).is_ok());
+    }
+
+    // ── KiloAgentTokens deserialization ──────────────────────────────────
+
+    #[test]
+    fn test_kilo_agent_tokens_all_fields() {
+        let json = r#"{"total":14155,"input":13862,"output":293,"reasoning":100,"cache":{"read":500,"write":200}}"#;
+        let tokens: KiloAgentTokens = serde_json::from_str(json).unwrap();
+        assert_eq!(tokens.total, 14155);
+        assert_eq!(tokens.input, 13862);
+        assert_eq!(tokens.output, 293);
+        assert_eq!(tokens.reasoning, 100);
+        assert_eq!(tokens.cache.read, 500);
+        assert_eq!(tokens.cache.write, 200);
+    }
+
+    #[test]
+    fn test_kilo_agent_tokens_reasoning_defaults_to_zero() {
+        let json = r#"{"total":100,"input":70,"output":30}"#;
+        let tokens: KiloAgentTokens = serde_json::from_str(json).unwrap();
+        assert_eq!(tokens.reasoning, 0);
+    }
+
+    #[test]
+    fn test_kilo_agent_tokens_cache_defaults_to_zero() {
+        let json = r#"{"total":100,"input":70,"output":30}"#;
+        let tokens: KiloAgentTokens = serde_json::from_str(json).unwrap();
+        // cache field has Default, so read/write both 0
+        assert_eq!(tokens.cache.read, 0);
+        assert_eq!(tokens.cache.write, 0);
+    }
+
+    #[test]
+    fn test_kilo_agent_tokens_zero_cost_step_finish() {
+        // Real Kilo output: cost=0 when using free tier
+        let json = r#"{"total":14155,"input":13862,"output":293,"reasoning":0,"cache":{"write":0,"read":0}}"#;
+        let tokens: KiloAgentTokens = serde_json::from_str(json).unwrap();
+        assert_eq!(tokens.total, 14155);
+        assert_eq!(tokens.cache.write, 0);
+        assert_eq!(tokens.cache.read, 0);
+    }
+
+    // ── KiloAgentCacheTokens defaults ────────────────────────────────────
+
+    #[test]
+    fn test_kilo_agent_cache_tokens_default_is_zero() {
+        let cache = KiloAgentCacheTokens::default();
+        assert_eq!(cache.read, 0);
+        assert_eq!(cache.write, 0);
+    }
+
+    #[test]
+    fn test_kilo_agent_cache_tokens_partial_deserialization() {
+        // Only write provided, read should default to 0
+        let json = r#"{"write":42}"#;
+        let cache: KiloAgentCacheTokens = serde_json::from_str(json).unwrap();
+        assert_eq!(cache.read, 0);
+        assert_eq!(cache.write, 42);
+    }
+
+    // ── Round-trip / integration deserialization ─────────────────────────
+
+    #[test]
+    fn test_kilo_agent_event_real_step_finish_json() {
+        // Based on actual Kilo CLI output captured during testing
+        let json = r#"{"type":"step-finish","timestamp":1777471505168,"sessionID":"ses_xxx","part":{"type":"step-finish","reason":"stop","tokens":{"total":14155,"input":13862,"output":293,"reasoning":0,"cache":{"write":0,"read":0}},"cost":0}}"#;
+        let event: KiloAgentEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type, "step-finish");
+        assert_eq!(event.session_id, Some("ses_xxx".to_string()));
+        let part = event.part.unwrap();
+        assert_eq!(part.reason, Some("stop".to_string()));
+        // cost: 0 (integer in JSON) should deserialize to Some(0.0)
+        assert_eq!(part.cost, Some(0.0));
+        let tokens = part.tokens.unwrap();
+        assert_eq!(tokens.total, 14155);
+        assert_eq!(tokens.input, 13862);
+        assert_eq!(tokens.output, 293);
+    }
+
+    #[test]
+    fn test_kilo_agent_event_real_text_json() {
+        let json = r#"{"type":"text","timestamp":1777471505165,"sessionID":"ses_xxx","part":{"type":"text","text":"Hello, this is a test response from Kilo"}}"#;
+        let event: KiloAgentEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type, "text");
+        let part = event.part.unwrap();
+        assert_eq!(part.text, Some("Hello, this is a test response from Kilo".to_string()));
+    }
+}

--- a/backend/src/adapters/kilo_event.rs
+++ b/backend/src/adapters/kilo_event.rs
@@ -1,0 +1,105 @@
+//! Kilo-specific event parsing.
+//!
+//! Kilo 复用了 OpenCode 的事件格式（hyphenated event types，例如 step-start、tool-use），
+//! 并额外使用 camelCase 字段名（如 sessionID）。
+//!
+//! 行为与 Opencode/Zhanlu 完全一致：相同的命令参数、相同的 JSON 输出格式、
+//! 相同的退出码语义（非零但含 step_finish 事件时视为成功）。
+//! 所以这里只把类型名从 Opencode 前缀重命名为 Kilo，serde 结构和字段映射保持完全一致。
+
+use std::collections::HashMap;
+use serde::Deserialize;
+
+/// Kilo agent event with hyphenated type names (与 OpenCode 完全相同的 JSON 结构)
+#[derive(Debug, Clone, Deserialize)]
+pub struct KiloAgentEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    #[serde(default)]
+    pub timestamp: Option<u64>,
+    #[serde(default, rename = "sessionID")]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub part: Option<KiloAgentPart>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct KiloAgentPart {
+    #[serde(rename = "type")]
+    pub part_type: Option<String>,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub tool: Option<String>,
+    #[serde(default)]
+    pub call_id: Option<String>,
+    #[serde(default)]
+    pub state: Option<KiloAgentToolState>,
+    #[serde(default)]
+    pub message_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub tokens: Option<KiloAgentTokens>,
+    #[serde(default)]
+    pub cost: Option<f64>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct KiloAgentToolState {
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub input: Option<KiloAgentToolInput>,
+    #[serde(default)]
+    pub output: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct KiloAgentToolInput {
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+impl KiloAgentToolInput {
+    pub fn to_full_json(&self) -> String {
+        let mut map = serde_json::Map::new();
+        if let Some(ref cmd) = self.command {
+            map.insert("command".into(), serde_json::Value::String(cmd.clone()));
+        }
+        if let Some(ref desc) = self.description {
+            map.insert("description".into(), serde_json::Value::String(desc.clone()));
+        }
+        for (k, v) in &self.extra {
+            map.insert(k.clone(), v.clone());
+        }
+        serde_json::to_string(&serde_json::Value::Object(map)).unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct KiloAgentTokens {
+    pub total: u64,
+    pub input: u64,
+    pub output: u64,
+    #[serde(default)]
+    pub reasoning: u64,
+    #[serde(default)]
+    pub cache: KiloAgentCacheTokens,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct KiloAgentCacheTokens {
+    #[serde(default)]
+    pub read: u64,
+    #[serde(default)]
+    pub write: u64,
+}

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -536,6 +536,55 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_executor_type_kilo() {
+        assert_eq!(parse_executor_type("kilo"), Some(ExecutorType::Kilo));
+        assert_eq!(parse_executor_type("KILO"), Some(ExecutorType::Kilo));
+        assert_eq!(parse_executor_type("Kilo"), Some(ExecutorType::Kilo));
+        assert_eq!(parse_executor_type(" kilo "), Some(ExecutorType::Kilo));
+    }
+
+    #[test]
+    fn test_find_executor_kilo() {
+        let def = find_executor("kilo").expect("kilo should be found");
+        assert_eq!(def.name, "kilo");
+        assert_eq!(def.binary_name, "kilo");
+        assert_eq!(def.display_name, "Kilo");
+        assert_eq!(def.default_path, "kilo");
+        assert_eq!(def.session_dir, "~/.kilo");
+        assert!(def.aliases.is_empty());
+        assert_eq!(def.executor_type, ExecutorType::Kilo);
+    }
+
+    #[test]
+    fn test_resumable_executors_contains_kilo() {
+        assert!(RESUMABLE_EXECUTORS.contains(&"kilo"),
+            "kilo should be in RESUMABLE_EXECUTORS; current list: {:?}", RESUMABLE_EXECUTORS);
+    }
+
+    #[test]
+    fn test_create_executor_kilo_returns_kilo_type() {
+        let executor = ExecutorRegistry::create_executor("kilo", "/usr/local/bin/kilo")
+            .expect("create_executor(\"kilo\", ...) should return Some");
+        assert_eq!(executor.executor_type(), ExecutorType::Kilo);
+        assert_eq!(executor.executable_path(), "/usr/local/bin/kilo");
+    }
+
+    #[test]
+    fn test_create_executor_kilo_supports_resume() {
+        let executor = ExecutorRegistry::create_executor("kilo", "kilo").unwrap();
+        assert!(executor.supports_resume(), "Kilo executor should support resume");
+    }
+
+    #[test]
+    fn test_kilo_has_no_aliases() {
+        // Kilo intentionally has no aliases: only "kilo" maps to Kilo
+        assert_eq!(find_executor("kilo").unwrap().aliases.len(), 0);
+        // Sanity-check: a made-up alias does not accidentally resolve
+        assert!(parse_executor_type("kc").is_none(),
+            "\"kc\" should not resolve to any executor including Kilo");
+    }
+
+    #[test]
     fn test_parse_executor_type_unknown() {
         assert_eq!(parse_executor_type("unknown"), None);
         assert_eq!(parse_executor_type(""), None);

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -134,9 +134,6 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         aliases: &["mimocode"],
     },
     ExecutorDef {
-        // Zhanlu: Issue #673 新增的执行器，行为与 opencode 完全一致。
-        // binary_name / default_path 都走 PATH 解析（统一为 `zl`），
-        // session 目录是 ~/.local/share/zhanlu/storage。
         name: "zhanlu",
         executor_type: ExecutorType::Zhanlu,
         binary_name: "zl",
@@ -145,10 +142,22 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         session_dir: "~/.local/share/zhanlu/storage",
         aliases: &["zhanlucode", "zl"],
     },
+    ExecutorDef {
+        // Kilo: 与 Opencode/Zhanlu 一致的开源 AI 编程执行器。
+        // binary_name / default_path 都走 PATH 解析（统一为 `kilo`），
+        // session 目录是 ~/.kilo。
+        name: "kilo",
+        executor_type: ExecutorType::Kilo,
+        binary_name: "kilo",
+        display_name: "Kilo",
+        default_path: "kilo",
+        session_dir: "~/.kilo",
+        aliases: &[],
+    },
 ];
 
 /// 支持继续对话的执行器集合（与前端 RESUMABLE_EXECUTORS 保持一致）
-pub const RESUMABLE_EXECUTORS: &[&str] = &["claudecode", "kimi", "opencode", "mobilecoder", "hermes", "codewhale", "pi", "mimo", "zhanlu"];
+pub const RESUMABLE_EXECUTORS: &[&str] = &["claudecode", "kimi", "opencode", "mobilecoder", "hermes", "codewhale", "pi", "mimo", "zhanlu", "kilo"];
 
 /// 默认执行器
 pub const DEFAULT_EXECUTOR: &str = "claudecode";
@@ -303,6 +312,8 @@ pub mod mimo;
 pub mod mimo_event;
 pub mod zhanlu;
 pub mod zhanlu_event;
+pub mod kilo;
+pub mod kilo_event;
 
 #[async_trait]
 pub trait CodeExecutor: Send + Sync {
@@ -437,6 +448,7 @@ impl ExecutorRegistry {
             "pi" => Arc::new(pi::PiExecutor::new(path.to_string())),
             "mimo" => Arc::new(mimo::MimoExecutor::new(path.to_string())),
             "zhanlu" => Arc::new(zhanlu::ZhanluExecutor::new(path.to_string())),
+            "kilo" => Arc::new(kilo::KiloExecutor::new(path.to_string())),
             _ => return None,
         };
         Some(executor)

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -1256,3 +1256,125 @@ pub async fn record_invocation(
 
     Ok(ApiResponse::ok(id))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::ExecutorType;
+
+    // ── executor_label() tests ───────────────────────────────────────────
+
+    #[test]
+    fn test_executor_label_kilo() {
+        assert_eq!(executor_label(ExecutorType::Kilo), "Kilo");
+    }
+
+    #[test]
+    fn test_executor_label_all_known_executors() {
+        // Regression guard: if a new executor is added to the enum but not to executor_label(),
+        // the compiler will panic at runtime (non-exhaustive match). This test verifies the
+        // known executor labels are correct and Kilo is included.
+        assert_eq!(executor_label(ExecutorType::Claudecode), "Claude Code");
+        assert_eq!(executor_label(ExecutorType::Hermes), "Hermes");
+        assert_eq!(executor_label(ExecutorType::Codex), "Codex");
+        assert_eq!(executor_label(ExecutorType::Codebuddy), "CodeBuddy");
+        assert_eq!(executor_label(ExecutorType::Opencode), "Opencode");
+        assert_eq!(executor_label(ExecutorType::Atomcode), "AtomCode");
+        assert_eq!(executor_label(ExecutorType::Kimi), "Kimi");
+        assert_eq!(executor_label(ExecutorType::Mobilecoder), "MobileCoder");
+        assert_eq!(executor_label(ExecutorType::Codewhale), "CodeWhale");
+        assert_eq!(executor_label(ExecutorType::Pi), "Pi");
+        assert_eq!(executor_label(ExecutorType::Mimo), "MiMo");
+        assert_eq!(executor_label(ExecutorType::Zhanlu), "Zhanlu");
+        assert_eq!(executor_label(ExecutorType::Kilo), "Kilo");
+    }
+
+    // ── ALL_EXECUTORS array tests ────────────────────────────────────────
+
+    #[test]
+    fn test_all_executors_contains_kilo() {
+        assert!(ALL_EXECUTORS.contains(&ExecutorType::Kilo),
+            "ALL_EXECUTORS should contain ExecutorType::Kilo");
+    }
+
+    #[test]
+    fn test_all_executors_count_is_thirteen() {
+        // The comment says 13 = 12 old + Kilo. Guard the count so additions are noticed.
+        assert_eq!(ALL_EXECUTORS.len(), 13,
+            "ALL_EXECUTORS length mismatch; update the array and this test when adding executors");
+    }
+
+    #[test]
+    fn test_all_executors_no_duplicates() {
+        let mut seen = std::collections::HashSet::new();
+        for et in &ALL_EXECUTORS {
+            assert!(seen.insert(et.as_str()),
+                "Duplicate executor in ALL_EXECUTORS: {}", et.as_str());
+        }
+    }
+
+    // ── executor_label_for_source() tests ───────────────────────────────
+
+    #[test]
+    fn test_executor_label_for_source_kilo() {
+        assert_eq!(executor_label_for_source("kilo"), "Kilo");
+    }
+
+    #[test]
+    fn test_executor_label_for_source_agents_is_special() {
+        assert_eq!(executor_label_for_source("agents"), "Agents");
+    }
+
+    #[test]
+    fn test_executor_label_for_source_unknown_returns_empty() {
+        assert_eq!(executor_label_for_source("does_not_exist"), "");
+    }
+
+    // ── is_readonly_skill_source() tests ────────────────────────────────
+
+    #[test]
+    fn test_is_readonly_skill_source_agents() {
+        assert!(is_readonly_skill_source("agents"));
+    }
+
+    #[test]
+    fn test_is_readonly_skill_source_kilo_is_not_readonly() {
+        assert!(!is_readonly_skill_source("kilo"));
+    }
+
+    // ── extract_yaml_front_matter() tests ───────────────────────────────
+
+    #[test]
+    fn test_extract_yaml_front_matter_basic() {
+        let content = "---\nname: test\ndescription: a test skill\n---\nBody here";
+        let yaml = extract_yaml_front_matter(content).unwrap();
+        assert!(yaml.contains("name: test"));
+        assert!(yaml.contains("description: a test skill"));
+    }
+
+    #[test]
+    fn test_extract_yaml_front_matter_missing_returns_none() {
+        let content = "No front matter here at all";
+        assert!(extract_yaml_front_matter(content).is_none());
+    }
+
+    // ── parse_skill_yaml_header() tests ─────────────────────────────────
+
+    #[test]
+    fn test_parse_skill_yaml_header_complete() {
+        let content = "---\nname: my-skill\ndescription: Does something useful\nversion: 1.2.3\nauthor: Alice\nlicense: MIT\n---\nBody";
+        let meta = parse_skill_yaml_header(content);
+        assert_eq!(meta.name, "my-skill");
+        assert_eq!(meta.description, "Does something useful");
+        assert_eq!(meta.version, Some("1.2.3".to_string()));
+        assert_eq!(meta.author, Some("Alice".to_string()));
+        assert_eq!(meta.license, Some("MIT".to_string()));
+    }
+
+    #[test]
+    fn test_parse_skill_yaml_header_fallback_name_from_heading() {
+        let content = "# My Skill Title\nSome description text here.";
+        let meta = parse_skill_yaml_header(content);
+        assert_eq!(meta.name, "My Skill Title");
+    }
+}

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -129,14 +129,15 @@ fn executor_label(et: ExecutorType) -> &'static str {
         ExecutorType::Pi => "Pi",
         ExecutorType::Mimo => "MiMo",
         ExecutorType::Zhanlu => "Zhanlu",
+        ExecutorType::Kilo => "Kilo",
     }
 }
 
 // 保留 ALL_EXECUTORS 供其他可能用到的代码；新代码请用 ALL_SKILL_SOURCES
-// 12 = 10 个旧执行器 + Mimo (PR #669) + Issue #673 新增的 Zhanlu
+// 13 = 12 个旧执行器 + 新增的 Kilo
 // 注意：加新执行器必须同时更新下面数组与本注释的计数，否则会出现 H1 同型错位。
 #[allow(dead_code)]
-const ALL_EXECUTORS: [ExecutorType; 12] = [
+const ALL_EXECUTORS: [ExecutorType; 13] = [
     ExecutorType::Claudecode,
     ExecutorType::Hermes,
     ExecutorType::Codex,
@@ -149,6 +150,7 @@ const ALL_EXECUTORS: [ExecutorType; 12] = [
     ExecutorType::Pi,
     ExecutorType::Mimo,
     ExecutorType::Zhanlu,
+    ExecutorType::Kilo,
 ];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1110,6 +1110,32 @@ mod tests {
     }
 
     #[test]
+    fn test_executor_type_kilo_as_str() {
+        assert_eq!(ExecutorType::Kilo.as_str(), "kilo");
+    }
+
+    #[test]
+    fn test_executor_type_kilo_display() {
+        assert_eq!(format!("{}", ExecutorType::Kilo), "kilo");
+    }
+
+    #[test]
+    fn test_executor_type_kilo_is_distinct_from_others() {
+        // Kilo must not accidentally compare equal to any other variant
+        assert_ne!(ExecutorType::Kilo, ExecutorType::Opencode);
+        assert_ne!(ExecutorType::Kilo, ExecutorType::Zhanlu);
+        assert_ne!(ExecutorType::Kilo, ExecutorType::Claudecode);
+    }
+
+    #[test]
+    fn test_executor_type_kilo_clone() {
+        let et = ExecutorType::Kilo;
+        let cloned = et.clone();
+        assert_eq!(cloned, ExecutorType::Kilo);
+        assert_eq!(cloned.as_str(), "kilo");
+    }
+
+    #[test]
     fn test_executor_type_default() {
         assert_eq!(ExecutorType::default(), ExecutorType::Claudecode);
     }

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -862,6 +862,7 @@ pub enum ExecutorType {
     Pi,
     Mimo,
     Zhanlu,
+    Kilo,
 }
 
 
@@ -880,6 +881,7 @@ impl ExecutorType {
             ExecutorType::Pi => "pi",
             ExecutorType::Mimo => "mimo",
             ExecutorType::Zhanlu => "zhanlu",
+            ExecutorType::Kilo => "kilo",
         }
     }
 }

--- a/backend/tests/executor_tests.rs
+++ b/backend/tests/executor_tests.rs
@@ -7,6 +7,7 @@ use ntd::adapters::atomcode::AtomcodeExecutor;
 use ntd::adapters::mobilecoder::MobilecoderExecutor;
 use ntd::adapters::codex::CodexExecutor;
 use ntd::adapters::zhanlu::ZhanluExecutor;
+use ntd::adapters::kilo::KiloExecutor;
 use ntd::models::{ParsedLogEntry, ExecutorType};
 
 #[cfg(test)]
@@ -604,5 +605,227 @@ mod parsed_log_entry_tests {
         let entry = ParsedLogEntry::stderr("stderr message".to_string());
         assert_eq!(entry.log_type, "stderr");
         assert_eq!(entry.content, "stderr message");
+    }
+}
+
+// Kilo: 与 Opencode/Zhanlu 一致的开源 AI 编程执行器。
+// 行为与 opencode/zhanlu 完全一致：相同的命令行参数、相同的 JSON 输出格式、相同的退出码语义。
+#[cfg(test)]
+mod kilo_executor_tests {
+    use super::*;
+
+    #[test]
+    fn test_kilo_executor_type() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        assert_eq!(executor.executor_type(), ExecutorType::Kilo);
+    }
+
+    #[test]
+    fn test_kilo_executable_path() {
+        let executor = KiloExecutor::new("/usr/local/bin/kilo".to_string());
+        assert_eq!(executor.executable_path(), "/usr/local/bin/kilo");
+    }
+
+    #[test]
+    fn test_kilo_command_args() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let args = executor.command_args("say hello");
+        assert!(args.contains(&"run".to_string()));
+        assert!(args.contains(&"--format".to_string()));
+        assert!(args.contains(&"json".to_string()));
+        assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
+        assert!(args.contains(&"say hello".to_string()));
+    }
+
+    #[test]
+    fn test_kilo_command_args_order() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let args = executor.command_args("hello");
+        assert_eq!(args[0], "run");
+        assert_eq!(args[1], "--format");
+        assert_eq!(args[2], "json");
+        assert_eq!(args[3], "--dangerously-skip-permissions");
+        assert_eq!(args[4], "hello");
+    }
+
+    #[test]
+    fn test_kilo_command_args_with_session_resume() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let args = executor.command_args_with_session("continue task", Some("ses_abc"), true);
+        assert!(args.contains(&"-s".to_string()));
+        assert!(args.contains(&"ses_abc".to_string()));
+        assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
+        assert!(args.contains(&"continue task".to_string()));
+    }
+
+    #[test]
+    fn test_kilo_command_args_with_session_no_resume() {
+        // is_resume=false: session_id is NOT passed
+        let executor = KiloExecutor::new("kilo".to_string());
+        let args = executor.command_args_with_session("new task", Some("ses_abc"), false);
+        assert!(!args.contains(&"-s".to_string()));
+        assert!(!args.contains(&"ses_abc".to_string()));
+        assert!(args.contains(&"new task".to_string()));
+    }
+
+    #[test]
+    fn test_kilo_command_args_with_session_resume_no_session_id() {
+        // is_resume=true but no session_id: -s flag should NOT appear
+        let executor = KiloExecutor::new("kilo".to_string());
+        let args = executor.command_args_with_session("task", None, true);
+        assert!(!args.contains(&"-s".to_string()));
+        assert!(args.contains(&"task".to_string()));
+    }
+
+    #[test]
+    fn test_kilo_check_success_zero() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        assert!(executor.check_success(0));
+    }
+
+    #[test]
+    fn test_kilo_check_success_non_zero_without_step_finish() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        assert!(!executor.check_success(1));
+        assert!(!executor.check_success(144));
+        assert!(!executor.check_success(-1));
+    }
+
+    #[test]
+    fn test_kilo_check_success_non_zero_with_step_finish() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        // Simulate step_finish event arriving before process exits
+        let line = r#"{"type":"step-finish","timestamp":1700000000000,"part":{"type":"step-finish","reason":"stop","tokens":{"total":100,"input":50,"output":50,"reasoning":0,"cache":{"read":0,"write":0}},"cost":0}}"#;
+        let _ = executor.parse_output_line(line);
+        assert!(executor.check_success(144),
+            "Non-zero exit code 144 should be treated as success when step_finish was received");
+    }
+
+    #[test]
+    fn test_kilo_supports_resume() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        assert!(executor.supports_resume());
+    }
+
+    #[test]
+    fn test_kilo_parse_step_start_underscore() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"step_start","timestamp":1700000000000}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_start");
+        assert_eq!(entry.content, "Step started");
+    }
+
+    #[test]
+    fn test_kilo_parse_step_start_hyphenated() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"step-start","timestamp":1777471473403,"sessionID":"ses_abc"}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "step_start");
+        assert_eq!(entry.content, "Step started");
+    }
+
+    #[test]
+    fn test_kilo_parse_text() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"text","timestamp":1777471505165,"sessionID":"ses_abc","part":{"type":"text","text":"hello from kilo"}}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "text");
+        assert_eq!(entry.content, "hello from kilo");
+    }
+
+    #[test]
+    fn test_kilo_extract_session_id_from_top_level() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"step-start","timestamp":1700000000000,"sessionID":"ses_kilo_001"}"#;
+        assert_eq!(executor.extract_session_id(line), Some("ses_kilo_001".to_string()));
+    }
+
+    #[test]
+    fn test_kilo_extract_session_id_from_part() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"text","timestamp":1700000000000,"part":{"type":"text","text":"hi","session_id":"ses_from_part"}}"#;
+        assert_eq!(executor.extract_session_id(line), Some("ses_from_part".to_string()));
+    }
+
+    #[test]
+    fn test_kilo_extract_session_id_missing_returns_none() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let line = r#"{"type":"step_start","timestamp":1700000000000}"#;
+        assert!(executor.extract_session_id(line).is_none());
+    }
+
+    /// Behavior alignment: Kilo and Opencode should produce identical ParsedLogEntry
+    /// from the same JSON input, since they use the same output format.
+    #[test]
+    fn test_kilo_matches_opencode_on_same_json() {
+        let opencode = OpencodeExecutor::new("opencode".to_string());
+        let kilo = KiloExecutor::new("kilo".to_string());
+
+        let line = r#"{"type":"tool-use","timestamp":1700000000000,"part":{"type":"tool","tool":"bash","state":{"status":"completed","input":{"description":"echo"},"output":"ok"}}}"#;
+        let o = opencode.parse_output_line(line).unwrap();
+        let k = kilo.parse_output_line(line).unwrap();
+        assert_eq!(o.log_type, k.log_type,
+            "Kilo and Opencode must produce same log_type for identical input");
+        assert_eq!(o.content, k.content,
+            "Kilo and Opencode must produce same content for identical input");
+        assert_eq!(o.tool_name, k.tool_name,
+            "Kilo and Opencode must produce same tool_name for identical input");
+    }
+
+    /// Kilo and Zhanlu both mirror OpenCode format; all three should agree on the same JSON.
+    #[test]
+    fn test_kilo_zhanlu_opencode_all_agree_on_step_start() {
+        let opencode = OpencodeExecutor::new("opencode".to_string());
+        let kilo = KiloExecutor::new("kilo".to_string());
+        let zhanlu = ZhanluExecutor::new("zl".to_string());
+
+        let line = r#"{"type":"step-start","timestamp":1700000000000,"sessionID":"ses_x"}"#;
+        let o = opencode.parse_output_line(line).unwrap();
+        let k = kilo.parse_output_line(line).unwrap();
+        let z = zhanlu.parse_output_line(line).unwrap();
+        assert_eq!(o.log_type, k.log_type);
+        assert_eq!(o.log_type, z.log_type);
+        assert_eq!(o.content, k.content);
+        assert_eq!(o.content, z.content);
+    }
+
+    #[test]
+    fn test_kilo_get_usage_before_any_event_is_none() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        assert!(executor.get_usage(&[]).is_none());
+    }
+
+    #[test]
+    fn test_kilo_get_model_is_always_none() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        assert!(executor.get_model().is_none());
+    }
+
+    #[test]
+    fn test_kilo_step_start_resets_usage() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        // First, set usage via step_finish
+        let finish = r#"{"type":"step_finish","timestamp":1700000000001,"part":{"type":"step_finish","tokens":{"total":100,"input":50,"output":50,"cache":{"read":0,"write":0}},"cost":0.001}}"#;
+        let _ = executor.parse_output_line(finish);
+        assert!(executor.get_usage(&[]).is_some());
+
+        // Then send step_start, which should reset usage
+        let start = r#"{"type":"step_start","timestamp":1700000000002}"#;
+        let _ = executor.parse_output_line(start);
+        assert!(executor.get_usage(&[]).is_none(),
+            "step_start must reset accumulated usage to None");
+    }
+
+    #[test]
+    fn test_kilo_clone_shares_state() {
+        let executor = KiloExecutor::new("kilo".to_string());
+        let cloned = executor.clone();
+
+        // Set state on the clone and verify the original sees it (Arc sharing)
+        let finish = r#"{"type":"step_finish","timestamp":1700000000000,"part":{"type":"step_finish","tokens":{"total":100,"input":60,"output":40,"cache":{"read":0,"write":0}},"cost":0.0}}"#;
+        let _ = cloned.parse_output_line(finish);
+        assert!(executor.get_usage(&[]).is_some(),
+            "Cloned executor should share Arc state with original");
     }
 }

--- a/frontend/src/types/execution.tsx
+++ b/frontend/src/types/execution.tsx
@@ -173,6 +173,7 @@ export const EXECUTORS: ExecutorOption[] = [
   // Issue #673: 新增 Zhanlu 执行器，与 Opencode 输出格式一致
   // 颜色与下方 EXECUTOR_COLORS.zhanlu 同步为 #0f766e，与 agents(#2d3436) 视觉可分。
   { value: 'zhanlu',    label: 'Zhanlu',    color: '#0f766e', icon: <FaSquare color="#0f766e" size={14} />, resumable: true },
+  { value: 'kilo',      label: 'Kilo',      color: '#e67700', icon: <FaSquare color="#e67700" size={14} />, resumable: true },
   // `agents` is read-only skill source (`~/.agents/skills`), not shown in executor management.
   // Included here so it appears in Skills overview/sync tabs.
   { value: 'agents',     label: 'Agents',    color: '#2d3436', icon: <FaSquare color="#2d3436" size={14} /> },
@@ -193,6 +194,7 @@ export const EXECUTOR_COLORS: Record<string, string> = {
   // Issue #673 + PR #677 review H1：zhanlu 颜色与 agents 撞色（都是 #2d3436），
   // 改为深青 `#0f766e` 与 opencode 的 `#fdcb6e` / agents 的 `#2d3436` 视觉可分。
   zhanlu: '#0f766e',
+  kilo: '#e67700',
   agents: '#2d3436',
   // Aliases for backward compatibility with database names
   'claude_code': '#e17055',

--- a/frontend/tests/kilo-executor.spec.ts
+++ b/frontend/tests/kilo-executor.spec.ts
@@ -1,0 +1,313 @@
+/**
+ * Kilo executor – execution.tsx tests
+ *
+ * Verifies that the Kilo executor entry is correctly configured in:
+ * - EXECUTORS constant (value, label, color, resumable flag)
+ * - EXECUTOR_COLORS constant
+ * - RESUMABLE_EXECUTORS derived set
+ * - EXECUTORS_FOR_PICKER (should include kilo; it is not agents)
+ * - getExecutorColor() helper
+ * - getExecutorOption() helper
+ * - supportsResume() logic based on resumable flag
+ *
+ * These tests use Playwright page.evaluate() to import the live module
+ * from the Vite dev server, matching the pattern used elsewhere in this
+ * test suite (hook-pre-trigger.spec.ts, issue-648-command-extractor.spec.ts).
+ */
+
+import { test, expect } from '@playwright/test';
+
+const DEV_URL = process.env.E2E_BASE_URL || 'http://localhost:5173';
+
+// ── EXECUTORS constant ──────────────────────────────────────────────────
+
+test('EXECUTORS contains a kilo entry', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const kiloEntry = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    return mod.EXECUTORS.find((e: { value: string }) => e.value === 'kilo');
+  });
+
+  expect(kiloEntry).toBeDefined();
+});
+
+test('EXECUTORS kilo entry has correct label', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const label = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    const entry = mod.EXECUTORS.find((e: { value: string }) => e.value === 'kilo');
+    return entry?.label;
+  });
+
+  expect(label).toBe('Kilo');
+});
+
+test('EXECUTORS kilo entry has correct color #e67700', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const color = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    const entry = mod.EXECUTORS.find((e: { value: string }) => e.value === 'kilo');
+    return entry?.color;
+  });
+
+  expect(color).toBe('#e67700');
+});
+
+test('EXECUTORS kilo entry has resumable: true', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const resumable = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    const entry = mod.EXECUTORS.find((e: { value: string }) => e.value === 'kilo');
+    return entry?.resumable;
+  });
+
+  expect(resumable).toBe(true);
+});
+
+// ── EXECUTOR_COLORS constant ────────────────────────────────────────────
+
+test('EXECUTOR_COLORS has kilo with color #e67700', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const color = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    return mod.EXECUTOR_COLORS['kilo'];
+  });
+
+  expect(color).toBe('#e67700');
+});
+
+test('EXECUTOR_COLORS kilo color matches EXECUTORS kilo color', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const { executorsColor, colorsMapColor } = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    const entry = mod.EXECUTORS.find((e: { value: string }) => e.value === 'kilo');
+    return {
+      executorsColor: entry?.color,
+      colorsMapColor: mod.EXECUTOR_COLORS['kilo'],
+    };
+  });
+
+  expect(executorsColor).toBe(colorsMapColor);
+});
+
+// ── RESUMABLE_EXECUTORS derived set ────────────────────────────────────
+
+test('RESUMABLE_EXECUTORS contains kilo', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const hasKilo = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    return mod.RESUMABLE_EXECUTORS.has('kilo');
+  });
+
+  expect(hasKilo).toBe(true);
+});
+
+// ── EXECUTORS_FOR_PICKER ────────────────────────────────────────────────
+
+test('EXECUTORS_FOR_PICKER contains kilo (kilo is not agents)', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const hasKilo = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    return mod.EXECUTORS_FOR_PICKER.some((e: { value: string }) => e.value === 'kilo');
+  });
+
+  expect(hasKilo).toBe(true);
+});
+
+test('EXECUTORS_FOR_PICKER does not contain agents', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const hasAgents = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    return mod.EXECUTORS_FOR_PICKER.some((e: { value: string }) => e.value === 'agents');
+  });
+
+  expect(hasAgents).toBe(false);
+});
+
+// ── getExecutorColor() helper ───────────────────────────────────────────
+
+test('getExecutorColor("kilo") returns #e67700', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const color = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    return mod.getExecutorColor('kilo');
+  });
+
+  expect(color).toBe('#e67700');
+});
+
+test('getExecutorColor(undefined) returns fallback #999', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const color = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    return mod.getExecutorColor(undefined);
+  });
+
+  expect(color).toBe('#999');
+});
+
+test('getExecutorColor("unknown_executor") returns fallback #999', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const color = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    return mod.getExecutorColor('unknown_executor');
+  });
+
+  expect(color).toBe('#999');
+});
+
+// ── getExecutorOption() helper ──────────────────────────────────────────
+
+test('getExecutorOption("kilo") returns kilo entry', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const option = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    const opt = mod.getExecutorOption('kilo');
+    return { value: opt.value, label: opt.label, color: opt.color };
+  });
+
+  expect(option.value).toBe('kilo');
+  expect(option.label).toBe('Kilo');
+  expect(option.color).toBe('#e67700');
+});
+
+test('getExecutorOption("KILO") is case-insensitive', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const value = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    return mod.getExecutorOption('KILO').value;
+  });
+
+  expect(value).toBe('kilo');
+});
+
+// ── supportsResume() function ───────────────────────────────────────────
+
+test('supportsResume returns true for kilo record with session_id', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const result = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    const record = {
+      id: 1,
+      todo_id: 1,
+      status: 'success' as const,
+      command: 'kilo run --format json --dangerously-skip-permissions test',
+      stdout: '',
+      stderr: '',
+      result: 'done',
+      started_at: '2024-01-01T00:00:00Z',
+      finished_at: '2024-01-01T00:01:00Z',
+      usage: null,
+      executor: 'kilo',
+      model: null,
+      trigger_type: 'manual',
+      pid: null,
+      session_id: 'ses_kilo_001',
+    };
+    return mod.supportsResume(record);
+  });
+
+  expect(result).toBe(true);
+});
+
+test('supportsResume returns false for kilo record without session_id', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const result = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    const record = {
+      id: 1,
+      todo_id: 1,
+      status: 'success' as const,
+      command: 'kilo run',
+      stdout: '',
+      stderr: '',
+      result: 'done',
+      started_at: '2024-01-01T00:00:00Z',
+      finished_at: '2024-01-01T00:01:00Z',
+      usage: null,
+      executor: 'kilo',
+      model: null,
+      trigger_type: 'manual',
+      pid: null,
+      session_id: null,
+    };
+    return mod.supportsResume(record);
+  });
+
+  expect(result).toBe(false);
+});
+
+test('supportsResume returns false for running kilo record even with session_id', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const result = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    const record = {
+      id: 1,
+      todo_id: 1,
+      status: 'running' as const,
+      command: 'kilo run',
+      stdout: '',
+      stderr: '',
+      result: null,
+      started_at: '2024-01-01T00:00:00Z',
+      finished_at: null,
+      usage: null,
+      executor: 'kilo',
+      model: null,
+      trigger_type: 'manual',
+      pid: 1234,
+      session_id: 'ses_kilo_002',
+    };
+    return mod.supportsResume(record);
+  });
+
+  expect(result).toBe(false);
+});
+
+// ── Boundary / regression tests ─────────────────────────────────────────
+
+test('kilo color does not conflict with zhanlu or agents colors', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const colors = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    return {
+      kilo: mod.EXECUTOR_COLORS['kilo'],
+      zhanlu: mod.EXECUTOR_COLORS['zhanlu'],
+      agents: mod.EXECUTOR_COLORS['agents'],
+    };
+  });
+
+  // Each executor should have a distinct color to avoid visual confusion
+  expect(colors.kilo).not.toBe(colors.zhanlu);
+  expect(colors.kilo).not.toBe(colors.agents);
+  expect(colors.kilo).toBe('#e67700');
+});
+
+test('EXECUTORS list does not contain duplicate kilo entries', async ({ page }) => {
+  await page.goto(DEV_URL);
+
+  const kiloCount = await page.evaluate(async () => {
+    const mod = await import('/src/types/execution');
+    return mod.EXECUTORS.filter((e: { value: string }) => e.value === 'kilo').length;
+  });
+
+  expect(kiloCount).toBe(1);
+});


### PR DESCRIPTION
### 概述

新增 **Kilo** 执行器，类似已有的 Opencode 和 Zhanlu 执行器，提供另一种代码执行/管理方案。

### 变更文件

| 文件 | 说明 |
|------|------|
| `backend/src/adapters/kilo.rs` | Kilo 适配器核心逻辑（399 行） |
| `backend/src/adapters/kilo_event.rs` | Kilo 事件处理（105 行） |
| `backend/src/adapters/mod.rs` | 注册 Kilo 适配器 |
| `backend/src/handlers/skills.rs` | 技能处理器对接 Kilo |
| `backend/src/models/mod.rs` | 数据模型枚举扩展 |
| `frontend/src/types/execution.tsx` | 前端执行器类型补充 |

### 改动量

+528 / -6 行