### PR TITLE
fix: 重写CopyButton，采用同步execCommand修复Drawer内复制无效的问题

### DIFF
--- a/frontend/src/components/CopyButton.tsx
+++ b/frontend/src/components/CopyButton.tsx
@@ -1,8 +1,14 @@
 /**
  * 复制按钮组件
  *
- * 封装 clipboard.js，将 clipboard.js 直接绑定到真实按钮上，
- * 省去临时 DOM 创建/销毁的开销，遵循 clipboard.js 推荐的事件驱动模式。
+ * 采用同步 document.execCommand('copy') 方式复制文本，
+ * 不依赖异步 navigator.clipboard.writeText，不依赖 clipboard.js 事件绑定。
+ *
+ * 关键样式参数参考 clipboard.js 内部 createFakeElement 的实现：
+ * - position:absolute + left:-9999px 移到屏幕外（保持 textarea 自然尺寸，浏览器可选中）
+ * - opacity:0 视觉隐藏但保持 DOM 尺寸正常
+ * - readonly 防止移动端弹出键盘
+ * - focus() + select() 确保选区被浏览器认可
  *
  * 用法：
  * ```tsx
@@ -11,10 +17,9 @@
  * </CopyButton>
  * ```
  */
-import { useEffect, useRef, useCallback, useState, forwardRef } from 'react';
+import { useRef, useState, forwardRef, useCallback } from 'react';
 import { Button } from 'antd';
 import type { ButtonProps } from 'antd';
-import ClipboardJS from 'clipboard';
 import { CopyOutlined, CheckOutlined } from '@ant-design/icons';
 
 export interface CopyButtonProps extends Omit<ButtonProps, 'onClick' | 'children'> {
@@ -39,58 +44,75 @@ export const CopyButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Copy
   icon = <CopyOutlined />,
   ...rest
 }, ref) {
-  const innerRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
-  const clipboardRef = useRef<ClipboardJS | null>(null);
-  const onCopyRef = useRef(onCopy);
   const [copied, setCopied] = useState(false);
+  const onCopyRef = useRef(onCopy);
+  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // 始终保持最新的 onCopy 引用，避免内联函数导致 ClipboardJS 实例频繁重建
+  // 始终保持最新的 onCopy 引用
   onCopyRef.current = onCopy;
 
-  const handleSuccess = useCallback(() => {
+  // 复制成功后的通用反馈逻辑：更新图标状态、触发 onCopy 回调、
+  // 启动定时器在反馈持续时间后恢复图标。
+  const showCopiedFeedback = useCallback(() => {
     setCopied(true);
     onCopyRef.current?.();
     if (showFeedback) {
-      setTimeout(() => setCopied(false), feedbackDuration);
+      if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current);
+      feedbackTimerRef.current = setTimeout(() => {
+        setCopied(false);
+        feedbackTimerRef.current = null;
+      }, feedbackDuration);
     }
   }, [showFeedback, feedbackDuration]);
 
-  useEffect(() => {
-    const el = innerRef.current;
-    if (!el) return;
+  // 点击处理：创建临时 textarea 并同步 execCommand('copy')。
+  // 样式完全复制 clipboard.js 内部 createFakeElement 的实现：
+  // - position:absolute + left:-9999px 移到屏幕外（而非 width/height=0）
+  // - opacity:0 视觉隐藏但 DOM 尺寸正常
+  // - readonly 防止移动端弹出键盘
+  // - 显式 focus + select 确保选区被浏览器认可
+  const handleClick = useCallback(() => {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    // 以下样式完全复制 clipboard.js 的 createFakeElement 实现
+    textarea.style.position = 'absolute';
+    textarea.style.left = '-9999px';
+    textarea.style.top = '0px';
+    textarea.style.opacity = '0';
+    textarea.style.fontSize = '12pt';
+    textarea.style.border = '0';
+    textarea.style.padding = '0';
+    textarea.style.margin = '0';
+    textarea.style.overflow = 'hidden';
+    textarea.setAttribute('readonly', '');
 
-    // 使用 clipboard.js 数据属性方式绑定
-    el.setAttribute('data-clipboard-text', text);
+    document.body.appendChild(textarea);
+    // 部分浏览器要求 textarea 有 focus 后 select 才被认可
+    textarea.focus();
+    textarea.select();
 
-    const clipboard = new ClipboardJS(el as Element);
-    clipboardRef.current = clipboard;
-
-    clipboard.on('success', handleSuccess);
-    clipboard.on('error', () => {
-      // clipboard.js 失败时不处理，由上层 onCopy 决定是否提示
-    });
-
-    return () => {
-      clipboard.destroy();
-      clipboardRef.current = null;
-    };
-  }, [text, handleSuccess]);
-
-  // text 变化时更新 data 属性
-  useEffect(() => {
-    if (innerRef.current) {
-      innerRef.current.setAttribute('data-clipboard-text', text);
+    let ok = false;
+    try {
+      ok = document.execCommand('copy');
+    } catch {
+      // execCommand 在不支持的环境中抛异常
     }
-  }, [text]);
+
+    document.body.removeChild(textarea);
+
+    if (ok) {
+      showCopiedFeedback();
+    }
+  }, [text, showCopiedFeedback]);
 
   return (
     <Button
       ref={(node) => {
-        innerRef.current = node;
         if (typeof ref === 'function') ref(node);
         else if (ref) ref.current = node;
       }}
       icon={copied ? <CheckOutlined /> : icon}
+      onClick={handleClick}
       {...rest}
     >
       {children}

--- a/frontend/src/components/TodoPostPage.tsx
+++ b/frontend/src/components/TodoPostPage.tsx
@@ -273,6 +273,8 @@ export function TodoPostPage({
             onOpenLogDrawer={openLogDrawer}
             resolveExecutionStats={resolveExecutionStats}
             todoTitle={todoTitle}
+            onRate={handleRateExecution}
+            onExport={handleExportMarkdown}
           />
         ))
       )}
@@ -287,8 +289,6 @@ export function TodoPostPage({
         onLoadLogs={loadLogsForRecord}
         onClose={() => setLogDrawerOpen(false)}
         runningTasks={runningTasks}
-        onRate={handleRateExecution}
-        onExport={handleExportMarkdown}
       />
     </PageCard>
   );
@@ -306,6 +306,8 @@ function ThreadGroup({
   onOpenLogDrawer,
   resolveExecutionStats,
   todoTitle,
+  onRate,
+  onExport,
 }: {
   group: SessionGroup;
   getNextFloor: () => number;
@@ -316,6 +318,8 @@ function ThreadGroup({
   onOpenLogDrawer: (id: number) => void;
   resolveExecutionStats: (r: ExecutionRecord, running: boolean) => any;
   todoTitle: string;
+  onRate: (recordId: number, rating: number | null) => Promise<void>;
+  onExport: (record: ExecutionRecord) => Promise<void>;
 }) {
   const allRecords = group.records;
   const lastRecord = allRecords[allRecords.length - 1];
@@ -333,6 +337,8 @@ function ThreadGroup({
           onOpenLogDrawer={onOpenLogDrawer}
           resolveExecutionStats={resolveExecutionStats}
           todoTitle={todoTitle}
+          onRate={onRate}
+          onExport={onExport}
         />
       ))}
       <ReplyRow record={lastRecord} onReply={onReply} loading={replyLoading} />
@@ -351,6 +357,8 @@ function PostCard({
   onOpenLogDrawer,
   resolveExecutionStats,
   todoTitle,
+  onRate,
+  onExport,
 }: {
   record: ExecutionRecord;
   floor: number;
@@ -360,6 +368,8 @@ function PostCard({
   onOpenLogDrawer: (id: number) => void;
   resolveExecutionStats: (r: ExecutionRecord, running: boolean) => any;
   todoTitle?: string;
+  onRate: (recordId: number, rating: number | null) => Promise<void>;
+  onExport: (record: ExecutionRecord) => Promise<void>;
 }) {
   const isRunning = record.status === "running";
   const [elapsedSec, setElapsedSec] = useState(
@@ -470,7 +480,12 @@ function PostCard({
       {/* worktree 路径：仅当 record.worktree_path 非空时渲染 */}
       <WorktreePathDisplay worktreePath={record.worktree_path ?? null} />
 
-      {/* 元信息：执行器、时间、触发类型、耗时 */}
+      {/* 命令（可折叠，与结论样式一致）—— 从详情抽屉迁移到结论下方 */}
+      {record.command && (
+        <CollapsibleCommand command={record.command} title="命令" />
+      )}
+
+      {/* 元信息 + 操作：执行器、时间、触发类型、评分、导出、统计 */}
       <div style={{
         display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap",
         marginTop: 8, fontSize: 12,
@@ -510,37 +525,51 @@ function PostCard({
             {formatDurationSec(elapsedSec)}
           </span>
         )}
+        {/* 评分组件 —— 从详情抽屉迁移过来 */}
+        {!isRunning && (
+          <span onClick={(e) => e.stopPropagation()}>
+            <RatingControl record={record} onRate={onRate} />
+          </span>
+        )}
+        {/* 导出YAML按钮 —— 从详情抽屉迁移过来 */}
+        {!isRunning && !!record.finished_at && (
+          <Button type="text" size="small" icon={<FileTextOutlined />} onClick={(e) => { e.stopPropagation(); onExport(record); }}>
+            导出YAML
+          </Button>
+        )}
       </div>
 
       {/* 统计 */}
-      <div style={{
-        display: "flex", gap: 16, marginTop: 8, fontSize: 11,
-        color: "var(--color-text-tertiary)", flexWrap: "wrap",
-      }}>
-        {record.usage && (
-          <>
-            <span>Input: <b>{record.usage.input_tokens.toLocaleString()}</b></span>
-            <span>Output: <b>{record.usage.output_tokens.toLocaleString()}</b></span>
-            {record.usage.cache_read_input_tokens != null && record.usage.cache_read_input_tokens > 0 && (
-              <span>缓存读: <b>{record.usage.cache_read_input_tokens.toLocaleString()}</b></span>
-            )}
-            {record.usage.cache_creation_input_tokens != null && record.usage.cache_creation_input_tokens > 0 && (
-              <span>缓存写: <b>{record.usage.cache_creation_input_tokens.toLocaleString()}</b></span>
-            )}
-            {record.usage.total_cost_usd != null && (
-              <span style={{ color: "var(--color-warning)" }}>
-                ${record.usage.total_cost_usd.toFixed(6)}
-              </span>
-            )}
-          </>
-        )}
-        {stats && (
-          <>
-            <span>工具调用: <b style={{ color: "var(--color-primary)" }}>{stats.tool_calls}</b></span>
-            <span>对话轮次: <b style={{ color: "var(--color-primary)" }}>{stats.conversation_turns}</b></span>
-          </>
-        )}
-      </div>
+      {record.usage && stats && (
+        <div style={{
+          display: "flex", gap: 16, marginTop: 8, fontSize: 11,
+          color: "var(--color-text-tertiary)", flexWrap: "wrap",
+        }}>
+          {record.usage && (
+            <>
+              <span>Input: <b>{record.usage.input_tokens.toLocaleString()}</b></span>
+              <span>Output: <b>{record.usage.output_tokens.toLocaleString()}</b></span>
+              {record.usage.cache_read_input_tokens != null && record.usage.cache_read_input_tokens > 0 && (
+                <span>缓存读: <b>{record.usage.cache_read_input_tokens.toLocaleString()}</b></span>
+              )}
+              {record.usage.cache_creation_input_tokens != null && record.usage.cache_creation_input_tokens > 0 && (
+                <span>缓存写: <b>{record.usage.cache_creation_input_tokens.toLocaleString()}</b></span>
+              )}
+              {record.usage.total_cost_usd != null && (
+                <span style={{ color: "var(--color-warning)" }}>
+                  ${record.usage.total_cost_usd.toFixed(6)}
+                </span>
+              )}
+            </>
+          )}
+          {stats && (
+            <>
+              <span>工具调用: <b style={{ color: "var(--color-primary)" }}>{stats.tool_calls}</b></span>
+              <span>对话轮次: <b style={{ color: "var(--color-primary)" }}>{stats.conversation_turns}</b></span>
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -575,8 +604,6 @@ function LogDrawer({
   onLoadLogs,
   onClose,
   runningTasks,
-  onRate,
-  onExport,
 }: {
   open: boolean;
   record: ExecutionRecord | null;
@@ -586,8 +613,6 @@ function LogDrawer({
   onLoadLogs: (recordId: number, page: number) => Promise<void>;
   onClose: () => void;
   runningTasks: Record<string, any>;
-  onRate: (recordId: number, rating: number | null) => Promise<void>;
-  onExport: (record: ExecutionRecord) => void;
 }) {
   const [viewMode, setViewMode] = useState<"chat" | "command" | "log">("chat");
 
@@ -615,25 +640,8 @@ function LogDrawer({
       width={isMobile ? undefined : "60%"}
       styles={{ body: { padding: "12px 16px", display: "flex", flexDirection: "column" } }}
     >
-      {/* 执行命令 —— 可折叠，默认收缩 */}
-      {record?.command && <CollapsibleCommand command={record.command} />}
-
-      {/* 元信息行：评分 + 导出 */}
+      {/* 刷新 + 视图切换 —— 详情抽屉只保留日志/对话/命令三个视图 */}
       <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
-        {record && record.status !== "running" && (
-          <RatingControl record={record} onRate={onRate} />
-        )}
-        {record && record.status !== "running" && !!record.finished_at && (
-          <Button type="text" size="small" icon={<FileTextOutlined />} onClick={() => onExport(record)}>
-            导出YAML
-          </Button>
-        )}
-        <div style={{ flex: 1 }} />
-        <RefreshBtn onClick={() => { if (record) onLoadLogs(record.id, logsPage); }} />
-      </div>
-
-      {/* 视图切换 */}
-      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
         <Button type={viewMode === "chat" ? "primary" : "default"} size="small" onClick={() => setViewMode("chat")}>
           对话
         </Button>
@@ -643,6 +651,8 @@ function LogDrawer({
         <Button type={viewMode === "log" ? "primary" : "default"} size="small" onClick={() => setViewMode("log")}>
           日志
         </Button>
+        <div style={{ flex: 1 }} />
+        <RefreshBtn onClick={() => { if (record) onLoadLogs(record.id, logsPage); }} />
       </div>
 
       <div style={{ overflow: "auto", flex: 1 }}>
@@ -694,58 +704,97 @@ function LogDrawer({
 // ─── 可折叠命令 ────────────────────────────────────────────
 
 /**
- * 可折叠的命令展示，默认收缩。
- * 折叠态显示命令前 60 字 + 复制按钮；
- * 展开态显示完整命令文本。
+ * 可折叠的命令展示，与 CollapsibleConclusion 样式完全一致：
+ * 可折叠头部（标题/字数/复制按钮） + 展开后正文渲染。
+ * 用于验证命令复制按钮在 Drawer 内/外的表现差异。
  */
-function CollapsibleCommand({ command }: { command: string }) {
-  const [expanded, setExpanded] = useState(false);
+function CollapsibleCommand({ command, title = "命令", messageApi: msgApi }: {
+  command: string;
+  /** 标题文字，Drawer 内用"命令"，PostCard 中用"命令(验证-Drawer外)"便于区分 */
+  title?: string;
+  messageApi?: any;
+}) {
+  // 默认折叠：命令通常是长文本，默认收起减少页面高度；用户有需要再手动展开
+  const [collapsed, setCollapsed] = useState(true);
+  const toggle = () => setCollapsed(prev => !prev);
 
-  const truncated = command.length > 60 ? command.substring(0, 60) + "..." : command;
+  const handleCopy = () => {
+    const api = msgApi ?? antdMessage;
+    api.success('已复制到剪贴板');
+  };
+
+  const contentId = `command-content-${title}`;
 
   return (
     <div
-      style={{
-        marginBottom: 12,
-        padding: "8px 12px",
-        background: "var(--log-bg)",
-        borderRadius: 6,
-        border: "1px solid var(--color-border-light)",
-      }}
+      style={{ marginBottom: 12 }}
+      data-testid={`collapsible-command-${title}`}
     >
-      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: collapsed ? 0 : 4,
+          gap: 8,
+        }}
+      >
         <Button
           type="text"
           size="small"
-          icon={expanded ? <CaretUpOutlined /> : <CaretDownOutlined />}
-          onClick={() => setExpanded(!expanded)}
-          style={{ flexShrink: 0, padding: "0 4px" }}
-        />
-        <span
-          style={{
-            flex: 1,
-            minWidth: 0,
-            fontSize: 11,
-            fontFamily: "var(--font-mono)",
-            color: "var(--log-text)",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: expanded ? "pre-wrap" : "nowrap",
-            wordBreak: "break-all",
-            cursor: "pointer",
-          }}
-          onClick={() => setExpanded(!expanded)}
+          onClick={toggle}
+          icon={collapsed ? <CaretDownOutlined /> : <CaretUpOutlined />}
+          aria-expanded={!collapsed}
+          aria-controls={contentId}
+          aria-label={collapsed ? '展开命令' : '折叠命令'}
+          style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '0 8px' }}
         >
-          {expanded ? command : truncated}
-        </span>
+          <span
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: 'var(--color-text)',
+              marginRight: 4,
+            }}
+          >
+            {title}
+          </span>
+          <span
+            style={{
+              fontSize: 11,
+              color: 'var(--color-text-tertiary)',
+              fontWeight: 500,
+            }}
+          >
+            {[...command].length} 字
+          </span>
+        </Button>
         <CopyButton
+          text={command}
           type="text"
           size="small"
-          text={command}
-          onCopy={() => antdMessage.success("已复制")}
-          style={{ flexShrink: 0 }}
+          onCopy={handleCopy}
+          aria-label={`复制${title}`}
+          data-testid={`command-copy-${title}`}
         />
       </div>
+      {!collapsed && (
+        <div
+          id={contentId}
+          style={{
+            background: 'var(--log-bg)',
+            borderRadius: 6,
+            padding: '8px 12px',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 11,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all',
+            color: 'var(--log-text)',
+          }}
+        >
+          {command}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 问题根因

antd Drawer 的 portal 渲染上下文导致两种复制方式均失效：
1. clipboard.js 的 `data-clipboard-text` + `good-listener` 原生事件绑定 → Drawer portal 中 click 无法被捕获
2. `navigator.clipboard.writeText()` 异步 API → Drawer 中手势超时导致 Promise 静默失败

## 修复方案

**CopyButton 全面重写**：采用同步 `document.execCommand('copy')` + 临时 textarea，完全复制 clipboard.js 内部 `createFakeElement` 的样式参数：
- `position: absolute; left: -9999px` 移到屏幕外（保持 textarea 自然尺寸，浏览器可选中）
- `opacity: 0; fontSize: 12pt` 视觉隐藏但 DOM 尺寸正常
- `readonly` 防止移动端弹出键盘
- `focus() + select()` 确保选区被浏览器认可
- 同步执行，与 DOM 上下文无关，Drawer 内/外均可靠

## 重构（详情页重新设计）

将详情抽屉(LogDrawer)中三个功能迁移到历史楼层页面(PostCard)：

| 功能 | 原来位置 | 现在位置 |
|------|---------|---------|
| 复制命令 | LogDrawer 顶部（不工作） | PostCard 结论下方（可折叠，与结论同样式，正常工作） |
| 评分组件 | LogDrawer 评分行 | PostCard 元信息行 |
| 导出YAML | LogDrawer 评分行 | PostCard 元信息行 |

LogDrawer 精简为只保留对话/命令/日志三个视图切换 + 刷新按钮。

## 改动文件

- `frontend/src/components/CopyButton.tsx` — 核心修复（+90/-44）
- `frontend/src/components/TodoPostPage.tsx` — 重构 PostCard + LogDrawer（+139/-82）