### PR TITLE
feat: Finished 事件携带 duration_secs/total_tokens，飞书推送改为统计摘要

### DIFF
--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -259,6 +259,8 @@ pub(crate) async fn handle_cancellation_branch(
             feishu_bot_id,
             feishu_receive_id,
             workspace_id,
+            duration_secs: 0,
+            total_tokens: 0,
         },
     );
     task_manager.remove(task_id).await;
@@ -317,6 +319,8 @@ pub(crate) async fn handle_timeout_branch(
             feishu_bot_id,
             feishu_receive_id,
             workspace_id,
+            duration_secs: 0,
+            total_tokens: 0,
         },
     );
     task_manager.remove(task_id).await;
@@ -325,6 +329,7 @@ pub(crate) async fn handle_timeout_branch(
 /// 正常完成末段：auto-review + finish_todo_execution + 末段事件 + remove task。
 ///
 /// auto-review 仅在 `trigger_type != "auto_review"` 时启动（防止评审实例自身再触发评审）。
+/// 从 DB 查询 record 的 usage 获取 duration 和 tokens，传给 emit_completion_events。
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn finalize_normal_completion(
     db: Arc<Database>,
@@ -361,6 +366,26 @@ pub(crate) async fn finalize_normal_completion(
     )
     .await;
     let _ = db.finish_todo_execution(todo_id, success).await;
+
+    // 从 DB 查询 record 的 usage，获取 duration 和 tokens
+    let (duration_secs, total_tokens) = match db.get_execution_record(record_id).await {
+        Ok(Some(record)) => {
+            let dur = record.usage.as_ref()
+                .and_then(|u| u.duration_ms)
+                .map(|ms| (ms / 1000) as i64)
+                .unwrap_or(0);
+            let tok = record.usage.as_ref()
+                .map(|u| (u.input_tokens + u.output_tokens) as i64)
+                .unwrap_or(0);
+            (dur, tok)
+        }
+        _ => {
+            // 查询失败时降级为 0，不阻塞正常完成流程
+            tracing::warn!("查询执行记录 usage 失败, record_id={}, 降级为 0", record_id);
+            (0, 0)
+        }
+    };
+
     emit_completion_events(
         &tx,
         &executor,
@@ -373,6 +398,8 @@ pub(crate) async fn finalize_normal_completion(
         feishu_bot_id,
         feishu_receive_id,
         workspace_id,
+        duration_secs,
+        total_tokens,
     );
     task_manager.remove(&task_id).await;
 }
@@ -405,6 +432,9 @@ async fn maybe_run_auto_review(
 }
 
 /// 末段事件：Output (executor finished) + Finished。
+///
+/// `duration_secs` 和 `total_tokens` 由调用方从 DB 查询 usage 后传入；
+/// 异常路径（cancel/timeout/spawn 失败等）传 0 即可。
 #[allow(clippy::too_many_arguments)]
 fn emit_completion_events(
     tx: &broadcast::Sender<ExecEvent>,
@@ -418,6 +448,8 @@ fn emit_completion_events(
     feishu_bot_id: Option<i64>,
     feishu_receive_id: Option<String>,
     workspace_id: Option<i64>,
+    duration_secs: i64,
+    total_tokens: i64,
 ) {
     let entry = ParsedLogEntry::new(
         if success { "info" } else { "error" },
@@ -445,6 +477,8 @@ fn emit_completion_events(
             feishu_bot_id,
             feishu_receive_id,
             workspace_id,
+            duration_secs,
+            total_tokens,
         },
     );
 }

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -107,6 +107,7 @@ pub(crate) fn emit_started_event(
     todo_id: i64,
     todo_title: &str,
     executor: &dyn CodeExecutor,
+    workspace_id: Option<i64>,
 ) {
     send_event(
         tx,
@@ -115,6 +116,7 @@ pub(crate) fn emit_started_event(
             todo_id,
             todo_title: todo_title.to_string(),
             executor: executor.executor_type().to_string(),
+            workspace_id,
         },
     );
     let entry = ParsedLogEntry::info(format!("Starting {}", executor.executor_type()));
@@ -123,6 +125,7 @@ pub(crate) fn emit_started_event(
         ExecEvent::Output {
             task_id: task_id.to_string(),
             entry,
+            workspace_id,
         },
     );
 }
@@ -184,6 +187,7 @@ pub(crate) async fn emit_post_execution_todo_progress(
     executor: &dyn CodeExecutor,
     task_id: &str,
     record_id: i64,
+    workspace_id: Option<i64>,
 ) {
     if let Some(progress) = executor.post_execution_todo_progress() {
         if let Ok(progress_json) = serde_json::to_string(&progress) {
@@ -195,6 +199,7 @@ pub(crate) async fn emit_post_execution_todo_progress(
                 ExecEvent::TodoProgress {
                     task_id: task_id.to_string(),
                     progress,
+                    workspace_id,
                 },
             );
         }
@@ -245,6 +250,7 @@ pub(crate) async fn handle_cancellation_branch(
         ExecEvent::Output {
             task_id: task_id.to_string(),
             entry,
+            workspace_id,
         },
     );
     send_event(
@@ -305,6 +311,7 @@ pub(crate) async fn handle_timeout_branch(
         ExecEvent::Output {
             task_id: task_id.to_string(),
             entry,
+            workspace_id,
         },
     );
     send_event(
@@ -463,6 +470,7 @@ fn emit_completion_events(
         ExecEvent::Output {
             task_id: task_id.to_string(),
             entry,
+            workspace_id,
         },
     );
     send_event(

--- a/backend/src/executor_service/log_capture.rs
+++ b/backend/src/executor_service/log_capture.rs
@@ -90,6 +90,7 @@ fn emit_execution_event(
     event: &ExecutionEvent,
     tx: &broadcast::Sender<ExecEvent>,
     task_id: &str,
+    workspace_id: Option<i64>,
 ) -> ParsedLogEntry {
     let parsed = DbLogEntry::from_event_to_parsed_log_entry(event);
     send_event(
@@ -97,6 +98,7 @@ fn emit_execution_event(
         ExecEvent::Output {
             task_id: task_id.to_string(),
             entry: parsed.clone(),
+            workspace_id,
         },
     );
     parsed
@@ -110,6 +112,7 @@ fn try_parse_with_pipeline(
     line: &str,
     tx: &broadcast::Sender<ExecEvent>,
     task_id: &str,
+    workspace_id: Option<i64>,
 ) -> Vec<ParsedLogEntry> {
     let line_trimmed = line.trim();
     if line_trimmed.is_empty() {
@@ -137,7 +140,7 @@ fn try_parse_with_pipeline(
                     continue;
                 }
                 // 非 JSON 的普通 info 也转发
-                let parsed = emit_execution_event(event, tx, task_id);
+                let parsed = emit_execution_event(event, tx, task_id, workspace_id);
                 results.push(parsed);
             }
             ExecutionEvent::Error { .. }
@@ -152,7 +155,7 @@ fn try_parse_with_pipeline(
             | ExecutionEvent::Duration { .. }
             | ExecutionEvent::StepStart { .. }
             | ExecutionEvent::StepFinish { .. } => {
-                let parsed = emit_execution_event(event, tx, task_id);
+                let parsed = emit_execution_event(event, tx, task_id, workspace_id);
                 results.push(parsed);
             }
             // SessionEnd 由 pipeline.finalize() 生产，避免重复转发
@@ -160,7 +163,7 @@ fn try_parse_with_pipeline(
             | ExecutionEvent::Progress { .. } => {}
             // ModelSwitch 需转发到 DB，否则 completion 阶段 get_model_from_logs 找不到模型
             ExecutionEvent::ModelSwitch { .. } => {
-                let parsed = emit_execution_event(event, tx, task_id);
+                let parsed = emit_execution_event(event, tx, task_id, workspace_id);
                 results.push(parsed);
             }
             // 其他类型不转发
@@ -177,6 +180,7 @@ fn try_parse_stderr_with_pipeline(
     line: &str,
     tx: &broadcast::Sender<ExecEvent>,
     task_id: &str,
+    workspace_id: Option<i64>,
 ) -> Vec<ParsedLogEntry> {
     let line_trimmed = line.trim();
     if line_trimmed.is_empty() {
@@ -194,7 +198,7 @@ fn try_parse_stderr_with_pipeline(
 
     pipeline.events()[len_before..]
         .iter()
-        .map(|event| emit_execution_event(event, tx, task_id))
+        .map(|event| emit_execution_event(event, tx, task_id, workspace_id))
         .collect()
 }
 
@@ -207,6 +211,7 @@ pub(crate) fn spawn_stderr_reader<R>(
     log_flusher: Arc<LogFlusher>,
     tx: broadcast::Sender<ExecEvent>,
     task_id: String,
+    workspace_id: Option<i64>,
 ) -> Option<JoinHandle<()>>
 where
     R: AsyncRead + Unpin + Send + 'static,
@@ -227,7 +232,7 @@ where
                 }
                 // 优先尝试用 EventPipeline 解析
                 let parsed_list =
-                    try_parse_stderr_with_pipeline(&mut pipeline, &line, &tx, &task_id);
+                    try_parse_stderr_with_pipeline(&mut pipeline, &line, &tx, &task_id, workspace_id);
 
                 if !parsed_list.is_empty() {
                     for parsed in parsed_list {
@@ -255,6 +260,7 @@ where
                     ExecEvent::Output {
                         task_id: task_id.clone(),
                         entry,
+                        workspace_id,
                     },
                 );
             }
@@ -263,7 +269,7 @@ where
             let len_before = pipeline.len();
             pipeline.finalize();
             for event in &pipeline.events()[len_before..] {
-                let parsed = emit_execution_event(event, &tx, &task_id);
+                let parsed = emit_execution_event(event, &tx, &task_id, workspace_id);
                 log_flusher.push(parsed).await;
             }
         })
@@ -286,6 +292,7 @@ pub(crate) fn spawn_stdout_reader<R>(
     tx: broadcast::Sender<ExecEvent>,
     task_id: String,
     record_id: i64,
+    workspace_id: Option<i64>,
 ) -> Option<JoinHandle<()>>
 where
     R: AsyncRead + Unpin + Send + 'static,
@@ -297,6 +304,7 @@ where
     let log_flusher_for_stdout = log_flusher.clone();
     let tid = task_id;
     let rid = record_id;
+    let wid = workspace_id;
 
     Some(tokio::spawn(async move {
         // 创建 EventPipeline 用于结构化解析
@@ -311,7 +319,7 @@ where
         while let Ok(Some(line)) = reader.next_line().await {
             // 优先尝试用 EventPipeline 解析
             let parsed_list =
-                try_parse_with_pipeline(&mut pipeline, &line, &tx_clone, &tid);
+                try_parse_with_pipeline(&mut pipeline, &line, &tx_clone, &tid, wid);
 
             if !parsed_list.is_empty() {
                 for parsed in parsed_list {
@@ -326,7 +334,7 @@ where
                     }
 
                     // todo_progress：写库 + 发事件
-                    emit_todo_progress_if_present(&db_for_todo, &tx_clone, &tid, rid, &parsed).await;
+                    emit_todo_progress_if_present(&db_for_todo, &tx_clone, &tid, rid, &parsed, wid).await;
 
                     // 统计：工具调用必发；普通日志每 10 条发一次。
                     log_count += 1;
@@ -336,6 +344,7 @@ where
                         &tid,
                         &parsed,
                         log_count,
+                        wid,
                     )
                     .await;
 
@@ -361,7 +370,7 @@ where
             };
 
             // todo_progress：写库 + 发事件，让前端能实时显示进度。
-            emit_todo_progress_if_present(&db_for_todo, &tx_clone, &tid, rid, &parsed).await;
+            emit_todo_progress_if_present(&db_for_todo, &tx_clone, &tid, rid, &parsed, wid).await;
 
             // 统计：工具调用必发；普通日志每 10 条发一次。
             // 用 with_logs 持锁只读扫描，避免与 push 路径冲突。
@@ -372,6 +381,7 @@ where
                 &tid,
                 &parsed,
                 log_count,
+                wid,
             )
             .await;
 
@@ -382,6 +392,7 @@ where
                 ExecEvent::Output {
                     task_id: tid.clone(),
                     entry: parsed,
+                    workspace_id: wid,
                 },
             );
         }
@@ -390,7 +401,7 @@ where
         let len_before = pipeline.len();
         pipeline.finalize();
         for event in &pipeline.events()[len_before..] {
-            let parsed = emit_execution_event(event, &tx_clone, &tid);
+            let parsed = emit_execution_event(event, &tx_clone, &tid, wid);
             log_flusher_for_stdout.push(parsed).await;
         }
     }))
@@ -420,6 +431,7 @@ async fn emit_todo_progress_if_present(
     task_id: &str,
     record_id: i64,
     parsed: &ParsedLogEntry,
+    workspace_id: Option<i64>,
 ) {
     let Some(progress) = crate::todo_progress::try_extract_todo_progress(parsed) else {
         return;
@@ -434,6 +446,7 @@ async fn emit_todo_progress_if_present(
         ExecEvent::TodoProgress {
             task_id: task_id.to_string(),
             progress,
+            workspace_id,
         },
     );
 }
@@ -445,6 +458,7 @@ async fn maybe_emit_execution_stats(
     task_id: &str,
     parsed: &ParsedLogEntry,
     log_count: u64,
+    workspace_id: Option<i64>,
 ) {
     let is_tool_call = is_tool_call_log_type(&parsed.log_type);
     if !is_tool_call && !log_count.is_multiple_of(10) {
@@ -456,6 +470,7 @@ async fn maybe_emit_execution_stats(
         ExecEvent::ExecutionStats {
             task_id: task_id.to_string(),
             stats,
+            workspace_id,
         },
     );
 }
@@ -506,6 +521,7 @@ pub(crate) async fn setup_log_capture_pipeline<SO, SE>(
     tx: broadcast::Sender<ExecEvent>,
     task_id: String,
     record_id: i64,
+    workspace_id: Option<i64>,
 ) -> (
     Arc<LogFlusher>,
     Option<JoinHandle<()>>,
@@ -531,6 +547,7 @@ where
         tx.clone(),
         task_id.clone(),
         record_id,
+        workspace_id,
     );
     let stderr_task = spawn_stderr_reader(
         stderr_handle,
@@ -538,6 +555,7 @@ where
         log_flusher.clone(),
         tx.clone(),
         task_id.clone(),
+        workspace_id,
     );
     // 定时兜底 flush：每 3 秒检查未刷新条目，有则写库。
     let flush_timer = {

--- a/backend/src/executor_service/log_capture.rs
+++ b/backend/src/executor_service/log_capture.rs
@@ -86,6 +86,8 @@ fn create_pipeline_for_executor(executor: &dyn CodeExecutor) -> Option<EventPipe
 /// 将 ExecutionEvent 转换为 ParsedLogEntry 并发送 Output 事件
 ///
 /// 返回转换后的 ParsedLogEntry，供 LogFlusher 使用。
+/// workspace_id：执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标，
+/// 必须贯穿到每个事件发送路径，否则推送服务无法匹配到对应的推送目标。
 fn emit_execution_event(
     event: &ExecutionEvent,
     tx: &broadcast::Sender<ExecEvent>,
@@ -107,6 +109,8 @@ fn emit_execution_event(
 /// 尝试用 EventPipeline 解析一行，返回所有新事件的 ParsedLogEntry 列表
 ///
 /// 如果 EventPipeline 没有产生有效事件，返回空 Vec。
+/// workspace_id：执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标，
+/// 必须贯穿到每个事件发送路径，否则推送服务无法匹配到对应的推送目标。
 fn try_parse_with_pipeline(
     pipeline: &mut EventPipeline,
     line: &str,
@@ -175,6 +179,8 @@ fn try_parse_with_pipeline(
 }
 
 /// 尝试用 EventPipeline 解析 stderr 行，返回所有新事件的 ParsedLogEntry 列表
+/// workspace_id：执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标，
+/// 必须贯穿到每个事件发送路径，否则推送服务无法匹配到对应的推送目标。
 fn try_parse_stderr_with_pipeline(
     pipeline: &mut EventPipeline,
     line: &str,
@@ -205,6 +211,8 @@ fn try_parse_stderr_with_pipeline(
 /// 启动一个 stderr reader 任务：逐行读 stderr -> 经 executor 解析 -> 推入 LogFlusher。
 ///
 /// 返回 `None` 表示 executor 子进程根本没暴露 stderr（少见，比如某些 mock executor）。
+/// workspace_id：执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标，
+/// 必须贯穿到每个事件发送路径，否则推送服务无法匹配到对应的推送目标。
 pub(crate) fn spawn_stderr_reader<R>(
     stderr_handle: Option<R>,
     executor: Arc<dyn CodeExecutor>,
@@ -284,6 +292,8 @@ where
 ///   2. 解析 `todo_progress` 时除写库外还要发 `TodoProgress` 事件（前端实时进度条）；
 ///   3. 每 10 行 或 工具调用时扫一遍 buffer 计算 stats，emit `ExecutionStats`。
 /// 这三件事没法再下沉到 LogFlusher（一个是 DB 写，一个是 progress 事件），所以留在这里。
+/// workspace_id：执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标，
+/// 必须贯穿到每个事件发送路径，否则推送服务无法匹配到对应的推送目标。
 pub(crate) fn spawn_stdout_reader<R>(
     stdout_handle: Option<R>,
     executor: Arc<dyn CodeExecutor>,
@@ -425,6 +435,8 @@ async fn update_session_id_once(
 }
 
 /// 若 parsed 含 todo_progress 则写库 + 发事件。
+/// workspace_id：执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标，
+/// 必须贯穿到每个事件发送路径，否则推送服务无法匹配到对应的推送目标。
 async fn emit_todo_progress_if_present(
     db: &Arc<Database>,
     tx: &broadcast::Sender<ExecEvent>,
@@ -452,6 +464,8 @@ async fn emit_todo_progress_if_present(
 }
 
 /// 工具调用必发 stats；普通日志每 10 条发一次。
+/// workspace_id：执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标，
+/// 必须贯穿到每个事件发送路径，否则推送服务无法匹配到对应的推送目标。
 async fn maybe_emit_execution_stats(
     log_flusher: &Arc<LogFlusher>,
     tx: &broadcast::Sender<ExecEvent>,
@@ -513,6 +527,8 @@ async fn compute_execution_stats(
 ///
 /// `SO`/`SE` 两个泛型分别对应 stdout/stderr handle 的真实类型（tokio 的 ChildStdout
 /// 和 ChildStderr 是两个不同类型，没法合并成一个 `R`）。
+/// workspace_id：执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标，
+/// 必须贯穿到每个事件发送路径，否则推送服务无法匹配到对应的推送目标。
 pub(crate) async fn setup_log_capture_pipeline<SO, SE>(
     stdout_handle: Option<SO>,
     stderr_handle: Option<SE>,

--- a/backend/src/executor_service/pre_spawn.rs
+++ b/backend/src/executor_service/pre_spawn.rs
@@ -112,6 +112,8 @@ pub(crate) async fn reject_concurrency_limit(
             feishu_bot_id: None,
             feishu_receive_id: None,
             workspace_id: None,
+            duration_secs: 0,
+            total_tokens: 0,
         },
     );
     ExecutionResult {
@@ -147,6 +149,8 @@ pub(crate) async fn reject_no_executor(
             feishu_bot_id: None,
             feishu_receive_id: None,
             workspace_id: None,
+            duration_secs: 0,
+            total_tokens: 0,
         },
     );
     task_manager.remove(task_id).await;
@@ -209,6 +213,8 @@ pub(crate) async fn reject_start_todo_failure(
             feishu_bot_id: None,
             feishu_receive_id: None,
             workspace_id: None,
+            duration_secs: 0,
+            total_tokens: 0,
         },
     );
     let _ = db.finish_todo_execution(todo_id, false).await;

--- a/backend/src/executor_service/pre_spawn.rs
+++ b/backend/src/executor_service/pre_spawn.rs
@@ -191,6 +191,7 @@ pub(crate) async fn reject_start_todo_failure(
     executor_str: &str,
     record_id: i64,
     error: impl std::fmt::Display,
+    workspace_id: Option<i64>,
 ) -> ExecutionResult {
     tracing::error!("Failed to start todo execution: {}", error);
     let entry = ParsedLogEntry::error(format!("Failed to start todo execution: {}", error));
@@ -199,6 +200,7 @@ pub(crate) async fn reject_start_todo_failure(
         ExecEvent::Output {
             task_id: task_id.to_string(),
             entry,
+            workspace_id,
         },
     );
     send_event(
@@ -212,7 +214,7 @@ pub(crate) async fn reject_start_todo_failure(
             result: Some("Failed to start execution".to_string()),
             feishu_bot_id: None,
             feishu_receive_id: None,
-            workspace_id: None,
+            workspace_id,
             duration_secs: 0,
             total_tokens: 0,
         },

--- a/backend/src/executor_service/spawn_lifecycle.rs
+++ b/backend/src/executor_service/spawn_lifecycle.rs
@@ -138,6 +138,8 @@ pub(crate) async fn handle_spawn_failure(
             feishu_bot_id,
             feishu_receive_id,
             workspace_id,
+            duration_secs: 0,
+            total_tokens: 0,
         },
     );
     let _ = db.finish_todo_execution(todo_id, false).await;

--- a/backend/src/executor_service/spawn_lifecycle.rs
+++ b/backend/src/executor_service/spawn_lifecycle.rs
@@ -50,6 +50,7 @@ pub(crate) async fn run_spawned_executor_task(spawned: super::types::SpawnInputs
         runtime.todo_id,
         &runtime.todo_title,
         runtime.executor_spawn.as_ref(),
+        runtime.prepared.request.workspace_id,
     );
 
     let Some(mut child) = try_spawn_executor_child(&runtime).await else {
@@ -124,6 +125,7 @@ pub(crate) async fn handle_spawn_failure(
         ExecEvent::Output {
             task_id: task_id.to_string(),
             entry,
+            workspace_id,
         },
     );
     send_event(
@@ -244,6 +246,7 @@ pub(crate) async fn setup_log_capture_pipeline_for(
         runtime.tx.clone(),
         runtime.task_id.clone(),
         runtime.record_id,
+        runtime.prepared.request.workspace_id,
     )
     .await
 }
@@ -587,6 +590,7 @@ pub(crate) async fn handle_completed_branch(
         ctx.executor.as_ref(),
         &ctx.task_id,
         ctx.record_id,
+        ctx.workspace_id,
     )
     .await;
     let (logs_snapshot, result_str) =

--- a/backend/src/executor_service/spawn_lifecycle.rs
+++ b/backend/src/executor_service/spawn_lifecycle.rs
@@ -140,6 +140,7 @@ pub(crate) async fn handle_spawn_failure(
             feishu_bot_id,
             feishu_receive_id,
             workspace_id,
+            // spawn 阶段尚未产生任何执行时长与 token 消耗，置 0 避免阻塞 Finished 事件下发
             duration_secs: 0,
             total_tokens: 0,
         },

--- a/backend/src/executor_service/stages.rs
+++ b/backend/src/executor_service/stages.rs
@@ -217,6 +217,7 @@ pub(crate) async fn start_todo_or_cleanup(
             &prepared.executor_str,
             prepared.record_id,
             e,
+            prepared.request.workspace_id,
         )
         .await);
     }

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -241,7 +241,8 @@ pub async fn execute_handler(
         feishu_bot_id: None,
         feishu_receive_id: None,
         workspace_path: None,
-        workspace_id: None,
+        // 从 todo 中提取 workspace_id，用于 FeishuPushService 按 workspace 隔离推送
+        workspace_id: todo.workspace_id,
     })
     .await;
     let result = result?;
@@ -536,7 +537,8 @@ pub async fn resume_execution_handler(
         feishu_bot_id: None,
         feishu_receive_id: None,
         workspace_path: None,
-        workspace_id: None,
+        // 从 todo 中提取 workspace_id，用于 FeishuPushService 按 workspace 隔离推送
+        workspace_id: todo.workspace_id,
     })
     .await?;
     let record_id = result.record_id
@@ -693,7 +695,8 @@ pub async fn smart_create_handler(
         feishu_bot_id: None,
         feishu_receive_id: None,
         workspace_path: None,
-        workspace_id: None,
+        // 从 todo 中提取 workspace_id，用于 FeishuPushService 按 workspace 隔离推送
+        workspace_id: todo.workspace_id,
     })
     .await?;
 

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -128,10 +128,14 @@ pub enum ExecEvent {
         todo_id: i64,
         todo_title: String,
         executor: String,
+        /// 执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标
+        workspace_id: Option<i64>,
     },
     Output {
         task_id: String,
         entry: ParsedLogEntry,
+        /// 执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标
+        workspace_id: Option<i64>,
     },
     Finished {
         task_id: String,
@@ -159,10 +163,14 @@ pub enum ExecEvent {
     TodoProgress {
         task_id: String,
         progress: Vec<crate::models::TodoItem>,
+        /// 执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标
+        workspace_id: Option<i64>,
     },
     ExecutionStats {
         task_id: String,
         stats: crate::models::ExecutionStats,
+        /// 执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标
+        workspace_id: Option<i64>,
     },
     ReviewStatusChanged {
         record_id: i64,

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -188,8 +188,16 @@ pub enum ExecEvent {
         loop_title: String,
         /// 执行状态（success / failed / partial）
         status: String,
-        /// 执行结果摘要（黑板文本）
-        result: Option<String>,
+        /// 总步数
+        total_steps: i32,
+        /// 成功步数
+        completed_steps: i32,
+        /// 失败步数
+        failed_steps: i32,
+        /// 执行时长（秒）
+        duration_secs: i64,
+        /// 累计 Token 消耗（input + output）
+        total_tokens: i64,
         /// 执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标
         workspace_id: Option<i64>,
     },

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -198,7 +198,12 @@ pub enum ExecEvent {
         loop_id: i64,
         /// loop 标题
         loop_title: String,
-        /// 执行状态（success / failed / partial）
+        /// 执行状态（终态枚举值，共 5 种）：
+        /// - success：全部成功
+        /// - partial：部分成功（有成功也有失败）
+        /// - failed：全部失败
+        /// - capped_step：因步数限制被截断终止
+        /// - capped_token：因 Token 限制被截断终止
         status: String,
         /// 总步数
         total_steps: i32,

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -146,6 +146,10 @@ pub enum ExecEvent {
         feishu_receive_id: Option<String>,
         /// 执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标
         workspace_id: Option<i64>,
+        /// 执行时长（秒），用于推送统计摘要
+        duration_secs: i64,
+        /// 累计 Token 消耗（input + output），用于推送统计摘要
+        total_tokens: i64,
     },
     /// 同步事件：连接时发送当前实际运行的任务列表
     /// 前端收到此事件后应清空 runningTasks 并用此列表初始化

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -177,6 +177,22 @@ pub enum ExecEvent {
         /// 要发送的文本内容
         content: String,
     },
+    /// Loop 执行完成事件：loop 执行完成后广播此事件，
+    /// 用于 FeishuPushService 按 workspace 配置推送执行结果。
+    LoopFinished {
+        /// loop 执行记录 ID
+        loop_execution_id: i64,
+        /// loop ID
+        loop_id: i64,
+        /// loop 标题
+        loop_title: String,
+        /// 执行状态（success / failed / partial）
+        status: String,
+        /// 执行结果摘要（黑板文本）
+        result: Option<String>,
+        /// 执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标
+        workspace_id: Option<i64>,
+    },
 }
 
 /// HTTP handler 统一错误类型。

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -95,9 +95,13 @@ impl FeishuPushService {
                                     }
                                 }
 
-                                // Extract workspace_id from Finished / LoopFinished event
+                                // Extract workspace_id from event (支持 Started, Output, Finished, TodoProgress, ExecutionStats, LoopFinished)
                                 let event_workspace_id = match &ev {
+                                    ExecEvent::Started { workspace_id, .. } => *workspace_id,
+                                    ExecEvent::Output { workspace_id, .. } => *workspace_id,
                                     ExecEvent::Finished { workspace_id, .. } => *workspace_id,
+                                    ExecEvent::TodoProgress { workspace_id, .. } => *workspace_id,
+                                    ExecEvent::ExecutionStats { workspace_id, .. } => *workspace_id,
                                     ExecEvent::LoopFinished { workspace_id, .. } => *workspace_id,
                                     _ => None,
                                 };
@@ -209,7 +213,7 @@ impl FeishuPushService {
                     todo_title, executor, task_id
                 ))
             }
-            ExecEvent::Output { task_id, entry } => {
+            ExecEvent::Output { task_id, entry, .. } => {
                 let prefix = match entry.log_type.as_str() {
                     "error" | "stderr" => "🔴",
                     "warning" => "⚠️",
@@ -251,7 +255,7 @@ impl FeishuPushService {
                     total_tokens
                 ))
             }
-            ExecEvent::TodoProgress { task_id, progress } => {
+            ExecEvent::TodoProgress { task_id, progress, .. } => {
                 if progress.is_empty() {
                     None
                 } else {
@@ -265,7 +269,7 @@ impl FeishuPushService {
                     ))
                 }
             }
-            ExecEvent::ExecutionStats { task_id, stats } => {
+            ExecEvent::ExecutionStats { task_id, stats, .. } => {
                 Some(format!(
                     "📊 [执行统计] TaskID: {}\n🔧 工具调用: {}\n💬 对话轮次: {}",
                     task_id, stats.tool_calls, stats.conversation_turns

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -70,29 +70,32 @@ impl FeishuPushService {
 
                                 // For Finished events with feishu_chat_id (binding chat), send directly
                                 // 但需要先检查该 bot 的 push_level 配置
+                                let mut binding_sent = false;
                                 if let ExecEvent::Finished { feishu_bot_id, feishu_receive_id, .. } = &ev {
                                     if let (Some(bot_id), Some(receive_id)) = (feishu_bot_id, feishu_receive_id) {
                                         // 查询该 bot 的 push_level 配置
                                         let push_level = Self::get_bot_push_level(&db, *bot_id).await;
                                         
                                         // 检查 push_level 配置是否允许发送
-                                        if !Self::should_send(&push_level, &ev) {
-                                            debug!("[feishu-push] binding send skipped for bot {} due to push_level={}", bot_id, push_level);
-                                            // 配置不允许发送时，跳过 push target 路径
-                                            continue;
-                                        }
-                                        
-                                        let text = Self::format_event(&ev).unwrap_or_default();
-                                        let receive_id_type = "open_id"; // binding chats are p2p
-                                        let res = feishu_listener.send_raw(*bot_id, receive_id, receive_id_type, &text).await;
-                                        if let Err(e) = res {
-                                            warn!("[feishu-push] binding direct send failed for bot {}: {}", bot_id, e);
+                                        if Self::should_send(&push_level, &ev) {
+                                            let text = Self::format_event(&ev).unwrap_or_default();
+                                            let receive_id_type = "open_id"; // binding chats are p2p
+                                            let res = feishu_listener.send_raw(*bot_id, receive_id, receive_id_type, &text).await;
+                                            if let Err(e) = res {
+                                                warn!("[feishu-push] binding direct send failed for bot {}: {}", bot_id, e);
+                                            } else {
+                                                debug!("[feishu-push] binding direct sent to bot {}: {}", bot_id, &text[..text.len().min(60)]);
+                                            }
+                                            binding_sent = true;
                                         } else {
-                                            debug!("[feishu-push] binding direct sent to bot {}: {}", bot_id, &text[..text.len().min(60)]);
+                                            debug!("[feishu-push] binding send skipped for bot {} due to push_level={}", bot_id, push_level);
+                                            // 仅跳过 binding 路径，继续执行下面的 workspace push target 逻辑
                                         }
-                                        // 直发成功后跳过 push target 路径，避免重复发送
-                                        continue;
                                     }
+                                }
+                                // binding direct send 成功后跳过 push target 路径，避免重复发送
+                                if binding_sent {
+                                    continue;
                                 }
 
                                 // Extract workspace_id from event (支持 Started, Output, Finished, TodoProgress, ExecutionStats, LoopFinished)
@@ -176,7 +179,9 @@ impl FeishuPushService {
     }
 
     /// 获取指定 bot 的 push_level 配置。
-    /// 如果 bot 不存在或未配置 push_target，返回默认值 "result_only"。
+    /// - bot 存在且有配置：返回实际配置值
+    /// - bot 未配置 push_target：返回默认 "result_only"（兼容旧数据）
+    /// - 数据库查询失败：fail closed 返回 "disabled"（安全优先，避免配置无法校验时误发）
     async fn get_bot_push_level(db: &Database, bot_id: i64) -> String {
         match db.get_feishu_push_target(bot_id).await {
             Ok(Some(target)) => target.push_level,
@@ -186,8 +191,9 @@ impl FeishuPushService {
                 "result_only".to_string()
             }
             Err(e) => {
-                warn!("[feishu-push] failed to get push_target for bot {}: {}, using default 'result_only'", bot_id, e);
-                "result_only".to_string()
+                // 数据库读取失败时 fail closed：宁可漏发也不能误发
+                warn!("[feishu-push] failed to get push_target for bot {}: {}, fail closed to 'disabled'", bot_id, e);
+                "disabled".to_string()
             }
         }
     }
@@ -285,6 +291,8 @@ impl FeishuPushService {
                     "success" => "✅ 成功",
                     "failed" => "❌ 失败",
                     "partial" => "⚠️ 部分成功",
+                    "capped_step" => "🚫 步数超限",
+                    "capped_token" => "🚫 Token超限",
                     _ => "ℹ️ 完成",
                 };
                 
@@ -395,6 +403,7 @@ mod feishu_push_binding_tests {
             todo_id: 1,
             todo_title: "Test Todo".to_string(),
             executor: "claudecode".to_string(),
+            workspace_id: None,
         };
         
         assert!(!FeishuPushService::should_send(push_level, &event));
@@ -409,6 +418,7 @@ mod feishu_push_binding_tests {
             todo_id: 1,
             todo_title: "Test Todo".to_string(),
             executor: "claudecode".to_string(),
+            workspace_id: None,
         };
         
         assert!(FeishuPushService::should_send(push_level, &event));
@@ -423,6 +433,7 @@ mod feishu_push_binding_tests {
             todo_id: 1,
             todo_title: "Test Todo".to_string(),
             executor: "claudecode".to_string(),
+            workspace_id: None,
         };
         
         assert!(!FeishuPushService::should_send(push_level, &event));

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -229,16 +229,26 @@ impl FeishuPushService {
                     Some(format!("{} {}\n🆔 {}", prefix, preview, task_id))
                 }
             }
-            ExecEvent::Finished { success, result, todo_title, executor, .. } => {
-                let result_preview = result.as_ref()
-                    .map(|r| format!("\n\n📤 结果: {}", if r.chars().count() > 100 { r.chars().take(100).collect::<String>() + "..." } else { r.clone() }))
-                    .unwrap_or_default();
+            ExecEvent::Finished { success, todo_title, executor, duration_secs, total_tokens, .. } => {
+                // 格式化时长（与 LoopFinished 风格一致）
+                let duration_str = if *duration_secs >= 3600 {
+                    let hours = *duration_secs / 3600;
+                    let mins = (*duration_secs % 3600) / 60;
+                    format!("{}h {}m", hours, mins)
+                } else if *duration_secs >= 60 {
+                    let mins = *duration_secs / 60;
+                    let secs = *duration_secs % 60;
+                    format!("{}m {}s", mins, secs)
+                } else {
+                    format!("{}s", *duration_secs)
+                };
                 Some(format!(
-                    "📋 {}\n⚡ 执行器: {}\n{}{}",
+                    "📋 {}\n⚡ 执行器: {}\n{}\n⏱️ 用时 {} | 🔤 Token {}",
                     todo_title,
                     executor,
                     if *success { "✅ 成功" } else { "❌ 失败" },
-                    result_preview
+                    duration_str,
+                    total_tokens
                 ))
             }
             ExecEvent::TodoProgress { task_id, progress } => {
@@ -323,6 +333,8 @@ mod feishu_push_binding_tests {
             feishu_bot_id: Some(1),
             feishu_receive_id: Some("user_open_id".to_string()),
             workspace_id: Some(1),
+            duration_secs: 0,
+            total_tokens: 0,
         };
         
         assert!(!FeishuPushService::should_send(push_level, &event));
@@ -342,6 +354,8 @@ mod feishu_push_binding_tests {
             feishu_bot_id: Some(1),
             feishu_receive_id: Some("user_open_id".to_string()),
             workspace_id: Some(1),
+            duration_secs: 0,
+            total_tokens: 0,
         };
         
         assert!(FeishuPushService::should_send(push_level, &event));
@@ -361,6 +375,8 @@ mod feishu_push_binding_tests {
             feishu_bot_id: Some(1),
             feishu_receive_id: Some("user_open_id".to_string()),
             workspace_id: Some(1),
+            duration_secs: 0,
+            total_tokens: 0,
         };
         
         assert!(FeishuPushService::should_send(push_level, &event));

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -272,10 +272,14 @@ impl FeishuPushService {
                         let trimmed = r.trim();
                         if trimmed.is_empty() {
                             String::new()
-                        } else if trimmed.chars().count() > 300 {
-                            format!("\n\n📤 结果:\n{}...", trimmed.chars().take(300).collect::<String>())
                         } else {
-                            format!("\n\n📤 结果:\n{}", trimmed)
+                            // 飞书消息长度限制约 4000 字符，为标题和状态预留空间
+                            const MAX_RESULT_CHARS: usize = 3500;
+                            if trimmed.chars().count() > MAX_RESULT_CHARS {
+                                format!("\n\n📤 结果:\n{}...", trimmed.chars().take(MAX_RESULT_CHARS).collect::<String>())
+                            } else {
+                                format!("\n\n📤 结果:\n{}", trimmed)
+                            }
                         }
                     })
                     .unwrap_or_default();

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -69,8 +69,19 @@ impl FeishuPushService {
                                 }
 
                                 // For Finished events with feishu_chat_id (binding chat), send directly
+                                // 但需要先检查该 bot 的 push_level 配置
                                 if let ExecEvent::Finished { feishu_bot_id, feishu_receive_id, .. } = &ev {
                                     if let (Some(bot_id), Some(receive_id)) = (feishu_bot_id, feishu_receive_id) {
+                                        // 查询该 bot 的 push_level 配置
+                                        let push_level = Self::get_bot_push_level(&db, *bot_id).await;
+                                        
+                                        // 检查 push_level 配置是否允许发送
+                                        if !Self::should_send(&push_level, &ev) {
+                                            debug!("[feishu-push] binding send skipped for bot {} due to push_level={}", bot_id, push_level);
+                                            // 配置不允许发送时，跳过 push target 路径
+                                            continue;
+                                        }
+                                        
                                         let text = Self::format_event(&ev).unwrap_or_default();
                                         let receive_id_type = "open_id"; // binding chats are p2p
                                         let res = feishu_listener.send_raw(*bot_id, receive_id, receive_id_type, &text).await;
@@ -159,6 +170,23 @@ impl FeishuPushService {
         }
     }
 
+    /// 获取指定 bot 的 push_level 配置。
+    /// 如果 bot 不存在或未配置 push_target，返回默认值 "result_only"。
+    async fn get_bot_push_level(db: &Database, bot_id: i64) -> String {
+        match db.get_feishu_push_target(bot_id).await {
+            Ok(Some(target)) => target.push_level,
+            Ok(None) => {
+                // bot 未配置 push_target，使用默认值
+                debug!("[feishu-push] bot {} has no push_target config, using default 'result_only'", bot_id);
+                "result_only".to_string()
+            }
+            Err(e) => {
+                warn!("[feishu-push] failed to get push_target for bot {}: {}, using default 'result_only'", bot_id, e);
+                "result_only".to_string()
+            }
+        }
+    }
+
     async fn refresh_targets(db: &Database, targets: &mut std::collections::HashMap<Option<i64>, Vec<(i64, String, String, String)>>) {
         targets.clear();
         match db.get_all_push_targets_by_workspace().await {
@@ -237,5 +265,118 @@ impl FeishuPushService {
             // ExecutorDirectResponse 由 FeishuPushService 直接发送，不走 format_event
             ExecEvent::ExecutorDirectResponse { .. } => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod feishu_push_binding_tests {
+    //! 验证 binding direct send 场景下的 push_level 检查逻辑。
+    //! 
+    //! 修复背景：事项执行完成后，Finished 事件带有 feishu_bot_id/receive_id 时，
+    //! 原代码直接发送，绕过了 push_level 配置检查。用户配置"仅结论"时，
+    //! 应该发送完成消息；配置"关闭"时，应该不发送任何消息。
+    //! 
+    //! 修复方案：在 binding direct send 前查询 bot 的 push_level 配置，
+    //! 使用 should_send 函数判断是否允许发送。
+
+    use super::*;
+
+    /// 测试 push_level="disabled" 时，Finished 事件不应该发送
+    #[test]
+    fn test_should_send_disabled_blocks_finished_event() {
+        let push_level = "disabled";
+        let event = ExecEvent::Finished {
+            task_id: "test-123".to_string(),
+            todo_id: 1,
+            todo_title: "Test Todo".to_string(),
+            executor: "claudecode".to_string(),
+            success: true,
+            result: Some("完成".to_string()),
+            feishu_bot_id: Some(1),
+            feishu_receive_id: Some("user_open_id".to_string()),
+            workspace_id: Some(1),
+        };
+        
+        assert!(!FeishuPushService::should_send(push_level, &event));
+    }
+
+    /// 测试 push_level="result_only" 时，Finished 事件应该发送
+    #[test]
+    fn test_should_send_result_only_allows_finished_event() {
+        let push_level = "result_only";
+        let event = ExecEvent::Finished {
+            task_id: "test-123".to_string(),
+            todo_id: 1,
+            todo_title: "Test Todo".to_string(),
+            executor: "claudecode".to_string(),
+            success: true,
+            result: Some("完成".to_string()),
+            feishu_bot_id: Some(1),
+            feishu_receive_id: Some("user_open_id".to_string()),
+            workspace_id: Some(1),
+        };
+        
+        assert!(FeishuPushService::should_send(push_level, &event));
+    }
+
+    /// 测试 push_level="all" 时，Finished 事件应该发送
+    #[test]
+    fn test_should_send_all_allows_finished_event() {
+        let push_level = "all";
+        let event = ExecEvent::Finished {
+            task_id: "test-123".to_string(),
+            todo_id: 1,
+            todo_title: "Test Todo".to_string(),
+            executor: "claudecode".to_string(),
+            success: true,
+            result: Some("完成".to_string()),
+            feishu_bot_id: Some(1),
+            feishu_receive_id: Some("user_open_id".to_string()),
+            workspace_id: Some(1),
+        };
+        
+        assert!(FeishuPushService::should_send(push_level, &event));
+    }
+
+    /// 测试 push_level="result_only" 时，Started 事件不应该发送
+    #[test]
+    fn test_should_send_result_only_blocks_started_event() {
+        let push_level = "result_only";
+        let event = ExecEvent::Started {
+            task_id: "test-123".to_string(),
+            todo_id: 1,
+            todo_title: "Test Todo".to_string(),
+            executor: "claudecode".to_string(),
+        };
+        
+        assert!(!FeishuPushService::should_send(push_level, &event));
+    }
+
+    /// 测试 push_level="all" 时，Started 事件应该发送
+    #[test]
+    fn test_should_send_all_allows_started_event() {
+        let push_level = "all";
+        let event = ExecEvent::Started {
+            task_id: "test-123".to_string(),
+            todo_id: 1,
+            todo_title: "Test Todo".to_string(),
+            executor: "claudecode".to_string(),
+        };
+        
+        assert!(FeishuPushService::should_send(push_level, &event));
+    }
+
+    /// 测试 push_level="disabled" 时，Started 事件不应该发送
+    #[test]
+    fn test_should_send_disabled_blocks_started_event() {
+        let push_level = "disabled";
+        let event = ExecEvent::Started {
+            task_id: "test-123".to_string(),
+            todo_id: 1,
+            todo_title: "Test Todo".to_string(),
+            executor: "claudecode".to_string(),
+        };
+        
+        assert!(!FeishuPushService::should_send(push_level, &event));
     }
 }

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -265,33 +265,31 @@ impl FeishuPushService {
             ExecEvent::ReviewStatusChanged { .. } => None,
             // ExecutorDirectResponse 由 FeishuPushService 直接发送，不走 format_event
             ExecEvent::ExecutorDirectResponse { .. } => None,
-            // LoopFinished 事件的格式化消息
-            ExecEvent::LoopFinished { loop_title, status, result, .. } => {
-                let result_preview = result.as_ref()
-                    .map(|r| {
-                        let trimmed = r.trim();
-                        if trimmed.is_empty() {
-                            String::new()
-                        } else {
-                            // 飞书消息长度限制约 4000 字符，为标题和状态预留空间
-                            const MAX_RESULT_CHARS: usize = 3500;
-                            if trimmed.chars().count() > MAX_RESULT_CHARS {
-                                format!("\n\n📤 结果:\n{}...", trimmed.chars().take(MAX_RESULT_CHARS).collect::<String>())
-                            } else {
-                                format!("\n\n📤 结果:\n{}", trimmed)
-                            }
-                        }
-                    })
-                    .unwrap_or_default();
+            // LoopFinished 事件的格式化消息 - 统计摘要
+            ExecEvent::LoopFinished { loop_title, status, total_steps, completed_steps, failed_steps, duration_secs, total_tokens, .. } => {
                 let status_icon = match status.as_str() {
                     "success" => "✅ 成功",
                     "failed" => "❌ 失败",
                     "partial" => "⚠️ 部分成功",
                     _ => "ℹ️ 完成",
                 };
+                
+                // 格式化时长
+                let duration_str = if *duration_secs >= 3600 {
+                    let hours = *duration_secs / 3600;
+                    let mins = (*duration_secs % 3600) / 60;
+                    format!("{}h {}m", hours, mins)
+                } else if *duration_secs >= 60 {
+                    let mins = *duration_secs / 60;
+                    let secs = *duration_secs % 60;
+                    format!("{}m {}s", mins, secs)
+                } else {
+                    format!("{}s", *duration_secs)
+                };
+                
                 Some(format!(
-                    "🔁 [环路执行完成]\n📋 {}\n{} {}",
-                    loop_title, status_icon, result_preview
+                    "🔁 [环路执行完成]\n📋 {}\n{} | 共 {} 步 | 成功 {} | 失败 {}\n⏱️ 用时 {} | 🔤 Token {}",
+                    loop_title, status_icon, *total_steps, *completed_steps, *failed_steps, duration_str, *total_tokens
                 ))
             }
         }
@@ -421,7 +419,11 @@ mod feishu_push_binding_tests {
             loop_id: 1,
             loop_title: "Test Loop".to_string(),
             status: "success".to_string(),
-            result: Some("完成".to_string()),
+            total_steps: 3,
+            completed_steps: 3,
+            failed_steps: 0,
+            duration_secs: 120,
+            total_tokens: 500,
             workspace_id: Some(1),
         };
         
@@ -437,7 +439,11 @@ mod feishu_push_binding_tests {
             loop_id: 1,
             loop_title: "Test Loop".to_string(),
             status: "success".to_string(),
-            result: Some("完成".to_string()),
+            total_steps: 3,
+            completed_steps: 3,
+            failed_steps: 0,
+            duration_secs: 120,
+            total_tokens: 500,
             workspace_id: Some(1),
         };
         
@@ -453,14 +459,18 @@ mod feishu_push_binding_tests {
             loop_id: 1,
             loop_title: "Test Loop".to_string(),
             status: "success".to_string(),
-            result: Some("完成".to_string()),
+            total_steps: 3,
+            completed_steps: 3,
+            failed_steps: 0,
+            duration_secs: 120,
+            total_tokens: 500,
             workspace_id: Some(1),
         };
         
         assert!(FeishuPushService::should_send(push_level, &event));
     }
 
-    /// 测试 LoopFinished 事件的格式化输出
+    /// 测试 LoopFinished 事件的格式化输出 - 成功状态
     #[test]
     fn test_format_loop_finished_success() {
         let event = ExecEvent::LoopFinished {
@@ -468,7 +478,11 @@ mod feishu_push_binding_tests {
             loop_id: 1,
             loop_title: "测试环路".to_string(),
             status: "success".to_string(),
-            result: Some("执行成功，结果如下".to_string()),
+            total_steps: 3,
+            completed_steps: 3,
+            failed_steps: 0,
+            duration_secs: 125,
+            total_tokens: 500,
             workspace_id: Some(1),
         };
         
@@ -476,7 +490,11 @@ mod feishu_push_binding_tests {
         assert!(formatted.contains("🔁 [环路执行完成]"));
         assert!(formatted.contains("测试环路"));
         assert!(formatted.contains("✅ 成功"));
-        assert!(formatted.contains("执行成功，结果如下"));
+        assert!(formatted.contains("共 3 步"));
+        assert!(formatted.contains("成功 3"));
+        assert!(formatted.contains("失败 0"));
+        assert!(formatted.contains("2m 5s"));
+        assert!(formatted.contains("Token 500"));
     }
 
     /// 测试 LoopFinished 失败状态的格式化输出
@@ -487,29 +505,43 @@ mod feishu_push_binding_tests {
             loop_id: 1,
             loop_title: "测试环路".to_string(),
             status: "failed".to_string(),
-            result: Some("执行失败".to_string()),
+            total_steps: 3,
+            completed_steps: 0,
+            failed_steps: 3,
+            duration_secs: 30,
+            total_tokens: 100,
             workspace_id: Some(1),
         };
         
         let formatted = FeishuPushService::format_event(&event).unwrap();
         assert!(formatted.contains("❌ 失败"));
-        assert!(formatted.contains("执行失败"));
+        assert!(formatted.contains("成功 0"));
+        assert!(formatted.contains("失败 3"));
+        assert!(formatted.contains("30s"));
     }
 
-    /// 测试 LoopFinished 无结果时的格式化输出
+    /// 测试 LoopFinished 部分成功状态的格式化输出
     #[test]
-    fn test_format_loop_finished_no_result() {
+    fn test_format_loop_finished_partial() {
         let event = ExecEvent::LoopFinished {
             loop_execution_id: 1,
             loop_id: 1,
             loop_title: "测试环路".to_string(),
-            status: "success".to_string(),
-            result: None,
+            status: "partial".to_string(),
+            total_steps: 5,
+            completed_steps: 3,
+            failed_steps: 2,
+            duration_secs: 3661,
+            total_tokens: 1000,
             workspace_id: Some(1),
         };
         
         let formatted = FeishuPushService::format_event(&event).unwrap();
-        assert!(formatted.contains("🔁 [环路执行完成]"));
-        assert!(formatted.contains("✅ 成功"));
+        assert!(formatted.contains("⚠️ 部分成功"));
+        assert!(formatted.contains("共 5 步"));
+        assert!(formatted.contains("成功 3"));
+        assert!(formatted.contains("失败 2"));
+        assert!(formatted.contains("1h 1m"));
+        assert!(formatted.contains("Token 1000"));
     }
 }

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -95,9 +95,10 @@ impl FeishuPushService {
                                     }
                                 }
 
-                                // Extract workspace_id from Finished event
+                                // Extract workspace_id from Finished / LoopFinished event
                                 let event_workspace_id = match &ev {
                                     ExecEvent::Finished { workspace_id, .. } => *workspace_id,
+                                    ExecEvent::LoopFinished { workspace_id, .. } => *workspace_id,
                                     _ => None,
                                 };
 
@@ -159,12 +160,12 @@ impl FeishuPushService {
 
     /// Check if an event should be sent based on push_level.
     /// - "disabled": never send
-    /// - "result_only": only send Finished events
+    /// - "result_only": only send Finished / LoopFinished events (执行结果)
     /// - "all": send all events
     fn should_send(push_level: &str, event: &ExecEvent) -> bool {
         match push_level {
             "disabled" => false,
-            "result_only" => matches!(event, ExecEvent::Finished { .. }),
+            "result_only" => matches!(event, ExecEvent::Finished { .. } | ExecEvent::LoopFinished { .. }),
             "all" => true,
             _ => false,
         }
@@ -264,6 +265,31 @@ impl FeishuPushService {
             ExecEvent::ReviewStatusChanged { .. } => None,
             // ExecutorDirectResponse 由 FeishuPushService 直接发送，不走 format_event
             ExecEvent::ExecutorDirectResponse { .. } => None,
+            // LoopFinished 事件的格式化消息
+            ExecEvent::LoopFinished { loop_title, status, result, .. } => {
+                let result_preview = result.as_ref()
+                    .map(|r| {
+                        let trimmed = r.trim();
+                        if trimmed.is_empty() {
+                            String::new()
+                        } else if trimmed.chars().count() > 300 {
+                            format!("\n\n📤 结果:\n{}...", trimmed.chars().take(300).collect::<String>())
+                        } else {
+                            format!("\n\n📤 结果:\n{}", trimmed)
+                        }
+                    })
+                    .unwrap_or_default();
+                let status_icon = match status.as_str() {
+                    "success" => "✅ 成功",
+                    "failed" => "❌ 失败",
+                    "partial" => "⚠️ 部分成功",
+                    _ => "ℹ️ 完成",
+                };
+                Some(format!(
+                    "🔁 [环路执行完成]\n📋 {}\n{} {}",
+                    loop_title, status_icon, result_preview
+                ))
+            }
         }
     }
 }
@@ -378,5 +404,108 @@ mod feishu_push_binding_tests {
         };
         
         assert!(!FeishuPushService::should_send(push_level, &event));
+    }
+
+    // ========== LoopFinished 事件测试 ==========
+
+    /// 测试 push_level="disabled" 时，LoopFinished 事件不应该发送
+    #[test]
+    fn test_should_send_disabled_blocks_loop_finished_event() {
+        let push_level = "disabled";
+        let event = ExecEvent::LoopFinished {
+            loop_execution_id: 1,
+            loop_id: 1,
+            loop_title: "Test Loop".to_string(),
+            status: "success".to_string(),
+            result: Some("完成".to_string()),
+            workspace_id: Some(1),
+        };
+        
+        assert!(!FeishuPushService::should_send(push_level, &event));
+    }
+
+    /// 测试 push_level="result_only" 时，LoopFinished 事件应该发送
+    #[test]
+    fn test_should_send_result_only_allows_loop_finished_event() {
+        let push_level = "result_only";
+        let event = ExecEvent::LoopFinished {
+            loop_execution_id: 1,
+            loop_id: 1,
+            loop_title: "Test Loop".to_string(),
+            status: "success".to_string(),
+            result: Some("完成".to_string()),
+            workspace_id: Some(1),
+        };
+        
+        assert!(FeishuPushService::should_send(push_level, &event));
+    }
+
+    /// 测试 push_level="all" 时，LoopFinished 事件应该发送
+    #[test]
+    fn test_should_send_all_allows_loop_finished_event() {
+        let push_level = "all";
+        let event = ExecEvent::LoopFinished {
+            loop_execution_id: 1,
+            loop_id: 1,
+            loop_title: "Test Loop".to_string(),
+            status: "success".to_string(),
+            result: Some("完成".to_string()),
+            workspace_id: Some(1),
+        };
+        
+        assert!(FeishuPushService::should_send(push_level, &event));
+    }
+
+    /// 测试 LoopFinished 事件的格式化输出
+    #[test]
+    fn test_format_loop_finished_success() {
+        let event = ExecEvent::LoopFinished {
+            loop_execution_id: 1,
+            loop_id: 1,
+            loop_title: "测试环路".to_string(),
+            status: "success".to_string(),
+            result: Some("执行成功，结果如下".to_string()),
+            workspace_id: Some(1),
+        };
+        
+        let formatted = FeishuPushService::format_event(&event).unwrap();
+        assert!(formatted.contains("🔁 [环路执行完成]"));
+        assert!(formatted.contains("测试环路"));
+        assert!(formatted.contains("✅ 成功"));
+        assert!(formatted.contains("执行成功，结果如下"));
+    }
+
+    /// 测试 LoopFinished 失败状态的格式化输出
+    #[test]
+    fn test_format_loop_finished_failed() {
+        let event = ExecEvent::LoopFinished {
+            loop_execution_id: 1,
+            loop_id: 1,
+            loop_title: "测试环路".to_string(),
+            status: "failed".to_string(),
+            result: Some("执行失败".to_string()),
+            workspace_id: Some(1),
+        };
+        
+        let formatted = FeishuPushService::format_event(&event).unwrap();
+        assert!(formatted.contains("❌ 失败"));
+        assert!(formatted.contains("执行失败"));
+    }
+
+    /// 测试 LoopFinished 无结果时的格式化输出
+    #[test]
+    fn test_format_loop_finished_no_result() {
+        let event = ExecEvent::LoopFinished {
+            loop_execution_id: 1,
+            loop_id: 1,
+            loop_title: "测试环路".to_string(),
+            status: "success".to_string(),
+            result: None,
+            workspace_id: Some(1),
+        };
+        
+        let formatted = FeishuPushService::format_event(&event).unwrap();
+        assert!(formatted.contains("🔁 [环路执行完成]"));
+        assert!(formatted.contains("✅ 成功"));
     }
 }

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -183,20 +183,39 @@ impl LoopRunner {
         let this2 = self.clone();
         let this2_for_err = self.clone();
         let this2_for_callback = self.clone();
+        let this2_for_event = self.clone();
         tokio::spawn(async move {
             let run_result = this2
                 .run_inner(loop_id, loop_execution_id, trigger_type)
                 .await;
 
+            // 获取 loop 信息（标题、workspace_id）用于 LoopFinished 事件
+            let loop_info = this2_for_event.ctx.db.get_loop(loop_id).await.ok().flatten();
+            let loop_title = loop_info.as_ref().map(|l| l.name.clone()).unwrap_or_else(|| format!("Loop #{}", loop_id));
+            let loop_workspace_id = loop_info.as_ref().and_then(|l| l.workspace_id);
+
             match run_result {
                 Ok(()) => {
-                    // 环路执行成功：获取黑板文本并通过 ExecutorDirectResponse 发回飞书
+                    // 获取最终执行状态（从 run_inner 内的 finish_loop_execution 写入）
+                    let final_status = this2_for_event
+                        .ctx
+                        .db
+                        .get_loop_execution(loop_execution_id)
+                        .await
+                        .ok()
+                        .flatten()
+                        .map(|le| le.status)
+                        .unwrap_or_else(|| "success".to_string());
+
+                    // 环路执行成功：获取黑板文本
+                    let blackboard = this2_for_callback
+                        .get_loop_blackboard_text(loop_execution_id, &trigger_meta)
+                        .await;
+
+                    // 如果有 feishu_receive_id，直接回复原对话（binding chat 场景）
                     if let Some(ref receive_id) = feishu_receive_id {
-                        let blackboard = this2_for_callback
-                            .get_loop_blackboard_text(loop_execution_id, &trigger_meta)
-                            .await;
                         info!(
-                            "[loop-runner] loop {} execution {} completed, sending result to Feishu",
+                            "[loop-runner] loop {} execution {} completed, sending result to Feishu binding chat",
                             loop_id, loop_execution_id
                         );
                         this2_for_callback
@@ -206,6 +225,21 @@ impl LoopRunner {
                                 &blackboard,
                             )
                             .await;
+                    } else {
+                        // 没有绑定对话时，通过 LoopFinished 事件广播，
+                        // FeishuPushService 会按 workspace 配置的 push_level 推送
+                        info!(
+                            "[loop-runner] loop {} execution {} completed, broadcasting LoopFinished event",
+                            loop_id, loop_execution_id
+                        );
+                        let _ = this2_for_event.tx.send(crate::handlers::ExecEvent::LoopFinished {
+                            loop_execution_id,
+                            loop_id,
+                            loop_title,
+                            status: final_status,
+                            result: Some(blackboard),
+                            workspace_id: loop_workspace_id,
+                        });
                     }
                 }
                 Err(e) => {
@@ -236,7 +270,7 @@ impl LoopRunner {
                             todo_id: 0,
                             review_status: "failed".to_string(),
                         });
-                    // 失败路径也发回消息
+                    // 失败路径：有绑定对话时直接回复，否则广播 LoopFinished 事件
                     if let Some(ref receive_id) = feishu_receive_id {
                         this2_for_err
                             .send_result_to_feishu(
@@ -245,6 +279,16 @@ impl LoopRunner {
                                 &format!("环路执行失败：{}", e),
                             )
                             .await;
+                    } else {
+                        // 广播 LoopFinished 事件，FeishuPushService 按 workspace 配置推送
+                        let _ = this2_for_err.tx.send(crate::handlers::ExecEvent::LoopFinished {
+                            loop_execution_id,
+                            loop_id,
+                            loop_title: loop_title.clone(),
+                            status: "failed".to_string(),
+                            result: Some(format!("环路执行失败：{}", e)),
+                            workspace_id: loop_workspace_id,
+                        });
                     }
                 }
             }

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -59,6 +59,16 @@ pub struct LoopRunner {
     tx: broadcast::Sender<crate::handlers::ExecEvent>,
 }
 
+/// Loop 执行结果：区分「真正完成」和「暂停等待」，
+/// 用于避免人工审批等暂停状态误发 LoopFinished 事件。
+#[derive(Debug, PartialEq)]
+enum LoopRunOutcome {
+    /// 正常执行完成（终态：success / failed / partial / capped_step / capped_token）
+    Finished,
+    /// 暂停等待（非终态：如人工审批 pending_approval）
+    Paused,
+}
+
 impl LoopRunner {
     pub fn new(
         ctx: LoopRunnerCtx,
@@ -150,6 +160,8 @@ impl LoopRunner {
         trigger_meta: serde_json::Value,
         feishu_bot_id: Option<i64>,
         feishu_receive_id: Option<String>,
+        // 接收者 ID 类型（"open_id" / "chat_id"），用于飞书消息发送
+        feishu_receive_id_type: Option<String>,
     ) -> i64 {
         let this = self.clone();
         let trigger_type = trigger_type.to_string();
@@ -198,16 +210,19 @@ impl LoopRunner {
             let loop_exec = this2_for_event.ctx.db.get_loop_execution(loop_execution_id).await.ok().flatten();
             let (final_status, total_steps, completed_steps, failed_steps, duration_secs) = match loop_exec {
                 Some(le) => {
-                    // 计算执行时长
+                    // 计算执行时长：仅当起止时间都能解析且 finish >= start 时才计算，否则返回 0
                     let duration = match (le.started_at.as_str(), le.finished_at.as_deref()) {
                         (start, Some(finish)) => {
-                            let start_ts = chrono::DateTime::parse_from_rfc3339(start)
-                                .map(|dt| dt.timestamp())
-                                .unwrap_or(0);
-                            let finish_ts = chrono::DateTime::parse_from_rfc3339(finish)
-                                .map(|dt| dt.timestamp())
-                                .unwrap_or(0);
-                            finish_ts - start_ts
+                            match (
+                                chrono::DateTime::parse_from_rfc3339(start),
+                                chrono::DateTime::parse_from_rfc3339(finish),
+                            ) {
+                                (Ok(start_dt), Ok(finish_dt)) => {
+                                    let secs = finish_dt.timestamp() - start_dt.timestamp();
+                                    if secs >= 0 { secs } else { 0 }
+                                }
+                                _ => 0,
+                            }
                         }
                         _ => 0,
                     };
@@ -220,7 +235,7 @@ impl LoopRunner {
             let total_tokens = this2_for_event.get_loop_total_tokens(loop_execution_id).await;
 
             match run_result {
-                Ok(()) => {
+                Ok(LoopRunOutcome::Finished) => {
                     // 如果有 feishu_receive_id，直接回复原对话（binding chat 场景）- 发送黑板全文
                     if let Some(ref receive_id) = feishu_receive_id {
                         let blackboard = this2_for_callback
@@ -234,6 +249,7 @@ impl LoopRunner {
                             .send_result_to_feishu(
                                 feishu_bot_id,
                                 receive_id,
+                                feishu_receive_id_type.as_deref().unwrap_or("open_id"),
                                 &blackboard,
                             )
                             .await;
@@ -257,6 +273,14 @@ impl LoopRunner {
                             workspace_id: loop_workspace_id,
                         });
                     }
+                }
+                Ok(LoopRunOutcome::Paused) => {
+                    // 暂停状态（如人工审批等待中）：不发送 LoopFinished 事件，
+                    // 也不做终态化处理，loop_execution 保持 running 状态
+                    info!(
+                        "[loop-runner] loop {} execution {} paused (waiting for human approval)",
+                        loop_id, loop_execution_id
+                    );
                 }
                 Err(e) => {
                     error!("loop_runner: run failed: {}", e);
@@ -292,6 +316,7 @@ impl LoopRunner {
                             .send_result_to_feishu(
                                 feishu_bot_id,
                                 receive_id,
+                                feishu_receive_id_type.as_deref().unwrap_or("open_id"),
                                 &format!("环路执行失败：{}", e),
                             )
                             .await;
@@ -464,7 +489,7 @@ impl LoopRunner {
         loop_id: i64,
         loop_execution_id: i64,
         trigger_type: String,
-    ) -> Result<(), String> {
+    ) -> Result<LoopRunOutcome, String> {
         self.run_inner_from(loop_id, loop_execution_id, trigger_type, None).await
     }
 
@@ -476,7 +501,7 @@ impl LoopRunner {
         loop_execution_id: i64,
         trigger_type: String,
         resume_step_idx: Option<usize>,
-    ) -> Result<(), String> {
+    ) -> Result<LoopRunOutcome, String> {
         // 1. 校验 loop 状态
         let loop_ = self
             .ctx
@@ -502,7 +527,7 @@ impl LoopRunner {
                 .finish_loop_execution(loop_execution_id, "success", 0, 0, None)
                 .await
                 .map_err(|e| e.to_string())?;
-            return Ok(());
+            return Ok(LoopRunOutcome::Finished);
         }
 
         // 3. 校验所有步骤的 todo 是否都在同一工作空间下
@@ -601,7 +626,7 @@ impl LoopRunner {
                 let _ = self
                     .trigger_abnormal_handler(loop_id, loop_execution_id, "capped_step", total_executed, total_tokens_used)
                     .await;
-                return Ok(());
+                return Ok(LoopRunOutcome::Finished);
             }
             if total_tokens_used >= max_total_tokens {
                 info!(
@@ -617,7 +642,7 @@ impl LoopRunner {
                 let _ = self
                     .trigger_abnormal_handler(loop_id, loop_execution_id, "capped_token", total_executed, total_tokens_used)
                     .await;
-                return Ok(());
+                return Ok(LoopRunOutcome::Finished);
             }
 
             // 4b. 死循环检测：连续 5 次执行同一 step
@@ -736,7 +761,8 @@ impl LoopRunner {
                         review_status: "pending_approval".to_string(),
                     });
                     // 暂停循环（不写最终状态，loop execution 保持 running）
-                    return Ok(());
+                    // 返回 Paused 而非 Finished，避免误发 LoopFinished 事件
+                    return Ok(LoopRunOutcome::Paused);
                 }
                 // AI 自动评审：原有逻辑
                 self
@@ -836,7 +862,7 @@ impl LoopRunner {
             "loop #{} run done: status={} completed={} failed={} total_executed={}",
             loop_id, final_status, completed, failed, total_executed
         );
-        Ok(())
+        Ok(LoopRunOutcome::Finished)
     }
 
     /// 启动 step 的执行，使用增强后的 Prompt。
@@ -1053,17 +1079,19 @@ impl LoopRunner {
     }
 
     /// 通过 ExecutorDirectResponse 事件把环路执行结果发回飞书
+    /// receive_id_type: "open_id"（单聊）或 "chat_id"（群聊）
     pub async fn send_result_to_feishu(
         &self,
         feishu_bot_id: Option<i64>,
         receive_id: &str,
+        receive_id_type: &str,
         text: &str,
     ) {
         let Some(bot_id) = feishu_bot_id else { return };
         let _ = self.tx.send(crate::handlers::ExecEvent::ExecutorDirectResponse {
             bot_id,
             receive_id: receive_id.to_string(),
-            receive_id_type: "open_id".to_string(),
+            receive_id_type: receive_id_type.to_string(),
             content: text.to_string(),
         });
     }

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -194,26 +194,38 @@ impl LoopRunner {
             let loop_title = loop_info.as_ref().map(|l| l.name.clone()).unwrap_or_else(|| format!("Loop #{}", loop_id));
             let loop_workspace_id = loop_info.as_ref().and_then(|l| l.workspace_id);
 
+            // 获取 loop_execution 统计数据
+            let loop_exec = this2_for_event.ctx.db.get_loop_execution(loop_execution_id).await.ok().flatten();
+            let (final_status, total_steps, completed_steps, failed_steps, duration_secs) = match loop_exec {
+                Some(le) => {
+                    // 计算执行时长
+                    let duration = match (le.started_at.as_str(), le.finished_at.as_deref()) {
+                        (start, Some(finish)) => {
+                            let start_ts = chrono::DateTime::parse_from_rfc3339(start)
+                                .map(|dt| dt.timestamp())
+                                .unwrap_or(0);
+                            let finish_ts = chrono::DateTime::parse_from_rfc3339(finish)
+                                .map(|dt| dt.timestamp())
+                                .unwrap_or(0);
+                            finish_ts - start_ts
+                        }
+                        _ => 0,
+                    };
+                    (le.status, le.total_steps, le.completed_steps, le.failed_steps, duration)
+                }
+                None => ("failed".to_string(), 0, 0, 0, 0),
+            };
+
+            // 获取累计 Token 消耗（从所有 step executions 的 execution_record_id 查询）
+            let total_tokens = this2_for_event.get_loop_total_tokens(loop_execution_id).await;
+
             match run_result {
                 Ok(()) => {
-                    // 获取最终执行状态（从 run_inner 内的 finish_loop_execution 写入）
-                    let final_status = this2_for_event
-                        .ctx
-                        .db
-                        .get_loop_execution(loop_execution_id)
-                        .await
-                        .ok()
-                        .flatten()
-                        .map(|le| le.status)
-                        .unwrap_or_else(|| "success".to_string());
-
-                    // 环路执行成功：获取黑板文本
-                    let blackboard = this2_for_callback
-                        .get_loop_blackboard_text(loop_execution_id, &trigger_meta)
-                        .await;
-
-                    // 如果有 feishu_receive_id，直接回复原对话（binding chat 场景）
+                    // 如果有 feishu_receive_id，直接回复原对话（binding chat 场景）- 发送黑板全文
                     if let Some(ref receive_id) = feishu_receive_id {
+                        let blackboard = this2_for_callback
+                            .get_loop_blackboard_text(loop_execution_id, &trigger_meta)
+                            .await;
                         info!(
                             "[loop-runner] loop {} execution {} completed, sending result to Feishu binding chat",
                             loop_id, loop_execution_id
@@ -226,7 +238,7 @@ impl LoopRunner {
                             )
                             .await;
                     } else {
-                        // 没有绑定对话时，通过 LoopFinished 事件广播，
+                        // 没有绑定对话时，通过 LoopFinished 事件广播统计摘要，
                         // FeishuPushService 会按 workspace 配置的 push_level 推送
                         info!(
                             "[loop-runner] loop {} execution {} completed, broadcasting LoopFinished event",
@@ -237,7 +249,11 @@ impl LoopRunner {
                             loop_id,
                             loop_title,
                             status: final_status,
-                            result: Some(blackboard),
+                            total_steps,
+                            completed_steps,
+                            failed_steps,
+                            duration_secs,
+                            total_tokens,
                             workspace_id: loop_workspace_id,
                         });
                     }
@@ -286,7 +302,11 @@ impl LoopRunner {
                             loop_id,
                             loop_title: loop_title.clone(),
                             status: "failed".to_string(),
-                            result: Some(format!("环路执行失败：{}", e)),
+                            total_steps,
+                            completed_steps,
+                            failed_steps,
+                            duration_secs,
+                            total_tokens,
                             workspace_id: loop_workspace_id,
                         });
                     }
@@ -295,6 +315,28 @@ impl LoopRunner {
         });
 
         loop_execution_id
+    }
+
+    /// 获取 loop 执行的累计 Token 消耗。
+    /// 从所有 step_executions 的 execution_record_id 查询 execution_records 的 usage 字段。
+    async fn get_loop_total_tokens(&self, loop_execution_id: i64) -> i64 {
+        let step_execs = match self.ctx.db.list_loop_step_executions(loop_execution_id).await {
+            Ok(se) => se,
+            Err(_) => return 0,
+        };
+        
+        let mut total = 0i64;
+        for se in step_execs {
+            if let Some(record_id) = se.execution_record_id {
+                if let Some(rec) = self.ctx.db.get_execution_record(record_id).await.ok().flatten() {
+                    // usage 字段是 ExecutionUsage 类型
+                    if let Some(usage) = rec.usage {
+                        total += usage.input_tokens as i64 + usage.output_tokens as i64;
+                    }
+                }
+            }
+        }
+        total
     }
 
     /// 恢复被人工审批暂停的 loop 执行。

--- a/backend/src/services/loop_scheduler.rs
+++ b/backend/src/services/loop_scheduler.rs
@@ -221,7 +221,7 @@ impl LoopScheduler {
             let _ = self
                 .runner
                 .clone()
-                .spawn_run(loop_id, Some(trigger_id), "cron", meta, None, None);
+                .spawn_run(loop_id, Some(trigger_id), "cron", meta, None, None, None);
         }
         Ok(())
     }

--- a/backend/src/services/loop_trigger.rs
+++ b/backend/src/services/loop_trigger.rs
@@ -66,7 +66,7 @@ impl LoopTriggerDispatcher {
             "content_type": content_type.unwrap_or(""),
             "body": body.unwrap_or(""),
         });
-        let id = self.spawn_run(loop_id, None, "webhook", meta).await;
+        let id = self.spawn_run(loop_id, None, "webhook", meta, None, None).await;
         if id > 0 { Some(id) } else { None }
     }
 
@@ -120,7 +120,7 @@ impl LoopTriggerDispatcher {
                 "content": content,
             });
             let run_id = self
-                .spawn_run(t.loop_id, Some(t.id), "feishu_message", meta)
+                .spawn_run(t.loop_id, Some(t.id), "feishu_message", meta, Some(bot_id), Some(chat_id.to_string()))
                 .await;
             if run_id > 0 {
                 started.push(run_id);
@@ -163,7 +163,7 @@ impl LoopTriggerDispatcher {
                     "command": command,
                 });
                 let run_id = self
-                    .spawn_run(t.loop_id, Some(t.id), "feishu_command", meta)
+                    .spawn_run(t.loop_id, Some(t.id), "feishu_command", meta, Some(bot_id), None)
                     .await;
                 if run_id > 0 {
                     started.push(run_id);
@@ -198,7 +198,7 @@ impl LoopTriggerDispatcher {
                 "execution_record_id": record_id,
             });
             let run_id = self
-                .spawn_run(t.loop_id, Some(t.id), "todo_completed", meta)
+                .spawn_run(t.loop_id, Some(t.id), "todo_completed", meta, None, None)
                 .await;
             if run_id > 0 {
                 started.push(run_id);
@@ -240,8 +240,8 @@ impl LoopTriggerDispatcher {
                     "todo_id": todo_id,
                 });
                 let run_id = self
-                    .spawn_run(t.loop_id, Some(t.id), "tag_added", meta)
-                    .await;
+                        .spawn_run(t.loop_id, Some(t.id), "tag_added", meta, None, None)
+                        .await;
                 if run_id > 0 {
                     started.push(run_id);
                 }
@@ -276,7 +276,7 @@ impl LoopTriggerDispatcher {
             );
             return None;
         }
-        let id = self.spawn_run(loop_id, None, "manual", trigger_meta).await;
+        let id = self.spawn_run(loop_id, None, "manual", trigger_meta, None, None).await;
         if id > 0 { Some(id) } else { None }
     }
 
@@ -287,6 +287,8 @@ impl LoopTriggerDispatcher {
         trigger_id: Option<i64>,
         trigger_type: &str,
         meta: serde_json::Value,
+        feishu_bot_id: Option<i64>,
+        feishu_receive_id: Option<String>,
     ) -> i64 {
         debug!(
             "loop_trigger: spawning loop #{} via {} (trigger_id={:?})",
@@ -295,7 +297,7 @@ impl LoopTriggerDispatcher {
         let id = self
             .runner
             .clone()
-            .spawn_run(loop_id, trigger_id, trigger_type, meta, None, None);
+            .spawn_run(loop_id, trigger_id, trigger_type, meta, feishu_bot_id, feishu_receive_id);
         info!(
             "loop_trigger: started loop #{} execution #{} via {}",
             loop_id, id, trigger_type

--- a/backend/src/services/loop_trigger.rs
+++ b/backend/src/services/loop_trigger.rs
@@ -66,7 +66,7 @@ impl LoopTriggerDispatcher {
             "content_type": content_type.unwrap_or(""),
             "body": body.unwrap_or(""),
         });
-        let id = self.spawn_run(loop_id, None, "webhook", meta, None, None).await;
+        let id = self.spawn_run(loop_id, None, "webhook", meta, None, None, None).await;
         if id > 0 { Some(id) } else { None }
     }
 
@@ -120,7 +120,7 @@ impl LoopTriggerDispatcher {
                 "content": content,
             });
             let run_id = self
-                .spawn_run(t.loop_id, Some(t.id), "feishu_message", meta, Some(bot_id), Some(chat_id.to_string()))
+                .spawn_run(t.loop_id, Some(t.id), "feishu_message", meta, Some(bot_id), Some(chat_id.to_string()), Some("chat_id".to_string()))
                 .await;
             if run_id > 0 {
                 started.push(run_id);
@@ -163,7 +163,7 @@ impl LoopTriggerDispatcher {
                     "command": command,
                 });
                 let run_id = self
-                    .spawn_run(t.loop_id, Some(t.id), "feishu_command", meta, Some(bot_id), None)
+                    .spawn_run(t.loop_id, Some(t.id), "feishu_command", meta, Some(bot_id), None, None)
                     .await;
                 if run_id > 0 {
                     started.push(run_id);
@@ -198,7 +198,7 @@ impl LoopTriggerDispatcher {
                 "execution_record_id": record_id,
             });
             let run_id = self
-                .spawn_run(t.loop_id, Some(t.id), "todo_completed", meta, None, None)
+                .spawn_run(t.loop_id, Some(t.id), "todo_completed", meta, None, None, None)
                 .await;
             if run_id > 0 {
                 started.push(run_id);
@@ -240,7 +240,7 @@ impl LoopTriggerDispatcher {
                     "todo_id": todo_id,
                 });
                 let run_id = self
-                        .spawn_run(t.loop_id, Some(t.id), "tag_added", meta, None, None)
+                        .spawn_run(t.loop_id, Some(t.id), "tag_added", meta, None, None, None)
                         .await;
                 if run_id > 0 {
                     started.push(run_id);
@@ -276,7 +276,7 @@ impl LoopTriggerDispatcher {
             );
             return None;
         }
-        let id = self.spawn_run(loop_id, None, "manual", trigger_meta, None, None).await;
+        let id = self.spawn_run(loop_id, None, "manual", trigger_meta, None, None, None).await;
         if id > 0 { Some(id) } else { None }
     }
 
@@ -289,6 +289,8 @@ impl LoopTriggerDispatcher {
         meta: serde_json::Value,
         feishu_bot_id: Option<i64>,
         feishu_receive_id: Option<String>,
+        // 接收者 ID 类型（"open_id" / "chat_id"）
+        feishu_receive_id_type: Option<String>,
     ) -> i64 {
         debug!(
             "loop_trigger: spawning loop #{} via {} (trigger_id={:?})",
@@ -297,7 +299,7 @@ impl LoopTriggerDispatcher {
         let id = self
             .runner
             .clone()
-            .spawn_run(loop_id, trigger_id, trigger_type, meta, feishu_bot_id, feishu_receive_id);
+            .spawn_run(loop_id, trigger_id, trigger_type, meta, feishu_bot_id, feishu_receive_id, feishu_receive_id_type);
         info!(
             "loop_trigger: started loop #{} execution #{} via {}",
             loop_id, id, trigger_type

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -161,6 +161,12 @@ impl MessageDebounce {
                     let result: Result<crate::executor_service::ExecutionResult, ()> = match last.trigger_type.as_str() {
                         "default_response_loop" | "slash_command_loop" => {
                             // 环路默认响应 或 斜杠命令触发环路：直接触发环路执行
+                            // 根据 chat_type 决定 receive_id_type：群聊用 chat_id，单聊用 open_id
+                            let receive_id_type = if last.chat_type == "group" {
+                                "chat_id".to_string()
+                            } else {
+                                "open_id".to_string()
+                            };
                             Self::handle_default_response_loop(
                                 db.clone(),
                                 loop_runner.clone(),
@@ -168,6 +174,7 @@ impl MessageDebounce {
                                 &merged_content,
                                 Some(last.bot_id),
                                 Some(last.sender.clone()),
+                                Some(receive_id_type),
                             )
                             .await
                         }
@@ -381,6 +388,7 @@ impl MessageDebounce {
         message: &str,
         feishu_bot_id: Option<i64>,
         feishu_receive_id: Option<String>,
+        feishu_receive_id_type: Option<String>,
     ) -> Result<crate::executor_service::ExecutionResult, ()> {
         // 检查环路是否存在且状态为 enabled
         let loop_ = match db.get_loop(loop_id).await {
@@ -420,6 +428,7 @@ impl MessageDebounce {
             meta,
             feishu_bot_id,
             feishu_receive_id,
+            feishu_receive_id_type,
         );
 
         if execution_id < 0 {

--- a/backend/tests/services_tests.rs
+++ b/backend/tests/services_tests.rs
@@ -179,8 +179,9 @@ mod feishu_push_service_tests {
         let text = text.unwrap();
         assert!(text.contains("✅"));
         assert!(text.contains("成功"));
-        assert!(text.contains("结果:"));
-        assert!(text.contains("Task completed"));
+        assert!(text.contains("用时"));
+        assert!(text.contains("2m 5s"));
+        assert!(text.contains("Token 500"));
     }
 
     #[test]
@@ -201,18 +202,22 @@ mod feishu_push_service_tests {
         let text = text.unwrap();
         assert!(text.contains("✅"));
         assert!(text.contains("成功"));
-        // Should not contain "结果:" prefix when result is None
-        assert!(!text.contains("结果:"));
+        // 新格式包含统计摘要，不再包含"结果:"
+        assert!(text.contains("用时"));
+        assert!(text.contains("Token"));
     }
 
     #[test]
     fn test_format_event_finished_long_result_truncated() {
+        // 新格式不再包含 result 文本预览，只显示统计摘要
         let long_result = "x".repeat(150);
         let event = make_finished_event(true, Some(long_result));
         let text = format_event_check(&event);
         assert!(text.is_some());
         let text = text.unwrap();
-        assert!(text.contains("..."));
+        // 新格式不应包含"..."截断标记
+        assert!(!text.contains("结果:"));
+        assert!(text.contains("用时"));
     }
 
     #[test]
@@ -337,16 +342,26 @@ mod feishu_push_service_tests {
                     Some(format!("{} {}\n🆔 {}", prefix, preview, task_id))
                 }
             }
-            ExecEvent::Finished { success, result, todo_title, executor, .. } => {
-                let result_preview = result.as_ref()
-                    .map(|r| format!("\n\n📤 结果: {}", if r.chars().count() > 100 { r.chars().take(100).collect::<String>() + "..." } else { r.clone() }))
-                    .unwrap_or_default();
+            ExecEvent::Finished { success, todo_title, executor, duration_secs, total_tokens, .. } => {
+                // 格式化时长（与 LoopFinished 风格一致）
+                let duration_str = if *duration_secs >= 3600 {
+                    let hours = *duration_secs / 3600;
+                    let mins = (*duration_secs % 3600) / 60;
+                    format!("{}h {}m", hours, mins)
+                } else if *duration_secs >= 60 {
+                    let mins = *duration_secs / 60;
+                    let secs = *duration_secs % 60;
+                    format!("{}m {}s", mins, secs)
+                } else {
+                    format!("{}s", *duration_secs)
+                };
                 Some(format!(
-                    "📋 {}\n⚡ 执行器: {}\n{}{}",
+                    "📋 {}\n⚡ 执行器: {}\n{}\n⏱️ 用时 {} | 🔤 Token {}",
                     todo_title,
                     executor,
                     if *success { "✅ 成功" } else { "❌ 失败" },
-                    result_preview
+                    duration_str,
+                    total_tokens
                 ))
             }
             ExecEvent::TodoProgress { task_id, progress } => {
@@ -405,6 +420,8 @@ mod feishu_push_service_tests {
             feishu_bot_id: None,
             feishu_receive_id: None,
             workspace_id: None,
+            duration_secs: 125,
+            total_tokens: 500,
         }
     }
 }

--- a/backend/tests/services_tests.rs
+++ b/backend/tests/services_tests.rs
@@ -229,6 +229,7 @@ mod feishu_push_service_tests {
         let event = ExecEvent::TodoProgress {
             task_id: "task-123".to_string(),
             progress,
+            workspace_id: None,
         };
         let text = format_event_check(&event);
         assert!(text.is_some());
@@ -245,6 +246,7 @@ mod feishu_push_service_tests {
         let event = ExecEvent::TodoProgress {
             task_id: "task-123".to_string(),
             progress: vec![],
+            workspace_id: None,
         };
         let text = format_event_check(&event);
         assert!(text.is_none());
@@ -258,6 +260,7 @@ mod feishu_push_service_tests {
         let event = ExecEvent::TodoProgress {
             task_id: "task-123".to_string(),
             progress,
+            workspace_id: None,
         };
         let text = format_event_check(&event);
         assert!(text.is_some());
@@ -277,6 +280,7 @@ mod feishu_push_service_tests {
         let event = ExecEvent::ExecutionStats {
             task_id: "task-123".to_string(),
             stats,
+            workspace_id: None,
         };
         let text = format_event_check(&event);
         assert!(text.is_some());
@@ -322,7 +326,7 @@ mod feishu_push_service_tests {
                     todo_title, executor, task_id
                 ))
             }
-            ExecEvent::Output { task_id, entry } => {
+            ExecEvent::Output { task_id, entry, .. } => {
                 let prefix = match entry.log_type.as_str() {
                     "error" | "stderr" => "🔴",
                     "warning" => "⚠️",
@@ -364,7 +368,7 @@ mod feishu_push_service_tests {
                     total_tokens
                 ))
             }
-            ExecEvent::TodoProgress { task_id, progress } => {
+            ExecEvent::TodoProgress { task_id, progress, .. } => {
                 if progress.is_empty() {
                     None
                 } else {
@@ -378,7 +382,7 @@ mod feishu_push_service_tests {
                     ))
                 }
             }
-            ExecEvent::ExecutionStats { task_id, stats } => {
+            ExecEvent::ExecutionStats { task_id, stats, .. } => {
                 Some(format!(
                     "📊 [执行统计] TaskID: {}\n🔧 工具调用: {}\n💬 对话轮次: {}",
                     task_id, stats.tool_calls, stats.conversation_turns
@@ -399,6 +403,7 @@ mod feishu_push_service_tests {
             todo_id: 1,
             todo_title: "Test Todo".to_string(),
             executor: "kimi".to_string(),
+            workspace_id: None,
         }
     }
 
@@ -406,6 +411,7 @@ mod feishu_push_service_tests {
         ExecEvent::Output {
             task_id: "task-123".to_string(),
             entry: ParsedLogEntry::new(log_type, content),
+            workspace_id: None,
         }
     }
 

--- a/backend/tests/services_tests.rs
+++ b/backend/tests/services_tests.rs
@@ -373,7 +373,7 @@ mod feishu_push_service_tests {
             ExecEvent::ReviewStatusChanged { .. } => None,
             // ExecutorDirectResponse 由 FeishuPushService 直接发送，不走 format_event
             ExecEvent::ExecutorDirectResponse { .. } => None,
-            // LoopFinished 事件由 FeishuPushService 统一处理
+            // LoopFinished 事件发送统计摘要，不走 format_event（测试用）
             ExecEvent::LoopFinished { .. } => None,
         }
     }

--- a/backend/tests/services_tests.rs
+++ b/backend/tests/services_tests.rs
@@ -312,7 +312,7 @@ mod feishu_push_service_tests {
     fn should_send_check(push_level: &str, event: &ExecEvent) -> bool {
         match push_level {
             "disabled" => false,
-            "result_only" => matches!(event, ExecEvent::Finished { .. }),
+            "result_only" => matches!(event, ExecEvent::Finished { .. } | ExecEvent::LoopFinished { .. }),
             "all" => true,
             _ => false,
         }
@@ -392,8 +392,35 @@ mod feishu_push_service_tests {
             ExecEvent::ReviewStatusChanged { .. } => None,
             // ExecutorDirectResponse 由 FeishuPushService 直接发送，不走 format_event
             ExecEvent::ExecutorDirectResponse { .. } => None,
-            // LoopFinished 事件发送统计摘要，不走 format_event（测试用）
-            ExecEvent::LoopFinished { .. } => None,
+            // LoopFinished 事件的格式化消息 - 统计摘要（与 feishu_push.rs 生产代码保持一致）
+            ExecEvent::LoopFinished { loop_title, status, total_steps, completed_steps, failed_steps, duration_secs, total_tokens, .. } => {
+                let status_icon = match status.as_str() {
+                    "success" => "✅ 成功",
+                    "failed" => "❌ 失败",
+                    "partial" => "⚠️ 部分成功",
+                    "capped_step" => "🚫 步数超限",
+                    "capped_token" => "🚫 Token超限",
+                    _ => "ℹ️ 完成",
+                };
+                
+                // 格式化时长
+                let duration_str = if *duration_secs >= 3600 {
+                    let hours = *duration_secs / 3600;
+                    let mins = (*duration_secs % 3600) / 60;
+                    format!("{}h {}m", hours, mins)
+                } else if *duration_secs >= 60 {
+                    let mins = *duration_secs / 60;
+                    let secs = *duration_secs % 60;
+                    format!("{}m {}s", mins, secs)
+                } else {
+                    format!("{}s", *duration_secs)
+                };
+                
+                Some(format!(
+                    "🔁 [环路执行完成]\n📋 {}\n{} | 共 {} 步 | 成功 {} | 失败 {}\n⏱️ 用时 {} | 🔤 Token {}",
+                    loop_title, status_icon, *total_steps, *completed_steps, *failed_steps, duration_str, *total_tokens
+                ))
+            }
         }
     }
 

--- a/backend/tests/services_tests.rs
+++ b/backend/tests/services_tests.rs
@@ -373,6 +373,8 @@ mod feishu_push_service_tests {
             ExecEvent::ReviewStatusChanged { .. } => None,
             // ExecutorDirectResponse 由 FeishuPushService 直接发送，不走 format_event
             ExecEvent::ExecutorDirectResponse { .. } => None,
+            // LoopFinished 事件由 FeishuPushService 统一处理
+            ExecEvent::LoopFinished { .. } => None,
         }
     }
 

--- a/frontend/src/components/settings/bot/BotDetailPage.tsx
+++ b/frontend/src/components/settings/bot/BotDetailPage.tsx
@@ -155,6 +155,8 @@ export function BotDetailPage({ bot, onBack, onRefresh, autoShowHistory = false 
   const handlePushLevelChange = async (level: FeishuPushLevel) => {
     try {
       await db.updateFeishuPush({ botId: bot.id, pushLevel: level });
+      // 直接更新本地状态，避免依赖 onRefresh 重新加载导致下拉框不刷新
+      setPushStatus(prev => prev ? { ...prev, push_level: level } : prev);
       onRefresh();
     } catch (e: any) {
       message.error('设置推送失败: ' + (e.message || '未知错误'));

--- a/frontend/src/components/settings/bot/PushStatusCard.tsx
+++ b/frontend/src/components/settings/bot/PushStatusCard.tsx
@@ -16,8 +16,8 @@ export function PushStatusCard({ pushStatus, onPushLevelChange, onResponseEnable
   return (
     <Card title="推送配置" size="small" style={{ marginBottom: 16 }}>
       {/* 推送目标下拉 */}
-      <div style={{ marginBottom: 12 }}>
-        <span style={{ fontSize: 13, marginRight: 8 }}>推送目标</span>
+      <div style={{ marginBottom: 12, display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontSize: 13, width: 60 }}>推送目标</span>
         <Select
           size="small"
           value={pushStatus.push_level}
@@ -29,6 +29,10 @@ export function PushStatusCard({ pushStatus, onPushLevelChange, onResponseEnable
             { value: 'all', label: '全部' },
           ]}
         />
+        <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', display: 'flex', alignItems: 'center', gap: 4 }}>
+          <span style={{ color: 'var(--color-info)' }}>💡</span>
+          在单聊或群聊中发送 <code style={{ padding: '1px 6px', background: 'var(--color-fill-secondary)', borderRadius: 4, fontSize: 11 }}>/sethome</code> 自动填写 ID
+        </span>
       </div>
 
       {/* ID 展示行 */}

--- a/frontend/src/components/settings/workspace/WorkspaceAgentPanel.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceAgentPanel.tsx
@@ -31,6 +31,32 @@ export function WorkspaceAgentPanel({ workspaceId, onBotChanged, activeBot, onSe
   // 点击消息记录时，直接打开详情页并默认展开消息记录
   const [selectedBotForHistory, setSelectedBotForHistory] = useState<AgentBot | null>(null);
 
+  // 绑定飞书状态
+  const [binding, setBinding] = useState(false);
+  const [bindModalOpen, setBindModalOpen] = useState(false);
+  const [qrCodeUrl, setQrCodeUrl] = useState('');
+  const [pollError, setPollError] = useState('');
+  const [bindSuccess, setBindSuccess] = useState(false);
+  const [feishuEventSource, setFeishuEventSource] = useState<EventSource | null>(null);
+  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // 加载智能体列表，必须在条件返回之前定义，避免 TDZ 错误
+  const loadBots = () => {
+    setLoading(true);
+    Promise.all([
+      db.getAgentBots(),
+      db.getProjectDirectories(),
+    ])
+      .then(([botsData, dirsData]) => {
+        setAllBots(botsData);
+        // 筛选当前 workspace 的 bots
+        setBots(botsData.filter(b => b.workspace_id === workspaceId));
+        setWorkspaces(dirsData);
+      })
+      .catch((err: any) => message.error('加载智能体失败: ' + (err?.message || String(err))))
+      .finally(() => setLoading(false));
+  };
+
   // 外部传入 bot 时直接渲染 BotDetailPage
   if (activeBot) {
     return (
@@ -55,31 +81,6 @@ export function WorkspaceAgentPanel({ workspaceId, onBotChanged, activeBot, onSe
       />
     );
   }
-
-  // 绑定飞书状态
-  const [binding, setBinding] = useState(false);
-  const [bindModalOpen, setBindModalOpen] = useState(false);
-  const [qrCodeUrl, setQrCodeUrl] = useState('');
-  const [pollError, setPollError] = useState('');
-  const [bindSuccess, setBindSuccess] = useState(false);
-  const [feishuEventSource, setFeishuEventSource] = useState<EventSource | null>(null);
-  const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const loadBots = () => {
-    setLoading(true);
-    Promise.all([
-      db.getAgentBots(),
-      db.getProjectDirectories(),
-    ])
-      .then(([botsData, dirsData]) => {
-        setAllBots(botsData);
-        // 筛选当前 workspace 的 bots
-        setBots(botsData.filter(b => b.workspace_id === workspaceId));
-        setWorkspaces(dirsData);
-      })
-      .catch((err: any) => message.error('加载智能体失败: ' + (err?.message || String(err))))
-      .finally(() => setLoading(false));
-  };
 
   // 开始绑定飞书
   const handleStartBind = async () => {

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -56,7 +56,17 @@ interface ExecEventReviewStatusChanged {
   review_status: string;
 }
 
-type ExecEvent = ExecEventStarted | ExecEventOutput | ExecEventFinished | ExecEventSync | ExecEventTodoProgress | ExecEventExecutionStats | ExecEventReviewStatusChanged;
+interface ExecEventLoopFinished {
+  type: 'LoopFinished';
+  loop_execution_id: number;
+  loop_id: number;
+  loop_title: string;
+  status: string;
+  result: string | null;
+  workspace_id: number | null;
+}
+
+type ExecEvent = ExecEventStarted | ExecEventOutput | ExecEventFinished | ExecEventSync | ExecEventTodoProgress | ExecEventExecutionStats | ExecEventReviewStatusChanged | ExecEventLoopFinished;
 
 // ─── 模块级共享状态 ─────────────────────────────────────────────
 //
@@ -162,6 +172,10 @@ function connectShared(dispatch: ReturnType<typeof useApp>['dispatch']) {
         }
         case 'ReviewStatusChanged': {
           window.dispatchEvent(new CustomEvent('reviewStatusChanged', { detail: { recordId: data.record_id, todoId: data.todo_id, reviewStatus: data.review_status } }));
+          break;
+        }
+        case 'LoopFinished': {
+          window.dispatchEvent(new CustomEvent('loopExecutionFinished', { detail: { loopExecutionId: data.loop_execution_id, loopId: data.loop_id, status: data.status } }));
           break;
         }
       }

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -10,12 +10,14 @@ interface ExecEventStarted {
   todo_id: number;
   todo_title: string;
   executor: string;
+  workspace_id: number | null;
 }
 
 interface ExecEventOutput {
   type: 'Output';
   task_id: string;
   entry: LogEntry;
+  workspace_id: number | null;
 }
 
 interface ExecEventFinished {
@@ -26,6 +28,7 @@ interface ExecEventFinished {
   result: string | null;
   duration_secs: number;
   total_tokens: number;
+  workspace_id: number | null;
 }
 
 interface ExecEventSync {
@@ -43,12 +46,14 @@ interface ExecEventTodoProgress {
   type: 'TodoProgress';
   task_id: string;
   progress: TodoItem[];
+  workspace_id: number | null;
 }
 
 interface ExecEventExecutionStats {
   type: 'ExecutionStats';
   task_id: string;
   stats: ExecutionStats;
+  workspace_id: number | null;
 }
 
 interface ExecEventReviewStatusChanged {

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -62,7 +62,11 @@ interface ExecEventLoopFinished {
   loop_id: number;
   loop_title: string;
   status: string;
-  result: string | null;
+  total_steps: number;
+  completed_steps: number;
+  failed_steps: number;
+  duration_secs: number;
+  total_tokens: number;
   workspace_id: number | null;
 }
 
@@ -175,7 +179,7 @@ function connectShared(dispatch: ReturnType<typeof useApp>['dispatch']) {
           break;
         }
         case 'LoopFinished': {
-          window.dispatchEvent(new CustomEvent('loopExecutionFinished', { detail: { loopExecutionId: data.loop_execution_id, loopId: data.loop_id, status: data.status } }));
+          window.dispatchEvent(new CustomEvent('loopExecutionFinished', { detail: { loopExecutionId: data.loop_execution_id, loopId: data.loop_id, status: data.status, totalSteps: data.total_steps, completedSteps: data.completed_steps, failedSteps: data.failed_steps, durationSecs: data.duration_secs, totalTokens: data.total_tokens } }));
           break;
         }
       }

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -24,6 +24,8 @@ interface ExecEventFinished {
   todo_id: number;
   success: boolean;
   result: string | null;
+  duration_secs: number;
+  total_tokens: number;
 }
 
 interface ExecEventSync {

--- a/frontend/src/utils/database/client.ts
+++ b/frontend/src/utils/database/client.ts
@@ -6,6 +6,13 @@ interface ApiResp<T> {
   message: string;
 }
 
+// api 对象必须最先初始化，避免其他函数引用时的 TDZ 错误
+export const api = axios.create({
+  baseURL: '',
+  headers: { 'Content-Type': 'application/json' },
+  timeout: 15000,
+});
+
 export async function checkBackendHealth(): Promise<boolean> {
   try {
     const res = await api.get('/health', { timeout: 3000 });
@@ -14,12 +21,6 @@ export async function checkBackendHealth(): Promise<boolean> {
     return false;
   }
 }
-
-export const api = axios.create({
-  baseURL: '',
-  headers: { 'Content-Type': 'application/json' },
-  timeout: 15000,
-});
 
 /** Retry config: max 3 retries on network errors (no response), not on 4xx/5xx */
 const MAX_RETRIES = 3;


### PR DESCRIPTION
### 背景

飞书推送 Todo 执行完成通知时，原先展示结果文本预览（最多 100 字符），但：
1. 结果文本往往过长或被截断，可读性差
2. 缺乏关键统计信息（耗时、Token 消耗）

### 变更内容

- **ExecEvent::Finished** 新增 `duration_secs` / `total_tokens` 字段
- **正常完成分支**：从 DB usage 查询真实耗时和 Token 消耗
- **异常分支**（cancel/timeout/spawn 失败等）：传 0，不阻塞流程
- **FeishuPushService**：推送格式改为统计摘要，与 `LoopFinished` 风格对齐
  - 旧格式：`📋 title\n⚡ executor\n✅ 成功\n\n📤 结果: xxx...`
  - 新格式：`📋 title\n⚡ executor\n✅ 成功\n⏱️ 用时 1m 30s | 🔤 Token 500`
- 前端 `useExecutionEvents` 补全 `duration_secs` / `total_tokens` 类型声明