### PR TITLE
feat(055): 工艺环节执行配置（执行器/专家/技能）安装时落到事项

### DIFF
--- a/backend/src/db/entity/todos.rs
+++ b/backend/src/db/entity/todos.rs
@@ -55,6 +55,11 @@ pub struct Model {
     /// 任务级指定的执行模型（覆盖 executor.default_model）。
     /// NULL = 未指定，回退到执行器默认模型；执行器也未指定则不传 --model。
     pub model: Option<String>,
+    /// 事项级技能名列表（JSON 数组串，需求 055）。
+    /// 工艺安装时从环节 skills 写入；执行时以 `/skill-name` 逐行注入 prompt 尾部，
+    /// 由执行器 CLI 自行解析 slash command。与 loop_steps.skill_names 同构。
+    #[sea_orm(default_value = "[]")]
+    pub skills: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -42,6 +42,7 @@ mod v80;
 mod v81;
 mod v82;
 mod v83;
+mod v84;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -147,6 +148,9 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         // V83 在 V82 之后：loop_steps 新增 step_template_refs 列（需求 054）——
         // 持久化环节 spec 模板引用，供执行器执行时注入 prompt「重点阅读」
         Box::new(v83::V83AddLoopStepTemplateRefs),
+        // V84 在 V83 之后：todos 新增 skills 列（需求 055）——
+        // 事项携带技能列表，安装工艺时从环节 skills 写入，执行时注入 prompt
+        Box::new(v84::V84AddTodoSkills),
     ]
 }
 

--- a/backend/src/db/migration/v84.rs
+++ b/backend/src/db/migration/v84.rs
@@ -1,0 +1,100 @@
+//! V84 迁移：`todos` 新增 `skills` 列（需求 055）。
+//!
+//! ## 背景
+//! 工艺环节（link）允许配置 `skills`，但安装工艺创建的事项此前不携带技能——
+//! `link.skills` 只落到 `loop_steps.skill_names` 供 AI 评审门禁引用，执行器
+//! 执行事项时 prompt 中没有任何 skill 引用。需求 055 要求事项自身携带技能列表，
+//! 执行时以 `/skill-name` 形式注入 prompt，由执行器 CLI 自行解析。
+//!
+//! ## 设计
+//! 列类型为 JSON 数组串（默认 `"[]"`），与 `loop_steps.skill_names` /
+//! `expected_artifacts` / `step_template_refs` 完全同构，保持全库 JSON 列口径一致。
+//!
+//! ## 幂等
+//! 通过 `add_column_if_missing` 先用 `pragma_table_info` 探测列是否存在，
+//! 已存在则跳过；重复执行不会报错。
+use super::super::Database;
+use super::{add_column_if_missing, Migration};
+
+/// V84：给 `todos` 增加 `skills` 列。
+pub(super) struct V84AddTodoSkills;
+
+#[async_trait::async_trait]
+impl Migration for V84AddTodoSkills {
+    // 紧随 V83，单调递增；新迁移必须严格大于已有版本。
+    fn version(&self) -> i64 {
+        84
+    }
+
+    fn name(&self) -> &'static str {
+        "V84AddTodoSkills"
+    }
+
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 存事项级技能名 JSON 数组（["code-review", ...]），默认空数组。
+        // 与 loop_steps.skill_names 同构，存量行自动获得默认空数组，零数据迁移成本。
+        add_column_if_missing(
+            db,
+            "todos",
+            "skills",
+            "ALTER TABLE todos ADD COLUMN skills TEXT NOT NULL DEFAULT '[]'",
+        )
+        .await?;
+        tracing::info!("V84: todos.skills 列已就绪（需求 055）");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::super::{table_exists, table_has_column};
+    use super::*;
+
+    async fn fresh_db() -> Database {
+        // Database::new 会先跑完全量迁移链；fresh 库上 v84 已把列加上。
+        Database::new(":memory:")
+            .await
+            .expect(":memory: db must open")
+    }
+
+    #[tokio::test]
+    async fn v84_adds_skills_column() {
+        let db = fresh_db().await;
+        // fresh 库跑完迁移链后，列必须存在。
+        assert!(
+            table_has_column(&db, "todos", "skills").await.unwrap(),
+            "v84 应用后 todos 必须有 skills 列"
+        );
+        // todos 表本身存在（防误删）。
+        assert!(table_exists(&db, "todos").await.unwrap(), "todos 表应存在");
+    }
+
+    #[tokio::test]
+    async fn v84_is_idempotent() {
+        let db = fresh_db().await;
+        // 列已存在（fresh 库）时重复应用不得报错。
+        V84AddTodoSkills.up(&db).await.unwrap();
+        V84AddTodoSkills.up(&db).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn v84_skills_defaults_to_empty_array() {
+        use sea_orm::ConnectionTrait;
+        let db = fresh_db().await;
+        // 直接读 schema 列默认值，确认是 '[]'（与 loop_steps.skill_names 同构，避免脏/空数据误解）。
+        let row = db
+            .conn
+            .query_one(sea_orm::Statement::from_string(
+                sea_orm::DbBackend::Sqlite,
+                "SELECT dflt_value FROM pragma_table_info('todos') \
+                 WHERE name='skills'",
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+        let dflt: String = row.try_get_by_index(0).unwrap();
+        // SQLite 把 DEFAULT '[]' 原样存为带单引号的 '[]'。
+        assert_eq!(dflt, "'[]'", "skills 列默认值应为 '[]'");
+    }
+}

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -103,6 +103,9 @@ impl Database {
             executor: m.executor,
             expert_name: m.expert_name,
             model: m.model,
+            // skills 列为 JSON 数组串（需求 055）；脏数据回退空数组，
+            // 与 loop_steps.skill_names / step_template_refs 的解析口径一致。
+            skills: serde_json::from_str(&m.skills).unwrap_or_default(),
             scheduler_enabled,
             scheduler_config,
             scheduler_timezone,
@@ -606,6 +609,28 @@ impl Database {
         if let Some(m) = model {
             am.model = ActiveValue::Set(if m.is_empty() { None } else { Some(m.to_string()) });
         }
+        self.exec_update(am).await
+    }
+
+    /// 仅更新 todo 的 skills（工艺模板安装时从环节 skills 写入，需求 055）。
+    ///
+    /// skills 以 JSON 数组串落库，与 `loop_steps.skill_names` 同构；
+    /// 传空切片会写回 `"[]"`，即显式清空事项技能。
+    pub async fn update_todo_skills(
+        &self,
+        id: i64,
+        skills: &[String],
+    ) -> Result<(), sea_orm::DbErr> {
+        let now = crate::models::utc_timestamp();
+        // 序列化失败兜底 "[]"：技能名是纯字符串数组，理论上不会失败，
+        // 这里与 installer 里 expected_artifacts 的序列化兜底口径保持一致。
+        let skills_json = serde_json::to_string(skills).unwrap_or_else(|_| "[]".to_string());
+        let am = todos::ActiveModel {
+            id: ActiveValue::Unchanged(id),
+            skills: ActiveValue::Set(skills_json),
+            updated_at: ActiveValue::Set(Some(now)),
+            ..Default::default()
+        };
         self.exec_update(am).await
     }
 
@@ -2136,6 +2161,64 @@ mod todo_center_tests {
             action_type: None,
             action_key: None,
             archived_at: None,
+            // 需求 055 新增字段；build_center_item 用例不关心技能，给空数组即可
+            skills: vec![],
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod todo_skills_tests {
+    //! `update_todo_skills` 与 `model_to_todo` skills 解析的单元测试（需求 055）。
+    //!
+    //! 关注三点：写入后能读回、覆盖写生效、未设置时默认为空数组（列默认值 '[]'）。
+
+    // 只用 Database 的公开方法，不引用父模块私有项，故不导 super::*。
+    use crate::db::Database;
+
+    async fn fresh_db() -> Database {
+        Database::new(":memory:").await.expect("memory db must open")
+    }
+
+    #[tokio::test]
+    async fn test_update_todo_skills_round_trip() {
+        let db = fresh_db().await;
+        let todo_id = db
+            .create_todo("带技能的事项", "do something")
+            .await
+            .expect("create todo");
+        // 新建事项默认无技能（列默认值 '[]' → 空数组）
+        let todo = db.get_todo(todo_id).await.unwrap().unwrap();
+        assert!(todo.skills.is_empty(), "新建事项 skills 应为空数组");
+
+        // 写入两个技能后能逐字读回
+        let skills = vec!["code-review".to_string(), "test-gen".to_string()];
+        db.update_todo_skills(todo_id, &skills).await.expect("update skills");
+        let todo = db.get_todo(todo_id).await.unwrap().unwrap();
+        assert_eq!(todo.skills, skills, "skills 写入后应读回一致");
+    }
+
+    #[tokio::test]
+    async fn test_update_todo_skills_overwrite_and_clear() {
+        let db = fresh_db().await;
+        let todo_id = db
+            .create_todo("覆盖写事项", "do something")
+            .await
+            .expect("create todo");
+        db.update_todo_skills(todo_id, &["a".to_string(), "b".to_string()])
+            .await
+            .expect("seed skills");
+        // 覆盖写：新列表整体替换旧列表（升级工艺重建场景依赖该语义）
+        db.update_todo_skills(todo_id, &["c".to_string()])
+            .await
+            .expect("overwrite skills");
+        let todo = db.get_todo(todo_id).await.unwrap().unwrap();
+        assert_eq!(todo.skills, vec!["c".to_string()], "覆盖写应整体替换");
+
+        // 传空切片 → 显式清空回 '[]'
+        db.update_todo_skills(todo_id, &[]).await.expect("clear skills");
+        let todo = db.get_todo(todo_id).await.unwrap().unwrap();
+        assert!(todo.skills.is_empty(), "空切片应清空 skills");
     }
 }

--- a/backend/src/executor_service/pre_spawn.rs
+++ b/backend/src/executor_service/pre_spawn.rs
@@ -736,6 +736,37 @@ pub(crate) async fn inject_step_context(db: &Database, todo_id: i64, message: &s
         .unwrap_or_else(|| message.to_string())
 }
 
+// ─── 事项级 skills 注入（需求 055）───
+//
+// 与上述前置段落的注入不同：skills 是给执行器 CLI 的斜杠命令而非说明文本，
+// 因此不前置标题段，而是把 `/skill-name` 逐行追加到最终 message 尾部。
+// 与 TodoDrawer 手动点击技能把 `/name` 插入 prompt 的既有语义完全一致。
+
+/// 把事项 skills 以 `/skill-name` 逐行追加到 message 尾部（需求 055）。
+///
+/// 纯函数：todo 已由 prepare_execution_state 加载，无需再查库。
+/// todo=None / skills 为空 → 原样返回（独立 todo、无技能事项零副作用）；
+/// 纯空白技能名会被过滤（数据卫生），但不去重——决策 3B：统一追加。
+pub(crate) fn inject_todo_skills(todo: &Option<crate::models::Todo>, message: &str) -> String {
+    // 无 todo（执行前加载失败）或未配置技能 → 原样返回，prompt 逐字不变。
+    let Some(todo) = todo else {
+        return message.to_string();
+    };
+    // 过滤纯空白技能名，避免脏数据产生裸 "/" 行。
+    let lines: Vec<String> = todo
+        .skills
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| format!("/{s}"))
+        .collect();
+    if lines.is_empty() {
+        return message.to_string();
+    }
+    // trim_end 收齐原 message 尾部空白后再补空行，保证 skills 区起始位置稳定。
+    format!("{}\n\n{}", message.trim_end(), lines.join("\n"))
+}
+
 /// 解析环节 JSON 数组字段为 `Vec<T>`；空串或解析失败返回空 Vec（不阻断注入）。
 fn parse_step_json_field<T: serde::de::DeserializeOwned>(raw: &str) -> Vec<T> {
     // 空串视作无配置，避免对空数据做无谓解析。
@@ -1295,6 +1326,8 @@ mod tests {
             action_key: None,
             archived_at: None,
             expert_name: expert_name.map(|s| s.to_string()),
+            // 需求 055 新增字段；专家注入用例不关心技能，给空数组即可
+            skills: vec![],
         }
     }
 
@@ -1743,5 +1776,58 @@ mod tests {
         assert!(!result.contains("## 参考 Spec 约定"), "损坏字段应按空处理");
         assert!(result.ends_with('M'));
         remove_test_bundled_spec(&uri);
+    }
+
+    // -------- inject_todo_skills（需求 055）--------
+
+    /// 构造一个带指定 skills 的 Todo（复用 make_todo_with_expert 再覆写技能字段）。
+    fn make_todo_with_skills(skills: Vec<&str>) -> crate::models::Todo {
+        let mut todo = make_todo_with_expert(None);
+        todo.skills = skills.into_iter().map(|s| s.to_string()).collect();
+        todo
+    }
+
+    /// todo 为 None（执行前加载失败）时原样返回，prompt 逐字不变。
+    #[test]
+    fn test_inject_todo_skills_none_todo_returns_original() {
+        let original = "原始任务内容";
+        let result = inject_todo_skills(&None, original);
+        assert_eq!(result, original);
+    }
+
+    /// skills 为空数组时原样返回，prompt 逐字不变。
+    #[test]
+    fn test_inject_todo_skills_empty_skills_returns_original() {
+        let todo = make_todo_with_skills(vec![]);
+        let original = "原始任务内容";
+        let result = inject_todo_skills(&Some(todo), original);
+        assert_eq!(result, original);
+    }
+
+    /// 非空 skills 逐行追加到尾部，以空行与原 prompt 分隔；原 prompt 内容保持在前。
+    #[test]
+    fn test_inject_todo_skills_appends_slash_lines_at_tail() {
+        let todo = make_todo_with_skills(vec!["code-review", "test-gen"]);
+        let result = inject_todo_skills(&Some(todo), "原始任务内容");
+        assert_eq!(result, "原始任务内容\n\n/code-review\n/test-gen");
+        assert!(result.starts_with("原始任务内容"), "原 prompt 应完整保留在前");
+    }
+
+    /// 不去重（决策 3B）：prompt 已含同名引用也统一追加。
+    #[test]
+    fn test_inject_todo_skills_no_dedup_appends_anyway() {
+        let todo = make_todo_with_skills(vec!["code-review"]);
+        let result = inject_todo_skills(&Some(todo), "请使用 /code-review 检查");
+        assert!(result.ends_with("\n\n/code-review"), "即使 prompt 已含引用也应追加");
+    }
+
+    /// 纯空白技能名被过滤；全部空白时原样返回（不产生裸 "/" 行）。
+    #[test]
+    fn test_inject_todo_skills_filters_blank_names() {
+        let todo = make_todo_with_skills(vec!["  ", "real-skill", ""]);
+        let result = inject_todo_skills(&Some(todo), "M");
+        assert_eq!(result, "M\n\n/real-skill");
+        let all_blank = make_todo_with_skills(vec![" ", ""]);
+        assert_eq!(inject_todo_skills(&Some(all_blank), "M"), "M");
     }
 }

--- a/backend/src/executor_service/stages.rs
+++ b/backend/src/executor_service/stages.rs
@@ -22,7 +22,7 @@ use crate::models::Todo;
 
 use super::pre_spawn::{
     create_run_execution_record, enforce_concurrency_limit,
-    inject_expert_context, inject_step_context, inject_workspace_background,
+    inject_expert_context, inject_step_context, inject_todo_skills, inject_workspace_background,
     inject_workspace_prompt, reject_start_todo_failure,
     select_executor_and_build_command, substitute_message_placeholders,
 };
@@ -85,9 +85,14 @@ pub(crate) async fn prepare_execution_state(
         .or_else(|| todo.as_ref().and_then(|t| t.workspace_id));
     let background_message =
         inject_workspace_background(&request.db, ws_id, &expert_message).await;
+    // 5.6) 注入事项级 skills（需求 055）：todo.skills 非空时把 /skill-name 逐行追加到
+    //      最终 message 尾部，由执行器 CLI 自行解析 slash command。
+    //      放在所有前缀注入之后，使技能命令落在执行器实际收到的 prompt 最尾部；
+    //      无技能/无 todo 时逐字回退，不阻断执行。
+    let final_message = inject_todo_skills(&todo, &background_message);
     // 6) 选定 executor 并构造 command_args（传入注入后的 message）。
     let selected =
-        select_executor_and_build_command(&request, &todo, &background_message).await?;
+        select_executor_and_build_command(&request, &todo, &final_message).await?;
     // 7) 创建 execution record 并把 stage 1 产物聚合成 PreparedExecution。
     create_run_execution_record(request, task_state, todo, timeout_secs, selected).await
 }

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -275,6 +275,8 @@ pub async fn create_todo(
         action_key: req.action_key.clone(),
         // 新建事项未归档
         archived_at: None,
+        // 新建 API 不接收 skills（需求 055：仅工艺安装路径写入），响应与库中默认 '[]' 对齐
+        skills: vec![],
     }))
 }
 

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -153,6 +153,11 @@ pub struct Todo {
     /// None = 未指定，执行时回退到执行器默认模型；执行器也未指定则不传 --model。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    /// 事项级技能名列表（需求 055）。工艺安装时从环节 skills 写入；
+    /// 执行时以 `/skill-name` 逐行注入 prompt 尾部，由执行器 CLI 解析。
+    /// `#[serde(default)]` 保证旧客户端/旧数据反序列化不受影响。
+    #[serde(default)]
+    pub skills: Vec<String>,
 }
 
 /// 事项中心的五类驱动分类（computed_bucket）。

--- a/backend/src/services/process/installer.rs
+++ b/backend/src/services/process/installer.rs
@@ -217,6 +217,13 @@ async fn create_todo_for_link(
             .await;
     }
 
+    // 环节 skills → todo.skills（需求 055）：事项自身携带技能列表，
+    // 执行时由 inject_todo_skills 以 /skill-name 形式注入 prompt 尾部。
+    // 错误处理沿用上面 expert/model 追写的既有模式：写失败不中断安装。
+    if !link.skills.is_empty() {
+        let _ = db.update_todo_skills(todo_id, &link.skills).await;
+    }
+
     // 048：评审是否启用由 gate_config 决定——环节含 ai_criteria_review 门禁才需要 auto_review 打分。
     // 不穿透这层，todo 会停在 create_todo_with_extras 硬编码的 false，AI 评审门禁拿不到评分。
     let has_ai_review_gate = link.gates.iter().any(|g| g.gate_type == "ai_criteria_review");
@@ -1191,6 +1198,8 @@ phases:
             archived_at: None,
             expert_name: None,
             model: None,
+            // 需求 055 新增字段；本用例聚焦评审 prompt 穿透，技能给空数组即可
+            skills: vec![],
         };
         let final_review_prompt = compose_review_prompt(
             &original,
@@ -1339,5 +1348,146 @@ todo_template: 旧字段应被忽略
             serde_yaml::from_str(yaml).expect("含旧 todo_template 不应报错");
         assert_eq!(cfg.prompt.as_deref(), Some("新版提示词"));
         assert!(cfg.trigger_on.contains(&"failed".to_string()));
+    }
+
+    /// 需求 055 夹具：环节带 executor/expert/skills 的工艺 YAML。
+    /// expert 键名与技能列表可参数化，供「expert:」与「expert_name:」两种写法复用。
+    fn yaml_with_exec_config(expert_key: &str, skills: &str) -> String {
+        format!(
+            r#"
+process:
+  name: exec-config-test
+  display_name: 执行配置落库测试
+  version: 0.1.0
+phases:
+  - id: p1
+    name: 阶段一
+    links:
+      - id: l1
+        name: 环节一
+        prompt: 执行任务
+        executor: claudecode
+        {expert_key}: senior-dev
+        skills: {skills}
+        on_success: end
+        on_gate_fail: break
+"#
+        )
+    }
+
+    /// 插入一条最小工艺模板记录，返回模型（供 install/upgrade 复用）。
+    async fn seed_exec_config_template(db: &Database) -> process_templates::Model {
+        process_templates::ActiveModel {
+            guid: ActiveValue::Set("guid-exec-config".to_string()),
+            name: ActiveValue::Set("exec-config-test".to_string()),
+            display_name: ActiveValue::Set("执行配置落库测试".to_string()),
+            description: ActiveValue::Set(String::new()),
+            category: ActiveValue::Set("test".to_string()),
+            complexity: ActiveValue::Set("light".to_string()),
+            version: ActiveValue::Set("0.1.0".to_string()),
+            source_path: ActiveValue::Set(Some("bundled://exec-config.yaml".to_string())),
+            is_system: ActiveValue::Set(true),
+            ..Default::default()
+        }
+        .insert(&db.conn)
+        .await
+        .expect("insert exec-config template")
+    }
+
+    /// 校验（需求 055 F2/F3/F6）：环节设置 executor/expert/skills 后，
+    /// 安装创建的事项三项配置齐全；expert 用标准 `expert:` 键。
+    #[tokio::test]
+    async fn test_install_writes_executor_expert_skills_to_todo() {
+        let db = fresh_db().await;
+        let ws_id = seed_workspace(&db).await;
+        let template = seed_exec_config_template(&db).await;
+
+        let result = install_process_template(
+            &db,
+            &template,
+            &yaml_with_exec_config("expert", "[code-review, test-gen]"),
+            ws_id,
+            "/tmp/test-ws",
+        )
+        .await
+        .expect("install should succeed");
+
+        let steps = db.list_loop_steps_by_loop(result.loop_id).await.unwrap();
+        assert_eq!(steps.len(), 1, "应只有一个环节");
+        let todo = db.get_todo(steps[0].todo_id).await.unwrap().unwrap();
+        assert_eq!(todo.executor.as_deref(), Some("claudecode"), "executor 应落到事项");
+        assert_eq!(todo.expert_name.as_deref(), Some("senior-dev"), "expert 应落到事项");
+        assert_eq!(
+            todo.skills,
+            vec!["code-review".to_string(), "test-gen".to_string()],
+            "skills 应落到事项"
+        );
+    }
+
+    /// 校验（需求 055 F3）：YAML 用历史 `expert_name:` 键时专家不再静默丢失。
+    /// bundled 工艺（lightweight-task 等）大量使用该写法，此前 serde 直接丢弃。
+    #[tokio::test]
+    async fn test_install_writes_expert_via_expert_name_alias() {
+        let db = fresh_db().await;
+        let ws_id = seed_workspace(&db).await;
+        let template = seed_exec_config_template(&db).await;
+
+        let result = install_process_template(
+            &db,
+            &template,
+            &yaml_with_exec_config("expert_name", "[]"),
+            ws_id,
+            "/tmp/test-ws",
+        )
+        .await
+        .expect("install should succeed");
+
+        let steps = db.list_loop_steps_by_loop(result.loop_id).await.unwrap();
+        let todo = db.get_todo(steps[0].todo_id).await.unwrap().unwrap();
+        assert_eq!(
+            todo.expert_name.as_deref(),
+            Some("senior-dev"),
+            "expert_name 别名键应同样落到事项"
+        );
+        // 未配置 skills 时事项技能为空数组（列默认值），而非脏数据
+        assert!(todo.skills.is_empty(), "未配置 skills 应为空数组");
+    }
+
+    /// 校验（需求 055 F5）：升级工艺换了 skills 后，重建的事项携带新技能列表。
+    #[tokio::test]
+    async fn test_upgrade_rebuilds_todo_skills() {
+        let db = fresh_db().await;
+        let ws_id = seed_workspace(&db).await;
+        let template = seed_exec_config_template(&db).await;
+
+        let installed = install_process_template(
+            &db,
+            &template,
+            &yaml_with_exec_config("expert", "[old-skill]"),
+            ws_id,
+            "/tmp/test-ws",
+        )
+        .await
+        .expect("install should succeed");
+
+        let upgraded = upgrade_process_template_loop(
+            &db,
+            &template,
+            &yaml_with_exec_config("expert", "[new-skill, another-skill]"),
+            installed.loop_id,
+            ws_id,
+            "/tmp/test-ws",
+        )
+        .await
+        .expect("upgrade should succeed");
+
+        let steps = db.list_loop_steps_by_loop(upgraded.loop_id).await.unwrap();
+        assert_eq!(steps.len(), 1, "升级后应重建为 1 个环节");
+        let todo = db.get_todo(steps[0].todo_id).await.unwrap().unwrap();
+        assert_eq!(
+            todo.skills,
+            vec!["new-skill".to_string(), "another-skill".to_string()],
+            "升级后事项 skills 应同步为新 YAML 的值"
+        );
     }
 }

--- a/backend/src/services/process/mod.rs
+++ b/backend/src/services/process/mod.rs
@@ -131,6 +131,10 @@ pub struct LinkDefinition {
     #[serde(default)]
     pub prompt: String,
     pub executor: Option<String>,
+    /// 专家名。`alias = "expert_name"`：bundled 工艺 YAML 历史上 `expert:` 与
+    /// `expert_name:` 两种键并存（需求 055），不加别名时 serde 会静默丢弃后者，
+    /// 导致专家配置在安装后丢失。别名只影响反序列化，序列化仍输出 `expert`。
+    #[serde(alias = "expert_name")]
     pub expert: Option<String>,
     #[serde(default)]
     pub skills: Vec<String>,
@@ -304,6 +308,27 @@ mod process_definition_tests {
             }
         }
         assert!(parsed >= 3, "应至少解析 3 个内置工艺模板");
+    }
+
+    /// 需求 055：环节专家字段两种 YAML 键都要能解析——
+    /// `expert:` 是标准键，`expert_name:` 是 bundled 工艺历史写法，
+    /// 靠 `#[serde(alias)]` 兼容；缺省时为 None。
+    #[test]
+    fn test_link_definition_expert_key_variants() {
+        // 标准键 expert:
+        let yaml = "id: l1\nname: 环节一\nexpert: senior-dev\n";
+        let link: LinkDefinition = serde_yaml::from_str(yaml).expect("expert 键应可解析");
+        assert_eq!(link.expert.as_deref(), Some("senior-dev"));
+
+        // 历史别名 expert_name:（bundled 工艺在用，未加别名前会被 serde 静默丢弃）
+        let yaml = "id: l1\nname: 环节一\nexpert_name: architect\n";
+        let link: LinkDefinition = serde_yaml::from_str(yaml).expect("expert_name 别名应可解析");
+        assert_eq!(link.expert.as_deref(), Some("architect"));
+
+        // 缺省 → None（未配置专家的环节不受影响）
+        let yaml = "id: l1\nname: 环节一\n";
+        let link: LinkDefinition = serde_yaml::from_str(yaml).expect("缺省 expert 应可解析");
+        assert!(link.expert.is_none());
     }
 
     #[test]

--- a/docs/design/055-工艺环节执行配置落到事项-设计.md
+++ b/docs/design/055-工艺环节执行配置落到事项-设计.md
@@ -1,0 +1,108 @@
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| Claude | 2026-08-01 | 初始版本（工艺环节执行配置落到事项） |
+
+# 设计：工艺环节执行配置落到事项（055）
+
+## 1. 总体思路
+
+补齐工艺安装链路「环节执行配置 → 事项」的最后两个缺口：
+
+1. **skills 结构化落库 + 运行时注入**（决策 1B）：`todos` 新增 `skills` 列，安装时从
+   `link.skills` 写入；执行时在 prompt 注入链尾部追加 `/skill-name` 行。
+   与 054（spec 模板）同原则：`todo.prompt` 只读，绝不写回 DB，注入只发生在执行内存中。
+2. **expert 键名兼容**（决策 2A）：`LinkDefinition.expert` 加 serde 别名 `expert_name`，
+   修掉 bundled 工艺 YAML 两种写法并存导致的静默丢失。
+
+executor 落库链路已存在（`create_todo_with_extras`），本需求只补回归测试，不改代码。
+
+## 2. 数据层改动
+
+### 2.1 迁移 v84：`todos.skills` 列
+
+- `ALTER TABLE todos ADD COLUMN skills TEXT NOT NULL DEFAULT '[]'`，JSON 数组串，
+  与 `loop_steps.skill_names` / `expected_artifacts` 同构。
+- 复用 `add_column_if_missing` 保证幂等；注册在 v83 之后。
+
+### 2.2 实体与模型
+
+- `db/entity/todos.rs`：`pub skills: String`（`#[sea_orm(default_value = "[]")]`）。
+- `models::Todo`：`pub skills: Vec<String>`（`#[serde(default)]`，API 始终下发该字段）。
+- `db/todo.rs::model_to_todo`：`serde_json::from_str(&m.skills).unwrap_or_default()`，
+  脏数据回退空数组（与 step_template_refs 解析口径一致）。
+
+### 2.3 DAO 新增 `update_todo_skills`
+
+- 签名：`pub async fn update_todo_skills(&self, id: i64, skills: &[String]) -> Result<(), DbErr>`。
+- 序列化为 JSON 数组串写入，同步刷新 `updated_at`。
+- 与 `update_todo_expert_and_model` 同模式（安装后追写单列），避免改动
+  `create_todo_with_extras` 的全部既有调用方。
+
+## 3. 安装链路改动（installer.rs）
+
+`create_todo_for_link` 在现有 expert/model 追写之后追加：
+
+```text
+if !link.skills.is_empty() → db.update_todo_skills(todo_id, &link.skills)
+```
+
+- 错误处理沿用同函数既有模式（`let _ =` 吞掉并继续），与 expert/model 追写保持一致——
+  安装主流程已建 loop，非关键字段写失败不中断安装。
+- 升级路径 `upgrade_process_template_loop` 复用 `create_phases_and_steps` → 同一函数，
+  天然生效（F5）。
+
+## 4. YAML 解析改动（process/mod.rs）
+
+```rust
+#[serde(alias = "expert_name")]
+pub expert: Option<String>,
+```
+
+- 别名只影响反序列化；序列化仍输出 `expert`，前端编辑器写盘格式不变。
+- 同一 link 同时写 `expert:` 和 `expert_name:` 会报 duplicate field 错误——视为非法配置，
+  显式失败优于静默二选一。
+
+## 5. 运行时注入（pre_spawn.rs / stages.rs）
+
+### 5.1 新增纯函数 `inject_todo_skills`
+
+```rust
+pub(crate) fn inject_todo_skills(todo: &Option<Todo>, message: &str) -> String
+```
+
+- `todo=None` / `skills` 为空 → 原样返回（独立 todo、无配置事项零副作用）。
+- 非空 → 在 message 尾部追加空行 + 每技能一行 `/skill-name`。
+- 过滤纯空白技能名（数据卫生），**不去重**（决策 3B）。
+- 同步纯函数：todo 已由 `prepare_execution_state` 加载，无需再查库。
+
+### 5.2 接入点
+
+`stages::prepare_execution_state`，在 `inject_workspace_background` 之后、
+`select_executor_and_build_command` 之前——即所有前缀注入完成后，skills 行落在
+最终 prompt 的最尾部，紧贴执行器实际收到的命令区。全部执行入口收敛于此，自动覆盖
+loop / 手动 / cron / 飞书 / hook（F4）。
+
+最终 prompt 层次：`# 运行背景 > 专家角色 > # 工作空间共识 > # 环节交付要求 > 核心 prompt > /skills 行`。
+
+## 6. 前端改动
+
+仅 `frontend/src/types/todo.ts` 的 `Todo` 接口补 `skills?: string[];`，保持与后端 API
+契约一致；无 UI 改动（非目标）。
+
+## 7. 测试计划
+
+| 层 | 用例 |
+|----|------|
+| 迁移 v84 | 列存在 / 幂等重复执行 / 默认值 `'[]'` |
+| DAO | `update_todo_skills` 写入→`get_todo` 读回一致；覆盖写 |
+| YAML 解析 | `expert:` 与 `expert_name:` 两种键均解析进 `LinkDefinition.expert` |
+| installer | 环节带 executor+expert+skills 安装后事项三字段齐全；`expert_name:` 键安装后 expert 落库；升级换 skills 后事项同步新值 |
+| 注入 | todo=None 原样 / skills 空原样 / 非空逐行追加在尾部 / 纯空白技能名过滤 |
+| 回归 | 既有 installer / pre_spawn 测试中的 `Todo` 字面量补 `skills` 字段后全绿 |
+
+## 8. 安全与兼容反思
+
+- 注入只追加文本到内存中的 prompt，不写 DB、不改文件，无注入面扩大。
+- skills 列默认 `'[]'`，存量数据零迁移成本；`model_to_todo` 解析失败回退空数组。
+- `update_todo_full` 不触碰 skills 列 → 前端编辑事项不会误清空技能。
+- 序列化兼容：`Todo` 新增字段带 `#[serde(default)]`，旧客户端反序列化不受影响。

--- a/docs/requirements/055-工艺环节执行配置落到事项-实现总结.md
+++ b/docs/requirements/055-工艺环节执行配置落到事项-实现总结.md
@@ -1,0 +1,85 @@
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| Claude | 2026-08-01 | 初始版本（需求 055 实现总结） |
+
+# 实现总结：工艺环节执行配置落到事项（055）
+
+## 1. 实现了什么
+
+工艺安装创建环路/事项时，环节 YAML 上的 `executor` / `expert` / `skills` 三项执行配置完整落到事项身上：
+
+- **executor**：既有链路（`create_todo_with_extras`）已落 `todos.executor`，本次仅补端到端回归测试。
+- **expert**：`LinkDefinition.expert` 增加 `#[serde(alias = "expert_name")]`，修掉 bundled 工艺
+  `expert_name:` 写法被 serde 静默丢弃导致专家丢失的问题。
+- **skills**：`todos` 新增 `skills` 列（迁移 v84，JSON 数组串），安装时从 `link.skills` 写入；
+  执行时在 prompt 注入链尾部逐行追加 `/skill-name`，由执行器 CLI 自行解析。
+
+## 2. 与需求对应
+
+| 需求项 | 实现 |
+|--------|------|
+| F1 `todos.skills` 列 | `migration/v84.rs` + 注册；幂等，默认 `'[]'` |
+| F2 安装落库 | `installer::create_todo_for_link` 调 `db.update_todo_skills` |
+| F3 expert 别名 | `LinkDefinition.expert` 加 `#[serde(alias = "expert_name")]` |
+| F4 执行注入 | `pre_spawn::inject_todo_skills` 纯函数，接入 `stages::prepare_execution_state` 最末（全执行入口覆盖） |
+| F5 升级重建 | 升级复用 `create_phases_and_steps` → 同一创建路径，测试验证新值同步 |
+| F6 executor 回归 | installer 测试断言 `todo.executor` 落库 |
+
+## 3. 关键实现点
+
+- **skills 承载**（决策 1B）：结构化列 + 运行时注入，不改写 `todo.prompt`（沿用 054「prompt 只读」原则）。
+  注入格式为 `/skill-name` 逐行追加，与 TodoDrawer 手动点技能插 `/name` 的语义一致。
+- **注入位置**：`inject_workspace_background` 之后、`select_executor_and_build_command` 之前，
+  技能命令落在最终 prompt 最尾部；无技能/无 todo 时逐字回退。
+- **不去重**（决策 3B）：prompt 已含同名引用也统一追加；仅过滤纯空白技能名（数据卫生）。
+- **expert 别名只影响反序列化**：序列化仍输出 `expert`，前端编辑器写盘格式不变。
+- **错误处理**：skills 追写沿用同函数 expert/model 追写的既有模式（失败不中断安装）。
+
+## 4. 改动文件
+
+| 文件 | 改动 |
+|------|------|
+| `backend/src/db/migration/v84.rs`（新） | `todos.skills` 列 + 幂等迁移 + 3 条测试 |
+| `backend/src/db/migration/mod.rs` | 注册 v84 |
+| `backend/src/db/entity/todos.rs` | entity 加 `skills` 字段 |
+| `backend/src/models/mod.rs` | `Todo` 加 `skills: Vec<String>`（`#[serde(default)]`） |
+| `backend/src/db/todo.rs` | `model_to_todo` 解析 skills；新增 `update_todo_skills`；2 条 DAO 测试 |
+| `backend/src/services/process/mod.rs` | `expert` 加 serde 别名 + 1 条解析测试 |
+| `backend/src/services/process/installer.rs` | `create_todo_for_link` 写入 skills；3 条安装/升级测试 |
+| `backend/src/executor_service/pre_spawn.rs` | 新增 `inject_todo_skills` + 5 条测试 |
+| `backend/src/executor_service/stages.rs` | 注入链接入 `inject_todo_skills` |
+| `backend/src/handlers/todo.rs` | 创建事项响应字面量补 `skills` 字段 |
+| `frontend/src/types/todo.ts` | `Todo` 接口补 `skills?: string[]` |
+| `docs/requirements/055-*`、`docs/design/055-*` | 需求 / 设计 / 实现总结三件套 |
+
+## 5. 测试验证
+
+- **clippy**：`cargo clippy --all-targets -- -D warnings` 相对 main **零新增**
+  （本机 rust 工具链下 main 存量 43 个 lint，分布于 daemon/linux.rs、daemon/redeploy.rs 等
+  未触碰文件，已用 main worktree 逐一核对一致；054 总结已记录同批漂移）。
+- **单测**：`cargo test --lib` 1523 passed；唯一失败 `git_sync::tests::test_sync_repo_restores_deleted_file`
+  为 main 存量环境依赖失败（054 已记录），与本需求无关。
+  新增 14 条全绿：v84 迁移 ×3、DAO ×2、别名解析 ×1、installer ×3、注入 ×5。
+- **集成测试**：`db_feature_supplement_tests` 42、`services_tests` 24、
+  `loop_step_execution_status_tests` 2、`api_integration_test` 36，全部通过。
+- **前端**：`npx tsc --noEmit` 零错误。
+- **活体 E2E**（dev 库 + 假 claude CLI 落盘 argv）：
+  - 安装真实 `lightweight-task`（`expert_name:` 键）→ 事项 `expert_name=senior-dev`
+    （修复前为 NULL）、`executor=atomcode`；`4p12s-delivery`（`expert:` 键 + 非空 skills）
+    → 事项 `expert_name=product-manager`、`skills=["4p12s-prd"]` 等逐环节一致。
+  - 执行带 skills 事项 → 执行器实收 prompt 尾部含 `/4p12s-prd`（运行背景 > 环节交付要求 > 核心 prompt > 技能行）。
+  - 执行无 skills 事项 → prompt 逐字不变，零副作用。
+  - 验证后已清理测试 loop/事项与假 CLI。
+
+## 6. 安全反思
+
+- 注入仅向内存中的 prompt 追加文本，不写 DB、不改文件；`todo.prompt` 保持只读。
+- skills 列默认 `'[]'`，存量行零迁移成本；`model_to_todo` 解析失败回退空数组，脏数据不拖垮读取。
+- `update_todo_full` 不触碰 skills 列，前端编辑事项不会误清技能。
+- `Todo` 新字段带 `#[serde(default)]`，旧客户端反序列化兼容。
+- 无越权面变化：安装与执行路径均沿用既有 workspace 校验。
+
+## 7. 已知限制
+
+- 复制 loop 丢 `skill_names` 的既有缺口（053 已记录）不在本次范围。
+- 事项 skills 暂无前端编辑入口与 UI 展示（需求非目标）；API 已下发字段，后续需求可接。

--- a/docs/requirements/055-工艺环节执行配置落到事项-需求.md
+++ b/docs/requirements/055-工艺环节执行配置落到事项-需求.md
@@ -1,0 +1,50 @@
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| Claude | 2026-08-01 | 初始版本（工艺环节执行配置落到事项） |
+
+# 需求：工艺环节执行配置落到事项（055）
+
+## 1. 背景与问题
+
+工艺 YAML 的环节（link）允许设置 `executor` / `expert` / `skills` 三个执行配置。安装工艺
+（`install_process_template` → `create_todo_for_link`）创建环路（loop）与事项（todo）时，
+这三项配置应当全部落到事项身上，但现状存在缺口：
+
+| 环节字段 | 现状 | 问题 |
+|---------|------|------|
+| `executor` | ✅ 已写入 `todos.executor` | 无 |
+| `expert` | ⚠️ 仅当 YAML 用 `expert:` 键时写入 `todos.expert_name` | bundled 工艺（lightweight-task / complex-refactor / oral-requirement 等）大量使用 `expert_name:` 键，`LinkDefinition` 只声明了 `expert` 字段，serde 反序列化**静默丢弃未知键** → 专家配置丢失 |
+| `skills` | ⚠️ 只落 `loop_steps.skill_names`（仅供 AI 评审门禁引用） | 事项本身不携带技能，执行器执行该事项时 prompt 中没有任何 skill 引用，环节配置的技能不生效 |
+
+**已确认的决策**（用户回复 `1b2a3b`）：
+
+- **skills 承载方式**：`todos` 表新增 `skills` 列（JSON 数组串，与 `loop_steps.skill_names` 同构），
+  执行时在 prompt 注入链统一把技能以 `/skill-name` 形式注入 —— 而非安装时直接改写 `todo.prompt`。
+- **`expert_name` 兼容**：`LinkDefinition.expert` 加 `#[serde(alias = "expert_name")]`，两种键都认。
+- **注入去重**：不做去重，统一追加（环节 prompt 作者手写 `/skill-name` 与 skills 列表重复是可接受边界）。
+
+## 2. 目标
+
+1. 环节设置 `executor` / `expert` / `skills` 后，安装工艺创建的事项完整携带这三项配置。
+2. 事项的 `skills` 在执行时注入 prompt（`/skill-name` 逐行追加尾部），由执行器 CLI 自行解析，
+   覆盖全部执行入口（loop / 手动 / cron / 飞书 / hook 均收敛于 `prepare_execution_state`）。
+3. YAML `expert_name:` 写法不再静默失效。
+4. 升级工艺（`upgrade_process_template_loop`）重建事项时同样生效（复用同一创建路径）。
+
+## 3. 功能点与验收标准
+
+| # | 功能点 | 验收标准 |
+|---|--------|---------|
+| F1 | `todos.skills` 列 | 迁移 v84 新增 `skills TEXT NOT NULL DEFAULT '[]'`，幂等可重复执行 |
+| F2 | 安装落库 | 环节含 skills 时，安装创建的事项 `skills` 与 YAML 一致；未配置为 `[]` |
+| F3 | expert 别名 | YAML 用 `expert:` 或 `expert_name:` 均能解析进 `LinkDefinition.expert` 并写入事项 |
+| F4 | 执行注入 | 事项 `skills` 非空时，执行 prompt 尾部逐行追加 `/skill-name`；空/无 todo 时 prompt 逐字不变 |
+| F5 | 升级重建 | 升级工艺换了 skills 的 YAML，重建的事项携带新值 |
+| F6 | executor 回归 | 环节 `executor` 仍正确写入 `todos.executor`（既有行为不破坏） |
+
+## 4. 边界与非目标
+
+- 不做前端 UI 改动（事项抽屉不新增 skills 展示区；API 类型补齐 `skills` 字段即可）。
+- 不处理复制 loop 丢 `skill_names` 的既有缺口（053 已记录，独立问题）。
+- 不修改 bundled 工艺 YAML 文件本身（它们在外部同步仓库）；靠 serde 别名兼容。
+- 不做 skills 的 API 编辑入口（`update_todo_full` 不触碰 skills 列，编辑场景待后续需求）。

--- a/frontend/src/types/todo.ts
+++ b/frontend/src/types/todo.ts
@@ -14,6 +14,8 @@ export interface Todo {
   expert_name?: string | null;
   /** 任务级执行模型（覆盖执行器默认）。null = 用执行器默认模型。 */
   model?: string | null;
+  /** 事项级技能名列表（需求 055）。工艺安装时从环节 skills 写入；执行时以 /skill-name 注入 prompt 尾部。 */
+  skills?: string[];
   scheduler_enabled?: boolean;
   scheduler_config?: string | null;
   scheduler_timezone?: string | null;


### PR DESCRIPTION
## 实现了什么

工艺安装创建环路/事项时，环节 YAML 上的**执行器、专家、skills** 三项配置完整落到事项（todo）身上：

| 环节字段 | 修复前 | 修复后 |
|---------|--------|--------|
| `executor` | ✅ 已落 `todos.executor` | 不变，补回归测试 |
| `expert` | ⚠️ YAML 用 `expert_name:` 键时被 serde **静默丢弃**（bundled 工艺大量中招） | ✅ 加 `#[serde(alias = "expert_name")]`，两种键都认 |
| `skills` | ⚠️ 只落 `loop_steps.skill_names`，事项不携带、执行不生效 | ✅ `todos` 新增 `skills` 列（迁移 v84），执行时以 `/skill-name` 逐行注入 prompt 尾部 |

## 与需求的对应

需求/设计/实现总结三件套：`docs/requirements/055-工艺环节执行配置落到事项-*.md`、`docs/design/055-工艺环节执行配置落到事项-设计.md`。

关键决策（已与需求方确认 `1b2a3b`）：
- skills 走「todos 新列 + 运行时注入」而非安装时改写 prompt（沿用 054「prompt 只读」原则）；
- `expert_name` 用 serde 别名兼容；
- 注入不去重、统一追加（仅过滤纯空白技能名）。

## 关键实现点

- **注入位置**：`stages::prepare_execution_state` 最末（`inject_workspace_background` 之后），loop/手动/cron/飞书/hook 全入口覆盖；最终 prompt 层次 = 运行背景 > 专家角色 > 工作空间共识 > 环节交付要求 > 核心 prompt > `/skills` 行。
- **升级路径**：`upgrade_process_template_loop` 复用同一创建函数，换 skills 的 YAML 升级后事项自动同步新值。
- **兼容性**：skills 列默认 `'[]'` 存量零迁移成本；`Todo` 新字段带 `#[serde(default)]` 旧客户端兼容；`update_todo_full` 不触碰该列，前端编辑事项不会误清。

## 测试与验证

- `cargo clippy --all-targets -- -D warnings`：相对 main **零新增**（main 存量 43 个工具链漂移 lint 已用 worktree 逐一核对，全在未触碰文件）。
- `cargo test --lib`：**1523 passed**；新增 14 条全绿（v84 迁移 ×3、DAO ×2、别名解析 ×1、installer ×3、注入 ×5）。唯一失败 `git_sync::tests::test_sync_repo_restores_deleted_file` 为 main 存量环境依赖失败（054 已记录）。
- 集成测试：`db_feature_supplement_tests` 42 / `services_tests` 24 / `loop_step_execution_status_tests` 2 / `api_integration_test` 36 全过。
- 前端 `npx tsc --noEmit` 零错误。
- **活体 E2E**（dev 库 + 假 claude CLI 落盘 argv）：
  - 安装真实 `lightweight-task`（`expert_name:` 键）→ 事项 `expert_name=senior-dev`（修复前为 NULL）、`executor=atomcode`；
  - 安装 `4p12s-delivery`（`expert:` + 非空 skills）→ 事项 `skills=["4p12s-prd"]` 等逐环节一致；
  - 执行带 skills 事项 → 执行器实收 prompt 尾部含 `/4p12s-prd`；
  - 执行无 skills 事项 → prompt 逐字不变。

## 已知限制

- 复制 loop 丢 `skill_names` 的既有缺口（053 已记录）不在本次范围。
- 事项 skills 暂无前端编辑入口与 UI 展示（非目标）；API 已下发字段，后续需求可接。
