### PR TITLE
fix(TodoPostPage): 手机端执行详情抽屉全屏显示

### DIFF
--- a/frontend/src/components/TodoPostPage.tsx
+++ b/frontend/src/components/TodoPostPage.tsx
@@ -602,12 +602,17 @@ function LogDrawer({
 
   const displayLogs = liveLogs && liveLogs.length > 0 ? liveLogs : paginatedLogs;
 
+  // 手机端使用从底部滑出的全屏抽屉；桌面端使用右侧 60% 宽度的抽屉
+  const isMobile = useIsMobile();
+
   return (
     <Drawer
       title={`执行详情 #${record?.id || ""}`}
       open={open}
       onClose={onClose}
-      width="60%"
+      placement={isMobile ? "bottom" : "right"}
+      height={isMobile ? "85vh" : undefined}
+      width={isMobile ? undefined : "60%"}
       styles={{ body: { padding: "12px 16px", display: "flex", flexDirection: "column" } }}
     >
       {/* 执行命令 —— 可折叠，默认收缩 */}


### PR DESCRIPTION
## 问题
手机端点击执行历史中的执行记录时，弹出的详情抽屉宽度按比例显示（60%），在窄屏上看起来非常窄，阅读体验差。

## 修复
- 手机端（`useIsMobile`）：使用 `placement="bottom"` + `height="85vh"` 从底部全屏滑出
- 桌面端：保持原有 `placement="right"` + `width="60%"` 行为

## 修改文件
- `frontend/src/components/TodoPostPage.tsx`：`LogDrawer` 组件添加响应式判断

## 测试
- [ ] 手机端访问 http://localhost:18088，点击执行记录，确认抽屉从底部全屏滑出
- [ ] 桌面端访问，确认行为不变
