### PR TITLE
fix(executor): 修复运行配置保存不生效的 bug

### DIFF
--- a/frontend/src/components/settings/ExecutorsPanel.tsx
+++ b/frontend/src/components/settings/ExecutorsPanel.tsx
@@ -685,6 +685,12 @@ export function ExecutorsPanel() {
                   unCheckedChildren="关闭"
                   onChange={handleExecutionTimeoutToggle}
                 />
+                {/*
+                  手动管理 value/onChange 而非交由 Form.Item 托管：
+                  展示层用分钟（executionTimeoutMinutes），存储层用秒（execution_timeout_secs），
+                  需要在 onChange 中做 v * 60 转换后通过 setFieldsValue 写入表单，
+                  因此不能依赖 Form.Item 的默认值管理路径。
+                */}
                 <Form.Item name="execution_timeout_secs" noStyle>
                   <InputNumber
                     size="small"

--- a/frontend/src/components/settings/ExecutorsPanel.tsx
+++ b/frontend/src/components/settings/ExecutorsPanel.tsx
@@ -660,65 +660,65 @@ export function ExecutorsPanel() {
           title={<><PlayCircleOutlined style={{ marginRight: 6 }} />运行配置</>}
           style={{ marginTop: 16 }}
         >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>最大并发数</span>
-              <InputNumber
+          <Form form={configForm} layout="inline">
+            <div style={{ display: 'flex', alignItems: 'center', gap: 24, flexWrap: 'wrap' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>最大并发数</span>
+                <Form.Item name="max_concurrent_todos">
+                  <InputNumber
+                    size="small"
+                    min={1}
+                    max={20}
+                    style={{ width: 70 }}
+                  />
+                </Form.Item>
+                <Tooltip title="同时运行的最大 Todo 数量，超出将排队等待">
+                  <InfoCircleOutlined style={{ color: 'var(--color-text-quaternary)', fontSize: 12 }} />
+                </Tooltip>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>执行超时</span>
+                <Switch
+                  size="small"
+                  checked={executionTimeoutEnabled}
+                  checkedChildren="开启"
+                  unCheckedChildren="关闭"
+                  onChange={handleExecutionTimeoutToggle}
+                />
+                <Form.Item name="execution_timeout_secs" noStyle>
+                  <InputNumber
+                    size="small"
+                    min={1}
+                    max={MAX_EXECUTION_TIMEOUT_MINUTES}
+                    style={{ width: 80 }}
+                    disabled={!executionTimeoutEnabled}
+                    value={executionTimeoutMinutes}
+                    onChange={(v) => {
+                      if (v) {
+                        const nextSecs = v * 60;
+                        setExecutionTimeoutSecs(nextSecs);
+                        configForm.setFieldsValue({ execution_timeout_secs: nextSecs });
+                        lastEnabledExecutionTimeoutSecsRef.current = nextSecs;
+                      }
+                    }}
+                  />
+                </Form.Item>
+                <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>分钟</span>
+                <Tooltip title={`单个执行任务的最大时长（1 ~ ${MAX_EXECUTION_TIMEOUT_MINUTES} 分钟，上限 7 天）；关闭后不再因超时自动终止`}>
+                  <InfoCircleOutlined style={{ color: 'var(--color-text-quaternary)', fontSize: 12 }} />
+                </Tooltip>
+              </div>
+              <Button
                 size="small"
-                min={1}
-                max={20}
-                value={configForm.getFieldValue('max_concurrent_todos') ?? 1}
-                onChange={(v) => {
-                  if (v) {
-                    configForm.setFieldsValue({ max_concurrent_todos: v });
-                  }
-                }}
-                style={{ width: 70 }}
-              />
-              <Tooltip title="同时运行的最大 Todo 数量，超出将排队等待">
-                <InfoCircleOutlined style={{ color: 'var(--color-text-quaternary)', fontSize: 12 }} />
-              </Tooltip>
+                type="primary"
+                icon={<SaveOutlined />}
+                loading={configSaving}
+                onClick={handleSaveConfig}
+              >
+                保存
+              </Button>
             </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>执行超时</span>
-              <Switch
-                size="small"
-                checked={executionTimeoutEnabled}
-                checkedChildren="开启"
-                unCheckedChildren="关闭"
-                onChange={handleExecutionTimeoutToggle}
-              />
-              <InputNumber
-                size="small"
-                min={1}
-                max={MAX_EXECUTION_TIMEOUT_MINUTES}
-                style={{ width: 80 }}
-                disabled={!executionTimeoutEnabled}
-                value={executionTimeoutMinutes}
-                onChange={(v) => {
-                  if (v) {
-                    const nextSecs = v * 60;
-                    setExecutionTimeoutSecs(nextSecs);
-                    configForm.setFieldsValue({ execution_timeout_secs: nextSecs });
-                    lastEnabledExecutionTimeoutSecsRef.current = nextSecs;
-                  }
-                }}
-              />
-              <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>分钟</span>
-              <Tooltip title={`单个执行任务的最大时长（1 ~ ${MAX_EXECUTION_TIMEOUT_MINUTES} 分钟，上限 7 天）；关闭后不再因超时自动终止`}>
-                <InfoCircleOutlined style={{ color: 'var(--color-text-quaternary)', fontSize: 12 }} />
-              </Tooltip>
-            </div>
-            <Button
-              size="small"
-              type="primary"
-              icon={<SaveOutlined />}
-              loading={configSaving}
-              onClick={handleSaveConfig}
-            >
-              保存
-            </Button>
-          </div>
+          </Form>
         </Card>
 
         <Card

--- a/frontend/tests/check_executor_config_persist.spec.ts
+++ b/frontend/tests/check_executor_config_persist.spec.ts
@@ -1,0 +1,196 @@
+// 回归测试：执行器「运行配置」保存后刷新页面值保持（PR #941 bug 修复验证）。
+//
+// 测试场景（对应 PR #941 的手动验证步骤）：
+// 1. 进入执行器设置页，初始值来自 mock API
+// 2. 修改最大并发数，点击保存，验证 PUT 请求 body 包含新值
+// 3. 修改执行超时分钟数，保存，验证 PUT body
+// 4. 刷新页面，验证新值持久化显示（mock 已更新）
+
+import { test, expect, type Page, type Route } from '@playwright/test';
+
+const BASE = 'http://localhost:18088';
+
+// 默认配置（运行配置部分）
+const DEFAULT_CONFIG = {
+  auto_backup_enabled: false,
+  auto_todo_backup_enabled: false,
+  auto_skill_backup_enabled: false,
+  max_concurrent_todos: 3,
+  execution_timeout_secs: 120,
+};
+
+/** 构造 /api/v1/config GET 响应体。 */
+function configPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    code: 0,
+    data: { ...DEFAULT_CONFIG, ...overrides },
+    message: '',
+  };
+}
+
+/**
+ * 注册 /api/v1/config GET 拦截。
+ * 使用 mutable responseRef 允许测试中途更新 mock 值（模拟持久化）。
+ */
+async function interceptConfigGet(
+  page: Page,
+  responseRef: { current: Record<string, unknown> },
+) {
+  await page.route('**/api/v1/config', async (route: Route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify(configPayload(responseRef.current)),
+      });
+    } else {
+      // PUT 等请求放行
+      await route.fallback();
+    }
+  });
+}
+
+/** 进入执行器设置页并等待运行配置区域渲染。 */
+async function openExecutorsPanel(page: Page) {
+  await page.goto(`${BASE}/#executors`);
+  // 等待运行配置 Card 出现（含「运行配置」标题和 InputNumber）
+  await page.waitForSelector('text=运行配置', { timeout: 15000 });
+  // 等 InputNumber 渲染完（确保 GET 响应已填充表单）
+  await page.waitForTimeout(500);
+}
+
+/**
+ * 读取最大并发数 InputNumber 的当前值。
+ * Ant Design InputNumber 内部用 input 控件承载值。
+ */
+async function readMaxConcurrent(page: Page): Promise<number> {
+  const input = page
+    .locator('.ant-card')
+    .filter({ hasText: '运行配置' })
+    .locator('.ant-input-number-input')
+    .first();
+  const val = await input.inputValue();
+  return Number(val);
+}
+
+test('修改最大并发数后保存，刷新后值持久化', async ({ page }) => {
+  // 初始 mock：并发数 = 3
+  const configState = { max_concurrent_todos: 3, execution_timeout_secs: 120 };
+  await interceptConfigGet(page, { current: configState });
+
+  // 拦截 PUT 请求，验证 payload 并更新 mock
+  let putBody: Record<string, unknown> | null = null;
+  await page.route('**/api/v1/config', async (route: Route) => {
+    if (route.request().method() === 'PUT') {
+      putBody = await route.request().postDataJSON();
+      // 更新 GET mock 的返回值，模拟后端已持久化
+      Object.assign(configState, putBody);
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, data: null, message: '' }),
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await openExecutorsPanel(page);
+
+  // 验证初始值为 3
+  expect(await readMaxConcurrent(page)).toBe(3);
+
+  // 修改并发数为 5
+  const input = page
+    .locator('.ant-card')
+    .filter({ hasText: '运行配置' })
+    .locator('.ant-input-number-input')
+    .first();
+  // 清空后输入
+  await input.click();
+  await input.fill('');
+  await input.fill('5');
+  // 失焦触发 InputNumber 更新
+  await page.locator('text=运行配置').click();
+  await page.waitForTimeout(200);
+
+  // 点击保存
+  await page.getByRole('button', { name: '保存' }).click();
+  // 等待保存完成（antd message 出现）
+  await expect(page.getByText('配置已保存')).toBeVisible({ timeout: 5000 });
+
+  // 验证 PUT body 包含新的并发数
+  expect(putBody).not.toBeNull();
+  expect(putBody!.max_concurrent_todos).toBe(5);
+
+  // 刷新页面，验证值持久化
+  await page.reload();
+  await page.waitForSelector('text=运行配置', { timeout: 15000 });
+  await page.waitForTimeout(500);
+  expect(await readMaxConcurrent(page)).toBe(5);
+});
+
+test('修改执行超时分钟后保存，刷新后值持久化', async ({ page }) => {
+  const configState = { max_concurrent_todos: 3, execution_timeout_secs: 120 };
+  await interceptConfigGet(page, { current: configState });
+
+  let putBody: Record<string, unknown> | null = null;
+  await page.route('**/api/v1/config', async (route: Route) => {
+    if (route.request().method() === 'PUT') {
+      putBody = await route.request().postDataJSON();
+      Object.assign(configState, putBody);
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, data: null, message: '' }),
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await openExecutorsPanel(page);
+
+  // 先开启执行超时开关
+  const timeoutSwitch = page
+    .locator('.ant-card')
+    .filter({ hasText: '运行配置' })
+    .locator('.ant-switch');
+  const switchClass = await timeoutSwitch.getAttribute('class');
+  const isChecked = switchClass?.includes('ant-switch-checked') ?? false;
+  if (!isChecked) {
+    await timeoutSwitch.click();
+    await page.waitForTimeout(200);
+  }
+
+  // 找到执行超时的 InputNumber（第二个 InputNumber）
+  const timeoutInput = page
+    .locator('.ant-card')
+    .filter({ hasText: '运行配置' })
+    .locator('.ant-input-number-input')
+    .nth(1);
+  await timeoutInput.click();
+  await timeoutInput.fill('');
+  await timeoutInput.fill('5'); // 5 分钟 → 300 秒
+  await page.locator('text=运行配置').click();
+  await page.waitForTimeout(200);
+
+  // 保存
+  await page.getByRole('button', { name: '保存' }).click();
+  await expect(page.getByText('配置已保存')).toBeVisible({ timeout: 5000 });
+
+  // 验证 PUT body execution_timeout_secs = 300（分钟→秒转换）
+  expect(putBody).not.toBeNull();
+  expect(putBody!.execution_timeout_secs).toBe(300);
+
+  // 刷新页面验证持久化
+  await page.reload();
+  await page.waitForSelector('text=运行配置', { timeout: 15000 });
+  await page.waitForTimeout(500);
+
+  // 读取 InputNumber 显示的值应为 5（分钟）
+  const displayVal = await page
+    .locator('.ant-card')
+    .filter({ hasText: '运行配置' })
+    .locator('.ant-input-number-input')
+    .nth(1)
+    .inputValue();
+  expect(Number(displayVal)).toBe(5);
+});


### PR DESCRIPTION
## 修复说明

### 问题描述

在执行器菜单页面的「运行配置」区域，修改最大并发数、执行超时开关和执行超时数值后点击保存，提示「配置成功」，但刷新页面后数值恢复为原值。控制台显示 PUT /api/v1/config 请求的 payload 为 `{}`，后端虽然返回成功响应，但实际未收到任何配置变更。

### 问题根因

[ExecutorsPanel.tsx](file:///Users/weibh/projects/rust/nothing-todo/frontend/src/components/settings/ExecutorsPanel.tsx) 的运行配置区域，`max_concurrent_todos` 和 `execution_timeout_secs` 字段没有用 `<Form.Item>` 包装，只是普通的 `<InputNumber>` 和 `<Switch>` 组件。调用 `configForm.validateFields()` 时，这些字段不在表单控制范围内，返回空对象 `{}`，导致请求 payload 为空。

### 修复方案

- 将 `max_concurrent_todos` 的 `<InputNumber>` 用 `<Form.Item>` 包装
- 将 `execution_timeout_secs` 的 `<InputNumber>` 用 `<Form.Item noStyle>` 包装（`noStyle` 避免额外表单样式）
- 在外层包裹 `<Form form={configForm} layout="inline">`

### 验证结果

| 验证项 | 结果 |
|--------|------|
| 前端类型检查 `npx tsc --noEmit` | ✅ 零错误 |
| 后端 API PUT 请求 | ✅ 能正确接收并保存配置 |
| 后端 API GET 请求 | ✅ 能读取到保存的值 |
| 开发服务器启动 | ✅ 正常运行在 http://localhost:18088 |

### 手动测试

1. 进入执行器菜单页面（`#settings_executors`）
2. 修改最大并发数（如改为 5）
3. 开启执行超时开关，修改超时分钟数（如改为 2 分钟）
4. 点击保存按钮
5. 刷新页面，配置应保持修改后的值