### PR TITLE
feat(startup): 启动时异步同步内置资源（专家/事项模板）

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -68,6 +68,8 @@ const DEFAULT_AUTO_USAGE_STATS_CRON: &str = "0 0 1 * * *";
 const DEFAULT_AUTO_UPDATE_HOUR: u32 = 3;
 /// 自动更新默认间隔类型:"day" / "week" / "month"。
 const DEFAULT_AUTO_UPDATE_INTERVAL: &str = "day";
+/// 启动时是否同步内置资源（专家/事项模板）。默认开启：每次启动拉取最新 bundled 资源。
+const DEFAULT_SYNC_ON_STARTUP: bool = true;
 
 /// 私有 helper:`auto_backup_*` / `auto_todo_backup_*` / `auto_skill_backup_*`
 /// 三组字段共享同一形状 (enabled: bool, cron: String, max_files: usize)。
@@ -269,6 +271,8 @@ pub struct BundledSourceConfig {
     pub auto_sync_enabled: bool,
     /// 自动同步 cron 表达式（6 字段，含秒）
     pub auto_sync_cron: String,
+    /// 启动时是否同步内置资源（每次启动异步拉取最新专家/事项模板）
+    pub sync_on_startup: bool,
     /// 上次同步时间
     pub last_sync_at: Option<String>,
 }
@@ -281,6 +285,7 @@ impl Default for BundledSourceConfig {
             local_path: "bundled".to_string(),
             auto_sync_enabled: false,
             auto_sync_cron: "0 0 4 * * *".to_string(),
+            sync_on_startup: DEFAULT_SYNC_ON_STARTUP,
             last_sync_at: None,
         }
     }

--- a/backend/src/git_sync/mod.rs
+++ b/backend/src/git_sync/mod.rs
@@ -79,6 +79,15 @@ impl GitSyncError {
     }
 }
 
+/// 环境中是否可用 git。
+///
+/// 供启动检查等场景在同步前探测：未安装 git 时给出明确提示并跳过同步，
+/// 而不是让 git_sync 抛错后被笼统记成「同步失败」、更不会 panic 主进程。
+/// 与 `run_git_command` 用同一套 `which::which("git")` 探测，保持单一事实来源。
+pub fn is_git_available() -> bool {
+    which::which("git").is_ok()
+}
+
 /// 执行 git 命令
 ///
 /// # 参数
@@ -368,5 +377,12 @@ mod tests {
     fn test_count_changed_files() {
         let output = "Updating abc123..def456\nFast-forward\n create mode 100644 experts/test.md\n delete mode 100644 experts/old.md";
         assert_eq!(count_changed_files(output), 3);
+    }
+
+    #[test]
+    fn test_is_git_available_when_git_present() {
+        // 开发/CI 环境通常装了 git；此处验证探测函数在 git 存在时返回 true 且不 panic。
+        // （git 缺失的分支无法在装了 git 的环境里测试，属可接受限制。）
+        assert!(is_git_available());
     }
 }

--- a/backend/src/handlers/bundled.rs
+++ b/backend/src/handlers/bundled.rs
@@ -110,31 +110,29 @@ pub struct StatusResponse {
     pub subdir_file_count: usize,
 }
 
-/// 手动触发同步
+/// 执行一次完整的内置资源同步：git clone/pull +（按 subdir）导入事项模板 + 重载专家 + 写 last_sync_at。
 ///
-/// POST /api/bundled/sync
-pub async fn sync_bundled(
-    State(state): State<AppState>,
-    Json(req): Json<SyncRequest>,
-) -> Result<ApiResponse<SyncResponse>, AppError> {
-    let cfg = state.config_clone();
-    let bundled_config = &cfg.bundled_source;
+/// 抽自 sync_bundled handler，供 HTTP 接口与启动检查任务共用，避免逻辑分叉。
+/// 返回 git 层 SyncResult，调用方据此组装 HTTP 响应或日志。
+pub(crate) async fn run_bundled_sync(
+    state: &AppState,
+    subdir: Subdir,
+    strategy: git_sync::SyncStrategy,
+) -> Result<git_sync::SyncResult, String> {
+    // 先快照出 owned bundled 配置并立即释放读锁卫，后续 .await 不持锁、future 保持 Send
+    let bundled_config = state.config_snapshot(|c| c.bundled_source.clone());
 
-    let repo_path = match git_sync::bundled_dir(&bundled_config.local_path) {
-        Some(p) => p,
-        None => return Err(AppError::BadRequest("无法获取 home 目录".to_string())),
-    };
+    let repo_path = git_sync::bundled_dir(&bundled_config.local_path)
+        .ok_or_else(|| "无法获取 home 目录".to_string())?;
 
-    let strategy = git_sync::SyncStrategy::from(req.strategy.as_str());
-    let subdir = req.subdir;
-
+    // 本地缺失或非合法 git 仓库 → 克隆；已存在 → 按策略同步更新
     let result = if !repo_path.exists() || !repo_path.join(".git").exists() {
         if repo_path.exists() {
+            // 目录存在但不是 git 仓库，清理后重新克隆，避免脏目录卡住 sync
             tracing::info!("本地目录存在但不是 git 仓库，清理后重新克隆");
-            if let Err(e) = tokio::fs::remove_dir_all(&repo_path).await {
-                tracing::error!("清理旧目录失败: {}", e);
-                return Err(AppError::Internal(format!("清理旧目录失败: {}", e)));
-            }
+            tokio::fs::remove_dir_all(&repo_path)
+                .await
+                .map_err(|e| format!("清理旧目录失败: {}", e))?;
         } else {
             tracing::info!("本地目录不存在，执行首次克隆");
         }
@@ -144,33 +142,48 @@ pub async fn sync_bundled(
         git_sync::sync_repo(&repo_path, "origin", &bundled_config.branch, strategy).await
     };
 
-    match result {
-        Ok(r) => {
-            update_last_sync_time(&state).await;
-            
-            // 同步完成后，如果子目录是 todos，触发数据库导入
-            if subdir == Subdir::Todos || subdir == Subdir::All {
-                if let Err(e) = import_todo_templates_from_bundled(&state).await {
-                    tracing::error!("从 bundled 导入事项模板失败: {}", e);
-                }
-            }
-            
-            // 同步完成后，如果子目录是 experts，触发专家重新加载
-            if subdir == Subdir::Experts || subdir == Subdir::All {
-                if let Err(e) = reload_experts_from_bundled(&state).await {
-                    tracing::error!("从 bundled 重新加载专家失败: {}", e);
-                }
-            }
-            
-            Ok(ApiResponse::ok(SyncResponse {
-                success: r.success,
-                message: r.message,
-                is_first_clone: r.is_first_clone,
-                has_updates: r.has_updates,
-                changed_files: r.changed_files,
-                subdir: subdir.as_str().to_string(),
-            }))
+    let r = result.map_err(|e| e.to_string())?;
+
+    // 刷新 last_sync_at：供启动检查的冷却判断使用
+    update_last_sync_time(state).await;
+
+    // todos / all：把 bundled/todos 下的模板导入数据库（失败不阻断，仅记日志）
+    if subdir == Subdir::Todos || subdir == Subdir::All {
+        if let Err(e) = import_todo_templates_from_bundled(state).await {
+            tracing::error!("从 bundled 导入事项模板失败: {}", e);
         }
+    }
+
+    // experts / all：重载专家索引（bundled 系统 + 用户自定义）
+    if subdir == Subdir::Experts || subdir == Subdir::All {
+        if let Err(e) = reload_experts_from_bundled(state).await {
+            tracing::error!("从 bundled 重新加载专家失败: {}", e);
+        }
+    }
+
+    Ok(r)
+}
+
+/// 手动触发同步
+///
+/// POST /api/bundled/sync
+pub async fn sync_bundled(
+    State(state): State<AppState>,
+    Json(req): Json<SyncRequest>,
+) -> Result<ApiResponse<SyncResponse>, AppError> {
+    let subdir = req.subdir;
+    let strategy = git_sync::SyncStrategy::from(req.strategy.as_str());
+
+    // 实际同步逻辑抽到 run_bundled_sync，handler 只负责参数解析与响应组装
+    match run_bundled_sync(&state, subdir, strategy).await {
+        Ok(r) => Ok(ApiResponse::ok(SyncResponse {
+            success: r.success,
+            message: r.message,
+            is_first_clone: r.is_first_clone,
+            has_updates: r.has_updates,
+            changed_files: r.changed_files,
+            subdir: subdir.as_str().to_string(),
+        })),
         Err(e) => {
             tracing::error!("同步失败: {}", e);
             Err(AppError::Internal(format!("同步失败: {}", e)))

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -380,7 +380,7 @@ async fn build_app_state(
     // 后台监听 todo 执行完成事件，派发给 loop_trigger_dispatcher
     spawn_todo_completed_listener(&tx, loop_trigger_dispatcher.clone());
 
-    AppState {
+    let state = AppState {
         db,
         executor_registry,
         tx: tx.clone(),
@@ -393,7 +393,13 @@ async fn build_app_state(
         loop_trigger_dispatcher,
         loop_runner,
         expert_manager: ctx.expert_manager.clone(),
-    }
+    };
+
+    // 启动检查（一次性异步任务）：查新版本（仅提示）+ 按配置同步内置资源，全程非阻塞。
+    // 放在 AppState 构造之后，使该任务能复用与 handler 同一套 run_bundled_sync 逻辑。
+    crate::services::startup_check::spawn_startup_check(state.clone());
+
+    state
 }
 
 /// 初始化 Loop Studio 三件套：runner / dispatcher / scheduler。

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -395,7 +395,7 @@ async fn build_app_state(
         expert_manager: ctx.expert_manager.clone(),
     };
 
-    // 启动检查（一次性异步任务）：查新版本（仅提示）+ 按配置同步内置资源，全程非阻塞。
+    // 启动检查（一次性异步任务）：按配置同步内置资源（专家/事项模板），全程非阻塞。
     // 放在 AppState 构造之后，使该任务能复用与 handler 同一套 run_bundled_sync 逻辑。
     crate::services::startup_check::spawn_startup_check(state.clone());
 

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -12,5 +12,6 @@ pub mod loop_scheduler;
 pub mod loop_trigger;
 pub mod master_switch;
 pub mod message_debounce;
+pub mod startup_check;
 pub mod usage_stats;
 pub mod worktree;

--- a/backend/src/services/startup_check.rs
+++ b/backend/src/services/startup_check.rs
@@ -1,0 +1,106 @@
+//! 启动检查：每次启动异步跑一次的「一次性」后台任务。
+//!
+//! 按配置 `bundled_source.sync_on_startup` 同步内置资源（专家 + 事项模板）。
+//! 全程非阻塞：失败只记日志，绝不拖垮或中断启动。
+//! 频繁重启时用 30 分钟冷却（复用 last_sync_at）避免反复打远端。
+//!
+//! 版本检查不在此处做——用户可在「设置 → 关于」页手动点「检查更新」
+//! （实时调 /api/version/latest），或开启「自动更新」让定时调度器处理升级。
+
+use std::time::Duration;
+
+use crate::git_sync::SyncStrategy;
+use crate::handlers::bundled::{run_bundled_sync, Subdir};
+use crate::handlers::AppState;
+
+/// 冷却窗口（秒）：距上次同步不足此时长则跳过。
+/// 取 30 分钟——既能覆盖「每次启动」的常态诉求，又能挡住快速重启循环对远端的连打。
+const COOLDOWN_SECS: i64 = 30 * 60;
+
+/// 启动检查入口：在 `build_app_state` 末尾调用。
+///
+/// `tokio::spawn` 一个一次性任务（无 loop），延迟一小段避让启动 IO 后执行资源同步。
+/// `state` 内部都是 Arc，clone 成本很低。
+pub fn spawn_startup_check(state: AppState) {
+    tokio::spawn(async move {
+        // 与现有 scheduler 一致：启动后短暂延迟，避免与其他初始化任务竞争 IO。
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        sync_resources(&state).await;
+    });
+}
+
+/// 按配置同步内置资源（专家 + 事项模板）。未开启或冷却期内跳过；失败只记日志。
+async fn sync_resources(state: &AppState) {
+    let (enabled, last_sync) = state
+        .config_snapshot(|c| (c.bundled_source.sync_on_startup, c.bundled_source.last_sync_at.clone()));
+    if !enabled {
+        tracing::debug!("[startup-check] sync_on_startup 关闭，跳过资源同步");
+        return;
+    }
+    if !cooldown_elapsed(&last_sync) {
+        tracing::debug!("[startup-check] 资源同步在冷却期内，跳过");
+        return;
+    }
+
+    tracing::info!("[startup-check] 开始同步内置资源（专家 + 事项模板）");
+    // Overwrite：bundled 是系统资源，远程为准；用户自定义在独立目录，不受影响。
+    match run_bundled_sync(state, Subdir::All, SyncStrategy::Overwrite).await {
+        Ok(r) => tracing::info!(
+            "[startup-check] 资源同步完成：{}（更新 {} 个文件）",
+            r.message,
+            r.changed_files
+        ),
+        Err(e) => tracing::warn!("[startup-check] 资源同步失败：{}", e),
+    }
+}
+
+/// 距上次记录时间是否已超过冷却窗口。
+///
+/// - `None`（从未记录）→ 视为需要执行；
+/// - 解析失败（脏数据）→ 同样视为需要执行，宁可多同步一次也不卡死。
+fn cooldown_elapsed(last_at: &Option<String>) -> bool {
+    let Some(ts) = last_at else { return true };
+    let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(ts) else {
+        return true;
+    };
+    // last_sync_at 用 Utc::now() 写入，带时区是合法 RFC3339，转 UTC 后比较一致。
+    let elapsed = chrono::Utc::now().signed_duration_since(parsed.with_timezone(&chrono::Utc));
+    elapsed.num_seconds() >= COOLDOWN_SECS
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    /// 用 RFC3339 字符串构造「距今 N 秒前」的时间戳，方便断言冷却窗口。
+    fn ago_rfc3339(secs_ago: i64) -> String {
+        (chrono::Utc::now() - chrono::Duration::seconds(secs_ago)).to_rfc3339()
+    }
+
+    #[test]
+    fn test_cooldown_elapsed_none_means_should_run() {
+        // 从未记录过 → 必须执行，不能因为冷却把首次同步挡掉。
+        assert!(cooldown_elapsed(&None));
+    }
+
+    #[test]
+    fn test_cooldown_elapsed_unparseable_means_should_run() {
+        // 脏数据解析失败 → 宁可多同步一次也不卡死，视为需要执行。
+        assert!(cooldown_elapsed(&Some("not-a-date".to_string())));
+    }
+
+    #[test]
+    fn test_cooldown_elapsed_within_window_skips() {
+        // 1 分钟前刚同步过，远小于 30 分钟冷却 → 跳过。
+        let recent = ago_rfc3339(60);
+        assert!(!cooldown_elapsed(&Some(recent)));
+    }
+
+    #[test]
+    fn test_cooldown_elapsed_beyond_window_runs() {
+        // 60 分钟前同步过，超过 30 分钟冷却 → 执行。
+        let stale = ago_rfc3339(60 * 60);
+        assert!(cooldown_elapsed(&Some(stale)));
+    }
+}

--- a/backend/src/services/startup_check.rs
+++ b/backend/src/services/startup_check.rs
@@ -42,6 +42,15 @@ async fn sync_resources(state: &AppState) {
         return;
     }
 
+    // 没装 git 时同步必然失败：提前探测给出明确提示并跳过，避免被笼统记成「同步失败」。
+    // 非阻塞——只 warn，不 panic、不影响主进程。
+    if !crate::git_sync::is_git_available() {
+        tracing::warn!(
+            "[startup-check] 未检测到 git，跳过内置资源同步。请安装 git 后重启，以拉取最新专家/事项模板。"
+        );
+        return;
+    }
+
     tracing::info!("[startup-check] 开始同步内置资源（专家 + 事项模板）");
     // Overwrite：bundled 是系统资源，远程为准；用户自定义在独立目录，不受影响。
     match run_bundled_sync(state, Subdir::All, SyncStrategy::Overwrite).await {


### PR DESCRIPTION
## 背景

希望每次启动时自动拉取最新的内置专家与事项模板，避免用户还得手动点「同步」。

## 机制

在 `build_app_state` 末尾 `tokio::spawn` 一个**一次性**异步任务（无 loop），延迟 10s 避让启动 IO 后执行资源同步：

```
sleep(10s) → sync_resources()
              ├─ 读 bundled_source.sync_on_startup（默认 true），关闭则跳过
              ├─ 30 分钟冷却（复用 last_sync_at），频繁重启不连打远端
              └─ run_bundled_sync(All, Overwrite)
                  → git pull → 导入事项模板到 DB → 重载专家索引 → 写 last_sync_at
```

全程非阻塞：任一步失败只记 `tracing::warn!`，绝不拖垮或中断启动。
Overwrite 策略只覆盖 system bundled 资源，用户自定义（`~/.ntd/experts/`）不受影响。

## 关键改动

| 文件 | 改动 |
|---|---|
| `config.rs` | 新增 `BundledSourceConfig.sync_on_startup`（默认 true，`const DEFAULT_SYNC_ON_STARTUP`），`#[serde(default)]` 兼容老配置 |
| `handlers/bundled.rs` | 抽出 `pub(crate) run_bundled_sync(state, subdir, strategy)`——HTTP handler 与启动任务共用同一套同步流水线，消除逻辑分叉 |
| `services/startup_check.rs` | 新模块：`spawn_startup_check` + `sync_resources` + 冷却判断 + 4 个单测 |
| `services/mod.rs` / `handlers/mod.rs` | 注册模块并在 `build_app_state` 接线 |

## 关于版本检查（已移除）

最初设计里还包含「启动时查 npm 最新版本」，但「关于」页已有独立的「检查更新」入口（实时调 `/api/version/latest`）和「自动更新」定时调度器，启动时重复检查意义不大，故**未接入**启动流程；`auto_update.rs` 也未做任何改动。

## 验证

- `cargo clippy --all-targets -- -D warnings` ✅ 零告警
- `cargo test` ✅ 全绿（1179 单测 + 集成测试，含 4 个新增冷却逻辑单测）
- 启动实测日志（`backend.dev.log`）确认同步流程按预期异步执行：
  ```
  [startup-check] 开始同步内置资源（专家 + 事项模板）
  本地仓库已存在，执行同步更新
  从 bundled/todos 导入了 30 个事项模板
  从 bundled 加载专家: 50 个
  [startup-check] 资源同步完成：已是最新版本（更新 0 个文件）
  ```
