### PR TITLE
feat: move sidebar collapse button to title area and color collapsed dots

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4447,6 +4447,13 @@ code {
   white-space: nowrap;
 }
 
+/* 标题后缀元素（如折叠按钮），紧跟在标题文字后、位于标题栏左侧区域 */
+.ntd-page-card-title-suffix {
+  display: flex;
+  align-items: center;
+  margin-left: 2px;
+}
+
 .ntd-page-card-extra {
   display: flex;
   align-items: center;

--- a/frontend/src/components/ListDetailPage.tsx
+++ b/frontend/src/components/ListDetailPage.tsx
@@ -46,16 +46,21 @@ export function ListDetailPage({
     setSidebarCollapsed(v => !v);
   };
 
+  // 左侧标题后的折叠按钮 — 将侧边栏的展开/折叠控制放在标题后方，
+  // 而非右侧操作区，方便用户快速切换列表可见性。
+  const collapseBtn = (
+    <Button
+      type="text"
+      size="small"
+      icon={sidebarCollapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
+      onClick={toggleSidebar}
+      style={{ padding: '0 4px' }}
+    />
+  );
+
   const headerExtra = (
     <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
       {extra}
-      <Button
-        type="text"
-        size="small"
-        icon={sidebarCollapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
-        onClick={toggleSidebar}
-        style={{ padding: '0 4px' }}
-      />
     </div>
   );
 
@@ -63,6 +68,7 @@ export function ListDetailPage({
     <PageCard
       icon={icon}
       title={title}
+      titleSuffix={collapseBtn}
       extra={headerExtra}
       className="list-detail-page-card"
       style={{ height: '100%', flex: 1, minWidth: 0 }}
@@ -92,23 +98,27 @@ export function ListDetailPage({
           </div>
         )}
         {sidebarCollapsed && (
+          /* 侧边栏折叠时显示红黄蓝三色圆点，提示此处有列表内容可点击展开 */
           <div
             style={{
               display: 'flex',
               flexDirection: 'column',
               alignItems: 'center',
               gap: 4,
-              opacity: 0.4,
             }}
           >
-            {[...Array(3)].map((_, i) => (
+            {[
+              'var(--color-red, #ff4d4f)',
+              'var(--color-yellow, #fadb14)',
+              'var(--color-blue, #1677ff)',
+            ].map((color, i) => (
               <div
                 key={i}
                 style={{
                   width: 4,
                   height: 4,
                   borderRadius: '50%',
-                  background: 'var(--color-text-tertiary)',
+                  background: color,
                 }}
               />
             ))}

--- a/frontend/src/components/common/PageCard.tsx
+++ b/frontend/src/components/common/PageCard.tsx
@@ -11,6 +11,7 @@ import type { ReactNode, CSSProperties } from 'react';
  *
  * @param icon     - 页面标题前的图标
  * @param title    - 页面标题文本
+ * @param titleSuffix - 标题文本后的附加元素（如折叠按钮），位于标题栏左侧区域
  * @param extra    - 标题栏右侧的操作按钮区域
  * @param children - 页面内容（渲染在横线下方）
  * @param showHeader - 是否显示顶部标题栏，默认为 true
@@ -22,6 +23,7 @@ import type { ReactNode, CSSProperties } from 'react';
 export function PageCard({
   icon,
   title,
+  titleSuffix,
   extra,
   children,
   showHeader = true,
@@ -32,6 +34,7 @@ export function PageCard({
 }: {
   icon?: ReactNode;
   title?: ReactNode;
+  titleSuffix?: ReactNode;
   extra?: ReactNode;
   children: ReactNode;
   showHeader?: boolean;
@@ -49,6 +52,7 @@ export function PageCard({
             <div className="ntd-page-card-title">
               {icon && <span className="ntd-page-card-icon">{icon}</span>}
               {title && <span className="ntd-page-card-title-text">{title}</span>}
+              {titleSuffix && <span className="ntd-page-card-title-suffix">{titleSuffix}</span>}
             </div>
             {extra && <div className="ntd-page-card-extra">{extra}</div>}
           </div>


### PR DESCRIPTION
## 变更内容

将事项/环路页面的侧边栏折叠按钮从右侧操作区（新建按钮旁）移到左侧标题文字后方，使标题栏布局更清晰。

同时将侧边栏折叠后的三色圆点从灰色改为红黄蓝三色，提高可见性。

## 改动文件

| 文件 | 变更 |
|------|------|
| `frontend/src/components/common/PageCard.tsx` | 新增 `titleSuffix` prop |
| `frontend/src/components/ListDetailPage.tsx` | 折叠按钮移到 `titleSuffix`，三色圆点改为红黄蓝 |
| `frontend/src/App.css` | 新增 `.ntd-page-card-title-suffix` 样式 |

## 视觉效果

**变更前：** `[图标 事项]                    [新建] [≡/☰]`
**变更后：** `[图标 事项 [≡/☰]]             [新建]`

折叠侧边栏后的三色圆点从灰色改为红/黄/蓝，更醒目。