### PR TITLE
chore(backend): 死代码清理 + clippy 零告警修复 (-94 行)

### DIFF
--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -1067,7 +1067,8 @@ fn status_icon(status: &str) -> &'static str {
 /// 渲染失败（字段缺失或类型错误）时降级输出原始 JSON + 错误提示，
 /// 而不是让 CLI 崩溃——黑板视图是辅助功能，不能阻塞主流程。
 // 保留为单元测试的稳定 stdout 入口；生产 dispatch 已直接走 render_blackboard_to 路径。
-#[allow(dead_code)]
+// cfg(test)：该函数仅被本文件 tests 模块调用，非测试构建不编入二进制，避免 dead_code 告警。
+#[cfg(test)]
 fn render_blackboard(data: Option<&Value>) {
     let mut buf: Vec<u8> = Vec::new();
     render_blackboard_to(data, &mut buf);

--- a/backend/src/daemon/common.rs
+++ b/backend/src/daemon/common.rs
@@ -44,13 +44,14 @@ pub(crate) fn shell_quote_single(path: &str) -> String {
     format!("'{}'", path)
 }
 
-#[allow(unused)]
 pub(crate) fn ntd_dir() -> PathBuf {
     let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
     home.join(".ntd")
 }
 
 /// Get the directory containing the ntd binary (for PATH in service definition)
+// 跨平台保留：仅 daemon/linux.rs 在 Linux 构建中调用；macOS/Windows 构建下无调用方，
+// 故 allow(unused) 而非 cfg(target_os)，否则 common.rs 里的单测在非 Linux 平台会编译失败。
 #[allow(unused)]
 pub(crate) fn ntd_bin_dir() -> PathBuf {
     ntd_binary_path()

--- a/backend/src/daemon/linux.rs
+++ b/backend/src/daemon/linux.rs
@@ -19,9 +19,7 @@ use std::process::Command;
 use super::common::{ntd_bin_dir, ntd_binary_path};
 use super::DaemonAction;
 
-#[allow(unused)]
 pub(super) const SERVICE_NAME: &str = "ntd";
-#[allow(unused)]
 pub(super) const SERVICE_DESCRIPTION: &str = "ntd (Now Task, Done) - AI Task Engine Service";
 
 pub(super) fn handle(action: &DaemonAction) {

--- a/backend/src/daemon/macos.rs
+++ b/backend/src/daemon/macos.rs
@@ -23,7 +23,6 @@ use std::process::Command;
 use super::common::{ntd_binary_path, ntd_dir};
 use super::DaemonAction;
 
-#[allow(unused)]
 const LAUNCHD_LABEL: &str = "com.nothing-todo.ntd";
 
 // handle 是 daemon 子命令的统一入口，根据 Action 分发到具体处理函数。

--- a/backend/src/daemon/windows.rs
+++ b/backend/src/daemon/windows.rs
@@ -16,7 +16,6 @@ use std::process::Command;
 use super::common::{ntd_binary_path, ntd_dir};
 use super::DaemonAction;
 
-#[allow(unused)]
 const TASK_NAME: &str = "ntd";
 
 // handle_task_scheduler 声明为 async 是为了内部 Restart 分支可以 .await

--- a/backend/src/db/dashboard.rs
+++ b/backend/src/db/dashboard.rs
@@ -374,7 +374,8 @@ pub(super) async fn fetch_executor_distribution(
             })
         })
         .collect();
-    distribution.sort_by(|a, b| b.execution_count.cmp(&a.execution_count));
+    // 降序：用 Reverse 包装 key，等价于 b.x.cmp(&a.x)，但避开 unnecessary_sort_by 告警。
+    distribution.sort_by_key(|b| std::cmp::Reverse(b.execution_count));
     Ok(distribution)
 }
 
@@ -428,7 +429,8 @@ pub(super) async fn fetch_model_distribution(
             })
         })
         .collect();
-    distribution.sort_by(|a, b| b.execution_count.cmp(&a.execution_count));
+    // 降序：用 Reverse 包装 key，等价于 b.x.cmp(&a.x)，但避开 unnecessary_sort_by 告警。
+    distribution.sort_by_key(|b| std::cmp::Reverse(b.execution_count));
     Ok(distribution)
 }
 
@@ -465,7 +467,8 @@ pub(super) async fn fetch_trigger_distribution(
             })
         })
         .collect();
-    distribution.sort_by(|a, b| b.count.cmp(&a.count));
+    // 降序：用 Reverse 包装 key，等价于 b.x.cmp(&a.x)，但避开 unnecessary_sort_by 告警。
+    distribution.sort_by_key(|b| std::cmp::Reverse(b.count));
     Ok(distribution)
 }
 
@@ -660,7 +663,8 @@ pub(super) async fn fetch_tag_distribution(
             })
         })
         .collect();
-    distribution.sort_by(|a, b| b.execution_count.cmp(&a.execution_count));
+    // 降序：用 Reverse 包装 key，等价于 b.x.cmp(&a.x)，但避开 unnecessary_sort_by 告警。
+    distribution.sort_by_key(|b| std::cmp::Reverse(b.execution_count));
     Ok(distribution)
 }
 
@@ -858,11 +862,8 @@ pub fn build_leaderboard(model_distribution: &[ModelCount]) -> Vec<LeaderboardIt
 
 /// 计算平均执行时长（毫秒）。`duration_count == 0` 时返回 0，避免除零。
 pub fn compute_avg_duration(total_duration_ms: u64, duration_count: u64) -> u64 {
-    if duration_count > 0 {
-        total_duration_ms / duration_count
-    } else {
-        0
-    }
+    // checked_div 在除零时返回 None，unwrap_or 兜底为 0，比手写 if 更直白且避免 manual_checked_division 告警。
+    total_duration_ms.checked_div(duration_count).unwrap_or(0)
 }
 
 /// 计算峰值每日执行数（success + failed 之和的最大值）。

--- a/backend/src/execution_events/metadata.rs
+++ b/backend/src/execution_events/metadata.rs
@@ -90,11 +90,9 @@ impl ExecutionMetadata {
             ExecutionEvent::Progress { percent, message } => {
                 tracing::debug!("执行进度: {}% - {:?}", percent, message);
             }
-            ExecutionEvent::StepStart { .. } => {
-                // 记录开始时间
-                if self.started_at.is_none() {
-                    self.started_at = Some(crate::models::utc_timestamp());
-                }
+            // 仅在首次 StepStart 时记录开始时间；guard 不满足时落入 `_ => {}`，与原 if 跳过语义一致。
+            ExecutionEvent::StepStart { .. } if self.started_at.is_none() => {
+                self.started_at = Some(crate::models::utc_timestamp());
             }
             _ => {}
         }

--- a/backend/src/execution_events/pipeline.rs
+++ b/backend/src/execution_events/pipeline.rs
@@ -224,47 +224,6 @@ impl EventPipeline {
     }
 }
 
-/// 测试用的模拟提取器
-#[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::useless_vec, clippy::redundant_pattern_matching, clippy::redundant_clone, clippy::len_zero, clippy::bool_assert_comparison, clippy::unnecessary_get_then_check, clippy::doc_lazy_continuation, clippy::clone_on_copy, clippy::print_stdout, clippy::needless_pass_by_value, clippy::sliced_string_as_bytes, clippy::manual_map, clippy::collapsible_match, clippy::question_mark)]
-mod test_extractor {
-    use super::*;
-
-    #[allow(dead_code)]
-    pub struct TestExtractor {
-        metadata: ExecutionMetadata,
-    }
-
-    #[allow(dead_code)]
-    impl TestExtractor {
-        pub fn new() -> Self {
-            Self {
-                metadata: ExecutionMetadata::new("test".to_string()),
-            }
-        }
-    }
-
-    impl EventExtractor for TestExtractor {
-        fn executor_name(&self) -> &str {
-            "test"
-        }
-
-        fn extract(&mut self, line: &str) -> Vec<ExecutionEvent> {
-            vec![ExecutionEvent::Info {
-                message: line.to_string(),
-            }]
-        }
-
-        fn metadata(&self) -> &ExecutionMetadata {
-            &self.metadata
-        }
-
-        fn metadata_mut(&mut self) -> &mut ExecutionMetadata {
-            &mut self.metadata
-        }
-    }
-}
-
 /// 默认提取器实现（从 impls 模块导入）
 use super::impls::DefaultExtractor;
 

--- a/backend/src/executor_service/pre_spawn.rs
+++ b/backend/src/executor_service/pre_spawn.rs
@@ -252,13 +252,16 @@ pub(crate) async fn reject_start_todo_failure(
 ///
 /// 决策顺序：显式 req_executor > todo.executor > registry default。命令构造
 /// 用 `command_args_with_session` 处理 resume / 非 resume 分支。
-#[allow(dead_code)]
 pub(crate) struct SelectedExecutor {
     pub executor: Arc<dyn CodeExecutor>,
     pub command_args: Vec<String>,
     pub executable_path: String,
     pub executor_str: String,
     pub todo_workspace_path: Option<String>,
+    // 仅在构造时赋值（= request.resume_session_id），当前无读取方：create_record_or_reject
+    // 刻意不用它（见该函数注释的 resume 语义说明），保留字段以承载未来 executor 对
+    // resume session 的直接消费，故 allow(dead_code) 而非删除。
+    #[allow(dead_code)]
     pub session_id_for_executor: Option<String>,
 }
 

--- a/backend/src/executor_service/types.rs
+++ b/backend/src/executor_service/types.rs
@@ -23,11 +23,13 @@ use super::RunTodoExecutionRequest;
 ///
 /// 设计取舍：把 `RunTodoExecutionRequest` 整段嵌入 `request` 字段而不是平铺。
 /// 平铺需要 14 个字段二次声明；嵌入只需 1 个字段，添加 request 字段时只动 1 处。
-#[allow(dead_code)]
 pub(crate) struct PreparedExecution {
     /// 入参 request。Stage 2 / Stage 3 仍会读到 todo_id / trigger_type 等。
     pub request: RunTodoExecutionRequest,
     /// RAII guard for task registry；必须 move 进 spawn 子任务，否则 drop 时会误删 sender。
+    // 该字段靠 move/drop 起作用（持有期间保持注册项存活），自身从不被按名读取，
+    // 故 allow(dead_code)——这是 RAII 模式的正常形态，删除会破坏存活期语义。
+    #[allow(dead_code)]
     pub task_guard: crate::task_manager::TaskGuard,
     /// 与 task_manager 的 cancel channel；spawn 子任务在 select! 中 recv 它。
     pub cancel_rx: tokio::sync::mpsc::Receiver<()>,

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -162,10 +162,11 @@ fn executor_label(et: ExecutorType) -> &'static str {
     }
 }
 
-// 保留 ALL_EXECUTORS 供其他可能用到的代码；新代码请用 ALL_SKILL_SOURCES
+// 仅用于本文件 tests 模块的数组完整性自检（元素齐全 / 无重复 / 含 Kilo）；
+// 生产代码请用 ALL_SKILL_SOURCES。cfg(test) 避免该常量在非测试构建中成为 dead_code。
 // 13 = 12 个旧执行器 + 新增的 Kilo
 // 注意：加新执行器必须同时更新下面数组与本注释的计数，否则会出现 H1 同型错位。
-#[allow(dead_code)]
+#[cfg(test)]
 const ALL_EXECUTORS: [ExecutorType; 13] = [
     ExecutorType::Claudecode,
     ExecutorType::Hermes,
@@ -528,7 +529,7 @@ fn discover_skills_for(name: &str, label: &str) -> ExecutorSkills {
 
     // 大小写不敏感排序：UI Tab 内显示顺序稳定，
     // 否则 "Foo" 和 "bar" 会按 ASCII 顺序穿插，跨执行器对比时不一致
-    skills.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    skills.sort_by_key(|a| a.name.to_lowercase());
 
     ExecutorSkills {
         executor: name.to_string(),

--- a/backend/src/services/feishu_history_fetcher.rs
+++ b/backend/src/services/feishu_history_fetcher.rs
@@ -45,7 +45,6 @@ struct MessageItem {
     message_id: String,
     msg_type: String,
     chat_id: String,
-    #[allow(dead_code)]
     chat_type: Option<String>,
     sender: Option<Sender>,
     body: Option<MessageBody>,
@@ -55,12 +54,7 @@ struct MessageItem {
 #[derive(Debug, Deserialize)]
 struct Sender {
     id: Option<String>,
-    #[allow(dead_code)]
-    id_type: Option<String>,
-    #[allow(dead_code)]
     sender_type: Option<String>,
-    #[allow(dead_code)]
-    tenant_key: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -430,54 +424,6 @@ impl FeishuHistoryFetcher {
     async fn resolve_todo_id(_config: &Arc<RwLock<AppConfig>>, _content: &str) -> Option<i64> {
         // 当前实现已移除，后续需要通过 workspace 设置查询
         None
-    }
-
-    #[allow(dead_code)]
-    /// 发送文本消息
-    async fn send_text(
-        bot_credentials: &Arc<DashMap<i64, (String, String, String)>>,
-        token_manager: &Arc<TokenManager>,
-        bot_id: i64,
-        receive_id: &str,
-        receive_id_type: &str,
-        text: &str,
-    ) {
-        let base_url = Self::base_url(bot_credentials, bot_id);
-        let Some(base_url) = base_url else { return };
-        let token = match Self::get_tenant_token(bot_credentials, token_manager, bot_id).await {
-            Some(t) => t,
-            None => return,
-        };
-
-        let client = reqwest::Client::new();
-        let url = format!(
-            "{}/open-apis/im/v1/messages?receive_id_type={}",
-            base_url, receive_id_type
-        );
-        let body = serde_json::json!({
-            "receive_id": receive_id,
-            "msg_type": "text",
-            "content": serde_json::to_string(&serde_json::json!({ "text": text })).unwrap_or_default()
-        });
-
-        match client
-            .post(&url)
-            .header("Authorization", format!("Bearer {token}"))
-            .header("Content-Type", "application/json")
-            .json(&body)
-            .send()
-            .await
-        {
-            Ok(res) => {
-                let status = res.status();
-                if !status.is_success() {
-                    tracing::error!("[feishu-history] send_text failed: status={}", status);
-                }
-            }
-            Err(e) => {
-                tracing::error!("[feishu-history] send_text request failed: {}", e);
-            }
-        }
     }
 
     fn base_url(

--- a/backend/src/sys.rs
+++ b/backend/src/sys.rs
@@ -124,7 +124,6 @@ pub fn set_socket_reuseaddr(_fd: std::os::raw::c_int) -> io::Result<()> {
 
 /// Windows 占位实现。
 #[cfg(not(unix))]
-#[allow(dead_code)]
 pub fn current_euid() -> u32 {
     0
 }

--- a/backend/src/wiki/log.rs
+++ b/backend/src/wiki/log.rs
@@ -173,9 +173,8 @@ mod tests {
 
     #[test]
     fn test_append_log_entry_reads_existing() {
-        // 验证 append_log_entry 会先读后写，不会覆盖现有内容
-        let workspace_id = 1;
-        // 直接测试 filter/rebuild 逻辑
+        // 验证 append_log_entry 会先读后写，不会覆盖现有内容；
+        // 这里直接测 filter/rebuild 逻辑（append_log_entry 内部即走该路径）。
         let existing = "## [2026-07-06 10:00] 摄入\n\n";
         let cutoff = cutoff_date();
         let filtered = filter_entries_by_date(existing, &cutoff);


### PR DESCRIPTION
## 背景

继 #852 之后的第二轮后端死代码清理 + clippy 零告警修复。

## 方法

临时移除全部 18 个 `#[allow(dead_code)]` / `#[allow(unused)]`，让编译器当裁判暴露真正死代码，再逐个核查处置（避免误删跨平台/RAII/resume 语义相关的合法保留项）。

## 死代码清理

| 处置 | 项 | 理由 |
|---|---|---|
| 删除 | `feishu_history_fetcher::send_text` | 完整方法无任何调用方，与 `feishu_listener::send_text` 重复 |
| 删除 | `Sender.id_type` / `tenant_key` | 反序列化后从未读取（serde 默认忽略未知字段，删除安全） |
| 删除 | `execution_events/pipeline.rs` 的 `test_extractor` 模块 | `TestExtractor` 从未被任何测试构造/引用 |
| `#[cfg(test)]` | `render_blackboard` / `ALL_EXECUTORS` | 仅测试模块调用，非测试构建不编入二进制 |
| 移除标注 | 11 个冗余 `#[allow]` | 对应项均有实际调用（`LAUNCHD_LABEL`/`TASK_NAME`/`SERVICE_NAME`/`chat_type`/`sender_type` 等） |
| 保留（精确定位到字段/函数级） | `ntd_bin_dir`、`task_guard`、`session_id_for_executor` | 跨平台（仅 linux.rs 调用）/ RAII 守卫（靠 move/drop 起作用）/ resume 语义（有设计注释） |

## clippy 零告警修复（main 上预存的 style lint）

CI 只跑 `cargo build --release`，不强制 clippy；但 CLAUDE.md 红线要求 `cargo clippy --all-targets -- -D warnings` 零告警。本 PR 顺手清掉 8 个预存 style lint：

- `db/dashboard.rs`：4 处降序 `sort_by` → `sort_by_key` + `Reverse`
- `handlers/skills.rs`：1 处升序 `sort_by` → `sort_by_key`
- `db/dashboard.rs` `compute_avg_duration`：`if/else` → `checked_div().unwrap_or(0)`
- `execution_events/metadata.rs`：`StepStart` 分支 `if` 折叠为 match guard
- `wiki/log.rs`：删除未使用的 `workspace_id` 变量

## 验证

- `cargo clippy --all-targets -- -D warnings` → 零告警零错误
- `cargo test` → 全绿（1037+ 用例，0 失败）

## 改动规模

14 文件，+30 / -124，净减 94 行。
