### PR TITLE
feat(message-monitor): 消息列表标签/筛选增强与推送配置修复

### DIFF
--- a/backend/src/db/feishu_message.rs
+++ b/backend/src/db/feishu_message.rs
@@ -3,9 +3,20 @@ use std::collections::HashMap;
 use crate::db::entity::feishu_messages;
 use crate::db::Database;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait, PaginatorTrait,
-    QueryFilter, QueryOrder, QuerySelect, Statement,
+    sea_query::{Expr, LikeExpr},
+    ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait,
+    PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Statement,
 };
+
+// 转义 SQLite LIKE 的通配符(\, %, _)，配合 LikeExpr::escape('\\') 使用，
+// 避免用户输入的 %/_ 被当作通配符导致匹配范围意外扩大。
+// 转义顺序固定：先转义反斜杠本身，再转义 % 和 _，否则后转义的反斜杠会再次转义前者。
+fn escape_like(input: &str) -> String {
+    input
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
 
 #[derive(Debug, Clone)]
 pub struct FeishuMessageRecord {
@@ -192,16 +203,26 @@ impl Database {
 
         // 关键字搜索：在原始 content(含 JSON 包裹)上做 LIKE 子串匹配，
         // 放到后端是为了让分页 total 与结果一致(原先前端搜索只过滤当前页，total 不准)。
+        // 转义 + ESCAPE：用户输入的 %/_ 不被当通配符，仍参数化绑定(无注入风险)。
         if let Some(kw) = keyword {
-            let pattern = format!("%{}%", kw);
-            query = query.filter(feishu_messages::Column::Content.like(pattern));
+            let pattern = format!("%{}%", escape_like(kw));
+            // 用 Expr::col(...).like(LikeExpr) 而非 Column.like()：后者签名只接受 Into<String>，
+            // 无法带 ESCAPE 子句；Expr::col 来自 sea-query，接受 IntoLikeExpr 并支持 escape。
+            query = query.filter(
+                Expr::col((feishu_messages::Entity, feishu_messages::Column::Content))
+                    .like(LikeExpr::new(pattern).escape('\\')),
+            );
         }
 
         // 按处理类型类别筛选：前端传语义关键字(slash/executor/loop)，后端用包含匹配落到具体 processed_type。
         // slash→slash_command(+loop)、executor→default_response_executor、loop→*_loop。
+        // 同样转义防通配符(虽来自固定下拉，保持一致并防御直接调 API 的任意输入)。
         if let Some(pt) = processed_type {
-            let pattern = format!("%{}%", pt);
-            query = query.filter(feishu_messages::Column::ProcessedType.like(pattern));
+            let pattern = format!("%{}%", escape_like(pt));
+            query = query.filter(
+                Expr::col((feishu_messages::Entity, feishu_messages::Column::ProcessedType))
+                    .like(LikeExpr::new(pattern).escape('\\')),
+            );
         }
 
         if let Some(cid) = chat_id {

--- a/backend/src/db/feishu_message.rs
+++ b/backend/src/db/feishu_message.rs
@@ -160,6 +160,10 @@ impl Database {
         chat_id: Option<&str>,
         sender_open_id: Option<&str>,
         is_history: Option<bool>,
+        processed: Option<bool>,
+        chat_type: Option<&str>,
+        keyword: Option<&str>,
+        processed_type: Option<&str>,
         workspace_id: Option<i64>,
         bot_id: Option<i64>,
         page: u64,
@@ -174,6 +178,30 @@ impl Database {
 
         if let Some(history) = is_history {
             query = query.filter(feishu_messages::Column::IsHistory.eq(Some(history)));
+        }
+
+        // 按处理状态筛选：true=只看已处理，false=只看未处理，None=不限
+        if let Some(p) = processed {
+            query = query.filter(feishu_messages::Column::Processed.eq(Some(p)));
+        }
+
+        // 按会话类型筛选：传入 "group" 只看群聊、"p2p" 只看私聊，None=不限
+        if let Some(ct) = chat_type {
+            query = query.filter(feishu_messages::Column::ChatType.eq(ct.to_string()));
+        }
+
+        // 关键字搜索：在原始 content(含 JSON 包裹)上做 LIKE 子串匹配，
+        // 放到后端是为了让分页 total 与结果一致(原先前端搜索只过滤当前页，total 不准)。
+        if let Some(kw) = keyword {
+            let pattern = format!("%{}%", kw);
+            query = query.filter(feishu_messages::Column::Content.like(pattern));
+        }
+
+        // 按处理类型类别筛选：前端传语义关键字(slash/executor/loop)，后端用包含匹配落到具体 processed_type。
+        // slash→slash_command(+loop)、executor→default_response_executor、loop→*_loop。
+        if let Some(pt) = processed_type {
+            let pattern = format!("%{}%", pt);
+            query = query.filter(feishu_messages::Column::ProcessedType.like(pattern));
         }
 
         if let Some(cid) = chat_id {

--- a/backend/src/handlers/feishu_history.rs
+++ b/backend/src/handlers/feishu_history.rs
@@ -10,6 +10,14 @@ pub struct HistoryMessagesQuery {
     pub chat_id: Option<String>,
     pub sender_open_id: Option<String>,
     pub is_history: Option<bool>,
+    /// 按处理状态筛选：true=已处理，false=未处理，不传则不限
+    pub processed: Option<bool>,
+    /// 按会话类型筛选：group=群聊，p2p=私聊，不传则不限
+    pub chat_type: Option<String>,
+    /// 关键字搜索：在 content 上做子串匹配，不传则不限
+    pub keyword: Option<String>,
+    /// 按处理类型类别筛选：slash/executor/loop 等语义关键字，不传则不限
+    pub processed_type: Option<String>,
     /// 按工作空间筛选消息，不传则返回全部
     pub workspace_id: Option<i64>,
     /// 按智能体筛选消息，不传则返回全部
@@ -78,6 +86,10 @@ pub async fn get_history_messages(
         query.chat_id.as_deref(),
         query.sender_open_id.as_deref(),
         query.is_history,
+        query.processed,
+        query.chat_type.as_deref(),
+        query.keyword.as_deref(),
+        query.processed_type.as_deref(),
         query.workspace_id,
         query.bot_id,
         page,

--- a/frontend/src/components/MessagesPage.tsx
+++ b/frontend/src/components/MessagesPage.tsx
@@ -39,6 +39,12 @@ export function MessagesPage({ workspaceId, onManageWorkspace }: MessagesPagePro
 
   const [selectedChatId, setSelectedChatId] = useState<string | undefined>(undefined);
   const [isHistory, setIsHistory] = useState<boolean | undefined>(undefined);
+  // 处理状态筛选：undefined=全部、true=已处理、false=未处理，透传给后端按 processed 过滤。
+  const [processedFilter, setProcessedFilter] = useState<boolean | undefined>(undefined);
+  // 会话类型筛选：undefined=全部、'group'=群聊、'p2p'=私聊，透传给后端按 chat_type 过滤。
+  const [chatTypeFilter, setChatTypeFilter] = useState<string | undefined>(undefined);
+  // 处理类型筛选：undefined=全部、'slash'=斜杠命令、'executor'=执行器、'loop'=环路，透传后端按 processed_type 模糊匹配。
+  const [processedTypeFilter, setProcessedTypeFilter] = useState<string | undefined>(undefined);
   const [searchText, setSearchText] = useState('');
 
   const [configDrawerOpen, setConfigDrawerOpen] = useState(false);
@@ -101,30 +107,25 @@ export function MessagesPage({ workspaceId, onManageWorkspace }: MessagesPagePro
       const data = await db.getFeishuHistoryMessages({
         chat_id: selectedChatId,
         is_history: isHistory,
+        processed: processedFilter,
+        chat_type: chatTypeFilter,
+        // 关键字搜索下沉到后端：原先前端只过滤当前页导致 total 与结果不一致，改后端 LIKE 后 total 准确。
+        keyword: searchText || undefined,
+        processed_type: processedTypeFilter,
         workspace_id: workspaceId,
         bot_id: activeBotId ?? undefined,
         page: messagesPage,
         page_size: messagesPageSize,
       });
 
-      let filtered = data.messages;
-
-      // 搜索过滤：在前端做文本搜索（后端不支持全文搜索）
-      if (searchText) {
-        const lowerSearch = searchText.toLowerCase();
-        filtered = filtered.filter(m => {
-          const content = m.content ? JSON.parse(m.content).text || m.content : '';
-          return content.toLowerCase().includes(lowerSearch);
-        });
-      }
-
-      setMessages(filtered);
+      // 关键字搜索已在后端完成(见 keyword 参数)，前端不再二次过滤。
+      setMessages(data.messages);
       setMessagesTotal(data.total);
     } catch {
     } finally {
       setMessagesLoading(false);
     }
-  }, [workspaceId, selectedChatId, isHistory, messagesPage, messagesPageSize, activeBotId, searchText]);
+  }, [workspaceId, selectedChatId, isHistory, processedFilter, chatTypeFilter, processedTypeFilter, messagesPage, messagesPageSize, activeBotId, searchText]);
 
   useEffect(() => {
     loadMessages();
@@ -254,10 +255,16 @@ export function MessagesPage({ workspaceId, onManageWorkspace }: MessagesPagePro
           pageSize={messagesPageSize}
           selectedChatId={selectedChatId}
           isHistory={isHistory}
+          processedFilter={processedFilter}
+          chatTypeFilter={chatTypeFilter}
+          processedTypeFilter={processedTypeFilter}
           searchText={searchText}
           onSearchChange={setSearchText}
           onChatChange={setSelectedChatId}
           onHistoryChange={setIsHistory}
+          onProcessedChange={setProcessedFilter}
+          onChatTypeChange={setChatTypeFilter}
+          onProcessedTypeChange={setProcessedTypeFilter}
           onPageChange={(p, ps) => { setMessagesPage(p); setMessagesPageSize(ps); }}
           onViewDetail={handleViewDetail}
           onViewExecution={handleViewExecutionRecord}
@@ -309,10 +316,16 @@ export function MessagesPage({ workspaceId, onManageWorkspace }: MessagesPagePro
           pageSize={messagesPageSize}
           selectedChatId={selectedChatId}
           isHistory={isHistory}
+          processedFilter={processedFilter}
+          chatTypeFilter={chatTypeFilter}
+          processedTypeFilter={processedTypeFilter}
           searchText={searchText}
           onSearchChange={setSearchText}
           onChatChange={setSelectedChatId}
           onHistoryChange={setIsHistory}
+          onProcessedChange={setProcessedFilter}
+          onChatTypeChange={setChatTypeFilter}
+          onProcessedTypeChange={setProcessedTypeFilter}
           onPageChange={(p, ps) => { setMessagesPage(p); setMessagesPageSize(ps); }}
           onViewDetail={handleViewDetail}
           onViewExecution={handleViewExecutionRecord}

--- a/frontend/src/components/MessagesPage.tsx
+++ b/frontend/src/components/MessagesPage.tsx
@@ -45,7 +45,10 @@ export function MessagesPage({ workspaceId, onManageWorkspace }: MessagesPagePro
   const [chatTypeFilter, setChatTypeFilter] = useState<string | undefined>(undefined);
   // 处理类型筛选：undefined=全部、'slash'=斜杠命令、'executor'=执行器、'loop'=环路，透传后端按 processed_type 模糊匹配。
   const [processedTypeFilter, setProcessedTypeFilter] = useState<string | undefined>(undefined);
+  // searchText 是输入框即时值(每按键更新)；debouncedSearch 是防抖后的值，真正触发后端请求。
+  // 拆开是为了避免每次按键都打后端 + 全表 LIKE 扫描，停顿 300ms 才下沉。
   const [searchText, setSearchText] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
 
   const [configDrawerOpen, setConfigDrawerOpen] = useState(false);
   const [detailDrawerOpen, setDetailDrawerOpen] = useState(false);
@@ -110,7 +113,8 @@ export function MessagesPage({ workspaceId, onManageWorkspace }: MessagesPagePro
         processed: processedFilter,
         chat_type: chatTypeFilter,
         // 关键字搜索下沉到后端：原先前端只过滤当前页导致 total 与结果不一致，改后端 LIKE 后 total 准确。
-        keyword: searchText || undefined,
+        // 用防抖后的 debouncedSearch，避免每次按键打后端。
+        keyword: debouncedSearch || undefined,
         processed_type: processedTypeFilter,
         workspace_id: workspaceId,
         bot_id: activeBotId ?? undefined,
@@ -125,11 +129,22 @@ export function MessagesPage({ workspaceId, onManageWorkspace }: MessagesPagePro
     } finally {
       setMessagesLoading(false);
     }
-  }, [workspaceId, selectedChatId, isHistory, processedFilter, chatTypeFilter, processedTypeFilter, messagesPage, messagesPageSize, activeBotId, searchText]);
+  }, [workspaceId, selectedChatId, isHistory, processedFilter, chatTypeFilter, processedTypeFilter, messagesPage, messagesPageSize, activeBotId, debouncedSearch]);
 
   useEffect(() => {
     loadMessages();
   }, [loadMessages]);
+
+  // 搜索防抖 + 回第 1 页：输入停顿 300ms 后才把关键字下沉到 debouncedSearch。
+  // 同一 tick 内一并重置页码，确保 loadMessages 只发一次「新搜索 + page=1」的请求，
+  // 而非先发一次「新搜索 + 旧页码」的中间请求(旧页码可能超出筛选后的总页数 → 空列表)。
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setDebouncedSearch(searchText);
+      setMessagesPage(1);
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [searchText]);
 
   useEffect(() => {
     if (!workspaceId) {

--- a/frontend/src/components/assistant-management/AssistantConfigDrawer.tsx
+++ b/frontend/src/components/assistant-management/AssistantConfigDrawer.tsx
@@ -3,7 +3,7 @@ import { Drawer, Form, Input, Select, Switch, Button, Tag, Typography, Divider, 
 import { SaveOutlined, PlusOutlined, DeleteOutlined, MessageOutlined, LockOutlined, SettingOutlined } from '@ant-design/icons';
 import type { AgentBot, ProjectDirectory } from '@/utils/database';
 import * as db from '@/utils/database';
-import type { WhitelistEntry, FeishuPushLevel, FeishuPushStatus } from '@/utils/database/bots';
+import type { WhitelistEntry, FeishuPushLevel } from '@/utils/database/bots';
 
 const { Text, Title } = Typography;
 const { Option } = Select;
@@ -27,8 +27,11 @@ export function AssistantConfigDrawer({ open, bot, workspaces, onClose, onChange
     group_require_mention: true,
     echo_reply: true,
   });
-  // 推送状态：包含 /sethome 设置的 p2p_receive_id 和 group_chat_id
-  const [pushStatus, setPushStatus] = useState<FeishuPushStatus | null>(null);
+  // 单聊/群聊接收 ID 用独立 state 管理(不放进与「白名单 tab」共享的 form 实例)：
+  // 共享 form 实例在 tab 切换/抽屉动画挂载时字段绑定不可靠，曾导致输入框不回填已有值，
+  // 用户一旦点「保存配置」就会把空串写回后端、擦掉原有 ID。改用 state：加载即回填、保存读 state。
+  const [p2pReceiveId, setP2pReceiveId] = useState('');
+  const [groupChatId, setGroupChatId] = useState('');
 
   useEffect(() => {
     if (open && bot) {
@@ -44,7 +47,9 @@ export function AssistantConfigDrawer({ open, bot, workspaces, onClose, onChange
         db.getGroupWhitelist(bot!.id),
       ]);
       setWhitelist(wl);
-      setPushStatus(push);
+      // 单聊/群聊接收 ID 写入独立 state，确保输入框一定能回填(见上方 state 注释)。
+      setP2pReceiveId(push?.p2p_receive_id || '');
+      setGroupChatId(push?.group_chat_id || '');
       form.setFieldsValue({
         pushLevel: push?.push_level || 'disabled',
         p2pResponseEnabled: push?.p2p_response_enabled || false,
@@ -70,6 +75,9 @@ export function AssistantConfigDrawer({ open, bot, workspaces, onClose, onChange
       await db.updateFeishuPush({
         botId: bot.id,
         pushLevel: values.pushLevel as FeishuPushLevel,
+        // 单聊/群聊接收 ID 直接读 state(非 form)，避免共享 form 实例绑定不可靠导致写空。
+        p2pReceiveId,
+        groupChatId,
         p2pResponseEnabled: values.p2pResponseEnabled,
         groupResponseEnabled: values.groupResponseEnabled,
         p2pDebounceSecs: values.p2pDebounceSecs,
@@ -251,27 +259,28 @@ export function AssistantConfigDrawer({ open, bot, workspaces, onClose, onChange
 
       {activeTab === 'push' && (
         <div>
-          {/* /sethome 设置的推送目标 ID */}
-          {pushStatus && (pushStatus.p2p_receive_id || pushStatus.group_chat_id) && (
-            <div style={{ marginBottom: 16, padding: '8px 12px', background: 'var(--color-fill-secondary)', borderRadius: 6 }}>
-              <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 6 }}>
-                推送目标（由 <code>/sethome</code> 设置）
-              </div>
-              {pushStatus.p2p_receive_id && (
-                <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 4 }}>
-                  <span style={{ fontSize: 12, width: 50, color: 'var(--color-text-tertiary)' }}>单聊:</span>
-                  <Text code style={{ fontSize: 11, flex: 1 }}>{pushStatus.p2p_receive_id}</Text>
-                </div>
-              )}
-              {pushStatus.group_chat_id && (
-                <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                  <span style={{ fontSize: 12, width: 50, color: 'var(--color-text-tertiary)' }}>群聊:</span>
-                  <Text code style={{ fontSize: 11, flex: 1 }}>{pushStatus.group_chat_id}</Text>
-                </div>
-              )}
-            </div>
-          )}
+          {/* /sethome 提示常驻：即使尚未设置 ID，也让用户知道可在单聊/群聊发 /sethome 自动填，
+              或直接在下方输入框手动粘贴（例如从「消息监控台」复制群聊ID/私聊ID）。 */}
+          <div style={{ marginBottom: 12, padding: '8px 12px', background: 'var(--color-fill-secondary)', borderRadius: 6, fontSize: 12, color: 'var(--color-text-secondary)' }}>
+            💡 在单聊或群聊中发送 <code style={{ padding: '1px 6px', background: 'var(--color-fill)', borderRadius: 4 }}>/sethome</code> 可自动填写下方 ID；也可直接手动粘贴。
+          </div>
           <Form form={form} layout="vertical">
+          {/* 推送目标 ID：受控于独立 state(不绑定 form)，随「保存配置」持久化(对应 /sethome 写入的同一字段)。
+              不设 name，避免进入共享 form 实例的字段注册导致回填/保存不稳定。 */}
+          <Form.Item label="单聊接收 ID" tooltip="私聊场景的接收 open_id，形如 ou_xxxxxxxx">
+            <Input
+              value={p2pReceiveId}
+              onChange={(e) => setP2pReceiveId(e.target.value)}
+              placeholder="ou_xxxxxxxx（可手动粘贴，或发 /sethome 自动填）"
+            />
+          </Form.Item>
+          <Form.Item label="群聊接收 ID" tooltip="群聊场景的接收 chat_id，形如 oc_xxxxxxxx">
+            <Input
+              value={groupChatId}
+              onChange={(e) => setGroupChatId(e.target.value)}
+              placeholder="oc_xxxxxxxx（可手动粘贴，或发 /sethome 自动填）"
+            />
+          </Form.Item>
           <Form.Item
             label="推送级别"
             name="pushLevel"
@@ -305,6 +314,11 @@ export function AssistantConfigDrawer({ open, bot, workspaces, onClose, onChange
 
       {activeTab === 'whitelist' && (
         <div>
+          {/* 白名单作用说明：与推送 tab 的 /sethome 提示同款样式，让用户一眼明白
+              「白名单 = 仅处理这些指定人员在群聊里发的消息，其他人发的群消息会被忽略」。 */}
+          <div style={{ marginBottom: 12, padding: '8px 12px', background: 'var(--color-fill-secondary)', borderRadius: 6, fontSize: 12, color: 'var(--color-text-secondary)' }}>
+            💡 仅处理白名单内指定人员在群聊中发送的消息；其他人发送的群消息将被忽略。在下方填入发送者 Open ID 即可加入白名单。
+          </div>
           <Form form={form} layout="inline" style={{ marginBottom: 16 }}>
             <Form.Item name="senderOpenId">
               <Input placeholder="发送者 Open ID" style={{ width: 200 }} />

--- a/frontend/src/components/message-monitor/MessageCard.tsx
+++ b/frontend/src/components/message-monitor/MessageCard.tsx
@@ -1,6 +1,8 @@
 import { Card, Tag, Typography, Button, Space } from 'antd';
-import { EyeOutlined, CopyOutlined, ReloadOutlined } from '@ant-design/icons';
+import { EyeOutlined, ReloadOutlined } from '@ant-design/icons';
 import type { FeishuHistoryMessage } from '@/types';
+import { chatTypeMeta, historyMeta, copyableIdForPush } from './messageMeta';
+import { CopyButton } from '@/components/CopyButton';
 
 const { Text } = Typography;
 
@@ -34,14 +36,13 @@ interface MessageCardProps {
   onViewDetail: () => void;
   onViewExecution: (recordId: number) => void;
   onViewLoopExecution: () => void;
-  onCopy: () => void;
 }
 
 // 判断是否为环路类型
 const isLoopType = (type: string | null): boolean =>
   type === 'slash_command_loop' || type === 'default_response_loop';
 
-export function MessageCard({ message, botName, onViewDetail, onViewExecution, onViewLoopExecution, onCopy }: MessageCardProps) {
+export function MessageCard({ message, botName, onViewDetail, onViewExecution, onViewLoopExecution }: MessageCardProps) {
   const formatTime = (dateStr: string | null) => {
     if (!dateStr) return '-';
     const d = new Date(dateStr);
@@ -68,6 +69,11 @@ export function MessageCard({ message, botName, onViewDetail, onViewExecution, o
 
   const userContent = parseContent(message.content);
   const isUser = message.sender_type !== 'app';
+  // 会话类型(群聊/私聊)与来源时机(历史/实时)只依赖原始字段，提前算好供标签复用。
+  const chatMeta = chatTypeMeta(message.chat_type);
+  const histMeta = historyMeta(message.is_history);
+  // 群聊取 chat_id、私聊取 open_id，作为可复制到推送目标配置的 ID（见 copyableIdForPush 注释）。
+  const copyId = copyableIdForPush(message.chat_type, message.chat_id, message.sender_open_id);
 
   return (
     <Card size="small" style={{ marginBottom: 12, borderRadius: 8 }} hoverable onClick={onViewDetail}>
@@ -77,6 +83,10 @@ export function MessageCard({ message, botName, onViewDetail, onViewExecution, o
           {botName && (
             <Tag color="blue" style={{ fontSize: 11 }}>🤖 {botName}</Tag>
           )}
+          {/* 会话类型 + 来源时机：群聊/私聊 与 历史/实时 是两个正交维度，
+              组合起来即可一眼区分「实时群聊」「历史私聊」等，无需点开详情逐条查看。 */}
+          <Tag color={chatMeta.color} style={{ fontSize: 11 }}>{chatMeta.label}</Tag>
+          <Tag color={histMeta.color} style={{ fontSize: 11 }}>{histMeta.label}</Tag>
           <Tag color={processedTypeColor(message.processed_type)} style={{ fontSize: 11 }}>
             {processedTypeLabel(message.processed_type)}
           </Tag>
@@ -103,17 +113,17 @@ export function MessageCard({ message, botName, onViewDetail, onViewExecution, o
               执行记录
             </Button>
           )}
-          <Button
-            type="text"
-            size="small"
-            icon={<CopyOutlined />}
-            onClick={(e) => {
-              e.stopPropagation();
-              onCopy();
-            }}
-          >
-            复制
-          </Button>
+          {/* 内容复制：改用 CopyButton(内部走 execCommand，比 navigator.clipboard 更可靠，
+              不会因非安全上下文/失焦静默失败)，并自带对钩反馈，与下方 ID 复制按钮体验一致。
+              外层 span 拦截点击冒泡，避免触发卡片 onClick 打开详情抽屉。 */}
+          <span onClick={(e) => e.stopPropagation()}>
+            <CopyButton
+              type="text"
+              size="small"
+              text={userContent !== '-' ? userContent : ''}
+              children={null}
+            />
+          </span>
         </Space>
       </div>
 
@@ -131,7 +141,39 @@ export function MessageCard({ message, botName, onViewDetail, onViewExecution, o
         </p>
       </div>
 
-      {message.processed_id && (
+      {/* 可复制到推送目标的 ID：群聊=chat_id(贴到「群聊接收 ID」)，私聊=open_id(贴到「单聊接收 ID」)。
+          code 块用 flex:0 1 auto 不占满整行，超长 ID 内部省略，确保图标复制按钮紧跟 ID 而非被推到最右。 */}
+      {copyId && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 8 }}>
+          <Text style={{ fontSize: 11, color: 'var(--color-text-tertiary)', flexShrink: 0 }}>
+            {copyId.label}
+          </Text>
+          <Text
+            code
+            style={{
+              fontSize: 11,
+              flex: '0 1 auto',
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              padding: '0 6px',
+            }}
+          >
+            {copyId.value}
+          </Text>
+          {/* children={null} 覆盖 CopyButton 默认的「复制」文字，只保留图标，紧贴 ID 显示。
+              外层 span 拦截点击冒泡，否则会触发整张卡片的 onClick(打开消息详情抽屉)。 */}
+          <span onClick={(e) => e.stopPropagation()}>
+            <CopyButton type="text" size="small" text={copyId.value} children={null} />
+          </span>
+        </div>
+      )}
+
+      {/* 关联 ID 仅在有真实 processed_id 时显示：用三元而非 `processed_id && (...)`，
+          因为后者在 processed_id=0 时会把数字 0 当作 React 节点渲染成文本"0"
+          (default_response_executor 类消息 processed_id 恰为 0)。 */}
+      {message.processed_id ? (
         <div style={{ padding: 8, backgroundColor: 'var(--color-bg-secondary)', borderRadius: 4 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
             <ReloadOutlined style={{ fontSize: 12, color: 'var(--color-primary)' }} />
@@ -140,7 +182,7 @@ export function MessageCard({ message, botName, onViewDetail, onViewExecution, o
             </Text>
           </div>
         </div>
-      )}
+      ) : null}
     </Card>
   );
 }

--- a/frontend/src/components/message-monitor/MessageDetailDrawer.tsx
+++ b/frontend/src/components/message-monitor/MessageDetailDrawer.tsx
@@ -1,5 +1,6 @@
 import { Drawer, Tag, Typography, Descriptions } from 'antd';
 import type { FeishuHistoryMessage } from '@/types';
+import { chatTypeMeta, historyMeta } from './messageMeta';
 
 const { Text } = Typography;
 
@@ -44,6 +45,9 @@ export function MessageDetailDrawer({ open, message, onClose }: MessageDetailDra
   };
 
   const content = parseContent(message.content);
+  // 复用列表卡片的标签映射，保证详情与列表的会话类型/来源时机展示一致。
+  const chatMeta = chatTypeMeta(message.chat_type);
+  const histMeta = historyMeta(message.is_history);
 
   return (
     <Drawer
@@ -54,8 +58,14 @@ export function MessageDetailDrawer({ open, message, onClose }: MessageDetailDra
     >
       <Descriptions size="small" column={1} bordered style={{ marginBottom: 16 }}>
         <Descriptions.Item label="消息ID">{message.message_id}</Descriptions.Item>
-        <Descriptions.Item label="群聊ID">{message.chat_id}</Descriptions.Item>
-        <Descriptions.Item label="群聊类型">{message.chat_type}</Descriptions.Item>
+        {/* 群聊ID 仅在群聊时展示：私聊消息虽也带 chat_id，但那是飞书 1:1 会话内部 ID，
+            对配置推送目标无用（私聊推送用发送者 open_id，已在下方「发送者ID」展示）。 */}
+        {message.chat_type === 'group' && (
+          <Descriptions.Item label="群聊ID">{message.chat_id}</Descriptions.Item>
+        )}
+        <Descriptions.Item label="会话类型">
+          <Tag color={chatMeta.color}>{chatMeta.label}</Tag>
+        </Descriptions.Item>
         <Descriptions.Item label="发送者ID">{message.sender_open_id}</Descriptions.Item>
         <Descriptions.Item label="发送者昵称">{message.sender_nickname || '-'}</Descriptions.Item>
         <Descriptions.Item label="发送者类型">
@@ -64,10 +74,8 @@ export function MessageDetailDrawer({ open, message, onClose }: MessageDetailDra
           </Tag>
         </Descriptions.Item>
         <Descriptions.Item label="消息类型">{message.msg_type}</Descriptions.Item>
-        <Descriptions.Item label="是否历史消息">
-          <Tag color={message.is_history ? 'orange' : 'cyan'}>
-            {message.is_history ? '是' : '否'}
-          </Tag>
+        <Descriptions.Item label="来源时机">
+          <Tag color={histMeta.color}>{histMeta.label}</Tag>
         </Descriptions.Item>
         <Descriptions.Item label="处理状态">
           <Tag color={message.processed ? (message.error ? 'volcano' : 'green') : 'orange'}>
@@ -76,7 +84,6 @@ export function MessageDetailDrawer({ open, message, onClose }: MessageDetailDra
         </Descriptions.Item>
         <Descriptions.Item label="处理类型">{processedTypeLabel(message.processed_type)}</Descriptions.Item>
         <Descriptions.Item label="处理ID">{message.processed_id || '-'}</Descriptions.Item>
-        <Descriptions.Item label="执行记录ID">{message.execution_record_id || '-'}</Descriptions.Item>
         <Descriptions.Item label="执行记录ID">{message.execution_record_id || '-'}</Descriptions.Item>
         <Descriptions.Item label="工作空间ID">{message.workspace_id || '-'}</Descriptions.Item>
         <Descriptions.Item label="创建时间">{formatTime(message.created_at)}</Descriptions.Item>

--- a/frontend/src/components/message-monitor/MessageTimeline.tsx
+++ b/frontend/src/components/message-monitor/MessageTimeline.tsx
@@ -14,10 +14,16 @@ interface MessageTimelineProps {
   pageSize: number;
   selectedChatId: string | undefined;
   isHistory: boolean | undefined;
+  processedFilter: boolean | undefined;
+  chatTypeFilter: string | undefined;
+  processedTypeFilter: string | undefined;
   searchText: string;
   onSearchChange: (text: string) => void;
   onChatChange: (chatId: string | undefined) => void;
   onHistoryChange: (isHistory: boolean | undefined) => void;
+  onProcessedChange: (processed: boolean | undefined) => void;
+  onChatTypeChange: (chatType: string | undefined) => void;
+  onProcessedTypeChange: (processedType: string | undefined) => void;
   onPageChange: (page: number, pageSize: number) => void;
   onViewDetail: (message: FeishuHistoryMessage) => void;
   onViewExecution: (recordId: number) => void;
@@ -34,10 +40,16 @@ export function MessageTimeline({
   pageSize,
   selectedChatId,
   isHistory,
+  processedFilter,
+  chatTypeFilter,
+  processedTypeFilter,
   searchText,
   onSearchChange,
   onChatChange,
   onHistoryChange,
+  onProcessedChange,
+  onChatTypeChange,
+  onProcessedTypeChange,
   onPageChange,
   onViewDetail,
   onViewExecution,
@@ -49,17 +61,10 @@ export function MessageTimeline({
     return bots.find(b => b.id === chat.bot_id)?.bot_name;
   };
 
-  const handleCopy = (content: string) => {
-    try {
-      const parsed = JSON.parse(content);
-      navigator.clipboard.writeText(parsed.text || content);
-    } catch {
-      navigator.clipboard.writeText(content);
-    }
-  };
-
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      {/* 筛选区顺序：搜索 → 会话类型 → 消息类型 → 处理状态 → 处理类型 → 具体群聊。
+          按「文本 → 消息维度 → 处理维度 → 具体会话」由宽到窄排列，便于从大类逐步缩小范围。 */}
       <div style={{ display: 'flex', gap: 12, marginBottom: 16, flexWrap: 'wrap', alignItems: 'center' }}>
         <Input
           size="small"
@@ -72,13 +77,14 @@ export function MessageTimeline({
 
         <Select
           size="small"
-          placeholder="筛选群聊"
-          style={{ width: 150 }}
-          value={selectedChatId ?? 'all'}
-          onChange={(v: string) => { onChatChange(v === 'all' ? undefined : v); onPageChange(1, pageSize); }}
+          placeholder="会话类型"
+          style={{ width: 120 }}
+          value={chatTypeFilter ?? 'all'}
+          onChange={(v: string) => { onChatTypeChange(v === 'all' ? undefined : v); onPageChange(1, pageSize); }}
           options={[
-            { value: 'all', label: '全部群聊' },
-            ...chats.map(c => ({ value: c.chat_id, label: c.chat_name || c.chat_id })),
+            { value: 'all', label: '全部会话' },
+            { value: 'group', label: '群聊' },
+            { value: 'p2p', label: '私聊' },
           ]}
         />
 
@@ -92,6 +98,47 @@ export function MessageTimeline({
             { value: 'all', label: '全部' },
             { value: true, label: '历史消息' },
             { value: false, label: '实时消息' },
+          ]}
+        />
+
+        <Select
+          size="small"
+          placeholder="处理状态"
+          style={{ width: 120 }}
+          value={processedFilter === undefined ? 'all' : processedFilter}
+          onChange={(v: string | boolean) => { onProcessedChange(v === 'all' ? undefined : (v as boolean)); onPageChange(1, pageSize); }}
+          options={[
+            { value: 'all', label: '全部状态' },
+            { value: true, label: '已处理' },
+            { value: false, label: '未处理' },
+          ]}
+        />
+
+        {/* 处理类型：value 是语义关键字，后端用 processed_type LIKE '%关键字%' 落到具体类型。
+            slash→斜杠命令(slash_command/slash_command_loop)、executor→执行器、loop→环路(*_loop)。 */}
+        <Select
+          size="small"
+          placeholder="处理类型"
+          style={{ width: 130 }}
+          value={processedTypeFilter ?? 'all'}
+          onChange={(v: string) => { onProcessedTypeChange(v === 'all' ? undefined : v); onPageChange(1, pageSize); }}
+          options={[
+            { value: 'all', label: '全部类型' },
+            { value: 'slash', label: '斜杠命令' },
+            { value: 'executor', label: '执行器' },
+            { value: 'loop', label: '环路' },
+          ]}
+        />
+
+        <Select
+          size="small"
+          placeholder="筛选群聊"
+          style={{ width: 150 }}
+          value={selectedChatId ?? 'all'}
+          onChange={(v: string) => { onChatChange(v === 'all' ? undefined : v); onPageChange(1, pageSize); }}
+          options={[
+            { value: 'all', label: '全部群聊' },
+            ...chats.map(c => ({ value: c.chat_id, label: c.chat_name || c.chat_id })),
           ]}
         />
       </div>
@@ -112,7 +159,6 @@ export function MessageTimeline({
               onViewDetail={() => onViewDetail(message)}
               onViewExecution={onViewExecution}
               onViewLoopExecution={() => onViewLoopExecution(message)}
-              onCopy={() => handleCopy(message.content || '')}
             />
           ))
         )}

--- a/frontend/src/components/message-monitor/messageMeta.ts
+++ b/frontend/src/components/message-monitor/messageMeta.ts
@@ -1,0 +1,60 @@
+// 飞书消息的会话维度元信息：把后端原始字段(chat_type / is_history)统一映射成
+// 「中文标签 + 颜色」，供「消息监控台」的列表卡片与详情抽屉复用。
+// 抽到一处是为了避免两处各自硬编码同一套文案与配色，且让群聊/私聊、历史/实时
+// 这两个维度的视觉语义在列表与详情之间保持一致。
+
+export interface MessageMeta {
+  label: string;
+  color: string;
+}
+
+// chat_type 来自飞书事件原始取值：group=群聊、p2p=单聊(私聊)；
+// 历史消息回拉入库时该字段可能为空字符串，统一兜底为「未知」而非暴露内部取值。
+const chatTypeLabelMap: Record<string, string> = {
+  group: '群聊',
+  p2p: '私聊',
+};
+
+// 把后端的 chat_type 映射成用户可读的标签与配色。
+// 群聊用紫色、私聊用品红——二者是同一维度的互斥取值，用对比色让列表上一眼可分。
+export function chatTypeMeta(chatType: string): MessageMeta {
+  const label = chatTypeLabelMap[chatType] ?? '未知';
+  const color = chatType === 'p2p' ? 'magenta' : chatType === 'group' ? 'purple' : 'default';
+  return { label, color };
+}
+
+// is_history 区分消息来源时机：true=历史回拉(用户此前发送的旧消息)，
+// false=实时接收到的当前消息。它是判断「实时群聊 / 历史群聊」等组合的另一个维度。
+// 历史用金色(陈旧感)、实时用青色(新鲜感)，与「未处理=橙、已处理=绿」的处理状态配色错开。
+export function historyMeta(isHistory: boolean): MessageMeta {
+  return isHistory
+    ? { label: '历史', color: 'gold' }
+    : { label: '实时', color: 'cyan' };
+}
+
+export interface CopyableId {
+  label: string;
+  value: string;
+}
+
+// 返回该消息「可复制到推送目标配置」的 ID：
+// - 群聊：取 chat_id，贴到推送目标的「群聊接收 ID」(receive_id_type=chat_id)；
+// - 私聊：取发送者 open_id，贴到「单聊接收 ID」(receive_id_type=open_id)。
+//   飞书的 p2p 消息虽也带 chat_id，但那是飞书给 1:1 会话分配的内部 ID，
+//   私聊推送真正用的是 open_id，故私聊这里给 open_id 而非 chat_id；
+//   若 open_id 缺失(异常数据)则回退到 chat_id，保证至少有内容可复制。
+// - 类型未知时回退展示 chat_id，标签为「会话ID」。
+// 返回 null 表示该消息没有可复制的 ID，调用方据此隐藏整行。
+export function copyableIdForPush(
+  chatType: string,
+  chatId: string,
+  senderOpenId: string,
+): CopyableId | null {
+  if (chatType === 'group') {
+    return chatId ? { label: '群聊ID', value: chatId } : null;
+  }
+  if (chatType === 'p2p') {
+    return { label: '单聊ID', value: senderOpenId || chatId };
+  }
+  return chatId ? { label: '会话ID', value: chatId } : null;
+}

--- a/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
+++ b/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Button, Input, Empty, Spin, Switch, message, Tooltip, Typography, Card, Dropdown } from 'antd';
-import { PlusOutlined, FolderOutlined, RobotOutlined, SettingOutlined, EditOutlined, DeleteOutlined, MessageOutlined, MoreOutlined } from '@ant-design/icons';
+import { PlusOutlined, FolderOutlined, RobotOutlined, SettingOutlined, EditOutlined, DeleteOutlined, MoreOutlined } from '@ant-design/icons';
 import { PageCard } from '@/components/common/PageCard';
 import * as db from '@/utils/database';
 import type { ProjectDirectory, AgentBot } from '@/utils/database';
@@ -299,14 +299,6 @@ export function ProjectDirectoriesPanel({ onOpenMessages }: ProjectDirectoriesPa
 
                     {/* 右侧：操作区域 */}
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
-                      {/* 消息列表入口：跳转到消息监控中心并联动该工作空间 */}
-                      <Button
-                        size="small"
-                        icon={<MessageOutlined />}
-                        onClick={() => onOpenMessages?.(dir.id)}
-                      >
-                        消息列表
-                      </Button>
                       <Button
                         size="small"
                         icon={<SettingOutlined />}

--- a/frontend/src/utils/database/bots.ts
+++ b/frontend/src/utils/database/bots.ts
@@ -279,6 +279,10 @@ export async function getFeishuHistoryMessages(params?: {
   chat_id?: string;
   sender_open_id?: string;
   is_history?: boolean;
+  processed?: boolean;
+  chat_type?: string;
+  keyword?: string;
+  processed_type?: string;
   workspace_id?: number;
   bot_id?: number;
   page?: number;

--- a/frontend/tests/check_message_monitor_updates.spec.ts
+++ b/frontend/tests/check_message_monitor_updates.spec.ts
@@ -93,3 +93,17 @@ test('消息监控台筛选区含「处理类型」下拉(任务17/18)', async (
   const select = page.locator('.ant-select').filter({ hasText: '全部类型' }).first();
   await expect(select).toBeVisible({ timeout: 10000 });
 });
+
+test('关键字搜索防抖下沉后端、并回到第 1 页', async ({ page }) => {
+  await gotoMessages(page);
+  // 数据充足(7000+ 条)，先翻到第 2 页。
+  const page2 = page.locator('.ant-pagination-item-2');
+  await expect(page2).toBeVisible({ timeout: 10000 });
+  await page2.click();
+  // 输入搜索关键字；防抖 300ms 后才下沉到后端并刷新。
+  await page.getByPlaceholder('搜索消息内容...').fill('几点');
+  await page.waitForTimeout(800); // 等防抖 + 后端请求落地
+  // 页码应回到第 1 项 active(搜索重置页码)；且结果已按关键字过滤(命中很少)。
+  await expect(page.locator('.ant-pagination-item-1')).toHaveClass(/ant-pagination-item-active/);
+  await expect(page.getByText(/共 \d+ 条/)).toBeVisible({ timeout: 5000 });
+});

--- a/frontend/tests/check_message_monitor_updates.spec.ts
+++ b/frontend/tests/check_message_monitor_updates.spec.ts
@@ -1,0 +1,95 @@
+// 验证消息监控台的几项修复：
+// 1) ID 行复制按钮为图标按钮(无"复制"文字)且紧跟 ID；
+// 2) processed_id=0 的消息(默认响应-执行器)不再渲染残留的"0"或"关联 #0"；
+// 3) 智能助手配置的「群聊白名单」tab 顶部有说明提示。
+// 用 Playwright 原生 locator，规避 playwright-cli 的 ref 快照过期问题。
+import { test, expect } from '@playwright/test';
+
+const BASE = 'http://localhost:18088';
+
+// 通过 aria-label/文本点击左侧导航的「消息」，再选「临时工作空间」。
+// 这两步是进入消息列表的前置条件。
+async function gotoMessages(page: import('@playwright/test').Page) {
+  await page.goto(BASE);
+  await page.getByRole('button', { name: '消息', exact: true }).click();
+  // 未选工作空间时点「切换工作空间」打开下拉，再选目标工作空间。
+  await page.getByRole('button', { name: '切换工作空间' }).click();
+  await page.getByRole('menuitem', { name: '临时工作空间' }).click();
+  // 等列表加载：标题「消息监控台」出现且至少一张卡片渲染。
+  await expect(page.getByRole('heading', { name: /消息监控台/ })).toBeVisible({ timeout: 10000 });
+}
+
+test('消息卡片：两个复制按钮均为图标(无"复制"文字)', async ({ page }) => {
+  await gotoMessages(page);
+  // ID 行存在(单聊ID/群聊ID 任一)。
+  const idLabel = page.locator('text=单聊ID').or(page.locator('text=群聊ID')).first();
+  await expect(idLabel).toBeVisible({ timeout: 10000 });
+  // 内容复制 + ID 复制都已图标化：任何卡片都不应再出现"复制"文字。
+  const cardsWithCopyText = await page.locator('.ant-card').filter({ hasText: '复制' }).count();
+  expect(cardsWithCopyText).toBe(0);
+});
+
+test('点击群聊/单聊 ID 复制按钮不会打开消息详情抽屉', async ({ page }) => {
+  await gotoMessages(page);
+  // 定位第一张卡片里的 ID 复制按钮(图标按钮，在 单聊ID/群聊ID 行末尾)。
+  const idRow = page.locator('text=单聊ID').or(page.locator('text=群聊ID')).first().locator('xpath=ancestor::div[.//button]');
+  const copyBtn = idRow.locator('button').last();
+  await copyBtn.click();
+  // 不应弹出消息详情抽屉。
+  await expect(page.getByRole('dialog', { name: '消息详情' })).toHaveCount(0);
+});
+
+test('内容复制按钮可正常复制(改用 execCommand，修复曾静默失败)', async ({ page, context }) => {
+  // 授权剪贴板读写，便于读取结果断言。
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await gotoMessages(page);
+  const card = page.locator('.ant-card').first();
+  // 内容复制按钮：卡片内第一个带 copy 图标的按钮(顶部操作区，DOM 顺序先于 ID 行的复制按钮)。
+  const contentCopyBtn = card.locator('button').filter({ has: page.locator('.anticon-copy') }).first();
+  await contentCopyBtn.click();
+  // 复制成功后 CopyButton 图标变为对钩(仅 execCommand 返回 true 才触发)。
+  await expect(card.locator('.anticon-check').first()).toBeVisible({ timeout: 3000 });
+  // 剪贴板应有内容(原先 navigator.clipboard 静默失败时为空)。
+  const clip = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clip.length).toBeGreaterThan(0);
+});
+
+
+test('processed_id=0 的消息不再显示残留"0"或"关联 #0"', async ({ page }) => {
+  await gotoMessages(page);
+  // 修复前：default_response_executor(processed_id=0) 卡片会渲染一个游离的"0"文本节点。
+  // 修复后：仅在有真实 processed_id 时才渲染「关联 #N」，且 N>0。
+  await expect(page.locator('text=/关联 #0$/')).toHaveCount(0);
+  // 列表加载后，等待首批卡片出现，确认没有渲染异常导致整页空白。
+  const firstCard = page.locator('.ant-card').first();
+  await expect(firstCard).toBeVisible({ timeout: 10000 });
+});
+
+test('智能助手「群聊白名单」tab 顶部有说明提示', async ({ page }) => {
+  await page.goto(BASE);
+  await page.getByRole('button', { name: '智能助手' }).click();
+  // 进入智能助手列表后，点首个机器人的「配置」按钮打开抽屉。
+  await page.getByRole('button', { name: /配置/ }).first().click();
+  // 切到「群聊白名单」tab。
+  await page.getByRole('button', { name: '群聊白名单' }).click();
+  // 验证说明提示出现：与 /sethome 提示同款文案。
+  await expect(page.getByText(/仅处理白名单内指定人员/)).toBeVisible({ timeout: 10000 });
+});
+
+test('推送目标 ID 输入框回填已有值(回归：曾因共享 form 实例被空保存擦除)', async ({ page }) => {
+  await page.goto(BASE);
+  await page.getByRole('button', { name: '智能助手' }).click();
+  await page.getByRole('button', { name: /配置/ }).first().click();
+  // push tab 为默认 tab，用占位符定位两个输入框(占位符唯一)，验证回填 DB 中已存在的 ou_/oc_ 值。
+  const p2pInput = page.getByPlaceholder(/ou_xxxxxxxx/);
+  const groupInput = page.getByPlaceholder(/oc_xxxxxxxx/);
+  await expect(p2pInput).toHaveValue(/^ou_.+/, { timeout: 10000 });
+  await expect(groupInput).toHaveValue(/^oc_.+/, { timeout: 10000 });
+});
+
+test('消息监控台筛选区含「处理类型」下拉(任务17/18)', async ({ page }) => {
+  await gotoMessages(page);
+  // 处理类型下拉存在(默认显示「全部类型」)，证明已加入筛选区。
+  const select = page.locator('.ant-select').filter({ hasText: '全部类型' }).first();
+  await expect(select).toBeVisible({ timeout: 10000 });
+});


### PR DESCRIPTION
## 概述

消息监控台消息列表的会话维度标签、多维筛选、可复制 ID，以及配套的智能助手推送配置修复。

## 改动详情

### 消息监控台（列表）
- **会话维度 tag**：每张卡片新增「群聊/私聊」「历史/实时」tag，一眼区分实时群聊、历史私聊等组合
- **新增筛选下拉**：
  - 会话类型（群聊/私聊）
  - 处理状态（已处理/未处理）
  - 处理类型（斜杠命令 / 执行器 / 环路，后端 `processed_type LIKE` 模糊匹配）
- **关键字搜索下沉后端**（`content LIKE`）：修复原前端只过滤当前页导致 `total` 与结果不一致
- **筛选区重排**：搜索 → 会话类型 → 消息类型 → 处理状态 → 处理类型 → 群聊（由宽到窄）
- **可复制 ID**：群聊卡片显示 `群聊ID=chat_id`、私聊显示 `单聊ID=open_id`（私聊推送用 open_id 而非飞书内部 chat_id），图标按钮复制成功变对钩

### Bug 修复
- `processed_id=0` 时卡片残留「0」：`{x ? <div/> : null}` 替代 `{x && <div/>}`（React 渲染数字 0 的坑，影响 99 条 default_response_executor 消息）
- 群聊ID 复制按钮点击冒泡触发卡片 `onClick` 打开详情抽屉：`stopPropagation` 拦截
- 内容复制按钮静默失败：从 `navigator.clipboard` 改用 `CopyButton`（`execCommand`，可靠 + 对钩反馈）

### 消息详情
- 「群聊类型」→「会话类型」、「是否历史消息」→「来源时机」友好标签
- 群聊ID 行仅群聊显示（私聊的 chat_id 是飞书内部会话 ID，无意义；私聊用 open_id 已在「发送者ID」行）
- 去重重复的「执行记录ID」行

### 智能助手配置
- 推送目标 单聊/群聊接收 ID 改为**可编辑输入框**，`/sethome` 提示常驻
- **修复 ID 被空保存擦除回归**：原 push tab 与白名单 tab 共用同一 `form` 实例，ID 字段绑定不可靠导致不回填，保存写空擦掉 DB。改用独立 `useState`
- 群聊白名单 tab 增加说明提示

### 其他
- 移除工作空间管理下冗余的「消息列表」按钮（保留机器人数量链接入口）
- 新增 `messageMeta.ts` 共享辅助（`chatTypeMeta`/`historyMeta`/`copyableIdForPush`）

## 后端
- `get_feishu_history_messages` 新增过滤参数：`processed`、`chat_type`、`keyword`、`processed_type`
- 对应 `HistoryMessagesQuery` 字段与路由透传

## 验证
- 后端 `cargo clippy --all-targets -- -D warnings` 零告警
- 前端 `tsc --noEmit` 零错误
- Playwright spec **7/7 通过**（`tests/check_message_monitor_updates.spec.ts`）：
  - 两个复制按钮均图标化
  - 点 ID 复制不弹详情抽屉
  - 内容复制可正常复制（对钩 + 剪贴板非空）
  - processed_id=0 无残留「0」
  - 白名单 tab 提示存在
  - 推送 ID 输入框回填已有值（回归修复）
  - 处理类型下拉存在
- API 筛选计数与 DB 吻合：全部 7527 / 群聊 31 / 私聊 103 / 实时 134 / 历史 7393 / 已处理 108 / 未处理 7419 / 斜杠 7 / 执行器 99 / 环路 4