### PR TITLE
feat(049): 环节属性面板补 max_rework 字段

### DIFF
--- a/frontend/src/components/process/propertyForms/LinkPropertyForm.tsx
+++ b/frontend/src/components/process/propertyForms/LinkPropertyForm.tsx
@@ -469,6 +469,21 @@ export function LinkPropertyForm({
         />
       </Form.Item>
 
+      {/* 最大返工次数：门禁失败跳转返工的上限，超过即终止工艺（防止死循环重试）。
+          对应 loop_steps.max_rework，后端默认 3。空 = 用默认值。 */}
+      <Form.Item label="最大返工次数" tooltip="门禁失败跳转返工的上限次数，超过即终止工艺。留空用默认 3。">
+        <InputNumber
+          value={link.max_rework}
+          onChange={(value) =>
+            handleFieldChange('max_rework', value === null ? undefined : value)
+          }
+          min={0}
+          max={20}
+          style={{ width: '100%' }}
+          placeholder="默认：3"
+        />
+      </Form.Item>
+
       {/* gates 嵌套表格 */}
       <Space style={sectionHeaderStyle}>
         <Text strong>门禁</Text>


### PR DESCRIPTION
## 改动
- **LinkPropertyForm** 加「最大返工次数」InputNumber（on_gate_fail 后），对应 loop_steps.max_rework（后端默认 3，留空用默认）。min=0/max=20。
- 文案提示：门禁失败跳转返工的上限次数，超过即终止工艺（防死循环）。

## 关于「on_success/on_gate_fail 不能选自己」
**main 代码已实现**：`buildGotoOptions`（L569-570）已 `if (link.id === currentLinkId) continue` 排除当前环节，下拉不会出现自己。若界面仍能选自己，是部署版本旧，更新到最新 main 即可。

## 验证
- `tsc --noEmit` 零错误