### PR TITLE
fix(031): 同步顶栏 extra 总览注释，补时间分段说明

### DIFF
--- a/frontend/src/components/tasks/TasksPage.tsx
+++ b/frontend/src/components/tasks/TasksPage.tsx
@@ -183,6 +183,7 @@ export function TasksPage({ workspaceId }: TasksPageProps) {
 
   // —— 顶栏 extra ——
   // 搜索框：所有视图共享（Table/卡片在前端 filter，看板不做 keyword filter）。
+  // 时间分段：TimeRangeSegmented（showAll 形态），页级按 created_at 过滤，三态共享。
   // 刷新按钮：自增 refreshKey 触发 useEffect 重拉。
   // Segmented：三态视图切换，与 MemorialBoard 的 Segmented 风格一致。
   // 新建按钮：打开 CreateTaskModal。
@@ -236,7 +237,7 @@ export function TasksPage({ workspaceId }: TasksPageProps) {
   );
 
   // 详情态顶栏 titleSuffix：返回按钮，紧贴标题右侧（与 TodoDetailPage/LoopDetailPage 一致）。
-  // 列表/看板/卡片态顶栏 extra：搜索 + 刷新 + Segmented + 新建。
+  // 列表/看板/卡片态顶栏 extra：搜索 + 时间分段 + 刷新 + 视图切换 + 新建。
   const isDetail = selectedTaskId != null;
 
   // 返回按钮：放在 titleSuffix，与事项/环路详情页位置一致


### PR DESCRIPTION
## 说明

PR #942 合并瞬间恰好推上了一个注释修复提交（本地 /review 发现），随本 PR 补入。

## 改动

仅 1 个提交、1 个文件、2 行注释：

- `TasksPage.tsx` 顶栏 extra 总览注释补充「时间分段」说明（修改既有代码时同步更新注释的项目规范要求）
- extra 构成注释更新为：搜索 + 时间分段 + 刷新 + 视图切换 + 新建

零代码逻辑改动。\n\n`npx tsc --noEmit` ✅