### PR TITLE
fix(blackboard): 删除死代码 take_pending_record_ids

### DIFF
--- a/backend/src/db/blackboard.rs
+++ b/backend/src/db/blackboard.rs
@@ -233,46 +233,16 @@ impl Database {
         Ok(())
     }
 
-    /// 取出并清空 pending 队列，返回待处理的 execution_record_id 列表。
-    ///
-    /// 两步非原子，竞态时可能丢失或重复，但 debounce 场景下可接受。
-    pub async fn take_pending_record_ids(
-        &self,
-        workspace_id: i64,
-    ) -> Result<Vec<i64>, sea_orm::DbErr> {
-        // 读取当前队列
-        let board = blackboards::Entity::find()
-            .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
-            .one(&self.conn)
-            .await?
-            .ok_or_else(|| sea_orm::DbErr::RecordNotFound(format!(
-                "blackboard for workspace {} not found",
-                workspace_id
-            )))?;
-
-        let ids: Vec<i64> = serde_json::from_str(&board.pending_record_ids)
-            .unwrap_or_default();
-
-        // 清空队列（非空才写，减少 DB 写入）；主键必须设置
-        if !ids.is_empty() {
-            let now = crate::models::utc_timestamp();
-            let _res = blackboards::ActiveModel {
-                id: ActiveValue::Unchanged(board.id),
-                workspace_id: ActiveValue::Unchanged(workspace_id),
-                pending_record_ids: ActiveValue::Set("[]".to_string()),
-                updated_at: ActiveValue::Set(Some(now)),
-                ..Default::default()
-            }.update(&self.conn).await?;
-        }
-
-        Ok(ids)
-    }
+    // 原 take_pending_record_ids（取出并清空 pending 队列）已删除：
+    // 该方法从未被调用——实际 flush 路径（executor_service/completion.rs）用
+    // get_blackboard 非破坏性读 + remove_specific_pending_record_ids 精准移除，
+    // 不走"全量清空"。且其"读快照→写 []"非原子，若被并发调用会与 append 竞态丢记录；
+    // 删除以消除这一潜在隐患，需要"取并清空"语义时请用带 queue_lock 的原子实现。
 
     /// 从 pending 队列中移除指定的 execution_record_id 列表，保留其余。
     ///
-    /// 与 [`take_pending_record_ids`] 的"全量取出+清空"不同，本方法只删除传入的 ID，
-    /// 用于 flush listener 在 wiki 更新成功后只移除已处理的记录，保留期间新到达的记录。
-    /// 若队列中不存在指定 ID（如已被其他写入覆盖），静默跳过不报错。
+    /// 本方法只删除传入的 ID（而非全量清空），用于 flush listener 在 wiki 更新成功后
+    /// 只移除已处理的记录、保留期间新到达的记录。
     pub async fn remove_specific_pending_record_ids(
         &self,
         workspace_id: i64,

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -360,8 +360,8 @@ async fn build_app_state(
 
     // 黑板防抖器初始化，启动 flush 监听器（监听 channel，收到消息后执行 LLM 更新黑板）。
     // 注意：防抖阈值已迁移到 per-workspace 配置（blackboards 表），此处使用系统级默认值
-    //（600s / 10 条），实际防抖逻辑在 push_pending_record / take_pending_record_ids 时
-    // 会从对应工作空间的黑板配置中读取真实值。
+    //（600s / 10 条），实际防抖逻辑在 push_pending_record / remove_specific_pending_record_ids
+    // 时会从对应工作空间的黑板配置中读取真实值。
     let flush_rx = crate::services::blackboard_debouncer::init().await;
     tokio::spawn(crate::executor_service::completion::blackboard_flush_listener(
         flush_rx,


### PR DESCRIPTION
审计 #2 复核修正（见 [code-quality-audit-2026-07](../docs/code-quality-audit-2026-07.md)）。

原判定：`take_pending_record_ids` 跳过 `queue_lock`，与 `append_pending_record_id` 竞态会丢记录。

**复核发现**：该方法从未被调用。实际 flush 路径（`executor_service/completion.rs:544`）用 `get_blackboard` 非破坏性读 + `remove_specific_pending_record_ids` 精准移除，注释显式写「不用 take_pending_record_ids」。**故原竞态无法触发**。

`pub` 方法在 lib crate 不被 `dead_code` lint 标记，静默残留。**删除以消除潜在隐患**（其「读快照→写 `[]`」非原子，若被未来代码误用会丢记录），并修正 `remove_specific_pending_record_ids` 与 `handlers/mod.rs` 中指向它的过时 rustdoc/注释引用。

**验证**：clippy 零告警；cargo test 1511 passed 0 failed。

> 注：审计文档 #2 的描述需后续更新（竞态不可触发，改为「死代码删除」）。