### PR TITLE
feat(blackboard): 黑板更新防抖debounce，周期汇总触发

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -68,6 +68,8 @@ const DEFAULT_AUTO_USAGE_STATS_CRON: &str = "0 0 1 * * *";
 const DEFAULT_AUTO_UPDATE_HOUR: u32 = 3;
 /// 自动更新默认间隔类型:"day" / "week" / "month"。
 const DEFAULT_AUTO_UPDATE_INTERVAL: &str = "day";
+/// 黑板更新防抖周期（秒），默认 10 分钟。
+const DEFAULT_BLACKBOARD_DEBOUNCE_SECS: u64 = 600;
 
 /// 私有 helper:`auto_backup_*` / `auto_todo_backup_*` / `auto_skill_backup_*`
 /// 三组字段共享同一形状 (enabled: bool, cron: String, max_files: usize)。
@@ -176,6 +178,10 @@ pub struct Config {
     pub auto_update_hour: u32,
     /// 自动更新上次检查时间（ISO 8601），None 表示从未检查过
     pub auto_update_last_check_at: Option<String>,
+    /// 黑板更新防抖周期（秒），默认 600 秒（10 分钟）。
+    /// todo 执行完成后不会立即触发黑板更新，而是暂存到 pending 队列，
+    /// 等到此周期到期后统一处理一次 LLM 调用。
+    pub blackboard_debounce_secs: u64,
 }
 
 /// Paths for each supported executor binary.
@@ -284,6 +290,7 @@ impl Default for Config {
             cloud_sync: CloudSyncConfig::default(), cors_allowed_origins: Vec::new(),
             auto_update_enabled: false, auto_update_interval: DEFAULT_AUTO_UPDATE_INTERVAL.to_string(),
             auto_update_hour: DEFAULT_AUTO_UPDATE_HOUR, auto_update_last_check_at: None,
+            blackboard_debounce_secs: DEFAULT_BLACKBOARD_DEBOUNCE_SECS,
         }
     }
 }

--- a/backend/src/db/blackboard.rs
+++ b/backend/src/db/blackboard.rs
@@ -41,6 +41,8 @@ impl Database {
             workspace_id: ActiveValue::Set(workspace_id),
             // 初始内容为空：创建时的黑板无内容，由后续 LLM 更新填充
             content: ActiveValue::Set(String::new()),
+            // 初始 pending 队列为空
+            pending_todo_ids: ActiveValue::Set("[]".to_string()),
             updated_at: ActiveValue::Set(Some(now)),
             created_at: ActiveValue::Set(Some(crate::models::utc_timestamp())),
             ..Default::default()
@@ -117,6 +119,7 @@ impl Database {
             content: ActiveValue::Set(content.to_string()),
             updated_at: ActiveValue::Set(Some(now.clone())),
             created_at: ActiveValue::Set(Some(now)),
+            pending_todo_ids: ActiveValue::Set("[]".to_string()),
             ..Default::default()
         };
         // ON CONFLICT(workspace_id)：命中后只覆盖 content/updated_at，保留 created_at
@@ -129,6 +132,77 @@ impl Database {
             .exec(&self.conn)
             .await?;
         Ok(())
+    }
+
+    /// 追加一个 todo_id 到黑板的 pending 队列。
+    ///
+    /// ORM 方式：读 → JSON parse → push → 序列化 → 写回。
+    /// 并发安全由 workspace_id 唯一约束保证串行写入。
+    pub async fn append_pending_todo_id(
+        &self,
+        workspace_id: i64,
+        todo_id: i64,
+    ) -> Result<(), sea_orm::DbErr> {
+        // 读取当前队列
+        let board = blackboards::Entity::find()
+            .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
+            .one(&self.conn)
+            .await?
+            .ok_or_else(|| sea_orm::DbErr::RecordNotFound(format!(
+                "blackboard for workspace {} not found",
+                workspace_id
+            )))?;
+
+        // 解析 + 追加
+        let mut ids: Vec<i64> = serde_json::from_str(&board.pending_todo_ids)
+            .unwrap_or_default();
+        ids.push(todo_id);
+        let ids_json = serde_json::to_string(&ids).unwrap_or_default();
+
+        // 写回
+        let now = crate::models::utc_timestamp();
+        let res = blackboards::ActiveModel {
+            workspace_id: ActiveValue::Unchanged(workspace_id),
+            pending_todo_ids: ActiveValue::Set(ids_json),
+            updated_at: ActiveValue::Set(Some(now)),
+            ..Default::default()
+        }.update(&self.conn).await?;
+
+        Ok(())
+    }
+
+    /// 取出并清空 pending 队列，返回待处理的 todo_id 列表。
+    ///
+    /// 两步非原子，竞态时可能丢失或重复，但 debounce 场景下可接受。
+    pub async fn take_pending_todo_ids(
+        &self,
+        workspace_id: i64,
+    ) -> Result<Vec<i64>, sea_orm::DbErr> {
+        // 读取当前队列
+        let board = blackboards::Entity::find()
+            .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
+            .one(&self.conn)
+            .await?
+            .ok_or_else(|| sea_orm::DbErr::RecordNotFound(format!(
+                "blackboard for workspace {} not found",
+                workspace_id
+            )))?;
+
+        let ids: Vec<i64> = serde_json::from_str(&board.pending_todo_ids)
+            .unwrap_or_default();
+
+        // 清空队列（非空才写，减少 DB 写入）
+        if !ids.is_empty() {
+            let now = crate::models::utc_timestamp();
+            let res = blackboards::ActiveModel {
+                workspace_id: ActiveValue::Unchanged(workspace_id),
+                pending_todo_ids: ActiveValue::Set("[]".to_string()),
+                updated_at: ActiveValue::Set(Some(now)),
+                ..Default::default()
+            }.update(&self.conn).await?;
+        }
+
+        Ok(ids)
     }
 }
 

--- a/backend/src/db/entity/blackboards.rs
+++ b/backend/src/db/entity/blackboards.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// 每个 workspace 最多一条记录（workspace_id 为 UNIQUE），
 /// content 字段存储 Markdown 格式的黑板内容。
+/// pending_todo_ids 暂存待处理的 todo_id，防抖批次处理时使用。
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "blackboards")]
 pub struct Model {
@@ -15,6 +16,9 @@ pub struct Model {
     /// 黑板 Markdown 内容
     #[sea_orm(column_type = "Text")]
     pub content: String,
+    /// 待处理的 todo_id 队列（JSON 数组），防抖周期到点后统一处理
+    #[sea_orm(column_type = "Text")]
+    pub pending_todo_ids: String,
     pub updated_at: Option<String>,
     pub created_at: Option<String>,
 }

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -201,6 +201,22 @@ impl Database {
         Ok(m.map(Into::into))
     }
 
+    /// 获取指定 todo 的最新一条执行记录（按 id 降序）。
+    ///
+    /// 用于黑板 debouncer：从 pending 队列取出 todo_id 后查其最新执行结论。
+    pub async fn get_latest_execution_record_for_todo(
+        &self,
+        todo_id: i64,
+    ) -> Result<Option<ExecutionRecord>, sea_orm::DbErr> {
+        let m = execution_records::Entity::find()
+            .filter(execution_records::Column::TodoId.eq(todo_id))
+            .order_by_desc(execution_records::Column::Id)
+            .limit(1)
+            .one(&self.conn)
+            .await?;
+        Ok(m.map(Into::into))
+    }
+
     /// 批量根据 task_id 列表获取执行记录（用于 WebSocket 同步等场景）
     pub async fn get_execution_records_by_task_ids(
         &self,

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -13,6 +13,7 @@ mod v2_v5;
 mod v41_v46;
 mod v47;
 mod v48;
+mod v49;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -48,6 +49,7 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v41_v46::V46AddTodosActionKey),
         Box::new(v47::V47CreateBlackboardsTable),
         Box::new(v48::V48ScopeTodosActionKeyByWorkspace),
+        Box::new(v49::V49AddBlackboardPendingTodoIds),
     ]
 }
 

--- a/backend/src/db/migration/v49.rs
+++ b/backend/src/db/migration/v49.rs
@@ -1,0 +1,59 @@
+//! 数据库迁移 V49：为 blackboards 表添加 pending_todo_ids 字段。
+//!
+//! 背景：黑板更新从"每次 todo 执行完毕立即触发"改为"debounce 周期汇总触发"。
+//! pending_todo_ids 存储待处理的 todo_id 队列（JSON 数组），周期到点后统一处理。
+//!
+//! 数据兼容性：已有 blackboards 记录的 pending_todo_ids 初始化为空数组 "[]"。
+
+use async_trait::async_trait;
+
+use super::super::Database;
+use super::Migration;
+
+pub(super) struct V49AddBlackboardPendingTodoIds;
+
+#[async_trait]
+impl Migration for V49AddBlackboardPendingTodoIds {
+    fn version(&self) -> i64 {
+        49
+    }
+
+    fn name(&self) -> &'static str {
+        "add_blackboard_pending_todo_ids"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 1. 检查列是否已存在（幂等：重复执行不报错）
+        if super::table_has_column(db, "blackboards", "pending_todo_ids").await? {
+            return Ok(());
+        }
+
+        // 2. 加列
+        db.exec("ALTER TABLE blackboards ADD COLUMN pending_todo_ids TEXT NOT NULL DEFAULT '[]'")
+            .await?;
+
+        tracing::info!("V49: blackboards.pending_todo_ids 字段已添加");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    #[tokio::test]
+    async fn test_v49_migration_succeeds() {
+        let db = Database::new(":memory:").await.unwrap();
+        // V47 创建了 blackboards 表
+        crate::db::migration::v47::V47CreateBlackboardsTable
+            .up(&db)
+            .await
+            .unwrap();
+        // V49 应当成功执行
+        V49AddBlackboardPendingTodoIds
+            .up(&db)
+            .await
+            .expect("V49 must succeed");
+    }
+}

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -436,8 +436,6 @@ pub async fn blackboard_flush_listener(
     task_manager: Arc<TaskManager>,
     config: Arc<std::sync::RwLock<crate::config::Config>>,
 ) {
-    use crate::services::blackboard_debouncer::BlackboardFlushMsg;
-
     while let Some(msg) = rx.recv().await {
         tracing::debug!("黑板 flush listener 收到消息: workspace_id={}", msg.workspace_id);
 

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -417,61 +417,85 @@ pub(crate) async fn finalize_normal_completion(
     task_manager.remove(&task_id).await;
 
     // ===== 黑板更新 (blackboard) =====
-    // 任务执行成功后，异步更新黑板内容。
-    // 用本作用域的 trigger_type 判定"自身"——黑板更新任务的 trigger_type == "blackboard"，
-    // 避免无限循环；与 todo.action_type 不同的是 trigger_type 跟随执行而非 todo，
-    // 即便以后新增相同 action_type 的非黑板 todo，也不会被错误地跳过。
+    // 任务执行成功后，将 todo_id 追加到 pending 队列，由 debouncer 周期汇总触发。
+    // 用 trigger_type 判定"自身"——黑板更新任务的 trigger_type == "blackboard"，
+    // 避免无限循环；即使以后新增相同 action_type 的非黑板 todo，也不会被错误地跳过。
     if success && trigger_type != "blackboard" {
         if let Some(ws_id) = workspace_id {
-            spawn_blackboard_update(
-                db.clone(),
-                executor_registry.clone(),
-                tx.clone(),
-                task_manager.clone(),
-                config.clone(),
-                ws_id,
-                &result_str,
-                todo_id,
-                &todo_title,
-            );
+            crate::services::blackboard_debouncer::push_pending_todo(ws_id, todo_id, &db).await;
         }
     }
 }
 
-/// 在后台异步触发黑板更新。
-///
-/// 将 async 调用包裹在独立的非 async 函数中，避免 Rust 编译器的 async 递归类型循环
-/// （`finalize_normal_completion` → `update_blackboard` → `run_todo_execution` → `dispatch_spawned_executor_task` → `finalize_normal_completion`）。
-fn spawn_blackboard_update(
+/// 启动黑板 flush 监听器：监听 debouncer channel，收到消息后执行 update_blackboard
+pub async fn blackboard_flush_listener(
+    mut rx: tokio::sync::mpsc::Receiver<crate::services::blackboard_debouncer::BlackboardFlushMsg>,
     db: Arc<Database>,
     executor_registry: Arc<ExecutorRegistry>,
     tx: broadcast::Sender<ExecEvent>,
     task_manager: Arc<TaskManager>,
     config: Arc<std::sync::RwLock<crate::config::Config>>,
-    workspace_id: i64,
-    result_str: &str,
-    todo_id: i64,
-    todo_title: &str,
 ) {
-    let result_str = result_str.to_string();
-    let todo_title = todo_title.to_string();
-    tokio::spawn(async move {
+    use crate::services::blackboard_debouncer::BlackboardFlushMsg;
+
+    while let Some(msg) = rx.recv().await {
+        tracing::debug!("黑板 flush listener 收到消息: workspace_id={}", msg.workspace_id);
+
+        // 从 DB 取出 pending 队列（take_pending_todo_ids 已清空队列）
+        let todo_ids = match db.take_pending_todo_ids(msg.workspace_id).await {
+            Ok(ids) => ids,
+            Err(e) => {
+                tracing::warn!("取 pending 队列失败: workspace_id={}, error={}", msg.workspace_id, e);
+                continue;
+            }
+        };
+
+        if todo_ids.is_empty() {
+            tracing::debug!("黑板 pending 队列为空: workspace_id={}", msg.workspace_id);
+            continue;
+        }
+
+        tracing::info!(
+            "黑板 flush listener 处理: workspace_id={}, todo_ids={:?}",
+            msg.workspace_id, todo_ids
+        );
+
+        // 按顺序查询每条 todo 的最新执行结论
+        let mut conclusions = Vec::with_capacity(todo_ids.len());
+        for todo_id in &todo_ids {
+            if let Ok(Some(record)) = db.get_latest_execution_record_for_todo(*todo_id).await {
+                conclusions.push(format!(
+                    "- 任务 ID: {}\n  结论: {}",
+                    todo_id,
+                    record.result.as_deref().unwrap_or("(无结论)")
+                ));
+            }
+        }
+
+        if conclusions.is_empty() {
+            tracing::debug!("所有 todo 均无执行记录: workspace_id={}", msg.workspace_id);
+            continue;
+        }
+
+        let conclusion_text = conclusions.join("\n\n");
+
+        // 调用 update_blackboard
         if let Err(e) = crate::services::blackboard::update_blackboard(
-            db,
-            executor_registry,
-            tx,
-            task_manager,
-            config,
-            workspace_id,
-            &result_str,
-            todo_id,
-            &todo_title,
+            db.clone(),
+            executor_registry.clone(),
+            tx.clone(),
+            task_manager.clone(),
+            config.clone(),
+            msg.workspace_id,
+            &conclusion_text,
+            todo_ids[0],
+            &format!("批量更新 ({}条)", todo_ids.len()),
         )
         .await
         {
-            tracing::warn!("黑板更新失败: todo_id={}, error={:?}", todo_id, e);
+            tracing::warn!("黑板 update_blackboard 失败: workspace_id={}, error={:?}", msg.workspace_id, e);
         }
-    });
+    }
 }
 
 /// 仅在 trigger_type != "auto_review" 时启动自动评审，避免评审实例反向触发评审。

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -239,12 +239,12 @@ pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade)
 /// todo hook 已整块移除（见 plan `purring-forging-petal`）：函数不再接收
 /// `hook_service`，避免出现「hook 体系已经从编排链摘除，但 AppState 还挂着
 /// Arc<HookService>」的接口残留。
-pub fn create_app(
+pub async fn create_app(
     ctx: ServiceContext,
     scheduler: Arc<TodoScheduler>,
 ) -> Router {
     // 把状态构造与中间件叠加分两步：先 build 再 merge，便于读者按"装配顺序"线性阅读
-    let state = build_app_state(ctx, scheduler);
+    let state = build_app_state(ctx, scheduler).await;
 
     Router::new()
         .merge(mount_domain_routes())
@@ -314,7 +314,7 @@ fn make_request_span(req: &Request) -> tracing::Span {
 ///
 /// todo hook 已整块移除，`build_app_state` 不再接收 hook_service 参数；下游的
 /// MessageDebounce / LoopRunner 同步取消该字段。
-fn build_app_state(
+async fn build_app_state(
     ctx: ServiceContext,
     scheduler: Arc<TodoScheduler>,
 ) -> AppState {
@@ -349,6 +349,18 @@ fn build_app_state(
 
     spawn_feishu_history_fetcher(ctx.clone(), db.clone(), feishu_listener.clone(), debounce.clone());
     ensure_default_review_template_blocking(&db);
+
+    // 黑板防抖器初始化，启动 flush 监听器（监听 channel，收到消息后执行 LLM 更新黑板）
+    let debounce_secs = config.read().unwrap().blackboard_debounce_secs.max(10);
+    let mut flush_rx = crate::services::blackboard_debouncer::init(debounce_secs).await;
+    tokio::spawn(crate::executor_service::completion::blackboard_flush_listener(
+        flush_rx,
+        db.clone(),
+        executor_registry.clone(),
+        tx.clone(),
+        task_manager.clone(),
+        config.clone(),
+    ));
 
     // 后台监听 todo 执行完成事件，派发给 loop_trigger_dispatcher
     spawn_todo_completed_listener(tx.clone(), loop_trigger_dispatcher.clone());
@@ -1256,8 +1268,8 @@ mod create_app_refactor_tests {
         const BODY_LINES_BUDGET: usize = 30;
         let src = include_str!("mod.rs");
 
-        // 1) regex 锚定 `pub fn create_app\s*(` 签名起点
-        let sig_re = regex::Regex::new(r"pub fn create_app\s*\(")
+        // 1) regex 锚定 `pub async fn create_app\s*(` 签名起点
+        let sig_re = regex::Regex::new(r"pub async fn create_app\s*\(")
             .expect("compile create_app signature regex");
         let sig_match = sig_re
             .find(src)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -586,7 +586,8 @@ async fn run_server(cli_port: Option<u16>) {
             config: config.clone(),
         },
         scheduler,
-    );
+    )
+    .await;
 
     let port = cli_port.unwrap_or(cfg.port);
 

--- a/backend/src/services/blackboard_debouncer.rs
+++ b/backend/src/services/blackboard_debouncer.rs
@@ -1,0 +1,118 @@
+//! 黑板（Blackboard）防抖服务。
+//!
+//! 核心思路：不再每次 todo 执行完毕立即触发黑板更新，而是将 todo_id 追加到
+//! 黑板的 pending 队列，周期到点后通过 channel 通知监听方执行实际 LLM 调用。
+//!
+//! 职责边界（避免 cycle）：
+//!   - 本模块只管 pending 队列 + timer，不调用 blackboard service 或 executor_service
+//!   - 调用方（本模块外部）负责启动监听 channel 的后台任务，由其调用 update_blackboard
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::{broadcast, mpsc, RwLock};
+use tokio::time::{interval, Duration};
+
+use crate::db::Database;
+
+/// 防抖消息：周期到点时通知监听方处理
+#[derive(Clone)]
+pub struct BlackboardFlushMsg {
+    pub workspace_id: i64,
+}
+
+/// 防抖器全局状态
+static DEBOUNCER: RwLock<Option<Debouncer>> = RwLock::const_new(None);
+
+/// 全局 channel 发送端（监听方持有接收端）
+static FLUSH_TX: RwLock<Option<mpsc::Sender<BlackboardFlushMsg>>> = RwLock::const_new(None);
+
+#[derive(Clone)]
+struct Debouncer {
+    timers: Arc<RwLock<HashMap<i64, bool>>>,
+    debounce_secs: u64,
+}
+
+impl Debouncer {
+    fn new(debounce_secs: u64) -> Self {
+        Self {
+            timers: Arc::new(RwLock::new(HashMap::new())),
+            debounce_secs,
+        }
+    }
+}
+
+/// 全局初始化：启动 channel，注册到全局，在 `build_app_state` 中调用
+pub async fn init(debounce_secs: u64) -> mpsc::Receiver<BlackboardFlushMsg> {
+    let (tx, rx) = mpsc::channel::<BlackboardFlushMsg>(100);
+
+    let debouncer = Debouncer::new(debounce_secs);
+
+    {
+        let mut w = DEBOUNCER.write().await;
+        *w = Some(debouncer);
+    }
+    {
+        let mut w = FLUSH_TX.write().await;
+        *w = Some(tx);
+    }
+
+    rx
+}
+
+/// 追加一个 todo_id 到 pending 队列；若 timer 未运行则启动。
+///
+/// 不调用任何 blackboard/executor_service 函数，职责纯粹为"入队 + 启动 timer"。
+pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Database>) {
+    // 追加到 DB
+    if let Err(e) = db.append_pending_todo_id(workspace_id, todo_id).await {
+        tracing::warn!(
+            "追加 pending_todo_id 失败: workspace_id={}, todo_id={}, error={}",
+            workspace_id, todo_id, e
+        );
+        return;
+    }
+
+    // 检查并启动 timer
+    let debouncer = {
+        let guard = DEBOUNCER.read().await;
+        guard.as_ref().cloned()
+    };
+    let Some(debouncer) = debouncer else {
+        tracing::warn!("BlackboardDebouncer 未初始化");
+        return;
+    };
+
+    let mut timers = debouncer.timers.write().await;
+    if timers.get(&workspace_id).copied().unwrap_or(false) {
+        return; // timer 已在运行
+    }
+    timers.insert(workspace_id, true);
+    drop(timers);
+
+    // 克隆所需数据
+    let timers = debouncer.timers.clone();
+    let debounce_secs = debouncer.debounce_secs;
+    let tx = {
+        let guard = FLUSH_TX.read().await;
+        guard.as_ref().cloned()
+    };
+    let db = db.clone();
+
+    // 启动 timer
+    tokio::spawn(async move {
+        let mut ticker = interval(Duration::from_secs(debounce_secs));
+        ticker.tick().await; // 等待 debounce 周期
+        tracing::debug!("黑板 debounce timer 触发: workspace_id={}", workspace_id);
+
+        if let Some(tx) = tx {
+            let msg = BlackboardFlushMsg { workspace_id };
+            if let Err(e) = tx.send(msg).await {
+                tracing::warn!("发送 flush 消息失败: workspace_id={}, error={}", workspace_id, e);
+            }
+        }
+
+        let mut timers = timers.write().await;
+        timers.insert(workspace_id, false);
+    });
+}

--- a/backend/src/services/blackboard_debouncer.rs
+++ b/backend/src/services/blackboard_debouncer.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use tokio::sync::{broadcast, mpsc, RwLock};
-use tokio::time::{interval, Duration};
+use tokio::time::Duration;
 
 use crate::db::Database;
 
@@ -97,12 +97,11 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
         let guard = FLUSH_TX.read().await;
         guard.as_ref().cloned()
     };
-    let db = db.clone();
 
     // 启动 timer
     tokio::spawn(async move {
-        let mut ticker = interval(Duration::from_secs(debounce_secs));
-        ticker.tick().await; // 等待 debounce 周期
+        // 使用 sleep 而非 interval：interval.tick() 第一次立即返回，不符合"等待周期"的需求
+        tokio::time::sleep(Duration::from_secs(debounce_secs)).await;
         tracing::debug!("黑板 debounce timer 触发: workspace_id={}", workspace_id);
 
         if let Some(tx) = tx {

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod auto_review;
 pub mod auto_update;
 pub mod blackboard;
+pub mod blackboard_debouncer;
 pub mod feishu_history_fetcher;
 pub mod feishu_listener;
 pub mod feishu_push;

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { Button, Typography, Skeleton, message, Modal, Form, InputNumber } from 'antd';
+import { Button, Typography, Skeleton, message, Modal, Form, InputNumber, Space } from 'antd';
 import { ReloadOutlined, SettingOutlined } from '@ant-design/icons';
 import { XMarkdown } from '@ant-design/x-markdown';
 import { useTheme } from '@/hooks/useTheme';
@@ -235,7 +235,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
         onCancel={() => setSettingsOpen(false)}
         okText="保存"
         confirmLoading={settingsSaving}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form layout="vertical">
           <Form.Item label="防抖周期">
@@ -248,13 +248,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
               style={{ width: 200 }}
             />
           </Form.Item>
-          <Form.Item
-            extra="周期到期后统一处理 pending 的 todo，减少频繁的 LLM 调用"
-          >
-            <span style={{ color: 'var(--color-text-secondary)', fontSize: 12 }}>
-              周期到期后统一处理 pending 的 todo，减少频繁的 LLM 调用
-            </span>
-          </Form.Item>
+          <Form.Item extra="周期到期后统一处理 pending 的 todo，减少频繁的 LLM 调用" />
         </Form>
       </Modal>
     </div>
@@ -291,7 +285,7 @@ function BlackboardHeader(props: BlackboardHeaderProps) {
       <Title level={4} style={{ margin: 0 }}>
         黑板
       </Title>
-      <Button.Group>
+      <Space.Compact>
         <Button
           icon={<SettingOutlined />}
           onClick={props.onOpenSettings}
@@ -306,7 +300,7 @@ function BlackboardHeader(props: BlackboardHeaderProps) {
         >
           {props.refreshing ? '更新中...' : '刷新'}
         </Button>
-      </Button.Group>
+      </Space.Compact>
     </div>
   );
 }

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -14,11 +14,12 @@
  */
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { Button, Typography, Skeleton, message } from 'antd';
-import { ReloadOutlined } from '@ant-design/icons';
+import { Button, Typography, Skeleton, message, Modal, Form, InputNumber } from 'antd';
+import { ReloadOutlined, SettingOutlined } from '@ant-design/icons';
 import { XMarkdown } from '@ant-design/x-markdown';
 import { useTheme } from '@/hooks/useTheme';
 import { useViewState } from '@/hooks/useViewState';
+import * as db from '@/utils/database';
 
 const { Title } = Typography;
 
@@ -147,6 +148,36 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
   // 数据状态：data 既是"内容"也是"是否加载完成"的判断
   const [data, setData] = useStateBlackboardData();
   const [refreshing, setRefreshing] = useState(false);
+  // 设置弹窗状态
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsSaving, setSettingsSaving] = useState(false);
+  const [debounceSecs, setDebounceSecs] = useState<number>(600);
+
+  // 打开设置弹窗：先拉取最新 config
+  const handleOpenSettings = useCallback(async () => {
+    setSettingsOpen(true);
+    try {
+      const cfg = await db.getConfig();
+      setDebounceSecs(cfg.blackboard_debounce_secs ?? 600);
+    } catch {
+      setDebounceSecs(600);
+    }
+  }, []);
+
+  // 保存设置
+  const handleSaveSettings = useCallback(async () => {
+    setSettingsSaving(true);
+    try {
+      const current = await db.getConfig();
+      await db.updateConfig({ ...current, blackboard_debounce_secs: debounceSecs });
+      message.success('设置已保存');
+      setSettingsOpen(false);
+    } catch (err) {
+      message.error('保存失败: ' + (err instanceof Error ? err.message : String(err)));
+    } finally {
+      setSettingsSaving(false);
+    }
+  }, [debounceSecs]);
 
   // 拉取（受 workspaceId 变化驱动）：useCallback 稳定引用，让 useEffect 只在 id 变时重跑
   const fetchData = useCallback(async () => {
@@ -192,8 +223,40 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
         // 空状态时禁用刷新：避免无意义的 LLM 调用
         onRefresh={handleRefresh}
         disabled={isEmpty}
+        onOpenSettings={handleOpenSettings}
       />
       <BlackboardBody isDark={isDark} data={data} />
+
+      {/* 黑板设置弹窗 */}
+      <Modal
+        title="黑板设置"
+        open={settingsOpen}
+        onOk={handleSaveSettings}
+        onCancel={() => setSettingsOpen(false)}
+        okText="保存"
+        confirmLoading={settingsSaving}
+        destroyOnClose
+      >
+        <Form layout="vertical">
+          <Form.Item label="防抖周期">
+            <InputNumber
+              value={debounceSecs}
+              onChange={(v) => setDebounceSecs(v ?? 600)}
+              min={10}
+              max={3600}
+              addonAfter="秒"
+              style={{ width: 200 }}
+            />
+          </Form.Item>
+          <Form.Item
+            extra="周期到期后统一处理 pending 的 todo，减少频繁的 LLM 调用"
+          >
+            <span style={{ color: 'var(--color-text-secondary)', fontSize: 12 }}>
+              周期到期后统一处理 pending 的 todo，减少频繁的 LLM 调用
+            </span>
+          </Form.Item>
+        </Form>
+      </Modal>
     </div>
   );
 }
@@ -211,9 +274,10 @@ interface BlackboardHeaderProps {
   refreshing: boolean;
   onRefresh: () => void;
   disabled: boolean;
+  onOpenSettings: () => void;
 }
 
-/** 顶部标题栏：标题 + 刷新按钮 */
+/** 顶部标题栏：标题 + 刷新按钮 + 设置按钮 */
 function BlackboardHeader(props: BlackboardHeaderProps) {
   return (
     <div
@@ -227,15 +291,22 @@ function BlackboardHeader(props: BlackboardHeaderProps) {
       <Title level={4} style={{ margin: 0 }}>
         黑板
       </Title>
-      <Button
-        type="primary"
-        icon={<ReloadOutlined />}
-        loading={props.refreshing}
-        onClick={props.onRefresh}
-        disabled={props.disabled}
-      >
-        {props.refreshing ? '更新中...' : '刷新'}
-      </Button>
+      <Button.Group>
+        <Button
+          icon={<SettingOutlined />}
+          onClick={props.onOpenSettings}
+          title="设置"
+        />
+        <Button
+          type="primary"
+          icon={<ReloadOutlined />}
+          loading={props.refreshing}
+          onClick={props.onRefresh}
+          disabled={props.disabled}
+        >
+          {props.refreshing ? '更新中...' : '刷新'}
+        </Button>
+      </Button.Group>
     </div>
   );
 }

--- a/frontend/src/types/config.tsx
+++ b/frontend/src/types/config.tsx
@@ -17,6 +17,8 @@ export interface Config {
   max_concurrent_todos?: number;
   execution_timeout_secs?: number;
   scheduler_default_timezone?: string;
+  /** 黑板更新防抖周期（秒），默认 600 秒 */
+  blackboard_debounce_secs?: number;
 }
 
 export interface ExecutorConfig {

--- a/frontend/tests/check_blackboard_settings.spec.ts
+++ b/frontend/tests/check_blackboard_settings.spec.ts
@@ -33,8 +33,8 @@ test('黑板设置弹窗能正常打开和保存', async ({ page }) => {
   // 等待一下让表单更新
   await page.waitForTimeout(500);
 
-  // 找到并点击保存按钮（注意：文字是"保 存"有空格）
-  const saveButton = page.locator('.ant-modal button:has-text("保 存")').first();
+  // 点击弹窗底部的确认按钮（primary button in footer）
+  const saveButton = page.locator('.ant-modal-footer .ant-btn-primary').first();
   await expect(saveButton).toBeVisible();
   await saveButton.click();
 

--- a/frontend/tests/check_blackboard_settings.spec.ts
+++ b/frontend/tests/check_blackboard_settings.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * 黑板设置弹窗验证：
+ * 1. 直接导航到黑板页面
+ * 2. 点击设置按钮能打开弹窗
+ * 3. 防抖时间 InputNumber 正常显示和修改
+ * 4. 保存后弹窗关闭并提示成功
+ */
+import { test, expect } from '@playwright/test';
+
+test('黑板设置弹窗能正常打开和保存', async ({ page }) => {
+  // 直接导航到黑板页面
+  await page.goto('http://localhost:18088/?view=blackboard&workspace=1');
+  // 等待 app 渲染完成
+  await page.waitForSelector('#root > *', { timeout: 15000 });
+
+  // 等待设置按钮可见
+  await page.waitForSelector('button[title="设置"]', { timeout: 10000 });
+
+  // 点击设置按钮
+  await page.click('button[title="设置"]');
+
+  // 弹窗应该出现
+  await expect(page.locator('.ant-modal')).toBeVisible({ timeout: 5000 });
+
+  // 防抖输入框应该可见
+  const input = page.locator('.ant-input-number-input').first();
+  await expect(input).toBeVisible();
+
+  // 修改防抖时间为 300
+  await input.fill('300');
+  await input.blur();
+
+  // 等待一下让表单更新
+  await page.waitForTimeout(500);
+
+  // 找到并点击保存按钮（注意：文字是"保 存"有空格）
+  const saveButton = page.locator('.ant-modal button:has-text("保 存")').first();
+  await expect(saveButton).toBeVisible();
+  await saveButton.click();
+
+  // 应该提示成功
+  await expect(page.locator('.ant-message')).toContainText('设置已保存', { timeout: 5000 });
+
+  // 弹窗应该关闭
+  await expect(page.locator('.ant-modal')).not.toBeVisible({ timeout: 5000 });
+});


### PR DESCRIPTION
## 功能说明

黑板更新从「每次todo执行完毕立即触发LLM调用」改为「debounce周期汇总触发」，减少频繁的LLM请求。

**核心机制：**
- todo执行成功后，todo_id追加到黑板的pending队列（DB持久化）
- 每个workspace独立计时器，周期（默认10分钟）到期后通知listener执行一次LLM调用
- listener按顺序查询所有pending todo的最新执行结论，拼成batch prompt后调用update_blackboard

**后端改动：**
- 表新增字段（JSON数组）
- 新增：管理workspace级独立timer + mpsc channel
- ：监听channel，收到消息后执行批量LLM更新
- ：触发链路改为（不再立即执行）
- 新增（默认600秒）
- DAO新增

**前端：** 待实现（设置按钮 + 弹窗编辑debounce时长）