### PR TITLE
fix(ui): 专家/专家团卡片补描边与常态阴影，修复与背景融为一体的层次问题

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -21,6 +21,13 @@
   --color-info: #3b82f6;
   --color-info-bg: #eff6ff;
 
+  /* 状态色的「强调态」浅底：用作头像渐变起点、高亮信息块底色。
+     与上面偏淡的 *-bg 配对——*-bg 做大面积填充，*-bg-1 略深做渐变起色与强调。
+     历史上被 ExpertCard/TeamCard/ExpertDetailModal 等引用却从未定义，
+     导致团队信息块底色失效、头像渐变起色缺失。*/
+  --color-info-bg-1: #dbeafe;
+  --color-warning-bg-1: #fef3c7;
+
   /* Neutrals */
   --color-bg: #f8fafc;
   --color-bg-layout: #f8fafc;
@@ -28,6 +35,11 @@
   --color-bg-hover: #f1f5f9;
   --color-border: #e2e8f0;
   --color-border-light: #f1f5f9;
+  /* 次级边框：比 --color-border 略深的 slate-300，用于卡片描边，
+     确保在白色 elevated 背景上仍能看清边界。
+     历史上被 14 处组件（含 ExpertCard/TeamCard）引用却从未定义，
+     导致整条 border 声明失效——卡片在深浅色模式下都没有描边。*/
+  --color-border-secondary: #cbd5e1;
 
   /* 卡片及三级背景 */
   --color-bg-card: #f8fafc;
@@ -106,6 +118,11 @@
   --color-error-bg: #450a0a;
   --color-info-bg: #172554;
 
+  /* 状态色强调态浅底（暗色）：比 *-bg 略亮，用作渐变起点与信息块底色，
+     保证暗底下仍能看出色相，而非一片死黑。*/
+  --color-info-bg-1: #1b2d52;
+  --color-warning-bg-1: #4d2e07;
+
   /* Base surfaces - Catppuccin Mocha */
   --color-bg: #1e1e2e;
   --color-bg-layout: #1e1e2e;
@@ -127,6 +144,10 @@
   /* Borders */
   --color-border: #313244;
   --color-border-light: #262637;
+  /* 次级边框（暗色）：取 Catppuccin surface1 (#45475a)，比 --color-border 更亮，
+     在 #1e1e2e 底色上才能显出卡片描边；同时与 antd 的 colorBorderSecondary 取值一致，
+     让自定义 CSS 变量与 antd token 视觉统一。*/
+  --color-border-secondary: #45475a;
 
   /* Text */
   --color-text: #cdd6f4;

--- a/frontend/src/components/settings/experts/ExpertCard.tsx
+++ b/frontend/src/components/settings/experts/ExpertCard.tsx
@@ -55,6 +55,9 @@ export function ExpertCard({ expert, onClick }: {
         transition: 'all 0.25s cubic-bezier(0.4, 0, 0.2, 1)',
         height: '100%',
         overflow: 'hidden',
+        // 常态即给一层极浅阴影，让卡片与同色的父容器（同为 --color-bg-elevated）拉开层次；
+        // 仅靠边框时，浅色模式下白底卡贴在白底容器上仍看不出边界，这层阴影补上「浮起」感。
+        boxShadow: 'var(--shadow-sm)',
       }}
       onMouseEnter={(e) => {
         (e.currentTarget as HTMLDivElement).style.transform = 'translateY(-4px)';
@@ -64,7 +67,8 @@ export function ExpertCard({ expert, onClick }: {
       onMouseLeave={(e) => {
         (e.currentTarget as HTMLDivElement).style.transform = 'translateY(0)';
         (e.currentTarget as HTMLDivElement).style.borderColor = 'var(--color-border-secondary)';
-        (e.currentTarget as HTMLDivElement).style.boxShadow = 'none';
+        // 离开时回到常态的浅阴影而非 'none'，否则鼠标移开后卡片重新贴平、边界再次消失。
+        (e.currentTarget as HTMLDivElement).style.boxShadow = 'var(--shadow-sm)';
       }}
     >
       {/* 头部：头像 + 名称 + 职业 */}

--- a/frontend/src/components/settings/experts/TeamCard.tsx
+++ b/frontend/src/components/settings/experts/TeamCard.tsx
@@ -63,6 +63,9 @@ export function TeamCard({ expert, onClick }: {
         transition: 'all 0.25s cubic-bezier(0.4, 0, 0.2, 1)',
         height: '100%',
         overflow: 'hidden',
+        // 常态即给一层极浅阴影，让卡片与同色的父容器（同为 --color-bg-elevated）拉开层次；
+        // 仅靠边框时，浅色模式下白底卡贴在白底容器上仍看不出边界，这层阴影补上「浮起」感。
+        boxShadow: 'var(--shadow-sm)',
       }}
       onMouseEnter={(e) => {
         (e.currentTarget as HTMLDivElement).style.transform = 'translateY(-4px)';
@@ -72,7 +75,8 @@ export function TeamCard({ expert, onClick }: {
       onMouseLeave={(e) => {
         (e.currentTarget as HTMLDivElement).style.transform = 'translateY(0)';
         (e.currentTarget as HTMLDivElement).style.borderColor = 'var(--color-border-secondary)';
-        (e.currentTarget as HTMLDivElement).style.boxShadow = 'none';
+        // 离开时回到常态的浅阴影而非 'none'，否则鼠标移开后卡片重新贴平、边界再次消失。
+        (e.currentTarget as HTMLDivElement).style.boxShadow = 'var(--shadow-sm)';
       }}
     >
       {/* 头部：团队头像 + 名称 + 类型标签 */}

--- a/frontend/tests/check_expert_card_layering.spec.ts
+++ b/frontend/tests/check_expert_card_layering.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// 验证专家 / 专家团队卡片在浅色与深色模式下都有清晰描边与常态阴影，
+// 解决「卡片边框与背景同色、看不出来、没有层次」的问题。
+//
+// 修复前根因：--color-border-secondary 从未定义，导致卡片
+//   border: '1px solid var(--color-border-secondary)'
+// 整条声明在计算时失效（border-style 退回初值 none、无描边），
+// 且卡片背景与父容器同为 --color-bg-elevated，又没有常态阴影，
+// 于是卡片与背景融为一体，只有 hover 才出阴影。
+//
+// 修复后：定义了 --color-border-secondary，并给卡片常态加 var(--shadow-sm)。
+// 因此可观测的不变量是：borderStyle === 'solid'（而非 none）、boxShadow !== 'none'。
+const BASE = 'http://localhost:18088';
+const THEMES = ['light', 'dark'] as const;
+
+// 取当前激活 tab 下的第一张卡片。专家/团队卡片底部都有「N 项技能」，
+// 用该文案配合 role=button 定位，可同时命中两种卡片。
+async function readFirstCardStyle(page: Page) {
+  const card = page
+    .locator('.ant-tabs-tabpane-active')
+    .getByRole('button', { name: /项技能/ })
+    .first();
+  await card.waitFor({ state: 'visible', timeout: 10000 });
+  // 读计算样式：var(--shadow-sm) 等变量会被 getComputedStyle 解析成真实值，
+  // 据此判断描边与阴影是否真的渲染出来。
+  return card.evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return { borderStyle: cs.borderStyle, borderColor: cs.borderColor, boxShadow: cs.boxShadow };
+  });
+}
+
+for (const theme of THEMES) {
+  test(`专家/团队卡片在${theme === 'dark' ? '深色' : '浅色'}模式下有清晰描边与常态阴影`, async ({ page }) => {
+    test.setTimeout(60000);
+    // 首帧前写入主题，让 ThemeProvider 初始化即进入目标主题，避免闪烁默认主题干扰断言。
+    await page.addInitScript((t) => localStorage.setItem('app_theme', t), theme);
+    await page.goto(`${BASE}/#/experts`);
+    // bundled 内置专家由后端提供，给一点加载时间。
+    await page.waitForTimeout(1500);
+
+    // 默认即「专家」tab：校验专家卡片。
+    const expert = await readFirstCardStyle(page);
+    console.log(`[${theme}/专家]`, expert);
+    expect(expert.borderStyle, '专家卡片常态描边应为 solid（修复前为 none）').toBe('solid');
+    expect(expert.borderColor, '专家卡片描边不应透明').not.toBe('rgba(0, 0, 0, 0)');
+    expect(expert.boxShadow, '专家卡片常态应有阴影层次（修复前为 none）').not.toBe('none');
+
+    // 切到「专家团队」tab：校验团队卡片。
+    await page.getByRole('tab', { name: '专家团队' }).click();
+    await page.waitForTimeout(600);
+    const team = await readFirstCardStyle(page);
+    console.log(`[${theme}/团队]`, team);
+    expect(team.borderStyle, '团队卡片常态描边应为 solid').toBe('solid');
+    expect(team.borderColor, '团队卡片描边不应透明').not.toBe('rgba(0, 0, 0, 0)');
+    expect(team.boxShadow, '团队卡片常态应有阴影层次').not.toBe('none');
+  });
+}


### PR DESCRIPTION
## 背景

专家菜单下「专家」「专家团队」两个 tab 的卡片，边框与背景同色、看不出来，没有层次感和边界感，只有鼠标 hover 才出阴影。深色、浅色模式都存在该问题。

## 根因

定位到是一个**缺失 CSS 变量**导致的连锁问题，不是单纯调色：

1. `--color-border-secondary` **在整个仓库从未被定义**，却被 14 处组件引用。卡片写的是
   `border: 1px solid var(--color-border-secondary)`，引用了一个未定义变量 → 整条 `border`
   声明在计算时失效，`border-style` 退回初值 `none` → **卡片根本没有描边**。
2. 卡片背景 `--color-bg-elevated` 与父容器 `.ntd-page-card` **完全相同**（浅色都是 `#fff`、
   深色都是 `#1e1e2e`），即使有边框也贴平。
3. 卡片**没有常态阴影**（只有 `onMouseEnter` 才设 `box-shadow`），所以常态势必融为一体；
   而且 hover 里只设了 `borderColor`，因 base 的 `border` 简写本就失效，hover 边框也画不出来，
   hover 只能靠 `box-shadow` + `translateY` 撑出立体感。
4. 顺带：`--color-info-bg-1` / `--color-warning-bg-1` 同样未定义，导致团队卡「负责人/成员数」
   信息块底色、头像渐变起色失效。

## 修复

- **`App.css`** 补齐缺失 token（根因修复，顺带修好另外 12 个引用 `--color-border-secondary` 的组件）：
  - `--color-border-secondary`：浅色 `#cbd5e1`(slate-300)、深色 `#45475a`(Catppuccin surface1，与 antd `colorBorderSecondary` 一致)。
  - `--color-info-bg-1` / `--color-warning-bg-1`：浅/深两套，用作头像渐变起点与信息块底色。
- **`ExpertCard.tsx` / `TeamCard.tsx`**：常态加 `boxShadow: var(--shadow-sm)` 极浅阴影，让卡片
  与同色父容器拉开「浮起」层次；`onMouseLeave` 的阴影由 `'none'` 改回 `var(--shadow-sm)`，
  避免鼠标移开后卡片重新贴平。

设计取舍：没有改卡片填充色（保持与全局卡片体系一致），而是用 **可见描边 + 常态浅阴影** 这套
经典组合来表达层次边界，最小改动、最大收益。

## 验证

`frontend/tests/check_expert_card_layering.spec.ts`：浅/深色模式下，分别对「专家」「专家团队」
卡片断言 `borderStyle === 'solid'`（修复前为 `none`）且 `boxShadow !== 'none'`（修复前无常态阴影）。

```
2 passed (6.6s)
```

实测计算样式（修复前 → 修复后）：

| 主题/卡片 | borderStyle | borderColor | boxShadow |
|---|---|---|---|
| 浅色·专家 | none → **solid** | (无) → **rgb(203,213,225)** | none → **rgba(0,0,0,.04) 0 1 2** |
| 浅色·团队 | none → **solid** | (无) → **rgb(203,213,225)** | none → **rgba(0,0,0,.04) 0 1 2** |
| 深色·专家 | none → **solid** | (无) → **rgb(69,71,90)** | none → **rgba(0,0,0,.3) 0 1 2** |
| 深色·团队 | none → **solid** | (无) → **rgb(69,71,90)** | none → **rgba(0,0,0,.3) 0 1 2** |

- `cd frontend && npx tsc --noEmit` ✅ 零错误
- `cd frontend && npm run build` ✅ 通过（仅原有的 vendor chunk 体积告警，与本次改动无关）
- `cd frontend && npx playwright test tests/check_expert_card_layering.spec.ts` ✅ 2 通过

视觉确认（浅色专家 / 深色专家团队）见会话内截图，卡片常态即有清晰描边与浮起层次，深浅色均与背景拉开边界。
