### PR TITLE
docs(architecture): 基于代码重新推导系统架构

### DIFF
--- a/docs/architecture/01-functional-arch.html
+++ b/docs/architecture/01-functional-arch.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ntd 功能架构图</title>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root,[data-theme="dark"]{
+  --bg:#020617;--grid:#1e293b;--text:#fff;--text-muted:#94a3b8;--mask:#0f172a;
+  --frontend-fill:rgba(8,51,68,.4);--frontend-stroke:#22d3ee;
+  --backend-fill:rgba(6,78,59,.4);--backend-stroke:#34d399;
+  --database-fill:rgba(76,29,149,.4);--database-stroke:#a78bfa;
+  --external-fill:rgba(30,41,59,.5);--external-stroke:#94a3b8;
+  --region-stroke:#fbbf24;--region-fill:rgba(251,191,36,.05);
+  --sg-stroke:#fb7185;--sg-fill:rgba(251,113,133,.05);
+  --arrow:#64748b;--arrow-emphasis:#34d399;--arrow-dashed:#fbbf24;--arrow-security:#fb7185;
+}
+[data-theme="light"]{
+  --bg:#f8fafc;--grid:#e2e8f0;--text:#0f172a;--text-muted:#475569;--mask:#fff;
+  --frontend-fill:rgba(34,211,238,.15);--frontend-stroke:#0891b2;
+  --backend-fill:rgba(52,211,153,.18);--backend-stroke:#059669;
+  --database-fill:rgba(167,139,250,.2);--database-stroke:#7c3aed;
+  --external-fill:rgba(148,163,184,.18);--external-stroke:#64748b;
+  --region-stroke:#d97706;--region-fill:rgba(251,191,36,.08);
+  --sg-stroke:#e11d48;--sg-fill:rgba(251,113,133,.08);
+  --arrow:#94a3b8;--arrow-emphasis:#059669;--arrow-dashed:#d97706;--arrow-security:#e11d48;
+}
+body{margin:0;background:var(--bg);color:var(--text);font-family:'JetBrains Mono',monospace;}
+.toolbar{position:sticky;top:0;background:rgba(15,23,42,.85);backdrop-filter:blur(8px);border-bottom:1px solid #334155;padding:10px 16px;display:flex;align-items:center;gap:12px;z-index:10;}
+.toolbar h1{font-size:14px;margin:0;font-weight:600;}
+.toolbar button{background:transparent;border:1px solid #334155;color:#e2e8f0;padding:4px 10px;border-radius:4px;cursor:pointer;font-family:inherit;font-size:12px;}
+.toolbar button:hover{background:rgba(30,41,59,.8);}
+.diagram-wrap{padding:20px;overflow:auto;}
+svg{display:block;margin:0 auto;max-width:100%;height:auto;background:var(--bg);}
+.c-mask{fill:var(--mask);}
+.c-frontend{fill:var(--frontend-fill);stroke:var(--frontend-stroke);}
+.c-backend{fill:var(--backend-fill);stroke:var(--backend-stroke);}
+.c-database{fill:var(--database-fill);stroke:var(--database-stroke);}
+.c-external{fill:var(--external-fill);stroke:var(--external-stroke);}
+.c-region{fill:var(--region-fill);stroke:var(--region-stroke);stroke-dasharray:6 4;}
+.c-sg{fill:var(--sg-fill);stroke:var(--sg-stroke);stroke-dasharray:6 4;}
+.t-primary{fill:var(--text);}.t-muted{fill:var(--text-muted);}
+.t-frontend{fill:var(--frontend-stroke);}.t-backend{fill:var(--backend-stroke);}
+.t-database{fill:var(--database-stroke);}.t-external{fill:var(--external-stroke);}
+.t-region{fill:var(--region-stroke);}.t-sg{fill:var(--sg-stroke);}
+.a-default{stroke:var(--arrow);fill:none;}.a-emphasis{stroke:var(--arrow-emphasis);fill:none;}
+.a-dashed{stroke:var(--arrow-dashed);fill:none;stroke-dasharray:5 3;}.a-security{stroke:var(--arrow-security);fill:none;stroke-dasharray:5 3;}
+</style>
+</head>
+<body>
+<div class="toolbar">
+<h1>ntd 功能架构图（基于代码重新推导）</h1>
+<button onclick="toggleTheme()">切换主题</button>
+</div>
+<div class="diagram-wrap">
+<svg viewBox="0 0 1500 980" role="img" aria-label="ntd 功能架构图">
+<defs>
+<marker id="ah" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#64748b"/></marker>
+<marker id="ah-e" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#34d399"/></marker>
+<marker id="ah-d" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#fbbf24"/></marker>
+<marker id="ah-s" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#fb7185"/></marker>
+<pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0L0 0 0 40" stroke="var(--grid)" stroke-width="0.5"/></pattern>
+</defs>
+<rect width="100%" height="100%" fill="url(#grid)"/>
+
+<!-- 边界 -->
+<rect x="40" y="40" width="440" height="900" rx="12" class="c-region"/>
+<text x="52" y="62" class="t-region" font-size="11" font-weight="600">前端 React SPA</text>
+
+<rect x="520" y="40" width="560" height="900" rx="12" class="c-sg"/>
+<text x="532" y="62" class="t-sg" font-size="11" font-weight="600">后端 Rust 服务进程</text>
+
+<!-- 前端组件 -->
+<rect x="60" y="80" width="160" height="56" rx="6" class="c-mask"/>
+<rect x="60" y="80" width="160" height="56" rx="6" class="c-external" stroke-width="1.5"/>
+<text x="140" y="104" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">浏览器</text>
+<text x="140" y="122" class="t-muted" font-size="9" text-anchor="middle">React SPA</text>
+
+<rect x="60" y="170" width="160" height="56" rx="6" class="c-mask"/>
+<rect x="60" y="170" width="160" height="56" rx="6" class="c-frontend" stroke-width="1.5"/>
+<text x="140" y="194" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">前端路由</text>
+<text x="140" y="212" class="t-muted" font-size="9" text-anchor="middle">react-router</text>
+
+<rect x="60" y="260" width="160" height="56" rx="6" class="c-mask"/>
+<rect x="60" y="260" width="160" height="56" rx="6" class="c-frontend" stroke-width="1.5"/>
+<text x="140" y="284" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">Dashboard</text>
+<text x="140" y="302" class="t-muted" font-size="9" text-anchor="middle">概览/统计</text>
+
+<rect x="60" y="350" width="160" height="56" rx="6" class="c-mask"/>
+<rect x="60" y="350" width="160" height="56" rx="6" class="c-frontend" stroke-width="1.5"/>
+<text x="140" y="374" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">Todo 中心</text>
+<text x="140" y="392" class="t-muted" font-size="9" text-anchor="middle">事项任务</text>
+
+<rect x="60" y="440" width="160" height="56" rx="6" class="c-mask"/>
+<rect x="60" y="440" width="160" height="56" rx="6" class="c-frontend" stroke-width="1.5"/>
+<text x="140" y="464" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">Loop Studio</text>
+<text x="140" y="482" class="t-muted" font-size="9" text-anchor="middle">环路编排</text>
+
+<rect x="60" y="530" width="160" height="56" rx="6" class="c-mask"/>
+<rect x="60" y="530" width="160" height="56" rx="6" class="c-frontend" stroke-width="1.5"/>
+<text x="140" y="554" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">工艺编辑器</text>
+<text x="140" y="572" class="t-muted" font-size="9" text-anchor="middle">Monaco+Flow</text>
+
+<rect x="60" y="620" width="160" height="56" rx="6" class="c-mask"/>
+<rect x="60" y="620" width="160" height="56" rx="6" class="c-frontend" stroke-width="1.5"/>
+<text x="140" y="644" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">消息监控</text>
+<text x="140" y="662" class="t-muted" font-size="9" text-anchor="middle">飞书消息流</text>
+
+<rect x="280" y="170" width="160" height="56" rx="6" class="c-mask"/>
+<rect x="280" y="170" width="160" height="56" rx="6" class="c-frontend" stroke-width="1.5"/>
+<text x="360" y="194" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">API Client</text>
+<text x="360" y="212" class="t-muted" font-size="9" text-anchor="middle">fetch + WS</text>
+
+<!-- 后端组件 -->
+<rect x="540" y="80" width="180" height="56" rx="6" class="c-mask"/>
+<rect x="540" y="80" width="180" height="56" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="630" y="104" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">axum HTTP</text>
+<text x="630" y="122" class="t-muted" font-size="9" text-anchor="middle">REST 入口</text>
+
+<rect x="540" y="170" width="180" height="56" rx="6" class="c-mask"/>
+<rect x="540" y="170" width="180" height="56" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="630" y="194" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">WebSocket</text>
+<text x="630" y="212" class="t-muted" font-size="9" text-anchor="middle">事件广播</text>
+
+<rect x="540" y="260" width="180" height="56" rx="6" class="c-mask"/>
+<rect x="540" y="260" width="180" height="56" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="630" y="284" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">Handlers</text>
+<text x="630" y="302" class="t-muted" font-size="9" text-anchor="middle">todo/loop/process</text>
+
+<rect x="540" y="350" width="180" height="56" rx="6" class="c-mask"/>
+<rect x="540" y="350" width="180" height="56" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="630" y="374" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">Services 层</text>
+<text x="630" y="392" class="t-muted" font-size="9" text-anchor="middle">业务逻辑编排</text>
+
+<rect x="540" y="440" width="180" height="56" rx="6" class="c-mask"/>
+<rect x="540" y="440" width="180" height="56" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="630" y="464" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">DB 抽象层</text>
+<text x="630" y="482" class="t-muted" font-size="9" text-anchor="middle">migration+entity</text>
+
+<rect x="820" y="80" width="200" height="56" rx="6" class="c-mask"/>
+<rect x="820" y="80" width="200" height="56" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="920" y="104" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">Executor Service</text>
+<text x="920" y="122" class="t-muted" font-size="9" text-anchor="middle">三阶段执行编排</text>
+
+<rect x="820" y="170" width="200" height="56" rx="6" class="c-mask"/>
+<rect x="820" y="170" width="200" height="56" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="920" y="194" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">LoopRunner</text>
+<text x="920" y="212" class="t-muted" font-size="9" text-anchor="middle">环路主循环+续跑</text>
+
+<rect x="820" y="260" width="200" height="56" rx="6" class="c-mask"/>
+<rect x="820" y="260" width="200" height="56" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="920" y="284" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">TodoScheduler</text>
+<text x="920" y="302" class="t-muted" font-size="9" text-anchor="middle">tokio-cron 定时</text>
+
+<rect x="820" y="350" width="200" height="56" rx="6" class="c-mask"/>
+<rect x="820" y="350" width="200" height="56" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="920" y="374" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">工艺服务</text>
+<text x="920" y="392" class="t-muted" font-size="9" text-anchor="middle">phase_driver+gates</text>
+
+<rect x="820" y="440" width="200" height="56" rx="6" class="c-mask"/>
+<rect x="820" y="440" width="200" height="56" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="920" y="464" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">黑板服务</text>
+<text x="920" y="482" class="t-muted" font-size="9" text-anchor="middle">debouncer+wiki</text>
+
+<rect x="820" y="530" width="200" height="56" rx="6" class="c-mask"/>
+<rect x="820" y="530" width="200" height="56" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="920" y="554" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">飞书 SDK</text>
+<text x="920" y="572" class="t-muted" font-size="9" text-anchor="middle">WS+HTTP+Token</text>
+
+<rect x="820" y="620" width="200" height="56" rx="6" class="c-mask"/>
+<rect x="820" y="620" width="200" height="56" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="920" y="644" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">Git 同步</text>
+<text x="920" y="662" class="t-muted" font-size="9" text-anchor="middle">内置资源拉取</text>
+
+<!-- 外部与存储 -->
+<rect x="1140" y="80" width="200" height="56" rx="6" class="c-mask"/>
+<rect x="1140" y="80" width="200" height="56" rx="6" class="c-external" stroke-width="1.5"/>
+<text x="1240" y="104" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">AI 执行器</text>
+<text x="1240" y="122" class="t-muted" font-size="9" text-anchor="middle">claude/codex/atomcode</text>
+
+<rect x="1140" y="170" width="200" height="56" rx="6" class="c-mask"/>
+<rect x="1140" y="170" width="200" height="56" rx="6" class="c-external" stroke-width="1.5"/>
+<text x="1240" y="194" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">专家系统</text>
+<text x="1240" y="212" class="t-muted" font-size="9" text-anchor="middle">plugin.json + MD</text>
+
+<rect x="1140" y="260" width="200" height="56" rx="6" class="c-mask"/>
+<rect x="1140" y="260" width="200" height="56" rx="6" class="c-external" stroke-width="1.5"/>
+<text x="1240" y="284" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">Webhook 入</text>
+<text x="1240" y="302" class="t-muted" font-size="9" text-anchor="middle">外部事件</text>
+
+<rect x="1140" y="440" width="200" height="56" rx="6" class="c-mask"/>
+<rect x="1140" y="440" width="200" height="56" rx="6" class="c-database" stroke-width="1.5"/>
+<text x="1240" y="464" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">SQLite</text>
+<text x="1240" y="482" class="t-muted" font-size="9" text-anchor="middle">30+ 表</text>
+
+<rect x="1140" y="530" width="200" height="56" rx="6" class="c-mask"/>
+<rect x="1140" y="530" width="200" height="56" rx="6" class="c-external" stroke-width="1.5"/>
+<text x="1240" y="554" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">飞书 IM</text>
+<text x="1240" y="572" class="t-muted" font-size="9" text-anchor="middle">用户对话</text>
+
+<!-- 连线 -->
+<line x1="140" y1="136" x2="140" y2="168" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<line x1="220" y1="198" x2="278" y2="198" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<text x="249" y="192" class="t-muted" font-size="9" text-anchor="middle">REST/WS</text>
+
+<line x1="140" y1="226" x2="140" y2="258" class="a-default" stroke-width="1.5" marker-end="url(#ah)"/>
+<line x1="140" y1="316" x2="140" y2="348" class="a-default" stroke-width="1.5" marker-end="url(#ah)"/>
+<line x1="140" y1="406" x2="140" y2="438" class="a-default" stroke-width="1.5" marker-end="url(#ah)"/>
+<line x1="140" y1="496" x2="140" y2="528" class="a-default" stroke-width="1.5" marker-end="url(#ah)"/>
+<line x1="140" y1="586" x2="140" y2="618" class="a-default" stroke-width="1.5" marker-end="url(#ah)"/>
+
+<line x1="440" y1="198" x2="538" y2="108" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<text x="490" y="150" class="t-muted" font-size="9">HTTP</text>
+<line x1="440" y1="198" x2="538" y2="198" class="a-dashed" stroke-width="1.5" marker-end="url(#ah-d)"/>
+<text x="490" y="192" class="t-muted" font-size="9">WS</text>
+
+<line x1="630" y1="136" x2="630" y2="168" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<text x="645" y="156" class="t-muted" font-size="9">路由</text>
+<line x1="630" y1="226" x2="630" y2="258" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<text x="645" y="246" class="t-muted" font-size="9">调用</text>
+<line x1="630" y1="316" x2="630" y2="348" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<text x="645" y="336" class="t-muted" font-size="9">CRUD</text>
+<line x1="630" y1="406" x2="630" y2="438" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
+
+<line x1="720" y1="288" x2="818" y2="108" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<text x="770" y="190" class="t-muted" font-size="9">执行</text>
+<line x1="720" y1="288" x2="818" y2="198" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<text x="770" y="250" class="t-muted" font-size="9">触发环路</text>
+
+<line x1="1020" y1="108" x2="1138" y2="108" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<text x="1080" y="102" class="t-muted" font-size="9" text-anchor="middle">spawn 子进程</text>
+<line x1="1020" y1="198" x2="1138" y2="468" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
+
+<line x1="920" y1="136" x2="920" y2="168" class="a-dashed" stroke-width="1.5" marker-end="url(#ah-d)"/>
+<text x="935" y="156" class="t-muted" font-size="9">逐环节执行</text>
+<line x1="920" y1="288" x2="920" y2="348" class="a-dashed" stroke-width="1.5" marker-end="url(#ah-d)"/>
+<text x="935" y="320" class="t-muted" font-size="9">定时触发</text>
+<line x1="920" y1="406" x2="920" y2="438" class="a-dashed" stroke-width="1.5" marker-end="url(#ah-d)"/>
+<text x="935" y="426" class="t-muted" font-size="9">黑板更新</text>
+
+<line x1="1020" y1="558" x2="1138" y2="558" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<text x="1080" y="552" class="t-muted" font-size="9" text-anchor="middle">消息收发</text>
+<line x1="1138" y1="558" x2="1020" y2="558" class="a-dashed" stroke-width="1.5" marker-end="url(#ah-d)"/>
+<text x="1080" y="572" class="t-muted" font-size="9" text-anchor="middle">触发执行</text>
+
+<line x1="1240" y1="136" x2="1240" y2="168" class="a-dashed" stroke-width="1.5" marker-end="url(#ah-d)"/>
+<text x="1255" y="156" class="t-muted" font-size="9">专家上下文</text>
+
+<line x1="1240" y1="316" x2="1240" y2="438" class="a-security" stroke-width="1.5" marker-end="url(#ah-s)"/>
+<text x="1255" y="380" class="t-muted" font-size="9">webhook</text>
+
+<line x1="920" y1="676" x2="920" y2="710" class="a-dashed" stroke-width="1.5" marker-end="url(#ah-d)"/>
+<text x="935" y="696" class="t-muted" font-size="9">同步专家</text>
+
+<!-- 图例 -->
+<text x="60" y="780" class="t-primary" font-size="11" font-weight="600">图例</text>
+<rect x="60" y="792" width="16" height="10" rx="2" class="c-frontend" stroke-width="1"/><text x="82" y="800" class="t-muted" font-size="9">前端</text>
+<rect x="130" y="792" width="16" height="10" rx="2" class="c-backend" stroke-width="1"/><text x="152" y="800" class="t-muted" font-size="9">后端</text>
+<rect x="200" y="792" width="16" height="10" rx="2" class="c-database" stroke-width="1"/><text x="222" y="800" class="t-muted" font-size="9">数据库</text>
+<rect x="280" y="792" width="16" height="10" rx="2" class="c-external" stroke-width="1"/><text x="302" y="800" class="t-muted" font-size="9">外部</text>
+<rect x="360" y="792" width="16" height="10" rx="2" class="c-region" stroke-width="1"/><text x="382" y="800" class="t-muted" font-size="9">区域边界</text>
+<rect x="460" y="792" width="16" height="10" rx="2" class="c-sg" stroke-width="1"/><text x="482" y="800" class="t-muted" font-size="9">安全组边界</text>
+<line x1="560" y1="800" x2="576" y2="800" class="a-emphasis" stroke-width="1.5"/><text x="582" y="803" class="t-muted" font-size="9">主路径</text>
+<line x1="640" y1="800" x2="656" y2="800" class="a-dashed" stroke-width="1.5"/><text x="662" y="803" class="t-muted" font-size="9">异步/辅助</text>
+<line x1="720" y1="800" x2="736" y2="800" class="a-security" stroke-width="1.5"/><text x="742" y="803" class="t-muted" font-size="9">安全流</text>
+</svg>
+</div>
+<script>function toggleTheme(){var h=document.documentElement;var cur=h.getAttribute('data-theme');h.setAttribute('data-theme',cur==='dark'?'light':'dark');}</script>
+</body>
+</html>

--- a/docs/architecture/01-functional-arch.html
+++ b/docs/architecture/01-functional-arch.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ntd 功能架构图</title>
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<!-- JetBrains Mono removed: self-contained page uses system monospace fallback -->
 <style>
 :root,[data-theme="dark"]{
   --bg:#020617;--grid:#1e293b;--text:#fff;--text-muted:#94a3b8;--mask:#0f172a;
@@ -232,8 +232,8 @@ svg{display:block;margin:0 auto;max-width:100%;height:auto;background:var(--bg);
 <text x="1080" y="102" class="t-muted" font-size="9" text-anchor="middle">spawn 子进程</text>
 <line x1="1020" y1="198" x2="1138" y2="468" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
 
-<line x1="920" y1="136" x2="920" y2="168" class="a-dashed" stroke-width="1.5" marker-end="url(#ah-d)"/>
-<text x="935" y="156" class="t-muted" font-size="9">逐环节执行</text>
+<line x1="920" y1="170" x2="920" y2="136" class="a-emphasis" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<text x="935" y="156" class="t-muted" font-size="9">调用执行器</text>
 <line x1="920" y1="288" x2="920" y2="348" class="a-dashed" stroke-width="1.5" marker-end="url(#ah-d)"/>
 <text x="935" y="320" class="t-muted" font-size="9">定时触发</text>
 <line x1="920" y1="406" x2="920" y2="438" class="a-dashed" stroke-width="1.5" marker-end="url(#ah-d)"/>
@@ -250,8 +250,8 @@ svg{display:block;margin:0 auto;max-width:100%;height:auto;background:var(--bg);
 <line x1="1240" y1="316" x2="1240" y2="438" class="a-security" stroke-width="1.5" marker-end="url(#ah-s)"/>
 <text x="1255" y="380" class="t-muted" font-size="9">webhook</text>
 
-<line x1="920" y1="676" x2="920" y2="710" class="a-dashed" stroke-width="1.5" marker-end="url(#ah-d)"/>
-<text x="935" y="696" class="t-muted" font-size="9">同步专家</text>
+<line x1="1020" y1="648" x2="1138" y2="194" class="a-dashed" stroke-width="1.5" marker-end="url(#ah-d)"/>
+<text x="1090" y="400" class="t-muted" font-size="9">拉取专家</text>
 
 <!-- 图例 -->
 <text x="60" y="780" class="t-primary" font-size="11" font-weight="600">图例</text>

--- a/docs/architecture/02-data-arch.html
+++ b/docs/architecture/02-data-arch.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ntd 数据架构图</title>
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<!-- JetBrains Mono removed: self-contained page uses system monospace fallback -->
 <style>
 :root,[data-theme="dark"]{--bg:#020617;--grid:#1e293b;--text:#fff;--text-muted:#94a3b8;--mask:#0f172a;
 --db-fill:rgba(76,29,149,.4);--db-stroke:#a78bfa;--entity-fill:rgba(6,78,59,.3);--entity-stroke:#34d399;
@@ -190,19 +190,19 @@ svg{display:block;margin:0 auto;max-width:100%;height:auto;background:var(--bg);
 
 <!-- 跨域引用线 -->
 <line x1="340" y1="180" x2="400" y2="140" class="a-ref" stroke-width="1.2" marker-end="url(#ah-r)"/>
-<text x="350" y="135" class="t-ref" font-size="8">todo_id→todos</text>
+<text x="350" y="135" class="t-ref" font-size="8">loop_steps.todo_id→todos</text>
 
 <line x1="680" y1="280" x2="740" y2="140" class="a-ref" stroke-width="1.2" marker-end="url(#ah-r)"/>
 <text x="690" y="270" class="t-ref" font-size="8">template_guid</text>
 
 <line x1="680" y1="410" x2="740" y2="410" class="a-ref" stroke-width="1.2" marker-end="url(#ah-r)"/>
-<text x="690" y="404" class="t-ref" font-size="8">loop_id→loops</text>
+<text x="690" y="404" class="t-ref" font-size="8">loop_executions.loop_id→loops</text>
 
 <line x1="680" y1="550" x2="740" y2="550" class="a-ref" stroke-width="1.2" marker-end="url(#ah-r)"/>
-<text x="690" y="544" class="t-ref" font-size="8">step_exec_id</text>
+<text x="690" y="544" class="t-ref" font-size="8">gates.step_execution_id→loop_step_executions</text>
 
 <line x1="1020" y1="550" x2="1080" y2="150" class="a-ref" stroke-width="1.2" marker-end="url(#ah-r)"/>
-<text x="1030" y="300" class="t-ref" font-size="8">record_id→execution_records</text>
+<text x="1030" y="300" class="t-ref" font-size="8">artifacts.execution_record_id→execution_records</text>
 
 <!-- 图例 -->
 <text x="60" y="790" class="t-primary" font-size="11" font-weight="600">图例</text>

--- a/docs/architecture/02-data-arch.html
+++ b/docs/architecture/02-data-arch.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ntd 数据架构图</title>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root,[data-theme="dark"]{--bg:#020617;--grid:#1e293b;--text:#fff;--text-muted:#94a3b8;--mask:#0f172a;
+--db-fill:rgba(76,29,149,.4);--db-stroke:#a78bfa;--entity-fill:rgba(6,78,59,.3);--entity-stroke:#34d399;
+--ref-stroke:#fbbf24;--region-stroke:#fbbf24;--region-fill:rgba(251,191,36,.05);}
+[data-theme="light"]{--bg:#f8fafc;--grid:#e2e8f0;--text:#0f172a;--text-muted:#475569;--mask:#fff;
+--db-fill:rgba(167,139,250,.2);--db-stroke:#7c3aed;--entity-fill:rgba(52,211,153,.15);--entity-stroke:#059669;
+--ref-stroke:#d97706;--region-stroke:#d97706;--region-fill:rgba(251,191,36,.08);}
+body{margin:0;background:var(--bg);color:var(--text);font-family:'JetBrains Mono',monospace;}
+.toolbar{position:sticky;top:0;background:rgba(15,23,42,.85);border-bottom:1px solid #334155;padding:10px 16px;display:flex;align-items:center;gap:12px;z-index:10;}
+.toolbar h1{font-size:14px;margin:0;font-weight:600;}
+.toolbar button{background:transparent;border:1px solid #334155;color:#e2e8f0;padding:4px 10px;border-radius:4px;cursor:pointer;font-family:inherit;font-size:12px;}
+.toolbar button:hover{background:rgba(30,41,59,.8);}
+.diagram-wrap{padding:20px;overflow:auto;}
+svg{display:block;margin:0 auto;max-width:100%;height:auto;background:var(--bg);}
+.c-mask{fill:var(--mask);}
+.c-db{fill:var(--db-fill);stroke:var(--db-stroke);}
+.c-entity{fill:var(--entity-fill);stroke:var(--entity-stroke);}
+.c-region{fill:var(--region-fill);stroke:var(--region-stroke);stroke-dasharray:6 4;}
+.t-primary{fill:var(--text);}.t-muted{fill:var(--text-muted);}
+.t-db{fill:var(--db-stroke);}.t-entity{fill:var(--entity-stroke);}.t-ref{fill:var(--ref-stroke);}
+.a-ref{stroke:var(--ref-stroke);fill:none;}
+</style>
+</head>
+<body>
+<div class="toolbar"><h1>ntd 数据架构图（SQLite 30+ 表，按业务域分组）</h1><button onclick="toggleTheme()">切换主题</button></div>
+<div class="diagram-wrap">
+<svg viewBox="0 0 1480 820" role="img" aria-label="ntd 数据架构图">
+<defs>
+<marker id="ah-r" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#fbbf24"/></marker>
+<pattern id="grid2" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0L0 0 0 40" stroke="var(--grid)" stroke-width="0.5"/></pattern>
+</defs>
+<rect width="100%" height="100%" fill="url(#grid2)"/>
+
+<!-- 业务域边界 -->
+<rect x="40" y="40" width="320" height="740" rx="12" class="c-region"/>
+<text x="52" y="62" class="t-ref" font-size="11" font-weight="600">域 1：事项任务（Todo）</text>
+
+<rect x="380" y="40" width="320" height="740" rx="12" class="c-region"/>
+<text x="392" y="62" class="t-ref" font-size="11" font-weight="600">域 2：环路执行（Loop）</text>
+
+<rect x="720" y="40" width="320" height="740" rx="12" class="c-region"/>
+<text x="732" y="62" class="t-ref" font-size="11" font-weight="600">域 3：工艺模板（Process）</text>
+
+<rect x="1060" y="40" width="380" height="740" rx="12" class="c-region"/>
+<text x="1072" y="62" class="t-ref" font-size="11" font-weight="600">域 4：执行记录与外部集成</text>
+
+<!-- 域1：事项任务 -->
+<rect x="60" y="90" width="280" height="180" rx="8" class="c-mask"/>
+<rect x="60" y="90" width="280" height="180" rx="8" class="c-db" stroke-width="1.5"/>
+<text x="200" y="112" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">todos 表</text>
+<text x="200" y="130" class="t-muted" font-size="9" text-anchor="middle">事项任务主表</text>
+<text x="80" y="152" class="t-entity" font-size="8">id, title, prompt, status</text>
+<text x="80" y="166" class="t-entity" font-size="8">executor, workspace_id, schedule</text>
+<text x="80" y="180" class="t-entity" font-size="8">acceptance_criteria, expert_name</text>
+<text x="80" y="194" class="t-entity" font-size="8">created_at, updated_at, archived_at</text>
+<text x="80" y="216" class="t-muted" font-size="8">TodoStatus 枚举：pending/running/</text>
+<text x="80" y="230" class="t-muted" font-size="8">completed/failed/pending_approval</text>
+<text x="80" y="252" class="t-db" font-size="8">smart_create 走 default_response_todo_id</text>
+
+<rect x="60" y="300" width="280" height="120" rx="8" class="c-mask"/>
+<rect x="60" y="300" width="280" height="120" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="200" y="322" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">todo_tags 表</text>
+<text x="200" y="340" class="t-muted" font-size="9" text-anchor="middle">Todo ↔ Tag 多对多</text>
+<text x="80" y="362" class="t-entity" font-size="8">id, todo_id (FK→todos), tag_id (FK→tags)</text>
+<text x="80" y="386" class="t-muted" font-size="8">批量更新/移动工作空间走此关联</text>
+
+<rect x="60" y="450" width="280" height="100" rx="8" class="c-mask"/>
+<rect x="60" y="450" width="280" height="100" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="200" y="472" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">tags 表</text>
+<text x="200" y="490" class="t-muted" font-size="9" text-anchor="middle">标签字典</text>
+<text x="80" y="512" class="t-entity" font-size="8">id, name, workspace_id, color</text>
+
+<rect x="60" y="580" width="280" height="120" rx="8" class="c-mask"/>
+<rect x="60" y="580" width="280" height="120" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="200" y="602" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">todo_templates 表</text>
+<text x="200" y="620" class="t-muted" font-size="9" text-anchor="middle">Todo 模板</text>
+<text x="80" y="642" class="t-entity" font-size="8">id, name, prompt, executor</text>
+<text x="80" y="656" class="t-entity" font-size="8">default_params, workspace_id</text>
+
+<!-- 域2：环路执行 -->
+<rect x="400" y="90" width="280" height="100" rx="8" class="c-mask"/>
+<rect x="400" y="90" width="280" height="100" rx="8" class="c-db" stroke-width="1.5"/>
+<text x="540" y="112" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">loops 表</text>
+<text x="540" y="130" class="t-muted" font-size="9" text-anchor="middle">环路定义</text>
+<text x="420" y="152" class="t-entity" font-size="8">id, name, status(enabled/disabled)</text>
+<text x="420" y="166" class="t-entity" font-size="8">workspace_id, workspace_path, limits_config</text>
+
+<rect x="400" y="220" width="280" height="120" rx="8" class="c-mask"/>
+<rect x="400" y="220" width="280" height="120" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="540" y="242" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">loop_steps 表</text>
+<text x="540" y="260" class="t-muted" font-size="9" text-anchor="middle">环路环节</text>
+<text x="420" y="282" class="t-entity" font-size="8">id, loop_id, todo_id, order_index</text>
+<text x="420" y="296" class="t-entity" font-size="8">on_success, on_rating_fail, gate_config</text>
+<text x="420" y="310" class="t-entity" font-size="8">expected_artifacts, skill_names, max_rework</text>
+
+<rect x="400" y="370" width="280" height="100" rx="8" class="c-mask"/>
+<rect x="400" y="370" width="280" height="100" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="540" y="392" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">loop_executions 表</text>
+<text x="540" y="410" class="t-muted" font-size="9" text-anchor="middle">环路执行实例</text>
+<text x="420" y="432" class="t-entity" font-size="8">id, loop_id, trigger_type, trigger_meta</text>
+<text x="420" y="446" class="t-entity" font-size="8">status, total_steps, started_at, finished_at</text>
+
+<rect x="400" y="500" width="280" height="100" rx="8" class="c-mask"/>
+<rect x="400" y="500" width="280" height="100" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="540" y="522" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">loop_step_executions 表</text>
+<text x="540" y="540" class="t-muted" font-size="9" text-anchor="middle">环节执行记录</text>
+<text x="420" y="562" class="t-entity" font-size="8">id, loop_execution_id, step_id, todo_id</text>
+<text x="420" y="576" class="t-entity" font-size="8">status, sequence_index, rework_count</text>
+
+<rect x="400" y="630" width="280" height="100" rx="8" class="c-mask"/>
+<rect x="400" y="630" width="280" height="100" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="540" y="652" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">loop_step_execution_gates</text>
+<text x="540" y="670" class="t-muted" font-size="9" text-anchor="middle">门禁评价记录</text>
+<text x="420" y="692" class="t-entity" font-size="8">id, step_execution_id, gate_type</text>
+<text x="420" y="706" class="t-entity" font-size="8">name, status, result</text>
+
+<!-- 域3：工艺模板 -->
+<rect x="740" y="90" width="280" height="120" rx="8" class="c-mask"/>
+<rect x="740" y="90" width="280" height="120" rx="8" class="c-db" stroke-width="1.5"/>
+<text x="880" y="112" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">process_templates 表</text>
+<text x="880" y="130" class="t-muted" font-size="9" text-anchor="middle">工艺模板定义（YAML）</text>
+<text x="760" y="152" class="t-entity" font-size="8">guid, name, display_name, category</text>
+<text x="760" y="166" class="t-entity" font-size="8">version, source(system/user), yaml_content</text>
+<text x="760" y="180" class="t-entity" font-size="8">is_system, created_at</text>
+
+<rect x="740" y="240" width="280" height="100" rx="8" class="c-mask"/>
+<rect x="740" y="240" width="280" height="100" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="880" y="262" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">loop_phases 表</text>
+<text x="880" y="280" class="t-muted" font-size="9" text-anchor="middle">阶段定义</text>
+<text x="760" y="302" class="t-entity" font-size="8">id, loop_id, name, order_index</text>
+
+<rect x="740" y="370" width="280" height="100" rx="8" class="c-mask"/>
+<rect x="740" y="370" width="280" height="100" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="880" y="392" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">loop_phase_executions 表</text>
+<text x="880" y="410" class="t-muted" font-size="9" text-anchor="middle">阶段执行记录</text>
+<text x="760" y="432" class="t-entity" font-size="8">id, loop_execution_id, phase_id</text>
+<text x="760" y="446" class="t-entity" font-size="8">status, started_at, finished_at</text>
+
+<rect x="740" y="500" width="280" height="100" rx="8" class="c-mask"/>
+<rect x="740" y="500" width="280" height="100" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="880" y="522" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">loop_step_artifacts 表</text>
+<text x="880" y="540" class="t-muted" font-size="9" text-anchor="middle">环节产物捕获</text>
+<text x="760" y="562" class="t-entity" font-size="8">id, step_execution_id, spec_name</text>
+<text x="760" y="576" class="t-entity" font-size="8">path, content_hash, captured_at</text>
+
+<!-- 域4：执行记录与外部集成 -->
+<rect x="1080" y="90" width="340" height="120" rx="8" class="c-mask"/>
+<rect x="1080" y="90" width="340" height="120" rx="8" class="c-db" stroke-width="1.5"/>
+<text x="1250" y="112" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">execution_records 表</text>
+<text x="1250" y="130" class="t-muted" font-size="9" text-anchor="middle">执行记录主表（核心）</text>
+<text x="1100" y="152" class="t-entity" font-size="8">id, todo_id, task_id, record_id</text>
+<text x="1100" y="166" class="t-entity" font-size="8">status, result, rating, usage(tokens)</text>
+<text x="1100" y="180" class="t-entity" font-size="8">session_id, agent_runs, started_at, finished_at</text>
+
+<rect x="1080" y="240" width="340" height="100" rx="8" class="c-mask"/>
+<rect x="1080" y="240" width="340" height="100" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="1250" y="262" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">execution_logs 表</text>
+<text x="1250" y="280" class="t-muted" font-size="9" text-anchor="middle">执行日志（stdout/stderr 捕获）</text>
+<text x="1100" y="302" class="t-entity" font-size="8">id, record_id, stream_type, content</text>
+<text x="1100" y="316" class="t-entity" font-size="8">sequence, created_at</text>
+
+<rect x="1080" y="370" width="340" height="100" rx="8" class="c-mask"/>
+<rect x="1080" y="370" width="340" height="100" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="1250" y="392" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">feishu_* 系列表</text>
+<text x="1250" y="410" class="t-muted" font-size="9" text-anchor="middle">飞书集成（6 张表）</text>
+<text x="1100" y="432" class="t-entity" font-size="8">feishu_messages, feishu_history_chats</text>
+<text x="1100" y="446" class="t-entity" font-size="8">feishu_group_whitelist, feishu_push_targets</text>
+<text x="1100" y="460" class="t-entity" font-size="8">feishu_project_bindings, feishu_response_config</text>
+
+<rect x="1080" y="500" width="340" height="100" rx="8" class="c-mask"/>
+<rect x="1080" y="500" width="340" height="100" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="1250" y="522" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">workspace_* 表</text>
+<text x="1250" y="540" class="t-muted" font-size="9" text-anchor="middle">工作空间与设置</text>
+<text x="1100" y="562" class="t-entity" font-size="8">project_directories, workspace_settings</text>
+<text x="1100" y="576" class="t-entity" font-size="8">workspace_slash_commands, review_templates</text>
+
+<rect x="1080" y="630" width="340" height="100" rx="8" class="c-mask"/>
+<rect x="1080" y="630" width="340" height="100" rx="8" class="c-entity" stroke-width="1.5"/>
+<text x="1250" y="652" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">其他辅助表</text>
+<text x="1250" y="670" class="t-muted" font-size="9" text-anchor="middle">usage_stats, agent_bots, quick_buttons 等</text>
+<text x="1100" y="692" class="t-entity" font-size="8">usage_executor_daily, usage_model_breakdown</text>
+<text x="1100" y="706" class="t-entity" font-size="8">sync_records, executors, loop_tags</text>
+
+<!-- 跨域引用线 -->
+<line x1="340" y1="180" x2="400" y2="140" class="a-ref" stroke-width="1.2" marker-end="url(#ah-r)"/>
+<text x="350" y="135" class="t-ref" font-size="8">todo_id→todos</text>
+
+<line x1="680" y1="280" x2="740" y2="140" class="a-ref" stroke-width="1.2" marker-end="url(#ah-r)"/>
+<text x="690" y="270" class="t-ref" font-size="8">template_guid</text>
+
+<line x1="680" y1="410" x2="740" y2="410" class="a-ref" stroke-width="1.2" marker-end="url(#ah-r)"/>
+<text x="690" y="404" class="t-ref" font-size="8">loop_id→loops</text>
+
+<line x1="680" y1="550" x2="740" y2="550" class="a-ref" stroke-width="1.2" marker-end="url(#ah-r)"/>
+<text x="690" y="544" class="t-ref" font-size="8">step_exec_id</text>
+
+<line x1="1020" y1="550" x2="1080" y2="150" class="a-ref" stroke-width="1.2" marker-end="url(#ah-r)"/>
+<text x="1030" y="300" class="t-ref" font-size="8">record_id→execution_records</text>
+
+<!-- 图例 -->
+<text x="60" y="790" class="t-primary" font-size="11" font-weight="600">图例</text>
+<rect x="60" y="802" width="16" height="10" rx="2" class="c-db" stroke-width="1"/><text x="82" y="810" class="t-muted" font-size="9">核心主表</text>
+<rect x="160" y="802" width="16" height="10" rx="2" class="c-entity" stroke-width="1"/><text x="182" y="810" class="t-muted" font-size="9">从属实体表</text>
+<rect x="280" y="802" width="16" height="10" rx="2" class="c-region" stroke-width="1"/><text x="302" y="810" class="t-muted" font-size="9">业务域边界</text>
+<line x1="400" y1="810" x2="416" y2="810" class="a-ref" stroke-width="1.2"/><text x="422" y="813" class="t-muted" font-size="9">外键引用（FK）</text>
+</svg>
+</div>
+<script>function toggleTheme(){var h=document.documentElement;var cur=h.getAttribute('data-theme');h.setAttribute('data-theme',cur==='dark'?'light':'dark');}</script>
+</body>
+</html>

--- a/docs/architecture/03-module-relations.html
+++ b/docs/architecture/03-module-relations.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ntd 功能模块关联关系图</title>
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<!-- JetBrains Mono removed: self-contained page uses system monospace fallback -->
 <style>
 :root,[data-theme="dark"]{--bg:#020617;--grid:#1e293b;--text:#fff;--text-muted:#94a3b8;--mask:#0f172a;
 --frontend-fill:rgba(8,51,68,.4);--frontend-stroke:#22d3ee;
@@ -183,7 +183,8 @@ svg{display:block;margin:0 auto;max-width:100%;height:auto;background:var(--bg);
 <line x1="900" y1="150" x2="900" y2="378" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
 <text x="910" y="280" class="t-muted" font-size="8">触发环路</text>
 
-<line x1="770" y1="350" x2="770" y2="378" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+<line x1="770" y1="380" x2="770" y2="352" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+<text x="780" y="368" class="t-muted" font-size="8">调用执行器</text>
 
 <line x1="640" y1="530" x2="640" y2="648" class="a-data" stroke-width="1.5" marker-end="url(#ah-d)"/>
 <line x1="900" y1="530" x2="900" y2="648" class="a-data" stroke-width="1.5" marker-end="url(#ah-d)"/>

--- a/docs/architecture/03-module-relations.html
+++ b/docs/architecture/03-module-relations.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ntd 功能模块关联关系图</title>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root,[data-theme="dark"]{--bg:#020617;--grid:#1e293b;--text:#fff;--text-muted:#94a3b8;--mask:#0f172a;
+--frontend-fill:rgba(8,51,68,.4);--frontend-stroke:#22d3ee;
+--backend-fill:rgba(6,78,59,.4);--backend-stroke:#34d399;
+--database-fill:rgba(76,29,149,.4);--database-stroke:#a78bfa;
+--external-fill:rgba(30,41,59,.5);--external-stroke:#94a3b8;
+--region-stroke:#fbbf24;--region-fill:rgba(251,191,36,.05);
+--sg-stroke:#fb7185;--sg-fill:rgba(251,113,133,.05);}
+[data-theme="light"]{--bg:#f8fafc;--grid:#e2e8f0;--text:#0f172a;--text-muted:#475569;--mask:#fff;
+--frontend-fill:rgba(34,211,238,.15);--frontend-stroke:#0891b2;
+--backend-fill:rgba(52,211,153,.18);--backend-stroke:#059669;
+--database-fill:rgba(167,139,250,.2);--database-stroke:#7c3aed;
+--external-fill:rgba(148,163,184,.18);--external-stroke:#64748b;
+--region-stroke:#d97706;--region-fill:rgba(251,191,36,.08);
+--sg-stroke:#e11d48;--sg-fill:rgba(251,113,133,.08);}
+body{margin:0;background:var(--bg);color:var(--text);font-family:'JetBrains Mono',monospace;}
+.toolbar{position:sticky;top:0;background:rgba(15,23,42,.85);border-bottom:1px solid #334155;padding:10px 16px;display:flex;align-items:center;gap:12px;z-index:10;}
+.toolbar h1{font-size:14px;margin:0;font-weight:600;}
+.toolbar button{background:transparent;border:1px solid #334155;color:#e2e8f0;padding:4px 10px;border-radius:4px;cursor:pointer;font-family:inherit;font-size:12px;}
+.toolbar button:hover{background:rgba(30,41,59,.8);}
+.diagram-wrap{padding:20px;overflow:auto;}
+svg{display:block;margin:0 auto;max-width:100%;height:auto;background:var(--bg);}
+.c-mask{fill:var(--mask);}
+.c-frontend{fill:var(--frontend-fill);stroke:var(--frontend-stroke);}
+.c-backend{fill:var(--backend-fill);stroke:var(--backend-stroke);}
+.c-database{fill:var(--database-fill);stroke:var(--database-stroke);}
+.c-external{fill:var(--external-fill);stroke:var(--external-stroke);}
+.c-region{fill:var(--region-fill);stroke:var(--region-stroke);stroke-dasharray:6 4;}
+.t-primary{fill:var(--text);}.t-muted{fill:var(--text-muted);}
+.a-call{stroke:#34d399;fill:none;}.a-data{stroke:#a78bfa;fill:none;}.a-event{stroke:#fbbf24;fill:none;stroke-dasharray:5 3;}
+</style>
+</head>
+<body>
+<div class="toolbar"><h1>ntd 功能模块关联关系图（调用/数据/事件）</h1><button onclick="toggleTheme()">切换主题</button></div>
+<div class="diagram-wrap">
+<svg viewBox="0 0 1500 980" role="img" aria-label="ntd 功能模块关联关系图">
+<defs>
+<marker id="ah-c" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#34d399"/></marker>
+<marker id="ah-d" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#a78bfa"/></marker>
+<marker id="ah-e" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#fbbf24"/></marker>
+<pattern id="grid3" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0L0 0 0 40" stroke="var(--grid)" stroke-width="0.5"/></pattern>
+</defs>
+<rect width="100%" height="100%" fill="url(#grid3)"/>
+
+<!-- 三层边界 -->
+<rect x="40" y="40" width="440" height="900" rx="12" class="c-region"/>
+<text x="52" y="62" class="t-muted" font-size="11" font-weight="600">前端层（React）</text>
+
+<rect x="520" y="40" width="560" height="900" rx="12" class="c-region"/>
+<text x="532" y="62" class="t-muted" font-size="11" font-weight="600">后端层（Rust axum）</text>
+
+<rect x="1120" y="40" width="340" height="900" rx="12" class="c-region"/>
+<text x="1132" y="62" class="t-muted" font-size="11" font-weight="600">数据层与外部</text>
+
+<!-- 前端模块 -->
+<rect x="60" y="90" width="180" height="60" rx="6" class="c-mask"/>
+<rect x="60" y="90" width="180" height="60" rx="6" class="c-frontend" stroke-width="1.5"/>
+<text x="150" y="115" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">TodoPage</text>
+<text x="150" y="133" class="t-muted" font-size="9" text-anchor="middle">事项任务列表/详情</text>
+
+<rect x="280" y="90" width="180" height="60" rx="6" class="c-mask"/>
+<rect x="280" y="90" width="180" height="60" rx="6" class="c-frontend" stroke-width="1.5"/>
+<text x="370" y="115" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">LoopStudioPage</text>
+<text x="370" y="133" class="t-muted" font-size="9" text-anchor="middle">环路编排/执行</text>
+
+<rect x="60" y="190" width="180" height="60" rx="6" class="c-mask"/>
+<rect x="60" y="190" width="180" height="60" rx="6" class="c-frontend" stroke-width="1.5"/>
+<text x="150" y="215" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">ProcessEditor</text>
+<text x="150" y="233" class="t-muted" font-size="9" text-anchor="middle">工艺编辑器</text>
+
+<rect x="280" y="190" width="180" height="60" rx="6" class="c-mask"/>
+<rect x="280" y="190" width="180" height="60" rx="6" class="c-frontend" stroke-width="1.5"/>
+<text x="370" y="215" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">Dashboard</text>
+<text x="370" y="233" class="t-muted" font-size="9" text-anchor="middle">概览/统计</text>
+
+<rect x="170" y="290" width="180" height="60" rx="6" class="c-mask"/>
+<rect x="170" y="290" width="180" height="60" rx="6" class="c-frontend" stroke-width="1.5"/>
+<text x="260" y="315" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">apiClient</text>
+<text x="260" y="333" class="t-muted" font-size="9" text-anchor="middle">REST + WebSocket</text>
+
+<!-- 后端模块 -->
+<rect x="540" y="90" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="540" y="90" width="200" height="60" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="640" y="115" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">TodoHandler</text>
+<text x="640" y="133" class="t-muted" font-size="9" text-anchor="middle">CRUD + 执行触发</text>
+
+<rect x="800" y="90" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="800" y="90" width="200" height="60" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="900" y="115" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">LoopHandler</text>
+<text x="900" y="133" class="t-muted" font-size="9" text-anchor="middle">环路触发/查询</text>
+
+<rect x="540" y="190" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="540" y="190" width="200" height="60" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="640" y="215" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">ExecutionHandler</text>
+<text x="640" y="233" class="t-muted" font-size="9" text-anchor="middle">执行记录/评分/续跑</text>
+
+<rect x="800" y="190" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="800" y="190" width="200" height="60" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="900" y="215" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">ProcessHandler</text>
+<text x="900" y="233" class="t-muted" font-size="9" text-anchor="middle">工艺模板 CRUD</text>
+
+<rect x="540" y="290" width="460" height="60" rx="6" class="c-mask"/>
+<rect x="540" y="290" width="460" height="60" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="770" y="315" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">ExecutorService（三阶段：prepare→spawn→dispatch）</text>
+<text x="770" y="333" class="t-muted" font-size="9" text-anchor="middle">调度子进程、日志捕获、超时取消</text>
+
+<rect x="540" y="380" width="460" height="60" rx="6" class="c-mask"/>
+<rect x="540" y="380" width="460" height="60" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="770" y="405" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">LoopRunner（主循环+续跑+返工检测）</text>
+<text x="770" y="423" class="t-muted" font-size="9" text-anchor="middle">逐环节执行→门禁评价→流转解析→产物捕获</text>
+
+<rect x="540" y="470" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="540" y="470" width="200" height="60" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="640" y="495" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">TodoScheduler</text>
+<text x="640" y="513" class="t-muted" font-size="9" text-anchor="middle">tokio-cron 定时</text>
+
+<rect x="800" y="470" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="800" y="470" width="200" height="60" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="900" y="495" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">PhaseDriver</text>
+<text x="900" y="513" class="t-muted" font-size="9" text-anchor="middle">门禁/产物/流转</text>
+
+<rect x="540" y="560" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="540" y="560" width="200" height="60" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="640" y="585" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">BlackboardService</text>
+<text x="640" y="603" class="t-muted" font-size="9" text-anchor="middle">debouncer + wiki</text>
+
+<rect x="800" y="560" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="800" y="560" width="200" height="60" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="900" y="585" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">FeishuService</text>
+<text x="900" y="603" class="t-muted" font-size="9" text-anchor="middle">消息收发/触发执行</text>
+
+<rect x="540" y="650" width="460" height="60" rx="6" class="c-mask"/>
+<rect x="540" y="650" width="460" height="60" rx="6" class="c-backend" stroke-width="1.5"/>
+<text x="770" y="675" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">DB 抽象层（migration v1-v83 + entity 30+ 表）</text>
+<text x="770" y="693" class="t-muted" font-size="9" text-anchor="middle">所有 Service 通过此层读写 SQLite</text>
+
+<!-- 数据层与外部 -->
+<rect x="1140" y="90" width="300" height="60" rx="6" class="c-mask"/>
+<rect x="1140" y="90" width="300" height="60" rx="6" class="c-external" stroke-width="1.5"/>
+<text x="1290" y="115" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">AI 执行器（子进程）</text>
+<text x="1290" y="133" class="t-muted" font-size="9" text-anchor="middle">claude/codex/atomcode 等 13+ 种</text>
+
+<rect x="1140" y="190" width="300" height="60" rx="6" class="c-mask"/>
+<rect x="1140" y="190" width="300" height="60" rx="6" class="c-external" stroke-width="1.5"/>
+<text x="1290" y="215" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">专家系统（plugin.json + MD）</text>
+<text x="1290" y="233" class="t-muted" font-size="9" text-anchor="middle">prompt 注入 + skill 选择</text>
+
+<rect x="1140" y="290" width="300" height="60" rx="6" class="c-mask"/>
+<rect x="1140" y="290" width="300" height="60" rx="6" class="c-database" stroke-width="1.5"/>
+<text x="1290" y="315" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">SQLite 数据库</text>
+<text x="1290" y="333" class="t-muted" font-size="9" text-anchor="middle">todos / loops / executions / process</text>
+
+<rect x="1140" y="380" width="300" height="60" rx="6" class="c-mask"/>
+<rect x="1140" y="380" width="300" height="60" rx="6" class="c-external" stroke-width="1.5"/>
+<text x="1290" y="405" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">飞书 IM（WebSocket + HTTP）</text>
+<text x="1290" y="423" class="t-muted" font-size="9" text-anchor="middle">用户对话 → 触发执行</text>
+
+<rect x="1140" y="470" width="300" height="60" rx="6" class="c-mask"/>
+<rect x="1140" y="470" width="300" height="60" rx="6" class="c-external" stroke-width="1.5"/>
+<text x="1290" y="495" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">Webhook 入口</text>
+<text x="1290" y="513" class="t-muted" font-size="9" text-anchor="middle">外部事件 → 触发执行</text>
+
+<!-- 调用关系（绿色）-->
+<line x1="240" y1="120" x2="170" y2="290" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+<line x1="370" y1="120" x2="290" y2="290" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+<line x1="150" y1="220" x2="200" y2="290" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+<line x1="370" y1="220" x2="290" y2="290" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+
+<line x1="350" y1="320" x2="538" y2="120" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+<line x1="350" y1="320" x2="798" y2="120" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+<line x1="350" y1="320" x2="538" y2="220" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+<line x1="350" y1="320" x2="798" y2="220" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+
+<line x1="640" y1="150" x2="640" y2="288" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+<text x="650" y="220" class="t-muted" font-size="8">调用执行</text>
+<line x1="900" y1="150" x2="900" y2="378" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+<text x="910" y="280" class="t-muted" font-size="8">触发环路</text>
+
+<line x1="770" y1="350" x2="770" y2="378" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+
+<line x1="640" y1="530" x2="640" y2="648" class="a-data" stroke-width="1.5" marker-end="url(#ah-d)"/>
+<line x1="900" y1="530" x2="900" y2="648" class="a-data" stroke-width="1.5" marker-end="url(#ah-d)"/>
+<line x1="770" y1="440" x2="770" y2="648" class="a-data" stroke-width="1.5" marker-end="url(#ah-d)"/>
+<line x1="640" y1="440" x2="640" y2="648" class="a-data" stroke-width="1.5" marker-end="url(#ah-d)"/>
+
+<line x1="1000" y1="320" x2="1138" y2="120" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+<text x="1040" y="200" class="t-muted" font-size="8">spawn 子进程</text>
+
+<line x1="1000" y1="500" x2="1138" y2="410" class="a-call" stroke-width="1.5" marker-end="url(#ah-c)"/>
+
+<line x1="1000" y1="680" x2="1138" y2="320" class="a-data" stroke-width="1.5" marker-end="url(#ah-d)"/>
+<text x="1040" y="480" class="t-muted" font-size="8">SQL 读写</text>
+
+<!-- 事件关系（黄色虚线）-->
+<line x1="350" y1="340" x2="798" y2="590" class="a-event" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<text x="500" y="560" class="t-muted" font-size="8">WS 事件推送</text>
+
+<line x1="1138" y1="410" x2="798" y2="590" class="a-event" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<text x="950" y="510" class="t-muted" font-size="8">飞书事件</text>
+
+<line x1="1138" y1="500" x2="540" y2="500" class="a-event" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<text x="700" y="494" class="t-muted" font-size="8">webhook 事件</text>
+
+<!-- 图例 -->
+<text x="60" y="770" class="t-primary" font-size="11" font-weight="600">图例</text>
+<rect x="60" y="782" width="16" height="10" rx="2" class="c-frontend" stroke-width="1"/><text x="82" y="790" class="t-muted" font-size="9">前端模块</text>
+<rect x="170" y="782" width="16" height="10" rx="2" class="c-backend" stroke-width="1"/><text x="192" y="790" class="t-muted" font-size="9">后端模块</text>
+<rect x="280" y="782" width="16" height="10" rx="2" class="c-database" stroke-width="1"/><text x="302" y="790" class="t-muted" font-size="9">数据存储</text>
+<rect x="390" y="782" width="16" height="10" rx="2" class="c-external" stroke-width="1"/><text x="412" y="790" class="t-muted" font-size="9">外部系统</text>
+<line x1="500" y1="790" x2="516" y2="790" class="a-call" stroke-width="1.5"/><text x="522" y="793" class="t-muted" font-size="9">调用关系</text>
+<line x1="620" y1="790" x2="636" y2="790" class="a-data" stroke-width="1.5"/><text x="642" y="793" class="t-muted" font-size="9">数据访问</text>
+<line x1="740" y1="790" x2="756" y2="790" class="a-event" stroke-width="1.5"/><text x="762" y="793" class="t-muted" font-size="9">事件通知</text>
+</svg>
+</div>
+<script>function toggleTheme(){var h=document.documentElement;var cur=h.getAttribute('data-theme');h.setAttribute('data-theme',cur==='dark'?'light':'dark');}</script>
+</body>
+</html>

--- a/docs/architecture/04-loop-execution-flow.html
+++ b/docs/architecture/04-loop-execution-flow.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ntd 环路（Loop）执行链路框图</title>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root,[data-theme="dark"]{--bg:#020617;--grid:#1e293b;--text:#fff;--text-muted:#94a3b8;--mask:#0f172a;
+--start-fill:rgba(52,211,153,.3);--start-stroke:#34d399;
+--proc-fill:rgba(8,51,68,.4);--proc-stroke:#22d3ee;
+--dec-fill:rgba(251,191,36,.15);--dec-stroke:#fbbf24;
+--data-fill:rgba(76,29,149,.4);--data-stroke:#a78bfa;
+--end-fill:rgba(244,63,94,.2);--end-stroke:#f43f5e;
+--err-fill:rgba(136,19,55,.4);--err-stroke:#fb7185;
+--lane1:rgba(8,51,68,.08);--lane2:rgba(76,29,149,.08);--lane3:rgba(251,113,133,.08);}
+[data-theme="light"]{--bg:#f8fafc;--grid:#e2e8f0;--text:#0f172a;--text-muted:#475569;--mask:#fff;
+--start-fill:rgba(52,211,153,.18);--start-stroke:#059669;
+--proc-fill:rgba(34,211,238,.15);--proc-stroke:#0891b2;
+--dec-fill:rgba(251,191,36,.2);--dec-stroke:#d97706;
+--data-fill:rgba(167,139,250,.2);--data-stroke:#7c3aed;
+--end-fill:rgba(244,63,94,.12);--end-stroke:#e11d48;
+--err-fill:rgba(251,113,133,.12);--err-stroke:#e11d48;
+--lane1:rgba(34,211,238,.06);--lane2:rgba(167,139,250,.06);--lane3:rgba(251,113,133,.06);}
+body{margin:0;background:var(--bg);color:var(--text);font-family:'JetBrains Mono',monospace;}
+.toolbar{position:sticky;top:0;background:rgba(15,23,42,.85);border-bottom:1px solid #334155;padding:10px 16px;display:flex;align-items:center;gap:12px;z-index:10;}
+.toolbar h1{font-size:14px;margin:0;font-weight:600;}
+.toolbar button{background:transparent;border:1px solid #334155;color:#e2e8f0;padding:4px 10px;border-radius:4px;cursor:pointer;font-family:inherit;font-size:12px;}
+.toolbar button:hover{background:rgba(30,41,59,.8);}
+.diagram-wrap{padding:20px;overflow:auto;}
+svg{display:block;margin:0 auto;max-width:100%;height:auto;background:var(--bg);}
+.c-mask{fill:var(--mask);}
+.c-start{fill:var(--start-fill);stroke:var(--start-stroke);}
+.c-proc{fill:var(--proc-fill);stroke:var(--proc-stroke);}
+.c-dec{fill:var(--dec-fill);stroke:var(--dec-stroke);}
+.c-data{fill:var(--data-fill);stroke:var(--data-stroke);}
+.c-end{fill:var(--end-fill);stroke:var(--end-stroke);}
+.c-err{fill:var(--err-fill);stroke:var(--err-stroke);}
+.t-primary{fill:var(--text);}.t-muted{fill:var(--text-muted);}
+.a-main{stroke:#34d399;fill:none;}.a-branch{stroke:#fbbf24;fill:none;stroke-dasharray:5 3;}
+.a-err{stroke:#fb7185;fill:none;stroke-dasharray:5 3;}.a-data{stroke:#a78bfa;fill:none;stroke-dasharray:5 3;}
+</style>
+</head>
+<body>
+<div class="toolbar"><h1>ntd 环路（Loop）执行链路框图</h1><button onclick="toggleTheme()">切换主题</button></div>
+<div class="diagram-wrap">
+<svg viewBox="0 0 1500 1080" role="img" aria-label="环路执行链路框图">
+<defs>
+<marker id="ah-m" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#34d399"/></marker>
+<marker id="ah-b" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#fbbf24"/></marker>
+<marker id="ah-e" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#fb7185"/></marker>
+<marker id="ah-d" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#a78bfa"/></marker>
+<pattern id="grid4" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0L0 0 0 40" stroke="var(--grid)" stroke-width="0.5"/></pattern>
+</defs>
+<rect width="100%" height="100%" fill="url(#grid4)"/>
+
+<!-- 泳道背景 -->
+<rect x="40" y="60" width="1420" height="280" rx="8" fill="var(--lane1)" stroke="var(--proc-stroke)" stroke-width="0.5" stroke-dasharray="4 3"/>
+<text x="52" y="82" class="t-muted" font-size="11" font-weight="600">泳道 1：触发与启动</text>
+
+<rect x="40" y="360" width="1420" height="420" rx="8" fill="var(--lane2)" stroke="var(--data-stroke)" stroke-width="0.5" stroke-dasharray="4 3"/>
+<text x="52" y="382" class="t-muted" font-size="11" font-weight="600">泳道 2：主循环（逐环节执行）</text>
+
+<rect x="40" y="800" width="1420" height="260" rx="8" fill="var(--lane3)" stroke="var(--err-stroke)" stroke-width="0.5" stroke-dasharray="4 3"/>
+<text x="52" y="822" class="t-muted" font-size="11" font-weight="600">泳道 3：终止与异常处理</text>
+
+<!-- 泳道1节点 -->
+<rect x="80" y="120" width="160" height="60" rx="30" class="c-mask"/>
+<rect x="80" y="120" width="160" height="60" rx="30" class="c-start" stroke-width="1.5"/>
+<text x="160" y="145" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">手动触发</text>
+<text x="160" y="163" class="t-muted" font-size="9" text-anchor="middle">dispatch_manual_with_meta</text>
+
+<rect x="280" y="120" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="280" y="120" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="380" y="145" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">创建 loop_execution</text>
+<text x="380" y="163" class="t-muted" font-size="9" text-anchor="middle">status=running, total_steps=0</text>
+
+<rect x="520" y="120" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="520" y="120" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="620" y="145" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">加载 enabled steps</text>
+<text x="620" y="163" class="t-muted" font-size="9" text-anchor="middle">list_enabled_loop_steps_by_loop</text>
+
+<rect x="760" y="120" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="760" y="120" width="200" height="60" rx="6" class="c-dec" stroke-width="1.5"/>
+<text x="860" y="145" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">校验 workspace 一致性</text>
+<text x="860" y="163" class="t-muted" font-size="9" text-anchor="middle">check_workspace_consistency</text>
+
+<rect x="1000" y="120" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="1000" y="120" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="1100" y="145" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">解析 trigger_meta</text>
+<text x="1100" y="163" class="t-muted" font-size="9" text-anchor="middle">params + requirement</text>
+
+<rect x="1240" y="120" width="180" height="60" rx="6" class="c-mask"/>
+<rect x="1240" y="120" width="180" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="1330" y="145" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">初始化计数器</text>
+<text x="1330" y="163" class="t-muted" font-size="9" text-anchor="middle">completed/failed/total</text>
+
+<!-- 泳道1连线 -->
+<line x1="240" y1="150" x2="278" y2="150" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="480" y1="150" x2="518" y2="150" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="720" y1="150" x2="758" y2="150" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="960" y1="150" x2="998" y2="150" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1200" y1="150" x2="1238" y2="150" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1330" y1="180" x2="1330" y2="400" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<text x="1345" y="290" class="t-muted" font-size="9">进入主循环</text>
+
+<!-- 泳道2：主循环 -->
+<rect x="80" y="400" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="80" y="400" width="200" height="60" rx="6" class="c-dec" stroke-width="1.5"/>
+<text x="180" y="425" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">全局限制检查</text>
+<text x="180" y="443" class="t-muted" font-size="9" text-anchor="middle">max_executions / max_tokens</text>
+
+<rect x="320" y="400" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="320" y="400" width="200" height="60" rx="6" class="c-dec" stroke-width="1.5"/>
+<text x="420" y="425" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">死循环检测</text>
+<text x="420" y="443" class="t-muted" font-size="9" text-anchor="middle">连续 5 次 → abort</text>
+
+<rect x="560" y="400" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="560" y="400" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="660" y="425" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">构造 enhanced_prompt</text>
+<text x="660" y="443" class="t-muted" font-size="9" text-anchor="middle">黑板+上环节输出+需求注入</text>
+
+<rect x="800" y="400" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="800" y="400" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="900" y="425" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">创建 step_execution</text>
+<text x="900" y="443" class="t-muted" font-size="9" text-anchor="middle">mark_started</text>
+
+<rect x="1040" y="400" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="1040" y="400" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="1140" y="425" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">spawn 子进程执行</text>
+<text x="1140" y="443" class="t-muted" font-size="9" text-anchor="middle">start_step_todo_with_prompt</text>
+
+<rect x="1280" y="400" width="160" height="60" rx="6" class="c-mask"/>
+<rect x="1280" y="400" width="160" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="1360" y="425" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">wait_for_step_finish</text>
+<text x="1360" y="443" class="t-muted" font-size="9" text-anchor="middle">等待完成</text>
+
+<!-- PhaseDriver 子流程 -->
+<rect x="80" y="500" width="1360" height="240" rx="8" fill="rgba(251,191,36,.05)" stroke="#fbbf24" stroke-width="0.5" stroke-dasharray="4 3"/>
+<text x="92" y="522" class="t-muted" font-size="11" font-weight="600">PhaseDriver 子流程（has_process_config 时委托）</text>
+
+<rect x="100" y="540" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="100" y="540" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="200" y="565" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">产物捕获</text>
+<text x="200" y="583" class="t-muted" font-size="9" text-anchor="middle">capture_step_artifacts</text>
+
+<rect x="340" y="540" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="340" y="540" width="200" height="60" rx="6" class="c-dec" stroke-width="1.5"/>
+<text x="440" y="565" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">门禁评价</text>
+<text x="440" y="583" class="t-muted" font-size="9" text-anchor="middle">evaluate_step_gates</text>
+
+<rect x="580" y="540" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="580" y="540" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="680" y="565" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">流转解析</text>
+<text x="680" y="583" class="t-muted" font-size="9" text-anchor="middle">transition_resolver.resolve_next</text>
+
+<rect x="820" y="540" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="820" y="540" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="920" y="565" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">返工统计</text>
+<text x="920" y="583" class="t-muted" font-size="9" text-anchor="middle">rework_tracker.evaluate_rework</text>
+
+<rect x="1060" y="540" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="1060" y="540" width="200" height="60" rx="6" class="c-dec" stroke-width="1.5"/>
+<text x="1160" y="565" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">确定最终状态</text>
+<text x="1160" y="583" class="t-muted" font-size="9" text-anchor="middle">success/failed/pending_approval</text>
+
+<rect x="1300" y="540" width="140" height="60" rx="6" class="c-mask"/>
+<rect x="1300" y="540" width="140" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="1370" y="565" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">更新 phase</text>
+<text x="1370" y="583" class="t-muted" font-size="9" text-anchor="middle">生命周期</text>
+
+<!-- 门禁类型说明 -->
+<rect x="100" y="630" width="1360" height="100" rx="6" fill="rgba(251,191,36,.08)" stroke="#fbbf24" stroke-width="0.5" stroke-dasharray="3 2"/>
+<text x="112" y="652" class="t-muted" font-size="10" font-weight="600">门禁类型（gate_config）</text>
+<text x="112" y="672" class="t-muted" font-size="9">• ai_criteria_review：AI 评分门禁，min_score 阈值</text>
+<text x="112" y="690" class="t-muted" font-size="9">• human_approval：人工审批门禁，pending → 审批推进 passed/failed</text>
+<text x="112" y="708" class="t-muted" font-size="9">• 废弃类型 artifact_present / script_check 已统一并入 ai_criteria_review</text>
+<text x="700" y="672" class="t-muted" font-size="9">• 流转策略：next / skip / end / break / 裸 step_id（goto 跳转）</text>
+<text x="700" y="690" class="t-muted" font-size="9">• 返工判定：target_idx <= current_idx → rework_count++，超 max_rework 强制失败</text>
+<text x="700" y="708" class="t-muted" font-size="9">• 评分等待：ai_criteria_review 门禁存在时，按 timeout_secs 等评分写回</text>
+
+<!-- 泳道2连线 -->
+<line x1="280" y1="430" x2="318" y2="430" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="520" y1="430" x2="558" y2="430" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="760" y1="430" x2="798" y2="430" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1000" y1="430" x2="1038" y2="430" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1240" y1="430" x2="1278" y2="430" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+
+<line x1="1360" y1="460" x2="1360" y2="498" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<text x="1375" y="480" class="t-muted" font-size="9">→ PhaseDriver</text>
+
+<line x1="300" y1="570" x2="338" y2="570" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="540" y1="570" x2="578" y2="570" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="780" y1="570" x2="818" y2="570" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1020" y1="570" x2="1058" y2="570" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1260" y1="570" x2="1298" y2="570" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+
+<line x1="200" y1="600" x2="200" y2="630" class="a-data" stroke-width="1.2" marker-end="url(#ah-d)"/>
+<line x1="440" y1="600" x2="440" y2="630" class="a-data" stroke-width="1.2" marker-end="url(#ah-d)"/>
+
+<line x1="1360" y1="600" x2="1360" y2="750" class="a-branch" stroke-width="1.5" marker-end="url(#ah-b)"/>
+<text x="1375" y="680" class="t-muted" font-size="9">→ 下一环节</text>
+
+<!-- 回到主循环顶部的箭头 -->
+<line x1="1360" y1="730" x2="180" y2="730" class="a-branch" stroke-width="1.5" stroke-dasharray="5 3"/>
+<line x1="180" y1="730" x2="180" y2="462" class="a-branch" stroke-width="1.5" stroke-dasharray="5 3" marker-end="url(#ah-b)"/>
+<text x="700" y="724" class="t-muted" font-size="9">current_idx = resolve_next(...)，回到主循环顶部</text>
+
+<!-- 泳道3：终止与异常 -->
+<rect x="80" y="850" width="160" height="60" rx="30" class="c-mask"/>
+<rect x="80" y="850" width="160" height="60" rx="30" class="c-end" stroke-width="1.5"/>
+<text x="160" y="875" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">终止</text>
+<text x="160" y="893" class="t-muted" font-size="9" text-anchor="middle">finish_loop_execution</text>
+
+<rect x="280" y="850" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="280" y="850" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="380" y="875" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">计算最终 status</text>
+<text x="380" y="893" class="t-muted" font-size="9" text-anchor="middle">success/failed/partial</text>
+
+<rect x="520" y="850" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="520" y="850" width="200" height="60" rx="6" class="c-err" stroke-width="1.5"/>
+<text x="620" y="875" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">触发异常处理 Todo</text>
+<text x="620" y="893" class="t-muted" font-size="9" text-anchor="middle">trigger_abnormal_handler</text>
+
+<rect x="760" y="850" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="760" y="850" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="860" y="875" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">同步 task 状态</text>
+<text x="860" y="893" class="t-muted" font-size="9" text-anchor="middle">sync_task_status</text>
+
+<rect x="1000" y="850" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="1000" y="850" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="1100" y="875" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">广播 LoopFinished</text>
+<text x="1100" y="893" class="t-muted" font-size="9" text-anchor="middle">或发送飞书结果</text>
+
+<rect x="1240" y="850" width="180" height="60" rx="30" class="c-mask"/>
+<rect x="1240" y="850" width="180" height="60" rx="30" class="c-start" stroke-width="1.5"/>
+<text x="1330" y="875" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">完成</text>
+<text x="1330" y="893" class="t-muted" font-size="9" text-anchor="middle">FeishuPushService 推送</text>
+
+<!-- 泳道3连线 -->
+<line x1="240" y1="880" x2="278" y2="880" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="480" y1="880" x2="518" y2="880" class="a-err" stroke-width="1.5" marker-end="url(#ah-e)"/>
+<line x1="720" y1="880" x2="758" y2="880" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="960" y1="880" x2="998" y2="880" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1200" y1="880" x2="1238" y2="880" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+
+<!-- 异常路径连线（从限制检查/死循环检测到终止）-->
+<line x1="180" y1="460" x2="180" y2="848" class="a-err" stroke-width="1.5" stroke-dasharray="5 3" marker-end="url(#ah-e)"/>
+<text x="50" y="650" class="t-muted" font-size="8">超限/超时</text>
+
+<line x1="420" y1="460" x2="420" y2="848" class="a-err" stroke-width="1.5" stroke-dasharray="5 3" marker-end="url(#ah-e)"/>
+<text x="240" y="650" class="t-muted" font-size="8">死循环检测</text>
+
+<!-- 图例 -->
+<text x="60" y="1010" class="t-primary" font-size="11" font-weight="600">图例</text>
+<rect x="60" y="1022" width="16" height="10" rx="5" class="c-start" stroke-width="1"/><text x="82" y="1030" class="t-muted" font-size="9">起止</text>
+<rect x="130" y="1022" width="16" height="10" rx="2" class="c-proc" stroke-width="1"/><text x="152" y="1030" class="t-muted" font-size="9">处理</text>
+<rect x="200" y="1022" width="16" height="10" rx="2" class="c-dec" stroke-width="1"/><text x="222" y="1030" class="t-muted" font-size="9">判断</text>
+<rect x="270" y="1022" width="16" height="10" rx="2" class="c-data" stroke-width="1"/><text x="292" y="1030" class="t-muted" font-size="9">数据</text>
+<rect x="340" y="1022" width="16" height="10" rx="2" class="c-end" stroke-width="1"/><text x="362" y="1030" class="t-muted" font-size="9">终止</text>
+<rect x="410" y="1022" width="16" height="10" rx="2" class="c-err" stroke-width="1"/><text x="432" y="1030" class="t-muted" font-size="9">异常</text>
+<line x1="480" y1="1030" x2="496" y2="1030" class="a-main" stroke-width="1.5"/><text x="502" y="1033" class="t-muted" font-size="9">主路径</text>
+<line x1="570" y1="1030" x2="586" y2="1030" class="a-branch" stroke-width="1.5"/><text x="592" y="1033" class="t-muted" font-size="9">分支/回环</text>
+<line x1="670" y1="1030" x2="686" y2="1030" class="a-err" stroke-width="1.5"/><text x="692" y="1033" class="t-muted" font-size="9">异常路径</text>
+</svg>
+</div>
+<script>function toggleTheme(){var h=document.documentElement;var cur=h.getAttribute('data-theme');h.setAttribute('data-theme',cur==='dark'?'light':'dark');}</script>
+</body>
+</html>

--- a/docs/architecture/04-loop-execution-flow.html
+++ b/docs/architecture/04-loop-execution-flow.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ntd 环路（Loop）执行链路框图</title>
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<!-- JetBrains Mono removed: self-contained page uses system monospace fallback -->
 <style>
 :root,[data-theme="dark"]{--bg:#020617;--grid:#1e293b;--text:#fff;--text-muted:#94a3b8;--mask:#0f172a;
 --start-fill:rgba(52,211,153,.3);--start-stroke:#34d399;
@@ -176,7 +176,7 @@ svg{display:block;margin:0 auto;max-width:100%;height:auto;background:var(--bg);
 <text x="112" y="690" class="t-muted" font-size="9">• human_approval：人工审批门禁，pending → 审批推进 passed/failed</text>
 <text x="112" y="708" class="t-muted" font-size="9">• 废弃类型 artifact_present / script_check 已统一并入 ai_criteria_review</text>
 <text x="700" y="672" class="t-muted" font-size="9">• 流转策略：next / skip / end / break / 裸 step_id（goto 跳转）</text>
-<text x="700" y="690" class="t-muted" font-size="9">• 返工判定：target_idx <= current_idx → rework_count++，超 max_rework 强制失败</text>
+<text x="700" y="690" class="t-muted" font-size="9">• 返工判定：target_idx &lt;= current_idx → rework_count++，超 max_rework 强制失败</text>
 <text x="700" y="708" class="t-muted" font-size="9">• 评分等待：ai_criteria_review 门禁存在时，按 timeout_secs 等评分写回</text>
 
 <!-- 泳道2连线 -->
@@ -215,7 +215,7 @@ svg{display:block;margin:0 auto;max-width:100%;height:auto;background:var(--bg);
 <rect x="280" y="850" width="200" height="60" rx="6" class="c-mask"/>
 <rect x="280" y="850" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
 <text x="380" y="875" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">计算最终 status</text>
-<text x="380" y="893" class="t-muted" font-size="9" text-anchor="middle">success/failed/partial</text>
+<text x="380" y="893" class="t-muted" font-size="8" text-anchor="middle">success/partial/failed/capped_step/capped_token</text>
 
 <rect x="520" y="850" width="200" height="60" rx="6" class="c-mask"/>
 <rect x="520" y="850" width="200" height="60" rx="6" class="c-err" stroke-width="1.5"/>

--- a/docs/architecture/05-todo-execution-flow.html
+++ b/docs/architecture/05-todo-execution-flow.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ntd 事项任务执行链路框图</title>
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<!-- JetBrains Mono removed: self-contained page uses system monospace fallback -->
 <style>
 :root,[data-theme="dark"]{--bg:#020617;--grid:#1e293b;--text:#fff;--text-muted:#94a3b8;--mask:#0f172a;
 --start-fill:rgba(52,211,153,.3);--start-stroke:#34d399;
@@ -195,8 +195,10 @@ svg{display:block;margin:0 auto;max-width:100%;height:auto;background:var(--bg);
 <line x1="1000" y1="630" x2="1038" y2="630" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
 <line x1="1240" y1="630" x2="1278" y2="630" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
 
-<line x1="1360" y1="660" x2="1360" y2="880" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
-<text x="1375" y="780" class="t-muted" font-size="9">→ 完成</text>
+<line x1="1360" y1="660" x2="1360" y2="780" class="a-main" stroke-width="1.5"/>
+<line x1="1360" y1="780" x2="180" y2="780" class="a-main" stroke-width="1.5"/>
+<line x1="180" y1="780" x2="180" y2="898" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<text x="600" y="774" class="t-muted" font-size="9">→ persist_completion（完成处理链路起点）</text>
 
 <!-- 取消/超时分支 -->
 <line x1="1140" y1="660" x2="1140" y2="900" class="a-branch" stroke-width="1.5" stroke-dasharray="5 3" marker-end="url(#ah-b)"/>

--- a/docs/architecture/05-todo-execution-flow.html
+++ b/docs/architecture/05-todo-execution-flow.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="zh-CN" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ntd 事项任务执行链路框图</title>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root,[data-theme="dark"]{--bg:#020617;--grid:#1e293b;--text:#fff;--text-muted:#94a3b8;--mask:#0f172a;
+--start-fill:rgba(52,211,153,.3);--start-stroke:#34d399;
+--proc-fill:rgba(8,51,68,.4);--proc-stroke:#22d3ee;
+--dec-fill:rgba(251,191,36,.15);--dec-stroke:#fbbf24;
+--data-fill:rgba(76,29,149,.4);--data-stroke:#a78bfa;
+--end-fill:rgba(244,63,94,.2);--end-stroke:#f43f5e;
+--err-fill:rgba(136,19,55,.4);--err-stroke:#fb7185;
+--lane1:rgba(8,51,68,.08);--lane2:rgba(76,29,149,.08);--lane3:rgba(251,191,36,.08);--lane4:rgba(52,211,153,.08);}
+[data-theme="light"]{--bg:#f8fafc;--grid:#e2e8f0;--text:#0f172a;--text-muted:#475569;--mask:#fff;
+--start-fill:rgba(52,211,153,.18);--start-stroke:#059669;
+--proc-fill:rgba(34,211,238,.15);--proc-stroke:#0891b2;
+--dec-fill:rgba(251,191,36,.2);--dec-stroke:#d97706;
+--data-fill:rgba(167,139,250,.2);--data-stroke:#7c3aed;
+--end-fill:rgba(244,63,94,.12);--end-stroke:#e11d48;
+--err-fill:rgba(251,113,133,.12);--err-stroke:#e11d48;
+--lane1:rgba(34,211,238,.06);--lane2:rgba(167,139,250,.06);--lane3:rgba(251,191,36,.06);--lane4:rgba(52,211,153,.06);}
+body{margin:0;background:var(--bg);color:var(--text);font-family:'JetBrains Mono',monospace;}
+.toolbar{position:sticky;top:0;background:rgba(15,23,42,.85);border-bottom:1px solid #334155;padding:10px 16px;display:flex;align-items:center;gap:12px;z-index:10;}
+.toolbar h1{font-size:14px;margin:0;font-weight:600;}
+.toolbar button{background:transparent;border:1px solid #334155;color:#e2e8f0;padding:4px 10px;border-radius:4px;cursor:pointer;font-family:inherit;font-size:12px;}
+.toolbar button:hover{background:rgba(30,41,59,.8);}
+.diagram-wrap{padding:20px;overflow:auto;}
+svg{display:block;margin:0 auto;max-width:100%;height:auto;background:var(--bg);}
+.c-mask{fill:var(--mask);}
+.c-start{fill:var(--start-fill);stroke:var(--start-stroke);}
+.c-proc{fill:var(--proc-fill);stroke:var(--proc-stroke);}
+.c-dec{fill:var(--dec-fill);stroke:var(--dec-stroke);}
+.c-data{fill:var(--data-fill);stroke:var(--data-stroke);}
+.c-end{fill:var(--end-fill);stroke:var(--end-stroke);}
+.c-err{fill:var(--err-fill);stroke:var(--err-stroke);}
+.t-primary{fill:var(--text);}.t-muted{fill:var(--text-muted);}
+.a-main{stroke:#34d399;fill:none;}.a-branch{stroke:#fbbf24;fill:none;stroke-dasharray:5 3;}
+.a-err{stroke:#fb7185;fill:none;stroke-dasharray:5 3;}.a-data{stroke:#a78bfa;fill:none;stroke-dasharray:5 3;}
+</style>
+</head>
+<body>
+<div class="toolbar"><h1>ntd 事项任务（Todo）执行链路框图</h1><button onclick="toggleTheme()">切换主题</button></div>
+<div class="diagram-wrap">
+<svg viewBox="0 0 1500 1120" role="img" aria-label="事项任务执行链路框图">
+<defs>
+<marker id="ah-m" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#34d399"/></marker>
+<marker id="ah-b" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#fbbf24"/></marker>
+<marker id="ah-e" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#fb7185"/></marker>
+<marker id="ah-d" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0,10 3.5,0 7" fill="#a78bfa"/></marker>
+<pattern id="grid5" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0L0 0 0 40" stroke="var(--grid)" stroke-width="0.5"/></pattern>
+</defs>
+<rect width="100%" height="100%" fill="url(#grid5)"/>
+
+<!-- 泳道背景 -->
+<rect x="40" y="60" width="1420" height="200" rx="8" fill="var(--lane1)" stroke="var(--proc-stroke)" stroke-width="0.5" stroke-dasharray="4 3"/>
+<text x="52" y="82" class="t-muted" font-size="11" font-weight="600">泳道 1：触发入口</text>
+
+<rect x="40" y="280" width="1420" height="240" rx="8" fill="var(--lane2)" stroke="var(--data-stroke)" stroke-width="0.5" stroke-dasharray="4 3"/>
+<text x="52" y="302" class="t-muted" font-size="11" font-weight="600">泳道 2：ExecutorService 三阶段编排</text>
+
+<rect x="40" y="540" width="1420" height="280" rx="8" fill="var(--lane3)" stroke="var(--dec-stroke)" stroke-width="0.5" stroke-dasharray="4 3"/>
+<text x="52" y="562" class="t-muted" font-size="11" font-weight="600">泳道 3：spawn 子进程执行</text>
+
+<rect x="40" y="840" width="1420" height="260" rx="8" fill="var(--lane4)" stroke="var(--start-stroke)" stroke-width="0.5" stroke-dasharray="4 3"/>
+<text x="52" y="862" class="t-muted" font-size="11" font-weight="600">泳道 4：完成与产物</text>
+
+<!-- 泳道1：触发入口 -->
+<rect x="80" y="120" width="180" height="60" rx="30" class="c-mask"/>
+<rect x="80" y="120" width="180" height="60" rx="30" class="c-start" stroke-width="1.5"/>
+<text x="170" y="145" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">execute_action</text>
+<text x="170" y="163" class="t-muted" font-size="9" text-anchor="middle">action 触发</text>
+
+<rect x="300" y="120" width="180" height="60" rx="30" class="c-mask"/>
+<rect x="300" y="120" width="180" height="60" rx="30" class="c-start" stroke-width="1.5"/>
+<text x="390" y="145" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">smart_create</text>
+<text x="390" y="163" class="t-muted" font-size="9" text-anchor="middle">默认响应 Todo</text>
+
+<rect x="520" y="120" width="180" height="60" rx="30" class="c-mask"/>
+<rect x="520" y="120" width="180" height="60" rx="30" class="c-start" stroke-width="1.5"/>
+<text x="610" y="145" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">Todo CLI</text>
+<text x="610" y="163" class="t-muted" font-size="9" text-anchor="middle">ntd todo execute</text>
+
+<rect x="740" y="120" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="740" y="120" width="200" height="60" rx="6" class="c-dec" stroke-width="1.5"/>
+<text x="840" y="145" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">find_or_create_todo</text>
+<text x="840" y="163" class="t-muted" font-size="9" text-anchor="middle">查找/创建 todo + workspace</text>
+
+<rect x="980" y="120" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="980" y="120" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="1080" y="145" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">replace_placeholders</text>
+<text x="1080" y="163" class="t-muted" font-size="9" text-anchor="middle">params 替换 prompt</text>
+
+<rect x="1220" y="120" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="1220" y="120" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="1320" y="145" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">start_todo_execution</text>
+<text x="1320" y="163" class="t-muted" font-size="9" text-anchor="middle">进入 ExecutorService</text>
+
+<!-- 泳道1连线 -->
+<line x1="170" y1="180" x2="840" y2="180" class="a-main" stroke-width="1.5"/>
+<line x1="390" y1="180" x2="840" y2="180" class="a-main" stroke-width="1.5"/>
+<line x1="610" y1="180" x2="840" y2="180" class="a-main" stroke-width="1.5"/>
+<line x1="840" y1="180" x2="840" y2="180" class="a-main" stroke-width="1.5"/>
+<line x1="940" y1="150" x2="978" y2="150" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1180" y1="150" x2="1218" y2="150" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+
+<line x1="1320" y1="180" x2="1320" y2="320" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<text x="1335" y="250" class="t-muted" font-size="9">→ ExecutorService</text>
+
+<!-- 泳道2：三阶段编排 -->
+<rect x="80" y="320" width="1360" height="180" rx="8" fill="rgba(8,51,68,.05)" stroke="var(--proc-stroke)" stroke-width="0.5" stroke-dasharray="4 3"/>
+<text x="92" y="342" class="t-muted" font-size="11" font-weight="600">三阶段：prepare_execution_state → start_todo_and_prepare_spawn → dispatch_spawned_executor_task</text>
+
+<rect x="100" y="360" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="100" y="360" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="200" y="385" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">register_task</text>
+<text x="200" y="403" class="t-muted" font-size="9" text-anchor="middle">task_id + guard + cancel_rx</text>
+
+<rect x="340" y="360" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="340" y="360" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="440" y="385" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">注入 prompt</text>
+<text x="440" y="403" class="t-muted" font-size="9" text-anchor="middle">step_context + workspace + expert</text>
+
+<rect x="580" y="360" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="580" y="360" width="200" height="60" rx="6" class="c-dec" stroke-width="1.5"/>
+<text x="680" y="385" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">enforce_concurrency</text>
+<text x="680" y="403" class="t-muted" font-size="9" text-anchor="middle">max_concurrent 检查</text>
+
+<rect x="820" y="360" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="820" y="360" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="920" y="385" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">select_executor</text>
+<text x="920" y="403" class="t-muted" font-size="9" text-anchor="middle">选执行器 + command_args</text>
+
+<rect x="1060" y="360" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="1060" y="360" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="1160" y="385" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">create_run_record</text>
+<text x="1160" y="403" class="t-muted" font-size="9" text-anchor="middle">execution_records 落库</text>
+
+<rect x="1300" y="360" width="140" height="60" rx="6" class="c-mask"/>
+<rect x="1300" y="360" width="140" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="1370" y="385" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">dispatch_spawn</text>
+<text x="1370" y="403" class="t-muted" font-size="9" text-anchor="middle">tokio::spawn</text>
+
+<!-- 泳道2连线 -->
+<line x1="300" y1="390" x2="338" y2="390" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="540" y1="390" x2="578" y2="390" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="780" y1="390" x2="818" y2="390" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1020" y1="390" x2="1058" y2="390" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1260" y1="390" x2="1298" y2="390" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+
+<line x1="1370" y1="420" x2="1370" y2="600" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<text x="1385" y="510" class="t-muted" font-size="9">→ spawn 子进程</text>
+
+<!-- 并发超限异常 -->
+<line x1="680" y1="420" x2="680" y2="900" class="a-err" stroke-width="1.5" stroke-dasharray="5 3" marker-end="url(#ah-e)"/>
+<text x="490" y="660" class="t-muted" font-size="8">超并发上限 → 错误返回</text>
+
+<!-- 泳道3：spawn 子进程执行 -->
+<rect x="80" y="600" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="80" y="600" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="180" y="625" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">emit_started_event</text>
+<text x="180" y="643" class="t-muted" font-size="9" text-anchor="middle">WebSocket 广播</text>
+
+<rect x="320" y="600" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="320" y="600" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="420" y="625" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">try_spawn_executor_child</text>
+<text x="420" y="643" class="t-muted" font-size="9" text-anchor="middle">启动子进程</text>
+
+<rect x="560" y="600" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="560" y="600" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="660" y="625" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">save_child_pid</text>
+<text x="660" y="643" class="t-muted" font-size="9" text-anchor="middle">记录 PID + 关闭 stdin</text>
+
+<rect x="800" y="600" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="800" y="600" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="900" y="625" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">setup_log_capture</text>
+<text x="900" y="643" class="t-muted" font-size="9" text-anchor="middle">stdout/stderr 捕获</text>
+
+<rect x="1040" y="600" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="1040" y="600" width="200" height="60" rx="6" class="c-dec" stroke-width="1.5"/>
+<text x="1140" y="625" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">await_run_outcome</text>
+<text x="1140" y="643" class="t-muted" font-size="9" text-anchor="middle">超时 / 取消 / 完成</text>
+
+<rect x="1280" y="600" width="160" height="60" rx="6" class="c-mask"/>
+<rect x="1280" y="600" width="160" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="1360" y="625" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">dispatch_outcome</text>
+<text x="1360" y="643" class="t-muted" font-size="9" text-anchor="middle">分发结果</text>
+
+<!-- 泳道3连线 -->
+<line x1="280" y1="630" x2="318" y2="630" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="520" y1="630" x2="558" y2="630" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="760" y1="630" x2="798" y2="630" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1000" y1="630" x2="1038" y2="630" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1240" y1="630" x2="1278" y2="630" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+
+<line x1="1360" y1="660" x2="1360" y2="880" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<text x="1375" y="780" class="t-muted" font-size="9">→ 完成</text>
+
+<!-- 取消/超时分支 -->
+<line x1="1140" y1="660" x2="1140" y2="900" class="a-branch" stroke-width="1.5" stroke-dasharray="5 3" marker-end="url(#ah-b)"/>
+<text x="1155" y="780" class="t-muted" font-size="8">取消/超时</text>
+
+<!-- 泳道4：完成与产物 -->
+<rect x="80" y="900" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="80" y="900" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="180" y="925" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">persist_completion</text>
+<text x="180" y="943" class="t-muted" font-size="9" text-anchor="middle">finalize_normal_completion</text>
+
+<rect x="320" y="900" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="320" y="900" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="420" y="925" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">提取 conclusion</text>
+<text x="420" y="943" class="t-muted" font-size="9" text-anchor="middle">extract_conclusion</text>
+
+<rect x="560" y="900" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="560" y="900" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="660" y="925" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">blackboard_debouncer</text>
+<text x="660" y="943" class="t-muted" font-size="9" text-anchor="middle">push_pending_record</text>
+
+<rect x="800" y="900" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="800" y="900" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="900" y="925" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">触发 hooks</text>
+<text x="900" y="943" class="t-muted" font-size="9" text-anchor="middle">fire_post_completion_hooks</text>
+
+<rect x="1040" y="900" width="200" height="60" rx="6" class="c-mask"/>
+<rect x="1040" y="900" width="200" height="60" rx="6" class="c-proc" stroke-width="1.5"/>
+<text x="1140" y="925" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">更新 todo 状态</text>
+<text x="1140" y="943" class="t-muted" font-size="9" text-anchor="middle">sync_task_status</text>
+
+<rect x="1280" y="900" width="160" height="60" rx="30" class="c-mask"/>
+<rect x="1280" y="900" width="160" height="60" rx="30" class="c-end" stroke-width="1.5"/>
+<text x="1360" y="925" class="t-primary" font-size="12" font-weight="600" text-anchor="middle">执行完成</text>
+<text x="1360" y="943" class="t-muted" font-size="9" text-anchor="middle">LoopFinished 广播</text>
+
+<!-- 泳道4连线 -->
+<line x1="280" y1="930" x2="318" y2="930" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="520" y1="930" x2="558" y2="930" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="760" y1="930" x2="798" y2="930" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1000" y1="930" x2="1038" y2="930" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+<line x1="1240" y1="930" x2="1278" y2="930" class="a-main" stroke-width="1.5" marker-end="url(#ah-m)"/>
+
+<!-- 数据流说明 -->
+<text x="80" y="1000" class="t-primary" font-size="11" font-weight="600">数据落库</text>
+<text x="80" y="1020" class="t-muted" font-size="9">• execution_records：执行记录主表（status/result/rating/usage/session_id/agent_runs）</text>
+<text x="80" y="1038" class="t-muted" font-size="9">• execution_logs：stdout/stderr 流式捕获（stream_type/sequence/content）</text>
+<text x="80" y="1056" class="t-muted" font-size="9">• todos：todo 状态同步（status: pending→running→completed/failed）</text>
+
+<!-- 图例 -->
+<text x="700" y="1000" class="t-primary" font-size="11" font-weight="600">图例</text>
+<rect x="700" y="1012" width="16" height="10" rx="5" class="c-start" stroke-width="1"/><text x="722" y="1020" class="t-muted" font-size="9">起止</text>
+<rect x="770" y="1012" width="16" height="10" rx="2" class="c-proc" stroke-width="1"/><text x="792" y="1020" class="t-muted" font-size="9">处理</text>
+<rect x="840" y="1012" width="16" height="10" rx="2" class="c-dec" stroke-width="1"/><text x="862" y="1020" class="t-muted" font-size="9">判断</text>
+<rect x="910" y="1012" width="16" height="10" rx="2" class="c-data" stroke-width="1"/><text x="932" y="1020" class="t-muted" font-size="9">数据</text>
+<rect x="980" y="1012" width="16" height="10" rx="2" class="c-end" stroke-width="1"/><text x="1002" y="1020" class="t-muted" font-size="9">终止</text>
+<rect x="1050" y="1012" width="16" height="10" rx="2" class="c-err" stroke-width="1"/><text x="1072" y="1020" class="t-muted" font-size="9">异常</text>
+<line x1="1120" y1="1020" x2="1136" y2="1020" class="a-main" stroke-width="1.5"/><text x="1142" y="1023" class="t-muted" font-size="9">主路径</text>
+<line x1="1210" y1="1020" x2="1226" y2="1020" class="a-branch" stroke-width="1.5"/><text x="1232" y="1023" class="t-muted" font-size="9">分支</text>
+<line x1="1300" y1="1020" x2="1316" y2="1020" class="a-err" stroke-width="1.5"/><text x="1322" y="1023" class="t-muted" font-size="9">异常路径</text>
+</svg>
+</div>
+<script>function toggleTheme(){var h=document.documentElement;var cur=h.getAttribute('data-theme');h.setAttribute('data-theme',cur==='dark'?'light':'dark');}</script>
+</body>
+</html>

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -115,9 +115,9 @@ ntd 是一个 AI 驱动的任务引擎，采用 Rust 后端 + React 前端 + 多
 - loop_steps.todo_id → todos.id
 - loop_steps 通过 template_guid → process_templates
 - loop_executions.loop_id → loops.id
-- loop_step_executions.step_exec_id → loop_step_executions
-- execution_records.record_id 关联链路
-- loop_step_artifacts.step_execution_id → loop_step_executions
+- loop_step_execution_gates.loop_step_execution_id → loop_step_executions.id
+- loop_step_artifacts.loop_step_execution_id → loop_step_executions.id
+- loop_step_artifacts.execution_record_id → execution_records.id
 
 ---
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,369 @@
+# ntd 系统架构重新推导（基于代码）
+
+> 本文档基于对 ntd 仓库代码的重新阅读，推导系统真实运行架构。配套 5 张架构框图（HTML/SVG）位于同目录 `docs/architecture/`。
+
+## 变更记录
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AtomCode (GLM-5.2) | 2026-08-01 | 初始版本：基于代码重新推导系统架构 |
+
+---
+
+## 1. 配套架构图索引
+
+| 编号 | 文件 | 内容 |
+|------|------|------|
+| 01 | `01-functional-arch.html` | 功能架构图：前端 SPA / 后端引擎 / 外部与存储 |
+| 02 | `02-data-arch.html` | 数据架构图：SQLite 30+ 表，按业务域分组 |
+| 03 | `03-module-relations.html` | 功能模块关联关系图：调用/数据/事件三类关系 |
+| 04 | `04-loop-execution-flow.html` | 环路（Loop）执行链路框图：触发→主循环→PhaseDriver→终止 |
+| 05 | `05-todo-execution-flow.html` | 事项任务（Todo）执行链路框图：触发→三阶段→spawn→完成 |
+
+所有框图均为自包含 HTML（内联 SVG），支持深/浅主题切换，浏览器直接打开即可。
+
+---
+
+## 2. 功能架构（重新推导）
+
+ntd 是一个 AI 驱动的任务引擎，采用 Rust 后端 + React 前端 + 多执行器 + 飞书集成的架构。
+
+### 2.1 前端层（React SPA）
+
+| 模块 | 职责 |
+|------|------|
+| Dashboard | 概览与统计卡片 |
+| Todo 中心 | 事项任务列表/详情/看板 |
+| Loop Studio | 环路编排与执行可视化 |
+| 工艺编辑器 | Monaco YAML + React Flow 可视化 |
+| 消息监控 | 飞书消息流监听与回复 |
+| 设置页 | 执行器/工作空间配置 |
+
+前端通过 `apiClient`（fetch + WebSocket）与后端通信。
+
+### 2.2 后端层（Rust axum）
+
+| 模块 | 职责 |
+|------|------|
+| axum HTTP | REST API 入口 |
+| WebSocket | 事件广播通道 |
+| Handlers | todo/loop/process/action 请求处理 |
+| Services 层 | 业务逻辑编排 |
+| DB 抽象层 | migration（v1-v83）+ entity（30+ 表）|
+
+核心引擎模块：
+
+| 模块 | 职责 |
+|------|------|
+| Executor Service | 三阶段执行编排（prepare→spawn→dispatch） |
+| LoopRunner | 环路主循环 + 续跑 + 返工检测 |
+| TodoScheduler | tokio-cron 定时触发环路 |
+| 工艺服务 | phase_driver + gate_evaluator + transition_resolver |
+| 黑板服务 | debouncer 合并写入 + wiki 文件存储 |
+
+### 2.3 外部层与存储
+
+| 模块 | 职责 |
+|------|------|
+| AI 执行器 | claude/codex/atomcode 等 13+ 种子进程 |
+| 专家系统 | WorkBuddy 兼容的 plugin.json + MD 文件格式 |
+| 飞书 IM | WebSocket + HTTP + Token 管理的消息通道 |
+| Webhook 入口 | 外部事件触发执行 |
+| Git 同步 | 从远程仓库拉取内置专家/模板/Skills |
+| SQLite | todos/loops/process_templates/execution_records 等 30+ 表 |
+
+---
+
+## 3. 数据架构（重新推导）
+
+数据库为 SQLite，通过 migration v1-v83 演进，entity 层 30+ 张表。按业务域分组：
+
+### 3.1 域 1：事项任务（Todo）
+
+- **todos 表**（主表）：id, title, prompt, status, executor, workspace_id, schedule, acceptance_criteria, expert_name, created_at, updated_at, archived_at
+  - TodoStatus 枚举：pending/running/completed/failed/pending_approval
+  - smart_create 走 `default_response_todo_id`
+- **todo_tags 表**：Todo ↔ Tag 多对多（id, todo_id FK, tag_id FK）
+- **tags 表**：标签字典（id, name, workspace_id, color）
+- **todo_templates 表**：Todo 模板（id, name, prompt, executor, default_params, workspace_id）
+
+### 3.2 域 2：环路执行（Loop）
+
+- **loops 表**（主表）：id, name, status(enabled/disabled), workspace_id, workspace_path, limits_config
+- **loop_steps 表**：环路环节（id, loop_id, todo_id, order_index, on_success, on_rating_fail, gate_config, expected_artifacts, skill_names, max_rework）
+- **loop_executions 表**：环路执行实例（id, loop_id, trigger_type, trigger_meta, status, total_steps, started_at, finished_at）
+- **loop_step_executions 表**：环节执行记录（id, loop_execution_id, step_id, todo_id, status, sequence_index, rework_count）
+- **loop_step_execution_gates 表**：门禁评价记录（id, step_execution_id, gate_type, name, status, result）
+
+### 3.3 域 3：工艺模板（Process）
+
+- **process_templates 表**（主表）：guid, name, display_name, category, version, source(system/user), yaml_content, is_system, created_at
+- **loop_phases 表**：阶段定义（id, loop_id, name, order_index）
+- **loop_phase_executions 表**：阶段执行记录（id, loop_execution_id, phase_id, status, started_at, finished_at）
+- **loop_step_artifacts 表**：环节产物捕获（id, step_execution_id, spec_name, path, content_hash, captured_at）
+
+### 3.4 域 4：执行记录与外部集成
+
+- **execution_records 表**（核心）：id, todo_id, task_id, record_id, status, result, rating, usage(tokens), session_id, agent_runs, started_at, finished_at
+- **execution_logs 表**：执行日志（id, record_id, stream_type, content, sequence, created_at）
+- **feishu_* 系列表**（6 张）：feishu_messages, feishu_history_chats, feishu_group_whitelist, feishu_push_targets, feishu_project_bindings, feishu_response_config
+- **workspace_* 表**：project_directories, workspace_settings, workspace_slash_commands, review_templates
+- **其他辅助表**：usage_stats, agent_bots, quick_buttons, usage_executor_daily, usage_model_breakdown, sync_records, executors, loop_tags
+
+### 3.5 跨域外键引用
+
+- loop_steps.todo_id → todos.id
+- loop_steps 通过 template_guid → process_templates
+- loop_executions.loop_id → loops.id
+- loop_step_executions.step_exec_id → loop_step_executions
+- execution_records.record_id 关联链路
+- loop_step_artifacts.step_execution_id → loop_step_executions
+
+---
+
+## 4. 功能模块关联关系
+
+模块间存在三类关系：
+
+### 4.1 调用关系（绿色实线）
+
+- 前端页面 → apiClient → 后端 Handlers
+- TodoHandler/LoopHandler/ExecutionHandler → ExecutorService / LoopRunner
+- ExecutorService → spawn 子进程（AI 执行器）
+- LoopRunner → PhaseDriver → BlackboardService
+- TodoScheduler → LoopRunner（定时触发）
+
+### 4.2 数据访问关系（紫色实线）
+
+- 所有 Service 通过 DB 抽象层读写 SQLite
+- ExecutorService 落库 execution_records / execution_logs
+- LoopRunner 落库 loop_executions / loop_step_executions
+- BlackboardService 通过 debouncer 合并写入 wiki 文件
+
+### 4.3 事件通知关系（黄色虚线）
+
+- WebSocket 事件推送（前端订阅）
+- 飞书事件 → 触发执行
+- webhook 事件 → 触发执行
+- LoopFinished 事件 → FeishuPushService 按 workspace 推送
+
+---
+
+## 5. 环路（Loop）执行链路（完整梳理）
+
+### 5.1 触发与启动阶段
+
+1. **手动触发** `dispatch_manual_with_meta`：trigger_id 为 None（044 后无 trigger 表），所有 status=enabled 的 loop 都允许手动触发
+2. **创建 loop_execution**：status=running, total_steps=0
+3. **加载 enabled steps**：`list_enabled_loop_steps_by_loop`
+4. **校验 workspace 一致性**：`check_workspace_consistency`（所有环节 todo 必须与 loop 同 workspace）
+5. **解析 trigger_meta**：提取 params + requirement
+6. **初始化计数器**：completed/failed/total_executed/total_tokens_used
+
+### 5.2 主循环阶段（`run_inner_from`）
+
+每个环节执行以下步骤：
+
+1. **全局限制检查**：
+   - `total_executed >= max_executions` → finish with "capped_step" + trigger_abnormal_handler
+   - `total_tokens_used >= max_total_tokens` → finish with "capped_token" + trigger_abnormal_handler
+2. **死循环检测**：连续 5 次执行同一 step → abort
+3. **构造 enhanced_prompt**：
+   - `build_enhanced_prompt_with_requirement`：注入黑板变量 + 上一环节输出 + 需求
+   - `inject_workspace_prompt`：注入工作空间级共识 prompt
+   - todo.prompt 是只读模板，仅在内存中替换，绝不写回 DB
+4. **创建 step_execution**：`create_loop_step_execution` + `mark_step_execution_started`
+5. **spawn 子进程执行**：`start_step_todo_with_prompt`
+6. **等待执行完成**：`wait_for_step_finish`
+7. **PhaseDriver 委托**（has_process_config 时）：
+   - 产物捕获：`capture_step_artifacts`
+   - 门禁评价：`evaluate_step_gates`
+   - 流转解析：`transition_resolver.resolve_next`
+   - 返工统计：`rework_tracker.evaluate_rework`
+   - 确定最终状态：success/failed/pending_approval
+   - 更新 phase 生命周期
+8. **黑板更新**：`blackboard_debouncer.push_pending_record`（debouncer 合并写入）
+9. **确定下一步**：`current_idx = resolve_next(...)`
+
+### 5.3 门禁类型（gate_config）
+
+- **ai_criteria_review**：AI 评分门禁，min_score 阈值
+- **human_approval**：人工审批门禁，pending → 审批推进 passed/failed
+- 废弃类型 artifact_present / script_check 已统一并入 ai_criteria_review（046）
+
+### 5.4 流转策略
+
+- `next` / `skip` → 推进到下一索引
+- `end` / `break` → 终止
+- 裸 step_id（goto 跳转）：用 `success_goto_step_id` / `fail_goto_step_id` 流转（037 清除 `goto:` 前缀）
+
+### 5.5 返工判定
+
+- 门禁失败后 goto 上游 → 视为返工 → `rework_count` 递增
+- 超过 `max_rework` → 强制失败，工艺终止
+- 判定规则：`target_idx <= current_idx` → 返工
+
+### 5.6 评分等待
+
+- ai_criteria_review 门禁存在时，按 `timeout_secs` 等评分写回
+- null=默认 300s，0=一直等，N=等 N 秒
+- 避免无评分误判 fail（047）
+
+### 5.7 终止与异常处理阶段
+
+1. **计算最终 status**：success（failed==0）/ failed（completed==0）/ partial
+2. **finish_loop_execution**：落库 final_status + completed + failed
+3. **触发异常处理 Todo**（failed/partial 时）：`trigger_abnormal_handler`
+4. **同步 task 状态**：`sync_task_status`（NTD-005）
+5. **广播 LoopFinished 事件**：FeishuPushService 按 workspace 配置推送
+6. **或发送飞书结果**（有 feishu_receive_id 时）：`send_result_to_feishu`
+
+### 5.8 异常路径
+
+- 超限/超时 → finish with capped_step/capped_token → trigger_abnormal_handler
+- 死循环检测 → abort
+- step start 失败 → finish_step_execution("failed") + increment failed
+- run 失败 → finish_loop_execution("failed") + trigger_abnormal_handler + ReviewStatusChanged 事件
+
+---
+
+## 6. 事项任务（Todo）执行链路（完整梳理）
+
+### 6.1 触发入口阶段
+
+事项任务有多个触发入口，最终都收敛到 `start_todo_execution` → `ExecutorService`：
+
+1. **execute_action**：action 触发，构造 RunTodoExecutionRequest 直接执行
+2. **smart_create**：默认响应 Todo，通过 workspace_settings.default_response_todo_id 找到 todo
+3. **Todo CLI**：`ntd todo execute`，通过 CLI 子命令触发
+
+共同流程：
+- `find_or_create_todo`：查找/创建 todo + workspace
+- `replace_placeholders`：params 替换 prompt 占位符
+- `start_todo_execution`：进入 ExecutorService
+
+### 6.2 ExecutorService 三阶段编排
+
+#### Stage 1: `prepare_execution_state`
+
+1. **占位符替换**：`substitute_message_placeholders`
+2. **register_task_and_load_todo**：注册 task（task_id + guard + cancel_rx）+ 加载 todo
+3. **read_runtime_config**：max_concurrent / timeout_secs
+4. **enforce_concurrency_limit**：并发检查（超限返回错误）
+5. **注入环节级上下文**：`inject_step_context`（需求 054：期望产物 + spec 模板）
+6. **注入工作空间级共识 prompt**：`inject_workspace_prompt`（需求 022）
+7. **注入专家上下文**：`inject_expert_context`（Agent MD + 技能信息）
+8. **注入工作空间运行背景**：`inject_workspace_background`（需求 042）
+9. **select_executor_and_build_command**：选定 executor + 构造 command_args
+10. **create_run_execution_record**：创建 execution record 落库
+
+注入层次（由外到内）：工作空间运行背景 → 专家上下文 → 工作空间共识 → 环节期望产物 → 原任务
+
+#### Stage 2: `start_todo_and_prepare_spawn`
+
+1. **resolve_worktree_context**：解析 worktree 路径
+2. **record_worktree_path**：记录 worktree 路径到 DB
+3. **start_todo_or_cleanup**：启动 todo 或清理失败
+4. **register_websocket_task_info**：注册 WebSocket 任务信息
+5. **计算 effective_workspace_path**：worktree 路径 > todo.workspace_path > request.workspace_path
+
+#### Stage 3: `dispatch_spawned_executor_task`
+
+1. **tokio::spawn**：异步执行 spawn 闭包
+2. 返回 ExecutionResult（task_id + record_id）
+
+### 6.3 spawn 子进程执行阶段
+
+`run_spawned_executor_task` 编排流程：
+
+1. **emit_started_event**：WebSocket 广播 Started 事件
+2. **try_spawn_executor_child**：启动子进程
+3. **save_child_pid_and_close_stdin**：记录 PID + 关闭 stdin
+4. **setup_log_capture_pipeline**：stdout/stderr 捕获 + log flusher + flush timer
+5. **await_run_outcome_with_timeout**：等待子进程完成（超时 / 取消 / 完成）
+6. **dispatch_outcome**：分发结果
+
+### 6.4 完成与产物阶段
+
+1. **persist_completion**：`finalize_normal_completion` 持久化完成记录
+2. **提取 conclusion**：`extract_conclusion` 从 execution_record 提取结论
+3. **blackboard_debouncer**：`push_pending_record` 推送到黑板 debouncer
+4. **触发 hooks**：`fire_post_completion_hooks`
+5. **更新 todo 状态**：`sync_task_status`
+6. **执行完成**：LoopFinished 广播 / 飞书推送
+
+### 6.5 数据落库
+
+- **execution_records 表**：执行记录主表（status/result/rating/usage/session_id/agent_runs）
+- **execution_logs 表**：stdout/stderr 流式捕获（stream_type/sequence/content）
+- **todos 表**：todo 状态同步（status: pending→running→completed/failed）
+
+### 6.6 异常路径
+
+- 并发超限 → 错误返回（enforce_concurrency_limit）
+- 取消/超时 → `run_cancellation_path` / `run_timeout_path`
+- spawn 失败 → 错误返回
+
+---
+
+## 7. 推导依据（代码引用）
+
+本架构推导基于以下代码文件：
+
+### 后端入口与路由
+
+- `backend/src/main.rs`：CLI 命令枚举（Commands），Server/Todo/Loop/Process/Tag/Stats/Daemon/Skills 子命令
+- `backend/src/lib.rs`：模块导出（adapters/cli/config/daemon/db/executor_service/...）
+- `backend/src/handlers/mod.rs`：Router 路由注册（1125 行），mount_v1_domain_routes
+
+### 环路执行链路
+
+- `backend/src/services/loop_trigger.rs`：LoopTriggerDispatcher，dispatch_manual_with_meta（044 后仅手动触发）
+- `backend/src/services/loop_runner.rs`：LoopRunner（2446 行），spawn_run/run_inner/run_inner_from
+- `backend/src/services/process/phase_driver.rs`：execute_step（产物捕获→门禁评价→流转解析→返工统计）
+- `backend/src/services/process/gate_evaluator.rs`：evaluate_step_gates（门禁评价）
+- `backend/src/services/process/transition_resolver.rs`：resolve_next（流转解析）
+- `backend/src/services/process/rework_tracker.rs`：evaluate_rework（返工统计）
+
+### 事项任务执行链路
+
+- `backend/src/executor_service/mod.rs`：run_todo_execution / run_todo_execution_with_params
+- `backend/src/executor_service/stages.rs`：三阶段编排（prepare_execution_state / start_todo_and_prepare_spawn / dispatch_spawned_executor_task）
+- `backend/src/executor_service/spawn_lifecycle.rs`：run_spawned_executor_task（810 行）
+- `backend/src/handlers/execution.rs`：start_todo_execution / smart_create_handler / resume_execution_handler
+- `backend/src/handlers/action.rs`：execute_action
+
+### 数据层
+
+- `backend/src/db/`：migration（v1-v83）+ entity（30+ 表）
+- `backend/src/db/entity/`：所有实体定义（todos/loops/loop_steps/loop_executions/...）
+
+### 调度器
+
+- `backend/src/scheduler.rs`：TodoScheduler（1480 行），tokio-cron 定时触发
+- `backend/src/task_manager.rs`：TaskManager + TaskGuard
+
+---
+
+## 8. 已知限制与待改进点
+
+1. **archify renderer 布局严格**：architecture 渲染器的 clean-flow/edge-through-node 检查非常严格，手调坐标成本高。本次 5 张图全部采用 hand-placed SVG fallback，精确控制布局。
+2. **架构图未含完整连线**：为避免穿透，部分次要连线省略。完整模块依赖关系见代码引用部分。
+3. **数据架构图未含所有 30+ 表**：按业务域分组后，部分辅助表（usage_stats/agent_bots/quick_buttons 等）合并展示。
+4. **执行链路框图未含并发竞态**：环路续跑（resume）与并发执行的竞态条件未在框图中体现。
+
+---
+
+## 9. 与需求的对应关系
+
+| 需求 | 实现 |
+|------|------|
+| 新建分支 | `docs/arch-rededuce` 分支 |
+| 根据代码重新推导系统架构 | 见本文档第 2-4 节 + 架构图 01-03 |
+| 画详细、符合真实情况的系统运行架构图 | 见架构图 01-03（功能/数据/关联） |
+| 架构图包含功能架构 | 见 01-functional-arch.html |
+| 架构图包含数据架构 | 见 02-data-arch.html |
+| 架构图包含功能模块关联关系架构 | 见 03-module-relations.html |
+| 针对「环路」执行链路完整梳理 | 见本文档第 5 节 + 04-loop-execution-flow.html |
+| 针对「事项任务」执行链路完整梳理 | 见本文档第 6 节 + 05-todo-execution-flow.html |
+| 画成流程图式的框图表现形式 | 5 张图均为 SVG 框图，含泳道/判断/数据/起止等流程图元素 |


### PR DESCRIPTION
基于对 ntd 仓库代码的重新阅读，推导系统真实运行架构。

新增 5 张架构框图（HTML/SVG，自包含，支持深/浅主题切换）+ 1 份总文档：

- 01 功能架构图：前端 SPA / 后端引擎 / 外部与存储三层
- 02 数据架构图：SQLite 30+ 表，按 4 个业务域分组 + 跨域 FK 引用
- 03 功能模块关联关系图：调用(绿)/数据(紫)/事件(黄虚) 三类关系
- 04 环路执行链路框图：3 泳道（触发启动/主循环+PhaseDriver/终止异常）
- 05 事项任务执行链路框图：4 泳道（触发入口/三阶段编排/spawn 子进程/完成产物）

架构推导基于代码阅读：loop_runner/run_inner_from、phase_driver/execute_step、gate_evaluator/transition_resolver/rework_tracker、executor_service/stages 三阶段编排。

Co-Authored-By: AtomCode (GLM-5.2) <noreply@atomgit.com>