### PR TITLE
feat(api): API 路由重构 — K8s 风格 workspace 层级 + v1 路径聚合

### DIFF
--- a/backend/src/cli/client.rs
+++ b/backend/src/cli/client.rs
@@ -18,8 +18,14 @@ impl ApiClient {
     // 统一 URL 拼接：base + /api/v1 + path。
     // ADR-7 之后所有业务端点都挂在 /api/v1 下，调用方传入相对路径（如 "/todos"、
     // "/workspaces/1/todos/2"），由这里统一前缀化，避免每个调用点重复写 v1。
+    // 防御性补上前导斜杠：调用方若漏写，避免拼出 /api/v1todos 这种非法路径。
     fn url(&self, path: &str) -> String {
-        format!("{}/api/v1{}", self.base_url, path)
+        // 调用方传入的路径必须以 / 开头；若遗漏则自动补 /，避免拼出 /api/v1todos。
+        if path.starts_with('/') {
+            format!("{}/api/v1{}", self.base_url, path)
+        } else {
+            format!("{}/api/v1/{}", self.base_url, path)
+        }
     }
 
     pub async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
@@ -48,5 +54,34 @@ impl ApiClient {
         let resp = self.client.delete(&url).send().await?;
         let body = resp.text().await?;
         Ok(serde_json::from_str(&body)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// base_url 带尾部斜杠、path 带前导斜杠：正确剥斜杠并拼出 v1 路径。
+    #[test]
+    fn test_url_with_trailing_slash_and_leading_slash() {
+        let client = ApiClient::new("http://localhost:18088/");
+        assert_eq!(client.url("/todos"), "http://localhost:18088/api/v1/todos");
+    }
+
+    /// base_url 无尾部斜杠、path 带前导斜杠：正常拼接。
+    #[test]
+    fn test_url_without_trailing_slash() {
+        let client = ApiClient::new("http://localhost:18088");
+        assert_eq!(
+            client.url("/workspaces/1/todos/2"),
+            "http://localhost:18088/api/v1/workspaces/1/todos/2"
+        );
+    }
+
+    /// path 漏写前导斜杠：防御性补 /，避免 /api/v1todos。
+    #[test]
+    fn test_url_without_leading_slash() {
+        let client = ApiClient::new("http://localhost:18088");
+        assert_eq!(client.url("todos"), "http://localhost:18088/api/v1/todos");
     }
 }

--- a/backend/src/cli/client.rs
+++ b/backend/src/cli/client.rs
@@ -10,33 +10,41 @@ impl ApiClient {
     pub fn new(base_url: &str) -> Self {
         Self {
             client: Client::new(),
+            // 末尾斜杠统一剥掉，避免拼路径时出现 // 造成 404
             base_url: base_url.trim_end_matches('/').to_string(),
         }
     }
 
+    // 统一 URL 拼接：base + /api/v1 + path。
+    // ADR-7 之后所有业务端点都挂在 /api/v1 下，调用方传入相对路径（如 "/todos"、
+    // "/workspaces/1/todos/2"），由这里统一前缀化，避免每个调用点重复写 v1。
+    fn url(&self, path: &str) -> String {
+        format!("{}/api/v1{}", self.base_url, path)
+    }
+
     pub async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
-        let url = format!("{}/api{}", self.base_url, path);
+        let url = self.url(path);
         let resp = self.client.get(&url).send().await?;
         let body = resp.text().await?;
         Ok(serde_json::from_str(&body)?)
     }
 
     pub async fn post<B: serde::Serialize, T: serde::de::DeserializeOwned>(&self, path: &str, body: &B) -> Result<T> {
-        let url = format!("{}/api{}", self.base_url, path);
+        let url = self.url(path);
         let resp = self.client.post(&url).json(body).send().await?;
         let body = resp.text().await?;
         Ok(serde_json::from_str(&body)?)
     }
 
     pub async fn put<B: serde::Serialize, T: serde::de::DeserializeOwned>(&self, path: &str, body: &B) -> Result<T> {
-        let url = format!("{}/api{}", self.base_url, path);
+        let url = self.url(path);
         let resp = self.client.put(&url).json(body).send().await?;
         let body = resp.text().await?;
         Ok(serde_json::from_str(&body)?)
     }
 
     pub async fn delete<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
-        let url = format!("{}/api{}", self.base_url, path);
+        let url = self.url(path);
         let resp = self.client.delete(&url).send().await?;
         let body = resp.text().await?;
         Ok(serde_json::from_str(&body)?)

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -88,7 +88,11 @@ pub enum Commands {
         action: TagAction,
     },
     /// Global statistics
-    Stats,
+    Stats {
+        /// Workspace ID (project_directories.id). v1 路由把 dashboard 嵌入 workspace URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+    },
     /// Blackboard (knowledge wiki) management
     Blackboard {
         #[command(subcommand)]
@@ -134,6 +138,12 @@ pub enum BlackboardAction {
     },
 }
 
+/// 把 workspace_id 拼成 v1 路径前缀 `/workspaces/{ws}`。
+/// 单独抽出来避免在每个分支里手写 format!，确保所有 workspace-scoped 命令路径一致。
+fn ws_prefix(workspace_id: i64) -> String {
+    format!("/workspaces/{}", workspace_id)
+}
+
 /// Wiki 文件子命令（替代旧的 Page 子命令）。
 #[derive(Debug, Clone, Subcommand)]
 pub enum WikiAction {
@@ -169,9 +179,10 @@ pub enum TodoAction {
         #[arg(short, long)]
         executor: Option<String>,
 
-        /// Working directory ID (project_directories.id). 唯一键，CLI 不再支持 path。
+        /// Working directory ID (project_directories.id). v1 路由必填（嵌入 URL）。
+        /// 唯一键，CLI 不再支持 path；stdin 模式下也必须传，body 字段会被本参数覆盖。
         #[arg(short = 'w', long = "workspace-id")]
-        workspace_id: Option<i64>,
+        workspace_id: i64,
 
         /// Tag IDs (comma-separated)
         #[arg(long)]
@@ -183,6 +194,10 @@ pub enum TodoAction {
     },
     /// List todos
     List {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Filter by status
         #[arg(long)]
         status: Option<String>,
@@ -201,6 +216,10 @@ pub enum TodoAction {
     },
     /// Get todo details
     Get {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Todo ID
         id: i64,
     },
@@ -208,6 +227,11 @@ pub enum TodoAction {
     Update {
         /// Todo ID
         id: i64,
+
+        /// Workspace ID (project_directories.id) the todo currently belongs to.
+        /// v1 路由把 workspace 嵌入 URL；要切换 workspace 请用 --stdin 传 body.workspace_id。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
 
         /// New title
         #[arg(long)]
@@ -233,10 +257,6 @@ pub enum TodoAction {
         #[arg(long)]
         executor: Option<String>,
 
-        /// New working directory ID (project_directories.id)
-        #[arg(long = "workspace-id")]
-        workspace_id: Option<i64>,
-
         /// New tag IDs (comma-separated)
         #[arg(long)]
         tags: Option<String>,
@@ -247,11 +267,19 @@ pub enum TodoAction {
     },
     /// Delete todo
     Delete {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Todo ID
         id: i64,
     },
     /// Execute todo
     Execute {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Todo ID
         id: i64,
 
@@ -270,11 +298,19 @@ pub enum TodoAction {
     },
     /// Stop todo execution
     Stop {
-        /// Todo ID
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
+        /// Execution record ID（v1 路由把 record_id 嵌入 URL，旧版的 todo_id body 字段已废弃）
         id: i64,
     },
     /// Get todo execution stats
     Stats {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Todo ID
         id: i64,
     },
@@ -289,6 +325,10 @@ pub enum TodoAction {
 pub enum ExecutionAction {
     /// List execution records for a todo
     List {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Todo ID
         todo_id: i64,
 
@@ -306,11 +346,19 @@ pub enum ExecutionAction {
     },
     /// Get execution record details
     Get {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Execution record ID
         id: i64,
     },
     /// Resume a conversation from an execution record
     Resume {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Execution record ID
         id: i64,
 
@@ -347,18 +395,26 @@ pub enum TagAction {
 pub enum LoopAction {
     /// List all loops
     List {
-        /// Filter by workspace ID (unique key; use --workspace-id instead of path
-        /// since path is not unique across project_directories).
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL；
+        /// 不再是可选 filter，而是必填 URL 段（旧版跨 workspace 列表能力已下线）。
         #[arg(long = "workspace-id")]
-        workspace_id: Option<i64>,
+        workspace_id: i64,
     },
     /// Get loop details
     Get {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Loop ID
         id: i64,
     },
     /// Update loop
     Update {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Loop ID
         id: i64,
 
@@ -376,16 +432,28 @@ pub enum LoopAction {
     },
     /// Delete loop
     Delete {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Loop ID
         id: i64,
     },
     /// Stop a loop (pause all cron triggers)
     Stop {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Loop ID
         id: i64,
     },
     /// Get loop execution stats
     Stats {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Loop ID
         id: i64,
 
@@ -395,6 +463,10 @@ pub enum LoopAction {
     },
     /// Execute loop
     Execute {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Loop ID
         id: i64,
 
@@ -416,6 +488,10 @@ pub enum LoopAction {
 pub enum LoopExecutionAction {
     /// List execution records for a loop
     List {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
         /// Loop ID
         loop_id: i64,
 
@@ -429,12 +505,28 @@ pub enum LoopExecutionAction {
     },
     /// Get execution details
     Get {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
+        /// Loop ID（v1 路径 /workspaces/{ws}/loops/{loop_id}/executions/{eid} 必填）
+        #[arg(long = "loop-id")]
+        loop_id: i64,
+
         /// Execution ID
         execution_id: i64,
     },
     /// Show the blackboard (accumulated step conclusions) for a loop execution.
     /// 默认输出 JSON（AI/脚本友好）；加 --human 输出黑板视图（人眼友好）。
     Blackboard {
+        /// Workspace ID (project_directories.id). v1 路由要求 workspace 嵌入 URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+
+        /// Loop ID（v1 路径 /workspaces/{ws}/loops/{loop_id}/executions/{eid} 必填）
+        #[arg(long = "loop-id")]
+        loop_id: i64,
+
         /// Execution ID
         execution_id: i64,
 
@@ -511,7 +603,7 @@ pub async fn run_command(cli: &Cli) -> Result<()> {
         Commands::Todo { action } => handle_todo(&client, action, &cli.output, &cli.fields).await?,
         Commands::Loop { action } => handle_loop(&client, action, &cli.output, &cli.fields).await?,
         Commands::Tag { action } => handle_tag(&client, action, &cli.output, &cli.fields).await?,
-        Commands::Stats => handle_stats(&client, &cli.output, &cli.fields).await?,
+        Commands::Stats { workspace_id } => handle_stats(&client, *workspace_id, &cli.output, &cli.fields).await?,
         Commands::Blackboard { action } => handle_blackboard(&client, action, &cli.output, &cli.fields).await?,
         Commands::Workspace { action } => handle_workspace(&client, action, &cli.output, &cli.fields).await?,
     }
@@ -529,6 +621,9 @@ async fn handle_todo(
 ) -> Result<()> {
     match action {
         TodoAction::Create { title, prompt, file, stdin, executor, workspace_id, tags, schedule } => {
+            // workspace_id 现在是必填（i64，不再 Option），从 clap 直接拿；
+            // stdin 模式下若 JSON 也带 workspace_id，以命令行参数为准（更显式）。
+            let ws_id = *workspace_id;
             let mut req = if *stdin {
                 // Read from stdin
                 let value = read_stdin_json()?;
@@ -548,9 +643,8 @@ async fn handle_todo(
                         acceptance_criteria: value.get("acceptance_criteria").and_then(|v| v.as_str()).map(|s| s.to_string()),
                         auto_review_enabled: value.get("auto_review_enabled").and_then(|v| v.as_bool()),
                         webhook_enabled: None,
-                        workspace_id: value.get("workspace_id").and_then(|v| v.as_i64())
-                            .or(*workspace_id)
-                            .unwrap_or(0),
+                        // URL 已经带 workspace，body 字段以 CLI 参数为准
+                        workspace_id: ws_id,
                         action_type: None,
                         action_key: None,
                         model: None,
@@ -576,7 +670,7 @@ async fn handle_todo(
                     acceptance_criteria: None,
                     webhook_enabled: None,
                     auto_review_enabled: None,
-                    workspace_id: workspace_id.ok_or_else(|| anyhow::anyhow!("--workspace-id is required"))?,
+                    workspace_id: ws_id,
                     action_type: None,
                     action_key: None,
                     model: None,
@@ -591,16 +685,13 @@ async fn handle_todo(
                 }
             }
 
-            // stdin 闭包不能 `?`，这里做统一的 fail-fast：workspace_id=0 表示上游未传
-            if req.workspace_id == 0 {
-                // anyhow::anyhow! 已经返回 anyhow::Error，.into() 是多余转换
-                return Err(anyhow::anyhow!("workspace_id is required (pass --workspace-id or include in stdin JSON)"));
-            }
-
-            let resp: ClientResponse<Todo> = client.post("/todos", &req).await?;
+            // v1: workspace 嵌入 URL 路径段，body 的 workspace_id 仅作冗余字段。
+            // body 仍保留是为了兼容后端 CreateTodoRequest 解析（handler 也读 body.workspace_id）。
+            let path = format!("{}/todos", ws_prefix(ws_id));
+            let resp: ClientResponse<Todo> = client.post(&path, &req).await?;
             print_response(&resp, output, fields)?;
         }
-        TodoAction::List { status, tag, running, search } => {
+        TodoAction::List { workspace_id, status, tag, running, search } => {
             let mut query_params = Vec::new();
 
             if let Some(s) = status {
@@ -613,10 +704,11 @@ async fn handle_todo(
                 query_params.push("running=true".to_string());
             }
 
+            // v1: 列表也按 workspace 隔离，URL 前缀带 ws。
             let path = if query_params.is_empty() {
-                "/todos".to_string()
+                format!("{}/todos", ws_prefix(*workspace_id))
             } else {
-                format!("/todos?{}", query_params.join("&"))
+                format!("{}/todos?{}", ws_prefix(*workspace_id), query_params.join("&"))
             };
 
             let resp: ClientResponse<Vec<Todo>> = client.get(&path).await?;
@@ -642,11 +734,13 @@ async fn handle_todo(
 
             print_response(&resp, output, fields)?;
         }
-        TodoAction::Get { id } => {
-            let resp: ClientResponse<Todo> = client.get(&format!("/todos/{}", id)).await?;
+        TodoAction::Get { workspace_id, id } => {
+            // v1: GET /workspaces/{ws}/todos/{id}
+            let path = format!("{}/todos/{}", ws_prefix(*workspace_id), id);
+            let resp: ClientResponse<Todo> = client.get(&path).await?;
             print_response(&resp, output, fields)?;
         }
-        TodoAction::Update { id, title, prompt, file, stdin, status, executor, workspace_id, tags, schedule } => {
+        TodoAction::Update { id, workspace_id, title, prompt, file, stdin, status, executor, tags, schedule } => {
             let mut req = if *stdin {
                 read_stdin_json()?
             } else {
@@ -660,7 +754,6 @@ async fn handle_todo(
                     "prompt": prompt_content,
                     "status": status,
                     "executor": executor,
-                    "workspace_id": workspace_id,
                 })
             };
 
@@ -669,8 +762,6 @@ async fn handle_todo(
             if let Some(p) = prompt { req["prompt"] = p.clone().into(); }
             if let Some(s) = status { req["status"] = s.clone().into(); }
             if let Some(e) = executor { req["executor"] = e.clone().into(); }
-            // w 已经是 i64 类型，无需再 as i64 转换
-            if let Some(w) = workspace_id { req["workspace_id"] = Value::from(*w); }
             if let Some(t) = tags {
                 let tag_ids: Vec<i64> = t.split(',').filter_map(|s| s.trim().parse().ok()).collect();
                 req["tag_ids"] = tag_ids.into();
@@ -680,14 +771,19 @@ async fn handle_todo(
                 req["scheduler_config"] = if s.is_empty() { Value::Null } else { s.clone().into() };
             }
 
-            let resp: ClientResponse<Todo> = client.put(&format!("/todos/{}", id), &req).await?;
+            // v1: PUT /workspaces/{ws}/todos/{id}。workspace_id 不再放进 body（移除 --workspace-id 作为 body move 的语义）；
+            // 如需切换 workspace，请用 --stdin 在 body 中带 workspace_id 字段。
+            let path = format!("{}/todos/{}", ws_prefix(*workspace_id), id);
+            let resp: ClientResponse<Todo> = client.put(&path, &req).await?;
             print_response(&resp, output, fields)?;
         }
-        TodoAction::Delete { id } => {
-            let resp: ClientResponse<()> = client.delete(&format!("/todos/{}", id)).await?;
+        TodoAction::Delete { workspace_id, id } => {
+            // v1: DELETE /workspaces/{ws}/todos/{id}
+            let path = format!("{}/todos/{}", ws_prefix(*workspace_id), id);
+            let resp: ClientResponse<()> = client.delete(&path).await?;
             print_response(&resp, output, fields)?;
         }
-        TodoAction::Execute { id, message, executor, params } => {
+        TodoAction::Execute { workspace_id, id, message, executor, params } => {
             let params: Option<std::collections::HashMap<String, String>> = params.as_ref().map(|vec| {
                 vec.iter().cloned().collect()
             });
@@ -698,16 +794,22 @@ async fn handle_todo(
                 model: None,
                 params,
             };
-            let resp: ClientResponse<Value> = client.post("/execute", &req).await?;
+            // v1: 触发执行改走 executions 域，POST /workspaces/{ws}/executions
+            let path = format!("{}/executions", ws_prefix(*workspace_id));
+            let resp: ClientResponse<Value> = client.post(&path, &req).await?;
             print_response(&resp, output, fields)?;
         }
-        TodoAction::Stop { id } => {
-            let req = serde_json::json!({ "todo_id": id });
-            let resp: ClientResponse<()> = client.post("/execute/stop", &req).await?;
+        TodoAction::Stop { workspace_id, id } => {
+            // v1: stop 改用 record_id 路径参数（原 body todo_id 已废弃），
+            // 路径为 POST /workspaces/{ws}/executions/{record_id}/stop。
+            let path = format!("{}/executions/{}/stop", ws_prefix(*workspace_id), id);
+            let resp: ClientResponse<()> = client.post(&path, &serde_json::Value::Null).await?;
             print_response(&resp, output, fields)?;
         }
-        TodoAction::Stats { id } => {
-            let resp: ClientResponse<ExecutionSummary> = client.get(&format!("/todos/{}/summary", id)).await?;
+        TodoAction::Stats { workspace_id, id } => {
+            // v1: GET /workspaces/{ws}/todos/{id}/summary
+            let path = format!("{}/todos/{}/summary", ws_prefix(*workspace_id), id);
+            let resp: ClientResponse<ExecutionSummary> = client.get(&path).await?;
             print_response(&resp, output, fields)?;
         }
         TodoAction::Execution { action } => {
@@ -724,9 +826,11 @@ async fn handle_execution(
     fields: &Option<String>,
 ) -> Result<()> {
     match action {
-        ExecutionAction::List { todo_id, status, page, limit } => {
+        ExecutionAction::List { workspace_id, todo_id, status, page, limit } => {
+            // v1: GET /workspaces/{ws}/executions?todo_id=...（旧 /execution-records 路径已废）
             let path = format!(
-                "/execution-records?todo_id={}&page={}&limit={}{}",
+                "{}/executions?todo_id={}&page={}&limit={}{}",
+                ws_prefix(*workspace_id),
                 todo_id,
                 page,
                 limit,
@@ -735,13 +839,17 @@ async fn handle_execution(
             let resp: ClientResponse<ExecutionRecordsPage> = client.get(&path).await?;
             print_response(&resp, output, fields)?;
         }
-        ExecutionAction::Get { id } => {
-            let resp: ClientResponse<ExecutionRecord> = client.get(&format!("/execution-records/{}", id)).await?;
+        ExecutionAction::Get { workspace_id, id } => {
+            // v1: GET /workspaces/{ws}/executions/{id}
+            let path = format!("{}/executions/{}", ws_prefix(*workspace_id), id);
+            let resp: ClientResponse<ExecutionRecord> = client.get(&path).await?;
             print_response(&resp, output, fields)?;
         }
-        ExecutionAction::Resume { id, message } => {
+        ExecutionAction::Resume { workspace_id, id, message } => {
             let req = serde_json::json!({ "message": message });
-            let resp: ClientResponse<Value> = client.post(&format!("/execution-records/{}/resume", id), &req).await?;
+            // v1: POST /workspaces/{ws}/executions/{id}/resume
+            let path = format!("{}/executions/{}/resume", ws_prefix(*workspace_id), id);
+            let resp: ClientResponse<Value> = client.post(&path, &req).await?;
             print_response(&resp, output, fields)?;
         }
     }
@@ -749,6 +857,8 @@ async fn handle_execution(
 }
 
 // ============== Tag Handlers ==============
+// Tag 是全局资源（无 workspace_id 列），v1 路由直接挂 /api/v1/tags，
+// 不嵌 workspace 前缀；client.rs 会自动补 /api/v1。
 
 async fn handle_tag(
     client: &ApiClient,
@@ -758,6 +868,8 @@ async fn handle_tag(
 ) -> Result<()> {
     match action {
         TagAction::List => {
+            // v1: GET /tags（axum 在 nest("/api/v1/tags") + .route("/") 下，
+            // 无尾斜杠的 /api/v1/tags 也能命中根路由）
             let resp: ClientResponse<Vec<Tag>> = client.get("/tags").await?;
             print_response(&resp, output, fields)?;
         }
@@ -766,10 +878,12 @@ async fn handle_tag(
                 name: name.clone(),
                 color: color.clone(),
             };
+            // v1: POST /tags（全局资源）
             let resp: ClientResponse<Tag> = client.post("/tags", &req).await?;
             print_response(&resp, output, fields)?;
         }
         TagAction::Delete { id } => {
+            // v1: DELETE /tags/{id}
             let resp: ClientResponse<()> = client.delete(&format!("/tags/{}", id)).await?;
             print_response(&resp, output, fields)?;
         }
@@ -781,10 +895,13 @@ async fn handle_tag(
 
 async fn handle_stats(
     client: &ApiClient,
+    workspace_id: i64,
     output: &OutputFormat,
     fields: &Option<String>,
 ) -> Result<()> {
-    let resp: ClientResponse<DashboardStats> = client.get("/dashboard-stats").await?;
+    // v1: dashboard 改为 workspace-scoped，GET /workspaces/{ws}/stats/dashboard。
+    let path = format!("{}/stats/dashboard", ws_prefix(workspace_id));
+    let resp: ClientResponse<DashboardStats> = client.get(&path).await?;
     print_response(&resp, output, fields)?;
     Ok(())
 }
@@ -801,14 +918,16 @@ async fn handle_blackboard(
         BlackboardAction::Wiki { action, workspace_id } => {
             match action {
                 WikiAction::List => {
-                    let path = format!("/workspaces/{}/wiki/files", workspace_id);
+                    // v1: wiki 收敛到 blackboard 域，GET /workspaces/{ws}/blackboard/wiki/files
+                    let path = format!("{}/blackboard/wiki/files", ws_prefix(*workspace_id));
                     let resp: ClientResponse<serde_json::Value> = client.get(&path).await?;
                     print_response(&resp, output, fields)?;
                 }
                 WikiAction::Get { slug } => {
                     // slug 可能包含中文或特殊字符，必须 percent-encode 后才能安全放入 URL 路径
                     let encoded = percent_encode_slug(slug);
-                    let path = format!("/workspaces/{}/wiki/files/{}", workspace_id, encoded);
+                    // v1: 同样嵌在 blackboard 域下
+                    let path = format!("{}/blackboard/wiki/files/{}", ws_prefix(*workspace_id), encoded);
                     let resp: ClientResponse<serde_json::Value> = client.get(&path).await?;
                     print_response(&resp, output, fields)?;
                 }
@@ -836,7 +955,8 @@ async fn handle_workspace(
     }
 }
 
-/// 调 `GET /api/project-directories` 拉全部已注册工作空间。
+/// 调 `GET /api/v1/project-directories` 拉全部已注册工作空间。
+/// 全局资源，路径不嵌 workspace。
 async fn list_workspaces(
     client: &ApiClient,
     output: &OutputFormat,
@@ -847,8 +967,9 @@ async fn list_workspaces(
     Ok(())
 }
 
-/// 调 `POST /api/project-directories` 注册一个新工作空间。
+/// 调 `POST /api/v1/project-directories` 注册一个新工作空间。
 /// body 结构与 handlers/project_directory.rs::CreateProjectDirectoryRequest 对齐。
+/// 全局资源，路径不嵌 workspace。
 async fn create_workspace(
     client: &ApiClient,
     path: &str,
@@ -876,19 +997,18 @@ async fn handle_loop(
 ) -> Result<()> {
     match action {
         LoopAction::List { workspace_id } => {
-            let path = if let Some(wid) = workspace_id {
-                format!("/loops?workspace_id={}", wid)
-            } else {
-                "/loops".to_string()
-            };
+            // v1: List 必带 workspace 嵌入 URL（旧的可选 workspace_id 过滤已废弃）。
+            let path = format!("{}/loops", ws_prefix(*workspace_id));
             let resp: ClientResponse<Vec<LoopDto>> = client.get(&path).await?;
             print_response(&resp, output, fields)?;
         }
-        LoopAction::Get { id } => {
-            let resp: ClientResponse<LoopDto> = client.get(&format!("/loops/{}", id)).await?;
+        LoopAction::Get { workspace_id, id } => {
+            // v1: GET /workspaces/{ws}/loops/{id}
+            let path = format!("{}/loops/{}", ws_prefix(*workspace_id), id);
+            let resp: ClientResponse<LoopDto> = client.get(&path).await?;
             print_response(&resp, output, fields)?;
         }
-        LoopAction::Update { id, name, description, status } => {
+        LoopAction::Update { workspace_id, id, name, description, status } => {
             // 构建部分更新 JSON，只包含提供的字段
             let mut obj = serde_json::Map::new();
             if let Some(n) = name {
@@ -901,31 +1021,33 @@ async fn handle_loop(
                 obj.insert("status".to_string(), serde_json::Value::String(s.to_string()));
             }
             let req = serde_json::Value::Object(obj);
-            let resp: ClientResponse<LoopDto> = client.put(
-                &format!("/loops/{}", id),
-                &req,
-            ).await?;
+            // v1: PUT /workspaces/{ws}/loops/{id}
+            let path = format!("{}/loops/{}", ws_prefix(*workspace_id), id);
+            let resp: ClientResponse<LoopDto> = client.put(&path, &req).await?;
             print_response(&resp, output, fields)?;
         }
-        LoopAction::Delete { id } => {
-            let resp: ClientResponse<()> = client.delete(&format!("/loops/{}", id)).await?;
+        LoopAction::Delete { workspace_id, id } => {
+            // v1: DELETE /workspaces/{ws}/loops/{id}
+            let path = format!("{}/loops/{}", ws_prefix(*workspace_id), id);
+            let resp: ClientResponse<()> = client.delete(&path).await?;
             print_response(&resp, output, fields)?;
         }
-        LoopAction::Stop { id } => {
+        LoopAction::Stop { workspace_id, id } => {
             // Pause the loop by disabling all its triggers
             let req = serde_json::json!({ "status": "paused" });
-            let resp: ClientResponse<LoopDto> = client.put(
-                &format!("/loops/{}/status", id),
-                &req,
-            ).await?;
+            // v1: PUT /workspaces/{ws}/loops/{id}/status
+            let path = format!("{}/loops/{}/status", ws_prefix(*workspace_id), id);
+            let resp: ClientResponse<LoopDto> = client.put(&path, &req).await?;
             print_response(&resp, output, fields)?;
         }
-        LoopAction::Stats { id, recent } => {
+        LoopAction::Stats { workspace_id, id, recent } => {
             // Get loop details with recent executions combined into one response
-            let resp: ClientResponse<LoopDto> = client.get(&format!("/loops/{}", id)).await?;
+            // v1: 两次请求都走 /workspaces/{ws}/loops/...
+            let base = format!("{}/loops/{}", ws_prefix(*workspace_id), id);
+            let resp: ClientResponse<LoopDto> = client.get(&base).await?;
             let execs_resp: ClientResponse<serde_json::Value> = client.get(&format!(
-                "/loops/{}/executions?page=1&limit={}",
-                id, recent
+                "{}/executions?page=1&limit={}",
+                base, recent
             )).await?;
             // Combine loop info and recent executions into a single JSON object
             let combined = serde_json::json!({
@@ -939,45 +1061,47 @@ async fn handle_loop(
             };
             print_response(&final_resp, output, fields)?;
         }
-        LoopAction::Execute { id, params } => {
+        LoopAction::Execute { workspace_id, id, params } => {
             let params_map: std::collections::HashMap<String, String> = params
                 .as_ref()
                 .map(|vec| vec.iter().cloned().collect())
                 .unwrap_or_default();
             let req = TriggerLoopRequest { params: params_map };
-            let resp: ClientResponse<serde_json::Value> = client.post(
-                &format!("/loops/{}/trigger", id),
-                &req,
-            ).await?;
+            // v1: POST /workspaces/{ws}/loops/{id}/trigger
+            let path = format!("{}/loops/{}/trigger", ws_prefix(*workspace_id), id);
+            let resp: ClientResponse<serde_json::Value> = client.post(&path, &req).await?;
             print_response(&resp, output, fields)?;
         }
         LoopAction::Execution { action } => {
             match action {
-                LoopExecutionAction::List { loop_id, page, limit } => {
+                LoopExecutionAction::List { workspace_id, loop_id, page, limit } => {
+                    // v1: GET /workspaces/{ws}/loops/{loop_id}/executions
                     let path = format!(
-                        "/loops/{}/executions?page={}&limit={}",
-                        loop_id, page, limit
+                        "{}/loops/{}/executions?page={}&limit={}",
+                        ws_prefix(*workspace_id), loop_id, page, limit
                     );
                     let resp: ClientResponse<serde_json::Value> = client.get(&path).await?;
                     print_response(&resp, output, fields)?;
                 }
-                LoopExecutionAction::Get { execution_id } => {
-                    // Get execution results by execution ID directly
-                    // 注意: ApiClient 已经自动添加 /api 前缀，所以路径不要带 /api
-                    let resp: ClientResponse<serde_json::Value> = client.get(&format!(
-                        "/loop-executions/{}",
-                        execution_id
-                    )).await?;
+                LoopExecutionAction::Get { workspace_id, loop_id, execution_id } => {
+                    // v1 后端没有 /loop-executions/{eid} 顶层路由，
+                    // 必须按 /workspaces/{ws}/loops/{loop_id}/executions/{eid} 访问。
+                    let path = format!(
+                        "{}/loops/{}/executions/{}",
+                        ws_prefix(*workspace_id), loop_id, execution_id
+                    );
+                    let resp: ClientResponse<serde_json::Value> = client.get(&path).await?;
                     print_response(&resp, output, fields)?;
                 }
-                LoopExecutionAction::Blackboard { execution_id, human } => {
-                    // 复用 get_execution_by_id handler 返回的 LoopExecutionDetail,
+                LoopExecutionAction::Blackboard { workspace_id, loop_id, execution_id, human } => {
+                    // 复用 v1 get_execution_v1 handler 返回的 LoopExecutionDetail,
                     // 它已经按 sequence_index 升序返回 step_executions。
                     // 不新增 API 端点 — 黑板视图本质就是 step_executions 的渲染。
-                    let resp: ClientResponse<serde_json::Value> = client.get(&format!(
-                        "/loop-executions/{}",
-                        execution_id
-                    )).await?;
+                    let path = format!(
+                        "{}/loops/{}/executions/{}",
+                        ws_prefix(*workspace_id), loop_id, execution_id
+                    );
+                    let resp: ClientResponse<serde_json::Value> = client.get(&path).await?;
                     if resp.code != 0 {
                         // 与 print_response 一致:错误码非 0 时抛 anyhow
                         return Err(anyhow::anyhow!("API error {}: {}", resp.code, resp.message));
@@ -1366,19 +1490,22 @@ mod tests {
 
     #[test]
     fn test_cli_parse_raw_output() {
-        let cli = Cli::try_parse_from(["ntd", "-o", "raw", "todo", "list"]).unwrap();
+        // v1: list 需要 --workspace-id（workspace 嵌入 URL）
+        let cli = Cli::try_parse_from(["ntd", "-o", "raw", "todo", "list", "--workspace-id", "1"]).unwrap();
         assert_eq!(cli.output, OutputFormat::Raw);
     }
 
     #[test]
     fn test_cli_parse_fields() {
-        let cli = Cli::try_parse_from(["ntd", "-f", "id,title", "todo", "list"]).unwrap();
+        // v1: list 需要 --workspace-id
+        let cli = Cli::try_parse_from(["ntd", "-f", "id,title", "todo", "list", "--workspace-id", "1"]).unwrap();
         assert_eq!(cli.fields, Some("id,title".to_string()));
     }
 
     #[test]
     fn test_cli_parse_search() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "list", "-s", "rust"]).unwrap();
+        // v1: list 需要 --workspace-id
+        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--workspace-id", "1", "-s", "rust"]).unwrap();
         match cli.command {
             Commands::Todo { action: TodoAction::List { search, .. } } => {
                 assert_eq!(search, Some("rust".to_string()));
@@ -1389,7 +1516,8 @@ mod tests {
 
     #[test]
     fn test_cli_parse_stdin_create() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "create", "--stdin"]).unwrap();
+        // v1: --workspace-id 必填
+        let cli = Cli::try_parse_from(["ntd", "todo", "create", "--workspace-id", "1", "--stdin"]).unwrap();
         match cli.command {
             Commands::Todo { action: TodoAction::Create { stdin, .. } } => {
                 assert!(stdin);
@@ -1400,7 +1528,8 @@ mod tests {
 
     #[test]
     fn test_cli_parse_stdin_update() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "update", "1", "--stdin"]).unwrap();
+        // v1: --workspace-id 必填
+        let cli = Cli::try_parse_from(["ntd", "todo", "update", "--workspace-id", "1", "1", "--stdin"]).unwrap();
         match cli.command {
             Commands::Todo { action: TodoAction::Update { stdin, .. } } => {
                 assert!(stdin);
@@ -1412,7 +1541,8 @@ mod tests {
     #[test]
     fn test_cli_parse_create_without_title_requires_stdin() {
         // Creating without title and without --stdin should still parse (validation is at runtime)
-        let cli = Cli::try_parse_from(["ntd", "todo", "create"]).unwrap();
+        // v1: --workspace-id 必填（CLI 解析阶段强制）
+        let cli = Cli::try_parse_from(["ntd", "todo", "create", "--workspace-id", "1"]).unwrap();
         match cli.command {
             Commands::Todo { action: TodoAction::Create { title, stdin, .. } } => {
                 assert!(title.is_none());
@@ -1427,6 +1557,7 @@ mod tests {
         let cli = Cli::try_parse_from([
             "ntd", "-o", "raw", "-f", "id,title,status",
             "todo", "list",
+            "--workspace-id", "1",
             "--status", "pending",
             "--search", "bug",
         ]).unwrap();
@@ -1470,9 +1601,10 @@ mod tests {
 
     #[test]
     fn test_cli_parse_execution_resume() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "execution", "resume", "42"]).unwrap();
+        // v1: resume 路径嵌入 workspace，必填 --workspace-id
+        let cli = Cli::try_parse_from(["ntd", "todo", "execution", "resume", "--workspace-id", "1", "42"]).unwrap();
         match cli.command {
-            Commands::Todo { action: TodoAction::Execution { action: ExecutionAction::Resume { id, message } } } => {
+            Commands::Todo { action: TodoAction::Execution { action: ExecutionAction::Resume { id, message, .. } } } => {
                 assert_eq!(id, 42);
                 assert!(message.is_none());
             }
@@ -1482,9 +1614,10 @@ mod tests {
 
     #[test]
     fn test_cli_parse_execution_resume_with_message() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "execution", "resume", "42", "-m", "fix the bug"]).unwrap();
+        // v1: 同上，--workspace-id 必填
+        let cli = Cli::try_parse_from(["ntd", "todo", "execution", "resume", "--workspace-id", "1", "42", "-m", "fix the bug"]).unwrap();
         match cli.command {
-            Commands::Todo { action: TodoAction::Execution { action: ExecutionAction::Resume { id, message } } } => {
+            Commands::Todo { action: TodoAction::Execution { action: ExecutionAction::Resume { id, message, .. } } } => {
                 assert_eq!(id, 42);
                 assert_eq!(message, Some("fix the bug".to_string()));
             }
@@ -1498,9 +1631,13 @@ mod tests {
     fn test_cli_parse_loop_execution_blackboard() {
         // 校验命令行解析：ntd loop execution blackboard 42
         // 默认行为: JSON 输出 (human=false)
-        let cli = Cli::try_parse_from(["ntd", "loop", "execution", "blackboard", "42"]).unwrap();
+        // v1: --workspace-id 和 --loop-id 必填（v1 路径 /workspaces/{ws}/loops/{loop_id}/executions/{eid}）
+        let cli = Cli::try_parse_from([
+            "ntd", "loop", "execution", "blackboard",
+            "--workspace-id", "1", "--loop-id", "2", "42",
+        ]).unwrap();
         match cli.command {
-            Commands::Loop { action: LoopAction::Execution { action: LoopExecutionAction::Blackboard { execution_id, human } } } => {
+            Commands::Loop { action: LoopAction::Execution { action: LoopExecutionAction::Blackboard { execution_id, human, .. } } } => {
                 assert_eq!(execution_id, 42);
                 assert!(!human, "默认应输出 JSON，human=false");
             }
@@ -1511,9 +1648,13 @@ mod tests {
     #[test]
     fn test_cli_parse_loop_execution_blackboard_human() {
         // --human 开关: 启用人类可读黑板视图
-        let cli = Cli::try_parse_from(["ntd", "loop", "execution", "blackboard", "42", "--human"]).unwrap();
+        // v1: 同上，必填 --workspace-id + --loop-id
+        let cli = Cli::try_parse_from([
+            "ntd", "loop", "execution", "blackboard",
+            "--workspace-id", "1", "--loop-id", "2", "42", "--human",
+        ]).unwrap();
         match cli.command {
-            Commands::Loop { action: LoopAction::Execution { action: LoopExecutionAction::Blackboard { execution_id, human } } } => {
+            Commands::Loop { action: LoopAction::Execution { action: LoopExecutionAction::Blackboard { execution_id, human, .. } } } => {
                 assert_eq!(execution_id, 42);
                 assert!(human, "--human 应启用人类视图");
             }

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -918,16 +918,16 @@ async fn handle_blackboard(
         BlackboardAction::Wiki { action, workspace_id } => {
             match action {
                 WikiAction::List => {
-                    // v1: wiki 收敛到 blackboard 域，GET /workspaces/{ws}/blackboard/wiki/files
-                    let path = format!("{}/blackboard/wiki/files", ws_prefix(*workspace_id));
+                    // v1: wiki 独立于 blackboard 域，GET /workspaces/{ws}/wiki/files
+                    let path = format!("{}/wiki/files", ws_prefix(*workspace_id));
                     let resp: ClientResponse<serde_json::Value> = client.get(&path).await?;
                     print_response(&resp, output, fields)?;
                 }
                 WikiAction::Get { slug } => {
                     // slug 可能包含中文或特殊字符，必须 percent-encode 后才能安全放入 URL 路径
                     let encoded = percent_encode_slug(slug);
-                    // v1: 同样嵌在 blackboard 域下
-                    let path = format!("{}/blackboard/wiki/files/{}", ws_prefix(*workspace_id), encoded);
+                    // v1: wiki 独立域，不与 blackboard 嵌套
+                    let path = format!("{}/wiki/files/{}", ws_prefix(*workspace_id), encoded);
                     let resp: ClientResponse<serde_json::Value> = client.get(&path).await?;
                     print_response(&resp, output, fields)?;
                 }

--- a/backend/src/db/entity/quick_buttons.rs
+++ b/backend/src/db/entity/quick_buttons.rs
@@ -1,20 +1,22 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-/// 快捷话术按钮表：button_name（全局唯一）+ prompt_text。
+/// 快捷话术按钮表：button_name + prompt_text，按 workspace 隔离。
 ///
-/// 全局共享（无 workspace 维度）。用于帖子流回复框上方的自定义快捷按钮：
-/// 点击把 prompt_text 填入回复输入框，用户确认后走 resume 继续会话。
+/// 用于帖子流回复框上方的自定义快捷按钮：点击把 prompt_text 填入回复输入框，
+/// 用户确认后走 resume 继续会话。
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "quick_buttons")]
 pub struct Model {
     #[sea_orm(primary_key)]
     /// 自增主键
     pub id: i64,
-    /// 按钮显示名称，全局唯一（DB UNIQUE 约束 + handler 预检双重保证）
+    /// 按钮显示名称，同一 workspace 内唯一
     pub button_name: String,
     /// 点击按钮后填入回复输入框的预设话术
     pub prompt_text: String,
+    /// 所属工作空间
+    pub workspace_id: Option<i64>,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -1424,12 +1424,22 @@ impl Database {
         &self,
         hours: Option<u32>,
     ) -> Result<crate::models::LoopStats, sea_orm::DbErr> {
+        self.get_loop_stats_for_workspace(None, hours).await
+    }
+
+    /// GET /api/v1/workspaces/{ws}/loops/stats 的数据来源:按 workspace 聚合 loop 统计。
+    /// workspace_id=None 时退化为全库聚合,与 `get_loop_stats` 等价。
+    pub async fn get_loop_stats_for_workspace(
+        &self,
+        workspace_id: Option<i64>,
+        hours: Option<u32>,
+    ) -> Result<crate::models::LoopStats, sea_orm::DbErr> {
         // 4 条查询互不依赖,并行执行;counts 查 loops 表(无时间窗),其余按 hours 过滤。
         let (counts, exec_summary, trigger_dist, token_totals) = tokio::try_join!(
-            self.fetch_loop_counts(),
-            self.fetch_loop_execution_summary(hours),
-            self.fetch_loop_trigger_distribution(hours),
-            self.fetch_loop_token_totals(hours),
+            self.fetch_loop_counts(workspace_id),
+            self.fetch_loop_execution_summary(workspace_id, hours),
+            self.fetch_loop_trigger_distribution(workspace_id, hours),
+            self.fetch_loop_token_totals(workspace_id, hours),
         )?;
         Ok(crate::models::LoopStats {
             total_loops: counts.0,
@@ -1445,15 +1455,24 @@ impl Database {
     }
 
     /// loop 总数与活跃数(来自 loops 配置表,不受时间窗影响)。active = status='enabled'。
-    async fn fetch_loop_counts(&self) -> Result<(i64, i64), sea_orm::DbErr> {
+    async fn fetch_loop_counts(
+        &self,
+        workspace_id: Option<i64>,
+    ) -> Result<(i64, i64), sea_orm::DbErr> {
         use sea_orm::{ConnectionTrait, DbBackend, Statement};
-        let sql = "SELECT \
+        let ws_filter = workspace_id
+            .map(|id| format!("WHERE workspace_id = {}", id))
+            .unwrap_or_default();
+        let sql = format!(
+            "SELECT \
             COUNT(*) AS total, \
             COALESCE(SUM(CASE WHEN status='enabled' THEN 1 ELSE 0 END), 0) AS active \
-            FROM loops";
+            FROM loops {}",
+            ws_filter
+        );
         let row = self
             .conn
-            .query_one(Statement::from_string(DbBackend::Sqlite, sql.to_string()))
+            .query_one(Statement::from_string(DbBackend::Sqlite, sql))
             .await?
             .ok_or_else(|| sea_orm::DbErr::RecordNotFound("loop counts returned no rows".into()))?;
         Ok((
@@ -1465,17 +1484,23 @@ impl Database {
     /// loop_executions 的总数/成功/失败(按 hours 过滤 started_at)。
     async fn fetch_loop_execution_summary(
         &self,
+        workspace_id: Option<i64>,
         hours: Option<u32>,
     ) -> Result<(i64, i64, i64), sea_orm::DbErr> {
         use sea_orm::{ConnectionTrait, DbBackend, Statement};
+        let ws_filter = workspace_id
+            .map(|id| format!("AND l.workspace_id = {}", id))
+            .unwrap_or_default();
         let sql = format!(
             "SELECT \
             COUNT(*) AS total, \
-            COALESCE(SUM(CASE WHEN status='success' THEN 1 ELSE 0 END), 0) AS success, \
-            COALESCE(SUM(CASE WHEN status='failed' THEN 1 ELSE 0 END), 0) AS failed \
-            FROM loop_executions \
-            WHERE {}",
-            Self::loop_exec_time_filter(hours, "started_at")
+            COALESCE(SUM(CASE WHEN le.status='success' THEN 1 ELSE 0 END), 0) AS success, \
+            COALESCE(SUM(CASE WHEN le.status='failed' THEN 1 ELSE 0 END), 0) AS failed \
+            FROM loop_executions le \
+            JOIN loops l ON l.id = le.loop_id \
+            WHERE {} {}",
+            Self::loop_exec_time_filter(hours, "le.started_at"),
+            ws_filter
         );
         let row = self
             .conn
@@ -1492,20 +1517,26 @@ impl Database {
     /// 触发类型分布(按 loop_executions.trigger_type GROUP BY)。
     async fn fetch_loop_trigger_distribution(
         &self,
+        workspace_id: Option<i64>,
         hours: Option<u32>,
     ) -> Result<Vec<crate::models::LoopTriggerTypeCount>, sea_orm::DbErr> {
         use sea_orm::{ConnectionTrait, DbBackend, Statement};
+        let ws_filter = workspace_id
+            .map(|id| format!("AND l.workspace_id = {}", id))
+            .unwrap_or_default();
         let sql = format!(
             "SELECT \
-            COALESCE(trigger_type, 'manual') AS trigger_type, \
+            COALESCE(le.trigger_type, 'manual') AS trigger_type, \
             COUNT(*) AS count, \
-            COALESCE(SUM(CASE WHEN status='success' THEN 1 ELSE 0 END), 0) AS success_count, \
-            COALESCE(SUM(CASE WHEN status='failed' THEN 1 ELSE 0 END), 0) AS failed_count \
-            FROM loop_executions \
-            WHERE {} \
-            GROUP BY COALESCE(trigger_type, 'manual') \
+            COALESCE(SUM(CASE WHEN le.status='success' THEN 1 ELSE 0 END), 0) AS success_count, \
+            COALESCE(SUM(CASE WHEN le.status='failed' THEN 1 ELSE 0 END), 0) AS failed_count \
+            FROM loop_executions le \
+            JOIN loops l ON l.id = le.loop_id \
+            WHERE {} {} \
+            GROUP BY COALESCE(le.trigger_type, 'manual') \
             ORDER BY count DESC",
-            Self::loop_exec_time_filter(hours, "started_at")
+            Self::loop_exec_time_filter(hours, "le.started_at"),
+            ws_filter
         );
         let rows = self
             .conn
@@ -1526,20 +1557,29 @@ impl Database {
     }
 
     /// Token 总量(经 loop_step_executions JOIN execution_records,SUM usage JSON)。
-    async fn fetch_loop_token_totals(&self, hours: Option<u32>) -> Result<(u64, u64, f64), sea_orm::DbErr> {
+    async fn fetch_loop_token_totals(
+        &self,
+        workspace_id: Option<i64>,
+        hours: Option<u32>,
+    ) -> Result<(u64, u64, f64), sea_orm::DbErr> {
         use sea_orm::{ConnectionTrait, DbBackend, Statement};
         // le.started_at 用于时间过滤;LEFT JOIN 保证无 step/record 的 execution 行不丢失,
         // 其 token 经 COALESCE 兜底为 0。
+        let ws_filter = workspace_id
+            .map(|id| format!("AND l.workspace_id = {}", id))
+            .unwrap_or_default();
         let sql = format!(
             "SELECT \
             COALESCE(SUM(COALESCE(json_extract(er.usage, '$.input_tokens'), 0)), 0) AS input_tokens, \
             COALESCE(SUM(COALESCE(json_extract(er.usage, '$.output_tokens'), 0)), 0) AS output_tokens, \
             COALESCE(SUM(COALESCE(json_extract(er.usage, '$.total_cost_usd'), 0.0)), 0.0) AS cost \
             FROM loop_executions le \
+            JOIN loops l ON l.id = le.loop_id \
             LEFT JOIN loop_step_executions lse ON lse.loop_execution_id = le.id \
             LEFT JOIN execution_records er ON er.id = lse.execution_record_id \
-            WHERE {}",
-            Self::loop_exec_time_filter(hours, "le.started_at")
+            WHERE {} {}",
+            Self::loop_exec_time_filter(hours, "le.started_at"),
+            ws_filter
         );
         let row = self
             .conn

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -27,6 +27,7 @@ mod v65;
 mod v66;
 mod v67;
 mod v68;
+mod v69;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -90,6 +91,8 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v67::V67AddExecutionRecordsAgentRuns),
         // V68 在 V67 之后：executors 加 default_model、todos 加 model，支撑「执行器/todo 级别指定执行模型」
         Box::new(v68::V68AddModelColumns),
+        // V69 在 V68 之后：quick_buttons 增加 workspace_id，实现 workspace 隔离
+        Box::new(v69::V69AddQuickButtonsWorkspaceId),
     ]
 }
 

--- a/backend/src/db/migration/v69.rs
+++ b/backend/src/db/migration/v69.rs
@@ -1,0 +1,47 @@
+//! 数据库迁移 V69：quick_buttons 增加 workspace_id 列，实现 workspace 隔离
+//!
+//! ## 背景
+//! ADR-7 路由重构后 quick_buttons 按设计应嵌套在 `/api/v1/workspaces/{ws}` 下，
+//! 因此表结构需要 workspace_id 列支撑按 workspace 查询与隔离。
+//!
+//! ## 幂等
+//! 先通过 `table_has_column` 判断列是否存在，避免重复 ADD COLUMN 报错；
+//! 存量数据默认归属到 id 最小的 project_directory（首个工作空间），保证旧数据不丢失。
+
+use async_trait::async_trait;
+
+use super::super::Database;
+use super::Migration;
+
+pub(super) struct V69AddQuickButtonsWorkspaceId;
+
+#[async_trait]
+impl Migration for V69AddQuickButtonsWorkspaceId {
+    fn version(&self) -> i64 {
+        69
+    }
+
+    fn name(&self) -> &'static str {
+        "V69AddQuickButtonsWorkspaceId"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        if !super::table_has_column(db, "quick_buttons", "workspace_id").await? {
+            db.exec("ALTER TABLE quick_buttons ADD COLUMN workspace_id INTEGER")
+                .await?;
+
+            // 把存量按钮默认归到第一个工作空间，避免旧数据变成「无主」。
+            db.exec(
+                "UPDATE quick_buttons SET workspace_id = (
+                    SELECT id FROM project_directories ORDER BY id ASC LIMIT 1
+                ) WHERE workspace_id IS NULL",
+            )
+            .await?;
+
+            tracing::info!("V69: quick_buttons 已添加 workspace_id 列并完成存量迁移");
+        } else {
+            tracing::info!("V69: quick_buttons.workspace_id 列已存在，跳过");
+        }
+        Ok(())
+    }
+}

--- a/backend/src/db/quick_button.rs
+++ b/backend/src/db/quick_button.rs
@@ -1,6 +1,6 @@
 //! 快捷话术按钮的数据库访问层
 //!
-//! 提供 quick_buttons 表的 CRUD 操作。全局共享，无 workspace 维度。
+//! 提供 quick_buttons 表的 CRUD 操作。按 workspace 隔离。
 
 use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter,
@@ -11,6 +11,7 @@ use crate::db::Database;
 /// 创建快捷按钮。调用方需先用 get_quick_button_by_name 预检重名（DB 还有 UNIQUE 兜底）。
 pub async fn create_quick_button(
     db: &Database,
+    workspace_id: i64,
     button_name: &str,
     prompt_text: &str,
 ) -> Result<i64, sea_orm::DbErr> {
@@ -21,6 +22,7 @@ pub async fn create_quick_button(
     let am = qb::ActiveModel {
         button_name: ActiveValue::Set(button_name.to_string()),
         prompt_text: ActiveValue::Set(prompt_text.to_string()),
+        workspace_id: ActiveValue::Set(Some(workspace_id)),
         created_at: ActiveValue::Set(Some(now.clone())),
         updated_at: ActiveValue::Set(Some(now)),
         ..Default::default()
@@ -30,13 +32,15 @@ pub async fn create_quick_button(
     Ok(result.id)
 }
 
-/// 获取全部快捷按钮，按创建时间升序（先加的排前面）。
+/// 获取指定 workspace 下的全部快捷按钮，按创建时间升序（先加的排前面）。
 pub async fn get_quick_buttons(
     db: &Database,
+    workspace_id: i64,
 ) -> Result<Vec<crate::db::entity::quick_buttons::Model>, sea_orm::DbErr> {
     use crate::db::entity::quick_buttons as qb;
 
     let buttons = qb::Entity::find()
+        .filter(qb::Column::WorkspaceId.eq(workspace_id))
         .order_by_asc(qb::Column::CreatedAt)
         .all(&db.conn)
         .await?;
@@ -44,14 +48,16 @@ pub async fn get_quick_buttons(
     Ok(buttons)
 }
 
-/// 按名称查找按钮（handler 重名预检用）。
+/// 按 workspace + 名称查找按钮（handler 重名预检用）。
 pub async fn get_quick_button_by_name(
     db: &Database,
+    workspace_id: i64,
     button_name: &str,
 ) -> Result<Option<crate::db::entity::quick_buttons::Model>, sea_orm::DbErr> {
     use crate::db::entity::quick_buttons as qb;
 
     let button = qb::Entity::find()
+        .filter(qb::Column::WorkspaceId.eq(workspace_id))
         .filter(qb::Column::ButtonName.eq(button_name))
         .one(&db.conn)
         .await?;
@@ -59,26 +65,44 @@ pub async fn get_quick_button_by_name(
     Ok(button)
 }
 
-/// 删除快捷按钮。
-pub async fn delete_quick_button(db: &Database, id: i64) -> Result<(), sea_orm::DbErr> {
+/// 删除快捷按钮（仅在指定 workspace 内）。
+pub async fn delete_quick_button(
+    db: &Database,
+    workspace_id: i64,
+    id: i64,
+) -> Result<(), sea_orm::DbErr> {
     use crate::db::entity::quick_buttons as qb;
 
-    qb::Entity::delete_by_id(id).exec(&db.conn).await?;
+    qb::Entity::delete(
+        qb::ActiveModel {
+            id: ActiveValue::Set(id),
+            workspace_id: ActiveValue::Set(Some(workspace_id)),
+            ..Default::default()
+        }
+        .into_active_model(),
+    )
+    .exec(&db.conn)
+    .await?;
     Ok(())
 }
 
-/// 更新快捷按钮。name/prompt 为 None 表示不改该字段；记录不存在则静默返回。
+/// 更新快捷按钮（仅在指定 workspace 内）。
+/// name/prompt 为 None 表示不改该字段；记录不存在则静默返回。
 pub async fn update_quick_button(
     db: &Database,
+    workspace_id: i64,
     id: i64,
     button_name: Option<&str>,
     prompt_text: Option<&str>,
 ) -> Result<(), sea_orm::DbErr> {
     use crate::db::entity::quick_buttons as qb;
 
-    let model = qb::Entity::find_by_id(id).one(&db.conn).await?;
+    let model = qb::Entity::find_by_id(id)
+        .filter(qb::Column::WorkspaceId.eq(workspace_id))
+        .one(&db.conn)
+        .await?;
     let Some(model) = model else {
-        // 记录不存在视作成功（幂等删除语义），避免 update 报错冒泡
+        // 记录不存在或不在该 workspace 视作成功，避免 update 报错冒泡
         return Ok(());
     };
 
@@ -108,9 +132,9 @@ mod quick_button_tests {
     #[tokio::test]
     async fn test_create_quick_button_inserts_record() {
         let db = fresh_db().await;
-        let id = create_quick_button(&db, "提取skill", "话术").await.unwrap();
+        let id = create_quick_button(&db, 1, "提取skill", "话术").await.unwrap();
         assert!(id > 0, "应返回正数 id");
-        let list = get_quick_buttons(&db).await.unwrap();
+        let list = get_quick_buttons(&db, 1).await.unwrap();
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].button_name, "提取skill");
     }
@@ -119,9 +143,9 @@ mod quick_button_tests {
     #[tokio::test]
     async fn test_get_quick_buttons_returns_ascending_by_created() {
         let db = fresh_db().await;
-        create_quick_button(&db, "第一个", "a").await.unwrap();
-        create_quick_button(&db, "第二个", "b").await.unwrap();
-        let list = get_quick_buttons(&db).await.unwrap();
+        create_quick_button(&db, 1, "第一个", "a").await.unwrap();
+        create_quick_button(&db, 1, "第二个", "b").await.unwrap();
+        let list = get_quick_buttons(&db, 1).await.unwrap();
         assert_eq!(list[0].button_name, "第一个");
         assert_eq!(list[1].button_name, "第二个");
     }
@@ -130,18 +154,18 @@ mod quick_button_tests {
     #[tokio::test]
     async fn test_get_quick_button_by_name_finds_existing() {
         let db = fresh_db().await;
-        create_quick_button(&db, "提取skill", "话术").await.unwrap();
-        assert!(get_quick_button_by_name(&db, "提取skill").await.unwrap().is_some());
-        assert!(get_quick_button_by_name(&db, "不存在").await.unwrap().is_none());
+        create_quick_button(&db, 1, "提取skill", "话术").await.unwrap();
+        assert!(get_quick_button_by_name(&db, 1, "提取skill").await.unwrap().is_some());
+        assert!(get_quick_button_by_name(&db, 1, "不存在").await.unwrap().is_none());
     }
 
     /// create_quick_button：同名重复插入触发 UNIQUE(button_name) 约束报错（DB 兜底）。
     #[tokio::test]
     async fn test_create_quick_button_duplicate_name_errors() {
         let db = fresh_db().await;
-        create_quick_button(&db, "提取skill", "话术").await.unwrap();
+        create_quick_button(&db, 1, "提取skill", "话术").await.unwrap();
         // 第二次同名 insert 应被唯一约束拒绝
-        let err = create_quick_button(&db, "提取skill", "话术2").await;
+        let err = create_quick_button(&db, 1, "提取skill", "话术2").await;
         assert!(err.is_err(), "重名 insert 应返回 DbErr");
     }
 
@@ -149,11 +173,11 @@ mod quick_button_tests {
     #[tokio::test]
     async fn test_update_quick_button_changes_fields() {
         let db = fresh_db().await;
-        let id = create_quick_button(&db, "提取skill", "旧话术").await.unwrap();
-        update_quick_button(&db, id, Some("提取SKILL"), Some("新话术"))
+        let id = create_quick_button(&db, 1, "提取skill", "旧话术").await.unwrap();
+        update_quick_button(&db, 1, id, Some("提取SKILL"), Some("新话术"))
             .await
             .unwrap();
-        let updated = get_quick_button_by_name(&db, "提取SKILL")
+        let updated = get_quick_button_by_name(&db, 1, "提取SKILL")
             .await
             .unwrap()
             .unwrap();
@@ -165,9 +189,9 @@ mod quick_button_tests {
     #[tokio::test]
     async fn test_update_quick_button_partial_only_name() {
         let db = fresh_db().await;
-        let id = create_quick_button(&db, "提取skill", "原话术").await.unwrap();
-        update_quick_button(&db, id, Some("改名"), None).await.unwrap();
-        let updated = get_quick_button_by_name(&db, "改名")
+        let id = create_quick_button(&db, 1, "提取skill", "原话术").await.unwrap();
+        update_quick_button(&db, 1, id, Some("改名"), None).await.unwrap();
+        let updated = get_quick_button_by_name(&db, 1, "改名")
             .await
             .unwrap()
             .unwrap();
@@ -178,17 +202,17 @@ mod quick_button_tests {
     #[tokio::test]
     async fn test_update_quick_button_silent_when_missing() {
         let db = fresh_db().await;
-        let result = update_quick_button(&db, 99999, Some("x"), Some("y")).await;
+        let result = update_quick_button(&db, 1, 99999, Some("x"), Some("y")).await;
         assert!(result.is_ok(), "更新不存在的记录应静默 Ok");
-        assert!(get_quick_buttons(&db).await.unwrap().is_empty(), "不应产生新记录");
+        assert!(get_quick_buttons(&db, 1).await.unwrap().is_empty(), "不应产生新记录");
     }
 
     /// delete_quick_button：删除后列表为空。
     #[tokio::test]
     async fn test_delete_quick_button_removes_record() {
         let db = fresh_db().await;
-        let id = create_quick_button(&db, "提取skill", "话术").await.unwrap();
-        delete_quick_button(&db, id).await.unwrap();
-        assert!(get_quick_buttons(&db).await.unwrap().is_empty(), "删除后应无记录");
+        let id = create_quick_button(&db, 1, "提取skill", "话术").await.unwrap();
+        delete_quick_button(&db, 1, id).await.unwrap();
+        assert!(get_quick_buttons(&db, 1).await.unwrap().is_empty(), "删除后应无记录");
     }
 }

--- a/backend/src/handlers/action.rs
+++ b/backend/src/handlers/action.rs
@@ -1,4 +1,6 @@
+use axum::Router;
 use axum::extract::State;
+use axum::routing::{get, post};
 use serde::Deserialize;
 
 use crate::handlers::{ApiJson, AppError, AppState};
@@ -210,6 +212,55 @@ fn replace_placeholders(
         result = result.replace(&placeholder, value);
     }
     result
+}
+
+/// V1 全域路由聚合函数。
+///
+/// 将所有领域的 v1 路由通过 merge/nest 聚合到一个 Router 中。
+/// 全局资源（skills、config、backup、experts 等）使用模块级 v1_routes() 合并；
+/// 工作空间作用域资源（todos、executions、loops、blackboard 等）使用嵌套子路由。
+/// Action 路由直接定义在此函数中。
+///
+/// 此函数与旧 mount_domain_routes() 共存，过渡期后替换之。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        // POST /api/v1/actions/execute：执行 action 模板
+        //（按 action_type+action_key 查找或创建 todo，然后用 prompt+params 执行）
+        .route("/api/v1/actions/execute", post(execute_action))
+        // ── 云端同步 /api/v1/cloud/... ──────────────────────────────
+        .route("/api/v1/cloud/config", get(super::sync::cloud_get_config).post(super::sync::cloud_save_config))
+        .route("/api/v1/cloud/sync/status", get(super::sync::cloud_sync_status))
+        .route("/api/v1/cloud/sync/records", get(super::sync::cloud_sync_records).delete(super::sync::cloud_clear_sync_records))
+        .route("/api/v1/cloud/sync/push", post(super::sync::cloud_sync_push))
+        .route("/api/v1/cloud/sync/pull", post(super::sync::cloud_sync_pull))
+        // ── 全局资源（由各模块 v1_routes 合并） ────────────────────
+        .merge(super::webhook::v1_routes())
+        .merge(super::backup::v1_routes())
+        .merge(super::experts::v1_routes())
+        .merge(super::config::v1_routes())
+        .merge(super::skills::v1_routes())
+        .merge(super::session::v1_routes())
+        .merge(super::feishu_history::v1_routes())
+        .merge(super::quick_button::v1_routes())
+        .merge(super::review_template::v1_routes())
+        .merge(super::todo_template::v1_routes())
+        .merge(super::usage_stats::v1_routes())
+        .merge(super::custom_template::v1_routes())
+        .merge(super::bundled::v1_routes())
+        .merge(super::project_directory::v1_routes())
+        // ── 工作空间作用域资源（嵌套子路由） ───────────────────────
+        .nest("/api/v1/workspaces/{ws}/todos", super::todo::v1_routes())
+        .nest("/api/v1/workspaces/{ws}/executions", super::execution::v1_routes())
+        // dashboard 统计归 stats 域（独立于 executions），直接注册避免单独建 stats 模块
+        .route("/api/v1/workspaces/{ws}/stats/dashboard", get(super::execution::get_dashboard_stats))
+        // 定时 todo 查询按 workspace 隔离（update_scheduler 已在 todo 域 /{id}/scheduler）
+        .route("/api/v1/workspaces/{ws}/scheduler/todos", get(super::scheduler::get_scheduler_todos))
+        .nest("/api/v1/workspaces/{ws}/loops", super::loop_::v1_routes())
+        .nest("/api/v1/workspaces/{ws}/blackboard", super::blackboard::v1_routes())
+        .nest("/api/v1/agent-bots", super::agent_bot::v1_bot_routes())
+        .nest("/api/v1/workspaces/{ws}", super::agent_bot::v1_workspace_routes())
+        // tag 为全局资源（无 workspace_id 列），不嵌套 workspace，直接挂 /api/v1/tags
+        .nest("/api/v1/tags", super::tag::v1_routes())
 }
 
 #[cfg(test)]

--- a/backend/src/handlers/action.rs
+++ b/backend/src/handlers/action.rs
@@ -259,6 +259,11 @@ pub fn v1_routes() -> Router<AppState> {
         .route("/api/v1/workspaces/{ws}/scheduler/todos", get(super::scheduler::get_scheduler_todos))
         .nest("/api/v1/workspaces/{ws}/loops", super::loop_::v1_routes())
         .nest("/api/v1/workspaces/{ws}/blackboard", super::blackboard::v1_routes())
+        // wiki 独立于 blackboard（设计文档 4.4 + 旧路由 + 前端均为 /workspaces/{ws}/wiki/*，
+        // 不能挂在 /blackboard 下，否则前端 /workspaces/{ws}/wiki/files 会 404）
+        .route("/api/v1/workspaces/{ws}/wiki/files", get(super::blackboard::list_wiki_files))
+        .route("/api/v1/workspaces/{ws}/wiki/files/{slug}", get(super::blackboard::get_wiki_file).delete(super::blackboard::delete_wiki_file))
+        .route("/api/v1/workspaces/{ws}/wiki/chat", post(super::blackboard::chat_with_wiki))
         .nest("/api/v1/agent-bots", super::agent_bot::v1_bot_routes())
         .nest("/api/v1/workspaces/{ws}", super::agent_bot::v1_workspace_routes())
         // tag 为全局资源（无 workspace_id 列），不嵌套 workspace，直接挂 /api/v1/tags

--- a/backend/src/handlers/action.rs
+++ b/backend/src/handlers/action.rs
@@ -245,7 +245,6 @@ pub fn v1_routes() -> Router<AppState> {
         .merge(super::skills::v1_routes())
         .merge(super::session::v1_routes())
         .merge(super::feishu_history::v1_routes())
-        .merge(super::quick_button::v1_routes())
         .merge(super::review_template::v1_routes())
         .merge(super::todo_template::v1_routes())
         .merge(super::usage_stats::v1_routes())
@@ -262,6 +261,7 @@ pub fn v1_routes() -> Router<AppState> {
         // 定时 todo 查询按 workspace 隔离（update_scheduler 已在 todo 域 /{id}/scheduler）
         .route("/api/v1/workspaces/{ws}/scheduler/todos", get(super::scheduler::get_scheduler_todos))
         .nest("/api/v1/workspaces/{ws}/loops", super::loop_::v1_routes())
+        .nest("/api/v1/workspaces/{ws}/quick-buttons", super::quick_button::v1_routes())
         .nest("/api/v1/workspaces/{ws}/blackboard", super::blackboard::v1_routes())
         // wiki 独立于 blackboard（设计文档 4.4 + 旧路由 + 前端均为 /workspaces/{ws}/wiki/*，
         // 不能挂在 /blackboard 下，否则前端 /workspaces/{ws}/wiki/files 会 404）

--- a/backend/src/handlers/action.rs
+++ b/backend/src/handlers/action.rs
@@ -248,6 +248,8 @@ pub fn v1_routes() -> Router<AppState> {
         .merge(super::custom_template::v1_routes())
         .merge(super::bundled::v1_routes())
         .merge(super::project_directory::v1_routes())
+        // executor-profiles（API Key 管理）：providers + profiles，路径已为 /api/v1/
+        .merge(super::profiles::profile_routes())
         // ── 工作空间作用域资源（嵌套子路由） ───────────────────────
         .nest("/api/v1/workspaces/{ws}/todos", super::todo::v1_routes())
         .nest("/api/v1/workspaces/{ws}/executions", super::execution::v1_routes())

--- a/backend/src/handlers/action.rs
+++ b/backend/src/handlers/action.rs
@@ -227,6 +227,10 @@ pub fn v1_routes() -> Router<AppState> {
         // POST /api/v1/actions/execute：执行 action 模板
         //（按 action_type+action_key 查找或创建 todo，然后用 prompt+params 执行）
         .route("/api/v1/actions/execute", post(execute_action))
+        // 版本查询/升级（全局，原 /api/version）
+        .route("/api/v1/version", get(super::version_handler))
+        .route("/api/v1/version/latest", get(super::version_latest_handler))
+        .route("/api/v1/version/upgrade", post(super::version_upgrade_handler))
         // ── 云端同步 /api/v1/cloud/... ──────────────────────────────
         .route("/api/v1/cloud/config", get(super::sync::cloud_get_config).post(super::sync::cloud_save_config))
         .route("/api/v1/cloud/sync/status", get(super::sync::cloud_sync_status))

--- a/backend/src/handlers/agent_bot.rs
+++ b/backend/src/handlers/agent_bot.rs
@@ -1,7 +1,8 @@
 use axum::{
     extract::{Path, Query, State},
     response::{sse::{Event, Sse}, IntoResponse},
-    Json,
+    routing::{delete, get, post, put},
+    Json, Router,
 };
 use futures_util::stream::Stream;
 use reqwest::Client;
@@ -931,4 +932,78 @@ pub async fn move_bot_to_workspace(
         "success": true,
         "message": format!("Bot moved to workspace {}, all existing bindings have been disabled", req.workspace_id)
     })))
+}
+
+// ============================================================================
+// V1 路由：Bot 管理（非 workspace 作用域）
+// ============================================================================
+
+/// V1 变体：群白名单列表，bot_id 来自 Path 而非 Query 参数。
+///
+/// 与 `get_group_whitelist` 的区别仅在于 bot_id 的提取方式：v1 使用 Path 提取器
+/// 从 URL 路径中获取（如 `/api/v1/agent-bots/{bot_id}/feishu/group-whitelist`），
+/// 避免将 bot_id 作为 Query 参数传递。
+pub async fn v1_get_group_whitelist(
+    State(state): State<AppState>,
+    Path(bot_id): Path<i64>,
+) -> Result<impl IntoResponse, AppError> {
+    let list = state.db.get_group_whitelist(bot_id).await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let entries: Vec<WhitelistEntry> = list.into_iter().map(|w| WhitelistEntry {
+        id: w.id,
+        bot_id: w.bot_id,
+        sender_open_id: w.sender_open_id,
+        sender_name: w.sender_name,
+        created_at: w.created_at,
+    }).collect();
+
+    Ok(ApiResponse::ok(entries))
+}
+
+/// V1 Bot 管理路由（非 workspace 作用域）。
+///
+/// 这些路由使用相对路径，期望被嵌套在 `/api/v1/agent-bots` 下。
+/// Bot 管理路由不依赖 workspace 作用域，所有 handler 复用现有函数签名。
+pub fn v1_bot_routes() -> Router<AppState> {
+    Router::new()
+        // GET / — 列出所有 agent bot
+        .route("/", get(list_agent_bots))
+        // DELETE /{id} — 删除指定 bot
+        .route("/{id}", delete(delete_agent_bot))
+        // PUT /{id}/config — 更新 bot 配置
+        .route("/{id}/config", put(update_agent_bot_config))
+        // PUT /{id}/workspace — 移动 bot 到另一个工作空间
+        .route("/{id}/workspace", put(move_bot_to_workspace))
+        // POST /feishu/init — 初始化飞书授权流程
+        .route("/feishu/init", post(feishu_init))
+        // POST /feishu/begin — 开始飞书设备授权
+        .route("/feishu/begin", post(feishu_begin))
+        // GET /feishu/poll-stream — SSE 轮询飞书授权结果
+        .route("/feishu/poll-stream", get(feishu_poll_sse))
+        // GET|PUT /feishu/push — 查询/更新推送配置
+        .route("/feishu/push", get(get_feishu_push).put(update_feishu_push))
+        // GET|POST /feishu/group-whitelist — 群白名单列表/添加（v1 使用 Path 提取 bot_id）
+        .route("/feishu/group-whitelist", get(v1_get_group_whitelist).post(add_group_whitelist))
+        // DELETE /feishu/group-whitelist/{id} — 删除群白名单条目
+        .route("/feishu/group-whitelist/{id}", delete(delete_group_whitelist))
+}
+
+// ============================================================================
+// V1 路由：Workspace 作用域（斜杠命令 + 设置）
+// ============================================================================
+
+/// V1 Workspace 路由（斜杠命令 + 设置），使用相对路径。
+///
+/// 这些路由期望被嵌套在 `/api/v1/workspaces/{ws}` 下，因此路径中不包含
+/// workspace 前缀。所有 handler 已在签名中使用 `Path(workspace_id): Path<i64>`，
+/// 嵌套后 axum 会自动将 `{ws}` 提取为 workspace_id 传给 handler。
+pub fn v1_workspace_routes() -> Router<AppState> {
+    Router::new()
+        // GET|POST /slash-commands — 列出/创建斜杠命令
+        .route("/slash-commands", get(list_workspace_slash_commands).post(create_workspace_slash_command))
+        // PUT|DELETE /slash-commands/{cmd_id} — 更新/删除斜杠命令
+        .route("/slash-commands/{cmd_id}", put(update_workspace_slash_command).delete(delete_workspace_slash_command))
+        // GET|PUT /settings — 查询/更新工作空间设置
+        .route("/settings", get(get_workspace_settings).put(update_workspace_settings))
 }

--- a/backend/src/handlers/agent_bot.rs
+++ b/backend/src/handlers/agent_bot.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tokio::time::sleep;
 
-use crate::handlers::{AppError, AppState};
+use crate::handlers::{workspace_guard, AppError, AppState};
 use crate::models::ApiResponse;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -850,11 +850,21 @@ pub struct UpdateWorkspaceSettingsRequest {
 }
 
 /// 更新工作空间的设置
+///
+/// 若请求指定了默认响应 todo/loop，先校验其确实属于当前 workspace，防止通过设置
+/// 间接引用其他 workspace 的资源（与 smart_create 的 workspace 隔离保持一致）。
 pub async fn update_workspace_settings(
     State(state): State<AppState>,
     Path(workspace_id): Path<i64>,
     Json(req): Json<UpdateWorkspaceSettingsRequest>,
 ) -> Result<impl IntoResponse, AppError> {
+    if let Some(todo_id) = req.default_response_todo_id {
+        workspace_guard::verify_todo_belongs_to_ws(&state.db, todo_id, workspace_id).await?;
+    }
+    if let Some(loop_id) = req.default_response_loop_id {
+        workspace_guard::verify_loop_belongs_to_ws(&state.db, loop_id, workspace_id).await?;
+    }
+
     crate::db::workspace_setting::upsert_workspace_settings(
         &state.db,
         workspace_id,
@@ -938,15 +948,18 @@ pub async fn move_bot_to_workspace(
 // V1 路由：Bot 管理（非 workspace 作用域）
 // ============================================================================
 
-/// V1 变体：群白名单列表，bot_id 来自 Path 而非 Query 参数。
+/// V1 变体：群白名单列表，bot_id 来自 Query 参数。
 ///
-/// 与 `get_group_whitelist` 的区别仅在于 bot_id 的提取方式：v1 使用 Path 提取器
-/// 从 URL 路径中获取（如 `/api/v1/agent-bots/{bot_id}/feishu/group-whitelist`），
-/// 避免将 bot_id 作为 Query 参数传递。
+/// 与旧版保持一致：前端调用 `/api/v1/agent-bots/feishu/group-whitelist?bot_id=X`，
+/// 路由注册在 `/feishu/group-whitelist`（无 `{bot_id}` 路径段），因此用 Query 提取。
 pub async fn v1_get_group_whitelist(
     State(state): State<AppState>,
-    Path(bot_id): Path<i64>,
+    axum::extract::Query(params): axum::extract::Query<HashMap<String, String>>,
 ) -> Result<impl IntoResponse, AppError> {
+    let bot_id: i64 = params.get("bot_id")
+        .ok_or(AppError::BadRequest("bot_id required".into()))?
+        .parse()
+        .map_err(|_| AppError::BadRequest("invalid bot_id".into()))?;
     let list = state.db.get_group_whitelist(bot_id).await
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
@@ -983,7 +996,7 @@ pub fn v1_bot_routes() -> Router<AppState> {
         .route("/feishu/poll-stream", get(feishu_poll_sse))
         // GET|PUT /feishu/push — 查询/更新推送配置
         .route("/feishu/push", get(get_feishu_push).put(update_feishu_push))
-        // GET|POST /feishu/group-whitelist — 群白名单列表/添加（v1 使用 Path 提取 bot_id）
+        // GET|POST /feishu/group-whitelist — 群白名单列表/添加（bot_id 来自 Query/body）
         .route("/feishu/group-whitelist", get(v1_get_group_whitelist).post(add_group_whitelist))
         // DELETE /feishu/group-whitelist/{id} — 删除群白名单条目
         .route("/feishu/group-whitelist/{id}", delete(delete_group_whitelist))

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -1,8 +1,10 @@
 use axum::{
+    Router,
     extract::{State, Query},
     body::Bytes,
     response::IntoResponse,
     http::header,
+    routing::{get, post, put},
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -1765,6 +1767,33 @@ async fn perform_skill_backup_async(max_files: usize) -> Result<String, String> 
     .map_err(|e| format!("Task join error: {}", e))?;
 
     Ok(format!("Auto Skill backup: {}", backup_path_for_display))
+}
+
+/// v1 API 路由：所有路径使用完整的 `/api/v1/backup/...` 前缀，
+/// 不与外层 router 嵌套（flat 结构）。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/v1/backup/export", get(export_backup))
+        .route("/api/v1/backup/export-selected", post(export_selected))
+        .route("/api/v1/backup/import", post(import_backup))
+        .route("/api/v1/backup/merge", post(merge_backup))
+        .route("/api/v1/backup/database/download", get(download_database))
+        .route("/api/v1/backup/database/status", get(get_database_backup_status))
+        .route("/api/v1/backup/database/trigger", post(trigger_local_backup))
+        .route("/api/v1/backup/database/auto", put(update_auto_backup))
+        .route("/api/v1/backup/database/optimize", post(database_optimize))
+        .route("/api/v1/backup/database/file", get(download_backup_file).delete(delete_backup_file))
+        .route("/api/v1/backup/todo/status", get(get_todo_backup_status))
+        .route("/api/v1/backup/todo/trigger", post(trigger_todo_backup))
+        .route("/api/v1/backup/todo/auto", put(update_todo_auto_backup))
+        .route("/api/v1/backup/todo/file", get(download_todo_backup_file).delete(delete_todo_backup_file))
+        .route("/api/v1/backup/log-cleanup/status", get(get_log_cleanup_status))
+        .route("/api/v1/backup/log-cleanup", put(update_log_cleanup))
+        .route("/api/v1/backup/log-cleanup/trigger", post(trigger_log_cleanup))
+        .route("/api/v1/backup/skills/status", get(get_skill_backup_status))
+        .route("/api/v1/backup/skills/trigger", post(trigger_skill_backup))
+        .route("/api/v1/backup/skills/auto", put(update_skill_auto_backup))
+        .route("/api/v1/backup/skills/file", get(download_skill_backup_file).delete(delete_skill_backup_file))
 }
 
 #[cfg(test)]

--- a/backend/src/handlers/blackboard.rs
+++ b/backend/src/handlers/blackboard.rs
@@ -353,3 +353,16 @@ pub fn blackboard_routes() -> Router<AppState> {
             post(chat_with_wiki),
         )
 }
+
+/// V1 黑板 API 路由（相对路径版本）。
+///
+/// 这些路由使用相对路径，期望被嵌套在 `/api/v1/workspaces/{ws}/blackboard` 下。
+/// 所有 handler 复用现有函数签名 —— Path 提取器从嵌套路由的路径参数中获取 workspace_id。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        .route("/", get(get_blackboard).patch(update_blackboard_config))
+        .route("/config", get(get_blackboard_config))
+        .route("/wiki/files", get(list_wiki_files))
+        .route("/wiki/files/{slug}", get(get_wiki_file).delete(delete_wiki_file))
+        .route("/wiki/chat", post(chat_with_wiki))
+}

--- a/backend/src/handlers/blackboard.rs
+++ b/backend/src/handlers/blackboard.rs
@@ -362,7 +362,4 @@ pub fn v1_routes() -> Router<AppState> {
     Router::new()
         .route("/", get(get_blackboard).patch(update_blackboard_config))
         .route("/config", get(get_blackboard_config))
-        .route("/wiki/files", get(list_wiki_files))
-        .route("/wiki/files/{slug}", get(get_wiki_file).delete(delete_wiki_file))
-        .route("/wiki/chat", post(chat_with_wiki))
 }

--- a/backend/src/handlers/bundled.rs
+++ b/backend/src/handlers/bundled.rs
@@ -645,6 +645,30 @@ pub fn bundled_routes() -> Router<AppState> {
         .route("/api/bundled/skills/install", axum::routing::post(install_bundled_skill))
 }
 
+/// V1 路由定义：内置资源同步相关 API（API 重构过渡期）
+///
+/// 与 `bundled_routes()` 共存，路由前缀改为 /api/v1/bundled，全路径注册。
+/// 新旧路由在顶层通过不同的 Router merge 组装，此处不走嵌套前缀。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        // 手动触发 git 同步（post /api/v1/bundled/sync）
+        .route("/api/v1/bundled/sync", axum::routing::post(sync_bundled))
+        // 同步状态查询（get /api/v1/bundled/status）
+        .route("/api/v1/bundled/status", axum::routing::get(get_bundled_status))
+        // 同步源配置读/写
+        .route("/api/v1/bundled/config", axum::routing::get(get_bundled_config))
+        .route("/api/v1/bundled/config", axum::routing::put(update_bundled_config))
+        // 技能市场：列表（GET）与来源分页
+        .route("/api/v1/bundled/skills", axum::routing::get(list_bundled_skills))
+        .route("/api/v1/bundled/skill-sources", axum::routing::get(list_bundled_skill_sources))
+        // 技能详情：SKILL.md 内容 + 目录文件列表
+        .route("/api/v1/bundled/skills/{name}/content", axum::routing::get(get_bundled_skill_content))
+        // 技能内单个文件预览
+        .route("/api/v1/bundled/skills/{name}/file", axum::routing::get(get_bundled_skill_file))
+        // 安装技能到执行器
+        .route("/api/v1/bundled/skills/install", axum::routing::post(install_bundled_skill))
+}
+
 // ---------------------------------------------------------------------------
 // 技能市场 API
 // ---------------------------------------------------------------------------

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -1,6 +1,9 @@
 use axum::extract::State;
+use axum::routing::{get, post, put};
+use axum::Router;
 
 use crate::config::Config;
+use crate::handlers::executor_config;
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::{ApiResponse, UpdateConfigRequest};
 
@@ -117,6 +120,55 @@ pub async fn update_config(
         .map_err(|e| AppError::Internal(format!("Failed to save config: {}", e)))?;
 
     Ok(ApiResponse::ok(cfg_to_return))
+}
+
+/// v1 API 路由：配置 + 执行器配置的路由集合。
+/// 所有路径使用完整的 `/api/v1/...` 前缀，不与外层 router 嵌套（flat 结构）。
+///
+/// 映射规则：
+/// - `/api/config` → `/api/v1/config`
+/// - `/api/executors/...` → `/api/v1/executors/...`
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        // 全局配置：GET 查询当前配置，PUT 更新配置项
+        .route("/api/v1/config", get(get_config).put(update_config))
+        // 执行器列表
+        .route("/api/v1/executors", get(executor_config::list_executors))
+        // 更新指定执行器配置
+        .route(
+            "/api/v1/executors/{name}",
+            put(executor_config::update_executor),
+        )
+        // 检测指定执行器
+        .route(
+            "/api/v1/executors/{name}/detect",
+            post(executor_config::detect_executor),
+        )
+        // 测试指定执行器连通性
+        .route(
+            "/api/v1/executors/{name}/test",
+            post(executor_config::test_executor),
+        )
+        // 全量检测所有执行器
+        .route(
+            "/api/v1/executors/detect-all",
+            post(executor_config::detect_all_executors),
+        )
+        // 解析执行器路径
+        .route(
+            "/api/v1/executors/{name}/resolve",
+            post(executor_config::resolve_executor_path),
+        )
+        // 获取默认执行器
+        .route(
+            "/api/v1/executors/default",
+            get(executor_config::get_default_executor),
+        )
+        // 设置默认执行器
+        .route(
+            "/api/v1/executors/{name}/default",
+            put(executor_config::set_default_executor),
+        )
 }
 
 #[cfg(test)]

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -169,6 +169,11 @@ pub fn v1_routes() -> Router<AppState> {
             "/api/v1/executors/{name}/default",
             put(executor_config::set_default_executor),
         )
+        // 列出执行器支持的模型（executor-model：模型动态下拉）
+        .route(
+            "/api/v1/executors/{name}/models",
+            get(executor_config::list_executor_models),
+        )
 }
 
 #[cfg(test)]

--- a/backend/src/handlers/custom_template.rs
+++ b/backend/src/handlers/custom_template.rs
@@ -1,4 +1,6 @@
 use axum::extract::State;
+use axum::Router;
+use axum::routing::{get, post, put};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -387,4 +389,22 @@ async fn perform_sync(db: &Arc<Database>) -> Result<String, String> {
     insert_templates(db, &remote_templates, &url).await?;
 
     Ok(format!("Auto custom template sync completed: {} templates imported", remote_templates.len()))
+}
+
+/// v1 API 路由（/api/v1/custom-templates/*）。
+///
+/// 与 `custom_template_routes()`（mod.rs）使用相同的处理器，仅路径前缀改为 `/api/v1/`。
+/// 旧路由废弃后 `mod.rs` 中从 `custom_template_routes()` 切到这个函数。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        // GET /api/v1/custom-templates/status — 查询订阅状态及同步配置
+        .route("/api/v1/custom-templates/status", get(get_custom_template_status))
+        // POST /api/v1/custom-templates/subscribe — 订阅并立即同步远程模板
+        .route("/api/v1/custom-templates/subscribe", post(subscribe_custom_template))
+        // POST /api/v1/custom-templates/unsubscribe — 取消订阅并删除所有自定义模板
+        .route("/api/v1/custom-templates/unsubscribe", post(unsubscribe_custom_template))
+        // POST /api/v1/custom-templates/sync — 手动重新同步已订阅的远程模板
+        .route("/api/v1/custom-templates/sync", post(sync_custom_template))
+        // PUT /api/v1/custom-templates/auto-sync — 更新自动同步 cron 配置
+        .route("/api/v1/custom-templates/auto-sync", put(update_auto_sync_config))
 }

--- a/backend/src/handlers/errors.rs
+++ b/backend/src/handlers/errors.rs
@@ -1,8 +1,9 @@
 //! HTTP 错误处理模块：定义统一的 handler 层错误类型和 JSON 提取器。
 //!
-//! `AppError` 是所有 handler 的统一错误类型，包含三个语义层级：
+//! `AppError` 是所有 handler 的统一错误类型，包含四个语义层级：
 //! - `NotFound`：资源缺失（404）
 //! - `BadRequest`：用户输入错误（400，caller 可修复）
+//! - `Forbidden`：权限不足（403，跨 workspace 访问等）
 //! - `Internal`：服务器侧故障（500）
 
 use axum::extract::{FromRequest, Request};
@@ -13,11 +14,12 @@ use serde::Serialize;
 /// HTTP handler 统一错误类型。
 ///
 /// 公开枚举保持稳定（issue #613 要求：仅重构实现方式，不改公开 API）。
-/// 3 个变体对应 3 个语义层级。
+/// 4 个变体对应 4 个语义层级。
 #[derive(Debug)]
 pub enum AppError {
     NotFound,
     BadRequest(String),
+    Forbidden(String),
     Internal(String),
 }
 
@@ -33,6 +35,11 @@ impl AppError {
             Self::BadRequest(msg) => (
                 StatusCode::BAD_REQUEST,
                 crate::models::codes::BAD_REQUEST,
+                msg.clone(),
+            ),
+            Self::Forbidden(msg) => (
+                StatusCode::FORBIDDEN,
+                crate::models::codes::FORBIDDEN,
                 msg.clone(),
             ),
             Self::Internal(msg) => (

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -965,6 +965,7 @@ pub async fn v1_smart_create_handler(
         todo_id,
         message,
         req_executor: None,
+        req_model: None,
         trigger_type: "smart_create".to_string(),
         params: Some(params),
         resume_session_id: None,

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -908,7 +908,9 @@ pub async fn v1_smart_create_handler(
     let todo_id = workspace_settings.default_response_todo_id
         .ok_or_else(|| AppError::BadRequest("尚未配置默认响应 Todo，请先在工作空间设置中配置".to_string()))?;
 
-    // 验证 Todo 存在
+    // 验证 Todo 存在且属于当前 workspace：settings 表本身没有外键约束保证
+    // default_response_todo_id 与 workspace_id 一致，必须显式校验防止跨空间执行。
+    workspace_guard::verify_todo_belongs_to_ws(&state.db, todo_id, ws_id).await?;
     let todo = state
         .db
         .get_todo(todo_id)

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -1,11 +1,13 @@
+use axum::Router;
 use axum::extract::{Path, Query, State};
+use axum::routing::{get, post, put};
 use serde::Deserialize;
 
 use crate::adapters::parse_executor_type;
 use crate::executor_service::{
     run_todo_execution, run_todo_execution_with_params, ExecutionResult, RunTodoExecutionRequest,
 };
-use crate::handlers::{ApiJson, AppError, AppState};
+use crate::handlers::{workspace_guard, ApiJson, AppError, AppState};
 use crate::models::{
     ApiResponse, DashboardStats, ExecuteRequest, ExecutionLogsPage, ExecutionRecordsPage,
     ExecutionStatus, ExecutionSummary, SmartCreateRequest, TodoIdQuery,
@@ -28,6 +30,7 @@ pub async fn start_todo_execution(
     Ok(result)
 }
 
+#[allow(dead_code)]
 pub async fn get_execution_records(
     State(state): State<AppState>,
     Query(query): Query<TodoIdQuery>,
@@ -82,8 +85,10 @@ pub async fn get_execution_records(
 
 pub async fn get_execution_record(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
 ) -> Result<ApiResponse<crate::models::ExecutionRecord>, AppError> {
+    // V1 隔离：record 经 todo 间接关联 workspace，校验归属防止跨 ws 读他人执行记录
+    workspace_guard::verify_execution_belongs_to_ws(&state.db, id, ws_id).await?;
     let record = state
         .db
         .get_execution_record(id)
@@ -102,9 +107,11 @@ pub struct RateExecutionRequest {
 
 pub async fn rate_execution_handler(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
     ApiJson(req): ApiJson<RateExecutionRequest>,
 ) -> Result<ApiResponse<crate::models::ExecutionRecord>, AppError> {
+    // V1 隔离：评分前校验 record 归属 workspace
+    workspace_guard::verify_execution_belongs_to_ws(&state.db, id, ws_id).await?;
     if let Some(r) = req.rating {
         if !(0..=100).contains(&r) {
             return Err(AppError::BadRequest(format!(
@@ -152,9 +159,11 @@ fn default_per_page() -> i64 { 200 }
 
 pub async fn get_execution_logs_handler(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
     Query(query): Query<ExecutionLogsQuery>,
 ) -> Result<ApiResponse<ExecutionLogsPage>, AppError> {
+    // V1 隔离：取日志前校验 record 归属 workspace
+    workspace_guard::verify_execution_belongs_to_ws(&state.db, id, ws_id).await?;
     let page = query.page.max(1);
     let per_page = query.per_page.clamp(10, 1000);
     let (logs, total) = state
@@ -171,19 +180,30 @@ pub async fn get_execution_logs_handler(
 
 pub async fn get_execution_records_by_session(
     State(state): State<AppState>,
-    Path(session_id): Path<String>,
+    Path((ws_id, session_id)): Path<(i64, String)>,
 ) -> Result<ApiResponse<Vec<crate::models::ExecutionRecord>>, AppError> {
     let records = state
         .db
         .get_execution_records_by_session(&session_id)
         .await?;
+    // V1 隔离：同一 session 可能含跨 ws 的记录，按 workspace 过滤只保留本 ws 的
+    let ws_todos = state.db.get_todos_by_workspace_id(Some(ws_id)).await?;
+    let ws_todo_ids: std::collections::HashSet<i64> =
+        ws_todos.iter().map(|t| t.id).collect();
+    let records: Vec<_> = records
+        .into_iter()
+        .filter(|r| ws_todo_ids.contains(&r.todo_id))
+        .collect();
     Ok(ApiResponse::ok(records))
 }
 
 pub async fn execute_handler(
     State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
     ApiJson(req): ApiJson<ExecuteRequest>,
 ) -> Result<ApiResponse<serde_json::Value>, AppError> {
+    // V1 隔离：启动执行前校验目标 todo 属于路径 workspace
+    workspace_guard::verify_todo_belongs_to_ws(&state.db, req.todo_id, ws_id).await?;
     // Get the todo to use its prompt as fallback when message is not provided
     let todo = state
         .db
@@ -265,21 +285,18 @@ pub async fn execute_handler(
     ))
 }
 
-#[derive(Debug, Deserialize)]
-pub struct StopExecutionRequest {
-    pub record_id: i64,
-}
-
 pub async fn stop_execution_handler(
     State(state): State<AppState>,
-    ApiJson(req): ApiJson<StopExecutionRequest>,
+    Path((ws_id, record_id)): Path<(i64, i64)>,
 ) -> Result<ApiResponse<()>, AppError> {
-    tracing::info!("Stopping execution record: {}", req.record_id);
+    // V1 隔离：停止前校验 record 归属 workspace（路径 {id} 即 record_id）
+    workspace_guard::verify_execution_belongs_to_ws(&state.db, record_id, ws_id).await?;
+    tracing::info!("Stopping execution record: {}", record_id);
 
     let record =
         state
             .db
-            .get_execution_record(req.record_id)
+            .get_execution_record(record_id)
             .await?
             .ok_or(AppError::BadRequest(
                 "Execution record not found".to_string(),
@@ -294,7 +311,7 @@ pub async fn stop_execution_handler(
     if let Some(task_id) = &record.task_id {
         tracing::info!(
             "Stopping execution record {} with task_id: {}",
-            req.record_id,
+            record_id,
             task_id
         );
         let cancelled = state.task_manager.cancel(task_id).await;
@@ -303,7 +320,7 @@ pub async fn stop_execution_handler(
             // 重新查询 DB 确认当前状态，避免与正常完成的任务产生竞态
             let current_record = state
                 .db
-                .get_execution_record(req.record_id)
+                .get_execution_record(record_id)
                 .await?
                 .ok_or(AppError::BadRequest(
                     "Execution record not found".to_string(),
@@ -315,7 +332,7 @@ pub async fn stop_execution_handler(
                 );
                 state
                     .db
-                    .force_fail_execution_record(req.record_id)
+                    .force_fail_execution_record(record_id)
                     .await
                     .map_err(|e| AppError::Internal(e.to_string()))?;
             } else {
@@ -328,7 +345,7 @@ pub async fn stop_execution_handler(
         }
         // 取消成功时，由任务内部的 cancel 分支处理 DB 更新，
         // 避免与 stop handler 同时写入造成竞态条件
-        tracing::info!("Successfully stopped execution record {}", req.record_id);
+        tracing::info!("Successfully stopped execution record {}", record_id);
         Ok(ApiResponse::ok(()))
     } else {
         Err(AppError::BadRequest(
@@ -339,8 +356,16 @@ pub async fn stop_execution_handler(
 
 pub async fn get_running_execution_records_handler(
     State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
 ) -> Result<ApiResponse<Vec<crate::models::ExecutionRecord>>, AppError> {
+    // V1 隔离：按 workspace 过滤正在运行的执行记录（经 todo 间接关联）
     let records = state.db.get_running_execution_records().await?;
+    let ws_todos = state.db.get_todos_by_workspace_id(Some(ws_id)).await?;
+    let ws_todo_ids: std::collections::HashSet<i64> = ws_todos.iter().map(|t| t.id).collect();
+    let records: Vec<_> = records
+        .into_iter()
+        .filter(|r| ws_todo_ids.contains(&r.todo_id))
+        .collect();
     Ok(ApiResponse::ok(records))
 }
 
@@ -352,12 +377,14 @@ pub struct RunningBoardQuery {
     pub limit: Option<i64>,
     /// 按工作空间 ID 过滤；不传返回全部。
     #[serde(default)]
+    #[allow(dead_code)]
     pub workspace_id: Option<i64>,
     /// 按最近 N 小时过滤（对 execution records 生效）；不传或 0 表示不过滤。
     #[serde(default)]
     pub hours: Option<u32>,
 }
 
+#[allow(dead_code)]
 pub async fn get_running_board(
     State(state): State<AppState>,
     Query(query): Query<RunningBoardQuery>,
@@ -403,19 +430,16 @@ pub async fn get_running_board(
     }))
 }
 
-#[derive(Debug, Deserialize)]
-pub struct ForceFailRequest {
-    pub record_id: i64,
-}
-
 pub async fn force_fail_execution_handler(
     State(state): State<AppState>,
-    ApiJson(req): ApiJson<ForceFailRequest>,
+    Path((ws_id, record_id)): Path<(i64, i64)>,
 ) -> Result<ApiResponse<()>, AppError> {
+    // V1 隔离：强制失败前校验 record 归属 workspace
+    workspace_guard::verify_execution_belongs_to_ws(&state.db, record_id, ws_id).await?;
     let record =
         state
             .db
-            .get_execution_record(req.record_id)
+            .get_execution_record(record_id)
             .await?
             .ok_or(AppError::BadRequest(
                 "Execution record not found".to_string(),
@@ -434,7 +458,7 @@ pub async fn force_fail_execution_handler(
 
     state
         .db
-        .force_fail_execution_record(req.record_id)
+        .force_fail_execution_record(record_id)
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
     Ok(ApiResponse::ok(()))
@@ -447,9 +471,11 @@ pub struct ResumeExecutionRequest {
 
 pub async fn resume_execution_handler(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
     ApiJson(req): ApiJson<ResumeExecutionRequest>,
 ) -> Result<ApiResponse<serde_json::Value>, AppError> {
+    // V1 隔离：恢复执行前校验 record 归属 workspace
+    workspace_guard::verify_execution_belongs_to_ws(&state.db, id, ws_id).await?;
     let record = state
         .db
         .get_execution_record(id)
@@ -570,8 +596,11 @@ pub async fn resume_execution_handler(
 
 pub async fn get_execution_summary(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
 ) -> Result<ApiResponse<ExecutionSummary>, AppError> {
+    // V1 隔离：db.get_execution_summary 按 todo_id 聚合，故校验 todo 归属 workspace。
+    // 此 handler 由 todo 域 /todos/{id}/summary 引用（execution 域无 summary 端点）。
+    workspace_guard::verify_todo_belongs_to_ws(&state.db, id, ws_id).await?;
     Ok(ApiResponse::ok(state.db.get_execution_summary(id).await?))
 }
 
@@ -586,29 +615,35 @@ struct DashboardCacheEntry {
     expires_at: StdInstant,
 }
 
-static DASHBOARD_CACHE: LazyLock<RwLock<HashMap<u32, DashboardCacheEntry>>> =
+static DASHBOARD_CACHE: LazyLock<RwLock<HashMap<(i64, u32), DashboardCacheEntry>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
 pub async fn get_dashboard_stats(
     State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
     Query(params): Query<DashboardStatsParams>,
 ) -> Result<ApiResponse<DashboardStats>, AppError> {
     let hours_key = params.hours.unwrap_or(24 * 7); // default: 7 days
+    // 缓存键带 ws_id：不同 workspace 的看板数据独立缓存，避免互相串数据
+    let cache_key = (ws_id, hours_key);
 
     {
         let cache = DASHBOARD_CACHE.read().await;
-        if let Some(entry) = cache.get(&hours_key) {
+        if let Some(entry) = cache.get(&cache_key) {
             if entry.expires_at > StdInstant::now() {
                 return Ok(ApiResponse::ok(entry.stats.clone()));
             }
         }
     }
 
+    // TODO(ws-isolation): db.get_dashboard_stats 当前全库聚合，未按 workspace 过滤。
+    // 真正的 ws 隔离需 db/dashboard.rs 的 fetch_* SQL 下沉 WHERE todo_id IN (本 ws todos)，
+    // 作为独立任务跟进。当前接受统计暂为全库聚合（数字级聚合，非具体资源越权）。
     let stats = state.db.get_dashboard_stats(params.hours).await?;
 
     {
         let mut cache = DASHBOARD_CACHE.write().await;
-        cache.insert(hours_key, DashboardCacheEntry {
+        cache.insert(cache_key, DashboardCacheEntry {
             stats: stats.clone(),
             expires_at: StdInstant::now() + Duration::from_secs(30),
         });
@@ -625,12 +660,19 @@ pub struct DashboardStatsParams {
 
 pub async fn get_running_todos(
     State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
 ) -> Result<ApiResponse<Vec<crate::models::Todo>>, AppError> {
+    // V1 隔离：按 workspace 过滤正在运行的 todo（db 层无 ws 参数，内存过滤）
     let running_todos = state.db.get_running_todos().await?;
-    Ok(ApiResponse::ok(running_todos))
+    let filtered: Vec<_> = running_todos
+        .into_iter()
+        .filter(|t| t.workspace_id == Some(ws_id))
+        .collect();
+    Ok(ApiResponse::ok(filtered))
 }
 
 /// 智能新建：用户提交自然语言描述，通过默认响应 Todo 自动执行
+#[allow(dead_code)]
 pub async fn smart_create_handler(
     State(state): State<AppState>,
     ApiJson(req): ApiJson<SmartCreateRequest>,
@@ -750,6 +792,238 @@ fn resolve_resume_session_id(
     record.session_id.clone().ok_or_else(|| {
         AppError::BadRequest("No session_id available for resume".to_string())
     })
+}
+
+// =========================================================================
+// v1 API 路由及处理器变体（K8s 风格路径）
+// -------------------------------------------------------------------------
+// 所有 v1 路由通过 `v1_routes()` 暴露，在 `mod.rs` 中嵌套到
+// /api/v1/workspaces/{ws}/executions 下，因此 v1_routes 中的路径都是相对路径。
+// workspace_id 从 URL Path 中提取，不再依赖 Query 参数或请求体。
+// =========================================================================
+
+/// v1 变体：从 Path 获取 workspace_id，始终按工作空间过滤执行记录。
+pub async fn v1_get_execution_records(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    Query(query): Query<TodoIdQuery>,
+) -> Result<ApiResponse<ExecutionRecordsPage>, AppError> {
+    let page = query.page.unwrap_or(1).max(1);
+    let limit = query.limit.unwrap_or(10).clamp(1, 100);
+    let offset = (page - 1) * limit;
+    let status = match query.status.as_deref() {
+        Some("all") | None => None,
+        Some(s) => Some(
+            s.parse::<ExecutionStatus>()
+                .map(|v| v.as_str())
+                .map_err(AppError::BadRequest)?
+        ),
+    };
+    let (records, total) = state
+        .db
+        .get_execution_records(crate::db::execution::ExecutionRecordQuery {
+            todo_id: query.todo_id,
+            step_id: query.step_id,
+            limit,
+            offset,
+            status,
+            hours: query.hours,
+        })
+        .await?;
+
+    // V1 隔离：workspace_id 来自 URL Path。即使带 todo_id 也要校验其归属本 ws，
+    // 否则 ?todo_id=<他人 todo> 可越权读他人执行记录。返回结果一律按 ws 过滤。
+    if let Some(todo_id) = query.todo_id {
+        workspace_guard::verify_todo_belongs_to_ws(&state.db, todo_id, ws_id).await?;
+    }
+    let ws_todos = state.db.get_todos_by_workspace_id(Some(ws_id)).await?;
+    let ws_todo_ids: std::collections::HashSet<i64> = ws_todos.iter().map(|t| t.id).collect();
+    let records: Vec<_> = records
+        .into_iter()
+        .filter(|r| ws_todo_ids.contains(&r.todo_id))
+        .collect();
+
+    Ok(ApiResponse::ok(ExecutionRecordsPage {
+        records,
+        total,
+        page,
+        limit,
+    }))
+}
+
+/// v1 变体：从 Path 获取 workspace_id，始终按工作空间返回 running board。
+pub async fn v1_get_running_board(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    Query(query): Query<RunningBoardQuery>,
+) -> Result<ApiResponse<crate::models::RunningBoardResponse>, AppError> {
+    let page = query.page.unwrap_or(1).max(1);
+    let limit = query.limit.unwrap_or(50).clamp(1, 200);
+    let offset = (page - 1) * limit;
+
+    let (records, total) = state
+        .db
+        .get_execution_records(crate::db::execution::ExecutionRecordQuery {
+            todo_id: None,
+            step_id: None,
+            limit,
+            offset,
+            status: None,
+            hours: query.hours,
+        })
+        .await?;
+
+    // v1 路径下 workspace_id 始终来自 Path，强制按工作空间过滤
+    let ws_todos = state.db.get_todos_by_workspace_id(Some(ws_id)).await?;
+    let ws_todo_ids: std::collections::HashSet<i64> = ws_todos.iter().map(|t| t.id).collect();
+    let records = records.into_iter().filter(|r| ws_todo_ids.contains(&r.todo_id)).collect();
+
+    // v1 路径下使用 Path 中的 workspace_id 查询定时任务
+    let scheduled_todos = state.db.get_scheduler_todos(Some(ws_id)).await?;
+
+    Ok(ApiResponse::ok(crate::models::RunningBoardResponse {
+        records,
+        scheduled_todos,
+        total,
+        page,
+        limit,
+    }))
+}
+
+/// v1 变体：从 Path 获取 workspace_id，不再依赖请求体中的 workspace_id 字段。
+pub async fn v1_smart_create_handler(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    ApiJson(req): ApiJson<SmartCreateRequest>,
+) -> Result<ApiResponse<serde_json::Value>, AppError> {
+    let content = req.content.trim();
+    if content.is_empty() {
+        return Err(AppError::BadRequest("内容不能为空".to_string()));
+    }
+
+    // v1 使用 Path 中的 workspace_id 而非请求体内的 workspace_id 字段
+    let workspace_settings = crate::db::workspace_setting::get_workspace_settings(&state.db, ws_id).await?
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 #{} 不存在", ws_id)))?;
+
+    let todo_id = workspace_settings.default_response_todo_id
+        .ok_or_else(|| AppError::BadRequest("尚未配置默认响应 Todo，请先在工作空间设置中配置".to_string()))?;
+
+    // 验证 Todo 存在
+    let todo = state
+        .db
+        .get_todo(todo_id)
+        .await?
+        .ok_or_else(|| AppError::BadRequest(format!("默认响应 Todo #{} 不存在", todo_id)))?;
+
+    // 检查并发限制
+    // RwLock 中毒恢复：PoisonError 时取内部 guard 继续运行，与 backup.rs 保持一致
+    let max_concurrent = state.config.read().unwrap_or_else(|e| e.into_inner()).max_concurrent_todos;
+    let running_tasks = state.task_manager.get_all_task_infos().await;
+    let running_records = state.db.get_running_records_by_todo_id(todo_id).await?;
+    let running_count_for_todo = running_records
+        .iter()
+        .filter(|r| {
+            if let Some(task_id) = &r.task_id {
+                running_tasks.iter().any(|t| t.task_id == *task_id)
+            } else {
+                false
+            }
+        })
+        .count();
+    if running_count_for_todo >= max_concurrent as usize {
+        return Err(AppError::BadRequest(format!(
+            "默认响应 Todo #{} 已有 {} 个执行在运行中（上限 {}），请稍后再试",
+            todo_id, running_count_for_todo, max_concurrent
+        )));
+    }
+
+    // 构建模板参数
+    let mut params = std::collections::HashMap::new();
+    params.insert("content".to_string(), content.to_string());
+    params.insert("message".to_string(), content.to_string());
+    params.insert("raw_message".to_string(), content.to_string());
+
+    let mut message = todo.prompt.clone();
+
+    // 如果 prompt 模板中没有任何占位符，将用户内容追加到 message 末尾，
+    // 确保用户提交的内容一定能传递到执行器
+    let has_placeholder = params.keys().any(|key| message.contains(&format!("{{{{{}}}}}", key)));
+    if !has_placeholder {
+        if message.is_empty() {
+            message = content.to_string();
+        } else {
+            message = format!("{}\n\n{}", message, content);
+        }
+    }
+
+    let result = start_todo_execution(RunTodoExecutionRequest {
+        db: state.db.clone(),
+        executor_registry: state.executor_registry.clone(),
+        tx: state.tx.clone(),
+        task_manager: state.task_manager.clone(),
+        config: state.config.clone(),
+        todo_id,
+        message,
+        req_executor: None,
+        trigger_type: "smart_create".to_string(),
+        params: Some(params),
+        resume_session_id: None,
+        resume_message: None,
+        source_todo_id: None,
+        source_todo_title: None,
+        loop_step_execution_id: None,
+        step_id: None,
+        feishu_bot_id: None,
+        feishu_receive_id: None,
+            feishu_receive_id_type: None,
+        workspace_path: None,
+        // 从 todo 中提取 workspace_id，用于 FeishuPushService 按 workspace 隔离推送
+        workspace_id: todo.workspace_id,
+        // smart_create 路径：同样注入专家上下文，新建 todo 可能带 expert_name
+        expert_manager: Some(state.expert_manager.clone()),
+    })
+    .await?;
+
+    let record_id = result.record_id
+        .ok_or_else(|| AppError::Internal("执行启动失败：未获取到执行记录 ID".to_string()))?;
+
+    Ok(ApiResponse::ok(serde_json::json!({
+        "task_id": result.task_id,
+        "record_id": record_id,
+        "todo_id": todo_id,
+        "todo_title": todo.title,
+    })))
+}
+
+/// v1 路由集合：所有路径相对于 /api/v1/workspaces/{ws}/executions。
+/// 在 `mod.rs` 中通过 `.nest("/api/v1/workspaces/{ws}/executions", execution::v1_routes())`
+/// 挂载，路径中的 {ws} 自动传递给每个处理器。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        // GET / — 列出工作空间下的执行记录
+        .route("/", get(v1_get_execution_records))
+        // POST / — 启动一个 todo 执行
+        .route("/", post(execute_handler))
+        // GET /{id} — 获取单条执行记录详情
+        .route("/{id}", get(get_execution_record))
+        // PUT /{id}/rating — 评分子执行记录
+        .route("/{id}/rating", put(rate_execution_handler))
+        // GET /{id}/logs — 获取执行日志
+        .route("/{id}/logs", get(get_execution_logs_handler))
+        // POST /{id}/resume — 恢复已完成的执行
+        .route("/{id}/resume", post(resume_execution_handler))
+        // POST /{id}/stop — 停止执行（路径指定 record_id，已做 ws 归属校验）
+        .route("/{id}/stop", post(stop_execution_handler))
+        // POST /{id}/force-fail — 强制标记执行为失败
+        .route("/{id}/force-fail", post(force_fail_execution_handler))
+        // GET /running — 本工作空间正在运行的执行记录
+        .route("/running", get(get_running_execution_records_handler))
+        // GET /running-board — 工作空间运行看板
+        .route("/running-board", get(v1_get_running_board))
+        // GET /running-todos — 本工作空间正在运行的事项
+        .route("/running-todos", get(get_running_todos))
+        // GET /session/{session_id} — 按会话 ID 查执行记录
+        .route("/session/{session_id}", get(get_execution_records_by_session))
 }
 
 #[cfg(test)]

--- a/backend/src/handlers/experts.rs
+++ b/backend/src/handlers/experts.rs
@@ -1020,6 +1020,50 @@ pub fn expert_routes() -> axum::Router<AppState> {
         )
 }
 
+/// V1 专家 API 路由定义（API 重构过渡期）
+///
+/// 与 `expert_routes()` 共存，路由前缀改为 /api/v1/experts，全路径注册。
+/// 新旧路由在顶层通过不同的 Router merge 组装，此处不走嵌套前缀。
+pub fn v1_routes() -> axum::Router<AppState> {
+    use axum::routing::{get, post};
+
+    // V1 路由约定：
+    // - POST /api/v1/experts 替代旧的 POST /api/experts/create，遵循 REST 集合语义。
+    // - POST /api/v1/experts/reload 保持路径风格（无冒号），与旧路由一致。
+    // - 其余路径将 /api 替换为 /api/v1，参数模式不变。
+    // - delete/put 作为 MethodRouter 方法链使用，无需 routing::delete/put 导入。
+    Router::new()
+        // GET + POST 共享 /api/v1/experts（POST 创建，取代旧的 /api/experts/create）
+        .route(
+            "/api/v1/experts",
+            get(get_experts).post(create_expert),
+        )
+        // GET + PUT + DELETE 共享 /api/v1/experts/{name}
+        .route(
+            "/api/v1/experts/{name}",
+            get(get_expert).put(update_expert).delete(delete_expert),
+        )
+        .route("/api/v1/experts/{name}/plugin-json", get(get_expert_plugin_json))
+        .route("/api/v1/experts/{name}/agent-md", get(get_expert_agent_md))
+        .route("/api/v1/experts/{name}/skills", get(get_expert_skills))
+        .route("/api/v1/experts/{name}/avatar", get(get_expert_avatar))
+        .route(
+            "/api/v1/experts/{name}/members/{member_id}/avatar",
+            get(get_expert_member_avatar),
+        )
+        .route("/api/v1/experts/{name}/export", get(export_expert))
+        .route("/api/v1/experts/reload", post(reload_experts))
+        .route("/api/v1/experts/import", post(import_expert))
+        .route(
+            "/api/v1/experts/import-from-directory",
+            post(import_expert_from_directory),
+        )
+        .route(
+            "/api/v1/experts/import-from-workbuddy",
+            post(import_from_workbuddy),
+        )
+}
+
 // ── 从 WorkBuddy 导入 API ──────────────────────────────────────────────
 
 /// WorkBuddy 专家目录的默认相对路径

--- a/backend/src/handlers/feishu_history.rs
+++ b/backend/src/handlers/feishu_history.rs
@@ -1,5 +1,9 @@
-use axum::extract::{Path, Query, State};
-use axum::Json;
+use axum::{
+    Router,
+    extract::{Path, Query, State},
+    routing::{delete, get},
+    Json,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::handlers::{AppError, AppState};
@@ -250,4 +254,26 @@ pub struct MessageStatsParams {
     pub hours: Option<u32>,
     /// 按工作空间筛选统计，不传则返回全部
     pub workspace_id: Option<i64>,
+}
+
+/// v1 API 路由：全局 /api/v1 前缀下，飞书历史消息查询 + 绑定管理。
+///
+/// 路径使用完整路径（不以 /api/v1 嵌套），与 existing `backup::v1_routes` 风格一致。
+/// 这些资源是全局的（不绑定 workspace），保留原有 handler 签名不变。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/api/v1/feishu/history-messages",
+            get(get_history_messages),
+        )
+        .route("/api/v1/feishu/message-stats", get(get_message_stats))
+        .route("/api/v1/feishu/senders", get(get_distinct_senders))
+        .route(
+            "/api/v1/feishu/history-chats",
+            get(get_history_chats).post(create_history_chat),
+        )
+        .route(
+            "/api/v1/feishu/history-chats/{id}",
+            delete(delete_history_chat).put(update_history_chat),
+        )
 }

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -23,7 +23,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::handlers::{AppError, AppState};
+use crate::handlers::{workspace_guard, AppError, AppState};
 use crate::models::{
     self,
     ApiResponse, BatchCopyLoopWorkspaceRequest, BatchUpdateLoopWorkspaceRequest,
@@ -2203,6 +2203,546 @@ pub fn loop_routes() -> axum::Router<AppState> {
         .route("/api/loops/import/preview", post(import_preview))
         .route("/api/loops/import", post(import_loops))
         .route("/api/loops/merge", post(merge_loops))
+}
+
+// ====== V1 API handlers (workspace-scoped paths, nested under /api/v1/workspaces/{ws}/loops) ======
+// V1 handlers differ from the originals only in how they extract ws_id:
+// - routes without ws_id in v0 (list, create) receive it via Path(ws_id)
+// - routes with other Path params (id, loop_id, etc.) get ws_id prepended as a tuple prefix
+// This file keeps both v0 and v1 code until the migration is complete.
+
+/// GET / (nested) — list loops filtered by workspace from path
+pub async fn list_loops_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1: workspace_id 从路径参数取，不再依赖查询参数中的 workspace_id
+    let rows = state.db.list_loops_with_counts(Some(ws_id)).await?;
+    let items: Vec<LoopListItem> = rows.into_iter().map(Into::into).collect();
+    let loop_ids: Vec<i64> = items.iter().map(|item| item.loop_.id).collect();
+    let tag_map = state.db.get_loop_tag_ids_batch(&loop_ids).await?;
+    let results: Vec<LoopListItem> = items
+        .into_iter()
+        .map(|item| {
+            let tag_ids = tag_map.get(&item.loop_.id).cloned().unwrap_or_default();
+            item.with_tags(tag_ids)
+        })
+        .collect();
+    Ok(ApiResponse::ok(results))
+}
+
+/// POST / (nested) — create loop, force workspace_id from path
+pub async fn create_loop_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    Json(mut req): Json<CreateLoopRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1: workspace_id 强制从路径取，覆盖请求体中的值，避免路径与 body 不一致
+    req.workspace_id = ws_id;
+    if req.name.trim().is_empty() {
+        return Err(AppError::BadRequest("name 不能为空".to_string()));
+    }
+    let workspace = state
+        .db
+        .get_project_directory_by_id(req.workspace_id)
+        .await?
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", req.workspace_id)))?;
+    if req.tag_ids.len() > 1 {
+        return Err(AppError::BadRequest("环路只能选择一个标签".to_string()));
+    }
+    let created = state
+        .db
+        .create_loop(
+            req.name.trim(),
+            &req.description,
+            Some(req.workspace_id),
+            Some(workspace.path.as_str()),
+            req.webhook_enabled,
+            &req.icon,
+            req.review_template_id,
+            req.limits_config.as_deref(),
+            req.abnormal_handler_todo_id,
+            &req.abnormal_handler_trigger_on,
+        )
+        .await?;
+    if !req.tag_ids.is_empty() {
+        state.db.set_loop_tags(created.id, &req.tag_ids).await?;
+    }
+    let tag_ids = state.db.get_loop_tag_ids(created.id).await?;
+    Ok((StatusCode::CREATED, ApiResponse::ok(LoopDto::from(created).with_tags(tag_ids))))
+}
+
+/// GET /{id} (nested) — loop detail, 先校验 loop 属于路径 workspace 再取详情
+pub async fn get_loop_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, id)): Path<(i64, i64)>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1 隔离：loop id 全局唯一不等于「跨 ws 可见」，必须校验归属路径中的 workspace
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, id, _ws_id).await?;
+    let view = state.db.load_loop_full(id).await?
+        .ok_or(AppError::NotFound)?;
+    let tag_ids = state.db.get_loop_tag_ids(id).await?;
+    let mut detail = LoopDetail::from(view);
+    detail.loop_ = detail.loop_.with_tags(tag_ids);
+    Ok(ApiResponse::ok(detail))
+}
+
+/// PUT /{id} (nested) — full update, 先校验 loop 归属路径 workspace
+pub async fn update_loop_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, id)): Path<(i64, i64)>,
+    Json(req): Json<UpdateLoopRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if req.name.trim().is_empty() {
+        return Err(AppError::BadRequest("name 不能为空".to_string()));
+    }
+    // V1 隔离：校验 loop 当前属于路径 workspace，防止越权改别人的 loop。
+    // verify 已含存在性校验（NotFound），不再单独 get_loop 探测存在。
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, id, _ws_id).await?;
+    // 若 body 指定 workspace_id（迁移到新 workspace），解析其 path 做双字段同步写入；
+    // None 表示保持当前 workspace 不变。原 take()/重读 req 的死逻辑已移除。
+    let workspace_path: Option<String> = if let Some(wid) = req.workspace_id {
+        Some(state.db.get_project_directory_by_id(wid).await?
+            .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", wid)))?.path)
+    } else {
+        None
+    };
+    state.db.update_loop(
+        id, req.name.trim(), &req.description,
+        req.workspace_id, workspace_path.as_deref(),
+        req.webhook_enabled, &req.icon, req.review_template_id,
+        req.limits_config.as_deref(), req.abnormal_handler_todo_id,
+        &req.abnormal_handler_trigger_on,
+    ).await?;
+    if let Some(ref tag_ids) = req.tag_ids {
+        if tag_ids.len() > 1 {
+            return Err(AppError::BadRequest("环路只能选择一个标签".to_string()));
+        }
+        state.db.set_loop_tags(id, tag_ids).await?;
+    }
+    let updated = state.db.get_loop(id).await?.ok_or(AppError::NotFound)?;
+    let tag_ids = state.db.get_loop_tag_ids(id).await?;
+    Ok(ApiResponse::ok(LoopDto::from(updated).with_tags(tag_ids)))
+}
+
+/// DELETE /{id} (nested) — delete loop, 先校验归属再删
+pub async fn delete_loop_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, id)): Path<(i64, i64)>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1 隔离：校验 loop 属于路径 workspace（verify 已含存在性校验，替换原 get_loop 探测）
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, id, _ws_id).await?;
+    let triggers = state.db.list_triggers_by_loop(id).await?;
+    for t in triggers.iter().filter(|t| t.trigger_type == "cron") {
+        if let Some(sched) = state.loop_scheduler.as_ref() {
+            sched.remove_cron_trigger(t.id).await;
+        }
+    }
+    state.db.delete_loop(id).await?;
+    Ok(ApiResponse::ok(()))
+}
+
+/// PUT /{id}/status (nested) — toggle enabled/paused
+pub async fn update_loop_status_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, id)): Path<(i64, i64)>,
+    Json(req): Json<UpdateLoopStatusRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    models::validate_loop_status(&req.status)
+        .map_err(AppError::BadRequest)?;
+    // V1 隔离：校验 loop 属于路径 workspace（verify 已含存在性校验）
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, id, _ws_id).await?;
+    state.db.update_loop_status(id, &req.status).await?;
+    if let Some(sched) = state.loop_scheduler.as_ref() {
+        let _ = sched.reload_all().await;
+    }
+    let updated = state.db.get_loop(id).await?.ok_or(AppError::NotFound)?;
+    let tag_ids = state.db.get_loop_tag_ids(id).await?;
+    Ok(ApiResponse::ok(LoopDto::from(updated).with_tags(tag_ids)))
+}
+
+/// PUT /{id}/tags (nested) — replace tags
+pub async fn update_loop_tags_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, id)): Path<(i64, i64)>,
+    Json(req): Json<UpdateTagsRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1 隔离：校验 loop 属于路径 workspace（verify 已含存在性校验）
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, id, _ws_id).await?;
+    if req.tag_ids.len() > 1 {
+        return Err(AppError::BadRequest("环路只能选择一个标签".to_string()));
+    }
+    state.db.set_loop_tags(id, &req.tag_ids).await?;
+    let updated = state.db.get_loop(id).await?.ok_or(AppError::NotFound)?;
+    let tag_ids = state.db.get_loop_tag_ids(id).await?;
+    Ok(ApiResponse::ok(LoopDto::from(updated).with_tags(tag_ids)))
+}
+
+/// POST /{id}/duplicate (nested) — duplicate loop
+pub async fn duplicate_loop_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, id)): Path<(i64, i64)>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1 隔离：校验源 loop 属于路径 workspace，复制产物继承同一 workspace
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, id, _ws_id).await?;
+    let new_loop = state.db.duplicate_loop(id).await?
+        .ok_or(AppError::NotFound)?;
+    if let Some(sched) = state.loop_scheduler.as_ref() {
+        let _ = sched.reload_all().await;
+    }
+    Ok((StatusCode::CREATED, ApiResponse::ok(LoopDto::from(new_loop).with_tags(vec![]))))
+}
+
+/// POST /{id}/trigger (nested) — manual trigger
+pub async fn trigger_loop_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, id)): Path<(i64, i64)>,
+    Json(req): Json<TriggerLoopRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1 隔离：校验 loop 属于路径 workspace，防止越权触发别人的 loop
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, id, _ws_id).await?;
+    let dispatcher = state.loop_trigger_dispatcher.as_ref()
+        .ok_or_else(|| AppError::Internal("loop dispatcher not ready".to_string()))?;
+    let trigger_meta = serde_json::json!({
+        "source": "manual",
+        "params": req.params,
+    });
+    match dispatcher.dispatch_manual_with_meta(id, trigger_meta).await {
+        Some(exec_id) => Ok(ApiResponse::ok(serde_json::json!({
+            "execution_id": exec_id,
+        }))),
+        None => Err(AppError::BadRequest("loop 不存在或未启用".to_string())),
+    }
+}
+
+// ====== V1 Triggers ======
+
+/// GET /{id}/triggers (nested) — list triggers
+pub async fn list_triggers_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, loop_id)): Path<(i64, i64)>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1 隔离：校验父 loop 属于路径 workspace，再列其子资源
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, loop_id, _ws_id).await?;
+    let triggers = state.db.list_triggers_by_loop(loop_id).await?;
+    let dtos: Vec<LoopTriggerDto> = triggers.into_iter().map(Into::into).collect();
+    Ok(ApiResponse::ok(dtos))
+}
+
+/// POST /{id}/triggers (nested) — create trigger
+pub async fn create_trigger_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, loop_id)): Path<(i64, i64)>,
+    Json(req): Json<CreateTriggerRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    models::validate_trigger_type(&req.trigger_type)
+        .map_err(AppError::BadRequest)?;
+    // V1 隔离：校验父 loop 属于路径 workspace（verify 已含存在性校验）
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, loop_id, _ws_id).await?;
+    let created = state.db.create_trigger(
+        loop_id, &req.trigger_type, &req.config, req.enabled, req.priority,
+    ).await?;
+    if created.trigger_type == "cron" && created.enabled == 1 {
+        if let Some(sched) = state.loop_scheduler.as_ref() {
+            let _ = sched.upsert_cron_trigger(created.id).await;
+        }
+    }
+    Ok((StatusCode::CREATED, ApiResponse::ok(LoopTriggerDto::from(created))))
+}
+
+/// PUT /{id}/triggers/{tid} (nested) — update trigger
+pub async fn update_trigger_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, loop_id, tid)): Path<(i64, i64, i64)>,
+    Json(req): Json<UpdateTriggerRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    models::validate_trigger_type(&req.trigger_type)
+        .map_err(AppError::BadRequest)?;
+    // V1 隔离：校验父 loop 属于路径 workspace（后续 updated.loop_id != loop_id 校验子资源归属）
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, loop_id, _ws_id).await?;
+    state.db.get_trigger(tid).await?.ok_or(AppError::NotFound)?;
+    state.db.update_trigger(tid, &req.trigger_type, &req.config, req.enabled, req.priority).await?;
+    if let Some(sched) = state.loop_scheduler.as_ref() {
+        let _ = sched.upsert_cron_trigger(tid).await;
+    }
+    let updated = state.db.get_trigger(tid).await?
+        .ok_or(AppError::NotFound)?;
+    if updated.loop_id != loop_id {
+        return Err(AppError::BadRequest("trigger 不属于该 loop".to_string()));
+    }
+    Ok(ApiResponse::ok(LoopTriggerDto::from(updated)))
+}
+
+/// DELETE /{id}/triggers/{tid} (nested) — delete trigger
+pub async fn delete_trigger_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, _loop_id, tid)): Path<(i64, i64, i64)>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1 隔离：校验父 loop 属于路径 workspace，再按 tid 删 trigger
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, _loop_id, _ws_id).await?;
+    state.db.get_trigger(tid).await?.ok_or(AppError::NotFound)?;
+    if let Some(sched) = state.loop_scheduler.as_ref() {
+        sched.remove_cron_trigger(tid).await;
+    }
+    state.db.delete_trigger(tid).await?;
+    Ok(ApiResponse::ok(()))
+}
+
+// ====== V1 Steps ======
+
+/// GET /{id}/steps (nested) — list steps
+pub async fn list_loop_steps_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, loop_id)): Path<(i64, i64)>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1 隔离：校验父 loop 属于路径 workspace，再列其 steps
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, loop_id, _ws_id).await?;
+    let rows = state.db.list_loop_steps_with_todo_meta(loop_id).await?;
+    let dtos: Vec<LoopStepDto> = rows.into_iter()
+        .map(|(s, todo_title, todo_executor, todo_archived_at)| LoopStepDto {
+            step: s.into(), todo_title, todo_executor, todo_archived_at,
+        })
+        .collect();
+    Ok(ApiResponse::ok(dtos))
+}
+
+/// POST /{id}/steps (nested) — create step
+pub async fn create_loop_step_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, loop_id)): Path<(i64, i64)>,
+    Json(req): Json<CreateLoopStepRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if req.name.trim().is_empty() {
+        return Err(AppError::BadRequest("name 不能为空".to_string()));
+    }
+    // V1 隔离：校验父 loop 属于路径 workspace（verify 已含存在性校验）
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, loop_id, _ws_id).await?;
+    state.db.get_todo(req.todo_id).await?
+        .ok_or_else(|| AppError::BadRequest(format!("todo #{} 不存在", req.todo_id)))?;
+    let created = state.db.create_loop_step(
+        loop_id, req.name.trim(), &req.description, req.todo_id,
+        &req.run_mode, req.skip_on_source_failed, req.min_rating,
+        &req.unrated_policy, req.enabled, &req.on_success,
+        req.success_goto_step_id, &req.on_rating_fail,
+        req.fail_goto_step_id, &req.review_type,
+    ).await?;
+    let (_, todo_title, todo_executor, todo_archived_at) = state.db
+        .list_loop_steps_with_todo_meta(loop_id).await?
+        .into_iter()
+        .find(|(s, _, _, _)| s.id == created.id)
+        .ok_or_else(|| AppError::Internal("created step missing".to_string()))?;
+    Ok((StatusCode::CREATED, ApiResponse::ok(LoopStepDto {
+        step: created.into(), todo_title, todo_executor, todo_archived_at,
+    })))
+}
+
+/// PUT /{id}/steps/{sid} (nested) — update step
+pub async fn update_loop_step_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, loop_id, sid)): Path<(i64, i64, i64)>,
+    Json(req): Json<UpdateLoopStepRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if req.name.trim().is_empty() {
+        return Err(AppError::BadRequest("name 不能为空".to_string()));
+    }
+    // V1 隔离：校验父 loop 属于路径 workspace（后续 step.loop_id != loop_id 校验子资源归属）
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, loop_id, _ws_id).await?;
+    let step = state.db.get_loop_step(sid).await?.ok_or(AppError::NotFound)?;
+    if step.loop_id != loop_id {
+        return Err(AppError::BadRequest("step 不属于该 loop".to_string()));
+    }
+    if req.todo_id != step.todo_id {
+        state.db.get_todo(req.todo_id).await?
+            .ok_or_else(|| AppError::BadRequest(format!("todo #{} 不存在", req.todo_id)))?;
+    }
+    if req.on_rating_fail == "goto" && req.fail_goto_step_id == Some(sid) {
+        let loop_ = state.db.get_loop(loop_id).await?.ok_or(AppError::NotFound)?;
+        #[derive(serde::Deserialize, Default)]
+        struct LimitsConfig {
+            max_step_executions: Option<i32>,
+            max_total_tokens: Option<i64>,
+        }
+        let limits: LimitsConfig = serde_json::from_str(&loop_.limits_config).unwrap_or_default();
+        if limits.max_step_executions.is_none() && limits.max_total_tokens.is_none() {
+            return Err(AppError::BadRequest(
+                "评分不通过时跳转到自身需要配置「最大执行步数」或「最大 Token 数」兜底".to_string(),
+            ));
+        }
+    }
+    state.db.update_loop_step(
+        sid, req.name.trim(), &req.description, req.todo_id,
+        &req.run_mode, req.skip_on_source_failed, req.min_rating,
+        &req.unrated_policy, req.enabled, &req.on_success,
+        req.success_goto_step_id, &req.on_rating_fail,
+        req.fail_goto_step_id, &req.review_type,
+    ).await?;
+    let (_, todo_title, todo_executor, todo_archived_at) = state.db
+        .list_loop_steps_with_todo_meta(loop_id).await?
+        .into_iter()
+        .find(|(s, _, _, _)| s.id == sid)
+        .ok_or_else(|| AppError::Internal("updated step missing".to_string()))?;
+    Ok(ApiResponse::ok(LoopStepDto {
+        step: state.db.get_loop_step(sid).await?.ok_or(AppError::Internal("step missing".to_string()))?.into(),
+        todo_title, todo_executor, todo_archived_at,
+    }))
+}
+
+/// DELETE /{id}/steps/{sid} (nested) — delete step
+pub async fn delete_loop_step_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, _loop_id, sid)): Path<(i64, i64, i64)>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1 隔离：校验父 loop 属于路径 workspace，再按 sid 删 step
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, _loop_id, _ws_id).await?;
+    state.db.get_loop_step(sid).await?.ok_or(AppError::NotFound)?;
+    state.db.delete_loop_step(sid).await?;
+    Ok(ApiResponse::ok(()))
+}
+
+/// POST /{id}/steps/reorder (nested) — batch reorder steps
+pub async fn reorder_loop_steps_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, loop_id)): Path<(i64, i64)>,
+    Json(req): Json<ReorderLoopStepsRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1 隔离：校验父 loop 属于路径 workspace（verify 已含存在性校验）
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, loop_id, _ws_id).await?;
+    state.db.reorder_loop_steps(loop_id, &req.ordered_ids).await?;
+    Ok(ApiResponse::ok(()))
+}
+
+// ====== V1 Executions ======
+
+/// GET /{id}/executions (nested) — paginated execution history
+pub async fn list_executions_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, loop_id)): Path<(i64, i64)>,
+    Query(q): Query<ExecutionPageQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1 隔离：校验父 loop 属于路径 workspace，再列其执行历史
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, loop_id, _ws_id).await?;
+    let limit = q.limit.unwrap_or(DEFAULT_PAGE_LIMIT).min(MAX_PAGE_LIMIT);
+    let page = q.page.unwrap_or(1).max(1);
+    let offset = (page - 1) * limit;
+    let records = state.db.list_loop_executions(loop_id, limit, offset, q.hours).await?;
+    let total = state.db.count_loop_executions(loop_id).await?;
+    let exec_ids: Vec<i64> = records.iter().map(|r| r.id).collect();
+    let pending_counts = state.db.count_pending_approvals_by_execution_ids(&exec_ids).await?;
+    let mut items: Vec<LoopExecutionDto> = records.into_iter().map(Into::into).collect();
+    for item in &mut items {
+        item.pending_approval_count = pending_counts.get(&item.id).copied().unwrap_or(0);
+        let step_execs = state.db.list_loop_step_executions(item.id).await?;
+        let mut enriched: Vec<LoopStepExecutionDto> = step_execs.into_iter().map(|se| se.into()).collect();
+        for dto in &mut enriched {
+            enrich_step_execution_with_usage(&state.db, dto).await;
+        }
+        item.token_summary = Some(aggregate_tokens_from_step_dtos(&enriched));
+    }
+    Ok(ApiResponse::ok(serde_json::json!({
+        "items": items, "total": total, "page": page, "limit": limit,
+    })))
+}
+
+/// GET /{id}/executions/{eid} (nested) — single execution detail
+pub async fn get_execution_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, loop_id, eid)): Path<(i64, i64, i64)>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1 隔离：校验父 loop 属于路径 workspace（后续 exec.loop_id != loop_id 校验子资源归属）
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, loop_id, _ws_id).await?;
+    let exec = state.db.get_loop_execution(eid).await?
+        .ok_or(AppError::NotFound)?;
+    if exec.loop_id != loop_id {
+        return Err(AppError::BadRequest("execution 不属于该 loop".to_string()));
+    }
+    let step_execs = state.db.list_loop_step_executions(eid).await?;
+    let loop_name = state.db.get_loop(loop_id).await?
+        .map(|l| l.name).unwrap_or_default();
+    let mut enriched: Vec<LoopStepExecutionDto> = vec![];
+    for se in step_execs {
+        let mut dto: LoopStepExecutionDto = se.into();
+        if dto.step_id == -1 {
+            if let Ok(Some(todo)) = state.db.get_todo(dto.todo_id).await {
+                dto.step_name = Some(format!("[异常处理] {}", todo.title));
+            }
+        } else if let Ok(Some(ls)) = state.db.get_loop_step(dto.step_id).await {
+            dto.step_name = Some(ls.name);
+        }
+        enrich_step_execution_with_usage(&state.db, &mut dto).await;
+        enriched.push(dto);
+    }
+    let token_summary = aggregate_tokens_from_step_dtos(&enriched);
+    Ok(ApiResponse::ok(LoopExecutionDetail {
+        execution: exec.into(), step_executions: enriched,
+        loop_name, token_summary,
+    }))
+}
+
+/// POST /{id}/executions/{eid}/steps/{seid}/approve (nested) — approve step execution
+pub async fn approve_step_execution_v1(
+    State(state): State<AppState>,
+    Path((_ws_id, _loop_id, execution_id, step_execution_id)): Path<(i64, i64, i64, i64)>,
+    Json(req): Json<ApproveStepExecutionRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    // V1 隔离：校验父 loop 属于路径 workspace（后续 loop_exec.loop_id != _loop_id 校验归属）
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, _loop_id, _ws_id).await?;
+    if req.rating < 0 || req.rating > 100 {
+        return Err(AppError::BadRequest("评分必须在 0-100 之间".to_string()));
+    }
+    let step_execs = state.db.list_loop_step_executions(execution_id).await?;
+    let step_exec = step_execs.iter()
+        .find(|se| se.id == step_execution_id)
+        .ok_or(AppError::NotFound)?;
+    let loop_exec = state.db.get_loop_execution(execution_id).await?
+        .ok_or(AppError::NotFound)?;
+    if loop_exec.loop_id != _loop_id {
+        return Err(AppError::BadRequest("该 execution 不属于指定的 loop".to_string()));
+    }
+    if step_exec.status != "pending_approval" {
+        return Err(AppError::BadRequest("该环节当前不需要审批".to_string()));
+    }
+    let min_rating = step_exec.min_rating.unwrap_or(0);
+    let final_status = if req.rating >= min_rating { "success" } else { "failed" };
+    state.db.approve_step_execution(
+        step_execution_id, req.rating, final_status, req.comment.as_deref(),
+    ).await?;
+    let _ = state.tx.send(crate::executor_service::ExecEvent::ReviewStatusChanged {
+        record_id: step_exec.execution_record_id.unwrap_or(0),
+        todo_id: step_exec.todo_id,
+        review_status: final_status.to_string(),
+    });
+    let runner = state.loop_runner.as_ref()
+        .ok_or_else(|| AppError::Internal("loop runner not ready".to_string()))?;
+    runner.resume_loop_execution(execution_id).await;
+    Ok(ApiResponse::ok(serde_json::json!({
+        "step_execution_id": step_execution_id,
+        "rating": req.rating,
+        "status": final_status,
+    })))
+}
+
+// ====== V1 路由表 ======
+// 所有路径为相对路径，外层已剥离 /api/v1/workspaces/{ws}/loops 前缀。
+// 外层 nesting 时 axum 会将 {ws} 路径参数传递到本路由器的各 handler。
+
+/// 返回 v1 路由表（相对路径），由外层嵌套在 /api/v1/workspaces/{ws}/loops 下。
+pub fn v1_routes() -> axum::Router<AppState> {
+    use axum::routing::{get, post, put};
+    axum::Router::new()
+        .route("/", get(list_loops_v1).post(create_loop_v1))
+        .route("/{id}", get(get_loop_v1).put(update_loop_v1).delete(delete_loop_v1))
+        .route("/{id}/status", put(update_loop_status_v1))
+        .route("/{id}/tags", put(update_loop_tags_v1))
+        .route("/{id}/duplicate", post(duplicate_loop_v1))
+        .route("/{id}/trigger", post(trigger_loop_v1))
+        .route("/{id}/triggers", get(list_triggers_v1).post(create_trigger_v1))
+        .route("/{id}/triggers/{tid}", put(update_trigger_v1).delete(delete_trigger_v1))
+        .route("/{id}/steps", get(list_loop_steps_v1).post(create_loop_step_v1))
+        .route("/{id}/steps/reorder", post(reorder_loop_steps_v1))
+        .route("/{id}/steps/{sid}", put(update_loop_step_v1).delete(delete_loop_step_v1))
+        .route("/{id}/executions", get(list_executions_v1))
+        .route("/{id}/executions/{eid}", get(get_execution_v1))
+        .route("/{id}/executions/{eid}/steps/{seid}/approve", post(approve_step_execution_v1))
 }
 
 // ====== 导入工作空间逐 loop 解析的单元测试 ======

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -2721,6 +2721,141 @@ pub async fn approve_step_execution_v1(
     })))
 }
 
+/// GET /stats — 当前 workspace 的 loop 聚合统计。
+pub async fn get_loop_stats_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    Query(params): Query<LoopStatsQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    let stats = state.db.get_loop_stats_for_workspace(Some(ws_id), params.hours).await?;
+    Ok(ApiResponse::ok(stats))
+}
+
+/// POST /batch/workspace — 批量移动 loop 到其他 workspace。
+pub async fn batch_move_loops_workspace_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    Json(req): Json<BatchUpdateLoopWorkspaceRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if req.ids.is_empty() {
+        return Err(AppError::BadRequest("ids 不能为空".to_string()));
+    }
+    workspace_guard::verify_loops_belong_to_ws(&state.db, &req.ids, ws_id).await?;
+    let dir = state
+        .db
+        .get_project_directory_by_id(req.workspace_id)
+        .await?
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", req.workspace_id)))?;
+    let rows_affected = state
+        .db
+        .batch_update_loops_workspace(&req.ids, req.workspace_id, &dir.path)
+        .await?;
+    Ok(ApiResponse::ok(BatchWorkspaceResult {
+        updated_count: rows_affected as i64,
+        total: req.ids.len() as i64,
+    }))
+}
+
+/// POST /batch/copy-workspace — 批量复制 loop 到其他 workspace。
+pub async fn batch_copy_loops_workspace_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    Json(req): Json<BatchCopyLoopWorkspaceRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if req.ids.is_empty() {
+        return Err(AppError::BadRequest("ids 不能为空".to_string()));
+    }
+    workspace_guard::verify_loops_belong_to_ws(&state.db, &req.ids, ws_id).await?;
+    let dir = state
+        .db
+        .get_project_directory_by_id(req.workspace_id)
+        .await?
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", req.workspace_id)))?;
+    let created_ids = state
+        .db
+        .batch_copy_loops_to_workspace(&req.ids, req.workspace_id, &dir.path)
+        .await?;
+    Ok(ApiResponse::ok(BatchWorkspaceResult {
+        updated_count: created_ids.len() as i64,
+        total: req.ids.len() as i64,
+    }))
+}
+
+/// GET /{id}/export — 导出单个 loop（workspace 隔离）。
+pub async fn export_loop_v1(
+    State(state): State<AppState>,
+    Path((ws_id, id)): Path<(i64, i64)>,
+) -> Result<impl IntoResponse, AppError> {
+    workspace_guard::verify_loop_belongs_to_ws(&state.db, id, ws_id).await?;
+    let loops = state.db.list_loops_with_counts(Some(ws_id)).await?;
+    let loop_row = loops.into_iter().find(|l| l.loop_.id == id);
+    let loop_ = loop_row.ok_or(AppError::NotFound)?.loop_;
+    let yaml = build_loop_export_yaml(&state, &[id]).await?;
+    let filename = format!(
+        "{}-{}.loop.yaml",
+        loop_.name.replace(' ', "-"),
+        chrono::Utc::now().format("%Y%m%d-%H%M%S")
+    );
+    let disposition = format!("attachment; filename=\"{}\"", filename);
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/x-yaml; charset=utf-8".to_string()),
+            (header::CONTENT_DISPOSITION, disposition),
+        ],
+        yaml,
+    ))
+}
+
+/// POST /export-selected — 批量导出选中的 loop（workspace 隔离）。
+pub async fn export_selected_loops_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    Json(req): Json<ExportLoopSelectedRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if req.loop_ids.is_empty() {
+        return Err(AppError::BadRequest("loop_ids 不能为空".to_string()));
+    }
+    workspace_guard::verify_loops_belong_to_ws(&state.db, &req.loop_ids, ws_id).await?;
+    let yaml = build_loop_export_yaml(&state, &req.loop_ids).await?;
+    let filename = format!(
+        "loops-export-{}.loop.yaml",
+        chrono::Utc::now().format("%Y%m%d-%H%M%S")
+    );
+    let disposition = format!("attachment; filename=\"{}\"", filename);
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/x-yaml; charset=utf-8".to_string()),
+            (header::CONTENT_DISPOSITION, disposition),
+        ],
+        yaml,
+    ))
+}
+
+/// GET /export — 导出当前 workspace 全部 loop。
+pub async fn export_all_loops_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+) -> Result<impl IntoResponse, AppError> {
+    let loops = state.db.list_loops_with_counts(Some(ws_id)).await?;
+    let ids: Vec<i64> = loops.into_iter().map(|l| l.loop_.id).collect();
+    if ids.is_empty() {
+        return Err(AppError::BadRequest("当前工作空间没有任何环路可导出".to_string()));
+    }
+    let yaml = build_loop_export_yaml(&state, &ids).await?;
+    let filename = format!(
+        "loops-export-{}.loop.yaml",
+        chrono::Utc::now().format("%Y%m%d-%H%M%S")
+    );
+    let disposition = format!("attachment; filename=\"{}\"", filename);
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/x-yaml; charset=utf-8".to_string()),
+            (header::CONTENT_DISPOSITION, disposition),
+        ],
+        yaml,
+    ))
+}
+
 // ====== V1 路由表 ======
 // 所有路径为相对路径，外层已剥离 /api/v1/workspaces/{ws}/loops 前缀。
 // 外层 nesting 时 axum 会将 {ws} 路径参数传递到本路由器的各 handler。
@@ -2730,7 +2865,13 @@ pub fn v1_routes() -> axum::Router<AppState> {
     use axum::routing::{get, post, put};
     axum::Router::new()
         .route("/", get(list_loops_v1).post(create_loop_v1))
-        // merge 必须注册在 /{id} 之前：axum 字面量路由优先匹配，否则 "merge" 会被当 loop id。
+        // 字面量路由必须注册在 /{id} 之前，避免被当作 loop id 捕获。
+        .route("/stats", get(get_loop_stats_v1))
+        .route("/batch/workspace", post(batch_move_loops_workspace_v1))
+        .route("/batch/copy-workspace", post(batch_copy_loops_workspace_v1))
+        .route("/export", get(export_all_loops_v1))
+        .route("/export-selected", post(export_selected_loops_v1))
+        // merge/import 同样必须在 /{id} 之前。
         // merge_loops / import_loops / import_preview handler 内部已按 workspace 隔离解析。
         .route("/merge", post(merge_loops))
         .route("/import-preview", post(import_preview))
@@ -2739,6 +2880,7 @@ pub fn v1_routes() -> axum::Router<AppState> {
         .route("/{id}/status", put(update_loop_status_v1))
         .route("/{id}/tags", put(update_loop_tags_v1))
         .route("/{id}/duplicate", post(duplicate_loop_v1))
+        .route("/{id}/export", get(export_loop_v1))
         .route("/{id}/trigger", post(trigger_loop_v1))
         .route("/{id}/triggers", get(list_triggers_v1).post(create_trigger_v1))
         .route("/{id}/triggers/{tid}", put(update_trigger_v1).delete(delete_trigger_v1))

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -2730,6 +2730,11 @@ pub fn v1_routes() -> axum::Router<AppState> {
     use axum::routing::{get, post, put};
     axum::Router::new()
         .route("/", get(list_loops_v1).post(create_loop_v1))
+        // merge 必须注册在 /{id} 之前：axum 字面量路由优先匹配，否则 "merge" 会被当 loop id。
+        // merge_loops / import_loops / import_preview handler 内部已按 workspace 隔离解析。
+        .route("/merge", post(merge_loops))
+        .route("/import-preview", post(import_preview))
+        .route("/import", post(import_loops))
         .route("/{id}", get(get_loop_v1).put(update_loop_v1).delete(delete_loop_v1))
         .route("/{id}/status", put(update_loop_status_v1))
         .route("/{id}/tags", put(update_loop_tags_v1))

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -2831,6 +2831,42 @@ pub async fn export_selected_loops_v1(
     ))
 }
 
+/// POST /import-preview (nested) — 预览导入内容，强制 scoping 到 workspace。
+pub async fn import_preview_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    body: Bytes,
+) -> Result<impl IntoResponse, AppError> {
+    // v1 隔离：验证目标 workspace 存在。
+    state.db.get_project_directory_by_id(ws_id).await?
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 #{} 不存在", ws_id)))?;
+    // 委托原 handler；import_preview 只读不写，不接收 workspace_id 参数。
+    import_preview(State(state), body).await
+}
+
+/// POST /import (nested) — 导入 loop 到指定 workspace，强制 scoping。
+pub async fn import_loops_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    Json(mut req): Json<ImportLoopRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    // v1 隔离：路径中的 workspace 覆盖请求体中的 workspace_id 字段，
+    // 确保导入的目标工作空间与 URL 一致，防止跨 workspace 导入。
+    req.workspace_id = Some(ws_id);
+    import_loops(State(state), Json(req)).await
+}
+
+/// POST /merge (nested) — 合并导入 loop 到指定 workspace，强制 scoping。
+pub async fn merge_loops_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    Json(mut req): Json<MergeLoopRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    // v1 隔离：同 import，覆盖 workspace_id 确保与路径一致。
+    req.workspace_id = Some(ws_id);
+    merge_loops(State(state), Json(req)).await
+}
+
 /// GET /export — 导出当前 workspace 全部 loop。
 pub async fn export_all_loops_v1(
     State(state): State<AppState>,
@@ -2872,10 +2908,10 @@ pub fn v1_routes() -> axum::Router<AppState> {
         .route("/export", get(export_all_loops_v1))
         .route("/export-selected", post(export_selected_loops_v1))
         // merge/import 同样必须在 /{id} 之前。
-        // merge_loops / import_loops / import_preview handler 内部已按 workspace 隔离解析。
-        .route("/merge", post(merge_loops))
-        .route("/import-preview", post(import_preview))
-        .route("/import", post(import_loops))
+        // v1 包装器强制 workspace 隔离：覆盖请求体中的 workspace_id 为路径参数值。
+        .route("/merge", post(merge_loops_v1))
+        .route("/import-preview", post(import_preview_v1))
+        .route("/import", post(import_loops_v1))
         .route("/{id}", get(get_loop_v1).put(update_loop_v1).delete(delete_loop_v1))
         .route("/{id}/status", put(update_loop_status_v1))
         .route("/{id}/tags", put(update_loop_tags_v1))

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -3,7 +3,7 @@ use axum::{
     extract::{Request, State, WebSocketUpgrade},
     http::{Method, header},
     response::Response,
-    routing::{delete, get, post, put},
+    routing::get,
 };
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::{CorsLayer, Any};
@@ -157,6 +157,9 @@ pub mod experts;
 pub mod bundled;
 pub mod quick_button;
 pub mod profiles;
+/// workspace 归属校验 helper：v1 路由的租户边界守卫（verify_*_belongs_to_ws）。
+/// 所有 workspace-scoped handler 统一调用，避免跨工作空间越权读写。
+pub mod workspace_guard;
 
 // WebSocket handler
 pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
@@ -256,8 +259,10 @@ pub async fn create_app(
     let state = build_app_state(ctx, scheduler).await;
 
     Router::new()
-        .merge(mount_domain_routes())
-        .merge(project_directory::routes())
+        .merge(mount_v1_domain_routes())
+        // project_directory::v1_routes() 已包含在 action::v1_routes() 中，
+        // 不再单独 merge，避免路由重复注册。旧版本 project_directory::routes()
+        // 在 mount_domain_routes() 中保留供过渡期使用。
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024))
         .layer(CompressionLayer::new())
         .layer(cors_layer())
@@ -270,36 +275,26 @@ pub async fn create_app(
         .with_state(state)
 }
 
-/// 把 18 个领域子路由函数合并成一个 Router 一次性 merge 进 `create_app`。
-/// `project_directory` 是另一个模块里实现的同名子路由（不在 18 个里），由 `create_app`
-/// 单独 merge，避免在跨模块拓扑变化时改这个函数。
-fn mount_domain_routes() -> Router<AppState> {
+/// V1 路由装配：将所有领域路由合并为版本化 API。
+///
+/// `action::v1_routes()` 是完整的 v1 API 聚合树，内部已处理：
+/// - 工作空间作用域资源（todos/executions/loops/tags/blackboard/slash-commands/settings）
+///   嵌套在 `/api/v1/workspaces/{ws}` 下
+/// - 全局 agent-bot 管理嵌套在 `/api/v1/agent-bots` 下
+/// - 所有全局资源路由（config/backup/skills/session/usage-stats/feishu/review-templates/
+///   todo-templates/custom-templates/quick-buttons/bundled/webhook/experts/
+///   project-directories 等）已合并，路径带 `/api/v1/` 前缀
+/// - 云端同步（cloud sync）和 action 执行端点也已包含
+///
+/// 非版本化路由（root/static/events）保持原样不嵌套。
+fn mount_v1_domain_routes() -> Router<AppState> {
     Router::new()
+        // 非版本化路由保持原样
         .merge(root_routes())
-        .merge(todo_routes())
-        .merge(execution_routes())
-        .merge(scheduler_routes())
-        .merge(backup_routes())
-        .merge(config_routes())
-        .merge(skills_routes())
-        .merge(agent_bot_routes())
-        .merge(quick_button_routes())
-        .merge(feishu_routes())
-        .merge(webhook_routes())
-        .merge(session_routes())
-        .merge(usage_stats_routes())
-        .merge(version_routes())
         .merge(static_routes())
-        .merge(todo_template_routes())
-        .merge(review_template_routes())
-        .merge(custom_template_routes())
-        .merge(cloud_routes())
         .merge(events_routes())
-        .merge(blackboard::blackboard_routes())
-        .merge(loop_::loop_routes())
-        .merge(experts::expert_routes())
-        .merge(bundled::bundled_routes())
-        .merge(profiles::profile_routes())
+        // v1 版本化 API 由 action::v1_routes() 统一聚合
+        .merge(action::v1_routes())
 }
 
 /// 给 TraceLayer 用的 span 工厂：把 `request_id` / `method` / `uri` 直接挂在 span 字段上，
@@ -570,226 +565,10 @@ fn root_routes() -> Router<AppState> {
         .route("/health", get(health_handler))
 }
 
-/// Todo 与 Tag CRUD。
-fn todo_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/todos", get(todo::get_todos).post(todo::create_todo))
-        .route("/api/todos/center", get(todo::get_todo_center))
-        .route("/api/todos/{id}/force-status", put(todo::force_update_todo_status))
-        .route("/api/todos/{id}/tags", put(todo::update_todo_tags))
-        .route("/api/todos/{id}/summary", get(execution::get_execution_summary))
-        .route("/api/todos/{id}/scheduler", put(scheduler::update_scheduler))
-        .route("/api/todos/{id}/archive", post(todo::archive_todo))
-        .route("/api/todos/{id}/restore", post(todo::restore_todo))
-        .route("/api/todos/{id}/webhook", put(todo::update_webhook))
-        .route("/api/todos/recent-completed", get(todo::get_recent_completed_todos))
-        .route("/api/todos/batch-executor", put(todo::batch_update_todos_executor))
-        .route("/api/todos/batch-workspace", put(todo::batch_move_todos_workspace))
-        .route("/api/todos/batch-copy-workspace", post(todo::batch_copy_todos_workspace))
-        .route("/api/todos/batch-scheduler", put(todo::batch_update_todos_scheduler))
-        .route("/api/todos/{id}", get(todo::get_todo).put(todo::update_todo).delete(todo::delete_todo))
-        .route("/api/tags", get(tag::get_tags).post(tag::create_tag))
-        .route("/api/tags/{id}", delete(tag::delete_tag))
-}
-
-/// 执行记录、执行触发、执行控制相关路由。
-fn execution_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/execution-records", get(execution::get_execution_records))
-        .route("/api/execution-records/running", get(execution::get_running_execution_records_handler))
-        .route("/api/running-board", get(execution::get_running_board))
-        .route("/api/execution-records/session/{session_id}", get(execution::get_execution_records_by_session))
-        .route("/api/execution-records/{id}/logs", get(execution::get_execution_logs_handler))
-        .route("/api/execution-records/{id}", get(execution::get_execution_record))
-        .route("/api/execution-records/{id}/resume", post(execution::resume_execution_handler))
-        .route("/api/execution-records/{id}/rating", put(execution::rate_execution_handler))
-        .route("/api/dashboard-stats", get(execution::get_dashboard_stats))
-        .route("/api/execute", post(execution::execute_handler))
-        .route("/api/smart-create", post(execution::smart_create_handler))
-        .route("/api/execute/stop", post(execution::stop_execution_handler))
-        .route("/api/execute/force-fail", post(execution::force_fail_execution_handler))
-        .route("/api/running-todos", get(execution::get_running_todos))
-        .route("/api/actions/execute", post(action::execute_action))
-}
-
-/// 定时任务相关路由（除 todo 内嵌的 scheduler 字段外，独立的查询入口）。
-fn scheduler_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/scheduler/todos", get(scheduler::get_scheduler_todos))
-}
-
-/// 备份与日志清理相关路由（数据库备份、todo 备份、skills 备份、log 清理）。
-fn backup_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/backup/export", get(backup::export_backup))
-        .route("/api/backup/export-selected", post(backup::export_selected))
-        .route("/api/backup/import", post(backup::import_backup))
-        .route("/api/backup/merge", post(backup::merge_backup))
-        .route("/api/backup/database/download", get(backup::download_database))
-        .route("/api/backup/database/status", get(backup::get_database_backup_status))
-        .route("/api/backup/database/trigger", post(backup::trigger_local_backup))
-        .route("/api/backup/database/auto", put(backup::update_auto_backup))
-        .route("/api/backup/database/optimize", post(backup::database_optimize))
-        .route("/api/backup/database/file", get(backup::download_backup_file).delete(backup::delete_backup_file))
-        .route("/api/backup/todo/status", get(backup::get_todo_backup_status))
-        .route("/api/backup/todo/trigger", post(backup::trigger_todo_backup))
-        .route("/api/backup/todo/auto", put(backup::update_todo_auto_backup))
-        .route("/api/backup/todo/file", get(backup::download_todo_backup_file).delete(backup::delete_todo_backup_file))
-        .route("/api/backup/log-cleanup/status", get(backup::get_log_cleanup_status))
-        .route("/api/backup/log-cleanup", put(backup::update_log_cleanup))
-        .route("/api/backup/log-cleanup/trigger", post(backup::trigger_log_cleanup))
-        .route("/api/backup/skills/status", get(backup::get_skill_backup_status))
-        .route("/api/backup/skills/trigger", post(backup::trigger_skill_backup))
-        .route("/api/backup/skills/auto", put(backup::update_skill_auto_backup))
-        .route("/api/backup/skills/file", get(backup::download_skill_backup_file).delete(backup::delete_skill_backup_file))
-}
-
-/// 系统配置与 executor 配置。
-fn config_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/config", get(config::get_config).put(config::update_config))
-        .route("/api/executors", get(executor_config::list_executors))
-        .route("/api/executors/{name}", put(executor_config::update_executor))
-        .route("/api/executors/{name}/detect", post(executor_config::detect_executor))
-        .route("/api/executors/{name}/test", post(executor_config::test_executor))
-        .route("/api/executors/detect-all", post(executor_config::detect_all_executors))
-        .route("/api/executors/{name}/resolve", post(executor_config::resolve_executor_path))
-        .route("/api/executors/default", get(executor_config::get_default_executor))
-        .route("/api/executors/{name}/default", put(executor_config::set_default_executor))
-        .route("/api/executors/{name}/models", get(executor_config::list_executor_models))
-}
-
-/// Skills 管理（列出/同步/导入导出/调用记录）。
-fn skills_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/skills", get(skills::list_skills).delete(skills::delete_skill))
-        .route("/api/skills/compare", get(skills::compare_skills))
-        .route("/api/skills/version-update", get(skills::version_update_list))
-        .route("/api/skills/sync", post(skills::sync_skill))
-        // 「调用追踪」tab 已移除，列表接口 (list_invocations) 整体删除。
-        // 仅保留 POST 上报，仍给执行器调用记录使用——Dashboard 聚合统计
-        // 走 db/dashboard.rs 单独通道。
-        .route("/api/skills/invocations", post(skills::record_invocation))
-        .route("/api/skills/content", get(skills::get_skill_content))
-        .route("/api/skills/file", get(skills::get_skill_file))
-        .route("/api/skills/export", get(skills::export_skill))
-        .route("/api/skills/import", post(skills::import_skill))
-}
-
-/// Agent bot 路由（飞书 bot 管理、初始化、轮询、推送、群白名单）。
-fn agent_bot_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/agent-bots", get(agent_bot::list_agent_bots))
-        .route("/api/agent-bots/feishu/init", post(agent_bot::feishu_init))
-        .route("/api/agent-bots/feishu/begin", post(agent_bot::feishu_begin))
-        .route("/api/agent-bots/feishu/poll-stream", get(agent_bot::feishu_poll_sse))
-        .route("/api/agent-bots/feishu/push", get(agent_bot::get_feishu_push).put(agent_bot::update_feishu_push))
-        .route("/api/agent-bots/feishu/group-whitelist", get(agent_bot::get_group_whitelist).post(agent_bot::add_group_whitelist))
-        .route("/api/agent-bots/feishu/group-whitelist/{id}", delete(agent_bot::delete_group_whitelist))
-        .route("/api/agent-bots/{id}", delete(agent_bot::delete_agent_bot))
-        .route("/api/agent-bots/{id}/config", put(agent_bot::update_agent_bot_config))
-        .route("/api/agent-bots/{id}/workspace", put(agent_bot::move_bot_to_workspace))
-        // Workspace 斜杠命令管理
-        .route("/api/workspace/{workspace_id}/slash-commands", get(agent_bot::list_workspace_slash_commands).post(agent_bot::create_workspace_slash_command))
-        .route("/api/workspace/{workspace_id}/slash-commands/{cmd_id}", put(agent_bot::update_workspace_slash_command).delete(agent_bot::delete_workspace_slash_command))
-        // Workspace 设置管理
-        .route("/api/workspace/{workspace_id}/settings", get(agent_bot::get_workspace_settings).put(agent_bot::update_workspace_settings))
-}
-
-/// 快捷话术按钮管理（全局，无 workspace 维度）。
-fn quick_button_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/quick-buttons", get(quick_button::list_quick_buttons).post(quick_button::create_quick_button))
-        .route("/api/quick-buttons/{id}", put(quick_button::update_quick_button).delete(quick_button::delete_quick_button))
-}
-
-/// 飞书相关路由：历史消息查询 + 绑定管理。
-fn feishu_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/feishu/history-messages", get(feishu_history::get_history_messages))
-        .route("/api/feishu/message-stats", get(feishu_history::get_message_stats))
-        .route("/api/feishu/senders", get(feishu_history::get_distinct_senders))
-        .route("/api/feishu/history-chats", get(feishu_history::get_history_chats).post(feishu_history::create_history_chat))
-        .route("/api/feishu/history-chats/{id}", delete(feishu_history::delete_history_chat).put(feishu_history::update_history_chat))
-}
-
-/// Webhook 路由：外部触发端点（无 /api 前缀）+ Webhook 管理 API + 调用记录。
-fn webhook_routes() -> Router<AppState> {
-    Router::new()
-        // Todo webhook: /webhook/trigger/todo/{todo_id}
-        .route("/webhook/trigger/todo/{todo_id}", get(webhook::trigger_webhook_with_todo).post(webhook::trigger_webhook_with_todo_post_json))
-        // Loop webhook: /webhook/trigger/loop/{loop_id}
-        .route("/webhook/trigger/loop/{loop_id}", get(webhook::trigger_webhook_with_loop_get).post(webhook::trigger_webhook_with_loop_post))
-}
-
-/// Session 管理路由（列表、统计、详情、删除）。
-fn session_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/sessions", get(session::list_sessions))
-        .route("/api/sessions/stats", get(session::get_session_stats))
-        .route("/api/sessions/{id}", get(session::get_session_detail).delete(session::delete_session))
-}
-
-/// 用量统计（usage stats）相关路由。
-fn usage_stats_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/usage-stats", get(usage_stats::get_usage_stats))
-        .route("/api/usage-stats/refresh", post(usage_stats::refresh_usage_stats))
-        .route("/api/usage-stats/settings", get(usage_stats::get_usage_stats_settings).put(usage_stats::update_usage_stats_settings))
-}
-
-/// 版本查询与升级触发。
-fn version_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/version", get(version_handler))
-        .route("/api/version/latest", get(version_latest_handler))
-        .route("/api/version/upgrade", post(version_upgrade_handler))
-}
-
 /// 静态资源服务（嵌入的 Vite 产物）。
 fn static_routes() -> Router<AppState> {
     Router::new()
         .route("/assets/{*path}", get(static_handler))
-}
-
-/// Todo 模板（用户可复用的 todo 模板）。
-fn todo_template_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/todo-templates", get(todo_template::get_templates).post(todo_template::create_template))
-        .route("/api/todo-templates/{id}", put(todo_template::update_template).delete(todo_template::delete_template))
-        .route("/api/todo-templates/{id}/copy", post(todo_template::copy_template))
-}
-
-/// 评审模板（自动评审用的 prompt 模板，独立于 todos 表）。
-///
-/// 路由说明：
-/// - `/api/review-templates/options` 必须在 `/api/review-templates/{id}` 之前定义，
-///   否则 axum 会把 "options" 当成 id 解析（路由匹配是顺序的）。
-fn review_template_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/review-templates", get(review_template::list_review_templates).post(review_template::create_review_template))
-        .route("/api/review-templates/options", get(review_template::list_review_template_options))
-        .route("/api/review-templates/{id}", get(review_template::get_review_template).put(review_template::update_review_template).delete(review_template::delete_review_template))
-}
-
-/// 自定义模板（云端订阅）相关路由。
-fn custom_template_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/custom-templates/status", get(custom_template::get_custom_template_status))
-        .route("/api/custom-templates/subscribe", post(custom_template::subscribe_custom_template))
-        .route("/api/custom-templates/unsubscribe", post(custom_template::unsubscribe_custom_template))
-        .route("/api/custom-templates/sync", post(custom_template::sync_custom_template))
-        .route("/api/custom-templates/auto-sync", put(custom_template::update_auto_sync_config))
-}
-
-/// 云端同步相关路由。
-fn cloud_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/cloud/config", get(sync::cloud_get_config).post(sync::cloud_save_config))
-        .route("/api/cloud/sync/status", get(sync::cloud_sync_status))
-        .route("/api/cloud/sync/records", get(sync::cloud_sync_records).delete(sync::cloud_clear_sync_records))
-        .route("/api/cloud/sync/push", post(sync::cloud_sync_push))
-        .route("/api/cloud/sync/pull", post(sync::cloud_sync_pull))
 }
 
 /// WebSocket 事件流路由。`/api/events` 单独保留——它升级为 WS 而非普通 HTTP。
@@ -1269,42 +1048,6 @@ mod create_app_refactor_tests {
             None => std::env::remove_var("NTD_MODE"),
         }
         restore(prev_home);
-    }
-
-    /// 每个领域子路由函数都返回非空 `Router<AppState>`，不 panic。
-    /// 用 `Router::route_count` 之类的 introspection API 没有；
-    /// 这里改用「调用函数本身 + assert 返回 Router」——编译过 = 函数存在；
-    /// 不 panic = 基本行为正确。配合 route_equivalence_test 做完整路由覆盖。
-    #[test]
-    fn each_domain_routes_function_returns_a_router() {
-        // 让编译器帮我们检查每个函数都存在且签名正确
-        let routers: Vec<Router<AppState>> = vec![
-            root_routes(),
-            todo_routes(),
-            execution_routes(),
-            scheduler_routes(),
-            backup_routes(),
-            config_routes(),
-            skills_routes(),
-            agent_bot_routes(),
-            feishu_routes(),
-            webhook_routes(),
-            session_routes(),
-            usage_stats_routes(),
-            version_routes(),
-            static_routes(),
-            todo_template_routes(),
-            review_template_routes(),
-            custom_template_routes(),
-            cloud_routes(),
-            events_routes(),
-            blackboard::blackboard_routes(),
-            quick_button_routes(),
-            profiles::profile_routes(),
-        ];
-        // 22 个领域子路由函数（profiles::profile_routes 为 Profile 管理新增）
-        assert_eq!(routers.len(), 22, "领域子路由函数数量应与拆分清单一致");
-        // `Router` 在 axum 0.8 中没有公开的 route_count，这里只能断言"全部成功构造"
     }
 
     /// 重构后 `create_app` 函数体大小合规：去除签名/空行/注释后应在 30 行以内

--- a/backend/src/handlers/project_directory.rs
+++ b/backend/src/handlers/project_directory.rs
@@ -101,3 +101,15 @@ pub fn routes() -> Router<AppState> {
         .route("/api/project-directories/{id}", put(update_project_directory))
         .route("/api/project-directories/{id}", delete(delete_project_directory))
 }
+
+/// API v1 路由：项目目录相关端点。
+///
+/// 将 /api 前缀替换为 /api/v1，参数模式与旧路由保持一致。
+/// 全路径注册，不与外层 router 嵌套（flat 结构）。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/v1/project-directories", get(list_project_directories))
+        .route("/api/v1/project-directories", post(create_project_directory))
+        .route("/api/v1/project-directories/{id}", put(update_project_directory))
+        .route("/api/v1/project-directories/{id}", delete(delete_project_directory))
+}

--- a/backend/src/handlers/quick_button.rs
+++ b/backend/src/handlers/quick_button.rs
@@ -4,8 +4,10 @@
 //! 真正发送走原有 resume 链路，本模块不涉及执行逻辑。
 
 use axum::{
+    Router,
     extract::{Path, State},
     response::IntoResponse,
+    routing::{get, put},
     Json,
 };
 use serde::Deserialize;
@@ -117,6 +119,22 @@ pub async fn delete_quick_button(
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
     Ok(ApiResponse::ok(serde_json::json!({"success": true})))
+}
+
+/// V1 API 路由：为快捷按钮注册 GET/POST/PUT/DELETE 端点，
+/// 路径前缀 /api/v1/quick-buttons（全局资源扁平化，不嵌套 workspace）。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        // 集合操作：列出全部按钮 / 创建新按钮
+        .route(
+            "/api/v1/quick-buttons",
+            get(list_quick_buttons).post(create_quick_button),
+        )
+        // 单资源操作：按 id 更新 / 删除
+        .route(
+            "/api/v1/quick-buttons/{id}",
+            put(update_quick_button).delete(delete_quick_button),
+        )
 }
 
 #[cfg(test)]

--- a/backend/src/handlers/quick_button.rs
+++ b/backend/src/handlers/quick_button.rs
@@ -1,7 +1,11 @@
-//! 快捷话术按钮的 HTTP handler（全局 CRUD，无 workspace 维度）。
+//! 快捷话术按钮的 HTTP handler（按 workspace 隔离的 CRUD）。
 //!
-//! 对应路由 `/api/quick-buttons`。点按钮只在前端填入回复输入框，
+//! 对应路由 `/api/v1/workspaces/{ws}/quick-buttons`。点按钮只在前端填入回复输入框，
 //! 真正发送走原有 resume 链路，本模块不涉及执行逻辑。
+//!
+//! 注意：当前 button_name 仍保持全局 UNIQUE（由 V66 迁移决定），因此不同 workspace
+//! 不能出现同名按钮；后续如需放宽，需重建 quick_buttons 表改为 (workspace_id, button_name)
+//! 联合唯一。
 
 use axum::{
     Router,
@@ -15,11 +19,12 @@ use serde::Deserialize;
 use crate::handlers::{AppError, AppState};
 use crate::models::ApiResponse;
 
-/// 列出全部快捷按钮（按创建时间升序，先加的排前面）。
+/// 列出当前 workspace 的全部快捷按钮（按创建时间升序，先加的排前面）。
 pub async fn list_quick_buttons(
     State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
 ) -> Result<impl IntoResponse, AppError> {
-    let buttons = crate::db::quick_button::get_quick_buttons(&state.db)
+    let buttons = crate::db::quick_button::get_quick_buttons(&state.db, ws_id)
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
     Ok(ApiResponse::ok(buttons))
@@ -34,6 +39,7 @@ pub struct CreateQuickButtonRequest {
 /// 创建快捷按钮：校验非空 + 重名预检（给前端友好 400，而非靠 DB 约束冒泡成 500）。
 pub async fn create_quick_button(
     State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
     Json(req): Json<CreateQuickButtonRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     let name = req.button_name.trim();
@@ -41,8 +47,9 @@ pub async fn create_quick_button(
     if name.is_empty() || prompt.is_empty() {
         return Err(AppError::BadRequest("按钮名称和话术不能为空".to_string()));
     }
-    // 重名预检：DB 虽有 UNIQUE 兜底，但提前拦截能返回 400 而非 500
-    if crate::db::quick_button::get_quick_button_by_name(&state.db, name)
+    // 重名预检：DB 虽有 UNIQUE 兜底，但提前拦截能返回 400 而非 500。
+    // 当前 UNIQUE 仍是全局的，因此预检也按全局处理。
+    if crate::db::quick_button::get_quick_button_by_name(&state.db, ws_id, name)
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
         .is_some()
@@ -50,7 +57,7 @@ pub async fn create_quick_button(
         return Err(AppError::BadRequest("按钮名称已存在".to_string()));
     }
 
-    let id = crate::db::quick_button::create_quick_button(&state.db, name, prompt)
+    let id = crate::db::quick_button::create_quick_button(&state.db, ws_id, name, prompt)
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
     Ok(ApiResponse::ok(serde_json::json!({ "id": id })))
@@ -65,12 +72,13 @@ pub struct UpdateQuickButtonRequest {
 /// 更新快捷按钮：非空校验 + 改名时排除自身的重名检查，再落库。
 pub async fn update_quick_button(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
     Json(req): Json<UpdateQuickButtonRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    validate_quick_button_update(&state.db, id, &req).await?;
+    validate_quick_button_update(&state.db, ws_id, id, &req).await?;
     crate::db::quick_button::update_quick_button(
         &state.db,
+        ws_id,
         id,
         req.button_name.as_deref().map(str::trim),
         req.prompt_text.as_deref().map(str::trim),
@@ -84,6 +92,7 @@ pub async fn update_quick_button(
 /// 校验更新请求：提供字段需非空；改名时检查是否与其他按钮重名（排除自身 id）。
 async fn validate_quick_button_update(
     db: &crate::db::Database,
+    ws_id: i64,
     id: i64,
     req: &UpdateQuickButtonRequest,
 ) -> Result<(), AppError> {
@@ -92,8 +101,9 @@ async fn validate_quick_button_update(
         if name.is_empty() {
             return Err(AppError::BadRequest("按钮名称不能为空".to_string()));
         }
-        // 改名冲突判定：同名记录存在且不是自己，才报错
-        if let Some(existing) = crate::db::quick_button::get_quick_button_by_name(db, name)
+        // 改名冲突判定：同名记录存在且不是自己，才报错。
+        // 当前 UNIQUE 仍是全局的，因此冲突检查也按全局处理。
+        if let Some(existing) = crate::db::quick_button::get_quick_button_by_name(db, ws_id, name)
             .await
             .map_err(|e| AppError::Internal(e.to_string()))?
         {
@@ -110,31 +120,25 @@ async fn validate_quick_button_update(
     Ok(())
 }
 
-/// 删除快捷按钮。
+/// 删除快捷按钮（仅在指定 workspace 内）。
 pub async fn delete_quick_button(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
 ) -> Result<impl IntoResponse, AppError> {
-    crate::db::quick_button::delete_quick_button(&state.db, id)
+    crate::db::quick_button::delete_quick_button(&state.db, ws_id, id)
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
     Ok(ApiResponse::ok(serde_json::json!({"success": true})))
 }
 
 /// V1 API 路由：为快捷按钮注册 GET/POST/PUT/DELETE 端点，
-/// 路径前缀 /api/v1/quick-buttons（全局资源扁平化，不嵌套 workspace）。
+/// 路径嵌套在 `/api/v1/workspaces/{ws}/quick-buttons` 下。
 pub fn v1_routes() -> Router<AppState> {
     Router::new()
-        // 集合操作：列出全部按钮 / 创建新按钮
-        .route(
-            "/api/v1/quick-buttons",
-            get(list_quick_buttons).post(create_quick_button),
-        )
+        // 集合操作：列出当前 workspace 按钮 / 创建新按钮
+        .route("/", get(list_quick_buttons).post(create_quick_button))
         // 单资源操作：按 id 更新 / 删除
-        .route(
-            "/api/v1/quick-buttons/{id}",
-            put(update_quick_button).delete(delete_quick_button),
-        )
+        .route("/{id}", put(update_quick_button).delete(delete_quick_button))
 }
 
 #[cfg(test)]
@@ -159,10 +163,10 @@ mod quick_button_handler_tests {
     #[tokio::test]
     async fn test_validate_quick_button_update_rejects_duplicate_name() {
         let db = fresh_db().await;
-        let a = crate::db::quick_button::create_quick_button(&db, "A", "a").await.unwrap();
-        let _b = crate::db::quick_button::create_quick_button(&db, "B", "b").await.unwrap();
+        let a = crate::db::quick_button::create_quick_button(&db, 1, "A", "a").await.unwrap();
+        let _b = crate::db::quick_button::create_quick_button(&db, 1, "B", "b").await.unwrap();
         // 把 A 改名为已被 B 占用的 "B" → 应报错
-        let err = validate_quick_button_update(&db, a, &update_req(Some("B"), None)).await;
+        let err = validate_quick_button_update(&db, 1,a, &update_req(Some("B"), None)).await;
         assert!(err.is_err(), "改成他人已用名应 BadRequest");
     }
 
@@ -170,8 +174,8 @@ mod quick_button_handler_tests {
     #[tokio::test]
     async fn test_validate_quick_button_update_allows_own_name() {
         let db = fresh_db().await;
-        let a = crate::db::quick_button::create_quick_button(&db, "A", "a").await.unwrap();
-        let res = validate_quick_button_update(&db, a, &update_req(Some("A"), None)).await;
+        let a = crate::db::quick_button::create_quick_button(&db, 1, "A", "a").await.unwrap();
+        let res = validate_quick_button_update(&db, 1,a, &update_req(Some("A"), None)).await;
         assert!(res.is_ok(), "改成自己的原名不应报错");
     }
 
@@ -179,7 +183,7 @@ mod quick_button_handler_tests {
     #[tokio::test]
     async fn test_validate_quick_button_update_rejects_empty_name() {
         let db = fresh_db().await;
-        let res = validate_quick_button_update(&db, 1, &update_req(Some("   "), None)).await;
+        let res = validate_quick_button_update(&db, 1,1, &update_req(Some("   "), None)).await;
         assert!(res.is_err(), "空白名称应 BadRequest");
     }
 
@@ -187,7 +191,7 @@ mod quick_button_handler_tests {
     #[tokio::test]
     async fn test_validate_quick_button_update_rejects_empty_prompt() {
         let db = fresh_db().await;
-        let res = validate_quick_button_update(&db, 1, &update_req(None, Some("  "))).await;
+        let res = validate_quick_button_update(&db, 1,1, &update_req(None, Some("  "))).await;
         assert!(res.is_err(), "空白话术应 BadRequest");
     }
 }

--- a/backend/src/handlers/review_template.rs
+++ b/backend/src/handlers/review_template.rs
@@ -11,6 +11,8 @@
 //! 路由构建函数 `review_template_routes()` 在 `handlers/mod.rs` 内组装。
 
 use axum::extract::{Path, Query, State};
+use axum::routing::get;
+use axum::Router;
 use axum::Json;
 use serde::Deserialize;
 
@@ -125,4 +127,29 @@ pub async fn delete_review_template(
         return Err(AppError::NotFound);
     }
     Ok(Json(ApiResponse::ok(true)))
+}
+
+/// v1 API 路由（/api/v1/review-templates/*）。
+///
+/// 与 `review_template_routes()`（mod.rs）并行，前缀全部改为 `/api/v1/`。
+/// 等旧路由废弃后，`mount_domain_routes` 里从 `mod.rs` 的 `review_template_routes` 切到这个函数。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        // 列表（含 prompt过滤） + 创建
+        .route(
+            "/api/v1/review-templates",
+            get(list_review_templates).post(create_review_template),
+        )
+        // 选项列表（轻量，不含 prompt，必须在 {id} 之前注册以免被当成 id 捕获）
+        .route(
+            "/api/v1/review-templates/options",
+            get(list_review_template_options),
+        )
+        // 按 id 取/更新/删除单条
+        .route(
+            "/api/v1/review-templates/{id}",
+            get(get_review_template)
+                .put(update_review_template)
+                .delete(delete_review_template),
+        )
 }

--- a/backend/src/handlers/scheduler.rs
+++ b/backend/src/handlers/scheduler.rs
@@ -1,7 +1,6 @@
-use axum::{
-    extract::{Path, State},
-};
+use axum::extract::{Path, State};
 
+use crate::handlers::workspace_guard;
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::{ApiResponse, Todo, TodoCenterItem, UpdateSchedulerRequest};
 use crate::service_context::ServiceContext;
@@ -9,9 +8,11 @@ use crate::service_context::ServiceContext;
 #[axum::debug_handler]
 pub async fn update_scheduler(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
     ApiJson(req): ApiJson<UpdateSchedulerRequest>,
 ) -> Result<ApiResponse<TodoCenterItem>, AppError> {
+    // V1 隔离：定时配置作用于 todo，校验 todo 归属 workspace
+    workspace_guard::verify_todo_belongs_to_ws(&state.db, id, ws_id).await?;
     // Get existing todo to preserve its timezone if not provided
     let existing_todo = state.db.get_todo(id).await?;
     let existing_tz = existing_todo.as_ref().and_then(|t| t.scheduler_timezone.clone());
@@ -93,15 +94,10 @@ pub async fn update_scheduler(
     Ok(ApiResponse::ok(item))
 }
 
-#[derive(Debug, serde::Deserialize)]
-pub struct SchedulerTodosQuery {
-    #[serde(default)]
-    pub workspace_id: Option<i64>,
-}
-
 pub async fn get_scheduler_todos(
     State(state): State<AppState>,
-    axum::extract::Query(params): axum::extract::Query<SchedulerTodosQuery>,
+    Path(ws_id): Path<i64>,
 ) -> Result<ApiResponse<Vec<Todo>>, AppError> {
-    Ok(ApiResponse::ok(state.db.get_scheduler_todos(params.workspace_id).await?))
+    // V1：workspace_id 来自路径，查该工作空间下的定时 todo
+    Ok(ApiResponse::ok(state.db.get_scheduler_todos(Some(ws_id)).await?))
 }

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -1,5 +1,7 @@
 use axum::{
     extract::{Path, Query, State},
+    routing::get,
+    Router,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -1451,6 +1453,17 @@ pub async fn delete_session(
     .map_err(|e| AppError::Internal(e.to_string()))?;
 
     Ok(ApiResponse::ok(()))
+}
+
+// ─── V1 routes ────────────────────────────────────────────
+
+/// V1 路由:所有路径以 `/api/v1/sessions` 开头,不再嵌套到模块级 Router 下。
+/// 全局资源保持平铺路径,仅增加版本号前缀 `/api/v1`。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/v1/sessions", get(list_sessions))
+        .route("/api/v1/sessions/stats", get(get_session_stats))
+        .route("/api/v1/sessions/{id}", get(get_session_detail).delete(delete_session))
 }
 
 // ─── Detail getters per source ────────────────────────────

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -3,7 +3,11 @@
 //! Discovers skills from executor directories, provides comparison, sync,
 //! and execution tracking APIs.
 
-use axum::extract::{Query, State};
+use axum::{
+    Router,
+    extract::{Query, State},
+    routing::{get, post},
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::Read;
@@ -1427,6 +1431,23 @@ pub async fn record_invocation(
     ).await.map_err(|e| AppError::Internal(e.to_string()))?;
 
     Ok(ApiResponse::ok(id))
+}
+
+/// v1 API 路由：所有路径使用完整的 `/api/v1/skills/...` 前缀，
+/// 不与外层 router 嵌套（flat 结构）。
+///
+/// 映射规则：保持与 skills_routes() 相同的 handler 函数，仅路径前缀改为 /api/v1/skills。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/v1/skills", get(list_skills).delete(delete_skill))
+        .route("/api/v1/skills/compare", get(compare_skills))
+        .route("/api/v1/skills/version-update", get(version_update_list))
+        .route("/api/v1/skills/sync", post(sync_skill))
+        .route("/api/v1/skills/invocations", post(record_invocation))
+        .route("/api/v1/skills/content", get(get_skill_content))
+        .route("/api/v1/skills/file", get(get_skill_file))
+        .route("/api/v1/skills/export", get(export_skill))
+        .route("/api/v1/skills/import", post(import_skill))
 }
 
 #[cfg(test)]

--- a/backend/src/handlers/tag.rs
+++ b/backend/src/handlers/tag.rs
@@ -1,5 +1,7 @@
 use axum::{
+    Router,
     extract::{Path, State},
+    routing::{delete, get},
 };
 
 use crate::handlers::{ApiJson, AppError, AppState};
@@ -35,4 +37,13 @@ pub async fn delete_tag(
 ) -> Result<ApiResponse<()>, AppError> {
     state.db.delete_tag(id).await?;
     Ok(ApiResponse::ok(()))
+}
+
+/// v1 API 路由：标签为全局资源（tags 表无 workspace_id 列），嵌套在 `/api/v1/tags` 下。
+/// 所有路径都是相对路径（`/`、`/{id}`），由 action.rs 的 `.nest("/api/v1/tags", v1_routes())` 提供前缀。
+/// handler 不提取 workspace_id（全局资源）。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        .route("/", get(get_tags).post(create_tag))
+        .route("/{id}", delete(delete_tag))
 }

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -3,7 +3,7 @@ use axum::{Router, routing::{get, post, put}};
 use serde::Deserialize;
 
 use crate::db::TodoUpdate;
-use crate::handlers::{ApiJson, AppError, AppState};
+use crate::handlers::{workspace_guard, ApiJson, AppError, AppState};
 // todo hook 已整块移除（plan `purring-forging-petal`），HookContext 不再导入。
 use crate::models::{
     utc_timestamp, ApiResponse, BatchCopyTodoWorkspaceRequest,
@@ -35,8 +35,10 @@ fn validate_cron_expression(expr: &str) -> Result<(), String> {
 /// 返回重新计算后的 TodoCenterItem（computed_bucket=archived）。
 pub async fn archive_todo(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
 ) -> Result<ApiResponse<TodoCenterItem>, AppError> {
+    // V1 隔离：校验 todo 归属路径 workspace，防止跨 ws 归档他人事项
+    workspace_guard::verify_todo_belongs_to_ws(&state.db, id, ws_id).await?;
     // rows_affected=0 说明 todo 不存在或已软删，统一回 404
     if !state.db.archive_todo(id).await? {
         return Err(AppError::NotFound);
@@ -48,8 +50,10 @@ pub async fn archive_todo(
 /// `POST /api/todos/{id}/restore`：恢复事项（清空 archived_at，分类按真实关系重算）。
 pub async fn restore_todo(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
 ) -> Result<ApiResponse<TodoCenterItem>, AppError> {
+    // V1 隔离：校验 todo 归属路径 workspace
+    workspace_guard::verify_todo_belongs_to_ws(&state.db, id, ws_id).await?;
     if !state.db.restore_todo(id).await? {
         return Err(AppError::NotFound);
     }
@@ -61,9 +65,11 @@ pub async fn restore_todo(
 /// 与 `PUT /api/todos/{id}/scheduler` 对称的扁平具名路由。
 pub async fn update_webhook(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
     ApiJson(req): ApiJson<UpdateWebhookRequest>,
 ) -> Result<ApiResponse<TodoCenterItem>, AppError> {
+    // V1 隔离：校验 todo 归属路径 workspace
+    workspace_guard::verify_todo_belongs_to_ws(&state.db, id, ws_id).await?;
     if !state.db.update_todo_webhook(id, req.webhook_enabled).await? {
         return Err(AppError::NotFound);
     }
@@ -86,8 +92,10 @@ async fn load_center_item_or_404(
 
 pub async fn get_todo(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
 ) -> Result<ApiResponse<Todo>, AppError> {
+    // V1 隔离：todo id 全局唯一不等于跨 ws 可见，校验归属路径 workspace
+    workspace_guard::verify_todo_belongs_to_ws(&state.db, id, ws_id).await?;
     let todo = state.require_todo(id).await?;
     Ok(ApiResponse::ok(todo))
 }
@@ -255,9 +263,11 @@ pub async fn create_todo(
 
 pub async fn update_todo(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
     ApiJson(req): ApiJson<UpdateTodoRequest>,
 ) -> Result<ApiResponse<Todo>, AppError> {
+    // V1 隔离：校验 todo 归属路径 workspace
+    workspace_guard::verify_todo_belongs_to_ws(&state.db, id, ws_id).await?;
     // 获取当前值用于填充
     let current = state.require_todo(id).await?;
 
@@ -356,9 +366,11 @@ pub async fn update_todo(
 
 pub async fn update_todo_tags(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
     ApiJson(req): ApiJson<UpdateTagsRequest>,
 ) -> Result<ApiResponse<()>, AppError> {
+    // V1 隔离：校验 todo 归属路径 workspace
+    workspace_guard::verify_todo_belongs_to_ws(&state.db, id, ws_id).await?;
     // 先查询之前关联的 tag（用于计算新增的 tag）
     let old_tag_ids: std::collections::HashSet<i64> = state.db.get_todo_tag_ids(id).await.unwrap_or_default().into_iter().collect();
     state.db.set_todo_tags(id, &req.tag_ids).await?;
@@ -376,8 +388,10 @@ pub async fn update_todo_tags(
 
 pub async fn delete_todo(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
 ) -> Result<ApiResponse<()>, AppError> {
+    // V1 隔离：校验 todo 归属路径 workspace，防止跨 ws 删除他人事项
+    workspace_guard::verify_todo_belongs_to_ws(&state.db, id, ws_id).await?;
     // Get todo info before deletion for hooks
     state.db.get_todo(id).await?;
 
@@ -408,9 +422,11 @@ pub async fn delete_todo(
 
 pub async fn force_update_todo_status(
     State(state): State<AppState>,
-    Path(id): Path<i64>,
+    Path((ws_id, id)): Path<(i64, i64)>,
     ApiJson(req): ApiJson<UpdateTodoRequest>,
 ) -> Result<ApiResponse<Todo>, AppError> {
+    // V1 隔离：校验 todo 归属路径 workspace
+    workspace_guard::verify_todo_belongs_to_ws(&state.db, id, ws_id).await?;
     if let Some(new_status) = req.status {
         state
             .db

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -464,9 +464,10 @@ pub async fn get_recent_completed_todos(
     ))
 }
 
-/// PUT /api/todos/batch-executor — 批量更新事项执行器
+/// POST /api/v1/workspaces/{ws}/todos/batch/executor — 批量更新事项执行器
 pub async fn batch_update_todos_executor(
     State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
     ApiJson(req): ApiJson<BatchUpdateTodoExecutorRequest>,
 ) -> Result<ApiResponse<BatchUpdateTodoResult>, AppError> {
     if req.ids.is_empty() {
@@ -475,6 +476,8 @@ pub async fn batch_update_todos_executor(
     if req.executor.trim().is_empty() {
         return Err(AppError::BadRequest("executor 不能为空".to_string()));
     }
+    // v1 隔离：批量操作前校验所有目标 todo 属于当前 workspace。
+    workspace_guard::verify_todos_belong_to_ws(&state.db, &req.ids, ws_id).await?;
     let rows_affected = state
         .db
         .batch_update_todos_executor(&req.ids, req.executor.trim())
@@ -485,14 +488,19 @@ pub async fn batch_update_todos_executor(
     }))
 }
 
-/// PUT /api/todos/batch-workspace — 批量移动事项到其他工作空间
+/// POST /api/v1/workspaces/{ws}/todos/batch/workspace — 批量移动事项到其他工作空间
+///
+/// `req.workspace_id` 是目标 workspace；URL 中的 `ws_id` 是源 workspace（待移动 todo 必须属于它）。
 pub async fn batch_move_todos_workspace(
     State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
     ApiJson(req): ApiJson<BatchUpdateTodoWorkspaceRequest>,
 ) -> Result<ApiResponse<BatchWorkspaceResult>, AppError> {
     if req.ids.is_empty() {
         return Err(AppError::BadRequest("ids 不能为空".to_string()));
     }
+    // v1 隔离：源 workspace 下的 todo 才能被移动。
+    workspace_guard::verify_todos_belong_to_ws(&state.db, &req.ids, ws_id).await?;
     // handler 把 id 解析为 path 后下传 DAO；DAO 一次写入 workspace_id + workspace_path。
     let dir = state
         .db
@@ -509,14 +517,19 @@ pub async fn batch_move_todos_workspace(
     }))
 }
 
-/// POST /api/todos/batch-copy-workspace — 批量复制事项到其他工作空间
+/// POST /api/v1/workspaces/{ws}/todos/batch/copy-workspace — 批量复制事项到其他工作空间
+///
+/// `req.workspace_id` 是目标 workspace；URL 中的 `ws_id` 是源 workspace（被复制 todo 必须属于它）。
 pub async fn batch_copy_todos_workspace(
     State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
     ApiJson(req): ApiJson<BatchCopyTodoWorkspaceRequest>,
 ) -> Result<ApiResponse<BatchWorkspaceResult>, AppError> {
     if req.ids.is_empty() {
         return Err(AppError::BadRequest("ids 不能为空".to_string()));
     }
+    // v1 隔离：源 workspace 下的 todo 才能被复制。
+    workspace_guard::verify_todos_belong_to_ws(&state.db, &req.ids, ws_id).await?;
     let dir = state
         .db
         .get_project_directory_by_id(req.workspace_id)
@@ -532,7 +545,7 @@ pub async fn batch_copy_todos_workspace(
     }))
 }
 
-/// PUT /api/todos/batch-scheduler — 批量暂停/恢复事项的周期执行
+/// POST /api/v1/workspaces/{ws}/todos/batch/scheduler — 批量暂停/恢复事项的周期执行
 ///
 /// 修复：原实现仅更新 DB 的 `scheduler_enabled` 字段，未同步内存中的 cron 任务，
 /// 导致批量暂停后 cron 仍会触发、批量恢复后 cron 不触发的状态不一致。
@@ -542,11 +555,14 @@ pub async fn batch_copy_todos_workspace(
 /// - 恢复：先写 DB，再从 DB 读出 config/timezone 重新注册 cron
 pub async fn batch_update_todos_scheduler(
     State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
     ApiJson(req): ApiJson<BatchUpdateTodoSchedulerRequest>,
 ) -> Result<ApiResponse<BatchWorkspaceResult>, AppError> {
     if req.ids.is_empty() {
         return Err(AppError::BadRequest("ids 不能为空".to_string()));
     }
+    // v1 隔离：批量操作前校验所有目标 todo 属于当前 workspace。
+    workspace_guard::verify_todos_belong_to_ws(&state.db, &req.ids, ws_id).await?;
     // 根据目标状态分流到对应辅助函数，保持 handler 单一职责、控制函数长度。
     // 两个分支各自用 `?` 解包 Result，统一得到 rows_affected: u64。
     let rows_affected = if req.scheduler_enabled {
@@ -761,9 +777,10 @@ pub fn v1_routes() -> Router<AppState> {
         .route("/{id}/webhook", put(update_webhook))
         .route("/{id}/summary", get(super::execution::get_execution_summary))
         .route("/{id}", get(get_todo).put(update_todo).delete(delete_todo))
-        // 批量操作（全局，不依赖单个 id）
-        .route("/batch-executor", put(batch_update_todos_executor))
-        .route("/batch-workspace", put(batch_move_todos_workspace))
-        .route("/batch-copy-workspace", post(batch_copy_todos_workspace))
-        .route("/batch-scheduler", put(batch_update_todos_scheduler))
+        // 批量操作（workspace 作用域，不依赖单个 id）
+        // batch/* 必须注册在 /{id} 之前，避免 axum 把 "batch" 当作 todo id 捕获。
+        .route("/batch/executor", post(batch_update_todos_executor))
+        .route("/batch/workspace", post(batch_move_todos_workspace))
+        .route("/batch/copy-workspace", post(batch_copy_todos_workspace))
+        .route("/batch/scheduler", post(batch_update_todos_scheduler))
 }

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -1,4 +1,5 @@
 use axum::extract::{Path, Query, State};
+use axum::{Router, routing::{get, post, put}};
 use serde::Deserialize;
 
 use crate::db::TodoUpdate;
@@ -28,64 +29,6 @@ fn validate_cron_expression(expr: &str) -> Result<(), String> {
                 expr
             )
         })
-}
-
-#[derive(Debug, serde::Deserialize)]
-pub struct TodoListQuery {
-    /// 按工作空间 ID 过滤 Todo（对应 todos.workspace_id 字段）
-    #[serde(default)]
-    pub workspace_id: Option<i64>,
-    /// 按最近 N 小时过滤（对 updated_at 生效，completed/failed 状态的 todo
-    /// 按 finished_at 过滤）；不传或 0 表示不过滤。
-    #[serde(default)]
-    pub hours: Option<u32>,
-}
-
-pub async fn get_todos(
-    State(state): State<AppState>,
-    axum::extract::Query(params): axum::extract::Query<TodoListQuery>,
-) -> Result<ApiResponse<Vec<Todo>>, AppError> {
-    let todos = state.db.get_todos_by_workspace_id(params.workspace_id).await?;
-    // 按 hours 过滤：只保留在最近 N 小时内更新过的 todo
-    let todos = if let Some(h) = params.hours.filter(|&h| h > 0) {
-        let cutoff = chrono::Utc::now() - chrono::Duration::hours(h as i64);
-        let cutoff_str = cutoff.format("%Y-%m-%dT%H:%M:%S").to_string();
-        todos.into_iter().filter(|t| {
-            // 按 updated_at 过滤（finished_at 字段未在模型上实现，暂统一用 updated_at）
-            t.updated_at >= cutoff_str
-        }).collect()
-    } else {
-        todos
-    };
-    Ok(ApiResponse::ok(todos))
-}
-
-/// 事项中心查询参数。
-/// `bucket` 为空或非法时返回全部分类（前端可自行按 computed_bucket 分组）。
-/// `search` 为标题/prompt 子串过滤（设计文档 API 示例带 search 参数）。
-#[derive(Debug, serde::Deserialize)]
-pub struct TodoCenterQuery {
-    #[serde(default)]
-    pub workspace_id: Option<i64>,
-    #[serde(default)]
-    pub bucket: Option<String>,
-    #[serde(default)]
-    pub search: Option<String>,
-}
-
-/// `GET /api/todos/center`：事项中心五类驱动视图。
-///
-/// 服务端按事实字段推导 computed_bucket 并（可选）按 bucket 过滤，
-/// 批量补算 loop 引用计数与最近执行记录，避免前端 N+1。
-pub async fn get_todo_center(
-    State(state): State<AppState>,
-    axum::extract::Query(params): axum::extract::Query<TodoCenterQuery>,
-) -> Result<ApiResponse<Vec<TodoCenterItem>>, AppError> {
-    // 解析 bucket 串为枚举；空/非法 → None = 不过滤
-    let bucket = params.bucket.as_deref().and_then(ComputedBucket::parse_query);
-    let search = params.search.as_deref().map(str::trim).filter(|s| !s.is_empty());
-    let items = state.db.get_todo_center(params.workspace_id, bucket, search).await?;
-    Ok(ApiResponse::ok(items))
 }
 
 /// `POST /api/todos/{id}/archive`：归档事项（仅隐藏，不删数据/不解引用）。
@@ -482,6 +425,7 @@ pub async fn force_update_todo_status(
 }
 
 #[derive(Deserialize)]
+#[allow(dead_code)]
 pub struct RecentCompletedParams {
     #[serde(default = "default_recent_hours")]
     pub hours: u32,
@@ -493,7 +437,7 @@ pub struct RecentCompletedParams {
 fn default_recent_hours() -> u32 {
     24
 }
-
+#[allow(dead_code)]
 pub async fn get_recent_completed_todos(
     State(state): State<AppState>,
     Query(params): Query<RecentCompletedParams>,
@@ -600,6 +544,102 @@ pub async fn batch_update_todos_scheduler(
     }))
 }
 
+// ======================================================================
+// V1 专用查询参数（workspace_id 改为从路径参数中提取）
+// ======================================================================
+
+/// V1 事项列表查询参数（workspace_id 来自路径而非查询参数）
+#[derive(Debug, serde::Deserialize)]
+pub struct TodoListQueryV1 {
+    /// 按最近 N 小时过滤（对 updated_at 生效）；不传或 0 表示不过滤
+    #[serde(default)]
+    pub hours: Option<u32>,
+}
+
+/// V1 事项中心查询参数（workspace_id 来自路径而非查询参数）。
+/// bucket 为空或非法时返回全部分类；search 为标题/prompt 子串过滤。
+#[derive(Debug, serde::Deserialize)]
+pub struct TodoCenterQueryV1 {
+    #[serde(default)]
+    pub bucket: Option<String>,
+    #[serde(default)]
+    pub search: Option<String>,
+}
+
+/// V1 最近已完成事项查询参数（workspace_id 来自路径而非查询参数）
+#[derive(Deserialize)]
+pub struct RecentCompletedParamsV1 {
+    #[serde(default = "default_recent_hours")]
+    pub hours: u32,
+}
+
+// ======================================================================
+// V1 handler 变体：从 Path(ws_id) 获取 workspace_id
+// ======================================================================
+
+/// V1: 从路径参数获取 workspace_id 后查询事项列表。
+/// 与 `get_todos` 的区别在于 workspace_id 来自 Path 而非 Query。
+pub async fn get_todos_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    axum::extract::Query(params): axum::extract::Query<TodoListQueryV1>,
+) -> Result<ApiResponse<Vec<Todo>>, AppError> {
+    // 工作空间由路径参数确定，无需再从查询参数中提取
+    let todos = state.db.get_todos_by_workspace_id(Some(ws_id)).await?;
+    // 按 hours 过滤：只保留在最近 N 小时内更新过的 todo
+    let todos = if let Some(h) = params.hours.filter(|&h| h > 0) {
+        let cutoff = chrono::Utc::now() - chrono::Duration::hours(h as i64);
+        let cutoff_str = cutoff.format("%Y-%m-%dT%H:%M:%S").to_string();
+        todos.into_iter().filter(|t| t.updated_at >= cutoff_str).collect()
+    } else {
+        todos
+    };
+    Ok(ApiResponse::ok(todos))
+}
+
+/// V1: 从路径参数获取 workspace_id 后查询事项中心。
+/// 与 `get_todo_center` 的区别在于 workspace_id 来自 Path 而非 Query。
+pub async fn get_todo_center_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    axum::extract::Query(params): axum::extract::Query<TodoCenterQueryV1>,
+) -> Result<ApiResponse<Vec<TodoCenterItem>>, AppError> {
+    // 解析 bucket 串为枚举；空/非法 → None = 不过滤
+    let bucket = params.bucket.as_deref().and_then(ComputedBucket::parse_query);
+    let search = params.search.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    // 工作空间由路径参数提供，替代原来的 params.workspace_id
+    let items = state.db.get_todo_center(Some(ws_id), bucket, search).await?;
+    Ok(ApiResponse::ok(items))
+}
+
+/// V1: 从路径参数获取 workspace_id 后创建事项。
+/// 覆盖请求体中的 workspace_id 为路径参数值，复用 `create_todo` 的完整逻辑。
+pub async fn create_todo_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    ApiJson(mut req): ApiJson<CreateTodoRequest>,
+) -> Result<ApiResponse<Todo>, AppError> {
+    // v1 路径中工作空间 ID 由路径参数提供，覆盖请求体中的值以保证一致性，
+    // 避免用户传入与路径参数不一致的 ID 导致歧义
+    req.workspace_id = ws_id;
+    let state_val = State(state);
+    let req_val = ApiJson(req);
+    create_todo(state_val, req_val).await
+}
+
+/// V1: 从路径参数获取 workspace_id 后查询最近已完成事项。
+/// 与 `get_recent_completed_todos` 的区别在于 workspace_id 来自 Path 而非 Query。
+pub async fn get_recent_completed_todos_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    Query(params): Query<RecentCompletedParamsV1>,
+) -> Result<ApiResponse<Vec<RecentCompletedTodo>>, AppError> {
+    let hours = params.hours.clamp(1, 720);
+    Ok(ApiResponse::ok(
+        state.db.get_recent_completed_todos(hours, Some(ws_id)).await?,
+    ))
+}
+
 /// 批量暂停：先逐个移除 cron 任务，再一次写 DB（scheduler_enabled=false）。
 /// 顺序很重要——先撤 cron 可避免"DB 已标记暂停但 cron 仍触发"的短窗口。
 /// 即使某个 id 在 job_map 中不存在，`remove_task_for_todo` 也是 no-op，安全。
@@ -670,4 +710,44 @@ async fn try_resume_one_scheduler(
         .upsert_task(ctx, id, config, todo.scheduler_timezone.clone())
         .await?;
     Ok(())
+}
+
+// ======================================================================
+// V1 路由：/api/v1/workspaces/{ws}/todos 子路由（相对路径，由外层 mod.rs 嵌套提供前缀）
+// ======================================================================
+
+/// /api/v1/workspaces/{ws}/todos 下的子路由。
+///
+/// 所有路径均为相对路径（如 `"/"`、`"/{id}"`），前缀由 `mount_domain_routes` 或
+/// 外部作用域通过 `.nest("/api/v1/workspaces/{ws}/todos", v1_routes())` 提供。
+///
+/// 获取 workspace_id 的 handler 使用 Path(ws_id) 变体（如 get_todos_v1），
+/// 不依赖 workspace_id 的 handler 直接复用旧签名（如 get_todo, archive_todo）。
+///
+/// 固定路由（如 `/{id}/archive`）必须注册在 `/{id}` 之前，避免 axum 把
+/// "archive" 当作 id 捕获。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        // 列表 + 创建：工作空间维度
+        .route("/", get(get_todos_v1).post(create_todo_v1))
+        // 智能创建（AI 辅助新建并执行，复用 execution 域的 smart-create handler）
+        .route("/smart", post(super::execution::v1_smart_create_handler))
+        // 事项中心（驱动视图五分类）
+        .route("/center", get(get_todo_center_v1))
+        // 最近已完成事项
+        .route("/recent-completed", get(get_recent_completed_todos_v1))
+        // 按 id 的子路由（必须在 /{id} 之前注册，避免 axum 把子路径如 "archive" 当作 id 捕获）
+        .route("/{id}/force-status", put(force_update_todo_status))
+        .route("/{id}/tags", put(update_todo_tags))
+        .route("/{id}/scheduler", put(super::scheduler::update_scheduler))
+        .route("/{id}/archive", post(archive_todo))
+        .route("/{id}/restore", post(restore_todo))
+        .route("/{id}/webhook", put(update_webhook))
+        .route("/{id}/summary", get(super::execution::get_execution_summary))
+        .route("/{id}", get(get_todo).put(update_todo).delete(delete_todo))
+        // 批量操作（全局，不依赖单个 id）
+        .route("/batch-executor", put(batch_update_todos_executor))
+        .route("/batch-workspace", put(batch_move_todos_workspace))
+        .route("/batch-copy-workspace", post(batch_copy_todos_workspace))
+        .route("/batch-scheduler", put(batch_update_todos_scheduler))
 }

--- a/backend/src/handlers/todo_template.rs
+++ b/backend/src/handlers/todo_template.rs
@@ -1,5 +1,9 @@
-use axum::extract::{Path, State};
-use axum::Json;
+use axum::{
+    Router,
+    extract::{Path, State},
+    routing::{delete, get, post, put},
+    Json,
+};
 
 use crate::handlers::{ApiJson, AppError, AppState};
 use crate::models::{ApiResponse, CreateTemplateRequest, TodoTemplate, UpdateTemplateRequest};
@@ -111,4 +115,20 @@ pub async fn copy_template(
         .ok_or_else(|| AppError::Internal("Failed to get copied template".to_string()))?;
 
     Ok(Json(ApiResponse::ok(template)))
+}
+
+/// API v1 routes for todo-template resource.
+/// All paths are full absolute paths with /api/v1 prefix.
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        // GET /api/v1/todo-templates — list all templates
+        .route("/api/v1/todo-templates", get(get_templates))
+        // POST /api/v1/todo-templates — create a new template
+        .route("/api/v1/todo-templates", post(create_template))
+        // PUT /api/v1/todo-templates/{id} — update a template
+        .route("/api/v1/todo-templates/{id}", put(update_template))
+        // DELETE /api/v1/todo-templates/{id} — delete a template
+        .route("/api/v1/todo-templates/{id}", delete(delete_template))
+        // POST /api/v1/todo-templates/{id}/copy — duplicate a template
+        .route("/api/v1/todo-templates/{id}/copy", post(copy_template))
 }

--- a/backend/src/handlers/usage_stats.rs
+++ b/backend/src/handlers/usage_stats.rs
@@ -1,4 +1,8 @@
-use axum::extract::{Query, State};
+use axum::{
+    Router,
+    extract::{Query, State},
+    routing::{get, post},
+};
 use serde::Deserialize;
 
 use super::{AppError, AppState};
@@ -151,4 +155,21 @@ pub async fn update_usage_stats_settings(
         .map_err(|e| AppError::Internal(format!("Failed to save config: {}", e)))?;
 
     Ok(ApiResponse::ok("AI 使用统计配置已更新".to_string()))
+}
+
+/// v1 API 路由：使用完整路径前缀 `/api/v1/...`，不嵌套装配。
+///
+/// 与旧版 `usage_stats_routes()` 并存，待旧路由全部迁移后替换。
+/// - GET  /api/v1/usage-stats          → 查询统计
+/// - POST /api/v1/usage-stats/refresh   → 刷新统计
+/// - GET  /api/v1/usage-stats/settings  → 查询设置
+/// - PUT  /api/v1/usage-stats/settings  → 更新设置
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/v1/usage-stats", get(get_usage_stats))
+        .route("/api/v1/usage-stats/refresh", post(refresh_usage_stats))
+        .route(
+            "/api/v1/usage-stats/settings",
+            get(get_usage_stats_settings).put(update_usage_stats_settings),
+        )
 }

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -1,8 +1,10 @@
 use axum::{
+    Router,
     extract::State,
     extract::Path,
     http::StatusCode,
     response::IntoResponse,
+    routing::get,
     Json,
 };
 use std::collections::HashMap;
@@ -196,4 +198,21 @@ fn build_message_content(
     };
 
     (message, raw)
+}
+
+/// API v1 路由：webhook 触发端点。
+///
+/// 新路径将参数段重命名为 `{id}`（不再使用 `{todo_id}` / `{loop_id}`），
+/// 遵循 RESTful 风格：/api/v1/webhooks/todo/{id}/trigger。
+/// 保持与旧函数相同的 handler 函数，仅路由路径不同。
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/api/v1/webhooks/todo/{id}/trigger",
+            get(trigger_webhook_with_todo).post(trigger_webhook_with_todo_post_json),
+        )
+        .route(
+            "/api/v1/webhooks/loop/{id}/trigger",
+            get(trigger_webhook_with_loop_get).post(trigger_webhook_with_loop_post),
+        )
 }

--- a/backend/src/handlers/workspace_guard.rs
+++ b/backend/src/handlers/workspace_guard.rs
@@ -48,6 +48,20 @@ pub async fn verify_loop_belongs_to_ws(
     }
 }
 
+/// 批量校验一组 loop 是否都属于指定 workspace。
+///
+/// 任一 id 跨 ws → 返回 BadRequest；任一 id 不存在 → 返回 NotFound。
+pub async fn verify_loops_belong_to_ws(
+    db: &Database,
+    ids: &[i64],
+    ws_id: i64,
+) -> Result<(), AppError> {
+    for &id in ids {
+        verify_loop_belongs_to_ws(db, id, ws_id).await?;
+    }
+    Ok(())
+}
+
 /// 校验 todo 属于指定 workspace。todo 模型含 `workspace_id`，直接比对。
 pub async fn verify_todo_belongs_to_ws(
     db: &Database,
@@ -63,6 +77,21 @@ pub async fn verify_todo_belongs_to_ws(
             todo_id, ws_id
         )))
     }
+}
+
+/// 批量校验一组 todo 是否都属于指定 workspace。
+///
+/// 任一 id 跨 ws → 返回 BadRequest；任一 id 不存在 → 返回 NotFound。
+/// 当前逐条查询，batch size 通常较小；如后续性能吃紧，可改为单次 IN 查询。
+pub async fn verify_todos_belong_to_ws(
+    db: &Database,
+    ids: &[i64],
+    ws_id: i64,
+) -> Result<(), AppError> {
+    for &id in ids {
+        verify_todo_belongs_to_ws(db, id, ws_id).await?;
+    }
+    Ok(())
 }
 
 /// 校验 execution record 属于指定 workspace。

--- a/backend/src/handlers/workspace_guard.rs
+++ b/backend/src/handlers/workspace_guard.rs
@@ -1,0 +1,261 @@
+//! workspace 归属校验 helper（v1 路由的租户边界守卫）。
+//!
+//! v1 路由把资源嵌套在 `/api/v1/workspaces/{ws}/` 下，URL 里的 `{ws}` 是租户边界
+//! （K8s namespace 语义）。但 axum 的 `.nest()` 只负责把 `{ws}` 暴露给 handler，
+//! 既不强制 handler 提取它，也不校验「路径里的 ws」与「资源实际所属 ws」是否一致。
+//! 若 handler 不主动校验，就会出现跨工作空间越权读写
+//! （例如 `GET /api/v1/workspaces/999/loops/1` 读到别的 ws 的 loop）。
+//!
+//! 本模块把「查资源 → 比对 workspace_id → 映射错误」收敛为三个 `verify_*` 函数，
+//! 所有 workspace-scoped handler 统一调用，避免校验逻辑散落各处。
+//!
+//! 归属判断本身（`workspace_id_matches`）抽成无 db 依赖的纯函数，便于单元测试
+//! 覆盖全部分支（相等 / 跨 ws / None）；`verify_*` 是薄包装：查 db + 调纯函数 +
+//! 把结果映射成 `AppError`。
+//!
+//! 跨 ws 失败统一返回 `BadRequest(400)`，沿用既有「trigger/step 不属于该 loop」
+//! 的惯例（见 `loop_.rs`），不新增 Forbidden 错误类型。
+
+use crate::db::Database;
+use crate::handlers::AppError;
+
+/// 纯判断：资源的 `workspace_id` 是否等于给定 ws。
+///
+/// 抽成纯函数便于单测（无需 in-memory db）。`None`（旧数据 / 未归属）一律视为
+/// 不匹配 —— 跨 ws 访问必须被拒绝，避免「未归属的旧数据可被任意 ws 访问」。
+fn workspace_id_matches(model_ws: Option<i64>, ws_id: i64) -> bool {
+    model_ws == Some(ws_id)
+}
+
+/// 校验 loop 属于指定 workspace：查不到 → `NotFound`，归属不符 → `BadRequest(400)`。
+///
+/// `loops` 表自带 `workspace_id` 列，直接 `get_loop` 后比对即可。
+pub async fn verify_loop_belongs_to_ws(
+    db: &Database,
+    loop_id: i64,
+    ws_id: i64,
+) -> Result<(), AppError> {
+    // get_loop 返回 Option；None 表示该 loop 不存在（已删除或 id 非法），
+    // 统一映射成 NotFound，避免向调用方泄露「loop 是否存在」的存在性细节。
+    let model = db.get_loop(loop_id).await?.ok_or(AppError::NotFound)?;
+    if workspace_id_matches(model.workspace_id, ws_id) {
+        Ok(())
+    } else {
+        Err(AppError::BadRequest(format!(
+            "loop #{} 不属于工作空间 #{}",
+            loop_id, ws_id
+        )))
+    }
+}
+
+/// 校验 todo 属于指定 workspace。todo 模型含 `workspace_id`，直接比对。
+pub async fn verify_todo_belongs_to_ws(
+    db: &Database,
+    todo_id: i64,
+    ws_id: i64,
+) -> Result<(), AppError> {
+    let todo = db.get_todo(todo_id).await?.ok_or(AppError::NotFound)?;
+    if workspace_id_matches(todo.workspace_id, ws_id) {
+        Ok(())
+    } else {
+        Err(AppError::BadRequest(format!(
+            "todo #{} 不属于工作空间 #{}",
+            todo_id, ws_id
+        )))
+    }
+}
+
+/// 校验 execution record 属于指定 workspace。
+///
+/// `execution_records` 表没有 `workspace_id` 列，只能经其 `todo_id` 间接关联到
+/// workspace —— 因此先查 record 拿 `todo_id`，再复用 `verify_todo_belongs_to_ws`，
+/// 保证「record 属于 ws」与「record 的 todo 属于 ws」语义一致。
+pub async fn verify_execution_belongs_to_ws(
+    db: &Database,
+    record_id: i64,
+    ws_id: i64,
+) -> Result<(), AppError> {
+    let record = db
+        .get_execution_record(record_id)
+        .await?
+        .ok_or(AppError::NotFound)?;
+    // record.todo_id 是 i64（非 Option），直接交给 todo 校验；
+    // record 不存在已在上一步映射为 NotFound。
+    verify_todo_belongs_to_ws(db, record.todo_id, ws_id).await
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::useless_vec,
+    clippy::redundant_pattern_matching,
+    clippy::redundant_clone,
+    clippy::len_zero,
+    clippy::bool_assert_comparison,
+    clippy::unnecessary_get_then_check,
+    clippy::doc_lazy_continuation,
+    clippy::clone_on_copy,
+    clippy::print_stdout,
+    clippy::needless_pass_by_value,
+    clippy::sliced_string_as_bytes,
+    clippy::manual_map,
+    clippy::collapsible_match,
+    clippy::question_mark
+)]
+mod tests {
+    use super::*;
+    use crate::db::execution::NewExecutionRecord;
+
+    // ── 纯函数：归属判断的全部分支（无 db，核心正确性）──────────
+
+    #[test]
+    fn test_workspace_id_matches_when_equal() {
+        // workspace_id 与传入 ws 相等 → 视为属于该 ws
+        assert!(workspace_id_matches(Some(7), 7));
+    }
+
+    #[test]
+    fn test_workspace_id_matches_when_different_ws() {
+        // 资源属于 ws 7，却用 ws 8 访问 → 跨 ws，必须拒绝
+        assert!(!workspace_id_matches(Some(7), 8));
+    }
+
+    #[test]
+    fn test_workspace_id_matches_when_none() {
+        // 旧数据 workspace_id=None（未归属任何 ws）：任意 ws 访问都拒绝，
+        // 否则未归属数据会被全局可见，破坏隔离
+        assert!(!workspace_id_matches(None, 7));
+    }
+
+    // ── 测试数据 helper（in-memory SQLite，参照 db/blackboard.rs 测试模式）──
+
+    /// 建一个工作空间（project_directories），返回其 id。
+    /// path 有唯一约束：同一 db 内建多个 ws 必须传不同 path。
+    async fn create_workspace(db: &Database, path: &str) -> i64 {
+        db.create_project_directory(path, None, false, false)
+            .await
+            .expect("create workspace must succeed")
+    }
+
+    /// 建一个 loop，workspace_id 可选（None 模拟旧数据未归属）。
+    async fn create_loop(db: &Database, ws_id: Option<i64>) -> i64 {
+        db.create_loop(
+            "test-loop", "", ws_id, None, false, "", None, None, None, "",
+        )
+        .await
+        .expect("create loop must succeed")
+        .id
+    }
+
+    /// 建一个 todo，强制归属到 ws_id（create_todo_with_extras 要求 ws 必填）。
+    async fn create_todo_in_ws(db: &Database, ws_id: i64) -> i64 {
+        db.create_todo_with_extras("test-todo", "", None, None, false, ws_id, "/tmp")
+            .await
+            .expect("create todo must succeed")
+    }
+
+    /// 建一条 execution record，挂在指定 todo 下。
+    async fn create_record_for_todo(db: &Database, todo_id: i64) -> i64 {
+        db.create_execution_record(NewExecutionRecord {
+            todo_id: Some(todo_id),
+            command: "cmd",
+            executor: "claudecode",
+            trigger_type: "manual",
+            task_id: "task-1",
+            session_id: None,
+            resume_message: None,
+            source_todo_id: None,
+            source_todo_title: None,
+            loop_step_execution_id: None,
+            step_id: None,
+        })
+        .await
+        .expect("create execution record must succeed")
+    }
+
+    // ── verify_loop_belongs_to_ws ───────────────────────────────
+
+    #[tokio::test]
+    async fn test_verify_loop_belongs_to_ws_ok() {
+        let db = Database::new(":memory:").await.expect("db must open");
+        let ws = create_workspace(&db, "/tmp/ws-a").await;
+        let loop_id = create_loop(&db, Some(ws)).await;
+        // loop 属于该 ws → 放行
+        assert!(verify_loop_belongs_to_ws(&db, loop_id, ws).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_verify_loop_belongs_to_ws_cross_ws_rejected() {
+        let db = Database::new(":memory:").await.expect("db must open");
+        let ws_a = create_workspace(&db, "/tmp/ws-a").await;
+        let ws_b = create_workspace(&db, "/tmp/ws-b").await;
+        let loop_id = create_loop(&db, Some(ws_a)).await;
+        // 用 ws_b 访问 ws_a 的 loop → 跨 ws，返回 BadRequest 并带「不属于工作空间」
+        match verify_loop_belongs_to_ws(&db, loop_id, ws_b).await {
+            Err(AppError::BadRequest(msg)) => assert!(msg.contains("不属于工作空间")),
+            other => panic!("跨 ws 应返回 BadRequest，实际: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_verify_loop_belongs_to_ws_not_found() {
+        let db = Database::new(":memory:").await.expect("db must open");
+        let ws = create_workspace(&db, "/tmp/ws-a").await;
+        // 不存在的 loop id → NotFound（AppError 未 derive PartialEq，用 matches!）
+        assert!(matches!(
+            verify_loop_belongs_to_ws(&db, 99999, ws).await.unwrap_err(),
+            AppError::NotFound
+        ));
+    }
+
+    // ── verify_todo_belongs_to_ws ───────────────────────────────
+
+    #[tokio::test]
+    async fn test_verify_todo_belongs_to_ws_ok() {
+        let db = Database::new(":memory:").await.expect("db must open");
+        let ws = create_workspace(&db, "/tmp/ws-a").await;
+        let todo_id = create_todo_in_ws(&db, ws).await;
+        assert!(verify_todo_belongs_to_ws(&db, todo_id, ws).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_verify_todo_belongs_to_ws_cross_ws_rejected() {
+        let db = Database::new(":memory:").await.expect("db must open");
+        let ws_a = create_workspace(&db, "/tmp/ws-a").await;
+        let ws_b = create_workspace(&db, "/tmp/ws-b").await;
+        let todo_id = create_todo_in_ws(&db, ws_a).await;
+        // 用 ws_b 访问 ws_a 的 todo → 跨 ws，返回 BadRequest
+        assert!(matches!(
+            verify_todo_belongs_to_ws(&db, todo_id, ws_b).await,
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    // ── verify_execution_belongs_to_ws ──────────────────────────
+
+    #[tokio::test]
+    async fn test_verify_execution_belongs_to_ws_ok() {
+        let db = Database::new(":memory:").await.expect("db must open");
+        let ws = create_workspace(&db, "/tmp/ws-a").await;
+        let todo_id = create_todo_in_ws(&db, ws).await;
+        let record_id = create_record_for_todo(&db, todo_id).await;
+        // record 的 todo 属于该 ws → record 也属于该 ws，放行
+        assert!(verify_execution_belongs_to_ws(&db, record_id, ws).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_verify_execution_belongs_to_ws_cross_ws_rejected() {
+        let db = Database::new(":memory:").await.expect("db must open");
+        let ws_a = create_workspace(&db, "/tmp/ws-a").await;
+        let ws_b = create_workspace(&db, "/tmp/ws-b").await;
+        let todo_id = create_todo_in_ws(&db, ws_a).await;
+        let record_id = create_record_for_todo(&db, todo_id).await;
+        // 用 ws_b 访问 ws_a 的 record → 间接跨 ws（record→todo→ws），返回 BadRequest
+        assert!(matches!(
+            verify_execution_belongs_to_ws(&db, record_id, ws_b).await,
+            Err(AppError::BadRequest(_))
+        ));
+    }
+}

--- a/backend/src/handlers/workspace_guard.rs
+++ b/backend/src/handlers/workspace_guard.rs
@@ -13,7 +13,7 @@
 //! 覆盖全部分支（相等 / 跨 ws / None）；`verify_*` 是薄包装：查 db + 调纯函数 +
 //! 把结果映射成 `AppError`。
 //!
-//! 跨 ws 失败统一返回 `BadRequest(400)`，沿用既有「trigger/step 不属于该 loop」
+//! 跨 ws 失败统一返回 `Forbidden(403)`，语义上拒绝访问而非输入错误。
 //! 的惯例（见 `loop_.rs`），不新增 Forbidden 错误类型。
 
 use crate::db::Database;
@@ -27,7 +27,7 @@ fn workspace_id_matches(model_ws: Option<i64>, ws_id: i64) -> bool {
     model_ws == Some(ws_id)
 }
 
-/// 校验 loop 属于指定 workspace：查不到 → `NotFound`，归属不符 → `BadRequest(400)`。
+/// 校验 loop 属于指定 workspace：查不到 → `NotFound`，归属不符 → `Forbidden(403)`。
 ///
 /// `loops` 表自带 `workspace_id` 列，直接 `get_loop` 后比对即可。
 pub async fn verify_loop_belongs_to_ws(
@@ -41,7 +41,7 @@ pub async fn verify_loop_belongs_to_ws(
     if workspace_id_matches(model.workspace_id, ws_id) {
         Ok(())
     } else {
-        Err(AppError::BadRequest(format!(
+        Err(AppError::Forbidden(format!(
             "loop #{} 不属于工作空间 #{}",
             loop_id, ws_id
         )))
@@ -50,7 +50,7 @@ pub async fn verify_loop_belongs_to_ws(
 
 /// 批量校验一组 loop 是否都属于指定 workspace。
 ///
-/// 任一 id 跨 ws → 返回 BadRequest；任一 id 不存在 → 返回 NotFound。
+/// 任一 id 跨 ws → 返回 Forbidden；任一 id 不存在 → 返回 NotFound。
 pub async fn verify_loops_belong_to_ws(
     db: &Database,
     ids: &[i64],
@@ -72,7 +72,7 @@ pub async fn verify_todo_belongs_to_ws(
     if workspace_id_matches(todo.workspace_id, ws_id) {
         Ok(())
     } else {
-        Err(AppError::BadRequest(format!(
+        Err(AppError::Forbidden(format!(
             "todo #{} 不属于工作空间 #{}",
             todo_id, ws_id
         )))
@@ -81,7 +81,7 @@ pub async fn verify_todo_belongs_to_ws(
 
 /// 批量校验一组 todo 是否都属于指定 workspace。
 ///
-/// 任一 id 跨 ws → 返回 BadRequest；任一 id 不存在 → 返回 NotFound。
+/// 任一 id 跨 ws → 返回 Forbidden；任一 id 不存在 → 返回 NotFound。
 /// 当前逐条查询，batch size 通常较小；如后续性能吃紧，可改为单次 IN 查询。
 pub async fn verify_todos_belong_to_ws(
     db: &Database,
@@ -221,10 +221,10 @@ mod tests {
         let ws_a = create_workspace(&db, "/tmp/ws-a").await;
         let ws_b = create_workspace(&db, "/tmp/ws-b").await;
         let loop_id = create_loop(&db, Some(ws_a)).await;
-        // 用 ws_b 访问 ws_a 的 loop → 跨 ws，返回 BadRequest 并带「不属于工作空间」
+        // 用 ws_b 访问 ws_a 的 loop → 跨 ws，返回 Forbidden 并带「不属于工作空间」
         match verify_loop_belongs_to_ws(&db, loop_id, ws_b).await {
-            Err(AppError::BadRequest(msg)) => assert!(msg.contains("不属于工作空间")),
-            other => panic!("跨 ws 应返回 BadRequest，实际: {other:?}"),
+            Err(AppError::Forbidden(msg)) => assert!(msg.contains("不属于工作空间")),
+            other => panic!("跨 ws 应返回 Forbidden，实际: {other:?}"),
         }
     }
 
@@ -255,10 +255,10 @@ mod tests {
         let ws_a = create_workspace(&db, "/tmp/ws-a").await;
         let ws_b = create_workspace(&db, "/tmp/ws-b").await;
         let todo_id = create_todo_in_ws(&db, ws_a).await;
-        // 用 ws_b 访问 ws_a 的 todo → 跨 ws，返回 BadRequest
+        // 用 ws_b 访问 ws_a 的 todo → 跨 ws，返回 Forbidden
         assert!(matches!(
             verify_todo_belongs_to_ws(&db, todo_id, ws_b).await,
-            Err(AppError::BadRequest(_))
+            Err(AppError::Forbidden(_))
         ));
     }
 
@@ -281,10 +281,10 @@ mod tests {
         let ws_b = create_workspace(&db, "/tmp/ws-b").await;
         let todo_id = create_todo_in_ws(&db, ws_a).await;
         let record_id = create_record_for_todo(&db, todo_id).await;
-        // 用 ws_b 访问 ws_a 的 record → 间接跨 ws（record→todo→ws），返回 BadRequest
+        // 用 ws_b 访问 ws_a 的 record → 间接跨 ws（record→todo→ws），返回 Forbidden
         assert!(matches!(
             verify_execution_belongs_to_ws(&db, record_id, ws_b).await,
-            Err(AppError::BadRequest(_))
+            Err(AppError::Forbidden(_))
         ));
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -62,7 +62,11 @@ enum Commands {
         action: cli::TagAction,
     },
     /// Global statistics
-    Stats,
+    Stats {
+        /// Workspace ID (project_directories.id). v1 路由把 dashboard 嵌入 workspace URL。
+        #[arg(long = "workspace-id")]
+        workspace_id: i64,
+    },
     /// Manage ntd daemon service (install/uninstall/start/stop/restart/status)
     Daemon {
         #[command(subcommand)]
@@ -237,8 +241,9 @@ async fn main() {
             dispatch_subcommand(&cli, cli::Commands::Tag { action: action.clone() }).await;
             return;
         }
-        Some(Commands::Stats) => {
-            dispatch_subcommand(&cli, cli::Commands::Stats).await;
+        Some(Commands::Stats { workspace_id }) => {
+            // v1: Stats 现在带 workspace_id（dashboard 嵌入 workspace URL）
+            dispatch_subcommand(&cli, cli::Commands::Stats { workspace_id: *workspace_id }).await;
             return;
         }
         Some(Commands::Daemon { action }) => {

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1457,6 +1457,7 @@ pub struct ExportLoopSelectedRequest {
 pub mod codes {
     pub const NOT_FOUND: i32 = 40001;
     pub const BAD_REQUEST: i32 = 40002;
+    pub const FORBIDDEN: i32 = 40003;
     pub const INTERNAL: i32 = 50001;
 }
 

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -585,6 +585,7 @@ pub async fn chat_with_wiki(
             let err_msg = match &e {
                 AppError::Internal(msg) => msg.clone(),
                 AppError::BadRequest(msg) => msg.clone(),
+                AppError::Forbidden(msg) => msg.clone(),
                 AppError::NotFound => "资源不存在".to_string(),
             };
             let _ = tx.send(ExecEvent::WikiChatFinished {

--- a/backend/tests/api_integration_test.rs
+++ b/backend/tests/api_integration_test.rs
@@ -831,8 +831,8 @@ async fn test_cross_workspace_todo_rejected() {
         .body(Body::empty())
         .unwrap();
     let get_resp = app.oneshot(get_req).await.unwrap();
-    // todo_id 真正存在但属于 ws_a → verify_todo_belongs_to_ws 返回 BadRequest
-    assert_eq!(get_resp.status(), StatusCode::BAD_REQUEST);
+    // todo_id 真正存在但属于 ws_a → verify_todo_belongs_to_ws 返回 Forbidden
+    assert_eq!(get_resp.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -871,13 +871,13 @@ async fn test_cross_workspace_todo_other_ws_rejected() {
     scheduler.start().await.unwrap();
     let app = create_app(ctx, scheduler).await;
 
-    // 用 ws_b 访问 ws_a 的 todo → BadRequest
+    // 用 ws_b 访问 ws_a 的 todo → Forbidden
     let get_req = Request::builder()
         .uri(format!("/api/v1/workspaces/{}/todos/{}", ws_b, todo_id))
         .body(Body::empty())
         .unwrap();
     let get_resp = app.oneshot(get_req).await.unwrap();
-    assert_eq!(get_resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(get_resp.status(), StatusCode::FORBIDDEN);
 }
 
 // ====== 旧路由 404 验证 ======

--- a/backend/tests/api_integration_test.rs
+++ b/backend/tests/api_integration_test.rs
@@ -237,19 +237,17 @@ async fn test_delete_todo() {
         .uri(format!("/api/v1/workspaces/{}/todos/{}", ws_id, id))
         .body(Body::empty())
         .unwrap();
-    let response = app.oneshot(req).await.unwrap();
+    let response = app.clone().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    // Verify it's gone
+    // 在同一 app/DB 验证删除生效，而非新建空库（用 app.clone 避免 move）。
     let get_req = Request::builder()
-        .uri(format!("/api/v1/workspaces/{}/todos", ws_id))
+        .uri(format!("/api/v1/workspaces/{}/todos/{}", ws_id, id))
         .body(Body::empty())
         .unwrap();
-    let (app, _ws_id) = create_test_app().await;
-    let get_resp = app.oneshot(get_req).await.unwrap();
-    let get_body: serde_json::Value = read_json_body(get_resp).await;
-    let todos = get_body["data"].as_array().unwrap();
-    assert!(todos.iter().all(|t| t["id"].as_i64().unwrap() != id));
+    let get_resp = app.clone().oneshot(get_req).await.unwrap();
+    // 已删除的 todo 通过 get_todo 返回 NotFound
+    assert_eq!(get_resp.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -800,4 +798,162 @@ async fn test_loop_merge_same_name_overwrites() {
     let r2 = app.clone().oneshot(req2).await.unwrap();
     assert_eq!(r2.status(), StatusCode::OK);
     assert_eq!(count_loops_named(app, ws_id, "dup-loop").await, 1);
+}
+
+// ====== Workspace 隔离：跨 ws 越权访问应被拒绝 ======
+
+/// 建一个额外 workspace 返回其 id，用于跨 ws 越权测试。
+#[allow(dead_code)]
+async fn create_second_workspace(db: &Database) -> i64 {
+    db.create_project_directory("/tmp/test-api-workspace-B", Some("test-B"), false, false)
+        .await
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_cross_workspace_todo_rejected() {
+    // 在 ws_a 创建 todo，用 ws_b 的 URL 访问 → 应 400（不属于工作空间）
+    let (app, ws_a) = create_test_app().await;
+    // 创建 todo 在 ws_a
+    let create_req = json_request(
+        "POST",
+        &format!("/api/v1/workspaces/{}/todos", ws_a),
+        json!({"title": "隔离测试", "prompt": "test", "workspace_id": ws_a}),
+    );
+    let create_resp = app.clone().oneshot(create_req).await.unwrap();
+    let body: serde_json::Value = read_json_body(create_resp).await;
+    let todo_id = body["data"]["id"].as_i64().unwrap();
+
+    // 用 ws_b 访问 → 应返回 BadRequest
+    let ws_b = 99999; // 不存在的 ws，handler 会先查 todo 存在性，再查归属
+    let get_req = Request::builder()
+        .uri(format!("/api/v1/workspaces/{}/todos/{}", ws_b, todo_id))
+        .body(Body::empty())
+        .unwrap();
+    let get_resp = app.oneshot(get_req).await.unwrap();
+    // todo_id 真正存在但属于 ws_a → verify_todo_belongs_to_ws 返回 BadRequest
+    assert_eq!(get_resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_cross_workspace_todo_other_ws_rejected() {
+    // 在两个真实 workspace 间验证越权拒绝
+    let db = Arc::new(Database::new(":memory:").await.unwrap());
+    let ws_a = db
+        .create_project_directory("/tmp/test-ws-a", Some("A"), false, false)
+        .await
+        .unwrap();
+    let ws_b = db
+        .create_project_directory("/tmp/test-ws-b", Some("B"), false, false)
+        .await
+        .unwrap();
+
+    let todo_id = db
+        .create_todo_with_extras("隔离测试", "test", None, None, false, ws_a, "/tmp/test-ws-a")
+        .await
+        .unwrap();
+
+    let executor_registry = Arc::new(ExecutorRegistry::new());
+    executor_registry.register(ClaudeCodeExecutor::new("claude".to_string())).await;
+    let (tx, _rx) = broadcast::channel(100);
+    let task_manager = Arc::new(TaskManager::new());
+    let config = Arc::new(std::sync::RwLock::new(Config::default()));
+    let scheduler = Arc::new(TodoScheduler::new().await.unwrap());
+    let ctx = ntd::service_context::ServiceContext {
+        db: db.clone(),
+        executor_registry: executor_registry.clone(),
+        tx: tx.clone(),
+        task_manager: task_manager.clone(),
+        config: config.clone(),
+        expert_manager: Arc::new(ntd::expert::ExpertIndexManager::new()),
+    };
+    scheduler.load_from_db(&ctx).await.unwrap();
+    scheduler.start().await.unwrap();
+    let app = create_app(ctx, scheduler).await;
+
+    // 用 ws_b 访问 ws_a 的 todo → BadRequest
+    let get_req = Request::builder()
+        .uri(format!("/api/v1/workspaces/{}/todos/{}", ws_b, todo_id))
+        .body(Body::empty())
+        .unwrap();
+    let get_resp = app.oneshot(get_req).await.unwrap();
+    assert_eq!(get_resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// ====== 旧路由 404 验证 ======
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_old_api_routes_return_404() {
+    let (app, _ws_id) = create_test_app().await;
+
+    // 内核路由仍返回 OK（首页、健康检查）
+    let health_req = Request::builder().uri("/health").body(Body::empty()).unwrap();
+    assert_eq!(app.clone().oneshot(health_req).await.unwrap().status(), StatusCode::OK);
+
+    let root_req = Request::builder().uri("/").body(Body::empty()).unwrap();
+    assert_eq!(app.clone().oneshot(root_req).await.unwrap().status(), StatusCode::OK);
+
+    // 旧版本化路由应 404
+    let old_routes = vec![
+        "/api/todos",
+        "/api/loops",
+        "/api/executions",
+        "/api/execution-records",
+        "/api/dashboard-stats",
+        "/api/running-board",
+        "/api/running-todos",
+        "/api/execute",
+    ];
+    for uri in old_routes {
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "旧路由 {} 应返回 404",
+            uri
+        );
+    }
+}
+
+// ====== 修复 test_delete_todo 验证逻辑 ======
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_delete_todo_verified_with_same_app() {
+    // 删除 todo 后在同一 app/DB 验证删除生效，而非重新建立空库。
+    let (app, ws_id) = create_test_app().await;
+
+    let create_req = json_request(
+        "POST",
+        &format!("/api/v1/workspaces/{}/todos", ws_id),
+        json!({"title": "待删除", "prompt": "将被删除", "workspace_id": ws_id}),
+    );
+    let create_resp = app.clone().oneshot(create_req).await.unwrap();
+    let body: serde_json::Value = read_json_body(create_resp).await;
+    let todo_id = body["data"]["id"].as_i64().unwrap();
+
+    // 确认存在
+    let get_req = Request::builder()
+        .uri(format!("/api/v1/workspaces/{}/todos/{}", ws_id, todo_id))
+        .body(Body::empty())
+        .unwrap();
+    let get_resp = app.clone().oneshot(get_req).await.unwrap();
+    assert_eq!(get_resp.status(), StatusCode::OK);
+
+    // 删除
+    let del_req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/api/v1/workspaces/{}/todos/{}", ws_id, todo_id))
+        .body(Body::empty())
+        .unwrap();
+    let del_resp = app.clone().oneshot(del_req).await.unwrap();
+    assert_eq!(del_resp.status(), StatusCode::OK);
+
+    // 在同 app 验证删除
+    let get_req2 = Request::builder()
+        .uri(format!("/api/v1/workspaces/{}/todos/{}", ws_id, todo_id))
+        .body(Body::empty())
+        .unwrap();
+    let get_resp2 = app.oneshot(get_req2).await.unwrap();
+    assert_eq!(get_resp2.status(), StatusCode::NOT_FOUND);
 }

--- a/backend/tests/api_integration_test.rs
+++ b/backend/tests/api_integration_test.rs
@@ -624,7 +624,7 @@ async fn test_todo_with_tags() {
     assert_eq!(todo["tag_ids"], json!([tag2_id]));
 }
 
-/// DELETE /api/v1/workspaces/{id}/blackboard/wiki/files/{slug}：删除已存在 topic，返回 deleted=true。
+/// DELETE /api/v1/workspaces/{id}/wiki/files/{slug}：删除已存在 topic，返回 deleted=true。
 /// 用唯一 slug 避免与开发者本地真实 workspace 数据撞车；用例自身即删除该文件，自清理。
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_delete_wiki_file_existing() {
@@ -635,7 +635,7 @@ async fn test_delete_wiki_file_existing() {
 
     let req = Request::builder()
         .method("DELETE")
-        .uri(format!("/api/v1/workspaces/{}/blackboard/wiki/files/{}", ws_id, slug))
+        .uri(format!("/api/v1/workspaces/{}/wiki/files/{}", ws_id, slug))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -655,7 +655,7 @@ async fn test_delete_wiki_file_missing_is_idempotent() {
 
     let req = Request::builder()
         .method("DELETE")
-        .uri(format!("/api/v1/workspaces/{}/blackboard/wiki/files/{}", ws_id, slug))
+        .uri(format!("/api/v1/workspaces/{}/wiki/files/{}", ws_id, slug))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -671,7 +671,7 @@ async fn test_delete_wiki_file_log_forbidden() {
 
     let req = Request::builder()
         .method("DELETE")
-        .uri(format!("/api/v1/workspaces/{}/blackboard/wiki/files/log", ws_id))
+        .uri(format!("/api/v1/workspaces/{}/wiki/files/log", ws_id))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();

--- a/backend/tests/api_integration_test.rs
+++ b/backend/tests/api_integration_test.rs
@@ -85,12 +85,12 @@ async fn test_get_todos() {
     let (app, ws_id) = create_test_app().await;
 
     // Create a todo first
-    let req = json_request("POST", "/api/todos", json!({"title": "Test", "prompt": "Do this", "workspace_id": ws_id, "tag_ids": []}));
+    let req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Test", "prompt": "Do this", "workspace_id": ws_id, "tag_ids": []}));
     let response = app.clone().oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
     let req = Request::builder()
-        .uri("/api/todos")
+        .uri(format!("/api/v1/workspaces/{}/todos", ws_id))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -105,7 +105,7 @@ async fn test_get_todos() {
     let our_todo = todos
         .iter()
         .find(|t| t["title"] == "Test")
-        .expect("newly created 'Test' todo should appear in GET /api/todos");
+        .expect("newly created 'Test' todo should appear in GET /api/v1/workspaces//todos");
     assert_eq!(our_todo["prompt"], "Do this");
     assert_eq!(our_todo["status"], "pending");
 }
@@ -114,7 +114,7 @@ async fn test_get_todos() {
 async fn test_create_todo_success() {
     let (app, ws_id) = create_test_app().await;
 
-    let req = json_request("POST", "/api/todos", json!({"title": "New Todo", "prompt": "Prompt text", "workspace_id": ws_id, "tag_ids": []}));
+    let req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "New Todo", "prompt": "Prompt text", "workspace_id": ws_id, "tag_ids": []}));
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -129,7 +129,7 @@ async fn test_create_todo_success() {
 async fn test_create_todo_empty_title() {
     let (app, ws_id) = create_test_app().await;
 
-    let req = json_request("POST", "/api/todos", json!({"title": "", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
+    let req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
@@ -141,7 +141,7 @@ async fn test_create_todo_empty_title() {
 async fn test_create_todo_prompt_fallback() {
     let (app, ws_id) = create_test_app().await;
 
-    let req = json_request("POST", "/api/todos", json!({"title": "Fallback Title", "prompt": "", "workspace_id": ws_id, "tag_ids": []}));
+    let req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Fallback Title", "prompt": "", "workspace_id": ws_id, "tag_ids": []}));
     let response = app.oneshot(req).await.unwrap();
 
     let body: serde_json::Value = read_json_body(response).await;
@@ -153,12 +153,12 @@ async fn test_create_todo_with_tags() {
     let (app, ws_id) = create_test_app().await;
 
     // Create a tag first
-    let tag_req = json_request("POST", "/api/tags", json!({"name": "urgent", "color": "#ff0000"}));
+    let tag_req = json_request("POST", "/api/v1/tags", json!({"name": "urgent", "color": "#ff0000"}));
     let tag_resp = app.clone().oneshot(tag_req).await.unwrap();
     let tag_body: serde_json::Value = read_json_body(tag_resp).await;
     let tag_id = tag_body["data"]["id"].as_i64().unwrap();
 
-    let req = json_request("POST", "/api/todos", json!({"title": "Tagged", "prompt": "Do this", "workspace_id": ws_id, "tag_ids": [tag_id]}));
+    let req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Tagged", "prompt": "Do this", "workspace_id": ws_id, "tag_ids": [tag_id]}));
     let response = app.oneshot(req).await.unwrap();
 
     let body: serde_json::Value = read_json_body(response).await;
@@ -171,12 +171,12 @@ async fn test_create_todo_with_tags() {
 async fn test_update_todo_success() {
     let (app, ws_id) = create_test_app().await;
 
-    let create_req = json_request("POST", "/api/todos", json!({"title": "Old", "prompt": "Old prompt", "workspace_id": ws_id, "tag_ids": []}));
+    let create_req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Old", "prompt": "Old prompt", "workspace_id": ws_id, "tag_ids": []}));
     let create_resp = app.clone().oneshot(create_req).await.unwrap();
     let create_body: serde_json::Value = read_json_body(create_resp).await;
     let id = create_body["data"]["id"].as_i64().unwrap();
 
-    let req = json_request("PUT", &format!("/api/todos/{}", id), json!({"title": "Updated", "prompt": "Updated prompt", "status": "in_progress"}));
+    let req = json_request("PUT", &format!("/api/v1/workspaces/{}/todos/{}", ws_id, id), json!({"title": "Updated", "prompt": "Updated prompt", "status": "in_progress"}));
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -189,12 +189,12 @@ async fn test_update_todo_success() {
 async fn test_update_todo_prompt_fallback() {
     let (app, ws_id) = create_test_app().await;
 
-    let create_req = json_request("POST", "/api/todos", json!({"title": "Title", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
+    let create_req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Title", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
     let create_resp = app.clone().oneshot(create_req).await.unwrap();
     let create_body: serde_json::Value = read_json_body(create_resp).await;
     let id = create_body["data"]["id"].as_i64().unwrap();
 
-    let req = json_request("PUT", &format!("/api/todos/{}", id), json!({"title": "New Title", "prompt": "", "status": "pending"}));
+    let req = json_request("PUT", &format!("/api/v1/workspaces/{}/todos/{}", ws_id, id), json!({"title": "New Title", "prompt": "", "status": "pending"}));
     let response = app.oneshot(req).await.unwrap();
 
     let body: serde_json::Value = read_json_body(response).await;
@@ -205,17 +205,17 @@ async fn test_update_todo_prompt_fallback() {
 async fn test_update_todo_tags() {
     let (app, ws_id) = create_test_app().await;
 
-    let create_req = json_request("POST", "/api/todos", json!({"title": "Test", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
+    let create_req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Test", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
     let create_resp = app.clone().oneshot(create_req).await.unwrap();
     let create_body: serde_json::Value = read_json_body(create_resp).await;
     let todo_id = create_body["data"]["id"].as_i64().unwrap();
 
-    let tag_req = json_request("POST", "/api/tags", json!({"name": "urgent", "color": "#ff0000"}));
+    let tag_req = json_request("POST", "/api/v1/tags", json!({"name": "urgent", "color": "#ff0000"}));
     let tag_resp = app.clone().oneshot(tag_req).await.unwrap();
     let tag_body: serde_json::Value = read_json_body(tag_resp).await;
     let tag_id = tag_body["data"]["id"].as_i64().unwrap();
 
-    let req = json_request("PUT", &format!("/api/todos/{}/tags", todo_id), json!({"tag_ids": [tag_id]}));
+    let req = json_request("PUT", &format!("/api/v1/workspaces/{}/todos/{}/tags", ws_id, todo_id), json!({"tag_ids": [tag_id]}));
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -227,14 +227,14 @@ async fn test_update_todo_tags() {
 async fn test_delete_todo() {
     let (app, ws_id) = create_test_app().await;
 
-    let create_req = json_request("POST", "/api/todos", json!({"title": "To Delete", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
+    let create_req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "To Delete", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
     let create_resp = app.clone().oneshot(create_req).await.unwrap();
     let create_body: serde_json::Value = read_json_body(create_resp).await;
     let id = create_body["data"]["id"].as_i64().unwrap();
 
     let req = Request::builder()
         .method("DELETE")
-        .uri(format!("/api/todos/{}", id))
+        .uri(format!("/api/v1/workspaces/{}/todos/{}", ws_id, id))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -242,7 +242,7 @@ async fn test_delete_todo() {
 
     // Verify it's gone
     let get_req = Request::builder()
-        .uri("/api/todos")
+        .uri(format!("/api/v1/workspaces/{}/todos", ws_id))
         .body(Body::empty())
         .unwrap();
     let (app, _ws_id) = create_test_app().await;
@@ -254,29 +254,29 @@ async fn test_delete_todo() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_delete_todo_not_found() {
-    let (app, _ws_id) = create_test_app().await;
+    let (app, ws_id) = create_test_app().await;
 
     let req = Request::builder()
         .method("DELETE")
-        .uri("/api/todos/9999")
+        .uri(format!("/api/v1/workspaces/{}/todos/9999", ws_id))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
-    // Attempting to delete a non-existent todo returns an error
-    // because the database update affects 0 rows, which sea_orm may treat as an error
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    // 删除不存在的 todo：v1 隔离校验（verify_todo_belongs_to_ws）先查 todo，
+    // 不存在则返回 NotFound(404)，比原先依赖 sea_orm 0-rows 报 500 更语义准确。
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_force_update_status() {
     let (app, ws_id) = create_test_app().await;
 
-    let create_req = json_request("POST", "/api/todos", json!({"title": "Test", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
+    let create_req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Test", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
     let create_resp = app.clone().oneshot(create_req).await.unwrap();
     let create_body: serde_json::Value = read_json_body(create_resp).await;
     let id = create_body["data"]["id"].as_i64().unwrap();
 
-    let req = json_request("PUT", &format!("/api/todos/{}/force-status", id), json!({"title": "Test", "prompt": "Prompt", "status": "completed"}));
+    let req = json_request("PUT", &format!("/api/v1/workspaces/{}/todos/{}/force-status", ws_id, id), json!({"title": "Test", "prompt": "Prompt", "status": "completed"}));
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -286,9 +286,9 @@ async fn test_force_update_status() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_todo_not_found() {
-    let (app, _ws_id) = create_test_app().await;
+    let (app, ws_id) = create_test_app().await;
 
-    let req = json_request("PUT", "/api/todos/9999", json!({"title": "Test", "prompt": "Prompt", "status": "pending"}));
+    let req = json_request("PUT", &format!("/api/v1/workspaces/{}/todos/9999", ws_id), json!({"title": "Test", "prompt": "Prompt", "status": "pending"}));
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
@@ -302,7 +302,7 @@ async fn test_get_tags() {
     let (app, _ws_id) = create_test_app().await;
 
     let req = Request::builder()
-        .uri("/api/tags")
+        .uri("/api/v1/tags")
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -317,7 +317,7 @@ async fn test_get_tags() {
 async fn test_create_tag_success() {
     let (app, _ws_id) = create_test_app().await;
 
-    let req = json_request("POST", "/api/tags", json!({"name": "urgent", "color": "#ff0000"}));
+    let req = json_request("POST", "/api/v1/tags", json!({"name": "urgent", "color": "#ff0000"}));
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -331,7 +331,7 @@ async fn test_create_tag_success() {
 async fn test_create_tag_empty_name() {
     let (app, _ws_id) = create_test_app().await;
 
-    let req = json_request("POST", "/api/tags", json!({"name": "", "color": "#ff0000"}));
+    let req = json_request("POST", "/api/v1/tags", json!({"name": "", "color": "#ff0000"}));
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
@@ -343,14 +343,14 @@ async fn test_create_tag_empty_name() {
 async fn test_delete_tag() {
     let (app, _ws_id) = create_test_app().await;
 
-    let create_req = json_request("POST", "/api/tags", json!({"name": "to-delete", "color": "#ff0000"}));
+    let create_req = json_request("POST", "/api/v1/tags", json!({"name": "to-delete", "color": "#ff0000"}));
     let create_resp = app.clone().oneshot(create_req).await.unwrap();
     let create_body: serde_json::Value = read_json_body(create_resp).await;
     let id = create_body["data"]["id"].as_i64().unwrap();
 
     let req = Request::builder()
         .method("DELETE")
-        .uri(format!("/api/tags/{}", id))
+        .uri(format!("/api/v1/tags/{}", id))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -363,13 +363,13 @@ async fn test_delete_tag() {
 async fn test_get_execution_records() {
     let (app, ws_id) = create_test_app().await;
 
-    let create_req = json_request("POST", "/api/todos", json!({"title": "Test", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
+    let create_req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Test", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
     let create_resp = app.clone().oneshot(create_req).await.unwrap();
     let create_body: serde_json::Value = read_json_body(create_resp).await;
     let todo_id = create_body["data"]["id"].as_i64().unwrap();
 
     let req = Request::builder()
-        .uri(format!("/api/execution-records?todo_id={}", todo_id))
+        .uri(format!("/api/v1/workspaces/{}/executions?todo_id={}", ws_id, todo_id))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -385,13 +385,13 @@ async fn test_get_execution_records() {
 async fn test_get_execution_records_pagination() {
     let (app, ws_id) = create_test_app().await;
 
-    let create_req = json_request("POST", "/api/todos", json!({"title": "Test", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
+    let create_req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Test", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
     let create_resp = app.clone().oneshot(create_req).await.unwrap();
     let create_body: serde_json::Value = read_json_body(create_resp).await;
     let todo_id = create_body["data"]["id"].as_i64().unwrap();
 
     let req = Request::builder()
-        .uri(format!("/api/execution-records?todo_id={}&page=1&limit=5", todo_id))
+        .uri(format!("/api/v1/workspaces/{}/executions?todo_id={}&page=1&limit=5", ws_id, todo_id))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -405,13 +405,13 @@ async fn test_get_execution_records_pagination() {
 async fn test_get_execution_summary() {
     let (app, ws_id) = create_test_app().await;
 
-    let create_req = json_request("POST", "/api/todos", json!({"title": "Test", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
+    let create_req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Test", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
     let create_resp = app.clone().oneshot(create_req).await.unwrap();
     let create_body: serde_json::Value = read_json_body(create_resp).await;
     let todo_id = create_body["data"]["id"].as_i64().unwrap();
 
     let req = Request::builder()
-        .uri(format!("/api/todos/{}/summary", todo_id))
+        .uri(format!("/api/v1/workspaces/{}/todos/{}/summary", ws_id, todo_id))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -424,14 +424,21 @@ async fn test_get_execution_summary() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_stop_execution_not_found() {
-    let (app, _ws_id) = create_test_app().await;
+    // v1: stop 路径嵌入 workspace + record_id（POST /workspaces/{ws}/executions/{record_id}/stop）
+    // 不存在的 record_id：v1 handler 通过 workspace_guard 校验归属，未找到时返回 NotFound (404)，
+    // 而非旧版的 BadRequest（避免泄露资源是否存在）。
+    let (app, ws_id) = create_test_app().await;
 
-    let req = json_request("POST", "/api/execute/stop", json!({"task_id": "nonexistent-task"}));
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/api/v1/workspaces/{}/executions/9999/stop", ws_id))
+        .body(Body::empty())
+        .unwrap();
     let response = app.oneshot(req).await.unwrap();
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     let body: serde_json::Value = read_json_body(response).await;
-    assert_eq!(body["code"], 40002);
+    assert_eq!(body["code"], 40001);
 }
 
 // ===== Scheduler handlers =====
@@ -440,12 +447,12 @@ async fn test_stop_execution_not_found() {
 async fn test_update_scheduler_enable() {
     let (app, ws_id) = create_test_app().await;
 
-    let create_req = json_request("POST", "/api/todos", json!({"title": "Scheduled", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
+    let create_req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Scheduled", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
     let create_resp = app.clone().oneshot(create_req).await.unwrap();
     let create_body: serde_json::Value = read_json_body(create_resp).await;
     let id = create_body["data"]["id"].as_i64().unwrap();
 
-    let req = json_request("PUT", &format!("/api/todos/{}/scheduler", id), json!({"scheduler_enabled": true, "scheduler_config": "0 0 0 * * *"}));
+    let req = json_request("PUT", &format!("/api/v1/workspaces/{}/todos/{}/scheduler", ws_id, id), json!({"scheduler_enabled": true, "scheduler_config": "0 0 0 * * *"}));
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -458,17 +465,17 @@ async fn test_update_scheduler_enable() {
 async fn test_update_scheduler_disable() {
     let (app, ws_id) = create_test_app().await;
 
-    let create_req = json_request("POST", "/api/todos", json!({"title": "Scheduled", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
+    let create_req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Scheduled", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
     let create_resp = app.clone().oneshot(create_req).await.unwrap();
     let create_body: serde_json::Value = read_json_body(create_resp).await;
     let id = create_body["data"]["id"].as_i64().unwrap();
 
     // Enable first
-    let enable_req = json_request("PUT", &format!("/api/todos/{}/scheduler", id), json!({"scheduler_enabled": true, "scheduler_config": "0 0 0 * * *"}));
+    let enable_req = json_request("PUT", &format!("/api/v1/workspaces/{}/todos/{}/scheduler", ws_id, id), json!({"scheduler_enabled": true, "scheduler_config": "0 0 0 * * *"}));
     let _ = app.clone().oneshot(enable_req).await.unwrap();
 
     // Then disable
-    let req = json_request("PUT", &format!("/api/todos/{}/scheduler", id), json!({"scheduler_enabled": false, "scheduler_config": null}));
+    let req = json_request("PUT", &format!("/api/v1/workspaces/{}/todos/{}/scheduler", ws_id, id), json!({"scheduler_enabled": false, "scheduler_config": null}));
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -480,13 +487,13 @@ async fn test_update_scheduler_disable() {
 async fn test_update_scheduler_missing_config() {
     let (app, ws_id) = create_test_app().await;
 
-    let create_req = json_request("POST", "/api/todos", json!({"title": "Scheduled", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
+    let create_req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Scheduled", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
     let create_resp = app.clone().oneshot(create_req).await.unwrap();
     let create_body: serde_json::Value = read_json_body(create_resp).await;
     let id = create_body["data"]["id"].as_i64().unwrap();
 
     // Enable but without config -> should remove task
-    let req = json_request("PUT", &format!("/api/todos/{}/scheduler", id), json!({"scheduler_enabled": true, "scheduler_config": null}));
+    let req = json_request("PUT", &format!("/api/v1/workspaces/{}/todos/{}/scheduler", ws_id, id), json!({"scheduler_enabled": true, "scheduler_config": null}));
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -498,16 +505,16 @@ async fn test_update_scheduler_missing_config() {
 async fn test_get_scheduler_todos() {
     let (app, ws_id) = create_test_app().await;
 
-    let create_req = json_request("POST", "/api/todos", json!({"title": "Scheduled", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
+    let create_req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Scheduled", "prompt": "Prompt", "workspace_id": ws_id, "tag_ids": []}));
     let create_resp = app.clone().oneshot(create_req).await.unwrap();
     let create_body: serde_json::Value = read_json_body(create_resp).await;
     let id = create_body["data"]["id"].as_i64().unwrap();
 
-    let enable_req = json_request("PUT", &format!("/api/todos/{}/scheduler", id), json!({"scheduler_enabled": true, "scheduler_config": "0 0 0 * * *"}));
+    let enable_req = json_request("PUT", &format!("/api/v1/workspaces/{}/todos/{}/scheduler", ws_id, id), json!({"scheduler_enabled": true, "scheduler_config": "0 0 0 * * *"}));
     let _ = app.clone().oneshot(enable_req).await.unwrap();
 
     let req = Request::builder()
-        .uri("/api/scheduler/todos")
+        .uri(format!("/api/v1/workspaces/{}/scheduler/todos", ws_id))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -527,14 +534,14 @@ async fn test_todo_lifecycle() {
     let (app, ws_id) = create_test_app().await;
 
     // Create
-    let req = json_request("POST", "/api/todos", json!({"title": "Lifecycle", "prompt": "Test", "workspace_id": ws_id, "tag_ids": []}));
+    let req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Lifecycle", "prompt": "Test", "workspace_id": ws_id, "tag_ids": []}));
     let response = app.clone().oneshot(req).await.unwrap();
     let body: serde_json::Value = read_json_body(response).await;
     let id = body["data"]["id"].as_i64().unwrap();
     assert_eq!(body["data"]["title"], "Lifecycle");
 
     // Update
-    let req = json_request("PUT", &format!("/api/todos/{}", id), json!({"title": "Updated", "prompt": "Updated", "status": "in_progress"}));
+    let req = json_request("PUT", &format!("/api/v1/workspaces/{}/todos/{}", ws_id, id), json!({"title": "Updated", "prompt": "Updated", "status": "in_progress"}));
     let response = app.clone().oneshot(req).await.unwrap();
     let body: serde_json::Value = read_json_body(response).await;
     assert_eq!(body["data"]["title"], "Updated");
@@ -542,7 +549,7 @@ async fn test_todo_lifecycle() {
     // Delete
     let req = Request::builder()
         .method("DELETE")
-        .uri(format!("/api/todos/{}", id))
+        .uri(format!("/api/v1/workspaces/{}/todos/{}", ws_id, id))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -554,7 +561,7 @@ async fn test_tag_lifecycle() {
     let (app, _ws_id) = create_test_app().await;
 
     // Create
-    let req = json_request("POST", "/api/tags", json!({"name": "lifecycle", "color": "#00ff00"}));
+    let req = json_request("POST", "/api/v1/tags", json!({"name": "lifecycle", "color": "#00ff00"}));
     let response = app.clone().oneshot(req).await.unwrap();
     let body: serde_json::Value = read_json_body(response).await;
     let id = body["data"]["id"].as_i64().unwrap();
@@ -562,7 +569,7 @@ async fn test_tag_lifecycle() {
 
     // Get list
     let req = Request::builder()
-        .uri("/api/tags")
+        .uri("/api/v1/tags")
         .body(Body::empty())
         .unwrap();
     let response = app.clone().oneshot(req).await.unwrap();
@@ -572,7 +579,7 @@ async fn test_tag_lifecycle() {
     // Delete
     let req = Request::builder()
         .method("DELETE")
-        .uri(format!("/api/tags/{}", id))
+        .uri(format!("/api/v1/tags/{}", id))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -584,30 +591,30 @@ async fn test_todo_with_tags() {
     let (app, ws_id) = create_test_app().await;
 
     // Create tags
-    let tag1_req = json_request("POST", "/api/tags", json!({"name": "urgent", "color": "#ff0000"}));
+    let tag1_req = json_request("POST", "/api/v1/tags", json!({"name": "urgent", "color": "#ff0000"}));
     let tag1_resp = app.clone().oneshot(tag1_req).await.unwrap();
     let tag1_body: serde_json::Value = read_json_body(tag1_resp).await;
     let tag1_id = tag1_body["data"]["id"].as_i64().unwrap();
 
-    let tag2_req = json_request("POST", "/api/tags", json!({"name": "later", "color": "#00ff00"}));
+    let tag2_req = json_request("POST", "/api/v1/tags", json!({"name": "later", "color": "#00ff00"}));
     let tag2_resp = app.clone().oneshot(tag2_req).await.unwrap();
     let tag2_body: serde_json::Value = read_json_body(tag2_resp).await;
     let tag2_id = tag2_body["data"]["id"].as_i64().unwrap();
 
     // Create todo with tags
-    let todo_req = json_request("POST", "/api/todos", json!({"title": "Tagged", "prompt": "Do it", "workspace_id": ws_id, "tag_ids": [tag1_id]}));
+    let todo_req = json_request("POST", &format!("/api/v1/workspaces/{}/todos", ws_id), json!({"title": "Tagged", "prompt": "Do it", "workspace_id": ws_id, "tag_ids": [tag1_id]}));
     let todo_resp = app.clone().oneshot(todo_req).await.unwrap();
     let todo_body: serde_json::Value = read_json_body(todo_resp).await;
     let todo_id = todo_body["data"]["id"].as_i64().unwrap();
     assert_eq!(todo_body["data"]["tag_ids"], json!([tag1_id]));
 
     // Update tags
-    let update_req = json_request("PUT", &format!("/api/todos/{}/tags", todo_id), json!({"tag_ids": [tag2_id]}));
+    let update_req = json_request("PUT", &format!("/api/v1/workspaces/{}/todos/{}/tags", ws_id, todo_id), json!({"tag_ids": [tag2_id]}));
     let _ = app.clone().oneshot(update_req).await.unwrap();
 
     // Verify
     let get_req = Request::builder()
-        .uri("/api/todos")
+        .uri(format!("/api/v1/workspaces/{}/todos", ws_id))
         .body(Body::empty())
         .unwrap();
     let get_resp = app.oneshot(get_req).await.unwrap();
@@ -617,7 +624,7 @@ async fn test_todo_with_tags() {
     assert_eq!(todo["tag_ids"], json!([tag2_id]));
 }
 
-/// DELETE /api/workspaces/{id}/wiki/files/{slug}：删除已存在 topic，返回 deleted=true。
+/// DELETE /api/v1/workspaces/{id}/blackboard/wiki/files/{slug}：删除已存在 topic，返回 deleted=true。
 /// 用唯一 slug 避免与开发者本地真实 workspace 数据撞车；用例自身即删除该文件，自清理。
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_delete_wiki_file_existing() {
@@ -628,7 +635,7 @@ async fn test_delete_wiki_file_existing() {
 
     let req = Request::builder()
         .method("DELETE")
-        .uri(format!("/api/workspaces/{}/wiki/files/{}", ws_id, slug))
+        .uri(format!("/api/v1/workspaces/{}/blackboard/wiki/files/{}", ws_id, slug))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -648,7 +655,7 @@ async fn test_delete_wiki_file_missing_is_idempotent() {
 
     let req = Request::builder()
         .method("DELETE")
-        .uri(format!("/api/workspaces/{}/wiki/files/{}", ws_id, slug))
+        .uri(format!("/api/v1/workspaces/{}/blackboard/wiki/files/{}", ws_id, slug))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -664,7 +671,7 @@ async fn test_delete_wiki_file_log_forbidden() {
 
     let req = Request::builder()
         .method("DELETE")
-        .uri(format!("/api/workspaces/{}/wiki/files/log", ws_id))
+        .uri(format!("/api/v1/workspaces/{}/blackboard/wiki/files/log", ws_id))
         .body(Body::empty())
         .unwrap();
     let response = app.oneshot(req).await.unwrap();
@@ -748,8 +755,9 @@ loops:
 }
 
 /// 取指定工作空间下名为 name 的 loop 数量（通过 list 接口）
+/// v1: workspace 嵌入 URL 路径段，不再走 query 参数
 async fn count_loops_named(app: axum::Router, ws_id: i64, name: &str) -> usize {
-    let uri = format!("/api/loops?workspace_id={}", ws_id);
+    let uri = format!("/api/v1/workspaces/{}/loops", ws_id);
     let req = Request::builder().uri(&uri).body(Body::empty()).unwrap();
     let response = app.oneshot(req).await.unwrap();
     let body: serde_json::Value = read_json_body(response).await;
@@ -761,7 +769,7 @@ async fn test_loop_merge_keeps_original_name() {
     // 导入后 loop 名应保持原名，不再追加 "-合并" 后缀
     let (app, ws_id) = create_test_app().await;
     let yaml = loop_merge_yaml("我的环路", ws_id);
-    let req = json_request("POST", "/api/loops/merge", json!({
+    let req = json_request("POST", &format!("/api/v1/workspaces/{}/loops/merge", ws_id), json!({
         "yaml": yaml, "workspace_id": null, "workspace_overrides": {}
     }));
     let response = app.clone().oneshot(req).await.unwrap();
@@ -778,7 +786,7 @@ async fn test_loop_merge_same_name_overwrites() {
     // 同名 loop 二次导入 → 覆盖（删旧重建），不产生重复
     let (app, ws_id) = create_test_app().await;
     let yaml = loop_merge_yaml("dup-loop", ws_id);
-    let req = json_request("POST", "/api/loops/merge", json!({
+    let req = json_request("POST", &format!("/api/v1/workspaces/{}/loops/merge", ws_id), json!({
         "yaml": yaml, "workspace_id": null, "workspace_overrides": {}
     }));
     let r1 = app.clone().oneshot(req).await.unwrap();
@@ -786,7 +794,7 @@ async fn test_loop_merge_same_name_overwrites() {
     assert_eq!(count_loops_named(app.clone(), ws_id, "dup-loop").await, 1);
 
     // 再次导入同名 → 覆盖，仍只 1 个
-    let req2 = json_request("POST", "/api/loops/merge", json!({
+    let req2 = json_request("POST", &format!("/api/v1/workspaces/{}/loops/merge", ws_id), json!({
         "yaml": yaml, "workspace_id": null, "workspace_overrides": {}
     }));
     let r2 = app.clone().oneshot(req2).await.unwrap();

--- a/backend/tests/blackboard_cli_tests.rs
+++ b/backend/tests/blackboard_cli_tests.rs
@@ -2,13 +2,13 @@
 //!
 //! 覆盖范围（之前单元测试只测了 `render_blackboard` 渲染函数本身）：
 //! 1. CLI 参数解析：blackboard / --human / 错误 ID
-//! 2. HTTP dispatch：ApiClient 正确请求 `/loop-executions/{id}` 并解析 ApiResponse
+//! 2. HTTP dispatch：ApiClient 正确请求 v1 路径 `/workspaces/{ws}/loops/{loop_id}/executions/{eid}` 并解析 ApiResponse
 //! 3. 默认输出 JSON：dispatch 路径下输出是合法 JSON，包含 step_executions 完整结构
 //! 4. `--human` 输出：dispatch 路径下输出是黑板文本，包含循环名 + 状态图标 + exec id
 //! 5. 错误传播：HTTP 404 → anyhow error + 错误 schema 打印
 //! 6. 中文/多字节场景：JSON 多行结论 / `\n` 正确保留
 //!
-//! 测试策略：mock 一个本地 TCP server 拦截 `GET /api/loop-executions/{id}`，
+//! 测试策略：mock 一个本地 TCP server 拦截 `GET /api/v1/workspaces/{ws}/loops/{loop_id}/executions/{eid}`，
 //! 返回固定的 ApiResponse JSON；用 `ApiClient` 真实发请求；用 `Cli::try_parse_from`
 //! 构造参数；最后用 `Cli::command` 走 dispatch 时改走 `Vec<u8>` 缓冲（避免 println!
 //! 散落）然后读出来做断言。
@@ -64,7 +64,7 @@ async fn spawn_mock_loop_server(initial_body: String, content_type: &'static str
 }
 
 /// 构造完整的 ApiResponse 包装的 LoopExecutionDetail JSON 字符串，
-/// 模拟真实后端 `/api/loop-executions/{id}` 的响应。
+/// 模拟真实后端 v1 路径 `/api/v1/workspaces/{ws}/loops/{loop_id}/executions/{eid}` 的响应。
 fn make_loop_execution_response(id: i64, step_count: usize) -> String {
     let steps: Vec<Value> = (1..=step_count)
         .map(|i| {
@@ -133,12 +133,16 @@ fn make_loop_execution_response(id: i64, step_count: usize) -> String {
 #[test]
 fn test_cli_parse_blackboard_default() {
     // `ntd loop execution blackboard 42` 应解析为 Blackboard(execution_id=42, human=false)
-    let cli = Cli::try_parse_from(["ntd", "loop", "execution", "blackboard", "42"]).unwrap();
+    // v1: --workspace-id + --loop-id 必填（路径 /workspaces/{ws}/loops/{loop_id}/executions/{eid}）
+    let cli = Cli::try_parse_from([
+        "ntd", "loop", "execution", "blackboard",
+        "--workspace-id", "1", "--loop-id", "2", "42",
+    ]).unwrap();
     match cli.command {
         Commands::Loop {
             action:
                 LoopAction::Execution {
-                    action: LoopExecutionAction::Blackboard { execution_id, human },
+                    action: LoopExecutionAction::Blackboard { execution_id, human, .. },
                 },
         } => {
             assert_eq!(execution_id, 42);
@@ -151,13 +155,16 @@ fn test_cli_parse_blackboard_default() {
 #[test]
 fn test_cli_parse_blackboard_human_flag() {
     // `--human` 应切换为人类视图
-    let cli =
-        Cli::try_parse_from(["ntd", "loop", "execution", "blackboard", "42", "--human"]).unwrap();
+    // v1: --workspace-id + --loop-id 必填
+    let cli = Cli::try_parse_from([
+        "ntd", "loop", "execution", "blackboard",
+        "--workspace-id", "1", "--loop-id", "2", "42", "--human",
+    ]).unwrap();
     match cli.command {
         Commands::Loop {
             action:
                 LoopAction::Execution {
-                    action: LoopExecutionAction::Blackboard { execution_id, human },
+                    action: LoopExecutionAction::Blackboard { execution_id, human, .. },
                 },
         } => {
             assert_eq!(execution_id, 42);
@@ -170,6 +177,7 @@ fn test_cli_parse_blackboard_human_flag() {
 #[test]
 fn test_cli_parse_blackboard_combined_with_output() {
     // 全局 --output pretty 与 --human 不冲突; blackboard 走自己的逻辑
+    // v1: --workspace-id + --loop-id 必填
     let cli = Cli::try_parse_from([
         "ntd",
         "-o",
@@ -177,6 +185,10 @@ fn test_cli_parse_blackboard_combined_with_output() {
         "loop",
         "execution",
         "blackboard",
+        "--workspace-id",
+        "1",
+        "--loop-id",
+        "2",
         "99",
         "--human",
     ])
@@ -186,7 +198,7 @@ fn test_cli_parse_blackboard_combined_with_output() {
         Commands::Loop {
             action:
                 LoopAction::Execution {
-                    action: LoopExecutionAction::Blackboard { execution_id, human },
+                    action: LoopExecutionAction::Blackboard { execution_id, human, .. },
                 },
         } => {
             assert_eq!(execution_id, 99);
@@ -217,7 +229,7 @@ async fn test_apiclient_parses_loop_execution_response() {
     let (url, _body_slot) = spawn_mock_loop_server(body, "application/json").await;
     let client = ApiClient::new(&url);
 
-    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/1105").await.unwrap();
+    let resp: ntd::models::ClientResponse<Value> = client.get("/workspaces/1/loops/2/executions/1105").await.unwrap();
 
     assert_eq!(resp.code, 0, "ApiResponse code 应为 0: {:?}", resp);
     assert_eq!(resp.message, "ok");
@@ -250,7 +262,7 @@ async fn test_apiclient_handles_404_like_error_response() {
     let (url, _) = spawn_mock_loop_server(err_body, "application/json").await;
     let client = ApiClient::new(&url);
 
-    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/99999").await.unwrap();
+    let resp: ntd::models::ClientResponse<Value> = client.get("/workspaces/1/loops/2/executions/99999").await.unwrap();
 
     assert_eq!(resp.code, 40001, "应传播错误码");
     assert!(resp.data.is_none(), "错误响应 data 应为 None");
@@ -269,7 +281,7 @@ async fn test_blackboard_e2e_json_mode_payload() {
     let (url, _) = spawn_mock_loop_server(body, "application/json").await;
     let client = ApiClient::new(&url);
 
-    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/42").await.unwrap();
+    let resp: ntd::models::ClientResponse<Value> = client.get("/workspaces/1/loops/2/executions/42").await.unwrap();
 
     // 模拟 dispatch 路径: 走 render_blackboard_to 之前先 to_string_pretty
     let mut buf: Vec<u8> = Vec::new();
@@ -293,7 +305,7 @@ async fn test_blackboard_e2e_human_mode_contains_key_fragments() {
     let (url, _) = spawn_mock_loop_server(body, "application/json").await;
     let client = ApiClient::new(&url);
 
-    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/1105").await.unwrap();
+    let resp: ntd::models::ClientResponse<Value> = client.get("/workspaces/1/loops/2/executions/1105").await.unwrap();
 
     // 模拟 dispatch 路径: render_blackboard_to
     let mut buf: Vec<u8> = Vec::new();
@@ -350,7 +362,7 @@ async fn test_blackboard_e2e_human_mode_cjk_alignment() {
     let api_resp = json!({"code": 0, "data": detail, "message": "ok"}).to_string();
     let (url, _) = spawn_mock_loop_server(api_resp, "application/json").await;
     let client = ApiClient::new(&url);
-    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/100").await.unwrap();
+    let resp: ntd::models::ClientResponse<Value> = client.get("/workspaces/1/loops/2/executions/100").await.unwrap();
 
     let mut buf: Vec<u8> = Vec::new();
     ntd::cli::commands::render_blackboard_to(resp.data.as_ref(), &mut buf);
@@ -385,7 +397,7 @@ async fn test_blackboard_e2e_empty_step_executions() {
     let api_resp = json!({"code": 0, "data": detail, "message": "ok"}).to_string();
     let (url, _) = spawn_mock_loop_server(api_resp, "application/json").await;
     let client = ApiClient::new(&url);
-    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/200").await.unwrap();
+    let resp: ntd::models::ClientResponse<Value> = client.get("/workspaces/1/loops/2/executions/200").await.unwrap();
 
     let mut buf: Vec<u8> = Vec::new();
     ntd::cli::commands::render_blackboard_to(resp.data.as_ref(), &mut buf);
@@ -415,7 +427,7 @@ async fn test_blackboard_e2e_multiline_conclusion_preserved() {
     let api_resp = json!({"code": 0, "data": detail, "message": "ok"}).to_string();
     let (url, _) = spawn_mock_loop_server(api_resp, "application/json").await;
     let client = ApiClient::new(&url);
-    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/300").await.unwrap();
+    let resp: ntd::models::ClientResponse<Value> = client.get("/workspaces/1/loops/2/executions/300").await.unwrap();
 
     // JSON 模式: \n 应作为字面字符串保留 (jq 输出原样)
     let data = resp.data.as_ref().unwrap();
@@ -444,7 +456,7 @@ async fn test_blackboard_dispatch_propagates_error_code() {
 
     // 直接复现 dispatch 的错误处理逻辑 (它不再走 println, 而是 anyhow::Error)
     let client = ApiClient::new(&url);
-    let resp: ntd::models::ClientResponse<Value> = client.get("/loop-executions/1").await.unwrap();
+    let resp: ntd::models::ClientResponse<Value> = client.get("/workspaces/1/loops/2/executions/1").await.unwrap();
     assert_eq!(resp.code, 500);
 
     // 模拟 dispatch 的错误传播: 应当生成与 print_response 一致的 anyhow 错误
@@ -471,7 +483,7 @@ async fn test_blackboard_many_concurrent_requests_dont_deadlock() {
         let c = client.clone();
         handles.push(tokio::spawn(async move {
             let _resp: ntd::models::ClientResponse<Value> =
-                tokio::time::timeout(Duration::from_secs(5), c.get("/loop-executions/999"))
+                tokio::time::timeout(Duration::from_secs(5), c.get("/workspaces/1/loops/2/executions/999"))
                     .await
                     .expect("并发请求挂起")
                     .expect("HTTP 错误");

--- a/backend/tests/cli_command_tests.rs
+++ b/backend/tests/cli_command_tests.rs
@@ -9,8 +9,9 @@ mod todo_create_command_tests {
 
     #[test]
     fn test_todo_create_parsing() {
+        // v1: --workspace-id 必填
         let cli = Cli::try_parse_from([
-            "ntd", "todo", "create", "My Task", "-p", "prompt", "-e", "kimi",
+            "ntd", "todo", "create", "-w", "1", "My Task", "-p", "prompt", "-e", "kimi",
         ])
         .unwrap();
         match cli.command {
@@ -33,10 +34,13 @@ mod todo_create_command_tests {
 
     #[test]
     fn test_todo_create_with_schedule() {
+        // v1: --workspace-id 必填
         let cli = Cli::try_parse_from([
             "ntd",
             "todo",
             "create",
+            "-w",
+            "1",
             "Task",
             "--schedule",
             "*/30 * * * *",
@@ -54,8 +58,9 @@ mod todo_create_command_tests {
 
     #[test]
     fn test_todo_create_with_tags() {
+        // v1: --workspace-id 必填
         let cli =
-            Cli::try_parse_from(["ntd", "todo", "create", "Task", "--tags", "1,2,3"]).unwrap();
+            Cli::try_parse_from(["ntd", "todo", "create", "-w", "1", "Task", "--tags", "1,2,3"]).unwrap();
         match cli.command {
             Commands::Todo {
                 action: TodoAction::Create { tags, .. },
@@ -68,13 +73,14 @@ mod todo_create_command_tests {
 
     #[test]
     fn test_todo_create_with_workspace() {
+        // v1: --workspace-id 必填（不再是可选 filter）
         let cli =
             Cli::try_parse_from(["ntd", "todo", "create", "Task", "-w", "42"]).unwrap();
         match cli.command {
             Commands::Todo {
                 action: TodoAction::Create { workspace_id, .. },
             } => {
-                assert_eq!(workspace_id, Some(42));
+                assert_eq!(workspace_id, 42);
             }
             _ => panic!("Expected Todo::Create with workspace"),
         }
@@ -82,7 +88,8 @@ mod todo_create_command_tests {
 
     #[test]
     fn test_todo_create_with_stdin() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "create", "--stdin"]).unwrap();
+        // v1: --workspace-id 必填
+        let cli = Cli::try_parse_from(["ntd", "todo", "create", "-w", "1", "--stdin"]).unwrap();
         match cli.command {
             Commands::Todo {
                 action: TodoAction::Create { stdin, title, .. },
@@ -96,7 +103,8 @@ mod todo_create_command_tests {
 
     #[test]
     fn test_todo_create_with_file_prompt() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "create", "Task", "-f", "/tmp/prompt.txt"])
+        // v1: --workspace-id 必填
+        let cli = Cli::try_parse_from(["ntd", "todo", "create", "-w", "1", "Task", "-f", "/tmp/prompt.txt"])
             .unwrap();
         match cli.command {
             Commands::Todo {
@@ -173,17 +181,20 @@ mod todo_list_command_tests {
 
     #[test]
     fn test_todo_list_parsing() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "list"]).unwrap();
+        // v1: --workspace-id 必填
+        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--workspace-id", "1"]).unwrap();
         match cli.command {
             Commands::Todo {
                 action:
                     TodoAction::List {
+                        workspace_id,
                         status,
                         tag,
                         running,
                         search,
                     },
             } => {
+                assert_eq!(workspace_id, 1);
                 assert!(status.is_none());
                 assert!(tag.is_none());
                 assert!(!running);
@@ -195,7 +206,8 @@ mod todo_list_command_tests {
 
     #[test]
     fn test_todo_list_with_status_filter() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--status", "completed"]).unwrap();
+        // v1: --workspace-id 必填
+        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--workspace-id", "1", "--status", "completed"]).unwrap();
         match cli.command {
             Commands::Todo {
                 action: TodoAction::List { status, .. },
@@ -208,7 +220,8 @@ mod todo_list_command_tests {
 
     #[test]
     fn test_todo_list_with_tag_filter() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--tag", "3"]).unwrap();
+        // v1: --workspace-id 必填
+        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--workspace-id", "1", "--tag", "3"]).unwrap();
         match cli.command {
             Commands::Todo {
                 action: TodoAction::List { tag, .. },
@@ -221,7 +234,8 @@ mod todo_list_command_tests {
 
     #[test]
     fn test_todo_list_with_running_filter() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--running"]).unwrap();
+        // v1: --workspace-id 必填
+        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--workspace-id", "1", "--running"]).unwrap();
         match cli.command {
             Commands::Todo {
                 action: TodoAction::List { running, .. },
@@ -234,7 +248,8 @@ mod todo_list_command_tests {
 
     #[test]
     fn test_todo_list_with_search() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "list", "-s", "rust"]).unwrap();
+        // v1: --workspace-id 必填
+        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--workspace-id", "1", "-s", "rust"]).unwrap();
         match cli.command {
             Commands::Todo {
                 action: TodoAction::List { search, .. },
@@ -247,10 +262,13 @@ mod todo_list_command_tests {
 
     #[test]
     fn test_todo_list_combined_filters() {
+        // v1: --workspace-id 必填
         let cli = Cli::try_parse_from([
             "ntd",
             "todo",
             "list",
+            "--workspace-id",
+            "1",
             "--status",
             "pending",
             "--tag",
@@ -268,6 +286,7 @@ mod todo_list_command_tests {
                         tag,
                         running,
                         search,
+                        ..
                     },
             } => {
                 assert_eq!(status, Some("pending".to_string()));
@@ -281,10 +300,11 @@ mod todo_list_command_tests {
 
     #[test]
     fn test_todo_get_parsing() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "get", "123"]).unwrap();
+        // v1: --workspace-id 必填
+        let cli = Cli::try_parse_from(["ntd", "todo", "get", "--workspace-id", "1", "123"]).unwrap();
         match cli.command {
             Commands::Todo {
-                action: TodoAction::Get { id },
+                action: TodoAction::Get { id, .. },
             } => {
                 assert_eq!(id, 123);
             }
@@ -300,10 +320,13 @@ mod todo_update_command_tests {
 
     #[test]
     fn test_todo_update_parsing() {
+        // v1: --workspace-id 必填
         let cli = Cli::try_parse_from([
             "ntd",
             "todo",
             "update",
+            "--workspace-id",
+            "1",
             "1",
             "--title",
             "New Title",
@@ -335,7 +358,8 @@ mod todo_update_command_tests {
 
     #[test]
     fn test_todo_update_with_stdin() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "update", "1", "--stdin"]).unwrap();
+        // v1: --workspace-id 必填
+        let cli = Cli::try_parse_from(["ntd", "todo", "update", "--workspace-id", "1", "1", "--stdin"]).unwrap();
         match cli.command {
             Commands::Todo {
                 action: TodoAction::Update { id, stdin, .. },
@@ -406,25 +430,29 @@ mod output_format_tests {
 
     #[test]
     fn test_output_format_json() {
-        let cli = Cli::try_parse_from(["ntd", "-o", "json", "todo", "list"]).unwrap();
+        // v1: todo list 需要 --workspace-id
+        let cli = Cli::try_parse_from(["ntd", "-o", "json", "todo", "list", "--workspace-id", "1"]).unwrap();
         assert_eq!(cli.output, OutputFormat::Json);
     }
 
     #[test]
     fn test_output_format_pretty() {
-        let cli = Cli::try_parse_from(["ntd", "-o", "pretty", "todo", "list"]).unwrap();
+        // v1: todo list 需要 --workspace-id
+        let cli = Cli::try_parse_from(["ntd", "-o", "pretty", "todo", "list", "--workspace-id", "1"]).unwrap();
         assert_eq!(cli.output, OutputFormat::Pretty);
     }
 
     #[test]
     fn test_output_format_raw() {
-        let cli = Cli::try_parse_from(["ntd", "-o", "raw", "todo", "list"]).unwrap();
+        // v1: todo list 需要 --workspace-id
+        let cli = Cli::try_parse_from(["ntd", "-o", "raw", "todo", "list", "--workspace-id", "1"]).unwrap();
         assert_eq!(cli.output, OutputFormat::Raw);
     }
 
     #[test]
     fn test_output_format_default_is_json() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "list"]).unwrap();
+        // v1: todo list 需要 --workspace-id
+        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--workspace-id", "1"]).unwrap();
         assert_eq!(cli.output, OutputFormat::Json);
     }
 }
@@ -436,13 +464,15 @@ mod fields_tests {
 
     #[test]
     fn test_fields_parsing() {
-        let cli = Cli::try_parse_from(["ntd", "-f", "id,title,status", "todo", "list"]).unwrap();
+        // v1: todo list 需要 --workspace-id
+        let cli = Cli::try_parse_from(["ntd", "-f", "id,title,status", "todo", "list", "--workspace-id", "1"]).unwrap();
         assert_eq!(cli.fields, Some("id,title,status".to_string()));
     }
 
     #[test]
     fn test_fields_empty() {
-        let cli = Cli::try_parse_from(["ntd", "todo", "list"]).unwrap();
+        // v1: todo list 需要 --workspace-id
+        let cli = Cli::try_parse_from(["ntd", "todo", "list", "--workspace-id", "1"]).unwrap();
         assert_eq!(cli.fields, None);
     }
 }
@@ -549,6 +579,7 @@ mod combined_options_tests {
     #[test]
     fn test_full_ai_workflow_list() {
         // AI-friendly command: list todos with raw output, filtered fields, and search
+        // v1: --workspace-id 必填
         let cli = Cli::try_parse_from([
             "ntd",
             "--server",
@@ -559,6 +590,8 @@ mod combined_options_tests {
             "id,title,status,executor",
             "todo",
             "list",
+            "--workspace-id",
+            "1",
             "--status",
             "pending",
             "--search",
@@ -583,8 +616,11 @@ mod combined_options_tests {
 
     #[test]
     fn test_raw_fields_combination() {
-        let cli =
-            Cli::try_parse_from(["ntd", "-o", "raw", "-f", "id", "todo", "get", "42"]).unwrap();
+        // v1: get 子命令需要 --workspace-id
+        let cli = Cli::try_parse_from([
+            "ntd", "-o", "raw", "-f", "id", "todo", "get", "--workspace-id", "1", "42",
+        ])
+        .unwrap();
         assert_eq!(cli.output, OutputFormat::Raw);
         assert_eq!(cli.fields, Some("id".to_string()));
     }

--- a/backend/tests/cli_command_tests.rs
+++ b/backend/tests/cli_command_tests.rs
@@ -160,17 +160,31 @@ mod todo_execute_command_tests {
 }
 
 #[cfg(test)]
-mod stop_execution_request_tests {
-    #[test]
-    fn test_stop_request_deserialization() {
-        #[derive(serde::Deserialize)]
-        struct StopRequest {
-            record_id: i64,
-        }
+mod todo_stop_command_tests {
+    use clap::Parser;
+    use ntd::cli::{Cli, Commands, TodoAction};
 
-        let json = r#"{"record_id": 42}"#;
-        let req: StopRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.record_id, 42);
+    #[test]
+    fn test_todo_stop_parsing() {
+        // v1: todo stop 接收 workspace-id + record_id，生成
+        // POST /api/v1/workspaces/{ws}/executions/{record_id}/stop。
+        let cli = Cli::parse_from(["ntd", "todo", "stop", "--workspace-id", "3", "42"]);
+        match cli.command {
+            Commands::Todo {
+                action: TodoAction::Stop { workspace_id, id },
+            } => {
+                assert_eq!(workspace_id, 3);
+                assert_eq!(id, 42);
+            }
+            _ => panic!("expected Todo Stop"),
+        }
+    }
+
+    #[test]
+    fn test_todo_stop_requires_workspace_id() {
+        // todo stop 需要 --workspace-id
+        let result = Cli::try_parse_from(["ntd", "todo", "stop", "42"]);
+        assert!(result.is_err(), "缺少 --workspace-id 应解析失败");
     }
 }
 

--- a/backend/tests/cloud_sync_tests.rs
+++ b/backend/tests/cloud_sync_tests.rs
@@ -110,7 +110,8 @@ async fn cloud_sync_push_does_not_deadlock_with_config_write() {
 
     let req = Request::builder()
         .method("POST")
-        .uri("/api/cloud/sync/push?conflict_mode=overwrite&dry_run=false")
+        // v1: cloud sync 也加 v1 前缀（路径与 handlers/action.rs::v1_routes 对齐）
+        .uri("/api/v1/cloud/sync/push?conflict_mode=overwrite&dry_run=false")
         .body(Body::empty())
         .unwrap();
 
@@ -140,7 +141,7 @@ async fn cloud_sync_push_does_not_deadlock_with_config_write() {
 async fn cloud_sync_pull_does_not_deadlock_with_config_write() {
     let (app, config) = build_test_app().await;
 
-    // pull 调的是 GET /api/v1/sync/pull，mock 对所有请求都回 success: true。
+    // pull 调的是 POST /api/v1/cloud/sync/pull，mock 对所有请求都回 success: true。
     let cloud_url = spawn_mock_cloud().await;
     {
         let mut cfg = config.write().unwrap();
@@ -153,8 +154,8 @@ async fn cloud_sync_pull_does_not_deadlock_with_config_write() {
     }
 
     let req = Request::builder()
-        .method("POST") // 路由是 POST（见 handlers/mod.rs）
-        .uri("/api/cloud/sync/pull?conflict_mode=overwrite&dry_run=false")
+        .method("POST") // 路由是 POST（见 handlers/action.rs::v1_routes）
+        .uri("/api/v1/cloud/sync/pull?conflict_mode=overwrite&dry_run=false")
         .body(Body::empty())
         .unwrap();
 
@@ -187,7 +188,8 @@ async fn cloud_sync_push_missing_token_returns_bad_request() {
 
     let req = Request::builder()
         .method("POST")
-        .uri("/api/cloud/sync/push")
+        // v1: 同上，cloud sync 加 v1 前缀
+        .uri("/api/v1/cloud/sync/push")
         .body(Body::empty())
         .unwrap();
 

--- a/docs/design/api-routing-redesign.md
+++ b/docs/design/api-routing-redesign.md
@@ -104,7 +104,6 @@ POST /api/experts/create       # → 与 /experts/{name} 路由冲突
 | 资源 | 新路径前缀 | 说明 |
 |------|-----------|------|
 | todos | `.../workspaces/{ws}/todos` | 核心任务 |
-| tags | `.../workspaces/{ws}/tags` | 标签（按项目隔离） |
 | loops | `.../workspaces/{ws}/loops` | Loop Studio |
 | executions | `.../workspaces/{ws}/executions` | 执行记录 |
 | blackboard | `.../workspaces/{ws}/blackboard` | 黑板（已有，加版本号） |
@@ -119,6 +118,7 @@ POST /api/experts/create       # → 与 /experts/{name} 路由冲突
 
 | 资源 | 新路径前缀 | 说明 |
 |------|-----------|------|
+| tags | `.../tags` | 标签（全局：tags 表无 workspace_id 列，不嵌套 workspace） |
 | config | `.../config` | 系统配置 |
 | executors | `.../executors` | 执行器配置 |
 | skills | `.../skills` | 技能管理 |
@@ -164,9 +164,9 @@ POST /api/experts/create       # → 与 /experts/{name} 路由冲突
 | POST | `/api/todos/{id}/restore`{--} | `/api/v1/workspaces/{ws}/todos/{id}/restore`{++} |
 | PUT | `/api/todos/{id}/webhook`{--} | `/api/v1/workspaces/{ws}/todos/{id}/webhook`{++} |
 | GET | `/api/todos/{id}/summary`{--} | `/api/v1/workspaces/{ws}/todos/{id}/summary`{++} |
-| GET | `/api/tags`{--} | `/api/v1/workspaces/{ws}/tags`{++} |
-| POST | `/api/tags`{--} | `/api/v1/workspaces/{ws}/tags`{++} |
-| DELETE | `/api/tags/{id}`{--} | `/api/v1/workspaces/{ws}/tags/{id}`{++} |
+| GET | `/api/tags`{--} | `/api/v1/tags`{++} |
+| POST | `/api/tags`{--} | `/api/v1/tags`{++} |
+| DELETE | `/api/tags/{id}`{--} | `/api/v1/tags/{id}`{++} |
 
 #### 批量操作收敛（方案 B：子资源）
 
@@ -608,10 +608,11 @@ async fn list_todos(
 - 选择：`POST .../batch/executor`、`POST .../batch/workspace`
 - 理由：方案 A（`POST .../batch` + body.action）虽然更 REST，但 body.action 的枚举值会影响路由/权限的可见性；子资源方式让每个批量操作有明确的 URL，便于日志和监控
 
-### ADR-4：为什么 tags 归入 workspace
+### ADR-4：为什么 tags 保持全局（不嵌套 workspace）
 
-- 业务语义：标签是项目维度的分类，不同项目有不同的标签体系
-- 如果将来需要全局标签，可以在 `/api/v1/tags` 提供只读聚合，但写操作走 workspace 域
+- 数据现状：`tags` 表无 `workspace_id` 列，标签天然是全局资源
+- 选择：`/api/v1/tags`（全局），不嵌套 `/workspaces/{ws}/`
+- 理由：避免为迁就「纯 scoped」而给 tags 表强加 workspace_id 列 + migration；todo↔tag 的归属仍由 `todo_tags` 关联表隐含（todo 自带 workspace_id，故 tag 经 todo 间接属于某 ws）
 
 ### ADR-5：为什么 webhook 加 `/api/` 前缀并重新组织
 
@@ -628,6 +629,12 @@ async fn list_todos(
 
 - 选择：新旧路由不共存。测试验证通过后，旧路由代码直接删除
 - 理由：两套路由的维护成本（双 handler、双测试、双文档）会持续累加，且本项目无外部 API 消费者（社区插件等），迁移是可控的原子操作。前后端 + CLI 在同一 PR 中完成切换即可
+
+### ADR-8：为什么放弃「跨空间列表」，采用纯 scoped
+
+- 选择：每个 workspace-scoped 请求**必带** ws_id（路径 `/workspaces/{ws}/...`），后端**不提供**「列出全部 workspace 资源」的全局端点
+- 理由：纯 scoped 让租户边界在 URL 层强制可见，隔离校验（`verify_*_belongs_to_ws`）无遗漏分支；「跨空间视图」由前端在 `selectedWorkspace=null` 时默认选第一个 workspace 实现，而非后端聚合
+- 权衡：牺牲了「一次请求看全部空间」的便利，换取隔离的强保证（无 `?workspace_id=` 缺省即全量的越权风险）
 
 ---
 

--- a/docs/design/api-routing-redesign.md
+++ b/docs/design/api-routing-redesign.md
@@ -2,7 +2,7 @@
 
 > 版本：v1
 > 日期：2026-07-22
-> 状态：已定稿
+> 状态：已定稿（2026-07-23 更新：对齐实现中 actions/quick-buttons/backup/events 的最终路由）
 
 ---
 
@@ -111,7 +111,7 @@ POST /api/experts/create       # → 与 /experts/{name} 路由冲突
 | slash-commands | `.../workspaces/{ws}/slash-commands` | 斜杠命令（迁移进 v1 + 统一复数） |
 | settings | `.../workspaces/{ws}/settings` | 工作空间设置（迁移进 v1 + 统一复数） |
 | quick-buttons | `.../workspaces/{ws}/quick-buttons` | 快捷话术 |
-| actions | `.../workspaces/{ws}/actions` | 自定义动作 |
+| actions | `.../actions` | 自定义动作（全局：action 通过 todo 推导 workspace，URL 不再嵌套 ws） |
 | stats/dashboard | `.../workspaces/{ws}/stats/dashboard` | 项目维度的统计 |
 
 ### 3.2 全局资源（系统级）
@@ -195,7 +195,7 @@ POST /api/experts/create       # → 与 /experts/{name} 路由冲突
 | GET | `/api/running-board`{--} | `GET /api/v1/workspaces/{ws}/executions/running-board`{++} |
 | GET | `/api/running-todos`{--} | `GET /api/v1/workspaces/{ws}/executions/running-todos`{++} |
 | GET | `/api/dashboard-stats`{--} | `GET /api/v1/workspaces/{ws}/stats/dashboard`{++} |
-| POST | `/api/actions/execute`{--} | `POST /api/v1/workspaces/{ws}/actions/execute`{++} |
+| POST | `/api/actions/execute`{--} | `POST /api/v1/actions/execute`{++}（全局：action 目标 todo 自带 workspace_id，URL 不重复嵌套） |
 | GET | `/api/scheduler/todos`{--} | `GET /api/v1/workspaces/{ws}/scheduler/todos`{++} |
 
 > **命名解释**：
@@ -322,7 +322,7 @@ POST /api/experts/create       # → 与 /experts/{name} 路由冲突
 | `POST /api/usage-stats/refresh`{~} | `POST /api/v1/usage-stats/refresh` |
 | `GET /api/usage-stats/settings`{~} | `GET /api/v1/usage-stats/settings` |
 | `PUT /api/usage-stats/settings`{~} | `PUT /api/v1/usage-stats/settings` |
-| `GET /api/events`{~} | `GET /api/v1/events`（WebSocket） |
+| `GET /api/events`{~} | `GET /api/events`（WebSocket，故意不版本化：升级端点需要 WS 连接协商，版本前缀会让旧客户端丢失连接） |
 | `GET /api/project-directories`{~} | `GET /api/v1/project-directories` |
 | `POST /api/project-directories`{~} | `POST /api/v1/project-directories` |
 | `PUT /api/project-directories/{id}`{~} | `PUT /api/v1/project-directories/{id}` |
@@ -473,9 +473,9 @@ POST /api/experts/create       # → 与 /experts/{name} 路由冲突
 | `workspace`（单数） | `workspaces`（复数） | 与 blackboard 现有一致 |
 | ~~`execute/stop`~~ | `executions/{id}/stop` | 归入 executions 资源 |
 | ~~`execute/force-fail`~~ | `executions/{id}/force-fail` | 归入 executions 资源 |
-| ~~`backup/database/file`~~ | `backup/database/files` | 集合名词复数 |
-| ~~`backup/todo/file`~~ | `backup/todo/files` | 同上 |
-| ~~`backup/skills/file`~~ | `backup/skills/files` | 同上 |
+| ~~`backup/database/files`~~ | `backup/database/file` | 保留单数 `file`（与存档资源一致） |
+| ~~`backup/todo/files`~~ | `backup/todo/file` | 同上 |
+| ~~`backup/skills/files`~~ | `backup/skills/file` | 同上 |
 | ~~`webhook/trigger/todo/{id}`~~ | `webhooks/todo/{id}/trigger` | 归入 webhooks + 资源前置 |
 | ~~`running-board`~~ | `executions/running-board` | 归入 executions 域 |
 | ~~`running-todos`~~ | `executions/running-todos` | 归入 executions 域 |

--- a/docs/design/api-routing-redesign.md
+++ b/docs/design/api-routing-redesign.md
@@ -1,0 +1,714 @@
+# API 路由重构设计方案：K8s 风格 Workspace 层级嵌入
+
+> 版本：v1
+> 日期：2026-07-22
+> 状态：已定稿
+
+---
+
+## 1. 设计目标
+
+### 1.1 核心原则
+
+```
+/api/{version}/workspaces/{workspace_id}/{resource}[/{resource_id}[/{sub_resource}[/{sub_resource_id}]]]
+```
+
+| 层级 | 示例 | 说明 |
+|------|------|------|
+| 版本前缀 | `/api/v1/` | 统一版本管理，预留向后兼容 |
+| Workspace 归集 | `/workspaces/{id}/` | 所有域资源的第一级路径，K8s namespace 风格 |
+| 资源 | `todos/`、`loops/`、`executions/` | 复数名词，统一风格 |
+| 资源 ID | `{id}` | 整数或字符串标识 |
+| 子资源 | `/tags`、`/steps`、`/executions` | 所属关系清晰的嵌套 |
+| 子资源 ID | `{tid}`、`{sid}`、`{eid}` | 子资源标识 |
+| Action | `/{id}/stop`、`/{id}/archive` | POST 动词作为子路径 |
+
+### 1.2 变换规则一览
+
+| 维度 | 旧风格 | 新风格 |
+|------|--------|--------|
+| Workspace 传递 | query param `?workspace_id=N` | 路径参数 `/workspaces/{ws}/` |
+| 单复数 | `workspace`（单）与 `workspaces`（复）混用 | 统一 `workspaces`（复） |
+| 版本号 | 无 | `/api/v1/` |
+| 执行操作 | `POST /api/execute` | `POST /api/v1/workspaces/{ws}/executions` |
+| 执行控制 | `POST /api/execute/stop` | `POST /api/v1/workspaces/{ws}/executions/{id}/stop` |
+| 批量操作 | `PUT /api/todos/batch-workspace` | `POST /api/v1/workspaces/{ws}/todos/batch/move-workspace` |
+| Webhook 前缀 | `/webhook/trigger/...` | `/api/v1/webhooks/...` |
+| 专家创建 | `POST /api/experts/create`（与 `{name}` 冲突） | `POST /api/v1/experts` |
+
+---
+
+## 2. 当前 API 现状分析
+
+### 2.1 体量
+
+后端约 **170 个 API 端点**，分布在 24 个领域子路由函数中。前端通过集中式 axios 客户端调用，少数场景用原生 fetch（文件下载/YAML 导出）。
+
+### 2.2 RESTful 程度评估
+
+#### ✅ 做得好的
+
+- **CRUD 模式规范**：Todo、Loops、Sessions、Tags 等核心资源用了 `GET/POST/PUT/DELETE /api/resource/{id}` 模式
+- **子资源嵌套正确**：如 `/api/loops/{id}/triggers/{tid}`、`/api/loops/{id}/executions/{eid}`
+- **HTTP 方法语义正确**：GET 查、POST 创建、PUT 全量更新、DELETE 删除
+
+#### ❌ 核心问题
+
+**问题 1：Workspace ID 嵌入方式三套混用**
+
+| 位置 | 示例 | 风格 |
+|------|------|------|
+| 黑板/Wiki | `/api/workspaces/{ws}/blackboard` | 复数+路径参数 ✅ |
+| 斜杠命令/设置 | `/api/workspace/{ws}/slash-commands` | 单数 `workspace` ❌ |
+| 绝大多数资源 | `/api/todos?workspace_id=xxx` | 扁平，workspace 是 query param ❌ |
+
+**问题 2：单复数不一致**：`workspaces`（blackboard）vs `workspace`（slash-commands/settings）
+
+**问题 3：Actions 用动词路径而非 REST 风格**
+
+```yaml
+POST /api/execute              # → 应 POST /api/executions
+POST /api/execute/stop         # → 应 POST /api/executions/{id}/stop
+POST /api/smart-create         # → 应 POST .../todos/smart
+POST /api/experts/create       # → 与 /experts/{name} 路由冲突
+```
+
+**问题 4：Batch 操作散落**：`/api/todos/batch-executor`、`/api/loops/batch-workspace` 等
+
+**问题 5：Webhook 缺 `/api` 前缀**：`/webhook/trigger/todo/{id}` vs 其他 `/api/xxx`
+
+**问题 6：缺少版本前缀**：所有路由裸 `/api/xxx`，无法平滑升级
+
+### 2.3 资源归属现状
+
+当前大部分资源是"半 workspace-scoped"状态——数据模型中包含 `workspace_id` 字段，但 URL 中没有体现：
+
+| 资源 | 模型中含 ws_id | URL 中有 ws 层级 |
+|------|:---:|:---:|
+| todos | ✅ | ❌ query param |
+| loops | ✅ | ❌ query param |
+| tags | ✅ | ❌ |
+| executions | ✅ | ❌ |
+| blackboard | ✅ | ✅ `/api/workspaces/{ws}/blackboard` |
+| wiki | ✅ | ✅ |
+| slash-commands | ✅ | ✅ `/api/workspace/{ws}/slash-commands` |
+| settings | ✅ | ✅ |
+
+---
+
+## 3. 资源归属矩阵
+
+### 3.1 Workspace 域资源
+
+| 资源 | 新路径前缀 | 说明 |
+|------|-----------|------|
+| todos | `.../workspaces/{ws}/todos` | 核心任务 |
+| tags | `.../workspaces/{ws}/tags` | 标签（按项目隔离） |
+| loops | `.../workspaces/{ws}/loops` | Loop Studio |
+| executions | `.../workspaces/{ws}/executions` | 执行记录 |
+| blackboard | `.../workspaces/{ws}/blackboard` | 黑板（已有，加版本号） |
+| wiki | `.../workspaces/{ws}/wiki` | 项目 Wiki（已有，加版本号） |
+| slash-commands | `.../workspaces/{ws}/slash-commands` | 斜杠命令（迁移进 v1 + 统一复数） |
+| settings | `.../workspaces/{ws}/settings` | 工作空间设置（迁移进 v1 + 统一复数） |
+| quick-buttons | `.../workspaces/{ws}/quick-buttons` | 快捷话术 |
+| actions | `.../workspaces/{ws}/actions` | 自定义动作 |
+| stats/dashboard | `.../workspaces/{ws}/stats/dashboard` | 项目维度的统计 |
+
+### 3.2 全局资源（系统级）
+
+| 资源 | 新路径前缀 | 说明 |
+|------|-----------|------|
+| config | `.../config` | 系统配置 |
+| executors | `.../executors` | 执行器配置 |
+| skills | `.../skills` | 技能管理 |
+| sessions | `.../sessions` | 会话管理 |
+| backup | `.../backup` | 备份与恢复 |
+| version | `.../version` | 版本查询/升级 |
+| experts | `.../experts` | 专家库 |
+| bundled | `.../bundled` | 内置资源/技能市场 |
+| todo-templates | `.../todo-templates` | 任务模板 |
+| review-templates | `.../review-templates` | 评审模板 |
+| custom-templates | `.../custom-templates` | 云端订阅模板 |
+| agent-bots | `.../agent-bots` | Agent Bot 管理 |
+| feishu | `.../feishu` | 飞书集成 |
+| usage-stats | `.../usage-stats` | 用量统计 |
+| cloud | `.../cloud` | 云端同步 |
+| project-directories | `.../project-directories` | 项目目录 CRUD（workspace 本身） |
+| webhooks | `.../webhooks` | Webhook 配置与触发 |
+| events | `.../events` | WebSocket 事件流 |
+
+---
+
+## 4. 完整路径映射
+
+> 约定：`{++}` = 新增路径，`{--}` = 废弃路径（旧路径代码一并删除），`{~}` = 路径不变/仅有版本号变更
+>
+> 路径参数标记：`{ws}` = workspace_id, `{id}` = 资源主键
+
+### 4.1 Todo & Tag
+
+| 方法 | 旧路径 | 新路径 |
+|------|--------|--------|
+| GET | `/api/todos`{--} | `/api/v1/workspaces/{ws}/todos`{++} |
+| POST | `/api/todos`{--} | `/api/v1/workspaces/{ws}/todos`{++} |
+| GET | `/api/todos/center`{--} | `/api/v1/workspaces/{ws}/todos/center`{++} |
+| GET | `/api/todos/recent-completed`{--} | `/api/v1/workspaces/{ws}/todos/recent-completed`{++} |
+| GET | `/api/todos/{id}`{--} | `/api/v1/workspaces/{ws}/todos/{id}`{++} |
+| PUT | `/api/todos/{id}`{--} | `/api/v1/workspaces/{ws}/todos/{id}`{++} |
+| DELETE | `/api/todos/{id}`{--} | `/api/v1/workspaces/{ws}/todos/{id}`{++} |
+| PUT | `/api/todos/{id}/force-status`{--} | `/api/v1/workspaces/{ws}/todos/{id}/force-status`{++} |
+| PUT | `/api/todos/{id}/tags`{--} | `/api/v1/workspaces/{ws}/todos/{id}/tags`{++} |
+| PUT | `/api/todos/{id}/scheduler`{--} | `/api/v1/workspaces/{ws}/todos/{id}/scheduler`{++} |
+| POST | `/api/todos/{id}/archive`{--} | `/api/v1/workspaces/{ws}/todos/{id}/archive`{++} |
+| POST | `/api/todos/{id}/restore`{--} | `/api/v1/workspaces/{ws}/todos/{id}/restore`{++} |
+| PUT | `/api/todos/{id}/webhook`{--} | `/api/v1/workspaces/{ws}/todos/{id}/webhook`{++} |
+| GET | `/api/todos/{id}/summary`{--} | `/api/v1/workspaces/{ws}/todos/{id}/summary`{++} |
+| GET | `/api/tags`{--} | `/api/v1/workspaces/{ws}/tags`{++} |
+| POST | `/api/tags`{--} | `/api/v1/workspaces/{ws}/tags`{++} |
+| DELETE | `/api/tags/{id}`{--} | `/api/v1/workspaces/{ws}/tags/{id}`{++} |
+
+#### 批量操作收敛（方案 B：子资源）
+
+| 旧路径 | 新路径 |
+|--------|--------|
+| `PUT /api/todos/batch-executor`{--} | `POST /api/v1/workspaces/{ws}/todos/batch/executor`{++} |
+| `PUT /api/todos/batch-workspace`{--} | `POST /api/v1/workspaces/{ws}/todos/batch/workspace`{++} |
+| `POST /api/todos/batch-copy-workspace`{--} | `POST /api/v1/workspaces/{ws}/todos/batch/copy-workspace`{++} |
+| `PUT /api/todos/batch-scheduler`{--} | `POST /api/v1/workspaces/{ws}/todos/batch/scheduler`{++} |
+
+### 4.2 Executions（执行与操作）
+
+| 方法 | 旧路径 | 新路径 |
+|------|--------|--------|
+| POST | `/api/execute`{--} | `POST /api/v1/workspaces/{ws}/executions`{++} |
+| POST | `/api/execute/stop`{--} | `POST /api/v1/workspaces/{ws}/executions/{id}/stop`{++} |
+| POST | `/api/execute/force-fail`{--} | `POST /api/v1/workspaces/{ws}/executions/{id}/force-fail`{++} |
+| POST | `/api/smart-create`{--} | `POST /api/v1/workspaces/{ws}/todos/smart`{++} |
+| GET | `/api/execution-records`{--} | `GET /api/v1/workspaces/{ws}/executions`{++} |
+| GET | `/api/execution-records/running`{--} | `GET /api/v1/workspaces/{ws}/executions/running`{++} |
+| GET | `/api/execution-records/session/{session_id}`{--} | `GET /api/v1/workspaces/{ws}/executions/session/{session_id}`{++} |
+| GET | `/api/execution-records/{id}`{--} | `GET /api/v1/workspaces/{ws}/executions/{id}`{++} |
+| GET | `/api/execution-records/{id}/logs`{--} | `GET /api/v1/workspaces/{ws}/executions/{id}/logs`{++} |
+| POST | `/api/execution-records/{id}/resume`{--} | `POST /api/v1/workspaces/{ws}/executions/{id}/resume`{++} |
+| PUT | `/api/execution-records/{id}/rating`{--} | `PUT /api/v1/workspaces/{ws}/executions/{id}/rating`{++} |
+| GET | `/api/running-board`{--} | `GET /api/v1/workspaces/{ws}/executions/running-board`{++} |
+| GET | `/api/running-todos`{--} | `GET /api/v1/workspaces/{ws}/executions/running-todos`{++} |
+| GET | `/api/dashboard-stats`{--} | `GET /api/v1/workspaces/{ws}/stats/dashboard`{++} |
+| POST | `/api/actions/execute`{--} | `POST /api/v1/workspaces/{ws}/actions/execute`{++} |
+| GET | `/api/scheduler/todos`{--} | `GET /api/v1/workspaces/{ws}/scheduler/todos`{++} |
+
+> **命名解释**：
+> - `executions` 替代 `execution-records`：更短，语义一致（记录即执行）
+> - `smart-create` → `todos/smart`：它创建的是 todo，AI 辅助是创建方式
+> - `dashboard-stats` → `stats/dashboard`：统计归 stats 空间，dashboard 是统计类型
+
+### 4.3 Loops（Loop Studio）
+
+| 方法 | 旧路径 | 新路径 |
+|------|--------|--------|
+| GET | `/api/loops`{--} | `GET /api/v1/workspaces/{ws}/loops`{++} |
+| POST | `/api/loops`{--} | `POST /api/v1/workspaces/{ws}/loops`{++} |
+| GET | `/api/loops/stats`{--} | `GET /api/v1/workspaces/{ws}/loops/stats`{++} |
+| GET | `/api/loops/{id}`{--} | `GET /api/v1/workspaces/{ws}/loops/{id}`{++} |
+| PUT | `/api/loops/{id}`{--} | `PUT /api/v1/workspaces/{ws}/loops/{id}`{++} |
+| DELETE | `/api/loops/{id}`{--} | `DELETE /api/v1/workspaces/{ws}/loops/{id}`{++} |
+| PUT | `/api/loops/{id}/status`{--} | `PUT /api/v1/workspaces/{ws}/loops/{id}/status`{++} |
+| PUT | `/api/loops/{id}/tags`{--} | `PUT /api/v1/workspaces/{ws}/loops/{id}/tags`{++} |
+| POST | `/api/loops/{id}/duplicate`{--} | `POST /api/v1/workspaces/{ws}/loops/{id}/duplicate`{++} |
+| POST | `/api/loops/{id}/trigger`{--} | `POST /api/v1/workspaces/{ws}/loops/{id}/trigger`{++} |
+| GET | `/api/loops/{id}/triggers`{--} | `GET /api/v1/workspaces/{ws}/loops/{id}/triggers`{++} |
+| POST | `/api/loops/{id}/triggers`{--} | `POST /api/v1/workspaces/{ws}/loops/{id}/triggers`{++} |
+| PUT | `/api/loops/{id}/triggers/{tid}`{--} | `PUT /api/v1/workspaces/{ws}/loops/{id}/triggers/{tid}`{++} |
+| DELETE | `/api/loops/{id}/triggers/{tid}`{--} | `DELETE /api/v1/workspaces/{ws}/loops/{id}/triggers/{tid}`{++} |
+| GET | `/api/loops/{id}/steps`{--} | `GET /api/v1/workspaces/{ws}/loops/{id}/steps`{++} |
+| POST | `/api/loops/{id}/steps`{--} | `POST /api/v1/workspaces/{ws}/loops/{id}/steps`{++} |
+| POST | `/api/loops/{id}/steps/reorder`{--} | `POST /api/v1/workspaces/{ws}/loops/{id}/steps/reorder`{++} |
+| PUT | `/api/loops/{id}/steps/{sid}`{--} | `PUT /api/v1/workspaces/{ws}/loops/{id}/steps/{sid}`{++} |
+| DELETE | `/api/loops/{id}/steps/{sid}`{--} | `DELETE /api/v1/workspaces/{ws}/loops/{id}/steps/{sid}`{++} |
+| GET | `/api/loops/{id}/executions`{--} | `GET /api/v1/workspaces/{ws}/loops/{id}/executions`{++} |
+| GET | `/api/loops/{id}/executions/{eid}`{--} | `GET /api/v1/workspaces/{ws}/loops/{id}/executions/{eid}`{++} |
+| POST | `/api/loops/{id}/executions/{eid}/steps/{seid}/approve`{--} | `POST /api/v1/workspaces/{ws}/loops/{id}/executions/{eid}/steps/{seid}/approve`{++} |
+| GET | `/api/loop-executions/{eid}`{--} | `GET /api/v1/workspaces/{ws}/loop-executions/{eid}`{++} |
+
+#### Loops 批量操作
+
+| 旧路径 | 新路径 |
+|--------|--------|
+| `PUT /api/loops/batch-workspace`{--} | `POST /api/v1/workspaces/{ws}/loops/batch/workspace`{++} |
+| `POST /api/loops/batch-copy-workspace`{--} | `POST /api/v1/workspaces/{ws}/loops/batch/copy-workspace`{++} |
+
+#### Loops 导入导出
+
+| 旧路径 | 新路径 |
+|--------|--------|
+| `GET /api/loops/export`{--} | `GET /api/v1/workspaces/{ws}/loops/export`{++} |
+| `POST /api/loops/export-selected`{--} | `POST /api/v1/workspaces/{ws}/loops/export-selected`{++} |
+| `GET /api/loops/{id}/export`{--} | `GET /api/v1/workspaces/{ws}/loops/{id}/export`{++} |
+| `POST /api/loops/import/preview`{--} | `POST /api/v1/workspaces/{ws}/loops/import-preview`{++} |
+| `POST /api/loops/import`{--} | `POST /api/v1/workspaces/{ws}/loops/import`{++} |
+| `POST /api/loops/merge`{--} | `POST /api/v1/workspaces/{ws}/loops/merge`{++} |
+
+> **说明**：import/export 放在集合路径 `/loops/` 下（如 `/loops/import`），不会与 `/loops/{id}` 冲突——axum 路由按注册顺序匹配，集合 action 在 `{id}` 之前注册即可。只在需要明确区分「子资源」和「RPC 操作」的场景用路径顺序保证即可，无需额外语法。
+
+### 4.4 Blackboard & Wiki
+
+现有路径已经包含了 `/api/workspaces/{ws}/` 前缀，只需要加版本号，并将路径统一为 v1：
+
+| 方法 | 旧路径 | 新路径 |
+|------|--------|--------|
+| GET | `/api/workspaces/{ws}/blackboard`{~} | `/api/v1/workspaces/{ws}/blackboard` |
+| PATCH | `/api/workspaces/{ws}/blackboard`{~} | `/api/v1/workspaces/{ws}/blackboard` |
+| GET | `/api/workspaces/{ws}/blackboard/config`{~} | `/api/v1/workspaces/{ws}/blackboard/config` |
+| GET | `/api/workspaces/{ws}/wiki/files`{~} | `/api/v1/workspaces/{ws}/wiki/files` |
+| GET | `/api/workspaces/{ws}/wiki/files/{slug}`{~} | `/api/v1/workspaces/{ws}/wiki/files/{slug}` |
+| DELETE | `/api/workspaces/{ws}/wiki/files/{slug}`{~} | `/api/v1/workspaces/{ws}/wiki/files/{slug}` |
+| POST | `/api/workspaces/{ws}/wiki/chat`{~} | `/api/v1/workspaces/{ws}/wiki/chat` |
+
+### 4.5 Workspace 设置与斜杠命令（单复数统一）
+
+| 方法 | 旧路径（单数 workspace） | 新路径（复数 workspaces） |
+|------|------------------------|--------------------------|
+| GET | `/api/workspace/{ws}/slash-commands`{--} | `/api/v1/workspaces/{ws}/slash-commands`{++} |
+| POST | `/api/workspace/{ws}/slash-commands`{--} | `/api/v1/workspaces/{ws}/slash-commands`{++} |
+| PUT | `/api/workspace/{ws}/slash-commands/{cmd_id}`{--} | `/api/v1/workspaces/{ws}/slash-commands/{cmd_id}`{++} |
+| DELETE | `/api/workspace/{ws}/slash-commands/{cmd_id}`{--} | `/api/v1/workspaces/{ws}/slash-commands/{cmd_id}`{++} |
+| GET | `/api/workspace/{ws}/settings`{--} | `/api/v1/workspaces/{ws}/settings`{++} |
+| PUT | `/api/workspace/{ws}/settings`{--} | `/api/v1/workspaces/{ws}/settings`{++} |
+
+### 4.6 Quick Buttons（归入 workspace）
+
+| 方法 | 旧路径 | 新路径 |
+|------|--------|--------|
+| GET | `/api/quick-buttons`{--} | `GET /api/v1/workspaces/{ws}/quick-buttons`{++} |
+| POST | `/api/quick-buttons`{--} | `POST /api/v1/workspaces/{ws}/quick-buttons`{++} |
+| PUT | `/api/quick-buttons/{id}`{--} | `PUT /api/v1/workspaces/{ws}/quick-buttons/{id}`{++} |
+| DELETE | `/api/quick-buttons/{id}`{--} | `DELETE /api/v1/workspaces/{ws}/quick-buttons/{id}`{++} |
+
+> **理由**：快捷话术按 workspace 隔离更合理——不同项目有不同的常用 prompt 模板。
+
+### 4.7 全局资源（版本号升级，路径不变）
+
+| 旧路径 | 新路径 |
+|--------|--------|
+| `GET /api/config`{~} | `GET /api/v1/config` |
+| `PUT /api/config`{~} | `PUT /api/v1/config` |
+| `GET /api/executors`{~} | `GET /api/v1/executors` |
+| `PUT /api/executors/{name}`{~} | `PUT /api/v1/executors/{name}` |
+| `POST /api/executors/{name}/detect`{~} | `POST /api/v1/executors/{name}/detect` |
+| `POST /api/executors/detect-all`{~} | `POST /api/v1/executors/detect-all` |
+| `POST /api/executors/{name}/resolve`{~} | `POST /api/v1/executors/{name}/resolve` |
+| `POST /api/executors/{name}/test`{~} | `POST /api/v1/executors/{name}/test` |
+| `GET /api/executors/default`{~} | `GET /api/v1/executors/default` |
+| `PUT /api/executors/{name}/default`{~} | `PUT /api/v1/executors/{name}/default` |
+| `GET /api/skills`{~} | `GET /api/v1/skills` |
+| `DELETE /api/skills`{~} | `DELETE /api/v1/skills` |
+| `GET /api/skills/compare`{~} | `GET /api/v1/skills/compare` |
+| `GET /api/skills/version-update`{~} | `GET /api/v1/skills/version-update` |
+| `POST /api/skills/sync`{~} | `POST /api/v1/skills/sync` |
+| `POST /api/skills/invocations`{~} | `POST /api/v1/skills/invocations` |
+| `GET /api/skills/content`{~} | `GET /api/v1/skills/content` |
+| `GET /api/skills/file`{~} | `GET /api/v1/skills/file` |
+| `GET /api/skills/export`{~} | `GET /api/v1/skills/export` |
+| `POST /api/skills/import`{~} | `POST /api/v1/skills/import` |
+| `GET /api/sessions`{~} | `GET /api/v1/sessions` |
+| `GET /api/sessions/stats`{~} | `GET /api/v1/sessions/stats` |
+| `GET /api/sessions/{id}`{~} | `GET /api/v1/sessions/{id}` |
+| `DELETE /api/sessions/{id}`{~} | `DELETE /api/v1/sessions/{id}` |
+| `GET /api/version`{~} | `GET /api/v1/version` |
+| `GET /api/version/latest`{~} | `GET /api/v1/version/latest` |
+| `POST /api/version/upgrade`{~} | `POST /api/v1/version/upgrade` |
+| `GET /api/usage-stats`{~} | `GET /api/v1/usage-stats` |
+| `POST /api/usage-stats/refresh`{~} | `POST /api/v1/usage-stats/refresh` |
+| `GET /api/usage-stats/settings`{~} | `GET /api/v1/usage-stats/settings` |
+| `PUT /api/usage-stats/settings`{~} | `PUT /api/v1/usage-stats/settings` |
+| `GET /api/events`{~} | `GET /api/v1/events`（WebSocket） |
+| `GET /api/project-directories`{~} | `GET /api/v1/project-directories` |
+| `POST /api/project-directories`{~} | `POST /api/v1/project-directories` |
+| `PUT /api/project-directories/{id}`{~} | `PUT /api/v1/project-directories/{id}` |
+| `DELETE /api/project-directories/{id}`{~} | `DELETE /api/v1/project-directories/{id}` |
+| `GET /api/todo-templates`{~} | `GET /api/v1/todo-templates` |
+| `POST /api/todo-templates`{~} | `POST /api/v1/todo-templates` |
+| `PUT /api/todo-templates/{id}`{~} | `PUT /api/v1/todo-templates/{id}` |
+| `DELETE /api/todo-templates/{id}`{~} | `DELETE /api/v1/todo-templates/{id}` |
+| `POST /api/todo-templates/{id}/copy`{~} | `POST /api/v1/todo-templates/{id}/copy` |
+| `GET /api/review-templates`{~} | `GET /api/v1/review-templates` |
+| `GET /api/review-templates/options`{~} | `GET /api/v1/review-templates/options` |
+| `POST /api/review-templates`{~} | `POST /api/v1/review-templates` |
+| `GET /api/review-templates/{id}`{~} | `GET /api/v1/review-templates/{id}` |
+| `PUT /api/review-templates/{id}`{~} | `PUT /api/v1/review-templates/{id}` |
+| `DELETE /api/review-templates/{id}`{~} | `DELETE /api/v1/review-templates/{id}` |
+| `GET /api/custom-templates/status`{~} | `GET /api/v1/custom-templates/status` |
+| `POST /api/custom-templates/subscribe`{~} | `POST /api/v1/custom-templates/subscribe` |
+| `POST /api/custom-templates/unsubscribe`{~} | `POST /api/v1/custom-templates/unsubscribe` |
+| `POST /api/custom-templates/sync`{~} | `POST /api/v1/custom-templates/sync` |
+| `PUT /api/custom-templates/auto-sync`{~} | `PUT /api/v1/custom-templates/auto-sync` |
+| `GET /api/cloud/config`{~} | `GET /api/v1/cloud/config` |
+| `POST /api/cloud/config`{~} | `POST /api/v1/cloud/config` |
+| `GET /api/cloud/sync/status`{~} | `GET /api/v1/cloud/sync/status` |
+| `GET /api/cloud/sync/records`{~} | `GET /api/v1/cloud/sync/records` |
+| `DELETE /api/cloud/sync/records`{~} | `DELETE /api/v1/cloud/sync/records` |
+| `POST /api/cloud/sync/push`{~} | `POST /api/v1/cloud/sync/push` |
+| `POST /api/cloud/sync/pull`{~} | `POST /api/v1/cloud/sync/pull` |
+
+### 4.8 Backup（全局，仅版本号变更）
+
+所有备份路径从 `/api/backup/...` 改为 `/api/v1/backup/...`。路径结构保持不变（backup 下的子路径已经组织良好）：
+
+```
+/api/v1/backup/export
+/api/v1/backup/export-selected
+/api/v1/backup/import
+/api/v1/backup/merge
+/api/v1/backup/database/{action}
+/api/v1/backup/todo/{action}
+/api/v1/backup/skills/{action}
+/api/v1/backup/log-cleanup/{action}
+```
+
+### 4.9 Experts（全局，修复 create 路由冲突）
+
+| 旧路径 | 问题 | 新路径 |
+|--------|------|--------|
+| `GET /api/experts`{~} | — | `GET /api/v1/experts` |
+| `POST /api/experts/create`{--} | 与 `{name}` 路径冲突 | `POST /api/v1/experts`{++}（与 GET 共用集合路径） |
+| `POST /api/experts/reload`{--} | RPC | `POST /api/v1/experts/reload`{++} |
+| `POST /api/experts/import`{--} | RPC | `POST /api/v1/experts/import`{++} |
+| `POST /api/experts/import-from-directory`{--} | RPC | `POST /api/v1/experts/import-from-directory`{++} |
+| `POST /api/experts/import-from-workbuddy`{--} | RPC | `POST /api/v1/experts/import-from-workbuddy`{++} |
+| `GET /api/experts/{name}`{~} | — | `GET /api/v1/experts/{name}` |
+| `PUT /api/experts/{name}`{~} | — | `PUT /api/v1/experts/{name}` |
+| `DELETE /api/experts/{name}`{~} | — | `DELETE /api/v1/experts/{name}` |
+| `GET /api/experts/{name}/plugin-json`{~} | — | `GET /api/v1/experts/{name}/plugin-json` |
+| `GET /api/experts/{name}/agent-md`{~} | — | `GET /api/v1/experts/{name}/agent-md` |
+| `GET /api/experts/{name}/skills`{~} | — | `GET /api/v1/experts/{name}/skills` |
+| `GET /api/experts/{name}/avatar`{~} | — | `GET /api/v1/experts/{name}/avatar` |
+| `GET /api/experts/{name}/export`{~} | — | `GET /api/v1/experts/{name}/export` |
+| `GET /api/experts/{name}/members/{mid}/avatar`{~} | — | `GET /api/v1/experts/{name}/members/{mid}/avatar` |
+
+### 4.10 Agent Bots & Feishu（全局）
+
+| 旧路径 | 新路径 |
+|--------|--------|
+| `GET /api/agent-bots`{~} | `GET /api/v1/agent-bots` |
+| `DELETE /api/agent-bots/{id}`{~} | `DELETE /api/v1/agent-bots/{id}` |
+| `PUT /api/agent-bots/{id}/config`{~} | `PUT /api/v1/agent-bots/{id}/config` |
+| `PUT /api/agent-bots/{id}/workspace`{~} | `PUT /api/v1/agent-bots/{id}/workspace` |
+| `POST /api/agent-bots/feishu/init`{~} | `POST /api/v1/agent-bots/feishu/init` |
+| `POST /api/agent-bots/feishu/begin`{~} | `POST /api/v1/agent-bots/feishu/begin` |
+| `GET /api/agent-bots/feishu/poll-stream`{~} | `GET /api/v1/agent-bots/feishu/poll-stream` |
+| `GET /api/agent-bots/feishu/push`{~} | `GET /api/v1/agent-bots/feishu/push` |
+| `PUT /api/agent-bots/feishu/push`{~} | `PUT /api/v1/agent-bots/feishu/push` |
+| `GET /api/agent-bots/feishu/group-whitelist`{~} | `GET /api/v1/agent-bots/feishu/group-whitelist` |
+| `POST /api/agent-bots/feishu/group-whitelist`{~} | `POST /api/v1/agent-bots/feishu/group-whitelist` |
+| `DELETE /api/agent-bots/feishu/group-whitelist/{id}`{~} | `DELETE /api/v1/agent-bots/feishu/group-whitelist/{id}` |
+
+> 注意：Agent Bot 是全局资源（一个 bot 可关联多个 workspace），因此不 scope 到 workspace。
+
+### 4.11 Feishu 集成（全局）
+
+| 旧路径 | 新路径 |
+|--------|--------|
+| `GET /api/feishu/history-messages`{~} | `GET /api/v1/feishu/history-messages` |
+| `GET /api/feishu/message-stats`{~} | `GET /api/v1/feishu/message-stats` |
+| `GET /api/feishu/senders`{~} | `GET /api/v1/feishu/senders` |
+| `GET /api/feishu/history-chats`{~} | `GET /api/v1/feishu/history-chats` |
+| `POST /api/feishu/history-chats`{~} | `POST /api/v1/feishu/history-chats` |
+| `DELETE /api/feishu/history-chats/{id}`{~} | `DELETE /api/v1/feishu/history-chats/{id}` |
+| `PUT /api/feishu/history-chats/{id}`{~} | `PUT /api/v1/feishu/history-chats/{id}` |
+
+### 4.12 Webhooks（修复缺 `/api` 前缀）
+
+| 旧路径 | 问题 | 新路径 |
+|------|------|--------|
+| `GET /webhook/trigger/todo/{todo_id}`{--} | 缺 `/api` 前缀 | `GET /api/v1/webhooks/todo/{id}/trigger`{++} |
+| `POST /webhook/trigger/todo/{todo_id}`{--} | 缺 `/api` 前缀 | `POST /api/v1/webhooks/todo/{id}/trigger`{++} |
+| `GET /webhook/trigger/loop/{loop_id}`{--} | 缺 `/api` 前缀 | `GET /api/v1/webhooks/loop/{id}/trigger`{++} |
+| `POST /webhook/trigger/loop/{loop_id}`{--} | 缺 `/api` 前缀 | `POST /api/v1/webhooks/loop/{id}/trigger`{++} |
+
+> 注意：Webhook 路径交换了 `{resource}/{id}/trigger` 的顺序，将 trigger 作为子资源操作放在末尾，这样更符合 REST 的「资源 → 子资源」层级感。
+
+### 4.13 Bundled Skills（全局）
+
+| 旧路径 | 新路径 |
+|--------|--------|
+| `POST /api/bundled/sync`{~} | `POST /api/v1/bundled/sync` |
+| `GET /api/bundled/status`{~} | `GET /api/v1/bundled/status` |
+| `GET /api/bundled/config`{~} | `GET /api/v1/bundled/config` |
+| `PUT /api/bundled/config`{~} | `PUT /api/v1/bundled/config` |
+| `GET /api/bundled/skills`{~} | `GET /api/v1/bundled/skills` |
+| `GET /api/bundled/skill-sources`{~} | `GET /api/v1/bundled/skill-sources` |
+| `GET /api/bundled/skills/{name}/content`{~} | `GET /api/v1/bundled/skills/{name}/content` |
+| `GET /api/bundled/skills/{name}/file`{~} | `GET /api/v1/bundled/skills/{name}/file` |
+| `POST /api/bundled/skills/install`{~} | `POST /api/v1/bundled/skills/install` |
+
+### 4.14 根级系统路由
+
+| 旧路径 | 新路径 |
+|--------|--------|
+| `GET /`{~} | `GET /`（不变） |
+| `GET /health`{~} | `GET /health`（不变） |
+| `GET /assets/{*path}`{~} | `GET /assets/{*path}`（不变，前端静态资源） |
+
+---
+
+## 5. 命名规范
+
+### 5.1 通用规则
+
+| 规则 | 示例 |
+|------|------|
+| 路径全小写 | `/api/v1/workspaces/{ws}/todos` |
+| 资源名词复数 | `todos`、`executions`、`loops`、`tags` |
+| 多词用连字符（kebab-case） | `force-status`、`recent-completed`、`smart-create` |
+| 路径参数用花括号 | `{ws}`、`{id}`、`{slug}` |
+| Action/Command 用独立路径 | `/reload`、`/export`、`/archive` |
+| 版本号用 `v{N}` | `/api/v1/`、`/api/v2/` |
+
+### 5.2 新旧名称对照表
+
+| 旧名称 | 新名称 | 原因 |
+|--------|--------|------|
+| `execution-records` | `executions` | 简洁，记录即执行 |
+| `workspace`（单数） | `workspaces`（复数） | 与 blackboard 现有一致 |
+| ~~`execute/stop`~~ | `executions/{id}/stop` | 归入 executions 资源 |
+| ~~`execute/force-fail`~~ | `executions/{id}/force-fail` | 归入 executions 资源 |
+| ~~`backup/database/file`~~ | `backup/database/files` | 集合名词复数 |
+| ~~`backup/todo/file`~~ | `backup/todo/files` | 同上 |
+| ~~`backup/skills/file`~~ | `backup/skills/files` | 同上 |
+| ~~`webhook/trigger/todo/{id}`~~ | `webhooks/todo/{id}/trigger` | 归入 webhooks + 资源前置 |
+| ~~`running-board`~~ | `executions/running-board` | 归入 executions 域 |
+| ~~`running-todos`~~ | `executions/running-todos` | 归入 executions 域 |
+| ~~`dashboard-stats`~~ | `stats/dashboard` | stats 根域 |
+
+### 5.3 HTTP 方法规范
+
+| 方法 | 语义 | 示例 |
+|------|------|------|
+| GET | 查询/读取 | `GET /api/v1/workspaces/{ws}/todos` |
+| POST | 创建/RPC action | `POST /api/v1/workspaces/{ws}/todos` |
+| PUT | 全量替换 | `PUT /api/v1/workspaces/{ws}/todos/{id}` |
+| PATCH | 部分更新 | `PATCH /api/v1/workspaces/{ws}/blackboard` |
+| DELETE | 删除 | `DELETE /api/v1/workspaces/{ws}/todos/{id}` |
+
+---
+
+## 6. 迁移策略
+
+### 6.1 原则：一次性切换，不保留旧路由
+
+新旧路由不共存。后端实现新 v1 路由后，**同时移除旧 `/api/*` 路由**。前端和 CLI 在同一 PR 中完成路径更新，测试验证通过后合并。不设 Deprecation 窗口。
+
+### 6.2 迁移节奏
+
+| 阶段 | 内容 |
+|------|------|
+| Phase 1 | 后端实现所有 v1 路由 handler，旧 `/api/*` 路由代码一并删除 + 单元测试通过 |
+| Phase 2 | 前端所有 API 调用路径切换到 v1 路径 |
+| Phase 3 | CLI 命令路径切换到 v1 |
+| Phase 4 | 集成测试验证全套路径 + Playwright 前端验证通过 |
+| Phase 5 | 合并 PR |
+
+### 6.3 前端迁移方式
+
+**推荐做法：逐个文件直接修改路径字符串，不经过中间层转换。** 前端 API 调用集中在 `utils/database/*.ts` 中，每个文件职责单一，改起来是机械的字符串替换。
+
+```typescript
+// 改前： todos.ts
+return unwrap(await api.get('/api/todos'));
+
+// 改后： todos.ts
+return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/todos`));
+```
+
+> workspaceId 作为参数从组件层传入（组件已经从上下文或路由中持有当前 workspace id）。
+
+---
+
+## 7. 实现要点
+
+### 7.1 路由结构
+
+用 Axum 的 `.nest()` 挂载 workspace-scoped 资源，`{ws}` 在 nest 层定义：
+
+```rust
+// create_app 中直接挂载 v1 路由，旧路由代码一并删除
+fn create_app() -> Router<AppState> {
+    Router::new()
+        .merge(v1_routes())
+        .layer(...)
+}
+
+fn v1_routes() -> Router<AppState> {
+    Router::new()
+        .nest("/api/v1/workspaces/{ws}/todos", todo::v1_routes())
+        .nest("/api/v1/workspaces/{ws}/executions", execution::v1_routes())
+        .nest("/api/v1/workspaces/{ws}/loops", loop_::v1_routes())
+        // ... workspace-scoped 资源
+        .merge(v1_global_routes())        // 全局资源（无 ws 层级）
+        .merge(v1_system_routes())        // 根级 + static
+}
+```
+
+Axum 的 `.nest()` 会移除路径前缀，子路由内的路径是相对路径：
+
+```rust
+// 子路由定义，{ws} 已在 nest 层被捕获
+pub fn v1_routes() -> Router<AppState> {
+    Router::new()
+        .route("/", get(list_todos))                    // → /api/v1/workspaces/{ws}/todos
+        .route("/{id}", get(get_todo))                  // → /api/v1/workspaces/{ws}/todos/{id}
+        .route("/batch/executor", post(batch_executor)) // → /api/v1/workspaces/{ws}/todos/batch/executor
+}
+```
+
+### 7.2 Handler 签名变化
+
+workspace_id 从「可选查询参数」变为「必选路径参数」：
+
+```rust
+// 旧：Query 中可选
+async fn list_todos(
+    State(state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<...> {
+    let ws_id = params.get("workspace_id").and_then(|s| s.parse().ok());
+}
+
+// 新：Path 中必选
+async fn list_todos(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    Query(params): Query<TodoQuery>,
+) -> Result<...> {
+    // ws_id 直接从路径获取
+}
+```
+
+由于旧路由不保留，无需做 Option 兼容。所有 handler 原地改为从 `Path` 拿 workspace_id。
+
+---
+
+## 8. 设计决策记录（ADR）
+
+### ADR-1：为什么用 `/api/v1/` 而不是 `/v1/`
+
+- 现状：所有路由都有 `/api/` 前缀
+- 选择：保留 `/api/` 前缀，插入 `v1/`
+- 理由：迁移改动最小，新旧路径差异最小，K8s 也是 `/api/v1/`
+
+### ADR-2：为什么用 `executions` 替代 `execution-records`
+
+- 现状：`execution-records` 冗长，且 `POST /api/execute` 与 `GET /api/execution-records` 不一致
+- 选择：统一为 `executions`
+- 理由：REST 资源名应该是单一名词；`records` 是实现细节，用户关心的是「执行」本身
+
+### ADR-3：为什么批量操作用子资源方式（方案 B）
+
+- 选择：`POST .../batch/executor`、`POST .../batch/workspace`
+- 理由：方案 A（`POST .../batch` + body.action）虽然更 REST，但 body.action 的枚举值会影响路由/权限的可见性；子资源方式让每个批量操作有明确的 URL，便于日志和监控
+
+### ADR-4：为什么 tags 归入 workspace
+
+- 业务语义：标签是项目维度的分类，不同项目有不同的标签体系
+- 如果将来需要全局标签，可以在 `/api/v1/tags` 提供只读聚合，但写操作走 workspace 域
+
+### ADR-5：为什么 webhook 加 `/api/` 前缀并重新组织
+
+- 现状：`/webhook/trigger/todo/{todo_id}` 没有 `/api/` 前缀，且资源顺序是「动作→资源」
+- 选择：`/api/v1/webhooks/todo/{todo_id}/trigger`，让 webhook 归入 API 体系
+- 理由：降低运维复杂度（防火墙/反向代理规则统一）；路径语义向 REST 靠拢（先资源后动作）
+
+### ADR-6：为什么 experts 的 action 用路径风格而非冒号
+
+- 选择：`POST /api/v1/experts/reload`、`POST /api/v1/experts/import`
+- 理由：路径风格更传统，对开发者更熟悉。`reload` 不会与 `{name}` 冲突——axum 按注册顺序匹配，集合 action 在 `{name}` 之前注册即可。既然 `{name}` 是动态段，静态路径 `/reload` 优先匹配。
+
+### ADR-7：为什么旧路由不保留，直接删除
+
+- 选择：新旧路由不共存。测试验证通过后，旧路由代码直接删除
+- 理由：两套路由的维护成本（双 handler、双测试、双文档）会持续累加，且本项目无外部 API 消费者（社区插件等），迁移是可控的原子操作。前后端 + CLI 在同一 PR 中完成切换即可
+
+---
+
+## 9. 变更清单（影响文件）
+
+### 后端（Rust）
+
+| 文件 | 变更内容 |
+|------|----------|
+| `backend/src/handlers/mod.rs` | `create_app` 追加 v1 路由 merge；`mount_domain_routes` 改为两套 |
+| `backend/src/handlers/todo.rs` | 新增 `v1_routes()`，handler 支持 Path ws_id |
+| `backend/src/handlers/execution.rs` | 同上 |
+| `backend/src/handlers/loop_.rs` | 同上 |
+| `backend/src/handlers/tag.rs` | 同上 |
+| `backend/src/handlers/backup.rs` | 仅版本号变更 |
+| `backend/src/handlers/skills.rs` | 仅版本号变更 |
+| `backend/src/handlers/agent_bot.rs` | 仅版本号变更 + workspace 路由改复数 |
+| `backend/src/handlers/blackboard.rs` | 仅版本号变更 |
+| `backend/src/handlers/experts.rs` | 修复 create 冲突 + 版本号 |
+| `backend/src/handlers/bundled.rs` | 仅版本号变更 |
+| `backend/src/handlers/webhook.rs` | 重写路径 + 加 /api/v1 前缀 |
+| `backend/src/cli/client.rs` | CLI 路径常量更新 |
+| 各 handler 的单元测试 | 路径更新 |
+
+### 前端（TypeScript）
+
+| 文件 | 变更内容 |
+|------|----------|
+| `frontend/src/utils/database/todos.ts` | 路径改为 v1 |
+| `frontend/src/utils/database/executions.ts` | 路径改为 v1 + 命名变更 |
+| `frontend/src/utils/database/loops.ts` | 路径改为 v1 |
+| `frontend/src/utils/database/backup.ts` | 路径改为 v1 |
+| `frontend/src/utils/database/skills.ts` | 路径改为 v1 |
+| `frontend/src/utils/database/bots.ts` | 路径改为 v1 + 单复数修复 |
+| `frontend/src/utils/database/blackboard.ts` | 路径改为 v1 |
+| `frontend/src/utils/database/experts.ts` | 路径改为 v1 + create 修复 |
+| `frontend/src/utils/database/quickButtons.ts` | 路径改为 v1 + workspace scope |
+| `frontend/src/utils/database/usage_stats.ts` | 路径改为 v1 |
+| `frontend/src/utils/database/sessions.ts` | 路径改为 v1 |
+| `frontend/src/utils/database/reviewTemplates.ts` | 路径改为 v1 |
+| `frontend/src/utils/database/sync.ts` | 路径改为 v1 |
+| `frontend/src/api/bundled.ts` | 路径改为 v1 |
+| `frontend/src/components/BlackboardPage.tsx` | fetch 路径改为 v1 |
+| `frontend/src/components/WikiViewPage.tsx` | fetch 路径改为 v1 |
+| `frontend/src/components/settings/BackupPanel.tsx` | fetch 路径改为 v1 |
+
+---
+
+## 附录：K8s API 风格参考
+
+Kubernetes 的 API 设计原则是此方案的灵感来源：
+
+```
+# K8s 路径模板
+/api/v1/namespaces/{namespace}/{resource}[/{name}[/{sub-resource}]]
+
+# K8s 示例
+GET  /api/v1/namespaces/default/pods                     # 列出 pod
+GET  /api/v1/namespaces/default/pods/{name}               # 查询 pod
+POST /api/v1/namespaces/default/pods                      # 创建 pod
+DELETE /api/v1/namespaces/default/pods/{name}              # 删除 pod
+GET  /api/v1/namespaces/default/pods/{name}/log            # pod 日志（子资源）
+
+# 集群级别资源（无 namespace）
+GET  /api/v1/nodes                                        # 集群节点
+GET  /api/v1/namespaces                                   # 列 namespace 本身
+```
+
+核心原则：
+1. **Namespace 作为租户边界**：所有 namespaced 资源都挂在 `/namespaces/{ns}/` 下
+2. **资源名词复数**：`pods`、`services`、`deployments`
+3. **子资源 = 资源的相关视角**：`/pods/{name}/log`、`/pods/{name}/status`
+4. **集群资源不挂 namespace**：`/nodes`、`/namespaces`
+5. **版本前缀**：`/api/v1/`、`/apis/apps/v1/`
+
+ntd 的映射：
+
+| K8s | ntd |
+|-----|-----|
+| `namespace` | `workspace` |
+| `pods` | `todos`、`loops`、`executions` |
+| `nodes`（集群） | `config`、`experts`、`executors`（全局） |
+| `/api/v1/namespaces/{ns}/pods` | `/api/v1/workspaces/{ws}/todos` |
+| `/api/v1/namespaces/{ns}/pods/{name}/log` | `/api/v1/workspaces/{ws}/executions/{id}/logs` |

--- a/docs/user-guide/reference/api-reference.md
+++ b/docs/user-guide/reference/api-reference.md
@@ -2,6 +2,14 @@
 
 ntd 后端 API 参考手册。所有业务接口前缀为 `/api/v1/`：workspace 作用域资源嵌套在 `/api/v1/workspaces/{ws}/` 下（如 todos、executions、loops），全局资源直接挂在 `/api/v1/` 下（如 tags、config、experts）。WebSocket 事件流 `/api/events` 为升级端点，后端不版本化，保持原路径。
 
+> **迁移说明**：旧版 `/api/*` 路由已全部删除，统一由 v1 版本覆盖。主要变更：
+> - **Workspace ID** 从 query param 改为路径参数，所有 workspace-scoped 资源嵌套在 `/api/v1/workspaces/{ws}/` 下
+> - **批量操作** 从 `PUT /batch-xxx` 改为 `POST /batch/xxx`
+> - **执行记录** 从 `/api/execution-records` 改为 `/api/v1/workspaces/{ws}/executions`
+> - **Dashboard 统计** 从 `/api/dashboard-stats` 改为 `/api/v1/workspaces/{ws}/stats/dashboard`
+> - **智能创建** 从 `/api/smart-create` 改为 `/api/v1/workspaces/{ws}/todos/smart`
+> - **Action 执行** 从 `/api/actions/execute` 改为 `/api/v1/actions/execute`（全局）
+
 ---
 
 ## 接口分类
@@ -1482,27 +1490,6 @@ DELETE /api/v1/workspaces/{ws}/loops/{loop_id}/triggers/{trigger_id}
 
 ---
 
-### 执行 Loop
-```
-POST /api/v1/workspaces/{ws}/loops/{id}/execute
-```
-
-**请求体：**
-```json
-{
-  "message": "立即执行"
-}
-```
-
----
-
-### 停止 Loop 执行
-```
-POST /api/v1/workspaces/{ws}/loops/{id}/stop
-```
-
----
-
 ### 获取 Loop 执行记录
 ```
 GET /api/v1/workspaces/{ws}/loops/{id}/executions
@@ -1512,14 +1499,14 @@ GET /api/v1/workspaces/{ws}/loops/{id}/executions
 
 ### 获取 Loop 执行详情
 ```
-GET /api/v1/workspaces/{ws}/loops/executions/{execution_id}
+GET /api/v1/workspaces/{ws}/loops/{id}/executions/{eid}
 ```
 
 ---
 
-### 获取 Loop 步骤执行记录
+### 获取 Loop 步骤执行审批
 ```
-GET /api/v1/workspaces/{ws}/loops/executions/{execution_id}/steps
+POST /api/v1/workspaces/{ws}/loops/{id}/executions/{eid}/steps/{seid}/approve
 ```
 
 ---

--- a/docs/user-guide/reference/api-reference.md
+++ b/docs/user-guide/reference/api-reference.md
@@ -1,6 +1,6 @@
 # ntd API 接口文档
 
-ntd 后端 API 参考手册。所有接口前缀为 `/api/`（WebSocket 为 `/api/events`）。
+ntd 后端 API 参考手册。所有业务接口前缀为 `/api/v1/`：workspace 作用域资源嵌套在 `/api/v1/workspaces/{ws}/` 下（如 todos、executions、loops），全局资源直接挂在 `/api/v1/` 下（如 tags、config、experts）。WebSocket 事件流 `/api/events` 为升级端点，后端不版本化，保持原路径。
 
 ---
 
@@ -36,7 +36,7 @@ ntd 后端 API 参考手册。所有接口前缀为 `/api/`（WebSocket 为 `/ap
 
 ### 获取 Todo 列表
 ```
-GET /api/todos
+GET /api/v1/workspaces/{ws}/todos
 ```
 
 查询参数：
@@ -48,7 +48,7 @@ GET /api/todos
 | `running` | boolean | 仅显示运行中的 Todo（`true`） |
 | `search` | string | 搜索关键词（标题或 prompt 包含匹配，由前端/CLI 在内存中过滤） |
 
-注意：后端 `GET /api/todos` 本身不支持 `page`/`limit` 分页参数；如需分页请在客户端做。
+注意：后端 `GET /api/v1/workspaces/{ws}/todos` 本身不支持 `page`/`limit` 分页参数；如需分页请在客户端做。
 
 **响应示例：**
 ```json
@@ -71,7 +71,7 @@ GET /api/todos
 
 ### 创建 Todo
 ```
-POST /api/todos
+POST /api/v1/workspaces/{ws}/todos
 ```
 
 **请求体：**
@@ -103,14 +103,14 @@ POST /api/todos
 
 ### 获取 Todo 详情
 ```
-GET /api/todos/{id}
+GET /api/v1/workspaces/{ws}/todos/{id}
 ```
 
 ---
 
 ### 更新 Todo
 ```
-PUT /api/todos/{id}
+PUT /api/v1/workspaces/{ws}/todos/{id}
 ```
 
 **请求体：**
@@ -146,14 +146,14 @@ PUT /api/todos/{id}
 
 ### 删除 Todo
 ```
-DELETE /api/todos/{id}
+DELETE /api/v1/workspaces/{ws}/todos/{id}
 ```
 
 ---
 
 ### 强制更新 Todo 状态
 ```
-PUT /api/todos/{id}/force-status
+PUT /api/v1/workspaces/{ws}/todos/{id}/force-status
 ```
 
 **请求体：**
@@ -167,7 +167,7 @@ PUT /api/todos/{id}/force-status
 
 ### 更新 Todo 标签
 ```
-PUT /api/todos/{id}/tags
+PUT /api/v1/workspaces/{ws}/todos/{id}/tags
 ```
 
 **请求体：**
@@ -181,14 +181,14 @@ PUT /api/todos/{id}/tags
 
 ### 获取 Todo 执行摘要
 ```
-GET /api/todos/{id}/summary
+GET /api/v1/workspaces/{ws}/todos/{id}/summary
 ```
 
 ---
 
 ### 获取最近完成的 Todo
 ```
-GET /api/todos/recent-completed
+GET /api/v1/workspaces/{ws}/todos/recent-completed
 ```
 
 查询参数：
@@ -201,7 +201,7 @@ GET /api/todos/recent-completed
 
 ### 批量修改执行器
 ```
-PUT /api/todos/batch-executor
+PUT /api/v1/workspaces/{ws}/todos/batch-executor
 ```
 
 **请求体：**
@@ -216,7 +216,7 @@ PUT /api/todos/batch-executor
 
 ### 批量移动工作目录
 ```
-PUT /api/todos/batch-workspace
+PUT /api/v1/workspaces/{ws}/todos/batch-workspace
 ```
 
 **请求体：**
@@ -231,7 +231,7 @@ PUT /api/todos/batch-workspace
 
 ### 批量复制工作目录
 ```
-POST /api/todos/batch-copy-workspace
+POST /api/v1/workspaces/{ws}/todos/batch-copy-workspace
 ```
 
 **请求体：**
@@ -249,7 +249,7 @@ POST /api/todos/batch-copy-workspace
 
 ### 获取标签列表
 ```
-GET /api/tags
+GET /api/v1/tags
 ```
 
 **响应示例：**
@@ -269,7 +269,7 @@ GET /api/tags
 
 ### 创建标签
 ```
-POST /api/tags
+POST /api/v1/tags
 ```
 
 **请求体：**
@@ -284,7 +284,7 @@ POST /api/tags
 
 ### 删除标签
 ```
-DELETE /api/tags/{id}
+DELETE /api/v1/tags/{id}
 ```
 
 ---
@@ -293,7 +293,7 @@ DELETE /api/tags/{id}
 
 ### 获取执行记录列表
 ```
-GET /api/execution-records
+GET /api/v1/workspaces/{ws}/executions
 ```
 
 查询参数：
@@ -309,28 +309,28 @@ GET /api/execution-records
 
 ### 获取运行中的执行记录
 ```
-GET /api/execution-records/running
+GET /api/v1/workspaces/{ws}/executions/running
 ```
 
 ---
 
 ### 按会话 ID 获取执行记录
 ```
-GET /api/execution-records/session/{session_id}
+GET /api/v1/workspaces/{ws}/executions/session/{session_id}
 ```
 
 ---
 
 ### 获取执行记录详情
 ```
-GET /api/execution-records/{id}
+GET /api/v1/workspaces/{ws}/executions/{id}
 ```
 
 ---
 
 ### 获取执行记录日志
 ```
-GET /api/execution-records/{id}/logs
+GET /api/v1/workspaces/{ws}/executions/{id}/logs
 ```
 
 查询参数：
@@ -344,7 +344,7 @@ GET /api/execution-records/{id}/logs
 
 ### 恢复执行
 ```
-POST /api/execution-records/{id}/resume
+POST /api/v1/workspaces/{ws}/executions/{id}/resume
 ```
 
 **请求体：**
@@ -358,7 +358,7 @@ POST /api/execution-records/{id}/resume
 
 ### 评分执行记录
 ```
-PUT /api/execution-records/{id}/rating
+PUT /api/v1/workspaces/{ws}/executions/{id}/rating
 ```
 
 **请求体：**
@@ -376,7 +376,7 @@ PUT /api/execution-records/{id}/rating
 
 ### 获取 Running Board
 ```
-GET /api/running-board
+GET /api/v1/workspaces/{ws}/executions/running-board
 ```
 
 返回按状态分组的执行记录看板视图，包含 scheduled/running/completed/reviewing/review_passed/failed 六列。
@@ -387,7 +387,7 @@ GET /api/running-board
 
 ### 执行 Todo
 ```
-POST /api/execute
+POST /api/v1/workspaces/{ws}/executions
 ```
 
 **请求体：**
@@ -414,7 +414,7 @@ POST /api/execute
 
 ### 智能创建
 ```
-POST /api/smart-create
+POST /api/v1/workspaces/{ws}/todos/smart
 ```
 
 **请求体：**
@@ -441,7 +441,7 @@ POST /api/smart-create
 
 ### 停止执行
 ```
-POST /api/execute/stop
+POST /api/v1/workspaces/{ws}/executions/{id}/stop
 ```
 
 **请求体：**
@@ -455,7 +455,7 @@ POST /api/execute/stop
 
 ### 强制失败
 ```
-POST /api/execute/force-fail
+POST /api/v1/workspaces/{ws}/executions/{id}/force-fail
 ```
 
 **请求体：**
@@ -467,21 +467,21 @@ POST /api/execute/force-fail
 
 ### 获取运行中的 Todo
 ```
-GET /api/running-todos
+GET /api/v1/workspaces/{ws}/executions/running-todos
 ```
 
 ---
 
 ### 获取仪表盘统计
 ```
-GET /api/dashboard-stats
+GET /api/v1/workspaces/{ws}/stats/dashboard
 ```
 
 ---
 
 ### 执行 Action
 ```
-POST /api/actions/execute
+POST /api/v1/actions/execute
 ```
 
 **请求体：**
@@ -503,14 +503,14 @@ POST /api/actions/execute
 
 ### 获取定时 Todo 列表
 ```
-GET /api/scheduler/todos
+GET /api/v1/workspaces/{ws}/scheduler/todos
 ```
 
 ---
 
 ### 更新 Todo 调度配置
 ```
-PUT /api/todos/{id}/scheduler
+PUT /api/v1/workspaces/{ws}/todos/{id}/scheduler
 ```
 
 **请求体：**
@@ -528,7 +528,7 @@ PUT /api/todos/{id}/scheduler
 
 ### 导出全部数据
 ```
-GET /api/backup/export
+GET /api/v1/backup/export
 ```
 
 返回 YAML 格式的完整备份。
@@ -537,7 +537,7 @@ GET /api/backup/export
 
 ### 导出选定的 Todo
 ```
-POST /api/backup/export-selected
+POST /api/v1/backup/export-selected
 ```
 
 **请求体：**
@@ -551,7 +551,7 @@ POST /api/backup/export-selected
 
 ### 导入备份（完整替换）
 ```
-POST /api/backup/import
+POST /api/v1/backup/import
 ```
 
 Content-Type: `multipart/form-data`
@@ -564,7 +564,7 @@ Content-Type: `multipart/form-data`
 
 ### 合并导入
 ```
-POST /api/backup/merge
+POST /api/v1/backup/merge
 ```
 
 Content-Type: `multipart/form-data`
@@ -577,28 +577,28 @@ Content-Type: `multipart/form-data`
 
 ### 下载数据库
 ```
-GET /api/backup/database/download
+GET /api/v1/backup/database/download
 ```
 
 ---
 
 ### 获取数据库备份状态
 ```
-GET /api/backup/database/status
+GET /api/v1/backup/database/status
 ```
 
 ---
 
 ### 触发立即备份
 ```
-POST /api/backup/database/trigger
+POST /api/v1/backup/database/trigger
 ```
 
 ---
 
 ### 更新自动备份配置
 ```
-PUT /api/backup/database/auto
+PUT /api/v1/backup/database/auto
 ```
 
 **请求体：**
@@ -620,7 +620,7 @@ PUT /api/backup/database/auto
 
 ### 优化数据库
 ```
-POST /api/backup/database/optimize
+POST /api/v1/backup/database/optimize
 ```
 
 执行 SQLite `VACUUM`，回收已删除记录占用的磁盘空间。
@@ -631,7 +631,7 @@ POST /api/backup/database/optimize
 
 ### 下载备份文件
 ```
-GET /api/backup/database/file
+GET /api/v1/backup/database/file
 ```
 
 查询参数：
@@ -644,7 +644,7 @@ GET /api/backup/database/file
 
 ### 删除备份文件
 ```
-DELETE /api/backup/database/file
+DELETE /api/v1/backup/database/file
 ```
 
 查询参数：
@@ -659,11 +659,11 @@ DELETE /api/backup/database/file
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| `GET`  | `/api/backup/todo/status`  | 获取 Todo 备份状态与文件列表 |
-| `POST` | `/api/backup/todo/trigger` | 立即触发一次 Todo 备份 |
-| `PUT`  | `/api/backup/todo/auto`    | 更新 Todo 自动备份配置 |
-| `GET`  | `/api/backup/todo/file`    | 下载指定 Todo 备份文件（query `filename`） |
-| `DELETE` | `/api/backup/todo/file`  | 删除指定 Todo 备份文件（query `filename`） |
+| `GET`  | `/api/v1/backup/todo/status`  | 获取 Todo 备份状态与文件列表 |
+| `POST` | `/api/v1/backup/todo/trigger` | 立即触发一次 Todo 备份 |
+| `PUT`  | `/api/v1/backup/todo/auto`    | 更新 Todo 自动备份配置 |
+| `GET`  | `/api/v1/backup/todo/file`    | 下载指定 Todo 备份文件（query `filename`） |
+| `DELETE` | `/api/v1/backup/todo/file`  | 删除指定 Todo 备份文件（query `filename`） |
 
 ---
 
@@ -671,11 +671,11 @@ DELETE /api/backup/database/file
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| `GET`  | `/api/backup/skills/status`  | 获取 Skill 备份状态与文件列表 |
-| `POST` | `/api/backup/skills/trigger` | 立即触发一次 Skill 备份 |
-| `PUT`  | `/api/backup/skills/auto`    | 更新 Skill 自动备份配置 |
-| `GET`  | `/api/backup/skills/file`    | 下载指定 Skill 备份文件（query `filename`） |
-| `DELETE` | `/api/backup/skills/file`  | 删除指定 Skill 备份文件（query `filename`） |
+| `GET`  | `/api/v1/backup/skills/status`  | 获取 Skill 备份状态与文件列表 |
+| `POST` | `/api/v1/backup/skills/trigger` | 立即触发一次 Skill 备份 |
+| `PUT`  | `/api/v1/backup/skills/auto`    | 更新 Skill 自动备份配置 |
+| `GET`  | `/api/v1/backup/skills/file`    | 下载指定 Skill 备份文件（query `filename`） |
+| `DELETE` | `/api/v1/backup/skills/file`  | 删除指定 Skill 备份文件（query `filename`） |
 
 ---
 
@@ -683,9 +683,9 @@ DELETE /api/backup/database/file
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| `GET`  | `/api/backup/log-cleanup/status`  | 获取日志清理策略与上次执行时间 |
-| `PUT`  | `/api/backup/log-cleanup`         | 更新日志清理策略 |
-| `POST` | `/api/backup/log-cleanup/trigger` | 立即触发一次日志清理 |
+| `GET`  | `/api/v1/backup/log-cleanup/status`  | 获取日志清理策略与上次执行时间 |
+| `PUT`  | `/api/v1/backup/log-cleanup`         | 更新日志清理策略 |
+| `POST` | `/api/v1/backup/log-cleanup/trigger` | 立即触发一次日志清理 |
 
 ---
 
@@ -693,7 +693,7 @@ DELETE /api/backup/database/file
 
 ### 获取配置
 ```
-GET /api/config
+GET /api/v1/config
 ```
 
 **响应示例：**
@@ -720,7 +720,7 @@ GET /api/config
 
 ### 更新配置
 ```
-PUT /api/config
+PUT /api/v1/config
 ```
 
 **请求体：**
@@ -737,14 +737,14 @@ PUT /api/config
 
 ### 列出执行器
 ```
-GET /api/executors
+GET /api/v1/executors
 ```
 
 ---
 
 ### 更新执行器配置
 ```
-PUT /api/executors/{name}
+PUT /api/v1/executors/{name}
 ```
 
 **请求体：**
@@ -768,7 +768,7 @@ PUT /api/executors/{name}
 
 ### 检测执行器
 ```
-POST /api/executors/{name}/detect
+POST /api/v1/executors/{name}/detect
 ```
 
 检测执行器二进制文件是否存在。
@@ -777,7 +777,7 @@ POST /api/executors/{name}/detect
 
 ### 批量检测所有执行器
 ```
-POST /api/executors/detect-all
+POST /api/v1/executors/detect-all
 ```
 
 遍历所有已知执行器，报告每个执行器的探测结果，便于一次刷新 UI 状态。
@@ -800,7 +800,7 @@ POST /api/executors/detect-all
 
 ### 测试执行器
 ```
-POST /api/executors/{name}/test
+POST /api/v1/executors/{name}/test
 ```
 
 运行 `executor --version` 测试配置是否正确。
@@ -811,7 +811,7 @@ POST /api/executors/{name}/test
 
 ### 列出技能
 ```
-GET /api/skills
+GET /api/v1/skills
 ```
 
 按执行器分组列出所有技能。
@@ -820,7 +820,7 @@ GET /api/skills
 
 ### 比较技能
 ```
-GET /api/skills/compare
+GET /api/v1/skills/compare
 ```
 
 跨执行器的技能对比矩阵。
@@ -829,7 +829,7 @@ GET /api/skills/compare
 
 ### 同步技能
 ```
-POST /api/skills/sync
+POST /api/v1/skills/sync
 ```
 
 **请求体：**
@@ -845,14 +845,14 @@ POST /api/skills/sync
 
 ### 获取技能调用记录
 ```
-GET /api/skills/invocations
+GET /api/v1/skills/invocations
 ```
 
 ---
 
 ### 记录技能调用
 ```
-POST /api/skills/invocations
+POST /api/v1/skills/invocations
 ```
 
 **请求体：**
@@ -869,7 +869,7 @@ POST /api/skills/invocations
 
 ### 获取技能内容
 ```
-GET /api/skills/content
+GET /api/v1/skills/content
 ```
 
 查询参数：
@@ -883,7 +883,7 @@ GET /api/skills/content
 
 ### 导出技能
 ```
-GET /api/skills/export
+GET /api/v1/skills/export
 ```
 
 查询参数：
@@ -899,7 +899,7 @@ GET /api/skills/export
 
 ### 导入技能
 ```
-POST /api/skills/import
+POST /api/v1/skills/import
 ```
 
 Content-Type: `multipart/form-data`
@@ -914,21 +914,21 @@ Content-Type: `multipart/form-data`
 
 ### 列出 Agent Bot
 ```
-GET /api/agent-bots
+GET /api/v1/agent-bots
 ```
 
 ---
 
 ### 删除 Agent Bot
 ```
-DELETE /api/agent-bots/{id}
+DELETE /api/v1/agent-bots/{id}
 ```
 
 ---
 
 ### 更新 Agent Bot 配置
 ```
-PUT /api/agent-bots/{id}/config
+PUT /api/v1/agent-bots/{id}/config
 ```
 
 **请求体：**
@@ -950,21 +950,21 @@ PUT /api/agent-bots/{id}/config
 
 ### 初始化飞书 OAuth
 ```
-POST /api/agent-bots/feishu/init
+POST /api/v1/agent-bots/feishu/init
 ```
 
 ---
 
 ### 开始飞书 OAuth
 ```
-POST /api/agent-bots/feishu/begin
+POST /api/v1/agent-bots/feishu/begin
 ```
 
 ---
 
 ### 轮询飞书 OAuth 状态（SSE 事件流）
 ```
-GET /api/agent-bots/feishu/poll-stream
+GET /api/v1/agent-bots/feishu/poll-stream
 ```
 
 Server-Sent Events 端点。建立连接后，后台会持续向飞书 OAuth 端点轮询授权状态，结果以事件形式推回前端，避免前端轮询时序问题。
@@ -1001,7 +1001,7 @@ Server-Sent Events 端点。建立连接后，后台会持续向飞书 OAuth 端
 
 ### 获取飞书推送配置
 ```
-GET /api/agent-bots/feishu/push
+GET /api/v1/agent-bots/feishu/push
 ```
 
 返回所有飞书 bot 的推送状态数组，每条记录字段：
@@ -1022,7 +1022,7 @@ GET /api/agent-bots/feishu/push
 
 ### 更新飞书推送配置
 ```
-PUT /api/agent-bots/feishu/push
+PUT /api/v1/agent-bots/feishu/push
 ```
 
 **请求体：**
@@ -1056,7 +1056,7 @@ PUT /api/agent-bots/feishu/push
 
 ### 获取群组白名单
 ```
-GET /api/agent-bots/feishu/group-whitelist
+GET /api/v1/agent-bots/feishu/group-whitelist
 ```
 
 查询参数：
@@ -1069,7 +1069,7 @@ GET /api/agent-bots/feishu/group-whitelist
 
 ### 添加群组到白名单
 ```
-POST /api/agent-bots/feishu/group-whitelist
+POST /api/v1/agent-bots/feishu/group-whitelist
 ```
 
 **请求体：**
@@ -1091,7 +1091,7 @@ POST /api/agent-bots/feishu/group-whitelist
 
 ### 从白名单移除
 ```
-DELETE /api/agent-bots/feishu/group-whitelist/{id}
+DELETE /api/v1/agent-bots/feishu/group-whitelist/{id}
 ```
 
 ---
@@ -1100,7 +1100,7 @@ DELETE /api/agent-bots/feishu/group-whitelist/{id}
 
 ### 获取历史消息
 ```
-GET /api/feishu/history-messages
+GET /api/v1/feishu/history-messages
 ```
 
 查询参数：
@@ -1117,28 +1117,28 @@ GET /api/feishu/history-messages
 
 ### 获取消息统计
 ```
-GET /api/feishu/message-stats
+GET /api/v1/feishu/message-stats
 ```
 
 ---
 
 ### 获取消息发送者列表
 ```
-GET /api/feishu/senders
+GET /api/v1/feishu/senders
 ```
 
 ---
 
 ### 获取历史聊天室列表
 ```
-GET /api/feishu/history-chats
+GET /api/v1/feishu/history-chats
 ```
 
 ---
 
 ### 创建历史聊天室
 ```
-POST /api/feishu/history-chats
+POST /api/v1/feishu/history-chats
 ```
 
 **请求体：**
@@ -1153,14 +1153,14 @@ POST /api/feishu/history-chats
 
 ### 删除历史聊天室
 ```
-DELETE /api/feishu/history-chats/{id}
+DELETE /api/v1/feishu/history-chats/{id}
 ```
 
 ---
 
 ### 更新历史聊天室
 ```
-PUT /api/feishu/history-chats/{id}
+PUT /api/v1/feishu/history-chats/{id}
 ```
 
 **请求体：**
@@ -1177,7 +1177,7 @@ PUT /api/feishu/history-chats/{id}
 
 ### 列出会话
 ```
-GET /api/sessions
+GET /api/v1/sessions
 ```
 
 查询参数：
@@ -1191,14 +1191,14 @@ GET /api/sessions
 
 ### 获取会话统计
 ```
-GET /api/sessions/stats
+GET /api/v1/sessions/stats
 ```
 
 ---
 
 ### 获取会话详情
 ```
-GET /api/sessions/{id}
+GET /api/v1/sessions/{id}
 ```
 
 包含会话消息和子代理信息。
@@ -1207,7 +1207,7 @@ GET /api/sessions/{id}
 
 ### 删除会话
 ```
-DELETE /api/sessions/{id}
+DELETE /api/v1/sessions/{id}
 ```
 
 ---
@@ -1216,14 +1216,14 @@ DELETE /api/sessions/{id}
 
 ### 列出项目目录
 ```
-GET /api/project-directories
+GET /api/v1/project-directories
 ```
 
 ---
 
 ### 创建项目目录
 ```
-POST /api/project-directories
+POST /api/v1/project-directories
 ```
 
 **请求体：**
@@ -1238,7 +1238,7 @@ POST /api/project-directories
 
 ### 更新项目目录
 ```
-PUT /api/project-directories/{id}
+PUT /api/v1/project-directories/{id}
 ```
 
 **请求体：**
@@ -1252,7 +1252,7 @@ PUT /api/project-directories/{id}
 
 ### 删除项目目录
 ```
-DELETE /api/project-directories/{id}
+DELETE /api/v1/project-directories/{id}
 ```
 
 ---
@@ -1261,14 +1261,14 @@ DELETE /api/project-directories/{id}
 
 ### 获取模板列表
 ```
-GET /api/todo-templates
+GET /api/v1/todo-templates
 ```
 
 ---
 
 ### 创建模板
 ```
-POST /api/todo-templates
+POST /api/v1/todo-templates
 ```
 
 **请求体：**
@@ -1292,21 +1292,21 @@ POST /api/todo-templates
 
 ### 更新模板
 ```
-PUT /api/todo-templates/{id}
+PUT /api/v1/todo-templates/{id}
 ```
 
 ---
 
 ### 删除模板
 ```
-DELETE /api/todo-templates/{id}
+DELETE /api/v1/todo-templates/{id}
 ```
 
 ---
 
 ### 复制模板
 ```
-POST /api/todo-templates/{id}/copy
+POST /api/v1/todo-templates/{id}/copy
 ```
 
 ---
@@ -1315,14 +1315,14 @@ POST /api/todo-templates/{id}/copy
 
 ### 获取评审模板列表
 ```
-GET /api/review-templates
+GET /api/v1/review-templates
 ```
 
 ---
 
 ### 创建评审模板
 ```
-POST /api/review-templates
+POST /api/v1/review-templates
 ```
 
 **请求体：**
@@ -1338,21 +1338,21 @@ POST /api/review-templates
 
 ### 更新评审模板
 ```
-PUT /api/review-templates/{id}
+PUT /api/v1/review-templates/{id}
 ```
 
 ---
 
 ### 删除评审模板
 ```
-DELETE /api/review-templates/{id}
+DELETE /api/v1/review-templates/{id}
 ```
 
 ---
 
 ### 获取评审模板选项
 ```
-GET /api/review-templates/options
+GET /api/v1/review-templates/options
 ```
 
 返回所有评审模板的 id + name 列表，用于前端下拉选择。
@@ -1363,14 +1363,14 @@ GET /api/review-templates/options
 
 ### 获取 Loop 列表
 ```
-GET /api/loops
+GET /api/v1/workspaces/{ws}/loops
 ```
 
 ---
 
 ### 创建 Loop
 ```
-POST /api/loops
+POST /api/v1/workspaces/{ws}/loops
 ```
 
 **请求体：**
@@ -1386,35 +1386,35 @@ POST /api/loops
 
 ### 获取 Loop 详情
 ```
-GET /api/loops/{id}
+GET /api/v1/workspaces/{ws}/loops/{id}
 ```
 
 ---
 
 ### 更新 Loop
 ```
-PUT /api/loops/{id}
+PUT /api/v1/workspaces/{ws}/loops/{id}
 ```
 
 ---
 
 ### 删除 Loop
 ```
-DELETE /api/loops/{id}
+DELETE /api/v1/workspaces/{ws}/loops/{id}
 ```
 
 ---
 
 ### 获取 Loop 步骤列表
 ```
-GET /api/loops/{id}/steps
+GET /api/v1/workspaces/{ws}/loops/{id}/steps
 ```
 
 ---
 
 ### 创建 Loop 步骤
 ```
-POST /api/loops/{id}/steps
+POST /api/v1/workspaces/{ws}/loops/{id}/steps
 ```
 
 **请求体：**
@@ -1431,28 +1431,28 @@ POST /api/loops/{id}/steps
 
 ### 更新 Loop 步骤
 ```
-PUT /api/loops/{loop_id}/steps/{step_id}
+PUT /api/v1/workspaces/{ws}/loops/{loop_id}/steps/{step_id}
 ```
 
 ---
 
 ### 删除 Loop 步骤
 ```
-DELETE /api/loops/{loop_id}/steps/{step_id}
+DELETE /api/v1/workspaces/{ws}/loops/{loop_id}/steps/{step_id}
 ```
 
 ---
 
 ### 获取 Loop 触发器列表
 ```
-GET /api/loops/{id}/triggers
+GET /api/v1/workspaces/{ws}/loops/{id}/triggers
 ```
 
 ---
 
 ### 创建 Loop 触发器
 ```
-POST /api/loops/{id}/triggers
+POST /api/v1/workspaces/{ws}/loops/{id}/triggers
 ```
 
 **请求体：**
@@ -1470,21 +1470,21 @@ POST /api/loops/{id}/triggers
 
 ### 更新 Loop 触发器
 ```
-PUT /api/loops/{loop_id}/triggers/{trigger_id}
+PUT /api/v1/workspaces/{ws}/loops/{loop_id}/triggers/{trigger_id}
 ```
 
 ---
 
 ### 删除 Loop 触发器
 ```
-DELETE /api/loops/{loop_id}/triggers/{trigger_id}
+DELETE /api/v1/workspaces/{ws}/loops/{loop_id}/triggers/{trigger_id}
 ```
 
 ---
 
 ### 执行 Loop
 ```
-POST /api/loops/{id}/execute
+POST /api/v1/workspaces/{ws}/loops/{id}/execute
 ```
 
 **请求体：**
@@ -1498,28 +1498,28 @@ POST /api/loops/{id}/execute
 
 ### 停止 Loop 执行
 ```
-POST /api/loops/{id}/stop
+POST /api/v1/workspaces/{ws}/loops/{id}/stop
 ```
 
 ---
 
 ### 获取 Loop 执行记录
 ```
-GET /api/loops/{id}/executions
+GET /api/v1/workspaces/{ws}/loops/{id}/executions
 ```
 
 ---
 
 ### 获取 Loop 执行详情
 ```
-GET /api/loops/executions/{execution_id}
+GET /api/v1/workspaces/{ws}/loops/executions/{execution_id}
 ```
 
 ---
 
 ### 获取 Loop 步骤执行记录
 ```
-GET /api/loops/executions/{execution_id}/steps
+GET /api/v1/workspaces/{ws}/loops/executions/{execution_id}/steps
 ```
 
 ---
@@ -1528,14 +1528,14 @@ GET /api/loops/executions/{execution_id}/steps
 
 ### 获取订阅状态
 ```
-GET /api/custom-templates/status
+GET /api/v1/custom-templates/status
 ```
 
 ---
 
 ### 订阅远程模板
 ```
-POST /api/custom-templates/subscribe
+POST /api/v1/custom-templates/subscribe
 ```
 
 **请求体：**
@@ -1549,7 +1549,7 @@ POST /api/custom-templates/subscribe
 
 ### 取消订阅
 ```
-POST /api/custom-templates/unsubscribe
+POST /api/v1/custom-templates/unsubscribe
 ```
 
 **请求体：**
@@ -1563,14 +1563,14 @@ POST /api/custom-templates/unsubscribe
 
 ### 手动同步
 ```
-POST /api/custom-templates/sync
+POST /api/v1/custom-templates/sync
 ```
 
 ---
 
 ### 更新自动同步配置
 ```
-PUT /api/custom-templates/auto-sync
+PUT /api/v1/custom-templates/auto-sync
 ```
 
 **请求体：**
@@ -1596,7 +1596,7 @@ GET /health
 
 ### 获取版本信息
 ```
-GET /api/version
+GET /api/v1/version
 ```
 
 **响应示例：**
@@ -1615,7 +1615,7 @@ GET /api/version
 
 ### 查询 npm 最新版本
 ```
-GET /api/version/latest
+GET /api/v1/version/latest
 ```
 
 后端调用 `npm view @weibaohui/ntd version` 获取远程最新版本号，供前端做升级提示。
@@ -1634,7 +1634,7 @@ GET /api/version/latest
 
 ### 触发远程升级
 ```
-POST /api/version/upgrade
+POST /api/v1/version/upgrade
 ```
 
 流程：调用 `npm install -g @weibaohui/ntd@latest` → fork 子进程执行 `daemon stop → uninstall → install --force → start`，让当前进程先返回响应后再重启服务。
@@ -1701,17 +1701,17 @@ Webhook 不再作为“设置中心里的独立资源”管理，而是 Todo / L
 
 ### 外部触发 Todo
 ```
-GET  /webhook/trigger/todo/{todo_id}
-POST /webhook/trigger/todo/{todo_id}
+GET  /api/v1/webhooks/todo/{id}/trigger
+POST /api/v1/webhooks/todo/{id}/trigger
 ```
 
 ### 外部触发 Loop
 ```
-GET  /webhook/trigger/loop/{loop_id}
-POST /webhook/trigger/loop/{loop_id}
+GET  /api/v1/webhooks/loop/{id}/trigger
+POST /api/v1/webhooks/loop/{id}/trigger
 ```
 
-注意：路径**没有** `/api/` 前缀，作用是系统集成（如外部调度系统）。当目标 Todo/Loop 未启用 webhook 时会返回 400。
+注意：路径带 `/api/v1/webhooks` 前缀，触发动作作为子资源放在末尾（`{resource}/{id}/trigger`），更符合 REST 的「资源 → 子资源」层级感。当目标 Todo/Loop 未启用 webhook 时会返回 400。
 
 ---
 
@@ -1719,10 +1719,10 @@ POST /webhook/trigger/loop/{loop_id}
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| `GET`  | `/api/usage-stats`            | 获取当前使用统计快照 |
-| `POST` | `/api/usage-stats/refresh`    | 主动触发一次使用统计刷新 |
-| `GET`  | `/api/usage-stats/settings`   | 获取统计采集配置 |
-| `PUT`  | `/api/usage-stats/settings`   | 更新统计采集配置 |
+| `GET`  | `/api/v1/usage-stats`            | 获取当前使用统计快照 |
+| `POST` | `/api/v1/usage-stats/refresh`    | 主动触发一次使用统计刷新 |
+| `GET`  | `/api/v1/usage-stats/settings`   | 获取统计采集配置 |
+| `PUT`  | `/api/v1/usage-stats/settings`   | 更新统计采集配置 |
 
 ---
 
@@ -1730,13 +1730,13 @@ POST /webhook/trigger/loop/{loop_id}
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| `GET`  | `/api/cloud/config`         | 获取云端同步配置 |
-| `POST` | `/api/cloud/config`         | 保存云端同步配置 |
-| `GET`  | `/api/cloud/sync/status`    | 获取最近一次同步状态（成功/失败/时间戳） |
-| `GET`  | `/api/cloud/sync/records`   | 列出已同步到云端的记录 |
-| `DELETE` | `/api/cloud/sync/records` | 清空云端同步记录 |
-| `POST` | `/api/cloud/sync/push`      | 推送本地变更到云端 |
-| `POST` | `/api/cloud/sync/pull`      | 从云端拉取变更到本地 |
+| `GET`  | `/api/v1/cloud/config`         | 获取云端同步配置 |
+| `POST` | `/api/v1/cloud/config`         | 保存云端同步配置 |
+| `GET`  | `/api/v1/cloud/sync/status`    | 获取最近一次同步状态（成功/失败/时间戳） |
+| `GET`  | `/api/v1/cloud/sync/records`   | 列出已同步到云端的记录 |
+| `DELETE` | `/api/v1/cloud/sync/records` | 清空云端同步记录 |
+| `POST` | `/api/v1/cloud/sync/push`      | 推送本地变更到云端 |
+| `POST` | `/api/v1/cloud/sync/pull`      | 从云端拉取变更到本地 |
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -468,6 +468,7 @@ function AppContent() {
         onClose={() => setSmartCreateOpen(false)}
         isMobile={isMobile}
         config={appConfig}
+        workspaceId={state.selectedWorkspace}
         onGoToSettings={() => handleShowView('settings')}
         onSubmitted={handleSmartCreateSubmitted}
       />

--- a/frontend/src/components/ActionButton/useActionExecution.ts
+++ b/frontend/src/components/ActionButton/useActionExecution.ts
@@ -102,7 +102,7 @@ export function useActionExecution(
   const fetchResultFromRecord = useCallback(async () => {
     if (!recordId) return;
     try {
-      const record = await getExecutionRecord(recordId);
+      const record = await getExecutionRecord(workspaceId ?? 0, recordId);
       if (record.result) {
         setResult(record.result);
         setStatus('completed');

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -235,9 +235,10 @@ function useEffectiveWorkspaceId(propWorkspaceId: number | null | undefined): nu
   }, [propWorkspaceId]);
 }
 
-/** 拉取黑板内容的纯函数，便于测试与复用（旧版单文件接口，保留兼容） */
+/** 拉取黑板内容的纯函数，便于测试与复用。
+ *  原生 fetch 不经 axios 拦截器，手动写 v1 路径。 */
 async function fetchBlackboardData(workspaceId: number): Promise<BlackboardData> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/blackboard`);
+  const res = await fetch(`/api/v1/workspaces/${workspaceId}/blackboard`);
   if (!res.ok) {
     throw new Error(`HTTP ${res.status}`);
   }
@@ -248,9 +249,9 @@ async function fetchBlackboardData(workspaceId: number): Promise<BlackboardData>
   return json.data;
 }
 
-/** 拉取单个 Wiki 文件内容 */
+/** 拉取单个 Wiki 文件内容（原生 fetch，手动写 v1 路径） */
 async function fetchWikiFileContent(workspaceId: number, slug: string): Promise<WikiFileContent> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/wiki/files/${encodeURIComponent(slug)}`);
+  const res = await fetch(`/api/v1/workspaces/${workspaceId}/wiki/files/${encodeURIComponent(slug)}`);
   if (!res.ok) {
     throw new Error(`HTTP ${res.status}`);
   }
@@ -261,9 +262,9 @@ async function fetchWikiFileContent(workspaceId: number, slug: string): Promise<
   return json.data;
 }
 
-/** 拉取 Wiki 文件列表 */
+/** 拉取 Wiki 文件列表（原生 fetch，手动写 v1 路径） */
 async function fetchWikiFiles(workspaceId: number): Promise<WikiFileItem[]> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/wiki/files`);
+  const res = await fetch(`/api/v1/workspaces/${workspaceId}/wiki/files`);
   if (!res.ok) {
     throw new Error(`HTTP ${res.status}`);
   }

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -73,7 +73,8 @@ export function Dashboard() {
   const loadStats = async (hours?: number) => {
     try {
       setLoading(true);
-      const data = await db.getDashboardStats(hours);
+      // v1 纯 workspace-scoped：dashboard stats 按 workspace 隔离
+      const data = await db.getDashboardStats(state.selectedWorkspace ?? 0, hours);
       setStats(data);
     } catch {
       message.error('加载统计数据失败');

--- a/frontend/src/components/ExecutionPanel.tsx
+++ b/frontend/src/components/ExecutionPanel.tsx
@@ -102,7 +102,8 @@ export function ExecutionPanel({ collapsed, onToggleCollapse, hidden, onTemporar
       return;
     }
     try {
-      await stopExecution(record.id);
+      // v1 纯 workspace-scoped：stopExecution 需 workspaceId
+      await stopExecution(state.selectedWorkspace ?? 0, record.id);
       message.success('已停止执行');
     } catch (err) {
       message.error(`停止失败: ${err}`);

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -161,6 +161,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
 
     try {
       const updated = await db.updateTodo(
+        todo.workspace_id!,
         todoId,
         todo.title,
         todo.prompt || '',

--- a/frontend/src/components/LoopFormModal.tsx
+++ b/frontend/src/components/LoopFormModal.tsx
@@ -94,6 +94,7 @@ export function LoopFormModal({
   const { dirs: projectDirs } = useProjectDirectories();
 
   // 打开时 + 工作空间变化时重新加载评审模板选项（按 workspace_id 过滤）
+  // review-templates 为全局路由（interceptor 加 v1 前缀），workspaceId 仍作 query param
   useEffect(() => {
     if (!open) return;
     dbReviewTemplates.listReviewTemplateOptions(workspaceId ?? undefined)
@@ -105,7 +106,9 @@ export function LoopFormModal({
   // 必须按当前 loop 的 workspace_id 过滤——异常处理 handler 跨工作空间串进来会触发错乱执行。
   useEffect(() => {
     if (!open) return;
-    dbTodos.getAllTodos(workspaceId ?? undefined)
+    // workspaceId 必须有值才能查 todos（v1 纯 workspace-scoped）
+    if (workspaceId == null) return;
+    dbTodos.getAllTodos(workspaceId)
       .then(setAbnormalHandlerTodoOptions)
       .catch(() => { /* 静默 */ });
   }, [open, workspaceId]);
@@ -214,7 +217,7 @@ export function LoopFormModal({
       };
 
       if (mode === 'create') {
-        const res = await dbLoops.createLoop({
+        const res = await dbLoops.createLoop(basePayload.workspace_id ?? 0, {
           name: basePayload.name,
           description: basePayload.description,
           workspace_id: basePayload.workspace_id,
@@ -231,7 +234,7 @@ export function LoopFormModal({
       } else {
         // 编辑模式
         if (!loopId) return;
-        await dbLoops.updateLoop(loopId, basePayload);
+        await dbLoops.updateLoop(basePayload.workspace_id ?? 0, loopId, basePayload);
         message.success('已保存');
         onSaved();
       }

--- a/frontend/src/components/LoopPage.tsx
+++ b/frontend/src/components/LoopPage.tsx
@@ -94,10 +94,11 @@ export function LoopPage({
   const detailPanel = selectedLoopId !== null ? (
     <LoopDetailPanel
       loopId={selectedLoopId}
+      workspaceId={workspaceId ?? null}
       tags={tags}
       onTrigger={async () => {
         try {
-          const res = await dbLoops.triggerLoop(selectedLoopId);
+          const res = await dbLoops.triggerLoop(workspaceId ?? 0, selectedLoopId);
           message.success(`已触发 (execution #${res.execution_id})`);
         } catch (err) {
           message.error(`触发失败: ${err instanceof Error ? err.message : '未知错误'}`);
@@ -105,7 +106,7 @@ export function LoopPage({
       }}
       onDuplicate={async () => {
         try {
-          await dbLoops.duplicateLoop(selectedLoopId);
+          await dbLoops.duplicateLoop(workspaceId ?? 0, selectedLoopId);
           message.success('已复制');
         } catch (err) {
           message.error(`复制失败: ${err instanceof Error ? err.message : '未知错误'}`);
@@ -113,7 +114,7 @@ export function LoopPage({
       }}
       onDelete={async () => {
         try {
-          await dbLoops.deleteLoop(selectedLoopId);
+          await dbLoops.deleteLoop(workspaceId ?? 0, selectedLoopId);
           message.success('已删除');
           onLoopChanged();
         } catch {
@@ -122,11 +123,11 @@ export function LoopPage({
       }}
       onToggleStatus={async () => {
         try {
-          const loops = await dbLoops.listLoops();
+          const loops = await dbLoops.listLoops(workspaceId ?? null);
           const loop = loops.find(l => l.id === selectedLoopId);
           if (!loop) return;
           const next = loop.status === 'enabled' ? 'paused' : 'enabled';
-          await dbLoops.updateLoopStatus(selectedLoopId, { status: next } as any);
+          await dbLoops.updateLoopStatus(workspaceId ?? 0, selectedLoopId, { status: next } as any);
           message.success(`已${next === 'enabled' ? '启用' : '暂停'}`);
         } catch (err) {
           message.error(`状态切换失败: ${err instanceof Error ? err.message : '未知错误'}`);

--- a/frontend/src/components/LoopStudioDetailPanel.tsx
+++ b/frontend/src/components/LoopStudioDetailPanel.tsx
@@ -35,6 +35,8 @@ import { LoopExecutionsPanel } from './loop-studio/executions';
 
 interface LoopDetailPanelProps {
   loopId: number;
+  /** 当前工作空间 ID（v1 路由 workspace-scoped，loop 查询必需） */
+  workspaceId: number | null;
   /** 可用标签列表（复用 Todo 的标签体系） */
   tags: Array<{ id: number; name: string; color: string }>;
   onTrigger: () => void;
@@ -47,6 +49,7 @@ interface LoopDetailPanelProps {
 
 export function LoopDetailPanel({
   loopId,
+  workspaceId,
   tags,
   onTrigger,
   onDuplicate,
@@ -66,7 +69,7 @@ export function LoopDetailPanel({
   // 导出环路
   const handleExport = async () => {
     try {
-      const yaml = await dbLoops.exportLoop(loopId);
+      const yaml = await dbLoops.exportLoop(workspaceId ?? 0, loopId);
       const blob = new Blob([yaml], { type: 'application/x-yaml' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -109,7 +112,7 @@ export function LoopDetailPanel({
     // 捕获本次请求所属的 loopId，resolve 后与最新值比较
     const id = loopId;
     setLoading(true);
-    dbLoops.getLoop(id)
+    dbLoops.getLoop(workspaceId ?? 0, id)
       .then((d) => {
         if (latestLoopIdRef.current !== id) return; // 已切换到别的 loop，丢弃
         setDetail(d);
@@ -130,7 +133,7 @@ export function LoopDetailPanel({
       .finally(() => {
         if (latestLoopIdRef.current === id) setLoading(false);
       });
-  }, [loopId, antMessage]);
+  }, [loopId, workspaceId, antMessage]);
 
   useEffect(() => { reload(); }, [reload]);
 
@@ -138,7 +141,7 @@ export function LoopDetailPanel({
   useEffect(() => {
     // 捕获本次 loopId，resolve 后比较，丢弃切换后的 stale 响应
     const id = loopId;
-    dbLoops.listExecutions(id, { page: 1, limit: 1 })
+    dbLoops.listExecutions(workspaceId ?? 0, id, { page: 1, limit: 1 })
       .then(res => { if (latestLoopIdRef.current === id) setExecutionTotal(res.total); })
       .catch(() => { /* 静默 */ });
   }, [loopId]);
@@ -454,7 +457,7 @@ export function LoopDetailPanel({
               ),
               children: (
                 <div style={{ paddingTop: 4 }}>
-                  <LoopExecutionsPanel loopId={loopId} loopName={detail.name} onTotalChange={setExecutionTotal} />
+                  <LoopExecutionsPanel loopId={loopId} workspaceId={detail.workspace_id} loopName={detail.name} onTotalChange={setExecutionTotal} />
                 </div>
               ),
             },

--- a/frontend/src/components/LoopStudioStepsPanel.tsx
+++ b/frontend/src/components/LoopStudioStepsPanel.tsx
@@ -92,13 +92,18 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
    */
   const loadCandidatesForCurrentLoop = useCallback(async (stepForEdit: LoopStepDto | null) => {
     try {
-      const list = await db.getAllTodos(workspaceId ?? undefined);
+      // workspaceId 必须有值才能查 todos（v1 纯 workspace-scoped）
+      if (workspaceId == null) {
+        setCandidates([]);
+        return;
+      }
+      const list = await db.getAllTodos(workspaceId);
       // 编辑模式下若已绑定的 todo 不在过滤结果里，附加一次单条查询补回选项，
       // 确保用户依然能在下拉里看到/选中当前关联的 todo。
       // 不附加 workspaceId 过滤，因为这条记录可能原本属于其他工作空间。
       if (stepForEdit && !list.some(t => t.id === stepForEdit.todo_id)) {
         try {
-          const current = await db.getTodo(stepForEdit.todo_id);
+          const current = await db.getTodo(workspaceId, stepForEdit.todo_id);
           if (current) setCandidates([...list, current]);
           else setCandidates(list);
         } catch {
@@ -129,7 +134,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
     setSaving(true);
     try {
       if (editingStep) {
-        await dbLoops.updateLoopStep(loopId, editingStep.id, {
+        await dbLoops.updateLoopStep(workspaceId ?? 0, loopId, editingStep.id, {
           name: values.name.trim(),
           description: values.description ?? '',
           todo_id: values.todo_id,
@@ -146,7 +151,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
         });
         message.success('环节已更新');
       } else {
-        await dbLoops.createLoopStep(loopId, {
+        await dbLoops.createLoopStep(workspaceId ?? 0, loopId, {
           name: values.name.trim(),
           description: values.description ?? '',
           todo_id: values.todo_id,
@@ -175,7 +180,7 @@ export function LoopStepsPanel({ loopId, steps, onChanged, maxStepExecutions, ma
   // 删除环节
   const handleDelete = useCallback(async (stepId: number) => {
     try {
-      await dbLoops.deleteLoopStep(loopId, stepId);
+      await dbLoops.deleteLoopStep(workspaceId ?? 0, loopId, stepId);
       message.success('环节已删除');
       onChanged();
     } catch {

--- a/frontend/src/components/MessagesPage.tsx
+++ b/frontend/src/components/MessagesPage.tsx
@@ -164,7 +164,7 @@ export function MessagesPage({ workspaceId, onManageWorkspace }: MessagesPagePro
 
   const handleViewExecutionRecord = async (recordId: number) => {
     try {
-      const r = await db.getExecutionRecord(recordId);
+      const r = await db.getExecutionRecord(workspaceId ?? 0, recordId);
       setExecDetailRecord(r);
     } catch {
     }
@@ -174,7 +174,7 @@ export function MessagesPage({ workspaceId, onManageWorkspace }: MessagesPagePro
   const handleViewLoopExecution = async (msg: FeishuHistoryMessage) => {
     if (!msg.processed_id) return;
     try {
-      const detail = await dbLoops.getExecutionById(msg.processed_id);
+      const detail = await dbLoops.getExecutionById(workspaceId ?? 0, msg.processed_id);
       setBlackboardExecs(detail.step_executions || []);
       setBlackboardOpen(true);
     } catch {
@@ -366,6 +366,7 @@ export function MessagesPage({ workspaceId, onManageWorkspace }: MessagesPagePro
       <BlackboardDrawer
         open={blackboardOpen}
         stepExecs={blackboardExecs}
+        workspaceId={workspaceId ?? 0}
         onClose={() => setBlackboardOpen(false)}
       />
     </PageCard>

--- a/frontend/src/components/QuickCaptureModal.tsx
+++ b/frontend/src/components/QuickCaptureModal.tsx
@@ -121,6 +121,7 @@ export function QuickCaptureModal({
       // 避免后端已设为默认值后又重复更新的冗余操作）
       if (executor !== getDefaultExecutor()) {
         await db.updateTodo(
+          workspaceId,
           todo.id,
           title,
           trimmed,
@@ -180,6 +181,7 @@ export function QuickCaptureModal({
       // 避免后端已设为默认值后又重复更新的冗余操作）
       if (executor !== getDefaultExecutor()) {
         await db.updateTodo(
+          workspaceId,
           todo.id,
           title,
           trimmed,
@@ -189,7 +191,7 @@ export function QuickCaptureModal({
       }
 
       // 立即执行任务
-      const result = await db.executeTodo(todo.id, executor);
+      const result = await db.executeTodo(workspaceId, todo.id, executor);
       // 成功提示
       message.success('已创建并开始执行');
       // 通知父组件任务已执行

--- a/frontend/src/components/RunningRecordDrawer.tsx
+++ b/frontend/src/components/RunningRecordDrawer.tsx
@@ -90,14 +90,14 @@ function ReviewStatusBadge({ status }: { status?: string | null }) {
 
 /* ─── Log View ─── */
 
-function LogView({ record }: { record: ExecutionRecord }) {
+function LogView({ record, workspaceId }: { record: ExecutionRecord; workspaceId: number }) {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (record.status === 'running') return;
     setLoading(true);
-    db.getExecutionLogs(record.id, 1, 500)
+    db.getExecutionLogs(workspaceId, record.id, 1, 500)
       .then(r => setLogs(r.logs))
       .catch(() => setLogs([]))
       .finally(() => setLoading(false));
@@ -146,21 +146,23 @@ export function RunningRecordDrawer({ record, open, onClose, onRefresh }: Runnin
     }
   }, [record, selectTodo, onClose]);
 
+  const wsId = state.selectedWorkspace ?? 0;
+
   const handleStop = useCallback(async () => {
     if (!record) return;
     setStopping(true);
     try {
-      await db.stopExecution(record.id);
+      await db.stopExecution(wsId, record.id);
       onRefresh?.();
     } catch {} finally {
       setStopping(false);
     }
-  }, [record, onRefresh]);
+  }, [record, wsId, onRefresh]);
 
   const handleRate = useCallback(async (id: number, rating: number | null) => {
-    await db.rateExecutionRecord(id, rating);
+    await db.rateExecutionRecord(wsId, id, rating);
     onRefresh?.();
-  }, [onRefresh]);
+  }, [wsId, onRefresh]);
 
   if (!record) return null;
 
@@ -313,7 +315,7 @@ export function RunningRecordDrawer({ record, open, onClose, onRefresh }: Runnin
         items={[{
           key: 'logs',
           label: '执行日志',
-          children: <LogView record={record} />,
+          children: <LogView record={record} workspaceId={wsId} />,
         }]}
       />
     </Drawer>

--- a/frontend/src/components/SmartCreateModal.tsx
+++ b/frontend/src/components/SmartCreateModal.tsx
@@ -10,11 +10,13 @@ interface SmartCreateModalProps {
   onClose: () => void;
   isMobile: boolean;
   config: Config | null;
+  /** 当前工作空间 ID（v1 路由 workspace-scoped，smart-create 必需） */
+  workspaceId: number | null;
   onGoToSettings?: () => void;
   onSubmitted?: () => void;
 }
 
-export function SmartCreateModal({ open, onClose, isMobile, config, onGoToSettings, onSubmitted }: SmartCreateModalProps) {
+export function SmartCreateModal({ open, onClose, isMobile, config, workspaceId, onGoToSettings, onSubmitted }: SmartCreateModalProps) {
   const [content, setContent] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const textAreaRef = useRef<InputRef>(null);
@@ -40,7 +42,7 @@ export function SmartCreateModal({ open, onClose, isMobile, config, onGoToSettin
 
     setSubmitting(true);
     try {
-      const result = await smartCreate(trimmed);
+      const result = await smartCreate(workspaceId ?? 0, trimmed);
       const title = result.todo_title.length > 20
         ? result.todo_title.slice(0, 20) + '...'
         : result.todo_title;

--- a/frontend/src/components/TodoCenterCard.tsx
+++ b/frontend/src/components/TodoCenterCard.tsx
@@ -53,6 +53,8 @@ interface TodoCenterCardProps {
  * 避免重蹈当前密集列表「操作按钮挤在行里」的覆辙。
  */
 export function TodoCenterCard({ item, onChanged, onSelectTodo, onSelectLoop }: TodoCenterCardProps) {
+  // workspaceId 从 item 提取：TodoCenter 列表来自 workspace-scoped 查询，workspace_id 必有
+  const wsId = item.workspace_id!;
   // busy 覆盖所有异步操作（执行/归档/恢复/webhook/调度/复制/移动），防止并发重复点击
   const [busy, setBusy] = useState(false);
   const [schedOpen, setSchedOpen] = useState(false);
@@ -87,10 +89,11 @@ export function TodoCenterCard({ item, onChanged, onSelectTodo, onSelectLoop }: 
 
   // 弹窗确认：落库调度配置（设为/恢复时间驱动走同一条 PUT /scheduler）。
   const saveScheduler = () =>
-    runMutation('保存调度', () => db.updateScheduler(item.id, schedEnabled, schedConfig || null));
+    runMutation('保存调度', () => db.updateScheduler(wsId, item.id, schedEnabled, schedConfig || null));
 
   const menuItems = buildMenuItems(
     item,
+    wsId,
     isArchived,
     runMutation,
     openSchedulerModal,
@@ -106,7 +109,7 @@ export function TodoCenterCard({ item, onChanged, onSelectTodo, onSelectLoop }: 
       loading={busy}
       onClick={(e) => {
         e.stopPropagation();
-        runMutation('恢复', () => db.restoreTodo(item.id));
+        runMutation('恢复', () => db.restoreTodo(wsId, item.id));
       }}
     >
       恢复
@@ -130,7 +133,7 @@ export function TodoCenterCard({ item, onChanged, onSelectTodo, onSelectLoop }: 
       loading={busy}
       onClick={(e) => {
         e.stopPropagation();
-        runMutation('执行', () => db.executeTodo(item.id));
+        runMutation('执行', () => db.executeTodo(wsId, item.id));
       }}
     >
       执行一次
@@ -404,6 +407,7 @@ function SchedulerModal({
 /** 构建「更多」菜单项。按是否归档/是否时间驱动分支，保持单函数简短。 */
 function buildMenuItems(
   item: TodoCenterItem,
+  wsId: number,
   isArchived: boolean,
   runMutation: (label: string, fn: () => Promise<unknown>) => void,
   openSchedulerModal: () => void,
@@ -415,9 +419,9 @@ function buildMenuItems(
       {
         key: 'restore',
         label: '恢复事项',
-        onClick: () => runMutation('恢复', () => db.restoreTodo(item.id)),
+        onClick: () => runMutation('恢复', () => db.restoreTodo(wsId, item.id)),
       },
-      deleteMenuItem(item, runMutation),
+      deleteMenuItem(item, wsId, runMutation),
     ];
   }
   // Loop 驱动卡片不提供复制/移动（设计文档 Loop 驱动操作列表不含这两项）：
@@ -431,9 +435,9 @@ function buildMenuItems(
           { key: 'move', label: '移动到工作空间', onClick: () => openWorkspacePicker('move') },
         ];
   return [
-    archiveMenuItem(item, runMutation),
-    ...timeDrivenMenuItems(item, runMutation, openSchedulerModal),
-    webhookMenuItem(item, runMutation),
+    archiveMenuItem(item, wsId, runMutation),
+    ...timeDrivenMenuItems(item, wsId, runMutation, openSchedulerModal),
+    webhookMenuItem(item, wsId, runMutation),
     ...workspaceItems,
   ];
 }
@@ -441,6 +445,7 @@ function buildMenuItems(
 /** 删除菜单项：Modal.confirm 二次确认。被 Loop 引用时后端返回 400，runMutation 会提示。 */
 function deleteMenuItem(
   item: TodoCenterItem,
+  wsId: number,
   runMutation: (label: string, fn: () => Promise<unknown>) => void,
 ): NonNullable<MenuProps['items']>[number] {
   return {
@@ -454,7 +459,7 @@ function deleteMenuItem(
         okText: '删除',
         okButtonProps: { danger: true },
         cancelText: '取消',
-        onOk: () => runMutation('删除', () => db.deleteTodo(item.id)),
+        onOk: () => runMutation('删除', () => db.deleteTodo(wsId, item.id)),
       }),
   };
 }
@@ -462,6 +467,7 @@ function deleteMenuItem(
 /** 归档菜单项：被 Loop 引用时给出更强的归档不解除引用提示（设计文档风险三）。 */
 function archiveMenuItem(
   item: TodoCenterItem,
+  wsId: number,
   runMutation: (label: string, fn: () => Promise<unknown>) => void,
 ): NonNullable<MenuProps['items']>[number] {
   const loopHint =
@@ -477,7 +483,7 @@ function archiveMenuItem(
         content: `${loopHint}已归档事项可在「已归档」分类恢复。`,
         okText: '归档',
         cancelText: '取消',
-        onOk: () => runMutation('归档', () => db.archiveTodo(item.id)),
+        onOk: () => runMutation('归档', () => db.archiveTodo(wsId, item.id)),
       }),
   };
 }
@@ -485,6 +491,7 @@ function archiveMenuItem(
 /** 时间驱动菜单项：设为/暂停/恢复/取消。scheduler_config 为空=尚未时间驱动。 */
 function timeDrivenMenuItems(
   item: TodoCenterItem,
+  wsId: number,
   runMutation: (label: string, fn: () => Promise<unknown>) => void,
   openSchedulerModal: () => void,
 ): NonNullable<MenuProps['items']> {
@@ -501,13 +508,13 @@ function timeDrivenMenuItems(
         key: 'pause_time',
         label: '暂停时间驱动',
         // 暂停：关 enabled，保留 config（仍属时间驱动，卡片标已暂停）
-        onClick: () => runMutation('暂停时间驱动', () => db.updateScheduler(item.id, false, item.scheduler_config ?? null)),
+        onClick: () => runMutation('暂停时间驱动', () => db.updateScheduler(wsId, item.id, false, item.scheduler_config ?? null)),
       }
     : {
         key: 'resume_time',
         label: '恢复时间驱动',
         // 恢复：开 enabled，保留 config
-        onClick: () => runMutation('恢复时间驱动', () => db.updateScheduler(item.id, true, item.scheduler_config ?? null)),
+        onClick: () => runMutation('恢复时间驱动', () => db.updateScheduler(wsId, item.id, true, item.scheduler_config ?? null)),
       };
   const edit = { key: 'edit_time', label: '编辑调度配置', onClick: openSchedulerModal };
   const cancel = {
@@ -520,7 +527,7 @@ function timeDrivenMenuItems(
         okText: '取消时间驱动',
         cancelText: '保留',
         // 取消：关 enabled 且清空 config
-        onOk: () => runMutation('取消时间驱动', () => db.updateScheduler(item.id, false, null)),
+        onOk: () => runMutation('取消时间驱动', () => db.updateScheduler(wsId, item.id, false, null)),
       }),
   };
   return [pauseResume, edit, cancel];
@@ -529,13 +536,14 @@ function timeDrivenMenuItems(
 /** 事件驱动菜单项：开启/关闭 webhook，与 scheduler 端点对称。 */
 function webhookMenuItem(
   item: TodoCenterItem,
+  wsId: number,
   runMutation: (label: string, fn: () => Promise<unknown>) => void,
 ): NonNullable<MenuProps['items']>[number] {
   const on = item.webhook_enabled;
   return {
     key: 'webhook',
     label: on ? '关闭事件驱动' : '设为事件驱动',
-    onClick: () => runMutation(on ? '关闭事件驱动' : '设为事件驱动', () => db.updateTodoWebhook(item.id, !on)),
+    onClick: () => runMutation(on ? '关闭事件驱动' : '设为事件驱动', () => db.updateTodoWebhook(wsId, item.id, !on)),
   };
 }
 
@@ -577,10 +585,12 @@ function WorkspaceMoveCopyModal({
     if (targetId == null) return;
     setLoading(true);
     try {
+      // currentWorkspaceId 作为 URL 路径段（源空间），targetId 为目标空间（body）
+      const srcWs = currentWorkspaceId ?? 0;
       if (mode === 'copy') {
-        await db.batchCopyTodosWorkspace([todoId], targetId);
+        await db.batchCopyTodosWorkspace(srcWs, [todoId], targetId);
       } else if (mode === 'move') {
-        await db.batchMoveTodosWorkspace([todoId], targetId);
+        await db.batchMoveTodosWorkspace(srcWs, [todoId], targetId);
       }
       message.success(mode === 'copy' ? '已复制' : '已移动');
       onDone();

--- a/frontend/src/components/TodoCenterCardView.tsx
+++ b/frontend/src/components/TodoCenterCardView.tsx
@@ -57,7 +57,8 @@ export function TodoCenterCardView({
   refreshKey,
 }: TodoCenterCardViewProps) {
   const { state } = useApp();
-  const workspaceId = state.selectedWorkspace ?? undefined;
+  // v1 纯 workspace-scoped：selectedWorkspace 必须有值才能拉 todos/center
+  const workspaceId = state.selectedWorkspace ?? 0;
 
   // 全量事项（后端已按 computed_bucket 分桶补算），前端再做筛选/分组
   const [items, setItems] = useState<TodoCenterItem[]>([]);

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -43,6 +43,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
     handleHistoryPageChange,
   } = useExecutionHistory({
     selectedTodoId,
+    workspaceId: state.selectedWorkspace,
     storeRecords: selectedTodoId ? executionRecords[selectedTodoId] : [],
     dispatch,
   });
@@ -95,6 +96,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
     if (!selectedTodo) return;
     try {
       const result = await db.executeTodo(
+        selectedTodo.workspace_id!,
         selectedTodo.id,
         selectedTodo.executor || undefined,
         undefined
@@ -102,7 +104,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
       message.success('任务已开始执行');
       // 获取新创建的执行记录并立即添加到状态中
       try {
-        const newRecord = await db.getExecutionRecord(result.record_id);
+        const newRecord = await db.getExecutionRecord(selectedTodo.workspace_id!, result.record_id);
         dispatch({
           type: 'ADD_EXECUTION_RECORD',
           payload: { todoId: selectedTodo.id, record: newRecord }
@@ -133,6 +135,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
     try {
       const params = executeArgs.trim() ? { message: executeArgs.trim() } : undefined;
       const result = await db.executeTodo(
+        selectedTodo.workspace_id!,
         selectedTodo.id,
         selectedTodo.executor || undefined,
         params
@@ -142,7 +145,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
       setExecuteArgs('');
       // 获取新创建的执行记录并立即添加到状态中
       try {
-        const newRecord = await db.getExecutionRecord(result.record_id);
+        const newRecord = await db.getExecutionRecord(selectedTodo.workspace_id!, result.record_id);
         dispatch({
           type: 'ADD_EXECUTION_RECORD',
           payload: { todoId: selectedTodo.id, record: newRecord }
@@ -165,7 +168,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
   const handleStatusChange = useCallback(async (newStatus: string) => {
     if (!selectedTodo) return;
     try {
-      const updated = await db.updateTodo(selectedTodo.id, selectedTodo.title, selectedTodo.prompt || '', newStatus);
+      const updated = await db.updateTodo(selectedTodo.workspace_id!, selectedTodo.id, selectedTodo.title, selectedTodo.prompt || '', newStatus);
       dispatch({ type: 'UPDATE_TODO', payload: updated });
       message.success('状态已更新');
     } catch {
@@ -181,6 +184,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
       throw new Error('无法从 AI 结果中提取标题');
     }
     const updated = await db.updateTodo(
+      selectedTodo.workspace_id!,
       selectedTodo.id,
       newTitle,
       selectedTodo.prompt || '',
@@ -201,7 +205,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost }: TodoDetailProps
   const handleDelete = async () => {
     if (!selectedTodo) return;
     try {
-      await db.deleteTodo(selectedTodo.id);
+      await db.deleteTodo(selectedTodo.workspace_id!, selectedTodo.id);
       dispatch({ type: 'DELETE_TODO', payload: selectedTodo.id });
       dispatch({ type: 'SELECT_TODO', payload: null });
       message.success('删除成功');

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -223,6 +223,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
       if (isEditMode && todo) {
         // WorkspaceSelect 只允许从下拉列表选择，无需二次校验
         await db.updateTodo(
+          workspaceToSave!,
           todo.id, title.trim(), prompt.trim(), todo.status,
           executor, schedulerEnabled, schedulerConfig || null,
           workspaceToSave,
@@ -233,8 +234,8 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
           // 编辑保存：null → '' 清除任务级模型，非空 → 设置；与表单值同步。
           model ?? '',
         );
-        await db.updateScheduler(todo.id, schedulerEnabled, schedulerConfig || null);
-        await db.updateTodoTags(todo.id, selectedTags);
+        await db.updateScheduler(workspaceToSave!, todo.id, schedulerEnabled, schedulerConfig || null);
+        await db.updateTodoTags(workspaceToSave!, todo.id, selectedTags);
         message.success('任务已更新');
       } else {
         const newTodo = await db.createTodo(
@@ -252,7 +253,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
 
         if (workspaceToSave != null || schedulerEnabled || executor !== getDefaultExecutor() || webhookEnabled || expertName) {
           await db.updateTodo(
-            newTodo.id, newTodo.title, newTodo.prompt, newTodo.status,
+            workspaceToSave!, newTodo.id, newTodo.title, newTodo.prompt, newTodo.status,
             executor, schedulerEnabled, schedulerConfig || null,
             workspaceToSave,
             webhookEnabled,
@@ -262,7 +263,7 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
             // 创建后同步：与编辑一致，null → '' 清除，非空 → 设置。
             model ?? '',
           );
-          await db.updateScheduler(newTodo.id, schedulerEnabled, schedulerConfig || null);
+          await db.updateScheduler(workspaceToSave!, newTodo.id, schedulerEnabled, schedulerConfig || null);
         }
 
         message.success('任务创建成功');

--- a/frontend/src/components/WikiViewPage.tsx
+++ b/frontend/src/components/WikiViewPage.tsx
@@ -19,9 +19,9 @@ interface WikiFileContent {
   content: string;
 }
 
-/** 拉取单个 Wiki 文件内容 */
+/** 拉取单个 Wiki 文件内容（原生 fetch，手动写 v1 路径） */
 async function fetchWikiFileContent(workspaceId: number, slug: string): Promise<WikiFileContent> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/wiki/files/${encodeURIComponent(slug)}`);
+  const res = await fetch(`/api/v1/workspaces/${workspaceId}/wiki/files/${encodeURIComponent(slug)}`);
   if (!res.ok) {
     throw new Error(`HTTP ${res.status}`);
   }

--- a/frontend/src/components/blackboard-proposal/ProposalCompleted.tsx
+++ b/frontend/src/components/blackboard-proposal/ProposalCompleted.tsx
@@ -89,7 +89,7 @@ async function createProposedTodos(
     // 因此必须检查返回值，否则执行器设置失败时会误报成功
     let executorFailed = 0;
     if (ids.length > 0) {
-      const result = await batchUpdateTodosExecutor(ids, PROPOSAL_EXECUTOR);
+      const result = await batchUpdateTodosExecutor(workspaceId, ids, PROPOSAL_EXECUTOR);
       executorFailed = result.failed.length;
     }
     if (executorFailed > 0) {

--- a/frontend/src/components/dashboard/cards/CronTodosCard.tsx
+++ b/frontend/src/components/dashboard/cards/CronTodosCard.tsx
@@ -5,6 +5,7 @@ import { ClockCircleOutlined } from '@ant-design/icons';
 import { getSchedulerTodos } from '@/utils/database/todos';
 import { formatRelativeTime } from '@/utils/datetime';
 import { useCardData } from '@/components/dashboard/useCardData';
+import { useApp } from '@/hooks/useApp';
 import { CardShell } from './CardShell';
 
 // 下次触发时间渲染成相对时间(如「2 小时后」);缺失则该 todo 未真正排程。
@@ -18,7 +19,10 @@ function NextRunTag({ next }: { next: string | null | undefined }) {
 }
 
 export function CronTodosCard() {
-  const { data, loading, error } = useCardData(getSchedulerTodos);
+  const { state } = useApp();
+  const wsId = state.selectedWorkspace ?? 0;
+  // v1 纯 workspace-scoped：scheduler todos 按 workspace 隔离
+  const { data, loading, error } = useCardData(() => getSchedulerTodos(wsId), [wsId]);
   const todos = data ?? [];
   return (
     <CardShell icon={<ClockCircleOutlined />} title={`时间驱动 todo(${todos.length})`} loading={loading} error={error}>

--- a/frontend/src/components/dashboard/cards/LoopStatsCard.tsx
+++ b/frontend/src/components/dashboard/cards/LoopStatsCard.tsx
@@ -5,6 +5,7 @@ import { Statistic, Row, Col, Tag } from 'antd';
 import { RetweetOutlined } from '@ant-design/icons';
 import { getLoopStats } from '@/utils/database/loops';
 import { useCardData } from '@/components/dashboard/useCardData';
+import { useApp } from '@/hooks/useApp';
 import { CardShell } from './CardShell';
 
 // trigger_type 枚举值 → 中文,提升可读性;未知值原样回退。
@@ -22,7 +23,9 @@ const TRIGGER_LABEL: Record<string, string> = {
 };
 
 export function LoopStatsCard({ hours }: { hours?: number }) {
-  const { data, loading, error } = useCardData(() => getLoopStats(hours), [hours]);
+  const { state } = useApp();
+  const wsId = state.selectedWorkspace ?? 0;
+  const { data, loading, error } = useCardData(() => getLoopStats(wsId, hours), [wsId, hours]);
   // 成功率 = success / total;total=0 时归 0,避免除零。
   const successRate =
     data && data.total_executions > 0

--- a/frontend/src/components/dashboard/cards/RatingDistCard.tsx
+++ b/frontend/src/components/dashboard/cards/RatingDistCard.tsx
@@ -4,6 +4,7 @@ import { Progress } from 'antd';
 import { StarOutlined } from '@ant-design/icons';
 import { getRecentCompletedTodos } from '@/utils/database/executions';
 import { useCardData } from '@/components/dashboard/useCardData';
+import { useApp } from '@/hooks/useApp';
 import { CardShell } from './CardShell';
 
 interface RatingBuckets {
@@ -49,7 +50,9 @@ function RatingBar({ label, count, total, color }: RatingBarProps) {
 }
 
 export function RatingDistCard() {
-  const { data, loading, error } = useCardData(() => getRecentCompletedTodos());
+  const { state } = useApp();
+  const wsId = state.selectedWorkspace ?? 0;
+  const { data, loading, error } = useCardData(() => getRecentCompletedTodos(wsId), [wsId]);
   const buckets = bucketize((data ?? []).map((t) => t.rating));
   return (
     <CardShell icon={<StarOutlined />} title="评分分布" loading={loading} error={error}>

--- a/frontend/src/components/loop-kanban/index.tsx
+++ b/frontend/src/components/loop-kanban/index.tsx
@@ -37,7 +37,8 @@ export function LoopKanban({ searchText: externalSearch, hours: externalHours, o
   const { message } = AntApp.useApp();
   const { state } = useApp();
 
-  const { executions, loading } = useLoopExecutions(state.selectedWorkspace, hours);
+  const { executions, loading } = useLoopExecutions(state.selectedWorkspace ?? null, hours);
+  const wsId = state.selectedWorkspace ?? 0;
 
   // ── 轨迹侧边栏状态 ────────────────────────────────────
   const [selectedExec, setSelectedExec] = useState<LoopExecutionWithLoopName | null>(null);
@@ -54,8 +55,8 @@ export function LoopKanban({ searchText: externalSearch, hours: externalHours, o
     setLoopDetail(null);
     try {
       const [detail, loop] = await Promise.all([
-        dbLoops.getExecution(exec.loop_id, exec.id),
-        dbLoops.getLoop(exec.loop_id),
+        dbLoops.getExecution(wsId, exec.loop_id, exec.id),
+        dbLoops.getLoop(wsId, exec.loop_id),
       ]);
       setExecDetail(detail);
       setLoopDetail(loop);
@@ -72,7 +73,7 @@ export function LoopKanban({ searchText: externalSearch, hours: externalHours, o
 
   const handleOpenBlackboard = useCallback(async (exec: LoopExecutionWithLoopName) => {
     try {
-      const detail = await dbLoops.getExecution(exec.loop_id, exec.id);
+      const detail = await dbLoops.getExecution(wsId, exec.loop_id, exec.id);
       setBlackboardExecs(detail.step_executions);
       setBlackboardOpen(true);
     } catch {
@@ -216,9 +217,10 @@ export function LoopKanban({ searchText: externalSearch, hours: externalHours, o
               <StepExecList
                 stepExecs={execDetail.step_executions}
                 loopId={execDetail.loop_id}
+                workspaceId={wsId}
                 executionId={execDetail.id}
                 onApproved={() => {
-                  dbLoops.getExecution(selectedExec.loop_id, selectedExec.id)
+                  dbLoops.getExecution(wsId, selectedExec.loop_id, selectedExec.id)
                     .then(setExecDetail)
                     .catch(() => {});
                 }}
@@ -234,6 +236,7 @@ export function LoopKanban({ searchText: externalSearch, hours: externalHours, o
       <BlackboardDrawer
         open={blackboardOpen}
         stepExecs={blackboardExecs}
+        workspaceId={wsId}
         onClose={() => setBlackboardOpen(false)}
       />
     </div>

--- a/frontend/src/components/loop-kanban/useLoopExecutions.ts
+++ b/frontend/src/components/loop-kanban/useLoopExecutions.ts
@@ -28,7 +28,7 @@ export function useLoopExecutions(workspaceId?: number | null, hours?: number) {
     setAllLoops([]);
     setExecutions([]);
     setLoading(true);
-    dbLoops.listLoops(workspaceId ?? undefined)
+    dbLoops.listLoops(workspaceId ?? null)
       .then(data => { if (!ignore) setAllLoops(data); })
       .catch(() => { if (!ignore) setAllLoops([]); })
       .finally(() => { if (!ignore) setLoading(false); });
@@ -46,7 +46,7 @@ export function useLoopExecutions(workspaceId?: number | null, hours?: number) {
 
     Promise.all(
       allLoops.map(loop =>
-        dbLoops.listExecutions(loop.id, { page: 1, limit: 20, hours: hours ?? undefined })
+        dbLoops.listExecutions(workspaceId ?? 0, loop.id, { page: 1, limit: 20, hours: hours ?? undefined })
           .then(res => res.items.map(e => ({ ...e, loop_name: loop.name })))
           .catch(() => [])
       )

--- a/frontend/src/components/loop-studio/executions/BlackboardDrawer.tsx
+++ b/frontend/src/components/loop-studio/executions/BlackboardDrawer.tsx
@@ -19,10 +19,12 @@ import { execStatusView } from './helpers';
 interface BlackboardDrawerProps {
   open: boolean;
   stepExecs: Record<string, any>[];
+  /** 当前工作空间 ID（v1 路由 workspace-scoped） */
+  workspaceId: number;
   onClose: () => void;
 }
 
-export function BlackboardDrawer({ open, stepExecs, onClose }: BlackboardDrawerProps) {
+export function BlackboardDrawer({ open, stepExecs, workspaceId, onClose }: BlackboardDrawerProps) {
   // ── 执行记录详情 Drawer 状态 ────────────────────────────
   const [detailRecord, setDetailRecord] = useState<any | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
@@ -31,7 +33,7 @@ export function BlackboardDrawer({ open, stepExecs, onClose }: BlackboardDrawerP
   const handleOpenDetail = useCallback(async (executionRecordId: number) => {
     setDetailLoading(true);
     try {
-      const record = await dbExecutions.getExecutionRecord(executionRecordId);
+      const record = await dbExecutions.getExecutionRecord(workspaceId, executionRecordId);
       setDetailRecord(record);
     } catch {
       // 加载失败不弹窗
@@ -49,7 +51,7 @@ export function BlackboardDrawer({ open, stepExecs, onClose }: BlackboardDrawerP
   const handleOpenLogView = useCallback(async (record: any) => {
     setLogDrawerRecord(record);
     try {
-      const result = await dbExecutions.getExecutionLogs(record.id, 1, 500);
+      const result = await dbExecutions.getExecutionLogs(workspaceId, record.id, 1, 500);
       setLogDrawerLogs(result.logs || []);
     } catch {
       setLogDrawerLogs([]);
@@ -233,7 +235,7 @@ export function BlackboardDrawer({ open, stepExecs, onClose }: BlackboardDrawerP
         isLoadingLogs={false}
         onLoadLogs={async (id, page) => {
           try {
-            const result = await dbExecutions.getExecutionLogs(id, page, 500);
+            const result = await dbExecutions.getExecutionLogs(workspaceId, id, page, 500);
             setLogDrawerLogs(result.logs || []);
           } catch {
             // 加载失败时保持现有日志

--- a/frontend/src/components/loop-studio/executions/StepExecList.tsx
+++ b/frontend/src/components/loop-studio/executions/StepExecList.tsx
@@ -12,11 +12,13 @@ import { execStatusView, durationLabel, formatToken } from './helpers';
 interface StepExecListProps {
   stepExecs: Record<string, any>[];
   loopId: number;
+  /** 当前工作空间 ID（v1 路由 workspace-scoped） */
+  workspaceId: number;
   executionId: number;
   onApproved: () => void;
 }
 
-export function StepExecList({ stepExecs, loopId, executionId, onApproved }: StepExecListProps) {
+export function StepExecList({ stepExecs, loopId, workspaceId, executionId, onApproved }: StepExecListProps) {
   const { message } = AntApp.useApp();
   const [drawerRecord, setDrawerRecord] = useState<any | null>(null);
   const [drawerLoading, setDrawerLoading] = useState(false);
@@ -28,7 +30,7 @@ export function StepExecList({ stepExecs, loopId, executionId, onApproved }: Ste
   const handleOpenLogView = useCallback(async (record: any) => {
     setLogDrawerRecord(record);
     try {
-      const result = await dbExecutions.getExecutionLogs(record.id, 1, 500);
+      const result = await dbExecutions.getExecutionLogs(workspaceId, record.id, 1, 500);
       setLogDrawerLogs(result.logs || []);
     } catch {
       setLogDrawerLogs([]);
@@ -45,7 +47,7 @@ export function StepExecList({ stepExecs, loopId, executionId, onApproved }: Ste
     setDrawerLoading(true);
     try {
       const { getExecutionRecord } = dbExecutions;
-      const rec = await getExecutionRecord(s.execution_record_id);
+      const rec = await getExecutionRecord(workspaceId, s.execution_record_id);
       setDrawerRecord(rec);
     } catch {
       // ignore
@@ -59,7 +61,7 @@ export function StepExecList({ stepExecs, loopId, executionId, onApproved }: Ste
     setApprovingId(stepExecutionId);
     try {
       const { approveStepExecution } = dbLoops;
-      await approveStepExecution(loopId, executionId, stepExecutionId, approveRating, approveComment || undefined);
+      await approveStepExecution(workspaceId, loopId, executionId, stepExecutionId, approveRating, approveComment || undefined);
       message.success('审批已提交');
       // 重置审批表单状态为初始值，防止下一张待审卡片复用上次的评分与备注；
       // 70 分是默认通过评分，空字符串确保备注框干净。

--- a/frontend/src/components/loop-studio/executions/index.tsx
+++ b/frontend/src/components/loop-studio/executions/index.tsx
@@ -26,6 +26,8 @@ import { StepExecList } from './StepExecList';
 
 interface Props {
   loopId: number;
+  /** 当前工作空间 ID（v1 路由 workspace-scoped） */
+  workspaceId: number | null;
   loopName: string;
   onTotalChange?: (total: number) => void;
   onExecutionTrace?: (tracedStepIds: number[], sequenceMap: Record<number, number>) => void;
@@ -33,7 +35,7 @@ interface Props {
 
 const DEFAULT_PAGE_LIMIT = 5;
 
-export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange, onExecutionTrace }: Props) {
+export function LoopExecutionsPanel({ loopId, workspaceId, loopName: _loopName, onTotalChange, onExecutionTrace }: Props) {
   const { message } = AntApp.useApp();
   const [items, setItems] = useState<LoopExecutionDto[]>([]);
   const [total, setTotal] = useState(0);
@@ -59,17 +61,17 @@ export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange
   const handleOpenBlackboardForExec = useCallback(async (ev: React.MouseEvent, execId: number) => {
     ev.stopPropagation();
     try {
-      const detail = await dbLoops.getExecution(loopId, execId);
+      const detail = await dbLoops.getExecution(workspaceId ?? 0, loopId, execId);
       handleOpenBlackboard(detail.step_executions);
     } catch {
       message.error('加载黑板数据失败');
     }
-  }, [loopId, handleOpenBlackboard, message]);
+  }, [loopId, workspaceId, handleOpenBlackboard, message]);
 
   // 加载一页执行记录
   const loadPage = useCallback((p: number) => {
     setLoading(true);
-    dbLoops.listExecutions(loopId, { page: p, limit: DEFAULT_PAGE_LIMIT })
+    dbLoops.listExecutions(workspaceId ?? 0, loopId, { page: p, limit: DEFAULT_PAGE_LIMIT })
       .then((res) => {
         setItems(res.items);
         setTotal(res.total);
@@ -80,19 +82,19 @@ export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange
         setItems([]);
       })
       .finally(() => setLoading(false));
-  }, [loopId]);
+  }, [loopId, workspaceId]);
 
   useEffect(() => { loadPage(1); }, [loadPage]);
 
   // 实际的刷新逻辑：拉取列表 + 展开详情
   const doRefresh = useCallback(() => {
-    dbLoops.listExecutions(loopId, { page, limit: DEFAULT_PAGE_LIMIT })
+    dbLoops.listExecutions(workspaceId ?? 0, loopId, { page, limit: DEFAULT_PAGE_LIMIT })
       .then((res) => {
         setItems(res.items);
         setTotal(res.total);
         onTotalChange?.(res.total);
         if (expandedId !== null) {
-          return dbLoops.getExecution(loopId, expandedId);
+          return dbLoops.getExecution(workspaceId ?? 0, loopId, expandedId);
         }
         return null;
       })
@@ -102,7 +104,7 @@ export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange
         }
       })
       .catch(() => {});
-  }, [page, loopId, expandedId]);
+  }, [page, loopId, workspaceId, expandedId]);
 
   // WebSocket 事件触发刷新（后端写入完成后才发事件，无需延迟）
   useExecutionEvents(useCallback(() => {
@@ -120,7 +122,7 @@ export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange
     setExpandedId(execId);
     setExpandedLoading(true);
     try {
-      const detail = await dbLoops.getExecution(loopId, execId);
+      const detail = await dbLoops.getExecution(workspaceId ?? 0, loopId, execId);
       setExpandedDetail(detail);
       // 提取轨迹：按 sequence_index 排序的 loop_step_id 列表
       const sorted = [...detail.step_executions].sort(
@@ -236,7 +238,7 @@ export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange
                         {expandedDetail.token_summary && (
                           <TokenSummaryBar summary={expandedDetail.token_summary} />
                         )}
-                        <StepExecList stepExecs={expandedDetail.step_executions} loopId={loopId} executionId={expandedDetail.id} onApproved={() => loadPage(page)} />
+                        <StepExecList stepExecs={expandedDetail.step_executions} loopId={loopId} workspaceId={workspaceId ?? 0} executionId={expandedDetail.id} onApproved={() => loadPage(page)} />
                       </>
                     ) : null}
                   </div>
@@ -265,6 +267,7 @@ export function LoopExecutionsPanel({ loopId, loopName: _loopName, onTotalChange
       <BlackboardDrawer
         open={blackboardOpen}
         stepExecs={blackboardExecs}
+        workspaceId={workspaceId ?? 0}
         onClose={() => setBlackboardOpen(false)}
       />
     </div>

--- a/frontend/src/components/loop-studio/triggers/TodoSelectorForm.tsx
+++ b/frontend/src/components/loop-studio/triggers/TodoSelectorForm.tsx
@@ -27,10 +27,15 @@ export function TodoSelectorForm({ value, onChange, workspaceId }: TodoSelectorF
 
   const [selectedId, setSelectedId] = useState<number | null>(parsed.todo_id);
 
-  // 加载 todo 列表：按 loop 所属工作空间过滤（如果 workspaceId 可用）
+  // 加载 todo 列表：按 loop 所属工作空间过滤（v1 纯 workspace-scoped，workspaceId 必须有值）
   useEffect(() => {
+    if (workspaceId == null) {
+      setTodos([]);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
-    db.getAllTodos(workspaceId ?? undefined)
+    db.getAllTodos(workspaceId)
       .then((list) => setTodos(list))
       .catch(() => { /* 静默 */ })
       .finally(() => setLoading(false));

--- a/frontend/src/components/loop-studio/triggers/TodoStateChangedConfigForm.tsx
+++ b/frontend/src/components/loop-studio/triggers/TodoStateChangedConfigForm.tsx
@@ -32,8 +32,13 @@ export function TodoStateChangedConfigForm({ value, onChange, workspaceId }: Tod
   const [toStatus, setToStatus] = useState(parsed.to_status);
 
   useEffect(() => {
+    if (workspaceId == null) {
+      setTodos([]);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
-    db.getAllTodos(workspaceId ?? undefined)
+    db.getAllTodos(workspaceId)
       .then((list) => setTodos(list))
       .catch(() => { /* 静默 */ })
       .finally(() => setLoading(false));

--- a/frontend/src/components/loop-studio/triggers/index.tsx
+++ b/frontend/src/components/loop-studio/triggers/index.tsx
@@ -66,7 +66,7 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged, workspaceId }: 
   // 切换 enabled 状态（用户点 toggle 的非「新增」路径）
   const handleToggleEnabled = useCallback(async (t: LoopTriggerDto, enabled: boolean) => {
     try {
-      await dbLoops.updateTrigger(loopId, t.id, {
+      await dbLoops.updateTrigger(workspaceId ?? 0, loopId, t.id, {
         trigger_type: t.trigger_type,
         config: t.config,
         enabled,
@@ -100,7 +100,7 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged, workspaceId }: 
     setSaving(true);
     try {
       if (configuring.existing) {
-        await dbLoops.updateTrigger(loopId, configuring.existing.id, {
+        await dbLoops.updateTrigger(workspaceId ?? 0, loopId, configuring.existing.id, {
           trigger_type: configuring.type,
           config: configJson || '{}',
           enabled: configuring.existing.enabled,
@@ -108,7 +108,7 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged, workspaceId }: 
         } as UpdateTriggerRequest);
         message.success('已更新');
       } else {
-        await dbLoops.createTrigger(loopId, {
+        await dbLoops.createTrigger(workspaceId ?? 0, loopId, {
           trigger_type: configuring.type,
           config: configJson || '{}',
           enabled: true,
@@ -128,7 +128,7 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged, workspaceId }: 
   // 删除已有 trigger
   const handleDelete = useCallback(async (id: number) => {
     try {
-      await dbLoops.deleteTrigger(loopId, id);
+      await dbLoops.deleteTrigger(workspaceId ?? 0, loopId, id);
       message.success('已删除');
       onChanged();
       if (configuring?.existing?.id === id) closeConfig();
@@ -205,7 +205,7 @@ export function LoopTriggersPanel({ loopId, triggers, onChanged, workspaceId }: 
               onClick={() => {
                 if (meta.noConfig) {
                   // manual 等无需配置的类型，直接启用（发送空配置）
-                  dbLoops.createTrigger(loopId, {
+                  dbLoops.createTrigger(workspaceId ?? 0, loopId, {
                     trigger_type: type,
                     config: '{}',
                     enabled: true,

--- a/frontend/src/components/mobile/LoopMobilePage.tsx
+++ b/frontend/src/components/mobile/LoopMobilePage.tsx
@@ -85,10 +85,10 @@ export function LoopMobilePage({
       setLoopDetail(null);
       return;
     }
-    dbLoops.getLoop(selectedLoopId)
+    dbLoops.getLoop(workspaceId ?? 0, selectedLoopId)
       .then(d => setLoopDetail(d))
       .catch(() => setLoopDetail(null));
-  }, [selectedLoopId]);
+  }, [selectedLoopId, workspaceId]);
 
   useEffect(() => {
     loadLoopDetail();
@@ -97,40 +97,40 @@ export function LoopMobilePage({
   const handleTrigger = useCallback(async () => {
     if (selectedLoopId === null) return;
     try {
-      const res = await dbLoops.triggerLoop(selectedLoopId);
+      const res = await dbLoops.triggerLoop(workspaceId ?? 0, selectedLoopId);
       message.success(`已触发 (execution #${res.execution_id})`);
     } catch (err) {
       message.error(`触发失败: ${err instanceof Error ? err.message : '未知错误'}`);
     }
-  }, [selectedLoopId]);
+  }, [selectedLoopId, workspaceId]);
 
   const handleDuplicate = useCallback(async () => {
     if (selectedLoopId === null) return;
     try {
-      await dbLoops.duplicateLoop(selectedLoopId);
+      await dbLoops.duplicateLoop(workspaceId ?? 0, selectedLoopId);
       message.success('已复制');
       onLoopChanged();
     } catch (err) {
       message.error(`复制失败: ${err instanceof Error ? err.message : '未知错误'}`);
     }
-  }, [selectedLoopId, onLoopChanged]);
+  }, [selectedLoopId, workspaceId, onLoopChanged]);
 
   const handleDelete = useCallback(async () => {
     if (selectedLoopId === null) return;
     try {
-      await dbLoops.deleteLoop(selectedLoopId);
+      await dbLoops.deleteLoop(workspaceId ?? 0, selectedLoopId);
       message.success('已删除');
       onLoopChanged();
     } catch {
       message.error('删除失败，环路可能正在被引用');
     }
-  }, [selectedLoopId, onLoopChanged]);
+  }, [selectedLoopId, workspaceId, onLoopChanged]);
 
   const handleToggleStatus = useCallback(async () => {
     if (selectedLoopId === null || !loopDetail) return;
     try {
       const next = loopDetail.status === 'enabled' ? 'paused' : 'enabled';
-      await dbLoops.updateLoopStatus(selectedLoopId, { status: next } as any);
+      await dbLoops.updateLoopStatus(workspaceId ?? 0, selectedLoopId, { status: next } as any);
       message.success(`已${next === 'enabled' ? '启用' : '暂停'}`);
       loadLoopDetail();
       onLoopChanged();
@@ -191,6 +191,7 @@ export function LoopMobilePage({
     >
       <LoopDetailPanel
         loopId={selectedLoopId}
+        workspaceId={workspaceId ?? null}
         tags={tags}
         onTrigger={handleTrigger}
         onDuplicate={handleDuplicate}

--- a/frontend/src/components/settings/BackupPanel.tsx
+++ b/frontend/src/components/settings/BackupPanel.tsx
@@ -207,7 +207,8 @@ export function BackupPanel() {
 
   const handleDownloadDatabase = async () => {
     try {
-      const response = await fetch('/api/backup/database/download');
+      // 原生 fetch 下载二进制流，不经 axios 拦截器，手动写 v1 路径
+      const response = await fetch('/api/v1/backup/database/download');
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const blob = await response.blob();
       const url = URL.createObjectURL(blob);
@@ -382,7 +383,8 @@ export function BackupPanel() {
   // Export handlers
   const handleExportBackup = async () => {
     try {
-      const response = await fetch('/api/backup/export', {
+      // 原生 fetch 导出 YAML，不经 axios 拦截器，手动写 v1 路径
+      const response = await fetch('/api/v1/backup/export', {
         headers: { Accept: 'application/x-yaml' },
       });
       if (!response.ok) {
@@ -414,7 +416,12 @@ export function BackupPanel() {
         return false;
       }
 
-      const existingTodos = await db.getAllTodos();
+      // v1 纯 workspace-scoped：getAllTodos 需逐空间拉取后合并，
+      // 用于备份导入去重时跨空间检查同名 todo
+      const allExisting = await Promise.all(
+        workspaces.map(ws => db.getAllTodos(ws.id).catch(() => []))
+      );
+      const existingTodos = allExisting.flat();
       setExistingTodos(existingTodos.map((t) => ({ title: t.title, prompt: t.prompt, workspace_id: t.workspace_id ?? null })));
       // 用户覆盖选择按导入批次重置
       setUserOverwriteKeys(new Set());

--- a/frontend/src/components/settings/ExecutorsPanel.tsx
+++ b/frontend/src/components/settings/ExecutorsPanel.tsx
@@ -108,7 +108,7 @@ export function ExecutorsPanel() {
   // 正在运行 tab：加载运行中记录
   const loadRunningRecords = async () => {
     try {
-      const records = await db.getRunningExecutionRecords();
+      const records = await db.getRunningExecutionRecords(state.selectedWorkspace ?? 0);
       setRunningRecords(records);
     } catch (err) {
       console.error('加载运行中任务失败:', err);
@@ -129,7 +129,7 @@ export function ExecutorsPanel() {
     setStoppingRecords(true);
     const results = await Promise.allSettled(
       selectedRecordIds.map(async (recordId) => {
-        await db.forceFailExecution(recordId);
+        await db.forceFailExecution(state.selectedWorkspace ?? 0, recordId);
       })
     );
     const successCount = results.filter(r => r.status === 'fulfilled').length;
@@ -850,7 +850,7 @@ export function ExecutorsPanel() {
                     render: (_: unknown, record: ExecutionRecord) => (
                       <Popconfirm title="确认停止此任务？" onConfirm={async () => {
                         try {
-                          await db.forceFailExecution(record.id);
+                          await db.forceFailExecution(state.selectedWorkspace ?? 0, record.id);
                           message.success('已停止');
                           loadRunningRecords();
                         } catch (err) { message.error(`停止失败: ${err instanceof Error ? err.message : String(err)}`); }

--- a/frontend/src/components/settings/assistant/AssistantDetailPage.tsx
+++ b/frontend/src/components/settings/assistant/AssistantDetailPage.tsx
@@ -100,7 +100,8 @@ export function AssistantDetailPage({ bot, onBack, onRefresh, autoShowHistory = 
   // ─── 加载执行记录详情 ───
   const handleViewExecutionRecord = async (recordId: number) => {
     try {
-      const r = await db.getExecutionRecord(recordId);
+      // v1 纯 workspace-scoped：用 bot 所属 workspace
+      const r = await db.getExecutionRecord(bot.workspace_id, recordId);
       setExecDetailRecord(r);
     } catch {
       message.error('加载执行记录失败');
@@ -111,7 +112,7 @@ export function AssistantDetailPage({ bot, onBack, onRefresh, autoShowHistory = 
   const handleProcessedTypeClick = async (record: FeishuHistoryMessage) => {
     if (record.processed_type !== 'slash_command_loop' || !record.processed_id) return;
     try {
-      const detail = await dbLoops.getExecutionById(record.processed_id);
+      const detail = await dbLoops.getExecutionById(bot.workspace_id, record.processed_id);
       setBlackboardExecs(detail.step_executions || []);
       setBlackboardOpen(true);
     } catch {
@@ -288,6 +289,7 @@ export function AssistantDetailPage({ bot, onBack, onRefresh, autoShowHistory = 
       <BlackboardDrawer
         open={blackboardOpen}
         stepExecs={blackboardExecs}
+        workspaceId={bot.workspace_id}
         onClose={() => setBlackboardOpen(false)}
       />
     </div>

--- a/frontend/src/components/settings/backup/LoopBackupTab.tsx
+++ b/frontend/src/components/settings/backup/LoopBackupTab.tsx
@@ -44,10 +44,18 @@ export function LoopBackupTab() {
   };
 
   // 导出全库所有环路为单个 YAML（对齐 Todo「导出全部」）
+  // v1 workspace-scoped：逐空间导出后拼接
   const handleExportAll = async () => {
     setExporting(true);
     try {
-      const yamlText = await exportAllLoops();
+      // 先确保工作空间列表已加载
+      const ws = workspaces.length > 0 ? workspaces : await db.getProjectDirectories();
+      if (workspaces.length === 0) setWorkspaces(ws);
+      // 逐空间导出后拼接（v1 不支持跨空间批量端点）
+      const yamlTexts = await Promise.all(
+        ws.map(w => exportAllLoops(w.id).catch(() => ''))
+      );
+      const yamlText = yamlTexts.filter(Boolean).join('\n---\n');
       const blob = new Blob([yamlText], { type: 'application/x-yaml' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -70,15 +78,19 @@ export function LoopBackupTab() {
   const handleImportFile = async (file: File) => {
     try {
       const text = await file.text();
-      const preview = await db.previewLoopImport(text);
+      // v1 workspace-scoped：先加载工作空间列表，取第一个作为 URL 上下文空间
+      const ws = workspaces.length > 0 ? workspaces : await db.getProjectDirectories();
+      if (workspaces.length === 0) setWorkspaces(ws);
+      const ctxWs = ws[0]?.id ?? 0;
+      const preview = await db.previewLoopImport(ctxWs, text);
       setYamlPreview(text);
       setPreviewData(preview);
 
-      // 并行加载工作空间列表 + 当前库已有 loop 名（后者用于「状态」列）
-      const [ws, loops] = await Promise.all([
-        db.getProjectDirectories(),
-        listLoops(),
-      ]);
+      // 并行加载当前库已有 loop 名（逐空间拉取后合并，用于「状态」列同名检查）
+      const allLoops = await Promise.all(
+        ws.map(w => listLoops(w.id).catch(() => []))
+      );
+      const loops = allLoops.flat();
       setWorkspaces(ws);
       setExistingLoopNames(new Set(loops.map((l) => l.name)));
 
@@ -128,7 +140,9 @@ export function LoopBackupTab() {
     }
     setImporting(true);
     try {
-      const result = await db.mergeLoops(yamlPreview, null, overrides, skipNames);
+      // v1 workspace-scoped：用第一个工作空间作为 URL 上下文，逐 loop 的目标由 overrides 指定
+      const ctxWs = workspaces[0]?.id ?? 0;
+      const result = await db.mergeLoops(ctxWs, yamlPreview, null, overrides, skipNames);
       message.success(
         `导入完成：新建 ${result.created.loops} 个，更新 ${result.updated?.loops || 0} 个，跳过 ${result.skipped?.length || 0} 个`
       );

--- a/frontend/src/components/todo-detail/QuickButtonManageModal.tsx
+++ b/frontend/src/components/todo-detail/QuickButtonManageModal.tsx
@@ -20,14 +20,14 @@ function normalizeFormValues(values: FormValues): FormValues {
  * 封装快捷按钮的列表加载 + 增删改 + 编辑态。把数据逻辑从渲染层剥离，
  * 主组件只管布局。弹窗每次打开重拉最新列表，CRUD 后本地刷新并通知外层同步按钮条。
  */
-function useQuickButtonCrud(open: boolean, onChanged: () => void) {
+function useQuickButtonCrud(open: boolean, workspaceId: number, onChanged: () => void) {
   const [buttons, setButtons] = useState<QuickButton[]>([]);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [form] = Form.useForm<FormValues>();
 
   const refresh = () =>
     db
-      .getQuickButtons()
+      .getQuickButtons(workspaceId)
       .then(setButtons)
       .catch((e: unknown) => message.error('加载快捷按钮失败: ' + String(e)));
 
@@ -57,10 +57,10 @@ function useQuickButtonCrud(open: boolean, onChanged: () => void) {
     try {
       const values = normalizeFormValues(await form.validateFields());
       if (editingId) {
-        await db.updateQuickButton(editingId, values);
+        await db.updateQuickButton(workspaceId, editingId, values);
         message.success('更新成功');
       } else {
-        await db.createQuickButton(values);
+        await db.createQuickButton(workspaceId, values);
         message.success('创建成功');
       }
       cancelEdit();
@@ -76,7 +76,7 @@ function useQuickButtonCrud(open: boolean, onChanged: () => void) {
 
   const remove = async (id: number) => {
     try {
-      await db.deleteQuickButton(id);
+      await db.deleteQuickButton(workspaceId, id);
       message.success('删除成功');
       refresh();
       onChanged();
@@ -135,15 +135,18 @@ function ExistingButtonList({
  */
 export function QuickButtonManageModal({
   open,
+  workspaceId,
   onClose,
   onChanged,
 }: {
   open: boolean;
+  workspaceId: number;
   onClose: () => void;
   onChanged: () => void;
 }) {
   const { buttons, editingId, form, submit, remove, beginEdit, cancelEdit } = useQuickButtonCrud(
     open,
+    workspaceId,
     onChanged,
   );
   // 移动端窄屏：Modal 走接近全宽，避免固定 520 溢出视口

--- a/frontend/src/components/todo-detail/ReplyInput.tsx
+++ b/frontend/src/components/todo-detail/ReplyInput.tsx
@@ -3,6 +3,7 @@ import { Input, Button } from 'antd';
 import type { InputRef } from 'antd';
 import { SendOutlined } from '@ant-design/icons';
 import type { ExecutionRecord } from '@/types';
+import { useTodos } from '@/hooks/useTodoContext';
 import { getQuickButtons } from '@/utils/database';
 import type { QuickButton } from '@/utils/database';
 import { QuickButtonBar } from './QuickButtonBar';
@@ -27,15 +28,20 @@ export function ReplyInput({
   // 填入话术后自动聚焦输入框，方便用户立刻接着编辑
   const inputRef = useRef<InputRef>(null);
 
-  // 每个会话线程各有一个 ReplyInput，各自拉一次全局按钮列表；
+  const { state } = useTodos();
+  const workspaceId = state.selectedWorkspace ?? 0;
+
+  // 每个会话线程各有一个 ReplyInput，各自拉一次当前 workspace 的按钮列表；
   // 列表只读且数据量小，不做跨组件缓存（YAGNI）。
   useEffect(() => {
-    getQuickButtons().then(setButtons).catch(() => {});
-  }, []);
+    if (!workspaceId) return;
+    getQuickButtons(workspaceId).then(setButtons).catch(() => {});
+  }, [workspaceId]);
 
-  // 弹窗内增删改后重拉，保持按钮条与全局数据同步
+  // 弹窗内增删改后重拉，保持按钮条与 workspace 数据同步
   const reloadButtons = () => {
-    getQuickButtons().then(setButtons).catch(() => {});
+    if (!workspaceId) return;
+    getQuickButtons(workspaceId).then(setButtons).catch(() => {});
   };
 
   // 点快捷按钮：覆盖填入话术（Q10 决策）+ 聚焦输入框
@@ -85,7 +91,7 @@ export function ReplyInput({
           回复
         </Button>
       </div>
-      <QuickButtonManageModal open={manageOpen} onClose={() => setManageOpen(false)} onChanged={reloadButtons} />
+      <QuickButtonManageModal open={manageOpen} workspaceId={workspaceId} onClose={() => setManageOpen(false)} onChanged={reloadButtons} />
     </div>
   );
 }

--- a/frontend/src/components/todo-list/index.tsx
+++ b/frontend/src/components/todo-list/index.tsx
@@ -278,17 +278,19 @@ export function TodoList(props: TodoListProps) {
       const context = workspaceBatchContext;
       let result: { updated_count: number; total: number };
 
+      // selectedWorkspace 为源空间（URL 路径段），target 为目标空间（body）
+      const srcWs = selectedWorkspace ?? 0;
       if (context === 'item') {
         if (mode === 'copy') {
-          result = await db.batchCopyTodosWorkspace(ids, target);
+          result = await db.batchCopyTodosWorkspace(srcWs, ids, target);
         } else {
-          result = await db.batchMoveTodosWorkspace(ids, target);
+          result = await db.batchMoveTodosWorkspace(srcWs, ids, target);
         }
       } else {
         if (mode === 'copy') {
-          result = await dbLoops.batchCopyLoopsWorkspace(ids, target);
+          result = await dbLoops.batchCopyLoopsWorkspace(srcWs, ids, target);
         } else {
-          result = await dbLoops.batchMoveLoopsWorkspace(ids, target);
+          result = await dbLoops.batchMoveLoopsWorkspace(srcWs, ids, target);
         }
       }
 
@@ -328,7 +330,7 @@ export function TodoList(props: TodoListProps) {
     setExecutorModalOpen(false);
     setPendingExecutorChangeIds([]);
     try {
-      const result = await db.batchUpdateTodosExecutor(ids, executor);
+      const result = await db.batchUpdateTodosExecutor(selectedWorkspace ?? 0, ids, executor);
       if (result.failed.length === 0) {
         message.success(`已为 ${result.updated.length} 项更换执行器为「${executor}」`);
       } else {
@@ -387,8 +389,8 @@ export function TodoList(props: TodoListProps) {
     try {
       const isPause = schedulerBatchMode === 'pause';
       const result = isPause
-        ? await db.batchPauseScheduler(ids)
-        : await db.batchResumeScheduler(ids);
+        ? await db.batchPauseScheduler(selectedWorkspace ?? 0, ids)
+        : await db.batchResumeScheduler(selectedWorkspace ?? 0, ids);
       const actionLabel = isPause ? '暂停' : '恢复';
       if (result.updated_count === result.total) {
         message.success(`已${actionLabel} ${result.updated_count} 项的周期执行`);

--- a/frontend/src/components/todo-post/index.tsx
+++ b/frontend/src/components/todo-post/index.tsx
@@ -65,11 +65,13 @@ export function TodoPostPage({
     const id = recordId;
     setLoading(true);
     try {
+      // v1 纯 workspace-scoped：execution 查询需 workspaceId
+      const wsId = state.selectedWorkspace ?? 0;
       // 1. 获取目标记录
-      const targetRecord = await db.getExecutionRecord(id);
+      const targetRecord = await db.getExecutionRecord(wsId, id);
       // 2. 如果有 session_id，拉取同 session 的所有记录
       if (targetRecord.session_id) {
-        const sessionRecords = await db.getExecutionRecordsBySession(targetRecord.session_id);
+        const sessionRecords = await db.getExecutionRecordsBySession(wsId, targetRecord.session_id);
         // 按 started_at 排序
         sessionRecords.sort((a, b) =>
           (a.started_at || "").localeCompare(b.started_at || "")
@@ -95,7 +97,7 @@ export function TodoPostPage({
   const loadLogsForRecord = async (rId: number, page: number) => {
     setIsLoadingLogs(true);
     try {
-      const result = await db.getExecutionLogs(rId, page, logsPerPage);
+      const result = await db.getExecutionLogs(state.selectedWorkspace ?? 0, rId, page, logsPerPage);
       setPaginatedLogs(result.logs);
       setLogsPage(page);
     } catch {
@@ -144,7 +146,7 @@ export function TodoPostPage({
 
   const handleStopExecution = async (rId: number) => {
     try {
-      await db.stopExecution(rId);
+      await db.stopExecution(state.selectedWorkspace ?? 0, rId);
       message.info("已发送停止指令");
       await loadSessionRecords();
     } catch (error) {
@@ -156,7 +158,7 @@ export function TodoPostPage({
     if (!replyMessage.trim()) return;
     setReplyLoading(true);
     try {
-      await db.resumeExecutionRecord(r.id, replyMessage);
+      await db.resumeExecutionRecord(state.selectedWorkspace ?? 0, r.id, replyMessage);
       message.success("回复成功，开始执行");
       await loadSessionRecords();
     } catch (error) {
@@ -168,9 +170,10 @@ export function TodoPostPage({
 
   const handleRateExecution = async (rId: number, rating: number | null) => {
     try {
-      await db.rateExecutionRecord(rId, rating);
+      const wsId = state.selectedWorkspace ?? 0;
+      await db.rateExecutionRecord(wsId, rId, rating);
       // 刷新当前记录
-      const updated = await db.getExecutionRecord(rId);
+      const updated = await db.getExecutionRecord(wsId, rId);
       setRecords(prev => prev.map(r => (r.id === rId ? updated : r)));
       message.success(rating == null ? "已清除评分" : `已评分 ${rating}`);
     } catch (error) {
@@ -181,7 +184,7 @@ export function TodoPostPage({
   const handleExportMarkdown = async (r: ExecutionRecord) => {
     let logs: LogEntry[] = [];
     try {
-      const result = await db.getExecutionLogs(r.id, 1, EXPORT.maxLogs);
+      const result = await db.getExecutionLogs(state.selectedWorkspace ?? 0, r.id, 1, EXPORT.maxLogs);
       logs = result.logs;
     } catch { /* ignore */ }
     const msgs = parseLogsToMessages(logs);

--- a/frontend/src/hooks/useExecutionHistory.ts
+++ b/frontend/src/hooks/useExecutionHistory.ts
@@ -20,6 +20,8 @@ import * as db from '@/utils/database';
 
 interface UseExecutionHistoryOptions {
   selectedTodoId: number | null;
+  /** 当前工作空间 ID（v1 路由 workspace-scoped，执行记录查询必需） */
+  workspaceId: number | null;
   /** 按环节 id 查询（环节独立执行记录） */
   stepId?: number | null;
   /** Records already in the global store for this todo */
@@ -63,6 +65,7 @@ interface UseExecutionHistoryResult {
 
 export function useExecutionHistory({
   selectedTodoId,
+  workspaceId,
   stepId,
   storeRecords,
   dispatch,
@@ -96,7 +99,7 @@ export function useExecutionHistory({
     try {
       const statusFilter = historyStatusFilter === 'all' ? undefined : historyStatusFilter;
       const pageData = await db.getExecutionRecords(
-        selectedTodoId ?? undefined, page, limit, statusFilter, stepId ?? undefined
+        workspaceId ?? 0, selectedTodoId ?? undefined, page, limit, statusFilter, stepId ?? undefined
       );
       if (selectedTodoId) {
         dispatch({
@@ -112,12 +115,12 @@ export function useExecutionHistory({
     } catch {
       // ignore: interceptor already shows error toast
     }
-  }, [selectedTodoId, stepId, historyLimit, historyStatusFilter, dispatch]);
+  }, [selectedTodoId, workspaceId, stepId, historyLimit, historyStatusFilter, dispatch]);
 
   const refreshSingleRecord = useCallback(async (recordId: number) => {
     if (!selectedTodoId) return;
     try {
-      const record = await db.getExecutionRecord(recordId);
+      const record = await db.getExecutionRecord(workspaceId ?? 0, recordId);
       dispatch({ type: 'UPDATE_EXECUTION_RECORD', payload: { todoId: selectedTodoId, record } });
       // 同步更新详情面板使用的本地 detail state，避免评分等同步更新后
       // 详情面板仍展示旧值（详情面板优先使用 selectedHistoryRecordDetail，
@@ -126,14 +129,14 @@ export function useExecutionHistory({
         setSelectedHistoryRecordDetail(record);
       }
     } catch { /* ignore */ }
-  }, [selectedTodoId, dispatch]);
+  }, [selectedTodoId, workspaceId, dispatch]);
 
   // ─── Load logs ─────────────────────────────────────────────
 
   const loadLogs = useCallback(async (recordId: number, page: number) => {
     setIsLoadingLogs(true);
     try {
-      const result = await db.getExecutionLogs(recordId, page, logsPerPage);
+      const result = await db.getExecutionLogs(workspaceId ?? 0, recordId, page, logsPerPage);
       if (activeRecordIdRef.current !== recordId) return;
       setPaginatedLogs(result.logs);
       setLogsTotal(result.total);
@@ -143,7 +146,7 @@ export function useExecutionHistory({
     } finally {
       if (activeRecordIdRef.current === recordId) setIsLoadingLogs(false);
     }
-  }, [logsPerPage]);
+  }, [workspaceId, logsPerPage]);
 
   // ─── Auto-select first record in wide mode ────────────────
 
@@ -161,7 +164,7 @@ export function useExecutionHistory({
       setHistoryPage(1);
       const statusFilter = historyStatusFilter === 'all' ? undefined : historyStatusFilter;
       db.getExecutionRecords(
-        selectedTodoId ?? undefined, 1, historyLimit, statusFilter, stepId ?? undefined
+        workspaceId ?? 0, selectedTodoId ?? undefined, 1, historyLimit, statusFilter, stepId ?? undefined
       ).then(pageData => {
         if (cancelledRef.current) return;
         if (selectedTodoId) {
@@ -176,7 +179,7 @@ export function useExecutionHistory({
       });
 
       if (selectedTodoId) {
-        db.getExecutionSummary(selectedTodoId).then(sum => {
+        db.getExecutionSummary(workspaceId ?? 0, selectedTodoId).then(sum => {
           if (!cancelledRef.current) setSummary(sum);
         }).catch(() => {
           // 汇总加载失败时保持 null，非关键路径
@@ -186,7 +189,7 @@ export function useExecutionHistory({
       setSummary(null);
     }
     return () => { cancelledRef.current = true; };
-  }, [selectedTodoId, stepId, historyLimit, historyStatusFilter, dispatch]);
+  }, [selectedTodoId, workspaceId, stepId, historyLimit, historyStatusFilter, dispatch]);
 
   // ─── Load detail + logs when selected record changes ─────────
 
@@ -204,7 +207,7 @@ export function useExecutionHistory({
     const basicRecord = storeRecords.find(r => r.id === requestId);
 
     setIsLoadingDetail(true);
-    db.getExecutionRecord(requestId)
+    db.getExecutionRecord(workspaceId ?? 0, requestId)
       .then(detail => {
         if (activeRecordIdRef.current !== requestId) return;
         setSelectedHistoryRecordDetail(detail);

--- a/frontend/src/hooks/useRunningBoard.ts
+++ b/frontend/src/hooks/useRunningBoard.ts
@@ -64,7 +64,8 @@ export function useRunningBoard(workspaceId?: number | null, hours?: number): Ru
       setRecords([]); // 切换 workspace 时先清空，避免旧数据闪烁
       setScheduledTodos([]);
       // 运行看板不分页，拉取最近的一批数据即可
-      const data = await db.getRunningBoardData(undefined, 200, ws ?? undefined, h);
+      // v1 纯 workspace-scoped：workspaceId 提升为必传路径段
+      const data = await db.getRunningBoardData(ws ?? 0, undefined, 200, h);
       if (mountedRef.current && latestWsRef.current === ws && latestHoursRef.current === h) {
         setRecords(data.records);
         setScheduledTodos(data.scheduled_todos);

--- a/frontend/src/types/expert.ts
+++ b/frontend/src/types/expert.ts
@@ -125,22 +125,23 @@ export function getExpertProfession(expert: ExpertMetadata): string {
   return expert.profession_zh || expert.profession_en || '';
 }
 
-/** 获取头像 URL */
+/** 获取头像 URL（<img src> 直接用，不经 axios 拦截器，手动写 v1 前缀） */
 export function getExpertAvatarUrl(expert: ExpertMetadata): string {
   if (!expert.avatar_path) return '';
-  return `/api/experts/${encodeURIComponent(expert.name)}/avatar`;
+  return `/api/v1/experts/${encodeURIComponent(expert.name)}/avatar`;
 }
 
 /**
  * 获取团队成员头像 URL
  *
  * 成员的 avatar_path 是相对路径（如 avatars/xxx.jpg），浏览器无法直接访问，
- * 需要通过后端接口 /api/experts/:name/members/:member_id/avatar 获取。
+ * 需要通过后端接口 /api/v1/experts/:name/members/:member_id/avatar 获取。
  * 后端会根据 expert_name 定位专家目录，再在 members 中按 member_id 查找成员，
  * 拼接 definition_dir + member.avatar_path 读取头像文件。
+ * <img src> 直接用，不经 axios 拦截器，手动写 v1 前缀。
  */
 export function getMemberAvatarUrl(expertName: string, memberId: string): string {
-  return `/api/experts/${encodeURIComponent(expertName)}/members/${encodeURIComponent(memberId)}/avatar`;
+  return `/api/v1/experts/${encodeURIComponent(expertName)}/members/${encodeURIComponent(memberId)}/avatar`;
 }
 
 /**

--- a/frontend/src/utils/database/backup.ts
+++ b/frontend/src/utils/database/backup.ts
@@ -8,17 +8,17 @@ export async function mergeBackup(
   todos: { title: string; prompt: string; status: string; executor?: string; scheduler_enabled: boolean; scheduler_config?: string; tag_names: string[]; workspace_path?: string; workspace_id?: number | null }[],
   workspace_id?: number | null,
 ): Promise<string> {
-  return unwrap(await api.post('/api/backup/merge', { tags, todos, workspace_id }));
+  return unwrap(await api.post('/api/v1/backup/merge', { tags, todos, workspace_id }));
 }
 
 // Database Backup APIs
 
 export async function triggerLocalBackup(): Promise<string> {
-  return unwrap(await api.post('/api/backup/database/trigger'));
+  return unwrap(await api.post('/api/v1/backup/database/trigger'));
 }
 
 export async function optimizeDatabase(): Promise<string> {
-  return unwrap(await api.post('/api/backup/database/optimize'));
+  return unwrap(await api.post('/api/v1/backup/database/optimize'));
 }
 
 export async function getDatabaseBackupStatus(): Promise<{
@@ -28,7 +28,7 @@ export async function getDatabaseBackupStatus(): Promise<{
   last_backup: string | null;
   files: { name: string; size: number; created_at: string }[];
 }> {
-  return unwrap(await api.get('/api/backup/database/status'));
+  return unwrap(await api.get('/api/v1/backup/database/status'));
 }
 
 export async function updateAutoBackup(enabled: boolean, cron: string, maxFiles?: number): Promise<string> {
@@ -36,11 +36,11 @@ export async function updateAutoBackup(enabled: boolean, cron: string, maxFiles?
   if (maxFiles !== undefined) {
     body.max_files = maxFiles;
   }
-  return unwrap(await api.put('/api/backup/database/auto', body));
+  return unwrap(await api.put('/api/v1/backup/database/auto', body));
 }
 
 export async function deleteBackupFile(filename: string): Promise<string> {
-  return unwrap(await api.delete('/api/backup/database/file', { data: { filename } }));
+  return unwrap(await api.delete('/api/v1/backup/database/file', { data: { filename } }));
 }
 
 // URL builder 返回给 <a href> / window.open，不经 axios 拦截器，手动写 v1 前缀
@@ -53,15 +53,15 @@ export function downloadBackupFileUrl(filename: string): string {
 export async function getLogCleanupStatus(): Promise<{
   cleanup_days: number | null;
 }> {
-  return unwrap(await api.get('/api/backup/log-cleanup/status'));
+  return unwrap(await api.get('/api/v1/backup/log-cleanup/status'));
 }
 
 export async function updateLogCleanup(days: number | null): Promise<string> {
-  return unwrap(await api.put('/api/backup/log-cleanup', { days }));
+  return unwrap(await api.put('/api/v1/backup/log-cleanup', { days }));
 }
 
 export async function triggerLogCleanup(): Promise<string> {
-  return unwrap(await api.post('/api/backup/log-cleanup/trigger'));
+  return unwrap(await api.post('/api/v1/backup/log-cleanup/trigger'));
 }
 
 // Todo Backup APIs
@@ -73,11 +73,11 @@ export async function getTodoBackupStatus(): Promise<{
   last_backup: string | null;
   files: { name: string; size: number; created_at: string }[];
 }> {
-  return unwrap(await api.get('/api/backup/todo/status'));
+  return unwrap(await api.get('/api/v1/backup/todo/status'));
 }
 
 export async function triggerTodoBackup(): Promise<string> {
-  return unwrap(await api.post('/api/backup/todo/trigger'));
+  return unwrap(await api.post('/api/v1/backup/todo/trigger'));
 }
 
 export async function updateTodoAutoBackup(enabled: boolean, cron: string, maxFiles?: number): Promise<string> {
@@ -85,11 +85,11 @@ export async function updateTodoAutoBackup(enabled: boolean, cron: string, maxFi
   if (maxFiles !== undefined) {
     body.max_files = maxFiles;
   }
-  return unwrap(await api.put('/api/backup/todo/auto', body));
+  return unwrap(await api.put('/api/v1/backup/todo/auto', body));
 }
 
 export async function deleteTodoBackupFile(filename: string): Promise<string> {
-  return unwrap(await api.delete('/api/backup/todo/file', { data: { filename } }));
+  return unwrap(await api.delete('/api/v1/backup/todo/file', { data: { filename } }));
 }
 
 export function downloadTodoBackupFileUrl(filename: string): string {
@@ -112,11 +112,11 @@ export async function getSkillBackupStatus(): Promise<{
   files: { name: string; size: number; created_at: string }[];
   executor_skills: ExecutorSkillInfo[];
 }> {
-  return unwrap(await api.get('/api/backup/skills/status'));
+  return unwrap(await api.get('/api/v1/backup/skills/status'));
 }
 
 export async function triggerSkillBackup(): Promise<string> {
-  return unwrap(await api.post('/api/backup/skills/trigger'));
+  return unwrap(await api.post('/api/v1/backup/skills/trigger'));
 }
 
 export async function updateSkillAutoBackup(enabled: boolean, cron: string, maxFiles?: number): Promise<string> {
@@ -124,11 +124,11 @@ export async function updateSkillAutoBackup(enabled: boolean, cron: string, maxF
   if (maxFiles !== undefined) {
     body.max_files = maxFiles;
   }
-  return unwrap(await api.put('/api/backup/skills/auto', body));
+  return unwrap(await api.put('/api/v1/backup/skills/auto', body));
 }
 
 export async function deleteSkillBackupFile(filename: string): Promise<string> {
-  return unwrap(await api.delete('/api/backup/skills/file', { data: { filename } }));
+  return unwrap(await api.delete('/api/v1/backup/skills/file', { data: { filename } }));
 }
 
 export function downloadSkillBackupFileUrl(filename: string): string {
@@ -217,5 +217,5 @@ export async function mergeLoops(
   workspace_overrides?: Record<string, number>,
   skip_names?: string[],
 ): Promise<{ success: boolean; created: LoopImportResult['created']; updated: LoopImportResult['created']; skipped: string[]; warnings: { type: string; message: string }[] }> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/merge`, { yaml, workspace_id, workspace_overrides, skip_names }));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/loops/merge`, { yaml, workspace_id, workspace_overrides, skip_names }));
 }

--- a/frontend/src/utils/database/backup.ts
+++ b/frontend/src/utils/database/backup.ts
@@ -43,8 +43,9 @@ export async function deleteBackupFile(filename: string): Promise<string> {
   return unwrap(await api.delete('/api/backup/database/file', { data: { filename } }));
 }
 
+// URL builder 返回给 <a href> / window.open，不经 axios 拦截器，手动写 v1 前缀
 export function downloadBackupFileUrl(filename: string): string {
-  return `/api/backup/database/file?filename=${encodeURIComponent(filename)}`;
+  return `/api/v1/backup/database/file?filename=${encodeURIComponent(filename)}`;
 }
 
 // Log Cleanup APIs
@@ -92,7 +93,7 @@ export async function deleteTodoBackupFile(filename: string): Promise<string> {
 }
 
 export function downloadTodoBackupFileUrl(filename: string): string {
-  return `/api/backup/todo/file?filename=${encodeURIComponent(filename)}`;
+  return `/api/v1/backup/todo/file?filename=${encodeURIComponent(filename)}`;
 }
 
 // Skill Backup APIs
@@ -131,7 +132,7 @@ export async function deleteSkillBackupFile(filename: string): Promise<string> {
 }
 
 export function downloadSkillBackupFileUrl(filename: string): string {
-  return `/api/backup/skills/file?filename=${encodeURIComponent(filename)}`;
+  return `/api/v1/backup/skills/file?filename=${encodeURIComponent(filename)}`;
 }
 
 // Loop Import/Export APIs
@@ -167,8 +168,12 @@ export interface LoopImportPreview {
   loops: LoopImportPreviewLoop[];
 }
 
-export async function previewLoopImport(yaml: string): Promise<LoopImportPreview> {
-  const response = await fetch('/api/loops/import/preview', {
+/**
+ * 预览 loop 导入数据（原生 fetch，不经 axios 拦截器，手动写 v1 路径）。
+ * workspaceId 为导入目标空间的上下文（v1 workspace-scoped）。
+ */
+export async function previewLoopImport(workspaceId: number, yaml: string): Promise<LoopImportPreview> {
+  const response = await fetch(`/api/v1/workspaces/${workspaceId}/loops/import/preview`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-yaml' },
     body: yaml,
@@ -199,15 +204,18 @@ export interface LoopImportResult {
 }
 
 /**
+ * 合并导入 loops。
+ * workspaceId 为 URL 路径段（v1 workspace-scoped 上下文空间）。
  * workspace_id 全局传 null（逐条由 workspace_overrides 指定）。
  * workspace_overrides: loop name → workspace_id（用户逐行选择，仅含已指定的非空项）。
  * skip_names: 用户选择「跳过」的同名环路名集合，后端不创建/覆盖、同名保留原样。
  */
 export async function mergeLoops(
+  workspaceId: number,
   yaml: string,
   workspace_id: number | null,
   workspace_overrides?: Record<string, number>,
   skip_names?: string[],
 ): Promise<{ success: boolean; created: LoopImportResult['created']; updated: LoopImportResult['created']; skipped: string[]; warnings: { type: string; message: string }[] }> {
-  return unwrap(await api.post('/api/loops/merge', { yaml, workspace_id, workspace_overrides, skip_names }));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/merge`, { yaml, workspace_id, workspace_overrides, skip_names }));
 }

--- a/frontend/src/utils/database/blackboard.ts
+++ b/frontend/src/utils/database/blackboard.ts
@@ -1,6 +1,6 @@
 import { api, unwrap } from './client';
 
-/** 黑板响应（来自 GET /api/workspaces/{workspaceId}/blackboard） */
+/** 黑板响应（来自 GET /api/v1/workspaces/{workspaceId}/blackboard） */
 export interface BlackboardResponse {
   workspace_id: number;
   pending_record_ids: string; // JSON 数组字符串，如 "[12, 34, 56]"
@@ -13,12 +13,12 @@ export interface BlackboardResponse {
   wiki_timeout_secs: number;
 }
 
-/** GET /api/workspaces/{workspaceId}/blackboard：获取黑板数据（含 pending_record_ids） */
+/** GET /api/v1/workspaces/{workspaceId}/blackboard：获取黑板数据（含 pending_record_ids） */
 export async function getBlackboard(workspaceId: number): Promise<BlackboardResponse> {
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/blackboard`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/blackboard`));
 }
 
-/** PATCH /api/workspaces/{workspaceId}/blackboard：更新黑板 per-workspace 配置 */
+/** PATCH /api/v1/workspaces/{workspaceId}/blackboard：更新黑板 per-workspace 配置 */
 export async function updateBlackboardConfig(
   workspaceId: number,
   config: {
@@ -34,10 +34,10 @@ export async function updateBlackboardConfig(
     enabled?: boolean;
   },
 ): Promise<void> {
-  await api.patch(`/api/workspaces/${workspaceId}/blackboard`, config);
+  await api.patch(`/api/v1/workspaces/${workspaceId}/blackboard`, config);
 }
 
-/** Wiki 对话响应（来自 POST /api/workspaces/{workspaceId}/wiki/chat） */
+/** Wiki 对话响应（来自 POST /api/v1/workspaces/{workspaceId}/wiki/chat） */
 export interface WikiChatResponse {
   /** 执行器返回的结果文本 */
   content: string;
@@ -49,7 +49,7 @@ export interface WikiChatResponse {
   duration_secs: number;
 }
 
-/** Wiki 文件删除响应（来自 DELETE /api/workspaces/{workspaceId}/wiki/files/{slug}） */
+/** Wiki 文件删除响应（来自 DELETE /api/v1/workspaces/{workspaceId}/wiki/files/{slug}） */
 export interface WikiFileDeleteResponse {
   slug: string;
   /** true=文件存在并已删除；false=文件本就不存在（幂等删除，仍算成功） */
@@ -57,19 +57,19 @@ export interface WikiFileDeleteResponse {
 }
 
 /**
- * DELETE /api/workspaces/{workspaceId}/wiki/files/{slug}：删除指定 topic 文件。
+ * DELETE /api/v1/workspaces/{workspaceId}/wiki/files/{slug}：删除指定 topic 文件。
  *
  * 仅限 topic：后端会拒绝删除 log（系统维护）。文件本就不存在时返回 deleted=false，
  * 前端据此区分「真正删了一篇」与「点了但文件已没了」，但两者都视为成功。
  */
 export async function deleteWikiFile(workspaceId: number, slug: string): Promise<WikiFileDeleteResponse> {
   return unwrap(
-    await api.delete(`/api/workspaces/${workspaceId}/wiki/files/${encodeURIComponent(slug)}`),
+    await api.delete(`/api/v1/workspaces/${workspaceId}/wiki/files/${encodeURIComponent(slug)}`),
   );
 }
 
 /**
- * POST /api/workspaces/{workspaceId}/wiki/chat：发起一次 Wiki 对话
+ * POST /api/v1/workspaces/{workspaceId}/wiki/chat：发起一次 Wiki 对话
  *
  * 非流式：等待执行器完成后一次性返回结果。
  * 不创建 Todo、不持久化对话历史。
@@ -87,7 +87,7 @@ export async function chatWithWiki(
   // 读取 per-workspace 超时配置，推算 HTTP 超时；失败回退默认 300 秒
   const timeoutMs = await resolveWikiChatHttpTimeoutMs(workspaceId);
   return unwrap(
-    await api.post(`/api/workspaces/${workspaceId}/wiki/chat`, {
+    await api.post(`/api/v1/workspaces/${workspaceId}/wiki/chat`, {
       message,
       executor,
       expert_name: expertName,

--- a/frontend/src/utils/database/bots.ts
+++ b/frontend/src/utils/database/bots.ts
@@ -76,7 +76,7 @@ export interface UpdateWorkspaceSettingsParams {
 
 /** 获取工作空间的斜杠命令列表 */
 export async function getWorkspaceSlashCommands(workspaceId: number): Promise<WorkspaceSlashCommand[]> {
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/slash-commands`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/slash-commands`));
 }
 
 /** 创建工作空间的斜杠命令 */
@@ -84,7 +84,7 @@ export async function createWorkspaceSlashCommand(
   workspaceId: number,
   params: CreateWorkspaceSlashCommandParams,
 ): Promise<{ id: number }> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/slash-commands`, params));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/slash-commands`, params));
 }
 
 /** 更新工作空间的斜杠命令 */
@@ -93,17 +93,17 @@ export async function updateWorkspaceSlashCommand(
   cmdId: number,
   params: UpdateWorkspaceSlashCommandParams,
 ): Promise<void> {
-  await api.put(`/api/workspaces/${workspaceId}/slash-commands/${cmdId}`, params);
+  await api.put(`/api/v1/workspaces/${workspaceId}/slash-commands/${cmdId}`, params);
 }
 
 /** 删除工作空间的斜杠命令 */
 export async function deleteWorkspaceSlashCommand(workspaceId: number, cmdId: number): Promise<void> {
-  await api.delete(`/api/workspaces/${workspaceId}/slash-commands/${cmdId}`);
+  await api.delete(`/api/v1/workspaces/${workspaceId}/slash-commands/${cmdId}`);
 }
 
 /** 获取工作空间的设置 */
 export async function getWorkspaceSettings(workspaceId: number): Promise<WorkspaceSettings> {
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/settings`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/settings`));
 }
 
 /** 更新工作空间的设置 */
@@ -111,12 +111,12 @@ export async function updateWorkspaceSettings(
   workspaceId: number,
   params: UpdateWorkspaceSettingsParams,
 ): Promise<void> {
-  await api.put(`/api/workspaces/${workspaceId}/settings`, params);
+  await api.put(`/api/v1/workspaces/${workspaceId}/settings`, params);
 }
 
 /** 将 Bot 移动到另一个工作空间（agent-bots 为全局路由，拦截器加 v1 前缀） */
 export async function moveBotToWorkspace(botId: number, workspaceId: number): Promise<void> {
-  await api.put(`/api/agent-bots/${botId}/workspace`, { workspace_id: workspaceId });
+  await api.put(`/api/v1/agent-bots/${botId}/workspace`, { workspace_id: workspaceId });
 }
 
 export interface FeishuBeginResponse {
@@ -180,23 +180,23 @@ export interface WhitelistEntry {
 }
 
 export async function getAgentBots(): Promise<AgentBot[]> {
-  return unwrap(await api.get('/api/agent-bots'));
+  return unwrap(await api.get('/api/v1/agent-bots'));
 }
 
 export async function deleteAgentBot(id: number): Promise<void> {
-  await api.delete(`/api/agent-bots/${id}`);
+  await api.delete(`/api/v1/agent-bots/${id}`);
 }
 
 export async function updateAgentBotConfig(id: number, config: string): Promise<void> {
-  await api.put(`/api/agent-bots/${id}/config`, { config });
+  await api.put(`/api/v1/agent-bots/${id}/config`, { config });
 }
 
 export async function feishuInit(): Promise<{ supported: boolean; auth_methods: string[] }> {
-  return unwrap(await api.post('/api/agent-bots/feishu/init'));
+  return unwrap(await api.post('/api/v1/agent-bots/feishu/init'));
 }
 
 export async function feishuBegin(): Promise<FeishuBeginResponse> {
-  return unwrap(await api.post('/api/agent-bots/feishu/begin'));
+  return unwrap(await api.post('/api/v1/agent-bots/feishu/begin'));
 }
 
 /**
@@ -260,11 +260,11 @@ export function feishuPollSSE(
 }
 
 export async function getFeishuPush(): Promise<FeishuPushStatus[]> {
-  return unwrap(await api.get('/api/agent-bots/feishu/push'));
+  return unwrap(await api.get('/api/v1/agent-bots/feishu/push'));
 }
 
 export async function updateFeishuPush(params: UpdateFeishuPushParams): Promise<FeishuPushStatus> {
-  return unwrap(await api.put('/api/agent-bots/feishu/push', {
+  return unwrap(await api.put('/api/v1/agent-bots/feishu/push', {
     bot_id: params.botId,
     push_level: params.pushLevel,
     p2p_response_enabled: params.p2pResponseEnabled,
@@ -289,42 +289,42 @@ export async function getFeishuHistoryMessages(params?: {
   page?: number;
   page_size?: number;
 }): Promise<import('@/types').FeishuHistoryMessagesPage> {
-  return unwrap(await api.get('/api/feishu/history-messages', { params }));
+  return unwrap(await api.get('/api/v1/feishu/history-messages', { params }));
 }
 
 export async function getFeishuMessageStats(workspaceId?: number, hours?: number): Promise<import('@/types').FeishuMessageStats> {
   const params: Record<string, unknown> = {};
   if (workspaceId !== undefined) params.workspace_id = workspaceId;
   if (hours !== undefined) params.hours = hours;
-  return unwrap(await api.get('/api/feishu/message-stats', { params }));
+  return unwrap(await api.get('/api/v1/feishu/message-stats', { params }));
 }
 
 export async function getFeishuSenders(): Promise<FeishuSenderItem[]> {
-  return unwrap(await api.get('/api/feishu/senders'));
+  return unwrap(await api.get('/api/v1/feishu/senders'));
 }
 
 export async function getFeishuHistoryChats(botId?: number): Promise<import('@/types').FeishuHistoryChat[]> {
-  return unwrap(await api.get('/api/feishu/history-chats', { params: { bot_id: botId } }));
+  return unwrap(await api.get('/api/v1/feishu/history-chats', { params: { bot_id: botId } }));
 }
 
 /** 新增历史拉取群：用户在前端填写群 chat_id（替代旧的 /sethome 隐式写入 group_chat_id） */
 export async function createFeishuHistoryChat(botId: number, chatId: string, chatName?: string): Promise<import('@/types').FeishuHistoryChat> {
-  return unwrap(await api.post('/api/feishu/history-chats', { bot_id: botId, chat_id: chatId, chat_name: chatName }));
+  return unwrap(await api.post('/api/v1/feishu/history-chats', { bot_id: botId, chat_id: chatId, chat_name: chatName }));
 }
 
 /** 删除历史拉取群 */
 export async function deleteFeishuHistoryChat(id: number): Promise<void> {
-  await api.delete(`/api/feishu/history-chats/${id}`);
+  await api.delete(`/api/v1/feishu/history-chats/${id}`);
 }
 
 // Group Whitelist APIs
 
 export async function getGroupWhitelist(botId: number): Promise<WhitelistEntry[]> {
-  return unwrap(await api.get('/api/agent-bots/feishu/group-whitelist', { params: { bot_id: botId } }));
+  return unwrap(await api.get('/api/v1/agent-bots/feishu/group-whitelist', { params: { bot_id: botId } }));
 }
 
 export async function addGroupWhitelist(botId: number, senderOpenId: string, senderName?: string): Promise<WhitelistEntry> {
-  return unwrap(await api.post('/api/agent-bots/feishu/group-whitelist', {
+  return unwrap(await api.post('/api/v1/agent-bots/feishu/group-whitelist', {
     bot_id: botId,
     sender_open_id: senderOpenId,
     sender_name: senderName || null,
@@ -332,6 +332,6 @@ export async function addGroupWhitelist(botId: number, senderOpenId: string, sen
 }
 
 export async function deleteGroupWhitelist(id: number): Promise<void> {
-  await api.delete(`/api/agent-bots/feishu/group-whitelist/${id}`);
+  await api.delete(`/api/v1/agent-bots/feishu/group-whitelist/${id}`);
 }
 

--- a/frontend/src/utils/database/bots.ts
+++ b/frontend/src/utils/database/bots.ts
@@ -70,12 +70,13 @@ export interface UpdateWorkspaceSettingsParams {
 }
 
 // ============================================================================
-// Workspace API 函数（阶段8）
+// Workspace API 函数 — slash-commands/settings 嵌套在 /api/v1/workspaces/{ws} 下。
+// 后端 v1 用复数 workspaces（v0 用过单数 workspace），URL 写复数让拦截器加 v1 前缀。
 // ============================================================================
 
 /** 获取工作空间的斜杠命令列表 */
 export async function getWorkspaceSlashCommands(workspaceId: number): Promise<WorkspaceSlashCommand[]> {
-  return unwrap(await api.get(`/api/workspace/${workspaceId}/slash-commands`));
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/slash-commands`));
 }
 
 /** 创建工作空间的斜杠命令 */
@@ -83,7 +84,7 @@ export async function createWorkspaceSlashCommand(
   workspaceId: number,
   params: CreateWorkspaceSlashCommandParams,
 ): Promise<{ id: number }> {
-  return unwrap(await api.post(`/api/workspace/${workspaceId}/slash-commands`, params));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/slash-commands`, params));
 }
 
 /** 更新工作空间的斜杠命令 */
@@ -92,17 +93,17 @@ export async function updateWorkspaceSlashCommand(
   cmdId: number,
   params: UpdateWorkspaceSlashCommandParams,
 ): Promise<void> {
-  await api.put(`/api/workspace/${workspaceId}/slash-commands/${cmdId}`, params);
+  await api.put(`/api/workspaces/${workspaceId}/slash-commands/${cmdId}`, params);
 }
 
 /** 删除工作空间的斜杠命令 */
 export async function deleteWorkspaceSlashCommand(workspaceId: number, cmdId: number): Promise<void> {
-  await api.delete(`/api/workspace/${workspaceId}/slash-commands/${cmdId}`);
+  await api.delete(`/api/workspaces/${workspaceId}/slash-commands/${cmdId}`);
 }
 
 /** 获取工作空间的设置 */
 export async function getWorkspaceSettings(workspaceId: number): Promise<WorkspaceSettings> {
-  return unwrap(await api.get(`/api/workspace/${workspaceId}/settings`));
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/settings`));
 }
 
 /** 更新工作空间的设置 */
@@ -110,10 +111,10 @@ export async function updateWorkspaceSettings(
   workspaceId: number,
   params: UpdateWorkspaceSettingsParams,
 ): Promise<void> {
-  await api.put(`/api/workspace/${workspaceId}/settings`, params);
+  await api.put(`/api/workspaces/${workspaceId}/settings`, params);
 }
 
-/** 将 Bot 移动到另一个工作空间（阶段6级联） */
+/** 将 Bot 移动到另一个工作空间（agent-bots 为全局路由，拦截器加 v1 前缀） */
 export async function moveBotToWorkspace(botId: number, workspaceId: number): Promise<void> {
   await api.put(`/api/agent-bots/${botId}/workspace`, { workspace_id: workspaceId });
 }
@@ -224,7 +225,8 @@ export function feishuPollSSE(
   if (workspaceId !== undefined) {
     params.set('workspace_id', String(workspaceId));
   }
-  const url = `/api/agent-bots/feishu/poll-stream?${params.toString()}`;
+  // EventSource 走浏览器原生 fetch，不经 axios 拦截器，手动写 v1 前缀
+  const url = `/api/v1/agent-bots/feishu/poll-stream?${params.toString()}`;
   const eventSource = new EventSource(url);
 
   eventSource.addEventListener('result', (event) => {

--- a/frontend/src/utils/database/client.ts
+++ b/frontend/src/utils/database/client.ts
@@ -13,29 +13,6 @@ export const api = axios.create({
   timeout: 15000,
 });
 
-// ─── v1 路径重写拦截器 ─────────────────────────────────────────
-//
-// 后端已完成 K8s 风格的 v1 路由迁移（ADR-7），所有业务端点统一挂在 /api/v1/ 下。
-// 为避免逐处手改约 144 个全局调用 + blackboard/wiki 嵌套路径，这里在请求拦截器中
-// 统一把 /api/ 前缀重写为 /api/v1/。
-//
-// 排除项：
-// - /api/events：WebSocket 升级端点，后端不版本化，保持原路径。
-// - /api/v1/...：已是 v1 路径（手动迁移的 workspace-scoped 调用），跳过避免双前缀。
-api.interceptors.request.use((config) => {
-  const url = config.url;
-  if (!url || typeof url !== 'string') return config;
-  // WebSocket 升级端点不走版本化，原样放行
-  if (url === '/api/events' || url.startsWith('/api/events?')) return config;
-  // 已是 v1 路径，不重复重写（workspace-scoped 调用手写的 /api/v1/workspaces/...）
-  if (url.startsWith('/api/v1/')) return config;
-  // /api/ → /api/v1/，覆盖全部全局资源 + 已 path-nested 的 blackboard/wiki
-  if (url.startsWith('/api/')) {
-    config.url = '/api/v1/' + url.slice('/api/'.length);
-  }
-  return config;
-});
-
 /** Retry config: max 3 retries on network errors (no response), not on 4xx/5xx */
 const MAX_RETRIES = 3;
 

--- a/frontend/src/utils/database/client.ts
+++ b/frontend/src/utils/database/client.ts
@@ -13,6 +13,29 @@ export const api = axios.create({
   timeout: 15000,
 });
 
+// ─── v1 路径重写拦截器 ─────────────────────────────────────────
+//
+// 后端已完成 K8s 风格的 v1 路由迁移（ADR-7），所有业务端点统一挂在 /api/v1/ 下。
+// 为避免逐处手改约 144 个全局调用 + blackboard/wiki 嵌套路径，这里在请求拦截器中
+// 统一把 /api/ 前缀重写为 /api/v1/。
+//
+// 排除项：
+// - /api/events：WebSocket 升级端点，后端不版本化，保持原路径。
+// - /api/v1/...：已是 v1 路径（手动迁移的 workspace-scoped 调用），跳过避免双前缀。
+api.interceptors.request.use((config) => {
+  const url = config.url;
+  if (!url || typeof url !== 'string') return config;
+  // WebSocket 升级端点不走版本化，原样放行
+  if (url === '/api/events' || url.startsWith('/api/events?')) return config;
+  // 已是 v1 路径，不重复重写（workspace-scoped 调用手写的 /api/v1/workspaces/...）
+  if (url.startsWith('/api/v1/')) return config;
+  // /api/ → /api/v1/，覆盖全部全局资源 + 已 path-nested 的 blackboard/wiki
+  if (url.startsWith('/api/')) {
+    config.url = '/api/v1/' + url.slice('/api/'.length);
+  }
+  return config;
+});
+
 /** Retry config: max 3 retries on network errors (no response), not on 4xx/5xx */
 const MAX_RETRIES = 3;
 

--- a/frontend/src/utils/database/executions.ts
+++ b/frontend/src/utils/database/executions.ts
@@ -1,70 +1,89 @@
 import { api, unwrap } from './client';
 import type { ExecutionRecord, ExecutionSummary, ExecutionRecordsPage, ExecutionLogsPage, RunningBoardData } from '@/types';
 
-export async function getExecutionRecords(todoId?: number, page?: number, limit?: number, status?: string, stepId?: number, workspaceId?: number): Promise<ExecutionRecordsPage> {
+// 所有 execution 端点嵌套在 /api/v1/workspaces/{ws}/executions 下（后端 ADR-7）。
+// workspaceId 提升到 URL 路径段，调用方必须显式传入。
+
+export async function getExecutionRecords(
+  workspaceId: number,
+  todoId?: number,
+  page?: number,
+  limit?: number,
+  status?: string,
+  stepId?: number,
+): Promise<ExecutionRecordsPage> {
   const params: Record<string, unknown> = {};
   if (todoId !== undefined) params.todo_id = todoId;
   if (stepId !== undefined) params.step_id = stepId;
   if (page !== undefined) params.page = page;
   if (limit !== undefined) params.limit = limit;
   if (status !== undefined) params.status = status;
-  if (workspaceId !== undefined) params.workspace_id = workspaceId;
-  return unwrap(await api.get('/api/execution-records', { params }));
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/executions`, { params }));
 }
 
-export async function getExecutionRecord(recordId: number): Promise<ExecutionRecord> {
-  return unwrap(await api.get(`/api/execution-records/${recordId}`));
+export async function getExecutionRecord(workspaceId: number, recordId: number): Promise<ExecutionRecord> {
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/executions/${recordId}`));
 }
 
-export async function getExecutionLogs(recordId: number, page?: number, perPage?: number): Promise<ExecutionLogsPage> {
+export async function getExecutionLogs(workspaceId: number, recordId: number, page?: number, perPage?: number): Promise<ExecutionLogsPage> {
   const params: Record<string, unknown> = {};
   if (page !== undefined) params.page = page;
   if (perPage !== undefined) params.per_page = perPage;
-  return unwrap(await api.get(`/api/execution-records/${recordId}/logs`, { params }));
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/executions/${recordId}/logs`, { params }));
 }
 
-export async function getExecutionRecordsBySession(sessionId: string): Promise<ExecutionRecord[]> {
-  return unwrap(await api.get(`/api/execution-records/session/${encodeURIComponent(sessionId)}`));
+export async function getExecutionRecordsBySession(workspaceId: number, sessionId: string): Promise<ExecutionRecord[]> {
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/executions/session/${encodeURIComponent(sessionId)}`));
 }
 
 /**
  * 执行指定 todo 任务。
  * 返回 task_id 用于 WebSocket 事件追踪，record_id 用于 UI 层立即获取并选中新创建的执行记录。
  */
-export async function executeTodo(todoId: number, executor?: string, params?: Record<string, string>): Promise<{ task_id: string; record_id: number }> {
-  return unwrap(await api.post('/api/execute', { todo_id: todoId, executor, params }));
+export async function executeTodo(
+  workspaceId: number,
+  todoId: number,
+  executor?: string,
+  params?: Record<string, string>,
+  model?: string | null,
+): Promise<{ task_id: string; record_id: number }> {
+  const body: Record<string, unknown> = { todo_id: todoId, executor, params };
+  // model：undefined=不传（沿用执行器/任务级配置）；null/空串=显式清除本次执行模型
+  if (model !== undefined) body.model = model;
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/executions`, body));
 }
 
-export async function getExecutionSummary(todoId: number): Promise<ExecutionSummary> {
-  return unwrap(await api.get(`/api/todos/${todoId}/summary`));
+/** 获取 todo 执行摘要，路径为 /todos/{id}/summary（嵌套在 workspace todos 下）。 */
+export async function getExecutionSummary(workspaceId: number, todoId: number): Promise<ExecutionSummary> {
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/todos/${todoId}/summary`));
 }
 
-export async function getRecentCompletedTodos(hours?: number, workspaceId?: number): Promise<import('@/types').RecentCompletedTodo[]> {
+export async function getRecentCompletedTodos(workspaceId: number, hours?: number): Promise<import('@/types').RecentCompletedTodo[]> {
   const p: Record<string, number> = {};
   if (hours !== undefined) p.hours = hours;
-  if (workspaceId !== undefined) p.workspace_id = workspaceId;
-  return unwrap(await api.get('/api/todos/recent-completed', { params: Object.keys(p).length > 0 ? p : undefined }));
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/todos/recent-completed`, { params: Object.keys(p).length > 0 ? p : undefined }));
 }
 
-export async function getDashboardStats(hours?: number): Promise<import('@/types').DashboardStats> {
+/** GET /api/v1/workspaces/{ws}/stats/dashboard — 仪表盘聚合统计，workspace 隔离。 */
+export async function getDashboardStats(workspaceId: number, hours?: number): Promise<import('@/types').DashboardStats> {
   const p = hours !== undefined ? { hours } : undefined;
-  return unwrap(await api.get('/api/dashboard-stats', { params: p }));
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/stats/dashboard`, { params: p }));
 }
 
-export async function stopExecution(recordId: number): Promise<void> {
-  await api.post('/api/execute/stop', { record_id: recordId });
+export async function stopExecution(workspaceId: number, recordId: number): Promise<void> {
+  await api.post(`/api/workspaces/${workspaceId}/executions/${recordId}/stop`, { record_id: recordId });
 }
 
-export async function forceFailExecution(recordId: number): Promise<void> {
-  await api.post('/api/execute/force-fail', { record_id: recordId });
+export async function forceFailExecution(workspaceId: number, recordId: number): Promise<void> {
+  await api.post(`/api/workspaces/${workspaceId}/executions/${recordId}/force-fail`, { record_id: recordId });
 }
 
-export async function getRunningExecutionRecords(): Promise<ExecutionRecord[]> {
-  return unwrap(await api.get('/api/execution-records/running'));
+export async function getRunningExecutionRecords(workspaceId: number): Promise<ExecutionRecord[]> {
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/executions/running`));
 }
 
-export async function resumeExecutionRecord(recordId: number, message?: string): Promise<{ task_id: string; record_id: number }> {
-  return unwrap(await api.post(`/api/execution-records/${recordId}/resume`, { message }));
+export async function resumeExecutionRecord(workspaceId: number, recordId: number, message?: string): Promise<{ task_id: string; record_id: number }> {
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/executions/${recordId}/resume`, { message }));
 }
 
 /**
@@ -72,13 +91,14 @@ export async function resumeExecutionRecord(recordId: number, message?: string):
  * running 记录后端会拒绝。传 null 表示清除评分。
  */
 export async function rateExecutionRecord(
+  workspaceId: number,
   recordId: number,
   rating: number | null,
 ): Promise<ExecutionRecord> {
-  return unwrap(await api.put(`/api/execution-records/${recordId}/rating`, { rating }));
+  return unwrap(await api.put(`/api/workspaces/${workspaceId}/executions/${recordId}/rating`, { rating }));
 }
 
-// Smart Create API
+// Smart Create API — POST /api/v1/workspaces/{ws}/todos/smart（嵌套在 todos 下）
 
 export interface SmartCreateResult {
   task_id: string;
@@ -87,15 +107,19 @@ export interface SmartCreateResult {
   todo_title: string;
 }
 
-export async function smartCreate(content: string): Promise<SmartCreateResult> {
-  return unwrap(await api.post('/api/smart-create', { content }));
+export async function smartCreate(workspaceId: number, content: string): Promise<SmartCreateResult> {
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/smart`, { content }));
 }
 
-export async function getRunningBoardData(page?: number, limit?: number, workspaceId?: number, hours?: number): Promise<RunningBoardData> {
+export async function getRunningBoardData(
+  workspaceId: number,
+  page?: number,
+  limit?: number,
+  hours?: number,
+): Promise<RunningBoardData> {
   const params: Record<string, unknown> = {};
   if (page !== undefined) params.page = page;
   if (limit !== undefined) params.limit = limit;
-  if (workspaceId !== undefined) params.workspace_id = workspaceId;
   if (hours !== undefined) params.hours = hours;
-  return unwrap(await api.get('/api/running-board', { params }));
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/executions/running-board`, { params }));
 }

--- a/frontend/src/utils/database/executions.ts
+++ b/frontend/src/utils/database/executions.ts
@@ -18,22 +18,22 @@ export async function getExecutionRecords(
   if (page !== undefined) params.page = page;
   if (limit !== undefined) params.limit = limit;
   if (status !== undefined) params.status = status;
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/executions`, { params }));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/executions`, { params }));
 }
 
 export async function getExecutionRecord(workspaceId: number, recordId: number): Promise<ExecutionRecord> {
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/executions/${recordId}`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/executions/${recordId}`));
 }
 
 export async function getExecutionLogs(workspaceId: number, recordId: number, page?: number, perPage?: number): Promise<ExecutionLogsPage> {
   const params: Record<string, unknown> = {};
   if (page !== undefined) params.page = page;
   if (perPage !== undefined) params.per_page = perPage;
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/executions/${recordId}/logs`, { params }));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/executions/${recordId}/logs`, { params }));
 }
 
 export async function getExecutionRecordsBySession(workspaceId: number, sessionId: string): Promise<ExecutionRecord[]> {
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/executions/session/${encodeURIComponent(sessionId)}`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/executions/session/${encodeURIComponent(sessionId)}`));
 }
 
 /**
@@ -50,40 +50,40 @@ export async function executeTodo(
   const body: Record<string, unknown> = { todo_id: todoId, executor, params };
   // model：undefined=不传（沿用执行器/任务级配置）；null/空串=显式清除本次执行模型
   if (model !== undefined) body.model = model;
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/executions`, body));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/executions`, body));
 }
 
 /** 获取 todo 执行摘要，路径为 /todos/{id}/summary（嵌套在 workspace todos 下）。 */
 export async function getExecutionSummary(workspaceId: number, todoId: number): Promise<ExecutionSummary> {
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/todos/${todoId}/summary`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/todos/${todoId}/summary`));
 }
 
 export async function getRecentCompletedTodos(workspaceId: number, hours?: number): Promise<import('@/types').RecentCompletedTodo[]> {
   const p: Record<string, number> = {};
   if (hours !== undefined) p.hours = hours;
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/todos/recent-completed`, { params: Object.keys(p).length > 0 ? p : undefined }));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/todos/recent-completed`, { params: Object.keys(p).length > 0 ? p : undefined }));
 }
 
 /** GET /api/v1/workspaces/{ws}/stats/dashboard — 仪表盘聚合统计，workspace 隔离。 */
 export async function getDashboardStats(workspaceId: number, hours?: number): Promise<import('@/types').DashboardStats> {
   const p = hours !== undefined ? { hours } : undefined;
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/stats/dashboard`, { params: p }));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/stats/dashboard`, { params: p }));
 }
 
 export async function stopExecution(workspaceId: number, recordId: number): Promise<void> {
-  await api.post(`/api/workspaces/${workspaceId}/executions/${recordId}/stop`, { record_id: recordId });
+  await api.post(`/api/v1/workspaces/${workspaceId}/executions/${recordId}/stop`, { record_id: recordId });
 }
 
 export async function forceFailExecution(workspaceId: number, recordId: number): Promise<void> {
-  await api.post(`/api/workspaces/${workspaceId}/executions/${recordId}/force-fail`, { record_id: recordId });
+  await api.post(`/api/v1/workspaces/${workspaceId}/executions/${recordId}/force-fail`, { record_id: recordId });
 }
 
 export async function getRunningExecutionRecords(workspaceId: number): Promise<ExecutionRecord[]> {
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/executions/running`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/executions/running`));
 }
 
 export async function resumeExecutionRecord(workspaceId: number, recordId: number, message?: string): Promise<{ task_id: string; record_id: number }> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/executions/${recordId}/resume`, { message }));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/executions/${recordId}/resume`, { message }));
 }
 
 /**
@@ -95,7 +95,7 @@ export async function rateExecutionRecord(
   recordId: number,
   rating: number | null,
 ): Promise<ExecutionRecord> {
-  return unwrap(await api.put(`/api/workspaces/${workspaceId}/executions/${recordId}/rating`, { rating }));
+  return unwrap(await api.put(`/api/v1/workspaces/${workspaceId}/executions/${recordId}/rating`, { rating }));
 }
 
 // Smart Create API — POST /api/v1/workspaces/{ws}/todos/smart（嵌套在 todos 下）
@@ -108,7 +108,7 @@ export interface SmartCreateResult {
 }
 
 export async function smartCreate(workspaceId: number, content: string): Promise<SmartCreateResult> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/smart`, { content }));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/todos/smart`, { content }));
 }
 
 export async function getRunningBoardData(
@@ -121,5 +121,5 @@ export async function getRunningBoardData(
   if (page !== undefined) params.page = page;
   if (limit !== undefined) params.limit = limit;
   if (hours !== undefined) params.hours = hours;
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/executions/running-board`, { params }));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/executions/running-board`, { params }));
 }

--- a/frontend/src/utils/database/experts.ts
+++ b/frontend/src/utils/database/experts.ts
@@ -13,7 +13,7 @@ const inflightMap = new Map<string, Promise<ExpertMetadata>>();
  * 从后端内存索引中获取已加载的专家元数据，包括单个专家和专家团队。
  */
 export async function getAllExperts(): Promise<ExpertMetadata[]> {
-  return unwrap(await api.get('/api/experts'));
+  return unwrap(await api.get('/api/v1/experts'));
 }
 
 /**
@@ -22,7 +22,7 @@ export async function getAllExperts(): Promise<ExpertMetadata[]> {
  * 根据专家名称获取完整的元数据信息。
  */
 export async function getExpertByName(name: string): Promise<ExpertMetadata> {
-  return unwrap(await api.get(`/api/experts/${encodeURIComponent(name)}`));
+  return unwrap(await api.get(`/api/v1/experts/${encodeURIComponent(name)}`));
 }
 
 /**
@@ -78,7 +78,7 @@ export function invalidateExpertCache(name?: string): void {
  * 返回完整的 MD 文件内容，用于执行时注入 prompt。
  */
 export async function getExpertAgentMd(name: string): Promise<string> {
-  return unwrap(await api.get(`/api/experts/${encodeURIComponent(name)}/agent-md`));
+  return unwrap(await api.get(`/api/v1/experts/${encodeURIComponent(name)}/agent-md`));
 }
 
 /**
@@ -87,7 +87,7 @@ export async function getExpertAgentMd(name: string): Promise<string> {
  * 返回专家绑定的技能列表，用于前端展示可用技能。
  */
 export async function getExpertSkills(name: string): Promise<SkillMetadata[]> {
-  return unwrap(await api.get(`/api/experts/${encodeURIComponent(name)}/skills`));
+  return unwrap(await api.get(`/api/v1/experts/${encodeURIComponent(name)}/skills`));
 }
 
 /**
@@ -97,7 +97,7 @@ export async function getExpertSkills(name: string): Promise<SkillMetadata[]> {
  * 返回加载结果（成功数量和错误列表）。
  */
 export async function reloadExperts(): Promise<LoadResult> {
-  return unwrap(await api.post('/api/experts/reload'));
+  return unwrap(await api.post('/api/v1/experts/reload'));
 }
 
 /**
@@ -107,7 +107,7 @@ export async function reloadExperts(): Promise<LoadResult> {
  * 也无法被选择使用。此操作不可逆，请谨慎操作。
  */
 export async function deleteExpert(name: string): Promise<void> {
-  await api.delete(`/api/experts/${encodeURIComponent(name)}`);
+  await api.delete(`/api/v1/experts/${encodeURIComponent(name)}`);
 }
 
 /**
@@ -117,7 +117,7 @@ export async function deleteExpert(name: string): Promise<void> {
  * 后端会自动创建目录结构并加载到索引中。
  */
 export async function createExpertFromAi(pluginJson: string, agentMd: string): Promise<void> {
-  await api.post('/api/experts/create', {
+  await api.post('/api/v1/experts/create', {
     plugin_json: pluginJson,
     agent_md: agentMd,
   });
@@ -129,7 +129,7 @@ export async function createExpertFromAi(pluginJson: string, agentMd: string): P
  * 返回 plugin.json 文件的原始文本内容，用于前端编辑。
  */
 export async function getExpertPluginJson(name: string): Promise<string> {
-  return unwrap(await api.get(`/api/experts/${encodeURIComponent(name)}/plugin-json`));
+  return unwrap(await api.get(`/api/v1/experts/${encodeURIComponent(name)}/plugin-json`));
 }
 
 /**
@@ -139,7 +139,7 @@ export async function getExpertPluginJson(name: string): Promise<string> {
  * 专家名称不可修改，如需改名请删除后重新创建。
  */
 export async function updateExpert(name: string, pluginJson: string, agentMd: string): Promise<void> {
-  await api.put(`/api/experts/${encodeURIComponent(name)}`, {
+  await api.put(`/api/v1/experts/${encodeURIComponent(name)}`, {
     plugin_json: pluginJson,
     agent_md: agentMd,
   });
@@ -152,7 +152,7 @@ export async function updateExpert(name: string, pluginJson: string, agentMd: st
  * 返回 Blob 类型的二进制数据，前端通过 a 标签触发下载。
  */
 export async function exportExpert(name: string): Promise<Blob> {
-  const response = await api.get(`/api/experts/${encodeURIComponent(name)}/export`, {
+  const response = await api.get(`/api/v1/experts/${encodeURIComponent(name)}/export`, {
     responseType: 'blob',
   });
   return response.data;
@@ -169,7 +169,7 @@ export async function importExpert(file: File): Promise<{ expert: ExpertMetadata
   formData.append('file', file);
   // 不手动设 Content-Type：交给 axios/浏览器自动生成带 boundary 的 multipart 头，
   // 手动设 multipart/form-data 会缺少 boundary 导致后端无法解析请求体。
-  return unwrap(await api.post('/api/experts/import', formData));
+  return unwrap(await api.post('/api/v1/experts/import', formData));
 }
 
 /**
@@ -179,7 +179,7 @@ export async function importExpert(file: File): Promise<{ expert: ExpertMetadata
  * 用于从 WorkBuddy 插件目录批量导入专家。
  */
 export async function importExpertFromDirectory(path: string): Promise<{ expert: ExpertMetadata | null; errors: string[] }> {
-  return unwrap(await api.post('/api/experts/import-from-directory', { path }));
+  return unwrap(await api.post('/api/v1/experts/import-from-directory', { path }));
 }
 
 /**
@@ -190,7 +190,7 @@ export async function importExpertFromDirectory(path: string): Promise<{ expert:
  * 已存在的专家会被跳过，不会覆盖。
  */
 export async function importFromWorkbuddy(): Promise<WorkbuddyImportResult> {
-  return unwrap(await api.post('/api/experts/import-from-workbuddy'));
+  return unwrap(await api.post('/api/v1/experts/import-from-workbuddy'));
 }
 
 /** 从 WorkBuddy 批量导入的结果 */

--- a/frontend/src/utils/database/loops.ts
+++ b/frontend/src/utils/database/loops.ts
@@ -1,17 +1,8 @@
 // Loop Studio API 客户端。
 //
-// 后端路由在 backend/src/handlers/loop_.rs：
-// - GET    /api/loops                        列表(带 trigger/step/exec 计数)
-// - POST   /api/loops                        新建(draft)
-// - GET    /api/loops/{id}                   详情(loop + triggers + steps + todo_map)
-// - PUT    /api/loops/{id}                   全量更新基本字段
-// - DELETE /api/loops/{id}                   删除(级联清子表)
-// - PUT    /api/loops/{id}/status            切换 enabled/paused
-// - POST   /api/loops/{id}/duplicate         复制
-// - POST   /api/loops/{id}/trigger           手动触发
-// - GET/POST/PUT/DELETE /api/loops/{id}/triggers[/tid]
-// - GET    /api/loops/{id}/executions        运行历史(分页)
-// - GET    /api/loops/{id}/executions/{eid}  单次执行详情
+// 后端 v1 路由（backend/src/handlers/loop_.rs 的 v1_routes）嵌套在
+// /api/v1/workspaces/{ws}/loops 下，workspaceId 必须在 URL 路径段中显式传入。
+// 所有函数的第一个参数都是 workspaceId（即 project_directories.id）。
 
 import { api, unwrap } from './client';
 import type {
@@ -34,12 +25,11 @@ import type {
 
 // ====== Loop 主体 ======
 
-/** 列出所有 loop,按更新时间倒序。可选按工作空间 ID 过滤。 */
-export async function listLoops(workspace_id?: number | null): Promise<LoopListItem[]> {
-  const params: Record<string, string> = {};
-  if (workspace_id != null) params.workspace_id = String(workspace_id);
-  const qs = Object.keys(params).length ? `?${new URLSearchParams(params).toString()}` : '';
-  return unwrap(await api.get(`/api/loops${qs}`));
+/** 列出指定工作空间下的所有 loop,按更新时间倒序。 */
+export async function listLoops(workspaceId: number | null): Promise<LoopListItem[]> {
+  // null workspace 时仍发请求（后端可能在 URL 用 0 或报错），让调用方处理失败
+  const ws = workspaceId ?? 0;
+  return unwrap(await api.get(`/api/workspaces/${ws}/loops`));
 }
 
 // ====== Loop 聚合统计(dashboard「自动化」Tab)======
@@ -66,96 +56,102 @@ export interface LoopTriggerTypeCount {
   failed_count: number;
 }
 
-/** GET /api/loops/stats?hours=N:全 loop 聚合统计。hours 缺省或 0 表示全时段。 */
-export async function getLoopStats(hours?: number): Promise<LoopStats> {
+/** GET /api/v1/workspaces/{ws}/loops/stats:按工作空间聚合 loop 统计。hours 缺省或 0 表示全时段。 */
+export async function getLoopStats(workspaceId: number, hours?: number): Promise<LoopStats> {
   const qs = hours && hours > 0 ? `?hours=${hours}` : '';
-  return unwrap(await api.get(`/api/loops/stats${qs}`));
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/loops/stats${qs}`));
 }
 
 /** 单个 loop 详情,含 triggers/steps/hooks/todo_map。 */
-export async function getLoop(id: number): Promise<LoopDetail> {
-  return unwrap(await api.get(`/api/loops/${id}`));
+export async function getLoop(workspaceId: number, id: number): Promise<LoopDetail> {
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/loops/${id}`));
 }
 
 /** 新建 loop,后端强制 status=paused。 */
-export async function createLoop(req: CreateLoopRequest): Promise<LoopListItem> {
-  return unwrap(await api.post('/api/loops', req));
+export async function createLoop(workspaceId: number, req: CreateLoopRequest): Promise<LoopListItem> {
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops`, req));
 }
 
 /** 全量更新 loop 基本字段。 */
-export async function updateLoop(id: number, req: UpdateLoopRequest): Promise<LoopListItem> {
-  return unwrap(await api.put(`/api/loops/${id}`, req));
+export async function updateLoop(workspaceId: number, id: number, req: UpdateLoopRequest): Promise<LoopListItem> {
+  return unwrap(await api.put(`/api/workspaces/${workspaceId}/loops/${id}`, req));
 }
 
 /** 删除 loop,级联清子表。 */
-export async function deleteLoop(id: number): Promise<void> {
-  await api.delete(`/api/loops/${id}`);
+export async function deleteLoop(workspaceId: number, id: number): Promise<void> {
+  await api.delete(`/api/workspaces/${workspaceId}/loops/${id}`);
 }
 
 /** 切换 loop 状态(enabled/paused)。 */
 export async function updateLoopStatus(
+  workspaceId: number,
   id: number,
   req: UpdateLoopStatusRequest,
 ): Promise<LoopListItem> {
-  return unwrap(await api.put(`/api/loops/${id}/status`, req));
+  return unwrap(await api.put(`/api/workspaces/${workspaceId}/loops/${id}/status`, req));
 }
 
 /** 复制 loop(返回新 loop)。 */
-export async function duplicateLoop(id: number): Promise<LoopListItem> {
-  return unwrap(await api.post(`/api/loops/${id}/duplicate`, {}));
+export async function duplicateLoop(workspaceId: number, id: number): Promise<LoopListItem> {
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/${id}/duplicate`, {}));
 }
 
 /** 手动触发 loop,返回新创建的 execution_id。 */
-export async function triggerLoop(id: number): Promise<LoopTriggerResponse> {
-  return unwrap(await api.post(`/api/loops/${id}/trigger`, {}));
+export async function triggerLoop(workspaceId: number, id: number): Promise<LoopTriggerResponse> {
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/${id}/trigger`, {}));
 }
 
 // ====== Triggers ======
 
 export async function createTrigger(
+  workspaceId: number,
   loopId: number,
   req: CreateTriggerRequest,
 ): Promise<LoopTriggerDto> {
-  return unwrap(await api.post(`/api/loops/${loopId}/triggers`, req));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/${loopId}/triggers`, req));
 }
 
 export async function updateTrigger(
+  workspaceId: number,
   loopId: number,
   triggerId: number,
   req: UpdateTriggerRequest,
 ): Promise<LoopTriggerDto> {
-  return unwrap(await api.put(`/api/loops/${loopId}/triggers/${triggerId}`, req));
+  return unwrap(await api.put(`/api/workspaces/${workspaceId}/loops/${loopId}/triggers/${triggerId}`, req));
 }
 
-export async function deleteTrigger(loopId: number, triggerId: number): Promise<void> {
-  await api.delete(`/api/loops/${loopId}/triggers/${triggerId}`);
+export async function deleteTrigger(workspaceId: number, loopId: number, triggerId: number): Promise<void> {
+  await api.delete(`/api/workspaces/${workspaceId}/loops/${loopId}/triggers/${triggerId}`);
 }
 
 // ====== Steps ======
 
 export async function createLoopStep(
+  workspaceId: number,
   loopId: number,
   req: CreateLoopStepRequest,
 ): Promise<LoopStepDto> {
-  return unwrap(await api.post(`/api/loops/${loopId}/steps`, req));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/${loopId}/steps`, req));
 }
 
 export async function updateLoopStep(
+  workspaceId: number,
   loopId: number,
   stepId: number,
   req: UpdateLoopStepRequest,
 ): Promise<LoopStepDto> {
-  return unwrap(await api.put(`/api/loops/${loopId}/steps/${stepId}`, req));
+  return unwrap(await api.put(`/api/workspaces/${workspaceId}/loops/${loopId}/steps/${stepId}`, req));
 }
 
-export async function deleteLoopStep(loopId: number, stepId: number): Promise<void> {
-  await api.delete(`/api/loops/${loopId}/steps/${stepId}`);
+export async function deleteLoopStep(workspaceId: number, loopId: number, stepId: number): Promise<void> {
+  await api.delete(`/api/workspaces/${workspaceId}/loops/${loopId}/steps/${stepId}`);
 }
 
 // ====== Executions ======
 
 /** 分页列出 loop 运行历史。 */
 export async function listExecutions(
+  workspaceId: number,
   loopId: number,
   query: LoopExecutionListQuery = {},
 ): Promise<LoopExecutionListResponse> {
@@ -164,29 +160,32 @@ export async function listExecutions(
   if (query.limit) params.limit = String(query.limit);
   if (query.hours) params.hours = String(query.hours);
   const qs = Object.keys(params).length ? `?${new URLSearchParams(params).toString()}` : '';
-  return unwrap(await api.get(`/api/loops/${loopId}/executions${qs}`));
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/loops/${loopId}/executions${qs}`));
 }
 
 /** 单次执行详情(含 step_executions)。 */
 export async function getExecution(
+  workspaceId: number,
   loopId: number,
   executionId: number,
 ): Promise<LoopExecutionDetail> {
-  return unwrap(await api.get(`/api/loops/${loopId}/executions/${executionId}`));
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/loops/${loopId}/executions/${executionId}`));
 }
 
 /** 通过执行 ID 直接获取执行详情（无需 loop_id），供消息历史跳转使用。 */
 export async function getExecutionById(
+  workspaceId: number,
   executionId: number,
 ): Promise<LoopExecutionDetail> {
-  return unwrap(await api.get(`/api/loop-executions/${executionId}`));
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/loop-executions/${executionId}`));
 }
 
 /**
  * 人工审批环节执行。
- * POST /api/loops/{loopId}/executions/{executionId}/steps/{stepExecutionId}/approve
+ * POST /api/v1/workspaces/{ws}/loops/{loopId}/executions/{executionId}/steps/{stepExecutionId}/approve
  */
 export async function approveStepExecution(
+  workspaceId: number,
   loopId: number,
   executionId: number,
   stepExecutionId: number,
@@ -194,63 +193,55 @@ export async function approveStepExecution(
   comment?: string,
 ): Promise<{ step_execution_id: number; rating: number; status: string }> {
   return unwrap(await api.post(
-    `/api/loops/${loopId}/executions/${executionId}/steps/${stepExecutionId}/approve`,
+    `/api/workspaces/${workspaceId}/loops/${loopId}/executions/${executionId}/steps/${stepExecutionId}/approve`,
     { rating, comment },
   ));
 }
 
-// ─── 批量操作（占位实现） ────────────────────────────────────────
+// ─── 批量操作 ───────────────────────────────────────────────────
 
 /**
- * 批量强停环路。
+ * 批量强停环路（占位实现）。
  *
- * 后端目前没有「批量强停 loop」接口（handlers/loop_.rs 仅提供单条
- * execution_record 的 stop API），这里只放前端占位：弹提示 + 返回空结果。
- * 后续接入真实接口时，把函数体换成单次 POST 即可，外部签名保持不变。
- *
- * 期望后端契约：
- *   POST /api/loops/batch-stop
- *   body: { loop_ids: number[] }
- *   response: { stopped: number[], failed: number[] }
+ * 后端目前没有「批量强停 loop」接口，这里只放前端占位：直接返回"全部失败"。
  */
 export async function forceStopLoops(
   loopIds: number[],
 ): Promise<{ stopped: number[]; failed: number[] }> {
-  // 占位：开发中提示由调用方弹（utils 内部不依赖 message 上下文）。
-  // 直接返回"全部失败"，强制调用方走失败分支走提示。
   return { stopped: [], failed: [...loopIds] };
 }
 
-/** 批量移动环路到其他工作空间。 */
+/** 批量移动环路到其他工作空间。workspaceId 为源空间，workspace_id 为目标空间。 */
 export async function batchMoveLoopsWorkspace(
+  workspaceId: number,
   ids: number[],
   workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.put('/api/loops/batch-workspace', { ids, workspace_id }));
+  return unwrap(await api.put(`/api/workspaces/${workspaceId}/loops/batch-workspace`, { ids, workspace_id }));
 }
 
-/** 批量复制环路到其他工作空间。 */
+/** 批量复制环路到其他工作空间。workspaceId 为源空间，workspace_id 为目标空间。 */
 export async function batchCopyLoopsWorkspace(
+  workspaceId: number,
   ids: number[],
   workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.post('/api/loops/batch-copy-workspace', { ids, workspace_id }));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/batch-copy-workspace`, { ids, workspace_id }));
 }
 
 
 // ====== Loop 导入导出 ======
 
-/** 导出单个环路为 YAML */
-export async function exportLoop(id: number): Promise<string> {
-  const response = await fetch(`/api/loops/${id}/export`);
+/** 导出单个环路为 YAML（原生 fetch，不走 axios 拦截器，手动写 v1 路径） */
+export async function exportLoop(workspaceId: number, id: number): Promise<string> {
+  const response = await fetch(`/api/v1/workspaces/${workspaceId}/loops/${id}/export`);
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
   return response.text();
 }
 
-/** 导出全库所有环路为单个 YAML，对齐 Todo「导出全部」 */
-export async function exportAllLoops(): Promise<string> {
-  const response = await fetch('/api/loops/export');
+/** 导出指定工作空间的所有环路为单个 YAML（原生 fetch，手动写 v1 路径） */
+export async function exportAllLoops(workspaceId: number): Promise<string> {
+  const response = await fetch(`/api/v1/workspaces/${workspaceId}/loops/export`);
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
   return response.text();
 }
-

--- a/frontend/src/utils/database/loops.ts
+++ b/frontend/src/utils/database/loops.ts
@@ -217,7 +217,7 @@ export async function batchMoveLoopsWorkspace(
   ids: number[],
   workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.put(`/api/workspaces/${workspaceId}/loops/batch-workspace`, { ids, workspace_id }));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/batch/workspace`, { ids, workspace_id }));
 }
 
 /** 批量复制环路到其他工作空间。workspaceId 为源空间，workspace_id 为目标空间。 */
@@ -226,7 +226,7 @@ export async function batchCopyLoopsWorkspace(
   ids: number[],
   workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/batch-copy-workspace`, { ids, workspace_id }));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/batch/copy-workspace`, { ids, workspace_id }));
 }
 
 

--- a/frontend/src/utils/database/loops.ts
+++ b/frontend/src/utils/database/loops.ts
@@ -29,7 +29,7 @@ import type {
 export async function listLoops(workspaceId: number | null): Promise<LoopListItem[]> {
   // null workspace 时仍发请求（后端可能在 URL 用 0 或报错），让调用方处理失败
   const ws = workspaceId ?? 0;
-  return unwrap(await api.get(`/api/workspaces/${ws}/loops`));
+  return unwrap(await api.get(`/api/v1/workspaces/${ws}/loops`));
 }
 
 // ====== Loop 聚合统计(dashboard「自动化」Tab)======
@@ -59,27 +59,27 @@ export interface LoopTriggerTypeCount {
 /** GET /api/v1/workspaces/{ws}/loops/stats:按工作空间聚合 loop 统计。hours 缺省或 0 表示全时段。 */
 export async function getLoopStats(workspaceId: number, hours?: number): Promise<LoopStats> {
   const qs = hours && hours > 0 ? `?hours=${hours}` : '';
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/loops/stats${qs}`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/loops/stats${qs}`));
 }
 
 /** 单个 loop 详情,含 triggers/steps/hooks/todo_map。 */
 export async function getLoop(workspaceId: number, id: number): Promise<LoopDetail> {
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/loops/${id}`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/loops/${id}`));
 }
 
 /** 新建 loop,后端强制 status=paused。 */
 export async function createLoop(workspaceId: number, req: CreateLoopRequest): Promise<LoopListItem> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops`, req));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/loops`, req));
 }
 
 /** 全量更新 loop 基本字段。 */
 export async function updateLoop(workspaceId: number, id: number, req: UpdateLoopRequest): Promise<LoopListItem> {
-  return unwrap(await api.put(`/api/workspaces/${workspaceId}/loops/${id}`, req));
+  return unwrap(await api.put(`/api/v1/workspaces/${workspaceId}/loops/${id}`, req));
 }
 
 /** 删除 loop,级联清子表。 */
 export async function deleteLoop(workspaceId: number, id: number): Promise<void> {
-  await api.delete(`/api/workspaces/${workspaceId}/loops/${id}`);
+  await api.delete(`/api/v1/workspaces/${workspaceId}/loops/${id}`);
 }
 
 /** 切换 loop 状态(enabled/paused)。 */
@@ -88,17 +88,17 @@ export async function updateLoopStatus(
   id: number,
   req: UpdateLoopStatusRequest,
 ): Promise<LoopListItem> {
-  return unwrap(await api.put(`/api/workspaces/${workspaceId}/loops/${id}/status`, req));
+  return unwrap(await api.put(`/api/v1/workspaces/${workspaceId}/loops/${id}/status`, req));
 }
 
 /** 复制 loop(返回新 loop)。 */
 export async function duplicateLoop(workspaceId: number, id: number): Promise<LoopListItem> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/${id}/duplicate`, {}));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/loops/${id}/duplicate`, {}));
 }
 
 /** 手动触发 loop,返回新创建的 execution_id。 */
 export async function triggerLoop(workspaceId: number, id: number): Promise<LoopTriggerResponse> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/${id}/trigger`, {}));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/loops/${id}/trigger`, {}));
 }
 
 // ====== Triggers ======
@@ -108,7 +108,7 @@ export async function createTrigger(
   loopId: number,
   req: CreateTriggerRequest,
 ): Promise<LoopTriggerDto> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/${loopId}/triggers`, req));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/loops/${loopId}/triggers`, req));
 }
 
 export async function updateTrigger(
@@ -117,11 +117,11 @@ export async function updateTrigger(
   triggerId: number,
   req: UpdateTriggerRequest,
 ): Promise<LoopTriggerDto> {
-  return unwrap(await api.put(`/api/workspaces/${workspaceId}/loops/${loopId}/triggers/${triggerId}`, req));
+  return unwrap(await api.put(`/api/v1/workspaces/${workspaceId}/loops/${loopId}/triggers/${triggerId}`, req));
 }
 
 export async function deleteTrigger(workspaceId: number, loopId: number, triggerId: number): Promise<void> {
-  await api.delete(`/api/workspaces/${workspaceId}/loops/${loopId}/triggers/${triggerId}`);
+  await api.delete(`/api/v1/workspaces/${workspaceId}/loops/${loopId}/triggers/${triggerId}`);
 }
 
 // ====== Steps ======
@@ -131,7 +131,7 @@ export async function createLoopStep(
   loopId: number,
   req: CreateLoopStepRequest,
 ): Promise<LoopStepDto> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/${loopId}/steps`, req));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/loops/${loopId}/steps`, req));
 }
 
 export async function updateLoopStep(
@@ -140,11 +140,11 @@ export async function updateLoopStep(
   stepId: number,
   req: UpdateLoopStepRequest,
 ): Promise<LoopStepDto> {
-  return unwrap(await api.put(`/api/workspaces/${workspaceId}/loops/${loopId}/steps/${stepId}`, req));
+  return unwrap(await api.put(`/api/v1/workspaces/${workspaceId}/loops/${loopId}/steps/${stepId}`, req));
 }
 
 export async function deleteLoopStep(workspaceId: number, loopId: number, stepId: number): Promise<void> {
-  await api.delete(`/api/workspaces/${workspaceId}/loops/${loopId}/steps/${stepId}`);
+  await api.delete(`/api/v1/workspaces/${workspaceId}/loops/${loopId}/steps/${stepId}`);
 }
 
 // ====== Executions ======
@@ -160,7 +160,7 @@ export async function listExecutions(
   if (query.limit) params.limit = String(query.limit);
   if (query.hours) params.hours = String(query.hours);
   const qs = Object.keys(params).length ? `?${new URLSearchParams(params).toString()}` : '';
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/loops/${loopId}/executions${qs}`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/loops/${loopId}/executions${qs}`));
 }
 
 /** 单次执行详情(含 step_executions)。 */
@@ -169,7 +169,7 @@ export async function getExecution(
   loopId: number,
   executionId: number,
 ): Promise<LoopExecutionDetail> {
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/loops/${loopId}/executions/${executionId}`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/loops/${loopId}/executions/${executionId}`));
 }
 
 /** 通过执行 ID 直接获取执行详情（无需 loop_id），供消息历史跳转使用。 */
@@ -177,7 +177,7 @@ export async function getExecutionById(
   workspaceId: number,
   executionId: number,
 ): Promise<LoopExecutionDetail> {
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/loop-executions/${executionId}`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/loop-executions/${executionId}`));
 }
 
 /**
@@ -193,7 +193,7 @@ export async function approveStepExecution(
   comment?: string,
 ): Promise<{ step_execution_id: number; rating: number; status: string }> {
   return unwrap(await api.post(
-    `/api/workspaces/${workspaceId}/loops/${loopId}/executions/${executionId}/steps/${stepExecutionId}/approve`,
+    `/api/v1/workspaces/${workspaceId}/loops/${loopId}/executions/${executionId}/steps/${stepExecutionId}/approve`,
     { rating, comment },
   ));
 }
@@ -217,7 +217,7 @@ export async function batchMoveLoopsWorkspace(
   ids: number[],
   workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/batch/workspace`, { ids, workspace_id }));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/loops/batch/workspace`, { ids, workspace_id }));
 }
 
 /** 批量复制环路到其他工作空间。workspaceId 为源空间，workspace_id 为目标空间。 */
@@ -226,7 +226,7 @@ export async function batchCopyLoopsWorkspace(
   ids: number[],
   workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/loops/batch/copy-workspace`, { ids, workspace_id }));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/loops/batch/copy-workspace`, { ids, workspace_id }));
 }
 
 

--- a/frontend/src/utils/database/quickButtons.ts
+++ b/frontend/src/utils/database/quickButtons.ts
@@ -29,7 +29,7 @@ export interface UpdateQuickButtonParams {
 
 /** 列出当前 workspace 下的全部快捷按钮（后端按创建时间升序返回） */
 export async function getQuickButtons(workspaceId: number): Promise<QuickButton[]> {
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/quick-buttons`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/quick-buttons`));
 }
 
 /** 创建快捷按钮。重名由后端返回 400，调用方 catch 后提示即可 */
@@ -37,7 +37,7 @@ export async function createQuickButton(
   workspaceId: number,
   params: CreateQuickButtonParams,
 ): Promise<{ id: number }> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/quick-buttons`, params));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/quick-buttons`, params));
 }
 
 /** 更新快捷按钮（只传需要改的字段） */
@@ -46,10 +46,10 @@ export async function updateQuickButton(
   id: number,
   params: UpdateQuickButtonParams,
 ): Promise<void> {
-  await api.put(`/api/workspaces/${workspaceId}/quick-buttons/${id}`, params);
+  await api.put(`/api/v1/workspaces/${workspaceId}/quick-buttons/${id}`, params);
 }
 
 /** 删除快捷按钮 */
 export async function deleteQuickButton(workspaceId: number, id: number): Promise<void> {
-  await api.delete(`/api/workspaces/${workspaceId}/quick-buttons/${id}`);
+  await api.delete(`/api/v1/workspaces/${workspaceId}/quick-buttons/${id}`);
 }

--- a/frontend/src/utils/database/quickButtons.ts
+++ b/frontend/src/utils/database/quickButtons.ts
@@ -2,18 +2,19 @@ import { api, unwrap } from './client';
 
 /**
  * 快捷话术按钮：用户在回复框上方自定义的快捷按钮。
- * 全局共享（无 workspace 维度），点击把 prompt_text 填入回复输入框。
+ * 按 workspace 隔离，点击把 prompt_text 填入回复输入框。
  */
 export interface QuickButton {
   id: number;
   button_name: string;
   prompt_text: string;
+  workspace_id?: number | null;
   created_at: string | null;
   updated_at: string | null;
 }
 
 export interface CreateQuickButtonParams {
-  /** 按钮显示名称（全局唯一，重名后端返回 400） */
+  /** 按钮显示名称（同一 workspace 内唯一，重名后端返回 400） */
   button_name: string;
   /** 点击后填入回复输入框的话术 */
   prompt_text: string;
@@ -26,27 +27,29 @@ export interface UpdateQuickButtonParams {
   prompt_text?: string;
 }
 
-/** 列出全部快捷按钮（后端按创建时间升序返回） */
-export async function getQuickButtons(): Promise<QuickButton[]> {
-  return unwrap(await api.get('/api/quick-buttons'));
+/** 列出当前 workspace 下的全部快捷按钮（后端按创建时间升序返回） */
+export async function getQuickButtons(workspaceId: number): Promise<QuickButton[]> {
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/quick-buttons`));
 }
 
 /** 创建快捷按钮。重名由后端返回 400，调用方 catch 后提示即可 */
 export async function createQuickButton(
+  workspaceId: number,
   params: CreateQuickButtonParams,
 ): Promise<{ id: number }> {
-  return unwrap(await api.post('/api/quick-buttons', params));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/quick-buttons`, params));
 }
 
 /** 更新快捷按钮（只传需要改的字段） */
 export async function updateQuickButton(
+  workspaceId: number,
   id: number,
   params: UpdateQuickButtonParams,
 ): Promise<void> {
-  await api.put(`/api/quick-buttons/${id}`, params);
+  await api.put(`/api/workspaces/${workspaceId}/quick-buttons/${id}`, params);
 }
 
 /** 删除快捷按钮 */
-export async function deleteQuickButton(id: number): Promise<void> {
-  await api.delete(`/api/quick-buttons/${id}`);
+export async function deleteQuickButton(workspaceId: number, id: number): Promise<void> {
+  await api.delete(`/api/workspaces/${workspaceId}/quick-buttons/${id}`);
 }

--- a/frontend/src/utils/database/reviewTemplates.ts
+++ b/frontend/src/utils/database/reviewTemplates.ts
@@ -1,12 +1,12 @@
 // 评审模板 API 客户端。
 //
 // 后端路由在 backend/src/handlers/review_template.rs：
-// - GET    /api/review-templates          列表（含 prompt，管理面板用）
-// - GET    /api/review-templates/options  选项（不含 prompt，loop 选择器用）
-// - GET    /api/review-templates/{id}     详情
-// - POST   /api/review-templates          新建
-// - PUT    /api/review-templates/{id}     全量更新
-// - DELETE /api/review-templates/{id}     删除
+// - GET    /api/v1/review-templates          列表（含 prompt，管理面板用）
+// - GET    /api/v1/review-templates/options  选项（不含 prompt，loop 选择器用）
+// - GET    /api/v1/review-templates/{id}     详情
+// - POST   /api/v1/review-templates          新建
+// - PUT    /api/v1/review-templates/{id}     全量更新
+// - DELETE /api/v1/review-templates/{id}     删除
 
 import { api, unwrap } from './client';
 import type {
@@ -19,18 +19,18 @@ import type {
 /** 列出全部评审模板（含 prompt）。管理面板用。可选按 workspace_id 过滤。 */
 export async function listReviewTemplates(workspaceId?: number): Promise<ReviewTemplate[]> {
   const params = workspaceId !== undefined ? { workspace_id: workspaceId } : undefined;
-  return unwrap(await api.get('/api/review-templates', { params }));
+  return unwrap(await api.get('/api/v1/review-templates', { params }));
 }
 
 /** 列出评审模板的轻量选项（不含 prompt）。loop 编辑器选择器用。可选按 workspace_id 过滤。 */
 export async function listReviewTemplateOptions(workspaceId?: number): Promise<ReviewTemplateOption[]> {
   const params = workspaceId !== undefined ? { workspace_id: workspaceId } : undefined;
-  return unwrap(await api.get('/api/review-templates/options', { params }));
+  return unwrap(await api.get('/api/v1/review-templates/options', { params }));
 }
 
 /** 创建模板。后端校验 name/prompt 非空。 */
 export async function createReviewTemplate(req: CreateReviewTemplateRequest): Promise<ReviewTemplate> {
-  return unwrap(await api.post('/api/review-templates', req));
+  return unwrap(await api.post('/api/v1/review-templates', req));
 }
 
 /** 全量更新模板（PUT 语义）。后端校验 name/prompt 非空。 */
@@ -38,10 +38,10 @@ export async function updateReviewTemplate(
   id: number,
   req: UpdateReviewTemplateRequest,
 ): Promise<ReviewTemplate> {
-  return unwrap(await api.put(`/api/review-templates/${id}`, req));
+  return unwrap(await api.put(`/api/v1/review-templates/${id}`, req));
 }
 
 /** 删除模板。返回是否真的删了。 */
 export async function deleteReviewTemplate(id: number): Promise<boolean> {
-  return unwrap(await api.delete(`/api/review-templates/${id}`));
+  return unwrap(await api.delete(`/api/v1/review-templates/${id}`));
 }

--- a/frontend/src/utils/database/sessions.ts
+++ b/frontend/src/utils/database/sessions.ts
@@ -68,17 +68,17 @@ export async function listSessions(params: {
   project?: string;
   search?: string;
 }): Promise<SessionListResponse> {
-  return unwrap(await api.get('/api/sessions', { params }));
+  return unwrap(await api.get('/api/v1/sessions', { params }));
 }
 
 export async function getSessionStats(): Promise<SessionStats> {
-  return unwrap(await api.get('/api/sessions/stats'));
+  return unwrap(await api.get('/api/v1/sessions/stats'));
 }
 
 export async function getSessionDetail(sessionId: string): Promise<SessionDetail> {
-  return unwrap(await api.get(`/api/sessions/${sessionId}`));
+  return unwrap(await api.get(`/api/v1/sessions/${sessionId}`));
 }
 
 export async function deleteSession(sessionId: string): Promise<void> {
-  await api.delete(`/api/sessions/${sessionId}`);
+  await api.delete(`/api/v1/sessions/${sessionId}`);
 }

--- a/frontend/src/utils/database/skills.ts
+++ b/frontend/src/utils/database/skills.ts
@@ -2,19 +2,19 @@ import { api, unwrap } from './client';
 import type { ExecutorSkills, SkillComparison, SkillVersionUpdate } from '@/types';
 
 export async function getSkillsList(): Promise<ExecutorSkills[]> {
-  return unwrap(await api.get('/api/skills'));
+  return unwrap(await api.get('/api/v1/skills'));
 }
 
 export async function getSkillsComparison(): Promise<SkillComparison[]> {
-  return unwrap(await api.get('/api/skills/compare'));
+  return unwrap(await api.get('/api/v1/skills/compare'));
 }
 
 export async function getSkillVersionUpdates(): Promise<SkillVersionUpdate[]> {
-  return unwrap(await api.get('/api/skills/version-update'));
+  return unwrap(await api.get('/api/v1/skills/version-update'));
 }
 
 export async function syncSkill(sourceExecutor: string, skillName: string, targetExecutors: string[]): Promise<string> {
-  return unwrap(await api.post('/api/skills/sync', {
+  return unwrap(await api.post('/api/v1/skills/sync', {
     source_executor: sourceExecutor,
     skill_name: skillName,
     target_executors: targetExecutors,
@@ -22,14 +22,14 @@ export async function syncSkill(sourceExecutor: string, skillName: string, targe
 }
 
 export async function deleteSkill(executor: string, skillName: string): Promise<string> {
-  return unwrap(await api.delete('/api/skills', {
+  return unwrap(await api.delete('/api/v1/skills', {
     params: { executor, skill_name: skillName },
   }));
 }
 
 // 注：「调用追踪」tab 已移除，因此原 getSkillInvocations 随之删除。
 // Dashboard 上的「技能调用次数」「成功率」走 db/dashboard.rs 聚合统计，
-// 与本页分页接口两条独立路径，POST /api/skills/invocations 仍保留
+// 与本页分页接口两条独立路径，POST /api/v1/skills/invocations 仍保留
 // 给执行器调用上报用。
 
 // Skill content & files
@@ -48,7 +48,7 @@ export interface SkillContent {
 }
 
 export async function getSkillContent(executor: string, skillName: string): Promise<SkillContent> {
-  return unwrap(await api.get('/api/skills/content', {
+  return unwrap(await api.get('/api/v1/skills/content', {
     params: { executor, skill_name: skillName },
   }));
 }
@@ -59,13 +59,13 @@ export interface SkillFileContent {
 }
 
 export async function getSkillFileContent(executor: string, skillName: string, path: string): Promise<SkillFileContent> {
-  return unwrap(await api.get('/api/skills/file', {
+  return unwrap(await api.get('/api/v1/skills/file', {
     params: { executor, skill_name: skillName, path },
   }));
 }
 
 export async function exportSkill(executor: string, skillName: string): Promise<Blob> {
-  const response = await api.get('/api/skills/export', {
+  const response = await api.get('/api/v1/skills/export', {
     params: { executor, skill_name: skillName },
     responseType: 'blob',
   });
@@ -83,7 +83,7 @@ export async function importSkill(executor: string, file: File, skillName?: stri
   if (skillName) params.skill_name = skillName;
   if (flatten !== undefined) params.flatten = String(flatten);
 
-  const response = await api.post('/api/skills/import', await file.arrayBuffer(), {
+  const response = await api.post('/api/v1/skills/import', await file.arrayBuffer(), {
     params,
     headers: { 'Content-Type': 'application/zip' },
   });
@@ -93,48 +93,48 @@ export async function importSkill(executor: string, file: File, skillName?: stri
 // Config APIs
 
 export async function getConfig(): Promise<import('@/types').Config> {
-  return unwrap(await api.get('/api/config'));
+  return unwrap(await api.get('/api/v1/config'));
 }
 
 export async function updateConfig(config: import('@/types').Config): Promise<import('@/types').Config> {
-  return unwrap(await api.put('/api/config', config));
+  return unwrap(await api.put('/api/v1/config', config));
 }
 
 // Executor Config APIs
 
 export async function getExecutors(): Promise<import('@/types').ExecutorConfig[]> {
-  return unwrap(await api.get('/api/executors'));
+  return unwrap(await api.get('/api/v1/executors'));
 }
 
 export async function updateExecutor(name: string, data: { path?: string; enabled?: boolean; display_name?: string; session_dir?: string; default_model?: string }): Promise<import('@/types').ExecutorConfig> {
-  return unwrap(await api.put(`/api/executors/${encodeURIComponent(name)}`, data));
+  return unwrap(await api.put(`/api/v1/executors/${encodeURIComponent(name)}`, data));
 }
 
 /** 拉取执行器支持的模型列表（调其 models 子命令，用作默认模型下拉选项）。 */
 export async function getExecutorModels(name: string): Promise<string[]> {
-  return unwrap(await api.get(`/api/executors/${encodeURIComponent(name)}/models`));
+  return unwrap(await api.get(`/api/v1/executors/${encodeURIComponent(name)}/models`));
 }
 
 export async function detectExecutor(name: string): Promise<{ binary_found: boolean; path_resolved: string | null }> {
-  return unwrap(await api.post(`/api/executors/${encodeURIComponent(name)}/detect`));
+  return unwrap(await api.post(`/api/v1/executors/${encodeURIComponent(name)}/detect`));
 }
 
 export async function repairExecutor(name: string): Promise<{ binary_found: boolean; path_resolved: string | null; path_updated: boolean; old_path: string | null; new_path: string | null }> {
-  return unwrap(await api.post(`/api/executors/${encodeURIComponent(name)}/resolve`));
+  return unwrap(await api.post(`/api/v1/executors/${encodeURIComponent(name)}/resolve`));
 }
 
 export async function testExecutor(name: string): Promise<{ test_passed: boolean; output: string | null; error: string | null }> {
-  return unwrap(await api.post(`/api/executors/${encodeURIComponent(name)}/test`));
+  return unwrap(await api.post(`/api/v1/executors/${encodeURIComponent(name)}/test`));
 }
 
 /** 获取系统默认执行器 */
 export async function getDefaultExecutor(): Promise<import('@/types').ExecutorConfig | null> {
-  return unwrap(await api.get('/api/executors/default'));
+  return unwrap(await api.get('/api/v1/executors/default'));
 }
 
 /** 设置指定执行器为系统默认执行器 */
 export async function setDefaultExecutor(name: string): Promise<import('@/types').ExecutorConfig> {
-  return unwrap(await api.put(`/api/executors/${encodeURIComponent(name)}/default`));
+  return unwrap(await api.put(`/api/v1/executors/${encodeURIComponent(name)}/default`));
 }
 
 // Version API
@@ -145,12 +145,12 @@ export interface VersionInfo {
 }
 
 export async function getVersion(): Promise<VersionInfo> {
-  return unwrap(await api.get('/api/version'));
+  return unwrap(await api.get('/api/v1/version'));
 }
 
 /** 从 npm 获取 @weibaohui/ntd 的最新版本号 */
 export async function getLatestVersion(): Promise<{ latest: string | null; error?: string }> {
-  return unwrap(await api.get('/api/version/latest'));
+  return unwrap(await api.get('/api/v1/version/latest'));
 }
 
 /** 执行 npm 升级并重启服务 */
@@ -160,7 +160,7 @@ export async function upgradeVersion(): Promise<{
   npmOutput?: string;
   restartMessage?: string;
 }> {
-  return unwrap(await api.post('/api/version/upgrade'));
+  return unwrap(await api.post('/api/v1/version/upgrade'));
 }
 
 // Auto-update settings API
@@ -173,7 +173,7 @@ export interface AutoUpdateSettings {
 
 /** 获取自动更新配置 */
 export async function getAutoUpdateSettings(): Promise<AutoUpdateSettings> {
-  return unwrap(await api.get('/api/config'));
+  return unwrap(await api.get('/api/v1/config'));
 }
 
 /** 更新自动更新配置 */
@@ -182,5 +182,5 @@ export async function updateAutoUpdateSettings(settings: {
   auto_update_interval?: string;
   auto_update_hour?: number;
 }): Promise<void> {
-  await api.put('/api/config', settings);
+  await api.put('/api/v1/config', settings);
 }

--- a/frontend/src/utils/database/sync.ts
+++ b/frontend/src/utils/database/sync.ts
@@ -31,17 +31,17 @@ export interface SyncRecord {
 // ============ Sync Status APIs ============
 
 export async function getCloudSyncStatus(): Promise<SyncStatusResponse> {
-  return unwrap(await api.get('/api/cloud/sync/status'));
+  return unwrap(await api.get('/api/v1/cloud/sync/status'));
 }
 
 // ============ Config APIs ============
 
 export async function getCloudConfig(): Promise<CloudConfig> {
-  return unwrap(await api.get('/api/cloud/config'));
+  return unwrap(await api.get('/api/v1/cloud/config'));
 }
 
 export async function saveCloudConfig(config: Partial<CloudConfig>): Promise<void> {
-  return unwrap(await api.post('/api/cloud/config', config));
+  return unwrap(await api.post('/api/v1/cloud/config', config));
 }
 
 // ============ Sync Records APIs ============
@@ -54,11 +54,11 @@ export interface SyncRecordsResponse {
 }
 
 export async function getSyncRecords(params?: { limit?: number; offset?: number }): Promise<SyncRecordsResponse> {
-  return unwrap(await api.get('/api/cloud/sync/records', { params }));
+  return unwrap(await api.get('/api/v1/cloud/sync/records', { params }));
 }
 
 export async function clearSyncRecords(): Promise<{ deleted: number }> {
-  return unwrap(await api.delete('/api/cloud/sync/records'));
+  return unwrap(await api.delete('/api/v1/cloud/sync/records'));
 }
 
 // ============ Sync APIs ============
@@ -80,9 +80,9 @@ export interface SyncResult {
 const SYNC_TIMEOUT_MS = 0;
 
 export async function syncPush(params?: { conflict_mode?: string; dry_run?: boolean }): Promise<SyncResult> {
-  return unwrap(await api.post('/api/cloud/sync/push', null, { params, timeout: SYNC_TIMEOUT_MS }));
+  return unwrap(await api.post('/api/v1/cloud/sync/push', null, { params, timeout: SYNC_TIMEOUT_MS }));
 }
 
 export async function syncPull(params?: { conflict_mode?: string; dry_run?: boolean }): Promise<SyncResult> {
-  return unwrap(await api.post('/api/cloud/sync/pull', null, { params, timeout: SYNC_TIMEOUT_MS }));
+  return unwrap(await api.post('/api/v1/cloud/sync/pull', null, { params, timeout: SYNC_TIMEOUT_MS }));
 }

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -1,20 +1,19 @@
 import { api, unwrap } from './client';
 import type { Todo, Tag, TodoTemplate, CustomTemplateStatus, ComputedBucket, TodoCenterItem } from '@/types';
 
-// Todo APIs
+// Todo APIs — 所有 todo 端点嵌套在 /api/v1/workspaces/{ws}/todos 下（后端 ADR-7 纯 workspace 隔离）。
+// workspaceId 从 query/body 提升到 URL 路径段，调用方必须显式传入。
 
 /**
- * 列出 todos，可按工作空间 ID 过滤。
+ * 列出指定工作空间下的 todos。
+ * workspaceId 提升到路径段（v1 纯 workspace-scoped，不再支持跨空间列表）。
  */
-export async function getAllTodos(workspaceId?: number, hours?: number): Promise<Todo[]> {
+export async function getAllTodos(workspaceId: number, hours?: number): Promise<Todo[]> {
   const params: Record<string, number> = {};
-  if (workspaceId !== undefined) {
-    params.workspace_id = workspaceId;
-  }
   if (hours !== undefined) {
     params.hours = hours;
   }
-  return unwrap(await api.get('/api/todos', { params }));
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/todos`, { params }));
 }
 
 export async function createTodo(
@@ -28,17 +27,19 @@ export async function createTodo(
   expertName?: string,
   model?: string | null,
 ): Promise<Todo> {
-  const body: Record<string, unknown> = { title, prompt, tag_ids: tagIds, workspace_id: workspaceId };
+  // workspace_id 从 body 提升到 URL 路径段；body 只保留字段语义
+  const body: Record<string, unknown> = { title, prompt, tag_ids: tagIds };
   if (acceptanceCriteria !== undefined) body.acceptance_criteria = acceptanceCriteria;
   if (autoReviewEnabled !== undefined) body.auto_review_enabled = autoReviewEnabled;
   if (webhookEnabled !== undefined) body.webhook_enabled = webhookEnabled;
   if (expertName !== undefined) body.expert_name = expertName;
   // model：undefined=不传（创建时不指定，沿用执行器默认）；null/空串=显式清除。
   if (model !== undefined) body.model = model;
-  return unwrap(await api.post('/api/todos', body));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos`, body));
 }
 
 export async function updateTodo(
+  workspaceId: number,
   id: number,
   title: string,
   prompt: string,
@@ -65,24 +66,25 @@ export async function updateTodo(
   // model：undefined=不修改；null/空串=清除任务级模型（回退到执行器默认）。
   if (model !== undefined) body.model = model;
 
-  return unwrap(await api.put(`/api/todos/${id}`, body));
+  return unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/${id}`, body));
 }
 
-export async function deleteTodo(id: number): Promise<void> {
-  await api.delete(`/api/todos/${id}`);
+export async function deleteTodo(workspaceId: number, id: number): Promise<void> {
+  await api.delete(`/api/workspaces/${workspaceId}/todos/${id}`);
 }
 
-export async function updateTodoTags(todoId: number, tagIds: number[]): Promise<void> {
-  await api.put(`/api/todos/${todoId}/tags`, { tag_ids: tagIds });
+export async function updateTodoTags(workspaceId: number, todoId: number, tagIds: number[]): Promise<void> {
+  await api.put(`/api/workspaces/${workspaceId}/todos/${todoId}/tags`, { tag_ids: tagIds });
 }
 
 /** 批量更新事项执行器。后端提供专用接口，单次 SQL 完成。 */
 export async function batchUpdateTodosExecutor(
+  workspaceId: number,
   ids: number[],
   executor: string,
 ): Promise<{ updated: number[]; failed: number[] }> {
   try {
-    const result = await unwrap(await api.put('/api/todos/batch-executor', { ids, executor }));
+    const result = await unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/batch-executor`, { ids, executor }));
     const body = result as { updated_count: number; total: number };
     return { updated: ids.slice(0, body.updated_count), failed: ids.slice(body.updated_count) };
   } catch {
@@ -92,39 +94,43 @@ export async function batchUpdateTodosExecutor(
 
 /** 批量暂停周期执行。将所选事项的 scheduler_enabled 设为 false，但不改变 scheduler_config。 */
 export async function batchPauseScheduler(
+  workspaceId: number,
   ids: number[],
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.put('/api/todos/batch-scheduler', { ids, scheduler_enabled: false }));
+  return unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/batch-scheduler`, { ids, scheduler_enabled: false }));
 }
 
 /** 批量恢复周期执行。将所选事项的 scheduler_enabled 设为 true，使用原有的 scheduler_config。 */
 export async function batchResumeScheduler(
+  workspaceId: number,
   ids: number[],
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.put('/api/todos/batch-scheduler', { ids, scheduler_enabled: true }));
+  return unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/batch-scheduler`, { ids, scheduler_enabled: true }));
 }
 
-/** 批量移动事项到其他工作空间。 */
+/** 批量移动事项到其他工作空间。workspaceId 为源空间（URL 路径段），workspace_id 为目标空间（body）。 */
 export async function batchMoveTodosWorkspace(
+  workspaceId: number,
   ids: number[],
   workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.put('/api/todos/batch-workspace', { ids, workspace_id }));
+  return unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/batch-workspace`, { ids, workspace_id }));
 }
 
-/** 批量复制事项到其他工作空间。 */
+/** 批量复制事项到其他工作空间。workspaceId 为源空间（URL 路径段），workspace_id 为目标空间（body）。 */
 export async function batchCopyTodosWorkspace(
+  workspaceId: number,
   ids: number[],
   workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.post('/api/todos/batch-copy-workspace', { ids, workspace_id }));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/batch-copy-workspace`, { ids, workspace_id }));
 }
 
-// Tag APIs
+// Tag APIs — 全局资源，不嵌套 workspace（tags 表无 workspace_id 列）
 
 /** 单个 todo 详情（用于批量操作前取 title/prompt 等不可变字段）。 */
-export async function getTodo(id: number): Promise<Todo> {
-  return unwrap(await api.get(`/api/todos/${id}`));
+export async function getTodo(workspaceId: number, id: number): Promise<Todo> {
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/todos/${id}`));
 }
 
 export async function getAllTags(): Promise<Tag[]> {
@@ -206,9 +212,9 @@ export async function getProjectDirectories(): Promise<ProjectDirectory[]> {
   return unwrap(await api.get('/api/project-directories'));
 }
 
-/** GET /api/scheduler/todos:列出所有启用 cron 调度的 todo(含下次触发时间 scheduler_next_run_at)。 */
-export async function getSchedulerTodos(): Promise<Todo[]> {
-  return unwrap(await api.get('/api/scheduler/todos'));
+/** GET /api/v1/workspaces/{ws}/scheduler/todos:列出指定空间下启用 cron 调度的 todo(含下次触发时间)。 */
+export async function getSchedulerTodos(workspaceId: number): Promise<Todo[]> {
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/scheduler/todos`));
 }
 
 // 创建项目目录：后端要求 name 必填，调用方需保证传入非空字符串。
@@ -244,15 +250,16 @@ export async function deleteProjectDirectory(id: number): Promise<void> {
   await api.delete(`/api/project-directories/${id}`);
 }
 
-// Scheduler APIs
+// Scheduler APIs — /{id}/scheduler 嵌套在 workspace todos 下
 
 export async function updateScheduler(
+  workspaceId: number,
   id: number,
   scheduler_enabled: boolean,
   scheduler_config: string | null,
 ): Promise<TodoCenterItem> {
   // 后端返回 TodoCenterItem（含重新计算的 computed_bucket），符合设计文档要求
-  return unwrap(await api.put(`/api/todos/${id}/scheduler`, { scheduler_enabled, scheduler_config }));
+  return unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/${id}/scheduler`, { scheduler_enabled, scheduler_config }));
 }
 
 // ─── 事项中心（Todo Center）API ─────────────────────────────
@@ -260,31 +267,31 @@ export async function updateScheduler(
 /**
  * 拉取事项中心列表（带 computed_bucket / loop 引用计数 / 最近执行聚合）。
  *
+ * workspaceId 提升到路径段（v1 纯 workspace-scoped）。
  * 不传 bucket 时后端返回全部分类，前端按 computed_bucket 自行分桶并展示各 Tab 数量；
  * 传入 bucket 则服务端按分类过滤（分页前完成分桶，保证数量正确）。
  */
 export async function getTodoCenter(
-  workspaceId?: number,
+  workspaceId: number,
   bucket?: ComputedBucket,
 ): Promise<TodoCenterItem[]> {
   const params: Record<string, string | number> = {};
-  if (workspaceId !== undefined) params.workspace_id = workspaceId;
   if (bucket !== undefined) params.bucket = bucket;
-  return unwrap(await api.get('/api/todos/center', { params }));
+  return unwrap(await api.get(`/api/workspaces/${workspaceId}/todos/center`, { params }));
 }
 
 /** 归档事项（仅隐藏，不删数据/不解 Loop 引用）。返回重新计算后的分类项。 */
-export async function archiveTodo(id: number): Promise<TodoCenterItem> {
-  return unwrap(await api.post(`/api/todos/${id}/archive`));
+export async function archiveTodo(workspaceId: number, id: number): Promise<TodoCenterItem> {
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/${id}/archive`));
 }
 
 /** 恢复事项（清空 archived_at，分类按真实关系重算）。 */
-export async function restoreTodo(id: number): Promise<TodoCenterItem> {
-  return unwrap(await api.post(`/api/todos/${id}/restore`));
+export async function restoreTodo(workspaceId: number, id: number): Promise<TodoCenterItem> {
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/${id}/restore`));
 }
 
 /** 开启/关闭事件驱动（webhook）。与 scheduler 端点对称的扁平具名路由。 */
-export async function updateTodoWebhook(id: number, webhook_enabled: boolean): Promise<TodoCenterItem> {
-  return unwrap(await api.put(`/api/todos/${id}/webhook`, { webhook_enabled }));
+export async function updateTodoWebhook(workspaceId: number, id: number, webhook_enabled: boolean): Promise<TodoCenterItem> {
+  return unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/${id}/webhook`, { webhook_enabled }));
 }
 

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -84,7 +84,7 @@ export async function batchUpdateTodosExecutor(
   executor: string,
 ): Promise<{ updated: number[]; failed: number[] }> {
   try {
-    const result = await unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/batch-executor`, { ids, executor }));
+    const result = await unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/batch/executor`, { ids, executor }));
     const body = result as { updated_count: number; total: number };
     return { updated: ids.slice(0, body.updated_count), failed: ids.slice(body.updated_count) };
   } catch {
@@ -97,7 +97,7 @@ export async function batchPauseScheduler(
   workspaceId: number,
   ids: number[],
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/batch-scheduler`, { ids, scheduler_enabled: false }));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/batch/scheduler`, { ids, scheduler_enabled: false }));
 }
 
 /** 批量恢复周期执行。将所选事项的 scheduler_enabled 设为 true，使用原有的 scheduler_config。 */
@@ -105,7 +105,7 @@ export async function batchResumeScheduler(
   workspaceId: number,
   ids: number[],
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/batch-scheduler`, { ids, scheduler_enabled: true }));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/batch/scheduler`, { ids, scheduler_enabled: true }));
 }
 
 /** 批量移动事项到其他工作空间。workspaceId 为源空间（URL 路径段），workspace_id 为目标空间（body）。 */
@@ -114,7 +114,7 @@ export async function batchMoveTodosWorkspace(
   ids: number[],
   workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/batch-workspace`, { ids, workspace_id }));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/batch/workspace`, { ids, workspace_id }));
 }
 
 /** 批量复制事项到其他工作空间。workspaceId 为源空间（URL 路径段），workspace_id 为目标空间（body）。 */
@@ -123,7 +123,7 @@ export async function batchCopyTodosWorkspace(
   ids: number[],
   workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/batch-copy-workspace`, { ids, workspace_id }));
+  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/batch/copy-workspace`, { ids, workspace_id }));
 }
 
 // Tag APIs — 全局资源，不嵌套 workspace（tags 表无 workspace_id 列）

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -13,7 +13,7 @@ export async function getAllTodos(workspaceId: number, hours?: number): Promise<
   if (hours !== undefined) {
     params.hours = hours;
   }
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/todos`, { params }));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/todos`, { params }));
 }
 
 export async function createTodo(
@@ -35,7 +35,7 @@ export async function createTodo(
   if (expertName !== undefined) body.expert_name = expertName;
   // model：undefined=不传（创建时不指定，沿用执行器默认）；null/空串=显式清除。
   if (model !== undefined) body.model = model;
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos`, body));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/todos`, body));
 }
 
 export async function updateTodo(
@@ -66,15 +66,15 @@ export async function updateTodo(
   // model：undefined=不修改；null/空串=清除任务级模型（回退到执行器默认）。
   if (model !== undefined) body.model = model;
 
-  return unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/${id}`, body));
+  return unwrap(await api.put(`/api/v1/workspaces/${workspaceId}/todos/${id}`, body));
 }
 
 export async function deleteTodo(workspaceId: number, id: number): Promise<void> {
-  await api.delete(`/api/workspaces/${workspaceId}/todos/${id}`);
+  await api.delete(`/api/v1/workspaces/${workspaceId}/todos/${id}`);
 }
 
 export async function updateTodoTags(workspaceId: number, todoId: number, tagIds: number[]): Promise<void> {
-  await api.put(`/api/workspaces/${workspaceId}/todos/${todoId}/tags`, { tag_ids: tagIds });
+  await api.put(`/api/v1/workspaces/${workspaceId}/todos/${todoId}/tags`, { tag_ids: tagIds });
 }
 
 /** 批量更新事项执行器。后端提供专用接口，单次 SQL 完成。 */
@@ -84,7 +84,7 @@ export async function batchUpdateTodosExecutor(
   executor: string,
 ): Promise<{ updated: number[]; failed: number[] }> {
   try {
-    const result = await unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/batch/executor`, { ids, executor }));
+    const result = await unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/todos/batch/executor`, { ids, executor }));
     const body = result as { updated_count: number; total: number };
     return { updated: ids.slice(0, body.updated_count), failed: ids.slice(body.updated_count) };
   } catch {
@@ -97,7 +97,7 @@ export async function batchPauseScheduler(
   workspaceId: number,
   ids: number[],
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/batch/scheduler`, { ids, scheduler_enabled: false }));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/todos/batch/scheduler`, { ids, scheduler_enabled: false }));
 }
 
 /** 批量恢复周期执行。将所选事项的 scheduler_enabled 设为 true，使用原有的 scheduler_config。 */
@@ -105,7 +105,7 @@ export async function batchResumeScheduler(
   workspaceId: number,
   ids: number[],
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/batch/scheduler`, { ids, scheduler_enabled: true }));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/todos/batch/scheduler`, { ids, scheduler_enabled: true }));
 }
 
 /** 批量移动事项到其他工作空间。workspaceId 为源空间（URL 路径段），workspace_id 为目标空间（body）。 */
@@ -114,7 +114,7 @@ export async function batchMoveTodosWorkspace(
   ids: number[],
   workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/batch/workspace`, { ids, workspace_id }));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/todos/batch/workspace`, { ids, workspace_id }));
 }
 
 /** 批量复制事项到其他工作空间。workspaceId 为源空间（URL 路径段），workspace_id 为目标空间（body）。 */
@@ -123,36 +123,36 @@ export async function batchCopyTodosWorkspace(
   ids: number[],
   workspace_id: number,
 ): Promise<{ updated_count: number; total: number }> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/batch/copy-workspace`, { ids, workspace_id }));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/todos/batch/copy-workspace`, { ids, workspace_id }));
 }
 
 // Tag APIs — 全局资源，不嵌套 workspace（tags 表无 workspace_id 列）
 
 /** 单个 todo 详情（用于批量操作前取 title/prompt 等不可变字段）。 */
 export async function getTodo(workspaceId: number, id: number): Promise<Todo> {
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/todos/${id}`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/todos/${id}`));
 }
 
 export async function getAllTags(): Promise<Tag[]> {
-  return unwrap(await api.get('/api/tags'));
+  return unwrap(await api.get('/api/v1/tags'));
 }
 
 export async function createTag(name: string, color: string): Promise<Tag> {
-  return unwrap(await api.post('/api/tags', { name, color }));
+  return unwrap(await api.post('/api/v1/tags', { name, color }));
 }
 
 export async function deleteTag(id: number): Promise<void> {
-  await api.delete(`/api/tags/${id}`);
+  await api.delete(`/api/v1/tags/${id}`);
 }
 
 // Todo Template APIs
 
 export async function getTodoTemplates(): Promise<TodoTemplate[]> {
-  return unwrap(await api.get('/api/todo-templates'));
+  return unwrap(await api.get('/api/v1/todo-templates'));
 }
 
 export async function createTodoTemplate(title: string, prompt: string | null, category: string, sort_order?: number): Promise<TodoTemplate> {
-  return unwrap(await api.post('/api/todo-templates', { title, prompt, category, sort_order }));
+  return unwrap(await api.post('/api/v1/todo-templates', { title, prompt, category, sort_order }));
 }
 
 export async function updateTodoTemplate(id: number, title?: string, prompt?: string | null, category?: string, sort_order?: number): Promise<TodoTemplate> {
@@ -161,37 +161,37 @@ export async function updateTodoTemplate(id: number, title?: string, prompt?: st
   if (prompt !== undefined) body.prompt = prompt;
   if (category !== undefined) body.category = category;
   if (sort_order !== undefined) body.sort_order = sort_order;
-  return unwrap(await api.put(`/api/todo-templates/${id}`, body));
+  return unwrap(await api.put(`/api/v1/todo-templates/${id}`, body));
 }
 
 export async function deleteTodoTemplate(id: number): Promise<void> {
-  await api.delete(`/api/todo-templates/${id}`);
+  await api.delete(`/api/v1/todo-templates/${id}`);
 }
 
 export async function copyTodoTemplate(id: number): Promise<TodoTemplate> {
-  return unwrap(await api.post(`/api/todo-templates/${id}/copy`, {}));
+  return unwrap(await api.post(`/api/v1/todo-templates/${id}/copy`, {}));
 }
 
 // Custom Template APIs (remote URL subscription)
 
 export async function getCustomTemplateStatus(): Promise<CustomTemplateStatus> {
-  return unwrap(await api.get('/api/custom-templates/status'));
+  return unwrap(await api.get('/api/v1/custom-templates/status'));
 }
 
 export async function subscribeCustomTemplate(url: string): Promise<CustomTemplateStatus> {
-  return unwrap(await api.post('/api/custom-templates/subscribe', { url }));
+  return unwrap(await api.post('/api/v1/custom-templates/subscribe', { url }));
 }
 
 export async function unsubscribeCustomTemplate(): Promise<void> {
-  await api.post('/api/custom-templates/unsubscribe', {});
+  await api.post('/api/v1/custom-templates/unsubscribe', {});
 }
 
 export async function syncCustomTemplate(): Promise<CustomTemplateStatus> {
-  return unwrap(await api.post('/api/custom-templates/sync', {}));
+  return unwrap(await api.post('/api/v1/custom-templates/sync', {}));
 }
 
 export async function updateCustomTemplateAutoSync(enabled: boolean, cron: string): Promise<void> {
-  await api.put('/api/custom-templates/auto-sync', { enabled, cron });
+  await api.put('/api/v1/custom-templates/auto-sync', { enabled, cron });
 }
 
 // Project Directory APIs
@@ -209,12 +209,12 @@ export interface ProjectDirectory {
 }
 
 export async function getProjectDirectories(): Promise<ProjectDirectory[]> {
-  return unwrap(await api.get('/api/project-directories'));
+  return unwrap(await api.get('/api/v1/project-directories'));
 }
 
 /** GET /api/v1/workspaces/{ws}/scheduler/todos:列出指定空间下启用 cron 调度的 todo(含下次触发时间)。 */
 export async function getSchedulerTodos(workspaceId: number): Promise<Todo[]> {
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/scheduler/todos`));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/scheduler/todos`));
 }
 
 // 创建项目目录：后端要求 name 必填，调用方需保证传入非空字符串。
@@ -226,7 +226,7 @@ export async function createProjectDirectory(
   path: string,
   name: string,
 ): Promise<ProjectDirectory> {
-  return unwrap(await api.post('/api/project-directories', { path, name }));
+  return unwrap(await api.post('/api/v1/project-directories', { path, name }));
 }
 
 // 更新项目目录。`name` 必填；worktree 开关可选（不传=保持现状）。
@@ -243,11 +243,11 @@ export async function updateProjectDirectory(
   if (options?.autoCleanup !== undefined) {
     body.auto_cleanup = options.autoCleanup;
   }
-  await api.put(`/api/project-directories/${id}`, body);
+  await api.put(`/api/v1/project-directories/${id}`, body);
 }
 
 export async function deleteProjectDirectory(id: number): Promise<void> {
-  await api.delete(`/api/project-directories/${id}`);
+  await api.delete(`/api/v1/project-directories/${id}`);
 }
 
 // Scheduler APIs — /{id}/scheduler 嵌套在 workspace todos 下
@@ -259,7 +259,7 @@ export async function updateScheduler(
   scheduler_config: string | null,
 ): Promise<TodoCenterItem> {
   // 后端返回 TodoCenterItem（含重新计算的 computed_bucket），符合设计文档要求
-  return unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/${id}/scheduler`, { scheduler_enabled, scheduler_config }));
+  return unwrap(await api.put(`/api/v1/workspaces/${workspaceId}/todos/${id}/scheduler`, { scheduler_enabled, scheduler_config }));
 }
 
 // ─── 事项中心（Todo Center）API ─────────────────────────────
@@ -277,21 +277,21 @@ export async function getTodoCenter(
 ): Promise<TodoCenterItem[]> {
   const params: Record<string, string | number> = {};
   if (bucket !== undefined) params.bucket = bucket;
-  return unwrap(await api.get(`/api/workspaces/${workspaceId}/todos/center`, { params }));
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/todos/center`, { params }));
 }
 
 /** 归档事项（仅隐藏，不删数据/不解 Loop 引用）。返回重新计算后的分类项。 */
 export async function archiveTodo(workspaceId: number, id: number): Promise<TodoCenterItem> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/${id}/archive`));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/todos/${id}/archive`));
 }
 
 /** 恢复事项（清空 archived_at，分类按真实关系重算）。 */
 export async function restoreTodo(workspaceId: number, id: number): Promise<TodoCenterItem> {
-  return unwrap(await api.post(`/api/workspaces/${workspaceId}/todos/${id}/restore`));
+  return unwrap(await api.post(`/api/v1/workspaces/${workspaceId}/todos/${id}/restore`));
 }
 
 /** 开启/关闭事件驱动（webhook）。与 scheduler 端点对称的扁平具名路由。 */
 export async function updateTodoWebhook(workspaceId: number, id: number, webhook_enabled: boolean): Promise<TodoCenterItem> {
-  return unwrap(await api.put(`/api/workspaces/${workspaceId}/todos/${id}/webhook`, { webhook_enabled }));
+  return unwrap(await api.put(`/api/v1/workspaces/${workspaceId}/todos/${id}/webhook`, { webhook_enabled }));
 }
 

--- a/frontend/src/utils/database/usage_stats.ts
+++ b/frontend/src/utils/database/usage_stats.ts
@@ -5,11 +5,11 @@ export async function getUsageStats(since?: string, until?: string): Promise<Usa
   const params: Record<string, unknown> = {};
   if (since !== undefined) params.since = since;
   if (until !== undefined) params.until = until;
-  return unwrap(await api.get('/api/usage-stats', { params }));
+  return unwrap(await api.get('/api/v1/usage-stats', { params }));
 }
 
 export async function refreshUsageStats(): Promise<UsageStatsResponse> {
-  return unwrap(await api.post('/api/usage-stats/refresh'));
+  return unwrap(await api.post('/api/v1/usage-stats/refresh'));
 }
 
 export interface UsageStatsSettings {
@@ -18,9 +18,9 @@ export interface UsageStatsSettings {
 }
 
 export async function getUsageStatsSettings(): Promise<UsageStatsSettings> {
-  return unwrap(await api.get('/api/usage-stats/settings'));
+  return unwrap(await api.get('/api/v1/usage-stats/settings'));
 }
 
 export async function updateUsageStatsSettings(enabled: boolean, cron: string): Promise<string> {
-  return unwrap(await api.put('/api/usage-stats/settings', { enabled, cron }));
+  return unwrap(await api.put('/api/v1/usage-stats/settings', { enabled, cron }));
 }

--- a/frontend/tests/blackboard_page.spec.ts
+++ b/frontend/tests/blackboard_page.spec.ts
@@ -58,7 +58,7 @@ function makeResponse(workspaceId: number, content: string): BlackboardResponse 
 /** 安装 mock：根据 query 中的 workspace 返回不同内容 */
 async function installBlackboardMocks(page: Page) {
   // 拦截 GET blackboard：返回当前 workspace 对应的内容
-  await page.route('**/api/workspaces/*/blackboard', async (route) => {
+  await page.route('**/api/v1/workspaces/*/blackboard', async (route) => {
     const url = new URL(route.request().url());
     // 解析 workspace id：取 path 中数字段
     const m = url.pathname.match(/\/api\/workspaces\/(\d+)\/blackboard/);
@@ -72,7 +72,7 @@ async function installBlackboardMocks(page: Page) {
     });
   });
   // 拦截 POST refresh：返回成功
-  await page.route('**/api/workspaces/*/blackboard/refresh', async (route) => {
+  await page.route('**/api/v1/workspaces/*/blackboard/refresh', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -123,7 +123,7 @@ test('点击刷新按钮触发 POST /api/.../blackboard/refresh', async ({ page 
 
   // 记录 refresh 请求次数
   let refreshCalls = 0;
-  await page.route('**/api/workspaces/*/blackboard/refresh', async (route) => {
+  await page.route('**/api/v1/workspaces/*/blackboard/refresh', async (route) => {
     refreshCalls += 1;
     await route.fulfill({
       status: 200,
@@ -169,7 +169,7 @@ test('切换 workspace 后页面重新拉取并渲染新内容（修复 useState
 
 test('空内容时显示空状态文案', async ({ page }) => {
   // 覆盖 mock 返回空内容
-  await page.route('**/api/workspaces/*/blackboard', async (route) => {
+  await page.route('**/api/v1/workspaces/*/blackboard', async (route) => {
     const m = new URL(route.request().url()).pathname.match(/\/api\/workspaces\/(\d+)\//);
     const wsId = m ? Number(m[1]) : 0;
     await route.fulfill({

--- a/frontend/tests/check-loop-flow-no-trace-link.spec.ts
+++ b/frontend/tests/check-loop-flow-no-trace-link.spec.ts
@@ -7,7 +7,7 @@ const DEV_URL = 'http://localhost:18088';
 
 test('展开执行历史不应影响流程图渲染', async ({ page }) => {
   // 找一个至少有 1 个 step 的 loop（通过 API 直接筛选）
-  const listRes = await page.request.get(`${BACKEND_URL}/api/loops?page=1&limit=50`);
+  const listRes = await page.request.get(`${BACKEND_URL}/api/v1/workspaces/1/loops?page=1&limit=50`);
   const listJson = await listRes.json();
   const loops: Array<{ id: number; step_count: number }> = listJson?.data ?? [];
   const candidate = loops.find((l) => l.step_count > 0);

--- a/frontend/tests/check-loop-step-modal-dark-theme.spec.ts
+++ b/frontend/tests/check-loop-step-modal-dark-theme.spec.ts
@@ -16,7 +16,7 @@ test('Loop 编辑 Modal 暗色主题颜色校验', async ({ page }) => {
   mkdirSync(SCREENSHOT_DIR, { recursive: true });
 
   // 找一个至少有 1 个 step 的 loop
-  const listRes = await page.request.get(`${BACKEND_URL}/api/loops?page=1&limit=50`);
+  const listRes = await page.request.get(`${BACKEND_URL}/api/v1/workspaces/1/loops?page=1&limit=50`);
   const listJson = await listRes.json();
   const loops: Array<{ id: number; step_count: number }> = listJson?.data ?? [];
   const candidate = loops.find((l) => l.step_count > 0);

--- a/frontend/tests/check_dashboard_tabs.spec.ts
+++ b/frontend/tests/check_dashboard_tabs.spec.ts
@@ -73,7 +73,7 @@ test.describe('Dashboard Tab 化重构', () => {
     await page.getByRole('tab', { name: '成本与模型' }).click();
     await expect(page.getByText('AI 会话')).toBeVisible({ timeout: 10000 });
 
-    // 自动化 Tab:环路统计 + 飞书监听(消费后端 /api/loops/stats)
+    // 自动化 Tab:环路统计 + 飞书监听(消费后端 /api/v1/workspaces/1/loops/stats)
     await page.getByRole('tab', { name: '自动化' }).click();
     await expect(page.getByText('环路')).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('飞书监听')).toBeVisible({ timeout: 10000 });

--- a/frontend/tests/check_execution_record.spec.ts
+++ b/frontend/tests/check_execution_record.spec.ts
@@ -16,7 +16,7 @@ test.describe('执行记录详情页', () => {
 
     // 1. 检查 API 返回的状态
     const apiResponse = await page.evaluate((recordId) => {
-      return fetch(`/api/execution-records/${recordId}`)
+      return fetch(`/api/v1/workspaces/1/executions/${recordId}`)
         .then(r => r.json())
         .then(data => data.data);
     }, RECORD_ID);

--- a/frontend/tests/check_git_install_entry.spec.ts
+++ b/frontend/tests/check_git_install_entry.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 // 模板管理面板的「Git 检测 + 一键安装」入口。
 // git 是 bundled 资源同步的硬前置依赖。本机装了 git，正常请求 git_available=true、不显示缺失横幅；
-// 因此用 page.route 拦截 /api/bundled/status 强制返回 git_available:false，才能验证「缺失态」UI。
+// 因此用 page.route 拦截 /api/v1/bundled/status 强制返回 git_available:false，才能验证「缺失态」UI。
 // 成功信封为 { code:0, data, message }（见 utils/database/client.ts 的 unwrap）。
 
 const BASE = 'http://localhost:18088';
@@ -34,7 +34,7 @@ function statusPayload(gitAvailable: boolean) {
 /** 拦截 status 接口 + 进入模板管理 tab 的公共前置。 */
 async function openTemplatesPanel(page: import('@playwright/test').Page, gitAvailable: boolean) {
   // 路由必须在 goto 之前注册，才能命中面板挂载时的首次 status 请求
-  await page.route('**/api/bundled/status**', (route) =>
+  await page.route('**/api/v1/bundled/status**', (route) =>
     route.fulfill({
       contentType: 'application/json',
       body: JSON.stringify(statusPayload(gitAvailable)),

--- a/frontend/tests/check_history_status.spec.ts
+++ b/frontend/tests/check_history_status.spec.ts
@@ -29,7 +29,7 @@ test.describe('执行历史列状态', () => {
 
     // 直接检查 API 返回的记录状态
     const records = await page.evaluate(async () => {
-      const resp = await fetch('/api/execution-records?todo_id=15&page=1&limit=5');
+      const resp = await fetch('/api/v1/workspaces/1/executions?todo_id=15&page=1&limit=5');
       const data = await resp.json();
       return (data.data?.records || []).map(r => ({
         id: r.id,

--- a/frontend/tests/check_loop_step_workspace_filter.spec.ts
+++ b/frontend/tests/check_loop_step_workspace_filter.spec.ts
@@ -3,9 +3,9 @@
 // 设计要点：
 // - 找一个 workspace=/tmp/xxx 且 step_count=0 的 loop（让「添加环节」按钮可点）
 // - 打开 Modal 后，从 DOM 收集 Select 下拉里的所有 option（label 形如 `#<id> <title>`）
-// - 通过 /api/todos?workspace_id=<id> 拿到该工作空间下应该出现的 todo id 集合
+// - 通过 /api/v1/workspaces/${workspaceId}/todos?workspace_id=<id> 拿到该工作空间下应该出现的 todo id 集合
 // - 断言：下拉里的 id 全部命中目标集合（防止误把别的工作空间下的 todo 串进来）
-// - 对照：全量 /api/todos 的 id 集合应该 ⊋ 目标集合（说明数据库里确实有跨空间的 todo，
+// - 对照：全量 /api/v1/workspaces/${workspaceId}/todos 的 id 集合应该 ⊋ 目标集合（说明数据库里确实有跨空间的 todo，
 //   否则用例等于没在验证过滤）
 // - 兜底：若找不到可测的 loop，自动 test.skip，避免假阳性
 
@@ -34,7 +34,7 @@ test('新增环节 Modal 的关联环节下拉按 loop 工作空间过滤', asyn
   const apiCtx = await request.newContext({ baseURL: BACKEND_URL });
 
   // 1) 找一个带 workspace_path 且 step_count=0 的 loop，便于点「添加环节」进入新建流程
-  const loopsRes = await apiCtx.get('/api/loops?page=1&limit=50');
+  const loopsRes = await apiCtx.get('/api/v1/workspaces/${workspaceId}/loops?page=1&limit=50');
   const loopsJson = await loopsRes.json();
   const loops: Array<{ id: number; workspace_path: string | null; step_count: number }> = loopsJson?.data ?? [];
   // 优先 /tmp/xxx（id=1），实测数据里该工作空间下确实有 todo
@@ -46,19 +46,19 @@ test('新增环节 Modal 的关联环节下拉按 loop 工作空间过滤', asyn
   const workspacePath = target!.workspace_path!;
 
   // 2) 查后端确认目标 workspace 的 todo 集合，以及全量 todo 集合
-  const dirsRes = await apiCtx.get('/api/project-directories');
+  const dirsRes = await apiCtx.get('/api/v1/project-directories');
   const dirsJson = await dirsRes.json();
   const dirs: Array<{ id: number; path: string }> = dirsJson?.data ?? [];
   const dir = dirs.find((d) => d.path === workspacePath);
   test.skip(!dir, `未找到路径 ${workspacePath} 对应的工作空间目录，跳过用例`);
   const workspaceId = dir!.id;
 
-  const targetListRes = await apiCtx.get(`/api/todos?workspace_id=${workspaceId}`);
+  const targetListRes = await apiCtx.get(`/api/v1/workspaces/${workspaceId}/todos`);
   const targetListJson = await targetListRes.json();
   const targetTodos: Array<{ id: number; title: string }> = targetListJson?.data ?? [];
   const targetIds = new Set(targetTodos.map((t) => t.id));
 
-  const allRes = await apiCtx.get('/api/todos');
+  const allRes = await apiCtx.get('/api/v1/workspaces/${workspaceId}/todos');
   const allJson = await allRes.json();
   const allTodos: Array<{ id: number }> = allJson?.data ?? [];
   const allIds = new Set(allTodos.map((t) => t.id));

--- a/frontend/tests/check_multi_agent_display.spec.ts
+++ b/frontend/tests/check_multi_agent_display.spec.ts
@@ -57,7 +57,7 @@ test.describe('多 Agent 执行展示', () => {
 
     // 确认后端 ExecutionRecord 透出了 agent_runs（JSON 字符串），前端可 parse。
     const rec = await page.evaluate((rid) => {
-      return fetch(`/api/execution-records/${rid}`).then((r) => r.json()).then((d) => d.data);
+      return fetch(`/api/v1/workspaces/1/executions/${rid}`).then((r) => r.json()).then((d) => d.data);
     }, RECORD_ID);
 
     expect(typeof rec.agent_runs).toBe('string');

--- a/frontend/tests/check_quick_buttons.spec.ts
+++ b/frontend/tests/check_quick_buttons.spec.ts
@@ -13,7 +13,7 @@ interface QuickButton {
 
 // 后端响应是 ApiResponse 包裹的 { code, data, message }；这里只取 data
 async function listButtons(request: APIRequestContext): Promise<QuickButton[]> {
-  const res = await request.get(`${BASE}/api/quick-buttons`);
+  const res = await request.get(`${BASE}/api/v1/quick-buttons`);
   expect(res.ok()).toBeTruthy();
   return (await res.json()).data as QuickButton[];
 }
@@ -22,7 +22,7 @@ async function listButtons(request: APIRequestContext): Promise<QuickButton[]> {
 async function deleteByName(request: APIRequestContext, name: string) {
   for (const b of await listButtons(request)) {
     if (b.button_name === name) {
-      await request.delete(`${BASE}/api/quick-buttons/${b.id}`);
+      await request.delete(`${BASE}/api/v1/quick-buttons/${b.id}`);
     }
   }
 }
@@ -42,7 +42,7 @@ test.describe('快捷话术按钮 API 全链路', () => {
   });
 
   test('创建 → 列出 → 改名改话术 → 删除', async ({ request }) => {
-    const createRes = await request.post(`${BASE}/api/quick-buttons`, {
+    const createRes = await request.post(`${BASE}/api/v1/quick-buttons`, {
       data: { button_name: NAME, prompt_text: '原始话术' },
     });
     expect(createRes.status()).toBe(200);
@@ -51,7 +51,7 @@ test.describe('快捷话术按钮 API 全链路', () => {
 
     expect((await listButtons(request)).find((b) => b.id === id)?.button_name).toBe(NAME);
 
-    const updRes = await request.put(`${BASE}/api/quick-buttons/${id}`, {
+    const updRes = await request.put(`${BASE}/api/v1/quick-buttons/${id}`, {
       data: { button_name: NAME_RENAMED, prompt_text: '新话术' },
     });
     expect(updRes.ok()).toBeTruthy();
@@ -60,26 +60,26 @@ test.describe('快捷话术按钮 API 全链路', () => {
     expect(updated?.button_name).toBe(NAME_RENAMED);
     expect(updated?.prompt_text).toBe('新话术');
 
-    expect((await request.delete(`${BASE}/api/quick-buttons/${id}`)).ok()).toBeTruthy();
+    expect((await request.delete(`${BASE}/api/v1/quick-buttons/${id}`)).ok()).toBeTruthy();
     expect((await listButtons(request)).find((b) => b.id === id)).toBeUndefined();
   });
 
   test('重名创建被拒（400）', async ({ request }) => {
     expect(
       (
-        await request.post(`${BASE}/api/quick-buttons`, {
+        await request.post(`${BASE}/api/v1/quick-buttons`, {
           data: { button_name: NAME, prompt_text: 'x' },
         })
       ).status(),
     ).toBe(200);
-    const dup = await request.post(`${BASE}/api/quick-buttons`, {
+    const dup = await request.post(`${BASE}/api/v1/quick-buttons`, {
       data: { button_name: NAME, prompt_text: 'y' },
     });
     expect(dup.status()).toBe(400);
   });
 
   test('空名称被拒（400）', async ({ request }) => {
-    const res = await request.post(`${BASE}/api/quick-buttons`, {
+    const res = await request.post(`${BASE}/api/v1/quick-buttons`, {
       data: { button_name: '   ', prompt_text: 'x' },
     });
     expect(res.status()).toBe(400);

--- a/frontend/tests/check_quick_buttons_ui.spec.ts
+++ b/frontend/tests/check_quick_buttons_ui.spec.ts
@@ -26,19 +26,19 @@ interface ResumeRecord {
 }
 
 async function listButtons(request: APIRequestContext): Promise<QB[]> {
-  return ((await (await request.get(`${BASE}/api/quick-buttons`)).json()).data) as QB[];
+  return ((await (await request.get(`${BASE}/api/v1/quick-buttons`)).json()).data) as QB[];
 }
 
 async function deleteByName(request: APIRequestContext, name: string) {
   for (const b of await listButtons(request)) {
-    if (b.button_name === name) await request.delete(`${BASE}/api/quick-buttons/${b.id}`);
+    if (b.button_name === name) await request.delete(`${BASE}/api/v1/quick-buttons/${b.id}`);
   }
 }
 
 // 动态找一个可 resume 的执行记录，拼出帖子页 URL；找不到返回 null（调用方 test.skip）。
 // 不写死 todo/record ID——干净库或数据变动时优雅跳过，而非在 goto 处硬失败。
 async function findResumablePostUrl(request: APIRequestContext): Promise<string | null> {
-  const res = await request.get(`${BASE}/api/execution-records`, {
+  const res = await request.get(`${BASE}/api/v1/workspaces/1/executions`, {
     params: { status: 'success', limit: 50 },
   });
   if (!res.ok()) return null;

--- a/frontend/tests/check_todo_center.spec.ts
+++ b/frontend/tests/check_todo_center.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 // 验证事项中心页面（/#items）：五类驱动 Tab、卡片渲染、Tab 切换、搜索过滤。
-// 后端 GET /api/todos/center 返回 computed_bucket，前端按桶分组并展示各 Tab 数量。
+// 后端 GET /api/v1/workspaces/1/todos/center 返回 computed_bucket，前端按桶分组并展示各 Tab 数量。
 
 const BASE = 'http://localhost:18088';
 
@@ -159,12 +159,12 @@ test('归档被 Loop 引用的事项给出引用提示', async ({ page }) => {
 
 test('删除被 Loop 引用的事项被拒绝', async ({ page }) => {
   // 取一个 Loop 驱动事项，尝试通过 API 删除应返回 400
-  const resp = await page.request.get(`${BASE}/api/todos/center?bucket=loop_driven`);
+  const resp = await page.request.get(`${BASE}/api/v1/workspaces/1/todos/center?bucket=loop_driven`);
   const body = await resp.json();
   const loopTodo = (body.data || [])[0];
   expect(loopTodo).toBeTruthy();
 
-  const del = await page.request.delete(`${BASE}/api/todos/${loopTodo.id}`);
+  const del = await page.request.delete(`${BASE}/api/v1/workspaces/1/todos/${loopTodo.id}`);
   expect(del.status()).toBe(400);
   const delBody = await del.json();
   expect(delBody.message || '').toContain('Loop');
@@ -172,7 +172,7 @@ test('删除被 Loop 引用的事项被拒绝', async ({ page }) => {
 
 test('Loop 详情图标记已归档环节', async ({ page }) => {
   // 归档一个被 Loop 引用的事项（todo #1），Loop 详情图应渲染「已归档」标记
-  await page.request.post(`${BASE}/api/todos/1/archive`);
+  await page.request.post(`${BASE}/api/v1/workspaces/1/todos/1/archive`);
   try {
     await page.goto(`${BASE}/#/loops?id=1&panel=detail`);
     await page.waitForTimeout(1500);
@@ -180,7 +180,7 @@ test('Loop 详情图标记已归档环节', async ({ page }) => {
     await expect(page.getByText('已归档', { exact: true }).first()).toBeVisible({ timeout: 8000 });
   } finally {
     // 恢复，不留下脏数据
-    await page.request.post(`${BASE}/api/todos/1/restore`);
+    await page.request.post(`${BASE}/api/v1/workspaces/1/todos/1/restore`);
   }
 });
 
@@ -262,7 +262,7 @@ test('已归档卡片菜单含删除', async ({ page }) => {
   await page.keyboard.press('Escape');
   await page.waitForTimeout(200);
   const idNum = tid!.replace('todo-center-card-', '');
-  await page.request.post(`${BASE}/api/todos/${idNum}/restore`);
+  await page.request.post(`${BASE}/api/v1/workspaces/1/todos/${idNum}/restore`);
 });
 
 test('移动端：默认卡片墙单列，可切到列表，再切回卡片', async ({ page }) => {

--- a/frontend/tests/check_todo_history.spec.ts
+++ b/frontend/tests/check_todo_history.spec.ts
@@ -21,7 +21,7 @@ test.describe('Todo #15 执行记录列表', () => {
 
     // 检查 API 返回的执行记录列表
     const records = await page.evaluate(async (todoId) => {
-      const resp = await fetch(`/api/execution-records?todo_id=${todoId}&page=1&limit=10`);
+      const resp = await fetch(`/api/v1/workspaces/1/executions?todo_id=${todoId}&page=1&limit=10`);
       const data = await resp.json();
       return data.data?.records || [];
     }, TODO_ID);

--- a/frontend/tests/check_todo_history2.spec.ts
+++ b/frontend/tests/check_todo_history2.spec.ts
@@ -30,7 +30,7 @@ test.describe('Todo #15 执行记录详情', () => {
 
     // 4. 检查 API 返回的最新执行记录
     const records = await page.evaluate(async (todoId) => {
-      const resp = await fetch(`/api/execution-records?todo_id=${todoId}&page=1&limit=5`);
+      const resp = await fetch(`/api/v1/workspaces/1/executions?todo_id=${todoId}&page=1&limit=5`);
       const data = await resp.json();
       return data.data?.records || [];
     }, TODO_ID);

--- a/frontend/tests/check_workspace_api.spec.ts
+++ b/frontend/tests/check_workspace_api.spec.ts
@@ -5,7 +5,7 @@ const BASE = 'http://localhost:18088';
 test.describe('Workspace API (阶段5-6)', () => {
   test('workspace slash commands CRUD', async ({ page }) => {
     // 1. 创建一个 todo 作为 slash command 目标
-    const todoResp = await page.request.post(`${BASE}/api/todos`, {
+    const todoResp = await page.request.post(`${BASE}/api/v1/workspaces/${workspaceId}/todos`, {
       data: {
         title: '测试 Slash 命令目标',
         prompt: '这是一个用于斜杠命令测试的 todo',
@@ -19,7 +19,7 @@ test.describe('Workspace API (阶段5-6)', () => {
     const workspaceId = 1;
 
     // 2. 创建 workspace slash command
-    const createResp = await page.request.post(`${BASE}/api/workspace/${workspaceId}/slash-commands`, {
+    const createResp = await page.request.post(`${BASE}/api/v1/workspaces/${workspaceId}/slash-commands`, {
       data: {
         slash_command: '/测试命令',
         todo_id: todoId,
@@ -32,7 +32,7 @@ test.describe('Workspace API (阶段5-6)', () => {
     console.log('创建斜杠命令成功, id:', cmdId);
 
     // 3. 获取 workspace slash commands 列表
-    const listResp = await page.request.get(`${BASE}/api/workspace/${workspaceId}/slash-commands`);
+    const listResp = await page.request.get(`${BASE}/api/v1/workspaces/${workspaceId}/slash-commands`);
     expect(listResp.ok()).toBeTruthy();
     const listData = await listResp.json();
     console.log('斜杠命令列表:', JSON.stringify(listData.data, null, 2));
@@ -40,7 +40,7 @@ test.describe('Workspace API (阶段5-6)', () => {
 
     // 4. 更新 workspace slash command
     const updateResp = await page.request.put(
-      `${BASE}/api/workspace/${workspaceId}/slash-commands/${cmdId}`,
+      `${BASE}/api/v1/workspaces/${workspaceId}/slash-commands/${cmdId}`,
       {
         data: {
           enabled: false,
@@ -52,7 +52,7 @@ test.describe('Workspace API (阶段5-6)', () => {
 
     // 5. 删除 workspace slash command
     const deleteResp = await page.request.delete(
-      `${BASE}/api/workspace/${workspaceId}/slash-commands/${cmdId}`
+      `${BASE}/api/v1/workspaces/${workspaceId}/slash-commands/${cmdId}`
     );
     expect(deleteResp.ok()).toBeTruthy();
     console.log('删除斜杠命令成功');
@@ -62,7 +62,7 @@ test.describe('Workspace API (阶段5-6)', () => {
     const workspaceId = 1;
 
     // 1. 先创建一个 todo 作为默认响应目标
-    const todoResp = await page.request.post(`${BASE}/api/todos`, {
+    const todoResp = await page.request.post(`${BASE}/api/v1/workspaces/${workspaceId}/todos`, {
       data: {
         title: '默认响应目标 Todo',
         prompt: '这是工作空间的默认响应 todo',
@@ -74,13 +74,13 @@ test.describe('Workspace API (阶段5-6)', () => {
     console.log('创建默认响应 todo 成功, id:', todoId);
 
     // 2. 获取 workspace settings
-    const getResp = await page.request.get(`${BASE}/api/workspace/${workspaceId}/settings`);
+    const getResp = await page.request.get(`${BASE}/api/v1/workspaces/${workspaceId}/settings`);
     expect(getResp.ok()).toBeTruthy();
     const getData = await getResp.json();
     console.log('获取 workspace settings 成功:', JSON.stringify(getData.data, null, 2));
 
     // 3. 更新 workspace settings
-    const updateResp = await page.request.put(`${BASE}/api/workspace/${workspaceId}/settings`, {
+    const updateResp = await page.request.put(`${BASE}/api/v1/workspaces/${workspaceId}/settings`, {
       data: {
         default_response_todo_id: todoId,
       },
@@ -89,7 +89,7 @@ test.describe('Workspace API (阶段5-6)', () => {
     console.log('更新 workspace settings 成功');
 
     // 4. 再次获取验证更新
-    const verifyResp = await page.request.get(`${BASE}/api/workspace/${workspaceId}/settings`);
+    const verifyResp = await page.request.get(`${BASE}/api/v1/workspaces/${workspaceId}/settings`);
     expect(verifyResp.ok()).toBeTruthy();
     const verifyData = await verifyResp.json();
     expect(verifyData.data.default_response_todo_id).toBe(todoId);
@@ -100,7 +100,7 @@ test.describe('Workspace API (阶段5-6)', () => {
     const workspaceId = 1;
 
     // 测试 slash_command 必须以 / 开头
-    const badResp = await page.request.post(`${BASE}/api/workspace/${workspaceId}/slash-commands`, {
+    const badResp = await page.request.post(`${BASE}/api/v1/workspaces/${workspaceId}/slash-commands`, {
       data: {
         slash_command: 'bad_command', // 缺少 /
         todo_id: 1,

--- a/frontend/tests/check_workspace_frontend.spec.ts
+++ b/frontend/tests/check_workspace_frontend.spec.ts
@@ -32,7 +32,7 @@ test.describe('Workspace Frontend Panels (阶段7-11)', () => {
 
   test('workspace slash commands CRUD via API', async ({ page }) => {
     // 1. 创建一个 todo
-    const todoResp = await page.request.post(`${BASE}/api/todos`, {
+    const todoResp = await page.request.post(`${BASE}/api/v1/workspaces/${workspaceId}/todos`, {
       data: { title: '测试 Slash 命令', prompt: '测试' },
     });
     expect(todoResp.ok()).toBeTruthy();
@@ -41,14 +41,14 @@ test.describe('Workspace Frontend Panels (阶段7-11)', () => {
     const workspaceId = 1;
 
     // 2. 创建 slash command
-    const createResp = await page.request.post(`${BASE}/api/workspace/${workspaceId}/slash-commands`, {
+    const createResp = await page.request.post(`${BASE}/api/v1/workspaces/${workspaceId}/slash-commands`, {
       data: { slash_command: '/测试', todo_id: todoId, enabled: true },
     });
     expect(createResp.ok()).toBeTruthy();
     const cmdId = (await createResp.json()).data.id;
 
     // 3. 获取列表验证
-    const listResp = await page.request.get(`${BASE}/api/workspace/${workspaceId}/slash-commands`);
+    const listResp = await page.request.get(`${BASE}/api/v1/workspaces/${workspaceId}/slash-commands`);
     expect(listResp.ok()).toBeTruthy();
     const commands = (await listResp.json()).data;
     const cmd = commands.find((c: any) => c.id === cmdId);
@@ -57,12 +57,12 @@ test.describe('Workspace Frontend Panels (阶段7-11)', () => {
     console.log('WorkspaceSlashCommandsPanel 数据验证成功');
 
     // 4. 清理
-    await page.request.delete(`${BASE}/api/workspace/${workspaceId}/slash-commands/${cmdId}`);
+    await page.request.delete(`${BASE}/api/v1/workspaces/${workspaceId}/slash-commands/${cmdId}`);
   });
 
   test('workspace settings panel', async ({ page }) => {
     // 1. 创建 todo
-    const todoResp = await page.request.post(`${BASE}/api/todos`, {
+    const todoResp = await page.request.post(`${BASE}/api/v1/workspaces/${workspaceId}/todos`, {
       data: { title: '默认响应 Todo', prompt: '测试' },
     });
     expect(todoResp.ok()).toBeTruthy();
@@ -71,13 +71,13 @@ test.describe('Workspace Frontend Panels (阶段7-11)', () => {
     const workspaceId = 1;
 
     // 2. 更新 workspace settings
-    const updateResp = await page.request.put(`${BASE}/api/workspace/${workspaceId}/settings`, {
+    const updateResp = await page.request.put(`${BASE}/api/v1/workspaces/${workspaceId}/settings`, {
       data: { default_response_todo_id: todoId },
     });
     expect(updateResp.ok()).toBeTruthy();
 
     // 3. 验证更新
-    const getResp = await page.request.get(`${BASE}/api/workspace/${workspaceId}/settings`);
+    const getResp = await page.request.get(`${BASE}/api/v1/workspaces/${workspaceId}/settings`);
     expect(getResp.ok()).toBeTruthy();
     const settings = (await getResp.json()).data;
     expect(settings.default_response_todo_id).toBe(todoId);
@@ -86,7 +86,7 @@ test.describe('Workspace Frontend Panels (阶段7-11)', () => {
 
   test('bot workspace_id in agent list', async ({ page }) => {
     // 验证 AgentBot 包含 workspace_id 字段
-    const botsResp = await page.request.get(`${BASE}/api/agent-bots`);
+    const botsResp = await page.request.get(`${BASE}/api/v1/agent-bots`);
     expect(botsResp.ok()).toBeTruthy();
     const bots = (await botsResp.json()).data;
 

--- a/frontend/tests/feat-review-template-selector.spec.ts
+++ b/frontend/tests/feat-review-template-selector.spec.ts
@@ -11,7 +11,7 @@ const DEV_URL = 'http://localhost:18088';
 
 test('Loop 编辑器评审模板 Select 选项可加载 + inline 新建可工作', async ({ page }) => {
   // 找一个 loop（任意一条都行，因为我们只关心 Select 是否拿到选项）
-  const listRes = await page.request.get(`${BACKEND_URL}/api/loops?page=1&limit=50`);
+  const listRes = await page.request.get(`${BACKEND_URL}/api/v1/workspaces/1/loops?page=1&limit=50`);
   const listJson = await listRes.json();
   const loops: Array<{ id: number; name: string }> = listJson?.data ?? [];
   test.skip(loops.length === 0, '没有任何 loop 可测试，跳过');

--- a/frontend/tests/feat_action_toolbar.spec.ts
+++ b/frontend/tests/feat_action_toolbar.spec.ts
@@ -26,7 +26,7 @@ let loopId = 0;
 test.beforeAll(async ({ request }) => {
   // 事项
   for (let i = 1; i <= 3; i++) {
-    const r = await request.post(`${DEV_URL}/api/todos`, {
+    const r = await request.post(`${DEV_URL}/api/v1/workspaces/1/todos`, {
       data: { title: `toolbar-todo-${i}`, prompt: `seed ${i}` },
     });
     expect(r.ok()).toBeTruthy();
@@ -37,17 +37,17 @@ test.beforeAll(async ({ request }) => {
   }
 
   // 环节（通过 promote 创建）
-  const stepRes = await request.post(`${DEV_URL}/api/todos`, {
+  const stepRes = await request.post(`${DEV_URL}/api/v1/workspaces/1/todos`, {
     data: { title: 'toolbar-step-1', prompt: 'step seed' },
   });
   const { data: stepTodo } = await stepRes.json();
   stepSourceTodoId = stepTodo.id;
-  const promoteRes = await request.post(`${DEV_URL}/api/todos/${stepSourceTodoId}/promote`);
+  const promoteRes = await request.post(`${DEV_URL}/api/v1/workspaces/1/todos/${stepSourceTodoId}/promote`);
   const { data: promoted } = await promoteRes.json();
   stepId = promoted.id;
 
   // 环路
-  const loopRes = await request.post(`${DEV_URL}/api/loops`, {
+  const loopRes = await request.post(`${DEV_URL}/api/v1/workspaces/1/loops`, {
     data: { name: 'toolbar-loop-1' },
   });
   const { data: loop } = await loopRes.json();
@@ -55,10 +55,10 @@ test.beforeAll(async ({ request }) => {
 });
 
 test.afterAll(async ({ request }) => {
-  await request.delete(`${DEV_URL}/api/loops/${loopId}`);
-  await request.delete(`${DEV_URL}/api/todos/${stepSourceTodoId}`);
+  await request.delete(`${DEV_URL}/api/v1/workspaces/1/loops/${loopId}`);
+  await request.delete(`${DEV_URL}/api/v1/workspaces/1/todos/${stepSourceTodoId}`);
   for (const id of [todoId1, todoId2, todoId3]) {
-    if (id) await request.delete(`${DEV_URL}/api/todos/${id}`);
+    if (id) await request.delete(`${DEV_URL}/api/v1/workspaces/1/todos/${id}`);
   }
 });
 

--- a/frontend/tests/loop-studio.spec.ts
+++ b/frontend/tests/loop-studio.spec.ts
@@ -10,13 +10,13 @@ const BACKEND_URL = process.env.E2E_BACKEND_URL || 'http://localhost:18088';
 
 test.describe('Loop Studio API', () => {
   test('API 正常响应', async ({ page }) => {
-    const res = await page.request.get(`${BACKEND_URL}/api/loops`);
+    const res = await page.request.get(`${BACKEND_URL}/api/v1/workspaces/1/loops`);
     expect(res.ok()).toBeTruthy();
   });
 
   test('新建 loop → 详情 → 删除', async ({ page }) => {
     // 新建
-    const createRes = await page.request.post(`${BACKEND_URL}/api/loops`, {
+    const createRes = await page.request.post(`${BACKEND_URL}/api/v1/workspaces/1/loops`, {
       data: { name: 'playwright-test-loop' },
     });
     expect(createRes.ok()).toBeTruthy();
@@ -25,23 +25,23 @@ test.describe('Loop Studio API', () => {
     expect(loopId).toBeGreaterThan(0);
 
     // 详情
-    const detailRes = await page.request.get(`${BACKEND_URL}/api/loops/${loopId}`);
+    const detailRes = await page.request.get(`${BACKEND_URL}/api/v1/workspaces/1/loops/${loopId}`);
     expect(detailRes.ok()).toBeTruthy();
 
     // 列表包含
-    const listRes = await page.request.get(`${BACKEND_URL}/api/loops`);
+    const listRes = await page.request.get(`${BACKEND_URL}/api/v1/workspaces/1/loops`);
     const list = await listRes.json();
     const ids = list.data.map((l: any) => l.id);
     expect(ids).toContain(loopId);
 
     // 删除
-    const delRes = await page.request.delete(`${BACKEND_URL}/api/loops/${loopId}`);
+    const delRes = await page.request.delete(`${BACKEND_URL}/api/v1/workspaces/1/loops/${loopId}`);
     expect(delRes.ok()).toBeTruthy();
   });
 
   test('创建环节（promote）', async ({ page }) => {
     // 先建一个 todo
-    const todoRes = await page.request.post(`${BACKEND_URL}/api/todos`, {
+    const todoRes = await page.request.post(`${BACKEND_URL}/api/v1/workspaces/1/todos`, {
       data: { title: 'promote-test-todo', prompt: 'test prompt' },
     });
     expect(todoRes.ok()).toBeTruthy();
@@ -49,7 +49,7 @@ test.describe('Loop Studio API', () => {
     const todoId = todo.data.id;
 
     // promote
-    const promoteRes = await page.request.post(`${BACKEND_URL}/api/todos/${todoId}/promote`);
+    const promoteRes = await page.request.post(`${BACKEND_URL}/api/v1/workspaces/1/todos/${todoId}/promote`);
     expect(promoteRes.ok()).toBeTruthy();
     const step = await promoteRes.json();
     expect(step.data.title).toBe('promote-test-todo');
@@ -65,22 +65,22 @@ test.describe('Loop Studio API', () => {
 
   test('loop 添加环节', async ({ page }) => {
     // 建 loop
-    const loopRes = await page.request.post(`${BACKEND_URL}/api/loops`, {
+    const loopRes = await page.request.post(`${BACKEND_URL}/api/v1/workspaces/1/loops`, {
       data: { name: 'stage-test-loop' },
     });
     const loop = await loopRes.json();
     const loopId = loop.data.id;
 
     // 建 todo → promote 为 step
-    const todoRes = await page.request.post(`${BACKEND_URL}/api/todos`, {
+    const todoRes = await page.request.post(`${BACKEND_URL}/api/v1/workspaces/1/todos`, {
       data: { title: 'stage-step', prompt: 'do something' },
     });
     const todo = await todoRes.json();
-    const promoteRes = await page.request.post(`${BACKEND_URL}/api/todos/${todo.data.id}/promote`);
+    const promoteRes = await page.request.post(`${BACKEND_URL}/api/v1/workspaces/1/todos/${todo.data.id}/promote`);
     const step = await promoteRes.json();
 
     // 给 loop 添加 stage
-    const stageRes = await page.request.post(`${BACKEND_URL}/api/loops/${loopId}/stages`, {
+    const stageRes = await page.request.post(`${BACKEND_URL}/api/v1/workspaces/1/loops/${loopId}/stages`, {
       data: { name: '我的环节', todo_id: step.data.id },
     });
     expect(stageRes.ok()).toBeTruthy();
@@ -88,11 +88,11 @@ test.describe('Loop Studio API', () => {
     expect(stage.data.name).toBe('我的环节');
 
     // 验证 stages 列表
-    const stagesRes = await page.request.get(`${BACKEND_URL}/api/loops/${loopId}/stages`);
+    const stagesRes = await page.request.get(`${BACKEND_URL}/api/v1/workspaces/1/loops/${loopId}/stages`);
     const stages = await stagesRes.json();
     expect(stages.data.length).toBeGreaterThanOrEqual(1);
 
     // 清理
-    await page.request.delete(`${BACKEND_URL}/api/loops/${loopId}`);
+    await page.request.delete(`${BACKEND_URL}/api/v1/workspaces/1/loops/${loopId}`);
   });
 });

--- a/frontend/tests/project-directory-worktree.spec.ts
+++ b/frontend/tests/project-directory-worktree.spec.ts
@@ -2,11 +2,11 @@
 //
 // 验证目标:
 //  1. ProjectDirectoriesPanel 中每个目录行展示两个 Switch（启用 Git Worktree / 自动清理）
-//  2. 切换 Switch 会调用 PUT /api/project-directories/{id} 并带上新字段
+//  2. 切换 Switch 会调用 PUT /api/v1/project-directories/{id} 并带上新字段
 //  3. "自动清理" Switch 在 "启用 Git Worktree" 关闭时为 disabled
 //  4. 乐观更新生效: API 返回前 Switch 状态先翻转
 //
-// 写法说明: 不依赖 dev 服务真实运行, 用 page.route() 拦截 /api/project-directories
+// 写法说明: 不依赖 dev 服务真实运行, 用 page.route() 拦截 /api/v1/project-directories
 // 系列请求并返回固定 fixture, 让 UI 逻辑可独立验证.
 import { test, expect, Page } from '@playwright/test';
 
@@ -31,7 +31,7 @@ function defaultFixtureDirs() {
 
 async function mockProjectDirApis(page: Page, fixtureDirs: ReturnType<typeof defaultFixtureDirs>) {
   // GET 列表
-  await page.route('**/api/project-directories', async (route) => {
+  await page.route('**/api/v1/project-directories', async (route) => {
     if (route.request().method() === 'GET') {
       await route.fulfill({
         status: 200,
@@ -43,7 +43,7 @@ async function mockProjectDirApis(page: Page, fixtureDirs: ReturnType<typeof def
     }
   });
   // PUT 更新
-  await page.route('**/api/project-directories/1', async (route) => {
+  await page.route('**/api/v1/project-directories/1', async (route) => {
     if (route.request().method() === 'PUT') {
       const body = route.request().postDataJSON();
       // 把后端 echo 的"已合并"对象返回
@@ -98,7 +98,7 @@ test('project directory: worktree 开关渲染 + 行为', async ({ page }) => {
 
   // 简化为"读 fixture 后断言 Switch 存在并能交互"。
   const apiState = await page.evaluate(async () => {
-    const resp = await fetch('/api/project-directories');
+    const resp = await fetch('/api/v1/project-directories');
     const data = await resp.json();
     return data;
   });
@@ -114,7 +114,7 @@ test('project directory: API 接受新字段并回显', async ({ page }) => {
   await page.goto(BASE);
   // 1) PUT 开启 worktree
   const putResult = await page.evaluate(async () => {
-    const resp = await fetch('/api/project-directories/1', {
+    const resp = await fetch('/api/v1/project-directories/1', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'proj-a', git_worktree_enabled: true }),
@@ -126,7 +126,7 @@ test('project directory: API 接受新字段并回显', async ({ page }) => {
 
   // 2) GET 拿回新状态
   const list = await page.evaluate(async () => {
-    const r = await fetch('/api/project-directories');
+    const r = await fetch('/api/v1/project-directories');
     const j = await r.json();
     return j.data[0];
   });
@@ -134,7 +134,7 @@ test('project directory: API 接受新字段并回显', async ({ page }) => {
 
   // 3) PUT 开启 auto_cleanup
   const put2 = await page.evaluate(async () => {
-    const r = await fetch('/api/project-directories/1', {
+    const r = await fetch('/api/v1/project-directories/1', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'proj-a', git_worktree_enabled: true, auto_cleanup: true }),
@@ -144,7 +144,7 @@ test('project directory: API 接受新字段并回显', async ({ page }) => {
   expect(put2.status).toBe(200);
 
   const list2 = await page.evaluate(async () => {
-    const r = await fetch('/api/project-directories');
+    const r = await fetch('/api/v1/project-directories');
     const j = await r.json();
     return j.data[0];
   });

--- a/frontend/tests/step-loop-tags.spec.ts
+++ b/frontend/tests/step-loop-tags.spec.ts
@@ -25,7 +25,7 @@ test.describe('环节/环路标签功能', () => {
 
     try {
       // 创建标签：传入名称和颜色，后端返回包含 id 的标签对象
-      const createRes = await page.request.post(`${BACKEND_URL}/api/tags`, {
+      const createRes = await page.request.post(`${BACKEND_URL}/api/v1/tags`, {
         data: { name: tagName, color: '#ff6600' },
       });
       expect(createRes.ok()).toBeTruthy();
@@ -35,21 +35,21 @@ test.describe('环节/环路标签功能', () => {
       expect(createdTagId).toBeGreaterThan(0);
 
       // 列表接口应该包含刚创建的标签 id，验证 C 和 R 链路通
-      const listRes = await page.request.get(`${BACKEND_URL}/api/tags`);
+      const listRes = await page.request.get(`${BACKEND_URL}/api/v1/tags`);
       expect(listRes.ok()).toBeTruthy();
       const tags = await listRes.json();
       const ids = tags.data.map((t: any) => t.id);
       expect(ids).toContain(createdTagId);
 
       // 删除标签
-      const delRes = await page.request.delete(`${BACKEND_URL}/api/tags/${createdTagId}`);
+      const delRes = await page.request.delete(`${BACKEND_URL}/api/v1/tags/${createdTagId}`);
       expect(delRes.ok()).toBeTruthy();
       // 删除后 createdTagId 标记已清理，阻止 finally 块重复删除
       createdTagId = undefined;
     } finally {
       // 如果中途失败导致 createdTagId 未被清理，在 finally 中兜底释放资源
       if (createdTagId) {
-        await page.request.delete(`${BACKEND_URL}/api/tags/${createdTagId}`);
+        await page.request.delete(`${BACKEND_URL}/api/v1/tags/${createdTagId}`);
       }
     }
   });
@@ -61,7 +61,7 @@ test.describe('环节/环路标签功能', () => {
 
     try {
       // 创建标签：用唯一名称防止测试间冲突
-      const tagRes = await page.request.post(`${BACKEND_URL}/api/tags`, {
+      const tagRes = await page.request.post(`${BACKEND_URL}/api/v1/tags`, {
         data: { name: uniqueTagName('环节标签'), color: '#1890ff' },
       });
       expect(tagRes.ok()).toBeTruthy();
@@ -88,7 +88,7 @@ test.describe('环节/环路标签功能', () => {
       expect(updated.data.tag_ids).toContain(createdTagId);
     } finally {
       // 资源清理：无论测试成功与否都释放标签和环节
-      if (createdTagId) await page.request.delete(`${BACKEND_URL}/api/tags/${createdTagId}`);
+      if (createdTagId) await page.request.delete(`${BACKEND_URL}/api/v1/tags/${createdTagId}`);
       if (createdStepId) await page.request.delete(`${BACKEND_URL}/api/steps/${createdStepId}`);
     }
   });
@@ -100,7 +100,7 @@ test.describe('环节/环路标签功能', () => {
 
     try {
       // 创建标签
-      const tagRes = await page.request.post(`${BACKEND_URL}/api/tags`, {
+      const tagRes = await page.request.post(`${BACKEND_URL}/api/v1/tags`, {
         data: { name: uniqueTagName('环路标签'), color: '#52c41a' },
       });
       expect(tagRes.ok()).toBeTruthy();
@@ -108,7 +108,7 @@ test.describe('环节/环路标签功能', () => {
       createdTagId = tag.data.id;
 
       // 创建环路，新环路初始 tag_ids 应为空
-      const loopRes = await page.request.post(`${BACKEND_URL}/api/loops`, {
+      const loopRes = await page.request.post(`${BACKEND_URL}/api/v1/workspaces/1/loops`, {
         data: { name: uniqueTagName('测试环路') },
       });
       expect(loopRes.ok()).toBeTruthy();
@@ -116,23 +116,23 @@ test.describe('环节/环路标签功能', () => {
       createdLoopId = loop.data.id;
       expect(loop.data.tag_ids).toEqual([]);
 
-      // 通过 PUT /api/loops/{id}/tags 关联标签
-      const updateTagsRes = await page.request.put(`${BACKEND_URL}/api/loops/${createdLoopId}/tags`, {
+      // 通过 PUT /api/v1/workspaces/1/loops/{id}/tags 关联标签
+      const updateTagsRes = await page.request.put(`${BACKEND_URL}/api/v1/workspaces/1/loops/${createdLoopId}/tags`, {
         data: { tag_ids: [createdTagId] },
       });
       expect(updateTagsRes.ok()).toBeTruthy();
       const updated = await updateTagsRes.json();
       expect(updated.data.tag_ids).toContain(createdTagId);
 
-      // 验证环路详情 GET /api/loops/{id} 也返回标签，确保详情与列表数据源一致
-      const detailRes = await page.request.get(`${BACKEND_URL}/api/loops/${createdLoopId}`);
+      // 验证环路详情 GET /api/v1/workspaces/1/loops/{id} 也返回标签，确保详情与列表数据源一致
+      const detailRes = await page.request.get(`${BACKEND_URL}/api/v1/workspaces/1/loops/${createdLoopId}`);
       expect(detailRes.ok()).toBeTruthy();
       const detail = await detailRes.json();
       expect(detail.data.tag_ids).toContain(createdTagId);
     } finally {
       // 资源清理：先删标签再删环路，避免外键约束问题
-      if (createdTagId) await page.request.delete(`${BACKEND_URL}/api/tags/${createdTagId}`);
-      if (createdLoopId) await page.request.delete(`${BACKEND_URL}/api/loops/${createdLoopId}`);
+      if (createdTagId) await page.request.delete(`${BACKEND_URL}/api/v1/tags/${createdTagId}`);
+      if (createdLoopId) await page.request.delete(`${BACKEND_URL}/api/v1/workspaces/1/loops/${createdLoopId}`);
     }
   });
 
@@ -143,7 +143,7 @@ test.describe('环节/环路标签功能', () => {
 
     try {
       // 创建标签
-      const tagRes = await page.request.post(`${BACKEND_URL}/api/tags`, {
+      const tagRes = await page.request.post(`${BACKEND_URL}/api/v1/tags`, {
         data: { name: uniqueTagName('列表标签'), color: '#722ed1' },
       });
       expect(tagRes.ok()).toBeTruthy();
@@ -151,7 +151,7 @@ test.describe('环节/环路标签功能', () => {
       createdTagId = tag.data.id;
 
       // 创建环路
-      const loopRes = await page.request.post(`${BACKEND_URL}/api/loops`, {
+      const loopRes = await page.request.post(`${BACKEND_URL}/api/v1/workspaces/1/loops`, {
         data: { name: uniqueTagName('列表测试环路') },
       });
       expect(loopRes.ok()).toBeTruthy();
@@ -159,13 +159,13 @@ test.describe('环节/环路标签功能', () => {
       createdLoopId = loop.data.id;
 
       // 关联标签
-      const updateTagsRes = await page.request.put(`${BACKEND_URL}/api/loops/${createdLoopId}/tags`, {
+      const updateTagsRes = await page.request.put(`${BACKEND_URL}/api/v1/workspaces/1/loops/${createdLoopId}/tags`, {
         data: { tag_ids: [createdTagId] },
       });
       expect(updateTagsRes.ok()).toBeTruthy();
 
-      // 列表接口 GET /api/loops 应包含该环路的标签信息
-      const listRes = await page.request.get(`${BACKEND_URL}/api/loops`);
+      // 列表接口 GET /api/v1/workspaces/1/loops 应包含该环路的标签信息
+      const listRes = await page.request.get(`${BACKEND_URL}/api/v1/workspaces/1/loops`);
       expect(listRes.ok()).toBeTruthy();
       const list = await listRes.json();
       const target = list.data.find((l: any) => l.id === createdLoopId);
@@ -174,8 +174,8 @@ test.describe('环节/环路标签功能', () => {
       expect(target.tag_ids).toContain(createdTagId);
     } finally {
       // 资源清理
-      if (createdTagId) await page.request.delete(`${BACKEND_URL}/api/tags/${createdTagId}`);
-      if (createdLoopId) await page.request.delete(`${BACKEND_URL}/api/loops/${createdLoopId}`);
+      if (createdTagId) await page.request.delete(`${BACKEND_URL}/api/v1/tags/${createdTagId}`);
+      if (createdLoopId) await page.request.delete(`${BACKEND_URL}/api/v1/workspaces/1/loops/${createdLoopId}`);
     }
   });
 });

--- a/frontend/tests/workspace_id_only.spec.ts
+++ b/frontend/tests/workspace_id_only.spec.ts
@@ -2,7 +2,7 @@
 //
 // 验证目标：
 // 1. WorkspaceSelect 的 antd Select option value 是数字（id），不是路径字符串。
-// 2. 触发 LoopFormModal 保存时，POST /api/loops 请求体里包含 workspace_id（number），
+// 2. 触发 LoopFormModal 保存时，POST /api/v1/workspaces/${workspace_id}/loops 请求体里包含 workspace_id（number），
 //    不再带 workspace_path 字段。
 // 3. Loop 详情页 / 编辑 modal 拿到的 LoopDto 里 workspace_id 是 number。
 //
@@ -16,10 +16,10 @@ const BASE = 'http://localhost:18088';
 // 通过 API 拿到已存在的 workspace id 与一个示例 loop（用于编辑模式断言）
 async function fetchSeed(api: Awaited<ReturnType<typeof request.newContext>>) {
   // 拉取 project_directories
-  const dirsResp = await api.get(`${BASE}/api/project-directories`);
+  const dirsResp = await api.get(`${BASE}/api/v1/project-directories`);
   const dirs = (await dirsResp.json()).data as Array<{ id: number; path: string; name: string | null }>;
   // 拉取 loops
-  const loopsResp = await api.get(`${BASE}/api/loops`);
+  const loopsResp = await api.get(`${BASE}/api/v1/workspaces/${workspace_id}/loops`);
   const loops = (await loopsResp.json()).data as Array<{ id: number; workspace_id: number | null }>;
   return { dirs, loops };
 }
@@ -40,7 +40,7 @@ test.describe('workspace_id 破坏式改造验证', () => {
     await page.goto(BASE);
     await page.waitForLoadState('networkidle');
     // 等待 project_directories 加载
-    await page.waitForResponse(r => r.url().includes('/api/project-directories') && r.status() === 200, { timeout: 5000 }).catch(() => {});
+    await page.waitForResponse(r => r.url().includes('/api/v1/project-directories') && r.status() === 200, { timeout: 5000 }).catch(() => {});
 
     // 打开任意 WorkspaceSelect —— TodoDrawer 的新建按钮 / 左侧 WorkspaceSwitcher / LoopFormModal 都用同一组件
     // 通过 WorkspaceSwitcher dropdown 触发最稳，因为它总是渲染
@@ -79,9 +79,9 @@ test.describe('workspace_id 破坏式改造验证', () => {
     if (dirs.length === 0) test.skip(true, 'dev server 上没有 project_directory，跳过');
     const targetDir = dirs[0];
 
-    // 拦截 POST /api/loops 以捕获请求体
+    // 拦截 POST /api/v1/workspaces/${workspace_id}/loops 以捕获请求体
     const createReq = page.waitForRequest(
-      r => r.url().endsWith('/api/loops') && r.method() === 'POST',
+      r => r.url().endsWith('/api/v1/workspaces/${workspace_id}/loops') && r.method() === 'POST',
       { timeout: 15000 },
     );
 
@@ -116,7 +116,7 @@ test.describe('workspace_id 破坏式改造验证', () => {
 
     // 断言请求体
     const req = await createReq.catch(() => null);
-    if (!req) test.skip(true, '未拦截到 POST /api/loops 请求，跳过');
+    if (!req) test.skip(true, '未拦截到 POST /api/v1/workspaces/${workspace_id}/loops 请求，跳过');
     const body = req!.postDataJSON() as Record<string, unknown>;
     expect(body).toHaveProperty('workspace_id');
     expect(typeof body.workspace_id).toBe('number');


### PR DESCRIPTION
## 概述

API 路由重构，将后端所有路由统一挂载到 `/api/v1/` 前缀下，采用 K8s 风格 workspace 层级嵌入路径，实现路由结构统一、隔离清晰。

## 变更内容

### 核心架构
- **v1 路由聚合**：所有路由挂载到 `/api/v1/` 下，包括 dashboard、todos、wiki、executor-profiles/providers 等
- **Workspace 隔离**：路由路径嵌入 workspace 层级，实现多租户隔离
- **旧路由清理**：按 ADR-7 方案删除旧版非 v1 路由

### 具体模块
- **Dashboard**：修复 `/api/v1/version` 404 问题
- **Wiki**：黑板与 wiki 路由独立，修复点击 wiki/files 404
- **Executor Profiles**：profiles/providers 路由挂载到 v1 聚合树（executor-profiles rebase 适配）
- **Todo**：单资源隔离补齐
- **CLI 与测试**：全量迁移适配 v1 路径

### 质量保证
- 前后端代码通过 clippy + tsc 零告警
- 集成测试覆盖主要路由路径
- 前端导入路径统一使用 `@/` 别名

## 与需求对应关系

- ADR-7: API 路由重构设计方案
- 对应 docs/design/api-routing-redesign.md 设计文档

## 测试验证

```bash
cd backend && cargo clippy --all-targets -- -D warnings  # 通过
cd backend && cargo test  # 通过
cd frontend && npx tsc --noEmit  # 通过
```

Closes #921