### PR TITLE
fix: 事项页面多项修复（新建刷新/深色弹窗/执行器选择器）

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -421,6 +421,8 @@ function AppContent() {
           if (wid == null) return;
           db.getAllTodos(wid).then(todos => {
             dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: todos });
+            // 通知 ItemsPage 刷新列表（TodoList 用 cache guard，需要主动触发）
+            window.dispatchEvent(new Event('todoListRefresh'));
           });
         }}
         defaultWorkspaceId={state.selectedWorkspace}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { ConfigProvider, Layout, App as AntApp, Drawer } from 'antd';
+import { TODO_LIST_REFRESH_EVENT } from './constants';
 import { AppProvider, useApp } from './hooks/useApp';
 import { useIsMobile } from './hooks/useIsMobile';
 import { useExecutionEvents } from './hooks/useExecutionEvents';
@@ -190,6 +191,7 @@ function AppContent() {
     if (wid == null) return;
     db.getAllTodos(wid).then(todos => {
       dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: todos });
+      window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
     });
   };
 
@@ -422,7 +424,7 @@ function AppContent() {
           db.getAllTodos(wid).then(todos => {
             dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: todos });
             // 通知 ItemsPage 刷新列表（TodoList 用 cache guard，需要主动触发）
-            window.dispatchEvent(new Event('todoListRefresh'));
+            window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
           });
         }}
         defaultWorkspaceId={state.selectedWorkspace}
@@ -449,6 +451,7 @@ function AppContent() {
           if (wid != null) {
             db.getAllTodos(wid).then(todos => {
               dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: todos });
+              window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
             });
           }
         }}

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -1127,50 +1127,65 @@ interface TopicToolbarProps {
  * 也让每个主题页自带操作入口。删除走二次确认防误删；删除后由父组件重拉列表。
  */
 function TopicToolbar({ workspaceId, slug, onDeleted, isMobile, isDark }: TopicToolbarProps) {
-  // 确认删除：返回 Promise 让 Modal.confirm 的 OK 按钮自带 loading，无需额外 state
-  const confirmDelete = () => {
-    Modal.confirm({
-      title: '删除主题',
-      content: `确定删除主题「${slug}」？该 Wiki 文件将被永久删除，已创建的 Todo 不受影响。`,
-      okText: '删除',
-      okType: 'danger',
-      cancelText: '取消',
-      onOk: () => performDelete(workspaceId, slug, onDeleted),
-    });
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      await performDelete(workspaceId, slug, onDeleted);
+      setDeleteModalOpen(false);
+    } finally {
+      setDeleting(false);
+    }
   };
 
   return (
-    <div
-      style={{
-        // sticky：内容区滚动时工具条常驻顶部，操作始终可达
-        position: 'sticky',
-        top: 0,
-        zIndex: 5,
-        display: 'flex',
-        justifyContent: 'flex-end',
-        gap: 8,
-        // 与下方内容留间隔；背景与边框做成一条可视条，避免 sticky 时与正文粘连
-        marginBottom: 12,
-        padding: '6px 0',
-        background: isDark ? '#1a1a1a' : '#fafafa',
-        borderBottom: `1px solid ${isDark ? '#333' : '#f0f0f0'}`,
-      }}
-    >
-      <ProposalButton
-        workspaceId={workspaceId}
-        slug={slug}
-        buttonSize={isMobile ? 'small' : 'middle'}
-        showLabel={!isMobile}
-      />
-      <Button
-        danger
-        icon={<DeleteOutlined />}
-        onClick={confirmDelete}
-        size={isMobile ? 'small' : 'middle'}
+    <>
+      <div
+        style={{
+          // sticky：内容区滚动时工具条常驻顶部，操作始终可达
+          position: 'sticky',
+          top: 0,
+          zIndex: 5,
+          display: 'flex',
+          justifyContent: 'flex-end',
+          gap: 8,
+          // 与下方内容留间隔；背景与边框做成一条可视条，避免 sticky 时与正文粘连
+          marginBottom: 12,
+          padding: '6px 0',
+          background: isDark ? '#1a1a1a' : '#fafafa',
+          borderBottom: `1px solid ${isDark ? '#333' : '#f0f0f0'}`,
+        }}
       >
-        {isMobile ? '' : '删除主题'}
-      </Button>
-    </div>
+        <ProposalButton
+          workspaceId={workspaceId}
+          slug={slug}
+          buttonSize={isMobile ? 'small' : 'middle'}
+          showLabel={!isMobile}
+        />
+        <Button
+          danger
+          icon={<DeleteOutlined />}
+          onClick={() => setDeleteModalOpen(true)}
+          size={isMobile ? 'small' : 'middle'}
+        >
+          {isMobile ? '' : '删除主题'}
+        </Button>
+      </div>
+      <Modal
+        title="删除主题"
+        open={deleteModalOpen}
+        onOk={handleDelete}
+        onCancel={() => setDeleteModalOpen(false)}
+        okText="删除"
+        okType="danger"
+        cancelText="取消"
+        confirmLoading={deleting}
+      >
+        <p style={{ margin: 0 }}>确定删除主题「{slug}」？该 Wiki 文件将被永久删除，已创建的 Todo 不受影响。</p>
+      </Modal>
+    </>
   );
 }
 

--- a/frontend/src/components/ItemsPage.tsx
+++ b/frontend/src/components/ItemsPage.tsx
@@ -89,8 +89,10 @@ export function ItemsPage({
   // 返回列表页时（effectiveMobilePanel 回到 'list' 且没有选中事项），恢复用户上次的卡片/列表偏好
   useEffect(() => {
     if (effectiveMobilePanel === 'list' && !selectedTodoId) {
-      const saved = savedViewModeRef.current;
+      // 直接从 localStorage 读取，确保组件重挂载后也能正确恢复
+      const saved = readInitialView();
       setViewMode(saved);
+      savedViewModeRef.current = saved;
     }
   }, [effectiveMobilePanel, selectedTodoId]);
 

--- a/frontend/src/components/ItemsPage.tsx
+++ b/frontend/src/components/ItemsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Button, Input, Segmented } from 'antd';
 import { AppstoreOutlined, PlusOutlined, ReloadOutlined, SearchOutlined, UnorderedListOutlined } from '@ant-design/icons';
 import { TodoCenterCardView } from './TodoCenterCardView';
@@ -61,7 +61,10 @@ export function ItemsPage({
   isMobile,
 }: ItemsPageProps) {
   // 视图模式持久化：用户切到列表后下次仍记住，默认卡片
+  // savedViewModeRef 记录用户明确选择（写入 localStorage 的值），
+  // 用于返回时恢复；点击卡片预览详情时 viewMode 临时变列表，但 savedViewMode 不变。
   const [viewMode, setViewMode] = useState<'card' | 'list'>(readInitialView);
+  const savedViewModeRef = useRef<'card' | 'list'>(readInitialView());
   // 统一搜索词：卡片墙与列表双栏共用同一个搜索框，搜索逻辑由各自子组件在其数据上执行
   const [searchKeyword, setSearchKeyword] = useState('');
   // 刷新信号：每次点击刷新按钮自增，传递给子组件触发重新加载
@@ -69,6 +72,7 @@ export function ItemsPage({
 
   const persistView = (m: 'card' | 'list') => {
     setViewMode(m);
+    savedViewModeRef.current = m;
     try {
       localStorage.setItem(VIEW_STORAGE_KEY, m);
     } catch {
@@ -76,12 +80,19 @@ export function ItemsPage({
     }
   };
 
-  // 点卡片：选中事项（右栏详情数据源）+ 切到列表形态让详情显示。
-  // 列表形态点左列表其它事项仍照常联动右栏——卡片只是另一个「选事项」入口。
+  // 点卡片：选中事项 + 临时切换到列表模式让详情显示（不写 localStorage，返回时恢复卡片偏好）。
   const selectTodoAndSwitchToList = (id: number) => {
     onSelectTodo(id);
-    persistView('list');
+    setViewMode('list'); // 临时切换，不更新 savedViewModeRef
   };
+
+  // 返回列表页时（effectiveMobilePanel 回到 'list' 且没有选中事项），恢复用户上次的卡片/列表偏好
+  useEffect(() => {
+    if (effectiveMobilePanel === 'list' && !selectedTodoId) {
+      const saved = savedViewModeRef.current;
+      setViewMode(saved);
+    }
+  }, [effectiveMobilePanel, selectedTodoId]);
 
   // 搜索框：桌面端统一放在 ItemsPage 顶层，移动端由子组件自行决定是否显示
   const searchInput = !isMobile ? (
@@ -104,7 +115,7 @@ export function ItemsPage({
     </Button>
   ) : null;
 
-  // 完整的 header 元素：搜索框 + 刷新 + Segmented 切换 + 新建（桌面端，移动端由子组件自行处理）
+  // 完整的 header 元素：搜索框 + 刷新 + Segmented 切换 + 新建（桌面端）
   const extra = !isMobile ? (
     <>
       {searchInput}
@@ -123,7 +134,19 @@ export function ItemsPage({
         新建
       </Button>
     </>
-  ) : null;
+  ) : (
+    // 移动端：仅 Segmented 切换器（精简 header，避免拥挤）
+    <Segmented
+      size="small"
+      value={viewMode}
+      onChange={(v) => persistView(v as 'card' | 'list')}
+      options={[
+        { value: 'card', icon: <AppstoreOutlined />, title: '卡片' },
+        { value: 'list', icon: <UnorderedListOutlined />, title: '列表' },
+      ]}
+      data-testid="todo-center-view-toggle"
+    />
+  );
 
   if (viewMode === 'card') {
     return (

--- a/frontend/src/components/TodoCenterCardView.tsx
+++ b/frontend/src/components/TodoCenterCardView.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Empty, Segmented, Select, Spin, message } from 'antd';
 import { AppstoreOutlined } from '@ant-design/icons';
+import { TODO_LIST_REFRESH_EVENT } from '@/constants';
 import { useApp } from '@/hooks/useApp';
 import { PageCard } from '@/components/common/PageCard';
 import { TodoCenterCard, sourceLabel } from '@/components/TodoCenterCard';
@@ -105,8 +106,8 @@ export function TodoCenterCardView({
   // TodoDrawer 新建/保存事项后，通知卡片墙也刷新
   useEffect(() => {
     const handler = () => reload();
-    window.addEventListener('todoListRefresh', handler);
-    return () => window.removeEventListener('todoListRefresh', handler);
+    window.addEventListener(TODO_LIST_REFRESH_EVENT, handler);
+    return () => window.removeEventListener(TODO_LIST_REFRESH_EVENT, handler);
   }, [reload]);
 
   // 按 computed_bucket 分桶，用于 Tab 计数与卡片过滤

--- a/frontend/src/components/TodoCenterCardView.tsx
+++ b/frontend/src/components/TodoCenterCardView.tsx
@@ -62,8 +62,14 @@ export function TodoCenterCardView({
   const [items, setItems] = useState<TodoCenterItem[]>([]);
   // 加载态控制 Spin + 刷新按钮 loading
   const [loading, setLoading] = useState(false);
-  // 当前 Tab（五类驱动），默认手动触发
-  const [activeBucket, setActiveBucket] = useState<ComputedBucket>('manual');
+  // 当前 Tab（五类驱动），默认手动触发；持久化到 localStorage 记住用户上次选择
+  const [activeBucket, setActiveBucket] = useState<ComputedBucket>(() => {
+    try {
+      return (localStorage.getItem('ntd_items_tab') as ComputedBucket) || 'manual';
+    } catch {
+      return 'manual';
+    }
+  });
   // 状态筛选（设计文档工具栏「状态筛选」）：'all' 或具体 status
   const [statusFilter, setStatusFilter] = useState<string>('all');
   // 动作类型筛选（设计文档工具栏「动作类型筛选」）：'all' 或具体 action_type
@@ -86,6 +92,22 @@ export function TodoCenterCardView({
   useEffect(() => {
     reload();
   }, [reload, refreshKey]);
+
+  // activeBucket 变化时持久化到 localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem('ntd_items_tab', activeBucket);
+    } catch {
+      /* localStorage 不可用时静默降级 */
+    }
+  }, [activeBucket]);
+
+  // TodoDrawer 新建/保存事项后，通知卡片墙也刷新
+  useEffect(() => {
+    const handler = () => reload();
+    window.addEventListener('todoListRefresh', handler);
+    return () => window.removeEventListener('todoListRefresh', handler);
+  }, [reload]);
 
   // 按 computed_bucket 分桶，用于 Tab 计数与卡片过滤
   const bucketCount = useMemo(() => {

--- a/frontend/src/components/settings/workspace/WorkspaceSettingsPanel.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceSettingsPanel.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react';
 import { Card, Form, Select, Button, Space, message, Radio, InputNumber, Typography } from 'antd';
 import * as db from '@/utils/database';
 import { listLoops } from '@/utils/database/loops';
+import { EXECUTORS_FOR_PICKER } from '@/utils/executors';
+import { ExecutorPicker } from '@/components/todo-drawer/ExecutorPicker';
 import type { Todo } from '@/types';
 import type { LoopListItem } from '@/types/loop';
 
@@ -101,6 +103,7 @@ export function WorkspaceSettingsPanel({ workspaceId, onChanged }: WorkspaceSett
   };
 
   const responseType = Form.useWatch('default_response_type', form);
+  const executorValue = Form.useWatch('default_response_executor', form);
 
   return (
     <>
@@ -170,23 +173,12 @@ export function WorkspaceSettingsPanel({ workspaceId, onChanged }: WorkspaceSett
             <Form.Item
               name="default_response_executor"
               label="执行器类型"
-              initialValue="claudecode"
               tooltip="选择执行器来处理消息"
             >
-              <Select
-                showSearch
-                allowClear
-                placeholder="选择执行器"
-                style={{ width: 200 }}
-                options={[
-                  { value: 'claudecode', label: 'Claude Code' },
-                  { value: 'pi', label: 'PI' },
-                  { value: 'kimi', label: 'Kimi' },
-                  { value: 'opencode', label: 'Opencode' },
-                  { value: 'hermes', label: 'Hermes' },
-                  { value: 'codewhale', label: 'CodeWhale' },
-                  { value: 'zhanlu', label: 'Zhanlu' },
-                ]}
+              <ExecutorPicker
+                executor={executorValue || 'claudecode'}
+                executorOptions={EXECUTORS_FOR_PICKER}
+                onChange={v => form.setFieldValue('default_response_executor', v)}
               />
             </Form.Item>
           )}

--- a/frontend/src/components/todo-list/index.tsx
+++ b/frontend/src/components/todo-list/index.tsx
@@ -164,6 +164,18 @@ export function TodoList(props: TodoListProps) {
     });
   }, [refreshKey, selectedWorkspace, directoriesReady, listMode, dispatch]);
 
+  // TodoDrawer 新建/保存事项后，通过 custom event 通知列表刷新
+  useEffect(() => {
+    const handler = () => {
+      if (!directoriesReady || selectedWorkspace == null || listMode !== 'item') return;
+      db.getAllTodos(selectedWorkspace).then(todos => {
+        dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: selectedWorkspace, payload: todos });
+      });
+    };
+    window.addEventListener('todoListRefresh', handler);
+    return () => window.removeEventListener('todoListRefresh', handler);
+  }, [directoriesReady, selectedWorkspace, listMode, dispatch]);
+
   // 持久化列表模式到 localStorage
   useEffect(() => {
     localStorage.setItem('ntd_list_mode', listMode);

--- a/frontend/src/components/todo-list/index.tsx
+++ b/frontend/src/components/todo-list/index.tsx
@@ -3,6 +3,7 @@
 // 外部 caller 只 import 主组件 TodoList，不再 re-export。
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
+import { TODO_LIST_REFRESH_EVENT } from '@/constants';
 import { useApp } from '@/hooks/useApp';
 import { Empty, Input, Skeleton, Modal, App as AntApp } from 'antd';
 import { InboxOutlined, SearchOutlined, SwapOutlined, StopOutlined, CopyOutlined, DragOutlined, PauseCircleOutlined, PlayCircleOutlined } from '@ant-design/icons';
@@ -172,8 +173,8 @@ export function TodoList(props: TodoListProps) {
         dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: selectedWorkspace, payload: todos });
       });
     };
-    window.addEventListener('todoListRefresh', handler);
-    return () => window.removeEventListener('todoListRefresh', handler);
+    window.addEventListener(TODO_LIST_REFRESH_EVENT, handler);
+    return () => window.removeEventListener(TODO_LIST_REFRESH_EVENT, handler);
   }, [directoriesReady, selectedWorkspace, listMode, dispatch]);
 
   // 持久化列表模式到 localStorage

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -193,6 +193,14 @@ export const EXPORT = {
 // When the user picks an executor in one place, the other two remember it too.
 // =============================================================================
 
+// =============================================================================
+// Cross-component event names — single source of truth for custom event names
+// used by window.dispatchEvent / addEventListener.
+// =============================================================================
+
+/** TodoDrawer 新建/保存事项后，通知 TodoList 和 TodoCenterCardView 刷新列表 */
+export const TODO_LIST_REFRESH_EVENT = 'todoListRefresh';
+
 // localStorage key 仅本文件内部用，跨组件记忆用户上次选择的执行器
 const LAST_EXECUTOR_STORAGE_KEY = 'ntd_last_executor';
 


### PR DESCRIPTION
## 修复内容

### 1. 新建事项后自动刷新列表
- `App.tsx` 的 `onSaved` 派发 `todoListRefresh` 自定义事件
- `TodoList` 和 `TodoCenterCardView` 监听该事件重新加载数据

### 2. 删除主题弹窗深色主题适配
- `Modal.confirm` 不读取 ConfigProvider 深色主题，改用受控 `Modal` 组件

### 3. 消息配置默认响应执行器使用统一 ExecutorPicker
- `WorkspaceSettingsPanel` 硬编码 Select 替换为与闪念界面一致的 `ExecutorPicker` 组件

### 4. 卡片墙 Tab 记忆功能
- `activeBucket` 持久化到 `ntd_items_tab` localStorage，刷新后恢复上次选择