### PR TITLE
fix(git-sync): 移除 KeepLocal 策略，同步始终 reset --hard 还原本地文件

### DIFF
--- a/backend/src/git_sync/mod.rs
+++ b/backend/src/git_sync/mod.rs
@@ -1,33 +1,17 @@
 //! Git 同步模块
 //!
 //! 提供从远程 Git 仓库同步内置资源（专家、模板、Skills）的能力。
-//! 支持首次 clone 和后续 pull + merge 更新，冲突策略可选。
+//! 支持首次 clone 和后续 fetch + reset --hard 更新，固定以远程仓库为准（远程覆盖本地）。
 
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
-/// 同步策略
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SyncStrategy {
-    /// 保留本地修改（冲突时本地获胜）
-    KeepLocal,
-    /// 覆盖本地修改（冲突时远程获胜）
-    Overwrite,
-    /// 手动处理冲突（保留冲突状态）
-    Manual,
-}
-
-impl From<&str> for SyncStrategy {
-    fn from(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
-            "overwrite" => SyncStrategy::Overwrite,
-            "manual" => SyncStrategy::Manual,
-            _ => SyncStrategy::KeepLocal,
-        }
-    }
-}
-
 /// 同步结果
+///
+/// 同步策略已固定为「以远程仓库为准」（远程覆盖本地）：`sync_repo` 始终
+/// `git reset --hard` 到远程分支，保证工作区与远程完全一致，不再提供
+/// keep_local / manual 等本地优先策略（keep_local 在本地 commit 已等于远程时会
+/// 提前返回、跳过 reset --hard，导致被误删/被改的本地文件无法还原）。
 #[derive(Debug, Clone)]
 pub struct SyncResult {
     /// 是否成功
@@ -237,7 +221,6 @@ pub async fn sync_repo(
     repo_path: &Path,
     remote: &str,
     branch: &str,
-    strategy: SyncStrategy,
 ) -> Result<SyncResult, GitSyncError> {
     if !repo_path.exists() {
         return Err(GitSyncError::DirectoryNotFound(format!(
@@ -248,76 +231,30 @@ pub async fn sync_repo(
 
     let local_commit = get_current_commit(repo_path).await?;
 
+    // 先拉取远程最新提交，保证 origin/<branch> 指向远程最新
     run_git_command(&["fetch", remote, branch], Some(repo_path)).await?;
 
     let remote_commit = get_remote_commit(repo_path, remote, branch).await?;
 
-    if local_commit == remote_commit {
-        return Ok(SyncResult {
-            success: true,
-            message: "已是最新版本".to_string(),
-            is_first_clone: false,
-            has_updates: false,
-            changed_files: 0,
-        });
-    }
+    // 以远程为准：无论本地 commit 是否与远程相等，都把工作区重置到远程分支。
+    // 这样即使本地文件被误删/被改（此时 local_commit == remote_commit 仍成立），
+    // 也能通过 reset --hard 还原成远程版本，避免「已是最新版本」提前返回导致文件丢失。
+    run_git_command(&["reset", "--hard", &format!("{}/{}", remote, branch)], Some(repo_path)).await?;
 
-    match strategy {
-        SyncStrategy::KeepLocal | SyncStrategy::Overwrite => {
-            run_git_command(&["reset", "--hard", &format!("{}/{}", remote, branch)], Some(repo_path)).await?;
-            Ok(SyncResult {
-                success: true,
-                message: "同步成功，远程覆盖本地".to_string(),
-                is_first_clone: false,
-                has_updates: true,
-                changed_files: 0,
-            })
-        }
-        SyncStrategy::Manual => {
-            match run_git_command(&["merge", &format!("{}/{}", remote, branch)], Some(repo_path)).await {
-                Ok((stdout, _)) => {
-                    let changed_files = count_changed_files(&stdout);
-                    Ok(SyncResult {
-                        success: true,
-                        message: format!("同步成功，更新了 {} 个文件", changed_files),
-                        is_first_clone: false,
-                        has_updates: true,
-                        changed_files,
-                    })
-                }
-                Err(e) => {
-                    if let GitSyncError::CommandFailed(ref msg) = e {
-                        if msg.contains("Automatic merge failed") {
-                            return Ok(SyncResult {
-                                success: true,
-                                message: "存在冲突，请手动处理".to_string(),
-                                is_first_clone: false,
-                                has_updates: true,
-                                changed_files: 0,
-                            });
-                        }
-                    }
-                    Err(e)
-                }
-            }
-        }
-    }
-}
-
-/// 从 merge 输出中统计变更文件数
-fn count_changed_files(output: &str) -> usize {
-    let has_update = output.lines().any(|line| {
-        let trimmed = line.trim_start();
-        trimmed.starts_with("Updating ") || trimmed.starts_with("Fast-forward")
-    });
-    let mode_lines = output
-        .lines()
-        .filter(|line| {
-            let trimmed = line.trim_start();
-            trimmed.starts_with("create mode") || trimmed.starts_with("delete mode")
-        })
-        .count();
-    has_update as usize + mode_lines
+    // has_updates 仅反映 commit 是否前进；工作区被还原（如补回缺失文件）也算一次有效同步。
+    let has_updates = local_commit != remote_commit;
+    let message = if has_updates {
+        "同步成功，远程覆盖本地".to_string()
+    } else {
+        "已是最新版本（如本地文件缺失已自动还原）".to_string()
+    };
+    Ok(SyncResult {
+        success: true,
+        message,
+        is_first_clone: false,
+        has_updates,
+        changed_files: 0,
+    })
 }
 
 /// 获取本地存储目录的绝对路径
@@ -357,12 +294,54 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_strategy_from_str() {
-        assert_eq!(SyncStrategy::from("keep_local"), SyncStrategy::KeepLocal);
-        assert_eq!(SyncStrategy::from("Keep_Local"), SyncStrategy::KeepLocal);
-        assert_eq!(SyncStrategy::from("overwrite"), SyncStrategy::Overwrite);
-        assert_eq!(SyncStrategy::from("manual"), SyncStrategy::Manual);
-        assert_eq!(SyncStrategy::from("unknown"), SyncStrategy::KeepLocal);
+    fn test_sync_repo_restores_deleted_file() {
+        // 回归测试：本地 commit 已等于远程、但工作区文件被删时，sync_repo 必须仍执行
+        // reset --hard 把文件还原，不能提前返回「已是最新版本」导致文件丢失。
+        // 这正是 keep_local 策略被移除前存在的同步缺陷。
+        use std::process::Command;
+
+        let remote = tempfile::tempdir().expect("创建临时远程仓库失败");
+        let local = tempfile::tempdir().expect("创建临时本地仓库失败");
+
+        // git 命令快捷执行器：失败即 panic，输出错误信息便于排查
+        let git = |dir: &std::path::Path, args: &[&str]| {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .expect("执行 git 失败");
+            assert!(
+                out.status.success(),
+                "git {:?} 失败: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+
+        // 1) 远程裸仓库（默认分支 main）
+        git(remote.path(), &["init", "--bare", "-b", "main"]);
+
+        // 2) 本地 clone 远程，落一个含 a.txt 的提交并推回远程
+        git(local.path(), &["clone", remote.path().to_str().unwrap(), "."]);
+        git(local.path(), &["config", "user.email", "t@t"]);
+        git(local.path(), &["config", "user.name", "t"]);
+        std::fs::write(local.path().join("a.txt"), "hello").expect("写 a.txt 失败");
+        git(local.path(), &["add", "a.txt"]);
+        git(local.path(), &["commit", "-m", "init"]);
+        git(local.path(), &["push", "origin", "main"]);
+
+        // 3) 模拟误删：删除工作区文件，但本地 commit 仍 == 远程（命中旧提前返回分支）
+        std::fs::remove_file(local.path().join("a.txt")).expect("删除 a.txt 失败");
+        assert!(!local.path().join("a.txt").exists(), "前置：a.txt 应已被删除");
+
+        // 4) 执行同步，预期文件被 reset --hard 还原
+        let rt = tokio::runtime::Runtime::new().expect("创建 tokio runtime 失败");
+        let result = rt.block_on(sync_repo(local.path(), "origin", "main"));
+        assert!(result.is_ok(), "sync_repo 应成功: {:?}", result.err());
+        assert!(
+            local.path().join("a.txt").exists(),
+            "被删文件应被 reset --hard 还原"
+        );
     }
 
     #[test]
@@ -371,12 +350,6 @@ mod tests {
             assert!(dir.to_string_lossy().contains(".ntd"));
             assert!(dir.to_string_lossy().contains("bundled"));
         }
-    }
-
-    #[test]
-    fn test_count_changed_files() {
-        let output = "Updating abc123..def456\nFast-forward\n create mode 100644 experts/test.md\n delete mode 100644 experts/old.md";
-        assert_eq!(count_changed_files(output), 3);
     }
 
     #[test]

--- a/backend/src/handlers/bundled.rs
+++ b/backend/src/handlers/bundled.rs
@@ -185,16 +185,9 @@ pub fn register_skills_cache(cache: Arc<SkillsMarketCache>) {
 /// 同步请求参数
 #[derive(Debug, Deserialize)]
 pub struct SyncRequest {
-    /// 同步策略：keep_local（保留本地）、overwrite（覆盖）、manual（手动处理冲突）
-    #[serde(default = "default_sync_strategy")]
-    pub strategy: String,
     /// 同步的子目录：all/experts/todos/skills，默认 all
     #[serde(default)]
     pub subdir: Subdir,
-}
-
-fn default_sync_strategy() -> String {
-    "keep_local".to_string()
 }
 
 /// 同步响应
@@ -231,8 +224,6 @@ pub struct StatusResponse {
     pub branch: String,
     /// 本地路径
     pub local_path: String,
-    /// 当前同步策略
-    pub sync_strategy: String,
     /// 自动同步是否启用
     pub auto_sync_enabled: bool,
     /// 本地是否存在
@@ -260,11 +251,11 @@ pub struct StatusResponse {
 /// 执行一次完整的内置资源同步：git clone/pull +（按 subdir）导入事项模板 + 重载专家 + 写 last_sync_at。
 ///
 /// 抽自 sync_bundled handler，供 HTTP 接口与启动检查任务共用，避免逻辑分叉。
+/// 固定以远程仓库为准（git fetch + reset --hard origin/<branch>），不再接收同步策略。
 /// 返回 git 层 SyncResult，调用方据此组装 HTTP 响应或日志。
 pub(crate) async fn run_bundled_sync(
     state: &AppState,
     subdir: Subdir,
-    strategy: git_sync::SyncStrategy,
 ) -> Result<git_sync::SyncResult, String> {
     // 先快照出 owned bundled 配置并立即释放读锁卫，后续 .await 不持锁、future 保持 Send
     let bundled_config = state.config_snapshot(|c| c.bundled_source.clone());
@@ -286,7 +277,7 @@ pub(crate) async fn run_bundled_sync(
         git_sync::clone_repo(&bundled_config.url, &repo_path, &bundled_config.branch).await
     } else {
         tracing::info!("本地仓库已存在，执行同步更新");
-        git_sync::sync_repo(&repo_path, "origin", &bundled_config.branch, strategy).await
+        git_sync::sync_repo(&repo_path, "origin", &bundled_config.branch).await
     };
 
     let r = result.map_err(|e| e.to_string())?;
@@ -348,10 +339,9 @@ pub async fn sync_bundled(
     Json(req): Json<SyncRequest>,
 ) -> Result<ApiResponse<SyncResponse>, AppError> {
     let subdir = req.subdir;
-    let strategy = git_sync::SyncStrategy::from(req.strategy.as_str());
 
     // 实际同步逻辑抽到 run_bundled_sync，handler 只负责参数解析与响应组装
-    match run_bundled_sync(&state, subdir, strategy).await {
+    match run_bundled_sync(&state, subdir).await {
         Ok(r) => Ok(ApiResponse::ok(SyncResponse {
             success: r.success,
             message: r.message,
@@ -419,7 +409,6 @@ pub async fn get_bundled_status(
         remote_url: bundled_config.url.clone(),
         branch: bundled_config.branch.clone(),
         local_path: repo_path.to_string_lossy().to_string(),
-        sync_strategy: "overwrite".to_string(),
         auto_sync_enabled: bundled_config.auto_sync_enabled,
         local_exists,
         local_commit,

--- a/backend/src/services/bundled_sync.rs
+++ b/backend/src/services/bundled_sync.rs
@@ -80,7 +80,7 @@ async fn perform_sync(url: &str, branch: &str, local_path: &str) {
         git_sync::clone_repo(url, &repo_path, branch).await
     } else {
         tracing::info!("[bundled-sync] 执行同步更新");
-        git_sync::sync_repo(&repo_path, "origin", branch, git_sync::SyncStrategy::Overwrite).await
+        git_sync::sync_repo(&repo_path, "origin", branch).await
     };
 
     match result {

--- a/backend/src/services/startup_check.rs
+++ b/backend/src/services/startup_check.rs
@@ -9,7 +9,6 @@
 
 use std::time::Duration;
 
-use crate::git_sync::SyncStrategy;
 use crate::handlers::bundled::{run_bundled_sync, Subdir};
 use crate::handlers::AppState;
 
@@ -52,8 +51,8 @@ async fn sync_resources(state: &AppState) {
     }
 
     tracing::info!("[startup-check] 开始同步内置资源（专家 + 事项模板）");
-    // Overwrite：bundled 是系统资源，远程为准；用户自定义在独立目录，不受影响。
-    match run_bundled_sync(state, Subdir::All, SyncStrategy::Overwrite).await {
+    // bundled 是系统资源，远程为准（sync_repo 固定 reset --hard 到远程分支）；用户自定义在独立目录，不受影响。
+    match run_bundled_sync(state, Subdir::All).await {
         Ok(r) => tracing::info!(
             "[startup-check] 资源同步完成：{}（更新 {} 个文件）",
             r.message,

--- a/frontend/src/api/bundled.ts
+++ b/frontend/src/api/bundled.ts
@@ -5,11 +5,6 @@
 import { api, unwrap } from '@/utils/database/client';
 
 /**
- * 同步策略
- */
-export type SyncStrategy = 'keep_local' | 'overwrite' | 'manual';
-
-/**
  * 子目录类型
  */
 export type Subdir = 'all' | 'experts' | 'todos' | 'skills' | 'processes';
@@ -18,7 +13,6 @@ export interface BundledStatus {
   remote_url: string;
   branch: string;
   local_path: string;
-  sync_strategy: string;
   auto_sync_enabled: boolean;
   local_exists: boolean;
   local_commit: string | null;
@@ -339,12 +333,12 @@ export const bundledApi = {
   /**
    * 手动触发同步
    */
-  async sync(params: { subdir?: Subdir; strategy?: SyncStrategy } = {}): Promise<SyncResult> {
+  async sync(params: { subdir?: Subdir } = {}): Promise<SyncResult> {
     // 后端返回 {code, data, message} 包裹，必须用 unwrap 取出 data，
     // 否则调用方拿到的会是整个 axios response，字段访问全部失效。
+    // 同步策略已固定为「以远程为准」，不再由前端传参。
     return unwrap(await api.post('/api/bundled/sync', {
       subdir: params.subdir || 'all',
-      strategy: params.strategy || 'keep_local',
     }));
   },
 

--- a/frontend/src/components/settings/TemplatesPanel.tsx
+++ b/frontend/src/components/settings/TemplatesPanel.tsx
@@ -111,7 +111,7 @@ export function TemplatesPanel() {
     setSyncing(true);
     const hide = antMessage.loading('正在同步全部资源...', 0);
     try {
-      const res = await bundledApi.sync({ subdir: 'all', strategy: 'overwrite' });
+      const res = await bundledApi.sync({ subdir: 'all' });
       if (res?.success) {
         message.success(`同步成功: ${res.message}`);
         await loadStatus();
@@ -441,7 +441,6 @@ function StatusModal({
           <Descriptions.Item label="远程仓库">{status.remote_url}</Descriptions.Item>
           <Descriptions.Item label="分支">{status.branch}</Descriptions.Item>
           <Descriptions.Item label="本地路径">{status.local_path}</Descriptions.Item>
-          <Descriptions.Item label="同步策略">{status.sync_strategy}</Descriptions.Item>
           <Descriptions.Item label="自动同步">
             {status.auto_sync_enabled ? '已启用' : '未启用'}
           </Descriptions.Item>


### PR DESCRIPTION
## 问题

`git_sync::sync_repo` 在 `local_commit == remote_commit` 时会提前返回 "已是最新版本"。当本地工作区文件被误删或被改、但 commit 指针还停在远端同位置时（极常见的场景），同步不会执行 `reset --hard`，导致文件丢失。

## 修复

- 删除 `SyncStrategy` 枚举（`KeepLocal` / `Overwrite` / `Manual`）及其 `From<&str>` 实现
- `sync_repo` 去掉 `strategy` 参数；始终执行 `git fetch` + `git reset --hard origin/<branch>`
- `has_updates` 仅反映 commit 是否前进；工作区被还原（如补回缺失文件）也视为有效同步
- bundled 资源属于系统资源，远程为准语义最干净；用户自定义在独立目录，不受影响

## 变更范围

- `backend/src/git_sync/mod.rs`：删除策略枚举、`sync_repo` 改写、新增还原回归测试
- `backend/src/handlers/bundled.rs`：去掉请求/响应中的 `strategy` 字段
- `backend/src/services/bundled_sync.rs` / `startup_check.rs`：同步调用点
- `frontend/src/api/bundled.ts` / `TemplatesPanel.tsx`：去掉 `strategy` 类型与 UI 展示

## 回归测试

`test_sync_repo_restores_deleted_file`：临时建裸远端 → 本地 clone → 提交 `a.txt` 推回 → 删除工作区文件 → 调 `sync_repo` → 断言 `a.txt` 被 `reset --hard` 还原。这正是旧 `KeepLocal` 路径下会触发的提前返回分支。