### PR TITLE
feat(046): 工艺编辑器 prompt 输入框升级为 MD 编辑控件

### DIFF
--- a/docs/design/046-工艺编辑器提示词MD编辑控件-设计.md
+++ b/docs/design/046-工艺编辑器提示词MD编辑控件-设计.md
@@ -1,0 +1,146 @@
+# 046-工艺编辑器提示词MD编辑控件-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI(Kimi) | 2026-07-31 | 初始版本 |
+
+> 对应需求：`docs/requirements/046-工艺编辑器提示词MD编辑控件-需求.md`
+
+## 0. 调研背景与设计思考
+
+### 0.1 现状调研结论
+
+工艺编辑器的 prompt 类长文本字段共 3 处（另 1 处「验收标准」不在本需求范围）：
+
+| 文件 | 字段 | 现状控件 | 附带能力 |
+|------|------|---------|---------|
+| `propertyForms/LinkPropertyForm.tsx` | `link.prompt`（提示词） | `Input.TextArea` rows=3 | 无 |
+| `propertyForms/LinkPropertyForm.tsx` | `link.review_prompt`（评审 Prompt） | `Input.TextArea` rows=4 | 参数插入条（尾部追加）+ `DefaultReviewPromptButton` |
+| `propertyForms/GlobalPropertyForm.tsx` | `abnormal_handler.prompt`（异常处理 Prompt） | `Input.TextArea` rows=4 | 参数插入条（尾部追加） |
+
+两处参数插入条的 JSX（`div + code + Tooltip + hover 变色`）是完全相同的拷贝，仅参数数组不同——已有重复坏味道。
+
+todo 侧参考实现：`TodoDrawer` 的 Prompt 字段链路为 `PromptEditor`（封装） → `MdEditor`（`@/components/MdEditor`，`@uiw/react-md-editor` 的主题适配封装） ，高度 200，`editorRef` 暴露内部 `textarea` 以支持光标处插入（`TodoDrawer.insertTextAtCursor`）。该路径已在生产稳定使用，直接复刻即可，无需验证新 API。
+
+### 0.2 为什么不直接复用 `todo-drawer/PromptEditor`
+
+`PromptEditor` 与 todo 表单强耦合：内置 `PROMPT_PARAMS`（todo 专属参数）、「从模板创建」按钮（todo 模板弹窗回调）、固定标题「Prompt」。工艺侧 3 个字段的参数数组各不相同（提示词无参数条、评审与异常处理各有专属参数集），且需要挂载 `DefaultReviewPromptButton`。强行复用需要加一堆开关 props，反而把 todo 组件改复杂——**收敛重复的正确位置是工艺侧自建一个轻封装**，而不是给 todo 组件加配置。
+
+### 0.3 为什么数据流不需要任何调整
+
+`MdEditor` 是受控组件（`value: string` / `onChange: (v: string) => void`），与 `Input.TextArea` 的受控契约完全一致。属性面板现有链路 `字段修改 → updateLinkField/浅克隆 → onDefinitionChange(newDef)` 原样适用，逐键触发频率也相同，React Flow 重渲染压力无变化。
+
+### 0.4 光标插入的实现依据
+
+`MdEditor` 已声明 `editorRef?: React.RefObject<any>` 并透传给 `@uiw/react-md-editor`，其 ref 上可拿到内部 `textarea` DOM。`TodoDrawer.insertTextAtCursor` 的成熟模式：
+
+1. `editorRef.current?.textarea` 存在 → 读 `selectionStart/selectionEnd`，切片插入，`setTimeout(0)` 恢复光标并 `focus()`（等 React 提交新 value 后再复位光标，否则被重渲染冲掉）
+2. ref/textarea 不存在（未挂载等边界）→ 兜底尾部追加，不报错
+
+本设计把该逻辑下沉到 `PromptMdField` 内部，调用方零感知。
+
+## 1. 组件设计
+
+### 1.1 新建 `frontend/src/components/process/propertyForms/PromptMdField.tsx`
+
+```
+PromptMdField
+├── MdEditor（@/components/MdEditor，height=200，editorRef）
+└── 参数条（params 非空时渲染）
+    ├── "可用参数:" 文案
+    ├── code 标签 × N（点击 → insertAtCursor(param.key)，样式迁移自现有实现）
+    └── extraActions 插槽（如 DefaultReviewPromptButton）
+```
+
+Props 定义：
+
+```ts
+// 可插入参数的描述结构（key 为插入文本，desc 为 Tooltip 说明）
+interface PromptParam {
+  key: string;
+  desc: string;
+}
+
+interface PromptMdFieldProps {
+  value: string;                     // 受控文本，空值调用方兜底为 ''
+  onChange: (value: string) => void; // 变更回调（直通 updateLinkField 等既有链路）
+  params?: PromptParam[];            // 可插入参数；缺省/空数组 → 不渲染参数条（提示词字段场景）
+  extraActions?: ReactNode;          // 参数条尾部扩展位（评审 Prompt 的默认模板按钮）
+  height?: number;                   // 编辑器高度，默认 200（需求锁定值）
+}
+```
+
+内部函数拆分（满足单函数 ≤30 行）：
+
+- `insertAtCursor(text)`：光标插入主逻辑（含兜底分支）
+- `buildAppendedText(prev, text)`：尾部追加的纯函数（空值/换行边界），便于单测
+- 参数条渲染抽为 JSX 内联（无分支逻辑），样式常量和现有两份拷贝保持一致
+
+### 1.2 改造 `LinkPropertyForm.tsx`
+
+- 「提示词」：`Form.Item` 内 `<Input.TextArea>` → `<PromptMdField value={link.prompt ?? ''} onChange={(v) => handleFieldChange('prompt', v)} />`，不传 `params`
+- 「评审 Prompt」：`Form.Item` 内整体（TextArea + 参数条 div + `DefaultReviewPromptButton`）→ `<PromptMdField ... params={REVIEW_PROMPT_PARAMS} extraActions={<DefaultReviewPromptButton onApply={...} />} />`
+- 删除迁走的参数条内联 JSX；`REVIEW_PROMPT_PARAMS` 常量及其占位符说明注释**原地保留**（注释承载后端 compose 契约，属重要上下文）
+- 「验收标准」不动
+
+### 1.3 改造 `GlobalPropertyForm.tsx`
+
+- 「异常处理 Prompt」：TextArea + 参数条 div → `<PromptMdField ... params={ABNORMAL_HANDLER_PROMPT_PARAMS} />`
+- `ABNORMAL_HANDLER_PROMPT_PARAMS` 常量及注释原地保留
+
+### 1.4 数据流（改造后，与现状同构）
+
+```
+MdEditor onChange
+  → PromptMdField.props.onChange
+  → handleFieldChange / handleAbnormalPromptChange
+  → updateLinkField / 浅克隆 definition
+  → onDefinitionChange(newDef) → ProcessEditor setDefinition
+  → React Flow 重渲染（频率与 TextArea 时代相同）
+```
+
+## 2. 测试设计
+
+### 2.1 单元测试 `PromptMdField.test.tsx`（Vitest + Testing Library）
+
+| 用例 | 场景 | 断言 |
+|------|------|------|
+| test_render_editor | 渲染 | 出现 `.w-md-editor`，value 透传到内部 textarea |
+| test_onChange_passthrough | 编辑 | onChange 被调用且参数为新文本 |
+| test_params_bar_hidden_when_empty | 不传 params | 不渲染"可用参数" |
+| test_param_click_appends_without_focus | 点击参数（jsdom 无真实光标，走兜底或光标路径） | onChange 收到包含参数 key 的文本 |
+| test_extraActions_render | 传 extraActions | 扩展位内容渲染 |
+| test_buildAppendedText_empty | 纯函数：空串 | 直接返回参数文本 |
+| test_buildAppendedText_trailing_newline | 纯函数：末尾有换行 | 不重复补换行 |
+
+> jsdom 环境下 `@uiw/react-md-editor` 渲染为真实 textarea，光标路径用 `selectionStart` 模拟；若组件在 jsdom 挂载异常，则降级为只测纯函数 + 参数点击行为，在实现总结中说明。
+
+### 2.2 Playwright 验证 `frontend/tests/046-process-prompt-md-editor.spec.ts`
+
+1. `make dev` 起服务，访问工艺编辑页（复用现有 spec 的登录/数据准备方式）
+2. 点击环节节点 → 断言属性面板内 `.w-md-editor` 数量 ≥ 2，且「提示词」「评审 Prompt」label 下无 `textarea.ant-input`
+3. 不选节点 → 全局面板「异常处理 Prompt」下存在 `.w-md-editor`
+4. 截图发 PR 评论（不入库）
+
+### 2.3 编译门禁
+
+- `cd frontend && npx tsc --noEmit` 零错误
+- 无 Rust 改动，无需 clippy
+
+## 3. 影响面与风险
+
+| 项 | 结论 |
+|----|------|
+| 后端 | 零改动 |
+| YAML 序列化 | 零改动（字段仍是 string，控件只改变输入方式） |
+| 性能 | 与现状一致（受控逐键更新路径不变） |
+| 主题 | `MdEditor` 内部已做 `data-color-mode` 主题适配，暗色模式自动生效 |
+| 依赖 | 零新增（`@uiw/react-md-editor` 已在依赖中） |
+| 工具栏折行 | 360px 面板已确认接受；`MdEditor` 自带 `minHeight` 保证编辑区可用 |
+| 存量数据 | 存量 prompt 文本为纯字符串，直接回显，无迁移 |
+
+## 4. 安全反思（前置）
+
+- 输入：prompt 为纯文本，MD 编辑器 `preview="edit"` 不渲染 HTML，无 XSS 面
+- 越权：无接口变更，无权限面变化
+- 依赖：`@uiw/react-md-editor` 为既有依赖，供应链面不扩大

--- a/docs/requirements/046-工艺编辑器提示词MD编辑控件-实现总结.md
+++ b/docs/requirements/046-工艺编辑器提示词MD编辑控件-实现总结.md
@@ -1,0 +1,62 @@
+# 046-工艺编辑器提示词MD编辑控件-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI(Kimi) | 2026-07-31 | 初始版本 |
+
+> 对应需求：`docs/requirements/046-工艺编辑器提示词MD编辑控件-需求.md`
+> 对应设计：`docs/design/046-工艺编辑器提示词MD编辑控件-设计.md`
+
+## 1. 实现了什么
+
+工艺可视化编辑器属性面板中的 3 处 prompt 大段文本输入框，由 Ant Design `Input.TextArea` 统一替换为 todo 页同款 MD 编辑控件（`@/components/MdEditor`，基于 `@uiw/react-md-editor`），高度 200px：
+
+| 位置 | 字段 | 改造结果 |
+|------|------|---------|
+| 环节属性面板 | 提示词 `link.prompt` | MD 编辑器，无参数条（保持现状） |
+| 环节属性面板 | 评审 Prompt `link.review_prompt` | MD 编辑器 + 参数条（光标处插入）+ 使用默认值按钮 |
+| 全局面板 | 异常处理 Prompt `abnormal_handler.prompt` | MD 编辑器 + 参数条（光标处插入） |
+
+## 2. 与需求的对应关系
+
+| 需求条目 | 实现 | 验证 |
+|---------|------|------|
+| R-目标1 提示词换 MD 控件 | `LinkPropertyForm` 引入 `PromptMdField`（不传 params） | e2e 用例 1 |
+| R-目标2 评审 Prompt 换 MD 控件，参数条/默认按钮保留 | `PromptMdField` 传 `REVIEW_PROMPT_PARAMS` + `DefaultReviewPromptButton` 作 extraActions | e2e 用例 1 |
+| R-目标3 异常处理 Prompt 换 MD 控件 | `GlobalPropertyForm` 引入 `PromptMdField` 传 `ABNORMAL_HANDLER_PROMPT_PARAMS` | e2e 用例 3 |
+| R-目标4 参数光标处插入 | `PromptMdField.insertAtCursor`（复刻 `TodoDrawer.insertTextAtCursor` 模式），ref 失效兜底 `buildAppendedText` 尾部追加 | e2e 用例 2 + 单测 |
+| R-目标5 面板宽度 360px 不变 | 未触碰 `ProcessEditor` 面板宽度代码 | e2e 通过即证明 |
+
+## 3. 关键实现点
+
+1. **新增共享组件 `PromptMdField`**（`frontend/src/components/process/propertyForms/PromptMdField.tsx`）
+   - 收敛了 Link/Global 两处完全重复的参数插入条 JSX，差异仅参数数组，收敛后样式交互只维护一份
+   - `editorRef` 类型声明为 `MdEditorHandle { textarea?: HTMLTextAreaElement }`，替代 `any`（遵守前端禁止清单 #1），与 `@uiw/react-md-editor` 的 `useImperativeHandle({...state})` 形态对齐
+   - 光标复位用 `setTimeout(0)` 等 React 提交新值后再 `selectionStart/focus`，避免被受控重渲染冲到文末
+2. **信息不丢失**：原 TextArea placeholder 中的使用说明（「环节专属评审模板，可空。非空时整体替代默认评审模板…」）迁移到 `Form.Item tooltip`，因为 `MdEditor` 封装不暴露 placeholder
+3. **导入规范化**：顺带清理了 Link/Global 两个文件中因参数条迁出而不再使用的 antd `Tooltip` 导入
+4. **零依赖新增、零后端改动**：数据流与 TextArea 时代完全同构（受控 → `updateLinkField`/浅克隆 → `onDefinitionChange`）
+
+## 4. 测试与验证结果
+
+| 验证项 | 命令 | 结果 |
+|--------|------|------|
+| 类型检查 | `cd frontend && npx tsc --noEmit` | ✅ 零错误 |
+| 单元测试（新组件） | `npx vitest run …/PromptMdField.test.tsx` | ✅ 8/8（渲染、onChange 透传、参数条显隐、光标插入、extraActions、buildAppendedText×3） |
+| 单元测试（全量） | `npx vitest run` | ✅ 23 文件 167 用例全部通过 |
+| UI 端到端 | `npx playwright test tests/046-process-prompt-md-editor.spec.ts` | ✅ 3/3（环节面板双 MD 编辑器、光标处插入断言 `abc{{original_output}}def`、全局面板 MD 编辑器） |
+
+e2e 踩坑记录：bundled 工艺 complex-refactor 有 9 个阶段横向排布，`fitView` 最小缩放限制下左右节点超出视口，直接点击 `first()` 环节节点超时；改为页内筛选「完整落在视口内」的节点再点击（`clickVisibleLinkNode` helper，已留在 spec 中复用）。
+
+## 5. 安全反思
+
+- **XSS**：编辑器 `preview="edit"` 不渲染 HTML，prompt 全程纯字符串，无注入面
+- **越权**：无接口/权限变更，编辑链路仍是既有 `PUT /api/v1/processes/{guid}`
+- **依赖**：`@uiw/react-md-editor` 为既有依赖，供应链面不扩大
+- **非公开 API 依赖**：`editorRef.current.textarea` 依赖 `@uiw/react-md-editor` 的 imperative handle 形态（非文档化 API）；todo 页已稳定使用同一路径，且失效时自动退化为尾部追加，不会报错阻断用户
+
+## 6. 已知限制 / 待改进
+
+- MD 编辑器工具栏在 360px 窄面板下可能折行（已在需求澄清阶段与用户确认接受，面板宽度保持 360px 是明确决策）
+- 原 TextArea 的 placeholder 提示改由 `Form.Item tooltip` 承载，空编辑器内不再有常驻占位文案（`MdEditor` 封装未暴露 placeholder 入口，按不可修改项约定未改动该封装）
+- e2e 验证依赖开发库中的 bundled 工艺 complex-refactor；若该模板被移除，spec 需更换 PROCESS_GUID 或补种子数据

--- a/docs/requirements/046-工艺编辑器提示词MD编辑控件-需求.md
+++ b/docs/requirements/046-工艺编辑器提示词MD编辑控件-需求.md
@@ -1,0 +1,86 @@
+# 046-工艺编辑器提示词MD编辑控件-需求
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI(Kimi) | 2026-07-31 | 初始版本 |
+
+## 1. 背景（Why）
+
+工艺可视化编辑器（`ProcessEditor`）右侧属性面板中，凡需要填写大段 prompt 文本的字段目前都使用 Ant Design `Input.TextArea`（3~4 行高）：无语法高亮、无工具栏、无 Markdown 预览能力，输入和回读长提示词体验差。而 todo 新建/编辑抽屉（`TodoDrawer`）的 Prompt 字段早已使用基于 `@uiw/react-md-editor` 的 `MdEditor` 控件（`frontend/src/components/todo-drawer/PromptEditor.tsx`），体验良好。用户要求工艺编辑器中的 prompt 输入框统一换成该 MD 编辑控件。
+
+## 2. 目标（What，必须可验证）
+
+- [ ] 环节属性面板（`LinkPropertyForm`）的「提示词」字段由 `Input.TextArea` 替换为 MD 编辑控件，高度 200px
+- [ ] 环节属性面板的「评审 Prompt」字段由 `Input.TextArea` 替换为 MD 编辑控件，高度 200px；下方 `{{参数}}` 快捷插入条与「默认评审模板」按钮保留
+- [ ] 全局面板（`GlobalPropertyForm`）的「异常处理 Prompt」字段由 `Input.TextArea` 替换为 MD 编辑控件，高度 200px；下方 `{{参数}}` 快捷插入条保留
+- [ ] 参数快捷插入的行为由「尾部追加」改为「光标处插入」（与 todo 页 PromptEditor 体验一致）；编辑器未挂载时兜底为尾部追加
+- [ ] 属性面板宽度保持 360px 不变
+
+## 3. 非目标（Explicitly Out of Scope）
+
+- ❌ 不改动「验收标准」字段（`acceptance_criteria`，仍为 TextArea）
+- ❌ 不改动阶段属性面板（`PhasePropertyForm`）的任何字段
+- ❌ 不改动属性面板宽度（保持 360px）、不改动可视化画布区
+- ❌ 不为「提示词」字段新增参数插入条或「从模板创建」按钮（保持现状能力，只换控件）
+- ❌ 不改动后端任何接口、字段与 YAML 序列化逻辑
+- ❌ 不改动 todo 侧 `PromptEditor` 的实现
+
+## 4. 使用场景 / 用户路径
+
+1. 用户进入「工艺」页面，打开任一工艺进入可视化编辑器
+2. 点击画布中的环节节点 → 右侧属性面板展示「环节属性」
+3. 在「提示词」字段的 MD 编辑器中输入大段 Markdown 提示词（可用工具栏加粗/列表/代码块等）
+4. 在「评审 Prompt」字段的 MD 编辑器中编辑评审模板；点击下方 `{{original_output}}` 等参数标签 → 参数插入到编辑器当前光标处
+5. 点击「默认评审模板」按钮 → 默认模板整体覆盖编辑器内容（行为同现状）
+6. 不选中任何节点时属性面板显示全局面板，「异常处理 Prompt」同样使用 MD 编辑器，参数同样光标处插入
+7. 保存工艺 → YAML 中 `prompt` / `review_prompt` / `abnormal_handler.prompt` 内容与编辑器文本一致（纯文本，无格式损失）
+
+## 5. 功能需求清单（Checklist）
+
+- [ ] F1 新建共享组件 `PromptMdField`：封装 `MdEditor` + 可选参数插入条 + 可选扩展操作位，支持 editorRef 光标处插入
+- [ ] F2 `LinkPropertyForm`「提示词」：`Input.TextArea` → `PromptMdField`（无参数条）
+- [ ] F3 `LinkPropertyForm`「评审 Prompt」：`Input.TextArea` + 内联参数条 → `PromptMdField`（参数 `REVIEW_PROMPT_PARAMS`，扩展位放 `DefaultReviewPromptButton`）
+- [ ] F4 `GlobalPropertyForm`「异常处理 Prompt」：`Input.TextArea` + 内联参数条 → `PromptMdField`（参数 `ABNORMAL_HANDLER_PROMPT_PARAMS`）
+- [ ] F5 参数插入逻辑：有 textarea 光标位置时在光标处插入并恢复光标聚焦；无 textarea 时尾部追加（保持空值/换行边界处理与现状一致）
+- [ ] F6 单元测试覆盖 `PromptMdField` 的渲染、onChange 透传、参数插入两条路径、扩展位渲染
+- [ ] F7 Playwright 验证：环节面板与全局面板均出现 `.w-md-editor`，原 TextArea 消失
+
+## 6. 约束条件
+
+- 技术约束：复用现有 `@/components/MdEditor`（`@uiw/react-md-editor`），**不新增 npm 依赖**；编辑器高度 200px
+- 架构约束：数据流不变——受控 `value`/`onChange` → `updateLinkField` / 浅克隆 → `onDefinitionChange`，与现 TextArea 路径完全一致
+- 样式约束：参数插入条视觉样式与现状一致（`code` 标签 + hover 变色，主题变量配色）；跨目录导入一律 `@/` 绝对路径
+- 安全约束：prompt 文本按纯字符串处理，不引入 HTML 渲染，无 XSS 面
+- 质量约束：`npx tsc --noEmit` 零错误；新增代码逐行注释；公开函数有单元测试
+
+## 7. 可修改 / 不可修改项
+
+- ❌ 不可修改：后端接口与数据模型、`@/components/MdEditor` 组件本身、todo 侧 `PromptEditor`、属性面板宽度（360px）
+- ✅ 可调整：`PromptMdField` 组件内部实现细节、参数条的具体布局、单元测试组织方式
+
+## 8. 接口与数据约定
+
+无后端接口变更。前端数据约定：
+
+- `link.prompt` / `link.review_prompt` / `abnormal_handler.prompt` 均为 `string | undefined`，编辑器受控值空时用 `''` 兜底（与现状一致）
+- `onDefinitionChange` 契约不变：每次编辑产生新的 `ProcessDefinition` 对象（不可变更新）
+
+## 9. 验收标准（Acceptance Criteria）
+
+- 如果打开环节属性面板，则「提示词」「评审 Prompt」显示为 MD 编辑器（存在 `.w-md-editor` DOM），且不存在对应 `textarea.ant-input`
+- 如果在「评审 Prompt」编辑器中将光标置于文本中间并点击参数标签，则参数插入到光标处而非文本末尾
+- 如果点击「默认评审模板」按钮，则编辑器内容被默认模板整体覆盖
+- 如果打开全局面板，则「异常处理 Prompt」显示为 MD 编辑器，参数点击同样在光标处插入
+- 如果编辑任意字段后保存工艺，则 YAML 对应字段内容与编辑结果一致
+- 如果运行 `cd frontend && npx tsc --noEmit`，则零错误
+- 如果运行前端单元测试，则 `PromptMdField` 相关测试全部通过
+
+## 10. 风险与已知不确定点
+
+- 风险：属性面板 360px 宽下 MD 编辑器工具栏可能折行——已在澄清阶段确认接受（用户明确保持 360px）
+- 风险：`@uiw/react-md-editor` 的 ref 暴露 `textarea` 为非公开 API——todo 页已稳定使用同一路径（`TodoDrawer.insertTextAtCursor`），按既有实现复刻；若失效则退化为尾部追加，不会报错阻断
+- 不确定点：Playwright 验证依赖开发库中存在工艺数据；若无数据，按 `frontend/tests/` 现有 spec 的方式构造前置数据或跳过 e2e 改以单元测试覆盖，并在实现总结中说明
+
+## 11. 非目标
+
+同第 3 节。特别强调：本需求不新增任何 prompt 能力（模板、参数种类均不新增），只做控件替换与参数插入行为对齐。

--- a/frontend/src/components/process/propertyForms/GlobalPropertyForm.tsx
+++ b/frontend/src/components/process/propertyForms/GlobalPropertyForm.tsx
@@ -21,10 +21,11 @@ import {
   InputNumber,
   Checkbox,
   Collapse,
-  Tooltip,
   Typography,
 } from 'antd';
 import type { ProcessDefinition } from '@/types/process';
+// 需求 046：prompt 类字段统一改用 MD 编辑控件（含参数条的光标插入）
+import { PromptMdField } from './PromptMdField';
 
 const { Text } = Typography;
 
@@ -225,51 +226,13 @@ export function GlobalPropertyForm({
         label="异常处理 Prompt"
         tooltip="环路异常终止（超步数/超Token/失败）时执行此提示词。可用下方参数占位符"
       >
-        <Input.TextArea
+        {/* 需求 046：由 TextArea 升级为 MD 编辑器（200px）；
+            参数插入条迁入 PromptMdField，插入行为由尾部追加升级为光标处插入（对齐 todo 页） */}
+        <PromptMdField
           value={abnormalHandler.prompt ?? ''}
-          onChange={(e) => handleAbnormalPromptChange(e.target.value)}
-          rows={4}
-          placeholder="异常发生时执行的补救/清理提示词，可空。可用 {{abnormal_status}}、{{error_detail}} 等占位符"
+          onChange={handleAbnormalPromptChange}
+          params={ABNORMAL_HANDLER_PROMPT_PARAMS}
         />
-        {/* 快速插入参数条：点击把 {{key}} 追加到异常处理 prompt 尾部，与评审 prompt 参数条样式一致 */}
-        <div style={{
-          marginTop: 8,
-          display: 'flex',
-          flexWrap: 'wrap',
-          gap: 6,
-          alignItems: 'center',
-        }}>
-          <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginRight: 2 }}>可用参数:</span>
-          {ABNORMAL_HANDLER_PROMPT_PARAMS.map((p) => (
-            <Tooltip key={p.key} title={p.desc}>
-              <code
-                onClick={() => handleAbnormalPromptChange(
-                  (abnormalHandler.prompt ?? '') + (abnormalHandler.prompt?.endsWith(' ') || !abnormalHandler.prompt ? '' : ' ') + p.key + ' ',
-                )}
-                style={{
-                  fontSize: 11,
-                  padding: '1px 6px',
-                  borderRadius: 4,
-                  background: 'var(--color-fill-quaternary)',
-                  border: '1px solid var(--color-border-secondary)',
-                  cursor: 'pointer',
-                  color: 'var(--color-text-secondary)',
-                  transition: 'all 0.2s',
-                }}
-                onMouseEnter={(e) => {
-                  (e.currentTarget as HTMLElement).style.borderColor = 'var(--color-primary)';
-                  (e.currentTarget as HTMLElement).style.color = 'var(--color-primary)';
-                }}
-                onMouseLeave={(e) => {
-                  (e.currentTarget as HTMLElement).style.borderColor = 'var(--color-border-secondary)';
-                  (e.currentTarget as HTMLElement).style.color = 'var(--color-text-secondary)';
-                }}
-              >
-                {p.key}
-              </code>
-            </Tooltip>
-          ))}
-        </div>
       </Form.Item>
 
 

--- a/frontend/src/components/process/propertyForms/LinkPropertyForm.tsx
+++ b/frontend/src/components/process/propertyForms/LinkPropertyForm.tsx
@@ -22,11 +22,12 @@ import {
   Button,
   Table,
   Space,
-  Tooltip,
   Typography,
 } from 'antd';
 import { DeleteOutlined, PlusOutlined, CloseOutlined } from '@ant-design/icons';
 import { DefaultReviewPromptButton } from '@/components/common/DefaultReviewPromptButton';
+// 需求 046：prompt 类字段统一改用 MD 编辑控件（含参数条的光标插入）
+import { PromptMdField } from './PromptMdField';
 import type {
   ProcessDefinition,
   LinkDefinition,
@@ -384,12 +385,12 @@ export function LinkPropertyForm({
         />
       </Form.Item>
 
+      {/* 提示词：需求 046 由 TextArea 升级为 MD 编辑器（200px）。
+          不传 params：该字段现状无参数条，保持能力不扩张（YAGNI） */}
       <Form.Item label="提示词">
-        <Input.TextArea
+        <PromptMdField
           value={link.prompt ?? ''}
-          onChange={(e) => handleFieldChange('prompt', e.target.value)}
-          rows={3}
-          placeholder="提示词，可空"
+          onChange={(v) => handleFieldChange('prompt', v)}
         />
       </Form.Item>
 
@@ -433,56 +434,22 @@ export function LinkPropertyForm({
         />
       </Form.Item>
 
-      <Form.Item label="评审 Prompt">
-        <Input.TextArea
+      {/* 评审 Prompt：需求 046 升级为 MD 编辑器（200px）。
+          原 TextArea placeholder 中的使用说明迁移到 Form.Item tooltip，避免提示信息丢失；
+          参数插入条迁入 PromptMdField，插入行为由尾部追加升级为光标处插入（对齐 todo 页）。 */}
+      <Form.Item
+        label="评审 Prompt"
+        tooltip="环节专属评审模板，可空。非空时整体替代默认评审模板；可用下方参数占位符"
+      >
+        <PromptMdField
           value={link.review_prompt ?? ''}
-          onChange={(e) => handleFieldChange('review_prompt', e.target.value)}
-          rows={4}
-          placeholder="环节专属评审模板，可空。非空时整体替代默认评审模板；可用 {{original_output}}、{{acceptance_criteria}} 等占位符"
+          onChange={(v) => handleFieldChange('review_prompt', v)}
+          params={REVIEW_PROMPT_PARAMS}
+          extraActions={
+            /* 一键填入系统默认评审 prompt（DEFAULT_REVIEWER_PROMPT 常量），直接覆盖原内容 */
+            <DefaultReviewPromptButton onApply={(t) => handleFieldChange('review_prompt', t)} />
+          }
         />
-        {/* 快速插入参数条：点击模板将 {{key}} 追加到评审 prompt 尾部。
-            与 todo 编辑区的 prompt 参数快速输入条样式一致。 */}
-        <div style={{
-          marginTop: 8,
-          display: 'flex',
-          flexWrap: 'wrap',
-          gap: 6,
-          alignItems: 'center',
-        }}>
-          <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginRight: 2 }}>可用参数:</span>
-          {REVIEW_PROMPT_PARAMS.map(p => (
-            <Tooltip key={p.key} title={p.desc}>
-              <code
-                onClick={() => handleFieldChange(
-                  'review_prompt',
-                  (link.review_prompt ?? '') + (link.review_prompt?.endsWith(' ') || !link.review_prompt ? '' : ' ') + p.key + ' ',
-                )}
-                style={{
-                  fontSize: 11,
-                  padding: '1px 6px',
-                  borderRadius: 4,
-                  background: 'var(--color-fill-quaternary)',
-                  border: '1px solid var(--color-border-secondary)',
-                  cursor: 'pointer',
-                  color: 'var(--color-text-secondary)',
-                  transition: 'all 0.2s',
-                }}
-                onMouseEnter={(e) => {
-                  (e.currentTarget as HTMLElement).style.borderColor = 'var(--color-primary)';
-                  (e.currentTarget as HTMLElement).style.color = 'var(--color-primary)';
-                }}
-                onMouseLeave={(e) => {
-                  (e.currentTarget as HTMLElement).style.borderColor = 'var(--color-border-secondary)';
-                  (e.currentTarget as HTMLElement).style.color = 'var(--color-text-secondary)';
-                }}
-              >
-                {p.key}
-              </code>
-            </Tooltip>
-          ))}
-          {/* 一键填入系统默认评审 prompt（DEFAULT_REVIEWER_PROMPT 常量），直接覆盖原内容 */}
-          <DefaultReviewPromptButton onApply={(t) => handleFieldChange('review_prompt', t)} />
-        </div>
       </Form.Item>
 
       <Form.Item label="成功后跳转">

--- a/frontend/src/components/process/propertyForms/PromptMdField.test.tsx
+++ b/frontend/src/components/process/propertyForms/PromptMdField.test.tsx
@@ -1,0 +1,104 @@
+// PromptMdField 单元测试。
+// 覆盖（需求 046 验收标准对应）：
+// - 渲染：MD 编辑器出现且受控值透传到内部 textarea；
+// - 编辑：onChange 原样透传新文本；
+// - 参数条：不传 params 时不渲染；点击参数在光标处插入（jsdom 下 textarea 存在，走光标路径）；
+// - 扩展位：extraActions 渲染且此时不显示「可用参数」标签；
+// - buildAppendedText 纯函数：空值 / 末尾有换行 / 末尾无换行三条边界。
+// mock 掉 useTheme：MdEditor 内部只消费 themeMode，mock 后无需包 ThemeProvider，保持用例聚焦。
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// mock useTheme，返回固定亮色模式，避免 ThemeProvider 依赖与 jsdom matchMedia 缺失问题
+vi.mock('@/hooks/useTheme', () => ({
+  useTheme: () => ({ themeMode: 'light' }),
+}));
+
+import { PromptMdField, buildAppendedText } from './PromptMdField';
+
+// 测试用参数集：与生产参数同构（key 为插入文本，desc 为 Tooltip 说明）
+const TEST_PARAMS = [{ key: '{{original_output}}', desc: '执行输出' }];
+
+describe('PromptMdField 渲染与编辑', () => {
+  it('渲染 MD 编辑器且受控值透传到内部 textarea', () => {
+    const { container } = render(
+      <PromptMdField value="初始提示词" onChange={() => {}} />,
+    );
+    // .w-md-editor 是 @uiw/react-md-editor 的根容器 class，作为「已换成 MD 控件」的断言锚点
+    expect(container.querySelector('.w-md-editor')).not.toBeNull();
+    // 受控值必须出现在内部 textarea 上，保证既有 prompt 文本原样回显
+    const textarea = container.querySelector('textarea');
+    expect(textarea).not.toBeNull();
+    expect(textarea!.value).toBe('初始提示词');
+  });
+
+  it('编辑内容时 onChange 原样透传新文本', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <PromptMdField value="" onChange={onChange} />,
+    );
+    const textarea = container.querySelector('textarea');
+    // 模拟用户输入：fireEvent.change 触发 @uiw 内部 onChange → 组件 onChange
+    fireEvent.change(textarea!, { target: { value: '新内容' } });
+    expect(onChange).toHaveBeenCalledWith('新内容');
+  });
+});
+
+describe('PromptMdField 参数条', () => {
+  it('不传 params 且不传 extraActions 时不渲染参数条', () => {
+    render(<PromptMdField value="abc" onChange={() => {}} />);
+    // 「提示词」字段场景：保持现状无参数条，断言标签不存在
+    expect(screen.queryByText('可用参数:')).toBeNull();
+  });
+
+  it('点击参数在光标处插入而非尾部追加', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <PromptMdField
+        value="hello world"
+        onChange={onChange}
+        params={TEST_PARAMS}
+      />,
+    );
+    const textarea = container.querySelector('textarea');
+    expect(textarea).not.toBeNull();
+    // 把光标移到 "hello " 与 "world" 之间（index 6），模拟用户在文本中间点击参数
+    textarea!.selectionStart = 6;
+    textarea!.selectionEnd = 6;
+    fireEvent.click(screen.getByText('{{original_output}}'));
+    // 光标路径：onChange 收到切片插入后的完整文本
+    expect(onChange).toHaveBeenCalledWith('hello {{original_output}}world');
+  });
+
+  it('extraActions 渲染且不显示「可用参数」标签', () => {
+    render(
+      <PromptMdField
+        value=""
+        onChange={() => {}}
+        extraActions={<button>使用默认值</button>}
+      />,
+    );
+    // 扩展位内容（如 DefaultReviewPromptButton）必须渲染出来
+    expect(screen.getByText('使用默认值')).toBeInTheDocument();
+    // 没有参数时不渲染参数标签，避免空标签造成视觉噪音
+    expect(screen.queryByText('可用参数:')).toBeNull();
+  });
+});
+
+describe('buildAppendedText 尾部追加纯函数', () => {
+  it('空文本直接返回插入内容', () => {
+    // 空串不需要任何分隔符，避免产生前导换行
+    expect(buildAppendedText('', '{{x}}')).toBe('{{x}}');
+  });
+
+  it('末尾有换行时不重复补换行', () => {
+    // 防止多次追加累积空行
+    expect(buildAppendedText('abc\n', '{{x}}')).toBe('abc\n{{x}}');
+  });
+
+  it('末尾无换行时先补换行再追加', () => {
+    // 参数独立成行，避免粘连破坏 prompt 语义
+    expect(buildAppendedText('abc', '{{x}}')).toBe('abc\n{{x}}');
+  });
+});

--- a/frontend/src/components/process/propertyForms/PromptMdField.tsx
+++ b/frontend/src/components/process/propertyForms/PromptMdField.tsx
@@ -1,0 +1,169 @@
+// PromptMdField.tsx
+// ---------------------------------------------------------------------------
+// 需求 046：工艺编辑器 prompt 字段的 MD 编辑控件封装。
+//
+// 设计意图（对应 docs/design/046-工艺编辑器提示词MD编辑控件-设计.md §1.1）：
+// - 复用 @/components/MdEditor（todo 页同款 @uiw/react-md-editor 封装），
+//   把工艺属性面板中的大段 prompt 输入从 TextArea 升级为带工具栏的 MD 编辑器；
+// - 收敛 LinkPropertyForm / GlobalPropertyForm 两处完全重复的「参数插入条」JSX，
+//   两者的差异仅是参数数组，收敛后样式与交互只维护一份；
+// - 参数插入由「尾部追加」升级为「光标处插入」，对齐 TodoDrawer.insertTextAtCursor
+//   已在生产验证的既有模式。
+//
+// 数据流（受控，与 TextArea 时代同构，调用方零改动）：
+//   MdEditor onChange → props.onChange → updateLinkField/浅克隆 → onDefinitionChange
+// ---------------------------------------------------------------------------
+
+import { useRef, type CSSProperties, type JSX, type ReactNode } from 'react';
+import { Tooltip } from 'antd';
+import { MdEditor } from '@/components/MdEditor';
+
+// 可插入参数的描述结构：key 为点击后插入编辑器的占位符文本，desc 为 Tooltip 说明。
+// 调用方的参数数组允许带多余字段（如 LinkPropertyForm 的 label），结构化类型天然兼容。
+export interface PromptParam {
+  key: string;
+  desc: string;
+}
+
+export interface PromptMdFieldProps {
+  // 受控文本；调用方用 ?? '' 兜底 undefined，与 TextArea 时代的受控契约一致
+  value: string;
+  // 变更回调：直通既有 handleFieldChange 链路，组件内不做任何加工
+  onChange: (value: string) => void;
+  // 可插入参数列表；缺省或空数组时不渲染参数条
+  // （「提示词」字段现状就没有参数条，保持能力不扩张，YAGNI）
+  params?: PromptParam[];
+  // 参数条尾部扩展位（如评审 Prompt 的 DefaultReviewPromptButton）
+  extraActions?: ReactNode;
+  // 编辑器高度，默认 200（需求 046 锁定值，与 todo 页 PromptEditor 一致）
+  height?: number;
+}
+
+// @uiw/react-md-editor 通过 useImperativeHandle 暴露 {...state, container, dispatch}，
+// 其中 state.textarea 是内部 HTMLTextAreaElement（TodoDrawer 光标插入已依赖此形态）。
+// 这里只声明组件真正依赖的字段，避免使用 any（前端禁止清单 #1）。
+interface MdEditorHandle {
+  textarea?: HTMLTextAreaElement;
+}
+
+// 尾部追加的纯函数：空串直接返回插入文本；末尾无换行时先补换行，
+// 避免参数粘连在既有文本尾部导致 prompt 语义被破坏。
+// 抽成独立导出纯函数，是为了单元测试可脱离 jsdom 编辑器环境直接断言边界行为。
+export function buildAppendedText(prev: string, text: string): string {
+  // 空值时无需任何分隔，直接以插入文本起步
+  if (!prev) return text;
+  // 已有换行结尾则不重复补，保证多次追加不会累积空行
+  return prev.endsWith('\n') ? prev + text : prev + '\n' + text;
+}
+
+export function PromptMdField({
+  value,
+  onChange,
+  params,
+  extraActions,
+  height = 200,
+}: PromptMdFieldProps): JSX.Element {
+  // 透传给 MdEditor 的 ref，用于读取/恢复内部 textarea 的光标位置
+  const editorRef = useRef<MdEditorHandle>(null);
+
+  // 参数点击 → 光标处插入。
+  // 优先走 textarea 光标路径；ref 失效（未挂载/@uiw 内部结构变化）时兜底尾部追加，
+  // 退化为改造前行为，保证功能可用不报错。
+  const insertAtCursor = (text: string): void => {
+    const textarea = editorRef.current?.textarea;
+    if (!textarea) {
+      onChange(buildAppendedText(value, text));
+      return;
+    }
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    // 以最新受控 value 为单一数据源做切片插入，不读 DOM value，避免受控/DOM 不一致
+    onChange(value.substring(0, start) + text + value.substring(end));
+    // setTimeout(0)：等 React 把新 value 提交到 DOM 后再复位光标，
+    // 否则光标会被受控重渲染冲到文本末尾（TodoDrawer 同款处理）
+    setTimeout(() => {
+      textarea.selectionStart = textarea.selectionEnd = start + text.length;
+      textarea.focus();
+    }, 0);
+  };
+
+  // hover 高亮提取为独立处理函数：避免在每个 code 标签上重复两坨内联事件体，
+  // 也让 JSX 保持干净（组件编写规范 §4：复杂逻辑抽离）
+  const handleParamMouseEnter = (e: React.MouseEvent<HTMLElement>): void => {
+    // 用主题变量而非硬编码颜色，暗色主题下自动跟随（禁止清单 #10）
+    e.currentTarget.style.borderColor = 'var(--color-primary)';
+    e.currentTarget.style.color = 'var(--color-primary)';
+  };
+  const handleParamMouseLeave = (e: React.MouseEvent<HTMLElement>): void => {
+    // 恢复默认配色，与 paramCodeStyle 中的初始值保持一致
+    e.currentTarget.style.borderColor = 'var(--color-border-secondary)';
+    e.currentTarget.style.color = 'var(--color-text-secondary)';
+  };
+
+  // 参数条的渲染条件：有参数或有扩展操作。
+  // 只有 extraActions 没有参数时也渲染（按钮需要落点），两者皆无则整条不渲染
+  const showParamsBar = (params && params.length > 0) || Boolean(extraActions);
+
+  return (
+    <div>
+      <MdEditor
+        value={value}
+        onChange={onChange}
+        height={height}
+        editorRef={editorRef}
+      />
+      {showParamsBar && (
+        <div style={paramsBarStyle}>
+          {params && params.length > 0 && (
+            <>
+              <span style={paramsLabelStyle}>可用参数:</span>
+              {params.map((p) => (
+                <Tooltip key={p.key} title={p.desc}>
+                  <code
+                    onClick={() => insertAtCursor(p.key)}
+                    style={paramCodeStyle}
+                    onMouseEnter={handleParamMouseEnter}
+                    onMouseLeave={handleParamMouseLeave}
+                  >
+                    {p.key}
+                  </code>
+                </Tooltip>
+              ))}
+            </>
+          )}
+          {extraActions}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── 样式 ──────────────────────────────────────────
+// 以下样式迁移自 LinkPropertyForm/GlobalPropertyForm 两处重复的参数条内联样式，
+// 保持视觉完全一致；颜色全部走主题变量，暗色模式自动适配。
+
+const paramsBarStyle: CSSProperties = {
+  // 与编辑器拉开 8px 间距，可换行排列以适配 360px 窄面板
+  marginTop: 8,
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 6,
+  alignItems: 'center',
+};
+
+const paramsLabelStyle: CSSProperties = {
+  fontSize: 12,
+  color: 'var(--color-text-tertiary)',
+  marginRight: 2,
+};
+
+const paramCodeStyle: CSSProperties = {
+  fontSize: 11,
+  padding: '1px 6px',
+  borderRadius: 4,
+  background: 'var(--color-fill-quaternary)',
+  border: '1px solid var(--color-border-secondary)',
+  cursor: 'pointer',
+  color: 'var(--color-text-secondary)',
+  transition: 'all 0.2s',
+};

--- a/frontend/tests/046-process-prompt-md-editor.spec.ts
+++ b/frontend/tests/046-process-prompt-md-editor.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * 046 工艺编辑器提示词 MD 编辑控件 — UI 端到端验证。
+ *
+ * 测试范围：
+ * 1. 环节属性面板：「提示词」「评审 Prompt」渲染为 MD 编辑器（.w-md-editor），原 antd TextArea 消失，
+ *    且评审参数条与「使用默认值」按钮保留；
+ * 2. 「评审 Prompt」参数点击在光标处插入（需求 046 关键行为：由尾部追加升级为光标插入）；
+ * 3. 全局面板：「异常处理 Prompt」渲染为 MD 编辑器，参数条保留。
+ *
+ * 数据准备：直接复用开发库既有工艺 complex-refactor（bundled 模板，含多环节），无需种子数据。
+ *
+ * 关键约定：
+ * - 工艺编辑页路由为 hash 形式 #/processes?processMode=edit&guid=<guid>（App.tsx useViewState）；
+ * - React Flow 环节节点 data-id 以 link- 开头（processGraphBuilder 的节点 id 约定 link-${i}-${j}）；
+ * - 画布配置 fitView，所有节点初始落在可视区内，可直接点击；
+ * - 默认无选中节点 → 属性面板渲染全局表单（ProcessPropertyPanel 路由规则）。
+ */
+
+import { test, expect } from '@playwright/test';
+
+// 开发服务地址（make dev 默认端口）
+const BASE = 'http://localhost:18088';
+// 开发库既有 bundled 工艺模板，多环节结构稳定，适合做编辑器验证
+const PROCESS_GUID = '8b986558-c5a4-4477-a0da-8a5b8f444194';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(`${BASE}/#/processes?processMode=edit&guid=${PROCESS_GUID}`);
+  // 环节节点出现 = 工艺定义已加载 + 可视化画布已渲染，此时属性面板也已就绪
+  await page.waitForSelector('.react-flow__node[data-id^="link-"]', { timeout: 15000 });
+});
+
+/**
+ * 点击第一个「完整落在视口内」的环节节点。
+ * 超宽工艺（如 9 阶段的 complex-refactor）在 fitView 最小缩放限制下左右会超出视口，
+ * 直接点 first() 会命中视口外节点导致 Playwright 点击超时，因此先页内筛选可视节点。
+ */
+async function clickVisibleLinkNode(page: import('@playwright/test').Page): Promise<void> {
+  const visibleLinkId = await page.evaluate(() => {
+    for (const el of document.querySelectorAll('.react-flow__node[data-id^="link-"]')) {
+      const r = el.getBoundingClientRect();
+      if (r.left >= 0 && r.top >= 0 && r.right <= window.innerWidth && r.bottom <= window.innerHeight) {
+        return el.getAttribute('data-id');
+      }
+    }
+    return null;
+  });
+  // 画布已 fitView 渲染环节节点，视口内必然存在至少一个可点击节点
+  if (!visibleLinkId) throw new Error('视口内未找到可点击的环节节点');
+  await page.locator(`.react-flow__node[data-id="${visibleLinkId}"]`).click();
+}
+
+test('环节属性面板的提示词与评审 Prompt 均为 MD 编辑器', async ({ page }) => {
+  // 点击视口内的环节节点 → 右侧属性面板切换为环节属性表单
+  await clickVisibleLinkNode(page);
+
+  // 「提示词」Form.Item：必须是 MD 编辑器，且不再有 antd TextArea
+  const promptItem = page.locator('.ant-form-item').filter({
+    has: page.locator('label[title="提示词"]'),
+  });
+  await expect(promptItem.locator('.w-md-editor')).toHaveCount(1);
+  await expect(promptItem.locator('textarea.ant-input')).toHaveCount(0);
+
+  // 「评审 Prompt」Form.Item：必须是 MD 编辑器，原 TextArea 消失
+  const reviewItem = page.locator('.ant-form-item').filter({
+    has: page.locator('label[title="评审 Prompt"]'),
+  });
+  await expect(reviewItem.locator('.w-md-editor')).toHaveCount(1);
+  await expect(reviewItem.locator('textarea.ant-input')).toHaveCount(0);
+
+  // 参数条与「使用默认值」按钮必须保留（改造只换控件，不削减既有能力）
+  await expect(reviewItem.getByText('{{original_output}}')).toBeVisible();
+  await expect(reviewItem.getByText('使用默认值')).toBeVisible();
+});
+
+test('评审 Prompt 参数点击在光标处插入', async ({ page }) => {
+  await clickVisibleLinkNode(page);
+
+  const reviewItem = page.locator('.ant-form-item').filter({
+    has: page.locator('label[title="评审 Prompt"]'),
+  });
+  // @uiw/react-md-editor 内部是真实 textarea，可直接 fill 驱动受控值
+  const editorTextarea = reviewItem.locator('.w-md-editor textarea');
+  await editorTextarea.waitFor();
+
+  // 填入基准文本并等受控值回流，确保后续切片基于最新 value
+  await editorTextarea.fill('abcdef');
+  await expect(editorTextarea).toHaveValue('abcdef');
+
+  // 光标放到 index 3（abc|def 之间），模拟用户在文本中间点击参数
+  await editorTextarea.evaluate((el) => {
+    const t = el as HTMLTextAreaElement;
+    t.focus();
+    t.selectionStart = 3;
+    t.selectionEnd = 3;
+  });
+  await reviewItem.getByText('{{original_output}}').click();
+
+  // 光标处插入的期望结果：abc{{original_output}}def（尾部追加则会是 abcdef{{original_output}}）
+  await expect(editorTextarea).toHaveValue('abc{{original_output}}def');
+});
+
+test('全局面板的异常处理 Prompt 为 MD 编辑器', async ({ page }) => {
+  // 默认无选中节点 → 属性面板即为全局表单，无需额外操作
+  const abnormalItem = page.locator('.ant-form-item').filter({
+    has: page.locator('label[title="异常处理 Prompt"]'),
+  });
+  await abnormalItem.waitFor();
+  await expect(abnormalItem.locator('.w-md-editor')).toHaveCount(1);
+  await expect(abnormalItem.locator('textarea.ant-input')).toHaveCount(0);
+
+  // 异常处理参数条必须保留
+  await expect(abnormalItem.getByText('{{abnormal_status}}')).toBeVisible();
+});


### PR DESCRIPTION
## 实现了什么

工艺可视化编辑器属性面板的 3 处 prompt 大段输入框由 `Input.TextArea` 统一替换为 todo 页同款 MD 编辑控件（`@uiw/react-md-editor`，200px）：

| 位置 | 字段 | 改造结果 |
|------|------|---------|
| 环节属性面板 | 提示词 `prompt` | MD 编辑器 |
| 环节属性面板 | 评审 Prompt `review_prompt` | MD 编辑器 + 参数条（**光标处插入**）+ 使用默认值按钮 |
| 全局面板 | 异常处理 Prompt `abnormal_handler.prompt` | MD 编辑器 + 参数条（**光标处插入**） |

## 与需求的对应关系

- 需求：`docs/requirements/046-工艺编辑器提示词MD编辑控件-需求.md`
- 设计：`docs/design/046-工艺编辑器提示词MD编辑控件-设计.md`
- 实现总结：`docs/requirements/046-工艺编辑器提示词MD编辑控件-实现总结.md`

## 关键实现点

1. 新增共享组件 `PromptMdField`：收敛 Link/Global 两处重复的参数插入条 JSX；`editorRef` 用结构化类型替代 `any`
2. 参数插入复刻 `TodoDrawer.insertTextAtCursor` 成熟模式：textarea 光标处插入 + `setTimeout(0)` 复位光标；ref 失效兜底尾部追加
3. 原 TextArea placeholder 使用说明迁移至 `Form.Item tooltip`，信息不丢失
4. 零依赖新增、零后端改动、数据流与 TextArea 时代同构

## 测试与验证结果

| 验证项 | 结果 |
|--------|------|
| `npx tsc --noEmit` | ✅ 零错误 |
| vitest 新组件 | ✅ 8/8 |
| vitest 全量 | ✅ 167/167（23 文件） |
| Playwright `tests/046-process-prompt-md-editor.spec.ts` | ✅ 3/3（环节面板双 MD 编辑器、光标插入断言 `abc{{original_output}}def`、全局面板 MD 编辑器） |

## 已知限制

- MD 编辑器工具栏在 360px 窄面板下可能折行（需求澄清阶段已确认接受，面板宽度不变是明确决策）
- 原 placeholder 常驻提示改为 label tooltip 承载（`MdEditor` 封装未暴露 placeholder 入口）
- `editorRef.current.textarea` 依赖 @uiw 非文档化 imperative handle，失效时自动退化为尾部追加不报错