### PR TITLE
feat(blackboard): 将黑板提示词作为可配置项

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -72,6 +72,58 @@ const DEFAULT_AUTO_UPDATE_INTERVAL: &str = "day";
 const DEFAULT_BLACKBOARD_DEBOUNCE_SECS: u64 = 600;
 /// 黑板更新防抖条数阈值，达到此条数立即触发（不等周期）。
 const DEFAULT_BLACKBOARD_DEBOUNCE_COUNT: u64 = 10;
+/// 默认黑板更新提示词模板（包含占位符 {{current}}、{{conclusion}}、{{todo_id}}、{{todo_title}}）。
+const DEFAULT_BLACKBOARD_UPDATE_PROMPT: &str = r#"你是一个工作空间知识库的维护者。你的任务是维护一个 Markdown 格式的"黑板"，记录工作空间中所有任务执行的结论和当前进展。
+
+当前黑板内容：
+```
+{{current}}
+```
+
+新任务结论：
+- 任务 ID: {{todo_id}}
+- 任务标题: {{todo_title}}
+- 执行结论: {{conclusion}}
+
+请更新黑板内容，要求：
+1. 将新结论整合到黑板中
+2. 保持以下结构：
+   - # 工作空间进展
+   - ## 已确认
+   - ## 新发现
+   - ## 待解决问题
+   - ## 矛盾/风险
+   - ## 下一步建议
+3. 每条结论标注来源，格式：(来源: [todo_{{todo_id}}](ntd://todo/{{todo_id}}))
+4. 如果新结论与已有结论矛盾，在"矛盾/风险"中标注
+5. 如果新结论提出了未解决的问题，在"待解决问题"中列出
+6. 更新"下一步建议"
+7. 保持 Markdown 格式，不要添加 HTML
+8. 如果黑板为空，根据新结论创建初始结构
+
+只输出更新后的黑板内容，不要输出任何解释。"#;
+/// 默认黑板刷新提示词模板（仅包含占位符 {{current}}）。
+const DEFAULT_BLACKBOARD_REFRESH_PROMPT: &str = r#"你是一个工作空间知识库的维护者。重新组织当前黑板内容，使其结构更清晰、信息更准确。
+
+当前黑板内容：
+```
+{{current}}
+```
+
+请重新组织黑板内容，要求：
+1. 保持以下结构：
+   - # 工作空间进展
+   - ## 已确认
+   - ## 新发现
+   - ## 待解决问题
+   - ## 矛盾/风险
+   - ## 下一步建议
+2. 不要添加任何新事实，不要虚构来源 todo；只整理、归并、提炼已有信息
+3. 禁止生成 ntd://todo/ 内部链接（手动刷新没有具体来源 todo）
+4. 合并相似条目；移除空段
+5. 保持 Markdown 格式，不要添加 HTML
+
+只输出重新组织后的黑板内容，不要输出任何解释。"#;
 
 /// 私有 helper:`auto_backup_*` / `auto_todo_backup_*` / `auto_skill_backup_*`
 /// 三组字段共享同一形状 (enabled: bool, cron: String, max_files: usize)。
@@ -186,6 +238,12 @@ pub struct Config {
     pub blackboard_debounce_secs: u64,
     /// 黑板更新防抖条数阈值，达到此条数时立即触发（不等周期）。
     pub blackboard_debounce_count: u64,
+    /// 黑板更新提示词模板（包含占位符 {{current}}、{{conclusion}}、{{todo_id}}、{{todo_title}}）。
+    /// 为空时使用内置默认提示词。
+    pub blackboard_update_prompt: String,
+    /// 黑板刷新提示词模板（仅包含占位符 {{current}}）。
+    /// 为空时使用内置默认提示词。
+    pub blackboard_refresh_prompt: String,
 }
 
 /// Paths for each supported executor binary.
@@ -296,6 +354,8 @@ impl Default for Config {
             auto_update_hour: DEFAULT_AUTO_UPDATE_HOUR, auto_update_last_check_at: None,
             blackboard_debounce_secs: DEFAULT_BLACKBOARD_DEBOUNCE_SECS,
             blackboard_debounce_count: DEFAULT_BLACKBOARD_DEBOUNCE_COUNT,
+            blackboard_update_prompt: DEFAULT_BLACKBOARD_UPDATE_PROMPT.to_string(),
+            blackboard_refresh_prompt: DEFAULT_BLACKBOARD_REFRESH_PROMPT.to_string(),
         }
     }
 }

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -98,6 +98,12 @@ pub async fn update_config(
             }
             cfg.auto_update_hour = hour;
         }
+        if let Some(blackboard_update_prompt) = req.blackboard_update_prompt {
+            cfg.blackboard_update_prompt = blackboard_update_prompt;
+        }
+        if let Some(blackboard_refresh_prompt) = req.blackboard_refresh_prompt {
+            cfg.blackboard_refresh_prompt = blackboard_refresh_prompt;
+        }
 
         cfg.normalize_paths();
         cfg.clamp_execution_timeout_secs();

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -786,6 +786,12 @@ pub struct UpdateConfigRequest {
     pub auto_update_interval: Option<String>,
     /// 自动更新检查小时（0-23）
     pub auto_update_hour: Option<u32>,
+    /// 黑板更新提示词模板（包含占位符 {{current}}、{{conclusion}}、{{todo_id}}、{{todo_title}}）。
+    /// 设置为空字符串可恢复内置默认提示词。
+    pub blackboard_update_prompt: Option<String>,
+    /// 黑板刷新提示词模板（仅包含占位符 {{current}}）。
+    /// 设置为空字符串可恢复内置默认提示词。
+    pub blackboard_refresh_prompt: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -25,6 +25,7 @@ const TRIGGER_TYPE_BLACKBOARD: &str = "blackboard";
 /// 每个工作空间独立维护自己的黑板更新 Todo。
 pub async fn find_or_create_blackboard_todo(
     db: &Database,
+    prompt_template: &str,
     workspace_id: i64,
 ) -> Result<(i64, bool), AppError> {
     // 1. 按 action_type + action_key + workspace_id 查找已有的 Todo
@@ -48,7 +49,7 @@ pub async fn find_or_create_blackboard_todo(
     // 标题便于在 todo 列表中识别黑板更新 todo
     let title = format!("Blackboard: workspace_{}", workspace_id);
     // prompt 模板内含占位符，下游 start_todo_execution 之前再做替换
-    let prompt = build_blackboard_prompt();
+    let prompt = prompt_template.to_string();
 
     // create_todo_with_extras 不支持直接传 action_type/action_key，先建再改
     let todo_id = db
@@ -174,7 +175,11 @@ async fn read_current_content(
 }
 
 /// 构造带占位符替换的最终 prompt，并把原 params 一并返回（start_todo_execution 也需要）。
+///
+/// 使用调用方传入的 prompt_template（来自运行时 config），而非从 DB 加载。
+/// 这样当用户修改 config 中的提示词后，下次执行会立即生效，无需重建 todo。
 fn assemble_prompt(
+    prompt_template: &str,
     current_content: String,
     conclusion: String,
     source_todo_id: i64,
@@ -187,7 +192,7 @@ fn assemble_prompt(
     params.insert("todo_id".to_string(), source_todo_id.to_string());
     params.insert("todo_title".to_string(), source_todo_title.to_string());
     // models::replace_placeholders 单遍替换 {{key}} -> params[key]
-    let message = crate::models::replace_placeholders(&build_blackboard_prompt(), &params);
+    let message = crate::models::replace_placeholders(prompt_template, &params);
     (message, params)
 }
 
@@ -343,9 +348,19 @@ pub async fn update_blackboard(
 ) -> Result<(), AppError> {
     // 1+2: 读当前内容、找或建 todo；任一失败直接返回
     let current_content = read_current_content(&db, workspace_id).await?;
-    let (todo_id, _) = find_or_create_blackboard_todo(&db, workspace_id).await?;
-    // 3: 组装 prompt：source_todo_id/title 来自上游任务，conclusion 是任务执行结果
+    // 从 config 中提取提示词模板（避免 guard 跨 await 持有）
+    let prompt_template = {
+        let guard = config.read().unwrap();
+        if guard.blackboard_update_prompt.is_empty() {
+            build_blackboard_prompt()
+        } else {
+            guard.blackboard_update_prompt.clone()
+        }
+    };
+    let (todo_id, _) = find_or_create_blackboard_todo(&db, &prompt_template, workspace_id).await?;
+    // 3: 组装 prompt：使用当前运行时 config 中的提示词模板
     let (message, params) = assemble_prompt(
+        &prompt_template,
         current_content,
         conclusion.to_string(),
         source_todo_id,
@@ -388,13 +403,28 @@ pub async fn refresh_blackboard(
     if current_content.is_empty() {
         return Err(AppError::BadRequest("黑板暂无内容，无需刷新".to_string()));
     }
+    // 从 config 中提取提示词模板（避免 guard 跨 await 持有）
+    let (update_prompt_template, refresh_prompt) = {
+        let guard = config.read().unwrap();
+        let update = if guard.blackboard_update_prompt.is_empty() {
+            build_blackboard_prompt()
+        } else {
+            guard.blackboard_update_prompt.clone()
+        };
+        let refresh = if guard.blackboard_refresh_prompt.is_empty() {
+            build_refresh_prompt()
+        } else {
+            guard.blackboard_refresh_prompt.clone()
+        };
+        (update, refresh)
+    };
     // 复用同一 todo + 同一执行/等待/写入流程；source_todo_* 留 None 表示"非任务触发"
-    let (todo_id, _) = find_or_create_blackboard_todo(&db, workspace_id).await?;
+    let (todo_id, _) = find_or_create_blackboard_todo(&db, &update_prompt_template, workspace_id).await?;
     // 手动刷新走独立 prompt 模板：避免 LLM 用 todo_id=0 拼出 ntd://todo/0 坏链接。
     // 模板只依赖 {{current}}，不需要 source_todo_* 之类的额外占位符。
     let mut params = HashMap::new();
     params.insert("current".to_string(), current_content);
-    let message = crate::models::replace_placeholders(&build_refresh_prompt(), &params);
+    let message = crate::models::replace_placeholders(&refresh_prompt, &params);
     let new_content = run_blackboard_execution(
         db.clone(),
         executor_registry,
@@ -462,7 +492,9 @@ mod tests {
     /// 防止模型 prompt 模板被误改后占位符替换断裂（导致 LLM 收到 "{{conclusion}}" 字面量）。
     #[test]
     fn test_assemble_prompt_replaces_all_placeholders() {
+        let prompt_template = build_blackboard_prompt();
         let (message, params) = assemble_prompt(
+            &prompt_template,
             "已有黑板".to_string(),
             "任务已成功".to_string(),
             42,
@@ -488,11 +520,12 @@ mod tests {
     async fn test_find_or_create_is_idempotent() {
         let db = Database::new(":memory:").await.unwrap();
         let ws_id = make_workspace(&db).await;
+        let prompt_template = build_blackboard_prompt();
         // 第一次：新建
-        let (id1, created1) = find_or_create_blackboard_todo(&db, ws_id).await.unwrap();
+        let (id1, created1) = find_or_create_blackboard_todo(&db, &prompt_template, ws_id).await.unwrap();
         assert!(created1, "首次调用应返回 created=true");
         // 第二次：复用
-        let (id2, created2) = find_or_create_blackboard_todo(&db, ws_id).await.unwrap();
+        let (id2, created2) = find_or_create_blackboard_todo(&db, &prompt_template, ws_id).await.unwrap();
         assert!(!created2, "第二次调用应返回 created=false");
         assert_eq!(id1, id2, "应返回同一 todo id");
     }
@@ -504,6 +537,7 @@ mod tests {
     #[tokio::test]
     async fn test_find_or_create_scoped_per_workspace() {
         let db = Database::new(":memory:").await.unwrap();
+        let prompt_template = build_blackboard_prompt();
         let ws1 = db
             .create_project_directory("/tmp/test-blackboard-svc-1", None, false, false)
             .await
@@ -512,8 +546,8 @@ mod tests {
             .create_project_directory("/tmp/test-blackboard-svc-2", None, false, false)
             .await
             .unwrap();
-        let (id1, _) = find_or_create_blackboard_todo(&db, ws1).await.unwrap();
-        let (id2, _) = find_or_create_blackboard_todo(&db, ws2).await.unwrap();
+        let (id1, _) = find_or_create_blackboard_todo(&db, &prompt_template, ws1).await.unwrap();
+        let (id2, _) = find_or_create_blackboard_todo(&db, &prompt_template, ws2).await.unwrap();
         assert_ne!(id1, id2, "不同 workspace 应当各自有独立 todo");
     }
 
@@ -522,7 +556,8 @@ mod tests {
     #[tokio::test]
     async fn test_find_or_create_missing_workspace_returns_bad_request() {
         let db = Database::new(":memory:").await.unwrap();
-        let result = find_or_create_blackboard_todo(&db, 9999).await;
+        let prompt_template = build_blackboard_prompt();
+        let result = find_or_create_blackboard_todo(&db, &prompt_template, 9999).await;
         match result {
             Err(AppError::BadRequest(_)) => {}
             other => panic!("expected BadRequest, got: {:?}", other),


### PR DESCRIPTION
## 概述

将黑板的提示词（更新提示词和刷新提示词）作为可配置项，支持用户自定义黑板的行为。

## 变更内容

### 新增配置项

- `blackboard_update_prompt` - 黑板更新提示词模板
  - 包含占位符：`{{current}}`、`{{conclusion}}`、`{{todo_id}}`、`{{todo_title}}`
  - 为空时使用内置默认提示词

- `blackboard_refresh_prompt` - 黑板刷新提示词模板
  - 包含占位符：`{{current}}`
  - 为空时使用内置默认提示词

### 使用方式

1. **通过 API 修改**：`PUT /api/config`
   ```json
   {
     "blackboard_update_prompt": "自定义更新提示词...",
     "blackboard_refresh_prompt": "自定义刷新提示词..."
   }
   ```

2. **通过配置文件修改**：`~/.ntd/config.yaml`
   ```yaml
   blackboard_update_prompt: |
     你是一个工作空间知识库的维护者...
   
   blackboard_refresh_prompt: |
     你是一个工作空间知识库的维护者...
   ```

3. **恢复默认**：设置为空字符串即可

## 测试

- 997 个单元测试全部通过
- 新增/修改的测试：
  - `test_assemble_prompt_replaces_all_placeholders`
  - `test_find_or_create_is_idempotent`
  - `test_find_or_create_scoped_per_workspace`
  - `test_find_or_create_missing_workspace_returns_bad_request`

## 影响范围

- `backend/src/config.rs` - 新增配置字段和默认值
- `backend/src/models/mod.rs` - UpdateConfigRequest 新增可选字段
- `backend/src/handlers/config.rs` - update_config handler 支持新字段
- `backend/src/services/blackboard.rs` - 使用配置的提示词创建 blackboard todo
