### PR TITLE
fix: 批量暂停/恢复 todo 时同步 cron 调度任务

### DIFF
--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -12,6 +12,9 @@ use crate::models::{
     BatchUpdateTodoSchedulerRequest, BatchUpdateTodoWorkspaceRequest, BatchWorkspaceResult,
     CreateTodoRequest, RecentCompletedTodo, Todo, UpdateTagsRequest, UpdateTodoRequest,
 };
+// 批量恢复调度需要在 handler 中构造 ServiceContext 调用 scheduler.upsert_task，
+// 与单个 update_scheduler handler (handlers/scheduler.rs) 的处理路径保持一致。
+use crate::service_context::ServiceContext;
 
 /// Validate cron expression, return helpful error for invalid ones
 fn validate_cron_expression(expr: &str) -> Result<(), String> {
@@ -456,6 +459,13 @@ pub async fn batch_copy_todos_workspace(
 }
 
 /// PUT /api/todos/batch-scheduler — 批量暂停/恢复事项的周期执行
+///
+/// 修复：原实现仅更新 DB 的 `scheduler_enabled` 字段，未同步内存中的 cron 任务，
+/// 导致批量暂停后 cron 仍会触发、批量恢复后 cron 不触发的状态不一致。
+/// 此处在 DB 写入前后同步调用 scheduler，与单个 `update_scheduler` handler
+/// (handlers/scheduler.rs) 的行为保持一致：
+/// - 暂停：先逐个移除 cron，再写 DB（避免撤 cron 前的触发窗口）
+/// - 恢复：先写 DB，再从 DB 读出 config/timezone 重新注册 cron
 pub async fn batch_update_todos_scheduler(
     State(state): State<AppState>,
     ApiJson(req): ApiJson<BatchUpdateTodoSchedulerRequest>,
@@ -463,12 +473,84 @@ pub async fn batch_update_todos_scheduler(
     if req.ids.is_empty() {
         return Err(AppError::BadRequest("ids 不能为空".to_string()));
     }
-    let rows_affected = state
-        .db
-        .batch_update_todos_scheduler(&req.ids, req.scheduler_enabled)
-        .await?;
+    // 根据目标状态分流到对应辅助函数，保持 handler 单一职责、控制函数长度。
+    // 两个分支各自用 `?` 解包 Result，统一得到 rows_affected: u64。
+    let rows_affected = if req.scheduler_enabled {
+        resume_batch_schedulers(&state, &req.ids).await?
+    } else {
+        pause_batch_schedulers(&state, &req.ids).await?
+    };
     Ok(ApiResponse::ok(BatchWorkspaceResult {
         updated_count: rows_affected as i64,
         total: req.ids.len() as i64,
     }))
+}
+
+/// 批量暂停：先逐个移除 cron 任务，再一次写 DB（scheduler_enabled=false）。
+/// 顺序很重要——先撤 cron 可避免"DB 已标记暂停但 cron 仍触发"的短窗口。
+/// 即使某个 id 在 job_map 中不存在，`remove_task_for_todo` 也是 no-op，安全。
+async fn pause_batch_schedulers(state: &AppState, ids: &[i64]) -> Result<u64, AppError> {
+    for id in ids {
+        state.scheduler.remove_task_for_todo(*id).await;
+    }
+    let rows = state.db.batch_update_todos_scheduler(ids, false).await?;
+    Ok(rows)
+}
+
+/// 批量恢复：先写 DB（scheduler_enabled=true），再逐个从 DB 读出 todo 的
+/// scheduler_config 与 scheduler_timezone 重新注册 cron。
+/// 单个 todo 注册失败只 warn 不中断，避免一个无效 cron 导致整批回滚。
+async fn resume_batch_schedulers(state: &AppState, ids: &[i64]) -> Result<u64, AppError> {
+    let rows = state.db.batch_update_todos_scheduler(ids, true).await?;
+    let ctx = ServiceContext {
+        db: state.db.clone(),
+        executor_registry: state.executor_registry.clone(),
+        tx: state.tx.clone(),
+        task_manager: state.task_manager.clone(),
+        config: state.config.clone(),
+    };
+    for id in ids {
+        // 单个恢复失败只记录日志，不中断批量流程；DB 状态已写入，下次重启时
+        // load_from_db 会跳过未注册的项，用户也可手动通过单条接口重试。
+        // AppError 未实现 Display，用 Debug 格式化保留错误上下文。
+        if let Err(e) = try_resume_one_scheduler(&state, &ctx, *id).await {
+            tracing::warn!("批量恢复调度时 todo {} 注册失败: {:?}", id, e);
+        }
+    }
+    Ok(rows)
+}
+
+/// 单个 todo 的恢复注册：从 DB 读出 scheduler_config 与 scheduler_timezone，
+/// 调用 scheduler.upsert_task。config 为空时仅移除残留 cron（与单个 handler
+/// 中 "enabled 但无 config" 分支一致），避免留下无表达式但标记 enabled 的脏状态。
+async fn try_resume_one_scheduler(
+    state: &AppState,
+    ctx: &ServiceContext,
+    id: i64,
+) -> Result<(), AppError> {
+    let todo = state
+        .db
+        .get_todo(id)
+        .await?
+        .ok_or_else(|| AppError::BadRequest(format!("todo {} 不存在", id)))?;
+    let config = match todo
+        .scheduler_config
+        .as_deref()
+        .filter(|s| !s.is_empty())
+    {
+        Some(c) => c.to_string(),
+        None => {
+            // 没有 cron 表达式无法注册，确保内存中无残留 cron 后返回。
+            state.scheduler.remove_task_for_todo(id).await;
+            return Ok(());
+        }
+    };
+    state
+        .scheduler
+        .upsert_task(ctx, id, config, todo.scheduler_timezone.clone())
+        .await
+        .inspect_err(|e| {
+            tracing::error!("批量恢复调度时 upsert_task 失败 todo {}: {}", id, e);
+        })?;
+    Ok(())
 }

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -502,6 +502,11 @@ async fn pause_batch_schedulers(state: &AppState, ids: &[i64]) -> Result<u64, Ap
 /// 单个 todo 注册失败只 warn 不中断，避免一个无效 cron 导致整批回滚。
 async fn resume_batch_schedulers(state: &AppState, ids: &[i64]) -> Result<u64, AppError> {
     let rows = state.db.batch_update_todos_scheduler(ids, true).await?;
+    // DB 写返回 0 行说明 ids 全无效：跳过 cron 重新注册循环，
+    // 避免对不存在的 todo 触发 N 次 get_todo 失败 + warn 噪音。
+    if rows == 0 {
+        return Ok(rows);
+    }
     let ctx = ServiceContext {
         db: state.db.clone(),
         executor_registry: state.executor_registry.clone(),
@@ -510,10 +515,10 @@ async fn resume_batch_schedulers(state: &AppState, ids: &[i64]) -> Result<u64, A
         config: state.config.clone(),
     };
     for id in ids {
-        // 单个恢复失败只记录日志，不中断批量流程；DB 状态已写入，下次重启时
-        // load_from_db 会跳过未注册的项，用户也可手动通过单条接口重试。
+        // 单个 todo 注册失败只 warn 不中断整批：DB 已置 enabled=true，
+        // 进程重启时 load_from_db 会基于 DB 字段再次尝试注册（自愈路径）。
         // AppError 未实现 Display，用 Debug 格式化保留错误上下文。
-        if let Err(e) = try_resume_one_scheduler(&state, &ctx, *id).await {
+        if let Err(e) = try_resume_one_scheduler(state, &ctx, *id).await {
             tracing::warn!("批量恢复调度时 todo {} 注册失败: {:?}", id, e);
         }
     }
@@ -548,9 +553,6 @@ async fn try_resume_one_scheduler(
     state
         .scheduler
         .upsert_task(ctx, id, config, todo.scheduler_timezone.clone())
-        .await
-        .inspect_err(|e| {
-            tracing::error!("批量恢复调度时 upsert_task 失败 todo {}: {}", id, e);
-        })?;
+        .await?;
     Ok(())
 }

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -547,6 +547,14 @@ impl TodoScheduler {
         }
     }
 
+    /// 查询某个 todo 当前是否在内存中持有已注册的 cron 任务。
+    /// 主要用于测试与诊断：让外部代码无需访问内部 `job_map` 即可判断
+    /// scheduler 的内存状态是否与 DB 的 `scheduler_enabled` 字段一致。
+    /// 只读、无副作用，不会触发调度。
+    pub async fn has_task(&self, todo_id: i64) -> bool {
+        self.job_map.lock().await.contains_key(&todo_id)
+    }
+
     /// 启动调度循环。`JobSchedulerError` 通过 `#[from]` 自动转为 `SchedulerError::SchedulerBackend`。
     pub async fn start(&self) -> Result<(), SchedulerError> {
         self.sched.lock().await.start().await?;
@@ -1418,5 +1426,42 @@ mod format_cron_field_tests {
     fn test_format_cron_field_two_elements_arithmetic() {
         let set: BTreeSet<u32> = BTreeSet::from([3, 5]);
         assert_eq!(format_cron_field(&set), "3-5/2");
+    }
+}
+
+#[cfg(test)]
+// 测试 mod 允许 unwrap/expect：失败即用例红，与 lib.rs 测试约定一致。
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod has_task_tests {
+    //! 覆盖 `TodoScheduler::has_task`：只读查询 job_map 是否含某 todo_id。
+    //! 不走 `upsert_task` 是因为它依赖完整 ServiceContext + DB + 真实 cron 注册，
+    //! 远超 `has_task` 的职责边界；这里直接操作 job_map 模拟注册后状态。
+    use super::TodoScheduler;
+
+    /// 空 scheduler 的 job_map 不含任何 todo_id，has_task 应一律返回 false。
+    #[tokio::test]
+    async fn test_has_task_returns_false_when_job_map_empty() {
+        let scheduler = TodoScheduler::new().await.unwrap();
+        assert!(
+            !scheduler.has_task(42).await,
+            "空 job_map 时 has_task 应返回 false"
+        );
+    }
+
+    /// 手动往 job_map 插入 fake uuid 后，对应 todo_id 应返回 true，
+    /// 其他 todo_id 仍返回 false，验证 contains_key 的精确匹配。
+    #[tokio::test]
+    async fn test_has_task_returns_true_after_manual_insert() {
+        let scheduler = TodoScheduler::new().await.unwrap();
+        scheduler
+            .job_map
+            .lock()
+            .await
+            .insert(7, uuid::Uuid::new_v4());
+        assert!(scheduler.has_task(7).await, "已注册的 todo_id 应返回 true");
+        assert!(
+            !scheduler.has_task(8).await,
+            "未注册的 todo_id 应返回 false"
+        );
     }
 }

--- a/backend/tests/api_integration_test.rs
+++ b/backend/tests/api_integration_test.rs
@@ -18,6 +18,15 @@ use ntd::{
 };
 
 async fn create_test_app() -> axum::Router {
+    // 保留原签名返回 Router，供不需要直接访问 scheduler 的测试使用。
+    create_test_app_with_scheduler().await.0
+}
+
+// 返回 (Router, Scheduler, workspace_id) 三元组。
+// - Scheduler：让需要直接访问 scheduler 内存状态（验证 cron 是否同步）的测试可拿到句柄。
+// - workspace_id：create_todo handler 现在要求 workspace_id 必填且必须存在，
+//   这里预置一个工作空间供测试复用，避免每个测试重复创建。
+async fn create_test_app_with_scheduler() -> (axum::Router, Arc<TodoScheduler>, i64) {
     let db = Arc::new(Database::new(":memory:").await.unwrap());
 
     let executor_registry = Arc::new(ExecutorRegistry::new());
@@ -28,6 +37,12 @@ async fn create_test_app() -> axum::Router {
 
     let config = Arc::new(std::sync::RwLock::new(Config::default()));
     let scheduler = Arc::new(TodoScheduler::new().await.unwrap());
+    // 预置工作空间：create_todo handler 强制校验 workspace_id 存在性，
+    // 测试不预置会导致所有创建 todo 的请求 400。
+    let dir = db
+        .get_or_create_project_directory("/tmp/ntd-test-ws", Some("测试空间"))
+        .await
+        .unwrap();
     let ctx = ntd::service_context::ServiceContext {
         db: db.clone(),
         executor_registry: executor_registry.clone(),
@@ -41,7 +56,8 @@ async fn create_test_app() -> axum::Router {
         .unwrap();
     scheduler.start().await.unwrap();
 
-    create_app(ctx, scheduler)
+    let app = create_app(ctx, scheduler.clone()).await;
+    (app, scheduler, dir.id)
 }
 
 async fn read_json_body<T: serde::de::DeserializeOwned>(
@@ -508,6 +524,106 @@ async fn test_get_scheduler_todos() {
     let todos = body["data"].as_array().unwrap();
     assert_eq!(todos.len(), 1);
     assert_eq!(todos[0]["id"], id);
+}
+
+// ===== Batch scheduler sync tests =====
+// 这组测试覆盖 issue：批量暂停/恢复时 cron 任务未与 DB 同步。
+// 通过 scheduler.has_task 直接验证内存 cron 状态，而非仅校验 HTTP 响应。
+
+// 创建一个 todo 并通过单条接口启用调度，返回 todo id。
+// 之所以走 HTTP 而非直接操作 DB，是为了与生产路径一致地注册 cron 任务。
+// workspace_id 必填：create_todo handler 据此校验工作空间存在性。
+async fn create_todo_with_scheduler(app: &axum::Router, workspace_id: i64, cron: &str) -> i64 {
+    let create_req = json_request("POST", "/api/todos", json!({"title": "T", "prompt": "P", "tag_ids": [], "workspace_id": workspace_id}));
+    let create_resp = app.clone().oneshot(create_req).await.unwrap();
+    let body: serde_json::Value = read_json_body(create_resp).await;
+    let id = body["data"]["id"].as_i64().unwrap();
+    let enable_req = json_request(
+        "PUT",
+        &format!("/api/todos/{}/scheduler", id),
+        json!({"scheduler_enabled": true, "scheduler_config": cron}),
+    );
+    let _ = app.clone().oneshot(enable_req).await.unwrap();
+    id
+}
+
+// 通过 GET /api/todos/{id} 读取单个 todo 的 scheduler_enabled 字段，
+// 让测试能在不直接访问 DB 句柄的情况下验证持久化状态。
+async fn get_todo_scheduler_enabled(app: &axum::Router, id: i64) -> bool {
+    let req = Request::builder()
+        .uri(format!("/api/todos/{}", id))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let body: serde_json::Value = read_json_body(resp).await;
+    body["data"]["scheduler_enabled"].as_bool().unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_batch_pause_removes_cron_tasks() {
+    // 验证修复：批量暂停后，scheduler 内存中的 cron 任务应被同步移除，
+    // 而不是仅把 DB 的 scheduler_enabled 置 false。
+    let (app, scheduler, ws_id) = create_test_app_with_scheduler().await;
+    let id1 = create_todo_with_scheduler(&app, ws_id, "0 */5 * * * *").await;
+    let id2 = create_todo_with_scheduler(&app, ws_id, "0 */7 * * * *").await;
+    assert!(scheduler.has_task(id1).await, "启用后 id1 应有 cron 任务");
+    assert!(scheduler.has_task(id2).await, "启用后 id2 应有 cron 任务");
+
+    let req = json_request("PUT", "/api/todos/batch-scheduler",
+        json!({"ids": [id1, id2], "scheduler_enabled": false}));
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    assert!(!scheduler.has_task(id1).await, "批量暂停后 id1 的 cron 应被移除");
+    assert!(!scheduler.has_task(id2).await, "批量暂停后 id2 的 cron 应被移除");
+    assert_eq!(get_todo_scheduler_enabled(&app, id1).await, false, "DB 中 id1 应为暂停");
+    assert_eq!(get_todo_scheduler_enabled(&app, id2).await, false, "DB 中 id2 应为暂停");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_batch_resume_restores_cron_tasks() {
+    // 验证修复：批量恢复后，scheduler 内存中应重新注册 cron 任务。
+    let (app, scheduler, ws_id) = create_test_app_with_scheduler().await;
+    let id1 = create_todo_with_scheduler(&app, ws_id, "0 */5 * * * *").await;
+    let id2 = create_todo_with_scheduler(&app, ws_id, "0 */7 * * * *").await;
+
+    // 先批量暂停，再批量恢复，验证 cron 重新注册。
+    let pause_req = json_request("PUT", "/api/todos/batch-scheduler",
+        json!({"ids": [id1, id2], "scheduler_enabled": false}));
+    let _ = app.clone().oneshot(pause_req).await.unwrap();
+    assert!(!scheduler.has_task(id1).await, "暂停后 id1 不应有 cron");
+
+    let resume_req = json_request("PUT", "/api/todos/batch-scheduler",
+        json!({"ids": [id1, id2], "scheduler_enabled": true}));
+    let resp = app.clone().oneshot(resume_req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    assert!(scheduler.has_task(id1).await, "恢复后 id1 应重新注册 cron");
+    assert!(scheduler.has_task(id2).await, "恢复后 id2 应重新注册 cron");
+    assert_eq!(get_todo_scheduler_enabled(&app, id1).await, true, "DB 中 id1 应为启用");
+    assert_eq!(get_todo_scheduler_enabled(&app, id2).await, true, "DB 中 id2 应为启用");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_batch_resume_skips_todo_without_config() {
+    // 验证：恢复时遇到 scheduler_config 为空的 todo，不应注册 cron（无表达式可注册），
+    // 也不会因为缺 config 而中断整批流程。
+    let (app, scheduler, ws_id) = create_test_app_with_scheduler().await;
+    // 创建一个 todo 但不启用调度（config 为空）
+    let create_req = json_request("POST", "/api/todos", json!({"title": "NoConfig", "prompt": "P", "tag_ids": [], "workspace_id": ws_id}));
+    let create_resp = app.clone().oneshot(create_req).await.unwrap();
+    let body: serde_json::Value = read_json_body(create_resp).await;
+    let id_no_config = body["data"]["id"].as_i64().unwrap();
+    // 另一个 todo 正常启用调度
+    let id_with_config = create_todo_with_scheduler(&app, ws_id, "0 */5 * * * *").await;
+
+    let resume_req = json_request("PUT", "/api/todos/batch-scheduler",
+        json!({"ids": [id_no_config, id_with_config], "scheduler_enabled": true}));
+    let resp = app.clone().oneshot(resume_req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    assert!(!scheduler.has_task(id_no_config).await, "无 config 的 todo 不应注册 cron");
+    assert!(scheduler.has_task(id_with_config).await, "有 config 的 todo 应注册 cron");
 }
 
 // ===== Lifecycle integration tests =====


### PR DESCRIPTION
### Bug 描述

批量暂停/恢复 todo（PUT /api/todos/batch-scheduler）只更新了 DB 的 `scheduler_enabled` 字段，**未同步内存中的 cron 任务**，导致：
- 批量暂停后，DB 标记为暂停但 cron 仍会触发
- 批量恢复后，DB 标记为启用但 cron 不会触发

### 根因

`batch_update_todos_scheduler` handler 仅调用 DB 层 `batch_update_todos_scheduler`，而单个 `update_scheduler` handler 会同时操作 DB 和 `TodoScheduler`。

### 修复方案

1. **handlers/todo.rs**：将 `batch_update_todos_scheduler` 拆分为三个职责单一的辅助函数（均 < 30 行）：
   - `pause_batch_schedulers`：先逐个 `remove_task_for_todo` 移除 cron，再写 DB（避免撤 cron 前的触发窗口）
   - `resume_batch_schedulers` + `try_resume_one_scheduler`：先写 DB，再从 DB 读出每个 todo 的 `scheduler_config`/`scheduler_timezone` 调用 `upsert_task` 重新注册；单个失败只 warn 不中断整批

2. **scheduler.rs**：新增 `TodoScheduler::has_task(todo_id) -> bool` 只读查询方法，用于测试与诊断 cron 内存状态，并补 2 个单元测试。

3. **tests/api_integration_test.rs**：新增 3 个集成测试，通过 `scheduler.has_task` 直接验证内存 cron 同步：
   - 批量暂停移除 cron
   - 批量恢复重新注册 cron
   - 恢复时跳过无 `scheduler_config` 的 todo

### 验证

- ✅ 新增 3 个集成测试全部通过
- ✅ 新增 2 个 `has_task` 单元测试全部通过
- ✅ scheduler 模块 79 个单元测试全部通过
- ✅ DB 层 4 个批量调度测试全部通过
- ✅ 修改的 3 个文件 clippy 零告警

（存量 clippy 告警为 clippy 1.93.0 新 lint 触发的项目级问题，与本 PR 无关）
