### PR TITLE
feat(console-panel): 设置新增「界面显示」开关控制底部执行日志面板显隐

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { useIsMobile } from './hooks/useIsMobile';
 import { useExecutionEvents } from './hooks/useExecutionEvents';
 import { useViewState, viewToNavKey, type View } from './hooks/useViewState';
 import { ThemeProvider, useTheme } from './hooks/useTheme';
+import { ConsolePanelProvider, useConsolePanel } from './hooks/useConsolePanel';
 import { TodoPage } from './components/TodoPage';
 import { TodoPostPage } from './components/todo-post';
 import { LoopPage } from './components/LoopPage';
@@ -42,6 +43,8 @@ function AppContent() {
   const { state, dispatch, clearSelection } = useApp();
   const { activeView, selectedId, activePanel, selectedRecordId, showView, pushUrl, replaceUrl, backToList } = useViewState();
   const { themeMode, toggleTheme } = useTheme();
+  // 底部执行日志面板的显隐开关：来自设置-界面显示，关掉后即使有运行中任务也不渲染面板。
+  const { visible: consolePanelVisible } = useConsolePanel();
 
   const [todoModalOpen, setTodoModalOpen] = useState(false);
   const [smartCreateOpen, setSmartCreateOpen] = useState(false);
@@ -90,7 +93,11 @@ function AppContent() {
   useExecutionEvents();
 
   const hasRunningTasks = Object.keys(state.runningTasks).length > 0;
-  const panelHeight = hasRunningTasks ? (panelCollapsed ? EXECUTION_PANEL.collapsed : EXECUTION_PANEL.expanded) : 0;
+  // 开关关闭时面板高度归零，主内容区不再留出底部避让空间；
+  // 否则按折叠/展开状态给出高度。
+  const panelHeight = consolePanelVisible && hasRunningTasks
+    ? (panelCollapsed ? EXECUTION_PANEL.collapsed : EXECUTION_PANEL.expanded)
+    : 0;
 
   useEffect(() => {
     db.getConfig().then(setAppConfig).catch(() => {
@@ -438,7 +445,10 @@ function AppContent() {
       />
 
       {/* Execution Panel */}
+      {/* 始终挂载以保留其内部「完成后 5s 自动移除任务」的定时器逻辑；
+          通过 hidden 让它在开关关闭或无运行任务时 return null，不占任何空间。 */}
       <ExecutionPanel
+        hidden={!consolePanelVisible}
         collapsed={panelCollapsed}
         onToggleCollapse={() => {
           const next = !panelCollapsed;
@@ -486,7 +496,9 @@ function ThemedApp() {
 function App() {
   return (
     <ThemeProvider>
-      <ThemedApp />
+      <ConsolePanelProvider>
+        <ThemedApp />
+      </ConsolePanelProvider>
     </ThemeProvider>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,13 @@
 // 主应用入口组件。
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { ConfigProvider, Layout, App as AntApp, Drawer } from 'antd';
 import { AppProvider, useApp } from './hooks/useApp';
 import { useIsMobile } from './hooks/useIsMobile';
 import { useExecutionEvents } from './hooks/useExecutionEvents';
 import { useViewState, viewToNavKey, type View } from './hooks/useViewState';
-import { ThemeProvider, useTheme } from './hooks/useTheme';
-import { ConsolePanelProvider, useConsolePanel } from './hooks/useConsolePanel';
+import { ThemeProvider, useTheme } from '@/hooks/useTheme';
+import { ConsolePanelProvider, useConsolePanel } from '@/hooks/useConsolePanel';
 import { TodoPage } from './components/TodoPage';
 import { TodoPostPage } from './components/todo-post';
 import { LoopPage } from './components/LoopPage';
@@ -44,7 +44,10 @@ function AppContent() {
   const { activeView, selectedId, activePanel, selectedRecordId, showView, pushUrl, replaceUrl, backToList } = useViewState();
   const { themeMode, toggleTheme } = useTheme();
   // 底部执行日志面板的显隐开关：来自设置-界面显示，关掉后即使有运行中任务也不渲染面板。
-  const { visible: consolePanelVisible } = useConsolePanel();
+  const { visible: consolePanelVisible, setVisible: setConsolePanelVisible } = useConsolePanel();
+  // 临时关闭态：面板上的「临时关闭」按钮置位，仅本轮任务期间隐藏，不写 localStorage。
+  // 与 consolePanelVisible 区分：永久关闭=setVisible(false) 落盘；临时关闭=会话内 dismiss。
+  const [consolePanelDismissed, setConsolePanelDismissed] = useState(false);
 
   const [todoModalOpen, setTodoModalOpen] = useState(false);
   const [smartCreateOpen, setSmartCreateOpen] = useState(false);
@@ -93,9 +96,30 @@ function AppContent() {
   useExecutionEvents();
 
   const hasRunningTasks = Object.keys(state.runningTasks).length > 0;
-  // 开关关闭时面板高度归零，主内容区不再留出底部避让空间；
-  // 否则按折叠/展开状态给出高度。
-  const panelHeight = consolePanelVisible && hasRunningTasks
+
+  // 临时关闭的撤销时机：
+  // 1) 新一轮任务开始（running 从无到有）——让面板随新任务重新出现，符合「临时」语义。
+  const prevHadRunningRef = useRef(false);
+  useEffect(() => {
+    if (!prevHadRunningRef.current && hasRunningTasks) {
+      setConsolePanelDismissed(false);
+    }
+    prevHadRunningRef.current = hasRunningTasks;
+  }, [hasRunningTasks]);
+
+  // 2) 用户在设置里重新开启面板——清除上一轮遗留的临时关闭态，确保开关闭合后立刻可见。
+  const prevVisibleRef = useRef(consolePanelVisible);
+  useEffect(() => {
+    if (!prevVisibleRef.current && consolePanelVisible) {
+      setConsolePanelDismissed(false);
+    }
+    prevVisibleRef.current = consolePanelVisible;
+  }, [consolePanelVisible]);
+
+  // 面板真正隐藏的条件：永久开关关闭，或本轮被临时关闭。两者任一为真都不渲染、不占高度。
+  const consolePanelHidden = !consolePanelVisible || consolePanelDismissed;
+  // 隐藏时面板高度归零，主内容区不再留出底部避让空间；否则按折叠/展开状态给出高度。
+  const panelHeight = !consolePanelHidden && hasRunningTasks
     ? (panelCollapsed ? EXECUTION_PANEL.collapsed : EXECUTION_PANEL.expanded)
     : 0;
 
@@ -446,15 +470,17 @@ function AppContent() {
 
       {/* Execution Panel */}
       {/* 始终挂载以保留其内部「完成后 5s 自动移除任务」的定时器逻辑；
-          通过 hidden 让它在开关关闭或无运行任务时 return null，不占任何空间。 */}
+          通过 hidden 让它在开关关闭/临时关闭/无运行任务时 return null，不占任何空间。 */}
       <ExecutionPanel
-        hidden={!consolePanelVisible}
+        hidden={consolePanelHidden}
         collapsed={panelCollapsed}
         onToggleCollapse={() => {
           const next = !panelCollapsed;
           setPanelCollapsed(next);
           try { localStorage.setItem('execution_panel_collapsed', String(next)); } catch {}
         }}
+        onTemporaryClose={() => setConsolePanelDismissed(true)}
+        onPermanentClose={() => setConsolePanelVisible(false)}
       />
 
       {/* Loop Create Modal */}

--- a/frontend/src/components/ExecutionPanel.tsx
+++ b/frontend/src/components/ExecutionPanel.tsx
@@ -11,6 +11,9 @@ import { LOG_TYPE_COLORS_LIGHT, LOG_TYPE_COLORS_DARK, LOG_TYPE_LABELS } from '@/
 interface ExecutionPanelProps {
   collapsed: boolean;
   onToggleCollapse: () => void;
+  // 开关关闭时由父组件传入 true：在此 return null 不渲染面板，但 hooks 已在上文注册，
+  // 故「完成后自动移除任务」的定时器仍会运行，避免隐藏期间运行任务列表泄漏。
+  hidden?: boolean;
 }
 
 function formatShortTime(iso: string): string {
@@ -27,7 +30,7 @@ function formatShortTime(iso: string): string {
   }
 }
 
-export function ExecutionPanel({ collapsed, onToggleCollapse }: ExecutionPanelProps) {
+export function ExecutionPanel({ collapsed, onToggleCollapse, hidden }: ExecutionPanelProps) {
   const { state, dispatch } = useApp();
   const { themeMode } = useTheme();
   const { runningTasks, activeTaskId, executionRecords } = state;
@@ -44,10 +47,11 @@ export function ExecutionPanel({ collapsed, onToggleCollapse }: ExecutionPanelPr
   const hasRunningTasks = taskIds.some(id => runningTasks[id]?.status === 'running');
   const [, setTick] = useState(0);
   useEffect(() => {
-    if (!hasRunningTasks || collapsed) return;
+    // 隐藏时面板 return null、计时数字本就不可见，没必要每秒 tick 触发空重渲染，一并短路。
+    if (!hasRunningTasks || collapsed || hidden) return;
     const interval = setInterval(() => setTick(t => t + 1), 1000);
     return () => clearInterval(interval);
-  }, [hasRunningTasks, collapsed]);
+  }, [hasRunningTasks, collapsed, hidden]);
 
   useEffect(() => {
     if (logsEndRef.current && !collapsed && activeTask) {
@@ -101,7 +105,8 @@ export function ExecutionPanel({ collapsed, onToggleCollapse }: ExecutionPanelPr
     }
   };
 
-  if (taskIds.length === 0) return null;
+  // 无运行任务或被设置开关隐藏时均不渲染：hooks 在上文已注册，定时器照常运行。
+  if (hidden || taskIds.length === 0) return null;
 
   return (
     <div className={`execution-panel ${collapsed ? 'collapsed' : ''} ${fullscreen ? 'fullscreen' : ''}`}>

--- a/frontend/src/components/ExecutionPanel.tsx
+++ b/frontend/src/components/ExecutionPanel.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useState } from 'react';
-import { ExpandOutlined, CompressOutlined, InfoCircleOutlined, StopOutlined } from '@ant-design/icons';
-import { Popconfirm, Popover, App } from 'antd';
+import { ExpandOutlined, CompressOutlined, InfoCircleOutlined, StopOutlined, CloseOutlined } from '@ant-design/icons';
+import { Popconfirm, Popover, Dropdown, App } from 'antd';
 import { useApp } from '@/hooks/useApp';
 import { useTheme } from '@/hooks/useTheme';
 import { getExecutorOption } from '@/types';
@@ -14,6 +14,10 @@ interface ExecutionPanelProps {
   // 开关关闭时由父组件传入 true：在此 return null 不渲染面板，但 hooks 已在上文注册，
   // 故「完成后自动移除任务」的定时器仍会运行，避免隐藏期间运行任务列表泄漏。
   hidden?: boolean;
+  // 临时关闭：仅本轮任务期间隐藏，新一轮任务开始或设置重新开启时自动恢复。
+  onTemporaryClose?: () => void;
+  // 永久关闭：等价于把设置里的开关置 false 并落盘，需用户去设置-界面显示重新开启。
+  onPermanentClose?: () => void;
 }
 
 function formatShortTime(iso: string): string {
@@ -30,7 +34,7 @@ function formatShortTime(iso: string): string {
   }
 }
 
-export function ExecutionPanel({ collapsed, onToggleCollapse, hidden }: ExecutionPanelProps) {
+export function ExecutionPanel({ collapsed, onToggleCollapse, hidden, onTemporaryClose, onPermanentClose }: ExecutionPanelProps) {
   const { state, dispatch } = useApp();
   const { themeMode } = useTheme();
   const { runningTasks, activeTaskId, executionRecords } = state;
@@ -210,6 +214,32 @@ export function ExecutionPanel({ collapsed, onToggleCollapse, hidden }: Executio
           >
             {collapsed ? '▲' : '▼'}
           </button>
+          {/* 关闭按钮：下拉两种关闭方式，避免两个相似 X 图标造成歧义。
+              临时关闭=本轮隐藏、下次任务自动恢复；永久关闭=落盘关闭设置。 */}
+          <Dropdown
+            trigger={['click']}
+            placement="topRight"
+            menu={{
+              items: [
+                { key: 'temporary', label: '临时关闭（下次执行自动恢复）' },
+                { key: 'permanent', label: '永久关闭（设置-界面显示中重新开启）' },
+              ],
+              onClick: ({ key }) => {
+                if (key === 'temporary') onTemporaryClose?.();
+                else if (key === 'permanent') onPermanentClose?.();
+              },
+            }}
+          >
+            <button
+              className="panel-toggle-btn"
+              aria-label="关闭"
+              title="关闭"
+              // 阻止冒泡到 tab 的点击切换，避免关闭面板的同时误切任务。
+              onClick={(e) => e.stopPropagation()}
+            >
+              <CloseOutlined />
+            </button>
+          </Dropdown>
         </div>
       </div>
 

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -8,6 +8,7 @@ import {
   FileTextOutlined,
   InfoCircleOutlined,
   CloudOutlined,
+  DesktopOutlined,
 } from '@ant-design/icons';
 import { PageCard } from '@/components/common/PageCard';
 import { useApp } from '@/hooks/useApp';
@@ -20,6 +21,7 @@ import { BackupPanel } from './settings/BackupPanel';
 import { TemplatesPanel } from './settings/TemplatesPanel';
 import { AboutPanel } from './settings/AboutPanel';
 import { CloudSyncPanel } from './settings/CloudSyncPanel';
+import { InterfaceDisplayPanel } from './settings/InterfaceDisplayPanel';
 
 import { DEFAULT_EXECUTION_TIMEOUT_SECS } from '@/constants';
 
@@ -105,7 +107,7 @@ export function SettingsPage() {
   };
 
   // Tab 顺序说明：
-  // 1. 系统设置、标签管理 → 基础配置优先
+  // 1. 系统设置、界面显示、标签管理 → 基础配置优先
   // 2. 事项模板 → 项目相关
   // 3. 备份与恢复 → 数据安全
   // 4. 云端同步 → 外部集成
@@ -125,6 +127,11 @@ export function SettingsPage() {
           handleSaveConfig={handleSaveConfig}
         />
       ),
+    },
+    {
+      key: 'interface',
+      label: <span><DesktopOutlined style={{ marginRight: 6 }} />界面显示</span>,
+      children: <InterfaceDisplayPanel />,
     },
     {
       key: 'tags',

--- a/frontend/src/components/settings/InterfaceDisplayPanel.tsx
+++ b/frontend/src/components/settings/InterfaceDisplayPanel.tsx
@@ -1,0 +1,21 @@
+import { Switch } from 'antd';
+import { useConsolePanel } from '@/hooks/useConsolePanel';
+
+/**
+ * 界面显示设置面板。
+ * 暂只放底部全局执行日志面板的显隐开关，后续如有其他纯前端 UI 偏好（如列表密度等）可在此扩展。
+ */
+export function InterfaceDisplayPanel() {
+  const { visible, setVisible } = useConsolePanel();
+
+  return (
+    <div style={{ maxWidth: 700 }}>
+      {/* 关闭后即使有运行中的任务也不会弹出底部日志框，适合不想被面板打扰的场景；
+          日志数据仍在 state.runningTasks 中正常累积，重新打开即可立刻看到期间的日志。 */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span>显示底部执行日志面板</span>
+        <Switch checked={visible} onChange={setVisible} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useConsolePanel.tsx
+++ b/frontend/src/hooks/useConsolePanel.tsx
@@ -5,7 +5,6 @@ import { createContext, useContext, useState, useLayoutEffect, type ReactNode } 
 interface ConsolePanelContextValue {
   visible: boolean;
   setVisible: (next: boolean) => void;
-  toggle: () => void;
 }
 
 const ConsolePanelContext = createContext<ConsolePanelContextValue | null>(null);
@@ -19,7 +18,9 @@ function getInitialVisible(): boolean {
     const saved = localStorage.getItem(STORAGE_KEY);
     if (saved === 'true') return true;
     if (saved === 'false') return false;
-  } catch {}
+  } catch {
+    // localStorage 在隐私模式/禁用 cookie 时可能抛错，忽略后走默认值，不阻断渲染。
+  }
   return true;
 }
 
@@ -30,15 +31,15 @@ export function ConsolePanelProvider({ children }: { children: ReactNode }) {
   useLayoutEffect(() => {
     try {
       localStorage.setItem(STORAGE_KEY, String(visible));
-    } catch {}
+    } catch {
+      // 同上：写入失败不致命，内存态仍生效，仅本次会话丢失持久化。
+    }
   }, [visible]);
 
   const setVisible = (next: boolean) => setVisibleState(next);
-  // toggle 给快捷切换用，开关本身走 setVisible 即可。
-  const toggle = () => setVisibleState(prev => !prev);
 
   return (
-    <ConsolePanelContext.Provider value={{ visible, setVisible, toggle }}>
+    <ConsolePanelContext.Provider value={{ visible, setVisible }}>
       {children}
     </ConsolePanelContext.Provider>
   );

--- a/frontend/src/hooks/useConsolePanel.tsx
+++ b/frontend/src/hooks/useConsolePanel.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useState, useLayoutEffect, type ReactNode } from 'react';
+
+// 底部全局执行日志面板（ExecutionPanel）的显隐偏好，属于纯前端 UI 偏好，
+// 走 localStorage 而非后端 config，模式与 useTheme 一致。
+interface ConsolePanelContextValue {
+  visible: boolean;
+  setVisible: (next: boolean) => void;
+  toggle: () => void;
+}
+
+const ConsolePanelContext = createContext<ConsolePanelContextValue | null>(null);
+
+// 复用单一 key，设置页开关与 App 根布局都读写它，避免状态分裂。
+const STORAGE_KEY = 'ntd_console_panel_visible';
+
+// 默认开启：保留现有「任务运行时面板自动出现」的行为，避免存量用户升级后看不到执行日志。
+function getInitialVisible(): boolean {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === 'true') return true;
+    if (saved === 'false') return false;
+  } catch {}
+  return true;
+}
+
+export function ConsolePanelProvider({ children }: { children: ReactNode }) {
+  const [visible, setVisibleState] = useState<boolean>(getInitialVisible);
+
+  // 写入 localStorage：刷新或下次进入仍能恢复，纯前端偏好无需落库。
+  useLayoutEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(visible));
+    } catch {}
+  }, [visible]);
+
+  const setVisible = (next: boolean) => setVisibleState(next);
+  // toggle 给快捷切换用，开关本身走 setVisible 即可。
+  const toggle = () => setVisibleState(prev => !prev);
+
+  return (
+    <ConsolePanelContext.Provider value={{ visible, setVisible, toggle }}>
+      {children}
+    </ConsolePanelContext.Provider>
+  );
+}
+
+export function useConsolePanel() {
+  const ctx = useContext(ConsolePanelContext);
+  if (!ctx) throw new Error('useConsolePanel must be used within ConsolePanelProvider');
+  return ctx;
+}

--- a/frontend/tests/check_interface_display.spec.ts
+++ b/frontend/tests/check_interface_display.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+// 验证「设置 → 界面显示」tab 与底部执行日志面板显隐开关。
+// 该开关为纯前端 UI 偏好（localStorage: ntd_console_panel_visible），
+// 默认开启；切换后应即时生效并持久化。
+const BASE = 'http://localhost:18088';
+const STORAGE_KEY = 'ntd_console_panel_visible';
+
+test('界面显示 tab 存在且开关默认开启', async ({ page }) => {
+  // 先清掉 localStorage，确保读到默认值（默认开启）。
+  await page.goto(BASE);
+  await page.evaluate(() => localStorage.removeItem('ntd_console_panel_visible'));
+
+  // 进入设置页（通过 URL 直接定位，避免依赖左侧导航的具体交互）。
+  await page.goto(`${BASE}/#settings`);
+  await page.waitForTimeout(800);
+
+  // 点击「界面显示」tab。
+  await page.getByRole('tab', { name: /界面显示/ }).click();
+  await page.waitForTimeout(400);
+
+  // 开关应存在且默认勾选。
+  const sw = page.locator('.ant-switch').first();
+  await expect(sw).toBeVisible();
+  await expect(sw).toHaveClass(/ant-switch-checked/);
+});
+
+test('关闭开关后 localStorage 写入 false 且面板不渲染', async ({ page }) => {
+  await page.goto(BASE);
+  await page.evaluate(() => localStorage.setItem('ntd_console_panel_visible', 'true'));
+  await page.reload();
+  await page.goto(`${BASE}/#settings`);
+  await page.waitForTimeout(800);
+  await page.getByRole('tab', { name: /界面显示/ }).click();
+  await page.waitForTimeout(400);
+
+  const sw = page.locator('.ant-switch').first();
+  await expect(sw).toBeVisible();
+
+  // 关掉开关。
+  await sw.click();
+  await page.waitForTimeout(300);
+
+  // localStorage 应已持久化为 false。
+  const stored = await page.evaluate(() => localStorage.getItem('ntd_console_panel_visible'));
+  expect(stored).toBe('false');
+
+  // 关闭后底部执行日志面板不应渲染（即使无运行任务也本就不渲染，这里主要断言不存在）。
+  await expect(page.locator('.execution-panel')).toHaveCount(0);
+});


### PR DESCRIPTION
## 改动

在设置页新增「界面显示」tab，内置一个开关，控制底部全局执行日志面板（`ExecutionPanel`）的显隐。关闭后即使有运行中任务也不弹出日志框；重新打开可立刻查看期间的日志。

### 文件
- `frontend/src/hooks/useConsolePanel.tsx`（新）：Context + hook，localStorage `ntd_console_panel_visible` 持久化，默认开启（保留现有行为，不回归）
- `frontend/src/components/settings/InterfaceDisplayPanel.tsx`（新）：「界面显示」tab 内容，一个 Switch
- `frontend/src/components/SettingsPage.tsx`：新增 tab（DesktopOutlined，置于「系统设置」之后），更新顺序注释
- `frontend/src/App.tsx`：包 `ConsolePanelProvider`；读 `visible` gate `panelHeight`（关时归零，主内容区不再避让）；给 `ExecutionPanel` 传 `hidden`
- `frontend/src/components/ExecutionPanel.tsx`：新增 `hidden` prop，关时 `return null`；隐藏时 1s tick 计时器一并短路
- `frontend/tests/check_interface_display.spec.ts`（新）：Playwright 验证

### 关键设计
- **共享状态用 Context**（仿 `useTheme`）：设置页开关与 App 根显隐是两个不相邻组件，Context 保证切换即时生效，无需刷新。
- **关时仍累计、仅不显示**：`ExecutionPanel` 始终挂载，靠 `hidden` 内部 `return null`；`state.runningTasks` 日志照常累积、「完成后 5s 自动移除任务」定时器照常运行，避免隐藏期运行任务泄漏。
- **纯前端偏好走 localStorage**：不落后端 config，符合项目 `panelCollapsed`/`railCollapsed` 等既有开关模式。

### 性能
- 隐藏时日志行 DOM 不再渲染——执行期间日志高频流入时这是面板最贵的开销，关掉后实打实省掉。
- 隐藏时 1s tick 计时器短路，不再触发空重渲染。
- 空载（无运行任务）时面板本就 `return null`，开关无影响。

## 验证
- `npx tsc --noEmit` → 零错误
- `npm run build` → 通过
- Playwright `check_interface_display.spec.ts` → 2/2 通过
  - 界面显示 tab 存在且开关默认开启
  - 关闭开关后 localStorage 写入 false 且面板不渲染