### PR TITLE
feat(skills): Skills 卡片视图

### DIFF
--- a/frontend/src/components/skills/SkillCardView.css
+++ b/frontend/src/components/skills/SkillCardView.css
@@ -1,0 +1,205 @@
+/* SkillCardView 样式 */
+
+/* 卡片容器 */
+.skill-card-view {
+  --skill-card-radius: 16px;
+  --skill-card-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --skill-card-shadow-hover: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+/* 卡片网格 */
+.skill-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+/* 响应式断点：平板（2列） */
+@media (max-width: 1024px) {
+  .skill-card-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* 响应式断点：手机（1列） */
+@media (max-width: 640px) {
+  .skill-card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* 单个卡片样式 */
+.skill-card-item {
+  background: var(--color-bg-card, #ffffff);
+  border-radius: var(--skill-card-radius);
+  border: 1px solid var(--color-border, #e2e8f0);
+  padding: 20px;
+  cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: var(--skill-card-shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+/* 卡片 hover 效果 */
+.skill-card-item:hover {
+  box-shadow: var(--skill-card-shadow-hover);
+  transform: translateY(-2px);
+}
+
+/* 头像容器 */
+.skill-card-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 20px;
+  font-weight: 700;
+  margin-bottom: 14px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+/* 卡片标题 */
+.skill-card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text, #0f172a);
+  margin-bottom: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* 卡片描述 */
+.skill-card-description {
+  font-size: 12px;
+  color: var(--color-text-secondary, #64748b);
+  line-height: 1.6;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 38px;
+  margin-bottom: 12px;
+}
+
+/* 标签区域 */
+.skill-card-tags {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+
+/* 执行器区域 */
+.skill-card-executors {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border, #e2e8f0);
+}
+
+/* 执行器方块 */
+.executor-block {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 600;
+  transition: all 0.2s;
+  cursor: default;
+  flex-shrink: 0;
+}
+
+.executor-block--installed {
+  color: #fff;
+}
+
+.executor-block--not-installed {
+  border: 1px dashed;
+  opacity: 0.4;
+}
+
+/* 分类标签云 */
+.skill-category-cloud {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* 分类标签按钮 */
+.skill-category-btn {
+  padding: 4px 12px;
+  border-radius: 16px;
+  border: 1px solid var(--color-border, #e2e8f0);
+  background: transparent;
+  color: var(--color-text-secondary, #64748b);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.skill-category-btn:hover {
+  border-color: #0891b2;
+  color: #0891b2;
+}
+
+.skill-category-btn--active {
+  border-color: #0891b2;
+  background: rgba(8, 145, 178, 0.1);
+  color: #0891b2;
+}
+
+/* 搜索框 */
+.skill-search-input {
+  border-radius: 20px;
+}
+
+/* 空状态 */
+.skill-empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--color-text-secondary, #64748b);
+}
+
+.skill-empty-state-icon {
+  font-size: 48px;
+  margin-bottom: 16px;
+  opacity: 0.3;
+}
+
+/* 暗色主题适配 */
+[data-theme="dark"] .skill-card-item {
+  background: var(--color-bg-card, #1e293b);
+  border-color: var(--color-border, #334155);
+}
+
+[data-theme="dark"] .skill-card-title {
+  color: var(--color-text, #f1f5f9);
+}
+
+[data-theme="dark"] .skill-card-description {
+  color: var(--color-text-secondary, #94a3b8);
+}
+
+[data-theme="dark"] .skill-category-btn {
+  border-color: var(--color-border, #334155);
+  color: var(--color-text-secondary, #94a3b8);
+}
+
+[data-theme="dark"] .skill-category-btn:hover,
+[data-theme="dark"] .skill-category-btn--active {
+  border-color: #22d3ee;
+  color: #22d3ee;
+  background: rgba(34, 211, 238, 0.1);
+}

--- a/frontend/src/components/skills/SkillCardView.tsx
+++ b/frontend/src/components/skills/SkillCardView.tsx
@@ -1,0 +1,314 @@
+import { useMemo, useState } from 'react';
+import { Tag, Tooltip } from 'antd';
+import { AppstoreOutlined } from '@ant-design/icons';
+import { EXECUTORS } from '@/types';
+import type { SkillMeta, ExecutorSkills } from '@/types';
+import { EXECUTOR_COLORS, splitSkillName, formatSize } from './helpers';
+import './SkillCardView.css';
+
+interface SkillCardViewProps {
+  data: ExecutorSkills[];
+  searchText: string;
+  onSkillClick: (skill: SkillMeta, executor: string) => void;
+}
+
+// 执行器固定顺序（与 EXECUTORS 保持一致，但只取有 skills_dir 的执行器）
+const EXECUTOR_ORDER = [
+  'claudecode', 'codebuddy', 'opencode', 'mobilecoder', 'atomcode',
+  'hermes', 'kimi', 'codex', 'pi', 'mimo', 'zhanlu', 'agents',
+];
+
+// 渐变背景色生成器，基于 skill 名称 hash
+function generateGradient(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
+  }
+  const h1 = Math.abs(hash) % 360;
+  const h2 = (h1 + 40) % 360;
+  return `linear-gradient(135deg, hsl(${h1}, 70%, 60%), hsl(${h2}, 60%, 50%))`;
+}
+
+// 执行器方块组件
+function ExecutorBlock({ executor, installed }: { executor: string; installed: boolean }) {
+  const color = EXECUTOR_COLORS[executor] || '#64748b';
+  const label = EXECUTORS.find(e => e.value === executor)?.label || executor;
+
+  return (
+    <Tooltip title={`${label}${installed ? ' ✓' : ' 未安装'}`} placement="bottom">
+      <div
+        style={{
+          width: 20,
+          height: 20,
+          borderRadius: 4,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 10,
+          fontWeight: 600,
+          color: installed ? '#fff' : color,
+          background: installed ? color : 'transparent',
+          border: installed ? 'none' : `1px dashed ${color}80`,
+          opacity: installed ? 1 : 0.4,
+          transition: 'all 0.2s',
+          cursor: 'default',
+          flexShrink: 0,
+        }}
+      >
+        {label.charAt(0).toUpperCase()}
+      </div>
+    </Tooltip>
+  );
+}
+
+// 单个 Skill 卡片
+function SkillCard({ skill, executors, onClick }: {
+  skill: SkillMeta;
+  executors: { name: string; installed: boolean }[];
+  onClick: () => void;
+}) {
+  const { category, shortName } = splitSkillName(skill.name);
+  const gradient = generateGradient(skill.name);
+
+  // 计算已安装的执行器数量
+  const installedCount = executors.filter(e => e.installed).length;
+
+  return (
+    <div
+      onClick={onClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      className="skill-card-item"
+    >
+      {/* 头像区域：渐变背景 + 首字母 */}
+      <div
+        className="skill-card-avatar"
+        style={{
+          background: gradient,
+          boxShadow: `0 4px 12px ${gradient.includes('hsl') ? 'rgba(0,0,0,0.15)' : gradient}`,
+        }}
+      >
+        {shortName.charAt(0).toUpperCase()}
+      </div>
+
+      {/* 名称 */}
+      <div className="skill-card-title">
+        {shortName}
+      </div>
+
+      {/* 描述 */}
+      {skill.description && (
+        <div className="skill-card-description">
+          {skill.description}
+        </div>
+      )}
+
+      {/* 标签区域：category + version + 文件大小 */}
+      <div className="skill-card-tags">
+        {category && (
+          <Tag style={{
+            margin: 0,
+            fontSize: 11,
+            lineHeight: '18px',
+            padding: '0 6px',
+            borderRadius: 6,
+            background: 'var(--color-fill, #f1f5f9)',
+            border: 'none',
+            color: 'var(--color-text-secondary, #64748b)',
+          }}>
+            {category}
+          </Tag>
+        )}
+        {skill.version && (
+          <Tag style={{
+            margin: 0,
+            fontSize: 11,
+            lineHeight: '18px',
+            padding: '0 6px',
+            borderRadius: 6,
+            background: 'rgba(8, 145, 178, 0.1)',
+            border: 'none',
+            color: '#0891b2',
+          }}>
+            v{skill.version}
+          </Tag>
+        )}
+        <span style={{
+          marginLeft: 'auto',
+          fontSize: 11,
+          color: 'var(--color-text-quaternary, #94a3b8)',
+        }}>
+          {formatSize(skill.total_size)}
+        </span>
+      </div>
+
+      {/* 执行器方块区域 */}
+      <div className="skill-card-executors">
+        <div style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 4,
+          flexWrap: 'wrap',
+        }}>
+          {executors.map(({ name, installed }) => (
+            <ExecutorBlock
+              key={name}
+              executor={name}
+              installed={installed}
+            />
+          ))}
+        </div>
+        <span style={{
+          fontSize: 11,
+          color: 'var(--color-text-tertiary, #94a3b8)',
+        }}>
+          {installedCount}/{executors.length}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// 卡片视图主组件
+export function SkillCardView({ data, searchText, onSkillClick }: SkillCardViewProps) {
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+
+  // 提取所有唯一的 category
+  const allCategories = useMemo(() => {
+    const categories = new Set<string>();
+    data.forEach(e => {
+      e.skills.forEach(s => {
+        const { category } = splitSkillName(s.name);
+        if (category) categories.add(category);
+      });
+    });
+    return Array.from(categories).sort();
+  }, [data]);
+
+  // 从 data 中提取实际存在的执行器列表（按固定顺序）
+  const activeExecutors = useMemo(() => {
+    const executorSet = new Set(data.map(e => e.executor));
+    return EXECUTOR_ORDER.filter(name => executorSet.has(name));
+  }, [data]);
+
+  // 去重后的 skill 列表，每个 skill 包含所有执行器的安装状态
+  const dedupedSkills = useMemo(() => {
+    // 按 skill name 去重，收集每个 skill 在哪些执行器上安装了
+    const skillMap = new Map<string, {
+      skill: SkillMeta;
+      installedExecutors: Set<string>;
+    }>();
+
+    data.forEach(executor => {
+      executor.skills.forEach(skill => {
+        const existing = skillMap.get(skill.name);
+        if (existing) {
+          existing.installedExecutors.add(executor.executor);
+        } else {
+          skillMap.set(skill.name, {
+            skill,
+            installedExecutors: new Set([executor.executor]),
+          });
+        }
+      });
+    });
+
+    return skillMap;
+  }, [data]);
+
+  // 过滤 + 按固定顺序补全执行器状态
+  const filteredSkills = useMemo(() => {
+    let entries = Array.from(dedupedSkills.entries());
+
+    // 按搜索文本过滤
+    if (searchText) {
+      const lower = searchText.toLowerCase();
+      entries = entries.filter(([_, { skill }]) =>
+        skill.name.toLowerCase().includes(lower) ||
+        skill.description?.toLowerCase().includes(lower) ||
+        skill.keywords?.some(k => k.toLowerCase().includes(lower))
+      );
+    }
+
+    // 按 category 过滤
+    if (selectedCategories.length > 0) {
+      entries = entries.filter(([_, { skill }]) => {
+        const { category } = splitSkillName(skill.name);
+        return selectedCategories.includes(category || '未分类');
+      });
+    }
+
+    // 为每个 skill 构建固定顺序的执行器列表
+    return entries.map(([_, { skill, installedExecutors }]) => {
+      const executors = activeExecutors.map(name => ({
+        name,
+        installed: installedExecutors.has(name),
+      }));
+      return { skill, executors };
+    });
+  }, [dedupedSkills, searchText, selectedCategories, activeExecutors]);
+
+  // 切换 category 选择
+  const toggleCategory = (category: string) => {
+    setSelectedCategories(prev =>
+      prev.includes(category)
+        ? prev.filter(c => c !== category)
+        : [...prev, category]
+    );
+  };
+
+  return (
+    <div className="skill-card-view">
+      {/* 标签云筛选 */}
+      {allCategories.length > 0 && (
+        <div className="skill-category-cloud" style={{ marginBottom: 16 }}>
+          <span style={{
+            fontSize: 12,
+            color: 'var(--color-text-tertiary, #94a3b8)',
+            flexShrink: 0,
+          }}>
+            分类:
+          </span>
+          {allCategories.map(category => {
+            const isSelected = selectedCategories.includes(category);
+            return (
+              <button
+                key={category}
+                onClick={() => toggleCategory(category)}
+                className={`skill-category-btn ${isSelected ? 'skill-category-btn--active' : ''}`}
+              >
+                {category}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* 卡片网格 */}
+      {filteredSkills.length === 0 ? (
+        <div className="skill-empty-state">
+          <AppstoreOutlined className="skill-empty-state-icon" />
+          <div style={{ fontSize: 16 }}>{searchText ? '无匹配结果' : '暂无 Skills'}</div>
+        </div>
+      ) : (
+        <div className="skill-card-grid">
+          {filteredSkills.map(({ skill, executors }) => (
+            <SkillCard
+              key={skill.name}
+              skill={skill}
+              executors={executors}
+              onClick={() => onSkillClick(skill, executors.find(e => e.installed)?.name || data[0]?.executor || '')}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/skills/SkillsOverview.tsx
+++ b/frontend/src/components/skills/SkillsOverview.tsx
@@ -5,6 +5,7 @@ import {
   ThunderboltOutlined, SearchOutlined,
   DownloadOutlined, ExportOutlined, ImportOutlined,
   AppstoreOutlined, FileTextOutlined,
+  UnorderedListOutlined, AppstoreOutlined as AppstoreOutlinedIcon,
 } from '@ant-design/icons';
 import { EXECUTORS } from '@/types';
 import type { SkillMeta, ExecutorSkills } from '@/types';
@@ -12,6 +13,7 @@ import * as db from '@/utils/database';
 import { EXECUTOR_COLORS, formatSize, splitSkillName } from './helpers';
 import { SkillDetailDrawer } from './SkillDetailDrawer';
 import { ImportExportModal } from './ImportExportModal';
+import { SkillCardView } from './SkillCardView';
 
 export function SkillsOverview() {
   const [loading, setLoading] = useState(true);
@@ -24,6 +26,7 @@ export function SkillsOverview() {
   const [exportModalOpen, setExportModalOpen] = useState(false);
   const [exportMode, setExportMode] = useState<'import' | 'export'>('export');
   const [initialSelectedSkills, setInitialSelectedSkills] = useState<string[] | undefined>(undefined);
+  const [viewMode, setViewMode] = useState<'list' | 'card'>('card');
 
   const loadData = () => {
     setLoading(true);
@@ -218,7 +221,7 @@ export function SkillsOverview() {
         </Card>
       </div>
 
-      {/* Filter & Search bar */}
+      {/* Search & Action bar - 始终显示 */}
       <div style={{
         display: 'flex',
         alignItems: 'center',
@@ -227,7 +230,76 @@ export function SkillsOverview() {
         gap: 12,
         flexWrap: 'wrap',
       }}>
-        {/* Executor filter pills */}
+        <Input
+          placeholder="搜索 Skills..."
+          prefix={<SearchOutlined style={{ color: 'var(--color-text-quaternary, #94a3b8)' }} />}
+          value={searchText}
+          onChange={e => setSearchText(e.target.value)}
+          style={{ width: 200, borderRadius: 20 }}
+          allowClear
+        />
+
+        <Space size={8}>
+          {/* 视图切换按钮 */}
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            border: '1px solid var(--color-border, #e2e8f0)',
+            borderRadius: 8,
+            overflow: 'hidden',
+          }}>
+            <button
+              onClick={() => setViewMode('list')}
+              title="列表视图"
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 32,
+                height: 32,
+                border: 'none',
+                background: viewMode === 'list' ? 'var(--color-fill, #e2e8f0)' : 'transparent',
+                color: viewMode === 'list' ? 'var(--color-text, #0f172a)' : 'var(--color-text-tertiary, #94a3b8)',
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+              }}
+            >
+              <UnorderedListOutlined />
+            </button>
+            <button
+              onClick={() => setViewMode('card')}
+              title="卡片视图"
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 32,
+                height: 32,
+                border: 'none',
+                borderLeft: '1px solid var(--color-border, #e2e8f0)',
+                background: viewMode === 'card' ? 'var(--color-fill, #e2e8f0)' : 'transparent',
+                color: viewMode === 'card' ? 'var(--color-text, #0f172a)' : 'var(--color-text-tertiary, #94a3b8)',
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+              }}
+            >
+              <AppstoreOutlinedIcon />
+            </button>
+          </div>
+          <Dropdown menu={{ items: exportMenuItems, onClick: handleExportMenuClick }} trigger={['click']}>
+            <Button
+              type="primary"
+              icon={<DownloadOutlined />}
+              style={{ borderRadius: 20 }}
+            >
+              导入/导出
+            </Button>
+          </Dropdown>
+        </Space>
+      </div>
+
+      {/* Executor filter pills - 仅列表模式显示 */}
+      {viewMode === 'list' && (
         <div
           role="tablist"
           aria-label="按执行器筛选"
@@ -235,7 +307,7 @@ export function SkillsOverview() {
             display: 'flex',
             gap: 6,
             flexWrap: 'wrap',
-            flex: 1,
+            marginBottom: 16,
           }}
         >
           {executorTabs.map(tab => {
@@ -283,53 +355,43 @@ export function SkillsOverview() {
             );
           })}
         </div>
+      )}
 
-        <Space size={8}>
-          <Input
-            placeholder="搜索 Skills..."
-            prefix={<SearchOutlined style={{ color: 'var(--color-text-quaternary, #94a3b8)' }} />}
-            value={searchText}
-            onChange={e => setSearchText(e.target.value)}
-            style={{ width: 200, borderRadius: 20 }}
-            allowClear
-          />
-          <Dropdown menu={{ items: exportMenuItems, onClick: handleExportMenuClick }} trigger={['click']}>
-            <Button
-              type="primary"
-              icon={<DownloadOutlined />}
-              style={{ borderRadius: 20 }}
-            >
-              导入/导出
-            </Button>
-          </Dropdown>
-        </Space>
-      </div>
-
-      {/* Skill card grid */}
-      {filteredSkills.length === 0 ? (
-        <div style={{
-          textAlign: 'center',
-          padding: '60px 20px',
-          color: 'var(--color-text-secondary, #475569)',
-        }}>
-          <AppstoreOutlined style={{ fontSize: 48, marginBottom: 16, opacity: 0.3 }} />
-          <div style={{ fontSize: 16 }}>{searchText ? '无匹配结果' : '暂无 Skills'}</div>
-        </div>
+      {/* Skill content - 根据视图模式切换 */}
+      {viewMode === 'card' ? (
+        // 卡片视图：使用新的 SkillCardView 组件（搜索由父组件提供）
+        <SkillCardView
+          data={data}
+          searchText={searchText}
+          onSkillClick={handleSkillClick}
+        />
       ) : (
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
-          gap: 12,
-        }}>
-          {filteredSkills.map(({ skill, executor }) => (
-            <SkillCard
-              key={`${executor}-${skill.name}`}
-              skill={skill}
-              executor={executor}
-              onClick={() => handleSkillClick(skill, executor)}
-            />
-          ))}
-        </div>
+        // 列表视图：保持原有的网格布局
+        filteredSkills.length === 0 ? (
+          <div style={{
+            textAlign: 'center',
+            padding: '60px 20px',
+            color: 'var(--color-text-secondary, #475569)',
+          }}>
+            <AppstoreOutlined style={{ fontSize: 48, marginBottom: 16, opacity: 0.3 }} />
+            <div style={{ fontSize: 16 }}>{searchText ? '无匹配结果' : '暂无 Skills'}</div>
+          </div>
+        ) : (
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+            gap: 12,
+          }}>
+            {filteredSkills.map(({ skill, executor }) => (
+              <SkillCard
+                key={`${executor}-${skill.name}`}
+                skill={skill}
+                executor={executor}
+                onClick={() => handleSkillClick(skill, executor)}
+              />
+            ))}
+          </div>
+        )
       )}
 
       <SkillDetailDrawer

--- a/frontend/src/components/skills/SkillsOverview.tsx
+++ b/frontend/src/components/skills/SkillsOverview.tsx
@@ -58,7 +58,8 @@ export function SkillsOverview() {
     const totalSkills = data.reduce((sum, e) => sum + e.skills.length, 0);
     const totalFiles = data.reduce((sum, e) => sum + e.skills.reduce((s, sk) => s + sk.file_count, 0), 0);
     const executorsWithSkills = data.filter(e => e.skills.length > 0).length;
-    return { totalSkills, totalFiles, executorsWithSkills };
+    // 分母用前端定义的执行器总数，而非 API 返回的数量（API 只返回有 skills 目录的）
+    return { totalSkills, totalFiles, executorsWithSkills, totalExecutors: EXECUTORS.length };
   }, [data]);
 
   // All skills flattened (filtered by executor, but not by search)
@@ -189,7 +190,7 @@ export function SkillsOverview() {
               <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #475569)' }}>执行器</div>
               <div style={{ fontSize: 20, fontWeight: 600, lineHeight: 1.2, color: 'var(--color-text, #0f172a)' }}>
                 {stats.executorsWithSkills}
-                <span style={{ fontSize: 13, fontWeight: 400, marginLeft: 2 }}>/ {data.length}</span>
+                <span style={{ fontSize: 13, fontWeight: 400, marginLeft: 2 }}>/ {stats.totalExecutors}</span>
               </div>
             </div>
           </div>

--- a/frontend/src/components/skills/SkillsOverview.tsx
+++ b/frontend/src/components/skills/SkillsOverview.tsx
@@ -99,7 +99,7 @@ export function SkillsOverview() {
       ).length;
     };
 
-    const tabs = [{ key: 'all', label: '全部', count: matchSearch(allSkills.map(s => s.skill)) }];
+    const tabs = [{ key: 'all', label: '全部', count: -1 }];
     data.forEach(e => {
       const label = EXECUTORS.find(x => x.value === e.executor)?.label || e.executor;
       tabs.push({ key: e.executor, label, count: matchSearch(e.skills) });
@@ -334,21 +334,23 @@ export function SkillsOverview() {
                 }}
               >
                 {tab.label}
-                <span style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  minWidth: 18,
-                  height: 18,
-                  borderRadius: 9,
-                  background: isActive ? color : 'var(--color-fill, #e2e8f0)',
-                  color: isActive ? '#fff' : 'var(--color-text-secondary, #475569)',
-                  fontSize: 11,
-                  lineHeight: 1,
-                  padding: '0 4px',
-                }}>
-                  {tab.count}
-                </span>
+                {tab.count >= 0 && (
+                  <span style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    minWidth: 18,
+                    height: 18,
+                    borderRadius: 9,
+                    background: isActive ? color : 'var(--color-fill, #e2e8f0)',
+                    color: isActive ? '#fff' : 'var(--color-text-secondary, #475569)',
+                    fontSize: 11,
+                    lineHeight: 1,
+                    padding: '0 4px',
+                  }}>
+                    {tab.count}
+                  </span>
+                )}
               </button>
             );
           })}

--- a/frontend/src/components/skills/SkillsOverview.tsx
+++ b/frontend/src/components/skills/SkillsOverview.tsx
@@ -86,9 +86,10 @@ export function SkillsOverview() {
     );
   }, [allSkills, searchText]);
 
-  // Executor filter tabs with counts synced to search
+  // Executor filter tabs — counts reflect each executor's own skill total,
+  // only narrowed by search text; never zeroed out by executor filter selection.
   const executorTabs = useMemo(() => {
-    const filterMatch = (skills: SkillMeta[]) => {
+    const matchSearch = (skills: SkillMeta[]) => {
       if (!searchText) return skills.length;
       const lower = searchText.toLowerCase();
       return skills.filter(s =>
@@ -98,16 +99,13 @@ export function SkillsOverview() {
       ).length;
     };
 
-    const tabs = [{ key: 'all', label: '全部', count: filterMatch(allSkills.map(s => s.skill)) }];
+    const tabs = [{ key: 'all', label: '全部', count: matchSearch(allSkills.map(s => s.skill)) }];
     data.forEach(e => {
       const label = EXECUTORS.find(x => x.value === e.executor)?.label || e.executor;
-      const count = filterExecutor === 'all' || filterExecutor === e.executor
-        ? filterMatch(e.skills)
-        : 0;
-      tabs.push({ key: e.executor, label, count });
+      tabs.push({ key: e.executor, label, count: matchSearch(e.skills) });
     });
     return tabs;
-  }, [data, filterExecutor, searchText, allSkills]);
+  }, [data, searchText, allSkills]);
 
   const exportMenuItems: MenuProps['items'] = [
     { key: 'export', icon: <ExportOutlined />, label: '导出选中' },

--- a/frontend/src/components/skills/SkillsOverview.tsx
+++ b/frontend/src/components/skills/SkillsOverview.tsx
@@ -247,24 +247,6 @@ export function SkillsOverview() {
             overflow: 'hidden',
           }}>
             <button
-              onClick={() => setViewMode('list')}
-              title="列表视图"
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                width: 32,
-                height: 32,
-                border: 'none',
-                background: viewMode === 'list' ? 'var(--color-fill, #e2e8f0)' : 'transparent',
-                color: viewMode === 'list' ? 'var(--color-text, #0f172a)' : 'var(--color-text-tertiary, #94a3b8)',
-                cursor: 'pointer',
-                transition: 'all 0.2s',
-              }}
-            >
-              <UnorderedListOutlined />
-            </button>
-            <button
               onClick={() => setViewMode('card')}
               title="卡片视图"
               style={{
@@ -274,7 +256,6 @@ export function SkillsOverview() {
                 width: 32,
                 height: 32,
                 border: 'none',
-                borderLeft: '1px solid var(--color-border, #e2e8f0)',
                 background: viewMode === 'card' ? 'var(--color-fill, #e2e8f0)' : 'transparent',
                 color: viewMode === 'card' ? 'var(--color-text, #0f172a)' : 'var(--color-text-tertiary, #94a3b8)',
                 cursor: 'pointer',
@@ -282,6 +263,25 @@ export function SkillsOverview() {
               }}
             >
               <AppstoreOutlinedIcon />
+            </button>
+            <button
+              onClick={() => setViewMode('list')}
+              title="列表视图"
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 32,
+                height: 32,
+                border: 'none',
+                borderLeft: '1px solid var(--color-border, #e2e8f0)',
+                background: viewMode === 'list' ? 'var(--color-fill, #e2e8f0)' : 'transparent',
+                color: viewMode === 'list' ? 'var(--color-text, #0f172a)' : 'var(--color-text-tertiary, #94a3b8)',
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+              }}
+            >
+              <UnorderedListOutlined />
             </button>
           </div>
           <Dropdown menu={{ items: exportMenuItems, onClick: handleExportMenuClick }} trigger={['click']}>


### PR DESCRIPTION
## Summary
- 新增 SkillCardView 卡片视图组件，响应式网格布局（桌面 3 列，平板 2 列，手机 1 列）
- 渐变背景头像基于 skill name hash 自动生成，每个卡片有独特辨识度
- 执行器方块按固定顺序显示，已安装彩色高亮，未安装灰色虚线边框
- 分类标签云筛选，支持多选过滤
- 列表/卡片视图切换，卡片视图作为默认视图

## Changes
- `frontend/src/components/skills/SkillCardView.tsx` — 新增卡片视图组件
- `frontend/src/components/skills/SkillCardView.css` — 卡片视图样式（含响应式断点、暗色主题适配）
- `frontend/src/components/skills/SkillsOverview.tsx` — 集成视图切换、修复执行器过滤标签数量和统计分母

## Bug Fixes
- 执行器过滤标签数量不再随选择清零（每个标签始终显示自身 skill 数）
- "全部"标签不再显示数量，避免随过滤器变化
- 执行器统计分母改用前端定义的 EXECUTORS.length（显示 12/14 而非 12/12）
- 执行器顺序固定（claudecode → agents），不再随数据随机排列