### PR TITLE
fix: install sigstore before npm publish --provenance

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -175,6 +175,9 @@ jobs:
             echo "Updated $pkg to $VERSION"
           done
 
+      - name: Install sigstore for npm provenance
+        run: npm install -g sigstore
+
       - name: Publish platform packages to npm
         run: |
           for pkg in ntd-linux-x64 ntd-linux-arm64 ntd-darwin-arm64 ntd-windows-x64; do


### PR DESCRIPTION
npm publish --provenance on Node.js 24 fails with MODULE_NOT_FOUND for the 'sigstore' module after npm install -g npm@latest. Add explicit npm install -g sigstore step before publishing platform packages to npm.