### PR TITLE
fix(pi): 修复 pi stdin y 在非 worktree 路径泄漏

### DIFF
--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -687,7 +687,7 @@ async fn spawn_executor_for_chat_streaming(
     session_id: Option<String>,
     timeout_secs: u64,
 ) -> Result<(Vec<crate::models::ParsedLogEntry>, String, String, bool), AppError> {
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::io::{AsyncBufReadExt, BufReader};
     use crate::executor_service::events::ExecEvent;
 
     let program = executor.executable_path();
@@ -713,20 +713,11 @@ async fn spawn_executor_for_chat_streaming(
         AppError::Internal(format!("启动执行器失败: {}", e))
     })?;
 
-    // 处理 stdin：无论是否有 payload，都需要 take() 并 drop 以确保 stdin 关闭，
-    // 避免 CLI 进程挂起等待 EOF。
-    if let Some(mut stdin) = child.stdin.take() {
-        if let Some(payload) = executor.stdin_payload() {
-            stdin
-                .write_all(payload.as_bytes())
-                .await
-                .map_err(|e| AppError::Internal(format!("写入 stdin payload 失败: {}", e)))?;
-            stdin
-                .flush()
-                .await
-                .map_err(|e| AppError::Internal(format!("flush stdin 失败: {}", e)))?;
-        }
-        drop(stdin);
+    // stdin 处理：take() 并 drop 关闭 stdin，避免 CLI 进程挂起等待 EOF。
+    // 注意：这里不写 stdin payload——blackboard wiki chat 不是 worktree 场景，
+    // pi 的 "y" 应答只在切换 worktree 目录时才有意义，乱写会污染 stdin。
+    if child.stdin.take().is_some() {
+        tracing::debug!("[blackboard] stdin 已关闭");
     }
 
     // 取出 stdout 和 stderr，用 BufReader 逐行读取

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use dashmap::DashMap;
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
@@ -1092,16 +1092,11 @@ impl MessageDebounce {
         // spawn 成功立即发"开始处理"标志，让飞书侧知道请求已被接收并在跑
         send_msg(executor_start_message(executor_type, message));
 
-        // 预写 stdin payload（部分执行器需要，如 pi）：写入后立即 flush 并 drop 以关闭 stdin
-        if let Some(payload) = executor.stdin_payload() {
-            if let Some(mut stdin) = child.stdin.take() {
-                if let Err(e) = stdin.write_all(payload.as_bytes()).await {
-                    tracing::warn!("[debounce] failed to write stdin payload for {}: {}", executor_type, e);
-                } else if let Err(e) = stdin.flush().await {
-                    tracing::warn!("[debounce] failed to flush stdin for {}: {}", executor_type, e);
-                }
-                drop(stdin);
-            }
+        // stdin 处理：take() 并 drop 关闭 stdin，避免 CLI 进程挂起等待 EOF。
+        // 注意：这里不写 stdin payload——debounce 流式路径不是 worktree 场景，
+        // pi 的 "y" 应答只在切换 worktree 目录时才有意义，乱写会污染 stdin。
+        if child.stdin.take().is_some() {
+            tracing::debug!("[debounce] stdin 已关闭");
         }
 
         // 启动流式读取任务：并发读取 stdout 并通过 EventPipeline 发送 Output 事件。


### PR DESCRIPTION
## 问题

PR #885 修复了 spawn_lifecycle.rs 中 worktree_active gate 缺失的问题，但漏掉了另外两个调用 stdin_payload() 的路径：

| 文件 | 行 | 场景 |
|---|---|---|
| blackboard.rs | 719 | 黑板/wiki chat（非 worktree 场景） |
| message_debounce.rs | 1096 | 流式消息推送（非 worktree 场景） |

这两处无条件调用 executor.stdin_payload()，对 pi 执行器会写入 y\n，污染 stdin 输入流。

## 修复

- 两处均移除 stdin_payload() 调用，改为直接 take + drop stdin（确保进程不挂起等待 EOF）
- 清理两处不再需要的 AsyncWriteExt import

## 验证

- cargo clippy --all-targets -- -D warnings：0 warnings
- cargo test --lib：1144 passed

## 后续

建议 Review 时确认还有无其他路径调用 stdin_payload() 而遗漏 gate。
