### PR TITLE
fix(db): 补齐 blackboards 表缺失演进列，修复黑板保存崩溃

### DIFF
--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -14,6 +14,7 @@ mod v41_v46;
 mod v47_v53;
 mod v54;
 mod v55;
+mod v56;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -50,6 +51,8 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v47_v53::V47ConsolidatedBlackboardFeatures),
         Box::new(v54::V54AddWikiChatExecutor),
         Box::new(v55::V55AddWikiChatSessions),
+        // V56 必须排在 V55 之后：补齐早期 V47 跳过建表演进列的旧部署遗留
+        Box::new(v56::V56AddMissingBlackboardColumns),
     ]
 }
 

--- a/backend/src/db/migration/v47_v53.rs
+++ b/backend/src/db/migration/v47_v53.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use sea_orm::{ConnectionTrait, DbBackend, Statement};
 
 use super::super::Database;
-use super::{Migration, table_exists};
+use super::{Migration, table_exists, add_column_if_missing};
 
 pub(super) struct V47ConsolidatedBlackboardFeatures;
 
@@ -31,6 +31,11 @@ impl Migration for V47ConsolidatedBlackboardFeatures {
     ///
     /// 每步通过 IF NOT EXISTS / table_exists 保证幂等性，
     /// 已执行过的步骤自动跳过。
+    ///
+    /// **重要**：建表后的 ALTER TABLE ADD COLUMN 段是兜底保护——早期 V47 的旧表
+    /// 可能只含原初列（content / debounce_secs 等），跑 V47 时若 table_exists 命中
+    /// 会跳过整段 CREATE TABLE，后续演进列（pending_record_ids / wiki_prompt 等）
+    /// 永远不会被追加。这里用 add_column_if_missing 显式补齐，避免依赖下游迁移修复。
     async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
         // ---- V47: 创建 blackboards 表（一次性包含所有字段） ----
         // 每个工作空间维护一条黑板记录，用于 LLM 自动生成的 Markdown 知识库内容
@@ -38,6 +43,25 @@ impl Migration for V47ConsolidatedBlackboardFeatures {
             db.exec(CREATE_BLACKBOARDS_SQL).await?;
             tracing::info!("V47: blackboards 表已创建");
         }
+
+        // ---- V47 兜底：对已存在的旧表补齐演进字段 ----
+        // 早期部署若 V47 建过只含原初列的旧表，上面 table_exists 会跳过 CREATE，
+        // 但新业务字段仍要追加，否则下游代码引用缺失列会启动失败。
+        // add_column_if_missing 内部用 PRAGMA table_info 探测，已存在则跳过，幂等。
+        add_column_if_missing(
+            db,
+            "blackboards",
+            "pending_record_ids",
+            "ALTER TABLE blackboards ADD COLUMN pending_record_ids TEXT NOT NULL DEFAULT '[]'",
+        )
+        .await?;
+        add_column_if_missing(
+            db,
+            "blackboards",
+            "wiki_prompt",
+            "ALTER TABLE blackboards ADD COLUMN wiki_prompt TEXT NOT NULL DEFAULT ''",
+        )
+        .await?;
 
         // ---- V48: 把 todos 上的唯一索引改为 workspace 级 ----
         // V46 创建的 (action_type, action_key) 是全局唯一，多 workspace 下

--- a/backend/src/db/migration/v56.rs
+++ b/backend/src/db/migration/v56.rs
@@ -1,0 +1,230 @@
+//! 数据库迁移 V56：补齐 blackboards 表缺失的演进字段。
+//!
+//! ## 背景
+//! V47 合并迁移用 `if !table_exists` 做幂等判断，对早期已建过 blackboards 旧表
+//! （只含 content / debounce_secs 等原初列）的用户，会跳过整段 CREATE TABLE，
+//! 导致后续演进列（pending_record_ids / wiki_prompt / wiki_chat_executor /
+//! wiki_chat_sessions）从未被追加。schema_version 已记成 47 已应用，再也不会重跑，
+//! 该用户永远缺列，运行时报 `no such column: blackboards.xxx` 启动失败。
+//!
+//! 还存在更早期的旧表残留字段 wiki_index_prompt / wiki_page_prompt（被 wiki_prompt
+//! 取代），本迁移不删它们（SQLite DROP COLUMN 自 v3.35 起支持但各发行版不一），
+//! 仅追加缺失的列；旧列保留为 dead column 不影响新代码路径。
+//!
+//! ## 幂等设计
+//! 用 `add_column_if_missing` 逐列追加，列已存在则静默跳过；新装 DB 也无害
+//! （V47 已建齐 + V56 跑个 noop）。
+//!
+//! ## 默认值
+//! - pending_record_ids: '[]'（空 JSON 数组字符串）
+//! - wiki_prompt: ''（空字符串，业务层会回落到内置默认模板）
+//! - wiki_chat_executor / wiki_chat_sessions: NULL（可空）
+//!
+//! 注意 SQLite 的 ADD COLUMN 不支持 NOT NULL 而无默认值，故对 nullable 列用纯 ADD，
+//! 对业务默认值列用 ADD COLUMN ... DEFAULT ...，旧行自动填充默认值。
+
+use async_trait::async_trait;
+
+use super::super::Database;
+use super::{Migration, add_column_if_missing};
+
+pub(super) struct V56AddMissingBlackboardColumns;
+
+#[async_trait]
+impl Migration for V56AddMissingBlackboardColumns {
+    fn version(&self) -> i64 {
+        56
+    }
+
+    fn name(&self) -> &'static str {
+        "add_missing_blackboard_columns"
+    }
+
+    /// 逐列追加 blackboards 表缺失字段。
+    ///
+    /// 顺序无所谓——`add_column_if_missing` 各自独立判断列存在性。
+    /// 把每列单独成调用而非批量 ALTER，是因为 SQLite 的 ALTER TABLE ADD COLUMN
+    /// 一次只能加一列，且失败一列不会自动回滚其他列。
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // pending_record_ids：防抖队列 JSON 数组字符串，业务默认 '[]'（空队列）
+        // 必须给 DEFAULT，否则旧行会写入 NULL，后续 JSON 解析会 panic
+        add_column_if_missing(
+            db,
+            "blackboards",
+            "pending_record_ids",
+            // SQLite ADD COLUMN 带 DEFAULT 会回填旧行，避免存量数据变 NULL
+            "ALTER TABLE blackboards ADD COLUMN pending_record_ids TEXT NOT NULL DEFAULT '[]'",
+        )
+        .await?;
+        // wiki_prompt：单阶段 Wiki 维护提示词模板，空字符串触发业务层内置默认模板
+        add_column_if_missing(
+            db,
+            "blackboards",
+            "wiki_prompt",
+            "ALTER TABLE blackboards ADD COLUMN wiki_prompt TEXT NOT NULL DEFAULT ''",
+        )
+        .await?;
+        // wiki_chat_executor：Wiki 对话执行器名称，nullable（None 表示用默认 "claudecode"）
+        add_column_if_missing(
+            db,
+            "blackboards",
+            "wiki_chat_executor",
+            "ALTER TABLE blackboards ADD COLUMN wiki_chat_executor TEXT",
+        )
+        .await?;
+        // wiki_chat_sessions：per-executor session ID 的 JSON 对象，nullable
+        add_column_if_missing(
+            db,
+            "blackboards",
+            "wiki_chat_sessions",
+            "ALTER TABLE blackboards ADD COLUMN wiki_chat_sessions TEXT",
+        )
+        .await?;
+        tracing::info!("V56: blackboards 缺失列已补齐（幂等）");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::db::migration::table_has_column;
+    use crate::db::Database;
+
+    /// 验证 V56 在全新库上跑是 no-op（V47 已建齐所有列）。
+    /// 目的：确保新部署不会被 V56 误伤，V56 严格幂等。
+    #[tokio::test]
+    async fn test_v56_noop_on_fresh_db() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+        // 先走完整迁移链到 V55，模拟新部署的稳态 schema
+        let v47 = crate::db::migration::v47_v53::V47ConsolidatedBlackboardFeatures;
+        v47.up(&db).await.expect("V47 must succeed");
+        let v54 = crate::db::migration::v54::V54AddWikiChatExecutor;
+        v54.up(&db).await.expect("V54 must succeed");
+        let v55 = crate::db::migration::v55::V55AddWikiChatSessions;
+        v55.up(&db).await.expect("V55 must succeed");
+
+        // 跑 V56：应成功且不改变任何 schema
+        let migration = V56AddMissingBlackboardColumns;
+        migration.up(&db).await.expect("V56 must succeed on fresh db");
+
+        // 关键断言：所有列仍然存在（幂等没破坏）
+        for col in &[
+            "pending_record_ids",
+            "wiki_prompt",
+            "wiki_chat_executor",
+            "wiki_chat_sessions",
+        ] {
+            assert!(
+                table_has_column(&db, "blackboards", col).await.unwrap(),
+                "column {col} must still exist after V56 noop"
+            );
+        }
+    }
+
+    /// 验证 V56 能修复「早期 V47 已建表但只含原初列」的旧部署。
+    /// 这是本迁移的核心场景：模拟旧表只有 content / debounce_secs / debounce_count，
+    /// 跑 V56 后应补齐全部演进列。
+    ///
+    /// 实现思路：Database::new(":memory:") 会自动跑全套迁移把 blackboards 建齐，
+    /// 所以这里先 DROP 掉完整表，手动重建一个「早期旧表」结构（缺演进列 + 多两个
+    /// 旧残留列 wiki_index_prompt / wiki_page_prompt），再调 V56.up 验证补列行为。
+    /// V56.up 内部用 add_column_if_missing 逐列探测 + ALTER，对新表会真实追加。
+    #[tokio::test]
+    async fn test_v56_adds_missing_columns_to_legacy_table() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+        // 模拟早期 V47 的旧表结构：DROP 完整表重建一个只含原初列的旧版
+        // 故意保留 wiki_index_prompt / wiki_page_prompt 两个旧残留列，
+        // 验证 V56 不会去碰它们（只追加缺失的新列）
+        db.exec("DROP TABLE blackboards").await.expect("must drop");
+        db.exec(
+            r#"CREATE TABLE blackboards (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                workspace_id INTEGER NOT NULL UNIQUE,
+                content TEXT NOT NULL DEFAULT '',
+                blackboard_debounce_secs INTEGER NOT NULL DEFAULT 600,
+                blackboard_debounce_count INTEGER NOT NULL DEFAULT 10,
+                wiki_index_prompt TEXT NOT NULL DEFAULT '',
+                wiki_page_prompt TEXT NOT NULL DEFAULT '',
+                updated_at TEXT,
+                created_at TEXT
+            )"#,
+        )
+        .await
+        .expect("legacy table must be created");
+        // 插一条旧行，验证 ADD COLUMN DEFAULT 能正确回填，不会变 NULL
+        // workspace_id=1 对应的 project_directories 行在 V1 迁移里不存在，
+        // 但 SQLite 默认不强制 FOREIGN KEY（除非 PRAGMA foreign_keys=ON），所以可以插
+        db.exec(
+            r#"INSERT INTO blackboards (workspace_id, content) VALUES (1, 'legacy')"#,
+        )
+        .await
+        .expect("legacy row must be inserted");
+
+        // 跑 V56：应补齐所有缺失列
+        let migration = V56AddMissingBlackboardColumns;
+        migration
+            .up(&db)
+            .await
+            .expect("V56 must succeed on legacy table");
+
+        // 关键断言：四个演进列全部到位
+        for col in &[
+            "pending_record_ids",
+            "wiki_prompt",
+            "wiki_chat_executor",
+            "wiki_chat_sessions",
+        ] {
+            assert!(
+                table_has_column(&db, "blackboards", col).await.unwrap(),
+                "column {col} must exist after V56 repair"
+            );
+        }
+        // 旧行的 pending_record_ids 应回填默认值 '[]'，而非 NULL
+        // 这是 NOT NULL DEFAULT 子句的关键作用，避免后续 JSON 解析 panic
+        use sea_orm::ConnectionTrait;
+        let row = db
+            .conn
+            .query_one(sea_orm::Statement::from_string(
+                sea_orm::DbBackend::Sqlite,
+                "SELECT pending_record_ids, wiki_prompt FROM blackboards WHERE workspace_id = 1"
+                    .to_string(),
+            ))
+            .await
+            .expect("row must be readable")
+            .expect("legacy row must still exist");
+        let pending: String = row.try_get_by_index(0).expect("pending_record_ids must be readable");
+        let prompt: String = row.try_get_by_index(1).expect("wiki_prompt must be readable");
+        assert_eq!(pending, "[]", "pending_record_ids must backfill to '[]'");
+        assert_eq!(prompt, "", "wiki_prompt must backfill to empty string");
+        // 旧残留列应仍然存在（V56 不删除任何列，只追加）
+        assert!(
+            table_has_column(&db, "blackboards", "wiki_index_prompt").await.unwrap(),
+            "V56 must not drop legacy wiki_index_prompt column"
+        );
+        assert!(
+            table_has_column(&db, "blackboards", "wiki_page_prompt").await.unwrap(),
+            "V56 must not drop legacy wiki_page_prompt column"
+        );
+    }
+
+    /// 验证 V56 是幂等的（重复执行不报错）。
+    /// 防止 schema_version 与 m.up 不一致时下次启动重跑失败。
+    #[tokio::test]
+    async fn test_v56_is_idempotent() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+        let v47 = crate::db::migration::v47_v53::V47ConsolidatedBlackboardFeatures;
+        v47.up(&db).await.expect("V47 must succeed");
+
+        let migration = V56AddMissingBlackboardColumns;
+        migration.up(&db).await.expect("First run must succeed");
+        migration.up(&db).await.expect("Second run must succeed (idempotent)");
+    }
+}


### PR DESCRIPTION
## 问题

保存黑板时报错：
> 更新黑板配置失败: Query Error: error returned from database: (code: 1) no such column: blackboards.pending_record_ids

## 根因

对比两个实际数据库证实：

| 检查项 | 生产 DB \`~/.ntd/data.db\` | 开发 DB \`~/.ntd/data.dev.db\` |
|---|---|---|
| schema_version 最大值 | **47**（停在这里） | 55 |
| pending_record_ids 列 | ✅ 存在 | ✅ 存在 |
| wiki_prompt 列 | ❌ 缺失 | ✅ 存在 |
| wiki_chat_executor 列 | ❌ 缺失 | ✅ 存在 |
| wiki_chat_sessions 列 | ❌ 缺失 | ✅ 存在 |
| 旧残留列 wiki_index_prompt / wiki_page_prompt | ⚠️ 存在 | — |

`v47_v53.rs` 的 V47 合并迁移用 \`if !table_exists\` 做幂等判断。早期部署在 V47 之前已建过旧版 blackboards 表（只含 content / debounce_secs + wiki_index_prompt / wiki_page_prompt），跑 V47 时 table_exists 命中 → **跳过整段 CREATE TABLE** → 后续演进列从未追加。但 schema_version 已记成 47 已应用，V54/V55 也因此跳过，从此永久缺列。报错 \`no such column: blackboards.pending_record_ids\` 是 sea-orm 在 prepare UPDATE 语句时校验所有 entity 字段引用触发。

## 修复

1. **新增 V56 迁移** (\`v56.rs\`)：幂等地用 \`add_column_if_missing\` 逐列补齐 pending_record_ids / wiki_prompt / wiki_chat_executor / wiki_chat_sessions，对存量旧行用 DEFAULT 回填合理初值（'[]' / '' / NULL）。这是修复存量部署的关键迁移。
2. **修复 V47** (\`v47_v53.rs\`)：建表后追加显式 \`add_column_if_missing\` 兜底段，防御未来再遇同类场景。
3. **注册 V56** 于 \`migration/mod.rs::all_migrations()\`，排在 V55 之后。

## 测试

3 个单元测试：
- \`test_v56_noop_on_fresh_db\`：全新 DB 跑 V56 是 no-op（不破坏新部署）
- \`test_v56_adds_missing_columns_to_legacy_table\`：模拟旧表结构（含旧残留列），跑 V56 后演进列全部补齐 + 旧行 DEFAULT 回填正确 + 不删除旧残留列
- \`test_v56_is_idempotent\`：幂等性

\`\`\`
cd backend && cargo clippy --all-targets -- -D warnings  → 零告警 ✅
cd backend && cargo test --lib db::migration            → 32 passed / 0 failed ✅
\`\`\`

## 部署后

下次启动 \`ntd daemon\`（生产端口 8088）时，迁移 runner 会自动应用 V56 把生产 DB 缺的三列补上，黑板保存功能即恢复。无需手动改 DB。

Co-Authored-By: AtomCode (GLM-5.2) <noreply@atomgit.com>