### PR TITLE
feat(skills): add file browser with fullscreen modal and theme support

### DIFF
--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1364,6 +1364,7 @@ fn skills_routes() -> Router<AppState> {
         .route("/api/skills/sync", post(skills::sync_skill))
         .route("/api/skills/invocations", get(skills::list_invocations).post(skills::record_invocation))
         .route("/api/skills/content", get(skills::get_skill_content))
+        .route("/api/skills/file", get(skills::get_skill_file))
         .route("/api/skills/export", get(skills::export_skill))
         .route("/api/skills/import", post(skills::import_skill))
 }

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -281,6 +281,13 @@ pub struct SkillExportQuery {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct SkillFileQuery {
+    pub executor: String,
+    pub skill_name: String,
+    pub path: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct ImportRequest {
     pub executor: String,
     pub skill_name: Option<String>,
@@ -614,6 +621,43 @@ pub async fn get_skill_content(
     })
     .await
     .map_err(|e| AppError::Internal(format!("spawn_blocking join error: {}", e)))?;
+
+    Ok(ApiResponse::ok(result))
+}
+
+/// GET /api/skills/file - Get a single file's content within a skill
+pub async fn get_skill_file(
+    Query(query): Query<SkillFileQuery>,
+) -> Result<ApiResponse<SkillFileContentResponse>, AppError> {
+    let skills_dir = executor_skills_dir_str(&query.executor)
+        .ok_or_else(|| AppError::BadRequest(format!("Unknown executor: {}", query.executor)))?;
+
+    let skill_dir = resolve_skill_path_for_read(&skills_dir, &query.skill_name)?;
+
+    // 安全校验：防止路径遍历攻击
+    let file_path = skill_dir.join(&query.path);
+    let file_path_canonical = file_path.canonicalize()
+        .map_err(|e| AppError::Internal(format!("Failed to resolve file path: {}", e)))?;
+    let skill_dir_canonical = skill_dir.canonicalize()
+        .map_err(|e| AppError::Internal(format!("Failed to resolve skill dir: {}", e)))?;
+    if !file_path_canonical.starts_with(&skill_dir_canonical) {
+        return Err(AppError::BadRequest("Invalid file path: escapes skill directory".to_string()));
+    }
+
+    if !file_path.exists() || !file_path.is_file() {
+        return Err(AppError::NotFound);
+    }
+
+    let result = tokio::task::spawn_blocking(move || -> Result<SkillFileContentResponse, AppError> {
+        let content = std::fs::read_to_string(&file_path)
+            .map_err(|e| AppError::Internal(format!("Failed to read file: {}", e)))?;
+        Ok(SkillFileContentResponse {
+            path: query.path.clone(),
+            content,
+        })
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("spawn_blocking join error: {}", e)))??;
 
     Ok(ApiResponse::ok(result))
 }
@@ -964,6 +1008,12 @@ pub struct SkillFileInfo {
     pub path: String,
     pub size: u64,
     pub modified_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SkillFileContentResponse {
+    pub path: String,
+    pub content: String,
 }
 
 /// GET /api/skills/compare - Cross-executor skill comparison matrix

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -115,6 +115,35 @@ fn resolve_skill_path_under(base: &Path, skill_name: &str) -> Result<PathBuf, Ap
     Ok(candidate_canonical)
 }
 
+/// 把外部 `skill_name` 解析为目录路径，用于**只读**操作（如获取内容、导出）。
+///
+/// 与 `resolve_skill_path_under` 的区别：
+/// - 允许符号链接指向 skills 目录外的路径（如 `~/.claude/skills/xxx -> ~/.agents/skills/xxx`）
+/// - 但仍拒绝绝对路径、`..` 父级引用等恶意输入
+///
+/// 这样用户可以通过符号链接访问其他位置的 skill，同时防止路径遍历攻击。
+fn resolve_skill_path_for_read(base: &Path, skill_name: &str) -> Result<PathBuf, AppError> {
+    // 第一道：纯字符串级校验（与 resolve_skill_path_under 相同）
+    let rel = Path::new(skill_name);
+    if rel.as_os_str().is_empty() {
+        return Err(AppError::BadRequest("Invalid skill name: empty".to_string()));
+    }
+    if rel.is_absolute() {
+        return Err(AppError::BadRequest("Invalid skill name: absolute paths are not allowed".to_string()));
+    }
+    if rel.components().any(|c| matches!(c, std::path::Component::ParentDir | std::path::Component::Prefix(_))) {
+        return Err(AppError::BadRequest("Invalid skill name: parent directory traversal is not allowed".to_string()));
+    }
+
+    // 第二道：检查路径是否存在（不检查是否在 base 下，允许符号链接逃逸）
+    let candidate = base.join(rel);
+    if !candidate.exists() {
+        return Err(AppError::NotFound);
+    }
+
+    Ok(candidate)
+}
+
 fn executor_label(et: ExecutorType) -> &'static str {
     match et {
         ExecutorType::Claudecode => "Claude Code",
@@ -559,9 +588,9 @@ pub async fn get_skill_content(
     let skills_dir = executor_skills_dir_str(&query.executor)
         .ok_or_else(|| AppError::BadRequest(format!("Unknown executor: {}", query.executor)))?;
 
-    // 用统一 helper 校验 skill_name 并解析出实际路径
-    // 比直接 join 多一层 canonicalize + starts_with 防御（防 ../ 逃逸和符号链接绕过）
-    let skill_dir = resolve_skill_path_under(&skills_dir, &query.skill_name)?;
+    // 用 resolve_skill_path_for_read 校验 skill_name
+    // 对于只读操作，允许符号链接指向 skills 目录外的路径
+    let skill_dir = resolve_skill_path_for_read(&skills_dir, &query.skill_name)?;
 
     let skill_name = query.skill_name.clone();
     let executor = query.executor.clone();
@@ -650,8 +679,9 @@ pub async fn export_skill(
     let skills_dir = executor_skills_dir_str(&query.executor)
         .ok_or_else(|| AppError::BadRequest(format!("Unknown executor: {}", query.executor)))?;
 
-    // 统一 containment 校验
-    let skill_dir = resolve_skill_path_under(&skills_dir, &query.skill_name)?;
+    // 用 resolve_skill_path_for_read 校验 skill_name
+    // 对于只读操作，允许符号链接指向 skills 目录外的路径
+    let skill_dir = resolve_skill_path_for_read(&skills_dir, &query.skill_name)?;
 
     // Create zip in memory
     let mut zip_data = Vec::new();

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -122,7 +122,7 @@ fn resolve_skill_path_under(base: &Path, skill_name: &str) -> Result<PathBuf, Ap
 /// - 但仍拒绝绝对路径、`..` 父级引用等恶意输入
 ///
 /// 这样用户可以通过符号链接访问其他位置的 skill，同时防止路径遍历攻击。
-fn resolve_skill_path_for_read(base: &Path, skill_name: &str) -> Result<PathBuf, AppError> {
+pub(crate) fn resolve_skill_path_for_read(base: &Path, skill_name: &str) -> Result<PathBuf, AppError> {
     // 第一道：纯字符串级校验（与 resolve_skill_path_under 相同）
     let rel = Path::new(skill_name);
     if rel.as_os_str().is_empty() {
@@ -1456,5 +1456,35 @@ mod tests {
         let content = "# My Skill Title\nSome description text here.";
         let meta = parse_skill_yaml_header(content);
         assert_eq!(meta.name, "My Skill Title");
+    }
+
+    // ── resolve_skill_path_for_read() tests ─────────────────────────────────
+
+    #[test]
+    fn test_resolve_skill_path_for_read_empty_name() {
+        let base = Path::new("/skills");
+        let result = resolve_skill_path_for_read(base, "");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_skill_path_for_read_absolute_path_rejected() {
+        let base = Path::new("/skills");
+        let result = resolve_skill_path_for_read(base, "/etc/passwd");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_skill_path_for_read_parent_traversal_rejected() {
+        let base = Path::new("/skills");
+        let result = resolve_skill_path_for_read(base, "../etc/passwd");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_skill_path_for_read_double_parent_traversal_rejected() {
+        let base = Path::new("/skills");
+        let result = resolve_skill_path_for_read(base, "foo/../../../etc/passwd");
+        assert!(result.is_err());
     }
 }

--- a/frontend/src/components/skills/SkillDetailDrawer.tsx
+++ b/frontend/src/components/skills/SkillDetailDrawer.tsx
@@ -34,7 +34,7 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
 
   const [content, setContent] = useState<string>('');
   const [files, setFiles] = useState<SkillFileInfo[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [contentLoading, setContentLoading] = useState(false);
   const [syncModalOpen, setSyncModalOpen] = useState(false);
   const [targetExecutors, setTargetExecutors] = useState<string[]>([]);
   const [syncing, setSyncing] = useState(false);
@@ -44,7 +44,7 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
 
   useEffect(() => {
     if (open && skill) {
-      setLoading(true);
+      setContentLoading(true);
       db.getSkillContent(executor, skill.name)
         .then(data => {
           const meta = `# ${data.skill_name}\n\n## 元信息\n- 文件数: ${data.files.length}\n- 大小: ${formatSize(skill.total_size)}\n- 更新时间: ${formatTime(skill.modified_at)}\n\n---\n\n${data.content}`;
@@ -58,7 +58,7 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
           setContent(`# ${skill.name}\n\n${skill.description || '暂无描述'}\n\n## 元信息\n- 版本: ${skill.version || '未指定'}\n- 作者: ${skill.author || '未知'}\n- 许可证: ${skill.license || '未指定'}\n- 文件数: ${skill.file_count}\n- 大小: ${formatSize(skill.total_size)}\n- 更新时间: ${formatTime(skill.modified_at)}`);
           setFiles([]);
         })
-        .finally(() => setLoading(false));
+        .finally(() => setContentLoading(false));
     }
   }, [open, skill, executor]);
 
@@ -129,7 +129,7 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
         onClose={onClose}
         open={open}
       >
-        {loading ? (
+        {contentLoading ? (
           <div style={{ textAlign: 'center', padding: 40 }}>
             <Spin size="large" />
           </div>
@@ -309,7 +309,7 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
       >
         <FileBrowserFullscreen
           files={files}
-          loading={loading}
+          contentLoading={contentLoading}
           selectedFile={selectedFile}
           onFileSelect={setSelectedFile}
           executor={executor}
@@ -324,7 +324,7 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
 // 文件浏览器全屏模态框内容组件，响应式支持手机端切换视图
 function FileBrowserFullscreen({
   files,
-  loading,
+  contentLoading,
   selectedFile,
   onFileSelect,
   executor,
@@ -332,7 +332,7 @@ function FileBrowserFullscreen({
   isDark,
 }: {
   files: SkillFileInfo[];
-  loading: boolean;
+  contentLoading: boolean;
   selectedFile: SkillFileInfo | null;
   onFileSelect: (file: SkillFileInfo) => void;
   executor: string;
@@ -365,7 +365,7 @@ function FileBrowserFullscreen({
         }}>
           <SkillFileBrowser
             files={files}
-            loading={loading}
+            loading={contentLoading}
             onFileSelect={onFileSelect}
             selectedFile={selectedFile}
             isDark={isDark}
@@ -461,7 +461,7 @@ function FileBrowserFullscreen({
           <div style={{ height: '100%', overflow: 'auto' }}>
             <SkillFileBrowser
               files={files}
-              loading={loading}
+              loading={contentLoading}
               onFileSelect={handleFileSelect}
               selectedFile={selectedFile}
               isDark={isDark}

--- a/frontend/src/components/skills/SkillDetailDrawer.tsx
+++ b/frontend/src/components/skills/SkillDetailDrawer.tsx
@@ -4,6 +4,7 @@ import Typography from 'antd/es/typography';
 import {
   FileTextOutlined, DownloadOutlined, InfoCircleOutlined,
   SwapOutlined, DeleteOutlined, FolderOutlined,
+  ArrowLeftOutlined, EyeOutlined,
 } from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
 import * as db from '@/utils/database';
@@ -306,37 +307,168 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
           },
         }}
       >
-        <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
-          {/* 左侧：文件树 */}
-          <div style={{
-            flex: '0 0 280px',
-            borderRight: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'}`,
-            overflow: 'auto',
-            background: isDark ? '#1a1a2e' : '#fff',
-          }}>
+        <FileBrowserFullscreen
+          files={files}
+          loading={loading}
+          selectedFile={selectedFile}
+          onFileSelect={setSelectedFile}
+          executor={executor}
+          skillName={skill?.name || ''}
+          isDark={isDark}
+        />
+      </Modal>
+    </>
+  );
+}
+
+// 文件浏览器全屏模态框内容组件，响应式支持手机端切换视图
+function FileBrowserFullscreen({
+  files,
+  loading,
+  selectedFile,
+  onFileSelect,
+  executor,
+  skillName,
+  isDark,
+}: {
+  files: SkillFileInfo[];
+  loading: boolean;
+  selectedFile: SkillFileInfo | null;
+  onFileSelect: (file: SkillFileInfo) => void;
+  executor: string;
+  skillName: string;
+  isDark: boolean;
+}) {
+  // 手机端使用独立状态控制视图模式，避免受 PC 端行为影响
+  const [isMobilePreviewMode, setIsMobilePreviewMode] = useState(false);
+
+  // 切换到文件列表视图时重置预览模式
+  const handleFileSelect = (file: SkillFileInfo) => {
+    onFileSelect(file);
+    // 手机端选中文件后自动进入预览模式
+    setIsMobilePreviewMode(true);
+  };
+
+  // 响应式布局：PC 端保持左右布局，手机端切换为单视图模式
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
+
+  // PC 端或未选中文件时显示左右分栏布局
+  if (!isMobile && !isMobilePreviewMode) {
+    return (
+      <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+        {/* 左侧：文件树 */}
+        <div style={{
+          flex: '0 0 280px',
+          borderRight: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'}`,
+          overflow: 'auto',
+          background: isDark ? '#1a1a2e' : '#fff',
+        }}>
+          <SkillFileBrowser
+            files={files}
+            loading={loading}
+            onFileSelect={onFileSelect}
+            selectedFile={selectedFile}
+            isDark={isDark}
+          />
+        </div>
+        {/* 右侧：文件预览 */}
+        <div style={{
+          flex: 1,
+          overflow: 'auto',
+          background: isDark ? '#1a1a2e' : '#fff',
+        }}>
+          <SkillFilePreview
+            file={selectedFile}
+            executor={executor}
+            skillName={skillName}
+            isDark={isDark}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // 手机端：显示文件列表视图或预览视图（通过按钮切换）
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* 手机端顶部切换按钮栏 */}
+      {isMobile && (
+        <div style={{
+          display: 'flex',
+          gap: 8,
+          padding: '8px 12px',
+          borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'}`,
+          background: isDark ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.02)',
+        }}>
+          <Button
+            size="small"
+            icon={<FolderOutlined />}
+            type={!isMobilePreviewMode ? 'primary' : 'default'}
+            onClick={() => setIsMobilePreviewMode(false)}
+          >
+            文件列表
+          </Button>
+          <Button
+            size="small"
+            icon={<EyeOutlined />}
+            type={isMobilePreviewMode ? 'primary' : 'default'}
+            onClick={() => setIsMobilePreviewMode(true)}
+            disabled={!selectedFile}
+          >
+            预览
+          </Button>
+        </div>
+      )}
+
+      {/* 内容区域 */}
+      <div style={{ flex: 1, overflow: 'hidden' }}>
+        {isMobilePreviewMode ? (
+          // 预览视图
+          <div style={{ height: '100%', overflow: 'auto' }}>
+            {/* 手机端预览顶部导航栏 */}
+            {isMobile && (
+              <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                padding: '8px 12px',
+                borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'}`,
+                background: isDark ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.02)',
+              }}>
+                <Button
+                  size="small"
+                  icon={<ArrowLeftOutlined />}
+                  onClick={() => setIsMobilePreviewMode(false)}
+                >
+                  返回列表
+                </Button>
+                {selectedFile && (
+                  <Text style={{ fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {selectedFile.path}
+                  </Text>
+                )}
+              </div>
+            )}
+            <SkillFilePreview
+              file={selectedFile}
+              executor={executor}
+              skillName={skillName}
+              isDark={isDark}
+            />
+          </div>
+        ) : (
+          // 文件列表视图
+          <div style={{ height: '100%', overflow: 'auto' }}>
             <SkillFileBrowser
               files={files}
               loading={loading}
-              onFileSelect={setSelectedFile}
+              onFileSelect={handleFileSelect}
               selectedFile={selectedFile}
               isDark={isDark}
             />
           </div>
-          {/* 右侧：文件预览 */}
-          <div style={{
-            flex: 1,
-            overflow: 'auto',
-            background: isDark ? '#1a1a2e' : '#fff',
-          }}>
-            <SkillFilePreview
-              file={selectedFile}
-              executor={executor}
-              skillName={skill?.name || ''}
-              isDark={isDark}
-            />
-          </div>
-        </div>
-      </Modal>
-    </>
+        )}
+      </div>
+    </div>
   );
 }

--- a/frontend/src/components/skills/SkillDetailDrawer.tsx
+++ b/frontend/src/components/skills/SkillDetailDrawer.tsx
@@ -1,12 +1,19 @@
 import { useState, useEffect } from 'react';
 import { Spin, Drawer, Descriptions, Tag, Alert, Button, Space, message, Modal, Checkbox, Row, Col, Popconfirm } from 'antd';
 import Typography from 'antd/es/typography';
-import { FileTextOutlined, DownloadOutlined, InfoCircleOutlined, SwapOutlined, DeleteOutlined } from '@ant-design/icons';
+import {
+  FileTextOutlined, DownloadOutlined, InfoCircleOutlined,
+  SwapOutlined, DeleteOutlined, FolderOutlined,
+} from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
 import * as db from '@/utils/database';
 import { formatSize, formatTime, EXECUTOR_COLORS } from './helpers';
 import { EXECUTORS, type ExecutorSkills } from '@/types';
 import type { SkillMeta } from '@/types';
+import type { SkillFileInfo } from '@/utils/database/skills';
+import { SkillFileBrowser } from './SkillFileBrowser';
+import { SkillFilePreview } from './SkillFilePreview';
+import { useTheme } from '@/hooks/useTheme';
 
 const { Text } = Typography;
 
@@ -21,12 +28,18 @@ interface SkillDetailDrawerProps {
 }
 
 export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClose, onSyncSuccess, onDeleteSuccess }: SkillDetailDrawerProps) {
+  const { themeMode } = useTheme();
+  const isDark = themeMode === 'dark';
+
   const [content, setContent] = useState<string>('');
+  const [files, setFiles] = useState<SkillFileInfo[]>([]);
   const [loading, setLoading] = useState(false);
   const [syncModalOpen, setSyncModalOpen] = useState(false);
   const [targetExecutors, setTargetExecutors] = useState<string[]>([]);
   const [syncing, setSyncing] = useState(false);
   const [executorsData, setExecutorsData] = useState<ExecutorSkills[]>([]);
+  const [selectedFile, setSelectedFile] = useState<SkillFileInfo | null>(null);
+  const [fileBrowserOpen, setFileBrowserOpen] = useState(false);
 
   useEffect(() => {
     if (open && skill) {
@@ -35,9 +48,14 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
         .then(data => {
           const meta = `# ${data.skill_name}\n\n## 元信息\n- 文件数: ${data.files.length}\n- 大小: ${formatSize(skill.total_size)}\n- 更新时间: ${formatTime(skill.modified_at)}\n\n---\n\n${data.content}`;
           setContent(meta);
+          setFiles(data.files);
+          // 默认选中 SKILL.md 文件
+          const skillMd = data.files.find(f => f.path === 'SKILL.md');
+          setSelectedFile(skillMd || data.files[0] || null);
         })
         .catch(() => {
           setContent(`# ${skill.name}\n\n${skill.description || '暂无描述'}\n\n## 元信息\n- 版本: ${skill.version || '未指定'}\n- 作者: ${skill.author || '未知'}\n- 许可证: ${skill.license || '未指定'}\n- 文件数: ${skill.file_count}\n- 大小: ${formatSize(skill.total_size)}\n- 更新时间: ${formatTime(skill.modified_at)}`);
+          setFiles([]);
         })
         .finally(() => setLoading(false));
     }
@@ -96,151 +114,229 @@ export function SkillDetailDrawer({ skill, executor, executorLabel, open, onClos
   };
 
   return (
-    <Drawer
-      title={
-        <Space>
-          <FileTextOutlined style={{ color: EXECUTOR_COLORS[executor] || '#7C3AED' }} />
-          <span>{skill?.name || 'Skill 详情'}</span>
-          <Tag color={EXECUTOR_COLORS[executor]}>{executorLabel}</Tag>
-        </Space>
-      }
-      placement="right"
-      width={640}
-      onClose={onClose}
-      open={open}
-      extra={
-        <Space>
-          <Button icon={<SwapOutlined />} onClick={handleOpenSyncModal}>
-            同步
-          </Button>
-          <Button icon={<DownloadOutlined />} onClick={handleExport}>
-            导出
-          </Button>
-          <Popconfirm
-            title="删除 Skill"
-            description={`确定要删除 ${executorLabel} 下的「${skill?.name}」吗？此操作不可恢复。`}
-            onConfirm={handleDelete}
-            okText="删除"
-            cancelText="取消"
-            okButtonProps={{ danger: true }}
-          >
-            <Button icon={<DeleteOutlined />} danger>
-              删除
-            </Button>
-          </Popconfirm>
-        </Space>
-      }
-    >
-      {loading ? (
-        <div style={{ textAlign: 'center', padding: 40 }}>
-          <Spin size="large" />
-        </div>
-      ) : (
-        <div>
-          {skill?.description && (
-            <Alert
-              message={skill.description}
-              type="info"
-              showIcon
-              icon={<InfoCircleOutlined />}
-              style={{ marginBottom: 16 }}
-            />
-          )}
-
-          <Descriptions bordered size="small" column={2}>
-            <Descriptions.Item label="版本">
-              {skill?.version ? <Tag color="blue">{skill.version}</Tag> : <Text type="secondary">未指定</Text>}
-            </Descriptions.Item>
-            <Descriptions.Item label="作者">
-              {skill?.author || <Text type="secondary">未知</Text>}
-            </Descriptions.Item>
-            <Descriptions.Item label="许可证">
-              {skill?.license || <Text type="secondary">未指定</Text>}
-            </Descriptions.Item>
-            <Descriptions.Item label="文件数">
-              {skill?.file_count || 0}
-            </Descriptions.Item>
-            <Descriptions.Item label="大小" span={2}>
-              {formatSize(skill?.total_size || 0)}
-            </Descriptions.Item>
-            <Descriptions.Item label="更新时间" span={2}>
-              {formatTime(skill?.modified_at ?? null)}
-            </Descriptions.Item>
-            {skill?.keywords && skill.keywords.length > 0 && (
-              <Descriptions.Item label="关键词" span={2}>
-                {skill.keywords.map(k => (
-                  <Tag key={k} color="purple" style={{ marginBottom: 4 }}>{k}</Tag>
-                ))}
-              </Descriptions.Item>
+    <>
+      <Drawer
+        title={
+          <Space>
+            <FileTextOutlined style={{ color: EXECUTOR_COLORS[executor] || '#7C3AED' }} />
+            <span>{skill?.name || 'Skill 详情'}</span>
+            <Tag color={EXECUTOR_COLORS[executor]}>{executorLabel}</Tag>
+          </Space>
+        }
+        placement="right"
+        width={640}
+        onClose={onClose}
+        open={open}
+      >
+        {loading ? (
+          <div style={{ textAlign: 'center', padding: 40 }}>
+            <Spin size="large" />
+          </div>
+        ) : (
+          <div>
+            {skill?.description && (
+              <Alert
+                message={skill.description}
+                type="info"
+                showIcon
+                icon={<InfoCircleOutlined />}
+                style={{ marginBottom: 16 }}
+              />
             )}
-          </Descriptions>
 
-          <h3 style={{ margin: '16px 0 8px', color: '#595959' }}>内容预览</h3>
-          <XMarkdown
-            content={content}
-            escapeRawHtml={true}
-            style={{
-              fontFamily: 'Fira Code, monospace',
-              fontSize: 13,
-              background: '#1e1e1e',
-              color: '#d4d4d4',
+            {/* 操作按钮区域 - 放在内容区域内部 */}
+            <div style={{
+              display: 'flex',
+              gap: 8,
+              flexWrap: 'wrap',
+              marginBottom: 16,
               padding: '12px',
-              borderRadius: '8px',
-            }}
-          />
-        </div>
-      )}
+              background: isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.02)',
+              borderRadius: 8,
+              border: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'}`,
+            }}>
+              <Button
+                type="primary"
+                icon={<FolderOutlined />}
+                onClick={() => setFileBrowserOpen(true)}
+                disabled={files.length === 0}
+              >
+                浏览文件 {files.length > 0 && `(${files.length})`}
+              </Button>
+              <Button icon={<SwapOutlined />} onClick={handleOpenSyncModal}>
+                同步
+              </Button>
+              <Button icon={<DownloadOutlined />} onClick={handleExport}>
+                导出
+              </Button>
+              <Popconfirm
+                title="删除 Skill"
+                description={`确定要删除 ${executorLabel} 下的「${skill?.name}」吗？此操作不可恢复。`}
+                onConfirm={handleDelete}
+                okText="删除"
+                cancelText="取消"
+                okButtonProps={{ danger: true }}
+              >
+                <Button icon={<DeleteOutlined />} danger>
+                  删除
+                </Button>
+              </Popconfirm>
+            </div>
+
+            <Descriptions bordered size="small" column={2}>
+              <Descriptions.Item label="版本">
+                {skill?.version ? <Tag color="blue">{skill.version}</Tag> : <Text type="secondary">未指定</Text>}
+              </Descriptions.Item>
+              <Descriptions.Item label="作者">
+                {skill?.author || <Text type="secondary">未知</Text>}
+              </Descriptions.Item>
+              <Descriptions.Item label="许可证">
+                {skill?.license || <Text type="secondary">未指定</Text>}
+              </Descriptions.Item>
+              <Descriptions.Item label="文件数">
+                {skill?.file_count || 0}
+              </Descriptions.Item>
+              <Descriptions.Item label="大小" span={2}>
+                {formatSize(skill?.total_size || 0)}
+              </Descriptions.Item>
+              <Descriptions.Item label="更新时间" span={2}>
+                {formatTime(skill?.modified_at ?? null)}
+              </Descriptions.Item>
+              {skill?.keywords && skill.keywords.length > 0 && (
+                <Descriptions.Item label="关键词" span={2}>
+                  {skill.keywords.map(k => (
+                    <Tag key={k} color="purple" style={{ marginBottom: 4 }}>{k}</Tag>
+                  ))}
+                </Descriptions.Item>
+              )}
+            </Descriptions>
+
+            <h3 style={{
+              margin: '16px 0 8px',
+              color: isDark ? '#e2e8f0' : '#595959',
+            }}>内容预览</h3>
+            <XMarkdown
+              content={content}
+              escapeRawHtml={true}
+              style={{
+                fontFamily: 'Fira Code, monospace',
+                fontSize: 13,
+                background: isDark ? '#1a1a2e' : '#1e1e1e',
+                color: '#d4d4d4',
+                padding: '12px',
+                borderRadius: '8px',
+              }}
+            />
+          </div>
+        )}
+        <Modal
+          title={
+            <Space>
+              <SwapOutlined style={{ color: '#7C3AED' }} />
+              <span>同步 Skill 到其他执行器</span>
+            </Space>
+          }
+          open={syncModalOpen}
+          onCancel={() => setSyncModalOpen(false)}
+          onOk={handleSync}
+          okText={`同步到 ${targetExecutors.length} 个执行器`}
+          okButtonProps={{ disabled: targetExecutors.length === 0 }}
+          confirmLoading={syncing}
+          width={480}
+        >
+          <div style={{ marginBottom: 16 }}>
+            <Text type="secondary">
+              将 <Text strong>{skill?.name}</Text> 从 <Tag color={EXECUTOR_COLORS[executor]}>{executorLabel}</Tag> 复制到以下执行器：
+            </Text>
+          </div>
+          <Checkbox.Group
+            value={targetExecutors}
+            onChange={v => setTargetExecutors(v as string[])}
+            style={{ width: '100%' }}
+          >
+            <Row gutter={[8, 8]}>
+              {EXECUTORS.filter(e => e.value !== executor).map(exec => {
+                const exists = executorsData.find(ex => ex.executor === exec.value);
+                const targetName = skill?.name?.split('/').pop() || skill?.name;
+                const alreadyHas = exists?.skills.find(s => s.name === targetName);
+                // agents 是只读来源，不能作为同步目标
+                const isReadonly = exec.value === 'agents';
+                return (
+                  <Col span={12} key={exec.value}>
+                    <Checkbox value={exec.value} disabled={isReadonly}>
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                        <span style={{
+                          width: 6, height: 6, borderRadius: '50%',
+                          backgroundColor: exec.color,
+                        }} />
+                        {exec.label}
+                        {isReadonly && <Tag color="default" style={{ fontSize: 10 }}>只读</Tag>}
+                        {alreadyHas && <Tag color="orange" style={{ fontSize: 10 }}>已存在</Tag>}
+                      </span>
+                    </Checkbox>
+                  </Col>
+                );
+              })}
+            </Row>
+          </Checkbox.Group>
+        </Modal>
+      </Drawer>
+
+      {/* 全屏文件浏览器模态框 */}
       <Modal
         title={
           <Space>
-            <SwapOutlined style={{ color: '#7C3AED' }} />
-            <span>同步 Skill 到其他执行器</span>
+            <FolderOutlined style={{ color: EXECUTOR_COLORS[executor] || '#7C3AED' }} />
+            <span>{skill?.name} - 文件浏览</span>
+            <Tag color={EXECUTOR_COLORS[executor]}>{executorLabel}</Tag>
+            <Tag color="default">{files.length} 个文件</Tag>
           </Space>
         }
-        open={syncModalOpen}
-        onCancel={() => setSyncModalOpen(false)}
-        onOk={handleSync}
-        okText={`同步到 ${targetExecutors.length} 个执行器`}
-        okButtonProps={{ disabled: targetExecutors.length === 0 }}
-        confirmLoading={syncing}
-        width={480}
+        open={fileBrowserOpen}
+        onCancel={() => setFileBrowserOpen(false)}
+        footer={null}
+        width="90vw"
+        style={{ top: 20 }}
+        styles={{
+          body: {
+            height: 'calc(100vh - 100px)',
+            padding: 0,
+            display: 'flex',
+            flexDirection: 'column',
+          },
+        }}
       >
-        <div style={{ marginBottom: 16 }}>
-          <Text type="secondary">
-            将 <Text strong>{skill?.name}</Text> 从 <Tag color={EXECUTOR_COLORS[executor]}>{executorLabel}</Tag> 复制到以下执行器：
-          </Text>
+        <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+          {/* 左侧：文件树 */}
+          <div style={{
+            flex: '0 0 280px',
+            borderRight: `1px solid ${isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'}`,
+            overflow: 'auto',
+            background: isDark ? '#1a1a2e' : '#fff',
+          }}>
+            <SkillFileBrowser
+              files={files}
+              loading={loading}
+              onFileSelect={setSelectedFile}
+              selectedFile={selectedFile}
+              isDark={isDark}
+            />
+          </div>
+          {/* 右侧：文件预览 */}
+          <div style={{
+            flex: 1,
+            overflow: 'auto',
+            background: isDark ? '#1a1a2e' : '#fff',
+          }}>
+            <SkillFilePreview
+              file={selectedFile}
+              executor={executor}
+              skillName={skill?.name || ''}
+              isDark={isDark}
+            />
+          </div>
         </div>
-        <Checkbox.Group
-          value={targetExecutors}
-          onChange={v => setTargetExecutors(v as string[])}
-          style={{ width: '100%' }}
-        >
-          <Row gutter={[8, 8]}>
-            {EXECUTORS.filter(e => e.value !== executor).map(exec => {
-              const exists = executorsData.find(ex => ex.executor === exec.value);
-              const targetName = skill?.name?.split('/').pop() || skill?.name;
-              const alreadyHas = exists?.skills.find(s => s.name === targetName);
-              // agents 是只读来源，不能作为同步目标
-              const isReadonly = exec.value === 'agents';
-              return (
-                <Col span={12} key={exec.value}>
-                  <Checkbox value={exec.value} disabled={isReadonly}>
-                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-                      <span style={{
-                        width: 6, height: 6, borderRadius: '50%',
-                        backgroundColor: exec.color,
-                      }} />
-                      {exec.label}
-                      {isReadonly && <Tag color="default" style={{ fontSize: 10 }}>只读</Tag>}
-                      {alreadyHas && <Tag color="orange" style={{ fontSize: 10 }}>已存在</Tag>}
-                    </span>
-                  </Checkbox>
-                </Col>
-              );
-            })}
-          </Row>
-        </Checkbox.Group>
       </Modal>
-    </Drawer>
+    </>
   );
 }

--- a/frontend/src/components/skills/SkillFileBrowser.tsx
+++ b/frontend/src/components/skills/SkillFileBrowser.tsx
@@ -4,7 +4,7 @@ import {
   SearchOutlined, FileOutlined, FolderOutlined, FolderOpenOutlined,
 } from '@ant-design/icons';
 import type { SkillFileInfo } from '@/utils/database/skills';
-import { formatSize } from './helpers';
+import { formatSize, getFileColor } from './helpers';
 
 const { Text } = Typography;
 
@@ -116,7 +116,7 @@ function FileTreeNodeItem({
   isDark?: boolean;
 }) {
   const isExpanded = expandedDirs.has(node.path);
-  const isSelected = selectedFile?.path === node.file?.path;
+  const isSelected = selectedFile !== null && node.file !== undefined && selectedFile?.path === node.file?.path;
 
   const handleClick = () => {
     if (node.isDir) {
@@ -124,26 +124,6 @@ function FileTreeNodeItem({
     } else if (node.file && onFileSelect) {
       onFileSelect(node.file);
     }
-  };
-
-  // 根据文件扩展名获取图标颜色
-  const getFileColor = (name: string) => {
-    const ext = name.split('.').pop()?.toLowerCase();
-    const colorMap: Record<string, string> = {
-      md: '#0891b2',
-      ts: '#3178c6',
-      tsx: '#3178c6',
-      js: '#f7df1e',
-      jsx: '#f7df1e',
-      json: '#f59e0b',
-      yaml: '#e11d48',
-      yml: '#e11d48',
-      toml: '#9333ea',
-      txt: isDark ? '#94a3b8' : '#64748b',
-      css: '#06b6d4',
-      html: '#ea580c',
-    };
-    return colorMap[ext || ''] || (isDark ? '#94a3b8' : '#64748b');
   };
 
   // 主题相关颜色
@@ -204,7 +184,7 @@ function FileTreeNodeItem({
             <FolderOutlined style={{ color: '#f59e0b', fontSize: 14 }} />
           )
         ) : (
-          <FileOutlined style={{ color: getFileColor(node.name), fontSize: 14 }} />
+          <FileOutlined style={{ color: getFileColor(node.name, isDark), fontSize: 14 }} />
         )}
 
         {/* 文件名 */}

--- a/frontend/src/components/skills/SkillFileBrowser.tsx
+++ b/frontend/src/components/skills/SkillFileBrowser.tsx
@@ -24,7 +24,9 @@ interface FileTreeNode {
   file?: SkillFileInfo;
 }
 
-// 构建文件树结构
+// 将文件列表按路径层级构建为树结构，支持目录嵌套展示。
+// 使用线性查找而非 Map：文件数量通常不多（<100），Map 初始化成本不划算；
+// 同时保持节点顺序与文件列表顺序一致，利于调试和人类阅读。
 function buildFileTree(files: SkillFileInfo[]): FileTreeNode {
   const root: FileTreeNode = {
     name: '/',
@@ -64,7 +66,9 @@ function buildFileTree(files: SkillFileInfo[]): FileTreeNode {
   return root;
 }
 
-// 过滤文件树
+// 根据搜索词递归过滤文件树，保留匹配的目录路径（即使目录本身不匹配，只要子节点有匹配就保留）。
+// 目录名匹配时保留整棵子树；文件名校验大小写不敏感。
+// 返回 null 表示该节点及所有子节点均不匹配，可直接跳过。
 function filterFileTree(node: FileTreeNode, searchText: string): FileTreeNode | null {
   if (!searchText) return node;
 
@@ -92,7 +96,8 @@ function filterFileTree(node: FileTreeNode, searchText: string): FileTreeNode | 
   };
 }
 
-// 单个文件/文件夹节点组件
+// 递归渲染文件树节点，支持展开/折叠目录、选中文件、键盘操作。
+// 使用普通 div 而非 ul/li 结构以简化样式控制，同时通过 role="treeitem" 保留无障碍语义。
 function FileTreeNodeItem({
   node,
   level,
@@ -150,7 +155,15 @@ function FileTreeNodeItem({
   return (
     <div>
       <div
+        role="treeitem"
+        tabIndex={0}
         onClick={handleClick}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleClick();
+          }
+        }}
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -236,6 +249,9 @@ function FileTreeNodeItem({
   );
 }
 
+// SkillFileBrowser：文件树浏览组件。
+// 接收文件列表，构建树结构后递归渲染；支持搜索过滤、目录展开/折叠、文件选中高亮。
+// 内部状态：searchText（搜索词）、expandedDirs（已展开目录集合）。
 export function SkillFileBrowser({ files, loading, onFileSelect, selectedFile, isDark }: SkillFileBrowserProps) {
   const [searchText, setSearchText] = useState('');
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set(['']));
@@ -259,7 +275,8 @@ export function SkillFileBrowser({ files, loading, onFileSelect, selectedFile, i
     });
   };
 
-  // 搜索时自动展开所有目录
+  // 搜索时自动展开所有目录，确保匹配结果可见；
+  // 取消搜索时不做特殊处理，已展开的目录由 expandedDirs 状态保持。
   const handleSearch = (value: string) => {
     setSearchText(value);
     if (value) {

--- a/frontend/src/components/skills/SkillFileBrowser.tsx
+++ b/frontend/src/components/skills/SkillFileBrowser.tsx
@@ -1,0 +1,343 @@
+import { useState, useMemo } from 'react';
+import { Input, Spin, Typography, Empty } from 'antd';
+import {
+  SearchOutlined, FileOutlined, FolderOutlined, FolderOpenOutlined,
+} from '@ant-design/icons';
+import type { SkillFileInfo } from '@/utils/database/skills';
+import { formatSize } from './helpers';
+
+const { Text } = Typography;
+
+interface SkillFileBrowserProps {
+  files: SkillFileInfo[];
+  loading?: boolean;
+  onFileSelect?: (file: SkillFileInfo) => void;
+  selectedFile?: SkillFileInfo | null;
+  isDark?: boolean;
+}
+
+interface FileTreeNode {
+  name: string;
+  path: string;
+  isDir: boolean;
+  children: FileTreeNode[];
+  file?: SkillFileInfo;
+}
+
+// 构建文件树结构
+function buildFileTree(files: SkillFileInfo[]): FileTreeNode {
+  const root: FileTreeNode = {
+    name: '/',
+    path: '',
+    isDir: true,
+    children: [],
+  };
+
+  files.forEach(file => {
+    const parts = file.path.split('/').filter(Boolean);
+    let current = root;
+
+    parts.forEach((part, index) => {
+      const isLast = index === parts.length - 1;
+      const existingChild = current.children.find(c => c.name === part);
+
+      if (existingChild) {
+        if (isLast) {
+          existingChild.file = file;
+          existingChild.isDir = false;
+        }
+        current = existingChild;
+      } else {
+        const newNode: FileTreeNode = {
+          name: part,
+          path: parts.slice(0, index + 1).join('/'),
+          isDir: !isLast,
+          children: [],
+          file: isLast ? file : undefined,
+        };
+        current.children.push(newNode);
+        current = newNode;
+      }
+    });
+  });
+
+  return root;
+}
+
+// 过滤文件树
+function filterFileTree(node: FileTreeNode, searchText: string): FileTreeNode | null {
+  if (!searchText) return node;
+
+  const lowerSearch = searchText.toLowerCase();
+  const filteredChildren: FileTreeNode[] = [];
+
+  node.children.forEach(child => {
+    if (child.isDir) {
+      const filteredChild = filterFileTree(child, searchText);
+      if (filteredChild && filteredChild.children.length > 0) {
+        filteredChildren.push(filteredChild);
+      }
+    } else if (child.name.toLowerCase().includes(lowerSearch)) {
+      filteredChildren.push(child);
+    }
+  });
+
+  if (filteredChildren.length === 0 && !node.name.toLowerCase().includes(lowerSearch)) {
+    return null;
+  }
+
+  return {
+    ...node,
+    children: filteredChildren,
+  };
+}
+
+// 单个文件/文件夹节点组件
+function FileTreeNodeItem({
+  node,
+  level,
+  onFileSelect,
+  selectedFile,
+  expandedDirs,
+  onToggleDir,
+  isDark,
+}: {
+  node: FileTreeNode;
+  level: number;
+  onFileSelect?: (file: SkillFileInfo) => void;
+  selectedFile?: SkillFileInfo | null;
+  expandedDirs: Set<string>;
+  onToggleDir: (path: string) => void;
+  isDark?: boolean;
+}) {
+  const isExpanded = expandedDirs.has(node.path);
+  const isSelected = selectedFile?.path === node.file?.path;
+
+  const handleClick = () => {
+    if (node.isDir) {
+      onToggleDir(node.path);
+    } else if (node.file && onFileSelect) {
+      onFileSelect(node.file);
+    }
+  };
+
+  // 根据文件扩展名获取图标颜色
+  const getFileColor = (name: string) => {
+    const ext = name.split('.').pop()?.toLowerCase();
+    const colorMap: Record<string, string> = {
+      md: '#0891b2',
+      ts: '#3178c6',
+      tsx: '#3178c6',
+      js: '#f7df1e',
+      jsx: '#f7df1e',
+      json: '#f59e0b',
+      yaml: '#e11d48',
+      yml: '#e11d48',
+      toml: '#9333ea',
+      txt: isDark ? '#94a3b8' : '#64748b',
+      css: '#06b6d4',
+      html: '#ea580c',
+    };
+    return colorMap[ext || ''] || (isDark ? '#94a3b8' : '#64748b');
+  };
+
+  // 主题相关颜色
+  const hoverBg = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)';
+  const selectedBg = isDark ? 'rgba(59, 130, 246, 0.2)' : 'rgba(37, 99, 235, 0.1)';
+  const textColor = isDark ? '#e2e8f0' : '#1e293b';
+  const secondaryColor = isDark ? '#94a3b8' : '#64748b';
+
+  return (
+    <div>
+      <div
+        onClick={handleClick}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          padding: '6px 8px',
+          paddingLeft: `${level * 16 + 8}px`,
+          cursor: 'pointer',
+          borderRadius: 4,
+          background: isSelected ? selectedBg : 'transparent',
+          borderLeft: isSelected ? '2px solid #3b82f6' : '2px solid transparent',
+          transition: 'all 0.15s',
+        }}
+        onMouseEnter={e => {
+          if (!isSelected) {
+            e.currentTarget.style.background = hoverBg;
+          }
+        }}
+        onMouseLeave={e => {
+          if (!isSelected) {
+            e.currentTarget.style.background = 'transparent';
+          }
+        }}
+      >
+        {/* 展开/折叠图标 */}
+        {node.isDir ? (
+          <span style={{ fontSize: 10, color: secondaryColor, width: 12 }}>
+            {isExpanded ? '▼' : '▶'}
+          </span>
+        ) : (
+          <span style={{ width: 12 }} />
+        )}
+
+        {/* 文件/文件夹图标 */}
+        {node.isDir ? (
+          isExpanded ? (
+            <FolderOpenOutlined style={{ color: '#f59e0b', fontSize: 14 }} />
+          ) : (
+            <FolderOutlined style={{ color: '#f59e0b', fontSize: 14 }} />
+          )
+        ) : (
+          <FileOutlined style={{ color: getFileColor(node.name), fontSize: 14 }} />
+        )}
+
+        {/* 文件名 */}
+        <Text
+          style={{
+            fontSize: 13,
+            flex: 1,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            color: isSelected ? '#3b82f6' : textColor,
+            fontWeight: isSelected ? 500 : 400,
+          }}
+        >
+          {node.name}
+        </Text>
+
+        {/* 文件大小 */}
+        {node.file && (
+          <Text
+            style={{ fontSize: 11, flexShrink: 0, color: secondaryColor }}
+          >
+            {formatSize(node.file.size)}
+          </Text>
+        )}
+      </div>
+
+      {/* 子节点 */}
+      {node.isDir && isExpanded && node.children.map(child => (
+        <FileTreeNodeItem
+          key={child.path}
+          node={child}
+          level={level + 1}
+          onFileSelect={onFileSelect}
+          selectedFile={selectedFile}
+          expandedDirs={expandedDirs}
+          onToggleDir={onToggleDir}
+          isDark={isDark}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function SkillFileBrowser({ files, loading, onFileSelect, selectedFile, isDark }: SkillFileBrowserProps) {
+  const [searchText, setSearchText] = useState('');
+  const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set(['']));
+
+  // 构建文件树
+  const fileTree = useMemo(() => buildFileTree(files), [files]);
+
+  // 过滤后的文件树
+  const filteredTree = useMemo(() => filterFileTree(fileTree, searchText), [fileTree, searchText]);
+
+  // 切换目录展开/折叠
+  const handleToggleDir = (path: string) => {
+    setExpandedDirs(prev => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  };
+
+  // 搜索时自动展开所有目录
+  const handleSearch = (value: string) => {
+    setSearchText(value);
+    if (value) {
+      // 搜索时展开所有匹配的目录路径
+      const allDirs = new Set<string>(['']);
+      files.forEach(file => {
+        const parts = file.path.split('/').filter(Boolean);
+        parts.forEach((_, index) => {
+          allDirs.add(parts.slice(0, index + 1).join('/'));
+        });
+      });
+      setExpandedDirs(allDirs);
+    }
+  };
+
+  // 主题相关颜色
+  const borderColor = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)';
+  const secondaryColor = isDark ? '#94a3b8' : '#64748b';
+
+  if (loading) {
+    return (
+      <div style={{ textAlign: 'center', padding: 40 }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* 搜索栏 */}
+      <div style={{ padding: '12px 12px 8px' }}>
+        <Input
+          placeholder="搜索文件..."
+          prefix={<SearchOutlined style={{ color: secondaryColor }} />}
+          value={searchText}
+          onChange={e => handleSearch(e.target.value)}
+          allowClear
+          size="small"
+          style={{ borderRadius: 6 }}
+        />
+      </div>
+
+      {/* 文件统计 */}
+      <div style={{
+        fontSize: 12,
+        color: secondaryColor,
+        padding: '0 12px 8px',
+        borderBottom: `1px solid ${borderColor}`,
+      }}>
+        共 {files.length} 个文件
+      </div>
+
+      {/* 文件树 */}
+      <div style={{
+        flex: 1,
+        overflow: 'auto',
+        padding: '4px 0',
+      }}>
+        {filteredTree && filteredTree.children.length > 0 ? (
+          filteredTree.children.map(node => (
+            <FileTreeNodeItem
+              key={node.path}
+              node={node}
+              level={0}
+              onFileSelect={onFileSelect}
+              selectedFile={selectedFile}
+              expandedDirs={expandedDirs}
+              onToggleDir={handleToggleDir}
+              isDark={isDark}
+            />
+          ))
+        ) : (
+          <Empty
+            description={searchText ? '没有匹配的文件' : '暂无文件'}
+            style={{ padding: '40px 0' }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/skills/SkillFilePreview.tsx
+++ b/frontend/src/components/skills/SkillFilePreview.tsx
@@ -1,0 +1,182 @@
+import { useState, useEffect } from 'react';
+import { Spin, Typography, Tag, Space, Button, message } from 'antd';
+import {
+  DownloadOutlined, CopyOutlined, FileOutlined,
+} from '@ant-design/icons';
+import XMarkdown from '@ant-design/x-markdown';
+import type { SkillFileInfo } from '@/utils/database/skills';
+import { getSkillContent } from '@/utils/database/skills';
+import { formatSize, formatTime } from './helpers';
+
+const { Text } = Typography;
+
+interface SkillFilePreviewProps {
+  file: SkillFileInfo | null;
+  executor: string;
+  skillName: string;
+  loading?: boolean;
+  isDark?: boolean;
+}
+
+// 获取文件扩展名对应的图标颜色
+function getFileColor(filename: string, isDark?: boolean): string {
+  const ext = filename.split('.').pop()?.toLowerCase();
+  const colorMap: Record<string, string> = {
+    md: '#0891b2',
+    ts: '#3178c6',
+    tsx: '#3178c6',
+    js: '#f7df1e',
+    jsx: '#f7df1e',
+    json: '#f59e0b',
+    yaml: '#e11d48',
+    yml: '#e11d48',
+    toml: '#9333ea',
+    txt: isDark ? '#94a3b8' : '#64748b',
+    css: '#06b6d4',
+    html: '#ea580c',
+  };
+  return colorMap[ext || ''] || (isDark ? '#94a3b8' : '#64748b');
+}
+
+export function SkillFilePreview({ file, executor, skillName, loading, isDark }: SkillFilePreviewProps) {
+  const [content, setContent] = useState<string>('');
+  const [contentLoading, setContentLoading] = useState(false);
+
+  // 加载文件内容
+  useEffect(() => {
+    if (!file) {
+      setContent('');
+      return;
+    }
+
+    // 对于 SKILL.md 文件，使用主内容
+    if (file.path === 'SKILL.md') {
+      setContentLoading(true);
+      getSkillContent(executor, skillName)
+        .then(data => setContent(data.content))
+        .catch(() => setContent('无法加载文件内容'))
+        .finally(() => setContentLoading(false));
+      return;
+    }
+
+    // 对于其他文件，需要通过 API 获取内容
+    // 目前后端没有提供单文件内容 API，这里显示文件信息
+    setContentLoading(true);
+    // 模拟加载延迟
+    setTimeout(() => {
+      setContentLoading(false);
+      setContent(`# ${file.path}\n\n文件信息：\n- 大小: ${formatSize(file.size)}\n- 修改时间: ${formatTime(file.modified_at)}\n\n---\n\n文件内容预览功能开发中...`);
+    }, 300);
+  }, [file, executor, skillName]);
+
+  // 主题相关颜色
+  const bgColor = isDark ? '#1a1a2e' : '#1e1e1e';
+  const headerBg = isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.02)';
+  const borderColor = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)';
+  const secondaryColor = isDark ? '#94a3b8' : '#64748b';
+
+  if (!file) {
+    return (
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100%',
+        color: secondaryColor,
+      }}>
+        <FileOutlined style={{ fontSize: 48, marginBottom: 16, opacity: 0.5 }} />
+        <Text style={{ color: secondaryColor }}>选择一个文件查看内容</Text>
+      </div>
+    );
+  }
+
+  if (contentLoading || loading) {
+    return (
+      <div style={{ textAlign: 'center', padding: 40 }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* 文件头部信息 */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '8px 12px',
+        background: headerBg,
+        borderRadius: '8px 8px 0 0',
+        borderBottom: `1px solid ${borderColor}`,
+      }}>
+        <Space size={8}>
+          <FileOutlined style={{ color: getFileColor(file.path, isDark) }} />
+          <Text strong style={{ fontSize: 13 }}>{file.path}</Text>
+          <Tag color="default" style={{ fontSize: 11, lineHeight: '16px', padding: '0 6px' }}>
+            {formatSize(file.size)}
+          </Tag>
+        </Space>
+        <Space size={4}>
+          <Button
+            type="text"
+            size="small"
+            icon={<CopyOutlined />}
+            onClick={() => {
+              navigator.clipboard.writeText(content);
+              message.success('已复制到剪贴板');
+            }}
+          />
+          <Button
+            type="text"
+            size="small"
+            icon={<DownloadOutlined />}
+            onClick={() => {
+              const blob = new Blob([content], { type: 'text/plain' });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = file.path.split('/').pop() || 'file';
+              a.click();
+              URL.revokeObjectURL(url);
+            }}
+          />
+        </Space>
+      </div>
+
+      {/* 文件内容 */}
+      <div style={{
+        flex: 1,
+        overflow: 'auto',
+        background: bgColor,
+        borderRadius: '0 0 8px 8px',
+      }}>
+        {file.path.endsWith('.md') ? (
+          <XMarkdown
+            content={content}
+            escapeRawHtml={true}
+            style={{
+              fontFamily: 'Fira Code, monospace',
+              fontSize: 13,
+              color: '#d4d4d4',
+              padding: '12px',
+            }}
+          />
+        ) : (
+          <pre style={{
+            fontFamily: 'Fira Code, monospace',
+            fontSize: 13,
+            color: '#d4d4d4',
+            padding: '12px',
+            margin: 0,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}>
+            {content}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/skills/SkillFilePreview.tsx
+++ b/frontend/src/components/skills/SkillFilePreview.tsx
@@ -6,7 +6,7 @@ import {
 import XMarkdown from '@ant-design/x-markdown';
 import type { SkillFileInfo } from '@/utils/database/skills';
 import { getSkillContent, getSkillFileContent } from '@/utils/database/skills';
-import { formatSize, formatTime } from './helpers';
+import { formatSize, formatTime, getFileColor } from './helpers';
 
 const { Text } = Typography;
 
@@ -16,26 +16,6 @@ interface SkillFilePreviewProps {
   skillName: string;
   loading?: boolean;
   isDark?: boolean;
-}
-
-// 获取文件扩展名对应的图标颜色
-function getFileColor(filename: string, isDark?: boolean): string {
-  const ext = filename.split('.').pop()?.toLowerCase();
-  const colorMap: Record<string, string> = {
-    md: '#0891b2',
-    ts: '#3178c6',
-    tsx: '#3178c6',
-    js: '#f7df1e',
-    jsx: '#f7df1e',
-    json: '#f59e0b',
-    yaml: '#e11d48',
-    yml: '#e11d48',
-    toml: '#9333ea',
-    txt: isDark ? '#94a3b8' : '#64748b',
-    css: '#06b6d4',
-    html: '#ea580c',
-  };
-  return colorMap[ext || ''] || (isDark ? '#94a3b8' : '#64748b');
 }
 
 export function SkillFilePreview({ file, executor, skillName, loading, isDark }: SkillFilePreviewProps) {

--- a/frontend/src/components/skills/SkillFilePreview.tsx
+++ b/frontend/src/components/skills/SkillFilePreview.tsx
@@ -122,8 +122,9 @@ export function SkillFilePreview({ file, executor, skillName, loading, isDark }:
             size="small"
             icon={<CopyOutlined />}
             onClick={() => {
-              navigator.clipboard.writeText(content);
-              message.success('已复制到剪贴板');
+              navigator.clipboard.writeText(content)
+                .then(() => message.success('已复制到剪贴板'))
+                .catch(() => message.error('复制失败'));
             }}
           />
           <Button

--- a/frontend/src/components/skills/SkillFilePreview.tsx
+++ b/frontend/src/components/skills/SkillFilePreview.tsx
@@ -5,7 +5,7 @@ import {
 } from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
 import type { SkillFileInfo } from '@/utils/database/skills';
-import { getSkillContent } from '@/utils/database/skills';
+import { getSkillContent, getSkillFileContent } from '@/utils/database/skills';
 import { formatSize, formatTime } from './helpers';
 
 const { Text } = Typography;
@@ -59,14 +59,12 @@ export function SkillFilePreview({ file, executor, skillName, loading, isDark }:
       return;
     }
 
-    // 对于其他文件，需要通过 API 获取内容
-    // 目前后端没有提供单文件内容 API，这里显示文件信息
+    // 对于其他文件，通过 API 获取单文件内容
     setContentLoading(true);
-    // 模拟加载延迟
-    setTimeout(() => {
-      setContentLoading(false);
-      setContent(`# ${file.path}\n\n文件信息：\n- 大小: ${formatSize(file.size)}\n- 修改时间: ${formatTime(file.modified_at)}\n\n---\n\n文件内容预览功能开发中...`);
-    }, 300);
+    getSkillFileContent(executor, skillName, file.path)
+      .then(data => setContent(data.content))
+      .catch(() => setContent(`# ${file.path}\n\n文件信息：\n- 大小: ${formatSize(file.size)}\n- 修改时间: ${formatTime(file.modified_at)}\n\n---\n\n[无法加载文件内容]`))
+      .finally(() => setContentLoading(false));
   }, [file, executor, skillName]);
 
   // 主题相关颜色

--- a/frontend/src/components/skills/helpers.ts
+++ b/frontend/src/components/skills/helpers.ts
@@ -13,6 +13,26 @@ export function formatSize(bytes: number): string {
 
 export { formatDateTime as formatTime };
 
+// 根据文件扩展名返回对应图标颜色，减少重复定义
+export function getFileColor(filename: string, isDark = false): string {
+  const ext = filename.split('.').pop()?.toLowerCase();
+  const colorMap: Record<string, string> = {
+    md: '#0891b2',
+    ts: '#3178c6',
+    tsx: '#3178c6',
+    js: '#f7df1e',
+    jsx: '#f7df1e',
+    json: '#f59e0b',
+    yaml: '#e11d48',
+    yml: '#e11d48',
+    toml: '#9333ea',
+    txt: isDark ? '#94a3b8' : '#64748b',
+    css: '#06b6d4',
+    html: '#ea580c',
+  };
+  return colorMap[ext || ''] || (isDark ? '#94a3b8' : '#64748b');
+}
+
 export function normalizeExecutor(name: string): string {
   return name.toLowerCase().replace(/[_\s-]/g, '');
 }

--- a/frontend/src/utils/database/skills.ts
+++ b/frontend/src/utils/database/skills.ts
@@ -51,6 +51,17 @@ export async function getSkillContent(executor: string, skillName: string): Prom
   }));
 }
 
+export interface SkillFileContent {
+  path: string;
+  content: string;
+}
+
+export async function getSkillFileContent(executor: string, skillName: string, path: string): Promise<SkillFileContent> {
+  return unwrap(await api.get('/api/skills/file', {
+    params: { executor, skill_name: skillName, path },
+  }));
+}
+
 export async function exportSkill(executor: string, skillName: string): Promise<Blob> {
   const response = await api.get('/api/skills/export', {
     params: { executor, skill_name: skillName },

--- a/frontend/tests/check_skill_file_browser.spec.ts
+++ b/frontend/tests/check_skill_file_browser.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Skill 文件浏览器功能', () => {
+  test.beforeEach(async ({ page }) => {
+    // 访问 Skills 页面
+    await page.goto('http://localhost:5173');
+    await page.waitForLoadState('networkidle');
+    
+    // 等待 Skills 面板加载
+    await page.waitForSelector('text=Skills', { timeout: 10000 });
+  });
+
+  test('点击 Skill 卡片应显示详情抽屉', async ({ page }) => {
+    // 等待 Skill 卡片加载
+    await page.waitForSelector('.skill-card', { timeout: 10000 });
+    
+    // 点击第一个 Skill 卡片
+    const firstCard = page.locator('.skill-card').first();
+    await firstCard.click();
+    
+    // 等待抽屉打开
+    await page.waitForSelector('.ant-drawer-content', { timeout: 5000 });
+    
+    // 验证抽屉标题包含 Skill 名称
+    const drawerTitle = page.locator('.ant-drawer-title');
+    await expect(drawerTitle).toBeVisible();
+  });
+
+  test('应显示标签页切换（内容预览和文件浏览）', async ({ page }) => {
+    // 等待 Skill 卡片加载
+    await page.waitForSelector('.skill-card', { timeout: 10000 });
+    
+    // 点击第一个 Skill 卡片
+    const firstCard = page.locator('.skill-card').first();
+    await firstCard.click();
+    
+    // 等待抽屉打开
+    await page.waitForSelector('.ant-drawer-content', { timeout: 5000 });
+    
+    // 验证标签页存在
+    await expect(page.locator('text=内容预览')).toBeVisible();
+    await expect(page.locator('text=文件浏览')).toBeVisible();
+  });
+
+  test('点击文件浏览标签页应显示文件浏览器', async ({ page }) => {
+    // 等待 Skill 卡片加载
+    await page.waitForSelector('.skill-card', { timeout: 10000 });
+    
+    // 点击第一个 Skill 卡片
+    const firstCard = page.locator('.skill-card').first();
+    await firstCard.click();
+    
+    // 等待抽屉打开
+    await page.waitForSelector('.ant-drawer-content', { timeout: 5000 });
+    
+    // 点击文件浏览标签页
+    await page.click('text=文件浏览');
+    
+    // 验证文件浏览器显示
+    await expect(page.locator('text=搜索文件...')).toBeVisible();
+  });
+
+  test('文件浏览器应显示搜索框和文件统计', async ({ page }) => {
+    // 等待 Skill 卡片加载
+    await page.waitForSelector('.skill-card', { timeout: 10000 });
+    
+    // 点击第一个 Skill 卡片
+    const firstCard = page.locator('.skill-card').first();
+    await firstCard.click();
+    
+    // 等待抽屉打开
+    await page.waitForSelector('.ant-drawer-content', { timeout: 5000 });
+    
+    // 点击文件浏览标签页
+    await page.click('text=文件浏览');
+    
+    // 验证搜索框存在
+    await expect(page.locator('input[placeholder="搜索文件..."]')).toBeVisible();
+    
+    // 验证文件统计显示
+    await expect(page.locator('text=/共 \\d+ 个文件/')).toBeVisible();
+  });
+
+  test('搜索框应能过滤文件列表', async ({ page }) => {
+    // 等待 Skill 卡片加载
+    await page.waitForSelector('.skill-card', { timeout: 10000 });
+    
+    // 点击第一个 Skill 卡片
+    const firstCard = page.locator('.skill-card').first();
+    await firstCard.click();
+    
+    // 等待抽屉打开
+    await page.waitForSelector('.ant-drawer-content', { timeout: 5000 });
+    
+    // 点击文件浏览标签页
+    await page.click('text=文件浏览');
+    
+    // 在搜索框中输入内容
+    const searchInput = page.locator('input[placeholder="搜索文件..."]');
+    await searchInput.fill('SKILL');
+    
+    // 验证文件列表被过滤
+    await page.waitForTimeout(500);
+    
+    // 清空搜索框
+    await searchInput.clear();
+  });
+
+  test('点击文件应显示文件预览', async ({ page }) => {
+    // 等待 Skill 卡片加载
+    await page.waitForSelector('.skill-card', { timeout: 10000 });
+    
+    // 点击第一个 Skill 卡片
+    const firstCard = page.locator('.skill-card').first();
+    await firstCard.click();
+    
+    // 等待抽屉打开
+    await page.waitForSelector('.ant-drawer-content', { timeout: 5000 });
+    
+    // 点击文件浏览标签页
+    await page.click('text=文件浏览');
+    
+    // 等待文件列表加载
+    await page.waitForTimeout(1000);
+    
+    // 点击第一个文件（如果存在）
+    const firstFile = page.locator('[style*="cursor: pointer"]').first();
+    if (await firstFile.isVisible()) {
+      await firstFile.click();
+      
+      // 验证文件预览区域显示
+      await page.waitForTimeout(500);
+    }
+  });
+});

--- a/frontend/tests/check_skill_file_browser.spec.ts
+++ b/frontend/tests/check_skill_file_browser.spec.ts
@@ -3,9 +3,9 @@ import { test, expect } from '@playwright/test';
 test.describe('Skill 文件浏览器功能', () => {
   test.beforeEach(async ({ page }) => {
     // 访问 Skills 页面
-    await page.goto('http://localhost:5173');
+    await page.goto('http://localhost:18088');
     await page.waitForLoadState('networkidle');
-    
+
     // 等待 Skills 面板加载
     await page.waitForSelector('text=Skills', { timeout: 10000 });
   });
@@ -13,95 +13,88 @@ test.describe('Skill 文件浏览器功能', () => {
   test('点击 Skill 卡片应显示详情抽屉', async ({ page }) => {
     // 等待 Skill 卡片加载
     await page.waitForSelector('.skill-card', { timeout: 10000 });
-    
+
     // 点击第一个 Skill 卡片
     const firstCard = page.locator('.skill-card').first();
     await firstCard.click();
-    
+
     // 等待抽屉打开
     await page.waitForSelector('.ant-drawer-content', { timeout: 5000 });
-    
+
     // 验证抽屉标题包含 Skill 名称
     const drawerTitle = page.locator('.ant-drawer-title');
     await expect(drawerTitle).toBeVisible();
   });
 
-  test('应显示标签页切换（内容预览和文件浏览）', async ({ page }) => {
+  test('浏览文件按钮应能打开文件浏览器模态框', async ({ page }) => {
     // 等待 Skill 卡片加载
     await page.waitForSelector('.skill-card', { timeout: 10000 });
-    
-    // 点击第一个 Skill 卡片
-    const firstCard = page.locator('.skill-card').first();
-    await firstCard.click();
-    
-    // 等待抽屉打开
-    await page.waitForSelector('.ant-drawer-content', { timeout: 5000 });
-    
-    // 验证标签页存在
-    await expect(page.locator('text=内容预览')).toBeVisible();
-    await expect(page.locator('text=文件浏览')).toBeVisible();
-  });
 
-  test('点击文件浏览标签页应显示文件浏览器', async ({ page }) => {
-    // 等待 Skill 卡片加载
-    await page.waitForSelector('.skill-card', { timeout: 10000 });
-    
     // 点击第一个 Skill 卡片
     const firstCard = page.locator('.skill-card').first();
     await firstCard.click();
-    
+
     // 等待抽屉打开
     await page.waitForSelector('.ant-drawer-content', { timeout: 5000 });
-    
-    // 点击文件浏览标签页
-    await page.click('text=文件浏览');
-    
-    // 验证文件浏览器显示
-    await expect(page.locator('text=搜索文件...')).toBeVisible();
+
+    // 点击"浏览文件"按钮
+    await page.click('text=浏览文件');
+
+    // 验证模态框打开
+    await expect(page.locator('.ant-modal')).toBeVisible();
+
+    // 验证文件浏览器内容显示
+    await expect(page.locator('input[placeholder="搜索文件..."]')).toBeVisible();
   });
 
   test('文件浏览器应显示搜索框和文件统计', async ({ page }) => {
     // 等待 Skill 卡片加载
     await page.waitForSelector('.skill-card', { timeout: 10000 });
-    
+
     // 点击第一个 Skill 卡片
     const firstCard = page.locator('.skill-card').first();
     await firstCard.click();
-    
+
     // 等待抽屉打开
     await page.waitForSelector('.ant-drawer-content', { timeout: 5000 });
-    
-    // 点击文件浏览标签页
-    await page.click('text=文件浏览');
-    
+
+    // 点击"浏览文件"按钮
+    await page.click('text=浏览文件');
+
+    // 验证模态框打开
+    await expect(page.locator('.ant-modal')).toBeVisible();
+
     // 验证搜索框存在
     await expect(page.locator('input[placeholder="搜索文件..."]')).toBeVisible();
-    
-    // 验证文件统计显示
+
+    // 验证文件统计显示（共 X 个文件）
     await expect(page.locator('text=/共 \\d+ 个文件/')).toBeVisible();
   });
 
   test('搜索框应能过滤文件列表', async ({ page }) => {
     // 等待 Skill 卡片加载
     await page.waitForSelector('.skill-card', { timeout: 10000 });
-    
+
     // 点击第一个 Skill 卡片
     const firstCard = page.locator('.skill-card').first();
     await firstCard.click();
-    
+
     // 等待抽屉打开
     await page.waitForSelector('.ant-drawer-content', { timeout: 5000 });
-    
-    // 点击文件浏览标签页
-    await page.click('text=文件浏览');
-    
+
+    // 点击"浏览文件"按钮
+    await page.click('text=浏览文件');
+
+    // 验证模态框打开
+    await expect(page.locator('.ant-modal')).toBeVisible();
+
     // 在搜索框中输入内容
     const searchInput = page.locator('input[placeholder="搜索文件..."]');
     await searchInput.fill('SKILL');
-    
-    // 验证文件列表被过滤
-    await page.waitForTimeout(500);
-    
+
+    // 等待过滤结果
+    await expect(page.locator('text=/共 \\d+ 个文件/')).toBeVisible();
+
     // 清空搜索框
     await searchInput.clear();
   });
@@ -109,27 +102,26 @@ test.describe('Skill 文件浏览器功能', () => {
   test('点击文件应显示文件预览', async ({ page }) => {
     // 等待 Skill 卡片加载
     await page.waitForSelector('.skill-card', { timeout: 10000 });
-    
+
     // 点击第一个 Skill 卡片
     const firstCard = page.locator('.skill-card').first();
     await firstCard.click();
-    
+
     // 等待抽屉打开
     await page.waitForSelector('.ant-drawer-content', { timeout: 5000 });
-    
-    // 点击文件浏览标签页
-    await page.click('text=文件浏览');
-    
-    // 等待文件列表加载
-    await page.waitForTimeout(1000);
-    
-    // 点击第一个文件（如果存在）
-    const firstFile = page.locator('[style*="cursor: pointer"]').first();
-    if (await firstFile.isVisible()) {
-      await firstFile.click();
-      
-      // 验证文件预览区域显示
-      await page.waitForTimeout(500);
-    }
+
+    // 点击"浏览文件"按钮
+    await page.click('text=浏览文件');
+
+    // 验证模态框打开
+    await expect(page.locator('.ant-modal')).toBeVisible();
+
+    // 点击第一个文件（使用 data-testid 或更稳定的选择器）
+    const firstFile = page.locator('[role="treeitem"]').first();
+    await expect(firstFile).toBeVisible();
+    await firstFile.click();
+
+    // 验证文件预览区域显示（文件路径头部）
+    await expect(page.locator('.ant-modal').locator('text=SKILL.md').or(page.locator('.ant-modal [role="treeitem"]'))).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- 添加 SkillFileBrowser 组件，支持树状文件导航
- 添加 SkillFilePreview 组件，支持文件内容预览
- 将文件浏览改为全屏模态框，提供更好的浏览体验
- 支持暗色/亮色主题适配
- 修复后端符号链接处理，允许只读操作访问符号链接的 skill
- 将操作按钮移入抽屉内部，防止溢出

## Changes

### 后端
- `backend/src/handlers/skills.rs`: 新增 `resolve_skill_path_for_read` 函数，允许只读操作（获取内容、导出）访问符号链接的 skill

### 前端
- `frontend/src/components/skills/SkillFileBrowser.tsx`: 新增文件浏览器组件
- `frontend/src/components/skills/SkillFilePreview.tsx`: 新增文件预览组件
- `frontend/src/components/skills/SkillDetailDrawer.tsx`: 重构抽屉组件，添加全屏文件浏览器模态框

## 测试

- [x] TypeScript 类型检查通过
- [x] 后端 cargo check 通过