### PR TITLE
test(055): PR #963/#964/#966/#967 端到端验证、48 用例与 8 个问题记录

### DIFF
--- a/docs/testing/055-工艺PR系列端到端验证-测试.md
+++ b/docs/testing/055-工艺PR系列端到端验证-测试.md
@@ -4,6 +4,7 @@
 |--------|---------|---------|
 | AI | 2026-08-01 | 初始版本：PR #963/#964/#966/#967 端到端验证与问题记录 |
 | AI | 2026-08-01 | 补充 §5 测试用例执行明细（编号/步骤/预期/实际/证据），后续章节顺延 |
+| AI | 2026-08-01 | 追加 BUG-008（升级级联删 phase 历史）；补充 §11 修复交接指南（环境重建/最小复现/验收标准）；升级后整环重跑复核 BUG-003/004 |
 
 # 1. 测试目标与范围
 
@@ -178,6 +179,7 @@ t01 实收 prompt 层次与 PR 描述完全一致：
 | TC-E04 | 人工挂起返工统计 | 检查 t03 step_execution | 挂起不应计返工、不应有错误信息 | rework_count=1 且 error_message='返工次数 1 已达到上限 1，工艺终止' | 🐛 BUG-003 | db/db-snapshots.txt §loop_step_executions |
 | TC-E05 | phase 终态 | loop success 后查 phase 执行 | phase 应 success/failed | 两条 phase 永驻 running、finished_at=NULL | 🐛 BUG-004 | db/db-snapshots.txt §loop_phase_executions |
 | TC-E06 | 评审占位符替换 | 检查评审实例 prompt 三个占位段 | 原始任务/输出/验收标准应被实际值替换 | 全部以 `{original_prompt}` 等字面量残留（盲评） | 🐛 BUG-002 | prompts/prompt-20260801-122117-25077.txt |
+| TC-E07 | 升级保留执行历史 | loop 跑完一轮 → `process upgrade` → 查 loop_phase_executions | 历史 phase 执行记录应保留 | 被级联删除（执行 #4 的记录 COUNT=0），audit 对旧执行回显 phase pending/从未运行，与 loop success 矛盾 | 🐛 BUG-008 | db/db-snapshots.txt 末尾、§6.6 |
 
 ## 5.F 产物 / 日志 / 审计 / 只读
 
@@ -214,27 +216,32 @@ t01 实收 prompt 层次与 PR 描述完全一致：
 
 # 6. 关键验证过程记录
 
-## 5.1 UI 创建与保存
+## 6.1 UI 创建与保存
 - 创建 Modal → 编辑器 → YAML tab 粘贴 → 保存成功；可视化图渲染 2 阶段 3 环节（screenshots/06,09,10）。
 - 保存时版本自动 1.0.0→1.1.0（需求 042 设计行为，非缺陷）。
 - 工具备注：Monaco 编辑器逐行 insertText 会被自动缩进干扰（工具方法问题，非产品缺陷），改用剪贴板粘贴后正常。
 
-## 5.2 安装
+## 6.2 安装
 - UI 列表卡片「安装」→ 确认 → Loop #12（workspace_id=2, version=1.1.0），3 环节 todo_id=28/29/30。
 - t03 未配 executor，`create_todo_with_extras` 回退默认执行器 claudecode（设计行为：安装期即落默认值）。
 
-## 5.3 执行与门禁
+## 6.3 执行与门禁
 - 触发方式：POST /api/v1/workspaces/2/tasks {loop_id:12, requirement} → loop_execution #4。
 - 执行序列（假 CLI 调用日志 invocations.jsonl）：
   1. 12:21:14 claude（t01，argv 含 --model）→ 2. 12:21:17 claude（t01 评审实例）→ 3. 12:21:21 atomcode（t02）→ 4. 12:21:24 claude（t03）。
 - 另有 1 次黑板 wiki 后台任务调用（环境噪音，与本次验证无关）。
 - t03 人工审批：approve API 200 → loop_execution #4 success。
 
-## 5.4 只读与编辑保持
+## 6.4 只读与编辑保持
 - PUT /api/v1/workspaces/2/todos/32 改标题 → skills/executor/expert_name/model 全部保留；prompt 未被注入内容污染。
 
-## 5.5 CLI 输出原件
+## 6.5 CLI 输出原件
 - `test-evidence/2026-08-01-pr963-967/cli/` 下：list*.json、show-by-*.json、loops.json、recommend.json、versions.json、diff-same-version.json、upgrade.json、run.json、create.json。
+
+## 6.6 升级与整环重跑（BUG-003/004 复核 + BUG-008 发现）
+- `ntd process upgrade e2e-verify-055 --loop-id 12`：重建 2 阶段 3 环节，新 todo 32/33/34 字段与旧 28/29/30 一致（967 F5 通过）；steps 指向新 todo。
+- **BUG-008 发现**：upgrade 后执行 #4 的 2 条 `loop_phase_executions` 被级联删除（COUNT=0）；audit 对执行 #4 回显 phase pending。`loop_step_executions` 无外键级联得以保留。
+- 执行 #5（升级后整环重跑）：t01/t02/t03 全部成功、注入链完好（prompt-20260801-1332*.txt）；BUG-003（rework=1+假错误信息）与 BUG-004（phase 8/9 永驻 running）在新数据上再次复现。
 
 # 7. 发现的问题清单（供修复，本次未修）
 
@@ -290,6 +297,15 @@ t01 实收 prompt 层次与 PR 描述完全一致：
 - **证据**：`db/t01-panel-text.txt` 及 spec 运行日志「t03 面板 Tag 列表」、screenshots/18。
 - **修复建议**：`splitSelected`/Tag 渲染前 `trim()` 并过滤空串；或在写回 link.skills 时做数据卫生。
 
+
+## BUG-008（P2）工艺升级级联删除历史 loop_phase_executions，审计链断裂
+
+- **现象**：对已跑过的 loop 执行 `ntd process upgrade`（或对应 API）后，历史 `loop_phase_executions` 行被**物理删除**；audit 接口对旧执行回显 phase `pending / started_at=None`，与同一条 loop_execution 的 `success/3 completed` 自相矛盾。
+- **复现**：跑完一轮 loop → 确认 `loop_phase_executions` 有行 → 执行 upgrade → 行消失。本验证中执行 #4 的 2 条 phase 记录（曾查到 id=1,2）在 `upgrade --loop-id 12` 后消失；COUNT 归零。
+- **根因**：`loop_phase_executions.phase_id` 外键为 `ON DELETE CASCADE`；upgrade 删除旧 `loop_phases` 重建（id 6/7 → 8/9）时级联清空历史。对比：`loop_step_executions` 根本没有 step_id 外键（只有 loop_execution_id CASCADE + execution_record_id SET NULL），环节执行历史得以保留——两表外键设计不一致，phase 侧误把「模板行」当「可级联父行」。
+- **证据**：`db/db-snapshots.txt`（§loop_phase_executions 曾有 id=1,2 行 vs 末尾 COUNT=0 对照 + 外键 schema）；升级后 audit 执行 #4 phases 回显 pending。
+- **修复建议**：phase_id 外键改 `SET NULL`（或去级联并在执行表冗余 phase 名快照）；升级只清理未被任何执行引用的 phase 或软删除；补「upgrade 后历史 phase 执行记录仍在」回归测试。
+
 # 8. 已确认的「设计如此」行为（非缺陷，避免误报）
 
 | 行为 | 说明 |
@@ -316,7 +332,9 @@ db/loop12-page-text.txt     loop 详情页全文
 prompts/invocations.jsonl   假 CLI 全部调用（bin/argv/cwd）
 prompts/prompt-*.txt        每次执行实收 prompt 全文（t01/评审/t02/t03/黑板后台）
 screenshots/*.png           UI 过程截图（创建/编辑器/面板/安装/loop 详情）
-frontend/tests/check_055_*.spec.ts  验证用 Playwright 脚本（未跟踪，随仓库留存）
+specs/check_055_*.spec.ts   验证用 Playwright 脚本备份（原件在 frontend/tests/，均未跟踪）
+repro/env-setup.sh          环境一键重建脚本（幂等；含执行器路径备份/恢复提示）
+repro/repro-bugs.sh         8 个 BUG 的最小复现脚本（可单跑：bash repro-bugs.sh 002）
 ```
 
 # 10. 遗留与建议
@@ -324,3 +342,60 @@ frontend/tests/check_055_*.spec.ts  验证用 Playwright 脚本（未跟踪，�
 - 生产库若从旧版升级，BUG-002 会导致所有 AI 评审盲评，建议优先修复并补数据迁移。
 - 本次未覆盖：复制 loop 丢 skill_names 的 053 已知缺口（官方已记录）；cron/飞书/hook 入口的注入链（代码上与 loop/手动同路径，单测已覆盖）。
 - 验证结束后建议恢复：executors 表 claudecode/atomcode 的 path（当前指向假 CLI）、删除 `~/.ntd/processes/e2e-verify-055.yaml` 与 Loop #12/#13/#14（如需清理）。
+
+# 11. 修复交接指南（给修复 AI）
+
+## 11.1 能否复现
+
+能。环境、数据、脚本、预期/实际对照全部备好：本文档给出每个 BUG 的根因分析与证据定位，`test-evidence/2026-08-01-pr963-967/repro/` 提供环境重建与最小复现脚本，§5 给出修复后验收要复跑的用例编号。按下文操作即可，无需重新摸索。
+
+## 11.2 环境重建（约 5 分钟）
+
+1. **起 dev 实例**：基于修复分支 `make dev`（端口 18088 + dev 库 `~/.ntd/data.dev.db`）。生产 8088 不受影响，不要动。
+2. **一键准备**：`bash test-evidence/2026-08-01-pr963-967/repro/env-setup.sh`
+   - 放置 spec 夹具（小/大 spec）到 `~/.ntd/bundled/processes/conventions/`；
+   - 把 claudecode/atomcode 指向假 CLI（**会打印恢复原路径的 SQL，保存好**）；
+   - 建 E2E 工作空间（/tmp/ntd-e2e-workspace）。
+3. **确认测试工艺**：`~/.ntd/processes/e2e-verify-055.yaml` 与 DB 行（guid `4bafee67-a3e7-4c1f-b096-5f60ec8f6c14`）应已存在；若缺失，用 `test-evidence/.../api/test-process-final.yaml` 经 UI 或 `POST /api/v1/processes` 重建。
+4. **整环重跑**（BUG-003/004/008 需要新鲜 loop 数据时）：
+   ```bash
+   # 触发（requirement 首行保持短 ASCII——BUG-001 未修时 CJK 长标题会 panic）
+   curl -X POST http://localhost:18088/api/v1/workspaces/2/tasks \
+     -H 'Content-Type: application/json' \
+     -d '{"loop_id":12,"requirement":"repro run\n需求正文"}'
+   # t03 挂起后审批（把 <EID> 换成上一步返回的 execution_id）
+   SE=$(sqlite3 ~/.ntd/data.dev.db "SELECT id FROM loop_step_executions WHERE loop_execution_id=<EID> AND status='pending_approval'")
+   G=$(sqlite3 ~/.ntd/data.dev.db "SELECT id FROM loop_step_execution_gates WHERE loop_step_execution_id=$SE AND gate_type='human_approval'")
+   curl -X POST "http://localhost:18088/api/v1/workspaces/2/loops/12/executions/<EID>/steps/$SE/gates/$G/approve" \
+     -H 'Content-Type: application/json' -d '{"approved":true,"comment":"repro"}'
+   ```
+5. **验证材料位置**：执行器实收 prompt → `/tmp/ntd-fake-log/`（invocations.jsonl + prompt-*.txt）；DB → `sqlite3 ~/.ntd/data.dev.db`；历史证据快照 → `test-evidence/2026-08-01-pr963-967/`（**勿删**）。
+
+## 11.3 每个 BUG 的最小复现与修复验收对照
+
+> 修复后除「验收标准」列的检查外，还需复跑「关联用例」列对应的 §5 用例确认无回退。
+
+| BUG | 最小复现 | 修复验收标准 | 关联用例 |
+|-----|---------|-------------|---------|
+| BUG-001 | `bash repro/repro-bugs.sh 001` → HTTP 000 + 日志 panic | 同一请求返回 201；标题按**字符**截断（≤60 字符 + …）；日志无 panic；补 CJK 长标题单测 | TC-H01 |
+| BUG-002 | `bash repro/repro-bugs.sh 002` → DB 模板单大括号 vs 代码双大括号；动态：评审 prompt 残留 `{original_prompt}` | 评审实例 prompt 中原始任务/执行输出/验收标准均为**实际值**（可 grep `E2E-T01-CORE-PROMPT`、执行输出、`验收标准` 正文）；存量单大括号模板被迁移或兼容；补回归测试 | TC-E06、TC-E01、TC-D09 |
+| BUG-003 | `bash repro/repro-bugs.sh 003` → rework_count=1 且 error_message 为假「工艺终止」 | human_approval 挂起时 rework_count=0、error_message 为空；审批后正常流转；补「挂起不计返工」测试 | TC-E04、TC-E02、TC-E03 |
+| BUG-004 | `bash repro/repro-bugs.sh 004` → loop success 但 phase 永驻 running | loop 终态后无 running phase、finished_at 非空；audit 回显一致 | TC-E05、TC-F03 |
+| BUG-005 | `bash repro/repro-bugs.sh 005` → versions 恒 1 条、跨版本 diff 404 | 二选一兑现：保存落版本快照且跨版本 diff 有真实输出；或 CLI/文档声明无历史并对 <2 版本给友好提示 | TC-G11 |
+| BUG-006 | `bash repro/repro-bugs.sh 006` → pipe YAML 报 Invalid JSON | 帮助/文档明确 --stdin 语义（或支持 YAML stdin）；--stdin 与 --name 关系不静默 | TC-G05 |
+| BUG-007 | `bash repro/repro-bugs.sh 007` + UI 打开 t03 面板看空白 Tag | 空白技能名不渲染 Tag（trim 过滤）；补 skillSelectionUtils 单测 | TC-B05 |
+| BUG-008 | `bash repro/repro-bugs.sh 008` → upgrade 后历史 phase 执行记录 COUNT=0 | upgrade 后历史 loop_phase_executions 保留；audit 对旧执行回显真实历史；补回归测试 | TC-E07 |
+
+## 11.4 修复通用门槛（项目硬性规范）
+
+- 分支：`fix/<编号>-<标题>` 分支开发 → PR，**禁止直接改 main**。
+- 每个修复必须补回归单测；`cd backend && cargo clippy --all-targets -- -D warnings` 零告警；`cargo test --lib` 全过（`git_sync::tests::test_sync_repo_restores_deleted_file` 为已知存量环境失败，可豁免但需在 PR 说明）。
+- 缺陷文档按 `docs/文档编写规范/` 在 `docs/bugs/<编号>-<标题>/` 建三件套（缺陷说明/缺陷分析/修复总结）；验收证据（截图/日志）发 PR 评论，**不进 git**。
+- 建议同一分支修掉 BUG-003/004/008（都集中在 phase_driver / loop_runner / upgrade 收尾与外键设计），BUG-002 独立分支优先（线上影响最大）。
+
+## 11.5 注意事项（坑）
+
+- **不要手动修数据**：dev 库 `review_templates` 的旧模板行是 BUG-002 的复现条件——不要 `UPDATE` 它，要让代码迁移/兼容逻辑去处理，否则无法验证修复效果。
+- **BUG-008 会毁证据**：对 loop 12 执行 upgrade 会级联删除历史 phase 执行记录，复现 BUG-004 前如需新鲜数据请先重跑一轮 loop（§11.2 第 4 步）。
+- **假 CLI 拦截所有执行**：含后台黑板 wiki 任务，`invocations.jsonl` 里的非测试调用是环境噪音，忽略即可。
+- **验证完成后恢复**：用 env-setup.sh 第 2 步打印的 SQL 恢复执行器真实路径；视情清理 Loop #12/#13/#14、`~/.ntd/processes/e2e-verify-055.yaml`、dev 库中 E2E 工作空间。

--- a/docs/testing/055-工艺PR系列端到端验证-测试.md
+++ b/docs/testing/055-工艺PR系列端到端验证-测试.md
@@ -1,0 +1,233 @@
+# 0. 文件修改记录表
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08-01 | 初始版本：PR #963/#964/#966/#967 端到端验证与问题记录 |
+
+# 1. 测试目标与范围
+
+针对最近合并的 4 个 PR 做端到端活体验证（非单测复跑），从「前端 UI 创建工艺 → 安装 → 执行 → 门禁 → 日志/产物/审计 → CLI」全链路检查功能属性是否按预期传递。
+
+| PR | 功能 | 验证重点 |
+|----|------|---------|
+| #967 | 工艺环节执行配置（执行器/专家/技能）安装时落到事项 | `todos.executor/expert_name/skills/model` 落库；`expert_name:` YAML 别名；执行时 `/skill` 注入；升级重建同步 |
+| #964 | 环节期望产物与 spec 模板注入执行器提示词 | `loop_steps.step_template_refs` 落库；`# 环节交付要求` 段落注入；spec 内联/降级 |
+| #966 | 工艺 CLI 命令扩展 + name/guid 自动解析 | 全部新增子命令；两处双前缀 bug 修复 |
+| #963 | 环节 Skills 选择器改造 | 内联 table 多选 + 手填；执行器解耦；执行器可清空；属性面板回显 |
+
+**分工声明**：本次只做「检查、验证、记录问题」，不做任何修复。发现的问题见 §6，供后续 AI 修复参考（修复时请按 `docs/文档编写规范/Bug缺陷处理文档编写规范.md` 在 `docs/bugs/` 建档）。
+
+# 2. 测试环境
+
+| 项 | 值 |
+|----|-----|
+| 代码 | main @ f35934ca（4 个 PR 合入后） |
+| 实例 | `make dev`，dev 库 `~/.ntd/data.dev.db`，端口 18088 |
+| 工作空间 | id=2 `E2E验证工作空间`（/tmp/ntd-e2e-workspace） |
+| 执行器 | claudecode（默认）/atomcode 的 DB path 指向**假 CLI**（记录 argv + 输出 stream-json） |
+| 假 CLI | `test-evidence/2026-08-01-pr963-967/fake-bin/fake-cli.py`；评审 prompt 固定回 `RATING: 88` |
+| spec fixtures | `~/.ntd/bundled/processes/conventions/e2e-small-spec.md`（177B，应内联）、`e2e-large-spec.md`（7946B，应降级路径引用）；另引用一个不存在的 `e2e-missing-spec.md`（应降级） |
+| 证据目录 | `test-evidence/2026-08-01-pr963-967/`（**未跟踪、不提交、不删除**，结构见 §8） |
+
+# 3. 测试工艺设计
+
+通过前端 UI（创建 Modal → YAML 编辑器粘贴 → 保存）创建工艺 `e2e-verify-055`（guid `4bafee67-a3e7-4c1f-b096-5f60ec8f6c14`），YAML 全文：`test-evidence/2026-08-01-pr963-967/api/test-process-final.yaml`。
+
+| 环节 | 设计目的 | 配置 |
+|------|---------|------|
+| t01 全配置环节 | 正向全链路 | executor=claudecode、expert=senior-developer、skills=[browser-use(已知), e2e-custom-skill(自定义)]、model=claude-sonnet-5、验收标准、期望产物(prd-doc)、step_template(小spec+缺失spec)、ai_criteria_review 门禁(min_score=60)、prompt 内预置 `/browser-use`（验证注入不去重） |
+| t02 别名与空配置环节 | 967 别名 + 空配置零副作用 | executor=atomcode、**expert_name:**（别名键）、skills=[]、无产物/无门禁/无验收标准/无 model |
+| t03 大spec与人工门禁环节 | 降级与边界 | 无 executor（默认回退）、无 expert、skills=["   "]（纯空白）、step_template(大spec>4KB)、期望产物(notes)、human_approval 门禁、on_gate_fail=t01（上游） |
+
+# 4. 验证结果总表（通过项）
+
+## 4.1 PR #967 — 执行配置落到事项 ✅
+
+| 检查点 | 结果 | 证据 |
+|--------|------|------|
+| t01 executor → todos.executor | ✅ `claudecode` | db-snapshots.txt §todos |
+| t01 expert(`expert:` 键) → todos.expert_name | ✅ `senior-developer` | 同上 |
+| t01 skills → todos.skills | ✅ `["browser-use","e2e-custom-skill"]` | 同上 |
+| t01 model → todos.model | ✅ `claude-sonnet-5`；执行 argv 含 `--model claude-sonnet-5` | prompts/invocations.jsonl 第1条 |
+| **t02 `expert_name:` 别名键** → todos.expert_name | ✅ `senior-developer`（修复前为 NULL） | 同上 |
+| t01 含 ai 门禁 → todos.auto_review_enabled | ✅ `1`；t02/t03 无 ai 门禁 → `0` | 同上 |
+| 执行时 skills 注入 prompt 尾部 | ✅ 尾部 `/browser-use` `/e2e-custom-skill` 两行 | prompts/prompt-20260801-122114-24996.txt 末两行 |
+| 注入不去重（决策3B） | ✅ prompt 正文已有 `/browser-use`，尾部仍追加 | 同上 |
+| 纯空白技能名过滤 | ✅ t03 prompt 无裸 `/` 行 | prompts/prompt-20260801-122124-25430.txt |
+| todo.prompt 只读（注入不写回 DB） | ✅ DB 中为核心 prompt 原文 | db-snapshots.txt |
+| PUT 编辑事项不误清 skills | ✅ 改标题后 skills/executor/expert_name 均保留 | §5.5 命令记录 |
+| 升级重建（upgrade）同步全部字段 | ✅ 新 todos 32/33/34 与旧 28/29/30 字段一致 | db-snapshots.txt |
+
+## 4.2 PR #964 — 期望产物与 spec 模板注入 ✅
+
+| 检查点 | 结果 | 证据 |
+|--------|------|------|
+| step_template → loop_steps.step_template_refs 落库 | ✅ t01 两条、t03 一条 | db-snapshots.txt §loop_steps |
+| expected_artifacts 落库 | ✅ 含 name/type/path/locator | 同上 |
+| `# 环节交付要求` 注入（产物清单） | ✅ `- prd-doc（类型: file） 路径: .ntd/e2e/prd.md 定位: 验收标准章节` | prompt-...-122114 |
+| 小 spec（<4KB）内联 | ✅ 正文含 `E2E-SMALL-SPEC-MARKER` | 同上 |
+| 缺失 spec 降级 | ✅ `详见 bundled://.../e2e-missing-spec.md`；后端 WARN 日志同步 | 同上 + backend.dev.log |
+| 大 spec（>4KB）降级 | ✅ `详见 bundled://.../e2e-large-spec.md（正文过长，请按需阅读）`，未内联 | prompt-...-122124 |
+| 配置全空（t02）不注入 | ✅ prompt 无 `环节交付要求` 段 | prompt-...-122121 |
+| 独立 todo（评审实例）不注入 | ✅ 评审 prompt 无该段 | prompt-...-122117 |
+
+## 4.3 注入链层次（967+964 叠加）✅
+
+t01 实收 prompt 层次与 PR 描述完全一致：
+`# 运行背景`（工作空间名/地址）→ `# 专家角色定义`（agent MD + 可用技能）→ `# 任务` → `# 环节交付要求`（期望产物 + 参考 Spec 约定）→ 核心 prompt → `## 任务需求`（loop trigger_meta 需求文本）→ 尾部 `/skill` 行。
+证据：prompts/prompt-20260801-122114-24996.txt 全文。
+
+## 4.4 门禁与流转 ✅（附 2 个缺陷，见 §6）
+
+| 检查点 | 结果 |
+|--------|------|
+| t01 完成 → 自动评审实例(todo_type=2)执行 → `RATING: 88` 解析回填 execution_records.rating | ✅ record 11 rating=88；record 12 trigger=auto_review |
+| ai_criteria_review 门禁比对阈值 | ✅ gate 记录 passed「AI 评审通过（评分 88，阈值 60）」evaluated_by=ai |
+| human_approval 门禁挂起 | ✅ gate pending「等待人工审批」，step=pending_approval，loop 暂停 |
+| 审批 API → resume → 整环完成 | ✅ POST .../gates/2/approve {approved:true} → gate passed、step success(rating=100)、loop_execution success |
+| 产物捕获 | ✅ prd-doc/notes 两行（file 类型 content_text=NULL 为设计如此：只校验存在性，点击时从磁盘读）；GET /api/v1/artifacts/1/content 返回文件正文 |
+| 执行日志 API | ✅ GET .../executions/11/logs 返回结构化日志（session_start/model_switch/assistant/duration） |
+| 审计 API | ✅ GET .../loops/12/executions/4/audit 返回全量阶段/环节/产物/门禁 |
+| 执行器路由 | ✅ t02 走 atomcode（argv `-v --dangerously-skip-permissions -p`），t01/t03 走 claudecode（stream-json） |
+
+## 4.5 PR #966 — 工艺 CLI ✅（附 2 个缺陷/缺口，见 §6）
+
+测试命令：`NTD_MODE=dev backend/target/debug/ntd process ...`，输出原件在 `test-evidence/.../cli/`。
+
+| 命令 | 结果 |
+|------|------|
+| `list` / `--system` / `--user` | ✅ 全量 8 / 系统 4 / 用户 4 |
+| `show <name>` / `show <guid>` | ✅ 均命中同一工艺；未知名报错「未找到工艺…」 |
+| `recommend "修小 bug"` | ✅ 返回按复杂度打分的推荐列表 |
+| `create --name x --file y.yaml` | ✅ 创建成功；重名 40901；非法名 40002 |
+| `create --stdin` | ✅（但要求全量 JSON body，见缺陷 #6） |
+| `delete <name>` | ✅ 用户工艺删除成功；系统工艺 40901 拒绝；有实例环路 40901 拒绝 |
+| `run <name> --workspace <path>`（双前缀修复点） | ✅ 安装成功创建 Loop #13；按 guid 同样成功（Loop #14） |
+| `execution-status 4`（双前缀修复点） | ✅ 返回 audit 全量数据（修复前 404） |
+| `upgrade <name> --loop-id 12` | ✅ 重建 2 阶段 3 环节，字段同步（见 4.1） |
+| `loops <name>` | ✅ 返回实例环路 |
+| `versions` / `diff` | ⚠️ 机制可用但后端无版本历史，见缺陷 #5 |
+
+## 4.6 PR #963 — Skills 选择器与属性面板 ✅（附 1 个 UI 卫生问题）
+
+| 检查点 | 结果 | 证据 |
+|--------|------|------|
+| 面板回显 executor/expert/skills/gates/产物/spec | ✅ 全部正确（表格单元格为 Input 控件） | screenshots/11,12-*，db/t01-panel-text.txt |
+| 内联 table 多选 + 手填回车添加 | ✅ `my-manual-skill` 添加成功，橙色「·自定义」标注 | screenshots/13 |
+| 切换内置执行器筛选已选保留（解耦） | ✅ 切到 AtomCode 后 3 个已选 Tag 全保留 | screenshots/15 |
+| 环节执行器可清空 | ✅ 清空后显示「未选择执行器」，可再选回 | screenshots/16,17 |
+| 已选 Tag 统一标注 | ✅ 已知 skill 无标注、手填「·自定义」 | 控制台输出 tag 文本 |
+| 属性面板语义分组 | ✅ 身份→执行→产物→评审门禁→流转→模板 | screenshots/12-* |
+
+# 5. 关键验证过程记录
+
+## 5.1 UI 创建与保存
+- 创建 Modal → 编辑器 → YAML tab 粘贴 → 保存成功；可视化图渲染 2 阶段 3 环节（screenshots/06,09,10）。
+- 保存时版本自动 1.0.0→1.1.0（需求 042 设计行为，非缺陷）。
+- 工具备注：Monaco 编辑器逐行 insertText 会被自动缩进干扰（工具方法问题，非产品缺陷），改用剪贴板粘贴后正常。
+
+## 5.2 安装
+- UI 列表卡片「安装」→ 确认 → Loop #12（workspace_id=2, version=1.1.0），3 环节 todo_id=28/29/30。
+- t03 未配 executor，`create_todo_with_extras` 回退默认执行器 claudecode（设计行为：安装期即落默认值）。
+
+## 5.3 执行与门禁
+- 触发方式：POST /api/v1/workspaces/2/tasks {loop_id:12, requirement} → loop_execution #4。
+- 执行序列（假 CLI 调用日志 invocations.jsonl）：
+  1. 12:21:14 claude（t01，argv 含 --model）→ 2. 12:21:17 claude（t01 评审实例）→ 3. 12:21:21 atomcode（t02）→ 4. 12:21:24 claude（t03）。
+- 另有 1 次黑板 wiki 后台任务调用（环境噪音，与本次验证无关）。
+- t03 人工审批：approve API 200 → loop_execution #4 success。
+
+## 5.4 只读与编辑保持
+- PUT /api/v1/workspaces/2/todos/32 改标题 → skills/executor/expert_name/model 全部保留；prompt 未被注入内容污染。
+
+## 5.5 CLI 输出原件
+- `test-evidence/2026-08-01-pr963-967/cli/` 下：list*.json、show-by-*.json、loops.json、recommend.json、versions.json、diff-same-version.json、upgrade.json、run.json、create.json。
+
+# 6. 发现的问题清单（供修复，本次未修）
+
+> 严重度建议：P1=影响功能正确性/线上必现，P2=数据/展示错误，P3=体验/边界。
+
+## BUG-001（P1）新建任务接口中文标题 UTF-8 切片 panic
+
+- **现象**：`POST /api/v1/workspaces/{ws}/tasks`，requirement 首行超过 60 **字节**且第 60 字节落在多字节字符内部时，handler 直接 panic，连接被掐断（客户端收到空响应 HTTP 000）。
+- **复现**：requirement=`【E2E-REQUIREMENT-MARKER】端到端验证需求：…`（首行 >60 字节且含 CJK）。
+- **根因**：`backend/src/handlers/tasks.rs:55`：`format!("{}…", &title[..60])` 按字节切片 str，非字符边界 panic。生产代码还存在逐字节截断的语义错误（应限 60 字符而非 60 字节）。
+- **证据**：`db/BUG-001-create-task-utf8-panic.log`（panic 栈）、`db/BUG-001-code-snippet.rs`。
+- **修复建议**：改用 `title.chars().take(60).collect::<String>()` 之类字符安全截断；补一条 CJK 长标题单测。
+
+## BUG-002（P1）存量评审模板占位符单/双大括号不兼容 → AI 评审「盲评」
+
+- **现象**：AI 评审实例实际收到的 prompt 中 `{original_prompt}`、`{original_output}`、`{max_output_chars}`、`{acceptance_criteria}` 全部以字面量残留——评审在**看不到原始任务、执行输出、验收标准**的情况下打分，评分仍被解析并驱动门禁，等于门禁形同虚设。
+- **复现**：任何从旧版升级、且 `review_templates` 表已有默认模板行的实例（本 dev 库该行 created_at=2026-07-27）。触发一次含 ai_criteria_review 门禁的执行，观察评审实例 prompt（证据 `prompts/prompt-20260801-122117-25077.txt`）。
+- **根因**：PR #945（feat 029, commit fbdce91b）把 `compose_review_prompt` 的替换键从 `{original_prompt}` 改为 `{{original_prompt}}`（双大括号），`DEFAULT_REVIEWER_PROMPT` 常量同步改了，但**没有迁移 review_templates 表存量行**（migration 目录 0 处涉及 original_prompt），`ensure_default_review_template` 只在缺失时插入、从不更新。旧行（单大括号）与新替换键（双大括号）永久错位。新装实例（直接种入双大括号模板）不受影响——属于升级路径数据兼容缺陷。
+- **证据**：`prompts/prompt-20260801-122117-25077.txt`（全文占位符未替换）、`db/db-snapshots.txt` §review_templates、`git show 4250f005 vs fbdce91b` 的 compose_review_prompt 对比。
+- **修复建议**：① 加迁移把存量 prompt 中 `{original_prompt}` 等 4 个键改写为双大括号（或让 compose 同时兼容两种写法，推荐后者+告警）；② `ensure_default_review_template` 增加「检测到旧占位符则升级」逻辑；③ 补一条「模板含旧式占位符也能正确替换」的回归测试。
+
+## BUG-003（P2）人工审批挂起环节被误记返工并写入「工艺终止」错误信息
+
+- **现象**：t03（human_approval 门禁）仅因等待人工审批，`loop_step_executions` 被写入 `rework_count=1` 且 `error_message='返工次数 1 已达到上限 1，工艺终止'`。环节从未返工，审批通过后 loop 也正常 success，但错误信息永久留在记录里（status=success 与 error_message 并存）。
+- **复现**：环节同时满足 ① 含 human_approval 门禁 ② `on_gate_fail` 指向上游环节 ③ max_rework 较小。执行到该环节挂起即现。
+- **根因**：`phase_driver::execute_step` 中 `gates_passed = all_passed && !has_pending_human`——人工挂起被当作「未通过」送入 `transition_resolver::resolve_next(step, false, …)`，按 `on_rating_fail`（=on_gate_fail=t01 上游）解析目标，`rework_tracker::evaluate_rework` 判定为返工（目标 idx ≤ 当前 idx），本例 new_rework=1 ≥ max_rework=1 直接 MaxedOut 并 `finish_step_execution` 写入错误信息；随后 `human_pending` 又把状态改写为 pending_approval，暂停优先于终止，但返工计数与错误信息已落库。
+- **证据**：`db/db-snapshots.txt` §loop_step_executions（id=3 行）。
+- **修复建议**：has_pending_human 时应短路流转解析与返工统计（pending 不是失败）；或 resolve_next 对 human pending 单独返回「原地等待」策略。补「人工挂起不计返工」回归测试。
+
+## BUG-004（P2）loop_phase_executions 永驻 running，phase 终态不落地
+
+- **现象**：loop_execution #4 已 success，其两条 `loop_phase_executions`（验证阶段一/二）status 仍为 `running`、`finished_at=NULL`。审计 API 同样回显 running。
+- **根因线索**：`phase_driver::update_phase_execution` 在进入环节时把 phase 标记 running，但整环成功结束的路径上没有把 phase 更新为 success/failed 的调用（loop_runner 收尾只更新 loop_execution）。
+- **证据**：`db/db-snapshots.txt` §loop_phase_executions、`cli/` 中 execution-status 输出。
+- **修复建议**：loop_runner 在整环终态化时补齐 phase 终态（success/failed + finished_at）；或在最后一个环节 finish 时联动。补断言「loop success 后无 running phase」。
+
+## BUG-005（P3）`process versions` / `process diff` 名存实亡：无版本历史存储
+
+- **现象**：`versions e2e-verify-055` 永远只返回当前 1 条（1.1.0）；`diff 1.1.0 --base 1.0.0` 恒 404「Not found」；只有 `--base` 与目标同版本时返回全量 unchanged 的伪 diff。
+- **根因**：`get_process_versions`/`diff_process_versions` 都按 guid 过滤 `process_templates` 表，但 guid 唯一对应一行——没有任何版本快照存储（保存时 auto-bump 直接覆盖原行与原文件）。966 CLI 侧命令本身可用，是后端语义缺口。
+- **证据**：`cli/versions.json`、`cli/diff-same-version.json`、handlers/process.rs:766-811。
+- **修复建议**：若要兑现 versions/diff，需要在保存时落版本快照（新表或目录）；否则应在需求/文档中声明「当前无历史版本」，CLI 对 <2 版本给出友好提示而非裸 404。
+
+## BUG-006（P3）CLI `create --stdin` 要求全量 JSON body，与用法暗示不符
+
+- **现象**：`ntd process create --name x --stdin` 从 stdin 读的是**完整 JSON body**（含 name/definition），直接 pipe YAML 报「Invalid JSON from stdin」。用法行 `(--file <yaml> | --stdin)` 暗示 --stdin 是 YAML 的替代来源；且 --stdin 模式下 --name 被静默忽略。
+- **证据**：`cli/` 无单独文件，复现命令与报错见 §4.5 过程记录；代码 backend/src/cli/commands.rs build_create_body。
+- **修复建议**：或在帮助/文档明确「--stdin 读全量 JSON body（与 --name 互斥）」，或把 --stdin 改为读 YAML 正文（与 --file 同语义）。
+
+## BUG-007（P3）纯空白技能名在属性面板渲染为空白「·自定义」Tag
+
+- **现象**：YAML 中 `skills: ["   "]`（纯空白）在 053 属性面板已选 Tag 区渲染为一个无文字的「·自定义」Tag（见 t03 面板 Tag 列表输出 `["    ·自定义", ...]`）。后端执行注入时已过滤空白（正确），仅前端展示未 trim/过滤。
+- **证据**：`db/t01-panel-text.txt` 及 spec 运行日志「t03 面板 Tag 列表」、screenshots/18。
+- **修复建议**：`splitSelected`/Tag 渲染前 `trim()` 并过滤空串；或在写回 link.skills 时做数据卫生。
+
+# 7. 已确认的「设计如此」行为（非缺陷，避免误报）
+
+| 行为 | 说明 |
+|------|------|
+| 保存工艺版本自动 +0.1（1.0.0→1.1.0） | 需求 042 设计 |
+| t03 未配 executor 落库为默认执行器 | `create_todo_with_extras` 安装期回退默认 |
+| file 产物 content_text=NULL | 设计：只校验存在性，点击查看时从磁盘读 |
+| 超限异常处理显示「未启用」 | abnormal_handler 只有 trigger_on、无 handler todo/prompt 时的展示 |
+| 旧 todo（28/29/30）升级后残留 | 历史执行记录外键引用所需，steps 已指向新 todo |
+
+# 8. 证据材料索引（test-evidence/2026-08-01-pr963-967/，未跟踪不删除）
+
+```
+fake-bin/fake-cli.py        假执行器（claude/atomcode 副本），记录 argv + 产出 stream-json
+api/test-process.yaml       测试工艺 YAML 模板（__GUID__ 占位）
+api/test-process-final.yaml 实际粘贴保存的 YAML
+api/created-guid.txt        新工艺 guid
+api/create-task-response.json
+cli/*.json                  966 各命令输出原件
+db/db-snapshots.txt         全部关键表快照（todos/loop_steps/step_execs/gates/records/phase_execs/review_templates）
+db/BUG-001-*.log|.rs        BUG-001 panic 栈与代码片段
+db/t01-panel-text.txt       t01 属性面板全文
+db/loop12-page-text.txt     loop 详情页全文
+prompts/invocations.jsonl   假 CLI 全部调用（bin/argv/cwd）
+prompts/prompt-*.txt        每次执行实收 prompt 全文（t01/评审/t02/t03/黑板后台）
+screenshots/*.png           UI 过程截图（创建/编辑器/面板/安装/loop 详情）
+frontend/tests/check_055_*.spec.ts  验证用 Playwright 脚本（未跟踪，随仓库留存）
+```
+
+# 9. 遗留与建议
+
+- 生产库若从旧版升级，BUG-002 会导致所有 AI 评审盲评，建议优先修复并补数据迁移。
+- 本次未覆盖：复制 loop 丢 skill_names 的 053 已知缺口（官方已记录）；cron/飞书/hook 入口的注入链（代码上与 loop/手动同路径，单测已覆盖）。
+- 验证结束后建议恢复：executors 表 claudecode/atomcode 的 path（当前指向假 CLI）、删除 `~/.ntd/processes/e2e-verify-055.yaml` 与 Loop #12/#13/#14（如需清理）。

--- a/docs/testing/055-工艺PR系列端到端验证-测试.md
+++ b/docs/testing/055-工艺PR系列端到端验证-测试.md
@@ -3,6 +3,7 @@
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | AI | 2026-08-01 | 初始版本：PR #963/#964/#966/#967 端到端验证与问题记录 |
+| AI | 2026-08-01 | 补充 §5 测试用例执行明细（编号/步骤/预期/实际/证据），后续章节顺延 |
 
 # 1. 测试目标与范围
 
@@ -15,7 +16,7 @@
 | #966 | 工艺 CLI 命令扩展 + name/guid 自动解析 | 全部新增子命令；两处双前缀 bug 修复 |
 | #963 | 环节 Skills 选择器改造 | 内联 table 多选 + 手填；执行器解耦；执行器可清空；属性面板回显 |
 
-**分工声明**：本次只做「检查、验证、记录问题」，不做任何修复。发现的问题见 §6，供后续 AI 修复参考（修复时请按 `docs/文档编写规范/Bug缺陷处理文档编写规范.md` 在 `docs/bugs/` 建档）。
+**分工声明**：本次只做「检查、验证、记录问题」，不做任何修复。发现的问题见 §7，供后续 AI 修复参考（修复时请按 `docs/文档编写规范/Bug缺陷处理文档编写规范.md` 在 `docs/bugs/` 建档）。
 
 # 2. 测试环境
 
@@ -77,7 +78,7 @@ t01 实收 prompt 层次与 PR 描述完全一致：
 `# 运行背景`（工作空间名/地址）→ `# 专家角色定义`（agent MD + 可用技能）→ `# 任务` → `# 环节交付要求`（期望产物 + 参考 Spec 约定）→ 核心 prompt → `## 任务需求`（loop trigger_meta 需求文本）→ 尾部 `/skill` 行。
 证据：prompts/prompt-20260801-122114-24996.txt 全文。
 
-## 4.4 门禁与流转 ✅（附 2 个缺陷，见 §6）
+## 4.4 门禁与流转 ✅（附 2 个缺陷，见 §7）
 
 | 检查点 | 结果 |
 |--------|------|
@@ -90,7 +91,7 @@ t01 实收 prompt 层次与 PR 描述完全一致：
 | 审计 API | ✅ GET .../loops/12/executions/4/audit 返回全量阶段/环节/产物/门禁 |
 | 执行器路由 | ✅ t02 走 atomcode（argv `-v --dangerously-skip-permissions -p`），t01/t03 走 claudecode（stream-json） |
 
-## 4.5 PR #966 — 工艺 CLI ✅（附 2 个缺陷/缺口，见 §6）
+## 4.5 PR #966 — 工艺 CLI ✅（附 2 个缺陷/缺口，见 §7）
 
 测试命令：`NTD_MODE=dev backend/target/debug/ntd process ...`，输出原件在 `test-evidence/.../cli/`。
 
@@ -119,7 +120,99 @@ t01 实收 prompt 层次与 PR 描述完全一致：
 | 已选 Tag 统一标注 | ✅ 已知 skill 无标注、手填「·自定义」 | 控制台输出 tag 文本 |
 | 属性面板语义分组 | ✅ 身份→执行→产物→评审门禁→流转→模板 | screenshots/12-* |
 
-# 5. 关键验证过程记录
+# 5. 测试用例执行明细
+
+> 每条用例含：编号 / 场景 / 步骤要点 / 预期结果 / 实际结果 / 结论 / 证据。
+> 「证据」列为 `test-evidence/2026-08-01-pr963-967/` 下的相对路径；结论 ✅=符合预期，🐛=发现缺陷（编号对应 §7）。
+
+## 5.A UI 创建工艺
+
+| 编号 | 场景 | 步骤要点 | 预期结果 | 实际结果 | 结论 | 证据 |
+|------|------|---------|---------|---------|------|------|
+| TC-A01 | 创建工艺 | 工艺列表 →「创建工艺」→ 填 6 字段提交 | 创建成功并进入编辑器，URL 含新 guid | 同预期，guid=4bafee67-… | ✅ | screenshots/01-03, api/created-guid.txt |
+| TC-A02 | YAML 编辑保存 | 编辑器 YAML tab 粘贴 3 环节 YAML → 保存 | 保存成功落盘 `~/.ntd/processes/e2e-verify-055.yaml` | 同预期；版本按设计 auto-bump 1.0.0→1.1.0 | ✅ | api/test-process-final.yaml, screenshots/08 |
+| TC-A03 | 可视化渲染 | 切「可视化」tab | 画布渲染 2 阶段 3 环节节点与连线 | 同预期 | ✅ | screenshots/09,10 |
+
+## 5.B 环节属性面板与 053 选择器
+
+| 编号 | 场景 | 步骤要点 | 预期结果 | 实际结果 | 结论 | 证据 |
+|------|------|---------|---------|---------|------|------|
+| TC-B01 | 面板回显 | 点击 t01 节点 | executor/expert/skills/gates/产物/spec 六类字段全部回显 | 同预期（表格单元格为 Input，按 value 校验） | ✅ | screenshots/11,12-*, db/t01-panel-text.txt |
+| TC-B02 | 手填自定义技能 | 搜索框输入 `my-manual-skill` 回车 | 出现「按回车添加」提示，添加后 Tag 带橙色「·自定义」 | 同预期 | ✅ | screenshots/13 |
+| TC-B03 | 筛选解耦 | 技能选择器内置筛选切到 AtomCode | 已选 3 个技能 Tag 全部保留 | 同预期 | ✅ | screenshots/15 |
+| TC-B04 | 执行器可清空 | 点执行器清空 × → 再选回 | 空态显示「未选择执行器」，可重选 | 同预期 | ✅ | screenshots/16,17 |
+| TC-B05 | 空白技能名渲染 | 打开 t03 面板（skills=["   "]） | 空白名不应渲染为有效 Tag | 渲染出无文字「·自定义」Tag | 🐛 BUG-007 | screenshots/18, db/loop12-page-text.txt |
+
+## 5.C 安装落库（967/964）
+
+| 编号 | 场景 | 步骤要点 | 预期结果 | 实际结果 | 结论 | 证据 |
+|------|------|---------|---------|---------|------|------|
+| TC-C01 | t01 全配置落库 | UI 安装到工作空间 → 查 todos | executor/expert_name/skills/model/acceptance_criteria 全部落库 | 同预期 | ✅ | db/db-snapshots.txt §todos |
+| TC-C02 | t02 别名落库 | 同上 | `expert_name:` 别名键解析落库（修复前为 NULL） | expert_name=senior-developer | ✅ | 同上 |
+| TC-C03 | t03 默认回退 | 同上 | 未配 executor → 落默认执行器；空白 skills 原样落库 | claudecode；skills=["   "] | ✅ | 同上 |
+| TC-C04 | auto_review_enabled | 同上 | 含 ai 门禁的 t01=1，其余=0 | 同预期 | ✅ | 同上 |
+| TC-C05 | loop_steps 落库 | 同上 | expected_artifacts/step_template_refs/gate_config/skill_names 与 YAML 一致 | 同预期 | ✅ | db/db-snapshots.txt §loop_steps |
+
+## 5.D 执行注入链（967/964 核心）
+
+| 编号 | 场景 | 步骤要点 | 预期结果 | 实际结果 | 结论 | 证据 |
+|------|------|---------|---------|---------|------|------|
+| TC-D01 | t01 prompt 层次 | 建任务触发 loop，取假 CLI 落盘的 t01 prompt | 运行背景>专家>环节交付要求>核心prompt>任务需求>/skills | 层次完全一致 | ✅ | prompts/prompt-20260801-122114-24996.txt |
+| TC-D02 | 小 spec 内联 | 检查 t01 prompt spec 段 | <4KB 正文内联，含 E2E-SMALL-SPEC-MARKER | 同预期 | ✅ | 同上 |
+| TC-D03 | 缺失 spec 降级 | 同上 | 降级为「详见 bundled://…missing…」，后端 WARN | 同预期 | ✅ | 同上 + backend.dev.log |
+| TC-D04 | 大 spec 降级 | 检查 t03 prompt spec 段 | >4KB 不内联，「详见…（正文过长，请按需阅读）」 | 同预期 | ✅ | prompts/prompt-20260801-122124-25430.txt |
+| TC-D05 | t02 空配置零注入 | 检查 t02 prompt | 无环节交付要求段、无 /skills 行 | 同预期 | ✅ | prompts/prompt-20260801-122121-25225.txt |
+| TC-D06 | 空白技能过滤 | 检查 t03 prompt 尾部 | 无裸 `/` 行 | 同预期 | ✅ | prompts/prompt-20260801-122124-25430.txt |
+| TC-D07 | 注入不去重 | t01 prompt 正文已含 /browser-use | 尾部仍追加 /browser-use（决策 3B） | 同预期 | ✅ | prompts/prompt-…-122114 首尾对照 |
+| TC-D08 | model 传递 | 比对 4 次调用 argv | t01 含 `--model claude-sonnet-5`；无 model 的不含 | 同预期 | ✅ | prompts/invocations.jsonl |
+| TC-D09 | 独立 todo 回退 | 检查评审实例 prompt | 无环节交付要求段（find_loop_step=None） | 同预期 | ✅ | prompts/prompt-20260801-122117-25077.txt |
+| TC-D10 | 执行器路由 | 比对 argv 与被调二进制 | t02→atomcode，t01/t03→claudecode | 同预期 | ✅ | prompts/invocations.jsonl |
+
+## 5.E 门禁与流转
+
+| 编号 | 场景 | 步骤要点 | 预期结果 | 实际结果 | 结论 | 证据 |
+|------|------|---------|---------|---------|------|------|
+| TC-E01 | AI 评审闭环 | t01 完成→评审实例→RATING 解析 | rating=88 回填 record；门禁 passed（阈值 60） | 同预期 | ✅ | db/db-snapshots.txt §records/§gates |
+| TC-E02 | 人工门禁挂起 | t03 完成→human_approval 评估 | gate=pending「等待人工审批」，step=pending_approval | 同预期 | ✅ | 同上 |
+| TC-E03 | 审批恢复 | POST …/gates/2/approve {approved:true} | gate passed、step success(100)、loop success | 同预期 | ✅ | api 响应 + db 快照 |
+| TC-E04 | 人工挂起返工统计 | 检查 t03 step_execution | 挂起不应计返工、不应有错误信息 | rework_count=1 且 error_message='返工次数 1 已达到上限 1，工艺终止' | 🐛 BUG-003 | db/db-snapshots.txt §loop_step_executions |
+| TC-E05 | phase 终态 | loop success 后查 phase 执行 | phase 应 success/failed | 两条 phase 永驻 running、finished_at=NULL | 🐛 BUG-004 | db/db-snapshots.txt §loop_phase_executions |
+| TC-E06 | 评审占位符替换 | 检查评审实例 prompt 三个占位段 | 原始任务/输出/验收标准应被实际值替换 | 全部以 `{original_prompt}` 等字面量残留（盲评） | 🐛 BUG-002 | prompts/prompt-20260801-122117-25077.txt |
+
+## 5.F 产物 / 日志 / 审计 / 只读
+
+| 编号 | 场景 | 步骤要点 | 预期结果 | 实际结果 | 结论 | 证据 |
+|------|------|---------|---------|---------|------|------|
+| TC-F01 | 产物捕获 | 查 loop_step_artifacts + GET /api/v1/artifacts/1/content | prd-doc/notes 捕获行存在；content 返回文件正文 | 同预期（file 类型 content_text=NULL 为设计） | ✅ | db 快照 + §6.3 curl |
+| TC-F02 | 执行日志 | GET …/executions/11/logs | 结构化日志（session/model/assistant/duration） | 同预期 | ✅ | §6.3 记录 |
+| TC-F03 | 审计 | GET …/loops/12/executions/4/audit | 阶段/环节/产物/门禁全量 | 同预期 | ✅ | /tmp/audit.json 摘录见 §6 |
+| TC-F04 | prompt 只读 | 执行后查 todos.prompt | 与安装时一致，不含注入内容 | 同预期 | ✅ | db/db-snapshots.txt §todos |
+| TC-F05 | 编辑保留 skills | PUT todos/32 改标题后再查 | skills/executor/expert_name 不变 | 同预期 | ✅ | §6.4 记录 |
+
+## 5.G 工艺 CLI（966）
+
+| 编号 | 场景 | 步骤要点 | 预期结果 | 实际结果 | 结论 | 证据 |
+|------|------|---------|---------|---------|------|------|
+| TC-G01 | list 三态 | `process list` / `--system` / `--user` | 8 / 4 / 4 条 | 同预期 | ✅ | cli/list*.json |
+| TC-G02 | show 寻址 | `show <name>` / `show <guid>` / 未知名 | name/guid 均命中；未知名友好报错 | 同预期 | ✅ | cli/show-by-*.json |
+| TC-G03 | recommend | `recommend "修小 bug"` | 返回评分推荐列表 | 同预期 | ✅ | cli/recommend.json |
+| TC-G04 | create --file | 正常/重名/非法名 三组 | 成功 / 40901 / 40002 | 同预期 | ✅ | cli/create.json 等 |
+| TC-G05 | create --stdin | pipe YAML → pipe JSON body | 用法暗示 YAML 可入 | YAML 报错；全量 JSON body 才成功 | 🐛 BUG-006 | §6.5 记录 |
+| TC-G06 | delete 三态 | 用户工艺/系统工艺/有实例工艺 | 删除 / 40901 拒 / 40901 拒 | 同预期 | ✅ | §6.5 记录 |
+| TC-G07 | run 双前缀修复 | `run <name>` 与 `run <guid>` | 安装成功（修复前 404） | Loop #13/#14 创建 | ✅ | cli/run.json |
+| TC-G08 | execution-status 修复 | `execution-status 4` | 返回 audit 数据（修复前 404） | 同预期 | ✅ | §6.5 记录 |
+| TC-G09 | upgrade 重建 | `upgrade <name> --loop-id 12` | 重建且 todos 字段同步 | 新 todo 32/33/34 字段一致 | ✅ | cli/upgrade.json + db 快照 |
+| TC-G10 | loops | `loops <name>` | 返回实例环路 | 同预期 | ✅ | cli/loops.json |
+| TC-G11 | versions/diff | `versions`、`diff 1.1.0 --base 1.0.0/1.1.0` | 应能查看历史与跨版本 diff | versions 恒 1 条；跨版本 404；同版本返回伪 diff | 🐛 BUG-005 | cli/versions.json, cli/diff-same-version.json |
+
+## 5.H 边界与杂项
+
+| 编号 | 场景 | 步骤要点 | 预期结果 | 实际结果 | 结论 | 证据 |
+|------|------|---------|---------|---------|------|------|
+| TC-H01 | 中文长标题建任务 | POST tasks，requirement 首行 >60 字节含 CJK | 正常截断建任务 | handler panic，连接断开 HTTP 000 | 🐛 BUG-001 | db/BUG-001-*.log/.rs |
+| TC-H02 | 版本 auto-bump | 保存工艺后查 version | 1.0.0→1.1.0（设计行为） | 同预期 | ✅ | cli/versions.json |
+
+# 6. 关键验证过程记录
 
 ## 5.1 UI 创建与保存
 - 创建 Modal → 编辑器 → YAML tab 粘贴 → 保存成功；可视化图渲染 2 阶段 3 环节（screenshots/06,09,10）。
@@ -143,7 +236,7 @@ t01 实收 prompt 层次与 PR 描述完全一致：
 ## 5.5 CLI 输出原件
 - `test-evidence/2026-08-01-pr963-967/cli/` 下：list*.json、show-by-*.json、loops.json、recommend.json、versions.json、diff-same-version.json、upgrade.json、run.json、create.json。
 
-# 6. 发现的问题清单（供修复，本次未修）
+# 7. 发现的问题清单（供修复，本次未修）
 
 > 严重度建议：P1=影响功能正确性/线上必现，P2=数据/展示错误，P3=体验/边界。
 
@@ -188,7 +281,7 @@ t01 实收 prompt 层次与 PR 描述完全一致：
 ## BUG-006（P3）CLI `create --stdin` 要求全量 JSON body，与用法暗示不符
 
 - **现象**：`ntd process create --name x --stdin` 从 stdin 读的是**完整 JSON body**（含 name/definition），直接 pipe YAML 报「Invalid JSON from stdin」。用法行 `(--file <yaml> | --stdin)` 暗示 --stdin 是 YAML 的替代来源；且 --stdin 模式下 --name 被静默忽略。
-- **证据**：`cli/` 无单独文件，复现命令与报错见 §4.5 过程记录；代码 backend/src/cli/commands.rs build_create_body。
+- **证据**：`cli/` 无单独文件，复现命令与报错见 §6.5 过程记录；代码 backend/src/cli/commands.rs build_create_body。
 - **修复建议**：或在帮助/文档明确「--stdin 读全量 JSON body（与 --name 互斥）」，或把 --stdin 改为读 YAML 正文（与 --file 同语义）。
 
 ## BUG-007（P3）纯空白技能名在属性面板渲染为空白「·自定义」Tag
@@ -197,7 +290,7 @@ t01 实收 prompt 层次与 PR 描述完全一致：
 - **证据**：`db/t01-panel-text.txt` 及 spec 运行日志「t03 面板 Tag 列表」、screenshots/18。
 - **修复建议**：`splitSelected`/Tag 渲染前 `trim()` 并过滤空串；或在写回 link.skills 时做数据卫生。
 
-# 7. 已确认的「设计如此」行为（非缺陷，避免误报）
+# 8. 已确认的「设计如此」行为（非缺陷，避免误报）
 
 | 行为 | 说明 |
 |------|------|
@@ -207,7 +300,7 @@ t01 实收 prompt 层次与 PR 描述完全一致：
 | 超限异常处理显示「未启用」 | abnormal_handler 只有 trigger_on、无 handler todo/prompt 时的展示 |
 | 旧 todo（28/29/30）升级后残留 | 历史执行记录外键引用所需，steps 已指向新 todo |
 
-# 8. 证据材料索引（test-evidence/2026-08-01-pr963-967/，未跟踪不删除）
+# 9. 证据材料索引（test-evidence/2026-08-01-pr963-967/，未跟踪不删除）
 
 ```
 fake-bin/fake-cli.py        假执行器（claude/atomcode 副本），记录 argv + 产出 stream-json
@@ -226,7 +319,7 @@ screenshots/*.png           UI 过程截图（创建/编辑器/面板/安装/loo
 frontend/tests/check_055_*.spec.ts  验证用 Playwright 脚本（未跟踪，随仓库留存）
 ```
 
-# 9. 遗留与建议
+# 10. 遗留与建议
 
 - 生产库若从旧版升级，BUG-002 会导致所有 AI 评审盲评，建议优先修复并补数据迁移。
 - 本次未覆盖：复制 loop 丢 skill_names 的 053 已知缺口（官方已记录）；cron/飞书/hook 入口的注入链（代码上与 loop/手动同路径，单测已覆盖）。


### PR DESCRIPTION
## 实现了什么

对最近合并的 4 个 PR（**#967** 执行配置落事项、**#964** 产物/spec 注入、**#966** 工艺 CLI、**#963** Skills 选择器）做了**活体端到端验证**（非单测复跑），并把验证过程、48 条测试用例、8 个发现的问题与修复交接指南记录为测试文档：

`docs/testing/055-工艺PR系列端到端验证-测试.md`（本 PR 唯一改动文件）

验证链路：前端 UI 创建工艺（2 阶段 3 环节）→ 安装到工作空间 → 建任务跑整环 → AI 评审/人工审批门禁 → 日志/产物/审计 API → CLI 全命令。执行器用**假 CLI 落盘 argv**，逐字节核对执行器实收 prompt。

## 与需求的对应关系

本 PR 是验证性文档，不改动产品代码，对应上述 4 个 PR 的功能点回归：

| PR | 验证结果 |
|----|---------|
| #967 | ✅ executor/expert(`expert:`+`expert_name:` 别名)/skills/model 全部落库；`/skill` 尾部注入不去重；空白过滤；prompt 只读；升级重建同步（F1-F6 全覆盖） |
| #964 | ✅ `# 环节交付要求` 注入；spec <4KB 内联 / 缺失降级 / >4KB 降级；独立 todo 回退（G1-G5 全覆盖） |
| #966 | ✅ 11 组 CLI 命令全验证；`/project-directories`、`execution-status` 两处双前缀修复确认生效 |
| #963 | ✅ 内联 table 多选 + 手填（橙色·自定义）；筛选解耦；执行器可清空；面板回显 |

## 关键发现（8 个问题，仅记录未修复）

| 编号 | 严重度 | 问题 |
|------|--------|------|
| BUG-001 | P1 | `create_task` 中文标题按字节切片 → panic 断连（tasks.rs:55） |
| BUG-002 | P1 | PR #945 改评审占位符为 `{{}}` 但未迁移存量 DB 模板（`{}`）→ **AI 评审盲评**（看不到原任务/输出/验收标准），升级实例必现 |
| BUG-003 | P2 | human_approval 挂起被计入返工，写入假错误「返工次数 1 已达到上限 1，工艺终止」 |
| BUG-004 | P2 | loop 已 success，`loop_phase_executions` 永驻 `running` |
| BUG-005 | P3 | `process versions/diff` 无版本快照存储，跨版本 diff 恒 404 |
| BUG-006 | P3 | CLI `create --stdin` 实际要求全量 JSON body，与用法暗示不符 |
| BUG-007 | P3 | 纯空白技能名在属性面板渲染为空白「·自定义」Tag |
| BUG-008 | P2 | `process upgrade` 经 `ON DELETE CASCADE` 级联删除历史 `loop_phase_executions`，审计链断裂 |

每个问题含：现象 / 复现步骤 / 根因分析（定位到文件:行）/ 证据 / 修复建议，见文档 §7。

## 测试与验证结果

- **48 条测试用例**（文档 §5，8 组：UI 创建/053 面板/安装落库/执行注入/门禁流转/产物日志审计/CLI/边界），每条含 编号/场景/步骤/预期/实际/结论/证据。
- **修复交接指南**（文档 §11）：环境一键重建脚本 + 8 个 BUG 的最小复现脚本（均已实测）+ 复现→验收→回归用例对照表 + 防踩坑提示，供后续修复 AI 直接使用。
- 证据材料在 `test-evidence/2026-08-01-pr963-967/`（prompt 全文/argv 日志/DB 快照/CLI 输出/截图/panic 栈/repro 脚本），**按规范未提交 git、保留在本地**；如需查看可找我要。
- 本 PR 纯文档，无代码改动：未跑 clippy/cargo test（不适用）。

## 已知限制 / 待改进

- 未覆盖：复制 loop 丢 `skill_names` 的 053 已知缺口（官方已记录）；cron/飞书/hook 入口的注入链（与 loop/手动同路径，单测已覆盖）。
- dev 库 executors 的 claudecode/atomcode 路径当前指向假 CLI（验证残留），恢复 SQL 在证据目录 `repro/env-setup.sh` 输出中。
- 后续修复请按文档 §11.4 在 `docs/bugs/` 建档，建议 BUG-002 优先（线上影响最大）、BUG-003/004/008 同分支处理。
