### PR TITLE
feat(blackboard): 将黑板提示词配置做到设置界面上

### DIFF
--- a/docs/design/blackboard-design.md
+++ b/docs/design/blackboard-design.md
@@ -149,7 +149,8 @@ POST /api/workspaces/{workspace_id}/blackboard/refresh
 ### 5.1 触发时机
 
 **自动触发**：任务执行完成时（`ExecEvent::Finished`）
-**手动触发**：用户点击黑板页面的"刷新"按钮
+
+> 注：手动刷新功能已移除。用户可通过刷新页面（刷新按钮 → `window.location.reload()`）重新拉取黑板内容，无需 LLM 参与。
 
 ### 5.2 更新逻辑
 
@@ -329,7 +330,7 @@ pub async fn update_blackboard(
 
 ```
 ┌─────────────────────────────────────────────┐
-│ 黑板                              [刷新按钮]  │
+│ 黑板                              [设置按钮]  │
 ├─────────────────────────────────────────────┤
 │                                             │
 │  # 工作空间进展                              │
@@ -429,7 +430,7 @@ async fn maybe_update_blackboard(
 | **Phase 2** | 后端 API | Handler + Service + 路由注册 |
 | **Phase 3** | LLM 更新逻辑 | Prompt + 调用 + Finished 事件 Hook |
 | **Phase 4** | 前端页面 | 菜单 + 页面 + API 调用 + Markdown 渲染 |
-| **Phase 5** | 手动刷新 | 刷新按钮 + 更新状态提示 |
+| **Phase 5** | 手动刷新 | ~~刷新按钮~~ → 页面 reload（无需 LLM） |
 
 ---
 

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { Button, Typography, Skeleton, message, Modal, Form, InputNumber, Space, Progress, Input } from 'antd';
+import { Button, Typography, Skeleton, message, Modal, Form, InputNumber, Space, Progress, Input, Tabs } from 'antd';
 import { ReloadOutlined, SettingOutlined } from '@ant-design/icons';
 import { XMarkdown } from '@ant-design/x-markdown';
 import { useTheme } from '@/hooks/useTheme';
@@ -40,6 +40,40 @@ const URL_WORKSPACE_PARAM = 'workspace';
 
 /** 默认工作空间 ID（首屏兜底，避免 URL 未带参时无 workspace） */
 const DEFAULT_WORKSPACE_ID = 1;
+
+/**
+ * 黑板更新提示词默认值，与后端 DEFAULT_BLACKBOARD_UPDATE_PROMPT 保持一致。
+ * 用于在 UI 上展示默认提示词内容，以及"恢复默认"时回填。
+ */
+const DEFAULT_BLACKBOARD_UPDATE_PROMPT = `你是一个工作空间知识库的维护者。你的任务是维护一个 Markdown 格式的"黑板"，记录工作空间中所有任务执行的结论和当前进展。
+
+当前黑板内容：
+\`\`\`
+{{current}}
+\`\`\`
+
+新任务结论：
+- 任务 ID: {{todo_id}}
+- 任务标题: {{todo_title}}
+- 执行结论: {{conclusion}}
+
+请更新黑板内容，要求：
+1. 将新结论整合到黑板中
+2. 保持以下结构：
+   - # 工作空间进展
+   - ## 已确认
+   - ## 新发现
+   - ## 待解决问题
+   - ## 矛盾/风险
+   - ## 下一步建议
+3. 每条结论标注来源，格式：(来源: [todo_{{todo_id}}](ntd://todo/{{todo_id}}))
+4. 如果新结论与已有结论矛盾，在"矛盾/风险"中标注
+5. 如果新结论提出了未解决的问题，在"待解决问题"中列出
+6. 更新"下一步建议"
+7. 保持 Markdown 格式，不要添加 HTML
+8. 如果黑板为空，根据新结论创建初始结构
+
+只输出更新后的黑板内容，不要输出任何解释。`;
 
 
 /** Markdown 链接组件 props 形状（XMarkdown ComponentProps 简化版） */
@@ -142,7 +176,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
   const [debounceSecs, setDebounceSecs] = useState<number>(600);
   const [debounceCount, setDebounceCount] = useState<number>(10);
   const [updatePrompt, setUpdatePrompt] = useState<string>('');
-  const [refreshPrompt, setRefreshPrompt] = useState<string>('');
+  const [activeTab, setActiveTab] = useState<'debounce' | 'prompt'>('debounce');
 
   // 打开设置弹窗：先拉取最新 config，等拉完再打开 modal，避免默认值闪烁
   const handleOpenSettings = useCallback(async () => {
@@ -151,13 +185,12 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
       setDebounceSecs(cfg.blackboard_debounce_secs ?? 600);
       setDebounceCount(cfg.blackboard_debounce_count ?? 10);
       setUpdatePrompt(cfg.blackboard_update_prompt ?? '');
-      setRefreshPrompt(cfg.blackboard_refresh_prompt ?? '');
     } catch {
       setDebounceSecs(600);
       setDebounceCount(10);
       setUpdatePrompt('');
-      setRefreshPrompt('');
     }
+    setActiveTab('debounce');
     setSettingsOpen(true);
   }, []);
 
@@ -166,7 +199,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
     setSettingsSaving(true);
     try {
       const current = await db.getConfig();
-      await db.updateConfig({ ...current, blackboard_debounce_secs: debounceSecs, blackboard_debounce_count: debounceCount, blackboard_update_prompt: updatePrompt, blackboard_refresh_prompt: refreshPrompt });
+      await db.updateConfig({ ...current, blackboard_debounce_secs: debounceSecs, blackboard_debounce_count: debounceCount, blackboard_update_prompt: updatePrompt });
       message.success('设置已保存');
       setSettingsOpen(false);
     } catch (err) {
@@ -174,7 +207,12 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
     } finally {
       setSettingsSaving(false);
     }
-  }, [debounceSecs, debounceCount, updatePrompt, refreshPrompt]);
+  }, [debounceSecs, debounceCount, updatePrompt]);
+
+  // 恢复默认提示词：把 updatePrompt 清空（空字符串表示使用后端内置默认）
+  const handleRestoreDefaultPrompt = useCallback(() => {
+    setUpdatePrompt('');
+  }, []);
 
   // 拉取（受 workspaceId 变化驱动）：useCallback 稳定引用，让 useEffect 只在 id 变时重跑
   const fetchData = useCallback(async () => {
@@ -208,7 +246,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
       />
       <BlackboardBody isDark={isDark} data={data} />
 
-      {/* 黑板设置弹窗 */}
+      {/* 黑板设置弹窗：Tab1 防抖设置，Tab2 提示词设置 */}
       <Modal
         title="黑板设置"
         open={settingsOpen}
@@ -217,46 +255,80 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
         okText="保存"
         confirmLoading={settingsSaving}
         destroyOnHidden
+        width={640}
       >
-        <Form layout="vertical">
-          <Form.Item label="防抖周期">
-            <InputNumber
-              value={debounceSecs}
-              onChange={(v) => setDebounceSecs(v ?? 600)}
-              min={10}
-              max={3600}
-              addonAfter="秒"
-              style={{ width: 200 }}
-            />
-          </Form.Item>
-          <Form.Item label="触发条数">
-            <InputNumber
-              value={debounceCount}
-              onChange={(v) => setDebounceCount(v ?? 10)}
-              min={1}
-              max={100}
-              addonAfter="条"
-              style={{ width: 200 }}
-            />
-          </Form.Item>
-          <Form.Item extra="达到条数阈值或周期到期时，统一处理 pending 的 todo，减少频繁的 LLM 调用" />
-          <Form.Item label="更新提示词">
-            <Input.TextArea
-              value={updatePrompt}
-              onChange={(e) => setUpdatePrompt(e.target.value)}
-              rows={4}
-              placeholder="包含占位符 {{current}}、{{conclusion}}、{{todo_id}}、{{todo_title}}，留空使用内置默认提示词"
-            />
-          </Form.Item>
-          <Form.Item label="刷新提示词">
-            <Input.TextArea
-              value={refreshPrompt}
-              onChange={(e) => setRefreshPrompt(e.target.value)}
-              rows={4}
-              placeholder="包含占位符 {{current}}，留空使用内置默认提示词"
-            />
-          </Form.Item>
-        </Form>
+        <Tabs
+          activeKey={activeTab}
+          onChange={(key) => setActiveTab(key as 'debounce' | 'prompt')}
+          items={[
+            {
+              key: 'debounce',
+              label: '防抖设置',
+              children: (
+                <Form layout="vertical" style={{ marginTop: 16 }}>
+                  <Form.Item label="防抖周期">
+                    <InputNumber
+                      value={debounceSecs}
+                      onChange={(v) => setDebounceSecs(v ?? 600)}
+                      min={10}
+                      max={3600}
+                      addonAfter="秒"
+                      style={{ width: 200 }}
+                    />
+                  </Form.Item>
+                  <Form.Item label="触发条数">
+                    <InputNumber
+                      value={debounceCount}
+                      onChange={(v) => setDebounceCount(v ?? 10)}
+                      min={1}
+                      max={100}
+                      addonAfter="条"
+                      style={{ width: 200 }}
+                    />
+                  </Form.Item>
+                  <Form.Item extra="达到条数阈值或周期到期时，统一处理 pending 的 todo，减少频繁的 LLM 调用" />
+                </Form>
+              ),
+            },
+            {
+              key: 'prompt',
+              label: '提示词设置',
+              children: (
+                <div style={{ marginTop: 16 }}>
+                  <Space style={{ marginBottom: 12 }}>
+                    <Button onClick={handleRestoreDefaultPrompt}>恢复默认</Button>
+                    <span style={{ color: '#888', fontSize: 12 }}>
+                      恢复默认后，将使用内置提示词模板
+                    </span>
+                  </Space>
+                  <Input.TextArea
+                    value={updatePrompt}
+                    onChange={(e) => setUpdatePrompt(e.target.value)}
+                    rows={12}
+                    placeholder="当前使用默认提示词（下方展示），如需自定义请在此输入"
+                  />
+                  {/* updatePrompt 为空时，隐性表示"使用默认"，此时在下方展示默认提示词供参照 */}
+                  {!updatePrompt && (
+                    <div
+                      style={{
+                        marginTop: 12,
+                        padding: '12px',
+                        background: '#f5f5f5',
+                        borderRadius: 6,
+                        fontSize: 12,
+                        color: '#666',
+                        whiteSpace: 'pre-wrap',
+                      }}
+                    >
+                      <div style={{ fontWeight: 500, marginBottom: 8, color: '#333' }}>默认提示词（当前生效）：</div>
+                      {DEFAULT_BLACKBOARD_UPDATE_PROMPT}
+                    </div>
+                  )}
+                </div>
+              ),
+            },
+          ]}
+        />
       </Modal>
     </div>
   );

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { Button, Typography, Skeleton, message, Modal, Form, InputNumber, Space, Progress } from 'antd';
+import { Button, Typography, Skeleton, message, Modal, Form, InputNumber, Space, Progress, Input } from 'antd';
 import { ReloadOutlined, SettingOutlined } from '@ant-design/icons';
 import { XMarkdown } from '@ant-design/x-markdown';
 import { useTheme } from '@/hooks/useTheme';
@@ -141,6 +141,8 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
   const [settingsSaving, setSettingsSaving] = useState(false);
   const [debounceSecs, setDebounceSecs] = useState<number>(600);
   const [debounceCount, setDebounceCount] = useState<number>(10);
+  const [updatePrompt, setUpdatePrompt] = useState<string>('');
+  const [refreshPrompt, setRefreshPrompt] = useState<string>('');
 
   // 打开设置弹窗：先拉取最新 config，等拉完再打开 modal，避免默认值闪烁
   const handleOpenSettings = useCallback(async () => {
@@ -148,9 +150,13 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
       const cfg = await db.getConfig();
       setDebounceSecs(cfg.blackboard_debounce_secs ?? 600);
       setDebounceCount(cfg.blackboard_debounce_count ?? 10);
+      setUpdatePrompt(cfg.blackboard_update_prompt ?? '');
+      setRefreshPrompt(cfg.blackboard_refresh_prompt ?? '');
     } catch {
       setDebounceSecs(600);
       setDebounceCount(10);
+      setUpdatePrompt('');
+      setRefreshPrompt('');
     }
     setSettingsOpen(true);
   }, []);
@@ -160,7 +166,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
     setSettingsSaving(true);
     try {
       const current = await db.getConfig();
-      await db.updateConfig({ ...current, blackboard_debounce_secs: debounceSecs, blackboard_debounce_count: debounceCount });
+      await db.updateConfig({ ...current, blackboard_debounce_secs: debounceSecs, blackboard_debounce_count: debounceCount, blackboard_update_prompt: updatePrompt, blackboard_refresh_prompt: refreshPrompt });
       message.success('设置已保存');
       setSettingsOpen(false);
     } catch (err) {
@@ -168,7 +174,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
     } finally {
       setSettingsSaving(false);
     }
-  }, [debounceSecs, debounceCount]);
+  }, [debounceSecs, debounceCount, updatePrompt, refreshPrompt]);
 
   // 拉取（受 workspaceId 变化驱动）：useCallback 稳定引用，让 useEffect 只在 id 变时重跑
   const fetchData = useCallback(async () => {
@@ -234,6 +240,22 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
             />
           </Form.Item>
           <Form.Item extra="达到条数阈值或周期到期时，统一处理 pending 的 todo，减少频繁的 LLM 调用" />
+          <Form.Item label="更新提示词">
+            <Input.TextArea
+              value={updatePrompt}
+              onChange={(e) => setUpdatePrompt(e.target.value)}
+              rows={4}
+              placeholder="包含占位符 {{current}}、{{conclusion}}、{{todo_id}}、{{todo_title}}，留空使用内置默认提示词"
+            />
+          </Form.Item>
+          <Form.Item label="刷新提示词">
+            <Input.TextArea
+              value={refreshPrompt}
+              onChange={(e) => setRefreshPrompt(e.target.value)}
+              rows={4}
+              placeholder="包含占位符 {{current}}，留空使用内置默认提示词"
+            />
+          </Form.Item>
         </Form>
       </Modal>
     </div>

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -209,9 +209,9 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
     }
   }, [debounceSecs, debounceCount, updatePrompt]);
 
-  // 恢复默认提示词：把 updatePrompt 清空（空字符串表示使用后端内置默认）
+  // 恢复默认提示词：把 updatePrompt 设为后端内置的默认提示词内容
   const handleRestoreDefaultPrompt = useCallback(() => {
-    setUpdatePrompt('');
+    setUpdatePrompt(DEFAULT_BLACKBOARD_UPDATE_PROMPT);
   }, []);
 
   // 拉取（受 workspaceId 变化驱动）：useCallback 稳定引用，让 useEffect 只在 id 变时重跑
@@ -298,32 +298,15 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
                   <Space style={{ marginBottom: 12 }}>
                     <Button onClick={handleRestoreDefaultPrompt}>恢复默认</Button>
                     <span style={{ color: '#888', fontSize: 12 }}>
-                      恢复默认后，将使用内置提示词模板
+                      点击将内置默认提示词填入输入框，可继续编辑
                     </span>
                   </Space>
                   <Input.TextArea
                     value={updatePrompt}
                     onChange={(e) => setUpdatePrompt(e.target.value)}
-                    rows={12}
-                    placeholder="当前使用默认提示词（下方展示），如需自定义请在此输入"
+                    rows={16}
+                    placeholder="留空使用内置默认提示词，如需自定义请直接在此输入"
                   />
-                  {/* updatePrompt 为空时，隐性表示"使用默认"，此时在下方展示默认提示词供参照 */}
-                  {!updatePrompt && (
-                    <div
-                      style={{
-                        marginTop: 12,
-                        padding: '12px',
-                        background: '#f5f5f5',
-                        borderRadius: 6,
-                        fontSize: 12,
-                        color: '#666',
-                        whiteSpace: 'pre-wrap',
-                      }}
-                    >
-                      <div style={{ fontWeight: 500, marginBottom: 8, color: '#333' }}>默认提示词（当前生效）：</div>
-                      {DEFAULT_BLACKBOARD_UPDATE_PROMPT}
-                    </div>
-                  )}
                 </div>
               ),
             },

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -178,7 +178,11 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
   const [updatePrompt, setUpdatePrompt] = useState<string>('');
   const [activeTab, setActiveTab] = useState<'debounce' | 'prompt'>('debounce');
 
-  // 打开设置弹窗：先拉取最新 config，等拉完再打开 modal，避免默认值闪烁
+  /**
+   * 打开设置弹窗：先拉取最新 config，等拉完再打开 modal，避免默认值闪烁。
+   * 加载失败时使用空字符串作为 updatePrompt 的兜底——空字符串会触发"使用内置默认"的业务逻辑，
+   * 不使用 DEFAULT_BLACKBOARD_UPDATE_PROMPT 作为兜底，是为了避免把后端常量耦合进前端状态初始化。
+   */
   const handleOpenSettings = useCallback(async () => {
     try {
       const cfg = await db.getConfig();
@@ -209,7 +213,11 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
     }
   }, [debounceSecs, debounceCount, updatePrompt]);
 
-  // 恢复默认提示词：把 updatePrompt 设为后端内置的默认提示词内容
+  /**
+   * 恢复默认提示词：把 updatePrompt 设为 DEFAULT_BLACKBOARD_UPDATE_PROMPT（与后端内置一致）。
+   * 写入后端后，backend blackboard_update_prompt 为非空字符串，不再走 build_blackboard_prompt() 内置逻辑。
+   * 区别于"留空"的语义——留空表示后端使用内置默认；填入默认值表示用户显式采用内置模板。
+   */
   const handleRestoreDefaultPrompt = useCallback(() => {
     setUpdatePrompt(DEFAULT_BLACKBOARD_UPDATE_PROMPT);
   }, []);
@@ -265,54 +273,92 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
               key: 'debounce',
               label: '防抖设置',
               children: (
-                <Form layout="vertical" style={{ marginTop: 16 }}>
-                  <Form.Item label="防抖周期">
-                    <InputNumber
-                      value={debounceSecs}
-                      onChange={(v) => setDebounceSecs(v ?? 600)}
-                      min={10}
-                      max={3600}
-                      addonAfter="秒"
-                      style={{ width: 200 }}
-                    />
-                  </Form.Item>
-                  <Form.Item label="触发条数">
-                    <InputNumber
-                      value={debounceCount}
-                      onChange={(v) => setDebounceCount(v ?? 10)}
-                      min={1}
-                      max={100}
-                      addonAfter="条"
-                      style={{ width: 200 }}
-                    />
-                  </Form.Item>
-                  <Form.Item extra="达到条数阈值或周期到期时，统一处理 pending 的 todo，减少频繁的 LLM 调用" />
-                </Form>
+                <DebounceSettingsTab
+                  debounceSecs={debounceSecs}
+                  setDebounceSecs={setDebounceSecs}
+                  debounceCount={debounceCount}
+                  setDebounceCount={setDebounceCount}
+                />
               ),
             },
             {
               key: 'prompt',
               label: '提示词设置',
               children: (
-                <div style={{ marginTop: 16 }}>
-                  <Space style={{ marginBottom: 12 }}>
-                    <Button onClick={handleRestoreDefaultPrompt}>恢复默认</Button>
-                    <span style={{ color: '#888', fontSize: 12 }}>
-                      点击将内置默认提示词填入输入框，可继续编辑
-                    </span>
-                  </Space>
-                  <Input.TextArea
-                    value={updatePrompt}
-                    onChange={(e) => setUpdatePrompt(e.target.value)}
-                    rows={16}
-                    placeholder="留空使用内置默认提示词，如需自定义请直接在此输入"
-                  />
-                </div>
+                <PromptSettingsTab
+                  updatePrompt={updatePrompt}
+                  setUpdatePrompt={setUpdatePrompt}
+                  onRestoreDefault={handleRestoreDefaultPrompt}
+                />
               ),
             },
           ]}
         />
       </Modal>
+    </div>
+  );
+}
+
+// ─── 设置弹窗子组件（避免 Tabs children 深层嵌套）─────────────────
+
+interface DebounceSettingsTabProps {
+  debounceSecs: number;
+  setDebounceSecs: (v: number) => void;
+  debounceCount: number;
+  setDebounceCount: (v: number) => void;
+}
+
+/** 防抖设置 Tab：防抖周期 + 触发条数，受父组件状态控制 */
+function DebounceSettingsTab({ debounceSecs, setDebounceSecs, debounceCount, setDebounceCount }: DebounceSettingsTabProps) {
+  return (
+    <Form layout="vertical" style={{ marginTop: 16 }}>
+      <Form.Item label="防抖周期">
+        <InputNumber
+          value={debounceSecs}
+          onChange={(v) => setDebounceSecs(v ?? 600)}
+          min={10}
+          max={3600}
+          addonAfter="秒"
+          style={{ width: 200 }}
+        />
+      </Form.Item>
+      <Form.Item label="触发条数">
+        <InputNumber
+          value={debounceCount}
+          onChange={(v) => setDebounceCount(v ?? 10)}
+          min={1}
+          max={100}
+          addonAfter="条"
+          style={{ width: 200 }}
+        />
+      </Form.Item>
+      <Form.Item extra="达到条数阈值或周期到期时，统一处理 pending 的 todo，减少频繁的 LLM 调用" />
+    </Form>
+  );
+}
+
+interface PromptSettingsTabProps {
+  updatePrompt: string;
+  setUpdatePrompt: (v: string) => void;
+  onRestoreDefault: () => void;
+}
+
+/** 提示词设置 Tab：TextArea 输入自定义提示词 + 恢复默认按钮 */
+function PromptSettingsTab({ updatePrompt, setUpdatePrompt, onRestoreDefault }: PromptSettingsTabProps) {
+  return (
+    <div style={{ marginTop: 16 }}>
+      <Space style={{ marginBottom: 12 }}>
+        <Button onClick={onRestoreDefault}>恢复默认</Button>
+        <span style={{ color: '#888', fontSize: 12 }}>
+          点击将内置默认提示词填入输入框，可继续编辑
+        </span>
+      </Space>
+      <Input.TextArea
+        value={updatePrompt}
+        onChange={(e) => setUpdatePrompt(e.target.value)}
+        rows={16}
+        placeholder="留空使用内置默认提示词，如需自定义请直接在此输入"
+      />
     </div>
   );
 }

--- a/frontend/src/types/config.tsx
+++ b/frontend/src/types/config.tsx
@@ -21,6 +21,10 @@ export interface Config {
   blackboard_debounce_secs?: number;
   /** 黑板更新防抖条数阈值，达到此条数立即触发 */
   blackboard_debounce_count?: number;
+  /** 黑板更新提示词模板（包含占位符 {{current}}、{{conclusion}}、{{todo_id}}、{{todo_title}}）*/
+  blackboard_update_prompt?: string;
+  /** 黑板刷新提示词模板（仅包含占位符 {{current}}）*/
+  blackboard_refresh_prompt?: string;
 }
 
 export interface ExecutorConfig {

--- a/frontend/src/types/config.tsx
+++ b/frontend/src/types/config.tsx
@@ -23,8 +23,6 @@ export interface Config {
   blackboard_debounce_count?: number;
   /** 黑板更新提示词模板（包含占位符 {{current}}、{{conclusion}}、{{todo_id}}、{{todo_title}}）*/
   blackboard_update_prompt?: string;
-  /** 黑板刷新提示词模板（仅包含占位符 {{current}}）*/
-  blackboard_refresh_prompt?: string;
 }
 
 export interface ExecutorConfig {

--- a/frontend/tests/check_blackboard_settings.spec.ts
+++ b/frontend/tests/check_blackboard_settings.spec.ts
@@ -3,7 +3,7 @@
  * 1. 直接导航到黑板页面
  * 2. 点击设置按钮能打开弹窗
  * 3. 防抖周期和触发条数 InputNumber 正常显示和修改
- * 4. 更新/刷新提示词 TextArea 正常显示和修改
+ * 4. 切换到提示词设置 Tab，验证 TextArea 和恢复默认按钮
  * 5. 保存后弹窗关闭并提示成功
  */
 import { test, expect } from '@playwright/test';
@@ -23,7 +23,7 @@ test('黑板设置弹窗能正常打开和保存', async ({ page }) => {
   // 弹窗应该出现
   await expect(page.locator('.ant-modal')).toBeVisible({ timeout: 5000 });
 
-  // 防抖输入框应该可见
+  // 防抖输入框应该可见（默认在防抖设置 Tab）
   const input = page.locator('.ant-input-number-input').first();
   await expect(input).toBeVisible();
 
@@ -31,17 +31,20 @@ test('黑板设置弹窗能正常打开和保存', async ({ page }) => {
   await input.fill('300');
   await input.blur();
 
+  // 切换到提示词设置 Tab
+  await page.click('.ant-tabs-tab:has-text("提示词设置")');
+
   // 更新提示词 TextArea 应该可见
   const updatePromptArea = page.locator('textarea').first();
   await expect(updatePromptArea).toBeVisible();
-  await updatePromptArea.fill('自定义更新提示词 {{current}}');
-  await updatePromptArea.blur();
 
-  // 刷新提示词 TextArea 应该可见
-  const refreshPromptArea = page.locator('textarea').nth(1);
-  await expect(refreshPromptArea).toBeVisible();
-  await refreshPromptArea.fill('自定义刷新提示词 {{current}}');
-  await refreshPromptArea.blur();
+  // 点击恢复默认按钮
+  const restoreBtn = page.locator('button:has-text("恢复默认")');
+  await expect(restoreBtn).toBeVisible();
+  await restoreBtn.click();
+
+  // 输入框应被填入默认提示词内容
+  await expect(updatePromptArea).not.toHaveValue('');
 
   // 等待一下让表单更新
   await page.waitForTimeout(500);

--- a/frontend/tests/check_blackboard_settings.spec.ts
+++ b/frontend/tests/check_blackboard_settings.spec.ts
@@ -3,7 +3,8 @@
  * 1. 直接导航到黑板页面
  * 2. 点击设置按钮能打开弹窗
  * 3. 防抖周期和触发条数 InputNumber 正常显示和修改
- * 4. 保存后弹窗关闭并提示成功
+ * 4. 更新/刷新提示词 TextArea 正常显示和修改
+ * 5. 保存后弹窗关闭并提示成功
  */
 import { test, expect } from '@playwright/test';
 
@@ -29,6 +30,18 @@ test('黑板设置弹窗能正常打开和保存', async ({ page }) => {
   // 修改防抖时间为 300
   await input.fill('300');
   await input.blur();
+
+  // 更新提示词 TextArea 应该可见
+  const updatePromptArea = page.locator('textarea').first();
+  await expect(updatePromptArea).toBeVisible();
+  await updatePromptArea.fill('自定义更新提示词 {{current}}');
+  await updatePromptArea.blur();
+
+  // 刷新提示词 TextArea 应该可见
+  const refreshPromptArea = page.locator('textarea').nth(1);
+  await expect(refreshPromptArea).toBeVisible();
+  await refreshPromptArea.fill('自定义刷新提示词 {{current}}');
+  await refreshPromptArea.blur();
 
   // 等待一下让表单更新
   await page.waitForTimeout(500);


### PR DESCRIPTION
## 改动内容

将黑板更新提示词配置从配置文件移到黑板页面的设置弹窗中，支持界面操作。

### 功能点
- 黑板设置弹窗改为 Tab 布局：**防抖设置** | **提示词设置**
- 提示词设置 Tab：TextArea 输入自定义提示词，留空使用内置默认
- 新增**恢复默认**按钮，点击将后端内置提示词填入输入框，可继续编辑
- 删除刷新提示词（刷新按钮已改为页面 reload，不再调用 LLM）

### 修改文件
-  - 新增  字段
-  - Tab 布局 + 提示词输入 + 恢复默认按钮
-  - 更新测试适配 Tab 结构