### PR TITLE
fix(ui): 全局修复 antd 浮层点击弹不出来(工作空间/执行器/推送级别)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4404,6 +4404,30 @@ code {
   transition: none !important;
 }
 
+/* 全局浮层修复：antd 6 / @rc-component/trigger 3.9.0 的 useAlign bug 影响所有 antd 浮层组件
+   (Dropdown/Select/Popover/Tooltip/DatePicker/Cascader...)。症状：点击触发器后浮层 DOM 已渲染
+   (菜单项齐全)却被锁在 -1000vw(=-12800px) 屏幕外，用户看不到——工作空间、执行器、推送级别等
+   下拉框全部「点击弹不出来」。
+   根因：useAlign 重新对齐时先把 popup 的 left/top reset 到 0，再用 getBoundingClientRect 测量以
+   计算偏移；但 popup 自带 `transition: all 1e-05s` 定位过渡，reset 后测量读到的仍是隐藏态坐标
+   -1000vw(=-12800px)，算出屏幕外偏移被判定不可见，popup 被推回 -12800px。
+   修复：给所有 antd 浮层只保留 opacity 过渡，移除 left/top/transform 过渡——
+     · left/top 不过渡 → useAlign reset 后立即读到真实坐标，定位准确；
+     · transform 不过渡 → getBoundingClientRect 读真实尺寸(保留它会干扰首次对齐算偏、菜单被裁)；
+     · 保留 opacity 过渡 → rc-motion 入场动画的 transitionend 才会触发，opacity 从 0 渐变到 1。
+   ⚠️ 不能用 transition:none：rc-motion 收不到 transitionend 会卡在初始 opacity:0 同样不可见
+      (PR #914 配置菜单对 Popover 用 transition:none 侥幸没暴露此问题，这里用更稳的 opacity 方案统一覆盖)。
+   代价：所有浮层仅 0.2s 淡入(无缩放/滑动)，换来精准定位与正常显示。 */
+.ant-dropdown,
+.ant-select-dropdown,
+.ant-popover,
+.ant-tooltip,
+.ant-picker-dropdown,
+.ant-cascader-menus,
+.ant-transfer-popup {
+  transition: opacity 0.2s ease !important;
+}
+
 /* 覆盖 antd Popover 默认内边距，让菜单面板更紧凑 */
 .ntd-config-menu-popover .ant-popover-inner {
   padding: 0 !important;


### PR DESCRIPTION
## 问题

最近界面优化后, 多个下拉框点击弹不出来(表面像 z-index, 实际不是):
- 工作空间下拉框
- 执行器下拉框
- 推送级别 Select

## 根因

`antd 6.3.6` / `@rc-component/trigger 3.9.0` 的 **useAlign bug**:

重新对齐时先把 popup 的 `left/top` reset 到 0, 再用 `getBoundingClientRect` 测量真实尺寸以计算偏移。但 popup 自带 `transition: all 1e-05s` 定位过渡, reset 后测量读到的仍是隐藏态坐标 `-1000vw`(=`-12800px`), 算出屏幕外偏移被判定「不可见」, popup 被推回 `-12800px`——**DOM 已渲染(菜单项齐全)但被锁在屏幕外, 用户看不到**。

经 agent-browser 实测确认: 点击后浮层 `rect.x = -12800`, `opacity` 正常, 纯粹是坐标被锁。

影响**所有** antd 浮层(Dropdown / Select / Popover / Tooltip / DatePicker / Cascader), 不是个例。PR #914 用 `transition:none` 修了配置菜单(Popover), 但没覆盖其他类型。

## 修复

`App.css` 一处全局规则: 给所有 antd 浮层**只保留 opacity 过渡**, 移除 `left/top/transform` 过渡。

| 过渡项 | 处理 | 原因 |
|---|---|---|
| `left/top` | 移除 | useAlign reset 后立即读到真实坐标, 定位准确 |
| `transform` | 移除 | 不干扰 `getBoundingClientRect` 尺寸读取(保留会让首次对齐算偏 ~66px、菜单被裁) |
| `opacity` | **保留** | rc-motion 入场动画的 `transitionend` 才会触发, opacity 从 0 渐变到 1 |

### 为什么不用 `transition: none`?

`transition:none` 会让 rc-motion 收不到 `transitionend` 事件, 卡在初始 `opacity:0` 同样不可见(我第一版踩过这个坑)。配置菜单(Popover)用 `transition:none` 是侥幸没暴露, 本 PR 用更稳的 **仅 opacity 过渡**方案统一覆盖。

## 代价

所有浮层仅 `0.2s` 淡入(无缩放/滑动动画), 换来精准定位与正常显示。功能优先于动画。

## 验证(agent-browser @ dev:18088)

| 浮层 | 类型 | 修复前 | 修复后 |
|---|---|---|---|
| 工作空间 | Dropdown | x:-12800 不可见 | x:13, opacity:1, items:5 ✓ |
| 全部状态筛选 | Select | 同 bug | x:607, opacity:1, items:5 ✓ |

(执行器 Dropdown、推送级别 Select 同类, 全局规则一并覆盖)

## 改动

仅 `frontend/src/App.css` 一处, 24 行新增。