### PR TITLE
feat: 导入导出交互统一 + 逐条配工作空间

### DIFF
--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -36,7 +36,7 @@ use crate::models::{
     LoopExportData, TagExportItem, ReviewTemplateExportItem, TodoExportItem,
     LoopExportItem, LoopTriggerExportItem, LoopStepExportItem,
     generate_pseudo_id, validate_pseudo_id,
-    LoopImportPreviewResponse, LoopImportSummary, LoopImportWarning,
+    LoopImportPreviewResponse, LoopImportPreviewLoop, LoopImportSummary, LoopImportWarning,
     LoopImportResponse, LoopImportCreatedCounts,
 };
 use crate::db::ReviewTemplateInput;
@@ -905,9 +905,219 @@ pub async fn export_selected_loops(
     ))
 }
 
+/// GET /api/loops/export — 导出全库所有环路为单个 YAML，对齐 Todo `GET /api/backup/export`。
+pub async fn export_all_loops(
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, AppError> {
+    // list_loops_with_counts(None) 不按工作空间过滤，取全库 loop
+    let loops = state.db.list_loops_with_counts(None).await?;
+    let ids: Vec<i64> = loops.into_iter().map(|l| l.loop_.id).collect();
+    if ids.is_empty() {
+        return Err(AppError::BadRequest("当前没有任何环路可导出".to_string()));
+    }
+    let yaml = build_loop_export_yaml(&state, &ids).await?;
+    let filename = format!("loops-export-{}.loop.yaml",
+        chrono::Utc::now().format("%Y%m%d-%H%M%S"));
+    let disposition = format!("attachment; filename=\"{}\"", filename);
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/x-yaml; charset=utf-8".to_string()),
+            (header::CONTENT_DISPOSITION, disposition),
+        ],
+        yaml,
+    ))
+}
+
+// ====== 导入工作空间逐 loop 解析 helpers ======
+// 镜像 db/todo.rs 的 merge_backup 解析模式：override > 全局 > 导出 id（重新解析）> 哨兵 0。
+// loop 导入 handler 不在事务内执行，无法复用 db/todo.rs 的事务版 resolve_workspace_pair，
+// 这里走非事务连接（state.db.get_project_directory_by_id）。
+
+/// 单条 loop 解析后的工作空间归属（id + path）；ws_id == 0 表示未匹配（哨兵）。
+struct LoopResolved {
+    name: String,
+    ws_id: i64,
+    ws_path: Option<String>,
+}
+
+/// 按 id 在当前库解析工作空间 (id, path, name)；None = id 不存在或入参为 None。
+async fn resolve_loop_workspace(
+    db: &crate::db::Database,
+    id: Option<i64>,
+) -> Result<Option<(i64, String, Option<String>)>, AppError> {
+    // 入参 None：备份里就没有工作空间信息，直接返回 None
+    let Some(id) = id else { return Ok(None) };
+    let dir = db.get_project_directory_by_id(id).await
+        .map_err(|e| AppError::Internal(format!("lookup workspace {}: {}", id, e)))?;
+    Ok(dir.map(|d| (d.id, d.path, d.name)))
+}
+
+/// 解析单条 loop 的 (id, path)，优先级：override > 全局 > 导出 id > 哨兵 0。
+/// path 与 id 成对写出，避免「id 指向 B、cwd 仍是备份源路径」的错配。
+async fn resolve_loop_ws_pair(
+    db: &crate::db::Database,
+    loop_export: &LoopExportItem,
+    global_ws: Option<&(i64, String)>,
+    override_id: Option<i64>,
+) -> Result<(i64, Option<String>), AppError> {
+    // 1) 用户 per-loop 覆盖优先
+    if let Some((id, path, _)) = resolve_loop_workspace(db, override_id).await? {
+        return Ok((id, Some(path)));
+    }
+    // 2) 全局覆盖（向后兼容，req.workspace_id）
+    if let Some((id, path)) = global_ws {
+        return Ok((*id, Some(path.clone())));
+    }
+    // 3) 导出文件里的 workspace_id 重新解析（跨环境更可靠）
+    if let Some((id, path, _)) = resolve_loop_workspace(db, loop_export.workspace_id).await? {
+        return Ok((id, Some(path)));
+    }
+    // 4) 悬空 → 哨兵 0（workspace_id 列 NOT NULL DEFAULT 0，0=未分配）
+    Ok((0, None))
+}
+
+/// 解析所有 loop 的工作空间，返回每条 (name, id, path)，供 todo 映射与 loop 创建复用。
+async fn resolve_all_loops(
+    db: &crate::db::Database,
+    data: &LoopExportData,
+    global_ws: Option<&(i64, String)>,
+    overrides: &std::collections::HashMap<String, i64>,
+) -> Result<Vec<LoopResolved>, AppError> {
+    let mut out = Vec::with_capacity(data.loops.len());
+    for l in &data.loops {
+        let ov = overrides.get(&l.name).copied();
+        let (id, path) = resolve_loop_ws_pair(db, l, global_ws, ov).await?;
+        out.push(LoopResolved { name: l.name.clone(), ws_id: id, ws_path: path });
+    }
+    Ok(out)
+}
+
+/// gate：任一 loop 解析为 0（未匹配）→ 报错列出未匹配 loop 名，阻止导入。
+fn gate_unmatched_loops(resolved: &[LoopResolved]) -> Result<(), AppError> {
+    let unmatched: Vec<&str> = resolved.iter()
+        .filter(|r| r.ws_id == 0)
+        .map(|r| r.name.as_str())
+        .collect();
+    if unmatched.is_empty() {
+        Ok(())
+    } else {
+        Err(AppError::BadRequest(format!(
+            "以下环路未匹配工作空间，请逐个指定: {}", unmatched.join(", ")
+        )))
+    }
+}
+
+/// data.todos 的 pseudo id → title 映射，供共享 todo warning 用。
+fn todo_title_map(data: &LoopExportData) -> std::collections::HashMap<String, String> {
+    data.todos.iter().map(|t| (t.id.clone(), t.title.clone())).collect()
+}
+
+/// todo→工作空间归属的累积器：记录每条 todo 首次归属的 loop，并对跨 loop 共享打 warning。
+struct TodoWsAccumulator {
+    todo_ws: std::collections::HashMap<String, (i64, Option<String>)>,
+    first_loop: std::collections::HashMap<String, String>,
+    warned: std::collections::HashSet<String>,
+}
+
+impl TodoWsAccumulator {
+    fn new() -> Self {
+        Self {
+            todo_ws: std::collections::HashMap::new(),
+            first_loop: std::collections::HashMap::new(),
+            warned: std::collections::HashSet::new(),
+        }
+    }
+
+    /// 记录一条 todo 的归属；返回 true 表示它已被更早的 loop 引用（跨 loop 共享）。
+    fn record(&mut self, todo_id: &str, loop_name: &str, pair: (i64, Option<String>)) -> bool {
+        use std::collections::hash_map::Entry;
+        match self.todo_ws.entry(todo_id.to_string()) {
+            // 空缺：首次归属，记下首个 loop 名
+            Entry::Vacant(e) => {
+                e.insert(pair);
+                self.first_loop.insert(todo_id.to_string(), loop_name.to_string());
+                false
+            }
+            // 已被更早 loop 归属 → 共享，不覆盖原归属
+            Entry::Occupied(_) => true,
+        }
+    }
+
+    /// 对跨 loop 共享的 todo 打一次 warning（同一条 todo 只打一次）。
+    fn warn_shared(
+        &mut self,
+        warnings: &mut Vec<LoopImportWarning>,
+        titles: &std::collections::HashMap<String, String>,
+        todo_id: &str,
+        fallback_title: &str,
+    ) {
+        // warned 只记一次，避免同一共享 todo 被多个后续 loop 重复 warning
+        if self.warned.insert(todo_id.to_string()) {
+            let title = titles.get(todo_id).map(String::as_str).unwrap_or(fallback_title);
+            let first = self.first_loop.get(todo_id).cloned().unwrap_or_default();
+            warnings.push(LoopImportWarning {
+                warning_type: "shared_todo_workspace".to_string(),
+                message: format!("Todo「{}」被多个环路引用，归到首个环路「{}」的工作空间", title, first),
+            });
+        }
+    }
+}
+
+/// 为每条 todo pseudo 决定工作空间 (id, path)：取首个引用它的 loop 的工作空间。
+fn build_todo_workspace_map(
+    data: &LoopExportData,
+    resolved_loops: &[LoopResolved],
+    warnings: &mut Vec<LoopImportWarning>,
+) -> std::collections::HashMap<String, (i64, Option<String>)> {
+    let mut acc = TodoWsAccumulator::new();
+    let titles = todo_title_map(data);
+    for (i, l) in data.loops.iter().enumerate() {
+        // pair 取自该 loop 的解析结果；step-todo 与 abnormal-handler 都跟随所属 loop
+        let pair = (resolved_loops[i].ws_id, resolved_loops[i].ws_path.clone());
+        for step in &l.steps {
+            if acc.record(&step.todo_id, &l.name, pair.clone()) {
+                acc.warn_shared(warnings, &titles, &step.todo_id, &step.todo_title);
+            }
+        }
+        if let Some(hid) = &l.abnormal_handler_todo_id {
+            let title = l.abnormal_handler_todo_title.as_deref().unwrap_or("");
+            if acc.record(hid, &l.name, pair.clone()) {
+                acc.warn_shared(warnings, &titles, hid, title);
+            }
+        }
+    }
+    acc.todo_ws
+}
+
+/// 预览：按导出原 id 解析每条 loop 的默认匹配情况（不接收用户 override）。
+async fn build_preview_loops(
+    db: &crate::db::Database,
+    data: &LoopExportData,
+) -> Result<Vec<LoopImportPreviewLoop>, AppError> {
+    let mut out = Vec::with_capacity(data.loops.len());
+    for l in &data.loops {
+        let resolved = resolve_loop_workspace(db, l.workspace_id).await?;
+        // 先取 matched 再 match 消费 resolved，避免部分移动后无法 is_some()
+        let source_matched = resolved.is_some();
+        let (rid, rname) = match resolved {
+            Some((id, _, name)) => (id, name),
+            None => (0, None),
+        };
+        out.push(LoopImportPreviewLoop {
+            name: l.name.clone(),
+            workspace_id: l.workspace_id,
+            workspace_path: l.workspace_path.clone(),
+            resolved_workspace_id: rid,
+            resolved_workspace_name: rname,
+            source_matched,
+        });
+    }
+    Ok(out)
+}
+
 /// POST /api/loops/import/preview — 预览导入数据
 pub async fn import_preview(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     body: Bytes,
 ) -> Result<impl IntoResponse, AppError> {
     let yaml_str = String::from_utf8(body.to_vec())
@@ -1071,12 +1281,15 @@ pub async fn import_preview(
         }
     }
 
+    let loops = build_preview_loops(state.db.as_ref(), &data).await?;
+
     let response = LoopImportPreviewResponse {
         valid,
         pseudo_ids,
         summary,
         conflicts: vec![],  // 新建模式无冲突
         warnings,
+        loops,
     };
 
     Ok(ApiResponse::ok(response))
@@ -1086,7 +1299,12 @@ pub async fn import_preview(
 #[derive(Deserialize)]
 pub struct ImportLoopRequest {
     pub yaml: String,
-    pub workspace_id: i64,
+    /// 全局目标工作空间（向后兼容）；None 时按 per-loop 解析。
+    #[serde(default)]
+    pub workspace_id: Option<i64>,
+    /// per-loop 覆盖：loop name → workspace_id（前端逐条选择）。
+    #[serde(default)]
+    pub workspace_overrides: Option<std::collections::HashMap<String, i64>>,
 }
 
 pub async fn import_loops(
@@ -1102,12 +1320,27 @@ pub async fn import_loops(
         return Err(AppError::BadRequest("No loops in export file".to_string()));
     }
 
-    // 获取目标工作空间
-    let workspace_id = req.workspace_id;
+    // 全局目标工作空间（可选，向后兼容）；None 时按 per-loop 解析
+    let global_ws: Option<(i64, String)> = match req.workspace_id {
+        Some(id) => {
+            let dir = state.db.get_project_directory_by_id(id).await?
+                .ok_or_else(|| AppError::BadRequest(format!("Workspace {} not found", id)))?;
+            Some((dir.id, dir.path))
+        }
+        None => None,
+    };
+    let overrides = req.workspace_overrides.unwrap_or_default();
 
-    // 验证工作空间存在
-    let workspace = state.db.get_project_directory_by_id(workspace_id).await?
-        .ok_or_else(|| AppError::BadRequest(format!("Workspace {} not found", workspace_id)))?;
+    // 逐 loop 解析工作空间，gate 未匹配；建 todo→ws 映射（共享 todo 取首 loop ws）
+    let resolved_loops = resolve_all_loops(state.db.as_ref(), &data, global_ws.as_ref(), &overrides).await?;
+    gate_unmatched_loops(&resolved_loops)?;
+    let mut warnings: Vec<LoopImportWarning> = Vec::new();
+    let todo_ws = build_todo_workspace_map(&data, &resolved_loops, &mut warnings);
+
+    // 评审模板按 name 匹配、跨 loop 复用，统一归到首个 loop 的工作空间（有意简化）
+    let template_ws_id = global_ws.map(|(id, _)| id)
+        .or_else(|| resolved_loops.first().map(|r| r.ws_id))
+        .unwrap_or(0);
 
     // 构建伪ID -> 真实ID 的映射表
     let mut tag_pseudo_to_real: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
@@ -1124,7 +1357,6 @@ pub async fn import_loops(
         triggers: 0,
         steps: 0,
     };
-    let warnings: Vec<LoopImportWarning> = Vec::new();
 
     // 阶段1: 导入标签
     for tag in &data.tags {
@@ -1133,20 +1365,20 @@ pub async fn import_loops(
         created_counts.tags += 1;
     }
 
-    // 阶段2: 导入评审模板（到目标工作空间）
+    // 阶段2: 导入评审模板（统一归到首个 loop 的工作空间，见 template_ws_id）
     for tmpl in &data.review_templates {
         let input = ReviewTemplateInput {
             name: tmpl.name.clone(),
             description: tmpl.description.clone(),
             prompt: tmpl.prompt.clone(),
-            workspace_id: Some(workspace_id),
+            workspace_id: Some(template_ws_id),
         };
         let new_tmpl = state.db.create_review_template(&input).await?;
         template_pseudo_to_real.insert(tmpl.id.clone(), new_tmpl);
         created_counts.review_templates += 1;
     }
 
-    // 阶段3: 导入Todo模板（完整字段导入）
+    // 阶段3: 导入Todo模板（完整字段导入）；workspace 取 todo_ws 映射（跟随所属 loop）
     for todo in &data.todos {
         // 解析 kind 字符串 → i32（导出时存为字符串以便序列化）
         let kind: Option<i32> = todo.kind.parse().ok().or(Some(0));
@@ -1154,14 +1386,16 @@ pub async fn import_loops(
         let real_review_template_id = todo.review_template_id.as_ref()
             .and_then(|tid| template_pseudo_to_real.get(tid))
             .copied();
+        // 该 todo 归属的工作空间 (id, path)；未在映射里（无 step/abnormal 引用）退化为哨兵 0
+        let (todo_ws_id, todo_ws_path) = todo_ws.get(&todo.id).cloned().unwrap_or((0, None));
         let new_todo_id = state.db.create_todo_for_import(
             &todo.title,
             &todo.prompt,
             todo.executor.as_deref(),
             todo.acceptance_criteria.as_deref(),
             todo.webhook_enabled,
-            workspace_id,
-            &workspace.path,
+            todo_ws_id,
+            todo_ws_path.as_deref().unwrap_or(""),
             Some(&todo.status),
             Some(todo.scheduler_enabled),
             Some(todo.auto_review_enabled),
@@ -1182,8 +1416,9 @@ pub async fn import_loops(
         }
     }
 
-    // 阶段4: 导入环路主体
-    for loop_export in &data.loops {
+    // 阶段4: 导入环路主体；workspace 用该 loop 解析出的 (id, path)
+    for (i, loop_export) in data.loops.iter().enumerate() {
+        let resolved = &resolved_loops[i];
         let review_template_id = loop_export.review_template_id.as_ref()
             .and_then(|tid| template_pseudo_to_real.get(tid))
             .copied();
@@ -1203,8 +1438,8 @@ pub async fn import_loops(
         let new_loop = state.db.create_loop(
             &loop_name,
             &loop_export.description,
-            Some(workspace_id),
-            Some(workspace.path.as_str()),
+            Some(resolved.ws_id),
+            resolved.ws_path.as_deref(),
             loop_export.webhook_enabled,
             &loop_export.icon,
             review_template_id,
@@ -1299,8 +1534,14 @@ pub async fn import_loops(
 #[derive(Deserialize)]
 pub struct MergeLoopRequest {
     pub yaml: String,
-    pub workspace_id: i64,
-    /// 冲突解决策略: "overwrite" | "rename" | "skip"
+    /// 全局目标工作空间（向后兼容）；None 时按 per-loop 解析。
+    #[serde(default)]
+    pub workspace_id: Option<i64>,
+    /// per-loop 覆盖：loop name → workspace_id（前端逐条选择）。
+    #[serde(default)]
+    pub workspace_overrides: Option<std::collections::HashMap<String, i64>>,
+    /// 冲突解决策略（已废弃：统一为覆盖语义，对齐 Todo；字段保留向后兼容，不再生效）。
+    #[serde(default)]
     pub conflict_resolution: std::collections::HashMap<String, String>,
 }
 
@@ -1326,9 +1567,27 @@ pub async fn merge_loops(
         return Err(AppError::BadRequest("No loops in export file".to_string()));
     }
 
-    // 验证工作空间存在
-    let workspace = state.db.get_project_directory_by_id(req.workspace_id).await?
-        .ok_or_else(|| AppError::BadRequest(format!("Workspace {} not found", req.workspace_id)))?;
+    // 全局目标工作空间（可选，向后兼容）；None 时按 per-loop 解析
+    let global_ws: Option<(i64, String)> = match req.workspace_id {
+        Some(id) => {
+            let dir = state.db.get_project_directory_by_id(id).await?
+                .ok_or_else(|| AppError::BadRequest(format!("Workspace {} not found", id)))?;
+            Some((dir.id, dir.path))
+        }
+        None => None,
+    };
+    let overrides = req.workspace_overrides.unwrap_or_default();
+
+    // 逐 loop 解析工作空间，gate 未匹配；建 todo→ws 映射（共享 todo 取首 loop ws）
+    let resolved_loops = resolve_all_loops(state.db.as_ref(), &data, global_ws.as_ref(), &overrides).await?;
+    gate_unmatched_loops(&resolved_loops)?;
+    let mut warnings: Vec<LoopImportWarning> = Vec::new();
+    let todo_ws = build_todo_workspace_map(&data, &resolved_loops, &mut warnings);
+
+    // 评审模板按 name 匹配、跨 loop 复用，统一归到首个 loop 的工作空间（有意简化）
+    let template_ws_id = global_ws.map(|(id, _)| id)
+        .or_else(|| resolved_loops.first().map(|r| r.ws_id))
+        .unwrap_or(0);
 
     // 构建伪ID -> 真实ID 的映射表
     let mut tag_pseudo_to_real: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
@@ -1343,8 +1602,8 @@ pub async fn merge_loops(
     let mut updated_counts = LoopImportCreatedCounts {
         loops: 0, todos: 0, review_templates: 0, tags: 0, triggers: 0, steps: 0,
     };
-    let mut skipped: Vec<String> = Vec::new();
-    let warnings: Vec<LoopImportWarning> = Vec::new();
+    // skipped 已废弃（统一覆盖语义，不再跳过）；保留空 vec 兼容响应结构
+    let skipped: Vec<String> = Vec::new();
 
     // 阶段1: 合并标签（按name匹配，同名复用）
     for tag in &data.tags {
@@ -1358,7 +1617,7 @@ pub async fn merge_loops(
         }
     }
 
-    // 阶段2: 合并评审模板（按name匹配，存在则覆盖）
+    // 阶段2: 合并评审模板（按name匹配，存在则覆盖；统一归到首个 loop 的工作空间）
     for tmpl in &data.review_templates {
         if let Some(existing) = state.db.get_review_template_by_name(&tmpl.name).await? {
             // 存在则更新
@@ -1366,7 +1625,7 @@ pub async fn merge_loops(
                 name: tmpl.name.clone(),
                 description: tmpl.description.clone(),
                 prompt: tmpl.prompt.clone(),
-                workspace_id: Some(req.workspace_id),
+                workspace_id: Some(template_ws_id),
             };
             state.db.update_review_template(existing.id, &input).await?;
             template_pseudo_to_real.insert(tmpl.id.clone(), existing.id);
@@ -1376,7 +1635,7 @@ pub async fn merge_loops(
                 name: tmpl.name.clone(),
                 description: tmpl.description.clone(),
                 prompt: tmpl.prompt.clone(),
-                workspace_id: Some(req.workspace_id),
+                workspace_id: Some(template_ws_id),
             };
             let new_id = state.db.create_review_template(&input).await?;
             template_pseudo_to_real.insert(tmpl.id.clone(), new_id);
@@ -1384,10 +1643,12 @@ pub async fn merge_loops(
         }
     }
 
-    // 阶段3: 合并Todo（按title+prompt+workspace匹配）
+    // 阶段3: 合并Todo（按 title+prompt+该 todo 归属 workspace 匹配，避免跨工作空间误覆盖）
     for todo in &data.todos {
-        // 尝试查找完全相同的 Todo（title + prompt + workspace）
-        if let Some(existing_todo) = state.db.get_todo_by_identity(&todo.title, &todo.prompt, req.workspace_id).await? {
+        // 该 todo 归属的工作空间 (id, path)；未在映射里退化为哨兵 0
+        let (todo_ws_id, todo_ws_path) = todo_ws.get(&todo.id).cloned().unwrap_or((0, None));
+        // 尝试查找完全相同的 Todo（title + prompt + 同工作空间）
+        if let Some(existing_todo) = state.db.get_todo_by_identity(&todo.title, &todo.prompt, todo_ws_id).await? {
             // 存在则复用，不重复创建
             todo_pseudo_to_real.insert(todo.id.clone(), existing_todo.id);
         } else {
@@ -1403,8 +1664,8 @@ pub async fn merge_loops(
                 todo.executor.as_deref(),
                 todo.acceptance_criteria.as_deref(),
                 todo.webhook_enabled,
-                req.workspace_id,
-                &workspace.path,
+                todo_ws_id,
+                todo_ws_path.as_deref().unwrap_or(""),
                 Some(&todo.status),
                 Some(todo.scheduler_enabled),
                 Some(todo.auto_review_enabled),
@@ -1416,50 +1677,26 @@ pub async fn merge_loops(
         }
     }
 
-    // 阶段4: 合并环路（按name匹配，检查冲突解决策略）
-    for loop_export in &data.loops {
-        let conflict_action = req.conflict_resolution.get(&loop_export.name)
-            .cloned()
-            .unwrap_or_else(|| "rename".to_string());
+    // 阶段4: 合并环路——单一覆盖语义，对齐 Todo merge_backup：
+    // 同名（在 resolved ws 内）→ 删旧 + 原名重建（覆盖）；不同名 → 原名新建。
+    // 不再有 重命名/跳过 分支；conflict_resolution 字段保留兼容但不再生效。
+    for (i, loop_export) in data.loops.iter().enumerate() {
+        let resolved = &resolved_loops[i];
 
-        // 查找同名环路
-        let existing_loop = state.db.list_loops_with_counts(Some(req.workspace_id)).await?
+        // 查找同名环路（只在该 loop 解析出的工作空间内查，避免跨工作空间误判同名）
+        let existing_loop = state.db.list_loops_with_counts(Some(resolved.ws_id)).await?
             .into_iter()
             .find(|l| l.loop_.name == loop_export.name);
 
-        let (new_loop_id, is_new) = match (existing_loop, conflict_action.as_str()) {
-            // 跳过
-            (Some(_), "skip") => {
-                skipped.push(loop_export.name.clone());
-                continue;
-            }
-            // 覆盖（删除旧环路，用新ID继续创建）
-            (Some(existing), "overwrite") => {
-                state.db.delete_loop(existing.loop_.id).await?;
-                let new_loop_id = create_loop_from_export(
-                    &state, loop_export, req.workspace_id, &workspace.path,
-                    &template_pseudo_to_real, &todo_pseudo_to_real, &tag_pseudo_to_real,
-                ).await?;
-                (new_loop_id, false)
-            }
-            // 重命名（追加后缀后创建新环路）
-            (Some(_), "rename") | (_, "rename") => {
-                let new_loop_id = create_loop_from_export(
-                    &state, loop_export, req.workspace_id, &workspace.path,
-                    &template_pseudo_to_real, &todo_pseudo_to_real, &tag_pseudo_to_real,
-                ).await?;
-                (new_loop_id, true) // rename 创建了新环路
-            }
-            // 默认：同名环路不存在，直接创建全新的
-            (None, _) => {
-                let new_loop_id = create_loop_from_export(
-                    &state, loop_export, req.workspace_id, &workspace.path,
-                    &template_pseudo_to_real, &todo_pseudo_to_real, &tag_pseudo_to_real,
-                ).await?;
-                (new_loop_id, true)
-            }
-            _ => continue,
-        };
+        // 同名存在 → 删除旧环路，随后用原名重建（= 覆盖）；不存在 → 直接原名新建
+        let is_new = existing_loop.is_none();
+        if let Some(existing) = existing_loop {
+            state.db.delete_loop(existing.loop_.id).await?;
+        }
+        let new_loop_id = create_loop_from_export(
+            &state, loop_export, resolved.ws_id, resolved.ws_path.as_deref(),
+            &template_pseudo_to_real, &todo_pseudo_to_real, &tag_pseudo_to_real,
+        ).await?;
 
         loop_pseudo_to_real.insert(loop_export.id.clone(), new_loop_id);
         if is_new {
@@ -1490,7 +1727,7 @@ async fn create_loop_from_export(
     state: &AppState,
     loop_export: &LoopExportItem,
     workspace_id: i64,
-    workspace_path: &str,
+    workspace_path: Option<&str>,
     template_pseudo_to_real: &std::collections::HashMap<String, i64>,
     todo_pseudo_to_real: &std::collections::HashMap<String, i64>,
     tag_pseudo_to_real: &std::collections::HashMap<String, i64>,
@@ -1508,14 +1745,14 @@ async fn create_loop_from_export(
     let abnormal_handler_trigger_on = serde_json::to_string(&loop_export.abnormal_handler_trigger_on)
         .unwrap_or_else(|_| "[]".to_string());
 
-    // 合并模式：同名环路名称追加 "-合并"
-    let loop_name = format!("{}-合并", loop_export.name);
+    // 统一覆盖语义：用原名（同名已在上游删除），不再追加 "-合并" 后缀，对齐 Todo
+    let loop_name = loop_export.name.clone();
 
     let new_loop = state.db.create_loop(
         &loop_name,
         &loop_export.description,
         Some(workspace_id),
-        Some(workspace_path),
+        workspace_path,
         loop_export.webhook_enabled,
         &loop_export.icon,
         review_template_id,
@@ -1901,6 +2138,7 @@ pub fn loop_routes() -> axum::Router<AppState> {
         .route("/api/loops/batch-workspace", put(batch_move_loops_workspace))
         .route("/api/loops/batch-copy-workspace", post(batch_copy_loops_workspace))
         .route("/api/loops/export-selected", post(export_selected_loops))
+        .route("/api/loops/export", get(export_all_loops))
         .route("/api/loops/{id}", get(get_loop).put(update_loop).delete(delete_loop))
         .route("/api/loops/{id}/export", get(export_loop))
         .route("/api/loops/{id}/status", put(update_loop_status))
@@ -1927,4 +2165,244 @@ pub fn loop_routes() -> axum::Router<AppState> {
         .route("/api/loops/import/preview", post(import_preview))
         .route("/api/loops/import", post(import_loops))
         .route("/api/loops/merge", post(merge_loops))
+}
+
+// ====== 导入工作空间逐 loop 解析的单元测试 ======
+// 覆盖 resolve 优先级、gate、共享 todo 归属、preview 匹配。
+// 用 in-memory SQLite，不依赖 AppState/Router，直接测私有 helper。
+#[cfg(test)]
+mod workspace_resolve_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::needless_pass_by_value, clippy::bool_assert_comparison)]
+    use super::*;
+    use crate::db::Database;
+    use crate::models::{LoopExportData, LoopExportItem, LoopStepExportItem, TodoExportItem};
+
+    async fn setup_db() -> Database {
+        Database::new(":memory:").await.unwrap()
+    }
+
+    // 构造一个最小可用 LoopExportItem，只关心 name/workspace_id/abnormal_handler，
+    // 其余字段填零值——测试只验证工作空间解析逻辑，不跑完整导入。
+    fn mk_loop(name: &str, ws_id: Option<i64>, handler_todo_id: Option<String>) -> LoopExportItem {
+        LoopExportItem {
+            id: format!("@loop_{}", name),
+            name: name.to_string(),
+            description: String::new(),
+            icon: String::new(),
+            color: String::new(),
+            status: "paused".to_string(),
+            webhook_enabled: false,
+            limits_config: serde_json::json!({}),
+            review_template_id: None,
+            review_template_name: None,
+            abnormal_handler_todo_id: handler_todo_id,
+            abnormal_handler_todo_title: None,
+            abnormal_handler_trigger_on: vec![],
+            tag_ids: vec![],
+            tag_names: vec![],
+            triggers: vec![],
+            steps: vec![],
+            workspace_id: ws_id,
+            workspace_path: None,
+        }
+    }
+
+    // 带一个 step（引用 todo_id）的 loop，用于共享 todo 归属测试。
+    fn mk_loop_with_step(name: &str, ws_id: Option<i64>, todo_id: &str, todo_title: &str) -> LoopExportItem {
+        let mut l = mk_loop(name, ws_id, None);
+        l.steps.push(LoopStepExportItem {
+            id: format!("@step_{}_{}", name, todo_id),
+            name: format!("step-{}", todo_id),
+            description: String::new(),
+            todo_id: todo_id.to_string(),
+            todo_title: todo_title.to_string(),
+            order_index: 0,
+            run_mode: "auto".to_string(),
+            skip_on_source_failed: false,
+            min_rating: None,
+            unrated_policy: "skip".to_string(),
+            on_success: "continue".to_string(),
+            success_goto_step_id: None,
+            success_goto_step_name: None,
+            on_rating_fail: "stop".to_string(),
+            fail_goto_step_id: None,
+            fail_goto_step_name: None,
+            review_type: "none".to_string(),
+            enabled: true,
+        });
+        l
+    }
+
+    fn mk_todo(id: &str, title: &str) -> TodoExportItem {
+        TodoExportItem {
+            id: id.to_string(),
+            title: title.to_string(),
+            prompt: String::new(),
+            status: "pending".to_string(),
+            executor: None,
+            scheduler_enabled: false,
+            webhook_enabled: false,
+            acceptance_criteria: None,
+            auto_review_enabled: false,
+            review_template_id: None,
+            review_template_name: None,
+            kind: "0".to_string(),
+            tag_ids: vec![],
+            tag_names: vec![],
+            is_abnormal_handler: false,
+            action_type: None,
+            action_key: None,
+            workspace_id: None,
+            workspace_path: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_loop_workspace_found() {
+        // 已登记的 id → 返回 (id, path, name)
+        let db = setup_db().await;
+        let id = db.create_project_directory("/tmp/ws-a", Some("A"), false, false).await.unwrap();
+        let r = resolve_loop_workspace(&db, Some(id)).await.unwrap();
+        let (rid, path, name) = r.expect("已存在的工作空间应能解析");
+        assert_eq!(rid, id);
+        assert_eq!(path, "/tmp/ws-a");
+        assert_eq!(name.as_deref(), Some("A"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_loop_workspace_missing_and_none() {
+        // 不存在的 id → None；入参 None → None
+        let db = setup_db().await;
+        assert!(resolve_loop_workspace(&db, Some(99999)).await.unwrap().is_none());
+        assert!(resolve_loop_workspace(&db, None).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_ws_pair_override_beats_global_and_exported() {
+        // override 优先于全局与导出值
+        let db = setup_db().await;
+        let a = db.create_project_directory("/tmp/ws-a", Some("A"), false, false).await.unwrap();
+        let b = db.create_project_directory("/tmp/ws-b", Some("B"), false, false).await.unwrap();
+        let c = db.create_project_directory("/tmp/ws-c", Some("C"), false, false).await.unwrap();
+        let l = mk_loop("L", Some(c), None);
+        let global = (a, "/tmp/ws-a".to_string());
+        let (id, path) = resolve_loop_ws_pair(&db, &l, Some(&global), Some(b)).await.unwrap();
+        assert_eq!(id, b);
+        assert_eq!(path.as_deref(), Some("/tmp/ws-b"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_ws_pair_global_when_no_override() {
+        // 无 override 时全局覆盖导出值
+        let db = setup_db().await;
+        let a = db.create_project_directory("/tmp/ws-a", Some("A"), false, false).await.unwrap();
+        let c = db.create_project_directory("/tmp/ws-c", Some("C"), false, false).await.unwrap();
+        let l = mk_loop("L", Some(c), None);
+        let global = (a, "/tmp/ws-a".to_string());
+        let (id, _) = resolve_loop_ws_pair(&db, &l, Some(&global), None).await.unwrap();
+        assert_eq!(id, a);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_ws_pair_exported_when_no_global() {
+        // 无 override 无全局 → 用导出 id 重新解析
+        let db = setup_db().await;
+        let c = db.create_project_directory("/tmp/ws-c", Some("C"), false, false).await.unwrap();
+        let l = mk_loop("L", Some(c), None);
+        let (id, path) = resolve_loop_ws_pair(&db, &l, None, None).await.unwrap();
+        assert_eq!(id, c);
+        assert_eq!(path.as_deref(), Some("/tmp/ws-c"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_ws_pair_dangling_sentinel_zero() {
+        // 导出 id 在当前库不存在且无全局无 override → 哨兵 (0, None)
+        let db = setup_db().await;
+        let l = mk_loop("L", Some(99999), None);
+        let (id, path) = resolve_loop_ws_pair(&db, &l, None, None).await.unwrap();
+        assert_eq!(id, 0);
+        assert!(path.is_none());
+    }
+
+    #[test]
+    fn test_gate_unmatched_loops() {
+        // 全部已匹配 → Ok；任一为 0 → 报错列出名字
+        let ok = vec![
+            LoopResolved { name: "L1".into(), ws_id: 1, ws_path: None },
+            LoopResolved { name: "L2".into(), ws_id: 2, ws_path: None },
+        ];
+        assert!(gate_unmatched_loops(&ok).is_ok());
+
+        let bad = vec![
+            LoopResolved { name: "L1".into(), ws_id: 1, ws_path: None },
+            LoopResolved { name: "L2".into(), ws_id: 0, ws_path: None },
+        ];
+        let err = gate_unmatched_loops(&bad).unwrap_err();
+        let msg = match err { AppError::BadRequest(m) => m, _ => String::new() };
+        assert!(msg.contains("L2"), "错误信息应列出未匹配 loop 名，got: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn test_build_todo_workspace_map_shared_todo_first_loop_wins() {
+        // 两个 loop 共享同一条 todo；todo 应归属首个引用它的 loop 的工作空间，并打一次 warning
+        let db = setup_db().await;
+        let a = db.create_project_directory("/tmp/ws-a", Some("A"), false, false).await.unwrap();
+        let b = db.create_project_directory("/tmp/ws-b", Some("B"), false, false).await.unwrap();
+        let l1 = mk_loop_with_step("L1", Some(a), "@todo_x", "TX");
+        let l2 = mk_loop_with_step("L2", Some(b), "@todo_x", "TX");
+        let data = LoopExportData {
+            version: "1.0".into(),
+            export_type: "loop".into(),
+            created_at: String::new(),
+            source: "test".into(),
+            schema_version: 1,
+            tags: vec![],
+            review_templates: vec![],
+            todos: vec![mk_todo("@todo_x", "TX")],
+            loops: vec![l1, l2],
+        };
+        let resolved = vec![
+            LoopResolved { name: "L1".into(), ws_id: a, ws_path: Some("/tmp/ws-a".into()) },
+            LoopResolved { name: "L2".into(), ws_id: b, ws_path: Some("/tmp/ws-b".into()) },
+        ];
+        let mut warnings = Vec::new();
+        let todo_ws = build_todo_workspace_map(&data, &resolved, &mut warnings);
+        // 共享 todo 归首 loop L1 的工作空间 A
+        let (wid, wpath) = todo_ws.get("@todo_x").expect("todo 应被映射");
+        assert_eq!(*wid, a);
+        assert_eq!(wpath.as_deref(), Some("/tmp/ws-a"));
+        // 只打一次共享 warning
+        assert_eq!(warnings.iter().filter(|w| w.warning_type == "shared_todo_workspace").count(), 1);
+        assert!(warnings[0].message.contains("TX"));
+        assert!(warnings[0].message.contains("L1"));
+    }
+
+    #[tokio::test]
+    async fn test_build_preview_loops_matched_and_unmatched() {
+        // 一条 loop 原 id 存在→matched + resolved=id；另一条不存在→unmatched + resolved=0
+        let db = setup_db().await;
+        let a = db.create_project_directory("/tmp/ws-a", Some("A"), false, false).await.unwrap();
+        let data = LoopExportData {
+            version: "1.0".into(),
+            export_type: "loop".into(),
+            created_at: String::new(),
+            source: "test".into(),
+            schema_version: 1,
+            tags: vec![],
+            review_templates: vec![],
+            todos: vec![],
+            loops: vec![
+                mk_loop("L1", Some(a), None),
+                mk_loop("L2", Some(99999), None),
+            ],
+        };
+        let previews = build_preview_loops(&db, &data).await.unwrap();
+        assert_eq!(previews.len(), 2);
+        assert!(previews[0].source_matched);
+        assert_eq!(previews[0].resolved_workspace_id, a);
+        assert_eq!(previews[0].resolved_workspace_name.as_deref(), Some("A"));
+        assert!(!previews[1].source_matched);
+        assert_eq!(previews[1].resolved_workspace_id, 0);
+        assert!(previews[1].resolved_workspace_name.is_none());
+    }
 }

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -1540,6 +1540,9 @@ pub struct MergeLoopRequest {
     /// per-loop 覆盖：loop name → workspace_id（前端逐条选择）。
     #[serde(default)]
     pub workspace_overrides: Option<std::collections::HashMap<String, i64>>,
+    /// 用户选择「跳过」的同名环路名集合：这些环路不会被创建/覆盖，同名保留原样。
+    #[serde(default)]
+    pub skip_names: Vec<String>,
     /// 冲突解决策略（已废弃：统一为覆盖语义，对齐 Todo；字段保留向后兼容，不再生效）。
     #[serde(default)]
     pub conflict_resolution: std::collections::HashMap<String, String>,
@@ -1559,7 +1562,7 @@ pub async fn merge_loops(
     Json(req): Json<MergeLoopRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     // 解析 YAML
-    let data: LoopExportData = serde_yaml::from_str(&req.yaml)
+    let mut data: LoopExportData = serde_yaml::from_str(&req.yaml)
         .map_err(|e| AppError::BadRequest(format!("Invalid YAML: {}", e)))?;
 
     // 基本校验
@@ -1577,6 +1580,18 @@ pub async fn merge_loops(
         None => None,
     };
     let overrides = req.workspace_overrides.unwrap_or_default();
+
+    // 用户选择「跳过」的同名环路：记录名字后从待处理列表移除——
+    // 不 resolve、不 gate、不创建，同名保留原样。其引用的 todo/模板/标签仍按全局资源合并。
+    let skip_set: std::collections::HashSet<&str> =
+        req.skip_names.iter().map(|s| s.as_str()).collect();
+    let skipped: Vec<String> = data.loops.iter()
+        .filter(|l| skip_set.contains(l.name.as_str()))
+        .map(|l| l.name.clone())
+        .collect();
+    if !skip_set.is_empty() {
+        data.loops.retain(|l| !skip_set.contains(l.name.as_str()));
+    }
 
     // 逐 loop 解析工作空间，gate 未匹配；建 todo→ws 映射（共享 todo 取首 loop ws）
     let resolved_loops = resolve_all_loops(state.db.as_ref(), &data, global_ws.as_ref(), &overrides).await?;
@@ -1602,8 +1617,7 @@ pub async fn merge_loops(
     let mut updated_counts = LoopImportCreatedCounts {
         loops: 0, todos: 0, review_templates: 0, tags: 0, triggers: 0, steps: 0,
     };
-    // skipped 已废弃（统一覆盖语义，不再跳过）；保留空 vec 兼容响应结构
-    let skipped: Vec<String> = Vec::new();
+    // skipped 已在前部按用户选择「跳过」的同名环路名收集（见 skip_names 处理）
 
     // 阶段1: 合并标签（按name匹配，同名复用）
     for tag in &data.tags {
@@ -1679,7 +1693,7 @@ pub async fn merge_loops(
 
     // 阶段4: 合并环路——单一覆盖语义，对齐 Todo merge_backup：
     // 同名（在 resolved ws 内）→ 删旧 + 原名重建（覆盖）；不同名 → 原名新建。
-    // 不再有 重命名/跳过 分支；conflict_resolution 字段保留兼容但不再生效。
+    // 用户选择「跳过」的同名环路已在 resolve 前从 data.loops 移除，不会进入本阶段。
     for (i, loop_export) in data.loops.iter().enumerate() {
         let resolved = &resolved_loops[i];
 

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1209,6 +1209,31 @@ pub struct LoopImportPreviewResponse {
     pub summary: LoopImportSummary,
     pub conflicts: Vec<LoopImportConflict>,
     pub warnings: Vec<LoopImportWarning>,
+    /// 每条 loop 的工作空间匹配情况，供前端逐条渲染/指派工作空间。
+    /// 新增字段，旧前端不读不报错（serde 反序列化侧用 #[serde(default)]）。
+    #[serde(default)]
+    pub loops: Vec<LoopImportPreviewLoop>,
+}
+
+/// 预览里单条 loop 的工作空间解析结果。
+/// resolved_workspace_id == 0 表示该 loop 的原工作空间在当前库不存在（未匹配），
+/// 前端需让用户手动指定后再导入。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopImportPreviewLoop {
+    pub name: String,
+    /// 导出文件里的原始工作空间 ID（可能为 None）
+    #[serde(default)]
+    pub workspace_id: Option<i64>,
+    /// 导出文件里的原始工作空间路径，展示用
+    #[serde(default)]
+    pub workspace_path: Option<String>,
+    /// 解析后的工作空间 ID（0=未匹配，需用户手动指派）
+    pub resolved_workspace_id: i64,
+    /// 解析后的工作空间名称（未匹配时为 None）
+    #[serde(default)]
+    pub resolved_workspace_name: Option<String>,
+    /// 原始 workspace_id 在当前库是否存在
+    pub source_matched: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/tests/api_integration_test.rs
+++ b/backend/tests/api_integration_test.rs
@@ -669,3 +669,126 @@ async fn test_delete_wiki_file_log_forbidden() {
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
+
+// ====== Loop 导入 merge 语义：原名保留 + 同名覆盖（对齐 Todo） ======
+
+/// 构造最小可用的 loop 导出 YAML：一个 loop + 一个 step-todo，workspace_id 指向给定 ws。
+fn loop_merge_yaml(name: &str, ws_id: i64) -> String {
+    format!(
+r#"version: "1.0"
+type: loop
+created_at: "2026-07-09T00:00:00Z"
+source: nothing-todo
+schema_version: 1
+tags: []
+review_templates: []
+todos:
+  - id: "@todo_1"
+    title: "merge-todo"
+    prompt: "p"
+    status: "pending"
+    executor: null
+    scheduler_enabled: false
+    webhook_enabled: false
+    acceptance_criteria: null
+    auto_review_enabled: false
+    review_template_id: null
+    review_template_name: null
+    kind: "0"
+    tag_ids: []
+    tag_names: []
+    is_abnormal_handler: false
+    action_type: null
+    action_key: null
+    workspace_id: {ws}
+    workspace_path: "/tmp/test-api-workspace"
+loops:
+  - id: "@loop_1"
+    name: "{name}"
+    description: ""
+    icon: ""
+    color: ""
+    status: "paused"
+    webhook_enabled: false
+    limits_config: {{}}
+    review_template_id: null
+    review_template_name: null
+    abnormal_handler_todo_id: null
+    abnormal_handler_todo_title: null
+    abnormal_handler_trigger_on: []
+    tag_ids: []
+    tag_names: []
+    triggers: []
+    steps:
+      - id: "@step_1"
+        name: "s1"
+        description: ""
+        todo_id: "@todo_1"
+        todo_title: "merge-todo"
+        order_index: 0
+        run_mode: "auto"
+        skip_on_source_failed: false
+        min_rating: null
+        unrated_policy: "skip"
+        on_success: "continue"
+        success_goto_step_id: null
+        success_goto_step_name: null
+        on_rating_fail: "stop"
+        fail_goto_step_id: null
+        fail_goto_step_name: null
+        review_type: "none"
+        enabled: true
+    workspace_id: {ws}
+    workspace_path: "/tmp/test-api-workspace"
+"#,
+        name = name,
+        ws = ws_id
+    )
+}
+
+/// 取指定工作空间下名为 name 的 loop 数量（通过 list 接口）
+async fn count_loops_named(app: axum::Router, ws_id: i64, name: &str) -> usize {
+    let uri = format!("/api/loops?workspace_id={}", ws_id);
+    let req = Request::builder().uri(&uri).body(Body::empty()).unwrap();
+    let response = app.oneshot(req).await.unwrap();
+    let body: serde_json::Value = read_json_body(response).await;
+    body["data"].as_array().unwrap_or(&vec![]).iter().filter(|l| l["name"] == name).count()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_loop_merge_keeps_original_name() {
+    // 导入后 loop 名应保持原名，不再追加 "-合并" 后缀
+    let (app, ws_id) = create_test_app().await;
+    let yaml = loop_merge_yaml("我的环路", ws_id);
+    let req = json_request("POST", "/api/loops/merge", json!({
+        "yaml": yaml, "workspace_id": null, "workspace_overrides": {}
+    }));
+    let response = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = read_json_body(response).await;
+    assert_eq!(body["code"], 0, "merge 应成功: {:?}", body);
+    // 原名命中 1 个，"-合并" 后缀命中 0 个
+    assert_eq!(count_loops_named(app.clone(), ws_id, "我的环路").await, 1);
+    assert_eq!(count_loops_named(app, ws_id, "我的环路-合并").await, 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_loop_merge_same_name_overwrites() {
+    // 同名 loop 二次导入 → 覆盖（删旧重建），不产生重复
+    let (app, ws_id) = create_test_app().await;
+    let yaml = loop_merge_yaml("dup-loop", ws_id);
+    let req = json_request("POST", "/api/loops/merge", json!({
+        "yaml": yaml, "workspace_id": null, "workspace_overrides": {}
+    }));
+    let r1 = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(r1.status(), StatusCode::OK);
+    assert_eq!(count_loops_named(app.clone(), ws_id, "dup-loop").await, 1);
+
+    // 再次导入同名 → 覆盖，仍只 1 个
+    let req2 = json_request("POST", "/api/loops/merge", json!({
+        "yaml": yaml, "workspace_id": null, "workspace_overrides": {}
+    }));
+    let r2 = app.clone().oneshot(req2).await.unwrap();
+    assert_eq!(r2.status(), StatusCode::OK);
+    assert_eq!(count_loops_named(app, ws_id, "dup-loop").await, 1);
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,9 +19,9 @@
         "dayjs": "^1.11.21",
         "js-yaml": "^4.1.1",
         "qrcode": "^1.5.4",
-        "react": "^19.1.0",
+        "react": "^19.2.0",
         "react-countup": "^6.5.3",
-        "react-dom": "^19.1.0",
+        "react-dom": "^19.2.0",
         "react-icons": "^5.6.0",
         "react-js-cron": "^6.0.2"
       },

--- a/frontend/src/components/settings/BackupPanel.tsx
+++ b/frontend/src/components/settings/BackupPanel.tsx
@@ -1,6 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Tabs, message } from 'antd';
-import { useApp } from '@/hooks/useApp';
 import * as db from '@/utils/database';
 import yaml from 'js-yaml';
 import { TodoBackupTab } from './backup/TodoBackupTab';
@@ -10,9 +9,46 @@ import { LoopBackupTab } from '@/components/settings/backup/LoopBackupTab';
 import { ImportExportModals, BackupDataYaml, ImportItem } from './backup/ImportExportModals';
 import type { ProjectDirectory } from '@/utils/database/todos';
 
+// 备份子 tab 的合法 key——每个子 tab 对应 URL 里的一个 sub 参数，支持深链直达
+const BACKUP_SUB_KEYS = ['todo', 'skill-backup', 'loop', 'database'] as const;
+type BackupSubKey = (typeof BACKUP_SUB_KEYS)[number];
+
+// 从 hash URL（如 #/settings?tab=backup&sub=loop）解析当前备份子 tab
+function getBackupSubFromHash(): BackupSubKey {
+  const hash = window.location.hash;
+  const qIdx = hash.indexOf('?');
+  if (qIdx < 0) return 'todo';
+  const sub = new URLSearchParams(hash.slice(qIdx + 1)).get('sub');
+  // 只认合法 key，否则回退到「事项备份」
+  return sub && (BACKUP_SUB_KEYS as readonly string[]).includes(sub) ? (sub as BackupSubKey) : 'todo';
+}
+
+// 把当前备份子 tab 写回 hash URL（replaceState 不污染浏览历史，仅更新深链）
+function setBackupSubInHash(sub: BackupSubKey) {
+  const hash = window.location.hash;
+  const qIdx = hash.indexOf('?');
+  const path = qIdx < 0 ? hash : hash.slice(0, qIdx);
+  const params = new URLSearchParams(qIdx < 0 ? '' : hash.slice(qIdx + 1));
+  params.set('sub', sub);
+  window.history.replaceState(null, '', `${path}?${params.toString()}`);
+}
+
+
 export function BackupPanel() {
-  const { state } = useApp();
-  const { todos } = state;
+  // 备份子 tab：初始值来自 URL（深链），切换时同步回 URL
+  const [backupSub, setBackupSub] = useState<BackupSubKey>(getBackupSubFromHash);
+  // 浏览器前进/后退时按 URL 同步子 tab
+  useEffect(() => {
+    const onPop = () => setBackupSub(getBackupSubFromHash());
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, []);
+  const handleBackupSubChange = useCallback((key: string) => {
+    if (!(BACKUP_SUB_KEYS as readonly string[]).includes(key)) return;
+    setBackupSub(key as BackupSubKey);
+    setBackupSubInHash(key as BackupSubKey);
+  }, []);
+
   // Database backup state
   const [backupStatus, setBackupStatus] = useState<{
     auto_backup_enabled: boolean;
@@ -56,39 +92,46 @@ export function BackupPanel() {
 
   // Import/Export state
   const [importing, setImporting] = useState(false);
-  const [exportModalOpen, setExportModalOpen] = useState(false);
-  const [exportTodoKeys, setExportTodoKeys] = useState<number[]>([]);
-  const [exportingSelected, setExportingSelected] = useState(false);
   const [wizardOpen, setWizardOpen] = useState(false);
   const [wizardItems, setWizardItems] = useState<ImportItem[]>([]);
   const [wizardTags, setWizardTags] = useState<{ name: string; color: string }[]>([]);
   const [selectedRowKeys, setSelectedRowKeys] = useState<number[]>([]);
-  // 导入目标工作空间
+  // 导入目标工作空间列表（父组件加载一次，下发给每行 WorkspaceSwitcher 复用）
   const [workspaces, setWorkspaces] = useState<ProjectDirectory[]>([]);
-  const [importWorkspaceId, setImportWorkspaceId] = useState<number | null>(null);
+  // 逐行工作空间选择：ImportItem.key → workspaceId（null=未匹配/待指定）
+  const [rowWorkspaceMap, setRowWorkspaceMap] = useState<Record<number, number | null>>({});
 
-  // 导入来源工作空间检测（从备份文件中提取，用于预览提示和默认选中）
+  // 导入来源工作空间检测（从备份文件中提取，用于预览提示）
   const [sourceWorkspaceInfo, setSourceWorkspaceInfo] = useState<{ id: number; path: string } | null>(null);
 
-  // 加载工作空间列表，优先匹配备份文件中的原始工作空间
-  // 注意：preferredId 未命中时必须重置回第一个工作空间，否则会残留上一次导入的选中值，
-  // 导致换一个备份文件后默认选中仍是旧值。
-  const loadWorkspaces = async (preferredId?: number | null) => {
+  // 加载工作空间列表（不再选全局默认——逐行按各自原 id 匹配）
+  const loadWorkspaces = async (): Promise<ProjectDirectory[]> => {
     try {
       const ws = await db.getProjectDirectories();
       setWorkspaces(ws);
-      if (preferredId != null && ws.some((w) => w.id === preferredId)) {
-        // 备份文件中检测到了原始工作空间且当前列表中能找到，默认选中它
-        setImportWorkspaceId(preferredId);
-      } else if (ws.length > 0) {
-        // 无匹配时退化为选中第一个（无论之前选过什么，都按当前文件重新默认）
-        setImportWorkspaceId(ws[0].id);
-      } else {
-        setImportWorkspaceId(null);
-      }
+      return ws;
     } catch (e) {
       console.error('Failed to load workspaces', e);
+      return [];
     }
+  };
+
+  // 设置某行的目标工作空间（供 ImportExportModals 逐行回写）
+  const setRowWorkspaceId = (key: number, id: number | null) => {
+    setRowWorkspaceMap((prev) => ({ ...prev, [key]: id }));
+  };
+
+  // 按 wizardItems + 当前工作空间列表，初始化每行默认：原 id 命中→原 id，否则 null（未匹配）
+  const buildDefaultRowWorkspace = (
+    items: ImportItem[],
+    ws: ProjectDirectory[],
+  ): Record<number, number | null> => {
+    const map: Record<number, number | null> = {};
+    for (const it of items) {
+      const matched = it.workspace_id != null && ws.some((w) => w.id === it.workspace_id);
+      map[it.key] = matched ? (it.workspace_id as number) : null;
+    }
+    return map;
   };
 
   // Load status
@@ -384,6 +427,8 @@ export function BackupPanel() {
           scheduler_config: todo.scheduler_config,
           tag_names: todo.tag_names || [],
           workspace_path: todo.workspace_path,
+          // 保留原始 workspace_id，供按行默认匹配与「来源」列展示
+          workspace_id: todo.workspace_id ?? null,
           action: exists ? 'overwrite' as const : 'new' as const,
           existingTitle: existing?.title,
         };
@@ -393,16 +438,19 @@ export function BackupPanel() {
       setWizardItems(items);
       setSelectedRowKeys(items.map(i => i.key));
 
-      // 从备份文件提取原始工作空间信息，用于预览提示和默认匹配
-      const firstTodoWithWs = data.todos.find((t: any) => t.workspace_id != null);
+      // 加载工作空间列表，并按行初始化默认归属（原 id 命中→原 id，否则 null 待指定）
+      const ws = await loadWorkspaces();
+      setRowWorkspaceMap(buildDefaultRowWorkspace(items, ws));
+
+      // 从备份文件提取原始工作空间信息，仅作预览提示（逐行匹配，不再自动选全局）
+      const firstTodoWithWs = data.todos.find((t) => t.workspace_id != null);
       if (firstTodoWithWs?.workspace_id != null) {
-        const srcInfo = { id: Number(firstTodoWithWs.workspace_id), path: firstTodoWithWs.workspace_path || '' };
-        setSourceWorkspaceInfo(srcInfo);
-        // 加载工作空间列表时传入检测到的原始 workspace ID，优先匹配
-        await loadWorkspaces(srcInfo.id);
+        setSourceWorkspaceInfo({
+          id: Number(firstTodoWithWs.workspace_id),
+          path: firstTodoWithWs.workspace_path || '',
+        });
       } else {
         setSourceWorkspaceInfo(null);
-        await loadWorkspaces();
       }
       setWizardOpen(true);
     } catch (err: any) {
@@ -418,10 +466,14 @@ export function BackupPanel() {
     }
     setImporting(true);
     try {
+      // 每条 todo 注入用户逐行选定的工作空间；全局 target 传 null，由后端按每条 workspace_id 解析
       const selectedTodos = wizardItems
         .filter(item => selectedRowKeys.includes(item.key))
-        .map(({ key, action, existingTitle, ...todo }) => todo);
-      const msg = await db.mergeBackup(wizardTags, selectedTodos, importWorkspaceId);
+        .map(({ key, action, existingTitle, ...todo }) => ({
+          ...todo,
+          workspace_id: rowWorkspaceMap[key] ?? null,
+        }));
+      const msg = await db.mergeBackup(wizardTags, selectedTodos, null);
       message.success(msg);
       setWizardOpen(false);
       window.location.reload();
@@ -432,49 +484,15 @@ export function BackupPanel() {
     }
   };
 
-  const handleExportSelected = async () => {
-    if (exportTodoKeys.length === 0) {
-      message.warning('请至少选择一项');
-      return;
-    }
-    setExportingSelected(true);
-    try {
-      const response = await fetch('/api/backup/export-selected', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Accept: 'application/x-yaml' },
-        body: JSON.stringify({ todo_ids: exportTodoKeys }),
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-      const yamlText = await response.text();
-      const blob = new Blob([yamlText], { type: 'application/x-yaml' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-      a.download = `aietodo-backup-selected-${timestamp}.yaml`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-      message.success(`已导出 ${exportTodoKeys.length} 项`);
-      setExportModalOpen(false);
-    } catch (err: any) {
-      message.error(err?.message || '导出失败');
-    } finally {
-      setExportingSelected(false);
-    }
-  };
-
   return (
     <div>
       <Tabs
-        defaultActiveKey="todo"
+        activeKey={backupSub}
+        onChange={handleBackupSubChange}
         items={[
           {
             key: 'todo',
-            label: 'Todo备份',
+            label: '事项备份',
             children: (
               <TodoBackupTab
                 todoBackupStatus={todoBackupStatus}
@@ -490,7 +508,6 @@ export function BackupPanel() {
                 onDeleteBackup={handleDeleteTodoBackup}
                 onDownloadBackupFile={handleDownloadTodoBackupFile}
                 onExportBackup={handleExportBackup}
-                onOpenExportModal={() => setExportModalOpen(true)}
                 onImportFile={handleImportFile}
               />
             ),
@@ -559,17 +576,10 @@ export function BackupPanel() {
         selectedRowKeys={selectedRowKeys}
         setSelectedRowKeys={setSelectedRowKeys}
         wizardItems={wizardItems}
-        exportModalOpen={exportModalOpen}
-        setExportModalOpen={setExportModalOpen}
-        handleExportSelected={handleExportSelected}
-        exportingSelected={exportingSelected}
-        exportTodoKeys={exportTodoKeys}
-        setExportTodoKeys={setExportTodoKeys}
-        todos={todos}
-        // 导入目标工作空间选择
+        // 逐行工作空间选择
         workspaces={workspaces}
-        importWorkspaceId={importWorkspaceId}
-        setImportWorkspaceId={setImportWorkspaceId}
+        rowWorkspaceMap={rowWorkspaceMap}
+        setRowWorkspaceId={setRowWorkspaceId}
         // 原始工作空间提示
         sourceWorkspaceInfo={sourceWorkspaceInfo}
       />

--- a/frontend/src/components/settings/BackupPanel.tsx
+++ b/frontend/src/components/settings/BackupPanel.tsx
@@ -100,6 +100,10 @@ export function BackupPanel() {
   const [workspaces, setWorkspaces] = useState<ProjectDirectory[]>([]);
   // 逐行工作空间选择：ImportItem.key → workspaceId（null=未匹配/待指定）
   const [rowWorkspaceMap, setRowWorkspaceMap] = useState<Record<number, number | null>>({});
+  // 当前库已有 todo：用于按「目标工作空间 + 标题 + prompt」动态判同名（对齐后端 merge_backup 判重口径）
+  const [existingTodos, setExistingTodos] = useState<{ title: string; prompt: string; workspace_id: number | null }[]>([]);
+  // 用户显式选「覆盖」的同名项 key（未在其中且同名的 = 默认跳过）
+  const [userOverwriteKeys, setUserOverwriteKeys] = useState<Set<number>>(new Set());
 
   // 导入来源工作空间检测（从备份文件中提取，用于预览提示）
   const [sourceWorkspaceInfo, setSourceWorkspaceInfo] = useState<{ id: number; path: string } | null>(null);
@@ -411,28 +415,26 @@ export function BackupPanel() {
       }
 
       const existingTodos = await db.getAllTodos();
-      const existingSet = new Set(existingTodos.map(t => `${t.title}\n${t.prompt}`));
+      setExistingTodos(existingTodos.map((t) => ({ title: t.title, prompt: t.prompt, workspace_id: t.workspace_id ?? null })));
+      // 用户覆盖选择按导入批次重置
+      setUserOverwriteKeys(new Set());
 
-      const items: ImportItem[] = data.todos.map((todo, idx) => {
-        const key = `${todo.title}\n${todo.prompt}`;
-        const exists = existingSet.has(key);
-        const existing = exists ? existingTodos.find(t => `${t.title}\n${t.prompt}` === key) : undefined;
-        return {
-          key: idx,
-          title: todo.title,
-          prompt: todo.prompt,
-          status: todo.status,
-          executor: todo.executor,
-          scheduler_enabled: todo.scheduler_enabled,
-          scheduler_config: todo.scheduler_config,
-          tag_names: todo.tag_names || [],
-          workspace_path: todo.workspace_path,
-          // 保留原始 workspace_id，供按行默认匹配与「来源」列展示
-          workspace_id: todo.workspace_id ?? null,
-          action: exists ? 'overwrite' as const : 'new' as const,
-          existingTitle: existing?.title,
-        };
-      });
+      // exists/action 不在此时静态判定：它们依赖用户逐行选定的目标工作空间，
+      // 改由下方的 itemsWithAction 动态派生（对齐后端 merge_backup 的判重口径）。
+      const items: ImportItem[] = data.todos.map((todo, idx) => ({
+        key: idx,
+        title: todo.title,
+        prompt: todo.prompt,
+        status: todo.status,
+        executor: todo.executor,
+        scheduler_enabled: todo.scheduler_enabled,
+        scheduler_config: todo.scheduler_config,
+        tag_names: todo.tag_names || [],
+        workspace_path: todo.workspace_path,
+        // 保留原始 workspace_id，供按行默认匹配与「来源」列展示
+        workspace_id: todo.workspace_id ?? null,
+        action: 'new',
+      }));
 
       setWizardTags(data.tags || []);
       setWizardItems(items);
@@ -459,20 +461,45 @@ export function BackupPanel() {
     return false;
   };
 
+  // 按「目标工作空间 + 标题 + prompt」动态派生每条的 exists/action，对齐后端 merge_backup：
+  // 同一目标工作空间内 title+prompt 命中 → 同名（默认跳过，userOverwriteKeys 里的为覆盖）；否则新建。
+  // 这样用户改某行工作空间后，该行是否同名会随之重算，避免跨工作空间误判同名导致「覆盖」变新建。
+  const itemsWithAction: ImportItem[] = wizardItems.map((it) => {
+    const targetWsId = rowWorkspaceMap[it.key] ?? 0; // null → 0（未分配哨兵，与后端一致）
+    const exists = existingTodos.some(
+      (t) => t.title === it.title && t.prompt === it.prompt && (t.workspace_id ?? 0) === targetWsId,
+    );
+    const action = exists ? (userOverwriteKeys.has(it.key) ? 'overwrite' : 'skip') : 'new';
+    return { ...it, exists, action };
+  });
+
+  // 同名项动作：选「覆盖」记入 userOverwriteKeys，选「跳过」移出（默认即跳过）
+  const setItemsAction = (keys: number[], action: 'overwrite' | 'skip') => {
+    setUserOverwriteKeys((prev) => {
+      const next = new Set(prev);
+      for (const k of keys) {
+        if (action === 'overwrite') next.add(k); else next.delete(k);
+      }
+      return next;
+    });
+  };
+
   const handleWizardConfirm = async () => {
-    if (selectedRowKeys.length === 0) {
-      message.warning('请至少选择一项');
+    // 实际将导入：已勾选 且 action 非 skip（skip 不提交）；action 取动态派生值
+    const willImport = itemsWithAction.filter(
+      (item) => selectedRowKeys.includes(item.key) && item.action !== 'skip',
+    );
+    if (willImport.length === 0) {
+      message.warning('没有可导入的项（选中的均为「跳过」）');
       return;
     }
     setImporting(true);
     try {
       // 每条 todo 注入用户逐行选定的工作空间；全局 target 传 null，由后端按每条 workspace_id 解析
-      const selectedTodos = wizardItems
-        .filter(item => selectedRowKeys.includes(item.key))
-        .map(({ key, action, existingTitle, ...todo }) => ({
-          ...todo,
-          workspace_id: rowWorkspaceMap[key] ?? null,
-        }));
+      const selectedTodos = willImport.map(({ key, action, existingTitle, exists, ...todo }) => ({
+        ...todo,
+        workspace_id: rowWorkspaceMap[key] ?? null,
+      }));
       const msg = await db.mergeBackup(wizardTags, selectedTodos, null);
       message.success(msg);
       setWizardOpen(false);
@@ -575,7 +602,9 @@ export function BackupPanel() {
         importing={importing}
         selectedRowKeys={selectedRowKeys}
         setSelectedRowKeys={setSelectedRowKeys}
-        wizardItems={wizardItems}
+        wizardItems={itemsWithAction}
+        // 同名项动作批量/逐条设置
+        setItemsAction={setItemsAction}
         // 逐行工作空间选择
         workspaces={workspaces}
         rowWorkspaceMap={rowWorkspaceMap}

--- a/frontend/src/components/settings/backup/ImportExportModals.tsx
+++ b/frontend/src/components/settings/backup/ImportExportModals.tsx
@@ -1,6 +1,7 @@
-import { Modal, Table, Tag as AntTag, Divider, Typography, Alert } from 'antd';
+import { Modal, Table, Tag as AntTag, Divider, Alert } from 'antd';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import type { ProjectDirectory } from '@/utils/database/todos';
+import { WorkspaceSwitcher } from '@/components/shell/WorkspaceSwitcher';
 
 export interface BackupDataYaml {
   version: string;
@@ -29,17 +30,22 @@ export interface ImportItem {
   scheduler_config?: string;
   tag_names: string[];
   workspace_path?: string;
+  /** 导出文件里的原始工作空间 ID，用于按行默认匹配与「来源」展示 */
+  workspace_id?: number | null;
   action: 'new' | 'overwrite';
   existingTitle?: string;
+}
+
+/** 按行判断原始工作空间是否在当前环境命中 */
+function isSourceMatched(item: ImportItem, workspaces: ProjectDirectory[]): boolean {
+  return item.workspace_id != null && workspaces.some((w) => w.id === item.workspace_id);
 }
 
 export function ImportExportModals({
   wizardOpen, setWizardOpen, handleWizardConfirm, importing,
   selectedRowKeys, setSelectedRowKeys, wizardItems,
-  exportModalOpen, setExportModalOpen, handleExportSelected,
-  exportingSelected, exportTodoKeys, setExportTodoKeys, todos,
-  // 导入目标工作空间选择
-  workspaces, importWorkspaceId, setImportWorkspaceId,
+  // 逐行工作空间选择
+  workspaces, rowWorkspaceMap, setRowWorkspaceId,
   // 原始工作空间提示（从备份文件检测到后展示，帮助用户判断）
   sourceWorkspaceInfo,
 }: {
@@ -50,20 +56,15 @@ export function ImportExportModals({
   selectedRowKeys: number[];
   setSelectedRowKeys: (keys: number[]) => void;
   wizardItems: ImportItem[];
-  exportModalOpen: boolean;
-  setExportModalOpen: (v: boolean) => void;
-  handleExportSelected: () => Promise<void>;
-  exportingSelected: boolean;
-  exportTodoKeys: number[];
-  setExportTodoKeys: (keys: number[]) => void;
-  todos: readonly any[];
-  // 导入目标工作空间选择
+  // 逐行工作空间选择：key → workspaceId（null=未指定，需用户手选）
   workspaces: ProjectDirectory[];
-  importWorkspaceId: number | null;
-  setImportWorkspaceId: (v: number | null) => void;
+  rowWorkspaceMap: Record<number, number | null>;
+  setRowWorkspaceId: (key: number, id: number | null) => void;
   // 原始工作空间提示（从备份文件检测到后展示，帮助用户判断）
   sourceWorkspaceInfo?: { id: number; path: string } | null;
 }) {
+  // OK gate：至少选一项，且每条已选 todo 都已指定工作空间（未匹配的必须手选）
+  const hasUnassigned = selectedRowKeys.some((k) => rowWorkspaceMap[k] == null);
   return (
     <>
       <Modal
@@ -74,8 +75,8 @@ export function ImportExportModals({
         okText={`导入 ${selectedRowKeys.length} 项`}
         cancelText="取消"
         confirmLoading={importing}
-        width={800}
-        okButtonProps={{ disabled: selectedRowKeys.length === 0 || !importWorkspaceId }}
+        width={900}
+        okButtonProps={{ disabled: selectedRowKeys.length === 0 || hasUnassigned }}
       >
         <div style={{ marginBottom: 12, display: 'flex', gap: 16 }}>
           <AntTag color="green">{wizardItems.filter(i => i.action === 'new').length} 个新建</AntTag>
@@ -91,12 +92,10 @@ export function ImportExportModals({
               message="检测到原始工作空间"
               description={
                 matched
-                  ? `该文件中的数据原本来自工作空间「${matched.name || matched.path}」${
-                      importWorkspaceId === sourceWorkspaceInfo.id ? '（已自动匹配）' : ''
-                    }`
+                  ? `该文件中的数据原本来自工作空间「${matched.name || matched.path}」，已按行自动匹配；可逐条点改`
                   : `该文件中的数据原本来自工作空间 ID=${sourceWorkspaceInfo.id}${
                       sourceWorkspaceInfo.path ? ` (${sourceWorkspaceInfo.path})` : ''
-                    }，当前环境未找到匹配的工作空间`
+                    }，当前环境未找到匹配的工作空间，请逐行指定`
               }
               type="info"
               showIcon
@@ -105,42 +104,6 @@ export function ImportExportModals({
             />
           );
         })()}
-
-        {/* 目标工作空间选择：表格形式总览，一行一个，点选某个 */}
-        <div style={{ marginBottom: 16 }}>
-          <Typography.Text strong>目标工作空间</Typography.Text>
-          <Typography.Paragraph type="secondary" style={{ margin: '4px 0 8px', fontSize: 12 }}>
-            选择导入后 Todo 所属的工作空间，此操作将覆盖备份文件中的原始工作空间信息
-          </Typography.Paragraph>
-          <Table
-            size="small"
-            pagination={false}
-            rowKey="id"
-            dataSource={workspaces}
-            rowSelection={{
-              type: 'radio',
-              selectedRowKeys: importWorkspaceId != null ? [importWorkspaceId] : [],
-              onChange: (keys) => {
-                if (keys.length > 0) setImportWorkspaceId(keys[0] as number);
-              },
-            }}
-            columns={[
-              {
-                title: '工作空间',
-                dataIndex: 'name',
-                width: '60%',
-                render: (_: unknown, r: ProjectDirectory) => r.name || r.path || '(未命名)',
-              },
-              {
-                title: '来源',
-                // 在 render 里直接判断是否为原始工作空间，不再往行对象注入 _isOriginal 字段，
-                // 避免污染从 API 拿到的 workspace 数据源。
-                render: (_: unknown, r: ProjectDirectory) =>
-                  sourceWorkspaceInfo?.id === r.id ? <AntTag color="blue">原始</AntTag> : null,
-              },
-            ]}
-          />
-        </div>
 
         <Divider style={{ margin: '12px 0' }} />
 
@@ -159,12 +122,12 @@ export function ImportExportModals({
               title: '标题',
               dataIndex: 'title',
               ellipsis: true,
-              width: '35%',
+              width: '22%',
             },
             {
               title: '状态',
               dataIndex: 'action',
-              width: 80,
+              width: 70,
               render: (action: 'new' | 'overwrite') => (
                 <AntTag color={action === 'new' ? 'green' : 'orange'}>
                   {action === 'new' ? '新建' : '覆盖'}
@@ -172,15 +135,39 @@ export function ImportExportModals({
               ),
             },
             {
+              title: '工作空间',
+              width: 180,
+              // 逐行工作空间选择：默认按原 id 匹配，匹配不上为 null（未匹配），可点改
+              render: (_: unknown, r: ImportItem) => (
+                <WorkspaceSwitcher
+                  dirs={workspaces}
+                  value={rowWorkspaceMap[r.key] ?? null}
+                  showAddOption={false}
+                  onChange={(id) => setRowWorkspaceId(r.key, id)}
+                />
+              ),
+            },
+            {
+              title: '来源',
+              width: 80,
+              // 原始工作空间命中→「原始」；有原 id 但当前库不存在→「未匹配」；无原 id→'-'
+              render: (_: unknown, r: ImportItem) => {
+                if (r.workspace_id == null) return '-';
+                return isSourceMatched(r, workspaces)
+                  ? <AntTag color="blue">原始</AntTag>
+                  : <AntTag color="red">未匹配</AntTag>;
+              },
+            },
+            {
               title: '执行器',
               dataIndex: 'executor',
-              width: 100,
+              width: 90,
               render: (v: string | undefined) => v || '-',
             },
             {
               title: '标签',
               dataIndex: 'tag_names',
-              width: 150,
+              width: 120,
               render: (names: string[]) => names.length > 0
                 ? names.slice(0, 3).map(n => <AntTag key={n}>{n}</AntTag>)
                 : '-',
@@ -189,59 +176,7 @@ export function ImportExportModals({
               title: 'Prompt 摘要',
               dataIndex: 'prompt',
               ellipsis: true,
-              render: (v: string) => v ? v.slice(0, 60) + (v.length > 60 ? '...' : '') : '-',
-            },
-          ]}
-        />
-      </Modal>
-
-      <Modal
-        title="选择性导出"
-        open={exportModalOpen}
-        onCancel={() => setExportModalOpen(false)}
-        onOk={handleExportSelected}
-        okText={`导出 ${exportTodoKeys.length} 项`}
-        cancelText="取消"
-        confirmLoading={exportingSelected}
-        width={700}
-        okButtonProps={{ disabled: exportTodoKeys.length === 0 }}
-      >
-        <Table
-          dataSource={todos}
-          rowKey="id"
-          size="small"
-          pagination={{ pageSize: 50 }}
-          scroll={{ y: 400 }}
-          rowSelection={{
-            selectedRowKeys: exportTodoKeys,
-            onChange: (keys) => setExportTodoKeys(keys as number[]),
-          }}
-          columns={[
-            {
-              title: '标题',
-              dataIndex: 'title',
-              ellipsis: true,
-            },
-            {
-              title: '执行器',
-              dataIndex: 'executor',
-              width: 100,
-              render: (v: string | undefined) => v || '-',
-            },
-            {
-              title: '状态',
-              dataIndex: 'status',
-              width: 80,
-              render: (v: string) => {
-                const map: Record<string, { color: string; label: string }> = {
-                  pending: { color: 'default', label: '待办' },
-                  running: { color: 'processing', label: '进行中' },
-                  completed: { color: 'success', label: '完成' },
-                  failed: { color: 'error', label: '失败' },
-                };
-                const s = map[v] || { color: 'default', label: v };
-                return <AntTag color={s.color}>{s.label}</AntTag>;
-              },
+              render: (v: string) => v ? v.slice(0, 40) + (v.length > 40 ? '...' : '') : '-',
             },
           ]}
         />

--- a/frontend/src/components/settings/backup/ImportExportModals.tsx
+++ b/frontend/src/components/settings/backup/ImportExportModals.tsx
@@ -1,4 +1,4 @@
-import { Modal, Table, Tag as AntTag, Divider, Alert } from 'antd';
+import { Modal, Table, Tag as AntTag, Divider, Alert, Select, Button } from 'antd';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import type { ProjectDirectory } from '@/utils/database/todos';
 import { WorkspaceSwitcher } from '@/components/shell/WorkspaceSwitcher';
@@ -32,7 +32,9 @@ export interface ImportItem {
   workspace_path?: string;
   /** 导出文件里的原始工作空间 ID，用于按行默认匹配与「来源」展示 */
   workspace_id?: number | null;
-  action: 'new' | 'overwrite';
+  /** 同名已存在：true 时该条可在「覆盖/跳过」间切换；false 为纯新建 */
+  exists?: boolean;
+  action: 'new' | 'overwrite' | 'skip';
   existingTitle?: string;
 }
 
@@ -44,6 +46,8 @@ function isSourceMatched(item: ImportItem, workspaces: ProjectDirectory[]): bool
 export function ImportExportModals({
   wizardOpen, setWizardOpen, handleWizardConfirm, importing,
   selectedRowKeys, setSelectedRowKeys, wizardItems,
+  // 同名项动作批量/逐条设置（覆盖/跳过）
+  setItemsAction,
   // 逐行工作空间选择
   workspaces, rowWorkspaceMap, setRowWorkspaceId,
   // 原始工作空间提示（从备份文件检测到后展示，帮助用户判断）
@@ -56,6 +60,8 @@ export function ImportExportModals({
   selectedRowKeys: number[];
   setSelectedRowKeys: (keys: number[]) => void;
   wizardItems: ImportItem[];
+  // 同名项动作批量/逐条设置（覆盖/跳过）
+  setItemsAction: (keys: number[], action: 'overwrite' | 'skip') => void;
   // 逐行工作空间选择：key → workspaceId（null=未指定，需用户手选）
   workspaces: ProjectDirectory[];
   rowWorkspaceMap: Record<number, number | null>;
@@ -63,8 +69,15 @@ export function ImportExportModals({
   // 原始工作空间提示（从备份文件检测到后展示，帮助用户判断）
   sourceWorkspaceInfo?: { id: number; path: string } | null;
 }) {
-  // OK gate：至少选一项，且每条已选 todo 都已指定工作空间（未匹配的必须手选）
-  const hasUnassigned = selectedRowKeys.some((k) => rowWorkspaceMap[k] == null);
+  // 同名项 keys（exists=true）：批量按钮与可编辑「同名处理」列的作用范围
+  const sameNameKeys = wizardItems.filter((i) => i.exists).map((i) => i.key);
+  // 实际将导入的项：已勾选 且 action 非 skip（skip 一律不提交）
+  const willImportItems = wizardItems.filter(
+    (i) => selectedRowKeys.includes(i.key) && i.action !== 'skip',
+  );
+  const willImportCount = willImportItems.length;
+  // OK gate：至少有一项将导入，且每条将导入的 todo 都已指定工作空间
+  const hasUnassigned = willImportItems.some((i) => rowWorkspaceMap[i.key] == null);
   return (
     <>
       <Modal
@@ -72,16 +85,19 @@ export function ImportExportModals({
         open={wizardOpen}
         onCancel={() => setWizardOpen(false)}
         onOk={handleWizardConfirm}
-        okText={`导入 ${selectedRowKeys.length} 项`}
+        okText={`导入 ${willImportCount} 项`}
         cancelText="取消"
         confirmLoading={importing}
         width={900}
-        okButtonProps={{ disabled: selectedRowKeys.length === 0 || hasUnassigned }}
+        okButtonProps={{ disabled: willImportCount === 0 || hasUnassigned }}
       >
-        <div style={{ marginBottom: 12, display: 'flex', gap: 16 }}>
-          <AntTag color="green">{wizardItems.filter(i => i.action === 'new').length} 个新建</AntTag>
-          <AntTag color="orange">{wizardItems.filter(i => i.action === 'overwrite').length} 个覆盖</AntTag>
-          <AntTag color="blue">已选 {selectedRowKeys.length} 项</AntTag>
+        <div style={{ marginBottom: 12, display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+          <AntTag color="green">{wizardItems.filter(i => i.action === 'new').length} 新建</AntTag>
+          <AntTag color="orange">{wizardItems.filter(i => i.action === 'overwrite').length} 覆盖</AntTag>
+          <AntTag>{wizardItems.filter(i => i.action === 'skip').length} 跳过</AntTag>
+          <AntTag color="blue">将导入 {willImportCount} 项</AntTag>
+          <Button size="small" disabled={sameNameKeys.length === 0} onClick={() => setItemsAction(sameNameKeys, 'overwrite')}>同名全覆盖</Button>
+          <Button size="small" disabled={sameNameKeys.length === 0} onClick={() => setItemsAction(sameNameKeys, 'skip')}>同名全跳过</Button>
         </div>
 
         {/* 原始工作空间提示：检测到备份文件中的工作空间后，显示给用户参考 */}
@@ -125,14 +141,24 @@ export function ImportExportModals({
               width: '22%',
             },
             {
-              title: '状态',
-              dataIndex: 'action',
-              width: 70,
-              render: (action: 'new' | 'overwrite') => (
-                <AntTag color={action === 'new' ? 'green' : 'orange'}>
-                  {action === 'new' ? '新建' : '覆盖'}
-                </AntTag>
-              ),
+              title: '同名处理',
+              width: 104,
+              // 同名项(exists)可在「覆盖/跳过」间切换；纯新建项固定显示「新建」
+              render: (_: unknown, r: ImportItem) =>
+                r.exists ? (
+                  <Select
+                    size="small"
+                    value={r.action === 'overwrite' ? 'overwrite' : 'skip'}
+                    onChange={(v) => setItemsAction([r.key], v as 'overwrite' | 'skip')}
+                    style={{ width: 96 }}
+                    options={[
+                      { value: 'overwrite', label: '覆盖' },
+                      { value: 'skip', label: '跳过' },
+                    ]}
+                  />
+                ) : (
+                  <AntTag color="green">新建</AntTag>
+                ),
             },
             {
               title: '工作空间',

--- a/frontend/src/components/settings/backup/LoopBackupTab.tsx
+++ b/frontend/src/components/settings/backup/LoopBackupTab.tsx
@@ -1,4 +1,4 @@
-import { Card, Button, Typography, Upload, Space, Modal, Tag, Alert, message, Table, Divider } from 'antd';
+import { Card, Button, Typography, Upload, Space, Modal, Tag, Alert, message, Table, Divider, Select } from 'antd';
 import { DownloadOutlined, InboxOutlined } from '@ant-design/icons';
 import { useState } from 'react';
 import * as db from '@/utils/database';
@@ -19,12 +19,28 @@ export function LoopBackupTab() {
   const [workspaces, setWorkspaces] = useState<ProjectDirectory[]>([]);
   // 逐 loop 工作空间选择：loop name → workspaceId（null=未匹配/待指定）
   const [loopWorkspaceMap, setLoopWorkspaceMap] = useState<Record<string, number | null>>({});
-  // 当前库已有 loop 名集合，供「状态」列判断新建/覆盖（对齐 Todo 用已有 todo 判定 action）
+  // 当前库已有 loop 名集合，供「同名处理」列判断新建/同名（对齐 Todo 用已有 todo 判定 action）
   const [existingLoopNames, setExistingLoopNames] = useState<Set<string>>(new Set());
+  // 同名 loop 的导入动作：loop name → 'overwrite' | 'skip'（默认 skip，避免误覆盖）；新建 loop 不入此表
+  const [loopActionMap, setLoopActionMap] = useState<Record<string, 'overwrite' | 'skip'>>({});
 
   // 设置某条 loop 的目标工作空间（供 per-loop 表回写）
   const setLoopWorkspace = (name: string, id: number | null) => {
     setLoopWorkspaceMap((prev) => ({ ...prev, [name]: id }));
+  };
+
+  // 设置某条同名 loop 的导入动作（覆盖/跳过）；setBulkLoopAction 批量作用于全部同名 loop
+  const setLoopAction = (name: string, action: 'overwrite' | 'skip') => {
+    setLoopActionMap((prev) => ({ ...prev, [name]: action }));
+  };
+  const setBulkLoopAction = (action: 'overwrite' | 'skip') => {
+    setLoopActionMap((prev) => {
+      const next = { ...prev };
+      for (const l of previewData?.loops ?? []) {
+        if (existingLoopNames.has(l.name)) next[l.name] = action;
+      }
+      return next;
+    });
   };
 
   // 导出全库所有环路为单个 YAML（对齐 Todo「导出全部」）
@@ -73,6 +89,13 @@ export function LoopBackupTab() {
         wsMap[l.name] = l.source_matched ? l.resolved_workspace_id : null;
       }
       setLoopWorkspaceMap(wsMap);
+      // 同名 loop 默认「跳过」（保守，避免误覆盖）；用户可逐条或批量改为「覆盖」
+      const actionMap: Record<string, 'overwrite' | 'skip'> = {};
+      const existing = new Set(loops.map((l) => l.name));
+      for (const l of preview.loops) {
+        if (existing.has(l.name)) actionMap[l.name] = 'skip';
+      }
+      setLoopActionMap(actionMap);
       setImportModalOpen(true);
     } catch (err) {
       message.error('解析文件失败: ' + (err instanceof Error ? err.message : String(err)));
@@ -80,27 +103,34 @@ export function LoopBackupTab() {
     return false;
   };
 
-  // 执行导入——单一覆盖语义（同名覆盖、否则新建），对齐 Todo
+  // 执行导入——同名按用户动作（覆盖/跳过，默认跳过），否则新建；对齐 Todo
   const handleConfirmImport = async () => {
     if (!yamlPreview || !previewData) {
       return;
     }
-    // gate：每条 loop 都必须已指定工作空间（未匹配的需用户手选）
-    const unassigned = previewData.loops.filter((l) => loopWorkspaceMap[l.name] == null);
+    // 收集「跳过」的同名 loop 名（默认 skip；用户改为 overwrite 的不计入）
+    const skipNames = previewData.loops
+      .filter((l) => existingLoopNames.has(l.name) && (loopActionMap[l.name] ?? 'skip') === 'skip')
+      .map((l) => l.name);
+    const skipSet = new Set(skipNames);
+    // gate：仅对「非跳过」的 loop 要求指定工作空间（跳过的不导入，无需归属）
+    const unassigned = previewData.loops.filter(
+      (l) => !skipSet.has(l.name) && loopWorkspaceMap[l.name] == null,
+    );
     if (unassigned.length > 0) {
       message.warning(`以下环路未指定工作空间: ${unassigned.map((l) => l.name).join(', ')}`);
       return;
     }
-    // 构造 per-loop overrides（仅含已指定的非空项），全局 workspace_id 传 null
+    // 构造 per-loop overrides（仅含非跳过且已指定的项），全局 workspace_id 传 null
     const overrides: Record<string, number> = {};
     for (const [name, id] of Object.entries(loopWorkspaceMap)) {
-      if (id != null) overrides[name] = id;
+      if (id != null && !skipSet.has(name)) overrides[name] = id;
     }
     setImporting(true);
     try {
-      const result = await db.mergeLoops(yamlPreview, null, overrides);
+      const result = await db.mergeLoops(yamlPreview, null, overrides, skipNames);
       message.success(
-        `导入完成：新建 ${result.created.loops} 个，更新 ${result.updated?.loops || 0} 个`
+        `导入完成：新建 ${result.created.loops} 个，更新 ${result.updated?.loops || 0} 个，跳过 ${result.skipped?.length || 0} 个`
       );
       setImportModalOpen(false);
       setYamlPreview(null);
@@ -117,14 +147,25 @@ export function LoopBackupTab() {
   const loopWsColumns = [
     { title: '环路', dataIndex: 'name', key: 'name', width: 120 },
     {
-      title: '状态',
+      title: '同名处理',
       key: 'status',
-      width: 70,
-      // 当前库已有同名 loop → 覆盖，否则新建（对齐 Todo 的 action 判定）
+      width: 104,
+      // 同名 loop 可在「覆盖/跳过」间切换（默认跳过）；纯新建 loop 固定显示「新建」
       render: (_: unknown, r: { name: string }) =>
-        existingLoopNames.has(r.name)
-          ? <Tag color="orange">覆盖</Tag>
-          : <Tag color="green">新建</Tag>,
+        existingLoopNames.has(r.name) ? (
+          <Select
+            size="small"
+            value={loopActionMap[r.name] ?? 'skip'}
+            onChange={(v) => setLoopAction(r.name, v)}
+            style={{ width: 96 }}
+            options={[
+              { value: 'overwrite', label: '覆盖' },
+              { value: 'skip', label: '跳过' },
+            ]}
+          />
+        ) : (
+          <Tag color="green">新建</Tag>
+        ),
     },
     {
       title: '工作空间',
@@ -148,8 +189,17 @@ export function LoopBackupTab() {
     },
   ];
 
-  // OK gate：任一 loop 未指定工作空间则禁用
-  const hasUnassignedLoop = (previewData?.loops ?? []).some((l) => loopWorkspaceMap[l.name] == null);
+  // 派生：同名 loop / 各动作计数 / 将跳过集合——批量按钮与 gate 复用
+  const loops = previewData?.loops ?? [];
+  const sameNameLoops = loops.filter((l) => existingLoopNames.has(l.name));
+  const sameNameLoopNames = sameNameLoops.map((l) => l.name);
+  const isOverwrite = (name: string) => existingLoopNames.has(name) && loopActionMap[name] === 'overwrite';
+  const newCount = loops.length - sameNameLoops.length;
+  const overwriteCount = sameNameLoops.filter((l) => isOverwrite(l.name)).length;
+  const skipCount = sameNameLoops.length - overwriteCount;
+  const skipNameSet = new Set(sameNameLoops.filter((l) => !isOverwrite(l.name)).map((l) => l.name));
+  // OK gate：任一「非跳过」loop 未指定工作空间则禁用
+  const hasUnassignedLoop = loops.some((l) => !skipNameSet.has(l.name) && loopWorkspaceMap[l.name] == null);
 
   return (
     <div style={{ maxWidth: 600 }}>
@@ -210,7 +260,15 @@ export function LoopBackupTab() {
       >
         {previewData && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-            {/* per-loop 工作空间指派 + 状态（新建/覆盖）：默认按原 id 匹配，可逐条点改 */}
+            {/* 同名处理统计 + 批量动作 */}
+            <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+              <Tag color="green">{newCount} 新建</Tag>
+              <Tag color="orange">{overwriteCount} 覆盖</Tag>
+              <Tag>{skipCount} 跳过</Tag>
+              <Button size="small" disabled={sameNameLoopNames.length === 0} onClick={() => setBulkLoopAction('overwrite')}>同名全覆盖</Button>
+              <Button size="small" disabled={sameNameLoopNames.length === 0} onClick={() => setBulkLoopAction('skip')}>同名全跳过</Button>
+            </div>
+            {/* per-loop 工作空间指派 + 同名处理（默认跳过）：默认按原 id 匹配，可逐条点改 */}
             <div>
               <Typography.Text strong>环路工作空间（逐条）</Typography.Text>
               <Table

--- a/frontend/src/components/settings/backup/LoopBackupTab.tsx
+++ b/frontend/src/components/settings/backup/LoopBackupTab.tsx
@@ -1,81 +1,54 @@
-import { Card, Button, Typography, Upload, Select, Space, Modal, Tag, Alert, message, Radio, Table, Divider } from 'antd';
+import { Card, Button, Typography, Upload, Space, Modal, Tag, Alert, message, Table, Divider } from 'antd';
 import { DownloadOutlined, InboxOutlined } from '@ant-design/icons';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import * as db from '@/utils/database';
-import { exportLoop, listLoops } from '@/utils/database/loops';
+import { listLoops, exportAllLoops } from '@/utils/database/loops';
 import { LoopImportPreview } from '@/utils/database/backup';
 import type { ProjectDirectory } from '@/utils/database/todos';
-import yaml from 'js-yaml';
+import { WorkspaceSwitcher } from '@/components/shell/WorkspaceSwitcher';
 
 const { Dragger } = Upload;
-const { Group: RadioGroup, Button: RadioButton } = Radio;
-
-type ImportMode = 'create' | 'merge';
-type ConflictAction = 'rename' | 'overwrite' | 'skip';
 
 export function LoopBackupTab() {
-  const [selectedLoopId, setSelectedLoopId] = useState<number | null>(null);
   const [exporting, setExporting] = useState(false);
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [yamlPreview, setYamlPreview] = useState<string | null>(null);
   const [previewData, setPreviewData] = useState<LoopImportPreview | null>(null);
   const [importing, setImporting] = useState(false);
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<number | null>(null);
+  // 工作空间列表（父组件加载一次，下发给每行 WorkspaceSwitcher 复用）
   const [workspaces, setWorkspaces] = useState<ProjectDirectory[]>([]);
-  const [loops, setLoops] = useState<any[]>([]);
-  // 导入模式：create=新建模式（默认），merge=合并模式
-  const [importMode, setImportMode] = useState<ImportMode>('create');
-  // 冲突解决映射：loop_name -> action
-  const [conflictResolutions, setConflictResolutions] = useState<Record<string, ConflictAction>>({});
+  // 逐 loop 工作空间选择：loop name → workspaceId（null=未匹配/待指定）
+  const [loopWorkspaceMap, setLoopWorkspaceMap] = useState<Record<string, number | null>>({});
+  // 当前库已有 loop 名集合，供「状态」列判断新建/覆盖（对齐 Todo 用已有 todo 判定 action）
+  const [existingLoopNames, setExistingLoopNames] = useState<Set<string>>(new Set());
 
-  // 加载环路列表
-  useEffect(() => {
-    listLoops().then(setLoops).catch(() => {});
-  }, []);
-
-  // 加载工作空间列表，优先匹配导出文件中的原始工作空间
-  const loadWorkspaces = async (preferredId?: number | null) => {
-    try {
-      const ws = await db.getProjectDirectories();
-      setWorkspaces(ws);
-      if (preferredId != null && ws.some((w) => w.id === preferredId)) {
-        // 导出文件中检测到了原始工作空间且当前列表中能找到，默认选中它
-        setSelectedWorkspaceId(preferredId);
-      } else if (ws.length > 0 && !selectedWorkspaceId) {
-        // 无匹配时退化为选中第一个
-        setSelectedWorkspaceId(ws[0].id);
-      }
-    } catch (e) {
-      console.error('Failed to load workspaces', e);
-    }
+  // 设置某条 loop 的目标工作空间（供 per-loop 表回写）
+  const setLoopWorkspace = (name: string, id: number | null) => {
+    setLoopWorkspaceMap((prev) => ({ ...prev, [name]: id }));
   };
 
-  // 导出单个环路
-  const handleExportLoop = async (loopId: number) => {
+  // 导出全库所有环路为单个 YAML（对齐 Todo「导出全部」）
+  const handleExportAll = async () => {
     setExporting(true);
     try {
-      const yaml = await exportLoop(loopId);
-      const blob = new Blob([yaml], { type: 'application/x-yaml' });
+      const yamlText = await exportAllLoops();
+      const blob = new Blob([yamlText], { type: 'application/x-yaml' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      const loop = loops.find((l: any) => l.id === loopId);
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-      a.download = `${loop?.name || 'loop'}-${timestamp}.loop.yaml`;
+      a.download = `loops-export-${timestamp}.loop.yaml`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
       message.success('环路导出成功');
-    } catch (err: any) {
-      message.error(err?.message || '导出失败');
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '导出失败');
     } finally {
       setExporting(false);
     }
   };
-
-  // 检测到的原始工作空间信息（从导出文件中提取，供预览提示用）
-  const [sourceWorkspaceInfo, setSourceWorkspaceInfo] = useState<{ id: number; path: string } | null>(null);
 
   // 导入文件解析
   const handleImportFile = async (file: File) => {
@@ -85,124 +58,114 @@ export function LoopBackupTab() {
       setYamlPreview(text);
       setPreviewData(preview);
 
-      // 从 YAML 中提取导出时的工作空间信息，用于预览提示
-      // 读取第一个 todo 或 loop 的 workspace_id/workspace_path，让用户知道原始来源
-      // 用局部变量 parsedSourceId 暂存，避免直接读 state：本函数内 setSourceWorkspaceInfo
-      // 触发的重渲染尚未发生，读 sourceWorkspaceInfo 拿到的是上一帧的过期值，会导致首次
-      // 导入时无法自动选中原始工作空间。
-      let parsedSourceId: number | null = null;
-      try {
-        const parsed: any = yaml.load(text);
-        // 用 ?? 而非 ||：workspace_id=0 或 workspace_path="" 是合法的 falsy 值，
-        // || 会错误地跳过它们回退到 loops 条目；?? 只在 null/undefined 时回退。
-        const sourceId = parsed?.todos?.[0]?.workspace_id ?? parsed?.loops?.[0]?.workspace_id;
-        const sourcePath = parsed?.todos?.[0]?.workspace_path ?? parsed?.loops?.[0]?.workspace_path;
-        if (sourceId != null) {
-          parsedSourceId = Number(sourceId);
-          setSourceWorkspaceInfo({ id: parsedSourceId, path: sourcePath || '' });
-        } else {
-          setSourceWorkspaceInfo(null);
-        }
-      } catch {
-        // YAML 解析失败不影响整体流程，静默忽略
-        setSourceWorkspaceInfo(null);
-      }
+      // 并行加载工作空间列表 + 当前库已有 loop 名（后者用于「状态」列）
+      const [ws, loops] = await Promise.all([
+        db.getProjectDirectories(),
+        listLoops(),
+      ]);
+      setWorkspaces(ws);
+      setExistingLoopNames(new Set(loops.map((l) => l.name)));
 
-      // 初始化冲突解决策略：默认重命名
-      const resolutions: Record<string, ConflictAction> = {};
-      if (preview.conflicts) {
-        for (const c of preview.conflicts) {
-          resolutions[c.name] = 'rename';
-        }
+      // 按预览里的 per-loop 匹配情况初始化默认归属：
+      // 原工作空间命中→原 id，否则 null（未匹配，需用户逐条指定）
+      const wsMap: Record<string, number | null> = {};
+      for (const l of preview.loops) {
+        wsMap[l.name] = l.source_matched ? l.resolved_workspace_id : null;
       }
-      setConflictResolutions(resolutions);
-      // 加载工作空间列表时传入检测到的原始 workspace ID，优先匹配
-      await loadWorkspaces(parsedSourceId);
+      setLoopWorkspaceMap(wsMap);
       setImportModalOpen(true);
-    } catch (err: any) {
-      message.error('解析文件失败: ' + (err?.message || String(err)));
+    } catch (err) {
+      message.error('解析文件失败: ' + (err instanceof Error ? err.message : String(err)));
     }
     return false;
   };
 
-  // 更新单个冲突的解决策略
-  const updateConflictResolution = (name: string, action: ConflictAction) => {
-    setConflictResolutions(prev => ({ ...prev, [name]: action }));
-  };
-
-  // 执行导入
+  // 执行导入——单一覆盖语义（同名覆盖、否则新建），对齐 Todo
   const handleConfirmImport = async () => {
-    if (!yamlPreview || !selectedWorkspaceId) {
-      message.warning('请选择目标工作空间');
+    if (!yamlPreview || !previewData) {
       return;
+    }
+    // gate：每条 loop 都必须已指定工作空间（未匹配的需用户手选）
+    const unassigned = previewData.loops.filter((l) => loopWorkspaceMap[l.name] == null);
+    if (unassigned.length > 0) {
+      message.warning(`以下环路未指定工作空间: ${unassigned.map((l) => l.name).join(', ')}`);
+      return;
+    }
+    // 构造 per-loop overrides（仅含已指定的非空项），全局 workspace_id 传 null
+    const overrides: Record<string, number> = {};
+    for (const [name, id] of Object.entries(loopWorkspaceMap)) {
+      if (id != null) overrides[name] = id;
     }
     setImporting(true);
     try {
-      if (importMode === 'merge') {
-        const result = await db.mergeLoops(yamlPreview, selectedWorkspaceId, conflictResolutions);
-        message.success(
-          `导入完成：新建 ${result.created.loops} 个，更新 ${result.updated?.loops || 0} 个，跳过 ${result.skipped?.length || 0} 个`
-        );
-      } else {
-        const result = await db.importLoops(yamlPreview, selectedWorkspaceId);
-        message.success(`导入成功：创建了 ${result.created.loops} 个环路`);
-      }
+      const result = await db.mergeLoops(yamlPreview, null, overrides);
+      message.success(
+        `导入完成：新建 ${result.created.loops} 个，更新 ${result.updated?.loops || 0} 个`
+      );
       setImportModalOpen(false);
       setYamlPreview(null);
       setPreviewData(null);
       window.location.reload();
-    } catch (err: any) {
-      message.error(err?.message || '导入失败');
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '导入失败');
     } finally {
       setImporting(false);
     }
   };
 
-  const loopOptions = loops.map((l: any) => ({ label: l.name, value: l.id }));
-
-  const conflictColumns = [
-    { title: '环路名称', dataIndex: 'name', key: 'name' },
+  // per-loop 工作空间表列：环路 | 状态(新建/覆盖) | 工作空间 | 来源
+  const loopWsColumns = [
+    { title: '环路', dataIndex: 'name', key: 'name', width: 120 },
     {
-      title: '解决策略',
-      dataIndex: 'action',
-      render: (_: any, record: any) => (
-        <RadioGroup
-          value={conflictResolutions[record.name] || 'rename'}
-          onChange={e => updateConflictResolution(record.name, e.target.value)}
-          size="small"
-        >
-          <RadioButton value="rename">重命名</RadioButton>
-          <RadioButton value="overwrite">覆盖</RadioButton>
-          <RadioButton value="skip">跳过</RadioButton>
-        </RadioGroup>
+      title: '状态',
+      key: 'status',
+      width: 70,
+      // 当前库已有同名 loop → 覆盖，否则新建（对齐 Todo 的 action 判定）
+      render: (_: unknown, r: { name: string }) =>
+        existingLoopNames.has(r.name)
+          ? <Tag color="orange">覆盖</Tag>
+          : <Tag color="green">新建</Tag>,
+    },
+    {
+      title: '工作空间',
+      key: 'ws',
+      width: 200,
+      render: (_: unknown, r: { name: string }) => (
+        <WorkspaceSwitcher
+          dirs={workspaces}
+          value={loopWorkspaceMap[r.name] ?? null}
+          showAddOption={false}
+          onChange={(id) => setLoopWorkspace(r.name, id)}
+        />
       ),
     },
+    {
+      title: '来源',
+      key: 'source',
+      width: 80,
+      render: (_: unknown, r: { source_matched: boolean }) =>
+        r.source_matched ? <Tag color="blue">原始</Tag> : <Tag color="red">未匹配</Tag>,
+    },
   ];
+
+  // OK gate：任一 loop 未指定工作空间则禁用
+  const hasUnassignedLoop = (previewData?.loops ?? []).some((l) => loopWorkspaceMap[l.name] == null);
 
   return (
     <div style={{ maxWidth: 600 }}>
       <Card title="导出环路" size="small" style={{ marginBottom: 24 }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           <Typography.Paragraph type="secondary">
-            将环路导出为 .loop.yaml 文件，方便迁移和分享
+            将全库所有环路导出为 .loop.yaml 文件，方便迁移和分享
           </Typography.Paragraph>
-          <Select
-            placeholder="选择一个环路"
-            options={loopOptions}
-            value={selectedLoopId}
-            onChange={setSelectedLoopId}
-            style={{ width: '100%' }}
-            allowClear
-          />
           <Button
             type="primary"
             icon={<DownloadOutlined />}
-            onClick={() => selectedLoopId && handleExportLoop(selectedLoopId)}
+            onClick={handleExportAll}
             loading={exporting}
-            disabled={!selectedLoopId}
             style={{ width: '100%' }}
           >
-            导出选中环路
+            导出全部环路
           </Button>
         </div>
       </Card>
@@ -210,44 +173,8 @@ export function LoopBackupTab() {
       <Card title="导入环路" size="small" style={{ marginBottom: 24 }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           <Typography.Paragraph type="secondary">
-            从 .loop.yaml 文件导入环路，先选择目标工作空间，再上传文件
+            从 .loop.yaml 文件导入环路；解析后可逐条 loop 指定目标工作空间
           </Typography.Paragraph>
-          {/* 目标工作空间选择：表格形式总览所有工作空间，一行一个，点选某个 */}
-          <div>
-            <Typography.Text strong style={{ fontSize: 13 }}>目标工作空间</Typography.Text>
-            <Table
-              size="small"
-              pagination={false}
-              rowKey="id"
-              dataSource={workspaces}
-              rowSelection={{
-                type: 'radio',
-                selectedRowKeys: selectedWorkspaceId != null ? [selectedWorkspaceId] : [],
-                onChange: (keys) => {
-                  if (keys.length > 0) setSelectedWorkspaceId(keys[0] as number);
-                },
-              }}
-              columns={[
-                {
-                  title: '工作空间',
-                  dataIndex: 'name',
-                  width: '60%',
-                  render: (_: any, r: ProjectDirectory) => r.name || r.path || '(未命名)',
-                },
-                {
-                  title: '来源',
-                  // 直接在 render 里判断是否为原始工作空间，不再往行对象里注入 _isOriginal 字段，
-                  // 避免污染从 API 拿到的 workspace 数据源。
-                  render: (_: any, r: ProjectDirectory) =>
-                    sourceWorkspaceInfo?.id === r.id ? <Tag color="blue">原始</Tag> : null,
-                },
-              ]}
-              style={{ marginTop: 4 }}
-            />
-            <Typography.Paragraph type="secondary" style={{ margin: '4px 0 0', fontSize: 11 }}>
-              选择导入后环路的 Todo 和 Loop 所属的工作空间
-            </Typography.Paragraph>
-          </div>
           <Dragger
             accept=".yaml,.yml,.loop.yaml"
             beforeUpload={handleImportFile}
@@ -258,7 +185,7 @@ export function LoopBackupTab() {
               <InboxOutlined style={{ color: '#0891b2' }} />
             </p>
             <p className="ant-upload-text">点击或拖拽 .loop.yaml 文件到此处</p>
-            <p className="ant-upload-hint">将解析文件并展示预览，确认后导入到选中的工作空间</p>
+            <p className="ant-upload-hint">将解析文件并展示预览，逐条指派工作空间后导入</p>
           </Dragger>
         </div>
       </Card>
@@ -273,43 +200,25 @@ export function LoopBackupTab() {
             key="import"
             type="primary"
             loading={importing}
-            disabled={!selectedWorkspaceId}
+            disabled={hasUnassignedLoop}
             onClick={handleConfirmImport}
           >
             确认导入
           </Button>,
         ]}
-        width={700}
+        width={780}
       >
         {previewData && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-            {/* 目标工作空间选择：表格形式总览，一行一个，点选某个，Tag 标记原始来源 */}
+            {/* per-loop 工作空间指派 + 状态（新建/覆盖）：默认按原 id 匹配，可逐条点改 */}
             <div>
-              <Typography.Text strong>目标工作空间</Typography.Text>
+              <Typography.Text strong>环路工作空间（逐条）</Typography.Text>
               <Table
                 size="small"
                 pagination={false}
-                rowKey="id"
-                dataSource={workspaces}
-                rowSelection={{
-                  type: 'radio',
-                  selectedRowKeys: selectedWorkspaceId != null ? [selectedWorkspaceId] : [],
-                  onChange: (keys) => {
-                    if (keys.length > 0) setSelectedWorkspaceId(keys[0] as number);
-                  },
-                }}
-                columns={[
-                  {
-                    title: '工作空间',
-                    dataIndex: 'name',
-                    render: (_: any, r: ProjectDirectory) => r.name || r.path || '(未命名)',
-                  },
-                  {
-                    title: '来源',
-                    render: (_: any, r: ProjectDirectory) =>
-                      sourceWorkspaceInfo?.id === r.id ? <Tag color="blue">原始</Tag> : null,
-                  },
-                ]}
+                rowKey="name"
+                dataSource={previewData.loops}
+                columns={loopWsColumns}
                 style={{ marginTop: 4 }}
               />
             </div>
@@ -337,7 +246,7 @@ export function LoopBackupTab() {
                 message="警告"
                 description={
                   <ul style={{ margin: 0, paddingLeft: 20 }}>
-                    {previewData.warnings.map((w: any, i: number) => (
+                    {previewData.warnings.map((w, i) => (
                       <li key={i}>{w.message}</li>
                     ))}
                   </ul>
@@ -345,44 +254,6 @@ export function LoopBackupTab() {
                 type="warning"
                 showIcon
               />
-            )}
-
-            <div>
-              <Typography.Text strong>导入模式</Typography.Text>
-              <RadioGroup
-                value={importMode}
-                onChange={e => setImportMode(e.target.value)}
-                style={{ marginLeft: 12 }}
-              >
-                <RadioButton value="create">新建模式</RadioButton>
-                <RadioButton value="merge" disabled={!previewData.conflicts?.length}>
-                  合并模式
-                </RadioButton>
-              </RadioGroup>
-              <Typography.Paragraph type="secondary" style={{ marginTop: 4, marginBottom: 0 }}>
-                {importMode === 'create'
-                  ? '所有环路作为全新实体创建，同名自动追加 "-导入" 后缀'
-                  : '同名环路按下方策略处理'}
-              </Typography.Paragraph>
-            </div>
-
-            {importMode === 'merge' && previewData.conflicts && previewData.conflicts.length > 0 && (
-              <>
-                <Divider style={{ margin: '12px 0' }} />
-                <div>
-                  <Typography.Text strong>冲突解决策略</Typography.Text>
-                  <Typography.Paragraph type="secondary">
-                    检测到 {previewData.conflicts.length} 个同名环路，请选择处理方式
-                  </Typography.Paragraph>
-                  <Table
-                    size="small"
-                    dataSource={previewData.conflicts.map((c: any) => ({ key: c.name, ...c }))}
-                    columns={conflictColumns}
-                    pagination={false}
-                    style={{ marginTop: 8 }}
-                  />
-                </div>
-              </>
             )}
           </div>
         )}

--- a/frontend/src/components/settings/backup/TodoBackupTab.tsx
+++ b/frontend/src/components/settings/backup/TodoBackupTab.tsx
@@ -20,7 +20,7 @@ export function TodoBackupTab({
   todoBackupStatus, autoTodoBackupEnabled, autoTodoBackupCron, autoTodoBackupMaxFiles, todoBackupLoading,
   setAutoTodoBackupEnabled, setAutoTodoBackupCron, setAutoTodoBackupMaxFiles,
   onTriggerBackup, onSaveAutoBackup, onDeleteBackup, onDownloadBackupFile,
-  onExportBackup, onOpenExportModal, onImportFile,
+  onExportBackup, onImportFile,
 }: {
   todoBackupStatus: BackupFilesInfo | null;
   autoTodoBackupEnabled: boolean;
@@ -35,7 +35,6 @@ export function TodoBackupTab({
   onDeleteBackup: (filename: string) => Promise<void>;
   onDownloadBackupFile: (filename: string) => void;
   onExportBackup: () => Promise<void>;
-  onOpenExportModal: () => void;
   onImportFile: (file: File) => Promise<boolean>;
 }) {
   return (
@@ -43,16 +42,11 @@ export function TodoBackupTab({
       <Card title="导出备份" size="small" style={{ marginBottom: 24 }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           <Typography.Paragraph type="secondary">
-            将 Todo 和标签导出为 YAML 文件，方便迁移和存档
+            将事项和标签导出为 YAML 文件，方便迁移和存档
           </Typography.Paragraph>
-          <div style={{ display: 'flex', gap: 8 }}>
-            <Button type="primary" icon={<DownloadOutlined />} onClick={onExportBackup} style={{ flex: 1 }}>
-              导出全部
-            </Button>
-            <Button icon={<DownloadOutlined />} onClick={onOpenExportModal} style={{ flex: 1 }}>
-              选择性导出
-            </Button>
-          </div>
+          <Button type="primary" icon={<DownloadOutlined />} onClick={onExportBackup}>
+            导出全部
+          </Button>
         </div>
       </Card>
 
@@ -76,10 +70,10 @@ export function TodoBackupTab({
         </div>
       </Card>
 
-      <Card title="Todo自动备份" size="small">
+      <Card title="事项自动备份" size="small">
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
           <Typography.Paragraph type="secondary">
-            将 Todo 和标签打包备份到服务器，支持定时自动备份
+            将事项和标签打包备份到服务器，支持定时自动备份
           </Typography.Paragraph>
           <div style={{ display: 'flex', gap: 8 }}>
             <Button icon={<DatabaseOutlined />} onClick={onTriggerBackup} loading={todoBackupLoading}>

--- a/frontend/src/components/shell/WorkspaceSwitcher.tsx
+++ b/frontend/src/components/shell/WorkspaceSwitcher.tsx
@@ -22,6 +22,12 @@ interface WorkspaceSwitcherProps {
   /** 是否显示下拉菜单中"新建工作空间"选项，默认 false */
   showAddOption?: boolean;
   mode?: WorkspaceSwitcherMode;
+  /**
+   * 外部预加载的工作空间列表。传入时直接复用、跳过内部 loadDirs——
+   * 用于表格里 N 行复用同一份列表，避免每行各发一次 getProjectDirectories。
+   * 不传时维持原行为：组件自己加载并监听 projectDirectoryAdded 事件刷新。
+   */
+  dirs?: ProjectDirectory[];
 }
 
 /**
@@ -42,9 +48,12 @@ export function WorkspaceSwitcher({
   onManage,
   showAddOption = false,
   mode = 'full',
+  dirs: externalDirs,
 }: WorkspaceSwitcherProps) {
   const { message } = App.useApp();
-  const [dirs, setDirs] = useState<ProjectDirectory[]>([]);
+  // 内部状态仅在外部未提供 dirs 时使用；提供外部 dirs 时跳过加载，由父组件统一管理列表
+  const [internalDirs, setInternalDirs] = useState<ProjectDirectory[]>([]);
+  const dirs = externalDirs ?? internalDirs;
   const [loading, setLoading] = useState(false);
   const [quickAddOpen, setQuickAddOpen] = useState(false);
   const [quickAddSaving, setQuickAddSaving] = useState(false);
@@ -54,22 +63,25 @@ export function WorkspaceSwitcher({
     setLoading(true);
     try {
       const list = await db.getProjectDirectories();
-      setDirs(list);
+      setInternalDirs(list);
     } catch (err) {
       message.error(`加载工作空间失败: ${err instanceof Error ? err.message : '未知错误'}`);
-      setDirs([]);
+      setInternalDirs([]);
     } finally {
       setLoading(false);
     }
   }, [message]);
 
-  useEffect(() => { loadDirs(); }, [loadDirs]);
+  // 外部传入 dirs 时不在组件内加载，避免与父组件重复请求
+  useEffect(() => { if (externalDirs === undefined) loadDirs(); }, [loadDirs, externalDirs]);
 
   useEffect(() => {
+    // 外部传入 dirs 时也不监听事件刷新（由父组件决定何时重载）
+    if (externalDirs !== undefined) return;
     const handler = () => loadDirs();
     window.addEventListener('projectDirectoryAdded', handler);
     return () => window.removeEventListener('projectDirectoryAdded', handler);
-  }, [loadDirs]);
+  }, [loadDirs, externalDirs]);
 
   const selectedLabel = useMemo(() => {
     if (value == null) return '请选择工作空间';
@@ -129,8 +141,9 @@ export function WorkspaceSwitcher({
       message.success('工作空间已创建');
       quickAddForm.resetFields();
       setQuickAddOpen(false);
-      const dirs = await db.getProjectDirectories();
-      setDirs(dirs);
+      // 新建后刷新内部列表（仅 externalDirs 未提供时有效；外部传入时由父组件重载）
+      const list = await db.getProjectDirectories();
+      setInternalDirs(list);
       onChange(created.id);
       window.dispatchEvent(new CustomEvent('projectDirectoryAdded', { detail: { id: created.id } }));
     } catch (e) {

--- a/frontend/src/utils/database/backup.ts
+++ b/frontend/src/utils/database/backup.ts
@@ -201,11 +201,13 @@ export interface LoopImportResult {
 /**
  * workspace_id 全局传 null（逐条由 workspace_overrides 指定）。
  * workspace_overrides: loop name → workspace_id（用户逐行选择，仅含已指定的非空项）。
+ * skip_names: 用户选择「跳过」的同名环路名集合，后端不创建/覆盖、同名保留原样。
  */
 export async function mergeLoops(
   yaml: string,
   workspace_id: number | null,
   workspace_overrides?: Record<string, number>,
+  skip_names?: string[],
 ): Promise<{ success: boolean; created: LoopImportResult['created']; updated: LoopImportResult['created']; skipped: string[]; warnings: { type: string; message: string }[] }> {
-  return unwrap(await api.post('/api/loops/merge', { yaml, workspace_id, workspace_overrides }));
+  return unwrap(await api.post('/api/loops/merge', { yaml, workspace_id, workspace_overrides, skip_names }));
 }

--- a/frontend/src/utils/database/backup.ts
+++ b/frontend/src/utils/database/backup.ts
@@ -4,7 +4,8 @@ import { api, unwrap } from './client';
 
 export async function mergeBackup(
   tags: { name: string; color: string }[],
-  todos: { title: string; prompt: string; status: string; executor?: string; scheduler_enabled: boolean; scheduler_config?: string; tag_names: string[]; workspace_path?: string }[],
+  // workspace_id 逐条携带用户选定的工作空间；全局 workspace_id 传 null，由后端按每条解析
+  todos: { title: string; prompt: string; status: string; executor?: string; scheduler_enabled: boolean; scheduler_config?: string; tag_names: string[]; workspace_path?: string; workspace_id?: number | null }[],
   workspace_id?: number | null,
 ): Promise<string> {
   return unwrap(await api.post('/api/backup/merge', { tags, todos, workspace_id }));
@@ -135,6 +136,20 @@ export function downloadSkillBackupFileUrl(filename: string): string {
 
 // Loop Import/Export APIs
 
+export interface LoopImportPreviewLoop {
+  name: string;
+  /** 导出文件里的原始工作空间 ID（可能为空） */
+  workspace_id?: number | null;
+  /** 导出文件里的原始工作空间路径，展示用 */
+  workspace_path?: string | null;
+  /** 解析后的工作空间 ID（0=未匹配，需用户逐条指定） */
+  resolved_workspace_id: number;
+  /** 解析后的工作空间名称（未匹配时为 null） */
+  resolved_workspace_name?: string | null;
+  /** 原始 workspace_id 在当前库是否存在 */
+  source_matched: boolean;
+}
+
 export interface LoopImportPreview {
   valid: boolean;
   pseudo_ids: string[];
@@ -148,6 +163,8 @@ export interface LoopImportPreview {
   };
   conflicts: { type: string; name: string; action: string }[];
   warnings: { type: string; message: string }[];
+  /** 每条 loop 的工作空间匹配情况，供前端逐条渲染/指派 */
+  loops: LoopImportPreviewLoop[];
 }
 
 export async function previewLoopImport(yaml: string): Promise<LoopImportPreview> {
@@ -160,7 +177,12 @@ export async function previewLoopImport(yaml: string): Promise<LoopImportPreview
     const err = await response.json().catch(() => ({ message: response.statusText }));
     throw new Error(err.message || `HTTP ${response.status}`);
   }
-  return response.json();
+  // 后端统一返回 {code, data, message} 包裹体，这里解包出 data
+  const body = await response.json() as { code: number; data: LoopImportPreview | null; message: string };
+  if (body.code !== 0 || !body.data) {
+    throw new Error(body.message || `Error ${body.code}`);
+  }
+  return body.data;
 }
 
 export interface LoopImportResult {
@@ -176,16 +198,14 @@ export interface LoopImportResult {
   warnings: { type: string; message: string }[];
 }
 
-export async function importLoops(yaml: string, workspace_id: number): Promise<LoopImportResult> {
-  return unwrap(await api.post('/api/loops/import', { yaml, workspace_id }));
-}
-
-export type ConflictAction = 'rename' | 'overwrite' | 'skip';
-
+/**
+ * workspace_id 全局传 null（逐条由 workspace_overrides 指定）。
+ * workspace_overrides: loop name → workspace_id（用户逐行选择，仅含已指定的非空项）。
+ */
 export async function mergeLoops(
   yaml: string,
-  workspace_id: number,
-  conflict_resolution: Record<string, ConflictAction>,
+  workspace_id: number | null,
+  workspace_overrides?: Record<string, number>,
 ): Promise<{ success: boolean; created: LoopImportResult['created']; updated: LoopImportResult['created']; skipped: string[]; warnings: { type: string; message: string }[] }> {
-  return unwrap(await api.post('/api/loops/merge', { yaml, workspace_id, conflict_resolution }));
+  return unwrap(await api.post('/api/loops/merge', { yaml, workspace_id, workspace_overrides }));
 }

--- a/frontend/src/utils/database/loops.ts
+++ b/frontend/src/utils/database/loops.ts
@@ -217,3 +217,10 @@ export async function exportLoop(id: number): Promise<string> {
   return response.text();
 }
 
+/** 导出全库所有环路为单个 YAML，对齐 Todo「导出全部」 */
+export async function exportAllLoops(): Promise<string> {
+  const response = await fetch('/api/loops/export');
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return response.text();
+}
+


### PR DESCRIPTION
## 改动

### 导出统一为「全部导出」
- **Todo**：去掉「选择性导出」按钮/Modal/state，只留「导出全部」
- **Loop**：新增 `GET /api/loops/export` 导出全库所有 loop；前端改为「导出全部环路」单按钮

### Loop 导入向 Todo 看齐（单一覆盖语义）
- 去掉「新建/合并」模式切换与「重命名/覆盖/跳过」三选一
- `merge_loops`：`conflict_resolution` 改可选默认覆盖；同名 loop 删旧+原名重建（不再追加 `-合并`）；不同名新建
- 预览表加「状态」列（按已有 loop 名判新建/覆盖），保留 per-loop 工作空间/来源列 + OK gate
- `workspace_overrides` 逐条携带
- **fix**：`previewLoopImport` 用裸 fetch 未解包 `{code,data}` → "X.loops is not iterable"（遗留 bug）

### 逐条配工作空间
- `WorkspaceSwitcher` 加可选 `dirs` 入参（表格 N 行复用一份列表）
- Todo 导入向导：逐行 `WorkspaceSwitcher`，去全局选择器，OK gate 强制未匹配行手选
- 后端 `merge_backup` 已支持逐条；loop 导入加 per-loop 解析（override > 全局 > 导出 id > 哨兵 0）

### 备份子 tab 各自 URL + 改名
- 每个备份子 tab 对应 URL `sub` 参数（`#/settings?tab=backup&sub=loop` 等），支持深链
- 「Todo备份」→「事项备份」，页面描述同步更新

## 测试
- 后端：9 个内联 workspace 解析用例 + 2 个 loop merge 集成用例（原名保留 / 同名覆盖），`cargo clippy --all-targets` 零告警
- 前端：`tsc --noEmit` 零错误、`npm run build` 通过
- 手测（`make dev` + curl + playwright-cli）：导出全部、逐条导入、深链 `sub=loop`、改名均通过