### PR TITLE
fix: normalize blackboard markdown — strip outer fenced code blocks

### DIFF
--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -259,11 +259,53 @@ async fn wait_for_finished(
     }
 }
 
+/// 归一化黑板 Markdown 内容：剥掉 LLM 误包的最外层 fenced code block。
+///
+/// 规则（尽量保守）：
+/// - 仅当整段内容以 ````markdown` / ````md` / ```` 开头，且以匹配的 ```` 结尾时才剥离
+/// - 内部代码块不受影响
+/// - 剥离后 trim() 一次
+/// - 不满足条件时原样返回
+///
+/// 这是"双保险"的后端侧：源头修正，防止脏数据入库。
+/// 前端也有一样的归一化逻辑作为兼容兜底。
+pub fn normalize_blackboard_markdown(content: &str) -> String {
+    let trimmed = content.trim();
+    // 快速失败：太短的内容不可能包着 fenced code block
+    if trimmed.len() < 5 {
+        return content.to_string();
+    }
+    // 匹配开头的 fenced code block：```markdown, ```md, 或纯 ```
+    // 用简单的字符串前缀匹配，避免正则开销
+    let start_marker = trimmed
+        .strip_prefix("```markdown")
+        .or_else(|| trimmed.strip_prefix("```md"))
+        .or_else(|| trimmed.strip_prefix("```"));
+    let Some(rest_after_start) = start_marker else {
+        // 不是以 ``` 开头，原样返回
+        return content.to_string();
+    };
+    // rest_after_start 可能是 '\n...' 或直接是内容，跳过开头的换行
+    let inner = rest_after_start.trim_start_matches('\n');
+    // 检查末尾是否有匹配的 ```
+    if !inner.ends_with("\n```") && inner != "```" {
+        // 末尾没有 ```，说明不是完整的外层包裹，原样返回
+        return content.to_string();
+    }
+    // 剥掉外层，trim 后返回
+    let cleaned = inner.trim_end_matches("```").trim();
+    // 剥掉后为空则返回原始内容（保护已有内容不被清空）
+    if cleaned.is_empty() {
+        return content.to_string();
+    }
+    cleaned.to_string()
+}
+
 /// 把 LLM 产出写入黑板表，必要时跳过（空内容保护）。
 ///
 /// 策略：
 /// - 产出为空 → 不覆盖现有黑板（LLM 偶发无意义输出时保护已有内容）
-/// - 产出非空 → 走 upsert，一次往返完成"创建/更新"判定 + 写入
+/// - 产出非空 → 先归一化剥掉外层 fenced markdown，再 upsert
 async fn save_blackboard(
     db: &Database,
     workspace_id: i64,
@@ -273,8 +315,10 @@ async fn save_blackboard(
     let Some(new_content) = new_content else {
         return Ok(());
     };
+    // 归一化：剥掉 LLM 误包的 ````markdown ... ```` 外层
+    let normalized = normalize_blackboard_markdown(&new_content);
     // 空内容保护：避免 LLM 偶发返回 "" 覆盖已有黑板
-    if new_content.trim().is_empty() {
+    if normalized.trim().is_empty() {
         tracing::warn!(
             "黑板更新结果为空，跳过写入: workspace_id={}",
             workspace_id
@@ -282,7 +326,7 @@ async fn save_blackboard(
         return Ok(());
     }
     // upsert：记录不存在时创建，已存在时覆盖 content/updated_at，保留 created_at
-    db.upsert_blackboard_content(workspace_id, &new_content)
+    db.upsert_blackboard_content(workspace_id, &normalized)
         .await
         .map_err(|e| AppError::Internal(format!("更新黑板失败: {}", e)))?;
     tracing::info!("黑板更新成功: workspace_id={}", workspace_id);
@@ -431,5 +475,72 @@ mod tests {
             Err(AppError::BadRequest(_)) => {}
             other => panic!("expected BadRequest, got: {:?}", other),
         }
+    }
+
+    /// 正常 Markdown 内容不应被误删。
+    #[test]
+    fn test_normalize_preserves_plain_markdown() {
+        let input = "# 工作空间进展\n\n- 已完成 A\n- 进行中 B";
+        assert_eq!(normalize_blackboard_markdown(input), input);
+    }
+
+    /// 剥掉 ````markdown 外层。
+    #[test]
+    fn test_normalize_strips_markdown_fence() {
+        let input = "```markdown\n# 工作空间进展\n\n- 已完成 A\n```";
+        let expected = "# 工作空间进展\n\n- 已完成 A";
+        assert_eq!(normalize_blackboard_markdown(input), expected);
+    }
+
+    /// 剥掉 ````md 外层。
+    #[test]
+    fn test_normalize_strips_md_fence() {
+        let input = "```md\n# 测试\n```";
+        let expected = "# 测试";
+        assert_eq!(normalize_blackboard_markdown(input), expected);
+    }
+
+    /// 剥掉纯 ```` 外层。
+    #[test]
+    fn test_normalize_strips_plain_fence() {
+        let input = "```\n# 测试\n```";
+        let expected = "# 测试";
+        assert_eq!(normalize_blackboard_markdown(input), expected);
+    }
+
+    /// 内部有代码块时不应误删。
+    #[test]
+    fn test_normalize_preserves_inner_code_blocks() {
+        let input = "# 进展\n\n```rust\nfn main() {}\n```";
+        assert_eq!(normalize_blackboard_markdown(input), input);
+    }
+
+    /// 开头有 ``` 但结尾不匹配时不删除。
+    #[test]
+    fn test_normalize_no_match_trailing_backticks() {
+        let input = "```\n# 测试";
+        assert_eq!(normalize_blackboard_markdown(input), input);
+    }
+
+    /// 剥掉外层后 trim 去除多余空白。
+    #[test]
+    fn test_normalize_trims_result() {
+        let input = "```markdown\n\n# 测试\n\n```";
+        let expected = "# 测试";
+        assert_eq!(normalize_blackboard_markdown(input), expected);
+    }
+
+    /// 空内容保护：剥掉外层后为空时返回原始内容。
+    #[test]
+    fn test_normalize_empty_inner_preserves_original() {
+        let input = "```markdown\n\n```";
+        assert_eq!(normalize_blackboard_markdown(input), input);
+    }
+
+    /// 太短的内容直接返回。
+    #[test]
+    fn test_normalize_too_short_returns_original() {
+        let input = "```";
+        assert_eq!(normalize_blackboard_markdown(input), input);
     }
 }

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -275,18 +275,17 @@ pub fn normalize_blackboard_markdown(content: &str) -> String {
     if trimmed.len() < 5 {
         return content.to_string();
     }
-    // 匹配开头的 fenced code block：```markdown, ```md, 或纯 ```
-    // 用简单的字符串前缀匹配，避免正则开销
-    let start_marker = trimmed
-        .strip_prefix("```markdown")
-        .or_else(|| trimmed.strip_prefix("```md"))
-        .or_else(|| trimmed.strip_prefix("```"));
-    let Some(rest_after_start) = start_marker else {
+    // 匹配开头的 fenced code block：``` 后跟任意语言标识符（markdown / md / code / ...），或纯 ```
+    // 找到第一个换行，将 fence 整行（```xxx）一起剥掉
+    if !trimmed.starts_with("```") {
         // 不是以 ``` 开头，原样返回
         return content.to_string();
+    }
+    let Some(first_newline) = trimmed.find('\n') else {
+        // 如果没有换行说明 fence 不完整（单行内容），原样返回
+        return content.to_string();
     };
-    // rest_after_start 可能是 '\n...' 或直接是内容，跳过开头的换行
-    let inner = rest_after_start.trim_start_matches('\n');
+    let inner = &trimmed[first_newline + 1..];
     // 检查末尾是否有匹配的 ```
     if !inner.ends_with("\n```") && inner != "```" {
         // 末尾没有 ```，说明不是完整的外层包裹，原样返回

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2257,7 +2257,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2267,7 +2266,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -22,6 +22,7 @@ import { useTheme } from '@/hooks/useTheme';
 import { useViewState } from '@/hooks/useViewState';
 import type { BlackboardDebounceStatus } from '@/hooks/useExecutionEvents';
 import { updateBlackboardConfig } from '@/utils/database/blackboard';
+import { normalizeBlackboardMarkdown } from '@/utils/markdown';
 
 const { Title } = Typography;
 
@@ -579,6 +580,8 @@ interface BlackboardContentProps {
 /** 真正渲染 Markdown：XMarkdown 内部走 DOMPurify 防止 XSS */
 function BlackboardContent(props: BlackboardContentProps) {
   const isDark = props.isDark;
+  // 前端兼容兜底：渲染前再剥一次外层 fenced markdown，保证历史脏数据也能正常显示
+  const renderedContent = normalizeBlackboardMarkdown(props.content);
   return (
     <div
       style={{
@@ -596,7 +599,7 @@ function BlackboardContent(props: BlackboardContentProps) {
         // 强制纯文本：XMarkdown 默认会注入 inline style，
         // className 包一层让主题色与外层容器保持一致
         className={isDark ? 'x-markdown-dark' : 'x-markdown-light'}
-        content={props.content}
+        content={renderedContent}
         // 覆盖 a 标签渲染：让 ntd://todo/{id} 走内部导航
         components={{ a: TodoLink }}
         // DOMPurify 默认会拒绝 ntd:// 等未知协议，会把整条链接剥成纯文本。

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -19,20 +19,20 @@ export function normalizeBlackboardMarkdown(content: string): string {
     return content;
   }
   // 匹配开头的 fenced code block：```markdown, ```md, 或纯 ```
-  const startMarker = trimmed
-    .startsWith('```markdown')
-      ? trimmed.slice(11)
-    : trimmed.startsWith('```md')
-      ? trimmed.slice(7)
-      : trimmed.startsWith('```')
-        ? trimmed.slice(3)
-        : null;
-  if (startMarker === undefined || startMarker === null) {
+  let inner: string | null = null;
+  if (trimmed.startsWith('```markdown')) {
+    inner = trimmed.slice(11);
+  } else if (trimmed.startsWith('```md')) {
+    inner = trimmed.slice(5);
+  } else if (trimmed.startsWith('```')) {
+    inner = trimmed.slice(3);
+  }
+  if (inner === null) {
     // 不是以 ``` 开头，原样返回
     return content;
   }
   // 跳过开头的换行
-  const inner = startMarker.replace(/^\n+/, '');
+  inner = inner.replace(/^\n+/, '');
   // 检查末尾是否有匹配的 ```
   if (!(inner.endsWith('\n```') || inner === '```')) {
     // 末尾没有 ```，说明不是完整的外层包裹，原样返回

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -18,21 +18,18 @@ export function normalizeBlackboardMarkdown(content: string): string {
   if (trimmed.length < 5) {
     return content;
   }
-  // 匹配开头的 fenced code block：```markdown, ```md, 或纯 ```
-  let inner: string | null = null;
-  if (trimmed.startsWith('```markdown')) {
-    inner = trimmed.slice(11);
-  } else if (trimmed.startsWith('```md')) {
-    inner = trimmed.slice(5);
-  } else if (trimmed.startsWith('```')) {
-    inner = trimmed.slice(3);
-  }
-  if (inner === null) {
+  // 匹配开头的 fenced code block：``` 后跟任意语言标识符（markdown / md / code / ...），或纯 ```
+  // 找到第一个换行，将 fence 整行（```xxx）一起剥掉
+  if (!trimmed.startsWith('```')) {
     // 不是以 ``` 开头，原样返回
     return content;
   }
-  // 跳过开头的换行
-  inner = inner.replace(/^\n+/, '');
+  const firstNewline = trimmed.indexOf('\n');
+  // 如果没有换行说明 fence 不完整（单行内容），原样返回
+  if (firstNewline < 0) {
+    return content;
+  }
+  let inner = trimmed.slice(firstNewline + 1);
   // 检查末尾是否有匹配的 ```
   if (!(inner.endsWith('\n```') || inner === '```')) {
     // 末尾没有 ```，说明不是完整的外层包裹，原样返回

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -1,6 +1,52 @@
 import yaml from 'js-yaml';
 import type { ChatMessage } from '@/types';
 
+/**
+ * 归一化黑板 Markdown 内容：剥掉 LLM 误包的最外层 fenced code block。
+ *
+ * 规则（尽量保守，与后端 normalize_blackboard_markdown 同语义）：
+ * - 仅当整段内容以 ```markdown / ```md / ``` 开头，且以匹配的 ``` 结尾时才剥离
+ * - 内部代码块不受影响
+ * - 剥离后 trim() 一次
+ * - 不满足条件时原样返回
+ *
+ * 这是"双保险"的前端侧：兼容兜底，保证历史脏数据也能正常渲染。
+ */
+export function normalizeBlackboardMarkdown(content: string): string {
+  const trimmed = content.trim();
+  // 快速失败：太短的内容不可能包着 fenced code block
+  if (trimmed.length < 5) {
+    return content;
+  }
+  // 匹配开头的 fenced code block：```markdown, ```md, 或纯 ```
+  const startMarker = trimmed
+    .startsWith('```markdown')
+      ? trimmed.slice(11)
+    : trimmed.startsWith('```md')
+      ? trimmed.slice(7)
+      : trimmed.startsWith('```')
+        ? trimmed.slice(3)
+        : null;
+  if (startMarker === undefined || startMarker === null) {
+    // 不是以 ``` 开头，原样返回
+    return content;
+  }
+  // 跳过开头的换行
+  const inner = startMarker.replace(/^\n+/, '');
+  // 检查末尾是否有匹配的 ```
+  if (!(inner.endsWith('\n```') || inner === '```')) {
+    // 末尾没有 ```，说明不是完整的外层包裹，原样返回
+    return content;
+  }
+  // 剥掉外层，trim 后返回
+  const cleaned = inner.replace(/\n*```$/, '').trim();
+  // 剥掉后为空则返回原始内容（保护已有内容不被清空）
+  if (cleaned.length === 0) {
+    return content;
+  }
+  return cleaned;
+}
+
 const STATUS_MAP: Record<string, string> = {
   success: '成功',
   failed: '失败',


### PR DESCRIPTION
## Summary

LLM sometimes wraps blackboard content in \`\`\`markdown ... \`\`\` code fences, causing @ant-design/x-markdown XMarkdown component to render raw text instead of rendered HTML.

## Fix (double insurance)

### Backend
- Add \`normalize_blackboard_markdown()\` in \`backend/src/services/blackboard.rs\`
- Call before upserting to DB — strips outer \`\`\`markdown / \`\`\`md / \`\`\` wrappers at write time
- 9 unit tests covering edge cases (all pass)

### Frontend
- Export \`normalizeBlackboardMarkdown()\` in \`frontend/src/utils/markdown.ts\` (same logic as backend)
- Call in \`BlackboardContent\` before passing to \`<XMarkdown>\` — renders historical dirty data correctly

## Strategy
- **Backend**: source-of-truth fix, prevents dirty data from accumulating in DB
- **Frontend**: compatibility fallback, renders existing dirty records immediately
- **Prompt**: not modified (靠代码层兜底 per user request)

## Test results
\`\`\`bash
cargo test --lib services::blackboard::tests::test_normalize
# 9 passed

npx tsc --noEmit  # 0 errors
\`\`\`