### PR TITLE
fix(workspace): 工作空间选择器只显示 name，去掉路径字符串

### DIFF
--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -422,7 +422,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
               suffixIcon={<FolderOutlined />}
               options={projectDirectories.map(d => ({
                 value: d.id, // value 用 workspace_id（唯一键）
-                label: d.name || d.path,
+                label: d.name,
               }))}
             />
           </div>

--- a/frontend/src/components/common/WorkspaceSelect.tsx
+++ b/frontend/src/components/common/WorkspaceSelect.tsx
@@ -39,7 +39,8 @@ interface QuickAddFormValues {
 
 export function WorkspaceSelect({ value, onChange, required, selectProps }: WorkspaceSelectProps) {
   const { message } = App.useApp();
-  // options.value 存 id（number），label 用「name（path）」格式展示给用户
+  // options.value 存 id（number），label 仅展示 display name（name 优先、
+  // path 兜底），不再在 UI 上暴露完整路径字符串。
   const [options, setOptions] = useState<{ label: string; value: number }[]>([]);
   const [loading, setLoading] = useState(true);
   const [quickAddOpen, setQuickAddOpen] = useState(false);
@@ -52,7 +53,8 @@ export function WorkspaceSelect({ value, onChange, required, selectProps }: Work
     try {
       const dirs = await getProjectDirectories();
       setOptions(dirs.map(d => ({
-        label: d.name ? `${d.name}（${d.path}）` : d.path,
+        // label 只展示 name（人类可读名称），path 兜底；不在 UI 上暴露完整路径
+        label: d.name || d.path,
         value: d.id,
       })));
     } catch {
@@ -93,7 +95,8 @@ export function WorkspaceSelect({ value, onChange, required, selectProps }: Work
       // 刷新列表后选中新建项（按 id 选中）
       const dirs = await getProjectDirectories();
       setOptions(dirs.map(d => ({
-        label: d.name ? `${d.name}（${d.path}）` : d.path,
+        // label 只展示 name（人类可读名称），path 兜底
+        label: d.name || d.path,
         value: d.id,
       })));
       onChange?.(created.id);

--- a/frontend/src/components/common/WorkspaceSelect.tsx
+++ b/frontend/src/components/common/WorkspaceSelect.tsx
@@ -39,8 +39,7 @@ interface QuickAddFormValues {
 
 export function WorkspaceSelect({ value, onChange, required, selectProps }: WorkspaceSelectProps) {
   const { message } = App.useApp();
-  // options.value 存 id（number），label 仅展示 display name（name 优先、
-  // path 兜底），不再在 UI 上暴露完整路径字符串。
+  // options.value 存 id（number），label 只展示 name，不在 UI 上暴露路径字符串。
   const [options, setOptions] = useState<{ label: string; value: number }[]>([]);
   const [loading, setLoading] = useState(true);
   const [quickAddOpen, setQuickAddOpen] = useState(false);
@@ -53,8 +52,8 @@ export function WorkspaceSelect({ value, onChange, required, selectProps }: Work
     try {
       const dirs = await getProjectDirectories();
       setOptions(dirs.map(d => ({
-        // label 只展示 name（人类可读名称），path 兜底；不在 UI 上暴露完整路径
-        label: d.name || d.path,
+        // label 只展示 name，不在 UI 上暴露路径字符串
+        label: d.name,
         value: d.id,
       })));
     } catch {
@@ -95,8 +94,8 @@ export function WorkspaceSelect({ value, onChange, required, selectProps }: Work
       // 刷新列表后选中新建项（按 id 选中）
       const dirs = await getProjectDirectories();
       setOptions(dirs.map(d => ({
-        // label 只展示 name（人类可读名称），path 兜底
-        label: d.name || d.path,
+        // label 只展示 name
+        label: d.name,
         value: d.id,
       })));
       onChange?.(created.id);

--- a/frontend/src/components/settings/ReviewTemplatesPanel.tsx
+++ b/frontend/src/components/settings/ReviewTemplatesPanel.tsx
@@ -41,7 +41,7 @@ export function ReviewTemplatesPanel({ workspaceId }: ReviewTemplatesPanelProps)
   const loadWorkspaceOptions = () => {
     getProjectDirectories()
       .then((dirs) => {
-        setWorkspaceIdOptions(dirs.map(d => ({ label: d.name || d.path, value: d.id })));
+        setWorkspaceIdOptions(dirs.map(d => ({ label: d.name, value: d.id })));
       })
       .catch(() => { /* 静默 */ });
   };

--- a/frontend/src/components/settings/ReviewTemplatesPanel.tsx
+++ b/frontend/src/components/settings/ReviewTemplatesPanel.tsx
@@ -41,7 +41,7 @@ export function ReviewTemplatesPanel({ workspaceId }: ReviewTemplatesPanelProps)
   const loadWorkspaceOptions = () => {
     getProjectDirectories()
       .then((dirs) => {
-        setWorkspaceIdOptions(dirs.map(d => ({ label: d.name ? `${d.name}（${d.path}）` : d.path, value: d.id })));
+        setWorkspaceIdOptions(dirs.map(d => ({ label: d.name || d.path, value: d.id })));
       })
       .catch(() => { /* 静默 */ });
   };

--- a/frontend/src/components/shell/WorkspaceSwitcher.tsx
+++ b/frontend/src/components/shell/WorkspaceSwitcher.tsx
@@ -55,14 +55,14 @@ export function WorkspaceSwitcher({ value, onChange, onManage, mode = 'full' }: 
   const selectedLabel = useMemo(() => {
     if (value == null) return '请选择工作空间';
     const found = dirs.find(d => d.id === value);
-    return found?.name || found?.path || String(value);
+    return found?.name || String(value);
   }, [dirs, value]);
 
   const menuItems = useMemo<NonNullable<MenuProps['items']>>(() => {
     const items: NonNullable<MenuProps['items']> = [
       ...dirs.map(dir => ({
         key: String(dir.id),
-        label: dir.name || dir.path,
+        label: dir.name,
         icon: <FolderOpenOutlined />,
       })),
       { type: 'divider' as const },


### PR DESCRIPTION
## 修改内容

所有工作空间选择器/下拉/列表的展示文本，从原来的「name（path）」改为只显示 name。
取消 path 兜底，避免路径字符串出现在 UI 上。

### 改动前

```
agent-connect (/media/Admin/数据盘1/projects/rust/agent-connect)
rms (/media/Admin/数据盘1/projects/rms)
```

### 改动后

```
agent-connect
rms
```

## 修改文件（4 文件 / 6 处）

| 文件 | 改动 |
|------|------|
| `WorkspaceSelect.tsx` | 2 处 `d.name \|\| d.path` → `d.name` |
| `ReviewTemplatesPanel.tsx` | 1 处 `d.name \|\| d.path` → `d.name` |
| `WorkspaceSwitcher.tsx` | 2 处 `name \|\| path` → 仅 `name` |
| `KanbanBoard.tsx` | 1 处 `d.name \|\| d.path` → `d.name` |

## 验证

- grep 确认所有 `name \|\| path` 模式已清零
- 所有工作空间展示位置统一使用纯 `name`