### PR TITLE
feat: 统一跨组件执行器选择记忆功能

### DIFF
--- a/frontend/src/components/ActionButton/index.tsx
+++ b/frontend/src/components/ActionButton/index.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Button, Drawer, Spin, Typography, Space, message, Input, Tag } from 'antd';
 import { ThunderboltOutlined, EditOutlined } from '@ant-design/icons';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useActionExecution } from './useActionExecution';
 import { ExecutorPicker } from '@/components/todo-drawer/ExecutorPicker';
 import { EXECUTORS_FOR_PICKER } from '@/types/execution';
+import { getLastExecutor, setLastExecutor } from '@/constants';
 import type { ActionButtonProps } from './types';
 
 const { Text, Paragraph } = Typography;
@@ -38,7 +39,10 @@ export function ActionButton({
 }: ActionButtonProps) {
   const [open, setOpen] = useState(false);
   const [editablePrompt, setEditablePrompt] = useState(prompt);
-  const [selectedExecutor, setSelectedExecutor] = useState<string | undefined>(executor);
+  // 初始化 selectedExecutor：优先从 localStorage 恢复上次选择，不存在时回退到 prop executor
+  const [selectedExecutor, setSelectedExecutor] = useState<string | undefined>(
+    () => getLastExecutor(executor)
+  );
   const isMobile = useIsMobile();
   const { status, result, error, execute, retry, reset } = useActionExecution(
     actionType,
@@ -49,13 +53,24 @@ export function ActionButton({
     executor,
   );
 
-  // 打开时重置 editablePrompt 为默认值
+  // 打开 Drawer 时：
+  // - 重置 editablePrompt 为最新的 prompt 默认值
+  // - 从 localStorage 恢复上次选的执行器（覆盖 prop 传入的默认值）
+  //   这样用户每次打开都是自己上次的选择，而不是每次回到默认。
   useEffect(() => {
     if (open) {
       setEditablePrompt(prompt);
-      setSelectedExecutor(executor);
+      const saved = getLastExecutor(executor);
+      setSelectedExecutor(saved);
     }
-  }, [open, prompt, executor]);
+  }, [open, prompt, executor, actionType, actionKey]);
+
+  // 用户切换执行器时同时保存选择到 localStorage，
+  // 确保本次关闭后下次打开 Drawer 能恢复成这个值。
+  const handleExecutorChange = useCallback((value: string) => {
+    setSelectedExecutor(value);
+    setLastExecutor(value);
+  }, []);
 
   const handleOpen = () => {
     reset();
@@ -110,11 +125,11 @@ export function ActionButton({
             />
           </div>
 
-          {/* 执行器选择 */}
+          {/* 执行器选择（选择后自动记住到 localStorage，下次打开同理恢复） */}
           <ExecutorPicker
             executor={selectedExecutor || 'claudecode'}
             executorOptions={EXECUTORS_FOR_PICKER}
-            onChange={setSelectedExecutor}
+            onChange={handleExecutorChange}
           />
 
           {/* 参数预览 */}

--- a/frontend/src/components/QuickCaptureModal.tsx
+++ b/frontend/src/components/QuickCaptureModal.tsx
@@ -5,6 +5,7 @@ import { WorkspaceSelect } from '@/components/common/WorkspaceSelect';
 import { ExecutorPickerPopover } from '@/components/common/ExecutorPickerPopover';
 import * as db from '@/utils/database';
 import { DEFAULT_EXECUTOR } from '@/types';
+import { getLastExecutor, setLastExecutor } from '@/constants';
 
 interface QuickCaptureModalProps {
   open: boolean;
@@ -20,23 +21,6 @@ function extractTitle(content: string): string {
   const firstLine = content.split('\n')[0]?.trim() ?? '';
   if (firstLine.length <= 30) return firstLine;
   return firstLine.slice(0, 30) + '...';
-}
-
-// localStorage key for remembering last executor choice
-const STORAGE_KEY_LAST_EXECUTOR = 'ntd_quick_capture_last_executor';
-
-function getLastExecutor(): string {
-  try {
-    return localStorage.getItem(STORAGE_KEY_LAST_EXECUTOR) || DEFAULT_EXECUTOR;
-  } catch {
-    return DEFAULT_EXECUTOR;
-  }
-}
-
-function setLastExecutor(executor: string) {
-  try {
-    localStorage.setItem(STORAGE_KEY_LAST_EXECUTOR, executor);
-  } catch {}
 }
 
 export function QuickCaptureModal({

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -6,6 +6,7 @@ import { WorkspaceSelect } from './common/WorkspaceSelect';
 
 import type { Todo, ExecutorConfig, ExecutorOption, SkillMeta, ExecutorSkills, TodoTemplate } from '@/types';
 import { EXECUTORS, executorConfigToOption, getExecutorColor, DEFAULT_EXECUTOR } from '@/types';
+import { getLastExecutor, setLastExecutor } from '@/constants';
 import { TagCheckCardGroup } from './TagCheckCard';
 import { ExecutorPicker } from './todo-drawer/ExecutorPicker';
 import { PromptEditor } from './todo-drawer/PromptEditor';
@@ -134,6 +135,14 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
       dispatch({ type: 'RESET_FORM', todo });
     }
   }, [open, todo]);
+
+  // 创建模式下，RESET_FORM 之后从 localStorage 恢复上次选择的执行器，
+  // 而不是每次都回退到 DEFAULT_EXECUTOR。编辑模式保持 todo 自带的 executor。
+  useEffect(() => {
+    if (open && !todo) {
+      setField('executor', getLastExecutor());
+    }
+  }, [open, todo, setField]);
 
   // 创建模式下自动选中当前工作空间（打开时 todo=null 触发）
   // 工作空间以 id（number）传递，不再用 path 字符串。
@@ -267,7 +276,12 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
         </div>
 
         <div style={{ flex: 1, overflow: 'auto', padding: '16px 20px' }}>
-          <ExecutorPicker executor={executor} executorOptions={executorOptions} onChange={(v) => setField('executor', v)} />
+          {/* 执行器选择（创建模式下切换后自动记住到 localStorage，下次新建同理恢复） */}
+          <ExecutorPicker executor={executor} executorOptions={executorOptions} onChange={(v) => {
+            setField('executor', v);
+            // 只在创建模式下记忆——编辑模式用户只是临时调整，不应覆盖记忆
+            if (!todo) setLastExecutor(v);
+          }} />
 
           <Divider style={{ margin: '8px 0 16px' }} />
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -225,3 +225,31 @@ export const EXPORT = {
 
 /** 复制反馈延迟 */
 export const COPY_FEEDBACK_DELAY = 2000;
+
+// =============================================================================
+// Executor last-choice persistence — single key shared across all components
+// that offer executor selection (ActionButton, TodoDrawer, QuickCaptureModal).
+// When the user picks an executor in one place, the other two remember it too.
+// =============================================================================
+
+/** localStorage key 统一用于跨组件记忆用户上次选择的执行器 */
+export const LAST_EXECUTOR_STORAGE_KEY = 'ntd_last_executor';
+
+/** 从 localStorage 读出上次选择的执行器，不存在时回退到 DEFAULT_EXECUTOR */
+export function getLastExecutor(defaultExecutor: string = 'claudecode'): string {
+  try {
+    return localStorage.getItem(LAST_EXECUTOR_STORAGE_KEY) || defaultExecutor;
+  } catch {
+    // 隐私模式 / 配额满：静默吞掉
+    return defaultExecutor;
+  }
+}
+
+/** 将用户选择的执行器写入 localStorage */
+export function setLastExecutor(executor: string) {
+  try {
+    localStorage.setItem(LAST_EXECUTOR_STORAGE_KEY, executor);
+  } catch {
+    // 写入失败不阻塞用户体验
+  }
+}


### PR DESCRIPTION
## 改动内容

将 ActionButton、TodoDrawer、QuickCaptureModal 三个组件中的执行器选择记忆功能统一为全局 localStorage key `ntd_last_executor`，用户在一个组件中选择执行器后，其他组件自动记住同一个值。

### 涉及文件

| 文件 | 改动 |
|------|------|
| `frontend/src/constants.ts` | 新增 `LAST_EXECUTOR_STORAGE_KEY` + `getLastExecutor()` / `setLastExecutor()` — 唯一数据源 |
| `frontend/src/components/ActionButton/index.tsx` | 改用 `@/constants` 导入，打开时从 localStorage 恢复，切换时保存 |
| `frontend/src/components/TodoDrawer.tsx` | 同上；创建模式生效，编辑模式不覆盖 todo 自身 executor |
| `frontend/src/components/QuickCaptureModal.tsx` | 删除本地 `STORAGE_KEY_LAST_EXECUTOR` 及重复函数，改用共享导入 |

### 设计决策
- **统一 key**：三个组件读写同一个 `ntd_last_executor` 键，一处设置处处生效
- **编辑模式不记忆**：TodoDrawer 编辑已有事项时，用户临时调整不应覆盖记忆值
- **try/catch 兜底**：隐私模式 / 配额满时静默降级到默认执行器

### 验证
```
npx tsc --noEmit --pretty  →  exit code: 0
```
