### PR TITLE
feat(reply): 回复框支持用户自定义快捷话术按钮

### DIFF
--- a/backend/src/db/entity/mod.rs
+++ b/backend/src/db/entity/mod.rs
@@ -30,6 +30,7 @@ pub mod usage_stats;
 pub mod usage_executor_daily;
 pub mod workspace_settings;
 pub mod workspace_slash_commands;
+pub mod quick_buttons;
 
 pub mod prelude {
     pub use super::agent_bots::Entity as AgentBots;
@@ -63,4 +64,5 @@ pub mod prelude {
     pub use super::usage_executor_daily::Entity as UsageExecutorDaily;
     pub use super::workspace_settings::Entity as WorkspaceSettings;
     pub use super::workspace_slash_commands::Entity as WorkspaceSlashCommands;
+    pub use super::quick_buttons::Entity as QuickButtons;
 }

--- a/backend/src/db/entity/quick_buttons.rs
+++ b/backend/src/db/entity/quick_buttons.rs
@@ -1,0 +1,25 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// 快捷话术按钮表：button_name（全局唯一）+ prompt_text。
+///
+/// 全局共享（无 workspace 维度）。用于帖子流回复框上方的自定义快捷按钮：
+/// 点击把 prompt_text 填入回复输入框，用户确认后走 resume 继续会话。
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "quick_buttons")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    /// 自增主键
+    pub id: i64,
+    /// 按钮显示名称，全局唯一（DB UNIQUE 约束 + handler 预检双重保证）
+    pub button_name: String,
+    /// 点击按钮后填入回复输入框的预设话术
+    pub prompt_text: String,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -24,6 +24,7 @@ mod v62;
 mod v63;
 mod v64;
 mod v65;
+mod v66;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -81,6 +82,8 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v64::V64AddAgentBotOwnerOpenId),
         // V65 在 V64 之后：为 todos 增加 expert_name 字段，支持配置专家/团队
         Box::new(v65::V65AddTodoExpertName),
+        // V66 在 V65 之后：新建 quick_buttons 表，支撑回复框自定义快捷话术按钮
+        Box::new(v66::V66AddQuickButtonsTable),
     ]
 }
 

--- a/backend/src/db/migration/v66.rs
+++ b/backend/src/db/migration/v66.rs
@@ -1,0 +1,43 @@
+//! 数据库迁移 V66：新建 quick_buttons 表（用户自定义快捷话术按钮）
+//!
+//! ## 背景
+//! 帖子流回复框上方提供用户自定义的快捷按钮：每个按钮存「名称 + 预设话术」，
+//! 点击把话术填入回复输入框。全局共享，无 workspace 维度。
+//!
+//! ## 幂等
+//! `CREATE TABLE IF NOT EXISTS` 天然幂等，从任意中间状态重启都能安全重入。
+
+use async_trait::async_trait;
+
+use super::super::Database;
+use super::Migration;
+
+pub(super) struct V66AddQuickButtonsTable;
+
+#[async_trait]
+impl Migration for V66AddQuickButtonsTable {
+    fn version(&self) -> i64 {
+        66
+    }
+
+    fn name(&self) -> &'static str {
+        "V66AddQuickButtonsTable"
+    }
+
+    /// 建 quick_buttons 表。button_name 全局唯一，避免用户加出同名按钮。
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        db.exec(
+            "CREATE TABLE IF NOT EXISTS quick_buttons (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                button_name TEXT NOT NULL,
+                prompt_text TEXT NOT NULL,
+                created_at TEXT,
+                updated_at TEXT,
+                UNIQUE(button_name)
+            )",
+        )
+        .await?;
+        tracing::info!("V66: quick_buttons 表已创建");
+        Ok(())
+    }
+}

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -329,6 +329,7 @@ mod review_template;
 pub use review_template::ReviewTemplateInput;
 pub mod workspace_setting;
 pub mod workspace_slash_command;
+pub mod quick_button;
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::useless_vec, clippy::redundant_pattern_matching, clippy::redundant_clone, clippy::len_zero, clippy::bool_assert_comparison, clippy::unnecessary_get_then_check, clippy::doc_lazy_continuation, clippy::clone_on_copy, clippy::print_stdout, clippy::needless_pass_by_value, clippy::sliced_string_as_bytes, clippy::manual_map, clippy::collapsible_match, clippy::question_mark)]

--- a/backend/src/db/quick_button.rs
+++ b/backend/src/db/quick_button.rs
@@ -1,0 +1,194 @@
+//! 快捷话术按钮的数据库访问层
+//!
+//! 提供 quick_buttons 表的 CRUD 操作。全局共享，无 workspace 维度。
+
+use sea_orm::{
+    ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter,
+    QueryOrder,
+};
+use crate::db::Database;
+
+/// 创建快捷按钮。调用方需先用 get_quick_button_by_name 预检重名（DB 还有 UNIQUE 兜底）。
+pub async fn create_quick_button(
+    db: &Database,
+    button_name: &str,
+    prompt_text: &str,
+) -> Result<i64, sea_orm::DbErr> {
+    use crate::db::entity::quick_buttons as qb;
+
+    // created/updated 同步写入，避免后续按 created_at 排序时出现 NULL 导致顺序不定
+    let now = crate::models::utc_timestamp();
+    let am = qb::ActiveModel {
+        button_name: ActiveValue::Set(button_name.to_string()),
+        prompt_text: ActiveValue::Set(prompt_text.to_string()),
+        created_at: ActiveValue::Set(Some(now.clone())),
+        updated_at: ActiveValue::Set(Some(now)),
+        ..Default::default()
+    };
+
+    let result = am.insert(&db.conn).await?;
+    Ok(result.id)
+}
+
+/// 获取全部快捷按钮，按创建时间升序（先加的排前面）。
+pub async fn get_quick_buttons(
+    db: &Database,
+) -> Result<Vec<crate::db::entity::quick_buttons::Model>, sea_orm::DbErr> {
+    use crate::db::entity::quick_buttons as qb;
+
+    let buttons = qb::Entity::find()
+        .order_by_asc(qb::Column::CreatedAt)
+        .all(&db.conn)
+        .await?;
+
+    Ok(buttons)
+}
+
+/// 按名称查找按钮（handler 重名预检用）。
+pub async fn get_quick_button_by_name(
+    db: &Database,
+    button_name: &str,
+) -> Result<Option<crate::db::entity::quick_buttons::Model>, sea_orm::DbErr> {
+    use crate::db::entity::quick_buttons as qb;
+
+    let button = qb::Entity::find()
+        .filter(qb::Column::ButtonName.eq(button_name))
+        .one(&db.conn)
+        .await?;
+
+    Ok(button)
+}
+
+/// 删除快捷按钮。
+pub async fn delete_quick_button(db: &Database, id: i64) -> Result<(), sea_orm::DbErr> {
+    use crate::db::entity::quick_buttons as qb;
+
+    qb::Entity::delete_by_id(id).exec(&db.conn).await?;
+    Ok(())
+}
+
+/// 更新快捷按钮。name/prompt 为 None 表示不改该字段；记录不存在则静默返回。
+pub async fn update_quick_button(
+    db: &Database,
+    id: i64,
+    button_name: Option<&str>,
+    prompt_text: Option<&str>,
+) -> Result<(), sea_orm::DbErr> {
+    use crate::db::entity::quick_buttons as qb;
+
+    let model = qb::Entity::find_by_id(id).one(&db.conn).await?;
+    let Some(model) = model else {
+        // 记录不存在视作成功（幂等删除语义），避免 update 报错冒泡
+        return Ok(());
+    };
+
+    let mut am = model.into_active_model();
+    if let Some(name) = button_name {
+        am.button_name = ActiveValue::Set(name.to_string());
+    }
+    if let Some(prompt) = prompt_text {
+        am.prompt_text = ActiveValue::Set(prompt.to_string());
+    }
+
+    am.updated_at = ActiveValue::Set(Some(crate::models::utc_timestamp()));
+    am.update(&db.conn).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::useless_vec, clippy::redundant_pattern_matching, clippy::redundant_clone, clippy::len_zero, clippy::bool_assert_comparison, clippy::unnecessary_get_then_check, clippy::doc_lazy_continuation, clippy::clone_on_copy, clippy::print_stdout, clippy::needless_pass_by_value, clippy::sliced_string_as_bytes, clippy::manual_map, clippy::collapsible_match, clippy::question_mark)]
+mod quick_button_tests {
+    use super::*;
+
+    async fn fresh_db() -> Database {
+        Database::new(":memory:").await.expect("memory db must open")
+    }
+
+    /// create_quick_button：插入后返回正数 id，且能被列出。
+    #[tokio::test]
+    async fn test_create_quick_button_inserts_record() {
+        let db = fresh_db().await;
+        let id = create_quick_button(&db, "提取skill", "话术").await.unwrap();
+        assert!(id > 0, "应返回正数 id");
+        let list = get_quick_buttons(&db).await.unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].button_name, "提取skill");
+    }
+
+    /// get_quick_buttons：按 created_at 升序，先创建的排前面。
+    #[tokio::test]
+    async fn test_get_quick_buttons_returns_ascending_by_created() {
+        let db = fresh_db().await;
+        create_quick_button(&db, "第一个", "a").await.unwrap();
+        create_quick_button(&db, "第二个", "b").await.unwrap();
+        let list = get_quick_buttons(&db).await.unwrap();
+        assert_eq!(list[0].button_name, "第一个");
+        assert_eq!(list[1].button_name, "第二个");
+    }
+
+    /// get_quick_button_by_name：已存在返回 Some，不存在返回 None。
+    #[tokio::test]
+    async fn test_get_quick_button_by_name_finds_existing() {
+        let db = fresh_db().await;
+        create_quick_button(&db, "提取skill", "话术").await.unwrap();
+        assert!(get_quick_button_by_name(&db, "提取skill").await.unwrap().is_some());
+        assert!(get_quick_button_by_name(&db, "不存在").await.unwrap().is_none());
+    }
+
+    /// create_quick_button：同名重复插入触发 UNIQUE(button_name) 约束报错（DB 兜底）。
+    #[tokio::test]
+    async fn test_create_quick_button_duplicate_name_errors() {
+        let db = fresh_db().await;
+        create_quick_button(&db, "提取skill", "话术").await.unwrap();
+        // 第二次同名 insert 应被唯一约束拒绝
+        let err = create_quick_button(&db, "提取skill", "话术2").await;
+        assert!(err.is_err(), "重名 insert 应返回 DbErr");
+    }
+
+    /// update_quick_button：同时改名改话术，新值生效、id 不变。
+    #[tokio::test]
+    async fn test_update_quick_button_changes_fields() {
+        let db = fresh_db().await;
+        let id = create_quick_button(&db, "提取skill", "旧话术").await.unwrap();
+        update_quick_button(&db, id, Some("提取SKILL"), Some("新话术"))
+            .await
+            .unwrap();
+        let updated = get_quick_button_by_name(&db, "提取SKILL")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.prompt_text, "新话术", "话术应已更新");
+        assert_eq!(updated.id, id, "id 不变");
+    }
+
+    /// update_quick_button：只传 name（prompt 为 None）时话术保持不变（局部更新）。
+    #[tokio::test]
+    async fn test_update_quick_button_partial_only_name() {
+        let db = fresh_db().await;
+        let id = create_quick_button(&db, "提取skill", "原话术").await.unwrap();
+        update_quick_button(&db, id, Some("改名"), None).await.unwrap();
+        let updated = get_quick_button_by_name(&db, "改名")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.prompt_text, "原话术", "未传 prompt 时话术应保持原值");
+    }
+
+    /// update_quick_button：记录不存在时静默返回 Ok（幂等语义，避免 update 报错冒泡）。
+    #[tokio::test]
+    async fn test_update_quick_button_silent_when_missing() {
+        let db = fresh_db().await;
+        let result = update_quick_button(&db, 99999, Some("x"), Some("y")).await;
+        assert!(result.is_ok(), "更新不存在的记录应静默 Ok");
+        assert!(get_quick_buttons(&db).await.unwrap().is_empty(), "不应产生新记录");
+    }
+
+    /// delete_quick_button：删除后列表为空。
+    #[tokio::test]
+    async fn test_delete_quick_button_removes_record() {
+        let db = fresh_db().await;
+        let id = create_quick_button(&db, "提取skill", "话术").await.unwrap();
+        delete_quick_button(&db, id).await.unwrap();
+        assert!(get_quick_buttons(&db).await.unwrap().is_empty(), "删除后应无记录");
+    }
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -156,6 +156,7 @@ pub mod action;
 pub mod blackboard;
 pub mod experts;
 pub mod bundled;
+pub mod quick_button;
 
 // WebSocket handler
 pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
@@ -282,6 +283,7 @@ fn mount_domain_routes() -> Router<AppState> {
         .merge(config_routes())
         .merge(skills_routes())
         .merge(agent_bot_routes())
+        .merge(quick_button_routes())
         .merge(feishu_routes())
         .merge(webhook_routes())
         .merge(session_routes())
@@ -681,6 +683,13 @@ fn agent_bot_routes() -> Router<AppState> {
         .route("/api/workspace/{workspace_id}/slash-commands/{cmd_id}", put(agent_bot::update_workspace_slash_command).delete(agent_bot::delete_workspace_slash_command))
         // Workspace 设置管理
         .route("/api/workspace/{workspace_id}/settings", get(agent_bot::get_workspace_settings).put(agent_bot::update_workspace_settings))
+}
+
+/// 快捷话术按钮管理（全局，无 workspace 维度）。
+fn quick_button_routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/quick-buttons", get(quick_button::list_quick_buttons).post(quick_button::create_quick_button))
+        .route("/api/quick-buttons/{id}", put(quick_button::update_quick_button).delete(quick_button::delete_quick_button))
 }
 
 /// 飞书相关路由：历史消息查询 + 绑定管理。
@@ -1279,9 +1288,10 @@ mod create_app_refactor_tests {
             cloud_routes(),
             events_routes(),
             blackboard::blackboard_routes(),
+            quick_button_routes(),
         ];
-        // 20 个领域子路由函数（blackboard_routes 为黑板功能新增）
-        assert_eq!(routers.len(), 20, "领域子路由函数数量应与拆分清单一致");
+        // 21 个领域子路由函数（quick_button_routes 为快捷话术按钮新增）
+        assert_eq!(routers.len(), 21, "领域子路由函数数量应与拆分清单一致");
         // `Router` 在 axum 0.8 中没有公开的 route_count，这里只能断言"全部成功构造"
     }
 

--- a/backend/src/handlers/quick_button.rs
+++ b/backend/src/handlers/quick_button.rs
@@ -1,0 +1,175 @@
+//! 快捷话术按钮的 HTTP handler（全局 CRUD，无 workspace 维度）。
+//!
+//! 对应路由 `/api/quick-buttons`。点按钮只在前端填入回复输入框，
+//! 真正发送走原有 resume 链路，本模块不涉及执行逻辑。
+
+use axum::{
+    extract::{Path, State},
+    response::IntoResponse,
+    Json,
+};
+use serde::Deserialize;
+
+use crate::handlers::{AppError, AppState};
+use crate::models::ApiResponse;
+
+/// 列出全部快捷按钮（按创建时间升序，先加的排前面）。
+pub async fn list_quick_buttons(
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, AppError> {
+    let buttons = crate::db::quick_button::get_quick_buttons(&state.db)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok(ApiResponse::ok(buttons))
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateQuickButtonRequest {
+    pub button_name: String,
+    pub prompt_text: String,
+}
+
+/// 创建快捷按钮：校验非空 + 重名预检（给前端友好 400，而非靠 DB 约束冒泡成 500）。
+pub async fn create_quick_button(
+    State(state): State<AppState>,
+    Json(req): Json<CreateQuickButtonRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let name = req.button_name.trim();
+    let prompt = req.prompt_text.trim();
+    if name.is_empty() || prompt.is_empty() {
+        return Err(AppError::BadRequest("按钮名称和话术不能为空".to_string()));
+    }
+    // 重名预检：DB 虽有 UNIQUE 兜底，但提前拦截能返回 400 而非 500
+    if crate::db::quick_button::get_quick_button_by_name(&state.db, name)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .is_some()
+    {
+        return Err(AppError::BadRequest("按钮名称已存在".to_string()));
+    }
+
+    let id = crate::db::quick_button::create_quick_button(&state.db, name, prompt)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok(ApiResponse::ok(serde_json::json!({ "id": id })))
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UpdateQuickButtonRequest {
+    pub button_name: Option<String>,
+    pub prompt_text: Option<String>,
+}
+
+/// 更新快捷按钮：非空校验 + 改名时排除自身的重名检查，再落库。
+pub async fn update_quick_button(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+    Json(req): Json<UpdateQuickButtonRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    validate_quick_button_update(&state.db, id, &req).await?;
+    crate::db::quick_button::update_quick_button(
+        &state.db,
+        id,
+        req.button_name.as_deref().map(str::trim),
+        req.prompt_text.as_deref().map(str::trim),
+    )
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok(ApiResponse::ok(serde_json::json!({"success": true})))
+}
+
+/// 校验更新请求：提供字段需非空；改名时检查是否与其他按钮重名（排除自身 id）。
+async fn validate_quick_button_update(
+    db: &crate::db::Database,
+    id: i64,
+    req: &UpdateQuickButtonRequest,
+) -> Result<(), AppError> {
+    if let Some(ref name) = req.button_name {
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(AppError::BadRequest("按钮名称不能为空".to_string()));
+        }
+        // 改名冲突判定：同名记录存在且不是自己，才报错
+        if let Some(existing) = crate::db::quick_button::get_quick_button_by_name(db, name)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?
+        {
+            if existing.id != id {
+                return Err(AppError::BadRequest("按钮名称已存在".to_string()));
+            }
+        }
+    }
+    if let Some(ref prompt) = req.prompt_text {
+        if prompt.trim().is_empty() {
+            return Err(AppError::BadRequest("话术不能为空".to_string()));
+        }
+    }
+    Ok(())
+}
+
+/// 删除快捷按钮。
+pub async fn delete_quick_button(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Result<impl IntoResponse, AppError> {
+    crate::db::quick_button::delete_quick_button(&state.db, id)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok(ApiResponse::ok(serde_json::json!({"success": true})))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::useless_vec, clippy::redundant_pattern_matching, clippy::redundant_clone, clippy::len_zero, clippy::bool_assert_comparison, clippy::unnecessary_get_then_check, clippy::doc_lazy_continuation, clippy::clone_on_copy, clippy::print_stdout, clippy::needless_pass_by_value, clippy::sliced_string_as_bytes, clippy::manual_map, clippy::collapsible_match, clippy::question_mark)]
+mod quick_button_handler_tests {
+    use super::*;
+    use crate::db::Database;
+
+    async fn fresh_db() -> Database {
+        Database::new(":memory:").await.expect("memory db must open")
+    }
+
+    /// 构造更新请求的辅助：None 表示不改该字段。
+    fn update_req(name: Option<&str>, prompt: Option<&str>) -> UpdateQuickButtonRequest {
+        UpdateQuickButtonRequest {
+            button_name: name.map(str::to_string),
+            prompt_text: prompt.map(str::to_string),
+        }
+    }
+
+    /// validate：改成他人已占用的名称应 BadRequest（重名预检的核心）。
+    #[tokio::test]
+    async fn test_validate_quick_button_update_rejects_duplicate_name() {
+        let db = fresh_db().await;
+        let a = crate::db::quick_button::create_quick_button(&db, "A", "a").await.unwrap();
+        let _b = crate::db::quick_button::create_quick_button(&db, "B", "b").await.unwrap();
+        // 把 A 改名为已被 B 占用的 "B" → 应报错
+        let err = validate_quick_button_update(&db, a, &update_req(Some("B"), None)).await;
+        assert!(err.is_err(), "改成他人已用名应 BadRequest");
+    }
+
+    /// validate：改成自己的原名不算冲突（排除自身的判定）。
+    #[tokio::test]
+    async fn test_validate_quick_button_update_allows_own_name() {
+        let db = fresh_db().await;
+        let a = crate::db::quick_button::create_quick_button(&db, "A", "a").await.unwrap();
+        let res = validate_quick_button_update(&db, a, &update_req(Some("A"), None)).await;
+        assert!(res.is_ok(), "改成自己的原名不应报错");
+    }
+
+    /// validate：空白名称应 BadRequest。
+    #[tokio::test]
+    async fn test_validate_quick_button_update_rejects_empty_name() {
+        let db = fresh_db().await;
+        let res = validate_quick_button_update(&db, 1, &update_req(Some("   "), None)).await;
+        assert!(res.is_err(), "空白名称应 BadRequest");
+    }
+
+    /// validate：空白话术应 BadRequest。
+    #[tokio::test]
+    async fn test_validate_quick_button_update_rejects_empty_prompt() {
+        let db = fresh_db().await;
+        let res = validate_quick_button_update(&db, 1, &update_req(None, Some("  "))).await;
+        assert!(res.is_err(), "空白话术应 BadRequest");
+    }
+}

--- a/frontend/src/components/todo-detail/QuickButtonBar.tsx
+++ b/frontend/src/components/todo-detail/QuickButtonBar.tsx
@@ -1,0 +1,41 @@
+import { Button } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
+import type { QuickButton } from '@/utils/database';
+
+/**
+ * 回复输入框上方的快捷按钮条：渲染用户自定义按钮 + 末尾「+」管理入口。
+ * 点按钮 → onInsert(话术) 由外层填入输入框；点「+」→ onManage 打开管理弹窗。
+ * 空列表时仍保留「+」，保证随时能新增第一个按钮。
+ */
+export function QuickButtonBar({
+  buttons,
+  onInsert,
+  onManage,
+}: {
+  buttons: QuickButton[];
+  onInsert: (text: string) => void;
+  onManage: () => void;
+}) {
+  return (
+    // overflowX auto：按钮多了横向滚动而非撑爆布局；flexShrink 0 防按钮被压缩
+    <div style={{ display: 'flex', gap: 4, overflowX: 'auto', marginBottom: 4 }}>
+      {buttons.map((b) => (
+        <Button
+          key={b.id}
+          size="small"
+          onClick={() => onInsert(b.prompt_text)}
+          style={{ borderRadius: 12, fontSize: 12, flexShrink: 0, whiteSpace: 'nowrap' }}
+        >
+          {b.button_name}
+        </Button>
+      ))}
+      <Button
+        size="small"
+        type="dashed"
+        icon={<PlusOutlined />}
+        onClick={onManage}
+        style={{ borderRadius: 12, fontSize: 12, flexShrink: 0 }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/todo-detail/QuickButtonManageModal.tsx
+++ b/frontend/src/components/todo-detail/QuickButtonManageModal.tsx
@@ -1,0 +1,178 @@
+import { useState, useEffect } from 'react';
+import { Modal, Form, Input, Button, List, Popconfirm, Space, message } from 'antd';
+import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import * as db from '@/utils/database';
+import type { QuickButton } from '@/utils/database';
+
+/** 示例话术占位符：引导用户加「提取 skill」这类按钮（只是提示，不内置数据） */
+const PROMPT_PLACEHOLDER =
+  '如：请把刚才这次执行的过程和结论提炼成一个可复用的 skill，写入对应 SKILL.md';
+
+type FormValues = { button_name: string; prompt_text: string };
+
+/** 提交前规整表单值：trim 防止全空格混过前端 required 校验 */
+function normalizeFormValues(values: FormValues): FormValues {
+  return { button_name: values.button_name.trim(), prompt_text: values.prompt_text.trim() };
+}
+
+/**
+ * 封装快捷按钮的列表加载 + 增删改 + 编辑态。把数据逻辑从渲染层剥离，
+ * 主组件只管布局。弹窗每次打开重拉最新列表，CRUD 后本地刷新并通知外层同步按钮条。
+ */
+function useQuickButtonCrud(open: boolean, onChanged: () => void) {
+  const [buttons, setButtons] = useState<QuickButton[]>([]);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [form] = Form.useForm<FormValues>();
+
+  const refresh = () =>
+    db
+      .getQuickButtons()
+      .then(setButtons)
+      .catch((e: unknown) => message.error('加载快捷按钮失败: ' + String(e)));
+
+  // 弹窗打开时重拉列表 + 回到「新建」态，避免上次编辑残留串到下次
+  useEffect(() => {
+    if (!open) return;
+    refresh();
+    setEditingId(null);
+    form.resetFields();
+    // open 是唯一触发源；form 引用稳定故不列入依赖
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // 进入编辑：回填表单，主组件据此切换按钮文案与高亮
+  const beginEdit = (b: QuickButton) => {
+    setEditingId(b.id);
+    form.setFieldsValue({ button_name: b.button_name, prompt_text: b.prompt_text });
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    form.resetFields();
+  };
+
+  // 新建或更新二合一：editingId 决定走哪条分支
+  const submit = async () => {
+    try {
+      const values = normalizeFormValues(await form.validateFields());
+      if (editingId) {
+        await db.updateQuickButton(editingId, values);
+        message.success('更新成功');
+      } else {
+        await db.createQuickButton(values);
+        message.success('创建成功');
+      }
+      cancelEdit();
+      refresh();
+      onChanged();
+    } catch (err: unknown) {
+      // errorFields 来自表单校验失败（antd 已在字段下提示），这里不重复弹错
+      if (!(err as { errorFields?: unknown })?.errorFields) {
+        message.error('操作失败: ' + String(err));
+      }
+    }
+  };
+
+  const remove = async (id: number) => {
+    try {
+      await db.deleteQuickButton(id);
+      message.success('删除成功');
+      refresh();
+      onChanged();
+    } catch (err: unknown) {
+      message.error('删除失败: ' + String(err));
+    }
+  };
+
+  return { buttons, editingId, form, submit, remove, beginEdit, cancelEdit };
+}
+
+/** 已有按钮列表：每条展示名称 + 话术，提供编辑（回填表单）与删除 */
+function ExistingButtonList({
+  buttons,
+  editingId,
+  onEdit,
+  onDelete,
+}: {
+  buttons: QuickButton[];
+  editingId: number | null;
+  onEdit: (b: QuickButton) => void;
+  onDelete: (id: number) => void;
+}) {
+  return (
+    <List
+      size="small"
+      dataSource={buttons}
+      locale={{ emptyText: '暂无快捷按钮，在上方添加第一个' }}
+      renderItem={(b) => (
+        <List.Item
+          // 编辑中的行高亮，提示用户当前正在改哪条
+          style={b.id === editingId ? { background: '#e6f4ff' } : undefined}
+          actions={[
+            <Button key="edit" type="text" size="small" icon={<EditOutlined />} onClick={() => onEdit(b)} />,
+            <Popconfirm
+              key="del"
+              title="确定删除此按钮？"
+              onConfirm={() => onDelete(b.id)}
+              okText="删除"
+              cancelText="取消"
+            >
+              <Button type="text" size="small" icon={<DeleteOutlined />} />
+            </Popconfirm>,
+          ]}
+        >
+          <List.Item.Meta title={b.button_name} description={b.prompt_text} />
+        </List.Item>
+      )}
+    />
+  );
+}
+
+/**
+ * 快捷按钮管理弹窗：上半新建/编辑表单，下半已有按钮列表。
+ * 编辑态时表单回填、高亮当前行；保存或取消后回到新建态。
+ */
+export function QuickButtonManageModal({
+  open,
+  onClose,
+  onChanged,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onChanged: () => void;
+}) {
+  const { buttons, editingId, form, submit, remove, beginEdit, cancelEdit } = useQuickButtonCrud(
+    open,
+    onChanged,
+  );
+  // 移动端窄屏：Modal 走接近全宽，避免固定 520 溢出视口
+  const isMobile = useIsMobile();
+
+  return (
+    <Modal
+      title={editingId ? '编辑快捷按钮' : '管理快捷按钮'}
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      width={isMobile ? '92%' : 520}
+      destroyOnClose
+    >
+      <Form form={form} layout="vertical" style={{ marginTop: 12 }}>
+        <Form.Item name="button_name" label="按钮名称" rules={[{ required: true, whitespace: true, message: '请输入按钮名称' }]}>
+          <Input placeholder="如：提取skill" maxLength={30} />
+        </Form.Item>
+        <Form.Item name="prompt_text" label="话术" rules={[{ required: true, whitespace: true, message: '请输入话术' }]}>
+          <Input.TextArea rows={3} placeholder={PROMPT_PLACEHOLDER} />
+        </Form.Item>
+        <Space style={{ marginBottom: 16 }}>
+          <Button type="primary" onClick={submit}>
+            {editingId ? '保存' : '添加'}
+          </Button>
+          {editingId && <Button onClick={cancelEdit}>取消编辑</Button>}
+        </Space>
+      </Form>
+      <ExistingButtonList buttons={buttons} editingId={editingId} onEdit={beginEdit} onDelete={remove} />
+    </Modal>
+  );
+}

--- a/frontend/src/components/todo-detail/ReplyInput.tsx
+++ b/frontend/src/components/todo-detail/ReplyInput.tsx
@@ -1,11 +1,16 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Input, Button } from 'antd';
+import type { InputRef } from 'antd';
 import { SendOutlined } from '@ant-design/icons';
 import type { ExecutionRecord } from '@/types';
+import { getQuickButtons } from '@/utils/database';
+import type { QuickButton } from '@/utils/database';
+import { QuickButtonBar } from './QuickButtonBar';
+import { QuickButtonManageModal } from './QuickButtonManageModal';
 
 /**
- * 论坛式内联回复框 —— 替代原来的 Modal "继续对话"。
- * 输入框 + 回复按钮，紧凑布局。
+ * 论坛式内联回复框 —— 输入框 + 回复按钮 + 上方一排用户自定义快捷按钮。
+ * 点快捷按钮把预设话术填入输入框（覆盖），用户可再编辑后点「回复」继续会话。
  */
 export function ReplyInput({
   record,
@@ -17,6 +22,27 @@ export function ReplyInput({
   loading?: boolean;
 }) {
   const [message, setMessage] = useState('');
+  const [buttons, setButtons] = useState<QuickButton[]>([]);
+  const [manageOpen, setManageOpen] = useState(false);
+  // 填入话术后自动聚焦输入框，方便用户立刻接着编辑
+  const inputRef = useRef<InputRef>(null);
+
+  // 每个会话线程各有一个 ReplyInput，各自拉一次全局按钮列表；
+  // 列表只读且数据量小，不做跨组件缓存（YAGNI）。
+  useEffect(() => {
+    getQuickButtons().then(setButtons).catch(() => {});
+  }, []);
+
+  // 弹窗内增删改后重拉，保持按钮条与全局数据同步
+  const reloadButtons = () => {
+    getQuickButtons().then(setButtons).catch(() => {});
+  };
+
+  // 点快捷按钮：覆盖填入话术（Q10 决策）+ 聚焦输入框
+  const handleInsert = (text: string) => {
+    setMessage(text);
+    inputRef.current?.focus();
+  };
 
   const handleReply = async () => {
     const trimmed = message.trim();
@@ -33,38 +59,33 @@ export function ReplyInput({
   };
 
   return (
-    <div style={{
-      marginLeft: 24,
-      marginTop: 4,
-      marginBottom: 8,
-      display: 'flex',
-      gap: 8,
-      alignItems: 'center',
-    }}>
-      <Input
-        size="small"
-        value={message}
-        onChange={(e) => setMessage(e.target.value)}
-        onKeyDown={handleKeyDown}
-        placeholder="输入回复内容..."
-        disabled={loading}
-        style={{
-          flex: 1,
-          borderRadius: 16,
-          fontSize: 12,
-        }}
-      />
-      <Button
-        type="primary"
-        size="small"
-        icon={<SendOutlined />}
-        onClick={handleReply}
-        loading={loading}
-        disabled={!message.trim()}
-        style={{ borderRadius: 16 }}
-      >
-        回复
-      </Button>
+    // 外层 block 容器：上方按钮条 + 下方输入行（输入行沿用原有 flex 横向布局）
+    <div style={{ marginLeft: 24, marginTop: 4, marginBottom: 8 }}>
+      <QuickButtonBar buttons={buttons} onInsert={handleInsert} onManage={() => setManageOpen(true)} />
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <Input
+          ref={inputRef}
+          size="small"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="输入回复内容..."
+          disabled={loading}
+          style={{ flex: 1, borderRadius: 16, fontSize: 12 }}
+        />
+        <Button
+          type="primary"
+          size="small"
+          icon={<SendOutlined />}
+          onClick={handleReply}
+          loading={loading}
+          disabled={!message.trim()}
+          style={{ borderRadius: 16 }}
+        >
+          回复
+        </Button>
+      </div>
+      <QuickButtonManageModal open={manageOpen} onClose={() => setManageOpen(false)} onChanged={reloadButtons} />
     </div>
   );
 }

--- a/frontend/src/utils/database/index.ts
+++ b/frontend/src/utils/database/index.ts
@@ -8,3 +8,4 @@ export * from './sessions';
 export * from './usage_stats';
 export * from './loops';
 export * from './experts';
+export * from './quickButtons';

--- a/frontend/src/utils/database/quickButtons.ts
+++ b/frontend/src/utils/database/quickButtons.ts
@@ -1,0 +1,52 @@
+import { api, unwrap } from './client';
+
+/**
+ * 快捷话术按钮：用户在回复框上方自定义的快捷按钮。
+ * 全局共享（无 workspace 维度），点击把 prompt_text 填入回复输入框。
+ */
+export interface QuickButton {
+  id: number;
+  button_name: string;
+  prompt_text: string;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface CreateQuickButtonParams {
+  /** 按钮显示名称（全局唯一，重名后端返回 400） */
+  button_name: string;
+  /** 点击后填入回复输入框的话术 */
+  prompt_text: string;
+}
+
+export interface UpdateQuickButtonParams {
+  /** 新名称，省略表示不改；提供时不能与他人重名 */
+  button_name?: string;
+  /** 新话术，省略表示不改 */
+  prompt_text?: string;
+}
+
+/** 列出全部快捷按钮（后端按创建时间升序返回） */
+export async function getQuickButtons(): Promise<QuickButton[]> {
+  return unwrap(await api.get('/api/quick-buttons'));
+}
+
+/** 创建快捷按钮。重名由后端返回 400，调用方 catch 后提示即可 */
+export async function createQuickButton(
+  params: CreateQuickButtonParams,
+): Promise<{ id: number }> {
+  return unwrap(await api.post('/api/quick-buttons', params));
+}
+
+/** 更新快捷按钮（只传需要改的字段） */
+export async function updateQuickButton(
+  id: number,
+  params: UpdateQuickButtonParams,
+): Promise<void> {
+  await api.put(`/api/quick-buttons/${id}`, params);
+}
+
+/** 删除快捷按钮 */
+export async function deleteQuickButton(id: number): Promise<void> {
+  await api.delete(`/api/quick-buttons/${id}`);
+}

--- a/frontend/tests/check_quick_buttons.spec.ts
+++ b/frontend/tests/check_quick_buttons.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+// 直连 embedded dev 服务（前后端同源），不走 vite 5173
+const BASE = 'http://localhost:18088';
+const NAME = 'PW测试按钮';
+const NAME_RENAMED = 'PW测试按钮改名';
+
+interface QuickButton {
+  id: number;
+  button_name: string;
+  prompt_text: string;
+}
+
+// 后端响应是 ApiResponse 包裹的 { code, data, message }；这里只取 data
+async function listButtons(request: APIRequestContext): Promise<QuickButton[]> {
+  const res = await request.get(`${BASE}/api/quick-buttons`);
+  expect(res.ok()).toBeTruthy();
+  return (await res.json()).data as QuickButton[];
+}
+
+// 按名清理，保证用例间独立、不污染全局数据
+async function deleteByName(request: APIRequestContext, name: string) {
+  for (const b of await listButtons(request)) {
+    if (b.button_name === name) {
+      await request.delete(`${BASE}/api/quick-buttons/${b.id}`);
+    }
+  }
+}
+
+// 验证 quick_buttons 全链路：DB 迁移建表 → 路由 → handler CRUD → 校验。
+// 用 APIRequestContext 直接打 HTTP，不依赖页面渲染（ReplyInput 需 resume record）。
+test.describe('快捷话术按钮 API 全链路', () => {
+  test.beforeEach(async ({ request }) => {
+    await deleteByName(request, NAME);
+    await deleteByName(request, NAME_RENAMED);
+  });
+
+  // afterEach 兜底：用例中途失败（如断言前抛错）时也清理共享数据，避免污染全局 quick_buttons 表
+  test.afterEach(async ({ request }) => {
+    await deleteByName(request, NAME);
+    await deleteByName(request, NAME_RENAMED);
+  });
+
+  test('创建 → 列出 → 改名改话术 → 删除', async ({ request }) => {
+    const createRes = await request.post(`${BASE}/api/quick-buttons`, {
+      data: { button_name: NAME, prompt_text: '原始话术' },
+    });
+    expect(createRes.status()).toBe(200);
+    const id = (await createRes.json()).data.id;
+    expect(typeof id).toBe('number');
+
+    expect((await listButtons(request)).find((b) => b.id === id)?.button_name).toBe(NAME);
+
+    const updRes = await request.put(`${BASE}/api/quick-buttons/${id}`, {
+      data: { button_name: NAME_RENAMED, prompt_text: '新话术' },
+    });
+    expect(updRes.ok()).toBeTruthy();
+
+    const updated = (await listButtons(request)).find((b) => b.id === id);
+    expect(updated?.button_name).toBe(NAME_RENAMED);
+    expect(updated?.prompt_text).toBe('新话术');
+
+    expect((await request.delete(`${BASE}/api/quick-buttons/${id}`)).ok()).toBeTruthy();
+    expect((await listButtons(request)).find((b) => b.id === id)).toBeUndefined();
+  });
+
+  test('重名创建被拒（400）', async ({ request }) => {
+    expect(
+      (
+        await request.post(`${BASE}/api/quick-buttons`, {
+          data: { button_name: NAME, prompt_text: 'x' },
+        })
+      ).status(),
+    ).toBe(200);
+    const dup = await request.post(`${BASE}/api/quick-buttons`, {
+      data: { button_name: NAME, prompt_text: 'y' },
+    });
+    expect(dup.status()).toBe(400);
+  });
+
+  test('空名称被拒（400）', async ({ request }) => {
+    const res = await request.post(`${BASE}/api/quick-buttons`, {
+      data: { button_name: '   ', prompt_text: 'x' },
+    });
+    expect(res.status()).toBe(400);
+  });
+});

--- a/frontend/tests/check_quick_buttons_ui.spec.ts
+++ b/frontend/tests/check_quick_buttons_ui.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+const BASE = 'http://localhost:18088';
+const NAME = 'PW_UI测试按钮';
+
+// 可继续会话的执行器集合（与 src/utils/executors.tsx 的 RESUMABLE_EXECUTORS 保持一致）。
+// 测试里不便直接 import 那个 tsx（含 JSX/运行时代码），故在此维护一份只读副本。
+const RESUMABLE_EXECUTORS = new Set([
+  'claudecode', 'opencode', 'mobilecoder', 'hermes', 'kimi',
+  'codewhale', 'pi', 'mimo', 'zhanlu', 'kilo',
+]);
+
+interface QB {
+  id: number;
+  button_name: string;
+  prompt_text: string;
+}
+
+// 仅取判断可恢复所需字段，避免拉入完整 ExecutionRecord 的几十个字段
+interface ResumeRecord {
+  id: number;
+  todo_id: number;
+  status: string;
+  session_id?: string | null;
+  executor?: string | null;
+}
+
+async function listButtons(request: APIRequestContext): Promise<QB[]> {
+  return ((await (await request.get(`${BASE}/api/quick-buttons`)).json()).data) as QB[];
+}
+
+async function deleteByName(request: APIRequestContext, name: string) {
+  for (const b of await listButtons(request)) {
+    if (b.button_name === name) await request.delete(`${BASE}/api/quick-buttons/${b.id}`);
+  }
+}
+
+// 动态找一个可 resume 的执行记录，拼出帖子页 URL；找不到返回 null（调用方 test.skip）。
+// 不写死 todo/record ID——干净库或数据变动时优雅跳过，而非在 goto 处硬失败。
+async function findResumablePostUrl(request: APIRequestContext): Promise<string | null> {
+  const res = await request.get(`${BASE}/api/execution-records`, {
+    params: { status: 'success', limit: 50 },
+  });
+  if (!res.ok()) return null;
+  const records = ((await res.json()).data?.records ?? []) as ResumeRecord[];
+  for (const r of records) {
+    if (r.session_id && r.executor && RESUMABLE_EXECUTORS.has(r.executor.toLowerCase())) {
+      return `${BASE}/#/items?panel=post&id=${r.todo_id}&record=${r.id}`;
+    }
+  }
+  return null;
+}
+
+// 驱动真实浏览器走完核心 UI 交互：加号 → 新建 → 点按钮把话术填入回复输入框。
+test.describe('快捷话术按钮 UI', () => {
+  test.beforeEach(async ({ request }) => {
+    await deleteByName(request, NAME);
+  });
+
+  // afterEach 兜底：用例中途失败（断言前抛错）也清理，避免污染全局 quick_buttons 表
+  test.afterEach(async ({ request }) => {
+    await deleteByName(request, NAME);
+  });
+
+  test('加号 → 新建 → 点按钮填入回复输入框', async ({ page, request }) => {
+    const url = await findResumablePostUrl(request);
+    test.skip(!url, '无可 resume 的执行记录，跳过（需 dev 库有 success + resumable executor 的会话）');
+    await page.goto(url!);
+
+    // 先确认 ReplyInput 渲染：回复输入框可见 = 帖子页加载完成且该会话可 resume
+    const replyInput = page.getByPlaceholder('输入回复内容...');
+    await replyInput.waitFor({ state: 'visible', timeout: 20000 });
+
+    // 快捷按钮条的「+」：dashed 且含 plus 图标，避免误选页面其他 dashed 按钮
+    const plus = page.locator('button.ant-btn-dashed:has(.anticon-plus)');
+    await plus.waitFor({ state: 'visible', timeout: 10000 });
+    await page.screenshot({ path: 'tests/__screenshots__/qb_post.png' });
+
+    // 打开管理弹窗
+    await plus.click();
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible({ timeout: 10000 });
+    await page.getByPlaceholder('如：提取skill').fill(NAME);
+    await page.getByPlaceholder(/请把刚才这次执行/).fill('UI填入测试话术');
+    // 提交按钮是 Modal 内唯一 primary 按钮；antd6 文本被 span 包裹，按 role name 取不稳定
+    await modal.locator('button.ant-btn-primary').click();
+    await expect(modal.getByText(NAME)).toBeVisible();
+    await page.screenshot({ path: 'tests/__screenshots__/qb_modal.png' });
+
+    // 关闭弹窗，按钮条出现新建的按钮
+    await page.locator('.ant-modal-close').last().click();
+    await expect(modal).toHaveCount(0);
+
+    // 点按钮条新按钮 → 回复输入框被填入话术（覆盖语义）
+    await page.getByRole('button', { name: NAME }).click();
+    await expect(replyInput).toHaveValue('UI填入测试话术');
+    await page.screenshot({ path: 'tests/__screenshots__/qb_filled.png' });
+  });
+});
+
+// 移动端：验证快捷按钮渲染 + 管理 Modal 在窄屏不溢出视口
+test('移动端窄屏渲染 + Modal 不溢出', async ({ page, request }) => {
+  const url = await findResumablePostUrl(request);
+  test.skip(!url, '无可 resume 的执行记录，跳过移动端 UI 测试');
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.goto(url!);
+  // 回复输入框可见 = ReplyInput（含快捷按钮条）已渲染
+  await page.getByPlaceholder('输入回复内容...').waitFor({ state: 'visible', timeout: 20000 });
+  await page.locator('button.ant-btn-dashed:has(.anticon-plus)').click();
+  const modal = page.getByRole('dialog');
+  await modal.waitFor({ state: 'visible', timeout: 10000 });
+  const box = await modal.boundingBox();
+  expect(box, 'Modal boundingBox 应存在').toBeTruthy();
+  // 横向不溢出 375 宽视口（留 1px 容差）
+  expect(box!.x, 'Modal 左侧不超出视口').toBeGreaterThanOrEqual(-1);
+  expect(box!.x + box!.width, 'Modal 右侧不超出视口').toBeLessThanOrEqual(376);
+  await page.screenshot({ path: 'tests/__screenshots__/qb_mobile.png', fullPage: true });
+});


### PR DESCRIPTION
## 功能

帖子流回复框上方增加**用户自定义快捷话术按钮** + 「+」管理入口：

- 点按钮把预设话术**填入回复输入框**（可再编辑后点回复继续会话）
- 「+」弹窗内新建 / 编辑 / 删除，落库 `quick_buttons` 表，全局共享（无 workspace 维度）
- 典型场景：自建「提取 skill」按钮，话术「请把执行过程提炼成 skill」，点一下灌进输入框

## 改动

**后端**（照抄 `workspace_slash_commands` 模板，去掉 workspace 维度）：
- 迁移 `v66` 建表 + entity + db 层（CRUD + 4 单测）+ handler（重名预检）+ 路由 + 路由测试断言 20→21

**前端**：
- API 层 + `QuickButtonBar` + `QuickButtonManageModal`（数据逻辑抽 `useQuickButtonCrud` hook）+ 改 `ReplyInput`
- Modal 移动端宽度适配（`isMobile ? '92%' : 520`）

## 验证

| 项 | 结果 |
|---|---|
| `cargo clippy --all-targets -D warnings` | ✅ 零告警 |
| `cargo test` | ✅ 1213 passed（含 4 新单测 + 路由断言 21）|
| Playwright API e2e | ✅ 3 passed（CRUD / 重名 / 空值）|
| `tsc --noEmit` + `npm run build` | ✅ 零错误 |
| Playwright UI e2e | ✅ 桌面 + 移动端 2 passed |

> 截图证据（帖子页 / 管理弹窗 / 话术填入 / 移动端 Modal）已单独发送。
