### PR TITLE
feat(ui): 将侧边栏配置项收拢为底部弹出菜单

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4278,6 +4278,20 @@ code {
   color: var(--color-text) !important;
 }
 
+/* 配置按钮 — 与主题切换按钮同款样式，放在底部操作区 */
+.ntd-left-rail-config-toggle {
+  width: 44px !important;
+  height: 44px !important;
+  border-radius: 14px !important;
+  color: var(--color-text-tertiary) !important;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.ntd-left-rail-config-toggle:hover {
+  background: var(--color-bg-hover) !important;
+  color: var(--color-text) !important;
+}
+
 .ntd-left-rail-drawer {
   width: 100%;
   height: 100%;
@@ -4316,6 +4330,71 @@ code {
 .ntd-left-rail-drawer-label {
   font-weight: 600;
   font-size: 14px;
+}
+
+/* ---------- 配置弹出菜单 ---------- */
+/* 覆盖 antd Popover 默认内边距，让菜单面板更紧凑 */
+.ntd-config-menu-popover .ant-popover-inner {
+  padding: 0 !important;
+}
+
+.ntd-config-menu {
+  min-width: 180px;
+}
+
+.ntd-config-menu-title {
+  padding: 10px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.ntd-config-menu-body {
+  display: flex;
+  flex-direction: column;
+  padding: 6px;
+}
+
+.ntd-config-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 14px;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  text-align: left;
+  width: 100%;
+}
+
+.ntd-config-menu-item:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text);
+}
+
+.ntd-config-menu-item.active {
+  background: var(--color-primary-bg);
+  color: var(--color-primary);
+}
+
+.ntd-config-menu-item-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  width: 20px;
+  flex-shrink: 0;
+}
+
+.ntd-config-menu-item-label {
+  font-weight: 500;
 }
 
 .ntd-logo-button {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4500,6 +4500,23 @@ code {
   border-color: var(--color-primary);
 }
 
+/* 时间驱动且调度活跃时：左侧青色强调条 + 轻微背景色，
+   让活跃卡片在视觉上更突出，与暂停卡片形成明显区分。 */
+.todo-center-card--time-active {
+  border-left: 3px solid var(--color-primary);
+  background: linear-gradient(
+    to right,
+    var(--color-primary-bg) 0%,
+    var(--color-primary-bg) 6px,
+    var(--color-bg-elevated) 6px,
+    var(--color-bg-elevated) 100%
+  );
+}
+
+.todo-center-card--time-active:hover {
+  border-left-color: var(--color-primary-hover);
+}
+
 .todo-center-card-head {
   display: flex;
   align-items: flex-start;
@@ -4550,6 +4567,27 @@ code {
   color: var(--color-text-tertiary);
 }
 
+/* 弱化态：暂停/非活跃的元信息行，降低视觉权重 */
+.todo-center-card-meta-line--muted {
+  color: var(--color-text-tertiary);
+  opacity: 0.7;
+}
+
+.todo-center-card-meta-line--muted .todo-center-card-meta-icon {
+  color: var(--color-text-tertiary);
+  opacity: 0.8;
+}
+
+/* 高亮态：重要信息（如下次运行时间），用主色 + 字重突出 */
+.todo-center-card-meta-line--highlight-primary {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.todo-center-card-meta-line--highlight-primary .todo-center-card-meta-icon {
+  color: var(--color-primary);
+}
+
 .todo-center-card-foot {
   display: flex;
   align-items: center;
@@ -4573,6 +4611,17 @@ code {
 /* 暗色模式：卡片背景与悬停边框适配 */
 [data-theme="dark"] .todo-center-card {
   background: var(--color-bg-elevated);
+}
+
+/* 暗色模式：时间驱动活跃卡片的渐变背景适配 */
+[data-theme="dark"] .todo-center-card--time-active {
+  background: linear-gradient(
+    to right,
+    var(--color-primary-bg) 0%,
+    var(--color-primary-bg) 6px,
+    var(--color-bg-elevated) 6px,
+    var(--color-bg-elevated) 100%
+  );
 }
 
 /* 事项中心筛选栏：状态/动作类型下拉 + 命令触发勾选 */

--- a/frontend/src/components/TodoCenterCard.tsx
+++ b/frontend/src/components/TodoCenterCard.tsx
@@ -137,9 +137,12 @@ export function TodoCenterCard({ item, onChanged, onSelectTodo, onSelectLoop }: 
     </Button>
   );
 
+  // 时间驱动卡片的调度活跃状态：用于控制左侧强调条、标签颜色等视觉区分
+  const isTimeDrivenActive = item.computed_bucket === 'time_driven' && item.scheduler_enabled;
+
   return (
     <div
-      className="todo-center-card"
+      className={`todo-center-card ${isTimeDrivenActive ? 'todo-center-card--time-active' : ''}`}
       // React Portal 会把 Dropdown 菜单的合成事件冒泡回卡片（即便菜单 DOM 在 body），
       // 因此不能只靠按钮 stopPropagation——点菜单项仍会触发卡片跳详情。
       // 这里用 target 检测：点击源自按钮/下拉/弹窗时视为操作意图，不跳详情。
@@ -167,9 +170,17 @@ export function TodoCenterCard({ item, onChanged, onSelectTodo, onSelectLoop }: 
       </div>
 
       <div className="todo-center-card-tags">
-        <Tag color={BUCKET_DISPLAY[item.computed_bucket].color}>
-          {BUCKET_DISPLAY[item.computed_bucket].label}
-        </Tag>
+        {/* 时间驱动且已暂停时，标签置灰以弱化视觉权重；活跃时用原青色强调 */}
+        {item.computed_bucket === 'time_driven' && !item.scheduler_enabled ? (
+          <>
+            <Tag color="default">{BUCKET_DISPLAY[item.computed_bucket].label}</Tag>
+            <Tag color="default">已暂停</Tag>
+          </>
+        ) : (
+          <Tag color={BUCKET_DISPLAY[item.computed_bucket].color}>
+            {BUCKET_DISPLAY[item.computed_bucket].label}
+          </Tag>
+        )}
         <StatusTag status={item.status} />
         {sourceLabel(item.action_type) && <Tag color="gold">{sourceLabel(item.action_type)}</Tag>}
         {/* 绑定斜杠命令：手动触发仍属手动分类（命令是执行入口，非持续驱动） */}
@@ -242,13 +253,25 @@ function CardMeta({
   onSelectLoop: (loopId: number) => void;
 }) {
   const failCount = item.consecutive_failure_count ?? 0;
+  // 时间驱动且调度已启用：视为活跃状态，视觉上高亮下次运行时间
+  const isTimeActive = item.computed_bucket === 'time_driven' && item.scheduler_enabled;
+  // 时间驱动但调度已暂停：弱化调度表达式显示，降低视觉权重
+  const isTimePaused = item.computed_bucket === 'time_driven' && !item.scheduler_enabled;
+
   return (
     <div className="todo-center-card-meta">
       {item.computed_bucket === 'time_driven' && item.scheduler_config && (
-        <MetaLine icon={<ClockCircleOutlined />} text={`调度 ${item.scheduler_config}`} />
+        <MetaLine
+          icon={<ClockCircleOutlined />}
+          text={`调度 ${item.scheduler_config}`}
+          muted={isTimePaused}
+        />
       )}
-      {item.computed_bucket === 'time_driven' && item.scheduler_next_run_at && (
-        <MetaLine text={`下次运行 ${formatRelativeTime(item.scheduler_next_run_at)}`} />
+      {isTimeActive && item.scheduler_next_run_at && (
+        <MetaLine
+          text={`下次运行 ${formatRelativeTime(item.scheduler_next_run_at)}`}
+          highlight="primary"
+        />
       )}
       {/* 事件驱动卡片：Webhook 入口路径 + 最近触发时间（webhook 专属，不受手动执行影响） */}
       {item.computed_bucket === 'event_driven' && (
@@ -304,10 +327,29 @@ function ReferencingLoops({
   );
 }
 
-/** 单行元信息：可选图标 + 文本。 */
-function MetaLine({ icon, text }: { icon?: React.ReactNode; text: string }) {
+/**
+ * 单行元信息：可选图标 + 文本。
+ * - muted：弱化显示（暂停/非活跃状态用）
+ * - highlight：高亮显示（活跃/重要信息用，primary = 主色强调）
+ */
+function MetaLine({
+  icon,
+  text,
+  muted,
+  highlight,
+}: {
+  icon?: React.ReactNode;
+  text: string;
+  muted?: boolean;
+  highlight?: 'primary';
+}) {
+  const className = [
+    'todo-center-card-meta-line',
+    muted ? 'todo-center-card-meta-line--muted' : '',
+    highlight === 'primary' ? 'todo-center-card-meta-line--highlight-primary' : '',
+  ].filter(Boolean).join(' ');
   return (
-    <div className="todo-center-card-meta-line">
+    <div className={className}>
       {icon && <span className="todo-center-card-meta-icon">{icon}</span>}
       <span>{text}</span>
     </div>

--- a/frontend/src/components/settings/experts/TeamCard.tsx
+++ b/frontend/src/components/settings/experts/TeamCard.tsx
@@ -150,17 +150,20 @@ export function TeamCard({ expert, onClick }: {
         gap: 8,
         padding: 8,
         borderRadius: 8,
-        background: 'var(--color-warning-bg-1)',
+        // 使用中性灰背景替代高饱和度警告色，避免视觉干扰；
+        // 亮色模式下为浅灰 (#f1f5f9)，暗色模式下为深灰 (#313244)，与整体风格一致。
+        background: 'var(--color-bg-tertiary)',
       }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-          <StarOutlined style={{ fontSize: 12, color: 'var(--color-warning)' }} />
+          {/* 图标使用三级文本色，与背景形成柔和对比，不再突出 */}
+          <StarOutlined style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }} />
           <span style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
             负责人：{leadMember ? (leadMember.name_zh || leadMember.name_en || '未知') : '无'}
           </span>
         </div>
         <div style={{ width: 1, height: 12, background: 'var(--color-border)' }} />
         <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-            <UserOutlined style={{ fontSize: 12, color: 'var(--color-warning)' }} />
+            <UserOutlined style={{ fontSize: 12, color: 'var(--color-text-tertiary)' }} />
             <span style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
               {memberCount} 人团队
             </span>

--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Button, Tooltip } from 'antd';
+import { Button, Tooltip, Popover } from 'antd';
 import type { ButtonProps } from 'antd';
 import {
   UnorderedListOutlined,
@@ -18,6 +18,7 @@ import {
   MessageOutlined,
   RobotOutlined,
   TeamOutlined,
+  AppstoreOutlined,
 } from '@ant-design/icons';
 import { TfiBlackboard } from 'react-icons/tfi';
 import { WorkspaceSwitcher } from './WorkspaceSwitcher';
@@ -87,18 +88,19 @@ export function LeftRail({
         { key: 'memorial', label: '看板', icon: <ReadOutlined />, ariaLabel: '看板' },
       ] satisfies LeftRailItem[],
     },
-    {
-      title: '配置',
-      items: [
-        { key: 'settings_bots', label: '智能助手', icon: <RobotOutlined />, ariaLabel: '智能助手' },
-        { key: 'settings_executors', label: '执行器', icon: <CodeOutlined />, ariaLabel: '执行器' },
-        { key: 'settings_skills', label: 'Skills', icon: <ThunderboltOutlined />, ariaLabel: 'Skills' },
-        { key: 'settings_experts', label: '专家', icon: <TeamOutlined />, ariaLabel: '专家' },
-        { key: 'settings_projectDirectories', label: '工作空间', icon: <FolderOutlined />, ariaLabel: '工作空间' },
-        { key: 'settings', label: '设置', icon: <SettingOutlined />, ariaLabel: '设置' },
-      ] satisfies LeftRailItem[],
-    },
   ]), []);
+
+  // 配置项菜单 — 从侧边栏主体收拢到底部弹出菜单，减少主导航的视觉噪音
+  const configItems = useMemo(() => ([
+    { key: 'settings_bots', label: '智能助手', icon: <RobotOutlined />, ariaLabel: '智能助手' },
+    { key: 'settings_executors', label: '执行器', icon: <CodeOutlined />, ariaLabel: '执行器' },
+    { key: 'settings_skills', label: 'Skills', icon: <ThunderboltOutlined />, ariaLabel: 'Skills' },
+    { key: 'settings_experts', label: '专家', icon: <TeamOutlined />, ariaLabel: '专家' },
+    { key: 'settings_projectDirectories', label: '工作空间', icon: <FolderOutlined />, ariaLabel: '工作空间' },
+    { key: 'settings', label: '设置', icon: <SettingOutlined />, ariaLabel: '设置' },
+  ] satisfies LeftRailItem[]), []);
+
+  const [openConfigPopover, setOpenConfigPopover] = useState(false);
 
   const isDrawer = variant === 'drawer';
   const shouldShowLabels = isDrawer || !collapsed;
@@ -153,6 +155,36 @@ export function LeftRail({
     );
   };
 
+  /**
+   * 渲染配置弹出菜单的内容面板。
+   * 将原来侧边栏里的配置 section 收拢为一个可点击展开的菜单，保持功能完整的同时减少主导航视觉噪音。
+   */
+  const renderConfigMenu = () => (
+    <div className="ntd-config-menu">
+      <div className="ntd-config-menu-title">配置</div>
+      <div className="ntd-config-menu-body">
+        {configItems.map((item) => {
+          const isActive = item.key === activeKey;
+          return (
+            <button
+              key={item.key}
+              className={`ntd-config-menu-item ${isActive ? 'active' : ''}`}
+              onClick={() => {
+                onSelect(item.key);
+                setOpenConfigPopover(false);
+              }}
+              aria-label={item.ariaLabel}
+              data-testid={`config-menu-${item.key}`}
+            >
+              <span className="ntd-config-menu-item-icon">{item.icon}</span>
+              <span className="ntd-config-menu-item-label">{item.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+
   const renderWorkspaceArea = () => {
     if (isDrawer || shouldShowLabels) {
       return (
@@ -205,7 +237,25 @@ export function LeftRail({
 
       {isDrawer && (
         <div className="ntd-left-rail-drawer-bottom">
-          {/* 移动端抽屉底部：亮/暗色主题切换按钮 */}
+          {/* 移动端抽屉底部：配置菜单 + 亮/暗色主题切换按钮 */}
+          <Popover
+            content={renderConfigMenu()}
+            open={openConfigPopover}
+            onOpenChange={setOpenConfigPopover}
+            placement="topLeft"
+            trigger="click"
+            overlayClassName="ntd-config-menu-popover"
+          >
+            <Button
+              type="text"
+              block
+              icon={<AppstoreOutlined />}
+              className="ntd-left-rail-drawer-btn"
+              data-testid="left-rail-config-toggle"
+            >
+              <span className="ntd-left-rail-drawer-label">配置</span>
+            </Button>
+          </Popover>
           <Button
             type="text"
             block
@@ -223,6 +273,25 @@ export function LeftRail({
 
       {!isDrawer && (
         <div className="ntd-left-rail-bottom">
+          {/* 配置按钮 — 点击弹出收拢的配置菜单，替代原来侧边栏里的配置 section */}
+          <Tooltip title="配置" placement="right">
+            <Popover
+              content={renderConfigMenu()}
+              open={openConfigPopover}
+              onOpenChange={setOpenConfigPopover}
+              placement="top"
+              trigger="click"
+              overlayClassName="ntd-config-menu-popover"
+            >
+              <Button
+                type="text"
+                className="ntd-left-rail-config-toggle"
+                icon={<AppstoreOutlined />}
+                aria-label="配置"
+                data-testid="left-rail-config-toggle"
+              />
+            </Popover>
+          </Tooltip>
           {/* 亮/暗色主题切换按钮 — 当前为亮色显示太阳，暗色显示月亮，点击切换 */}
           <Tooltip title={themeMode === 'light' ? '切换暗色' : '切换亮色'} placement="right">
             <Button


### PR DESCRIPTION
- 从 LeftRail 主体中移除"配置"section，减少主导航视觉噪音
- 在底部操作区新增配置图标按钮（AppstoreOutlined）
- 点击弹出 Popover 菜单，包含智能助手/执行器/Skills/专家/工作空间/设置六项
- 当前选中的配置项在菜单中高亮显示
- 适配桌面端 rail 模式和移动端 drawer 模式
- 弹出菜单位于按钮正上方（placement: top）