### PR TITLE
feat(quick-capture): 闪念捕捉 — ⌘+K 快速创建任务

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { ConfigProvider, Layout, App as AntApp, Drawer } from 'antd';
+import { ConfigProvider, Layout, App as AntApp, Drawer, Tooltip } from 'antd';
 import { PlusOutlined, ThunderboltOutlined, CloseOutlined, ArrowLeftOutlined, MenuOutlined } from '@ant-design/icons';
 import { AppProvider, useApp } from './hooks/useApp';
 import { useIsMobile } from './hooks/useIsMobile';
@@ -20,6 +20,7 @@ import { ExecutorsPanel } from './components/settings/ExecutorsPanel';
 import { ExecutionPanel } from './components/ExecutionPanel';
 import { TodoDrawer } from './components/TodoDrawer';
 import { SmartCreateModal } from './components/SmartCreateModal';
+import { QuickCaptureModal } from './components/QuickCaptureModal';
 import { LoopFormModal } from './components/LoopFormModal';
 import { LeftRail, type LeftRailKey } from './components/shell/LeftRail';
 
@@ -38,6 +39,7 @@ function AppContent() {
 
   const [todoModalOpen, setTodoModalOpen] = useState(false);
   const [smartCreateOpen, setSmartCreateOpen] = useState(false);
+  const [quickCaptureOpen, setQuickCaptureOpen] = useState(false);
   const [fabExpanded, setFabExpanded] = useState(false);
   const [navDrawerOpen, setNavDrawerOpen] = useState(false);
   const [railCollapsed, setRailCollapsed] = useState(() => {
@@ -95,6 +97,18 @@ function AppContent() {
   // Load app config on mount
   useEffect(() => {
     db.getConfig().then(setAppConfig).catch(() => {});
+  }, []);
+
+  // 全局快捷键 ⌘+K / Ctrl+K 打开闪念捕捉
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        setQuickCaptureOpen(true);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
 
@@ -517,6 +531,25 @@ function AppContent() {
         onSubmitted={handleSmartCreateSubmitted}
       />
 
+      <QuickCaptureModal
+        open={quickCaptureOpen}
+        onClose={() => setQuickCaptureOpen(false)}
+        isMobile={isMobile}
+        defaultWorkspaceId={state.selectedWorkspace}
+        onCreated={() => {
+          // 创建后刷新当前 workspace 的 todo 列表
+          const wid = state.selectedWorkspace;
+          if (wid != null) {
+            db.getAllTodos(wid).then(todos => {
+              dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: todos });
+            });
+          }
+        }}
+        onExecuted={() => {
+          // 执行后也会触发执行面板更新，无需额外操作
+        }}
+      />
+
       <ExecutionPanel
         collapsed={panelCollapsed}
         onToggleCollapse={() => {
@@ -541,6 +574,44 @@ function AppContent() {
         onClose={() => setLoopCreateModalOpen(false)}
         defaultWorkspaceId={state.selectedWorkspace}
       />
+
+      {/* 悬浮按钮：闪念捕捉入口（⌘+K 打开） */}
+      {!isMobile && (
+        <Tooltip title="闪念捕捉 (⌘+K)" placement="left">
+          <button
+            onClick={() => setQuickCaptureOpen(true)}
+            style={{
+              position: 'fixed',
+              bottom: 24,
+              right: 24,
+              width: 48,
+              height: 48,
+              borderRadius: '50%',
+              background: 'var(--color-primary)',
+              color: '#fff',
+              border: 'none',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              boxShadow: '0 4px 12px rgba(0,0,0,0.2)',
+              transition: 'transform 0.2s, box-shadow 0.2s',
+              zIndex: 1000,
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.transform = 'scale(1.1)';
+              e.currentTarget.style.boxShadow = '0 6px 16px rgba(0,0,0,0.3)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.transform = 'scale(1)';
+              e.currentTarget.style.boxShadow = '0 4px 12px rgba(0,0,0,0.2)';
+            }}
+            aria-label="闪念捕捉"
+          >
+            <ThunderboltOutlined style={{ fontSize: 22 }} />
+          </button>
+        </Tooltip>
+      )}
     </Layout>
   );
 }

--- a/frontend/src/components/QuickCaptureModal.tsx
+++ b/frontend/src/components/QuickCaptureModal.tsx
@@ -1,0 +1,291 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Modal, Drawer, Button, App } from 'antd';
+import { ThunderboltOutlined, ClockCircleOutlined } from '@ant-design/icons';
+import { WorkspaceSelect } from '@/components/common/WorkspaceSelect';
+import { ExecutorPickerPopover } from '@/components/common/ExecutorPickerPopover';
+import * as db from '@/utils/database';
+import { DEFAULT_EXECUTOR } from '@/types';
+
+interface QuickCaptureModalProps {
+  open: boolean;
+  onClose: () => void;
+  isMobile: boolean;
+  defaultWorkspaceId?: number | null;
+  onCreated?: (todoId: number) => void;
+  onExecuted?: (taskId: string, recordId: number) => void;
+}
+
+// 从内容中截取简洁标题（最多 30 字符）
+function extractTitle(content: string): string {
+  const firstLine = content.split('\n')[0]?.trim() ?? '';
+  if (firstLine.length <= 30) return firstLine;
+  return firstLine.slice(0, 30) + '...';
+}
+
+// localStorage key for remembering last executor choice
+const STORAGE_KEY_LAST_EXECUTOR = 'ntd_quick_capture_last_executor';
+
+function getLastExecutor(): string {
+  try {
+    return localStorage.getItem(STORAGE_KEY_LAST_EXECUTOR) || DEFAULT_EXECUTOR;
+  } catch {
+    return DEFAULT_EXECUTOR;
+  }
+}
+
+function setLastExecutor(executor: string) {
+  try {
+    localStorage.setItem(STORAGE_KEY_LAST_EXECUTOR, executor);
+  } catch {}
+}
+
+export function QuickCaptureModal({
+  open,
+  onClose,
+  isMobile,
+  defaultWorkspaceId,
+  onCreated,
+  onExecuted,
+}: QuickCaptureModalProps) {
+  const { message } = App.useApp();
+  const [content, setContent] = useState('');
+  const [workspaceId, setWorkspaceId] = useState<number | null>(defaultWorkspaceId ?? null);
+  const [executor, setExecutor] = useState<string>(getLastExecutor);
+  const [loading, setLoading] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // 打开时自动聚焦
+  useEffect(() => {
+    if (open && !isMobile) {
+      setTimeout(() => textareaRef.current?.focus(), 100);
+    }
+  }, [open, isMobile]);
+
+  // 打开时重置工作空间为默认值
+  useEffect(() => {
+    if (open && defaultWorkspaceId != null) {
+      setWorkspaceId(defaultWorkspaceId);
+    }
+  }, [open, defaultWorkspaceId]);
+
+  // 关闭时清空
+  const handleClose = useCallback(() => {
+    setContent('');
+    setLoading(false);
+    onClose();
+  }, [onClose]);
+
+  // 选择执行器时记住
+  const handleExecutorChange = useCallback((value: string) => {
+    setExecutor(value);
+    setLastExecutor(value);
+  }, []);
+
+  // 创建任务（稍后执行）
+  const handleCreateLater = useCallback(async () => {
+    const trimmed = content.trim();
+    if (!trimmed) {
+      message.warning('请输入内容');
+      return;
+    }
+    if (!workspaceId) {
+      message.warning('请选择工作空间');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const title = extractTitle(trimmed);
+      const todo = await db.createTodo(
+        title,
+        trimmed,
+        [],
+        workspaceId,
+      );
+
+      // 更新执行器
+      if (executor !== DEFAULT_EXECUTOR) {
+        await db.updateTodo(
+          todo.id,
+          title,
+          trimmed,
+          'pending',
+          executor,
+        );
+      }
+
+      message.success('已创建任务');
+      onCreated?.(todo.id);
+      handleClose();
+    } catch (err: any) {
+      message.error(err?.message || '创建失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [content, workspaceId, executor, message, onCreated, handleClose]);
+
+  // 立即执行
+  const handleExecuteNow = useCallback(async () => {
+    const trimmed = content.trim();
+    if (!trimmed) {
+      message.warning('请输入内容');
+      return;
+    }
+    if (!workspaceId) {
+      message.warning('请选择工作空间');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const title = extractTitle(trimmed);
+      const todo = await db.createTodo(
+        title,
+        trimmed,
+        [],
+        workspaceId,
+      );
+
+      // 更新执行器
+      if (executor !== DEFAULT_EXECUTOR) {
+        await db.updateTodo(
+          todo.id,
+          title,
+          trimmed,
+          'pending',
+          executor,
+        );
+      }
+
+      // 立即执行
+      const result = await db.executeTodo(todo.id, executor);
+      message.success('已创建并开始执行');
+      onExecuted?.(result.task_id, result.record_id);
+      handleClose();
+    } catch (err: any) {
+      message.error(err?.message || '执行失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [content, workspaceId, executor, message, onExecuted, handleClose]);
+
+  // Ctrl+Enter 快捷提交
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault();
+      handleExecuteNow();
+    }
+  }, [handleExecuteNow]);
+
+  const bodyContent = (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {/* 内容输入框 */}
+      <textarea
+        ref={textareaRef}
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="要做什么..."
+        rows={4}
+        disabled={loading}
+        style={{
+          width: '100%',
+          padding: '12px',
+          borderRadius: 8,
+          border: '1px solid var(--color-border-secondary)',
+          background: 'var(--color-bg-elevated)',
+          color: 'var(--color-text)',
+          fontSize: 14,
+          resize: 'vertical',
+          outline: 'none',
+          fontFamily: 'inherit',
+        }}
+      />
+
+      {/* 工作空间选择 */}
+      <div>
+        <div style={{ marginBottom: 6, fontWeight: 600, fontSize: 13, color: 'var(--color-text-secondary)' }}>
+          工作空间
+        </div>
+        <WorkspaceSelect
+          value={workspaceId}
+          onChange={(v) => setWorkspaceId(v)}
+          required
+        />
+      </div>
+
+      {/* 执行器选择（Popover） */}
+      <div>
+        <div style={{ marginBottom: 6, fontWeight: 600, fontSize: 13, color: 'var(--color-text-secondary)' }}>
+          执行器
+        </div>
+        <ExecutorPickerPopover
+          value={executor}
+          onChange={handleExecutorChange}
+        />
+      </div>
+
+      {/* 操作按钮 */}
+      <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+        <Button
+          onClick={handleCreateLater}
+          loading={loading}
+          disabled={!content.trim() || !workspaceId}
+          style={{ flex: 1 }}
+        >
+          <ClockCircleOutlined style={{ marginRight: 4 }} />
+          稍后
+        </Button>
+        <Button
+          type="primary"
+          icon={<ThunderboltOutlined />}
+          onClick={handleExecuteNow}
+          loading={loading}
+          disabled={!content.trim() || !workspaceId}
+          style={{ flex: 1 }}
+        >
+          立即执行
+        </Button>
+      </div>
+
+      {/* 快捷键提示 */}
+      {!isMobile && (
+        <div style={{ textAlign: 'center', fontSize: 12, color: 'var(--color-text-tertiary)' }}>
+          <div>Ctrl+Enter / ⌘+Enter 立即执行</div>
+          <div style={{ marginTop: 4 }}>Ctrl+K / ⌘+K 随时唤出</div>
+        </div>
+      )}
+    </div>
+  );
+
+  // 移动端：底部 Drawer
+  if (isMobile) {
+    return (
+      <Drawer
+        title="闪念捕捉"
+        placement="bottom"
+        open={open}
+        onClose={handleClose}
+        height="auto"
+        destroyOnClose
+      >
+        {bodyContent}
+      </Drawer>
+    );
+  }
+
+  // 桌面端：居中 Modal
+  return (
+    <Modal
+      title="闪念捕捉"
+      open={open}
+      onCancel={handleClose}
+      width={480}
+      centered
+      destroyOnClose
+      footer={null}
+    >
+      {bodyContent}
+    </Modal>
+  );
+}

--- a/frontend/src/components/common/ExecutorPickerPopover.tsx
+++ b/frontend/src/components/common/ExecutorPickerPopover.tsx
@@ -1,0 +1,147 @@
+import { memo, useState, useRef, useEffect, useCallback } from 'react';
+import { CheckOutlined } from '@ant-design/icons';
+import { EXECUTORS_FOR_PICKER, getExecutorOption } from '@/types';
+
+interface ExecutorPickerPopoverProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+// 执行器选择弹出面板
+// 设计：小按钮显示当前执行器，点击弹出选择面板，选择后关闭
+export const ExecutorPickerPopover = memo(function ExecutorPickerPopover({
+  value,
+  onChange,
+}: ExecutorPickerPopoverProps) {
+  const [open, setOpen] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const current = getExecutorOption(value);
+
+  // 点击外部关闭
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  const handleSelect = useCallback((v: string) => {
+    onChange(v);
+    setOpen(false);
+  }, [onChange]);
+
+  return (
+    <div ref={popoverRef} style={{ position: 'relative', display: 'inline-block' }}>
+      {/* 触发按钮 */}
+      <button
+        onClick={() => setOpen(!open)}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          padding: '6px 12px',
+          borderRadius: 8,
+          border: `1px solid ${current.color}40`,
+          background: `${current.color}10`,
+          cursor: 'pointer',
+          transition: 'all 0.2s',
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.borderColor = `${current.color}80`;
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.borderColor = `${current.color}40`;
+        }}
+      >
+        <span style={{ fontSize: 12, lineHeight: 1 }}>{current.icon}</span>
+        <span style={{ fontSize: 13, fontWeight: 600, color: current.color }}>
+          {current.label}
+        </span>
+      </button>
+
+      {/* 弹出选择面板 */}
+      {open && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            marginTop: 4,
+            padding: 8,
+            borderRadius: 10,
+            border: '1px solid var(--color-border-secondary)',
+            background: 'var(--color-bg-elevated)',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+            zIndex: 1000,
+            minWidth: 200,
+            maxHeight: 320,
+            overflowY: 'auto',
+          }}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {EXECUTORS_FOR_PICKER.map((opt) => {
+              const selected = value === opt.value;
+              return (
+                <button
+                  key={opt.value}
+                  onClick={() => handleSelect(opt.value)}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    padding: '8px 10px',
+                    borderRadius: 6,
+                    border: 'none',
+                    background: selected ? `${opt.color}15` : 'transparent',
+                    cursor: 'pointer',
+                    transition: 'all 0.15s',
+                    textAlign: 'left',
+                  }}
+                  onMouseEnter={(e) => {
+                    if (!selected) {
+                      e.currentTarget.style.background = `${opt.color}08`;
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!selected) {
+                      e.currentTarget.style.background = 'transparent';
+                    }
+                  }}
+                >
+                  <span style={{ fontSize: 14, lineHeight: 1 }}>{opt.icon}</span>
+                  <span style={{
+                    flex: 1,
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: selected ? opt.color : 'var(--color-text)',
+                  }}>
+                    {opt.label}
+                  </span>
+                  {selected && (
+                    <span style={{
+                      width: 16,
+                      height: 16,
+                      borderRadius: '50%',
+                      backgroundColor: opt.color,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}>
+                      <CheckOutlined style={{ fontSize: 10, color: '#fff' }} />
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});


### PR DESCRIPTION
## Summary

- 新增 QuickCaptureModal 组件，支持 ⌘+K 全局快捷键快速创建任务
- 内容输入 → 自动截取前 30 字作为标题，无需手动填写
- 执行器选择器：Popover 弹出面板，localStorage 记住上次选择
- 两种操作：「稍后」创建任务 / 「立即执行」创建+执行
- 右下角悬浮按钮（⚡）作为鼠标入口，桌面端 Modal / 移动端 Drawer 自适应

## Changes

| 文件 | 说明 |
|------|------|
| `frontend/src/components/QuickCaptureModal.tsx` | 闪念捕捉主组件 |
| `frontend/src/components/common/ExecutorPickerPopover.tsx` | 执行器选择弹出面板 |
| `frontend/src/App.tsx` | 集成：⌘+K 快捷键 + 悬浮按钮 + 渲染 |

## Usage

- 按 `⌘+K`（macOS）或 `Ctrl+K`（Windows/Linux）打开
- 或点击右下角 ⚡ 悬浮按钮
- 输入内容 → 选择工作空间 → 点击「稍后」或「立即执行」