### PR TITLE
fix: Wiki 对话占位提示改为强调当前工作空间

### DIFF
--- a/frontend/src/components/wiki-chat/ChatInputPanel.tsx
+++ b/frontend/src/components/wiki-chat/ChatInputPanel.tsx
@@ -81,7 +81,7 @@ export function ChatInputPanel({
       <TextArea
         value={inputValue}
         onChange={(e) => onInputChange(e.target.value)}
-        placeholder="向 Wiki 提问..."
+        placeholder="问点什么？AI 会结合本工作空间回答…"
         autoSize={{ minRows: 1, maxRows: mobile ? 4 : 6 }}
         disabled={loading || workspaceId == null}
         onKeyDown={handleKeyDown}

--- a/frontend/src/components/wiki-chat/ChatMessageItem.tsx
+++ b/frontend/src/components/wiki-chat/ChatMessageItem.tsx
@@ -173,7 +173,7 @@ export function ChatEmptyPlaceholder({ mobile = false, isDark }: { mobile?: bool
     <div style={{ textAlign: 'center', color: colors.hintColor, fontSize: mobile ? 14 : 13, padding: '32px 0' }}>
       <MessageOutlined style={{ fontSize: 36, marginBottom: 12, opacity: 0.3 }} />
       <div>还没有对话记录</div>
-      <div style={{ marginTop: 6, fontSize: mobile ? 13 : 12 }}>输入问题开始与 Wiki 交互</div>
+      <div style={{ marginTop: 6, fontSize: mobile ? 13 : 12 }}>输入问题，AI 会结合当前工作空间回答你</div>
     </div>
   );
 }


### PR DESCRIPTION
## 实现了什么
将 FAB 菜单中「对话」图标打开后的两处用户可见文案，从「向 Wiki 提问 / 与 Wiki 交互」调整为强调「当前工作空间」下的 AI 对话，弱化 Wiki 主语。

- `frontend/src/components/wiki-chat/ChatInputPanel.tsx` 输入框占位符：
  - 旧：`向 Wiki 提问...`
  - 新：`问点什么？AI 会结合本工作空间回答…`
- `frontend/src/components/wiki-chat/ChatMessageItem.tsx` 空状态副文案：
  - 旧：`输入问题开始与 Wiki 交互`
  - 新：`输入问题，AI 会结合当前工作空间回答你`

## 与需求的对应关系
用户指出：该对话本质是在**当前工作空间**下与 AI 交互（执行器跑在 workspace 目录下、可读取工作空间上下文），并非狭义的「问 Wiki」。原占位文案用「Wiki」作主语会误导用户预期。本次仅调整用户可见提示文案，对齐真实能力边界。

## 关键实现点
- 纯字面量文案修改，不涉及任何逻辑、接口或数据流变更。
- 代码注释与内部命名中的「Wiki 对话」未改动，避免无关噪音（YAGNI）。
- 两处文案统一口径，避免一处说 Wiki、一处说工作空间造成割裂。

## 测试与验证结果
- `cd frontend && npx tsc --noEmit`：零错误通过。
- 已确认用户可见位置不再残留旧的「Wiki」主语提示。

## 已知限制 / 待改进
- 未拉起 `make dev` 全链路做 Playwright 端到端验证（本次为纯文案变更、零逻辑变动，风险极低）；如需可在合入前补一次 UI 校验。

🤖 Generated with CodeBuddy Code