### PR TITLE
fix(frontend): 修复 3 处 id 切换竞态

### DIFF
--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -9,7 +9,7 @@
 //
 // (对齐 LoopDto 的可编辑字段)。
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import {
   Skeleton, App as AntApp, Button, Space, Tooltip, Popconfirm, Empty,
   Collapse, Switch,
@@ -99,11 +99,19 @@ export function LoopDetailPanel({
     abnormal_handler_trigger_on: string;
   } | null>(null);
 
+  // 防切换竞态：ref 始终持有最新 loopId。reload 与 executionTotal 的请求 resolve 后
+  // 与 ref 比较，不一致说明期间已切到别的 loop，丢弃 stale 响应避免覆盖新 loop 的数据。
+  const latestLoopIdRef = useRef(loopId);
+  latestLoopIdRef.current = loopId;
+
   // 加载完整 detail, 子面板变更后也要重新拉以保持最新
   const reload = useCallback(() => {
+    // 捕获本次请求所属的 loopId，resolve 后与最新值比较
+    const id = loopId;
     setLoading(true);
-    dbLoops.getLoop(loopId)
+    dbLoops.getLoop(id)
       .then((d) => {
+        if (latestLoopIdRef.current !== id) return; // 已切换到别的 loop，丢弃
         setDetail(d);
         // 解析 limits_config 缓存限制值，传递给子面板做跳转自身时的兜底校验
         try {
@@ -115,18 +123,23 @@ export function LoopDetailPanel({
         }
       })
       .catch(() => {
+        if (latestLoopIdRef.current !== id) return; // 切换后的错误不弹窗
         // 只提示错误，不清空已加载的 detail；保留最后一次成功加载的数据供用户查看
         antMessage.error('加载 loop 详情失败');
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (latestLoopIdRef.current === id) setLoading(false);
+      });
   }, [loopId, antMessage]);
 
   useEffect(() => { reload(); }, [reload]);
 
   // 预加载执行记录总数（用于折叠标签展示，不等用户展开后才显示）
   useEffect(() => {
-    dbLoops.listExecutions(loopId, { page: 1, limit: 1 })
-      .then(res => setExecutionTotal(res.total))
+    // 捕获本次 loopId，resolve 后比较，丢弃切换后的 stale 响应
+    const id = loopId;
+    dbLoops.listExecutions(id, { page: 1, limit: 1 })
+      .then(res => { if (latestLoopIdRef.current === id) setExecutionTotal(res.total); })
       .catch(() => { /* 静默 */ });
   }, [loopId]);
 

--- a/frontend/src/components/todo-post/index.tsx
+++ b/frontend/src/components/todo-post/index.tsx
@@ -46,6 +46,10 @@ export function TodoPostPage({
   const [records, setRecords] = useState<ExecutionRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [replyLoading, setReplyLoading] = useState(false);
+  // 防切换竞态：ref 持有最新 recordId。loadSessionRecords resolve 后比较，
+  // 不一致说明用户已切到别的 record，丢弃 stale 响应避免覆盖新 record 的列表。
+  const latestRecordIdRef = useRef(recordId);
+  latestRecordIdRef.current = recordId;
 
   // 日志抽屉状态
   const [logDrawerOpen, setLogDrawerOpen] = useState(false);
@@ -57,10 +61,12 @@ export function TodoPostPage({
 
   // 加载 session 记录
   const loadSessionRecords = async () => {
+    // 捕获本次请求所属的 recordId，resolve 后与最新值比较，丢弃切换后的 stale 响应
+    const id = recordId;
     setLoading(true);
     try {
       // 1. 获取目标记录
-      const targetRecord = await db.getExecutionRecord(recordId);
+      const targetRecord = await db.getExecutionRecord(id);
       // 2. 如果有 session_id，拉取同 session 的所有记录
       if (targetRecord.session_id) {
         const sessionRecords = await db.getExecutionRecordsBySession(targetRecord.session_id);
@@ -68,15 +74,16 @@ export function TodoPostPage({
         sessionRecords.sort((a, b) =>
           (a.started_at || "").localeCompare(b.started_at || "")
         );
-        setRecords(sessionRecords);
+        if (latestRecordIdRef.current === id) setRecords(sessionRecords);
       } else {
         // 无 session_id，只显示这一条
-        setRecords([targetRecord]);
+        if (latestRecordIdRef.current === id) setRecords([targetRecord]);
       }
     } catch (error) {
+      if (latestRecordIdRef.current !== id) return; // 切换后的错误不弹窗
       message.error("加载执行记录失败: " + (error instanceof Error ? error.message : String(error)));
     } finally {
-      setLoading(false);
+      if (latestRecordIdRef.current === id) setLoading(false);
     }
   };
 

--- a/frontend/src/hooks/useRunningBoard.ts
+++ b/frontend/src/hooks/useRunningBoard.ts
@@ -47,26 +47,36 @@ export function useRunningBoard(workspaceId?: number | null, hours?: number): Ru
   const [loading, setLoading] = useState(true);
   const [total, setTotal] = useState(0);
   const mountedRef = useRef(true);
+  // 防切换竞态：mountedRef 只能挡 unmount（新 effect 会把它重置为 true），
+  // 挡不住 workspaceId/hours 切换——晚返回的旧请求仍会 setRecords 旧工作空间的数据。
+  // 用 latestWs/latestHours 持有最新值，请求 resolve 后比较，不一致即丢弃。
+  const latestWsRef = useRef(workspaceId);
+  latestWsRef.current = workspaceId;
+  const latestHoursRef = useRef(hours);
+  latestHoursRef.current = hours;
 
   const refresh = useCallback(async () => {
+    // 捕获本次请求所属的 workspace/hours，resolve 后与最新值比较
+    const ws = workspaceId;
+    const h = hours;
     try {
       setLoading(true);
       setRecords([]); // 切换 workspace 时先清空，避免旧数据闪烁
       setScheduledTodos([]);
       // 运行看板不分页，拉取最近的一批数据即可
-      const data = await db.getRunningBoardData(undefined, 200, workspaceId ?? undefined, hours);
-      if (mountedRef.current) {
+      const data = await db.getRunningBoardData(undefined, 200, ws ?? undefined, h);
+      if (mountedRef.current && latestWsRef.current === ws && latestHoursRef.current === h) {
         setRecords(data.records);
         setScheduledTodos(data.scheduled_todos);
         setTotal(data.total);
       }
     } catch {
-      if (mountedRef.current) {
+      if (mountedRef.current && latestWsRef.current === ws && latestHoursRef.current === h) {
         setRecords([]);
         setScheduledTodos([]);
       }
     } finally {
-      if (mountedRef.current) setLoading(false);
+      if (mountedRef.current && latestWsRef.current === ws && latestHoursRef.current === h) setLoading(false);
     }
   }, [workspaceId, hours]);
 


### PR DESCRIPTION
审计 #13（见 [code-quality-audit-2026-07](../docs/code-quality-audit-2026-07.md)）。

`mountedRef`/无守卫只挡 unmount 不挡 id 切换，晚到响应覆盖新 id 的 state。

- **`LoopStudioDetailPanel.tsx`**：`reload` 与 `executionTotal` 无守卫，loopId 快速切换时旧 loop 的晚到响应覆盖新 loop 的 detail/total。加 `latestLoopIdRef`。
- **`useRunningBoard.ts`**：`mountedRef` 被 new effect 重置为 true，挡不住 workspaceId/hours 切换。加 `latestWsRef`/`latestHoursRef`。
- **`todo-post/index.tsx`**：`loadSessionRecords` 无守卫，recordId 切换时旧 record 的晚到响应覆盖新 record 的列表。加 `latestRecordIdRef`。

模式与 #5（BlackboardPage）/ `useLoopExecutions` / `useExecutionHistory` 一致（latest-wins）。

**验证**：`npx tsc --noEmit` 零错误；`npm run build` 成功。