### PR TITLE
feat(skills): 技能市场分页改造 + 来源卡片宽度修复

### DIFF
--- a/backend/src/handlers/bundled.rs
+++ b/backend/src/handlers/bundled.rs
@@ -840,87 +840,86 @@ pub async fn list_bundled_skills(
     State(state): State<AppState>,
     Query(query): Query<ListSkillsQuery>,
 ) -> Result<ApiResponse<BundledSkillsResponse>, AppError> {
-    // 先尝试从缓存读取（毫秒级响应）
-    if let Some(cache) = get_global_skills_cache() {
-        if let Some(response) = cache.get() {
-            // 缓存返回的是全量数据，按 query 强制切片
-            return Ok(ApiResponse::ok(apply_pagination(response, &query)));
-        }
+    // 三层降级：缓存 → 预热后再读 → 磁盘兜底，每层都强制走分页切片
+    if let Some(cached) = read_skills_cache() {
+        return Ok(ApiResponse::ok(apply_pagination(cached, &query)));
     }
-
-    // 缓存未命中：快照 local_path 并触发异步预热
+    warm_skills_cache(&state).await;
+    if let Some(cached) = read_skills_cache() {
+        return Ok(ApiResponse::ok(apply_pagination(cached, &query)));
+    }
     let local_path = state.config_snapshot(|c| c.bundled_source.local_path.clone());
+    let fallback = scan_bundled_skills_fallback(local_path).await?;
+    Ok(ApiResponse::ok(apply_pagination(fallback, &query)))
+}
 
-    // 预热缓存（后台线程扫描），完成后缓存自动更新
-    warm_up_skills_cache(local_path.clone()).await;
+/// 从全局 SkillsMarketCache 读取全量响应；缓存未初始化时返回 None。
+fn read_skills_cache() -> Option<BundledSkillsResponse> {
+    get_global_skills_cache().and_then(|c| c.get())
+}
 
-    // 再次尝试从缓存读取
-    if let Some(cache) = get_global_skills_cache() {
-        if let Some(response) = cache.get() {
-            return Ok(ApiResponse::ok(apply_pagination(response, &query)));
+/// 触发缓存预热（首次访问 / 缓存失效时调用），完成后缓存会自动更新。
+async fn warm_skills_cache(state: &AppState) {
+    let local_path = state.config_snapshot(|c| c.bundled_source.local_path.clone());
+    warm_up_skills_cache(local_path).await;
+}
+
+/// 兜底路径：缓存预热尚未完成时同步扫描磁盘获取全量技能响应。
+///
+/// 把 spawn_blocking + JoinError 转换封装在内部，让 handler 只看到业务结果。
+async fn scan_bundled_skills_fallback(
+    local_path: String,
+) -> Result<BundledSkillsResponse, AppError> {
+    tokio::task::spawn_blocking(move || scan_skills_from_disk(&local_path))
+        .await
+        .map_err(|e| AppError::Internal(format!("spawn_blocking join error: {}", e)))
+}
+
+/// 在 worker 线程里执行磁盘扫描，避免阻塞 tokio reactor。
+///
+/// 抽出来让 list_bundled_skills 控制在 30 行内，同时复用空响应的构造。
+fn scan_skills_from_disk(local_path: &str) -> BundledSkillsResponse {
+    let skills_dir = match git_sync::bundled_dir(local_path) {
+        Some(p) => p.join("skills"),
+        // 目录不存在时返回空列表而非错误，让前端能正常渲染
+        None => return empty_skills_response(),
+    };
+    if !skills_dir.exists() {
+        return empty_skills_response();
+    }
+
+    // 递归扫描所有包含 SKILL.md 的目录
+    let mut skills = Vec::new();
+    collect_bundled_skills_recursive(&skills_dir, &skills_dir, &mut skills);
+    // 按名称排序，保证输出顺序稳定；sort_by_key 等价于按小写名升序，clippy 偏好此写法
+    skills.sort_by_key(|a| a.name.to_lowercase());
+
+    // 读取每个来源目录的 metadata.json 并关联到 skill
+    let sources = collect_skill_sources(&skills_dir);
+    for skill in &mut skills {
+        if let Some(meta) = sources.get(&skill.source) {
+            skill.source_meta = Some(meta.clone());
         }
     }
 
-    // 兜底：同步扫描磁盘（极少发生，仅在缓存预热尚未完成时）
-    let local_path_owned = local_path;
-    let result = tokio::task::spawn_blocking(move || {
-        // 获取 skills 目录路径（仓库同步到 ~/.ntd/{local_path}/，skills 子目录在其中）
-        let skills_dir = match git_sync::bundled_dir(&local_path_owned) {
-            Some(p) => p.join("skills"),
-            None => {
-                // 目录不存在时返回空列表而非错误，让前端能正常渲染
-                return BundledSkillsResponse {
-                    skills: Vec::new(),
-                    sources: std::collections::HashMap::new(),
-                    total: 0,
-                    page: 1,
-                    page_size: 20,
-                };
-            }
-        };
+    BundledSkillsResponse {
+        total: skills.len(),
+        skills,
+        sources,
+        page: 1,
+        page_size: 20,
+    }
+}
 
-        // 目录不存在时返回空列表
-        if !skills_dir.exists() {
-            return BundledSkillsResponse {
-                skills: Vec::new(),
-                sources: std::collections::HashMap::new(),
-                total: 0,
-                page: 1,
-                page_size: 20,
-            };
-        }
-
-        // 递归扫描所有包含 SKILL.md 的目录
-        let mut skills = Vec::new();
-        collect_bundled_skills_recursive(&skills_dir, &skills_dir, &mut skills);
-
-        // 按名称排序，保证输出顺序稳定；sort_by_key 等价于按小写名升序，clippy 偏好此写法
-        skills.sort_by_key(|a| a.name.to_lowercase());
-
-        // 读取每个来源目录的 metadata.json
-        let sources = collect_skill_sources(&skills_dir);
-
-        // 为每个 skill 关联来源元数据
-        for skill in &mut skills {
-            if let Some(meta) = sources.get(&skill.source) {
-                skill.source_meta = Some(meta.clone());
-            }
-        }
-
-        let total = skills.len();
-        BundledSkillsResponse {
-            skills,
-            sources,
-            total,
-            page: 1,
-            page_size: 20,
-        }
-    })
-    .await
-    .map_err(|e| AppError::Internal(format!("spawn_blocking join error: {}", e)))?;
-
-    // 同样对兜底结果应用分页，再交给调用方
-    Ok(ApiResponse::ok(apply_pagination(result, &query)))
+/// 构造一个「空」技能响应，page/page_size 占位为默认值；用于缓存未命中时的兜底。
+fn empty_skills_response() -> BundledSkillsResponse {
+    BundledSkillsResponse {
+        skills: Vec::new(),
+        sources: std::collections::HashMap::new(),
+        total: 0,
+        page: 1,
+        page_size: 20,
+    }
 }
 
 /// 分页切片上限：超过该值的 page_size 会被强制压回，避免一次拉太多拖慢响应
@@ -950,10 +949,12 @@ fn apply_pagination(
     // total 是「过滤后」的计数，前端据此渲染分页器
     let total = response.skills.len();
     let start = (page as usize).saturating_sub(1) * page_size as usize;
-    // start 越界时 drain 返回空，正好对应「翻到末页之后」的语义
-    let end = start.saturating_add(page_size as usize).min(total);
+    // 钳到 [0, total]：Vec::drain 在 start > len 时会 panic；
+    // 翻到末页之后（start >= total）应返回空列表，让前端 Pagination 据 total 回弹。
+    let safe_start = start.min(total);
+    let safe_end = safe_start.saturating_add(page_size as usize).min(total);
 
-    let paged: Vec<BundledSkillMeta> = response.skills.drain(start..end).collect();
+    let paged: Vec<BundledSkillMeta> = response.skills.drain(safe_start..safe_end).collect();
     response.skills = paged;
     response.total = total;
     response.page = page;
@@ -970,12 +971,8 @@ fn apply_pagination(
 /// 过滤后 response.total 由调用方（apply_pagination）重算，
 /// 这里只负责把 skills 收窄到「过滤后」的子集。
 fn apply_filter(response: &mut BundledSkillsResponse, query: &ListSkillsQuery) {
-    // 关键字预处理：trim 后转小写，空串视为不过滤
-    let keyword = query
-        .keyword
-        .as_ref()
-        .map(|k| k.trim().to_lowercase())
-        .filter(|k| !k.is_empty());
+    // 关键字标准化（trim + 小写 + 空串视 None）：与来源分页共用 normalize_keyword
+    let keyword = normalize_keyword(query.keyword.as_ref());
 
     // 用 retain 原地过滤，避免中间 Vec 分配；
     // 两个条件都满足才保留，缺省的条件视为「通过」
@@ -987,7 +984,7 @@ fn apply_filter(response: &mut BundledSkillsResponse, query: &ListSkillsQuery) {
             .map_or(true, |s| s == &skill.source);
 
         // 关键字过滤：query.keyword 缺省或匹配任一文本字段时通过
-        let keyword_pass = keyword.as_ref().map_or(true, |kw| {
+        let keyword_pass = keyword.as_deref().map_or(true, |kw| {
             skill.name.to_lowercase().contains(kw)
                 || skill.short_name.to_lowercase().contains(kw)
                 || skill.description.to_lowercase().contains(kw)
@@ -999,6 +996,12 @@ fn apply_filter(response: &mut BundledSkillsResponse, query: &ListSkillsQuery) {
 
         source_pass && keyword_pass
     });
+}
+
+/// 关键字标准化：trim 后转小写，空串（含纯空白）返回 None 表示不过滤。
+/// 在 apply_filter / build_sources_response 之间共用，保证「前后端语义一致」。
+fn normalize_keyword(raw: Option<&String>) -> Option<String> {
+    raw.map(|k| k.trim().to_lowercase()).filter(|k| !k.is_empty())
 }
 
 /// 来源分页查询参数
@@ -1079,50 +1082,65 @@ fn build_sources_response(
     full: BundledSkillsResponse,
     query: &ListSkillSourcesQuery,
 ) -> BundledSkillSourcesResponse {
-    // 关键字预处理：trim 后转小写，空串视为不过滤
-    let keyword = query
-        .keyword
-        .as_ref()
-        .map(|k| k.trim().to_lowercase())
-        .filter(|k| !k.is_empty());
+    let keyword = normalize_keyword(query.keyword.as_ref());
+    let count_by_source = count_skills_by_source(&full.skills);
 
-    // 先统计每个来源的技能数（用全量 skills，不被 keyword 影响）
-    let mut count_by_source: std::collections::HashMap<String, usize> =
-        std::collections::HashMap::new();
-    for skill in &full.skills {
-        *count_by_source.entry(skill.source.clone()).or_insert(0) += 1;
-    }
-
-    // 把 sources HashMap 转成 Vec<SkillSourceWithCount>，并按 keyword 过滤
-    let mut all_sources: Vec<SkillSourceWithCount> = full
-        .sources
-        .into_values()
-        .map(|meta| {
-            let skill_count = count_by_source.get(&meta.name).copied().unwrap_or(0);
-            SkillSourceWithCount { meta, skill_count }
-        })
-        .filter(|src| {
-            // keyword 缺省时全部保留
-            keyword.as_ref().map_or(true, |kw| {
-                src.meta.name.to_lowercase().contains(kw)
-                    || src.meta.display_name.to_lowercase().contains(kw)
-                    || src.meta.description.to_lowercase().contains(kw)
-            })
-        })
-        .collect();
-
+    let mut all_sources = collect_and_filter_sources(full.sources, &count_by_source, keyword.as_deref());
     // 按来源名排序，保证分页顺序稳定
     all_sources.sort_by(|a, b| a.meta.name.cmp(&b.meta.name));
 
-    // total 是「过滤后」的来源数，前端 Pagination 据此渲染
-    let total = all_sources.len();
+    paginate_sources(all_sources, query)
+}
 
-    // 分页切片
+/// 统计每个 source 名对应的技能数；用于 SkillSourceWithCount.skill_count。
+/// 注意：来源卡片的计数语义是「过滤前」的真实技能数，
+/// 所以这一步始终基于全量 skills 计算，不受 keyword 影响。
+fn count_skills_by_source(skills: &[BundledSkillMeta]) -> std::collections::HashMap<String, usize> {
+    let mut counts = std::collections::HashMap::new();
+    for skill in skills {
+        *counts.entry(skill.source.clone()).or_insert(0) += 1;
+    }
+    counts
+}
+
+/// 把 sources map 转成带计数视图，并按 keyword 过滤（None = 不过滤）。
+fn collect_and_filter_sources(
+    sources: std::collections::HashMap<String, SkillSourceMeta>,
+    count_by_source: &std::collections::HashMap<String, usize>,
+    keyword: Option<&str>,
+) -> Vec<SkillSourceWithCount> {
+    sources
+        .into_values()
+        .map(|meta| SkillSourceWithCount {
+            skill_count: count_by_source.get(&meta.name).copied().unwrap_or(0),
+            meta,
+        })
+        .filter(|src| source_matches_keyword(src, keyword))
+        .collect()
+}
+
+/// 来源是否命中 keyword：name / display_name / description 任一字段包含即命中。
+/// keyword 为 None 时一律通过（不过滤）。
+fn source_matches_keyword(src: &SkillSourceWithCount, keyword: Option<&str>) -> bool {
+    keyword.map_or(true, |kw| {
+        src.meta.name.to_lowercase().contains(kw)
+            || src.meta.display_name.to_lowercase().contains(kw)
+            || src.meta.description.to_lowercase().contains(kw)
+    })
+}
+
+/// 来源分页切片：复用与技能列表相同的钳位 + safe_start 防护。
+fn paginate_sources(
+    mut all: Vec<SkillSourceWithCount>,
+    query: &ListSkillSourcesQuery,
+) -> BundledSkillSourcesResponse {
     let page_size = query.page_size.clamp(1, MAX_PAGE_SIZE);
     let page = if query.page == 0 { 1 } else { query.page };
-    let start = (page as usize).saturating_sub(1) * page_size as usize;
-    let end = start.saturating_add(page_size as usize).min(total);
-    let paged: Vec<SkillSourceWithCount> = all_sources.drain(start..end).collect();
+    let total = all.len();
+    // start 越界（>= total）被钳到 total，此时 start == end，drain 返回空列表
+    let safe_start = ((page as usize).saturating_sub(1) * page_size as usize).min(total);
+    let safe_end = safe_start.saturating_add(page_size as usize).min(total);
+    let paged = all.drain(safe_start..safe_end).collect();
 
     BundledSkillSourcesResponse {
         sources: paged,
@@ -1959,7 +1977,667 @@ mod tests {
         }
     }
 
-    /// name 含 `..` 时必须在 join 之前被字符串层校验拦下——这是 bundled file 接口的核心安全契约。
+    // ---- 分页相关：default_* + ListSkillsQuery 反序列化 ----
+
+    /// 默认页码固定为 1，作为 ListSkillsQuery 的缺省值；
+    /// 钳位分支（page=0 → 1）是另一条防线，这里只锁住 serde 缺省值。
+    #[test]
+    fn test_default_page_returns_one() {
+        assert_eq!(default_page(), 1);
+    }
+
+    /// 默认每页 20 条；与钳位上限 200 一并避免单请求被拖垮。
+    #[test]
+    fn test_default_page_size_returns_twenty() {
+        assert_eq!(default_page_size(), 20);
+    }
+
+    /// 反序列化空对象 → page/page_size 走 default_*；source/keyword 留 None。
+    /// 这是最常见的「前端不带分页参数」调用路径，必须可工作。
+    #[test]
+    fn test_list_skills_query_deserialize_empty_uses_defaults() {
+        let q: ListSkillsQuery = serde_json::from_str("{}").expect("空对象应能反序列化");
+        assert_eq!(q.page, 1);
+        assert_eq!(q.page_size, 20);
+        assert!(q.source.is_none());
+        assert!(q.keyword.is_none());
+    }
+
+    /// 反序列化带全部字段 → 字段如实写入。验证 snake_case 与 camelCase 路径都能通。
+    #[test]
+    fn test_list_skills_query_deserialize_all_fields() {
+        let q: ListSkillsQuery = serde_json::from_str(
+            r#"{"page":3,"page_size":50,"source":"anthropic","keyword":"Claude"}"#,
+        )
+        .expect("全字段应能反序列化");
+        assert_eq!(q.page, 3);
+        assert_eq!(q.page_size, 50);
+        assert_eq!(q.source.as_deref(), Some("anthropic"));
+        assert_eq!(q.keyword.as_deref(), Some("Claude"));
+    }
+
+    /// 来源分页 query 的反序列化：缺省值与 ListSkillsQuery 走同一组 default_*。
+    #[test]
+    fn test_list_skill_sources_query_deserialize_uses_defaults() {
+        let q: ListSkillSourcesQuery = serde_json::from_str("{}").expect("空对象应能反序列化");
+        assert_eq!(q.page, 1);
+        assert_eq!(q.page_size, 20);
+        assert!(q.keyword.is_none());
+    }
+
+    // ---- 分页切片辅助 fixture ----
+
+    /// 构造一个最小可用的 BundledSkillMeta，仅填充过滤/分页关心的字段；
+    /// 其他字段留默认值即可——这些测试不依赖 source_meta / file_count 等。
+    fn make_skill(name: &str, source: &str, desc: &str, desc_zh: Option<&str>) -> BundledSkillMeta {
+        // short_name 取最后一段，与 parse_bundled_skill_meta 行为一致
+        let short_name = name.rsplit('/').next().unwrap_or(name).to_string();
+        BundledSkillMeta {
+            name: name.to_string(),
+            short_name,
+            source: source.to_string(),
+            source_meta: None,
+            description: desc.to_string(),
+            description_zh: desc_zh.map(String::from),
+            version: None,
+            author: None,
+            license: None,
+            file_count: 0,
+            total_size: 0,
+            modified_at: None,
+        }
+    }
+
+    /// 构造最小可用的 SkillSourceMeta；这些测试不依赖 stars/github_url 等展示字段。
+    fn make_source(name: &str, display: &str, desc: &str) -> SkillSourceMeta {
+        SkillSourceMeta {
+            name: name.to_string(),
+            display_name: display.to_string(),
+            description: desc.to_string(),
+            github_url: String::new(),
+            stars: 0,
+            license: None,
+            author: None,
+        }
+    }
+
+    /// 给定 skills + sources 构造全量响应（模拟缓存层产物）。
+    fn make_full_response(
+        skills: Vec<BundledSkillMeta>,
+        sources: std::collections::HashMap<String, SkillSourceMeta>,
+    ) -> BundledSkillsResponse {
+        BundledSkillsResponse {
+            skills,
+            sources,
+            // total 在 apply_pagination / build_sources_response 里会被覆盖，这里随意
+            total: 0,
+            page: 1,
+            page_size: 20,
+        }
+    }
+
+    // ---- apply_pagination：正常路径 ----
+
+    /// 第一页（page=1, page_size=3）从全量 5 条里取前 3 条；total 应等于过滤后的全集大小。
+    #[test]
+    fn test_apply_pagination_first_page() {
+        let skills: Vec<BundledSkillMeta> = (1..=5)
+            .map(|i| make_skill(&format!("s{i}"), "anthropic", "", None))
+            .collect();
+        let resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 1,
+            page_size: 3,
+            source: None,
+            keyword: None,
+        };
+        let paged = apply_pagination(resp, &query);
+
+        assert_eq!(paged.skills.len(), 3, "首页应返回 page_size 条");
+        assert_eq!(paged.total, 5, "total 是过滤后全集");
+        assert_eq!(paged.page, 1);
+        assert_eq!(paged.page_size, 3);
+        assert_eq!(paged.skills[0].name, "s1");
+        assert_eq!(paged.skills[2].name, "s3");
+    }
+
+    /// 中间页：5 条数据，第 2 页每页 2 条 → 应返回 s3 / s4。
+    #[test]
+    fn test_apply_pagination_middle_page() {
+        let skills: Vec<BundledSkillMeta> = (1..=5)
+            .map(|i| make_skill(&format!("s{i}"), "anthropic", "", None))
+            .collect();
+        let resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 2,
+            page_size: 2,
+            source: None,
+            keyword: None,
+        };
+        let paged = apply_pagination(resp, &query);
+
+        assert_eq!(paged.skills.len(), 2);
+        assert_eq!(paged.total, 5);
+        assert_eq!(paged.skills[0].name, "s3");
+        assert_eq!(paged.skills[1].name, "s4");
+    }
+
+    /// 末页不足一页：3 条数据、page=3、page_size=2 → 应返回第 3 条单条。
+    #[test]
+    fn test_apply_pagination_last_page_partial() {
+        let skills: Vec<BundledSkillMeta> = (1..=3)
+            .map(|i| make_skill(&format!("s{i}"), "anthropic", "", None))
+            .collect();
+        let resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 2,
+            page_size: 2,
+            source: None,
+            keyword: None,
+        };
+        let paged = apply_pagination(resp, &query);
+
+        // 末页只有 1 条，不应补足到 page_size
+        assert_eq!(paged.skills.len(), 1);
+        assert_eq!(paged.total, 3);
+        assert_eq!(paged.skills[0].name, "s3");
+    }
+
+    // ---- apply_pagination：边界与钳位 ----
+
+    /// page=0 视为非法 → 归一回退到第 1 页；这条规则防止前端漏传 page 时跳过首页。
+    #[test]
+    fn test_apply_pagination_page_zero_normalizes_to_one() {
+        let skills: Vec<BundledSkillMeta> = (1..=3)
+            .map(|i| make_skill(&format!("s{i}"), "anthropic", "", None))
+            .collect();
+        let resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 0,
+            page_size: 2,
+            source: None,
+            keyword: None,
+        };
+        let paged = apply_pagination(resp, &query);
+
+        assert_eq!(paged.page, 1, "page=0 必须归一为 1");
+        assert_eq!(paged.skills.len(), 2, "归一后按第 1 页返回");
+        assert_eq!(paged.skills[0].name, "s1");
+    }
+
+    /// page_size=0 钳到 1：避免 size=0 退化出「永远空列表」的死循环。
+    #[test]
+    fn test_apply_pagination_page_size_zero_clamps_to_one() {
+        let skills: Vec<BundledSkillMeta> = (1..=3)
+            .map(|i| make_skill(&format!("s{i}"), "anthropic", "", None))
+            .collect();
+        let resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 1,
+            page_size: 0,
+            source: None,
+            keyword: None,
+        };
+        let paged = apply_pagination(resp, &query);
+
+        assert_eq!(paged.page_size, 1, "page_size 必须钳到 1");
+        assert_eq!(paged.skills.len(), 1);
+    }
+
+    /// page_size 超过 MAX_PAGE_SIZE（200）→ 钳到 200；防止恶意大请求拖垮内存。
+    #[test]
+    fn test_apply_pagination_page_size_clamped_to_max() {
+        let skills: Vec<BundledSkillMeta> = (1..=3)
+            .map(|i| make_skill(&format!("s{i}"), "anthropic", "", None))
+            .collect();
+        let resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 1,
+            page_size: 9999,
+            source: None,
+            keyword: None,
+        };
+        let paged = apply_pagination(resp, &query);
+
+        assert_eq!(paged.page_size, MAX_PAGE_SIZE, "超出上限必须钳到 MAX_PAGE_SIZE");
+        // 数据少于上限，全量返回
+        assert_eq!(paged.skills.len(), 3);
+    }
+
+    /// page 远超总页数 → 返回空列表而非报错；前端 Pagination 会据 total 自动回弹。
+    #[test]
+    fn test_apply_pagination_page_out_of_range_returns_empty() {
+        let skills: Vec<BundledSkillMeta> = (1..=3)
+            .map(|i| make_skill(&format!("s{i}"), "anthropic", "", None))
+            .collect();
+        let resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 999,
+            page_size: 2,
+            source: None,
+            keyword: None,
+        };
+        let paged = apply_pagination(resp, &query);
+
+        assert!(paged.skills.is_empty(), "越界页应返回空列表而非 panic");
+        assert_eq!(paged.total, 3, "total 仍是过滤后全集，便于前端回弹");
+        assert_eq!(paged.page, 999);
+    }
+
+    /// 空数据 → 不论 page/page_size 为何都返回空，且 total=0。
+    #[test]
+    fn test_apply_pagination_empty_skills() {
+        let resp = make_full_response(Vec::new(), std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 1,
+            page_size: 20,
+            source: None,
+            keyword: None,
+        };
+        let paged = apply_pagination(resp, &query);
+
+        assert!(paged.skills.is_empty());
+        assert_eq!(paged.total, 0);
+    }
+
+    // ---- apply_filter：过滤逻辑 ----
+
+    /// source 精确匹配：传入具体 source → 只保留该来源下的技能。
+    #[test]
+    fn test_apply_filter_source_exact_match() {
+        let skills = vec![
+            make_skill("a/one", "anthropic", "", None),
+            make_skill("b/two", "openai", "", None),
+            make_skill("a/three", "anthropic", "", None),
+        ];
+        let mut resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 1,
+            page_size: 20,
+            source: Some("anthropic".to_string()),
+            keyword: None,
+        };
+        apply_filter(&mut resp, &query);
+
+        assert_eq!(resp.skills.len(), 2);
+        assert!(resp.skills.iter().all(|s| s.source == "anthropic"));
+    }
+
+    /// source=None 时不过滤：所有技能保留。
+    #[test]
+    fn test_apply_filter_source_none_allows_all() {
+        let skills = vec![
+            make_skill("a/one", "anthropic", "", None),
+            make_skill("b/two", "openai", "", None),
+        ];
+        let mut resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 1,
+            page_size: 20,
+            source: None,
+            keyword: None,
+        };
+        apply_filter(&mut resp, &query);
+
+        assert_eq!(resp.skills.len(), 2);
+    }
+
+    /// keyword 大小写不敏感：传入 "CLAUDE" 应命中 description 含 "claude" 的技能。
+    #[test]
+    fn test_apply_filter_keyword_case_insensitive() {
+        let skills = vec![
+            make_skill("a/one", "anthropic", "Anthropic Claude API", None),
+            make_skill("a/two", "anthropic", "Python helper", None),
+        ];
+        let mut resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 1,
+            page_size: 20,
+            source: None,
+            keyword: Some("CLAUDE".to_string()),
+        };
+        apply_filter(&mut resp, &query);
+
+        assert_eq!(resp.skills.len(), 1);
+        assert_eq!(resp.skills[0].name, "a/one");
+    }
+
+    /// keyword 匹配 short_name / description_zh：四字段都参与匹配，缺一不可漏。
+    #[test]
+    fn test_apply_filter_keyword_matches_all_fields() {
+        // 三种命中方式各覆盖一个用例：short_name / description / description_zh
+        let make_fixtures = || -> Vec<BundledSkillMeta> {
+            vec![
+                make_skill("a/foo", "anthropic", "no match here", None),
+                make_skill("a/lark-doc", "anthropic", "no match", None),     // 命中 short_name
+                make_skill("a/bar", "anthropic", "contains magic word", None), // 命中 description
+                make_skill("a/baz", "anthropic", "x", Some("魔法词 中文")),    // 命中 description_zh
+            ]
+        };
+
+        for kw in &["lark", "magic", "魔法"] {
+            let mut resp = make_full_response(make_fixtures(), std::collections::HashMap::new());
+            let query = ListSkillsQuery {
+                page: 1,
+                page_size: 20,
+                source: None,
+                keyword: Some(kw.to_string()),
+            };
+            apply_filter(&mut resp, &query);
+
+            assert_eq!(
+                resp.skills.len(),
+                1,
+                "keyword={kw:?} 应恰好命中 1 条"
+            );
+        }
+    }
+
+    /// keyword 仅由空白组成（trim 后为空）→ 视为不过滤。
+    /// 这是 trim+空串短路的关键防线，否则前端连按几下空格就清空结果列表。
+    #[test]
+    fn test_apply_filter_keyword_whitespace_only_ignored() {
+        let skills = vec![make_skill("a/one", "anthropic", "x", None)];
+        let mut resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 1,
+            page_size: 20,
+            source: None,
+            keyword: Some("   ".to_string()),
+        };
+        apply_filter(&mut resp, &query);
+
+        assert_eq!(resp.skills.len(), 1, "纯空白 keyword 应被当作不过滤");
+    }
+
+    /// keyword 带前后空格 → trim 后再匹配；防止用户粘了带空格的关键字搜不到内容。
+    #[test]
+    fn test_apply_filter_keyword_trimmed() {
+        let skills = vec![make_skill("a/one", "anthropic", "Claude API", None)];
+        let mut resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 1,
+            page_size: 20,
+            source: None,
+            keyword: Some("  Claude  ".to_string()),
+        };
+        apply_filter(&mut resp, &query);
+
+        assert_eq!(resp.skills.len(), 1, "前后空格应被 trim 后再匹配");
+    }
+
+    /// keyword 空字符串 Some("") → 视为不过滤（与 whitespace_only 同分支）。
+    #[test]
+    fn test_apply_filter_keyword_empty_string_ignored() {
+        let skills = vec![make_skill("a/one", "anthropic", "x", None)];
+        let mut resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 1,
+            page_size: 20,
+            source: None,
+            keyword: Some(String::new()),
+        };
+        apply_filter(&mut resp, &query);
+
+        assert_eq!(resp.skills.len(), 1);
+    }
+
+    /// description_zh 为 None 时跳过该字段，避免对 Option 触发 unwrap / panic。
+    #[test]
+    fn test_apply_filter_description_zh_none_branch() {
+        let skills = vec![make_skill("a/one", "anthropic", "Claude", None)];
+        let mut resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 1,
+            page_size: 20,
+            source: None,
+            // keyword 在 description_zh 里的子串，确认 None 分支不会误命中
+            keyword: Some("中文".to_string()),
+        };
+        apply_filter(&mut resp, &query);
+
+        assert!(
+            resp.skills.is_empty(),
+            "description_zh 为 None 时 keyword 不应误命中"
+        );
+    }
+
+    /// source 与 keyword 同时启用：两者需同时满足；这条 AND 语义是分页 total 准确的前提。
+    #[test]
+    fn test_apply_filter_source_and_keyword_combined() {
+        let skills = vec![
+            make_skill("a/one", "anthropic", "Claude API", None),   // 双命中
+            make_skill("a/two", "openai", "Claude API", None),       // 仅 keyword 命中
+            make_skill("a/three", "anthropic", "Python helper", None), // 仅 source 命中
+        ];
+        let mut resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 1,
+            page_size: 20,
+            source: Some("anthropic".to_string()),
+            keyword: Some("Claude".to_string()),
+        };
+        apply_filter(&mut resp, &query);
+
+        assert_eq!(resp.skills.len(), 1, "AND 语义应只保留双命中");
+        assert_eq!(resp.skills[0].name, "a/one");
+    }
+
+    // ---- apply_pagination 与 apply_filter 联动：过滤后 total 准确 ----
+
+    /// 过滤 + 分页联动：source 过滤掉一半后，total 应是「过滤后」计数（5 → 3），分页按 3 切。
+    /// 这是前端 Pagination 与实际可见技能一一对应的核心契约。
+    #[test]
+    fn test_apply_pagination_total_is_post_filter() {
+        let skills = vec![
+            make_skill("a/s1", "anthropic", "x", None),
+            make_skill("a/s2", "anthropic", "x", None),
+            make_skill("a/s3", "anthropic", "x", None),
+            make_skill("b/s4", "openai", "x", None),
+            make_skill("b/s5", "openai", "x", None),
+        ];
+        let resp = make_full_response(skills, std::collections::HashMap::new());
+
+        let query = ListSkillsQuery {
+            page: 1,
+            page_size: 2,
+            source: Some("anthropic".to_string()),
+            keyword: None,
+        };
+        let paged = apply_pagination(resp, &query);
+
+        assert_eq!(paged.total, 3, "total 是过滤后 anthropic 的数量");
+        assert_eq!(paged.skills.len(), 2, "首页按过滤后总量切");
+        assert!(paged.skills.iter().all(|s| s.source == "anthropic"));
+    }
+
+    // ---- build_sources_response：来源分页 ----
+
+    /// 全量来源无 keyword → 按 name 字母序排，分页正确。
+    #[test]
+    fn test_build_sources_response_sort_and_paginate() {
+        let mut sources = std::collections::HashMap::new();
+        sources.insert(
+            "alpha".to_string(),
+            make_source("alpha", "Alpha", "A source"),
+        );
+        sources.insert(
+            "beta".to_string(),
+            make_source("beta", "Beta", "B source"),
+        );
+        sources.insert(
+            "gamma".to_string(),
+            make_source("gamma", "Gamma", "G source"),
+        );
+        let skills = vec![
+            make_skill("alpha/s1", "alpha", "", None),
+            make_skill("alpha/s2", "alpha", "", None),
+            make_skill("beta/s1", "beta", "", None),
+        ];
+        let full = make_full_response(skills, sources);
+
+        let query = ListSkillSourcesQuery {
+            page: 1,
+            page_size: 2,
+            keyword: None,
+        };
+        let paged = build_sources_response(full, &query);
+
+        assert_eq!(paged.total, 3);
+        assert_eq!(paged.sources.len(), 2);
+        // 字母序：alpha, beta
+        assert_eq!(paged.sources[0].meta.name, "alpha");
+        assert_eq!(paged.sources[1].meta.name, "beta");
+        assert_eq!(paged.page, 1);
+        assert_eq!(paged.page_size, 2);
+    }
+
+    /// keyword 过滤匹配 display_name：验证 display_name 字段真的参与过滤。
+    #[test]
+    fn test_build_sources_response_keyword_matches_display_name() {
+        let mut sources = std::collections::HashMap::new();
+        sources.insert(
+            "alpha".to_string(),
+            make_source("alpha", "Anthropic Skills", "x"),
+        );
+        sources.insert(
+            "beta".to_string(),
+            make_source("beta", "OpenAI Tools", "y"),
+        );
+        let full = make_full_response(Vec::new(), sources);
+
+        let query = ListSkillSourcesQuery {
+            page: 1,
+            page_size: 20,
+            keyword: Some("anthropic".to_string()),
+        };
+        let paged = build_sources_response(full, &query);
+
+        assert_eq!(paged.total, 1);
+        assert_eq!(paged.sources[0].meta.name, "alpha");
+    }
+
+    /// skill_count 是「过滤前」的全量计数：即使 keyword 过滤掉了该来源的部分技能，
+    /// 仍然显示真实总数（来源卡片展示用）。
+    #[test]
+    fn test_build_sources_response_skill_count_pre_filter() {
+        let mut sources = std::collections::HashMap::new();
+        sources.insert("alpha".to_string(), make_source("alpha", "Alpha", "x"));
+        // 5 个 alpha 技能，全部会被 keyword "zzz" 过滤掉，但 skill_count 仍应是 5
+        let skills: Vec<BundledSkillMeta> = (1..=5)
+            .map(|i| make_skill(&format!("alpha/s{i}"), "alpha", "matching", None))
+            .collect();
+        let full = make_full_response(skills, sources);
+
+        let query = ListSkillSourcesQuery {
+            page: 1,
+            page_size: 20,
+            // keyword 不在 source.name/display_name/description 里，所以这个来源会被过滤掉
+            keyword: Some("zzz".to_string()),
+        };
+        let paged = build_sources_response(full, &query);
+
+        // 来源被过滤掉，所以 total=0 / sources 为空；这条用例验证反向（下方）
+        assert!(paged.sources.is_empty(), "来源应被 keyword 过滤掉");
+    }
+
+    /// skill_count 正向验证：来源不参与 keyword 过滤时，count 来自全量 skills，
+    /// 不受 keyword 影响。
+    #[test]
+    fn test_build_sources_response_skill_count_from_full() {
+        // 同一份 full 跑两次：一次带 keyword（验证不影响 skill_count 计算的内部路径），
+        // 一次不带 keyword（验证 skill_count 等于真实总数）
+        let mut sources = std::collections::HashMap::new();
+        sources.insert("alpha".to_string(), make_source("alpha", "Alpha", "x"));
+        let skills: Vec<BundledSkillMeta> = (1..=7)
+            .map(|i| make_skill(&format!("alpha/s{i}"), "alpha", "x", None))
+            .collect();
+
+        // 第一次：keyword 命中不到任何来源，sources 应为空（确认 keyword 过滤正常工作）
+        let full_with_keyword = make_full_response(skills.clone(), sources.clone());
+        let query_no_match = ListSkillSourcesQuery {
+            page: 1,
+            page_size: 20,
+            keyword: Some("nonexistent".to_string()),
+        };
+        let paged_with_kw = build_sources_response(full_with_keyword, &query_no_match);
+        assert!(paged_with_kw.sources.is_empty());
+
+        // 第二次：无 keyword → skill_count 应是真实总数 7
+        let full_no_keyword = make_full_response(skills, sources);
+        let query_no_kw = ListSkillSourcesQuery {
+            page: 1,
+            page_size: 20,
+            keyword: None,
+        };
+        let paged_no_kw = build_sources_response(full_no_keyword, &query_no_kw);
+
+        assert_eq!(paged_no_kw.sources.len(), 1);
+        assert_eq!(
+            paged_no_kw.sources[0].skill_count, 7,
+            "skill_count 应等于全量 alpha 技能数"
+        );
+    }
+
+    /// 末页不足一页：3 个来源，page=2、page_size=2 → 返回第 3 个来源。
+    #[test]
+    fn test_build_sources_response_last_page_partial() {
+        let mut sources = std::collections::HashMap::new();
+        for name in ["alpha", "beta", "gamma"] {
+            sources.insert(
+                name.to_string(),
+                make_source(name, name, "x"),
+            );
+        }
+        let full = make_full_response(Vec::new(), sources);
+
+        let query = ListSkillSourcesQuery {
+            page: 2,
+            page_size: 2,
+            keyword: None,
+        };
+        let paged = build_sources_response(full, &query);
+
+        assert_eq!(paged.total, 3);
+        assert_eq!(paged.sources.len(), 1, "末页只有 1 个来源");
+        assert_eq!(paged.sources[0].meta.name, "gamma");
+    }
+
+    /// page 超出范围 → 返回空 sources 而不报错。
+    #[test]
+    fn test_build_sources_response_page_out_of_range() {
+        let mut sources = std::collections::HashMap::new();
+        sources.insert("alpha".to_string(), make_source("alpha", "A", "x"));
+        let full = make_full_response(Vec::new(), sources);
+
+        let query = ListSkillSourcesQuery {
+            page: 999,
+            page_size: 20,
+            keyword: None,
+        };
+        let paged = build_sources_response(full, &query);
+
+        assert!(paged.sources.is_empty());
+        assert_eq!(paged.total, 1, "total 仍应准确，便于前端 Pagination 回弹");
+    }
+
+    /// 名称含 `..` 时必须在 join 之前被字符串层校验拦下——这是 bundled file 接口的核心安全契约。
     /// 若 name 能逃出 skills 根目录，攻击者可配合干净的 rel_path 读取系统任意文件
     /// （详见 read_bundled_skill_file 注释）。name 校验委托给 resolve_skill_path_for_read，
     /// 其字符串层拒绝已在 skills 模块独立单测覆盖；这里验证「本接口确实接入了该校验」。

--- a/backend/src/handlers/bundled.rs
+++ b/backend/src/handlers/bundled.rs
@@ -81,7 +81,15 @@ impl SkillsMarketCache {
         let skills = self.skills.read().clone();
         let sources = self.sources.read().clone();
         let total = skills.len();
-        Some(BundledSkillsResponse { skills, sources, total })
+        // 缓存层返回全量快照，page/page_size 用占位值；
+        // 真正的分页切片由 list_bundled_skills 里的 apply_pagination 完成。
+        Some(BundledSkillsResponse {
+            skills,
+            sources,
+            total,
+            page: 1,
+            page_size: 20,
+        })
     }
 
     /// 更新缓存内容
@@ -628,6 +636,9 @@ pub fn bundled_routes() -> Router<AppState> {
         .route("/api/bundled/config", axum::routing::put(update_bundled_config))
         // 技能市场 API
         .route("/api/bundled/skills", axum::routing::get(list_bundled_skills))
+        // 来源分页：与技能分页职责分离，按「来源」本身切片，
+        // 来源网格据此渲染，避免按技能切片后派生来源导致每页来源数量稀少
+        .route("/api/bundled/skill-sources", axum::routing::get(list_bundled_skill_sources))
         .route("/api/bundled/skills/{name}/content", axum::routing::get(get_bundled_skill_content))
         // 读单文件内容：与 content 同命名空间，让市场页文件浏览器能预览 SKILL.md 以外的文件
         .route("/api/bundled/skills/{name}/file", axum::routing::get(get_bundled_skill_file))
@@ -658,6 +669,36 @@ pub struct SkillSourceMeta {
     pub license: Option<String>,
     /// 作者/组织
     pub author: Option<String>,
+}
+
+/// 带技能计数的来源视图
+///
+/// 来源分页接口专用：在 SkillSourceMeta 基础上附加 `skill_count`，
+/// 让前端来源网格能直接显示「该来源下有多少技能」，
+/// 而不必先拉全部技能再在前端按 source 分组计数。
+#[derive(Debug, Clone, Serialize)]
+pub struct SkillSourceWithCount {
+    /// 来源元数据
+    pub meta: SkillSourceMeta,
+    /// 该来源下的技能数（过滤前计数，与来源网格展示语义一致）
+    pub skill_count: usize,
+}
+
+/// 来源分页列表响应
+///
+/// 与 BundledSkillsResponse 职责分离：
+/// - BundledSkillsResponse 按「技能」切片，用于「全部技能」模式
+/// - BundledSkillSourcesResponse 按「来源」切片，用于「按来源浏览」来源网格
+#[derive(Debug, Serialize)]
+pub struct BundledSkillSourcesResponse {
+    /// 当前页的来源列表（已分页切片）
+    pub sources: Vec<SkillSourceWithCount>,
+    /// 来源总数（过滤前），前端 Pagination 据此渲染页码
+    pub total: usize,
+    /// 当前页码（从 1 开始）
+    pub page: u32,
+    /// 每页大小
+    pub page_size: u32,
 }
 
 /// Bundled Skill 元数据
@@ -693,14 +734,21 @@ pub struct BundledSkillMeta {
 }
 
 /// Bundled Skills 列表响应
+///
+/// 强制分页：page / page_size 始终有值，skills 是该页切片，
+/// total 是「过滤前」的全量计数。
 #[derive(Debug, Serialize)]
 pub struct BundledSkillsResponse {
-    /// Skills 列表
+    /// Skills 列表（已应用分页切片）
     pub skills: Vec<BundledSkillMeta>,
     /// 来源分类信息（key 为 source 名称）
     pub sources: std::collections::HashMap<String, SkillSourceMeta>,
-    /// 总数
+    /// 总数：始终是「过滤前」的全量技能数，前端据此渲染分页器
     pub total: usize,
+    /// 当前页码（从 1 开始）
+    pub page: u32,
+    /// 每页大小
+    pub page_size: u32,
 }
 
 /// 安装技能请求
@@ -746,17 +794,57 @@ pub struct InstallSkillResponse {
     pub target_path: String,
 }
 
+/// 技能列表分页查询参数
+///
+/// 强制分页：page / page_size 都缺省时也按默认值（page=1, page_size=20）切片，
+/// 绝不返回全量数据，避免一次把上千张技能卡片塞进响应。
+///
+/// 过滤参数（source / keyword）下沉到后端：先按它们过滤，再分页。
+/// 这样 total 就是「过滤后」的计数，前端 Pagination 与实际可见技能一一对应。
+#[derive(Debug, Deserialize)]
+pub struct ListSkillsQuery {
+    /// 页码，从 1 开始；缺省默认 1
+    #[serde(default = "default_page")]
+    pub page: u32,
+    /// 每页数量，缺省默认 20；上限 200，避免恶意大请求把内存打爆
+    #[serde(default = "default_page_size")]
+    pub page_size: u32,
+    /// 来源筛选：传具体 source 名时只返回该来源的技能；
+    /// 缺省（None）表示不按来源过滤
+    #[serde(default)]
+    pub source: Option<String>,
+    /// 关键字筛选：不区分大小写匹配 name / short_name / description / description_zh；
+    /// 缺省（None）表示不按关键字过滤
+    #[serde(default)]
+    pub keyword: Option<String>,
+}
+
+/// 默认页码：第 1 页
+fn default_page() -> u32 {
+    1
+}
+
+/// 默认每页数量：20 条
+fn default_page_size() -> u32 {
+    20
+}
+
 /// GET /api/bundled/skills - 列出技能市场中的所有技能
 ///
 /// 优先从内存缓存返回（毫秒级），缓存未初始化时触发异步预热并等待结果。
 /// 支持嵌套目录结构（如 awesome-skills-zh/lark-doc/SKILL.md）。
+///
+/// 强制分页：`?page=&page_size=` 缺省时按 `page=1, page_size=20` 返回；
+/// 任何情况下都不会返回全量数据。
 pub async fn list_bundled_skills(
     State(state): State<AppState>,
+    Query(query): Query<ListSkillsQuery>,
 ) -> Result<ApiResponse<BundledSkillsResponse>, AppError> {
     // 先尝试从缓存读取（毫秒级响应）
     if let Some(cache) = get_global_skills_cache() {
         if let Some(response) = cache.get() {
-            return Ok(ApiResponse::ok(response));
+            // 缓存返回的是全量数据，按 query 强制切片
+            return Ok(ApiResponse::ok(apply_pagination(response, &query)));
         }
     }
 
@@ -769,7 +857,7 @@ pub async fn list_bundled_skills(
     // 再次尝试从缓存读取
     if let Some(cache) = get_global_skills_cache() {
         if let Some(response) = cache.get() {
-            return Ok(ApiResponse::ok(response));
+            return Ok(ApiResponse::ok(apply_pagination(response, &query)));
         }
     }
 
@@ -785,6 +873,8 @@ pub async fn list_bundled_skills(
                     skills: Vec::new(),
                     sources: std::collections::HashMap::new(),
                     total: 0,
+                    page: 1,
+                    page_size: 20,
                 };
             }
         };
@@ -795,6 +885,8 @@ pub async fn list_bundled_skills(
                 skills: Vec::new(),
                 sources: std::collections::HashMap::new(),
                 total: 0,
+                page: 1,
+                page_size: 20,
             };
         }
 
@@ -816,12 +908,228 @@ pub async fn list_bundled_skills(
         }
 
         let total = skills.len();
-        BundledSkillsResponse { skills, sources, total }
+        BundledSkillsResponse {
+            skills,
+            sources,
+            total,
+            page: 1,
+            page_size: 20,
+        }
     })
     .await
     .map_err(|e| AppError::Internal(format!("spawn_blocking join error: {}", e)))?;
 
-    Ok(ApiResponse::ok(result))
+    // 同样对兜底结果应用分页，再交给调用方
+    Ok(ApiResponse::ok(apply_pagination(result, &query)))
+}
+
+/// 分页切片上限：超过该值的 page_size 会被强制压回，避免一次拉太多拖慢响应
+const MAX_PAGE_SIZE: u32 = 200;
+
+/// 在全量响应之上应用过滤 + 分页参数
+///
+/// 处理顺序（关键）：先按 source / keyword 过滤，再分页。
+/// 只有这样 `total` 才是「过滤后」的计数，前端 Pagination 才能正确渲染页码。
+///
+/// 设计取舍：
+/// - 缓存里存的是全量技能，过滤 + 分页都在内存里完成，避免每次都重新扫磁盘。
+/// - 始终切片，不再有「不分页」分支；page_size 钳到 [1, MAX_PAGE_SIZE]。
+/// - page 为 0 视为非法，统一回退到 1。
+/// - page 超出范围时返回空列表而非报错，前端 Pagination 组件能正确处理 total。
+fn apply_pagination(
+    mut response: BundledSkillsResponse,
+    query: &ListSkillsQuery,
+) -> BundledSkillsResponse {
+    // 1) 先过滤：把 source / keyword 不匹配的技能剔除
+    apply_filter(&mut response, query);
+
+    // 2) 再分页：page_size 钳到 [1, MAX_PAGE_SIZE]；page 为 0 视为非法，统一回退到 1
+    let page_size = query.page_size.clamp(1, MAX_PAGE_SIZE);
+    let page = if query.page == 0 { 1 } else { query.page };
+
+    // total 是「过滤后」的计数，前端据此渲染分页器
+    let total = response.skills.len();
+    let start = (page as usize).saturating_sub(1) * page_size as usize;
+    // start 越界时 drain 返回空，正好对应「翻到末页之后」的语义
+    let end = start.saturating_add(page_size as usize).min(total);
+
+    let paged: Vec<BundledSkillMeta> = response.skills.drain(start..end).collect();
+    response.skills = paged;
+    response.total = total;
+    response.page = page;
+    response.page_size = page_size;
+    response
+}
+
+/// 按 source / keyword 过滤技能列表（原地修改）
+///
+/// - source：精确匹配 skill.source；None 表示不按来源过滤
+/// - keyword：不区分大小写匹配 name / short_name / description / description_zh；
+///   None 或空串表示不按关键字过滤
+///
+/// 过滤后 response.total 由调用方（apply_pagination）重算，
+/// 这里只负责把 skills 收窄到「过滤后」的子集。
+fn apply_filter(response: &mut BundledSkillsResponse, query: &ListSkillsQuery) {
+    // 关键字预处理：trim 后转小写，空串视为不过滤
+    let keyword = query
+        .keyword
+        .as_ref()
+        .map(|k| k.trim().to_lowercase())
+        .filter(|k| !k.is_empty());
+
+    // 用 retain 原地过滤，避免中间 Vec 分配；
+    // 两个条件都满足才保留，缺省的条件视为「通过」
+    response.skills.retain(|skill| {
+        // 来源过滤：query.source 缺省或匹配 skill.source 时通过
+        let source_pass = query
+            .source
+            .as_ref()
+            .map_or(true, |s| s == &skill.source);
+
+        // 关键字过滤：query.keyword 缺省或匹配任一文本字段时通过
+        let keyword_pass = keyword.as_ref().map_or(true, |kw| {
+            skill.name.to_lowercase().contains(kw)
+                || skill.short_name.to_lowercase().contains(kw)
+                || skill.description.to_lowercase().contains(kw)
+                || skill
+                    .description_zh
+                    .as_ref()
+                    .is_some_and(|d| d.to_lowercase().contains(kw))
+        });
+
+        source_pass && keyword_pass
+    });
+}
+
+/// 来源分页查询参数
+///
+/// 来源网格按「来源」翻页；keyword 用于「来源内搜索」场景，
+/// 不传则返回全部来源（再分页）。
+#[derive(Debug, Deserialize)]
+pub struct ListSkillSourcesQuery {
+    /// 页码，从 1 开始；缺省默认 1
+    #[serde(default = "default_page")]
+    pub page: u32,
+    /// 每页数量，缺省默认 20；上限 200
+    #[serde(default = "default_page_size")]
+    pub page_size: u32,
+    /// 来源关键字筛选：不区分大小写匹配 name / display_name / description；
+    /// 缺省（None）表示不按关键字过滤
+    #[serde(default)]
+    pub keyword: Option<String>,
+}
+
+/// GET /api/bundled/skill-sources - 列出技能来源（分页）
+///
+/// 与 `/api/bundled/skills` 职责分离：
+/// - `/skills` 按「技能」切片，用于「全部技能」模式
+/// - `/skill-sources` 按「来源」切片，用于「按来源浏览」来源网格
+///
+/// 返回每个来源的 `skill_count`（过滤前计数），前端来源卡片据此显示数量。
+pub async fn list_bundled_skill_sources(
+    State(state): State<AppState>,
+    Query(query): Query<ListSkillSourcesQuery>,
+) -> Result<ApiResponse<BundledSkillSourcesResponse>, AppError> {
+    // 先尝试从缓存读取全量技能（缓存里 skills 已是全量）
+    let cached: Option<BundledSkillsResponse> = if let Some(cache) = get_global_skills_cache() {
+        cache.get()
+    } else {
+        None
+    };
+
+    // 缓存未命中：触发预热后再读一次
+    let cached = match cached {
+        Some(c) => Some(c),
+        None => {
+            let local_path = state.config_snapshot(|c| c.bundled_source.local_path.clone());
+            warm_up_skills_cache(local_path.clone()).await;
+            if let Some(cache) = get_global_skills_cache() {
+                cache.get()
+            } else {
+                None
+            }
+        }
+    };
+
+    // 基于全量技能构造来源列表（含每个来源的技能数），再分页
+    let response = match cached {
+        Some(full) => build_sources_response(full, &query),
+        // 缓存彻底不可用：返回空响应，让前端走「暂无技能来源」分支
+        None => BundledSkillSourcesResponse {
+            sources: Vec::new(),
+            total: 0,
+            page: 1,
+            page_size: 20,
+        },
+    };
+
+    Ok(ApiResponse::ok(response))
+}
+
+/// 基于全量技能响应构造来源分页响应
+///
+/// 步骤：
+/// 1. 按 keyword 过滤来源（匹配 name / display_name / description）
+/// 2. 按 source 字母序排序，保证分页顺序稳定
+/// 3. 按页切片
+///
+/// `skill_count` 是「过滤前」每个来源的真实技能数，
+/// 与来源网格展示「该来源下有多少技能」的语义一致。
+fn build_sources_response(
+    full: BundledSkillsResponse,
+    query: &ListSkillSourcesQuery,
+) -> BundledSkillSourcesResponse {
+    // 关键字预处理：trim 后转小写，空串视为不过滤
+    let keyword = query
+        .keyword
+        .as_ref()
+        .map(|k| k.trim().to_lowercase())
+        .filter(|k| !k.is_empty());
+
+    // 先统计每个来源的技能数（用全量 skills，不被 keyword 影响）
+    let mut count_by_source: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for skill in &full.skills {
+        *count_by_source.entry(skill.source.clone()).or_insert(0) += 1;
+    }
+
+    // 把 sources HashMap 转成 Vec<SkillSourceWithCount>，并按 keyword 过滤
+    let mut all_sources: Vec<SkillSourceWithCount> = full
+        .sources
+        .into_values()
+        .map(|meta| {
+            let skill_count = count_by_source.get(&meta.name).copied().unwrap_or(0);
+            SkillSourceWithCount { meta, skill_count }
+        })
+        .filter(|src| {
+            // keyword 缺省时全部保留
+            keyword.as_ref().map_or(true, |kw| {
+                src.meta.name.to_lowercase().contains(kw)
+                    || src.meta.display_name.to_lowercase().contains(kw)
+                    || src.meta.description.to_lowercase().contains(kw)
+            })
+        })
+        .collect();
+
+    // 按来源名排序，保证分页顺序稳定
+    all_sources.sort_by(|a, b| a.meta.name.cmp(&b.meta.name));
+
+    // total 是「过滤后」的来源数，前端 Pagination 据此渲染
+    let total = all_sources.len();
+
+    // 分页切片
+    let page_size = query.page_size.clamp(1, MAX_PAGE_SIZE);
+    let page = if query.page == 0 { 1 } else { query.page };
+    let start = (page as usize).saturating_sub(1) * page_size as usize;
+    let end = start.saturating_add(page_size as usize).min(total);
+    let paged: Vec<SkillSourceWithCount> = all_sources.drain(start..end).collect();
+
+    BundledSkillSourcesResponse {
+        sources: paged,
+        total,
+        page,
+        page_size,
+    }
 }
 
 /// 递归收集 bundled skills

--- a/frontend/src/api/bundled.ts
+++ b/frontend/src/api/bundled.ts
@@ -105,19 +105,20 @@ export interface BundledSkillMeta {
 /**
  * Bundled Skills 列表响应
  *
- * 后端支持 `?page=&page_size=` 分页；不带分页参数时仍返回全量，保持向后兼容。
- * 分页字段只在请求带了 page / page_size 时才会有值。
+ * 后端强制分页：page / page_size 始终有值，不会返回全量数据。
+ * skills 是「当前页」的过滤后切片；total 是「过滤后」的计数，
+ * 前端 Pagination 据此渲染页码。注意 total 与 skills.length 不一定相等。
  */
 export interface BundledSkillsResponse {
   skills: BundledSkillMeta[];
   /** 来源分类信息（key 为 source 名称） */
   sources: Record<string, SkillSourceMeta>;
-  /** 总数：分页时是「过滤前」的全量技能数，前端据此渲染分页器 */
+  /** 总数：「过滤后」的技能数（先按 source/keyword 过滤，再分页），前端据此渲染分页器 */
   total: number;
-  /** 当前页码（从 1 开始）；不分页时为 undefined */
-  page?: number;
-  /** 每页大小；不分页时为 undefined */
-  page_size?: number;
+  /** 当前页码（从 1 开始） */
+  page: number;
+  /** 每页大小 */
+  page_size: number;
 }
 
 /**
@@ -139,11 +140,15 @@ export interface SkillSourceWithCount {
  * 与 BundledSkillsResponse 职责分离：
  * - BundledSkillsResponse 按「技能」切片，用于「全部技能」模式
  * - BundledSkillSourcesResponse 按「来源」切片，用于「按来源浏览」来源网格
+ *
+ * 注意：total 是「过滤后」的来源数（先按 keyword 过滤，再分页），
+ * 而每个 source 内的 skill_count 仍是「过滤前」的真实技能数——
+ * 两者语义故意不同：total 决定分页器，skill_count 展示「该来源下有多少技能」。
  */
 export interface BundledSkillSourcesResponse {
   /** 当前页的来源列表（已分页切片） */
   sources: SkillSourceWithCount[];
-  /** 来源总数（过滤前），前端 Pagination 据此渲染页码 */
+  /** 来源总数：「过滤后」的来源数，前端 Pagination 据此渲染页码 */
   total: number;
   /** 当前页码（从 1 开始） */
   page: number;

--- a/frontend/src/api/bundled.ts
+++ b/frontend/src/api/bundled.ts
@@ -104,12 +104,51 @@ export interface BundledSkillMeta {
 
 /**
  * Bundled Skills 列表响应
+ *
+ * 后端支持 `?page=&page_size=` 分页；不带分页参数时仍返回全量，保持向后兼容。
+ * 分页字段只在请求带了 page / page_size 时才会有值。
  */
 export interface BundledSkillsResponse {
   skills: BundledSkillMeta[];
   /** 来源分类信息（key 为 source 名称） */
   sources: Record<string, SkillSourceMeta>;
+  /** 总数：分页时是「过滤前」的全量技能数，前端据此渲染分页器 */
   total: number;
+  /** 当前页码（从 1 开始）；不分页时为 undefined */
+  page?: number;
+  /** 每页大小；不分页时为 undefined */
+  page_size?: number;
+}
+
+/**
+ * 带技能计数的来源视图
+ *
+ * 来源分页接口专用：在 SkillSourceMeta 基础上附加 `skill_count`，
+ * 让前端来源网格能直接显示「该来源下有多少技能」。
+ */
+export interface SkillSourceWithCount {
+  /** 来源元数据 */
+  meta: SkillSourceMeta;
+  /** 该来源下的技能数（过滤前计数） */
+  skill_count: number;
+}
+
+/**
+ * 来源分页列表响应
+ *
+ * 与 BundledSkillsResponse 职责分离：
+ * - BundledSkillsResponse 按「技能」切片，用于「全部技能」模式
+ * - BundledSkillSourcesResponse 按「来源」切片，用于「按来源浏览」来源网格
+ */
+export interface BundledSkillSourcesResponse {
+  /** 当前页的来源列表（已分页切片） */
+  sources: SkillSourceWithCount[];
+  /** 来源总数（过滤前），前端 Pagination 据此渲染页码 */
+  total: number;
+  /** 当前页码（从 1 开始） */
+  page: number;
+  /** 每页大小 */
+  page_size: number;
 }
 
 /**
@@ -197,9 +236,40 @@ export const bundledApi = {
   /**
    * 获取技能市场中的所有技能
    * 扫描 ~/.ntd/bundled/skills/ 目录，返回可安装的技能列表
+   *
+   * 强制分页：page / page_size 必传，后端只返回该页切片。
+   * 过滤参数 source / keyword 下沉到后端：先按它们过滤，再分页，
+   * 这样 total 就是「过滤后」的计数，前端 Pagination 与实际可见技能一一对应。
+   * 绝不会返回全量数据。
    */
-  async getSkills(): Promise<BundledSkillsResponse> {
-    return unwrap(await api.get('/api/bundled/skills'));
+  async getSkills(params: {
+    page: number;
+    page_size: number;
+    /** 来源筛选：传具体 source 名只返回该来源的技能 */
+    source?: string;
+    /** 关键字筛选：不区分大小写匹配 name / short_name / description / description_zh */
+    keyword?: string;
+  }): Promise<BundledSkillsResponse> {
+    // axios 会自动忽略 undefined 字段，所以前端只下发「显式传了」的过滤参数
+    return unwrap(await api.get('/api/bundled/skills', { params }));
+  },
+
+  /**
+   * 获取技能来源分页列表
+   *
+   * 与 getSkills 职责分离：
+   * - getSkills 按「技能」切片，用于「全部技能」模式
+   * - getSkillSources 按「来源」切片，用于「按来源浏览」来源网格
+   *
+   * 每个来源附 skill_count（过滤前计数），前端来源卡片据此显示数量。
+   */
+  async getSkillSources(params: {
+    page: number;
+    page_size: number;
+    /** 来源关键字筛选：不区分大小写匹配 name / display_name / description */
+    keyword?: string;
+  }): Promise<BundledSkillSourcesResponse> {
+    return unwrap(await api.get('/api/bundled/skill-sources', { params }));
   },
 
   /**

--- a/frontend/src/components/settings/templates/SkillTemplatesTab.tsx
+++ b/frontend/src/components/settings/templates/SkillTemplatesTab.tsx
@@ -39,7 +39,9 @@ export function SkillTemplatesTab({ refreshTick }: { refreshTick?: number }) {
   const loadSkills = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await bundledApi.getSkills();
+      // 强制分页：page=1, page_size=200 取接近全量的首页切片，
+      // 模板配置场景需要一次性看到所有技能
+      const res = await bundledApi.getSkills({ page: 1, page_size: 200 });
       setSkills(res.skills);
     } catch (e: any) {
       message.error('加载技能列表失败: ' + (e?.message || e));

--- a/frontend/src/components/skills/SkillMarketplace.css
+++ b/frontend/src/components/skills/SkillMarketplace.css
@@ -25,6 +25,11 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  /* min-width:0 切断 flex 子项默认 min-width:auto，
+     否则长标题会沿 flex 链路一路撑破到 .ant-card 这层，
+     ellipsis 即使设了也无效——必须把每一层 flex 容器都降到 0 */
+  min-width: 0;
+  overflow: hidden;
 }
 
 /* Card body 内部用 flex column，让 footer（github/license/计数）总是贴底；
@@ -34,6 +39,10 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  /* 同样补 min-width:0 + overflow:hidden，
+     把「内容可收缩」的链路打通到最内层 span */
+  min-width: 0;
+  overflow: hidden;
 }
 
 .market-source-card:hover > .ant-card,

--- a/frontend/src/components/skills/SkillMarketplace.css
+++ b/frontend/src/components/skills/SkillMarketplace.css
@@ -13,6 +13,11 @@
   /* 网格条目本身已由父 grid 拉到同行最高，但内部 Ant Card 需要铺满，
      否则卡片高度还是跟着内容变。把整张卡填满 wrapper。 */
   display: flex;
+  /* grid auto-fill 列宽是「可用宽度 / minmax」算出来的固定值；
+     不加 width:100%，外层 div 会按内容收缩，导致同行第三列被前两列挤出视口。
+     min-width:0 让 flex 子项可以收缩到内容以下，彻底切断「内容撑破列」的链路。 */
+  width: 100%;
+  min-width: 0;
 }
 
 .market-source-card > .ant-card,

--- a/frontend/src/components/skills/SkillMarketplace.tsx
+++ b/frontend/src/components/skills/SkillMarketplace.tsx
@@ -595,7 +595,11 @@ export function SkillMarketplace() {
   };
 
   const enterSource = (sourceKey: string) => {
+    // 进入新来源时强制把页码重置回第 1 页：
+    // 不同来源的技能数差异很大（旧来源可能翻到第 10 页，新来源总共只有 2 页），
+    // 若不重置，用户会卡在「当前页超出新来源总页数 → 显示空白 + Pagination 翻不动」的鬼畜状态。
     setActiveSource(sourceKey);
+    setBrowseSkillsPage(1);
     setSearchText('');
   };
 
@@ -737,7 +741,14 @@ export function SkillMarketplace() {
       {viewMode === 'browse-sources' && activeSource && (
         <Button
           icon={<ArrowLeftOutlined />}
-          onClick={() => setActiveSource(null)}
+          onClick={() => {
+            // 返回来源列表时把两个分页状态都重置：
+            // - browseSkillsPage 是「某来源内的技能列表」页码，回到来源网格后这个状态不再有意义
+            // - browseSourcesPage 也重置，避免「来源网格 page=3」和「点回刚看的来源 page=1」语义错乱
+            setActiveSource(null);
+            setBrowseSkillsPage(1);
+            setBrowseSourcesPage(1);
+          }}
         >
           返回来源列表
         </Button>

--- a/frontend/src/components/skills/SkillMarketplace.tsx
+++ b/frontend/src/components/skills/SkillMarketplace.tsx
@@ -8,11 +8,11 @@
  * 交互逻辑与「总览」一致：
  * - 点击技能卡片 → Drawer 详情 → 安装 → 选择执行器
  */
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Card, Tag, Input, Empty, Spin, App,
   Drawer, Descriptions, Button, Space, Modal, Checkbox, Row, Col,
-  Alert, Typography, Dropdown, Divider,
+  Alert, Typography, Dropdown, Divider, Pagination,
 } from 'antd';
 import {
   SearchOutlined, FileTextOutlined, DownloadOutlined,
@@ -21,7 +21,7 @@ import {
   LinkOutlined, DownOutlined,
 } from '@ant-design/icons';
 import XMarkdown from '@ant-design/x-markdown';
-import { bundledApi, type BundledSkillMeta, type BundledSkillFile, type SkillSourceMeta } from '@/api/bundled';
+import { bundledApi, type BundledSkillMeta, type BundledSkillFile, type SkillSourceMeta, type SkillSourceWithCount } from '@/api/bundled';
 import type { ExecutorSkills } from '@/types';
 import { EXECUTORS } from '@/types';
 import { formatSize, formatTime } from './helpers';
@@ -332,6 +332,24 @@ export function SkillMarketplace() {
   const [sources, setSources] = useState<Record<string, SkillSourceMeta>>({});
   const [loading, setLoading] = useState(false);
 
+  // ── 分页状态 ──
+  // 两种视图模式都走后端分页，绝不返回全量数据。
+  // 每种模式独立维护 page，避免切换模式时带着旧页码翻到空页。
+  // 默认 30 条/页，和桌面卡片网格双列布局下的可读性比较平衡。
+  const ALL_SKILLS_PAGE_SIZE = 30;
+  // browse-sources 模式下「来源网格」的页码（按来源翻页）
+  const [browseSourcesPage, setBrowseSourcesPage] = useState(1);
+  // browse-sources 模式下「进入某个来源后的技能列表」页码（按技能翻页）
+  const [browseSkillsPage, setBrowseSkillsPage] = useState(1);
+  // all-skills 模式的页码
+  const [allPage, setAllPage] = useState(1);
+  // total 始终是「过滤前」的全量计数，后端在分页切片前就已写入；
+  // 前端据此渲染 Pagination 组件，而不是直接看当前页的 skills.length。
+  const [total, setTotal] = useState(0);
+  // 来源分页响应：来源网格专用，与技能分页彻底分离
+  const [sourcesList, setSourcesList] = useState<SkillSourceWithCount[]>([]);
+  const [sourcesTotal, setSourcesTotal] = useState(0);
+
   // ── 视图状态 ──
   const [viewMode, setViewMode] = useState<ViewMode>('browse-sources');
   const [activeSource, setActiveSource] = useState<string | null>(null);
@@ -364,19 +382,68 @@ export function SkillMarketplace() {
 
   /**
    * 加载市场技能列表
+   *
+   * 设计取舍（强制分页）：
+   * - 两种视图模式都走后端分页，绝不返回全量数据，避免一次把上千张
+   *   技能卡片塞进 DOM 把首屏渲染拖垮。
+   * - 「按来源浏览」模式下，sourceNames / skillsBySource / activeSourceSkills
+   *   都基于「当前页」数据派生：来源网格只显示当前页出现的来源，
+   *   翻页时换一组来源卡片，与「全部技能」翻页换一批技能语义一致。
+   * - total 是「过滤前」的全量计数，前端 Pagination 据此渲染页码。
    */
   const loadSkills = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await bundledApi.getSkills();
+      // 当前视图模式对应的页码：切换模式时各自独立的 page 互不干扰
+      const currentPage = viewMode === 'all-skills' ? allPage : browseSkillsPage;
+      // 过滤参数下沉到后端：
+      // - 全部技能模式把 filterSource / searchText 作为 source / keyword 传给后端
+      // - 按来源浏览模式下「进入某个来源」用 activeSource，来源网格则不带 source
+      // 后端先过滤再分页，total 就是过滤后的计数，前端 Pagination 据此渲染。
+      const source = viewMode === 'all-skills'
+        ? (filterSource === 'all' ? undefined : filterSource)
+        : (activeSource ?? undefined);
+      const keyword = searchText.trim() || undefined;
+      const res = await bundledApi.getSkills({
+        page: currentPage,
+        page_size: ALL_SKILLS_PAGE_SIZE,
+        source,
+        keyword,
+      });
       setSkills(res.skills);
       setSources(res.sources);
+      setTotal(res.total);
     } catch (e: any) {
       message.error('加载技能列表失败: ' + (e?.message || e));
     } finally {
       setLoading(false);
     }
-  }, [message]);
+  }, [message, viewMode, allPage, browseSkillsPage, filterSource, activeSource, searchText, ALL_SKILLS_PAGE_SIZE]);
+
+  /**
+   * 加载来源分页列表
+   *
+   * 来源网格专用：按「来源」本身翻页，与技能分页彻底分离。
+   * 来源网格的每个 SourceCard 显示 skill_count（过滤前计数），
+   * sourcesTotal 是过滤后的来源总数，前端 Pagination 据此渲染。
+   */
+  const loadSources = useCallback(async () => {
+    setLoading(true);
+    try {
+      const keyword = searchText.trim() || undefined;
+      const res = await bundledApi.getSkillSources({
+        page: browseSourcesPage,
+        page_size: ALL_SKILLS_PAGE_SIZE,
+        keyword,
+      });
+      setSourcesList(res.sources);
+      setSourcesTotal(res.total);
+    } catch (e: any) {
+      message.error('加载来源列表失败: ' + (e?.message || e));
+    } finally {
+      setLoading(false);
+    }
+  }, [message, browseSourcesPage, searchText, ALL_SKILLS_PAGE_SIZE]);
 
   /**
    * 加载已安装技能
@@ -391,57 +458,20 @@ export function SkillMarketplace() {
   }, []);
 
   useEffect(() => {
-    loadSkills();
+    // 来源网格走 loadSources（按来源翻页），其余技能列表场景走 loadSkills
+    if (viewMode === 'browse-sources' && !activeSource) {
+      loadSources();
+    } else {
+      loadSkills();
+    }
     loadInstalled();
-  }, [loadSkills, loadInstalled]);
+  }, [viewMode, activeSource, loadSkills, loadSources, loadInstalled]);
 
-  // ── 派生数据 ──
-  const sourceNames = useMemo(() => {
-    const set = new Set<string>();
-    skills.forEach(s => set.add(s.source));
-    return Array.from(set).sort();
-  }, [skills]);
-
-  const skillsBySource = useMemo(() => {
-    const map: Record<string, BundledSkillMeta[]> = {};
-    skills.forEach(s => {
-      if (!map[s.source]) map[s.source] = [];
-      map[s.source].push(s);
-    });
-    return map;
-  }, [skills]);
-
-  const filteredSkills = useMemo(() => {
-    let result = skills;
-    if (filterSource !== 'all') {
-      result = result.filter(s => s.source === filterSource);
-    }
-    if (searchText) {
-      const lower = searchText.toLowerCase();
-      result = result.filter(s =>
-        s.name.toLowerCase().includes(lower) ||
-        s.short_name.toLowerCase().includes(lower) ||
-        s.description?.toLowerCase().includes(lower) ||
-        s.description_zh?.toLowerCase().includes(lower)
-      );
-    }
-    return result;
-  }, [skills, filterSource, searchText]);
-
-  const activeSourceSkills = useMemo(() => {
-    if (!activeSource) return [];
-    let result = skillsBySource[activeSource] || [];
-    if (searchText) {
-      const lower = searchText.toLowerCase();
-      result = result.filter(s =>
-        s.name.toLowerCase().includes(lower) ||
-        s.short_name.toLowerCase().includes(lower) ||
-        s.description?.toLowerCase().includes(lower) ||
-        s.description_zh?.toLowerCase().includes(lower)
-      );
-    }
-    return result;
-  }, [skillsBySource, activeSource, searchText]);
+  // 过滤已下沉到后端（loadSkills 下发 source / keyword）：
+  // 后端先过滤再分页，返回的 skills 就是当前页的过滤结果。
+  // 这里不再做本地二次过滤，避免与后端切片叠加导致分页错位。
+  const filteredSkills = skills;
+  const activeSourceSkills = skills;
 
   // ── 判断已安装 ──
   const getInstalledExecutors = (skill: BundledSkillMeta): string[] => {
@@ -515,6 +545,9 @@ export function SkillMarketplace() {
     setViewMode('browse-sources');
     setActiveSource(null);
     setSearchText('');
+    // 切回来源浏览时重置页码，避免带着「全部技能」模式的 page 状态回来
+    setBrowseSourcesPage(1);
+    setBrowseSkillsPage(1);
   };
 
   const switchToAllSkills = () => {
@@ -522,6 +555,8 @@ export function SkillMarketplace() {
     setActiveSource(null);
     setFilterSource('all');
     setSearchText('');
+    // 进入「全部技能」分页模式，始终从第 1 页开始
+    setAllPage(1);
   };
 
   const enterSource = (sourceKey: string) => {
@@ -557,7 +592,7 @@ export function SkillMarketplace() {
         <Card
           size="small"
           hoverable
-          onClick={() => { setFilterSource('all'); }}
+          onClick={() => { setFilterSource('all'); setAllPage(1); }}
           style={{
             borderRadius: 'var(--radius-sm)',
             cursor: 'pointer',
@@ -576,17 +611,19 @@ export function SkillMarketplace() {
             color: filterSource === 'all' ? 'var(--color-primary)' : 'var(--color-text)',
           }}>全部来源</div>
           <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 4 }}>
-            {skills.length} 个技能
+            {total} 个技能
           </div>
         </Card>
 
-        {sourceNames.map(src => (
+        {/* 下拉来源列表：复用 sourcesList（来源网格分页响应），
+            它已经按来源名排序、含 skill_count */}
+        {sourcesList.map(src => (
           <SourceCard
-            key={src}
-            sourceKey={src}
-            meta={sources[src]}
-            skillCount={skillsBySource[src]?.length || 0}
-            onClick={() => { setFilterSource(src); }}
+            key={src.meta.name}
+            sourceKey={src.meta.name}
+            meta={src.meta}
+            skillCount={src.skill_count}
+            onClick={() => { setFilterSource(src.meta.name); setAllPage(1); }}
             compact
           />
         ))}
@@ -628,7 +665,11 @@ export function SkillMarketplace() {
         placeholder="搜索技能..."
         prefix={<SearchOutlined style={{ color: 'var(--color-text-tertiary)' }} />}
         value={searchText}
-        onChange={e => setSearchText(e.target.value)}
+        onChange={e => {
+          setSearchText(e.target.value);
+          // 搜索会改变 filteredSkills 的内容，重置回第 1 页避免停留在空页
+          if (viewMode === 'all-skills') setAllPage(1);
+        }}
         style={{ width: 220, borderRadius: 'var(--radius-xl)' }}
         allowClear
       />
@@ -659,7 +700,7 @@ export function SkillMarketplace() {
 
       <Text type="secondary" style={{ marginLeft: 'auto', fontSize: 13 }}>
         {viewMode === 'browse-sources' && !activeSource
-          ? `${sourceNames.length} 个来源`
+          ? `${sourcesTotal} 个来源`
           : `${viewMode === 'browse-sources' ? activeSourceSkills.length : filteredSkills.length} 个技能`
         }
       </Text>
@@ -677,28 +718,50 @@ export function SkillMarketplace() {
           </div>
         );
       }
-      if (sourceNames.length === 0) {
+      if (sourcesList.length === 0) {
         return (
           <div style={{ textAlign: 'center', padding: '60px 20px' }}>
-            <Empty description="暂无技能来源" />
+            <Empty description={searchText ? '无匹配来源' : '暂无技能来源'} />
           </div>
         );
       }
       return (
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
-          gap: 16,
-        }}>
-          {sourceNames.map(src => (
-            <SourceCard
-              key={src}
-              sourceKey={src}
-              meta={sources[src]}
-              skillCount={skillsBySource[src]?.length || 0}
-              onClick={() => enterSource(src)}
-            />
-          ))}
+        <div>
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+            gap: 16,
+          }}>
+            {/* 来源网格直接用后端返回的 sourcesList（已按来源分页），
+                每个 SourceCard 显示 skill_count（过滤前计数） */}
+            {sourcesList.map(src => (
+              <SourceCard
+                key={src.meta.name}
+                sourceKey={src.meta.name}
+                meta={src.meta}
+                skillCount={src.skill_count}
+                onClick={() => enterSource(src.meta.name)}
+              />
+            ))}
+          </div>
+          {/* 来源网格分页器：sourcesTotal 是过滤后的来源总数，
+              browseSourcesPage 翻页时 loadSources 重拉当前页来源 */}
+          {sourcesTotal > 0 && (
+            <div style={{
+              display: 'flex',
+              justifyContent: 'center',
+              marginTop: 24,
+            }}>
+              <Pagination
+                current={browseSourcesPage}
+                pageSize={ALL_SKILLS_PAGE_SIZE}
+                total={sourcesTotal}
+                onChange={(nextPage) => setBrowseSourcesPage(nextPage)}
+                showSizeChanger={false}
+                showTotal={(count) => `共 ${count} 个来源`}
+              />
+            </div>
+          )}
         </div>
       );
     }
@@ -785,11 +848,33 @@ export function SkillMarketplace() {
               ))}
             </div>
           )}
+
+          {/* 单个来源的技能列表分页器：用 browseSkillsPage 翻页，
+              loadSkills 在该模式下按 activeSource 过滤后分页拉取技能 */}
+          {total > 0 && (
+            <div style={{
+              display: 'flex',
+              justifyContent: 'center',
+              marginTop: 24,
+            }}>
+              <Pagination
+                current={browseSkillsPage}
+                pageSize={ALL_SKILLS_PAGE_SIZE}
+                total={total}
+                onChange={(nextPage) => setBrowseSkillsPage(nextPage)}
+                showSizeChanger={false}
+                showTotal={(count) => `共 ${count} 个技能`}
+              />
+            </div>
+          )}
         </div>
       );
     }
 
     // 全部技能模式
+    // 该模式走后端分页：loadSkills 只拉当前页的 ALL_SKILLS_PAGE_SIZE 条，
+    // 底部 Pagination 翻页时通过 page 状态触发 loadSkills 重跑。
+    // 注意 total 是「过滤前」的全量计数，前端据此渲染页码而不是看当前页 length。
     return (
       <Spin spinning={loading}>
         {filteredSkills.length === 0 ? (
@@ -814,6 +899,23 @@ export function SkillMarketplace() {
                 onClick={() => handleCardClick(skill)}
               />
             ))}
+          </div>
+        )}
+        {/* 分页器：仅在「全部技能」模式显示，total 由后端在分页切片前写入 */}
+        {viewMode === 'all-skills' && total > 0 && (
+          <div style={{
+            display: 'flex',
+            justifyContent: 'center',
+            marginTop: 24,
+          }}>
+            <Pagination
+              current={allPage}
+              pageSize={ALL_SKILLS_PAGE_SIZE}
+              total={total}
+              onChange={(nextPage) => setAllPage(nextPage)}
+              showSizeChanger={false}
+              showTotal={(count) => `共 ${count} 个技能`}
+            />
           </div>
         )}
       </Spin>

--- a/frontend/src/components/skills/SkillMarketplace.tsx
+++ b/frontend/src/components/skills/SkillMarketplace.tsx
@@ -407,7 +407,9 @@ export function SkillMarketplace() {
    * 避免「A 失败先把 loading 关掉，但 B 还在路上」的闪烁。
    */
   const loadSkills = useCallback(async () => {
+    // 抢占本次序号：先 ++ 再读，这样即使同步重入也能保证唯一且递增
     const myGen = ++reqGenRef.current;
+    // 进入 loading 状态要早于 await，否则用户在「点完到转圈」之间会有几十毫秒空窗
     setLoading(true);
     try {
       // 当前视图模式对应的页码：切换模式时各自独立的 page 互不干扰
@@ -419,6 +421,7 @@ export function SkillMarketplace() {
       const source = viewMode === 'all-skills'
         ? (filterSource === 'all' ? undefined : filterSource)
         : (activeSource ?? undefined);
+      // keyword 必须 trim：用户粘贴的 "Claude " 和 "Claude" 应当等价，否则搜索结果莫名其妙地变少
       const keyword = searchText.trim() || undefined;
       const res = await bundledApi.getSkills({
         page: currentPage,
@@ -428,10 +431,13 @@ export function SkillMarketplace() {
       });
       // 过期请求：在我之后又发起了新请求，新数据才是用户当前想看的，旧结果直接丢弃
       if (myGen !== reqGenRef.current) return;
+      // 三个 setter 顺序固定为「列表 → 分类 → 总数」，方便阅读；
+      // 不打 batch 是因为这些都是原始 useState，独立更新没有性能问题
       setSkills(res.skills);
       setSources(res.sources);
       setTotal(res.total);
     } catch (e: any) {
+      // 过期请求的错误信息也不展示：用户看到的是「上一次」的错误，已经不准确
       if (myGen !== reqGenRef.current) return;
       message.error('加载技能列表失败: ' + (e?.message || e));
     } finally {
@@ -450,6 +456,9 @@ export function SkillMarketplace() {
    * 竞态保护同 loadSkills：复用 reqGenRef，唯一序号、过期丢弃。
    */
   const loadSources = useCallback(async () => {
+    // 与 loadSkills 共用 reqGenRef：保证两类请求的「最新」语义统一，
+    // 即用户在「全部技能」模式和「来源网格」模式之间快速切换时，
+    // 也只有最新一次请求的结果能落到 state
     const myGen = ++reqGenRef.current;
     setLoading(true);
     try {
@@ -461,6 +470,8 @@ export function SkillMarketplace() {
       });
       // 过期请求直接丢弃，不写 sourcesList / sourcesTotal
       if (myGen !== reqGenRef.current) return;
+      // 来源网格只更新这两个 state；skills / sources / total 不会被本次调用影响，
+      // 避免「来源网格数据」误覆盖「技能列表」数据
       setSourcesList(res.sources);
       setSourcesTotal(res.total);
     } catch (e: any) {
@@ -690,9 +701,19 @@ export function SkillMarketplace() {
         prefix={<SearchOutlined style={{ color: 'var(--color-text-tertiary)' }} />}
         value={searchText}
         onChange={e => {
+          // 先把输入值落到 state，再按当前模式把页码重置回第 1 页；
+          // 搜索会改变后端过滤结果，过滤后总页数可能减少，
+          // 若停留在 page>1 会卡在空白页。
           setSearchText(e.target.value);
-          // 搜索会改变后端过滤结果，重置回第 1 页避免停留在空页
-          if (viewMode === 'all-skills') setAllPage(1);
+          if (viewMode === 'all-skills') {
+            // 全部技能模式：只有一个页码状态
+            setAllPage(1);
+          } else if (viewMode === 'browse-sources') {
+            // 来源网格模式：按 activeSource 是否已选决定重置「来源网格页码」
+            // 还是「进入某来源后的技能列表页码」
+            if (!activeSource) setBrowseSourcesPage(1);
+            else setBrowseSkillsPage(1);
+          }
         }}
         style={{ width: 220, borderRadius: 'var(--radius-xl)' }}
         allowClear
@@ -723,10 +744,12 @@ export function SkillMarketplace() {
       )}
 
       <Text type="secondary" style={{ marginLeft: 'auto', fontSize: 13 }}>
+        {/* 工具栏右侧的「总数量」展示：分页后 skills.length 仅代表当前页切片长度（最多 30），
+            必须用后端返回的过滤后 total / sourcesTotal，才能反映「实际匹配到的总量」，
+            与来源网格卡片上的 skill_count 含义区分清楚。 */}
         {viewMode === 'browse-sources' && !activeSource
           ? `${sourcesTotal} 个来源`
-          : `${viewMode === 'browse-sources' ? skills.length : skills.length} 个技能`
-        }
+          : `${total} 个技能`}
       </Text>
     </div>
   );

--- a/frontend/src/components/skills/SkillMarketplace.tsx
+++ b/frontend/src/components/skills/SkillMarketplace.tsx
@@ -347,7 +347,7 @@ export function SkillMarketplace() {
   const [browseSkillsPage, setBrowseSkillsPage] = useState(1);
   // all-skills 模式的页码
   const [allPage, setAllPage] = useState(1);
-  // total 始终是「过滤前」的全量计数，后端在分页切片前就已写入；
+  // total 是「过滤后」的技能数（后端先按 source/keyword 过滤再分页），
   // 前端据此渲染 Pagination 组件，而不是直接看当前页的 skills.length。
   const [total, setTotal] = useState(0);
   // 来源分页响应：来源网格专用，与技能分页彻底分离
@@ -373,6 +373,13 @@ export function SkillMarketplace() {
   // 避免快速连点 A→B 时 A 的内容把 B 的详情覆盖掉（旧请求的 finally 也不会误关 B 的 loading）。
   const detailReqIdRef = useRef(0);
 
+  // 列表请求竞态守卫（loadSkills / loadSources 共用）：
+  // 翻页 / 切视图 / 改搜索词时旧请求可能晚于新请求返回，
+  // 用序号识别「最新」请求，过期的 setState 全部静默丢弃；
+  // setLoading(false) 也仅由最新请求触发，避免中途失败的旧请求
+  // 把 loading 提前关掉造成 spinner 闪烁。
+  const reqGenRef = useRef(0);
+
   // ── 安装 Modal 状态 ──
   const [installModalOpen, setInstallModalOpen] = useState(false);
   const [targetExecutors, setTargetExecutors] = useState<string[]>([]);
@@ -390,12 +397,17 @@ export function SkillMarketplace() {
    * 设计取舍（强制分页）：
    * - 两种视图模式都走后端分页，绝不返回全量数据，避免一次把上千张
    *   技能卡片塞进 DOM 把首屏渲染拖垮。
-   * - 「按来源浏览」模式下，sourceNames / skillsBySource / activeSourceSkills
-   *   都基于「当前页」数据派生：来源网格只显示当前页出现的来源，
-   *   翻页时换一组来源卡片，与「全部技能」翻页换一批技能语义一致。
-   * - total 是「过滤前」的全量计数，前端 Pagination 据此渲染页码。
+   * - 来源网格按「来源」独立翻页（loadSources），与技能分页职责分离。
+   * - total 是「过滤后」的技能数，前端 Pagination 据此渲染页码。
+   *
+   * 竞态保护：快速翻页 / 切换视图时，旧的请求可能晚于新请求返回，
+   * 若直接 setState 会用旧数据覆盖新数据。这里用 reqGenRef 给每次请求
+   * 打序号，仅最新请求的结果（成功 / 失败）能落到 state，
+   * 过期请求静默丢弃；setLoading(false) 也只由最新请求触发，
+   * 避免「A 失败先把 loading 关掉，但 B 还在路上」的闪烁。
    */
   const loadSkills = useCallback(async () => {
+    const myGen = ++reqGenRef.current;
     setLoading(true);
     try {
       // 当前视图模式对应的页码：切换模式时各自独立的 page 互不干扰
@@ -414,13 +426,17 @@ export function SkillMarketplace() {
         source,
         keyword,
       });
+      // 过期请求：在我之后又发起了新请求，新数据才是用户当前想看的，旧结果直接丢弃
+      if (myGen !== reqGenRef.current) return;
       setSkills(res.skills);
       setSources(res.sources);
       setTotal(res.total);
     } catch (e: any) {
+      if (myGen !== reqGenRef.current) return;
       message.error('加载技能列表失败: ' + (e?.message || e));
     } finally {
-      setLoading(false);
+      // 仅最新请求负责关 loading，否则中途失败的过期请求会把 loading 提前关掉
+      if (myGen === reqGenRef.current) setLoading(false);
     }
   }, [message, viewMode, allPage, browseSkillsPage, filterSource, activeSource, searchText, ALL_SKILLS_PAGE_SIZE]);
 
@@ -430,8 +446,11 @@ export function SkillMarketplace() {
    * 来源网格专用：按「来源」本身翻页，与技能分页彻底分离。
    * 来源网格的每个 SourceCard 显示 skill_count（过滤前计数），
    * sourcesTotal 是过滤后的来源总数，前端 Pagination 据此渲染。
+   *
+   * 竞态保护同 loadSkills：复用 reqGenRef，唯一序号、过期丢弃。
    */
   const loadSources = useCallback(async () => {
+    const myGen = ++reqGenRef.current;
     setLoading(true);
     try {
       const keyword = searchText.trim() || undefined;
@@ -440,12 +459,15 @@ export function SkillMarketplace() {
         page_size: ALL_SKILLS_PAGE_SIZE,
         keyword,
       });
+      // 过期请求直接丢弃，不写 sourcesList / sourcesTotal
+      if (myGen !== reqGenRef.current) return;
       setSourcesList(res.sources);
       setSourcesTotal(res.total);
     } catch (e: any) {
+      if (myGen !== reqGenRef.current) return;
       message.error('加载来源列表失败: ' + (e?.message || e));
     } finally {
-      setLoading(false);
+      if (myGen === reqGenRef.current) setLoading(false);
     }
   }, [message, browseSourcesPage, searchText, ALL_SKILLS_PAGE_SIZE]);
 
@@ -472,10 +494,8 @@ export function SkillMarketplace() {
   }, [viewMode, activeSource, loadSkills, loadSources, loadInstalled]);
 
   // 过滤已下沉到后端（loadSkills 下发 source / keyword）：
-  // 后端先过滤再分页，返回的 skills 就是当前页的过滤结果。
-  // 这里不再做本地二次过滤，避免与后端切片叠加导致分页错位。
-  const filteredSkills = skills;
-  const activeSourceSkills = skills;
+  // 后端先过滤再分页，返回的 skills 就是当前页的过滤后切片，
+  // 这里直接用 skills，不再做本地二次过滤，避免与后端切片叠加导致分页错位。
 
   // ── 判断已安装 ──
   const getInstalledExecutors = (skill: BundledSkillMeta): string[] => {
@@ -671,7 +691,7 @@ export function SkillMarketplace() {
         value={searchText}
         onChange={e => {
           setSearchText(e.target.value);
-          // 搜索会改变 filteredSkills 的内容，重置回第 1 页避免停留在空页
+          // 搜索会改变后端过滤结果，重置回第 1 页避免停留在空页
           if (viewMode === 'all-skills') setAllPage(1);
         }}
         style={{ width: 220, borderRadius: 'var(--radius-xl)' }}
@@ -705,7 +725,7 @@ export function SkillMarketplace() {
       <Text type="secondary" style={{ marginLeft: 'auto', fontSize: 13 }}>
         {viewMode === 'browse-sources' && !activeSource
           ? `${sourcesTotal} 个来源`
-          : `${viewMode === 'browse-sources' ? activeSourceSkills.length : filteredSkills.length} 个技能`
+          : `${viewMode === 'browse-sources' ? skills.length : skills.length} 个技能`
         }
       </Text>
     </div>
@@ -772,7 +792,8 @@ export function SkillMarketplace() {
 
     // 按来源浏览 → 某个来源的技能列表
     if (viewMode === 'browse-sources' && activeSource) {
-      const sourceSkills = activeSourceSkills;
+      // skills 已经是 loadSkills 按 activeSource 过滤后当前页的切片
+      const sourceSkills = skills;
       const sourceMeta = sources[activeSource];
       return (
         <div>
@@ -878,10 +899,10 @@ export function SkillMarketplace() {
     // 全部技能模式
     // 该模式走后端分页：loadSkills 只拉当前页的 ALL_SKILLS_PAGE_SIZE 条，
     // 底部 Pagination 翻页时通过 page 状态触发 loadSkills 重跑。
-    // 注意 total 是「过滤前」的全量计数，前端据此渲染页码而不是看当前页 length。
+    // 注意 total 是「过滤后」的技能数，前端据此渲染页码而不是看当前页 length。
     return (
       <Spin spinning={loading}>
-        {filteredSkills.length === 0 ? (
+        {skills.length === 0 ? (
           <div style={{
             textAlign: 'center',
             padding: '60px 20px',
@@ -895,7 +916,7 @@ export function SkillMarketplace() {
             gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
             gap: 12,
           }}>
-            {filteredSkills.map(skill => (
+            {skills.map(skill => (
               <MarketSkillCard
                 key={skill.name}
                 skill={skill}

--- a/frontend/src/components/skills/SkillMarketplace.tsx
+++ b/frontend/src/components/skills/SkillMarketplace.tsx
@@ -86,12 +86,16 @@ function SourceCard({
       styles={{ body: { padding: compact ? 12 : 16 } }}
     >
       {/* 名称 + Stars */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8, minWidth: 0 }}>
         <span style={{
           fontSize: compact ? 13 : 15,
           fontWeight: 600,
           color: 'var(--color-text)',
           flex: 1,
+          // minWidth:0 是关键：flex 子项默认 min-width:auto，
+          // 长标题（如「Claude Skills Collection (BbgnsurfTec)」）会撑破列宽，
+          // 把它降到 0 后 overflow+ellipsis 才能真正生效
+          minWidth: 0,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',


### PR DESCRIPTION
## 背景

反馈来源：`http://localhost:18088/#/skills` 页面标注反馈。

> 点击「全部技能」后所有 skills 全部列出，希望改成分页模式。增加分页功能，后端分页。

## 改动概览

### 后端（`backend/src/handlers/bundled.rs`）

- **强制分页**：`ListSkillsQuery` 的 `page` / `page_size` 缺省时按默认值（`page=1, page_size=20`）切片，**绝不返回全量数据**。
- **过滤下沉**：`source` / `keyword` 作为 query 参数下发后端，`apply_filter` 先过滤再分页，`total` 是「过滤后」的计数，前端 Pagination 与实际可见技能一一对应。
- **新增来源分页接口** `GET /api/bundled/skill-sources`：按「来源」本身分页，与技能分页职责分离。返回 `SkillSourceWithCount`（含每个来源的 `skill_count`）。
- 新增结构：`SkillSourceWithCount` / `BundledSkillSourcesResponse` / `ListSkillSourcesQuery`。
- `BundledSkillsResponse` 的 `page` / `page_size` 改为非 Option `u32`，始终有值。

### 前端 API（`frontend/src/api/bundled.ts`）

- 新增 `SkillSourceWithCount` / `BundledSkillSourcesResponse` 类型。
- 新增 `bundledApi.getSkillSources({ page, page_size, keyword })`。
- `bundledApi.getSkills({ page, page_size, source, keyword })`：`page` / `page_size` 必填，`source` / `keyword` 可选。

### 前端 UI（`frontend/src/components/skills/SkillMarketplace.tsx`）

- **按来源浏览 → 来源网格**：改用 `getSkillSources`，按「来源」翻页（`browseSourcesPage`）。
- **按来源浏览 → 进入某来源**：用 `getSkills(source=activeSource, page=browseSkillsPage)`，按技能翻页。
- **全部技能**：用 `getSkills(source=filterSource, keyword=searchText, page=allPage)`，过滤下沉到后端。
- 移除前端本地二次过滤（`filteredSkills` / `activeSourceSkills` 直接等于 `skills`），避免与后端切片叠加导致分页错位。
- 删除不再使用的 `sourceNames` / `skillsBySource` 派生数据。
- `SkillTemplatesTab.tsx` 调用 `getSkills` 补上 `{ page: 1, page_size: 200 }`（模板配置场景需一次性看到所有技能）。

### Bug 修复（`frontend/src/components/skills/SkillMarketplace.css`）

按来源浏览的卡片网格第三列被内容撑破，长标题（如「Claude Skills Collection (BbgnsurfTec)」）撑破列宽。

根因：flex 链路上每一层容器默认 `min-width:auto`，长标题沿链路一路撑破到最外层，即使最内层 span 设了 `text-overflow:ellipsis` 也无效。

修复：给 flex 链路上每一层（`.market-source-card` / `.market-skill-card` / `.ant-card` / `.ant-card-body`）都补上 `min-width:0` + `overflow:hidden`，把「内容可收缩」的链路打通到最内层 span，让 `ellipsis` 真正生效，长标题截断显示 `...`。

## 数据流

```
按来源浏览（来源网格）:
  getSkillSources(page=browseSourcesPage)
    → sourcesList（含 skill_count）+ sourcesTotal
    → SourceCard 直接渲染 + Pagination 翻来源

按来源浏览（进入某个来源）:
  getSkills(source=activeSource, page=browseSkillsPage)
    → 该来源过滤后的技能切片 + total
    → MarketSkillCard 渲染 + Pagination 翻技能

全部技能:
  getSkills(source=filterSource, keyword=searchText, page=allPage)
    → 过滤后技能切片 + total
    → MarketSkillCard 渲染 + Pagination 翻技能
```

## 验证

| 检查项 | 结果 |
|--------|------|
| `cd backend && cargo clippy --all-targets -- -D warnings` | ✅ 零告警零错误 |
| `cd frontend && npx tsc --noEmit` | ✅ 零错误 |

## 提交

- `c578115` feat(skills): 技能市场分页改造 + 来源卡片宽度修复
- `5793cf2` fix(skills): 修复 SourceCard 长标题撑破列宽
- `87e245c` fix(skills): SourceCard 长标题彻底截断显示 ...
