### PR TITLE
fix(BlackboardDebounce): 修改防抖阈值时根据已计时长决定立即触发或继续计时

### DIFF
--- a/backend/src/handlers/blackboard.rs
+++ b/backend/src/handlers/blackboard.rs
@@ -102,6 +102,9 @@ pub async fn get_blackboard_config(
 /// 更新指定工作空间的黑板配置（防抖阈值、提示词）。
 /// 若黑板记录不存在，先通过 create_blackboard 幂等创建（保证记录存在），再更新配置。
 /// 返回更新后的完整配置（从 DB 重新查询）。
+///
+/// 当 debounce_secs 变更时，自动重置运行中的计时器，避免旧的计时状态与新的阈值不匹配
+/// 导致前端显示负数秒数。
 pub async fn update_blackboard_config(
     State(state): State<AppState>,
     Path(workspace_id): Path<i64>,
@@ -117,6 +120,18 @@ pub async fn update_blackboard_config(
         req.blackboard_debounce_count,
         req.blackboard_update_prompt,
     ).await.map_err(|e| AppError::Internal(format!("更新黑板配置失败: {}", e)))?;
+
+    // debounce_secs 变更时，根据已计时长决定：超则立即触发 flush，未超则继续用新阈值计时
+    // 传入钳制后的值，与 DB update_blackboard_config 内部 v.max(10) 保持一致
+    if let Some(new_secs) = req.blackboard_debounce_secs {
+        let clamped = new_secs.max(10);
+        crate::services::blackboard_debouncer::reconcile_timer_after_config_change(
+            workspace_id,
+            clamped,
+        )
+        .await;
+    }
+
     let cfg = state.db.get_blackboard_config(workspace_id).await.map_err(|e| {
         AppError::Internal(format!("更新后查询黑板配置失败: {}", e))
     })?;

--- a/backend/src/services/blackboard_debouncer.rs
+++ b/backend/src/services/blackboard_debouncer.rs
@@ -50,6 +50,78 @@ pub async fn get_timer_state(workspace_id: i64) -> Option<WorkspaceTimerState> {
     guard.as_ref().and_then(|m| m.get(&workspace_id).cloned())
 }
 
+/// 黑板防抖阈值变更后，调整运行中的计时器：
+/// - 若已计时长 ≥ 新阈值 → 立即触发 flush（已超时不继续等），清除计时器状态
+/// - 若已计时长 < 新阈值 → 更新 TIMER_STATES 的 debounce_secs 为新值，
+///   保持 started_at_ms 不变，让计时器用新阈值继续运行
+///
+/// 全程持 TIMER_STATES 写锁（读→算→改），防止后台 timer 任务在间隙中插入操作。
+pub async fn reconcile_timer_after_config_change(workspace_id: i64, new_debounce_secs: i64) {
+    // 持写锁进行读取-判断-修改，避免与后台 timer 任务产生竞态
+    let should_flush = {
+        let mut states = TIMER_STATES.write().await;
+        let map = states.as_mut();
+        let Some(map) = map else {
+            // TIMER_STATES 尚未初始化（理论上不会发生），跳过
+            return;
+        };
+        let Some(state) = map.get(&workspace_id) else {
+            // 没有活跃 timer，无需处理
+            return;
+        };
+
+        // 计算已计时长（秒）；saturating_sub 防御时钟回拨
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        let elapsed_secs = now_ms.saturating_sub(state.started_at_ms) / 1000;
+
+        if elapsed_secs >= new_debounce_secs as u64 {
+            // 已计时长已达到或超过新阈值 → 立即触发 flush
+            tracing::info!(
+                "黑板阈值变更：已计时 {}s ≥ 新阈值 {}s，立即触发 flush: workspace_id={}",
+                elapsed_secs, new_debounce_secs, workspace_id
+            );
+            map.remove(&workspace_id);
+            true // 标记需要发送 flush
+        } else {
+            // 已计时长还未达新阈值 → 更新 debounce_secs，继续计时
+            tracing::info!(
+                "黑板阈值变更：已计时 {}s < 新阈值 {}s，更新 debounce_secs 继续计时: workspace_id={}",
+                elapsed_secs, new_debounce_secs, workspace_id
+            );
+            map.insert(workspace_id, WorkspaceTimerState {
+                started_at_ms: state.started_at_ms,
+                debounce_secs: new_debounce_secs,
+            });
+            false // 不需要发送 flush
+        }
+    }; // TIMER_STATES 写锁在此释放
+
+    if should_flush {
+        // 标记 timer 未运行（与 TIMER_STATES 无锁序依赖，单独持锁）
+        {
+            let timers = ACTIVE_TIMERS.get().expect("ActiveTimers 未初始化");
+            let mut timers = timers.write().await;
+            if let Some(map) = timers.as_mut() {
+                map.insert(workspace_id, false);
+            }
+        }
+        // 发送 flush 消息
+        let tx = {
+            let guard = FLUSH_TX.read().await;
+            guard.as_ref().cloned()
+        };
+        if let Some(tx) = tx {
+            let msg = BlackboardFlushMsg { workspace_id };
+            if let Err(e) = tx.send(msg).await {
+                tracing::warn!("reconcile_timer: 发送 flush 消息失败: workspace_id={}, error={}", workspace_id, e);
+            }
+        }
+    }
+}
+
 /// 全局初始化：启动 channel，注册到全局，在 `build_app_state` 中调用。
 /// 注意：不再在启动时传入默认防抖值——防抖阈值现在从 per-workspace DB 配置读取。
 pub async fn init() -> mpsc::Receiver<BlackboardFlushMsg> {

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -180,8 +180,8 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
   // 设置弹窗状态
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsSaving, setSettingsSaving] = useState(false);
-  const [debounceSecs, setDebounceSecs] = useState<number>(600);
-  const [debounceCount, setDebounceCount] = useState<number>(10);
+  const [debounceSecs, setDebounceSecs] = useState<number | null>(600);
+  const [debounceCount, setDebounceCount] = useState<number | null>(10);
   const [updatePrompt, setUpdatePrompt] = useState<string>('');
   const [activeTab, setActiveTab] = useState<'debounce' | 'prompt'>('debounce');
 
@@ -209,13 +209,14 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
     setSettingsSaving(true);
     try {
       await updateBlackboardConfig(workspaceId, {
-        blackboard_debounce_secs: debounceSecs,
-        blackboard_debounce_count: debounceCount,
+        // 用户清空输入时 null → 用默认值，避免后端意外覆盖
+        blackboard_debounce_secs: debounceSecs ?? 600,
+        blackboard_debounce_count: debounceCount ?? 10,
         blackboard_update_prompt: updatePrompt,
       });
       // 保存成功后同步更新 data，避免下次打开弹窗读到旧值
       if (data) {
-        setData({ ...data, blackboard_debounce_secs: debounceSecs, blackboard_debounce_count: debounceCount, blackboard_update_prompt: updatePrompt });
+        setData({ ...data, blackboard_debounce_secs: debounceSecs ?? 600, blackboard_debounce_count: debounceCount ?? 10, blackboard_update_prompt: updatePrompt });
       }
       message.success('设置已保存');
       setSettingsOpen(false);
@@ -315,10 +316,10 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
 // ─── 设置弹窗子组件（避免 Tabs children 深层嵌套）─────────────────
 
 interface DebounceSettingsTabProps {
-  debounceSecs: number;
-  setDebounceSecs: (v: number) => void;
-  debounceCount: number;
-  setDebounceCount: (v: number) => void;
+  debounceSecs: number | null;
+  setDebounceSecs: (v: number | null) => void;
+  debounceCount: number | null;
+  setDebounceCount: (v: number | null) => void;
 }
 
 /** 防抖设置 Tab：防抖周期 + 触发条数，受父组件状态控制 */
@@ -328,7 +329,9 @@ function DebounceSettingsTab({ debounceSecs, setDebounceSecs, debounceCount, set
       <Form.Item label="防抖周期">
         <InputNumber
           value={debounceSecs}
-          onChange={(v) => setDebounceSecs(v ?? 600)}
+          // 用户清空输入时 value=null，不立即回填默认值，只透传 null 给 state；
+          // 保存时由 handleSaveSettings 用 ?? 兜底，避免删值瞬间被 600 覆盖
+          onChange={(v) => setDebounceSecs(v)}
           min={10}
           max={3600}
           addonAfter="秒"
@@ -338,7 +341,7 @@ function DebounceSettingsTab({ debounceSecs, setDebounceSecs, debounceCount, set
       <Form.Item label="触发条数">
         <InputNumber
           value={debounceCount}
-          onChange={(v) => setDebounceCount(v ?? 10)}
+          onChange={(v) => setDebounceCount(v)}
           min={1}
           max={100}
           addonAfter="条"


### PR DESCRIPTION
## 问题

当黑板计时器以 `debounce_secs=600s` 运行时，通过设置弹窗将阈值改为 `60s`，后端只更新了 DB 配置，但**正在运行的计时器状态**仍持有旧的 `debounce_secs=600` 和 `started_at_ms`。导致：

1. 后续每秒 ticker 计算出的 `remaining_secs` 对不上新的 `debounce_secs`
2. 前端出现负数秒数（如 `-365s / 60s`）
3. 即使已计时长已超过新阈值，也不会立即触发整理

## 修复

在 `blackboard_debouncer.rs` 新增 `reconcile_timer_after_config_change` 函数，在 PATCH 更新配置时自动调用：

| 场景 | 行为 |
|---|---|
| 已计时长 ≥ 新阈值 | 立即发送 flush 消息触发整理，无需额外等待 |
| 已计时长 < 新阈值 | 更新 TIMER_STATES 的 `debounce_secs` 为新值，保持 `started_at_ms` 不变继续计时 |

### 额外修复

| # | 问题 | 修复 |
|---|---|---|
| 1 | **竞态条件**：读 TIMER_STATES 用读锁，释放后才拿写锁，后台 timer 任务可插入修改 | 全程持 **写锁** 贯穿读→算→改 |
| 2 | **u64 下溢**：`now_ms - state.started_at_ms` 在时钟回拨时 panic 或 wrap | 改用 **`saturating_sub`** |
| 3 | **未钳制输入**：reconcile 接收原始值 `3` 而 DB 存 `10`，计时器状态和 DB 不一致 | 调用前做 **`.max(10)`** 钳制 |
| 4 | **前端输入不便**：InputNumber 清空瞬间自动回填 `60`/`10`，无法流畅键入新值 | state 改为 `number | null`，清空透传 null，**保存时用 `??` 兜底** |

## 变更文件

- `backend/src/services/blackboard_debouncer.rs` — 新增 `reconcile_timer_after_config_change`
- `backend/src/handlers/blackboard.rs` — 更新配置后调用该函数（含钳制）
- `frontend/src/components/BlackboardPage.tsx` — InputNumber 允许空值