### PR TITLE
fix(BlackboardPage): 修复工作区切换竞态，丢弃 stale 响应

### DIFF
--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -22,7 +22,7 @@
  *   └──────────────────────────┘
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Button, Skeleton, message, Modal, Form, InputNumber, Space, Progress, Input, Tabs, Menu, Drawer } from 'antd';
 import { ReloadOutlined, SettingOutlined, UnorderedListOutlined, MenuOutlined } from '@ant-design/icons';
 import { PageCard } from '@/components/common/PageCard';
@@ -287,6 +287,15 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
   const [fileLoading, setFileLoading] = useState(false);
   // 旧版数据（配置用）
   const [configData, setConfigData] = useStateBlackboardData();
+
+  // 防切换竞态：ref 始终持有「最新一次渲染」的 workspaceId / currentSlug。
+  // fetch 回调在 await 前捕获闭包里的旧 key，resolve 后与 ref 比较——
+  // 不一致说明期间已切换工作空间/文件，晚到的响应直接丢弃，避免覆盖新工作空间的数据。
+  // 与 useLoopExecutions/useExecutionHistory 的 cancelledRef 思路一致（latest-wins）。
+  const latestWorkspaceIdRef = useRef(workspaceId);
+  latestWorkspaceIdRef.current = workspaceId;
+  const latestSlugRef = useRef(currentSlug);
+  latestSlugRef.current = currentSlug;
   // 设置弹窗状态
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsSaving, setSettingsSaving] = useState(false);
@@ -352,9 +361,12 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
 
   // 拉取页面列表
   const fetchFiles = useCallback(async () => {
+    // 捕获本次请求所属的工作空间，resolve 后与最新值比较，防止切换后旧响应覆盖新数据
+    const ws = workspaceId;
     try {
       setFilesLoading(true);
-      const list = await fetchWikiFiles(workspaceId);
+      const list = await fetchWikiFiles(ws);
+      if (latestWorkspaceIdRef.current !== ws) return; // 已切换到别的工作空间，丢弃
       setFiles(list);
       // 计算默认 slug：优先 topic，其次 log，都没有则空
       const defaultSlug = list.find(f => f.file_type === 'topic')?.slug
@@ -363,39 +375,49 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
       // 用函数式更新读取最新 currentSlug，避免将其放入依赖数组而每次切页重拉列表
       setCurrentSlug(prev => (list.some(p => p.slug === prev) ? prev : defaultSlug));
     } catch (err) {
+      if (latestWorkspaceIdRef.current !== ws) return; // 切换后的错误也不弹窗
       console.error('获取页面列表失败:', err);
       message.error('获取页面列表失败');
     } finally {
-      setFilesLoading(false);
+      // 仅当仍是本次请求的工作空间时才动 loading，避免把新工作空间的 loading 提前置 false
+      if (latestWorkspaceIdRef.current === ws) setFilesLoading(false);
     }
   }, [workspaceId]);
 
   // 拉取当前页面详情
   const fetchCurrentFile = useCallback(async () => {
+    // 捕获本次请求所属的工作空间 + slug，resolve 后与最新值比较，防切换竞态
+    const ws = workspaceId;
+    const slug = currentSlug;
     // 空 slug 不发起请求：初始态或切换工作空间清空后，slug 为空字符串，
     // 此时请求会得到 404 或意外数据，应直接跳过。
-    if (!currentSlug) {
+    if (!slug) {
       setFileLoading(false);
       return;
     }
     try {
       setFileLoading(true);
-      const file = await fetchWikiFileContent(workspaceId, currentSlug);
+      const file = await fetchWikiFileContent(ws, slug);
+      if (latestWorkspaceIdRef.current !== ws || latestSlugRef.current !== slug) return;
       setCurrentFile(file);
     } catch (err) {
+      if (latestWorkspaceIdRef.current !== ws || latestSlugRef.current !== slug) return;
       console.error('获取页面详情失败:', err);
       setCurrentFile(null);
     } finally {
-      setFileLoading(false);
+      if (latestWorkspaceIdRef.current === ws && latestSlugRef.current === slug) setFileLoading(false);
     }
   }, [workspaceId, currentSlug]);
 
   // 拉取配置（旧版接口，只用于设置弹窗）
   const fetchConfig = useCallback(async () => {
+    const ws = workspaceId;
     try {
-      const fetched = await fetchBlackboardData(workspaceId);
+      const fetched = await fetchBlackboardData(ws);
+      if (latestWorkspaceIdRef.current !== ws) return; // 已切换，丢弃旧响应
       setConfigData(fetched);
     } catch (err) {
+      if (latestWorkspaceIdRef.current !== ws) return;
       console.error('获取黑板配置失败:', err);
     }
   }, [workspaceId, setConfigData]);


### PR DESCRIPTION
审计 #5（见 [code-quality-audit-2026-07](../docs/code-quality-audit-2026-07.md)）。

`fetchFiles` / `fetchConfig` / `fetchCurrentFile` 无竞态守卫，A→B 快速切换时 A 的晚到响应覆盖 B 的 state。`useEffect([workspaceId])` 只清 state 不取消在途请求。同仓库 `useLoopExecutions` / `useExecutionHistory` 已用 `cancelledRef` 正确处理，此处漏了。

**修法**（latest-wins，匹配仓库既有模式）：
- 新增 `latestWorkspaceIdRef` / `latestSlugRef`，每轮渲染同步为当前值。
- 三个 fetch 在 await 前捕获闭包 key，resolve 后与 ref 比较；不一致 = 期间已切换，丢弃 `setFiles`/`setConfigData`/`setCurrentFile` 与 loading，错误也不弹窗。
- 初始加载与 `handleRefresh` 的 ws 与 ref 一致，正常 apply。

**验证**：`npx tsc --noEmit` 零错误；`npm run build` 成功。

> 注：现有 `blackboard_page.spec.ts` 在 main 上即 5/5 失败（环境依赖：dev DB 无 workspace + 未 mock `/wiki/files` + embedded 模式运行二进制为旧 bundle），非本改动引入。完整 Playwright 验证需重启 `make dev` 并准备带 workspace 的 dev DB，可作后续跟进。