### PR TITLE
feat: 实现黑板 (Blackboard) 功能

### DIFF
--- a/backend/src/db/blackboard.rs
+++ b/backend/src/db/blackboard.rs
@@ -27,8 +27,9 @@ impl Database {
 
     /// 为指定工作空间创建一条空的黑板记录。
     ///
-    /// 如果该工作空间已有黑板记录，会因 UNIQUE 约束失败返回 Err。
-    /// 调用方应先调用 get_blackboard 检查是否存在，或使用 Service 层的 find_or_create 封装方法。
+    /// 幂等实现：使用 `ON CONFLICT(workspace_id) DO NOTHING` + 重新查询，
+    /// 避免并发场景下两个请求同时走"先查后建"路径时因 UNIQUE 约束相互失败。
+    /// 返回值始终是该工作空间当前的黑板记录（新建或已存在）。
     pub async fn create_blackboard(
         &self,
         workspace_id: i64,
@@ -40,11 +41,33 @@ impl Database {
             workspace_id: ActiveValue::Set(workspace_id),
             // 初始内容为空：创建时的黑板无内容，由后续 LLM 更新填充
             content: ActiveValue::Set(String::new()),
-            updated_at: ActiveValue::Set(Some(now.clone())),
-            created_at: ActiveValue::Set(Some(now)),
+            updated_at: ActiveValue::Set(Some(now)),
+            created_at: ActiveValue::Set(Some(crate::models::utc_timestamp())),
             ..Default::default()
         };
-        model.insert(&self.conn).await
+        // ON CONFLICT(workspace_id) DO NOTHING：若记录已存在则跳过 insert，
+        // 避免并发竞争下两个并发请求都走 insert 路径时第二个失败。
+        // 后续重读以拿到稳定的 Model（含实际的主键 id）。
+        blackboards::Entity::insert(model)
+            .on_conflict(
+                OnConflict::column(blackboards::Column::WorkspaceId)
+                    .do_nothing()
+                    .to_owned(),
+            )
+            .exec_without_returning(&self.conn)
+            .await?;
+        // 重读：insert 的 ON CONFLICT DO NOTHING 不会返回行，必须重新查询拿主键
+        blackboards::Entity::find()
+            .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
+            .one(&self.conn)
+            .await?
+            // 极端情况：上一句 insert 后立刻被外部删除，理论上不会发生
+            .ok_or_else(|| {
+                sea_orm::DbErr::RecordNotFound(format!(
+                    "blackboard for workspace {} not found after upsert",
+                    workspace_id
+                ))
+            })
     }
 
     /// 更新指定工作空间的黑板内容（记录必须已存在）。
@@ -150,6 +173,35 @@ mod tests {
         let fetched = db.get_blackboard(ws_id).await.unwrap();
         assert!(fetched.is_some());
         assert_eq!(fetched.unwrap().id, board.id);
+    }
+
+    /// 验证 create_blackboard 在记录已存在时返回相同记录（幂等）。
+    /// 防止并发场景下两个请求同时首次创建时第二个因 UNIQUE 约束失败。
+    /// 行为：第二次调用应直接拿到第一条记录，不应 panic / 返回 Err。
+    #[tokio::test]
+    async fn test_create_blackboard_is_idempotent_for_same_workspace() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+        let ws_id = create_test_workspace(&db).await;
+
+        // 第一次：创建
+        let first = db.create_blackboard(ws_id).await.unwrap();
+        // 第二次：应幂等返回同一条记录（不会因 UNIQUE 冲突失败）
+        let second = db.create_blackboard(ws_id).await.unwrap();
+        assert_eq!(
+            first.id, second.id,
+            "重复 create_blackboard 应返回同一条记录的 id"
+        );
+        assert_eq!(second.workspace_id, ws_id);
+        assert_eq!(second.content, "");
+        // 数据库中应只有一条记录，没有产生重复行
+        let all = blackboards::Entity::find()
+            .filter(blackboards::Column::WorkspaceId.eq(ws_id))
+            .all(&db.conn)
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 1, "同一 workspace 只能有一条黑板记录");
     }
 
     /// 验证 update_blackboard_content 更新成功。

--- a/backend/src/db/blackboard.rs
+++ b/backend/src/db/blackboard.rs
@@ -1,0 +1,152 @@
+//! 黑板（Blackboard）数据库层方法。
+//!
+//! 提供黑板的 CRUD 操作，每个工作空间最多一条黑板记录（由 UNIQUE 约束保证）。
+
+use sea_orm::{
+    ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter,
+};
+
+use super::entity::blackboards;
+use super::Database;
+
+impl Database {
+    /// 根据 workspace_id 获取黑板内容。
+    ///
+    /// 返回 Option<blackboards::Model>，None 表示该工作空间还没有黑板记录。
+    /// 新工作空间首次访问时返回 None，由 Service 层的 find_or_create 方法处理初始化。
+    pub async fn get_blackboard(
+        &self,
+        workspace_id: i64,
+    ) -> Result<Option<blackboards::Model>, sea_orm::DbErr> {
+        blackboards::Entity::find()
+            .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
+            .one(&self.conn)
+            .await
+    }
+
+    /// 为指定工作空间创建一条空的黑板记录。
+    ///
+    /// 如果该工作空间已有黑板记录，会因 UNIQUE 约束失败返回 Err。
+    /// 调用方应先调用 get_blackboard 检查是否存在，或使用 Service 层的 find_or_create 封装方法。
+    pub async fn create_blackboard(
+        &self,
+        workspace_id: i64,
+    ) -> Result<blackboards::Model, sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+        let model = blackboards::ActiveModel {
+            workspace_id: ActiveValue::Set(workspace_id),
+            content: ActiveValue::Set(String::new()),
+            updated_at: ActiveValue::Set(Some(now.clone())),
+            created_at: ActiveValue::Set(Some(now)),
+            ..Default::default()
+        };
+        model.insert(&self.conn).await
+    }
+
+    /// 更新指定工作空间的黑板内容。
+    ///
+    /// 如果该工作空间没有黑板记录，会因 Foreign Key 约束失败返回 Err。
+    /// 调用方应先确保黑板记录存在（get_blackboard 返回 Some），
+    /// 或使用 Service 层的 find_or_create_blackboard 封装方法。
+    pub async fn update_blackboard_content(
+        &self,
+        workspace_id: i64,
+        content: &str,
+    ) -> Result<(), sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+        let model = blackboards::Entity::find()
+            .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
+            .one(&self.conn)
+            .await?;
+
+        let Some(model) = model else {
+            // 记录不存在时返回 RecordNotFound 错误
+            return Err(sea_orm::DbErr::RecordNotFound(format!(
+                "blackboard for workspace {} not found",
+                workspace_id
+            )));
+        };
+
+        let mut am: blackboards::ActiveModel = model.into();
+        am.content = ActiveValue::Set(content.to_string());
+        am.updated_at = ActiveValue::Set(Some(now));
+        am.update(&self.conn).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    /// 创建一个测试用工作空间（project_directories），返回其 id。
+    async fn create_test_workspace(db: &Database) -> i64 {
+        db.create_project_directory("/tmp/test-blackboard-workspace", None, false, false)
+            .await
+            .expect("create workspace must succeed")
+    }
+
+    /// 验证 get_blackboard 在无记录时返回 None。
+    #[tokio::test]
+    async fn test_get_blackboard_returns_none_when_empty() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+        // 不存在的 workspace_id 应返回 None
+        let result = db.get_blackboard(999).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    /// 验证 create_blackboard 成功创建一条空黑板记录。
+    #[tokio::test]
+    async fn test_create_blackboard_success() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+        let ws_id = create_test_workspace(&db).await;
+
+        let board = db.create_blackboard(ws_id).await.unwrap();
+        assert_eq!(board.workspace_id, ws_id);
+        assert_eq!(board.content, "");
+        assert!(board.created_at.is_some());
+        assert!(board.updated_at.is_some());
+
+        // 验证可通过 get 查到
+        let fetched = db.get_blackboard(ws_id).await.unwrap();
+        assert!(fetched.is_some());
+        assert_eq!(fetched.unwrap().id, board.id);
+    }
+
+    /// 验证 update_blackboard_content 更新成功。
+    #[tokio::test]
+    async fn test_update_blackboard_content_success() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+        let ws_id = create_test_workspace(&db).await;
+        let _ = db.create_blackboard(ws_id).await.unwrap();
+
+        db.update_blackboard_content(ws_id, "# 更新后的内容")
+            .await
+            .unwrap();
+
+        let fetched = db.get_blackboard(ws_id).await.unwrap().unwrap();
+        assert_eq!(fetched.content, "# 更新后的内容");
+    }
+
+    /// 验证 update_blackboard_content 在不存在的 workspace 上返回 RecordNotFound。
+    #[tokio::test]
+    async fn test_update_blackboard_content_record_not_found() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+
+        let result = db.update_blackboard_content(999, "# test").await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            sea_orm::DbErr::RecordNotFound(_) => {} // 期望的错误类型
+            other => panic!("expected RecordNotFound, got: {:?}", other),
+        }
+    }
+}

--- a/backend/src/db/blackboard.rs
+++ b/backend/src/db/blackboard.rs
@@ -3,7 +3,8 @@
 //! 提供黑板的 CRUD 操作，每个工作空间最多一条黑板记录（由 UNIQUE 约束保证）。
 
 use sea_orm::{
-    ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter,
+    sea_query::OnConflict, ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait,
+    QueryFilter, UpdateResult,
 };
 
 use super::entity::blackboards;
@@ -32,9 +33,12 @@ impl Database {
         &self,
         workspace_id: i64,
     ) -> Result<blackboards::Model, sea_orm::DbErr> {
+        // 用 utc_timestamp() 统一时间源，避免不同 DB driver 时区差异
         let now = crate::models::utc_timestamp();
+        // 构造 ActiveModel：除主键外的字段显式赋值，主键交由 SQLite 自增
         let model = blackboards::ActiveModel {
             workspace_id: ActiveValue::Set(workspace_id),
+            // 初始内容为空：创建时的黑板无内容，由后续 LLM 更新填充
             content: ActiveValue::Set(String::new()),
             updated_at: ActiveValue::Set(Some(now.clone())),
             created_at: ActiveValue::Set(Some(now)),
@@ -43,34 +47,64 @@ impl Database {
         model.insert(&self.conn).await
     }
 
-    /// 更新指定工作空间的黑板内容。
+    /// 更新指定工作空间的黑板内容（记录必须已存在）。
     ///
-    /// 如果该工作空间没有黑板记录，会因 Foreign Key 约束失败返回 Err。
-    /// 调用方应先确保黑板记录存在（get_blackboard 返回 Some），
-    /// 或使用 Service 层的 find_or_create_blackboard 封装方法。
+    /// 性能取舍：单条 `UPDATE ... WHERE workspace_id = ?`，避免原先 SELECT-then-UPDATE
+    /// 的两次往返 + TOCTOU 窗口。如果记录不存在，rows_affected = 0，
+    /// 返回 `RecordNotFound` 让调用方能识别这种情况。
     pub async fn update_blackboard_content(
         &self,
         workspace_id: i64,
         content: &str,
     ) -> Result<(), sea_orm::DbErr> {
+        // 时间戳：单独变量确保 created_at / updated_at 用同一时刻
         let now = crate::models::utc_timestamp();
-        let model = blackboards::Entity::find()
+        // 单语句 UPDATE：workspace_id 是 UNIQUE 索引，命中后只更新一行
+        let res: UpdateResult = blackboards::Entity::update_many()
+            .col_expr(blackboards::Column::Content, content.into())
+            .col_expr(blackboards::Column::UpdatedAt, now.into())
             .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
-            .one(&self.conn)
+            .exec(&self.conn)
             .await?;
-
-        let Some(model) = model else {
-            // 记录不存在时返回 RecordNotFound 错误
+        // rows_affected == 0 表示记录不存在（区别于"存在但内容相同"的 0 变更）
+        if res.rows_affected == 0 {
             return Err(sea_orm::DbErr::RecordNotFound(format!(
                 "blackboard for workspace {} not found",
                 workspace_id
             )));
-        };
+        }
+        Ok(())
+    }
 
-        let mut am: blackboards::ActiveModel = model.into();
-        am.content = ActiveValue::Set(content.to_string());
-        am.updated_at = ActiveValue::Set(Some(now));
-        am.update(&self.conn).await?;
+    /// Upsert 黑板内容：记录不存在则创建，存在则更新。
+    ///
+    /// 通过 `INSERT ... ON CONFLICT(workspace_id) DO UPDATE` 一次往返完成
+    /// 创建/更新判断 + 写入，避免 service 层先 get 再 create 再 update 的 3 次往返。
+    /// 用 workspace_id 唯一约束做冲突判定，与 schema UNIQUE 保持一致。
+    pub async fn upsert_blackboard_content(
+        &self,
+        workspace_id: i64,
+        content: &str,
+    ) -> Result<(), sea_orm::DbErr> {
+        // 同一时刻填充 created_at 和 updated_at：upsert 时两个字段语义一致
+        let now = crate::models::utc_timestamp();
+        // 构造 ActiveModel：与 create_blackboard 保持一致的初始结构
+        let am = blackboards::ActiveModel {
+            workspace_id: ActiveValue::Set(workspace_id),
+            content: ActiveValue::Set(content.to_string()),
+            updated_at: ActiveValue::Set(Some(now.clone())),
+            created_at: ActiveValue::Set(Some(now)),
+            ..Default::default()
+        };
+        // ON CONFLICT(workspace_id)：命中后只覆盖 content/updated_at，保留 created_at
+        blackboards::Entity::insert(am)
+            .on_conflict(
+                OnConflict::column(blackboards::Column::WorkspaceId)
+                    .update_columns([blackboards::Column::Content, blackboards::Column::UpdatedAt])
+                    .to_owned(),
+            )
+            .exec(&self.conn)
+            .await?;
         Ok(())
     }
 }
@@ -148,5 +182,49 @@ mod tests {
             sea_orm::DbErr::RecordNotFound(_) => {} // 期望的错误类型
             other => panic!("expected RecordNotFound, got: {:?}", other),
         }
+    }
+
+    /// 验证 upsert_blackboard_content 在记录不存在时直接创建。
+    #[tokio::test]
+    async fn test_upsert_creates_when_missing() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+        let ws_id = create_test_workspace(&db).await;
+
+        // 首次 upsert：记录不存在，应当走 INSERT 分支
+        db.upsert_blackboard_content(ws_id, "# 初始内容")
+            .await
+            .unwrap();
+
+        let fetched = db.get_blackboard(ws_id).await.unwrap().unwrap();
+        assert_eq!(fetched.content, "# 初始内容");
+    }
+
+    /// 验证 upsert_blackboard_content 在记录已存在时更新内容并保留 created_at。
+    #[tokio::test]
+    async fn test_upsert_updates_when_exists() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+        let ws_id = create_test_workspace(&db).await;
+
+        // 先 upsert 一次拿到初始记录
+        db.upsert_blackboard_content(ws_id, "# 第一次")
+            .await
+            .unwrap();
+        let first = db.get_blackboard(ws_id).await.unwrap().unwrap();
+        let first_created = first.created_at.clone();
+        let first_id = first.id;
+
+        // 二次 upsert：ON CONFLICT 分支，应当覆盖 content 但保留 id/created_at
+        db.upsert_blackboard_content(ws_id, "# 第二次")
+            .await
+            .unwrap();
+        let second = db.get_blackboard(ws_id).await.unwrap().unwrap();
+
+        assert_eq!(second.id, first_id, "upsert 不应改变主键");
+        assert_eq!(second.content, "# 第二次", "content 应当被覆盖");
+        assert_eq!(second.created_at, first_created, "created_at 应当保留");
     }
 }

--- a/backend/src/db/entity/blackboards.rs
+++ b/backend/src/db/entity/blackboards.rs
@@ -1,0 +1,25 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// 黑板（Blackboard）实体：每个工作空间维护一个黑板，由 LLM 自动维护。
+///
+/// 每个 workspace 最多一条记录（workspace_id 为 UNIQUE），
+/// content 字段存储 Markdown 格式的黑板内容。
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "blackboards")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    /// 工作空间 ID（唯一），关联 project_directories(id)
+    pub workspace_id: i64,
+    /// 黑板 Markdown 内容
+    #[sea_orm(column_type = "Text")]
+    pub content: String,
+    pub updated_at: Option<String>,
+    pub created_at: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/entity/mod.rs
+++ b/backend/src/db/entity/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent_bots;
+pub mod blackboards;
 pub mod execution_logs;
 pub mod execution_records;
 pub mod executors;
@@ -31,6 +32,7 @@ pub mod workspace_slash_commands;
 
 pub mod prelude {
     pub use super::agent_bots::Entity as AgentBots;
+    pub use super::blackboards::Entity as Blackboards;
     pub use super::execution_logs::Entity as ExecutionLogs;
     pub use super::execution_records::Entity as ExecutionRecords;
     pub use super::executors::Entity as Executors;

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -11,6 +11,7 @@ use super::Database;
 mod v1;
 mod v2_v5;
 mod v41_v46;
+mod v47;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -44,6 +45,7 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v41_v46::V44AddFeishuMessagesProcessedId),
         Box::new(v41_v46::V45AddTodosActionType),
         Box::new(v41_v46::V46AddTodosActionKey),
+        Box::new(v47::V47CreateBlackboardsTable),
     ]
 }
 

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -12,6 +12,7 @@ mod v1;
 mod v2_v5;
 mod v41_v46;
 mod v47;
+mod v48;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -46,6 +47,7 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v41_v46::V45AddTodosActionType),
         Box::new(v41_v46::V46AddTodosActionKey),
         Box::new(v47::V47CreateBlackboardsTable),
+        Box::new(v48::V48ScopeTodosActionKeyByWorkspace),
     ]
 }
 

--- a/backend/src/db/migration/v47.rs
+++ b/backend/src/db/migration/v47.rs
@@ -1,0 +1,77 @@
+//! 数据库迁移 V47：创建 blackboards 表。
+//!
+//! 每个工作空间维护一个黑板记录，用于存储 LLM 自动生成的 Markdown 知识库内容。
+//! workspace_id 为 UNIQUE，确保每个工作空间最多一条黑板记录。
+
+use async_trait::async_trait;
+
+use super::super::Database;
+use super::{Migration, table_exists};
+
+pub(super) struct V47CreateBlackboardsTable;
+
+#[async_trait]
+impl Migration for V47CreateBlackboardsTable {
+    fn version(&self) -> i64 {
+        47
+    }
+
+    fn name(&self) -> &'static str {
+        "create_blackboards_table"
+    }
+
+    /// 创建 blackboards 表。
+    ///
+    /// 使用 CREATE TABLE IF NOT EXISTS 保证幂等性。
+    /// workspace_id 设为 UNIQUE，每个工作空间只能有一条黑板记录。
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 先检查表是否已存在，避免重复执行 CREATE TABLE 的日志噪声
+        if table_exists(db, "blackboards").await? {
+            return Ok(());
+        }
+
+        let sql = r#"
+CREATE TABLE IF NOT EXISTS blackboards (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    workspace_id INTEGER NOT NULL UNIQUE,
+    content TEXT NOT NULL DEFAULT '',
+    updated_at TEXT,
+    created_at TEXT,
+    FOREIGN KEY (workspace_id) REFERENCES project_directories(id) ON DELETE CASCADE
+);
+"#;
+        db.exec(sql).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    /// 验证 V47 迁移可成功创建 blackboards 表。
+    #[tokio::test]
+    async fn test_v47_creates_blackboards_table() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+
+        let migration = V47CreateBlackboardsTable;
+        migration.up(&db).await.expect("V47 migration must succeed");
+
+        // 验证表已存在
+        assert!(table_exists(&db, "blackboards").await.unwrap());
+    }
+
+    /// 验证 V47 迁移是幂等的（重复执行不会报错）。
+    #[tokio::test]
+    async fn test_v47_is_idempotent() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+
+        let migration = V47CreateBlackboardsTable;
+        migration.up(&db).await.expect("First run must succeed");
+        migration.up(&db).await.expect("Second run must succeed (idempotent)");
+    }
+}

--- a/backend/src/db/migration/v48.rs
+++ b/backend/src/db/migration/v48.rs
@@ -1,0 +1,154 @@
+//! 数据库迁移 V48：把 todos 上的 (action_type, action_key) 唯一索引改为
+//! 包含 workspace_id 的复合唯一索引。
+//!
+//! 背景：V46 创建的 `idx_todos_action_type_key` 是全局唯一约束，
+//! 但 `find_or_create_blackboard_todo` 按 (action_type, action_key, workspace_id)
+//! 查找并为每个 workspace 单独创建黑板更新 todo。
+//! 在多 workspace 场景下，全局唯一会让第二个 workspace 的创建语句
+//! 触发 `UNIQUE constraint failed: todos.action_type, todos.action_key`。
+//!
+//! 修复方式：
+//! 1. 删除 V46 创建的旧索引
+//! 2. 新建 (action_type, action_key, workspace_id) 唯一索引，保持 WHERE 过滤
+//!    NULL 列的语义
+//!
+//! 数据兼容性：新索引在已有数据上可能因历史脏数据而失败。
+//! 黑板功能是本次 PR 引入，所以生产环境不应有 (blackboard, update) 跨 workspace
+//! 的历史脏数据。其它 action_type/action_key 由调用方保证单一 workspace。
+
+use async_trait::async_trait;
+use sea_orm::{ConnectionTrait, DbBackend, Statement};
+
+use super::super::Database;
+use super::Migration;
+
+pub(super) struct V48ScopeTodosActionKeyByWorkspace;
+
+#[async_trait]
+impl Migration for V48ScopeTodosActionKeyByWorkspace {
+    fn version(&self) -> i64 {
+        48
+    }
+
+    fn name(&self) -> &'static str {
+        "scope_todos_action_key_by_workspace"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 1. 删除 V46 留下的旧唯一索引。索引不存在时忽略错误以保证迁移可重入。
+        let _ = db
+            .conn
+            .execute(Statement::from_string(
+                DbBackend::Sqlite,
+                "DROP INDEX IF EXISTS idx_todos_action_type_key".to_string(),
+            ))
+            .await;
+
+        // 2. 新建 (action_type, action_key, workspace_id) 唯一索引。
+        //    保留 WHERE 过滤 NULL 列的语义，避免把未分类的 todo 也纳入唯一约束。
+        db.conn
+            .execute(Statement::from_string(
+                DbBackend::Sqlite,
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_todos_action_type_key_workspace \
+                 ON todos (action_type, action_key, workspace_id) \
+                 WHERE action_type IS NOT NULL AND action_key IS NOT NULL"
+                    .to_string(),
+            ))
+            .await?;
+
+        tracing::info!("V48: todos (action_type, action_key, workspace_id) 唯一索引已建立");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    /// 验证 V48 迁移可成功执行（包含 DROP + CREATE）。
+    /// 在干净的 :memory: 数据库上跑，验证幂等且不报错。
+    #[tokio::test]
+    async fn test_v48_migration_succeeds() {
+        let db = Database::new(":memory:").await.unwrap();
+        let migration = V48ScopeTodosActionKeyByWorkspace;
+        migration.up(&db).await.expect("V48 must succeed");
+        // 二次执行：旧索引已不在，DROP IF EXISTS 静默跳过，CREATE IF NOT EXISTS 跳过
+        migration
+            .up(&db)
+            .await
+            .expect("V48 second run must succeed (idempotent)");
+    }
+
+    /// 验证迁移后不同 workspace 可以拥有同 (action_type, action_key) 的 todo。
+    /// 这是修复的核心断言：原先 V46 的全局唯一会让两条 INSERT 失败，
+    /// V48 应当允许它们共存。
+    /// V1 初始 schema 已经包含 action_type/action_key 列，直接用 create_todo_with_extras
+    /// 即可触发 INSERT 路径；V48 在 up 时替换索引，所以测试只用 V48 的 up。
+    #[tokio::test]
+    async fn test_v48_allows_per_workspace_action_template() {
+        let db = Database::new(":memory:").await.unwrap();
+        // 关键：先跑 V48 创建 (action_type, action_key, workspace_id) 索引
+        V48ScopeTodosActionKeyByWorkspace
+            .up(&db)
+            .await
+            .unwrap();
+        // 不同 workspace 各自建一个 todo
+        let ws1 = db
+            .create_project_directory("/tmp/v48-ws-1", None, false, false)
+            .await
+            .unwrap();
+        let ws2 = db
+            .create_project_directory("/tmp/v48-ws-2", None, false, false)
+            .await
+            .unwrap();
+        // create_todo_with_extras 不会自动设 action_type/action_key，
+        // 所以用 find_or_create_blackboard_todo 的等价路径：
+        // 调 create_todo_with_extras 再 update_todo_full 设 action 字段。
+        let todo1 = db
+            .create_todo_with_extras("t1", "p1", None, None, false, ws1, "/tmp/v48-ws-1")
+            .await
+            .unwrap();
+        let todo2 = db
+            .create_todo_with_extras("t2", "p2", None, None, false, ws2, "/tmp/v48-ws-2")
+            .await
+            .unwrap();
+        db.update_todo_full(crate::db::TodoUpdate {
+            id: todo1,
+            title: "t1",
+            prompt: "p1",
+            status: crate::models::TodoStatus::Pending,
+            executor: None,
+            scheduler_enabled: None,
+            scheduler_config: None,
+            scheduler_timezone: None,
+            workspace_id: None,
+            webhook_enabled: None,
+            acceptance_criteria: None,
+            auto_review_enabled: None,
+            action_type: Some("blackboard"),
+            action_key: Some("update"),
+        })
+        .await
+        .unwrap();
+        // 关键断言：V46 唯一索引会拒绝第二条；V48 应当通过
+        db.update_todo_full(crate::db::TodoUpdate {
+            id: todo2,
+            title: "t2",
+            prompt: "p2",
+            status: crate::models::TodoStatus::Pending,
+            executor: None,
+            scheduler_enabled: None,
+            scheduler_config: None,
+            scheduler_timezone: None,
+            workspace_id: None,
+            webhook_enabled: None,
+            acceptance_criteria: None,
+            auto_review_enabled: None,
+            action_type: Some("blackboard"),
+            action_key: Some("update"),
+        })
+        .await
+        .expect("per-workspace action template should be allowed after V48");
+    }
+}

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -274,6 +274,7 @@ impl Database {
 
 }
 
+pub mod blackboard;
 mod todo;
 pub use todo::{SchedulerUpdate, TodoUpdate};
 pub mod execution;

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -148,6 +148,31 @@ impl Database {
             .collect())
     }
 
+    /// 按 action_type + action_key + workspace_id 查找 todo。
+    ///
+    /// 用于黑板（Blackboard）等需要按工作空间隔离 Action 模板的场景。
+    /// 每个工作空间可以有自己的 blackboard update todo。
+    pub async fn get_todo_by_action_type_and_key_and_workspace(
+        &self,
+        action_type: &str,
+        action_key: &str,
+        workspace_id: i64,
+    ) -> Result<Option<Todo>, sea_orm::DbErr> {
+        use crate::db::entity::todos;
+        let model = todos::Entity::find()
+            .filter(todos::Column::ActionType.eq(action_type))
+            .filter(todos::Column::ActionKey.eq(action_key))
+            .filter(todos::Column::WorkspaceId.eq(workspace_id))
+            .filter(todos::Column::DeletedAt.is_null())
+            .one(&self.conn)
+            .await?;
+
+        Ok(model.map(|m| {
+            let tag_ids = vec![]; // action template 不需要 tags
+            Self::model_to_todo(m, tag_ids)
+        }))
+    }
+
     /// 按 action_type + action_key 查找 todo。
     /// 用于 ActionButton 组件的 action 模板查找。
     pub async fn get_todo_by_action_type_and_key(

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use tokio::sync::broadcast;
 
-use crate::adapters::CodeExecutor;
+use crate::adapters::{CodeExecutor, ExecutorRegistry};
 use crate::db::Database;
 use crate::executor_service::ExecEvent;
 use crate::models::{ExecutionUsage, ParsedLogEntry};
@@ -409,6 +409,73 @@ pub(crate) async fn finalize_normal_completion(
         total_tokens,
     );
     task_manager.remove(&task_id).await;
+
+    // ===== 黑板更新 (blackboard) =====
+    // 任务执行成功后，异步更新黑板内容（仅当源任务不是 blackboard update todo 时）。
+    // 黑板更新任务自身完成后也会触发此 hook，但通过 action_type 检查避免无限循环。
+    if success {
+        if let Some(ws_id) = workspace_id {
+            // 查询当前 todo 的 action_type，跳过黑板更新任务自身
+            let is_blackboard = db
+                .get_todo(todo_id)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|t| t.action_type)
+                .map(|at| at == "blackboard")
+                .unwrap_or(false);
+
+            if !is_blackboard {
+                spawn_blackboard_update(
+                    db.clone(),
+                    executor_registry.clone(),
+                    tx.clone(),
+                    task_manager.clone(),
+                    config.clone(),
+                    ws_id,
+                    &result_str,
+                    todo_id,
+                    &todo_title,
+                );
+            }
+        }
+    }
+}
+
+/// 在后台异步触发黑板更新。
+///
+/// 将 async 调用包裹在独立的非 async 函数中，避免 Rust 编译器的 async 递归类型循环
+/// （`finalize_normal_completion` → `update_blackboard` → `run_todo_execution` → `dispatch_spawned_executor_task` → `finalize_normal_completion`）。
+fn spawn_blackboard_update(
+    db: Arc<Database>,
+    executor_registry: Arc<ExecutorRegistry>,
+    tx: broadcast::Sender<ExecEvent>,
+    task_manager: Arc<TaskManager>,
+    config: Arc<std::sync::RwLock<crate::config::Config>>,
+    workspace_id: i64,
+    result_str: &str,
+    todo_id: i64,
+    todo_title: &str,
+) {
+    let result_str = result_str.to_string();
+    let todo_title = todo_title.to_string();
+    tokio::spawn(async move {
+        if let Err(e) = crate::services::blackboard::update_blackboard(
+            db,
+            executor_registry,
+            tx,
+            task_manager,
+            config,
+            workspace_id,
+            &result_str,
+            todo_id,
+            &todo_title,
+        )
+        .await
+        {
+            tracing::warn!("黑板更新失败: todo_id={}, error={:?}", todo_id, e);
+        }
+    });
 }
 
 /// 仅在 trigger_type != "auto_review" 时启动自动评审，避免评审实例反向触发评审。

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -267,6 +267,9 @@ pub(crate) async fn handle_cancellation_branch(
             workspace_id,
             duration_secs: 0,
             total_tokens: 0,
+            // cancel 分支无法拿到原始 trigger_type（参数链已断），传 None。
+            // 取消是失败终态，黑板更新只在 success 时触发，不影响。
+            trigger_type: None,
         },
     );
     task_manager.remove(task_id).await;
@@ -328,6 +331,8 @@ pub(crate) async fn handle_timeout_branch(
             workspace_id,
             duration_secs: 0,
             total_tokens: 0,
+            // timeout 分支与 cancel 一样：失败终态不触发黑板，传 None 即可。
+            trigger_type: None,
         },
     );
     task_manager.remove(task_id).await;
@@ -407,37 +412,28 @@ pub(crate) async fn finalize_normal_completion(
         workspace_id,
         duration_secs,
         total_tokens,
+        Some(trigger_type.clone()),
     );
     task_manager.remove(&task_id).await;
 
     // ===== 黑板更新 (blackboard) =====
-    // 任务执行成功后，异步更新黑板内容（仅当源任务不是 blackboard update todo 时）。
-    // 黑板更新任务自身完成后也会触发此 hook，但通过 action_type 检查避免无限循环。
-    if success {
+    // 任务执行成功后，异步更新黑板内容。
+    // 用本作用域的 trigger_type 判定"自身"——黑板更新任务的 trigger_type == "blackboard"，
+    // 避免无限循环；与 todo.action_type 不同的是 trigger_type 跟随执行而非 todo，
+    // 即便以后新增相同 action_type 的非黑板 todo，也不会被错误地跳过。
+    if success && trigger_type != "blackboard" {
         if let Some(ws_id) = workspace_id {
-            // 查询当前 todo 的 action_type，跳过黑板更新任务自身
-            let is_blackboard = db
-                .get_todo(todo_id)
-                .await
-                .ok()
-                .flatten()
-                .and_then(|t| t.action_type)
-                .map(|at| at == "blackboard")
-                .unwrap_or(false);
-
-            if !is_blackboard {
-                spawn_blackboard_update(
-                    db.clone(),
-                    executor_registry.clone(),
-                    tx.clone(),
-                    task_manager.clone(),
-                    config.clone(),
-                    ws_id,
-                    &result_str,
-                    todo_id,
-                    &todo_title,
-                );
-            }
+            spawn_blackboard_update(
+                db.clone(),
+                executor_registry.clone(),
+                tx.clone(),
+                task_manager.clone(),
+                config.clone(),
+                ws_id,
+                &result_str,
+                todo_id,
+                &todo_title,
+            );
         }
     }
 }
@@ -509,6 +505,7 @@ async fn maybe_run_auto_review(
 ///
 /// `duration_secs` 和 `total_tokens` 由调用方从 DB 查询 usage 后传入；
 /// 异常路径（cancel/timeout/spawn 失败等）传 0 即可。
+/// `trigger_type` 透传本次执行的触发类型，供下游识别"自身"避免递归（如 blackboard）。
 #[allow(clippy::too_many_arguments)]
 fn emit_completion_events(
     tx: &broadcast::Sender<ExecEvent>,
@@ -524,6 +521,7 @@ fn emit_completion_events(
     workspace_id: Option<i64>,
     duration_secs: i64,
     total_tokens: i64,
+    trigger_type: Option<String>,
 ) {
     let entry = ParsedLogEntry::new(
         if success { "info" } else { "error" },
@@ -554,6 +552,7 @@ fn emit_completion_events(
             workspace_id,
             duration_secs,
             total_tokens,
+            trigger_type,
         },
     );
 }

--- a/backend/src/executor_service/events.rs
+++ b/backend/src/executor_service/events.rs
@@ -48,6 +48,10 @@ pub enum ExecEvent {
         duration_secs: i64,
         /// 累计 Token 消耗（input + output），用于推送统计摘要
         total_tokens: i64,
+        /// 本次执行的触发类型（"manual" / "smart_create" / "auto_review" / "blackboard" 等），
+        /// 用于黑板更新等场景在 Finished 钩子中识别"自身"以避免递归触发。
+        /// 旧代码路径未传时为 None。
+        trigger_type: Option<String>,
     },
     /// 同步事件：连接时发送当前实际运行的任务列表
     /// 前端收到此事件后应清空 runningTasks 并用此列表初始化

--- a/backend/src/executor_service/pre_spawn.rs
+++ b/backend/src/executor_service/pre_spawn.rs
@@ -114,6 +114,9 @@ pub(crate) async fn reject_concurrency_limit(
             workspace_id: None,
             duration_secs: 0,
             total_tokens: 0,
+            // pre-spawn 阶段没有 trigger_type 上下文：阻塞/无 executor 都属于早期失败，
+            // 不会被黑板逻辑用到，None 即可。
+            trigger_type: None,
         },
     );
     ExecutionResult {
@@ -151,6 +154,7 @@ pub(crate) async fn reject_no_executor(
             workspace_id: None,
             duration_secs: 0,
             total_tokens: 0,
+            trigger_type: None,
         },
     );
     task_manager.remove(task_id).await;
@@ -217,6 +221,7 @@ pub(crate) async fn reject_start_todo_failure(
             workspace_id,
             duration_secs: 0,
             total_tokens: 0,
+            trigger_type: None,
         },
     );
     let _ = db.finish_todo_execution(todo_id, false).await;

--- a/backend/src/executor_service/spawn_lifecycle.rs
+++ b/backend/src/executor_service/spawn_lifecycle.rs
@@ -143,6 +143,8 @@ pub(crate) async fn handle_spawn_failure(
             // spawn 阶段尚未产生任何执行时长与 token 消耗，置 0 避免阻塞 Finished 事件下发
             duration_secs: 0,
             total_tokens: 0,
+            // spawn 失败属于早期阶段，没有 trigger_type 上下文，传 None。
+            trigger_type: None,
         },
     );
     let _ = db.finish_todo_execution(todo_id, false).await;

--- a/backend/src/handlers/blackboard.rs
+++ b/backend/src/handlers/blackboard.rs
@@ -114,3 +114,97 @@ pub fn blackboard_routes() -> Router<AppState> {
             post(refresh_blackboard),
         )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    /// 验证 BlackboardResponse 在有记录时正确序列化为前端期望的 JSON 结构。
+    /// 字段名（snake_case）必须稳定：前端 BlackboardData 接口与之对应。
+    /// 缺字段或命名漂移会导致前端拿不到数据。
+    #[test]
+    fn test_blackboard_response_serialization_with_data() {
+        let resp = BlackboardResponse {
+            id: 7,
+            workspace_id: 3,
+            content: "# 工作空间进展".to_string(),
+            updated_at: Some("2026-07-03T10:00:00Z".to_string()),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["id"], 7);
+        assert_eq!(json["workspace_id"], 3);
+        assert_eq!(json["content"], "# 工作空间进展");
+        assert_eq!(json["updated_at"], "2026-07-03T10:00:00Z");
+    }
+
+    /// 验证 BlackboardResponse 在空记录时（id=0, content=""）的序列化为空骨架。
+    /// 前端看到 `id=0 + content=""` 判定"工作空间尚无黑板"，渲染空状态。
+    #[test]
+    fn test_blackboard_response_serialization_empty() {
+        let resp = BlackboardResponse {
+            id: 0,
+            workspace_id: 42,
+            content: String::new(),
+            updated_at: None,
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["id"], 0);
+        assert_eq!(json["workspace_id"], 42);
+        assert_eq!(json["content"], "");
+        assert!(json["updated_at"].is_null());
+    }
+
+    /// 验证 RefreshRequest 接受空 body。
+    /// 刷新端点不要求 body 参数，但 axum 默认要求 Content-Length 与 Content-Type 头；
+    /// 序列化反序列化的空结构体对应 `{}` 或空 body。
+    #[test]
+    fn test_refresh_request_accepts_empty_object() {
+        let req: RefreshRequest = serde_json::from_str("{}").unwrap();
+        // 反序列化无字段：结构体为空，只要类型正确即可
+        let _ = req;
+    }
+
+    /// 验证 RefreshResponse 序列化字段稳定。
+    /// 字段名必须与前端 `RefreshResponse` 接口一致。
+    #[test]
+    fn test_refresh_response_serialization() {
+        let resp = RefreshResponse {
+            success: true,
+            message: "黑板刷新已触发".to_string(),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["success"], true);
+        assert_eq!(json["message"], "黑板刷新已触发");
+    }
+
+    /// 集成测试：通过 DB 写入后用 ApiResponse 包装，验证完整 JSON 包络。
+    /// 这条用例模拟"GET 端点返 ApiResponse 包装"的数据结构，
+    /// 防止 ApiResponse 的 data 字段命名（snake_case）漂移导致前端解析失败。
+    #[tokio::test]
+    async fn test_get_blackboard_returns_wrapped_response() {
+        // 准备数据：建 workspace + 写黑板
+        let db = Database::new(":memory:").await.unwrap();
+        let ws_id = db
+            .create_project_directory("/tmp/test-blackboard-handler", None, false, false)
+            .await
+            .unwrap();
+        db.upsert_blackboard_content(ws_id, "# 工作空间进展\n\n- foo")
+            .await
+            .unwrap();
+        // 直接调 DB 层（绕过 handler 的 State<AppState>，因为它依赖完整 AppState 装配）
+        let board = db.get_blackboard(ws_id).await.unwrap().unwrap();
+        // 模拟 handler 行为：构造 BlackboardResponse 并包到 ApiResponse
+        let resp = ApiResponse::ok(BlackboardResponse {
+            id: board.id,
+            workspace_id: board.workspace_id,
+            content: board.content,
+            updated_at: board.updated_at,
+        });
+        let json = serde_json::to_value(&resp).unwrap();
+        // ApiResponse 包装格式：{"data": {...}}
+        assert!(json["data"].is_object());
+        assert_eq!(json["data"]["workspace_id"], ws_id);
+        assert_eq!(json["data"]["content"], "# 工作空间进展\n\n- foo");
+    }
+}

--- a/backend/src/handlers/blackboard.rs
+++ b/backend/src/handlers/blackboard.rs
@@ -1,0 +1,116 @@
+//! 黑板（Blackboard）API Handler。
+//!
+//! 提供两个端点：
+//! - `GET /api/workspaces/{workspace_id}/blackboard`：获取当前黑板内容
+//! - `POST /api/workspaces/{workspace_id}/blackboard/refresh`：手动触发热刷新
+
+use axum::extract::{Path, State};
+use axum::routing::{get, post};
+use axum::Router;
+
+use crate::handlers::{ApiJson, AppError, AppState};
+use crate::models::ApiResponse;
+
+/// 黑板响应体
+#[derive(Debug, serde::Serialize)]
+pub struct BlackboardResponse {
+    pub id: i64,
+    pub workspace_id: i64,
+    pub content: String,
+    pub updated_at: Option<String>,
+}
+
+/// `GET /api/workspaces/{workspace_id}/blackboard`
+///
+/// 获取指定工作空间的当前黑板内容。
+/// 如果该工作空间还没有黑板记录，返回空内容（content=""）。
+pub async fn get_blackboard(
+    State(state): State<AppState>,
+    Path(workspace_id): Path<i64>,
+) -> Result<ApiResponse<BlackboardResponse>, AppError> {
+    let board = state.db.get_blackboard(workspace_id).await.map_err(|e| {
+        AppError::Internal(format!("查询黑板失败: {}", e))
+    })?;
+
+    match board {
+        Some(model) => Ok(ApiResponse::ok(BlackboardResponse {
+            id: model.id,
+            workspace_id: model.workspace_id,
+            content: model.content,
+            updated_at: model.updated_at,
+        })),
+        None => Ok(ApiResponse::ok(BlackboardResponse {
+            id: 0,
+            workspace_id,
+            content: String::new(),
+            updated_at: None,
+        })),
+    }
+}
+
+/// 刷新请求体（预留，当前为空）
+#[derive(Debug, serde::Deserialize)]
+pub struct RefreshRequest {}
+
+/// 刷新响应体
+#[derive(Debug, serde::Serialize)]
+pub struct RefreshResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+/// `POST /api/workspaces/{workspace_id}/blackboard/refresh`
+///
+/// 手动触发黑板刷新：重新执行 blackboard update todo，
+/// 让 LLM 根据当前黑板内容重新组织生成。
+///
+/// 这是一个异步操作，请求返回后黑板内容会在几秒到几十秒后更新。
+/// 前端需要间隔轮询或等待 WebSocket 推送来获取最新内容。
+pub async fn refresh_blackboard(
+    State(state): State<AppState>,
+    Path(workspace_id): Path<i64>,
+) -> Result<ApiResponse<RefreshResponse>, AppError> {
+    // 异步触发黑板刷新，不阻塞请求
+    // tokio::spawn 确保刷新任务在后台运行，即使 HTTP 连接已断开
+    let db = state.db.clone();
+    let executor_registry = state.executor_registry.clone();
+    let tx = state.tx.clone();
+    let task_manager = state.task_manager.clone();
+    let config = state.config.clone();
+
+    tokio::spawn(async move {
+        if let Err(e) = crate::services::blackboard::refresh_blackboard(
+            db,
+            executor_registry,
+            tx,
+            task_manager,
+            config,
+            workspace_id,
+        )
+        .await
+        {
+            tracing::warn!("黑板刷新失败: workspace_id={}, error={:?}", workspace_id, e);
+        }
+    });
+
+    Ok(ApiResponse::ok(RefreshResponse {
+        success: true,
+        message: "黑板刷新已触发".to_string(),
+    }))
+}
+
+/// 返回黑板领域路由。
+///
+/// 路由设计遵循 RESTful 风格，以 workspace 为作用域：
+/// - `/api/workspaces/{workspace_id}/blackboard`
+pub fn blackboard_routes() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/api/workspaces/{workspace_id}/blackboard",
+            get(get_blackboard),
+        )
+        .route(
+            "/api/workspaces/{workspace_id}/blackboard/refresh",
+            post(refresh_blackboard),
+        )
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -147,6 +147,7 @@ pub mod sync;
 pub mod sub_states; // 由 #604 引入，当前无内容占位
 pub mod loop_;
 pub mod action;
+pub mod blackboard;
 
 // WebSocket handler
 pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
@@ -284,6 +285,7 @@ fn mount_domain_routes() -> Router<AppState> {
         .merge(custom_template_routes())
         .merge(cloud_routes())
         .merge(events_routes())
+        .merge(blackboard::blackboard_routes())
         .merge(loop_::loop_routes())
 }
 
@@ -1237,9 +1239,10 @@ mod create_app_refactor_tests {
             custom_template_routes(),
             cloud_routes(),
             events_routes(),
+            blackboard::blackboard_routes(),
         ];
-        // 19 个领域子路由函数（与 issue #661 中声明的拆分清单一致；review_template_routes 为评审模板新增）
-        assert_eq!(routers.len(), 19, "领域子路由函数数量应与拆分清单一致");
+        // 20 个领域子路由函数（blackboard_routes 为黑板功能新增）
+        assert_eq!(routers.len(), 20, "领域子路由函数数量应与拆分清单一致");
         // `Router` 在 axum 0.8 中没有公开的 route_count，这里只能断言"全部成功构造"
     }
 

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -163,14 +163,18 @@ pub async fn update_blackboard(
     params.insert("todo_title".to_string(), source_todo_title.to_string());
     let message = crate::models::replace_placeholders(&prompt, &params);
 
-    // 4. 启动执行（复用 run_todo_execution）
+    // 4. 先订阅 broadcast channel（必须在启动执行之前订阅，否则极速完成的任务
+    //    会导致 Finished 事件在 subscribe 之前发出而被丢失，函数无限等待）
+    let mut rx = tx.subscribe();
+
+    // 5. 启动执行（复用 run_todo_execution）
     //    使用 trigger_type="blackboard" 标记这是黑板更新任务，
     //    这样 Finished 事件 Hook 中可以跳过再次触发黑板更新（避免无限循环）
     let result = crate::handlers::execution::start_todo_execution(
         RunTodoExecutionRequest {
             db: db.clone(),
             executor_registry,
-            tx: tx.clone(),
+            tx,
             task_manager,
             config,
             todo_id,
@@ -199,9 +203,8 @@ pub async fn update_blackboard(
         AppError::Internal("黑板更新任务启动失败".to_string())
     })?;
 
-    // 5. 订阅 broadcast channel 等待 Finished 事件
+    // 6. 等待 Finished 事件
     //    用 task_id 匹配对应的完成事件，忽略其他事件的干扰
-    let mut rx = tx.subscribe();
     loop {
         match rx.recv().await {
             Ok(ExecEvent::Finished {
@@ -210,6 +213,16 @@ pub async fn update_blackboard(
                 ..
             }) if *finished_task_id == task_id => {
                 let new_content = new_content.clone();
+                // 如果 LLM 返回空内容，跳过更新，保护已有黑板内容不被覆盖
+                if new_content.trim().is_empty() {
+                    tracing::warn!(
+                        "黑板更新结果为空，跳过更新: workspace_id={}, source_todo_id={}, task_id={}",
+                        workspace_id,
+                        source_todo_id,
+                        task_id
+                    );
+                    return Ok(());
+                }
                 // 6. 更新黑板内容到数据库
                 //    先确保黑板记录存在（首次更新时自动创建）
                 if db.get_blackboard(workspace_id).await.map_err(|e| {
@@ -226,6 +239,21 @@ pub async fn update_blackboard(
 
                 tracing::info!(
                     "黑板更新成功: workspace_id={}, source_todo_id={}, task_id={}",
+                    workspace_id,
+                    source_todo_id,
+                    task_id
+                );
+                return Ok(());
+            }
+            // Finished 事件中 result 为 None 说明执行未产出结果，
+            // 跳过但不报错，避免阻塞后续黑板更新
+            Ok(ExecEvent::Finished {
+                task_id: ref finished_task_id,
+                result: None,
+                ..
+            }) if *finished_task_id == task_id => {
+                tracing::warn!(
+                    "黑板更新执行未产出结果: workspace_id={}, source_todo_id={}, task_id={}",
                     workspace_id,
                     source_todo_id,
                     task_id
@@ -288,12 +316,15 @@ pub async fn refresh_blackboard(
     params.insert("todo_title".to_string(), "手动刷新黑板".to_string());
     let message = crate::models::replace_placeholders(&prompt, &params);
 
+    // 先订阅 broadcast channel，再启动执行，避免错过 Finished 事件
+    let mut rx = tx.subscribe();
+
     // 启动执行
     let result = crate::handlers::execution::start_todo_execution(
         RunTodoExecutionRequest {
             db: db.clone(),
             executor_registry,
-            tx: tx.clone(),
+            tx,
             task_manager,
             config,
             todo_id,
@@ -321,7 +352,6 @@ pub async fn refresh_blackboard(
     })?;
 
     // 等待 Finished 事件
-    let mut rx = tx.subscribe();
     loop {
         match rx.recv().await {
             Ok(ExecEvent::Finished {
@@ -330,12 +360,34 @@ pub async fn refresh_blackboard(
                 ..
             }) if *finished_task_id == task_id => {
                 let new_content = new_content.clone();
+                // 如果 LLM 返回空内容，跳过更新，保护已有黑板内容不被覆盖
+                if new_content.trim().is_empty() {
+                    tracing::warn!(
+                        "黑板刷新结果为空，跳过更新: workspace_id={}, task_id={}",
+                        workspace_id,
+                        task_id
+                    );
+                    return Ok(());
+                }
                 db.update_blackboard_content(workspace_id, &new_content)
                     .await
                     .map_err(|e| AppError::Internal(format!("更新黑板失败: {}", e)))?;
 
                 tracing::info!(
                     "黑板刷新成功: workspace_id={}, task_id={}",
+                    workspace_id,
+                    task_id
+                );
+                return Ok(());
+            }
+            // Finished 事件中 result 为 None 说明执行未产出结果
+            Ok(ExecEvent::Finished {
+                task_id: ref finished_task_id,
+                result: None,
+                ..
+            }) if *finished_task_id == task_id => {
+                tracing::warn!(
+                    "黑板刷新执行未产出结果: workspace_id={}, task_id={}",
                     workspace_id,
                     task_id
                 );

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -15,6 +15,9 @@ use crate::executor_service::{ExecEvent, RunTodoExecutionRequest};
 use crate::handlers::AppError;
 use crate::task_manager::TaskManager;
 
+/// 当前实现的固定 trigger_type：在 Finished 钩子中用于识别"自身"避免递归触发。
+const TRIGGER_TYPE_BLACKBOARD: &str = "blackboard";
+
 /// 查找或创建当前工作空间的黑板更新 Todo。
 ///
 /// 黑板更新 Todo 的特征是 action_type="blackboard", action_key="update"。
@@ -35,16 +38,19 @@ pub async fn find_or_create_blackboard_todo(
     }
 
     // 2. 未找到，自动创建
-    // 先获取工作空间的路径信息（create_todo_with_extras 需要）
+    //    create_todo_with_extras 需要 workspace 路径信息，先查询工作空间
     let dir = db
         .get_project_directory_by_id(workspace_id)
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
         .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", workspace_id)))?;
 
+    // 标题便于在 todo 列表中识别黑板更新 todo
     let title = format!("Blackboard: workspace_{}", workspace_id);
+    // prompt 模板内含占位符，下游 start_todo_execution 之前再做替换
     let prompt = build_blackboard_prompt();
 
+    // create_todo_with_extras 不支持直接传 action_type/action_key，先建再改
     let todo_id = db
         .create_todo_with_extras(
             &title,
@@ -58,7 +64,7 @@ pub async fn find_or_create_blackboard_todo(
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
-    // 更新 action_type 和 action_key，标记为黑板更新 Todo
+    // 标记为黑板更新 todo：action_type/action_key 用于 find_or_create 的下次查找
     db.update_todo_full(crate::db::TodoUpdate {
         id: todo_id,
         title: &title,
@@ -118,15 +124,176 @@ fn build_blackboard_prompt() -> String {
 只输出更新后的黑板内容，不要输出任何解释。"#.to_string()
 }
 
+/// 读取指定工作空间的黑板内容；无记录时返回空字符串。
+///
+/// 隐藏 None/Some 差异，让上游不用每次都 .map().unwrap_or_default()。
+async fn read_current_content(
+    db: &Database,
+    workspace_id: i64,
+) -> Result<String, AppError> {
+    // 首次访问可能为 None：未创建过黑板的工作空间返回空字符串作为初始值
+    let board = db
+        .get_blackboard(workspace_id)
+        .await
+        .map_err(|e| AppError::Internal(format!("读取黑板失败: {}", e)))?;
+    Ok(board.map(|b| b.content).unwrap_or_default())
+}
+
+/// 构造带占位符替换的最终 prompt，并把原 params 一并返回（start_todo_execution 也需要）。
+fn assemble_prompt(
+    current_content: String,
+    conclusion: String,
+    source_todo_id: i64,
+    source_todo_title: &str,
+) -> (String, HashMap<String, String>) {
+    // 用与上游一致的 key 命名：current / conclusion / todo_id / todo_title
+    let mut params = HashMap::new();
+    params.insert("current".to_string(), current_content);
+    params.insert("conclusion".to_string(), conclusion);
+    params.insert("todo_id".to_string(), source_todo_id.to_string());
+    params.insert("todo_title".to_string(), source_todo_title.to_string());
+    // models::replace_placeholders 单遍替换 {{key}} -> params[key]
+    let message = crate::models::replace_placeholders(&build_blackboard_prompt(), &params);
+    (message, params)
+}
+
+/// 启动 blackboard todo 执行并阻塞等待它的 Finished 事件，返回 LLM 产出的新内容。
+///
+/// 核心时序（不可调整）：
+/// 1. tx.subscribe() 必须在 start_todo_execution 之前：极快完成的任务会在订阅前
+///    发出 Finished 事件，导致函数永远阻塞等待。
+/// 2. 等待阶段按 task_id 精确过滤：并发场景下其他任务的 Finished 会被忽略。
+///
+/// 返回的 String 是 LLM 输出的原始内容；调用方负责判空 + 写库。
+async fn run_blackboard_execution(
+    db: Arc<Database>,
+    executor_registry: Arc<ExecutorRegistry>,
+    tx: broadcast::Sender<ExecEvent>,
+    task_manager: Arc<TaskManager>,
+    config: Arc<std::sync::RwLock<Config>>,
+    workspace_id: i64,
+    todo_id: i64,
+    message: String,
+    params: HashMap<String, String>,
+    source_todo_id: Option<i64>,
+    source_todo_title: Option<String>,
+) -> Result<Option<String>, AppError> {
+    // 先订阅：broadcast 通道不会重发订阅前的事件，必须在 start 之前
+    let mut rx = tx.subscribe();
+    // 启动执行：trigger_type=blackboard 让 Finished 钩子识别"自身"避免递归
+    let result = crate::handlers::execution::start_todo_execution(RunTodoExecutionRequest {
+        db: db.clone(),
+        executor_registry,
+        tx,
+        task_manager,
+        config,
+        todo_id,
+        message,
+        req_executor: None,
+        trigger_type: TRIGGER_TYPE_BLACKBOARD.to_string(),
+        params: Some(params),
+        resume_session_id: None,
+        resume_message: None,
+        source_todo_id,
+        source_todo_title,
+        feishu_bot_id: None,
+        feishu_receive_id: None,
+        loop_step_execution_id: None,
+        step_id: None,
+        workspace_path: None,
+        workspace_id: Some(workspace_id),
+    })
+    .await?;
+    // record_id 为 None 视为启动失败；task_id 同时 clone 出来用于事件匹配
+    let task_id = result.task_id.clone();
+    result.record_id.ok_or_else(|| {
+        AppError::Internal("黑板更新任务启动失败".to_string())
+    })?;
+    // 阻塞等 Finished；返回 None 表示执行未产出结果（非错误）
+    wait_for_finished(&mut rx, &task_id, workspace_id).await
+}
+
+/// 等待目标 task_id 对应的 Finished 事件，区分"完成有空内容/无内容/通道异常"。
+async fn wait_for_finished(
+    rx: &mut tokio::sync::broadcast::Receiver<ExecEvent>,
+    task_id: &str,
+    workspace_id: i64,
+) -> Result<Option<String>, AppError> {
+    loop {
+        match rx.recv().await {
+            // 命中：result 携带 LLM 产出（可能为空字符串）
+            Ok(ExecEvent::Finished {
+                task_id: ref finished_task_id,
+                result: Some(ref new_content),
+                ..
+            }) if *finished_task_id == task_id => {
+                return Ok(Some(new_content.clone()));
+            }
+            // 命中但无 result：执行未产出结果，按"无内容"处理，不报错
+            Ok(ExecEvent::Finished {
+                task_id: ref finished_task_id,
+                result: None,
+                ..
+            }) if *finished_task_id == task_id => {
+                tracing::warn!(
+                    "黑板执行未产出结果: workspace_id={}, task_id={}",
+                    workspace_id,
+                    task_id
+                );
+                return Ok(None);
+            }
+            // 其他任务的 Finished / Started / Output：忽略继续等
+            Ok(_) => {}
+            // 通道积压：跳过丢失的事件继续等（task_id 匹配会再次命中）
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                tracing::warn!("黑板更新事件通道积压，跳过 {} 个事件", n);
+            }
+            // 通道关闭：异常状态，应当报错让上游知晓
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                return Err(AppError::Internal("事件通道已关闭".to_string()));
+            }
+        }
+    }
+}
+
+/// 把 LLM 产出写入黑板表，必要时跳过（空内容保护）。
+///
+/// 策略：
+/// - 产出为空 → 不覆盖现有黑板（LLM 偶发无意义输出时保护已有内容）
+/// - 产出非空 → 走 upsert，一次往返完成"创建/更新"判定 + 写入
+async fn save_blackboard(
+    db: &Database,
+    workspace_id: i64,
+    new_content: Option<String>,
+) -> Result<(), AppError> {
+    // None = 执行未产出结果：没有可写内容，按"无变化"处理
+    let Some(new_content) = new_content else {
+        return Ok(());
+    };
+    // 空内容保护：避免 LLM 偶发返回 "" 覆盖已有黑板
+    if new_content.trim().is_empty() {
+        tracing::warn!(
+            "黑板更新结果为空，跳过写入: workspace_id={}",
+            workspace_id
+        );
+        return Ok(());
+    }
+    // upsert：记录不存在时创建，已存在时覆盖 content/updated_at，保留 created_at
+    db.upsert_blackboard_content(workspace_id, &new_content)
+        .await
+        .map_err(|e| AppError::Internal(format!("更新黑板失败: {}", e)))?;
+    tracing::info!("黑板更新成功: workspace_id={}", workspace_id);
+    Ok(())
+}
+
 /// 更新黑板内容。
 ///
 /// 核心逻辑：
-/// 1. 读取当前黑板内容（来自 blackboards 表）
-/// 2. 查找或创建 blackboard update Todo（action_type="blackboard", action_key="update"）
-/// 3. 用 `replace_placeholders` 替换 Prompt 中的占位符
-/// 4. 调用 `run_todo_execution` 启动执行（复用现有的 LLM 执行机制）
-/// 5. 订阅 broadcast channel 等待 `Finished` 事件
-/// 6. 提取 `result` 并更新 blackboards 表
+/// 1. 读取当前黑板内容
+/// 2. 查找或创建 blackboard update Todo
+/// 3. 构造 Prompt + 启动执行
+/// 4. 阻塞等待 Finished 事件
+/// 5. upsert 写回黑板
 ///
 /// 黑板更新失败不会影响源任务的执行流程，只在日志中记录 warn。
 pub async fn update_blackboard(
@@ -140,150 +307,40 @@ pub async fn update_blackboard(
     source_todo_id: i64,
     source_todo_title: &str,
 ) -> Result<(), AppError> {
-    // 1. 读取当前黑板内容
-    //    首次使用时可能为 None，此时使用空字符串作为初始内容
-    let current = db.get_blackboard(workspace_id).await.map_err(|e| {
-        AppError::Internal(format!("读取黑板失败: {}", e))
-    })?;
-    let current_content = current
-        .map(|b| b.content)
-        .unwrap_or_default();
-
-    // 2. 查找或创建 blackboard update todo
-    //    每个工作空间使用独立的 blackboard todo，避免跨空间混淆
+    // 1+2: 读当前内容、找或建 todo；任一失败直接返回
+    let current_content = read_current_content(&db, workspace_id).await?;
     let (todo_id, _) = find_or_create_blackboard_todo(&db, workspace_id).await?;
-
-    // 3. 构造 prompt（复用 Action 的占位符替换机制）
-    //    models::replace_placeholders 将 {{key}} 占位符替换为 params 中的值
-    let prompt = build_blackboard_prompt();
-    let mut params = HashMap::new();
-    params.insert("current".to_string(), current_content);
-    params.insert("conclusion".to_string(), conclusion.to_string());
-    params.insert("todo_id".to_string(), source_todo_id.to_string());
-    params.insert("todo_title".to_string(), source_todo_title.to_string());
-    let message = crate::models::replace_placeholders(&prompt, &params);
-
-    // 4. 先订阅 broadcast channel（必须在启动执行之前订阅，否则极速完成的任务
-    //    会导致 Finished 事件在 subscribe 之前发出而被丢失，函数无限等待）
-    let mut rx = tx.subscribe();
-
-    // 5. 启动执行（复用 run_todo_execution）
-    //    使用 trigger_type="blackboard" 标记这是黑板更新任务，
-    //    这样 Finished 事件 Hook 中可以跳过再次触发黑板更新（避免无限循环）
-    let result = crate::handlers::execution::start_todo_execution(
-        RunTodoExecutionRequest {
-            db: db.clone(),
-            executor_registry,
-            tx,
-            task_manager,
-            config,
-            todo_id,
-            message,
-            req_executor: None,
-            trigger_type: "blackboard".to_string(),
-            params: Some(params),
-            resume_session_id: None,
-            resume_message: None,
-            source_todo_id: Some(source_todo_id),
-            source_todo_title: Some(source_todo_title.to_string()),
-            feishu_bot_id: None,
-            feishu_receive_id: None,
-            loop_step_execution_id: None,
-            step_id: None,
-            workspace_path: None,
-            workspace_id: Some(workspace_id),
-        },
+    // 3: 组装 prompt：source_todo_id/title 来自上游任务，conclusion 是任务执行结果
+    let (message, params) = assemble_prompt(
+        current_content,
+        conclusion.to_string(),
+        source_todo_id,
+        source_todo_title,
+    );
+    // 4: 启动执行 + 等待 Finished
+    let new_content = run_blackboard_execution(
+        db.clone(),
+        executor_registry,
+        tx,
+        task_manager,
+        config,
+        workspace_id,
+        todo_id,
+        message,
+        params,
+        Some(source_todo_id),
+        Some(source_todo_title.to_string()),
     )
     .await?;
-
-    // 获取 task_id 用于后续匹配 Finished 事件（ExecEvent::Finished 没有 record_id 字段，
-    // 用全局唯一的 task_id 区分多次执行，避免并发时匹配到错误的完成事件）
-    let task_id = result.task_id.clone();
-    result.record_id.ok_or_else(|| {
-        AppError::Internal("黑板更新任务启动失败".to_string())
-    })?;
-
-    // 6. 等待 Finished 事件
-    //    用 task_id 匹配对应的完成事件，忽略其他事件的干扰
-    loop {
-        match rx.recv().await {
-            Ok(ExecEvent::Finished {
-                task_id: ref finished_task_id,
-                result: Some(ref new_content),
-                ..
-            }) if *finished_task_id == task_id => {
-                let new_content = new_content.clone();
-                // 如果 LLM 返回空内容，跳过更新，保护已有黑板内容不被覆盖
-                if new_content.trim().is_empty() {
-                    tracing::warn!(
-                        "黑板更新结果为空，跳过更新: workspace_id={}, source_todo_id={}, task_id={}",
-                        workspace_id,
-                        source_todo_id,
-                        task_id
-                    );
-                    return Ok(());
-                }
-                // 6. 更新黑板内容到数据库
-                //    先确保黑板记录存在（首次更新时自动创建）
-                if db.get_blackboard(workspace_id).await.map_err(|e| {
-                    AppError::Internal(format!("查询黑板失败: {}", e))
-                })?.is_none() {
-                    db.create_blackboard(workspace_id).await.map_err(|e| {
-                        AppError::Internal(format!("创建黑板失败: {}", e))
-                    })?;
-                }
-
-                db.update_blackboard_content(workspace_id, &new_content)
-                    .await
-                    .map_err(|e| AppError::Internal(format!("更新黑板失败: {}", e)))?;
-
-                tracing::info!(
-                    "黑板更新成功: workspace_id={}, source_todo_id={}, task_id={}",
-                    workspace_id,
-                    source_todo_id,
-                    task_id
-                );
-                return Ok(());
-            }
-            // Finished 事件中 result 为 None 说明执行未产出结果，
-            // 跳过但不报错，避免阻塞后续黑板更新
-            Ok(ExecEvent::Finished {
-                task_id: ref finished_task_id,
-                result: None,
-                ..
-            }) if *finished_task_id == task_id => {
-                tracing::warn!(
-                    "黑板更新执行未产出结果: workspace_id={}, source_todo_id={}, task_id={}",
-                    workspace_id,
-                    source_todo_id,
-                    task_id
-                );
-                return Ok(());
-            }
-            Ok(_) => {
-                // 其他事件（Output/Started 等），忽略继续等待
-            }
-            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                // 通道积压：发生 Lagged 时跳过丢失的事件，继续等待
-                tracing::warn!("黑板更新事件通道积压，跳过 {} 个事件", n);
-            }
-            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                // 通道关闭：不应发生，如果通道关闭则返回错误
-                return Err(AppError::Internal("事件通道已关闭".to_string()));
-            }
-        }
-    }
+    // 5: 写回黑板（带空内容保护 + upsert）
+    save_blackboard(&db, workspace_id, new_content).await
 }
 
-/// 手动刷新黑板：重新执行 blackboard update todo。
+/// 手动刷新黑板：重新执行 blackboard update todo，让 LLM 重新组织现有内容。
 ///
-/// 与 `update_blackboard` 不同，手动刷新只是纯粹地要求 LLM 根据当前黑板内容
-/// 重新组织生成（没有新的结论输入）。效果相当于让 LLM"重新检视"现有内容。
-///
-/// 工作方式：
-/// 1. 查找 blackboard update todo
-/// 2. 以当前黑板内容 + "手动刷新"作为输入执行该 todo
-/// 3. 等待 Finished 事件并更新黑板
+/// 与 `update_blackboard` 的区别：conclusion 是占位文本"无新结论"，
+/// 作用是触发一次"基于现状的重新组织"而不是"基于新结论的合并"。
+/// 因此要求黑板非空：空黑板无内容可"重新组织"，直接返回 BadRequest。
 pub async fn refresh_blackboard(
     db: Arc<Database>,
     executor_registry: Arc<ExecutorRegistry>,
@@ -292,114 +349,127 @@ pub async fn refresh_blackboard(
     config: Arc<std::sync::RwLock<Config>>,
     workspace_id: i64,
 ) -> Result<(), AppError> {
-    // 查找黑板的当前内容，如果没有内容则无需刷新
-    let current = db.get_blackboard(workspace_id).await.map_err(|e| {
-        AppError::Internal(format!("读取黑板失败: {}", e))
-    })?;
-    let current_content = current
-        .map(|b| b.content)
-        .unwrap_or_default();
-
+    // 早退：空黑板没有"重新组织"的对象，避免无意义的 LLM 调用
+    let current_content = read_current_content(&db, workspace_id).await?;
     if current_content.is_empty() {
         return Err(AppError::BadRequest("黑板暂无内容，无需刷新".to_string()));
     }
-
-    // 查找或创建 blackboard update todo
+    // 复用同一 todo + 同一执行/等待/写入流程；source_todo_* 留 None 表示"非任务触发"
     let (todo_id, _) = find_or_create_blackboard_todo(&db, workspace_id).await?;
-
-    // 构造 prompt：使用当前黑板内容 + 手动刷新标记
-    let prompt = build_blackboard_prompt();
-    let mut params = HashMap::new();
-    params.insert("current".to_string(), current_content);
-    params.insert("conclusion".to_string(), "手动刷新：无新结论，请重新组织现有内容".to_string());
-    params.insert("todo_id".to_string(), "0".to_string());
-    params.insert("todo_title".to_string(), "手动刷新黑板".to_string());
-    let message = crate::models::replace_placeholders(&prompt, &params);
-
-    // 先订阅 broadcast channel，再启动执行，避免错过 Finished 事件
-    let mut rx = tx.subscribe();
-
-    // 启动执行
-    let result = crate::handlers::execution::start_todo_execution(
-        RunTodoExecutionRequest {
-            db: db.clone(),
-            executor_registry,
-            tx,
-            task_manager,
-            config,
-            todo_id,
-            message,
-            req_executor: None,
-            trigger_type: "blackboard".to_string(),
-            params: Some(params),
-            resume_session_id: None,
-            resume_message: None,
-            source_todo_id: None,
-            source_todo_title: None,
-            feishu_bot_id: None,
-            feishu_receive_id: None,
-            loop_step_execution_id: None,
-            step_id: None,
-            workspace_path: None,
-            workspace_id: Some(workspace_id),
-        },
+    let (message, params) = assemble_prompt(
+        current_content,
+        "手动刷新：无新结论，请重新组织现有内容".to_string(),
+        0,
+        "手动刷新黑板",
+    );
+    let new_content = run_blackboard_execution(
+        db.clone(),
+        executor_registry,
+        tx,
+        task_manager,
+        config,
+        workspace_id,
+        todo_id,
+        message,
+        params,
+        None,
+        None,
     )
     .await?;
+    save_blackboard(&db, workspace_id, new_content).await
+}
 
-    let task_id = result.task_id.clone();
-    result.record_id.ok_or_else(|| {
-        AppError::Internal("黑板刷新任务启动失败".to_string())
-    })?;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
 
-    // 等待 Finished 事件
-    loop {
-        match rx.recv().await {
-            Ok(ExecEvent::Finished {
-                task_id: ref finished_task_id,
-                result: Some(ref new_content),
-                ..
-            }) if *finished_task_id == task_id => {
-                let new_content = new_content.clone();
-                // 如果 LLM 返回空内容，跳过更新，保护已有黑板内容不被覆盖
-                if new_content.trim().is_empty() {
-                    tracing::warn!(
-                        "黑板刷新结果为空，跳过更新: workspace_id={}, task_id={}",
-                        workspace_id,
-                        task_id
-                    );
-                    return Ok(());
-                }
-                db.update_blackboard_content(workspace_id, &new_content)
-                    .await
-                    .map_err(|e| AppError::Internal(format!("更新黑板失败: {}", e)))?;
+    /// 测试用：建一个 workspace，返回 id。
+    async fn make_workspace(db: &Database) -> i64 {
+        db.create_project_directory("/tmp/test-blackboard-svc", None, false, false)
+            .await
+            .expect("create workspace must succeed")
+    }
 
-                tracing::info!(
-                    "黑板刷新成功: workspace_id={}, task_id={}",
-                    workspace_id,
-                    task_id
-                );
-                return Ok(());
-            }
-            // Finished 事件中 result 为 None 说明执行未产出结果
-            Ok(ExecEvent::Finished {
-                task_id: ref finished_task_id,
-                result: None,
-                ..
-            }) if *finished_task_id == task_id => {
-                tracing::warn!(
-                    "黑板刷新执行未产出结果: workspace_id={}, task_id={}",
-                    workspace_id,
-                    task_id
-                );
-                return Ok(());
-            }
-            Ok(_) => {}
-            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                tracing::warn!("黑板刷新事件通道积压，跳过 {} 个事件", n);
-            }
-            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                return Err(AppError::Internal("事件通道已关闭".to_string()));
-            }
+    /// 验证 build_blackboard_prompt 含所有必要占位符。
+    /// 缺占位符会导致 assemble_prompt 替换后 prompt 不完整，LLM 行为会偏离预期。
+    #[test]
+    fn test_prompt_contains_required_placeholders() {
+        let prompt = build_blackboard_prompt();
+        assert!(prompt.contains("{{current}}"));
+        assert!(prompt.contains("{{conclusion}}"));
+        assert!(prompt.contains("{{todo_id}}"));
+        assert!(prompt.contains("{{todo_title}}"));
+    }
+
+    /// 验证 assemble_prompt 正确替换占位符，且结论字段透传。
+    /// 防止模型 prompt 模板被误改后占位符替换断裂（导致 LLM 收到 "{{conclusion}}" 字面量）。
+    #[test]
+    fn test_assemble_prompt_replaces_all_placeholders() {
+        let (message, params) = assemble_prompt(
+            "已有黑板".to_string(),
+            "任务已成功".to_string(),
+            42,
+            "示例 todo",
+        );
+        // 原始占位符应全部被替换
+        assert!(!message.contains("{{current}}"));
+        assert!(!message.contains("{{conclusion}}"));
+        assert!(!message.contains("{{todo_id}}"));
+        assert!(!message.contains("{{todo_title}}"));
+        // 替换值应透传到 message
+        assert!(message.contains("已有黑板"));
+        assert!(message.contains("任务已成功"));
+        // params 也应原样返回，供 start_todo_execution 使用
+        assert_eq!(params.get("todo_id"), Some(&"42".to_string()));
+        assert_eq!(params.get("todo_title"), Some(&"示例 todo".to_string()));
+    }
+
+    /// 验证 find_or_create 第二次调用返回 (same_id, false)，避免重复创建。
+    /// 黑板更新 todo 重复创建会让数据库里出现多个 action_type=blackboard 记录，
+    /// 后续 update_blackboard 不知道该用哪个。
+    #[tokio::test]
+    async fn test_find_or_create_is_idempotent() {
+        let db = Database::new(":memory:").await.unwrap();
+        let ws_id = make_workspace(&db).await;
+        // 第一次：新建
+        let (id1, created1) = find_or_create_blackboard_todo(&db, ws_id).await.unwrap();
+        assert!(created1, "首次调用应返回 created=true");
+        // 第二次：复用
+        let (id2, created2) = find_or_create_blackboard_todo(&db, ws_id).await.unwrap();
+        assert!(!created2, "第二次调用应返回 created=false");
+        assert_eq!(id1, id2, "应返回同一 todo id");
+    }
+
+    /// 验证不同 workspace 各自有独立的 blackboard todo。
+    /// 工作空间隔离是黑板的关键约束：跨 workspace 复用 todo 会导致 prompt 串味。
+    /// 注意：两个 workspace 的 path 必须不同（project_directories.path 是 UNIQUE），
+    /// 这里用 ws_id 后缀保证唯一。
+    #[tokio::test]
+    async fn test_find_or_create_scoped_per_workspace() {
+        let db = Database::new(":memory:").await.unwrap();
+        let ws1 = db
+            .create_project_directory("/tmp/test-blackboard-svc-1", None, false, false)
+            .await
+            .unwrap();
+        let ws2 = db
+            .create_project_directory("/tmp/test-blackboard-svc-2", None, false, false)
+            .await
+            .unwrap();
+        let (id1, _) = find_or_create_blackboard_todo(&db, ws1).await.unwrap();
+        let (id2, _) = find_or_create_blackboard_todo(&db, ws2).await.unwrap();
+        assert_ne!(id1, id2, "不同 workspace 应当各自有独立 todo");
+    }
+
+    /// 验证 find_or_create 在 workspace 不存在时返回 BadRequest。
+    /// 用过宽松的 Internal 错误会掩盖调用方错误，BadRequest 更合适。
+    #[tokio::test]
+    async fn test_find_or_create_missing_workspace_returns_bad_request() {
+        let db = Database::new(":memory:").await.unwrap();
+        let result = find_or_create_blackboard_todo(&db, 9999).await;
+        match result {
+            Err(AppError::BadRequest(_)) => {}
+            other => panic!("expected BadRequest, got: {:?}", other),
         }
     }
 }

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -1,0 +1,353 @@
+//! 黑板（Blackboard）Service 层。
+//!
+//! 实现黑板的更新逻辑，复用现有的 Action/Todo 执行机制（run_todo_execution）。
+//! 核心流程：读取当前黑板 → 构造 Prompt → 通过 Action Todo 调用 LLM → 更新黑板。
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+
+use crate::adapters::ExecutorRegistry;
+use crate::config::Config;
+use crate::db::Database;
+use crate::executor_service::{ExecEvent, RunTodoExecutionRequest};
+use crate::handlers::AppError;
+use crate::task_manager::TaskManager;
+
+/// 查找或创建当前工作空间的黑板更新 Todo。
+///
+/// 黑板更新 Todo 的特征是 action_type="blackboard", action_key="update"。
+/// 如果已存在则直接返回，否则自动创建一个新的 Todo（markdown 模板作为 prompt）。
+/// 每个工作空间独立维护自己的黑板更新 Todo。
+pub async fn find_or_create_blackboard_todo(
+    db: &Database,
+    workspace_id: i64,
+) -> Result<(i64, bool), AppError> {
+    // 1. 按 action_type + action_key + workspace_id 查找已有的 Todo
+    //    作用域限定在当前工作空间，确保每个 workspace 有独立的黑板更新 Todo
+    if let Some(todo) = db
+        .get_todo_by_action_type_and_key_and_workspace("blackboard", "update", workspace_id)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+    {
+        return Ok((todo.id, false));
+    }
+
+    // 2. 未找到，自动创建
+    // 先获取工作空间的路径信息（create_todo_with_extras 需要）
+    let dir = db
+        .get_project_directory_by_id(workspace_id)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", workspace_id)))?;
+
+    let title = format!("Blackboard: workspace_{}", workspace_id);
+    let prompt = build_blackboard_prompt();
+
+    let todo_id = db
+        .create_todo_with_extras(
+            &title,
+            &prompt,
+            None,   // executor: 使用默认
+            None,   // acceptance_criteria
+            false,  // webhook_enabled
+            workspace_id,
+            &dir.path,
+        )
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    // 更新 action_type 和 action_key，标记为黑板更新 Todo
+    db.update_todo_full(crate::db::TodoUpdate {
+        id: todo_id,
+        title: &title,
+        prompt: &prompt,
+        status: crate::models::TodoStatus::Pending,
+        executor: None,
+        scheduler_enabled: None,
+        scheduler_config: None,
+        scheduler_timezone: None,
+        workspace_id: None,
+        webhook_enabled: None,
+        acceptance_criteria: None,
+        auto_review_enabled: None,
+        action_type: Some("blackboard"),
+        action_key: Some("update"),
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok((todo_id, true))
+}
+
+/// 构建黑板更新的 Prompt 模板。
+///
+/// 包含占位符 `{{current}}`、`{{conclusion}}`、`{{todo_id}}`、`{{todo_title}}`，
+/// 在执行前由 `replace_placeholders` 替换为实际值。
+/// 模板要求 LLM 按固定 Markdown 结构输出，便于前端直接渲染。
+fn build_blackboard_prompt() -> String {
+    r#"你是一个工作空间知识库的维护者。你的任务是维护一个 Markdown 格式的"黑板"，记录工作空间中所有任务执行的结论和当前进展。
+
+当前黑板内容：
+```
+{{current}}
+```
+
+新任务结论：
+- 任务 ID: {{todo_id}}
+- 任务标题: {{todo_title}}
+- 执行结论: {{conclusion}}
+
+请更新黑板内容，要求：
+1. 将新结论整合到黑板中
+2. 保持以下结构：
+   - # 工作空间进展
+   - ## 已确认
+   - ## 新发现
+   - ## 待解决问题
+   - ## 矛盾/风险
+   - ## 下一步建议
+3. 每条结论标注来源，格式：(来源: [todo_{{todo_id}}](ntd://todo/{{todo_id}}))
+4. 如果新结论与已有结论矛盾，在"矛盾/风险"中标注
+5. 如果新结论提出了未解决的问题，在"待解决问题"中列出
+6. 更新"下一步建议"
+7. 保持 Markdown 格式，不要添加 HTML
+8. 如果黑板为空，根据新结论创建初始结构
+
+只输出更新后的黑板内容，不要输出任何解释。"#.to_string()
+}
+
+/// 更新黑板内容。
+///
+/// 核心逻辑：
+/// 1. 读取当前黑板内容（来自 blackboards 表）
+/// 2. 查找或创建 blackboard update Todo（action_type="blackboard", action_key="update"）
+/// 3. 用 `replace_placeholders` 替换 Prompt 中的占位符
+/// 4. 调用 `run_todo_execution` 启动执行（复用现有的 LLM 执行机制）
+/// 5. 订阅 broadcast channel 等待 `Finished` 事件
+/// 6. 提取 `result` 并更新 blackboards 表
+///
+/// 黑板更新失败不会影响源任务的执行流程，只在日志中记录 warn。
+pub async fn update_blackboard(
+    db: Arc<Database>,
+    executor_registry: Arc<ExecutorRegistry>,
+    tx: broadcast::Sender<ExecEvent>,
+    task_manager: Arc<TaskManager>,
+    config: Arc<std::sync::RwLock<Config>>,
+    workspace_id: i64,
+    conclusion: &str,
+    source_todo_id: i64,
+    source_todo_title: &str,
+) -> Result<(), AppError> {
+    // 1. 读取当前黑板内容
+    //    首次使用时可能为 None，此时使用空字符串作为初始内容
+    let current = db.get_blackboard(workspace_id).await.map_err(|e| {
+        AppError::Internal(format!("读取黑板失败: {}", e))
+    })?;
+    let current_content = current
+        .map(|b| b.content)
+        .unwrap_or_default();
+
+    // 2. 查找或创建 blackboard update todo
+    //    每个工作空间使用独立的 blackboard todo，避免跨空间混淆
+    let (todo_id, _) = find_or_create_blackboard_todo(&db, workspace_id).await?;
+
+    // 3. 构造 prompt（复用 Action 的占位符替换机制）
+    //    models::replace_placeholders 将 {{key}} 占位符替换为 params 中的值
+    let prompt = build_blackboard_prompt();
+    let mut params = HashMap::new();
+    params.insert("current".to_string(), current_content);
+    params.insert("conclusion".to_string(), conclusion.to_string());
+    params.insert("todo_id".to_string(), source_todo_id.to_string());
+    params.insert("todo_title".to_string(), source_todo_title.to_string());
+    let message = crate::models::replace_placeholders(&prompt, &params);
+
+    // 4. 启动执行（复用 run_todo_execution）
+    //    使用 trigger_type="blackboard" 标记这是黑板更新任务，
+    //    这样 Finished 事件 Hook 中可以跳过再次触发黑板更新（避免无限循环）
+    let result = crate::handlers::execution::start_todo_execution(
+        RunTodoExecutionRequest {
+            db: db.clone(),
+            executor_registry,
+            tx: tx.clone(),
+            task_manager,
+            config,
+            todo_id,
+            message,
+            req_executor: None,
+            trigger_type: "blackboard".to_string(),
+            params: Some(params),
+            resume_session_id: None,
+            resume_message: None,
+            source_todo_id: Some(source_todo_id),
+            source_todo_title: Some(source_todo_title.to_string()),
+            feishu_bot_id: None,
+            feishu_receive_id: None,
+            loop_step_execution_id: None,
+            step_id: None,
+            workspace_path: None,
+            workspace_id: Some(workspace_id),
+        },
+    )
+    .await?;
+
+    // 获取 task_id 用于后续匹配 Finished 事件（ExecEvent::Finished 没有 record_id 字段，
+    // 用全局唯一的 task_id 区分多次执行，避免并发时匹配到错误的完成事件）
+    let task_id = result.task_id.clone();
+    result.record_id.ok_or_else(|| {
+        AppError::Internal("黑板更新任务启动失败".to_string())
+    })?;
+
+    // 5. 订阅 broadcast channel 等待 Finished 事件
+    //    用 task_id 匹配对应的完成事件，忽略其他事件的干扰
+    let mut rx = tx.subscribe();
+    loop {
+        match rx.recv().await {
+            Ok(ExecEvent::Finished {
+                task_id: ref finished_task_id,
+                result: Some(ref new_content),
+                ..
+            }) if *finished_task_id == task_id => {
+                let new_content = new_content.clone();
+                // 6. 更新黑板内容到数据库
+                //    先确保黑板记录存在（首次更新时自动创建）
+                if db.get_blackboard(workspace_id).await.map_err(|e| {
+                    AppError::Internal(format!("查询黑板失败: {}", e))
+                })?.is_none() {
+                    db.create_blackboard(workspace_id).await.map_err(|e| {
+                        AppError::Internal(format!("创建黑板失败: {}", e))
+                    })?;
+                }
+
+                db.update_blackboard_content(workspace_id, &new_content)
+                    .await
+                    .map_err(|e| AppError::Internal(format!("更新黑板失败: {}", e)))?;
+
+                tracing::info!(
+                    "黑板更新成功: workspace_id={}, source_todo_id={}, task_id={}",
+                    workspace_id,
+                    source_todo_id,
+                    task_id
+                );
+                return Ok(());
+            }
+            Ok(_) => {
+                // 其他事件（Output/Started 等），忽略继续等待
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                // 通道积压：发生 Lagged 时跳过丢失的事件，继续等待
+                tracing::warn!("黑板更新事件通道积压，跳过 {} 个事件", n);
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                // 通道关闭：不应发生，如果通道关闭则返回错误
+                return Err(AppError::Internal("事件通道已关闭".to_string()));
+            }
+        }
+    }
+}
+
+/// 手动刷新黑板：重新执行 blackboard update todo。
+///
+/// 与 `update_blackboard` 不同，手动刷新只是纯粹地要求 LLM 根据当前黑板内容
+/// 重新组织生成（没有新的结论输入）。效果相当于让 LLM"重新检视"现有内容。
+///
+/// 工作方式：
+/// 1. 查找 blackboard update todo
+/// 2. 以当前黑板内容 + "手动刷新"作为输入执行该 todo
+/// 3. 等待 Finished 事件并更新黑板
+pub async fn refresh_blackboard(
+    db: Arc<Database>,
+    executor_registry: Arc<ExecutorRegistry>,
+    tx: broadcast::Sender<ExecEvent>,
+    task_manager: Arc<TaskManager>,
+    config: Arc<std::sync::RwLock<Config>>,
+    workspace_id: i64,
+) -> Result<(), AppError> {
+    // 查找黑板的当前内容，如果没有内容则无需刷新
+    let current = db.get_blackboard(workspace_id).await.map_err(|e| {
+        AppError::Internal(format!("读取黑板失败: {}", e))
+    })?;
+    let current_content = current
+        .map(|b| b.content)
+        .unwrap_or_default();
+
+    if current_content.is_empty() {
+        return Err(AppError::BadRequest("黑板暂无内容，无需刷新".to_string()));
+    }
+
+    // 查找或创建 blackboard update todo
+    let (todo_id, _) = find_or_create_blackboard_todo(&db, workspace_id).await?;
+
+    // 构造 prompt：使用当前黑板内容 + 手动刷新标记
+    let prompt = build_blackboard_prompt();
+    let mut params = HashMap::new();
+    params.insert("current".to_string(), current_content);
+    params.insert("conclusion".to_string(), "手动刷新：无新结论，请重新组织现有内容".to_string());
+    params.insert("todo_id".to_string(), "0".to_string());
+    params.insert("todo_title".to_string(), "手动刷新黑板".to_string());
+    let message = crate::models::replace_placeholders(&prompt, &params);
+
+    // 启动执行
+    let result = crate::handlers::execution::start_todo_execution(
+        RunTodoExecutionRequest {
+            db: db.clone(),
+            executor_registry,
+            tx: tx.clone(),
+            task_manager,
+            config,
+            todo_id,
+            message,
+            req_executor: None,
+            trigger_type: "blackboard".to_string(),
+            params: Some(params),
+            resume_session_id: None,
+            resume_message: None,
+            source_todo_id: None,
+            source_todo_title: None,
+            feishu_bot_id: None,
+            feishu_receive_id: None,
+            loop_step_execution_id: None,
+            step_id: None,
+            workspace_path: None,
+            workspace_id: Some(workspace_id),
+        },
+    )
+    .await?;
+
+    let task_id = result.task_id.clone();
+    result.record_id.ok_or_else(|| {
+        AppError::Internal("黑板刷新任务启动失败".to_string())
+    })?;
+
+    // 等待 Finished 事件
+    let mut rx = tx.subscribe();
+    loop {
+        match rx.recv().await {
+            Ok(ExecEvent::Finished {
+                task_id: ref finished_task_id,
+                result: Some(ref new_content),
+                ..
+            }) if *finished_task_id == task_id => {
+                let new_content = new_content.clone();
+                db.update_blackboard_content(workspace_id, &new_content)
+                    .await
+                    .map_err(|e| AppError::Internal(format!("更新黑板失败: {}", e)))?;
+
+                tracing::info!(
+                    "黑板刷新成功: workspace_id={}, task_id={}",
+                    workspace_id,
+                    task_id
+                );
+                return Ok(());
+            }
+            Ok(_) => {}
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                tracing::warn!("黑板刷新事件通道积压，跳过 {} 个事件", n);
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                return Err(AppError::Internal("事件通道已关闭".to_string()));
+            }
+        }
+    }
+}

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -124,6 +124,40 @@ fn build_blackboard_prompt() -> String {
 只输出更新后的黑板内容，不要输出任何解释。"#.to_string()
 }
 
+/// 构建手动刷新黑板的 Prompt 模板。
+///
+/// 与 `build_blackboard_prompt` 的区别：
+/// - 没有"新任务结论"段（手动刷新不携带具体任务）
+/// - 明确禁止生成 `ntd://todo/{{id}}` 内部链接：
+///   手动刷新没有真实的"来源 todo"，沿用 update 模板会让 LLM 注入
+///   `ntd://todo/0` 这种指向不存在记录的坏链接
+/// - 目标是"重新组织现有信息"，不引入新事实
+///
+/// 仅依赖 `{{current}}` 占位符，调用方只需替换 current 即可。
+fn build_refresh_prompt() -> String {
+    r#"你是一个工作空间知识库的维护者。重新组织当前黑板内容，使其结构更清晰、信息更准确。
+
+当前黑板内容：
+```
+{{current}}
+```
+
+请重新组织黑板内容，要求：
+1. 保持以下结构：
+   - # 工作空间进展
+   - ## 已确认
+   - ## 新发现
+   - ## 待解决问题
+   - ## 矛盾/风险
+   - ## 下一步建议
+2. 不要添加任何新事实，不要虚构来源 todo；只整理、归并、提炼已有信息
+3. 禁止生成 ntd://todo/ 内部链接（手动刷新没有具体来源 todo）
+4. 合并相似条目；移除空段
+5. 保持 Markdown 格式，不要添加 HTML
+
+只输出重新组织后的黑板内容，不要输出任何解释。"#.to_string()
+}
+
 /// 读取指定工作空间的黑板内容；无记录时返回空字符串。
 ///
 /// 隐藏 None/Some 差异，让上游不用每次都 .map().unwrap_or_default()。
@@ -356,12 +390,11 @@ pub async fn refresh_blackboard(
     }
     // 复用同一 todo + 同一执行/等待/写入流程；source_todo_* 留 None 表示"非任务触发"
     let (todo_id, _) = find_or_create_blackboard_todo(&db, workspace_id).await?;
-    let (message, params) = assemble_prompt(
-        current_content,
-        "手动刷新：无新结论，请重新组织现有内容".to_string(),
-        0,
-        "手动刷新黑板",
-    );
+    // 手动刷新走独立 prompt 模板：避免 LLM 用 todo_id=0 拼出 ntd://todo/0 坏链接。
+    // 模板只依赖 {{current}}，不需要 source_todo_* 之类的额外占位符。
+    let mut params = HashMap::new();
+    params.insert("current".to_string(), current_content);
+    let message = crate::models::replace_placeholders(&build_refresh_prompt(), &params);
     let new_content = run_blackboard_execution(
         db.clone(),
         executor_registry,
@@ -371,7 +404,8 @@ pub async fn refresh_blackboard(
         workspace_id,
         todo_id,
         message,
-        params,
+        // params 用空 map：手动刷新只用了 {{current}}，无其它占位符
+        HashMap::new(),
         None,
         None,
     )
@@ -400,6 +434,28 @@ mod tests {
         assert!(prompt.contains("{{conclusion}}"));
         assert!(prompt.contains("{{todo_id}}"));
         assert!(prompt.contains("{{todo_title}}"));
+    }
+
+    /// 验证 build_refresh_prompt 不含 todo 来源占位符，并显式禁止 ntd:// 内部链接。
+    /// 防止手动刷新误用 update 模板生成 `ntd://todo/0` 坏链接。
+    #[test]
+    fn test_refresh_prompt_has_no_source_attribution() {
+        let prompt = build_refresh_prompt();
+        // 不应有 source-todo 相关占位符（手动刷新无来源 todo）
+        assert!(!prompt.contains("{{todo_id}}"));
+        assert!(!prompt.contains("{{todo_title}}"));
+        assert!(!prompt.contains("{{conclusion}}"));
+        // 应显式禁止生成 ntd://todo/ 内部链接
+        assert!(
+            prompt.contains("ntd://todo/"),
+            "refresh prompt 必须显式提到 ntd://todo/ 以提醒 LLM 不要伪造来源"
+        );
+        assert!(
+            prompt.contains("禁止") || prompt.contains("不要"),
+            "refresh prompt 应包含明确的禁止/不要类指令"
+        );
+        // 仍保留 {{current}} 占位符
+        assert!(prompt.contains("{{current}}"));
     }
 
     /// 验证 assemble_prompt 正确替换占位符，且结论字段透传。

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -347,6 +347,8 @@ mod feishu_push_binding_tests {
             workspace_id: Some(1),
             duration_secs: 0,
             total_tokens: 0,
+            // 测试构造，无需真实 trigger_type 上下文
+            trigger_type: None,
         };
         
         assert!(!FeishuPushService::should_send(push_level, &event));
@@ -368,6 +370,8 @@ mod feishu_push_binding_tests {
             workspace_id: Some(1),
             duration_secs: 0,
             total_tokens: 0,
+            // 测试构造，无需真实 trigger_type 上下文
+            trigger_type: None,
         };
         
         assert!(FeishuPushService::should_send(push_level, &event));
@@ -389,6 +393,8 @@ mod feishu_push_binding_tests {
             workspace_id: Some(1),
             duration_secs: 0,
             total_tokens: 0,
+            // 测试构造，无需真实 trigger_type 上下文
+            trigger_type: None,
         };
         
         assert!(FeishuPushService::should_send(push_level, &event));

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod auto_review;
 pub mod auto_update;
+pub mod blackboard;
 pub mod feishu_history_fetcher;
 pub mod feishu_listener;
 pub mod feishu_push;

--- a/backend/tests/services_tests.rs
+++ b/backend/tests/services_tests.rs
@@ -455,6 +455,7 @@ mod feishu_push_service_tests {
             workspace_id: None,
             duration_secs: 125,
             total_tokens: 500,
+            trigger_type: None,
         }
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2257,6 +2257,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2266,7 +2267,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2257,7 +2257,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2267,7 +2266,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { SettingsPage } from './components/SettingsPage';
 import { SkillsPanel } from './components/SkillsPanel';
 import { ProjectDirectoriesPanel } from './components/settings/ProjectDirectoriesPanel';
 import { ExecutorsPanel } from './components/settings/ExecutorsPanel';
+import { BlackboardPage } from './components/BlackboardPage';
 import { ExecutionPanel } from './components/ExecutionPanel';
 import { TodoDrawer } from './components/TodoDrawer';
 import { SmartCreateModal } from './components/SmartCreateModal';
@@ -359,6 +360,8 @@ function AppContent() {
                 <SettingsPage />
               ) : activeView === 'memorial' ? (
                 <MemorialBoard />
+              ) : activeView === 'blackboard' ? (
+                <BlackboardPage />
               ) : (
                 <Dashboard />
               )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -190,6 +190,7 @@ function AppContent() {
     if (key === 'loops') { showListSection('loop'); return; }
     if (key === 'dashboard') { handleShowView('dashboard'); return; }
     if (key === 'memorial') { handleShowView('memorial'); return; }
+    if (key === 'blackboard') { handleShowView('blackboard'); return; }
     if (key === 'settings') { showSettings(null); return; }
     if (key === 'settings_projectDirectories') { showStandaloneSettingsPanel('projectDirectories'); return; }
     if (key === 'settings_skills') { showStandaloneSettingsPanel('skills'); return; }
@@ -361,7 +362,7 @@ function AppContent() {
               ) : activeView === 'memorial' ? (
                 <MemorialBoard />
               ) : activeView === 'blackboard' ? (
-                <BlackboardPage />
+                <BlackboardPage workspaceId={state.selectedWorkspace} />
               ) : (
                 <Dashboard />
               )}

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -8,6 +8,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Button, Typography, Skeleton, message } from 'antd';
 import { ReloadOutlined } from '@ant-design/icons';
+import { useTheme } from '@/hooks/useTheme';
 
 const { Title } = Typography;
 
@@ -45,15 +46,16 @@ function renderMarkdownLinks(content: string): string {
  *   │  (或空状态提示"暂无内容...")        │
  *   └──────────────────────────────────┘
  */
-export function BlackboardPage() {
+export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?: number | null }) {
+  const { themeMode } = useTheme();
+  const isDark = themeMode === 'dark';
   const [data, setData] = useState<BlackboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
 
-  // 当前工作空间 ID — 从 URL 参数或全局状态获取
-  // 后端 API 路径为 /api/workspaces/{workspace_id}/blackboard
-  // 这里从 URL 的 workspace 参数获取，默认使用 1
+  // 当前工作空间 ID：优先使用父组件传入的当前工作空间，降级到 URL 参数字段，默认 1
   const [workspaceId] = useState<number>(() => {
+    if (propWorkspaceId != null) return propWorkspaceId;
     const ws = new URLSearchParams(window.location.search).get('workspace');
     return ws ? Number(ws) : 1;
   });
@@ -149,12 +151,13 @@ export function BlackboardPage() {
       ) : data && data.content ? (
         <div
           style={{
-            background: '#fff',
+            background: isDark ? '#1f1f1f' : '#fff',
             borderRadius: 8,
             padding: 16,
             minHeight: 200,
             lineHeight: 1.8,
             fontSize: 14,
+            color: isDark ? '#e0e0e0' : '#333',
           }}
           dangerouslySetInnerHTML={{ __html: renderContent(data.content) }}
         />
@@ -163,10 +166,10 @@ export function BlackboardPage() {
           style={{
             textAlign: 'center',
             padding: '48px 0',
-            color: '#999',
+            color: isDark ? '#666' : '#999',
           }}
         >
-          <p style={{ fontSize: 16, marginBottom: 8 }}>暂无内容</p>
+          <p style={{ fontSize: 16, marginBottom: 8, color: isDark ? '#aaa' : '#666' }}>暂无内容</p>
           <p>任务执行后将自动更新黑板内容</p>
         </div>
       )}

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -1,0 +1,175 @@
+/**
+ * BlackboardPage — 黑板页面。
+ *
+ * 渲染工作空间的黑板内容（Markdown 格式），
+ * 支持手动刷新和 ntd://todo/{id} 链接跳转。
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { Button, Typography, Skeleton, message } from 'antd';
+import { ReloadOutlined } from '@ant-design/icons';
+
+const { Title } = Typography;
+
+// 黑板数据接口（匹配后端 API 返回结构）
+interface BlackboardData {
+  id: number;
+  workspace_id: number;
+  content: string;
+  updated_at: string | null;
+}
+
+/**
+ * 自定义 Markdown 链接渲染器：识别 ntd://todo/{id} 协议。
+ *
+ * 当用户在黑板中点击类似 (来源: [todo_123](ntd://todo/123)) 的链接时，
+ * 解析 todo_id 并通过 URL 参数跳转到事项详情页。
+ */
+function renderMarkdownLinks(content: string): string {
+  // 将 ntd://todo/{id} 替换为普通的 #/items?id={id} HTML 链接
+  // 使用正则匹配，不依赖额外依赖
+  return content.replace(
+    /ntd:\/\/todo\/(\d+)/g,
+    (_match, todoId: string) => `#/items?id=${todoId}`
+  );
+}
+
+/**
+ * 黑板页面组件。
+ *
+ * 布局：
+ *   ┌──────────────────────────────────┐
+ *   │ 黑板                     [刷新按钮] |
+ *   ├──────────────────────────────────┤
+ *   │            Markdown 内容          │
+ *   │  (或空状态提示"暂无内容...")        │
+ *   └──────────────────────────────────┘
+ */
+export function BlackboardPage() {
+  const [data, setData] = useState<BlackboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  // 当前工作空间 ID — 从 URL 参数或全局状态获取
+  // 后端 API 路径为 /api/workspaces/{workspace_id}/blackboard
+  // 这里从 URL 的 workspace 参数获取，默认使用 1
+  const [workspaceId] = useState<number>(() => {
+    const ws = new URLSearchParams(window.location.search).get('workspace');
+    return ws ? Number(ws) : 1;
+  });
+
+  // 获取黑板内容
+  const fetchBlackboard = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await fetch(`/api/workspaces/${workspaceId}/blackboard`);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const json = await res.json();
+      if (json.data) {
+        setData(json.data as BlackboardData);
+      }
+    } catch (err) {
+      console.error('获取黑板失败:', err);
+      message.error('获取黑板内容失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId]);
+
+  // 手动刷新黑板
+  const handleRefresh = useCallback(async () => {
+    try {
+      setRefreshing(true);
+      const res = await fetch(`/api/workspaces/${workspaceId}/blackboard/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      message.success('黑板刷新已触发，请稍后查看');
+      // 延迟 2 秒后自动拉取最新内容
+      setTimeout(() => {
+        fetchBlackboard();
+      }, 2000);
+    } catch (err) {
+      console.error('刷新黑板失败:', err);
+      message.error('刷新黑板失败');
+    } finally {
+      setRefreshing(false);
+    }
+  }, [workspaceId, fetchBlackboard]);
+
+  // 页面加载时自动获取黑板内容
+  useEffect(() => {
+    fetchBlackboard();
+  }, [fetchBlackboard]);
+
+  // 渲染 Markdown 内容为 HTML（简单换行 + 链接处理）
+  const renderContent = (text: string): string => {
+    // 先处理特殊链接协议
+    let html = renderMarkdownLinks(text);
+    // 简单的 Markdown 到 HTML 转换（标题、列表、代码块）
+    // 使用 @ant-design/x-markdown 需要额外安装，这里先用基础渲染
+    // 将 \n 转换为 <br/>
+    html = html.replace(/\n/g, '<br/>');
+    return html;
+  };
+
+  return (
+    <div style={{ padding: '16px 24px', height: '100%', overflow: 'auto' }}>
+      {/* 顶部标题栏：左侧标题 + 右侧刷新按钮 */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 16,
+        }}
+      >
+        <Title level={4} style={{ margin: 0 }}>
+          黑板
+        </Title>
+        <Button
+          type="primary"
+          icon={<ReloadOutlined />}
+          loading={refreshing}
+          onClick={handleRefresh}
+          disabled={loading || data === null}
+        >
+          {refreshing ? '更新中...' : '刷新'}
+        </Button>
+      </div>
+
+      {/* 内容区域 */}
+      {loading ? (
+        <Skeleton active paragraph={{ rows: 8 }} />
+      ) : data && data.content ? (
+        <div
+          style={{
+            background: '#fff',
+            borderRadius: 8,
+            padding: 16,
+            minHeight: 200,
+            lineHeight: 1.8,
+            fontSize: 14,
+          }}
+          dangerouslySetInnerHTML={{ __html: renderContent(data.content) }}
+        />
+      ) : (
+        <div
+          style={{
+            textAlign: 'center',
+            padding: '48px 0',
+            color: '#999',
+          }}
+        >
+          <p style={{ fontSize: 16, marginBottom: 8 }}>暂无内容</p>
+          <p>任务执行后将自动更新黑板内容</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -2,41 +2,7 @@
  * BlackboardPage — 黑板页面。
  *
  * 渲染工作空间的黑板内容（Markdown 格式），
- * 支持手动刷新和 ntd://todo/{id} 链接跳转。
- */
-
-import { useState, useEffect, useCallback } from 'react';
-import { Button, Typography, Skeleton, message } from 'antd';
-import { ReloadOutlined } from '@ant-design/icons';
-import { useTheme } from '@/hooks/useTheme';
-
-const { Title } = Typography;
-
-// 黑板数据接口（匹配后端 API 返回结构）
-interface BlackboardData {
-  id: number;
-  workspace_id: number;
-  content: string;
-  updated_at: string | null;
-}
-
-/**
- * 自定义 Markdown 链接渲染器：识别 ntd://todo/{id} 协议。
- *
- * 当用户在黑板中点击类似 (来源: [todo_123](ntd://todo/123)) 的链接时，
- * 解析 todo_id 并通过 URL 参数跳转到事项详情页。
- */
-function renderMarkdownLinks(content: string): string {
-  // 将 ntd://todo/{id} 替换为普通的 #/items?id={id} HTML 链接
-  // 使用正则匹配，不依赖额外依赖
-  return content.replace(
-    /ntd:\/\/todo\/(\d+)/g,
-    (_match, todoId: string) => `#/items?id=${todoId}`
-  );
-}
-
-/**
- * 黑板页面组件。
+ * 支持手动刷新和 ntd://todo/{id} 内部链接跳转。
  *
  * 布局：
  *   ┌──────────────────────────────────┐
@@ -46,133 +12,307 @@ function renderMarkdownLinks(content: string): string {
  *   │  (或空状态提示"暂无内容...")        │
  *   └──────────────────────────────────┘
  */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Button, Typography, Skeleton, message } from 'antd';
+import { ReloadOutlined } from '@ant-design/icons';
+import { XMarkdown } from '@ant-design/x-markdown';
+import { useTheme } from '@/hooks/useTheme';
+import { useViewState } from '@/hooks/useViewState';
+
+const { Title } = Typography;
+
+/** 黑板 API 返回的 JSON 形状（与后端 BlackboardResponse 对应） */
+interface BlackboardData {
+  id: number;
+  workspace_id: number;
+  content: string;
+  updated_at: string | null;
+}
+
+/** ntd://todo/{id} 协议的前缀，用于解析 LLM 注入的内部链接 */
+const NTD_TODO_PROTOCOL_PREFIX = 'ntd://todo/';
+
+/** URL search 参数 `workspace` 的键名 */
+const URL_WORKSPACE_PARAM = 'workspace';
+
+/** 默认工作空间 ID（首屏兜底，避免 URL 未带参时无 workspace） */
+const DEFAULT_WORKSPACE_ID = 1;
+
+/** 触发刷新后延迟拉取最新内容的时间，让 LLM 任务有时间写库 */
+const REFRESH_POLL_DELAY_MS = 2000;
+
+/** Markdown 链接组件 props 形状（XMarkdown ComponentProps 简化版） */
+interface MarkdownLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  href?: string;
+  children?: React.ReactNode;
+}
+
+/**
+ * Markdown 链接渲染器：识别 ntd://todo/{id} 内部协议。
+ *
+ * 行为：
+ * - href 以 ntd://todo/ 开头 → 渲染为可点击的"内链"按钮，
+ *   点击时通过 useViewState.selectTodo 导航到事项详情，
+ *   阻止浏览器尝试解析 ntd:// 自定义协议导致"找不到应用"提示。
+ * - 其他 href（http/https/mailto 等）→ 用原生 <a target="_blank"> 打开外部链接。
+ */
+function TodoLink(props: MarkdownLinkProps): React.ReactElement {
+  // 用 hook 不能放在条件分支里：TodoLink 总是组件实例，调用安全
+  const { selectTodo } = useViewState();
+  const href = props.href ?? '';
+  // 解析 ntd://todo/{id} → 提取纯数字 id
+  const isInternal = href.startsWith(NTD_TODO_PROTOCOL_PREFIX);
+  const todoId = isInternal ? Number(href.slice(NTD_TODO_PROTOCOL_PREFIX.length)) : NaN;
+
+  // 内部链接：用 button 风格 + onClick，避免浏览器把 ntd:// 解释成未知协议
+  if (isInternal && Number.isFinite(todoId)) {
+    return (
+      <a
+        {...props}
+        href={`#/items?id=${todoId}`}
+        // preventDefault：阻止浏览器实际跳到 #/items?id=...，完全交给 selectTodo
+        onClick={(e) => {
+          e.preventDefault();
+          // stopPropagation：避免外层 XMarkdown 的 link 行为再次触发
+          e.stopPropagation();
+          selectTodo(todoId);
+        }}
+        style={{ color: 'var(--color-primary, #1677ff)', textDecoration: 'underline', cursor: 'pointer' }}
+      >
+        {props.children}
+      </a>
+    );
+  }
+
+  // 外部链接：新窗口打开 + rel=noopener 防 tabnabbing
+  return (
+    <a {...props} target="_blank" rel="noopener noreferrer">
+      {props.children}
+    </a>
+  );
+}
+
+/** 从 URL ?workspace=N 解析工作空间 ID；解析失败时返回默认值 */
+function resolveWorkspaceFromUrl(): number {
+  // 在浏览器外（如 SSR/测试）调用 window 会炸；外层先保证只在浏览器跑
+  const raw = new URLSearchParams(window.location.search).get(URL_WORKSPACE_PARAM);
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isFinite(parsed) ? parsed : DEFAULT_WORKSPACE_ID;
+}
+
+/** 决定当前生效的 workspaceId：prop 优先，否则从 URL 解析 */
+function useEffectiveWorkspaceId(propWorkspaceId: number | null | undefined): number {
+  // 每次渲染都重新计算：避免 useState 初始化只跑一次的旧 bug
+  // 切换工作空间时 propWorkspaceId 会变，依赖它让派生值自动跟随
+  return useMemo(() => {
+    if (propWorkspaceId != null) return propWorkspaceId;
+    return resolveWorkspaceFromUrl();
+  }, [propWorkspaceId]);
+}
+
+/** 拉取黑板内容的纯函数，便于测试与复用 */
+async function fetchBlackboardData(workspaceId: number): Promise<BlackboardData> {
+  // 走原生 fetch：项目其它页也直接用 fetch，引入 axios 不会带来收益
+  const res = await fetch(`/api/workspaces/${workspaceId}/blackboard`);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  // 后端返回 { data: {...} }：解包 data 字段
+  const json = (await res.json()) as { data?: BlackboardData };
+  if (!json.data) {
+    throw new Error('Empty response body');
+  }
+  return json.data;
+}
+
+/** 触发手动刷新，返回是否成功 */
+async function triggerRefresh(workspaceId: number): Promise<void> {
+  const res = await fetch(`/api/workspaces/${workspaceId}/blackboard/refresh`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+}
+
 export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?: number | null }) {
+  // 主题：决定黑板容器背景与文字色
   const { themeMode } = useTheme();
   const isDark = themeMode === 'dark';
-  const [data, setData] = useState<BlackboardData | null>(null);
-  const [loading, setLoading] = useState(true);
+  // 派生值（不再 useState）：切换工作空间时自动跟随 prop 变化
+  const workspaceId = useEffectiveWorkspaceId(propWorkspaceId);
+
+  // 数据状态：data 既是"内容"也是"是否加载完成"的判断
+  const [data, setData] = useStateBlackboardData();
   const [refreshing, setRefreshing] = useState(false);
 
-  // 当前工作空间 ID：优先使用父组件传入的当前工作空间，降级到 URL 参数字段，默认 1
-  const [workspaceId] = useState<number>(() => {
-    if (propWorkspaceId != null) return propWorkspaceId;
-    const ws = new URLSearchParams(window.location.search).get('workspace');
-    return ws ? Number(ws) : 1;
-  });
-
-  // 获取黑板内容
-  const fetchBlackboard = useCallback(async () => {
+  // 拉取（受 workspaceId 变化驱动）：useCallback 稳定引用，让 useEffect 只在 id 变时重跑
+  const fetchData = useCallback(async () => {
     try {
-      setLoading(true);
-      const res = await fetch(`/api/workspaces/${workspaceId}/blackboard`);
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
-      }
-      const json = await res.json();
-      if (json.data) {
-        setData(json.data as BlackboardData);
-      }
+      const fetched = await fetchBlackboardData(workspaceId);
+      setData(fetched);
     } catch (err) {
+      // 业务错误不影响页面骨架：仅弹 toast 让用户知晓
       console.error('获取黑板失败:', err);
       message.error('获取黑板内容失败');
-    } finally {
-      setLoading(false);
     }
-  }, [workspaceId]);
+  }, [workspaceId, setData]);
 
-  // 手动刷新黑板
+  // 副作用：workspaceId 变化时重拉
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // 刷新：发请求 + 延迟再拉取（让 LLM 任务有时间写库）
   const handleRefresh = useCallback(async () => {
     try {
       setRefreshing(true);
-      const res = await fetch(`/api/workspaces/${workspaceId}/blackboard/refresh`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-      });
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
-      }
+      await triggerRefresh(workspaceId);
       message.success('黑板刷新已触发，请稍后查看');
-      // 延迟 2 秒后自动拉取最新内容
-      setTimeout(() => {
-        fetchBlackboard();
-      }, 2000);
+      // 延迟拉取：避免与触发请求竞争；用 setTimeout 即可，不需要后端推送
+      window.setTimeout(fetchData, REFRESH_POLL_DELAY_MS);
     } catch (err) {
       console.error('刷新黑板失败:', err);
       message.error('刷新黑板失败');
     } finally {
       setRefreshing(false);
     }
-  }, [workspaceId, fetchBlackboard]);
+  }, [workspaceId, fetchData]);
 
-  // 页面加载时自动获取黑板内容
-  useEffect(() => {
-    fetchBlackboard();
-  }, [fetchBlackboard]);
-
-  // 渲染 Markdown 内容为 HTML（简单换行 + 链接处理）
-  const renderContent = (text: string): string => {
-    // 先处理特殊链接协议
-    let html = renderMarkdownLinks(text);
-    // 简单的 Markdown 到 HTML 转换（标题、列表、代码块）
-    // 使用 @ant-design/x-markdown 需要额外安装，这里先用基础渲染
-    // 将 \n 转换为 <br/>
-    html = html.replace(/\n/g, '<br/>');
-    return html;
-  };
+  // 是否为空：id=0 是后端"无记录"的占位
+  const isEmpty = data === null || data.id === 0 || data.content.length === 0;
 
   return (
     <div style={{ padding: '16px 24px', height: '100%', overflow: 'auto' }}>
-      {/* 顶部标题栏：左侧标题 + 右侧刷新按钮 */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          marginBottom: 16,
-        }}
-      >
-        <Title level={4} style={{ margin: 0 }}>
-          黑板
-        </Title>
-        <Button
-          type="primary"
-          icon={<ReloadOutlined />}
-          loading={refreshing}
-          onClick={handleRefresh}
-          disabled={loading || data === null}
-        >
-          {refreshing ? '更新中...' : '刷新'}
-        </Button>
-      </div>
+      <BlackboardHeader
+        isDark={isDark}
+        refreshing={refreshing}
+        // 空状态时禁用刷新：避免无意义的 LLM 调用
+        onRefresh={handleRefresh}
+        disabled={isEmpty}
+      />
+      <BlackboardBody isDark={isDark} data={data} />
+    </div>
+  );
+}
 
-      {/* 内容区域 */}
-      {loading ? (
-        <Skeleton active paragraph={{ rows: 8 }} />
-      ) : data && data.content ? (
-        <div
-          style={{
-            background: isDark ? '#1f1f1f' : '#fff',
-            borderRadius: 8,
-            padding: 16,
-            minHeight: 200,
-            lineHeight: 1.8,
-            fontSize: 14,
-            color: isDark ? '#e0e0e0' : '#333',
-          }}
-          dangerouslySetInnerHTML={{ __html: renderContent(data.content) }}
-        />
-      ) : (
-        <div
-          style={{
-            textAlign: 'center',
-            padding: '48px 0',
-            color: isDark ? '#666' : '#999',
-          }}
-        >
-          <p style={{ fontSize: 16, marginBottom: 8, color: isDark ? '#aaa' : '#666' }}>暂无内容</p>
-          <p>任务执行后将自动更新黑板内容</p>
-        </div>
-      )}
+/**
+ * useState 黑板数据的轻封装：未来若加缓存/打点只改这里。
+ * 单独抽 hook 是为了让上层组件更可测。
+ */
+function useStateBlackboardData() {
+  return useState<BlackboardData | null>(null);
+}
+
+interface BlackboardHeaderProps {
+  isDark: boolean;
+  refreshing: boolean;
+  onRefresh: () => void;
+  disabled: boolean;
+}
+
+/** 顶部标题栏：标题 + 刷新按钮 */
+function BlackboardHeader(props: BlackboardHeaderProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        marginBottom: 16,
+      }}
+    >
+      <Title level={4} style={{ margin: 0 }}>
+        黑板
+      </Title>
+      <Button
+        type="primary"
+        icon={<ReloadOutlined />}
+        loading={props.refreshing}
+        onClick={props.onRefresh}
+        disabled={props.disabled}
+      >
+        {props.refreshing ? '更新中...' : '刷新'}
+      </Button>
+    </div>
+  );
+}
+
+interface BlackboardBodyProps {
+  isDark: boolean;
+  data: BlackboardData | null;
+}
+
+/** 正文区：loading / 有内容 / 空状态三分支 */
+function BlackboardBody(props: BlackboardBodyProps) {
+  // 首次加载用 skeleton 提升感知性能；data 还没回来时显示占位
+  if (props.data === null) {
+    return <Skeleton active paragraph={{ rows: 8 }} />;
+  }
+  if (props.data.id === 0 || props.data.content.length === 0) {
+    return <BlackboardEmpty isDark={props.isDark} />;
+  }
+  return <BlackboardContent isDark={props.isDark} content={props.data.content} />;
+}
+
+interface BlackboardContentProps {
+  isDark: boolean;
+  content: string;
+}
+
+/** 真正渲染 Markdown：XMarkdown 内部走 DOMPurify 防止 XSS */
+function BlackboardContent(props: BlackboardContentProps) {
+  const isDark = props.isDark;
+  return (
+    <div
+      style={{
+        // 主题适配：暗色用近黑容器，亮色用白底
+        background: isDark ? '#1f1f1f' : '#fff',
+        borderRadius: 8,
+        padding: 16,
+        minHeight: 200,
+        lineHeight: 1.8,
+        fontSize: 14,
+        color: isDark ? '#e0e0e0' : '#333',
+      }}
+    >
+      <XMarkdown
+        // 强制纯文本：XMarkdown 默认会注入 inline style，
+        // className 包一层让主题色与外层容器保持一致
+        className={isDark ? 'x-markdown-dark' : 'x-markdown-light'}
+        content={props.content}
+        // 覆盖 a 标签渲染：让 ntd://todo/{id} 走内部导航
+        components={{ a: TodoLink }}
+        // DOMPurify 默认会拒绝 ntd:// 等未知协议，会把整条链接剥成纯文本。
+        // 显式允许 ntd 协议，让内部链接得以保留；其它未知协议仍被拒绝。
+        dompurifyConfig={{
+          ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|tel|ntd):)/i,
+        }}
+      />
+    </div>
+  );
+}
+
+interface BlackboardEmptyProps {
+  isDark: boolean;
+}
+
+/** 空状态：占位文案，明确告诉用户"任务执行后会自动出现内容" */
+function BlackboardEmpty(props: BlackboardEmptyProps) {
+  return (
+    <div
+      style={{
+        textAlign: 'center',
+        padding: '48px 0',
+        color: props.isDark ? '#666' : '#999',
+      }}
+    >
+      <p style={{ fontSize: 16, marginBottom: 8, color: props.isDark ? '#aaa' : '#666' }}>
+        暂无内容
+      </p>
+      <p>任务执行后将自动更新黑板内容</p>
     </div>
   );
 }

--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -11,6 +11,7 @@ import {
   ThunderboltOutlined,
   FolderOutlined,
   CodeOutlined,
+  FormOutlined,
   DoubleRightOutlined,
   DoubleLeftOutlined,
   SunOutlined,
@@ -23,6 +24,7 @@ export type LeftRailKey =
   | 'loops'
   | 'dashboard'
   | 'memorial'
+  | 'blackboard'
   | 'settings'
   | 'settings_projectDirectories'
   | 'settings_sessions'
@@ -73,6 +75,7 @@ export function LeftRail({
       items: [
         { key: 'items', label: '事项', icon: <UnorderedListOutlined />, ariaLabel: '事项' },
         { key: 'loops', label: '环路', icon: <RetweetOutlined />, ariaLabel: '环路' },
+        { key: 'blackboard', label: '黑板', icon: <FormOutlined />, ariaLabel: '黑板' },
         { key: 'dashboard', label: '仪表盘', icon: <DashboardOutlined />, ariaLabel: '仪表盘' },
         { key: 'memorial', label: '看板', icon: <ReadOutlined />, ariaLabel: '看板' },
       ] satisfies LeftRailItem[],

--- a/frontend/src/hooks/useViewState.ts
+++ b/frontend/src/hooks/useViewState.ts
@@ -34,7 +34,8 @@ export type View =
   | 'skills'
   | 'projectDirectories'
   | 'sessions'
-  | 'executors';
+  | 'executors'
+  | 'blackboard';
 
 export type Panel = 'list' | 'detail' | 'post';
 
@@ -42,6 +43,7 @@ const ALL_VIEWS: View[] = [
   'items', 'loops',
   'dashboard', 'settings', 'memorial',
   'runtime', 'skills', 'projectDirectories', 'sessions', 'executors',
+  'blackboard',
 ];
 
 // ─── URL 解析/构建 ─────────────────────────────────────────
@@ -98,6 +100,7 @@ const VIEW_TO_NAV_KEY: Record<View, string> = {
   loops: 'loops',
   dashboard: 'dashboard',
   memorial: 'memorial',
+  blackboard: 'blackboard',
   settings: 'settings',
   runtime: 'settings_runtime',
   skills: 'settings_skills',

--- a/frontend/tests/blackboard_page.spec.ts
+++ b/frontend/tests/blackboard_page.spec.ts
@@ -1,0 +1,191 @@
+// 验证 BlackBoardPage 的核心行为：
+// 1. Markdown 渲染：h1 / list / link 都能正常显示
+// 2. ntd://todo/{id} 内部链接点击后通过 useViewState.selectTodo 导航到 items 视图
+// 3. 刷新按钮触发 POST /api/.../blackboard/refresh
+// 4. workspace 切换时重新拉取（修复 useState 快照 bug）
+//
+// 测试策略：使用 page.route() 拦截后端 API 返回固定 JSON，
+// 避免依赖真实 LLM 写入。
+
+import { test, expect, Page } from '@playwright/test';
+
+const BACKEND_URL = 'http://localhost:18088';
+
+const SAMPLE_CONTENT = [
+  '# 工作空间进展',
+  '',
+  '## 已确认',
+  '',
+  '- 关键结论见 [todo_42](ntd://todo/42)',
+  '- 文档位置：[/docs/spec.md](ntd://todo/99)',
+  '',
+  '## 下一步建议',
+  '',
+  '- 继续完成 [todo_100](ntd://todo/100)',
+  '',
+].join('\n');
+
+const SAMPLE_CONTENT_WS2 = [
+  '# 工作空间进展',
+  '',
+  '## 已确认',
+  '',
+  '- 关键结论见 [todo_77](ntd://todo/77)',
+  '- 文档位置：[/docs/spec.md](ntd://todo/88)',
+  '',
+  '## 下一步建议',
+  '',
+  '- 继续完成 [todo_200](ntd://todo/200)',
+  '',
+].join('\n');
+
+interface BlackboardResponse {
+  id: number;
+  workspace_id: number;
+  content: string;
+  updated_at: string | null;
+}
+
+function makeResponse(workspaceId: number, content: string): BlackboardResponse {
+  return {
+    id: content ? 1 : 0,
+    workspace_id: workspaceId,
+    content,
+    updated_at: content ? '2026-07-03T10:00:00Z' : null,
+  };
+}
+
+/** 安装 mock：根据 query 中的 workspace 返回不同内容 */
+async function installBlackboardMocks(page: Page) {
+  // 拦截 GET blackboard：返回当前 workspace 对应的内容
+  await page.route('**/api/workspaces/*/blackboard', async (route) => {
+    const url = new URL(route.request().url());
+    // 解析 workspace id：取 path 中数字段
+    const m = url.pathname.match(/\/api\/workspaces\/(\d+)\/blackboard/);
+    const wsId = m ? Number(m[1]) : 0;
+    // 用独立的 SAMPLE_CONTENT_WS2（不仅文字不同，URL 也不同），避免 href 漂移
+    const content = wsId === 2 ? SAMPLE_CONTENT_WS2 : SAMPLE_CONTENT;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ code: 0, data: makeResponse(wsId, content), message: 'ok' }),
+    });
+  });
+  // 拦截 POST refresh：返回成功
+  await page.route('**/api/workspaces/*/blackboard/refresh', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ code: 0, data: { success: true, message: '黑板刷新已触发' }, message: 'ok' }),
+    });
+  });
+}
+
+test('黑板页面渲染 Markdown：h1 / list / link 都能显示', async ({ page }) => {
+  await installBlackboardMocks(page);
+  await page.goto(`${BACKEND_URL}/?view=blackboard`);
+  await page.waitForTimeout(1000);
+
+  // 标题
+  const h1 = page.locator('h1', { hasText: '工作空间进展' });
+  await expect(h1).toBeVisible();
+
+  // 子标题
+  const h2 = page.locator('h2', { hasText: '已确认' });
+  await expect(h2).toBeVisible();
+
+  // 列表项
+  const item = page.locator('li', { hasText: /关键结论见/ });
+  await expect(item).toBeVisible();
+
+  // 内部链接渲染为可点击元素
+  const internalLink = page.locator('a[href*="/items?id=42"]');
+  await expect(internalLink).toBeVisible();
+});
+
+test('ntd://todo/42 内部链接点击后导航到 items 视图并选中对应 todo', async ({ page }) => {
+  await installBlackboardMocks(page);
+  await page.goto(`${BACKEND_URL}/?view=blackboard`);
+  await page.waitForTimeout(1000);
+
+  // 点击内部链接
+  const link = page.locator('a[href*="/items?id=42"]').first();
+  await link.click();
+  await page.waitForTimeout(500);
+
+  // 验证 URL 已更新到 items?id=42
+  expect(page.url()).toContain('view=items');
+  expect(page.url()).toContain('id=42');
+});
+
+test('点击刷新按钮触发 POST /api/.../blackboard/refresh', async ({ page }) => {
+  await installBlackboardMocks(page);
+
+  // 记录 refresh 请求次数
+  let refreshCalls = 0;
+  await page.route('**/api/workspaces/*/blackboard/refresh', async (route) => {
+    refreshCalls += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ code: 0, data: { success: true, message: '黑板刷新已触发' }, message: 'ok' }),
+    });
+  });
+
+  await page.goto(`${BACKEND_URL}/?view=blackboard`);
+  await page.waitForTimeout(1000);
+
+  // 刷新按钮：先等 button 可点击（loading 结束）
+  const refreshButton = page.locator('button', { hasText: '刷新' });
+  await expect(refreshButton).toBeEnabled();
+  await refreshButton.click();
+  await page.waitForTimeout(500);
+
+  expect(refreshCalls).toBeGreaterThanOrEqual(1);
+});
+
+test('切换 workspace 后页面重新拉取并渲染新内容（修复 useState 快照 bug）', async ({ page }) => {
+  await installBlackboardMocks(page);
+
+  // 默认 workspace=1，先打开黑板
+  await page.goto(`${BACKEND_URL}/?view=blackboard`);
+  await page.waitForTimeout(1000);
+  // 验证初始内容（todo_42）
+  const link42 = page.locator('a[href*="/items?id=42"]');
+  await expect(link42).toBeVisible();
+
+  // 通过 URL 切换到 workspace=2，触发 prop 或 URL 变化
+  await page.goto(`${BACKEND_URL}/?view=blackboard&workspace=2`);
+  await page.waitForTimeout(1500);
+
+  // 验证新内容（todo_77）出现，旧内容不再可见
+  const link77 = page.locator('a[href*="/items?id=77"]');
+  await expect(link77).toBeVisible();
+  // todo_42 是 workspace=1 特有的；切换后不应当还显示
+  // （注：playwright locator 仍可能匹配上 DOM 节点，需要等 fetch 完成；这里给 1.5s 缓冲）
+  const count42 = await page.locator('a[href*="/items?id=42"]').count();
+  expect(count42).toBe(0);
+});
+
+test('空内容时显示空状态文案', async ({ page }) => {
+  // 覆盖 mock 返回空内容
+  await page.route('**/api/workspaces/*/blackboard', async (route) => {
+    const m = new URL(route.request().url()).pathname.match(/\/api\/workspaces\/(\d+)\//);
+    const wsId = m ? Number(m[1]) : 0;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ code: 0, data: makeResponse(wsId, ''), message: 'ok' }),
+    });
+  });
+  await page.goto(`${BACKEND_URL}/?view=blackboard`);
+  await page.waitForTimeout(1000);
+
+  // 验证空状态文案
+  await expect(page.getByText('暂无内容')).toBeVisible();
+  await expect(page.getByText('任务执行后将自动更新黑板内容')).toBeVisible();
+
+  // 空状态下刷新按钮被禁用（避免无意义的 LLM 调用）
+  const refreshButton = page.locator('button', { hasText: '刷新' });
+  await expect(refreshButton).toBeDisabled();
+});


### PR DESCRIPTION
## 黑板 (Blackboard) 功能完整实现

基于 `docs/design/blackboard-design.md` 和 `docs/design/blackboard-dev-plan.md` 实现全部 5 个阶段。

### Phase 1 — 数据库层
- 创建 `blackboards` Entity（SeaORM，`workspace_id` UNIQUE）
- V47 迁移：创建 `blackboards` 表
- DB 层 CRUD：`get_blackboard` / `create_blackboard` / `update_blackboard_content`

### Phase 2 — 后端 API
- Blackboard Service：`find_or_create_blackboard_todo` / `update_blackboard` / `refresh_blackboard`
- 两个 API 端点：`GET` / `POST /api/workspaces/{id}/blackboard`
- 注册路由（领域路由数 19→20）

### Phase 3 — LLM 更新逻辑
- 黑板更新复用现有的 Action/Todo 执行机制（`run_todo_execution`）
- Finished 事件 Hook：任务成功后异步触发黑板更新
- 跳过 blackboard update todo 自身，避免无限循环
- 先 subscribe broadcast channel 再启动执行，避免错过快完成的任务事件
- 空结果保护：LLM 返回空内容时不覆盖已有黑板内容

### Phase 4 — 前端页面
- 左侧菜单新增「黑板」项（`FormOutlined` 图标）
- `BlackboardPage` 组件：Markdown 渲染 + `ntd://todo/{id}` 链接
- 支持暗色主题（`useTheme` hook）
- 使用当前活动工作空间 ID（`state.selectedWorkspace`）

### Phase 5 — 手动刷新
- 刷新按钮 + 更新中状态提示
- 自动重新拉取最新内容

### 验证
- ✅ 后端 `cargo check` 通过
- ✅ 前端 `npm run build` 通过
- ✅ 6 个新增单元测试通过（DB + Migration）
- ✅ 109 个现有 handler 测试全部通过