### PR TITLE
feat(blackboard): 新增 debounce 条数阈值，达到立即触发

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -70,6 +70,8 @@ const DEFAULT_AUTO_UPDATE_HOUR: u32 = 3;
 const DEFAULT_AUTO_UPDATE_INTERVAL: &str = "day";
 /// 黑板更新防抖周期（秒），默认 10 分钟。
 const DEFAULT_BLACKBOARD_DEBOUNCE_SECS: u64 = 600;
+/// 黑板更新防抖条数阈值，达到此条数立即触发（不等周期）。
+const DEFAULT_BLACKBOARD_DEBOUNCE_COUNT: u64 = 10;
 
 /// 私有 helper:`auto_backup_*` / `auto_todo_backup_*` / `auto_skill_backup_*`
 /// 三组字段共享同一形状 (enabled: bool, cron: String, max_files: usize)。
@@ -182,6 +184,8 @@ pub struct Config {
     /// todo 执行完成后不会立即触发黑板更新，而是暂存到 pending 队列，
     /// 等到此周期到期后统一处理一次 LLM 调用。
     pub blackboard_debounce_secs: u64,
+    /// 黑板更新防抖条数阈值，达到此条数时立即触发（不等周期）。
+    pub blackboard_debounce_count: u64,
 }
 
 /// Paths for each supported executor binary.
@@ -291,6 +295,7 @@ impl Default for Config {
             auto_update_enabled: false, auto_update_interval: DEFAULT_AUTO_UPDATE_INTERVAL.to_string(),
             auto_update_hour: DEFAULT_AUTO_UPDATE_HOUR, auto_update_last_check_at: None,
             blackboard_debounce_secs: DEFAULT_BLACKBOARD_DEBOUNCE_SECS,
+            blackboard_debounce_count: DEFAULT_BLACKBOARD_DEBOUNCE_COUNT,
         }
     }
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -351,8 +351,11 @@ async fn build_app_state(
     ensure_default_review_template_blocking(&db);
 
     // 黑板防抖器初始化，启动 flush 监听器（监听 channel，收到消息后执行 LLM 更新黑板）
-    let debounce_secs = config.read().unwrap().blackboard_debounce_secs.max(10);
-    let mut flush_rx = crate::services::blackboard_debouncer::init(debounce_secs).await;
+    let cfg = config.read().unwrap();
+    let debounce_secs = cfg.blackboard_debounce_secs.max(10);
+    let debounce_count = cfg.blackboard_debounce_count.max(1);
+    drop(cfg);
+    let mut flush_rx = crate::services::blackboard_debouncer::init(debounce_secs, debounce_count).await;
     tokio::spawn(crate::executor_service::completion::blackboard_flush_listener(
         flush_rx,
         db.clone(),

--- a/backend/src/services/blackboard_debouncer.rs
+++ b/backend/src/services/blackboard_debouncer.rs
@@ -31,22 +31,24 @@ static FLUSH_TX: RwLock<Option<mpsc::Sender<BlackboardFlushMsg>>> = RwLock::cons
 struct Debouncer {
     timers: Arc<RwLock<HashMap<i64, bool>>>,
     debounce_secs: u64,
+    debounce_count: u64,
 }
 
 impl Debouncer {
-    fn new(debounce_secs: u64) -> Self {
+    fn new(debounce_secs: u64, debounce_count: u64) -> Self {
         Self {
             timers: Arc::new(RwLock::new(HashMap::new())),
             debounce_secs,
+            debounce_count,
         }
     }
 }
 
 /// 全局初始化：启动 channel，注册到全局，在 `build_app_state` 中调用
-pub async fn init(debounce_secs: u64) -> mpsc::Receiver<BlackboardFlushMsg> {
+pub async fn init(debounce_secs: u64, debounce_count: u64) -> mpsc::Receiver<BlackboardFlushMsg> {
     let (tx, rx) = mpsc::channel::<BlackboardFlushMsg>(100);
 
-    let debouncer = Debouncer::new(debounce_secs);
+    let debouncer = Debouncer::new(debounce_secs, debounce_count);
 
     {
         let mut w = DEBOUNCER.write().await;
@@ -73,7 +75,7 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
         return;
     }
 
-    // 检查并启动 timer
+    // 获取 debouncer
     let debouncer = {
         let guard = DEBOUNCER.read().await;
         guard.as_ref().cloned()
@@ -83,6 +85,32 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
         return;
     };
 
+    // 检查队列长度是否达到阈值，达到则立即触发
+    if let Ok(Some(board)) = db.get_blackboard(workspace_id).await {
+        let queue_len = serde_json::from_str::<Vec<i64>>(&board.pending_todo_ids)
+            .map(|v| v.len())
+            .unwrap_or(0);
+        if queue_len as u64 >= debouncer.debounce_count {
+            tracing::info!(
+                "黑板 pending 队列达到阈值 {} 条，立即触发: workspace_id={}",
+                queue_len, workspace_id
+            );
+            let tx = {
+                let guard = FLUSH_TX.read().await;
+                guard.as_ref().cloned()
+            };
+            if let Some(tx) = tx {
+                let msg = BlackboardFlushMsg { workspace_id };
+                if let Err(e) = tx.send(msg).await {
+                    tracing::warn!("发送 flush 消息失败: workspace_id={}, error={}", workspace_id, e);
+                }
+            }
+            // 达到阈值触发后，不等 timer，等下次 append 再检查
+            return;
+        }
+    }
+
+    // 未达阈值，检查并启动 timer
     let mut timers = debouncer.timers.write().await;
     if timers.get(&workspace_id).copied().unwrap_or(false) {
         return; // timer 已在运行

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -152,6 +152,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsSaving, setSettingsSaving] = useState(false);
   const [debounceSecs, setDebounceSecs] = useState<number>(600);
+  const [debounceCount, setDebounceCount] = useState<number>(10);
 
   // 打开设置弹窗：先拉取最新 config
   const handleOpenSettings = useCallback(async () => {
@@ -159,8 +160,10 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
     try {
       const cfg = await db.getConfig();
       setDebounceSecs(cfg.blackboard_debounce_secs ?? 600);
+      setDebounceCount(cfg.blackboard_debounce_count ?? 10);
     } catch {
       setDebounceSecs(600);
+      setDebounceCount(10);
     }
   }, []);
 
@@ -169,7 +172,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
     setSettingsSaving(true);
     try {
       const current = await db.getConfig();
-      await db.updateConfig({ ...current, blackboard_debounce_secs: debounceSecs });
+      await db.updateConfig({ ...current, blackboard_debounce_secs: debounceSecs, blackboard_debounce_count: debounceCount });
       message.success('设置已保存');
       setSettingsOpen(false);
     } catch (err) {
@@ -177,7 +180,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
     } finally {
       setSettingsSaving(false);
     }
-  }, [debounceSecs]);
+  }, [debounceSecs, debounceCount]);
 
   // 拉取（受 workspaceId 变化驱动）：useCallback 稳定引用，让 useEffect 只在 id 变时重跑
   const fetchData = useCallback(async () => {
@@ -248,7 +251,17 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
               style={{ width: 200 }}
             />
           </Form.Item>
-          <Form.Item extra="周期到期后统一处理 pending 的 todo，减少频繁的 LLM 调用" />
+          <Form.Item label="触发条数">
+            <InputNumber
+              value={debounceCount}
+              onChange={(v) => setDebounceCount(v ?? 10)}
+              min={1}
+              max={100}
+              addonAfter="条"
+              style={{ width: 200 }}
+            />
+          </Form.Item>
+          <Form.Item extra="达到条数阈值或周期到期时，统一处理 pending 的 todo，减少频繁的 LLM 调用" />
         </Form>
       </Modal>
     </div>

--- a/frontend/src/types/config.tsx
+++ b/frontend/src/types/config.tsx
@@ -19,6 +19,8 @@ export interface Config {
   scheduler_default_timezone?: string;
   /** 黑板更新防抖周期（秒），默认 600 秒 */
   blackboard_debounce_secs?: number;
+  /** 黑板更新防抖条数阈值，达到此条数立即触发 */
+  blackboard_debounce_count?: number;
 }
 
 export interface ExecutorConfig {

--- a/frontend/tests/check_blackboard_settings.spec.ts
+++ b/frontend/tests/check_blackboard_settings.spec.ts
@@ -2,7 +2,7 @@
  * 黑板设置弹窗验证：
  * 1. 直接导航到黑板页面
  * 2. 点击设置按钮能打开弹窗
- * 3. 防抖时间 InputNumber 正常显示和修改
+ * 3. 防抖周期和触发条数 InputNumber 正常显示和修改
  * 4. 保存后弹窗关闭并提示成功
  */
 import { test, expect } from '@playwright/test';


### PR DESCRIPTION
## 功能

黑板更新 debounce 新增条数阈值条件，达到阈值时立即触发（不等周期）。

**触发条件（满足任一即触发）：**
- 周期到期（默认 10 分钟）
- 队列达到条数阈值（默认 10 条）

**改动：**
- 后端 `blackboard_debounce_count` 配置 + 阈值检查逻辑
- 前端设置弹窗新增触发条数输入项
