### PR TITLE
feat: 黑板设置增加总开关（enabled）

### DIFF
--- a/backend/src/db/blackboard.rs
+++ b/backend/src/db/blackboard.rs
@@ -108,6 +108,8 @@ impl Database {
             wiki_chat_executor: ActiveValue::Set(None),
             // Wiki 执行超时默认 5 分钟，与历史写死值一致
             wiki_timeout_secs: ActiveValue::Set(DEFAULT_WIKI_TIMEOUT_SECS),
+            // 黑板功能默认启用
+            enabled: ActiveValue::Set(1),
             updated_at: ActiveValue::Set(Some(now.clone())),
             created_at: ActiveValue::Set(Some(now)),
             ..Default::default()
@@ -324,6 +326,7 @@ impl Database {
             wiki_chat_executor: b.wiki_chat_executor,
             wiki_chat_sessions: b.wiki_chat_sessions,
             wiki_timeout_secs: b.wiki_timeout_secs,
+            enabled: b.enabled != 0,
         }))
     }
 
@@ -341,6 +344,7 @@ impl Database {
     ///   - 外层 Some(Some(s))：设为指定执行器名
     ///
     /// 记录不存在时返回 RecordNotFound；调用方须确保黑板记录已存在。
+    #[allow(clippy::too_many_arguments)]
     pub async fn update_blackboard_config(
         &self,
         workspace_id: i64,
@@ -349,6 +353,7 @@ impl Database {
         wiki_prompt: Option<String>,
         wiki_chat_executor: Option<Option<String>>,
         wiki_timeout_secs: Option<i64>,
+        enabled: Option<bool>,
     ) -> Result<(), sea_orm::DbErr> {
         let board = blackboards::Entity::find()
             .filter(blackboards::Column::WorkspaceId.eq(workspace_id))
@@ -381,6 +386,9 @@ impl Database {
         }
         if let Some(v) = wiki_timeout_secs {
             am.wiki_timeout_secs = ActiveValue::Set(clamp_wiki_timeout(v));
+        }
+        if let Some(v) = enabled {
+            am.enabled = ActiveValue::Set(v as i64);
         }
         am.update(&self.conn).await?;
         Ok(())
@@ -483,6 +491,9 @@ pub struct BlackboardConfig {
     pub wiki_chat_sessions: Option<String>,
     /// Wiki 执行超时（秒），控制 update_blackboard_wiki 等待与 Wiki 对话子进程的时长。
     pub wiki_timeout_secs: i64,
+    /// 黑板功能总开关：true=启用，false=禁用。
+    /// 关闭后不执行任何黑板相关逻辑（防抖入队、flush 刷新、Wiki 自动维护）。
+    pub enabled: bool,
 }
 
 #[cfg(test)]
@@ -670,7 +681,7 @@ mod tests {
         let ws_id = create_test_workspace(&db).await;
         db.create_blackboard(ws_id).await.unwrap();
 
-        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("wiki".to_string()), Some(Some("codex".to_string())), None)
+        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("wiki".to_string()), Some(Some("codex".to_string())), None, None)
             .await
             .unwrap();
 
@@ -691,12 +702,12 @@ mod tests {
         db.create_blackboard(ws_id).await.unwrap();
 
         // 先全部更新
-        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("wiki".to_string()), Some(Some("kimi".to_string())), Some(600))
+        db.update_blackboard_config(ws_id, Some(300), Some(5), Some("wiki".to_string()), Some(Some("kimi".to_string())), Some(600), None)
             .await
             .unwrap();
 
         // 再只更新其中两个
-        db.update_blackboard_config(ws_id, Some(900), None, None, None, None)
+        db.update_blackboard_config(ws_id, Some(900), None, None, None, None, None)
             .await
             .unwrap();
 
@@ -714,7 +725,7 @@ mod tests {
     async fn test_update_blackboard_config_record_not_found() {
         let db = Database::new(":memory:").await.expect(":memory: must open");
         // 第 4 个参数 wiki_prompt 传 None，不参与此次测试验证
-        let result = db.update_blackboard_config(999, Some(300), None, None, None, None).await;
+        let result = db.update_blackboard_config(999, Some(300), None, None, None, None, None).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             sea_orm::DbErr::RecordNotFound(_) => {}
@@ -730,14 +741,14 @@ mod tests {
         db.create_blackboard(ws_id).await.unwrap();
 
         // 传入小于最小值的 debounce_secs，应被钳制到 10
-        db.update_blackboard_config(ws_id, Some(3), None, None, None, None)
+        db.update_blackboard_config(ws_id, Some(3), None, None, None, None, None)
             .await
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
         assert_eq!(cfg.debounce_secs, 10);
 
         // 传入小于最小值的 debounce_count，应被钳制到 1
-        db.update_blackboard_config(ws_id, None, Some(0), None, None, None)
+        db.update_blackboard_config(ws_id, None, Some(0), None, None, None, None)
             .await
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
@@ -752,14 +763,14 @@ mod tests {
         db.create_blackboard(ws_id).await.unwrap();
 
         // 先设置一个值
-        db.update_blackboard_config(ws_id, None, None, None, Some(Some("codex".to_string())), None)
+        db.update_blackboard_config(ws_id, None, None, None, Some(Some("codex".to_string())), None, None)
             .await
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
         assert_eq!(cfg.wiki_chat_executor, Some("codex".to_string()));
 
         // 再设为 None（清空回退到默认）
-        db.update_blackboard_config(ws_id, None, None, None, Some(None), None)
+        db.update_blackboard_config(ws_id, None, None, None, Some(None), None, None)
             .await
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
@@ -776,21 +787,21 @@ mod tests {
         db.create_blackboard(ws_id).await.unwrap();
 
         // 传入低于下限的值（0），应被钳制到 MIN_WIKI_TIMEOUT_SECS
-        db.update_blackboard_config(ws_id, None, None, None, None, Some(0))
+        db.update_blackboard_config(ws_id, None, None, None, None, Some(0), None)
             .await
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
         assert_eq!(cfg.wiki_timeout_secs, MIN_WIKI_TIMEOUT_SECS);
 
         // 传入高于上限的值，应被钳制到 MAX_WIKI_TIMEOUT_SECS
-        db.update_blackboard_config(ws_id, None, None, None, None, Some(MAX_WIKI_TIMEOUT_SECS + 1000))
+        db.update_blackboard_config(ws_id, None, None, None, None, Some(MAX_WIKI_TIMEOUT_SECS + 1000), None)
             .await
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
         assert_eq!(cfg.wiki_timeout_secs, MAX_WIKI_TIMEOUT_SECS);
 
         // 区间内的值原样保留
-        db.update_blackboard_config(ws_id, None, None, None, None, Some(600))
+        db.update_blackboard_config(ws_id, None, None, None, None, Some(600), None)
             .await
             .unwrap();
         let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
@@ -891,5 +902,31 @@ mod tests {
             "并发 append 丢失 ID：期望 1..=100 全部落库，实际 {:?}",
             ids
         );
+    }
+
+    /// 验证 update_blackboard_config 正确更新 enabled 字段。
+    #[tokio::test]
+    async fn test_update_blackboard_config_enabled_toggle() {
+        let db = Database::new(":memory:").await.expect(":memory: must open");
+        let ws_id = create_test_workspace(&db).await;
+        db.create_blackboard(ws_id).await.unwrap();
+
+        // 默认启用
+        let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
+        assert!(cfg.enabled, "默认应为启用");
+
+        // 禁用
+        db.update_blackboard_config(ws_id, None, None, None, None, None, Some(false))
+            .await
+            .unwrap();
+        let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
+        assert!(!cfg.enabled, "应为禁用");
+
+        // 重新启用
+        db.update_blackboard_config(ws_id, None, None, None, None, None, Some(true))
+            .await
+            .unwrap();
+        let cfg = db.get_blackboard_config(ws_id).await.unwrap().unwrap();
+        assert!(cfg.enabled, "应为启用");
     }
 }

--- a/backend/src/db/entity/blackboards.rs
+++ b/backend/src/db/entity/blackboards.rs
@@ -41,6 +41,9 @@ pub struct Model {
     /// 以及 Wiki 对话子进程的最长存活时间。默认 300（5 分钟），
     /// 可在黑板设置界面按工作空间调整，避免慢模型被强制超时。
     pub wiki_timeout_secs: i64,
+    /// 黑板功能总开关：1=启用，0=禁用。关闭后不执行任何黑板相关逻辑
+    /// （防抖入队、flush 刷新、Wiki 自动维护），节省不需要黑板的工作空间资源。
+    pub enabled: i64,
     pub updated_at: Option<String>,
     pub created_at: Option<String>,
 }

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -19,6 +19,7 @@ mod v57;
 mod v58;
 mod v59;
 mod v60;
+mod v61;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -65,6 +66,8 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v59::V59AddTodosArchivedAtIndex),
         // V60 在 V59 之后：为 feishu_messages 增加 error 字段，记录处理失败原因
         Box::new(v60::V60AddFeishuMessagesError),
+        // V61 在 V60 之后：为 blackboards 增加 enabled 总开关
+        Box::new(v61::V61AddBlackboardEnabled),
     ]
 }
 

--- a/backend/src/db/migration/v61.rs
+++ b/backend/src/db/migration/v61.rs
@@ -1,0 +1,40 @@
+//! 数据库迁移 V61：为 blackboards 表新增 enabled 总开关。
+//!
+//! ## 背景
+//! 黑板功能需要一个 per-workspace 的总开关：关闭后不执行任何黑板相关逻辑
+//! （防抖入队、flush 刷新、Wiki 自动维护），避免不需要黑板的工作空间浪费资源。
+//!
+//! ## 幂等
+//! `add_column_if_missing` 已存在则静默跳过。
+
+use async_trait::async_trait;
+
+use super::super::Database;
+use super::{Migration, add_column_if_missing};
+
+pub(super) struct V61AddBlackboardEnabled;
+
+#[async_trait]
+impl Migration for V61AddBlackboardEnabled {
+    fn version(&self) -> i64 {
+        61
+    }
+
+    fn name(&self) -> &'static str {
+        "V61AddBlackboardEnabled"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // enabled 列：INTEGER NOT NULL DEFAULT 1，1=启用，0=禁用。
+        // 默认启用保持向后兼容：已有工作空间无需手动开启。
+        add_column_if_missing(
+            db,
+            "blackboards",
+            "enabled",
+            "ALTER TABLE blackboards ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1",
+        )
+        .await?;
+        tracing::info!("V61: blackboards.enabled 列已添加");
+        Ok(())
+    }
+}

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -669,6 +669,27 @@ async fn handle_flush_msg(
 ) {
     let ws_id = msg.workspace_id;
 
+    // 优先检查黑板功能总开关：关闭时直接返回，不执行任何 wiki 维护操作。
+    // 这是第二道防线（第一道在 push_pending_record 阻止新记录入队）：
+    // 即使 timer 在用户禁用前已调度、在禁用后自然到期发送了 flush 消息，也在此拦截。
+    match db.get_blackboard_config(ws_id).await {
+        Ok(Some(cfg)) if !cfg.enabled => {
+            tracing::debug!(
+                "黑板功能已禁用，跳过 flush 消息处理: workspace_id={}",
+                ws_id
+            );
+            return;
+        }
+        Err(e) => {
+            // DB 错误时 warn 并继续处理（降级策略：假定启用，避免配置读取临时失败导致黑板永久卡死）
+            tracing::warn!(
+                "读取黑板配置失败（继续处理 flush）: workspace_id={}, error={}",
+                ws_id, e
+            );
+        }
+        _ => {}
+    }
+
     // 确保 workspace 在已知列表中
     if !known_workspaces.contains(&ws_id) {
         known_workspaces.push(ws_id);

--- a/backend/src/handlers/blackboard.rs
+++ b/backend/src/handlers/blackboard.rs
@@ -186,6 +186,14 @@ pub async fn update_blackboard_config(
         );
     }
 
+    // enabled 变更为 false 时，取消已调度的防抖 timer，确保黑板彻底停止工作。
+    // 已在队列中的 pending_record_ids 保留不清理（用户重新启用后继续处理）；
+    // timer 逻辑取消（清除状态 + 标记未运行）后，即使 timer task 自然到期发送 flush 消息，
+    // handle_flush_msg 的 enabled 检查也会拦截，不会派生 worker 执行 wiki 维护。
+    if let Some(false) = req.enabled {
+        crate::services::blackboard_debouncer::cancel_timer(workspace_id).await;
+    }
+
     // debounce_secs 变更时，根据已计时长决定：超则立即触发 flush，未超则继续用新阈值计时
     if let Some(new_secs) = req.blackboard_debounce_secs {
         let clamped = new_secs.max(10);

--- a/backend/src/handlers/blackboard.rs
+++ b/backend/src/handlers/blackboard.rs
@@ -33,6 +33,8 @@ pub struct BlackboardResponse {
     pub wiki_timeout_secs: i64,
     /// 待处理的 execution_record_id 列表（JSON 数组字符串）
     pub pending_record_ids: String,
+    /// 黑板功能总开关
+    pub enabled: bool,
 }
 
 /// Wiki 文件列表项
@@ -72,6 +74,8 @@ pub struct UpdateBlackboardConfigRequest {
     pub wiki_chat_executor: Option<String>,
     /// Wiki 执行超时（秒）。None 不修改，Some(v) 会被后端钳制到合法区间。
     pub wiki_timeout_secs: Option<i64>,
+    /// 黑板功能总开关。None 不修改，Some(true/false) 启用/禁用。
+    pub enabled: Option<bool>,
 }
 
 /// `GET /api/workspaces/{workspace_id}/blackboard`
@@ -96,6 +100,7 @@ pub async fn get_blackboard(
             wiki_chat_executor: model.wiki_chat_executor,
             wiki_timeout_secs: model.wiki_timeout_secs,
             pending_record_ids: model.pending_record_ids,
+            enabled: model.enabled != 0,
         })),
         None => Ok(ApiResponse::ok(BlackboardResponse {
             id: 0,
@@ -107,6 +112,7 @@ pub async fn get_blackboard(
             wiki_chat_executor: None,
             wiki_timeout_secs: crate::db::blackboard::DEFAULT_WIKI_TIMEOUT_SECS,
             pending_record_ids: String::from("[]"),
+            enabled: true,
         })),
     }
 }
@@ -133,6 +139,7 @@ pub async fn get_blackboard_config(
             wiki_chat_executor: None,
             wiki_chat_sessions: None,
             wiki_timeout_secs: crate::db::blackboard::DEFAULT_WIKI_TIMEOUT_SECS,
+            enabled: true,
         })),
     }
 }
@@ -160,6 +167,8 @@ pub async fn update_blackboard_config(
         req.wiki_chat_executor.map(|s| if s.is_empty() { None } else { Some(s) }),
         // wiki_timeout_secs: None 不修改，Some(v) 由 db 层钳制到合法区间
         req.wiki_timeout_secs,
+        // enabled: None 不修改，Some(true/false) 启用/禁用黑板功能
+        req.enabled,
     ).await.map_err(|e| AppError::Internal(format!("更新黑板配置失败: {}", e)))?;
 
     // 配置变更后同步到该 workspace 已存在的 Wiki Todo 的 prompt 字段：

--- a/backend/src/services/blackboard_debouncer.rs
+++ b/backend/src/services/blackboard_debouncer.rs
@@ -347,3 +347,37 @@ pub async fn restart_timer(workspace_id: i64, db: &Arc<Database>) {
     };
     start_timer(workspace_id, debounce_secs).await;
 }
+
+/// 停止指定 workspace 的活跃防抖 timer，清理所有相关状态。
+///
+/// 调用场景：用户禁用黑板功能（`enabled = false`）时，需要立即停止已调度的 timer，
+/// 避免 timer 到期后仍触发 wiki 维护任务（违背用户的"关闭黑板"意图）。
+///
+/// 实现说明：tokio::spawn 的后台 timer task 无法被外部直接 abort（需 JoinHandle 才能 abort），
+/// 这里采用"逻辑取消"：清除 TIMER_STATES（让 UI 立即停止显示倒计时），并标记 ACTIVE_TIMERS
+/// 为 false（让 timer task 自然到期时不会重复启动）。timer task 即使继续运行到期并发送 flush
+/// 消息，也会被 handle_flush_msg 的 enabled 检查拦截，不会派生 worker 执行 wiki 维护。
+pub async fn cancel_timer(workspace_id: i64) {
+    // 清除 timer 启动时间状态，让前端 UI 立即停止显示倒计时（remaining_secs=-1）
+    {
+        let mut states = TIMER_STATES.write().await;
+        if let Some(map) = states.as_mut() {
+            map.remove(&workspace_id);
+        }
+    }
+
+    // 标记 timer 未运行，阻止已调度的 timer task 在到期时重复启动新一轮 timer。
+    // 注意：已 spawn 的 timer task（sleep 中）无法被物理取消，只能等其自然到期；
+    // 但 handle_flush_msg 会在入口检查 enabled 标志，拦截到期后的 flush 消息。
+    if let Some(timers) = ACTIVE_TIMERS.get() {
+        let mut timers = timers.write().await;
+        if let Some(map) = timers.as_mut() {
+            map.insert(workspace_id, false);
+        }
+    }
+
+    tracing::info!(
+        "黑板 timer 已取消: workspace_id={} (后台 sleep task 会自然到期，但 flush 消息将被 enabled 检查拦截)",
+        workspace_id
+    );
+}

--- a/backend/src/services/blackboard_debouncer.rs
+++ b/backend/src/services/blackboard_debouncer.rs
@@ -169,6 +169,21 @@ pub async fn push_pending_record(workspace_id: i64, record_id: i64, db: &Arc<Dat
         workspace_id, record_id
     );
 
+    // 检查黑板功能总开关：关闭时跳过入队，不阻塞主流程
+    match db.get_blackboard_config(workspace_id).await {
+        Ok(Some(cfg)) if !cfg.enabled => {
+            tracing::debug!(
+                "黑板功能已禁用，跳过 push_pending_record: workspace_id={}",
+                workspace_id
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::warn!("读取黑板配置失败（继续入队）: workspace_id={}, error={}", workspace_id, e);
+        }
+        _ => {}
+    }
+
     // 追加到 DB
     if let Err(e) = db.append_pending_record_id(workspace_id, record_id).await {
         tracing::warn!(

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -23,7 +23,7 @@
  */
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Button, Skeleton, message, Modal, Form, InputNumber, Space, Progress, Input, Tabs, Menu, Drawer } from 'antd';
+import { Button, Skeleton, message, Modal, Form, InputNumber, Space, Progress, Input, Tabs, Menu, Drawer, Switch } from 'antd';
 import { ReloadOutlined, SettingOutlined, UnorderedListOutlined, MenuOutlined, DeleteOutlined } from '@ant-design/icons';
 import { PageCard } from '@/components/common/PageCard';
 import { TfiBlackboard } from 'react-icons/tfi';
@@ -51,6 +51,8 @@ interface BlackboardData {
   wiki_chat_executor?: string | null;
   /** Wiki 执行超时（秒），控制 Wiki 任务与 Wiki 对话的最长存活时间 */
   wiki_timeout_secs: number;
+  /** 黑板功能总开关 */
+  enabled: boolean;
 }
 
 /** Wiki 文件列表项（对应后端 WikiFileItem） */
@@ -307,6 +309,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
   const [wikiPrompt, setWikiPrompt] = useState<string>('');
   // Wiki 执行超时（秒）：与后端 DEFAULT_WIKI_TIMEOUT_SECS=300 一致，清空时回退默认
   const [wikiTimeoutSecs, setWikiTimeoutSecs] = useState<number | null>(300);
+  const [bbEnabled, setBbEnabled] = useState<boolean>(true);
   const [activeTab, setActiveTab] = useState<'debounce' | 'prompt'>('debounce');
   // 移动端目录 Drawer 开关状态
   const [menuDrawerOpen, setMenuDrawerOpen] = useState(false);
@@ -322,11 +325,13 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
       setDebounceCount(configData.blackboard_debounce_count ?? 10);
       setWikiPrompt(configData.wiki_prompt ?? '');
       setWikiTimeoutSecs(configData.wiki_timeout_secs ?? 300);
+      setBbEnabled(configData.enabled ?? true);
     } else {
       setDebounceSecs(600);
       setDebounceCount(10);
       setWikiPrompt('');
       setWikiTimeoutSecs(300);
+      setBbEnabled(true);
     }
     setActiveTab('debounce');
     setSettingsOpen(true);
@@ -342,6 +347,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
         blackboard_debounce_count: debounceCount ?? 10,
         wiki_prompt: wikiPrompt,
         wiki_timeout_secs: wikiTimeoutSecs ?? 300,
+        enabled: bbEnabled,
       });
       // 保存成功后同步更新 data，避免下次打开弹窗读到旧值
       if (configData) {
@@ -351,6 +357,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
           blackboard_debounce_count: debounceCount ?? 10,
           wiki_prompt: wikiPrompt,
           wiki_timeout_secs: wikiTimeoutSecs ?? 300,
+          enabled: bbEnabled,
         });
       }
       message.success('设置已保存');
@@ -360,7 +367,7 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
     } finally {
       setSettingsSaving(false);
     }
-  }, [workspaceId, debounceSecs, debounceCount, wikiPrompt, wikiTimeoutSecs, configData]);
+  }, [workspaceId, debounceSecs, debounceCount, wikiPrompt, wikiTimeoutSecs, bbEnabled, configData]);
 
   // 恢复默认提示词：把 wikiPrompt 设为内置默认值。
   // 区别于"留空"的语义——留空表示后端使用内置默认；填入默认值表示用户显式采用内置模板。
@@ -527,6 +534,10 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
         destroyOnHidden
         width={isMobile ? '90%' : 640}
       >
+        <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <span style={{ fontSize: 14, fontWeight: 500 }}>启用黑板</span>
+          <Switch checked={bbEnabled} onChange={setBbEnabled} />
+        </div>
         <Tabs
           activeKey={activeTab}
           onChange={(key) => setActiveTab(key as 'debounce' | 'prompt')}

--- a/frontend/src/utils/database/blackboard.ts
+++ b/frontend/src/utils/database/blackboard.ts
@@ -30,6 +30,8 @@ export async function updateBlackboardConfig(
     wiki_chat_executor?: string;
     /** Wiki 执行超时（秒），后端会钳制到 [60, 3600] 区间 */
     wiki_timeout_secs?: number;
+    /** 黑板功能总开关 */
+    enabled?: boolean;
   },
 ): Promise<void> {
   await api.patch(`/api/workspaces/${workspaceId}/blackboard`, config);


### PR DESCRIPTION
## Summary
- 新增 `blackboards.enabled` 字段（DB 迁移 V61），默认启用保持向后兼容
- 关闭后 `push_pending_record` 直接跳过，不入队、不 flush、不触发 Wiki 维护
- 前端设置弹窗顶部新增「启用黑板」Switch 开关
- 新增单元测试覆盖 enabled 读写

## Changes
- `backend/src/db/migration/v61.rs`：新增迁移，ALTER TABLE 添加 enabled 列
- `backend/src/db/entity/blackboards.rs`：Model 新增 enabled 字段
- `backend/src/db/blackboard.rs`：BlackboardConfig 支持 enabled，get/update 读写
- `backend/src/services/blackboard_debouncer.rs`：push_pending_record 入口检查 enabled
- `backend/src/handlers/blackboard.rs`：API 请求/响应体新增 enabled
- `frontend/src/components/BlackboardPage.tsx`：设置弹窗新增 Switch
- `frontend/src/utils/database/blackboard.ts`：updateBlackboardConfig 参数新增 enabled