### PR TITLE
fix(workspace): 修复 workspace label 编译类型错误

### DIFF
--- a/frontend/src/components/common/WorkspaceSelect.tsx
+++ b/frontend/src/components/common/WorkspaceSelect.tsx
@@ -52,8 +52,9 @@ export function WorkspaceSelect({ value, onChange, required, selectProps }: Work
     try {
       const dirs = await getProjectDirectories();
       setOptions(dirs.map(d => ({
-        // label 只展示 name，不在 UI 上暴露路径字符串
-        label: d.name,
+        // label 只展示 name，不在 UI 上暴露路径字符串；
+        // ?? '' 确保类型为 string（d.name 是 string | null），满足 antd Select 的 label 类型要求
+        label: d.name ?? '',
         value: d.id,
       })));
     } catch {
@@ -94,8 +95,8 @@ export function WorkspaceSelect({ value, onChange, required, selectProps }: Work
       // 刷新列表后选中新建项（按 id 选中）
       const dirs = await getProjectDirectories();
       setOptions(dirs.map(d => ({
-        // label 只展示 name
-        label: d.name,
+        // label 只展示 name；?? '' 确保 label 类型为 string
+        label: d.name ?? '',
         value: d.id,
       })));
       onChange?.(created.id);

--- a/frontend/src/components/settings/ReviewTemplatesPanel.tsx
+++ b/frontend/src/components/settings/ReviewTemplatesPanel.tsx
@@ -41,7 +41,7 @@ export function ReviewTemplatesPanel({ workspaceId }: ReviewTemplatesPanelProps)
   const loadWorkspaceOptions = () => {
     getProjectDirectories()
       .then((dirs) => {
-        setWorkspaceIdOptions(dirs.map(d => ({ label: d.name, value: d.id })));
+        setWorkspaceIdOptions(dirs.map(d => ({ label: d.name ?? '', value: d.id })));
       })
       .catch(() => { /* 静默 */ });
   };


### PR DESCRIPTION
## 问题

合并 #800 后，（`string | null`）直接赋值给 `label: string` 导致 TS2345 类型错误：

```
error TS2345: Argument of type '{ label: string | null; value: number; }[]' is not assignable to parameter of type 'SetStateAction<{ label: string; value: number; }[]>'.
```

## 修复

在 `WorkspaceSelect.tsx`（2 处）和 `ReviewTemplatesPanel.tsx`（1 处）中，将 `d.name` 改为 `d.name ?? ''`，确保 label 始终为 `string` 类型。

## 验证

`tsc --noEmit` 通过，相关文件无错误。