### PR TITLE
feat(todo): 批量暂停/恢复周期执行

### DIFF
--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -376,6 +376,32 @@ impl Database {
         Ok(rows_affected)
     }
 
+    /// 批量暂停/恢复事项的周期执行（单条 SQL，原子语义）。
+    /// scheduler_enabled 为 true 表示恢复调度，false 表示暂停调度；scheduler_config 保持不变。
+    pub async fn batch_update_todos_scheduler(
+        &self,
+        ids: &[i64],
+        scheduler_enabled: bool,
+    ) -> Result<u64, sea_orm::DbErr> {
+        if ids.is_empty() {
+            return Ok(0);
+        }
+        let now = crate::models::utc_timestamp();
+        let placeholders: Vec<String> = (1..=ids.len()).map(|i| format!("?{}", i)).collect();
+        let in_clause = placeholders.join(",");
+        let enabled_idx = ids.len() + 1;
+        let now_idx = ids.len() + 2;
+        let sql = format!(
+            "UPDATE todos SET scheduler_enabled = ?{enabled_idx}, updated_at = ?{now_idx} WHERE id IN ({in_clause})"
+        );
+        let mut vals: Vec<sea_orm::Value> = ids.iter().map(|id| (*id).into()).collect();
+        vals.push((scheduler_enabled as i32).into()); // SQLite 用整数存储布尔值
+        vals.push(now.into());
+        let stmt = sea_orm::Statement::from_sql_and_values(sea_orm::DbBackend::Sqlite, sql, vals);
+        let rows_affected = self.conn.execute(stmt).await?.rows_affected();
+        Ok(rows_affected)
+    }
+
     /// todo hook 已整块移除（见 plan `purring-forging-petal`），`update_todo_hooks` 不再存在：
     /// todo 的 `hooks` 字段与 `todos.hooks` 列随 V23 迁移一起删掉。
 

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -541,6 +541,7 @@ fn todo_routes() -> Router<AppState> {
         .route("/api/todos/batch-executor", put(todo::batch_update_todos_executor))
         .route("/api/todos/batch-workspace", put(todo::batch_move_todos_workspace))
         .route("/api/todos/batch-copy-workspace", post(todo::batch_copy_todos_workspace))
+        .route("/api/todos/batch-scheduler", put(todo::batch_update_todos_scheduler))
         .route("/api/todos/{id}", get(todo::get_todo).put(todo::update_todo).delete(todo::delete_todo))
         .route("/api/tags", get(tag::get_tags).post(tag::create_tag))
         .route("/api/tags/{id}", delete(tag::delete_tag))

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -9,7 +9,7 @@ use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::{
     utc_timestamp, ApiResponse, BatchCopyTodoWorkspaceRequest,
     BatchUpdateTodoExecutorRequest, BatchUpdateTodoResult,
-    BatchUpdateTodoWorkspaceRequest, BatchWorkspaceResult,
+    BatchUpdateTodoSchedulerRequest, BatchUpdateTodoWorkspaceRequest, BatchWorkspaceResult,
     CreateTodoRequest, RecentCompletedTodo, Todo, UpdateTagsRequest, UpdateTodoRequest,
 };
 
@@ -451,6 +451,24 @@ pub async fn batch_copy_todos_workspace(
         .await?;
     Ok(ApiResponse::ok(BatchWorkspaceResult {
         updated_count: created_ids.len() as i64,
+        total: req.ids.len() as i64,
+    }))
+}
+
+/// PUT /api/todos/batch-scheduler — 批量暂停/恢复事项的周期执行
+pub async fn batch_update_todos_scheduler(
+    State(state): State<AppState>,
+    ApiJson(req): ApiJson<BatchUpdateTodoSchedulerRequest>,
+) -> Result<ApiResponse<BatchWorkspaceResult>, AppError> {
+    if req.ids.is_empty() {
+        return Err(AppError::BadRequest("ids 不能为空".to_string()));
+    }
+    let rows_affected = state
+        .db
+        .batch_update_todos_scheduler(&req.ids, req.scheduler_enabled)
+        .await?;
+    Ok(ApiResponse::ok(BatchWorkspaceResult {
+        updated_count: rows_affected as i64,
         total: req.ids.len() as i64,
     }))
 }

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -489,6 +489,13 @@ pub struct BatchCopyTodoWorkspaceRequest {
     pub workspace_id: i64,
 }
 
+/// 批量暂停/恢复周期执行请求体。scheduler_enabled 为 true 表示恢复，false 表示暂停。
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchUpdateTodoSchedulerRequest {
+    pub ids: Vec<i64>,
+    pub scheduler_enabled: bool,
+}
+
 /// 批量更新环路工作空间请求体（移动到其他工作空间）。
 #[derive(Debug, Clone, Deserialize)]
 pub struct BatchUpdateLoopWorkspaceRequest {

--- a/backend/tests/db_feature_supplement_tests.rs
+++ b/backend/tests/db_feature_supplement_tests.rs
@@ -723,3 +723,140 @@ async fn test_template_does_not_cascade_to_todo() {
     let todo = db.get_todo(todo_id).await.unwrap();
     assert!(todo.is_some(), "模板删除后 todo 必须仍然存在");
 }
+
+// =====================================================================
+// 批量周期调度相关测试
+// =====================================================================
+
+#[tokio::test]
+async fn test_batch_update_todos_scheduler_pause() {
+    // 批量暂停：scheduler_enabled 设为 false，scheduler_config 保持不变
+    let db = setup_db().await;
+
+    // 创建工作空间（todo 的 workspace_id 依赖）
+    let dir = db
+        .get_or_create_project_directory("/tmp/scheduler-test", Some("测试空间"))
+        .await
+        .unwrap();
+
+    // 创建带调度配置的 todo
+    let todo_id = db
+        .create_todo_with_extras(
+            "待暂停",
+            "Do it",
+            None,
+            None,
+            false,
+            dir.id,
+            &dir.path,
+        )
+        .await
+        .unwrap();
+
+    // 先开启调度（使用 SchedulerUpdate 结构）
+    db.update_todo_scheduler(ntd::db::SchedulerUpdate {
+        id: todo_id,
+        enabled: true,
+        config: Some("*/5 * * * * *"),
+        timezone: None,
+    })
+    .await
+    .unwrap();
+
+    // 批量暂停
+    let rows = db
+        .batch_update_todos_scheduler(&[todo_id], false)
+        .await
+        .unwrap();
+    assert_eq!(rows, 1);
+
+    // 验证 scheduler_enabled 已关闭，但 scheduler_config 仍保留
+    let todo = db.get_todo(todo_id).await.unwrap().unwrap();
+    assert_eq!(todo.scheduler_enabled, false, "scheduler_enabled should be false");
+    assert_eq!(todo.scheduler_config.as_deref(), Some("*/5 * * * * *"));
+}
+
+#[tokio::test]
+async fn test_batch_update_todos_scheduler_resume() {
+    // 批量恢复：scheduler_enabled 设为 true，scheduler_config 保持不变
+    let db = setup_db().await;
+
+    let dir = db
+        .get_or_create_project_directory("/tmp/scheduler-resume", Some("恢复空间"))
+        .await
+        .unwrap();
+
+    let todo_id = db
+        .create_todo_with_extras("待恢复", "Do it", None, None, false, dir.id, &dir.path)
+        .await
+        .unwrap();
+
+    // 开启调度后再暂停
+    db.update_todo_scheduler(ntd::db::SchedulerUpdate {
+        id: todo_id,
+        enabled: true,
+        config: Some("0 */10 * * * *"),
+        timezone: None,
+    })
+    .await
+    .unwrap();
+    db.batch_update_todos_scheduler(&[todo_id], false)
+        .await
+        .unwrap();
+
+    // 批量恢复
+    let rows = db
+        .batch_update_todos_scheduler(&[todo_id], true)
+        .await
+        .unwrap();
+    assert_eq!(rows, 1);
+
+    // 验证 scheduler_enabled 已开启，scheduler_config 保持
+    let todo = db.get_todo(todo_id).await.unwrap().unwrap();
+    assert_eq!(todo.scheduler_enabled, true);
+    assert_eq!(todo.scheduler_config.as_deref(), Some("0 */10 * * * *"));
+}
+
+#[tokio::test]
+async fn test_batch_update_todos_scheduler_empty_ids() {
+    // 空 ids 列表应直接返回 0，不报错
+    let db = setup_db().await;
+    let rows = db.batch_update_todos_scheduler(&[], true).await.unwrap();
+    assert_eq!(rows, 0);
+}
+
+#[tokio::test]
+async fn test_batch_update_todos_scheduler_multiple() {
+    // 批量操作多个 todos，应全部更新
+    let db = setup_db().await;
+
+    let dir = db
+        .get_or_create_project_directory("/tmp/batch-multi", Some("批量测试"))
+        .await
+        .unwrap();
+
+    let id1 = db
+        .create_todo_with_extras("A", "Do A", None, None, false, dir.id, &dir.path)
+        .await
+        .unwrap();
+    let id2 = db
+        .create_todo_with_extras("B", "Do B", None, None, false, dir.id, &dir.path)
+        .await
+        .unwrap();
+    let id3 = db
+        .create_todo_with_extras("C", "Do C", None, None, false, dir.id, &dir.path)
+        .await
+        .unwrap();
+
+    let rows = db
+        .batch_update_todos_scheduler(&[id1, id2, id3], false)
+        .await
+        .unwrap();
+    assert_eq!(rows, 3);
+
+    // 验证全部已暂停
+    for id in &[id1, id2, id3] {
+        let todo = db.get_todo(*id).await.unwrap().unwrap();
+        assert_eq!(todo.scheduler_enabled, false, "todo {} should be paused", id);
+    }
+}

--- a/frontend/src/components/todo-list/index.tsx
+++ b/frontend/src/components/todo-list/index.tsx
@@ -7,7 +7,7 @@ export { TodoItemRow } from './TodoItemRow';
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useApp } from '@/hooks/useApp';
 import { Empty, Input, Skeleton, Modal, App as AntApp } from 'antd';
-import { InboxOutlined, SearchOutlined, SwapOutlined, StopOutlined, CopyOutlined, DragOutlined } from '@ant-design/icons';
+import { InboxOutlined, SearchOutlined, SwapOutlined, StopOutlined, CopyOutlined, DragOutlined, PauseCircleOutlined, PlayCircleOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import type { ProjectDirectory } from '@/types';
 import { LoopListPanel } from '@/components/LoopStudioListPanel';
@@ -71,6 +71,11 @@ export function TodoList(props: TodoListProps) {
   const [pendingWorkspaceBatchIds, setPendingWorkspaceBatchIds] = useState<number[]>([]);
   const [workspaceBatchProcessing, setWorkspaceBatchProcessing] = useState(false);
   const [workspaceBatchContext, setWorkspaceBatchContext] = useState<'item' | 'loop'>('item');
+  // 批量暂停/恢复周期执行 Modal
+  const [schedulerBatchModalOpen, setSchedulerBatchModalOpen] = useState(false);
+  const [schedulerBatchMode, setSchedulerBatchMode] = useState<'pause' | 'resume'>('pause');
+  const [pendingSchedulerBatchIds, setPendingSchedulerBatchIds] = useState<number[]>([]);
+  const [schedulerBatchProcessing, setSchedulerBatchProcessing] = useState(false);
 
   useEffect(() => {
     setIsLoading(false);
@@ -330,6 +335,51 @@ export function TodoList(props: TodoListProps) {
     }
   }, [pendingForceStopIds, message]);
 
+  // 打开暂停周期执行确认 Modal
+  const openItemPauseScheduler = useCallback((ids: number[]) => {
+    setSchedulerBatchMode('pause');
+    setPendingSchedulerBatchIds(ids);
+    setSchedulerBatchModalOpen(true);
+  }, []);
+
+  // 打开恢复周期执行确认 Modal
+  const openItemResumeScheduler = useCallback((ids: number[]) => {
+    setSchedulerBatchMode('resume');
+    setPendingSchedulerBatchIds(ids);
+    setSchedulerBatchModalOpen(true);
+  }, []);
+
+  // 确认暂停/恢复周期执行
+  const handleConfirmSchedulerBatch = useCallback(async () => {
+    const ids = pendingSchedulerBatchIds;
+    if (ids.length === 0) return;
+    setSchedulerBatchProcessing(true);
+    try {
+      const isPause = schedulerBatchMode === 'pause';
+      const result = isPause
+        ? await db.batchPauseScheduler(ids)
+        : await db.batchResumeScheduler(ids);
+      const actionLabel = isPause ? '暂停' : '恢复';
+      if (result.updated_count === result.total) {
+        message.success(`已${actionLabel} ${result.updated_count} 项的周期执行`);
+      } else {
+        message.warning(`${actionLabel}成功 ${result.updated_count} 条，失败 ${result.total - result.updated_count} 条`);
+      }
+      // 刷新列表
+      const wid = selectedWorkspace;
+      if (wid != null) {
+        const allItems = await db.getAllTodos(wid);
+        dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: allItems });
+      }
+      setSchedulerBatchModalOpen(false);
+      setSelectedIds([]);
+    } catch (err) {
+      message.error(`操作失败: ${err instanceof Error ? err.message : '未知错误'}`);
+    } finally {
+      setSchedulerBatchProcessing(false);
+    }
+  }, [pendingSchedulerBatchIds, schedulerBatchMode, message, selectedWorkspace, dispatch]);
+
   const toolbarConfig = useMemo<{
     createLabel: string;
     batchActions: BatchActionItem<number>[];
@@ -352,6 +402,16 @@ export function TodoList(props: TodoListProps) {
           label: '移动到',
           icon: <DragOutlined />,
           onClick: openItemMoveWorkspace,
+        }, {
+          key: 'pause-scheduler',
+          label: '暂停周期执行',
+          icon: <PauseCircleOutlined />,
+          onClick: openItemPauseScheduler,
+        }, {
+          key: 'resume-scheduler',
+          label: '恢复周期执行',
+          icon: <PlayCircleOutlined />,
+          onClick: openItemResumeScheduler,
         }],
       };
     }
@@ -375,7 +435,7 @@ export function TodoList(props: TodoListProps) {
         onClick: openLoopForceStop,
       }],
     };
-  }, [listMode, openItemChangeExecutor, openItemCopyWorkspace, openItemMoveWorkspace, openLoopCopyWorkspace, openLoopMoveWorkspace, openLoopForceStop]);
+  }, [listMode, openItemChangeExecutor, openItemCopyWorkspace, openItemMoveWorkspace, openLoopCopyWorkspace, openLoopMoveWorkspace, openLoopForceStop, openItemPauseScheduler, openItemResumeScheduler]);
 
   if (isLoading) {
     return (
@@ -538,6 +598,25 @@ export function TodoList(props: TodoListProps) {
             复制后，原工作空间和目标工作空间中各有一份相同的条目。
           </p>
         )}
+      </Modal>
+
+      {/* 批量暂停/恢复周期执行确认 Modal */}
+      <Modal
+        title={schedulerBatchMode === 'pause' ? '暂停周期执行' : '恢复周期执行'}
+        open={schedulerBatchModalOpen}
+        onOk={handleConfirmSchedulerBatch}
+        onCancel={() => { setSchedulerBatchModalOpen(false); setPendingSchedulerBatchIds([]); }}
+        okText="确认"
+        cancelText="取消"
+        confirmLoading={schedulerBatchProcessing}
+        destroyOnClose
+      >
+        <p>
+          {schedulerBatchMode === 'pause'
+            ? <>确定暂停 <strong>{pendingSchedulerBatchIds.length}</strong> 项的周期执行吗？暂停后定时调度将不再触发。</>
+            : <>确定恢复 <strong>{pendingSchedulerBatchIds.length}</strong> 项的周期执行吗？将使用原有的调度配置继续运行。</>
+          }
+        </p>
       </Modal>
     </div>
   );

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -84,6 +84,20 @@ export async function batchUpdateTodosExecutor(
   }
 }
 
+/** 批量暂停周期执行。将所选事项的 scheduler_enabled 设为 false，但不改变 scheduler_config。 */
+export async function batchPauseScheduler(
+  ids: number[],
+): Promise<{ updated_count: number; total: number }> {
+  return unwrap(await api.put('/api/todos/batch-scheduler', { ids, scheduler_enabled: false }));
+}
+
+/** 批量恢复周期执行。将所选事项的 scheduler_enabled 设为 true，使用原有的 scheduler_config。 */
+export async function batchResumeScheduler(
+  ids: number[],
+): Promise<{ updated_count: number; total: number }> {
+  return unwrap(await api.put('/api/todos/batch-scheduler', { ids, scheduler_enabled: true }));
+}
+
 /** 批量移动事项到其他工作空间。 */
 export async function batchMoveTodosWorkspace(
   ids: number[],


### PR DESCRIPTION
## 功能说明

事项 Todo 列表批量按钮下新增两个功能：

- **暂停周期执行**：批量关闭所选 Todo 的 ，定时调度不再触发
- **恢复周期执行**：批量开启所选 Todo 的 ，使用原有  继续运行

## 改动范围

| 层级 | 文件 | 说明 |
|------|------|------|
| 前端 API |  | 新增  /  |
| 前端 UI |  | 工具栏新增按钮 + 确认 Modal |
| 后端模型 |  | 新增  |
| 后端 Handler |  | 新增  |
| 后端 DAO |  | 单条 SQL 原子更新 |
| 后端路由 |  | 注册  |

## 交互

1. 选中若干 Todo → 点击「暂停/恢复周期执行」→ 确认 Modal 提示影响范围 → 确认后刷新列表
2.  全程保持不变，只切换  开关状态
3. 前后端均为批量接口，无循环调用