### PR TITLE
feat: 将环路配置按钮从工作空间页面迁移至环路页面

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -359,6 +359,7 @@ function AppContent() {
                 onListModeChange={() => setForcedListMode(undefined)}
                 onLoopChanged={() => setLoopUpdateCount(c => c + 1)}
                 effectiveMobilePanel={effectiveMobilePanel}
+                workspaceId={state.selectedWorkspace}
               />
             )
           )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -345,6 +345,7 @@ function AppContent() {
                 onListModeChange={() => setForcedListMode(undefined)}
                 onLoopChanged={() => setLoopUpdateCount(c => c + 1)}
                 effectiveMobilePanel={effectiveMobilePanel}
+                workspaceId={state.selectedWorkspace}
               />
             ) : (
               <LoopPage

--- a/frontend/src/components/LoopPage.tsx
+++ b/frontend/src/components/LoopPage.tsx
@@ -1,9 +1,13 @@
-import { RetweetOutlined, PlusOutlined } from '@ant-design/icons';
+import { useState, useEffect, useCallback } from 'react';
+import { RetweetOutlined, PlusOutlined, SettingOutlined } from '@ant-design/icons';
 import { Button, message } from 'antd';
 import { ListDetailPage } from './ListDetailPage';
 import { TodoList } from './todo-list';
 import { LoopDetailPanel } from './LoopStudioDetailPanel';
+import { WorkspaceLoopConfigPage } from './settings/workspace/WorkspaceLoopConfigPage';
+import * as db from '@/utils/database';
 import * as dbLoops from '@/utils/database/loops';
+import type { ProjectDirectory } from '@/types';
 
 interface LoopPageProps {
   selectedLoopId: number | null;
@@ -17,12 +21,15 @@ interface LoopPageProps {
   onListModeChange: () => void;
   onLoopChanged: () => void;
   effectiveMobilePanel: 'list' | 'detail';
+  // 当前选中的工作空间 id，用于环路配置功能
+  workspaceId?: number | null;
 }
 
 /**
  * 桌面端环路页面组件
  * 使用 ListDetailPage 实现左侧列表 + 右侧详情的双栏布局
  * 移动端逻辑已独立到 LoopMobilePage 组件
+ * 支持工作空间环路配置功能，配置按钮位于右上角新建按钮左侧
  */
 export function LoopPage({
   selectedLoopId,
@@ -35,7 +42,42 @@ export function LoopPage({
   forcedListMode,
   onListModeChange,
   onLoopChanged,
+  workspaceId,
 }: LoopPageProps) {
+  // 状态：是否显示环路配置页面（替代默认的环路详情页）
+  const [showLoopConfig, setShowLoopConfig] = useState(false);
+  // 当前选中的工作空间对象，用于传递给 WorkspaceLoopConfigPage
+  const [currentWorkspace, setCurrentWorkspace] = useState<ProjectDirectory | null>(null);
+
+  // 当 workspaceId 变化时，重新加载工作空间信息
+  useEffect(() => {
+    if (workspaceId == null) {
+      setCurrentWorkspace(null);
+      return;
+    }
+    // 拉取工作空间详情，用于环路配置页面显示工作空间名称
+    db.getProjectDirectories().then(dirs => {
+      const dir = dirs.find(d => d.id === workspaceId);
+      if (dir) setCurrentWorkspace(dir);
+    }).catch(() => {
+      // 加载失败时静默处理，不影响主流程
+    });
+  }, [workspaceId]);
+
+  // 打开环路配置页面的处理函数
+  const handleOpenLoopConfig = useCallback(() => {
+    if (workspaceId == null) {
+      message.warning('请先选择工作空间');
+      return;
+    }
+    setShowLoopConfig(true);
+  }, [workspaceId]);
+
+  // 关闭环路配置页面，回到环路列表+详情视图
+  const handleCloseLoopConfig = useCallback(() => {
+    setShowLoopConfig(false);
+  }, []);
+
   const listPanel = (
     <TodoList
       onOpenCreateModal={onOpenCreateModal}
@@ -94,23 +136,44 @@ export function LoopPage({
     />
   ) : null;
 
+  // 若显示环路配置页面，则替换右侧详情面板为 WorkspaceLoopConfigPage
+  // 否则显示默认的环路详情面板（selectedLoopId 选中的环路）
+  const effectiveDetailPanel = showLoopConfig && currentWorkspace ? (
+    <WorkspaceLoopConfigPage
+      workspace={currentWorkspace}
+      onBack={handleCloseLoopConfig}
+    />
+  ) : detailPanel;
+
   return (
     <ListDetailPage
       icon={<RetweetOutlined />}
       title="环路"
       storageKey="loop_page_sidebar_collapsed"
       extra={
-        <Button
-          type="primary"
-          size="small"
-          icon={<PlusOutlined />}
-          onClick={onCreateLoop}
-        >
-          新建
-        </Button>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {/* 环路配置按钮：放在新建按钮左边，点击后打开配置页面 */}
+          <Button
+            size="small"
+            icon={<SettingOutlined />}
+            onClick={handleOpenLoopConfig}
+            disabled={workspaceId == null}
+          >
+            配置
+          </Button>
+          {/* 新建环路按钮 */}
+          <Button
+            type="primary"
+            size="small"
+            icon={<PlusOutlined />}
+            onClick={onCreateLoop}
+          >
+            新建
+          </Button>
+        </div>
       }
       listPanel={listPanel}
-      detailPanel={detailPanel}
+      detailPanel={effectiveDetailPanel}
     />
   );
 }

--- a/frontend/src/components/mobile/LoopMobilePage.tsx
+++ b/frontend/src/components/mobile/LoopMobilePage.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState, useCallback } from 'react';
-import { RetweetOutlined, PlusOutlined } from '@ant-design/icons';
+import { RetweetOutlined, PlusOutlined, SettingOutlined } from '@ant-design/icons';
 import { Button, message } from 'antd';
 import { PageCard } from '../common/PageCard';
 import { TodoList } from '../todo-list';
 import { LoopDetailPanel } from '../LoopStudioDetailPanel';
 import { EmptyDetailPlaceholder } from '../EmptyDetailPlaceholder';
+import { WorkspaceLoopConfigPage } from '../settings/workspace/WorkspaceLoopConfigPage';
 import { SIDEBAR_WIDTH } from '@/constants';
+import * as db from '@/utils/database';
 import * as dbLoops from '@/utils/database/loops';
 import type { LoopDetail } from '@/types/loop';
+import type { ProjectDirectory } from '@/types';
 
 interface LoopMobilePageProps {
   selectedLoopId: number | null;
@@ -21,6 +24,7 @@ interface LoopMobilePageProps {
   onListModeChange: () => void;
   onLoopChanged: () => void;
   effectiveMobilePanel: 'list' | 'detail';
+  workspaceId?: number | null;
 }
 
 /**
@@ -40,8 +44,41 @@ export function LoopMobilePage({
   onListModeChange,
   onLoopChanged,
   effectiveMobilePanel,
+  workspaceId,
 }: LoopMobilePageProps) {
   const [loopDetail, setLoopDetail] = useState<LoopDetail | null>(null);
+  // 状态：是否显示环路配置页面（替代默认的环路详情页）
+  const [showLoopConfig, setShowLoopConfig] = useState(false);
+  // 当前选中的工作空间对象，用于传递给 WorkspaceLoopConfigPage
+  const [currentWorkspace, setCurrentWorkspace] = useState<ProjectDirectory | null>(null);
+
+  // 当 workspaceId 变化时，重新加载工作空间信息
+  useEffect(() => {
+    if (workspaceId == null) {
+      setCurrentWorkspace(null);
+      return;
+    }
+    db.getProjectDirectories().then(dirs => {
+      const dir = dirs.find(d => d.id === workspaceId);
+      if (dir) setCurrentWorkspace(dir);
+    }).catch(() => {
+      // 加载失败时静默处理，不影响主流程
+    });
+  }, [workspaceId]);
+
+  // 打开环路配置页面的处理函数
+  const handleOpenLoopConfig = useCallback(() => {
+    if (workspaceId == null) {
+      message.warning('请先选择工作空间');
+      return;
+    }
+    setShowLoopConfig(true);
+  }, [workspaceId]);
+
+  // 关闭环路配置页面，回到环路列表+详情视图
+  const handleCloseLoopConfig = useCallback(() => {
+    setShowLoopConfig(false);
+  }, []);
 
   const loadLoopDetail = useCallback(() => {
     if (selectedLoopId === null) {
@@ -107,14 +144,26 @@ export function LoopMobilePage({
       icon={<RetweetOutlined />}
       title="环路"
       extra={
-        <Button
-          type="primary"
-          size="small"
-          icon={<PlusOutlined />}
-          onClick={onCreateLoop}
-        >
-          新建
-        </Button>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {/* 环路配置按钮：放在新建按钮左边 */}
+          <Button
+            size="small"
+            icon={<SettingOutlined />}
+            onClick={handleOpenLoopConfig}
+            disabled={workspaceId == null}
+          >
+            配置
+          </Button>
+          {/* 新建环路按钮 */}
+          <Button
+            type="primary"
+            size="small"
+            icon={<PlusOutlined />}
+            onClick={onCreateLoop}
+          >
+            新建
+          </Button>
+        </div>
       }
       style={{ height: '100%' }}
       contentStyle={{ padding: 0, height: 'calc(100% - 43px)' }}
@@ -150,6 +199,18 @@ export function LoopMobilePage({
           loadLoopDetail();
           onLoopChanged();
         }}
+      />
+    </PageCard>
+  ) : showLoopConfig && currentWorkspace ? (
+    <PageCard
+      icon={<RetweetOutlined />}
+      title="环路"
+      style={{ height: '100%', flex: 1, minWidth: 0 }}
+      contentStyle={{ padding: 0, display: 'flex', flexDirection: 'column', height: 'calc(100% - 43px)', overflow: 'hidden' }}
+    >
+      <WorkspaceLoopConfigPage
+        workspace={currentWorkspace}
+        onBack={handleCloseLoopConfig}
       />
     </PageCard>
   ) : (

--- a/frontend/src/components/mobile/LoopMobilePage.tsx
+++ b/frontend/src/components/mobile/LoopMobilePage.tsx
@@ -181,7 +181,8 @@ export function LoopMobilePage({
     </PageCard>
   );
 
-  const detailPage = selectedLoopId !== null ? (
+  // 环路详情面板：有环路选中时显示，无则显示空状态占位
+  const detailPanel = selectedLoopId !== null ? (
     <PageCard
       icon={<RetweetOutlined />}
       title="环路"
@@ -201,18 +202,6 @@ export function LoopMobilePage({
         }}
       />
     </PageCard>
-  ) : showLoopConfig && currentWorkspace ? (
-    <PageCard
-      icon={<RetweetOutlined />}
-      title="环路"
-      style={{ height: '100%', flex: 1, minWidth: 0 }}
-      contentStyle={{ padding: 0, display: 'flex', flexDirection: 'column', height: 'calc(100% - 43px)', overflow: 'hidden' }}
-    >
-      <WorkspaceLoopConfigPage
-        workspace={currentWorkspace}
-        onBack={handleCloseLoopConfig}
-      />
-    </PageCard>
   ) : (
     <PageCard
       icon={<RetweetOutlined />}
@@ -223,6 +212,9 @@ export function LoopMobilePage({
       <EmptyDetailPlaceholder />
     </PageCard>
   );
+
+  // 配置页已移至全屏 overlay 渲染，detailPage 只做普通详情/空状态切换
+  const detailPage = detailPanel;
 
   return (
     <>
@@ -249,6 +241,24 @@ export function LoopMobilePage({
       >
         {detailPage}
       </div>
+      {/* 环路配置是全局页面，不属于任何环路，作为全屏覆盖层独立渲染 */}
+      {showLoopConfig && currentWorkspace && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 1000,
+            background: 'var(--ntd-bg-color)',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <WorkspaceLoopConfigPage
+            workspace={currentWorkspace}
+            onBack={handleCloseLoopConfig}
+          />
+        </div>
+      )}
     </>
   );
 }

--- a/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
+++ b/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
@@ -1,10 +1,9 @@
 import { useState, useEffect } from 'react';
 import { Button, Input, Empty, Spin, Switch, message, Tooltip, Typography, Card, Dropdown } from 'antd';
-import { PlusOutlined, FolderOutlined, RobotOutlined, SettingOutlined, EditOutlined, DeleteOutlined, MoreOutlined } from '@ant-design/icons';
+import { PlusOutlined, FolderOutlined, RobotOutlined, EditOutlined, DeleteOutlined, MoreOutlined } from '@ant-design/icons';
 import { PageCard } from '@/components/common/PageCard';
 import * as db from '@/utils/database';
 import type { ProjectDirectory, AgentBot } from '@/utils/database';
-import { WorkspaceLoopConfigPage } from './workspace/WorkspaceLoopConfigPage';
 
 interface ProjectDirectoriesPanelProps {
   /** 点击某个工作空间的「消息配置」入口时触发，参数为该工作空间 id；
@@ -24,9 +23,6 @@ export function ProjectDirectoriesPanel({ onOpenMessages }: ProjectDirectoriesPa
   const [editingDirName, setEditingDirName] = useState('');
   // 智能体列表，用于统计每个工作区的绑定数量
   const [agentBots, setAgentBots] = useState<AgentBot[]>([]);
-  // 选中的工作空间和页面类型；消息配置已迁移为独立菜单，这里仅保留环路配置的嵌入入口
-  const [selectedWorkspace, setSelectedWorkspace] = useState<ProjectDirectory | null>(null);
-  const [selectedPageType, setSelectedPageType] = useState<'loop' | null>(null);
 
   // 每次进入页面都重新拉取一次，确保用户在其他地方新增/删除后能立刻看到
   const loadProjectDirectories = () => {
@@ -153,16 +149,6 @@ export function ProjectDirectoriesPanel({ onOpenMessages }: ProjectDirectoriesPa
       message.error('删除失败: ' + (err?.message || String(err)));
     }
   };
-
-  // 选中工作空间，显示对应配置页（消息配置已迁移为独立菜单，仅保留环路配置嵌入入口）
-  if (selectedWorkspace && selectedPageType === 'loop') {
-    return (
-      <WorkspaceLoopConfigPage
-        workspace={selectedWorkspace}
-        onBack={() => { setSelectedWorkspace(null); setSelectedPageType(null); }}
-      />
-    );
-  }
 
   return (
     <PageCard icon={<FolderOutlined />} title="工作空间">
@@ -299,13 +285,6 @@ export function ProjectDirectoriesPanel({ onOpenMessages }: ProjectDirectoriesPa
 
                     {/* 右侧：操作区域 */}
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
-                      <Button
-                        size="small"
-                        icon={<SettingOutlined />}
-                        onClick={() => { setSelectedWorkspace(dir); setSelectedPageType('loop'); }}
-                      >
-                        环路配置
-                      </Button>
                       {/* 更多操作菜单 */}
                       <Dropdown
                         menu={{


### PR DESCRIPTION
## 变更说明

将「环路配置」按钮从工作空间管理页面迁移到环路页面，提高操作便捷性。

## 主要改动

### 新增功能
- 在环路页面（桌面端+移动端）右上角新增「配置」按钮，位于「新建」按钮左侧
- 点击配置按钮可打开当前工作空间的环路配置页面（评审模板管理）
- 配置按钮会根据当前是否选中工作空间自动启用/禁用

### 代码变更
- **LoopPage.tsx**：添加环路配置功能，支持打开 WorkspaceLoopConfigPage
- **LoopMobilePage.tsx**：适配移动端，实现相同的环路配置功能
- **App.tsx**：传递 workspaceId 参数给环路页面组件
- **ProjectDirectoriesPanel.tsx**：移除原有的环路配置按钮及相关状态

## 兼容性
- 前端类型检查通过（`tsc --noEmit`）
- 桌面端和移动端均已适配

## 测试建议
1. 在环路页面点击「配置」按钮，确认能打开环路配置页面
2. 未选中工作空间时，配置按钮应处于禁用状态
3. 配置页面的返回按钮能正确回到环路列表视图