### PR TITLE
fix(stats): 移除 dashboard handler 多余 Path(ws_id)，修复 /api/v1/stats/dashboard 500

### DIFF
--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -601,7 +601,7 @@ pub async fn run_command(cli: &Cli) -> Result<()> {
         Commands::Todo { action } => handle_todo(&client, action, &cli.output, &cli.fields).await?,
         Commands::Loop { action } => handle_loop(&client, action, &cli.output, &cli.fields).await?,
         Commands::Tag { action } => handle_tag(&client, action, &cli.output, &cli.fields).await?,
-        Commands::Stats { } => handle_stats(&client, 0, &cli.output, &cli.fields).await?,
+        Commands::Stats { } => handle_stats(&client, &cli.output, &cli.fields).await?,
         Commands::Blackboard { action } => handle_blackboard(&client, action, &cli.output, &cli.fields).await?,
         Commands::Workspace { action } => handle_workspace(&client, action, &cli.output, &cli.fields).await?,
     }
@@ -893,7 +893,6 @@ async fn handle_tag(
 
 async fn handle_stats(
     client: &ApiClient,
-    workspace_id: i64,
     output: &OutputFormat,
     fields: &Option<String>,
 ) -> Result<()> {

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -620,7 +620,8 @@ static DASHBOARD_CACHE: LazyLock<RwLock<HashMap<(i64, u32), DashboardCacheEntry>
 
 pub async fn get_dashboard_stats(
     State(state): State<AppState>,
-    Path(ws_id): Path<i64>,
+    // Dashboard 为全局运营视图，路由注册在 /api/v1/stats/dashboard（无 workspace 路径参数），
+    // 因此 handler 不能声明 Path(ws_id)，否则 Axum 提取器会因路径参数缺失而直接返回 500。
     Query(params): Query<DashboardStatsParams>,
 ) -> Result<ApiResponse<DashboardStats>, AppError> {
     let hours_key = params.hours.unwrap_or(24 * 7); // default: 7 days

--- a/backend/tests/api_integration_test.rs
+++ b/backend/tests/api_integration_test.rs
@@ -916,6 +916,31 @@ async fn test_old_api_routes_return_404() {
     }
 }
 
+// ====== Dashboard stats 全局路由回归测试 ======
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_dashboard_stats_global_route_returns_ok() {
+    // 全局 /api/v1/stats/dashboard 路由没有 workspace 路径参数，
+    // 若 handler 仍声明 Path(ws_id)，Axum 提取器会失败并返回 500。
+    // 此测试确保带 hours 查询参数的请求能正常返回 200。
+    let (app, _ws_id) = create_test_app().await;
+
+    let req = Request::builder()
+        .uri("/api/v1/stats/dashboard?hours=720")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "/api/v1/stats/dashboard?hours=720 应返回 200"
+    );
+
+    let body: serde_json::Value = read_json_body(resp).await;
+    assert_eq!(body["code"], 0, "Dashboard stats 响应 code 应为 0");
+    assert!(body["data"].is_object(), "Dashboard stats 响应 data 应为对象");
+}
+
 // ====== 修复 test_delete_todo 验证逻辑 ======
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## 问题

访问 `/api/v1/stats/dashboard?hours=720` 返回 500：



## 根因

`get_dashboard_stats` handler 声明了 `Path(ws_id): Path<i64>`，但路由注册在 `/api/v1/stats/dashboard`（无 workspace 路径参数）。Axum 提取器因参数不匹配直接返回 500。

Dashboard 为全局运营视图，不应依赖 workspace 路径参数。

## 修改

- `backend/src/handlers/execution.rs`：移除 `get_dashboard_stats` 中多余的 `Path(ws_id)`
- `backend/src/cli/commands.rs`：彻底删除 `handle_stats` 未使用的 `workspace_id` 参数及调用处的 `0`
- `backend/tests/api_integration_test.rs`：新增回归测试，验证 `/api/v1/stats/dashboard?hours=720` 返回 200

## 验证

- `cargo test --test api_integration_test test_dashboard_stats_global_route_returns_ok` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ 零告警
- `cargo test` ✅ 全部通过
- 本地启动服务器后访问 `/api/v1/stats/dashboard?hours=720` 返回 HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)