### PR TITLE
feat: 移除 todo/loop 创建表单中的 workspace 选择器，body 不再传递 workspace_id

### DIFF
--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -642,7 +642,7 @@ async fn handle_todo(
                         auto_review_enabled: value.get("auto_review_enabled").and_then(|v| v.as_bool()),
                         webhook_enabled: None,
                         // URL 已经带 workspace，body 字段以 CLI 参数为准
-                        workspace_id: ws_id,
+                        workspace_id: Some(ws_id),
                         action_type: None,
                         action_key: None,
                         model: None,
@@ -668,7 +668,7 @@ async fn handle_todo(
                     acceptance_criteria: None,
                     webhook_enabled: None,
                     auto_review_enabled: None,
-                    workspace_id: ws_id,
+                    workspace_id: Some(ws_id),
                     action_type: None,
                     action_key: None,
                     model: None,

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -99,11 +99,15 @@ pub async fn create_loop(
     }
     // 工作空间必填且必须存在：handler 强制把 id 解析为 path 后再下传 DAO，
     // 避免 DAO 再做路径反查，也保证 workspace_id / workspace_path 双字段同步写入。
+    // v1 路由已从 URL 路径覆盖此值，body 不传时仍应有值。
+    let loop_ws_id = req.workspace_id.ok_or_else(|| {
+        AppError::BadRequest("workspace_id 为必填项".to_string())
+    })?;
     let workspace = state
         .db
-        .get_project_directory_by_id(req.workspace_id)
+        .get_project_directory_by_id(loop_ws_id)
         .await?
-        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", req.workspace_id)))?;
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", loop_ws_id)))?;
     // 创建环路前校验标签约束：环路只能选择一个标签
     if req.tag_ids.len() > 1 {
         return Err(AppError::BadRequest("环路只能选择一个标签".to_string()));
@@ -113,7 +117,7 @@ pub async fn create_loop(
         .create_loop(
             req.name.trim(),
             &req.description,
-            Some(req.workspace_id),
+            Some(loop_ws_id),
             Some(workspace.path.as_str()),
             req.webhook_enabled,
             &req.icon,
@@ -2238,15 +2242,15 @@ pub async fn create_loop_v1(
     Json(mut req): Json<CreateLoopRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     // V1: workspace_id 强制从路径取，覆盖请求体中的值，避免路径与 body 不一致
-    req.workspace_id = ws_id;
+    req.workspace_id = Some(ws_id);
     if req.name.trim().is_empty() {
         return Err(AppError::BadRequest("name 不能为空".to_string()));
     }
     let workspace = state
         .db
-        .get_project_directory_by_id(req.workspace_id)
+        .get_project_directory_by_id(ws_id)
         .await?
-        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", req.workspace_id)))?;
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", ws_id)))?;
     if req.tag_ids.len() > 1 {
         return Err(AppError::BadRequest("环路只能选择一个标签".to_string()));
     }
@@ -2255,7 +2259,7 @@ pub async fn create_loop_v1(
         .create_loop(
             req.name.trim(),
             &req.description,
-            Some(req.workspace_id),
+            Some(ws_id),
             Some(workspace.path.as_str()),
             req.webhook_enabled,
             &req.icon,

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -128,11 +128,15 @@ pub async fn create_todo(
 
     // 工作空间 id 必填且必须存在：handler 按 id 解析出 path 后再下传，
     // DAO 一次写入 workspace_id + workspace_path 两列保证双字段同步。
+    // v1 路由已从 URL 路径覆盖此值，body 不传时仍应有值。
+    let todo_ws_id = req.workspace_id.ok_or_else(|| {
+        AppError::BadRequest("workspace_id 为必填项".to_string())
+    })?;
     let dir = state
         .db
-        .get_project_directory_by_id(req.workspace_id)
+        .get_project_directory_by_id(todo_ws_id)
         .await?
-        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", req.workspace_id)))?;
+        .ok_or_else(|| AppError::BadRequest(format!("工作空间 {} 不存在", todo_ws_id)))?;
     let id = state.db.create_todo_with_extras(
         title,
         &prompt,
@@ -140,7 +144,7 @@ pub async fn create_todo(
         Some(&executor_name),
         req.acceptance_criteria.as_deref(),
         req.webhook_enabled.unwrap_or(false),
-        req.workspace_id,
+        todo_ws_id,
         &dir.path,
     ).await?;
 
@@ -247,7 +251,7 @@ pub async fn create_todo(
         // cwd 字段保留为 None：handler 已通过 create_todo_with_extras 把 path 同步写入 DB，
         // 这里只对外回传 workspace_id；前端不再消费 workspace_path。
         workspace_path: None,
-        workspace_id: Some(req.workspace_id),
+        workspace_id: Some(todo_ws_id),
         webhook_enabled: req.webhook_enabled.unwrap_or(false),
         acceptance_criteria: req.acceptance_criteria.clone(),
         todo_type: 0,
@@ -653,7 +657,7 @@ pub async fn create_todo_v1(
 ) -> Result<ApiResponse<Todo>, AppError> {
     // v1 路径中工作空间 ID 由路径参数提供，覆盖请求体中的值以保证一致性，
     // 避免用户传入与路径参数不一致的 ID 导致歧义
-    req.workspace_id = ws_id;
+    req.workspace_id = Some(ws_id);
     let state_val = State(state);
     let req_val = ApiJson(req);
     create_todo(state_val, req_val).await

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -408,7 +408,9 @@ pub struct CreateLoopRequest {
     pub description: String,
     /// 工作空间 ID（project_directories.id），必填、唯一键。
     /// 不再接受路径——避免 path 不唯一带来的歧义。
-    pub workspace_id: i64,
+    /// 使用 #[serde(default)]：v1 路由从 URL 路径覆盖此值，body 中不传也不影响。
+    #[serde(default)]
+    pub workspace_id: Option<i64>,
     #[serde(default)]
     pub webhook_enabled: bool,
     #[serde(default)]

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -494,7 +494,9 @@ pub struct CreateTodoRequest {
     pub auto_review_enabled: Option<bool>,
     /// 工作空间 ID（project_directories.id），唯一键。
     /// 创建时必填；handler 据此查 path 写入 DB cwd 字段。
-    pub workspace_id: i64,
+    /// 使用 #[serde(default)]：v1 路由从 URL 路径覆盖此值，body 中不传也不影响。
+    #[serde(default)]
+    pub workspace_id: Option<i64>,
     /// Action 类型标记（如 "rewrite_title"、"optimize_prompt"），
     /// 仅供前端 ActionButton 组件做 UI 分类展示，不影响执行逻辑。
     #[serde(default)]
@@ -1818,13 +1820,14 @@ mod tests {
         assert_eq!(req.title, "Test");
         assert_eq!(req.prompt, "Do this");
         assert_eq!(req.tag_ids, vec![1, 2]);
-        assert_eq!(req.workspace_id, 42);
+        assert_eq!(req.workspace_id, Some(42));
     }
 
     #[test]
     fn test_create_todo_request_default_tag_ids() {
-        // workspace_id 必填：缺失则反序列化失败，这是 API 契约的一部分。
-        let json = r#"{"title":"Test","prompt":"Do this","workspace_id":1}"#;
+        // workspace_id 可选（#[serde(default)]）：缺失时默认 None，v1 路由从路径覆盖。
+        // 测试确保 tag_ids 的 #[serde(default)] 仍正常工作。
+        let json = r#"{"title":"Test","prompt":"Do this"}"#;
         let req: CreateTodoRequest = serde_json::from_str(json).unwrap();
         assert!(req.tag_ids.is_empty());
     }

--- a/backend/tests/business_logic_tests.rs
+++ b/backend/tests/business_logic_tests.rs
@@ -98,7 +98,7 @@ mod prompt_fallback_tests {
         assert_eq!(req.prompt, "This is the prompt");
         assert_eq!(req.executor, Some("kimi".to_string()));
         assert_eq!(req.tag_ids, vec![1, 2, 3]);
-        assert_eq!(req.workspace_id, 1);
+        assert_eq!(req.workspace_id, Some(1));
     }
 
     #[test]
@@ -110,7 +110,7 @@ mod prompt_fallback_tests {
         assert!(req.prompt.is_empty());
         assert!(req.executor.is_none());
         assert!(req.tag_ids.is_empty());
-        assert_eq!(req.workspace_id, 1);
+        assert_eq!(req.workspace_id, Some(1));
     }
 }
 

--- a/frontend/src/components/LoopFormModal.tsx
+++ b/frontend/src/components/LoopFormModal.tsx
@@ -24,7 +24,6 @@ import type { ReviewTemplateOption } from '@/types/reviewTemplate';
 import type { Todo } from '@/types/todo';
 import { getWorkspaceDisplayName, useProjectDirectories } from '@/utils/workspaceDisplay';
 import { TagCheckCardGroup } from './TagCheckCard';
-import { WorkspaceSwitcher } from './shell/WorkspaceSwitcher';
 
 // ---------- props ----------
 
@@ -196,9 +195,10 @@ export function LoopFormModal({
         ? JSON.stringify(values.abnormal_handler_trigger_on)
         : '["capped_step","capped_token","failed"]';
 
-      // 工作空间必填校验：保存时若未选择 id 直接报错
+      // 工作空间由 defaultWorkspaceId / initialData.workspace_id 自动传入，
+      // 防御性校验确保不为 null
       if (workspaceId == null) {
-        message.error('请选择工作空间');
+        message.error('无法确定工作空间');
         setSaving(false);
         return;
       }
@@ -273,30 +273,12 @@ export function LoopFormModal({
             <Input.TextArea rows={2} maxLength={500} />
           </Form.Item>
 
-          {/* 工作空间 + 评审模板联动区 */}
+          {/* 评审模板（按当前工作空间过滤） */}
           <div style={{ fontWeight: 600, fontSize: 14, marginTop: 16, marginBottom: 8, color: 'var(--color-text-secondary, #64748b)' }}>
-            工作空间与评审模板
+            评审模板
           </div>
           <div style={{ background: 'var(--color-bg-elevated, #f8fafc)', padding: 12, borderRadius: 8 }}>
-            {/* 工作空间：创建模式必填，编辑模式可选；value/onChange 以 id 为唯一键 */}
             <Form.Item
-              label={<>工作空间 {mode === 'create' && <span style={{ color: '#ff4d4f' }}>*</span>}</>}
-              tooltip="此 loop 所属的工作空间，切换后评审模板自动过滤"
-              rules={mode === 'create' ? [{ required: true, message: '请选择工作空间' }] : []}
-            >
-              <WorkspaceSwitcher
-                value={workspaceId}
-                showAddOption={false}
-                onChange={(v) => {
-                  setWorkspaceId(v);
-                  // 切换工作空间时清掉已选模板，避免跨工作空间串模板
-                  form.setFieldsValue({ review_template_id: null });
-                }}
-              />
-            </Form.Item>
-            {/* 评审模板（随 workspace 联动过滤） */}
-            <Form.Item
-              label="评审模板"
               name="review_template_id"
               tooltip="选择用于自动评审的模板（不选则使用默认模板）。切换工作空间后自动过滤。"
               extra={
@@ -317,7 +299,7 @@ export function LoopFormModal({
                 showSearch
                 optionFilterProp="label"
                 options={reviewTemplateOptions.map(t => ({ value: t.id, label: t.name }))}
-                notFoundContent={workspaceId != null ? '暂无模板，可点击"新建模板"' : '请先选择工作空间'}
+                notFoundContent={workspaceId != null ? '暂无模板，可点击"新建模板"' : '暂无模板'}
               />
             </Form.Item>
           </div>

--- a/frontend/src/components/TodoDrawer.tsx
+++ b/frontend/src/components/TodoDrawer.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback, useReducer } from 'react';
 import { Drawer, Input, Button, App, Divider, Switch } from 'antd';
-import { FolderOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
-import { WorkspaceSwitcher } from './shell/WorkspaceSwitcher';
 
 import type { Todo, ExecutorConfig, ExecutorOption, SkillMeta, ExecutorSkills, TodoTemplate } from '@/types';
 import { EXECUTORS, executorConfigToOption, getExecutorColor } from '@/types';
@@ -209,9 +207,10 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
       return;
     }
 
-    // 创建模式：工作空间为必填项
-    if (!isEditMode && workspaceId == null) {
-      message.error('请选择工作空间');
+    // 创建模式：工作空间由 defaultWorkspaceId 自动传入，不应为 null
+    // 编辑模式：来自 todo.workspace_id
+    if (workspaceId == null) {
+      message.error('无法确定工作空间');
       return;
     }
 
@@ -370,20 +369,6 @@ export function TodoDrawer({ open, todo, tags, onClose, onSaved, defaultWorkspac
               </div>
             </>
           )}
-
-          <Divider style={{ margin: '8px 0 16px' }} />
-
-          <div style={{ marginBottom: 16 }}>
-            <div style={{ marginBottom: 10, fontWeight: 600, fontSize: 14 }}>
-              <FolderOutlined style={{ color: 'var(--color-primary)', marginRight: 6 }} />
-              工作空间 <span style={{ color: '#ff4d4f' }}>*</span>
-            </div>
-            <WorkspaceSwitcher
-              value={workspaceId}
-              showAddOption={false}
-              onChange={(v) => setField('workspaceId', v)}
-            />
-          </div>
 
           <Divider style={{ margin: '8px 0 16px' }} />
 

--- a/frontend/src/components/todo-list/index.tsx
+++ b/frontend/src/components/todo-list/index.tsx
@@ -36,7 +36,7 @@ interface TodoListProps {
 }
 
 export function TodoList(props: TodoListProps) {
-  const { onOpenCreateModal, onSelectTodo, onSelectLoop, onCreateLoop, refreshKey, forcedListMode, onListModeChange, hideCreateButton, searchKeyword: externalSearchKeyword } = props;
+  const { onOpenCreateModal, onSelectTodo, onSelectLoop, onCreateLoop, refreshKey, loopUpdateCount, forcedListMode, onListModeChange, hideCreateButton, searchKeyword: externalSearchKeyword } = props;
   const { state, dispatch } = useApp();
   const { todos, selectedTodoId, selectedTagId, selectedWorkspace, tags } = state;
   const { message } = AntApp.useApp();
@@ -140,7 +140,7 @@ export function TodoList(props: TodoListProps) {
       .then(setLoopList)
       .catch(() => setLoopList([]))
       .finally(() => setLoopLoading(false));
-  }, [listMode, selectedWorkspace, projectDirectories, directoriesReady]);
+  }, [listMode, selectedWorkspace, projectDirectories, directoriesReady, loopUpdateCount]);
 
   // 切换工作空间后按需拉取该工作空间的 todo 列表。
   useEffect(() => {

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -27,7 +27,7 @@ export async function createTodo(
   expertName?: string,
   model?: string | null,
 ): Promise<Todo> {
-  // workspace_id 从 body 提升到 URL 路径段；body 只保留字段语义
+  // workspace_id 仅从 URL 路径段传入（后端 v1 路由从 Path 提取），body 中不再传递
   const body: Record<string, unknown> = { title, prompt, tag_ids: tagIds };
   if (acceptanceCriteria !== undefined) body.acceptance_criteria = acceptanceCriteria;
   if (autoReviewEnabled !== undefined) body.auto_review_enabled = autoReviewEnabled;


### PR DESCRIPTION
## 变更内容

workspace id 已放在 URL 路径中（`/api/v1/workspaces/{ws}/todos`），新建/编辑 todo 和 loop 时不再需要用户手动选择工作空间，也不再需要从 body 传递 workspace_id。

### 前端 UI
- **TodoDrawer.tsx**: 删除 `WorkspaceSwitcher` 选择器 UI（创建模式用 `defaultWorkspaceId`，编辑模式用 `todo.workspace_id`）
- **LoopFormModal.tsx**: 删除 workspace 选择器 UI；修复「评审模板」标题重复
- **todo-list/index.tsx**: 修复创建环路后列表不刷新（`loopUpdateCount` 加入 `useEffect` 依赖）

### 后端
- **CreateTodoRequest / CreateLoopRequest**: `workspace_id` → `Option<i64>` + `#[serde(default)]`
- **v1 handler**: 从 URL 路径 `Path(ws_id)` 覆盖 `req.workspace_id`

### 前端 API
- **createTodo()**: body 中不再传递 `workspace_id`，仅从 URL 路径传入

### 验证
| 检查项 | 结果 |
|--------|------|
| `cargo clippy --all-targets -- -D warnings` | ✅ 零告警 |
| `npx tsc --noEmit` | ✅ 无新增错误 |