### PR TITLE
feat(ui): 技能/专家提升为常驻配置区，「设置」改名「更多设置」

### DIFF
--- a/frontend/src/components/shell/LeftRail.tsx
+++ b/frontend/src/components/shell/LeftRail.tsx
@@ -88,16 +88,26 @@ export function LeftRail({
         { key: 'memorial', label: '看板', icon: <ReadOutlined />, ariaLabel: '看板' },
       ] satisfies LeftRailItem[],
     },
+    // 「配置」区放在主「工作区」下方：
+    // 技能/专家原本藏在底部弹出菜单里，层级过深，提升为常驻入口更易触达。
+    // key 复用 settings_skills / settings_experts，路由与 active 高亮无需额外改动。
+    {
+      title: '配置',
+      items: [
+        { key: 'settings_skills', label: '技能', icon: <ThunderboltOutlined />, ariaLabel: '技能' },
+        { key: 'settings_experts', label: '专家', icon: <TeamOutlined />, ariaLabel: '专家' },
+      ] satisfies LeftRailItem[],
+    },
   ]), []);
 
-  // 配置项菜单 — 从侧边栏主体收拢到底部弹出菜单，减少主导航的视觉噪音
+  // 配置项菜单 — 从侧边栏主体收拢到底部弹出菜单，减少主导航的视觉噪音。
+  // 技能/专家已提升为工作空间下方的常驻「配置」区，这里只保留次要配置入口；
+  // 「设置」改名「更多设置」，强调它是技能/专家之外的其余配置入口。
   const configItems = useMemo(() => ([
     { key: 'settings_bots', label: '智能助手', icon: <RobotOutlined />, ariaLabel: '智能助手' },
     { key: 'settings_executors', label: '执行器', icon: <CodeOutlined />, ariaLabel: '执行器' },
-    { key: 'settings_skills', label: 'Skills', icon: <ThunderboltOutlined />, ariaLabel: 'Skills' },
-    { key: 'settings_experts', label: '专家', icon: <TeamOutlined />, ariaLabel: '专家' },
     { key: 'settings_projectDirectories', label: '工作空间', icon: <FolderOutlined />, ariaLabel: '工作空间' },
-    { key: 'settings', label: '设置', icon: <SettingOutlined />, ariaLabel: '设置' },
+    { key: 'settings', label: '更多设置', icon: <SettingOutlined />, ariaLabel: '更多设置' },
   ] satisfies LeftRailItem[]), []);
 
   const [openConfigPopover, setOpenConfigPopover] = useState(false);


### PR DESCRIPTION
## 背景

页面 `http://localhost:18088/#/skills` 标注反馈（3 条）：

1. 底部配置弹出菜单里某项文案改为「更多设置」。
2. 「专家」按钮：从弹出菜单拿出来，提升为常驻导航。
3. 「Skills」按钮：同上。

用户原话：「这个菜单拿到外面，放到工作空间下发，增加一个配置区域，放两个菜单一个技能一个专家。」并在复核中明确：**「配置」区放在主「工作区」下方**。

## 改动（单文件：`frontend/src/components/shell/LeftRail.tsx`）

- 左侧导航新增「配置」section（**技能** + **专家**），放在主「工作区」section **下方**；原藏在底部弹出菜单里的入口提升为常驻，层级更浅。
- 底部配置弹出菜单移除 skills/experts，仅保留：智能助手 / 执行器 / 工作空间 / **更多设置**。
- 弹出菜单原「设置」改名「**更多设置**」，强调它是技能/专家之外的次要配置入口。
- 「Skills」label 同步改为中文「技能」（与「专家」一致）。
- key 复用 `settings_skills` / `settings_experts`，**路由（`App.tsx`）与 active 高亮（`useViewState.ts`）无需改动**；CSS、WorkspaceSwitcher 均未改动。

折叠态：配置区两按钮仅图标 + Tooltip；展开态/drawer：图标 + 文字 + 「配置」section 标题。

## 验证

- `cd frontend && npx tsc --noEmit` —— 零错误（`npm run build` 通过）。
- `make dev` 启动后用 playwright-cli（会话隔离）验证：
  - 左侧导航顺序：工作空间切换器 → 工作区（事项/环路/消息/黑板/仪表盘/看板）→ 配置（技能/专家）→ 底部（配置弹出按钮/主题/折叠）。✅
  - 在 `/#/skills`：常驻「技能」按钮 active；点击「专家」→ 跳转 `/#/experts` 且「专家」active。✅
  - 底部配置弹出菜单仅 4 项：智能助手 / 执行器 / 工作空间 / 更多设置（无 Skills/专家）。✅
  - 展开态出现「配置」「工作区」两个 section 标题。✅

## 不受影响

- `tests/left-rail-shell.spec.ts`、`tests/check_mobile_skills.spec.ts`、`tests/check_mobile_expert_and_template.spec.ts`：均直接用 URL 访问页面本身，不依赖菜单项。