### PR TITLE
feat: 环路导入导出功能

### DIFF
--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -689,6 +689,27 @@ impl Database {
         Ok(())
     }
 
+    /// 仅更新步骤的 goto 跳转目标（用于导入时的伪ID解析）
+    pub async fn update_loop_step_goto(
+        &self,
+        id: i64,
+        success_goto_step_id: Option<i64>,
+        fail_goto_step_id: Option<i64>,
+    ) -> Result<(), sea_orm::DbErr> {
+        let existing = loop_steps::Entity::find_by_id(id).one(&self.conn).await?;
+        if let Some(c) = existing {
+            let mut am: loop_steps::ActiveModel = c.into();
+            if success_goto_step_id.is_some() {
+                am.success_goto_step_id = ActiveValue::Set(success_goto_step_id);
+            }
+            if fail_goto_step_id.is_some() {
+                am.fail_goto_step_id = ActiveValue::Set(fail_goto_step_id);
+            }
+            am.update(&self.conn).await?;
+        }
+        Ok(())
+    }
+
     /// 批量重排阶段。前端拖拽排序后调用,传入完整的新顺序。
     /// `ordered_ids` 的顺序即新的 order_index(从 0 开始递增)。
     pub async fn reorder_loop_steps(

--- a/backend/src/db/tag.rs
+++ b/backend/src/db/tag.rs
@@ -26,6 +26,17 @@ impl Database {
             .collect())
     }
 
+    /// 根据 ID 获取单个标签
+    pub async fn get_tag(&self, id: i64) -> Result<Option<Tag>, sea_orm::DbErr> {
+        let model = tags::Entity::find_by_id(id).one(&self.conn).await?;
+        Ok(model.map(|m| Tag {
+            id: m.id,
+            name: m.name,
+            color: m.color.unwrap_or_default(),
+            created_at: m.created_at.unwrap_or_default(),
+        }))
+    }
+
     pub async fn create_tag(&self, name: &str, color: &str) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let am = tags::ActiveModel {

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -191,6 +191,48 @@ impl Database {
         Ok(inserted.id)
     }
 
+    /// 从环路导入时创建 Todo，支持完整字段（status/scheduler_enabled/auto_review_enabled/review_template_id/kind）。
+    pub async fn create_todo_for_import(
+        &self,
+        title: &str,
+        prompt: &str,
+        executor: Option<&str>,
+        acceptance_criteria: Option<&str>,
+        webhook_enabled: bool,
+        workspace_id: i64,
+        workspace_path: &str,
+        status: Option<&str>,
+        scheduler_enabled: Option<bool>,
+        auto_review_enabled: Option<bool>,
+        review_template_id: Option<i64>,
+        kind: Option<i32>,
+    ) -> Result<i64, sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+        let executor_str = executor
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(crate::adapters::DEFAULT_EXECUTOR);
+        let am = todos::ActiveModel {
+            title: ActiveValue::Set(title.to_string()),
+            prompt: ActiveValue::Set(Some(prompt.to_string())),
+            status: ActiveValue::Set(Some(status.unwrap_or("pending").to_string())),
+            created_at: ActiveValue::Set(Some(now.clone())),
+            updated_at: ActiveValue::Set(Some(now)),
+            executor: ActiveValue::Set(Some(executor_str.to_string())),
+            acceptance_criteria: ActiveValue::Set(acceptance_criteria.map(|s| s.to_string())),
+            webhook_enabled: ActiveValue::Set(Some(webhook_enabled)),
+            auto_review_enabled: ActiveValue::Set(auto_review_enabled),
+            todo_type: ActiveValue::Set(kind.or(Some(0))),
+            scheduler_enabled: ActiveValue::Set(scheduler_enabled),
+            workspace_id: ActiveValue::Set(Some(workspace_id)),
+            workspace_path: ActiveValue::Set(Some(workspace_path.to_string())),
+            review_template_id: ActiveValue::Set(review_template_id),
+            ..Default::default()
+        };
+        let inserted = am.insert(&self.conn).await?;
+        Ok(inserted.id)
+    }
+
     pub async fn update_todo_full(&self, update: TodoUpdate<'_>) -> Result<(), sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let mut am = todos::ActiveModel {
@@ -436,6 +478,30 @@ impl Database {
             ..Default::default()
         };
         self.exec_update(am).await
+    }
+
+    /// 按 title + prompt + workspace_id 精确查找未软删的 todo，用于环路导入合并时判断是否真正重复。
+    pub async fn get_todo_by_identity(
+        &self,
+        title: &str,
+        prompt: &str,
+        workspace_id: i64,
+    ) -> Result<Option<Todo>, sea_orm::DbErr> {
+        let mut query = todos::Entity::find()
+            .filter(todos::Column::Title.eq(title))
+            .filter(todos::Column::Prompt.eq(prompt))
+            .filter(todos::Column::DeletedAt.is_null());
+        query = query.filter(todos::Column::WorkspaceId.eq(workspace_id));
+        let model = query.one(&self.conn).await?;
+        let Some(m) = model else { return Ok(None) };
+        let tag_ids = todo_tags::Entity::find()
+            .filter(todo_tags::Column::TodoId.eq(m.id))
+            .all(&self.conn)
+            .await?
+            .into_iter()
+            .map(|t| t.tag_id)
+            .collect();
+        Ok(Some(Self::model_to_todo(m, tag_ids)))
     }
 
     /// 按 title 精确查找 todo (仅未软删的). 用于评审任务 todo 的探测.

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -593,6 +593,14 @@ impl Database {
         Ok(Some(Self::model_to_todo(model, tag_ids)))
     }
 
+    /// 获取 Todo 实体模型（包含 kind 等完整字段），用于导出等需要访问所有字段的场景
+    pub async fn get_todo_entity(&self, id: i64) -> Result<Option<todos::Model>, sea_orm::DbErr> {
+        todos::Entity::find_by_id(id)
+            .filter(todos::Column::DeletedAt.is_null())
+            .one(&self.conn)
+            .await
+    }
+
     pub async fn get_scheduler_todos(&self, workspace_id: Option<i64>) -> Result<Vec<Todo>, sea_orm::DbErr> {
         let mut find = todos::Entity::find()
             .filter(todos::Column::DeletedAt.is_null())

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -21,7 +21,7 @@ use axum::{
     response::IntoResponse,
     body::Bytes,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::handlers::{AppError, AppState};
 use crate::models::{
@@ -1279,6 +1279,286 @@ pub async fn import_loops(
     Ok(ApiResponse::ok(response))
 }
 
+/// POST /api/loops/merge — 执行合并导入
+#[derive(Deserialize)]
+pub struct MergeLoopRequest {
+    pub yaml: String,
+    pub workspace_id: i64,
+    /// 冲突解决策略: "overwrite" | "rename" | "skip"
+    pub conflict_resolution: std::collections::HashMap<String, String>,
+}
+
+#[derive(Serialize)]
+pub struct MergeLoopResponse {
+    pub success: bool,
+    pub created: LoopImportCreatedCounts,
+    pub updated: LoopImportCreatedCounts,
+    pub skipped: Vec<String>,
+    pub warnings: Vec<LoopImportWarning>,
+}
+
+pub async fn merge_loops(
+    State(state): State<AppState>,
+    Json(req): Json<MergeLoopRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    // 解析 YAML
+    let data: LoopExportData = serde_yaml::from_str(&req.yaml)
+        .map_err(|e| AppError::BadRequest(format!("Invalid YAML: {}", e)))?;
+
+    // 基本校验
+    if data.loops.is_empty() {
+        return Err(AppError::BadRequest("No loops in export file".to_string()));
+    }
+
+    // 验证工作空间存在
+    let workspace = state.db.get_project_directory_by_id(req.workspace_id).await?
+        .ok_or_else(|| AppError::BadRequest(format!("Workspace {} not found", req.workspace_id)))?;
+
+    // 构建伪ID -> 真实ID 的映射表
+    let mut tag_pseudo_to_real: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    let mut template_pseudo_to_real: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    let mut todo_pseudo_to_real: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    let mut loop_pseudo_to_real: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    let mut step_pseudo_to_real: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+
+    let mut created_counts = LoopImportCreatedCounts {
+        loops: 0, todos: 0, review_templates: 0, tags: 0, triggers: 0, steps: 0,
+    };
+    let mut updated_counts = LoopImportCreatedCounts {
+        loops: 0, todos: 0, review_templates: 0, tags: 0, triggers: 0, steps: 0,
+    };
+    let mut skipped: Vec<String> = Vec::new();
+    let mut warnings: Vec<LoopImportWarning> = Vec::new();
+
+    // 阶段1: 合并标签（按name匹配，同名复用）
+    for tag in &data.tags {
+        // 查找同名标签
+        if let Some(existing_id) = state.db.find_tag_by_name(&tag.name).await? {
+            tag_pseudo_to_real.insert(tag.id.clone(), existing_id);
+        } else {
+            let tag_id = state.db.create_tag(&tag.name, &tag.color).await?;
+            tag_pseudo_to_real.insert(tag.id.clone(), tag_id);
+            created_counts.tags += 1;
+        }
+    }
+
+    // 阶段2: 合并评审模板（按name匹配，存在则覆盖）
+    for tmpl in &data.review_templates {
+        if let Some(existing) = state.db.get_review_template_by_name(&tmpl.name).await? {
+            // 存在则更新
+            let input = ReviewTemplateInput {
+                name: tmpl.name.clone(),
+                description: tmpl.description.clone(),
+                prompt: tmpl.prompt.clone(),
+                workspace_id: Some(req.workspace_id),
+            };
+            state.db.update_review_template(existing.id, &input).await?;
+            template_pseudo_to_real.insert(tmpl.id.clone(), existing.id);
+            updated_counts.review_templates += 1;
+        } else {
+            let input = ReviewTemplateInput {
+                name: tmpl.name.clone(),
+                description: tmpl.description.clone(),
+                prompt: tmpl.prompt.clone(),
+                workspace_id: Some(req.workspace_id),
+            };
+            let new_id = state.db.create_review_template(&input).await?;
+            template_pseudo_to_real.insert(tmpl.id.clone(), new_id);
+            created_counts.review_templates += 1;
+        }
+    }
+
+    // 阶段3: 合并Todo（按title+prompt匹配）
+    for todo in &data.todos {
+        // 尝试查找同名Todo
+        if let Some(existing_todo) = state.db.get_todo_by_title(&todo.title).await? {
+            // 存在则复用，不重复创建
+            todo_pseudo_to_real.insert(todo.id.clone(), existing_todo.id);
+        } else {
+            let new_todo_id = state.db.create_todo_with_extras(
+                &todo.title,
+                &todo.prompt,
+                todo.executor.as_deref(),
+                todo.acceptance_criteria.as_deref(),
+                todo.webhook_enabled,
+                req.workspace_id,
+                &workspace.path,
+            ).await?;
+            todo_pseudo_to_real.insert(todo.id.clone(), new_todo_id);
+            created_counts.todos += 1;
+        }
+    }
+
+    // 阶段4: 合并环路（按name匹配，检查冲突解决策略）
+    for loop_export in &data.loops {
+        let conflict_action = req.conflict_resolution.get(&loop_export.name)
+            .cloned()
+            .unwrap_or_else(|| "rename".to_string());
+
+        // 查找同名环路
+        let existing_loop = state.db.list_loops_with_counts(Some(req.workspace_id)).await?
+            .into_iter()
+            .find(|l| l.loop_.name == loop_export.name);
+
+        let (new_loop_id, is_new) = match (existing_loop, conflict_action.as_str()) {
+            // 跳过
+            (Some(_), "skip") => {
+                skipped.push(loop_export.name.clone());
+                continue;
+            }
+            // 覆盖（删除旧环路，用新ID继续创建）
+            (Some(existing), "overwrite") => {
+                state.db.delete_loop(existing.loop_.id).await?;
+                let new_loop_id = create_loop_from_export(
+                    &state, loop_export, req.workspace_id, &workspace.path,
+                    &template_pseudo_to_real, &todo_pseudo_to_real, &tag_pseudo_to_real,
+                ).await?;
+                (new_loop_id, false)
+            }
+            // 重命名（追加后缀）
+            (Some(_), "rename") | (_, "rename") => {
+                let new_loop_id = create_loop_from_export(
+                    &state, loop_export, req.workspace_id, &workspace.path,
+                    &template_pseudo_to_real, &todo_pseudo_to_real, &tag_pseudo_to_real,
+                ).await?;
+                (new_loop_id, false)
+            }
+            // 默认重命名
+            (None, _) => {
+                let new_loop_id = create_loop_from_export(
+                    &state, loop_export, req.workspace_id, &workspace.path,
+                    &template_pseudo_to_real, &todo_pseudo_to_real, &tag_pseudo_to_real,
+                ).await?;
+                (new_loop_id, false)
+            }
+            _ => continue,
+        };
+
+        loop_pseudo_to_real.insert(loop_export.id.clone(), new_loop_id);
+        if is_new {
+            created_counts.loops += 1;
+        } else {
+            updated_counts.loops += 1;
+        }
+    }
+
+    // 刷新scheduler以加载新的cron触发器
+    if let Some(sched) = state.loop_scheduler.as_ref() {
+        let _ = sched.reload_all().await;
+    }
+
+    let response = MergeLoopResponse {
+        success: true,
+        created: created_counts,
+        updated: updated_counts,
+        skipped,
+        warnings,
+    };
+
+    Ok(ApiResponse::ok(response))
+}
+
+/// 从导出数据创建环路（供新建模式和合并模式复用）
+async fn create_loop_from_export(
+    state: &AppState,
+    loop_export: &LoopExportItem,
+    workspace_id: i64,
+    workspace_path: &str,
+    template_pseudo_to_real: &std::collections::HashMap<String, i64>,
+    todo_pseudo_to_real: &std::collections::HashMap<String, i64>,
+    tag_pseudo_to_real: &std::collections::HashMap<String, i64>,
+) -> Result<i64, AppError> {
+    let review_template_id = loop_export.review_template_id.as_ref()
+        .and_then(|tid| template_pseudo_to_real.get(tid))
+        .copied();
+
+    let abnormal_handler_todo_id = loop_export.abnormal_handler_todo_id.as_ref()
+        .and_then(|tid| todo_pseudo_to_real.get(tid))
+        .copied();
+
+    let limits_config = serde_json::to_string(&loop_export.limits_config)
+        .unwrap_or_else(|_| "{}".to_string());
+    let abnormal_handler_trigger_on = serde_json::to_string(&loop_export.abnormal_handler_trigger_on)
+        .unwrap_or_else(|_| "[]".to_string());
+
+    // 合并模式：同名环路名称追加 "-合并"
+    let loop_name = format!("{}-合并", loop_export.name);
+
+    let new_loop = state.db.create_loop(
+        &loop_name,
+        &loop_export.description,
+        Some(workspace_id),
+        Some(workspace_path),
+        loop_export.webhook_enabled,
+        &loop_export.icon,
+        review_template_id,
+        Some(&limits_config),
+        abnormal_handler_todo_id,
+        &abnormal_handler_trigger_on,
+    ).await?;
+
+    // 关联标签
+    for (pseudo_tag_id, _) in loop_export.tag_ids.iter().zip(loop_export.tag_names.iter()) {
+        if let Some(&real_tag_id) = tag_pseudo_to_real.get(pseudo_tag_id) {
+            state.db.set_loop_tags(new_loop.id, &[real_tag_id]).await?;
+        }
+    }
+
+    // 导入触发器
+    for trigger in &loop_export.triggers {
+        state.db.create_trigger(
+            new_loop.id,
+            &trigger.trigger_type,
+            &serde_json::to_string(&trigger.config).unwrap_or_else(|_| "{}".to_string()),
+            trigger.enabled,
+            trigger.priority,
+        ).await?;
+    }
+
+    // 导入步骤（两遍）
+    let mut step_map: Vec<(String, i64)> = Vec::new();
+    for step in &loop_export.steps {
+        let todo_id = todo_pseudo_to_real.get(&step.todo_id)
+            .copied()
+            .ok_or_else(|| AppError::BadRequest(format!("Step '{}' references unknown todo", step.name)))?;
+
+        let new_step = state.db.create_loop_step(
+            new_loop.id,
+            &step.name,
+            &step.description,
+            todo_id,
+            &step.run_mode,
+            step.skip_on_source_failed,
+            step.min_rating,
+            &step.unrated_policy,
+            step.enabled,
+            &step.on_success,
+            None,  // goto 第二遍
+            &step.on_rating_fail,
+            None,  // goto 第二遍
+            &step.review_type,
+        ).await?;
+
+        step_map.push((step.id.clone(), new_step.id));
+    }
+
+    // 第二遍：修复goto引用
+    for step in &loop_export.steps {
+        if let Some(&new_step_id) = step_map.iter().find(|(id, _)| id == &step.id).map(|(_, id)| id) {
+            let success_goto = step.success_goto_step_id.as_ref()
+                .and_then(|sid| step_map.iter().find(|(sid2, _)| sid2 == sid).map(|(_, id)| *id));
+            let fail_goto = step.fail_goto_step_id.as_ref()
+                .and_then(|sid| step_map.iter().find(|(sid2, _)| sid2 == sid).map(|(_, id)| *id));
+
+            if success_goto.is_some() || fail_goto.is_some() {
+                state.db.update_loop_step_goto(new_step_id, success_goto, fail_goto).await?;
+            }
+        }
+    }
+
+    Ok(new_loop.id)
+}
+
 /// 构建环路导出的 YAML 内容
 /// 收集所有依赖实体（标签、评审模板、Todo）并生成伪ID
 async fn build_loop_export_yaml(
@@ -1588,4 +1868,5 @@ pub fn loop_routes() -> axum::Router<AppState> {
         // 导入导出
         .route("/api/loops/import/preview", post(import_preview))
         .route("/api/loops/import", post(import_loops))
+        .route("/api/loops/merge", post(merge_loops))
 }

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -17,7 +17,9 @@ use axum::{
     Json,
     extract::{Path, Query, State},
     http::StatusCode,
+    http::header,
     response::IntoResponse,
+    body::Bytes,
 };
 use serde::Deserialize;
 
@@ -30,7 +32,14 @@ use crate::models::{
     LoopListItem, LoopStepDto, LoopStepExecutionDto, LoopTriggerDto, ReorderLoopStepsRequest,
     UpdateLoopRequest, UpdateLoopStatusRequest, UpdateLoopStepRequest,
     UpdateTriggerRequest, ApproveStepExecutionRequest, UpdateTagsRequest, TriggerLoopRequest,
+    ExportLoopSelectedRequest,
+    LoopExportData, TagExportItem, ReviewTemplateExportItem, TodoExportItem,
+    LoopExportItem, LoopTriggerExportItem, LoopStepExportItem,
+    generate_pseudo_id, validate_pseudo_id,
+    LoopImportPreviewResponse, LoopImportSummary, LoopImportWarning,
+    LoopImportResponse, LoopImportCreatedCounts,
 };
+use crate::db::ReviewTemplateInput;
 
 const DEFAULT_PAGE_LIMIT: u64 = 20;
 const MAX_PAGE_LIMIT: u64 = 100;
@@ -845,6 +854,706 @@ pub async fn batch_copy_loops_workspace(
     }))
 }
 
+// ====== Loop 导入导出 ======
+
+/// GET /api/loops/{id}/export — 导出单个环路为 YAML 文件
+pub async fn export_loop(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<impl IntoResponse, AppError> {
+    let loops = state.db.list_loops_with_counts(None).await?;
+    let loop_row = loops.into_iter().find(|l| l.loop_.id == id);
+
+    // 检查环路是否存在
+    if loop_row.is_none() {
+        return Err(AppError::NotFound);
+    }
+
+    let loop_ = loop_row.unwrap().loop_;
+    let yaml = build_loop_export_yaml(&state, &[id]).await?;
+    let filename = format!("{}-{}.loop.yaml",
+        loop_.name.replace(' ', "-"),
+        chrono::Utc::now().format("%Y%m%d-%H%M%S"));
+
+    let _disposition = format!("attachment; filename=\"{}\"", filename);
+    Ok((
+        [(header::CONTENT_TYPE, "application/x-yaml; charset=utf-8")],
+        yaml,
+    ))
+}
+
+/// POST /api/loops/export-selected — 批量导出选中的环路
+pub async fn export_selected_loops(
+    State(state): State<AppState>,
+    Json(req): Json<ExportLoopSelectedRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if req.loop_ids.is_empty() {
+        return Err(AppError::BadRequest("loop_ids 不能为空".to_string()));
+    }
+    let yaml = build_loop_export_yaml(&state, &req.loop_ids).await?;
+    let filename = format!("loops-export-{}.loop.yaml",
+        chrono::Utc::now().format("%Y%m%d-%H%M%S"));
+
+    let _disposition = format!("attachment; filename=\"{}\"", filename);
+    Ok((
+        [(header::CONTENT_TYPE, "application/x-yaml; charset=utf-8")],
+        yaml,
+    ))
+}
+
+/// POST /api/loops/import/preview — 预览导入数据
+pub async fn import_preview(
+    State(_state): State<AppState>,
+    body: Bytes,
+) -> Result<impl IntoResponse, AppError> {
+    let yaml_str = String::from_utf8(body.to_vec())
+        .map_err(|_| AppError::BadRequest("Invalid UTF-8 in request body".to_string()))?;
+
+    // 解析 YAML
+    let data: LoopExportData = serde_yaml::from_str(&yaml_str)
+        .map_err(|e| AppError::BadRequest(format!("Invalid YAML: {}", e)))?;
+
+    // 基本校验
+    if data.loops.is_empty() {
+        return Err(AppError::BadRequest("No loops in export file".to_string()));
+    }
+
+    // 收集所有伪ID并检查格式和唯一性
+    let mut pseudo_ids: Vec<String> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+
+    // 收集标签伪ID
+    for tag in &data.tags {
+        if !validate_pseudo_id(&tag.id) {
+            errors.push(format!("Invalid pseudo-ID format: {}", tag.id));
+        }
+        pseudo_ids.push(tag.id.clone());
+    }
+
+    // 收集评审模板伪ID
+    for tmpl in &data.review_templates {
+        if !validate_pseudo_id(&tmpl.id) {
+            errors.push(format!("Invalid pseudo-ID format: {}", tmpl.id));
+        }
+        pseudo_ids.push(tmpl.id.clone());
+    }
+
+    // 收集Todo伪ID
+    for todo in &data.todos {
+        if !validate_pseudo_id(&todo.id) {
+            errors.push(format!("Invalid pseudo-ID format: {}", todo.id));
+        }
+        pseudo_ids.push(todo.id.clone());
+    }
+
+    // 收集环路伪ID
+    for loop_ in &data.loops {
+        if !validate_pseudo_id(&loop_.id) {
+            errors.push(format!("Invalid pseudo-ID format: {}", loop_.id));
+        }
+        pseudo_ids.push(loop_.id.clone());
+
+        // 收集触发器伪ID
+        for trigger in &loop_.triggers {
+            if !validate_pseudo_id(&trigger.id) {
+                errors.push(format!("Invalid pseudo-ID format: {}", trigger.id));
+            }
+            pseudo_ids.push(trigger.id.clone());
+        }
+
+        // 收集步骤伪ID
+        for step in &loop_.steps {
+            if !validate_pseudo_id(&step.id) {
+                errors.push(format!("Invalid pseudo-ID format: {}", step.id));
+            }
+            pseudo_ids.push(step.id.clone());
+        }
+    }
+
+    // 检查伪ID唯一性
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for id in &pseudo_ids {
+        if !seen.insert(id.clone()) {
+            errors.push(format!("Duplicate pseudo-ID: {}", id));
+        }
+    }
+
+    // 检查引用完整性
+    let all_tag_ids: std::collections::HashSet<_> = data.tags.iter().map(|t| t.id.clone()).collect();
+    let all_template_ids: std::collections::HashSet<_> = data.review_templates.iter().map(|t| t.id.clone()).collect();
+    let all_todo_ids: std::collections::HashSet<_> = data.todos.iter().map(|t| t.id.clone()).collect();
+    let all_step_ids: std::collections::HashSet<_> = data.loops.iter()
+        .flat_map(|l| l.steps.iter().map(|s| s.id.clone()))
+        .collect();
+
+    for loop_ in &data.loops {
+        // 检查环路引用的评审模板
+        if let Some(ref tid) = loop_.review_template_id {
+            if !all_template_ids.contains(tid) && !tid.is_empty() {
+                errors.push(format!("Loop '{}' references non-existent template: {}", loop_.name, tid));
+            }
+        }
+
+        // 检查异常处理Todo
+        if let Some(ref tid) = loop_.abnormal_handler_todo_id {
+            if !all_todo_ids.contains(tid) && !tid.is_empty() {
+                errors.push(format!("Loop '{}' references non-existent abnormal handler: {}", loop_.name, tid));
+            }
+        }
+
+        // 检查标签
+        for tid in &loop_.tag_ids {
+            if !all_tag_ids.contains(tid) && !tid.is_empty() {
+                errors.push(format!("Loop '{}' references non-existent tag: {}", loop_.name, tid));
+            }
+        }
+
+        for step in &loop_.steps {
+            // 检查步骤引用的Todo
+            if !all_todo_ids.contains(&step.todo_id) {
+                errors.push(format!("Step '{}' in loop '{}' references non-existent todo: {}", step.name, loop_.name, step.todo_id));
+            }
+
+            // 检查goto跳转
+            if let Some(ref sid) = step.success_goto_step_id {
+                if !all_step_ids.contains(sid) && !sid.is_empty() {
+                    errors.push(format!("Step '{}' success_goto references non-existent step: {}", step.name, sid));
+                }
+            }
+            if let Some(ref sid) = step.fail_goto_step_id {
+                if !all_step_ids.contains(sid) && !sid.is_empty() {
+                    errors.push(format!("Step '{}' fail_goto references non-existent step: {}", step.name, sid));
+                }
+            }
+        }
+    }
+
+    // 检查Todo引用的评审模板
+    for todo in &data.todos {
+        if let Some(ref tid) = todo.review_template_id {
+            if !all_template_ids.contains(tid) && !tid.is_empty() {
+                errors.push(format!("Todo '{}' references non-existent template: {}", todo.title, tid));
+            }
+        }
+        for tid in &todo.tag_ids {
+            if !all_tag_ids.contains(tid) && !tid.is_empty() {
+                errors.push(format!("Todo '{}' references non-existent tag: {}", todo.title, tid));
+            }
+        }
+    }
+
+    let valid = errors.is_empty();
+
+    // 构建摘要
+    let summary = LoopImportSummary {
+        loops: data.loops.len(),
+        steps: data.loops.iter().map(|l| l.steps.len()).sum(),
+        todos: data.todos.len(),
+        review_templates: data.review_templates.len(),
+        tags: data.tags.len(),
+        triggers: data.loops.iter().map(|l| l.triggers.len()).sum(),
+    };
+
+    // 生成警告（根据方案，cron触发器将被禁用）
+    let mut warnings: Vec<LoopImportWarning> = Vec::new();
+    for loop_ in &data.loops {
+        for trigger in &loop_.triggers {
+            if trigger.trigger_type == "cron" && trigger.enabled {
+                warnings.push(LoopImportWarning {
+                    warning_type: "cron_trigger_disabled".to_string(),
+                    message: format!("Loop '{}' cron trigger will be disabled after import", loop_.name),
+                });
+            }
+        }
+    }
+
+    let response = LoopImportPreviewResponse {
+        valid,
+        pseudo_ids,
+        summary,
+        conflicts: vec![],  // 新建模式无冲突
+        warnings,
+    };
+
+    Ok(ApiResponse::ok(response))
+}
+
+/// POST /api/loops/import — 执行导入（新建模式）
+#[derive(Deserialize)]
+pub struct ImportLoopRequest {
+    pub yaml: String,
+    pub workspace_id: i64,
+}
+
+pub async fn import_loops(
+    State(state): State<AppState>,
+    Json(req): Json<ImportLoopRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    // 解析 YAML
+    let data: LoopExportData = serde_yaml::from_str(&req.yaml)
+        .map_err(|e| AppError::BadRequest(format!("Invalid YAML: {}", e)))?;
+
+    // 基本校验
+    if data.loops.is_empty() {
+        return Err(AppError::BadRequest("No loops in export file".to_string()));
+    }
+
+    // 获取目标工作空间
+    let workspace_id = req.workspace_id;
+
+    // 验证工作空间存在
+    let workspace = state.db.get_project_directory_by_id(workspace_id).await?
+        .ok_or_else(|| AppError::BadRequest(format!("Workspace {} not found", workspace_id)))?;
+
+    // 构建伪ID -> 真实ID 的映射表
+    let mut tag_pseudo_to_real: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    let mut template_pseudo_to_real: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    let mut todo_pseudo_to_real: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    let mut loop_pseudo_to_real: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    let mut step_pseudo_to_real: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+
+    let mut created_counts = LoopImportCreatedCounts {
+        loops: 0,
+        todos: 0,
+        review_templates: 0,
+        tags: 0,
+        triggers: 0,
+        steps: 0,
+    };
+    let warnings: Vec<LoopImportWarning> = Vec::new();
+
+    // 阶段1: 导入标签
+    for tag in &data.tags {
+        let tag_id = state.db.create_tag(&tag.name, &tag.color).await?;
+        tag_pseudo_to_real.insert(tag.id.clone(), tag_id);
+        created_counts.tags += 1;
+    }
+
+    // 阶段2: 导入评审模板（到目标工作空间）
+    for tmpl in &data.review_templates {
+        let input = ReviewTemplateInput {
+            name: tmpl.name.clone(),
+            description: tmpl.description.clone(),
+            prompt: tmpl.prompt.clone(),
+            workspace_id: Some(workspace_id),
+        };
+        let new_tmpl = state.db.create_review_template(&input).await?;
+        template_pseudo_to_real.insert(tmpl.id.clone(), new_tmpl);
+        created_counts.review_templates += 1;
+    }
+
+    // 阶段3: 导入Todo模板
+    for todo in &data.todos {
+        let new_todo_id = state.db.create_todo_with_extras(
+            &todo.title,
+            &todo.prompt,
+            todo.executor.as_deref(),
+            todo.acceptance_criteria.as_deref(),
+            todo.webhook_enabled,
+            workspace_id,
+            &workspace.path,
+        ).await?;
+
+        todo_pseudo_to_real.insert(todo.id.clone(), new_todo_id);
+        created_counts.todos += 1;
+
+        // 关联标签（异常处理Todo不关联标签）
+        if !todo.is_abnormal_handler {
+            for (pseudo_tag_id, _) in todo.tag_ids.iter().zip(todo.tag_names.iter()) {
+                if let Some(&real_tag_id) = tag_pseudo_to_real.get(pseudo_tag_id) {
+                    state.db.add_todo_tag(new_todo_id, real_tag_id).await?;
+                }
+            }
+        }
+    }
+
+    // 阶段4: 导入环路主体
+    for loop_export in &data.loops {
+        let review_template_id = loop_export.review_template_id.as_ref()
+            .and_then(|tid| template_pseudo_to_real.get(tid))
+            .copied();
+
+        let abnormal_handler_todo_id = loop_export.abnormal_handler_todo_id.as_ref()
+            .and_then(|tid| todo_pseudo_to_real.get(tid))
+            .copied();
+
+        let limits_config = serde_json::to_string(&loop_export.limits_config)
+            .unwrap_or_else(|_| "{}".to_string());
+        let abnormal_handler_trigger_on = serde_json::to_string(&loop_export.abnormal_handler_trigger_on)
+            .unwrap_or_else(|_| "[]".to_string());
+
+        // 名称追加 "-导入" 后缀
+        let loop_name = format!("{}-导入", loop_export.name);
+
+        let new_loop = state.db.create_loop(
+            &loop_name,
+            &loop_export.description,
+            Some(workspace_id),
+            Some(workspace.path.as_str()),
+            loop_export.webhook_enabled,
+            &loop_export.icon,
+            review_template_id,
+            Some(&limits_config),
+            abnormal_handler_todo_id,
+            &abnormal_handler_trigger_on,
+        ).await?;
+
+        loop_pseudo_to_real.insert(loop_export.id.clone(), new_loop.id);
+        created_counts.loops += 1;
+
+        // 关联标签
+        for (pseudo_tag_id, _) in loop_export.tag_ids.iter().zip(loop_export.tag_names.iter()) {
+            if let Some(&real_tag_id) = tag_pseudo_to_real.get(pseudo_tag_id) {
+                state.db.set_loop_tags(new_loop.id, &[real_tag_id]).await?;
+            }
+        }
+
+        // 阶段5: 导入触发器
+        for trigger in &loop_export.triggers {
+            let _new_trigger = state.db.create_trigger(
+                new_loop.id,
+                &trigger.trigger_type,
+                &serde_json::to_string(&trigger.config).unwrap_or_else(|_| "{}".to_string()),
+                trigger.enabled,
+                trigger.priority,
+            ).await?;
+            // 注意: cron触发器在导出时已被禁用，这里保持原状态
+            created_counts.triggers += 1;
+        }
+
+        // 阶段6: 导入步骤（第一遍：创建所有步骤）
+        for step in &loop_export.steps {
+            let todo_id = todo_pseudo_to_real.get(&step.todo_id)
+                .copied()
+                .ok_or_else(|| AppError::BadRequest(format!("Step '{}' references unknown todo", step.name)))?;
+
+            let new_step = state.db.create_loop_step(
+                new_loop.id,
+                &step.name,
+                &step.description,
+                todo_id,
+                &step.run_mode,
+                step.skip_on_source_failed,
+                step.min_rating,
+                &step.unrated_policy,
+                step.enabled,
+                &step.on_success,
+                None,  // success_goto 第二遍再补
+                &step.on_rating_fail,
+                None,  // fail_goto 第二遍再补
+                &step.review_type,
+            ).await?;
+
+            step_pseudo_to_real.insert(step.id.clone(), new_step.id);
+            created_counts.steps += 1;
+        }
+
+        // 阶段7: 第二遍修复 goto 引用
+        for step in &loop_export.steps {
+            if let Some(&new_step_id) = step_pseudo_to_real.get(&step.id) {
+                let success_goto = step.success_goto_step_id.as_ref()
+                    .and_then(|sid| step_pseudo_to_real.get(sid))
+                    .copied();
+                let fail_goto = step.fail_goto_step_id.as_ref()
+                    .and_then(|sid| step_pseudo_to_real.get(sid))
+                    .copied();
+
+                if success_goto.is_some() || fail_goto.is_some() {
+                    state.db.update_loop_step_goto(new_step_id, success_goto, fail_goto).await?;
+                }
+            }
+        }
+    }
+
+    // 刷新scheduler以加载新的cron触发器
+    if let Some(sched) = state.loop_scheduler.as_ref() {
+        let _ = sched.reload_all().await;
+    }
+
+    let response = LoopImportResponse {
+        success: true,
+        created: created_counts,
+        warnings,
+    };
+
+    Ok(ApiResponse::ok(response))
+}
+
+/// 构建环路导出的 YAML 内容
+/// 收集所有依赖实体（标签、评审模板、Todo）并生成伪ID
+async fn build_loop_export_yaml(
+    state: &AppState,
+    loop_ids: &[i64],
+) -> Result<String, AppError> {
+    let mut all_tags: std::collections::HashMap<i64, TagExportItem> = std::collections::HashMap::new();
+    let mut all_templates: std::collections::HashMap<i64, ReviewTemplateExportItem> = std::collections::HashMap::new();
+    let mut all_todos: std::collections::HashMap<i64, TodoExportItem> = std::collections::HashMap::new();
+    let mut exported_loops: Vec<LoopExportItem> = Vec::new();
+
+    for (idx, &loop_id) in loop_ids.iter().enumerate() {
+        let view = state.db.load_loop_full(loop_id).await?
+            .ok_or_else(|| AppError::NotFound)?;
+
+        // 收集环路关联的标签
+        let loop_tag_ids = state.db.get_loop_tag_ids(loop_id).await?;
+        for tag_id in &loop_tag_ids {
+            if !all_tags.contains_key(tag_id) {
+                // 获取标签详情
+                if let Some(tag) = state.db.get_tag(*tag_id).await? {
+                    all_tags.insert(*tag_id, TagExportItem {
+                        id: generate_pseudo_id("tag", all_tags.len() + 1),
+                        name: tag.name,
+                        color: tag.color,
+                    });
+                }
+            }
+        }
+
+        // 收集环路引用的评审模板
+        if let Some(tpl_id) = view.loop_.review_template_id {
+            if !all_templates.contains_key(&tpl_id) {
+                if let Some(tpl) = state.db.get_review_template(tpl_id).await? {
+                    all_templates.insert(tpl_id, ReviewTemplateExportItem {
+                        id: generate_pseudo_id("template", all_templates.len() + 1),
+                        name: tpl.name,
+                        description: tpl.description,
+                        prompt: tpl.prompt,
+                    });
+                }
+            }
+        }
+
+        // 遍历步骤收集 Todo 和标签
+        for (step, _todo_title, _) in &view.steps_meta {
+            if !all_todos.contains_key(&step.todo_id) {
+                if let Some(todo) = state.db.get_todo_entity(step.todo_id).await? {
+                    // 收集 Todo 的标签
+                    let todo_tag_ids = state.db.get_todo_tag_ids(step.todo_id).await?;
+                    let mut todo_tag_items: Vec<TagExportItem> = Vec::new();
+                    for tag_id in &todo_tag_ids {
+                        if !all_tags.contains_key(tag_id) {
+                            if let Some(tag) = state.db.get_tag(*tag_id).await? {
+                                let pseudo_id = generate_pseudo_id("tag", all_tags.len() + 1);
+                                let color = tag.color.clone();
+                                all_tags.insert(*tag_id, TagExportItem {
+                                    id: pseudo_id.clone(),
+                                    name: tag.name.clone(),
+                                    color: color.clone(),
+                                });
+                                todo_tag_items.push(TagExportItem {
+                                    id: pseudo_id,
+                                    name: tag.name,
+                                    color,
+                                });
+                            }
+                        } else if let Some(existing) = all_tags.get(tag_id) {
+                            todo_tag_items.push(existing.clone());
+                        }
+                    }
+
+                    // 收集 Todo 引用的评审模板
+                    let mut review_template_id: Option<String> = None;
+                    let mut review_template_name: Option<String> = None;
+                    if let Some(rt_id) = todo.review_template_id {
+                        if !all_templates.contains_key(&rt_id) {
+                            if let Some(tpl) = state.db.get_review_template(rt_id).await? {
+                                review_template_id = Some(generate_pseudo_id("template", all_templates.len() + 1));
+                                review_template_name = Some(tpl.name.clone());
+                                all_templates.insert(rt_id, ReviewTemplateExportItem {
+                                    id: review_template_id.clone().unwrap(),
+                                    name: tpl.name,
+                                    description: tpl.description,
+                                    prompt: tpl.prompt,
+                                });
+                            }
+                        } else if let Some(existing) = all_templates.get(&rt_id) {
+                            review_template_id = Some(existing.id.clone());
+                            review_template_name = Some(existing.name.clone());
+                        }
+                    }
+
+                    let tag_ids: Vec<String> = todo_tag_items.iter().map(|t| t.id.clone()).collect();
+                    let tag_names: Vec<String> = todo_tag_items.iter().map(|t| t.name.clone()).collect();
+
+                    // 实体模型 status 是 Option<String>，需要 unwrap_or_default
+                    // kind 是 Option<String>，需要 unwrap_or_default
+                    all_todos.insert(step.todo_id, TodoExportItem {
+                        id: generate_pseudo_id("todo", all_todos.len() + 1),
+                        title: todo.title.clone(),
+                        prompt: todo.prompt.clone().unwrap_or_default(),
+                        status: todo.status.clone().unwrap_or_else(|| "pending".to_string()),
+                        executor: todo.executor.clone(),
+                        scheduler_enabled: todo.scheduler_enabled.unwrap_or(false),
+                        webhook_enabled: todo.webhook_enabled.unwrap_or(false),
+                        acceptance_criteria: todo.acceptance_criteria.clone(),
+                        auto_review_enabled: todo.auto_review_enabled.unwrap_or(false),
+                        review_template_id,
+                        review_template_name,
+                        kind: todo.kind.clone().unwrap_or_else(|| "item".to_string()),
+                        tag_ids,
+                        tag_names,
+                        is_abnormal_handler: false,
+                    });
+                }
+            }
+        }
+
+        // 收集异常处理 Todo（如果有）
+        let mut abnormal_handler_todo_id: Option<String> = None;
+        let mut abnormal_handler_todo_title: Option<String> = None;
+        if let Some(handler_todo_id) = view.loop_.abnormal_handler_todo_id {
+            if !all_todos.contains_key(&handler_todo_id) {
+                if let Some(todo) = state.db.get_todo_entity(handler_todo_id).await? {
+                    // 异常处理 Todo 不导出标签
+                    all_todos.insert(handler_todo_id, TodoExportItem {
+                        id: generate_pseudo_id("todo", all_todos.len() + 1),
+                        title: todo.title.clone(),
+                        prompt: todo.prompt.clone().unwrap_or_default(),
+                        status: todo.status.clone().unwrap_or_else(|| "pending".to_string()),
+                        executor: todo.executor.clone(),
+                        scheduler_enabled: todo.scheduler_enabled.unwrap_or(false),
+                        webhook_enabled: todo.webhook_enabled.unwrap_or(false),
+                        acceptance_criteria: todo.acceptance_criteria.clone(),
+                        auto_review_enabled: todo.auto_review_enabled.unwrap_or(false),
+                        review_template_id: None,
+                        review_template_name: None,
+                        kind: todo.kind.clone().unwrap_or_else(|| "item".to_string()),
+                        tag_ids: vec![],
+                        tag_names: vec![],
+                        is_abnormal_handler: true,
+                    });
+                }
+            }
+            if let Some(td) = all_todos.get(&handler_todo_id) {
+                abnormal_handler_todo_id = Some(td.id.clone());
+                abnormal_handler_todo_title = Some(td.title.clone());
+            }
+        }
+
+        // 构建环路导出项
+        let mut triggers: Vec<LoopTriggerExportItem> = Vec::new();
+        let mut trigger_idx = 0;
+        for t in &view.triggers {
+            // 只导出 manual 和 cron 触发器
+            if t.trigger_type != "manual" && t.trigger_type != "cron" {
+                continue;
+            }
+            trigger_idx += 1;
+            let mut enabled = t.enabled != 0;
+            // cron 触发器导出时强制禁用
+            if t.trigger_type == "cron" {
+                enabled = false;
+            }
+            triggers.push(LoopTriggerExportItem {
+                id: generate_pseudo_id("trigger", trigger_idx),
+                trigger_type: t.trigger_type.clone(),
+                config: serde_json::from_str(&t.config).unwrap_or_default(),
+                enabled,
+                priority: t.priority,
+            });
+        }
+
+        let mut steps: Vec<LoopStepExportItem> = Vec::new();
+        let mut step_idx = 0;
+        for (step, _todo_title, _) in &view.steps_meta {
+            step_idx += 1;
+            let todo_pseudo_id = all_todos.get(&step.todo_id)
+                .map(|t| t.id.clone())
+                .unwrap_or_else(|| generate_pseudo_id("todo", 999));
+
+            let success_goto_step_id = step.success_goto_step_id
+                .and_then(|gid| view.steps.iter().position(|s| s.id == gid))
+                .map(|pos| generate_pseudo_id("step", pos + 1));
+            let fail_goto_step_id = step.fail_goto_step_id
+                .and_then(|gid| view.steps.iter().position(|s| s.id == gid))
+                .map(|pos| generate_pseudo_id("step", pos + 1));
+
+            steps.push(LoopStepExportItem {
+                id: generate_pseudo_id("step", step_idx),
+                name: step.name.clone(),
+                description: step.description.clone(),
+                todo_id: todo_pseudo_id,
+                todo_title: all_todos.get(&step.todo_id).map(|t| t.title.clone()).unwrap_or_default(),
+                order_index: step.order_index,
+                run_mode: step.run_mode.clone(),
+                skip_on_source_failed: step.skip_on_source_failed != 0,
+                min_rating: step.min_rating,
+                unrated_policy: step.unrated_policy.clone(),
+                on_success: step.on_success.clone(),
+                success_goto_step_id,
+                success_goto_step_name: step.success_goto_step_id
+                    .and_then(|gid| view.steps.iter().find(|s| s.id == gid))
+                    .map(|s| s.name.clone()),
+                on_rating_fail: step.on_rating_fail.clone(),
+                fail_goto_step_id,
+                fail_goto_step_name: step.fail_goto_step_id
+                    .and_then(|gid| view.steps.iter().find(|s| s.id == gid))
+                    .map(|s| s.name.clone()),
+                review_type: step.review_type.clone(),
+                enabled: step.enabled != 0,
+            });
+        }
+
+        // 环路级别的评审模板
+        let mut loop_review_template_id: Option<String> = None;
+        let mut loop_review_template_name: Option<String> = None;
+        if let Some(rt_id) = view.loop_.review_template_id {
+            if let Some(existing) = all_templates.get(&rt_id) {
+                loop_review_template_id = Some(existing.id.clone());
+                loop_review_template_name = Some(existing.name.clone());
+            }
+        }
+
+        let loop_tag_ids = state.db.get_loop_tag_ids(loop_id).await?;
+        let loop_tag_pseudo_ids: Vec<String> = loop_tag_ids.iter()
+            .filter_map(|id| all_tags.get(id).map(|t| t.id.clone()))
+            .collect();
+        let loop_tag_names: Vec<String> = loop_tag_ids.iter()
+            .filter_map(|id| all_tags.get(id).map(|t| t.name.clone()))
+            .collect();
+
+        let limits_config: serde_json::Value = serde_json::from_str(&view.loop_.limits_config)
+            .unwrap_or_default();
+
+        let abnormal_handler_trigger_on: Vec<String> = serde_json::from_str(&view.loop_.abnormal_handler_trigger_on)
+            .unwrap_or_default();
+
+        exported_loops.push(LoopExportItem {
+            id: generate_pseudo_id("loop", idx + 1),
+            name: view.loop_.name.clone(),
+            description: view.loop_.description.clone(),
+            icon: view.loop_.icon.clone(),
+            color: view.loop_.color.clone(),
+            status: "paused".to_string(), // 导出时统一为 paused
+            webhook_enabled: view.loop_.webhook_enabled,
+            limits_config,
+            review_template_id: loop_review_template_id,
+            review_template_name: loop_review_template_name,
+            abnormal_handler_todo_id,
+            abnormal_handler_todo_title,
+            abnormal_handler_trigger_on,
+            tag_ids: loop_tag_pseudo_ids,
+            tag_names: loop_tag_names,
+            triggers,
+            steps,
+        });
+    }
+
+    let export_data = LoopExportData {
+        version: "1.0".to_string(),
+        export_type: "loop".to_string(),
+        created_at: chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string(),
+        source: "nothing-todo".to_string(),
+        schema_version: 1,
+        tags: all_tags.into_values().collect(),
+        review_templates: all_templates.into_values().collect(),
+        todos: all_todos.into_values().collect(),
+        loops: exported_loops,
+    };
+
+    serde_yaml::to_string(&export_data).map_err(|e| AppError::Internal(e.to_string()))
+}
+
 // ====== 路由表 ======
 
 pub fn loop_routes() -> axum::Router<AppState> {
@@ -853,7 +1562,9 @@ pub fn loop_routes() -> axum::Router<AppState> {
         .route("/api/loops", get(list_loops).post(create_loop))
         .route("/api/loops/batch-workspace", put(batch_move_loops_workspace))
         .route("/api/loops/batch-copy-workspace", post(batch_copy_loops_workspace))
+        .route("/api/loops/export-selected", post(export_selected_loops))
         .route("/api/loops/{id}", get(get_loop).put(update_loop).delete(delete_loop))
+        .route("/api/loops/{id}/export", get(export_loop))
         .route("/api/loops/{id}/status", put(update_loop_status))
         .route("/api/loops/{id}/tags", put(update_loop_tags))
         .route("/api/loops/{id}/duplicate", post(duplicate_loop))
@@ -874,4 +1585,7 @@ pub fn loop_routes() -> axum::Router<AppState> {
         .route("/api/loops/{id}/executions/{eid}/steps/{seid}/approve", post(approve_step_execution))
         // 通过执行 ID 直接获取执行详情（无需 loop_id），供消息历史中 "处理类型" 列跳转使用
         .route("/api/loop-executions/{eid}", get(get_execution_by_id))
+        // 导入导出
+        .route("/api/loops/import/preview", post(import_preview))
+        .route("/api/loops/import", post(import_loops))
 }

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -875,9 +875,12 @@ pub async fn export_loop(
         loop_.name.replace(' ', "-"),
         chrono::Utc::now().format("%Y%m%d-%H%M%S"));
 
-    let _disposition = format!("attachment; filename=\"{}\"", filename);
+    let disposition = format!("attachment; filename=\"{}\"", filename);
     Ok((
-        [(header::CONTENT_TYPE, "application/x-yaml; charset=utf-8")],
+        [
+            (header::CONTENT_TYPE, "application/x-yaml; charset=utf-8".to_string()),
+            (header::CONTENT_DISPOSITION, disposition),
+        ],
         yaml,
     ))
 }
@@ -894,9 +897,12 @@ pub async fn export_selected_loops(
     let filename = format!("loops-export-{}.loop.yaml",
         chrono::Utc::now().format("%Y%m%d-%H%M%S"));
 
-    let _disposition = format!("attachment; filename=\"{}\"", filename);
+    let disposition = format!("attachment; filename=\"{}\"", filename);
     Ok((
-        [(header::CONTENT_TYPE, "application/x-yaml; charset=utf-8")],
+        [
+            (header::CONTENT_TYPE, "application/x-yaml; charset=utf-8".to_string()),
+            (header::CONTENT_DISPOSITION, disposition),
+        ],
         yaml,
     ))
 }
@@ -1142,9 +1148,15 @@ pub async fn import_loops(
         created_counts.review_templates += 1;
     }
 
-    // 阶段3: 导入Todo模板
+    // 阶段3: 导入Todo模板（完整字段导入）
     for todo in &data.todos {
-        let new_todo_id = state.db.create_todo_with_extras(
+        // 解析 kind 字符串 → i32（导出时存为字符串以便序列化）
+        let kind: Option<i32> = todo.kind.parse().ok().or(Some(0));
+        // 解析 review_template_id 伪ID → 真实ID
+        let real_review_template_id = todo.review_template_id.as_ref()
+            .and_then(|tid| template_pseudo_to_real.get(tid))
+            .copied();
+        let new_todo_id = state.db.create_todo_for_import(
             &todo.title,
             &todo.prompt,
             todo.executor.as_deref(),
@@ -1152,6 +1164,11 @@ pub async fn import_loops(
             todo.webhook_enabled,
             workspace_id,
             &workspace.path,
+            Some(&todo.status),
+            Some(todo.scheduler_enabled),
+            Some(todo.auto_review_enabled),
+            real_review_template_id,
+            kind,
         ).await?;
 
         todo_pseudo_to_real.insert(todo.id.clone(), new_todo_id);
@@ -1201,11 +1218,12 @@ pub async fn import_loops(
         loop_pseudo_to_real.insert(loop_export.id.clone(), new_loop.id);
         created_counts.loops += 1;
 
-        // 关联标签
-        for (pseudo_tag_id, _) in loop_export.tag_ids.iter().zip(loop_export.tag_names.iter()) {
-            if let Some(&real_tag_id) = tag_pseudo_to_real.get(pseudo_tag_id) {
-                state.db.set_loop_tags(new_loop.id, &[real_tag_id]).await?;
-            }
+        // 关联标签 - 先收集所有 tag_id，再一次性写入，避免 set_loop_tags 全量替换导致只保留最后一个
+        let tag_ids: Vec<i64> = loop_export.tag_ids.iter()
+            .filter_map(|pseudo_tag_id| tag_pseudo_to_real.get(pseudo_tag_id).copied())
+            .collect();
+        if !tag_ids.is_empty() {
+            state.db.set_loop_tags(new_loop.id, &tag_ids).await?;
         }
 
         // 阶段5: 导入触发器
@@ -1368,14 +1386,20 @@ pub async fn merge_loops(
         }
     }
 
-    // 阶段3: 合并Todo（按title+prompt匹配）
+    // 阶段3: 合并Todo（按title+prompt+workspace匹配）
     for todo in &data.todos {
-        // 尝试查找同名Todo
-        if let Some(existing_todo) = state.db.get_todo_by_title(&todo.title).await? {
+        // 尝试查找完全相同的 Todo（title + prompt + workspace）
+        if let Some(existing_todo) = state.db.get_todo_by_identity(&todo.title, &todo.prompt, req.workspace_id).await? {
             // 存在则复用，不重复创建
             todo_pseudo_to_real.insert(todo.id.clone(), existing_todo.id);
         } else {
-            let new_todo_id = state.db.create_todo_with_extras(
+            // 解析 kind 字符串 → i32
+            let kind: Option<i32> = todo.kind.parse().ok().or(Some(0));
+            // 解析 review_template_id 伪ID → 真实ID
+            let real_review_template_id = todo.review_template_id.as_ref()
+                .and_then(|tid| template_pseudo_to_real.get(tid))
+                .copied();
+            let new_todo_id = state.db.create_todo_for_import(
                 &todo.title,
                 &todo.prompt,
                 todo.executor.as_deref(),
@@ -1383,6 +1407,11 @@ pub async fn merge_loops(
                 todo.webhook_enabled,
                 req.workspace_id,
                 &workspace.path,
+                Some(&todo.status),
+                Some(todo.scheduler_enabled),
+                Some(todo.auto_review_enabled),
+                real_review_template_id,
+                kind,
             ).await?;
             todo_pseudo_to_real.insert(todo.id.clone(), new_todo_id);
             created_counts.todos += 1;
@@ -1415,21 +1444,21 @@ pub async fn merge_loops(
                 ).await?;
                 (new_loop_id, false)
             }
-            // 重命名（追加后缀）
+            // 重命名（追加后缀后创建新环路）
             (Some(_), "rename") | (_, "rename") => {
                 let new_loop_id = create_loop_from_export(
                     &state, loop_export, req.workspace_id, &workspace.path,
                     &template_pseudo_to_real, &todo_pseudo_to_real, &tag_pseudo_to_real,
                 ).await?;
-                (new_loop_id, false)
+                (new_loop_id, true) // rename 创建了新环路
             }
-            // 默认重命名
+            // 默认：同名环路不存在，直接创建全新的
             (None, _) => {
                 let new_loop_id = create_loop_from_export(
                     &state, loop_export, req.workspace_id, &workspace.path,
                     &template_pseudo_to_real, &todo_pseudo_to_real, &tag_pseudo_to_real,
                 ).await?;
-                (new_loop_id, false)
+                (new_loop_id, true)
             }
             _ => continue,
         };
@@ -1497,11 +1526,12 @@ async fn create_loop_from_export(
         &abnormal_handler_trigger_on,
     ).await?;
 
-    // 关联标签
-    for (pseudo_tag_id, _) in loop_export.tag_ids.iter().zip(loop_export.tag_names.iter()) {
-        if let Some(&real_tag_id) = tag_pseudo_to_real.get(pseudo_tag_id) {
-            state.db.set_loop_tags(new_loop.id, &[real_tag_id]).await?;
-        }
+    // 关联标签 - 先收集所有 tag_id，再一次性写入，避免 set_loop_tags 全量替换导致只保留最后一个
+    let tag_ids: Vec<i64> = loop_export.tag_ids.iter()
+        .filter_map(|pseudo_tag_id| tag_pseudo_to_real.get(pseudo_tag_id).copied())
+        .collect();
+    if !tag_ids.is_empty() {
+        state.db.set_loop_tags(new_loop.id, &tag_ids).await?;
     }
 
     // 导入触发器
@@ -1569,6 +1599,10 @@ async fn build_loop_export_yaml(
     let mut all_templates: std::collections::HashMap<i64, ReviewTemplateExportItem> = std::collections::HashMap::new();
     let mut all_todos: std::collections::HashMap<i64, TodoExportItem> = std::collections::HashMap::new();
     let mut exported_loops: Vec<LoopExportItem> = Vec::new();
+
+    // 全局计数器，避免批量导出时多个环路的 trigger/step pseudo-ID 冲突
+    let mut global_trigger_idx = 0;
+    let mut global_step_idx = 0;
 
     for (idx, &loop_id) in loop_ids.iter().enumerate() {
         let view = state.db.load_loop_full(loop_id).await?
@@ -1712,20 +1746,19 @@ async fn build_loop_export_yaml(
 
         // 构建环路导出项
         let mut triggers: Vec<LoopTriggerExportItem> = Vec::new();
-        let mut trigger_idx = 0;
         for t in &view.triggers {
             // 只导出 manual 和 cron 触发器
             if t.trigger_type != "manual" && t.trigger_type != "cron" {
                 continue;
             }
-            trigger_idx += 1;
+            global_trigger_idx += 1;
             let mut enabled = t.enabled != 0;
             // cron 触发器导出时强制禁用
             if t.trigger_type == "cron" {
                 enabled = false;
             }
             triggers.push(LoopTriggerExportItem {
-                id: generate_pseudo_id("trigger", trigger_idx),
+                id: generate_pseudo_id("trigger", global_trigger_idx),
                 trigger_type: t.trigger_type.clone(),
                 config: serde_json::from_str(&t.config).unwrap_or_default(),
                 enabled,
@@ -1734,22 +1767,26 @@ async fn build_loop_export_yaml(
         }
 
         let mut steps: Vec<LoopStepExportItem> = Vec::new();
-        let mut step_idx = 0;
+        // 本地位置 → 全局 step pseudo-ID 映射（用于解析 goto 引用）
+        let mut step_pos_to_global: Vec<i32> = Vec::new();
         for (step, _todo_title, _) in &view.steps_meta {
-            step_idx += 1;
+            global_step_idx += 1;
+            step_pos_to_global.push(global_step_idx);
             let todo_pseudo_id = all_todos.get(&step.todo_id)
                 .map(|t| t.id.clone())
                 .unwrap_or_else(|| generate_pseudo_id("todo", 999));
 
             let success_goto_step_id = step.success_goto_step_id
                 .and_then(|gid| view.steps.iter().position(|s| s.id == gid))
-                .map(|pos| generate_pseudo_id("step", pos + 1));
+                .and_then(|pos| step_pos_to_global.get(pos).copied())
+                .map(|idx| generate_pseudo_id("step", idx as usize));
             let fail_goto_step_id = step.fail_goto_step_id
                 .and_then(|gid| view.steps.iter().position(|s| s.id == gid))
-                .map(|pos| generate_pseudo_id("step", pos + 1));
+                .and_then(|pos| step_pos_to_global.get(pos).copied())
+                .map(|idx| generate_pseudo_id("step", idx as usize));
 
             steps.push(LoopStepExportItem {
-                id: generate_pseudo_id("step", step_idx),
+                id: generate_pseudo_id("step", global_step_idx as usize),
                 name: step.name.clone(),
                 description: step.description.clone(),
                 todo_id: todo_pseudo_id,

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1028,11 +1028,232 @@ pub struct TodoBackup {
     pub worktree: Option<String>,
 }
 
+// ============ 环路导入导出 DTO ============
+// 方案：伪ID引用（@loop_1, @todo_1 等）解决跨实体引用问题
+
+/// 导出文件顶层结构
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopExportData {
+    pub version: String,
+    #[serde(rename = "type")]
+    pub export_type: String,
+    pub created_at: String,
+    pub source: String,
+    pub schema_version: i32,
+    pub tags: Vec<TagExportItem>,
+    pub review_templates: Vec<ReviewTemplateExportItem>,
+    pub todos: Vec<TodoExportItem>,
+    pub loops: Vec<LoopExportItem>,
+}
+
+/// 标签导出项（伪ID格式）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TagExportItem {
+    pub id: String,    // 伪ID: "@tag_1"
+    pub name: String,
+    pub color: String,
+}
+
+/// 评审模板导出项（伪ID格式）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewTemplateExportItem {
+    pub id: String,               // 伪ID: "@template_1"
+    pub name: String,
+    pub description: Option<String>,
+    pub prompt: String,
+}
+
+/// Todo 导出项（伪ID格式）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TodoExportItem {
+    pub id: String,               // 伪ID: "@todo_1"
+    pub title: String,
+    pub prompt: String,
+    pub status: String,
+    pub executor: Option<String>,
+    pub scheduler_enabled: bool,
+    pub webhook_enabled: bool,
+    pub acceptance_criteria: Option<String>,
+    pub auto_review_enabled: bool,
+    pub review_template_id: Option<String>,    // 伪ID引用
+    pub review_template_name: Option<String>,  // 展示用
+    pub kind: String,
+    pub tag_ids: Vec<String>,                   // 伪ID引用
+    pub tag_names: Vec<String>,                // 展示用
+    /// 是否为异常处理 Todo（异常处理 Todo 不导出标签）
+    #[serde(default)]
+    pub is_abnormal_handler: bool,
+}
+
+/// 环路导出项（伪ID格式）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopExportItem {
+    pub id: String,               // 伪ID: "@loop_1"
+    pub name: String,
+    pub description: String,
+    pub icon: String,
+    pub color: String,
+    pub status: String,
+    pub webhook_enabled: bool,
+    pub limits_config: serde_json::Value,
+    pub review_template_id: Option<String>,          // 伪ID引用
+    pub review_template_name: Option<String>,        // 展示用
+    pub abnormal_handler_todo_id: Option<String>,   // 伪ID引用
+    pub abnormal_handler_todo_title: Option<String>, // 展示用
+    pub abnormal_handler_trigger_on: Vec<String>,
+    pub tag_ids: Vec<String>,                        // 伪ID引用
+    pub tag_names: Vec<String>,                      // 展示用
+    pub triggers: Vec<LoopTriggerExportItem>,
+    pub steps: Vec<LoopStepExportItem>,
+}
+
+/// 触发器导出项（只包含 manual 和 cron）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopTriggerExportItem {
+    pub id: String,           // 伪ID: "@trigger_1"
+    pub trigger_type: String, // "manual" 或 "cron"
+    pub config: serde_json::Value,
+    pub enabled: bool,
+    pub priority: i32,
+}
+
+/// 步骤导出项（伪ID格式）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopStepExportItem {
+    pub id: String,               // 伪ID: "@step_1"
+    pub name: String,
+    pub description: String,
+    pub todo_id: String,          // 伪ID引用
+    pub todo_title: String,       // 展示用
+    pub order_index: i32,
+    pub run_mode: String,
+    pub skip_on_source_failed: bool,
+    pub min_rating: Option<i32>,
+    pub unrated_policy: String,
+    pub on_success: String,
+    pub success_goto_step_id: Option<String>,   // 伪ID引用
+    pub success_goto_step_name: Option<String>, // 展示用
+    pub on_rating_fail: String,
+    pub fail_goto_step_id: Option<String>,      // 伪ID引用
+    pub fail_goto_step_name: Option<String>,    // 展示用
+    pub review_type: String,
+    pub enabled: bool,
+}
+
+// ============ 导入预览/执行响应 DTO ============
+
+/// 导入预览响应
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopImportPreviewResponse {
+    pub valid: bool,
+    pub pseudo_ids: Vec<String>,
+    pub summary: LoopImportSummary,
+    pub conflicts: Vec<LoopImportConflict>,
+    pub warnings: Vec<LoopImportWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopImportSummary {
+    pub loops: usize,
+    pub steps: usize,
+    pub todos: usize,
+    pub review_templates: usize,
+    pub tags: usize,
+    pub triggers: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopImportConflict {
+    #[serde(rename = "type")]
+    pub conflict_type: String,
+    pub name: String,
+    pub action: String, // "rename" | "overwrite" | "skip"
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopImportWarning {
+    #[serde(rename = "type")]
+    pub warning_type: String,
+    pub message: String,
+}
+
+/// 导入执行响应
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopImportResponse {
+    pub success: bool,
+    pub created: LoopImportCreatedCounts,
+    pub warnings: Vec<LoopImportWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopImportCreatedCounts {
+    pub loops: usize,
+    pub todos: usize,
+    pub review_templates: usize,
+    pub tags: usize,
+    pub triggers: usize,
+    pub steps: usize,
+}
+
+/// 导出选择请求
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExportLoopSelectedRequest {
+    pub loop_ids: Vec<i64>,
+}
+
 // Business error codes
 pub mod codes {
     pub const NOT_FOUND: i32 = 40001;
     pub const BAD_REQUEST: i32 = 40002;
     pub const INTERNAL: i32 = 50001;
+}
+
+// ============ 伪ID工具函数 ============
+
+/// 伪ID类型前缀
+const PSEUDO_ID_PREFIXES: &[&str] = &["loop", "todo", "step", "trigger", "template", "tag"];
+
+/// 生成伪ID: "@{prefix}_{index}"
+pub fn generate_pseudo_id(prefix: &str, index: usize) -> String {
+    format!("@{}_{}", prefix, index)
+}
+
+/// 校验伪ID格式是否合法
+/// 格式: ^@(loop|todo|step|trigger|template|tag)_\d+$
+pub fn validate_pseudo_id(id: &str) -> bool {
+    // 必须以 @ 开头
+    if !id.starts_with('@') {
+        return false;
+    }
+    // 去掉 @ 前缀后检查格式
+    let rest = &id[1..];
+    // 检查是否包含 _ 和数字部分
+    if let Some(underscore_pos) = rest.find('_') {
+        let prefix = &rest[..underscore_pos];
+        let suffix = &rest[underscore_pos + 1..];
+        return PSEUDO_ID_PREFIXES.contains(&prefix) && suffix.parse::<usize>().is_ok();
+    }
+    false
+}
+
+/// 从伪ID提取前缀
+pub fn extract_pseudo_prefix(id: &str) -> Option<&str> {
+    if !id.starts_with('@') {
+        return None;
+    }
+    let rest = &id[1..];
+    // 没有下划线则不是合法伪ID格式
+    let underscore_pos = rest.find('_')?;
+    Some(&rest[..underscore_pos])
+}
+
+/// 从伪ID提取序号
+pub fn extract_pseudo_index(id: &str) -> Option<usize> {
+    if !id.starts_with('@') {
+        return None;
+    }
+    let rest = &id[1..];
+    rest.split('_').nth(1)?.parse().ok()
 }
 
 /// 返回当前 UTC 时间的 ISO 8601 格式字符串 (2024-01-15T08:30:00.000Z)
@@ -1292,6 +1513,60 @@ mod tests {
         assert!(req.executor.is_none());
         assert!(req.scheduler_enabled.is_none());
         assert!(req.scheduler_config.is_none());
+    }
+
+    // ============ 伪ID工具函数测试 ============
+
+    #[test]
+    fn test_generate_pseudo_id() {
+        assert_eq!(generate_pseudo_id("loop", 1), "@loop_1");
+        assert_eq!(generate_pseudo_id("todo", 42), "@todo_42");
+        assert_eq!(generate_pseudo_id("step", 100), "@step_100");
+    }
+
+    #[test]
+    fn test_validate_pseudo_id_valid() {
+        assert!(validate_pseudo_id("@loop_1"));
+        assert!(validate_pseudo_id("@todo_42"));
+        assert!(validate_pseudo_id("@step_100"));
+        assert!(validate_pseudo_id("@trigger_5"));
+        assert!(validate_pseudo_id("@template_3"));
+        assert!(validate_pseudo_id("@tag_99"));
+    }
+
+    #[test]
+    fn test_validate_pseudo_id_invalid() {
+        // 不是以 @ 开头
+        assert!(!validate_pseudo_id("loop_1"));
+        assert!(!validate_pseudo_id(""));
+        // 没有下划线
+        assert!(!validate_pseudo_id("@loop"));
+        assert!(!validate_pseudo_id("@todoabc"));
+        // 前缀不合法
+        assert!(!validate_pseudo_id("@invalid_1"));
+        assert!(!validate_pseudo_id("@_1"));
+        // 数字部分不合法
+        assert!(!validate_pseudo_id("@loop_abc"));
+        assert!(!validate_pseudo_id("@loop_-1"));
+    }
+
+    #[test]
+    fn test_extract_pseudo_prefix() {
+        assert_eq!(extract_pseudo_prefix("@loop_1"), Some("loop"));
+        assert_eq!(extract_pseudo_prefix("@todo_42"), Some("todo"));
+        assert_eq!(extract_pseudo_prefix("@step_100"), Some("step"));
+        assert_eq!(extract_pseudo_prefix("loop_1"), None);  // 没有 @ 前缀
+        assert_eq!(extract_pseudo_prefix("@"), None);       // @ 后无下划线，不是合法伪ID
+    }
+
+    #[test]
+    fn test_extract_pseudo_index() {
+        assert_eq!(extract_pseudo_index("@loop_1"), Some(1));
+        assert_eq!(extract_pseudo_index("@todo_42"), Some(42));
+        assert_eq!(extract_pseudo_index("@step_100"), Some(100));
+        assert_eq!(extract_pseudo_index("loop_1"), None);
+        assert_eq!(extract_pseudo_index("@loop"), None);
+        assert_eq!(extract_pseudo_index("@loop_abc"), None);
     }
 }
 

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -22,6 +22,7 @@ import {
   ExclamationCircleOutlined,
   CheckCircleOutlined,
   CloseCircleOutlined,
+  ExportOutlined,
 } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
 import type { LoopDetail } from '@/types/loop';
@@ -54,13 +55,32 @@ export function LoopDetailPanel({
   onChanged,
   hideTitleRow = false,
 }: LoopDetailPanelProps) {
-  const { message } = AntApp.useApp();
+  const { message: antMessage } = AntApp.useApp();
   const [detail, setDetail] = useState<LoopDetail | null>(null);
   const [loading, setLoading] = useState(true);
   // 基础信息编辑 modal 开关 (替代之前的 inline 编辑)
   const [editing, setEditing] = useState(false);
   // 工作空间目录（低基数集合，详情展示时把 path 转成 name 用）
   const { dirs: projectDirs } = useProjectDirectories();
+
+  // 导出环路
+  const handleExport = async () => {
+    try {
+      const yaml = await dbLoops.exportLoop(loopId);
+      const blob = new Blob([yaml], { type: 'application/x-yaml' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${detail?.name || 'loop'}.loop.yaml`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      antMessage.success('导出成功');
+    } catch (err: any) {
+      antMessage.error(err?.message || '导出失败');
+    }
+  };
   // 执行记录总数，由 LoopExecutionsPanel 通过回调更新
   const [executionTotal, setExecutionTotal] = useState(0);
   // 从 loop.limits_config 解析出的限制值，传递给子面板做兜底校验
@@ -95,11 +115,11 @@ export function LoopDetailPanel({
         }
       })
       .catch(() => {
-        message.error('加载 loop 详情失败');
+        antMessage.error('加载 loop 详情失败');
         setDetail(null);
       })
       .finally(() => setLoading(false));
-  }, [loopId, message]);
+  }, [loopId, antMessage]);
 
   useEffect(() => { reload(); }, [reload]);
 
@@ -169,6 +189,9 @@ export function LoopDetailPanel({
               </Tooltip>
               <Tooltip title="复制">
                 <Button type="text" size="small" icon={<CopyOutlined />} onClick={onDuplicate} />
+              </Tooltip>
+              <Tooltip title="导出">
+                <Button type="text" size="small" icon={<ExportOutlined />} onClick={handleExport} />
               </Tooltip>
               <Tooltip title="编辑">
                 <Button type="text" size="small" icon={<EditOutlined />} onClick={handleOpenEdit} />
@@ -260,8 +283,8 @@ export function LoopDetailPanel({
                   icon={<CopyOutlined />}
                   onClick={async () => {
                     const ok = await copyToClipboard(`${window.location.origin}/webhook/trigger/loop/${detail.id}`);
-                    if (ok) message.success('已复制 Webhook 地址');
-                    else message.error('复制失败');
+                    if (ok) antMessage.success('已复制 Webhook 地址');
+                    else antMessage.error('复制失败');
                   }}
                 />
               </span>

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -115,8 +115,8 @@ export function LoopDetailPanel({
         }
       })
       .catch(() => {
+        // 只提示错误，不清空已加载的 detail；保留最后一次成功加载的数据供用户查看
         antMessage.error('加载 loop 详情失败');
-        setDetail(null);
       })
       .finally(() => setLoading(false));
   }, [loopId, antMessage]);

--- a/frontend/src/components/settings/BackupPanel.tsx
+++ b/frontend/src/components/settings/BackupPanel.tsx
@@ -6,6 +6,7 @@ import yaml from 'js-yaml';
 import { TodoBackupTab } from './backup/TodoBackupTab';
 import { SkillBackupTab } from './backup/SkillBackupTab';
 import { DatabaseBackupTab } from './backup/DatabaseBackupTab';
+import { LoopBackupTab } from './backup/LoopBackupTab';
 import { ImportExportModals, BackupDataYaml, ImportItem } from './backup/ImportExportModals';
 
 export function BackupPanel() {
@@ -472,6 +473,13 @@ export function BackupPanel() {
                 onDeleteBackup={handleDeleteSkillBackup}
                 onDownloadBackupFile={handleDownloadSkillBackupFile}
               />
+            ),
+          },
+          {
+            key: 'loop',
+            label: '环路备份',
+            children: (
+              <LoopBackupTab />
             ),
           },
           {

--- a/frontend/src/components/settings/BackupPanel.tsx
+++ b/frontend/src/components/settings/BackupPanel.tsx
@@ -6,7 +6,7 @@ import yaml from 'js-yaml';
 import { TodoBackupTab } from './backup/TodoBackupTab';
 import { SkillBackupTab } from './backup/SkillBackupTab';
 import { DatabaseBackupTab } from './backup/DatabaseBackupTab';
-import { LoopBackupTab } from './backup/LoopBackupTab';
+import { LoopBackupTab } from '@/components/settings/backup/LoopBackupTab';
 import { ImportExportModals, BackupDataYaml, ImportItem } from './backup/ImportExportModals';
 
 export function BackupPanel() {

--- a/frontend/src/components/settings/backup/LoopBackupTab.tsx
+++ b/frontend/src/components/settings/backup/LoopBackupTab.tsx
@@ -1,0 +1,221 @@
+import { Card, Button, Typography, Upload, Select, Space, Modal, Tag, Alert, message } from 'antd';
+import { DownloadOutlined, InboxOutlined } from '@ant-design/icons';
+import { useState, useEffect } from 'react';
+import * as db from '@/utils/database';
+import { exportLoop, listLoops } from '@/utils/database/loops';
+
+const { Dragger } = Upload;
+
+export function LoopBackupTab() {
+  const [selectedLoopId, setSelectedLoopId] = useState<number | null>(null);
+  const [exporting, setExporting] = useState(false);
+  const [importModalOpen, setImportModalOpen] = useState(false);
+  const [yamlPreview, setYamlPreview] = useState<string | null>(null);
+  const [previewData, setPreviewData] = useState<any>(null);
+  const [importing, setImporting] = useState(false);
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<number | null>(null);
+  const [workspaces, setWorkspaces] = useState<any[]>([]);
+  const [loops, setLoops] = useState<any[]>([]);
+
+  // 加载环路列表
+  useEffect(() => {
+    listLoops().then(setLoops).catch(() => {});
+  }, []);
+
+  // 加载工作空间列表
+  const loadWorkspaces = async () => {
+    try {
+      const ws = await db.getProjectDirectories();
+      setWorkspaces(ws);
+      if (ws.length > 0 && !selectedWorkspaceId) {
+        setSelectedWorkspaceId(ws[0].id);
+      }
+    } catch (e) {
+      console.error('Failed to load workspaces', e);
+    }
+  };
+
+  // 导出单个环路
+  const handleExportLoop = async (loopId: number) => {
+    setExporting(true);
+    try {
+      const yaml = await exportLoop(loopId);
+      const blob = new Blob([yaml], { type: 'application/x-yaml' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const loop = loops.find(l => l.id === loopId);
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+      a.download = `${loop?.name || 'loop'}-${timestamp}.loop.yaml`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      message.success('环路导出成功');
+    } catch (err: any) {
+      message.error(err?.message || '导出失败');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  // 导入文件解析
+  const handleImportFile = async (file: File) => {
+    try {
+      const text = await file.text();
+      const preview = await db.previewLoopImport(text);
+      if (!preview.valid) {
+        message.error('文件格式校验失败');
+        return false;
+      }
+      setYamlPreview(text);
+      setPreviewData(preview);
+      await loadWorkspaces();
+      setImportModalOpen(true);
+    } catch (err: any) {
+      message.error('解析文件失败: ' + (err?.message || String(err)));
+    }
+    return false; // 阻止默认上传
+  };
+
+  // 执行导入
+  const handleConfirmImport = async () => {
+    if (!yamlPreview || !selectedWorkspaceId) {
+      message.warning('请选择目标工作空间');
+      return;
+    }
+    setImporting(true);
+    try {
+      const result = await db.importLoops(yamlPreview, selectedWorkspaceId);
+      message.success(`导入成功：创建了 ${result.created.loops} 个环路`);
+      setImportModalOpen(false);
+      setYamlPreview(null);
+      setPreviewData(null);
+      // 刷新页面
+      window.location.reload();
+    } catch (err: any) {
+      message.error(err?.message || '导入失败');
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const loopOptions = loops.map(l => ({ label: l.name, value: l.id }));
+
+  return (
+    <div style={{ maxWidth: 600 }}>
+      <Card title="导出环路" size="small" style={{ marginBottom: 24 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <Typography.Paragraph type="secondary">
+            将环路导出为 .loop.yaml 文件，方便迁移和分享
+          </Typography.Paragraph>
+          <Select
+            placeholder="选择一个环路"
+            options={loopOptions}
+            value={selectedLoopId}
+            onChange={setSelectedLoopId}
+            style={{ width: '100%' }}
+            allowClear
+          />
+          <Button
+            type="primary"
+            icon={<DownloadOutlined />}
+            onClick={() => selectedLoopId && handleExportLoop(selectedLoopId)}
+            loading={exporting}
+            disabled={!selectedLoopId}
+            style={{ width: '100%' }}
+          >
+            导出选中环路
+          </Button>
+        </div>
+      </Card>
+
+      <Card title="导入环路" size="small" style={{ marginBottom: 24 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <Typography.Paragraph type="secondary">
+            从 .loop.yaml 文件导入环路，支持预览和选择性导入
+          </Typography.Paragraph>
+          <Dragger
+            accept=".yaml,.yml,.loop.yaml"
+            beforeUpload={handleImportFile}
+            showUploadList={false}
+            style={{ borderRadius: 12 }}
+          >
+            <p className="ant-upload-drag-icon">
+              <InboxOutlined style={{ color: '#0891b2' }} />
+            </p>
+            <p className="ant-upload-text">点击或拖拽 .loop.yaml 文件到此处</p>
+            <p className="ant-upload-hint">将解析文件并展示预览，确认后导入到目标工作空间</p>
+          </Dragger>
+        </div>
+      </Card>
+
+      <Modal
+        title="导入环路预览"
+        open={importModalOpen}
+        onCancel={() => setImportModalOpen(false)}
+        footer={[
+          <Button key="cancel" onClick={() => setImportModalOpen(false)}>取消</Button>,
+          <Button
+            key="import"
+            type="primary"
+            loading={importing}
+            disabled={!selectedWorkspaceId}
+            onClick={handleConfirmImport}
+          >
+            确认导入
+          </Button>,
+        ]}
+        width={600}
+      >
+        {previewData && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <Alert
+              message="即将导入以下内容"
+              description={
+                <div>
+                  <Space direction="vertical" size="small">
+                    <Tag>环路: {previewData.summary.loops} 个</Tag>
+                    <Tag>步骤: {previewData.summary.steps} 个</Tag>
+                    <Tag>Todo模板: {previewData.summary.todos} 个</Tag>
+                    <Tag>评审模板: {previewData.summary.review_templates} 个</Tag>
+                    <Tag>标签: {previewData.summary.tags} 个</Tag>
+                    <Tag>触发器: {previewData.summary.triggers} 个</Tag>
+                  </Space>
+                </div>
+              }
+              type="info"
+              showIcon
+            />
+
+            {previewData.warnings && previewData.warnings.length > 0 && (
+              <Alert
+                message="警告"
+                description={
+                  <ul style={{ margin: 0, paddingLeft: 20 }}>
+                    {previewData.warnings.map((w: any, i: number) => (
+                      <li key={i}>{w.message}</li>
+                    ))}
+                  </ul>
+                }
+                type="warning"
+                showIcon
+              />
+            )}
+
+            <div>
+              <Typography.Text strong>目标工作空间</Typography.Text>
+              <Select
+                placeholder="选择工作空间"
+                options={workspaces.map(w => ({ label: w.name, value: w.id }))}
+                value={selectedWorkspaceId}
+                onChange={setSelectedWorkspaceId}
+                style={{ width: '100%', marginTop: 8 }}
+              />
+            </div>
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/backup/LoopBackupTab.tsx
+++ b/frontend/src/components/settings/backup/LoopBackupTab.tsx
@@ -104,10 +104,15 @@ export function LoopBackupTab() {
     }
     setImporting(true);
     try {
-      // TODO: 合并模式 conflictResolutions 暂未支持后端
-      // 统一走 db.importLoops 创建模式
-      const result = await db.importLoops(yamlPreview, selectedWorkspaceId);
-      message.success(`导入成功：创建了 ${result.created.loops} 个环路`);
+      if (importMode === 'merge') {
+        const result = await db.mergeLoops(yamlPreview, selectedWorkspaceId, conflictResolutions);
+        message.success(
+          `导入完成：新建 ${result.created.loops} 个，更新 ${result.updated?.loops || 0} 个，跳过 ${result.skipped?.length || 0} 个`
+        );
+      } else {
+        const result = await db.importLoops(yamlPreview, selectedWorkspaceId);
+        message.success(`导入成功：创建了 ${result.created.loops} 个环路`);
+      }
       setImportModalOpen(false);
       setYamlPreview(null);
       setPreviewData(null);

--- a/frontend/src/components/settings/backup/LoopBackupTab.tsx
+++ b/frontend/src/components/settings/backup/LoopBackupTab.tsx
@@ -1,21 +1,30 @@
-import { Card, Button, Typography, Upload, Select, Space, Modal, Tag, Alert, message } from 'antd';
+import { Card, Button, Typography, Upload, Select, Space, Modal, Tag, Alert, message, Radio, Table, Divider } from 'antd';
 import { DownloadOutlined, InboxOutlined } from '@ant-design/icons';
 import { useState, useEffect } from 'react';
 import * as db from '@/utils/database';
 import { exportLoop, listLoops } from '@/utils/database/loops';
+import { LoopImportPreview } from '@/utils/database/backup';
 
 const { Dragger } = Upload;
+const { Group: RadioGroup, Button: RadioButton } = Radio;
+
+type ImportMode = 'create' | 'merge';
+type ConflictAction = 'rename' | 'overwrite' | 'skip';
 
 export function LoopBackupTab() {
   const [selectedLoopId, setSelectedLoopId] = useState<number | null>(null);
   const [exporting, setExporting] = useState(false);
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [yamlPreview, setYamlPreview] = useState<string | null>(null);
-  const [previewData, setPreviewData] = useState<any>(null);
+  const [previewData, setPreviewData] = useState<LoopImportPreview | null>(null);
   const [importing, setImporting] = useState(false);
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<number | null>(null);
   const [workspaces, setWorkspaces] = useState<any[]>([]);
   const [loops, setLoops] = useState<any[]>([]);
+  // 导入模式：create=新建模式（默认），merge=合并模式
+  const [importMode, setImportMode] = useState<ImportMode>('create');
+  // 冲突解决映射：loop_name -> action
+  const [conflictResolutions, setConflictResolutions] = useState<Record<string, ConflictAction>>({});
 
   // 加载环路列表
   useEffect(() => {
@@ -44,7 +53,7 @@ export function LoopBackupTab() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      const loop = loops.find(l => l.id === loopId);
+      const loop = loops.find((l: any) => l.id === loopId);
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
       a.download = `${loop?.name || 'loop'}-${timestamp}.loop.yaml`;
       document.body.appendChild(a);
@@ -64,18 +73,27 @@ export function LoopBackupTab() {
     try {
       const text = await file.text();
       const preview = await db.previewLoopImport(text);
-      if (!preview.valid) {
-        message.error('文件格式校验失败');
-        return false;
-      }
       setYamlPreview(text);
       setPreviewData(preview);
+      // 初始化冲突解决策略：默认重命名
+      const resolutions: Record<string, ConflictAction> = {};
+      if (preview.conflicts) {
+        for (const c of preview.conflicts) {
+          resolutions[c.name] = 'rename';
+        }
+      }
+      setConflictResolutions(resolutions);
       await loadWorkspaces();
       setImportModalOpen(true);
     } catch (err: any) {
       message.error('解析文件失败: ' + (err?.message || String(err)));
     }
-    return false; // 阻止默认上传
+    return false;
+  };
+
+  // 更新单个冲突的解决策略
+  const updateConflictResolution = (name: string, action: ConflictAction) => {
+    setConflictResolutions(prev => ({ ...prev, [name]: action }));
   };
 
   // 执行导入
@@ -86,12 +104,13 @@ export function LoopBackupTab() {
     }
     setImporting(true);
     try {
+      // TODO: 合并模式 conflictResolutions 暂未支持后端
+      // 统一走 db.importLoops 创建模式
       const result = await db.importLoops(yamlPreview, selectedWorkspaceId);
       message.success(`导入成功：创建了 ${result.created.loops} 个环路`);
       setImportModalOpen(false);
       setYamlPreview(null);
       setPreviewData(null);
-      // 刷新页面
       window.location.reload();
     } catch (err: any) {
       message.error(err?.message || '导入失败');
@@ -100,7 +119,26 @@ export function LoopBackupTab() {
     }
   };
 
-  const loopOptions = loops.map(l => ({ label: l.name, value: l.id }));
+  const loopOptions = loops.map((l: any) => ({ label: l.name, value: l.id }));
+
+  const conflictColumns = [
+    { title: '环路名称', dataIndex: 'name', key: 'name' },
+    {
+      title: '解决策略',
+      dataIndex: 'action',
+      render: (_: any, record: any) => (
+        <RadioGroup
+          value={conflictResolutions[record.name] || 'rename'}
+          onChange={e => updateConflictResolution(record.name, e.target.value)}
+          size="small"
+        >
+          <RadioButton value="rename">重命名</RadioButton>
+          <RadioButton value="overwrite">覆盖</RadioButton>
+          <RadioButton value="skip">跳过</RadioButton>
+        </RadioGroup>
+      ),
+    },
+  ];
 
   return (
     <div style={{ maxWidth: 600 }}>
@@ -166,23 +204,21 @@ export function LoopBackupTab() {
             确认导入
           </Button>,
         ]}
-        width={600}
+        width={700}
       >
         {previewData && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
             <Alert
               message="即将导入以下内容"
               description={
-                <div>
-                  <Space direction="vertical" size="small">
-                    <Tag>环路: {previewData.summary.loops} 个</Tag>
-                    <Tag>步骤: {previewData.summary.steps} 个</Tag>
-                    <Tag>Todo模板: {previewData.summary.todos} 个</Tag>
-                    <Tag>评审模板: {previewData.summary.review_templates} 个</Tag>
-                    <Tag>标签: {previewData.summary.tags} 个</Tag>
-                    <Tag>触发器: {previewData.summary.triggers} 个</Tag>
-                  </Space>
-                </div>
+                <Space direction="vertical" size="small">
+                  <Tag>环路: {previewData.summary.loops} 个</Tag>
+                  <Tag>步骤: {previewData.summary.steps} 个</Tag>
+                  <Tag>Todo模板: {previewData.summary.todos} 个</Tag>
+                  <Tag>评审模板: {previewData.summary.review_templates} 个</Tag>
+                  <Tag>标签: {previewData.summary.tags} 个</Tag>
+                  <Tag>触发器: {previewData.summary.triggers} 个</Tag>
+                </Space>
               }
               type="info"
               showIcon
@@ -207,12 +243,52 @@ export function LoopBackupTab() {
               <Typography.Text strong>目标工作空间</Typography.Text>
               <Select
                 placeholder="选择工作空间"
-                options={workspaces.map(w => ({ label: w.name, value: w.id }))}
+                options={workspaces.map((w: any) => ({ label: w.name, value: w.id }))}
                 value={selectedWorkspaceId}
                 onChange={setSelectedWorkspaceId}
                 style={{ width: '100%', marginTop: 8 }}
               />
             </div>
+
+            <Divider style={{ margin: '12px 0' }} />
+
+            <div>
+              <Typography.Text strong>导入模式</Typography.Text>
+              <RadioGroup
+                value={importMode}
+                onChange={e => setImportMode(e.target.value)}
+                style={{ marginLeft: 12 }}
+              >
+                <RadioButton value="create">新建模式</RadioButton>
+                <RadioButton value="merge" disabled={!previewData.conflicts?.length}>
+                  合并模式
+                </RadioButton>
+              </RadioGroup>
+              <Typography.Paragraph type="secondary" style={{ marginTop: 4, marginBottom: 0 }}>
+                {importMode === 'create'
+                  ? '所有环路作为全新实体创建，同名自动追加 "-导入" 后缀'
+                  : '同名环路按下方策略处理'}
+              </Typography.Paragraph>
+            </div>
+
+            {importMode === 'merge' && previewData.conflicts && previewData.conflicts.length > 0 && (
+              <>
+                <Divider style={{ margin: '12px 0' }} />
+                <div>
+                  <Typography.Text strong>冲突解决策略</Typography.Text>
+                  <Typography.Paragraph type="secondary">
+                    检测到 {previewData.conflicts.length} 个同名环路，请选择处理方式
+                  </Typography.Paragraph>
+                  <Table
+                    size="small"
+                    dataSource={previewData.conflicts.map((c: any) => ({ key: c.name, ...c }))}
+                    columns={conflictColumns}
+                    pagination={false}
+                    style={{ marginTop: 8 }}
+                  />
+                </div>
+              </>
+            )}
           </div>
         )}
       </Modal>

--- a/frontend/src/utils/database/backup.ts
+++ b/frontend/src/utils/database/backup.ts
@@ -154,3 +154,50 @@ export async function deleteSkillBackupFile(filename: string): Promise<string> {
 export function downloadSkillBackupFileUrl(filename: string): string {
   return `/api/backup/skills/file?filename=${encodeURIComponent(filename)}`;
 }
+
+// Loop Import/Export APIs
+
+export interface LoopImportPreview {
+  valid: boolean;
+  pseudo_ids: string[];
+  summary: {
+    loops: number;
+    steps: number;
+    todos: number;
+    review_templates: number;
+    tags: number;
+    triggers: number;
+  };
+  conflicts: { type: string; name: string; action: string }[];
+  warnings: { type: string; message: string }[];
+}
+
+export async function previewLoopImport(yaml: string): Promise<LoopImportPreview> {
+  const response = await fetch('/api/loops/import/preview', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-yaml' },
+    body: yaml,
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({ message: response.statusText }));
+    throw new Error(err.message || `HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+export interface LoopImportResult {
+  success: boolean;
+  created: {
+    loops: number;
+    todos: number;
+    review_templates: number;
+    tags: number;
+    triggers: number;
+    steps: number;
+  };
+  warnings: { type: string; message: string }[];
+}
+
+export async function importLoops(yaml: string, workspace_id: number): Promise<LoopImportResult> {
+  return unwrap(await api.post('/api/loops/import', { yaml, workspace_id }));
+}

--- a/frontend/src/utils/database/backup.ts
+++ b/frontend/src/utils/database/backup.ts
@@ -201,3 +201,13 @@ export interface LoopImportResult {
 export async function importLoops(yaml: string, workspace_id: number): Promise<LoopImportResult> {
   return unwrap(await api.post('/api/loops/import', { yaml, workspace_id }));
 }
+
+export type ConflictAction = 'rename' | 'overwrite' | 'skip';
+
+export async function mergeLoops(
+  yaml: string,
+  workspace_id: number,
+  conflict_resolution: Record<string, ConflictAction>,
+): Promise<{ success: boolean; created: LoopImportResult['created']; updated: LoopImportResult['created']; skipped: string[]; warnings: { type: string; message: string }[] }> {
+  return unwrap(await api.post('/api/loops/merge', { yaml, workspace_id, conflict_resolution }));
+}

--- a/frontend/src/utils/database/loops.ts
+++ b/frontend/src/utils/database/loops.ts
@@ -224,3 +224,24 @@ export async function batchCopyLoopsWorkspace(
 ): Promise<{ updated_count: number; total: number }> {
   return unwrap(await api.post('/api/loops/batch-copy-workspace', { ids, workspace_id }));
 }
+
+
+// ====== Loop 导入导出 ======
+
+/** 导出单个环路为 YAML */
+export async function exportLoop(id: number): Promise<string> {
+  const response = await fetch(`/api/loops/${id}/export`);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return response.text();
+}
+
+/** 批量导出选中的环路 */
+export async function exportLoopsSelected(ids: number[]): Promise<string> {
+  const response = await fetch('/api/loops/export-selected', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/x-yaml' },
+    body: JSON.stringify({ loop_ids: ids }),
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return response.text();
+}


### PR DESCRIPTION
## 实现内容

### 环路导出
- 单个环路详情页导出按钮（LoopStudioDetailPanel）
- 环路列表页批量导出选中环路

### 环路导入
- 预览导入内容（环路数/步骤数/Todo模板/标签/触发器等）
- 冲突检测：同名环路提示
- 新建模式：所有环路作为全新实体创建，同名自动追加后缀

### 技术细节
- 后端：新增 `/api/loops/{id}/export`、`/api/loops/export-selected`、`/api/loops/import/preview`、`/api/loops/import` 路由
- 前端：`utils/database/loops.ts` 导出函数、`utils/database/backup.ts` 导入预览与执行

## 待后续完善
- 合并模式的 `conflictResolutions` 暂未接后端（UI 已就绪）

