### PR TITLE
fix(pi): stdin 预写 y 仅在启用 git worktree 时生效

### DIFF
--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -398,6 +398,11 @@ pub trait CodeExecutor: Send + Sync {
     /// 自动应答（例如 pi 在启用 Worktree 切目录后会在交互式 prompt 卡住，
     /// 通过预写 "y" 自动确认目录切换）时可 override 返回 `Some(...)`。
     ///
+    /// 开关边界：本方法只声明「需要预写什么」，是否真的预写由 `save_child_pid_and_close_stdin`
+    /// 的 `worktree_active` 入参 gate——pi 的 y 应答只在切到 worktree 目录时才需要，
+    /// 未启用 worktree 时调用方不会进来，避免多余的输入污染子进程 stdin。因此 override
+    /// 时无需自行判断 worktree 状态，无条件返回需要的 payload 即可。
+    ///
     /// 实现要求：内容应一次性写入并立刻 flush；写入失败由调用方记录 warning 但不视为致命错误，
     /// 因为 stdin 关闭本身仍能保证子进程正常退出。
     fn stdin_payload(&self) -> Option<String> {

--- a/backend/src/adapters/pi.rs
+++ b/backend/src/adapters/pi.rs
@@ -274,8 +274,10 @@ impl CodeExecutor for PiExecutor {
     /// 等价于 `echo y | pi ...`：预写一行 y 后关闭 stdin，pi 读到 y 后继续后续执行，
     /// 不会再向 stdin 请求输入。
     ///
-    /// 仅在 pi 启动时（-p 模式）需要这一次应答；非交互模式（-p 下 pi 也走 stdin 询问）
-    /// 下也安全：多写一个 y 不会让 pi 异常。
+    /// 语义边界：本方法只描述「pi 切目录后需要应答 y」这一恒定事实，是否真的预写由
+    /// `save_child_pid_and_close_stdin` 的 `worktree_active` 入参 gate——未启用 worktree
+    /// 时调用方根本不会进来，避免多余的 y 污染 pi 的 stdin 输入流（被 pi 当作用户对
+    /// 其问题的应答消费掉）。因此这里无条件返回 `Some("y\n")` 是正确的：调用方负责开关。
     fn stdin_payload(&self) -> Option<String> {
         Some("y\n".to_string())
     }
@@ -424,8 +426,10 @@ mod tests {
         assert_eq!(executor.extract_session_id("not json"), None);
     }
 
-    /// stdin_payload 应返回 "y\n" —— 等价于 `echo "y" | pi -p ...`，
+    /// stdin_payload 恒返回 "y\n" —— 等价于 `echo "y" | pi -p ...`，
     /// 用来自动应答 pi 启用 Worktree 切目录后的交互式确认 prompt。
+    /// 注意：方法本身不判断 worktree 是否启用，开关由 `save_child_pid_and_close_stdin`
+    /// 的 `worktree_active` 入参 gate；这里只验证「需要预写时给出的内容是 y」。
     #[test]
     fn test_stdin_payload_returns_y() {
         let executor = PiExecutor::new("pi".to_string());

--- a/backend/src/executor_service/spawn_lifecycle.rs
+++ b/backend/src/executor_service/spawn_lifecycle.rs
@@ -56,7 +56,10 @@ pub(crate) async fn run_spawned_executor_task(spawned: super::types::SpawnInputs
     let Some(mut child) = try_spawn_executor_child(&runtime).await else {
         return;
     };
-    save_child_pid_and_close_stdin(&mut child, runtime.executor_spawn.as_ref(), &runtime.db, runtime.record_id).await;
+    // 仅当 worktree 真正启用（effective_workspace_path 有值）时才让 stdin payload 预写生效，
+    // 避免 pi 在未切目录场景下被多余的 `y` 污染 stdin 输入流。
+    let worktree_active = runtime.worktree_ctx.effective_workspace_path.is_some();
+    save_child_pid_and_close_stdin(&mut child, runtime.executor_spawn.as_ref(), &runtime.db, runtime.record_id, worktree_active).await;
 
     let (log_flusher, stdout_task, stderr_task, flush_timer) =
         setup_log_capture_pipeline_for(&runtime, &mut child).await;
@@ -162,30 +165,39 @@ pub(crate) async fn handle_spawn_failure(
 ///
 /// `executor` 用于查询 `stdin_payload()`：部分执行器（pi 等）需要在关闭 stdin 之前
 /// 预写自动应答，避免子进程卡在交互式 prompt 上；等价于 `echo y | pi -p ...`。
+///
+/// `worktree_active` 仅在本次执行真正启用了 git worktree（即 `WorktreeContext.effective_workspace_path`
+/// 为 `Some`）时传 true。pi 的 stdin 应答只有在这种场景下才需要——pi 切换到 worktree
+/// 目录后会弹"directory changed, continue? [y/N]"的交互式确认；未启用 worktree 时
+/// pi 不会弹该 prompt，预写 `y` 反而会污染 pi 的 stdin 输入流（被 pi 当作用户对
+/// 其问题的应答消费掉），所以 gate 在本参数上精准开关。
 pub(crate) async fn save_child_pid_and_close_stdin(
     child: &mut command_group::AsyncGroupChild,
     executor: &dyn crate::adapters::CodeExecutor,
     db: &Database,
     record_id: i64,
+    worktree_active: bool,
 ) {
-    // 若执行器声明需要预写 stdin（典型场景：pi 启用 Worktree 后会在交互式 prompt
-    // 卡住，等价于 `echo y | pi ...` 的管道输入），先一次性写入再关闭 stdin。
+    // 仅当本次执行启用了 worktree 才预写 stdin payload。pi 的交互式确认 prompt
+    // 只在切到 worktree 目录时出现；其他场景预写只会污染 stdin 输入流。
     // 写入失败不视为致命：关 stdin 本身仍能让子进程正常退出。
-    if let Some(payload) = executor.stdin_payload() {
-        if let Some(stdin) = child.inner().stdin.as_mut() {
-            if let Err(e) = stdin.write_all(payload.as_bytes()).await {
-                tracing::warn!(
-                    "[spawn] 写入执行器 stdin payload 失败: executor={} err={}",
-                    executor.executor_type().as_str(),
-                    e
-                );
-            }
-            if let Err(e) = stdin.flush().await {
-                tracing::warn!(
-                    "[spawn] flush 执行器 stdin 失败: executor={} err={}",
-                    executor.executor_type().as_str(),
-                    e
-                );
+    if worktree_active {
+        if let Some(payload) = executor.stdin_payload() {
+            if let Some(stdin) = child.inner().stdin.as_mut() {
+                if let Err(e) = stdin.write_all(payload.as_bytes()).await {
+                    tracing::warn!(
+                        "[spawn] 写入执行器 stdin payload 失败: executor={} err={}",
+                        executor.executor_type().as_str(),
+                        e
+                    );
+                }
+                if let Err(e) = stdin.flush().await {
+                    tracing::warn!(
+                        "[spawn] flush 执行器 stdin 失败: executor={} err={}",
+                        executor.executor_type().as_str(),
+                        e
+                    );
+                }
             }
         }
     }
@@ -728,5 +740,72 @@ mod tests {
                 rt.prepared.todo_workspace_path.as_ref(),
             )
         }
+    }
+
+    /// issue 回归：pi 的 `echo y` stdin 预写只应在启用 worktree 时生效。
+    /// 用 `cat` 作 mock child（把 stdin 回打到 stdout），分别传 worktree_active=false / true，
+    /// 断言前者 stdout 空（未预写）、后者 stdout 含 payload（预写生效）。
+    #[tokio::test]
+    async fn test_save_child_pid_and_close_stdin_gates_by_worktree_active() {
+        // 用 cat 把 stdin 内容回打到 stdout，作为「子进程是否收到 payload」的可观测代理。
+        // Memory DB 让 update_execution_record_pid 不依赖真实表结构（record_id 不存在时 update no-op）。
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+        // 用 pi executor：唯一 override stdin_payload 返回 Some("y\n") 的执行器，
+        // 让 gate 的「不进入 stdin_payload 分支」语义可被 stdout 是否含 y 验证。
+        let executor = crate::adapters::pi::PiExecutor::new("pi".to_string());
+
+        // 未启用 worktree：gate 关闭，不应预写任何 payload，cat 收到空 stdin → stdout 空。
+        let mut child_false = build_executor_command("cat", &[], None)
+            .group_spawn()
+            .expect("cat spawn must succeed");
+        save_child_pid_and_close_stdin(
+            &mut child_false,
+            &executor,
+            &db,
+            0,
+            false,
+        )
+        .await;
+        let stdout_false = {
+            // child 的 stdout 在 spawn 后由 group 持有；take 出来读全部内容直到 EOF。
+            // 用 read_to_end 而非 readline，因为 cat 关 stdin 后会立刻退出。
+            use tokio::io::AsyncReadExt;
+            let mut buf = Vec::new();
+            if let Some(mut out) = child_false.inner().stdout.take() {
+                out.read_to_end(&mut buf).await.expect("cat stdout read ok");
+            }
+            String::from_utf8_lossy(&buf).to_string()
+        };
+        assert_eq!(
+            stdout_false, "",
+            "worktree_active=false 时不应预写 stdin payload，cat stdout 应为空"
+        );
+
+        // 启用 worktree：gate 打开，预写 "y\n"，cat 回打 → stdout 含 "y\n"。
+        let mut child_true = build_executor_command("cat", &[], None)
+            .group_spawn()
+            .expect("cat spawn must succeed");
+        save_child_pid_and_close_stdin(
+            &mut child_true,
+            &executor,
+            &db,
+            0,
+            true,
+        )
+        .await;
+        let stdout_true = {
+            use tokio::io::AsyncReadExt;
+            let mut buf = Vec::new();
+            if let Some(mut out) = child_true.inner().stdout.take() {
+                out.read_to_end(&mut buf).await.expect("cat stdout read ok");
+            }
+            String::from_utf8_lossy(&buf).to_string()
+        };
+        assert_eq!(
+            stdout_true, "y\n",
+            "worktree_active=true 时应预写 pi 的 stdin payload 'y\\n'，cat stdout 应回打该内容"
+        );
     }
 }


### PR DESCRIPTION
## 问题

pi 执行器的 `stdin_payload()` 恒返回 `"y\n"`，调用方 `save_child_pid_and_close_stdin` 无条件写入。但该 `y` 应答只在 pi 切到 worktree 目录后弹出的「directory changed, continue? [y/N]」交互式确认 prompt 时才需要——**未启用 worktree 时预写 `y` 会污染 pi 的 stdin 输入流**，被 pi 当作用户对其问题的应答消费掉，可能导致非预期行为。

## 改造方案

把开关责任上移到调用方，而非 trait 方法自判：

| 文件 | 改动 |
|------|------|
| `executor_service/spawn_lifecycle.rs` | `save_child_pid_and_close_stdin` 增 `worktree_active: bool` 入参，仅当 true 时才调 `stdin_payload()` 并写入；调用点从 `runtime.worktree_ctx.effective_workspace_path.is_some()` 取值传入 |
| `adapters/pi.rs` | `stdin_payload()` 注释更新为「恒返回语义 + 开关由调用方 gate」，消除原「多写一个 y 也安全」的误导描述；单元测试注释同步 |
| `adapters/mod.rs` | trait `stdin_payload` 默认注释补充「调用方负责开关」的语义边界说明 |

**为什么不动 trait 约束**：`stdin_payload(&self)` 拿不到外部 worktree 信号，改 trait 签名会污染所有执行器。把 gate 放在 `save_child_pid_and_close_stdin` 既精准又不扩散污染范围。

## 验证

- `cd backend && cargo clippy --all-targets -- -D warnings` 零告警
- `cd backend && cargo test --lib adapters::pi::tests::test_stdin_payload_returns_y` ✅
- `cd backend && cargo test --lib executor_service::spawn_lifecycle::tests::test_save_child_pid_and_close_stdin_gates_by_worktree_active` ✅
  - 用 `cat` 作 mock child 验证 gate：`worktree_active=false` → stdout 空（未预写）；`worktree_active=true` + pi executor → stdout 含 `"y\n"`（预写生效）
- `cd frontend && npx tsc --noEmit` 零错误

Co-Authored-By: AtomCode (GLM-5.2) <noreply@atomgit.com>