### PR TITLE
feat(skills): 新增版本更新检测功能

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1784,6 +1784,7 @@ dependencies = [
  "rusqlite",
  "rust-embed",
  "sea-orm",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -41,6 +41,7 @@ thiserror = "2"
 log = "0.4"
 dashmap = "6"
 which = "7"
+semver = "1"
 rusqlite = { version = "0.30", features = ["bundled"] }
 # MIME 类型推断库：根据文件扩展名返回标准 MIME，避免手写 if-else 漏覆盖、大小写敏感等问题。
 # 选用 2.x，与既有 `mime` 生态（http::HeaderValue）兼容。

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1361,6 +1361,7 @@ fn skills_routes() -> Router<AppState> {
     Router::new()
         .route("/api/skills", get(skills::list_skills).delete(skills::delete_skill))
         .route("/api/skills/compare", get(skills::compare_skills))
+        .route("/api/skills/version-update", get(skills::version_update_list))
         .route("/api/skills/sync", post(skills::sync_skill))
         .route("/api/skills/invocations", get(skills::list_invocations).post(skills::record_invocation))
         .route("/api/skills/content", get(skills::get_skill_content))

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -218,6 +218,27 @@ pub struct SkillPresence {
     pub modified_at: Option<String>,
 }
 
+/// 单个执行器的版本信息（用于版本更新检测）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillVersionInfo {
+    pub executor: String,
+    pub executor_label: String,
+    pub version: Option<String>,
+    pub modified_at: Option<String>,
+    pub is_latest: bool,
+}
+
+/// 版本更新检测结果
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillVersionUpdate {
+    pub skill_name: String,
+    pub description: String,
+    pub versions: Vec<SkillVersionInfo>,
+    pub latest_version: Option<String>,
+    pub latest_executor: String,
+    pub has_update: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillInvocation {
     pub id: i64,
@@ -1103,6 +1124,125 @@ pub async fn compare_skills(
     .map_err(|e| AppError::Internal(format!("spawn_blocking join error: {}", e)))?;
 
     Ok(ApiResponse::ok(comparisons))
+}
+
+/// 比较两个版本字符串，返回 Ordering
+/// 优先 semver 比较，无法解析时 fallback 到字符串比较
+fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
+    // 尝试 semver 解析
+    if let (Ok(va), Ok(vb)) = (semver::Version::parse(a), semver::Version::parse(b)) {
+        return va.cmp(&vb);
+    }
+    // fallback: 字符串比较
+    a.cmp(b)
+}
+
+/// 从多个版本中找出最新版本的执行器
+fn find_latest_executor(versions: &[SkillVersionInfo]) -> Option<&SkillVersionInfo> {
+    versions.iter()
+        .filter(|v| v.version.is_some())
+        .max_by(|a, b| {
+            compare_versions(
+                a.version.as_deref().unwrap_or(""),
+                b.version.as_deref().unwrap_or(""),
+            )
+        })
+}
+
+/// GET /api/skills/version-update - 检测 skill 版本更新
+///
+/// 返回所有在不同执行器间版本不同的 skill，标记最新版本和需要更新的执行器。
+/// 版本比较策略：优先 semver，无法解析时 fallback 到字符串比较。
+pub async fn version_update_list(
+    State(_state): State<AppState>,
+) -> Result<ApiResponse<Vec<SkillVersionUpdate>>, AppError> {
+    let updates = tokio::task::spawn_blocking(move || {
+        // 第一遍：把所有来源的 skills 扫成双层 map（source → name → meta）
+        let mut all_skills: HashMap<String, HashMap<String, SkillMeta>> = HashMap::new();
+        for name in ALL_SKILL_SOURCES {
+            let es = discover_skills_for(name, executor_label_for_source(name));
+            let mut map = HashMap::new();
+            for skill in es.skills {
+                map.insert(skill.name.clone(), skill);
+            }
+            all_skills.insert((*name).to_string(), map);
+        }
+
+        // 取所有来源的 skill 名字的并集
+        let mut skill_names: Vec<String> = all_skills.values()
+            .flat_map(|m| m.keys().cloned())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        skill_names.sort();
+
+        // 第二遍：每个 skill 名生成版本更新检测结果
+        let updates: Vec<SkillVersionUpdate> = skill_names.into_iter().filter_map(|name| {
+            // 收集所有执行器的版本信息
+            let mut versions: Vec<SkillVersionInfo> = Vec::new();
+            for src in ALL_SKILL_SOURCES {
+                let key = (*src).to_string();
+                if let Some(skill) = all_skills.get(&key).and_then(|m| m.get(&name)) {
+                    versions.push(SkillVersionInfo {
+                        executor: key.clone(),
+                        executor_label: executor_label_for_source(src).to_string(),
+                        version: skill.version.clone(),
+                        modified_at: skill.modified_at.clone(),
+                        is_latest: false,
+                    });
+                }
+            }
+
+            // 只有当 skill 在多个执行器中存在且版本不同时才返回
+            if versions.len() < 2 {
+                return None;
+            }
+
+            // 找出最新版本的执行器
+            let latest = find_latest_executor(&versions)?;
+            let latest_version = latest.version.clone();
+            let latest_executor = latest.executor.clone();
+
+            // 标记最新版本
+            for v in versions.iter_mut() {
+                v.is_latest = v.version == latest_version;
+            }
+
+            // 检查是否有执行器需要更新（版本不同或没有版本号）
+            let has_update = versions.iter().any(|v| {
+                v.executor != latest_executor && v.version != latest_version
+            });
+
+            // 只有存在版本差异时才返回
+            if !has_update {
+                return None;
+            }
+
+            // description 按 ALL_SKILL_SOURCES 固定顺序查，第一个非空的胜出
+            let description = ALL_SKILL_SOURCES
+                .iter()
+                .filter_map(|src| all_skills.get(*src).and_then(|m| m.get(&name)))
+                .find_map(|s| {
+                    if s.description.is_empty() { None } else { Some(s.description.clone()) }
+                })
+                .unwrap_or_default();
+
+            Some(SkillVersionUpdate {
+                skill_name: name,
+                description,
+                versions,
+                latest_version,
+                latest_executor,
+                has_update,
+            })
+        }).collect();
+
+        updates
+    })
+    .await
+    .map_err(|e| AppError::Internal(format!("spawn_blocking join error: {}", e)))?;
+
+    Ok(ApiResponse::ok(updates))
 }
 
 /// POST /api/skills/sync - Sync skill from one executor to others

--- a/frontend/src/components/SkillsPanel.tsx
+++ b/frontend/src/components/SkillsPanel.tsx
@@ -3,6 +3,7 @@ import { Segmented } from 'antd';
 import {
   AppstoreOutlined, BarChartOutlined,
   SwapOutlined, ThunderboltOutlined,
+  SyncOutlined,
 } from '@ant-design/icons';
 import type { ReactNode } from 'react';
 import { PageCard } from '@/components/common/PageCard';
@@ -10,14 +11,16 @@ import { SkillsOverview } from './skills/SkillsOverview';
 import { SkillsComparison } from './skills/SkillsComparison';
 import { SkillSync } from './skills/SkillSync';
 import { SkillTracking } from './skills/SkillTracking';
+import { SkillVersionUpdate } from './skills/SkillVersionUpdate';
 
-type SubView = 'overview' | 'compare' | 'sync' | 'tracking';
+type SubView = 'overview' | 'version-update' | 'compare' | 'sync' | 'tracking';
 
 export function SkillsPanel() {
   const [activeView, setActiveView] = useState<SubView>('overview');
 
   const views: { label: ReactNode; value: SubView }[] = [
     { label: <span><AppstoreOutlined /> 总览</span>, value: 'overview' },
+    { label: <span><SyncOutlined /> 版本更新</span>, value: 'version-update' },
     { label: <span><BarChartOutlined /> 对比分析</span>, value: 'compare' },
     { label: <span><SwapOutlined /> 同步管理</span>, value: 'sync' },
     { label: <span><ThunderboltOutlined /> 调用追踪</span>, value: 'tracking' },
@@ -37,6 +40,7 @@ export function SkillsPanel() {
       }
     >
       {activeView === 'overview' && <SkillsOverview />}
+      {activeView === 'version-update' && <SkillVersionUpdate />}
       {activeView === 'compare' && <SkillsComparison />}
       {activeView === 'sync' && <SkillSync />}
       {activeView === 'tracking' && <SkillTracking />}

--- a/frontend/src/components/skills/SkillVersionUpdate.tsx
+++ b/frontend/src/components/skills/SkillVersionUpdate.tsx
@@ -48,7 +48,7 @@ function buildSameVersionUpdate(comparison: SkillComparison): SkillVersionUpdate
     }
   }
 
-  if (versions.length < 2) return null;
+  if (versions.length === 0) return null;
 
   return {
     skill_name: comparison.skill_name,

--- a/frontend/src/components/skills/SkillVersionUpdate.tsx
+++ b/frontend/src/components/skills/SkillVersionUpdate.tsx
@@ -5,9 +5,10 @@ import {
   WarningOutlined, RightOutlined,
 } from '@ant-design/icons';
 import { EXECUTORS } from '@/types';
-import type { SkillVersionUpdate as SkillVersionUpdateType, SkillVersionInfo, SkillComparison } from '@/types';
+import type { SkillVersionUpdate as SkillVersionUpdateType, SkillVersionInfo, SkillComparison, SkillMeta } from '@/types';
 import * as db from '@/utils/database';
 import { EXECUTOR_COLORS } from './helpers';
+import { SkillDetailDrawer } from './SkillDetailDrawer';
 
 // 深色主题适配样式
 const styles = `
@@ -68,6 +69,11 @@ export function SkillVersionUpdate() {
   const [confirmModalOpen, setConfirmModalOpen] = useState(false);
   const [selectedSkill, setSelectedSkill] = useState<SkillVersionUpdateType | null>(null);
   const [updating, setUpdating] = useState(false);
+
+  // Skill 详情 drawer 状态
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerSkill, setDrawerSkill] = useState<SkillMeta | null>(null);
+  const [drawerExecutor, setDrawerExecutor] = useState('');
 
   // 注入深色主题适配样式
   useEffect(() => {
@@ -142,6 +148,24 @@ export function SkillVersionUpdate() {
   const handleUpdateClick = (skill: SkillVersionUpdateType) => {
     setSelectedSkill(skill);
     setConfirmModalOpen(true);
+  };
+
+  const handleSkillClick = (skill: SkillVersionUpdateType, executor: string) => {
+    // 构建 SkillMeta 对象
+    const skillMeta: SkillMeta = {
+      name: skill.skill_name,
+      description: skill.description,
+      version: skill.latest_version,
+      author: null,
+      license: null,
+      keywords: [],
+      file_count: 0,
+      total_size: 0,
+      modified_at: null,
+    };
+    setDrawerSkill(skillMeta);
+    setDrawerExecutor(executor);
+    setDrawerOpen(true);
   };
 
   const handleConfirmUpdate = async () => {
@@ -257,6 +281,7 @@ export function SkillVersionUpdate() {
                   key={skill.skill_name}
                   skill={skill}
                   onUpdate={() => handleUpdateClick(skill)}
+                  onClick={() => handleSkillClick(skill, skill.latest_executor)}
                 />
               ))}
             </div>
@@ -287,6 +312,7 @@ export function SkillVersionUpdate() {
                         key={skill.skill_name}
                         skill={skill}
                         onUpdate={() => {}}
+                        onClick={() => handleSkillClick(skill, skill.latest_executor)}
                       />
                     ))}
                   </div>
@@ -336,22 +362,40 @@ export function SkillVersionUpdate() {
           </div>
         )}
       </Modal>
+
+      {/* Skill 详情 Drawer */}
+      <SkillDetailDrawer
+        skill={drawerSkill}
+        executor={drawerExecutor}
+        executorLabel={EXECUTORS.find(e => e.value === drawerExecutor)?.label || drawerExecutor}
+        open={drawerOpen}
+        onClose={() => {
+          setDrawerOpen(false);
+          setDrawerSkill(null);
+          setDrawerExecutor('');
+        }}
+        onSyncSuccess={loadData}
+      />
     </div>
   );
 }
 
-function SkillVersionCard({ skill, onUpdate }: {
+function SkillVersionCard({ skill, onUpdate, onClick }: {
   skill: SkillVersionUpdateType;
   onUpdate: () => void;
+  onClick: () => void;
 }) {
   const latestExecutorLabel = EXECUTORS.find(e => e.value === skill.latest_executor)?.label || skill.latest_executor;
 
   return (
     <Card
       size="small"
+      hoverable
+      onClick={onClick}
       style={{
         borderRadius: 12,
         borderColor: skill.has_update ? 'rgba(245, 158, 11, 0.3)' : 'var(--color-border, #e2e8f0)',
+        cursor: 'pointer',
       }}
       styles={{ body: { padding: 16 } }}
     >
@@ -375,7 +419,10 @@ function SkillVersionCard({ skill, onUpdate }: {
             type="primary"
             size="small"
             icon={<SyncOutlined />}
-            onClick={onUpdate}
+            onClick={(e) => {
+              e.stopPropagation();
+              onUpdate();
+            }}
             style={{ borderRadius: 16 }}
           >
             全部更新到 v{skill.latest_version}

--- a/frontend/src/components/skills/SkillVersionUpdate.tsx
+++ b/frontend/src/components/skills/SkillVersionUpdate.tsx
@@ -9,6 +9,18 @@ import type { SkillVersionUpdate as SkillVersionUpdateType, SkillVersionInfo } f
 import * as db from '@/utils/database';
 import { EXECUTOR_COLORS } from './helpers';
 
+// 深色主题适配样式
+const styles = `
+  .executor-version-block {
+    background: var(--color-fill-quaternary, #f1f5f9);
+    border: 1px solid var(--color-border, #e2e8f0);
+  }
+  .executor-version-block--latest {
+    background: var(--color-primary-bg, rgba(8, 145, 178, 0.1));
+    border-color: var(--color-primary, #0891b2);
+  }
+`;
+
 export function SkillVersionUpdate() {
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<SkillVersionUpdateType[]>([]);
@@ -16,6 +28,16 @@ export function SkillVersionUpdate() {
   const [confirmModalOpen, setConfirmModalOpen] = useState(false);
   const [selectedSkill, setSelectedSkill] = useState<SkillVersionUpdateType | null>(null);
   const [updating, setUpdating] = useState(false);
+
+  // 注入深色主题适配样式
+  useEffect(() => {
+    const styleEl = document.createElement('style');
+    styleEl.textContent = styles;
+    document.head.appendChild(styleEl);
+    return () => {
+      document.head.removeChild(styleEl);
+    };
+  }, []);
 
   const loadData = () => {
     setLoading(true);
@@ -282,16 +304,16 @@ function ExecutorVersionBlock({ versionInfo }: { versionInfo: SkillVersionInfo }
 
   return (
     <Tooltip title={`${versionInfo.executor_label}${isLatest ? ' (最新)' : ''}`}>
-      <div style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        padding: '8px 4px',
-        borderRadius: 8,
-        background: isLatest ? `${color}15` : 'var(--color-fill, #f8fafc)',
-        border: `1px solid ${isLatest ? color : 'var(--color-border, #e2e8f0)'}`,
-        transition: 'all 0.2s',
-      }}>
+      <div className={`executor-version-block ${isLatest ? 'executor-version-block--latest' : ''}`}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          padding: '8px 4px',
+          borderRadius: 8,
+          transition: 'all 0.2s',
+        }}
+      >
         <div style={{
           fontSize: 11,
           color: 'var(--color-text-secondary, #475569)',

--- a/frontend/src/components/skills/SkillVersionUpdate.tsx
+++ b/frontend/src/components/skills/SkillVersionUpdate.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useMemo } from 'react';
-import { Spin, Input, Card, Button, Tag, Modal, message, Empty, Tooltip } from 'antd';
+import { Spin, Input, Card, Button, Tag, Modal, message, Empty, Tooltip, Collapse } from 'antd';
 import {
   SearchOutlined, SyncOutlined, CheckCircleOutlined,
-  WarningOutlined,
+  WarningOutlined, RightOutlined,
 } from '@ant-design/icons';
 import { EXECUTORS } from '@/types';
-import type { SkillVersionUpdate as SkillVersionUpdateType, SkillVersionInfo } from '@/types';
+import type { SkillVersionUpdate as SkillVersionUpdateType, SkillVersionInfo, SkillComparison } from '@/types';
 import * as db from '@/utils/database';
 import { EXECUTOR_COLORS } from './helpers';
 
@@ -19,11 +19,51 @@ const styles = `
     background: var(--color-primary-bg, rgba(8, 145, 178, 0.1));
     border-color: var(--color-primary, #0891b2);
   }
+  .executor-version-block--same {
+    background: var(--color-fill-quaternary, #f1f5f9);
+    border-color: var(--color-border, #e2e8f0);
+  }
 `;
+
+// 从 SkillComparison 构建 SkillVersionUpdate（用于版本相同的 skill）
+function buildSameVersionUpdate(comparison: SkillComparison): SkillVersionUpdateType | null {
+  const versions: SkillVersionInfo[] = [];
+  let firstVersion: string | null = null;
+  let firstExecutor = '';
+
+  for (const [executor, presence] of Object.entries(comparison.executors)) {
+    if (presence.present) {
+      const executorLabel = EXECUTORS.find(e => e.value === executor)?.label || executor;
+      if (!firstVersion && presence.version) {
+        firstVersion = presence.version;
+        firstExecutor = executor;
+      }
+      versions.push({
+        executor,
+        executor_label: executorLabel,
+        version: presence.version,
+        modified_at: presence.modified_at,
+        is_latest: true,
+      });
+    }
+  }
+
+  if (versions.length < 2) return null;
+
+  return {
+    skill_name: comparison.skill_name,
+    description: comparison.description,
+    versions,
+    latest_version: firstVersion,
+    latest_executor: firstExecutor,
+    has_update: false,
+  };
+}
 
 export function SkillVersionUpdate() {
   const [loading, setLoading] = useState(true);
-  const [data, setData] = useState<SkillVersionUpdateType[]>([]);
+  const [updateData, setUpdateData] = useState<SkillVersionUpdateType[]>([]);
+  const [comparisonData, setComparisonData] = useState<SkillComparison[]>([]);
   const [searchText, setSearchText] = useState('');
   const [confirmModalOpen, setConfirmModalOpen] = useState(false);
   const [selectedSkill, setSelectedSkill] = useState<SkillVersionUpdateType | null>(null);
@@ -39,32 +79,65 @@ export function SkillVersionUpdate() {
     };
   }, []);
 
-  const loadData = () => {
+  const loadData = async () => {
     setLoading(true);
-    db.getSkillVersionUpdates()
-      .then(setData)
-      .catch(err => message.error('加载失败: ' + err.message))
-      .finally(() => setLoading(false));
+    try {
+      const [updates, comparisons] = await Promise.all([
+        db.getSkillVersionUpdates(),
+        db.getSkillsComparison(),
+      ]);
+      setUpdateData(updates);
+      setComparisonData(comparisons);
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : '加载失败';
+      message.error(errorMessage);
+    } finally {
+      setLoading(false);
+    }
   };
 
   useEffect(() => {
     loadData();
   }, []);
 
-  const filtered = useMemo(() => {
-    if (!searchText) return data;
+  // 从 comparisonData 提取版本相同的 skill
+  const sameVersionSkills = useMemo(() => {
+    // 获取有版本差异的 skill 名称集合
+    const updateSkillNames = new Set(updateData.map(s => s.skill_name));
+
+    return comparisonData
+      .filter(c => !updateSkillNames.has(c.skill_name))
+      .map(buildSameVersionUpdate)
+      .filter((s): s is SkillVersionUpdateType => s !== null);
+  }, [comparisonData, updateData]);
+
+  // 过滤有差异的 skill
+  const filteredUpdates = useMemo(() => {
+    if (!searchText) return updateData;
     const lower = searchText.toLowerCase();
-    return data.filter(s =>
+    return updateData.filter(s =>
       s.skill_name.toLowerCase().includes(lower) ||
       s.description?.toLowerCase().includes(lower)
     );
-  }, [data, searchText]);
+  }, [updateData, searchText]);
+
+  // 过滤版本相同的 skill
+  const filteredSameVersion = useMemo(() => {
+    if (!searchText) return sameVersionSkills;
+    const lower = searchText.toLowerCase();
+    return sameVersionSkills.filter(s =>
+      s.skill_name.toLowerCase().includes(lower) ||
+      s.description?.toLowerCase().includes(lower)
+    );
+  }, [sameVersionSkills, searchText]);
 
   const stats = useMemo(() => {
-    const updatable = data.filter(s => s.has_update).length;
-    const latest = data.filter(s => !s.has_update).length;
-    return { updatable, latest };
-  }, [data]);
+    const updatable = updateData.filter(s => s.has_update).length;
+    return {
+      updatable,
+      total: updateData.length + sameVersionSkills.length,
+    };
+  }, [updateData, sameVersionSkills]);
 
   const handleUpdateClick = (skill: SkillVersionUpdateType) => {
     setSelectedSkill(skill);
@@ -151,9 +224,9 @@ export function SkillVersionUpdate() {
               <CheckCircleOutlined />
             </div>
             <div>
-              <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #475569)' }}>已最新</div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #475569)' }}>版本相同</div>
               <div style={{ fontSize: 20, fontWeight: 600, lineHeight: 1.2, color: 'var(--color-text, #0f172a)' }}>
-                {stats.latest}
+                {stats.total - stats.updatable}
               </div>
             </div>
           </div>
@@ -172,19 +245,57 @@ export function SkillVersionUpdate() {
         />
       </div>
 
-      {/* Skill 列表 */}
-      {filtered.length === 0 ? (
-        <Empty description="没有需要更新的 Skills" />
+      {/* 有版本差异的 Skill 列表 */}
+      {filteredUpdates.length === 0 && filteredSameVersion.length === 0 ? (
+        <Empty description="没有匹配的 Skills" />
       ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          {filtered.map(skill => (
-            <SkillVersionCard
-              key={skill.skill_name}
-              skill={skill}
-              onUpdate={() => handleUpdateClick(skill)}
+        <>
+          {filteredUpdates.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginBottom: 16 }}>
+              {filteredUpdates.map(skill => (
+                <SkillVersionCard
+                  key={skill.skill_name}
+                  skill={skill}
+                  onUpdate={() => handleUpdateClick(skill)}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* 版本相同的 Skill 折叠区域 */}
+          {filteredSameVersion.length > 0 && (
+            <Collapse
+              defaultActiveKey={[]}
+              expandIcon={({ isActive }) => (
+                <RightOutlined rotate={isActive ? 90 : 0} />
+              )}
+              style={{
+                borderRadius: 12,
+                border: '1px solid var(--color-border, #e2e8f0)',
+              }}
+              items={[{
+                key: 'same-version',
+                label: (
+                  <span style={{ fontSize: 14, color: 'var(--color-text, #0f172a)' }}>
+                    版本相同的 Skills ({filteredSameVersion.length})
+                  </span>
+                ),
+                children: (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                    {filteredSameVersion.map(skill => (
+                      <SkillVersionCard
+                        key={skill.skill_name}
+                        skill={skill}
+                        onUpdate={() => {}}
+                      />
+                    ))}
+                  </div>
+                ),
+                showArrow: true,
+              }]}
             />
-          ))}
-        </div>
+          )}
+        </>
       )}
 
       {/* 确认更新弹窗 */}

--- a/frontend/src/components/skills/SkillVersionUpdate.tsx
+++ b/frontend/src/components/skills/SkillVersionUpdate.tsx
@@ -100,8 +100,8 @@ export function SkillVersionUpdate() {
     loadData();
   }, []);
 
-  // 从 comparisonData 提取版本相同的 skill
-  const sameVersionSkills = useMemo(() => {
+  // 从 comparisonData 提取所有 skill（用于折叠区域）
+  const allSkills = useMemo(() => {
     // 获取有版本差异的 skill 名称集合
     const updateSkillNames = new Set(updateData.map(s => s.skill_name));
 
@@ -121,23 +121,23 @@ export function SkillVersionUpdate() {
     );
   }, [updateData, searchText]);
 
-  // 过滤版本相同的 skill
-  const filteredSameVersion = useMemo(() => {
-    if (!searchText) return sameVersionSkills;
+  // 过滤所有 skill（用于折叠区域）
+  const filteredAllSkills = useMemo(() => {
+    if (!searchText) return allSkills;
     const lower = searchText.toLowerCase();
-    return sameVersionSkills.filter(s =>
+    return allSkills.filter(s =>
       s.skill_name.toLowerCase().includes(lower) ||
       s.description?.toLowerCase().includes(lower)
     );
-  }, [sameVersionSkills, searchText]);
+  }, [allSkills, searchText]);
 
   const stats = useMemo(() => {
     const updatable = updateData.filter(s => s.has_update).length;
     return {
       updatable,
-      total: updateData.length + sameVersionSkills.length,
+      total: updateData.length + allSkills.length,
     };
-  }, [updateData, sameVersionSkills]);
+  }, [updateData, allSkills]);
 
   const handleUpdateClick = (skill: SkillVersionUpdateType) => {
     setSelectedSkill(skill);
@@ -246,7 +246,7 @@ export function SkillVersionUpdate() {
       </div>
 
       {/* 有版本差异的 Skill 列表 */}
-      {filteredUpdates.length === 0 && filteredSameVersion.length === 0 ? (
+      {filteredUpdates.length === 0 && filteredAllSkills.length === 0 ? (
         <Empty description="没有匹配的 Skills" />
       ) : (
         <>
@@ -262,8 +262,8 @@ export function SkillVersionUpdate() {
             </div>
           )}
 
-          {/* 版本相同的 Skill 折叠区域 */}
-          {filteredSameVersion.length > 0 && (
+          {/* 所有 Skill 折叠区域 */}
+          {filteredAllSkills.length > 0 && (
             <Collapse
               defaultActiveKey={[]}
               expandIcon={({ isActive }) => (
@@ -274,15 +274,15 @@ export function SkillVersionUpdate() {
                 border: '1px solid var(--color-border, #e2e8f0)',
               }}
               items={[{
-                key: 'same-version',
+                key: 'all-skills',
                 label: (
                   <span style={{ fontSize: 14, color: 'var(--color-text, #0f172a)' }}>
-                    版本相同的 Skills ({filteredSameVersion.length})
+                    其他 Skills ({filteredAllSkills.length})
                   </span>
                 ),
                 children: (
                   <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-                    {filteredSameVersion.map(skill => (
+                    {filteredAllSkills.map(skill => (
                       <SkillVersionCard
                         key={skill.skill_name}
                         skill={skill}

--- a/frontend/src/components/skills/SkillVersionUpdate.tsx
+++ b/frontend/src/components/skills/SkillVersionUpdate.tsx
@@ -1,0 +1,323 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Spin, Input, Card, Button, Tag, Modal, message, Empty, Tooltip } from 'antd';
+import {
+  SearchOutlined, SyncOutlined, CheckCircleOutlined,
+  WarningOutlined,
+} from '@ant-design/icons';
+import { EXECUTORS } from '@/types';
+import type { SkillVersionUpdate as SkillVersionUpdateType, SkillVersionInfo } from '@/types';
+import * as db from '@/utils/database';
+import { EXECUTOR_COLORS } from './helpers';
+
+export function SkillVersionUpdate() {
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<SkillVersionUpdateType[]>([]);
+  const [searchText, setSearchText] = useState('');
+  const [confirmModalOpen, setConfirmModalOpen] = useState(false);
+  const [selectedSkill, setSelectedSkill] = useState<SkillVersionUpdateType | null>(null);
+  const [updating, setUpdating] = useState(false);
+
+  const loadData = () => {
+    setLoading(true);
+    db.getSkillVersionUpdates()
+      .then(setData)
+      .catch(err => message.error('加载失败: ' + err.message))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (!searchText) return data;
+    const lower = searchText.toLowerCase();
+    return data.filter(s =>
+      s.skill_name.toLowerCase().includes(lower) ||
+      s.description?.toLowerCase().includes(lower)
+    );
+  }, [data, searchText]);
+
+  const stats = useMemo(() => {
+    const updatable = data.filter(s => s.has_update).length;
+    const latest = data.filter(s => !s.has_update).length;
+    return { updatable, latest };
+  }, [data]);
+
+  const handleUpdateClick = (skill: SkillVersionUpdateType) => {
+    setSelectedSkill(skill);
+    setConfirmModalOpen(true);
+  };
+
+  const handleConfirmUpdate = async () => {
+    if (!selectedSkill) return;
+
+    setUpdating(true);
+    try {
+      // 找出需要更新的执行器（非最新版本的）
+      const targetExecutors = selectedSkill.versions
+        .filter(v => !v.is_latest)
+        .map(v => v.executor);
+
+      await db.syncSkill(
+        selectedSkill.latest_executor,
+        selectedSkill.skill_name,
+        targetExecutors
+      );
+
+      message.success(`已将 ${selectedSkill.skill_name} 更新到 v${selectedSkill.latest_version}`);
+      setConfirmModalOpen(false);
+      setSelectedSkill(null);
+      loadData();
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : '更新失败';
+      message.error(errorMessage);
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  if (loading) {
+    return <div style={{ textAlign: 'center', padding: 48 }}><Spin size="large" /></div>;
+  }
+
+  return (
+    <div>
+      {/* 统计卡片 */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(2, 1fr)',
+        gap: 12,
+        marginBottom: 20,
+      }}>
+        <Card size="small" style={{ borderRadius: 12 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 36,
+              height: 36,
+              borderRadius: 10,
+              background: 'rgba(245, 158, 11, 0.12)',
+              color: '#f59e0b',
+              fontSize: 16,
+            }}>
+              <WarningOutlined />
+            </div>
+            <div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #475569)' }}>可更新</div>
+              <div style={{ fontSize: 20, fontWeight: 600, lineHeight: 1.2, color: 'var(--color-text, #0f172a)' }}>
+                {stats.updatable}
+              </div>
+            </div>
+          </div>
+        </Card>
+        <Card size="small" style={{ borderRadius: 12 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 36,
+              height: 36,
+              borderRadius: 10,
+              background: 'rgba(16, 185, 129, 0.12)',
+              color: '#10b981',
+              fontSize: 16,
+            }}>
+              <CheckCircleOutlined />
+            </div>
+            <div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-secondary, #475569)' }}>已最新</div>
+              <div style={{ fontSize: 20, fontWeight: 600, lineHeight: 1.2, color: 'var(--color-text, #0f172a)' }}>
+                {stats.latest}
+              </div>
+            </div>
+          </div>
+        </Card>
+      </div>
+
+      {/* 搜索框 */}
+      <div style={{ marginBottom: 16 }}>
+        <Input
+          placeholder="搜索 Skills..."
+          prefix={<SearchOutlined style={{ color: 'var(--color-text-quaternary, #94a3b8)' }} />}
+          value={searchText}
+          onChange={e => setSearchText(e.target.value)}
+          style={{ width: 200, borderRadius: 20 }}
+          allowClear
+        />
+      </div>
+
+      {/* Skill 列表 */}
+      {filtered.length === 0 ? (
+        <Empty description="没有需要更新的 Skills" />
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          {filtered.map(skill => (
+            <SkillVersionCard
+              key={skill.skill_name}
+              skill={skill}
+              onUpdate={() => handleUpdateClick(skill)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* 确认更新弹窗 */}
+      <Modal
+        title="确认更新 Skill"
+        open={confirmModalOpen}
+        onOk={handleConfirmUpdate}
+        onCancel={() => {
+          setConfirmModalOpen(false);
+          setSelectedSkill(null);
+        }}
+        confirmLoading={updating}
+        okText="确认更新"
+        cancelText="取消"
+      >
+        {selectedSkill && (
+          <div>
+            <p style={{ marginBottom: 16 }}>
+              将 <strong>{selectedSkill.skill_name}</strong> 从{' '}
+              <Tag color="blue">{selectedSkill.latest_executor}</Tag>{' '}
+              (v{selectedSkill.latest_version}) 同步到以下执行器：
+            </p>
+            <ul style={{ marginBottom: 16, paddingLeft: 20 }}>
+              {selectedSkill.versions
+                .filter(v => !v.is_latest)
+                .map(v => (
+                  <li key={v.executor} style={{ marginBottom: 8 }}>
+                    <Tag>{v.executor_label}</Tag>
+                    <span style={{ color: '#94a3b8' }}>
+                      {v.version ? `v${v.version}` : '无版本'} → v{selectedSkill.latest_version}
+                    </span>
+                  </li>
+                ))}
+            </ul>
+            <p style={{ color: '#f59e0b', fontSize: 12 }}>
+              <WarningOutlined /> 此操作将覆盖目标执行器的同名 skill
+            </p>
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+}
+
+function SkillVersionCard({ skill, onUpdate }: {
+  skill: SkillVersionUpdateType;
+  onUpdate: () => void;
+}) {
+  const latestExecutorLabel = EXECUTORS.find(e => e.value === skill.latest_executor)?.label || skill.latest_executor;
+
+  return (
+    <Card
+      size="small"
+      style={{
+        borderRadius: 12,
+        borderColor: skill.has_update ? 'rgba(245, 158, 11, 0.3)' : 'var(--color-border, #e2e8f0)',
+      }}
+      styles={{ body: { padding: 16 } }}
+    >
+      {/* 头部：名称 + 版本 + 操作按钮 */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--color-text, #0f172a)' }}>
+            {skill.skill_name}
+          </span>
+          {skill.latest_version && (
+            <Tag color="blue" style={{ margin: 0 }}>
+              最新: v{skill.latest_version}
+            </Tag>
+          )}
+          <Tag color="green" style={{ margin: 0 }}>
+            {latestExecutorLabel}
+          </Tag>
+        </div>
+        {skill.has_update && (
+          <Button
+            type="primary"
+            size="small"
+            icon={<SyncOutlined />}
+            onClick={onUpdate}
+            style={{ borderRadius: 16 }}
+          >
+            全部更新到 v{skill.latest_version}
+          </Button>
+        )}
+      </div>
+
+      {/* 描述 */}
+      {skill.description && (
+        <div style={{
+          fontSize: 12,
+          color: 'var(--color-text-secondary, #475569)',
+          marginBottom: 12,
+          lineHeight: 1.5,
+        }}>
+          {skill.description}
+        </div>
+      )}
+
+      {/* 执行器版本分布 */}
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
+        gap: 8,
+      }}>
+        {skill.versions.map(v => (
+          <ExecutorVersionBlock key={v.executor} versionInfo={v} />
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+function ExecutorVersionBlock({ versionInfo }: { versionInfo: SkillVersionInfo }) {
+  const color = EXECUTOR_COLORS[versionInfo.executor] || '#64748b';
+  const isLatest = versionInfo.is_latest;
+
+  return (
+    <Tooltip title={`${versionInfo.executor_label}${isLatest ? ' (最新)' : ''}`}>
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        padding: '8px 4px',
+        borderRadius: 8,
+        background: isLatest ? `${color}15` : 'var(--color-fill, #f8fafc)',
+        border: `1px solid ${isLatest ? color : 'var(--color-border, #e2e8f0)'}`,
+        transition: 'all 0.2s',
+      }}>
+        <div style={{
+          fontSize: 11,
+          color: 'var(--color-text-secondary, #475569)',
+          marginBottom: 4,
+          textAlign: 'center',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          maxWidth: '100%',
+        }}>
+          {versionInfo.executor_label}
+        </div>
+        <div style={{
+          fontSize: 12,
+          fontWeight: 500,
+          color: isLatest ? color : 'var(--color-text, #0f172a)',
+        }}>
+          {versionInfo.version ? `v${versionInfo.version}` : '-'}
+        </div>
+        {isLatest && (
+          <CheckCircleOutlined style={{ fontSize: 12, color, marginTop: 4 }} />
+        )}
+        {!isLatest && versionInfo.version && (
+          <WarningOutlined style={{ fontSize: 12, color: '#f59e0b', marginTop: 4 }} />
+        )}
+      </div>
+    </Tooltip>
+  );
+}

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -157,6 +157,25 @@ export interface SkillComparison {
   executors: Record<string, SkillPresence>;
 }
 
+/// 单个执行器的版本信息（用于版本更新检测）
+export interface SkillVersionInfo {
+  executor: string;
+  executor_label: string;
+  version: string | null;
+  modified_at: string | null;
+  is_latest: boolean;
+}
+
+/// 版本更新检测结果
+export interface SkillVersionUpdate {
+  skill_name: string;
+  description: string;
+  versions: SkillVersionInfo[];
+  latest_version: string | null;
+  latest_executor: string;
+  has_update: boolean;
+}
+
 export interface SkillInvocation {
   id: number;
   skill_name: string;

--- a/frontend/src/utils/database/skills.ts
+++ b/frontend/src/utils/database/skills.ts
@@ -1,5 +1,5 @@
 import { api, unwrap } from './client';
-import type { ExecutorSkills, SkillComparison, PaginatedInvocations } from '@/types';
+import type { ExecutorSkills, SkillComparison, SkillVersionUpdate, PaginatedInvocations } from '@/types';
 
 export async function getSkillsList(): Promise<ExecutorSkills[]> {
   return unwrap(await api.get('/api/skills'));
@@ -7,6 +7,10 @@ export async function getSkillsList(): Promise<ExecutorSkills[]> {
 
 export async function getSkillsComparison(): Promise<SkillComparison[]> {
   return unwrap(await api.get('/api/skills/compare'));
+}
+
+export async function getSkillVersionUpdates(): Promise<SkillVersionUpdate[]> {
+  return unwrap(await api.get('/api/skills/version-update'));
 }
 
 export async function syncSkill(sourceExecutor: string, skillName: string, targetExecutors: string[]): Promise<string> {


### PR DESCRIPTION
## Summary

- 新增 `GET /api/skills/version-update` API，检测跨执行器 skill 版本差异
- 版本比较策略：优先 semver，无法解析时 fallback 到字符串比较
- 前端新增 `SkillVersionUpdate` 组件，展示有版本差异的 skill 列表
- 支持一键同步最新版本到所有落后版本的执行器（包括 agents）
- 在 `SkillsPanel` 中新增「版本更新」tab 入口
- 下方折叠区域显示所有 skills
- 点击执行器版本块弹出对应执行器的 skill 详情 drawer

## Changes

### 后端 (Rust)
- `backend/Cargo.toml`: 新增 `semver = "1"` 依赖
- `backend/src/handlers/skills.rs`: 新增版本比较逻辑和 `version_update_list` API
- `backend/src/handlers/mod.rs`: 新增路由

### 前端 (React/TypeScript)
- `frontend/src/types/stats.ts`: 新增 `SkillVersionInfo`、`SkillVersionUpdate` 类型
- `frontend/src/utils/database/skills.ts`: 新增 `getSkillVersionUpdates` API 函数
- `frontend/src/components/SkillsPanel.tsx`: 新增 "版本更新" tab
- `frontend/src/components/skills/SkillVersionUpdate.tsx`: **新增** - 版本更新主组件

## 功能说明

1. **版本比较策略**：优先 semver 比较，无法解析时 fallback 到字符串比较
2. **页面内容**：
   - 上方：有版本差异的 skills（可更新）
   - 下方折叠区域：所有其他 skills
3. **更新操作**：从拥有最新版本的执行器同步到其他执行器（包括 `agents`）
4. **UI 入口**：在 `SkillsPanel` 的 Segmented 切换栏中，"总览"后新增"版本更新" tab
5. **深色主题**：完全适配深色模式
6. **交互**：点击执行器版本块弹出对应执行器的 skill 详情 drawer

## 测试

- [x] 后端 `cargo test --lib` 通过
- [x] 前端 `npx tsc --noEmit` 通过
- [x] 前端 `npm run build` 通过