### PR TITLE
feat(055): 工艺CLI命令扩展+name/guid自动解析

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,21 @@ ntd loop stats <id>                 # 执行统计
 ntd loop execution blackboard <eid> --human   # 人类可读的黑板视图
 ```
 
+#### 工艺（Process）操作
+
+```bash
+ntd process list                         # 列出所有工艺模板（--system / --user 过滤）
+ntd process recommend "搭持续交付流水线"  # 按任务描述推荐工艺
+ntd process show 4p12s-delivery          # 查看工艺详情（name 或 guid 都行）
+ntd process run 4p12s-delivery --workspace /path/to/proj   # 装到工作空间并触发
+ntd process loops 4p12s-delivery         # 该工艺装出了哪些 loop
+ntd process upgrade 4p12s-delivery --loop-id 7             # 把 loop 升级到工艺最新版
+ntd process create --name my-proc --file ./proc.yaml       # 新建自建工艺
+ntd process delete my-proc               # 删除自建工艺
+ntd process versions my-proc             # 版本历史
+ntd process diff my-proc 1.2.0 --base 1.1.0                # 版本对比
+```
+
 #### 标签 / 统计 / 工作空间
 
 ```bash

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -392,25 +392,114 @@ pub enum TagAction {
 
 // ============== Loop Commands ==============
 
-/// 工艺模板 CLI 动作：列出 / 查看 / 安装并执行 / 审计状态。
+/// 工艺模板 CLI 动作。
+///
+/// 主标识统一用位置参数 `<NAME_OR_GUID>`：传人类可读的 name（如 4p12s-delivery）
+/// 或 guid（UUID v4）都行，由 `resolve_process_guid` 自动解析——修复了 040 之后
+/// 旧版把 name 直接塞进 guid 路径段导致 404 的 bug。
+///
+/// 风格与 todo/loop 对齐：位置参数放主标识、内容走 --file/--stdin、输出复用全局
+/// --output/--fields。后端能力（recommend/create/delete/upgrade/loops/versions/diff）
+/// 已就绪，这里只做 CLI 封装。
 #[derive(Debug, Clone, Subcommand)]
 pub enum ProcessAction {
-    /// 列出所有工艺模板
-    List,
-    /// 查看工艺模板详情
-    Show {
-        /// 工艺模板名称（如 4p12s-delivery）
-        name: String,
+    /// 列出所有工艺模板（--system 只看系统模板，--user 只看用户自建，二者互斥）
+    List {
+        /// 只看系统工艺（bundled 同步来的）
+        #[arg(long)]
+        system: bool,
+        /// 只看用户自建工艺
+        #[arg(long)]
+        user: bool,
     },
-    /// 安装工艺模板到工作空间并触发执行
+    /// 查看工艺模板详情（name 或 guid 都可）
+    Show {
+        /// 工艺 name（如 4p12s-delivery）或 guid（UUID v4）
+        name_or_guid: String,
+    },
+    /// 根据任务描述推荐合适的工艺（AI 最常用：描述目标 → 拿到匹配工艺 + 理由）
+    Recommend {
+        /// 任务描述（自然语言，描述你想达成什么目标）
+        description: String,
+    },
+    /// 新建用户工艺（YAML 正文走 --file 或 --stdin）
+    Create {
+        /// 工艺唯一标识，^[a-zA-Z0-9_-]+$（--stdin 模式下可省略，从 body 读）
+        #[arg(short = 'n', long)]
+        name: Option<String>,
+
+        /// 人类可读名称（可空，回退到 name）
+        #[arg(long)]
+        display_name: Option<String>,
+
+        /// 分类（可空）
+        #[arg(long)]
+        category: Option<String>,
+
+        /// 复杂度（可空）
+        #[arg(long)]
+        complexity: Option<String>,
+
+        /// 版本（可空，默认由后端给 1.0.0）
+        #[arg(long)]
+        version: Option<String>,
+
+        /// 从文件读取工艺 YAML 正文
+        #[arg(short = 'f', long)]
+        file: Option<String>,
+
+        /// 从 stdin 读取完整 JSON body（覆盖以上字段）
+        #[arg(long)]
+        stdin: bool,
+    },
+    /// 删除用户工艺（系统工艺后端会拒绝，错误经统一通道透出）
+    Delete {
+        /// 工艺 name 或 guid
+        name_or_guid: String,
+    },
+    /// 安装工艺到工作空间并触发执行
     Run {
-        /// 工艺模板名称
-        name: String,
-        /// 目标工作空间路径
+        /// 工艺 name 或 guid
+        name_or_guid: String,
+
+        /// 目标工作空间路径（按 path 反查 workspace_id）
+        /// process 域一直按 path 消费（与 todo/loop 的 --workspace-id 不同），
+        /// 因为 AI 手里通常是项目路径而非 ws_id，按 path 更顺手。
         #[arg(long = "workspace")]
         workspace: String,
     },
-    /// 查看工艺实例审计状态
+    /// 把指定 loop 升级到工艺模板最新版
+    Upgrade {
+        /// 工艺 name 或 guid
+        name_or_guid: String,
+
+        /// 要升级的 loop id（先用 `ntd process loops <name-or-guid>` 查到）
+        #[arg(long = "loop-id")]
+        loop_id: i64,
+    },
+    /// 列出该工艺实例化的所有 loop
+    Loops {
+        /// 工艺 name 或 guid
+        name_or_guid: String,
+    },
+    /// 查看工艺版本历史
+    Versions {
+        /// 工艺 name 或 guid
+        name_or_guid: String,
+    },
+    /// 对比两个版本的工艺正文 diff
+    Diff {
+        /// 工艺 name 或 guid
+        name_or_guid: String,
+
+        /// 目标版本号（如 1.2.0）
+        version: String,
+
+        /// 基准版本号
+        #[arg(long = "base")]
+        base: String,
+    },
+    /// 查看工艺实例审计状态（按 loop execution id 遍历工作空间查找）
     ExecutionStatus {
         /// Loop execution ID
         id: i64,
@@ -968,6 +1057,86 @@ async fn handle_workspace(
 }
 
 // ============== Process Handlers ==============
+// 工艺 CLI：所有子命令在 handle_process 分派，每个动作拆成独立小函数（≤30 行）。
+// handle_process 只做 match 路由、不掺业务逻辑（与 run_command 同构）。
+
+/// name/guid 解析结果。Ambiguous 携带候选 guid 列表，供错误提示直接列出，AI 可复制重试。
+#[derive(Debug, PartialEq)]
+enum GuidResolution {
+    Found(String),
+    NotFound,
+    Ambiguous(Vec<String>),
+}
+
+/// 纯逻辑：在已拉取的工艺模板列表里，把 name-or-guid 解析成 guid。
+/// 抽出来不碰网络，便于单测覆盖 0/1/多条与 guid 直命中等分支。
+///
+/// 规则：guid 全局唯一，先看 key 本身是否某条 guid，命中即返回；
+/// 否则按 name 匹配——0 条 NotFound、1 条返回该 guid、>1 条 Ambiguous（040 起 name 不唯一）。
+fn resolve_guid_from_items(items: &[Value], key: &str) -> GuidResolution {
+    // 1. guid 精确命中：guid 唯一，找到即确定，无需再判 name。
+    let guid_hit = items
+        .iter()
+        .find(|t| t.get("guid").and_then(Value::as_str) == Some(key));
+    if let Some(guid) = guid_hit.and_then(|t| t.get("guid").and_then(Value::as_str)) {
+        return GuidResolution::Found(guid.to_string());
+    }
+    // 2. 按 name 匹配：收集所有同名项的 guid，用数量区分 NotFound/唯一/歧义。
+    let hits: Vec<String> = items
+        .iter()
+        .filter(|t| t.get("name").and_then(Value::as_str) == Some(key))
+        .filter_map(|t| t.get("guid").and_then(Value::as_str).map(str::to_string))
+        .collect();
+    match hits.len() {
+        0 => GuidResolution::NotFound,
+        1 => GuidResolution::Found(hits[0].clone()),
+        _ => GuidResolution::Ambiguous(hits),
+    }
+}
+
+/// 网络：GET /bundled/processes 拉全量后用纯逻辑解析。
+/// 一次请求搞定，避免「guid 直查 404 → 再 list」的二次往返；
+/// name 命中多条时给出候选 guid 清单，引导 AI 改用 guid 重试。
+async fn resolve_process_guid(client: &ApiClient, key: &str) -> Result<String> {
+    let resp: ClientResponse<Vec<Value>> = client.get("/bundled/processes").await?;
+    let items = resp.data.unwrap_or_default();
+    match resolve_guid_from_items(&items, key) {
+        GuidResolution::Found(guid) => Ok(guid),
+        GuidResolution::NotFound => Err(anyhow::anyhow!(
+            "未找到工艺「{}」。用 `ntd process list` 查看可用工艺。",
+            key
+        )),
+        GuidResolution::Ambiguous(guids) => Err(anyhow::anyhow!(
+            "工艺名「{}」命中 {} 条，请改用 guid：\n  {}",
+            key,
+            guids.len(),
+            guids.join("\n  ")
+        )),
+    }
+}
+
+/// 按 path 反查 workspace_id。project_directories.path 不保证唯一，取第一条匹配。
+/// 抽出来供 run 复用，统一 path→id 解析口径（修复旧版 /v1/project-directories 双前缀 404）。
+async fn resolve_workspace_id_by_path(client: &ApiClient, path: &str) -> Result<i64> {
+    let resp: ClientResponse<Vec<Value>> = client.get("/project-directories").await?;
+    let ws_id = resp
+        .data
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .find_map(|ws| {
+            let p = ws.get("path").and_then(Value::as_str)?;
+            if p == path {
+                ws.get("id").and_then(Value::as_i64)
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!("工作空间 {} 未找到，用 `ntd workspace list` 查看已注册工作空间", path)
+        })?;
+    Ok(ws_id)
+}
 
 #[allow(clippy::print_stdout)]
 async fn handle_process(
@@ -976,72 +1145,294 @@ async fn handle_process(
     output: &OutputFormat,
     fields: &Option<String>,
 ) -> Result<()> {
+    // 纯分派：每个动作一个 process_* 小函数，本函数不掺业务逻辑（与 run_command 同构）。
+    // arm 较多是工艺能力齐全的结果，但每条都是单行调用、无嵌套，符合「扁平分派」豁免。
     match action {
-        ProcessAction::List => {
-            let resp: ClientResponse<Vec<serde_json::Value>> =
-                client.get("/bundled/processes").await?;
-            print_response(&resp, output, fields)?;
+        ProcessAction::List { system, user } => {
+            process_list(client, *system, *user, output, fields).await
         }
-        ProcessAction::Show { name } => {
-            let encoded = percent_encode_slug(name);
-            let path = format!("/bundled/processes/{}", encoded);
-            let resp: ClientResponse<serde_json::Value> = client.get(&path).await?;
-            print_response(&resp, output, fields)?;
+        ProcessAction::Show { name_or_guid } => {
+            process_show(client, name_or_guid, output, fields).await
         }
-        ProcessAction::Run { name, workspace } => {
-            run_process_install(client, name, workspace, output, fields).await?
+        ProcessAction::Recommend { description } => {
+            process_recommend(client, description, output, fields).await
+        }
+        ProcessAction::Create { name, display_name, category, complexity, version, file, stdin } => {
+            // 7 个字段收拢成结构体再传，避免 process_create 触发 too_many_arguments。
+            let args = ProcessCreateArgs {
+                name: name.as_deref(),
+                display_name: display_name.as_deref(),
+                category: category.as_deref(),
+                complexity: complexity.as_deref(),
+                version: version.as_deref(),
+                file: file.as_deref(),
+                stdin: *stdin,
+            };
+            process_create(client, &args, output, fields).await
+        }
+        ProcessAction::Delete { name_or_guid } => {
+            process_delete(client, name_or_guid, output, fields).await
+        }
+        ProcessAction::Run { name_or_guid, workspace } => {
+            run_process_install(client, name_or_guid, workspace, output, fields).await
+        }
+        ProcessAction::Upgrade { name_or_guid, loop_id } => {
+            process_upgrade(client, name_or_guid, *loop_id, output, fields).await
+        }
+        ProcessAction::Loops { name_or_guid } => {
+            process_loops(client, name_or_guid, output, fields).await
+        }
+        ProcessAction::Versions { name_or_guid } => {
+            process_versions(client, name_or_guid, output, fields).await
+        }
+        ProcessAction::Diff { name_or_guid, version, base } => {
+            process_diff(client, name_or_guid, version, base, output, fields).await
         }
         ProcessAction::ExecutionStatus { id } => {
-            query_execution_status(client, *id, output, fields).await?
+            query_execution_status(client, *id, output, fields).await
         }
     }
+}
+
+/// list：--system/--user 决定 ?is_system 查询参数（同传报错，二者语义互斥）。
+async fn process_list(
+    client: &ApiClient,
+    system: bool,
+    user: bool,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
+    let path = match (system, user) {
+        (true, true) => return Err(anyhow::anyhow!("--system 与 --user 互斥，请只选其一")),
+        (true, false) => "/bundled/processes?is_system=true",
+        (false, true) => "/bundled/processes?is_system=false",
+        (false, false) => "/bundled/processes",
+    };
+    let resp: ClientResponse<Vec<Value>> = client.get(path).await?;
+    print_response(&resp, output, fields)?;
     Ok(())
 }
 
-/// ProcessRun：查找工作空间 → 安装工艺模板 → 打印结果。
+/// show：先 name-or-guid → guid，再取详情。修复旧版把 name 塞进 guid 槽的 bug。
+async fn process_show(
+    client: &ApiClient,
+    name_or_guid: &str,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
+    let guid = resolve_process_guid(client, name_or_guid).await?;
+    let path = format!("/bundled/processes/{}", percent_encode_slug(&guid));
+    let resp: ClientResponse<Value> = client.get(&path).await?;
+    print_response(&resp, output, fields)?;
+    Ok(())
+}
+
+/// recommend：把任务描述发给后端，返回按 score 排序的推荐工艺 + reasons。
+async fn process_recommend(
+    client: &ApiClient,
+    description: &str,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
+    let body = serde_json::json!({ "description": description });
+    let resp: ClientResponse<Value> = client.post("/processes/recommend", &body).await?;
+    print_response(&resp, output, fields)?;
+    Ok(())
+}
+
+/// Create 子命令的 7 个字段收拢成一个结构，避免 process_create 参数过多触发 too_many_arguments。
+/// 借用 Create arm 解构出的 &String → &str，零拷贝传给 body 构造。
+struct ProcessCreateArgs<'a> {
+    name: Option<&'a str>,
+    display_name: Option<&'a str>,
+    category: Option<&'a str>,
+    complexity: Option<&'a str>,
+    version: Option<&'a str>,
+    file: Option<&'a str>,
+    stdin: bool,
+}
+
+/// 新建用户工艺。body 构造抽到 build_create_body，本函数保持纤薄只发请求。
+async fn process_create(
+    client: &ApiClient,
+    args: &ProcessCreateArgs<'_>,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
+    let body = build_create_body(args)?;
+    let resp: ClientResponse<Value> = client.post("/processes", &body).await?;
+    print_response(&resp, output, fields)?;
+    Ok(())
+}
+
+/// 构造新建工艺请求体。
+/// 两条来源：--stdin 读全量 JSON body；否则 --name + --file(definition) 组装，可选元数据按需附上。
+fn build_create_body(args: &ProcessCreateArgs<'_>) -> Result<Value> {
+    if args.stdin {
+        // read_stdin_json 已返回 Result<Value>，直接转发，无需 Ok(...?) 多此一举。
+        return read_stdin_json();
+    }
+    let name = args
+        .name
+        .ok_or_else(|| anyhow::anyhow!("新建工艺需要 --name（或用 --stdin 传完整 body）"))?;
+    let definition = read_definition_source(args.file)?;
+    let mut obj = serde_json::Map::new();
+    obj.insert("name".to_string(), Value::String(name.to_string()));
+    obj.insert("definition".to_string(), Value::String(definition));
+    // 可选元数据：只附用户显式传入的字段，避免把 null 写进 body。
+    for (k, v) in [
+        ("display_name", args.display_name),
+        ("category", args.category),
+        ("complexity", args.complexity),
+        ("version", args.version),
+    ] {
+        if let Some(val) = v {
+            obj.insert(k.to_string(), Value::String(val.to_string()));
+        }
+    }
+    Ok(Value::Object(obj))
+}
+
+/// 读取工艺 YAML 正文来源。非 stdin 模式下 --file 必填，缺失给出可操作的错误。
+fn read_definition_source(file: Option<&str>) -> Result<String> {
+    match file {
+        Some(p) => std::fs::read_to_string(p)
+            .map_err(|e| anyhow::anyhow!("读取 YAML 文件 {} 失败: {}", p, e)),
+        None => Err(anyhow::anyhow!(
+            "新建工艺需要 YAML 正文：用 --file <yaml> 或 --stdin 传入"
+        )),
+    }
+}
+
+/// delete：name-or-guid → guid → DELETE。系统工艺或有实例 loop 时后端会拒绝。
+async fn process_delete(
+    client: &ApiClient,
+    name_or_guid: &str,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
+    let guid = resolve_process_guid(client, name_or_guid).await?;
+    let path = format!("/processes/{}", percent_encode_slug(&guid));
+    let resp: ClientResponse<Value> = client.delete(&path).await?;
+    print_response(&resp, output, fields)?;
+    Ok(())
+}
+
+/// upgrade：把指定 loop 升级到工艺模板最新版。
+async fn process_upgrade(
+    client: &ApiClient,
+    name_or_guid: &str,
+    loop_id: i64,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
+    let guid = resolve_process_guid(client, name_or_guid).await?;
+    let path = format!(
+        "/processes/{}/loops/{}/upgrade",
+        percent_encode_slug(&guid),
+        loop_id
+    );
+    let resp: ClientResponse<Value> = client.post(&path, &serde_json::Value::Null).await?;
+    print_response(&resp, output, fields)?;
+    Ok(())
+}
+
+/// loops：列出该工艺实例化的全部 loop（含各 loop 执行次数）。
+async fn process_loops(
+    client: &ApiClient,
+    name_or_guid: &str,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
+    let guid = resolve_process_guid(client, name_or_guid).await?;
+    let path = format!("/processes/{}/loops", percent_encode_slug(&guid));
+    let resp: ClientResponse<Value> = client.get(&path).await?;
+    print_response(&resp, output, fields)?;
+    Ok(())
+}
+
+/// versions：该工艺的版本历史（id/version/updated_at/source_path）。
+async fn process_versions(
+    client: &ApiClient,
+    name_or_guid: &str,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
+    let guid = resolve_process_guid(client, name_or_guid).await?;
+    let path = format!("/processes/{}/versions", percent_encode_slug(&guid));
+    let resp: ClientResponse<Value> = client.get(&path).await?;
+    print_response(&resp, output, fields)?;
+    Ok(())
+}
+
+/// diff：对比 base → version 两个版本的工艺正文逐行 diff。
+async fn process_diff(
+    client: &ApiClient,
+    name_or_guid: &str,
+    version: &str,
+    base: &str,
+    output: &OutputFormat,
+    fields: &Option<String>,
+) -> Result<()> {
+    let guid = resolve_process_guid(client, name_or_guid).await?;
+    let path = format!(
+        "/processes/{}/versions/{}/diff?base={}",
+        percent_encode_slug(&guid),
+        percent_encode_slug(version),
+        percent_encode_slug(base)
+    );
+    let resp: ClientResponse<Value> = client.get(&path).await?;
+    print_response(&resp, output, fields)?;
+    Ok(())
+}
+
+/// ProcessRun：path→workspace_id → name/guid→guid → 安装 → 打印结果。
+/// 线性管道：三步紧密依赖上一步、每步只调一次，拆开反而要传一堆中间参数，故按豁免保留为流水线。
 #[allow(clippy::print_stdout)]
 async fn run_process_install(
-    client: &ApiClient, name: &str, workspace: &str,
-    output: &OutputFormat, fields: &Option<String>,
+    client: &ApiClient,
+    name_or_guid: &str,
+    workspace: &str,
+    output: &OutputFormat,
+    fields: &Option<String>,
 ) -> Result<()> {
-    let ws_resp: ClientResponse<Vec<serde_json::Value>> = client.get("/v1/project-directories").await?;
-    let ws_list = ws_resp.data.as_deref().unwrap_or(&[]);
-    let ws_id = ws_list.iter().find_map(|ws| {
-        let path = ws.get("path").and_then(|p| p.as_str())?;
-        if path == workspace { ws.get("id").and_then(|id| id.as_i64()) } else { None }
-    }).ok_or_else(|| anyhow::anyhow!("工作空间 {} 未找到", workspace))?;
+    let ws_id = resolve_workspace_id_by_path(client, workspace).await?;
+    let guid = resolve_process_guid(client, name_or_guid).await?;
     let install_req = serde_json::json!({ "workspace_id": ws_id });
-    let install_path = format!("/bundled/processes/{}/install", percent_encode_slug(name));
-    let install_resp: ClientResponse<serde_json::Value> = client.post(&install_path, &install_req).await?;
-    println!("工艺模板「{}」已安装到工作空间「{}」", name, workspace);
+    let install_path = format!("/bundled/processes/{}/install", percent_encode_slug(&guid));
+    let install_resp: ClientResponse<Value> = client.post(&install_path, &install_req).await?;
+    println!("工艺模板「{}」已安装到工作空间「{}」", name_or_guid, workspace);
     if let Some(ref data) = install_resp.data {
-        if let Some(loop_id) = data.get("loop_id").and_then(|v| v.as_i64()) {
-            println!("创建 Loop #{}，请在前端或 CLI 启用后触发执行", loop_id);
+        if let Some(loop_id) = data.get("loop_id").and_then(Value::as_i64) {
+            println!("创建 Loop #{}，可用 `ntd process upgrade` 升级或在前端启用触发", loop_id);
         }
     }
     print_response(&install_resp, output, fields)?;
     Ok(())
 }
 
-/// ProcessExecutionStatus：遍历工作空间查找审计数据。
+/// ProcessExecutionStatus：遍历工作空间 → loop → 查找审计数据。
+/// audit 端点是 workspace/loop 作用域的，CLI 不持有这层映射，只能穷举查找命中即返回。
 #[allow(clippy::print_stdout)]
 async fn query_execution_status(
-    client: &ApiClient, id: i64,
-    output: &OutputFormat, fields: &Option<String>,
+    client: &ApiClient,
+    id: i64,
+    output: &OutputFormat,
+    fields: &Option<String>,
 ) -> Result<()> {
-    let ws_resp: ClientResponse<Vec<serde_json::Value>> = client.get("/v1/project-directories").await?;
-    let ws_data = ws_resp.data.as_deref().unwrap_or(&[]);
-    for ws in ws_data {
-        let Some(ws_id) = ws.get("id").and_then(|v| v.as_i64()) else { continue };
-        let loops_resp: ClientResponse<Vec<serde_json::Value>> =
-            match client.get(&format!("/v1/workspaces/{}/loops", ws_id)).await {
+    let ws_resp: ClientResponse<Vec<Value>> = client.get("/project-directories").await?;
+    for ws in ws_resp.data.as_deref().unwrap_or(&[]) {
+        let Some(ws_id) = ws.get("id").and_then(Value::as_i64) else { continue };
+        // 修复旧版 /v1/workspaces 双前缀 404：client 已自动补 /api/v1。
+        let loops_resp: ClientResponse<Vec<Value>> =
+            match client.get(&format!("/workspaces/{}/loops", ws_id)).await {
                 Ok(r) => r,
                 Err(_) => continue,
             };
         for lp in loops_resp.data.as_deref().unwrap_or(&[]) {
-            let Some(lp_id) = lp.get("id").and_then(|v| v.as_i64()) else { continue };
-            let audit_path = format!("/v1/workspaces/{}/loops/{}/executions/{}/audit", ws_id, lp_id, id);
-            if let Ok(audit_resp) = client.get::<ClientResponse<serde_json::Value>>(&audit_path).await {
+            let Some(lp_id) = lp.get("id").and_then(Value::as_i64) else { continue };
+            let audit_path = format!("/workspaces/{}/loops/{}/executions/{}/audit", ws_id, lp_id, id);
+            if let Ok(audit_resp) = client.get::<ClientResponse<Value>>(&audit_path).await {
                 if audit_resp.data.is_some() {
                     return print_response(&audit_resp, output, fields);
                 }
@@ -1949,6 +2340,330 @@ mod tests {
         });
         let out = render_blackboard_to_string(Some(&data));
         assert!(out.contains("异常处理"), "missing anomaly handler name: {out}");
+    }
+
+    // ===== Process CLI 解析测试 =====
+    // 每个新子命令一条 try_parse_from 断言，沿用现有 test_cli_parse_* 风格，
+    // 确保命令面/flag/位置参数与设计文档一致。
+
+    #[test]
+    fn test_cli_parse_process_list_default() {
+        // 无过滤：列出全部工艺
+        let cli = Cli::try_parse_from(["ntd", "process", "list"]).unwrap();
+        match cli.command {
+            Commands::Process { action: ProcessAction::List { system, user } } => {
+                assert!(!system && !user);
+            }
+            _ => panic!("Expected Process::List"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_process_list_filters() {
+        // --system / --user 两个互斥过滤开关各解析一次
+        let cli = Cli::try_parse_from(["ntd", "process", "list", "--system"]).unwrap();
+        match cli.command {
+            Commands::Process { action: ProcessAction::List { system, user } } => {
+                assert!(system && !user);
+            }
+            _ => panic!("Expected Process::List --system"),
+        }
+        let cli = Cli::try_parse_from(["ntd", "process", "list", "--user"]).unwrap();
+        match cli.command {
+            Commands::Process { action: ProcessAction::List { system, user } } => {
+                assert!(!system && user);
+            }
+            _ => panic!("Expected Process::List --user"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_process_show() {
+        // show 接受 name 或 guid（运行期解析，CLI 层只校验位置参数到位）
+        let cli = Cli::try_parse_from(["ntd", "process", "show", "4p12s-delivery"]).unwrap();
+        match cli.command {
+            Commands::Process { action: ProcessAction::Show { name_or_guid } } => {
+                assert_eq!(name_or_guid, "4p12s-delivery");
+            }
+            _ => panic!("Expected Process::Show"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_process_recommend() {
+        // recommend：位置参数是任务描述，含中文/空格也应以单参传入
+        let cli =
+            Cli::try_parse_from(["ntd", "process", "recommend", "Rust 持续交付流水线"]).unwrap();
+        match cli.command {
+            Commands::Process { action: ProcessAction::Recommend { description } } => {
+                assert_eq!(description, "Rust 持续交付流水线");
+            }
+            _ => panic!("Expected Process::Recommend"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_process_create_file() {
+        // 非 stdin：--name 必填 + 可选元数据 + --file 读 YAML
+        let cli = Cli::try_parse_from([
+            "ntd", "process", "create",
+            "--name", "my-delivery",
+            "--display-name", "我的交付",
+            "--category", "devops",
+            "--complexity", "high",
+            "--version", "1.0.0",
+            "--file", "/tmp/delivery.yaml",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Process {
+                action:
+                    ProcessAction::Create {
+                        name, display_name, category, complexity, version, file, stdin,
+                    },
+            } => {
+                assert_eq!(name.as_deref(), Some("my-delivery"));
+                assert_eq!(display_name.as_deref(), Some("我的交付"));
+                assert_eq!(category.as_deref(), Some("devops"));
+                assert_eq!(complexity.as_deref(), Some("high"));
+                assert_eq!(version.as_deref(), Some("1.0.0"));
+                assert_eq!(file.as_deref(), Some("/tmp/delivery.yaml"));
+                assert!(!stdin);
+            }
+            _ => panic!("Expected Process::Create"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_process_create_stdin() {
+        // --stdin 模式：name 可省略，body 从 stdin 读
+        let cli = Cli::try_parse_from(["ntd", "process", "create", "--stdin"]).unwrap();
+        match cli.command {
+            Commands::Process { action: ProcessAction::Create { stdin, name, .. } } => {
+                assert!(stdin);
+                assert!(name.is_none());
+            }
+            _ => panic!("Expected Process::Create --stdin"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_process_delete() {
+        let cli = Cli::try_parse_from(["ntd", "process", "delete", "abc-123-guid"]).unwrap();
+        match cli.command {
+            Commands::Process { action: ProcessAction::Delete { name_or_guid } } => {
+                assert_eq!(name_or_guid, "abc-123-guid");
+            }
+            _ => panic!("Expected Process::Delete"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_process_run() {
+        // run：位置 name-or-guid + --workspace 路径
+        let cli = Cli::try_parse_from([
+            "ntd", "process", "run", "4p12s-delivery", "--workspace", "/tmp/proj",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Process { action: ProcessAction::Run { name_or_guid, workspace } } => {
+                assert_eq!(name_or_guid, "4p12s-delivery");
+                assert_eq!(workspace, "/tmp/proj");
+            }
+            _ => panic!("Expected Process::Run"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_process_upgrade() {
+        let cli =
+            Cli::try_parse_from(["ntd", "process", "upgrade", "my-proc", "--loop-id", "7"]).unwrap();
+        match cli.command {
+            Commands::Process { action: ProcessAction::Upgrade { name_or_guid, loop_id } } => {
+                assert_eq!(name_or_guid, "my-proc");
+                assert_eq!(loop_id, 7);
+            }
+            _ => panic!("Expected Process::Upgrade"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_process_loops() {
+        let cli = Cli::try_parse_from(["ntd", "process", "loops", "my-proc"]).unwrap();
+        match cli.command {
+            Commands::Process { action: ProcessAction::Loops { name_or_guid } } => {
+                assert_eq!(name_or_guid, "my-proc");
+            }
+            _ => panic!("Expected Process::Loops"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_process_versions() {
+        let cli = Cli::try_parse_from(["ntd", "process", "versions", "my-proc"]).unwrap();
+        match cli.command {
+            Commands::Process { action: ProcessAction::Versions { name_or_guid } } => {
+                assert_eq!(name_or_guid, "my-proc");
+            }
+            _ => panic!("Expected Process::Versions"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_process_diff() {
+        // diff：位置 name-or-guid + 位置目标版本 + --base 基准版本
+        let cli =
+            Cli::try_parse_from(["ntd", "process", "diff", "my-proc", "1.2.0", "--base", "1.1.0"])
+                .unwrap();
+        match cli.command {
+            Commands::Process { action: ProcessAction::Diff { name_or_guid, version, base } } => {
+                assert_eq!(name_or_guid, "my-proc");
+                assert_eq!(version, "1.2.0");
+                assert_eq!(base, "1.1.0");
+            }
+            _ => panic!("Expected Process::Diff"),
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_process_execution_status() {
+        // execution-status：保留命令，确认 kebab-case 子命令名可解析
+        let cli = Cli::try_parse_from(["ntd", "process", "execution-status", "42"]).unwrap();
+        match cli.command {
+            Commands::Process { action: ProcessAction::ExecutionStatus { id } } => {
+                assert_eq!(id, 42);
+            }
+            _ => panic!("Expected Process::ExecutionStatus"),
+        }
+    }
+
+    // ===== name/guid 解析纯逻辑测试 =====
+    // resolve_guid_from_items 不碰网络，直接喂数据断言 0/1/多条与优先级分支。
+
+    /// 构造一份模拟的 GET /bundled/processes data，覆盖唯一 name、guid 直命中、同名多条。
+    fn sample_process_items() -> Vec<Value> {
+        vec![
+            json!({ "id": 1, "guid": "11111111-1111-1111-1111-111111111111", "name": "alpha" }),
+            json!({ "id": 2, "guid": "22222222-2222-2222-2222-222222222222", "name": "beta" }),
+            // 同名 gamma 两条：模拟 040 后 name 不唯一的歧义场景
+            json!({ "id": 3, "guid": "33333333-3333-3333-3333-333333333333", "name": "gamma" }),
+            json!({ "id": 4, "guid": "44444444-4444-4444-4444-444444444444", "name": "gamma" }),
+        ]
+    }
+
+    #[test]
+    fn test_resolve_guid_from_items_by_guid() {
+        // 传 guid 直接命中，唯一确定
+        let items = sample_process_items();
+        let key = "22222222-2222-2222-2222-222222222222";
+        assert_eq!(resolve_guid_from_items(&items, key), GuidResolution::Found(key.to_string()));
+    }
+
+    #[test]
+    fn test_resolve_guid_from_items_by_name_unique() {
+        // name 唯一命中：返回该条的 guid
+        let items = sample_process_items();
+        match resolve_guid_from_items(&items, "beta") {
+            GuidResolution::Found(g) => assert_eq!(g, "22222222-2222-2222-2222-222222222222"),
+            other => panic!("expected Found, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_resolve_guid_from_items_by_name_ambiguous() {
+        // name 命中多条：返回 Ambiguous 并携带全部候选 guid，供错误提示列出
+        let items = sample_process_items();
+        match resolve_guid_from_items(&items, "gamma") {
+            GuidResolution::Ambiguous(g) => {
+                assert_eq!(g.len(), 2);
+                assert!(g.contains(&"33333333-3333-3333-3333-333333333333".to_string()));
+                assert!(g.contains(&"44444444-4444-4444-4444-444444444444".to_string()));
+            }
+            other => panic!("expected Ambiguous, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_resolve_guid_from_items_not_found() {
+        let items = sample_process_items();
+        assert_eq!(resolve_guid_from_items(&items, "nope"), GuidResolution::NotFound);
+    }
+
+    #[test]
+    fn test_resolve_guid_from_items_guid_priority_over_name() {
+        // 极端：某条 name 恰好等于另一条的 guid 字符串时，guid 直命中应优先、不误判为 name
+        let items = vec![
+            json!({ "guid": "special-guid", "name": "alpha" }),
+            json!({ "guid": "real-guid", "name": "special-guid" }),
+        ];
+        assert_eq!(
+            resolve_guid_from_items(&items, "special-guid"),
+            GuidResolution::Found("special-guid".to_string())
+        );
+    }
+
+    /// 写一段内容到系统临时目录的固定文件，返回路径供 build_create_body 测 --file 来源。
+    /// 不用 tempfile 的 guard（drop 即删），改用固定路径 + 测试结束手动清理，避免生命周期问题。
+    fn temp_yaml_with(content: &str) -> String {
+        let path = std::env::temp_dir().join("ntd_cli_test_def.yaml");
+        std::fs::write(&path, content).expect("write temp file");
+        path.to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn test_build_create_body_name_and_file() {
+        // 非 stdin：name + 文件正文组装，可选元数据按需附上，未传字段不应出现
+        let tmp = temp_yaml_with("process: dummy");
+        let args = ProcessCreateArgs {
+            name: Some("my-proc"),
+            display_name: Some("显示名"),
+            category: None,
+            complexity: None,
+            version: Some("2.0.0"),
+            file: Some(&tmp),
+            stdin: false,
+        };
+        let body = build_create_body(&args).unwrap();
+        assert_eq!(body["name"], "my-proc");
+        assert_eq!(body["definition"], "process: dummy");
+        assert_eq!(body["display_name"], "显示名");
+        assert_eq!(body["version"], "2.0.0");
+        // 未传字段不应落进 body，避免把 null 写给后端
+        assert!(body.get("category").is_none());
+        assert!(body.get("complexity").is_none());
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
+    fn test_build_create_body_requires_name_without_stdin() {
+        // 非 stdin 且无 --name：给出可操作错误，而不是静默构造空 name
+        let args = ProcessCreateArgs {
+            name: None,
+            display_name: None,
+            category: None,
+            complexity: None,
+            version: None,
+            file: None,
+            stdin: false,
+        };
+        let err = build_create_body(&args).unwrap_err();
+        assert!(err.to_string().contains("--name"), "应提示 --name: {}", err);
+    }
+
+    #[test]
+    fn test_build_create_body_requires_file_without_stdin() {
+        // 有 name 但无 --file 且非 stdin：提示用 --file 或 --stdin
+        let args = ProcessCreateArgs {
+            name: Some("my-proc"),
+            display_name: None,
+            category: None,
+            complexity: None,
+            version: None,
+            file: None,
+            stdin: false,
+        };
+        let err = build_create_body(&args).unwrap_err();
+        assert!(err.to_string().contains("--file"), "应提示 --file: {}", err);
     }
 
     /// 把 render_blackboard 的全部输出收集到 String，便于测试断言关键片段。

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -1146,7 +1146,7 @@ async fn handle_process(
     fields: &Option<String>,
 ) -> Result<()> {
     // 纯分派：每个动作一个 process_* 小函数，本函数不掺业务逻辑（与 run_command 同构）。
-    // arm 较多是工艺能力齐全的结果，但每条都是单行调用、无嵌套，符合「扁平分派」豁免。
+    // 函数体未超 50 行、无需豁免；arm 多是工艺能力齐全的结果，每条都是单行调用、无嵌套。
     match action {
         ProcessAction::List { system, user } => {
             process_list(client, *system, *user, output, fields).await
@@ -1202,12 +1202,17 @@ async fn process_list(
     output: &OutputFormat,
     fields: &Option<String>,
 ) -> Result<()> {
+    // 两个过滤开关语义互斥：同传会让后端困惑该返回哪一类，提前在客户端拦下并给出可操作提示。
     let path = match (system, user) {
         (true, true) => return Err(anyhow::anyhow!("--system 与 --user 互斥，请只选其一")),
+        // is_system=true 只返回 bundled 同步来的系统工艺
         (true, false) => "/bundled/processes?is_system=true",
+        // is_system=false 只返回用户自建工艺
         (false, true) => "/bundled/processes?is_system=false",
+        // 都不传：返回全量，与旧版 list 行为一致
         (false, false) => "/bundled/processes",
     };
+    // 列表端点返回数组，交 print_response 统一按 --output/--fields 渲染（AI/脚本友好）
     let resp: ClientResponse<Vec<Value>> = client.get(path).await?;
     print_response(&resp, output, fields)?;
     Ok(())
@@ -1220,7 +1225,9 @@ async fn process_show(
     output: &OutputFormat,
     fields: &Option<String>,
 ) -> Result<()> {
+    // 后端 040 起按 guid 寻址，直接传 name 进 {guid} 路径段会 404，必须先解析成 guid
     let guid = resolve_process_guid(client, name_or_guid).await?;
+    // guid 是 UUID 无特殊字符，encode 实际是 no-op；保留是为与其它路径一致的防御习惯
     let path = format!("/bundled/processes/{}", percent_encode_slug(&guid));
     let resp: ClientResponse<Value> = client.get(&path).await?;
     print_response(&resp, output, fields)?;
@@ -1234,7 +1241,9 @@ async fn process_recommend(
     output: &OutputFormat,
     fields: &Option<String>,
 ) -> Result<()> {
+    // recommend 端点只吃一个 description 字段（见后端 RecommendRequest），直接拼 body
     let body = serde_json::json!({ "description": description });
+    // client 自动补 /api/v1；返回按 score 排序的推荐工艺 + reasons
     let resp: ClientResponse<Value> = client.post("/processes/recommend", &body).await?;
     print_response(&resp, output, fields)?;
     Ok(())
@@ -1311,8 +1320,10 @@ async fn process_delete(
     output: &OutputFormat,
     fields: &Option<String>,
 ) -> Result<()> {
+    // 同 show：先解析成 guid 再入 URL，避免 name 直传 404
     let guid = resolve_process_guid(client, name_or_guid).await?;
     let path = format!("/processes/{}", percent_encode_slug(&guid));
+    // 系统工艺 / 已有实例 loop 时后端会 409 拒绝，错误经 print_response 抛 anyhow 透出
     let resp: ClientResponse<Value> = client.delete(&path).await?;
     print_response(&resp, output, fields)?;
     Ok(())
@@ -1327,11 +1338,13 @@ async fn process_upgrade(
     fields: &Option<String>,
 ) -> Result<()> {
     let guid = resolve_process_guid(client, name_or_guid).await?;
+    // 升级按 (guid, loop_id) 定位；loop 不属于该工艺时后端返回 400
     let path = format!(
         "/processes/{}/loops/{}/upgrade",
         percent_encode_slug(&guid),
         loop_id
     );
+    // upgrade 无请求体，传 Null 占位（client.post 要求一个可序列化的 body）
     let resp: ClientResponse<Value> = client.post(&path, &serde_json::Value::Null).await?;
     print_response(&resp, output, fields)?;
     Ok(())
@@ -1345,6 +1358,7 @@ async fn process_loops(
     fields: &Option<String>,
 ) -> Result<()> {
     let guid = resolve_process_guid(client, name_or_guid).await?;
+    // 返回该工艺实例化的全部 loop，含各 loop 执行次数（后端批量聚合，避免 N+1）
     let path = format!("/processes/{}/loops", percent_encode_slug(&guid));
     let resp: ClientResponse<Value> = client.get(&path).await?;
     print_response(&resp, output, fields)?;
@@ -1359,6 +1373,7 @@ async fn process_versions(
     fields: &Option<String>,
 ) -> Result<()> {
     let guid = resolve_process_guid(client, name_or_guid).await?;
+    // 按 guid 聚合版本历史（040 起 name 可重复，不能按 name 聚合版本）
     let path = format!("/processes/{}/versions", percent_encode_slug(&guid));
     let resp: ClientResponse<Value> = client.get(&path).await?;
     print_response(&resp, output, fields)?;
@@ -1375,6 +1390,7 @@ async fn process_diff(
     fields: &Option<String>,
 ) -> Result<()> {
     let guid = resolve_process_guid(client, name_or_guid).await?;
+    // 版本号是 semver（含 '.'），percent_encode_slug 把 '.' 列为安全字符，不会被破坏
     let path = format!(
         "/processes/{}/versions/{}/diff?base={}",
         percent_encode_slug(&guid),

--- a/docs/design/055-工艺CLI命令扩展-设计.md
+++ b/docs/design/055-工艺CLI命令扩展-设计.md
@@ -1,0 +1,141 @@
+# 055 - 工艺（Process）CLI 命令扩展
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| Claude | 2026-07-31 | 初始版本：补齐 process 子命令 + name/guid 自动解析 |
+
+---
+
+## 1. 背景与目标
+
+### 1.1 要解决的问题
+
+`ntd process` 子命令目前只暴露了 4 个动作：`list / show / run / execution-status`。但后端工艺 API（`handlers/process.rs`）已经支持十几个能力（create / delete / update / upgrade / validate / recommend / versions / diff / stats / copy-to-user / list-loops / approve-gate …），CLI 与后端能力严重不对齐。
+
+更关键的是两处"让 AI 用不起来"的硬伤：
+
+1. **寻址口径不一致（潜在 bug）**：040 重构后，后端工艺路由一律按 `guid`（UUID v4）寻址（`get_process_template_by_guid`），且 `name` 已不再唯一。但现有 CLI 的 `show`/`run` 仍把用户传入的 `name` 直接塞进 `{guid}` 路径段（`percent_encode_slug(name)` → `/bundled/processes/{name}`）。用户/AI 传 `4p12s-delivery` 这类 name 进去，后端按 guid 查不到，大概率返回 404。
+2. **缺最常用的 AI 工作流命令**：AI 引导用户"选工艺 → 装 → 跑 → 升级"时，没有 `recommend`（描述目标→推荐工艺）、`create`、`delete`、`upgrade`、`loops`、`versions`/`diff` 可用，只能绕道前端。
+
+### 1.2 目标
+
+把 `ntd process` 扩展成 **AI 顺手、风格与现有 todo/loop 命令一致** 的命令集：
+
+- 新增子命令：`recommend / create / delete / upgrade / loops / versions / diff`。
+- 修复 `show` / `run` 的寻址：支持 **name 或 guid 自动解析**，name 可读、guid 精确，二者都能用。
+- `list` 增补 `--system` / `--user` 过滤，让 AI 能只看用户自建或只看系统模板。
+- 所有命令复用现有 `--output` / `--fields` 全局参数，输出走统一的 `ApiResponse` 包裹与 `print_response`，AI/脚本可直接 parse。
+- 同步更新 `ntd-usage` skill，让 AI 知道这些命令存在、怎么用。
+
+### 1.3 非目标（YAGNI，本次不做）
+
+- **不**封装 `update / validate / stats / copy-to-user / approve / artifact`：这些偏"工艺编辑/门禁运维"，AI 高频引导场景用不到，留给后续按需扩展（用户已确认本次取"AI 工作流优先子集"）。
+- **不**改后端 API：所有能力后端已就绪，本次纯 CLI 封装。
+- **不**改前端：`process` 命令消费的是已存在的 HTTP 接口。
+- **不**新增进程级命令或 daemon 命令：仅扩展 `process` 子命令面。
+
+---
+
+## 2. 现状分析
+
+### 2.1 现有 ProcessAction 与对应后端路由
+
+| CLI 动作 | 现状实现 | 后端路由 | 问题 |
+|----------|---------|---------|------|
+| `List` | `GET /bundled/processes` | `list_process_templates`（支持 `?is_system`） | 无过滤参数，拿不到"只看我的" |
+| `Show { name }` | `GET /bundled/processes/{name}` | `get_process_template`（按 guid） | **传 name 进 guid 槽，查不到** |
+| `Run { name, workspace }` | path→ws_id 查找 + `POST /bundled/processes/{name}/install` | `install_process`（按 guid） | **同上，name 进 guid 槽** |
+| `ExecutionStatus { id }` | 遍历 workspace 找 audit | `get_loop_execution_audit` | 正常 |
+
+### 2.2 待封装的后端能力（请求/响应口径）
+
+| 能力 | 方法 + 路由 | 请求体 / 参数 | 响应 data |
+|------|------------|--------------|----------|
+| 推荐 | `POST /api/v1/processes/recommend` | `{ description }` | `{ recommendations: [{ template_guid, template_name, display_name, complexity, score, reasons }] }` |
+| 新建 | `POST /api/v1/processes` | `{ name, display_name?, category?, complexity?, version?, definition }` | `{ source_path }` |
+| 删除 | `DELETE /api/v1/processes/{guid}` | — | `{ deleted: true }` |
+| 升级 loop | `POST /api/v1/processes/{guid}/loops/{loop_id}/upgrade` | — | `{ loop_id, loop_name, phase_count, step_count }` |
+| 列 loop | `GET /api/v1/processes/{guid}/loops` | — | `[{ ...build_process_loop_items }]` |
+| 版本历史 | `GET /api/v1/processes/{guid}/versions` | — | `{ guid, versions: [{ id, version, updated_at, source_path }] }` |
+| 版本 diff | `GET /api/v1/processes/{guid}/versions/{v}/diff?base={base_v}` | query | `{ guid, base_version, target_version, diff: [{ type, line }] }` |
+
+> 注意：`/api/v1/processes/*` 由 `client.rs` 自动补 `/api/v1` 前缀；`/bundled/processes` 走旧前缀（与现有 `list`/`show`/`install` 一致）。
+
+---
+
+## 3. 方案设计
+
+### 3.1 命令面（ProcessAction 扩展后）
+
+```
+ntd process list [--system | --user]
+ntd process show    <NAME_OR_GUID>
+ntd process recommend "<任务描述>"
+ntd process create  --name <name> [--display-name X] [--category X] [--complexity X] [--version X]
+                    (--file <yaml> | --stdin)
+ntd process delete  <NAME_OR_GUID>
+ntd process run     <NAME_OR_GUID> --workspace <PATH>
+ntd process upgrade <NAME_OR_GUID> --loop-id <N>
+ntd process loops   <NAME_OR_GUID>
+ntd process versions <NAME_OR_GUID>
+ntd process diff    <NAME_OR_GUID> <VERSION> --base <BASE_VERSION>
+ntd process execution-status <ID>
+```
+
+设计取舍：
+
+- **主标识用位置参数 `<NAME_OR_GUID>`**：与 todo/loop 的 `id` 位置参数风格一致；name 是人类可读的，AI 从 `list` 输出里直接抄。
+- **`create` 的 definition 走 `--file` / `--stdin`**：对齐 `todo create` 的 `prompt` 处理（`--file` 读文件 / `--stdin` 读 JSON），AI 可把 YAML 写临时文件再传入，也可 pipe 全量 body。
+- **`run` 保留 `--workspace <PATH>`**：沿用现有 run 的 path→ws_id 解析；AI 手里有的是项目路径而非 ws_id，更顺手（与 todo/loop 用 `--workspace-id` 不同，但 process 一直按 path 消费，保持域内一致）。
+- **`upgrade` 用 `--loop-id <N>`**：loop_id 是 DB 主键，唯一明确，用 flag 而非位置参数避免和 `<NAME_OR_GUID>` 混淆。
+- **`diff` 用位置 `<VERSION>` + `--base`**：版本号是字符串（如 `1.2.0`），位置参数放目标版本，`--base` 放基准版本，与后端 `versions/{v}/diff?base=` 语义直接对应。
+
+### 3.2 name/guid 自动解析（核心）
+
+抽出一个纯逻辑函数 + 一个网络函数，分离可测性：
+
+```rust
+/// 解析结果：Found(guid) / NotFound / Ambiguous(命中条数)
+enum GuidResolution { Found(String), NotFound, Ambiguous(usize) }
+
+/// 纯逻辑：在已拉取的模板列表里按 key 解析 guid，不碰网络，便于单测。
+/// 规则：guid 精确命中优先；否则按 name 匹配——0 条 NotFound、1 条返回、>1 条 Ambiguous。
+fn resolve_guid_from_items(items: &[Value], key: &str) -> GuidResolution { ... }
+
+/// 网络：GET /bundled/processes 拉全量后调上面的纯逻辑。
+/// 一次请求解决，避免 guid 直查 + name 回退的两次往返。
+async fn resolve_process_guid(client: &ApiClient, key: &str) -> Result<String> { ... }
+```
+
+为什么是"一次 list 然后本地匹配"而不是"先 GET 单条，404 再 list"：
+
+- list 端点本就是 `show`/`run` 前要用的，单次请求即可同时完成"解析 + 展示安装来源"；
+- 避免对 guid 直查时 404 的二次往返；
+- name 命中多条时能给出"请改用 guid"的明确歧义提示，而不是静默取第一条。
+
+歧义提示里会带上命中项的 guid 列表，AI 可直接复制其中之一重试。
+
+### 3.3 handler 拆分
+
+每个子命令一个独立 `process_*` 小函数（≤30 行），`handle_process` 只做 match 分派，与现有 `handle_workspace`/`run_process_install` 的拆法一致。`recommend`/`create`/`delete`/`upgrade`/`loops`/`versions`/`diff` 各一个函数；`show`/`run` 复用 `resolve_process_guid`。
+
+### 3.4 输出与错误
+
+- 全部复用 `print_response(resp, output, fields)`，`--output raw` 默认对 AI 最友好。
+- 后端 `code != 0`（如系统工艺不可删、loop 不属于该工艺）由 `print_response` 统一抛 `anyhow`，CLI 顶层走 `print_structured_error` 输出 JSON 到 stderr，与现有契约一致。
+
+---
+
+## 4. 测试策略
+
+- **纯逻辑单测**（`resolve_guid_from_items`）：guid 命中 / name 唯一命中 / name 歧义 / name+guid 都不中。不依赖网络。
+- **clap 解析单测**：每个新变体一条 `Cli::try_parse_from` 断言（沿用现有 `test_cli_parse_*` 风格），覆盖必填参数与 flag。
+- **create 的 definition 来源**：测 `--file` 与 `--stdin` 两条路径的 body 构造（纯逻辑，不发请求）。
+- 不新增集成测试（工艺 CLI 依赖运行中的 server + bundled 资源，已有的 `tests/` 里无 process CLI 用例，本次保持一致，靠单测保证解析与 body 构造正确）。
+
+---
+
+## 5. 风险与回滚
+
+- **风险**：`show`/`run` 行为变化（从"传 name 必然 404"变成"name 或 guid 都能用"）。这是修 bug，对依赖旧（错误）行为的人无影响。
+- **回滚**：纯 CLI 层改动，revert 单个 commit 即可恢复，不涉及 DB migration。

--- a/docs/requirements/055-工艺CLI命令扩展-实现总结.md
+++ b/docs/requirements/055-工艺CLI命令扩展-实现总结.md
@@ -1,0 +1,76 @@
+# 0. 文件修改记录表
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| Claude | 2026-07-31 | 初始版本（工艺 CLI 命令扩展实现总结） |
+
+---
+
+# 实现总结：工艺（Process）CLI 命令扩展（055）
+
+## 1. 与需求的对应关系
+
+| 需求目标 | 实现位置 | 状态 |
+|----------|---------|------|
+| G1 `show` name/guid 都能用 | `process_show` + `resolve_process_guid` | ✅ |
+| G2 `run` name/guid 都能用 | `run_process_install` + `resolve_process_guid` | ✅ |
+| G3 `recommend` | `process_recommend` → `POST /processes/recommend` | ✅ |
+| G4 `create`（--file/--stdin） | `process_create` + `build_create_body` | ✅ |
+| G5 `delete` | `process_delete` → `DELETE /processes/{guid}` | ✅ |
+| G6 `upgrade` | `process_upgrade` → `POST /processes/{guid}/loops/{loop_id}/upgrade` | ✅ |
+| G7 `loops` | `process_loops` → `GET /processes/{guid}/loops` | ✅ |
+| G8 `versions` | `process_versions` → `GET /processes/{guid}/versions` | ✅ |
+| G9 `diff` | `process_diff` → `GET /processes/{guid}/versions/{v}/diff?base=` | ✅ |
+| G10 `list --system/--user` | `process_list` → `GET /bundled/processes?is_system=` | ✅ |
+| G11 复用 --output/--fields | 全部走 `print_response` | ✅ |
+| G12 name 歧义提示候选 guid | `GuidResolution::Ambiguous` + `resolve_process_guid` 错误文案 | ✅ |
+| G13 ntd-usage skill 同步 | `ntd-skills/ntd-usage/SKILL.md` 新增「工艺」章节 | ✅ |
+
+## 2. 改了什么
+
+### 2.1 `backend/src/cli/commands.rs`
+
+- **扩展 `ProcessAction` 枚举**：新增 `Recommend / Create / Delete / Upgrade / Loops / Versions / Diff`；`List` 增补 `--system/--user`；`Show/Run` 的标识参数从 `name` 改为 `name_or_guid`。
+- **新增 name/guid 解析**：
+  - `GuidResolution` 枚举（`Found/NotFound/Ambiguous(Vec<String>)`）。
+  - `resolve_guid_from_items(items, key)` —— 纯逻辑，guid 精确命中优先，否则按 name 匹配（0/1/多条）。
+  - `resolve_process_guid(client, key)` —— 一次 `GET /bundled/processes` 后本地匹配，歧义时列出候选 guid。
+- **新增 `resolve_workspace_id_by_path`**：path → workspace_id，供 `run` 复用。
+- **每个子命令一个 `process_*` 小函数**（≤30 行），`handle_process` 仅做扁平分派。
+- **顺带修复两个现存 bug**：
+  - `run_process_install` 原用 `/v1/project-directories` → 经 client 补前缀变成 `/api/v1/v1/...` 双前缀必然 404；改为 `/project-directories`。
+  - `query_execution_status` 原用 `/v1/workspaces/...` 同样双前缀；改为 `/workspaces/...`。
+
+### 2.2 `ntd-skills/ntd-usage/SKILL.md`
+
+新增「🧪 工艺（Process）怎么用」章节：命令速查表 + 从零跑工艺的典型工作流示例 + name/guid 标识说明。
+
+### 2.3 设计 / 需求文档
+
+- `docs/design/055-工艺CLI命令扩展-设计.md`
+- `docs/requirements/055-工艺CLI命令扩展-需求.md`
+
+## 3. 关键设计取舍
+
+- **name/guid 自动解析用「一次 list 本地匹配」**：避免「guid 直查 404 → 再 list」的二次往返；name 多条时直接给候选 guid，AI 可复制重试。
+- **`create` 用 `ProcessCreateArgs` 结构收拢 7 个字段**：避免 `process_create` 触发 clippy `too_many_arguments`（10/7），同时 body 构造更内聚、可单测。
+- **`run` 保留 `--workspace <PATH>`**：与 todo/loop 的 `--workspace-id` 不同，但 process 域一直按 path 消费，AI 手里通常是项目路径，按 path 更顺手。
+- **不封装 update/validate/stats/copy-to-user/approve/artifact**：偏编辑/门禁运维，AI 高频引导场景用不到（用户确认取「AI 工作流优先子集」）。
+
+## 4. 测试
+
+- **clippy**：`cargo clippy --all-targets -- -D warnings` 零告警。
+- **lib 单测**：1530 passed / 0 failed。新增 21 条（13 条 clap 解析 + 5 条 `resolve_guid_from_items` 纯逻辑 + 3 条 `build_create_body`）。
+- 不新增集成测试：工艺 CLI 依赖运行中的 server + bundled 资源，`tests/` 内无 process CLI 用例，本次保持一致；解析与 body 构造正确性由单测保证。
+
+## 5. 安全反思
+
+- 所有工艺标识经 `resolve_process_guid` 解析为 guid 后再 percent-encode 入 URL，name 含特殊字符也不会破坏路径。
+- `create` 的 `--name` 直接来自命令行，但写盘/校验在后端（`validate_process_name` + 正则 `^[a-zA-Z0-9_-]+$` + 唯一性 + 文件存在性），CLI 不做旁路。
+- 错误（系统工艺不可删、loop 不属于该工艺等）经 `print_response` → `anyhow` → 顶层 `print_structured_error` 走 stderr JSON，与现有 CLI 契约一致，不泄露内部细节。
+
+## 6. 风险与回滚
+
+- `show`/`run` 行为变化是修 bug（从「传 name 必然 404」→「name/guid 都能用」），对依赖旧错误行为的人无影响。
+- `run`/`execution-status` 的路径 bug 修复会让原本 404 的命令真正可用，属正向修复。
+- 纯 CLI 层改动，无 DB migration，revert 单 commit 即可回滚。

--- a/docs/requirements/055-工艺CLI命令扩展-需求.md
+++ b/docs/requirements/055-工艺CLI命令扩展-需求.md
@@ -1,0 +1,87 @@
+# 0. 文件修改记录表
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| Claude | 2026-07-31 | 初始版本（工艺 CLI 命令扩展） |
+
+---
+
+# 需求：工艺（Process）CLI 命令扩展（055）
+
+## 1. 背景（Why）
+
+`ntd process` 现有 CLI 只有 `list / show / run / execution-status` 四个动作，而后端工艺 API 已支持十几个能力，CLI 严重滞后。更影响使用的是：
+
+- **寻址 bug**：040 起后端按 `guid` 寻址且 `name` 不再唯一，但 CLI 的 `show`/`run` 仍把 `name` 塞进 guid 路径段，传人类可读的 name 大概率 404。
+- **缺高频命令**：AI 引导用户"选工艺 → 装 → 跑 → 升级"时，没有 `recommend / create / delete / upgrade / loops / versions / diff`，只能绕前端。
+
+目标是让 `ntd process` 成为 **AI 顺手、风格统一** 的命令集，让 AI 在终端就能完成工艺的推荐、创建、删除、安装、升级、版本回溯。
+
+## 2. 目标（What，可验证）
+
+- [ ] G1 `ntd process show <name-or-guid>`：传 name 或 guid 都能正确返回工艺详情（修复寻址 bug）。
+- [ ] G2 `ntd process run <name-or-guid> --workspace <PATH>`：name 或 guid 都能正确安装到工作空间。
+- [ ] G3 `ntd process recommend "<描述>"`：根据任务描述返回推荐工艺列表（含 score 与 reasons）。
+- [ ] G4 `ntd process create`：通过 `--file <yaml>` 或 `--stdin` 新建用户工艺，支持 `--name` 及可选元数据。
+- [ ] G5 `ntd process delete <name-or-guid>`：删除用户工艺（系统工艺后端会拒绝，错误经统一通道透出）。
+- [ ] G6 `ntd process upgrade <name-or-guid> --loop-id <N>`：把指定 loop 升级到工艺模板最新版。
+- [ ] G7 `ntd process loops <name-or-guid>`：列出该工艺实例化的全部 loop。
+- [ ] G8 `ntd process versions <name-or-guid>`：返回该工艺的版本历史。
+- [ ] G9 `ntd process diff <name-or-guid> <VERSION> --base <BASE>`：返回两个版本的逐行 diff。
+- [ ] G10 `ntd process list [--system|--user]`：支持按系统/用户过滤。
+- [ ] G11 所有新命令复用全局 `--output`/`--fields`，输出 JSON 可被 AI/脚本直接 parse。
+- [ ] G12 name 命中多条时给出明确歧义提示（含候选 guid），引导改用 guid。
+- [ ] G13 `ntd-usage` skill 同步补充"工艺"章节，给 AI 列出命令速查与示例。
+
+## 3. 非目标（Out of Scope）
+
+- 不封装 `update / validate / stats / copy-to-user / approve / artifact`（偏编辑/门禁运维，AI 高频场景用不到，后续按需扩展）。
+- 不改任何后端 API（纯 CLI 封装）。
+- 不改前端。
+- 不新增进程级 / daemon 命令。
+
+## 4. 使用场景 / 用户路径
+
+### 场景 A：AI 帮用户挑工艺并装上
+
+```
+用户："我想给一个 Rust 项目做持续交付流水线"
+AI：
+1. ntd process recommend "Rust 项目持续交付流水线"   # 拿到推荐工艺 + 理由
+2. ntd process show 4p12s-delivery                  # 看一眼环节定义（用 name 即可）
+3. ntd process run 4p12s-delivery --workspace /path/to/proj   # 装到工作空间
+```
+
+### 场景 B：AI 帮用户管理自建工艺
+
+```
+用户："把我这份流程存成一个工艺"
+AI：
+1. 把用户流程写成 YAML 到 /tmp/delivery.yaml
+2. ntd process create --name my-delivery --file /tmp/delivery.yaml
+3. 后续要改：ntd process versions my-delivery / ntd process diff my-delivery 1.1.0 --base 1.0.0
+4. 不要了：ntd process delete my-delivery
+```
+
+### 场景 C：升级已装的 loop 到工艺最新版
+
+```
+用户："工艺模板更新了，把跑着的那个 loop 也升一下"
+AI：
+1. ntd process loops 4p12s-delivery                 # 找到 loop_id
+2. ntd process upgrade 4p12s-delivery --loop-id 7
+```
+
+## 5. 验收标准
+
+1. `cargo clippy --all-targets -- -D warnings` 零告警。
+2. `cargo test` 全绿，含新增的 clap 解析单测与 guid 解析纯逻辑单测。
+3. 命令风格（位置参数、`--file`/`--stdin`、`--output`/`--fields`、JSON 输出、错误走 stderr JSON）与 todo/loop 命令一致。
+4. `ntd-usage/SKILL.md` 新增"工艺"章节且示例可直接复制运行。
+
+## 6. 依赖与关联
+
+- 设计文档：`docs/design/055-工艺CLI命令扩展-设计.md`
+- 后端能力来源：`backend/src/handlers/process.rs`（已就绪，无需改动）
+- CLI 实现：`backend/src/cli/commands.rs`
+- AI 入口：`ntd-skills/ntd-usage/SKILL.md`

--- a/docs/user-guide/reference/cli-reference.md
+++ b/docs/user-guide/reference/cli-reference.md
@@ -603,7 +603,201 @@ ntd loop results <EXECUTION_ID>
 
 ---
 
-### 7. 守护进程命令
+### 7. 工艺（Process）管理命令
+
+> **工艺（Process）** 是可复用的多环节任务流水线模板（有序环节 + 门禁 + 期望产物）。
+> `ntd process` 让你在终端完成「选工艺 → 装到工作空间 → 跑 → 升级 → 版本回溯」全链路。
+>
+> **name 或 guid 都能标识工艺**：下面带 `<NAME_OR_GUID>` 的命令，位置参数既接受人类可读的 name（如 `4p12s-delivery`），也接受 UUID 形式的 guid。同名命中多条时 CLI 会列出候选 guid，复制其一改用 guid 重试即可。
+
+#### `ntd process list`
+列出所有工艺模板。
+
+```bash
+ntd process list [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 说明 |
+|------|------|
+| `--system` | 只看系统工艺（bundled 同步来的） |
+| `--user` | 只看用户自建工艺（与 `--system` 互斥） |
+
+**示例：**
+```bash
+ntd process list                       # 全部
+ntd process list --system              # 只看系统模板
+ntd process list --user --output raw --fields "name,guid,version,is_system"
+```
+
+---
+
+#### `ntd process show <NAME_OR_GUID>`
+查看工艺模板详情（环节定义）。
+
+```bash
+ntd process show <NAME_OR_GUID>
+```
+
+**示例：**
+```bash
+ntd process show 4p12s-delivery                          # 用 name
+ntd process show 11111111-1111-1111-1111-111111111111    # 用 guid
+```
+
+---
+
+#### `ntd process recommend <DESCRIPTION>`
+根据任务描述推荐合适的工艺（返回推荐工艺 + 匹配理由 + score）。不确定用哪个工艺时的首选入口。
+
+```bash
+ntd process recommend "<任务描述>"
+```
+
+**示例：**
+```bash
+ntd process recommend "给 Rust 项目搭持续交付流水线"
+```
+
+---
+
+#### `ntd process create`
+新建用户工艺。YAML 正文从 `--file` 读取，或用 `--stdin` 传完整 JSON body。
+
+```bash
+ntd process create [OPTIONS]
+```
+
+**选项：**
+
+| 选项 | 简写 | 说明 |
+|------|------|------|
+| `--name <SLUG>` | `-n` | 工艺唯一标识，`^[a-zA-Z0-9_-]+$`（非 `--stdin` 时必填） |
+| `--display-name <NAME>` | - | 人类可读名称（可空） |
+| `--category <CAT>` | - | 分类（可空） |
+| `--complexity <LVL>` | - | 复杂度（可空） |
+| `--version <VER>` | - | 版本（可空，默认 `1.0.0`） |
+| `--file <PATH>` | `-f` | 从文件读取工艺 YAML 正文（非 `--stdin` 时必填） |
+| `--stdin` | - | 从 stdin 读取完整 JSON body |
+
+**示例：**
+```bash
+# 从 YAML 文件创建
+ntd process create --name my-delivery --display-name "我的交付" --file ./delivery.yaml
+
+# 用 --stdin 传完整 body
+ntd process create --stdin <<EOF
+{ "name": "my-delivery", "definition": "process: ...", "version": "1.0.0" }
+EOF
+```
+
+---
+
+#### `ntd process delete <NAME_OR_GUID>`
+删除用户工艺（系统工艺后端会拒绝）。
+
+```bash
+ntd process delete <NAME_OR_GUID>
+```
+
+**示例：**
+```bash
+ntd process delete my-delivery
+```
+
+---
+
+#### `ntd process run <NAME_OR_GUID>`
+安装工艺到工作空间并触发执行。`--workspace` 按项目路径指定，CLI 会自动反查 workspace_id。
+
+```bash
+ntd process run <NAME_OR_GUID> --workspace <PATH>
+```
+
+**选项：**
+
+| 选项 | 说明 |
+|------|------|
+| `--workspace <PATH>` | 必填，目标工作空间路径 |
+
+**示例：**
+```bash
+ntd process run 4p12s-delivery --workspace /Users/me/projects/myapp
+```
+
+---
+
+#### `ntd process upgrade <NAME_OR_GUID>`
+把指定 loop 升级到工艺模板最新版。
+
+```bash
+ntd process upgrade <NAME_OR_GUID> --loop-id <ID>
+```
+
+**选项：**
+
+| 选项 | 说明 |
+|------|------|
+| `--loop-id <ID>` | 必填，要升级的 loop id（先用 `ntd process loops` 查到） |
+
+**示例：**
+```bash
+ntd process loops 4p12s-delivery           # 先拿到 loop_id
+ntd process upgrade 4p12s-delivery --loop-id 7
+```
+
+---
+
+#### `ntd process loops <NAME_OR_GUID>`
+列出该工艺实例化的所有 loop（含各 loop 执行次数）。
+
+```bash
+ntd process loops <NAME_OR_GUID>
+```
+
+---
+
+#### `ntd process versions <NAME_OR_GUID>`
+查看工艺版本历史。
+
+```bash
+ntd process versions <NAME_OR_GUID>
+```
+
+---
+
+#### `ntd process diff <NAME_OR_GUID> <VERSION>`
+对比两个版本的工艺正文逐行 diff。
+
+```bash
+ntd process diff <NAME_OR_GUID> <VERSION> --base <BASE_VERSION>
+```
+
+**参数 / 选项：**
+
+| 参数 | 说明 |
+|------|------|
+| `<VERSION>` | 必填（位置参数），目标版本号 |
+| `--base <BASE_VERSION>` | 必填，基准版本号 |
+
+**示例：**
+```bash
+ntd process diff my-delivery 1.2.0 --base 1.1.0
+```
+
+---
+
+#### `ntd process execution-status <ID>`
+查看工艺实例审计状态（按 loop execution id 遍历工作空间查找）。
+
+```bash
+ntd process execution-status <LOOP_EXECUTION_ID>
+```
+
+---
+
+### 8. 守护进程命令
 
 #### `ntd daemon install`
 安装 ntd 为系统守护进程。
@@ -739,7 +933,7 @@ ntd daemon status -v
 
 ---
 
-## 7. 技能管理命令
+## 9. 技能管理命令
 
 > 用于将内嵌的 `ntd-usage` skill 安装到各执行器的技能目录，让 AI 助手在执行时能自动发现并加载 ntd 使用说明。
 >

--- a/ntd-skills/ntd-usage/SKILL.md
+++ b/ntd-skills/ntd-usage/SKILL.md
@@ -179,6 +179,47 @@ ntd 不再接受用路径指定工作空间——同一个目录路径在 `proje
 
 ---
 
+## 🧪 工艺（Process）怎么用
+
+**工艺（Process）** 是可复用的多环节任务流水线模板（一组有序环节 + 门禁 + 期望产物）。`ntd process` 子命令让 AI 在终端就能完成「挑工艺 → 装到工作空间 → 跑 → 升级 → 版本回溯」全链路，不必切前端。
+
+工艺用 **name 或 guid 都能标识**：name 人类可读（如 `4p12s-delivery`），guid 是 UUID。**同名命中多条时** CLI 会列出候选 guid，复制其一改用 guid 重试即可。
+
+| 想做的事 | 怎么做 |
+|----------|--------|
+| 按任务目标找工艺 | `ntd process recommend "Rust 项目持续交付流水线"`（返回推荐工艺 + 匹配理由 + score） |
+| 列出所有工艺 | `ntd process list`（`--system` 只看系统模板，`--user` 只看自建） |
+| 看工艺详情（环节定义） | `ntd process show <name-or-guid>` |
+| 装到工作空间并触发 | `ntd process run <name-or-guid> --workspace /path/to/proj` |
+| 看某工艺装出了哪些 loop | `ntd process loops <name-or-guid>` |
+| 把 loop 升级到工艺最新版 | `ntd process upgrade <name-or-guid> --loop-id <N>` |
+| 新建自建工艺 | `ntd process create --name <slug> --file <工艺.yaml>`（可选 `--display-name`/`--category`/`--complexity`/`--version`，或 `--stdin` 传完整 body） |
+| 删除自建工艺 | `ntd process delete <name-or-guid>`（系统工艺后端会拒绝） |
+| 看版本历史 | `ntd process versions <name-or-guid>` |
+| 对比两个版本 | `ntd process diff <name-or-guid> <目标版本> --base <基准版本>` |
+| 看某次执行的审计链 | `ntd process execution-status <loop-execution-id>` |
+
+**典型工作流（AI 引导用户从零跑一个工艺）：**
+
+```bash
+# 1. 不知道用哪个？先用自然语言描述目标，让系统推荐
+ntd process recommend "给 Rust 项目搭持续交付流水线"
+
+# 2. 看一眼推荐的工艺长啥样（用 name 即可，不必记 guid）
+ntd process show 4p12s-delivery
+
+# 3. 装到目标工作空间（按项目路径指定，会自动反查 workspace_id）
+ntd process run 4p12s-delivery --workspace /Users/me/projects/myapp
+
+# 4. 工艺模板更新了，把跑着的 loop 也升到最新
+ntd process loops 4p12s-delivery        # 先拿到 loop_id
+ntd process upgrade 4p12s-delivery --loop-id 7
+```
+
+**小提示**：所有 process 命令都支持 `--output raw --fields "..."` 精简输出、减少 token，例如 `ntd process list --output raw --fields "name,guid,version,is_system"`。
+
+---
+
 ## 🧩 变量替换实战
 
 ntd 支持在 todo 消息中使用 `{{变量名}}` 占位符，通过 `--param` 注入值：


### PR DESCRIPTION
## 背景

`ntd process` CLI 原本只有 `list / show / run / execution-status` 4 个动作，后端工艺 API 已支持十几个能力，CLI 严重滞后；且 040 重构后后端按 `guid` 寻址、`name` 不再唯一，但 `show`/`run` 仍把 `name` 塞进 guid 路径段，传人类可读 name 大概率 404。本 PR 把 `ntd process` 扩展成 **AI 顺手、风格与 todo/loop 一致** 的命令集。

用户确认范围：**AI 工作流优先子集** + **name/guid 自动解析**。

## 改了什么

### `backend/src/cli/commands.rs`
- **新增子命令**：`recommend / create / delete / upgrade / loops / versions / diff`
- **`list`** 增补 `--system` / `--user` 过滤（互斥）
- **修复 `show`/`run` 寻址**：主标识改为 `<name-or-guid>`，由 `resolve_process_guid` 自动解析（一次 list 本地匹配；name 命中多条时列出候选 guid）
- **顺带修复两个现存 bug**：
  - `run` 用 `/v1/project-directories` → client 补前缀后变 `/api/v1/v1/...` 双前缀 404，改为 `/project-directories`
  - `execution-status` 用 `/v1/workspaces/...` 同样双前缀，改为 `/workspaces/...`
- name/guid 解析拆成纯逻辑 `resolve_guid_from_items`（可单测）+ 网络 `resolve_process_guid`

### `ntd-skills/ntd-usage/SKILL.md`
新增「🧪 工艺（Process）怎么用」章节：命令速查表 + 从零跑工艺的典型工作流 + name/guid 标识说明。

### 文档
- `docs/design/055-工艺CLI命令扩展-设计.md`
- `docs/requirements/055-工艺CLI命令扩展-需求.md`
- `docs/requirements/055-工艺CLI命令扩展-实现总结.md`

## 命令速览

```
ntd process list [--system | --user]
ntd process show    <NAME_OR_GUID>
ntd process recommend "<任务描述>"
ntd process create  --name <slug> [--display-name X] [--category X] [--complexity X] [--version X] (--file <yaml> | --stdin)
ntd process delete  <NAME_OR_GUID>
ntd process run     <NAME_OR_GUID> --workspace <PATH>
ntd process upgrade <NAME_OR_GUID> --loop-id <N>
ntd process loops   <NAME_OR_GUID>
ntd process versions <NAME_OR_GUID>
ntd process diff    <NAME_OR_GUID> <VERSION> --base <BASE_VERSION>
ntd process execution-status <ID>
```

## 与需求对应（055）

G1–G13 全部达成，详见实现总结文档。非目标（不封装 update/validate/stats/copy-to-user/approve/artifact）已在需求文档声明。

## 测试

- `cargo clippy --all-targets -- -D warnings` —— **零告警**
- `cargo test --lib` —— **1530 passed / 0 failed / 2 ignored**
- 新增 21 条单测：13 条 clap 解析（覆盖每个新子命令）+ 5 条 `resolve_guid_from_items` 纯逻辑（guid 命中/name 唯一/name 歧义/未找到/guid 优先）+ 3 条 `build_create_body`
- 不新增集成测试：`tests/` 内无 process CLI 用例，本次保持一致；解析与 body 构造正确性由单测保证

## 安全反思

- 工艺标识经 `resolve_process_guid` 解析为 guid 后再 percent-encode 入 URL，name 含特殊字符不破坏路径
- `create --name` 写盘/校验全在后端（正则 + 唯一性 + 文件存在性），CLI 不旁路
- 错误（系统工艺不可删等）经统一通道走 stderr JSON，与现有 CLI 契约一致

## 回滚

纯 CLI 层改动，无 DB migration，revert 单 commit 即可。
