### PR TITLE
feat(054): 列表表格交互增强(列宽拖拽+点击排序+默认ID倒序+localStorage持久化)

### DIFF
--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -1325,7 +1325,7 @@ impl Database {
                                WHERE le2.loop_id = l.id AND lse.approval_status = 'pending') as pending_approval_count \
                        FROM loops l \
                        WHERE l.workspace_id = ?1 \
-                       ORDER BY l.updated_at DESC",
+                       ORDER BY l.id DESC",
                 None => "SELECT l.id, l.name, l.description, l.workspace_path, \
                           l.workspace_id, l.status, l.limits_config, \
                           l.abnormal_handler_todo_id, l.abnormal_handler_trigger_on, \
@@ -1340,7 +1340,7 @@ impl Database {
                            INNER JOIN loop_executions le2 ON le2.id = lse.loop_execution_id \
                            WHERE le2.loop_id = l.id AND lse.approval_status = 'pending') as pending_approval_count \
                        FROM loops l \
-                       ORDER BY l.updated_at DESC",
+                       ORDER BY l.id DESC",
             };
             let rows = if let Some(wid) = workspace_id {
                 self.conn

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -1309,6 +1309,8 @@ impl Database {
             // 044：loops 已移除 color/icon/review_template_id/webhook_enabled；
             // loop_triggers 表已下线，不再 JOIN 聚合 trigger_count。
             // 列表查询补回 l.workspace_id（筛选键），供 LoopListRow.loop_ 完整填充。
+            // 054 起统一按 id DESC（列表默认排序），替代原 updated_at DESC 口径；
+            // 与 task.rs / todo.rs 保持一致，下方两个分支（带/不带 workspace_id 过滤）排序口径相同。
             let sql = match workspace_id {
                 Some(_) => "SELECT l.id, l.name, l.description, l.workspace_path, \
                               l.workspace_id, l.status, l.limits_config, \

--- a/backend/src/db/task.rs
+++ b/backend/src/db/task.rs
@@ -31,7 +31,8 @@ impl Database {
     ) -> Result<Vec<tasks::Model>, sea_orm::DbErr> {
         let mut q = tasks::Entity::find().filter(tasks::Column::WorkspaceId.eq(workspace_id));
         if let Some(s) = status { q = q.filter(tasks::Column::Status.eq(s)); }
-        q.order_by_desc(tasks::Column::CreatedAt).all(&self.conn).await
+        // 054 起统一按 id DESC（列表默认排序），替代原 created_at DESC 口径。
+        q.order_by_desc(tasks::Column::Id).all(&self.conn).await
     }
 
     pub async fn update_task_status(&self, id: i64, status: &str) -> Result<(), sea_orm::DbErr> {

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -203,10 +203,11 @@ impl Database {
         bucket: Option<ComputedBucket>,
         search: Option<&str>,
     ) -> Result<Vec<TodoCenterItem>, sea_orm::DbErr> {
-        // 不过滤 archived_at：已归档事项也要在「已归档」分类出现
+        // 不过滤 archived_at：已归档事项也要在「已归档」分类出现；
+        // 054 起统一按 id DESC（列表默认排序），与用户点击排序的默认列保持一致。
         let mut query = todos::Entity::find()
             .filter(todos::Column::DeletedAt.is_null())
-            .order_by_desc(todos::Column::UpdatedAt);
+            .order_by_desc(todos::Column::Id);
         if let Some(id) = workspace_id {
             query = query.filter(todos::Column::WorkspaceId.eq(id));
         }

--- a/docs/design/054-列表表格交互增强-设计.md
+++ b/docs/design/054-列表表格交互增强-设计.md
@@ -1,0 +1,114 @@
+# 0. 文件修改记录表
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-07-31 | 初始版本 |
+
+# 1. 背景
+
+三大业务列表当前无列宽拖拽、无点击排序、后端默认排序不统一（按时间字段而非 ID）。
+需求文档 054 定义了三项交互增强的具体功能点与验收标准。
+
+# 2. 设计决策
+
+## 2.1 列宽拖拽：自研 ResizableTitle（零依赖）
+
+antd Table 支持通过 `components={{ header: { cell: CustomHeaderCell } }}` 替换表头渲染。
+
+```
+ResizableTitle（纯函数组件）
+  ├ props: { width, minWidth(60), onResize, children }
+  ├ pointerdown → setPointerCapture + document.body.style.userSelect = 'none'
+  ├ pointermove → onResize(prevWidth + deltaX)（受控于列宽 state）
+  └ pointerup/pointercancel → 释放捕获 + 恢复 userSelect
+```
+
+**为何不引 react-resizable？**
+- 该库最后更新于 2020 年，peer dependency 声明不兼容 React 19
+- 自研只需 ~60 行 Pointer Events 代码，功能完全覆盖
+
+## 2.2 排序：客户端受控排序
+
+antd Table 原生支持 `sorter`，使用**受控模式**（每列 `sortOrder` 受 state 控制 + `onChange` 捕获）：
+
+```tsx
+// Table onChange 参数中 sorters 为对象（单排序）或数组（多排序）
+// 本设计采用单排序：field + order 存 localStorage
+```
+
+可排序列范围（3B 确认）：
+- TodoListView：ID、标题、状态、执行时间、更新时间
+- TasksTableView：#、标题、状态、复杂度、创建时间
+- LoopListView：ID、名称、状态、环节、待审批、执行时间、更新时间
+
+不可排序：标签、操作列、执行器、专家等复合/渲染列。
+
+## 2.3 localStorage 持久化：纯函数层 + hook
+
+```
+tablePrefs.ts（纯函数，不依赖 React）
+  ├ getTablePrefs(key) → Prefs | null    // JSON.parse 容错 + 白名单校验
+  ├ setTablePrefs(key, prefs)            // JSON.stringify 写入
+  └ resetTablePrefs(key)                 // removeItem
+
+useResizableColumns(tableKey, defaultWidths, columns, dataSource)
+  ├ [widths, setWidths] = useState(loaded.widths ?? defaultWidths)
+  ├ [sortState, setSortState] = useState(loaded.sort ?? { field:'id', order:'descend' })
+  ├ ResizableTitle 注入每列（通过 onResize callback）
+  ├ sortState 注入 columns → sortOrder 映射
+  ├ Table onChange → 提取 sorter → setSortState → setTablePrefs
+  └ sortedData = useMemo(() => 客户端排序结果, [dataSource, sortState])
+  └ scroll.x = useMemo(() => widths 求和 + 操作列兜底, [widths])
+```
+
+## 2.4 客户端排序实现
+
+```ts
+// sortDataSource(data, sortState) → 排序后数组
+// - order='ascend' → compare(a, b)
+// - order='descend' → compare(b, a)
+// - order=null → 原序
+// - 比较器：数字用数值，字符串用 localeCompare
+```
+
+# 3. 改动清单
+
+## 后端（3 处 ORDER BY 修改）
+
+| 文件 | 函数 | 改动 |
+|------|------|------|
+| `backend/src/db/todo.rs` | `get_todo_center` L209 | `order_by_desc(UpdatedAt)` → `order_by_desc(Id)` |
+| `backend/src/db/task.rs` | `list_tasks` L34 | `order_by_desc(CreatedAt)` → `order_by_desc(Id)` |
+| `backend/src/db/loop_.rs` | `list_loops_with_counts` SQL | 两处 `ORDER BY l.updated_at DESC` → `ORDER BY l.id DESC` |
+
+## 前端（新建 3 文件 + 修改 3 文件）
+
+| 文件 | 改动 |
+|------|------|
+| `frontend/src/components/common/tablePrefs.ts` | **新建**：localStorage 读写纯函数 |
+| `frontend/src/components/common/tablePrefs.test.ts` | **新建**：纯函数单测 |
+| `frontend/src/components/common/ResizableTitle.tsx` | **新建**：拖拽表头 cell 组件 |
+| `frontend/src/hooks/useResizableColumns.tsx` | **新建**：hook，注入列宽 + 排序 + scroll.x |
+| `frontend/src/components/todo-list/TodoListView.tsx` | 接入 hook，配置排序列 |
+| `frontend/src/components/tasks/TasksTableView.tsx` | 接入 hook，配置排序列 |
+| `frontend/src/components/loop-list/LoopListViewParts.tsx` | 接入 hook，配置排序列 |
+
+# 4. 函数长度控制
+
+拆分原则（每个函数 ≤ 30 行）：
+- `ResizableTitle`：组件本体 ~20 行（事件处理内联）
+- `tablePrefs.ts`：3 个纯函数，每个 ≤ 10 行
+- `useResizableColumns.tsx`：hook 本体 ~25 行，排序比较器拆为独立函数
+- 排序比较器按类型拆分：`compareNumeric` / `compareString` / `compareDate`
+
+# 5. 验证
+
+1. `cargo clippy --all-targets -- -D warnings` 零告警
+2. `cargo test` 全量通过
+3. `npx tsc --noEmit` 零错误
+4. `tablePrefs.test.ts` 单测通过
+5. `make dev` 后手工/Playwright 验证三列表：
+   - 拖拽列宽 ≥ 60px 正常、< 60px 锁定
+   - 点击排序列头升/降/取消三态切换
+   - 刷新页面列宽与排序恢复
+   - 清除 localStorage 后 ID 倒序兜底

--- a/docs/requirements/054-列表表格交互增强-实现总结.md
+++ b/docs/requirements/054-列表表格交互增强-实现总结.md
@@ -1,0 +1,81 @@
+# 0. 文件修改记录表
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-07-31 | 初始版本 — 列表表格交互增强实现总结 |
+
+# 1. 实现了什么
+
+为三大业务列表（事项 TodoListView / 任务 TasksTableView / 环路 LoopListView）的 antd Table 增加：
+1. **自由拖动列宽**：自研 `ResizableTitle` 表头 cell（Pointer Events + setPointerCapture，最小列宽 60px，零新依赖）
+2. **点击排序**：语义可排序列（ID/名称/状态/时间类）点击列头切换升/降序，antd 受控 `sortOrder` 实现
+3. **默认 ID 倒序**：前端 ID 列默认 `descend`，后端三个列表查询统一改为 `ORDER BY id DESC` 双保险
+4. **状态持久化**：列宽与排序写入 localStorage（`ntd_table_prefs:<tableKey>`），刷新自动恢复
+
+# 2. 与需求的对应关系
+
+| 需求条目 | 实现 | 状态 |
+|---------|------|------|
+| G1 列宽拖拽 | `ResizableTitle.tsx` + `useResizableColumns` hook | ✅ |
+| G2 点击排序 | 列定义注入 `sorter: makeSorter(field)`，受控 `sortOrder` | ✅ |
+| G3 默认 ID 倒序 | 前端 `DEFAULT_SORT` + 后端 3 处 `ORDER BY id DESC` | ✅ |
+| G4 状态持久化 | `tablePrefs.ts` 纯函数层（白名单校验 + JSON 容错） | ✅ |
+| FR6 动态 scroll.x | hook 内 `columns.reduce` 求和，替代硬编码 1720/1290/1360 | ✅ |
+
+# 3. 关键实现点
+
+## 后端（3 处排序统一）
+
+| 文件 | 函数 | 改动 |
+|------|------|------|
+| `backend/src/db/todo.rs` | `get_todo_center` | `order_by_desc(UpdatedAt)` → `order_by_desc(Id)` |
+| `backend/src/db/task.rs` | `list_tasks` | `order_by_desc(CreatedAt)` → `order_by_desc(Id)` |
+| `backend/src/db/loop_.rs` | `list_loops_with_counts` | 原生 SQL 两处分支 `ORDER BY l.updated_at DESC` → `ORDER BY l.id DESC` |
+
+## 前端新建文件
+
+| 文件 | 职责 |
+|------|------|
+| `src/components/common/tablePrefs.ts` | localStorage 读写纯函数：key 白名单（todos/tasks/loops）、JSON.parse 容错、widths 数值过滤、sort.order 白名单 |
+| `src/components/common/tablePrefs.test.ts` | 11 个单测：白名单/容错/读写/清除 |
+| `src/components/common/ResizableTitle.tsx` | 拖拽表头 cell：Pointer Events、最小 60px、拖拽结束才持久化、固定列不覆盖 sticky 定位 |
+| `src/hooks/useResizableColumns.tsx` | hook：注入 width/onHeaderCell/受控 sortOrder，动态 scroll.x，Table onChange 提取排序并持久化 |
+| `src/hooks/useResizableColumns.test.tsx` | 9 个单测：compareValues、默认排序、偏好注入、scroll.x、tableProps 结构 |
+
+## 前端改造文件
+
+- `TodoListView.tsx`：ID/标题/状态/执行时间/更新时间 5 列加 `sorter`，接入 hook
+- `TasksTableView.tsx`：#/标题/状态/复杂度/创建时间 5 列加 `sorter`，接入 hook
+- `LoopListViewParts.tsx` + `LoopListView.tsx`：ID/名称/状态/环节/待审批/执行时间/更新时间 7 列加 `sorter`，接入 hook
+
+## 设计细节
+
+1. **拖拽与排序冲突**：拖拽手柄 `stopPropagation` onClick，避免触发列头排序切换
+2. **固定列兼容**：ID 列 `fixed:'left'`、操作列 `fixed:'right'` 已是 `position:sticky`，ResizableTitle 检测 `fixed` 标记后不再覆盖 `position:relative`
+3. **高频写优化**：拖拽中只更新 state（onResize），拖拽结束才写 localStorage（onResizeEnd）
+4. **操作列排除**：`key` 含 `action` 或无 `dataIndex` 的列不注入拖拽手柄
+
+# 4. 验证结果
+
+| 验证项 | 结果 |
+|--------|------|
+| `cargo check --lib` | ✅ 通过（1 个存量 warning 与本次无关） |
+| `cargo test --lib` | ✅ 1489 passed，1 failed（`git_sync` 存量失败，main 分支同样失败，已用 stash 验证） |
+| `npx tsc --noEmit` | ✅ 零错误 |
+| `npx vitest run` | ✅ 27 文件 223 测试全部通过（含新增 20 个） |
+| `npm run build` | ✅ 成功（chunk 大小警告为存量） |
+| Playwright `054-table-interaction.spec.ts` | ✅ 9/9 通过（三列表渲染/拖拽手柄/排序写 localStorage/拖拽写 localStorage/刷新恢复排序/刷新恢复列宽） |
+
+# 5. 安全反思
+
+- **localStorage 输入不信任**：`getTablePrefs` 做 key 白名单 + JSON.parse try/catch + widths 数值有限性过滤 + sort.order 白名单，恶意/损坏数据静默 fallback 默认值
+- **无注入风险**：拖拽宽度经 `Math.max(MIN_WIDTH, ...)` 钳制；排序 field 只来自列定义
+- **无越权变更**：后端仅改 ORDER BY，不涉及权限/数据范围
+- **无敏感信息**：localStorage 只存列宽数字与排序字段名
+
+# 6. 已知限制
+
+- 环路列表后端默认排序从「最近更新优先」变为「ID 倒序」（已在需求澄清 4B 中确认接受）
+- 排序为前端客户端排序（数据全量加载，单页数据量可控；若未来改服务端分页需重评）
+- 列宽无「恢复默认」UI（清除 localStorage 对应 key 即可恢复）
+- 存量 clippy 告警 43 个、存量测试失败 1 个（git_sync），均为 main 分支既有问题，按规范不在本 PR 处理

--- a/docs/requirements/054-列表表格交互增强-需求.md
+++ b/docs/requirements/054-列表表格交互增强-需求.md
@@ -1,0 +1,92 @@
+# 0. 文件修改记录表
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-07-31 | 初始版本 — 列表表格交互增强（列宽拖拽 + 点击排序 + 默认ID倒序 + 状态持久化） |
+
+# 1. 背景（Why）
+
+项目三大业务列表（事项 TodoListView、任务 TasksTableView、环路 LoopListView）当前存在三个交互缺口：
+1. **列宽固定**，长文本被截断时用户无法自行调整；
+2. **点击列头不排序**，数据全量在前端，排序能力未开放；
+3. **默认排序不一致**（事项/任务按 `updated_at`、环路按 `updated_at`），后端也未统一 `ORDER BY id`。
+
+# 2. 目标（What，必须可验证）
+
+- [ ] G1：三个列表的所有列支持鼠标拖拽调整列宽，拖动流畅、不跳变
+- [ ] G2：三个列表的语义可排序列（ID、名称、状态、时间类）点击列头可升/降切换排序
+- [ ] G3：默认排序统一为 **ID 倒序**（`ORDER BY id DESC`），后端三个列表查询函数同步修改
+- [ ] G4：列宽与排序状态通过 localStorage 持久化，刷新页面后自动恢复
+
+# 3. 非目标（Explicitly Out of Scope）
+
+- 不改造设置页/仪表盘/弹窗等辅助表格（仅三大业务列表）
+- 不新增后端排序参数或分页参数
+- 不引入 `react-resizable` 等第三方拖拽库
+
+# 4. 使用场景 / 用户路径
+
+1. 用户进入事项/任务/环路列表页面，表格默认按 ID 倒序排列（最新创建的在前）
+2. 用户点击"标题"列头 → 按标题字母序升序排列，再次点击 → 降序
+3. 用户拖拽列分隔线调整列宽，拖完后刷新页面，列宽保持上次的值
+4. 用户离开页面再返回，上次使用的排序方式与列宽自动恢复
+
+# 5. 功能需求清单（Checklist）
+
+- [ ] FR1：自研 `ResizableTitle` 组件（Pointer Events，最小列宽 60px）
+- [ ] FR2：`useResizableColumns` hook 注入列宽 + 排序状态，读写 localStorage
+- [ ] FR3：`tablePrefs.ts` 纯函数层：localStorage 读写与容错
+- [ ] FR4：三个列表接入 hook，ID 列默认 `descend` 排序
+- [ ] FR5：后端 `get_todo_center` / `list_tasks` / `list_loops_with_counts` 改为 `ORDER BY id DESC`
+- [ ] FR6：`scroll.x` 动态计算（当前列宽求和），避免拖宽后被裁剪
+
+# 6. 约束条件
+
+- 技术：antd 6.3.6 Table 组件，React 19，TypeScript
+- 架构：前端纯客户端排序（数据已全量加载）
+- 安全：localStorage 读取必须 JSON.parse 容错，不信任外部输入
+- 性能：拖拽使用 Pointer Events（非 mouse，兼容触屏）
+
+# 7. 可修改 / 不可修改项
+
+- ❌ 不可修改：三大列表的后端分页逻辑、`rowSelection` 批量选择行为、onRow 点击跳转
+- ✅ 可调整：列初始宽度、可排序列范围、localStorage key 命名
+
+# 8. 接口与数据约定
+
+**localStorage 结构**：
+```
+Key: "ntd_table_prefs:todos" | "ntd_table_prefs:tasks" | "ntd_table_prefs:loops"
+Value (JSON): {
+  "widths": { "id": 80, "title": 200, "status": 90 },
+  "sort": { "field": "id", "order": "descend" }
+}
+```
+
+**后端排序变更**（仅 `ORDER BY` 子句）：
+
+| 函数 | 原排序 | 新排序 |
+|------|--------|--------|
+| `db/todo.rs:get_todo_center` | `ORDER BY updated_at DESC` | `ORDER BY id DESC` |
+| `db/task.rs:list_tasks` | `ORDER BY created_at DESC` | `ORDER BY id DESC` |
+| `db/loop_.rs:list_loops_with_counts` | `ORDER BY updated_at DESC` | `ORDER BY id DESC` |
+
+# 9. 验收标准
+
+- 如果用户拖拽列宽 ≥ 60px，则列宽跟随鼠标；拖至 < 60px 时自动锁定为 60px
+- 如果用户点击可排序列头，则数据按该列排序（升序→降序→取消）
+- 如果 localStorage 中无记录，则 ID 列默认按降序排列
+- 如果 localStorage 中有记录，则恢复上次列宽与排序
+- 如果 JSON 解析失败，则静默 fallback 到默认值，不抛异常
+
+# 10. 风险与已知不确定点
+
+- 后端改为 `id DESC` 后，环路列表不再按「最近更新优先」展示——已在 4B 选择中确认接受
+- `scroll.x` 动态计算：拖宽后表格可能产生横向滚动，需在测试中验证各分辨率下的行为
+
+# 11. 非目标
+
+- 不新增列
+- 不改变列的 render 逻辑
+- 不修改后端 API 参数
+- 不处理设置页/弹窗中的表格

--- a/frontend/src/components/common/ResizableTitle.tsx
+++ b/frontend/src/components/common/ResizableTitle.tsx
@@ -1,0 +1,126 @@
+/**
+ * ResizableTitle — 可拖拽列宽的 antd Table 表头 cell 组件。
+ *
+ * 设计要点：
+ * 1. 通过 antd Table 的 `components={{ header: { cell: ResizableTitle } }}` 注入；
+ *    列的 width / onResize / onResizeEnd 由列定义上的 `onHeaderCell` 透传进来。
+ * 2. 拖拽用 Pointer Events（非 Mouse Events），天然兼容触屏与鼠标。
+ * 3. `setPointerCapture` 把后续 pointermove/pointerup 路由到手柄元素，
+ *    即使指针快速移出表头也能持续追踪，避免"断线"。
+ * 4. 拖拽中禁用 document.body 的 userSelect，防止文本被意外选中。
+ * 5. 最小列宽 60px，防止用户把列拖成 0 宽导致内容消失。
+ * 6. 拖拽过程只回调 onResize（高频更新 state），结束时回调 onResizeEnd
+ *    （父级在此刻写 localStorage），避免拖拽期间高频写存储。
+ *
+ * 本组件不持有列宽 state，只通过回调通知父级 hook（useResizableColumns）。
+ */
+
+import React, { useRef } from 'react';
+
+/** 最小列宽（px）：低于此值锁定，防止列被拖成不可见。 */
+const MIN_WIDTH = 60;
+
+export interface ResizableTitleProps {
+  /** 当前列宽（由列定义 onHeaderCell 注入）。 */
+  width?: number;
+  /** 固定列标记（antd fixed: 'left'|'right'）：固定列已是 sticky 定位，
+      不能再设 position:relative（inline 样式会覆盖 class 的 sticky）。 */
+  fixed?: string | boolean;
+  /** 拖拽中回调：实时新宽度。 */
+  onResize?: (width: number) => void;
+  /** 拖拽结束回调：最终宽度（父级在此持久化）。 */
+  onResizeEnd?: (width: number) => void;
+  /** antd 透传的子节点（列标题文本）。 */
+  children?: React.ReactNode;
+  /** antd 透传的其他 th 属性（className / style 等）。 */
+  [key: string]: unknown;
+}
+
+/**
+ * 可拖拽表头 cell。
+ * 无 width 的列（操作列、选择框列等）退化为普通 th，不附加拖拽手柄。
+ */
+export const ResizableTitle: React.FC<ResizableTitleProps> = ({
+  width,
+  fixed,
+  onResize,
+  onResizeEnd,
+  children,
+  ...restProps
+}) => {
+  // 拖拽会话状态用 ref 存储：避免高频 pointermove 触发组件重渲染。
+  // dragging 用独立布尔值而非 startX===0 判断，因为 clientX 合法值可以是 0（屏幕左边缘）。
+  const draggingRef = useRef(false);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+  const latestWidthRef = useRef(0);
+
+  if (!width) {
+    return <th {...restProps}>{children}</th>;
+  }
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    // 只在主键（鼠标左键/触屏单指）触发，避免右键/中键误触。
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    draggingRef.current = true;
+    startXRef.current = e.clientX;
+    startWidthRef.current = width;
+    latestWidthRef.current = width;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    // 拖拽中禁止文本选中，避免用户看到蓝色高亮块。
+    document.body.style.userSelect = 'none';
+  };
+
+  const handlePointerMove = (e: React.PointerEvent) => {
+    if (!draggingRef.current) return;
+    const delta = e.clientX - startXRef.current;
+    const newWidth = Math.max(MIN_WIDTH, startWidthRef.current + delta);
+    latestWidthRef.current = newWidth;
+    onResize?.(newWidth);
+  };
+
+  const handlePointerUp = (e: React.PointerEvent) => {
+    if (!draggingRef.current) return;
+    draggingRef.current = false;
+    (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+    document.body.style.userSelect = '';
+    // 只在宽度真正变化时才通知结束，避免纯点击（未拖动）触发无谓的持久化。
+    if (latestWidthRef.current !== startWidthRef.current) {
+      onResizeEnd?.(latestWidthRef.current);
+    }
+  };
+
+  return (
+    <th
+      {...restProps}
+      style={{
+        ...((restProps.style as React.CSSProperties) ?? {}),
+        width,
+        // 固定列（fixed left/right）已由 antd class 设为 sticky，
+        // 不能再覆盖为 relative；非固定列需 relative 作为拖拽手柄的定位父级。
+        ...(fixed ? {} : { position: 'relative' as const }),
+      }}
+    >
+      {children}
+      {/* 拖拽手柄：表头右边缘 8px 热区；stopPropagation 防止触发列头排序切换。 */}
+      <span
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          position: 'absolute',
+          right: 0,
+          top: 0,
+          bottom: 0,
+          width: 8,
+          cursor: 'col-resize',
+          zIndex: 1,
+        }}
+      />
+    </th>
+  );
+};

--- a/frontend/src/components/common/tablePrefs.test.ts
+++ b/frontend/src/components/common/tablePrefs.test.ts
@@ -1,0 +1,84 @@
+/**
+ * tablePrefs 单元测试。
+ * 覆盖：白名单校验、JSON 容错、字段白名单、正常读写、清除。
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getTablePrefs, setTablePrefs, resetTablePrefs } from './tablePrefs';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('getTablePrefs', () => {
+  it('无记录时返回 null', () => {
+    expect(getTablePrefs('todos')).toBeNull();
+  });
+
+  it('非法 key 返回 null', () => {
+    localStorage.setItem('ntd_table_prefs:evil', '{}');
+    expect(getTablePrefs('evil')).toBeNull();
+  });
+
+  it('JSON 损坏返回 null（不抛异常）', () => {
+    localStorage.setItem('ntd_table_prefs:todos', '{invalid');
+    expect(getTablePrefs('todos')).toBeNull();
+  });
+
+  it('非对象 JSON 返回 null', () => {
+    localStorage.setItem('ntd_table_prefs:todos', '"string"');
+    expect(getTablePrefs('todos')).toBeNull();
+    localStorage.setItem('ntd_table_prefs:todos', '42');
+    expect(getTablePrefs('todos')).toBeNull();
+  });
+
+  it('widths 过滤非数字值', () => {
+    localStorage.setItem(
+      'ntd_table_prefs:todos',
+      JSON.stringify({ widths: { id: 80, title: 'abc', bad: -1 }, sort: { field: 'id', order: 'descend' } })
+    );
+    const prefs = getTablePrefs('todos');
+    expect(prefs?.widths).toEqual({ id: 80 });
+  });
+
+  it('非法 order 回退 null', () => {
+    localStorage.setItem(
+      'ntd_table_prefs:todos',
+      JSON.stringify({ widths: {}, sort: { field: 'id', order: 'invalid' } })
+    );
+    expect(getTablePrefs('todos')?.sort.order).toBeNull();
+  });
+
+  it('缺失 sort.field 回退 id', () => {
+    localStorage.setItem(
+      'ntd_table_prefs:todos',
+      JSON.stringify({ widths: {}, sort: { order: 'ascend' } })
+    );
+    expect(getTablePrefs('todos')?.sort.field).toBe('id');
+  });
+});
+
+describe('setTablePrefs', () => {
+  it('正常写入后可读回', () => {
+    setTablePrefs('tasks', { widths: { id: 60 }, sort: { field: 'id', order: 'ascend' } });
+    expect(getTablePrefs('tasks')?.widths.id).toBe(60);
+  });
+
+  it('非法 key 静默拒绝', () => {
+    expect(() =>
+      setTablePrefs('evil', { widths: {}, sort: { field: 'id', order: null } })
+    ).not.toThrow();
+    expect(localStorage.getItem('ntd_table_prefs:evil')).toBeNull();
+  });
+});
+
+describe('resetTablePrefs', () => {
+  it('清除后返回 null', () => {
+    setTablePrefs('loops', { widths: { id: 70 }, sort: { field: 'id', order: 'descend' } });
+    resetTablePrefs('loops');
+    expect(getTablePrefs('loops')).toBeNull();
+  });
+
+  it('非法 key 不抛异常', () => {
+    expect(() => resetTablePrefs('evil')).not.toThrow();
+  });
+});

--- a/frontend/src/components/common/tablePrefs.ts
+++ b/frontend/src/components/common/tablePrefs.ts
@@ -1,0 +1,96 @@
+/**
+ * tablePrefs — 列表表格用户偏好（列宽 + 排序）的 localStorage 读写纯函数层。
+ *
+ * 设计要点：
+ * 1. 纯函数无 React 依赖，可在单测中直接运行。
+ * 2. JSON.parse 失败静默返回 null（不信任 localStorage 中的外部输入）。
+ * 3. key 白名单校验：只允许 "todos" | "tasks" | "loops" 三个已知 tableKey。
+ * 4. 排序 order 白名单校验：只允许 "ascend" | "descend" | null。
+ */
+
+/** 排序方向白名单（与 antd SortOrder 对齐）。 */
+export type SortOrder = 'ascend' | 'descend' | null;
+
+/** 排序状态：field 为列 dataIndex，order 为方向。 */
+export interface SortState {
+  field: string;
+  order: SortOrder;
+}
+
+/** 单张表的完整偏好：列宽 map + 当前排序。 */
+export interface TablePrefs {
+  widths: Record<string, number>;
+  sort: SortState;
+}
+
+/** localStorage key 前缀，避免与项目其他 key 冲突。 */
+const PREFIX = 'ntd_table_prefs:';
+
+/** 允许的 tableKey 白名单：防止未知 key 写入/读取任意 localStorage 数据。 */
+const VALID_KEYS = new Set(['todos', 'tasks', 'loops']);
+
+/**
+ * 从 localStorage 读取指定表的偏好。
+ *
+ * 安全策略：
+ * - key 不在白名单 → 返回 null（拒绝读取）
+ * - JSON.parse 抛异常 → 返回 null（静默容错）
+ * - sort.field / sort.order 不在白名单 → 回退到 { field: 'id', order: 'descend' }
+ * - widths 中非数字值 → 过滤剔除
+ */
+export function getTablePrefs(tableKey: string): TablePrefs | null {
+  if (!VALID_KEYS.has(tableKey)) return null;
+  const raw = localStorage.getItem(PREFIX + tableKey);
+  if (raw === null) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null; // JSON 损坏：静默 fallback，不抛异常
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+
+  // widths：只保留值为有限数字的条目，防止恶意注入
+  const widths: Record<string, number> = {};
+  if (typeof obj.widths === 'object' && obj.widths !== null) {
+    for (const [k, v] of Object.entries(obj.widths as Record<string, unknown>)) {
+      if (typeof v === 'number' && Number.isFinite(v) && v > 0) {
+        widths[k] = v;
+      }
+    }
+  }
+
+  // sort：field 必须是字符串，order 必须在白名单内，否则回退默认
+  const rawSort = obj.sort as Record<string, unknown> | undefined;
+  const sort: SortState = {
+    field: typeof rawSort?.field === 'string' ? rawSort.field : 'id',
+    order:
+      rawSort?.order === 'ascend' || rawSort?.order === 'descend'
+        ? rawSort.order
+        : null,
+  };
+
+  return { widths, sort };
+}
+
+/**
+ * 把偏好写入 localStorage。
+ * key 不在白名单时静默拒绝，不抛异常（写失败不影响渲染）。
+ */
+export function setTablePrefs(tableKey: string, prefs: TablePrefs): void {
+  if (!VALID_KEYS.has(tableKey)) return;
+  try {
+    localStorage.setItem(PREFIX + tableKey, JSON.stringify(prefs));
+  } catch {
+    // localStorage 写满 / 隐私模式：静默失败，不影响功能
+  }
+}
+
+/** 清除指定表的偏好，下次访问回退到默认值。 */
+export function resetTablePrefs(tableKey: string): void {
+  if (!VALID_KEYS.has(tableKey)) return;
+  localStorage.removeItem(PREFIX + tableKey);
+}

--- a/frontend/src/components/loop-list/LoopListView.tsx
+++ b/frontend/src/components/loop-list/LoopListView.tsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Table } from 'antd';
 import { useApp } from '@/hooks/useApp';
 import { useBatchActions } from '@/components/todo-list/useBatchActions';
+import { useResizableColumns } from '@/hooks/useResizableColumns';
 import type { Tag as TagType } from '@/types';
 import type { LoopListItem } from '@/types/loop';
 import {
@@ -75,12 +76,14 @@ export function LoopListView({
   });
 
   // 列定义：抽为独立 useMemo，避免每次渲染重建（已拆到 buildColumns）
-  const columns = useMemo(() => buildColumns({
+  const rawColumns = useMemo(() => buildColumns({
     tags,
     onSelectLoop,
     onDelete,
     onToggleStatus,
   }), [tags, onSelectLoop, onDelete, onToggleStatus]);
+  // 054：注入可拖拽列宽 + 受控排序 + localStorage 持久化。
+  const { columns, tableProps } = useResizableColumns('loops', rawColumns);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
@@ -115,8 +118,8 @@ export function LoopListView({
           dataSource={items}
           loading={loading}
           size="small"
-          // 工艺名称/版本两列合并为单列「工艺」后，scroll.x 从 1440 收回 1360。
-          scroll={{ x: 1360 }}
+          // 054：scroll.x 由 hook 动态计算（列宽求和），替代原硬编码 1360
+          {...tableProps}
           pagination={{
             pageSize: 20,
             showSizeChanger: true,

--- a/frontend/src/components/loop-list/LoopListViewParts.tsx
+++ b/frontend/src/components/loop-list/LoopListViewParts.tsx
@@ -23,6 +23,7 @@ import {
 } from '@ant-design/icons';
 import { formatRelativeTime } from '@/utils/datetime';
 import { formatProcessText } from '@/utils/processText';
+import { makeSorter } from '@/hooks/useResizableColumns';
 import type { Tag as TagType } from '@/types';
 import type { LoopListItem } from '@/types/loop';
 
@@ -134,6 +135,8 @@ export function buildColumns({
       dataIndex: 'id',
       width: 70,
       fixed: 'left',
+      // 054：可排序列（ID 数值排序）
+      sorter: makeSorter<LoopListItem>('id'),
       render: (id: number) => (
         <span style={{ fontFamily: 'monospace', color: 'var(--color-text-tertiary)' }}>
           #{id}
@@ -144,6 +147,8 @@ export function buildColumns({
       title: '名称',
       dataIndex: 'name',
       ellipsis: true,
+      // 054：可排序列（名称字符串排序）
+      sorter: makeSorter<LoopListItem>('name'),
       render: (name: string, record) => (
         <a
           onClick={(e) => { e.stopPropagation(); onSelectLoop(record.id); }}
@@ -165,6 +170,8 @@ export function buildColumns({
       title: '状态',
       dataIndex: 'status',
       width: 100,
+      // 054：可排序列（状态枚举字符串排序）
+      sorter: makeSorter<LoopListItem>('status'),
       render: renderLoopStatusTag,
     },
     {
@@ -178,12 +185,16 @@ export function buildColumns({
       dataIndex: 'step_count',
       width: 70,
       align: 'center' as const,
+      // 054：可排序列（环节数数值排序）
+      sorter: makeSorter<LoopListItem>('step_count'),
     },
     {
       title: '待审批',
       dataIndex: 'pending_approval_count',
       width: 80,
       align: 'center' as const,
+      // 054：可排序列（待审批数数值排序）
+      sorter: makeSorter<LoopListItem>('pending_approval_count'),
       render: (n: number) => (n > 0 ? <Tag color="warning">{n}</Tag> : '-'),
     },
     {
@@ -196,12 +207,16 @@ export function buildColumns({
       title: '执行时间',
       dataIndex: 'last_execution_at',
       width: 130,
+      // 054：可排序列（ISO 时间字符串排序）
+      sorter: makeSorter<LoopListItem>('last_execution_at'),
       render: (t?: string | null) => t ? formatRelativeTime(t) : '-',
     },
     {
       title: '更新时间',
       dataIndex: 'updated_at',
       width: 130,
+      // 054：可排序列（ISO 时间字符串排序）
+      sorter: makeSorter<LoopListItem>('updated_at'),
       render: (t: string | null) => t ? formatRelativeTime(t) : '-',
     },
     {

--- a/frontend/src/components/tasks/TasksTableView.tsx
+++ b/frontend/src/components/tasks/TasksTableView.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/tasks/constants';
 import bundledApi from '@/api/bundled';
 import { formatProcessText } from '@/utils/processText';
+import { useResizableColumns, makeSorter } from '@/hooks/useResizableColumns';
 
 const { Text } = Typography;
 
@@ -55,6 +56,8 @@ function buildColumns(): ColumnsType<TaskItem> {
       dataIndex: 'id',
       key: 'id',
       width: 60,
+      // 054：可排序列（ID 数值排序）
+      sorter: makeSorter<TaskItem>('id'),
       render: (id: number) => <Text type="secondary">#{id}</Text>,
     },
     {
@@ -62,6 +65,8 @@ function buildColumns(): ColumnsType<TaskItem> {
       dataIndex: 'title',
       key: 'title',
       ellipsis: true,
+      // 054：可排序列（标题字符串排序）
+      sorter: makeSorter<TaskItem>('title'),
       render: (title: string) => <Text strong>{title}</Text>,
     },
     {
@@ -69,6 +74,8 @@ function buildColumns(): ColumnsType<TaskItem> {
       dataIndex: 'status',
       key: 'status',
       width: 100,
+      // 054：可排序列（状态枚举字符串排序）
+      sorter: makeSorter<TaskItem>('status'),
       render: (status: string) => (
         <Tag color={statusColor(status)}>{STATUS_LABEL[status] ?? status}</Tag>
       ),
@@ -78,6 +85,8 @@ function buildColumns(): ColumnsType<TaskItem> {
       dataIndex: 'complexity',
       key: 'complexity',
       width: 80,
+      // 054：可排序列（复杂度枚举字符串排序）
+      sorter: makeSorter<TaskItem>('complexity'),
       render: (complexity?: string) =>
         complexity ? (
           <Tag color={complexityColor(complexity)}>{complexityLabel(complexity)}</Tag>
@@ -113,6 +122,8 @@ function buildColumns(): ColumnsType<TaskItem> {
       dataIndex: 'created_at',
       key: 'created_at',
       width: 110,
+      // 054：可排序列（ISO 时间字符串排序）
+      sorter: makeSorter<TaskItem>('created_at'),
       render: (iso?: string) => <Text type="secondary">{formatDateShort(iso)}</Text>,
     },
   ];
@@ -205,7 +216,9 @@ export function TasksTableView({
   }, [tasks, statusFilter, searchKeyword]);
 
   // 列定义：useMemo 避免每次 render 重建造成 Table 性能抖动。
-  const columns = useMemo(() => buildColumns(), []);
+  const rawColumns = useMemo(() => buildColumns(), []);
+  // 054：注入可拖拽列宽 + 受控排序 + localStorage 持久化。
+  const { columns, tableProps } = useResizableColumns('tasks', rawColumns);
 
   // 批量删除确认：使用上下文 modal.confirm，保证弹窗随当前主题渲染；
   // 确认文案与危险按钮保持原样，避免引入额外交互变化。
@@ -274,8 +287,8 @@ export function TasksTableView({
           dataSource={visibleTasks}
           loading={loading}
           size="small"
-          // 工艺列从 130 扩到 220 以容纳 #id-名称-版本 三段式文本，scroll.x 同步加宽。
-          scroll={{ x: 1290 }}
+          // 054：scroll.x 由 hook 动态计算（列宽求和），替代原硬编码 1290
+          {...tableProps}
           pagination={{
             pageSize: 20,
             showSizeChanger: true,

--- a/frontend/src/components/todo-list/TodoListView.tsx
+++ b/frontend/src/components/todo-list/TodoListView.tsx
@@ -24,6 +24,7 @@ import {
   ThunderboltOutlined,
 } from '@ant-design/icons';
 import { useApp } from '@/hooks/useApp';
+import { useResizableColumns, makeSorter } from '@/hooks/useResizableColumns';
 import { useBatchActions } from './useBatchActions'; // .tsx 含 JSX（批量 Modal）
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { ExpertBadge } from '@/components/ExpertBadge';
@@ -196,6 +197,8 @@ function buildTodoColumns(
       dataIndex: 'id',
       width: 70,
       fixed: 'left',
+      // 054：可排序列（ID 数值排序）
+      sorter: makeSorter<TodoCenterItem>('id'),
       render: (id: number) => (
         <span style={{ fontFamily: 'monospace', color: 'var(--color-text-tertiary)' }}>
           #{id}
@@ -222,6 +225,8 @@ function buildTodoColumns(
       // scroll.x 时会被压成 0 宽（整列「消失」，用户曾因此报标题列丢失）
       width: 220,
       ellipsis: true,
+      // 054：可排序列（标题字符串排序）
+      sorter: makeSorter<TodoCenterItem>('title'),
       render: (title: string, record) => (
         <a
           onClick={(e) => { e.stopPropagation(); callbacks.onSelectTodo(record.id); }}
@@ -235,6 +240,8 @@ function buildTodoColumns(
       title: '状态',
       dataIndex: 'status',
       width: 100,
+      // 054：可排序列（状态枚举字符串排序）
+      sorter: makeSorter<TodoCenterItem>('status'),
       render: renderStatusTag,
     },
     {
@@ -287,12 +294,16 @@ function buildTodoColumns(
       title: '执行时间',
       dataIndex: 'last_execution_at',
       width: 130,
+      // 054：可排序列（ISO 时间字符串排序）
+      sorter: makeSorter<TodoCenterItem>('last_execution_at'),
       render: (t?: string | null) => (t ? formatRelativeTime(t) : '-'),
     },
     {
       title: '更新时间',
       dataIndex: 'updated_at',
       width: 130,
+      // 054：可排序列（ISO 时间字符串排序）
+      sorter: makeSorter<TodoCenterItem>('updated_at'),
       render: (t: string) => formatRelativeTime(t),
     },
     {
@@ -382,7 +393,10 @@ export function TodoListView({
 
   // 列定义：useMemo 避免每次渲染重建
   const callbacks = { onSelectTodo, onExecuteTodo, onExecuteWithArgs, onEditTodo, onDeleteTodo };
-  const columns = useMemo(() => buildTodoColumns(tags, callbacks), [tags, callbacks]);
+  const rawColumns = useMemo(() => buildTodoColumns(tags, callbacks), [tags, callbacks]);
+  // 054：注入可拖拽列宽 + 受控排序 + localStorage 持久化。
+  // 返回的 tableProps 包含 components / scroll / onChange，直接展开到 Table。
+  const { columns, tableProps } = useResizableColumns('todos', rawColumns);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
@@ -406,9 +420,8 @@ export function TodoListView({
           dataSource={items}
           loading={loading}
           size="small"
-          // scroll.x 必须 ≥ 所有固定宽列之和（新增环路列 160）：合计 1690，
-          // 取 1720 留余量；否则窗口变窄时弹性列会被压成 0 宽
-          scroll={{ x: 1720 }}
+          // 054：scroll.x 由 hook 动态计算（列宽求和），替代原硬编码 1720
+          {...tableProps}
           pagination={{
             pageSize: 20,
             showSizeChanger: true,

--- a/frontend/src/hooks/useResizableColumns.test.tsx
+++ b/frontend/src/hooks/useResizableColumns.test.tsx
@@ -47,6 +47,34 @@ describe('compareValues', () => {
   });
 });
 
+describe('makeSorter', () => {
+  it('按数字字段比较（委托 compareValues 数值分支）', () => {
+    const sorter = makeSorter<TestItem>('id');
+    expect(sorter({ id: 1, name: 'a' }, { id: 2, name: 'b' })).toBeLessThan(0);
+    expect(sorter({ id: 2, name: 'a' }, { id: 1, name: 'b' })).toBeGreaterThan(0);
+  });
+
+  it('按字符串字段比较（委托 compareValues localeCompare 分支）', () => {
+    const sorter = makeSorter<TestItem>('name');
+    expect(sorter({ id: 1, name: 'a' }, { id: 2, name: 'b' })).toBeLessThan(0);
+    expect(sorter({ id: 2, name: 'b' }, { id: 1, name: 'a' })).toBeGreaterThan(0);
+  });
+
+  it('两元素同字段相等时返回 0', () => {
+    const sorter = makeSorter<TestItem>('id');
+    expect(sorter({ id: 5, name: 'a' }, { id: 5, name: 'b' })).toBe(0);
+  });
+
+  it('字段缺失（undefined）走空字符串兜底，不抛错', () => {
+    interface WithOpt { id: number; tag?: string }
+    const sorter = makeSorter<WithOpt>('tag');
+    // 两边 tag 均缺失：都转 '' → 比较结果为 0
+    expect(sorter({ id: 1 }, { id: 2 })).toBe(0);
+    // 一方有值一方缺失：'a' 排在 '' 之后 → 正数
+    expect(sorter({ id: 1, tag: 'a' }, { id: 2 })).toBeGreaterThan(0);
+  });
+});
+
 describe('useResizableColumns', () => {
   it('无 localStorage 时默认按 ID 倒序', () => {
     const { result } = renderHook(() => useResizableColumns('todos', RAW_COLUMNS));

--- a/frontend/src/hooks/useResizableColumns.test.tsx
+++ b/frontend/src/hooks/useResizableColumns.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * useResizableColumns 单元测试。
+ *
+ * 验证：
+ * 1. 默认排序兜底（无 localStorage 时 ID 倒序）
+ * 2. localStorage 中排序偏好被正确注入列定义（sortOrder）
+ * 3. localStorage 中列宽偏好被正确注入列定义（width）
+ * 4. scroll.x 动态计算（列宽求和）
+ * 5. tableProps 结构完整（components / scroll / onChange）
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ColumnsType } from 'antd/es/table';
+import { useResizableColumns, compareValues, makeSorter } from './useResizableColumns';
+import { setTablePrefs } from '@/components/common/tablePrefs';
+
+interface TestItem {
+  id: number;
+  name: string;
+}
+
+/** 最小列定义：ID + 名称，供测试注入。 */
+const RAW_COLUMNS: ColumnsType<TestItem> = [
+  { title: 'ID', dataIndex: 'id', key: 'id', width: 70, sorter: makeSorter<TestItem>('id') },
+  { title: '名称', dataIndex: 'name', key: 'name', width: 200, sorter: makeSorter<TestItem>('name') },
+];
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('compareValues', () => {
+  it('数字比较', () => {
+    expect(compareValues(1, 2)).toBeLessThan(0);
+    expect(compareValues(2, 1)).toBeGreaterThan(0);
+    expect(compareValues(1, 1)).toBe(0);
+  });
+
+  it('字符串比较', () => {
+    expect(compareValues('a', 'b')).toBeLessThan(0);
+    expect(compareValues('b', 'a')).toBeGreaterThan(0);
+  });
+
+  it('null/undefined 转为空字符串比较', () => {
+    expect(compareValues(null, 'a')).toBeLessThan(0);
+    expect(compareValues(undefined, '')).toBe(0);
+  });
+});
+
+describe('useResizableColumns', () => {
+  it('无 localStorage 时默认按 ID 倒序', () => {
+    const { result } = renderHook(() => useResizableColumns('todos', RAW_COLUMNS));
+    const idCol = result.current.columns.find(c => c.key === 'id');
+    // 默认 ID 列 sortOrder = descend
+    expect((idCol as Record<string, unknown>)?.sortOrder).toBe('descend');
+    // 其他列 sortOrder = null
+    const nameCol = result.current.columns.find(c => c.key === 'name');
+    expect((nameCol as Record<string, unknown>)?.sortOrder).toBeNull();
+  });
+
+  it('localStorage 中的排序偏好被注入列定义', () => {
+    setTablePrefs('todos', { widths: {}, sort: { field: 'name', order: 'ascend' } });
+    const { result } = renderHook(() => useResizableColumns('todos', RAW_COLUMNS));
+    const nameCol = result.current.columns.find(c => c.key === 'name');
+    expect((nameCol as Record<string, unknown>)?.sortOrder).toBe('ascend');
+    const idCol = result.current.columns.find(c => c.key === 'id');
+    expect((idCol as Record<string, unknown>)?.sortOrder).toBeNull();
+  });
+
+  it('localStorage 中的列宽偏好覆盖默认宽度', () => {
+    setTablePrefs('todos', { widths: { id: 150 }, sort: { field: 'id', order: 'descend' } });
+    const { result } = renderHook(() => useResizableColumns('todos', RAW_COLUMNS));
+    const idCol = result.current.columns.find(c => c.key === 'id');
+    expect(idCol?.width).toBe(150);
+    // 未保存的列保持默认宽度
+    const nameCol = result.current.columns.find(c => c.key === 'name');
+    expect(nameCol?.width).toBe(200);
+  });
+
+  it('scroll.x = 列宽求和', () => {
+    const { result } = renderHook(() => useResizableColumns('todos', RAW_COLUMNS));
+    // 默认宽度 70 + 200 = 270
+    expect(result.current.tableProps.scroll?.x).toBe(270);
+  });
+
+  it('tableProps 包含 components / onChange', () => {
+    const { result } = renderHook(() => useResizableColumns('todos', RAW_COLUMNS));
+    expect(result.current.tableProps.components).toBeDefined();
+    expect(result.current.tableProps.onChange).toBeDefined();
+  });
+
+  it('每列都有 onHeaderCell（注入 width + onResize）', () => {
+    const { result } = renderHook(() => useResizableColumns('todos', RAW_COLUMNS));
+    for (const col of result.current.columns) {
+      expect(col.onHeaderCell).toBeDefined();
+      // onHeaderCell 的参数是列定义本身（antd 内部透传），不是行数据
+      const headerProps = col.onHeaderCell?.(col as never);
+      expect(headerProps).toHaveProperty('width');
+      expect(headerProps).toHaveProperty('onResize');
+    }
+  });
+});

--- a/frontend/src/hooks/useResizableColumns.tsx
+++ b/frontend/src/hooks/useResizableColumns.tsx
@@ -1,0 +1,138 @@
+/**
+ * useResizableColumns — 给 antd Table 列定义注入「可拖拽列宽 + 受控排序 + 持久化」。
+ *
+ * 功能：
+ * 1. 列宽注入：为每列添加 `onHeaderCell`（透传 width + onResize/onResizeEnd），
+ *    并返回 `components` 供 Table 替换表头 cell 为 ResizableTitle。
+ * 2. 受控排序：为可排序列注入 `sortOrder`（由 state 驱动），
+ *    Table onChange 时提取排序状态并写 localStorage。
+ *    排序本身由 antd Table 内置机制完成（列定义中的 `sorter` 比较函数）。
+ * 3. 动态 scroll.x：当前列宽求和，替代硬编码的固定值。
+ * 4. 持久化：列宽拖拽结束 / 排序切换时写 localStorage（tablePrefs 纯函数层）。
+ *
+ * 用法：
+ *   const { columns, components, tableProps } = useResizableColumns('todos', rawColumns);
+ *   <Table columns={columns} {...tableProps} dataSource={items} />
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import type { ColumnsType } from 'antd/es/table';
+import type { TableProps } from 'antd';
+import { ResizableTitle } from '@/components/common/ResizableTitle';
+import { getTablePrefs, setTablePrefs, type SortState } from '@/components/common/tablePrefs';
+
+/** 默认排序兜底：localStorage 无记录时按 ID 倒序。 */
+const DEFAULT_SORT: SortState = { field: 'id', order: 'descend' };
+
+/**
+ * 通用排序比较器：数字按数值、日期按时间戳、其余按中文字符串比较。
+ * 供列定义的 `sorter` 字段直接引用，避免每个列表重复写比较逻辑。
+ */
+export function compareValues(a: unknown, b: unknown): number {
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  if (a instanceof Date && b instanceof Date) return a.getTime() - b.getTime();
+  const sa = String(a ?? '');
+  const sb = String(b ?? '');
+  return sa.localeCompare(sb, 'zh-CN');
+}
+
+/**
+ * 为列定义生成 `sorter` 比较函数。
+ * 用法：在列定义中加 `sorter: (a, b) => compareValues(a.title, b.title)`。
+ */
+export function makeSorter<T>(field: keyof T) {
+  return (a: T, b: T) => compareValues(a[field], b[field]);
+}
+
+export function useResizableColumns<T>(
+  tableKey: string,
+  rawColumns: ColumnsType<T>,
+) {
+  // 初始化：从 localStorage 读偏好，无记录则用默认值。
+  const [prefs, setPrefs] = useState(() => {
+    const saved = getTablePrefs(tableKey);
+    return {
+      widths: saved?.widths ?? {},
+      sort: saved?.sort ?? DEFAULT_SORT,
+    };
+  });
+
+  /** 拖拽中更新列宽 state（高频，不写存储）。 */
+  const handleResize = useCallback((colKey: string, width: number) => {
+    setPrefs(prev => ({ ...prev, widths: { ...prev.widths, [colKey]: width } }));
+  }, []);
+
+  /** 拖拽结束：写 localStorage + 更新 state。 */
+  const handleResizeEnd = useCallback(
+    (colKey: string, width: number) => {
+      setPrefs(prev => {
+        const next = { ...prev, widths: { ...prev.widths, [colKey]: width } };
+        setTablePrefs(tableKey, next);
+        return next;
+      });
+    },
+    [tableKey],
+  );
+
+  /** Table onChange：提取排序状态并持久化。 */
+  const handleTableChange = useCallback<
+    NonNullable<TableProps<T>['onChange']>
+  >(
+    (_pagination, _filters, sorter) => {
+      // antd 单排序时 sorter 为对象；多排序为数组（本设计只用单排序）。
+      const s = Array.isArray(sorter) ? sorter[0] : sorter;
+      const nextSort: SortState = s?.field
+        ? { field: String(s.field), order: s.order ?? null }
+        : DEFAULT_SORT;
+      setPrefs(prev => {
+        const next = { ...prev, sort: nextSort };
+        setTablePrefs(tableKey, next);
+        return next;
+      });
+    },
+    [tableKey],
+  );
+
+  /** 注入列宽与排序后的列定义。 */
+  const columns = useMemo<ColumnsType<T>>(() => {
+    return rawColumns.map(col => {
+      // ColumnGroupType 无 dataIndex（是分组容器）；本项目全部用扁平 ColumnType，
+      // 用 'dataIndex' in col 收窄类型，TypeScript 才允许访问。
+      const dataIndex = 'dataIndex' in col ? col.dataIndex : undefined;
+      const key = String(col.key ?? dataIndex ?? '');
+      const defaultWidth = typeof col.width === 'number' ? col.width : 120;
+      const currentWidth = prefs.widths[key] ?? defaultWidth;
+      // 操作列（key 含 action 或无 dataIndex）不注入拖拽手柄，保持固定宽度。
+      const isActionCol = !dataIndex || key.toLowerCase().includes('action');
+      return {
+        ...col,
+        width: currentWidth,
+        onHeaderCell: () => ({
+          width: currentWidth,
+          // 透传 fixed 标记：ResizableTitle 据此决定是否覆盖 position（固定列已是 sticky）
+          fixed: 'fixed' in col ? col.fixed : undefined,
+          onResize: isActionCol ? undefined : (w: number) => handleResize(key, w),
+          onResizeEnd: isActionCol ? undefined : (w: number) => handleResizeEnd(key, w),
+        }),
+        // 可排序列：注入受控 sortOrder；无 sorter 的列不动。
+        ...(col.sorter
+          ? { sortOrder: (prefs.sort.field === key ? prefs.sort.order : null) as 'ascend' | 'descend' | null }
+          : {}),
+      };
+    });
+  }, [rawColumns, prefs, handleResize, handleResizeEnd]);
+
+  /** 动态 scroll.x：当前列宽求和。 */
+  const scrollX = useMemo(() => {
+    return columns.reduce((acc, col) => acc + (typeof col.width === 'number' ? col.width : 0), 0);
+  }, [columns]);
+
+  return {
+    columns,
+    tableProps: {
+      components: { header: { cell: ResizableTitle } },
+      scroll: { x: scrollX },
+      onChange: handleTableChange,
+    } satisfies Partial<TableProps<T>>,
+  };
+}

--- a/frontend/tests/054-table-interaction.spec.ts
+++ b/frontend/tests/054-table-interaction.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * 054-列表表格交互增强 — Playwright 功能验证。
+ *
+ * 验证三大列表（事项/任务/环路）：
+ * 1. Table 渲染正常（列宽/拖拽手柄正确渲染）
+ * 2. 可排序列点击后显示排序指示器
+ * 3. 排序/列宽状态写入 localStorage，刷新后恢复
+ */
+import { test, expect } from '@playwright/test';
+
+const BASE = 'http://localhost:18088';
+
+/**
+ * 辅助：跳转到目标路由并等 Table 渲染完毕。
+ *
+ * 用 page.addInitScript（而非 context.addInitScript）保证脚本在页面
+ * 下次导航时、任何应用 JS 之前执行——事项页 readInitialView 依赖
+ * localStorage 中的 ntd_items_view='list' 才渲染 table 形态。
+ */
+async function gotoList(
+  page: import('@playwright/test').Page,
+  route: string,
+  init?: { key: string; value: string },
+) {
+  if (init) {
+    await page.addInitScript(([k, v]) => localStorage.setItem(k, v), [init.key, init.value]);
+  }
+  await page.goto(`${BASE}/#${route}`);
+  await page.waitForSelector('.ant-table-thead th', { timeout: 10000 });
+  await page.waitForTimeout(500);
+}
+
+/** 检查列头的拖拽手柄（cursor: col-resize 的 span）是否存在。 */
+async function hasResizableHandle(page: import('@playwright/test').Page, colText: string) {
+  const th = page.locator('.ant-table-thead th').filter({ hasText: colText }).first();
+  const handle = th.locator('span[style*="col-resize"]');
+  return (await handle.count()) > 0;
+}
+
+/** 检查列头是否有激活的排序指示器。 */
+async function hasActiveSortIndicator(page: import('@playwright/test').Page, colText: string) {
+  const th = page.locator('.ant-table-thead th').filter({ hasText: colText }).first();
+  return (await th.locator('.ant-table-column-sorter').count()) > 0;
+}
+
+/** 读取 localStorage 中指定表的偏好。 */
+async function readPrefs(page: import('@playwright/test').Page, tableKey: string) {
+  const raw = await page.evaluate(k => localStorage.getItem(`ntd_table_prefs:${k}`), tableKey);
+  return raw ? JSON.parse(raw) : null;
+}
+
+test.describe('054-列表表格交互增强', () => {
+  // ── 事项列表（需 ntd_items_view=list 切到 table 形态）──
+  test('事项列表：Table 渲染正常，列有拖拽手柄', async ({ page }) => {
+    await gotoList(page, '/todos', { key: 'ntd_items_view', value: 'list' });
+    await expect(page.locator('.ant-table-thead th').filter({ hasText: 'ID' }).first()).toBeVisible();
+    await expect(page.locator('.ant-table-thead th').filter({ hasText: '标题' }).first()).toBeVisible();
+    expect(await hasResizableHandle(page, 'ID')).toBe(true);
+  });
+
+  test('事项列表：点击可排序列写入 localStorage', async ({ page }) => {
+    await gotoList(page, '/todos', { key: 'ntd_items_view', value: 'list' });
+    await page.locator('.ant-table-thead th').filter({ hasText: '标题' }).first().click();
+    await page.waitForTimeout(300);
+    const prefs = await readPrefs(page, 'todos');
+    expect(prefs).not.toBeNull();
+    expect(prefs.sort.field).toBe('title');
+    expect(['ascend', 'descend']).toContain(prefs.sort.order);
+  });
+
+  test('事项列表：ID 列默认倒序（localStorage 无记录时）', async ({ page }) => {
+    await gotoList(page, '/todos', { key: 'ntd_items_view', value: 'list' });
+    // 默认排序不点击任何列时，ID 列应有激活的降序指示
+    const idTh = page.locator('.ant-table-thead th').filter({ hasText: 'ID' }).first();
+    // antd 受控 sortOrder=descend 时 th 带 ant-table-column-sort class
+    await expect(idTh).toHaveClass(/ant-table-column-sort/);
+  });
+
+  // ── 任务列表 ──
+  test('任务列表：Table 渲染正常，列有拖拽手柄', async ({ page }) => {
+    await gotoList(page, '/tasks');
+    await expect(page.locator('.ant-table-thead th').filter({ hasText: '标题' }).first()).toBeVisible();
+    expect(await hasResizableHandle(page, '标题')).toBe(true);
+  });
+
+  test('任务列表：点击可排序列写入 localStorage', async ({ page }) => {
+    await gotoList(page, '/tasks');
+    await page.locator('.ant-table-thead th').filter({ hasText: '状态' }).first().click();
+    await page.waitForTimeout(300);
+    const prefs = await readPrefs(page, 'tasks');
+    expect(prefs).not.toBeNull();
+    expect(prefs.sort.field).toBe('status');
+  });
+
+  // ── 环路列表 ──
+  test('环路列表：Table 渲染正常，列有拖拽手柄', async ({ page }) => {
+    await gotoList(page, '/loops');
+    await expect(page.locator('.ant-table-thead th').filter({ hasText: '名称' }).first()).toBeVisible();
+    expect(await hasResizableHandle(page, '名称')).toBe(true);
+  });
+
+  test('环路列表：列宽拖拽后写入 localStorage', async ({ page }) => {
+    await gotoList(page, '/loops');
+    const idTh = page.locator('.ant-table-thead th').filter({ hasText: 'ID' }).first();
+    const handle = idTh.locator('span[style*="col-resize"]');
+    const box = await handle.boundingBox();
+    test.skip(!box, '拖拽手柄未找到');
+    // 拖拽：向右拖 50px
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width / 2 + 50, box!.y + box!.height / 2, { steps: 5 });
+    await page.mouse.up();
+    await page.waitForTimeout(300);
+    const prefs = await readPrefs(page, 'loops');
+    expect(prefs).not.toBeNull();
+    // 默认 ID 列宽 70px，拖宽后应 > 70
+    expect(prefs.widths.id).toBeGreaterThan(70);
+  });
+
+  // ── 刷新恢复 ──
+  test('刷新后排序状态恢复', async ({ page }) => {
+    await gotoList(page, '/todos', { key: 'ntd_items_view', value: 'list' });
+    await page.locator('.ant-table-thead th').filter({ hasText: '标题' }).first().click();
+    await page.waitForTimeout(300);
+    await page.reload();
+    await page.waitForSelector('.ant-table-thead th', { timeout: 10000 });
+    await page.waitForTimeout(500);
+    // 刷新后排序指示器仍在标题列
+    expect(await hasActiveSortIndicator(page, '标题')).toBe(true);
+    const prefs = await readPrefs(page, 'todos');
+    expect(prefs.sort.field).toBe('title');
+  });
+
+  test('刷新后列宽状态恢复', async ({ page }) => {
+    await gotoList(page, '/loops');
+    const idTh = page.locator('.ant-table-thead th').filter({ hasText: 'ID' }).first();
+    const handle = idTh.locator('span[style*="col-resize"]');
+    const box = await handle.boundingBox();
+    test.skip(!box, '拖拽手柄未找到');
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width / 2 + 50, box!.y + box!.height / 2, { steps: 5 });
+    await page.mouse.up();
+    await page.waitForTimeout(300);
+    await page.reload();
+    await page.waitForSelector('.ant-table-thead th', { timeout: 10000 });
+    await page.waitForTimeout(500);
+    // 刷新后 ID 列宽保持拖宽后的值
+    const width = await page.locator('.ant-table-thead th').filter({ hasText: 'ID' }).first()
+      .evaluate(el => el.clientWidth);
+    expect(width).toBeGreaterThan(70);
+  });
+});


### PR DESCRIPTION
## 实现了什么

三大业务列表（事项/任务/环路）的 antd Table 交互增强：
1. **自由拖动列宽**：自研 `ResizableTitle` 表头 cell（Pointer Events + setPointerCapture，最小列宽 60px，**零新依赖**）
2. **点击排序**：语义可排序列点击列头切换升/降序（受控 `sortOrder`）
3. **默认 ID 倒序**：前端 ID 列默认 `descend` + 后端三个列表查询统一 `ORDER BY id DESC`
4. **状态持久化**：列宽与排序写 localStorage（`ntd_table_prefs:<tableKey>`），刷新自动恢复

## 与需求的对应关系

需求文档：`docs/requirements/054-列表表格交互增强-需求.md`
设计文档：`docs/design/054-列表表格交互增强-设计.md`
实现总结：`docs/requirements/054-列表表格交互增强-实现总结.md`

澄清决策（用户确认 1A2A3B4B5B）：
- 范围：仅 3 个主业务列表
- 拖拽：自研轻量组件，不引 react-resizable
- 排序列：仅语义列（ID/名称/状态/时间类），操作列/标签列不排
- 默认排序：前端 defaultSortOrder + 后端 ORDER BY id DESC 双保险
- 持久化：localStorage

## 关键实现点

| 层 | 文件 | 说明 |
|---|------|------|
| 后端 | `db/todo.rs` `db/task.rs` `db/loop_.rs` | 3 处 ORDER BY 统一为 id DESC |
| 前端 | `common/tablePrefs.ts` | localStorage 纯函数层（白名单+容错） |
| 前端 | `common/ResizableTitle.tsx` | 拖拽表头 cell（固定列 sticky 兼容） |
| 前端 | `hooks/useResizableColumns.tsx` | 注入列宽/受控排序/动态 scroll.x |
| 前端 | 三个列表 View | 接入 hook + 列加 sorter |

## 测试与验证结果

- `npx tsc --noEmit` ✅ 零错误
- `npx vitest run` ✅ 27 文件 223 测试（含新增 20 个）
- `npm run build` ✅ 成功
- Playwright `tests/054-table-interaction.spec.ts` ✅ 9/9（三列表渲染/拖拽手柄/排序与列宽写 localStorage/刷新恢复）
- `cargo check --lib` ✅ 通过
- `cargo test --lib` ✅ 1489 passed / 1 failed（`git_sync` 存量失败，main 分支同样失败，已 stash 验证与本次无关）
- `cargo clippy --all-targets -- -D warnings`：43 个存量错误（main 分支 45 个），非本次引入

## 已知限制

- 环路列表默认排序从「最近更新优先」变为「ID 倒序」（需求澄清中已确认）
- 排序为前端客户端排序（数据全量加载，未来改服务端分页需重评）
- 列宽无「恢复默认」按钮（清 localStorage 对应 key 即可）