### PR TITLE
refactor(048): 废弃 review_type，统一 gate_config

### DIFF
--- a/backend/src/db/entity/loop_steps.rs
+++ b/backend/src/db/entity/loop_steps.rs
@@ -25,9 +25,6 @@ pub struct Model {
     pub on_rating_fail: String,
     /// on_rating_fail="goto" 时的目标 step_id
     pub fail_goto_step_id: Option<i64>,
-    /// 评审类型: "ai" = AI 自动评审, "human" = 人工审批（默认 "ai"）
-    #[sea_orm(default_value = "ai")]
-    pub review_type: String,
     /// 环节级评审模板正文（完整模板，含占位符）；NULL = 未设置，评审时回退到环路级/默认。
     pub review_prompt: Option<String>,
     /// 所属阶段 ID，NULL 表示未分组（兼容旧 Loop）。

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -368,7 +368,6 @@ impl Database {
                     None, // success_goto 第二遍再补
                     &s.on_rating_fail,
                     None, // fail_goto 第二遍再补
-                    &s.review_type,
                 )
                 .await?;
 
@@ -691,7 +690,6 @@ impl Database {
         success_goto_step_id: Option<i64>,
         on_rating_fail: &str,
         fail_goto_step_id: Option<i64>,
-        review_type: &str,
     ) -> Result<loop_steps::Model, sea_orm::DbErr> {
         // 自动分配 order_index: 当前最大 + 1
         let next_order = self
@@ -716,7 +714,6 @@ impl Database {
             success_goto_step_id: ActiveValue::Set(success_goto_step_id),
             on_rating_fail: ActiveValue::Set(on_rating_fail.to_string()),
             fail_goto_step_id: ActiveValue::Set(fail_goto_step_id),
-            review_type: ActiveValue::Set(review_type.to_string()),
             created_at: ActiveValue::Set(Some(now)),
             ..Default::default()
         };
@@ -1231,7 +1228,6 @@ impl Database {
         let sql = format!(
             "SELECT s.id, s.loop_id, s.name, s.description, s.order_index, s.todo_id, \
                     s.on_success, s.success_goto_step_id, s.on_rating_fail, s.fail_goto_step_id, \
-                    s.review_type, \
                     s.phase_id, s.expected_artifacts, s.gate_config, s.max_rework, \
                     s.skill_names, s.expert_name, s.review_prompt, \
                     s.enabled, s.created_at, \
@@ -1262,7 +1258,6 @@ impl Database {
                 success_goto_step_id: row.try_get_by::<Option<i64>, _>("success_goto_step_id")?,
                 on_rating_fail: row.try_get_by::<String, _>("on_rating_fail")?,
                 fail_goto_step_id: row.try_get_by::<Option<i64>, _>("fail_goto_step_id")?,
-                review_type: row.try_get_by::<String, _>("review_type")?,
                 phase_id: row.try_get_by::<Option<i64>, _>("phase_id")?,
                 expected_artifacts: row.try_get_by::<String, _>("expected_artifacts")?,
                 gate_config: row.try_get_by::<String, _>("gate_config")?,
@@ -1770,22 +1765,20 @@ mod loop_step_count_tests {
         let todo_id = seed_todo(&db, "环节todo").await;
         let free_todo = seed_todo(&db, "自由todo").await;
         let loop_id = seed_loop(&db, "L").await;
-        // 044：min_rating 列已下线，闸门改由 gate_config 表达；这里只验证反查命中与 review_type
         db.exec(&format!(
-            "INSERT INTO loop_steps (loop_id, name, todo_id, enabled, review_type) \
-             VALUES ({loop_id}, 's', {todo_id}, 1, 'ai')"
+            "INSERT INTO loop_steps (loop_id, name, todo_id, enabled) \
+             VALUES ({loop_id}, 's', {todo_id}, 1)"
         ))
         .await
         .expect("insert step");
 
-        // 命中：返回该 step，review_type=ai（原 min_rating 闸门语义已迁到 gate_config）
+        // 命中：返回该 step
         let found = db
             .find_loop_step_by_todo_id(todo_id)
             .await
             .unwrap()
             .expect("step should exist");
         assert_eq!(found.todo_id, todo_id);
-        assert_eq!(found.review_type, "ai");
 
         // 未命中：未被环节引用的 todo 返回 None
         let missing = db.find_loop_step_by_todo_id(free_todo).await.unwrap();

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -39,6 +39,7 @@ mod v77;
 mod v78;
 mod v79;
 mod v80;
+mod v81;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -134,7 +135,10 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v79::V79ProcessTemplateGuid),
         // V80 在 V79 之后：环路瘦身（需求 044）——手工环路级联删除，
         // 触发器表下线，loops/loop_steps 冗余定义列删除；YAML 成为唯一定义来源
+        // V81 在 V80 之后：删除 loop_steps.review_type 死列（需求 048）——
+        // 评审/门禁统一由 gate_config 表达，review_type 与 gate 语义重复已废弃
         Box::new(v80::V80LoopSlim),
+        Box::new(v81::V81DropLoopStepReviewType),
     ]
 }
 

--- a/backend/src/db/migration/v81.rs
+++ b/backend/src/db/migration/v81.rs
@@ -1,0 +1,30 @@
+//! V81 迁移：删除 `loop_steps.review_type` 列（需求 048）。
+//!
+//! 背景：046 门禁统一后，评审/门禁语义收敛到 `gate_config`（ai_criteria_review /
+//! human_approval）。`review_type` 与 gate 一一重复（review_type=ai ≈ ai_criteria_review，
+//! review_type=human ≈ human_approval），loop_runner 已改由 `gate_config` 判定人工审批步骤、
+//! installer 已改由 `gate_config` 推导 `auto_review_enabled`。`review_type` 成为死列，删除
+//! 以免「两套配置打架」—— 留着会让用户误以为改 review_type 能影响评审，实际已被 gate 覆盖。
+//!
+//! 幂等：列不存在则跳过（`drop_column_if_exists` 先用 `pragma_table_info` 检查）。
+//! 删除的是无外键约束的普通 TEXT 列，SQLite `DROP COLUMN` 安全。
+use super::{drop_column_if_exists, Migration};
+use crate::db::Database;
+
+/// 删除 `loop_steps.review_type` 死列（评审/门禁统一由 gate_config 表达）。
+pub(super) struct V81DropLoopStepReviewType;
+
+#[async_trait::async_trait]
+impl Migration for V81DropLoopStepReviewType {
+    fn version(&self) -> i64 {
+        // 紧随 V80，单调递增；新迁移必须严格大于已有版本
+        81
+    }
+    fn name(&self) -> &'static str {
+        "V81DropLoopStepReviewType"
+    }
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 幂等删列：旧库已无该列（全新库或已升级）时跳过，避免重复 ALTER 报错
+        drop_column_if_exists(db, "loop_steps", "review_type").await
+    }
+}

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -230,8 +230,6 @@ pub struct LoopStepRawDto {
     pub on_rating_fail: String,
     /// on_rating_fail="goto" 时的目标 step_id
     pub fail_goto_step_id: Option<i64>,
-    /// 评审类型: "ai" = AI 自动评审, "human" = 人工审批
-    pub review_type: String,
     pub enabled: bool,
     pub created_at: Option<String>,
     /// 所属阶段 ID（process management）
@@ -255,7 +253,6 @@ impl From<loop_steps::Model> for LoopStepRawDto {
             success_goto_step_id: m.success_goto_step_id,
             on_rating_fail: m.on_rating_fail,
             fail_goto_step_id: m.fail_goto_step_id,
-            review_type: m.review_type,
             enabled: m.enabled != 0,
             created_at: m.created_at,
             phase_id: m.phase_id,

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1375,7 +1375,6 @@ pub struct LoopStepExportItem {
     pub on_rating_fail: String,
     pub fail_goto_step_id: Option<String>,      // 伪ID引用
     pub fail_goto_step_name: Option<String>,    // 展示用
-    pub review_type: String,
     pub enabled: bool,
 }
 

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -843,7 +843,10 @@ impl LoopRunner {
             // 4e. 检查 todo 状态：人工审批步骤的 todo 在所有 execution 间共享，
             //     如果 todo 已 completed，步骤应直接进入 pending_approval 而非 running
             //     （否则步骤永远卡在 running，审批界面不会出现）。
-            let initial_status = if step.review_type == "human" {
+            // 048：人工审批步骤改由 gate_config 含 human_approval 判定（review_type 已废弃）。
+            let is_human_approval_step =
+                crate::services::process::gate_evaluator::has_human_approval_gate(&step.gate_config);
+            let initial_status = if is_human_approval_step {
                 match self.ctx.db.get_todo(step.todo_id).await {
                     Ok(Some(t)) if t.status == crate::models::TodoStatus::Completed => "pending_approval",
                     _ => "running",
@@ -852,8 +855,8 @@ impl LoopRunner {
                 "running"
             };
             tracing::info!(
-                "loop_exec {}: step #{} review_type={:?} todo_id={} initial_status={}",
-                loop_execution_id, step.id, step.review_type, step.todo_id, initial_status,
+                "loop_exec {}: step #{} human_approval={} todo_id={} initial_status={}",
+                loop_execution_id, step.id, is_human_approval_step, step.todo_id, initial_status,
             );
             // 4f. 创建 step execution 记录
             // 044：min_rating/unrated_policy 已从 loop_steps 移除，创建快照时不再透传；
@@ -1855,7 +1858,6 @@ mod tests {
             success_goto_step_id: success_goto,
             on_rating_fail: on_rating_fail.to_string(),
             fail_goto_step_id: fail_goto,
-            review_type: "ai".to_string(),
             phase_id: None,
             expected_artifacts: "[]".to_string(),
             gate_config: "[]".to_string(),
@@ -2110,7 +2112,6 @@ mod tests {
                 // 044：run_mode/skip_on_source_failed/min_rating/unrated_policy 列已下线
                 on_success: "next".to_string(), success_goto_step_id: None,
                 on_rating_fail: "break".to_string(), fail_goto_step_id: None,
-                review_type: "ai".to_string(),
                 phase_id: None,
                 expected_artifacts: "[]".to_string(),
                 gate_config: "[]".to_string(),
@@ -2126,7 +2127,6 @@ mod tests {
                 description: String::new(), order_index: 1, todo_id: todo_b,
                 on_success: "next".to_string(), success_goto_step_id: None,
                 on_rating_fail: "break".to_string(), fail_goto_step_id: None,
-                review_type: "ai".to_string(),
                 phase_id: None,
                 expected_artifacts: "[]".to_string(),
                 gate_config: "[]".to_string(),
@@ -2159,7 +2159,6 @@ mod tests {
                 description: String::new(), order_index: 0, todo_id: todo_a,
                 on_success: "next".to_string(), success_goto_step_id: None,
                 on_rating_fail: "break".to_string(), fail_goto_step_id: None,
-                review_type: "ai".to_string(),
                 phase_id: None,
                 expected_artifacts: "[]".to_string(),
                 gate_config: "[]".to_string(),
@@ -2175,7 +2174,6 @@ mod tests {
                 description: String::new(), order_index: 1, todo_id: todo_b,
                 on_success: "next".to_string(), success_goto_step_id: None,
                 on_rating_fail: "break".to_string(), fail_goto_step_id: None,
-                review_type: "ai".to_string(),
                 phase_id: None,
                 expected_artifacts: "[]".to_string(),
                 gate_config: "[]".to_string(),
@@ -2211,7 +2209,6 @@ mod tests {
                 description: String::new(), order_index: 0, todo_id: todo_a,
                 on_success: "next".to_string(), success_goto_step_id: None,
                 on_rating_fail: "break".to_string(), fail_goto_step_id: None,
-                review_type: "ai".to_string(),
                 phase_id: None,
                 expected_artifacts: "[]".to_string(),
                 gate_config: "[]".to_string(),
@@ -2227,7 +2224,6 @@ mod tests {
                 description: String::new(), order_index: 1, todo_id: todo_b,
                 on_success: "next".to_string(), success_goto_step_id: None,
                 on_rating_fail: "break".to_string(), fail_goto_step_id: None,
-                review_type: "ai".to_string(),
                 phase_id: None,
                 expected_artifacts: "[]".to_string(),
                 gate_config: "[]".to_string(),
@@ -2259,7 +2255,6 @@ mod tests {
                 description: String::new(), order_index: 0, todo_id: todo_a,
                 on_success: "next".to_string(), success_goto_step_id: None,
                 on_rating_fail: "break".to_string(), fail_goto_step_id: None,
-                review_type: "ai".to_string(),
                 phase_id: None,
                 expected_artifacts: "[]".to_string(),
                 gate_config: "[]".to_string(),
@@ -2275,7 +2270,6 @@ mod tests {
                 description: String::new(), order_index: 1, todo_id: todo_a,
                 on_success: "next".to_string(), success_goto_step_id: None,
                 on_rating_fail: "break".to_string(), fail_goto_step_id: None,
-                review_type: "ai".to_string(),
                 phase_id: None,
                 expected_artifacts: "[]".to_string(),
                 gate_config: "[]".to_string(),

--- a/backend/src/services/process/gate_evaluator.rs
+++ b/backend/src/services/process/gate_evaluator.rs
@@ -24,6 +24,18 @@ pub struct GateSummary {
     pub gate_records: Vec<loop_step_execution_gates::Model>,
 }
 
+/// gate_config 是否含 human_approval 门禁。
+///
+/// 048：替代废弃的 `review_type` 字段——人工审批步骤改由 gate_config 含 human_approval 判定，
+/// 消除 review_type 与 gate 的语义冗余。解析失败视为无（evaluate_step_gates 后续会以 ParseError 显式报）。
+pub fn has_human_approval_gate(gate_config_json: &str) -> bool {
+    let gates: Vec<GateDefinition> = match serde_json::from_str(gate_config_json) {
+        Ok(gs) => gs,
+        Err(_) => return false,
+    };
+    gates.iter().any(|g| g.gate_type == "human_approval")
+}
+
 /// 编排某环节的全部门禁。
 ///
 /// 1. 解析 `expected_gates` 为 `GateDefinition` 列表；

--- a/backend/src/services/process/installer.rs
+++ b/backend/src/services/process/installer.rs
@@ -221,12 +221,11 @@ async fn create_todo_for_link(
             .await;
     }
 
-    // 工艺环节 review_type="ai" 等价于「执行完成后自动派生评审 todo 打分」，
-    // 翻译到 todo.auto_review_enabled；human 则保持 false，由环路闸门暂停等待人工审批。
-    // 不穿透这层，todo 会永远停在 create_todo_with_extras 硬编码的 false，
-    // 导致工艺里选了 AI 评审却从不触发打分（id=8 即此问题）。
+    // 048：评审是否启用由 gate_config 决定——环节含 ai_criteria_review 门禁才需要 auto_review 打分。
+    // 不穿透这层，todo 会停在 create_todo_with_extras 硬编码的 false，AI 评审门禁拿不到评分。
+    let has_ai_review_gate = link.gates.iter().any(|g| g.gate_type == "ai_criteria_review");
     let _ = db
-        .update_todo_auto_review_enabled(todo_id, link.review_type == "ai")
+        .update_todo_auto_review_enabled(todo_id, has_ai_review_gate)
         .await;
 
     Ok(todo_id)
@@ -296,7 +295,6 @@ async fn create_loop_step_for_link(
             link.on_rating_fail.clone()
         }),
         fail_goto_step_id: ActiveValue::Set(None),
-        review_type: ActiveValue::Set(link.review_type.clone()),
         // 环节级评审模板正文（需求 033）：空串视为未设置（NULL），评审时回退环路级/默认
         review_prompt: ActiveValue::Set(if link.review_prompt.trim().is_empty() {
             None
@@ -748,10 +746,15 @@ phases:
         on_success: next
         on_gate_fail: write-prd
         max_rework: 2
+        gates:
+          - name: AI评审
+            type: ai_criteria_review
       - id: confirm-prd
         name: 确认 PRD
         prompt: 请确认 PRD
-        review_type: human
+        gates:
+          - name: 人工审批
+            type: human_approval
         on_success: next
         on_gate_fail: write-prd
 "#
@@ -946,9 +949,9 @@ phases:
         assert_eq!(result.step_count, 1);
     }
 
-    /// installer 应把 link.review_type 翻译到 todo.auto_review_enabled：
-    /// 默认 ai -> true，human -> false。
-    /// 修复「工艺选了 AI 评审却从不触发打分」--此前 create_todo_with_extras 硬编码 false。
+    /// installer 应按 gate_config 推导 todo.auto_review_enabled：
+    /// 含 ai_criteria_review 门禁 -> true；仅 human_approval -> false。
+    /// 048 起 review_type 字段废弃，评审启用改由 gate_config 决定。
     #[tokio::test]
     async fn test_install_link_review_type_enables_auto_review() {
         let db = fresh_db().await;
@@ -976,27 +979,25 @@ phases:
             .expect("install should succeed");
 
         let steps = db.list_loop_steps_by_loop(result.loop_id).await.unwrap();
-        // write-prd: review_type 默认 ai -> todo.auto_review_enabled=true
+        // write-prd: 含 ai_criteria_review 门禁 -> todo.auto_review_enabled=true
         let write_step = steps
             .iter()
             .find(|s| s.name == "编写 PRD")
             .expect("write-prd exists");
         let write_todo = db.get_todo(write_step.todo_id).await.unwrap().unwrap();
-        assert_eq!(write_step.review_type, "ai");
         assert!(
             write_todo.auto_review_enabled,
-            "review_type=ai 的环节 todo 必须自动开启 auto_review_enabled"
+            "含 ai_criteria_review 门禁的环节 todo 必须自动开启 auto_review_enabled"
         );
-        // confirm-prd: review_type=human -> auto_review_enabled=false
+        // confirm-prd: 仅 human_approval 门禁 -> auto_review_enabled=false
         let confirm_step = steps
             .iter()
             .find(|s| s.name == "确认 PRD")
             .expect("confirm-prd exists");
         let confirm_todo = db.get_todo(confirm_step.todo_id).await.unwrap().unwrap();
-        assert_eq!(confirm_step.review_type, "human");
         assert!(
             !confirm_todo.auto_review_enabled,
-            "review_type=human 的环节 todo 不应开启 auto_review_enabled"
+            "仅 human_approval 门禁的环节 todo 不应开启 auto_review_enabled"
         );
     }
 
@@ -1045,7 +1046,6 @@ phases:
         prompt: 请交付产物
         on_success: end
         on_gate_fail: break
-        review_type: ai
         acceptance_criteria: 产物完整
         review_prompt: |
           你是评审师。PENETRATION_MARKER_033

--- a/backend/src/services/process/mod.rs
+++ b/backend/src/services/process/mod.rs
@@ -135,9 +135,6 @@ pub struct LinkDefinition {
     #[serde(default)]
     pub skills: Vec<String>,
     pub model: Option<String>,
-    /// 评审类型：ai / human，默认 ai
-    #[serde(default = "default_review_type")]
-    pub review_type: String,
     #[serde(default)]
     pub expected_artifacts: Vec<ExpectedArtifact>,
     #[serde(default)]
@@ -159,10 +156,6 @@ pub struct LinkDefinition {
     /// 空串 = 未设置，评审时回退到环路级 `review_template_id` → 全局默认模板。
     #[serde(default)]
     pub review_prompt: String,
-}
-
-fn default_review_type() -> String {
-    "ai".to_string()
 }
 
 fn default_on_success() -> String {

--- a/backend/src/services/process/transition_resolver.rs
+++ b/backend/src/services/process/transition_resolver.rs
@@ -108,7 +108,6 @@ mod tests {
             success_goto_step_id: success_goto,
             on_rating_fail: on_rating_fail.to_string(),
             fail_goto_step_id: fail_goto,
-            review_type: "ai".to_string(),
             phase_id: None,
             expected_artifacts: "[]".to_string(),
             gate_config: "[]".to_string(),

--- a/backend/tests/loop_step_execution_status_tests.rs
+++ b/backend/tests/loop_step_execution_status_tests.rs
@@ -28,7 +28,7 @@ async fn build_step_execution(db: &Database, initial_status: &str) -> (i64, i64)
     let step = db
         .create_loop_step(
             lp.id, "step_1", "", todo_id,
-            true, "next", None, "fail", None, "human",
+            true, "next", None, "fail", None,
         )
         .await
         .unwrap();

--- a/docs/design/048-废弃review_type统一gate_config-设计.md
+++ b/docs/design/048-废弃review_type统一gate_config-设计.md
@@ -1,0 +1,58 @@
+# 048-废弃 review_type 统一 gate_config-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AtomCode (GLM-5.2) | 2026-07-31 | 初始版本 |
+
+> 关联需求：`docs/requirements/048-废弃review_type统一gate_config-需求.md`
+
+## 1. 背景
+
+046 建立了 gate_config（门禁统一），但 review_type 旧字段保留，与 gate 语义重复。详见需求文档。
+
+## 2. 决策
+
+**gate_config 作为唯一权威，废弃 review_type**（不保留兼容列）。
+
+| 判定 | 现状（review_type） | 048（gate_config） |
+|---|---|---|
+| 人工审批步骤（loop_runner initial_status） | `review_type == "human"` | gate_config 含 `human_approval` |
+| AI 评审启用（installer auto_review_enabled） | `link.review_type == "ai"` | gate_config 含 `ai_criteria_review` |
+
+保留 review_type 会持续产出「两套配置打架」的 bug（用户改 review_type 不生效），故直接删除而非降级为兼容字段。
+
+## 3. 详细设计
+
+### 3.1 后端逻辑
+- **`gate_evaluator.rs`** 新增 `pub fn has_human_approval_gate(gate_config_json) -> bool`（与 `rating_wait::has_ai_criteria_review_gate` 同模式，serde 解析后判 gate_type）。
+- **`loop_runner.rs:846`**：`is_human_approval_step = gate_evaluator::has_human_approval_gate(&step.gate_config)`，替代 `step.review_type == "human"`。
+- **`installer.rs`**：`auto_review_enabled = link.gates.iter().any(|g| g.gate_type == "ai_criteria_review")`，替代 `link.review_type == "ai"`。
+
+### 3.2 后端字段删除
+`db/entity/loop_steps.rs`、`db/loop_.rs`（create_loop_step 参数 + ActiveValue + clone + SQL SELECT + Model 构造）、`models/loop_.rs`（LoopStepRawDto + From）、`models/mod.rs`（导入预览 DTO）、`services/process/mod.rs`（`LinkDefinition.review_type` + `default_review_type`）。
+
+### 3.3 DB 迁移 v81
+`db/migration/v81.rs`：`drop_column_if_exists(db, "loop_steps", "review_type")`（幂等，与 v77 同模式）。注册到 `all_migrations`。
+
+### 3.4 前端
+`types/process.ts`（LinkDefinition）、`types/loop.ts`（LoopStepDto）删字段；`LinkPropertyForm.tsx` 删「审核类型」下拉；`concepts.tsx` onboarding `GATE_TYPES` 删废弃门禁类型（046 编辑器清理同源）。
+
+### 3.5 工艺 YAML
+删 `review_type` 行（gate-test ×4 + 4p12s）。ntd-resource 源仓库同步（commit `fca4dbd7`）。
+
+## 4. 不做的
+
+- **不重排 persist/finalize 顺序**（047 已评估，破坏 executor 终态信号）。
+- **不回溯改历史文档**（025/029/033/034/037/044 记录当时设计）。
+- **不删 gate_config 多门禁能力**（complex-refactor 的 ai+human 保留）。
+
+## 5. 测试
+
+- `gate_evaluator::has_human_approval_gate`（含/空/非法 JSON）。
+- `installer::test_install_link_review_type_enables_auto_review` 改验证：write-prd（ai_criteria_review）→ auto_review=true；confirm-prd（human_approval）→ auto_review=false。
+- `db::migration` fresh-db 全迁移（含 v81）注册测试。
+
+## 6. 风险
+
+- **DB drop 列**：v81 幂等（drop_column_if_exists），旧库无列跳过。部署时启动一次即迁移。
+- **历史 review_type=human 无 human_approval gate**：数据本身已不一致（046 后审批已依赖 gate），属于历史脏数据，不在本需求兜底。

--- a/docs/requirements/048-废弃review_type统一gate_config-实现总结.md
+++ b/docs/requirements/048-废弃review_type统一gate_config-实现总结.md
@@ -1,0 +1,40 @@
+# 048-废弃 review_type 统一 gate_config-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AtomCode (GLM-5.2) | 2026-07-31 | 初始版本 |
+
+> 关联：[需求](./048-废弃review_type统一gate_config-需求.md) / [设计](../design/048-废弃review_type统一gate_config-设计.md)
+
+## 实现内容
+
+### A. 后端逻辑（gate_config 为权威）
+- **`gate_evaluator.rs`** 新增 `has_human_approval_gate(gate_config_json)`。
+- **`loop_runner.rs:846`**：人工审批步骤改由 `gate_evaluator::has_human_approval_gate(&step.gate_config)` 判定，替代 `step.review_type == "human"`。
+- **`installer.rs`**：`auto_review_enabled` 改从 `link.gates.iter().any(|g| g.gate_type == "ai_criteria_review")` 推导，替代 `link.review_type == "ai"`。
+
+### B. 后端字段删除
+`entity/loop_steps.rs`、`db/loop_.rs`（create_loop_step 参数/ActiveValue/clone/SQL SELECT/Model 构造 + test）、`models/loop_.rs`（LoopStepRawDto + From）、`models/mod.rs`（导入预览 DTO）、`process/mod.rs`（LinkDefinition.review_type + default_review_type）、`transition_resolver.rs` + `loop_runner.rs` tests 构造点。
+
+### C. DB 迁移 v81
+`db/migration/v81.rs`：`drop_column_if_exists("loop_steps", "review_type")`，注册到 `all_migrations`。
+
+### D. 前端
+`types/process.ts`、`types/loop.ts` 删 review_type；`LinkPropertyForm.tsx` 删「审核类型」下拉；`concepts.tsx` GATE_TYPES 删废弃门禁类型（046 编辑器清理同源）。
+
+### E. 工艺 YAML
+gate-test ×4 + 4p12s（user/bundled/ntd-resource 源）删 review_type。ntd-resource 已 push（`fca4dbd7`）。
+
+## 验证
+
+- `cargo clippy --all-targets -- -D warnings`：**零告警**。
+- `cargo test`：**1486+ 全通过**（含 v81 fresh-db 迁移、installer auto_review 改 gates 推导、gate_evaluator has_human_approval_gate）。
+- `npx tsc --noEmit`：**零错误**。
+
+## 文件清单
+- 后端：`gate_evaluator.rs`、`loop_runner.rs`、`installer.rs`、`process/mod.rs`、`transition_resolver.rs`、`db/loop_.rs`、`db/entity/loop_steps.rs`、`db/migration/v81.rs`(新)+`mod.rs`、`models/loop_.rs`、`models/mod.rs`、`tests/loop_step_execution_status_tests.rs`
+- 前端：`types/loop.ts`、`types/process.ts`、`propertyForms/LinkPropertyForm.tsx`、`onboarding/concepts.tsx`
+
+## 遗留
+- v81 迁移在 dev/prod 库下次启动时自动 drop review_type 列（fresh-db 测试已覆盖迁移逻辑）。
+- 历史设计文档（025/029/033/034/037/044 等）含 review_type，按「记录当时设计」惯例不回溯修改。

--- a/docs/requirements/048-废弃review_type统一gate_config-需求.md
+++ b/docs/requirements/048-废弃review_type统一gate_config-需求.md
@@ -1,0 +1,48 @@
+# 048-废弃 review_type 统一 gate_config-需求
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AtomCode (GLM-5.2) | 2026-07-31 | 初始版本 |
+
+> 关联：046 门禁与评审统一（建立 gate_config）/ 047 门禁评分等待与评审追溯。本需求是 046 的收尾——清除与 gate 语义重复的 `review_type` 旧字段。
+
+## 背景
+
+046 门禁统一后，门禁类型收敛为 `ai_criteria_review` + `human_approval`。但 `loop_steps.review_type` 字段（ai/human）仍保留，与 gate 语义**一一重复**：
+
+- `review_type: ai` ≡ gate `ai_criteria_review`
+- `review_type: human` ≡ gate `human_approval`
+
+两套配置并存容易迷惑——用户改 review_type 不生效（已被 gate 覆盖），还可能建出「review_type=ai 但 gate=human_approval」自相矛盾的配置。gate_config 才是 046 后的权威。
+
+## 现状
+
+`review_type` 唯一运行时用途：`loop_runner.rs:846` 判定人工审批步骤（决定 `initial_status = pending_approval`）。
+- AI 评审触发（auto_review）**不依赖** review_type（看 `auto_review_enabled`，v74 已把 `review_type='ai'` 回填）。
+- 其余引用为 DB 存取 / 展示。
+- 人工审批判定与 auto_review 启用都能从 `gate_config` 完整推导（含 human_approval / 含 ai_criteria_review）。
+
+## 需求
+
+1. **废弃 `review_type` 字段**，`gate_config` 成为评审/门禁唯一权威。
+2. `loop_runner` 人工审批步骤判定改由「gate_config 含 human_approval」（新增 `has_human_approval_gate` helper）。
+3. `installer` 的 `todo.auto_review_enabled` 从 gate_config 推导（含 ai_criteria_review → 启用）。
+4. 删除 `review_type`：后端 entity/db/models/LinkDefinition + 前端 types/编辑表单 + 工艺 YAML。
+
+## 边界
+
+- **DB schema 变更**：drop `loop_steps.review_type` 列（迁移 v81，幂等）。
+- 历史设计文档（025/029/033/034/037/044 等）记录当时设计，**不回溯修改**；本需求为后续变更。
+- 不影响 gate_config 多门禁能力（complex-refactor 的 ai_criteria_review + human_approval 组合保留）。
+- `review_type=human` 的历史步骤，gate_config 应已有 human_approval（046 后审批已依赖 gate）；无则数据本身已不一致。
+
+## 验收标准
+
+- [ ] `loop_runner` 用 `has_human_approval_gate` 判定人工审批步骤
+- [ ] `installer` `auto_review_enabled` 从 gate_config 推导
+- [ ] `review_type` 字段全删（entity/db/models/LinkDefinition/前端 types/编辑表单）
+- [ ] DB 迁移 v81 drop `loop_steps.review_type` 列（幂等）
+- [ ] 工艺 YAML 删 `review_type`（gate-test + 4p12s）
+- [ ] `cargo clippy --all-targets -- -D warnings` 零告警
+- [ ] `cargo test` 全通过
+- [ ] `tsc --noEmit` 零错误

--- a/frontend/src/components/onboarding/concepts.tsx
+++ b/frontend/src/components/onboarding/concepts.tsx
@@ -354,12 +354,10 @@ export const EXECUTOR_VS_EXPERT_VS_MODEL: Array<{
   { concept: '模型', essence: '具体跑哪个 LLM', example: 'glm-5.2 / claude-sonnet-5 / gpt-4o' },
 ] as const;
 
-/** 门禁 4 种类型 + 中文标签，用于环路/事项详细说明区。 */
+/** 门禁类型 + 中文标签，用于环路/事项详细说明区。046 起仅 2 类（artifact_present/script_check 已废弃）。 */
 export const GATE_TYPES: ReadonlyArray<{ type: string; label: string }> = [
-  { type: 'artifact_present', label: '产物存在' },
   { type: 'ai_criteria_review', label: 'AI 评审' },
   { type: 'human_approval', label: '人工审批' },
-  { type: 'script_check', label: '脚本校验' },
 ] as const;
 
 /** ThunderboltOutlined 给任务卡用（避免在 ConceptNode 里重复 import）。 */

--- a/frontend/src/components/process/propertyForms/LinkPropertyForm.tsx
+++ b/frontend/src/components/process/propertyForms/LinkPropertyForm.tsx
@@ -3,7 +3,7 @@
 // M4 里程碑：环节属性面板（LinkPropertyForm）。
 //
 // 设计意图（对应 docs/design/029-M4-ReactFlow可视化编辑器-方案.md §3.1.9 + 设计 §7.1）：
-// - 暴露 8 个常用字段（id/name/step_template/prompt/executor/review_type/on_success/on_gate_fail）。
+// - 暴露 7 个常用字段（id/name/step_template/prompt/executor/on_success/on_gate_fail）。
 // - 嵌套字段：gates + expected_artifacts 用 Ant Design Table 增删行。
 // - on_success / on_gate_fail 用分组下拉（OptGroup by phase）。
 // - 每个字段 onChange → updateLinkField → onDefinitionChange。
@@ -420,18 +420,8 @@ export function LinkPropertyForm({
         onToggleSkill={handleToggleSkill}
       />
 
-      <Form.Item label="审核类型">
-        <Select
-          value={link.review_type}
-          onChange={(value) => handleFieldChange('review_type', value ?? undefined)}
-          allowClear
-          placeholder="默认 AI 审核"
-          options={[
-            { value: 'ai', label: 'AI 审核' },
-            { value: 'human', label: '人工审核' },
-          ]}
-        />
-      </Form.Item>
+      {/* 048：审核类型(review_type)已废弃——评审/门禁统一由下方 gates 配置
+          (ai_criteria_review / human_approval) 决定，不再单列 review_type 字段。 */}
 
       <Form.Item label="评审 Prompt">
         <Input.TextArea
@@ -642,11 +632,10 @@ const tableStyle: CSSProperties = {
   marginBottom: 16,
 };
 
-// 门禁类型可选项（对齐后端 services/process/gates 模块支持的 4 种 type）。
+// 门禁类型可选项。046 起 artifact_present/script_check 已废弃（统一并入 ai_criteria_review），
+// 编辑器不再产出这两种类型，避免建出运行时报「废弃门禁类型」错误的工艺。
 // 用下拉避免用户手填拼错 type 字符串，导致门禁匹配不到执行器而不生效。
 const GATE_TYPE_OPTIONS = [
-  { value: 'artifact_present', label: '产物存在' },
   { value: 'ai_criteria_review', label: 'AI 评审' },
   { value: 'human_approval', label: '人工审批' },
-  { value: 'script_check', label: '脚本检查' },
 ];

--- a/frontend/src/types/loop.ts
+++ b/frontend/src/types/loop.ts
@@ -134,8 +134,6 @@ export interface LoopStepDto {
   success_goto_step_id: number | null;
   on_rating_fail: string;
   fail_goto_step_id: number | null;
-  /** 评审类型: 'ai' = AI 自动评审, 'human' = 人工审批 */
-  review_type: string;
   enabled: boolean;
   created_at: string | null;
   /** 关联的 todo title */

--- a/frontend/src/types/process.ts
+++ b/frontend/src/types/process.ts
@@ -40,7 +40,6 @@ export interface LinkDefinition {
   expert?: string;
   skills?: string[];
   model?: string;
-  review_type?: string;
   /** 环节级评审模板正文（完整模板，含占位符）；空 = 未设置，回退环路级/默认 */
   review_prompt?: string;
   expected_artifacts?: ExpectedArtifact[];


### PR DESCRIPTION
## 背景
046 门禁统一后 `review_type`(ai/human) 与 gate 语义一一重复（review_type=ai≡ai_criteria_review，human≡human_approval），两套配置并存易迷惑（改 review_type 不生效被 gate 覆盖）。本 PR 是 046 收尾——删除 review_type，gate_config 成为唯一权威。

## 改动
- **后端逻辑**：loop_runner 人工审批改由 `has_human_approval_gate` 判定；installer `auto_review_enabled` 从 gate_config 推导（含 ai_criteria_review 启用）
- **字段删除**：entity/db/models/LinkDefinition/前端 types/编辑表单
- **DB 迁移 v81**：drop `loop_steps.review_type` 列（幂等）
- **前端**：删「审核类型」下拉；onboarding GATE_TYPES 清理废弃门禁类型（046 编辑器清理同源）
- **工艺 YAML**：gate-test + 4p12s 删 review_type（ntd-resource 源已对齐，commit fca4dbd7）

## 验证
- `cargo clippy --all-targets -- -D warnings` 零告警
- `cargo test` 1486+ 全过（含 v81 迁移、installer auto_review 改 gates 推导、has_human_approval_gate）
- `tsc --noEmit` 零错误

## 文档
- 需求/设计/实现总结 `docs/.../048-废弃review_type统一gate_config-*.md`

## ⚠️ 部署注意
DB schema 变更（drop 列），合并后部署需让 dev/prod 启动一次跑 v81 迁移。