### PR TITLE
docs: 品牌名 'Nothing Todo' → 'Now Task Done'

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -432,9 +432,9 @@ ntd [全局选项] <子命令>
 
 | 平台 | 架构 | 分发包 |
 |------|------|--------|
-| Linux | x86_64 / ARM64 | `nothing-todo-linux-x64.tar.gz` / `...-arm64.tar.gz` |
-| macOS | ARM64 (Apple Silicon) | `nothing-todo-darwin-arm64.tar.gz` |
-| Windows | x86_64 | `nothing-todo-windows-x64.zip` |
+| Linux | x86_64 / ARM64 | `ntd-linux-x64.tar.gz` / `...-arm64.tar.gz` |
+| macOS | ARM64 (Apple Silicon) | `ntd-darwin-arm64.tar.gz` |
+| Windows | x86_64 | `ntd-windows-x64.zip` |
 | npm | 跨平台 | `@weibaohui/ntd` |
 | Cargo | 跨平台 | `crates.io` (源码) |
 

--- a/docs/NPM_PUBLIST.md
+++ b/docs/NPM_PUBLIST.md
@@ -1,4 +1,4 @@
-# NothingTodo npm 发布系统
+# ntd npm 发布系统
 
 ## 架构概述
 
@@ -13,19 +13,19 @@
 
 ```
 packages/
-├── nothing-todo/                    # 主包（wrapper）
+├── ntd/                             # 主包（wrapper）
 │   ├── install.js                  # 跨平台安装脚本
 │   └── package.json
-├── nothing-todo-linux-x64/         # Linux x86_64 平台包
+├── ntd-linux-x64/                   # Linux x86_64 平台包
 │   ├── bin/ntd                     # 二进制
 │   └── package.json
-├── nothing-todo-linux-arm64/       # Linux ARM64 平台包
+├── ntd-linux-arm64/                 # Linux ARM64 平台包
 │   ├── bin/ntd
 │   └── package.json
-├── nothing-todo-darwin-arm64/      # macOS ARM64 平台包
+├── ntd-darwin-arm64/                # macOS ARM64 平台包
 │   ├── bin/ntd
 │   └── package.json
-└── nothing-todo-windows-x64/       # Windows x86_64 平台包
+└── ntd-windows-x64/                 # Windows x86_64 平台包
     ├── bin/ntd.exe
     └── package.json
 ```
@@ -66,16 +66,16 @@ make cross-build
 
 ```bash
 # Linux x64
-cp backend/target/cross/ntd-x86_64-unknown-linux-gnu packages/nothing-todo-linux-x64/bin/ntd
+cp backend/target/cross/ntd-x86_64-unknown-linux-gnu packages/ntd-linux-x64/bin/ntd
 
 # Linux arm64
-cp backend/target/cross/ntd-aarch64-unknown-linux-gnu packages/nothing-todo-linux-arm64/bin/ntd
+cp backend/target/cross/ntd-aarch64-unknown-linux-gnu packages/ntd-linux-arm64/bin/ntd
 
 # macOS arm64
-cp backend/target/cross/ntd-aarch64-apple-darwin packages/nothing-todo-darwin-arm64/bin/ntd
+cp backend/target/cross/ntd-aarch64-apple-darwin packages/ntd-darwin-arm64/bin/ntd
 
 # Windows x64
-cp backend/target/cross/ntd-x86_64-pc-windows-gnu.exe packages/nothing-todo-windows-x64/bin/ntd.exe
+cp backend/target/cross/ntd-x86_64-pc-windows-gnu.exe packages/ntd-windows-x64/bin/ntd.exe
 ```
 
 > **另**：i686（32 位 Windows）二进制当前未打包。`PLATFORMS` 数组仅含 4 个目标（linux x64/arm64、darwin arm64、windows x64）。
@@ -128,13 +128,13 @@ for pkg in packages/*/package.json; do
 done
 
 # 2. 发布平台包（注意：实际只发布 4 个，无 darwin-x64）
-cd packages/nothing-todo-linux-x64 && npm publish --access public && cd -
-cd packages/nothing-todo-linux-arm64 && npm publish --access public && cd -
-cd packages/nothing-todo-darwin-arm64 && npm publish --access public && cd -
-cd packages/nothing-todo-windows-x64 && npm publish --access public && cd -
+cd packages/ntd-linux-x64 && npm publish --access public && cd -
+cd packages/ntd-linux-arm64 && npm publish --access public && cd -
+cd packages/ntd-darwin-arm64 && npm publish --access public && cd -
+cd packages/ntd-windows-x64 && npm publish --access public && cd -
 
 # 3. 发布主包
-cd packages/nothing-todo && npm publish --access public && cd -
+cd packages/ntd && npm publish --access public && cd -
 ```
 
 ### 步骤 8: 验证发布

--- a/ntd-skills/ntd-usage/SKILL.md
+++ b/ntd-skills/ntd-usage/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: ntd-usage
-description: ntd (Nothing Todo) 使用教练 — 教 AI 如何引导用户用 ntd 管理系统化地让 AI 执行任务
+description: ntd (Now Task Done) 使用教练 — 教 AI 如何引导用户用 ntd 管理系统化地让 AI 执行任务
 version: 2.0.0
 executors: [claudecode, atomcode, mobilecoder, hermes, codex, codebuddy, opencode, kimi, pi, agents]
 ---
 
-# ntd (Nothing Todo) 使用教练
+# ntd (Now Task Done) 使用教练
 
 ## 🎯 你是谁
 
-你是 ntd (Nothing Todo) 使用教练。你的目标是**帮助用户通过 ntd 管理系统化地让 AI 执行任务**，而不是你自己直接写代码或跑命令。
+你是 ntd (Now Task Done) 使用教练。你的目标是**帮助用户通过 ntd 管理系统化地让 AI 执行任务**，而不是你自己直接写代码或跑命令。
 
 **核心原则：**
 1. **识别任务意图** — 判断用户说的是知识问答（直接回答）还是可管理的任务（用 ntd）

--- a/script/npm_publish.sh
+++ b/script/npm_publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# NothingTodo npm 发布脚本
+# ntd npm 发布脚本
 # 用法: ./npm_publish.sh v0.1.2
 #
 # 需要先执行交叉编译: make cross-build
@@ -42,7 +42,7 @@ fi
 VERSION=${VERSION_TAG#v}
 
 info "========================================"
-info "开始发布 NothingTodo"
+info "开始发布 ntd"
 info "版本号: $VERSION_TAG (npm: $VERSION)"
 info "========================================"
 echo ""
@@ -56,10 +56,10 @@ info "步骤 1/7: 检查交叉编译产物..."
 CROSS_DIR="$PROJECT_ROOT/backend/target/cross"
 
 PLATFORMS=(
-    "nothing-todo-linux-x64:linux-x64:linux:x64:ntd-x86_64-unknown-linux-gnu"
-    "nothing-todo-linux-arm64:linux-arm64:linux:arm64:ntd-aarch64-unknown-linux-gnu"
-    "nothing-todo-darwin-arm64:darwin-arm64:darwin:arm64:ntd-aarch64-apple-darwin"
-    "nothing-todo-windows-x64:windows-x64:win32:x64:ntd-x86_64-pc-windows-gnu.exe"
+    "ntd-linux-x64:linux-x64:linux:x64:ntd-x86_64-unknown-linux-gnu"
+    "ntd-linux-arm64:linux-arm64:linux:arm64:ntd-aarch64-unknown-linux-gnu"
+    "ntd-darwin-arm64:darwin-arm64:darwin:arm64:ntd-aarch64-apple-darwin"
+    "ntd-windows-x64:windows-x64:win32:x64:ntd-x86_64-pc-windows-gnu.exe"
 )
 
 # 检查是否需要构建
@@ -120,8 +120,8 @@ for entry in "${PLATFORMS[@]}"; do
 done
 
 # 同步主包
-node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('$PROJECT_ROOT/packages/nothing-todo/package.json','utf8')); p.version='$VERSION'; fs.writeFileSync('$PROJECT_ROOT/packages/nothing-todo/package.json', JSON.stringify(p, null, 2)+'\n');"
-success "  nothing-todo (wrapper): $VERSION"
+node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('$PROJECT_ROOT/packages/ntd/package.json','utf8')); p.version='$VERSION'; fs.writeFileSync('$PROJECT_ROOT/packages/ntd/package.json', JSON.stringify(p, null, 2)+'\n');"
+success "  ntd (wrapper): $VERSION"
 echo ""
 
 # 步骤 5: 提交版本更新
@@ -158,7 +158,7 @@ for entry in "${PLATFORMS[@]}"; do
 done
 
 # 发布主包（wrapper）
-publish_pkg "$PROJECT_ROOT/packages/nothing-todo"
+publish_pkg "$PROJECT_ROOT/packages/ntd"
 
 echo ""
 success "========================================"


### PR DESCRIPTION
将项目中所有 'Nothing Todo' / 'NothingTodo' / 'nothing-todo' 品牌名引用更新为新的品牌名。

## 修改清单

| 文件 | 改动 |
|------|------|
| `ntd-skills/ntd-usage/SKILL.md` | `Nothing Todo` → `Now Task Done`（3处） |
| `docs/NPM_PUBLIST.md` | 标题/目录/路径中的 `nothing-todo-*` → `ntd-*`（15处） |
| `script/npm_publish.sh` | 注释/PLATFORMS/路径中的 `nothing-todo` → `ntd`（9处） |
| `docs/FEATURES.md` | 分发包名 `nothing-todo-*` → `ntd-*`（3处） |

**修复：** `npm_publish.sh` 中的 PLATFORMS 数组原写为 `nothing-todo-linux-x64` 等，但实际磁盘目录是 `ntd-linux-x64` —— 脚本原本路径错误，现已对齐真实目录结构。