### PR TITLE
feat(todo-list): 去掉 prompt 显示，对齐环路列表的简洁卡片风格

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -446,9 +446,7 @@ html, body {
 }
 
 .todo-item-content {
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
+  /* 不再需要 flex — 右侧 StatusPicker 已移除，.todo-item-main 是唯一子元素 */
 }
 
 .todo-item-main {
@@ -465,8 +463,7 @@ html, body {
 
 
 /* (todo-item-desc 已移除 — 不再显示 prompt，对齐环路列表的简洁风格) */
-
-.todo-item-tags {
+/* (todo-item-status 已移除 — 列表行中不再显示圆形状态按钮，通过底部颜色条展示状态) */
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
@@ -489,21 +486,6 @@ html, body {
   letter-spacing: 0.5px;
 }
 
-/* Status Container */
-.todo-item-status {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  cursor: pointer;
-  border-radius: 50%;
-}
-
-.todo-item-status:hover {
-  background: var(--color-border-light);
-}
 
 /* ---------- Detail Panel ---------- */
 .detail-panel {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -425,23 +425,20 @@ html, body {
 /* ---------- Todo Item ---------- */
 .todo-item {
   background: var(--color-bg-elevated);
-  border-radius: var(--radius-md);
-  padding: 14px var(--space-lg);
-  margin-bottom: var(--space-sm);
+  border-radius: 10px;
+  padding: 12px 12px 14px 16px;
+  margin-bottom: 8px;
   cursor: pointer;
   border: 1px solid var(--color-border-light);
-  box-shadow: var(--shadow-sm);
 }
 
 .todo-item:hover {
   border-color: var(--color-primary);
-  box-shadow: var(--shadow-md);
 }
 
 .todo-item.selected {
   border-color: var(--color-primary);
   background: var(--color-primary-bg);
-  box-shadow: var(--shadow-primary);
 }
 
 [data-theme="dark"] .todo-item.selected {
@@ -463,17 +460,11 @@ html, body {
   font-weight: 600;
   font-size: 15px;
   color: var(--color-text);
-  margin-bottom: var(--space-xs);
   line-height: 1.4;
 }
 
 
-.todo-item-desc {
-  font-size: 13px;
-  color: var(--color-text-secondary);
-  line-height: 1.5;
-  margin-bottom: var(--space-xs);
-}
+/* (todo-item-desc 已移除 — 不再显示 prompt，对齐环路列表的简洁风格) */
 
 .todo-item-tags {
   display: flex;

--- a/frontend/src/components/todo-list/TodoItemRow.tsx
+++ b/frontend/src/components/todo-list/TodoItemRow.tsx
@@ -1,4 +1,11 @@
-// Todo 列表项行组件。
+// Todo 列表项行组件 — 简洁卡片风格。
+//
+// 对齐环路列表 LoopCard 的视觉风格：去掉 prompt 显示，改用左 3px 色条 +
+// 标题行 + meta 行的紧凑布局，不再用 4px 左边框和高胖的 desc 区域。
+//
+// 设计取舍：
+// - 用 inline style 处理 hover 的 transform/boxShadow 过渡，避免依赖额外 CSS class。
+// - 选中态用 inset box-shadow 模拟边框，不改变元素实际尺寸，防止 layout 跳动。
 
 import { Checkbox } from 'antd';
 import type { Todo, Tag } from '@/types';
@@ -19,8 +26,8 @@ interface TodoItemRowProps {
 }
 
 /**
- * Todo 列表项行组件。
- * 抽离平铺与分组两个模式共用，避免重复代码。
+ * Todo 列表项行组件 — 简洁卡片风格。
+ * 去掉了 prompt 显示；左 3px 色条 + 标题行 + meta 行，对齐 LoopCard 紧凑布局。
  */
 export function TodoItemRow({
   todo,
@@ -39,6 +46,7 @@ export function TodoItemRow({
   const isCompleted = todo.status === 'completed';
   const relativeTime = formatRelativeTime(todo.updated_at);
   const isChecked = selectedIds.includes(todo.id);
+  const isSelected = selectedTodoId === todo.id;
 
   return (
     <div
@@ -47,16 +55,16 @@ export function TodoItemRow({
         onSelectTodo(todo.id);
         onSelect(todo.id);
       }}
-      className={`todo-item ${selectedTodoId === todo.id ? 'selected' : ''}`}
+      className={`todo-item ${isSelected ? 'selected' : ''}`}
       style={{
         cursor: 'pointer',
-        borderLeftColor: primaryTag?.color || '#cbd5e1',
-        borderLeftWidth: 4,
-        borderLeftStyle: 'solid',
-        // 工具栏的多选复选框用 position: absolute 浮在卡片左上；
-        // 若 .todo-item 不设 position: relative，复选框会逃逸到上层容器，
-        // 所有卡片的复选框都叠在同一个屏幕坐标，点击会命中最后渲染的那个。
         position: 'relative',
+        // 选中态用 inset box-shadow 模拟边框，避免 border 撑大尺寸导致 layout 跳动
+        boxShadow: isSelected
+          ? 'inset 0 0 0 1px var(--color-primary, #0891b2)'
+          : '0 1px 2px color-mix(in srgb, var(--color-text, #0f172a) 6%, transparent)',
+        // 与 LoopCard 一致的过渡动画
+        transition: 'background 200ms, border-color 200ms, box-shadow 200ms, transform 200ms',
       }}
       role="button"
       tabIndex={0}
@@ -67,9 +75,32 @@ export function TodoItemRow({
           onSelect(todo.id);
         }
       }}
+      // hover 效果：非选中态时加深 border + 微抬升，与 LoopCard 行为一致
+      onMouseEnter={(e) => {
+        if (!isSelected) {
+          e.currentTarget.style.borderColor = 'var(--color-text-tertiary, #94a3b8)';
+          e.currentTarget.style.boxShadow = '0 4px 10px color-mix(in srgb, var(--color-text, #0f172a) 10%, transparent)';
+          e.currentTarget.style.transform = 'translateY(-1px)';
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (!isSelected) {
+          e.currentTarget.style.borderColor = 'var(--color-border, #e2e8f0)';
+          e.currentTarget.style.boxShadow = '0 1px 2px color-mix(in srgb, var(--color-text, #0f172a) 6%, transparent)';
+          e.currentTarget.style.transform = 'translateY(0)';
+        }
+      }}
     >
-      {/* 多选复选框：position absolute 浮在卡片左上，避免打乱原本的 layout。
-          stopPropagation 阻止冒泡到卡片的 onClick（不会触发详情选中）。 */}
+      {/* 左侧 3px 颜色条：标签色兜底到 primary 色 */}
+      <span
+        style={{
+          position: 'absolute', left: 0, top: 0, bottom: 0, width: 3,
+          background: primaryTag?.color || 'var(--color-primary, #0891b2)',
+          borderRadius: '3px 0 0 3px',
+        }}
+      />
+
+      {/* 多选复选框：position absolute 浮在卡片左上，避免打乱 layout */}
       <Checkbox
         checked={isChecked}
         onChange={(e) => { e.stopPropagation(); onToggleSelect(todo.id); }}
@@ -79,72 +110,64 @@ export function TodoItemRow({
       />
       <div className="todo-item-content" style={{ paddingLeft: 28 }}>
         <div className="todo-item-main">
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+          {/* 标题行：#id + 标题 + ExecutorBadge（紧凑排列，对齐 LoopCard 标题行） */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+            <span style={{ color: 'var(--color-text-tertiary, #94a3b8)', fontSize: 11, fontFamily: 'monospace' }}>
+              #{todo.id}
+            </span>
             <div
               className="todo-item-title"
-              style={{ opacity: isCompleted ? 0.6 : 1 }}
+              style={{
+                opacity: isCompleted ? 0.6 : 1,
+                flex: 1, minWidth: 0,
+                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              }}
             >
-              <span style={{ color: '#999', marginRight: 4, fontSize: 13 }}>#{todo.id}</span>{todo.title}
+              {todo.title}
             </div>
+            {/* ExecutorBadge 放在标题右侧，类似 LoopCard 的 status Tag */}
             <ExecutorBadge executor={todo.executor || 'claudecode'} />
           </div>
-          {todo.prompt && (
-            <div className="todo-item-desc">
-              {todo.prompt.length > 60 ? todo.prompt.substring(0, 60) + '...' : todo.prompt}
-            </div>
-          )}
-          <div className="todo-item-tags" style={{ justifyContent: 'space-between' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' }}>
-              {todoTags.map(t => (
-                <span
-                  key={t.id}
-                  className="todo-tag-badge"
-                  style={{
-                    backgroundColor: t.color + '18',
-                    color: t.color,
-                    border: `1px solid ${t.color}30`,
-                  }}
-                >
-                  {t.name}
-                </span>
-              ))}
-              {todo.scheduler_config && (
-                <ClockCircleOutlined
-                  style={{
-                    fontSize: 12,
-                    color: todo.scheduler_enabled ? 'var(--color-warning)' : 'var(--color-text-tertiary)',
-                    marginLeft: todoTags.length > 0 ? 4 : 0,
-                  }}
-                />
-              )}
-              {/* todo_type === 1 已废弃：评审模板自 V15 起迁出至 review_templates 表。 */}
-              {todo.todo_type === 2 && (
-                <span
-                  className="todo-tag-badge"
-                  style={{
-                    backgroundColor: '#13c2c218',
-                    color: '#13c2c2',
-                    border: '1px solid #13c2c230',
-                  }}
-                  title={`评审实例 (原 todo #${todo.parent_todo_id ?? '?'})`}
-                >
-                  [评审]
-                </span>
-              )}
-            </div>
-            <span
-              style={{
-                fontSize: 11,
-                color: 'var(--color-text-quaternary)',
-                flexShrink: 0,
-                marginLeft: 8,
-              }}
-              title={relativeTime}
-            >
-              {relativeTime}
-            </span>
+
+          {/* meta 行：标签 + 调度器图标 + 评审徽章 + 相对时间（紧凑、对齐 LoopCard meta 行） */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'var(--color-text-tertiary, #94a3b8)' }}>
+            {todoTags.map(t => (
+              <span
+                key={t.id}
+                className="todo-tag-badge"
+                style={{
+                  backgroundColor: t.color + '18',
+                  color: t.color,
+                  border: `1px solid ${t.color}30`,
+                }}
+              >
+                {t.name}
+              </span>
+            ))}
+            {todo.scheduler_config && (
+              <ClockCircleOutlined
+                style={{
+                  fontSize: 11,
+                  color: todo.scheduler_enabled ? 'var(--color-warning)' : 'var(--color-text-tertiary)',
+                }}
+              />
+            )}
+            {todo.todo_type === 2 && (
+              <span
+                className="todo-tag-badge"
+                style={{
+                  backgroundColor: '#13c2c218',
+                  color: '#13c2c2',
+                  border: '1px solid #13c2c230',
+                }}
+              >
+                评审
+              </span>
+            )}
+            <span style={{ marginLeft: 'auto' }}>{relativeTime}</span>
           </div>
         </div>
+        {/* StatusPicker 保持原有位置，不改变交互方式 */}
         <div
           className="todo-item-status"
           aria-label="更改任务状态"

--- a/frontend/src/components/todo-list/TodoItemRow.tsx
+++ b/frontend/src/components/todo-list/TodoItemRow.tsx
@@ -10,7 +10,6 @@
 import { Checkbox } from 'antd';
 import type { Todo, Tag } from '@/types';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
-import { StatusPicker } from '@/components/StatusPicker';
 import { formatRelativeTime } from '@/utils/datetime';
 import { ClockCircleOutlined } from '@ant-design/icons';
 
@@ -22,7 +21,6 @@ interface TodoItemRowProps {
   onSelectTodo: (id: number) => void;
   onSelect: (id: number) => void;
   onToggleSelect: (id: number) => void;
-  onStatusChange: (todoId: number, title: string, prompt: string, newStatus: string) => void;
 }
 
 /**
@@ -37,7 +35,6 @@ export function TodoItemRow({
   onSelectTodo,
   onSelect,
   onToggleSelect,
-  onStatusChange,
 }: TodoItemRowProps) {
   // tag_ids 在 Todo 类型中是必填 number[]，但历史接口偶发返回缺失字段，
   // 所以用可选链 + 空数组兜底，避免运行时崩溃。
@@ -119,7 +116,7 @@ export function TodoItemRow({
         data-testid={`todo-row-checkbox-${todo.id}`}
         style={{ position: 'absolute', top: 12, left: 12, zIndex: 1 }}
       />
-      <div className="todo-item-content" style={{ paddingLeft: 28 }}>
+      <div className="todo-item-content">
         <div className="todo-item-main">
           {/* 标题行：#id + 标题 + ExecutorBadge（紧凑排列，对齐 LoopCard 标题行） */}
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
@@ -177,16 +174,6 @@ export function TodoItemRow({
             )}
             <span style={{ marginLeft: 'auto' }}>{relativeTime}</span>
           </div>
-        </div>
-        {/* StatusPicker 保持原有位置，不改变交互方式 */}
-        <div
-          className="todo-item-status"
-          aria-label="更改任务状态"
-        >
-          <StatusPicker
-            value={todo.status}
-            onChange={(newStatus) => onStatusChange(todo.id, todo.title, todo.prompt || '', newStatus)}
-          />
         </div>
       </div>
       {/* 底部 3px 颜色条：按 todo 状态着色，与 LoopCard 底部进度条设计一致 */}

--- a/frontend/src/components/todo-list/TodoItemRow.tsx
+++ b/frontend/src/components/todo-list/TodoItemRow.tsx
@@ -48,6 +48,17 @@ export function TodoItemRow({
   const isChecked = selectedIds.includes(todo.id);
   const isSelected = selectedTodoId === todo.id;
 
+  // 底部 3px 颜色条映射：按 todo 状态着色，与 LoopCard 的 progressBarColor 设计一致
+  const statusBarColor: Record<string, string> = {
+    pending: 'var(--color-text-quaternary, #94a3b8)',
+    running: 'var(--color-info, #3b82f6)',
+    completed: 'var(--color-success, #22c55e)',
+    failed: 'var(--color-error, #ef4444)',
+  };
+  // pending 状态用半透明表示"未开始"，其他状态全透明
+  const barColor = statusBarColor[todo.status] || statusBarColor.pending;
+  const barOpacity = todo.status === 'pending' ? 0.35 : 1;
+
   return (
     <div
       key={todo.id}
@@ -178,6 +189,15 @@ export function TodoItemRow({
           />
         </div>
       </div>
+      {/* 底部 3px 颜色条：按 todo 状态着色，与 LoopCard 底部进度条设计一致 */}
+      <div
+        style={{
+          position: 'absolute', left: 0, right: 0, bottom: 0, height: 3,
+          background: barColor,
+          opacity: barOpacity,
+          borderRadius: '0 0 10px 10px',
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/components/todo-list/index.tsx
+++ b/frontend/src/components/todo-list/index.tsx
@@ -190,15 +190,6 @@ export function TodoList(props: TodoListProps) {
     return filteredLoopList.map(l => l.id);
   }, [listMode, filteredTodos, filteredLoopList]);
 
-  const handleStatusChange = useCallback(async (todoId: number, title: string, prompt: string, newStatus: string) => {
-    try {
-      const updated = await db.updateTodo(todoId, title, prompt, newStatus);
-      dispatch({ type: 'UPDATE_TODO', payload: updated });
-    } catch {
-      // ignore: interceptor already shows error
-    }
-  }, [dispatch]);
-
   // 批量操作 handlers
   const openItemChangeExecutor = useCallback((ids: number[]) => {
     setPendingExecutorChangeIds(ids);
@@ -482,7 +473,6 @@ export function TodoList(props: TodoListProps) {
                   onSelectTodo?.(id);
                 }}
                 onToggleSelect={toggleSelect}
-                onStatusChange={handleStatusChange}
               />
             ))
           )}


### PR DESCRIPTION
## 改动内容

事项列表的卡片样式向环路列表（LoopCard）靠齐，去掉 prompt 显示，整体更紧凑。

### 主要变化

1. **移除 prompt 显示** — 列表项不再展示 `todo.prompt` 文本，不再臃肿
2. **左 3px 色条** — 替代原来 4px 左边框，与 LoopCard 一致
3. **hover 微抬升** — `translateY(-1px)` + 阴影加深，与 LoopCard 行为一致
4. **选中态** — 改用 `inset box-shadow` 模拟边框，防止 layout 跳动
5. **标题行** — monospace #id + 单行省略标题 + ExecutorBadge（紧凑排列）
6. **meta 行** — 标签、调度器图标、评审徽章、相对时间紧凑排列
7. **CSS 清理** — 移除不再使用的 `.todo-item-desc` 规则

### 改动文件

| 文件 | 行差 |
|------|------|
| `frontend/src/components/todo-list/TodoItemRow.tsx` | +97 / -83 |
| `frontend/src/App.css` | 精简 padding/删除无用样式 |

### 视觉对比

**改前**：每项卡片高胖，显示 #id + 标题 + prompt 截断文本 + 标签行 + 时间 + 状态选择器

**改后**：每项卡片紧凑，3px 色条 + #id + 标题 + ExecutorBadge + 标签/时间 meta 行 + 状态选择器