### PR TITLE
fix: update 'ntd skill install' to 'ntd skills install' in all docs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -122,7 +122,7 @@ make dev
 | `ntd tag ...` | 标签管理 |
 | `ntd stats` | 全局统计 |
 | `ntd daemon install\|uninstall\|start\|stop\|restart\|status` | 服务管理 |
-| `ntd skill install [--force] [--executor claudecode,...]` | 把内置的 `ntd-usage` 技能安装到各执行器技能目录 |
+| `ntd skills install [--force] [--executor claudecode,...]` | 把内置的 `ntd-usage` 技能安装到各执行器技能目录 |
 
 ---
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -429,7 +429,7 @@ fn handle_skill_install(force: bool, all: bool, executor_filter: Option<&str>) -
     }
 
     if installed == 0 && skipped > 0 {
-        println!("All skills already installed. Use `ntd skill install --force` to reinstall.");
+        println!("All skills already installed. Use `ntd skills install --force` to reinstall.");
     } else {
         println!("Done. Installed for {} executor(s), skipped {} (already present).", installed, skipped);
     }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -254,7 +254,7 @@
 | 跨执行器对比 | 展示各执行器共有 / 独有 Skill |
 | 同步 | 选源 Skill 同步到其他执行器 |
 | 调用追踪 | 记录 Skill 调用历史,可按 Skill/执行器筛选分页 |
-| ntd-usage Skill | 内置 ntd 使用技能,`ntd skill install` 一键安装到执行器 |
+| ntd-usage Skill | 内置 ntd 使用技能,`ntd skills install` 一键安装到执行器 |
 
 ---
 

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -193,7 +193,7 @@ footer a{color:var(--accent2)}
 │  CLI 层（clap 4）                                           │
 │  ─────────────────────────────────────────────────────────  │
 │  ntd server | ntd todo | ntd loop | ntd tag | ntd daemon    │
-│  ntd skill install | ntd upgrade | ntd stats | ntd version   │
+│  ntd skills install | ntd upgrade | ntd stats | ntd version   │
 └────────────────────────┬────────────────────────────────────┘
                          │ HTTP / WebSocket / CLI 分发
 ┌────────────────────────▼────────────────────────────────────┐

--- a/docs/ntd-cli.md
+++ b/docs/ntd-cli.md
@@ -745,11 +745,11 @@ ntd daemon status -v
 >
 > 当前内嵌的 skill 是 `ntd-usage`，所有支持的执行器共享同一份内容，安装到各自的 skill 目录下。
 
-#### `ntd skill install`
+#### `ntd skills install`
 安装内嵌的 `ntd-usage` skill 到执行器技能目录。
 
 ```bash
-ntd skill install [OPTIONS]
+ntd skills install [OPTIONS]
 ```
 
 **选项：**
@@ -764,16 +764,16 @@ ntd skill install [OPTIONS]
 **示例：**
 ```bash
 # 安装到所有执行器（首次安装或大版本更新后推荐执行一次）
-ntd skill install
+ntd skills install
 
 # 仅安装到 Claude Code
-ntd skill install --executor claudecode
+ntd skills install --executor claudecode
 
 # 强制重新安装（升级 skill 内容后使用）
-ntd skill install --force
+ntd skills install --force
 
 # 强制重装到指定执行器
-ntd skill install --force --executor claudecode,atomcode
+ntd skills install --force --executor claudecode,atomcode
 ```
 
 > `--executor` 显式传值时遇到未知执行器会报错退出；不传时未知执行器会被跳过并打印警告。


### PR DESCRIPTION
## Summary
修复命令名称不一致问题：将旧名称   ✓ Installed ntd-usage skill for claudecode (1 files)
  ✓ Installed ntd-usage skill for hermes (1 files)
  ✓ Installed ntd-usage skill for codex (1 files)
  ✓ Installed ntd-usage skill for codebuddy (1 files)
  ✓ Installed ntd-usage skill for opencode (1 files)
  ✓ Installed ntd-usage skill for atomcode (1 files)
  ✓ Installed ntd-usage skill for kimi (1 files)
  ✓ Installed ntd-usage skill for mobilecoder (1 files)
  ✓ Installed ntd-usage skill for pi (1 files)
  ✓ Installed ntd-usage skill for mimo (1 files)
  ✗ Unknown executor 'codewhale', skipping
Done. Installed for 10 executor(s), skipped 0 (already present).（单数）更新为 （复数）。

## Changed files
-  — 错误提示消息
-  — 标题和示例
-  — 表格
-  — ASCII 架构图
-  — 命令参考