### PR TITLE
refactor: 将 system_prompt 控件从消息配置移至工作空间管理页

### DIFF
--- a/frontend/src/components/message-monitor/MessageConfigDrawer.tsx
+++ b/frontend/src/components/message-monitor/MessageConfigDrawer.tsx
@@ -1,6 +1,6 @@
 import { Drawer, Divider } from 'antd';
 import { WorkspaceSlashCommandsPanel } from '@/components/settings/workspace/WorkspaceSlashCommandsPanel';
-import { WorkspaceSettingsPanel } from '@/components/settings/workspace/WorkspaceSettingsPanel';
+import { DefaultResponseConfigPanel } from '@/components/settings/workspace/DefaultResponseConfigPanel';
 
 interface MessageConfigDrawerProps {
   open: boolean;
@@ -32,7 +32,7 @@ export function MessageConfigDrawer({ open, workspaceId, onClose, onChanged }: M
 
         <div style={{ marginBottom: 16 }}>
           <h4 style={{ margin: '0 0 12px', fontSize: 14, fontWeight: 500 }}>默认响应规则</h4>
-          <WorkspaceSettingsPanel
+          <DefaultResponseConfigPanel
             workspaceId={workspaceId}
             onChanged={onChanged}
           />

--- a/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
+++ b/frontend/src/components/settings/ProjectDirectoriesPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Button, Input, Empty, Spin, Switch, message, Tooltip, Typography, Card, Dropdown } from 'antd';
-import { PlusOutlined, FolderOutlined, RobotOutlined, EditOutlined, DeleteOutlined, MoreOutlined } from '@ant-design/icons';
+import { PlusOutlined, FolderOutlined, RobotOutlined, EditOutlined, DeleteOutlined, MoreOutlined, FileTextOutlined } from '@ant-design/icons';
+import { WorkspacePromptModal } from '@/components/settings/workspace/WorkspacePromptModal';
 import { PageCard } from '@/components/common/PageCard';
 import * as db from '@/utils/database';
 import type { ProjectDirectory, AgentBot } from '@/utils/database';
@@ -23,6 +24,8 @@ export function ProjectDirectoriesPanel({ onOpenMessages }: ProjectDirectoriesPa
   const [editingDirName, setEditingDirName] = useState('');
   // 智能体列表，用于统计每个工作区的绑定数量
   const [agentBots, setAgentBots] = useState<AgentBot[]>([]);
+  // 基础约定弹窗状态：记录要编辑的工作空间 id 和名称
+  const [promptModalWorkspace, setPromptModalWorkspace] = useState<{ id: number; name: string } | null>(null);
 
   // 每次进入页面都重新拉取一次，确保用户在其他地方新增/删除后能立刻看到
   const loadProjectDirectories = () => {
@@ -323,8 +326,18 @@ export function ProjectDirectoriesPanel({ onOpenMessages }: ProjectDirectoriesPa
                       paddingTop: 12,
                       borderTop: '1px solid var(--color-border-light)',
                       flexWrap: 'wrap',
+                      alignItems: 'center',
                     }}
                   >
+                    <Tooltip title="配置该工作空间下所有 todo 执行时注入的前置 prompt">
+                      <span
+                        style={{ display: 'inline-flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}
+                        onClick={() => setPromptModalWorkspace({ id: dir.id, name: dir.name || '' })}
+                      >
+                        <FileTextOutlined style={{ fontSize: 13, color: 'var(--color-text-secondary)' }} />
+                        <span style={{ fontSize: 13, color: 'var(--color-text-secondary)' }}>基础约定</span>
+                      </span>
+                    </Tooltip>
                     <Tooltip title="执行事项时自动创建 git worktree，保持工作区干净">
                       <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
                         <Switch
@@ -358,6 +371,15 @@ export function ProjectDirectoriesPanel({ onOpenMessages }: ProjectDirectoriesPa
           )}
         </Spin>
       </div>
+
+      {/* 基础约定弹窗：编辑工作空间级共识 prompt */}
+      <WorkspacePromptModal
+        open={!!promptModalWorkspace}
+        workspaceId={promptModalWorkspace?.id ?? 0}
+        workspaceName={promptModalWorkspace?.name ?? ''}
+        onClose={() => setPromptModalWorkspace(null)}
+        onSaved={loadProjectDirectories}
+      />
     </PageCard>
   );
 }

--- a/frontend/src/components/settings/workspace/DefaultResponseConfigPanel.tsx
+++ b/frontend/src/components/settings/workspace/DefaultResponseConfigPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Card, Form, Select, Button, Space, message, Radio, InputNumber, Typography, Input, Alert } from 'antd';
+import { Card, Form, Select, Button, Space, message, Radio, InputNumber, Typography } from 'antd';
 import * as db from '@/utils/database';
 import { listLoops } from '@/utils/database/loops';
 import { EXECUTORS_FOR_PICKER } from '@/utils/executors';
@@ -12,12 +12,12 @@ import { HistoryChatsCard } from '@/components/settings/assistant/HistoryChatsCa
 
 const { Paragraph } = Typography;
 
-interface WorkspaceSettingsPanelProps {
+interface DefaultResponseConfigPanelProps {
   workspaceId: number;
   onChanged?: () => void;
 }
 
-export function WorkspaceSettingsPanel({ workspaceId, onChanged }: WorkspaceSettingsPanelProps) {
+export function DefaultResponseConfigPanel({ workspaceId, onChanged }: DefaultResponseConfigPanelProps) {
   const [todos, setTodos] = useState<Todo[]>([]);
   const [loops, setLoops] = useState<LoopListItem[]>([]);
   const [loading, setLoading] = useState(false);
@@ -56,8 +56,6 @@ export function WorkspaceSettingsPanel({ workspaceId, onChanged }: WorkspaceSett
           default_response_todo_id: s.default_response_todo_id,
           default_response_loop_id: s.default_response_loop_id,
           default_response_executor: s.default_response_executor,
-          // 工作空间 prompt：null 视作空串，让 TextArea 显示空
-          system_prompt: s.system_prompt ?? '',
         });
       })
       .catch((err: any) => message.error('加载设置失败: ' + (err?.message || String(err))))
@@ -85,8 +83,6 @@ export function WorkspaceSettingsPanel({ workspaceId, onChanged }: WorkspaceSett
         default_response_todo_id: values.default_response_type === 'todo' ? values.default_response_todo_id : undefined,
         default_response_loop_id: values.default_response_type === 'loop' ? values.default_response_loop_id : 0,
         default_response_executor: values.default_response_type === 'executor' ? values.default_response_executor : undefined,
-        // 工作空间 prompt 始终随默认响应一起保存；空串表示显式清空
-        system_prompt: values.system_prompt ?? '',
       });
       message.success('设置已保存');
       loadSettings();
@@ -226,31 +222,6 @@ export function WorkspaceSettingsPanel({ workspaceId, onChanged }: WorkspaceSett
               />
             </Form.Item>
           )}
-
-          <Form.Item
-            name="system_prompt"
-            label="工作空间 Prompt"
-            tooltip="该工作空间下所有 todo 执行时作为前置 prompt 注入。可填写产物目录约定、认证信息、基本文件路径等共识内容。"
-          >
-            <Input.TextArea
-              rows={8}
-              maxLength={8000}
-              showCount
-              placeholder={
-                '## 工作空间共识\n\n' +
-                '- 产物目录：编译输出放在 ./target/release\n' +
-                '- 认证：访问内部服务用 token xxx\n' +
-                '- 项目根：/path/to/project'
-              }
-            />
-          </Form.Item>
-
-          <Alert
-            type="warning"
-            showIcon
-            style={{ marginBottom: 16 }}
-            message="⚠️ 此处写入的内容将作为执行器前置 prompt 注入到该工作空间下所有 todo 的执行中，请谨慎填写敏感信息。"
-          />
 
           <Form.Item>
             <Space>

--- a/frontend/src/components/settings/workspace/WorkspaceMessageConfigPage.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceMessageConfigPage.tsx
@@ -5,7 +5,7 @@ import { PageCard } from '@/components/common/PageCard';
 import type { AgentBot, ProjectDirectory } from '@/utils/database';
 import { WorkspaceAgentPanel } from './WorkspaceAgentPanel';
 import { WorkspaceSlashCommandsPanel } from './WorkspaceSlashCommandsPanel';
-import { WorkspaceSettingsPanel } from './WorkspaceSettingsPanel';
+import { DefaultResponseConfigPanel } from './DefaultResponseConfigPanel';
 
 interface WorkspaceMessageConfigPageProps {
   workspace: ProjectDirectory;
@@ -93,7 +93,7 @@ export function WorkspaceMessageConfigPage({ workspace, onBack }: WorkspaceMessa
           <WorkspaceSlashCommandsPanel workspaceId={workspace.id} />
         </div>
         <div style={{ marginTop: 24 }}>
-          <WorkspaceSettingsPanel workspaceId={workspace.id} />
+          <DefaultResponseConfigPanel workspaceId={workspace.id} />
         </div>
       </div>
     </PageCard>

--- a/frontend/src/components/settings/workspace/WorkspacePromptModal.tsx
+++ b/frontend/src/components/settings/workspace/WorkspacePromptModal.tsx
@@ -1,0 +1,88 @@
+import { useState, useEffect } from 'react';
+import { Modal, Form, Input, Alert, message } from 'antd';
+import * as db from '@/utils/database';
+
+interface WorkspacePromptModalProps {
+  open: boolean;
+  workspaceId: number;
+  workspaceName: string;
+  onClose: () => void;
+  onSaved?: () => void;
+}
+
+/**
+ * 工作空间基础约定弹窗：编辑和保存 system_prompt（工作空间级共识 prompt）。
+ * 从 WorkspaceSettingsPanel 中提取出的独立控件，可直接在工作空间管理页打开。
+ */
+export function WorkspacePromptModal({ open, workspaceId, workspaceName, onClose, onSaved }: WorkspacePromptModalProps) {
+  const [form] = Form.useForm();
+  const [saving, setSaving] = useState(false);
+
+  // 每次打开弹窗时加载最新的 system_prompt
+  useEffect(() => {
+    if (!open) return;
+    db.getWorkspaceSettings(workspaceId)
+      .then(s => {
+        // null 视作空串让 TextArea 显示空，与 DefaultResponseConfigPanel 保持一致
+        form.setFieldsValue({ system_prompt: s.system_prompt ?? '' });
+      })
+      .catch((err: any) => message.error('加载工作空间设置失败: ' + (err?.message || String(err))));
+  }, [open, workspaceId, form]);
+
+  const handleSave = async () => {
+    try {
+      const values = await form.validateFields();
+      setSaving(true);
+      // 保存工作空间级 prompt；空串表示显式清空
+      await db.updateWorkspaceSettings(workspaceId, {
+        system_prompt: values.system_prompt ?? '',
+      });
+      message.success('基础约定已保存');
+      onSaved?.();
+      onClose();
+    } catch (err: any) {
+      if (!err?.errorFields) {
+        message.error('保存失败: ' + (err?.message || String(err)));
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      title={`${workspaceName} - 基础约定`}
+      open={open}
+      onOk={handleSave}
+      onCancel={onClose}
+      confirmLoading={saving}
+      width={640}
+      destroyOnClose
+    >
+      <Form form={form} layout="vertical" initialValues={{ system_prompt: '' }}>
+        <Form.Item
+          name="system_prompt"
+          label="工作空间 Prompt"
+          tooltip="该工作空间下所有 todo 执行时作为前置 prompt 注入。可填写产物目录约定、认证信息、基本文件路径等共识内容。"
+        >
+          <Input.TextArea
+            rows={8}
+            maxLength={8000}
+            showCount
+            placeholder={
+              '## 工作空间共识\n\n' +
+              '- 产物目录：编译输出放在 ./target/release\n' +
+              '- 认证：访问内部服务用 token xxx\n' +
+              '- 项目根：/path/to/project'
+            }
+          />
+        </Form.Item>
+        <Alert
+          type="warning"
+          showIcon
+          message="⚠️ 此处写入的内容将作为执行器前置 prompt 注入到该工作空间下所有 todo 的执行中，请谨慎填写敏感信息。"
+        />
+      </Form>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## 背景

原来 `system_prompt`（工作空间 Prompt 控件）放在 `MessageConfigDrawer`（消息监控台→配置抽屉）中，属于"消息里面放工作空间约定"，位置不合理。

## 改动

| 文件 | 操作 |
|------|------|
| `WorkspacePromptModal.tsx` | **新建** — 独立弹窗，只编辑 `system_prompt` |
| `ProjectDirectoriesPanel.tsx` | 工作空间卡片底部增加「📄 基础约定」按钮，点击弹出弹窗 |
| `DefaultResponseConfigPanel.tsx` | 从 `WorkspaceSettingsPanel.tsx` 重命名，移除 `system_prompt` 所有代码 |
| `WorkspaceMessageConfigPage.tsx` | 更新 import 引用 |
| `MessageConfigDrawer.tsx` | 更新 import 引用 |

## 访问路径

```
左侧菜单 → 配置 → 工作空间 → 找到目标空间 → 卡片底部「📄 基础约定」
```

`system_prompt` 从消息配置抽屉中移除，不再在消息功能区域显示无关的工作空间级设置。