### PR TITLE
fix: resolve CodeRabbit review comments for PR 839

### DIFF
--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -13,6 +13,30 @@ use crate::models::{
 use crate::cli::client::ApiClient;
 use crate::config;
 
+/// 对 slug 进行 percent-encoding，防止特殊字符破坏 URL 路径结构。
+/// 只对非常规字符进行编码，A-Z a-z 0-9 - _ . ~ 保持不变。
+fn percent_encode_slug(s: &str) -> String {
+    let mut result = String::with_capacity(s.len() * 3);
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                result.push(b as char);
+            }
+            _ => {
+                result.push('%');
+                result.push_str(&hex_digit(b >> 4));
+                result.push_str(&hex_digit(b & 0xf));
+            }
+        }
+    }
+    result
+}
+
+fn hex_digit(b: u8) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    format!("{}{}", HEX[(b as usize) >> 4] as char, HEX[(b as usize) & 0xf] as char)
+}
+
 #[derive(Parser, Debug)]
 #[command(name = "ntd")]
 #[command(about = "AI Todo CLI - Manage AI-powered tasks", long_about = None)]
@@ -75,7 +99,8 @@ pub enum Commands {
 /// Blackboard CLI actions: manage wiki pages for a workspace.
 #[derive(Debug, Clone, Subcommand)]
 pub enum BlackboardAction {
-    /// Wiki file management
+    /// Wiki 文件管理（从旧的 Page 语义迁移为 Wiki 文件语义）。
+    /// workspace_id 用于限定文件系统 Wiki 读取范围，确保不同 workspace 数据隔离。
     Wiki {
         #[command(subcommand)]
         action: WikiAction,
@@ -85,14 +110,14 @@ pub enum BlackboardAction {
     },
 }
 
-/// Wiki file subcommands.
+/// Wiki 文件子命令（替代旧的 Page 子命令）。
 #[derive(Debug, Clone, Subcommand)]
 pub enum WikiAction {
-    /// List all wiki files (index, log, topics)
+    /// 列出所有 wiki 文件（index, log, topics）
     List,
-    /// Get a single wiki file content by slug
+    /// 根据 slug 获取单个 wiki 文件内容
     Get {
-        /// File slug (e.g. "auth-module", "index", "log")
+        /// 文件 slug（如 "auth-module", "index", "log"）
         slug: String,
     },
 }
@@ -752,7 +777,9 @@ async fn handle_blackboard(
                     print_response(resp, output, fields)?;
                 }
                 WikiAction::Get { slug } => {
-                    let path = format!("/workspaces/{}/wiki/files/{}", workspace_id, slug);
+                    // slug 可能包含中文或特殊字符，必须 percent-encode 后才能安全放入 URL 路径
+                    let encoded = percent_encode_slug(slug);
+                    let path = format!("/workspaces/{}/wiki/files/{}", workspace_id, encoded);
                     let resp: ClientResponse<serde_json::Value> = client.get(&path).await?;
                     print_response(resp, output, fields)?;
                 }

--- a/backend/src/db/entity/blackboards.rs
+++ b/backend/src/db/entity/blackboards.rs
@@ -24,8 +24,8 @@ pub struct Model {
     pub blackboard_debounce_secs: i64,
     /// 黑板更新防抖条数阈值，达到该条数后立即触发，无需等待周期
     pub blackboard_debounce_count: i64,
-    /// Wiki 维护提示词模板（占位符 {{page_summaries}}、{{pending_record_ids}}、{{operations_json}}、{{page_contents}}）。
-    /// 应用于 Wiki 分析与执行阶段，空字符串表示使用内置默认模板。
+    /// Wiki 单阶段维护提示词模板（占位符 {{workspace_id}}、{{pending_record_ids}}）。
+    /// LLM 直接编辑 wiki 目录下的 Markdown 文件，空字符串表示使用内置默认模板。
     #[sea_orm(column_type = "Text")]
     pub wiki_prompt: String,
     pub updated_at: Option<String>,

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -262,25 +262,60 @@ async fn run_wiki_execution(
 }
 
 /// 等待目标 task_id 对应的 Finished 事件。
+///
+/// 使用 5 分钟超时防止无限等待；仅当 `success=true` 时才认为执行成功并返回结果。
 async fn wait_for_finished(
     rx: &mut tokio::sync::broadcast::Receiver<ExecEvent>,
     task_id: &str,
     workspace_id: i64,
 ) -> Result<Option<String>, AppError> {
+    // 5 分钟超时，防止事件丢失时永久阻塞
+    let timeout_duration = tokio::time::Duration::from_secs(5 * 60);
+    let deadline = tokio::time::Instant::now() + timeout_duration;
+
     loop {
-        match rx.recv().await {
-            Ok(ExecEvent::Finished {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            // 超时：事件未在规定时间内到达
+            Err(_) => {
+                tracing::warn!(
+                    "Wiki 执行超时: workspace_id={}, task_id={}, timeout_secs=300",
+                    workspace_id,
+                    task_id
+                );
+                return Err(AppError::Internal(format!(
+                    "Wiki 执行超时（5 分钟），task_id={}",
+                    task_id
+                )));
+            }
+            Ok(Ok(ExecEvent::Finished {
                 task_id: ref finished_task_id,
                 result: Some(ref new_content),
+                success: true,
                 ..
-            }) if *finished_task_id == task_id => {
+            })) if *finished_task_id == task_id => {
                 return Ok(Some(new_content.clone()));
             }
-            Ok(ExecEvent::Finished {
+            Ok(Ok(ExecEvent::Finished {
+                task_id: ref finished_task_id,
+                result: _,
+                success: false,
+                ..
+            })) if *finished_task_id == task_id => {
+                // 执行失败（LLM 返回了 Finished 但 success=false）
+                tracing::warn!(
+                    "Wiki 执行失败: workspace_id={}, task_id={}",
+                    workspace_id,
+                    task_id
+                );
+                return Ok(None);
+            }
+            Ok(Ok(ExecEvent::Finished {
                 task_id: ref finished_task_id,
                 result: None,
+                success: true,
                 ..
-            }) if *finished_task_id == task_id => {
+            })) if *finished_task_id == task_id => {
                 tracing::warn!(
                     "Wiki 执行未产出结果: workspace_id={}, task_id={}",
                     workspace_id,
@@ -288,11 +323,11 @@ async fn wait_for_finished(
                 );
                 return Ok(None);
             }
-            Ok(_) => {}
-            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+            Ok(Ok(_)) => {}
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(n))) => {
                 tracing::warn!("Wiki 更新事件通道积压，跳过 {} 个事件", n);
             }
-            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
                 return Err(AppError::Internal("事件通道已关闭".to_string()));
             }
         }
@@ -302,10 +337,11 @@ async fn wait_for_finished(
 /// Wiki 更新入口：单阶段调用，LLM 直接编辑文件。
 ///
 /// 流程：
-/// 1. 确保 wiki 目录存在
-/// 2. 构造 prompt（含 workspace_id 和 record_ids）
-/// 3. 单次 LLM 调用
-/// 4. 后处理：生成 index.md、追加 log.md
+/// 1. 空队列直接返回（无需处理）
+/// 2. 确保 wiki 目录存在
+/// 3. 构造 prompt（含 workspace_id 和 record_ids）
+/// 4. 单次 LLM 调用
+/// 5. 后处理：生成 index.md、追加 log.md
 pub async fn update_blackboard_wiki(
     db: Arc<Database>,
     executor_registry: Arc<ExecutorRegistry>,
@@ -315,15 +351,21 @@ pub async fn update_blackboard_wiki(
     workspace_id: i64,
     pending_record_ids: Vec<i64>,
 ) -> Result<(), AppError> {
-    // 1. 确保 wiki 目录存在
+    // 1. 空队列直接返回，避免无意义地启动 LLM 调用
+    if pending_record_ids.is_empty() {
+        tracing::debug!("Wiki 更新跳过: pending_record_ids 为空, workspace_id={}", workspace_id);
+        return Ok(());
+    }
+
+    // 2. 确保 wiki 目录存在
     init_wiki_dir(workspace_id).map_err(|e| {
         AppError::Internal(format!("初始化 wiki 目录失败: {:?}", e))
     })?;
 
-    // 2. 查找或创建 todo（prompt 由配置保存接口同步，执行时不触碰）
+    // 3. 查找或创建 todo（prompt 由配置保存接口同步，执行时不触碰）
     let todo_id = find_or_create_wiki_todo(&db, workspace_id).await?;
 
-    // 3. 用 todo.prompt 作为执行 message：这是真相源
+    // 4. 用 todo.prompt 作为执行 message：这是真相源
     //    - 用户在配置页保存提示词 → apply_wiki_prompt_to_todo 同步到 todo.prompt
     //    - 未配置 → 创建时已用内置默认兜底
     let prompt_template = db
@@ -338,7 +380,7 @@ pub async fn update_blackboard_wiki(
     params.insert("pending_record_ids".to_string(), ids_str);
     let message = crate::models::replace_placeholders(&prompt_template, &params);
 
-    // 4. 启动执行
+    // 5. 启动执行
     let _result = run_wiki_execution(
         db.clone(),
         executor_registry,
@@ -351,7 +393,7 @@ pub async fn update_blackboard_wiki(
         params,
     ).await?;
 
-    // 5. 后处理：生成 index、追加 log
+    // 6. 后处理：生成 index、追加 log
     // 无论 LLM 是否输出，都尝试生成 index 和 log
     let topics = list_topics(workspace_id).map_err(|e| {
         AppError::Internal(format!("列出 topic 失败: {:?}", e))

--- a/backend/src/wiki/fs.rs
+++ b/backend/src/wiki/fs.rs
@@ -9,59 +9,84 @@ use std::path::PathBuf;
 /// 获取 ntd home 目录（~/.ntd）。
 ///
 /// 与系统其他模块保持一致，使用 dirs::home_dir()。
-fn ntd_home() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join(".ntd")
+/// 如果 home_dir 不可用则报错，防止 wiki 数据意外写入 /tmp 导致丢失。
+fn ntd_home() -> io::Result<PathBuf> {
+    let home = dirs::home_dir()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "无法获取用户 home 目录，请检查 $HOME 环境变量"))?;
+    Ok(home.join(".ntd"))
 }
 
 /// 获取指定工作空间的 wiki 目录路径。
 ///
 /// 路径格式：~/.ntd/workspace/<workspace_id>/wiki/
-pub fn wiki_dir(workspace_id: i64) -> PathBuf {
-    ntd_home()
+pub fn wiki_dir(workspace_id: i64) -> io::Result<PathBuf> {
+    Ok(ntd_home()?
         .join("workspace")
         .join(workspace_id.to_string())
-        .join("wiki")
+        .join("wiki"))
 }
 
 /// 获取 topics 子目录路径。
 ///
 /// 路径格式：~/.ntd/workspace/<workspace_id>/wiki/topics/
-pub fn topics_dir(workspace_id: i64) -> PathBuf {
-    wiki_dir(workspace_id).join("topics")
+pub fn topics_dir(workspace_id: i64) -> io::Result<PathBuf> {
+    Ok(wiki_dir(workspace_id)?.join("topics"))
 }
 
 /// 获取 index.md 文件路径。
-pub fn index_file(workspace_id: i64) -> PathBuf {
-    wiki_dir(workspace_id).join("index.md")
+pub fn index_file(workspace_id: i64) -> io::Result<PathBuf> {
+    Ok(wiki_dir(workspace_id)?.join("index.md"))
 }
 
 /// 获取 log.md 文件路径。
-pub fn log_file(workspace_id: i64) -> PathBuf {
-    wiki_dir(workspace_id).join("log.md")
+pub fn log_file(workspace_id: i64) -> io::Result<PathBuf> {
+    Ok(wiki_dir(workspace_id)?.join("log.md"))
+}
+
+/// 验证 topic slug 防止路径遍历攻击。
+///
+/// 只允许字母、数字、连字符（-）、下划线（_），不允许路径分隔符和 ..。
+fn validate_slug(slug: &str) -> io::Result<()> {
+    if slug.is_empty() {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "slug 不能为空"));
+    }
+    // 拒绝所有路径分隔符和双点
+    if slug.contains('/') || slug.contains('\\') || slug.contains("..") {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("slug 包含非法字符: {}", slug),
+        ));
+    }
+    // 拒绝文件名特殊字符
+    for c in slug.chars() {
+        if c == '.' || c == '<' || c == '>' || c == ':' || c == '"' || c == '|' || c == '?' || c == '*' {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("slug 包含非法字符 '{}': {}", c, slug),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// 获取指定 topic 文件路径。
 ///
 /// slug 示例：auth-module → topics/auth-module.md
-pub fn topic_file(workspace_id: i64, slug: &str) -> PathBuf {
-    topics_dir(workspace_id).join(format!("{}.md", slug))
+pub fn topic_file(workspace_id: i64, slug: &str) -> io::Result<PathBuf> {
+    validate_slug(slug)?;
+    Ok(topics_dir(workspace_id)?.join(format!("{}.md", slug)))
 }
 
 /// 初始化 wiki 目录结构。
 ///
 /// 创建 wiki/ 和 topics/ 目录（如果不存在）。
 pub fn init_wiki_dir(workspace_id: i64) -> io::Result<()> {
-    let wiki = wiki_dir(workspace_id);
-    let topics = topics_dir(workspace_id);
+    let wiki = wiki_dir(workspace_id)?;
+    let topics = topics_dir(workspace_id)?;
 
-    // 创建 wiki 目录
     if !wiki.exists() {
         fs::create_dir_all(&wiki)?;
     }
-
-    // 创建 topics 子目录
     if !topics.exists() {
         fs::create_dir_all(&topics)?;
     }
@@ -73,7 +98,7 @@ pub fn init_wiki_dir(workspace_id: i64) -> io::Result<()> {
 ///
 /// 返回 topics 目录下所有 .md 文件的 slug 列表（不含 .md 后缀）。
 pub fn list_topics(workspace_id: i64) -> io::Result<Vec<String>> {
-    let topics = topics_dir(workspace_id);
+    let topics = topics_dir(workspace_id)?;
 
     if !topics.exists() {
         return Ok(Vec::new());
@@ -84,7 +109,6 @@ pub fn list_topics(workspace_id: i64) -> io::Result<Vec<String>> {
         let entry = entry?;
         let path = entry.path();
 
-        // 只处理 .md 文件
         if path.extension().map(|e| e == "md").unwrap_or(false) {
             let slug = path
                 .file_stem()
@@ -95,9 +119,7 @@ pub fn list_topics(workspace_id: i64) -> io::Result<Vec<String>> {
         }
     }
 
-    // 按文件名排序
     slugs.sort();
-
     Ok(slugs)
 }
 
@@ -105,7 +127,7 @@ pub fn list_topics(workspace_id: i64) -> io::Result<Vec<String>> {
 ///
 /// 返回 None 表示文件不存在。
 pub fn read_topic(workspace_id: i64, slug: &str) -> io::Result<Option<String>> {
-    let path = topic_file(workspace_id, slug);
+    let path = topic_file(workspace_id, slug)?;
 
     if !path.exists() {
         return Ok(None);
@@ -117,12 +139,9 @@ pub fn read_topic(workspace_id: i64, slug: &str) -> io::Result<Option<String>> {
 
 /// 写入 topic 文件（创建或覆盖）。
 pub fn write_topic(workspace_id: i64, slug: &str, content: &str) -> io::Result<()> {
-    // 确保目录存在
     init_wiki_dir(workspace_id)?;
-
-    let path = topic_file(workspace_id, slug);
+    let path = topic_file(workspace_id, slug)?;
     fs::write(path, content)?;
-
     Ok(())
 }
 
@@ -130,7 +149,7 @@ pub fn write_topic(workspace_id: i64, slug: &str, content: &str) -> io::Result<(
 ///
 /// 返回 false 表示文件不存在。
 pub fn delete_topic(workspace_id: i64, slug: &str) -> io::Result<bool> {
-    let path = topic_file(workspace_id, slug);
+    let path = topic_file(workspace_id, slug)?;
 
     if !path.exists() {
         return Ok(false);
@@ -142,7 +161,7 @@ pub fn delete_topic(workspace_id: i64, slug: &str) -> io::Result<bool> {
 
 /// 读取 index.md 内容。
 pub fn read_index(workspace_id: i64) -> io::Result<Option<String>> {
-    let path = index_file(workspace_id);
+    let path = index_file(workspace_id)?;
 
     if !path.exists() {
         return Ok(None);
@@ -154,18 +173,15 @@ pub fn read_index(workspace_id: i64) -> io::Result<Option<String>> {
 
 /// 写入 index.md（覆盖）。
 pub fn write_index(workspace_id: i64, content: &str) -> io::Result<()> {
-    // 确保目录存在
     init_wiki_dir(workspace_id)?;
-
-    let path = index_file(workspace_id);
+    let path = index_file(workspace_id)?;
     fs::write(path, content)?;
-
     Ok(())
 }
 
 /// 读取 log.md 内容。
 pub fn read_log(workspace_id: i64) -> io::Result<Option<String>> {
-    let path = log_file(workspace_id);
+    let path = log_file(workspace_id)?;
 
     if !path.exists() {
         return Ok(None);
@@ -176,24 +192,19 @@ pub fn read_log(workspace_id: i64) -> io::Result<Option<String>> {
 }
 
 /// 追加内容到 log.md。
+///
+/// 使用 `.append(true).create(true)` 原子性追加，避免 TOCTOU 竞争。
 pub fn append_log(workspace_id: i64, entry: &str) -> io::Result<()> {
-    // 确保目录存在
     init_wiki_dir(workspace_id)?;
+    let path = log_file(workspace_id)?;
 
-    let path = log_file(workspace_id);
-
-    // 如果文件不存在，先创建一个空文件
-    if !path.exists() {
-        fs::write(&path, "# 执行日志\n\n")?;
-    }
-
-    // 追加内容
+    // 原子性追加：文件不存在时自动创建，指针自动跳到末尾
     let mut file = fs::OpenOptions::new()
         .append(true)
+        .create(true)
         .open(path)?;
 
     use std::io::Write;
     file.write_all(entry.as_bytes())?;
-
     Ok(())
 }

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -30,11 +30,10 @@ import { normalizeBlackboardMarkdown } from '@/utils/markdown';
 
 const { Title } = Typography;
 
-/** 黑板 API 返回的 JSON 形状（与后端 BlackboardResponse 对应） */
+/** 黑板 API 返回的配置形状（与后端 BlackboardResponse 对应，不含内容）。 */
 interface BlackboardData {
   id: number;
   workspace_id: number;
-  content: string;
   updated_at: string | null;
   /** 黑板更新防抖周期（秒）*/
   blackboard_debounce_secs: number;

--- a/frontend/src/utils/database/blackboard.ts
+++ b/frontend/src/utils/database/blackboard.ts
@@ -17,6 +17,7 @@ export async function updateBlackboardConfig(
   config: {
     blackboard_debounce_secs?: number;
     blackboard_debounce_count?: number;
+    /** 单阶段 Wiki 维护提示词，与后端 UpdateBlackboardConfigRequest.wiki_prompt 对齐 */
     wiki_prompt?: string;
   },
 ): Promise<void> {


### PR DESCRIPTION
## Summary

修复 PR #839 中 CodeRabbit 提出的安全问题、功能 bug 和文档问题。

## Changes

### 安全修复
- fs.rs: ntd_home() 失败时返回错误而非静默降级到 /tmp，防止 wiki 数据丢失
- fs.rs: 新增 validate_slug() 验证 slug 防止路径遍历攻击
- fs.rs: append_log 修复 TOCTOU 竞争条件，使用 .append(true).create(true) 原子性追加
- commands.rs: CLI 的 WikiAction::Get 对 slug 进行 percent-encode 防止 URL 注入

### 功能修复
- blackboard.rs: wait_for_finished 增加 success 标志检查，不仅依赖 result 是否存在
- blackboard.rs: wait_for_finished 增加 5 分钟超时防止永久阻塞
- blackboard.rs: pending_record_ids 为空时直接返回，避免无意义 LLM 调用

### 文档修复
- blackboards.rs: 更新 wiki_prompt 字段注释，修正为单阶段而非双阶段描述
- commands.rs: 为 Wiki CLI 迁移添加原因注释
- blackboard.ts: 为 wiki_prompt 字段添加说明注释
- BlackboardPage.tsx: 从 BlackboardData 接口移除已废弃的 content 字段
