### PR TITLE
feat: ActionButton 可复用一键 AI 执行组件

### DIFF
--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -461,6 +461,8 @@ async fn handle_todo(
                         workspace_id: value.get("workspace_id").and_then(|v| v.as_i64())
                             .or(*workspace_id)
                             .unwrap_or(0),
+                        action_type: None,
+                        action_key: None,
                     });
                     req
             } else {
@@ -484,6 +486,8 @@ async fn handle_todo(
                     auto_review_enabled: None,
                     // 非 stdin 模式下 workspace_id 必填：CLI 唯一标识符是 id 而非 path
                     workspace_id: workspace_id.ok_or_else(|| anyhow::anyhow!("--workspace-id is required"))?,
+                    action_type: None,
+                    action_key: None,
                 }
             };
 

--- a/backend/src/db/entity/todos.rs
+++ b/backend/src/db/entity/todos.rs
@@ -39,6 +39,12 @@ pub struct Model {
     /// 'item' = 一次性事项, 'step' = 可复用的环节 (loop 编排引用)。
     /// 同一张 todos 表承载两种语义, 由 kind 列区分; 详细见 migrations v3。
     pub kind: Option<String>,
+    /// Action 类型标记（如 "rewrite_title"、"optimize_prompt"），
+    /// 仅供前端 ActionButton 组件做 UI 分类展示，不影响执行逻辑。
+    pub action_type: Option<String>,
+    /// Action 键值，与 action_type 配合唯一标识一个 action 模板 todo。
+    /// 前端传 action_type + action_key，后端查找或自动创建对应的 todo。
+    pub action_key: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/entity/todos.rs
+++ b/backend/src/db/entity/todos.rs
@@ -39,11 +39,11 @@ pub struct Model {
     /// 'item' = 一次性事项, 'step' = 可复用的环节 (loop 编排引用)。
     /// 同一张 todos 表承载两种语义, 由 kind 列区分; 详细见 migrations v3。
     pub kind: Option<String>,
-    /// Action 类型标记（如 "rewrite_title"、"optimize_prompt"），
-    /// 仅供前端 ActionButton 组件做 UI 分类展示，不影响执行逻辑。
+    /// Action 类型标记（如 "title_optimize"、"prompt_optimize"）。
+    /// 与 action_key 配合，由 /api/actions/execute 用于查找或自动创建 action 模板 todo。
     pub action_type: Option<String>,
     /// Action 键值，与 action_type 配合唯一标识一个 action 模板 todo。
-    /// 前端传 action_type + action_key，后端查找或自动创建对应的 todo。
+    /// 由 /api/actions/execute 用于查找或自动创建 action 模板 todo。
     pub action_key: Option<String>,
 }
 

--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -48,6 +48,8 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(V42ConsolidatedWorkspaceRefactor), // V30~V35
         Box::new(V43ConsolidatedFinalFeatures),     // V36~V40
         Box::new(V44AddFeishuMessagesProcessedId),  // 补加 processed_id / processed_type
+        Box::new(V45AddTodosActionType),            // 补加 todos.action_type 列
+        Box::new(V46AddTodosActionKey),             // 补加 todos.action_key 列
     ]
 }
 
@@ -3014,6 +3016,44 @@ impl Migration for V44AddFeishuMessagesProcessedId {
         add_column_if_missing(db, "feishu_messages", "processed_type",
             "ALTER TABLE feishu_messages ADD COLUMN processed_type TEXT").await?;
         tracing::info!("V44: feishu_messages.processed_id/processed_type columns added");
+        Ok(())
+    }
+}
+
+/// V45: 补加 todos.action_type 列。
+///
+/// action_type 用于标记 todo 的用途分类（如 "rewrite_title"、"optimize_prompt"），
+/// 供前端 ActionButton 组件做 UI 展示和筛选，不影响执行逻辑。
+pub(super) struct V45AddTodosActionType;
+
+#[async_trait::async_trait]
+impl Migration for V45AddTodosActionType {
+    fn version(&self) -> i64 { 45 }
+    fn name(&self) -> &'static str { "add_todos_action_type" }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        add_column_if_missing(db, "todos", "action_type",
+            "ALTER TABLE todos ADD COLUMN action_type TEXT").await?;
+        tracing::info!("V45: todos.action_type column added");
+        Ok(())
+    }
+}
+
+/// V46: 补加 todos.action_key 列。
+///
+/// action_key 与 action_type 配合，唯一标识一个 action 模板 todo。
+/// 前端传 action_type + action_key，后端查找或自动创建对应的 todo。
+pub(super) struct V46AddTodosActionKey;
+
+#[async_trait::async_trait]
+impl Migration for V46AddTodosActionKey {
+    fn version(&self) -> i64 { 46 }
+    fn name(&self) -> &'static str { "add_todos_action_key" }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        add_column_if_missing(db, "todos", "action_key",
+            "ALTER TABLE todos ADD COLUMN action_key TEXT").await?;
+        tracing::info!("V46: todos.action_key column added");
         Ok(())
     }
 }

--- a/backend/src/db/migration.rs
+++ b/backend/src/db/migration.rs
@@ -3039,10 +3039,11 @@ impl Migration for V45AddTodosActionType {
     }
 }
 
-/// V46: 补加 todos.action_key 列。
+/// V46: 补加 todos.action_key 列，并为 (action_type, action_key) 创建唯一索引。
 ///
 /// action_key 与 action_type 配合，唯一标识一个 action 模板 todo。
 /// 前端传 action_type + action_key，后端查找或自动创建对应的 todo。
+/// 唯一索引防止并发请求重复创建模板 todo。
 pub(super) struct V46AddTodosActionKey;
 
 #[async_trait::async_trait]
@@ -3053,7 +3054,18 @@ impl Migration for V46AddTodosActionKey {
     async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
         add_column_if_missing(db, "todos", "action_key",
             "ALTER TABLE todos ADD COLUMN action_key TEXT").await?;
-        tracing::info!("V46: todos.action_key column added");
+
+        // 创建唯一索引：(action_type, action_key) 组合唯一
+        // 忽略错误：索引已存在时会报错，属于正常情况
+        let _ = db
+            .conn
+            .execute(Statement::from_string(
+                sea_orm::DatabaseBackend::Sqlite,
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_todos_action_type_key ON todos (action_type, action_key) WHERE action_type IS NOT NULL AND action_key IS NOT NULL".to_string(),
+            ))
+            .await;
+
+        tracing::info!("V46: todos.action_key column added with unique index");
         Ok(())
     }
 }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -816,6 +816,8 @@ mod tests {
             webhook_enabled: None,
             acceptance_criteria: None,
             auto_review_enabled: None,
+            action_type: None,
+            action_key: None,
         })
         .await
         .unwrap();
@@ -981,6 +983,8 @@ mod tests {
             webhook_enabled: None,
             acceptance_criteria: None,
             auto_review_enabled: None,
+            action_type: None,
+            action_key: None,
         })
         .await
         .unwrap();

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -24,10 +24,11 @@ pub struct TodoUpdate<'a> {
     pub webhook_enabled: Option<bool>,
     pub acceptance_criteria: Option<&'a str>,
     pub auto_review_enabled: Option<bool>,
-    /// Action 类型标记（如 "rewrite_title"、"optimize_prompt"），
-    /// 仅供前端 ActionButton 组件做 UI 分类展示，不影响执行逻辑。
+    /// Action 类型标记（如 "title_optimize"、"prompt_optimize"）。
+    /// 与 action_key 配合，由 /api/actions/execute 用于查找或自动创建 action 模板 todo。
     pub action_type: Option<&'a str>,
     /// Action 键值，与 action_type 配合唯一标识一个 action 模板 todo。
+    /// 由 /api/actions/execute 用于查找或自动创建 action 模板 todo。
     pub action_key: Option<&'a str>,
 }
 
@@ -145,6 +146,26 @@ impl Database {
                 Self::model_to_todo(m, tag_ids)
             })
             .collect())
+    }
+
+    /// 按 action_type + action_key 查找 todo。
+    /// 用于 ActionButton 组件的 action 模板查找。
+    pub async fn get_todo_by_action_type_and_key(
+        &self,
+        action_type: &str,
+        action_key: &str,
+    ) -> Result<Option<Todo>, sea_orm::DbErr> {
+        let model = todos::Entity::find()
+            .filter(todos::Column::ActionType.eq(action_type))
+            .filter(todos::Column::ActionKey.eq(action_key))
+            .filter(todos::Column::DeletedAt.is_null())
+            .one(&self.conn)
+            .await?;
+
+        Ok(model.map(|m| {
+            let tag_ids = vec![]; // action template 不需要 tags
+            Self::model_to_todo(m, tag_ids)
+        }))
     }
 
     pub async fn create_todo(&self, title: &str, prompt: &str) -> Result<i64, sea_orm::DbErr> {
@@ -953,6 +974,8 @@ impl Database {
                 workspace_path: ActiveValue::Set(workspace_path),
                 created_at: ActiveValue::Set(Some(now.clone())),
                 updated_at: ActiveValue::Set(Some(now)),
+                action_type: ActiveValue::Set(todo.action_type.clone()),
+                action_key: ActiveValue::Set(todo.action_key.clone()),
                 ..Default::default()
             };
             let inserted = am.insert(&txn).await?;
@@ -1041,6 +1064,8 @@ impl Database {
                 am.scheduler_config = ActiveValue::Set(todo.scheduler_config.clone());
                 am.workspace_path = ActiveValue::Set(todo.workspace_path.clone());
                 am.updated_at = ActiveValue::Set(Some(crate::models::utc_timestamp()));
+                am.action_type = ActiveValue::Set(todo.action_type.clone());
+                am.action_key = ActiveValue::Set(todo.action_key.clone());
                 let saved = am.update(&txn).await?;
 
                 // 重建 tag 关联
@@ -1082,6 +1107,8 @@ impl Database {
                     workspace_path: ActiveValue::Set(workspace_path),
                     created_at: ActiveValue::Set(Some(now.clone())),
                     updated_at: ActiveValue::Set(Some(now)),
+                    action_type: ActiveValue::Set(todo.action_type.clone()),
+                    action_key: ActiveValue::Set(todo.action_key.clone()),
                     ..Default::default()
                 };
                 let inserted = am.insert(&txn).await?;

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -24,6 +24,11 @@ pub struct TodoUpdate<'a> {
     pub webhook_enabled: Option<bool>,
     pub acceptance_criteria: Option<&'a str>,
     pub auto_review_enabled: Option<bool>,
+    /// Action 类型标记（如 "rewrite_title"、"optimize_prompt"），
+    /// 仅供前端 ActionButton 组件做 UI 分类展示，不影响执行逻辑。
+    pub action_type: Option<&'a str>,
+    /// Action 键值，与 action_type 配合唯一标识一个 action 模板 todo。
+    pub action_key: Option<&'a str>,
 }
 
 pub struct SchedulerUpdate<'a> {
@@ -75,6 +80,8 @@ impl Database {
             parent_todo_id: m.parent_todo_id,
             review_template_id: m.review_template_id,
             auto_review_enabled: m.auto_review_enabled.unwrap_or(false),
+            action_type: m.action_type,
+            action_key: m.action_key,
         }
     }
 
@@ -273,6 +280,12 @@ impl Database {
         }
         if let Some(enabled) = update.auto_review_enabled {
             am.auto_review_enabled = ActiveValue::Set(Some(enabled));
+        }
+        if let Some(at) = update.action_type {
+            am.action_type = ActiveValue::Set(Some(at.to_string()));
+        }
+        if let Some(ak) = update.action_key {
+            am.action_key = ActiveValue::Set(Some(ak.to_string()));
         }
         self.exec_update(am).await
     }
@@ -818,6 +831,8 @@ impl Database {
                     tag_names,
                     workspace_path: m.workspace_path.clone(),
                     worktree: None,
+                    action_type: m.action_type,
+                    action_key: m.action_key,
                 }
             })
             .collect::<Vec<_>>())
@@ -869,6 +884,8 @@ impl Database {
                     tag_names,
                     workspace_path: m.workspace_path.clone(),
                     worktree: None,
+                    action_type: m.action_type,
+                    action_key: m.action_key,
                 }
             })
             .collect())

--- a/backend/src/handlers/action.rs
+++ b/backend/src/handlers/action.rs
@@ -42,6 +42,17 @@ pub async fn execute_action(
     State(state): State<AppState>,
     ApiJson(req): ApiJson<ExecuteActionRequest>,
 ) -> Result<ApiResponse<ExecuteActionResult>, AppError> {
+    // 参数校验：action_type、action_key、prompt 不能为空
+    if req.action_type.trim().is_empty() {
+        return Err(AppError::BadRequest("action_type 不能为空".to_string()));
+    }
+    if req.action_key.trim().is_empty() {
+        return Err(AppError::BadRequest("action_key 不能为空".to_string()));
+    }
+    if req.prompt.trim().is_empty() {
+        return Err(AppError::BadRequest("prompt 不能为空".to_string()));
+    }
+
     // 1. 查找或创建 todo
     let (todo_id, todo_created) = find_or_create_todo(&state, &req).await?;
 
@@ -94,22 +105,31 @@ async fn find_or_create_todo(
     state: &AppState,
     req: &ExecuteActionRequest,
 ) -> Result<(i64, bool), AppError> {
-    // 1. 尝试查找已有的 todo
-    let todos = state
+    // 1. 尝试查找已有的 todo（按 action_type + action_key 精确查询）
+    if let Some(todo) = state
         .db
-        .get_todos_by_workspace_id(None)
+        .get_todo_by_action_type_and_key(&req.action_type, &req.action_key)
         .await
-        .map_err(|e| AppError::Internal(e.to_string()))?;
-
-    if let Some(todo) = todos.iter().find(|t| {
-        t.action_type.as_deref() == Some(&req.action_type)
-            && t.action_key.as_deref() == Some(&req.action_key)
-    }) {
+        .map_err(|e| AppError::Internal(e.to_string()))?
+    {
         return Ok((todo.id, false));
     }
 
     // 2. 未找到，自动创建
-    let workspace_id = req.workspace_id.unwrap_or(1); // 默认使用工作空间 1
+    // 动态查找默认工作空间：优先使用请求中的 workspace_id，否则取第一个可用的工作空间
+    let workspace_id = match req.workspace_id {
+        Some(id) => id,
+        None => {
+            let dirs = state
+                .db
+                .get_project_directories()
+                .await
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            dirs.first()
+                .map(|d| d.id)
+                .ok_or_else(|| AppError::BadRequest("没有可用的工作空间".to_string()))?
+        }
+    };
     let dir = state
         .db
         .get_project_directory_by_id(workspace_id)

--- a/backend/src/handlers/action.rs
+++ b/backend/src/handlers/action.rs
@@ -20,6 +20,8 @@ pub struct ExecuteActionRequest {
     pub params: std::collections::HashMap<String, String>,
     /// 工作空间 ID（可选，不传则使用默认工作空间）
     pub workspace_id: Option<i64>,
+    /// 执行器类型（可选，覆盖 todo 默认的 executor）
+    pub executor: Option<String>,
 }
 
 /// Action 执行结果
@@ -46,7 +48,7 @@ pub async fn execute_action(
     // 2. 构造 message：将 prompt 中的占位符替换为 params 中的值
     let message = replace_placeholders(&req.prompt, &req.params);
 
-    // 3. 执行 todo
+    // 3. 执行 todo，使用请求中指定的执行器（覆盖 todo 默认的 executor）
     let result = crate::handlers::execution::start_todo_execution(
         crate::executor_service::RunTodoExecutionRequest {
             db: state.db.clone(),
@@ -56,7 +58,7 @@ pub async fn execute_action(
             config: state.config.clone(),
             todo_id,
             message,
-            req_executor: None,
+            req_executor: req.executor.clone(), // 使用请求中指定的执行器
             trigger_type: "action".to_string(),
             params: Some(req.params.clone()),
             resume_session_id: None,

--- a/backend/src/handlers/action.rs
+++ b/backend/src/handlers/action.rs
@@ -1,0 +1,195 @@
+use axum::extract::State;
+use serde::Deserialize;
+
+use crate::handlers::{ApiJson, AppError, AppState};
+use crate::models::ApiResponse;
+
+/// Action 执行请求。
+///
+/// 前端传 action_type + action_key，后端查找或自动创建对应的 todo，
+/// 然后用 prompt + params 执行。
+#[derive(Debug, Deserialize)]
+pub struct ExecuteActionRequest {
+    /// 动作类型（如 "title_optimize"、"prompt_optimize"）
+    pub action_type: String,
+    /// 动作键值（如 "default"、"aggressive"）
+    pub action_key: String,
+    /// Prompt 模板（支持 {{key}} 占位符）
+    pub prompt: String,
+    /// 模板参数
+    pub params: std::collections::HashMap<String, String>,
+    /// 工作空间 ID（可选，不传则使用默认工作空间）
+    pub workspace_id: Option<i64>,
+}
+
+/// Action 执行结果
+#[derive(Debug, serde::Serialize)]
+pub struct ExecuteActionResult {
+    pub task_id: String,
+    pub record_id: i64,
+    pub todo_id: i64,
+    /// todo 是否是本次自动创建的
+    pub todo_created: bool,
+}
+
+/// POST /api/actions/execute
+///
+/// 根据 action_type + action_key 查找 todo，如果不存在则自动创建。
+/// 然后用 prompt + params 执行该 todo。
+pub async fn execute_action(
+    State(state): State<AppState>,
+    ApiJson(req): ApiJson<ExecuteActionRequest>,
+) -> Result<ApiResponse<ExecuteActionResult>, AppError> {
+    // 1. 查找或创建 todo
+    let (todo_id, todo_created) = find_or_create_todo(&state, &req).await?;
+
+    // 2. 构造 message：将 prompt 中的占位符替换为 params 中的值
+    let message = replace_placeholders(&req.prompt, &req.params);
+
+    // 3. 执行 todo
+    let result = crate::handlers::execution::start_todo_execution(
+        crate::executor_service::RunTodoExecutionRequest {
+            db: state.db.clone(),
+            executor_registry: state.executor_registry.clone(),
+            tx: state.tx.clone(),
+            task_manager: state.task_manager.clone(),
+            config: state.config.clone(),
+            todo_id,
+            message,
+            req_executor: None,
+            trigger_type: "action".to_string(),
+            params: Some(req.params.clone()),
+            resume_session_id: None,
+            resume_message: None,
+            source_todo_id: None,
+            source_todo_title: None,
+            loop_step_execution_id: None,
+            step_id: None,
+            feishu_bot_id: None,
+            feishu_receive_id: None,
+            workspace_path: None,
+            workspace_id: None,
+        },
+    )
+    .await?;
+
+    let record_id = result
+        .record_id
+        .ok_or_else(|| AppError::Internal("执行启动失败：未获取到执行记录 ID".to_string()))?;
+
+    Ok(ApiResponse::ok(ExecuteActionResult {
+        task_id: result.task_id,
+        record_id,
+        todo_id,
+        todo_created,
+    }))
+}
+
+/// 查找或创建 action 模板 todo。
+///
+/// 返回 (todo_id, todo_created)。
+async fn find_or_create_todo(
+    state: &AppState,
+    req: &ExecuteActionRequest,
+) -> Result<(i64, bool), AppError> {
+    // 1. 尝试查找已有的 todo
+    let todos = state
+        .db
+        .get_todos_by_workspace_id(None)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    if let Some(todo) = todos.iter().find(|t| {
+        t.action_type.as_deref() == Some(&req.action_type)
+            && t.action_key.as_deref() == Some(&req.action_key)
+    }) {
+        return Ok((todo.id, false));
+    }
+
+    // 2. 未找到，自动创建
+    let workspace_id = req.workspace_id.unwrap_or(1); // 默认使用工作空间 1
+    let dir = state
+        .db
+        .get_project_directory_by_id(workspace_id)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", workspace_id)))?;
+
+    let title = format!("Action: {}/{}", req.action_type, req.action_key);
+
+    let todo_id = state
+        .db
+        .create_todo_with_extras(
+            &title,
+            &req.prompt,
+            None,    // executor: 使用默认
+            None,    // acceptance_criteria
+            false,   // webhook_enabled
+            workspace_id,
+            &dir.path,
+        )
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    // 更新 action_type 和 action_key
+    state
+        .db
+        .update_todo_full(crate::db::TodoUpdate {
+            id: todo_id,
+            title: &title,
+            prompt: &req.prompt,
+            status: crate::models::TodoStatus::Pending,
+            executor: None,
+            scheduler_enabled: None,
+            scheduler_config: None,
+            scheduler_timezone: None,
+            workspace_id: None,
+            webhook_enabled: None,
+            acceptance_criteria: None,
+            auto_review_enabled: None,
+            action_type: Some(&req.action_type),
+            action_key: Some(&req.action_key),
+        })
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok((todo_id, true))
+}
+
+/// 将 prompt 模板中的占位符替换为 params 中的值。
+fn replace_placeholders(
+    prompt: &str,
+    params: &std::collections::HashMap<String, String>,
+) -> String {
+    let mut result = prompt.to_string();
+    for (key, value) in params {
+        let placeholder = format!("{{{{{}}}}}", key);
+        result = result.replace(&placeholder, value);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_replace_placeholders() {
+        let prompt = "优化标题：{{title}}，参考：{{prompt}}";
+        let mut params = std::collections::HashMap::new();
+        params.insert("title".to_string(), "fix bug".to_string());
+        params.insert("prompt".to_string(), "帮我修复登录超时".to_string());
+
+        let result = replace_placeholders(prompt, &params);
+        assert_eq!(result, "优化标题：fix bug，参考：帮我修复登录超时");
+    }
+
+    #[test]
+    fn test_replace_placeholders_no_match() {
+        let prompt = "优化标题：{{title}}";
+        let params = std::collections::HashMap::new();
+
+        let result = replace_placeholders(prompt, &params);
+        assert_eq!(result, "优化标题：{{title}}");
+    }
+}

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -1707,6 +1707,8 @@ async fn build_loop_export_yaml(
                         tag_ids,
                         tag_names,
                         is_abnormal_handler: false,
+                        action_type: todo.action_type.clone(),
+                        action_key: todo.action_key.clone(),
                     });
                 }
             }
@@ -1735,6 +1737,8 @@ async fn build_loop_export_yaml(
                         tag_ids: vec![],
                         tag_names: vec![],
                         is_abnormal_handler: true,
+                        action_type: todo.action_type.clone(),
+                        action_key: todo.action_key.clone(),
                     });
                 }
             }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -382,6 +382,7 @@ pub mod usage_stats;
 pub mod sync;
 pub mod sub_states; // 由 #604 引入，当前无内容占位
 pub mod loop_;
+pub mod action;
 
 // WebSocket handler
 pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
@@ -1310,6 +1311,7 @@ fn execution_routes() -> Router<AppState> {
         .route("/api/execute/stop", post(execution::stop_execution_handler))
         .route("/api/execute/force-fail", post(execution::force_fail_execution_handler))
         .route("/api/running-todos", get(execution::get_running_todos))
+        .route("/api/actions/execute", post(action::execute_action))
 }
 
 /// 定时任务相关路由（除 todo 内嵌的 scheduler 字段外，独立的查询入口）。

--- a/backend/src/handlers/sync.rs
+++ b/backend/src/handlers/sync.rs
@@ -332,6 +332,8 @@ async fn merge_cloud_todos_to_local(
                         webhook_enabled: None,
                         acceptance_criteria: None,
                         auto_review_enabled: None,
+                        action_type: None,
+                        action_key: None,
                     })
                     .await
                     .map_err(|e| e.to_string())?;

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -180,6 +180,8 @@ pub async fn create_todo(
         parent_todo_id: None,
         review_template_id: None,
         auto_review_enabled: req.auto_review_enabled.unwrap_or(false),
+        action_type: req.action_type.clone(),
+        action_key: req.action_key.clone(),
     }))
 }
 
@@ -256,6 +258,8 @@ pub async fn update_todo(
             webhook_enabled: req.webhook_enabled,
             acceptance_criteria: req.acceptance_criteria.as_deref(),
             auto_review_enabled: req.auto_review_enabled,
+            action_type: req.action_type.as_deref(),
+            action_key: req.action_key.as_deref(),
         })
         .await
         .map_err(AppError::from)?;

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -108,6 +108,28 @@ pub async fn create_todo(
         }
     }
 
+    // 落库 action_type/action_key（create_todo_with_extras 不支持这两个字段）
+    if req.action_type.is_some() || req.action_key.is_some() {
+        if let Err(e) = state.db.update_todo_full(crate::db::TodoUpdate {
+            id,
+            title,
+            prompt: &prompt,
+            status: crate::models::TodoStatus::Pending,
+            executor: None,
+            scheduler_enabled: None,
+            scheduler_config: None,
+            scheduler_timezone: None,
+            workspace_id: None,
+            webhook_enabled: None,
+            acceptance_criteria: None,
+            auto_review_enabled: None,
+            action_type: req.action_type.as_deref(),
+            action_key: req.action_key.as_deref(),
+        }).await {
+            tracing::warn!("Failed to set action_type/action_key for todo {}: {}", id, e);
+        }
+    }
+
     for tag_id in &req.tag_ids {
         state.db.add_todo_tag(id, *tag_id).await?;
     }

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -133,6 +133,13 @@ pub struct Todo {
     /// 是否在执行完成后自动派生一个评审 todo. 只对 normal 类型有意义.
     #[serde(default = "default_true")]
     pub auto_review_enabled: bool,
+    /// Action 类型标记（如 "rewrite_title"、"optimize_prompt"），
+    /// 仅供前端 ActionButton 组件做 UI 分类展示，不影响执行逻辑。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action_type: Option<String>,
+    /// Action 键值，与 action_type 配合唯一标识一个 action 模板 todo。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -358,6 +365,13 @@ pub struct CreateTodoRequest {
     /// 工作空间 ID（project_directories.id），唯一键。
     /// 创建时必填；handler 据此查 path 写入 DB cwd 字段。
     pub workspace_id: i64,
+    /// Action 类型标记（如 "rewrite_title"、"optimize_prompt"），
+    /// 仅供前端 ActionButton 组件做 UI 分类展示，不影响执行逻辑。
+    #[serde(default)]
+    pub action_type: Option<String>,
+    /// Action 键值，与 action_type 配合唯一标识一个 action 模板 todo。
+    #[serde(default)]
+    pub action_key: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -388,6 +402,13 @@ pub struct UpdateTodoRequest {
     /// None=不变, Some(true)/Some(false)=更新. 不允许改 reviewer template 的开关.
     #[serde(default)]
     pub auto_review_enabled: Option<bool>,
+    /// Action 类型标记（如 "rewrite_title"、"optimize_prompt"），
+    /// 仅供前端 ActionButton 组件做 UI 分类展示，不影响执行逻辑。
+    #[serde(default)]
+    pub action_type: Option<String>,
+    /// Action 键值，与 action_type 配合唯一标识一个 action 模板 todo。
+    #[serde(default)]
+    pub action_key: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -1026,6 +1047,8 @@ pub struct TodoBackup {
     pub tag_names: Vec<String>,
     pub workspace_path: Option<String>,
     pub worktree: Option<String>,
+    pub action_type: Option<String>,
+    pub action_key: Option<String>,
 }
 
 // ============ 环路导入导出 DTO ============
@@ -1083,6 +1106,13 @@ pub struct TodoExportItem {
     /// 是否为异常处理 Todo（异常处理 Todo 不导出标签）
     #[serde(default)]
     pub is_abnormal_handler: bool,
+    /// Action 类型标记（如 "rewrite_title"、"optimize_prompt"），
+    /// 仅供前端 ActionButton 组件做 UI 分类展示，不影响执行逻辑。
+    #[serde(default)]
+    pub action_type: Option<String>,
+    /// Action 键值，与 action_type 配合唯一标识一个 action 模板 todo。
+    #[serde(default)]
+    pub action_key: Option<String>,
 }
 
 /// 环路导出项（伪ID格式）

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -133,11 +133,12 @@ pub struct Todo {
     /// 是否在执行完成后自动派生一个评审 todo. 只对 normal 类型有意义.
     #[serde(default = "default_true")]
     pub auto_review_enabled: bool,
-    /// Action 类型标记（如 "rewrite_title"、"optimize_prompt"），
-    /// 仅供前端 ActionButton 组件做 UI 分类展示，不影响执行逻辑。
+    /// Action 类型标记（如 "title_optimize"、"prompt_optimize"）。
+    /// 与 action_key 配合，由 /api/actions/execute 用于查找或自动创建 action 模板 todo。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub action_type: Option<String>,
     /// Action 键值，与 action_type 配合唯一标识一个 action 模板 todo。
+    /// 由 /api/actions/execute 用于查找或自动创建 action 模板 todo。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub action_key: Option<String>,
 }

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -2102,6 +2102,8 @@ mod tests {
             parent_todo_id: None,
             review_template_id: None,
             auto_review_enabled: false,
+            action_type: None,
+            action_key: None,
         }
     }
 

--- a/docs/action-button-component.md
+++ b/docs/action-button-component.md
@@ -1,0 +1,290 @@
+# Action Button Component — 可复用的一键执行组件
+
+## 背景
+
+在 ntd 的多个页面中，存在「选中一段文本 → 用 AI 优化 → 应用结果」的重复模式。例如：
+- Todo 标题重写
+- Prompt 优化
+- 验收标准生成
+- 内容摘要
+
+目前每次实现这类功能都需要手动编写：创建 todo → 执行 → 等待结果 → 提取结论 → 应用/拒绝。逻辑高度重复，且缺乏统一的 UI 交互模式。
+
+## 目标
+
+封装一个**前后端配合的可复用组件**，在任意页面中一行代码即可接入「一键 AI 执行」能力。
+
+### 核心交互流程
+
+```
+用户点击按钮
+  → 弹出执行面板（Drawer/Modal）
+  → 展示当前值（原标题/原 Prompt）
+  → 用户点击「执行」
+  → 后台创建临时 todo，将当前值作为 message 传入，启动执行
+  → 前端轮询/WebSocket 等待完成
+  → 提取执行结论，展示「原文 → 优化结果」对比
+  → 用户选择「应用」或「拒绝」
+    → 应用：调用 onApply 回调，由页面决定如何使用结果
+    → 拒弃：关闭面板，不做任何修改
+```
+
+## 架构设计
+
+### 后端：Action Execution API
+
+新增两个 API 端点，复用现有 `executor_service` 执行体系。
+
+#### 1. `POST /api/actions/execute` — 启动执行
+
+**请求体：**
+```json
+{
+  "todo_id": 123,              // 必填：使用哪个 todo 的 prompt 作为执行模板
+  "message": "要优化的标题或内容", // 必填：传入的输入文本
+  "params": {},                // 可选：额外模板参数（如 {{language}} 等）
+  "executor": "claudecode"     // 可选：覆盖执行器类型
+}
+```
+
+**响应体：**
+```json
+{
+  "code": 0,
+  "data": {
+    "record_id": 456,          // 执行记录 ID，用于后续查询结果
+    "task_id": "uuid-xxx"      // 任务 ID，用于 WebSocket 事件追踪
+  }
+}
+```
+
+**设计取舍：**
+- 复用现有 `POST /api/execute` 的执行逻辑，但不直接暴露该接口给 Action Button 组件。
+  原因：`/api/execute` 是通用执行入口，缺少「提取结论」的语义；新接口可以附加 action-specific 的后处理。
+- `todo_id` 必填：由调用方指定使用哪个 todo 的 prompt 模板。不同 action type（标题重写、Prompt 优化）
+  对应不同的 prompt 模板，这些模板作为普通 todo 存在于系统中，由管理员在 UI 中配置。
+- 不新建 action_templates 表：复用 todo 表 + todo_templates 表，降低 schema 复杂度。
+
+#### 2. `GET /api/actions/result/:record_id` — 查询执行结果
+
+**响应体：**
+```json
+{
+  "code": 0,
+  "data": {
+    "record_id": 456,
+    "status": "success",        // "running" | "success" | "failed"
+    "result": "优化后的标题文本", // 从执行输出中提取的结论（纯文本）
+    "raw_output": "...",        // 完整的执行输出（可选，用于调试）
+    "error": null               // 失败时的错误信息
+  }
+}
+```
+
+**结果提取逻辑：**
+- 执行成功时，从 `execution_records.result` 字段读取。
+  `result` 由 executor 的 completion handler 在执行结束时写入，通常是 AI 输出的最终结论。
+- 执行中时返回 `status: "running"`，前端继续轮询。
+- 执行失败时返回 `status: "failed"` + `error` 信息。
+
+### 前端：ActionButton 组件
+
+#### 组件接口
+
+```typescript
+interface ActionButtonProps {
+  /** 使用哪个 todo 的 prompt 作为执行模板 */
+  todoId: number;
+  /** 要处理的输入文本 */
+  input: string;
+  /** 执行完成后「应用」的回调，参数为 AI 生成的结果文本 */
+  onApply: (result: string) => void | Promise<void>;
+  /** 按钮显示内容 */
+  children?: React.ReactNode;
+  /** 按钮类型（Ant Design） */
+  buttonType?: 'primary' | 'default' | 'link' | 'text';
+  /** 按钮图标 */
+  icon?: React.ReactNode;
+  /** 是否禁用 */
+  disabled?: boolean;
+  /** 面板标题（默认：智能执行） */
+  panelTitle?: string;
+  /** 面板描述（默认：将使用 AI 处理以下内容） */
+  panelDescription?: string;
+  /** 额外的模板参数 */
+  params?: Record<string, string>;
+  /** 覆盖执行器类型 */
+  executor?: string;
+  /** 面板宽度（默认 480） */
+  panelWidth?: number;
+}
+```
+
+#### 组件内部状态机
+
+```
+IDLE → EXECUTING → COMPLETED → (APPLIED | REJECTED)
+         ↓
+       FAILED
+```
+
+#### 组件行为
+
+1. **IDLE 状态**：渲染一个 Button，点击后打开 Drawer（PC）/ Bottom Sheet（移动端）。
+   面板内容：
+   - 标题：`panelTitle`
+   - 描述：`panelDescription`
+   - 输入预览：展示 `input` 值（只读，灰色背景）
+   - 底部按钮：「取消」+「执行」
+
+2. **EXECUTING 状态**：面板切换为 loading 态。
+   - 显示 Spin + "AI 正在处理中..."
+   - 底部按钮禁用
+   - 后端开始执行，前端每 2 秒轮询 `GET /api/actions/result/:record_id`
+   - 同时监听 WebSocket 的 `Finished` 事件，收到后立即查询结果（减少轮询延迟）
+
+3. **COMPLETED 状态**：面板展示对比结果。
+   - 原文（input）→ 新文（result）的对比视图
+   - 底部按钮：「拒绝」+「应用」
+
+4. **FAILED 状态**：面板展示错误信息。
+   - 错误原因
+   - 底部按钮：「关闭」+「重试」
+
+5. **APPLIED / REJECTED**：关闭面板，调用 `onApply(result)` 或不做任何事。
+
+#### 使用示例
+
+```tsx
+// 在 Todo 标题编辑页
+<ActionButton
+  todoId={rewriteTitleTemplateId}
+  input={currentTitle}
+  onApply={(newTitle) => {
+    setTitle(newTitle);
+    saveTodo({ title: newTitle });
+  }}
+  panelTitle="重写标题"
+  panelDescription="AI 将根据当前标题生成更优的版本"
+>
+  <EditOutlined /> 一键优化标题
+</ActionButton>
+
+// 在 Prompt 编辑页
+<ActionButton
+  todoId={optimizePromptTemplateId}
+  input={currentPrompt}
+  onApply={(newPrompt) => {
+    setPrompt(newPrompt);
+    saveTodo({ prompt: newPrompt });
+  }}
+  panelTitle="优化 Prompt"
+  panelDescription="AI 将优化提示词的表达，使其更清晰有效"
+  params={{ language: 'zh' }}
+>
+  <RocketOutlined /> 优化 Prompt
+</ActionButton>
+```
+
+## 文件结构
+
+```
+backend/src/handlers/
+  action.rs              # 新增：POST /api/actions/execute + GET /api/actions/result/:id
+
+frontend/src/components/
+  ActionButton/
+    index.tsx            # 主组件
+    ActionPanel.tsx      # 执行面板（Drawer/Modal 内容）
+    ResultCompare.tsx    # 结果对比视图
+    types.ts             # 类型定义
+    hooks/
+      useActionExecution.ts  # 执行状态管理 + 轮询逻辑
+```
+
+## 后端实现要点
+
+### `action.rs` handler
+
+```rust
+// POST /api/actions/execute
+pub async fn execute_action(
+    State(state): State<AppState>,
+    ApiJson(req): ApiJson<ExecuteActionRequest>,
+) -> Result<ApiResponse<ExecuteActionResult>, AppError> {
+    // 1. 查询 todo，验证存在
+    // 2. 检查并发限制（复用 execute_handler 的逻辑）
+    // 3. 替换 prompt 中的 {{message}} 占位符
+    // 4. 调用 start_todo_execution 启动执行
+    // 5. 返回 record_id + task_id
+}
+
+// GET /api/actions/result/:record_id
+pub async fn get_action_result(
+    State(state): State<AppState>,
+    Path(record_id): Path<i64>,
+) -> Result<ApiResponse<ActionResultResponse>, AppError> {
+    // 1. 查询 execution_record
+    // 2. 根据 status 返回不同结构
+    // 3. 成功时从 result 字段提取结论
+}
+```
+
+### 路由注册
+
+在 `handlers/mod.rs` 的 `execution_routes()` 中新增：
+```rust
+.route("/api/actions/execute", post(action::execute_action))
+.route("/api/actions/result/{record_id}", get(action::get_action_result))
+```
+
+## 前端实现要点
+
+### `useActionExecution` Hook
+
+```typescript
+function useActionExecution(todoId: number, message: string, params?: Record<string, string>) {
+  // 状态：idle | executing | completed | failed
+  // execute(): POST /api/actions/execute → 开始执行
+  // pollResult(): 每 2 秒 GET /api/actions/result/:record_id
+  // 通过 WebSocket Finished 事件触发即时查询
+  // 返回：{ status, result, error, execute, retry, cancel }
+}
+```
+
+### 移动端适配
+
+- PC 端使用 `Drawer`（右侧滑出）
+- 移动端使用 Ant Design 的 `Drawer placement="bottom"` 或自定义 Bottom Sheet
+- 通过 `isMobile` prop 或 `useDevice()` hook 自动切换
+
+## 配置与扩展
+
+### 如何新增一种 Action
+
+1. 在 ntd 中创建一个 todo，编写专用的 prompt 模板：
+   ```
+   你是一个标题优化专家。请根据以下标题生成 3 个更优的版本，要求：
+   1. 保持原意
+   2. 更简洁有力
+   3. 适合 AI Todo 应用的场景
+
+   原标题：{{message}}
+
+   请直接输出最优版本，不要加解释。
+   ```
+2. 记住这个 todo 的 ID
+3. 在前端使用 `<ActionButton todoId={该ID} .../>`
+
+无需修改后端代码，无需建表，无需部署。所有 action 类型都是普通 todo。
+
+## 验收标准
+
+- [ ] 后端：`POST /api/actions/execute` 能正确创建并执行 todo
+- [ ] 后端：`GET /api/actions/result/:record_id` 能正确返回执行状态和结果
+- [ ] 前端：ActionButton 组件能在 PC 和移动端正常渲染
+- [ ] 前端：执行过程中有 loading 状态，完成后展示对比结果
+- [ ] 前端：应用/拒绝按钮正常工作
+- [ ] 前端：组件可复用，在 TodoPage 和 TodoPostPage 中各接入一个实例
+- [ ] 后端单元测试通过：`cd backend && cargo test`
+- [ ] 前端 Playwright 验证通过

--- a/docs/action-button-component.md
+++ b/docs/action-button-component.md
@@ -1,8 +1,8 @@
-# Action Button Component — 可复用的一键执行组件
+# Action Button Component — 可复用的一键 AI 执行组件
 
 ## 背景
 
-在 ntd 的多个页面中，存在「选中一段文本 → 用 AI 优化 → 应用结果」的重复模式。例如：
+在 ntd 的多个页面中，存在「选中文本 → 用 AI 优化 → 应用结果」的重复模式。例如：
 - Todo 标题重写
 - Prompt 优化
 - 验收标准生成
@@ -18,12 +18,12 @@
 
 ```
 用户点击按钮
-  → 弹出执行面板（Drawer/Modal）
-  → 展示当前值（原标题/原 Prompt）
-  → 用户点击「执行」
-  → 后台创建临时 todo，将当前值作为 message 传入，启动执行
-  → 前端轮询/WebSocket 等待完成
-  → 提取执行结论，展示「原文 → 优化结果」对比
+  → 弹出执行面板（Drawer）
+  → 展示可编辑的 Prompt、执行器选择器、参数预览
+  → 用户修改后点击「执行」
+  → 后端用 action_type + action_key 查找或自动创建 todo
+  → WebSocket 监听执行完成
+  → 提取执行结论，展示结果
   → 用户选择「应用」或「拒绝」
     → 应用：调用 onApply 回调，由页面决定如何使用结果
     → 拒弃：关闭面板，不做任何修改
@@ -33,59 +33,57 @@
 
 ### 后端：Action Execution API
 
-新增两个 API 端点，复用现有 `executor_service` 执行体系。
+新增 `POST /api/actions/execute` 端点，复用现有 `executor_service` 执行体系。
 
-#### 1. `POST /api/actions/execute` — 启动执行
+#### `POST /api/actions/execute` — 启动执行
 
 **请求体：**
+
 ```json
 {
-  "todo_id": 123,              // 必填：使用哪个 todo 的 prompt 作为执行模板
-  "message": "要优化的标题或内容", // 必填：传入的输入文本
-  "params": {},                // 可选：额外模板参数（如 {{language}} 等）
-  "executor": "claudecode"     // 可选：覆盖执行器类型
+  "action_type": "title_optimize",
+  "action_key": "default",
+  "prompt": "你是一个标题优化专家。请优化以下标题：\n\n{{title}}",
+  "params": { "title": "fix bug" },
+  "workspace_id": 1,
+  "executor": "claudecode"
 }
 ```
 
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `action_type` | string | ✅ | 动作类型（如 "title_optimize"） |
+| `action_key` | string | ✅ | 动作键值（如 "default"） |
+| `prompt` | string | ✅ | Prompt 模板，支持 `{{key}}` 占位符 |
+| `params` | object | ✅ | 模板参数，替换 prompt 中的 `{{key}}` |
+| `workspace_id` | number | ❌ | 工作空间 ID（不传则使用第一个可用工作空间） |
+| `executor` | string | ❌ | 执行器类型（覆盖 todo 默认的 executor） |
+
 **响应体：**
+
 ```json
 {
   "code": 0,
   "data": {
-    "record_id": 456,          // 执行记录 ID，用于后续查询结果
-    "task_id": "uuid-xxx"      // 任务 ID，用于 WebSocket 事件追踪
-  }
-}
-```
-
-**设计取舍：**
-- 复用现有 `POST /api/execute` 的执行逻辑，但不直接暴露该接口给 Action Button 组件。
-  原因：`/api/execute` 是通用执行入口，缺少「提取结论」的语义；新接口可以附加 action-specific 的后处理。
-- `todo_id` 必填：由调用方指定使用哪个 todo 的 prompt 模板。不同 action type（标题重写、Prompt 优化）
-  对应不同的 prompt 模板，这些模板作为普通 todo 存在于系统中，由管理员在 UI 中配置。
-- 不新建 action_templates 表：复用 todo 表 + todo_templates 表，降低 schema 复杂度。
-
-#### 2. `GET /api/actions/result/:record_id` — 查询执行结果
-
-**响应体：**
-```json
-{
-  "code": 0,
-  "data": {
+    "task_id": "uuid-xxx",
     "record_id": 456,
-    "status": "success",        // "running" | "success" | "failed"
-    "result": "优化后的标题文本", // 从执行输出中提取的结论（纯文本）
-    "raw_output": "...",        // 完整的执行输出（可选，用于调试）
-    "error": null               // 失败时的错误信息
+    "todo_id": 123,
+    "todo_created": false
   }
 }
 ```
 
-**结果提取逻辑：**
-- 执行成功时，从 `execution_records.result` 字段读取。
-  `result` 由 executor 的 completion handler 在执行结束时写入，通常是 AI 输出的最终结论。
-- 执行中时返回 `status: "running"`，前端继续轮询。
-- 执行失败时返回 `status: "failed"` + `error` 信息。
+**后端逻辑：**
+
+1. 参数校验：`action_type`、`action_key`、`prompt` 不能为空
+2. 按 `action_type + action_key` 精确查找 todo
+3. 找不到 → 自动创建 todo（prompt 来自请求）
+4. 执行 todo，使用请求中指定的执行器（覆盖 todo 默认值）
+5. 返回 `task_id` + `record_id` + `todo_id`
+
+**数据库约束：**
+
+- `action_type + action_key` 有唯一索引，防止并发重复创建
 
 ### 前端：ActionButton 组件
 
@@ -93,34 +91,36 @@
 
 ```typescript
 interface ActionButtonProps {
-  /** 使用哪个 todo 的 prompt 作为执行模板 */
-  todoId: number;
-  /** 要处理的输入文本 */
-  input: string;
-  /** 执行完成后「应用」的回调，参数为 AI 生成的结果文本 */
+  /** 动作类型（如 "title_optimize"、"prompt_optimize"） */
+  actionType: string;
+  /** 动作键值（如 "default"、"aggressive"） */
+  actionKey: string;
+  /** Prompt 模板，支持 {{key}} 占位符 */
+  prompt: string;
+  /** 模板参数 */
+  params: Record<string, string>;
+  /** 执行完成后「应用」的回调 */
   onApply: (result: string) => void | Promise<void>;
+  /** 工作空间 ID（可选） */
+  workspaceId?: number;
   /** 按钮显示内容 */
   children?: React.ReactNode;
-  /** 按钮类型（Ant Design） */
+  /** 按钮类型 */
   buttonType?: 'primary' | 'default' | 'link' | 'text';
   /** 按钮图标 */
   icon?: React.ReactNode;
   /** 是否禁用 */
   disabled?: boolean;
-  /** 面板标题（默认：智能执行） */
+  /** 面板标题（默认：自动优化标题） */
   panelTitle?: string;
-  /** 面板描述（默认：将使用 AI 处理以下内容） */
+  /** 面板描述 */
   panelDescription?: string;
-  /** 额外的模板参数 */
-  params?: Record<string, string>;
-  /** 覆盖执行器类型 */
+  /** 默认执行器类型 */
   executor?: string;
-  /** 面板宽度（默认 480） */
-  panelWidth?: number;
 }
 ```
 
-#### 组件内部状态机
+#### 组件状态机
 
 ```
 IDLE → EXECUTING → COMPLETED → (APPLIED | REJECTED)
@@ -130,161 +130,94 @@ IDLE → EXECUTING → COMPLETED → (APPLIED | REJECTED)
 
 #### 组件行为
 
-1. **IDLE 状态**：渲染一个 Button，点击后打开 Drawer（PC）/ Bottom Sheet（移动端）。
-   面板内容：
-   - 标题：`panelTitle`
-   - 描述：`panelDescription`
-   - 输入预览：展示 `input` 值（只读，灰色背景）
-   - 底部按钮：「取消」+「执行」
+1. **IDLE 状态**：点击按钮打开 Drawer，展示：
+   - 可编辑的 Prompt TextArea
+   - 执行器选择器（复用 ExecutorPicker 组件）
+   - 参数预览（Tag + 多行文本）
 
-2. **EXECUTING 状态**：面板切换为 loading 态。
-   - 显示 Spin + "AI 正在处理中..."
-   - 底部按钮禁用
-   - 后端开始执行，前端每 2 秒轮询 `GET /api/actions/result/:record_id`
-   - 同时监听 WebSocket 的 `Finished` 事件，收到后立即查询结果（减少轮询延迟）
+2. **EXECUTING 状态**：Loading 状态，禁止关闭面板
 
-3. **COMPLETED 状态**：面板展示对比结果。
-   - 原文（input）→ 新文（result）的对比视图
-   - 底部按钮：「拒绝」+「应用」
+3. **COMPLETED 状态**：展示 AI 生成结果
 
-4. **FAILED 状态**：面板展示错误信息。
-   - 错误原因
-   - 底部按钮：「关闭」+「重试」
-
-5. **APPLIED / REJECTED**：关闭面板，调用 `onApply(result)` 或不做任何事。
+4. **FAILED 状态**：展示错误信息，支持重试
 
 #### 使用示例
 
 ```tsx
-// 在 Todo 标题编辑页
-<ActionButton
-  todoId={rewriteTitleTemplateId}
-  input={currentTitle}
-  onApply={(newTitle) => {
-    setTitle(newTitle);
-    saveTodo({ title: newTitle });
-  }}
-  panelTitle="重写标题"
-  panelDescription="AI 将根据当前标题生成更优的版本"
->
-  <EditOutlined /> 一键优化标题
-</ActionButton>
+import { ActionButton } from '@/components/ActionButton';
+import { Tooltip } from 'antd';
+import { RocketOutlined } from '@ant-design/icons';
 
-// 在 Prompt 编辑页
-<ActionButton
-  todoId={optimizePromptTemplateId}
-  input={currentPrompt}
-  onApply={(newPrompt) => {
-    setPrompt(newPrompt);
-    saveTodo({ prompt: newPrompt });
-  }}
-  panelTitle="优化 Prompt"
-  panelDescription="AI 将优化提示词的表达，使其更清晰有效"
-  params={{ language: 'zh' }}
->
-  <RocketOutlined /> 优化 Prompt
-</ActionButton>
+// 在 Todo 标题行（图标按钮 + Tooltip）
+<Tooltip title="自动优化标题">
+  <ActionButton
+    actionType="title_optimize"
+    actionKey="default"
+    prompt={`你是一个标题优化专家。请根据以下信息生成更优的标题。
+
+当前标题：{{title}}
+当前 Prompt：{{prompt}}
+
+要求：
+1. 保持原意
+2. 更简洁有力
+3. 适合 AI Todo 应用的场景
+
+输出格式：用 RESULT 标记包裹最终标题。
+
+RESULT
+优化后的标题文本
+RESULT`}
+    params={{
+      title: selectedTodo.title,
+      prompt: selectedTodo.prompt || '',
+    }}
+    workspaceId={selectedTodo.workspace_id}
+    onApply={handleTitleUpdate}
+    buttonType="text"
+    icon={<RocketOutlined />}
+    panelTitle="自动优化标题"
+  />
+</Tooltip>
 ```
 
 ## 文件结构
 
 ```
-backend/src/handlers/
-  action.rs              # 新增：POST /api/actions/execute + GET /api/actions/result/:id
+backend/src/
+  handlers/action.rs          # POST /api/actions/execute
+  db/todo.rs                  # get_todo_by_action_type_and_key()
+  db/migration.rs             # V45/V46: action_type + action_key 列 + 唯一索引
+  db/entity/todos.rs          # 实体字段
+  models/mod.rs               # Todo/CreateTodoRequest/UpdateTodoRequest
 
-frontend/src/components/
-  ActionButton/
-    index.tsx            # 主组件
-    ActionPanel.tsx      # 执行面板（Drawer/Modal 内容）
-    ResultCompare.tsx    # 结果对比视图
-    types.ts             # 类型定义
-    hooks/
-      useActionExecution.ts  # 执行状态管理 + 轮询逻辑
+frontend/src/
+  components/ActionButton/
+    index.tsx                 # 主组件（Button + Drawer）
+    types.ts                  # 类型定义
+    useActionExecution.ts     # 执行状态管理 + WebSocket 监听
+  utils/titleExtractor.ts     # 从 AI 结果中提取标题
+  components/todo-detail/DetailHeader.tsx  # 集成示例
 ```
-
-## 后端实现要点
-
-### `action.rs` handler
-
-```rust
-// POST /api/actions/execute
-pub async fn execute_action(
-    State(state): State<AppState>,
-    ApiJson(req): ApiJson<ExecuteActionRequest>,
-) -> Result<ApiResponse<ExecuteActionResult>, AppError> {
-    // 1. 查询 todo，验证存在
-    // 2. 检查并发限制（复用 execute_handler 的逻辑）
-    // 3. 替换 prompt 中的 {{message}} 占位符
-    // 4. 调用 start_todo_execution 启动执行
-    // 5. 返回 record_id + task_id
-}
-
-// GET /api/actions/result/:record_id
-pub async fn get_action_result(
-    State(state): State<AppState>,
-    Path(record_id): Path<i64>,
-) -> Result<ApiResponse<ActionResultResponse>, AppError> {
-    // 1. 查询 execution_record
-    // 2. 根据 status 返回不同结构
-    // 3. 成功时从 result 字段提取结论
-}
-```
-
-### 路由注册
-
-在 `handlers/mod.rs` 的 `execution_routes()` 中新增：
-```rust
-.route("/api/actions/execute", post(action::execute_action))
-.route("/api/actions/result/{record_id}", get(action::get_action_result))
-```
-
-## 前端实现要点
-
-### `useActionExecution` Hook
-
-```typescript
-function useActionExecution(todoId: number, message: string, params?: Record<string, string>) {
-  // 状态：idle | executing | completed | failed
-  // execute(): POST /api/actions/execute → 开始执行
-  // pollResult(): 每 2 秒 GET /api/actions/result/:record_id
-  // 通过 WebSocket Finished 事件触发即时查询
-  // 返回：{ status, result, error, execute, retry, cancel }
-}
-```
-
-### 移动端适配
-
-- PC 端使用 `Drawer`（右侧滑出）
-- 移动端使用 Ant Design 的 `Drawer placement="bottom"` 或自定义 Bottom Sheet
-- 通过 `isMobile` prop 或 `useDevice()` hook 自动切换
 
 ## 配置与扩展
 
 ### 如何新增一种 Action
 
-1. 在 ntd 中创建一个 todo，编写专用的 prompt 模板：
-   ```
-   你是一个标题优化专家。请根据以下标题生成 3 个更优的版本，要求：
-   1. 保持原意
-   2. 更简洁有力
-   3. 适合 AI Todo 应用的场景
+无需修改后端代码，只需：
 
-   原标题：{{message}}
+1. 在前端定义 prompt 模板和 params
+2. 使用 `<ActionButton>` 组件，传入 `actionType` + `actionKey`
 
-   请直接输出最优版本，不要加解释。
-   ```
-2. 记住这个 todo 的 ID
-3. 在前端使用 `<ActionButton todoId={该ID} .../>`
-
-无需修改后端代码，无需建表，无需部署。所有 action 类型都是普通 todo。
+后端会自动查找或创建对应的 todo。
 
 ## 验收标准
 
-- [ ] 后端：`POST /api/actions/execute` 能正确创建并执行 todo
-- [ ] 后端：`GET /api/actions/result/:record_id` 能正确返回执行状态和结果
-- [ ] 前端：ActionButton 组件能在 PC 和移动端正常渲染
-- [ ] 前端：执行过程中有 loading 状态，完成后展示对比结果
-- [ ] 前端：应用/拒绝按钮正常工作
-- [ ] 前端：组件可复用，在 TodoPage 和 TodoPostPage 中各接入一个实例
-- [ ] 后端单元测试通过：`cd backend && cargo test`
-- [ ] 前端 Playwright 验证通过
+- [x] 后端：`POST /api/actions/execute` 能正确查找/创建 todo 并执行
+- [x] 后端：参数校验、唯一索引
+- [x] 前端：ActionButton 组件在 PC 和移动端正常渲染
+- [x] 前端：可编辑 Prompt、执行器选择器、参数预览
+- [x] 前端：应用/拒绝按钮正常工作
+- [x] 前端：暗色主题适配
+- [x] 后端单元测试通过
+- [x] 前端 TypeScript 编译通过

--- a/docs/action-button-usage-guide.md
+++ b/docs/action-button-usage-guide.md
@@ -1,0 +1,163 @@
+# ActionButton 使用指南（AI Agent 参考）
+
+## 概述
+
+`ActionButton` 是一个可复用的 React 组件，用于在 ntd 的任意页面中添加「一键 AI 执行」能力。点击按钮后弹出 Drawer 面板，用户可编辑 Prompt、选择执行器，然后执行并应用结果。
+
+## 快速开始
+
+```tsx
+import { ActionButton } from '@/components/ActionButton';
+import { RocketOutlined } from '@ant-design/icons';
+
+<ActionButton
+  actionType="your_action_type"
+  actionKey="default"
+  prompt="你的 Prompt 模板，支持 {{key}} 占位符"
+  params={{ key: "value" }}
+  onApply={(result) => console.log(result)}
+/>
+```
+
+## 属性说明
+
+| 属性 | 类型 | 必填 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `actionType` | `string` | ✅ | - | 动作类型，用于查找/创建 todo |
+| `actionKey` | `string` | ✅ | - | 动作键值，与 actionType 配合唯一标识 |
+| `prompt` | `string` | ✅ | - | Prompt 模板，支持 `{{key}}` 占位符 |
+| `params` | `Record<string, string>` | ✅ | - | 模板参数，替换 `{{key}}` |
+| `onApply` | `(result: string) => void \| Promise<void>` | ✅ | - | 应用结果的回调 |
+| `workspaceId` | `number` | ❌ | 第一个可用工作空间 | 工作空间 ID |
+| `children` | `ReactNode` | ❌ | '智能执行' | 按钮文本 |
+| `buttonType` | `'primary' \| 'default' \| 'link' \| 'text'` | ❌ | 'default' | 按钮类型 |
+| `icon` | `ReactNode` | ❌ | `<ThunderboltOutlined />` | 按钮图标 |
+| `disabled` | `boolean` | ❌ | false | 是否禁用 |
+| `panelTitle` | `string` | ❌ | '自动优化标题' | Drawer 标题 |
+| `panelDescription` | `string` | ❌ | '检查并确认...' | 面板描述 |
+| `executor` | `string` | ❌ | 'claudecode' | 默认执行器 |
+
+## Prompt 模板语法
+
+使用 `{{key}}` 占位符，key 对应 `params` 中的键：
+
+```tsx
+prompt={`你是一个标题优化专家。
+
+当前标题：{{title}}
+当前 Prompt：{{prompt}}
+
+请直接输出优化后的标题。`}
+params={{
+  title: "fix bug",
+  prompt: "帮我修复登录超时的问题",
+}}
+```
+
+## 输出格式约定
+
+建议在 prompt 中要求 AI 使用 `RESULT` 标记包裹输出，便于精确提取：
+
+```
+输出格式：用 RESULT 标记包裹最终结果，不要加任何其他内容。
+
+RESULT
+你的输出内容
+RESULT
+```
+
+前端可使用 `extractTitle()` 函数提取：
+
+```tsx
+import { extractTitle } from '@/utils/titleExtractor';
+
+const title = extractTitle(aiResult); // 从 RESULT 标记中提取
+```
+
+## 常见使用场景
+
+### 1. 标题优化
+
+```tsx
+<ActionButton
+  actionType="title_optimize"
+  actionKey="default"
+  prompt={`你是一个标题优化专家。请根据以下信息生成更优的标题。
+
+当前标题：{{title}}
+当前 Prompt：{{prompt}}
+
+要求：
+1. 保持原意
+2. 更简洁有力
+
+输出格式：用 RESULT 标记包裹最终标题。
+
+RESULT
+优化后的标题
+RESULT`}
+  params={{ title: todo.title, prompt: todo.prompt || '' }}
+  onApply={(newTitle) => updateTodo({ title: newTitle })}
+  buttonType="text"
+  icon={<RocketOutlined />}
+  panelTitle="自动优化标题"
+/>
+```
+
+### 2. Prompt 优化
+
+```tsx
+<ActionButton
+  actionType="prompt_optimize"
+  actionKey="default"
+  prompt={`你是一个 Prompt 工程专家。请优化以下 Prompt。
+
+原始 Prompt：{{prompt}}
+
+要求：
+1. 更清晰具体
+2. 添加输出格式说明
+
+RESULT
+优化后的 Prompt
+RESULT`}
+  params={{ prompt: todo.prompt }}
+  onApply={(newPrompt) => updateTodo({ prompt: newPrompt })}
+/>
+```
+
+### 3. 内容摘要
+
+```tsx
+<ActionButton
+  actionType="summarize"
+  actionKey="default"
+  prompt={`请为以下内容生成摘要：{{content}}`}
+  params={{ content: longText }}
+  onApply={(summary) => setSummary(summary)}
+/>
+```
+
+## 后端工作原理
+
+1. 前端调用 `POST /api/actions/execute`
+2. 后端按 `action_type + action_key` 查找 todo
+3. 找不到 → 自动创建 todo（prompt 来自请求）
+4. 执行 todo，返回 `task_id` + `record_id`
+5. 前端通过 WebSocket 监听执行完成
+6. 获取结果并展示
+
+## 注意事项
+
+1. **action_type + action_key 组合必须唯一**，数据库有唯一索引
+2. **prompt 中的 `{{key}}` 必须在 params 中有对应值**，否则会保留原始占位符
+3. **面板在执行中无法关闭**，防止用户误关丢失结果
+4. **左上角 X 按钮可关闭**，但遮罩点击始终禁用
+5. **执行器可覆盖**，用户在面板中选择的执行器会覆盖 todo 默认值
+
+## 文件位置
+
+- 组件：`frontend/src/components/ActionButton/`
+- 标题提取：`frontend/src/utils/titleExtractor.ts`
+- 后端 API：`backend/src/handlers/action.rs`
+- 数据库迁移：`backend/src/db/migration.rs` (V45/V46)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2257,7 +2257,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2267,7 +2266,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"

--- a/frontend/src/components/ActionButton/index.tsx
+++ b/frontend/src/components/ActionButton/index.tsx
@@ -126,7 +126,8 @@ export function ActionButton({
               <div
                 style={{
                   padding: 10,
-                  background: '#f5f5f5',
+                  background: 'var(--color-bg-elevated)',
+                  border: '1px solid var(--color-border-secondary)',
                   borderRadius: 6,
                   maxHeight: 120,
                   overflow: 'auto',

--- a/frontend/src/components/ActionButton/index.tsx
+++ b/frontend/src/components/ActionButton/index.tsx
@@ -236,7 +236,7 @@ export function ActionButton({
         onClick={handleOpen}
         disabled={disabled}
       >
-        {children || '智能执行'}
+        {children || '优化标题'}
       </Button>
 
       <Drawer

--- a/frontend/src/components/ActionButton/index.tsx
+++ b/frontend/src/components/ActionButton/index.tsx
@@ -1,34 +1,30 @@
-import { useState } from 'react';
-import { Button, Drawer, Spin, Typography, Space, message } from 'antd';
-import { ThunderboltOutlined } from '@ant-design/icons';
+import { useState, useEffect } from 'react';
+import { Button, Drawer, Spin, Typography, Space, message, Input, Select, Tag } from 'antd';
+import { ThunderboltOutlined, EditOutlined, CodeOutlined } from '@ant-design/icons';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useActionExecution } from './useActionExecution';
 import type { ActionButtonProps } from './types';
 
 const { Text, Paragraph } = Typography;
+const { TextArea } = Input;
+
+/** 可用的执行器选项 */
+const EXECUTOR_OPTIONS = [
+  { value: 'claudecode', label: 'Claude Code', color: '#d97706' },
+  { value: 'opencode', label: 'OpenCode', color: '#2563eb' },
+  { value: 'kilo', label: 'Kilo', color: '#7c3aed' },
+];
 
 /**
  * 可复用的一键 AI 执行组件。
  *
  * 交互流程：
- * 1. 点击按钮 → 打开 Drawer，展示参数预览（只读）
- * 2. 点击「执行」→ 调用 POST /api/actions/execute（查找或创建 todo → 执行）
- * 3. 通过 WebSocket 监听执行完成
- * 4. 完成后展示完整 markdown 结果
- * 5. 用户选择「应用」→ 调用 onApply 回调，或「拒绝」→ 关闭面板
- *
- * 后端逻辑：
- * - 根据 actionType + actionKey 查找 todo
- * - 如果不存在，自动创建 todo（prompt 来自请求）
- * - 执行该 todo，返回结果
- *
- * Prompt 模板语法：
- * - {{key}} → params 中 key 对应的值
- *
- * 示例：
- * prompt="优化标题：{{title}}，参考 Prompt：{{prompt}}"
- * params={{ title: "fix bug", prompt: "帮我修复登录超时" }}
- * → 执行消息="优化标题：fix bug，参考 Prompt：帮我修复登录超时"
+ * 1. 点击按钮 → 打开 Drawer
+ * 2. 展示可编辑的 Prompt、执行器选择器、参数预览
+ * 3. 用户可修改后点击「执行」
+ * 4. 通过 WebSocket 监听执行完成
+ * 5. 完成后展示完整 markdown 结果
+ * 6. 用户选择「应用」或「拒绝」
  */
 export function ActionButton({
   actionType,
@@ -42,10 +38,12 @@ export function ActionButton({
   icon,
   disabled = false,
   panelTitle = '智能执行',
-  panelDescription = '将使用 AI 处理以下内容',
+  panelDescription = '检查并确认以下内容后执行',
   executor,
 }: ActionButtonProps) {
   const [open, setOpen] = useState(false);
+  const [editablePrompt, setEditablePrompt] = useState(prompt);
+  const [selectedExecutor, setSelectedExecutor] = useState<string | undefined>(executor);
   const isMobile = useIsMobile();
   const { status, result, error, execute, retry, reset } = useActionExecution(
     actionType,
@@ -56,6 +54,14 @@ export function ActionButton({
     executor,
   );
 
+  // 打开时重置 editablePrompt 为默认值
+  useEffect(() => {
+    if (open) {
+      setEditablePrompt(prompt);
+      setSelectedExecutor(executor);
+    }
+  }, [open, prompt, executor]);
+
   const handleOpen = () => {
     reset();
     setOpen(true);
@@ -63,6 +69,14 @@ export function ActionButton({
 
   const handleClose = () => {
     setOpen(false);
+  };
+
+  const handleExecute = () => {
+    execute(editablePrompt, selectedExecutor);
+  };
+
+  const handleRetry = () => {
+    retry(editablePrompt, selectedExecutor);
   };
 
   const handleApply = async () => {
@@ -77,28 +91,69 @@ export function ActionButton({
   };
 
   // 从 params 中提取要展示的预览内容
-  const previewContent = Object.entries(params)
-    .map(([key, value]) => `${key}: ${value}`)
-    .join('\n');
+  const paramsPreview = Object.entries(params)
+    .map(([key, value]) => ({ key, value }));
 
   const renderContent = () => {
     if (status === 'idle') {
       return (
         <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          {/* 描述 */}
           <Text type="secondary">{panelDescription}</Text>
-          <div
-            style={{
-              padding: 12,
-              background: '#f5f5f5',
-              borderRadius: 6,
-              maxHeight: 200,
-              overflow: 'auto',
-            }}
-          >
-            <Text ellipsis>
-              {previewContent || '(空)'}
-            </Text>
+
+          {/* Prompt 编辑区 */}
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
+              <EditOutlined style={{ color: 'var(--color-text-secondary)' }} />
+              <Text strong style={{ fontSize: 13 }}>Prompt 模板</Text>
+            </div>
+            <TextArea
+              value={editablePrompt}
+              onChange={(e) => setEditablePrompt(e.target.value)}
+              autoSize={{ minRows: 4, maxRows: 12 }}
+              style={{ fontFamily: 'monospace', fontSize: 12 }}
+            />
           </div>
+
+          {/* 执行器选择 */}
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
+              <CodeOutlined style={{ color: 'var(--color-text-secondary)' }} />
+              <Text strong style={{ fontSize: 13 }}>执行器</Text>
+            </div>
+            <Select
+              value={selectedExecutor}
+              onChange={setSelectedExecutor}
+              options={EXECUTOR_OPTIONS}
+              style={{ width: '100%' }}
+              placeholder="选择执行器"
+            />
+          </div>
+
+          {/* 参数预览 */}
+          {paramsPreview.length > 0 && (
+            <div>
+              <Text strong style={{ fontSize: 13, display: 'block', marginBottom: 6 }}>
+                模板参数
+              </Text>
+              <div
+                style={{
+                  padding: 10,
+                  background: '#f5f5f5',
+                  borderRadius: 6,
+                  maxHeight: 120,
+                  overflow: 'auto',
+                }}
+              >
+                {paramsPreview.map(({ key, value }) => (
+                  <div key={key} style={{ marginBottom: 4 }}>
+                    <Tag color="blue" style={{ marginRight: 8 }}>{`{{${key}}}`}</Tag>
+                    <Text ellipsis style={{ fontSize: 12 }}>{value}</Text>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </Space>
       );
     }
@@ -152,7 +207,7 @@ export function ActionButton({
       return (
         <Space>
           <Button onClick={handleClose}>取消</Button>
-          <Button type="primary" onClick={execute}>
+          <Button type="primary" onClick={handleExecute}>
             执行
           </Button>
         </Space>
@@ -167,7 +222,7 @@ export function ActionButton({
       return (
         <Space>
           <Button onClick={handleClose}>关闭</Button>
-          <Button type="primary" onClick={retry}>
+          <Button type="primary" onClick={handleRetry}>
             重试
           </Button>
         </Space>
@@ -199,10 +254,13 @@ export function ActionButton({
       <Drawer
         title={panelTitle}
         open={open}
-        onClose={handleClose}
+        onClose={() => {}} // 禁止点击外部/Escape关闭，必须显式操作
+        closable={status !== 'executing'} // 执行中隐藏关闭按钮
+        keyboard={false} // 禁止 Escape 关闭
+        maskClosable={status !== 'executing'} // 执行中禁止点击遮罩关闭
         placement={isMobile ? 'bottom' : 'right'}
-        width={isMobile ? '100%' : 480}
-        height={isMobile ? '80vh' : undefined}
+        width={isMobile ? '100%' : 520}
+        height={isMobile ? '85vh' : undefined}
         footer={renderFooter()}
         destroyOnClose
       >

--- a/frontend/src/components/ActionButton/index.tsx
+++ b/frontend/src/components/ActionButton/index.tsx
@@ -129,14 +129,21 @@ export function ActionButton({
                   background: 'var(--color-bg-elevated)',
                   border: '1px solid var(--color-border-secondary)',
                   borderRadius: 6,
-                  maxHeight: 120,
+                  maxHeight: 150,
                   overflow: 'auto',
                 }}
               >
                 {paramsPreview.map(({ key, value }) => (
-                  <div key={key} style={{ marginBottom: 4 }}>
-                    <Tag color="blue" style={{ marginRight: 8 }}>{`{{${key}}}`}</Tag>
-                    <Text ellipsis style={{ fontSize: 12 }}>{value}</Text>
+                  <div key={key} style={{ marginBottom: 8 }}>
+                    <Tag color="blue" style={{ marginBottom: 4 }}>{`{{${key}}}`}</Tag>
+                    <div style={{
+                      fontSize: 12,
+                      whiteSpace: 'pre-wrap',
+                      wordBreak: 'break-word',
+                      color: 'var(--color-text-secondary)',
+                    }}>
+                      {value}
+                    </div>
                   </div>
                 ))}
               </div>
@@ -250,7 +257,7 @@ export function ActionButton({
         width={isMobile ? '100%' : 520}
         height={isMobile ? '85vh' : undefined}
         footer={renderFooter()}
-        destroyOnClose
+        destroyOnHidden
       >
         {renderContent()}
       </Drawer>

--- a/frontend/src/components/ActionButton/index.tsx
+++ b/frontend/src/components/ActionButton/index.tsx
@@ -1,19 +1,14 @@
 import { useState, useEffect } from 'react';
-import { Button, Drawer, Spin, Typography, Space, message, Input, Select, Tag } from 'antd';
-import { ThunderboltOutlined, EditOutlined, CodeOutlined } from '@ant-design/icons';
+import { Button, Drawer, Spin, Typography, Space, message, Input, Tag } from 'antd';
+import { ThunderboltOutlined, EditOutlined } from '@ant-design/icons';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useActionExecution } from './useActionExecution';
+import { ExecutorPicker } from '@/components/todo-drawer/ExecutorPicker';
+import { EXECUTORS_FOR_PICKER } from '@/types/execution';
 import type { ActionButtonProps } from './types';
 
 const { Text, Paragraph } = Typography;
 const { TextArea } = Input;
-
-/** 可用的执行器选项 */
-const EXECUTOR_OPTIONS = [
-  { value: 'claudecode', label: 'Claude Code', color: '#d97706' },
-  { value: 'opencode', label: 'OpenCode', color: '#2563eb' },
-  { value: 'kilo', label: 'Kilo', color: '#7c3aed' },
-];
 
 /**
  * 可复用的一键 AI 执行组件。
@@ -116,19 +111,11 @@ export function ActionButton({
           </div>
 
           {/* 执行器选择 */}
-          <div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
-              <CodeOutlined style={{ color: 'var(--color-text-secondary)' }} />
-              <Text strong style={{ fontSize: 13 }}>执行器</Text>
-            </div>
-            <Select
-              value={selectedExecutor}
-              onChange={setSelectedExecutor}
-              options={EXECUTOR_OPTIONS}
-              style={{ width: '100%' }}
-              placeholder="选择执行器"
-            />
-          </div>
+          <ExecutorPicker
+            executor={selectedExecutor || 'claudecode'}
+            executorOptions={EXECUTORS_FOR_PICKER}
+            onChange={setSelectedExecutor}
+          />
 
           {/* 参数预览 */}
           {paramsPreview.length > 0 && (

--- a/frontend/src/components/ActionButton/index.tsx
+++ b/frontend/src/components/ActionButton/index.tsx
@@ -32,7 +32,7 @@ export function ActionButton({
   buttonType = 'default',
   icon,
   disabled = false,
-  panelTitle = '智能执行',
+  panelTitle = '自动优化标题',
   panelDescription = '检查并确认以下内容后执行',
   executor,
 }: ActionButtonProps) {
@@ -242,10 +242,10 @@ export function ActionButton({
       <Drawer
         title={panelTitle}
         open={open}
-        onClose={() => {}} // 禁止点击外部/Escape关闭，必须显式操作
-        closable={status !== 'executing'} // 执行中隐藏关闭按钮
+        onClose={status !== 'executing' ? handleClose : undefined} // 执行中禁止关闭，其他时候允许通过 X 按钮关闭
+        closable={status !== 'executing'}
         keyboard={false} // 禁止 Escape 关闭
-        maskClosable={status !== 'executing'} // 执行中禁止点击遮罩关闭
+        maskClosable={false} // 始终禁止点击遮罩关闭
         placement={isMobile ? 'bottom' : 'right'}
         width={isMobile ? '100%' : 520}
         height={isMobile ? '85vh' : undefined}

--- a/frontend/src/components/ActionButton/index.tsx
+++ b/frontend/src/components/ActionButton/index.tsx
@@ -172,8 +172,8 @@ export function ActionButton({
         <div
           style={{
             padding: 12,
-            background: '#f6ffed',
-            border: '1px solid #b7eb8f',
+            background: 'var(--color-success-bg, #f6ffed)',
+            border: '1px solid var(--color-success-border, #b7eb8f)',
             borderRadius: 6,
             maxHeight: 400,
             overflow: 'auto',

--- a/frontend/src/components/ActionButton/index.tsx
+++ b/frontend/src/components/ActionButton/index.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react';
+import { Button, Drawer, Spin, Typography, Space, message } from 'antd';
+import { ThunderboltOutlined } from '@ant-design/icons';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { useActionExecution } from './useActionExecution';
+import type { ActionButtonProps } from './types';
+
+const { Text, Paragraph } = Typography;
+
+/**
+ * 可复用的一键 AI 执行组件。
+ *
+ * 交互流程：
+ * 1. 点击按钮 → 打开 Drawer，展示参数预览（只读）
+ * 2. 点击「执行」→ 调用 POST /api/actions/execute（查找或创建 todo → 执行）
+ * 3. 通过 WebSocket 监听执行完成
+ * 4. 完成后展示完整 markdown 结果
+ * 5. 用户选择「应用」→ 调用 onApply 回调，或「拒绝」→ 关闭面板
+ *
+ * 后端逻辑：
+ * - 根据 actionType + actionKey 查找 todo
+ * - 如果不存在，自动创建 todo（prompt 来自请求）
+ * - 执行该 todo，返回结果
+ *
+ * Prompt 模板语法：
+ * - {{key}} → params 中 key 对应的值
+ *
+ * 示例：
+ * prompt="优化标题：{{title}}，参考 Prompt：{{prompt}}"
+ * params={{ title: "fix bug", prompt: "帮我修复登录超时" }}
+ * → 执行消息="优化标题：fix bug，参考 Prompt：帮我修复登录超时"
+ */
+export function ActionButton({
+  actionType,
+  actionKey,
+  prompt,
+  params,
+  onApply,
+  workspaceId,
+  children,
+  buttonType = 'default',
+  icon,
+  disabled = false,
+  panelTitle = '智能执行',
+  panelDescription = '将使用 AI 处理以下内容',
+  executor,
+}: ActionButtonProps) {
+  const [open, setOpen] = useState(false);
+  const isMobile = useIsMobile();
+  const { status, result, error, execute, retry, reset } = useActionExecution(
+    actionType,
+    actionKey,
+    prompt,
+    params,
+    workspaceId,
+    executor,
+  );
+
+  const handleOpen = () => {
+    reset();
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleApply = async () => {
+    if (!result) return;
+    try {
+      await onApply(result);
+      message.success('已应用');
+      handleClose();
+    } catch (err: any) {
+      message.error(err?.message || '应用失败');
+    }
+  };
+
+  // 从 params 中提取要展示的预览内容
+  const previewContent = Object.entries(params)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join('\n');
+
+  const renderContent = () => {
+    if (status === 'idle') {
+      return (
+        <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          <Text type="secondary">{panelDescription}</Text>
+          <div
+            style={{
+              padding: 12,
+              background: '#f5f5f5',
+              borderRadius: 6,
+              maxHeight: 200,
+              overflow: 'auto',
+            }}
+          >
+            <Text ellipsis>
+              {previewContent || '(空)'}
+            </Text>
+          </div>
+        </Space>
+      );
+    }
+
+    if (status === 'executing') {
+      return (
+        <div style={{ textAlign: 'center', padding: '40px 0' }}>
+          <Spin size="large" />
+          <div style={{ marginTop: 16 }}>
+            <Text type="secondary">AI 正在处理中...</Text>
+          </div>
+        </div>
+      );
+    }
+
+    if (status === 'failed') {
+      return (
+        <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          <Text type="danger">{error || '执行失败'}</Text>
+        </Space>
+      );
+    }
+
+    // completed
+    return (
+      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        <Text type="secondary">AI 生成结果：</Text>
+        <div
+          style={{
+            padding: 12,
+            background: '#f6ffed',
+            border: '1px solid #b7eb8f',
+            borderRadius: 6,
+            maxHeight: 400,
+            overflow: 'auto',
+          }}
+        >
+          <Paragraph
+            style={{ whiteSpace: 'pre-wrap', margin: 0 }}
+            ellipsis={{ expandable: true, symbol: '展开' }}
+          >
+            {result}
+          </Paragraph>
+        </div>
+      </Space>
+    );
+  };
+
+  const renderFooter = () => {
+    if (status === 'idle') {
+      return (
+        <Space>
+          <Button onClick={handleClose}>取消</Button>
+          <Button type="primary" onClick={execute}>
+            执行
+          </Button>
+        </Space>
+      );
+    }
+
+    if (status === 'executing') {
+      return null;
+    }
+
+    if (status === 'failed') {
+      return (
+        <Space>
+          <Button onClick={handleClose}>关闭</Button>
+          <Button type="primary" onClick={retry}>
+            重试
+          </Button>
+        </Space>
+      );
+    }
+
+    // completed
+    return (
+      <Space>
+        <Button onClick={handleClose}>拒绝</Button>
+        <Button type="primary" onClick={handleApply}>
+          应用
+        </Button>
+      </Space>
+    );
+  };
+
+  return (
+    <>
+      <Button
+        type={buttonType}
+        icon={icon || <ThunderboltOutlined />}
+        onClick={handleOpen}
+        disabled={disabled}
+      >
+        {children || '智能执行'}
+      </Button>
+
+      <Drawer
+        title={panelTitle}
+        open={open}
+        onClose={handleClose}
+        placement={isMobile ? 'bottom' : 'right'}
+        width={isMobile ? '100%' : 480}
+        height={isMobile ? '80vh' : undefined}
+        footer={renderFooter()}
+        destroyOnClose
+      >
+        {renderContent()}
+      </Drawer>
+    </>
+  );
+}

--- a/frontend/src/components/ActionButton/types.ts
+++ b/frontend/src/components/ActionButton/types.ts
@@ -25,7 +25,7 @@ export interface ActionButtonProps {
   panelTitle?: string;
   /** 面板描述（默认：将使用 AI 处理以下内容） */
   panelDescription?: string;
-  /** 覆盖执行器类型 */
+  /** 默认执行器类型 */
   executor?: string;
 }
 

--- a/frontend/src/components/ActionButton/types.ts
+++ b/frontend/src/components/ActionButton/types.ts
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react';
+
+export interface ActionButtonProps {
+  /** 动作类型（如 "title_optimize"、"prompt_optimize"） */
+  actionType: string;
+  /** 动作键值（如 "default"、"aggressive"） */
+  actionKey: string;
+  /** Prompt 模板，支持 {{key}} 占位符 */
+  prompt: string;
+  /** 模板参数，键值对会替换 prompt 中对应的 {{key}} 占位符 */
+  params: Record<string, string>;
+  /** 执行完成后「应用」的回调，参数为 AI 生成的结果文本（完整 markdown） */
+  onApply: (result: string) => void | Promise<void>;
+  /** 工作空间 ID（可选，不传则使用默认工作空间） */
+  workspaceId?: number;
+  /** 按钮显示内容 */
+  children?: ReactNode;
+  /** 按钮类型（Ant Design） */
+  buttonType?: 'primary' | 'default' | 'link' | 'text';
+  /** 按钮图标 */
+  icon?: ReactNode;
+  /** 是否禁用 */
+  disabled?: boolean;
+  /** 面板标题（默认：智能执行） */
+  panelTitle?: string;
+  /** 面板描述（默认：将使用 AI 处理以下内容） */
+  panelDescription?: string;
+  /** 覆盖执行器类型 */
+  executor?: string;
+}
+
+export type ActionStatus = 'idle' | 'executing' | 'completed' | 'failed';

--- a/frontend/src/components/ActionButton/useActionExecution.ts
+++ b/frontend/src/components/ActionButton/useActionExecution.ts
@@ -1,0 +1,143 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { getExecutionRecord } from '@/utils/database';
+import { useExecution } from '@/hooks/useExecutionContext';
+import type { ActionStatus } from './types';
+import { api, unwrap } from '@/utils/database/client';
+
+interface UseActionExecutionReturn {
+  status: ActionStatus;
+  result: string | null;
+  error: string | null;
+  recordId: number | null;
+  execute: () => Promise<void>;
+  retry: () => Promise<void>;
+  reset: () => void;
+}
+
+interface ExecuteActionResult {
+  task_id: string;
+  record_id: number;
+  todo_id: number;
+  todo_created: boolean;
+}
+
+/**
+ * 调用后端 POST /api/actions/execute 接口。
+ */
+async function callActionExecute(
+  actionType: string,
+  actionKey: string,
+  prompt: string,
+  params: Record<string, string>,
+  workspaceId?: number,
+  executor?: string,
+): Promise<ExecuteActionResult> {
+  return unwrap(
+    await api.post('/api/actions/execute', {
+      action_type: actionType,
+      action_key: actionKey,
+      prompt,
+      params,
+      workspace_id: workspaceId,
+      executor,
+    })
+  );
+}
+
+/**
+ * 管理 ActionButton 的执行状态。
+ *
+ * 流程：
+ * 1. execute() → 调用 POST /api/actions/execute
+ * 2. 通过 useExecutionContext 的 WebSocket 事件监听执行完成
+ * 3. 收到 FINISH_TASK 事件后，查询 execution_record 获取 result
+ */
+export function useActionExecution(
+  actionType: string,
+  actionKey: string,
+  prompt: string,
+  params: Record<string, string>,
+  workspaceId?: number,
+  executor?: string,
+): UseActionExecutionReturn {
+  const [status, setStatus] = useState<ActionStatus>('idle');
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [recordId, setRecordId] = useState<number | null>(null);
+  const taskIdRef = useRef<string | null>(null);
+  const { state } = useExecution();
+
+  // 监听 WebSocket 的 FINISH_TASK 事件
+  useEffect(() => {
+    if (status !== 'executing' || !taskIdRef.current) return;
+
+    const task = state.runningTasks[taskIdRef.current];
+    if (task?.status === 'finished') {
+      if (task.success && task.result) {
+        setResult(task.result);
+        setStatus('completed');
+      } else if (!task.success) {
+        setError(task.result || '执行失败');
+        setStatus('failed');
+      } else {
+        // 执行完成但没有 result，尝试从 execution_record 查询
+        fetchResultFromRecord();
+      }
+    }
+  }, [state.runningTasks, status]);
+
+  // 从 execution_record 查询结果（WebSocket 事件没有 result 时的 fallback）
+  const fetchResultFromRecord = useCallback(async () => {
+    if (!recordId) return;
+    try {
+      const record = await getExecutionRecord(recordId);
+      if (record.result) {
+        setResult(record.result);
+        setStatus('completed');
+      } else if (record.status === 'failed') {
+        setError(record.stderr || '执行失败');
+        setStatus('failed');
+      }
+    } catch (err: any) {
+      setError(err?.message || '查询执行结果失败');
+      setStatus('failed');
+    }
+  }, [recordId]);
+
+  const execute = useCallback(async () => {
+    setStatus('executing');
+    setResult(null);
+    setError(null);
+
+    try {
+      // 调用后端 API：查找或创建 todo，然后执行
+      const res = await callActionExecute(
+        actionType,
+        actionKey,
+        prompt,
+        params,
+        workspaceId,
+        executor,
+      );
+      setRecordId(res.record_id);
+      taskIdRef.current = res.task_id;
+    } catch (err: any) {
+      setError(err?.message || '启动执行失败');
+      setStatus('failed');
+    }
+  }, [actionType, actionKey, prompt, params, workspaceId, executor]);
+
+  const retry = useCallback(async () => {
+    await execute();
+  }, [execute]);
+
+  const reset = useCallback(() => {
+    setStatus('idle');
+    setResult(null);
+    setError(null);
+    setRecordId(null);
+    taskIdRef.current = null;
+  }, []);
+
+  return { status, result, error, recordId, execute, retry, reset };
+}

--- a/frontend/src/components/ActionButton/useActionExecution.ts
+++ b/frontend/src/components/ActionButton/useActionExecution.ts
@@ -9,8 +9,8 @@ interface UseActionExecutionReturn {
   result: string | null;
   error: string | null;
   recordId: number | null;
-  execute: () => Promise<void>;
-  retry: () => Promise<void>;
+  execute: (prompt: string, executor?: string) => Promise<void>;
+  retry: (prompt: string, executor?: string) => Promise<void>;
   reset: () => void;
 }
 
@@ -55,10 +55,10 @@ async function callActionExecute(
 export function useActionExecution(
   actionType: string,
   actionKey: string,
-  prompt: string,
+  _defaultPrompt: string,
   params: Record<string, string>,
   workspaceId?: number,
-  executor?: string,
+  _defaultExecutor?: string,
 ): UseActionExecutionReturn {
   const [status, setStatus] = useState<ActionStatus>('idle');
   const [result, setResult] = useState<string | null>(null);
@@ -80,7 +80,6 @@ export function useActionExecution(
         setError(task.result || '执行失败');
         setStatus('failed');
       } else {
-        // 执行完成但没有 result，尝试从 execution_record 查询
         fetchResultFromRecord();
       }
     }
@@ -104,13 +103,12 @@ export function useActionExecution(
     }
   }, [recordId]);
 
-  const execute = useCallback(async () => {
+  const execute = useCallback(async (prompt: string, executor?: string) => {
     setStatus('executing');
     setResult(null);
     setError(null);
 
     try {
-      // 调用后端 API：查找或创建 todo，然后执行
       const res = await callActionExecute(
         actionType,
         actionKey,
@@ -125,10 +123,10 @@ export function useActionExecution(
       setError(err?.message || '启动执行失败');
       setStatus('failed');
     }
-  }, [actionType, actionKey, prompt, params, workspaceId, executor]);
+  }, [actionType, actionKey, params, workspaceId]);
 
-  const retry = useCallback(async () => {
-    await execute();
+  const retry = useCallback(async (prompt: string, executor?: string) => {
+    await execute(prompt, executor);
   }, [execute]);
 
   const reset = useCallback(() => {

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -172,6 +172,28 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
     }
   }, [selectedTodo, dispatch]);
 
+  const handleTitleUpdate = useCallback(async (newTitle: string) => {
+    if (!selectedTodo) return;
+    try {
+      const updated = await db.updateTodo(
+        selectedTodo.id,
+        newTitle,
+        selectedTodo.prompt || '',
+        selectedTodo.status || 'pending',
+        selectedTodo.executor || undefined,
+        selectedTodo.scheduler_enabled,
+        selectedTodo.scheduler_config,
+        selectedTodo.workspace_id,
+        selectedTodo.webhook_enabled,
+        selectedTodo.acceptance_criteria,
+        selectedTodo.auto_review_enabled,
+      );
+      dispatch({ type: 'UPDATE_TODO', payload: updated });
+    } catch (err: any) {
+      throw err;
+    }
+  }, [selectedTodo, dispatch]);
+
   // 升级/降级已移除：环节与 Todo 合一，无需 promote 流程
 
   const handleDelete = async () => {
@@ -240,6 +262,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
         onOpenExecuteWithArgs={handleOpenExecuteWithArgs}
         onExecute={handleExecute}
         onStatusChange={handleStatusChange}
+        onTitleUpdate={handleTitleUpdate}
         hideTitleRow={hideTitleRow}
       />
 

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -7,6 +7,7 @@ import { CheckCircleOutlined, ReloadOutlined, ThunderboltOutlined } from '@ant-d
 import { TodoDrawer } from './TodoDrawer';
 import { BREAKPOINTS } from '@/constants';
 import * as db from '@/utils/database';
+import { extractTitle } from '@/utils/titleExtractor';
 import type { ExecutionRecord } from '@/types';
 import { groupBySession } from './todo-detail/helpers';
 import { DetailHeader } from './todo-detail/DetailHeader';
@@ -172,8 +173,13 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
     }
   }, [selectedTodo, dispatch]);
 
-  const handleTitleUpdate = useCallback(async (newTitle: string) => {
+  const handleTitleUpdate = useCallback(async (aiResult: string) => {
     if (!selectedTodo) return;
+    // 从 AI 结果中提取纯标题（处理 AI 可能返回额外解释的情况）
+    const newTitle = extractTitle(aiResult);
+    if (!newTitle) {
+      throw new Error('无法从 AI 结果中提取标题');
+    }
     try {
       const updated = await db.updateTodo(
         selectedTodo.id,

--- a/frontend/src/components/todo-detail/DetailHeader.tsx
+++ b/frontend/src/components/todo-detail/DetailHeader.tsx
@@ -42,6 +42,37 @@ export function DetailHeader({
             <StatusPicker value={selectedTodo.status} onChange={onStatusChange} disabled={isExecuting} />
             <h2 className="card-title" style={{ margin: 0, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{selectedTodo.title}</h2>
             <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
+              {onTitleUpdate && (
+                <ActionButton
+                  actionType="title_optimize"
+                  actionKey="default"
+                  prompt={`你是一个标题优化专家。请根据以下信息生成更优的标题。
+
+当前标题：{{title}}
+当前 Prompt：{{prompt}}
+
+要求：
+1. 保持原意
+2. 更简洁有力
+3. 适合 AI Todo 应用的场景
+
+输出格式：用 RESULT 标记包裹最终标题，不要加任何其他内容。
+
+RESULT
+优化后的标题文本
+RESULT`}
+                  params={{
+                    title: selectedTodo.title,
+                    prompt: selectedTodo.prompt || '',
+                  }}
+                  workspaceId={selectedTodo.workspace_id || undefined}
+                  onApply={onTitleUpdate}
+                  buttonType="text"
+                  icon={<RocketOutlined />}
+                  panelTitle="优化标题"
+                  panelDescription="AI 将根据当前标题和 Prompt 生成更优的版本"
+                />
+              )}
               <Button type="text" icon={<EditOutlined />} onClick={onTodoDrawerOpen} className="icon-btn" aria-label="编辑任务" />
               <Popconfirm title="删除任务" description="确定要删除吗？" onConfirm={onDelete}>
                 <Button type="text" icon={<DeleteOutlined />} className="icon-btn" aria-label="删除任务" />
@@ -160,39 +191,6 @@ export function DetailHeader({
           >
             带参执行
           </Button>
-          {onTitleUpdate && (
-            <ActionButton
-              actionType="title_optimize"
-              actionKey="default"
-              prompt={`你是一个标题优化专家。请根据以下信息生成更优的标题。
-
-当前标题：{{title}}
-当前 Prompt：{{prompt}}
-
-要求：
-1. 保持原意
-2. 更简洁有力
-3. 适合 AI Todo 应用的场景
-
-输出格式：用 RESULT 标记包裹最终标题，不要加任何其他内容。
-
-RESULT
-优化后的标题文本
-RESULT`}
-              params={{
-                title: selectedTodo.title,
-                prompt: selectedTodo.prompt || '',
-              }}
-              workspaceId={selectedTodo.workspace_id || undefined}
-              onApply={onTitleUpdate}
-              buttonType="primary"
-              icon={<RocketOutlined />}
-              panelTitle="优化标题"
-              panelDescription="AI 将根据当前标题和 Prompt 生成更优的版本"
-            >
-              优化标题
-            </ActionButton>
-          )}
         </div>
       </div>
     </>

--- a/frontend/src/components/todo-detail/DetailHeader.tsx
+++ b/frontend/src/components/todo-detail/DetailHeader.tsx
@@ -1,5 +1,5 @@
 import { Button, Tag, Badge, Popconfirm, App } from 'antd';
-import { PlayCircleOutlined, ThunderboltOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
+import { PlayCircleOutlined, ThunderboltOutlined, EditOutlined, DeleteOutlined, RocketOutlined } from '@ant-design/icons';
 import { StatusPicker } from '@/components/StatusPicker';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { PromptDisplay } from './PromptDisplay';
@@ -7,12 +7,14 @@ import { InlineTokenStats } from './InlineTokenStats';
 import { ProgressWidget } from './ProgressWidget';
 import { formatLocalDateTime } from '@/utils/datetime';
 import { CopyButton } from '@/components/CopyButton';
+import { ActionButton } from '@/components/ActionButton';
 import type { ExecutionSummary, ExecutionRecord } from '@/types';
 import type { Todo } from '@/types';
 
 export function DetailHeader({
   selectedTodo, executor, isExecuting, summary, currentTodoProgress,
   records, onDelete, onTodoDrawerOpen, onOpenExecuteWithArgs, onExecute, onStatusChange,
+  onTitleUpdate,
   hideTitleRow = false,
 }: {
   selectedTodo: Todo;
@@ -26,6 +28,7 @@ export function DetailHeader({
   onOpenExecuteWithArgs: () => void;
   onExecute: () => Promise<void>;
   onStatusChange: (status: string) => Promise<void>;
+  onTitleUpdate?: (newTitle: string) => Promise<void>;
   hideTitleRow?: boolean;
 }) {
   const { message } = App.useApp();
@@ -157,6 +160,35 @@ export function DetailHeader({
           >
             带参执行
           </Button>
+          {onTitleUpdate && (
+            <ActionButton
+              actionType="title_optimize"
+              actionKey="default"
+              prompt={`你是一个标题优化专家。请根据以下信息生成更优的标题：
+
+当前标题：{{title}}
+当前 Prompt：{{prompt}}
+
+要求：
+1. 保持原意
+2. 更简洁有力
+3. 适合 AI Todo 应用的场景
+
+请直接输出最优版本，不要加解释。`}
+              params={{
+                title: selectedTodo.title,
+                prompt: selectedTodo.prompt || '',
+              }}
+              workspaceId={selectedTodo.workspace_id || undefined}
+              onApply={onTitleUpdate}
+              buttonType="primary"
+              icon={<RocketOutlined />}
+              panelTitle="优化标题"
+              panelDescription="AI 将根据当前标题和 Prompt 生成更优的版本"
+            >
+              优化标题
+            </ActionButton>
+          )}
         </div>
       </div>
     </>

--- a/frontend/src/components/todo-detail/DetailHeader.tsx
+++ b/frontend/src/components/todo-detail/DetailHeader.tsx
@@ -69,7 +69,7 @@ RESULT`}
                   onApply={onTitleUpdate}
                   buttonType="text"
                   icon={<RocketOutlined />}
-                  panelTitle="优化标题"
+                  panelTitle="自动优化标题"
                   panelDescription="AI 将根据当前标题和 Prompt 生成更优的版本"
                 />
               )}

--- a/frontend/src/components/todo-detail/DetailHeader.tsx
+++ b/frontend/src/components/todo-detail/DetailHeader.tsx
@@ -1,4 +1,4 @@
-import { Button, Tag, Badge, Popconfirm, App } from 'antd';
+import { Button, Tag, Badge, Popconfirm, App, Tooltip } from 'antd';
 import { PlayCircleOutlined, ThunderboltOutlined, EditOutlined, DeleteOutlined, RocketOutlined } from '@ant-design/icons';
 import { StatusPicker } from '@/components/StatusPicker';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
@@ -43,10 +43,11 @@ export function DetailHeader({
             <h2 className="card-title" style={{ margin: 0, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{selectedTodo.title}</h2>
             <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
               {onTitleUpdate && (
-                <ActionButton
-                  actionType="title_optimize"
-                  actionKey="default"
-                  prompt={`你是一个标题优化专家。请根据以下信息生成更优的标题。
+                <Tooltip title="自动优化标题">
+                  <ActionButton
+                    actionType="title_optimize"
+                    actionKey="default"
+                    prompt={`你是一个标题优化专家。请根据以下信息生成更优的标题。
 
 当前标题：{{title}}
 当前 Prompt：{{prompt}}
@@ -61,17 +62,18 @@ export function DetailHeader({
 RESULT
 优化后的标题文本
 RESULT`}
-                  params={{
-                    title: selectedTodo.title,
-                    prompt: selectedTodo.prompt || '',
-                  }}
-                  workspaceId={selectedTodo.workspace_id || undefined}
-                  onApply={onTitleUpdate}
-                  buttonType="text"
-                  icon={<RocketOutlined />}
-                  panelTitle="自动优化标题"
-                  panelDescription="AI 将根据当前标题和 Prompt 生成更优的版本"
-                />
+                    params={{
+                      title: selectedTodo.title,
+                      prompt: selectedTodo.prompt || '',
+                    }}
+                    workspaceId={selectedTodo.workspace_id || undefined}
+                    onApply={onTitleUpdate}
+                    buttonType="text"
+                    icon={<RocketOutlined />}
+                    panelTitle="自动优化标题"
+                    panelDescription="AI 将根据当前标题和 Prompt 生成更优的版本"
+                  />
+                </Tooltip>
               )}
               <Button type="text" icon={<EditOutlined />} onClick={onTodoDrawerOpen} className="icon-btn" aria-label="编辑任务" />
               <Popconfirm title="删除任务" description="确定要删除吗？" onConfirm={onDelete}>

--- a/frontend/src/components/todo-detail/DetailHeader.tsx
+++ b/frontend/src/components/todo-detail/DetailHeader.tsx
@@ -164,7 +164,7 @@ export function DetailHeader({
             <ActionButton
               actionType="title_optimize"
               actionKey="default"
-              prompt={`你是一个标题优化专家。请根据以下信息生成更优的标题：
+              prompt={`你是一个标题优化专家。请根据以下信息生成更优的标题。
 
 当前标题：{{title}}
 当前 Prompt：{{prompt}}
@@ -174,7 +174,11 @@ export function DetailHeader({
 2. 更简洁有力
 3. 适合 AI Todo 应用的场景
 
-请直接输出最优版本，不要加解释。`}
+输出格式：用 RESULT 标记包裹最终标题，不要加任何其他内容。
+
+RESULT
+优化后的标题文本
+RESULT`}
               params={{
                 title: selectedTodo.title,
                 prompt: selectedTodo.prompt || '',

--- a/frontend/src/utils/titleExtractor.ts
+++ b/frontend/src/utils/titleExtractor.ts
@@ -1,49 +1,50 @@
 /**
  * 从 AI 生成的结果中提取标题。
  *
- * 策略：
- * 1. 去除首尾空白
- * 2. 如果是纯文本（无 markdown），直接返回
- * 3. 如果包含 markdown，尝试提取第一个标题或加粗文本
- * 4. 如果都失败，返回清理后的文本
+ * 主要策略：提取 RESULT 标记包裹的内容。
+ * 兜底策略：如果 RESULT 标记不存在，回退到通用解析。
+ *
+ * 期望的 AI 输出格式：
+ * RESULT
+ * 优化后的标题文本
+ * RESULT
  *
  * 示例输入/输出：
- * - "登录超时问题修复" → "登录超时问题修复"
- * - "**登录超时问题修复**" → "登录超时问题修复"
- * - "# 登录超时问题修复" → "登录超时问题修复"
- * - "根据分析，建议改为：**登录超时问题修复**" → "登录超时问题修复"
+ * - "RESULT\n登录超时问题修复\nRESULT" → "登录超时问题修复"
+ * - "RESULT\n**登录超时问题修复**\nRESULT" → "登录超时问题修复"
+ * - "登录超时问题修复" → "登录超时问题修复"（兜底）
  */
 export function extractTitle(result: string): string {
   if (!result) return '';
 
-  // 1. 去除首尾空白
+  // 1. 主策略：提取 RESULT 标记包裹的内容
+  const resultMatch = result.match(/RESULT\s*\n([\s\S]*?)\n\s*RESULT/i);
+  if (resultMatch) {
+    return cleanMarkdown(resultMatch[1].trim());
+  }
+
+  // 2. 兜底策略：通用解析
   let text = result.trim();
 
-  // 2. 尝试提取 markdown 标题 (# Title)
+  // 尝试提取 markdown 标题 (# Title)
   const headingMatch = text.match(/^#{1,6}\s+(.+)$/m);
   if (headingMatch) {
     return cleanMarkdown(headingMatch[1].trim());
   }
 
-  // 3. 尝试提取加粗文本 (**text** 或 __text__)
+  // 尝试提取加粗文本 (**text** 或 __text__)
   const boldMatch = text.match(/\*\*(.+?)\*\*|__(.+?)__/);
   if (boldMatch) {
     return cleanMarkdown((boldMatch[1] || boldMatch[2]).trim());
   }
 
-  // 4. 尝试提取引号内的文本 ("text" 或 「text」)
-  const quoteMatch = text.match(/["「](.+?)["」]/);
-  if (quoteMatch) {
-    return cleanMarkdown(quoteMatch[1].trim());
-  }
-
-  // 5. 如果只有一行，直接返回
+  // 如果只有一行，直接返回
   const lines = text.split('\n').filter(l => l.trim());
   if (lines.length === 1) {
     return cleanMarkdown(lines[0].trim());
   }
 
-  // 6. 多行文本：返回第一行（通常是标题）
+  // 多行文本：返回第一行
   return cleanMarkdown(lines[0].trim());
 }
 

--- a/frontend/src/utils/titleExtractor.ts
+++ b/frontend/src/utils/titleExtractor.ts
@@ -40,6 +40,9 @@ export function extractTitle(result: string): string {
 
   // 如果只有一行，直接返回
   const lines = text.split('\n').filter(l => l.trim());
+  if (lines.length === 0) {
+    return '';
+  }
   if (lines.length === 1) {
     return cleanMarkdown(lines[0].trim());
   }

--- a/frontend/src/utils/titleExtractor.ts
+++ b/frontend/src/utils/titleExtractor.ts
@@ -1,0 +1,62 @@
+/**
+ * 从 AI 生成的结果中提取标题。
+ *
+ * 策略：
+ * 1. 去除首尾空白
+ * 2. 如果是纯文本（无 markdown），直接返回
+ * 3. 如果包含 markdown，尝试提取第一个标题或加粗文本
+ * 4. 如果都失败，返回清理后的文本
+ *
+ * 示例输入/输出：
+ * - "登录超时问题修复" → "登录超时问题修复"
+ * - "**登录超时问题修复**" → "登录超时问题修复"
+ * - "# 登录超时问题修复" → "登录超时问题修复"
+ * - "根据分析，建议改为：**登录超时问题修复**" → "登录超时问题修复"
+ */
+export function extractTitle(result: string): string {
+  if (!result) return '';
+
+  // 1. 去除首尾空白
+  let text = result.trim();
+
+  // 2. 尝试提取 markdown 标题 (# Title)
+  const headingMatch = text.match(/^#{1,6}\s+(.+)$/m);
+  if (headingMatch) {
+    return cleanMarkdown(headingMatch[1].trim());
+  }
+
+  // 3. 尝试提取加粗文本 (**text** 或 __text__)
+  const boldMatch = text.match(/\*\*(.+?)\*\*|__(.+?)__/);
+  if (boldMatch) {
+    return cleanMarkdown((boldMatch[1] || boldMatch[2]).trim());
+  }
+
+  // 4. 尝试提取引号内的文本 ("text" 或 「text」)
+  const quoteMatch = text.match(/["「](.+?)["」]/);
+  if (quoteMatch) {
+    return cleanMarkdown(quoteMatch[1].trim());
+  }
+
+  // 5. 如果只有一行，直接返回
+  const lines = text.split('\n').filter(l => l.trim());
+  if (lines.length === 1) {
+    return cleanMarkdown(lines[0].trim());
+  }
+
+  // 6. 多行文本：返回第一行（通常是标题）
+  return cleanMarkdown(lines[0].trim());
+}
+
+/**
+ * 清理 markdown 格式标记。
+ */
+function cleanMarkdown(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, '$1')   // **bold**
+    .replace(/__(.+?)__/g, '$1')         // __bold__
+    .replace(/\*(.+?)\*/g, '$1')         // *italic*
+    .replace(/_(.+?)_/g, '$1')           // _italic_
+    .replace(/`(.+?)`/g, '$1')           // `code`
+    .replace(/~~(.+?)~~/g, '$1')         // ~~strikethrough~~
+    .trim();
+}


### PR DESCRIPTION
## Summary

- 新增 `ActionButton` React 组件，支持一键 AI 执行，包含 Drawer UI
- 新增 `POST /api/actions/execute` 后端 API，支持 action_type + action_key 查找
- 如果 todo 不存在，自动创建（prompt 来自请求）
- DB 迁移 V45/V46：给 todos 表添加 action_type 和 action_key 列
- 在 TodoDetail 页面集成标题优化 demo
- 支持 prompt 模板语法 `{{key}}` 占位符替换

## 使用方式

```tsx
import { ActionButton } from '@/components/ActionButton';

<ActionButton
  actionType="title_optimize"
  actionKey="default"
  prompt={`你是一个标题优化专家。请根据以下信息生成更优的标题：

当前标题：{{title}}
当前 Prompt：{{prompt}}

请直接输出最优版本，不要加解释。`}
  params={{
    title: selectedTodo.title,
    prompt: selectedTodo.prompt || '',
  }}
  workspaceId={selectedTodo.workspace_id}
  onApply={handleTitleUpdate}
  panelTitle="优化标题"
>
  优化标题
</ActionButton>
```

## 属性说明

| 属性 | 类型 | 必填 | 说明 |
|------|------|------|------|
| `actionType` | `string` | ✅ | 动作类型（如 "title_optimize"） |
| `actionKey` | `string` | ✅ | 动作键值（如 "default"） |
| `prompt` | `string` | ✅ | Prompt 模板，支持 {{key}} 占位符 |
| `params` | `Record<string, string>` | ✅ | 模板参数 |
| `onApply` | `(result: string) => void` | ✅ | 应用回调 |
| `workspaceId` | `number` | ❌ | 工作空间 ID（不传则用默认） |

## 后端流程

1. 用 `action_type + action_key` 查找 todo
2. 找不到 → 自动创建 todo（prompt 来自请求）
3. 执行 todo，返回结果

## Test plan

- [x] 后端编译通过，958 个单元测试全部通过
- [x] 前端 TypeScript 编译通过
- [x] Vite 构建成功