### PR TITLE
fix: 恢复回复按钮 + 楼层分组修复 + UI 优化

### DIFF
--- a/backend/src/executor_service/log_capture.rs
+++ b/backend/src/executor_service/log_capture.rs
@@ -303,6 +303,7 @@ pub(crate) fn spawn_stdout_reader<R>(
     task_id: String,
     record_id: i64,
     workspace_id: Option<i64>,
+    initial_session_id: Option<String>,
 ) -> Option<JoinHandle<()>>
 where
     R: AsyncRead + Unpin + Send + 'static,
@@ -324,7 +325,8 @@ where
         let mut reader = BufReader::new(stdout_reader).lines();
         let mut log_count = 0u64;
         // session_id 只更新一次：避免每次重复出现 session_id 时反复触发 DB UPDATE。
-        let mut session_id_updated = false;
+        // resume 场景下 DB 已有正确 session_id，跳过覆盖。
+        let mut session_id_updated = initial_session_id.is_some();
 
         while let Ok(Some(line)) = reader.next_line().await {
             // 优先尝试用 EventPipeline 解析
@@ -538,6 +540,7 @@ pub(crate) async fn setup_log_capture_pipeline<SO, SE>(
     task_id: String,
     record_id: i64,
     workspace_id: Option<i64>,
+    initial_session_id: Option<String>,
 ) -> (
     Arc<LogFlusher>,
     Option<JoinHandle<()>>,
@@ -564,6 +567,7 @@ where
         task_id.clone(),
         record_id,
         workspace_id,
+        initial_session_id,
     );
     let stderr_task = spawn_stderr_reader(
         stderr_handle,

--- a/backend/src/executor_service/spawn_lifecycle.rs
+++ b/backend/src/executor_service/spawn_lifecycle.rs
@@ -248,6 +248,7 @@ pub(crate) async fn setup_log_capture_pipeline_for(
         runtime.task_id.clone(),
         runtime.record_id,
         runtime.prepared.request.workspace_id,
+        runtime.prepared.request.resume_session_id.clone(),
     )
     .await
 }

--- a/frontend/src/components/todo-detail/ForumPostCard.tsx
+++ b/frontend/src/components/todo-detail/ForumPostCard.tsx
@@ -84,8 +84,26 @@ export function ForumPostCard({
         transition: 'background 0.15s, border-color 0.15s',
       }}
     >
-      {/* 第一行：状态 + 标题 + 追问 badge */}
+      {/* 第一行：#id + 标题 + 追问 badge + 状态 tag（最右） */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+        <span style={{ flexShrink: 0, fontSize: 11, color: 'var(--color-text-tertiary)', fontFamily: 'monospace' }}>
+          #{record.id}
+        </span>
+        <span style={{
+          fontSize: 13,
+          fontWeight: 600,
+          color: isRunning ? 'var(--color-info)' : 'var(--color-text)',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          flex: 1,
+          minWidth: 0,
+        }}>
+          {title}
+        </span>
+        {replyCount != null && replyCount > 0 && (
+          <Badge count={replyCount} size="small" style={{ backgroundColor: 'var(--color-primary)' }} />
+        )}
         <span style={{
           flexShrink: 0,
           fontSize: 10,
@@ -98,19 +116,6 @@ export function ForumPostCard({
         }}>
           {statusText}
         </span>
-        <span style={{
-          fontSize: 13,
-          fontWeight: 600,
-          color: isRunning ? 'var(--color-info)' : 'var(--color-text)',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}>
-          {title}
-        </span>
-        {replyCount != null && replyCount > 0 && (
-          <Badge count={replyCount} size="small" style={{ backgroundColor: 'var(--color-primary)' }} />
-        )}
       </div>
 
       {/* 第二行：元信息 */}

--- a/frontend/src/components/todo-list/TodoItemRow.tsx
+++ b/frontend/src/components/todo-list/TodoItemRow.tsx
@@ -116,7 +116,7 @@ export function TodoItemRow({
         data-testid={`todo-row-checkbox-${todo.id}`}
         style={{ position: 'absolute', top: 12, left: 12, zIndex: 1 }}
       />
-      <div className="todo-item-content">
+      <div className="todo-item-content" style={{ paddingLeft: 28 }}>
         <div className="todo-item-main">
           {/* 标题行：#id + 标题 + ExecutorBadge（紧凑排列，对齐 LoopCard 标题行） */}
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>

--- a/frontend/src/components/todo-post/PostCard.tsx
+++ b/frontend/src/components/todo-post/PostCard.tsx
@@ -156,16 +156,14 @@ export function PostCard({
         <CollapsibleCommand command={record.command} title="命令" />
       )}
 
-      {/* 记录 ID：便于在楼层中快速定位 */}
-      <span style={{ fontSize: 11, color: "var(--color-text-tertiary)", fontFamily: "monospace" }}>
-        #{record.id}
-      </span>
-
-      {/* 元信息 + 操作：执行器、时间、触发类型、评分、导出、统计 */}
+      {/* 元信息 + 操作：记录ID、执行器、时间、触发类型、评分、导出、统计 */}
       <div style={{
         display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap",
         marginTop: 8, fontSize: 12,
       }}>
+        <span style={{ fontSize: 11, color: "var(--color-text-tertiary)", fontFamily: "monospace" }}>
+          #{record.id}
+        </span>
         {record.executor && <ExecutorBadge executor={record.executor} />}
         {record.model && (
           <Tag color="#3b82f6" style={{ margin: 0, fontSize: 11 }}>

--- a/frontend/src/components/todo-post/PostCard.tsx
+++ b/frontend/src/components/todo-post/PostCard.tsx
@@ -156,6 +156,11 @@ export function PostCard({
         <CollapsibleCommand command={record.command} title="命令" />
       )}
 
+      {/* 记录 ID：便于在楼层中快速定位 */}
+      <span style={{ fontSize: 11, color: "var(--color-text-tertiary)", fontFamily: "monospace" }}>
+        #{record.id}
+      </span>
+
       {/* 元信息 + 操作：执行器、时间、触发类型、评分、导出、统计 */}
       <div style={{
         display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap",

--- a/frontend/src/components/todo-post/ReplyRow.tsx
+++ b/frontend/src/components/todo-post/ReplyRow.tsx
@@ -1,6 +1,7 @@
 // 回复输入行组件。
 
 import type { ExecutionRecord } from '@/types';
+import { supportsResume } from '@/types';
 import { ReplyInput } from '../todo-detail/ReplyInput';
 
 interface ReplyRowProps {
@@ -14,7 +15,7 @@ interface ReplyRowProps {
  */
 export function ReplyRow({ record, onReply, loading }: ReplyRowProps) {
   // 仅在 running 状态或不支持 resume 时不渲染
-  if (record.status === 'running' || !record.resume_message) return null;
+  if (!supportsResume(record)) return null;
   return (
     <div style={{ padding: "4px 0" }}>
       <ReplyInput record={record} onReply={onReply} loading={loading} />


### PR DESCRIPTION
## Summary

- 恢复执行历史楼层页面的回复按钮（重构时误改了 `supportsResume` 判断条件）
- 修复 resume 场景下 `session_id` 被 executor stdout 覆盖的问题，确保回复与原始执行在同一楼层分组
- todo 列表 `#id` 避开复选框遮挡
- 执行历史列表改为 `#recordid title` 格式，状态 tag 移至最右
- 楼层详情中执行器左侧显示 `#recordId`

## Changes

### 后端
- `log_capture.rs`: `spawn_stdout_reader` 新增 `initial_session_id` 参数，resume 时跳过 session_id 覆盖
- `spawn_lifecycle.rs`: 传递 `resume_session_id` 到 log capture

### 前端
- `ReplyRow.tsx`: 恢复 `supportsResume(record)` 判断（替代错误的 `record.resume_message`）
- `TodoItemRow.tsx`: content 区域 `paddingLeft: 28` 避开复选框
- `ForumPostCard.tsx`: 第一行改为 `#recordid + title`，状态 tag 最右
- `PostCard.tsx`: 楼层元信息行新增 `#recordId` 显示

### DB
- 手动修正 record 6164/6170 的 session_id 与 6163 对齐