### PR TITLE
fix(ui): 修复手机端「事项」页 header 新建按钮缺失

### DIFF
--- a/frontend/src/components/ItemsPage.tsx
+++ b/frontend/src/components/ItemsPage.tsx
@@ -137,17 +137,25 @@ export function ItemsPage({
       </Button>
     </>
   ) : (
-    // 移动端：仅 Segmented 切换器（精简 header，避免拥挤）
-    <Segmented
-      size="small"
-      value={viewMode}
-      onChange={(v) => persistView(v as 'card' | 'list')}
-      options={[
-        { value: 'card', icon: <AppstoreOutlined />, title: '卡片' },
-        { value: 'list', icon: <UnorderedListOutlined />, title: '列表' },
-      ]}
-      data-testid="todo-center-view-toggle"
-    />
+    // 移动端：精简 header（去掉搜索/刷新），保留 Segmented 切换器 + 新建按钮。
+    // 新建必须在此提供——本 extra 会同时下发到 TodoCenterCardView（卡片视图）与
+    // TodoMobilePage（列表视图），两者都没有自备新建按钮；若只给 Segmented，
+    // 手机端事项页就找不到创建入口（环路页 LoopMobilePage 自带新建，故不受影响）。
+    <>
+      <Segmented
+        size="small"
+        value={viewMode}
+        onChange={(v) => persistView(v as 'card' | 'list')}
+        options={[
+          { value: 'card', icon: <AppstoreOutlined />, title: '卡片' },
+          { value: 'list', icon: <UnorderedListOutlined />, title: '列表' },
+        ]}
+        data-testid="todo-center-view-toggle"
+      />
+      <Button size="small" type="primary" icon={<PlusOutlined />} onClick={onOpenCreateModal}>
+        新建
+      </Button>
+    </>
   );
 
   if (viewMode === 'card') {

--- a/frontend/tests/check_mobile_todo_create_button.spec.ts
+++ b/frontend/tests/check_mobile_todo_create_button.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+// 验证手机端「事项」页 header 的「新建」按钮可见。
+// 修复前：ItemsPage 在移动端构建的 extra 只有 Segmented、没有「新建」，
+// 该 extra 下发到 TodoCenterCardView / TodoMobilePage（均无自备新建），
+// 导致手机端事项页找不到创建入口；而「环路」页 LoopMobilePage 自带新建，故正常。
+const BASE = 'http://localhost:18088';
+
+// 手机视口（iPhone X 尺寸），触发 useIsMobile(阈值 768) 的手机分支。
+test.use({ viewport: { width: 375, height: 812 } });
+
+test('手机端事项页 header 的「新建」按钮可见且可打开创建弹窗', async ({ page }) => {
+  test.setTimeout(60000);
+  // 直接进入事项列表（默认 panel=list）。事项卡片/列表由后端 bundled 提供，稍等加载。
+  await page.goto(`${BASE}/#/items`);
+  await page.waitForTimeout(2000);
+
+  // 定位 header extra 区里的「新建」按钮。修复前该区域只有 Segmented，此按钮不存在。
+  const createBtn = page
+    .locator('.ntd-page-card-extra')
+    .getByRole('button', { name: '新建' });
+  await expect(createBtn, '手机端事项页 header 应有「新建」按钮').toBeVisible({ timeout: 10000 });
+
+  // 截图留档（目录已 gitignore）：手机端事项页 header 的「新建」按钮清晰可见。
+  await page.screenshot({ path: 'tests/__screenshots__/mobile-todo-create-header.png' });
+
+  // 点击应打开创建事项的抽屉（onOpenCreateModal → setTodoModalOpen → TodoDrawer），
+  // 证明按钮确实接到了创建逻辑，而非只是一个空壳。
+  await createBtn.click();
+  await expect(page.locator('.ant-drawer'), '点击「新建」应打开创建抽屉').toBeVisible({ timeout: 8000 });
+  // 截图留档（目录已 gitignore），便于在 PR 里附图说明手机端效果。
+  await page.screenshot({ path: 'tests/__screenshots__/mobile-todo-create.png' });
+});


### PR DESCRIPTION
## 问题

手机端「事项」页 header 的「新建」按钮看不到，无法创建 todo 事项。「环路」页则正常显示「新建」按钮。

## 根因

不是 CSS 隐藏，是 React 条件渲染 + prop 透传的问题：

- `ItemsPage.tsx` 为 header 构建 `extra`，桌面端包含「搜索 + 刷新 + Segmented + 新建」，
  **移动端分支只放了 Segmented、漏了「新建」按钮**。
- 这个 `extra` 会被同时透传给：
  - 卡片视图 `TodoCenterCardView`（`<PageCard extra={extra}>`，无自备新建）
  - 列表视图 `TodoMobilePage`（`extra ?? 默认header`，默认含新建，但 extra 非空导致默认被覆盖）
- 两者在手机端都拿不到「新建」→ 创建入口消失。
- 「环路」页走的是 `LoopMobilePage`，自带「新建」且不接受外部 `extra` 覆盖，所以正常（与反馈一致）。

注：`TodoMobilePage` 的 `extra` JSDoc 本就写明「移动端传 null 由本组件自行构建」，但 `ItemsPage`
在移动端传了一个非空 extra，违背了该约定。不过若简单改成传 `null`，会让卡片视图
`TodoCenterCardView`（无默认 extra）连 Segmented 一起丢掉，所以采用下面的方案。

## 修复

`ItemsPage.tsx` 移动端 `extra` 分支补上「新建」`<Button>`（与桌面端、以及 `TodoCenterCardView`
里「保留切换器 + 新建」的设计注释保持一致）。一处改动，卡片/列表两种视图同时恢复。

## 验证

`frontend/tests/check_mobile_todo_create_button.spec.ts`（375 视口）：
- 断言事项页 `.ntd-page-card-extra` 内「新建」按钮可见（修复前不存在）；
- 点击后 `.ant-drawer` 可见，证明按钮接到了 `onOpenCreateModal → TodoDrawer` 创建流程。

```
1 passed (3.3s)
```

- `cd frontend && npx tsc --noEmit` ✅ 零错误
- `cd frontend && npm run build` ✅ 通过（仅原有 vendor chunk 体积告警，与本次无关）
- `cd frontend && npx playwright test tests/check_mobile_todo_create_button.spec.ts` ✅ 1 通过

手机端事项页 header 效果见会话内截图（Segmented 切换器 + 青色「新建」按钮，点击打开创建抽屉）。
