### PR TITLE
feat(blackboard): 黑板倒计时进度条 + pending todo 修复

### DIFF
--- a/backend/src/db/blackboard.rs
+++ b/backend/src/db/blackboard.rs
@@ -25,6 +25,11 @@ impl Database {
             .await
     }
 
+    /// 返回所有黑板记录（供 flush listener 广播状态用）。
+    pub async fn get_all_blackboards(&self) -> Result<Vec<blackboards::Model>, sea_orm::DbErr> {
+        blackboards::Entity::find().all(&self.conn).await
+    }
+
     /// 为指定工作空间创建一条空的黑板记录。
     ///
     /// 幂等实现：使用 `ON CONFLICT(workspace_id) DO NOTHING` + 重新查询，
@@ -159,9 +164,10 @@ impl Database {
         ids.push(todo_id);
         let ids_json = serde_json::to_string(&ids).unwrap_or_default();
 
-        // 写回
+        // 写回：必须用 Unchanged 设置主键，sea-orm 的 update() 要求主键必须存在
         let now = crate::models::utc_timestamp();
-        let res = blackboards::ActiveModel {
+        let _res = blackboards::ActiveModel {
+            id: ActiveValue::Unchanged(board.id),
             workspace_id: ActiveValue::Unchanged(workspace_id),
             pending_todo_ids: ActiveValue::Set(ids_json),
             updated_at: ActiveValue::Set(Some(now)),
@@ -191,10 +197,11 @@ impl Database {
         let ids: Vec<i64> = serde_json::from_str(&board.pending_todo_ids)
             .unwrap_or_default();
 
-        // 清空队列（非空才写，减少 DB 写入）
+        // 清空队列（非空才写，减少 DB 写入）；主键必须设置
         if !ids.is_empty() {
             let now = crate::models::utc_timestamp();
-            let res = blackboards::ActiveModel {
+            let _res = blackboards::ActiveModel {
+                id: ActiveValue::Unchanged(board.id),
                 workspace_id: ActiveValue::Unchanged(workspace_id),
                 pending_todo_ids: ActiveValue::Set("[]".to_string()),
                 updated_at: ActiveValue::Set(Some(now)),

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -572,7 +572,7 @@ pub async fn blackboard_flush_listener(
                         let conclusion_text = conclusions.join("\n\n");
 
                         // 调用 update_blackboard
-                        if let Err(e) = crate::services::blackboard::update_blackboard(
+                        let update_result = crate::services::blackboard::update_blackboard(
                             db.clone(),
                             executor_registry.clone(),
                             tx.clone(),
@@ -583,8 +583,20 @@ pub async fn blackboard_flush_listener(
                             todo_ids[0],
                             &format!("批量更新 ({}条)", todo_ids.len()),
                         )
-                        .await
-                        {
+                        .await;
+
+                        // flush 完成，广播 refreshing=false 状态
+                        let done_event = ExecEvent::BlackboardDebounceStatus {
+                            workspace_id: msg.workspace_id,
+                            pending_count: 0,
+                            threshold: debounce_count,
+                            debounce_secs,
+                            remaining_secs: -1,
+                            refreshing: false,
+                        };
+                        let _ = tx.send(done_event);
+
+                        if let Err(e) = update_result {
                             tracing::warn!("黑板 update_blackboard 失败: workspace_id={}, error={:?}", msg.workspace_id, e);
                         }
                     }

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -427,7 +427,52 @@ pub(crate) async fn finalize_normal_completion(
     }
 }
 
-/// 启动黑板 flush 监听器：监听 debouncer channel，收到消息后执行 update_blackboard
+/// 构建黑板防抖状态事件（用于 WebSocket 推送）。
+/// 从 DB 读取 pending 队列，从 debouncer 读取 timer 状态。
+async fn build_blackboard_status(
+    db: &Database,
+    workspace_id: i64,
+    debounce_secs: u64,
+    debounce_count: u64,
+) -> ExecEvent {
+    let pending_count = db
+        .get_blackboard(workspace_id)
+        .await
+        .ok()
+        .flatten()
+        .map(|b| {
+            serde_json::from_str::<Vec<i64>>(&b.pending_todo_ids)
+                .map(|v| v.len() as u64)
+                .unwrap_or(0)
+        })
+        .unwrap_or(0);
+
+    let remaining_secs = crate::services::blackboard_debouncer::get_timer_state(workspace_id)
+        .await
+        .map(|state| {
+            let elapsed_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as i64
+                - state.started_at_ms as i64;
+            let remaining = state.debounce_secs as i64 - elapsed_ms / 1000;
+            remaining.max(0) as i64
+        })
+        .unwrap_or(-1);
+
+    ExecEvent::BlackboardDebounceStatus {
+        workspace_id,
+        pending_count,
+        threshold: debounce_count,
+        debounce_secs,
+        remaining_secs,
+        refreshing: false,
+    }
+}
+
+/// 启动黑板 flush 监听器：
+/// - 监听 debouncer channel，收到消息后执行 update_blackboard
+/// - 每秒通过 broadcast::tx 推送一次 BlackboardDebounceStatus 事件
 pub async fn blackboard_flush_listener(
     mut rx: tokio::sync::mpsc::Receiver<crate::services::blackboard_debouncer::BlackboardFlushMsg>,
     db: Arc<Database>,
@@ -436,62 +481,116 @@ pub async fn blackboard_flush_listener(
     task_manager: Arc<TaskManager>,
     config: Arc<std::sync::RwLock<crate::config::Config>>,
 ) {
-    while let Some(msg) = rx.recv().await {
-        tracing::debug!("黑板 flush listener 收到消息: workspace_id={}", msg.workspace_id);
+    // 每秒 ticker 用于推送状态
+    let mut ticker = tokio::time::interval(tokio::time::Duration::from_secs(1));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-        // 从 DB 取出 pending 队列（take_pending_todo_ids 已清空队列）
-        let todo_ids = match db.take_pending_todo_ids(msg.workspace_id).await {
-            Ok(ids) => ids,
-            Err(e) => {
-                tracing::warn!("取 pending 队列失败: workspace_id={}, error={}", msg.workspace_id, e);
-                continue;
-            }
+    // 已知的 workspace_id 列表（首次发送时从 DB 拉取）
+    let mut known_workspaces: Vec<i64> = Vec::new();
+
+    loop {
+        // 从 config 读取当前的 debounce 参数（可能运行时变更）
+        let (debounce_secs, debounce_count) = {
+            let cfg = config.read().unwrap();
+            (cfg.blackboard_debounce_secs, cfg.blackboard_debounce_count)
         };
 
-        if todo_ids.is_empty() {
-            tracing::debug!("黑板 pending 队列为空: workspace_id={}", msg.workspace_id);
-            continue;
-        }
+        tokio::select! {
+            // 每秒 ticker：广播所有已知 workspace 的状态
+            _ = ticker.tick() => {
+                // 确保 known_workspaces 非空（首次）
+                if known_workspaces.is_empty() {
+                    if let Ok(boards) = db.get_all_blackboards().await {
+                        known_workspaces = boards.iter().map(|b| b.workspace_id).collect();
+                    }
+                }
 
-        tracing::info!(
-            "黑板 flush listener 处理: workspace_id={}, todo_ids={:?}",
-            msg.workspace_id, todo_ids
-        );
-
-        // 按顺序查询每条 todo 的最新执行结论
-        let mut conclusions = Vec::with_capacity(todo_ids.len());
-        for todo_id in &todo_ids {
-            if let Ok(Some(record)) = db.get_latest_execution_record_for_todo(*todo_id).await {
-                conclusions.push(format!(
-                    "- 任务 ID: {}\n  结论: {}",
-                    todo_id,
-                    record.result.as_deref().unwrap_or("(无结论)")
-                ));
+                for ws_id in &known_workspaces {
+                    let event = build_blackboard_status(&db, *ws_id, debounce_secs, debounce_count).await;
+                    let _ = tx.send(event);
+                }
             }
-        }
 
-        if conclusions.is_empty() {
-            tracing::debug!("所有 todo 均无执行记录: workspace_id={}", msg.workspace_id);
-            continue;
-        }
+            // flush 消息：执行黑板刷新
+            msg = rx.recv() => {
+                match msg {
+                    Some(msg) => {
+                        tracing::debug!("黑板 flush listener 收到消息: workspace_id={}", msg.workspace_id);
 
-        let conclusion_text = conclusions.join("\n\n");
+                        // 先确保 workspace 在已知列表中
+                        if !known_workspaces.contains(&msg.workspace_id) {
+                            known_workspaces.push(msg.workspace_id);
+                        }
 
-        // 调用 update_blackboard
-        if let Err(e) = crate::services::blackboard::update_blackboard(
-            db.clone(),
-            executor_registry.clone(),
-            tx.clone(),
-            task_manager.clone(),
-            config.clone(),
-            msg.workspace_id,
-            &conclusion_text,
-            todo_ids[0],
-            &format!("批量更新 ({}条)", todo_ids.len()),
-        )
-        .await
-        {
-            tracing::warn!("黑板 update_blackboard 失败: workspace_id={}, error={:?}", msg.workspace_id, e);
+                        // 广播 refreshing=true 状态
+                        let refreshing_event = ExecEvent::BlackboardDebounceStatus {
+                            workspace_id: msg.workspace_id,
+                            pending_count: 0,
+                            threshold: debounce_count,
+                            debounce_secs,
+                            remaining_secs: -1,
+                            refreshing: true,
+                        };
+                        let _ = tx.send(refreshing_event);
+
+                        // 从 DB 取出 pending 队列（take_pending_todo_ids 已清空队列）
+                        let todo_ids = match db.take_pending_todo_ids(msg.workspace_id).await {
+                            Ok(ids) => ids,
+                            Err(e) => {
+                                tracing::warn!("取 pending 队列失败: workspace_id={}, error={}", msg.workspace_id, e);
+                                continue;
+                            }
+                        };
+
+                        if todo_ids.is_empty() {
+                            tracing::debug!("黑板 pending 队列为空: workspace_id={}", msg.workspace_id);
+                            continue;
+                        }
+
+                        tracing::info!(
+                            "黑板 flush listener 处理: workspace_id={}, todo_ids={:?}",
+                            msg.workspace_id, todo_ids
+                        );
+
+                        // 按顺序查询每条 todo 的最新执行结论
+                        let mut conclusions = Vec::with_capacity(todo_ids.len());
+                        for todo_id in &todo_ids {
+                            if let Ok(Some(record)) = db.get_latest_execution_record_for_todo(*todo_id).await {
+                                conclusions.push(format!(
+                                    "- 任务 ID: {}\n  结论: {}",
+                                    todo_id,
+                                    record.result.as_deref().unwrap_or("(无结论)")
+                                ));
+                            }
+                        }
+
+                        if conclusions.is_empty() {
+                            tracing::debug!("所有 todo 均无执行记录: workspace_id={}", msg.workspace_id);
+                            continue;
+                        }
+
+                        let conclusion_text = conclusions.join("\n\n");
+
+                        // 调用 update_blackboard
+                        if let Err(e) = crate::services::blackboard::update_blackboard(
+                            db.clone(),
+                            executor_registry.clone(),
+                            tx.clone(),
+                            task_manager.clone(),
+                            config.clone(),
+                            msg.workspace_id,
+                            &conclusion_text,
+                            todo_ids[0],
+                            &format!("批量更新 ({}条)", todo_ids.len()),
+                        )
+                        .await
+                        {
+                            tracing::warn!("黑板 update_blackboard 失败: workspace_id={}, error={:?}", msg.workspace_id, e);
+                        }
+                    }
+                    None => break, // channel 已关闭
+                }
+            }
         }
     }
 }

--- a/backend/src/executor_service/events.rs
+++ b/backend/src/executor_service/events.rs
@@ -119,4 +119,20 @@ pub enum ExecEvent {
         /// 执行所在的工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标
         workspace_id: Option<i64>,
     },
+/// 黑板防抖状态事件：定期推送倒计时和 pending 数量，前端据此渲染双进度条。
+/// 由 blackboard_flush_listener 转发 debouncer 的状态到 WebSocket。
+BlackboardDebounceStatus {
+    /// 工作空间 ID
+    workspace_id: i64,
+    /// 当前 pending 队列条数
+    pending_count: u64,
+    /// 触发阈值（条数）
+    threshold: u64,
+    /// 配置的防抖周期（秒）
+    debounce_secs: u64,
+    /// Timer 剩余秒数（-1 表示无 active timer，即等待中）
+    remaining_secs: i64,
+    /// 是否正在刷新（LLM 调用中）
+    refreshing: bool,
+},
 }

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -104,6 +104,12 @@ pub async fn update_config(
         if let Some(blackboard_refresh_prompt) = req.blackboard_refresh_prompt {
             cfg.blackboard_refresh_prompt = blackboard_refresh_prompt;
         }
+        if let Some(v) = req.blackboard_debounce_secs {
+            cfg.blackboard_debounce_secs = v.max(10);
+        }
+        if let Some(v) = req.blackboard_debounce_count {
+            cfg.blackboard_debounce_count = v.max(1);
+        }
 
         cfg.normalize_paths();
         cfg.clamp_execution_timeout_secs();

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -792,6 +792,10 @@ pub struct UpdateConfigRequest {
     /// 黑板刷新提示词模板（仅包含占位符 {{current}}）。
     /// 设置为空字符串可恢复内置默认提示词。
     pub blackboard_refresh_prompt: Option<String>,
+    /// 黑板防抖周期（秒），达到该时间后统一处理 pending 队列。
+    pub blackboard_debounce_secs: Option<u64>,
+    /// 黑板防抖条数阈值，达到该条数后立即触发处理，无需等待周期。
+    pub blackboard_debounce_count: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/services/blackboard_debouncer.rs
+++ b/backend/src/services/blackboard_debouncer.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use tokio::sync::{broadcast, mpsc, RwLock};
-use tokio::time::Duration;
+use tokio::time::{Duration, Instant};
 
 use crate::db::Database;
 
@@ -26,6 +26,27 @@ static DEBOUNCER: RwLock<Option<Debouncer>> = RwLock::const_new(None);
 
 /// 全局 channel 发送端（监听方持有接收端）
 static FLUSH_TX: RwLock<Option<mpsc::Sender<BlackboardFlushMsg>>> = RwLock::const_new(None);
+
+/// workspace 维度的计时器状态，供 flush listener 读取以计算剩余秒数
+#[derive(Clone)]
+pub struct WorkspaceTimerState {
+    /// 计时器启动时的时间戳（unix ms），用于计算 remaining_secs
+    pub started_at_ms: u64,
+    /// 防抖周期秒数
+    pub debounce_secs: u64,
+}
+
+/// 全局计时器状态（只读，供 flush listener 查询）。使用 Option 包装以支持 const_new。
+static TIMER_STATES: RwLock<Option<HashMap<i64, WorkspaceTimerState>>> = RwLock::const_new(None);
+
+/// 查询 workspace 的当前计时器状态，返回 None 表示无 active timer。
+pub async fn get_timer_state(workspace_id: i64) -> Option<WorkspaceTimerState> {
+    let guard = TIMER_STATES.read().await;
+    match guard.as_ref() {
+        Some(map) => map.get(&workspace_id).cloned(),
+        None => None,
+    }
+}
 
 #[derive(Clone)]
 struct Debouncer {
@@ -66,6 +87,22 @@ pub async fn init(debounce_secs: u64, debounce_count: u64) -> mpsc::Receiver<Bla
 ///
 /// 不调用任何 blackboard/executor_service 函数，职责纯粹为"入队 + 启动 timer"。
 pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Database>) {
+    // 确保黑板记录已存在：首次有 todo 执行完成时，黑板记录还未创建。
+    // create_blackboard 是幂等的（ON CONFLICT DO NOTHING），重复调用安全。
+    if let Err(e) = db.create_blackboard(workspace_id).await {
+        tracing::warn!(
+            "创建黑板记录失败: workspace_id={}, error={}",
+            workspace_id, e
+        );
+        // 黑板不存在时跳过入队，不阻塞主流程
+        return;
+    }
+
+    tracing::info!(
+        "push_pending_todo called: workspace_id={}, todo_id={}",
+        workspace_id, todo_id
+    );
+
     // 追加到 DB
     if let Err(e) = db.append_pending_todo_id(workspace_id, todo_id).await {
         tracing::warn!(
@@ -74,6 +111,8 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
         );
         return;
     }
+
+    tracing::info!("append_pending_todo_id 成功: workspace_id={}, todo_id={}", workspace_id, todo_id);
 
     // 获取 debouncer
     let debouncer = {
@@ -90,11 +129,22 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
         let queue_len = serde_json::from_str::<Vec<i64>>(&board.pending_todo_ids)
             .map(|v| v.len())
             .unwrap_or(0);
+        tracing::info!(
+            "pending 队列检查: workspace_id={}, queue_len={}, threshold={}, debounce_secs={}",
+            workspace_id, queue_len, debouncer.debounce_count, debouncer.debounce_secs
+        );
         if queue_len as u64 >= debouncer.debounce_count {
             tracing::info!(
                 "黑板 pending 队列达到阈值 {} 条，立即触发: workspace_id={}",
                 queue_len, workspace_id
             );
+            // 阈值触发时清除 timer 状态，避免 flush listener 再次等待
+            {
+                let mut states = TIMER_STATES.write().await;
+                if let Some(map) = states.as_mut() {
+                    map.remove(&workspace_id);
+                }
+            }
             let tx = {
                 let guard = FLUSH_TX.read().await;
                 guard.as_ref().cloned()
@@ -116,7 +166,20 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
         return; // timer 已在运行
     }
     timers.insert(workspace_id, true);
+    // 记录 timer 启动时间，供 flush listener 计算剩余秒数
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
     drop(timers);
+    {
+        let mut states = TIMER_STATES.write().await;
+        states.get_or_insert_with(HashMap::new);
+        states.as_mut().unwrap().insert(workspace_id, WorkspaceTimerState {
+            started_at_ms: now_ms,
+            debounce_secs: debouncer.debounce_secs,
+        });
+    }
 
     // 克隆所需数据
     let timers = debouncer.timers.clone();
@@ -131,6 +194,14 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
         // 使用 sleep 而非 interval：interval.tick() 第一次立即返回，不符合"等待周期"的需求
         tokio::time::sleep(Duration::from_secs(debounce_secs)).await;
         tracing::debug!("黑板 debounce timer 触发: workspace_id={}", workspace_id);
+
+        // 清除 timer 状态
+        {
+            let mut states = TIMER_STATES.write().await;
+            if let Some(map) = states.as_mut() {
+                map.remove(&workspace_id);
+            }
+        }
 
         if let Some(tx) = tx {
             let msg = BlackboardFlushMsg { workspace_id };

--- a/backend/src/services/blackboard_debouncer.rs
+++ b/backend/src/services/blackboard_debouncer.rs
@@ -174,8 +174,7 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
     drop(timers);
     {
         let mut states = TIMER_STATES.write().await;
-        states.get_or_insert_with(HashMap::new);
-        states.as_mut().unwrap().insert(workspace_id, WorkspaceTimerState {
+        states.get_or_insert_with(HashMap::new).insert(workspace_id, WorkspaceTimerState {
             started_at_ms: now_ms,
             debounce_secs: debouncer.debounce_secs,
         });

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -314,6 +314,8 @@ impl FeishuPushService {
                     loop_title, status_icon, *total_steps, *completed_steps, *failed_steps, duration_str, *total_tokens
                 ))
             }
+            // BlackboardDebounceStatus 仅用于前端 WebSocket 推送，不发飞书
+            ExecEvent::BlackboardDebounceStatus { .. } => None,
         }
     }
 }

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -806,6 +806,17 @@ impl LoopRunner {
                     .await
                     .map_err(|e| e.to_string())?;
                 *consecutive_retries.get_mut(&step.id).unwrap_or(&mut 0) = 0;
+
+                // 4l. 触发黑板更新：Step 执行成功，将 todo_id 追加到黑板 pending 队列。
+                // 与普通 Todo 执行完成后的处理保持一致，让 LLM 将 step 结论整合到黑板。
+                if let Some(ws_id) = loop_.workspace_id.filter(|&id| id != 0) {
+                    crate::services::blackboard_debouncer::push_pending_todo(
+                        ws_id,
+                        step.todo_id,
+                        &self.ctx.db,
+                    )
+                    .await;
+                }
             } else {
                 failed += 1;
                 self.ctx

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -14,11 +14,12 @@
  */
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { Button, Typography, Skeleton, message, Modal, Form, InputNumber, Space } from 'antd';
+import { Button, Typography, Skeleton, message, Modal, Form, InputNumber, Space, Progress } from 'antd';
 import { ReloadOutlined, SettingOutlined } from '@ant-design/icons';
 import { XMarkdown } from '@ant-design/x-markdown';
 import { useTheme } from '@/hooks/useTheme';
 import { useViewState } from '@/hooks/useViewState';
+import type { BlackboardDebounceStatus } from '@/hooks/useExecutionEvents';
 import * as db from '@/utils/database';
 
 const { Title } = Typography;
@@ -141,9 +142,8 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
   const [debounceSecs, setDebounceSecs] = useState<number>(600);
   const [debounceCount, setDebounceCount] = useState<number>(10);
 
-  // 打开设置弹窗：先拉取最新 config
+  // 打开设置弹窗：先拉取最新 config，等拉完再打开 modal，避免默认值闪烁
   const handleOpenSettings = useCallback(async () => {
-    setSettingsOpen(true);
     try {
       const cfg = await db.getConfig();
       setDebounceSecs(cfg.blackboard_debounce_secs ?? 600);
@@ -152,6 +152,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
       setDebounceSecs(600);
       setDebounceCount(10);
     }
+    setSettingsOpen(true);
   }, []);
 
   // 保存设置
@@ -197,6 +198,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
         isDark={isDark}
         onRefresh={handleRefresh}
         onOpenSettings={handleOpenSettings}
+        workspaceId={workspaceId}
       />
       <BlackboardBody isDark={isDark} data={data} />
 
@@ -250,9 +252,10 @@ interface BlackboardHeaderProps {
   isDark: boolean;
   onRefresh: () => void;
   onOpenSettings: () => void;
+  workspaceId: number;
 }
 
-/** 顶部标题栏：标题 + 刷新按钮 + 设置按钮 */
+/** 顶部标题栏：标题 + 倒计时进度条 + 刷新按钮 + 设置按钮 */
 function BlackboardHeader(props: BlackboardHeaderProps) {
   return (
     <div
@@ -261,11 +264,14 @@ function BlackboardHeader(props: BlackboardHeaderProps) {
         alignItems: 'center',
         justifyContent: 'space-between',
         marginBottom: 16,
+        gap: 12,
       }}
     >
-      <Title level={4} style={{ margin: 0 }}>
+      <Title level={4} style={{ margin: 0, flexShrink: 0 }}>
         黑板
       </Title>
+      {/* 双进度条倒计时（自动监听 WebSocket 事件） */}
+      <BlackboardDebounceBar workspaceId={props.workspaceId} />
       <Space.Compact>
         <Button
           icon={<SettingOutlined />}
@@ -280,6 +286,126 @@ function BlackboardHeader(props: BlackboardHeaderProps) {
           刷新
         </Button>
       </Space.Compact>
+    </div>
+  );
+}
+
+// ─── 黑板倒计时进度条 ───────────────────────────────────────────
+
+interface BlackboardDebounceBarProps {
+  /** 当前工作空间 ID，用于过滤事件 */
+  workspaceId: number;
+  /** 刷新状态回调（正在刷新时禁用手动刷新按钮） */
+  onRefreshing?: (v: boolean) => void;
+}
+
+/**
+ * 黑板防抖倒计时双进度条组件。
+ *
+ * 监听 blackboardDebounceStatus WebSocket 事件，渲染：
+ * - 时间进度条（蓝色/绿色）
+ * - 条数进度条（蓝色/绿色）
+ * - 点击整体弹出详情，同时显示时间和条数数据
+ */
+function BlackboardDebounceBar({ workspaceId }: BlackboardDebounceBarProps) {
+  const [status, setStatus] = useState<BlackboardDebounceStatus | null>(null);
+  const [showDetail, setShowDetail] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const s = (e as CustomEvent<BlackboardDebounceStatus>).detail;
+      if (s.workspace_id !== workspaceId) return;
+      setStatus(s);
+    };
+    window.addEventListener('blackboardDebounceStatus', handler);
+    return () => window.removeEventListener('blackboardDebounceStatus', handler);
+  }, [workspaceId]);
+
+  if (!status) return null;
+
+  const { pending_count, threshold, debounce_secs, remaining_secs, refreshing } = status;
+  const isThresholdMet = pending_count >= threshold;
+  const hasTimer = remaining_secs >= 0;
+
+  // 时间进度（整数，已过时间正向累加，0% → 100%）
+  const elapsed = hasTimer ? debounce_secs - remaining_secs : 0;
+  const timePercent = hasTimer
+    ? Math.floor(Math.min(100, (elapsed / debounce_secs) * 100))
+    : 0;
+  const timeColor = isThresholdMet || refreshing ? '#52c41a' : '#2080f0';
+
+  // 条数进度（整数）
+  const countPercent = threshold > 0
+    ? Math.floor(Math.min(100, (pending_count / threshold) * 100))
+    : 0;
+  const countColor = isThresholdMet || refreshing ? '#52c41a' : '#2080f0';
+
+  // hasTimer=false 时区分：pending>0 表示数据已入队等待刷新，否则才是真正的等待中
+  const timeLabel = hasTimer
+    ? `${elapsed}s / ${debounce_secs}s`
+    : pending_count > 0
+      ? '等待刷新'
+      : '等待中';
+  const countLabel = `${pending_count} / ${threshold} 条`;
+
+  return (
+    <div style={{ position: 'relative', flex: 1, marginRight: 16 }}>
+      {/* 整个组件可点击，弹出详情 */}
+      <div
+        style={{ cursor: 'pointer' }}
+        onClick={() => setShowDetail(v => !v)}
+      >
+        <div style={{ marginBottom: 6 }}>
+          <Progress
+            percent={timePercent}
+            size="small"
+            strokeColor={timeColor}
+            trailColor="rgba(0,0,0,0.06)"
+            status={refreshing ? 'active' : 'normal'}
+          />
+        </div>
+        <div>
+          <Progress
+            percent={countPercent}
+            size="small"
+            strokeColor={countColor}
+            trailColor="rgba(0,0,0,0.06)"
+            status={refreshing ? 'active' : 'normal'}
+          />
+        </div>
+      </div>
+
+      {/* 点击弹出的详情气泡 */}
+      {showDetail && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            right: 0,
+            marginTop: 4,
+            background: '#fff',
+            border: '1px solid #ddd',
+            borderRadius: 6,
+            padding: '8px 12px',
+            fontSize: 12,
+            color: '#444',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+            zIndex: 100,
+            whiteSpace: 'nowrap',
+          }}
+          onClick={() => setShowDetail(false)}
+        >
+          <div style={{ marginBottom: 4 }}>
+            ⏱ 时间: <b>{timeLabel}</b>
+          </div>
+          <div style={{ marginBottom: refreshing ? 4 : 0 }}>
+            📊 条数: <b>{countLabel}</b>
+          </div>
+          {refreshing && (
+            <div style={{ color: '#52c41a' }}>刷新中...</div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -77,7 +77,17 @@ interface ExecEventLoopFinished {
   workspace_id: number | null;
 }
 
-type ExecEvent = ExecEventStarted | ExecEventOutput | ExecEventFinished | ExecEventSync | ExecEventTodoProgress | ExecEventExecutionStats | ExecEventReviewStatusChanged | ExecEventLoopFinished;
+/** 黑板防抖状态：双进度条倒计时数据 */
+export interface BlackboardDebounceStatus {
+  workspace_id: number;
+  pending_count: number;
+  threshold: number;
+  debounce_secs: number;
+  remaining_secs: number; // -1 表示无 active timer
+  refreshing: boolean;
+}
+
+type ExecEvent = ExecEventStarted | ExecEventOutput | ExecEventFinished | ExecEventSync | ExecEventTodoProgress | ExecEventExecutionStats | ExecEventReviewStatusChanged | ExecEventLoopFinished | { type: 'BlackboardDebounceStatus' } & BlackboardDebounceStatus;
 
 // ─── 模块级共享状态 ─────────────────────────────────────────────
 //
@@ -187,6 +197,10 @@ function connectShared(dispatch: ReturnType<typeof useApp>['dispatch']) {
         }
         case 'LoopFinished': {
           window.dispatchEvent(new CustomEvent('loopExecutionFinished', { detail: { loopExecutionId: data.loop_execution_id, loopId: data.loop_id, status: data.status, totalSteps: data.total_steps, completedSteps: data.completed_steps, failedSteps: data.failed_steps, durationSecs: data.duration_secs, totalTokens: data.total_tokens } }));
+          break;
+        }
+        case 'BlackboardDebounceStatus': {
+          window.dispatchEvent(new CustomEvent('blackboardDebounceStatus', { detail: data }));
           break;
         }
       }


### PR DESCRIPTION
## 改动

### 后端

**黑板倒计时 WebSocket 推送**
- 新增 `ExecEvent::BlackboardDebounceStatus` 事件类型
- `flush_listener` 每秒通过 broadcast 推送所有 workspace 的倒计时状态
- `TIMER_STATES` 全局状态记录每个 workspace 的 timer 启动时间

**pending todo 修复**
- 修复 `append_pending_todo_id` 更新时缺少主键导致的 panic
- `push_pending_todo` 在入队前自动创建黑板记录（幂等）
- Loop step 完成时触发 `push_pending_todo`（此前遗漏）
- `update_config` 支持 `blackboard_debounce_secs` 和 `blackboard_debounce_count` 持久化

### 前端

**黑板页面双进度条**
- 两条进度条：时间进度 + 条数进度，点击整体弹出详情气泡
- 时间进度：elapsed / debounce_secs 正向累加 0 到 100
- 条数进度：pending / threshold 填充
- pending>0 但无 active timer 时显示"等待刷新"
- 刷新/阈值到达时进度条变绿

**设置弹窗修复**
- 先拉取 config 再打开 modal，避免默认值闪烁
- 修复保存后配置不生效的问题

## 测试

1. 访问黑板页面，看到双进度条
2. 点击进度条弹出详情，显示时间和条数
3. 执行几个 todo，观察条数进度条上涨
4. 等待计时器触发，观察时间进度条走完并变绿刷新
