### PR TITLE
feat(App): 手机端FAB闪念入口替换智能新建

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -297,11 +297,11 @@ function AppContent() {
             {fabExpanded && (
               <>
                 <div className="mobile-fab-item" style={{ animationDelay: '0ms' }}>
-                  <span className="mobile-fab-item-label">智能新建</span>
+                  <span className="mobile-fab-item-label">闪念</span>
                   <button
                     className="mobile-fab-item-btn mobile-fab-smart"
-                    onClick={() => { setFabExpanded(false); setSmartCreateOpen(true); }}
-                    aria-label="智能新建"
+                    onClick={() => { setFabExpanded(false); setQuickCaptureOpen(true); }}
+                    aria-label="闪念捕捉"
                   >
                     <ThunderboltOutlined style={{ fontSize: 20, color: '#fff' }} />
                   </button>


### PR DESCRIPTION
## 改动
- 手机端 FAB 第一个按钮从「智能新建」改为「闪念」
- 点击行为改为打开 
- 桌面端行为不变