### PR TITLE
fix(running-board): DB 读失败不再被吞成空工作空间

### DIFF
--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -376,7 +376,10 @@ pub async fn get_running_board(
     // 需通过 todos 表关联过滤）。一次查出该 workspace 下所有 todo_ids，
     // 构建 Hashset 后在内存中过滤。
     let records = if let Some(wid) = query.workspace_id {
-        let ws_todos = state.db.get_todos_by_workspace_id(Some(wid)).await.unwrap_or_default();
+        // 用 ? 传播 DbErr：旧实现 unwrap_or_default() 会把 DB 读失败（SQLite locked/IO）
+        // 静默当成「空工作空间」，下游 filter 把所有 record 过滤掉、返回 200+0 条，
+        // 调用方无法区分真空还是 DB 挂了。改为传播错误让请求返回 5xx。
+        let ws_todos = state.db.get_todos_by_workspace_id(Some(wid)).await?;
         let ws_todo_ids: std::collections::HashSet<i64> = ws_todos.iter().map(|t| t.id).collect();
         records.into_iter().filter(|r| ws_todo_ids.contains(&r.todo_id)).collect()
     } else {

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -60,7 +60,9 @@ pub async fn get_execution_records(
     // 走这个分支，但保持接口一致性，传了就能用。
     let records = if let Some(wid) = query.workspace_id {
         if query.todo_id.is_none() && query.step_id.is_none() {
-            let ws_todos = state.db.get_todos_by_workspace_id(Some(wid)).await.unwrap_or_default();
+            // ? 传播 DbErr：旧实现 unwrap_or_default() 会把 DB 读失败静默当成空 Vec，
+            // 下游 filter 把所有 record 过滤掉、返回 200+0 条，调用方无法区分真空还是 DB 挂了。
+            let ws_todos = state.db.get_todos_by_workspace_id(Some(wid)).await?;
             let ws_todo_ids: std::collections::HashSet<i64> = ws_todos.iter().map(|t| t.id).collect();
             records.into_iter().filter(|r| ws_todo_ids.contains(&r.todo_id)).collect()
         } else {


### PR DESCRIPTION
审计 #8（见 [code-quality-audit-2026-07](../docs/code-quality-audit-2026-07.md)）。

`get_running_board` 里 `get_todos_by_workspace_id(...).await.unwrap_or_default()` 把任何 DbErr（SQLite locked/IO）静默当成空 Vec，下游 filter 把所有 record 过滤掉、返回 200+0 条，调用方无法区分「真空」还是「DB 挂了」。

**修复**：改为 `?` 传播 DbErr（与同函数内 `get_execution_records` / `get_scheduler_todos` 一致），DB 读失败时请求返回 5xx。

**验证**：clippy 零告警；cargo test 1511 passed 0 failed。