### PR TITLE
refactor: 黑板pending队列从todo_id改为execution_record_id

### DIFF
--- a/backend/src/db/blackboard.rs
+++ b/backend/src/db/blackboard.rs
@@ -49,7 +49,7 @@ impl Database {
             // 初始内容为空：创建时的黑板无内容，由后续 LLM 更新填充
             content: ActiveValue::Set(String::new()),
             // 初始 pending 队列为空
-            pending_todo_ids: ActiveValue::Set("[]".to_string()),
+            pending_record_ids: ActiveValue::Set("[]".to_string()),
             // 默认防抖周期 600 秒
             blackboard_debounce_secs: ActiveValue::Set(600),
             // 默认防抖条数阈值 10 条
@@ -135,7 +135,7 @@ impl Database {
             content: ActiveValue::Set(content.to_string()),
             updated_at: ActiveValue::Set(Some(now.clone())),
             created_at: ActiveValue::Set(Some(now)),
-            pending_todo_ids: ActiveValue::Set("[]".to_string()),
+            pending_record_ids: ActiveValue::Set("[]".to_string()),
             blackboard_debounce_secs: ActiveValue::Set(600),
             blackboard_debounce_count: ActiveValue::Set(10),
             blackboard_update_prompt: ActiveValue::Set(String::new()),
@@ -153,14 +153,14 @@ impl Database {
         Ok(())
     }
 
-    /// 追加一个 todo_id 到黑板的 pending 队列。
+    /// 追加一个 execution_record_id 到黑板的 pending 队列。
     ///
     /// ORM 方式：读 → JSON parse → push → 序列化 → 写回。
     /// 并发安全由 workspace_id 唯一约束保证串行写入。
-    pub async fn append_pending_todo_id(
+    pub async fn append_pending_record_id(
         &self,
         workspace_id: i64,
-        todo_id: i64,
+        record_id: i64,
     ) -> Result<(), sea_orm::DbErr> {
         // 读取当前队列
         let board = blackboards::Entity::find()
@@ -173,9 +173,9 @@ impl Database {
             )))?;
 
         // 解析 + 追加
-        let mut ids: Vec<i64> = serde_json::from_str(&board.pending_todo_ids)
+        let mut ids: Vec<i64> = serde_json::from_str(&board.pending_record_ids)
             .unwrap_or_default();
-        ids.push(todo_id);
+        ids.push(record_id);
         let ids_json = serde_json::to_string(&ids).unwrap_or_default();
 
         // 写回：必须用 Unchanged 设置主键，sea-orm 的 update() 要求主键必须存在
@@ -183,7 +183,7 @@ impl Database {
         let _res = blackboards::ActiveModel {
             id: ActiveValue::Unchanged(board.id),
             workspace_id: ActiveValue::Unchanged(workspace_id),
-            pending_todo_ids: ActiveValue::Set(ids_json),
+            pending_record_ids: ActiveValue::Set(ids_json),
             updated_at: ActiveValue::Set(Some(now)),
             ..Default::default()
         }.update(&self.conn).await?;
@@ -191,10 +191,10 @@ impl Database {
         Ok(())
     }
 
-    /// 取出并清空 pending 队列，返回待处理的 todo_id 列表。
+    /// 取出并清空 pending 队列，返回待处理的 execution_record_id 列表。
     ///
     /// 两步非原子，竞态时可能丢失或重复，但 debounce 场景下可接受。
-    pub async fn take_pending_todo_ids(
+    pub async fn take_pending_record_ids(
         &self,
         workspace_id: i64,
     ) -> Result<Vec<i64>, sea_orm::DbErr> {
@@ -208,7 +208,7 @@ impl Database {
                 workspace_id
             )))?;
 
-        let ids: Vec<i64> = serde_json::from_str(&board.pending_todo_ids)
+        let ids: Vec<i64> = serde_json::from_str(&board.pending_record_ids)
             .unwrap_or_default();
 
         // 清空队列（非空才写，减少 DB 写入）；主键必须设置
@@ -217,7 +217,7 @@ impl Database {
             let _res = blackboards::ActiveModel {
                 id: ActiveValue::Unchanged(board.id),
                 workspace_id: ActiveValue::Unchanged(workspace_id),
-                pending_todo_ids: ActiveValue::Set("[]".to_string()),
+                pending_record_ids: ActiveValue::Set("[]".to_string()),
                 updated_at: ActiveValue::Set(Some(now)),
                 ..Default::default()
             }.update(&self.conn).await?;

--- a/backend/src/db/entity/blackboards.rs
+++ b/backend/src/db/entity/blackboards.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// 每个 workspace 最多一条记录（workspace_id 为 UNIQUE），
 /// content 字段存储 Markdown 格式的黑板内容。
-/// pending_todo_ids 暂存待处理的 todo_id，防抖批次处理时使用。
+/// pending_record_ids 暂存待处理的 execution_record_id，防抖批次处理时使用。
 /// 防抖阈值与提示词模板均为 per-workspace 配置，存储在本表。
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "blackboards")]
@@ -17,9 +17,9 @@ pub struct Model {
     /// 黑板 Markdown 内容
     #[sea_orm(column_type = "Text")]
     pub content: String,
-    /// 待处理的 todo_id 队列（JSON 数组），防抖周期到点后统一处理
+    /// 待处理的 execution_record_id 队列（JSON 数组），防抖周期到点后统一处理
     #[sea_orm(column_type = "Text")]
-    pub pending_todo_ids: String,
+    pub pending_record_ids: String,
     /// 黑板更新防抖周期（秒），达到该时间后统一处理 pending 队列
     pub blackboard_debounce_secs: i64,
     /// 黑板更新防抖条数阈值，达到该条数后立即触发，无需等待周期

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -15,6 +15,8 @@ mod v47;
 mod v48;
 mod v49;
 mod v50;
+mod v51;
+mod v52;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -52,6 +54,8 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v48::V48ScopeTodosActionKeyByWorkspace),
         Box::new(v49::V49AddBlackboardPendingTodoIds),
         Box::new(v50::V50AddBlackboardWorkspaceConfig),
+        Box::new(v51::V51AddBlackboardPendingRecordIds),
+        Box::new(v52::V52DropBlackboardPendingTodoIds),
     ]
 }
 

--- a/backend/src/db/migration/v2_v5.rs
+++ b/backend/src/db/migration/v2_v5.rs
@@ -688,21 +688,19 @@ async fn v5_project_directory_worktree(db: &Database) -> Result<(), sea_orm::DbE
 // v6: todos.kind 列 (issue #674: 事项 vs 环节区分)
 // ---------------------------------------------------------------------------
 
-/// v6 迁移：为 todos 表增加 `kind` 列, 区分一次性事项('item')和
-/// 可被 loop 编排复用的环节('step')。
-///
-/// 设计动机：
-/// - 一次性 todo 是「事项」，循环复用的 todo 是「环节（Agent）」；
-/// - 环路编排的节点只应引用环节，引用一次性事项会污染"循环复用"语义；
-/// - 同一张 todos 表承载两种语义, 靠 `kind` 列区分; 避免新建 steps 表的
-///   schema 迁移 + 跨表 JOIN 成本。
-///
-/// 升级策略：
-/// - 新库: v1 的 CREATE TABLE 已经包含 `kind` 列, v6 ALTER 在 v1 之后跑会
-///   触发 "duplicate column name", 与历史 add_legacy_*_columns 同样的 warn-skip 模式;
-/// - 旧库: ALTER TABLE 加列, 默认 'item'; 把被 loop_steps 引用的 todo
-///   标记为 'step', 避免环路失效;
-/// - 加 `(kind)` 索引支持按 kind 过滤。
+// v6 迁移：为 todos 表增加 `kind` 列, 区分一次性事项('item')和
+// 可被 loop 编排复用的环节('step')。
+// 设计动机：
+// - 一次性 todo 是「事项」，循环复用的 todo 是「环节（Agent）」；
+// - 环路编排的节点只应引用环节，引用一次性事项会污染"循环复用"语义；
+// - 同一张 todos 表承载两种语义, 靠 `kind` 列区分; 避免新建 steps 表的
+//   schema 迁移 + 跨表 JOIN 成本。
+// 升级策略：
+// - 新库: v1 的 CREATE TABLE 已经包含 `kind` 列, v6 ALTER 在 v1 之后跑会
+//   触发 "duplicate column name", 与历史 add_legacy_*_columns 同样的 warn-skip 模式;
+// - 旧库: ALTER TABLE 加列, 默认 'item'; 把被 loop_steps 引用的 todo
+//   标记为 'step', 避免环路失效;
+// - 加 `(kind)` 索引支持按 kind 过滤。
 
 #[cfg(test)]
 mod v15_review_templates_tests {
@@ -975,16 +973,15 @@ mod v16_loop_step_execution_snapshot_columns_tests {
     //! 1) auto-migrate 跑到 V16 时必须给 loop_step_executions 补齐这三列；
     //! 2) 已跑过 V16 的实例再跑一次 up() 必须幂等（不报 duplicate column）。
 
-    use super::*;
     use crate::db::Database;
-    use sea_orm::{ConnectionTrait, DbBackend, Statement};
+    use crate::db::migration::table_has_column as migration_table_has_column;
 
     async fn fresh_db() -> Database {
         Database::new(":memory:").await.expect("memory db must open")
     }
 
     async fn table_has_column(db: &Database, table: &str, column: &str) -> bool {
-        super::table_has_column(db, table, column).await.unwrap_or(false)
+        migration_table_has_column(db, table, column).await.unwrap_or(false)
     }
 
     /// 场景 1：auto-migrate 跑到 V16（含）后，
@@ -1256,8 +1253,8 @@ pub async fn drop_column_if_exists(
 // - 普通事项执行完成后不再触发自动评审（由 completion.rs:maybe_run_auto_review 兜底）
 // - Loop 环节的评分闸门评审完全不受影响（apply_rating_gate 不读该字段）
 // - 飞书创建的事项也走相同的默认值逻辑，不受影响
-/// v40: 删除 feishu_messages.processed_todo_id 列（用 processed_id 代替）。
-/// processed_id + processed_type 已能完整表达处理信息，去除冗余列。
+// v40: 删除 feishu_messages.processed_todo_id 列（用 processed_id 代替）。
+// processed_id + processed_type 已能完整表达处理信息，去除冗余列。
 // =============================================================================
 // 合并迁移 V41~V43
 //
@@ -1340,7 +1337,7 @@ async fn v15_review_templates(db: &Database) -> Result<(), sea_orm::DbErr> {
     ))
     .await?;
 
-    if table_has_column(db, "loop_steps", "todo_id").await? {
+    if crate::db::migration::table_has_column(db, "loop_steps", "todo_id").await? {
         db.exec("DELETE FROM loop_steps WHERE todo_id IN (SELECT id FROM todos WHERE todo_type = 1)")
             .await?;
     } else {
@@ -1350,7 +1347,7 @@ async fn v15_review_templates(db: &Database) -> Result<(), sea_orm::DbErr> {
     db.exec("DELETE FROM loop_hooks WHERE target_todo_id IN (SELECT id FROM todos WHERE todo_type = 1)")
         .await?;
     db.exec("DELETE FROM todos WHERE todo_type = 1").await?;
-    add_column_warn(db, "ALTER TABLE todos ADD COLUMN review_template_id INTEGER").await;
+    crate::db::migration::add_column_warn(db, "ALTER TABLE todos ADD COLUMN review_template_id INTEGER").await;
     db.exec("CREATE INDEX IF NOT EXISTS idx_todos_review_template_id ON todos(review_template_id)")
         .await?;
 
@@ -1384,4 +1381,3 @@ async fn consolidate_review_instance_todos(db: &Database) -> Result<(), sea_orm:
         .await?;
     Ok(())
 }
-

--- a/backend/src/db/migration/v51.rs
+++ b/backend/src/db/migration/v51.rs
@@ -1,0 +1,61 @@
+//! 数据库迁移 V51：为 blackboards 表添加 pending_record_ids 字段。
+//!
+//! 背景：黑板 pending 队列从存 todo_id 改为存 execution_record_id。
+//! 这样 flusher 可以直接按 record_id 查结论，避免 get_latest_execution_record_for_todo
+//! 在 debounce 窗口内同一 todo 多次执行时丢失中间结论的问题。
+//!
+//! 数据兼容性：已有 blackboards 记录的 pending_record_ids 初始化为空数组 "[]"。
+//! 存量 pending_todo_ids 列由 V52 迁移清理删除。
+
+use async_trait::async_trait;
+
+use super::super::Database;
+use super::Migration;
+
+pub(super) struct V51AddBlackboardPendingRecordIds;
+
+#[async_trait]
+impl Migration for V51AddBlackboardPendingRecordIds {
+    fn version(&self) -> i64 {
+        51
+    }
+
+    fn name(&self) -> &'static str {
+        "add_blackboard_pending_record_ids"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 1. 检查列是否已存在（幂等：重复执行不报错）
+        if super::table_has_column(db, "blackboards", "pending_record_ids").await? {
+            return Ok(());
+        }
+
+        // 2. 加列
+        db.exec("ALTER TABLE blackboards ADD COLUMN pending_record_ids TEXT NOT NULL DEFAULT '[]'")
+            .await?;
+
+        tracing::info!("V51: blackboards.pending_record_ids 字段已添加");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    #[tokio::test]
+    async fn test_v51_migration_succeeds() {
+        let db = Database::new(":memory:").await.unwrap();
+        // V47 创建了 blackboards 表
+        crate::db::migration::v47::V47CreateBlackboardsTable
+            .up(&db)
+            .await
+            .unwrap();
+        // V51 应当成功执行
+        V51AddBlackboardPendingRecordIds
+            .up(&db)
+            .await
+            .expect("V51 must succeed");
+    }
+}

--- a/backend/src/db/migration/v52.rs
+++ b/backend/src/db/migration/v52.rs
@@ -1,0 +1,64 @@
+//! 数据库迁移 V52：删除 blackboards 表的 pending_todo_ids 列。
+//!
+//! 背景：V51 引入了 pending_record_ids 代替 pending_todo_ids，
+//! 本迁移清理不再使用的旧列。
+//!
+//! 安全删除：SQLite 3.35.0+ 支持 ALTER TABLE DROP COLUMN，
+//! drop_column_if_exists 内置存在性检查，重复执行幂等。
+
+use async_trait::async_trait;
+
+use super::super::Database;
+use super::Migration;
+
+pub(super) struct V52DropBlackboardPendingTodoIds;
+
+#[async_trait]
+impl Migration for V52DropBlackboardPendingTodoIds {
+    fn version(&self) -> i64 {
+        52
+    }
+
+    fn name(&self) -> &'static str {
+        "drop_blackboard_pending_todo_ids"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 使用带存在性检查的 drop 工具函数，幂等安全
+        crate::db::migration::v2_v5::drop_column_if_exists(
+            db,
+            "blackboards",
+            "pending_todo_ids",
+        )
+        .await?;
+
+        tracing::info!("V52: blackboards.pending_todo_ids 列已删除");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    #[tokio::test]
+    async fn test_v52_migration_succeeds() {
+        let db = Database::new(":memory:").await.unwrap();
+        // V47 创建了 blackboards 表
+        crate::db::migration::v47::V47CreateBlackboardsTable
+            .up(&db)
+            .await
+            .unwrap();
+        // V49 添加了 pending_todo_ids 列
+        crate::db::migration::v49::V49AddBlackboardPendingTodoIds
+            .up(&db)
+            .await
+            .unwrap();
+        // V52 应当成功删除该列
+        V52DropBlackboardPendingTodoIds
+            .up(&db)
+            .await
+            .expect("V52 must succeed");
+    }
+}

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -417,12 +417,12 @@ pub(crate) async fn finalize_normal_completion(
     task_manager.remove(&task_id).await;
 
     // ===== 黑板更新 (blackboard) =====
-    // 任务执行成功后，将 todo_id 追加到 pending 队列，由 debouncer 周期汇总触发。
+    // 任务执行成功后，将 execution_record_id 追加到 pending 队列，由 debouncer 周期汇总触发。
     // 用 trigger_type 判定"自身"——黑板更新任务的 trigger_type == "blackboard"，
     // 避免无限循环；即使以后新增相同 action_type 的非黑板 todo，也不会被错误地跳过。
     if success && trigger_type != "blackboard" {
         if let Some(ws_id) = workspace_id {
-            crate::services::blackboard_debouncer::push_pending_todo(ws_id, todo_id, &db).await;
+            crate::services::blackboard_debouncer::push_pending_record(ws_id, record_id, &db).await;
         }
     }
 }
@@ -441,7 +441,7 @@ async fn build_blackboard_status(
         .ok()
         .flatten()
         .map(|b| {
-            serde_json::from_str::<Vec<i64>>(&b.pending_todo_ids)
+            serde_json::from_str::<Vec<i64>>(&b.pending_record_ids)
                 .map(|v| v.len() as u64)
                 .unwrap_or(0)
         })
@@ -543,8 +543,8 @@ pub async fn blackboard_flush_listener(
                         };
                         let _ = tx.send(refreshing_event);
 
-                        // 从 DB 取出 pending 队列（take_pending_todo_ids 已清空队列）
-                        let todo_ids = match db.take_pending_todo_ids(msg.workspace_id).await {
+                        // 从 DB 取出 pending 队列（take_pending_record_ids 已清空队列）
+                        let record_ids = match db.take_pending_record_ids(msg.workspace_id).await {
                             Ok(ids) => ids,
                             Err(e) => {
                                 tracing::warn!("取 pending 队列失败: workspace_id={}, error={}", msg.workspace_id, e);
@@ -552,23 +552,28 @@ pub async fn blackboard_flush_listener(
                             }
                         };
 
-                        if todo_ids.is_empty() {
+                        if record_ids.is_empty() {
                             tracing::debug!("黑板 pending 队列为空: workspace_id={}", msg.workspace_id);
                             continue;
                         }
 
                         tracing::info!(
-                            "黑板 flush listener 处理: workspace_id={}, todo_ids={:?}",
-                            msg.workspace_id, todo_ids
+                            "黑板 flush listener 处理: workspace_id={}, record_ids={:?}",
+                            msg.workspace_id, record_ids
                         );
 
-                        // 按顺序查询每条 todo 的最新执行结论
-                        let mut conclusions = Vec::with_capacity(todo_ids.len());
-                        for todo_id in &todo_ids {
-                            if let Ok(Some(record)) = db.get_latest_execution_record_for_todo(*todo_id).await {
+                        // 按顺序查询每条 execution_record 的结论
+                        let mut conclusions = Vec::with_capacity(record_ids.len());
+                        // 取第一条记录的 todo_id 作为 update_blackboard 的 source_todo_id
+                        let mut source_todo_id = 0i64;
+                        for (i, record_id) in record_ids.iter().enumerate() {
+                            if let Ok(Some(record)) = db.get_execution_record(*record_id).await {
+                                if i == 0 {
+                                    source_todo_id = record.todo_id;
+                                }
                                 conclusions.push(format!(
                                     "- 任务 ID: {}\n  结论: {}",
-                                    todo_id,
+                                    record.todo_id,
                                     record.result.as_deref().unwrap_or("(无结论)")
                                 ));
                             }
@@ -590,8 +595,8 @@ pub async fn blackboard_flush_listener(
                             config.clone(),
                             msg.workspace_id,
                             &conclusion_text,
-                            todo_ids[0],
-                            &format!("批量更新 ({}条)", todo_ids.len()),
+                            source_todo_id,
+                            &format!("批量更新 ({}条)", record_ids.len()),
                         )
                         .await;
 

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -352,7 +352,7 @@ async fn build_app_state(
 
     // 黑板防抖器初始化，启动 flush 监听器（监听 channel，收到消息后执行 LLM 更新黑板）。
     // 注意：防抖阈值已迁移到 per-workspace 配置（blackboards 表），此处使用系统级默认值
-    //（600s / 10 条），实际防抖逻辑在 push_pending_todo / take_pending_todo_ids 时
+    //（600s / 10 条），实际防抖逻辑在 push_pending_record / take_pending_record_ids 时
     // 会从对应工作空间的黑板配置中读取真实值。
     let flush_rx = crate::services::blackboard_debouncer::init().await;
     tokio::spawn(crate::executor_service::completion::blackboard_flush_listener(

--- a/backend/src/services/blackboard_debouncer.rs
+++ b/backend/src/services/blackboard_debouncer.rs
@@ -1,6 +1,6 @@
 //! 黑板（Blackboard）防抖服务。
 //!
-//! 核心思路：不再每次 todo 执行完毕立即触发黑板更新，而是将 todo_id 追加到
+//! 核心思路：不再每次 todo 执行完毕立即触发黑板更新，而是将 execution_record_id 追加到
 //! 黑板的 pending 队列，周期到点后通过 channel 通知监听方执行实际 LLM 调用。
 //!
 //! 职责边界（避免 cycle）：
@@ -144,12 +144,12 @@ pub async fn init() -> mpsc::Receiver<BlackboardFlushMsg> {
     rx
 }
 
-/// 追加一个 todo_id 到 pending 队列；若 timer 未运行则启动。
+/// 追加一个 execution_record_id 到 pending 队列；若 timer 未运行则启动。
 ///
 /// 核心流程：入队 → 检查阈值是否达到立即触发 → 检查 timer 是否在运行 → 启动 timer。
 /// 防抖阈值（debounce_secs、debounce_count）从 per-workspace 黑板配置（blackboards 表）读取，
 /// 实现各工作空间独立的防抖策略。不调用任何 blackboard/executor_service 函数，职责纯粹为"入队 + 启动 timer"。
-pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Database>) {
+pub async fn push_pending_record(workspace_id: i64, record_id: i64, db: &Arc<Database>) {
     // 确保黑板记录已存在：首次有 todo 执行完成时，黑板记录还未创建。
     // create_blackboard 是幂等的（ON CONFLICT DO NOTHING），重复调用安全。
     if let Err(e) = db.create_blackboard(workspace_id).await {
@@ -162,20 +162,20 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
     }
 
     tracing::info!(
-        "push_pending_todo called: workspace_id={}, todo_id={}",
-        workspace_id, todo_id
+        "push_pending_record called: workspace_id={}, record_id={}",
+        workspace_id, record_id
     );
 
     // 追加到 DB
-    if let Err(e) = db.append_pending_todo_id(workspace_id, todo_id).await {
+    if let Err(e) = db.append_pending_record_id(workspace_id, record_id).await {
         tracing::warn!(
-            "追加 pending_todo_id 失败: workspace_id={}, todo_id={}, error={}",
-            workspace_id, todo_id, e
+            "追加 pending_record_id 失败: workspace_id={}, record_id={}, error={}",
+            workspace_id, record_id, e
         );
         return;
     }
 
-    tracing::info!("append_pending_todo_id 成功: workspace_id={}, todo_id={}", workspace_id, todo_id);
+    tracing::info!("append_pending_record_id 成功: workspace_id={}, record_id={}", workspace_id, record_id);
 
     // 读取 per-workspace 防抖配置（从 blackboards 表）
     let (debounce_secs, debounce_count) = match db.get_blackboard_config(workspace_id).await {
@@ -189,7 +189,7 @@ pub async fn push_pending_todo(workspace_id: i64, todo_id: i64, db: &Arc<Databas
 
     // 检查队列长度是否达到阈值，达到则立即触发
     if let Ok(Some(board)) = db.get_blackboard(workspace_id).await {
-        let queue_len = serde_json::from_str::<Vec<i64>>(&board.pending_todo_ids)
+        let queue_len = serde_json::from_str::<Vec<i64>>(&board.pending_record_ids)
             .map(|v| v.len())
             .unwrap_or(0);
         tracing::info!(

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -807,12 +807,12 @@ impl LoopRunner {
                     .map_err(|e| e.to_string())?;
                 *consecutive_retries.get_mut(&step.id).unwrap_or(&mut 0) = 0;
 
-                // 4l. 触发黑板更新：Step 执行成功，将 todo_id 追加到黑板 pending 队列。
+                // 4l. 触发黑板更新：Step 执行成功，将 execution_record_id 追加到黑板 pending 队列。
                 // 与普通 Todo 执行完成后的处理保持一致，让 LLM 将 step 结论整合到黑板。
                 if let Some(ws_id) = loop_.workspace_id.filter(|&id| id != 0) {
-                    crate::services::blackboard_debouncer::push_pending_todo(
+                    crate::services::blackboard_debouncer::push_pending_record(
                         ws_id,
-                        step.todo_id,
+                        record_id,
                         &self.ctx.db,
                     )
                     .await;


### PR DESCRIPTION
## 背景

黑板防抖的 pending 队列之前存的是 `todo_id`，flusher 通过 `get_latest_execution_record_for_todo` 取最新结论。但 debounce 窗口内同一 todo 可能多次执行，导致中间结论丢失。

## 改动

1. **新增 V51 迁移**：添加 `blackboards.pending_record_ids` 列
2. **新增 V52 迁移**：删除 `blackboards.pending_todo_ids` 列
3. **全量 Rust 代码重命名**：
   - `pending_todo_ids` → `pending_record_ids`
   - `push_pending_todo` → `push_pending_record`
   - `append_pending_todo_id` → `append_pending_record_id`
   - `take_pending_todo_ids` → `take_pending_record_ids`
4. **flusher 逻辑改进**：按 `record_id` 直接查 `execution_record`，用第一条记录的 `todo_id` 作为 `update_blackboard` 的 `source_todo_id`

## 涉及文件

- `backend/src/db/blackboard.rs` — DB 方法重命名
- `backend/src/db/entity/blackboards.rs` — ORM 字段重命名
- `backend/src/db/migration/mod.rs` — 注册 V51/V52
- `backend/src/db/migration/v51.rs` — 新增迁移
- `backend/src/db/migration/v52.rs` — 新增迁移
- `backend/src/executor_service/completion.rs` — flusher 监听器改用 record_id
- `backend/src/handlers/mod.rs` — 注释更新
- `backend/src/services/blackboard_debouncer.rs` — push 函数重命名
- `backend/src/services/loop_runner.rs` — loop step 黑板通知改用 record_id

## 验证

- `cargo check --lib` ✅ 通过