### PR TITLE
fix: cron 触发的 todo 任务回填 workspace_id 以进入黑板分析

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -139,6 +139,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +861,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1804,6 +1819,7 @@ dependencies = [
  "vergen-gitcl",
  "wait-timeout",
  "which",
+ "yaml-rust2",
  "zip",
 ]
 
@@ -4628,6 +4644,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a1a1c0bc9823338a3bdf8c61f994f23ac004c6fa32c08cd152984499b445e8d"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -14,6 +14,7 @@ rust-embed = "8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+yaml-rust2 = "0.9"
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }

--- a/backend/src/db/blackboard.rs
+++ b/backend/src/db/blackboard.rs
@@ -2,13 +2,42 @@
 //!
 //! 提供黑板的 CRUD 操作，每个工作空间最多一条黑板记录（由 UNIQUE 约束保证）。
 
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
 use sea_orm::{
     sea_query::OnConflict, ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait,
     QueryFilter, UpdateResult,
 };
+use tokio::sync::Mutex;
 
 use super::entity::blackboards;
 use super::Database;
+
+/// per-workspace 互斥锁，串行化 pending 队列的「读-改-写」操作。
+///
+/// 背景：`append_pending_record_id` 与 `remove_specific_pending_record_ids` 都是
+/// 非原子的「读 → 改 → 写」三步。两者并发执行时，后写的会覆盖前写的，
+/// 导致已被 remove 移除的 ID 被 append 的旧快照「复活」，队列永远不收敛——
+/// worker 反复分析同一批 record，UI 持续显示「等待刷新 / N / 阈值 条」。
+///
+/// 用 per-workspace Mutex 把同一工作空间的 append / remove 串行化，
+/// 不同 workspace 之间不互相阻塞。Mutex 懒初始化（首次用到才创建）。
+static PENDING_QUEUE_LOCKS: OnceLock<std::sync::Mutex<HashMap<i64, Arc<Mutex<()>>>>> =
+    OnceLock::new();
+
+/// 取得指定 workspace 的队列互斥锁句柄（不存在则创建）。
+///
+/// 返回 Arc<Mutex> 而非直接守卫，是因为调用方需要在 await 之前获取守卫、
+/// 在 await 之后释放，Arc 让守卫可以跨 await 点持有。
+fn queue_lock(workspace_id: i64) -> Arc<Mutex<()>> {
+    let outer = PENDING_QUEUE_LOCKS.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+    let mut guard = outer.lock().expect("PENDING_QUEUE_LOCKS poisoned");
+    guard
+        .entry(workspace_id)
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
 
 impl Database {
     /// 根据 workspace_id 获取黑板内容。
@@ -164,6 +193,13 @@ impl Database {
         workspace_id: i64,
         record_id: i64,
     ) -> Result<(), sea_orm::DbErr> {
+        // 持 per-workspace 互斥锁串行化「读-改-写」，避免与并发的
+        // remove_specific_pending_record_ids 互相覆盖：旧实现里 append 读快照后，
+        // 若期间 remove 写回了新队列，append 仍会用旧快照+push 新 ID 覆盖回去，
+        // 把已被 remove 移除的 ID「复活」，导致队列永不收敛。
+        let lock = queue_lock(workspace_id);
+        let _guard = lock.lock().await;
+
         // 读取当前队列
         let board = blackboards::Entity::find()
             .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
@@ -238,6 +274,14 @@ impl Database {
         workspace_id: i64,
         ids_to_remove: &[i64],
     ) -> Result<(), sea_orm::DbErr> {
+        // 持 per-workspace 互斥锁串行化「读-改-写」，与 append_pending_record_id 互斥。
+        // 旧实现非原子：remove 读快照后若期间 append 写回了新队列（含新 ID），
+        // remove 仍会用旧快照 retain 后的结果覆盖回去，丢失 append 刚写入的新 ID；
+        // 反之 append 读快照后若 remove 写回了精简队列，append 会把已移除的 ID「复活」。
+        // 串行化后任一时刻只有一个操作在改队列，彻底消除覆盖竞态。
+        let lock = queue_lock(workspace_id);
+        let _guard = lock.lock().await;
+
         // 读取当前队列
         let board = blackboards::Entity::find()
             .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
@@ -595,5 +639,101 @@ mod tests {
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
         assert_eq!(cfg.debounce_count, 1);
+    }
+
+    /// 并发回归测试：append 与 remove 交错执行时，队列必须正确收敛，
+    /// 不允许 append 的旧快照「复活」已被 remove 移除的 ID。
+    ///
+    /// 场景：先 append [1,2,3]，启动一个并发任务不断 append 新 ID（4..N），
+    /// 主任务同时调 remove_specific_pending_record_ids([1,2,3])。
+    /// 修复前（无互斥锁）：append 与 remove 的读-改-写交错会互相覆盖，
+    ///   要么丢新追加的 ID，要么把已移除的 1/2/3 写回来。
+    /// 修复后（per-workspace Mutex）：操作串行化，最终队列应恰好等于
+    ///   「本次并发追加的所有 ID 减去被 remove 的 [1,2,3]」，无丢失无复活。
+    ///
+    /// 由于 SQLite :memory: 单连接 + tokio 单线程协作式调度，
+    /// 真正的并发竞态需要 yield 点制造交错——append/remove 内部的 await
+    /// 就是天然的 yield 点，多任务并发调用时调度器会在这些点切换。
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_append_remove_converges_under_concurrency() {
+        let db = std::sync::Arc::new(
+            Database::new(":memory:").await.expect(":memory: must open"),
+        );
+        let ws_id = create_test_workspace(&db).await;
+        db.create_blackboard(ws_id).await.unwrap();
+
+        // 预填充 [1,2,3]
+        for id in 1..=3 {
+            db.append_pending_record_id(ws_id, id).await.unwrap();
+        }
+
+        // 并发任务：连续 append 4..=100，与主任务的 remove 交错
+        let db_clone = db.clone();
+        let append_handle = tokio::spawn(async move {
+            for id in 4..=100 {
+                // 每次都重新 clone Arc，避免 move 语义影响下一轮
+                db_clone.append_pending_record_id(ws_id, id).await.unwrap();
+            }
+        });
+
+        // 主任务：反复 remove [1,2,3]，确保它们在任何时刻都不会被「复活」
+        // 循环多次以增加与 append 交错的概率
+        for _ in 0..20 {
+            db.remove_specific_pending_record_ids(ws_id, &[1, 2, 3])
+                .await
+                .unwrap();
+        }
+
+        append_handle.await.unwrap();
+
+        // 最终一致性检查：队列应恰好包含 4..=100，不含 1/2/3
+        let board = db.get_blackboard(ws_id).await.unwrap().unwrap();
+        let ids: Vec<i64> = serde_json::from_str(&board.pending_record_ids).unwrap_or_default();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        assert_eq!(
+            sorted, (4..=100).collect::<Vec<_>>(),
+            "队列未收敛：append 与 remove 并发后应恰好是 4..=100，实际 {:?}。\
+             若含 1/2/3 说明 append 旧快照复活了已移除 ID；若缺号说明 remove 覆盖丢失了 append 的新 ID",
+            ids
+        );
+    }
+
+    /// 并发回归测试：多个 append 并发执行不应丢失任何 ID。
+    ///
+    /// 修复前：两个 append 并发读同一快照，各自 push 后写回，后写覆盖前写，
+    ///   丢失一个 ID。修复后：per-workspace Mutex 串行化，所有 append 都落库。
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_appends_no_loss() {
+        let db = std::sync::Arc::new(
+            Database::new(":memory:").await.expect(":memory: must open"),
+        );
+        let ws_id = create_test_workspace(&db).await;
+        db.create_blackboard(ws_id).await.unwrap();
+
+        // 启动 10 个并发任务，每个 append 10 个不同 ID（1..=100）
+        let mut handles = Vec::new();
+        for chunk_start in (1..=100).step_by(10) {
+            let db_clone = db.clone();
+            handles.push(tokio::spawn(async move {
+                for id in chunk_start..chunk_start + 10 {
+                    db_clone.append_pending_record_id(ws_id, id).await.unwrap();
+                }
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        // 100 个 ID 必须全部落库，无丢失
+        let board = db.get_blackboard(ws_id).await.unwrap().unwrap();
+        let ids: Vec<i64> = serde_json::from_str(&board.pending_record_ids).unwrap_or_default();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        assert_eq!(
+            sorted, (1..=100).collect::<Vec<_>>(),
+            "并发 append 丢失 ID：期望 1..=100 全部落库，实际 {:?}",
+            ids
+        );
     }
 }

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -533,10 +533,6 @@ fn spawn_flush_worker(
     refreshing_workspaces: Arc<tokio::sync::Mutex<std::collections::HashSet<i64>>>,
 ) {
     tokio::spawn(async move {
-        // 标记本次 worker 是否处理失败：失败时需要重启 timer 让残留队列再次触发，
-        // 否则队列会永久卡住（阈值分支不会启动 timer，timer 自然到期也只会发一次 flush，
-        // 失败后无后续触发源）。
-        let mut had_failure = false;
         // 单批处理的 record 上限。LLM 输出受 output_tokens（通常 4096）限制，
         // 一次塞太多 record 会让 LLM 整合的 Markdown JSON 过长被截断，extract_json_from_output
         // 解析失败 → Phase 2 失败 → 队列不清 → 下次更多 → 更易截断，恶性循环。
@@ -553,7 +549,6 @@ fn spawn_flush_worker(
                 Ok(None) => break,
                 Err(e) => {
                     tracing::warn!("读取 pending 队列失败: workspace_id={}, error={}", ws_id, e);
-                    had_failure = true;
                     break;
                 }
             };
@@ -598,9 +593,9 @@ fn spawn_flush_worker(
                     ws_id, e
                 );
                 // 失败时保留 pending 队列不删除（update_blackboard_wiki 内部
-                // 已改用 remove_specific_pending_record_ids，失败时不调用），
-                // 退出循环避免死循环；had_failure=true 触发下方 timer 重启逻辑
-                had_failure = true;
+                // 已改用 remove_specific_pending_record_ids，失败时不调用）。
+                // 退出循环避免死循环；
+                // 剩余队列由下方的 restart_timer 统一处理（不再区分失败/成功）。
                 break;
             }
             // 成功：继续循环检查是否有新记录在处理期间到达
@@ -629,12 +624,18 @@ fn spawn_flush_worker(
             refreshing: false,
         });
 
-        // 失败且有残留队列时重启防抖 timer，让队列在 debounce_secs 后再次触发 flush，
-        // 避免「等待刷新 / N / 阈值 条」永久卡死的假象。
-        if had_failure && final_pending_count > 0 {
+        // 有残留队列时重启防抖 timer，让队列在 debounce_secs 后再次触发 flush。
+        // 剩余记录可能来自：
+        // 1. 分批处理后的下一批（worker 内循环已清空，但期间又到达了新的）
+        // 2. 失败后保留的队列（update_blackboard_wiki 失败不清理）
+        // 3. worker 运行期间新到达、但 flush 消息被 per-workspace 互斥丢弃的
+        // 注意：不管 had_failure 真假都要重启——即使成功清空了本批，期间新到达
+        // 的记录也不会触发新一轮 push（阈值只在 append 时检查，没有新 append 就
+        // 不会触发），必须靠 timer 到期发起新的 flush。
+        if final_pending_count > 0 {
             tracing::info!(
-                "worker 失败退出，重启防抖 timer 让残留队列重试: workspace_id={}, pending={}",
-                ws_id, final_pending_count
+                "worker 退出，队列仍有 {} 条残留，重启防抖 timer 触发下一轮: workspace_id={}",
+                final_pending_count, ws_id
             );
             crate::services::blackboard_debouncer::restart_timer(ws_id, &db).await;
         }

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -731,6 +731,39 @@ pub async fn blackboard_flush_listener(
     let refreshing_workspaces =
         Arc::new(tokio::sync::Mutex::new(std::collections::HashSet::<i64>::new()));
 
+    // ===== 启动时扫描：为有残留队列的 workspace 重启防抖 timer =====
+    // 实例重启后 TIMER_STATES / ACTIVE_TIMERS 全部丢失，DB 中残留的 pending 记录
+    // 不会再有新的 push 触发阈值检查，也没有 worker 退出时调用 restart_timer，
+    // 导致残留队列永久卡死。启动时统一检查所有 blackboard，若有非空 pending 队列
+    // 则重启 timer，让它们在 debounce_secs 后重新触发 flush。
+    {
+        let rescan_timer = db.clone();
+        tokio::spawn(async move {
+            match rescan_timer.get_all_blackboards().await {
+                Ok(boards) => {
+                    for board in &boards {
+                        let ids: Vec<i64> = serde_json::from_str(&board.pending_record_ids)
+                            .unwrap_or_default();
+                        if !ids.is_empty() {
+                            tracing::info!(
+                                "启动时检测到黑板残留队列，重启 timer: workspace_id={}, pending={}",
+                                board.workspace_id, ids.len()
+                            );
+                            crate::services::blackboard_debouncer::restart_timer(
+                                board.workspace_id,
+                                &rescan_timer,
+                            )
+                            .await;
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("启动时扫描黑板残留队列失败: {:?}", e);
+                }
+            }
+        });
+    }
+
     loop {
         tokio::select! {
             // 每秒 ticker：广播所有已知 workspace 的状态

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -533,6 +533,10 @@ fn spawn_flush_worker(
     refreshing_workspaces: Arc<tokio::sync::Mutex<std::collections::HashSet<i64>>>,
 ) {
     tokio::spawn(async move {
+        // 标记本次 worker 是否处理失败：失败时需要重启 timer 让残留队列再次触发，
+        // 否则队列会永久卡住（阈值分支不会启动 timer，timer 自然到期也只会发一次 flush，
+        // 失败后无后续触发源）。
+        let mut had_failure = false;
         // 循环处理，直到队列为空或某次处理失败
         loop {
             // 非破坏性读取 pending 队列（不用 take_pending_record_ids）
@@ -543,6 +547,7 @@ fn spawn_flush_worker(
                 Ok(None) => break,
                 Err(e) => {
                     tracing::warn!("读取 pending 队列失败: workspace_id={}, error={}", ws_id, e);
+                    had_failure = true;
                     break;
                 }
             };
@@ -578,21 +583,45 @@ fn spawn_flush_worker(
                 );
                 // 失败时保留 pending 队列不删除（update_blackboard_wiki 内部
                 // 已改用 remove_specific_pending_record_ids，失败时不调用），
-                // 退出循环避免死循环
+                // 退出循环避免死循环；had_failure=true 触发下方 timer 重启逻辑
+                had_failure = true;
                 break;
             }
             // 成功：继续循环检查是否有新记录在处理期间到达
         }
 
-        // 广播 refreshing=false 状态
+        // 退出前从 DB 重新读取真实 pending_count。
+        // 旧实现写死 pending_count=0，但失败时队列实际仍有残留（update_blackboard_wiki
+        // 失败不调 remove_specific_pending_record_ids），下一秒 ticker 会从 DB 读回真实值，
+        // 造成 UI 在 0 和真实值之间反复跳；这里一次性广播真实值，避免抖动。
+        let final_pending_count = match db.get_blackboard(ws_id).await {
+            Ok(Some(board)) => {
+                serde_json::from_str::<Vec<i64>>(&board.pending_record_ids)
+                    .map(|v| v.len() as u64)
+                    .unwrap_or(0)
+            }
+            _ => 0,
+        };
+
+        // 广播 refreshing=false 状态（携带真实 pending_count）
         let _ = tx.send(ExecEvent::BlackboardDebounceStatus {
             workspace_id: ws_id,
-            pending_count: 0,
+            pending_count: final_pending_count,
             threshold: debounce_count as u64,
             debounce_secs: debounce_secs as u64,
             remaining_secs: -1,
             refreshing: false,
         });
+
+        // 失败且有残留队列时重启防抖 timer，让队列在 debounce_secs 后再次触发 flush，
+        // 避免「等待刷新 / N / 阈值 条」永久卡死的假象。
+        if had_failure && final_pending_count > 0 {
+            tracing::info!(
+                "worker 失败退出，重启防抖 timer 让残留队列重试: workspace_id={}, pending={}",
+                ws_id, final_pending_count
+            );
+            crate::services::blackboard_debouncer::restart_timer(ws_id, &db).await;
+        }
 
         // 释放 per-workspace 互斥锁
         let mut guard = refreshing_workspaces.lock().await;

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -537,10 +537,16 @@ fn spawn_flush_worker(
         // 否则队列会永久卡住（阈值分支不会启动 timer，timer 自然到期也只会发一次 flush，
         // 失败后无后续触发源）。
         let mut had_failure = false;
+        // 单批处理的 record 上限。LLM 输出受 output_tokens（通常 4096）限制，
+        // 一次塞太多 record 会让 LLM 整合的 Markdown JSON 过长被截断，extract_json_from_output
+        // 解析失败 → Phase 2 失败 → 队列不清 → 下次更多 → 更易截断，恶性循环。
+        // 分批让单次 LLM 输出量可控，worker 内循环会继续处理后续批次。
+        // 10 条是经验值：每条 record 结论约几百字，10 条整合后约几千字，在 4096 token 内有富余。
+        const MAX_BATCH_SIZE: usize = 10;
         // 循环处理，直到队列为空或某次处理失败
         loop {
             // 非破坏性读取 pending 队列（不用 take_pending_record_ids）
-            let record_ids = match db.get_blackboard(ws_id).await {
+            let all_record_ids = match db.get_blackboard(ws_id).await {
                 Ok(Some(board)) => {
                     serde_json::from_str::<Vec<i64>>(&board.pending_record_ids).unwrap_or_default()
                 }
@@ -551,14 +557,24 @@ fn spawn_flush_worker(
                     break;
                 }
             };
-            if record_ids.is_empty() {
+            if all_record_ids.is_empty() {
                 break;
             }
 
-            // 广播 refreshing=true 状态
+            // 分批：只取前 MAX_BATCH_SIZE 条，剩余留给下一轮循环
+            let batch_len = all_record_ids.len().min(MAX_BATCH_SIZE);
+            let record_ids: Vec<i64> = all_record_ids.iter().take(batch_len).copied().collect();
+            if record_ids.len() < all_record_ids.len() {
+                tracing::info!(
+                    "黑板 worker 分批处理: workspace_id={}, 本批={}/{}",
+                    ws_id, record_ids.len(), all_record_ids.len()
+                );
+            }
+
+            // 广播 refreshing=true 状态（用全队列长度，让 UI 看到真实剩余量）
             let _ = tx.send(ExecEvent::BlackboardDebounceStatus {
                 workspace_id: ws_id,
-                pending_count: record_ids.len() as u64,
+                pending_count: all_record_ids.len() as u64,
                 threshold: debounce_count as u64,
                 debounce_secs: debounce_secs as u64,
                 remaining_secs: -1,

--- a/backend/src/handlers/blackboard.rs
+++ b/backend/src/handlers/blackboard.rs
@@ -30,6 +30,8 @@ pub struct BlackboardResponse {
     pub wiki_index_prompt: String,
     /// Wiki 主题页面生成提示词模板（空字符串表示使用内置默认）
     pub wiki_page_prompt: String,
+    /// 待处理的 execution_record_id 列表（JSON 数组字符串，如 "[12, 34, 56]"）
+    pub pending_record_ids: String,
 }
 
 /// 页面列表项：用于 GET /pages 接口，只返回摘要信息不返回完整 content。
@@ -91,6 +93,7 @@ pub async fn get_blackboard(
             blackboard_debounce_count: model.blackboard_debounce_count,
             wiki_index_prompt: model.wiki_index_prompt,
             wiki_page_prompt: model.wiki_page_prompt,
+            pending_record_ids: model.pending_record_ids,
         })),
         None => Ok(ApiResponse::ok(BlackboardResponse {
             id: 0,
@@ -102,6 +105,7 @@ pub async fn get_blackboard(
             blackboard_debounce_count: 10,
             wiki_index_prompt: String::new(),
             wiki_page_prompt: String::new(),
+            pending_record_ids: String::from("[]"),
         })),
     }
 }

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -469,6 +469,13 @@ impl TodoScheduler {
                         };
                         let executor = todo.executor.clone();
                         info!("Scheduled execution triggered for todo {}", todo_id);
+                        // 从 todo 自身回填 workspace_id / workspace_path。
+                        // 早期实现把两者都置 None，导致 cron 触发的任务在执行完成后，
+                        // 黑板更新钩子（completion.rs：仅当 workspace_id 为 Some 时才
+                        // push pending record）被跳过，cron 任务永远进不了黑板分析。
+                        // 这里取自 DB 的 todo 字段，与手动触发路径保持一致。
+                        let workspace_id = todo.workspace_id;
+                        let workspace_path = todo.workspace_path.clone();
                         run_todo_execution(RunTodoExecutionRequest {
                             db,
                             executor_registry: registry,
@@ -488,8 +495,8 @@ impl TodoScheduler {
                             feishu_bot_id: None,
                             step_id: None,
                             feishu_receive_id: None,
-                            workspace_path: None,
-                            workspace_id: None,
+                            workspace_path,
+                            workspace_id,
                         })
                         .await;
                     }

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -646,42 +646,78 @@ async fn run_execute_phase(
 /// 原样保留，无需转义引号/反斜杠，LLM 输出更稳更短更不易截断。JSON 转义大段
 /// 文本容易出错且 token 占用大，已废弃。旧数据不保留，新 todo 一律输出 YAML。
 fn extract_yaml_from_output(raw: &str) -> Result<serde_json::Value, AppError> {
-    use regex::Regex;
-    use std::sync::OnceLock;
-
-    // 正则编译开销不小，用 OnceLock 缓存编译结果，多次调用复用。
-    // (?s) 让 . 匹配换行；非贪婪 .*? 确保停在第一个闭合 ```。
-    static RE: OnceLock<Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| {
-        Regex::new(r"(?s)```yaml\s*\n(.*?)```").expect("yaml fence regex must compile")
-    });
-
-    // 先尝试从 ```yaml ``` 包裹块提取
-    if let Some(caps) = re.captures(raw) {
-        let inner = caps.get(1).map(|m| m.as_str()).unwrap_or("").trim();
-        if !inner.is_empty() {
-            match serde_yaml::from_str::<serde_json::Value>(inner) {
-                Ok(v) => return Ok(v),
-                Err(e) => {
-                    return Err(AppError::Internal(format!(
-                        "YAML 代码块内容解析失败: {:?}; 内容前 200 字: {:?}",
-                        e,
-                        inner.chars().take(200).collect::<String>()
-                    )));
-                }
+    // 第一步：从 ```yaml ``` 包裹块中提取 YAML 内容（若存在）
+    let trimmed = raw.trim();
+    if let Some(fence_start) = trimmed.find("```yaml") {
+        let after_fence = &trimmed[fence_start + 7..];  // skip "```yaml"
+        // 跳过第一个换行或空白
+        let after_newline = after_fence.trim_start();
+        if let Some(fence_end) = after_newline.find("```") {
+            let inner = after_newline[..fence_end].trim();
+            if !inner.is_empty() {
+                return parse_yaml_to_json(inner);
             }
         }
     }
 
     // 回退：整段当 YAML 直接解析（LLM 偶尔不按格式包裹时兜底）
-    let trimmed = raw.trim();
-    match serde_yaml::from_str::<serde_json::Value>(trimmed) {
-        Ok(v) => Ok(v),
-        Err(e) => Err(AppError::Internal(format!(
+    parse_yaml_to_json(trimmed).map_err(|e| {
+        let preview: String = trimmed.chars().take(200).collect();
+        AppError::Internal(format!(
             "无法从 LLM 输出提取 YAML（未找到 ```yaml ``` 包裹块且整段解析失败）: {:?}; 内容前 200 字: {:?}",
+            e, preview
+        ))
+    })
+}
+
+/// 用 yaml_rust2 解析 YAML 字符串为 serde_json::Value。
+///
+/// serde_yaml 0.9 对 value 中中文引号字符「」有解析 bug（libyaml 绑定限制），
+/// yaml_rust2 是纯 Rust 实现，无此问题。本函数作为 serde_yaml 的替换物。
+fn parse_yaml_to_json(yaml_str: &str) -> Result<serde_json::Value, AppError> {
+    use yaml_rust2::{Yaml, YamlLoader};
+
+    let docs = YamlLoader::load_from_str(yaml_str).map_err(|e| {
+        AppError::Internal(format!(
+            "YAML 解析失败: {:?}; 内容前 200 字: {:?}",
             e,
-            trimmed.chars().take(200).collect::<String>()
-        ))),
+            yaml_str.chars().take(200).collect::<String>()
+        ))
+    })?;
+
+    let doc = docs.into_iter().next().unwrap_or(Yaml::Null);
+    Ok(yaml_to_json_value(&doc))
+}
+
+/// 递归将 yaml_rust2::Yaml 枚举转为 serde_json::Value。
+fn yaml_to_json_value(y: &yaml_rust2::Yaml) -> serde_json::Value {
+    use yaml_rust2::Yaml;
+    match y {
+        Yaml::Null | Yaml::BadValue => serde_json::Value::Null,
+        Yaml::Boolean(b) => serde_json::Value::Bool(*b),
+        Yaml::Integer(i) => serde_json::Value::Number(serde_json::Number::from(*i)),
+        Yaml::Real(s) => {
+            s.parse::<f64>().ok()
+                .and_then(|f| serde_json::Number::from_f64(f))
+                .map(serde_json::Value::Number)
+                .unwrap_or_else(|| serde_json::Value::String(s.clone()))
+        }
+        Yaml::String(s) => serde_json::Value::String(s.clone()),
+        Yaml::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(yaml_to_json_value).collect())
+        }
+        Yaml::Hash(hash) => {
+            let mut map = serde_json::Map::new();
+            for (k, v) in hash {
+                let key = match k {
+                    Yaml::String(s) => s.clone(),
+                    other => format!("{:?}", other),
+                };
+                map.insert(key, yaml_to_json_value(v));
+            }
+            serde_json::Value::Object(map)
+        }
+        Yaml::Alias(i) => serde_json::Value::Number(serde_json::Number::from(*i as i64)),
     }
 }
 

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -684,6 +684,15 @@ pub async fn update_blackboard_wiki(
 
     if operations.is_empty() {
         tracing::info!("Wiki 分析结果为空操作，跳过执行阶段: workspace_id={}", workspace_id);
+        // 即使 LLM 判定本批 record 无需更新任何页面，也必须从 pending 队列移除已处理的 ID。
+        // 旧实现直接 return Ok() 跳过 Phase 6 的清理，导致这批 record 永远留在队列里：
+        // worker 内循环下一轮 get_blackboard 又读到同样的 ID，再次调用本函数又得到空 operations，
+        // 形成「分析→空→不清理→再分析同一批」的静默死循环，UI 持续显示
+        // 「刷新中 / N / 阈值 条」却永不收敛。空操作是合法的 LLM 判断结果，
+        // 应视为已成功处理。
+        db.remove_specific_pending_record_ids(workspace_id, &pending_record_ids).await.map_err(|e| {
+            AppError::Internal(format!("空操作分支：移除已处理 pending 记录失败: {:?}", e))
+        })?;
         return Ok(());
     }
 

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -670,7 +670,17 @@ pub async fn update_blackboard_wiki(
     pending_record_ids: Vec<i64>,
 ) -> Result<(), AppError> {
     // Phase 1: 分析
-    let operations = run_analyze_phase(
+    //
+    // 失败清理约定：本函数有多个失败提前返回点（Phase 1 分析失败、Phase 2 执行失败、
+    // Phase 3-5 落库失败）。旧实现用 `?` 直接返回，跳过 Phase 6 的 remove_specific_pending_record_ids，
+    // 导致这批 record 永远留在 pending 队列。下次 worker 又读到同一批 ID，又调 LLM，又失败……
+    // 形成「失败→不清理→重试同一批→又失败」的死循环。当失败原因是 LLM 输出截断（output_tokens
+    // 上限）时，队列越长 LLM 输出越长越易截断，越易失败越积越多，恶性循环直至无解。
+    //
+    // 修复：任何失败路径都先调 remove_specific_pending_record_ids 清理本批已处理 ID，
+    // 把这批 record 视为「处理失败已放弃」，记 warn 但不重试。代价是这批 record 的结论
+    // 不会写入 wiki，但换来队列能继续往前走、新 record 能正常处理。优于永久卡死。
+    let operations = match run_analyze_phase(
         db.clone(),
         executor_registry.clone(),
         tx.clone(),
@@ -678,9 +688,18 @@ pub async fn update_blackboard_wiki(
         config.clone(),
         workspace_id,
         pending_record_ids.clone(),
-    ).await.map_err(|e| {
-        AppError::Internal(format!("Wiki 分析阶段失败: {:?}", e))
-    })?;
+    ).await {
+        Ok(ops) => ops,
+        Err(e) => {
+            // 分析失败：清理本批 record 避免死循环重试，记录 warn 供排查
+            let err_msg = format!("Wiki 分析阶段失败: {:?}", e);
+            tracing::warn!("黑板分析失败，放弃本批 record: workspace_id={}, pending_count={}, error={}", workspace_id, pending_record_ids.len(), err_msg);
+            if let Err(cleanup_err) = db.remove_specific_pending_record_ids(workspace_id, &pending_record_ids).await {
+                tracing::warn!("分析失败后清理 pending 队列又失败: workspace_id={}, error={:?}", workspace_id, cleanup_err);
+            }
+            return Err(AppError::Internal(err_msg));
+        }
+    };
 
     if operations.is_empty() {
         tracing::info!("Wiki 分析结果为空操作，跳过执行阶段: workspace_id={}", workspace_id);
@@ -697,7 +716,11 @@ pub async fn update_blackboard_wiki(
     }
 
     // Phase 2: 执行
-    let page_contents = run_execute_phase(
+    //
+    // 同 Phase 1 约定：失败时清理本批 record 避免死循环。
+    // 这是最常见的失败点——LLM 输出被 output_tokens 上限截断，JSON 不完整无法解析。
+    // 清理后这批 record 的结论不会写入 wiki，但队列能继续往前走。
+    let page_contents = match run_execute_phase(
         db.clone(),
         executor_registry,
         tx,
@@ -705,9 +728,17 @@ pub async fn update_blackboard_wiki(
         config,
         workspace_id,
         &operations,
-    ).await.map_err(|e| {
-        AppError::Internal(format!("Wiki 执行阶段失败: {:?}", e))
-    })?;
+    ).await {
+        Ok(map) => map,
+        Err(e) => {
+            let err_msg = format!("Wiki 执行阶段失败: {:?}", e);
+            tracing::warn!("黑板执行失败，放弃本批 record: workspace_id={}, pending_count={}, error={}", workspace_id, pending_record_ids.len(), err_msg);
+            if let Err(cleanup_err) = db.remove_specific_pending_record_ids(workspace_id, &pending_record_ids).await {
+                tracing::warn!("执行失败后清理 pending 队列又失败: workspace_id={}, error={:?}", workspace_id, cleanup_err);
+            }
+            return Err(AppError::Internal(err_msg));
+        }
+    };
 
     // Phase 3: 落库 — 逐个 upsert topic 页面
     for op in &operations {

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -99,7 +99,10 @@ async fn find_or_create_wiki_todo(
 /// - `{{page_summaries}}`：现有页面列表（slug + title + 摘要）
 /// - `{{pending_record_ids}}`：待分析的执行记录 ID 列表
 ///
-/// 输出要求：严格 JSON 格式，包含 operations 数组，每项描述 create/update 哪个页面。
+/// 输出要求：严格 YAML 格式，包含 operations 数组，每项描述 create/update 哪个页面。
+///
+/// 为什么用 YAML 而非 JSON：YAML 用缩进表达结构，无需引号/反斜杠转义，
+/// LLM 输出更稳更短，不易因转义错误或 token 截断导致解析失败。
 fn build_wiki_analyze_prompt() -> String {
     r##"你是一个工作空间黑板维护者。你的任务是分析新的执行记录，决定它们应该归到哪些主题页面。
 
@@ -118,28 +121,24 @@ fn build_wiki_analyze_prompt() -> String {
 1. 逐个调用 `ntd todo execution get <id>` 获取每条执行记录的完整结论
 2. 仔细分析每条结论涉及哪些主题领域
 3. 根据分析结果决定：是创建新页面还是更新现有页面
-4. 输出严格的 JSON 格式，不要输出任何其他解释
+4. 输出严格的 YAML 格式，不要输出任何其他解释
 
 输出格式：
-```json
-{
-  "operations": [
-    {
-      "action": "create",
-      "slug": "auth-module",
-      "title": "认证模块",
-      "summary": "关于 JWT 验证、token 刷新、权限控制的结论汇总",
-      "record_ids": [42, 45]
-    },
-    {
-      "action": "update",
-      "slug": "performance",
-      "title": "性能优化",
-      "summary": "数据库查询优化、缓存策略、接口响应时间",
-      "record_ids": [47]
-    }
-  ]
-}
+```yaml
+operations:
+  - action: create
+    slug: auth-module
+    title: 认证模块
+    summary: 关于 JWT 验证、token 刷新、权限控制的结论汇总
+    record_ids:
+      - 42
+      - 45
+  - action: update
+    slug: performance
+    title: 性能优化
+    summary: 数据库查询优化、缓存策略、接口响应时间
+    record_ids:
+      - 47
 ```
 
 要求：
@@ -149,24 +148,28 @@ fn build_wiki_analyze_prompt() -> String {
 - record_ids 列出涉及的执行记录 ID
 - 如果结论涉及多个主题，可以分配到多个页面
 - 不要创建过于细碎的页面，尽量将相关结论归到同一主题下
-- 只输出 JSON，不要输出其他任何文字"##.to_string()
+- 整个 YAML 内容必须用 ```yaml 起始、``` 结尾的代码块包裹，不要在代码块外输出任何文字"##.to_string()
 }
 
 /// 构建 Wiki 执行阶段的 Prompt 模板（第二次调用）。
 ///
 /// 输入占位符：
-/// - `{{operations_json}}`：分析阶段输出的操作列表 JSON
+/// - `{{operations_json}}`：分析阶段输出的操作列表（YAML 字符串）
 /// - `{{page_contents}}`：待更新页面的当前内容（仅包含 operations 中涉及的页面）
 ///
-/// 输出要求：严格 JSON 格式，key 为 slug，value 为新的 Markdown 内容。
+/// 输出要求：严格 YAML 格式，key 为 slug，value 为 Markdown 内容。
+///
+/// 为什么用 YAML 而非 JSON：执行阶段 value 是大段 Markdown，含大量引号/换行/反斜杠。
+/// JSON 要对这些字符转义，LLM 容易转义出错或截断在转义中途；YAML 字面量块标量
+/// （`|`）能原样保留大段文本，几乎零转义负担，LLM 输出更稳更短更不易截断。
 fn build_wiki_execute_prompt() -> String {
     r##"你是一个工作空间黑板维护者。你的任务是根据分析结果，更新或创建主题页面的 Markdown 内容。
 
 你拥有以下工具，可以直接在执行过程中调用：
 - `ntd todo execution get <id>`：获取指定执行记录的完整结论（result 字段）。例如：`ntd todo execution get 42` 获取第 42 条执行记录的结论。
 
-操作列表（JSON）：
-```json
+操作列表（YAML）：
+```yaml
 {{operations_json}}
 ```
 
@@ -190,15 +193,26 @@ fn build_wiki_execute_prompt() -> String {
 5. 如果新结论与已有结论矛盾，在"矛盾/风险"中标注
 6. 保持 Markdown 格式，不要添加 HTML
 
-输出严格的 JSON 格式，key 为页面 slug，value 为完整的 Markdown 内容：
-```json
-{
-  "auth-module": "# 认证模块\n\n## 已确认\n- ...",
-  "performance": "# 性能优化\n\n## 已确认\n- ..."
-}
+输出严格的 YAML 格式，整体用 ```yaml ``` 代码块包裹，key 为页面 slug，value 为完整的 Markdown 内容。
+value 用 YAML 字面量块标量 `|` 表达，可原样保留多行 Markdown，无需转义引号或换行：
+
+```yaml
+auth-module: |
+  # 认证模块
+
+  ## 已确认
+  - ...
+performance: |
+  # 性能优化
+
+  ## 已确认
+  - ...
 ```
 
-只输出 JSON，不要输出其他任何文字。"##.to_string()
+要求：
+- 整个 YAML 内容必须用 ```yaml 起始、``` 结尾的代码块包裹，不要在代码块外输出任何文字
+- value 一律用 `|` 字面量块标量，不要用引号包裹
+- 不要输出其他任何文字"##.to_string()
 }
 
 /// 启动 blackboard todo 执行并阻塞等待它的 Finished 事件，返回 LLM 产出的新内容。
@@ -525,9 +539,9 @@ async fn run_analyze_phase(
         params,
     ).await?;
 
-    // 5. 解析输出为 JSON operations 数组
+    // 5. 解析输出为 YAML operations 数组
     let raw = result.ok_or_else(|| AppError::Internal("分析阶段未产出结果".to_string()))?;
-    let parsed = extract_json_from_output(&raw)?;
+    let parsed = extract_yaml_from_output(&raw)?;
     let ops = parsed.get("operations")
         .and_then(|v| v.as_array())
         .ok_or_else(|| AppError::Internal("分析阶段输出缺少 operations 数组".to_string()))?;
@@ -538,7 +552,7 @@ async fn run_analyze_phase(
 /// 第二次 LLM 调用：执行阶段 — 写页面内容。
 ///
 /// 输入：operations + 待更新页面的当前内容
-/// 输出：{slug: markdown_content} JSON 对象
+/// 输出：{slug: markdown_content} YAML 映射（反序列化后即 serde_json::Map）
 async fn run_execute_phase(
     db: Arc<Database>,
     executor_registry: Arc<ExecutorRegistry>,
@@ -607,49 +621,68 @@ async fn run_execute_phase(
         params,
     ).await?;
 
-    // 6. 解析输出为 {slug: content} JSON 对象
+    // 6. 解析输出为 {slug: content} YAML 映射
     let raw = result.ok_or_else(|| AppError::Internal("执行阶段未产出结果".to_string()))?;
-    let parsed = extract_json_from_output(&raw)?;
+    let parsed = extract_yaml_from_output(&raw)?;
     let map = parsed.as_object()
-        .ok_or_else(|| AppError::Internal("执行阶段输出不是 JSON 对象".to_string()))?;
+        .ok_or_else(|| AppError::Internal("执行阶段输出不是 YAML 映射".to_string()))?;
 
     Ok(map.clone())
 }
 
-/// 从 LLM 输出中提取 JSON（兼容被 ```json 代码块包裹的情况）。
+/// 从 LLM 输出中提取 YAML（要求被 ```yaml ... ``` 代码块包裹）。
 ///
-/// LLM 有时会在 JSON 外加 markdown 代码块标记，需要剥掉才能解析。
-fn extract_json_from_output(raw: &str) -> Result<serde_json::Value, AppError> {
+/// 设计：prompt 强制 LLM 把 YAML 内容用 ```yaml 起始、``` 结尾的代码块包裹，
+/// 解析器用正则 `(?s)```yaml\s*\n(.*?)``` ` 非贪婪匹配代码块内部内容，
+/// 再交给 serde_yaml 反序列化为 serde_json::Value（结构契约不变，调用方
+/// 仍用 .get("operations") / .as_object() 访问）。
+///
+/// 为什么用正则而非 find: 旧 JSON 解析器用 `find("```yaml")` + `find("```")`
+/// 找闭合标记，遇到 YAML 内容里嵌套的 ``` （比如 Markdown 示例）会错位截断。
+/// 正则 `(.*?)```` 非贪婪匹配第一个闭合 ```，配合 `(?s)` 让 `.` 匹配换行，
+/// 既能跨多行又能停在第一个闭合标记，更鲁棒。
+///
+/// 为什么只支持 YAML 不兼容 JSON: YAML 对大段 Markdown 文本用字面量块标量 `|`
+/// 原样保留，无需转义引号/反斜杠，LLM 输出更稳更短更不易截断。JSON 转义大段
+/// 文本容易出错且 token 占用大，已废弃。旧数据不保留，新 todo 一律输出 YAML。
+fn extract_yaml_from_output(raw: &str) -> Result<serde_json::Value, AppError> {
+    use regex::Regex;
+    use std::sync::OnceLock;
+
+    // 正则编译开销不小，用 OnceLock 缓存编译结果，多次调用复用。
+    // (?s) 让 . 匹配换行；非贪婪 .*? 确保停在第一个闭合 ```。
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r"(?s)```yaml\s*\n(.*?)```").expect("yaml fence regex must compile")
+    });
+
+    // 先尝试从 ```yaml ``` 包裹块提取
+    if let Some(caps) = re.captures(raw) {
+        let inner = caps.get(1).map(|m| m.as_str()).unwrap_or("").trim();
+        if !inner.is_empty() {
+            match serde_yaml::from_str::<serde_json::Value>(inner) {
+                Ok(v) => return Ok(v),
+                Err(e) => {
+                    return Err(AppError::Internal(format!(
+                        "YAML 代码块内容解析失败: {:?}; 内容前 200 字: {:?}",
+                        e,
+                        inner.chars().take(200).collect::<String>()
+                    )));
+                }
+            }
+        }
+    }
+
+    // 回退：整段当 YAML 直接解析（LLM 偶尔不按格式包裹时兜底）
     let trimmed = raw.trim();
-    // 尝试直接解析
-    if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
-        return Ok(v);
+    match serde_yaml::from_str::<serde_json::Value>(trimmed) {
+        Ok(v) => Ok(v),
+        Err(e) => Err(AppError::Internal(format!(
+            "无法从 LLM 输出提取 YAML（未找到 ```yaml ``` 包裹块且整段解析失败）: {:?}; 内容前 200 字: {:?}",
+            e,
+            trimmed.chars().take(200).collect::<String>()
+        ))),
     }
-    // 尝试剥掉 ```json ... ``` 包裹
-    if let Some(start) = trimmed.find("```json") {
-        let rest = &trimmed[start + 7..];
-        if let Some(end) = rest.find("```") {
-            let inner = rest[..end].trim();
-            if let Ok(v) = serde_json::from_str::<serde_json::Value>(inner) {
-                return Ok(v);
-            }
-        }
-    }
-    // 尝试剥掉 ``` ... ``` 包裹（无 json 标记）
-    if let Some(start) = trimmed.find("```") {
-        let rest = &trimmed[start + 3..];
-        if let Some(end) = rest.find("```") {
-            let inner = rest[..end].trim();
-            if let Ok(v) = serde_json::from_str::<serde_json::Value>(inner) {
-                return Ok(v);
-            }
-        }
-    }
-    // 按字符截断前 200 字，避免按字节切片在多字节字符（如中文）边界处 panic
-    Err(AppError::Internal(format!(
-        "无法解析 LLM 输出为 JSON: {:?}",
-        trimmed.chars().take(200).collect::<String>()
-    )))
 }
 
 /// Wiki 模式：更新黑板（两次 LLM 调用 + index/log 自动生成）。
@@ -864,5 +897,133 @@ mod tests {
     fn test_normalize_too_short_returns_original() {
         let input = "```";
         assert_eq!(normalize_blackboard_markdown(input), input);
+    }
+
+    // ===== extract_yaml_from_output 单元测试 =====
+    //
+    // 覆盖四个场景：标准包裹、Markdown 内嵌 ``` 不误截、缺包裹块回退整段解析、
+    // YAML 语法错误返回 Err。这些场景对应生产中 LLM 输出的真实变体，
+    // 确保解析器鲁棒性。
+
+    /// 标准 ```yaml ``` 包裹的 operations 数组能正确解析。
+    #[test]
+    fn test_extract_yaml_standard_fence_operations() {
+        let raw = r#"```yaml
+operations:
+  - action: create
+    slug: auth-module
+    title: 认证模块
+    summary: JWT 验证汇总
+    record_ids:
+      - 42
+      - 45
+```
+"#;
+        let v = extract_yaml_from_output(raw).expect("标准包裹必须解析成功");
+        let ops = v.get("operations").and_then(|o| o.as_array()).expect("必须有 operations 数组");
+        assert_eq!(ops.len(), 1);
+        let op = &ops[0];
+        assert_eq!(op.get("action").and_then(|v| v.as_str()), Some("create"));
+        assert_eq!(op.get("slug").and_then(|v| v.as_str()), Some("auth-module"));
+        let record_ids: Vec<i64> = op.get("record_ids")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_i64()).collect())
+            .unwrap_or_default();
+        assert_eq!(record_ids, vec![42, 45]);
+    }
+
+    /// execute 阶段输出：slug → Markdown 字面量块标量，能原样保留多行内容。
+    /// 这是 YAML 相对 JSON 的核心优势——大段 Markdown 无需转义。
+    #[test]
+    fn test_extract_yaml_execute_phase_literal_block() {
+        let raw = r#"```yaml
+auth-module: |
+  # 认证模块
+
+  ## 已确认
+  - JWT 验证已实现，含 "引号" 和 `反引号`
+  - token 刷新策略：见 [record_42](/?view=items&id=10)
+performance: |
+  # 性能优化
+
+  ## 已确认
+  - 查询耗时下降 50%
+```
+"#;
+        let v = extract_yaml_from_output(raw).expect("execute phase YAML 必须解析成功");
+        let map = v.as_object().expect("必须是映射");
+        assert_eq!(map.len(), 2);
+        let auth = map.get("auth-module").and_then(|v| v.as_str()).expect("auth-module 必须存在");
+        assert!(auth.contains("# 认证模块"));
+        assert!(auth.contains("含 \"引号\" 和 `反引号`"));
+        assert!(auth.contains("[record_42]"));
+    }
+
+    /// LLM 在 YAML 前后输出了自然语言前缀/后缀，正则仍能精准提取代码块内容。
+    /// 这是正则相比旧 find 方案的优势——不依赖整段是合法 YAML。
+    #[test]
+    fn test_extract_yaml_tolerates_surrounding_prose() {
+        let raw = r#"Now I have all the data. Let me output the YAML.
+
+```yaml
+operations:
+  - action: update
+    slug: perf
+    title: 性能
+    summary: 优化
+    record_ids:
+      - 7
+```
+
+Done. Above is the YAML.
+"#;
+        let v = extract_yaml_from_output(raw).expect("有包裹块时必须提取成功，忽略前后自然语言");
+        let ops = v.get("operations").and_then(|o| o.as_array()).expect("operations 必须存在");
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].get("slug").and_then(|v| v.as_str()), Some("perf"));
+    }
+
+    /// 缺少 ```yaml ``` 包裹时，回退到整段当 YAML 解析。
+    /// LLM 偶尔不按格式包裹，回退保证兜底可用。
+    #[test]
+    fn test_extract_yaml_fallback_when_no_fence() {
+        let raw = "operations:\n  - action: create\n    slug: x\n    title: X\n    summary: s\n    record_ids: []\n";
+        let v = extract_yaml_from_output(raw).expect("无包裹块时回退整段解析应成功");
+        assert!(v.get("operations").is_some());
+    }
+
+    /// 既无包裹块、整段也不是合法 YAML 时，返回 Err 并附前 200 字诊断。
+    ///
+    /// 注意 YAML 的宽容性：纯文本无冒号会被当成合法字符串标量解析成功，
+    /// 所以测试输入必须用真正违反 YAML 语法的结构（如非法缩进映射）。
+    #[test]
+    fn test_extract_yaml_returns_err_for_garbage() {
+        // 非法 YAML：映射 key 后跟另一个冒号，语法错误
+        let raw = "key: : value: broken\n  - : :\n";
+        let err = extract_yaml_from_output(raw).expect_err("非法 YAML 必须返回 Err");
+        let msg = format!("{:?}", err);
+        assert!(msg.contains("YAML") || msg.contains("yaml"), "错误信息应提示 YAML: {}", msg);
+    }
+
+    /// YAML value 里含普通代码（无 ``` fence），字面量块标量能原样保留。
+    ///
+    /// 注意：不测试 value 里嵌套 ``` 的场景——那是 fence 协议的歧义，
+    /// 非贪婪正则无法区分「内容里的 ```」和「真正的闭合 ```」。
+    /// 正确做法是 prompt 约束 LLM 不要在 value 里用 ``` fence，
+    /// 而非试图解析这种歧义。这里只验证普通代码（缩进块）能正常保留。
+    #[test]
+    fn test_extract_yaml_value_with_plain_code_block() {
+        let raw = r#"```yaml
+guide: |
+  示例代码（无 fence，纯缩进）：
+      print('hi')
+      echo 'bye'
+  上述代码应原样保留。
+```
+"#;
+        let v = extract_yaml_from_output(raw).expect("普通代码内容不应破坏解析");
+        let guide = v.get("guide").and_then(|v| v.as_str()).expect("guide 字段必须存在");
+        assert!(guide.contains("print('hi')"), "代码内容应完整保留: {:?}", guide);
+        assert!(guide.contains("echo 'bye'"), "多行代码应完整保留: {:?}", guide);
     }
 }

--- a/backend/src/services/blackboard_debouncer.rs
+++ b/backend/src/services/blackboard_debouncer.rs
@@ -201,13 +201,16 @@ pub async fn push_pending_record(workspace_id: i64, record_id: i64, db: &Arc<Dat
                 "黑板 pending 队列达到阈值 {} 条，立即触发: workspace_id={}",
                 queue_len, workspace_id
             );
-            // 阈值触发时清除 timer 状态，避免 flush listener 再次等待
-            {
-                let mut states = TIMER_STATES.write().await;
-                if let Some(map) = states.as_mut() {
-                    map.remove(&workspace_id);
-                }
-            }
+            // 注意：此处不再清除 TIMER_STATES。
+            // 旧实现提前删除 timer 状态，会在 worker 真正 spawn 起来、把 workspace
+            // 加入 refreshing_workspaces 之前，制造一个时间窗口：每秒 ticker 调用
+            // build_blackboard_status 时 get_timer_state 返回 None → remaining_secs=-1
+            // → 前端 hasTimer=false 且 pending_count>0 → 渲染为「等待刷新」，与
+            // 「条数已远超阈值」的事实矛盾。
+            // 保留 timer 状态让前端继续显示倒计时；worker 接管后由 refreshing=true
+            // 表达「正在刷新」语义。即使 timer 自然到期再发一次 flush 消息，
+            // handle_flush_msg 的 per-workspace 互斥会安全丢弃重复消息，不会 spawn
+            // 第二个 worker。
             let tx = {
                 let guard = FLUSH_TX.read().await;
                 guard.as_ref().cloned()
@@ -223,7 +226,18 @@ pub async fn push_pending_record(workspace_id: i64, record_id: i64, db: &Arc<Dat
         }
     }
 
-    // 未达阈值，检查并启动 timer
+    // 未达阈值，启动防抖 timer（若尚未运行）
+    start_timer(workspace_id, debounce_secs).await;
+}
+
+/// 启动 per-workspace 防抖 timer（若该 workspace 已有 timer 运行中则不重复启动）。
+///
+/// 抽取自 `push_pending_record` 的后半段，同时供 worker 失败重试调用：
+/// worker 处理失败时 pending 队列保留，需要重新启动 timer 让队列在下一周期再次触发，
+/// 否则队列会永久卡住（阈值分支注释「达到阈值触发后，不等 timer」意味着失败后没人会再触发）。
+async fn start_timer(workspace_id: i64, debounce_secs: i64) {
+    // 检查并标记 timer 运行中：用 ACTIVE_TIMERS 的 bool 标志做互斥，
+    // 避免同一 workspace 重复 spawn 多个 sleep 任务导致重复 flush。
     {
         let timers = ACTIVE_TIMERS.get().expect("ActiveTimers 未初始化");
         let mut timers = timers.write().await;
@@ -286,4 +300,29 @@ pub async fn push_pending_record(workspace_id: i64, record_id: i64, db: &Arc<Dat
             }
         }
     });
+}
+
+/// 重新启动 per-workspace 防抖 timer，用于 worker 处理失败后的恢复。
+///
+/// 场景：`update_blackboard_wiki` 失败时 pending 队列保留（`remove_specific_pending_record_ids`
+/// 未调用），但阈值触发分支不会启动 timer。若不主动恢复，残留队列将永久卡住，UI 持续显示
+/// 「等待刷新 / N / 阈值 条」却永不触发刷新。
+///
+/// 本函数从 DB 重新读取该 workspace 的防抖配置后调用 `start_timer`，
+/// 让队列在 `debounce_secs` 秒后再次触发 flush，给 LLM 一个重试窗口。
+/// 若 DB 读取失败则回退默认防抖值（600s），保证队列最终能再次触发而非永久挂起。
+pub async fn restart_timer(workspace_id: i64, db: &Arc<Database>) {
+    // 复用 push_pending_record 的默认值逻辑：DB 错误时回退默认值保证可用性
+    let debounce_secs = match db.get_blackboard_config(workspace_id).await {
+        Ok(Some(cfg)) => cfg.debounce_secs,
+        Ok(None) => 600,
+        Err(e) => {
+            tracing::warn!(
+                "restart_timer 读取黑板配置失败，使用默认值: workspace_id={}, error={}",
+                workspace_id, e
+            );
+            600
+        }
+    };
+    start_timer(workspace_id, debounce_secs).await;
 }

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -19,13 +19,13 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Button, Typography, Skeleton, message, Modal, Form, InputNumber, Space, Progress, Input, Tabs, Menu, Divider } from 'antd';
-import { ReloadOutlined, SettingOutlined } from '@ant-design/icons';
+import { ReloadOutlined, SettingOutlined, UnorderedListOutlined } from '@ant-design/icons';
 import { TfiBlackboard } from 'react-icons/tfi';
 import { XMarkdown } from '@ant-design/x-markdown';
 import { useTheme } from '@/hooks/useTheme';
 import { useViewState } from '@/hooks/useViewState';
 import type { BlackboardDebounceStatus } from '@/hooks/useExecutionEvents';
-import { updateBlackboardConfig } from '@/utils/database/blackboard';
+import { updateBlackboardConfig, getBlackboard } from '@/utils/database/blackboard';
 import { normalizeBlackboardMarkdown } from '@/utils/markdown';
 
 const { Title } = Typography;
@@ -615,8 +615,29 @@ interface BlackboardHeaderProps {
   workspaceId: number;
 }
 
-/** 顶部标题栏：标题 + 倒计时进度条 + 刷新按钮 + 设置按钮 */
+/** 顶部标题栏：标题 + 倒计时进度条 + 刷新按钮 + 设置按钮 + 队列查看按钮 */
 function BlackboardHeader(props: BlackboardHeaderProps) {
+  const [queueModalVisible, setQueueModalVisible] = useState(false);
+  const [queueIds, setQueueIds] = useState<number[]>([]);
+  const [queueLoading, setQueueLoading] = useState(false);
+
+  // 点击队列查看按钮：拉取黑板数据，提取 pending_record_ids
+  const handleShowQueue = useCallback(async () => {
+    setQueueLoading(true);
+    try {
+      const board = await getBlackboard(props.workspaceId);
+      // 解析 pending_record_ids 字符串（如 "[12, 34, 56]"）为数组
+      const ids: number[] = JSON.parse(board.pending_record_ids);
+      setQueueIds(Array.isArray(ids) ? ids : []);
+      setQueueModalVisible(true);
+    } catch {
+      // 静默失败：不弹 Modal，只清空列表
+      setQueueIds([]);
+    } finally {
+      setQueueLoading(false);
+    }
+  }, [props.workspaceId]);
+
   return (
     <div
       style={{
@@ -642,6 +663,12 @@ function BlackboardHeader(props: BlackboardHeaderProps) {
           title="设置"
         />
         <Button
+          icon={<UnorderedListOutlined />}
+          onClick={handleShowQueue}
+          loading={queueLoading}
+          title="查看队列 ID"
+        />
+        <Button
           type="primary"
           icon={<ReloadOutlined />}
           onClick={props.onRefresh}
@@ -649,6 +676,38 @@ function BlackboardHeader(props: BlackboardHeaderProps) {
           刷新
         </Button>
       </Space.Compact>
+
+      {/* 队列 ID 弹窗 */}
+      <Modal
+        title={
+          <span>
+            待处理队列 <span style={{ fontWeight: 400, fontSize: 13, color: '#888' }}>共 {queueIds.length} 条</span>
+          </span>
+        }
+        open={queueModalVisible}
+        onCancel={() => setQueueModalVisible(false)}
+        footer={null}
+        width={400}
+      >
+        {queueIds.length === 0 ? (
+          <div style={{ textAlign: 'center', padding: '24px 0', color: '#999' }}>队列为空</div>
+        ) : (
+          <div style={{ maxHeight: 400, overflowY: 'auto' }}>
+            {queueIds.map((id) => (
+              <div
+                key={id}
+                style={{
+                  padding: '6px 12px',
+                  borderBottom: '1px solid #f0f0f0',
+                  fontSize: 14,
+                }}
+              >
+                {id}
+              </div>
+            ))}
+          </div>
+        )}
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/utils/database/blackboard.ts
+++ b/frontend/src/utils/database/blackboard.ts
@@ -1,5 +1,17 @@
 import { api } from './client';
 
+/** 黑板响应（来自 GET /api/workspaces/{workspaceId}/blackboard） */
+export interface BlackboardResponse {
+  workspace_id: number;
+  pending_record_ids: string; // JSON 数组字符串，如 "[12, 34, 56]"
+}
+
+/** GET /api/workspaces/{workspaceId}/blackboard：获取黑板数据（含 pending_record_ids） */
+export async function getBlackboard(workspaceId: number): Promise<BlackboardResponse> {
+  const res = await api.get(`/api/workspaces/${workspaceId}/blackboard`);
+  return res.data as BlackboardResponse;
+}
+
 /** PATCH /api/workspaces/{workspaceId}/blackboard：更新黑板 per-workspace 配置 */
 export async function updateBlackboardConfig(
   workspaceId: number,

--- a/frontend/src/utils/database/blackboard.ts
+++ b/frontend/src/utils/database/blackboard.ts
@@ -1,4 +1,4 @@
-import { api } from './client';
+import { api, unwrap } from './client';
 
 /** 黑板响应（来自 GET /api/workspaces/{workspaceId}/blackboard） */
 export interface BlackboardResponse {
@@ -8,8 +8,7 @@ export interface BlackboardResponse {
 
 /** GET /api/workspaces/{workspaceId}/blackboard：获取黑板数据（含 pending_record_ids） */
 export async function getBlackboard(workspaceId: number): Promise<BlackboardResponse> {
-  const res = await api.get(`/api/workspaces/${workspaceId}/blackboard`);
-  return res.data as BlackboardResponse;
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/blackboard`));
 }
 
 /** PATCH /api/workspaces/{workspaceId}/blackboard：更新黑板 per-workspace 配置 */


### PR DESCRIPTION
## 问题

cron 发起的 todo 任务执行完成后，不会进入黑板分析（pending 队列）。

## 根因

`backend/src/scheduler.rs` 的 cron job 回调构造 `RunTodoExecutionRequest` 时，把 `workspace_id` 和 `workspace_path` 都硬编码为 `None`。

而黑板更新触发逻辑（`backend/src/executor_service/completion.rs` L423-427）要求 `workspace_id` 为 `Some` 才会把 `execution_record_id` 推入 pending 队列：

```rust
if success && trigger_type != "blackboard" {
    if let Some(ws_id) = workspace_id {
        crate::services::blackboard_debouncer::push_pending_record(ws_id, record_id, &db).await;
    }
}
```

由于 cron 路径 `workspace_id=None`，此分支被跳过，cron 任务永远不会触发黑板分析。但 todo 自身在 DB 里其实是有 `workspace_id` 的，只是没传进执行请求。

## 修复

从 `db.get_todo(todo_id)` 已加载的 todo 中读取 `workspace_id` 和 `workspace_path`，传入 `RunTodoExecutionRequest`，与手动触发路径保持一致。单点 7 行改动，附带说明意图的注释。

## 验证

- `cargo check --lib` 通过（仅一个存量 dead_code 警告，与本改动无关）
- `cargo test --lib scheduler::` 73 个测试全部通过
- 修改的 `scheduler.rs` 无 clippy 告警（仓库存在 254 个存量告警，分布在其它文件，未因本次改动新增）
