### PR TITLE
feat(cli): add ntd loop execution blackboard command

### DIFF
--- a/backend/ARCHITECTURE.md
+++ b/backend/ARCHITECTURE.md
@@ -218,17 +218,22 @@ erDiagram
         i64 id PK
         i64 loop_id FK
         string status
-        string blackboard
         string started_at
         string finished_at
     }
 
+    // 「黑板」并不是一个独立列,而是 loop_step_executions.conclusion 按
+    // sequence_index ASC 排序后渲染的虚拟视图。运行时通过 `build_blackboard_text`
+    // 在每步执行前组装（services/loop_runner.rs），注入到下一步的 prompt。
+    // CLI 端用 `ntd loop execution blackboard <eid>` 查看（docs/loop-blackboard-cli.md）。
     loop_step_executions {
         i64 id PK
         i64 loop_execution_id FK
         i64 loop_step_id FK
         i64 execution_record_id FK
         string status
+        i32 sequence_index
+        string conclusion  "黑板写入内容"
     }
 
     loop_tags {

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -353,6 +353,16 @@ pub enum LoopExecutionAction {
         /// Execution ID
         execution_id: i64,
     },
+    /// Show the blackboard (accumulated step conclusions) for a loop execution.
+    /// 默认输出人类可读视图; 加 --json 输出原始 JSON,便于脚本消费。
+    Blackboard {
+        /// Execution ID
+        execution_id: i64,
+
+        /// 输出原始 JSON（默认是人类可读黑板视图）
+        #[arg(long, default_value = "false")]
+        json: bool,
+    },
 }
 
 // ============== Helper Functions ==============
@@ -798,6 +808,26 @@ async fn handle_loop(
                     )).await?;
                     print_response(resp, output, fields)?;
                 }
+                LoopExecutionAction::Blackboard { execution_id, json } => {
+                    // 复用 get_execution_by_id handler 返回的 LoopExecutionDetail,
+                    // 它已经按 sequence_index 升序返回 step_executions。
+                    // 不新增 API 端点 — 黑板视图本质就是 step_executions 的渲染。
+                    let resp: ClientResponse<serde_json::Value> = client.get(&format!(
+                        "/loop-executions/{}",
+                        execution_id
+                    )).await?;
+                    if resp.code != 0 {
+                        // 与 print_response 一致:错误码非 0 时抛 anyhow
+                        return Err(anyhow::anyhow!("API error {}: {}", resp.code, resp.message));
+                    }
+                    if *json {
+                        // JSON 模式: 输出 data 字段的原始 JSON, 跳过 ApiResponse 包装层
+                        println!("{}", serde_json::to_string_pretty(&resp.data)?);
+                    } else {
+                        // 默认: 黑板视图
+                        render_blackboard(resp.data.as_ref());
+                    }
+                }
             }
         }
     }
@@ -839,6 +869,168 @@ fn print_response<T: serde::Serialize>(
         }
     }
     Ok(())
+}
+
+// ============== Blackboard Rendering ==============
+
+/// 把 step.status 映射到人类可读的 emoji，与前端 `BlackboardDrawer.tsx` 保持一致。
+/// 未知状态使用 ❔ 而非抛错，避免数据库新增状态时让旧 CLI 直接崩溃。
+fn status_icon(status: &str) -> &'static str {
+    match status {
+        "success" => "✅",
+        "failed" => "❌",
+        "running" => "⏳",
+        "pending" => "⏸ ",
+        "pending_approval" => "🤔",
+        "skipped" => "⏭️",
+        _ => "❔",
+    }
+}
+
+/// 把 LoopExecutionDetail 渲染成人类可读的黑板视图。
+///
+/// 输入是 `serde_json::Value`（来自 ApiClient 的反序列化结果），不是强类型，
+/// 是因为这个函数唯一的调用点在 CLI 命令分发处，没必要为它再定义一个 DTO。
+/// 如果渲染失败（字段缺失或类型错误），降级输出原始 JSON + 错误提示，
+/// 而不是让 CLI 崩溃——黑板视图是辅助功能，不能阻塞主流程。
+fn render_blackboard(data: Option<&Value>) {
+    let Some(data) = data else {
+        println!("(无数据)");
+        return;
+    };
+
+    let exec_id = data.get("id").and_then(Value::as_i64).unwrap_or(0);
+    let loop_name = data.get("loop_name").and_then(Value::as_str).unwrap_or("?");
+    let trigger_meta = data.get("trigger_meta").and_then(Value::as_str).unwrap_or("");
+    let status = data.get("status").and_then(Value::as_str).unwrap_or("unknown");
+    let total = data.get("total_steps").and_then(Value::as_i64).unwrap_or(0);
+    let completed = data.get("completed_steps").and_then(Value::as_i64).unwrap_or(0);
+    let started = data.get("started_at").and_then(Value::as_str).unwrap_or("");
+    let finished = data.get("finished_at").and_then(Value::as_str).unwrap_or("");
+
+    println!("═══ Loop Execution #{exec_id} ────────────────────────────────");
+    println!("循环: {loop_name}");
+    if !trigger_meta.is_empty() && trigger_meta != "{}" {
+        println!("触发: {trigger_meta}");
+    }
+    println!(
+        "状态: {} {} · 完成 {}/{} 步",
+        status_icon(status),
+        status,
+        completed,
+        total
+    );
+    if !started.is_empty() {
+        let end_part = if !finished.is_empty() {
+            format!(" · 结束: {finished}")
+        } else {
+            String::new()
+        };
+        println!("开始: {started}{end_part}");
+    }
+    println!();
+
+    let steps = data.get("step_executions").and_then(Value::as_array);
+    let Some(steps) = steps else {
+        println!("(step_executions 字段缺失或类型错误)");
+        println!("\n原始数据:\n{}", serde_json::to_string_pretty(data).unwrap_or_default());
+        return;
+    };
+
+    if steps.is_empty() {
+        println!("黑板为空（loop 尚未执行任何步骤）");
+        println!();
+    } else {
+        for step in steps {
+            render_blackboard_step(step);
+        }
+        println!();
+    }
+
+    // Token 汇总：LoopExecutionDetail.token_summary 是独立字段
+    if let Some(ts) = data.get("token_summary") {
+        let ti = ts.get("total_input_tokens").and_then(Value::as_i64).unwrap_or(0);
+        let to = ts.get("total_output_tokens").and_then(Value::as_i64).unwrap_or(0);
+        println!("═══ {} 步 / Token: 输入 {} 输出 {} ════════════════════════", steps.len(), ti, to);
+    } else {
+        println!("═══ {} 步 ═══════════════════════════════════════════════════", steps.len());
+    }
+}
+
+/// 渲染单个 step 块。
+/// 字段名与 `LoopStepExecutionDto` 一致（见 `backend/src/models/loop_.rs`）。
+fn render_blackboard_step(step: &Value) {
+    let seq = step.get("sequence_index").and_then(Value::as_i64).unwrap_or(0);
+    let status = step.get("status").and_then(Value::as_str).unwrap_or("unknown");
+    // step_name 为 None 时回退到 "step #{step_id}"，异常处理步骤（step_id=-1）显示「异常处理」
+    let step_name = match (
+        step.get("step_name").and_then(Value::as_str),
+        step.get("step_id").and_then(Value::as_i64),
+    ) {
+        (Some(name), _) if !name.is_empty() => name.to_string(),
+        (None, Some(-1)) => "异常处理".to_string(),
+        (_, Some(sid)) => format!("step #{sid}"),
+        (_, None) => "(未知环节)".to_string(),
+    };
+    let rating = step
+        .get("rating")
+        .and_then(Value::as_i64)
+        .map(|r| r.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let exec_id = step
+        .get("execution_record_id")
+        .and_then(Value::as_i64)
+        .map(|r| format!("#{r}"))
+        .unwrap_or_else(|| "-".to_string());
+
+    println!(
+        "  #{seq} {} {:<22} 评分 {rating}",
+        status_icon(status),
+        truncate(&step_name, 22),
+    );
+    println!("     exec: {exec_id}");
+
+    // 结论展示：优先级为 approval_comment (pending_approval) > conclusion > error_message > (无结论)
+    if status == "pending_approval" {
+        if let Some(comment) = step.get("approval_comment").and_then(Value::as_str) {
+            if !comment.is_empty() {
+                println!("     待审批意见: {comment}");
+            }
+        }
+        println!("     (等待人工审批)");
+    } else if let Some(err) = step.get("error_message").and_then(Value::as_str) {
+        if !err.is_empty() {
+            println!("     失败: {err}");
+        }
+        if let Some(c) = step.get("conclusion").and_then(Value::as_str) {
+            if !c.is_empty() {
+                println!("     结论: {c}");
+            }
+        }
+    } else if let Some(c) = step.get("conclusion").and_then(Value::as_str) {
+        if !c.is_empty() {
+            // 多行结论：保留缩进让层级清晰
+            for line in c.lines() {
+                println!("     {line}");
+            }
+        } else {
+            println!("     (无结论)");
+        }
+    } else {
+        println!("     (无结论)");
+    }
+}
+
+/// 截断字符串到指定字符宽度（按 char 边界，安全处理 UTF-8）。
+/// 中文/全角字符按 1 个单位计算，与终端实际宽度一致。
+fn truncate(s: &str, max: usize) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() <= max {
+        return s.to_string();
+    }
+    let mut out: String = chars.into_iter().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
 }
 
 // ============== Tests ==============
@@ -1032,5 +1224,196 @@ mod tests {
             }
             _ => panic!("Expected Todo::Execution::Resume with message"),
         }
+    }
+
+    // ===== Blackboard CLI tests =====
+
+    #[test]
+    fn test_cli_parse_loop_execution_blackboard() {
+        // 校验命令行解析：ntd loop execution blackboard 42
+        let cli = Cli::try_parse_from(["ntd", "loop", "execution", "blackboard", "42"]).unwrap();
+        match cli.command {
+            Commands::Loop { action: LoopAction::Execution { action: LoopExecutionAction::Blackboard { execution_id, json } } } => {
+                assert_eq!(execution_id, 42);
+                assert!(!json);
+            }
+            _ => panic!("Expected Loop::Execution::Blackboard"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_loop_execution_blackboard_json() {
+        // --json 开关
+        let cli = Cli::try_parse_from(["ntd", "loop", "execution", "blackboard", "42", "--json"]).unwrap();
+        match cli.command {
+            Commands::Loop { action: LoopAction::Execution { action: LoopExecutionAction::Blackboard { execution_id, json } } } => {
+                assert_eq!(execution_id, 42);
+                assert!(json);
+            }
+            _ => panic!("Expected Loop::Execution::Blackboard with --json"),
+        }
+    }
+
+    #[test]
+    fn test_status_icon_known() {
+        // 已知状态全部映射到正确 emoji
+        assert_eq!(status_icon("success"), "✅");
+        assert_eq!(status_icon("failed"), "❌");
+        assert_eq!(status_icon("running"), "⏳");
+        assert_eq!(status_icon("pending"), "⏸ ");
+        assert_eq!(status_icon("pending_approval"), "🤔");
+        assert_eq!(status_icon("skipped"), "⏭️");
+    }
+
+    #[test]
+    fn test_status_icon_unknown() {
+        // 未知状态降级为 ❔ 而非 panic — 数据库可能新增 status 时不应让旧 CLI 崩溃
+        assert_eq!(status_icon("something_new"), "❔");
+        assert_eq!(status_icon(""), "❔");
+    }
+
+    #[test]
+    fn test_truncate_short() {
+        // 短于阈值原样返回
+        assert_eq!(truncate("hello", 10), "hello");
+        assert_eq!(truncate("中文测试", 10), "中文测试");
+    }
+
+    #[test]
+    fn test_truncate_long() {
+        // 超长截断到阈值-1 + 省略号，避免 panic 在 UTF-8 字符边界
+        let s = "this is a very long step name that exceeds limit";
+        let out = truncate(s, 10);
+        assert_eq!(out.chars().count(), 10);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn test_truncate_utf8_safe() {
+        // 截断点落在多字节字符中间时不能 panic
+        let s = "中文abcdefghij";
+        let out = truncate(s, 5);
+        assert!(out.chars().count() <= 5);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn test_render_blackboard_none() {
+        // data 为 None 时输出降级提示，不 panic
+        render_blackboard(None);
+    }
+
+    #[test]
+    fn test_render_blackboard_normal() {
+        // 正常 3 step 全 success：断言输出包含关键字段
+        let data = json!({
+            "id": 42,
+            "loop_name": "每日代码 review",
+            "trigger_meta": "cron @ 0 9 * * *",
+            "status": "success",
+            "total_steps": 3,
+            "completed_steps": 3,
+            "started_at": "2026-07-03 09:00:00",
+            "finished_at": "2026-07-03 09:45:32",
+            "step_executions": [
+                {"sequence_index": 1, "step_id": 1, "step_name": "编写 CRUD 代码", "status": "success", "rating": 85, "execution_record_id": 1024, "conclusion": "完成了用户登录功能的 CRUD 代码"},
+                {"sequence_index": 2, "step_id": 2, "step_name": "补充单元测试", "status": "success", "rating": 90, "execution_record_id": 1025, "conclusion": "新增 12 个测试用例，覆盖率提升到 87%"},
+                {"sequence_index": 3, "step_id": 3, "step_name": "更新 README", "status": "success", "rating": 75, "execution_record_id": 1026, "conclusion": "更新了安装步骤"}
+            ],
+            "token_summary": {"total_input_tokens": 12000, "total_output_tokens": 5000}
+        });
+        render_blackboard(Some(&data));
+        // 渲染函数直接 println，单元测试只验证它不 panic；
+        // 真实输出验证放在手动测试或集成测试。
+    }
+
+    #[test]
+    fn test_render_blackboard_no_record_id() {
+        // execution_record_id 为 None 时不应 panic
+        let data = json!({
+            "id": 1,
+            "loop_name": "L",
+            "status": "running",
+            "total_steps": 1,
+            "completed_steps": 0,
+            "step_executions": [
+                {"sequence_index": 1, "step_id": 1, "step_name": "等待中", "status": "pending", "conclusion": null, "execution_record_id": null}
+            ]
+        });
+        render_blackboard(Some(&data));
+    }
+
+    #[test]
+    fn test_render_blackboard_empty() {
+        // step_executions 为空时显示「黑板为空」提示
+        let data = json!({
+            "id": 1,
+            "loop_name": "L",
+            "status": "pending",
+            "total_steps": 0,
+            "completed_steps": 0,
+            "step_executions": []
+        });
+        render_blackboard(Some(&data));
+    }
+
+    #[test]
+    fn test_render_blackboard_failed() {
+        // failed step：有 error_message 但无 conclusion 时，error_message 替代结论
+        let data = json!({
+            "id": 1,
+            "loop_name": "L",
+            "status": "failed",
+            "total_steps": 2,
+            "completed_steps": 1,
+            "step_executions": [
+                {"sequence_index": 1, "step_id": 1, "step_name": "成功步骤", "status": "success", "rating": 80, "conclusion": "ok"},
+                {"sequence_index": 2, "step_id": 2, "step_name": "失败步骤", "status": "failed", "error_message": "执行超时", "conclusion": null, "execution_record_id": null}
+            ]
+        });
+        render_blackboard(Some(&data));
+    }
+
+    #[test]
+    fn test_render_blackboard_pending_approval() {
+        // pending_approval：显示 approval_comment + 待审批提示
+        let data = json!({
+            "id": 1,
+            "loop_name": "L",
+            "status": "running",
+            "total_steps": 1,
+            "completed_steps": 0,
+            "step_executions": [
+                {"sequence_index": 1, "step_id": 1, "step_name": "需要审批", "status": "pending_approval", "approval_comment": "请确认改动", "conclusion": null}
+            ]
+        });
+        render_blackboard(Some(&data));
+    }
+
+    #[test]
+    fn test_render_blackboard_anomaly_handler() {
+        // step_id=-1 → 显示「异常处理」
+        let data = json!({
+            "id": 1,
+            "loop_name": "L",
+            "status": "failed",
+            "total_steps": 2,
+            "completed_steps": 1,
+            "step_executions": [
+                {"sequence_index": 999, "step_id": -1, "step_name": null, "status": "failed", "conclusion": "触发异常处理流程"}
+            ]
+        });
+        render_blackboard(Some(&data));
+    }
+
+    #[test]
+    fn test_render_blackboard_missing_step_executions() {
+        // step_executions 字段缺失时降级：打印提示 + 原始数据，不 panic
+        let data = json!({
+            "id": 1,
+            "loop_name": "L",
+            "status": "running"
+        });
+        render_blackboard(Some(&data));
     }
 }

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -887,18 +887,58 @@ fn status_icon(status: &str) -> &'static str {
     }
 }
 
-/// 把 LoopExecutionDetail 渲染成人类可读的黑板视图。
+/// 把 LoopExecutionDetail 渲染成人类可读的黑板视图（写到 stdout）。
 ///
-/// 输入是 `serde_json::Value`（来自 ApiClient 的反序列化结果），不是强类型，
-/// 是因为这个函数唯一的调用点在 CLI 命令分发处，没必要为它再定义一个 DTO。
-/// 如果渲染失败（字段缺失或类型错误），降级输出原始 JSON + 错误提示，
+/// 输入是 `Option<&serde_json::Value>` —— None 时由调用方传入表示「API 返回
+/// 的 data 字段为 null」，本函数显式处理这种情况而不是强制调用方过滤，
+/// 让 dispatch 层代码更扁平。
+///
+/// 渲染失败（字段缺失或类型错误）时降级输出原始 JSON + 错误提示，
 /// 而不是让 CLI 崩溃——黑板视图是辅助功能，不能阻塞主流程。
 fn render_blackboard(data: Option<&Value>) {
+    let mut buf: Vec<u8> = Vec::new();
+    render_blackboard_to(data, &mut buf);
+    // CLI 入口把 buf 一次性 flush 到 stdout, 而不是 println! 散落到各 helper,
+    // 这样测试也能通过 render_blackboard_to 抓取完整输出。
+    use std::io::Write;
+    let _ = std::io::stdout().write_all(&buf);
+}
+
+/// 把黑板渲染到任意 `Write` 目标，单元测试用 `Vec<u8>` 抓取输出做断言。
+/// 所有 println! 在这里都改成 writeln!，避免分散在 helper 里写死 stdout。
+fn render_blackboard_to<W: std::io::Write>(data: Option<&Value>, w: &mut W) {
     let Some(data) = data else {
-        println!("(无数据)");
+        let _ = writeln!(w, "(无数据)");
         return;
     };
 
+    write_blackboard_header(data, w);
+    let _ = writeln!(w);
+
+    match data.get("step_executions").and_then(Value::as_array) {
+        Some(steps) if !steps.is_empty() => {
+            for step in steps {
+                write_blackboard_step(step, w);
+            }
+            let _ = writeln!(w);
+            write_blackboard_footer(data, steps.len(), w);
+        }
+        Some(_) => {
+            let _ = writeln!(w, "黑板为空（loop 尚未执行任何步骤）");
+            let _ = writeln!(w);
+            write_blackboard_footer(data, 0, w);
+        }
+        None => {
+            let _ = writeln!(w, "(step_executions 字段缺失或类型错误)");
+            let _ = writeln!(w, "\n原始数据:\n{}", serde_json::to_string_pretty(data).unwrap_or_default());
+        }
+    }
+}
+
+/// 渲染黑板头部：循环名、触发信息、状态、时间。
+/// 字段全部缺失时降级为占位符，不影响主流程。
+fn write_blackboard_header<W: std::io::Write>(data: &Value, w: &mut W) {
+    use std::io::Write;
     let exec_id = data.get("id").and_then(Value::as_i64).unwrap_or(0);
     let loop_name = data.get("loop_name").and_then(Value::as_str).unwrap_or("?");
     let trigger_meta = data.get("trigger_meta").and_then(Value::as_str).unwrap_or("");
@@ -908,12 +948,13 @@ fn render_blackboard(data: Option<&Value>) {
     let started = data.get("started_at").and_then(Value::as_str).unwrap_or("");
     let finished = data.get("finished_at").and_then(Value::as_str).unwrap_or("");
 
-    println!("═══ Loop Execution #{exec_id} ────────────────────────────────");
-    println!("循环: {loop_name}");
+    let _ = writeln!(w, "═══ Loop Execution #{exec_id} ────────────────────────────────");
+    let _ = writeln!(w, "循环: {loop_name}");
     if !trigger_meta.is_empty() && trigger_meta != "{}" {
-        println!("触发: {trigger_meta}");
+        let _ = writeln!(w, "触发: {trigger_meta}");
     }
-    println!(
+    let _ = writeln!(
+        w,
         "状态: {} {} · 完成 {}/{} 步",
         status_icon(status),
         status,
@@ -926,42 +967,48 @@ fn render_blackboard(data: Option<&Value>) {
         } else {
             String::new()
         };
-        println!("开始: {started}{end_part}");
-    }
-    println!();
-
-    let steps = data.get("step_executions").and_then(Value::as_array);
-    let Some(steps) = steps else {
-        println!("(step_executions 字段缺失或类型错误)");
-        println!("\n原始数据:\n{}", serde_json::to_string_pretty(data).unwrap_or_default());
-        return;
-    };
-
-    if steps.is_empty() {
-        println!("黑板为空（loop 尚未执行任何步骤）");
-        println!();
-    } else {
-        for step in steps {
-            render_blackboard_step(step);
-        }
-        println!();
-    }
-
-    // Token 汇总：LoopExecutionDetail.token_summary 是独立字段
-    if let Some(ts) = data.get("token_summary") {
-        let ti = ts.get("total_input_tokens").and_then(Value::as_i64).unwrap_or(0);
-        let to = ts.get("total_output_tokens").and_then(Value::as_i64).unwrap_or(0);
-        println!("═══ {} 步 / Token: 输入 {} 输出 {} ════════════════════════", steps.len(), ti, to);
-    } else {
-        println!("═══ {} 步 ═══════════════════════════════════════════════════", steps.len());
+        let _ = writeln!(w, "开始: {started}{end_part}");
     }
 }
 
-/// 渲染单个 step 块。
+/// 渲染黑板尾部：步骤总数 + Token 汇总（如果有）。
+/// Token 汇总来自 LoopExecutionDetail.token_summary，与 step_executions 平级。
+fn write_blackboard_footer<W: std::io::Write>(data: &Value, step_count: usize, w: &mut W) {
+    use std::io::Write;
+    if let Some(ts) = data.get("token_summary") {
+        let ti = ts.get("total_input_tokens").and_then(Value::as_i64).unwrap_or(0);
+        let to = ts.get("total_output_tokens").and_then(Value::as_i64).unwrap_or(0);
+        let _ = writeln!(w, "═══ {} 步 / Token: 输入 {} 输出 {} ════════════════════════", step_count, ti, to);
+    } else {
+        let _ = writeln!(w, "═══ {} 步 ═══════════════════════════════════════════════════", step_count);
+    }
+}
+
+/// 渲染单个 step 块（标题行 + exec id + 多行结论）。
 /// 字段名与 `LoopStepExecutionDto` 一致（见 `backend/src/models/loop_.rs`）。
-fn render_blackboard_step(step: &Value) {
+fn write_blackboard_step<W: std::io::Write>(step: &Value, w: &mut W) {
+    use std::io::Write;
+    let header = format_step_header(step);
+    let _ = writeln!(w, "  {header}");
+    let exec_id = step
+        .get("execution_record_id")
+        .and_then(Value::as_i64)
+        .map(|r| format!("#{r}"))
+        .unwrap_or_else(|| "-".to_string());
+    let _ = writeln!(w, "     exec: {exec_id}");
+    write_step_body(step, w);
+}
+
+/// 格式化 step 标题行：`#<seq> <icon> <name(padded to 22)> 评分 <rating>`。
+/// 名字用 display-width-aware 截断，避免中文字符把对齐打乱。
+fn format_step_header(step: &Value) -> String {
     let seq = step.get("sequence_index").and_then(Value::as_i64).unwrap_or(0);
     let status = step.get("status").and_then(Value::as_str).unwrap_or("unknown");
+    let rating = step
+        .get("rating")
+        .and_then(Value::as_i64)
+        .map(|r| r.to_string())
+        .unwrap_or_else(|| "-".to_string());
     // step_name 为 None 时回退到 "step #{step_id}"，异常处理步骤（step_id=-1）显示「异常处理」
     let step_name = match (
         step.get("step_name").and_then(Value::as_str),
@@ -972,63 +1019,81 @@ fn render_blackboard_step(step: &Value) {
         (_, Some(sid)) => format!("step #{sid}"),
         (_, None) => "(未知环节)".to_string(),
     };
-    let rating = step
-        .get("rating")
-        .and_then(Value::as_i64)
-        .map(|r| r.to_string())
-        .unwrap_or_else(|| "-".to_string());
-    let exec_id = step
-        .get("execution_record_id")
-        .and_then(Value::as_i64)
-        .map(|r| format!("#{r}"))
-        .unwrap_or_else(|| "-".to_string());
-
-    println!(
-        "  #{seq} {} {:<22} 评分 {rating}",
+    // 按终端显示宽度截断（中文/Emoji 按 2 计算），并 pad 空格让「评分」列对齐。
+    let padded = truncate_to_width(&step_name, 22);
+    format!(
+        "#{seq} {} {:<22} 评分 {rating}",
         status_icon(status),
-        truncate(&step_name, 22),
-    );
-    println!("     exec: {exec_id}");
+        padded,
+    )
+}
 
-    // 结论展示：优先级为 approval_comment (pending_approval) > conclusion > error_message > (无结论)
+/// 写 step 正文：结论 / 错误 / 待审批意见。
+/// 优先级：pending_approval 的 approval_comment > error_message > conclusion > (无结论)。
+fn write_step_body<W: std::io::Write>(step: &Value, w: &mut W) {
+    use std::io::Write;
+    let status = step.get("status").and_then(Value::as_str).unwrap_or("unknown");
     if status == "pending_approval" {
         if let Some(comment) = step.get("approval_comment").and_then(Value::as_str) {
             if !comment.is_empty() {
-                println!("     待审批意见: {comment}");
+                let _ = writeln!(w, "     待审批意见: {comment}");
             }
         }
-        println!("     (等待人工审批)");
-    } else if let Some(err) = step.get("error_message").and_then(Value::as_str) {
+        let _ = writeln!(w, "     (等待人工审批)");
+        return;
+    }
+    if let Some(err) = step.get("error_message").and_then(Value::as_str) {
         if !err.is_empty() {
-            println!("     失败: {err}");
+            let _ = writeln!(w, "     失败: {err}");
         }
-        if let Some(c) = step.get("conclusion").and_then(Value::as_str) {
-            if !c.is_empty() {
-                println!("     结论: {c}");
-            }
-        }
-    } else if let Some(c) = step.get("conclusion").and_then(Value::as_str) {
-        if !c.is_empty() {
+    }
+    match step.get("conclusion").and_then(Value::as_str) {
+        Some(c) if !c.is_empty() => {
             // 多行结论：保留缩进让层级清晰
             for line in c.lines() {
-                println!("     {line}");
+                let _ = writeln!(w, "     {line}");
             }
-        } else {
-            println!("     (无结论)");
         }
-    } else {
-        println!("     (无结论)");
+        _ => {
+            let _ = writeln!(w, "     (无结论)");
+        }
     }
 }
 
-/// 截断字符串到指定字符宽度（按 char 边界，安全处理 UTF-8）。
-/// 中文/全角字符按 1 个单位计算，与终端实际宽度一致。
-fn truncate(s: &str, max: usize) -> String {
-    let chars: Vec<char> = s.chars().collect();
-    if chars.len() <= max {
-        return s.to_string();
+/// 截断字符串到指定「终端显示宽度」（display width），按 char 边界安全处理 UTF-8。
+/// ASCII 按 1 计算宽度，CJK（>= U+0080）按 2。
+/// 注意：emoji 的实际宽度因字体而异，这里按统一近似计算；
+/// 真正的 terminal width 需要 unicode-width crate，但对黑板视图而言够用。
+///
+/// 输出长度恒等于 max_width：不足时右补空格（让对齐列就位），超出时截断到
+/// `max_width - 1` 个 width 后追加 `…` 占第 max_width 个 width。
+fn truncate_to_width(s: &str, max_width: usize) -> String {
+    // 第一遍: 计算 s 的真实 display width
+    let total: usize = s
+        .chars()
+        .map(|c| if (c as u32) < 0x80 { 1 } else { 2 })
+        .sum();
+    if total <= max_width {
+        // 短于阈值: 原样 + 补空格到 max_width
+        let mut out = String::with_capacity(max_width);
+        out.push_str(s);
+        for _ in 0..(max_width - total) {
+            out.push(' ');
+        }
+        return out;
     }
-    let mut out: String = chars.into_iter().take(max.saturating_sub(1)).collect();
+    // 超长: 截到 max_width - 1 个 width 的字符 + … = max_width
+    let mut out = String::with_capacity(max_width);
+    let mut w = 0usize;
+    let target = max_width.saturating_sub(1); // 留给 … 的位置
+    for c in s.chars() {
+        let cw = if (c as u32) < 0x80 { 1 } else { 2 };
+        if w + cw > target {
+            break;
+        }
+        out.push(c);
+        w += cw;
+    }
     out.push('…');
     out
 }
@@ -1274,39 +1339,50 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_short() {
-        // 短于阈值原样返回
-        assert_eq!(truncate("hello", 10), "hello");
-        assert_eq!(truncate("中文测试", 10), "中文测试");
+    fn test_truncate_to_width_short() {
+        // 短于阈值: 原样返回 + 补 pad 空格到 max_width
+        assert_eq!(truncate_to_width("hello", 10), "hello     ");
+        // 中文按 2 计算宽度, 4 个中文 = 8, 小于 10, pad 2 个空格
+        assert_eq!(truncate_to_width("中文测试", 10), "中文测试  ");
     }
 
     #[test]
-    fn test_truncate_long() {
-        // 超长截断到阈值-1 + 省略号，避免 panic 在 UTF-8 字符边界
+    fn test_truncate_to_width_ascii_overflow() {
+        // 超长 ASCII 截断: 末尾加 … 占第 max_width 位, 总长 = max_width
         let s = "this is a very long step name that exceeds limit";
-        let out = truncate(s, 10);
+        let out = truncate_to_width(s, 10);
+        // 9 个 ASCII + … = 10 字符, 总长 == max_width
+        assert_eq!(out, "this is a…");
         assert_eq!(out.chars().count(), 10);
-        assert!(out.ends_with('…'));
     }
 
     #[test]
-    fn test_truncate_utf8_safe() {
-        // 截断点落在多字节字符中间时不能 panic
-        let s = "中文abcdefghij";
-        let out = truncate(s, 5);
-        assert!(out.chars().count() <= 5);
-        assert!(out.ends_with('…'));
+    fn test_truncate_to_width_cjk_safe() {
+        // 中文按 2 计算宽度, 「中文abcdefghij」: 中(2)文(2)a(1)b(1)c(1)d(1)e(1)f(1)g(1)h(1)i(1)j(1) = 13
+        // 截断到 max_width=5: 留 1 个位置给 …, 所以填充 4 个 width 的字符 = 「中文」 (4), 再 + … = 5
+        let out = truncate_to_width("中文abcdefghij", 5);
+        assert_eq!(out, "中文…");
     }
 
+    #[test]
+    fn test_truncate_to_width_exact() {
+        // 宽度刚好等于 max_width 时, 不截断也不加 …
+        assert_eq!(truncate_to_width("hello", 5), "hello");
+        // 「中文ab」= 2+2+1+1=6, max_width=6, 刚好填满
+        assert_eq!(truncate_to_width("中文ab", 6), "中文ab");
+    }
+
+    /// 截断到指定 display width 的 helper 测试。
     #[test]
     fn test_render_blackboard_none() {
-        // data 为 None 时输出降级提示，不 panic
+        // data 为 None 时输出降级提示, 不 panic
+        // 内部只 println, 不返回 String, 此测试只验不崩溃
         render_blackboard(None);
     }
 
     #[test]
     fn test_render_blackboard_normal() {
-        // 正常 3 step 全 success：断言输出包含关键字段
+        // 正常 3 step 全 success: 不 panic
         let data = json!({
             "id": 42,
             "loop_name": "每日代码 review",
@@ -1318,14 +1394,98 @@ mod tests {
             "finished_at": "2026-07-03 09:45:32",
             "step_executions": [
                 {"sequence_index": 1, "step_id": 1, "step_name": "编写 CRUD 代码", "status": "success", "rating": 85, "execution_record_id": 1024, "conclusion": "完成了用户登录功能的 CRUD 代码"},
-                {"sequence_index": 2, "step_id": 2, "step_name": "补充单元测试", "status": "success", "rating": 90, "execution_record_id": 1025, "conclusion": "新增 12 个测试用例，覆盖率提升到 87%"},
+                {"sequence_index": 2, "step_id": 2, "step_name": "补充单元测试", "status": "success", "rating": 90, "execution_record_id": 1025, "conclusion": "新增 12 个测试用例"},
                 {"sequence_index": 3, "step_id": 3, "step_name": "更新 README", "status": "success", "rating": 75, "execution_record_id": 1026, "conclusion": "更新了安装步骤"}
             ],
             "token_summary": {"total_input_tokens": 12000, "total_output_tokens": 5000}
         });
         render_blackboard(Some(&data));
-        // 渲染函数直接 println，单元测试只验证它不 panic；
-        // 真实输出验证放在手动测试或集成测试。
+    }
+
+    #[test]
+    fn test_render_blackboard_normal_assert_output() {
+        // 把 render_blackboard 的输出抓到字符串, 断言关键片段, 防止回归。
+        let data = json!({
+            "id": 42,
+            "loop_name": "L",
+            "status": "success",
+            "total_steps": 1,
+            "completed_steps": 1,
+            "step_executions": [
+                {"sequence_index": 1, "step_id": 1, "step_name": "S1", "status": "success", "rating": 85, "execution_record_id": 1024, "conclusion": "ok"}
+            ]
+        });
+        let out = render_blackboard_to_string(Some(&data));
+        // 头部: 包含 exec id 和循环名
+        assert!(out.contains("Loop Execution #42"), "missing exec id header: {out}");
+        assert!(out.contains("循环: L"), "missing loop name: {out}");
+        // 状态行: 包含图标和进度
+        assert!(out.contains("✅"), "missing success icon: {out}");
+        assert!(out.contains("完成 1/1 步"), "missing progress: {out}");
+        // step 标题: 序号 + 图标 + 评分
+        assert!(out.contains("#1"), "missing seq: {out}");
+        assert!(out.contains("评分 85"), "missing rating: {out}");
+        // exec 行
+        assert!(out.contains("exec: #1024"), "missing exec id: {out}");
+        // 结论多行
+        assert!(out.contains("ok"), "missing conclusion: {out}");
+    }
+
+    #[test]
+    fn test_render_blackboard_failed_assert_output() {
+        // failed: 有 error_message 但无 conclusion 时, error_message 替代结论
+        let data = json!({
+            "id": 1,
+            "loop_name": "L",
+            "status": "failed",
+            "total_steps": 1,
+            "completed_steps": 0,
+            "step_executions": [
+                {"sequence_index": 1, "step_id": 1, "step_name": "失败步骤", "status": "failed", "error_message": "执行超时", "conclusion": null, "execution_record_id": null}
+            ]
+        });
+        let out = render_blackboard_to_string(Some(&data));
+        assert!(out.contains("❌"), "missing failed icon: {out}");
+        assert!(out.contains("失败: 执行超时"), "missing error message: {out}");
+        assert!(out.contains("(无结论)"), "missing fallback conclusion: {out}");
+        assert!(out.contains("exec: -"), "missing record id fallback: {out}");
+    }
+
+    #[test]
+    fn test_render_blackboard_pending_approval_assert_output() {
+        let data = json!({
+            "id": 1,
+            "loop_name": "L",
+            "status": "running",
+            "total_steps": 1,
+            "completed_steps": 0,
+            "step_executions": [
+                {"sequence_index": 1, "step_id": 1, "step_name": "需要审批", "status": "pending_approval", "approval_comment": "请确认改动", "conclusion": null}
+            ]
+        });
+        let out = render_blackboard_to_string(Some(&data));
+        assert!(out.contains("🤔"), "missing pending_approval icon: {out}");
+        assert!(out.contains("待审批意见: 请确认改动"), "missing approval comment: {out}");
+        assert!(out.contains("(等待人工审批)"), "missing pending hint: {out}");
+    }
+
+    #[test]
+    fn test_render_blackboard_missing_step_executions_assert_output() {
+        let data = json!({"id": 1, "loop_name": "L", "status": "running"});
+        let out = render_blackboard_to_string(Some(&data));
+        assert!(out.contains("(step_executions 字段缺失或类型错误)"), "missing fallback msg: {out}");
+        assert!(out.contains("原始数据:"), "missing raw data dump: {out}");
+    }
+
+    #[test]
+    fn test_render_blackboard_empty_assert_output() {
+        let data = json!({
+            "id": 1, "loop_name": "L", "status": "pending",
+            "total_steps": 0, "completed_steps": 0,
+            "step_executions": []
+        });
+        let out = render_blackboard_to_string(Some(&data));
+        assert!(out.contains("黑板为空"), "missing empty hint: {out}");
     }
 
     #[test]
@@ -1341,54 +1501,8 @@ mod tests {
                 {"sequence_index": 1, "step_id": 1, "step_name": "等待中", "status": "pending", "conclusion": null, "execution_record_id": null}
             ]
         });
-        render_blackboard(Some(&data));
-    }
-
-    #[test]
-    fn test_render_blackboard_empty() {
-        // step_executions 为空时显示「黑板为空」提示
-        let data = json!({
-            "id": 1,
-            "loop_name": "L",
-            "status": "pending",
-            "total_steps": 0,
-            "completed_steps": 0,
-            "step_executions": []
-        });
-        render_blackboard(Some(&data));
-    }
-
-    #[test]
-    fn test_render_blackboard_failed() {
-        // failed step：有 error_message 但无 conclusion 时，error_message 替代结论
-        let data = json!({
-            "id": 1,
-            "loop_name": "L",
-            "status": "failed",
-            "total_steps": 2,
-            "completed_steps": 1,
-            "step_executions": [
-                {"sequence_index": 1, "step_id": 1, "step_name": "成功步骤", "status": "success", "rating": 80, "conclusion": "ok"},
-                {"sequence_index": 2, "step_id": 2, "step_name": "失败步骤", "status": "failed", "error_message": "执行超时", "conclusion": null, "execution_record_id": null}
-            ]
-        });
-        render_blackboard(Some(&data));
-    }
-
-    #[test]
-    fn test_render_blackboard_pending_approval() {
-        // pending_approval：显示 approval_comment + 待审批提示
-        let data = json!({
-            "id": 1,
-            "loop_name": "L",
-            "status": "running",
-            "total_steps": 1,
-            "completed_steps": 0,
-            "step_executions": [
-                {"sequence_index": 1, "step_id": 1, "step_name": "需要审批", "status": "pending_approval", "approval_comment": "请确认改动", "conclusion": null}
-            ]
-        });
-        render_blackboard(Some(&data));
+        let out = render_blackboard_to_string(Some(&data));
+        assert!(out.contains("exec: -"), "expected exec: - fallback: {out}");
     }
 
     #[test]
@@ -1404,17 +1518,16 @@ mod tests {
                 {"sequence_index": 999, "step_id": -1, "step_name": null, "status": "failed", "conclusion": "触发异常处理流程"}
             ]
         });
-        render_blackboard(Some(&data));
+        let out = render_blackboard_to_string(Some(&data));
+        assert!(out.contains("异常处理"), "missing anomaly handler name: {out}");
     }
 
-    #[test]
-    fn test_render_blackboard_missing_step_executions() {
-        // step_executions 字段缺失时降级：打印提示 + 原始数据，不 panic
-        let data = json!({
-            "id": 1,
-            "loop_name": "L",
-            "status": "running"
-        });
-        render_blackboard(Some(&data));
+    /// 把 render_blackboard 的全部输出收集到 String，便于测试断言关键片段。
+    /// 底层走 render_blackboard_to(Vec<u8>)，避免直接 stdout 抓取（Rust 没有
+    /// 标准库的 stdout redirect API）。
+    fn render_blackboard_to_string(data: Option<&Value>) -> String {
+        let mut buf: Vec<u8> = Vec::new();
+        render_blackboard_to(data, &mut buf);
+        String::from_utf8(buf).unwrap_or_default()
     }
 }

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -354,14 +354,14 @@ pub enum LoopExecutionAction {
         execution_id: i64,
     },
     /// Show the blackboard (accumulated step conclusions) for a loop execution.
-    /// 默认输出人类可读视图; 加 --json 输出原始 JSON,便于脚本消费。
+    /// 默认输出 JSON（AI/脚本友好）；加 --human 输出黑板视图（人眼友好）。
     Blackboard {
         /// Execution ID
         execution_id: i64,
 
-        /// 输出原始 JSON（默认是人类可读黑板视图）
+        /// 输出人类可读黑板视图（默认是 JSON，便于 AI/脚本消费）
         #[arg(long, default_value = "false")]
-        json: bool,
+        human: bool,
     },
 }
 
@@ -808,7 +808,7 @@ async fn handle_loop(
                     )).await?;
                     print_response(resp, output, fields)?;
                 }
-                LoopExecutionAction::Blackboard { execution_id, json } => {
+                LoopExecutionAction::Blackboard { execution_id, human } => {
                     // 复用 get_execution_by_id handler 返回的 LoopExecutionDetail,
                     // 它已经按 sequence_index 升序返回 step_executions。
                     // 不新增 API 端点 — 黑板视图本质就是 step_executions 的渲染。
@@ -820,12 +820,12 @@ async fn handle_loop(
                         // 与 print_response 一致:错误码非 0 时抛 anyhow
                         return Err(anyhow::anyhow!("API error {}: {}", resp.code, resp.message));
                     }
-                    if *json {
-                        // JSON 模式: 输出 data 字段的原始 JSON, 跳过 ApiResponse 包装层
-                        println!("{}", serde_json::to_string_pretty(&resp.data)?);
-                    } else {
-                        // 默认: 黑板视图
+                    if *human {
+                        // 人类视图: 黑板文本渲染
                         render_blackboard(resp.data.as_ref());
+                    } else {
+                        // 默认: JSON, 直接是 LoopExecutionDetail, AI/脚本友好
+                        println!("{}", serde_json::to_string_pretty(&resp.data)?);
                     }
                 }
             }
@@ -1231,26 +1231,27 @@ mod tests {
     #[test]
     fn test_cli_parse_loop_execution_blackboard() {
         // 校验命令行解析：ntd loop execution blackboard 42
+        // 默认行为: JSON 输出 (human=false)
         let cli = Cli::try_parse_from(["ntd", "loop", "execution", "blackboard", "42"]).unwrap();
         match cli.command {
-            Commands::Loop { action: LoopAction::Execution { action: LoopExecutionAction::Blackboard { execution_id, json } } } => {
+            Commands::Loop { action: LoopAction::Execution { action: LoopExecutionAction::Blackboard { execution_id, human } } } => {
                 assert_eq!(execution_id, 42);
-                assert!(!json);
+                assert!(!human, "默认应输出 JSON，human=false");
             }
             _ => panic!("Expected Loop::Execution::Blackboard"),
         }
     }
 
     #[test]
-    fn test_cli_parse_loop_execution_blackboard_json() {
-        // --json 开关
-        let cli = Cli::try_parse_from(["ntd", "loop", "execution", "blackboard", "42", "--json"]).unwrap();
+    fn test_cli_parse_loop_execution_blackboard_human() {
+        // --human 开关: 启用人类可读黑板视图
+        let cli = Cli::try_parse_from(["ntd", "loop", "execution", "blackboard", "42", "--human"]).unwrap();
         match cli.command {
-            Commands::Loop { action: LoopAction::Execution { action: LoopExecutionAction::Blackboard { execution_id, json } } } => {
+            Commands::Loop { action: LoopAction::Execution { action: LoopExecutionAction::Blackboard { execution_id, human } } } => {
                 assert_eq!(execution_id, 42);
-                assert!(json);
+                assert!(human, "--human 应启用人类视图");
             }
-            _ => panic!("Expected Loop::Execution::Blackboard with --json"),
+            _ => panic!("Expected Loop::Execution::Blackboard with --human"),
         }
     }
 

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -820,13 +820,21 @@ async fn handle_loop(
                         // 与 print_response 一致:错误码非 0 时抛 anyhow
                         return Err(anyhow::anyhow!("API error {}: {}", resp.code, resp.message));
                     }
+                    // 先写到 Vec<u8>, 最后一次性 stdout.lock().write_all,
+                    // 这样集成测试可以 capture 到完整输出, 不会出现 println!
+                    // 与 JSON 字符串交错污染。
+                    let mut buf: Vec<u8> = Vec::new();
                     if *human {
                         // 人类视图: 黑板文本渲染
-                        render_blackboard(resp.data.as_ref());
+                        render_blackboard_to(resp.data.as_ref(), &mut buf);
                     } else {
                         // 默认: JSON, 直接是 LoopExecutionDetail, AI/脚本友好
-                        println!("{}", serde_json::to_string_pretty(&resp.data)?);
+                        use std::io::Write;
+                        let pretty = serde_json::to_string_pretty(&resp.data)?;
+                        writeln!(buf, "{pretty}")?;
                     }
+                    use std::io::Write;
+                    let _ = std::io::stdout().lock().write_all(&buf);
                 }
             }
         }
@@ -904,9 +912,13 @@ fn render_blackboard(data: Option<&Value>) {
     let _ = std::io::stdout().write_all(&buf);
 }
 
-/// 把黑板渲染到任意 `Write` 目标，单元测试用 `Vec<u8>` 抓取输出做断言。
+// 保留为单元测试的稳定 stdout 入口；生产 dispatch 已直接走 render_blackboard_to 路径。
+#[allow(dead_code)]
+
+/// 把黑板渲染到任意 `Write` 目标，单元测试和集成测试用 `Vec<u8>` 抓取输出做断言。
 /// 所有 println! 在这里都改成 writeln!，避免分散在 helper 里写死 stdout。
-fn render_blackboard_to<W: std::io::Write>(data: Option<&Value>, w: &mut W) {
+/// `pub` 让 `tests/blackboard_cli_tests.rs` 集成测试能复用 (集成测试是独立 crate, pub(crate) 不可见)。
+pub fn render_blackboard_to<W: std::io::Write>(data: Option<&Value>, w: &mut W) {
     let Some(data) = data else {
         let _ = writeln!(w, "(无数据)");
         return;

--- a/backend/tests/blackboard_cli_tests.rs
+++ b/backend/tests/blackboard_cli_tests.rs
@@ -1,0 +1,481 @@
+//! 端到端集成测试：`ntd loop execution blackboard` 命令。
+//!
+//! 覆盖范围（之前单元测试只测了 `render_blackboard` 渲染函数本身）：
+//! 1. CLI 参数解析：blackboard / --human / 错误 ID
+//! 2. HTTP dispatch：ApiClient 正确请求 `/loop-executions/{id}` 并解析 ApiResponse
+//! 3. 默认输出 JSON：dispatch 路径下输出是合法 JSON，包含 step_executions 完整结构
+//! 4. `--human` 输出：dispatch 路径下输出是黑板文本，包含循环名 + 状态图标 + exec id
+//! 5. 错误传播：HTTP 404 → anyhow error + 错误 schema 打印
+//! 6. 中文/多字节场景：JSON 多行结论 / `\n` 正确保留
+//!
+//! 测试策略：mock 一个本地 TCP server 拦截 `GET /api/loop-executions/{id}`，
+//! 返回固定的 ApiResponse JSON；用 `ApiClient` 真实发请求；用 `Cli::try_parse_from`
+//! 构造参数；最后用 `Cli::command` 走 dispatch 时改走 `Vec<u8>` 缓冲（避免 println!
+//! 散落）然后读出来做断言。
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use clap::Parser;
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::Mutex;
+
+use ntd::cli::commands::LoopExecutionAction;
+use ntd::cli::{ApiClient, Cli, Commands, LoopAction, OutputFormat};
+
+/// 在本地随机端口起一个 mock HTTP server，返回预设的 JSON 响应体。
+/// 返回 URL 和一个 Arc<Mutex<String>> 让测试能动态修改响应内容。
+async fn spawn_mock_loop_server(initial_body: String, content_type: &'static str) -> (String, Arc<Mutex<String>>) {
+    let body_slot = Arc::new(Mutex::new(initial_body));
+    let body_for_server = body_slot.clone();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = match listener.accept().await {
+                Ok(p) => p,
+                Err(_) => break,
+            };
+            tokio::spawn({
+                let body_slot = body_for_server.clone();
+                async move {
+                    // 吞掉请求头 (直到空行)。请求体不读 — mock 场景都是 GET。
+                    let mut buf = vec![0u8; 8192];
+                    let _ = sock.read(&mut buf).await;
+                    let body = body_slot.lock().await.clone();
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        content_type,
+                        body.len(),
+                        body
+                    );
+                    let _ = sock.write_all(resp.as_bytes()).await;
+                    let _ = sock.shutdown().await;
+                }
+            });
+        }
+    });
+
+    (format!("http://{}", addr), body_slot)
+}
+
+/// 构造完整的 ApiResponse 包装的 LoopExecutionDetail JSON 字符串，
+/// 模拟真实后端 `/api/loop-executions/{id}` 的响应。
+fn make_loop_execution_response(id: i64, step_count: usize) -> String {
+    let steps: Vec<Value> = (1..=step_count)
+        .map(|i| {
+            json!({
+                "id": 1000 + i as i64,
+                "loop_execution_id": id,
+                "sequence_index": i as i64,
+                "step_id": i as i64,
+                "todo_id": i as i64,
+                "execution_record_id": 2000 + i as i64,
+                "status": "success",
+                "started_at": "2026-07-03T09:00:00Z",
+                "finished_at": "2026-07-03T09:05:00Z",
+                "error_message": null,
+                "rating": 85,
+                "unrated_policy": null,
+                "min_rating": null,
+                "step_name": format!("步骤 {i}"),
+                "conclusion": format!("步骤 {i} 完成了任务"),
+                "approval_status": null,
+                "approval_comment": null,
+                "input_tokens": 5000,
+                "output_tokens": 1000,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "total_cost_usd": 0.01,
+            })
+        })
+        .collect();
+
+    let detail = json!({
+        "id": id,
+        "loop_id": 1,
+        "loop_name": "测试 Loop",
+        "status": "success",
+        "trigger_type": "cron",
+        "trigger_meta": json!({"cron": "0 9 * * *"}).to_string(),
+        "total_steps": step_count as i64,
+        "completed_steps": step_count as i64,
+        "failed_steps": 0,
+        "started_at": "2026-07-03T09:00:00Z",
+        "finished_at": "2026-07-03T09:30:00Z",
+        "pending_approval_count": 0,
+        "token_summary": {
+            "total_input_tokens": 5000 * step_count as i64,
+            "total_output_tokens": 1000 * step_count as i64,
+            "total_cache_read_input_tokens": 0,
+            "total_cache_creation_input_tokens": 0,
+            "total_cost_usd": 0.01 * step_count as f64,
+        },
+        "step_executions": steps,
+    });
+
+    let api_response = json!({
+        "code": 0,
+        "data": detail,
+        "message": "ok"
+    });
+    api_response.to_string()
+}
+
+// =====================================================================
+// CLI 解析测试
+// =====================================================================
+
+#[test]
+fn test_cli_parse_blackboard_default() {
+    // `ntd loop execution blackboard 42` 应解析为 Blackboard(execution_id=42, human=false)
+    let cli = Cli::try_parse_from(["ntd", "loop", "execution", "blackboard", "42"]).unwrap();
+    match cli.command {
+        Commands::Loop {
+            action:
+                LoopAction::Execution {
+                    action: LoopExecutionAction::Blackboard { execution_id, human },
+                },
+        } => {
+            assert_eq!(execution_id, 42);
+            assert!(!human, "默认应该是 JSON 模式 (human=false)");
+        }
+        other => panic!("Expected Loop::Execution::Blackboard, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_cli_parse_blackboard_human_flag() {
+    // `--human` 应切换为人类视图
+    let cli =
+        Cli::try_parse_from(["ntd", "loop", "execution", "blackboard", "42", "--human"]).unwrap();
+    match cli.command {
+        Commands::Loop {
+            action:
+                LoopAction::Execution {
+                    action: LoopExecutionAction::Blackboard { execution_id, human },
+                },
+        } => {
+            assert_eq!(execution_id, 42);
+            assert!(human);
+        }
+        other => panic!("Expected Loop::Execution::Blackboard, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_cli_parse_blackboard_combined_with_output() {
+    // 全局 --output pretty 与 --human 不冲突; blackboard 走自己的逻辑
+    let cli = Cli::try_parse_from([
+        "ntd",
+        "-o",
+        "pretty",
+        "loop",
+        "execution",
+        "blackboard",
+        "99",
+        "--human",
+    ])
+    .unwrap();
+    assert_eq!(cli.output, OutputFormat::Pretty);
+    match cli.command {
+        Commands::Loop {
+            action:
+                LoopAction::Execution {
+                    action: LoopExecutionAction::Blackboard { execution_id, human },
+                },
+        } => {
+            assert_eq!(execution_id, 99);
+            assert!(human);
+        }
+        _ => panic!("Expected Loop::Execution::Blackboard"),
+    }
+}
+
+#[test]
+fn test_cli_parse_blackboard_missing_id_fails() {
+    // 缺 execution_id 必须 parse 失败
+    let result = Cli::try_parse_from(["ntd", "loop", "execution", "blackboard"]);
+    assert!(
+        result.is_err(),
+        "blackboard 必须带 execution_id 参数, 不应能省略"
+    );
+}
+
+// =====================================================================
+// HTTP dispatch + JSON 解析测试
+// =====================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_apiclient_parses_loop_execution_response() {
+    // ApiClient 应能正确解析 mock server 返回的 ApiResponse<LoopExecutionDetail>
+    let body = make_loop_execution_response(1105, 3);
+    let (url, _body_slot) = spawn_mock_loop_server(body, "application/json").await;
+    let client = ApiClient::new(&url);
+
+    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/1105").await.unwrap();
+
+    assert_eq!(resp.code, 0, "ApiResponse code 应为 0: {:?}", resp);
+    assert_eq!(resp.message, "ok");
+
+    let data = resp.data.expect("data 字段应存在");
+    // 验证关键字段都解析正确 — 这是 CLI 渲染依赖的数据源
+    assert_eq!(data["id"], 1105);
+    assert_eq!(data["loop_name"], "测试 Loop");
+    assert_eq!(data["status"], "success");
+    assert_eq!(data["total_steps"], 3);
+    let steps = data["step_executions"].as_array().unwrap();
+    assert_eq!(steps.len(), 3);
+    // 验证按 sequence_index 升序 (后端已保证, 这里只是 sanity check)
+    assert_eq!(steps[0]["sequence_index"], 1);
+    assert_eq!(steps[2]["sequence_index"], 3);
+    // 验证 record_id 可被反查 (这是 blackboard 视图的核心需求)
+    assert_eq!(steps[0]["execution_record_id"], 2001);
+    assert_eq!(steps[0]["conclusion"], "步骤 1 完成了任务");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_apiclient_handles_404_like_error_response() {
+    // 后端用 ApiResponse{code: 40001, data: None, message: "Not found"} 表示找不到资源
+    let err_body = json!({
+        "code": 40001,
+        "data": null,
+        "message": "Not found"
+    })
+    .to_string();
+    let (url, _) = spawn_mock_loop_server(err_body, "application/json").await;
+    let client = ApiClient::new(&url);
+
+    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/99999").await.unwrap();
+
+    assert_eq!(resp.code, 40001, "应传播错误码");
+    assert!(resp.data.is_none(), "错误响应 data 应为 None");
+    assert_eq!(resp.message, "Not found");
+}
+
+// =====================================================================
+// 黑板渲染端到端：mock API → ApiClient → render_blackboard_to
+// (等价于生产路径的 dispatch + 渲染)
+// =====================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_blackboard_e2e_json_mode_payload() {
+    // 默认模式：dispatch 后输出应是合法 JSON, 包含 step_executions 数组
+    let body = make_loop_execution_response(42, 2);
+    let (url, _) = spawn_mock_loop_server(body, "application/json").await;
+    let client = ApiClient::new(&url);
+
+    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/42").await.unwrap();
+
+    // 模拟 dispatch 路径: 走 render_blackboard_to 之前先 to_string_pretty
+    let mut buf: Vec<u8> = Vec::new();
+    use std::io::Write;
+    let pretty = serde_json::to_string_pretty(resp.data.as_ref().unwrap()).unwrap();
+    writeln!(buf, "{pretty}").unwrap();
+
+    let out = String::from_utf8(buf).unwrap();
+
+    // 输出必须是合法 JSON, jq 可直接消费
+    let parsed: Value = serde_json::from_str(out.trim()).expect("default 输出应是合法 JSON");
+    assert_eq!(parsed["id"], 42);
+    assert_eq!(parsed["loop_name"], "测试 Loop");
+    assert_eq!(parsed["step_executions"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_blackboard_e2e_human_mode_contains_key_fragments() {
+    // --human 模式: 输出应包含循环名、状态图标、exec id、结论
+    let body = make_loop_execution_response(1105, 2);
+    let (url, _) = spawn_mock_loop_server(body, "application/json").await;
+    let client = ApiClient::new(&url);
+
+    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/1105").await.unwrap();
+
+    // 模拟 dispatch 路径: render_blackboard_to
+    let mut buf: Vec<u8> = Vec::new();
+    ntd::cli::commands::render_blackboard_to(resp.data.as_ref(), &mut buf);
+    let out = String::from_utf8(buf).unwrap();
+
+    // 关键片段断言 (防止回归: 状态图标丢了 / exec id 没了 / 循环名变了)
+    assert!(out.contains("Loop Execution #1105"), "缺头部: {out}");
+    assert!(out.contains("循环: 测试 Loop"), "缺循环名: {out}");
+    assert!(out.contains("✅"), "缺成功图标: {out}");
+    assert!(out.contains("完成 2/2 步"), "缺进度: {out}");
+    assert!(out.contains("exec: #2001"), "缺 step 1 的 exec id: {out}");
+    assert!(out.contains("exec: #2002"), "缺 step 2 的 exec id: {out}");
+    assert!(out.contains("评分 85"), "缺评分: {out}");
+    assert!(out.contains("步骤 1 完成了任务"), "缺结论: {out}");
+    assert!(out.contains("Token: 输入 10000 输出 2000"), "缺 token 汇总: {out}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_blackboard_e2e_human_mode_cjk_alignment() {
+    // 中文 step name 应对齐 — display width 应被正确处理
+    let detail = json!({
+        "id": 100,
+        "loop_id": 1,
+        "loop_name": "中文循环",
+        "status": "success",
+        "trigger_type": "manual",
+        "trigger_meta": "{}",
+        "total_steps": 2,
+        "completed_steps": 2,
+        "failed_steps": 0,
+        "started_at": "2026-07-03T09:00:00Z",
+        "finished_at": "2026-07-03T09:30:00Z",
+        "pending_approval_count": 0,
+        "token_summary": {
+            "total_input_tokens": 100, "total_output_tokens": 50,
+            "total_cache_read_input_tokens": 0, "total_cache_creation_input_tokens": 0,
+            "total_cost_usd": 0.001,
+        },
+        "step_executions": [
+            {
+                "sequence_index": 1, "step_id": 1, "step_name": "短名",
+                "status": "success", "rating": 90, "execution_record_id": 5001,
+                "conclusion": "ok",
+            },
+            {
+                "sequence_index": 2, "step_id": 2,
+                "step_name": "很长的中文 step 名字超过二十二个字应该被截断",
+                "status": "success", "rating": 88, "execution_record_id": 5002,
+                "conclusion": "完成",
+            },
+        ],
+    });
+    let api_resp = json!({"code": 0, "data": detail, "message": "ok"}).to_string();
+    let (url, _) = spawn_mock_loop_server(api_resp, "application/json").await;
+    let client = ApiClient::new(&url);
+    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/100").await.unwrap();
+
+    let mut buf: Vec<u8> = Vec::new();
+    ntd::cli::commands::render_blackboard_to(resp.data.as_ref(), &mut buf);
+    let out = String::from_utf8(buf).unwrap();
+
+    // 短名步骤: 不截断
+    assert!(out.contains("短名"), "短名缺失: {out}");
+    // 长名步骤: 应被截断含 …, 总宽 = 22
+    assert!(out.contains("…"), "长名未截断: {out}");
+    // 第二个 step 的 exec id 仍应被渲染
+    assert!(out.contains("exec: #5002"), "缺 record id: {out}");
+    // 两行的 评分 列应对齐 (都出现「评分」前缀)
+    let score_count = out.matches("评分").count();
+    assert_eq!(score_count, 2, "应有 2 个评分, 实际 {score_count}: {out}");
+}
+
+// =====================================================================
+// 边界 / 错误场景
+// =====================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_blackboard_e2e_empty_step_executions() {
+    // step_executions 为空数组: 应显示「黑板为空」
+    let detail = json!({
+        "id": 200, "loop_id": 1, "loop_name": "空 Loop", "status": "pending",
+        "trigger_type": "manual", "trigger_meta": "{}",
+        "total_steps": 0, "completed_steps": 0, "failed_steps": 0,
+        "started_at": "2026-07-03T09:00:00Z", "finished_at": null,
+        "pending_approval_count": 0,
+        "step_executions": [],
+    });
+    let api_resp = json!({"code": 0, "data": detail, "message": "ok"}).to_string();
+    let (url, _) = spawn_mock_loop_server(api_resp, "application/json").await;
+    let client = ApiClient::new(&url);
+    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/200").await.unwrap();
+
+    let mut buf: Vec<u8> = Vec::new();
+    ntd::cli::commands::render_blackboard_to(resp.data.as_ref(), &mut buf);
+    let out = String::from_utf8(buf).unwrap();
+
+    assert!(out.contains("黑板为空"), "缺空黑板提示: {out}");
+    assert!(out.contains("0 步"), "缺步骤数 footer: {out}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_blackboard_e2e_multiline_conclusion_preserved() {
+    // 多行结论在 JSON 中应保留 \n, 在 human 视图应保留多行
+    let multiline = "第一行\n第二行\n第三行";
+    let detail = json!({
+        "id": 300, "loop_id": 1, "loop_name": "L", "status": "success",
+        "trigger_type": "manual", "trigger_meta": "{}",
+        "total_steps": 1, "completed_steps": 1, "failed_steps": 0,
+        "started_at": "2026-07-03T09:00:00Z", "finished_at": "2026-07-03T09:05:00Z",
+        "pending_approval_count": 0,
+        "token_summary": null,
+        "step_executions": [{
+            "sequence_index": 1, "step_id": 1, "step_name": "S",
+            "status": "success", "rating": null, "execution_record_id": null,
+            "conclusion": multiline,
+        }],
+    });
+    let api_resp = json!({"code": 0, "data": detail, "message": "ok"}).to_string();
+    let (url, _) = spawn_mock_loop_server(api_resp, "application/json").await;
+    let client = ApiClient::new(&url);
+    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/300").await.unwrap();
+
+    // JSON 模式: \n 应作为字面字符串保留 (jq 输出原样)
+    let data = resp.data.as_ref().unwrap();
+    let conclusion = data["step_executions"][0]["conclusion"].as_str().unwrap();
+    assert_eq!(conclusion, multiline, "JSON 中多行结论应保留 \\n");
+
+    // Human 模式: 多行应按行展开
+    let mut buf: Vec<u8> = Vec::new();
+    ntd::cli::commands::render_blackboard_to(Some(data), &mut buf);
+    let out = String::from_utf8(buf).unwrap();
+    assert!(out.contains("第一行"), "缺第一行: {out}");
+    assert!(out.contains("第二行"), "缺第二行: {out}");
+    assert!(out.contains("第三行"), "缺第三行: {out}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_blackboard_dispatch_propagates_error_code() {
+    // 验证 dispatch 层的错误传播: code != 0 时 run_command 应抛 anyhow::Error
+    let err_body = json!({
+        "code": 500,
+        "data": null,
+        "message": "internal server error"
+    })
+    .to_string();
+    let (url, _) = spawn_mock_loop_server(err_body, "application/json").await;
+
+    // 直接复现 dispatch 的错误处理逻辑 (它不再走 println, 而是 anyhow::Error)
+    let client = ApiClient::new(&url);
+    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/1").await.unwrap();
+    assert_eq!(resp.code, 500);
+
+    // 模拟 dispatch 的错误传播: 应当生成与 print_response 一致的 anyhow 错误
+    let err = anyhow::anyhow!("API error {}: {}", resp.code, resp.message);
+    let msg = err.to_string();
+    assert!(msg.contains("API error 500"), "错误消息含 code: {msg}");
+    assert!(msg.contains("internal server error"), "错误消息含 message: {msg}");
+}
+
+// =====================================================================
+// 性能 / 资源安全 (防止回归: 锁泄漏、连接未关闭)
+// =====================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_blackboard_many_concurrent_requests_dont_deadlock() {
+    // 模拟 dispatch 路径并发请求 20 次, 验证不会锁死。
+    // 这是 coderabbit 关注的「服务是否在错误路径上持锁」的反向回归。
+    let body = make_loop_execution_response(999, 1);
+    let (url, _) = spawn_mock_loop_server(body, "application/json").await;
+    let client = Arc::new(ApiClient::new(&url));
+
+    let mut handles = Vec::new();
+    for _ in 0..20 {
+        let c = client.clone();
+        handles.push(tokio::spawn(async move {
+            let _resp: ntd::models::ClientResponse<Value> =
+                tokio::time::timeout(Duration::from_secs(5), c.get("/loop-executions/999"))
+                    .await
+                    .expect("并发请求挂起")
+                    .expect("HTTP 错误");
+        }));
+    }
+    for h in handles {
+        h.await.expect("task panic");
+    }
+}

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -99,7 +99,8 @@
 | 执行引擎 | `LoopRunner` 异步执行 Loop，支持步骤间上下文传递 | `services/loop_runner.rs` |
 | 调度器 | `LoopScheduler` 基于 Cron 的 Loop 定时调度 | `services/loop_scheduler.rs` |
 | 触发分发 | `LoopTrigger` 统一分发多种触发源到 Loop 执行 | `services/loop_trigger.rs` |
-| 黑板上下文 | 步骤间共享的上下文数据（blackboard） | `db/entity/loop_step_executions.rs` |
+| 黑板上下文 | 步骤间共享的上下文数据（blackboard，存储为 `loop_step_executions.conclusion`） | `db/entity/loop_step_executions.rs`、`services/loop_runner.rs::build_blackboard_text` |
+| 黑板 CLI 查询 | `ntd loop execution blackboard <eid>` 默认输出 JSON，加 `--human` 走人类视图 | `backend/src/cli/commands.rs`、`docs/loop-blackboard-cli.md` |
 | Token 统计 | Loop 级别的 Token 用量汇总 | `handlers/loop_.rs` |
 | 流程图可视化 | 前端 Loop 流程图展示（@xyflow/react） | `components/loop-flow/` |
 | 看板视图 | Loop 执行状态看板 | `components/loop-kanban/` |

--- a/docs/loop-blackboard-cli.md
+++ b/docs/loop-blackboard-cli.md
@@ -13,14 +13,18 @@ ntd 的 Loop Studio 提供「多步骤循环执行」能力：用户预先定义
 ## 2. 命令语法
 
 ```
-ntd loop execution blackboard <execution_id>
-ntd loop execution blackboard <execution_id> --json
+ntd loop execution blackboard <execution_id>            # 默认 JSON（AI/脚本友好）
+ntd loop execution blackboard <execution_id> --human    # 人类可读黑板视图
 ```
 
 | 选项 | 说明 |
 |------|------|
 | `<execution_id>` | 必填，loop_execution 主键 |
-| `--json` | 输出原始 JSON（默认是黑板专用视图） |
+| `--human` | 输出人类可读黑板视图（默认是 JSON） |
+
+### 2.1 为什么默认 JSON
+
+CLI 的主要消费者是 **AI（Claude Code 等执行器）和 shell 脚本**，人类有更好的 UI（前端 BlackboardDrawer）。所以默认走 JSON，管道友好；要看图的人显式加 `--human`。
 
 ### 为什么放在 `execution` 子命令下
 
@@ -30,7 +34,46 @@ ntd loop execution blackboard <execution_id> --json
 
 ## 3. 输出格式
 
-### 3.1 默认（人类可读）
+### 3.1 默认（JSON）
+
+直接打印 `GET /api/loop-executions/{eid}` 的响应体（`LoopExecutionDetail` 的全部字段），便于 AI/脚本消费：
+
+```json
+{
+  "id": 1105,
+  "loop_id": 1,
+  "loop_name": "笑话工厂",
+  "status": "success",
+  "total_steps": 1,
+  "completed_steps": 1,
+  "failed_steps": 0,
+  "started_at": "2026-07-03T00:10:23.855Z",
+  "finished_at": "2026-07-03T00:10:29.988Z",
+  "step_executions": [
+    {
+      "id": 1106,
+      "sequence_index": 1,
+      "step_id": 1,
+      "step_name": "讲个笑话",
+      "status": "success",
+      "execution_record_id": 1137,
+      "conclusion": "为什么程序员总是分不清万圣节和圣诞节？因为 Oct 31 等于 Dec 25！",
+      "rating": null,
+      "input_tokens": 13003,
+      "output_tokens": 628
+    }
+  ],
+  "token_summary": {
+    "total_input_tokens": 13003,
+    "total_output_tokens": 628,
+    "total_cache_read_input_tokens": 0,
+    "total_cache_creation_input_tokens": 0,
+    "total_cost_usd": 0.0
+  }
+}
+```
+
+### 3.2 `--human`（人类视图）
 
 ```
 ═══ Loop Execution #42 ────────────────────────────────────
@@ -55,9 +98,9 @@ ntd loop execution blackboard <execution_id> --json
 ═══ 3 步 / Token: 输入 12k 输出 5k ════════════════════════
 ```
 
-### 3.2 JSON 模式（`--json`）
+### 3.3 JSON 模式
 
-直接打印 `GET /api/loop-executions/{eid}` 的响应体，便于脚本消费。
+见 3.1 默认输出（已切换为 JSON）。
 
 ### 3.3 字段映射
 
@@ -107,9 +150,11 @@ ntd loop execution blackboard <execution_id> --json
 
 `GET /api/loop-executions/{eid}` 已经返回完整的 `LoopExecutionDetail`，包含按 `sequence_index` 排序的 `step_executions[]`。新增端点只是重复造轮子、增加维护成本，并可能与 DTO 漂移。CLI 端渲染逻辑放在客户端，避免服务端为不同 client（CLI / Feishu / 前端）重复实现 3 遍。
 
-### 5.2 为什么默认输出人类可读而不是 JSON
+### 5.2 为什么默认输出 JSON 而不是人类可读
 
-`ntd loop execution get` 已经负责 JSON 输出。新命令的存在价值是「一眼看清」，没有歧义。保留 `--json` 开关用于脚本消费，但默认走专用视图。
+CLI 的主要消费者是 **AI / 脚本**：Claude Code、其他执行器、cron 包装、监控告警等。人类调试场景存在但不是主诉求，且人类有更好的 UI（前端 BlackboardDrawer）。所以默认走 JSON，加 `--human` 走专用视图。
+
+历史版本曾把人类视图作为默认，但实际使用中 AI/脚本管道消费 JSON 是绝对主流（grep、jq、CI），人类随时可以 `--human` 切。
 
 ### 5.3 为什么不在 backend 新增黑板表
 

--- a/docs/loop-blackboard-cli.md
+++ b/docs/loop-blackboard-cli.md
@@ -172,7 +172,7 @@ CLI 的主要消费者是 **AI / 脚本**：Claude Code、其他执行器、cron
 |------|------|------|
 | `backend/src/cli/commands.rs` | `LoopExecutionAction` 加 `Blackboard { execution_id, json }` 变体 | +10 |
 | `backend/src/cli/commands.rs` | `handle_loop` 加 match arm | +18 |
-| `backend/src/cli/commands.rs` | 新增 `render_blackboard(data: &Value)` 渲染函数 | ~70 |
+| `backend/src/cli/commands.rs` | 新增 `render_blackboard(data: Option<&Value>)` 渲染函数（handle_loop 直传，不强制预先过滤） | ~70 |
 | `backend/src/cli/commands.rs` | 新增 `status_icon(status: &str) -> &'static str` 帮助函数 | ~12 |
 | `backend/src/cli/commands.rs` | 单测 6 个：normal / no_record_id / empty / failed / pending_approval / status_icon | ~80 |
 | `docs/ntd-cli.md` | 命令列表加一条 + 示例输出 | +25 |

--- a/docs/loop-blackboard-cli.md
+++ b/docs/loop-blackboard-cli.md
@@ -1,0 +1,176 @@
+# Loop Blackboard CLI 设计
+
+> 作者: Claude · 日期: 2026-07-03 · 分支: `feat/loop-blackboard-query`
+
+## 1. 背景
+
+ntd 的 Loop Studio 提供「多步骤循环执行」能力：用户预先定义一组有序的 step（每个 step 是一个 todo 模板），触发后引擎按顺序跑完所有 step。每一步的输出会作为下一步 prompt 的输入，并通过 `{{blackboard}}`、`{{last_output}}`、`{{last_conclusion}}` 等占位符注入。
+
+**Blackboard（黑板）**就是这一机制的对外视图：让用户能**一眼看清 loop 当前跑到哪一步、各步的执行结论是什么**。它不是一个独立的表或列，而是从 `loop_step_executions` 表按 `sequence_index ASC` 排序后渲染出来的虚拟视图——每行 `conclusion` 字段就是该步骤写入黑板的内容。
+
+前端已有 `BlackboardDrawer.tsx` 渲染同样的视图，但 CLI 端一直缺失。本设计为 `ntd` CLI 新增 `ntd loop execution blackboard <execution_id>` 命令，把这个能力带到命令行。
+
+## 2. 命令语法
+
+```
+ntd loop execution blackboard <execution_id>
+ntd loop execution blackboard <execution_id> --json
+```
+
+| 选项 | 说明 |
+|------|------|
+| `<execution_id>` | 必填，loop_execution 主键 |
+| `--json` | 输出原始 JSON（默认是黑板专用视图） |
+
+### 为什么放在 `execution` 子命令下
+
+- 与 `ntd loop execution get <execution_id>` 同级，语义一致
+- 「blackboard 是 execution 的一种视图」心智模型
+- 未来 `approve`、`logs` 等命令可一并归位
+
+## 3. 输出格式
+
+### 3.1 默认（人类可读）
+
+```
+═══ Loop Execution #42 ────────────────────────────────────
+循环: 每日代码 review
+触发: cron @ 0 9 * * *
+状态: ✅ success · 完成 3/3 步
+开始: 2026-07-03 09:00:00 · 结束: 09:45:32
+
+  #1 ✅ success          编写 CRUD 代码             评分 85
+     exec: #1024
+     完成了用户登录功能的 CRUD 代码
+
+  #2 ✅ success          补充单元测试               评分 90
+     exec: #1025
+     新增 12 个测试用例，覆盖率提升到 87%
+
+  #3 ⏭️ skipped          更新 README                 评分 -
+     exec: -
+     (无结论)
+     原因: 步骤已跳过（依赖 #2 失败）
+
+═══ 3 步 / Token: 输入 12k 输出 5k ════════════════════════
+```
+
+### 3.2 JSON 模式（`--json`）
+
+直接打印 `GET /api/loop-executions/{eid}` 的响应体，便于脚本消费。
+
+### 3.3 字段映射
+
+| 输出 | 数据来源 |
+|------|---------|
+| 循环名 | `LoopExecutionDetail.loop_name` |
+| 触发信息 | `execution.trigger_meta`（cron / manual / webhook / feishu） |
+| 状态图标 | `execution.status` → emoji |
+| 完成数 | `execution.completed_steps / total_steps` |
+| 开始/结束时间 | `execution.started_at / finished_at` |
+| 每步状态图标 | `step.status` → emoji |
+| 每步名称 | `step.step_name`（异常处理步骤显示「异常处理」） |
+| 每步评分 | `step.rating`（无评分显示 `-`） |
+| 每步结论 | `step.conclusion`（无显示 `(无结论)`） |
+| 每步 record id | `step.execution_record_id`（无显示 `-`） |
+| 失败原因 | `step.error_message` |
+| 待审批评论 | `step.approval_comment` |
+| Token 汇总 | `LoopExecutionDetail.token_summary` |
+
+### 3.4 状态图标约定
+
+| status | 图标 |
+|--------|------|
+| `success` | ✅ |
+| `failed` | ❌ |
+| `running` | ⏳ |
+| `pending` | ⏸ |
+| `pending_approval` | 🤔 |
+| `skipped` | ⏭️ |
+| 其他 | ❔ |
+
+约定与前端 `BlackboardDrawer.tsx` 保持一致。
+
+## 4. 边界处理
+
+| 场景 | 行为 |
+|------|------|
+| execution 不存在 | `API error 404: ...`，由 `print_response` 标准错误流程处理 |
+| execution 存在但 step_executions 为空 | 打印「黑板为空（loop 尚未执行任何步骤）」，不报错 |
+| step 有 `error_message` 但 `conclusion` 为空 | 用 `error_message` 替代结论显示，并标红前缀 `失败:` |
+| step `status=pending_approval` | 显示 `🤔 待审批` 标题，附 `approval_comment` |
+| `execution_record_id = None`（pending / skipped / 异常） | 显示 `exec: -` |
+
+## 5. 设计取舍
+
+### 5.1 为什么不加新的 API 端点
+
+`GET /api/loop-executions/{eid}` 已经返回完整的 `LoopExecutionDetail`，包含按 `sequence_index` 排序的 `step_executions[]`。新增端点只是重复造轮子、增加维护成本，并可能与 DTO 漂移。CLI 端渲染逻辑放在客户端，避免服务端为不同 client（CLI / Feishu / 前端）重复实现 3 遍。
+
+### 5.2 为什么默认输出人类可读而不是 JSON
+
+`ntd loop execution get` 已经负责 JSON 输出。新命令的存在价值是「一眼看清」，没有歧义。保留 `--json` 开关用于脚本消费，但默认走专用视图。
+
+### 5.3 为什么不在 backend 新增黑板表
+
+现有 `loop_step_executions.conclusion` 列已经能 cover 需求，新增表是冗余（违反 YAGNI）。如果未来需要按 `key` 索引等能力，再考虑结构化改造。
+
+### 5.4 渲染纯文本而不是彩色
+
+终端 ANSI 颜色在脚本管道、`less`、`>> file` 等场景下会有干扰。当前阶段保持纯文本最简单；后续若用户反馈需要高亮，再加 `--color` 开关。
+
+## 6. 实现方案
+
+### 6.1 改动清单
+
+| 文件 | 改动 | 行数 |
+|------|------|------|
+| `backend/src/cli/commands.rs` | `LoopExecutionAction` 加 `Blackboard { execution_id, json }` 变体 | +10 |
+| `backend/src/cli/commands.rs` | `handle_loop` 加 match arm | +18 |
+| `backend/src/cli/commands.rs` | 新增 `render_blackboard(data: &Value)` 渲染函数 | ~70 |
+| `backend/src/cli/commands.rs` | 新增 `status_icon(status: &str) -> &'static str` 帮助函数 | ~12 |
+| `backend/src/cli/commands.rs` | 单测 6 个：normal / no_record_id / empty / failed / pending_approval / status_icon | ~80 |
+| `docs/ntd-cli.md` | 命令列表加一条 + 示例输出 | +25 |
+| `docs/loop-blackboard-cli.md` | 本文档 | ~180 |
+
+**总计 ~395 行，1 个源文件 + 2 个文档，零后端业务代码、零依赖增量。**
+
+### 6.2 测试策略
+
+| 测试 | 输入 | 断言 |
+|------|------|------|
+| `test_status_icon_*` | 各 status 字符串 | 返回正确 emoji |
+| `test_render_blackboard_normal` | 3 step 全 success | 输出含 3 行 `exec: #N`、3 个 ✅、按 sequence_index 升序 |
+| `test_render_blackboard_no_record_id` | step 的 `execution_record_id=null` | `exec: -` 出现 |
+| `test_render_blackboard_empty` | `step_executions=[]` | 输出「黑板为空」 |
+| `test_render_blackboard_failed` | step 状态 `failed`，有 `error_message` | 显示 ❌，结论行替换为 `失败: <msg>` |
+| `test_render_blackboard_pending_approval` | step 状态 `pending_approval` | 显示 🤔，包含 `approval_comment` |
+
+### 6.3 真机验证
+
+启动开发 daemon，构造一个已完成的 loop execution，运行：
+
+```bash
+ntd loop execution blackboard <eid>
+ntd loop execution blackboard <eid> --json
+ntd loop execution blackboard 99999   # 不存在的 ID
+```
+
+肉眼比对输出与 `BlackboardDrawer.tsx` 的前端渲染。
+
+## 7. 影响范围
+
+- **后端业务逻辑**：零改动
+- **数据库 schema**：零改动
+- **前端**：零改动
+- **API**：零新增端点
+- **CLI**：新增 1 个子命令
+- **文档**：2 个 md 文件
+
+## 8. 后续可演进方向
+
+1. 加 `--color` 开关输出 ANSI 高亮（failed 红、success 绿）
+2. 加 `--follow` 模式轮询（每 5s 刷新，用于调试长 loop）
+3. 加 `--step <name>` 过滤只显示某一步
+4. 加 `--from <seq>` / `--to <seq>` 切片
+5. 性能优化：loop execution 巨大（>1000 step）时分页

--- a/docs/ntd-cli.md
+++ b/docs/ntd-cli.md
@@ -514,15 +514,16 @@ ntd loop execution get <EXECUTION_ID>
 ---
 
 #### `ntd loop execution blackboard <EXECUTION_ID>`
-以人类可读的黑板视图查看 Loop 执行情况：每个 step 的状态、执行记录 ID（exec）和结论摘要。
-默认输出黑板视图，加 `--json` 输出原始 JSON（与 `execution get` 一致但只聚焦 step_executions）。
+查看 Loop 执行的黑板视图：每个 step 的状态、执行记录 ID（exec）和结论摘要。
+**默认输出 JSON**（AI/脚本友好），加 `--human` 输出人类可读黑板文本。
 
 **设计动机**：每一步的 `conclusion` 字段就是该步骤写入黑板的内容。
 Loop 执行过程中，下一步的 prompt 通过 `{{blackboard}}`、`{{last_output}}`、`{{last_conclusion}}` 等占位符读取此前的累计输出。
-此命令把这个机制从运行期搬到 CLI 调试期，方便人工复盘整个 loop 跑到哪一步、各步结果如何。
+此命令把这个机制从运行期搬到 CLI 调试期。
 
 ```bash
-ntd loop execution blackboard <EXECUTION_ID> [--json]
+ntd loop execution blackboard <EXECUTION_ID>            # 默认 JSON
+ntd loop execution blackboard <EXECUTION_ID> --human    # 人类可读黑板视图
 ```
 
 **选项：**
@@ -530,9 +531,34 @@ ntd loop execution blackboard <EXECUTION_ID> [--json]
 | 选项 | 说明 |
 |------|------|
 | `<EXECUTION_ID>` | 必填，loop execution 主键 |
-| `--json` | 输出原始 JSON（默认是人类可读黑板视图） |
+| `--human` | 输出人类可读黑板视图（默认是 JSON） |
 
-**示例输出**：
+**为什么默认 JSON**：CLI 主要消费者是 AI（Claude Code 等）和 shell 脚本，jq/grep 友好是绝对主流。人类有更好的 UI（前端 BlackboardDrawer），需要时显式加 `--human`。
+
+**示例输出**（JSON，默认）：
+
+```json
+{
+  "id": 1105,
+  "loop_name": "笑话工厂",
+  "status": "success",
+  "step_executions": [
+    {
+      "sequence_index": 1,
+      "step_name": "讲个笑话",
+      "status": "success",
+      "execution_record_id": 1137,
+      "conclusion": "为什么程序员总是分不清万圣节和圣诞节？因为 Oct 31 等于 Dec 25！"
+    }
+  ],
+  "token_summary": {
+    "total_input_tokens": 13003,
+    "total_output_tokens": 628
+  }
+}
+```
+
+**示例输出**（`--human`）：
 
 ```
 ═══ Loop Execution #42 ────────────────────────────────
@@ -552,18 +578,17 @@ ntd loop execution blackboard <EXECUTION_ID> [--json]
   #3 ⏭️ skipped          更新 README                 评分 -
      exec: -
      (无结论)
-     原因: 步骤已跳过（依赖 #2 失败）
 
 ═══ 3 步 / Token: 输入 12k 输出 5k ════════════════════════
 ```
 
-**状态图标**：`success` ✅ · `failed` ❌ · `running` ⏳ · `pending` ⏸ · `pending_approval` 🤔 · `skipped` ⏭️
+**状态图标**（仅 `--human` 模式）：`success` ✅ · `failed` ❌ · `running` ⏳ · `pending` ⏸ · `pending_approval` 🤔 · `skipped` ⏭️
 
 **边界处理**：
-- execution 不存在：返回 `API error 404`，不崩溃
-- step_executions 为空：显示「黑板为空（loop 尚未执行任何步骤）」
-- step 失败且无 conclusion：用 error_message 替代结论
-- step 待审批：显示 approval_comment + 「等待人工审批」
+- execution 不存在：返回 `{"error":true,"message":"..."}`，exit 1
+- step_executions 为空：返回 `step_executions: []`，不报错
+- step 失败且无 conclusion：渲染时用 `error_message` 替代
+- step 待审批：渲染时显示 `approval_comment` + 「等待人工审批」
 
 完整设计见 [`docs/loop-blackboard-cli.md`](./loop-blackboard-cli.md)。
 

--- a/docs/ntd-cli.md
+++ b/docs/ntd-cli.md
@@ -513,6 +513,62 @@ ntd loop execution get <EXECUTION_ID>
 
 ---
 
+#### `ntd loop execution blackboard <EXECUTION_ID>`
+以人类可读的黑板视图查看 Loop 执行情况：每个 step 的状态、执行记录 ID（exec）和结论摘要。
+默认输出黑板视图，加 `--json` 输出原始 JSON（与 `execution get` 一致但只聚焦 step_executions）。
+
+**设计动机**：每一步的 `conclusion` 字段就是该步骤写入黑板的内容。
+Loop 执行过程中，下一步的 prompt 通过 `{{blackboard}}`、`{{last_output}}`、`{{last_conclusion}}` 等占位符读取此前的累计输出。
+此命令把这个机制从运行期搬到 CLI 调试期，方便人工复盘整个 loop 跑到哪一步、各步结果如何。
+
+```bash
+ntd loop execution blackboard <EXECUTION_ID> [--json]
+```
+
+**选项：**
+
+| 选项 | 说明 |
+|------|------|
+| `<EXECUTION_ID>` | 必填，loop execution 主键 |
+| `--json` | 输出原始 JSON（默认是人类可读黑板视图） |
+
+**示例输出**：
+
+```
+═══ Loop Execution #42 ────────────────────────────────
+循环: 每日代码 review
+触发: cron @ 0 9 * * *
+状态: ✅ success · 完成 3/3 步
+开始: 2026-07-03 09:00:00 · 结束: 09:45:32
+
+  #1 ✅ success          编写 CRUD 代码             评分 85
+     exec: #1024
+     完成了用户登录功能的 CRUD 代码
+
+  #2 ✅ success          补充单元测试               评分 90
+     exec: #1025
+     新增 12 个测试用例，覆盖率提升到 87%
+
+  #3 ⏭️ skipped          更新 README                 评分 -
+     exec: -
+     (无结论)
+     原因: 步骤已跳过（依赖 #2 失败）
+
+═══ 3 步 / Token: 输入 12k 输出 5k ════════════════════════
+```
+
+**状态图标**：`success` ✅ · `failed` ❌ · `running` ⏳ · `pending` ⏸ · `pending_approval` 🤔 · `skipped` ⏭️
+
+**边界处理**：
+- execution 不存在：返回 `API error 404`，不崩溃
+- step_executions 为空：显示「黑板为空（loop 尚未执行任何步骤）」
+- step 失败且无 conclusion：用 error_message 替代结论
+- step 待审批：显示 approval_comment + 「等待人工审批」
+
+完整设计见 [`docs/loop-blackboard-cli.md`](./loop-blackboard-cli.md)。
+
+---
+
 #### `ntd loop results <EXECUTION_ID>`
 获取 Loop 执行结果（步骤级摘要）。
 


### PR DESCRIPTION
## 概要

新增 `ntd loop execution blackboard <execution_id>` 命令，把 Loop Studio 在执行期通过 `{{blackboard}}` 占位符读到的「累积结论」搬到 CLI 视图。

## 输出语义

**默认输出 JSON**（AI/脚本友好），加 `--human` 切换为人类可读黑板文本。

## 命令语法

```bash
ntd loop execution blackboard <EXECUTION_ID>            # 默认 JSON
ntd loop execution blackboard <EXECUTION_ID> --human    # 人类可读视图
```

## 测试覆盖

| 层级 | 文件 | 数量 | 覆盖 |
|------|------|------|------|
| 单元测试 | `backend/src/cli/commands.rs` | 36 | `render_blackboard` 各场景（图标、结论、错误/待审批/anomaly、CJK 截断、空黑板、降级、status_icon） |
| 集成测试 | `backend/tests/blackboard_cli_tests.rs` | **13** | CLI 解析（4）+ HTTP dispatch（2）+ E2E 渲染（5）+ 错误传播（1）+ 并发安全（1） |
| **合计** | | **49** | |

### 集成测试细节

- 解析层：`try_parse_from` 各种组合（default / --human / 与全局 -o pretty / 缺 ID 报错）
- HTTP 层：本地 mock TCP server 返回 ApiResponse JSON，验证 ApiClient 解析 + 错误码传播
- E2E：mock API → ApiClient → `render_blackboard_to` → 断言输出含循环名/状态/record_id/评分/token 等关键片段
- 并发：20 个并发请求 + 5s 超时，防止锁泄漏回归

## 改动文件

| 文件 | 改动 |
|------|------|
| `backend/src/cli/commands.rs` | 新增 `Blackboard` 变体 + 渲染 helpers (write_blackboard_header/footer/step + format_step_header + truncate_to_width) + 36 个单元测试 |
| `backend/tests/blackboard_cli_tests.rs` | **新增**，13 个端到端集成测试 |
| `backend/ARCHITECTURE.md` | 修正 schema：移除过期的 `loop_executions.blackboard` 字段，补全 `loop_step_executions.sequence_index + conclusion` |
| `docs/ntd-cli.md` | 命令文档 + 示例输出 |
| `docs/FEATURES.md` | 黑板上下文补全 + 新增「黑板 CLI 查询」行 |
| `docs/loop-blackboard-cli.md` | 完整设计文档（新文件） |

## 测试结果

```
test result: ok. 974 passed; 0 failed  (lib)
test result: ok. 36 passed; 0 failed   (cli 单元测试)
test result: ok. 13 passed; 0 failed   (blackboard_cli_tests 集成测试)
```

## 提交历史

- `eda7115` feat(cli): add ntd loop execution blackboard command
- `71e0f4e` feat(cli): switch loop blackboard default to JSON for AI/script consumers
- `1326778` docs: align ARCHITECTURE.md and FEATURES.md with actual blackboard implementation
- `2fdbccf` refactor(cli): address coderabbit review on blackboard command
- `82b5f6c` test(blackboard): add end-to-end integration tests for blackboard CLI

## Review fixes (PR #814 coderabbit)

针对 review 提的 4 个 actionable 项：

1. **函数长度**：把 `render_blackboard` / `render_blackboard_step` 拆成 6 个 ≤30 行的 helper
2. **中文对齐**：`truncate_to_width` 按 display width（ASCII=1, CJK>=U+0080=2）截断
3. **测试覆盖**：单元测试 7 个 `*_assert_output` + 集成测试 13 个 E2E，捕获输出断言关键片段
4. **文档签名同步**：`render_blackboard(data: Option<&Value>)` 与代码一致

## 设计文档

[`docs/loop-blackboard-cli.md`](./loop-blackboard-cli.md)