### PR TITLE
feat(051): 执行历史卡片显示执行记录 ID

### DIFF
--- a/frontend/src/components/loop-studio/executions/StepExecList.tsx
+++ b/frontend/src/components/loop-studio/executions/StepExecList.tsx
@@ -131,10 +131,16 @@ export function StepExecList({ stepExecs, loopId, workspaceId, executionId, onAp
                 userSelect: 'none',
               }}
             >
-              {/* 黑板序号 + 执行序号 */}
-              <div style={{ position: 'absolute', top: 6, left: 10, fontSize: 11, fontWeight: 600, color: 'var(--color-text-tertiary, #94a3b8)', display: 'flex', gap: 6 }}>
-                {s.sequence_index != null && <span style={{ fontFamily: 'monospace' }}>#{s.sequence_index}</span>}
-                <span style={{ fontFamily: 'monospace', color: 'var(--color-text-tertiary)' }}>/#{idx + 1}</span>
+              {/* 左上角编号：黑板全局序号 / 环节序号 / 执行记录ID。
+                  三者用 tooltip 区分含义；rec#id 即该环节 todo 的执行记录 ID（点击卡片看详情）。 */}
+              <div style={{ position: 'absolute', top: 6, left: 10, fontSize: 11, fontWeight: 600, color: 'var(--color-text-tertiary, #94a3b8)', display: 'flex', gap: 6, alignItems: 'center' }}>
+                {s.sequence_index != null && (
+                  <span style={{ fontFamily: 'monospace' }} title="黑板全局序号（跨环节递增）">#{s.sequence_index}</span>
+                )}
+                <span style={{ fontFamily: 'monospace', color: 'var(--color-text-tertiary)' }} title="本环路内环节序号">/#{idx + 1}</span>
+                {s.execution_record_id != null && (
+                  <span style={{ fontFamily: 'monospace', color: 'var(--color-primary, #6366f1)' }} title="执行记录 ID（点击卡片查看该 record 详情）">·rec#{s.execution_record_id}</span>
+                )}
               </div>
 
               {/* 状态指示圆点 */}


### PR DESCRIPTION
## 问题
环路执行历史 → 点开执行记录 → 一排环节卡片，左上角 `#x /#y` 两个编号都不是执行记录 ID；execution_record_id 只在点击卡片弹出的 Drawer 标题里，卡片上不显示。

## 改动（StepExecList.tsx 左上角编号区）
- `#x` = `sequence_index` 黑板全局序号 —— 加 tooltip 说明
- `#y` = `idx+1` 本环路环节序号 —— 加 tooltip 说明
- 新增 `·rec#{execution_record_id}`（primary 色区分）—— 该环节 todo 的执行记录 ID，点击卡片仍弹出该 record 详情

## 验证
- `tsc --noEmit` 零错误