### PR TITLE
fix: WorktreePathDisplay 改为 flex 居左对齐

### DIFF
--- a/frontend/src/components/todo-post/WorktreePathDisplay.tsx
+++ b/frontend/src/components/todo-post/WorktreePathDisplay.tsx
@@ -43,6 +43,7 @@ export function WorktreePathDisplay({ worktreePath }: WorktreePathDisplayProps) 
           lineHeight: 1.6,
           display: 'inline-flex',
           alignItems: 'center',
+          justifyContent: 'flex-start',
           gap: 6,
           overflow: 'hidden',
           textOverflow: 'ellipsis',


### PR DESCRIPTION
Ant Design Button 默认 justify-content: center，之前用 textAlign: 'left'
在 flex 容器中无效。改为 justifyContent: 'flex-start' 修复。