### PR TITLE
refactor: rename 'ntd skill' to 'ntd skills' and add --all flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,13 @@ ntd loop results <execution_id>
 
 ### Skill 安装
 
-`ntd skill install` 将内置的 ntd 使用技能安装到各 AI 执行器的 skill 目录（如 `~/.claude/skills/ntd-usage/`），让 AI 执行器在执行任务时能更好地理解和使用 ntd。
+`ntd skills install` 将内置的 ntd 使用技能安装到各 AI 执行器的 skill 目录（如 `~/.claude/skills/ntd-usage/`），让 AI 执行器在执行任务时能更好地理解和使用 ntd。
 
 ```bash
-ntd skill install              # 安装到所有已配置的执行器
-ntd skill install --force       # 强制重新安装（覆盖已有）
-ntd skill install -e claudecode # 仅安装到指定执行器
+ntd skills install              # 安装到所有已知执行器
+ntd skills install --all        # 安装到所有执行器（包括 agents 只读来源）
+ntd skills install --force      # 强制重新安装（覆盖已有）
+ntd skills install -e claudecode # 仅安装到指定执行器
 ```
 
 支持的执行器：Claude Code、CodeBuddy、Opencode、MobileCoder、AtomCode、Hermes、Kimi、Pi、Codex、CodeWhale、MiMo、Zhanlu、Kilo 等（根据你配置的 AI 执行器自动适配）。

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -62,7 +62,7 @@ enum Commands {
         action: daemon::DaemonAction,
     },
     /// Manage ntd usage skills for AI executors
-    Skill {
+    Skills {
         #[command(subcommand)]
         action: SkillAction,
     },
@@ -75,6 +75,9 @@ enum SkillAction {
         /// Force reinstall even if already installed
         #[arg(short, long)]
         force: bool,
+        /// Install to all executors including agents (default: all known executors)
+        #[arg(short, long)]
+        all: bool,
         /// Only install for specific executors (comma-separated, e.g. "claudecode,atomcode")
         #[arg(short, long)]
         executor: Option<String>,
@@ -236,8 +239,8 @@ async fn main() {
             daemon::handle_daemon_command(action).await;
             return;
         }
-        Some(Commands::Skill { action: SkillAction::Install { force, executor } }) => {
-            if let Err(e) = handle_skill_install(*force, executor.as_deref()) {
+        Some(Commands::Skills { action: SkillAction::Install { force, all, executor } }) => {
+            if let Err(e) = handle_skill_install(*force, *all, executor.as_deref()) {
                 // Skill install 失败时仍用结构化 JSON 走 stderr（CLI 解析约定），
                 // 同时通过 tracing 记录带 target/level 的日志，便于日志聚合。
                 let payload = serde_json::json!({"error": true, "message": e.to_string()});
@@ -320,18 +323,22 @@ fn executor_skills_dir(et: &str) -> Option<PathBuf> {
     handlers::skills::executor_skills_dir_str(et)
 }
 
-const ALL_EXECUTORS: &[&str] = &[
+// Known executors (不含 agents，agents 是只读 skill 来源，用 --all 单独注入）
+const KNOWN_EXECUTORS: &[&str] = &[
     "claudecode", "hermes", "codex", "codebuddy",
     "opencode", "atomcode", "kimi", "mobilecoder", "codewhale", "pi", "mimo",
     "zhanlu",
 ];
 
 /// Install embedded ntd-usage skill to executor skill directories.
-fn handle_skill_install(force: bool, executor_filter: Option<&str>) -> anyhow::Result<()> {
-    let executors: Vec<&str> = if let Some(filter) = executor_filter {
+fn handle_skill_install(force: bool, all: bool, executor_filter: Option<&str>) -> anyhow::Result<()> {
+    // --all 时追加 agents，实现「所有 skill 来源都装入」语义
+    let executors: Vec<&str> = if all {
+        KNOWN_EXECUTORS.iter().copied().chain(std::iter::once("agents")).collect()
+    } else if let Some(filter) = executor_filter {
         filter.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect()
     } else {
-        ALL_EXECUTORS.to_vec()
+        KNOWN_EXECUTORS.to_vec()
     };
 
     if executors.is_empty() {
@@ -414,7 +421,7 @@ fn handle_skill_install(force: bool, executor_filter: Option<&str>) -> anyhow::R
         anyhow::bail!(
             "Unknown executor(s): {}. Supported executors: {}",
             unknown.join(", "),
-            ALL_EXECUTORS.join(", ")
+            KNOWN_EXECUTORS.join(", ")
         );
     }
     for et in &unknown {

--- a/docs/CLI_DESIGN.md
+++ b/docs/CLI_DESIGN.md
@@ -667,7 +667,7 @@ ntd stats
 | `ntd daemon stop [--system]` | 停止服务 |
 | `ntd daemon restart [--system]` | 重启服务 |
 | `ntd daemon status [--system] [-v]` | 查看状态（`-v` 追加近期日志） |
-| `ntd skill install [-f] [-e EX1,EX2,...]` | 安装 ntd-usage skill 到执行器 skills 目录 |
+| `ntd skills install [-f] [--all] [-e EX1,EX2,...]` | 安装 ntd-usage skill 到执行器 skills 目录 |
 | `ntd todo execution resume <id> [-m MSG]` | 沿用原 `session_id` 继续对话（仅 `claudecode` / `codex` / `hermes` / `kimi` / `atomcode` / `opencode` / `mobilecoder` / `codewhale` / `pi` 支持） |
 
 ---

--- a/ntd-skills/ntd-usage/SKILL.md
+++ b/ntd-skills/ntd-usage/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ntd-usage
 description: ntd (Nothing Todo) AI Todo 应用 — CLI & API 使用指南
-version: 1.0.1
-executors: [claudecode, atomcode, mobilecoder, hermes, codex, codebuddy, opencode, kimi, pi]
+version: 1.1.0
+executors: [claudecode, atomcode, mobilecoder, hermes, codex, codebuddy, opencode, kimi, pi, agents]
 ---
 
 # ntd (Nothing Todo) 使用指南
@@ -19,10 +19,18 @@ ntd daemon restart        # 重启
 ntd daemon status         # 查看状态
 ```
 
-
 ## CLI 命令参考
 
 所有 CLI 命令通过 `ntd` 二进制执行。
+
+### Skill 管理
+
+```bash
+ntd skills install              # 安装 ntd-usage skill 到所有已知执行器
+ntd skills install --all       # 安装到所有执行器，包括 agents 只读来源
+ntd skills install --force     # 强制重装
+ntd skills install -e claudecode,atomcode  # 仅安装到指定执行器
+```
 
 ### Todo 管理
 
@@ -193,7 +201,7 @@ ntd todo get 1 --output raw
 ntd todo create "分析日志" --executor claudecode --workspace /var/log
 
 # 稍后用详细 prompt 执行
-echo "请分析 /var/log/nginx/access.log 中最近 1 小时的 5xx 错误" | ntd todo execute 1 --stdin
+ntd todo execute 1 --message "请分析 /var/log/nginx/access.log 中最近 1 小时的 5xx 错误"
 
 # 发现需要更多上下文，可以 resume
 ntd execution resume 1 --message "再看看 error.log"


### PR DESCRIPTION
## Summary

- **CLI**:  →  (plural统一)
- **新 flag**:  会将 ntd-usage 安装到 agents 目录 ()，实现「所有 skill 来源都装入」语义
- **SKILL.md 更新**: v1.0.1 → v1.1.0，executors 新增 ，更新文档示例

## Files changed

-  — CLI 重命名 +  flag
-  — 版本更新 + agents 支持
-  — 文档同步
-  — 命令签名更新