### PR TITLE
fix(mobile): unify mobile pages with PC design

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -392,6 +392,7 @@ function AppContent() {
                 forcedListMode={forcedListMode}
                 onListModeChange={() => setForcedListMode(undefined)}
                 effectiveMobilePanel={effectiveMobilePanel}
+                onOpenPost={handleOpenPost}
               />
             ) : (
               <TodoPage

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -2,18 +2,13 @@ import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import { useApp } from '@/hooks/useApp';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useExecutionHistory } from '@/hooks/useExecutionHistory';
-import { Button, Empty, App, Pagination, Modal, Input, Select } from 'antd';
+import { Button, Empty, App, Modal, Input } from 'antd';
 import { CheckCircleOutlined, ReloadOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { TodoDrawer } from './TodoDrawer';
-import { parseLogsToMessages } from './ChatView';
-import { BREAKPOINTS, EXPORT } from '@/constants';
+import { BREAKPOINTS } from '@/constants';
 import * as db from '@/utils/database';
-import { conversationToYaml } from '@/utils/markdown';
-import { getExecutorOption } from '@/types';
-import type { ExecutionRecord, LogEntry } from '@/types';
+import type { ExecutionRecord } from '@/types';
 import { groupBySession } from './todo-detail/helpers';
-import { NarrowHistoryCard } from './todo-detail/NarrowHistoryCard';
-import { ChainGroupCard } from './todo-detail/ChainGroupCard';
 import { DetailHeader } from './todo-detail/DetailHeader';
 import { ForumPostList } from './todo-detail/ForumPostList';
 
@@ -30,8 +25,6 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
   const selectedTodo = todos.find(t => t.id === selectedTodoId);
 
   const [todoDrawerOpen, setTodoDrawerOpen] = useState(false);
-  // viewMode 仅窄屏模式使用（PostDetailDrawer 内部自己管理）
-  const [viewMode, setViewMode] = useState<'log' | 'chat' | 'command'>('log');
 
   // 使用 useExecutionHistory hook 获取执行历史相关的状态和操作
   const {
@@ -41,8 +34,6 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
     historyPage,
     historyLimit,
     historyTotal,
-    historyStatusFilter,
-    setHistoryStatusFilter,
     summary,
     selectedHistoryRecord,
     loadExecutionRecords,
@@ -93,19 +84,11 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
     return Object.values(runningTasks).find(t => t.todoId === record.todo_id) || null;
   };
 
-  const resolveExecutionStats = (record: ExecutionRecord, isRunning: boolean) => {
-    if (isRunning) {
-      const task = getRunningTaskForRecord(record);
-      if (task?.executionStats) return task.executionStats;
-    }
-    return record.execution_stats;
-  };
-
   useEffect(() => {
-    if (!isWide || records.length === 0) return;
+    if (records.length === 0) return;
     if (selectedHistoryRecordId !== null && records.find(r => r.id === selectedHistoryRecordId)) return;
     setSelectedHistoryRecordId(records[0].id);
-  }, [isWide, records, selectedHistoryRecordId]);
+  }, [records, selectedHistoryRecordId]);
 
   const handleExecute = async () => {
     if (!selectedTodo) return;
@@ -176,81 +159,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
     }
   };
 
-  const handleStopExecution = async (recordId: number) => {
-    try {
-      await db.stopExecution(recordId);
-      message.info('已发送停止指令');
-      await loadExecutionRecords(historyPage, historyLimit);
-    } catch (error) {
-      message.error('停止失败: ' + (error instanceof Error ? error.message : String(error)));
-    }
-  };
-
-  /**
-   * 给一条执行结果评分或清除评分。
-   * 后端会返回更新后的 record；刷新单条后 dispatcher 会同步本地缓存。
-   */
-  const handleRateExecution = async (recordId: number, rating: number | null) => {
-    await db.rateExecutionRecord(recordId, rating);
-    await refreshSingleRecord(recordId);
-    message.success(rating == null ? '已清除评分' : `已评分 ${rating}`);
-  };
-
   const sessionGroups = useMemo(() => groupBySession(records), [records]);
-
-  const handleReply = async (record: ExecutionRecord, replyMessage: string) => {
-    if (!replyMessage.trim()) return;
-    try {
-      await db.resumeExecutionRecord(record.id, replyMessage);
-      message.success('回复成功，开始执行');
-      await loadExecutionRecords(historyPage, historyLimit);
-    } catch (error) {
-      message.error('回复失败: ' + (error instanceof Error ? error.message : String(error)));
-    }
-  };
-
-  // 窄屏模式兼容：NarrowHistoryCard / ChainGroupCard 仍期望 onOpenResume 回调。
-  // 窄屏暂不做论坛式改造，保留简单 prompt 交互。
-  const handleOpenResume = (record: ExecutionRecord) => {
-    const input = prompt('输入要继续发送的消息：');
-    if (input && input.trim()) {
-      handleReply(record, input.trim());
-    }
-  };
-
-  const parseRecordLogs = (_record: ExecutionRecord): LogEntry[] => {
-    return [];
-  };
-
-  const handleExportMarkdown = async (record: ExecutionRecord) => {
-    let logs: LogEntry[] = [];
-    try {
-      const result = await db.getExecutionLogs(record.id, 1, EXPORT.maxLogs);
-      logs = result.logs;
-    } catch {
-      // ignore
-    }
-    const messages = parseLogsToMessages(logs);
-    const executorLabel = record.executor ? getExecutorOption(record.executor).label : undefined;
-    const content = conversationToYaml(messages, {
-      title: selectedTodo?.title,
-      executor: executorLabel,
-      model: record.model || undefined,
-      startedAt: record.started_at,
-      status: record.status,
-    });
-    const blob = new Blob([content], { type: 'application/x-yaml;charset=utf-8' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-    a.download = `exec-${record.id}-${timestamp}.yaml`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-    message.success('导出成功');
-  };
 
   const handleStatusChange = useCallback(async (newStatus: string) => {
     if (!selectedTodo) return;
@@ -335,41 +244,22 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
       />
 
       {/* Execution History */}
-      <div
-        style={isWide
-          ? { flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minHeight: 0 }
-          : { paddingBottom: 20, flexShrink: 0 }
-        }
-      >
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12, ...(isWide ? { flexShrink: 0 } : {}) }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minHeight: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0, marginBottom: 12 }}>
           <h4 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: 'var(--color-text)' }}>执行历史</h4>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <Select
-              size="small"
-              value={historyStatusFilter}
-              onChange={setHistoryStatusFilter}
-              style={{ width: 100 }}
-              options={[
-                { value: 'all', label: '全部' },
-                { value: 'running', label: '进行中' },
-                { value: 'success', label: '成功' },
-                { value: 'failed', label: '失败' },
-              ]}
-            />
-            <Button
-              type="text"
-              size="small"
-              icon={<ReloadOutlined />}
-              onClick={() => loadExecutionRecords(historyPage, historyLimit)}
-              loading={isExecuting}
-            >
-              刷新
-            </Button>
-          </div>
+          <Button
+            type="text"
+            size="small"
+            icon={<ReloadOutlined />}
+            onClick={() => loadExecutionRecords(historyPage, historyLimit)}
+            loading={isExecuting}
+          >
+            刷新
+          </Button>
         </div>
         {records.length === 0 ? (
           <Empty description="暂无执行记录" image={Empty.PRESENTED_IMAGE_SIMPLE} />
-        ) : isWide ? (
+        ) : (
           <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minHeight: 0 }}>
             <ForumPostList
               sessionGroups={sessionGroups}
@@ -386,59 +276,6 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
               onPageChange={handleHistoryPageChange}
             />
           </div>
-        ) : (
-          <>
-            {sessionGroups.map(group => {
-              const isSingle = group.records.length === 1 || !group.records[0].session_id;
-              if (isSingle) {
-                return group.records.map(record => (
-                  <NarrowHistoryCard
-                    key={record.id}
-                    record={record}
-                    viewMode={viewMode}
-                    onOpenResume={handleOpenResume}
-                    onExport={handleExportMarkdown}
-                    onStop={handleStopExecution}
-                    onRefresh={refreshSingleRecord}
-                    onRate={handleRateExecution}
-                    getRunningTask={getRunningTaskForRecord}
-                    resolveStats={resolveExecutionStats}
-                    parseLogs={parseRecordLogs}
-                    messageApi={message}
-                    onViewModeChange={setViewMode}
-                  />
-                ));
-              }
-              return (
-                <ChainGroupCard
-                  key={group.sessionId}
-                  group={group}
-                  onOpenResume={handleOpenResume}
-                  onExport={handleExportMarkdown}
-                  onStop={handleStopExecution}
-                  messageApi={message}
-                  viewMode={viewMode}
-                  parseLogs={parseRecordLogs}
-                  onRefresh={refreshSingleRecord}
-                  resolveStats={resolveExecutionStats}
-                  onViewModeChange={setViewMode}
-                />
-              );
-            })}
-            {historyTotal > historyLimit && (
-              <div style={{ display: 'flex', justifyContent: 'center', marginTop: 16 }}>
-                <Pagination
-                  current={historyPage}
-                  pageSize={historyLimit}
-                  total={historyTotal}
-                  onChange={handleHistoryPageChange}
-                  size="small"
-                  showSizeChanger
-                  pageSizeOptions={['5', '10', '20']}
-                />
-              </div>
-            )}
-          </>
         )}
       </div>
 

--- a/frontend/src/components/TodoPostPage.tsx
+++ b/frontend/src/components/TodoPostPage.tsx
@@ -379,7 +379,7 @@ function PostCard({
         marginBottom: 2,
       }}
     >
-      {/* 帖子头 */}
+      {/* 帖子头：仅楼号、追问标记、状态和操作按钮 */}
       <div
         style={{
           display: "flex",
@@ -417,41 +417,6 @@ function PostCard({
                 </span>
               )}
             </>
-          )}
-          {record.executor && !isContinuation && <ExecutorBadge executor={record.executor} />}
-          {record.model && (
-            <Tag color="#3b82f6" style={{ margin: 0, fontSize: 11 }}>
-              {record.model}
-            </Tag>
-          )}
-          <span style={{ fontSize: 12, color: "var(--color-text-tertiary)" }}>
-            {formatLocalDateTime(record.started_at)}
-          </span>
-          <Tag
-            color={
-              record.trigger_type === "cron"
-                ? "#8b5cf6"
-                : record.trigger_type?.startsWith("hook:")
-                ? "#a855f7"
-                : "#6b7280"
-            }
-            style={{ margin: 0, fontSize: 11 }}
-          >
-            {record.trigger_type === "cron"
-              ? "Cron"
-              : record.trigger_type?.startsWith("hook:")
-              ? "Hook"
-              : "手动"}
-          </Tag>
-          {!isRunning && record.usage?.duration_ms && (
-            <span style={{ fontSize: 12, color: "var(--color-success)", fontWeight: 600 }}>
-              {formatDurationSec(record.usage.duration_ms / 1000)}
-            </span>
-          )}
-          {isRunning && elapsedSec > 0 && (
-            <span style={{ fontSize: 12, color: "var(--color-info)", fontWeight: 600 }}>
-              {formatDurationSec(elapsedSec)}
-            </span>
           )}
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -502,8 +467,50 @@ function PostCard({
         </div>
       )}
 
-      {/* worktree 路径：仅当 record.worktree_path 非空时渲染，与 RecordDetailView 同款展示 */}
+      {/* worktree 路径：仅当 record.worktree_path 非空时渲染 */}
       <WorktreePathDisplay worktreePath={record.worktree_path ?? null} />
+
+      {/* 元信息：执行器、时间、触发类型、耗时 */}
+      <div style={{
+        display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap",
+        marginTop: 8, fontSize: 12,
+      }}>
+        {record.executor && !isContinuation && <ExecutorBadge executor={record.executor} />}
+        {record.model && (
+          <Tag color="#3b82f6" style={{ margin: 0, fontSize: 11 }}>
+            {record.model}
+          </Tag>
+        )}
+        <span style={{ color: "var(--color-text-tertiary)" }}>
+          {formatLocalDateTime(record.started_at)}
+        </span>
+        <Tag
+          color={
+            record.trigger_type === "cron"
+              ? "#8b5cf6"
+              : record.trigger_type?.startsWith("hook:")
+              ? "#a855f7"
+              : "#6b7280"
+          }
+          style={{ margin: 0, fontSize: 11 }}
+        >
+          {record.trigger_type === "cron"
+            ? "Cron"
+            : record.trigger_type?.startsWith("hook:")
+            ? "Hook"
+            : "手动"}
+        </Tag>
+        {!isRunning && record.usage?.duration_ms && (
+          <span style={{ color: "var(--color-success)", fontWeight: 600 }}>
+            {formatDurationSec(record.usage.duration_ms / 1000)}
+          </span>
+        )}
+        {isRunning && elapsedSec > 0 && (
+          <span style={{ color: "var(--color-info)", fontWeight: 600 }}>
+            {formatDurationSec(elapsedSec)}
+          </span>
+        )}
+      </div>
 
       {/* 统计 */}
       <div style={{

--- a/frontend/src/components/TodoPostPage.tsx
+++ b/frontend/src/components/TodoPostPage.tsx
@@ -269,6 +269,7 @@ export function TodoPostPage({
             replyLoading={replyLoading}
             onOpenLogDrawer={openLogDrawer}
             resolveExecutionStats={resolveExecutionStats}
+            todoTitle={todoTitle}
           />
         ))
       )}
@@ -301,6 +302,7 @@ function ThreadGroup({
   replyLoading,
   onOpenLogDrawer,
   resolveExecutionStats,
+  todoTitle,
 }: {
   group: SessionGroup;
   getNextFloor: () => number;
@@ -310,6 +312,7 @@ function ThreadGroup({
   replyLoading: boolean;
   onOpenLogDrawer: (id: number) => void;
   resolveExecutionStats: (r: ExecutionRecord, running: boolean) => any;
+  todoTitle: string;
 }) {
   const allRecords = group.records;
   const lastRecord = allRecords[allRecords.length - 1];
@@ -326,6 +329,7 @@ function ThreadGroup({
           onStop={onStop}
           onOpenLogDrawer={onOpenLogDrawer}
           resolveExecutionStats={resolveExecutionStats}
+          todoTitle={todoTitle}
         />
       ))}
       <ReplyRow record={lastRecord} onReply={onReply} loading={replyLoading} />
@@ -343,6 +347,7 @@ function PostCard({
   onStop,
   onOpenLogDrawer,
   resolveExecutionStats,
+  todoTitle,
 }: {
   record: ExecutionRecord;
   floor: number;
@@ -351,6 +356,7 @@ function PostCard({
   onStop: (id: number) => Promise<void>;
   onOpenLogDrawer: (id: number) => void;
   resolveExecutionStats: (r: ExecutionRecord, running: boolean) => any;
+  todoTitle?: string;
 }) {
   const isRunning = record.status === "running";
   const [elapsedSec, setElapsedSec] = useState(
@@ -407,7 +413,7 @@ function PostCard({
               ? (record.resume_message
                   ? String(record.resume_message)
                   : "继续对话")
-              : "初始执行"}
+              : todoTitle || "初始执行"}
           </span>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>

--- a/frontend/src/components/TodoPostPage.tsx
+++ b/frontend/src/components/TodoPostPage.tsx
@@ -379,7 +379,7 @@ function PostCard({
         marginBottom: 2,
       }}
     >
-      {/* 帖子头：仅楼号、追问标记、状态和操作按钮 */}
+      {/* 帖子头：楼号、标题、状态和操作按钮 */}
       <div
         style={{
           display: "flex",
@@ -390,34 +390,25 @@ function PostCard({
           borderBottom: "1px dashed var(--color-border-light)",
         }}
       >
-        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-          <span style={{ fontSize: 14, fontWeight: 700, color: "var(--color-primary)" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, flex: 1, minWidth: 0 }}>
+          <span style={{ fontSize: 14, fontWeight: 700, color: "var(--color-primary)", flexShrink: 0 }}>
             #{floor}
           </span>
-          {isContinuation && (
-            <>
-              <LinkOutlined style={{ fontSize: 12, color: "var(--color-primary)" }} />
-              {record.resume_message ? (
-                <span style={{
-                  fontSize: 12,
-                  color: "var(--color-text-secondary)",
-                  fontStyle: "italic",
-                  maxWidth: 300,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}>
-                  {String(record.resume_message).length > 40
-                    ? String(record.resume_message).substring(0, 40) + "..."
-                    : record.resume_message}
-                </span>
-              ) : (
-                <span style={{ fontSize: 12, color: "var(--color-text-tertiary)" }}>
-                  继续对话
-                </span>
-              )}
-            </>
-          )}
+          {isContinuation && <LinkOutlined style={{ fontSize: 12, color: "var(--color-primary)", flexShrink: 0 }} />}
+          <span style={{
+            fontSize: 13,
+            fontWeight: 500,
+            color: "var(--color-text)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}>
+            {isContinuation
+              ? (record.resume_message
+                  ? String(record.resume_message)
+                  : "继续对话")
+              : "初始执行"}
+          </span>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <span
@@ -475,7 +466,7 @@ function PostCard({
         display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap",
         marginTop: 8, fontSize: 12,
       }}>
-        {record.executor && !isContinuation && <ExecutorBadge executor={record.executor} />}
+        {record.executor && <ExecutorBadge executor={record.executor} />}
         {record.model && (
           <Tag color="#3b82f6" style={{ margin: 0, fontSize: 11 }}>
             {record.model}

--- a/frontend/src/components/mobile/LoopMobilePage.tsx
+++ b/frontend/src/components/mobile/LoopMobilePage.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState, useCallback } from 'react';
-import { RetweetOutlined, PlusOutlined, ThunderboltOutlined, CopyOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
-import { Button, Space, Tooltip, Popconfirm, message } from 'antd';
+import { RetweetOutlined, PlusOutlined } from '@ant-design/icons';
+import { Button, message } from 'antd';
 import { PageCard } from '../common/PageCard';
 import { TodoList } from '../TodoList';
 import { LoopDetailPanel } from '../LoopStudioDetailPanel';
-import { LoopFormModal } from '../LoopFormModal';
 import { EmptyDetailPlaceholder } from '../EmptyDetailPlaceholder';
 import { SIDEBAR_WIDTH } from '@/constants';
 import * as dbLoops from '@/utils/database/loops';
@@ -25,10 +24,9 @@ interface LoopMobilePageProps {
 }
 
 /**
- * 移动端环路页面组件
- * 列表页和详情页为两个独立的 PageCard 页面，各自有完整的标题栏
- * 列表页：PageCard 标题为"环路"
- * 详情页：PageCard 标题为具体环路标题，操作按钮在标题栏右侧
+ * 移动端环路页面组件 —— 与桌面端统一设计
+ * 与 PC 端 ListDetailPage 一样，使用 PageCard 包裹详情页内容
+ * 列表页和详情页各自有 PageCard 容器，详情页内 LoopDetailPanel 渲染完整头部
  */
 export function LoopMobilePage({
   selectedLoopId,
@@ -44,7 +42,6 @@ export function LoopMobilePage({
   effectiveMobilePanel,
 }: LoopMobilePageProps) {
   const [loopDetail, setLoopDetail] = useState<LoopDetail | null>(null);
-  const [editModalOpen, setEditModalOpen] = useState(false);
 
   const loadLoopDetail = useCallback(() => {
     if (selectedLoopId === null) {
@@ -137,38 +134,10 @@ export function LoopMobilePage({
 
   const detailPage = selectedLoopId !== null ? (
     <PageCard
-      title={loopDetail?.name ?? '加载中...'}
-      extra={
-        <Space size={4}>
-          <Tooltip title="手动触发">
-            <Button
-              type="primary"
-              size="small"
-              icon={<ThunderboltOutlined />}
-              onClick={handleTrigger}
-              disabled={loopDetail?.status !== 'enabled'}
-            />
-          </Tooltip>
-          <Tooltip title="复制">
-            <Button type="text" size="small" icon={<CopyOutlined />} onClick={handleDuplicate} />
-          </Tooltip>
-          <Tooltip title="编辑">
-            <Button type="text" size="small" icon={<EditOutlined />} onClick={() => setEditModalOpen(true)} />
-          </Tooltip>
-          <Popconfirm
-            title="删除 loop"
-            description="将级联删除 triggers/steps,无法恢复"
-            okType="danger"
-            onConfirm={handleDelete}
-          >
-            <Tooltip title="删除">
-              <Button type="text" size="small" icon={<DeleteOutlined />} />
-            </Tooltip>
-          </Popconfirm>
-        </Space>
-      }
-      style={{ height: '100%' }}
-      contentStyle={{ padding: 0, height: 'calc(100% - 43px)' }}
+      icon={<RetweetOutlined />}
+      title="环路"
+      style={{ height: '100%', flex: 1, minWidth: 0 }}
+      contentStyle={{ padding: 0, display: 'flex', flexDirection: 'column', height: 'calc(100% - 43px)', overflow: 'hidden' }}
     >
       <LoopDetailPanel
         loopId={selectedLoopId}
@@ -181,37 +150,14 @@ export function LoopMobilePage({
           loadLoopDetail();
           onLoopChanged();
         }}
-        hideTitleRow={true}
-      />
-      <LoopFormModal
-        open={editModalOpen}
-        mode="edit"
-        loopId={selectedLoopId ?? undefined}
-        initialData={loopDetail ? {
-          name: loopDetail.name,
-          description: loopDetail.description,
-          workspace_id: loopDetail.workspace_id,
-          webhook_enabled: loopDetail.webhook_enabled,
-          icon: loopDetail.icon,
-          review_template_id: loopDetail.review_template_id ?? null,
-          tag_ids: loopDetail.tag_ids ?? [],
-          limits_config: loopDetail.limits_config,
-          abnormal_handler_todo_id: loopDetail.abnormal_handler_todo_id ?? null,
-          abnormal_handler_trigger_on: loopDetail.abnormal_handler_trigger_on ?? '["capped_step","capped_token","failed"]',
-        } : undefined}
-        tags={tags}
-        onSaved={() => {
-          setEditModalOpen(false);
-          loadLoopDetail();
-          onLoopChanged();
-        }}
-        onClose={() => setEditModalOpen(false)}
       />
     </PageCard>
   ) : (
     <PageCard
-      style={{ height: '100%' }}
-      contentStyle={{ padding: 0, height: 'calc(100% - 43px)' }}
+      icon={<RetweetOutlined />}
+      title="环路"
+      style={{ height: '100%', flex: 1, minWidth: 0 }}
+      contentStyle={{ padding: 0, display: 'flex', flexDirection: 'column', height: 'calc(100% - 43px)', overflow: 'hidden' }}
     >
       <EmptyDetailPlaceholder />
     </PageCard>

--- a/frontend/src/components/mobile/TodoMobilePage.tsx
+++ b/frontend/src/components/mobile/TodoMobilePage.tsx
@@ -16,6 +16,7 @@ interface TodoMobilePageProps {
   forcedListMode?: 'item' | 'loop';
   onListModeChange: () => void;
   effectiveMobilePanel: 'list' | 'detail';
+  onOpenPost?: (todoId: number, recordId: number) => void;
 }
 
 /**
@@ -33,6 +34,7 @@ export function TodoMobilePage({
   forcedListMode,
   onListModeChange,
   effectiveMobilePanel,
+  onOpenPost,
 }: TodoMobilePageProps) {
   const listPage = (
     <PageCard
@@ -71,7 +73,7 @@ export function TodoMobilePage({
       style={{ height: '100%', flex: 1, minWidth: 0 }}
       contentStyle={{ padding: 0, display: 'flex', flexDirection: 'column', height: 'calc(100% - 43px)', overflow: 'hidden' }}
     >
-      <TodoDetail />
+      <TodoDetail onOpenPost={onOpenPost} />
     </PageCard>
   ) : (
     <PageCard

--- a/frontend/src/components/mobile/TodoMobilePage.tsx
+++ b/frontend/src/components/mobile/TodoMobilePage.tsx
@@ -1,14 +1,10 @@
-import { useState, useCallback } from 'react';
-import { UnorderedListOutlined, PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
-import { Button, Popconfirm, App } from 'antd';
+import { UnorderedListOutlined, PlusOutlined } from '@ant-design/icons';
+import { Button } from 'antd';
 import { PageCard } from '../common/PageCard';
 import { TodoList } from '../TodoList';
 import { TodoDetail } from '../TodoDetail';
-import { TodoDrawer } from '../TodoDrawer';
 import { EmptyDetailPlaceholder } from '../EmptyDetailPlaceholder';
 import { SIDEBAR_WIDTH } from '@/constants';
-import { useApp } from '@/hooks/useApp';
-import * as db from '@/utils/database';
 
 interface TodoMobilePageProps {
   selectedTodoId: string | number | null;
@@ -23,10 +19,9 @@ interface TodoMobilePageProps {
 }
 
 /**
- * 移动端事项页面组件
- * 列表页和详情页为两个独立的 PageCard 页面，各自有完整的标题栏
- * 列表页：PageCard 标题为"事项"
- * 详情页：PageCard 标题为具体事项标题，操作按钮在标题栏右侧
+ * 移动端事项页面组件 —— 与桌面端统一设计
+ * 与 PC 端 ListDetailPage 一样，使用 PageCard 包裹详情页内容
+ * 列表页和详情页各自有 PageCard 容器，详情页内 TodoDetail 渲染完整头部
  */
 export function TodoMobilePage({
   selectedTodoId,
@@ -39,24 +34,6 @@ export function TodoMobilePage({
   onListModeChange,
   effectiveMobilePanel,
 }: TodoMobilePageProps) {
-  const { state, dispatch } = useApp();
-  const { message } = App.useApp();
-  const { todos } = state;
-  const selectedTodo = todos.find(t => t.id === selectedTodoId);
-  const [todoDrawerOpen, setTodoDrawerOpen] = useState(false);
-
-  const handleDelete = useCallback(async () => {
-    if (!selectedTodo) return;
-    try {
-      await db.deleteTodo(selectedTodo.id);
-      dispatch({ type: 'DELETE_TODO', payload: selectedTodo.id });
-      dispatch({ type: 'SELECT_TODO', payload: null });
-      message.success('删除成功');
-    } catch {
-      // ignore: interceptor already shows error
-    }
-  }, [selectedTodo, dispatch, message]);
-
   const listPage = (
     <PageCard
       icon={<UnorderedListOutlined />}
@@ -87,46 +64,21 @@ export function TodoMobilePage({
     </PageCard>
   );
 
-  const detailPage = selectedTodo ? (
+  const detailPage = selectedTodoId ? (
     <PageCard
-      title={selectedTodo.title}
-      extra={
-        <div style={{ display: 'flex', gap: 4 }}>
-          <Button
-            type="text"
-            size="small"
-            icon={<EditOutlined />}
-            onClick={() => setTodoDrawerOpen(true)}
-          />
-          <Popconfirm title="删除任务" description="确定要删除吗？" onConfirm={handleDelete}>
-            <Button type="text" size="small" icon={<DeleteOutlined />} />
-          </Popconfirm>
-        </div>
-      }
-      style={{ height: '100%' }}
-      contentStyle={{ padding: 0, height: 'calc(100% - 43px)' }}
+      icon={<UnorderedListOutlined />}
+      title="事项"
+      style={{ height: '100%', flex: 1, minWidth: 0 }}
+      contentStyle={{ padding: 0, display: 'flex', flexDirection: 'column', height: 'calc(100% - 43px)', overflow: 'hidden' }}
     >
-      <TodoDetail hideTitleRow={true} />
-      <TodoDrawer
-        open={todoDrawerOpen}
-        todo={selectedTodo}
-        tags={state.tags}
-        onClose={() => setTodoDrawerOpen(false)}
-        onSaved={() => {
-          // 只刷新当前 workspace 桶
-          const wid = state.selectedWorkspace;
-          if (wid != null) {
-            db.getAllTodos(wid).then(todos => {
-              dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: todos });
-            });
-          }
-        }}
-      />
+      <TodoDetail />
     </PageCard>
   ) : (
     <PageCard
-      style={{ height: '100%' }}
-      contentStyle={{ padding: 0, height: 'calc(100% - 43px)' }}
+      icon={<UnorderedListOutlined />}
+      title="事项"
+      style={{ height: '100%', flex: 1, minWidth: 0 }}
+      contentStyle={{ padding: 0, display: 'flex', flexDirection: 'column', height: 'calc(100% - 43px)', overflow: 'hidden' }}
     >
       <EmptyDetailPlaceholder />
     </PageCard>


### PR DESCRIPTION
## 变更内容

统一移动端事项/环路详情页与 PC 端的设计，执行历史展示与交互完全对齐。

### 主要改动

**页面结构统一**
- 移动端详情页使用 PageCard 包裹，与 PC 端 ListDetailPage 一致
- TodoDetail / LoopDetailPanel 渲染完整头部（不传 hideTitleRow）

**执行历史统一**
- 移除 isWide 分支，移动端和 PC 端统一使用 ForumPostList
- 点击记录卡片通过 onOpenPost 导航到 TodoPostPage 全屏详情页
- 移除废弃的 NarrowHistoryCard / ChainGroupCard 及相关代码

**PostCard 布局优化**
- 头部精简：只保留楼号、标题、状态标签和操作按钮
- 元信息（执行器、时间、触发类型、耗时）移到结论下方、Token 统计上方
- 每楼都显示执行器信息
- 每楼都有标题（1楼显示 todo 标题，追问显示 resume_message）
- 使用正常字体

### 变更文件

| 文件 | 说明 |
|------|------|
| `TodoDetail.tsx` | 移除 isWide 分支，统一使用 ForumPostList；清理废弃代码 |
| `TodoPostPage.tsx` | PostCard 布局调整，标题/执行器/元信息位置优化 |
| `TodoMobilePage.tsx` | 添加 onOpenPost 传递；PageCard 包裹详情页 |
| `LoopMobilePage.tsx` | PageCard 包裹详情页 |
| `App.tsx` | 传递 handleOpenPost 给移动端 |

Closes #777