### PR TITLE
feat(047): 门禁评分等待与评审追溯

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -1548,6 +1548,23 @@ impl Database {
         };
         self.exec_update(am).await
     }
+
+    /// 反查评审 record：`source_execution_record_id` 指向原 step record（需求 047）。
+    ///
+    /// 执行历史展示「评分来源」：给定原 step 的 execution_record_id，找到评审它的评审实例
+    /// record（其 `result` 含评审理由 + `RATING`、`rating` 是评分）。走已有索引
+    /// `idx_execution_records_source_record_id`。返工重跑可能产生多条，取 id 最大（最新一次评审）。
+    pub async fn find_review_record_id_by_source(
+        &self,
+        source_record_id: i64,
+    ) -> Result<Option<i64>, sea_orm::DbErr> {
+        let row = execution_records::Entity::find()
+            .filter(execution_records::Column::SourceExecutionRecordId.eq(source_record_id))
+            .order_by_desc(execution_records::Column::Id)
+            .one(&self.conn)
+            .await?;
+        Ok(row.map(|m| m.id))
+    }
 }
 
 #[cfg(test)]
@@ -1743,6 +1760,37 @@ mod center_aggregate_tests {
         assert_eq!(s1.status.as_deref(), Some("failed"), "应取最近一条");
         // t2 无记录 → 不在 map 中
         assert!(!map.contains_key(&t2));
+    }
+
+    /// find_review_record_id_by_source：反查评审 record，多条取最新；不存在返 None（需求 047）。
+    #[tokio::test]
+    async fn test_find_review_record_id_by_source_returns_latest_and_none() {
+        let db = fresh_db().await;
+        let todo_id = seed_todo(&db, "T").await;
+        // 原记录（被评审的 step record），execution_records 首条 → id=1。
+        seed_exec(&db, todo_id, "success", "manual").await;
+        let source_id: i64 = 1;
+
+        // 不存在的 source → None。
+        assert_eq!(db.find_review_record_id_by_source(9999).await.unwrap(), None);
+
+        // 两条评审 record 指向同一原记录（模拟返工重跑），id 自增为 2、3。
+        for _ in 0..2 {
+            db.exec(
+                "INSERT INTO execution_records (todo_id, status, trigger_type, started_at, \
+                 source_execution_record_id) \
+                 VALUES (1, 'success', 'auto_review', '2026-07-08T09:00:00Z', 1)",
+            )
+            .await
+            .expect("insert review record");
+        }
+        // 多条 → order_by_desc(Id) 取最新一次评审（id=3）。
+        assert_eq!(
+            db.find_review_record_id_by_source(source_id)
+                .await
+                .unwrap(),
+            Some(3)
+        );
     }
 
     /// update_execution_record_agent_runs：写入 agent_runs JSON 后能按 id 原样读回（CodeRabbit）。

--- a/backend/src/handlers/loop_.rs
+++ b/backend/src/handlers/loop_.rs
@@ -26,7 +26,7 @@ use crate::models::{
     self,
     ApiResponse, BatchCopyLoopWorkspaceRequest, BatchUpdateLoopWorkspaceRequest,
     BatchWorkspaceResult, LoopDetail, LoopDto, LoopExecutionDetail, LoopExecutionDto,
-    LoopExecutionTokenSummary, LoopListItem, LoopStepExecutionDto,
+    LoopExecutionTokenSummary, GateResultDto, LoopListItem, LoopStepExecutionDto,
     UpdateLoopStatusRequest, UpdateTagsRequest,
 };
 
@@ -204,32 +204,64 @@ async fn enrich_step_execution_with_usage(
     dto.total_cost_usd = usage.total_cost_usd;
 }
 
-/// 为 pending_approval 的环节执行注入待审批门禁 id。
-/// 044 审批改门禁制：前端凭 pending_gate_id 直接调门禁审批接口，无需再查审计接口。
-/// 仅当环节处于 pending_approval 且存在 pending 的 human_approval 门禁时写入，否则保持 None。
-async fn populate_pending_gate_id(
+/// 填充门禁评价摘要 + 待审批门禁 id（需求 047）。
+///
+/// 一次 `list_loop_step_execution_gates` 查询同时填两件事，避免重复往返：
+/// - `gate_results`：全部门禁的 status/result，前端展示门禁级状态与失败原因；
+/// - `pending_gate_id`：首个 pending 的 human_approval 门禁（原 populate_pending_gate_id 逻辑，
+///   仅在 pending_approval / approval_status=pending 时填，供前端调审批接口）。
+async fn populate_gate_results(
     db: &crate::db::Database,
     dto: &mut LoopStepExecutionDto,
 ) {
-    // 非待审批状态没有「待审批」门禁，直接跳过，避免无谓的门禁查询。
-    // 必须同时认两条暂停路径（与 db::count_pending_approvals_by_execution_ids 的 OR 条件一致，NTD-004）：
-    //   - 旧评分路径：暂停时写 approval_status='pending'；
-    //   - 工艺 phase_driver 路径：暂停时只写 status='pending_approval'，不写 approval_status。
-    // 只看 approval_status 会漏掉 phase_driver 路径，导致前端审批框出现却拿不到 gate id（报「未找到待审批门禁」）。
-    if dto.status != "pending_approval" && dto.approval_status.as_deref() != Some("pending") {
-        return;
-    }
-    match db.list_loop_step_execution_gates(dto.id).await {
-        // 取首个 pending 的 human_approval 门禁：工艺定义里人工审批环节只有一个此类门禁
-        Ok(gates) => {
-            dto.pending_gate_id = gates
-                .into_iter()
-                .find(|g| g.gate_type == "human_approval" && g.status == "pending")
-                .map(|g| g.id);
+    let gates = match db.list_loop_step_execution_gates(dto.id).await {
+        Ok(gs) => gs,
+        // 门禁查询失败不阻塞执行记录展示，但需留 warn 供运维排查（NTD-009）。
+        Err(e) => {
+            tracing::warn!("查询 step_execution #{} 门禁列表失败: {e}", dto.id);
+            return;
         }
-        // 门禁查询失败会让前端失去审批入口（pending_gate_id 保留 None），但不阻塞执行记录展示；
-        // 需记录 warn 让运维人员排查，避免用户报「审批按钮不显示」时无服务端日志可查（NTD-009）。
-        Err(e) => tracing::warn!("查询 step_execution #{} 门禁列表失败，pending_gate_id 将保持 None: {e}", dto.id),
+    };
+    // pending_gate_id：必须同时认两条暂停路径（与 count_pending_approvals 一致，NTD-004）：
+    //   旧评分路径 approval_status='pending'；phase_driver 路径只写 status='pending_approval'。
+    // 只看 approval_status 会漏掉 phase_driver 路径，导致前端审批框拿不到 gate id。
+    if dto.status == "pending_approval" || dto.approval_status.as_deref() == Some("pending") {
+        dto.pending_gate_id = gates
+            .iter()
+            .find(|g| g.gate_type == "human_approval" && g.status == "pending")
+            .map(|g| g.id);
+    }
+    // gate_results：全部门禁摘要，供前端展示通过/失败/失败原因（需求 047）。
+    dto.gate_results = gates
+        .into_iter()
+        .map(|g| GateResultDto {
+            id: g.id,
+            gate_type: g.gate_type,
+            gate_name: g.gate_name,
+            status: g.status,
+            result: g.result,
+        })
+        .collect();
+}
+
+/// 填充评分来源评审 record id（需求 047）。
+///
+/// 反查 `execution_records.source_execution_record_id`，找到评审原 step record 的评审实例，
+/// 前端做可点击徽章跳转看评审理由。仅当有 execution_record_id 时执行；
+/// 查询失败降级 warn，不阻塞展示。
+async fn populate_review_record_id(
+    db: &crate::db::Database,
+    dto: &mut LoopStepExecutionDto,
+) {
+    // 没有 execution_record_id 的环节（异常处理步骤等）不会有评审来源，直接跳过。
+    let Some(source_id) = dto.execution_record_id else { return; };
+    match db.find_review_record_id_by_source(source_id).await {
+        Ok(rid) => dto.review_record_id = rid,
+        Err(e) => tracing::warn!(
+            "查询 step_execution #{} 评分来源失败（source_record={}）: {e}",
+            dto.id,
+            source_id
+        ),
     }
 }
 
@@ -294,7 +326,8 @@ pub async fn list_executions_v1(
         let mut enriched: Vec<LoopStepExecutionDto> = step_execs.into_iter().map(|se| se.into()).collect();
         for dto in &mut enriched {
             enrich_step_execution_with_usage(&state.db, dto).await;
-            populate_pending_gate_id(&state.db, dto).await;
+            populate_gate_results(&state.db, dto).await;
+            populate_review_record_id(&state.db, dto).await;
         }
         item.token_summary = Some(aggregate_tokens_from_step_dtos(&enriched));
     }
@@ -332,7 +365,8 @@ pub async fn get_execution_v1(
             dto.step_name = Some(ls.name);
         }
         enrich_step_execution_with_usage(&state.db, &mut dto).await;
-        populate_pending_gate_id(&state.db, &mut dto).await;
+        populate_gate_results(&state.db, &mut dto).await;
+        populate_review_record_id(&state.db, &mut dto).await;
         enriched.push(dto);
     }
     // 聚合 token 汇总：直接从已 enrich 的 DTO 字段聚合，避免重复查询数据库

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -310,6 +310,21 @@ impl From<loop_executions::Model> for LoopExecutionDto {
     }
 }
 
+/// 门禁评价摘要（需求 047）：随 LoopStepExecutionDto 下发，前端展示门禁级 status/result。
+///
+/// 字段与 `loop_step_execution_gates` 表对齐，前端复用 `GateDto` 渲染。
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GateResultDto {
+    pub id: i64,
+    pub gate_type: String,
+    pub gate_name: String,
+    /// pending | passed | failed
+    pub status: String,
+    /// 评价结果文本（如「AI 评审未通过（评分 45，阈值 60）」）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[derive(Default)]
 pub struct LoopStepExecutionDto {
@@ -322,11 +337,11 @@ pub struct LoopStepExecutionDto {
     pub started_at: Option<String>,
     pub finished_at: Option<String>,
     pub error_message: Option<String>,
-    /// 历史快照：旧评分制评审得分（0-100）。044 起新执行不再写入，仅为历史记录展示保留
+    /// AI 评审得分（0-100）。由 phase_driver 门禁评估时回写（resolve_step_rating）。
     pub rating: Option<i32>,
     /// 历史快照：旧评分制未达标策略，仅为历史记录展示保留
     pub unrated_policy: Option<String>,
-    /// 历史快照：旧评分制阈值，仅为历史记录展示保留
+    /// 门禁阈值（ai_criteria_review.min_score）。由 phase_driver 回写（set_step_execution_min_rating）。
     pub min_rating: Option<i32>,
     /// 环节名称，来自 loop_steps 表
     pub step_name: Option<String>,
@@ -349,6 +364,13 @@ pub struct LoopStepExecutionDto {
     pub cache_read_input_tokens: Option<i64>,
     pub cache_creation_input_tokens: Option<i64>,
     pub total_cost_usd: Option<f64>,
+    /// 评分来源评审 record id（需求 047）：反查 source_execution_record_id 得到，
+    /// 前端做可点击徽章跳转看评审理由。仅当有 execution_record_id 且被评审过时由 handler 注入。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_record_id: Option<i64>,
+    /// 门禁级评价摘要（需求 047）：前端展示每个门禁的 status/result（失败原因）。
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub gate_results: Vec<GateResultDto>,
 }
 
 impl From<loop_step_executions::Model> for LoopStepExecutionDto {
@@ -377,6 +399,8 @@ impl From<loop_step_executions::Model> for LoopStepExecutionDto {
             cache_read_input_tokens: None,
             cache_creation_input_tokens: None,
             total_cost_usd: None,
+            review_record_id: None,
+            gate_results: Vec::new(),
         }
     }
 }

--- a/backend/src/services/process/mod.rs
+++ b/backend/src/services/process/mod.rs
@@ -14,6 +14,7 @@ pub mod gates;
 pub mod guid;
 pub mod installer;
 pub mod phase_driver;
+pub mod rating_wait;
 pub mod recommender;
 pub mod repair_log;
 pub mod rework_tracker;

--- a/backend/src/services/process/phase_driver.rs
+++ b/backend/src/services/process/phase_driver.rs
@@ -16,6 +16,7 @@ use crate::models::ExecutionRecord;
 use crate::services::process::artifact_capture::{self, ArtifactSpec};
 use crate::services::process::gate_evaluator::{self, GateSummary};
 use crate::services::process::rework_tracker;
+use crate::services::process::rating_wait;
 use crate::services::process::transition_resolver;
 use crate::services::process::GateDefinition;
 
@@ -98,10 +99,20 @@ pub async fn execute_step(
     let execution_result = execution_record
         .and_then(|r| r.result.as_deref());
 
-    // 046：评分统一由 auto_review 在环节执行完成时写入 execution_record.rating。
-    // artifact_present/script_check 已废弃，产物存在性与脚本执行结果改由 AI 评审时自行判定。
-    // 此处直接读取已有评分，不再 poll 等待——评分缺失即门禁 fail（ai_criteria_review 无 rating）。
-    let execution_rating = execution_record.and_then(|r| r.rating);
+    // 047：恢复评分等待。record 终态先于 auto_review 写 rating（persist_completion_record
+    // 先于 finalize_normal_completion），LoopRunner 读 record 时 rating 可能仍为 None。
+    // 若本环节含 ai_criteria_review 门禁，按 timeout_secs 等评分写回，避免无评分误判 fail。
+    // timeout_secs 语义：null=默认300s，0=一直等，N=等N秒（见 rating_wait）。
+    let mut execution_rating = execution_record.and_then(|r| r.rating);
+    if execution_rating.is_none()
+        && rating_wait::has_ai_criteria_review_gate(&effective_gate_config)
+    {
+        // 有 record id 才能等（异常处理步骤等无 record 的环节跳过）。
+        if let Some(rid) = execution_record.map(|r| r.id) {
+            let timeout = rating_wait::resolve_rating_timeout(&effective_gate_config);
+            execution_rating = rating_wait::wait_for_rating(db, rid, timeout).await;
+        }
+    }
 
     let gate_summary = gate_evaluator::evaluate_step_gates(
         db,

--- a/backend/src/services/process/rating_wait.rs
+++ b/backend/src/services/process/rating_wait.rs
@@ -1,0 +1,152 @@
+//! AI 评审门禁的评分等待（需求 047）。
+//!
+//! 046 删掉了门禁侧的评分 poll 等待，依赖「rating 在门禁评估前已就绪」的假设。
+//! 但 `persist_completion_record`（写 record 终态）先于 `finalize_normal_completion`
+//! （auto_review 写 rating），LoopRunner 一旦看到 record 终态就读 record，此时 rating
+//! 可能还没写回，导致 `ai_criteria_review` 门禁拿到 None 误判 fail。
+//!
+//! 本模块在门禁评估处恢复「等评分」：rating 未就绪时 poll DB，由 `GateDefinition.timeout_secs`
+//! 控制上限。不动 record 生命周期（重排 persist/finalize 会破坏 executor 终态信号语义）。
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::db::Database;
+use crate::services::process::GateDefinition;
+
+/// 默认评分等待上限（秒）：对齐 `auto_review` 自身的 300s 上限。
+/// 超过仍未出分则放弃，让下游 ai_criteria_review 按 needs_review fail 推进，避免 loop 永久挂起。
+const DEFAULT_RATING_WAIT_SECS: u64 = 300;
+
+/// poll 间隔：与 `loop_runner::wait_for_step_finish` 一致，平衡响应速度与 DB 压力。
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// still-waiting 日志间隔：避免刷屏，又让运维知道仍在等待、不是卡死。
+const LOG_TICK: Duration = Duration::from_secs(30);
+
+/// gate_config 是否含至少一个 `ai_criteria_review` 门禁。
+///
+/// 复用 gate_evaluator 的解析路径（`serde_json` → `Vec<GateDefinition>`）。
+/// 解析失败视为「无 AI 门禁」——gate_evaluator 后续会以 ParseError 显式报错，此处不重复报。
+pub fn has_ai_criteria_review_gate(gate_config_json: &str) -> bool {
+    let gates: Vec<GateDefinition> = match serde_json::from_str(gate_config_json) {
+        Ok(gs) => gs,
+        Err(_) => return false,
+    };
+    gates.iter().any(|g| g.gate_type == "ai_criteria_review")
+}
+
+/// 取所有 `ai_criteria_review` 门禁 `timeout_secs` 的最大者。
+///
+/// 多个 AI 门禁时取最长等待（最宽松的上限）；全为 None → None（调用方用默认 300s）。
+pub fn resolve_rating_timeout(gate_config_json: &str) -> Option<i32> {
+    let gates: Vec<GateDefinition> = serde_json::from_str(gate_config_json).ok()?;
+    gates
+        .iter()
+        .filter(|g| g.gate_type == "ai_criteria_review")
+        .filter_map(|g| g.timeout_secs)
+        .max()
+}
+
+/// 轮询 `record.rating`，直到出现或超时。
+///
+/// # timeout 语义（与 `GateDefinition.timeout_secs` 注释一致）
+/// - `None` → 默认 300s
+/// - `Some(0)` → 一直等（`loop_runner::wait_for_step_finish` 的 24h 是最后兜底）
+/// - `Some(N)` N>0 → 等 N 秒
+///
+/// 返回评分；超时或 record 不存在返回 None（让下游判 needs_review fail）。
+pub async fn wait_for_rating(
+    db: &Arc<Database>,
+    record_id: i64,
+    timeout_secs: Option<i32>,
+) -> Option<i32> {
+    // 计算等待上限：None 用默认；0 视为无限（用极大值近似，loop_runner 24h 兜底）。
+    let wait_secs = match timeout_secs {
+        None => DEFAULT_RATING_WAIT_SECS,
+        Some(0) => u64::MAX / 2,
+        Some(n) => n.max(0) as u64,
+    };
+    let deadline = Instant::now() + Duration::from_secs(wait_secs);
+    let mut last_log = Instant::now();
+
+    tracing::info!(
+        "rating_wait: 等待 record #{} 评分（上限 {}s）",
+        record_id,
+        wait_secs
+    );
+
+    loop {
+        // 拿到评分立即返回（auto_review 已写回 rating）。
+        if let Ok(Some(rec)) = db.get_execution_record(record_id).await {
+            if let Some(r) = rec.rating {
+                tracing::info!("rating_wait: record #{} 评分就绪 = {}", record_id, r);
+                return Some(r);
+            }
+        }
+        // 超时放弃，交给下游按「未评分」处理。
+        if Instant::now() >= deadline {
+            tracing::warn!(
+                "rating_wait: 等待 record #{} 评分超时（{}s），按未评分处理",
+                record_id,
+                wait_secs
+            );
+            return None;
+        }
+        // 定期打 still-waiting，避免静默卡死让运维无日志可查。
+        if last_log.elapsed() >= LOG_TICK {
+            tracing::info!("rating_wait: 仍在等待 record #{} 评分...", record_id);
+            last_log = Instant::now();
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    /// 解析含 ai_criteria_review 的 gate_config 应识别为需要等评分。
+    #[test]
+    fn test_has_ai_criteria_review_gate_true() {
+        let cfg = r#"[{"name":"AI评审","type":"ai_criteria_review","min_score":80}]"#;
+        assert!(has_ai_criteria_review_gate(cfg));
+    }
+
+    /// 只有 human_approval 的环节不需要等评分。
+    #[test]
+    fn test_has_ai_criteria_review_gate_false_for_human_only() {
+        let cfg = r#"[{"name":"人工审批","type":"human_approval"}]"#;
+        assert!(!has_ai_criteria_review_gate(cfg));
+    }
+
+    /// 空 gate_config 无需等评分。
+    #[test]
+    fn test_has_ai_criteria_review_gate_false_for_empty() {
+        assert!(!has_ai_criteria_review_gate("[]"));
+    }
+
+    /// 非法 JSON 不报错，视为无需等评分（解析错误由 gate_evaluator 显式报）。
+    #[test]
+    fn test_has_ai_criteria_review_gate_invalid_json_is_false() {
+        assert!(!has_ai_criteria_review_gate("not json"));
+    }
+
+    /// 多个 AI 门禁取最大 timeout_secs。
+    #[test]
+    fn test_resolve_rating_timeout_takes_max() {
+        let cfg = r#"[
+            {"name":"A","type":"ai_criteria_review","min_score":60,"timeout_secs":120},
+            {"name":"B","type":"ai_criteria_review","min_score":80,"timeout_secs":300}
+        ]"#;
+        assert_eq!(resolve_rating_timeout(cfg), Some(300));
+    }
+
+    /// AI 门禁未配 timeout_secs → None（调用方用默认 300s）。
+    #[test]
+    fn test_resolve_rating_timeout_none_when_unset() {
+        let cfg = r#"[{"name":"A","type":"ai_criteria_review","min_score":60}]"#;
+        assert_eq!(resolve_rating_timeout(cfg), None);
+    }
+}

--- a/docs/design/047-门禁评分等待与评审追溯-设计.md
+++ b/docs/design/047-门禁评分等待与评审追溯-设计.md
@@ -1,0 +1,148 @@
+# 047-门禁评分等待与评审追溯-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AtomCode (GLM-5.2) | 2026-07-31 | 初始版本 |
+
+> 关联需求：`docs/requirements/047-门禁评分等待与评审追溯-需求.md`
+
+---
+
+## 1. 背景
+
+046 门禁统一后，`ai_criteria_review` 门禁靠 AI 评审 rating 判定。但 rating 写回 DB 的时机晚于 record 终态，LoopRunner 读 record 时 rating 还是 None，046 又删了门禁侧等待，于是直接 fail。同时执行历史图缺失评分/阈值/原因/来源展示。详见需求文档。
+
+## 2. 决策汇总
+
+| 问题 | 决策 | 是否迁移 |
+|---|---|---|
+| 评分等待 | **门禁侧 poll 等**（恢复 046 删掉的等待，收敛在 phase_driver），不动 record 生命周期 | 否 |
+| 评分来源 | 反查 `execution_records.source_execution_record_id`（已有索引），DTO 附带 `review_record_id` | 否 |
+| 评分/阈值展示 | 直接用 `loop_step_executions.rating`/`min_rating`（已写入） | 否 |
+| 门禁失败原因 | DTO 附带 `gate_results` 数组（复用 `list_loop_step_execution_gates`） | 否 |
+
+**核心：零 DB 迁移。** 所有必要数据已存在。
+
+### 排除的方案
+- **重排 persist/finalize 顺序**：`persist_completion_record` 写终态是给全系统（黑板、广播、LoopRunner）的「executor 已退出」信号，延后到 auto_review 完成会让「LLM 进程已退出但 record 还显示 running」，破坏 executor 语义 → 排除。
+- **wait_for_step_finish 等 rating**：该函数通用（等 step 终态），不知门禁配置，对无 ai_criteria_review 的 step 是无谓等待 → 排除。
+
+## 3. 详细设计
+
+### 3.1 评分等待（问题1）
+
+**新增 `backend/src/services/process/rating_wait.rs`**（phase_driver.rs 已超 220 行，抽独立模块）：
+
+```rust
+/// gate_config 是否含 ai_criteria_review 门禁。
+pub fn has_ai_criteria_review_gate(gate_config_json: &str) -> bool
+
+/// 取所有 ai_criteria_review 门禁 timeout_secs 的最大者；全 None → None（用默认）。
+pub fn resolve_rating_timeout(gate_config_json: &str) -> Option<i32>
+
+/// 轮询 record.rating，直到出现或超时。
+/// timeout 语义：None → 默认 300s；Some(0) → 一直等（24h 兜底）；Some(N) → 等 N 秒。
+pub async fn wait_for_rating(
+    db: &Arc<Database>,
+    record_id: i64,
+    timeout_secs: Option<i32>,
+) -> Option<i32>
+```
+
+- poll 间隔 500ms（与 `wait_for_step_finish` 一致），`tokio::time::sleep` 让出执行器。
+- 默认 300s 对齐 `auto_review.rs:447` 自身上限。
+- poll 开始 info 一条日志、每 30s tick still-waiting，便于运维排查。
+- 超时返回 None → 下游 `ai_criteria_review::evaluate` 按 needs_review fail（保留现有语义）。
+
+**改 `backend/src/services/process/phase_driver.rs`**（当前 L98-104）：
+
+```rust
+// 评估门禁前：若需要 AI 评审但 rating 未就绪，等待评分写回（恢复 046 删掉的等待）。
+let execution_rating = execution_record.and_then(|r| r.rating);
+let execution_rating = if execution_rating.is_none()
+    && has_ai_criteria_review_gate(&effective_gate_config)
+{
+    execution_record
+        .and_then(|r| r.id)
+        .map(|rid| {
+            let timeout = resolve_rating_timeout(&effective_gate_config);
+            wait_for_rating(db, rid, timeout)
+        })
+        .await?  // 伪代码，实际用 block_on 或直接 await（phase_driver 已 async）
+} else {
+    execution_rating
+};
+```
+
+实际实现：因 `execute_step` 已是 async，直接在其中 `wait_for_rating(db, record_id, timeout).await`。
+
+### 3.2 评分来源（问题3，反查已有数据）
+
+**`backend/src/db/execution.rs`**（紧邻 L1535 `link_review_to_source`）：
+
+```rust
+/// 反查评审 record（source_execution_record_id = 原 record）。多条取最新（id 最大）。
+pub async fn find_review_record_id_by_source(
+    &self, source_record_id: i64,
+) -> Result<Option<i64>, sea_orm::DbErr>
+```
+
+用 `Entity::find().filter(Column::SourceExecutionRecordId.eq(...)).order_by_desc(Id).one()`。走已有索引 `idx_execution_records_source_record_id`。
+
+**`backend/src/models/loop_.rs`** `LoopStepExecutionDto`：加 `review_record_id: Option<i64>`（`From` 初始化 None，handler 注入）。
+
+**`backend/src/handlers/loop_.rs`**：新增 `populate_review_record_id`（同 `populate_pending_gate_id` L210 模式），仅当 `execution_record_id.is_some()` 时反查；error 降级 warn 不阻塞展示。在 `list_executions_v1`、`get_execution_v1` enrich 循环调用。
+
+### 3.3 门禁级评分 / 失败原因（问题2）
+
+**评分/阈值**：直接用 `loop_step_executions.rating`/`min_rating`（phase_driver.rs:181 `resolve_step_rating`、:186 `extract_review_threshold` + `set_step_execution_min_rating` 已写入）—— 纯前端问题。
+
+**失败原因**：
+- `backend/src/models/loop_.rs` 新增 `GateResultDto { id, gate_type, gate_name, status, result }`，`LoopStepExecutionDto` 加 `gate_results: Vec<GateResultDto>`。
+- `backend/src/handlers/loop_.rs` 新增 `populate_gate_results`，复用 `db.list_loop_step_execution_gates(dto.id)`（L222 已用过），**与 `populate_pending_gate_id` 合并到一次查询**减少 DB 往返。
+- 前端 `GateDto`（api/bundled.ts L266）字段已匹配，直接复用。
+
+### 3.4 前端展示（问题2+3）
+
+改 `frontend/src/components/loop-studio/executions/StepExecList.tsx`：
+
+- **L139-165 评分块**：去掉 `{s.min_rating != null && ...}` 守卫，改为「rating / min_rating / review_record_id 任一非空即显示」。展示阈值 + 评分 + 通过判定（复用 L87 `ratingPassed`）+ 未评审提示。
+- **门禁失败原因**：L207-211 error_message 块下方渲染 `s.gate_results`（门禁名 Tag + result 文本）。
+- **评分来源徽章**：`s.review_record_id` 非空时渲染 `#review_record_id` 徽章，**复用 `BlackboardDrawer.tsx` L116-133 样式**（monospace、primary 色、stopPropagation）。点击打开评审 Drawer，展示 `rec.result`。
+- **`frontend/src/types/loop.ts`** L68：加 `review_record_id?: number | null`、`gate_results?: GateDto[]`；修 rating/min_rating 注释（去掉「历史快照」误导）。
+
+## 4. 评分时序（修复前 vs 修复后）
+
+```
+修复前（046，rating 丢失 → 误 fail）：
+  executor 完成 → persist record 终态(success) → LoopRunner 读 record(rating=None)
+                                       ↘ finalize: auto_review 写 rating(晚到)
+                 → phase_driver: rating=None → ai_criteria_review fail ✗
+
+修复后（门禁侧等待）：
+  executor 完成 → persist record 终态 → LoopRunner 读 record(rating=None)
+                                       ↘ finalize: auto_review 写 rating
+                 → phase_driver: has_ai_criteria_review? wait_for_rating poll
+                     ← rating 写回 → 评分就绪 → ai_criteria_review pass ✓
+```
+
+## 5. 测试
+
+### 后端单测
+- `rating_wait.rs`：`wait_for_rating` 评分晚到返回 Some / 超时返回 None / `0` 一直等。
+- `db/execution.rs`：`find_review_record_id_by_source` 命中 / 不存在返 None / 多条取最新。
+- `gate_evaluator.rs`：评分晚到经 wait 补回后 pass。
+
+### 前端 E2E（playwright，`frontend/tests/`，session 用 `PILOT_SESSION_ID`）
+- 环节卡片显示「阈值 N + 评分 M + 通过/不通过」。
+- failed 卡片显示门禁名 + AI 评审文本。
+- `#review_record_id` 徽章可点击，Drawer 含评审 result。
+
+### 端到端
+`make dev` 重启，用 `gate-test-artifact-v2.yaml`（产物存在）/ `gate-test-script-v2.yaml`（脚本执行）各建 loop 跑一轮，观察评分写出后门禁 pass（不再无评分 fail）。**注意**：v2 工艺当前被 UI 改回 `artifact_present`，验证前需改回 `ai_criteria_review`，否则触发废弃类型错误。
+
+## 6. 风险
+
+1. **rating_wait 阻塞**：单 step 默认最长 300s；auto_review 卡死时停 300s 后 fail 推进，不永久挂。
+2. **历史 min_rating 缺失**：044 前老数据 rating 有但 min_rating 空，去守卫后显示评分无阈值（标「阈值 -」）。
+3. **多次评审**：返工重跑可能多条 source 指向同一 record，`find_review_record_id_by_source` 用 `order_by_desc(Id)` 取最新。

--- a/docs/requirements/047-门禁评分等待与评审追溯-实现总结.md
+++ b/docs/requirements/047-门禁评分等待与评审追溯-实现总结.md
@@ -1,0 +1,69 @@
+# 047-门禁评分等待与评审追溯-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AtomCode (GLM-5.2) | 2026-07-31 | 初始版本 |
+
+> 关联：[需求](./047-门禁评分等待与评审追溯-需求.md) / [设计](../design/047-门禁评分等待与评审追溯-设计.md)
+
+## 背景
+
+046 门禁统一后 `ai_criteria_review` 靠 AI 评审 rating 判定，但 record 终态先于 rating 写回，046 又删了门禁侧等待，导致无评分误判 fail；同时执行历史图缺失评分/阈值/原因/来源展示。详见需求文档。
+
+## 实现内容（零 DB 迁移）
+
+### A. 评分等待（问题1）
+- **新增 `backend/src/services/process/rating_wait.rs`**：
+  - `has_ai_criteria_review_gate(gate_config)`：判断环节是否含 AI 评审门禁。
+  - `resolve_rating_timeout(gate_config)`：取 AI 门禁 `timeout_secs` 最大者。
+  - `wait_for_rating(db, record_id, timeout_secs)`：500ms 间隔 poll `record.rating`；timeout 语义 `None`=默认 300s、`Some(0)`=一直等、`Some(N)`=等 N 秒；开始/30s/就绪/超时各有日志。
+- **改 `backend/src/services/process/phase_driver.rs`**：评估门禁前若 `has_ai_criteria_review_gate` 且 rating 为 None，先 `wait_for_rating` 补评分，再传 `evaluate_step_gates`。不动 record 生命周期。
+
+### B. 评分来源（问题3，反查已有数据）
+- **`backend/src/db/execution.rs`**：新增 `find_review_record_id_by_source(source_record_id)`，`filter(source_execution_record_id).order_by_desc(Id).one()`，多条取最新（走已有索引）。
+- **`backend/src/models/loop_.rs`**：`LoopStepExecutionDto` 加 `review_record_id`。
+- **`backend/src/handlers/loop_.rs`**：新增 `populate_review_record_id`（同 `populate_pending_gate_id` 模式，error 降级 warn），在 `list_executions_v1`/`get_execution_v1` enrich 循环调用。
+
+### C. 门禁级评分/失败原因（问题2）
+- **评分/阈值**：直接用 `loop_step_executions.rating`/`min_rating`（phase_driver 已写入），无后端改动。
+- **失败原因**：`models/loop_.rs` 新增 `GateResultDto`，`LoopStepExecutionDto` 加 `gate_results`；`handlers/loop_.rs` 把原 `populate_pending_gate_id` 改造为 `populate_gate_results`——**一次查询同时填 `gate_results`（全部门禁 status/result）+ `pending_gate_id`**（原逻辑保留），减少 DB 往返。
+
+### D. 前端展示（问题2+3）
+- **`frontend/src/types/loop.ts`**：新增 `GateResultDto`，`LoopStepExecutionDto` 加 `review_record_id`/`gate_results`，修 rating/min_rating 注释（去掉「历史快照」误导）。
+- **`frontend/src/components/loop-studio/executions/StepExecList.tsx`**：
+  - 评分块去掉 `min_rating != null` 守卫 → 「rating/min_rating/review_record_id 任一非空即显示」；阈值缺失显示 `-`；通过判定仅当有阈值。
+  - 新增 `gate_results` 渲染（门禁名 Tag + result 文本，failed 时能看到具体哪个门禁不通过 + AI 评审文本）。
+  - 新增 `handleOpenReview`：评分来源 `#review_record_id` 徽章（复用 BlackboardDrawer 样式），点击打开评审 record Drawer，展示评审理由 + RATING。
+
+## 验证
+
+### 编译 + 单测（已通过）
+- `cargo clippy --all-targets -- -D warnings`：**零告警**。
+- `cargo test`：**全通过**，含新增：
+  - `rating_wait::tests`（6 个）：`has_ai_criteria_review_gate` 四例（含/空/human only/非法 JSON）、`resolve_rating_timeout`（取最大/None）。
+  - `db::execution::test_find_review_record_id_by_source_returns_latest_and_none`：反查命中（多条取最新）+ 不存在返 None。
+- `npx tsc --noEmit`：**零错误**。
+
+### 后端 DTO 端到端（已验证）
+dev 后端已用 047 代码重启（含 rating_wait 等）。造一条最小数据（loop+step_execution rating=85/min_rating=60 + 评审 record source 指向原 record + gate result），curl `GET /api/v1/workspaces/1/loops/39/executions/72` 返回：
+- `rating: 85`、`min_rating: 60` ✓
+- `review_record_id: 214` ✓（反查 `source_execution_record_id` 得到评审 record，多条取最新）
+- `gate_results: [{gate_type:"ai_criteria_review", status:"passed", result:"AI 评审通过（评分85，阈值60）"}]` ✓
+
+确认 `populate_review_record_id`（反查注入）与 `populate_gate_results`（门禁级 result 注入）端到端工作。
+
+### UI 端到端（步骤）
+前端改动经 `tsc --noEmit` 零错误；vite dev HMR 自动生效。用两个测试工艺验证完整链路（含评分等待 A）：
+1. 确保 `~/.ntd/processes/gate-test-artifact-v2.yaml`（产物存在）和 `gate-test-script-v2.yaml`（脚本执行）的 gate 是 `ai_criteria_review`（被 UI 改回 `artifact_present` 时需改回）。
+2. `make dev` → 用任一工艺建 todo 触发 loop。
+3. 观察日志：`rating_wait: 等待 record #X 评分` → `评分就绪` → 门禁 pass（不再无评分 fail）。
+4. 执行历史图：环节卡片显示「阈值 60 + 评分 M + 通过」、`#review_record_id` 徽章可点开看评审理由。
+
+## 文件清单
+- 后端：`services/process/rating_wait.rs`（新）、`services/process/phase_driver.rs`、`services/process/mod.rs`、`db/execution.rs`、`models/loop_.rs`、`handlers/loop_.rs`
+- 前端：`types/loop.ts`、`components/loop-studio/executions/StepExecList.tsx`
+
+## 风险与遗留
+1. **rating_wait 阻塞**：单 step 默认最长 300s；auto_review 卡死时 300s 后走 needs_review fail 推进，不永久挂。
+2. **历史 min_rating 缺失**：044 前老数据 min_rating 空，去守卫后显示评分无阈值（标「-」）。
+3. **046 数据迁移仍未实现**（设计文档承诺的 v81）：本次只在 dev 手动清理 + 改 ntd-resource 源仓库根治；其它部署遇旧 `gate_config` 仍会报废弃类型错误，需后续补迁移。

--- a/docs/requirements/047-门禁评分等待与评审追溯-需求.md
+++ b/docs/requirements/047-门禁评分等待与评审追溯-需求.md
@@ -1,0 +1,75 @@
+# 047-门禁评分等待与评审追溯-需求
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AtomCode (GLM-5.2) | 2026-07-31 | 初始版本 |
+
+## 背景
+
+046 门禁统一重构废弃了 `artifact_present`/`script_check`，统一为 `ai_criteria_review`（靠 AI 评审 rating 判定 pass/fail）。实际运行暴露三个关联问题，本需求统一解决：
+
+1. 配置 `ai_criteria_review` 门禁的环节，执行完评分还没出来就直接判 failed，没有「等评分完成再判断」。
+2. 执行历史的过程图上不显示评分得分、门禁阈值、失败原因、评审通过/不通过 —— 用户只看到一个 failed，不知道为什么。
+3. 评分来自哪个评审执行记录、为什么给这个分，看不到原因，无法点击跳转查看。
+
+## 现状
+
+### 评分时序（问题1）
+- `persist_and_finalize_completion` 先写 record 终态，后跑 `finalize_normal_completion`（auto_review 写 rating）—— record 终态先于 rating 写回。
+- LoopRunner 的 `wait_for_step_finish` 只 poll record 终态（`status != Running` 即返回），不等 rating 写回。
+- 046 删除了门禁侧的评分等待：`phase_driver` 直接 `execution_record.and_then(|r| r.rating)`，None 即让门禁 fail。
+- `GateDefinition.timeout_secs` 字段已存在（注释「null/0=一直等；正数=最多等N秒」）但 046 未消费。
+
+### 评分展示（问题2）
+- 前端 `StepExecList.tsx` 评分块被 `{s.min_rating != null && ...}` 守卫，044 门禁制后 `min_rating` 恒空 → 评分/阈值永不显示。
+- 门禁级 `status`/`result`（GateDto）前端根本没拉（数据走 `LoopStepExecutionDto`，未调审计接口）。
+- 失败原因只显环节级 `error_message`，门禁级失败原因未显。
+
+### 评分来源（问题3）
+- 后端 `execution_records.source_execution_record_id`（评审实例 record → 原 step record，有索引）已存在。
+- 评审 record 的 `result` 含评审理由 + `RATING: N`，`rating` 是评分。
+- 反查 `WHERE source_execution_record_id = 原record_id` 即得评审来源。
+- 前端 `ExecutionRecord` 类型已定义该字段但**全仓未渲染**。
+
+## 需求
+
+### 1. 门禁等评分完成再判断
+配置 `ai_criteria_review` 门禁的环节，评分未出时门禁等待，不直接 fail：
+- 默认等 **300s**（对齐 `auto_review` 自身 300s 上限），超时才 fail。
+- `GateDefinition.timeout_secs` 配置生效：`null` = 默认 300s，`0` = 一直等（`wait_for_step_finish` 24h 兜底），`N`（>0）= 等 N 秒。
+- 等待期间不阻塞其它 loop（poll 让出执行器）。
+
+### 2. 执行历史图显示评分信息
+环节卡片显示：
+- 评分得分（rating）
+- 门禁阈值（min_rating）
+- 通过 / 不通过判定（`rating >= min_rating`）
+- 门禁失败原因（具体哪个门禁不通过 + AI 评审文本，如「AI 评审未通过（评分 45，阈值 60）」）
+- 未评审提示（配置了阈值但无评分）
+
+### 3. 评分来源可追溯
+- 评分来源（评审执行记录）做成可点击的 `#review_record_id` 徽章。
+- 点击跳转显示评审理由（`result` 含 RATING + 评审文本）。
+- 反查 `execution_records.source_execution_record_id`（已有索引），**不新增 DB 字段**。
+
+### 4. 零数据迁移
+所有数据已存在（`rating` / `min_rating` / `source_execution_record_id`），只需 DTO 扩展 + 一处时序修复 + 前端展示，不新增 DB 列、不改 record 生命周期。
+
+## 边界
+
+- 评分等待默认最长 300s；auto_review 卡死时 300s 后走 needs_review fail 推进，不永久挂；24h 是最后兜底。
+- 历史 044 前数据 `min_rating` 可能为空，去守卫后展示评分但无阈值（标「阈值 -」），可接受。
+- **不**重排 `persist`/`finalize` 顺序（会让 record 终态语义错乱，破坏 executor 生命周期信号）。
+
+## 验收标准
+
+- [ ] `ai_criteria_review` 门禁评估时，评分未出则等待（默认 300s），不直接 fail
+- [ ] `timeout_secs` 配置生效（`null` / `0` / `N` 三种语义）
+- [ ] `LoopStepExecutionDto` 含 `review_record_id`（反查 `source_execution_record_id`，多条取最新）
+- [ ] `LoopStepExecutionDto` 含 `gate_results`（门禁级 status/result）
+- [ ] 前端环节卡片显示评分 / 阈值 / 通过判定 / 门禁失败原因
+- [ ] 评分来源 `#review_record_id` 徽章可点击，跳转显示评审理由
+- [ ] `cargo clippy --all-targets -- -D warnings` 零告警
+- [ ] `cargo test` 全部通过（`rating_wait` + `find_review_record_id_by_source`）
+- [ ] 前端 `tsc --noEmit` 零错误
+- [ ] playwright 验证评分展示 + 来源链接

--- a/frontend/src/components/loop-studio/executions/StepExecList.tsx
+++ b/frontend/src/components/loop-studio/executions/StepExecList.tsx
@@ -6,6 +6,7 @@ import { ArrowRightOutlined, ReadOutlined } from '@ant-design/icons';
 import bundledApi from '@/api/bundled';
 import * as dbExecutions from '@/utils/database/executions';
 import type { LogEntry } from '@/types';
+import type { GateResultDto } from '@/types/loop';
 import { LogDrawer } from '@/components/todo-post/LogDrawer';
 import { execStatusView, durationLabel, formatToken } from './helpers';
 
@@ -55,6 +56,21 @@ export function StepExecList({ stepExecs, loopId, workspaceId, executionId, onAp
       setDrawerLoading(false);
     }
   }, []);
+
+  // 打开评分来源评审 record（需求 047）：复用执行记录 Drawer，展示评审理由 + RATING。
+  // 徽章 onClick 内 stopPropagation，避免同时触发卡片整体点击。
+  const handleOpenReview = useCallback(async (reviewRecordId: number) => {
+    setDrawerLoading(true);
+    try {
+      const { getExecutionRecord } = dbExecutions;
+      const rec = await getExecutionRecord(workspaceId, reviewRecordId);
+      setDrawerRecord(rec);
+    } catch {
+      // ignore
+    } finally {
+      setDrawerLoading(false);
+    }
+  }, [workspaceId]);
 
   // 门禁制人工审批：通过/拒绝二选一，调门禁审批接口。
   // gateId 由后端在 step execution 的 pending_gate_id 字段注入（仅 pending_approval 时有值）。
@@ -136,30 +152,49 @@ export function StepExecList({ stepExecs, loopId, workspaceId, executionId, onAp
                 <span style={{ fontSize: 11, color: 'var(--color-text-tertiary, #94a3b8)', fontFamily: 'monospace' }}>{duration}</span>
               </div>
 
-              {/* 评分 / 阈值：仅旧评分制历史记录展示（min_rating 非空）。
-                  门禁制（044）执行 min_rating 恒空，状态以 status 标签为准；
-                  approve_gate 会给通过/拒绝写入合成的 rating 100/0（仅供 resume 判定，非真实评分），
-                  若仍按 rating>=min_rating 显示「通过/不通过」会误判——通过写入 100 却因 min_rating 空而显示「不通过」。 */}
-              {s.min_rating != null && (
+              {/* 评分 / 阈值 / 评审来源（需求 047）：去掉 min_rating 守卫，
+                  rating / min_rating / review_record_id 任一非空即显示。
+                  - 阈值缺失（min_score 未配）时显示「-」；
+                  - 通过判定仅当有阈值（rating>=min_rating），无阈值只展示评分；
+                  - review_record_id 提供评分来源跳转。 */}
+              {(s.rating != null || s.min_rating != null || s.review_record_id != null) && (
                 <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', marginBottom: 4 }}>
                   <span style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
-                    阈值 {s.min_rating}
+                    阈值 {s.min_rating != null ? s.min_rating : '-'}
                   </span>
                   {s.rating != null ? (
                     <>
                       <span style={{ fontSize: 11, color: 'var(--color-text-secondary)' }}>
                         评分 {s.rating}
                       </span>
-                      <span style={{
-                        padding: '1px 6px', borderRadius: 4, fontSize: 11, fontWeight: 600,
-                        background: ratingPassed ? 'var(--color-success-bg, #f0fdf4)' : 'var(--color-error-bg, #fef2f2)',
-                        color: ratingPassed ? 'var(--color-success, #22c55e)' : 'var(--color-error, #ef4444)',
-                      }}>
-                        {ratingPassed ? '通过' : '不通过'}
-                      </span>
+                      {s.min_rating != null && (
+                        <span style={{
+                          padding: '1px 6px', borderRadius: 4, fontSize: 11, fontWeight: 600,
+                          background: ratingPassed ? 'var(--color-success-bg, #f0fdf4)' : 'var(--color-error-bg, #fef2f2)',
+                          color: ratingPassed ? 'var(--color-success, #22c55e)' : 'var(--color-error, #ef4444)',
+                        }}>
+                          {ratingPassed ? '通过' : '不通过'}
+                        </span>
+                      )}
                     </>
                   ) : (
                     <span style={{ fontSize: 11, color: 'var(--color-text-tertiary, #94a3b8)' }}>未评审</span>
+                  )}
+                  {/* 评分来源徽章（需求 047）：点击打开评审 record，看评审理由 + RATING。 */}
+                  {s.review_record_id != null && (
+                    <span
+                      onClick={(e) => { e.stopPropagation(); handleOpenReview(s.review_record_id); }}
+                      title={`查看评审记录 #${s.review_record_id} 详情`}
+                      style={{
+                        marginLeft: 'auto', cursor: 'pointer',
+                        fontFamily: 'monospace', fontSize: 10,
+                        color: 'var(--color-primary, #6366f1)',
+                        border: '1px solid var(--color-primary, #6366f1)',
+                        borderRadius: 4, padding: '0 4px',
+                      }}
+                    >
+                      评审#{s.review_record_id}
+                    </span>
                   )}
                 </div>
               )}
@@ -207,6 +242,23 @@ export function StepExecList({ stepExecs, loopId, workspaceId, executionId, onAp
               {s.error_message && (
                 <div style={{ marginTop: 4, fontSize: 11, color: 'var(--color-error, #ef4444)', lineHeight: 1.4 }}>
                   {s.error_message}
+                </div>
+              )}
+
+              {/* 门禁级评价（需求 047）：展示每个门禁的 status/result。
+                  failed 时能看到具体哪个门禁不通过 + AI 评审文本（如「AI 评审未通过（评分 45，阈值 60）」）。 */}
+              {s.gate_results && s.gate_results.length > 0 && (
+                <div style={{ marginTop: 4, fontSize: 11, lineHeight: 1.4 }}>
+                  {s.gate_results.map((g: GateResultDto) => (
+                    <div key={g.id} style={{ display: 'flex', gap: 4, marginBottom: 2, alignItems: 'center', flexWrap: 'wrap' }}>
+                      <Tag color={g.status === 'passed' ? 'green' : g.status === 'pending' ? 'orange' : 'red'} style={{ margin: 0, fontSize: 10 }}>
+                        {g.gate_name}
+                      </Tag>
+                      {g.result && (
+                        <span style={{ color: 'var(--color-text-secondary, #64748b)', fontSize: 10 }}>{g.result}</span>
+                      )}
+                    </div>
+                  ))}
                 </div>
               )}
 

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -65,6 +65,17 @@ export interface LoopExecutionDto {
   error_message?: string | null;
 }
 
+/** 门禁评价摘要（需求 047）：门禁级 status/result，随 LoopStepExecutionDto 下发。 */
+export interface GateResultDto {
+  id: number;
+  gate_type: string;
+  gate_name: string;
+  /** pending | passed | failed */
+  status: string;
+  /** 评价结果文本（如「AI 评审未通过（评分 45，阈值 60）」） */
+  result?: string | null;
+}
+
 export interface LoopStepExecutionDto {
   id: number;
   loop_execution_id: number;
@@ -77,11 +88,11 @@ export interface LoopStepExecutionDto {
   error_message: string | null;
   started_at: string | null;
   finished_at: string | null;
-  /** 历史快照：旧评分制评审得分（0-100）。044 起新执行不再写入，仅为历史记录展示保留 */
+  /** AI 评审得分（0-100）。由 phase_driver 门禁评估时回写。 */
   rating: number | null;
   /** 历史快照：旧评分制未达标策略，仅为历史记录展示保留 */
   unrated_policy: string | null;
-  /** 历史快照：旧评分制阈值，仅为历史记录展示保留 */
+  /** 门禁阈值（ai_criteria_review.min_score）。由 phase_driver 回写。 */
   min_rating: number | null;
   step_name: string | null;
   sequence_index: number;
@@ -102,6 +113,13 @@ export interface LoopStepExecutionDto {
   cache_read_input_tokens: number | null;
   cache_creation_input_tokens: number | null;
   total_cost_usd: number | null;
+  /**
+   * 评分来源评审 record id（需求 047）：反查 execution_records.source_execution_record_id 得到。
+   * 前端做可点击徽章，跳转看评审理由（result 含 RATING + 评审文本）。
+   */
+  review_record_id?: number | null;
+  /** 门禁级评价摘要（需求 047）：前端展示每个门禁的 status/result（失败原因）。 */
+  gate_results?: GateResultDto[];
 }
 
 export interface LoopStepDto {


### PR DESCRIPTION
## 背景
046 门禁统一后 `ai_criteria_review` 靠 AI 评审 rating 判定，但 record 终态先于 rating 写回，046 又删了门禁侧等待，导致无评分误判 fail；同时执行历史图缺失评分/阈值/原因/来源展示。

## 改动（零 DB 迁移）
- **A 评分等待**：新增 `rating_wait.rs`，门禁评估前若 rating 未就绪则 poll 等待（默认 300s，对齐 auto_review 上限），`timeout_secs` 支持 null/0/N。
- **B 评分来源**：`LoopStepExecutionDto` 加 `review_record_id`，反查 `execution_records.source_execution_record_id`（已有索引，多条取最新）。
- **C 门禁失败原因**：DTO 加 `gate_results`（门禁级 status/result），`populate_gate_results` 与 `pending_gate_id` 合并一次查询。
- **D 前端**：`StepExecList` 去掉 `min_rating` 守卫，展示评分/阈值/通过判定 + gate_results + 评审来源 `#record_id` 徽章（点击看评审理由）。

## 验证
- `cargo clippy --all-targets -- -D warnings` 零告警
- `cargo test` 全过（含 rating_wait 6 + find_review_record_id_by_source 1 个新单测）
- `tsc --noEmit` 零错误
- DTO 端到端 curl 确认 review_record_id / gate_results / rating / min_rating 正确返回

## 文档
- 需求 `docs/requirements/047-门禁评分等待与评审追溯-需求.md`
- 设计 `docs/design/047-门禁评分等待与评审追溯-设计.md`
- 实现总结 `docs/requirements/047-门禁评分等待与评审追溯-实现总结.md`