### PR TITLE
fix: 新建 V44 迁移补加 feishu_messages.processed_id / processed_type 列

### DIFF
--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -47,6 +47,7 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V41ConsolidatedLoopFeatures),      // V6~V12,V14~V19,V23,V24,V26~V29
         Box::new(V42ConsolidatedWorkspaceRefactor), // V30~V35
         Box::new(V43ConsolidatedFinalFeatures),     // V36~V40
+        Box::new(V44AddFeishuMessagesProcessedId),  // 补加 processed_id / processed_type
     ]
 }
 
@@ -3092,18 +3093,34 @@ impl Migration for V43ConsolidatedFinalFeatures {
         add_column_if_missing(db, "feishu_messages", "workspace_id",
             "ALTER TABLE feishu_messages ADD COLUMN workspace_id INTEGER").await?;
 
-        // V1 CREATE TABLE IF NOT EXISTS 包含 processed_id / processed_type，
-        // 但老数据库可能是在这两列被加入 CREATE TABLE 之前创建的，
-        // IF NOT EXISTS 不会给已有表加列，这里兜底补加（幂等）。
-        add_column_if_missing(db, "feishu_messages", "processed_id",
-            "ALTER TABLE feishu_messages ADD COLUMN processed_id INTEGER").await?;
-        add_column_if_missing(db, "feishu_messages", "processed_type",
-            "ALTER TABLE feishu_messages ADD COLUMN processed_type TEXT").await?;
-
         // V40: 删除 feishu_messages.processed_todo_id
         drop_column_if_exists(db, "feishu_messages", "processed_todo_id").await?;
 
         tracing::info!("V43 (consolidated_final_features) applied");
+        Ok(())
+    }
+}
+
+/// V44: 补加 feishu_messages.processed_id / processed_type 列。
+///
+/// V1 的 CREATE TABLE IF NOT EXISTS 当前代码虽包含这两列，但老数据库可能是在
+/// 这两列加入 CREATE TABLE 之前创建的，IF NOT EXISTS 不会给已有表加列。
+/// V43 合并迁移（V39）补了 workspace_id，但从未添加 processed_id / processed_type，
+/// 导致 get_feishu_message_stats() 查询 "processed_id IS NOT NULL" 时报
+/// "no such column: processed_id" 错误，handler 返回 500。
+pub(super) struct V44AddFeishuMessagesProcessedId;
+
+#[async_trait::async_trait]
+impl Migration for V44AddFeishuMessagesProcessedId {
+    fn version(&self) -> i64 { 44 }
+    fn name(&self) -> &'static str { "add_feishu_messages_processed_id" }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        add_column_if_missing(db, "feishu_messages", "processed_id",
+            "ALTER TABLE feishu_messages ADD COLUMN processed_id INTEGER").await?;
+        add_column_if_missing(db, "feishu_messages", "processed_type",
+            "ALTER TABLE feishu_messages ADD COLUMN processed_type TEXT").await?;
+        tracing::info!("V44: feishu_messages.processed_id/processed_type columns added");
         Ok(())
     }
 }

--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -3092,6 +3092,14 @@ impl Migration for V43ConsolidatedFinalFeatures {
         add_column_if_missing(db, "feishu_messages", "workspace_id",
             "ALTER TABLE feishu_messages ADD COLUMN workspace_id INTEGER").await?;
 
+        // V1 CREATE TABLE IF NOT EXISTS 包含 processed_id / processed_type，
+        // 但老数据库可能是在这两列被加入 CREATE TABLE 之前创建的，
+        // IF NOT EXISTS 不会给已有表加列，这里兜底补加（幂等）。
+        add_column_if_missing(db, "feishu_messages", "processed_id",
+            "ALTER TABLE feishu_messages ADD COLUMN processed_id INTEGER").await?;
+        add_column_if_missing(db, "feishu_messages", "processed_type",
+            "ALTER TABLE feishu_messages ADD COLUMN processed_type TEXT").await?;
+
         // V40: 删除 feishu_messages.processed_todo_id
         drop_column_if_exists(db, "feishu_messages", "processed_todo_id").await?;
 


### PR DESCRIPTION
## 问题

`GET /api/feishu/message-stats?hours=720` 返回 500，日志只看到 `Status code: 500`。

## 根因

`feishu_messages` 表缺少 `processed_id` 列，导致查询：
```sql
COALESCE(SUM(CASE WHEN processed_id IS NOT NULL THEN 1 ELSE 0 END), 0) as triggered_todos
```
报错 `no such column: processed_id`。

V1 `CREATE TABLE IF NOT EXISTS` 当前代码虽包含这两列，但老数据库可能是在这两列加入 CREATE TABLE 之前创建的，`IF NOT EXISTS` 不会给已有表加列。V43 合并迁移补了 `workspace_id`（V39）但**从未添加 `processed_id` / `processed_type`**。

## 修复

新建 **V44** 独立迁移，通过 `add_column_if_missing` 兜底补加 `processed_id` 和 `processed_type` 两列。幂等安全：列已存在时跳过。

> ⚠️ 最初尝试修改 V43 内部代码，但 V43 已在 `schema_version` 表标记为已执行，重启会被跳过。为此改为新建 V44 迁移。

## 验证

- [x] `cargo check` 通过
- [x] 幂等：`add_column_if_missing` 确保重复迁移不报错