### PR TITLE
fix: PageCard extra 区域内容右对齐，解决操作按钮紧贴标题的问题

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4396,6 +4396,9 @@ code {
   gap: 8px;
   flex: 1;
   min-width: 0;
+  /* 内容从右侧向左排列：即使 extra 里只有单个按钮也能推到最右侧，
+     而非紧跟在标题后面。进度条等拉伸元素会自然从左到右撑满。 */
+  justify-content: flex-end;
 }
 
 .ntd-page-card-divider {


### PR DESCRIPTION
## 问题
PageCard header 中 `.ntd-page-card-extra` 使用了 `flex: 1` 撑满剩余宽度，但 flex 容器默认 `justify-content: flex-start`，导致 extra 里的返回按钮等操作元素紧跟在标题后面，而非右侧。

## 修复
在 `.ntd-page-card-extra` 增加 `justify-content: flex-end`，使内容从右侧向左排列。

## 影响范围
所有使用 PageCard `extra` 属性的页面（黑板页进度条不受影响，仍会自然撑满）。