### PR TITLE
fix(feishu): 设置默认响应执行器时同步 default_response_type=executor

### DIFF
--- a/backend/src/services/feishu_card.rs
+++ b/backend/src/services/feishu_card.rs
@@ -558,17 +558,17 @@ pub struct HelpCardState {
     pub page: usize,
     /// 所有工作空间（工作空间页切换用）
     pub workspaces: Vec<WorkspaceItem>,
-    /// 已注册的可用执行器列表（工作空间页切换默认执行器用）。
+    /// 已注册的可用执行器列表（工作空间页切换默认响应执行器用）。
     /// listener 从 executor_registry.list_executors() 拉出，卡片层只读渲染成按钮排。
     pub available_executors: Vec<ExecutorOption>,
 }
 
-/// 可选执行器项（工作空间页「默认执行器」按钮排）。
+/// 可选执行器项（工作空间页「默认响应执行器」按钮排）。
 #[derive(Debug, Clone)]
 pub struct ExecutorOption {
     /// 执行器名（ExecutorType::as_str，如 "pi" / "claudecode"）
     pub name: String,
-    /// 是否为当前工作空间已配的默认执行器（primary 高亮）
+    /// 是否为当前工作空间已配的默认响应执行器（primary 高亮）
     pub is_current: bool,
 }
 
@@ -636,7 +636,7 @@ pub fn build_help_console_card(state: &HelpCardState) -> Card {
         "workspace" => build_workspace_page(builder, state),
         _ => build_status_page(builder, state),
     };
-    builder.note("💡 直接发消息即可让 AI 执行任务 | 点按钮原地操作").build()
+    builder.build()
 }
 
 /// 4 个 Tab 按钮，当前 Tab 高亮 primary。
@@ -721,7 +721,7 @@ fn pagination_buttons(kind: &str, page: usize, total_pages: usize) -> Vec<CardBu
     nav_btns
 }
 
-/// 工作空间页：当前工作空间 + 列表[切换] + 默认执行器按钮排 + 推送 3 按钮 + 设为推送目标。
+/// 工作空间页：当前工作空间 + 列表[切换] + 默认响应执行器按钮排 + 推送 3 按钮 + 设为推送目标。
 fn build_workspace_page(mut builder: CardBuilder, state: &HelpCardState) -> CardBuilder {
     builder = builder.markdown(&match &state.workspace {
         Some(w) => format!("**当前工作空间** {}（执行器 {}）", w.name, w.executor),
@@ -737,8 +737,10 @@ fn build_workspace_page(mut builder: CardBuilder, state: &HelpCardState) -> Card
         );
     }
     builder = builder.divider();
-    // 默认执行器选择：换行列出所有已注册执行器，当前配的 primary 高亮，点击即设为该 workspace 的默认执行器。
-    builder = builder.markdown("**默认执行器**");
+    // 默认响应执行器选择：换行列出所有已注册执行器，当前配的 primary 高亮，点击即设为该 workspace 的默认响应执行器。
+    // 文案叫「默认响应执行器」而非「默认执行器」——按钮点的不只是配 executor 字段，连 default_response_type 也一并切到 executor，
+    // 让 dispatch_default_response 真走执行器分支，文案和实际行为对齐，避免用户误以为只配了个名字。
+    builder = builder.markdown("**默认响应执行器**");
     if state.available_executors.is_empty() {
         builder = builder.markdown("_暂无已注册执行器_");
     } else {
@@ -1377,6 +1379,46 @@ mod tests {
         assert!(json.contains("act:/push result_only"), "应含推送级别按钮");
         assert!(json.contains("act:/sethome"), "应含设为推送目标");
         assert!(json.contains("pi"), "应显示执行器");
+    }
+
+    /// 工作空间页「默认响应执行器」按钮排：文案改名后不应再出现旧词「默认执行器」单独成段，
+    /// available_executors 非空时每个执行器渲染成 act:/setexecutor 按钮，当前配的 primary 高亮。
+    /// 底部 note「💡 直接发消息即可让 AI 执行任务」已删除，断言其不出现在任何页。
+    #[test]
+    fn test_build_help_console_card_workspace_default_response_executor_label() {
+        let state = HelpCardState {
+            current_group: "workspace".to_string(),
+            workspace: Some(WorkspaceSummary { id: 1, name: "my-app".to_string(), executor: "pi".to_string() }),
+            available_executors: vec![
+                ExecutorOption { name: "pi".to_string(), is_current: true },
+                ExecutorOption { name: "claudecode".to_string(), is_current: false },
+            ],
+            ..Default::default()
+        };
+        let json = render_card_map(&build_help_console_card(&state), "sk").to_string();
+        // 新文案落地
+        assert!(json.contains("默认响应执行器"), "应使用新文案「默认响应执行器」");
+        // 旧文案不应残留——"默认执行器**" 严格匹配段落标题，改名后必须消失
+        assert!(!json.contains("**默认执行器**"), "旧文案「默认执行器」段落标题应已移除");
+        // 每个执行器按钮 value
+        assert!(json.contains("act:/setexecutor pi"), "pi 为当前执行器，应渲染按钮");
+        assert!(json.contains("act:/setexecutor claudecode"), "claudecode 亦应渲染为按钮");
+        // 底部 note 已删
+        assert!(!json.contains("直接发消息即可让"), "底部 note 已删除，不应再出现");
+        assert!(!json.contains("点按钮原地操作"), "底部 note 已删除，不应再出现");
+    }
+
+    /// 底部 note 删除对所有 Tab 生效：状态页也不应再出现旧 note 文案。
+    #[test]
+    fn test_build_help_console_card_status_page_note_removed() {
+        let state = HelpCardState {
+            current_group: "status".to_string(),
+            workspace: Some(WorkspaceSummary { id: 1, name: "my-app".to_string(), executor: "pi".to_string() }),
+            push_level: "all".to_string(),
+            ..Default::default()
+        };
+        let json = render_card_map(&build_help_console_card(&state), "sk").to_string();
+        assert!(!json.contains("直接发消息即可让"), "状态页也不应出现已删除的底部 note");
     }
 
     /// 事项页：当前 workspace 的事项列表 + [执行] 按钮。

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -1752,40 +1752,51 @@ impl FeishuListener {
         ActionOutcome { success: true, message: format!("已触发环路「{name}」") }
     }
 
-    /// 设当前 workspace 的默认执行器：写 workspace_settings.default_response_executor。
+    /// 把当前 workspace 的「默认响应执行器」设为指定 executor：
+    /// 既写 workspace_settings.default_response_executor，又把 default_response_type 改为 "executor"。
+    /// 只写 executor 字段而不改 type 是有 bug 的——dispatch_default_response 按 default_response_type
+    /// 分发，type 仍是 todo/loop 时点了「默认响应执行器」按钮也不会真的切到执行器，所以两字段必须同改。
     /// executor 名必须是已注册的（ExecutorType::as_str），否则视为无效拒绝写入。
     async fn act_set_executor(context: &ListenerMessageContext<'_>, executor_name: &str) -> ActionOutcome {
         let Some(wid) = context.db.get_agent_bot_workspace_id(context.bot_id).await.ok().flatten() else {
             return ActionOutcome { success: false, message: "未设置工作空间".to_string() };
         };
         // 校验 executor 已注册，避免把无效名写进 settings 让下次 dispatch 失败
-        let registered: Vec<String> = context
-            .ctx
-            .executor_registry
-            .list_executors()
-            .await
-            .into_iter()
-            .map(|t| t.as_str().to_string())
-            .collect();
+        let registered: Vec<String> = Self::registered_executor_names(context).await;
         if !registered.iter().any(|s| s == executor_name) {
             return ActionOutcome {
                 success: false,
                 message: format!("执行器 {executor_name} 未注册（可用：{}）", registered.join(", ")),
             };
         }
+        // type 与 executor 同改：type=executor 让 dispatch 走执行器分支，executor 字段指定具体执行器。
+        // todo_id/loop_id 传 None 表示不动旧值——切回 todo/loop 时这些旧值还有用，不在这里清。
         match crate::db::workspace_setting::upsert_workspace_settings(
             context.db,
             wid,
-            None,
+            Some("executor".to_string()),
             None,
             None,
             Some(executor_name.to_string()),
         )
         .await
         {
-            Ok(_) => ActionOutcome { success: true, message: format!("默认执行器已设为 {executor_name}") },
+            Ok(_) => ActionOutcome { success: true, message: format!("默认响应执行器已设为 {executor_name}") },
             Err(e) => ActionOutcome { success: false, message: format!("设置失败：{e}") },
         }
+    }
+
+    /// 从 executor_registry 拉出所有已注册执行器名（ExecutorType::as_str），返回 Vec<String>。
+    /// 抽出来一是让 act_set_executor 更短，二是注册名查询本身也是可复用的小步骤。
+    async fn registered_executor_names(context: &ListenerMessageContext<'_>) -> Vec<String> {
+        context
+            .ctx
+            .executor_registry
+            .list_executors()
+            .await
+            .into_iter()
+            .map(|t| t.as_str().to_string())
+            .collect()
     }
 
     /// act 执行后 patch 刷新控制台：assemble 最新状态 + 顶部插入操作结果提示。


### PR DESCRIPTION
## 问题

在飞书 `/help` 控制台的工作空间页点选某个执行器设为默认时，原先 `act_set_executor` 只写 `workspace_settings.default_response_executor` 字段，**未改 `default_response_type`**。

若工作空间的默认响应类型停在 `todo` 或 `loop`，`dispatch_default_response` 仍按旧 `type` 分发——点了「默认执行器」按钮实际不会切到执行器，用户感知到的「设默认执行器」与真实行为不一致。

## 修复

`act_set_executor` 同次把 `default_response_type` 也设为 `"executor"`，让 dispatch 真走执行器分支。

## 附带改动

- 工作空间页文案「默认执行器」→「默认响应执行器」，与实际行为对齐
- 移除底部 note「💡 直接发消息即可让 AI 执行任务 | 点按钮原地操作」
- 抽出 `registered_executor_names` 辅助函数，`act_set_executor` 保持在 30 行内
- 新增两个卡片单测覆盖文案与 note 删除

## 验证

| 检查项 | 结果 |
|--------|------|
| `cargo clippy --all-targets -- -D warnings` | ✅ 零告警 |
| `cargo test --lib` | ✅ 1154 passed / 0 failed（含新增 2 个测试） |

## 改动文件

- `backend/src/services/feishu_listener.rs` — bug 修复 + 抽辅助函数
- `backend/src/services/feishu_card.rs` — 文案微调 + 删 note + 测试