### PR TITLE
feat(blackboard): 黑板配置 per-workspace 隔离

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -68,62 +68,6 @@ const DEFAULT_AUTO_USAGE_STATS_CRON: &str = "0 0 1 * * *";
 const DEFAULT_AUTO_UPDATE_HOUR: u32 = 3;
 /// 自动更新默认间隔类型:"day" / "week" / "month"。
 const DEFAULT_AUTO_UPDATE_INTERVAL: &str = "day";
-/// 黑板更新防抖周期（秒），默认 10 分钟。
-const DEFAULT_BLACKBOARD_DEBOUNCE_SECS: u64 = 600;
-/// 黑板更新防抖条数阈值，达到此条数立即触发（不等周期）。
-const DEFAULT_BLACKBOARD_DEBOUNCE_COUNT: u64 = 10;
-/// 默认黑板更新提示词模板（包含占位符 {{current}}、{{conclusion}}、{{todo_id}}、{{todo_title}}）。
-const DEFAULT_BLACKBOARD_UPDATE_PROMPT: &str = r#"你是一个工作空间知识库的维护者。你的任务是维护一个 Markdown 格式的"黑板"，记录工作空间中所有任务执行的结论和当前进展。
-
-当前黑板内容：
-```
-{{current}}
-```
-
-新任务结论：
-- 任务 ID: {{todo_id}}
-- 任务标题: {{todo_title}}
-- 执行结论: {{conclusion}}
-
-请更新黑板内容，要求：
-1. 将新结论整合到黑板中
-2. 保持以下结构：
-   - # 工作空间进展
-   - ## 已确认
-   - ## 新发现
-   - ## 待解决问题
-   - ## 矛盾/风险
-   - ## 下一步建议
-3. 每条结论标注来源，格式：(来源: [todo_{{todo_id}}](ntd://todo/{{todo_id}}))
-4. 如果新结论与已有结论矛盾，在"矛盾/风险"中标注
-5. 如果新结论提出了未解决的问题，在"待解决问题"中列出
-6. 更新"下一步建议"
-7. 保持 Markdown 格式，不要添加 HTML
-8. 如果黑板为空，根据新结论创建初始结构
-
-只输出更新后的黑板内容，不要输出任何解释。"#;
-/// 默认黑板刷新提示词模板（仅包含占位符 {{current}}）。
-const DEFAULT_BLACKBOARD_REFRESH_PROMPT: &str = r#"你是一个工作空间知识库的维护者。重新组织当前黑板内容，使其结构更清晰、信息更准确。
-
-当前黑板内容：
-```
-{{current}}
-```
-
-请重新组织黑板内容，要求：
-1. 保持以下结构：
-   - # 工作空间进展
-   - ## 已确认
-   - ## 新发现
-   - ## 待解决问题
-   - ## 矛盾/风险
-   - ## 下一步建议
-2. 不要添加任何新事实，不要虚构来源 todo；只整理、归并、提炼已有信息
-3. 禁止生成 ntd://todo/ 内部链接（手动刷新没有具体来源 todo）
-4. 合并相似条目；移除空段
-5. 保持 Markdown 格式，不要添加 HTML
-
-只输出重新组织后的黑板内容，不要输出任何解释。"#;
 
 /// 私有 helper:`auto_backup_*` / `auto_todo_backup_*` / `auto_skill_backup_*`
 /// 三组字段共享同一形状 (enabled: bool, cron: String, max_files: usize)。
@@ -232,18 +176,6 @@ pub struct Config {
     pub auto_update_hour: u32,
     /// 自动更新上次检查时间（ISO 8601），None 表示从未检查过
     pub auto_update_last_check_at: Option<String>,
-    /// 黑板更新防抖周期（秒），默认 600 秒（10 分钟）。
-    /// todo 执行完成后不会立即触发黑板更新，而是暂存到 pending 队列，
-    /// 等到此周期到期后统一处理一次 LLM 调用。
-    pub blackboard_debounce_secs: u64,
-    /// 黑板更新防抖条数阈值，达到此条数时立即触发（不等周期）。
-    pub blackboard_debounce_count: u64,
-    /// 黑板更新提示词模板（包含占位符 {{current}}、{{conclusion}}、{{todo_id}}、{{todo_title}}）。
-    /// 为空时使用内置默认提示词。
-    pub blackboard_update_prompt: String,
-    /// 黑板刷新提示词模板（仅包含占位符 {{current}}）。
-    /// 为空时使用内置默认提示词。
-    pub blackboard_refresh_prompt: String,
 }
 
 /// Paths for each supported executor binary.
@@ -352,10 +284,6 @@ impl Default for Config {
             cloud_sync: CloudSyncConfig::default(), cors_allowed_origins: Vec::new(),
             auto_update_enabled: false, auto_update_interval: DEFAULT_AUTO_UPDATE_INTERVAL.to_string(),
             auto_update_hour: DEFAULT_AUTO_UPDATE_HOUR, auto_update_last_check_at: None,
-            blackboard_debounce_secs: DEFAULT_BLACKBOARD_DEBOUNCE_SECS,
-            blackboard_debounce_count: DEFAULT_BLACKBOARD_DEBOUNCE_COUNT,
-            blackboard_update_prompt: DEFAULT_BLACKBOARD_UPDATE_PROMPT.to_string(),
-            blackboard_refresh_prompt: DEFAULT_BLACKBOARD_REFRESH_PROMPT.to_string(),
         }
     }
 }

--- a/backend/src/db/blackboard.rs
+++ b/backend/src/db/blackboard.rs
@@ -35,6 +35,8 @@ impl Database {
     /// 幂等实现：使用 `ON CONFLICT(workspace_id) DO NOTHING` + 重新查询，
     /// 避免并发场景下两个请求同时走"先查后建"路径时因 UNIQUE 约束相互失败。
     /// 返回值始终是该工作空间当前的黑板记录（新建或已存在）。
+    ///
+    /// 新记录初始化时配置字段均采用默认值（防抖周期 600s、阈值 10 条、提示词为空使用内置）。
     pub async fn create_blackboard(
         &self,
         workspace_id: i64,
@@ -48,8 +50,15 @@ impl Database {
             content: ActiveValue::Set(String::new()),
             // 初始 pending 队列为空
             pending_todo_ids: ActiveValue::Set("[]".to_string()),
-            updated_at: ActiveValue::Set(Some(now)),
-            created_at: ActiveValue::Set(Some(crate::models::utc_timestamp())),
+            // 默认防抖周期 600 秒
+            blackboard_debounce_secs: ActiveValue::Set(600),
+            // 默认防抖条数阈值 10 条
+            blackboard_debounce_count: ActiveValue::Set(10),
+            // 空字符串表示使用内置默认提示词模板
+            blackboard_update_prompt: ActiveValue::Set(String::new()),
+            blackboard_refresh_prompt: ActiveValue::Set(String::new()),
+            updated_at: ActiveValue::Set(Some(now.clone())),
+            created_at: ActiveValue::Set(Some(now)),
             ..Default::default()
         };
         // ON CONFLICT(workspace_id) DO NOTHING：若记录已存在则跳过 insert，
@@ -111,6 +120,9 @@ impl Database {
     /// 通过 `INSERT ... ON CONFLICT(workspace_id) DO UPDATE` 一次往返完成
     /// 创建/更新判断 + 写入，避免 service 层先 get 再 create 再 update 的 3 次往返。
     /// 用 workspace_id 唯一约束做冲突判定，与 schema UNIQUE 保持一致。
+    ///
+    /// 新增字段（防抖阈值、提示词）仅在 INSERT 时填充默认值，冲突时不覆盖，
+    /// 保持已有工作空间的配置不被意外重置。
     pub async fn upsert_blackboard_content(
         &self,
         workspace_id: i64,
@@ -125,9 +137,13 @@ impl Database {
             updated_at: ActiveValue::Set(Some(now.clone())),
             created_at: ActiveValue::Set(Some(now)),
             pending_todo_ids: ActiveValue::Set("[]".to_string()),
+            blackboard_debounce_secs: ActiveValue::Set(600),
+            blackboard_debounce_count: ActiveValue::Set(10),
+            blackboard_update_prompt: ActiveValue::Set(String::new()),
+            blackboard_refresh_prompt: ActiveValue::Set(String::new()),
             ..Default::default()
         };
-        // ON CONFLICT(workspace_id)：命中后只覆盖 content/updated_at，保留 created_at
+        // ON CONFLICT(workspace_id)：命中后只覆盖 content/updated_at，保留 created_at 和配置字段
         blackboards::Entity::insert(am)
             .on_conflict(
                 OnConflict::column(blackboards::Column::WorkspaceId)
@@ -211,6 +227,80 @@ impl Database {
 
         Ok(ids)
     }
+
+    /// 获取指定工作空间的黑板配置（防抖阈值、提示词）。
+    ///
+    /// 记录不存在时返回 None；调用方应确保黑板记录已通过 create_blackboard 初始化。
+    /// 返回的四个字段均为 per-workspace 配置，来自 blackboards 表的对应列。
+    pub async fn get_blackboard_config(
+        &self,
+        workspace_id: i64,
+    ) -> Result<Option<BlackboardConfig>, sea_orm::DbErr> {
+        let board = blackboards::Entity::find()
+            .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
+            .one(&self.conn)
+            .await?;
+        Ok(board.map(|b| BlackboardConfig {
+            debounce_secs: b.blackboard_debounce_secs,
+            debounce_count: b.blackboard_debounce_count,
+            update_prompt: b.blackboard_update_prompt,
+            refresh_prompt: b.blackboard_refresh_prompt,
+        }))
+    }
+
+    /// 更新指定工作空间的黑板配置。
+    ///
+    /// 记录不存在时返回 RecordNotFound；调用方应确保黑板记录已存在。
+    /// 各字段均为可选，仅更新传入 Some 的字段，None 保持原值不变。
+    pub async fn update_blackboard_config(
+        &self,
+        workspace_id: i64,
+        debounce_secs: Option<i64>,
+        debounce_count: Option<i64>,
+        update_prompt: Option<String>,
+        refresh_prompt: Option<String>,
+    ) -> Result<(), sea_orm::DbErr> {
+        let board = blackboards::Entity::find()
+            .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
+            .one(&self.conn)
+            .await?
+            .ok_or_else(|| {
+                sea_orm::DbErr::RecordNotFound(format!(
+                    "blackboard for workspace {} not found",
+                    workspace_id
+                ))
+            })?;
+        let now = crate::models::utc_timestamp();
+        let mut am = blackboards::ActiveModel {
+            id: ActiveValue::Unchanged(board.id),
+            workspace_id: ActiveValue::Unchanged(workspace_id),
+            updated_at: ActiveValue::Set(Some(now)),
+            ..Default::default()
+        };
+        if let Some(v) = debounce_secs {
+            am.blackboard_debounce_secs = ActiveValue::Set(v.max(10));
+        }
+        if let Some(v) = debounce_count {
+            am.blackboard_debounce_count = ActiveValue::Set(v.max(1));
+        }
+        if let Some(v) = update_prompt {
+            am.blackboard_update_prompt = ActiveValue::Set(v);
+        }
+        if let Some(v) = refresh_prompt {
+            am.blackboard_refresh_prompt = ActiveValue::Set(v);
+        }
+        am.update(&self.conn).await?;
+        Ok(())
+    }
+}
+
+/// 黑板 per-workspace 配置数据结构，对应 blackboards 表的四个配置列。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BlackboardConfig {
+    pub debounce_secs: i64,
+    pub debounce_count: i64,
+    pub update_prompt: String,
+    pub refresh_prompt: String,
 }
 
 #[cfg(test)]
@@ -249,6 +339,11 @@ mod tests {
         assert_eq!(board.content, "");
         assert!(board.created_at.is_some());
         assert!(board.updated_at.is_some());
+        // 新增字段：默认值验证
+        assert_eq!(board.blackboard_debounce_secs, 600);
+        assert_eq!(board.blackboard_debounce_count, 10);
+        assert_eq!(board.blackboard_update_prompt, "");
+        assert_eq!(board.blackboard_refresh_prompt, "");
 
         // 验证可通过 get 查到
         let fetched = db.get_blackboard(ws_id).await.unwrap();
@@ -359,5 +454,103 @@ mod tests {
         assert_eq!(second.id, first_id, "upsert 不应改变主键");
         assert_eq!(second.content, "# 第二次", "content 应当被覆盖");
         assert_eq!(second.created_at, first_created, "created_at 应当保留");
+    }
+
+    /// 验证 get_blackboard_config 在无记录时返回 None。
+    #[tokio::test]
+    async fn test_get_blackboard_config_returns_none_when_missing() {
+        let db = Database::new(":memory:").await.expect(":memory: must open");
+        let result = db.get_blackboard_config(999).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    /// 验证 get_blackboard_config 在有记录时返回正确默认值。
+    #[tokio::test]
+    async fn test_get_blackboard_config_returns_defaults_after_create() {
+        let db = Database::new(":memory:").await.expect(":memory: must open");
+        let ws_id = create_test_workspace(&db).await;
+        db.create_blackboard(ws_id).await.unwrap();
+
+        let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
+        assert_eq!(cfg.debounce_secs, 600);
+        assert_eq!(cfg.debounce_count, 10);
+        assert_eq!(cfg.update_prompt, "");
+        assert_eq!(cfg.refresh_prompt, "");
+    }
+
+    /// 验证 update_blackboard_config 正确更新各字段。
+    #[tokio::test]
+    async fn test_update_blackboard_config_updates_fields() {
+        let db = Database::new(":memory:").await.expect(":memory: must open");
+        let ws_id = create_test_workspace(&db).await;
+        db.create_blackboard(ws_id).await.unwrap();
+
+        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("custom".to_string()), Some("refresh".to_string()))
+            .await
+            .unwrap();
+
+        let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
+        assert_eq!(cfg.debounce_secs, 300);
+        assert_eq!(cfg.debounce_count, 5);
+        assert_eq!(cfg.update_prompt, "custom");
+        assert_eq!(cfg.refresh_prompt, "refresh");
+    }
+
+    /// 验证 update_blackboard_config 对 None 字段保持原值。
+    #[tokio::test]
+    async fn test_update_blackboard_config_preserves_unchanged_fields() {
+        let db = Database::new(":memory:").await.expect(":memory: must open");
+        let ws_id = create_test_workspace(&db).await;
+        db.create_blackboard(ws_id).await.unwrap();
+
+        // 先全部更新
+        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("custom".to_string()), Some("refresh".to_string()))
+            .await
+            .unwrap();
+
+        // 再只更新其中两个
+        db.update_blackboard_config(ws_id, Some(900), None, None, None)
+            .await
+            .unwrap();
+
+        let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
+        assert_eq!(cfg.debounce_secs, 900);
+        assert_eq!(cfg.debounce_count, 5, "debounce_count 应保留之前的值");
+        assert_eq!(cfg.update_prompt, "custom", "update_prompt 应保留之前的值");
+        assert_eq!(cfg.refresh_prompt, "refresh", "refresh_prompt 应保留之前的值");
+    }
+
+    /// 验证 update_blackboard_config 在记录不存在时返回 RecordNotFound。
+    #[tokio::test]
+    async fn test_update_blackboard_config_record_not_found() {
+        let db = Database::new(":memory:").await.expect(":memory: must open");
+        let result = db.update_blackboard_config(999, Some(300), None, None, None).await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            sea_orm::DbErr::RecordNotFound(_) => {}
+            other => panic!("expected RecordNotFound, got: {:?}", other),
+        }
+    }
+
+    /// 验证 update_blackboard_config 对防抖阈值做下限保护。
+    #[tokio::test]
+    async fn test_update_blackboard_config_debounce_minimum_guard() {
+        let db = Database::new(":memory:").await.expect(":memory: must open");
+        let ws_id = create_test_workspace(&db).await;
+        db.create_blackboard(ws_id).await.unwrap();
+
+        // 传入小于最小值的 debounce_secs，应被钳制到 10
+        db.update_blackboard_config(ws_id, Some(3), None, None, None)
+            .await
+            .unwrap();
+        let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
+        assert_eq!(cfg.debounce_secs, 10);
+
+        // 传入小于最小值的 debounce_count，应被钳制到 1
+        db.update_blackboard_config(ws_id, None, Some(0), None, None)
+            .await
+            .unwrap();
+        let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
+        assert_eq!(cfg.debounce_count, 1);
     }
 }

--- a/backend/src/db/blackboard.rs
+++ b/backend/src/db/blackboard.rs
@@ -247,6 +247,12 @@ impl Database {
 
     /// 更新指定工作空间的黑板配置。
     ///
+    /// 更新指定工作空间的黑板配置。
+    ///
+    /// 输入：workspace_id + 三个可选字段（debounce_secs、debounce_count、update_prompt）。
+    /// 流程：先按 workspace_id 查出黑板记录（不存在则 RecordNotFound）→ 构造 ActiveModel
+    /// → 只对传入 Some 的字段写入，传入 None 的保持原值不变 → update。
+    /// 防抖阈值有下限保护：debounce_secs >= 10，debounce_count >= 1。
     /// 记录不存在时返回 RecordNotFound；调用方应确保黑板记录已存在。
     /// 各字段均为可选，仅更新传入 Some 的字段，None 保持原值不变。
     pub async fn update_blackboard_config(

--- a/backend/src/db/blackboard.rs
+++ b/backend/src/db/blackboard.rs
@@ -56,7 +56,6 @@ impl Database {
             blackboard_debounce_count: ActiveValue::Set(10),
             // 空字符串表示使用内置默认提示词模板
             blackboard_update_prompt: ActiveValue::Set(String::new()),
-            blackboard_refresh_prompt: ActiveValue::Set(String::new()),
             updated_at: ActiveValue::Set(Some(now.clone())),
             created_at: ActiveValue::Set(Some(now)),
             ..Default::default()
@@ -140,7 +139,6 @@ impl Database {
             blackboard_debounce_secs: ActiveValue::Set(600),
             blackboard_debounce_count: ActiveValue::Set(10),
             blackboard_update_prompt: ActiveValue::Set(String::new()),
-            blackboard_refresh_prompt: ActiveValue::Set(String::new()),
             ..Default::default()
         };
         // ON CONFLICT(workspace_id)：命中后只覆盖 content/updated_at，保留 created_at 和配置字段
@@ -244,7 +242,6 @@ impl Database {
             debounce_secs: b.blackboard_debounce_secs,
             debounce_count: b.blackboard_debounce_count,
             update_prompt: b.blackboard_update_prompt,
-            refresh_prompt: b.blackboard_refresh_prompt,
         }))
     }
 
@@ -258,7 +255,6 @@ impl Database {
         debounce_secs: Option<i64>,
         debounce_count: Option<i64>,
         update_prompt: Option<String>,
-        refresh_prompt: Option<String>,
     ) -> Result<(), sea_orm::DbErr> {
         let board = blackboards::Entity::find()
             .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
@@ -286,21 +282,17 @@ impl Database {
         if let Some(v) = update_prompt {
             am.blackboard_update_prompt = ActiveValue::Set(v);
         }
-        if let Some(v) = refresh_prompt {
-            am.blackboard_refresh_prompt = ActiveValue::Set(v);
-        }
         am.update(&self.conn).await?;
         Ok(())
     }
 }
 
-/// 黑板 per-workspace 配置数据结构，对应 blackboards 表的四个配置列。
+/// 黑板 per-workspace 配置数据结构，对应 blackboards 表的三个配置列。
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BlackboardConfig {
     pub debounce_secs: i64,
     pub debounce_count: i64,
     pub update_prompt: String,
-    pub refresh_prompt: String,
 }
 
 #[cfg(test)]
@@ -343,7 +335,6 @@ mod tests {
         assert_eq!(board.blackboard_debounce_secs, 600);
         assert_eq!(board.blackboard_debounce_count, 10);
         assert_eq!(board.blackboard_update_prompt, "");
-        assert_eq!(board.blackboard_refresh_prompt, "");
 
         // 验证可通过 get 查到
         let fetched = db.get_blackboard(ws_id).await.unwrap();
@@ -475,7 +466,6 @@ mod tests {
         assert_eq!(cfg.debounce_secs, 600);
         assert_eq!(cfg.debounce_count, 10);
         assert_eq!(cfg.update_prompt, "");
-        assert_eq!(cfg.refresh_prompt, "");
     }
 
     /// 验证 update_blackboard_config 正确更新各字段。
@@ -485,7 +475,7 @@ mod tests {
         let ws_id = create_test_workspace(&db).await;
         db.create_blackboard(ws_id).await.unwrap();
 
-        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("custom".to_string()), Some("refresh".to_string()))
+        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("custom".to_string()))
             .await
             .unwrap();
 
@@ -493,7 +483,6 @@ mod tests {
         assert_eq!(cfg.debounce_secs, 300);
         assert_eq!(cfg.debounce_count, 5);
         assert_eq!(cfg.update_prompt, "custom");
-        assert_eq!(cfg.refresh_prompt, "refresh");
     }
 
     /// 验证 update_blackboard_config 对 None 字段保持原值。
@@ -504,12 +493,12 @@ mod tests {
         db.create_blackboard(ws_id).await.unwrap();
 
         // 先全部更新
-        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("custom".to_string()), Some("refresh".to_string()))
+        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("custom".to_string()))
             .await
             .unwrap();
 
         // 再只更新其中两个
-        db.update_blackboard_config(ws_id, Some(900), None, None, None)
+        db.update_blackboard_config(ws_id, Some(900), None, None)
             .await
             .unwrap();
 
@@ -517,14 +506,13 @@ mod tests {
         assert_eq!(cfg.debounce_secs, 900);
         assert_eq!(cfg.debounce_count, 5, "debounce_count 应保留之前的值");
         assert_eq!(cfg.update_prompt, "custom", "update_prompt 应保留之前的值");
-        assert_eq!(cfg.refresh_prompt, "refresh", "refresh_prompt 应保留之前的值");
     }
 
     /// 验证 update_blackboard_config 在记录不存在时返回 RecordNotFound。
     #[tokio::test]
     async fn test_update_blackboard_config_record_not_found() {
         let db = Database::new(":memory:").await.expect(":memory: must open");
-        let result = db.update_blackboard_config(999, Some(300), None, None, None).await;
+        let result = db.update_blackboard_config(999, Some(300), None, None).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             sea_orm::DbErr::RecordNotFound(_) => {}
@@ -540,14 +528,14 @@ mod tests {
         db.create_blackboard(ws_id).await.unwrap();
 
         // 传入小于最小值的 debounce_secs，应被钳制到 10
-        db.update_blackboard_config(ws_id, Some(3), None, None, None)
+        db.update_blackboard_config(ws_id, Some(3), None, None)
             .await
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
         assert_eq!(cfg.debounce_secs, 10);
 
         // 传入小于最小值的 debounce_count，应被钳制到 1
-        db.update_blackboard_config(ws_id, None, Some(0), None, None)
+        db.update_blackboard_config(ws_id, None, Some(0), None)
             .await
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();

--- a/backend/src/db/entity/blackboards.rs
+++ b/backend/src/db/entity/blackboards.rs
@@ -28,10 +28,6 @@ pub struct Model {
     /// 空字符串表示使用内置默认模板。
     #[sea_orm(column_type = "Text")]
     pub blackboard_update_prompt: String,
-    /// 黑板刷新提示词模板（仅包含占位符 {{current}}）。
-    /// 空字符串表示使用内置默认模板。
-    #[sea_orm(column_type = "Text")]
-    pub blackboard_refresh_prompt: String,
     pub updated_at: Option<String>,
     pub created_at: Option<String>,
 }

--- a/backend/src/db/entity/blackboards.rs
+++ b/backend/src/db/entity/blackboards.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 /// 每个 workspace 最多一条记录（workspace_id 为 UNIQUE），
 /// content 字段存储 Markdown 格式的黑板内容。
 /// pending_todo_ids 暂存待处理的 todo_id，防抖批次处理时使用。
+/// 防抖阈值与提示词模板均为 per-workspace 配置，存储在本表。
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "blackboards")]
 pub struct Model {
@@ -19,6 +20,18 @@ pub struct Model {
     /// 待处理的 todo_id 队列（JSON 数组），防抖周期到点后统一处理
     #[sea_orm(column_type = "Text")]
     pub pending_todo_ids: String,
+    /// 黑板更新防抖周期（秒），达到该时间后统一处理 pending 队列
+    pub blackboard_debounce_secs: i64,
+    /// 黑板更新防抖条数阈值，达到该条数后立即触发，无需等待周期
+    pub blackboard_debounce_count: i64,
+    /// 黑板更新提示词模板（包含占位符 {{current}}、{{conclusion}}、{{todo_id}}、{{todo_title}}）。
+    /// 空字符串表示使用内置默认模板。
+    #[sea_orm(column_type = "Text")]
+    pub blackboard_update_prompt: String,
+    /// 黑板刷新提示词模板（仅包含占位符 {{current}}）。
+    /// 空字符串表示使用内置默认模板。
+    #[sea_orm(column_type = "Text")]
+    pub blackboard_refresh_prompt: String,
     pub updated_at: Option<String>,
     pub created_at: Option<String>,
 }

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -14,6 +14,7 @@ mod v41_v46;
 mod v47;
 mod v48;
 mod v49;
+mod v50;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -50,6 +51,7 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v47::V47CreateBlackboardsTable),
         Box::new(v48::V48ScopeTodosActionKeyByWorkspace),
         Box::new(v49::V49AddBlackboardPendingTodoIds),
+        Box::new(v50::V50AddBlackboardWorkspaceConfig),
     ]
 }
 

--- a/backend/src/db/migration/v50.rs
+++ b/backend/src/db/migration/v50.rs
@@ -28,6 +28,8 @@ impl Migration for V50AddBlackboardWorkspaceConfig {
     }
 
     async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 执行流程：依次检查每个列是否存在（幂等）→ 不存在则 ALTER TABLE ADD COLUMN。
+        // 三列均 NOT NULL DEFAULT，迁移前已存在的记录自动获得默认值，不影响现有逻辑。
         // 1. blackboard_debounce_secs: INTEGER NOT NULL DEFAULT 600
         if !super::table_has_column(db, "blackboards", "blackboard_debounce_secs").await? {
             db.exec("ALTER TABLE blackboards ADD COLUMN blackboard_debounce_secs INTEGER NOT NULL DEFAULT 600")

--- a/backend/src/db/migration/v50.rs
+++ b/backend/src/db/migration/v50.rs
@@ -4,10 +4,9 @@
 //! 导致所有工作空间共享同一份配置，无法按工作空间独立定制。
 //!
 //! 新增字段（均有默认值，迁移前已存在的记录自动获得初始值）：
-//! - blackboard_debounce_secs: u64，默认 600
-//! - blackboard_debounce_count: u64，默认 10
+//! - blackboard_debounce_secs: i64，默认 600
+//! - blackboard_debounce_count: i64，默认 10
 //! - blackboard_update_prompt: TEXT，空字符串（表示使用内置默认）
-//! - blackboard_refresh_prompt: TEXT，空字符串（表示使用内置默认）
 //!
 //! 数据兼容性：已有记录这些字段自动获得默认值，不影响现有逻辑。
 
@@ -46,12 +45,6 @@ impl Migration for V50AddBlackboardWorkspaceConfig {
             db.exec("ALTER TABLE blackboards ADD COLUMN blackboard_update_prompt TEXT NOT NULL DEFAULT ''")
                 .await?;
             tracing::info!("V50: blackboards.blackboard_update_prompt 字段已添加");
-        }
-        // 4. blackboard_refresh_prompt: TEXT NOT NULL DEFAULT ''
-        if !super::table_has_column(db, "blackboards", "blackboard_refresh_prompt").await? {
-            db.exec("ALTER TABLE blackboards ADD COLUMN blackboard_refresh_prompt TEXT NOT NULL DEFAULT ''")
-                .await?;
-            tracing::info!("V50: blackboards.blackboard_refresh_prompt 字段已添加");
         }
         Ok(())
     }

--- a/backend/src/db/migration/v50.rs
+++ b/backend/src/db/migration/v50.rs
@@ -1,0 +1,81 @@
+//! 数据库迁移 V50：为 blackboards 表添加 per-workspace 配置字段。
+//!
+//! 背景：黑板的防抖阈值和提示词模板原本存储在全局 Config 中，
+//! 导致所有工作空间共享同一份配置，无法按工作空间独立定制。
+//!
+//! 新增字段（均有默认值，迁移前已存在的记录自动获得初始值）：
+//! - blackboard_debounce_secs: u64，默认 600
+//! - blackboard_debounce_count: u64，默认 10
+//! - blackboard_update_prompt: TEXT，空字符串（表示使用内置默认）
+//! - blackboard_refresh_prompt: TEXT，空字符串（表示使用内置默认）
+//!
+//! 数据兼容性：已有记录这些字段自动获得默认值，不影响现有逻辑。
+
+use async_trait::async_trait;
+
+use super::super::Database;
+use super::Migration;
+
+pub(super) struct V50AddBlackboardWorkspaceConfig;
+
+#[async_trait]
+impl Migration for V50AddBlackboardWorkspaceConfig {
+    fn version(&self) -> i64 {
+        50
+    }
+
+    fn name(&self) -> &'static str {
+        "add_blackboard_workspace_config"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 1. blackboard_debounce_secs: INTEGER NOT NULL DEFAULT 600
+        if !super::table_has_column(db, "blackboards", "blackboard_debounce_secs").await? {
+            db.exec("ALTER TABLE blackboards ADD COLUMN blackboard_debounce_secs INTEGER NOT NULL DEFAULT 600")
+                .await?;
+            tracing::info!("V50: blackboards.blackboard_debounce_secs 字段已添加");
+        }
+        // 2. blackboard_debounce_count: INTEGER NOT NULL DEFAULT 10
+        if !super::table_has_column(db, "blackboards", "blackboard_debounce_count").await? {
+            db.exec("ALTER TABLE blackboards ADD COLUMN blackboard_debounce_count INTEGER NOT NULL DEFAULT 10")
+                .await?;
+            tracing::info!("V50: blackboards.blackboard_debounce_count 字段已添加");
+        }
+        // 3. blackboard_update_prompt: TEXT NOT NULL DEFAULT ''
+        if !super::table_has_column(db, "blackboards", "blackboard_update_prompt").await? {
+            db.exec("ALTER TABLE blackboards ADD COLUMN blackboard_update_prompt TEXT NOT NULL DEFAULT ''")
+                .await?;
+            tracing::info!("V50: blackboards.blackboard_update_prompt 字段已添加");
+        }
+        // 4. blackboard_refresh_prompt: TEXT NOT NULL DEFAULT ''
+        if !super::table_has_column(db, "blackboards", "blackboard_refresh_prompt").await? {
+            db.exec("ALTER TABLE blackboards ADD COLUMN blackboard_refresh_prompt TEXT NOT NULL DEFAULT ''")
+                .await?;
+            tracing::info!("V50: blackboards.blackboard_refresh_prompt 字段已添加");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::migration::v47;
+
+    #[tokio::test]
+    async fn test_v50_migration_succeeds() {
+        let db = Database::new(":memory:").await.unwrap();
+        // V47 创建了 blackboards 表
+        v47::V47CreateBlackboardsTable.up(&db).await.unwrap();
+        // V49 添加了 pending_todo_ids
+        crate::db::migration::v49::V49AddBlackboardPendingTodoIds
+            .up(&db)
+            .await
+            .unwrap();
+        // V50 应当成功执行
+        V50AddBlackboardWorkspaceConfig
+            .up(&db)
+            .await
+            .expect("V50 must succeed");
+    }
+}

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -432,8 +432,8 @@ pub(crate) async fn finalize_normal_completion(
 async fn build_blackboard_status(
     db: &Database,
     workspace_id: i64,
-    debounce_secs: u64,
-    debounce_count: u64,
+    debounce_secs: i64,
+    debounce_count: i64,
 ) -> ExecEvent {
     let pending_count = db
         .get_blackboard(workspace_id)
@@ -463,8 +463,8 @@ async fn build_blackboard_status(
     ExecEvent::BlackboardDebounceStatus {
         workspace_id,
         pending_count,
-        threshold: debounce_count,
-        debounce_secs,
+        threshold: debounce_count as u64,
+        debounce_secs: debounce_secs as u64,
         remaining_secs,
         refreshing: false,
     }
@@ -473,6 +473,9 @@ async fn build_blackboard_status(
 /// 启动黑板 flush 监听器：
 /// - 监听 debouncer channel，收到消息后执行 update_blackboard
 /// - 每秒通过 broadcast::tx 推送一次 BlackboardDebounceStatus 事件
+///
+/// 防抖阈值（周期秒数、条数阈值）从 per-workspace 黑板配置（blackboards 表）读取，
+/// 实现工作空间隔离。
 pub async fn blackboard_flush_listener(
     mut rx: tokio::sync::mpsc::Receiver<crate::services::blackboard_debouncer::BlackboardFlushMsg>,
     db: Arc<Database>,
@@ -488,13 +491,15 @@ pub async fn blackboard_flush_listener(
     // 已知的 workspace_id 列表（首次发送时从 DB 拉取）
     let mut known_workspaces: Vec<i64> = Vec::new();
 
-    loop {
-        // 从 config 读取当前的 debounce 参数（可能运行时变更）
-        let (debounce_secs, debounce_count) = {
-            let cfg = config.read().unwrap();
-            (cfg.blackboard_debounce_secs, cfg.blackboard_debounce_count)
-        };
+    // 从 per-workspace 黑板配置中读取防抖参数的 helper
+    async fn get_workspace_debounce(db: &Database, ws_id: i64) -> (i64, i64) {
+        match db.get_blackboard_config(ws_id).await {
+            Ok(Some(cfg)) => (cfg.debounce_secs, cfg.debounce_count),
+            _ => (600, 10), // 回退默认值
+        }
+    }
 
+    loop {
         tokio::select! {
             // 每秒 ticker：广播所有已知 workspace 的状态
             _ = ticker.tick() => {
@@ -506,6 +511,7 @@ pub async fn blackboard_flush_listener(
                 }
 
                 for ws_id in &known_workspaces {
+                    let (debounce_secs, debounce_count) = get_workspace_debounce(&db, *ws_id).await;
                     let event = build_blackboard_status(&db, *ws_id, debounce_secs, debounce_count).await;
                     let _ = tx.send(event);
                 }
@@ -522,12 +528,16 @@ pub async fn blackboard_flush_listener(
                             known_workspaces.push(msg.workspace_id);
                         }
 
+                        // 读取该 workspace 的 per-workspace 防抖配置
+                        let (debounce_secs, debounce_count) =
+                            get_workspace_debounce(&db, msg.workspace_id).await;
+
                         // 广播 refreshing=true 状态
                         let refreshing_event = ExecEvent::BlackboardDebounceStatus {
                             workspace_id: msg.workspace_id,
                             pending_count: 0,
-                            threshold: debounce_count,
-                            debounce_secs,
+                            threshold: debounce_count as u64,
+                            debounce_secs: debounce_secs as u64,
                             remaining_secs: -1,
                             refreshing: true,
                         };
@@ -589,8 +599,8 @@ pub async fn blackboard_flush_listener(
                         let done_event = ExecEvent::BlackboardDebounceStatus {
                             workspace_id: msg.workspace_id,
                             pending_count: 0,
-                            threshold: debounce_count,
-                            debounce_secs,
+                            threshold: debounce_count as u64,
+                            debounce_secs: debounce_secs as u64,
                             remaining_secs: -1,
                             refreshing: false,
                         };

--- a/backend/src/handlers/blackboard.rs
+++ b/backend/src/handlers/blackboard.rs
@@ -27,8 +27,6 @@ pub struct BlackboardResponse {
     pub blackboard_debounce_count: i64,
     /// 黑板更新提示词模板（空字符串表示使用内置默认）
     pub blackboard_update_prompt: String,
-    /// 黑板刷新提示词模板（空字符串表示使用内置默认）
-    pub blackboard_refresh_prompt: String,
 }
 
 /// 更新黑板配置的请求体（所有字段可选，None 保持原值不变）。
@@ -37,7 +35,6 @@ pub struct UpdateBlackboardConfigRequest {
     pub blackboard_debounce_secs: Option<i64>,
     pub blackboard_debounce_count: Option<i64>,
     pub blackboard_update_prompt: Option<String>,
-    pub blackboard_refresh_prompt: Option<String>,
 }
 
 /// `GET /api/workspaces/{workspace_id}/blackboard`
@@ -61,7 +58,6 @@ pub async fn get_blackboard(
             blackboard_debounce_secs: model.blackboard_debounce_secs,
             blackboard_debounce_count: model.blackboard_debounce_count,
             blackboard_update_prompt: model.blackboard_update_prompt,
-            blackboard_refresh_prompt: model.blackboard_refresh_prompt,
         })),
         None => Ok(ApiResponse::ok(BlackboardResponse {
             id: 0,
@@ -72,7 +68,6 @@ pub async fn get_blackboard(
             blackboard_debounce_secs: 600,
             blackboard_debounce_count: 10,
             blackboard_update_prompt: String::new(),
-            blackboard_refresh_prompt: String::new(),
         })),
     }
 }
@@ -98,7 +93,6 @@ pub async fn get_blackboard_config(
             debounce_secs: 600,
             debounce_count: 10,
             update_prompt: String::new(),
-            refresh_prompt: String::new(),
         })),
     }
 }
@@ -121,7 +115,6 @@ pub async fn update_blackboard_config(
         req.blackboard_debounce_secs,
         req.blackboard_debounce_count,
         req.blackboard_update_prompt,
-        req.blackboard_refresh_prompt,
     ).await.map_err(|e| AppError::Internal(format!("更新黑板配置失败: {}", e)))?;
     let cfg = state.db.get_blackboard_config(workspace_id).await.map_err(|e| {
         AppError::Internal(format!("更新后查询黑板配置失败: {}", e))
@@ -218,7 +211,6 @@ mod tests {
             blackboard_debounce_secs: 600,
             blackboard_debounce_count: 10,
             blackboard_update_prompt: "custom prompt".to_string(),
-            blackboard_refresh_prompt: "refresh prompt".to_string(),
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["id"], 7);
@@ -239,7 +231,6 @@ mod tests {
             blackboard_debounce_secs: 600,
             blackboard_debounce_count: 10,
             blackboard_update_prompt: String::new(),
-            blackboard_refresh_prompt: String::new(),
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["id"], 0);
@@ -296,7 +287,6 @@ mod tests {
             blackboard_debounce_secs: board.blackboard_debounce_secs,
             blackboard_debounce_count: board.blackboard_debounce_count,
             blackboard_update_prompt: board.blackboard_update_prompt,
-            blackboard_refresh_prompt: board.blackboard_refresh_prompt,
         });
         let json = serde_json::to_value(&resp).unwrap();
         // ApiResponse 包装格式：{"data": {...}}

--- a/backend/src/handlers/blackboard.rs
+++ b/backend/src/handlers/blackboard.rs
@@ -1,29 +1,49 @@
 //! 黑板（Blackboard）API Handler。
 //!
-//! 提供两个端点：
-//! - `GET /api/workspaces/{workspace_id}/blackboard`：获取当前黑板内容
+//! 提供四个端点：
+//! - `GET /api/workspaces/{workspace_id}/blackboard`：获取当前黑板内容与配置
+//! - `PATCH /api/workspaces/{workspace_id}/blackboard`：更新黑板配置
+//! - `GET /api/workspaces/{workspace_id}/blackboard/config`：仅获取黑板配置
 //! - `POST /api/workspaces/{workspace_id}/blackboard/refresh`：手动触发热刷新
 
 use axum::extract::{Path, State};
-use axum::routing::{get, post};
+use axum::routing::{get, patch, post};
 use axum::Router;
 
+use crate::db::blackboard::BlackboardConfig;
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::ApiResponse;
 
-/// 黑板响应体
+/// 黑板响应体（含内容与 per-workspace 配置）
 #[derive(Debug, serde::Serialize)]
 pub struct BlackboardResponse {
     pub id: i64,
     pub workspace_id: i64,
     pub content: String,
     pub updated_at: Option<String>,
+    /// 黑板更新防抖周期（秒）
+    pub blackboard_debounce_secs: i64,
+    /// 黑板更新防抖条数阈值
+    pub blackboard_debounce_count: i64,
+    /// 黑板更新提示词模板（空字符串表示使用内置默认）
+    pub blackboard_update_prompt: String,
+    /// 黑板刷新提示词模板（空字符串表示使用内置默认）
+    pub blackboard_refresh_prompt: String,
+}
+
+/// 更新黑板配置的请求体（所有字段可选，None 保持原值不变）。
+#[derive(Debug, serde::Deserialize)]
+pub struct UpdateBlackboardConfigRequest {
+    pub blackboard_debounce_secs: Option<i64>,
+    pub blackboard_debounce_count: Option<i64>,
+    pub blackboard_update_prompt: Option<String>,
+    pub blackboard_refresh_prompt: Option<String>,
 }
 
 /// `GET /api/workspaces/{workspace_id}/blackboard`
 ///
-/// 获取指定工作空间的当前黑板内容。
-/// 如果该工作空间还没有黑板记录，返回空内容（content=""）。
+/// 获取指定工作空间的当前黑板内容与配置。
+/// 如果该工作空间还没有黑板记录，返回空内容与默认配置（content=""）。
 pub async fn get_blackboard(
     State(state): State<AppState>,
     Path(workspace_id): Path<i64>,
@@ -38,14 +58,75 @@ pub async fn get_blackboard(
             workspace_id: model.workspace_id,
             content: model.content,
             updated_at: model.updated_at,
+            blackboard_debounce_secs: model.blackboard_debounce_secs,
+            blackboard_debounce_count: model.blackboard_debounce_count,
+            blackboard_update_prompt: model.blackboard_update_prompt,
+            blackboard_refresh_prompt: model.blackboard_refresh_prompt,
         })),
         None => Ok(ApiResponse::ok(BlackboardResponse {
             id: 0,
             workspace_id,
             content: String::new(),
             updated_at: None,
+            // 无记录时返回默认值；配置会在首次 create_blackboard 时写入
+            blackboard_debounce_secs: 600,
+            blackboard_debounce_count: 10,
+            blackboard_update_prompt: String::new(),
+            blackboard_refresh_prompt: String::new(),
         })),
     }
+}
+
+/// `GET /api/workspaces/{workspace_id}/blackboard/config`
+///
+/// 仅获取指定工作空间的黑板配置（防抖阈值、提示词）。
+/// 若黑板记录不存在，返回默认配置。
+pub async fn get_blackboard_config(
+    State(state): State<AppState>,
+    Path(workspace_id): Path<i64>,
+) -> Result<ApiResponse<BlackboardConfig>, AppError> {
+    // 先确保黑板记录存在（幂等），避免首次访问时 get_blackboard_config 返回 None
+    if let Err(e) = state.db.create_blackboard(workspace_id).await {
+        tracing::warn!("get_blackboard_config: create_blackboard 幂等创建失败: {:?}", e);
+    }
+    let cfg = state.db.get_blackboard_config(workspace_id).await.map_err(|e| {
+        AppError::Internal(format!("查询黑板配置失败: {}", e))
+    })?;
+    match cfg {
+        Some(c) => Ok(ApiResponse::ok(c)),
+        None => Ok(ApiResponse::ok(BlackboardConfig {
+            debounce_secs: 600,
+            debounce_count: 10,
+            update_prompt: String::new(),
+            refresh_prompt: String::new(),
+        })),
+    }
+}
+
+/// `PATCH /api/workspaces/{workspace_id}/blackboard/config`
+///
+/// 更新指定工作空间的黑板配置（防抖阈值、提示词）。
+/// 若黑板记录不存在，先创建再更新。
+pub async fn update_blackboard_config(
+    State(state): State<AppState>,
+    Path(workspace_id): Path<i64>,
+    ApiJson(req): ApiJson<UpdateBlackboardConfigRequest>,
+) -> Result<ApiResponse<BlackboardConfig>, AppError> {
+    // 先确保黑板记录已存在，避免在不存在的记录上更新
+    if let Err(e) = state.db.create_blackboard(workspace_id).await {
+        tracing::warn!("update_blackboard_config: create_blackboard 幂等创建失败: {:?}", e);
+    }
+    state.db.update_blackboard_config(
+        workspace_id,
+        req.blackboard_debounce_secs,
+        req.blackboard_debounce_count,
+        req.blackboard_update_prompt,
+        req.blackboard_refresh_prompt,
+    ).await.map_err(|e| AppError::Internal(format!("更新黑板配置失败: {}", e)))?;
+    let cfg = state.db.get_blackboard_config(workspace_id).await.map_err(|e| {
+        AppError::Internal(format!("更新后查询黑板配置失败: {}", e))
+    })?;
+    Ok(ApiResponse::ok(cfg.unwrap()))
 }
 
 /// 刷新请求体（预留，当前为空）
@@ -107,7 +188,11 @@ pub fn blackboard_routes() -> Router<AppState> {
     Router::new()
         .route(
             "/api/workspaces/{workspace_id}/blackboard",
-            get(get_blackboard),
+            get(get_blackboard).patch(update_blackboard_config),
+        )
+        .route(
+            "/api/workspaces/{workspace_id}/blackboard/config",
+            get(get_blackboard_config),
         )
         .route(
             "/api/workspaces/{workspace_id}/blackboard/refresh",
@@ -130,6 +215,10 @@ mod tests {
             workspace_id: 3,
             content: "# 工作空间进展".to_string(),
             updated_at: Some("2026-07-03T10:00:00Z".to_string()),
+            blackboard_debounce_secs: 600,
+            blackboard_debounce_count: 10,
+            blackboard_update_prompt: "custom prompt".to_string(),
+            blackboard_refresh_prompt: "refresh prompt".to_string(),
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["id"], 7);
@@ -147,6 +236,10 @@ mod tests {
             workspace_id: 42,
             content: String::new(),
             updated_at: None,
+            blackboard_debounce_secs: 600,
+            blackboard_debounce_count: 10,
+            blackboard_update_prompt: String::new(),
+            blackboard_refresh_prompt: String::new(),
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["id"], 0);
@@ -200,6 +293,10 @@ mod tests {
             workspace_id: board.workspace_id,
             content: board.content,
             updated_at: board.updated_at,
+            blackboard_debounce_secs: board.blackboard_debounce_secs,
+            blackboard_debounce_count: board.blackboard_debounce_count,
+            blackboard_update_prompt: board.blackboard_update_prompt,
+            blackboard_refresh_prompt: board.blackboard_refresh_prompt,
         });
         let json = serde_json::to_value(&resp).unwrap();
         // ApiResponse 包装格式：{"data": {...}}

--- a/backend/src/handlers/blackboard.rs
+++ b/backend/src/handlers/blackboard.rs
@@ -100,7 +100,8 @@ pub async fn get_blackboard_config(
 /// `PATCH /api/workspaces/{workspace_id}/blackboard/config`
 ///
 /// 更新指定工作空间的黑板配置（防抖阈值、提示词）。
-/// 若黑板记录不存在，先创建再更新。
+/// 若黑板记录不存在，先通过 create_blackboard 幂等创建（保证记录存在），再更新配置。
+/// 返回更新后的完整配置（从 DB 重新查询）。
 pub async fn update_blackboard_config(
     State(state): State<AppState>,
     Path(workspace_id): Path<i64>,

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -98,18 +98,6 @@ pub async fn update_config(
             }
             cfg.auto_update_hour = hour;
         }
-        if let Some(blackboard_update_prompt) = req.blackboard_update_prompt {
-            cfg.blackboard_update_prompt = blackboard_update_prompt;
-        }
-        if let Some(blackboard_refresh_prompt) = req.blackboard_refresh_prompt {
-            cfg.blackboard_refresh_prompt = blackboard_refresh_prompt;
-        }
-        if let Some(v) = req.blackboard_debounce_secs {
-            cfg.blackboard_debounce_secs = v.max(10);
-        }
-        if let Some(v) = req.blackboard_debounce_count {
-            cfg.blackboard_debounce_count = v.max(1);
-        }
 
         cfg.normalize_paths();
         cfg.clamp_execution_timeout_secs();

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -350,12 +350,11 @@ async fn build_app_state(
     spawn_feishu_history_fetcher(ctx.clone(), db.clone(), feishu_listener.clone(), debounce.clone());
     ensure_default_review_template_blocking(&db);
 
-    // 黑板防抖器初始化，启动 flush 监听器（监听 channel，收到消息后执行 LLM 更新黑板）
-    let cfg = config.read().unwrap();
-    let debounce_secs = cfg.blackboard_debounce_secs.max(10);
-    let debounce_count = cfg.blackboard_debounce_count.max(1);
-    drop(cfg);
-    let mut flush_rx = crate::services::blackboard_debouncer::init(debounce_secs, debounce_count).await;
+    // 黑板防抖器初始化，启动 flush 监听器（监听 channel，收到消息后执行 LLM 更新黑板）。
+    // 注意：防抖阈值已迁移到 per-workspace 配置（blackboards 表），此处使用系统级默认值
+    //（600s / 10 条），实际防抖逻辑在 push_pending_todo / take_pending_todo_ids 时
+    // 会从对应工作空间的黑板配置中读取真实值。
+    let flush_rx = crate::services::blackboard_debouncer::init().await;
     tokio::spawn(crate::executor_service::completion::blackboard_flush_listener(
         flush_rx,
         db.clone(),

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -786,16 +786,6 @@ pub struct UpdateConfigRequest {
     pub auto_update_interval: Option<String>,
     /// 自动更新检查小时（0-23）
     pub auto_update_hour: Option<u32>,
-    /// 黑板更新提示词模板（包含占位符 {{current}}、{{conclusion}}、{{todo_id}}、{{todo_title}}）。
-    /// 设置为空字符串可恢复内置默认提示词。
-    pub blackboard_update_prompt: Option<String>,
-    /// 黑板刷新提示词模板（仅包含占位符 {{current}}）。
-    /// 设置为空字符串可恢复内置默认提示词。
-    pub blackboard_refresh_prompt: Option<String>,
-    /// 黑板防抖周期（秒），达到该时间后统一处理 pending 队列。
-    pub blackboard_debounce_secs: Option<u64>,
-    /// 黑板防抖条数阈值，达到该条数后立即触发处理，无需等待周期。
-    pub blackboard_debounce_count: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -348,13 +348,11 @@ pub async fn update_blackboard(
 ) -> Result<(), AppError> {
     // 1+2: 读当前内容、找或建 todo；任一失败直接返回
     let current_content = read_current_content(&db, workspace_id).await?;
-    // 从 config 中提取提示词模板（避免 guard 跨 await 持有）
+    // 从 per-workspace 配置中提取提示词模板；若为空则使用内置默认
     let prompt_template = {
-        let guard = config.read().unwrap();
-        if guard.blackboard_update_prompt.is_empty() {
-            build_blackboard_prompt()
-        } else {
-            guard.blackboard_update_prompt.clone()
+        match db.get_blackboard_config(workspace_id).await {
+            Ok(Some(cfg)) if !cfg.update_prompt.is_empty() => cfg.update_prompt,
+            _ => build_blackboard_prompt(),
         }
     };
     let (todo_id, _) = find_or_create_blackboard_todo(&db, &prompt_template, workspace_id).await?;
@@ -403,20 +401,27 @@ pub async fn refresh_blackboard(
     if current_content.is_empty() {
         return Err(AppError::BadRequest("黑板暂无内容，无需刷新".to_string()));
     }
-    // 从 config 中提取提示词模板（避免 guard 跨 await 持有）
+    // 从 per-workspace 配置中提取提示词模板；若为空则降级到全局 config
     let (update_prompt_template, refresh_prompt) = {
-        let guard = config.read().unwrap();
-        let update = if guard.blackboard_update_prompt.is_empty() {
-            build_blackboard_prompt()
-        } else {
-            guard.blackboard_update_prompt.clone()
-        };
-        let refresh = if guard.blackboard_refresh_prompt.is_empty() {
-            build_refresh_prompt()
-        } else {
-            guard.blackboard_refresh_prompt.clone()
-        };
-        (update, refresh)
+        match db.get_blackboard_config(workspace_id).await {
+            Ok(Some(cfg)) => {
+                let update = if cfg.update_prompt.is_empty() {
+                    build_blackboard_prompt()
+                } else {
+                    cfg.update_prompt
+                };
+                let refresh = if cfg.refresh_prompt.is_empty() {
+                    build_refresh_prompt()
+                } else {
+                    cfg.refresh_prompt
+                };
+                (update, refresh)
+            }
+            _ => {
+                // 无记录或查库失败时使用内置默认模板
+                (build_blackboard_prompt(), build_refresh_prompt())
+            }
+        }
     };
     // 复用同一 todo + 同一执行/等待/写入流程；source_todo_* 留 None 表示"非任务触发"
     let (todo_id, _) = find_or_create_blackboard_todo(&db, &update_prompt_template, workspace_id).await?;

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -368,7 +368,10 @@ pub async fn refresh_blackboard(
     if current_content.is_empty() {
         return Err(AppError::BadRequest("黑板暂无内容，无需刷新".to_string()));
     }
-    // 从 per-workspace 配置中提取更新提示词模板；若为空则使用内置默认
+    // 从 per-workspace 配置中提取更新提示词模板；若为空则使用内置默认。
+    // 注意：手动刷新复用 update_prompt 而非单独的 refresh_prompt。
+    // 旧版 refresh_prompt 曾有独立模板（禁止 ntd://todo/ 链接），但该功能已移除，
+    // 两个场景现共用同一套 prompt 模板，均由用户配置或使用内置默认。
     let update_prompt_template = {
         match db.get_blackboard_config(workspace_id).await {
             Ok(Some(cfg)) if !cfg.update_prompt.is_empty() => cfg.update_prompt,

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -125,39 +125,6 @@ fn build_blackboard_prompt() -> String {
 只输出更新后的黑板内容，不要输出任何解释。"#.to_string()
 }
 
-/// 构建手动刷新黑板的 Prompt 模板。
-///
-/// 与 `build_blackboard_prompt` 的区别：
-/// - 没有"新任务结论"段（手动刷新不携带具体任务）
-/// - 明确禁止生成 `ntd://todo/{{id}}` 内部链接：
-///   手动刷新没有真实的"来源 todo"，沿用 update 模板会让 LLM 注入
-///   `ntd://todo/0` 这种指向不存在记录的坏链接
-/// - 目标是"重新组织现有信息"，不引入新事实
-///
-/// 仅依赖 `{{current}}` 占位符，调用方只需替换 current 即可。
-fn build_refresh_prompt() -> String {
-    r#"你是一个工作空间知识库的维护者。重新组织当前黑板内容，使其结构更清晰、信息更准确。
-
-当前黑板内容：
-```
-{{current}}
-```
-
-请重新组织黑板内容，要求：
-1. 保持以下结构：
-   - # 工作空间进展
-   - ## 已确认
-   - ## 新发现
-   - ## 待解决问题
-   - ## 矛盾/风险
-   - ## 下一步建议
-2. 不要添加任何新事实，不要虚构来源 todo；只整理、归并、提炼已有信息
-3. 禁止生成 ntd://todo/ 内部链接（手动刷新没有具体来源 todo）
-4. 合并相似条目；移除空段
-5. 保持 Markdown 格式，不要添加 HTML
-
-只输出重新组织后的黑板内容，不要输出任何解释。"#.to_string()
-}
 
 /// 读取指定工作空间的黑板内容；无记录时返回空字符串。
 ///
@@ -401,35 +368,19 @@ pub async fn refresh_blackboard(
     if current_content.is_empty() {
         return Err(AppError::BadRequest("黑板暂无内容，无需刷新".to_string()));
     }
-    // 从 per-workspace 配置中提取提示词模板；若为空则降级到全局 config
-    let (update_prompt_template, refresh_prompt) = {
+    // 从 per-workspace 配置中提取更新提示词模板；若为空则使用内置默认
+    let update_prompt_template = {
         match db.get_blackboard_config(workspace_id).await {
-            Ok(Some(cfg)) => {
-                let update = if cfg.update_prompt.is_empty() {
-                    build_blackboard_prompt()
-                } else {
-                    cfg.update_prompt
-                };
-                let refresh = if cfg.refresh_prompt.is_empty() {
-                    build_refresh_prompt()
-                } else {
-                    cfg.refresh_prompt
-                };
-                (update, refresh)
-            }
-            _ => {
-                // 无记录或查库失败时使用内置默认模板
-                (build_blackboard_prompt(), build_refresh_prompt())
-            }
+            Ok(Some(cfg)) if !cfg.update_prompt.is_empty() => cfg.update_prompt,
+            _ => build_blackboard_prompt(),
         }
     };
     // 复用同一 todo + 同一执行/等待/写入流程；source_todo_* 留 None 表示"非任务触发"
     let (todo_id, _) = find_or_create_blackboard_todo(&db, &update_prompt_template, workspace_id).await?;
-    // 手动刷新走独立 prompt 模板：避免 LLM 用 todo_id=0 拼出 ntd://todo/0 坏链接。
-    // 模板只依赖 {{current}}，不需要 source_todo_* 之类的额外占位符。
+    // 手动刷新使用与更新相同的 prompt 模板（已包含 {{current}} 占位符）
     let mut params = HashMap::new();
     params.insert("current".to_string(), current_content);
-    let message = crate::models::replace_placeholders(&refresh_prompt, &params);
+    let message = crate::models::replace_placeholders(&update_prompt_template, &params);
     let new_content = run_blackboard_execution(
         db.clone(),
         executor_registry,
@@ -469,28 +420,6 @@ mod tests {
         assert!(prompt.contains("{{conclusion}}"));
         assert!(prompt.contains("{{todo_id}}"));
         assert!(prompt.contains("{{todo_title}}"));
-    }
-
-    /// 验证 build_refresh_prompt 不含 todo 来源占位符，并显式禁止 ntd:// 内部链接。
-    /// 防止手动刷新误用 update 模板生成 `ntd://todo/0` 坏链接。
-    #[test]
-    fn test_refresh_prompt_has_no_source_attribution() {
-        let prompt = build_refresh_prompt();
-        // 不应有 source-todo 相关占位符（手动刷新无来源 todo）
-        assert!(!prompt.contains("{{todo_id}}"));
-        assert!(!prompt.contains("{{todo_title}}"));
-        assert!(!prompt.contains("{{conclusion}}"));
-        // 应显式禁止生成 ntd://todo/ 内部链接
-        assert!(
-            prompt.contains("ntd://todo/"),
-            "refresh prompt 必须显式提到 ntd://todo/ 以提醒 LLM 不要伪造来源"
-        );
-        assert!(
-            prompt.contains("禁止") || prompt.contains("不要"),
-            "refresh prompt 应包含明确的禁止/不要类指令"
-        );
-        // 仍保留 {{current}} 占位符
-        assert!(prompt.contains("{{current}}"));
     }
 
     /// 验证 assemble_prompt 正确替换占位符，且结论字段透传。

--- a/backend/src/services/blackboard_debouncer.rs
+++ b/backend/src/services/blackboard_debouncer.rs
@@ -69,8 +69,9 @@ pub async fn init() -> mpsc::Receiver<BlackboardFlushMsg> {
 
 /// 追加一个 todo_id 到 pending 队列；若 timer 未运行则启动。
 ///
-/// 防抖阈值从 per-workspace 黑板配置（blackboards 表）读取，实现工作空间隔离。
-/// 不调用任何 blackboard/executor_service 函数，职责纯粹为"入队 + 启动 timer"。
+/// 核心流程：入队 → 检查阈值是否达到立即触发 → 检查 timer 是否在运行 → 启动 timer。
+/// 防抖阈值（debounce_secs、debounce_count）从 per-workspace 黑板配置（blackboards 表）读取，
+/// 实现各工作空间独立的防抖策略。不调用任何 blackboard/executor_service 函数，职责纯粹为"入队 + 启动 timer"。
 pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Database>) {
     // 确保黑板记录已存在：首次有 todo 执行完成时，黑板记录还未创建。
     // create_blackboard 是幂等的（ON CONFLICT DO NOTHING），重复调用安全。

--- a/backend/src/services/blackboard_debouncer.rs
+++ b/backend/src/services/blackboard_debouncer.rs
@@ -6,12 +6,15 @@
 //! 职责边界（避免 cycle）：
 //!   - 本模块只管 pending 队列 + timer，不调用 blackboard service 或 executor_service
 //!   - 调用方（本模块外部）负责启动监听 channel 的后台任务，由其调用 update_blackboard
+//!
+//! 防抖阈值（周期秒数、条数阈值）从各工作空间的黑板配置（blackboards 表）读取，
+//! 实现 per-workspace 隔离。
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use tokio::sync::{broadcast, mpsc, RwLock};
-use tokio::time::{Duration, Instant};
+use tokio::sync::{mpsc, RwLock};
+use tokio::time::Duration;
 
 use crate::db::Database;
 
@@ -21,9 +24,6 @@ pub struct BlackboardFlushMsg {
     pub workspace_id: i64,
 }
 
-/// 防抖器全局状态
-static DEBOUNCER: RwLock<Option<Debouncer>> = RwLock::const_new(None);
-
 /// 全局 channel 发送端（监听方持有接收端）
 static FLUSH_TX: RwLock<Option<mpsc::Sender<BlackboardFlushMsg>>> = RwLock::const_new(None);
 
@@ -32,59 +32,44 @@ static FLUSH_TX: RwLock<Option<mpsc::Sender<BlackboardFlushMsg>>> = RwLock::cons
 pub struct WorkspaceTimerState {
     /// 计时器启动时的时间戳（unix ms），用于计算 remaining_secs
     pub started_at_ms: u64,
-    /// 防抖周期秒数
-    pub debounce_secs: u64,
+    /// 防抖周期秒数（来自黑板配置的运行时值）
+    pub debounce_secs: i64,
 }
 
-/// 全局计时器状态（只读，供 flush listener 查询）。使用 Option 包装以支持 const_new。
+/// 全局计时器状态（只读，供 flush listener 查询）
 static TIMER_STATES: RwLock<Option<HashMap<i64, WorkspaceTimerState>>> = RwLock::const_new(None);
+
+/// 全局 timer 运行状态：记录哪个 workspace 的 timer 正在运行。
+/// Arc 包装使 static 可跨 tokio::spawn 共享引用。
+static ACTIVE_TIMERS: std::sync::OnceLock<Arc<RwLock<Option<HashMap<i64, bool>>>>> =
+    std::sync::OnceLock::new();
 
 /// 查询 workspace 的当前计时器状态，返回 None 表示无 active timer。
 pub async fn get_timer_state(workspace_id: i64) -> Option<WorkspaceTimerState> {
     let guard = TIMER_STATES.read().await;
-    match guard.as_ref() {
-        Some(map) => map.get(&workspace_id).cloned(),
-        None => None,
-    }
+    guard.as_ref().and_then(|m| m.get(&workspace_id).cloned())
 }
 
-#[derive(Clone)]
-struct Debouncer {
-    timers: Arc<RwLock<HashMap<i64, bool>>>,
-    debounce_secs: u64,
-    debounce_count: u64,
-}
-
-impl Debouncer {
-    fn new(debounce_secs: u64, debounce_count: u64) -> Self {
-        Self {
-            timers: Arc::new(RwLock::new(HashMap::new())),
-            debounce_secs,
-            debounce_count,
-        }
-    }
-}
-
-/// 全局初始化：启动 channel，注册到全局，在 `build_app_state` 中调用
-pub async fn init(debounce_secs: u64, debounce_count: u64) -> mpsc::Receiver<BlackboardFlushMsg> {
+/// 全局初始化：启动 channel，注册到全局，在 `build_app_state` 中调用。
+/// 注意：不再在启动时传入默认防抖值——防抖阈值现在从 per-workspace DB 配置读取。
+pub async fn init() -> mpsc::Receiver<BlackboardFlushMsg> {
     let (tx, rx) = mpsc::channel::<BlackboardFlushMsg>(100);
-
-    let debouncer = Debouncer::new(debounce_secs, debounce_count);
-
-    {
-        let mut w = DEBOUNCER.write().await;
-        *w = Some(debouncer);
-    }
     {
         let mut w = FLUSH_TX.write().await;
         *w = Some(tx);
     }
-
+    {
+        let mut w = TIMER_STATES.write().await;
+        *w = Some(HashMap::new());
+    }
+    // OnceLock 保证 init 只会被调用一次（实际也确实只调用一次）
+    ACTIVE_TIMERS.get_or_init(|| Arc::new(RwLock::new(None)));
     rx
 }
 
 /// 追加一个 todo_id 到 pending 队列；若 timer 未运行则启动。
 ///
+/// 防抖阈值从 per-workspace 黑板配置（blackboards 表）读取，实现工作空间隔离。
 /// 不调用任何 blackboard/executor_service 函数，职责纯粹为"入队 + 启动 timer"。
 pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Database>) {
     // 确保黑板记录已存在：首次有 todo 执行完成时，黑板记录还未创建。
@@ -114,14 +99,14 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
 
     tracing::info!("append_pending_todo_id 成功: workspace_id={}, todo_id={}", workspace_id, todo_id);
 
-    // 获取 debouncer
-    let debouncer = {
-        let guard = DEBOUNCER.read().await;
-        guard.as_ref().cloned()
-    };
-    let Some(debouncer) = debouncer else {
-        tracing::warn!("BlackboardDebouncer 未初始化");
-        return;
+    // 读取 per-workspace 防抖配置（从 blackboards 表）
+    let (debounce_secs, debounce_count) = match db.get_blackboard_config(workspace_id).await {
+        Ok(Some(cfg)) => (cfg.debounce_secs, cfg.debounce_count),
+        Ok(None) => (600, 10), // 无配置时用默认值（理论上不会发生）
+        Err(e) => {
+            tracing::warn!("读取黑板配置失败，使用默认值: workspace_id={}, error={}", workspace_id, e);
+            (600, 10)
+        }
     };
 
     // 检查队列长度是否达到阈值，达到则立即触发
@@ -131,9 +116,9 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
             .unwrap_or(0);
         tracing::info!(
             "pending 队列检查: workspace_id={}, queue_len={}, threshold={}, debounce_secs={}",
-            workspace_id, queue_len, debouncer.debounce_count, debouncer.debounce_secs
+            workspace_id, queue_len, debounce_count, debounce_secs
         );
-        if queue_len as u64 >= debouncer.debounce_count {
+        if queue_len as u64 >= debounce_count as u64 {
             tracing::info!(
                 "黑板 pending 队列达到阈值 {} 条，立即触发: workspace_id={}",
                 queue_len, workspace_id
@@ -161,37 +146,42 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
     }
 
     // 未达阈值，检查并启动 timer
-    let mut timers = debouncer.timers.write().await;
-    if timers.get(&workspace_id).copied().unwrap_or(false) {
-        return; // timer 已在运行
+    {
+        let timers = ACTIVE_TIMERS.get().expect("ActiveTimers 未初始化");
+        let mut timers = timers.write().await;
+        let timers_map = timers.as_mut().expect("ActiveTimers 未初始化");
+        if timers_map.get(&workspace_id).copied().unwrap_or(false) {
+            return; // timer 已在运行
+        }
+        timers_map.insert(workspace_id, true);
     }
-    timers.insert(workspace_id, true);
+
     // 记录 timer 启动时间，供 flush listener 计算剩余秒数
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_millis() as u64;
-    drop(timers);
     {
         let mut states = TIMER_STATES.write().await;
         states.get_or_insert_with(HashMap::new).insert(workspace_id, WorkspaceTimerState {
             started_at_ms: now_ms,
-            debounce_secs: debouncer.debounce_secs,
+            debounce_secs,
         });
     }
 
-    // 克隆所需数据
-    let timers = debouncer.timers.clone();
-    let debounce_secs = debouncer.debounce_secs;
+    // 获取 channel sender 和 active timers 的 Arc 句柄，供 timer task 使用
     let tx = {
         let guard = FLUSH_TX.read().await;
         guard.as_ref().cloned()
     };
 
-    // 启动 timer
+    // 获取 ACTIVE_TIMERS 的 Arc 句柄供 timer task 使用
+    let timers_handle = ACTIVE_TIMERS.get().expect("ActiveTimers 未初始化").clone();
+
+    // 启动 timer（per-workspace 防抖时长）
     tokio::spawn(async move {
         // 使用 sleep 而非 interval：interval.tick() 第一次立即返回，不符合"等待周期"的需求
-        tokio::time::sleep(Duration::from_secs(debounce_secs)).await;
+        tokio::time::sleep(Duration::from_secs(debounce_secs as u64)).await;
         tracing::debug!("黑板 debounce timer 触发: workspace_id={}", workspace_id);
 
         // 清除 timer 状态
@@ -209,7 +199,12 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
             }
         }
 
-        let mut timers = timers.write().await;
-        timers.insert(workspace_id, false);
+        // 重置 timer 运行状态
+        {
+            let mut timers = timers_handle.write().await;
+            if let Some(map) = timers.as_mut() {
+                map.insert(workspace_id, false);
+            }
+        }
     });
 }

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -37,8 +37,6 @@ interface BlackboardData {
   blackboard_debounce_count: number;
   /** 黑板更新提示词模板（空字符串表示使用内置默认）*/
   blackboard_update_prompt: string;
-  /** 黑板刷新提示词模板（空字符串表示使用内置默认）*/
-  blackboard_refresh_prompt: string;
 }
 
 /** ntd://todo/{id} 协议的前缀，用于解析 LLM 注入的内部链接 */

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -21,7 +21,7 @@ import { XMarkdown } from '@ant-design/x-markdown';
 import { useTheme } from '@/hooks/useTheme';
 import { useViewState } from '@/hooks/useViewState';
 import type { BlackboardDebounceStatus } from '@/hooks/useExecutionEvents';
-import * as db from '@/utils/database';
+import { updateBlackboardConfig } from '@/utils/database/blackboard';
 
 const { Title } = Typography;
 
@@ -31,6 +31,14 @@ interface BlackboardData {
   workspace_id: number;
   content: string;
   updated_at: string | null;
+  /** 黑板更新防抖周期（秒）*/
+  blackboard_debounce_secs: number;
+  /** 黑板更新防抖条数阈值 */
+  blackboard_debounce_count: number;
+  /** 黑板更新提示词模板（空字符串表示使用内置默认）*/
+  blackboard_update_prompt: string;
+  /** 黑板刷新提示词模板（空字符串表示使用内置默认）*/
+  blackboard_refresh_prompt: string;
 }
 
 /** ntd://todo/{id} 协议的前缀，用于解析 LLM 注入的内部链接 */
@@ -180,31 +188,33 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
   const [activeTab, setActiveTab] = useState<'debounce' | 'prompt'>('debounce');
 
   /**
-   * 打开设置弹窗：先拉取最新 config，等拉完再打开 modal，避免默认值闪烁。
-   * 加载失败时使用空字符串作为 updatePrompt 的兜底——空字符串会触发"使用内置默认"的业务逻辑，
-   * 不使用 DEFAULT_BLACKBOARD_UPDATE_PROMPT 作为兜底，是为了避免把后端常量耦合进前端状态初始化。
+   * 打开设置弹窗：从已加载的黑板数据中读取 per-workspace 配置。
+   * 配置现在由 GET /api/workspaces/{workspaceId}/blackboard 接口随内容一并返回，
+   * 不再需要单独调用 db.getConfig()（getConfig 是全局配置，与黑板配置无关）。
    */
-  const handleOpenSettings = useCallback(async () => {
-    try {
-      const cfg = await db.getConfig();
-      setDebounceSecs(cfg.blackboard_debounce_secs ?? 600);
-      setDebounceCount(cfg.blackboard_debounce_count ?? 10);
-      setUpdatePrompt(cfg.blackboard_update_prompt ?? '');
-    } catch {
+  const handleOpenSettings = useCallback(() => {
+    if (data) {
+      setDebounceSecs(data.blackboard_debounce_secs ?? 600);
+      setDebounceCount(data.blackboard_debounce_count ?? 10);
+      setUpdatePrompt(data.blackboard_update_prompt ?? '');
+    } else {
       setDebounceSecs(600);
       setDebounceCount(10);
       setUpdatePrompt('');
     }
     setActiveTab('debounce');
     setSettingsOpen(true);
-  }, []);
+  }, [data]);
 
   // 保存设置
   const handleSaveSettings = useCallback(async () => {
     setSettingsSaving(true);
     try {
-      const current = await db.getConfig();
-      await db.updateConfig({ ...current, blackboard_debounce_secs: debounceSecs, blackboard_debounce_count: debounceCount, blackboard_update_prompt: updatePrompt });
+      await updateBlackboardConfig(workspaceId, {
+        blackboard_debounce_secs: debounceSecs,
+        blackboard_debounce_count: debounceCount,
+        blackboard_update_prompt: updatePrompt,
+      });
       message.success('设置已保存');
       setSettingsOpen(false);
     } catch (err) {
@@ -212,7 +222,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
     } finally {
       setSettingsSaving(false);
     }
-  }, [debounceSecs, debounceCount, updatePrompt]);
+  }, [workspaceId, debounceSecs, debounceCount, updatePrompt]);
 
   /**
    * 恢复默认提示词：把 updatePrompt 设为 DEFAULT_BLACKBOARD_UPDATE_PROMPT（与后端内置一致）。

--- a/frontend/src/utils/database/blackboard.ts
+++ b/frontend/src/utils/database/blackboard.ts
@@ -1,0 +1,14 @@
+import { api } from './client';
+
+/** PATCH /api/workspaces/{workspaceId}/blackboard：更新黑板 per-workspace 配置 */
+export async function updateBlackboardConfig(
+  workspaceId: number,
+  config: {
+    blackboard_debounce_secs?: number;
+    blackboard_debounce_count?: number;
+    blackboard_update_prompt?: string;
+    blackboard_refresh_prompt?: string;
+  },
+): Promise<void> {
+  await api.patch(`/api/workspaces/${workspaceId}/blackboard`, config);
+}

--- a/frontend/src/utils/database/blackboard.ts
+++ b/frontend/src/utils/database/blackboard.ts
@@ -7,7 +7,6 @@ export async function updateBlackboardConfig(
     blackboard_debounce_secs?: number;
     blackboard_debounce_count?: number;
     blackboard_update_prompt?: string;
-    blackboard_refresh_prompt?: string;
   },
 ): Promise<void> {
   await api.patch(`/api/workspaces/${workspaceId}/blackboard`, config);


### PR DESCRIPTION
## 背景
黑板的防抖阈值（周期秒数、条数阈值）和更新提示词模板原本存储在全局 Config 中，导致所有工作空间共享同一份配置。切换工作空间时配置不会跟随切换。

## 改动
- **DB**:  表新增 3 列：、、，均有默认值
- **迁移 V50**: 创建上述 3 个新列
- **API**:  响应体附带配置字段；新增  更新配置；新增  获取配置
- **防抖服务**: 防抖阈值从 per-workspace DB 配置读取，各工作空间独立计时
- **提示词**: 从 per-workspace DB 配置读取，不再使用全局 Config
- **前端**: 设置弹窗从已加载的黑板数据读取配置（无需单独请求）；保存时调用 per-workspace PATCH 接口
- **全局 Config**: 移除 、、 字段（ 早已移除）

## 效果
- 切换工作空间时，黑板内容和配置自动跟随切换，无需刷新
- 不同工作空间可以有独立的防抖周期、阈值和提示词模板

## 测试
- [x] 后端 1003 个测试全部通过
- [x] 前端 TypeScript 编译通过