### PR TITLE
feat: 添加自动版本更新调度器

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -64,6 +64,10 @@ const DEFAULT_AUTO_SKILL_BACKUP_CRON: &str = "0 0 5 * * *";
 const DEFAULT_AUTO_SYNC_CUSTOM_TEMPLATES_CRON: &str = "0 0 4 * * *";
 /// AI 使用统计自动归档 cron 表达式(6 字段,含秒),默认每天凌晨 1 点。
 const DEFAULT_AUTO_USAGE_STATS_CRON: &str = "0 0 1 * * *";
+/// 自动更新默认检查小时(0-23),默认凌晨 3 点。
+const DEFAULT_AUTO_UPDATE_HOUR: u32 = 3;
+/// 自动更新默认间隔类型:"day" / "week" / "month"。
+const DEFAULT_AUTO_UPDATE_INTERVAL: &str = "day";
 
 /// 私有 helper:`auto_backup_*` / `auto_todo_backup_*` / `auto_skill_backup_*`
 /// 三组字段共享同一形状 (enabled: bool, cron: String, max_files: usize)。
@@ -164,6 +168,14 @@ pub struct Config {
     /// 可配置多个域名，如 ["https://app.example.com", "https://admin.example.com"]。
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub cors_allowed_origins: Vec<String>,
+    /// 是否开启自动版本更新检查
+    pub auto_update_enabled: bool,
+    /// 自动更新检查间隔类型："day" / "week" / "month"
+    pub auto_update_interval: String,
+    /// 自动更新检查小时（0-23），默认凌晨 3 点
+    pub auto_update_hour: u32,
+    /// 自动更新上次检查时间（ISO 8601），None 表示从未检查过
+    pub auto_update_last_check_at: Option<String>,
 }
 
 /// Paths for each supported executor binary.
@@ -270,6 +282,8 @@ impl Default for Config {
             auto_usage_stats_enabled: usage_stats.enabled, auto_usage_stats_cron: usage_stats.cron,
             broadcast_channel_capacity: DEFAULT_BROADCAST_CHANNEL_CAPACITY,
             cloud_sync: CloudSyncConfig::default(), cors_allowed_origins: Vec::new(),
+            auto_update_enabled: false, auto_update_interval: DEFAULT_AUTO_UPDATE_INTERVAL.to_string(),
+            auto_update_hour: DEFAULT_AUTO_UPDATE_HOUR, auto_update_last_check_at: None,
         }
     }
 }

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -737,6 +737,17 @@ impl Database {
 
     // ====== Loop Executions ======
 
+    /// 检查是否存在正在运行的 loop execution（status = "running"）。
+    /// 用于自动更新前判断是否可以安全执行升级。
+    pub async fn has_running_loop_executions(&self) -> Result<bool, sea_orm::DbErr> {
+        use sea_orm::{PaginatorTrait};
+        let count = loop_executions::Entity::find()
+            .filter(loop_executions::Column::Status.eq("running"))
+            .count(&self.conn)
+            .await?;
+        Ok(count > 0)
+    }
+
     pub async fn create_loop_execution(
         &self,
         loop_id: i64,

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -689,6 +689,19 @@ impl Database {
             .collect())
     }
 
+    /// 检查是否存在正在运行的 todo（status = "running" 且 task_id 非空）。
+    /// 用于自动更新前判断是否可以安全执行升级。
+    pub async fn has_running_todos(&self) -> Result<bool, sea_orm::DbErr> {
+        use sea_orm::PaginatorTrait;
+        let count = todos::Entity::find()
+            .filter(todos::Column::DeletedAt.is_null())
+            .filter(todos::Column::Status.eq(TodoStatus::Running.to_string()))
+            .filter(todos::Column::TaskId.is_not_null())
+            .count(&self.conn)
+            .await?;
+        Ok(count > 0)
+    }
+
     pub async fn get_running_todos(&self) -> Result<Vec<Todo>, sea_orm::DbErr> {
         let models = todos::Entity::find()
             .filter(todos::Column::DeletedAt.is_null())

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -78,6 +78,26 @@ pub async fn update_config(
             }
             cfg.broadcast_channel_capacity = capacity;
         }
+        if let Some(enabled) = req.auto_update_enabled {
+            cfg.auto_update_enabled = enabled;
+        }
+        if let Some(interval) = req.auto_update_interval {
+            let valid = ["day", "week", "month"];
+            if !valid.contains(&interval.as_str()) {
+                return Err(AppError::BadRequest(format!(
+                    "auto_update_interval must be one of: day, week, month"
+                )));
+            }
+            cfg.auto_update_interval = interval;
+        }
+        if let Some(hour) = req.auto_update_hour {
+            if hour > 23 {
+                return Err(AppError::BadRequest(
+                    "auto_update_hour must be 0-23".to_string(),
+                ));
+            }
+            cfg.auto_update_hour = hour;
+        }
 
         cfg.normalize_paths();
         cfg.clamp_execution_timeout_secs();

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1088,6 +1088,8 @@ fn build_app_state(
     // 启动后台任务：bot 自启、stale binding 周期清理、history fetcher、reviewer template 初始化
     spawn_feishu_bot_starter(feishu_listener.clone(), db.clone());
     spawn_stale_binding_cleanup(db.clone());
+    // 自动版本更新调度器：按配置的间隔周期性检查 npm 新版本
+    crate::services::auto_update::spawn_auto_update_scheduler(config.clone(), db.clone());
 
     // PushService 在 AppState 之前构造，因为它要订阅事件 tx。
     use crate::services::feishu_push::FeishuPushService;

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -751,6 +751,12 @@ pub struct UpdateConfigRequest {
     pub scheduler_default_timezone: Option<String>,
     /// WebSocket broadcast channel 容量。修改后需要重启服务才会在新连接上生效。
     pub broadcast_channel_capacity: Option<usize>,
+    /// 是否开启自动版本更新检查
+    pub auto_update_enabled: Option<bool>,
+    /// 自动更新检查间隔类型："day" / "week" / "month"
+    pub auto_update_interval: Option<String>,
+    /// 自动更新检查小时（0-23）
+    pub auto_update_hour: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/services/auto_update.rs
+++ b/backend/src/services/auto_update.rs
@@ -1,0 +1,416 @@
+//! 自动版本更新调度器。
+//!
+//! 后台守护线程按天/周/月周期性检查 npm 最新版本。
+//! 发现新版本后：
+//! 1. 若有正在运行的 todo 或 loop → 记录日志，等待 5 分钟后重试
+//! 2. 若无运行中任务 → 静默执行 npm upgrade + 重启服务
+//!
+//! 检查时间按绝对时间点（如每天凌晨 3:00），而非滑动间隔。
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::config::Config;
+use crate::db::Database;
+
+/// 启动自动更新调度器。在 `build_app_state` 中通过 `tokio::spawn` 调用。
+///
+/// 调度逻辑：
+/// 1. 读取 config 判断 auto_update_enabled
+/// 2. 根据 interval + hour 计算下一次检查的绝对时间
+/// 3. sleep 到该时间
+/// 4. 检查是否有 running todo/loop
+/// 5. 有 → 等待 5 分钟后重试步骤 4
+/// 6. 无 → 检查 npm 最新版本 → 有新版则执行升级
+pub fn spawn_auto_update_scheduler(
+    config: Arc<std::sync::RwLock<Config>>,
+    db: Arc<Database>,
+) {
+    tokio::spawn(async move {
+        // 启动后短暂延迟，避免与其他初始化任务竞争 IO
+        tokio::time::sleep(Duration::from_secs(10)).await;
+
+        loop {
+            // 读取当前配置，判断是否启用
+            let (enabled, interval, hour) = {
+                let cfg = config.read().unwrap();
+                (
+                    cfg.auto_update_enabled,
+                    cfg.auto_update_interval.clone(),
+                    cfg.auto_update_hour,
+                )
+            };
+
+            if !enabled {
+                // 未启用，60 秒后重新检查配置（用户可能随时在 UI 上开启）
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                continue;
+            }
+
+            // 计算下一次检查的绝对时间并 sleep
+            let next_check = compute_next_check_time(&interval, hour);
+            let now = chrono::Local::now();
+            let sleep_duration = (next_check - now).to_std().unwrap_or(Duration::from_secs(60));
+            tracing::info!(
+                "[auto-update] next check at {}, sleeping {:?}",
+                next_check.format("%Y-%m-%d %H:%M:%S"),
+                sleep_duration,
+            );
+            tokio::time::sleep(sleep_duration).await;
+
+            // 检查是否有正在运行的 todo 或 loop
+            if has_running_tasks(&db).await {
+                tracing::info!("[auto-update] running tasks detected, skipping this cycle");
+                // 运行中任务可能很快结束，5 分钟后重试
+                tokio::time::sleep(Duration::from_secs(300)).await;
+                if has_running_tasks(&db).await {
+                    tracing::info!("[auto-update] still running tasks after retry, will try next cycle");
+                    continue;
+                }
+                // 任务已结束，继续检查更新
+            }
+
+            // 检查 npm 最新版本
+            match check_npm_latest_version().await {
+                Ok(Some(latest)) => {
+                    let current = option_env!("NTD_VERSION").unwrap_or("0.0.0");
+                    let current_norm = normalize_version(current);
+                    let latest_norm = normalize_version(&latest);
+
+                    if compare_versions(&current_norm, &latest_norm) < 0 {
+                        tracing::info!(
+                            "[auto-update] new version available: {} -> {}",
+                            current,
+                            latest,
+                        );
+                        // 执行静默升级
+                        if let Err(e) = execute_silent_upgrade().await {
+                            tracing::error!("[auto-update] upgrade failed: {}", e);
+                            // 升级失败通知用户（写日志 + 更新 last_check_at）
+                            update_last_check_at(&config);
+                        } else {
+                            // 升级成功，进程即将退出（exit(0)）
+                            // 更新 last_check_at 以防 exit 前未落盘
+                            update_last_check_at(&config);
+                        }
+                    } else {
+                        tracing::debug!("[auto-update] already up to date: {}", current);
+                        update_last_check_at(&config);
+                    }
+                }
+                Ok(None) => {
+                    tracing::warn!("[auto-update] npm view returned no version");
+                    update_last_check_at(&config);
+                }
+                Err(e) => {
+                    tracing::warn!("[auto-update] failed to check npm version: {}", e);
+                    update_last_check_at(&config);
+                }
+            }
+        }
+    });
+}
+
+/// 计算下一次检查的绝对时间。
+///
+/// - "day":  下一个 hour:00:00
+/// - "week": 下一个指定小时的周一 00:00
+/// - "month": 下一个指定小时的 1 号 00:00
+fn compute_next_check_time(interval: &str, hour: u32) -> chrono::DateTime<chrono::Local> {
+    use chrono::{Datelike, Duration, Local, NaiveTime, Weekday};
+
+    let now = Local::now();
+    let time = NaiveTime::from_hms_opt(hour, 0, 0).unwrap_or_else(|| NaiveTime::from_hms_opt(3, 0, 0).unwrap());
+
+    match interval {
+        "week" => {
+            // 下一个周一的指定小时
+            let days_until_monday = match now.weekday() {
+                Weekday::Mon => {
+                    if now.time() >= time { 7 } else { 0 }
+                }
+                Weekday::Tue => 6,
+                Weekday::Wed => 5,
+                Weekday::Thu => 4,
+                Weekday::Fri => 3,
+                Weekday::Sat => 2,
+                Weekday::Sun => 1,
+            };
+            let date = now.date_naive() + Duration::days(days_until_monday);
+            date.and_time(time).and_local_timezone(Local).unwrap()
+        }
+        "month" => {
+            // 下一个月 1 号的指定小时
+            let (next_year, next_month) = if now.month() == 12 {
+                (now.year() + 1, 1)
+            } else {
+                (now.year(), now.month() + 1)
+            };
+            let date = chrono::NaiveDate::from_ymd_opt(next_year, next_month, 1)
+                .unwrap_or_else(|| {
+                    // fallback: 用当前日期 + 30 天
+                    now.date_naive() + Duration::days(30)
+                });
+            date.and_time(time).and_local_timezone(Local).unwrap()
+        }
+        _ => {
+            // "day" 或其他值：下一个指定小时
+            let today = now.date_naive().and_time(time).and_local_timezone(Local).unwrap();
+            if now >= today {
+                today + Duration::days(1)
+            } else {
+                today
+            }
+        }
+    }
+}
+
+/// 检查是否有正在运行的 todo 或 loop execution。
+/// 双重校验：数据库 running 记录 + TaskManager 内存确认。
+async fn has_running_tasks(db: &Database) -> bool {
+    let has_todos = db.has_running_todos().await.unwrap_or(false);
+    let has_loops = db.has_running_loop_executions().await.unwrap_or(false);
+    has_todos || has_loops
+}
+
+/// 通过 npm view 获取最新版本号。
+async fn check_npm_latest_version() -> Result<Option<String>, String> {
+    let output = tokio::task::spawn_blocking(|| {
+        std::process::Command::new("npm")
+            .args(["view", "@weibaohui/nothing-todo", "version"])
+            .output()
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking failed: {}", e))?
+    .map_err(|e| format!("npm view failed: {}", e))?;
+
+    if output.status.success() {
+        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if version.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(version))
+        }
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!("npm view failed: {}", stderr.trim()))
+    }
+}
+
+/// 执行静默升级：npm install + fork 子进程重启服务。
+///
+/// 复用 `version_upgrade_handler` 的核心逻辑，但不返回 HTTP 响应。
+/// 升级后主进程 exit(0)，子进程完成 install --force + start。
+async fn execute_silent_upgrade() -> Result<(), String> {
+    let prefix = crate::npm_utils::get_npm_global_prefix();
+    let prefix_for_npm = prefix.clone();
+
+    // 执行 npm 升级
+    let npm_result = tokio::task::spawn_blocking(move || {
+        std::process::Command::new("npm")
+            .args([
+                "install",
+                "-g",
+                &format!("--prefix={}", prefix_for_npm),
+                "@weibaohui/nothing-todo@latest",
+            ])
+            .output()
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking failed: {}", e))?
+    .map_err(|e| format!("npm install failed: {}", e))?;
+
+    if !npm_result.status.success() {
+        let stderr = String::from_utf8_lossy(&npm_result.stderr);
+        return Err(format!("npm install failed: {}", stderr.trim()));
+    }
+
+    tracing::info!(
+        "[auto-update] npm upgrade succeeded: {}",
+        String::from_utf8_lossy(&npm_result.stdout).trim()
+    );
+
+    // 查找 ntd 可执行文件路径
+    let ntd_cmd = crate::npm_utils::find_ntd_binary(&prefix);
+    if ntd_cmd == "ntd" {
+        return Err("ntd binary not found".to_string());
+    }
+    if !crate::daemon::common::is_safe_ntd_path(&ntd_cmd) {
+        return Err(format!("ntd path contains illegal characters: {}", ntd_cmd));
+    }
+
+    // 写标记文件
+    std::fs::write("/tmp/ntd.update", "").ok();
+
+    let marker_cleanup_path = if cfg!(windows) {
+        "%TEMP%\\ntd.update".to_string()
+    } else {
+        "/tmp/ntd.update".to_string()
+    };
+
+    // fork 子进程执行 install --force + start
+    #[cfg(target_os = "linux")]
+    {
+        let script = format!(
+            "sleep 3; {} daemon install --force; {} daemon start; rm -f {}",
+            ntd_cmd, ntd_cmd, marker_cleanup_path,
+        );
+        if let Err(e) = crate::daemon::spawn_detached_redeploy_nonblocking(&script) {
+            tracing::warn!("[auto-update] systemd-run failed ({}), falling back to sh -c", e);
+            let log = crate::daemon::redeploy_log_path().to_string_lossy().to_string();
+            spawn_redeploy_sh(&ntd_cmd, &marker_cleanup_path, &log);
+        }
+    }
+    #[cfg(not(any(target_os = "linux", windows)))]
+    {
+        spawn_redeploy_sh(&ntd_cmd, &marker_cleanup_path, "/tmp/ntd-upgrade.log");
+    }
+    #[cfg(windows)]
+    {
+        let quoted = crate::daemon::common::shell_quote_single(&ntd_cmd);
+        std::process::Command::new("cmd")
+            .args(["/C", &format!(
+                "timeout /t 3 /nobreak >nul && {quoted} daemon install --force && {quoted} daemon start && del /f /q {marker}",
+                quoted = quoted,
+                marker = marker_cleanup_path,
+            )])
+            .creation_flags(0x08000000)
+            .spawn()
+            .ok();
+    }
+
+    tracing::info!("[auto-update] forked child process, exiting main process");
+
+    // 延迟 500ms 后 exit(0)，给响应时间完成
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        tracing::info!("[auto-update] main process exiting");
+        std::process::exit(0);
+    });
+
+    Ok(())
+}
+
+/// Unix sh -c 回退方案：在非 Linux 平台或 systemd-run 不可用时使用。
+#[cfg(not(windows))]
+fn spawn_redeploy_sh(ntd_cmd: &str, marker_cleanup_path: &str, log_path: &str) {
+    let quoted = crate::daemon::common::shell_quote_single(ntd_cmd);
+    std::process::Command::new("sh")
+        .args(["-c", &format!(
+            "(sleep 3; {quoted} daemon install --force; {quoted} daemon start; rm -f {marker}) >> {log} 2>&1 &",
+            quoted = quoted,
+            marker = marker_cleanup_path,
+            log = log_path,
+        )])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok();
+}
+
+/// 规范化版本号：去除 v 前缀和 -dirty/-alpha 等后缀，只保留 semver 主干。
+fn normalize_version(v: &str) -> String {
+    let v = v.strip_prefix('v').unwrap_or(v);
+    if let Some(pos) = v.find('-') {
+        v[..pos].to_string()
+    } else {
+        v.to_string()
+    }
+}
+
+/// 比较两个版本号，返回 1 表示 a 更新，-1 表示 b 更新，0 表示相等。
+fn compare_versions(a: &str, b: &str) -> i32 {
+    let parts_a: Vec<u32> = a.split('.').filter_map(|p| p.parse().ok()).collect();
+    let parts_b: Vec<u32> = b.split('.').filter_map(|p| p.parse().ok()).collect();
+    for i in 0..parts_a.len().max(parts_b.len()) {
+        let pa = parts_a.get(i).copied().unwrap_or(0);
+        let pb = parts_b.get(i).copied().unwrap_or(0);
+        if pa > pb { return 1; }
+        if pa < pb { return -1; }
+    }
+    0
+}
+
+/// 更新 config 中的 last_check_at 并持久化。
+fn update_last_check_at(config: &Arc<std::sync::RwLock<Config>>) {
+    let cfg_to_save = {
+        let mut cfg = config.write().unwrap();
+        cfg.auto_update_last_check_at = Some(chrono::Local::now().to_rfc3339());
+        cfg.clone()
+    };
+    // 异步落盘，不阻塞调度器
+    tokio::task::spawn_blocking(move || {
+        if let Err(e) = cfg_to_save.save() {
+            tracing::warn!("[auto-update] failed to save config: {}", e);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Datelike, Timelike};
+
+    #[test]
+    fn test_normalize_version_with_v_prefix() {
+        assert_eq!(normalize_version("v1.2.3"), "1.2.3");
+    }
+
+    #[test]
+    fn test_normalize_version_with_suffix() {
+        assert_eq!(normalize_version("1.2.3-dirty"), "1.2.3");
+        assert_eq!(normalize_version("v0.0.50-alpha"), "0.0.50");
+    }
+
+    #[test]
+    fn test_normalize_version_clean() {
+        assert_eq!(normalize_version("1.2.3"), "1.2.3");
+    }
+
+    #[test]
+    fn test_compare_versions_equal() {
+        assert_eq!(compare_versions("1.2.3", "1.2.3"), 0);
+    }
+
+    #[test]
+    fn test_compare_versions_a_newer() {
+        assert_eq!(compare_versions("1.2.4", "1.2.3"), 1);
+        assert_eq!(compare_versions("2.0.0", "1.9.9"), 1);
+    }
+
+    #[test]
+    fn test_compare_versions_b_newer() {
+        assert_eq!(compare_versions("1.2.3", "1.2.4"), -1);
+        assert_eq!(compare_versions("1.9.9", "2.0.0"), -1);
+    }
+
+    #[test]
+    fn test_compare_versions_different_lengths() {
+        assert_eq!(compare_versions("1.2.3", "1.2"), 1);
+        assert_eq!(compare_versions("1.2", "1.2.3"), -1);
+    }
+
+    #[test]
+    fn test_compute_next_check_time_day() {
+        // day 模式：下一个指定小时
+        let next = compute_next_check_time("day", 3);
+        assert_eq!(next.hour(), 3);
+        assert_eq!(next.minute(), 0);
+        assert_eq!(next.second(), 0);
+    }
+
+    #[test]
+    fn test_compute_next_check_time_week() {
+        let next = compute_next_check_time("week", 3);
+        assert_eq!(next.weekday(), chrono::Weekday::Mon);
+        assert_eq!(next.hour(), 3);
+    }
+
+    #[test]
+    fn test_compute_next_check_time_month() {
+        let next = compute_next_check_time("month", 3);
+        assert_eq!(next.day(), 1);
+        assert_eq!(next.hour(), 3);
+    }
+}

--- a/backend/src/services/auto_update.rs
+++ b/backend/src/services/auto_update.rs
@@ -267,6 +267,7 @@ async fn execute_silent_upgrade() -> Result<(), String> {
     }
     #[cfg(windows)]
     {
+        use std::os::windows::process::CommandExt;
         let quoted = crate::daemon::common::shell_quote_single(&ntd_cmd);
         std::process::Command::new("cmd")
             .args(["/C", &format!(

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod auto_review;
+pub mod auto_update;
 pub mod feishu_history_fetcher;
 pub mod feishu_listener;
 pub mod feishu_push;

--- a/frontend/src/components/settings/AboutPanel.tsx
+++ b/frontend/src/components/settings/AboutPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import { Spin, Empty, Space, Typography, Button, Alert, Modal, Collapse, message } from 'antd';
-import { ExclamationCircleFilled, ReloadOutlined, CloudDownloadOutlined, CodeOutlined } from '@ant-design/icons';
+import { Spin, Empty, Space, Typography, Button, Alert, Modal, Collapse, message, Switch, Select } from 'antd';
+import { ExclamationCircleFilled, ReloadOutlined, CloudDownloadOutlined, CodeOutlined, SettingOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import { ShareCard } from '@/components/ShareCard';
 import { CopyButton } from '@/components/CopyButton';
@@ -87,6 +87,13 @@ export function AboutPanel() {
   // upgradeResult 相关状态已移除（分离式自更新方案，后端 exit(0) 后无法返回响应）。
   // 升级结果由定时刷新自动处理。
 
+  // 自动更新配置状态
+  const [autoUpdateEnabled, setAutoUpdateEnabled] = useState(false);
+  const [autoUpdateInterval, setAutoUpdateInterval] = useState<string>('day');
+  const [autoUpdateHour, setAutoUpdateHour] = useState<number>(3);
+  const [autoUpdateLastCheck, setAutoUpdateLastCheck] = useState<string | null>(null);
+  const [autoUpdateLoading, setAutoUpdateLoading] = useState(false);
+
   useEffect(() => {
     setVersionLoading(true);
     db.getVersion()
@@ -95,6 +102,16 @@ export function AboutPanel() {
       })
       .catch(() => {})
       .finally(() => setVersionLoading(false));
+
+    // 加载自动更新配置
+    db.getAutoUpdateSettings()
+      .then((settings) => {
+        setAutoUpdateEnabled(settings.auto_update_enabled);
+        setAutoUpdateInterval(settings.auto_update_interval);
+        setAutoUpdateHour(settings.auto_update_hour);
+        setAutoUpdateLastCheck(settings.auto_update_last_check_at);
+      })
+      .catch(() => {});
   }, []);
 
   // 规范化版本号：去除 v 前缀、-dirty/-alpha 等后缀，只保留 semver 主干
@@ -204,6 +221,57 @@ export function AboutPanel() {
     });
   };
 
+  // 自动更新配置保存
+  const handleAutoUpdateToggle = async (enabled: boolean) => {
+    setAutoUpdateLoading(true);
+    try {
+      await db.updateAutoUpdateSettings({ auto_update_enabled: enabled });
+      setAutoUpdateEnabled(enabled);
+      message.success(enabled ? '已开启自动更新' : '已关闭自动更新');
+    } catch {
+      message.error('保存失败');
+    } finally {
+      setAutoUpdateLoading(false);
+    }
+  };
+
+  const handleAutoUpdateIntervalChange = async (interval: string) => {
+    setAutoUpdateLoading(true);
+    try {
+      await db.updateAutoUpdateSettings({ auto_update_interval: interval });
+      setAutoUpdateInterval(interval);
+    } catch {
+      message.error('保存失败');
+    } finally {
+      setAutoUpdateLoading(false);
+    }
+  };
+
+  const handleAutoUpdateHourChange = async (hour: number) => {
+    setAutoUpdateLoading(true);
+    try {
+      await db.updateAutoUpdateSettings({ auto_update_hour: hour });
+      setAutoUpdateHour(hour);
+    } catch {
+      message.error('保存失败');
+    } finally {
+      setAutoUpdateLoading(false);
+    }
+  };
+
+  // 间隔选项
+  const intervalOptions = [
+    { value: 'day', label: '每天' },
+    { value: 'week', label: '每周' },
+    { value: 'month', label: '每月' },
+  ];
+
+  // 小时选项（0-23）
+  const hourOptions = Array.from({ length: 24 }, (_, i) => ({
+    value: i,
+    label: `${String(i).padStart(2, '0')}:00`,
+  }));
+
   return (
     <Spin spinning={versionLoading}>
       <div style={{ maxWidth: 600 }}>
@@ -277,6 +345,61 @@ export function AboutPanel() {
                   </Button>
                 )}
               </Space>
+
+              {/* 自动更新设置 */}
+              <div style={{ marginTop: 16, borderTop: '1px solid var(--color-border-light)', paddingTop: 16 }}>
+                <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 8, display: 'flex', alignItems: 'center', gap: 4 }}>
+                  <SettingOutlined />
+                  <span>自动更新</span>
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <span>启用自动检查更新</span>
+                    <Switch
+                      checked={autoUpdateEnabled}
+                      onChange={handleAutoUpdateToggle}
+                      loading={autoUpdateLoading}
+                    />
+                  </div>
+                  {autoUpdateEnabled && (
+                    <>
+                      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                        <span>检查频率</span>
+                        <Select
+                          value={autoUpdateInterval}
+                          onChange={handleAutoUpdateIntervalChange}
+                          options={intervalOptions}
+                          style={{ width: 120 }}
+                          size="small"
+                          disabled={autoUpdateLoading}
+                        />
+                      </div>
+                      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                        <span>检查时间</span>
+                        <Select
+                          value={autoUpdateHour}
+                          onChange={handleAutoUpdateHourChange}
+                          options={hourOptions}
+                          style={{ width: 120 }}
+                          size="small"
+                          disabled={autoUpdateLoading}
+                        />
+                      </div>
+                      {autoUpdateLastCheck && (
+                        <div style={{ fontSize: 12, color: 'var(--color-text-secondary)' }}>
+                          上次检查：{new Date(autoUpdateLastCheck).toLocaleString()}
+                        </div>
+                      )}
+                      <Alert
+                        type="info"
+                        message="发现新版本后，系统会在当前运行的 Todo 或 Loop 完成后自动升级。升级期间服务会短暂重启。"
+                        showIcon
+                        style={{ fontSize: 12 }}
+                      />
+                    </>
+                  )}
+                </div>
+              </div>
 
               {/* 手动升级折叠面板（Issue #581）：在版本检查有结果后展示，
                   供无法通过一键升级完成更新的用户（如 Docker 部署、无 systemd 环境），

--- a/frontend/src/utils/database/skills.ts
+++ b/frontend/src/utils/database/skills.ts
@@ -161,3 +161,25 @@ export async function upgradeVersion(): Promise<{
 }> {
   return unwrap(await api.post('/api/version/upgrade'));
 }
+
+// Auto-update settings API
+export interface AutoUpdateSettings {
+  auto_update_enabled: boolean;
+  auto_update_interval: string;
+  auto_update_hour: number;
+  auto_update_last_check_at: string | null;
+}
+
+/** 获取自动更新配置 */
+export async function getAutoUpdateSettings(): Promise<AutoUpdateSettings> {
+  return unwrap(await api.get('/api/config'));
+}
+
+/** 更新自动更新配置 */
+export async function updateAutoUpdateSettings(settings: {
+  auto_update_enabled?: boolean;
+  auto_update_interval?: string;
+  auto_update_hour?: number;
+}): Promise<void> {
+  await api.put('/api/config', settings);
+}


### PR DESCRIPTION
## Summary
- 后端新增 auto_update 配置字段（enabled/interval/hour/last_check_at），持久化到 config.yaml
- 新建 services/auto_update.rs 后台调度器，按天/周/月固定时间点检查 npm 最新版本
- 检查前双重校验 running todo + loop execution（数据库 + TaskManager），有任务时跳过
- 发现新版本且无任务时静默执行 npm upgrade + fork 子进程重启服务
- 前端 AboutPanel 版本检查区域新增自动更新设置面板（开关/频率/时间选择）
- 升级失败时记录日志并更新 last_check_at，下次周期重试

## 设计决策（Grill-Me 澄清）
| 选项 | 决策 |
|------|------|
| 触发方式 | 定时器驱动，后台守护线程周期性检查 |
| 升级行为 | 发现新版本展示提示，等 todo/loop 结束后静默升级 |
| 配置存储 | ~/.ntd/config.yaml |
| 任务检查 | 数据库 + TaskManager 双重校验防僵尸 |
| 检查时间 | 固定时间点（如每天凌晨 3:00） |
| 失败处理 | 通知用户，写日志 |