### PR TITLE
fix: 执行器默认超时改为关闭（永不超时），启用后默认 180 分钟

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -17,8 +17,14 @@ pub const DEFAULT_DEV_PORT: u16 = 18088;
 pub const DEFAULT_HOST: &str = "0.0.0.0";
 /// Default executor paths (binary names).
 pub const DEFAULT_EXECUTOR_PATH: &str = ""; // use binary name directly
-/// 默认执行超时时间（秒）。
-pub const DEFAULT_EXECUTION_TIMEOUT_SECS: u64 = 3600;
+/// 执行超时「开关打开时」使用的默认时长（秒）。
+///
+/// 这是推荐/启用态的默认时长：180 分钟 = 10800 秒。
+/// 注意它**不是** `Config` 的字段默认值——`Config::default` 把 `execution_timeout_secs`
+/// 设为 `0`（关闭超时、永不超时）。当用户在 UI 打开「执行超时」开关时，前端用本常量
+/// 作为回填值，因此只改这里就能把「打开后默认 180 分钟」生效。系统以 `execution_timeout_secs > 0`
+/// 判定超时是否启用，所以 `0` 即永不超时（见 `spawn_lifecycle::configure_timeout_sleep`）。
+pub const DEFAULT_EXECUTION_TIMEOUT_SECS: u64 = 10800;
 /// 执行超时上限（秒）：7 天。YAML 加载和 HTTP update 均受此约束。
 pub const MAX_EXECUTION_TIMEOUT_SECS: u64 = 604800;
 /// WebSocket broadcast channel 默认容量。
@@ -141,7 +147,9 @@ pub struct Config {
     pub history_message_max_age_secs: u64,
     /// 最大并发执行数（默认 3）
     pub max_concurrent_todos: u32,
-    /// 执行超时时间（秒，默认 3600 = 60 分钟）；设置为 0 表示不限制执行时长；上限 604800（7 天）
+    /// 执行超时时间（秒）。默认 0 表示**关闭超时、永不超时**（默认开关状态为关）；
+    /// 大于 0 时本值即为超时时长，前端打开「执行超时」开关后默认回填 10800（180 分钟，
+    /// 见 `DEFAULT_EXECUTION_TIMEOUT_SECS`）；上限 604800（7 天）
     pub execution_timeout_secs: u64,
     /// 日志清理保留天数（None 表示不清理）
     pub auto_cleanup_logs_days: Option<usize>,
@@ -310,7 +318,9 @@ impl Default for Config {
             auto_skill_backup_enabled: skill_backup.enabled, auto_skill_backup_cron: skill_backup.cron, auto_skill_backup_max_files: skill_backup.max_files,
             auto_sync_custom_templates_enabled: sync_templates.enabled, auto_sync_custom_templates_cron: sync_templates.cron,
             history_message_max_age_secs: DEFAULT_HISTORY_MESSAGE_MAX_AGE_SECS,
-            max_concurrent_todos: DEFAULT_MAX_CONCURRENT_TODOS, execution_timeout_secs: DEFAULT_EXECUTION_TIMEOUT_SECS,
+            // 默认关闭执行超时（永不超时）：系统以 `>0` 判定启用，0 即禁用。
+            // 用户打开开关后，前端用 DEFAULT_EXECUTION_TIMEOUT_SECS(10800) 回填，得到 180 分钟。
+            max_concurrent_todos: DEFAULT_MAX_CONCURRENT_TODOS, execution_timeout_secs: 0,
             auto_cleanup_logs_days: DEFAULT_AUTO_CLEANUP_LOGS_DAYS, scheduler_default_timezone: None,
             auto_usage_stats_enabled: usage_stats.enabled, auto_usage_stats_cron: usage_stats.cron,
             broadcast_channel_capacity: DEFAULT_BROADCAST_CHANNEL_CAPACITY,
@@ -617,10 +627,14 @@ mod tests {
     #[test]
     fn test_default_execution_timeout_round_trip() {
         let cfg = Config::default();
-        // 验证序列化/反序列化后默认值仍为 3600，而非恒真断言
+        // 默认关闭超时（永不超时），所以字段默认值为 0；
+        // 验证序列化/反序列化后默认值仍为 0，而非恒真断言。
+        assert_eq!(cfg.execution_timeout_secs, 0);
         let yaml = serde_yaml::to_string(&cfg).unwrap();
         let restored: Config = serde_yaml::from_str(&yaml).unwrap();
-        assert_eq!(restored.execution_timeout_secs, DEFAULT_EXECUTION_TIMEOUT_SECS);
+        assert_eq!(restored.execution_timeout_secs, 0);
+        // 打开开关后回填的「启用默认时长」应为 180 分钟（10800 秒）。
+        assert_eq!(DEFAULT_EXECUTION_TIMEOUT_SECS, 10800);
     }
 
     #[test]

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -21,9 +21,12 @@ pub const DEFAULT_EXECUTOR_PATH: &str = ""; // use binary name directly
 ///
 /// 这是推荐/启用态的默认时长：180 分钟 = 10800 秒。
 /// 注意它**不是** `Config` 的字段默认值——`Config::default` 把 `execution_timeout_secs`
-/// 设为 `0`（关闭超时、永不超时）。当用户在 UI 打开「执行超时」开关时，前端用本常量
-/// 作为回填值，因此只改这里就能把「打开后默认 180 分钟」生效。系统以 `execution_timeout_secs > 0`
-/// 判定超时是否启用，所以 `0` 即永不超时（见 `spawn_lifecycle::configure_timeout_sleep`）。
+/// 设为 `0`（关闭超时、永不超时）。系统以 `execution_timeout_secs > 0` 判定是否启用超时，
+/// 所以 `0` 即永不超时（见 `spawn_lifecycle::configure_timeout_sleep`）。
+///
+/// 前端在 `frontend/src/constants.ts` 中维护了一份**独立副本** `DEFAULT_EXECUTION_TIMEOUT_SECS`，
+/// 作为 UI 打开「执行超时」开关后的回填默认值。两端数值必须手动保持同步（当前均为 10800），
+/// 改动任一端时务必同步另一端，否则会出现「后端默认 0 / 前端回填 10800」之外的前后不一致。
 pub const DEFAULT_EXECUTION_TIMEOUT_SECS: u64 = 10800;
 /// 执行超时上限（秒）：7 天。YAML 加载和 HTTP update 均受此约束。
 pub const MAX_EXECUTION_TIMEOUT_SECS: u64 = 604800;
@@ -633,8 +636,40 @@ mod tests {
         let yaml = serde_yaml::to_string(&cfg).unwrap();
         let restored: Config = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(restored.execution_timeout_secs, 0);
+        // 健壮性验证：配置 YAML 完全缺失 execution_timeout_secs 键时，
+        // 反序列化应回退到 Config::default() 的 0（关闭/永不超时），而非报错或误用其他值。
+        let mut doc: serde_yaml::Value = serde_yaml::from_str(&yaml).unwrap();
+        if let Some(map) = doc.as_mapping_mut() {
+            map.shift_remove(serde_yaml::Value::from("execution_timeout_secs"));
+        }
+        let yaml_without_key = serde_yaml::to_string(&doc).unwrap();
+        let restored_without: Config = serde_yaml::from_str(&yaml_without_key).unwrap();
+        assert_eq!(restored_without.execution_timeout_secs, 0);
         // 打开开关后回填的「启用默认时长」应为 180 分钟（10800 秒）。
         assert_eq!(DEFAULT_EXECUTION_TIMEOUT_SECS, 10800);
+    }
+
+    #[test]
+    fn test_execution_timeout_constants_synced_with_frontend() {
+        // 前端 `frontend/src/constants.ts` 维护了一份独立副本 `DEFAULT_EXECUTION_TIMEOUT_SECS`，
+        // 必须与后端该常量保持一致（当前均为 10800）。任一侧被改动而另一侧未同步时，此测试会失败，
+        // 作为「前后端默认值必须同步」的护栏。
+        // 若前端源文件不在预期位置（某些不含前端代码的构建环境），则跳过，避免误报阻断 CI。
+        let backend_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let fe_constants = backend_dir
+            .parent()
+            .map(|repo| repo.join("frontend").join("src").join("constants.ts"))
+            .filter(|p| p.exists());
+        let Some(path) = fe_constants else {
+            return;
+        };
+        let content = std::fs::read_to_string(&path).expect("读取前端 constants.ts 失败");
+        let expected = format!("DEFAULT_EXECUTION_TIMEOUT_SECS = {}", DEFAULT_EXECUTION_TIMEOUT_SECS);
+        assert!(
+            content.contains(&expected),
+            "前端 frontend/src/constants.ts 的 DEFAULT_EXECUTION_TIMEOUT_SECS 未与后端同步（应为 {}）",
+            DEFAULT_EXECUTION_TIMEOUT_SECS
+        );
     }
 
     #[test]

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -6,8 +6,10 @@
 
 import { getDefaultExecutor } from '@/utils/executors';
 
-/** Default execution timeout in seconds (1 hour). Used as fallback when no config is set. */
-export const DEFAULT_EXECUTION_TIMEOUT_SECS = 3600;
+/** 执行超时「开关打开时」回填的默认时长（秒）：180 分钟 = 10800 秒。
+ * 仅作为启用态的默认值，而非配置开关的默认状态——后端默认 execution_timeout_secs=0（关闭/永不超时）。
+ * 与 backend/src/config.rs::DEFAULT_EXECUTION_TIMEOUT_SECS 保持同步。 */
+export const DEFAULT_EXECUTION_TIMEOUT_SECS = 10800;
 
 /** Maximum execution timeout in minutes (7 days = 10080 min).
  * Derived from backend config::MAX_EXECUTION_TIMEOUT_SECS (604800 seconds).


### PR DESCRIPTION
## 需求对应

用户要求调整执行器默认超时：
- 超时是一个「开关」+「默认值（开关打开时的时长）」两个独立概念，互不冲突。
- **默认开关状态改为关闭**（配置默认值 = 0，即永不超时，系统以 `execution_timeout_secs > 0` 判定启用）。
- **打开开关后的默认时长从 60 分钟改为 180 分钟**（10800 秒）。

## 代码位置

- `backend/src/config.rs`
  - `DEFAULT_EXECUTION_TIMEOUT_SECS`：3600 → **10800**（180 分钟），语义改为「开关打开时的默认时长」。
  - `Config::default().execution_timeout_secs`：**0**（默认关闭、永不超时）。
- `frontend/src/constants.ts`：`DEFAULT_EXECUTION_TIMEOUT_SECS` 同步改为 **10800**，作为前端打开开关后的回填默认值（`ExecutorsPanel` 的 `lastEnabledExecutionTimeoutSecsRef` 初始值）。

## 关键实现点

- 0 即永不超时已贯穿执行链路：`spawn_lifecycle::configure_timeout_sleep`（`timeout_enabled = execution_timeout_secs > 0`）、`direct_executor_timeout(0) → None` 均支持。
- 仅影响新安装（配置从默认值初始化）；已有 `config.yaml` 中已持久化的值不受影响。
- 更新 `test_default_execution_timeout_round_trip`：断言默认值 = 0，并新增「启用默认时长 = 10800」断言。

## 验证

- 后端 `cargo clippy --all-targets -- -D warnings`：零告警通过。
- 后端 `cargo test --lib config::tests`：37 passed（含更新后的 `test_default_execution_timeout_round_trip`）。
- 前端仅改动一个常量字面量（3600 → 10800），低风险（worktree 未 `npm install`，未跑 `tsc`，待需时补充）。

## 已知限制

- 前端 `tsc` 未在 worktree 内运行（缺 node_modules，按规范 worktree 需 `npm install`）；改动为纯常量，风险极低。