### PR TITLE
feat(blackboard): Wiki 执行超时做成 per-workspace 可配置项

### DIFF
--- a/backend/src/db/blackboard.rs
+++ b/backend/src/db/blackboard.rs
@@ -14,6 +14,22 @@ use tokio::sync::Mutex;
 use super::entity::blackboards;
 use super::Database;
 
+/// Wiki 执行超时的下限（秒）。低于此值的配置会被钳制到此值，
+/// 避免用户误填 0 或极小值导致 Wiki 任务刚启动就超时。
+pub const MIN_WIKI_TIMEOUT_SECS: i64 = 60;
+/// Wiki 执行超时的上限（秒）。超过此值视为异常配置，避免单次任务无限期占用资源。
+pub const MAX_WIKI_TIMEOUT_SECS: i64 = 3600;
+/// Wiki 执行超时的默认值（秒），与历史写死的 5 分钟一致。
+pub const DEFAULT_WIKI_TIMEOUT_SECS: i64 = 300;
+
+/// 将用户输入的 wiki 超时秒数钳制到合法区间。
+///
+/// 设计取舍：超时太小会让 Wiki 任务刚启动就超时；太大则可能让异常任务长期占用资源。
+/// 因此设 [MIN, MAX] 区间，超界值会被静默钳制而非拒收，避免用户反复试错。
+fn clamp_wiki_timeout(secs: i64) -> i64 {
+    secs.clamp(MIN_WIKI_TIMEOUT_SECS, MAX_WIKI_TIMEOUT_SECS)
+}
+
 /// per-workspace 互斥锁，串行化 pending 队列的「读-改-写」操作。
 ///
 /// 背景：`append_pending_record_id` 与 `remove_specific_pending_record_ids` 都是
@@ -90,11 +106,13 @@ impl Database {
             wiki_prompt: ActiveValue::Set(String::new()),
             // None 表示使用默认执行器 "claudecode"
             wiki_chat_executor: ActiveValue::Set(None),
+            // Wiki 执行超时默认 5 分钟，与历史写死值一致
+            wiki_timeout_secs: ActiveValue::Set(DEFAULT_WIKI_TIMEOUT_SECS),
             updated_at: ActiveValue::Set(Some(now.clone())),
             created_at: ActiveValue::Set(Some(now)),
             ..Default::default()
         };
-        // ON CONFLICT(workspace_id) DO NOTHING：若记录已存在则跳过 insert，
+        // ON CONFLICT(workspace_id) DO NOTHING：若记录已存在则跳过 insert,
         // 避免并发竞争下两个并发请求都走 insert 路径时第二个失败。
         // 后续重读以拿到稳定的 Model（含实际的主键 id）。
         blackboards::Entity::insert(model)
@@ -174,6 +192,8 @@ impl Database {
             blackboard_debounce_count: ActiveValue::Set(10),
             wiki_prompt: ActiveValue::Set(String::new()),
             wiki_chat_executor: ActiveValue::Set(None),
+            // 新建行时给 Wiki 超时填默认值；冲突分支不覆盖，保留用户已调过的配置
+            wiki_timeout_secs: ActiveValue::Set(DEFAULT_WIKI_TIMEOUT_SECS),
             ..Default::default()
         };
         // ON CONFLICT(workspace_id)：命中后只覆盖 content/updated_at，保留 created_at 和配置字段
@@ -303,15 +323,18 @@ impl Database {
             wiki_prompt: b.wiki_prompt,
             wiki_chat_executor: b.wiki_chat_executor,
             wiki_chat_sessions: b.wiki_chat_sessions,
+            wiki_timeout_secs: b.wiki_timeout_secs,
         }))
     }
 
     /// 更新指定工作空间的黑板配置。
     ///
-    /// 输入：workspace_id + 四个可选字段（debounce_secs、debounce_count、wiki_prompt、wiki_chat_executor）。
+    /// 输入：workspace_id + 五个可选字段（debounce_secs、debounce_count、wiki_prompt、
+    /// wiki_chat_executor、wiki_timeout_secs）。
     /// 流程：先按 workspace_id 查出黑板记录（不存在则 RecordNotFound）→ 构造 ActiveModel
     /// → 只对传入 Some 的字段写入，传入 None 的保持原值不变 → update。
     /// 防抖阈值有下限保护：debounce_secs >= 10，debounce_count >= 1。
+    /// wiki_timeout_secs 有区间保护：钳制到 [MIN_WIKI_TIMEOUT_SECS, MAX_WIKI_TIMEOUT_SECS]。
     /// wiki_chat_executor 使用 Option<Option<String>>：
     ///   - 外层 None：不修改
     ///   - 外层 Some(None)：设为 NULL（使用默认执行器）
@@ -325,6 +348,7 @@ impl Database {
         debounce_count: Option<i64>,
         wiki_prompt: Option<String>,
         wiki_chat_executor: Option<Option<String>>,
+        wiki_timeout_secs: Option<i64>,
     ) -> Result<(), sea_orm::DbErr> {
         let board = blackboards::Entity::find()
             .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
@@ -354,6 +378,9 @@ impl Database {
         }
         if let Some(v) = wiki_chat_executor {
             am.wiki_chat_executor = ActiveValue::Set(v);
+        }
+        if let Some(v) = wiki_timeout_secs {
+            am.wiki_timeout_secs = ActiveValue::Set(clamp_wiki_timeout(v));
         }
         am.update(&self.conn).await?;
         Ok(())
@@ -454,6 +481,8 @@ pub struct BlackboardConfig {
     /// Wiki 对话各执行器的 session ID（JSON 对象）。
     /// 例如：{"claudecode": "uuid-session-1", "hermes": "uuid-session-2"}
     pub wiki_chat_sessions: Option<String>,
+    /// Wiki 执行超时（秒），控制 update_blackboard_wiki 等待与 Wiki 对话子进程的时长。
+    pub wiki_timeout_secs: i64,
 }
 
 #[cfg(test)]
@@ -498,6 +527,7 @@ mod tests {
         assert_eq!(board.blackboard_debounce_count, 10);
         assert_eq!(board.wiki_prompt, "");
         assert_eq!(board.wiki_chat_executor, None);
+        assert_eq!(board.wiki_timeout_secs, DEFAULT_WIKI_TIMEOUT_SECS);
 
         // 验证可通过 get 查到
         let fetched = db.get_blackboard(ws_id).await.unwrap();
@@ -630,6 +660,7 @@ mod tests {
         assert_eq!(cfg.debounce_count, 10);
         assert_eq!(cfg.wiki_prompt, "");
         assert_eq!(cfg.wiki_chat_executor, None);
+        assert_eq!(cfg.wiki_timeout_secs, DEFAULT_WIKI_TIMEOUT_SECS);
     }
 
     /// 验证 update_blackboard_config 正确更新各字段。
@@ -639,7 +670,7 @@ mod tests {
         let ws_id = create_test_workspace(&db).await;
         db.create_blackboard(ws_id).await.unwrap();
 
-        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("wiki".to_string()), Some(Some("codex".to_string())))
+        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("wiki".to_string()), Some(Some("codex".to_string())), None)
             .await
             .unwrap();
 
@@ -648,6 +679,8 @@ mod tests {
         assert_eq!(cfg.debounce_count, 5);
         assert_eq!(cfg.wiki_prompt, "wiki");
         assert_eq!(cfg.wiki_chat_executor, Some("codex".to_string()));
+        // wiki_timeout_secs 未传 None → 应保留 create_blackboard 写入的默认 300
+        assert_eq!(cfg.wiki_timeout_secs, DEFAULT_WIKI_TIMEOUT_SECS);
     }
 
     /// 验证 update_blackboard_config 对 None 字段保持原值。
@@ -658,12 +691,12 @@ mod tests {
         db.create_blackboard(ws_id).await.unwrap();
 
         // 先全部更新
-        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("wiki".to_string()), Some(Some("kimi".to_string())))
+        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("wiki".to_string()), Some(Some("kimi".to_string())), Some(600))
             .await
             .unwrap();
 
         // 再只更新其中两个
-        db.update_blackboard_config(ws_id, Some(900), None, None, None)
+        db.update_blackboard_config(ws_id, Some(900), None, None, None, None)
             .await
             .unwrap();
 
@@ -672,6 +705,8 @@ mod tests {
         assert_eq!(cfg.debounce_count, 5, "debounce_count 应保留之前的值");
         assert_eq!(cfg.wiki_prompt, "wiki", "wiki_prompt 应保留之前的值");
         assert_eq!(cfg.wiki_chat_executor, Some("kimi".to_string()), "wiki_chat_executor 应保留之前的值");
+        // wiki_timeout_secs 第二次传 None → 应保留第一次写入的 600
+        assert_eq!(cfg.wiki_timeout_secs, 600, "wiki_timeout_secs 应保留之前的值");
     }
 
     /// 验证 update_blackboard_config 在记录不存在时返回 RecordNotFound。
@@ -679,7 +714,7 @@ mod tests {
     async fn test_update_blackboard_config_record_not_found() {
         let db = Database::new(":memory:").await.expect(":memory: must open");
         // 第 4 个参数 wiki_prompt 传 None，不参与此次测试验证
-        let result = db.update_blackboard_config(999, Some(300), None, None, None).await;
+        let result = db.update_blackboard_config(999, Some(300), None, None, None, None).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             sea_orm::DbErr::RecordNotFound(_) => {}
@@ -695,14 +730,14 @@ mod tests {
         db.create_blackboard(ws_id).await.unwrap();
 
         // 传入小于最小值的 debounce_secs，应被钳制到 10
-        db.update_blackboard_config(ws_id, Some(3), None, None, None)
+        db.update_blackboard_config(ws_id, Some(3), None, None, None, None)
             .await
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
         assert_eq!(cfg.debounce_secs, 10);
 
         // 传入小于最小值的 debounce_count，应被钳制到 1
-        db.update_blackboard_config(ws_id, None, Some(0), None, None)
+        db.update_blackboard_config(ws_id, None, Some(0), None, None, None)
             .await
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
@@ -717,18 +752,49 @@ mod tests {
         db.create_blackboard(ws_id).await.unwrap();
 
         // 先设置一个值
-        db.update_blackboard_config(ws_id, None, None, None, Some(Some("codex".to_string())))
+        db.update_blackboard_config(ws_id, None, None, None, Some(Some("codex".to_string())), None)
             .await
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
         assert_eq!(cfg.wiki_chat_executor, Some("codex".to_string()));
 
         // 再设为 None（清空回退到默认）
-        db.update_blackboard_config(ws_id, None, None, None, Some(None))
+        db.update_blackboard_config(ws_id, None, None, None, Some(None), None)
             .await
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
         assert_eq!(cfg.wiki_chat_executor, None);
+    }
+
+    /// 验证 update_blackboard_config 对 wiki_timeout_secs 做区间钳制。
+    /// 低于下限应钳到 MIN_WIKI_TIMEOUT_SECS，高于上限应钳到 MAX_WIKI_TIMEOUT_SECS，
+    /// 区间内原样保留。避免用户误填 0 或超大值导致任务刚启动就超时 / 长期占用资源。
+    #[tokio::test]
+    async fn test_update_blackboard_config_wiki_timeout_clamp() {
+        let db = Database::new(":memory:").await.expect(":memory: must open");
+        let ws_id = create_test_workspace(&db).await;
+        db.create_blackboard(ws_id).await.unwrap();
+
+        // 传入低于下限的值（0），应被钳制到 MIN_WIKI_TIMEOUT_SECS
+        db.update_blackboard_config(ws_id, None, None, None, None, Some(0))
+            .await
+            .unwrap();
+        let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
+        assert_eq!(cfg.wiki_timeout_secs, MIN_WIKI_TIMEOUT_SECS);
+
+        // 传入高于上限的值，应被钳制到 MAX_WIKI_TIMEOUT_SECS
+        db.update_blackboard_config(ws_id, None, None, None, None, Some(MAX_WIKI_TIMEOUT_SECS + 1000))
+            .await
+            .unwrap();
+        let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
+        assert_eq!(cfg.wiki_timeout_secs, MAX_WIKI_TIMEOUT_SECS);
+
+        // 区间内的值原样保留
+        db.update_blackboard_config(ws_id, None, None, None, None, Some(600))
+            .await
+            .unwrap();
+        let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
+        assert_eq!(cfg.wiki_timeout_secs, 600);
     }
 
     /// 并发回归测试：append 与 remove 交错执行时，队列必须正确收敛，

--- a/backend/src/db/entity/blackboards.rs
+++ b/backend/src/db/entity/blackboards.rs
@@ -37,6 +37,10 @@ pub struct Model {
     /// 切换执行器时不会丢失 session，支持连续对话。
     #[sea_orm(column_type = "Text")]
     pub wiki_chat_sessions: Option<String>,
+    /// Wiki 执行超时（秒）。控制 `update_blackboard_wiki` 等待 Finished 事件、
+    /// 以及 Wiki 对话子进程的最长存活时间。默认 300（5 分钟），
+    /// 可在黑板设置界面按工作空间调整，避免慢模型被强制超时。
+    pub wiki_timeout_secs: i64,
     pub updated_at: Option<String>,
     pub created_at: Option<String>,
 }

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -15,6 +15,7 @@ mod v47_v53;
 mod v54;
 mod v55;
 mod v56;
+mod v57;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -53,6 +54,8 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v55::V55AddWikiChatSessions),
         // V56 必须排在 V55 之后：补齐早期 V47 跳过建表演进列的旧部署遗留
         Box::new(v56::V56AddMissingBlackboardColumns),
+        // V57 在 V56 之后：把写死的 Wiki 执行超时做成 per-workspace 可配置项
+        Box::new(v57::V57AddWikiTimeoutSecs),
     ]
 }
 

--- a/backend/src/db/migration/v47_v53.rs
+++ b/backend/src/db/migration/v47_v53.rs
@@ -100,6 +100,7 @@ CREATE TABLE IF NOT EXISTS blackboards (
     blackboard_debounce_count INTEGER NOT NULL DEFAULT 10,
     wiki_prompt TEXT NOT NULL DEFAULT '',
     wiki_chat_executor TEXT,
+    wiki_timeout_secs INTEGER NOT NULL DEFAULT 300,
     updated_at TEXT,
     created_at TEXT,
     FOREIGN KEY (workspace_id) REFERENCES project_directories(id) ON DELETE CASCADE
@@ -132,6 +133,7 @@ mod tests {
             "blackboard_debounce_count",
             "wiki_prompt",
             "wiki_chat_executor",
+            "wiki_timeout_secs",
         ] {
             assert!(
                 super::super::table_has_column(&db, "blackboards", col)

--- a/backend/src/db/migration/v57.rs
+++ b/backend/src/db/migration/v57.rs
@@ -1,0 +1,148 @@
+//! 数据库迁移 V57：为 blackboards 表新增 wiki_timeout_secs 字段。
+//!
+//! ## 背景
+//! 黑板的 Wiki 自动维护（`update_blackboard_wiki`）和 Wiki 对话
+//! （`spawn_executor_for_chat_streaming`）此前都把超时写死成 300 秒，
+//! 用户无法在设置界面调整。一旦 Wiki 维护任务因模型慢、上下文大而超过 5 分钟，
+//! 就会被强制超时失败（日志：`Wiki 执行超时（5 分钟）`）。
+//!
+//! 本迁移把超时做成 per-workspace 可配置项，默认值仍为 300 秒（与旧行为一致），
+//! 用户可在黑板设置界面按需调大/调小。
+//!
+//! ## 幂等设计
+//! 复用 `add_column_if_missing`，列已存在则静默跳过；新装 DB（V47 已建齐表）
+//! 跑本迁移也只是 noop，不会破坏已有数据。
+//!
+//! ## 默认值
+//! - wiki_timeout_secs: 300（与原写死的 5 分钟一致，保证存量行为不变）
+//!
+//! 注意 SQLite 的 ADD COLUMN 带 DEFAULT 会回填旧行，避免存量行变 NULL 导致
+//! 后续业务层读取时拿到 0 误判成「无超时」。
+
+use async_trait::async_trait;
+
+use super::super::Database;
+use super::{Migration, add_column_if_missing};
+
+pub(super) struct V57AddWikiTimeoutSecs;
+
+#[async_trait]
+impl Migration for V57AddWikiTimeoutSecs {
+    fn version(&self) -> i64 {
+        57
+    }
+
+    fn name(&self) -> &'static str {
+        "add_blackboards_wiki_timeout_secs"
+    }
+
+    /// 为 blackboards 表追加 wiki_timeout_secs 列。
+    ///
+    /// 用 NOT NULL DEFAULT 300 回填旧行，保证存量工作空间立即拥有与原写死值
+    /// 一致的 5 分钟超时，迁移后行为零变化。
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        add_column_if_missing(
+            db,
+            "blackboards",
+            "wiki_timeout_secs",
+            // DEFAULT 300 让旧行回填，避免业务层读到 NULL/0 误判
+            "ALTER TABLE blackboards ADD COLUMN wiki_timeout_secs INTEGER NOT NULL DEFAULT 300",
+        )
+        .await?;
+        tracing::info!("V57: blackboards.wiki_timeout_secs 列已添加");
+        Ok(())
+    }
+}
+
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::migration::table_has_column;
+    use crate::db::Database;
+
+    /// 验证 V57 迁移成功添加 wiki_timeout_secs 列。
+    /// 目的：确保列在全新库上被正确追加，且不破坏 V47 已建的表结构。
+    #[tokio::test]
+    async fn test_v57_adds_wiki_timeout_secs_column() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+
+        // 先走 V47 建表，模拟一个已有 blackboards 表的环境
+        let v47 = crate::db::migration::v47_v53::V47ConsolidatedBlackboardFeatures;
+        v47.up(&db).await.expect("V47 migration must succeed");
+
+        // 执行 V57
+        let migration = V57AddWikiTimeoutSecs;
+        migration.up(&db).await.expect("V57 migration must succeed");
+
+        // 关键断言：列已存在
+        assert!(
+            table_has_column(&db, "blackboards", "wiki_timeout_secs")
+                .await
+                .unwrap(),
+            "wiki_timeout_secs column must exist after V57"
+        );
+    }
+
+    /// 验证 V57 迁移是幂等的（重复执行不报错）。
+    /// 防止 schema_version 与 m.up 不一致时下次启动重跑失败。
+    #[tokio::test]
+    async fn test_v57_is_idempotent() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+
+        let v47 = crate::db::migration::v47_v53::V47ConsolidatedBlackboardFeatures;
+        v47.up(&db).await.expect("V47 migration must succeed");
+
+        let migration = V57AddWikiTimeoutSecs;
+        migration.up(&db).await.expect("First run must succeed");
+        migration.up(&db).await.expect("Second run must succeed (idempotent)");
+    }
+
+    /// 验证 V57 给旧行回填默认值 300，而非 NULL/0。
+    /// 这是 NOT NULL DEFAULT 子句的关键作用：存量工作空间的超时行为在迁移后
+    /// 必须与原写死的 5 分钟完全一致，不能因为迁移悄悄变成「无超时」或「0 秒」。
+    #[tokio::test]
+    async fn test_v57_backfills_default_300_to_legacy_rows() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+
+        let v47 = crate::db::migration::v47_v53::V47ConsolidatedBlackboardFeatures;
+        v47.up(&db).await.expect("V47 migration must succeed");
+
+        // 插一条旧行（迁移前没有 wiki_timeout_secs 列，这里模拟迁移前的存量数据）
+        // workspace_id=1 对应的 project_directories 行可能不存在，但 SQLite 默认不强制外键
+        db.exec(
+            r#"INSERT INTO blackboards (workspace_id, content) VALUES (1, 'legacy')"#,
+        )
+        .await
+        .expect("legacy row must be inserted");
+
+        // 跑 V57：应追加列并回填默认值
+        let migration = V57AddWikiTimeoutSecs;
+        migration.up(&db).await.expect("V57 migration must succeed");
+
+        // 读取旧行，确认 wiki_timeout_secs 被回填成 300，而非 NULL 或 0
+        use sea_orm::ConnectionTrait;
+        let row = db
+            .conn
+            .query_one(sea_orm::Statement::from_string(
+                sea_orm::DbBackend::Sqlite,
+                "SELECT wiki_timeout_secs FROM blackboards WHERE workspace_id = 1".to_string(),
+            ))
+            .await
+            .expect("row must be readable")
+            .expect("legacy row must still exist");
+        let timeout: i64 = row
+            .try_get_by_index(0)
+            .expect("wiki_timeout_secs must be readable");
+        assert_eq!(
+            timeout, 300,
+            "legacy row must backfill to 300 (5 min), matching old hardcoded behavior"
+        );
+    }
+}

--- a/backend/src/handlers/blackboard.rs
+++ b/backend/src/handlers/blackboard.rs
@@ -29,6 +29,8 @@ pub struct BlackboardResponse {
     pub wiki_prompt: String,
     /// Wiki 对话使用的执行器名称（None 表示使用默认值 "claudecode"）
     pub wiki_chat_executor: Option<String>,
+    /// Wiki 执行超时（秒），控制 Wiki 任务与 Wiki 对话的最长存活时间
+    pub wiki_timeout_secs: i64,
     /// 待处理的 execution_record_id 列表（JSON 数组字符串）
     pub pending_record_ids: String,
 }
@@ -68,6 +70,8 @@ pub struct UpdateBlackboardConfigRequest {
     pub blackboard_debounce_count: Option<i64>,
     pub wiki_prompt: Option<String>,
     pub wiki_chat_executor: Option<String>,
+    /// Wiki 执行超时（秒）。None 不修改，Some(v) 会被后端钳制到合法区间。
+    pub wiki_timeout_secs: Option<i64>,
 }
 
 /// `GET /api/workspaces/{workspace_id}/blackboard`
@@ -90,6 +94,7 @@ pub async fn get_blackboard(
             blackboard_debounce_count: model.blackboard_debounce_count,
             wiki_prompt: model.wiki_prompt,
             wiki_chat_executor: model.wiki_chat_executor,
+            wiki_timeout_secs: model.wiki_timeout_secs,
             pending_record_ids: model.pending_record_ids,
         })),
         None => Ok(ApiResponse::ok(BlackboardResponse {
@@ -100,6 +105,7 @@ pub async fn get_blackboard(
             blackboard_debounce_count: 10,
             wiki_prompt: String::new(),
             wiki_chat_executor: None,
+            wiki_timeout_secs: crate::db::blackboard::DEFAULT_WIKI_TIMEOUT_SECS,
             pending_record_ids: String::from("[]"),
         })),
     }
@@ -126,6 +132,7 @@ pub async fn get_blackboard_config(
             wiki_prompt: String::new(),
             wiki_chat_executor: None,
             wiki_chat_sessions: None,
+            wiki_timeout_secs: crate::db::blackboard::DEFAULT_WIKI_TIMEOUT_SECS,
         })),
     }
 }
@@ -151,6 +158,8 @@ pub async fn update_blackboard_config(
         //   - 字段为 "" → Some(None)（设为 NULL，用默认执行器）
         //   - 字段为非空 → Some(Some(s))（设为指定执行器）
         req.wiki_chat_executor.map(|s| if s.is_empty() { None } else { Some(s) }),
+        // wiki_timeout_secs: None 不修改，Some(v) 由 db 层钳制到合法区间
+        req.wiki_timeout_secs,
     ).await.map_err(|e| AppError::Internal(format!("更新黑板配置失败: {}", e)))?;
 
     // 配置变更后同步到该 workspace 已存在的 Wiki Todo 的 prompt 字段：

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -258,20 +258,25 @@ async fn run_wiki_execution(
         AppError::Internal("Wiki 更新任务启动失败".to_string())
     })?;
 
+    // 读取 per-workspace 超时配置：用户在黑板设置界面可调，DB 读失败回退默认 5 分钟
+    let timeout_secs = resolve_wiki_timeout_secs(&db, workspace_id).await;
+
     // 等待 Finished
-    wait_for_finished(&mut rx, &task_id, workspace_id).await
+    wait_for_finished(&mut rx, &task_id, workspace_id, timeout_secs).await
 }
 
 /// 等待目标 task_id 对应的 Finished 事件。
 ///
-/// 使用 5 分钟超时防止无限等待；仅当 `success=true` 时才认为执行成功并返回结果。
+/// 超时时长由调用方传入（来自 per-workspace 黑板配置 wiki_timeout_secs），
+/// 防止事件丢失时永久阻塞；仅当 `success=true` 时才认为执行成功并返回结果。
 async fn wait_for_finished(
     rx: &mut tokio::sync::broadcast::Receiver<ExecEvent>,
     task_id: &str,
     workspace_id: i64,
+    timeout_secs: u64,
 ) -> Result<Option<String>, AppError> {
-    // 5 分钟超时，防止事件丢失时永久阻塞
-    let timeout_duration = tokio::time::Duration::from_secs(5 * 60);
+    // 用配置的超时时长，防止事件丢失时永久阻塞
+    let timeout_duration = tokio::time::Duration::from_secs(timeout_secs);
     let deadline = tokio::time::Instant::now() + timeout_duration;
 
     loop {
@@ -280,12 +285,14 @@ async fn wait_for_finished(
             // 超时：事件未在规定时间内到达
             Err(_) => {
                 tracing::warn!(
-                    "Wiki 执行超时: workspace_id={}, task_id={}, timeout_secs=300",
+                    "Wiki 执行超时: workspace_id={}, task_id={}, timeout_secs={}",
                     workspace_id,
-                    task_id
+                    task_id,
+                    timeout_secs
                 );
                 return Err(AppError::Internal(format!(
-                    "Wiki 执行超时（5 分钟），task_id={}",
+                    "Wiki 执行超时（{}秒），task_id={}",
+                    timeout_secs,
                     task_id
                 )));
             }
@@ -496,6 +503,8 @@ pub async fn chat_with_wiki(
     });
 
     // 7. spawn 执行器子进程，流式读取 stdout，逐行推送 WikiChatOutput 事件
+    //    超时读 per-workspace 配置：用户在黑板设置界面可调，DB 读失败回退默认 5 分钟
+    let timeout_secs = resolve_wiki_timeout_secs(db, workspace_id).await;
     let started_at = std::time::Instant::now();
     let spawn_result = spawn_executor_for_chat_streaming(
         &executor,
@@ -505,6 +514,7 @@ pub async fn chat_with_wiki(
         workspace_id,
         tx,
         session_id.clone(),
+        timeout_secs,
     )
     .await;
 
@@ -629,6 +639,26 @@ async fn resolve_chat_executor(
     Ok("claudecode".to_string())
 }
 
+/// 从 per-workspace 黑板配置读取 Wiki 执行超时秒数。
+///
+/// DB 读取失败或记录缺失时回退默认值（5 分钟），与历史写死行为一致，
+/// 避免配置读取异常影响 Wiki 任务的可用性。返回值已被 db 层钳制到合法区间，
+/// 这里只做防御性兜底：负值/0 视为未配置回退默认。
+async fn resolve_wiki_timeout_secs(db: &Arc<Database>, workspace_id: i64) -> u64 {
+    // 读黑板配置，失败不致命——回退默认值保证 Wiki 任务能继续跑
+    match db.get_blackboard_config(workspace_id).await {
+        Ok(Some(cfg)) if cfg.wiki_timeout_secs > 0 => cfg.wiki_timeout_secs as u64,
+        // 配置缺失/读到 0/负值 → 回退默认 5 分钟
+        _ => {
+            tracing::debug!(
+                "wiki timeout 未配置或非法，回退默认值: workspace_id={}",
+                workspace_id
+            );
+            crate::db::blackboard::DEFAULT_WIKI_TIMEOUT_SECS as u64
+        }
+    }
+}
+
 /// spawn 执行器子进程，流式读取 stdout，逐行解析并推送 WikiChatOutput 事件。
 ///
 /// 与 handle_default_response_executor 的 spawn 逻辑保持一致：
@@ -640,7 +670,12 @@ async fn resolve_chat_executor(
 /// 返回：(解析出的日志条目列表, 原始 stdout 文本, 原始 stderr 文本, 是否成功退出)
 /// 同时通过 broadcast channel 实时推送每一行日志，前端 WebSocket 可收到。
 ///
-/// 超时保护 5 分钟，超时后 kill 子进程并返回错误。
+/// 超时保护由调用方传入（来自 per-workspace 配置 wiki_timeout_secs），
+/// 超时后 kill 子进程并返回错误。
+///
+/// 参数较多但均为生成子进程所必需的上下文，拆 struct 反而割裂调用点可读性，
+/// 故与项目内其他 spawn 类函数一致允许 too_many_arguments。
+#[allow(clippy::too_many_arguments)]
 async fn spawn_executor_for_chat_streaming(
     executor: &std::sync::Arc<dyn crate::adapters::CodeExecutor>,
     message: &str,
@@ -649,6 +684,7 @@ async fn spawn_executor_for_chat_streaming(
     workspace_id: i64,
     tx: &tokio::sync::broadcast::Sender<crate::executor_service::events::ExecEvent>,
     session_id: Option<String>,
+    timeout_secs: u64,
 ) -> Result<(Vec<crate::models::ParsedLogEntry>, String, String, bool), AppError> {
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
     use crate::executor_service::events::ExecEvent;
@@ -707,9 +743,8 @@ async fn spawn_executor_for_chat_streaming(
     let mut raw_stdout_lines: Vec<String> = Vec::new();
     let mut raw_stderr_lines: Vec<String> = Vec::new();
 
-    // 超时保护：5 分钟
-    const EXEC_TIMEOUT_SECS: u64 = 300;
-    let timeout_fut = tokio::time::sleep(std::time::Duration::from_secs(EXEC_TIMEOUT_SECS));
+    // 超时保护：用 per-workspace 配置值，超时后 kill 子进程避免僵尸进程
+    let timeout_fut = tokio::time::sleep(std::time::Duration::from_secs(timeout_secs));
     tokio::pin!(timeout_fut);
 
     loop {
@@ -791,14 +826,14 @@ async fn spawn_executor_for_chat_streaming(
             _ = &mut timeout_fut => {
                 tracing::error!(
                     "wiki chat executor timed out after {}s, killing child: task_id={}",
-                    EXEC_TIMEOUT_SECS,
+                    timeout_secs,
                     task_id
                 );
                 let _ = child.kill().await;
                 let stderr_raw = raw_stderr_lines.join("\n");
                 return Err(AppError::Internal(format!(
                     "执行器超时（{}秒），请稍后重试或简化问题\nstderr: {}",
-                    EXEC_TIMEOUT_SECS, stderr_raw
+                    timeout_secs, stderr_raw
                 )));
             }
         }

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -49,6 +49,8 @@ interface BlackboardData {
   wiki_prompt: string;
   /** Wiki 对话使用的执行器名称，空/undefined 表示使用默认值 claudecode */
   wiki_chat_executor?: string | null;
+  /** Wiki 执行超时（秒），控制 Wiki 任务与 Wiki 对话的最长存活时间 */
+  wiki_timeout_secs: number;
 }
 
 /** Wiki 文件列表项（对应后端 WikiFileItem） */
@@ -303,6 +305,8 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
   const [debounceSecs, setDebounceSecs] = useState<number | null>(600);
   const [debounceCount, setDebounceCount] = useState<number | null>(10);
   const [wikiPrompt, setWikiPrompt] = useState<string>('');
+  // Wiki 执行超时（秒）：与后端 DEFAULT_WIKI_TIMEOUT_SECS=300 一致，清空时回退默认
+  const [wikiTimeoutSecs, setWikiTimeoutSecs] = useState<number | null>(300);
   const [activeTab, setActiveTab] = useState<'debounce' | 'prompt'>('debounce');
   // 移动端目录 Drawer 开关状态
   const [menuDrawerOpen, setMenuDrawerOpen] = useState(false);
@@ -317,10 +321,12 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
       setDebounceSecs(configData.blackboard_debounce_secs ?? 600);
       setDebounceCount(configData.blackboard_debounce_count ?? 10);
       setWikiPrompt(configData.wiki_prompt ?? '');
+      setWikiTimeoutSecs(configData.wiki_timeout_secs ?? 300);
     } else {
       setDebounceSecs(600);
       setDebounceCount(10);
       setWikiPrompt('');
+      setWikiTimeoutSecs(300);
     }
     setActiveTab('debounce');
     setSettingsOpen(true);
@@ -335,6 +341,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
         blackboard_debounce_secs: debounceSecs ?? 600,
         blackboard_debounce_count: debounceCount ?? 10,
         wiki_prompt: wikiPrompt,
+        wiki_timeout_secs: wikiTimeoutSecs ?? 300,
       });
       // 保存成功后同步更新 data，避免下次打开弹窗读到旧值
       if (configData) {
@@ -343,6 +350,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
           blackboard_debounce_secs: debounceSecs ?? 600,
           blackboard_debounce_count: debounceCount ?? 10,
           wiki_prompt: wikiPrompt,
+          wiki_timeout_secs: wikiTimeoutSecs ?? 300,
         });
       }
       message.success('设置已保存');
@@ -352,7 +360,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
     } finally {
       setSettingsSaving(false);
     }
-  }, [workspaceId, debounceSecs, debounceCount, wikiPrompt, configData]);
+  }, [workspaceId, debounceSecs, debounceCount, wikiPrompt, wikiTimeoutSecs, configData]);
 
   // 恢复默认提示词：把 wikiPrompt 设为内置默认值。
   // 区别于"留空"的语义——留空表示后端使用内置默认；填入默认值表示用户显式采用内置模板。
@@ -532,6 +540,8 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
                   setDebounceSecs={setDebounceSecs}
                   debounceCount={debounceCount}
                   setDebounceCount={setDebounceCount}
+                  wikiTimeoutSecs={wikiTimeoutSecs}
+                  setWikiTimeoutSecs={setWikiTimeoutSecs}
                 />
               ),
             },
@@ -560,10 +570,13 @@ interface DebounceSettingsTabProps {
   setDebounceSecs: (v: number | null) => void;
   debounceCount: number | null;
   setDebounceCount: (v: number | null) => void;
+  /** Wiki 执行超时（秒） */
+  wikiTimeoutSecs: number | null;
+  setWikiTimeoutSecs: (v: number | null) => void;
 }
 
-/** 防抖设置 Tab：防抖周期 + 触发条数，受父组件状态控制 */
-function DebounceSettingsTab({ debounceSecs, setDebounceSecs, debounceCount, setDebounceCount }: DebounceSettingsTabProps) {
+/** 防抖设置 Tab：防抖周期 + 触发条数 + Wiki 执行超时，受父组件状态控制 */
+function DebounceSettingsTab({ debounceSecs, setDebounceSecs, debounceCount, setDebounceCount, wikiTimeoutSecs, setWikiTimeoutSecs }: DebounceSettingsTabProps) {
   return (
     <Form layout="vertical" style={{ marginTop: 16 }}>
       <Form.Item label="防抖周期">
@@ -585,6 +598,21 @@ function DebounceSettingsTab({ debounceSecs, setDebounceSecs, debounceCount, set
           min={1}
           max={100}
           addonAfter="条"
+          style={{ width: 200 }}
+        />
+      </Form.Item>
+      <Form.Item
+        label="Wiki 执行超时"
+        // 后端会把输入值钳制到 [60, 3600]，这里同步展示边界提示；
+        // 默认 300 秒（5 分钟），慢模型可调大避免被强制超时
+        extra="Wiki 自动维护与 Wiki 对话的最长执行时长（后端会自动钳制到 60–3600 秒），默认 300 秒"
+      >
+        <InputNumber
+          value={wikiTimeoutSecs}
+          onChange={(v) => setWikiTimeoutSecs(v)}
+          min={60}
+          max={3600}
+          addonAfter="秒"
           style={{ width: 200 }}
         />
       </Form.Item>

--- a/frontend/src/utils/database/blackboard.ts
+++ b/frontend/src/utils/database/blackboard.ts
@@ -9,6 +9,8 @@ export interface BlackboardResponse {
   wiki_prompt: string;
   /** Wiki 对话使用的执行器名称，null/undefined 表示使用默认值 claudecode */
   wiki_chat_executor?: string | null;
+  /** Wiki 执行超时（秒），控制 Wiki 任务与 Wiki 对话的最长存活时间 */
+  wiki_timeout_secs: number;
 }
 
 /** GET /api/workspaces/{workspaceId}/blackboard：获取黑板数据（含 pending_record_ids） */
@@ -26,6 +28,8 @@ export async function updateBlackboardConfig(
     wiki_prompt?: string;
     /** Wiki 对话执行器，空字符串表示清空回退到默认值 */
     wiki_chat_executor?: string;
+    /** Wiki 执行超时（秒），后端会钳制到 [60, 3600] 区间 */
+    wiki_timeout_secs?: number;
   },
 ): Promise<void> {
   await api.patch(`/api/workspaces/${workspaceId}/blackboard`, config);
@@ -68,20 +72,45 @@ export async function deleteWikiFile(workspaceId: number, slug: string): Promise
  * 非流式：等待执行器完成后一次性返回结果。
  * 不创建 Todo、不持久化对话历史。
  *
- * 超时单独设为 5 分钟：执行器（如 claude code）可能需要较长时间完成，
- * 远超 axios 默认的 15 秒。
+ * HTTP 超时随 per-workspace 的 wiki_timeout_secs 动态调整（后端会钳制到 [60,3600]），
+ * 并额外加 10 秒缓冲，避免 HTTP 请求在执行器即将完成时先于后端超时失败。
+ * 取不到配置时回退到 5 分钟（与历史行为一致）。
  */
 export async function chatWithWiki(
   workspaceId: number,
   message: string,
   executor?: string,
 ): Promise<WikiChatResponse> {
+  // 读取 per-workspace 超时配置，推算 HTTP 超时；失败回退默认 300 秒
+  const timeoutMs = await resolveWikiChatHttpTimeoutMs(workspaceId);
   return unwrap(
     await api.post(`/api/workspaces/${workspaceId}/wiki/chat`, {
       message,
       executor,
     }, {
-      timeout: 300000,
+      timeout: timeoutMs,
     }),
   );
+}
+
+/** 默认 Wiki 执行超时（秒），与后端 DEFAULT_WIKI_TIMEOUT_SECS 保持一致。 */
+const DEFAULT_WIKI_TIMEOUT_SECS = 300;
+/** HTTP 超时相对后端执行超时的额外缓冲（毫秒），给后端收尾 + 网络往返留余量。 */
+const WIKI_CHAT_HTTP_BUFFER_MS = 10_000;
+
+/**
+ * 推算 Wiki 对话 HTTP 请求超时（毫秒）。
+ *
+ * 取黑板配置中的 wiki_timeout_secs（后端已钳制到 [60,3600]），换算成毫秒后加缓冲；
+ * 配置缺失/请求失败时回退默认值，保证可用性优先于精确性。
+ */
+async function resolveWikiChatHttpTimeoutMs(workspaceId: number): Promise<number> {
+  try {
+    const board = await getBlackboard(workspaceId);
+    const secs = board.wiki_timeout_secs ?? DEFAULT_WIKI_TIMEOUT_SECS;
+    return secs * 1000 + WIKI_CHAT_HTTP_BUFFER_MS;
+  } catch {
+    // 配置读取失败不阻断对话：回退默认超时，让用户至少能正常用
+    return DEFAULT_WIKI_TIMEOUT_SECS * 1000 + WIKI_CHAT_HTTP_BUFFER_MS;
+  }
 }

--- a/frontend/tests/check_blackboard_settings.spec.ts
+++ b/frontend/tests/check_blackboard_settings.spec.ts
@@ -3,14 +3,15 @@
  * 1. 直接导航到黑板页面
  * 2. 点击设置按钮能打开弹窗
  * 3. 防抖周期和触发条数 InputNumber 正常显示和修改
- * 4. 切换到提示词设置 Tab，验证 TextArea 和恢复默认按钮
- * 5. 保存后弹窗关闭并提示成功
+ * 4. Wiki 执行超时 InputNumber 正常显示和修改（per-workspace 可配）
+ * 5. 切换到提示词设置 Tab，验证 TextArea 和恢复默认按钮
+ * 6. 保存后弹窗关闭并提示成功
  */
 import { test, expect } from '@playwright/test';
 
 test('黑板设置弹窗能正常打开和保存', async ({ page }) => {
-  // 直接导航到黑板页面
-  await page.goto('http://localhost:18088/?view=blackboard&workspace=1');
+  // 直接导航到黑板页面（hash 路由：#/blackboard?workspace=1）
+  await page.goto('http://localhost:18088/#/blackboard?workspace=1');
   // 等待 app 渲染完成
   await page.waitForSelector('#root > *', { timeout: 15000 });
 
@@ -30,6 +31,14 @@ test('黑板设置弹窗能正常打开和保存', async ({ page }) => {
   // 修改防抖时间为 300
   await input.fill('300');
   await input.blur();
+
+  // Wiki 执行超时输入框应在防抖设置 Tab 中可见（防抖周期 / 触发条数 / Wiki 执行超时）
+  // 验证第三个 InputNumber 存在且可修改，确认超时设置已上界面
+  const timeoutInput = page.locator('.ant-input-number-input').nth(2);
+  await expect(timeoutInput).toBeVisible();
+  await timeoutInput.fill('600');
+  await timeoutInput.blur();
+  await expect(timeoutInput).toHaveValue('600');
 
   // 切换到提示词设置 Tab
   await page.click('.ant-tabs-tab:has-text("提示词设置")');

--- a/frontend/tests/check_wiki_timeout_setting.spec.ts
+++ b/frontend/tests/check_wiki_timeout_setting.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Wiki 执行超时设置验证：
+ *
+ * 背景：blackboard.rs 的 wait_for_finished / spawn_executor_for_chat_streaming
+ * 原本把超时写死成 300 秒，用户无法调整。现已把超时做成 per-workspace
+ * 可配置项（wiki_timeout_secs），暴露在黑板设置弹窗的「防抖设置」Tab 中。
+ *
+ * 本脚本验证：
+ * 1. 打开黑板设置弹窗，能在「防抖设置」Tab 看到「Wiki 执行超时」输入框
+ * 2. 输入框可修改（填入 600）
+ * 3. 保存后弹窗关闭，提示「设置已保存」
+ * 4. 重新打开弹窗，输入框回显刚才保存的 600（配置已持久化）
+ * 5. 恢复默认 300 并保存，避免污染后续测试
+ */
+import { test, expect } from '@playwright/test';
+
+/** 防抖设置 Tab 中「Wiki 执行超时」对应的 InputNumber 在 DOM 中的序号。
+ * 防抖设置 Tab 自上而下依次为：防抖周期(0) / 触发条数(1) / Wiki 执行超时(2)。 */
+const WIKI_TIMEOUT_INPUT_INDEX = 2;
+
+test('Wiki 执行超时可在黑板设置界面配置并持久化', async ({ page }) => {
+  // 用 hash 路由直接进入黑板页面（与 useViewState 的 hash 路由对齐）
+  await page.goto('http://localhost:18088/#/blackboard?workspace=1');
+  await page.waitForSelector('#root > *', { timeout: 15000 });
+  await page.waitForSelector('button[title="设置"]', { timeout: 10000 });
+
+  // 打开设置弹窗
+  await page.click('button[title="设置"]');
+  await expect(page.locator('.ant-modal')).toBeVisible({ timeout: 5000 });
+
+  // 第三个 InputNumber 即「Wiki 执行超时」，验证它已上界面
+  const timeoutInput = page.locator('.ant-input-number-input').nth(WIKI_TIMEOUT_INPUT_INDEX);
+  await expect(timeoutInput).toBeVisible();
+
+  // 修改为 600 秒并保存
+  await timeoutInput.fill('600');
+  await timeoutInput.blur();
+  await expect(timeoutInput).toHaveValue('600');
+
+  // 点击保存
+  await page.locator('.ant-modal-footer .ant-btn-primary').first().click();
+  await expect(page.locator('.ant-message')).toContainText('设置已保存', { timeout: 5000 });
+  await expect(page.locator('.ant-modal')).not.toBeVisible({ timeout: 5000 });
+
+  // 重新打开弹窗，验证配置已持久化（回显 600）
+  await page.click('button[title="设置"]');
+  await expect(page.locator('.ant-modal')).toBeVisible({ timeout: 5000 });
+  const timeoutInputReopen = page.locator('.ant-input-number-input').nth(WIKI_TIMEOUT_INPUT_INDEX);
+  await expect(timeoutInputReopen).toHaveValue('600');
+
+  // 恢复默认 300 并保存，避免污染其他测试用例
+  await timeoutInputReopen.fill('300');
+  await timeoutInputReopen.blur();
+  await page.locator('.ant-modal-footer .ant-btn-primary').first().click();
+  await expect(page.locator('.ant-message')).toContainText('设置已保存', { timeout: 5000 });
+});


### PR DESCRIPTION
## 背景

黑板的 Wiki 自动维护与 Wiki 对话此前把执行超时**写死成 300 秒（5 分钟）**，用户无法调整。当 Wiki 维护任务因模型慢、上下文大而超过 5 分钟，就会被强制超时失败：

\`\`\`
WARN ntd::services::blackboard: Wiki 执行超时: workspace_id=3, task_id=..., timeout_secs=300
WARN ntd::executor_service::completion: 黑板 update_blackboard_wiki 失败: ... error=Internal("Wiki 执行超时（5 分钟），task_id=...")
\`\`\`

本 PR 把这个值做到**黑板的设置界面**，做成 per-workspace 可配置项。

## 改动

### 后端
- **数据库迁移 V57**：`blackboards` 表新增 `wiki_timeout_secs` 列（`INTEGER NOT NULL DEFAULT 300`），幂等追加，旧行回填 300，迁移后行为零变化。同时把列加入 V47 的 CREATE TABLE DDL，新装 DB 开箱即有。
- **DB 层**：`BlackboardConfig` 新增 `wiki_timeout_secs`；`get/update_blackboard_config` 贯通该字段；`create_blackboard` / `upsert_blackboard_content` 写默认 300；新增 `clamp_wiki_timeout` 把输入钳制到 `[60, 3600]`。
- **Handler**：`BlackboardResponse` / `UpdateBlackboardConfigRequest` 新增 `wiki_timeout_secs`。
- **服务层**（关键）：
  - `wait_for_finished`（`update_blackboard_wiki` 调用）：超时改用配置值，不再写死 `5 * 60`。
  - `spawn_executor_for_chat_streaming`（Wiki 对话）：超时由调用方传入，移除写死的 `EXEC_TIMEOUT_SECS = 300`。
  - 新增 `resolve_wiki_timeout_secs` helper：读 per-workspace 配置，DB 读失败/记录缺失回退默认 5 分钟，保证可用性。

### 前端
- `utils/database/blackboard.ts`：`BlackboardResponse` 与 `updateBlackboardConfig` 贯通 `wiki_timeout_secs`；`chatWithWiki` 的 HTTP 超时随配置动态调整（配置秒数 ×1000 + 10s 缓冲），避免 HTTP 请求先于执行器超时。
- `BlackboardPage.tsx`：设置弹窗「防抖设置」Tab 新增「Wiki 执行超时」`InputNumber`（min 60 / max 3600，后端会钳制），默认 300。

### 测试
- 后端：V57 迁移幂等性 + 旧行回填测试；`update_blackboard_config` 超时钳制测试；`create_blackboard` 默认值断言。
- 前端：新增 `check_wiki_timeout_setting.spec.ts`（配置可改、保存、重新打开回显、恢复默认）；修正 `check_blackboard_settings.spec.ts` 的路由 URL（hash 路由）并补超时字段断言。

## 验证

- 后端 \`cargo clippy --all-targets -- -D warnings\` ✅ 零告警
- 后端 \`cargo test --lib\` ✅ 1049 passed
- 后端迁移测试 ✅ 全部通过（含 V57）
- 前端 \`npx tsc --noEmit\` ✅ 零错误
- 前端 \`npm run build\` ✅
- Playwright \`check_blackboard_settings\` + \`check_wiki_timeout_setting\` ✅
- API 手动验证：GET 返回 \`wiki_timeout_secs: 300\`；PATCH \`{"wiki_timeout_secs":600}\` 持久化成功；钳制验证 0→60、999999→3600 ✅

## 截图证据

Playwright 验证通过（设置可改、保存、重新打开回显 600、恢复 300）。截图请见下方评论。