### PR TITLE
feat(cli): add ntd loop automation commands for AI control

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,7 @@ ntd loop update <id> --name "新名称" --description "描述"
 # 删除 loop
 ntd loop delete <id>
 
-# 启动 loop（可指定 cron 调度或立即执行一次）
-ntd loop start <id>                                    # 立即执行一次
-ntd loop start <id> --schedule "0 */5 * * * *"       # 每5分钟执行
-ntd loop start <id> --param key=value                 # 带参数执行
-
-# 停止 loop（暂停所有触发器）
+# 停止 loop
 ntd loop stop <id>
 
 # 查看 loop 执行统计和最近执行

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ ntd --help       # 查看帮助
 ### Loop 命令
 
 Loop 是 ntd 的自动化循环任务功能，支持 Cron 调度和 AI 驱动的工作流。
+命令结构与 Todo 保持一致，降低认知成本。
 
 ```bash
 # 查看所有 loop
@@ -108,6 +109,12 @@ ntd loop list
 
 # 查看 loop 详情
 ntd loop get <id>
+
+# 更新 loop
+ntd loop update <id> --name "新名称" --description "描述"
+
+# 删除 loop
+ntd loop delete <id>
 
 # 启动 loop（可指定 cron 调度或立即执行一次）
 ntd loop start <id>                                    # 立即执行一次
@@ -117,18 +124,16 @@ ntd loop start <id> --param key=value                 # 带参数执行
 # 停止 loop（暂停所有触发器）
 ntd loop stop <id>
 
-# 查看 loop 状态和最近执行
-ntd loop status <id>                                   # 查看状态 + 最近5次执行
-ntd loop status <id> --recent 10                       # 查看最近10次执行
+# 查看 loop 执行统计和最近执行
+ntd loop stats <id>                                   # 查看 + 最近5次执行
+ntd loop stats <id> --recent 10                       # 查看最近10次执行
 
-# 手动触发 loop
-ntd loop trigger <id> --param project=myproject
+# 执行 loop（立即触发）
+ntd loop execute <id> --param message=hello
 
-# 查看执行历史
-ntd loop executions <id> --page 1 --limit 20
-
-# 查看执行详情
-ntd loop execution <loop_id> <execution_id>
+# 执行记录
+ntd loop execution list <loop_id>                     # 列出执行历史
+ntd loop execution get <execution_id>                 # 查看执行详情
 
 # 查看执行结果（步骤级摘要）
 ntd loop results <execution_id>

--- a/README.md
+++ b/README.md
@@ -98,6 +98,42 @@ ntd upgrade      # 升级到最新版本
 ntd --help       # 查看帮助
 ```
 
+### Loop 命令
+
+Loop 是 ntd 的自动化循环任务功能，支持 Cron 调度和 AI 驱动的工作流。
+
+```bash
+# 查看所有 loop
+ntd loop list
+
+# 查看 loop 详情
+ntd loop get <id>
+
+# 启动 loop（可指定 cron 调度或立即执行一次）
+ntd loop start <id>                                    # 立即执行一次
+ntd loop start <id> --schedule "0 */5 * * * *"       # 每5分钟执行
+ntd loop start <id> --param key=value                 # 带参数执行
+
+# 停止 loop（暂停所有触发器）
+ntd loop stop <id>
+
+# 查看 loop 状态和最近执行
+ntd loop status <id>                                   # 查看状态 + 最近5次执行
+ntd loop status <id> --recent 10                       # 查看最近10次执行
+
+# 手动触发 loop
+ntd loop trigger <id> --param project=myproject
+
+# 查看执行历史
+ntd loop executions <id> --page 1 --limit 20
+
+# 查看执行详情
+ntd loop execution <loop_id> <execution_id>
+
+# 查看执行结果（步骤级摘要）
+ntd loop results <execution_id>
+```
+
 ### Skill 安装
 
 `ntd skill install` 将内置的 ntd 使用技能安装到各 AI 执行器的 skill 目录（如 `~/.claude/skills/ntd-usage/`），让 AI 执行器在执行任务时能更好地理解和使用 ntd。

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -6,9 +6,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::models::{
-    ClientResponse, CreateTagRequest, CreateTodoRequest, CreateTriggerRequest, DashboardStats,
+    ClientResponse, CreateTagRequest, CreateTodoRequest, DashboardStats,
     ExecutionRecord, ExecutionRecordsPage, ExecutionSummary, Tag, Todo, ExecuteRequest, LoopDto,
-    TriggerLoopRequest, LoopTriggerDto,
+    TriggerLoopRequest,
 };
 use crate::cli::client::ApiClient;
 use crate::config;
@@ -299,21 +299,6 @@ pub enum LoopAction {
     Delete {
         /// Loop ID
         id: i64,
-    },
-    /// Start a loop (create a cron trigger to run it periodically)
-    Start {
-        /// Loop ID
-        id: i64,
-
-        /// Cron expression (e.g., "0 */5 * * * *" for every 5 minutes)
-        /// Use "once" to run immediately without cron, or specify a cron schedule.
-        #[arg(long, default_value = "once")]
-        schedule: String,
-
-        /// Parameters for placeholder replacement (key=value format, can be repeated)
-        /// Example: --param project_name=myproject --param env=production
-        #[arg(long = "param", num_args = 1, value_parser = parse_key_value)]
-        params: Option<Vec<(String, String)>>,
     },
     /// Stop a loop (pause all cron triggers)
     Stop {
@@ -748,32 +733,6 @@ async fn handle_loop(
         }
         LoopAction::Delete { id } => {
             let resp: ClientResponse<()> = client.delete(&format!("/loops/{}", id)).await?;
-            print_response(resp, output, fields)?;
-        }
-        LoopAction::Start { id, schedule, params } => {
-            // Create a cron trigger for the loop
-            let params_map: std::collections::HashMap<String, String> = params
-                .as_ref()
-                .map(|vec| vec.iter().cloned().collect())
-                .unwrap_or_default();
-            let req = CreateTriggerRequest {
-                trigger_type: if schedule == "once" {
-                    "manual".to_string()
-                } else {
-                    "cron".to_string()
-                },
-                // config 是 String 类型，需要序列化为 JSON 字符串
-                config: serde_json::to_string(&serde_json::json!({
-                    "cron": schedule,
-                    "params": params_map,
-                }))?,
-                enabled: true,
-                priority: 0,
-            };
-            let resp: ClientResponse<LoopTriggerDto> = client.post(
-                &format!("/loops/{}/triggers", id),
-                &req,
-            ).await?;
             print_response(resp, output, fields)?;
         }
         LoopAction::Stop { id } => {

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -278,6 +278,28 @@ pub enum LoopAction {
         /// Loop ID
         id: i64,
     },
+    /// Update loop
+    Update {
+        /// Loop ID
+        id: i64,
+
+        /// New name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// New description
+        #[arg(long)]
+        description: Option<String>,
+
+        /// New status (enabled/paused)
+        #[arg(long)]
+        status: Option<String>,
+    },
+    /// Delete loop
+    Delete {
+        /// Loop ID
+        id: i64,
+    },
     /// Start a loop (create a cron trigger to run it periodically)
     Start {
         /// Loop ID
@@ -298,8 +320,8 @@ pub enum LoopAction {
         /// Loop ID
         id: i64,
     },
-    /// Check loop status (get loop details with recent executions summary)
-    Status {
+    /// Get loop execution stats
+    Stats {
         /// Loop ID
         id: i64,
 
@@ -307,8 +329,8 @@ pub enum LoopAction {
         #[arg(long, default_value = "5")]
         recent: i64,
     },
-    /// Trigger (execute) a loop immediately
-    Trigger {
+    /// Execute loop
+    Execute {
         /// Loop ID
         id: i64,
 
@@ -318,10 +340,20 @@ pub enum LoopAction {
         #[arg(long = "param", num_args = 1, value_parser = parse_key_value)]
         params: Option<Vec<(String, String)>>,
     },
-    /// Get loop execution history
-    Executions {
+    /// Execution records
+    Execution {
+        #[command(subcommand)]
+        action: LoopExecutionAction,
+    },
+}
+
+/// Loop execution records subcommands
+#[derive(Debug, Clone, Subcommand)]
+pub enum LoopExecutionAction {
+    /// List execution records for a loop
+    List {
         /// Loop ID
-        id: i64,
+        loop_id: i64,
 
         /// Page number
         #[arg(long, default_value = "1")]
@@ -332,15 +364,7 @@ pub enum LoopAction {
         limit: i64,
     },
     /// Get execution details
-    Execution {
-        /// Loop ID
-        loop_id: i64,
-
-        /// Execution ID
-        execution_id: i64,
-    },
-    /// Get execution results (step-by-step summary)
-    Results {
+    Get {
         /// Execution ID
         execution_id: i64,
     },
@@ -703,6 +727,29 @@ async fn handle_loop(
             let resp: ClientResponse<LoopDto> = client.get(&format!("/loops/{}", id)).await?;
             print_response(resp, output, fields)?;
         }
+        LoopAction::Update { id, name, description, status } => {
+            // 构建部分更新 JSON，只包含提供的字段
+            let mut obj = serde_json::Map::new();
+            if let Some(n) = name {
+                obj.insert("name".to_string(), serde_json::Value::String(n.to_string()));
+            }
+            if let Some(d) = description {
+                obj.insert("description".to_string(), serde_json::Value::String(d.to_string()));
+            }
+            if let Some(s) = status {
+                obj.insert("status".to_string(), serde_json::Value::String(s.to_string()));
+            }
+            let req = serde_json::Value::Object(obj);
+            let resp: ClientResponse<LoopDto> = client.put(
+                &format!("/loops/{}", id),
+                &req,
+            ).await?;
+            print_response(resp, output, fields)?;
+        }
+        LoopAction::Delete { id } => {
+            let resp: ClientResponse<()> = client.delete(&format!("/loops/{}", id)).await?;
+            print_response(resp, output, fields)?;
+        }
         LoopAction::Start { id, schedule, params } => {
             // Create a cron trigger for the loop
             let params_map: std::collections::HashMap<String, String> = params
@@ -738,7 +785,7 @@ async fn handle_loop(
             ).await?;
             print_response(resp, output, fields)?;
         }
-        LoopAction::Status { id, recent } => {
+        LoopAction::Stats { id, recent } => {
             // Get loop details with recent executions combined into one response
             let resp: ClientResponse<LoopDto> = client.get(&format!("/loops/{}", id)).await?;
             let execs_resp: ClientResponse<serde_json::Value> = client.get(&format!(
@@ -757,7 +804,7 @@ async fn handle_loop(
             };
             print_response(final_resp, output, fields)?;
         }
-        LoopAction::Trigger { id, params } => {
+        LoopAction::Execute { id, params } => {
             let params_map: std::collections::HashMap<String, String> = params
                 .as_ref()
                 .map(|vec| vec.iter().cloned().collect())
@@ -769,29 +816,26 @@ async fn handle_loop(
             ).await?;
             print_response(resp, output, fields)?;
         }
-        LoopAction::Executions { id, page, limit } => {
-            let path = format!(
-                "/loops/{}/executions?page={}&limit={}",
-                id, page, limit
-            );
-            let resp: ClientResponse<serde_json::Value> = client.get(&path).await?;
-            print_response(resp, output, fields)?;
-        }
-        LoopAction::Execution { loop_id, execution_id } => {
-            let resp: ClientResponse<serde_json::Value> = client.get(&format!(
-                "/loops/{}/executions/{}",
-                loop_id, execution_id
-            )).await?;
-            print_response(resp, output, fields)?;
-        }
-        LoopAction::Results { execution_id } => {
-            // Get execution results by execution ID directly
-            // 注意: ApiClient 已经自动添加 /api 前缀，所以路径不要带 /api
-            let resp: ClientResponse<serde_json::Value> = client.get(&format!(
-                "/loop-executions/{}",
-                execution_id
-            )).await?;
-            print_response(resp, output, fields)?;
+        LoopAction::Execution { action } => {
+            match action {
+                LoopExecutionAction::List { loop_id, page, limit } => {
+                    let path = format!(
+                        "/loops/{}/executions?page={}&limit={}",
+                        loop_id, page, limit
+                    );
+                    let resp: ClientResponse<serde_json::Value> = client.get(&path).await?;
+                    print_response(resp, output, fields)?;
+                }
+                LoopExecutionAction::Get { execution_id } => {
+                    // Get execution results by execution ID directly
+                    // 注意: ApiClient 已经自动添加 /api 前缀，所以路径不要带 /api
+                    let resp: ClientResponse<serde_json::Value> = client.get(&format!(
+                        "/loop-executions/{}",
+                        execution_id
+                    )).await?;
+                    print_response(resp, output, fields)?;
+                }
+            }
         }
     }
     Ok(())

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -6,9 +6,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::models::{
-    ClientResponse, CreateTagRequest, CreateTodoRequest, DashboardStats, ExecutionRecord,
-    ExecutionRecordsPage, ExecutionSummary, Tag, Todo, ExecuteRequest, LoopDto,
-    TriggerLoopRequest,
+    ClientResponse, CreateTagRequest, CreateTodoRequest, CreateTriggerRequest, DashboardStats,
+    ExecutionRecord, ExecutionRecordsPage, ExecutionSummary, Tag, Todo, ExecuteRequest, LoopDto,
+    TriggerLoopRequest, LoopTriggerDto,
 };
 use crate::cli::client::ApiClient;
 use crate::config;
@@ -278,7 +278,36 @@ pub enum LoopAction {
         /// Loop ID
         id: i64,
     },
-    /// Trigger (execute) a loop
+    /// Start a loop (create a cron trigger to run it periodically)
+    Start {
+        /// Loop ID
+        id: i64,
+
+        /// Cron expression (e.g., "0 */5 * * * *" for every 5 minutes)
+        /// Use "once" to run immediately without cron, or specify a cron schedule.
+        #[arg(long, default_value = "once")]
+        schedule: String,
+
+        /// Parameters for placeholder replacement (key=value format, can be repeated)
+        /// Example: --param project_name=myproject --param env=production
+        #[arg(long = "param", num_args = 1, value_parser = parse_key_value)]
+        params: Option<Vec<(String, String)>>,
+    },
+    /// Stop a loop (pause all cron triggers)
+    Stop {
+        /// Loop ID
+        id: i64,
+    },
+    /// Check loop status (get loop details with recent executions summary)
+    Status {
+        /// Loop ID
+        id: i64,
+
+        /// Show recent executions (last N)
+        #[arg(long, default_value = "5")]
+        recent: i64,
+    },
+    /// Trigger (execute) a loop immediately
     Trigger {
         /// Loop ID
         id: i64,
@@ -307,6 +336,11 @@ pub enum LoopAction {
         /// Loop ID
         loop_id: i64,
 
+        /// Execution ID
+        execution_id: i64,
+    },
+    /// Get execution results (step-by-step summary)
+    Results {
         /// Execution ID
         execution_id: i64,
     },
@@ -669,6 +703,60 @@ async fn handle_loop(
             let resp: ClientResponse<LoopDto> = client.get(&format!("/loops/{}", id)).await?;
             print_response(resp, output, fields)?;
         }
+        LoopAction::Start { id, schedule, params } => {
+            // Create a cron trigger for the loop
+            let params_map: std::collections::HashMap<String, String> = params
+                .as_ref()
+                .map(|vec| vec.iter().cloned().collect())
+                .unwrap_or_default();
+            let req = CreateTriggerRequest {
+                trigger_type: if schedule == "once" {
+                    "manual".to_string()
+                } else {
+                    "cron".to_string()
+                },
+                // config 是 String 类型，需要序列化为 JSON 字符串
+                config: serde_json::to_string(&serde_json::json!({
+                    "cron": schedule,
+                    "params": params_map,
+                }))?,
+                enabled: true,
+                priority: 0,
+            };
+            let resp: ClientResponse<LoopTriggerDto> = client.post(
+                &format!("/loops/{}/triggers", id),
+                &req,
+            ).await?;
+            print_response(resp, output, fields)?;
+        }
+        LoopAction::Stop { id } => {
+            // Pause the loop by disabling all its triggers
+            let req = serde_json::json!({ "status": "paused" });
+            let resp: ClientResponse<LoopDto> = client.put(
+                &format!("/loops/{}/status", id),
+                &req,
+            ).await?;
+            print_response(resp, output, fields)?;
+        }
+        LoopAction::Status { id, recent } => {
+            // Get loop details with recent executions combined into one response
+            let resp: ClientResponse<LoopDto> = client.get(&format!("/loops/{}", id)).await?;
+            let execs_resp: ClientResponse<serde_json::Value> = client.get(&format!(
+                "/loops/{}/executions?page=1&limit={}",
+                id, recent
+            )).await?;
+            // Combine loop info and recent executions into a single JSON object
+            let combined = serde_json::json!({
+                "loop": resp.data,
+                "recent_executions": execs_resp.data,
+            });
+            let final_resp: ClientResponse<serde_json::Value> = ClientResponse {
+                code: execs_resp.code,
+                data: Some(combined),
+                message: execs_resp.message,
+            };
+            print_response(final_resp, output, fields)?;
+        }
         LoopAction::Trigger { id, params } => {
             let params_map: std::collections::HashMap<String, String> = params
                 .as_ref()
@@ -693,6 +781,14 @@ async fn handle_loop(
             let resp: ClientResponse<serde_json::Value> = client.get(&format!(
                 "/loops/{}/executions/{}",
                 loop_id, execution_id
+            )).await?;
+            print_response(resp, output, fields)?;
+        }
+        LoopAction::Results { execution_id } => {
+            // Get execution results by execution ID directly
+            let resp: ClientResponse<serde_json::Value> = client.get(&format!(
+                "/api/loop-executions/{}",
+                execution_id
             )).await?;
             print_response(resp, output, fields)?;
         }

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -786,8 +786,9 @@ async fn handle_loop(
         }
         LoopAction::Results { execution_id } => {
             // Get execution results by execution ID directly
+            // 注意: ApiClient 已经自动添加 /api 前缀，所以路径不要带 /api
             let resp: ClientResponse<serde_json::Value> = client.get(&format!(
-                "/api/loop-executions/{}",
+                "/loop-executions/{}",
                 execution_id
             )).await?;
             print_response(resp, output, fields)?;

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -29,7 +29,7 @@ use crate::models::{
     LoopDetail, LoopDto, LoopExecutionDetail, LoopExecutionDto, LoopExecutionTokenSummary,
     LoopListItem, LoopStepDto, LoopStepExecutionDto, LoopTriggerDto, ReorderLoopStepsRequest,
     UpdateLoopRequest, UpdateLoopStatusRequest, UpdateLoopStepRequest,
-    UpdateTriggerRequest, ApproveStepExecutionRequest, UpdateTagsRequest,
+    UpdateTriggerRequest, ApproveStepExecutionRequest, UpdateTagsRequest, TriggerLoopRequest,
 };
 
 const DEFAULT_PAGE_LIMIT: u64 = 20;
@@ -253,12 +253,18 @@ pub async fn update_loop_tags(
 pub async fn trigger_loop(
     State(state): State<AppState>,
     Path(id): Path<i64>,
+    Json(req): Json<TriggerLoopRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     let dispatcher = state
         .loop_trigger_dispatcher
         .as_ref()
         .ok_or_else(|| AppError::Internal("loop dispatcher not ready".to_string()))?;
-    match dispatcher.dispatch_manual(id).await {
+    // 将 params 存入 trigger_meta，供后续 step prompt 替换使用
+    let trigger_meta = serde_json::json!({
+        "source": "manual",
+        "params": req.params,
+    });
+    match dispatcher.dispatch_manual_with_meta(id, trigger_meta).await {
         Some(exec_id) => Ok(ApiResponse::ok(serde_json::json!({
             "execution_id": exec_id,
         }))),

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -432,7 +432,7 @@ pub struct TriggerLoopRequest {
     pub params: std::collections::HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateTriggerRequest {
     pub trigger_type: String,
     #[serde(default = "default_trigger_config")]

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -424,6 +424,19 @@ impl LoopRunner {
         // 否则 cwd/worktree 无法统一，跨空间数据流会导致不可预期的行为。
         self.check_workspace_consistency(&loop_, &all_steps).await?;
 
+        // 4. 加载 trigger_meta 中的 params（从 CLI/外部传入的变量）
+        let trigger_params: HashMap<String, String> = {
+            if let Ok(Some(exec)) = self.ctx.db.get_loop_execution(loop_execution_id).await {
+                if let Ok(meta) = serde_json::from_str::<serde_json::Value>(&exec.trigger_meta) {
+                    if let Some(params) = meta.get("params").and_then(|v| v.as_object()) {
+                        params.iter()
+                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                            .collect()
+                    } else { HashMap::new() }
+                } else { HashMap::new() }
+            } else { HashMap::new() }
+        };
+
         // 4. 初始化（全新执行）或恢复状态（续跑）
         let is_resume = resume_step_idx.is_some();
         if !is_resume {
@@ -579,7 +592,7 @@ impl LoopRunner {
 
             // 4f. 执行
             let record_id = match self
-                .start_step_todo_with_prompt(&todo, &trigger_type, idx as i64, step_exec.id, &enhanced_prompt, loop_.workspace_path.clone())
+                .start_step_todo_with_prompt(&todo, &trigger_type, idx as i64, step_exec.id, &enhanced_prompt, loop_.workspace_path.clone(), &trigger_params)
                 .await
             {
                 Ok(rid) => rid,
@@ -741,6 +754,7 @@ impl LoopRunner {
     }
 
     /// 启动 step 的执行，使用增强后的 Prompt。
+    /// trigger_params 是从 CLI/外部传入的变量，会合并到 params 中供 prompt 占位符替换。
     async fn start_step_todo_with_prompt(
         &self,
         todo: &crate::models::Todo,
@@ -749,7 +763,11 @@ impl LoopRunner {
         step_exec_id: i64,
         enhanced_prompt: &str,
         workspace_path: Option<String>,
+        trigger_params: &HashMap<String, String>,
     ) -> Result<i64, String> {
+        // 合并 trigger_params（CLI 传入的外部变量）和内置的 loop_step_index
+        let mut params = trigger_params.clone();
+        params.insert("loop_step_index".to_string(), loop_idx.to_string());
         let request = RunTodoExecutionRequest {
             db: self.ctx.db.clone(),
             executor_registry: self.ctx.executor_registry.clone(),
@@ -762,11 +780,7 @@ impl LoopRunner {
             message: enhanced_prompt.to_string(),
             req_executor: todo.executor.clone(),
             trigger_type: format!("loop_stage:{}", trigger_type),
-            params: Some({
-                let mut p = HashMap::new();
-                p.insert("loop_step_index".to_string(), loop_idx.to_string());
-                p
-            }),
+            params: Some(params),
             resume_session_id: None,
             resume_message: None,
             source_todo_id: None,

--- a/backend/src/services/loop_trigger.rs
+++ b/backend/src/services/loop_trigger.rs
@@ -255,6 +255,16 @@ impl LoopTriggerDispatcher {
         &self,
         loop_id: i64,
     ) -> Option<i64> {
+        let meta = serde_json::json!({ "source": "manual" });
+        self.dispatch_manual_with_meta(loop_id, meta).await
+    }
+
+    /// 手动触发（带自定义 meta）：trigger_id 为 None，支持传入 params 等元数据。
+    pub async fn dispatch_manual_with_meta(
+        &self,
+        loop_id: i64,
+        trigger_meta: serde_json::Value,
+    ) -> Option<i64> {
         let loop_ = self.ctx.db.get_loop(loop_id).await.ok().flatten();
         if loop_.is_none() {
             return None;
@@ -266,8 +276,7 @@ impl LoopTriggerDispatcher {
             );
             return None;
         }
-        let meta = serde_json::json!({ "source": "manual" });
-        let id = self.spawn_run(loop_id, None, "manual", meta).await;
+        let id = self.spawn_run(loop_id, None, "manual", trigger_meta).await;
         if id > 0 { Some(id) } else { None }
     }
 


### PR DESCRIPTION
## 功能说明

为 `ntd loop` 添加 CLI 命令，支持 AI 自动化控制 Loop 执行。

### 新增命令

| 命令 | 说明 |
|------|------|
| `ntd loop execute <id> --param key=value` | 执行 loop，传递参数到 step prompt 占位符 |
| `ntd loop stats <id>` | 查看 loop 执行统计和最近执行 |
| `ntd loop execution list <loop_id>` | 列出执行历史 |
| `ntd loop execution get <exec_id>` | 查看执行详情 |
| `ntd loop update <id>` | 更新 loop |
| `ntd loop delete <id>` | 删除 loop |
| `ntd loop stop <id>` | 停止 loop |

### 核心改进

1. **参数传递**：`--param key=value` 会注入到 step prompt 的 `{{key}}` 占位符
2. **命令对齐**：loop 子命令与 todo 子命令结构完全一致
3. **执行结果获取**：通过 `loop execution get <exec_id>` 获取完整执行结果

### 使用示例

```bash
# 执行 loop 并传递参数
ntd loop execute 1 --param message="hello world"

# 在 step prompt 中使用 {{message}} 占位符
# 实际执行时会被替换为 "hello world"

# 查看执行结果
ntd loop execution get 123
```

## 技术改动

- `handlers/loop_.rs`: `trigger_loop` 接受 `TriggerLoopRequest` 并传递 params
- `services/loop_trigger.rs`: 新增 `dispatch_manual_with_meta` 方法
- `services/loop_runner.rs`: 从 `trigger_meta` 提取 params 传递给 step 执行
- `cli/commands.rs`: 新增 loop 子命令，与 todo 命令结构对齐
