### PR TITLE
feat(bundled): Git 缺失检测 + 一键安装入口

### DIFF
--- a/backend/src/handlers/bundled.rs
+++ b/backend/src/handlers/bundled.rs
@@ -113,6 +113,10 @@ pub struct StatusResponse {
     pub subdir_exists: bool,
     /// 子目录下文件数
     pub subdir_file_count: usize,
+    /// 环境中是否安装了 git —— bundled 资源同步的前置依赖（同步靠系统 git CLI 完成）。
+    /// 单独暴露给前端：让前端在「模板管理」页就展示「未检测到 Git + 一键安装」入口，
+    /// 而不是等到用户点「立即同步」、收到一个笼统的 500 错误之后才知道根因。
+    pub git_available: bool,
 }
 
 /// 执行一次完整的内置资源同步：git clone/pull +（按 subdir）导入事项模板 + 重载专家 + 写 last_sync_at。
@@ -277,6 +281,10 @@ pub async fn get_bundled_status(
         subdir: subdir_name.to_string(),
         subdir_exists,
         subdir_file_count,
+        // 直接同步调用 is_git_available：which::which("git") 只做一次 PATH 目录扫描，
+        // 耗时在微秒级，不值得为此 spawn_blocking 占一个阻塞线程池槽位。
+        // 与启动检查（services/startup_check.rs）用的是同一个探测函数，单一事实来源。
+        git_available: git_sync::is_git_available(),
     }))
 }
 

--- a/frontend/src/api/bundled.ts
+++ b/frontend/src/api/bundled.ts
@@ -28,6 +28,8 @@ export interface BundledStatus {
   subdir: string;
   subdir_exists: boolean;
   subdir_file_count: number;
+  /** 环境中是否安装了 git（同步的前置依赖）；false 时前端展示「一键安装 Git」入口 */
+  git_available: boolean;
 }
 
 export interface BundledConfig {

--- a/frontend/src/components/settings/InstallGitButton.tsx
+++ b/frontend/src/components/settings/InstallGitButton.tsx
@@ -1,0 +1,63 @@
+import { DownloadOutlined } from '@ant-design/icons';
+import { ActionButton } from '@/components/ActionButton';
+import { INSTALL_GIT_ACTION_TYPE, INSTALL_GIT_ACTION_KEY, INSTALL_GIT_PROMPT } from './installGitPrompt';
+
+interface InstallGitButtonProps {
+  /** 安装动作完成后回调（通常用来重新探测 git 是否可用、刷新状态展示）。
+   *  ActionButton 的 onApply 在用户点「应用」时触发；装 git 没有需要「应用回填」的产物，
+   *  复用这个时机来重跑 is_git_available 最自然——用户看到版本号后点应用，状态即转绿。 */
+  onInstalled?: () => void | Promise<void>;
+  /** 按钮类型：横幅里用 primary 强引导，状态弹窗里用 default 次级 */
+  buttonType?: 'primary' | 'default' | 'link' | 'text';
+  /** 按钮尺寸，与周围按钮对齐 */
+  buttonSize?: 'small' | 'middle' | 'large';
+  /** 是否显示「安装 Git」文字，空间紧张可传 false 只留图标 */
+  showLabel?: boolean;
+  /** 外部额外禁用条件 */
+  disabled?: boolean;
+}
+
+/**
+ * 「一键安装 Git」触发按钮。
+ *
+ * 复用通用 ActionButton 承载完整交互：点击 → 弹 Drawer 看 prompt / 选执行器 / 选 workspace →
+ * 执行 → 实时看执行器日志（brew/apt/winget 的输出过程）→ 完成后用户点「应用」触发 onInstalled 重探。
+ *
+ * 不指定 executor：让用户在 Drawer 里挑一个本机已装的执行器（Claude Code 等）来跑安装命令；
+ * 能打开本应用就必然已配置至少一个执行器，因此不存在「没有执行器可装 git」的死结。
+ * worktree 也不构成障碍：install_git 这条 action todo 一般不在已启用 worktree 的项目目录下执行；
+ * 即便命中，create_worktree 失败也会优雅降级回原 workspace（见 executor_service/worktree.rs 的 fallback）。
+ */
+export function InstallGitButton({
+  onInstalled,
+  buttonType = 'default',
+  buttonSize = 'middle',
+  showLabel = true,
+  disabled,
+}: InstallGitButtonProps) {
+  return (
+    <ActionButton
+      actionType={INSTALL_GIT_ACTION_TYPE}
+      actionKey={INSTALL_GIT_ACTION_KEY}
+      prompt={INSTALL_GIT_PROMPT}
+      // 不需要前端参数：操作系统由执行器在目标机器上自行检测（见 installGitPrompt 注释）
+      params={{}}
+      // 不传 executor：让用户在 Drawer 里选本机已装的执行器；后端 find_or_create_todo
+      // 会取第一个可用 workspace 兜底，用户也可在 Drawer 的 WorkspaceSwitcher 里改。
+      buttonType={buttonType}
+      icon={<DownloadOutlined />}
+      buttonSize={buttonSize}
+      showLabel={showLabel}
+      disabled={disabled}
+      panelTitle="安装 Git"
+      panelDescription="AI 将检测你的操作系统并自动安装 Git（macOS 用 Homebrew / Linux 用 apt、dnf / Windows 用 winget），全程可在面板看到执行日志"
+      // 完成态默认渲染「结果原文 + 应用/拒绝」即够用：执行器会汇报 git --version 输出；
+      // 用户点「应用」触发重探，状态由红转绿。无需自定义 completedView。
+      onApply={async () => {
+        await onInstalled?.();
+      }}
+    >
+      安装 Git
+    </ActionButton>
+  );
+}

--- a/frontend/src/components/settings/TemplatesPanel.tsx
+++ b/frontend/src/components/settings/TemplatesPanel.tsx
@@ -138,7 +138,7 @@ export function TemplatesPanel() {
           type="error"
           style={{ marginBottom: 16 }}
           message="未检测到 Git"
-          description="远程仓库同步依赖系统 Git，当前环境未检测到。请先安装 Git，安装后即可同步专家 / 事项 / Skill 模板。"
+          description="远程仓库同步依赖系统 Git，当前环境未检测到。点右侧「安装 Git」一键安装；装完在弹窗里点「应用」即可重新检测。若已装好仍显示未安装，说明后端进程的 PATH 是启动时固定的、未刷新，重启本应用后即恢复。"
           action={<InstallGitButton onInstalled={loadStatus} buttonType="primary" showLabel />}
         />
       )}

--- a/frontend/src/components/settings/TemplatesPanel.tsx
+++ b/frontend/src/components/settings/TemplatesPanel.tsx
@@ -14,6 +14,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import {
+  Alert,
   App,
   Button,
   Empty,
@@ -44,6 +45,7 @@ import { ExpertsTemplatesTab } from './templates/ExpertsTemplatesTab';
 import { TodoTemplatesTab } from './templates/TodoTemplatesTab';
 import { SkillTemplatesTab } from './templates/SkillTemplatesTab';
 import { bundledApi } from '@/api/bundled';
+import { InstallGitButton } from './InstallGitButton';
 
 /**
  * 模板管理面板入口
@@ -97,6 +99,14 @@ export function TemplatesPanel() {
    * 触发同步（同步全部资源：experts + todos + skills）
    */
   const handleSync = async () => {
+    // 前置依赖检查：git 没装时同步注定失败（后端靠系统 git CLI 拉仓库），
+    // 干脆别发那个注定 500 的请求，直接引导用户去装 git，体验远好于事后看一条笼统错误。
+    if (status && !status.git_available) {
+      message.warning('未检测到 Git，请先安装 Git 后再同步');
+      // 弹出状态面板：里面「Git 运行环境」那行带「安装 Git」按钮，指给用户一条明路
+      setStatusModalOpen(true);
+      return;
+    }
     setSyncing(true);
     const hide = antMessage.loading('正在同步全部资源...', 0);
     try {
@@ -119,6 +129,19 @@ export function TemplatesPanel() {
 
   return (
     <div className="ntd-templates-panel">
+      {/* git 是 bundled 资源同步的硬前置依赖：缺失时在面板顶部强提示 + 内联一键安装入口，
+          而不是等用户点了「立即同步」再去吃一个笼统的 500。装完 onInstalled 触发 loadStatus 重探，
+          status.git_available 变 true 后本横幅自动消失。 */}
+      {status && !status.git_available && (
+        <Alert
+          showIcon
+          type="error"
+          style={{ marginBottom: 16 }}
+          message="未检测到 Git"
+          description="远程仓库同步依赖系统 Git，当前环境未检测到。请先安装 Git，安装后即可同步专家 / 事项 / Skill 模板。"
+          action={<InstallGitButton onInstalled={loadStatus} buttonType="primary" showLabel />}
+        />
+      )}
       <Space style={{ marginBottom: 16 }}>
         <Tooltip title="查看同步状态">
           <Button
@@ -383,6 +406,22 @@ function StatusModal({
     >
       {status ? (
         <Descriptions column={1} bordered size="small">
+          {/* Git 运行环境放第一行：这是同步能否进行的最关键前置条件，
+              缺失时直接在行内给「安装 Git」按钮（onRefresh 重探后标签转绿）。 */}
+          <Descriptions.Item label="Git 运行环境">
+            {status.git_available ? (
+              <Tag color="green" icon={<CheckCircleOutlined />}>
+                已安装
+              </Tag>
+            ) : (
+              <Space>
+                <Tag color="red" icon={<ExclamationCircleOutlined />}>
+                  未安装
+                </Tag>
+                <InstallGitButton onInstalled={onRefresh} buttonSize="small" />
+              </Space>
+            )}
+          </Descriptions.Item>
           <Descriptions.Item label="远程仓库">{status.remote_url}</Descriptions.Item>
           <Descriptions.Item label="分支">{status.branch}</Descriptions.Item>
           <Descriptions.Item label="本地路径">{status.local_path}</Descriptions.Item>

--- a/frontend/src/components/settings/installGitPrompt.ts
+++ b/frontend/src/components/settings/installGitPrompt.ts
@@ -1,0 +1,32 @@
+/**
+ * 「一键安装 Git」的 Prompt 模板常量。
+ *
+ * 设计取舍：
+ * - 不在前端猜操作系统塞进 params，而是让执行器（如 Claude Code）自己在目标机器上检测系统后
+ *   选择对应的安装命令。理由：前端 navigator.userAgent 可被改写、也不区分 Linux 发行版，
+ *   而执行器跑在真实 shell 里，`uname`/包管理器探测比浏览器猜的准得多。
+ * - 安装是「环境级」操作，与具体 workspace 无关（brew/apt/winget 都是全局安装），
+ *   因此不依赖 workspace_id；用户仍可在 ActionButton Drawer 里选 workspace 作为执行 cwd。
+ * - 末尾强制 `git --version` 验证：装完未必进当前 shell 的 PATH（尤其 macOS/Linux 新装），
+ *   让执行器显式验证并把结果汇报回来，前端 onApply 再触发一次 is_git_available 重探。
+ * - 权限提示单独列出来：apt/dnf 要 sudo、Windows 可能弹 UAC，提前告知执行器「需要密码时找用户要」，
+ *   避免它在提权交互上卡死或静默失败。
+ */
+export const INSTALL_GIT_ACTION_TYPE = 'install_git';
+export const INSTALL_GIT_ACTION_KEY = 'default';
+
+export const INSTALL_GIT_PROMPT = `你的任务：在本机安装 Git 命令行工具。
+
+请先检测当前操作系统，再选择对应的安装方式：
+
+- macOS：优先用 Homebrew 执行 \`brew install git\`；若检测到尚未安装 Homebrew，先按官方方式安装 Homebrew（https://brew.sh），再装 git。
+- Linux（Debian/Ubuntu）：\`sudo apt-get update && sudo apt-get install -y git\`。
+- Linux（Fedora/RHEL/CentOS）：\`sudo dnf install -y git\`，旧系统无 dnf 则用 \`sudo yum install -y git\`。
+- Windows：优先 \`winget install --id Git.Git -e --source winget\`；若无 winget，引导用户从 https://git-scm.com/download/win 下载安装包并执行。
+
+注意事项：
+- 涉及 sudo 或 UAC 提权时，如需密码请在终端提示用户输入，不要卡死或反复重试。
+- 安装完成后，运行 \`git --version\` 验证已正确安装并能看到版本号。
+- 若新装的 git 在当前 shell 还不在 PATH 里（常见于刚装完未重开终端），请明确告知用户「需要新开一个终端」。
+
+完成后简要汇报三点：检测到的操作系统、实际执行的安装命令、最终的 \`git --version\` 输出。`;

--- a/frontend/tests/check_git_install_entry.spec.ts
+++ b/frontend/tests/check_git_install_entry.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test';
+
+// 模板管理面板的「Git 检测 + 一键安装」入口。
+// git 是 bundled 资源同步的硬前置依赖。本机装了 git，正常请求 git_available=true、不显示缺失横幅；
+// 因此用 page.route 拦截 /api/bundled/status 强制返回 git_available:false，才能验证「缺失态」UI。
+// 成功信封为 { code:0, data, message }（见 utils/database/client.ts 的 unwrap）。
+
+const BASE = 'http://localhost:18088';
+
+/** 构造一份 status 响应体，仅 git_available 可变，其余给稳定默认值。 */
+function statusPayload(gitAvailable: boolean) {
+  return {
+    code: 0,
+    data: {
+      remote_url: 'https://example.com/test.git',
+      branch: 'main',
+      local_path: '/tmp/test-bundled',
+      sync_strategy: 'overwrite',
+      auto_sync_enabled: false,
+      local_exists: true,
+      local_commit: 'abc12345',
+      remote_commit: 'abc12345',
+      needs_update: false,
+      last_sync_at: null,
+      subdir: 'all',
+      subdir_exists: true,
+      subdir_file_count: 3,
+      git_available: gitAvailable,
+    },
+    message: '',
+  };
+}
+
+/** 拦截 status 接口 + 进入模板管理 tab 的公共前置。 */
+async function openTemplatesPanel(page: import('@playwright/test').Page, gitAvailable: boolean) {
+  // 路由必须在 goto 之前注册，才能命中面板挂载时的首次 status 请求
+  await page.route('**/api/bundled/status**', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(statusPayload(gitAvailable)),
+    })
+  );
+  await page.goto(`${BASE}/#settings`);
+  await page.getByRole('tab', { name: /模板管理/ }).click();
+  // 等待 useEffect 拉取 status 并完成渲染
+  await page.waitForTimeout(800);
+}
+
+test('git 缺失时模板管理页顶部展示告警 + 一键安装按钮', async ({ page }) => {
+  await openTemplatesPanel(page, false);
+
+  // 顶部 Alert 的 message 文案应可见
+  await expect(page.getByText('未检测到 Git')).toBeVisible();
+  // ActionButton 渲染出的「安装 Git」按钮应存在，即一键安装入口已挂上
+  await expect(page.getByRole('button', { name: /安装 Git/ })).toBeVisible();
+});
+
+test('git 可用时不展示缺失告警', async ({ page }) => {
+  await openTemplatesPanel(page, true);
+
+  // git_available=true 时缺失告警不应渲染
+  await expect(page.getByText('未检测到 Git')).toHaveCount(0);
+  // 也不应出现安装按钮（只有缺失态才挂）
+  await expect(page.getByRole('button', { name: /安装 Git/ })).toHaveCount(0);
+});
+
+test('点击「同步状态」弹窗里展示 Git 运行环境行（缺失态带安装按钮）', async ({ page }) => {
+  await openTemplatesPanel(page, false);
+
+  // 打开同步状态弹窗
+  await page.getByRole('button', { name: /同步状态/ }).click();
+  await page.waitForTimeout(500);
+
+  // 弹窗内的 Descriptions 应包含「Git 运行环境」这一行
+  await expect(page.getByText('Git 运行环境')).toBeVisible();
+  // 缺失态下弹窗内同样有「安装 Git」按钮（与顶部横幅共两个）
+  await expect(page.getByRole('button', { name: /安装 Git/ })).toHaveCount(2);
+});


### PR DESCRIPTION
## 背景

内置资源（专家 / 事项 / Skill 模板）通过系统 Git CLI 从远程仓库同步。但用户机器若未装 Git，此前只能在点「立即同步」后收到一个笼统的 `500 同步失败: git 命令未找到` 才发现根因，体验差且根因不明。

## 方案

采用「检测折叠进同步状态 + ActionButton 一键安装」，不开专门的「基础组件」菜单（YAGNI：当前只有 Git 一个依赖，执行器/npm 各自有家，开菜单会重复）。

### 后端（最小改动，安装链路零改动）
- `StatusResponse` 增加 `git_available` 字段，`get_bundled_status` 直接调现成的 `git_sync::is_git_available()`（与启动检查同源）。
- 安装本身**不改后端**：`POST /api/actions/execute` 本就接受任意 `action_type`，传 `install_git` 即自动建 todo 跑执行器。

### 前端（`设置 → 模板管理`）
- Git 缺失时顶部红色 `Alert` 横幅 + 内联「安装 Git」按钮（ActionButton）。
- 「立即同步」前置预检：缺 Git 时不发那个注定 500 的同步请求，直接弹状态面板引导安装。
- 同步状态弹窗增加「Git 运行环境」行，缺失时行内带安装按钮。
- 新增 `installGitPrompt.ts`：OS 感知提示词（让执行器自己探测系统 → Homebrew / apt / dnf / winget → `git --version` 验证）。
- 新增 `InstallGitButton.tsx`：复用通用 `ActionButton`，完成态点「应用」触发重新探测。

### 为什么不存在「鸡生蛋」
- 能打开本应用就必然已配置至少一个执行器（Claude Code 等），安装 Git 的执行器永远可得。
- 即便 install_git 这条 action 命中了 worktree 路径，`create_worktree` 失败也会优雅降级回原 workspace（见 `executor_service/worktree.rs` 的 fallback），不阻断安装。

## 验证

- `cargo clippy --all-targets -- -D warnings`：零告警
- `cargo test`：全绿（~1700+ 用例）
- `npx tsc --noEmit` + `npm run build`：零错误
- Playwright `frontend/tests/check_git_install_entry.spec.ts`：3/3 通过
  - Git 缺失：顶部告警 + 安装按钮可见
  - Git 可用：不显示缺失告警
  - 同步状态弹窗：含「Git 运行环境」行 + 安装按钮
- 真实 `/api/bundled/status` 接口已确认返回 `git_available` 字段