### PR TITLE
feat: 支持在执行器管理中设置默认执行器

### DIFF
--- a/backend/src/db/entity/executors.rs
+++ b/backend/src/db/entity/executors.rs
@@ -12,6 +12,8 @@ pub struct Model {
     pub enabled: bool,
     pub display_name: String,
     pub session_dir: String,
+    /// 是否为系统默认执行器。同一时间只能有一个默认执行器。
+    pub is_default: bool,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }

--- a/backend/src/db/executor_config.rs
+++ b/backend/src/db/executor_config.rs
@@ -199,6 +199,9 @@ impl Database {
                     enabled: ActiveValue::Set(true),
                     display_name: ActiveValue::Set(exec.display_name.to_string()),
                     session_dir: ActiveValue::Set(exec.session_dir.to_string()),
+                    // 后补进来的执行器默认不是系统默认；显式写 false 与 seed/migrate 两处
+                    // 插入逻辑保持一致，避免依赖隐式 DB 默认值造成阅读歧义。
+                    is_default: ActiveValue::Set(false),
                     created_at: ActiveValue::Set(Some(now.clone())),
                     updated_at: ActiveValue::Set(Some(now.clone())),
                     ..Default::default()
@@ -251,14 +254,20 @@ impl Database {
     /// 设置指定执行器为系统默认执行器。
     /// 会先清除所有执行器的默认标记，再将指定执行器设为默认，
     /// 确保同一时间只有一个默认执行器。
-    /// 返回更新后的执行器配置。
+    /// 返回更新后的执行器配置；目标不存在时返回 None。
     pub async fn set_default_executor(&self, name: &str) -> Result<Option<ExecutorConfig>, sea_orm::DbErr> {
-        // 先确认目标执行器存在，不存在则返回 None
+        use sea_orm::TransactionTrait;
+        // 「清除全部默认」+「设置目标为默认」是两步相关写入，
+        // 包在同一事务里提交，避免中途崩溃出现「全部被清但目标未设」的临时无默认态。
+        let txn = self.conn.begin().await?;
+
+        // 先确认目标执行器存在，不存在则回滚（无写入）并返回 None。
         let target = executors::Entity::find()
             .filter(executors::Column::Name.eq(name))
-            .one(&self.conn)
+            .one(&txn)
             .await?;
         let Some(target) = target else {
+            txn.rollback().await?;
             return Ok(None);
         };
 
@@ -267,15 +276,16 @@ impl Database {
         // 清除所有执行器的默认标记
         executors::Entity::update_many()
             .col_expr(executors::Column::IsDefault, sea_orm::sea_query::Expr::value(false))
-            .exec(&self.conn)
+            .exec(&txn)
             .await?;
 
-        // 将目标执行器设为默认
-        let mut am: executors::ActiveModel = target.clone().into();
+        // 将目标执行器设为默认。target 此后不再使用，直接消费掉即可，无需 clone。
+        let mut am: executors::ActiveModel = target.into();
         am.is_default = ActiveValue::Set(true);
         am.updated_at = ActiveValue::Set(Some(now));
-        let updated = am.update(&self.conn).await?;
+        let updated = am.update(&txn).await?;
 
+        txn.commit().await?;
         Ok(Some(map_executor(updated)))
     }
 }

--- a/backend/src/db/executor_config.rs
+++ b/backend/src/db/executor_config.rs
@@ -13,6 +13,7 @@ fn map_executor(m: executors::Model) -> ExecutorConfig {
         enabled: m.enabled,
         display_name: m.display_name,
         session_dir: m.session_dir,
+        is_default: m.is_default,
         created_at: m.created_at,
         updated_at: m.updated_at,
     }
@@ -104,7 +105,10 @@ impl Database {
 
         let now = crate::models::utc_timestamp();
 
-        for exec in EXECUTORS {
+        for (i, exec) in EXECUTORS.iter().enumerate() {
+            // 第一个执行器设为默认（通常是 claudecode），
+            // 保持与历史行为一致：默认执行器就是列表第一个。
+            let is_default = i == 0;
             // Try primary name first, then aliases (for backward compatibility with legacy config keys)
             let path = cfg_executors.paths.get(exec.name)
                 .or_else(|| {
@@ -119,6 +123,7 @@ impl Database {
                 enabled: ActiveValue::Set(true),
                 display_name: ActiveValue::Set(exec.display_name.to_string()),
                 session_dir: ActiveValue::Set(exec.session_dir.to_string()),
+                is_default: ActiveValue::Set(is_default),
                 created_at: ActiveValue::Set(Some(now.clone())),
                 updated_at: ActiveValue::Set(Some(now.clone())),
                 ..Default::default()
@@ -131,6 +136,7 @@ impl Database {
     }
 
     /// Seed default executors if table is empty (fresh install).
+    /// 全新安装时，第一个执行器（claudecode）会被设为默认执行器。
     pub async fn seed_default_executors(&self) -> Result<(), sea_orm::DbErr> {
         let count = executors::Entity::find().count(&self.conn).await?;
         if count > 0 {
@@ -138,13 +144,17 @@ impl Database {
         }
 
         let now = crate::models::utc_timestamp();
-        for exec in EXECUTORS {
+        for (i, exec) in EXECUTORS.iter().enumerate() {
+            // 第一个执行器设为默认（通常是 claudecode），
+            // 保持与历史行为一致：默认执行器就是列表第一个。
+            let is_default = i == 0;
             let am = executors::ActiveModel {
                 name: ActiveValue::Set(exec.name.to_string()),
                 path: ActiveValue::Set(exec.default_path.to_string()),
                 enabled: ActiveValue::Set(true),
                 display_name: ActiveValue::Set(exec.display_name.to_string()),
                 session_dir: ActiveValue::Set(exec.session_dir.to_string()),
+                is_default: ActiveValue::Set(is_default),
                 created_at: ActiveValue::Set(Some(now.clone())),
                 updated_at: ActiveValue::Set(Some(now.clone())),
                 ..Default::default()
@@ -214,5 +224,58 @@ impl Database {
         }
 
         Ok(())
+    }
+
+    /// 获取系统默认执行器。
+    /// 如果没有标记为默认的执行器，返回 None；
+    /// 调用方应自行决定回退策略（如使用 claudecode 常量）。
+    pub async fn get_default_executor(&self) -> Result<Option<ExecutorConfig>, sea_orm::DbErr> {
+        let model = executors::Entity::find()
+            .filter(executors::Column::IsDefault.eq(true))
+            .one(&self.conn)
+            .await?;
+        Ok(model.map(map_executor))
+    }
+
+    /// 获取默认执行器的名称，便捷方法。
+    /// 优先从数据库读取 is_default=true 的执行器，
+    /// 如果没有则回退到 `DEFAULT_EXECUTOR` 常量（claudecode）。
+    /// 用于创建 todo 等需要默认执行器名的场景。
+    pub async fn get_default_executor_name(&self) -> Result<String, sea_orm::DbErr> {
+        let default = self.get_default_executor().await?;
+        Ok(default
+            .map(|e| e.name)
+            .unwrap_or_else(|| crate::adapters::DEFAULT_EXECUTOR.to_string()))
+    }
+
+    /// 设置指定执行器为系统默认执行器。
+    /// 会先清除所有执行器的默认标记，再将指定执行器设为默认，
+    /// 确保同一时间只有一个默认执行器。
+    /// 返回更新后的执行器配置。
+    pub async fn set_default_executor(&self, name: &str) -> Result<Option<ExecutorConfig>, sea_orm::DbErr> {
+        // 先确认目标执行器存在，不存在则返回 None
+        let target = executors::Entity::find()
+            .filter(executors::Column::Name.eq(name))
+            .one(&self.conn)
+            .await?;
+        let Some(target) = target else {
+            return Ok(None);
+        };
+
+        let now = crate::models::utc_timestamp();
+
+        // 清除所有执行器的默认标记
+        executors::Entity::update_many()
+            .col_expr(executors::Column::IsDefault, sea_orm::sea_query::Expr::value(false))
+            .exec(&self.conn)
+            .await?;
+
+        // 将目标执行器设为默认
+        let mut am: executors::ActiveModel = target.clone().into();
+        am.is_default = ActiveValue::Set(true);
+        am.updated_at = ActiveValue::Set(Some(now));
+        let updated = am.update(&self.conn).await?;
+
+        Ok(Some(map_executor(updated)))
     }
 }

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -21,6 +21,7 @@ mod v59;
 mod v60;
 mod v61;
 mod v62;
+mod v63;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -71,6 +72,8 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v61::V61AddProjectDirectoriesExecutorSessions),
         // V62 在 V61 之后：为 blackboards 增加 enabled 总开关
         Box::new(v62::V62AddBlackboardEnabled),
+        // V63 在 V62 之后：为 executors 增加 is_default 字段，支持设置默认执行器
+        Box::new(v63::V63AddExecutorIsDefault),
     ]
 }
 

--- a/backend/src/db/migration/v63.rs
+++ b/backend/src/db/migration/v63.rs
@@ -1,0 +1,90 @@
+//! 数据库迁移 V63：为 executors 表新增 is_default 字段。
+//!
+//! ## 背景
+//! 用户希望能在执行器菜单中设置默认执行器，而不是写死 claudecode。
+//! 在 executors 表增加 is_default 布尔字段，标记哪一个是系统默认执行器。
+//!
+//! ## 幂等
+//! `add_column_if_missing` 已存在则静默跳过。
+
+use async_trait::async_trait;
+
+use super::super::Database;
+use super::{Migration, add_column_if_missing};
+
+pub(super) struct V63AddExecutorIsDefault;
+
+#[async_trait]
+impl Migration for V63AddExecutorIsDefault {
+    fn version(&self) -> i64 {
+        63
+    }
+
+    fn name(&self) -> &'static str {
+        "V63AddExecutorIsDefault"
+    }
+
+    /// 为 executors 表添加 is_default 列，默认 0（非默认）。
+    /// 首次迁移时，如果表中已有 claudecode 且无任何默认执行器，将其设为默认，
+    /// 保持与历史行为一致。
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // is_default 列：INTEGER NOT NULL DEFAULT 0，1=默认，0=非默认。
+        // 默认 0 保持向后兼容：已有执行器都不是默认，由后续种子逻辑处理。
+        add_column_if_missing(
+            db,
+            "executors",
+            "is_default",
+            "ALTER TABLE executors ADD COLUMN is_default INTEGER NOT NULL DEFAULT 0",
+        )
+        .await?;
+        tracing::info!("V63: executors.is_default 列已添加");
+
+        // 首次迁移后，如果没有任何执行器被标记为默认，
+        // 则把 claudecode 设为默认（与历史默认值一致）。
+        let has_default = Self::check_has_default(db).await?;
+        if !has_default {
+            Self::seed_default_executor(db).await?;
+        }
+
+        Ok(())
+    }
+}
+
+impl V63AddExecutorIsDefault {
+    /// 检查是否已有执行器被标记为默认。
+    async fn check_has_default(db: &Database) -> Result<bool, sea_orm::DbErr> {
+        use sea_orm::{ConnectionTrait, DbBackend, Statement};
+        let row = db
+            .conn
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT COUNT(*) FROM executors WHERE is_default = 1",
+            ))
+            .await?;
+        Ok(row
+            .and_then(|r| r.try_get_by_index::<i64>(0).ok())
+            .unwrap_or(0)
+            > 0)
+    }
+
+    /// 将 claudecode 设为默认执行器（保持历史行为一致）。
+    /// 仅在 claudecode 存在时设置；不存在则不操作，由用户后续手动设置。
+    async fn seed_default_executor(db: &Database) -> Result<(), sea_orm::DbErr> {
+        use sea_orm::{ConnectionTrait, DbBackend, Statement};
+        let result = db
+            .conn
+            .execute(Statement::from_string(
+                DbBackend::Sqlite,
+                "UPDATE executors SET is_default = 1 WHERE name = 'claudecode'",
+            ))
+            .await?;
+        if result.rows_affected() > 0 {
+            tracing::info!("V63: claudecode 已设为默认执行器（种子值）");
+        } else {
+            tracing::warn!(
+                "V63: 未找到 claudecode 执行器，未设置默认值；请用户手动配置"
+            );
+        }
+        Ok(())
+    }
+}

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -390,11 +390,14 @@ impl Database {
     }
 
     pub async fn create_todo(&self, title: &str, prompt: &str) -> Result<i64, sea_orm::DbErr> {
-        self.create_todo_with_executor(title, prompt, Some(crate::adapters::DEFAULT_EXECUTOR)).await
+        // 从数据库读取默认执行器，不再使用硬编码常量；
+        // 若数据库未配置默认执行器，get_default_executor_name 内部会回退到 claudecode。
+        let default_executor = self.get_default_executor_name().await?;
+        self.create_todo_with_executor(title, prompt, Some(&default_executor)).await
     }
 
     /// 创建 Todo，可指定执行器。
-    /// executor 为 None、空串或仅空白时默认为 claudecode（防止空/空白字符串污染 DB）。
+    /// executor 为 None、空串或仅空白时使用数据库配置的默认执行器（防止空/空白字符串污染 DB）。
     ///
     /// 注意：本方法保留 path-only 语义作为「最简 helper」专用入口——调用方（feishu_listener /
     /// sync.rs 等）已经决定好了 workspace，没有工作空间语义可推导时不应使用本方法。
@@ -419,17 +422,19 @@ impl Database {
         workspace_path: &str,
     ) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
-        let executor_str = executor
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .unwrap_or(crate::adapters::DEFAULT_EXECUTOR);
+        // 先尝试使用调用方传入的 executor；为空则从数据库读取默认执行器。
+        // get_default_executor_name 内部会回退到 DEFAULT_EXECUTOR 常量，确保不会为空。
+        let executor_str = match executor.map(str::trim).filter(|s| !s.is_empty()) {
+            Some(s) => s.to_string(),
+            None => self.get_default_executor_name().await?,
+        };
         let am = todos::ActiveModel {
             title: ActiveValue::Set(title.to_string()),
             prompt: ActiveValue::Set(Some(prompt.to_string())),
             status: ActiveValue::Set(Some(TodoStatus::Pending.to_string())),
             created_at: ActiveValue::Set(Some(now.clone())),
             updated_at: ActiveValue::Set(Some(now)),
-            executor: ActiveValue::Set(Some(executor_str.to_string())),
+            executor: ActiveValue::Set(Some(executor_str)),
             acceptance_criteria: ActiveValue::Set(acceptance_criteria.map(|s| s.to_string())),
             webhook_enabled: ActiveValue::Set(Some(webhook_enabled)),
             auto_review_enabled: ActiveValue::Set(Some(false)),
@@ -461,17 +466,19 @@ impl Database {
         kind: Option<i32>,
     ) -> Result<i64, sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
-        let executor_str = executor
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .unwrap_or(crate::adapters::DEFAULT_EXECUTOR);
+        // 先尝试使用调用方传入的 executor；为空则从数据库读取默认执行器。
+        // get_default_executor_name 内部会回退到 DEFAULT_EXECUTOR 常量，确保不会为空。
+        let executor_str = match executor.map(str::trim).filter(|s| !s.is_empty()) {
+            Some(s) => s.to_string(),
+            None => self.get_default_executor_name().await?,
+        };
         let am = todos::ActiveModel {
             title: ActiveValue::Set(title.to_string()),
             prompt: ActiveValue::Set(Some(prompt.to_string())),
             status: ActiveValue::Set(Some(status.unwrap_or("pending").to_string())),
             created_at: ActiveValue::Set(Some(now.clone())),
             updated_at: ActiveValue::Set(Some(now)),
-            executor: ActiveValue::Set(Some(executor_str.to_string())),
+            executor: ActiveValue::Set(Some(executor_str)),
             acceptance_criteria: ActiveValue::Set(acceptance_criteria.map(|s| s.to_string())),
             webhook_enabled: ActiveValue::Set(Some(webhook_enabled)),
             auto_review_enabled: ActiveValue::Set(auto_review_enabled),

--- a/backend/src/handlers/executor_config.rs
+++ b/backend/src/handlers/executor_config.rs
@@ -262,3 +262,25 @@ pub async fn resolve_executor_path(
         new_path: Some(resolved),
     }))
 }
+
+/// 获取系统默认执行器。
+/// 如果没有设置默认执行器，返回 null（前端可回退到 claudecode）。
+pub async fn get_default_executor(
+    State(state): State<AppState>,
+) -> Result<ApiResponse<Option<ExecutorConfig>>, AppError> {
+    let executor = state.db.get_default_executor().await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok(ApiResponse::ok(executor))
+}
+
+/// 设置指定执行器为系统默认执行器。
+/// 会自动清除其他执行器的默认标记，确保只有一个默认执行器。
+pub async fn set_default_executor(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<ApiResponse<ExecutorConfig>, AppError> {
+    let executor = state.db.set_default_executor(&name).await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .ok_or(AppError::NotFound)?;
+    Ok(ApiResponse::ok(executor))
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -625,6 +625,8 @@ fn config_routes() -> Router<AppState> {
         .route("/api/executors/{name}/test", post(executor_config::test_executor))
         .route("/api/executors/detect-all", post(executor_config::detect_all_executors))
         .route("/api/executors/{name}/resolve", post(executor_config::resolve_executor_path))
+        .route("/api/executors/default", get(executor_config::get_default_executor))
+        .route("/api/executors/{name}/default", put(executor_config::set_default_executor))
 }
 
 /// Skills 管理（列出/同步/导入导出/调用记录）。

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -2360,6 +2360,7 @@ mod session_scanner_tests {
             enabled: true,
             display_name: "x".into(),
             session_dir: d.into(),
+            is_default: false,
             created_at: None,
             updated_at: None,
         };

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -164,7 +164,17 @@ pub async fn create_todo(
     } else {
         req.prompt.trim().to_string()
     };
-    let executor_input = req.executor.as_deref();
+    // 在 handler 层解析一次最终执行器名：有显式非空值用它，否则取数据库默认执行器。
+    // 这样既作为 create_todo_with_extras 的入参（传入确定值后 DAO 内部不再重复解析、
+    // 不再重复查库），又直接复用为返回给前端的 executor 字段——避免「解析两次 + 逻辑重复」。
+    let executor_name = match req.executor.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        Some(s) => s.to_string(),
+        None => state
+            .db
+            .get_default_executor_name()
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+    };
 
     // 工作空间 id 必填且必须存在：handler 按 id 解析出 path 后再下传，
     // DAO 一次写入 workspace_id + workspace_path 两列保证双字段同步。
@@ -176,7 +186,8 @@ pub async fn create_todo(
     let id = state.db.create_todo_with_extras(
         title,
         &prompt,
-        executor_input,
+        // executor_name 已是非空确定值，DAO 不会再触发默认执行器回退逻辑
+        Some(&executor_name),
         req.acceptance_criteria.as_deref(),
         req.webhook_enabled.unwrap_or(false),
         req.workspace_id,
@@ -262,14 +273,6 @@ pub async fn create_todo(
         }
     }
 
-    // 计算最终的执行器名称，用于返回给前端
-    // 与 create_todo_with_extras 内部逻辑一致：有值用值，空值用数据库默认
-    let executor_name = match executor_input.map(str::trim).filter(|s| !s.is_empty()) {
-        Some(s) => s.to_string(),
-        None => state.db.get_default_executor_name().await
-            .map_err(|e| AppError::Internal(e.to_string()))?,
-    };
-
     Ok(ApiResponse::ok(Todo {
         id,
         title: title.to_string(),
@@ -278,6 +281,8 @@ pub async fn create_todo(
         created_at: now.clone(),
         updated_at: now,
         tag_ids: req.tag_ids.clone(),
+        // executor_name 在创建前已解析（见函数前段），这里直接复用，
+        // 与写入 DB 的值是同一个，确保返回值与落库值一致。
         executor: Some(executor_name),
         scheduler_enabled,
         scheduler_config: scheduler_config.clone(),

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -164,10 +164,7 @@ pub async fn create_todo(
     } else {
         req.prompt.trim().to_string()
     };
-    let executor = req
-        .executor
-        .clone()
-        .unwrap_or_else(|| "claudecode".to_string());
+    let executor_input = req.executor.as_deref();
 
     // 工作空间 id 必填且必须存在：handler 按 id 解析出 path 后再下传，
     // DAO 一次写入 workspace_id + workspace_path 两列保证双字段同步。
@@ -179,7 +176,7 @@ pub async fn create_todo(
     let id = state.db.create_todo_with_extras(
         title,
         &prompt,
-        Some(&executor),
+        executor_input,
         req.acceptance_criteria.as_deref(),
         req.webhook_enabled.unwrap_or(false),
         req.workspace_id,
@@ -265,6 +262,14 @@ pub async fn create_todo(
         }
     }
 
+    // 计算最终的执行器名称，用于返回给前端
+    // 与 create_todo_with_extras 内部逻辑一致：有值用值，空值用数据库默认
+    let executor_name = match executor_input.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(s) => s.to_string(),
+        None => state.db.get_default_executor_name().await
+            .map_err(|e| AppError::Internal(e.to_string()))?,
+    };
+
     Ok(ApiResponse::ok(Todo {
         id,
         title: title.to_string(),
@@ -273,7 +278,7 @@ pub async fn create_todo(
         created_at: now.clone(),
         updated_at: now,
         tag_ids: req.tag_ids.clone(),
-        executor: Some(executor),
+        executor: Some(executor_name),
         scheduler_enabled,
         scheduler_config: scheduler_config.clone(),
         scheduler_timezone: scheduler_timezone.clone(),

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -940,6 +940,8 @@ pub struct ExecutorConfig {
     pub enabled: bool,
     pub display_name: String,
     pub session_dir: String,
+    /// 是否为系统默认执行器
+    pub is_default: bool,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }

--- a/backend/tests/db_feature_supplement_tests.rs
+++ b/backend/tests/db_feature_supplement_tests.rs
@@ -613,6 +613,105 @@ async fn test_executor_backfill_session_dir_fills_empty() {
     assert!(after.iter().any(|e| !e.session_dir.is_empty()));
 }
 
+#[tokio::test]
+async fn test_executor_get_default_none_and_fallback_when_unset() {
+    // 全新内存库（未 seed）：没有任何 is_default=true 的行，
+    // get_default_executor 返回 None；get_default_executor_name 回退到 DEFAULT_EXECUTOR 常量。
+    let db = setup_db().await;
+    let none = db.get_default_executor().await.unwrap();
+    assert!(none.is_none(), "未配置默认执行器时应返回 None");
+    let name = db.get_default_executor_name().await.unwrap();
+    assert_eq!(
+        name, "claudecode",
+        "无默认执行器时名称应回退到 DEFAULT_EXECUTOR 常量"
+    );
+}
+
+#[tokio::test]
+async fn test_executor_get_default_after_seed() {
+    // seed_default_executors 会把 EXECUTORS[0]（claudecode）标记为默认，
+    // 随后 get_default_executor / get_default_executor_name 都应命中它。
+    let db = setup_db().await;
+    db.seed_default_executors().await.unwrap();
+    let default = db
+        .get_default_executor()
+        .await
+        .unwrap()
+        .expect("seed 后应存在默认执行器");
+    assert_eq!(default.name, "claudecode");
+    assert!(default.is_default, "默认执行器的 is_default 必须为 true");
+    assert_eq!(
+        db.get_default_executor_name().await.unwrap(),
+        "claudecode"
+    );
+}
+
+#[tokio::test]
+async fn test_executor_set_default_switches_and_clears_others() {
+    // set_default_executor 切换默认到另一个执行器：新目标置 true，旧默认被清成 false，
+    // 全表有且仅有一个 is_default=true。重复设置同一目标也应保持唯一。
+    let db = setup_db().await;
+    db.seed_default_executors().await.unwrap();
+    let all = db.get_executors().await.unwrap();
+    // 选一个非 claudecode 的执行器作为新默认；若执行器列表只有一项则跳过本断言。
+    let target = all
+        .iter()
+        .find(|e| e.name != "claudecode")
+        .expect("种子执行器应至少包含两个，用于切换默认");
+
+    let updated = db
+        .set_default_executor(&target.name)
+        .await
+        .unwrap()
+        .expect("已存在的执行器应能被设为默认");
+    assert_eq!(updated.name, target.name);
+    assert!(updated.is_default);
+
+    // 旧的默认执行器（claudecode）必须被清成非默认
+    let claude = db
+        .get_executor_by_name("claudecode")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(!claude.is_default, "切换默认后旧默认必须被清除");
+
+    // 全表只能有一个默认执行器
+    let defaults = db
+        .get_executors()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.is_default)
+        .collect::<Vec<_>>();
+    assert_eq!(defaults.len(), 1, "同一时间只能有一个默认执行器");
+    assert_eq!(defaults[0].name, target.name);
+
+    // 重复设置同一目标：仍应保持唯一默认，不产生多个 is_default=true
+    db.set_default_executor(&target.name).await.unwrap();
+    let default_count2 = db
+        .get_executors()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|e| e.is_default)
+        .count();
+    assert_eq!(default_count2, 1, "重复设置同一目标不应新增默认标记");
+}
+
+#[tokio::test]
+async fn test_executor_set_default_unknown_returns_none() {
+    // 设置一个不存在的执行器为默认：返回 None，且不改变现有默认状态。
+    let db = setup_db().await;
+    db.seed_default_executors().await.unwrap();
+    let result = db.set_default_executor("not-a-real-executor").await.unwrap();
+    assert!(result.is_none(), "不存在的执行器应返回 None");
+    // 原默认 claudecode 不受影响
+    assert_eq!(
+        db.get_default_executor_name().await.unwrap(),
+        "claudecode"
+    );
+}
+
 // =====================================================================
 // 同步记录相关测试
 // =====================================================================

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import { WikiViewPage } from '@/components/WikiViewPage';
 
 import { EXECUTION_PANEL, LEFT_RAIL_WIDTH } from './constants';
 import * as db from './utils/database';
+import { loadDefaultExecutor } from '@/utils/executors';
 import type { Config } from './types';
 import zhCN from 'antd/locale/zh_CN';
 import './App.css';
@@ -129,6 +130,10 @@ function AppContent() {
   useEffect(() => {
     db.getConfig().then(setAppConfig).catch(() => {
       // 配置加载失败时使用默认值，非关键路径不阻塞主流程
+    });
+    // 启动时加载默认执行器配置，供创建 todo、快速捕获等场景使用
+    loadDefaultExecutor().catch(() => {
+      // 加载失败时内部会回退到常量值，这里静默处理
     });
   }, []);
 

--- a/frontend/src/components/QuickCaptureModal.tsx
+++ b/frontend/src/components/QuickCaptureModal.tsx
@@ -4,7 +4,7 @@ import { ThunderboltOutlined, ClockCircleOutlined } from '@ant-design/icons';
 import { WorkspaceSwitcher } from '@/components/shell/WorkspaceSwitcher';
 import { ExecutorPickerPopover } from '@/components/common/ExecutorPickerPopover';
 import * as db from '@/utils/database';
-import { DEFAULT_EXECUTOR } from '@/types';
+import { getDefaultExecutor } from '@/utils/executors';
 import { getLastExecutor, setLastExecutor } from '@/constants';
 
 interface QuickCaptureModalProps {
@@ -87,8 +87,9 @@ export function QuickCaptureModal({
         workspaceId,
       );
 
-      // 更新执行器
-      if (executor !== DEFAULT_EXECUTOR) {
+      // 更新执行器（仅当用户选择的执行器与系统默认不同时更新，
+      // 避免后端已设为默认值后又重复更新的冗余操作）
+      if (executor !== getDefaultExecutor()) {
         await db.updateTodo(
           todo.id,
           title,
@@ -130,8 +131,9 @@ export function QuickCaptureModal({
         workspaceId,
       );
 
-      // 更新执行器
-      if (executor !== DEFAULT_EXECUTOR) {
+      // 更新执行器（仅当用户选择的执行器与系统默认不同时更新，
+      // 避免后端已设为默认值后又重复更新的冗余操作）
+      if (executor !== getDefaultExecutor()) {
         await db.updateTodo(
           todo.id,
           title,

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -5,7 +5,8 @@ import * as db from '@/utils/database';
 import { WorkspaceSwitcher } from './shell/WorkspaceSwitcher';
 
 import type { Todo, ExecutorConfig, ExecutorOption, SkillMeta, ExecutorSkills, TodoTemplate } from '@/types';
-import { EXECUTORS, executorConfigToOption, getExecutorColor, DEFAULT_EXECUTOR } from '@/types';
+import { EXECUTORS, executorConfigToOption, getExecutorColor } from '@/types';
+import { getDefaultExecutor } from '@/utils/executors';
 import { getLastExecutor, setLastExecutor } from '@/constants';
 import { TagCheckCardGroup } from './TagCheckCard';
 import { ExecutorPicker } from './todo-drawer/ExecutorPicker';
@@ -15,7 +16,7 @@ import { SchedulerSection } from './todo-drawer/SchedulerSection';
 import { TemplateModal } from './todo-drawer/TemplateModal';
 import {
   todoFormReducer,
-  initialFormState,
+  createInitialFormState,
   type TodoFormState,
   type TodoFormAction,
 } from './todo-drawer/reducer';
@@ -35,7 +36,8 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
   const isEditMode = todo !== null;
 
   // 使用 useReducer 替代多个 useState，集中管理表单状态
-  const [formState, dispatch] = useReducer(todoFormReducer, initialFormState);
+  // 使用工厂函数初始化，确保使用最新的系统默认执行器
+  const [formState, dispatch] = useReducer(todoFormReducer, undefined, createInitialFormState);
 
   // UI 相关的状态（不属于表单数据）
   const [executorOptions, setExecutorOptions] = useState<ExecutorOption[]>(EXECUTORS);
@@ -137,7 +139,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
   }, [open, todo]);
 
   // 创建模式下，RESET_FORM 之后从 localStorage 恢复上次选择的执行器，
-  // 而不是每次都回退到 DEFAULT_EXECUTOR。编辑模式保持 todo 自带的 executor。
+  // 而不是每次都回退到系统默认执行器。编辑模式保持 todo 自带的 executor。
   useEffect(() => {
     if (open && !todo) {
       setField('executor', getLastExecutor());
@@ -225,7 +227,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
           webhookEnabled,
         );
 
-        if (workspaceToSave != null || schedulerEnabled || executor !== DEFAULT_EXECUTOR || webhookEnabled) {
+        if (workspaceToSave != null || schedulerEnabled || executor !== getDefaultExecutor() || webhookEnabled) {
           await db.updateTodo(
             newTodo.id, newTodo.title, newTodo.prompt, newTodo.status,
             executor, schedulerEnabled, schedulerConfig || null,

--- a/frontend/src/components/WikiChatFloatingWindow.tsx
+++ b/frontend/src/components/WikiChatFloatingWindow.tsx
@@ -218,26 +218,24 @@ export function WikiChatFloatingWindow({ defaultMode = 'minimized', forceMode, o
     }
   }, [dispatch]);
 
-  // ─── 最小化模式：不渲染 ──────────────────────────────────────
-  if (mode === 'minimized') return null;
-
   // ─── 移动端：底部 Drawer ──────────────────────────────────
+  // 使用 forceMode 判断显隐（TypeScript 无法 narrow 来自 props 的值，避免 mode !== 'minimized' 编译错误）
   if (isMobile) {
     return (
       <Drawer
         title="Wiki 对话"
         placement="bottom"
-        open={true}
-        onClose={() => setMode('minimized')}
+        open={forceMode !== 'minimized'}
+        onClose={() => {
+          setMode('minimized');
+          onClose?.();
+        }}
         height="85vh"
         destroyOnHidden
         styles={{
           body: { padding: 0, display: 'flex', flexDirection: 'column', height: 'calc(85vh - 55px)', background: colors.panelBg },
           header: { background: colors.headerBg, borderBottom: `1px solid ${colors.panelBorder}`, padding: '12px 16px' },
         }}
-        extra={
-          <Button type="text" size="small" icon={<CloseOutlined />} onClick={onClose || (() => setMode('minimized'))} style={{ color: colors.hintColor }} />
-        }
       >
         <ChatMessageList messages={messages} loading={loading} mobile isDark={isDark} />
         <ChatInputPanel
@@ -318,8 +316,11 @@ export function WikiChatFloatingWindow({ defaultMode = 'minimized', forceMode, o
   // ─── 最大化模式：全屏模态 ──────────────────────────────────
   return (
     <Modal
-      open={true}
-      onCancel={() => setMode('side')}
+      open={forceMode === 'maximized'}
+      onCancel={() => {
+        setMode('side');
+        onClose?.();
+      }}
       footer={null}
       width="90vw"
       styles={{

--- a/frontend/src/components/common/ExecutorPickerPopover.tsx
+++ b/frontend/src/components/common/ExecutorPickerPopover.tsx
@@ -1,47 +1,61 @@
-import { memo, useState, useRef, useEffect, useCallback } from 'react';
+import { memo, useCallback } from 'react';
+import { Dropdown } from 'antd';
 import { CheckOutlined } from '@ant-design/icons';
 import { EXECUTORS_FOR_PICKER, getExecutorOption } from '@/types';
+import type { MenuProps } from 'antd';
 
 interface ExecutorPickerPopoverProps {
   value?: string;
   onChange?: (value: string) => void;
 }
 
-// 执行器选择弹出面板
-// 设计：小按钮显示当前执行器，点击弹出选择面板，选择后关闭
-// 支持 Antd Form.Item 自动注入 value/onChange
+/**
+ * 执行器选择弹出面板
+ *
+ * 使用 Ant Design Dropdown 组件，内置边界自动检测：
+ * 当下方空间不足时自动向上弹出，避免底部选项被遮挡。
+ * 触发按钮保持原有样式（执行器图标+名称+颜色主题）。
+ */
 export const ExecutorPickerPopover = memo(function ExecutorPickerPopover({
   value = 'claudecode',
   onChange,
 }: ExecutorPickerPopoverProps) {
-  const [open, setOpen] = useState(false);
-  const popoverRef = useRef<HTMLDivElement>(null);
   const current = getExecutorOption(value);
 
-  // 点击外部关闭
-  useEffect(() => {
-    if (!open) return;
+  // 构建下拉菜单项
+  const items: MenuProps['items'] = EXECUTORS_FOR_PICKER.map((opt) => ({
+    key: opt.value,
+    label: (
+      <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontSize: 14, lineHeight: 1 }}>{opt.icon}</span>
+        <span style={{
+          flex: 1,
+          fontSize: 13,
+          fontWeight: 600,
+          color: value === opt.value ? opt.color : 'var(--color-text)',
+        }}>
+          {opt.label}
+        </span>
+        {value === opt.value && (
+          <CheckOutlined style={{ fontSize: 12, color: opt.color }} />
+        )}
+      </span>
+    ),
+  }));
 
-    const handleClickOutside = (e: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [open]);
-
-  const handleSelect = useCallback((v: string) => {
-    onChange?.(v);
-    setOpen(false);
+  const handleMenuClick = useCallback<NonNullable<MenuProps['onClick']>>(({ key }) => {
+    onChange?.(String(key));
   }, [onChange]);
 
   return (
-    <div ref={popoverRef} style={{ position: 'relative', display: 'inline-block' }}>
-      {/* 触发按钮 */}
+    <Dropdown
+      menu={{ items, onClick: handleMenuClick }}
+      // bottomLeft 优先；Ant Design 内置自动边界检测，下方空间不足时自动翻转到 topLeft
+      placement="bottomLeft"
+      // 触发方式：点击
+      trigger={['click']}
+    >
       <button
-        onClick={() => setOpen(!open)}
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -65,84 +79,6 @@ export const ExecutorPickerPopover = memo(function ExecutorPickerPopover({
           {current.label}
         </span>
       </button>
-
-      {/* 弹出选择面板 */}
-      {open && (
-        <div
-          style={{
-            position: 'absolute',
-            top: '100%',
-            left: 0,
-            marginTop: 4,
-            padding: 8,
-            borderRadius: 10,
-            border: '1px solid var(--color-border-secondary)',
-            background: 'var(--color-bg-elevated)',
-            boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-            zIndex: 1000,
-            minWidth: 200,
-            maxHeight: 320,
-            overflowY: 'auto',
-          }}
-        >
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-            {EXECUTORS_FOR_PICKER.map((opt) => {
-              const selected = value === opt.value;
-              return (
-                <button
-                  key={opt.value}
-                  onClick={() => handleSelect(opt.value)}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 8,
-                    padding: '8px 10px',
-                    borderRadius: 6,
-                    border: 'none',
-                    background: selected ? `${opt.color}15` : 'transparent',
-                    cursor: 'pointer',
-                    transition: 'all 0.15s',
-                    textAlign: 'left',
-                  }}
-                  onMouseEnter={(e) => {
-                    if (!selected) {
-                      e.currentTarget.style.background = `${opt.color}08`;
-                    }
-                  }}
-                  onMouseLeave={(e) => {
-                    if (!selected) {
-                      e.currentTarget.style.background = 'transparent';
-                    }
-                  }}
-                >
-                  <span style={{ fontSize: 14, lineHeight: 1 }}>{opt.icon}</span>
-                  <span style={{
-                    flex: 1,
-                    fontSize: 13,
-                    fontWeight: 600,
-                    color: selected ? opt.color : 'var(--color-text)',
-                  }}>
-                    {opt.label}
-                  </span>
-                  {selected && (
-                    <span style={{
-                      width: 16,
-                      height: 16,
-                      borderRadius: '50%',
-                      backgroundColor: opt.color,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                    }}>
-                      <CheckOutlined style={{ fontSize: 10, color: '#fff' }} />
-                    </span>
-                  )}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      )}
-    </div>
+    </Dropdown>
   );
 });

--- a/frontend/src/components/settings/ExecutorsPanel.tsx
+++ b/frontend/src/components/settings/ExecutorsPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { Button, Card, Input, Switch, Spin, Tooltip, Modal, message, Typography, InputNumber, Form, Table, Space, Empty, Tabs, Popconfirm } from 'antd';
-import { SearchOutlined, PlayCircleOutlined, ClockCircleOutlined, BugOutlined, CodeOutlined, InfoCircleOutlined, SaveOutlined, StopOutlined, ReloadOutlined } from '@ant-design/icons';
+import { SearchOutlined, PlayCircleOutlined, ClockCircleOutlined, BugOutlined, CodeOutlined, InfoCircleOutlined, SaveOutlined, StopOutlined, ReloadOutlined, StarOutlined, StarFilled } from '@ant-design/icons';
 import { Cron } from 'react-js-cron';
 import 'react-js-cron/dist/styles.css';
 import { CronPresetSelect } from '@/components/CronPresetSelect';
@@ -12,6 +12,7 @@ import { useApp } from '@/hooks/useApp';
 import { SessionManager } from '@/components/SessionManager';
 
 import { DEFAULT_EXECUTION_TIMEOUT_SECS, MAX_EXECUTION_TIMEOUT_MINUTES } from '@/constants';
+import { setDefaultExecutorCache } from '@/utils/executors';
 
 const { Paragraph } = Typography;
 
@@ -26,6 +27,7 @@ export function ExecutorsPanel() {
   const [testModalVisible, setTestModalVisible] = useState(false);
   const [testModalData, setTestModalData] = useState<{ name: string; result: { test_passed: boolean; output: string | null; error: string | null } } | null>(null);
   const [savingExecutor, setSavingExecutor] = useState<string | null>(null);
+  const [settingDefaultExecutor, setSettingDefaultExecutor] = useState<string | null>(null);
 
   // 运行配置：并发数、超时等
   const [configForm] = Form.useForm();
@@ -297,9 +299,16 @@ export function ExecutorsPanel() {
               title: '执行器',
               dataIndex: 'display_name',
               key: 'display_name',
-              width: 110,
+              width: 130,
               render: (name: string, record: ExecutorConfig) => (
-                <span style={{ fontWeight: 500, opacity: record.enabled ? 1 : 0.5 }}>{name}</span>
+                <span style={{ fontWeight: 500, opacity: record.enabled ? 1 : 0.5, display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                  {name}
+                  {record.is_default && (
+                    <Tooltip title="默认执行器">
+                      <StarFilled style={{ color: '#faad14', fontSize: 12 }} />
+                    </Tooltip>
+                  )}
+                </span>
               ),
             },
             {
@@ -392,13 +401,45 @@ export function ExecutorsPanel() {
             {
               title: '操作',
               key: 'action',
-              width: 180,
+              width: 240,
               render: (_: unknown, record: ExecutorConfig) => {
                 const detectResult = detectResults[record.name];
                 const isDetecting = detectingExecutor === record.name;
                 const isTesting = testingExecutor === record.name;
+                const isSettingDefault = settingDefaultExecutor === record.name;
                 return (
                   <Space size={4}>
+                    <Tooltip title={record.is_default ? '当前为默认执行器' : '设为默认执行器'}>
+                      <Button
+                        size="small"
+                        type={record.is_default ? 'primary' : 'default'}
+                        icon={record.is_default ? <StarFilled /> : <StarOutlined />}
+                        loading={isSettingDefault}
+                        disabled={record.is_default}
+                        onClick={async () => {
+                          if (record.is_default) return;
+                          setSettingDefaultExecutor(record.name);
+                          try {
+                            const updated = await db.setDefaultExecutor(record.name);
+                            // 更新前端缓存，使新的默认值立即生效
+                            setDefaultExecutorCache(updated.name);
+                            setExecutors((prev) =>
+                              prev.map((e) => ({
+                                ...e,
+                                is_default: e.name === updated.name,
+                              }))
+                            );
+                            message.success(`${record.display_name} 已设为默认执行器`);
+                          } catch (err: any) {
+                            message.error('设置失败: ' + (err?.message || String(err)));
+                          } finally {
+                            setSettingDefaultExecutor(null);
+                          }
+                        }}
+                      >
+                        {record.is_default ? '默认' : '设为默认'}
+                      </Button>
+                    </Tooltip>
                     <Button
                       size="small"
                       icon={<SearchOutlined />}

--- a/frontend/src/components/todo-drawer/reducer.ts
+++ b/frontend/src/components/todo-drawer/reducer.ts
@@ -10,7 +10,7 @@
  */
 
 import type { Todo } from '@/types';
-import { DEFAULT_EXECUTOR } from '@/types/execution';
+import { getDefaultExecutor } from '@/utils/executors';
 
 /** 表单数据状态 */
 export interface TodoFormState {
@@ -42,18 +42,27 @@ export type TodoFormAction =
   | { type: 'RESET_FORM'; todo?: Todo | null }
   | { type: 'RESET_CREATE_MODE' };
 
-/** 初始状态（创建模式） */
-export const initialFormState: TodoFormState = {
-  title: '',
-  prompt: '',
-  selectedTags: [],
-  executor: DEFAULT_EXECUTOR,
-  workspaceId: null,
-  webhookEnabled: false,
-  schedulerEnabled: false,
-  schedulerConfig: '',
-  acceptanceCriteria: '',
-};
+/** 初始状态（创建模式）。
+ *  使用工厂函数以便动态获取系统默认执行器，而非硬编码常量。
+ */
+export function createInitialFormState(): TodoFormState {
+  return {
+    title: '',
+    prompt: '',
+    selectedTags: [],
+    executor: getDefaultExecutor(),
+    workspaceId: null,
+    webhookEnabled: false,
+    schedulerEnabled: false,
+    schedulerConfig: '',
+    acceptanceCriteria: '',
+  };
+}
+
+/** 兼容旧代码：保留 initialFormState 导出，值为工厂函数首次调用结果。
+ *  新代码应直接使用 createInitialFormState() 以获取最新默认执行器。
+ */
+export const initialFormState: TodoFormState = createInitialFormState();
 
 /** 表单 reducer */
 export function todoFormReducer(state: TodoFormState, action: TodoFormAction): TodoFormState {
@@ -75,7 +84,7 @@ export function todoFormReducer(state: TodoFormState, action: TodoFormAction): T
           title: action.todo.title || '',
           prompt: action.todo.prompt || '',
           selectedTags: action.todo.tag_ids || [],
-          executor: action.todo.executor || DEFAULT_EXECUTOR,
+          executor: action.todo.executor || getDefaultExecutor(),
           workspaceId: action.todo.workspace_id ?? null,
           webhookEnabled: action.todo.webhook_enabled || false,
           schedulerEnabled: action.todo.scheduler_enabled || false,
@@ -83,10 +92,10 @@ export function todoFormReducer(state: TodoFormState, action: TodoFormAction): T
           acceptanceCriteria: action.todo.acceptance_criteria ?? '',
         };
       }
-      return initialFormState;
+      return createInitialFormState();
 
     case 'RESET_CREATE_MODE':
-      return initialFormState;
+      return createInitialFormState();
 
     default:
       return state;

--- a/frontend/src/components/todo-drawer/reducer.ts
+++ b/frontend/src/components/todo-drawer/reducer.ts
@@ -59,11 +59,6 @@ export function createInitialFormState(): TodoFormState {
   };
 }
 
-/** 兼容旧代码：保留 initialFormState 导出，值为工厂函数首次调用结果。
- *  新代码应直接使用 createInitialFormState() 以获取最新默认执行器。
- */
-export const initialFormState: TodoFormState = createInitialFormState();
-
 /** 表单 reducer */
 export function todoFormReducer(state: TodoFormState, action: TodoFormAction): TodoFormState {
   switch (action.type) {

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -4,6 +4,8 @@
 // backend/src/config.rs::DEFAULT_EXECUTION_TIMEOUT_SECS.
 // =============================================================================
 
+import { getDefaultExecutor } from '@/utils/executors';
+
 /** Default execution timeout in seconds (1 hour). Used as fallback when no config is set. */
 export const DEFAULT_EXECUTION_TIMEOUT_SECS = 3600;
 
@@ -204,14 +206,22 @@ export const TODO_LIST_REFRESH_EVENT = 'todoListRefresh';
 // localStorage key 仅本文件内部用，跨组件记忆用户上次选择的执行器
 const LAST_EXECUTOR_STORAGE_KEY = 'ntd_last_executor';
 
-/** 从 localStorage 读出上次选择的执行器，不存在时回退到 DEFAULT_EXECUTOR */
-export function getLastExecutor(defaultExecutor: string = 'claudecode'): string {
+/** 从 localStorage 读出上次选择的执行器，不存在时回退到系统默认执行器 */
+export function getLastExecutor(defaultExecutor?: string): string {
   try {
-    return localStorage.getItem(LAST_EXECUTOR_STORAGE_KEY) || defaultExecutor;
+    const saved = localStorage.getItem(LAST_EXECUTOR_STORAGE_KEY);
+    if (saved) return saved;
+    // 没有保存值时，优先使用调用方传入的默认值，否则使用系统默认执行器
+    return defaultExecutor || getSystemDefaultExecutor();
   } catch {
-    // 隐私模式 / 配额满：静默吞掉
-    return defaultExecutor;
+    // 隐私模式 / 配额满：静默吞掉，返回系统默认
+    return defaultExecutor || getSystemDefaultExecutor();
   }
+}
+
+/** 获取系统默认执行器（从缓存读取，回退到 claudecode） */
+function getSystemDefaultExecutor(): string {
+  return getDefaultExecutor();
 }
 
 /** 将用户选择的执行器写入 localStorage */

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -212,16 +212,11 @@ export function getLastExecutor(defaultExecutor?: string): string {
     const saved = localStorage.getItem(LAST_EXECUTOR_STORAGE_KEY);
     if (saved) return saved;
     // 没有保存值时，优先使用调用方传入的默认值，否则使用系统默认执行器
-    return defaultExecutor || getSystemDefaultExecutor();
+    return defaultExecutor || getDefaultExecutor();
   } catch {
     // 隐私模式 / 配额满：静默吞掉，返回系统默认
-    return defaultExecutor || getSystemDefaultExecutor();
+    return defaultExecutor || getDefaultExecutor();
   }
-}
-
-/** 获取系统默认执行器（从缓存读取，回退到 claudecode） */
-function getSystemDefaultExecutor(): string {
-  return getDefaultExecutor();
 }
 
 /** 将用户选择的执行器写入 localStorage */

--- a/frontend/src/types/config.tsx
+++ b/frontend/src/types/config.tsx
@@ -32,6 +32,8 @@ export interface ExecutorConfig {
   enabled: boolean;
   display_name: string;
   session_dir: string;
+  /** 是否为系统默认执行器 */
+  is_default: boolean;
   created_at: string | null;
   updated_at: string | null;
 }

--- a/frontend/src/types/execution.tsx
+++ b/frontend/src/types/execution.tsx
@@ -18,6 +18,9 @@ export {
   RESUMABLE_EXECUTOR_OPTIONS,
   supportsResume,
   executorConfigToOption,
+  loadDefaultExecutor,
+  getDefaultExecutor,
+  setDefaultExecutorCache,
 } from '@/utils/executors';
 
 export interface LogEntry {

--- a/frontend/src/utils/database/skills.ts
+++ b/frontend/src/utils/database/skills.ts
@@ -120,6 +120,16 @@ export async function testExecutor(name: string): Promise<{ test_passed: boolean
   return unwrap(await api.post(`/api/executors/${encodeURIComponent(name)}/test`));
 }
 
+/** 获取系统默认执行器 */
+export async function getDefaultExecutor(): Promise<import('@/types').ExecutorConfig | null> {
+  return unwrap(await api.get('/api/executors/default'));
+}
+
+/** 设置指定执行器为系统默认执行器 */
+export async function setDefaultExecutor(name: string): Promise<import('@/types').ExecutorConfig> {
+  return unwrap(await api.put(`/api/executors/${encodeURIComponent(name)}/default`));
+}
+
 // Version API
 export interface VersionInfo {
   version: string;

--- a/frontend/src/utils/executors.tsx
+++ b/frontend/src/utils/executors.tsx
@@ -5,6 +5,48 @@
 
 import { FaSquare } from 'react-icons/fa';
 import type { ExecutorOption, ExecutionRecord } from '@/types/execution';
+import * as db from '@/utils/database';
+
+// ─── 全局默认执行器缓存 ──────────────────────────────────────
+//
+// 模块级缓存：应用启动时从后端加载 is_default=true 的执行器，
+// 后续通过 getDefaultExecutor() 同步读取，避免每次都发请求。
+// 若加载失败或尚未加载，回退到 DEFAULT_EXECUTOR 常量（claudecode）。
+
+let cachedDefaultExecutor: string | null = null;
+let defaultExecutorLoading: Promise<void> | null = null;
+
+/** 从后端加载默认执行器并缓存。应用启动时调用一次即可。 */
+export async function loadDefaultExecutor(): Promise<void> {
+  // 防止重复请求：已在加载中则复用同一个 Promise
+  if (defaultExecutorLoading) return defaultExecutorLoading;
+
+  defaultExecutorLoading = (async () => {
+    try {
+      const result = await db.getDefaultExecutor();
+      if (result?.name) {
+        cachedDefaultExecutor = result.name;
+      }
+    } catch (err) {
+      // 加载失败时静默使用常量回退，不阻塞应用启动
+      console.warn('加载默认执行器失败，使用回退值:', err);
+    }
+  })();
+
+  return defaultExecutorLoading;
+}
+
+/** 获取当前默认执行器名称（同步读取缓存）。
+ *  优先返回从后端加载的缓存值，未加载或加载失败时回退到 DEFAULT_EXECUTOR 常量。
+ */
+export function getDefaultExecutor(): string {
+  return cachedDefaultExecutor || DEFAULT_EXECUTOR;
+}
+
+/** 设置默认执行器缓存（在前端修改默认执行器后调用，同步更新本地缓存）。 */
+export function setDefaultExecutorCache(name: string): void {
+  cachedDefaultExecutor = name;
+}
 
 // ─── Executor 摘要映射 ──────────────────────────────────────
 


### PR DESCRIPTION
## 改动说明

将硬编码的 `claudecode` 默认执行器改为可配置，用户可在执行器管理面板中设置任意执行器为默认。

### 后端
- `executors` 表新增 `is_default` 字段（V63 迁移，幂等）
- 新增 `GET /api/executors/default` 和 `PUT /api/executors/:name/default` API
- `create_todo` 等创建逻辑从数据库读取默认执行器，无配置时回退 `claudecode`
- handler 层不再硬编码默认值，交给 DAO 层统一处理

### 前端
- 执行器面板新增「设为默认」按钮（星形图标），当前默认执行器高亮显示
- 应用启动时从后端加载默认执行器并缓存
- `QuickCaptureModal`、`TodoDrawer`、`reducer` 等组件使用 `getDefaultExecutor()` 替代硬编码 `DEFAULT_EXECUTOR` 常量
- 修改默认执行器后同步更新本地缓存，立即生效

### 向后兼容
- 未配置默认执行器时，系统回退到 `claudecode`，行为与改动前一致

### 验证
- ✅ `cargo clippy --all-targets -- -D warnings` 零告警
- ✅ `cargo test --lib` 1152 个测试全部通过
- ✅ `npx tsc --noEmit` 零错误