### PR TITLE
feat(skills): 技能市场文件浏览器支持预览任意文件

### DIFF
--- a/backend/src/handlers/bundled.rs
+++ b/backend/src/handlers/bundled.rs
@@ -12,8 +12,11 @@ use crate::config::BundledSourceConfig;
 use crate::handlers::{AppError, AppState};
 use crate::models::ApiResponse;
 use crate::git_sync;
-// 复用 skills 模块的 { path, content } 文件内容响应结构，避免在本文件重复定义同构类型
-use crate::handlers::skills::SkillFileContentResponse;
+// 复用 skills 模块的工具：
+// - SkillFileContentResponse：{ path, content } 响应结构，避免在本文件重复定义同构类型
+// - resolve_skill_path_for_read：对 skill name 做字符串层安全校验，与 get_skill_file 同源，
+//   拦截 `..`/绝对路径等，防止 name 经 URL 编码逃出 skills 根目录（详见 read_bundled_skill_file）
+use crate::handlers::skills::{resolve_skill_path_for_read, SkillFileContentResponse};
 
 /// 子目录类型
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -906,15 +909,22 @@ fn read_bundled_skill_file(
     name: &str,
     rel_path: &str,
 ) -> Result<SkillFileContentResponse, AppError> {
-    // 定位技能目录；local_path 取自配置，与扫描/安装同源，否则自定义路径时永远找不到
-    let skill_dir = git_sync::bundled_dir(local_path)
+    // skills 根目录取自配置，与扫描/安装同源；自定义 local_path 时才能定位到正确目录
+    let skills_root = git_sync::bundled_dir(local_path)
         .ok_or_else(|| AppError::Internal("无法获取 home 目录".to_string()))?
-        .join("skills")
-        .join(name);
+        .join("skills");
 
-    // 技能不存在给 400 而非 404：与 content 接口一致，便于前端区分「技能没了」与「文件没了」
-    if !skill_dir.exists() || !skill_dir.is_dir() {
-        return Err(AppError::BadRequest(format!("技能 '{}' 不存在", name)));
+    // name 必须先校验再 join：axum 会对 URL 路径段内的 %2F 解码，攻击者能把 `..%2F..` 编码进
+    // {name} 段、绕过路由层的 `..` 折叠。复用 get_skill_file 同款校验（字符串层拒绝空/绝对路径/
+    // `..`/Windows 盘符），否则下方 resolve_file_under_skill 的前缀检查会和「已逃逸的 skill_dir」
+    // 比较而彻底失效——配合干净的 rel_path 即可读取系统任意文件。
+    // 校验器内部约定：不合法返回 BadRequest；技能不存在返回 NotFound（与 get_skill_file 一致）
+    let skill_dir = resolve_skill_path_for_read(&skills_root, name)?;
+
+    // resolve_skill_path_for_read 只判存在不判类型，补一道目录校验：
+    // name 命中普通文件时（理论上 bundled skills 不会出现）也一并拦下
+    if !skill_dir.is_dir() {
+        return Err(AppError::NotFound);
     }
 
     // 安全校验返回 canonicalize 后的绝对路径；文件不存在时内部已转 NotFound
@@ -1480,5 +1490,23 @@ mod tests {
                 "指向外部的符号链接应被前缀检查拦截"
             );
         }
+    }
+
+    /// name 含 `..` 时必须在 join 之前被字符串层校验拦下——这是 bundled file 接口的核心安全契约。
+    /// 若 name 能逃出 skills 根目录，攻击者可配合干净的 rel_path 读取系统任意文件
+    /// （详见 read_bundled_skill_file 注释）。name 校验委托给 resolve_skill_path_for_read，
+    /// 其字符串层拒绝已在 skills 模块独立单测覆盖；这里验证「本接口确实接入了该校验」。
+    #[test]
+    fn test_read_bundled_skill_file_rejects_traversal_in_name() {
+        // local_path 取任意值即可：name 的字符串层校验发生在任何文件系统访问之前，
+        // 不依赖该目录是否真实存在，因此本用例在任意环境（含 CI）都稳定
+        let err = read_bundled_skill_file("any/local", "../escape", "passwd")
+            .expect_err("含 .. 的 name 必须被拒绝，不得触达文件读取");
+        // 校验失败统一为 BadRequest，与 get_skill_file 的 name 校验语义一致
+        assert!(
+            matches!(err, AppError::BadRequest(_)),
+            "期望 BadRequest，实际: {:?}",
+            err
+        );
     }
 }

--- a/backend/src/handlers/bundled.rs
+++ b/backend/src/handlers/bundled.rs
@@ -12,6 +12,8 @@ use crate::config::BundledSourceConfig;
 use crate::handlers::{AppError, AppState};
 use crate::models::ApiResponse;
 use crate::git_sync;
+// 复用 skills 模块的 { path, content } 文件内容响应结构，避免在本文件重复定义同构类型
+use crate::handlers::skills::SkillFileContentResponse;
 
 /// 子目录类型
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -486,6 +488,8 @@ pub fn bundled_routes() -> Router<AppState> {
         // 技能市场 API
         .route("/api/bundled/skills", axum::routing::get(list_bundled_skills))
         .route("/api/bundled/skills/{name}/content", axum::routing::get(get_bundled_skill_content))
+        // 读单文件内容：与 content 同命名空间，让市场页文件浏览器能预览 SKILL.md 以外的文件
+        .route("/api/bundled/skills/{name}/file", axum::routing::get(get_bundled_skill_file))
         .route("/api/bundled/skills/install", axum::routing::post(install_bundled_skill))
 }
 
@@ -865,6 +869,107 @@ pub async fn get_bundled_skill_content(
     .map_err(|e| AppError::Internal(format!("spawn_blocking join error: {}", e)))??;
 
     Ok(ApiResponse::ok(result))
+}
+
+/// 单文件内容读取的 query 参数
+#[derive(Debug, Deserialize)]
+pub struct BundledSkillFileQuery {
+    /// 目标文件相对技能目录的路径，如 `references/guide.md`；含子目录用 `/` 分隔
+    pub path: String,
+}
+
+/// GET /api/bundled/skills/{name}/file - 读取 bundled 技能内某个文件的内容
+///
+/// 市场页文件浏览器预览非 SKILL.md 文件时调用。磁盘 IO 下放到 `read_bundled_skill_file`
+/// 并整体塞进 `spawn_blocking`，避免 read_to_string 阻塞 tokio reactor worker。
+pub async fn get_bundled_skill_file(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Query(query): Query<BundledSkillFileQuery>,
+) -> Result<ApiResponse<SkillFileContentResponse>, AppError> {
+    // 快照 local_path 后立刻释放读锁，再 move 进阻塞任务，保证 future 为 Send
+    let local_path = state.config_snapshot(|c| c.bundled_source.local_path.clone());
+    // name 含 `/`（如 src1/lark-doc），由前端 encodeURIComponent 编码、axum Path 解码，
+    // 与 get_bundled_skill_content 同一处理方式，这里无需二次解码
+    let result = tokio::task::spawn_blocking(move || read_bundled_skill_file(&local_path, &name, &query.path))
+        .await
+        .map_err(|e| AppError::Internal(format!("spawn_blocking join error: {}", e)))??;
+    Ok(ApiResponse::ok(result))
+}
+
+/// 在阻塞任务中读取 bundled 技能的单个文件内容。
+///
+/// skill_dir 的定位与 content 接口同源（`{local_path}/skills/{name}`），
+/// 文件路径经 `resolve_file_under_skill` 做安全校验，防止 `..`/符号链接逃逸出技能目录。
+fn read_bundled_skill_file(
+    local_path: &str,
+    name: &str,
+    rel_path: &str,
+) -> Result<SkillFileContentResponse, AppError> {
+    // 定位技能目录；local_path 取自配置，与扫描/安装同源，否则自定义路径时永远找不到
+    let skill_dir = git_sync::bundled_dir(local_path)
+        .ok_or_else(|| AppError::Internal("无法获取 home 目录".to_string()))?
+        .join("skills")
+        .join(name);
+
+    // 技能不存在给 400 而非 404：与 content 接口一致，便于前端区分「技能没了」与「文件没了」
+    if !skill_dir.exists() || !skill_dir.is_dir() {
+        return Err(AppError::BadRequest(format!("技能 '{}' 不存在", name)));
+    }
+
+    // 安全校验返回 canonicalize 后的绝对路径；文件不存在时内部已转 NotFound
+    let file_path = resolve_file_under_skill(&skill_dir, rel_path)?;
+    // canonicalize 对目录也会成功，这里补一道 is_file，拦截「请求了一个目录」的情况
+    if !file_path.is_file() {
+        return Err(AppError::NotFound);
+    }
+
+    // skill 资源均为文本（md/json/js/ts 等），用 read_to_string 即可，与 get_skill_file 一致；
+    // 真遇到二进制会因无效 UTF-8 报错，统一转 500，由前端预览区显示「无法加载」占位
+    let content = std::fs::read_to_string(&file_path)
+        .map_err(|e| AppError::Internal(format!("读取文件失败: {}", e)))?;
+
+    Ok(SkillFileContentResponse {
+        path: rel_path.to_string(),
+        content,
+    })
+}
+
+/// 校验 rel_path 位于 skill_dir 之内，返回 canonicalize 后的绝对文件路径。
+///
+/// 双重防护缺一不可：
+/// - 字符串层先拒绝空/绝对路径/`..`，把绝大多数恶意输入挡在文件系统访问之前；
+/// - canonicalize 后再做前缀检查，兜住「合法相对路径 + 符号链接」绕出到目录外的情形。
+fn resolve_file_under_skill(
+    skill_dir: &std::path::Path,
+    rel_path: &str,
+) -> Result<std::path::PathBuf, AppError> {
+    let rel = std::path::Path::new(rel_path);
+    // 空路径会让 join 退化为 skill_dir 本身，必须先拦
+    if rel.as_os_str().is_empty() {
+        return Err(AppError::BadRequest("文件路径不能为空".to_string()));
+    }
+    // 绝对路径会无视 skill_dir 直接指向任意位置，禁止
+    if rel.is_absolute() {
+        return Err(AppError::BadRequest("不允许使用绝对路径".to_string()));
+    }
+    // 拒绝 `..`（父级遍历）与 Windows 盘符前缀，二者都能逃出技能目录
+    if rel.components().any(|c| matches!(c, std::path::Component::ParentDir | std::path::Component::Prefix(_))) {
+        return Err(AppError::BadRequest("不允许的文件路径".to_string()));
+    }
+
+    let file_path = skill_dir.join(rel);
+    // canonicalize 会解析符号链接并要求文件真实存在；不存在归 404，让前端走「文件没了」分支
+    let file_canon = file_path.canonicalize().map_err(|_| AppError::NotFound)?;
+    let dir_canon = skill_dir
+        .canonicalize()
+        .map_err(|e| AppError::Internal(format!("解析技能目录失败: {}", e)))?;
+    // 最终保险：解析后的绝对路径必须仍落在技能目录之内（拦符号链接逃逸）
+    if !file_canon.starts_with(&dir_canon) {
+        return Err(AppError::BadRequest("文件路径超出技能目录".to_string()));
+    }
+
+    Ok(file_canon)
 }
 
 /// 收集所有来源目录的 metadata.json
@@ -1293,5 +1398,87 @@ mod tests {
         let mut skills = Vec::new();
         collect_bundled_skills_recursive(base.path(), base.path(), &mut skills);
         assert!(skills.is_empty(), "没有任何 SKILL.md 时结果应为空");
+    }
+
+    // ---- resolve_file_under_skill：文件路径安全校验（字符串层 + canonicalize 前缀层）----
+
+    /// 技能目录内的合法文件应返回 canonicalize 后的绝对路径。
+    #[test]
+    fn test_resolve_file_under_skill_normal() {
+        let dir = tempfile::tempdir().expect("创建 tempdir 失败");
+        let skill_md = write_rel(dir.path(), "SKILL.md", "x");
+        let skill_dir = skill_md.parent().expect("SKILL.md 应有父目录");
+
+        let resolved = resolve_file_under_skill(skill_dir, "SKILL.md")
+            .expect("技能目录内的合法文件应通过校验");
+        // 返回值就是 canonical 路径，再 canonicalize 应幂等
+        assert_eq!(resolved.canonicalize().unwrap(), resolved);
+        assert!(resolved.ends_with("SKILL.md"));
+    }
+
+    /// 含子目录的相对路径（如 references/guide.md）也属合法，应放行。
+    #[test]
+    fn test_resolve_file_under_skill_allows_nested() {
+        let dir = tempfile::tempdir().expect("创建 tempdir 失败");
+        let nested = write_rel(dir.path(), "refs/guide.md", "y");
+
+        let resolved = resolve_file_under_skill(dir.path(), "refs/guide.md")
+            .expect("子目录内的文件应通过校验");
+        assert_eq!(resolved, nested.canonicalize().unwrap());
+    }
+
+    /// 空路径会让 join 退化为读技能目录本身，必须在字符串层拒绝。
+    #[test]
+    fn test_resolve_file_under_skill_rejects_empty() {
+        let dir = tempfile::tempdir().expect("创建 tempdir 失败");
+        assert!(resolve_file_under_skill(dir.path(), "").is_err(), "空路径应被拒绝");
+    }
+
+    /// `..` 父级引用直接被字符串层拦下，根本不会触达文件系统。
+    #[test]
+    fn test_resolve_file_under_skill_rejects_parent_traversal() {
+        let dir = tempfile::tempdir().expect("创建 tempdir 失败");
+        assert!(resolve_file_under_skill(dir.path(), "../escape.md").is_err(), "含 .. 的路径应被拒绝");
+    }
+
+    /// `sub/../../escape` 这类先下钻再绕回上级的写法同样含 `..`，应被拒。
+    #[test]
+    fn test_resolve_file_under_skill_rejects_subdir_traversal() {
+        let dir = tempfile::tempdir().expect("创建 tempdir 失败");
+        write_rel(dir.path(), "sub/keep.md", "z");
+        assert!(
+            resolve_file_under_skill(dir.path(), "sub/../../escape.md").is_err(),
+            "绕回上级的路径应被拒绝"
+        );
+    }
+
+    /// 绝对路径无视 skill_dir，必须拒绝，防止读到任意系统文件。
+    #[test]
+    fn test_resolve_file_under_skill_rejects_absolute() {
+        let dir = tempfile::tempdir().expect("创建 tempdir 失败");
+        assert!(
+            resolve_file_under_skill(dir.path(), "/etc/passwd").is_err(),
+            "绝对路径应被拒绝"
+        );
+    }
+
+    /// 技能目录内的符号链接指向外部文件：字符串层放行（无 `..`），但 canonicalize 解析后
+    /// 落到技能目录之外，必须被前缀层拦截——这是字符串层兜不住的唯一逃逸路径。
+    #[test]
+    fn test_resolve_file_under_skill_rejects_symlink_escape() {
+        let skill_root = tempfile::tempdir().expect("创建 skill tempdir 失败");
+        let outside = tempfile::tempdir().expect("创建 outside tempdir 失败");
+        let target = write_rel(outside.path(), "secret.md", "top secret");
+
+        // 仅 unix 支持无权限创建符号链接，Windows 上该用例整体跳过
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&target, skill_root.path().join("link.md"))
+                .expect("创建符号链接失败");
+            assert!(
+                resolve_file_under_skill(skill_root.path(), "link.md").is_err(),
+                "指向外部的符号链接应被前缀检查拦截"
+            );
+        }
     }
 }

--- a/frontend/src/api/bundled.ts
+++ b/frontend/src/api/bundled.ts
@@ -209,6 +209,17 @@ export const bundledApi = {
   },
 
   /**
+   * 读取 bundled 技能内单个文件的内容
+   * 用于市场页文件浏览器预览 SKILL.md 以外的文件
+   */
+  async getSkillFileContent(skillName: string, path: string): Promise<{ path: string; content: string }> {
+    // path 作为 query 参数透传，axios 会自动 encode；skillName 含 `/` 需手动 encode 进路径段
+    return unwrap(await api.get(`/api/bundled/skills/${encodeURIComponent(skillName)}/file`, {
+      params: { path },
+    }));
+  },
+
+  /**
    * 安装技能到指定执行器
    * 将 bundled/skills/{skill_name} 复制到目标执行器的 skills 目录
    */

--- a/frontend/src/components/skills/SkillMarketplace.tsx
+++ b/frontend/src/components/skills/SkillMarketplace.tsx
@@ -1014,8 +1014,14 @@ export function SkillMarketplace() {
           if (file.path === 'SKILL.md') {
             return content;
           }
-          // 其他文件由后端按技能名 + 相对路径读取；selectedSkill 为组件 state，闭包可达
-          const res = await bundledApi.getSkillFileContent(selectedSkill?.name ?? '', file.path);
+          // 没有选中技能时不发请求：name 为空时后端会把 skill_dir 解析成 skills 根目录，
+          // 即便服务端已校验 name，前端也应在源头短路，避免发出无意义/异常的请求
+          const skillName = selectedSkill?.name;
+          if (!skillName) {
+            throw new Error('未选中技能，无法读取文件');
+          }
+          // 其他文件由后端按技能名 + 相对路径读取
+          const res = await bundledApi.getSkillFileContent(skillName, file.path);
           return res.content;
         }}
       />

--- a/frontend/src/components/skills/SkillMarketplace.tsx
+++ b/frontend/src/components/skills/SkillMarketplace.tsx
@@ -998,8 +998,8 @@ export function SkillMarketplace() {
       </Modal>
 
       {/* 文件浏览 Modal：复用与已安装技能一致的 SkillFileBrowserModal。
-          对 bundled 技能而言，SKILL.md 用已缓存的 content（presetContent），
-          其他文件 loadContent 报错 → 预览区显示「无法加载」占位文案。 */}
+          SKILL.md 走已缓存的 content（presetContent，省一次请求），
+          其他文件调 bundledApi.getSkillFileContent 实时读取后端文件内容。 */}
       <SkillFileBrowserModal
         open={fileBrowserOpen}
         onClose={() => setFileBrowserOpen(false)}
@@ -1010,11 +1010,13 @@ export function SkillMarketplace() {
         presetContent={content}
         presetPath="SKILL.md"
         loadContent={async (file) => {
+          // SKILL.md 命中预设缓存，直接返回，避免重复请求
           if (file.path === 'SKILL.md') {
             return content;
           }
-          // bundled API 没提供单文件内容接口 → 让预览区显示「无法加载」占位
-          throw new Error('市场暂不支持预览此文件');
+          // 其他文件由后端按技能名 + 相对路径读取；selectedSkill 为组件 state，闭包可达
+          const res = await bundledApi.getSkillFileContent(selectedSkill?.name ?? '', file.path);
+          return res.content;
         }}
       />
     </div>
@@ -1033,9 +1035,9 @@ function formatStars(n: number): string {
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 文件浏览：复用 SkillFileBrowserModal。
-// bundled API 只返回 SKILL.md 的 content + 文件元信息（path+size），
-// 其他文件没有读取接口，所以 loadContent 对 SKILL.md 走缓存，其他文件抛出错误。
-// SkillFilePreview 会捕获错误并展示"无法加载"占位。
+// bundled 的 content 接口返回 SKILL.md 文本 + 全量文件元信息（path+size）；
+// 单文件内容由 GET /api/bundled/skills/{name}/file 按需读取，
+// 所以 loadContent 对 SKILL.md 走缓存，其他文件调 getSkillFileContent。
 // ─────────────────────────────────────────────────────────────────────────────
 function toSkillFileInfos(files: BundledSkillFile[]): SkillFileInfo[] {
   // 转类型补齐 SkillFileInfo 字段（modified_at 改为可选，这里用空串占位）


### PR DESCRIPTION
## 背景

技能市场文件浏览器中，除 `SKILL.md` 外的任意文件点击后都显示「无法加载文件内容: 市场暂不支持预览此文件」；而已安装 skill 的文件浏览器可正常预览所有文件。

## 根因

- 已安装 skill 走 `GET /api/skills/file`，后端能读任意文件内容；
- 技能市场走 bundled API，只有 `GET /api/bundled/skills/{name}/content`（返回 SKILL.md + 文件元信息），**没有读单文件内容的接口**，前端只能对非 SKILL.md `throw new Error('市场暂不支持预览此文件')`。

## 方案

补一个对齐现有实现的 bundled 单文件读取接口，前端市场页接入。前端 `SkillFileBrowserModal` / `SkillFilePreview` 已通用，无需改动。

### 改动

| 文件 | 改动 |
|------|------|
| `backend/src/handlers/bundled.rs` | 新增路由 `GET /api/bundled/skills/{name}/file`、`get_bundled_skill_file` handler、`read_bundled_skill_file`、`resolve_file_under_skill`，复用 `SkillFileContentResponse` |
| `frontend/src/api/bundled.ts` | 新增 `getSkillFileContent` |
| `frontend/src/components/skills/SkillMarketplace.tsx` | `loadContent` 改调单文件接口，更新注释 |

### 安全

路径校验双重防护，对齐 `get_skill_file`：
1. 字符串层拒绝空 / 绝对路径 / `..` / Windows 盘符前缀；
2. `canonicalize` 后校验解析路径必须落在技能目录内，兜住符号链接逃逸。

## 验证

- ✅ `cargo clippy --all-targets -- -D warnings`：零告警
- ✅ `cargo test`：全部通过（lib 单测 1208 passed；新增 `resolve_file_under_skill` 7 个用例覆盖正常 / 空 / `..` / 子目录绕回 / 绝对路径 / 符号链接逃逸；集成测试 0 failed）
- ✅ `npx tsc --noEmit`：零错误
- ⏳ E2E（Playwright）：本机 dev 实例重启受阻未跑，待补