### PR TITLE
refactor(056): Todo 列表服务端分页化与质量修复

### DIFF
--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -808,10 +808,12 @@ async fn handle_todo(
                 );
                 let resp: ClientResponse<crate::models::TodoListPage> = client.get(&path).await?;
                 let Some(page_data) = resp.data else { break };
-                let fetched = page_data.items.len() as i64;
+                let fetched = page_data.items.len();
+                let total = page_data.total;
                 all_todos.extend(page_data.items);
-                // 拿满一页说明可能还有下一页；不满则为最后一页
-                if fetched < 200 {
+                // CodeRabbit#14：翻页由响应 total 驱动——不以「条数 < 请求的 page_size」
+                // 判末页（后端若调整 page_size 上限会提前截断）；本页为空防御死循环
+                if all_todos.len() as i64 >= total || fetched == 0 {
                     break;
                 }
                 page += 1;

--- a/backend/src/cli/commands.rs
+++ b/backend/src/cli/commands.rs
@@ -795,46 +795,49 @@ async fn handle_todo(
             print_response(&resp, output, fields)?;
         }
         TodoAction::List { workspace_id, status, tag, running, search } => {
-            let mut query_params = Vec::new();
-
-            if let Some(s) = status {
-                query_params.push(format!("status={}", s));
-            }
-            if let Some(t) = tag {
-                query_params.push(format!("tag_id={}", t));
-            }
-            if *running {
-                query_params.push("running=true".to_string());
-            }
-
-            // v1: 列表也按 workspace 隔离，URL 前缀带 ws。
-            let path = if query_params.is_empty() {
-                format!("{}/todos", ws_prefix(*workspace_id))
-            } else {
-                format!("{}/todos?{}", ws_prefix(*workspace_id), query_params.join("&"))
-            };
-
-            let resp: ClientResponse<Vec<Todo>> = client.get(&path).await?;
-
-            // Client-side search filtering
-            let resp = if let Some(keyword) = search {
-                let keyword = keyword.to_lowercase();
-                match resp.data {
-                    Some(todos) => {
-                        let filtered: Vec<Todo> = todos.into_iter()
-                            .filter(|t| {
-                                t.title.to_lowercase().contains(&keyword)
-                                    || t.prompt.to_lowercase().contains(&keyword)
-                            })
-                            .collect();
-                        ClientResponse { code: resp.code, data: Some(filtered), message: resp.message }
-                    }
-                    None => resp,
+            // 056：GET /todos 响应改为分页结构 { items, total, page, page_size }。
+            // CLI 的 --status/--tag/--running/--search 均为客户端过滤（后端不认识这些参数），
+            // 因此需要拉齐所有页再过滤，否则只能看到第一页的过滤结果。
+            let mut all_todos: Vec<Todo> = Vec::new();
+            let mut page = 1i64;
+            loop {
+                let path = format!(
+                    "{}/todos?page={}&page_size=200",
+                    ws_prefix(*workspace_id),
+                    page
+                );
+                let resp: ClientResponse<crate::models::TodoListPage> = client.get(&path).await?;
+                let Some(page_data) = resp.data else { break };
+                let fetched = page_data.items.len() as i64;
+                all_todos.extend(page_data.items);
+                // 拿满一页说明可能还有下一页；不满则为最后一页
+                if fetched < 200 {
+                    break;
                 }
-            } else {
-                resp
-            };
+                page += 1;
+            }
 
+            // 客户端过滤：status/tag/running 后端本就不支持（原实现发出去但被忽略），
+            // 056 补齐为真正的客户端过滤，行为与参数文档一致。
+            let filtered: Vec<Todo> = all_todos
+                .into_iter()
+                .filter(|t| {
+                    status.as_deref().map_or(true, |s| t.status.as_str() == s)
+                })
+                .filter(|t| {
+                    tag.map_or(true, |tid| t.tag_ids.contains(&tid))
+                })
+                .filter(|t| !*running || t.status.as_str() == "running")
+                .filter(|t| {
+                    search.as_deref().map_or(true, |kw| {
+                        let kw = kw.to_lowercase();
+                        t.title.to_lowercase().contains(&kw)
+                            || t.prompt.to_lowercase().contains(&kw)
+                    })
+                })
+                .collect();
+
+            let resp = ClientResponse { code: 0, data: Some(filtered), message: String::new() };
             print_response(&resp, output, fields)?;
         }
         TodoAction::Get { workspace_id, id } => {
@@ -1282,7 +1285,7 @@ fn build_create_body(args: &ProcessCreateArgs<'_>) -> Result<Value> {
         // 有 --name 时 stdin 是 YAML 正文（方便 shell heredoc），无 --name 时是 JSON body
         if args.name.is_some() {
             let yaml = read_stdin_string()?;
-            return Ok(build_body_from_parts(args.name, Some(yaml), args)?);
+            return build_body_from_parts(args.name, Some(yaml), args);
         }
         return read_stdin_json();
     }
@@ -1290,7 +1293,7 @@ fn build_create_body(args: &ProcessCreateArgs<'_>) -> Result<Value> {
         .name
         .ok_or_else(|| anyhow::anyhow!("新建工艺需要 --name（或用 --stdin 传完整 body）"))?;
     let definition = read_definition_source(args.file)?;
-    Ok(build_body_from_parts(Some(name), Some(definition), args)?)
+    build_body_from_parts(Some(name), Some(definition), args)
 }
 
 /// 从 stdin 读取原始字符串。

--- a/backend/src/daemon/common.rs
+++ b/backend/src/daemon/common.rs
@@ -44,6 +44,9 @@ pub(crate) fn shell_quote_single(path: &str) -> String {
     format!("'{}'", path)
 }
 
+/// 仅 Windows 构建使用（watchdog 脚本目录）；Linux/macOS 无调用方。
+/// 不用 cfg(windows) 是因为本文件单测（见下）在所有平台运行并覆盖该函数。
+#[allow(dead_code)]
 pub(crate) fn ntd_dir() -> PathBuf {
     let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
     home.join(".ntd")

--- a/backend/src/daemon/linux.rs
+++ b/backend/src/daemon/linux.rs
@@ -1,5 +1,10 @@
 //! Linux 平台的 daemon 实现：基于 systemd (system / user instance)。
 //!
+//! #![allow(print_stdout/print_stderr)]：daemon 子命令（install/start/stop/status）
+//! 的 stdout/stderr 就是用户界面——systemctl 状态、unit 路径、下一步提示都必须
+//! 直接打到用户终端，走 tracing 会错进 daemon 日志文件而用户看不到。
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+//!
 //! 设计要点：
 //! - 支持两套 scope：
 //!   - system (--system): /etc/systemd/system/ntd.service，需要 root
@@ -59,10 +64,15 @@ fn run_systemctl(system: bool, args: &[&str]) -> std::process::ExitStatus {
     let cmd = systemctl_cmd(system);
     let full_args: Vec<&str> = cmd.iter().copied().chain(args.iter().copied()).collect();
 
+    // systemctl 不存在（非 systemd 发行版/containers）时优雅退出而非 panic，
+    // 错误信息告诉用户缺什么，退出码与 daemon 其它失败路径一致。
     Command::new(full_args[0])
         .args(&full_args[1..])
         .status()
-        .expect("Failed to run systemctl. Is systemd installed?")
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to run {}: {e}. Is systemd installed?", full_args[0]);
+            std::process::exit(1);
+        })
 }
 
 fn run_systemctl_output(system: bool, args: &[&str]) -> std::process::Output {
@@ -72,7 +82,10 @@ fn run_systemctl_output(system: bool, args: &[&str]) -> std::process::Output {
     Command::new(full_args[0])
         .args(&full_args[1..])
         .output()
-        .expect("Failed to run systemctl")
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to run {}: {e}", full_args[0]);
+            std::process::exit(1);
+        })
 }
 
 /// 从 /etc/passwd 解析 username 对应的 home 目录。

--- a/backend/src/daemon/redeploy.rs
+++ b/backend/src/daemon/redeploy.rs
@@ -1,5 +1,9 @@
 //! Linux 专属的 detached redeploy 实现（升级流程用）。
 //!
+//! #![allow(print_stdout/print_stderr)]：redeploy 进度需直接打到用户终端，
+//! 走 tracing 会错进 daemon 日志文件。
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+//!
 //! 设计动机：`ntd.service` 的 `KillMode=mixed` 在 `daemon stop` 触发时，
 //! 会按 cgroup 清理所有子进程。原实现 `sh -c "ntd daemon stop && ..."` 的
 //! 子 shell 仍属于 ntd.service 的 cgroup，会被 SIGKILL 一起带走，导致
@@ -129,7 +133,7 @@ pub fn build_redeploy_spec_nonblocking(
 /// - User 模式必须加 --user 才能连到用户的 systemd 实例；
 ///   System 模式和 Unknown 模式都不加，这样即使探测失败回退也能跑
 ///   （Unknown 时连不上 ntd.service 的实例，但 redeploy 脚本里用的是
-///    ntd 自己的 stop/uninstall/install 逻辑，会重新匹配实际模式）。
+///   ntd 自己的 stop/uninstall/install 逻辑，会重新匹配实际模式）。
 fn build_redeploy_spec_inner(
     mode: DaemonInstallMode,
     script: &str,

--- a/backend/src/daemon/windows.rs
+++ b/backend/src/daemon/windows.rs
@@ -1,5 +1,9 @@
 //! Windows 平台的 daemon 实现：基于 Task Scheduler。
 //!
+//! #![allow(print_stdout/print_stderr)]：daemon 子命令的 stdout/stderr 即用户界面，
+//! 状态与提示必须直接打到用户终端，走 tracing 会错进日志文件。
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+//!
 //! 设计要点：
 //! - 用 schtasks /create onlogon + /it 让 task 仅在用户登录态跑，
 //!   避免 service 在锁屏 / 注销状态下还要拉起的麻烦。
@@ -75,7 +79,11 @@ fn install(force: bool) {
             "/it",  // Run only when user is logged on (interactive)
         ])
         .output()
-        .expect("Failed to run schtasks");
+        // schtasks 不存在（精简版 Windows/容器）时优雅退出而非 panic
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to run schtasks: {e}");
+            std::process::exit(1);
+        });
 
     if output.status.success() {
         println!();

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -93,10 +93,29 @@ pub struct UpdateExecutionRecordRequest<'a> {
 pub struct ExecutionRecordQuery<'a> {
     pub todo_id: Option<i64>,
     pub step_id: Option<i64>,
+    /// 工作空间过滤：execution_records 无 workspace_id 列，经 todos 子查询间接关联。
+    /// 下推 SQL 而非内存过滤——内存过滤发生在 LIMIT/OFFSET 之后，会把本 ws 记录
+    /// 稀释到各页导致分页条数与 total 对不上（056 修复的正确性 bug）。
+    pub workspace_id: Option<i64>,
     pub limit: i64,
     pub offset: i64,
     pub status: Option<&'a str>,
     pub hours: Option<u32>,
+}
+
+/// 构造「本工作空间 todo」的子查询条件：todo_id IN (SELECT id FROM todos ...)。
+///
+/// 抽成独立函数是因为数据查询与 COUNT 查询必须共用完全相同的过滤条件，
+/// 任何一边漏加都会让分页元数据失真。
+fn workspace_todo_subquery(
+    workspace_id: i64,
+) -> sea_orm::sea_query::SelectStatement {
+    sea_orm::sea_query::Query::select()
+        .column(todos::Column::Id)
+        .from(todos::Entity)
+        .and_where(todos::Column::WorkspaceId.eq(workspace_id))
+        .and_where(todos::Column::DeletedAt.is_null())
+        .to_owned()
 }
 
 /// `get_execution_summary` 使用的固定 SQL 字面量。
@@ -195,6 +214,16 @@ impl Database {
         let filter = match query.status {
             Some("all") | None => base_filter,
             Some(s) => base_filter.and(execution_records::Column::Status.eq(s)),
+        };
+
+        // workspace 过滤以 AND 叠加：与 (todo_id, step_id) 组合分支兼容——
+        // 即使指定了 todo_id，也要求该 todo 属于本 ws（防 ?todo_id=<他人> 越权读）。
+        let filter = if let Some(wid) = query.workspace_id {
+            filter.and(execution_records::Column::TodoId.in_subquery(
+                workspace_todo_subquery(wid),
+            ))
+        } else {
+            filter
         };
 
         let filter = if let Some(h) = query.hours.filter(|&h| h > 0) {
@@ -834,9 +863,19 @@ impl Database {
     pub async fn get_execution_records_by_session(
         &self,
         session_id: &str,
+        workspace_id: Option<i64>,
     ) -> Result<Vec<ExecutionRecord>, sea_orm::DbErr> {
+        // V1 隔离：同一 session 可能含跨 ws 记录（todo 被移过空间），按子查询过滤只留本 ws
+        let filter = execution_records::Column::SessionId.eq(session_id);
+        let filter = if let Some(wid) = workspace_id {
+            filter.and(execution_records::Column::TodoId.in_subquery(
+                workspace_todo_subquery(wid),
+            ))
+        } else {
+            filter
+        };
         Ok(execution_records::Entity::find()
-            .filter(execution_records::Column::SessionId.eq(session_id))
+            .filter(filter)
             .order_by_asc(execution_records::Column::StartedAt)
             .all(&self.conn)
             .await?
@@ -1067,9 +1106,18 @@ impl Database {
     /// 查询所有 status='running' 的执行记录（包括僵尸记录）
     pub async fn get_running_execution_records(
         &self,
+        workspace_id: Option<i64>,
     ) -> Result<Vec<ExecutionRecord>, sea_orm::DbErr> {
+        let filter = execution_records::Column::Status.eq("running");
+        let filter = if let Some(wid) = workspace_id {
+            filter.and(execution_records::Column::TodoId.in_subquery(
+                workspace_todo_subquery(wid),
+            ))
+        } else {
+            filter
+        };
         let models = execution_records::Entity::find()
-            .filter(execution_records::Column::Status.eq("running"))
+            .filter(filter)
             .order_by_desc(execution_records::Column::StartedAt)
             .all(&self.conn)
             .await?;

--- a/backend/src/db/feishu_project_binding.rs
+++ b/backend/src/db/feishu_project_binding.rs
@@ -131,6 +131,7 @@ impl Database {
             .get_execution_records(ExecutionRecordQuery {
                 todo_id: Some(binding.todo_id),
                 step_id: None,
+                workspace_id: None,
                 limit,
                 offset: 0,
                 status: None,

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -309,7 +309,7 @@ impl Database {
 pub mod blackboard;
 
 mod todo;
-pub use todo::{SchedulerUpdate, TODO_TYPE_ABNORMAL_HANDLER, TodoUpdate};
+pub use todo::{SchedulerUpdate, TODO_TYPE_ABNORMAL_HANDLER, TodoCenterPageQuery, TodoUpdate};
 pub mod execution;
 pub(super) mod dashboard;
 mod tag;
@@ -594,6 +594,7 @@ mod tests {
         let (records, _) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
             todo_id: Some(todo_id),
             step_id: None,
+            workspace_id: None,
             limit: 100,
             offset: 0,
             status: None,
@@ -632,6 +633,7 @@ mod tests {
         let (records, _) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
             todo_id: Some(todo_id),
             step_id: None,
+            workspace_id: None,
             limit: 100,
             offset: 0,
             status: None,
@@ -666,7 +668,7 @@ mod tests {
         let db = setup_db().await;
         let id = db.create_todo("Active", "Prompt").await.unwrap();
         db.delete_todo(id).await.unwrap();
-        let todos = db.get_todos().await.unwrap();
+        let (todos, _) = db.get_todos_page_by_workspace(None, None, 1, 200).await.unwrap();
         assert!(todos.iter().all(|t| t.id != id));
     }
 
@@ -676,7 +678,7 @@ mod tests {
         let id1 = db.create_todo("First", "Prompt").await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         let id2 = db.create_todo("Second", "Prompt").await.unwrap();
-        let todos = db.get_todos().await.unwrap();
+        let (todos, _) = db.get_todos_page_by_workspace(None, None, 1, 200).await.unwrap();
         assert_eq!(todos[0].id, id2);
         assert_eq!(todos[1].id, id1);
     }
@@ -766,7 +768,7 @@ mod tests {
         let id = db.create_todo("Test", "Prompt").await.unwrap();
         db.delete_todo(id).await.unwrap();
         assert!(db.get_todo(id).await.unwrap().is_none());
-        let todos = db.get_todos().await.unwrap();
+        let (todos, _) = db.get_todos_page_by_workspace(None, None, 1, 200).await.unwrap();
         assert!(todos.iter().all(|t| t.id != id));
     }
 
@@ -928,6 +930,7 @@ mod tests {
         let (records, total) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
             todo_id: Some(todo_id),
             step_id: None,
+            workspace_id: None,
             limit: 100,
             offset: 0,
             status: None,
@@ -954,6 +957,7 @@ mod tests {
         let (records, total) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
             todo_id: Some(todo_id),
             step_id: None,
+            workspace_id: None,
             limit: 2,
             offset: 0,
             status: None,
@@ -963,6 +967,42 @@ mod tests {
         .unwrap();
         assert_eq!(total, 5);
         assert_eq!(records.len(), 2);
+    }
+
+    /// 056 回归：workspace 过滤必须在 SQL 层与分页同口径——
+    /// 修复前「先分页后内存过滤」导致本 ws 记录被稀释、total 是全库总数。
+    #[tokio::test]
+    async fn test_execution_records_workspace_filter_pagination() {
+        let db = setup_db().await;
+        // 两个 workspace：ws_a 1 个 todo，ws_b 1 个 todo
+        let ws_a = db.create_project_directory("/tmp/056-ws-a", Some("wa"), false, false).await.unwrap();
+        let ws_b = db.create_project_directory("/tmp/056-ws-b", Some("wb"), false, false).await.unwrap();
+        let todo_a = db.create_todo("A", "p").await.unwrap();
+        let todo_b = db.create_todo("B", "p").await.unwrap();
+        db.exec(&format!("UPDATE todos SET workspace_id = {ws_a} WHERE id = {todo_a}")).await.unwrap();
+        db.exec(&format!("UPDATE todos SET workspace_id = {ws_b} WHERE id = {todo_b}")).await.unwrap();
+        // ws_b 造 4 条（淹没第一页），ws_a 造 1 条
+        for i in 0..4 {
+            create_test_execution_record(&db, todo_b, &format!("b{}", i)).await;
+        }
+        create_test_execution_record(&db, todo_a, "a0").await;
+
+        let (records, total) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
+            todo_id: None,
+            step_id: None,
+            workspace_id: Some(ws_a),
+            limit: 2,
+            offset: 0,
+            status: None,
+            hours: None,
+        })
+        .await
+        .unwrap();
+        // 修复前：第一页被 ws_b 的 4 条占满，内存过滤后 0 条，total=5
+        // 修复后：SQL 过滤后只有 ws_a 的 1 条，total=1
+        assert_eq!(total, 1, "total 必须是过滤后的计数");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].todo_id, todo_a);
     }
 
     #[tokio::test]
@@ -975,6 +1015,7 @@ mod tests {
         let (records, total) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
             todo_id: Some(todo_id),
             step_id: None,
+            workspace_id: None,
             limit: 10,
             offset: 2,
             status: None,
@@ -1021,6 +1062,7 @@ mod tests {
             db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
                 todo_id: Some(todo_id),
             step_id: None,
+                workspace_id: None,
                 limit: 10,
                 offset: 0,
                 status: Some("running"),
@@ -1036,6 +1078,7 @@ mod tests {
             db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
                 todo_id: Some(todo_id),
             step_id: None,
+                workspace_id: None,
                 limit: 10,
                 offset: 0,
                 status: Some("success"),
@@ -1051,6 +1094,7 @@ mod tests {
             db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
                 todo_id: Some(todo_id),
             step_id: None,
+                workspace_id: None,
                 limit: 10,
                 offset: 0,
                 status: Some("failed"),
@@ -1065,6 +1109,7 @@ mod tests {
         let (all, total_all) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
             todo_id: Some(todo_id),
             step_id: None,
+            workspace_id: None,
             limit: 10,
             offset: 0,
             status: None,
@@ -1080,6 +1125,7 @@ mod tests {
             db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
                 todo_id: Some(todo_id),
             step_id: None,
+                workspace_id: None,
                 limit: 10,
                 offset: 0,
                 status: Some("all"),
@@ -1118,6 +1164,7 @@ mod tests {
         let (records, _) = db.get_execution_records(crate::db::execution::ExecutionRecordQuery {
             todo_id: Some(todo_id),
             step_id: None,
+            workspace_id: None,
             limit: 100,
             offset: 0,
             status: None,

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -67,9 +67,8 @@ pub struct TodoCenterPageQuery<'a> {
 fn brief_from_row(row: &sea_orm::QueryResult) -> Result<crate::models::TodoBrief, sea_orm::DbErr> {
     Ok(crate::models::TodoBrief {
         id: row.try_get_by("id")?,
-        title: row
-            .try_get_by::<Option<String>, _>("title")?
-            .unwrap_or_default(),
+        // title 在 schema 上 NOT NULL：读不出来是数据损坏信号，传播错误而非静默置空
+        title: row.try_get_by("title")?,
         status: row
             .try_get_by::<Option<String>, _>("status")?
             .as_deref()
@@ -290,15 +289,11 @@ impl Database {
     // 两侧实现由集成测试对拍，防止语义漂移（见 todo.rs 测试模块）。
 
     /// bucket 过滤/计数共用的 WHERE 组装：返回 (sql_fragment, values)。
-    /// `include_bucket` 控制是否叠加 bucket 条件——bucket_counts 统计要用
-    /// 「应用 search 但不应用 bucket」的口径，保证 Tab 角标不随当前选中分类塌缩。
-    /// bucket 过滤/计数共用的 WHERE 组装：返回 (sql_fragment, values)。
-    /// `include_bucket` 控制是否叠加 bucket 条件——bucket_counts 统计要用
-    /// 「应用 search/status/action_type 但不应用 bucket」的口径，
+    /// bucket 条件由 `q.bucket` 决定——bucket_counts 统计时调用方传
+    /// `bucket=None` 的克隆，即「应用 search/status/action_type 但不应用 bucket」，
     /// 保证 Tab 角标不随当前选中分类塌缩。
     fn center_page_where(
         q: &TodoCenterPageQuery<'_>,
-        include_bucket: bool,
     ) -> (String, Vec<sea_orm::Value>) {
         let mut sql = String::from("t.deleted_at IS NULL");
         let mut values: Vec<sea_orm::Value> = Vec::new();
@@ -322,13 +317,11 @@ impl Database {
             values.push(pattern.clone().into());
             values.push(pattern.into());
         }
-        if include_bucket {
-            if let Some(b) = q.bucket {
-                sql.push_str(" AND ");
-                sql.push_str(TODO_CENTER_BUCKET_EXPR);
-                sql.push_str(" = ?");
-                values.push(center_bucket_str(b).into());
-            }
+        if let Some(b) = q.bucket {
+            sql.push_str(" AND ");
+            sql.push_str(TODO_CENTER_BUCKET_EXPR);
+            sql.push_str(" = ?");
+            values.push(center_bucket_str(b).into());
         }
         (sql, values)
     }
@@ -344,7 +337,7 @@ impl Database {
     ) -> Result<(Vec<TodoCenterItem>, i64, std::collections::HashMap<String, i64>, Vec<String>), sea_orm::DbErr> {
         let page = q.page.max(1);
         let page_size = q.page_size.clamp(1, 200);
-        let (where_sql, values) = Self::center_page_where(&q, true);
+        let (where_sql, values) = Self::center_page_where(&q);
         let order = if q.sort_desc { "DESC" } else { "ASC" };
         let sql = format!(
             "SELECT t.id FROM todos t WHERE {where_sql} ORDER BY {} {order} LIMIT ? OFFSET ?",
@@ -407,7 +400,7 @@ impl Database {
         &self,
         q: &TodoCenterPageQuery<'_>,
     ) -> Result<i64, sea_orm::DbErr> {
-        let (where_sql, values) = Self::center_page_where(q, true);
+        let (where_sql, values) = Self::center_page_where(q);
         let sql = format!("SELECT COUNT(*) AS cnt FROM todos t WHERE {where_sql}");
         let row = self
             .conn
@@ -430,7 +423,7 @@ impl Database {
         // bucket 角标口径：应用 search/status/action_type，但不应用 bucket 过滤
         let mut count_q = q.clone();
         count_q.bucket = None;
-        let (where_sql, values) = Self::center_page_where(&count_q, false);
+        let (where_sql, values) = Self::center_page_where(&count_q);
         let sql = format!(
             "SELECT {TODO_CENTER_BUCKET_EXPR} AS bucket, COUNT(*) AS cnt FROM todos t WHERE {where_sql} GROUP BY bucket"
         );
@@ -2750,6 +2743,150 @@ mod todo_center_tests {
         let ids = db.get_todo_ids_by_workspace(ws).await.unwrap();
         assert_eq!(ids, vec![keep]);
         assert_eq!(db.count_todos_by_workspace(ws).await.unwrap(), 1);
+    }
+
+    /// 056 评审补测：sort_by=computed_bucket 的 SQL 表达式排序。
+    /// 按 CASE 输出串字典序：archived < event_driven < loop_driven < manual < time_driven。
+    #[tokio::test]
+    async fn test_center_page_sort_by_computed_bucket() {
+        let db = fresh_db().await;
+        let manual_id = seed_todo(&db, "m").await;
+        let time_id = seed_todo(&db, "t").await;
+        db.exec(&format!(
+            "UPDATE todos SET scheduler_config = '0 0 9 * * *' WHERE id = {time_id}"
+        ))
+        .await
+        .unwrap();
+        let archived_id = seed_todo(&db, "a").await;
+        db.archive_todo(archived_id).await.unwrap();
+
+        let (items, _, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None,
+                bucket: None,
+                search: None,
+                status: None,
+                action_type: None,
+                sort_by: Some("computed_bucket"),
+                sort_desc: false, // ASC
+                page: 1,
+                page_size: 20,
+            })
+            .await
+            .unwrap();
+        let order: Vec<i64> = items.iter().map(|i| i.todo.id).collect();
+        assert_eq!(
+            order,
+            vec![archived_id, manual_id, time_id],
+            "ASC 应按 bucket 名字典序 archived < manual < time_driven"
+        );
+    }
+
+    /// 056 评审补测：搜索词含 LIKE 通配符（%/_）时被转义，不作为通配符匹配。
+    #[tokio::test]
+    async fn test_center_page_search_escapes_like_wildcards() {
+        let db = fresh_db().await;
+        seed_todo(&db, "进度 50% 完成").await;
+        seed_todo(&db, "进度 50x 完成").await;
+        // 未转义时 "%50%" 中的 % 会同时命中两条；转义后只命中字面条目
+        let (items, total, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None,
+                bucket: None,
+                search: Some("50%"),
+                status: None,
+                action_type: None,
+                sort_by: None,
+                sort_desc: true,
+                page: 1,
+                page_size: 20,
+            })
+            .await
+            .unwrap();
+        assert_eq!(total, 1, "% 必须按字面匹配");
+        assert_eq!(items[0].todo.title, "进度 50% 完成");
+        // 下划线同样转义
+        let (_, total2, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None,
+                bucket: None,
+                search: Some("50_"),
+                status: None,
+                action_type: None,
+                sort_by: None,
+                sort_desc: true,
+                page: 1,
+                page_size: 20,
+            })
+            .await
+            .unwrap();
+        assert_eq!(total2, 0, "_ 必须按字面匹配，不存在含 50_ 的标题");
+    }
+
+    /// 056 评审补测：status / action_type 精确过滤下推 SQL。
+    #[tokio::test]
+    async fn test_center_page_status_and_action_type_filters() {
+        let db = fresh_db().await;
+        let pending_id = seed_todo(&db, "待办").await;
+        let done_id = seed_todo(&db, "完成").await;
+        db.exec(&format!("UPDATE todos SET status = 'completed' WHERE id = {done_id}"))
+            .await
+            .unwrap();
+        let act_id = seed_todo(&db, "快捷").await;
+        db.exec(&format!("UPDATE todos SET action_type = 'quick' WHERE id = {act_id}"))
+            .await
+            .unwrap();
+
+        let base = crate::db::TodoCenterPageQuery {
+            workspace_id: None,
+            bucket: None,
+            search: None,
+            status: None,
+            action_type: None,
+            sort_by: None,
+            sort_desc: true,
+            page: 1,
+            page_size: 20,
+        };
+        let (items, total, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                status: Some("completed"),
+                ..base.clone()
+            })
+            .await
+            .unwrap();
+        assert_eq!(total, 1);
+        assert_eq!(items[0].todo.id, done_id);
+
+        let (items, total, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                action_type: Some("quick"),
+                ..base.clone()
+            })
+            .await
+            .unwrap();
+        assert_eq!(total, 1);
+        assert_eq!(items[0].todo.id, act_id);
+
+        // 组合过滤：completed + quick 应无交集（quick 是 pending）
+        let (_, total3, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                status: Some("completed"),
+                action_type: Some("quick"),
+                ..base.clone()
+            })
+            .await
+            .unwrap();
+        assert_eq!(total3, 0);
+        // pending_id 只是防止 unused 警告，并验证 status=pending 能命中
+        let (_, total4, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                status: Some("pending"),
+                ..base.clone()
+            })
+            .await
+            .unwrap();
+        assert_eq!(total4, 2, "pending 应命中 待办+快捷（{pending_id}/{act_id}）");
     }
 }
 

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -335,8 +335,12 @@ impl Database {
         &self,
         q: TodoCenterPageQuery<'_>,
     ) -> Result<(Vec<TodoCenterItem>, i64, std::collections::HashMap<String, i64>, Vec<String>), sea_orm::DbErr> {
-        let page = q.page.max(1);
         let page_size = q.page_size.clamp(1, 200);
+        // 先计数再钳页码（CodeRabbit#2）：page 无上界时大 OFFSET 是外部可触发的慢查询；
+        // offset 超出 total 时截断到最后一页，而不是让 SQLite 逐行跳过几千万行。
+        let total = self.count_todo_center(&q).await?;
+        let max_page = if total == 0 { 1 } else { (total + page_size - 1) / page_size };
+        let page = q.page.max(1).min(max_page.max(1));
         let (where_sql, values) = Self::center_page_where(&q);
         let order = if q.sort_desc { "DESC" } else { "ASC" };
         let sql = format!(
@@ -359,7 +363,6 @@ impl Database {
             .filter_map(|r| r.try_get_by::<i64, _>("id").ok())
             .collect();
 
-        let total = self.count_todo_center(&q).await?;
         let bucket_counts = self.count_todo_center_buckets(&q).await?;
         let action_types = self.list_center_action_types(q.workspace_id).await?;
         let items = self.build_center_items_by_ids(&ids).await?;
@@ -491,18 +494,23 @@ impl Database {
              (prompt IS NOT NULL AND prompt != '') AS has_prompt FROM todos WHERE deleted_at IS NULL",
         );
         let mut values: Vec<sea_orm::Value> = Vec::new();
-        if let Some(wid) = workspace_id {
-            sql.push_str(" AND workspace_id = ?");
-            values.push(wid.into());
-        }
         match ids {
             Some(ids) if !ids.is_empty() => {
+                // 定点模式（CodeRabbit#6）：id 全局唯一，不再叠加 workspace_id 条件——
+                // Dashboard 全局运营视图的跨 ws 标题反查、运行记录抽屉补标题都依赖这一点。
                 let (ph, vals) = Database::in_clause(ids);
                 sql.push_str(&format!(" AND id IN ({ph})"));
                 values.extend(vals);
             }
             Some(_) => return Ok(Vec::new()), // 空 id 集 = 空结果，避免 IN () 非法 SQL
-            None => sql.push_str(" AND archived_at IS NULL"), // 看板模式隐藏已归档
+            None => {
+                // 看板模式：按 ws 过滤且隐藏已归档（与旧 getAllTodos 数据源语义一致）
+                if let Some(wid) = workspace_id {
+                    sql.push_str(" AND workspace_id = ?");
+                    values.push(wid.into());
+                }
+                sql.push_str(" AND archived_at IS NULL");
+            }
         }
         if let Some(h) = hours.filter(|&h| h > 0) {
             // hours 已验证 > 0 的 u32，format! 是构建 SQL 时间表达式的唯一途径
@@ -585,19 +593,22 @@ impl Database {
                 "REPLACE(REPLACE(updated_at, 'T', ' '), 'Z', '') >= datetime('now', '-{h} hours')"
             )));
         }
-        let models = todos::Entity::find()
+        // 先计数再钳页码（CodeRabbit#2）：大 OFFSET 是外部可触发的慢查询
+        let total: i64 = todos::Entity::find()
             .filter(cond.clone())
+            .count(&self.conn)
+            .await?
+            .try_into()
+            .unwrap_or(i64::MAX);
+        let max_page = if total == 0 { 1 } else { (total + page_size - 1) / page_size };
+        let page = page.min(max_page.max(1));
+        let models = todos::Entity::find()
+            .filter(cond)
             .order_by_desc(todos::Column::UpdatedAt)
             .limit(page_size as u64)
             .offset(((page - 1) * page_size) as u64)
             .all(&self.conn)
             .await?;
-        let total: i64 = todos::Entity::find()
-            .filter(cond)
-            .count(&self.conn)
-            .await?
-            .try_into()
-            .unwrap_or(i64::MAX);
         let ids: Vec<i64> = models.iter().map(|m| m.id).collect();
         let tag_map = self.fetch_tag_ids_for_many(&ids).await?;
         Ok((
@@ -613,18 +624,27 @@ impl Database {
     }
 
     /// 云同步合并用（056）：只取 id+title 两列建 title→id 映射，替代整行全量拉取。
+    ///
+    /// 实现说明：用原生 SQL 而非 select_only()——SeaORM 的 Model 反序列化要求全列
+    /// （CodeRabbit#1 复核确认缺列会在运行时 ColumnNotFound），两列投影必须走原生 SQL。
     pub async fn get_todo_title_id_map(
         &self,
     ) -> Result<std::collections::HashMap<String, i64>, sea_orm::DbErr> {
-        let models = todos::Entity::find()
-            .select_only()
-            .columns([todos::Column::Id, todos::Column::Title])
-            .filter(todos::Column::DeletedAt.is_null())
-            .all(&self.conn)
+        let rows = self
+            .conn
+            .query_all(sea_orm::Statement::from_string(
+                sea_orm::DbBackend::Sqlite,
+                "SELECT id, title FROM todos WHERE deleted_at IS NULL".to_string(),
+            ))
             .await?;
-        Ok(models
-            .into_iter()
-            .map(|m| (m.title.trim().to_lowercase(), m.id))
+        Ok(rows
+            .iter()
+            .filter_map(|r| {
+                Some((
+                    r.try_get_by::<String, _>("title").ok()?.trim().to_lowercase(),
+                    r.try_get_by::<i64, _>("id").ok()?,
+                ))
+            })
             .collect())
     }
 
@@ -2887,6 +2907,49 @@ mod todo_center_tests {
             .await
             .unwrap();
         assert_eq!(total4, 2, "pending 应命中 待办+快捷（{pending_id}/{act_id}）");
+    }
+
+    /// CodeRabbit#1 回归：两列投影必须走原生 SQL（select_only + 部分列 + Model 反序列化
+    /// 会在运行时 ColumnNotFound）。验证映射键为小写 title、值为 id。
+    #[tokio::test]
+    async fn test_todo_title_id_map_two_column_projection() {
+        let db = fresh_db().await;
+        let id = seed_todo(&db, "MyTask").await;
+        let map = db.get_todo_title_id_map().await.unwrap();
+        assert_eq!(map.get("mytask"), Some(&id), "键为小写化 title");
+    }
+
+    /// CodeRabbit#2 回归：page 超界时按 total 截断到最后一页，不执行大 OFFSET。
+    #[tokio::test]
+    async fn test_center_page_clamps_overflow_page() {
+        let db = fresh_db().await;
+        for i in 0..5 {
+            seed_todo(&db, &format!("项{i}")).await;
+        }
+        // page=100000 应被截断到最后一页（total=5, page_size=2 → max_page=3）
+        let (items, total, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None,
+                bucket: None,
+                search: None,
+                status: None,
+                action_type: None,
+                sort_by: None,
+                sort_desc: true,
+                page: 100000,
+                page_size: 2,
+            })
+            .await
+            .unwrap();
+        assert_eq!(total, 5);
+        assert_eq!(items.len(), 1, "截断到最后一页只剩 1 条");
+
+        // 旧 /todos 分页同样截断
+        let (items2, _) = db
+            .get_todos_page_by_workspace(None, None, 99999, 2)
+            .await
+            .unwrap();
+        assert_eq!(items2.len(), 1);
     }
 }
 

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -1,6 +1,6 @@
 use sea_orm::{
-    ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter,
-    QueryOrder, Statement,
+    ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait, PaginatorTrait,
+    QueryFilter, QueryOrder, QuerySelect, Statement,
 };
 
 use crate::db::entity::project_directories;
@@ -12,6 +12,81 @@ use crate::models::{ComputedBucket, Todo, TodoBackup, TodoCenterItem, TodoStatus
 /// todo_type 取值：异常处理载体 Todo（工艺安装时按 abnormal_handler.prompt 创建）。
 /// 模式与 todo_type=2 评审实例对称；事项列表以「异常处理」标签区分。需求 035。
 pub const TODO_TYPE_ABNORMAL_HANDLER: i32 = 3;
+
+/// 056：computed_bucket 的 SQL 表达式，优先级与 `models::compute_bucket` 严格一致
+/// （已归档 > Loop 驱动 > 时间驱动 > 事件驱动 > 手动）。
+/// 两侧实现由测试对拍防漂移（见本文件测试 `test_center_bucket_sql_matches_rust`）。
+const TODO_CENTER_BUCKET_EXPR: &str = "CASE \
+    WHEN t.archived_at IS NOT NULL THEN 'archived' \
+    WHEN (SELECT COUNT(*) FROM loop_steps ls WHERE ls.todo_id = t.id AND ls.enabled = 1) > 0 THEN 'loop_driven' \
+    WHEN t.scheduler_config IS NOT NULL THEN 'time_driven' \
+    WHEN t.webhook_enabled = 1 THEN 'event_driven' \
+    ELSE 'manual' END";
+
+/// ComputedBucket → SQL 表达式输出字符串（与 serde snake_case 保持一致）。
+fn center_bucket_str(b: ComputedBucket) -> &'static str {
+    match b {
+        ComputedBucket::Archived => "archived",
+        ComputedBucket::LoopDriven => "loop_driven",
+        ComputedBucket::TimeDriven => "time_driven",
+        ComputedBucket::EventDriven => "event_driven",
+        ComputedBucket::Manual => "manual",
+    }
+}
+
+/// 排序字段白名单：拒绝白名单外输入，退化为默认 id——
+/// 排序列名要拼进 SQL 字符串（参数绑定不能绑标识符），白名单是唯一安全途径。
+fn center_sort_column(sort_by: Option<&str>) -> &'static str {
+    match sort_by {
+        Some("updated_at") => "t.updated_at",
+        Some("title") => "t.title COLLATE NOCASE",
+        Some("status") => "t.status",
+        Some("computed_bucket") => TODO_CENTER_BUCKET_EXPR,
+        _ => "t.id",
+    }
+}
+
+/// 事项中心分页查询参数（056）：打包传参避免 too_many_arguments。
+/// `search=None` 表示不搜索；排序方向由 `sort_desc` 显式给出（handler 默认 true）。
+#[derive(Debug, Clone)]
+pub struct TodoCenterPageQuery<'a> {
+    pub workspace_id: Option<i64>,
+    pub bucket: Option<ComputedBucket>,
+    pub search: Option<&'a str>,
+    /// 状态精确过滤（卡片墙「状态筛选」下拉；None=全部）
+    pub status: Option<&'a str>,
+    /// 动作类型精确过滤（卡片墙「来源筛选」下拉；None=全部）
+    pub action_type: Option<&'a str>,
+    pub sort_by: Option<&'a str>,
+    pub sort_desc: bool,
+    pub page: i64,
+    pub page_size: i64,
+}
+
+/// QueryResult 行 → TodoBrief（056 轻量摘要）。独立函数保持 get_todo_briefs 函数体合规。
+fn brief_from_row(row: &sea_orm::QueryResult) -> Result<crate::models::TodoBrief, sea_orm::DbErr> {
+    Ok(crate::models::TodoBrief {
+        id: row.try_get_by("id")?,
+        title: row
+            .try_get_by::<Option<String>, _>("title")?
+            .unwrap_or_default(),
+        status: row
+            .try_get_by::<Option<String>, _>("status")?
+            .as_deref()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(TodoStatus::Pending),
+        executor: row.try_get_by("executor")?,
+        updated_at: row
+            .try_get_by::<Option<String>, _>("updated_at")?
+            .unwrap_or_default(),
+        archived_at: row.try_get_by("archived_at")?,
+        workspace_id: row.try_get_by("workspace_id")?,
+        // tag_ids 由调用方批量补算（见 get_todo_briefs），此处占位
+        tag_ids: Vec::new(),
+        // SQLite 布尔表达式以 0/1 返回
+        has_prompt: row.try_get_by::<i64, _>("has_prompt")? != 0,
+    })
+}
 
 pub struct TodoUpdate<'a> {
     pub id: i64,
@@ -146,103 +221,12 @@ impl Database {
             }))
     }
 
-    pub async fn get_todos(&self) -> Result<Vec<Todo>, sea_orm::DbErr> {
-        let models = todos::Entity::find()
-            .filter(todos::Column::DeletedAt.is_null())
-            .order_by_desc(todos::Column::UpdatedAt)
-            .all(&self.conn)
-            .await?;
-
-        let ids: Vec<i64> = models.iter().map(|m| m.id).collect();
-        let tag_map = self.fetch_tag_ids_for_many(&ids).await?;
-
-        Ok(models
-            .into_iter()
-            .map(|m| {
-                let tag_ids = tag_map.get(&m.id).cloned().unwrap_or_default();
-                Self::model_to_todo(m, tag_ids)
-            })
-            .collect())
-    }
-
-    /// 按工作空间 ID 过滤 Todo（日常视图）。
-    ///
-    /// 额外过滤 `archived_at IS NULL`：已归档事项从日常视图隐藏，
-    /// 仅在事项中心「已归档」分类可见（见 `get_todo_center`）。
-    pub async fn get_todos_by_workspace_id(&self, workspace_id: Option<i64>) -> Result<Vec<Todo>, sea_orm::DbErr> {
-        let mut query = todos::Entity::find()
-            .filter(todos::Column::DeletedAt.is_null())
-            .filter(todos::Column::ArchivedAt.is_null())
-            .order_by_desc(todos::Column::UpdatedAt);
-
-        if let Some(id) = workspace_id {
-            query = query.filter(todos::Column::WorkspaceId.eq(id));
-        }
-
-        let models = query.all(&self.conn).await?;
-
-        let ids: Vec<i64> = models.iter().map(|m| m.id).collect();
-        let tag_map = self.fetch_tag_ids_for_many(&ids).await?;
-
-        Ok(models
-            .into_iter()
-            .map(|m| {
-                let tag_ids = tag_map.get(&m.id).cloned().unwrap_or_default();
-                Self::model_to_todo(m, tag_ids)
-            })
-            .collect())
-    }
-
-    /// 事项中心列表：按工作空间返回带运行时推导字段的 TodoCenterItem 集合。
-    ///
-    /// 与日常视图不同，这里**不**过滤 `archived_at`——已归档事项也需在
-    /// 「已归档」分类可见。可选 `bucket` 在内存中按 `computed_bucket` 过滤
-    /// （分页前完成分桶，避免数量/分页错乱，见设计文档风险二）。
-    /// 第一版数据量有限，采用「全量载入 + 批量聚合 + 内存过滤」的简单正确实现；
-    /// 真正的分页与 SQL 层分桶留待后续按性能需要再加。
-    pub async fn get_todo_center(
-        &self,
-        workspace_id: Option<i64>,
-        bucket: Option<ComputedBucket>,
-        search: Option<&str>,
-    ) -> Result<Vec<TodoCenterItem>, sea_orm::DbErr> {
-        // 不过滤 archived_at：已归档事项也要在「已归档」分类出现；
-        // 054 起统一按 id DESC（列表默认排序），与用户点击排序的默认列保持一致。
-        let mut query = todos::Entity::find()
-            .filter(todos::Column::DeletedAt.is_null())
-            .order_by_desc(todos::Column::Id);
-        if let Some(id) = workspace_id {
-            query = query.filter(todos::Column::WorkspaceId.eq(id));
-        }
-        let models = query.all(&self.conn).await?;
-
-        // 一次性批量补算 loop 引用计数/引用 Loop 摘要与执行相关聚合，避免逐 todo N+1
-        let ids: Vec<i64> = models.iter().map(|m| m.id).collect();
-        let tag_map = self.fetch_tag_ids_for_many(&ids).await?;
-        let aggs = self.build_center_aggregates(&ids).await?;
-
-        // 组装 TodoCenterItem，按 bucket + search 过滤（分页前完成，保证 Tab 数量正确）
-        let kw = search.map(str::to_ascii_lowercase);
-        let mut items = Vec::with_capacity(models.len());
-        for m in models {
-            let tag_ids = tag_map.get(&m.id).cloned().unwrap_or_default();
-            let todo = Self::model_to_todo(m, tag_ids);
-            // search 在组装前按 title/prompt 子串过滤（大小写不敏感）
-            if let Some(ref k) = kw {
-                if !todo.title.to_ascii_lowercase().contains(k)
-                    && !todo.prompt.to_ascii_lowercase().contains(k)
-                {
-                    continue;
-                }
-            }
-            let item = Self::build_center_item(todo, &aggs);
-            // 用 map_or 而非 is_none_or：后者稳定于 1.82，当前 MSRV 1.81 不支持
-            if bucket.map_or(true, |b| b == item.computed_bucket) {
-                items.push(item);
-            }
-        }
-        Ok(items)
-    }
+    // 056：`get_todos` / `get_todos_by_workspace_id` / `get_todo_center` 三个全量
+    // 查询已删除，由以下接口替代：
+    // - get_todos_page_by_workspace（日常视图，强制分页）
+    // - get_todo_center_page（事项中心，SQL 分桶 + 分页）
+    // - get_todo_briefs / get_todo_ids_by_workspace / count_todos_by_workspace（轻量）
+    // - get_todos_batch_after_id（云同步游标分批）
 
     /// 批量构造 TodoCenterAggregates（列表与单条路径共用，避免两处重复构造）。
     async fn build_center_aggregates(
@@ -297,6 +281,383 @@ impl Database {
             last_webhook_trigger_at,
             bound_slash_command,
         }
+    }
+
+    // ==================== 056：服务端分页与轻量查询 ====================
+    //
+    // computed_bucket 的 SQL 表达式。优先级与 `models::compute_bucket` 严格一致：
+    // 已归档 > Loop 驱动 > 时间驱动 > 事件驱动 > 手动。
+    // 两侧实现由集成测试对拍，防止语义漂移（见 todo.rs 测试模块）。
+
+    /// bucket 过滤/计数共用的 WHERE 组装：返回 (sql_fragment, values)。
+    /// `include_bucket` 控制是否叠加 bucket 条件——bucket_counts 统计要用
+    /// 「应用 search 但不应用 bucket」的口径，保证 Tab 角标不随当前选中分类塌缩。
+    /// bucket 过滤/计数共用的 WHERE 组装：返回 (sql_fragment, values)。
+    /// `include_bucket` 控制是否叠加 bucket 条件——bucket_counts 统计要用
+    /// 「应用 search/status/action_type 但不应用 bucket」的口径，
+    /// 保证 Tab 角标不随当前选中分类塌缩。
+    fn center_page_where(
+        q: &TodoCenterPageQuery<'_>,
+        include_bucket: bool,
+    ) -> (String, Vec<sea_orm::Value>) {
+        let mut sql = String::from("t.deleted_at IS NULL");
+        let mut values: Vec<sea_orm::Value> = Vec::new();
+        if let Some(wid) = q.workspace_id {
+            sql.push_str(" AND t.workspace_id = ?");
+            values.push(wid.into());
+        }
+        if let Some(status) = q.status.map(str::trim).filter(|s| !s.is_empty()) {
+            sql.push_str(" AND t.status = ?");
+            values.push(status.into());
+        }
+        if let Some(at) = q.action_type.map(str::trim).filter(|s| !s.is_empty()) {
+            sql.push_str(" AND t.action_type = ?");
+            values.push(at.into());
+        }
+        if let Some(kw) = q.search.map(str::trim).filter(|s| !s.is_empty()) {
+            // LIKE 通配符先转义再包 %，避免用户输入 %/_ 被当通配符；ESCAPE 用反斜杠
+            let escaped = kw.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_");
+            let pattern = format!("%{}%", escaped.to_lowercase());
+            sql.push_str(" AND (LOWER(t.title) LIKE ? ESCAPE '\\' OR LOWER(t.prompt) LIKE ? ESCAPE '\\')");
+            values.push(pattern.clone().into());
+            values.push(pattern.into());
+        }
+        if include_bucket {
+            if let Some(b) = q.bucket {
+                sql.push_str(" AND ");
+                sql.push_str(TODO_CENTER_BUCKET_EXPR);
+                sql.push_str(" = ?");
+                values.push(center_bucket_str(b).into());
+            }
+        }
+        (sql, values)
+    }
+
+    /// 事项中心服务端分页（056 核心）：SQL 层完成分桶/搜索/排序/分页，
+    /// 聚合字段只对当页 ids 批量补算（避免全表聚合）。
+    ///
+    /// 返回 (items, total, bucket_counts)；total 与 bucket_counts 的过滤口径见
+    /// `center_page_where` 注释。
+    pub async fn get_todo_center_page(
+        &self,
+        q: TodoCenterPageQuery<'_>,
+    ) -> Result<(Vec<TodoCenterItem>, i64, std::collections::HashMap<String, i64>, Vec<String>), sea_orm::DbErr> {
+        let page = q.page.max(1);
+        let page_size = q.page_size.clamp(1, 200);
+        let (where_sql, values) = Self::center_page_where(&q, true);
+        let order = if q.sort_desc { "DESC" } else { "ASC" };
+        let sql = format!(
+            "SELECT t.id FROM todos t WHERE {where_sql} ORDER BY {} {order} LIMIT ? OFFSET ?",
+            center_sort_column(q.sort_by),
+        );
+        let mut vals = values.clone();
+        vals.push(page_size.into());
+        vals.push(((page - 1) * page_size).into());
+        let rows = self
+            .conn
+            .query_all(sea_orm::Statement::from_sql_and_values(
+                sea_orm::DbBackend::Sqlite,
+                sql,
+                vals,
+            ))
+            .await?;
+        let ids: Vec<i64> = rows
+            .iter()
+            .filter_map(|r| r.try_get_by::<i64, _>("id").ok())
+            .collect();
+
+        let total = self.count_todo_center(&q).await?;
+        let bucket_counts = self.count_todo_center_buckets(&q).await?;
+        let action_types = self.list_center_action_types(q.workspace_id).await?;
+        let items = self.build_center_items_by_ids(&ids).await?;
+        Ok((items, total, bucket_counts, action_types))
+    }
+
+    /// 当前工作空间内出现过的 action_type 去重列表（卡片墙「来源筛选」下拉数据源，056）。
+    /// 口径：未删除事项 + 同 ws；不受 search/status 等过滤影响（下拉项应稳定）。
+    async fn list_center_action_types(
+        &self,
+        workspace_id: Option<i64>,
+    ) -> Result<Vec<String>, sea_orm::DbErr> {
+        let mut sql = String::from(
+            "SELECT DISTINCT action_type FROM todos WHERE deleted_at IS NULL AND action_type IS NOT NULL AND action_type != ''",
+        );
+        let mut values: Vec<sea_orm::Value> = Vec::new();
+        if let Some(wid) = workspace_id {
+            sql.push_str(" AND workspace_id = ?");
+            values.push(wid.into());
+        }
+        sql.push_str(" ORDER BY action_type");
+        let rows = self
+            .conn
+            .query_all(sea_orm::Statement::from_sql_and_values(
+                sea_orm::DbBackend::Sqlite,
+                sql,
+                values,
+            ))
+            .await?;
+        Ok(rows
+            .iter()
+            .filter_map(|r| r.try_get_by::<String, _>("action_type").ok())
+            .collect())
+    }
+
+    /// 事项中心总数（与分页查询同一过滤口径，含 bucket）。
+    async fn count_todo_center(
+        &self,
+        q: &TodoCenterPageQuery<'_>,
+    ) -> Result<i64, sea_orm::DbErr> {
+        let (where_sql, values) = Self::center_page_where(q, true);
+        let sql = format!("SELECT COUNT(*) AS cnt FROM todos t WHERE {where_sql}");
+        let row = self
+            .conn
+            .query_one(sea_orm::Statement::from_sql_and_values(
+                sea_orm::DbBackend::Sqlite,
+                sql,
+                values,
+            ))
+            .await?;
+        Ok(row
+            .and_then(|r| r.try_get_by::<i64, _>("cnt").ok())
+            .unwrap_or(0))
+    }
+
+    /// 各 bucket 计数（应用 search、不应用 bucket 过滤——Tab 角标语义）。
+    async fn count_todo_center_buckets(
+        &self,
+        q: &TodoCenterPageQuery<'_>,
+    ) -> Result<std::collections::HashMap<String, i64>, sea_orm::DbErr> {
+        // bucket 角标口径：应用 search/status/action_type，但不应用 bucket 过滤
+        let mut count_q = q.clone();
+        count_q.bucket = None;
+        let (where_sql, values) = Self::center_page_where(&count_q, false);
+        let sql = format!(
+            "SELECT {TODO_CENTER_BUCKET_EXPR} AS bucket, COUNT(*) AS cnt FROM todos t WHERE {where_sql} GROUP BY bucket"
+        );
+        let rows = self
+            .conn
+            .query_all(sea_orm::Statement::from_sql_and_values(
+                sea_orm::DbBackend::Sqlite,
+                sql,
+                values,
+            ))
+            .await?;
+        Ok(rows
+            .iter()
+            .filter_map(|r| {
+                Some((
+                    r.try_get_by::<String, _>("bucket").ok()?,
+                    r.try_get_by::<i64, _>("cnt").ok()?,
+                ))
+            })
+            .collect())
+    }
+
+    /// 按 id 列表加载 TodoCenterItem（保序），tag/聚合批量补算——分页路径的组装段。
+    async fn build_center_items_by_ids(
+        &self,
+        ids: &[i64],
+    ) -> Result<Vec<TodoCenterItem>, sea_orm::DbErr> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let models = todos::Entity::find()
+            .filter(todos::Column::Id.is_in(ids.iter().copied()))
+            .all(&self.conn)
+            .await?;
+        // is_in 不保证返回顺序，按传入 ids 重排，保持与 ORDER BY 一致的分页语义
+        let mut by_id: std::collections::HashMap<i64, todos::Model> =
+            models.into_iter().map(|m| (m.id, m)).collect();
+        let tag_map = self.fetch_tag_ids_for_many(ids).await?;
+        let aggs = self.build_center_aggregates(ids).await?;
+        let mut items = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(m) = by_id.remove(id) {
+                let tag_ids = tag_map.get(id).cloned().unwrap_or_default();
+                items.push(Self::build_center_item(Self::model_to_todo(m, tag_ids), &aggs));
+            }
+        }
+        Ok(items)
+    }
+
+    /// 轻量摘要列表（056）：只取展示字段，不读 prompt 大文本。
+    /// `ids=None` 返回该 ws 全部 brief（看板全量渲染用），此模式隐藏已归档事项
+    /// （与旧「日常视图」语义一致）；`ids=Some` 为按 id 定点查询，不过滤归档
+    /// （已归档事项也需要能解析出标题）。`hours` 过滤 updated_at。
+    ///
+    /// 实现说明：用原生 SQL 而非 select_only()——SeaORM 的 Model 映射要求全列，
+    /// 部分列查询走 into_model 需额外派生类型，原生 SQL + try_get_by 更直白。
+    pub async fn get_todo_briefs(
+        &self,
+        workspace_id: Option<i64>,
+        ids: Option<&[i64]>,
+        hours: Option<u32>,
+    ) -> Result<Vec<crate::models::TodoBrief>, sea_orm::DbErr> {
+        let mut sql = String::from(
+            "SELECT id, title, status, executor, updated_at, archived_at, workspace_id, \
+             (prompt IS NOT NULL AND prompt != '') AS has_prompt FROM todos WHERE deleted_at IS NULL",
+        );
+        let mut values: Vec<sea_orm::Value> = Vec::new();
+        if let Some(wid) = workspace_id {
+            sql.push_str(" AND workspace_id = ?");
+            values.push(wid.into());
+        }
+        match ids {
+            Some(ids) if !ids.is_empty() => {
+                let (ph, vals) = Database::in_clause(ids);
+                sql.push_str(&format!(" AND id IN ({ph})"));
+                values.extend(vals);
+            }
+            Some(_) => return Ok(Vec::new()), // 空 id 集 = 空结果，避免 IN () 非法 SQL
+            None => sql.push_str(" AND archived_at IS NULL"), // 看板模式隐藏已归档
+        }
+        if let Some(h) = hours.filter(|&h| h > 0) {
+            // hours 已验证 > 0 的 u32，format! 是构建 SQL 时间表达式的唯一途径
+            sql.push_str(&format!(
+                " AND REPLACE(REPLACE(updated_at, 'T', ' '), 'Z', '') >= datetime('now', '-{h} hours')"
+            ));
+        }
+        sql.push_str(" ORDER BY updated_at DESC");
+        let rows = self
+            .conn
+            .query_all(sea_orm::Statement::from_sql_and_values(
+                sea_orm::DbBackend::Sqlite,
+                sql,
+                values,
+            ))
+            .await?;
+        // tag_ids 批量补算：一次 IN 查询建立 id→tags 映射，不逐行 N+1
+        let mut briefs: Vec<crate::models::TodoBrief> =
+            rows.iter().map(brief_from_row).collect::<Result<_, _>>()?;
+        let ids: Vec<i64> = briefs.iter().map(|b| b.id).collect();
+        let tag_map = self.fetch_tag_ids_for_many(&ids).await?;
+        for b in &mut briefs {
+            b.tag_ids = tag_map.get(&b.id).cloned().unwrap_or_default();
+        }
+        Ok(briefs)
+    }
+
+    /// 工作空间内全部 todo id（056 轻量接口）：只取 id 列，隐藏已归档（日常视图片语义）。
+    pub async fn get_todo_ids_by_workspace(
+        &self,
+        workspace_id: i64,
+    ) -> Result<Vec<i64>, sea_orm::DbErr> {
+        let rows = self
+            .conn
+            .query_all(sea_orm::Statement::from_sql_and_values(
+                sea_orm::DbBackend::Sqlite,
+                "SELECT id FROM todos WHERE deleted_at IS NULL AND archived_at IS NULL AND workspace_id = ? ORDER BY id DESC",
+                vec![workspace_id.into()],
+            ))
+            .await?;
+        Ok(rows
+            .iter()
+            .filter_map(|r| r.try_get_by::<i64, _>("id").ok())
+            .collect())
+    }
+
+    /// 工作空间内未删除且未归档 todo 计数（056 轻量接口）：COUNT(*)，不拉行。
+    pub async fn count_todos_by_workspace(
+        &self,
+        workspace_id: i64,
+    ) -> Result<i64, sea_orm::DbErr> {
+        let count = todos::Entity::find()
+            .filter(todos::Column::DeletedAt.is_null())
+            .filter(todos::Column::ArchivedAt.is_null())
+            .filter(todos::Column::WorkspaceId.eq(workspace_id))
+            .count(&self.conn)
+            .await?;
+        Ok(count.try_into().unwrap_or(i64::MAX))
+    }
+
+    /// 旧 /todos 接口的服务端分页版（056 决策 3b：直接强制分页）。
+    /// 隐藏已归档（「日常视图」语义，与旧 get_todos_by_workspace_id 一致）；
+    /// hours 过滤从内存下推 SQL；返回 (items, total)。
+    pub async fn get_todos_page_by_workspace(
+        &self,
+        workspace_id: Option<i64>,
+        hours: Option<u32>,
+        page: i64,
+        page_size: i64,
+    ) -> Result<(Vec<Todo>, i64), sea_orm::DbErr> {
+        let page = page.max(1);
+        let page_size = page_size.clamp(1, 200);
+        let mut cond = todos::Column::DeletedAt.is_null()
+            .and(todos::Column::ArchivedAt.is_null());
+        if let Some(wid) = workspace_id {
+            cond = cond.and(todos::Column::WorkspaceId.eq(wid));
+        }
+        if let Some(h) = hours.filter(|&h| h > 0) {
+            cond = cond.and(sea_orm::sea_query::Expr::cust(format!(
+                "REPLACE(REPLACE(updated_at, 'T', ' '), 'Z', '') >= datetime('now', '-{h} hours')"
+            )));
+        }
+        let models = todos::Entity::find()
+            .filter(cond.clone())
+            .order_by_desc(todos::Column::UpdatedAt)
+            .limit(page_size as u64)
+            .offset(((page - 1) * page_size) as u64)
+            .all(&self.conn)
+            .await?;
+        let total: i64 = todos::Entity::find()
+            .filter(cond)
+            .count(&self.conn)
+            .await?
+            .try_into()
+            .unwrap_or(i64::MAX);
+        let ids: Vec<i64> = models.iter().map(|m| m.id).collect();
+        let tag_map = self.fetch_tag_ids_for_many(&ids).await?;
+        Ok((
+            models
+                .into_iter()
+                .map(|m| {
+                    let tag_ids = tag_map.get(&m.id).cloned().unwrap_or_default();
+                    Self::model_to_todo(m, tag_ids)
+                })
+                .collect(),
+            total,
+        ))
+    }
+
+    /// 云同步合并用（056）：只取 id+title 两列建 title→id 映射，替代整行全量拉取。
+    pub async fn get_todo_title_id_map(
+        &self,
+    ) -> Result<std::collections::HashMap<String, i64>, sea_orm::DbErr> {
+        let models = todos::Entity::find()
+            .select_only()
+            .columns([todos::Column::Id, todos::Column::Title])
+            .filter(todos::Column::DeletedAt.is_null())
+            .all(&self.conn)
+            .await?;
+        Ok(models
+            .into_iter()
+            .map(|m| (m.title.trim().to_lowercase(), m.id))
+            .collect())
+    }
+
+    /// 云同步上传用（056）：id 游标分批拉取，避免一次性全表载入。
+    /// 传入 `after_id`（上一批最后一个 id，首批传 0），按 id ASC 取 limit 条。
+    pub async fn get_todos_batch_after_id(
+        &self,
+        after_id: i64,
+        limit: i64,
+    ) -> Result<Vec<Todo>, sea_orm::DbErr> {
+        let models = todos::Entity::find()
+            .filter(todos::Column::DeletedAt.is_null())
+            .filter(todos::Column::Id.gt(after_id))
+            .order_by_asc(todos::Column::Id)
+            .limit(limit.max(1) as u64)
+            .all(&self.conn)
+            .await?;
+        let ids: Vec<i64> = models.iter().map(|m| m.id).collect();
+        let tag_map = self.fetch_tag_ids_for_many(&ids).await?;
+        Ok(models
+            .into_iter()
+            .map(|m| {
+                let tag_ids = tag_map.get(&m.id).cloned().unwrap_or_default();
+                Self::model_to_todo(m, tag_ids)
+            })
+            .collect())
     }
 
     /// 取单个 todo 的 TodoCenterItem（archive/restore/webhook 后回传用）。
@@ -1622,7 +1983,7 @@ impl Database {
 
         let where_clause = conditions.join(" AND ");
         let sql = format!(
-            "SELECT t.id as todo_id, t.title, t.prompt, t.executor, \
+            "SELECT t.id as todo_id, t.title, t.prompt, t.executor, t.workspace_id, \
              er.status as execution_status, er.finished_at, er.result, er.model, er.usage, \
              er.trigger_type, er.id as record_id, er.rating \
              FROM todos t \
@@ -1674,6 +2035,7 @@ impl Database {
                     prompt,
                     executor,
                     tag_ids: tag_map.get(&todo_id).cloned().unwrap_or_default(),
+                    workspace_id: row.try_get_by("workspace_id").ok().flatten(),
                     completed_at,
                     result,
                     model,
@@ -1872,17 +2234,17 @@ mod todo_center_tests {
         row.try_get_by_index::<i64>(0).expect("id readable")
     }
 
-    /// 日常视图（get_todos_by_workspace_id）不返回已归档事项。
+    /// 日常视图（get_todos_page_by_workspace）不返回已归档事项。
     /// 这是归档「从日常视图隐藏」语义的落地点。
     #[tokio::test]
     async fn test_get_todos_by_workspace_id_excludes_archived() {
         let db = fresh_db().await;
         let id = seed_todo(&db, "归档项").await;
-        let before = db.get_todos_by_workspace_id(None).await.unwrap();
+        let (before, _) = db.get_todos_page_by_workspace(None, None, 1, 200).await.unwrap();
         assert_eq!(before.len(), 1, "归档前应在日常视图可见");
 
         assert!(db.archive_todo(id).await.unwrap(), "archive 应命中一行");
-        let after = db.get_todos_by_workspace_id(None).await.unwrap();
+        let (after, _) = db.get_todos_page_by_workspace(None, None, 1, 200).await.unwrap();
         assert!(after.is_empty(), "归档后日常视图应隐藏该事项");
     }
 
@@ -1931,12 +2293,16 @@ mod todo_center_tests {
         db.archive_todo(archived_id).await.unwrap();
 
         // 不过滤：应同时含两类
-        let all = db.get_todo_center(None, None, None).await.unwrap();
+        let (all, _, _, _) = db.get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None, bucket: None, search: None, status: None, action_type: None, sort_by: None, sort_desc: true, page: 1, page_size: 200,
+            }).await.unwrap();
         assert_eq!(all.len(), 2, "未过滤应返回全部非软删事项");
 
         // 手动桶
-        let manual = db
-            .get_todo_center(None, Some(ComputedBucket::Manual), None)
+        let (manual, _, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None, bucket: Some(ComputedBucket::Manual), search: None, status: None, action_type: None, sort_by: None, sort_desc: true, page: 1, page_size: 200,
+            })
             .await
             .unwrap();
         assert_eq!(manual.len(), 1);
@@ -1944,8 +2310,10 @@ mod todo_center_tests {
         assert_eq!(manual[0].computed_bucket, ComputedBucket::Manual);
 
         // 已归档桶
-        let archived = db
-            .get_todo_center(None, Some(ComputedBucket::Archived), None)
+        let (archived, _, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None, bucket: Some(ComputedBucket::Archived), search: None, status: None, action_type: None, sort_by: None, sort_desc: true, page: 1, page_size: 200,
+            })
             .await
             .unwrap();
         assert_eq!(archived.len(), 1);
@@ -1970,7 +2338,9 @@ mod todo_center_tests {
         .await
         .expect("insert step");
 
-        let items = db.get_todo_center(None, None, None).await.unwrap();
+        let (items, _, _, _) = db.get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None, bucket: None, search: None, status: None, action_type: None, sort_by: None, sort_desc: true, page: 1, page_size: 200,
+            }).await.unwrap();
         let item = items.iter().find(|i| i.todo.id == id).expect("todo present");
         assert_eq!(item.used_by_loop_step_count, 1, "应聚合到 1 次启用引用");
         assert_eq!(item.computed_bucket, ComputedBucket::LoopDriven);
@@ -1983,14 +2353,20 @@ mod todo_center_tests {
         seed_todo(&db, "修复登录").await;
         seed_todo(&db, "优化prompt").await;
         // 全量应含两条
-        let all = db.get_todo_center(None, None, None).await.unwrap();
+        let (all, _, _, _) = db.get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None, bucket: None, search: None, status: None, action_type: None, sort_by: None, sort_desc: true, page: 1, page_size: 200,
+            }).await.unwrap();
         assert_eq!(all.len(), 2);
         // search="登录" 只命中第一条
-        let hit = db.get_todo_center(None, None, Some("登录")).await.unwrap();
+        let (hit, _, _, _) = db.get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None, bucket: None, search: Some("登录"), status: None, action_type: None, sort_by: None, sort_desc: true, page: 1, page_size: 200,
+            }).await.unwrap();
         assert_eq!(hit.len(), 1);
         assert_eq!(hit[0].todo.title, "修复登录");
         // 大小写不敏感：search="PROMPT" 命中 prompt 子串
-        let hit2 = db.get_todo_center(None, None, Some("PROMPT")).await.unwrap();
+        let (hit2, _, _, _) = db.get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None, bucket: None, search: Some("PROMPT"), status: None, action_type: None, sort_by: None, sort_desc: true, page: 1, page_size: 200,
+            }).await.unwrap();
         assert_eq!(hit2.len(), 1);
         assert_eq!(hit2[0].todo.title, "优化prompt");
     }
@@ -2164,6 +2540,216 @@ mod todo_center_tests {
             // 需求 055 新增字段；build_center_item 用例不关心技能，给空数组即可
             skills: vec![],
         }
+    }
+
+    // ==================== 056：服务端分页与轻量查询测试 ====================
+
+    /// 056 核心防漂移测试：SQL bucket 表达式与 Rust `compute_bucket` 逐条对拍。
+    /// 四种事实字段组合（手动/时间/事件/归档）+ Loop 引用，两侧分类必须一致。
+    #[tokio::test]
+    async fn test_center_bucket_sql_matches_rust() {
+        let db = fresh_db().await;
+        // 手动：无任何标记
+        let manual_id = seed_todo(&db, "纯手动").await;
+        // 时间驱动：scheduler_config 非空
+        let time_id = seed_todo(&db, "时间").await;
+        db.exec(&format!(
+            "UPDATE todos SET scheduler_config = '0 0 9 * * *' WHERE id = {time_id}"
+        ))
+        .await
+        .unwrap();
+        // 事件驱动：webhook_enabled=1
+        let event_id = seed_todo(&db, "事件").await;
+        db.update_todo_webhook(event_id, true).await.unwrap();
+        // 已归档
+        let archived_id = seed_todo(&db, "归档").await;
+        db.archive_todo(archived_id).await.unwrap();
+        // Loop 驱动：启用 loop_step 引用
+        let loop_id = seed_todo(&db, "被环引用").await;
+        db.exec("INSERT INTO loops (name) VALUES ('Lx')").await.unwrap();
+        db.exec(&format!(
+            "INSERT INTO loop_steps (loop_id, name, todo_id, enabled) VALUES (1, 's', {loop_id}, 1)"
+        ))
+        .await
+        .unwrap();
+
+        // SQL 侧：bucket_counts 是 SQL 表达式的直接输出
+        let counts = db
+            .count_todo_center_buckets(&crate::db::TodoCenterPageQuery {
+                workspace_id: None, bucket: None, search: None, status: None, action_type: None,
+                sort_by: None, sort_desc: true, page: 1, page_size: 200,
+            })
+            .await
+            .unwrap();
+        assert_eq!(counts.get("manual"), Some(&1), "manual 计数");
+        assert_eq!(counts.get("time_driven"), Some(&1), "time 计数");
+        assert_eq!(counts.get("event_driven"), Some(&1), "event 计数");
+        assert_eq!(counts.get("archived"), Some(&1), "archived 计数");
+        assert_eq!(counts.get("loop_driven"), Some(&1), "loop 计数");
+
+        // Rust 侧：同一批数据经 build_center_item 推导（聚合来自 DB，同源）
+        let (items, total, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None,
+                bucket: None,
+                search: None,
+                status: None, action_type: None, sort_by: None,
+                sort_desc: true,
+                page: 1,
+                page_size: 200,
+            })
+            .await
+            .unwrap();
+        assert_eq!(total, 5);
+        let rust_bucket = |id: i64| {
+            items
+                .iter()
+                .find(|i| i.todo.id == id)
+                .map(|i| format!("{:?}", i.computed_bucket))
+        };
+        assert_eq!(rust_bucket(manual_id).as_deref(), Some("Manual"));
+        assert_eq!(rust_bucket(time_id).as_deref(), Some("TimeDriven"));
+        assert_eq!(rust_bucket(event_id).as_deref(), Some("EventDriven"));
+        assert_eq!(rust_bucket(archived_id).as_deref(), Some("Archived"));
+        assert_eq!(rust_bucket(loop_id).as_deref(), Some("LoopDriven"));
+    }
+
+    /// 056：分页元数据——page 越界截断、total 与 bucket 过滤一致、counts 不含 bucket 过滤。
+    #[tokio::test]
+    async fn test_center_page_pagination_metadata() {
+        let db = fresh_db().await;
+        for i in 0..5 {
+            seed_todo(&db, &format!("事项{i}")).await;
+        }
+        // page_size=2 时第 3 页只有 1 条，total=5
+        let (items, total, counts, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None,
+                bucket: None,
+                search: None,
+                status: None, action_type: None, sort_by: None,
+                sort_desc: true,
+                page: 3,
+                page_size: 2,
+            })
+            .await
+            .unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(total, 5);
+        assert_eq!(counts.get("manual"), Some(&5));
+        // bucket 过滤后 total 收縮，counts 不受影响（Tab 角标语义）
+        let (items, total, counts, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None,
+                bucket: Some(ComputedBucket::Archived),
+                search: None,
+                status: None, action_type: None, sort_by: None,
+                sort_desc: true,
+                page: 1,
+                page_size: 20,
+            })
+            .await
+            .unwrap();
+        assert!(items.is_empty());
+        assert_eq!(total, 0, "archived 桶为空，total=0");
+        assert_eq!(counts.get("manual"), Some(&5), "counts 不随 bucket 过滤塌缩");
+    }
+
+    /// 056：brief 语义——看板模式（ids=None）隐藏已归档；定点模式（ids=Some）包含已归档。
+    #[tokio::test]
+    async fn test_todo_briefs_archived_semantics() {
+        let db = fresh_db().await;
+        let keep = seed_todo(&db, "保留").await;
+        let gone = seed_todo(&db, "归档").await;
+        db.archive_todo(gone).await.unwrap();
+
+        let kanban = db.get_todo_briefs(None, None, None).await.unwrap();
+        assert!(kanban.iter().any(|b| b.id == keep));
+        assert!(!kanban.iter().any(|b| b.id == gone), "看板模式隐藏已归档");
+
+        let lookup = db.get_todo_briefs(None, Some(&[gone]), None).await.unwrap();
+        assert_eq!(lookup.len(), 1, "定点模式能查到已归档事项的标题");
+        assert_eq!(lookup[0].title, "归档");
+        assert!(lookup[0].archived_at.is_some());
+    }
+
+    /// 056：旧 /todos 分页版——hours 过滤下推 SQL、未归档隐藏、total 正确。
+    #[tokio::test]
+    async fn test_todos_page_by_workspace_hours_and_total() {
+        let db = fresh_db().await;
+        let recent = seed_todo(&db, "最近").await;
+        let old = seed_todo(&db, "老旧").await;
+        // seed_todo 最小列集不带 updated_at（生产由触发器写入），测试显式赋值
+        db.exec(&format!(
+            "UPDATE todos SET updated_at = datetime('now') WHERE id = {recent}"
+        ))
+        .await
+        .unwrap();
+        // 把 old 的 updated_at 改到 10 天前
+        db.exec(&format!(
+            "UPDATE todos SET updated_at = datetime('now', '-240 hours') WHERE id = {old}"
+        ))
+        .await
+        .unwrap();
+        let (items, total) = db
+            .get_todos_page_by_workspace(None, Some(24), 1, 200)
+            .await
+            .unwrap();
+        assert_eq!(total, 1, "hours=24 只留最近一条");
+        assert_eq!(items[0].id, recent);
+
+        let (_, total_all) = db
+            .get_todos_page_by_workspace(None, None, 1, 200)
+            .await
+            .unwrap();
+        assert_eq!(total_all, 2);
+    }
+
+    /// 056：云同步游标分批——批间不漏不重，末批为空终止。
+    #[tokio::test]
+    async fn test_todos_batch_after_id_cursor() {
+        let db = fresh_db().await;
+        let mut seeded = Vec::new();
+        for i in 0..5 {
+            seeded.push(seed_todo(&db, &format!("批{i}")).await);
+        }
+        seeded.sort_unstable();
+        let mut collected = Vec::new();
+        let mut after = 0i64;
+        loop {
+            let batch = db.get_todos_batch_after_id(after, 2).await.unwrap();
+            if batch.is_empty() {
+                break;
+            }
+            after = batch.last().map(|t| t.id).unwrap_or(after);
+            collected.extend(batch.into_iter().map(|t| t.id));
+        }
+        assert_eq!(collected, seeded, "游标分批应不重不漏收齐全部");
+    }
+
+    /// 056：ids/count 轻量接口——不拉行，且隐藏已归档（日常视图片语义）。
+    #[tokio::test]
+    async fn test_todo_ids_and_count_exclude_archived() {
+        let db = fresh_db().await;
+        // ids/count 接口按 ws 过滤，需要一个真实 workspace
+        let ws = db
+            .create_project_directory("/tmp/056-ids", Some("w056"), false, false)
+            .await
+            .unwrap();
+        let keep = seed_todo(&db, "ws内").await;
+        db.exec(&format!("UPDATE todos SET workspace_id = {ws} WHERE id = {keep}"))
+            .await
+            .unwrap();
+        let gone = seed_todo(&db, "ws归档").await;
+        db.exec(&format!("UPDATE todos SET workspace_id = {ws} WHERE id = {gone}"))
+            .await
+            .unwrap();
+        db.archive_todo(gone).await.unwrap();
+        seed_todo(&db, "ws外").await; // 不属于该 ws
+
+        let ids = db.get_todo_ids_by_workspace(ws).await.unwrap();
+        assert_eq!(ids, vec![keep]);
+        assert_eq!(db.count_todos_by_workspace(ws).await.unwrap(), 1);
     }
 }
 

--- a/backend/src/execution_events/metadata.rs
+++ b/backend/src/execution_events/metadata.rs
@@ -72,11 +72,9 @@ impl ExecutionMetadata {
             ExecutionEvent::SessionStart { session_id } => {
                 self.session_id = Some(session_id.clone());
             }
-            ExecutionEvent::SessionEnd { session_id } => {
-                // 如果之前没有设置 session_id，则设置
-                if self.session_id.is_none() {
-                    self.session_id = Some(session_id.clone());
-                }
+            ExecutionEvent::SessionEnd { session_id } if self.session_id.is_none() => {
+                // 仅在之前未设置 session_id 时才回填（SessionStart 优先）
+                self.session_id = Some(session_id.clone());
             }
             ExecutionEvent::ModelSwitch { model } => {
                 self.model = Some(model.clone());

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -298,6 +298,8 @@ pub(crate) async fn handle_cancellation_branch(
         },
     );
     task_manager.remove(task_id).await;
+    // 056：终态落定后主动失效 dashboard 缓存，统计立刻可见
+    crate::handlers::execution::invalidate_dashboard_cache().await;
 }
 
 /// timeout 分支末段：写 DB（failed + 包含超时常量文案） + 发 Output/Finished 事件 + remove task。
@@ -363,6 +365,8 @@ pub(crate) async fn handle_timeout_branch(
         },
     );
     task_manager.remove(task_id).await;
+    // 056：终态落定后主动失效 dashboard 缓存
+    crate::handlers::execution::invalidate_dashboard_cache().await;
 }
 
 /// 正常完成末段：auto-review + finish_todo_execution + 末段事件 + remove task。
@@ -949,6 +953,8 @@ fn emit_completion_events(
             trigger_type,
         },
     );
+    // 056：正常终态落定后主动失效 dashboard 缓存（调用方为 async 上下文，直接 await）
+    tokio::spawn(crate::handlers::execution::invalidate_dashboard_cache());
 }
 
 /// 格式化超时秒数为人类可读字符串。

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -953,7 +953,8 @@ fn emit_completion_events(
             trigger_type,
         },
     );
-    // 056：正常终态落定后主动失效 dashboard 缓存（调用方为 async 上下文，直接 await）
+    // 056：正常终态落定后主动失效 dashboard 缓存。
+    // emit_completion_events 是 sync fn 无法 await，spawn 异步失效（下一拍执行）。
     tokio::spawn(crate::handlers::execution::invalidate_dashboard_cache());
 }
 

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -46,34 +46,25 @@ pub async fn get_execution_records(
                 .map_err(AppError::BadRequest)?
         ),
     };
+    // 056：workspace 过滤下推 SQL（子查询），修复「先分页后内存过滤」导致的
+    // 条数稀释/total 失真。todo_id/step_id 已指定时 ws 隐含，无需再过滤。
+    let ws_filter = if query.todo_id.is_none() && query.step_id.is_none() {
+        query.workspace_id
+    } else {
+        None
+    };
     let (records, total) = state
         .db
         .get_execution_records(crate::db::execution::ExecutionRecordQuery {
             todo_id: query.todo_id,
             step_id: query.step_id,
+            workspace_id: ws_filter,
             limit,
             offset,
             status,
             hours: query.hours,
         })
         .await?;
-
-    // 当提供了 todo_id 或 step_id 时，workspace_id 是隐含的（由 todo 决定）。
-    // 仅在 todo_id/step_id 都为空且 workspace_id 有值时过滤——目前没有调用方
-    // 走这个分支，但保持接口一致性，传了就能用。
-    let records = if let Some(wid) = query.workspace_id {
-        if query.todo_id.is_none() && query.step_id.is_none() {
-            // ? 传播 DbErr：旧实现 unwrap_or_default() 会把 DB 读失败静默当成空 Vec，
-            // 下游 filter 把所有 record 过滤掉、返回 200+0 条，调用方无法区分真空还是 DB 挂了。
-            let ws_todos = state.db.get_todos_by_workspace_id(Some(wid)).await?;
-            let ws_todo_ids: std::collections::HashSet<i64> = ws_todos.iter().map(|t| t.id).collect();
-            records.into_iter().filter(|r| ws_todo_ids.contains(&r.todo_id)).collect()
-        } else {
-            records
-        }
-    } else {
-        records
-    };
 
     Ok(ApiResponse::ok(ExecutionRecordsPage {
         records,
@@ -182,18 +173,11 @@ pub async fn get_execution_records_by_session(
     State(state): State<AppState>,
     Path((ws_id, session_id)): Path<(i64, String)>,
 ) -> Result<ApiResponse<Vec<crate::models::ExecutionRecord>>, AppError> {
+    // 056：workspace 过滤下推 SQL（V1 隔离：同一 session 可能含跨 ws 记录，只留本 ws）
     let records = state
         .db
-        .get_execution_records_by_session(&session_id)
+        .get_execution_records_by_session(&session_id, Some(ws_id))
         .await?;
-    // V1 隔离：同一 session 可能含跨 ws 的记录，按 workspace 过滤只保留本 ws 的
-    let ws_todos = state.db.get_todos_by_workspace_id(Some(ws_id)).await?;
-    let ws_todo_ids: std::collections::HashSet<i64> =
-        ws_todos.iter().map(|t| t.id).collect();
-    let records: Vec<_> = records
-        .into_iter()
-        .filter(|r| ws_todo_ids.contains(&r.todo_id))
-        .collect();
     Ok(ApiResponse::ok(records))
 }
 
@@ -358,14 +342,8 @@ pub async fn get_running_execution_records_handler(
     State(state): State<AppState>,
     Path(ws_id): Path<i64>,
 ) -> Result<ApiResponse<Vec<crate::models::ExecutionRecord>>, AppError> {
-    // V1 隔离：按 workspace 过滤正在运行的执行记录（经 todo 间接关联）
-    let records = state.db.get_running_execution_records().await?;
-    let ws_todos = state.db.get_todos_by_workspace_id(Some(ws_id)).await?;
-    let ws_todo_ids: std::collections::HashSet<i64> = ws_todos.iter().map(|t| t.id).collect();
-    let records: Vec<_> = records
-        .into_iter()
-        .filter(|r| ws_todo_ids.contains(&r.todo_id))
-        .collect();
+    // 056：workspace 过滤下推 SQL（V1 隔离：经 todo 子查询关联）
+    let records = state.db.get_running_execution_records(Some(ws_id)).await?;
     Ok(ApiResponse::ok(records))
 }
 
@@ -393,31 +371,19 @@ pub async fn get_running_board(
     let limit = query.limit.unwrap_or(50).clamp(1, 200);
     let offset = (page - 1) * limit;
 
+    // 056：workspace 过滤下推 SQL，total 与过滤后数据同源，分页元数据不再失真
     let (records, total) = state
         .db
         .get_execution_records(crate::db::execution::ExecutionRecordQuery {
             todo_id: None,
             step_id: None,
+            workspace_id: query.workspace_id,
             limit,
             offset,
             status: None,
             hours: query.hours,
         })
         .await?;
-
-    // 按 workspace_id 过滤 execution records（表本身无 workspace_id，
-    // 需通过 todos 表关联过滤）。一次查出该 workspace 下所有 todo_ids，
-    // 构建 Hashset 后在内存中过滤。
-    let records = if let Some(wid) = query.workspace_id {
-        // 用 ? 传播 DbErr：旧实现 unwrap_or_default() 会把 DB 读失败（SQLite locked/IO）
-        // 静默当成「空工作空间」，下游 filter 把所有 record 过滤掉、返回 200+0 条，
-        // 调用方无法区分真空还是 DB 挂了。改为传播错误让请求返回 5xx。
-        let ws_todos = state.db.get_todos_by_workspace_id(Some(wid)).await?;
-        let ws_todo_ids: std::collections::HashSet<i64> = ws_todos.iter().map(|t| t.id).collect();
-        records.into_iter().filter(|r| ws_todo_ids.contains(&r.todo_id)).collect()
-    } else {
-        records
-    };
 
     let scheduled_todos = state.db.get_scheduler_todos(query.workspace_id).await?;
 
@@ -461,6 +427,8 @@ pub async fn force_fail_execution_handler(
         .force_fail_execution_record(record_id)
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
+    // 056：强制失败也是终态落定，主动失效 dashboard 缓存
+    invalidate_dashboard_cache().await;
     Ok(ApiResponse::ok(()))
 }
 
@@ -618,6 +586,10 @@ struct DashboardCacheEntry {
 static DASHBOARD_CACHE: LazyLock<RwLock<HashMap<(i64, u32), DashboardCacheEntry>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
+/// 056：单飞锁——并发过期刷新只放行一个，其余等锁后走双重检查命中。
+static DASHBOARD_REFRESH_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
+
 pub async fn get_dashboard_stats(
     State(state): State<AppState>,
     // Dashboard 为全局运营视图，路由注册在 /api/v1/stats/dashboard（无 workspace 路径参数），
@@ -628,27 +600,62 @@ pub async fn get_dashboard_stats(
     // Dashboard 为全局运营视图，缓存键仅按时间窗口区分
     let cache_key = (0i64, hours_key);
 
-    {
-        let cache = DASHBOARD_CACHE.read().await;
-        if let Some(entry) = cache.get(&cache_key) {
-            if entry.expires_at > StdInstant::now() {
-                return Ok(ApiResponse::ok(entry.stats.clone()));
+    // 快路径：未过期直接命中
+    if let Some(stats) = dashboard_cache_get_fresh(cache_key).await {
+        return Ok(ApiResponse::ok(stats));
+    }
+
+    // 056：过期/miss 走单飞刷新——并发请求只放行一个去算全量聚合，
+    // 其余在锁上等结果（双重检查），避免 N 个请求同时打 20 条全表聚合 SQL。
+    let _permit = DASHBOARD_REFRESH_LOCK.lock().await;
+
+    // 双重检查：等锁期间可能已有并发请求完成刷新
+    if let Some(stats) = dashboard_cache_get_fresh(cache_key).await {
+        return Ok(ApiResponse::ok(stats));
+    }
+    // 取旧值备用：刷新失败时 stale-while-revalidate，返旧值比 5xx 更有用
+    let stale = DASHBOARD_CACHE.read().await.get(&cache_key).map(|e| e.stats.clone());
+
+    // Dashboard 聚合全库数据，作为全局运营视图；不再按 workspace 隔离。
+    match state.db.get_dashboard_stats(params.hours).await {
+        Ok(stats) => {
+            DASHBOARD_CACHE.write().await.insert(cache_key, DashboardCacheEntry {
+                stats: stats.clone(),
+                expires_at: StdInstant::now() + Duration::from_secs(30),
+            });
+            Ok(ApiResponse::ok(stats))
+        }
+        Err(e) => {
+            if let Some(stale) = stale {
+                // 返旧值并续短 TTL：DB 抖动期间防止每个请求都穿透重试
+                tracing::warn!("dashboard 聚合失败，返回过期缓存: {e}");
+                DASHBOARD_CACHE.write().await.insert(cache_key, DashboardCacheEntry {
+                    stats: stale.clone(),
+                    expires_at: StdInstant::now() + Duration::from_secs(5),
+                });
+                Ok(ApiResponse::ok(stale))
+            } else {
+                Err(AppError::from_db_err(e))
             }
         }
     }
+}
 
-    // Dashboard 聚合全库数据，作为全局运营视图；不再按 workspace 隔离。
-    let stats = state.db.get_dashboard_stats(params.hours).await?;
-
-    {
-        let mut cache = DASHBOARD_CACHE.write().await;
-        cache.insert(cache_key, DashboardCacheEntry {
-            stats: stats.clone(),
-            expires_at: StdInstant::now() + Duration::from_secs(30),
-        });
+/// 读取未过期的缓存项（快路径抽函数，保持 handler 与单飞段都 <30 行）。
+async fn dashboard_cache_get_fresh(key: (i64, u32)) -> Option<DashboardStats> {
+    let cache = DASHBOARD_CACHE.read().await;
+    let entry = cache.get(&key)?;
+    if entry.expires_at > StdInstant::now() {
+        Some(entry.stats.clone())
+    } else {
+        None
     }
+}
 
-    Ok(ApiResponse::ok(stats))
+/// 056：执行状态落定（成功/失败/取消/强制失败）时主动失效 dashboard 缓存，
+/// 用户跑完任务立刻看到最新统计，不必等 30s TTL。
+pub(crate) async fn invalidate_dashboard_cache() {
+    DASHBOARD_CACHE.write().await.clear();
 }
 
 #[derive(Deserialize)]
@@ -818,29 +825,22 @@ pub async fn v1_get_execution_records(
                 .map_err(AppError::BadRequest)?
         ),
     };
+    // 056：workspace 过滤下推 SQL；todo_id 显式传入时仍先校验归属（403 语义）
+    if let Some(todo_id) = query.todo_id {
+        workspace_guard::verify_todo_belongs_to_ws(&state.db, todo_id, ws_id).await?;
+    }
     let (records, total) = state
         .db
         .get_execution_records(crate::db::execution::ExecutionRecordQuery {
             todo_id: query.todo_id,
             step_id: query.step_id,
+            workspace_id: Some(ws_id),
             limit,
             offset,
             status,
             hours: query.hours,
         })
         .await?;
-
-    // V1 隔离：workspace_id 来自 URL Path。即使带 todo_id 也要校验其归属本 ws，
-    // 否则 ?todo_id=<他人 todo> 可越权读他人执行记录。返回结果一律按 ws 过滤。
-    if let Some(todo_id) = query.todo_id {
-        workspace_guard::verify_todo_belongs_to_ws(&state.db, todo_id, ws_id).await?;
-    }
-    let ws_todos = state.db.get_todos_by_workspace_id(Some(ws_id)).await?;
-    let ws_todo_ids: std::collections::HashSet<i64> = ws_todos.iter().map(|t| t.id).collect();
-    let records: Vec<_> = records
-        .into_iter()
-        .filter(|r| ws_todo_ids.contains(&r.todo_id))
-        .collect();
 
     Ok(ApiResponse::ok(ExecutionRecordsPage {
         records,
@@ -860,22 +860,19 @@ pub async fn v1_get_running_board(
     let limit = query.limit.unwrap_or(50).clamp(1, 200);
     let offset = (page - 1) * limit;
 
+    // 056：workspace 过滤下推 SQL（v1 路径 ws 来自 Path，强制过滤）
     let (records, total) = state
         .db
         .get_execution_records(crate::db::execution::ExecutionRecordQuery {
             todo_id: None,
             step_id: None,
+            workspace_id: Some(ws_id),
             limit,
             offset,
             status: None,
             hours: query.hours,
         })
         .await?;
-
-    // v1 路径下 workspace_id 始终来自 Path，强制按工作空间过滤
-    let ws_todos = state.db.get_todos_by_workspace_id(Some(ws_id)).await?;
-    let ws_todo_ids: std::collections::HashSet<i64> = ws_todos.iter().map(|t| t.id).collect();
-    let records = records.into_iter().filter(|r| ws_todo_ids.contains(&r.todo_id)).collect();
 
     // v1 路径下使用 Path 中的 workspace_id 查询定时任务
     let scheduled_todos = state.db.get_scheduler_todos(Some(ws_id)).await?;

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -171,13 +171,30 @@ pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade)
         // 批量获取执行记录，避免 N+1 查询
         let mut running_tasks = state.task_manager.get_all_task_infos().await;
         let task_ids: Vec<String> = running_tasks.iter().map(|t| t.task_id.clone()).collect();
-        let records = state.db.get_execution_records_by_task_ids(&task_ids).await.unwrap_or_default();
+        // 056：WS 升级已完成无法回 HTTP 错误，DB 失败时记 error 日志后降级为空
+        // （调用方至少能区分「无运行任务」与「日志缺失」——服务端日志可查）。
+        // 原 unwrap_or_default() 静默吞错，故障排查时无法定位。
+        let records = state
+            .db
+            .get_execution_records_by_task_ids(&task_ids)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::error!("[ws-events] 查询执行记录失败，Sync 降级为空记录: {e}");
+                Vec::new()
+            });
         let record_map: std::collections::HashMap<String, _> = records
             .into_iter()
             .filter_map(|r| r.task_id.clone().map(|tid| (tid, r)))
             .collect();
         let record_ids: Vec<i64> = record_map.values().map(|r| r.id).collect();
-        let logs_map = state.db.get_all_execution_logs_for_records(&record_ids).await.unwrap_or_default();
+        let logs_map = state
+            .db
+            .get_all_execution_logs_for_records(&record_ids)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::error!("[ws-events] 查询执行日志失败，Sync 降级为空日志: {e}");
+                std::collections::HashMap::new()
+            });
         for task in &mut running_tasks {
             if let Some(record) = record_map.get(&task.task_id) {
                 let logs = logs_map.get(&record.id).cloned().unwrap_or_default();

--- a/backend/src/handlers/session.rs
+++ b/backend/src/handlers/session.rs
@@ -798,10 +798,8 @@ fn parse_pi_line(line: &str) -> Option<(String, serde_json::Value)> {
 fn apply_pi_event(summary: &mut PiSessionSummary, event_type: &str, v: &serde_json::Value) {
     match event_type {
         "session" => apply_pi_session_event(summary, v),
-        "model_change" => {
-            if summary.model.is_none() {
-                summary.model = pi_model_from_change_event(v);
-            }
+        "model_change" if summary.model.is_none() => {
+            summary.model = pi_model_from_change_event(v);
         }
         "message" => {
             // 跳过缺 message 字段的行(防御性,与原 match Some(m) 行为一致)

--- a/backend/src/handlers/sync.rs
+++ b/backend/src/handlers/sync.rs
@@ -285,12 +285,8 @@ async fn merge_cloud_todos_to_local(
     conflict_mode: &str,
 ) -> Result<i64, String> {
     let mut affected = 0i64;
-    let local_todos = db.get_todos().await.map_err(|e| e.to_string())?;
-    // 用 title 作为冲突判断键（小写比较避免大小写差异）
-    let local_by_title: HashMap<String, i64> = local_todos
-        .iter()
-        .map(|t| (t.title.trim().to_lowercase(), t.id))
-        .collect();
+    // 056：只取 id+title 两列建映射，替代整行全量拉取（合并冲突判断只需要 title→id）
+    let local_by_title = db.get_todo_title_id_map().await.map_err(|e| e.to_string())?;
 
     for item in cloud_todos {
         let title = item.title.trim();
@@ -497,10 +493,21 @@ pub async fn cloud_sync_push(
         (server_url, token, conflict_mode)
     };
 
-    // 获取本地 todos
-    let todos = state.db.get_todos().await.map_err(|e| {
-        AppError::Internal(format!("获取本地 todos 失败: {}", e))
-    })?;
+    // 获取本地 todos（056：id 游标分批拉取，每批 500，避免一次性全表载入）
+    let mut todos = Vec::new();
+    let mut after_id = 0i64;
+    loop {
+        let batch = state
+            .db
+            .get_todos_batch_after_id(after_id, 500)
+            .await
+            .map_err(|e| AppError::Internal(format!("获取本地 todos 失败: {}", e)))?;
+        if batch.is_empty() {
+            break;
+        }
+        after_id = batch.last().map(|t| t.id).unwrap_or(after_id);
+        todos.extend(batch);
+    }
 
     // 获取标签映射
     let tags = state.db.get_tags().await.map_err(|e| {

--- a/backend/src/handlers/tasks.rs
+++ b/backend/src/handlers/tasks.rs
@@ -234,7 +234,9 @@ pub async fn get_artifact_content(
     State(state): State<AppState>, Path(aid): Path<i64>,
 ) -> Result<impl axum::response::IntoResponse, AppError> {
     let artifact = state.db.get_loop_step_artifact(aid).await?.ok_or(AppError::NotFound)?;
-    let ws_path = resolve_artifact_workspace(&state.db, &artifact).await.unwrap_or_default();
+    // 056：workspace 解析失败必须传播——空路径会继续走到 read_workspace_file
+    // 产生误导性错误（读到错误位置或报「文件不存在」），掩盖真实的 DB 故障。
+    let ws_path = resolve_artifact_workspace(&state.db, &artifact).await?;
     let content = if artifact.artifact_type == "file" {
         read_workspace_file(&ws_path, &artifact.locator).await
     } else {

--- a/backend/src/handlers/todo.rs
+++ b/backend/src/handlers/todo.rs
@@ -628,16 +628,49 @@ pub struct TodoListQueryV1 {
     /// 按最近 N 小时过滤（对 updated_at 生效）；不传或 0 表示不过滤
     #[serde(default)]
     pub hours: Option<u32>,
+    /// 页码（1 起）。056 起本接口强制服务端分页，默认 1
+    #[serde(default)]
+    pub page: Option<i64>,
+    /// 每页条数（1-200，越界截断）。默认 50
+    #[serde(default)]
+    pub page_size: Option<i64>,
 }
 
 /// V1 事项中心查询参数（workspace_id 来自路径而非查询参数）。
 /// bucket 为空或非法时返回全部分类；search 为标题/prompt 子串过滤。
+/// 056 起支持服务端分页与排序；不传 page 时默认第 1 页。
 #[derive(Debug, serde::Deserialize)]
 pub struct TodoCenterQueryV1 {
     #[serde(default)]
     pub bucket: Option<String>,
     #[serde(default)]
     pub search: Option<String>,
+    #[serde(default)]
+    pub page: Option<i64>,
+    #[serde(default)]
+    pub page_size: Option<i64>,
+    /// 排序字段白名单：id(默认)/updated_at/title/status/computed_bucket
+    #[serde(default)]
+    pub sort_by: Option<String>,
+    /// asc / desc（默认 desc）
+    #[serde(default)]
+    pub sort_order: Option<String>,
+    /// 状态精确过滤（卡片墙「状态筛选」下拉；缺省=全部）
+    #[serde(default)]
+    pub status: Option<String>,
+    /// 动作类型精确过滤（卡片墙「来源筛选」下拉；缺省=全部）
+    #[serde(default)]
+    pub action_type: Option<String>,
+}
+
+/// V1 事项 brief 查询参数：ids 逗号分隔；省略时返回该 ws 全部 brief（看板用）。
+#[derive(Debug, serde::Deserialize)]
+pub struct TodoBriefQueryV1 {
+    #[serde(default)]
+    pub ids: Option<String>,
+    /// 按最近 N 小时过滤（对 updated_at 生效）；不传或 0 表示不过滤
+    #[serde(default)]
+    pub hours: Option<u32>,
 }
 
 /// V1 最近已完成事项查询参数（workspace_id 来自路径而非查询参数）
@@ -652,38 +685,101 @@ pub struct RecentCompletedParamsV1 {
 // ======================================================================
 
 /// V1: 从路径参数获取 workspace_id 后查询事项列表。
-/// 与 `get_todos` 的区别在于 workspace_id 来自 Path 而非 Query。
+/// 056（决策 3b）：响应从全量 Vec<Todo> 改为强制分页 TodoListPage，
+/// hours 过滤同时从内存下推 SQL——CLI 已同步适配该结构。
 pub async fn get_todos_v1(
     State(state): State<AppState>,
     Path(ws_id): Path<i64>,
     axum::extract::Query(params): axum::extract::Query<TodoListQueryV1>,
-) -> Result<ApiResponse<Vec<Todo>>, AppError> {
-    // 工作空间由路径参数确定，无需再从查询参数中提取
-    let todos = state.db.get_todos_by_workspace_id(Some(ws_id)).await?;
-    // 按 hours 过滤：只保留在最近 N 小时内更新过的 todo
-    let todos = if let Some(h) = params.hours.filter(|&h| h > 0) {
-        let cutoff = chrono::Utc::now() - chrono::Duration::hours(h as i64);
-        let cutoff_str = cutoff.format("%Y-%m-%dT%H:%M:%S").to_string();
-        todos.into_iter().filter(|t| t.updated_at >= cutoff_str).collect()
-    } else {
-        todos
-    };
-    Ok(ApiResponse::ok(todos))
+) -> Result<ApiResponse<crate::models::TodoListPage>, AppError> {
+    let page = params.page.unwrap_or(1).max(1);
+    let page_size = params.page_size.unwrap_or(50).clamp(1, 200);
+    let (items, total) = state
+        .db
+        .get_todos_page_by_workspace(Some(ws_id), params.hours, page, page_size)
+        .await?;
+    Ok(ApiResponse::ok(crate::models::TodoListPage {
+        items,
+        total,
+        page,
+        page_size,
+    }))
+}
+
+/// V1: 工作空间内全部 todo id（056 轻量接口，替代「全表拉取取 id」）。
+pub async fn get_todo_ids_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+) -> Result<ApiResponse<Vec<i64>>, AppError> {
+    let ids = state.db.get_todo_ids_by_workspace(ws_id).await?;
+    Ok(ApiResponse::ok(ids))
+}
+
+/// V1: 工作空间内 todo 计数（056 轻量接口，替代「全表拉取取 length」）。
+pub async fn get_todo_count_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+) -> Result<ApiResponse<serde_json::Value>, AppError> {
+    let count = state.db.count_todos_by_workspace(ws_id).await?;
+    Ok(ApiResponse::ok(serde_json::json!({ "count": count })))
+}
+
+/// V1: 事项轻量摘要（056）。ids 省略时返回该 ws 全部 brief（看板全量渲染用，
+/// 传输量约为整行 Todo 的 1/10）；指定 ids 时按给定集合返回。
+pub async fn get_todo_briefs_v1(
+    State(state): State<AppState>,
+    Path(ws_id): Path<i64>,
+    axum::extract::Query(params): axum::extract::Query<TodoBriefQueryV1>,
+) -> Result<ApiResponse<Vec<crate::models::TodoBrief>>, AppError> {
+    // ids 逗号分隔解析：非法段直接丢弃（宽容策略，与 bucket 非法=不过滤一致）
+    let ids: Option<Vec<i64>> = params.ids.as_deref().map(|s| {
+        s.split(',')
+            .filter_map(|seg| seg.trim().parse::<i64>().ok())
+            .collect()
+    });
+    let briefs = state
+        .db
+        .get_todo_briefs(Some(ws_id), ids.as_deref(), params.hours)
+        .await?;
+    Ok(ApiResponse::ok(briefs))
 }
 
 /// V1: 从路径参数获取 workspace_id 后查询事项中心。
-/// 与 `get_todo_center` 的区别在于 workspace_id 来自 Path 而非 Query。
+/// 056：分桶/搜索/排序/分页全部下推 SQL，响应带 total 与 bucket_counts。
 pub async fn get_todo_center_v1(
     State(state): State<AppState>,
     Path(ws_id): Path<i64>,
     axum::extract::Query(params): axum::extract::Query<TodoCenterQueryV1>,
-) -> Result<ApiResponse<Vec<TodoCenterItem>>, AppError> {
+) -> Result<ApiResponse<crate::models::TodoCenterPage>, AppError> {
     // 解析 bucket 串为枚举；空/非法 → None = 不过滤
     let bucket = params.bucket.as_deref().and_then(ComputedBucket::parse_query);
     let search = params.search.as_deref().map(str::trim).filter(|s| !s.is_empty());
-    // 工作空间由路径参数提供，替代原来的 params.workspace_id
-    let items = state.db.get_todo_center(Some(ws_id), bucket, search).await?;
-    Ok(ApiResponse::ok(items))
+    let page = params.page.unwrap_or(1).max(1);
+    let page_size = params.page_size.unwrap_or(20).clamp(1, 200);
+    // 排序方向仅识别 asc，其余一律 desc（白名单，防注入）
+    let sort_desc = !matches!(params.sort_order.as_deref(), Some("asc"));
+    let (items, total, bucket_counts, action_types) = state
+        .db
+        .get_todo_center_page(crate::db::TodoCenterPageQuery {
+            workspace_id: Some(ws_id),
+            bucket,
+            search,
+            status: params.status.as_deref(),
+            action_type: params.action_type.as_deref(),
+            sort_by: params.sort_by.as_deref(),
+            sort_desc,
+            page,
+            page_size,
+        })
+        .await?;
+    Ok(ApiResponse::ok(crate::models::TodoCenterPage {
+        items,
+        total,
+        page,
+        page_size,
+        bucket_counts,
+        action_types,
+    }))
 }
 
 /// V1: 从路径参数获取 workspace_id 后创建事项。
@@ -808,6 +904,10 @@ pub fn v1_routes() -> Router<AppState> {
         .route("/smart", post(super::execution::v1_smart_create_handler))
         // 事项中心（驱动视图五分类）
         .route("/center", get(get_todo_center_v1))
+        // 056 轻量接口：ids / count / brief（静态段，axum 优先于 /{id} 匹配）
+        .route("/ids", get(get_todo_ids_v1))
+        .route("/count", get(get_todo_count_v1))
+        .route("/brief", get(get_todo_briefs_v1))
         // 最近已完成事项
         .route("/recent-completed", get(get_recent_completed_todos_v1))
         // 按 id 的子路由（必须在 /{id} 之前注册，避免 axum 把子路径如 "archive" 当作 id 捕获）

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -264,6 +264,56 @@ pub struct TodoCenterItem {
     pub bound_slash_command: Option<String>,
 }
 
+/// 事项中心服务端分页响应（056）。
+///
+/// `bucket_counts` 供前端分类 Tab 角标：统计口径=应用 search 后、应用 bucket 过滤前，
+/// 与「分页前完成分桶」的旧内存实现语义一致。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TodoCenterPage {
+    pub items: Vec<TodoCenterItem>,
+    pub total: i64,
+    pub page: i64,
+    pub page_size: i64,
+    pub bucket_counts: std::collections::HashMap<String, i64>,
+    /// 当前工作空间内出现过的 action_type 去重列表（卡片墙「来源筛选」下拉数据源）
+    #[serde(default)]
+    pub action_types: Vec<String>,
+}
+
+/// 事项轻量摘要（056）：不含 prompt/acceptance_criteria 大文本字段。
+///
+/// 供看板全量渲染、下拉选择、记录详情补标题等「只需要展示字段」的场景，
+/// 替代过去「整行 Todo 全量拉取」的做法。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TodoBrief {
+    pub id: i64,
+    pub title: String,
+    pub status: TodoStatus,
+    #[serde(default)]
+    pub executor: Option<String>,
+    pub updated_at: String,
+    #[serde(default)]
+    pub archived_at: Option<String>,
+    /// 所属工作空间（拖拽/归属展示用，小字段）
+    #[serde(default)]
+    pub workspace_id: Option<i64>,
+    /// 标签 id 列表（看板标签徽章用；批量查询补算，不逐行 N+1）
+    #[serde(default)]
+    pub tag_ids: Vec<i64>,
+    /// prompt 是否非空（看板「展开 prompt」区块的显示开关，不必传输 prompt 本体）
+    #[serde(default)]
+    pub has_prompt: bool,
+}
+
+/// 事项列表分页响应（056，旧全量接口改造后的统一结构）。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TodoListPage {
+    pub items: Vec<Todo>,
+    pub total: i64,
+    pub page: i64,
+    pub page_size: i64,
+}
+
 /// Loop 引用摘要：事项中心展示「所属环路」与「工艺」两列共用。
 /// - loop_id/loop_name：引用该事项的环路实例。
 /// - process_template_*：该环路所基于的工艺模板（loops.process_template_id → process_templates），
@@ -832,6 +882,9 @@ pub struct RecentCompletedTodo {
     pub prompt: Option<String>,
     pub executor: Option<String>,
     pub tag_ids: Vec<i64>,
+    /// 所属工作空间（056 补充：纪念板据此反查项目名，免去前端按 id 二次查询）
+    #[serde(default)]
+    pub workspace_id: Option<i64>,
     pub completed_at: String,
     pub result: Option<String>,
     pub model: Option<String>,

--- a/backend/src/services/auto_update.rs
+++ b/backend/src/services/auto_update.rs
@@ -181,16 +181,16 @@ fn compute_next_check_time(interval: &str, hour: u32) -> chrono::DateTime<chrono
 fn resolve_local_datetime(
     dt: chrono::NaiveDateTime,
 ) -> chrono::DateTime<chrono::Local> {
-    use chrono::{Local, TimeZone};
+    use chrono::Local;
     match dt.and_local_timezone(Local) {
         chrono::LocalResult::Single(t) => t,
         chrono::LocalResult::Ambiguous(earlier, _) => earlier,
         chrono::LocalResult::None => (dt + chrono::Duration::hours(1))
             .and_local_timezone(Local)
             .single()
-            .unwrap_or_else(|| {
-                Local.from_local_datetime(&dt).single().unwrap_or_else(Local::now)
-            }),
+            // dt+1h 仍落不进本地时间（理论上连续两次切换）时兜底当前时间，
+            // sleep 逻辑会自然修正到下一轮检查点。
+            .unwrap_or_else(Local::now),
     }
 }
 

--- a/backend/src/services/auto_update.rs
+++ b/backend/src/services/auto_update.rs
@@ -143,7 +143,7 @@ fn compute_next_check_time(interval: &str, hour: u32) -> chrono::DateTime<chrono
                 Weekday::Sun => 1,
             };
             let date = now.date_naive() + Duration::days(days_until_monday);
-            date.and_time(time).and_local_timezone(Local).unwrap()
+            resolve_local_datetime(date.and_time(time))
         }
         "month" => {
             // 下一个月 1 号的指定小时
@@ -157,17 +157,40 @@ fn compute_next_check_time(interval: &str, hour: u32) -> chrono::DateTime<chrono
                     // fallback: 用当前日期 + 30 天
                     now.date_naive() + Duration::days(30)
                 });
-            date.and_time(time).and_local_timezone(Local).unwrap()
+            resolve_local_datetime(date.and_time(time))
         }
         _ => {
             // "day" 或其他值：下一个指定小时
-            let today = now.date_naive().and_time(time).and_local_timezone(Local).unwrap();
+            let today = resolve_local_datetime(now.date_naive().and_time(time));
             if now >= today {
                 today + Duration::days(1)
             } else {
                 today
             }
         }
+    }
+}
+
+/// 把 naive 本地时间安全映射到 Local（056 修复：原 `.unwrap()` 在夏令时切换日 panic）。
+///
+/// 三种情况：
+/// - Single：正常映射；
+/// - Ambiguous（秋令时回拨，该时刻出现两次）：取较早一次，避免跳过当天的检查；
+/// - None（春令时前跳，该时刻不存在）：顺延 1 小时重试，仍失败兜底为当前时间
+///   （此时段检查后 sleep 逻辑会自然修正到下一轮）。
+fn resolve_local_datetime(
+    dt: chrono::NaiveDateTime,
+) -> chrono::DateTime<chrono::Local> {
+    use chrono::{Local, TimeZone};
+    match dt.and_local_timezone(Local) {
+        chrono::LocalResult::Single(t) => t,
+        chrono::LocalResult::Ambiguous(earlier, _) => earlier,
+        chrono::LocalResult::None => (dt + chrono::Duration::hours(1))
+            .and_local_timezone(Local)
+            .single()
+            .unwrap_or_else(|| {
+                Local.from_local_datetime(&dt).single().unwrap_or_else(Local::now)
+            }),
     }
 }
 
@@ -424,5 +447,50 @@ mod tests {
         let next = compute_next_check_time("month", 3);
         assert_eq!(next.day(), 1);
         assert_eq!(next.hour(), 3);
+    }
+
+    /// 056：resolve_local_datetime 三个分支（正常/歧义/不存在）均不 panic。
+    /// 夏令时切换日是原 `.unwrap()` 的 panic 场景，这里用固定时区构造等价输入。
+    #[test]
+    fn test_resolve_local_datetime_normal_time() {
+        // 普通时刻：能唯一映射，且时分与输入一致
+        let dt = chrono::NaiveDate::from_ymd_opt(2026, 6, 15)
+            .unwrap()
+            .and_hms_opt(3, 30, 0)
+            .unwrap();
+        let resolved = resolve_local_datetime(dt);
+        // 不 panic 即主要断言；时刻字段应保留
+        assert_eq!(resolved.hour(), 3);
+        assert_eq!(resolved.minute(), 30);
+    }
+
+    #[test]
+    fn test_resolve_local_datetime_nonexistent_time_falls_forward() {
+        // 春令时前跳时刻（美国东部 2026-03-08 02:30 不存在）。
+        // 本机时区未必有 DST，但 None 分支代码路径必须不 panic 且返回有效时间。
+        let dt = chrono::NaiveDate::from_ymd_opt(2026, 3, 8)
+            .unwrap()
+            .and_hms_opt(2, 30, 0)
+            .unwrap();
+        let resolved = resolve_local_datetime(dt);
+        // 无论本机时区是否有 DST，结果必须是不晚于 dt+2h 的有效时间
+        let upper = (dt + chrono::Duration::hours(2))
+            .and_local_timezone(chrono::Local)
+            .single();
+        if let Some(upper) = upper {
+            assert!(resolved <= upper);
+        }
+    }
+
+    #[test]
+    fn test_resolve_local_datetime_ambiguous_time_picks_earlier() {
+        // 秋令时回拨时刻（美国东部 2026-11-01 01:30 出现两次）。
+        // 函数应取较早一次；本机无 DST 时走 Single 分支，同样不 panic。
+        let dt = chrono::NaiveDate::from_ymd_opt(2026, 11, 1)
+            .unwrap()
+            .and_hms_opt(1, 30, 0)
+            .unwrap();
+        let resolved = resolve_local_datetime(dt);
+        assert_eq!(resolved.minute(), 30);
     }
 }

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -1851,12 +1851,16 @@ impl FeishuListener {
         let todos = match wid {
             Some(id) => db
                 // 056：卡片只展示最近 20 条摘要（id+标题+状态图标），
-                // 用 brief 接口替代整行全量拉取；take(20) 截断保持卡片体积
+                // 用 brief 接口替代整行全量拉取；take(20) 截断保持卡片体积。
+                // DB 失败时记 error（含 bot/ws 上下文）后降级为空列表——
+                // 卡片缺区块可接受，但静默吞错会让故障无法定位（CodeRabbit#4）。
                 .get_todo_briefs(Some(id), None, None)
                 .await
-                .ok()
                 .map(|ts| ts.into_iter().take(20).map(Self::brief_to_item).collect())
-                .unwrap_or_default(),
+                .unwrap_or_else(|e| {
+                    tracing::error!("飞书卡片加载 todo 摘要失败（bot={bot_id}, ws={id}）: {e}");
+                    Vec::new()
+                }),
             None => vec![],
         };
         let loops = match wid {

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -1850,10 +1850,12 @@ impl FeishuListener {
         let (recent_records, is_running) = Self::recent_records_and_running(db, wid).await;
         let todos = match wid {
             Some(id) => db
-                .get_todos_by_workspace_id(Some(id))
+                // 056：卡片只展示最近 20 条摘要（id+标题+状态图标），
+                // 用 brief 接口替代整行全量拉取；take(20) 截断保持卡片体积
+                .get_todo_briefs(Some(id), None, None)
                 .await
                 .ok()
-                .map(|ts| ts.into_iter().map(Self::todo_to_item).collect())
+                .map(|ts| ts.into_iter().take(20).map(Self::brief_to_item).collect())
                 .unwrap_or_default(),
             None => vec![],
         };
@@ -1931,7 +1933,8 @@ impl FeishuListener {
     }
 
     /// Todo → 事项页列表项。
-    fn todo_to_item(t: crate::models::Todo) -> TodoItem {
+    /// TodoBrief → 卡片「事项列表」项（056：摘要字段足够拼状态图标，无需整行 Todo）。
+    fn brief_to_item(t: crate::models::TodoBrief) -> TodoItem {
         use crate::models::TodoStatus;
         let status_icon = match t.status {
             TodoStatus::Completed => "✅",

--- a/backend/src/services/process/guid.rs
+++ b/backend/src/services/process/guid.rs
@@ -79,6 +79,32 @@ pub fn new_guid() -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
+/// 插入 guid 的增强版（056）：先行级插入（保格式），失败后退化 serde 往返。
+///
+/// 背景：行级插入只认 block 风格 `process:` + 2 空格缩进，遇到 flow 风格
+/// （`process: {name: x}`）或非常规缩进时永远失败，且调用方每次导入都重试，
+/// 造成「同一条 warn 反复刷屏」。serde 往返会丢注释并标准化格式，
+/// 但对这些本就非标准的文件而言，「能修复」比「格式原样」更重要。
+///
+/// 已有 guid 时返回原文（幂等）；YAML 无法解析或没有 process 映射时返回 None。
+pub fn insert_guid_with_serde_fallback(yaml: &str, guid: &str) -> Option<String> {
+    if let Some(out) = insert_guid_after_name(yaml, guid) {
+        return Some(out);
+    }
+    let mut value: serde_yaml::Value = serde_yaml::from_str(yaml).ok()?;
+    let mapping = value.get_mut("process")?.as_mapping_mut()?;
+    let guid_key = serde_yaml::Value::String("guid".to_string());
+    // 已有非空 guid：幂等，返回原文避免无谓写盘；
+    // `guid: ""` 空值视为缺失，覆盖写入新 guid（否则每次扫描都会重复生成）。
+    if let Some(existing) = mapping.get(&guid_key) {
+        if existing.as_str().is_some_and(|s| !s.is_empty()) {
+            return Some(yaml.to_string());
+        }
+    }
+    mapping.insert(guid_key, serde_yaml::Value::String(guid.to_string()));
+    serde_yaml::to_string(&value).ok()
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -125,5 +151,54 @@ mod tests {
         let g = new_guid();
         assert_eq!(g.len(), 36, "UUID v4 字符串应为 36 字符");
         assert_ne!(new_guid(), new_guid(), "两次生成不应相同");
+    }
+
+    /// 056：flow 风格 `process: {name: x}` 行级插入失败，serde fallback 应修复。
+    /// 这是生产日志刷屏的根因用例（~/.ntd/processes/repro-stdin.yaml）。
+    #[test]
+    fn test_fallback_handles_flow_style_process() {
+        let yaml = "process: {name: x}\n";
+        let out = insert_guid_with_serde_fallback(yaml, "g-flow").unwrap();
+        // serde 往返后为 block 风格且带 guid
+        let value: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        assert_eq!(
+            value["process"]["guid"].as_str(),
+            Some("g-flow"),
+            "guid 应被写入: {out}"
+        );
+        assert_eq!(value["process"]["name"].as_str(), Some("x"), "原字段不丢");
+    }
+
+    /// 056：block 风格优先走行级插入（保注释与格式），不走 serde。
+    #[test]
+    fn test_fallback_prefers_line_based_insert() {
+        let yaml = "# 顶部注释\nprocess:\n  name: demo\n";
+        let out = insert_guid_with_serde_fallback(yaml, "g-line").unwrap();
+        assert!(out.contains("# 顶部注释"), "行级插入应保住注释");
+        assert!(out.contains("  name: demo\n  guid: g-line\n"));
+    }
+
+    /// 056：已有非空 guid 时幂等返回原文（不覆盖、不写盘）。
+    #[test]
+    fn test_fallback_idempotent_with_existing_guid() {
+        let yaml = "process: {name: x, guid: old-g}\n";
+        let out = insert_guid_with_serde_fallback(yaml, "new-g").unwrap();
+        assert_eq!(out, yaml, "已有 guid 应原样返回");
+    }
+
+    /// 056：`guid: ""` 空值视为缺失，覆盖写入新 guid。
+    #[test]
+    fn test_fallback_overwrites_empty_guid() {
+        let yaml = "process: {name: x, guid: ''}\n";
+        let out = insert_guid_with_serde_fallback(yaml, "g-new").unwrap();
+        let value: serde_yaml::Value = serde_yaml::from_str(&out).unwrap();
+        assert_eq!(value["process"]["guid"].as_str(), Some("g-new"));
+    }
+
+    /// 056：无 process 映射的非法输入返回 None（调用方报错）。
+    #[test]
+    fn test_fallback_returns_none_for_invalid() {
+        assert!(insert_guid_with_serde_fallback("foo: bar\n", "g").is_none());
+        assert!(insert_guid_with_serde_fallback("process: 42\n", "g").is_none());
     }
 }

--- a/backend/src/services/process/user_dir.rs
+++ b/backend/src/services/process/user_dir.rs
@@ -17,6 +17,24 @@ use crate::handlers::AppState;
 /// 用户工艺根目录名称（与系统层 `bundled/processes/` 区分）。
 const USER_PROCESSES_DIR_NAME: &str = "processes";
 
+/// 056：导入失败 warn 的进程内去重表（source_path → 已告警的错误首行）。
+/// 导入链路在每次工艺变更后全量重扫，不可修复的文件会每次触发同一条 warn；
+/// 记录「文件+错误」组合，只在该组合首次出现时告警。
+static IMPORT_WARNED: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<(String, String)>>> =
+    std::sync::OnceLock::new();
+
+/// 同一 (source_path, error) 组合进程内只 warn 一次（056 日志刷屏治理）。
+fn warn_once_per_file(source_path: &str, err: &str) {
+    let warned = IMPORT_WARNED.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+    // Mutex 中毒时取内部数据继续：告警去重不是关键路径，不值得 panic
+    let mut set = warned.lock().unwrap_or_else(|e| e.into_inner());
+    // 错误消息可能含动态细节，取首行做键，避免时间戳类噪声导致去重失效
+    let key = (source_path.to_string(), err.lines().next().unwrap_or("").to_string());
+    if set.insert(key) {
+        tracing::warn!("保存用户工艺模板 {} 失败: {}", source_path, err);
+    }
+}
+
 /// 用户工艺 `source_path` 前缀，与系统层 `bundled://` 区分。
 pub const USER_SOURCE_PREFIX: &str = "user://";
 
@@ -72,7 +90,10 @@ pub async fn import_user_process_templates(state: &AppState) -> Result<(), Strin
             // Ok(false)：guid 冲突跳过，已在内部 warn。
             Ok(false) => {}
             Err(e) => {
-                tracing::warn!("保存用户工艺模板 {} 失败: {}", source_path, e);
+                // 056：同一文件的同一错误进程内只 warn 一次——
+                // 该导入在每次 PUT /api/v1/processes 后都会全量重扫，
+                // 不可修复的文件（如 flow 风格 YAML）会产生日志刷屏。
+                warn_once_per_file(&source_path, &e);
             }
         }
     }
@@ -100,11 +121,15 @@ async fn upsert_user_process_yaml(
     // 040：缺 guid 的用户层文件生成并回写，之后按 guid 作为身份。
     if wrapper.process.guid.is_empty() {
         let guid = super::guid::new_guid();
-        let updated = super::guid::insert_guid_after_name(content, &guid)
+        // 056：行级插入失败时退化 serde 往返（flow 风格/非常规缩进文件）
+        let updated = super::guid::insert_guid_with_serde_fallback(content, &guid)
             .ok_or_else(|| format!("无法在 {source_path} 的 process 块内插入 guid 行"))?;
-        std::fs::write(path, &updated)
-            .map_err(|e| format!("回写 guid 到 {} 失败: {}", path.display(), e))?;
-        tracing::info!("为用户工艺 {} 生成并回写 guid: {}", source_path, guid);
+        // 幂等情况下内容未变（文件已有 guid 但 serde 模型读为空），跳过写盘
+        if updated != content {
+            std::fs::write(path, &updated)
+                .map_err(|e| format!("回写 guid 到 {} 失败: {}", path.display(), e))?;
+            tracing::info!("为用户工艺 {} 生成并回写 guid: {}", source_path, guid);
+        }
         wrapper.process.guid = guid;
     }
 

--- a/backend/tests/api_integration_test.rs
+++ b/backend/tests/api_integration_test.rs
@@ -98,7 +98,8 @@ async fn test_get_todos() {
 
     let body: serde_json::Value = read_json_body(response).await;
     assert_eq!(body["code"], 0);
-    let todos = body["data"].as_array().unwrap();
+    // 056：GET /todos 响应从全量数组改为分页结构 { items, total, page, page_size }
+    let todos = body["data"]["items"].as_array().unwrap();
     // Database::new 在 :memory: db 上会自动 seed 评审任务(todo_type=1)。
     // 这里只验证我们刚创建的 "Test" todo 出现在列表里,
     // 不去数总数(seed 数据是基础设施的一部分,不是用户数据)。
@@ -617,7 +618,7 @@ async fn test_todo_with_tags() {
         .unwrap();
     let get_resp = app.oneshot(get_req).await.unwrap();
     let get_body: serde_json::Value = read_json_body(get_resp).await;
-    let todos = get_body["data"].as_array().unwrap();
+    let todos = get_body["data"]["items"].as_array().unwrap();
     let todo = todos.iter().find(|t| t["id"].as_i64().unwrap() == todo_id).unwrap();
     assert_eq!(todo["tag_ids"], json!([tag2_id]));
 }

--- a/backend/tests/db_feature_supplement_tests.rs
+++ b/backend/tests/db_feature_supplement_tests.rs
@@ -1049,9 +1049,10 @@ async fn test_merge_backup_target_workspace_overrides_backup_value() {
     // 新建的 todo 应归属目标工作空间 B，而非备份中的 A；且 workspace_path 与 id 成对，
     // 指向 B 的当前库路径（不沿用备份里可能为空的 path），避免 id/path 错配。
     let todo = db
-        .get_todos_by_workspace_id(Some(dir_b))
+        .get_todos_page_by_workspace(Some(dir_b), None, 1, 200)
         .await
         .unwrap()
+        .0
         .into_iter()
         .next()
         .expect("应在工作空间 B 下找到导入的 todo");
@@ -1073,9 +1074,10 @@ async fn test_merge_backup_none_target_falls_back_to_backup_workspace() {
     assert_eq!(created, 1);
 
     let todo = db
-        .get_todos_by_workspace_id(Some(dir_a))
+        .get_todos_page_by_workspace(Some(dir_a), None, 1, 200)
         .await
         .unwrap()
+        .0
         .into_iter()
         .next()
         .expect("应在原工作空间 A 下找到导入的 todo");
@@ -1134,9 +1136,10 @@ async fn test_merge_backup_drops_dangling_backup_workspace_id() {
 
     // workspace_id 降级为未分配哨兵 0，workspace_path 为空
     let todo = db
-        .get_todos_by_workspace_id(Some(0))
+        .get_todos_page_by_workspace(Some(0), None, 1, 200)
         .await
         .unwrap()
+        .0
         .into_iter()
         .find(|t| t.title == "t1")
         .expect("应找到导入的 todo");

--- a/backend/tests/db_pool_concurrency_tests.rs
+++ b/backend/tests/db_pool_concurrency_tests.rs
@@ -48,7 +48,11 @@ async fn test_concurrent_reads_all_succeed_under_pool_size() {
         handles.push(tokio::spawn(async move {
             // 在屏障处汇合，确保 8 个任务几乎同时发起 read。
             barrier.wait().await;
-            let todos = db.get_todos().await.expect("concurrent read should succeed");
+            let todos = db
+                .get_todos_page_by_workspace(None, None, 1, 200)
+                .await
+                .expect("concurrent read should succeed")
+                .0;
             // 新库应为 0 条；这个断言同时也是「读到了 init 后的表」的烟雾测试。
             assert_eq!(todos.len(), 0);
         }));
@@ -78,7 +82,11 @@ async fn test_wal_reads_not_blocked_by_single_writer() {
         handles.push(tokio::spawn(async move {
             // 32 次连续读，故意放大观察窗口；用 task_idx 让每次标题不同避免互相影响。
             for i in 0..32 {
-                let _todos = db.get_todos().await.expect("read should succeed");
+                let _todos = db
+                    .get_todos_page_by_workspace(None, None, 1, 200)
+                    .await
+                    .expect("read should succeed")
+                    .0;
                 // 至少有一条 seed 在；让该任务在循环里产生微小延迟，模拟真实业务节拍。
                 if i % 8 == 0 {
                     tokio::task::yield_now().await;

--- a/docs/design/056-Todo列表服务端分页化与质量修复-设计.md
+++ b/docs/design/056-Todo列表服务端分页化与质量修复-设计.md
@@ -1,0 +1,230 @@
+# 056-Todo 列表服务端分页化与质量修复-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| pi (AI) | 2026-08-01 | 初始版本 |
+
+> 对应需求：`docs/requirements/056-Todo列表服务端分页化与质量修复-需求.md`
+> 决策已确认：看板用 brief 全量（1a）、全局桶删除（2a）、旧接口直接强制分页（3b）、单 PR（4a）。
+
+## 1. 总体思路
+
+```
+调用点分类治理：
+  A 类(列表展示)  → todo-center 真分页（SQL CASE WHEN 分桶 + LIMIT/OFFSET）
+  B 类(id 集合)   → SQL 子查询下推（IN (SELECT id FROM todos WHERE workspace_id=?)）
+  C 类(计数)      → 新增 count 接口
+  D 类(摘要/单条) → 新增 brief 接口 / 已有 by-id 接口
+  E 类(真全量)    → id 游标分批（sync）或 LIMIT（feishu 卡片）
+  F 类(全局缓存)  → 删除，改按需 by-id
+```
+
+## 2. R1 执行记录过滤下推 SQL
+
+### 2.1 db 层（`db/execution.rs`）
+
+`ExecutionRecordQuery` 增加字段：
+
+```rust
+pub struct ExecutionRecordQuery<'a> {
+    pub todo_id: Option<i64>,
+    pub step_id: Option<i64>,
+    pub workspace_id: Option<i64>,   // 新增：SQL 子查询过滤
+    pub limit: i64,
+    pub offset: i64,
+    pub status: Option<&'a str>,
+    pub hours: Option<u32>,
+}
+```
+
+SeaORM 条件（数据查询与 COUNT 共用同一 `Condition`）：
+
+```rust
+Condition::all().add(
+    execution_records::Column::TodoId.in_subquery(
+        Query::select()
+            .column(todos::Column::Id)
+            .from(todos::Entity)
+            .and_where(todos::Column::WorkspaceId.eq(wid))
+            .and_where(todos::Column::DeletedAt.is_null())
+            .to_owned()
+    )
+)
+```
+
+- `get_running_execution_records` / `get_execution_records_by_session` 增加 `workspace_id: Option<i64>` 参数，同样子查询过滤。
+- 注意 `(todo_id, step_id)` 组合分支：base_filter 含 `TodoId.is_not_null()` 兜底，workspace 条件用 AND 叠加，语义为"本 ws 的 todo 产生的记录"。
+
+### 2.2 handler 层（`handlers/execution.rs`）
+
+删除 6 处 `get_todos_by_workspace_id` + HashSet 内存过滤（行 68、190、363、415、838、876 附近），改为把 `ws_id` 传入 query。`total` 自然与过滤后一致，分页错乱 bug 消除。
+
+## 3. R2 todo-center 服务端分页
+
+### 3.1 bucket 的 SQL 表达式
+
+推导规则（`models/mod.rs:207`，优先级：archived > loop > time > event > manual）翻译为：
+
+```sql
+CASE
+  WHEN t.archived_at IS NOT NULL THEN 'archived'
+  WHEN (SELECT COUNT(*) FROM loop_steps ls
+        WHERE ls.todo_id = t.id AND ls.enabled = 1) > 0 THEN 'loop_driven'
+  WHEN t.scheduler_config IS NOT NULL THEN 'time_driven'
+  WHEN t.webhook_enabled = 1 THEN 'event_driven'
+  ELSE 'manual'
+END
+```
+
+依据：`count_enabled_loop_steps_by_todos`（db/loop_.rs:608）确认 loop 引用只查 `loop_steps.enabled = 1`，不 join loops 表，子查询可行。
+
+### 3.2 查询策略：先分页后聚合
+
+```
+第 1 步：SELECT t.id, <bucket_expr> AS bucket FROM todos t
+         WHERE deleted_at IS NULL [AND workspace_id=?] [AND bucket=?] [AND (LOWER(title) LIKE ? OR LOWER(prompt) LIKE ?)]
+         ORDER BY <sort> LIMIT n OFFSET m
+         → 当页 ids（≤ page_size 个）
+第 2 步：COUNT(*) 同条件 → total；GROUP BY bucket_expr 同条件 → 各 bucket counts
+第 3 步：build_center_aggregates(&ids) 现有批量聚合（仅当页 ≤ page_size 条，成本可控）
+第 4 步：build_center_item 组装（复用现有纯函数）
+```
+
+- 排序白名单：`id`（默认 DESC）、`updated_at`、`title`、`status`、`computed_bucket`（bucket_expr 可排序）。拒绝白名单外字段防注入。
+- `search`：`LOWER(title) LIKE '%kw%' ESCAPE '\'` 参数绑定，kw 先转义 `%`/`_`。
+- 响应：`TodoCenterPage { items: Vec<TodoCenterItem>, total: i64, page: i64, page_size: i64, bucket_counts: HashMap<String, i64> }`。
+- `page_size` 上限 200，超出截断；`page` 从 1 开始。
+- 兼容：不传 `page` 时保持旧行为（全量返回，字段同构）——**仅限内部迁移期**，前端切完后随 R4 移除。决策 3b 仅针对 `/todos` 旧接口直接强制分页；todo-center 是 054 新接口，前端只有两处调用，直接切。
+
+### 3.3 新轻量接口
+
+| 接口 | 响应 | 用途 |
+|------|------|------|
+| `GET /workspaces/{ws}/todos/ids` | `Vec<i64>` | B 类残留（如前端需要全 id 集） |
+| `GET /workspaces/{ws}/todos/count` | `{ count: i64 }` | useConceptCounts |
+| `GET /workspaces/{ws}/todos/brief?ids=1,2,3` | `Vec<TodoBrief>` | D 类下拉/摘要；ids 省略=全 ws（看板） |
+
+`TodoBrief { id, title, status, executor, updated_at, archived_at }` —— 不含 prompt/acceptance_criteria 大文本。
+
+### 3.4 旧 `/todos` 强制分页（决策 3b）
+
+- 响应从 `Vec<Todo>` 改为 `TodoListPage { items, total, page, page_size }`（ApiResponse 包裹）。
+- `hours` 过滤从内存改 SQL（`updated_at >= datetime('now', '-N hours')`，N 为 u32 绑参）。
+- 默认 `page=1, page_size=50`，上限 200。
+- CLI（`cli/commands.rs` list）同步适配新响应结构。
+
+## 4. R4 收尾
+
+- `handlers/sync.rs`：`merge_cloud_todos_to_local` 只需 `title→id` 映射，新增 db 方法 `get_todo_title_id_map()`（`SELECT id, title FROM todos WHERE deleted_at IS NULL`，两列轻量）；上传侧 `local_todos_to_cloud` 需全字段，改 id 游标分批（`WHERE id > ? ORDER BY id LIMIT 500` 循环）。
+- `feishu_listener.rs:1853`：卡片 todo 列表改 brief + `ORDER BY updated_at DESC LIMIT 20`。
+- 删除 `get_todos()` / `get_todos_by_workspace_id()`；测试改用新接口构造断言。
+
+## 5. R5–R10 质量修复设计
+
+### R5 L3（auto_update.rs）
+
+```rust
+fn resolve_local(dt: NaiveDateTime) -> DateTime<Local> {
+    match dt.and_local_timezone(Local) {
+        LocalResult::Single(t) => t,
+        LocalResult::Ambiguous(earlier, _) => earlier, // 秋令时取较早，避免跳过检查
+        LocalResult::None => dt.and_local_timezone(Local).single()
+            .unwrap_or_else(|| Local::now()),          // 春令时顺延策略见实现注释
+    }
+}
+```
+
+实际实现：None 分支用 `dt + Duration::hours(1)` 重试 single，兜底 `Local::now()`。附 3 个单测（正常/歧义/不存在）。
+
+### R6 L4
+
+| 点位 | 现状 | 修法 |
+|------|------|------|
+| handlers/mod.rs:174 | WS 同步 records 查询失败→空 | `?` 传播前 log，WS 升级失败返回错误 |
+| handlers/mod.rs:180 | logs 查询失败→空 | `tracing::error!` 后降级（WS 已升级，允许部分数据） |
+| tasks.rs:237 | artifact workspace 解析→空串 | `?` 传播 |
+
+逐个复核 skills.rs/backup.rs/process.rs/session.rs/agent_bot.rs 的其余点位，仅改"DB 故障与空数据无法区分"的，保留合法默认值。
+
+### R7 L5（guid.rs + user_dir.rs）
+
+- `insert_guid_after_name` 返回类型改 `Result<Option<String>, GuidInsertError>` 不准确；保持 `Option` 但新增 `insert_guid_serde_fallback(content, guid) -> Option<String>`：serde 解析 → 置 guid → 重序列化。文本路径失败时调用 fallback。
+- `user_dir.rs` 维护 `static WARNED_FILES: OnceLock<Mutex<HashSet<PathBuf>>>`，每文件只 warn 一次。
+- 单测：flow-style `process: {name: x}`、缺 name 行、正常 block 三种用例。
+
+### R8 L6（useExecutionEvents.ts）
+
+- `sharedRemoveTaskTimers` 从 `Set` 改 `Map<taskId, timer>`；`Finished` 时按 taskId 登记。
+- `Sync` case：遍历 tasks，对存在的 taskId 清除其定时器（任务被 Sync 重置为 running，不应被旧定时器移除）。
+- 定时器回调内检查任务仍存在再 dispatch（经 `sharedGetState` 或让 reducer 幂等——reducer `REMOVE_RUNNING_TASK` 对不存在 id 已是 no-op，只需 Sync 清定时器）。
+
+### R9 P3（execution.rs dashboard）
+
+```
+GET /stats/dashboard:
+  hit 且未过期 → 返回
+  hit 但过期   → 返回旧值 + tokio::spawn 后台刷新（单飞：刷新中标记防并发击穿）
+  miss         → 同步计算 + 写缓存
+执行完成（executor_service/completion.rs）→ invalidate_dashboard_cache()
+heatmap → 独立 HEATMAP_CACHE，TTL 10min
+```
+
+单飞用 `tokio::sync::OnceCell`/刷新中布尔 + 写锁双重检查。
+
+### R10 规范
+
+- daemon/linux.rs、daemon/redeploy.rs、cli/commands.rs 的 `println!/eprintln!`：模块级 `#![allow(clippy::print_stdout, clippy::print_stderr)]` + 注释说明"CLI 子命令 stdout 即用户界面"。（项目禁止清单#13 限 `#[cfg(test)]` 外用 allow——但 CLAUDE.md 豁免场景是 lint 抑制需说明理由；此处选择改为 `tracing` 不可行，daemon install 输出必须到用户终端。采用在函数/模块上最小范围 allow + 注释。）
+- `custom_template.rs:328,338` `config.read().unwrap()` → `unwrap_or_else(|e| e.into_inner())`（与 mod.rs 既有模式一致）。
+- `custom_template.rs:344` cron 解析 unwrap → 兜底默认 cron。
+- `auto_update.rs` 3 处 unwrap → R5 修复。
+- `experts.rs:605` file_name().unwrap() → `ok_or` 传播。
+- `scheduler.rs:242`、其余已有不变量注释的 expect → 保留（已有 #[allow] + 理由）。
+- 删除 dead code `ntd_dir`；修 `collapsible_match`（execution_events/metadata.rs、handlers/session.rs）、`needless_borrows_for_generic_args` 等。
+
+## 6. 前端详细改动
+
+| 文件 | 改动 |
+|------|------|
+| utils/database/todos.ts | `getAllTodos` 改分页响应；新增 `getTodoIds/getTodoCount/getTodoBriefs`；`getTodoCenter` 加分页参数 |
+| utils/database/todos.ts | 新增 `getTodoById`（若已有则复用） |
+| todo-list/TodoListPage.tsx | useTodoListData 改服务端分页：state 增加 page/page_size/sort/bucket/search，reload 携带；Table onChange 驱动；删除 filterBySearchKeyword |
+| todo-list/TodoListView.tsx | pagination 改受控（current/pageSize/total/onChange）；bucket Tabs 用 bucket_counts 角标 |
+| TodoCenterCardView.tsx | 同改服务端分页（卡片底部 ant Pagination） |
+| KanbanBoard.tsx | 改 getTodoBriefs 全量（无 ids）；hours 过滤保留（brief 接口支持 hours 参数） |
+| hooks/useTodoContext.tsx | 删除 todosByWorkspace 桶与 SET_TODOS_BY_WORKSPACE；state.todos 派生删除 |
+| hooks/useConceptCounts.ts | getAllTodos→getTodoCount |
+| MemorialBoard / RunningRecordDrawer / todo-post / running-board | state.todos.find(id) → getTodoById 按需 + 本地 useState 缓存 |
+| App.tsx / TodoDetail.tsx | onSaved 等回调不再全量重拉，只 dispatch TODO_LIST_REFRESH_EVENT |
+| hooks/useExecutionEvents.ts | R8 修复 |
+| useApp.tsx:65 | 启动不再预拉 todos |
+
+**by-id 缓存策略**：新增 `hooks/useTodoById.ts`（Map<id, Todo> + 请求中去重 + TODO_LIST_REFRESH_EVENT 失效），供 D 类组件使用，避免每个组件自造缓存。
+
+## 7. 测试计划
+
+### 后端（`backend/tests/` + 模块内单测）
+- execution workspace 过滤：两 ws 各造记录，验证分页 total/条数正确（修复前稀释场景回归）
+- todo-center：分页元数据、bucket 过滤、bucket_counts、search、排序白名单拒绝非法字段
+- ids/count/brief 接口
+- 旧 /todos 分页响应结构 + hours SQL 过滤
+- sync 分批游标（造 1200 条验证两批）
+- R5 DST 三单测；R7 flow-style/缺 name/正常三单测
+- R9 缓存：过期 stale 返回、主动失效
+
+### 前端
+- `npx tsc --noEmit` 零错误
+- TodoListPage 翻页/搜索/bucket 切换 Playwright 验证（`frontend/tests/check_056_pagination.spec.ts`）
+- 看板 brief 加载渲染验证
+
+### 质量门禁
+- `cargo clippy --all-targets -- -D warnings` 零告警
+- `cargo test` 全过
+
+## 8. 风险与回滚
+
+| 风险 | 缓解 |
+|------|------|
+| todo-center SQL 分桶与 Rust `compute_bucket` 语义漂移 | 同一优先级表驱动两边；集成测试对拍两实现结果一致 |
+| 旧 /todos 响应结构破坏外部脚本 | CLI 同步升级；需求文档已记录 breaking change；版本号 minor bump |
+| 全局桶删除后某读取点遗漏 | `state.todos` 编译期删除，tsc 报错即遗漏点清单 |
+| dashboard 单飞实现复杂度 | 退化为"过期同步重算"（现状）也可接受，单飞失败不阻塞 |

--- a/docs/requirements/056-Todo列表服务端分页化与质量修复-实现总结.md
+++ b/docs/requirements/056-Todo列表服务端分页化与质量修复-实现总结.md
@@ -1,0 +1,88 @@
+# 056-Todo 列表服务端分页化与质量修复-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| pi (AI) | 2026-08-01 | 初始版本 |
+
+> 对应需求：`docs/requirements/056-Todo列表服务端分页化与质量修复-需求.md`
+> 对应设计：`docs/design/056-Todo列表服务端分页化与质量修复-设计.md`
+
+## 1. 需求对应关系
+
+| 需求 | 状态 | 实现说明 |
+|------|------|---------|
+| R1 执行记录 ws 过滤下推 SQL | ✅ | `ExecutionRecordQuery.workspace_id` 子查询；execution.rs 6 处内存过滤删除；**分页稀释 bug 修复**（有回归测试） |
+| R2 todo-center 服务端分页 | ✅ | SQL CASE WHEN 分桶 + LIMIT/OFFSET；新增 ids/count/brief 三轻量接口；旧 `/todos` 强制分页（决策 3b） |
+| R3 前端切换 | ✅ | 列表/卡片页服务端分页；看板 brief（决策 1a）；计数/摘要/下拉全部换轻量接口；全局桶删除（决策 2a） |
+| R4 全量查询收尾 | ✅ | `get_todos`/`get_todos_by_workspace_id`/`get_todo_center` 三函数删除；sync 改游标分批 + title/id 映射；feishu 卡片 brief+take(20) |
+| R5 L3 DST unwrap | ✅ | `resolve_local_datetime`：Ambiguous 取早、None 顺延 1h、兜底 now；3 个单测 |
+| R6 L4 吞 DB 错误 | ✅ | `handlers/mod.rs` WS 同步两处改 error 日志降级；`tasks.rs` artifact 路径解析改 `?` 传播 |
+| R7 L5 guid 刷屏 | ✅ | `insert_guid_with_serde_fallback`（flow 风格 serde 往返修复）；`warn_once_per_file` 进程内去重 |
+| R8 L6 WS 竞争 | ✅ | 移除定时器改 Map 按 taskId 管理；Sync 到达撤销对应定时器；Started/Finished 改发列表刷新事件 |
+| R9 P3 dashboard | ✅ | 单飞刷新锁 + 双重检查 + stale-on-error（续 5s 短 TTL 防穿透）；执行终态（Finished×3 + force_fail）主动失效 |
+| R10 规范项 | ✅ | `cargo clippy --all-targets -- -D warnings` **零告警**；生产 unwrap 逐处处理 |
+
+## 2. 关键实现点
+
+### 2.1 后端
+
+- **bucket SQL 表达式**（`db/todo.rs::TODO_CENTER_BUCKET_EXPR`）：与 Rust `compute_bucket` 同优先级（archived > loop > time > event > manual），并有**对拍测试** `test_center_bucket_sql_matches_rust` 防漂移。
+- **先分页后聚合**：SQL 只查当页 ids，`build_center_aggregates` 仅对 ≤page_size 条批量补算，避免全表聚合。
+- **排序白名单**：id/updated_at/title/status/computed_bucket，白名单外退化为 id（列名拼 SQL 无法绑参，白名单是唯一安全途径）。
+- **search LIKE 转义**：`\`、`%`、`_` 先转义，`ESCAPE '\'` 参数绑定。
+- **brief 接口**：`SELECT` 只取 8 个轻量列 + `(prompt != '') AS has_prompt`；`ids=None`（看板模式）隐藏已归档，`ids=Some`（定点模式）包含已归档；tag_ids 批量补算无 N+1。
+- **CLI 适配**（决策 3b）：`ntd todo list` 逐页拉齐后客户端过滤（status/tag/running/search 原本就被后端忽略，现补齐为真正的客户端过滤）。
+- **RecentCompletedTodo 增加 workspace_id**：纪念板项目名反查免去前端 N+1。
+
+### 2.2 前端
+
+- **全局桶删除**：`todosByWorkspace` 及 5 个相关 action 从 `useTodoContext` 移除；`useApp.state.todos` 删除（10 个读取点全部迁移）。
+- **新增 `useTodoById`**：模块级缓存 + 请求中去重 + TODO_LIST_REFRESH_EVENT 失效，供 by-id 消费点。
+- **TodoListPage**：page/pageSize/sort/search 全下推，搜索 300ms 防抖；`last_execution_at` 列移除 sorter（聚合字段不支持服务端排序）。
+- **TodoCenterCardView**：bucket/status/actionType/search 全下推（后端为此新增 status/action_type 过滤与 `action_types` DISTINCT 聚合）；Tab 角标用服务端 bucket_counts；底部 Pagination（24/48/96）。
+- **KanbanBoard**：brief 全量（决策 1a）；prompt 展开时按需拉全文（TodoCard 新增 hasPrompt/promptLoading props）；拖拽改走 `force-status` 单字段端点（不再携带 prompt 全量更新）；搜索收缩为标题。
+- **WS 事件**：Started/Finished 不再写全局桶，改发 TODO_LIST_REFRESH_EVENT 让各页重拉当前页。
+
+### 2.3 与设计文档的偏差
+
+| 偏差 | 原因 |
+|------|------|
+| dashboard heatmap 独立长缓存未做 | SWR+主动失效后，heatmap 仅是 miss 成本的 1/20，YAGNI |
+| 后台异步 SWR 改为「单飞 + stale-on-error」 | 无后台任务泄漏风险，实现更简单；刷新失败续 5s TTL 防穿透 |
+| 看板搜索/prompt 搜索收缩为标题 | brief 不含 prompt（决策 1a 的取舍）；执行记录搜索同样收缩 |
+| 看板卡片选中态跨页裁剪 | 服务端分页后批量选择仅对当前页有效 |
+
+## 3. 验证结果
+
+### 质量门禁
+
+| 门禁 | 结果 |
+|------|------|
+| `cargo clippy --all-targets -- -D warnings` | ✅ 零告警（修复前 45 条） |
+| `cargo test`（lib 1574 + 集成 293） | ✅ 全过；唯一失败 `git_sync::test_sync_repo_restores_deleted_file` 为**存量环境问题**（本机 git 2.20 不支持 `git init -b`，main 分支同样失败，与本 PR 无关） |
+| `npx tsc --noEmit` | ✅ 零错误 |
+| `npx vitest run`（227 用例） | ✅ 全过 |
+| Playwright `tests/check_056_pagination.spec.ts` | ✅ 3/3（列表分页/卡片角标+分页/看板 brief） |
+
+### 新增测试
+
+- 后端：`test_center_bucket_sql_matches_rust`（SQL/Rust 分桶对拍）、`test_center_page_pagination_metadata`、`test_todo_briefs_archived_semantics`、`test_todos_page_by_workspace_hours_and_total`、`test_todos_batch_after_id_cursor`、`test_todo_ids_and_count_exclude_archived`、`test_execution_records_workspace_filter_pagination`（R1 稀释回归）、DST×3、guid fallback×5
+- API 实测：`/todos` 分页元数据、`/center` bucket 过滤（manual total=2 且 items 全 manual）、`/ids`、`/count`、`/brief` 字段集、执行记录 ws 过滤（ws2 total=27 vs ws1 total=1）
+
+### 存量问题（不在本 PR 范围）
+
+- `db_pool_concurrency_tests` 在本机曾现 v85 迁移对 fresh file-DB 的重复建表失败（main 分支同样复现，与 056 无关；本次全量跑通过，疑似时序敏感）。
+- `git_sync` 测试需 git ≥ 2.28。
+
+## 4. Breaking Changes
+
+1. `GET /api/v1/workspaces/{ws}/todos` 响应从 `Todo[]` 变为 `{ items, total, page, page_size }`（决策 3b）。CLI 已同步适配。
+2. `GET /todos/center` 响应从 `TodoCenterItem[]` 变为 `TodoCenterPage` 结构（该接口为 054 新增，仅前端两处调用，已同步）。
+3. 前端全局 `state.todos` 删除——若有外部插件依赖（无），需改 `useTodoById`。
+
+## 5. 已知限制
+
+- 看板/执行记录搜索不再匹配 prompt（brief 无此字段）。
+- 表格「执行时间」列不再可排序（聚合字段）。
+- 批量选择仅对当前页有效。
+- todo-center page_size 上限 200；超过 200 条的 ws 在卡片墙需翻页。

--- a/docs/requirements/056-Todo列表服务端分页化与质量修复-需求.md
+++ b/docs/requirements/056-Todo列表服务端分页化与质量修复-需求.md
@@ -1,0 +1,96 @@
+# 056-Todo 列表服务端分页化与质量修复-需求
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| pi (AI) | 2026-08-01 | 初始版本 |
+
+## 1. 背景与问题
+
+代码审查发现 `get_todos` / `get_todos_by_workspace_id` 全量查询存在三层架构错位，并附带一个正确性 bug：
+
+1. **API 层**：`GET /workspaces/{ws}/todos` 与 `GET /workspaces/{ws}/todo-center` 仅返回全量数组，无分页参数。
+2. **前端层**：Ant Table 的 `pagination` 是浏览器内存切片（假分页），首屏需下载全表（含 prompt 大文本）。
+3. **复用层**：`get_todos_by_workspace_id` 被后端 9 处、前端 13 处当作"万能取数口"，其中约 80% 调用点只需要 id 集合 / 计数 / 单条摘要。
+4. **正确性 bug（优先修）**：`handlers/execution.rs` 6 处先 `LIMIT/OFFSET` 分页、再按 workspace 内存过滤，导致执行记录列表在多 workspace 下每页条数稀释、`total` 与实际不符。
+
+同时修复审查确认的 6 项质量缺陷（L3–L6、P3、规范项）。
+
+## 2. 需求条目
+
+### R1 执行记录 workspace 过滤下推 SQL（修正确性 bug）
+
+- `get_execution_records` / `get_running_execution_records` / `get_execution_records_by_session` 支持 workspace_id 过滤，SQL 层使用 `todo_id IN (SELECT id FROM todos WHERE workspace_id = ? AND deleted_at IS NULL)` 子查询。
+- `COUNT(*)` 与数据查询使用同一过滤条件，保证分页元数据一致。
+- 删除 execution.rs 中 6 处「拉全量 todos 建 HashSet 内存过滤」代码。
+
+### R2 Todo 列表接口服务端分页化
+
+- `GET /workspaces/{ws}/todo-center` 新增 `page`/`page_size`/`sort_by`/`sort_order`/`bucket`/`search` 参数，全部下推 SQL；`computed_bucket` 由内存推导改为 SQL `CASE WHEN` 表达式；响应携带 `total` 与各 bucket `counts`。
+- `GET /workspaces/{ws}/todos`（旧全量接口，CLI 在用）直接改为强制分页语义（决策 3b），响应结构从 `Vec<Todo>` 变为 `{ items, total, page, page_size }`；CLI 同步升级适配。
+- 新增轻量接口：
+  - `GET /workspaces/{ws}/todos/ids` → `Vec<i64>`
+  - `GET /workspaces/{ws}/todos/count` → `{ count }`
+  - `GET /workspaces/{ws}/todos/brief?ids=` → `Vec<{id, title, status, updated_at}>`（不含 prompt 大字段；ids 为空时返回该 ws 全部 brief，供看板使用）
+
+### R3 前端切换
+
+- TodoListPage / TodoCenterCardView：翻页 / 排序 / 搜索 / 切 bucket 时请求对应页（服务端分页），删除前端内存分页与搜索过滤。
+- KanbanBoard：保持全量渲染，改用 brief 接口（决策 1a）。
+- useConceptCounts 改用 count 接口；RunningRecordDrawer / todo-post / MemorialBoard / running-board / settings 下拉改用 by-id 或 brief 接口。
+- 全局 `state.todos` 全量桶彻底删除，10 个读取点改按需 by-id 查询（决策 2a）。
+
+### R4 全量查询收尾
+
+- db 层删除 `get_todos()` / `get_todos_by_workspace_id()`：
+  - `handlers/sync.rs` 云同步改 id 游标分批（每批 500）。
+  - `services/feishu_listener.rs` 卡片数据改 brief + `LIMIT 20`。
+- `SET_TODOS_BY_WORKSPACE` 全量 action 退役。
+
+### R5 L3：auto_update DST unwrap panic
+
+`services/auto_update.rs:146,160,164` 的 `and_local_timezone(Local).unwrap()` 在夏令时切换日（本地时刻不存在/歧义）会 panic。改用 `LocalResult::single()`，歧义取较早值、不存在顺延 1 小时，附 DST 单测。
+
+### R6 L4：DB 错误被 unwrap_or_default 吞掉
+
+仅修复"DB 读取失败后降级为 200 空数据、调用方无法区分真空与故障"的点位（`handlers/mod.rs:174,180` WS 同步等），改为 `?` 传播或 `tracing::error!` 后降级。合法默认值语义不动。
+
+### R7 L5：工艺模板 guid 插入失败日志刷屏
+
+根因：flow-style YAML（`process: {name: x}`）下 `process_block_range` 找不到块起始行，`insert_guid_after_name` 永远失败且每次 PUT 重试。
+
+- `insert_guid_after_name` 文本插入失败时 fallback：serde 结构体重序列化回写（保留数据，格式标准化）。
+- 对仍无法修复的文件，进程内去重 warn（每文件只告警一次）。
+
+### R8 L6：WS Finished 移除定时器与重连 Sync 竞争
+
+- Sync 到达时清除对应 task 的待执行移除定时器。
+- 移除定时器触发时若任务已不在 running 列表则跳过。
+
+### R9 P3：dashboard 缓存增强
+
+现状已有 30s TTL + try_join 并发。改进为：
+
+- stale-while-revalidate：过期仍先返回旧值，后台异步刷新。
+- 执行完成事件主动失效缓存。
+- heatmap（当年口径，年内缓慢变化）结果单独长缓存（10 分钟）。
+
+### R10 规范项：clippy 告警与生产 unwrap
+
+- 45 个 clippy 告警清零：daemon/cli 的 36 个 `println!/eprintln!` 属 CLI 用户输出，显式 `#[allow]` 标注理由；2 个生产 expect 改错误传播；删除 dead code `ntd_dir`；修复 collapsible_match 等。
+- 生产代码 26 处 unwrap/expect/panic 逐个审查：有不变量保护的补 `#[allow]` + 注释，无保护的改错误传播。
+- 提交前 `cargo clippy --all-targets -- -D warnings` 零告警、`cargo test` 全过、`npx tsc --noEmit` 零错误。
+
+## 3. 已确认决策
+
+| # | 决策点 | 结论 |
+|---|--------|------|
+| 1 | KanbanBoard 数据策略 | 保持全量渲染，改用 brief 接口（a） |
+| 2 | 全局 state.todos 桶 | 彻底删除，改按需 by-id（a） |
+| 3 | 旧全量接口去留 | 本版本直接改为强制分页，CLI 同步升级（b） |
+| 4 | 实施节奏 | 单 PR 全量交付（a） |
+
+## 4. 非目标（Out of Scope）
+
+- BlackboardPage.tsx 1285 行巨型组件拆分（用户明确排除）。
+- 认证体系、CORS、webhook secret 等安全项（另立项）。
+- keyset/cursor 分页（数据量未达需要，OFFSET 足够）。

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -200,12 +200,8 @@ function AppContent() {
   }, [clearSelection, pushUrl]);
 
   const handleSmartCreateSubmitted = () => {
-    const wid = state.selectedWorkspace;
-    if (wid == null) return;
-    db.getAllTodos(wid).then(todos => {
-      dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: todos });
-      window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
-    });
+    // 056：全局 todos 桶已删除，创建成功后只需通知列表页重拉当前页
+    window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
   };
 
   const handleShowView = useCallback((view: View) => {
@@ -483,13 +479,8 @@ function AppContent() {
           setEditingTodo(null);
         }}
         onSaved={() => {
-          const wid = state.selectedWorkspace;
-          if (wid == null) return;
-          db.getAllTodos(wid).then(todos => {
-            dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: todos });
-            // 通知 TodoListPage 刷新列表（卡片/列表两种形态都监听此事件）
-            window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
-          });
+          // 056：全局 todos 桶已删除，保存后通知列表页重拉当前页即可
+          window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
         }}
         defaultWorkspaceId={state.selectedWorkspace}
       />
@@ -512,13 +503,8 @@ function AppContent() {
         isMobile={isMobile}
         defaultWorkspaceId={state.selectedWorkspace}
         onCreated={() => {
-          const wid = state.selectedWorkspace;
-          if (wid != null) {
-            db.getAllTodos(wid).then(todos => {
-              dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: todos });
-              window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
-            });
-          }
+          // 056：全局 todos 桶已删除，创建后通知列表页重拉当前页
+          window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
         }}
         onExecuted={() => {}}
       />

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -25,7 +25,7 @@ import { useApp } from '@/hooks/useApp';
 import { useViewState } from '@/hooks/useViewState';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import * as db from '@/utils/database';
-import type { DashboardStats, FeishuMessageStats } from '@/types';
+import type { DashboardStats, FeishuMessageStats, TodoBrief } from '@/types';
 import { TimeRangeSelector } from './dashboard/SpecialCards';
 import { OverviewTab } from './dashboard/tabs/OverviewTab';
 import { TasksTab } from './dashboard/tabs/TasksTab';
@@ -45,13 +45,15 @@ type IconType = ComponentType<{ style?: CSSProperties }>;
 export function Dashboard() {
   const { state } = useApp();
   const { message } = App.useApp();
-  const { todos, tags, runningTasks } = state;
+  const { tags, runningTasks } = state;
   const { activeTab, pushUrl } = useViewState();
   // Dashboard 是全局运营视图，不依赖当前选中的 workspace；
   // 数据由 /api/v1/stats/dashboard 全库聚合返回。
   const isMobile = useIsMobile();
 
   const [stats, setStats] = useState<DashboardStats | null>(null);
+  // 056：最近执行记录的 todo 标题按 id 集轻量反查（替代原全局全量桶）
+  const [recentTodos, setRecentTodos] = useState<TodoBrief[]>([]);
   const [loading, setLoading] = useState(true);
   const [msgStats, setMsgStats] = useState<FeishuMessageStats | null>(null);
   const [msgStatsError, setMsgStatsError] = useState(false);
@@ -61,7 +63,8 @@ export function Dashboard() {
   const [usageStatsRange, setUsageStatsRange] = useState<{ since?: string; until?: string }>({});
 
   // 顶层派生量:多处 Tab 共用,在此算一次后通过 props 下发,避免各 Tab 重复计算。
-  const totalTodos = stats?.total_todos ?? todos.length;
+  // 056：全局桶删除后，total_todos 只信服务端聚合，无兜底本地计数
+  const totalTodos = stats?.total_todos ?? 0;
   const successRate =
     stats && stats.total_executions > 0 ? (stats.success_executions / stats.total_executions) * 100 : 0;
   const processingRate =
@@ -80,6 +83,14 @@ export function Dashboard() {
       // Dashboard 为概览，调用全局 stats 接口，不再传入 workspaceId
       const data = await db.getDashboardStats(hours);
       setStats(data);
+      // 056：按最近执行记录的 todo_id 集合拉 brief 反查标题（替代全量 todos）
+      const todoIds = [...new Set((data.recent_executions ?? []).map(r => r.todo_id))];
+      if (todoIds.length > 0 && state.selectedWorkspace != null) {
+        const briefs = await db.getTodoBriefs(state.selectedWorkspace, { ids: todoIds }).catch(() => []);
+        setRecentTodos(briefs);
+      } else {
+        setRecentTodos([]);
+      }
     } catch {
       message.error('加载统计数据失败');
     } finally {
@@ -172,7 +183,7 @@ export function Dashboard() {
           loading={loading}
           successRate={successRate}
           runningTasks={Object.values(runningTasks)}
-          todos={todos}
+          todos={recentTodos}
         />
       ),
     },

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -86,7 +86,10 @@ export function Dashboard() {
       // 056：按最近执行记录的 todo_id 集合拉 brief 反查标题（替代全量 todos）
       const todoIds = [...new Set((data.recent_executions ?? []).map(r => r.todo_id))];
       if (todoIds.length > 0 && state.selectedWorkspace != null) {
-        const briefs = await db.getTodoBriefs(state.selectedWorkspace, { ids: todoIds }).catch(() => []);
+        const briefs = await db.getTodoBriefs(state.selectedWorkspace, { ids: todoIds }).catch((e) => {
+          console.error('最近执行记录的 todo 标题反查失败:', e);
+          return [];
+        });
         setRecentTodos(briefs);
       } else {
         setRecentTodos([]);

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -23,8 +23,6 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
   // 056：看板数据源改为 TodoBrief（决策 1a）——不含 prompt 大字段，
   // 卡片 prompt 区块按 has_prompt 显示入口、展开时按需取全文。
   const [briefs, setBriefs] = useState<TodoBrief[]>([]);
-  // 本地时间过滤后的 brief 列表：当 hours 有值时，按 API 过滤结果只保留最近 N 小时的。
-  const [kanbanTodos, setKanbanTodos] = useState<TodoBrief[] | null>(null);
   // 按需加载的 prompt 全文缓存（id → prompt），首次展开时拉取
   const [promptCache, setPromptCache] = useState<Map<number, string>>(new Map());
   const [promptLoadingIds, setPromptLoadingIds] = useState<Set<number>>(new Set());
@@ -45,20 +43,22 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
   const isMobile = useIsMobile();
   const [activeKey, setActiveKey] = useState<Todo['status']>('pending');
 
-  // 渲染用的列表：有本地过滤结果则用，否则用全量 brief
-  const displayTodos = kanbanTodos ?? briefs;
+  // 渲染用的列表即 briefs（hours 由请求参数下推服务端）
+  const displayTodos = briefs;
 
   /* ─── Execution record cache (delegated to hook) ─── */
   const cache = useKanbanExecutionCache({ todos: displayTodos, storeRecords: state.executionRecords, workspaceId: state.selectedWorkspace });
 
-  // 056：切换工作空间后拉取该 ws 的 brief 列表；
-  // TODO_LIST_REFRESH_EVENT（保存/删除/执行事件）触发重拉，保持与列表页一致。
+  // 056（CodeRabbit#7）：合并为单一 effect——按当前 hours 拉取 brief 并监听刷新事件。
+  // 旧实现两个 effect 分别维护 briefs/kanbanTodos：刷新事件只更新不被渲染的 briefs，
+  // 看板在 hours 过滤下永不刷新；且挂载时并发两请求，全量那次结果不会被渲染。
   useEffect(() => {
     const wid = state.selectedWorkspace;
     if (wid == null) return;
     let cancelled = false;
     const load = () => {
-      db.getTodoBriefs(wid).then(bs => {
+      // hours 为 null 表示「全部」不传参；为数值时下推服务端过滤
+      db.getTodoBriefs(wid, hours == null ? {} : { hours }).then(bs => {
         if (!cancelled) setBriefs(bs);
       }).catch((e) => console.error('看板 brief 列表加载失败:', e));
     };
@@ -68,14 +68,6 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
       cancelled = true;
       window.removeEventListener(TODO_LIST_REFRESH_EVENT, load);
     };
-  }, [state.selectedWorkspace]);
-
-  // 时间分段按钮切换时，用 hours 参数重新拉取（只影响本地 kanbanTodos，不污染基础列表）。
-  useEffect(() => {
-    const wid = state.selectedWorkspace;
-    if (wid == null) return;
-    if (hours == null) { setKanbanTodos(null); return; }
-    db.getTodoBriefs(wid, { hours }).then(setKanbanTodos).catch((e) => console.error('看板 hours 过滤加载失败:', e));
   }, [state.selectedWorkspace, hours]);
 
   // 加载项目目录列表，供项目维度过滤使用。
@@ -184,7 +176,6 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
       await db.updateTodoStatus(todo.workspace_id, todoId, targetStatus);
       // 本地就地更新 brief 状态（避免整列重拉闪烁）
       setBriefs(prev => prev.map(b => b.id === todoId ? { ...b, status: targetStatus } : b));
-      setKanbanTodos(prev => prev ? prev.map(b => b.id === todoId ? { ...b, status: targetStatus } : b) : prev);
       message.success(`已移动到「${getColumnForStatus(targetStatus).label}」`);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : '更新状态失败';

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -60,7 +60,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
     const load = () => {
       db.getTodoBriefs(wid).then(bs => {
         if (!cancelled) setBriefs(bs);
-      }).catch(() => {});
+      }).catch((e) => console.error('看板 brief 列表加载失败:', e));
     };
     load();
     window.addEventListener(TODO_LIST_REFRESH_EVENT, load);
@@ -75,7 +75,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
     const wid = state.selectedWorkspace;
     if (wid == null) return;
     if (hours == null) { setKanbanTodos(null); return; }
-    db.getTodoBriefs(wid, { hours }).then(setKanbanTodos).catch(() => {});
+    db.getTodoBriefs(wid, { hours }).then(setKanbanTodos).catch((e) => console.error('看板 hours 过滤加载失败:', e));
   }, [state.selectedWorkspace, hours]);
 
   // 加载项目目录列表，供项目维度过滤使用。
@@ -172,7 +172,12 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
     if (isNaN(todoId)) return;
 
     const todo = displayTodos.find(t => t.id === todoId);
-    if (!todo || todo.status === targetStatus || todo.workspace_id == null) return;
+    if (!todo || todo.status === targetStatus) return;
+    if (todo.workspace_id == null) {
+      // 无归属工作空间的事项无法定位更新路径，明确告知而非静默失败
+      message.warning('该事项缺少工作空间归属，无法移动');
+      return;
+    }
 
     try {
       // 056：force-status 单字段更新，无需携带 prompt 全量字段
@@ -202,7 +207,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
       .then(full => {
         setPromptCache(prev => new Map(prev).set(todoId, full.prompt || ''));
       })
-      .catch(() => {})
+      .catch((e) => console.error(`prompt 加载失败 (todo ${todoId}):`, e))
       .finally(() => {
         setPromptLoadingIds(prev => {
           const next = new Set(prev);

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -7,8 +7,9 @@ import { useKanbanExecutionCache } from '@/hooks/useKanbanExecutionCache';
 import { TodoCard } from './TodoCard';
 import * as db from '@/utils/database';
 import { formatRelativeTime } from '@/utils/datetime';
-import type { Todo, ExecutionRecord, ProjectDirectory } from '@/types';
+import type { Todo, TodoBrief, ExecutionRecord, ProjectDirectory } from '@/types';
 import { TimeRangeSegmented } from '@/components/common/TimeRangeSegmented';
+import { TODO_LIST_REFRESH_EVENT } from '@/constants';
 import { COLUMNS } from './kanban/constants';
 import { getColumnForStatus } from './kanban/helpers';
 import type { ColumnDef } from './kanban/constants';
@@ -16,12 +17,17 @@ import type { ColumnDef } from './kanban/constants';
 /* ─── Component ─── */
 
 export function KanbanBoard({ searchText: externalSearch, hours: externalHours, onSearchChange, onHoursChange }: { searchText?: string; hours?: number; onSearchChange?: (v: string) => void; onHoursChange?: (h: number) => void } = {}) {
-  const { state, dispatch } = useApp();
+  const { state } = useApp();
   const { message } = App.useApp();
-  const { todos, tags, selectedTodoId } = state;
-  // 本地时间过滤后的 todo 列表：当 hours 有值时，按 API 过滤结果只保留最近 N 小时的 todo。
-  // 不与全局 store 共享，避免污染其他视图。
-  const [kanbanTodos, setKanbanTodos] = useState<Todo[] | null>(null);
+  const { tags, selectedTodoId } = state;
+  // 056：看板数据源改为 TodoBrief（决策 1a）——不含 prompt 大字段，
+  // 卡片 prompt 区块按 has_prompt 显示入口、展开时按需取全文。
+  const [briefs, setBriefs] = useState<TodoBrief[]>([]);
+  // 本地时间过滤后的 brief 列表：当 hours 有值时，按 API 过滤结果只保留最近 N 小时的。
+  const [kanbanTodos, setKanbanTodos] = useState<TodoBrief[] | null>(null);
+  // 按需加载的 prompt 全文缓存（id → prompt），首次展开时拉取
+  const [promptCache, setPromptCache] = useState<Map<number, string>>(new Map());
+  const [promptLoadingIds, setPromptLoadingIds] = useState<Set<number>>(new Set());
   const [projectDirectories, setProjectDirectories] = useState<ProjectDirectory[]>([]);
   // selectedProject 使用 workspace_id（project_directories.id），不再用 path。
   const [selectedProject, setSelectedProject] = useState<number | null>(null);
@@ -39,30 +45,38 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
   const isMobile = useIsMobile();
   const [activeKey, setActiveKey] = useState<Todo['status']>('pending');
 
-  // 渲染用的 todo 列表：有本地过滤结果则用，否则用全局 store
-  const displayTodos = kanbanTodos ?? todos;
+  // 渲染用的列表：有本地过滤结果则用，否则用全量 brief
+  const displayTodos = kanbanTodos ?? briefs;
 
   /* ─── Execution record cache (delegated to hook) ─── */
   const cache = useKanbanExecutionCache({ todos: displayTodos, storeRecords: state.executionRecords, workspaceId: state.selectedWorkspace });
 
-  // 切换工作空间后立即拉取该 workspace 的 todo，保证数据最新。
-  // 先 dispatch 空数组占位清除旧数据，避免闪烁。
+  // 056：切换工作空间后拉取该 ws 的 brief 列表；
+  // TODO_LIST_REFRESH_EVENT（保存/删除/执行事件）触发重拉，保持与列表页一致。
   useEffect(() => {
     const wid = state.selectedWorkspace;
     if (wid == null) return;
-    dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: [] });
-    db.getAllTodos(wid).then(todos => {
-      dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: todos });
-    });
-  }, [state.selectedWorkspace, dispatch]);
+    let cancelled = false;
+    const load = () => {
+      db.getTodoBriefs(wid).then(bs => {
+        if (!cancelled) setBriefs(bs);
+      }).catch(() => {});
+    };
+    load();
+    window.addEventListener(TODO_LIST_REFRESH_EVENT, load);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(TODO_LIST_REFRESH_EVENT, load);
+    };
+  }, [state.selectedWorkspace]);
 
-  // 时间分段按钮切换时，用 hours 参数重新拉取（只影响本地 kanbanTodos，不污染全局 store）。
+  // 时间分段按钮切换时，用 hours 参数重新拉取（只影响本地 kanbanTodos，不污染基础列表）。
   useEffect(() => {
     const wid = state.selectedWorkspace;
     if (wid == null) return;
     if (hours == null) { setKanbanTodos(null); return; }
-    db.getAllTodos(wid, hours).then(setKanbanTodos).catch(() => {});
-  }, [state.selectedWorkspace, hours, dispatch]);
+    db.getTodoBriefs(wid, { hours }).then(setKanbanTodos).catch(() => {});
+  }, [state.selectedWorkspace, hours]);
 
   // 加载项目目录列表，供项目维度过滤使用。
   // 监听 'projectDirectoryAdded' 事件：当 TodoDrawer 中快速新增目录后，
@@ -89,11 +103,10 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
         const tUpdated = new Date(t.updated_at).getTime();
         if (isNaN(tUpdated) || tUpdated < cutoff) return false;
       }
-      // Search filter
+      // Search filter（056：brief 不含 prompt，搜索范围收缩为标题）
       if (searchText.trim()) {
         const q = searchText.toLowerCase();
-        return t.title.toLowerCase().includes(q) ||
-          (t.prompt && t.prompt.toLowerCase().includes(q));
+        return t.title.toLowerCase().includes(q);
       }
       return true;
     });
@@ -101,15 +114,16 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
 
   /* ─── Group by status ─── */
   const grouped = useMemo(() => {
-    const map: Record<Todo['status'], Todo[]> = {
+    const map: Record<Todo['status'], TodoBrief[]> = {
       pending: [],
       running: [],
       completed: [],
       failed: [],
     };
     for (const todo of filteredTodos) {
-      if (map[todo.status]) {
-        map[todo.status].push(todo);
+      const status = todo.status as Todo['status'];
+      if (map[status]) {
+        map[status].push(todo);
       } else {
         map.pending.push(todo);
       }
@@ -157,34 +171,46 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
     const todoId = parseInt(e.dataTransfer.getData('text/plain'), 10);
     if (isNaN(todoId)) return;
 
-    const todo = todos.find(t => t.id === todoId);
-    if (!todo || todo.status === targetStatus) return;
+    const todo = displayTodos.find(t => t.id === todoId);
+    if (!todo || todo.status === targetStatus || todo.workspace_id == null) return;
 
     try {
-      const updated = await db.updateTodo(
-        todo.workspace_id!,
-        todoId,
-        todo.title,
-        todo.prompt || '',
-        targetStatus,
-        todo.executor,
-      );
-      dispatch({ type: 'UPDATE_TODO', payload: updated });
+      // 056：force-status 单字段更新，无需携带 prompt 全量字段
+      await db.updateTodoStatus(todo.workspace_id, todoId, targetStatus);
+      // 本地就地更新 brief 状态（避免整列重拉闪烁）
+      setBriefs(prev => prev.map(b => b.id === todoId ? { ...b, status: targetStatus } : b));
+      setKanbanTodos(prev => prev ? prev.map(b => b.id === todoId ? { ...b, status: targetStatus } : b) : prev);
       message.success(`已移动到「${getColumnForStatus(targetStatus).label}」`);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : '更新状态失败';
       message.error(msg);
     }
-  }, [todos, dispatch, message]);
+  }, [displayTodos, message]);
 
-  /* ─── Toggle expand prompt ─── */
+  /* ─── Toggle expand prompt（056：首次展开时按需拉取 prompt 全文）─── */
   const togglePrompt = useCallback((todoId: number) => {
     setExpandedPromptIds(prev => {
       const next = new Set(prev);
       if (next.has(todoId)) next.delete(todoId); else next.add(todoId);
       return next;
     });
-  }, []);
+    // 未缓存且未在途时才发请求；展开动作幂等
+    const wid = state.selectedWorkspace;
+    if (wid == null || promptCache.has(todoId)) return;
+    setPromptLoadingIds(prev => new Set(prev).add(todoId));
+    db.getTodo(wid, todoId)
+      .then(full => {
+        setPromptCache(prev => new Map(prev).set(todoId, full.prompt || ''));
+      })
+      .catch(() => {})
+      .finally(() => {
+        setPromptLoadingIds(prev => {
+          const next = new Set(prev);
+          next.delete(todoId);
+          return next;
+        });
+      });
+  }, [state.selectedWorkspace, promptCache]);
 
   /* ─── Toggle result card expansion ─────────────────────────────
    * Responsibilities are intentionally split:
@@ -192,7 +218,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
    *   - cache.toggleResult handles lazy-fetch of result text
    * Splitting avoids duplicating UI state into the hook and keeps
    * the hook purely about data fetching. ─── */
-  const handleToggleResult = useCallback(async (todo: Todo) => {
+  const handleToggleResult = useCallback(async (todo: TodoBrief) => {
     // Update local UI expansion state
     setExpandedResultIds(prev => {
       const next = new Set(prev);
@@ -204,7 +230,7 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
   }, [cache]);
 
   /* ─── Render Card ─── */
-  const renderCard = (todo: Todo) => {
+  const renderCard = (todo: TodoBrief) => {
     const column = getColumnForStatus(todo.status);
     const todoTags = tags.filter(t => todo.tag_ids?.includes(t.id));
     const projectDir = projectDirectories.find(d => d.id === todo.workspace_id);
@@ -267,7 +293,9 @@ export function KanbanBoard({ searchText: externalSearch, hours: externalHours, 
         <TodoCard
           id={todo.id}
           title={todo.title}
-          prompt={todo.prompt}
+          prompt={promptCache.get(todo.id) ?? null}
+          hasPrompt={todo.has_prompt}
+          promptLoading={promptLoadingIds.has(todo.id)}
           resultText={resultText}
           isSuccess={isSuccess}
           showResultSection={isFinished}

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -78,14 +78,8 @@ export function MemorialBoard() {
     return () => { cancelled = true; };
   }, [hours, boardMode, state.selectedWorkspace]);
 
-  // 切换工作空间后立即拉取该 workspace 的 todo，保证数据最新。
-  useEffect(() => {
-    const wid = state.selectedWorkspace;
-    if (wid == null) return;
-    db.getAllTodos(wid).then(todos => {
-      dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: todos });
-    });
-  }, [state.selectedWorkspace, dispatch]);
+  // 056：全局 todos 桶已删除，纪念板不再需要按工作空间预拉 todos——
+  // 项目名由 RecentCompletedTodo.workspace_id 直接反查 projectDirectories。
 
   // 加载项目目录列表，供项目维度过滤使用。
   // 与 KanbanBoard 逻辑一致：首次加载 + 监听 TodoDrawer 快速新增事件刷新。
@@ -207,7 +201,7 @@ export function MemorialBoard() {
       );
     }
     return result;
-  }, [items, searchText, state.todos]);
+  }, [items, searchText]);
 
   /* ─── Responsive column count ─── */
   const [columnCount, setColumnCount] = useState(() => {
@@ -252,9 +246,8 @@ export function MemorialBoard() {
     const isSuccess = item.execution_status === 'success';
     const expanded = expandedIds.has(item.todo_id);
     const resolvedTags = item.tag_ids.map(tid => state.tags.find(t => t.id === tid)).filter(Boolean) as Tag[];
-    // 获取项目名称（按 workspace_id 匹配）
-    const todo = state.todos.find(t => t.id === item.todo_id);
-    const projectDir = projectDirectories.find(d => d.id === todo?.workspace_id);
+    // 获取项目名称（056：item.workspace_id 直接反查，不再绕道全量 todos 桶）
+    const projectDir = projectDirectories.find(d => d.id === item.workspace_id);
     const projectName = projectDir?.name || null;
 
     // Run history: determine which run to display

--- a/frontend/src/components/RunningRecordDrawer.tsx
+++ b/frontend/src/components/RunningRecordDrawer.tsx
@@ -12,6 +12,7 @@ import XMarkdown from '@ant-design/x-markdown';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { useApp } from '@/hooks/useApp';
 import { useViewState } from '@/hooks/useViewState';
+import { useTodoById } from '@/hooks/useTodoById';
 import { formatLocalDateTime } from '@/utils/datetime';
 import { formatTokens, formatDuration, elapsedSeconds } from '@/utils/format';
 import { LOG_TYPE_COLORS, STATUS_COLORS, REVIEW_RESULT_COLORS } from '@/constants';
@@ -136,7 +137,8 @@ export function RunningRecordDrawer({ record, open, onClose, onRefresh }: Runnin
   const { selectTodo } = useViewState();
   const [stopping, setStopping] = useState(false);
 
-  const todo = record ? state.todos.find(t => t.id === record.todo_id) : null;
+  // 056：全局桶删除后按 id 定点查询（带共享缓存），记录为 null 时不发请求
+  const todo = useTodoById(state.selectedWorkspace, record?.todo_id ?? null);
   const isRunning = record?.status === 'running';
 
   const handleNavigateTodo = useCallback(() => {

--- a/frontend/src/components/TodoCard.tsx
+++ b/frontend/src/components/TodoCard.tsx
@@ -208,10 +208,14 @@ export const TodoCard = memo(function TodoCard({
             </div>
             {promptExpanded && (
               <div className="kanban-card-section-content">
-                {promptLoading || prompt == null ? (
+                {promptLoading ? (
                   <Spin size="small" />
-                ) : (
+                ) : prompt != null ? (
                   <XMarkdown content={prompt} />
+                ) : (
+                  // CodeRabbit#10：加载失败后 promptLoading=false 且 prompt 为 null，
+                  // 必须给出终态文案，否则永远停在加载动画
+                  <span style={{ color: 'var(--color-text-tertiary)', fontSize: 12 }}>加载失败，收起后重试</span>
                 )}
               </div>
             )}

--- a/frontend/src/components/TodoCard.tsx
+++ b/frontend/src/components/TodoCard.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { Tag, Badge, message } from 'antd';
+import { Tag, Badge, message, Spin } from 'antd';
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
@@ -23,6 +23,10 @@ export interface TodoCardProps {
   title: string;
   prompt: string | null;
   resultText: string | null;
+  /** 056：prompt 是否非空（看板 brief 模式不传 prompt 本体，仅据此显示区块入口） */
+  hasPrompt?: boolean;
+  /** 056：prompt 正按需加载中（展开时显示 Spin 而非内容） */
+  promptLoading?: boolean;
 
   /** Status display */
   isSuccess: boolean;
@@ -98,6 +102,8 @@ export const TodoCard = memo(function TodoCard({
   title,
   prompt,
   resultText,
+  hasPrompt,
+  promptLoading,
   isSuccess,
   showResultSection,
   executor,
@@ -175,8 +181,8 @@ export const TodoCard = memo(function TodoCard({
 
       {/* ── Card Body (Expandable Sections) ── */}
       <div className="kanban-card-body">
-        {/* Prompt Section */}
-        {prompt && (
+        {/* Prompt Section（056：hasPrompt 决定区块入口；内容按需加载） */}
+        {(prompt || hasPrompt) && (
           <div className="kanban-card-section">
             <div
               className="kanban-card-section-header kanban-section-prompt"
@@ -186,7 +192,7 @@ export const TodoCard = memo(function TodoCard({
               onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); onTogglePrompt(); } }}
             >
               <span className="kanban-card-section-label"><EditOutlined /> Prompt</span>
-              {prompt && (
+              {prompt != null && prompt !== '' && (
                 <CopyButton
                   text={prompt}
                   type="text"
@@ -202,7 +208,11 @@ export const TodoCard = memo(function TodoCard({
             </div>
             {promptExpanded && (
               <div className="kanban-card-section-content">
-                <XMarkdown content={prompt} />
+                {promptLoading || prompt == null ? (
+                  <Spin size="small" />
+                ) : (
+                  <XMarkdown content={prompt} />
+                )}
               </div>
             )}
           </div>

--- a/frontend/src/components/TodoCenterCardView.tsx
+++ b/frontend/src/components/TodoCenterCardView.tsx
@@ -86,10 +86,25 @@ export function TodoCenterCardView({
       return 'manual';
     }
   });
-  // 状态筛选（设计文档工具栏「状态筛选」）：'all' 或具体 status
+  // 状态筛选（设计文档工具栏「状态筛选」下拉）：'all' 或具体 status
   const [statusFilter, setStatusFilter] = useState<string>('all');
-  // 动作类型筛选（设计文档工具栏「动作类型筛选」）：'all' 或具体 action_type
+  // 动作类型筛选（设计文档工具栏「动作类型筛选」下拉）：'all' 或具体 action_type
   const [actionTypeFilter, setActionTypeFilter] = useState<string>('all');
+
+  // 筛选 setter 合并「回第 1 页」：与条件变更同批次提交（React 批处理后单次 render），
+  // 避免「条件先变→用旧页码发请求→页码再变→再发一次」的双重请求与响应竞争（评审 C1）。
+  const changeBucket = useCallback((b: ComputedBucket) => {
+    setActiveBucket(b);
+    setPage(1);
+  }, []);
+  const changeStatusFilter = useCallback((s: string) => {
+    setStatusFilter(s);
+    setPage(1);
+  }, []);
+  const changeActionTypeFilter = useCallback((t: string) => {
+    setActionTypeFilter(t);
+    setPage(1);
+  }, []);
 
   // 拉取事项中心当前页（056：bucket/search/status/actionType/分页全部下推 SQL）。
   // 工作空间变化、筛选变化、翻页或手动刷新时触发；
@@ -119,11 +134,6 @@ export function TodoCenterCardView({
   useEffect(() => {
     reload();
   }, [reload, refreshKey]);
-
-  // 筛选/分类变化时重回第 1 页（当前页在新过滤口径下可能越界）
-  useEffect(() => {
-    setPage(1);
-  }, [activeBucket, statusFilter, actionTypeFilter]);
 
   // activeBucket 变化时持久化到 localStorage
   useEffect(() => {
@@ -162,7 +172,7 @@ export function TodoCenterCardView({
         <div className="todo-center-tabs-toolbar">
           <Segmented
             value={activeBucket}
-            onChange={(val) => setActiveBucket(val as ComputedBucket)}
+            onChange={(val) => changeBucket(val as ComputedBucket)}
             options={BUCKETS.map((b) => ({
               label: (
                 <span data-testid={`todo-center-tab-${b.value}`}>
@@ -179,7 +189,7 @@ export function TodoCenterCardView({
               <Select
                 size="small"
                 value={statusFilter}
-                onChange={setStatusFilter}
+                onChange={changeStatusFilter}
                 style={{ width: 120 }}
                 options={[
                   { value: 'all', label: '全部状态' },
@@ -193,7 +203,7 @@ export function TodoCenterCardView({
               <Select
                 size="small"
                 value={actionTypeFilter}
-                onChange={setActionTypeFilter}
+                onChange={changeActionTypeFilter}
                 style={{ width: 140 }}
                 options={[{ value: 'all', label: '全部来源' }, ...actionTypeOptions.map((t) => ({ value: t, label: sourceLabel(t) ?? t }))]}
                 data-testid="todo-center-action-filter"

--- a/frontend/src/components/TodoCenterCardView.tsx
+++ b/frontend/src/components/TodoCenterCardView.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Empty, Segmented, Select, Spin, message } from 'antd';
+import { useCallback, useEffect, useState } from 'react';
+import { Empty, Pagination, Segmented, Select, Spin, message } from 'antd';
 import { AppstoreOutlined } from '@ant-design/icons';
 import { TODO_LIST_REFRESH_EVENT } from '@/constants';
 import { useApp } from '@/hooks/useApp';
@@ -60,10 +60,24 @@ export function TodoCenterCardView({
   // v1 纯 workspace-scoped：selectedWorkspace 必须有值才能拉 todos/center
   const workspaceId = state.selectedWorkspace ?? 0;
 
-  // 全量事项（后端已按 computed_bucket 分桶补算），前端再做筛选/分组
+  // 056：服务端分页——items 仅当前页；bucket_counts/action_types 由后端聚合返回
   const [items, setItems] = useState<TodoCenterItem[]>([]);
+  const [bucketCounts, setBucketCounts] = useState<Record<string, number>>({});
+  const [actionTypeOptions, setActionTypeOptions] = useState<string[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(24);
   // 加载态控制 Spin + 刷新按钮 loading
   const [loading, setLoading] = useState(false);
+  // 搜索词防抖（与列表页同口径：停顿 300ms 后再发请求）
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchKeyword.trim());
+      setPage(1);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchKeyword]);
   // 当前 Tab（五类驱动），默认手动触发；持久化到 localStorage 记住用户上次选择
   const [activeBucket, setActiveBucket] = useState<ComputedBucket>(() => {
     try {
@@ -77,23 +91,39 @@ export function TodoCenterCardView({
   // 动作类型筛选（设计文档工具栏「动作类型筛选」）：'all' 或具体 action_type
   const [actionTypeFilter, setActionTypeFilter] = useState<string>('all');
 
-  // 拉取事项中心列表。工作空间变化或手动刷新时触发；
+  // 拉取事项中心当前页（056：bucket/search/status/actionType/分页全部下推 SQL）。
+  // 工作空间变化、筛选变化、翻页或手动刷新时触发；
   // 卡片操作（归档/恢复/webhook/执行）完成后也会调它重拉，保持口径一致。
   const reload = useCallback(async () => {
     setLoading(true);
     try {
-      const data = await db.getTodoCenter(workspaceId);
-      setItems(data);
+      const data = await db.getTodoCenter(workspaceId, {
+        bucket: activeBucket,
+        search: debouncedSearch || undefined,
+        status: statusFilter,
+        actionType: actionTypeFilter,
+        page,
+        pageSize,
+      });
+      setItems(data.items);
+      setTotal(data.total);
+      setBucketCounts(data.bucket_counts);
+      setActionTypeOptions(data.action_types);
     } catch (e) {
       message.error(`加载事项中心失败：${e instanceof Error ? e.message : String(e)}`);
     } finally {
       setLoading(false);
     }
-  }, [workspaceId]);
+  }, [workspaceId, activeBucket, debouncedSearch, statusFilter, actionTypeFilter, page, pageSize]);
 
   useEffect(() => {
     reload();
   }, [reload, refreshKey]);
+
+  // 筛选/分类变化时重回第 1 页（当前页在新过滤口径下可能越界）
+  useEffect(() => {
+    setPage(1);
+  }, [activeBucket, statusFilter, actionTypeFilter]);
 
   // activeBucket 变化时持久化到 localStorage
   useEffect(() => {
@@ -111,33 +141,11 @@ export function TodoCenterCardView({
     return () => window.removeEventListener(TODO_LIST_REFRESH_EVENT, handler);
   }, [reload]);
 
-  // 按 computed_bucket 分桶，用于 Tab 计数与卡片过滤
-  const bucketCount = useMemo(() => {
-    const counts: Record<ComputedBucket, number> = {
-      manual: 0, time_driven: 0, event_driven: 0, loop_driven: 0, archived: 0,
-    };
-    for (const it of items) counts[it.computed_bucket]++;
-    return counts;
-  }, [items]);
+  // 056：Tab 计数与卡片数据均来自服务端（bucket_counts 后端聚合），不再页内分桶
+  const bucketCount = (b: ComputedBucket): number => bucketCounts[b] ?? 0;
 
-  // 当前 Tab 的卡片：按分类 + 搜索 + 状态 + 动作类型过滤
-  const visibleItems = useMemo(() => {
-    const kw = searchKeyword.trim().toLowerCase();
-    return items.filter((it) => {
-      if (it.computed_bucket !== activeBucket) return false;
-      if (statusFilter !== 'all' && it.status !== statusFilter) return false;
-      if (actionTypeFilter !== 'all' && (it.action_type ?? 'none') !== actionTypeFilter) return false;
-      if (!kw) return true;
-      return it.title.toLowerCase().includes(kw) || it.prompt.toLowerCase().includes(kw);
-    });
-  }, [items, activeBucket, searchKeyword, statusFilter, actionTypeFilter]);
-
-  // 动作类型筛选项：从当前数据动态去重，避免硬编码漏掉新类型
-  const actionTypeOptions = useMemo(() => {
-    const set = new Set<string>();
-    for (const it of items) if (it.action_type) set.add(it.action_type);
-    return Array.from(set);
-  }, [items]);
+  // 当前 Tab 的卡片即服务端当前页（bucket/search/status/actionType 过滤已在 SQL 层完成）
+  const visibleItems = items;
 
   return (
     <PageCard
@@ -158,7 +166,7 @@ export function TodoCenterCardView({
             options={BUCKETS.map((b) => ({
               label: (
                 <span data-testid={`todo-center-tab-${b.value}`}>
-                  {b.label} <span className="todo-center-tab-count">{bucketCount[b.value]}</span>
+                  {b.label} <span className="todo-center-tab-count">{bucketCount(b.value)}</span>
                 </span>
               ),
               value: b.value,
@@ -197,17 +205,32 @@ export function TodoCenterCardView({
         {visibleItems.length === 0 ? (
           <Empty description={EMPTY_TEXT[activeBucket]} style={{ marginTop: 48 }} />
         ) : (
-          <div className="todo-center-grid">
-            {visibleItems.map((item) => (
-              <TodoCenterCard
-                key={item.id}
-                item={item}
-                onChanged={reload}
-                onSelectTodo={onSelectTodo}
-                onSelectLoop={onSelectLoop}
+          <>
+            <div className="todo-center-grid">
+              {visibleItems.map((item) => (
+                <TodoCenterCard
+                  key={item.id}
+                  item={item}
+                  onChanged={reload}
+                  onSelectTodo={onSelectTodo}
+                  onSelectLoop={onSelectLoop}
+                />
+              ))}
+            </div>
+            {/* 056：卡片墙服务端分页——翻页只影响当前 Tab 的卡片集 */}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '12px 4px' }}>
+              <Pagination
+                current={page}
+                pageSize={pageSize}
+                total={total}
+                onChange={(p, ps) => { setPage(ps !== pageSize ? 1 : p); setPageSize(ps); }}
+                showSizeChanger
+                pageSizeOptions={['24', '48', '96']}
+                showTotal={(t) => `共 ${t} 项`}
+                size="small"
               />
-            ))}
-          </div>
+            </div>
+          </>
         )}
       </Spin>
     </PageCard>

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -5,7 +5,7 @@ import { useExecutionHistory } from '@/hooks/useExecutionHistory';
 import { Button, Empty, App, Modal, Input, Skeleton } from 'antd';
 import { CheckCircleOutlined, ReloadOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { TodoDrawer } from './TodoDrawer';
-import { BREAKPOINTS } from '@/constants';
+import { BREAKPOINTS, TODO_LIST_REFRESH_EVENT } from '@/constants';
 import * as db from '@/utils/database';
 import { extractTitle } from '@/utils/titleExtractor';
 import type { ExecutionRecord, Todo } from '@/types';
@@ -277,9 +277,9 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost, onActionsReady }:
     if (!selectedTodo) return;
     try {
       const updated = await db.updateTodo(selectedTodo.workspace_id!, selectedTodo.id, selectedTodo.title, selectedTodo.prompt || '', newStatus);
-      dispatch({ type: 'UPDATE_TODO', payload: updated });
-      // 同步更新 local state，避免详情页状态滞后
+      // 056：全局桶已删除——详情页本地 state 为准，列表页经刷新事件重拉
       setSelectedTodo(updated);
+      window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
       message.success('状态已更新');
     } catch {
       // ignore: interceptor already shows error
@@ -307,9 +307,9 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost, onActionsReady }:
       selectedTodo.acceptance_criteria,
       selectedTodo.auto_review_enabled,
     );
-    dispatch({ type: 'UPDATE_TODO', payload: updated });
-    // 同步更新 local state，避免详情页标题滞后
+    // 056：全局桶已删除——详情页本地 state 为准，列表页经刷新事件重拉
     setSelectedTodo(updated);
+    window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
   }, [selectedTodo, dispatch]);
 
   // 升级/降级已移除：环节与 Todo 合一，无需 promote 流程
@@ -319,7 +319,8 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost, onActionsReady }:
     if (!selectedTodo) return;
     try {
       await db.deleteTodo(selectedTodo.workspace_id!, selectedTodo.id);
-      dispatch({ type: 'DELETE_TODO', payload: selectedTodo.id });
+      // 056：全局桶已删除——通知列表页重拉
+      window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
       dispatch({ type: 'SELECT_TODO', payload: null });
       message.success('删除成功');
     } catch {
@@ -491,13 +492,8 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost, onActionsReady }:
           // 抽屉保存可能修改多个字段（标题/prompt/执行器/调度等），
           // 直接用 reloadSelectedTodo 拉取最新数据，避免 local state 滞后。
           reloadSelectedTodo();
-          // 同步刷新当前 workspace 桶，保持列表与详情一致
-          const wid = state.selectedWorkspace;
-          if (wid != null) {
-            db.getAllTodos(wid).then(todos => {
-              dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: todos });
-            });
-          }
+          // 056：全局桶已删除——通知列表页重拉当前页，保持列表与详情一致
+          window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
           if (selectedTodoId) {
             loadExecutionRecords(1, historyLimit);
           }

--- a/frontend/src/components/dashboard/RecentExecutionsTable.tsx
+++ b/frontend/src/components/dashboard/RecentExecutionsTable.tsx
@@ -6,7 +6,7 @@
 import type { ColumnsType } from 'antd/es/table';
 import { Card, Table, Badge, Tag, Empty } from 'antd';
 import { ThunderboltOutlined } from '@ant-design/icons';
-import type { DashboardStats, Todo } from '@/types';
+import type { DashboardStats, TodoBrief } from '@/types';
 import { getExecutorOption } from '@/types';
 import { formatRelativeTime } from '@/utils/datetime';
 
@@ -15,12 +15,12 @@ type RecentExecution = DashboardStats['recent_executions'][number];
 
 interface RecentExecutionsTableProps {
   executions: RecentExecution[];
-  /** 全量 todo,用于把 todo_id 反查为标题;查不到时回退「任务 #id」。 */
-  todos: Todo[];
+  /** 056：todo 摘要（仅标题反查需要），查不到时回退「任务 #id」。 */
+  todos: TodoBrief[];
 }
 
 // 把 todo_id 渲染为可读标题:优先用 todo 标题,缺失才回退编号,避免空白单元格。
-function renderTodoTitle(todoId: number, todos: Todo[]) {
+function renderTodoTitle(todoId: number, todos: TodoBrief[]) {
   const todo = todos.find((t) => t.id === todoId);
   return <span style={{ fontWeight: 600 }}>{todo?.title ?? `任务 #${todoId}`}</span>;
 }
@@ -64,7 +64,7 @@ function renderTime(startedAt: string) {
 
 // 列定义抽成纯函数:依赖 todos(标题反查)。
 // 标注 ColumnsType<RecentExecution> 让 render 的 value 形参得到精确类型而非隐式 any。
-function buildColumns(todos: Todo[]): ColumnsType<RecentExecution> {
+function buildColumns(todos: TodoBrief[]): ColumnsType<RecentExecution> {
   return [
     { title: '任务', dataIndex: 'todo_id', key: 'todo_id', render: (v) => renderTodoTitle(v as number, todos) },
     { title: '执行器', dataIndex: 'executor', key: 'executor', width: 100, render: (v) => renderExecutor(v as string | null) },

--- a/frontend/src/components/dashboard/tabs/OverviewTab.tsx
+++ b/frontend/src/components/dashboard/tabs/OverviewTab.tsx
@@ -3,7 +3,7 @@
 // 设计目标:一屏看完系统健康度,不放细节卡片(细节下沉到其他 Tab)。
 // 包含:核心 KPI、运行中任务、执行趋势、贡献热力图、活跃/连续打卡、最近执行记录表,
 // 末尾放分享卡(安装引导)——看完核心数据后的自然推广位。
-import type { DashboardStats, RunningTask, Todo } from '@/types';
+import type { DashboardStats, RunningTask, TodoBrief } from '@/types';
 import { KeyMetricsCard, OverviewCard } from '@/components/dashboard/StatsGridCards';
 import { ActiveTasksCard, ShareCardPanel } from '@/components/dashboard/SpecialCards';
 import { TrendChartCard, ContributionHeatmapCard } from '@/components/dashboard/ChartCards';
@@ -15,7 +15,8 @@ interface OverviewTabProps {
   loading: boolean;
   successRate: number;
   runningTasks: RunningTask[];
-  todos: Todo[];
+  /** 056：只传最近执行记录涉及的 todo 摘要（按 id 集反查），不再是全量列表 */
+  todos: TodoBrief[];
 }
 
 export function OverviewTab({ stats, loading, successRate, runningTasks, todos }: OverviewTabProps) {

--- a/frontend/src/components/running-board/index.tsx
+++ b/frontend/src/components/running-board/index.tsx
@@ -16,7 +16,7 @@ import {
   useAutoRefreshRunningBoard,
 } from '@/hooks/useRunningBoard';
 import { STATUS_COLORS } from '@/constants';
-import type { ExecutionRecord, RunningBoardColumn } from '@/types';
+import type { ExecutionRecord, RunningBoardColumn, TodoBrief } from '@/types';
 import { ScheduledTodoCard } from './ScheduledTodoCard';
 import { ExecutionRecordCard } from './ExecutionRecordCard';
 import { RunningBoardColumnView } from './RunningBoardColumnView';
@@ -37,15 +37,26 @@ export function RunningBoard({ searchText, hours }: RunningBoardProps = {}) {
   const { records, scheduledTodos, loading, refresh } = useRunningBoard(state.selectedWorkspace, hours);
   useAutoRefreshRunningBoard(refresh);
 
-  // 切换工作空间后立即拉取该 workspace 的 todo，保证数据最新。
-  const { dispatch } = useApp();
+  // 056：全局 todos 桶已删除。运行面板的 todo 标题按 id 集轻量反查——
+  // 记录/定时任务变化时，对其涉及的 todo_id 集合拉 brief 建映射。
+  const [briefMap, setBriefMap] = useState<Map<number, TodoBrief>>(new Map());
   useEffect(() => {
     const wid = state.selectedWorkspace;
-    if (wid == null) return;
-    db.getAllTodos(wid).then(todos => {
-      dispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: wid, payload: todos });
-    });
-  }, [state.selectedWorkspace, dispatch]);
+    if (wid == null) { setBriefMap(new Map()); return; }
+    const ids = [...new Set([
+      ...records.map(r => r.todo_id),
+      ...scheduledTodos.map(t => t.id),
+    ])];
+    if (ids.length === 0) { setBriefMap(new Map()); return; }
+    let cancelled = false;
+    db.getTodoBriefs(wid, { ids })
+      .then(briefs => {
+        if (!cancelled) setBriefMap(new Map(briefs.map(b => [b.id, b])));
+      })
+      .catch(() => {});
+    // cancelled 防御快速切换：晚返回的响应若发现参数已变，直接丢弃
+    return () => { cancelled = true; };
+  }, [state.selectedWorkspace, records, scheduledTodos]);
 
   const handleCardClick = useCallback((record: ExecutionRecord) => {
     setDrawerRecord(record);
@@ -55,8 +66,8 @@ export function RunningBoard({ searchText, hours }: RunningBoardProps = {}) {
     setDrawerRecord(null);
   }, []);
 
-  // O(1) todo lookup map
-  const todoById = useMemo(() => new Map(state.todos.map(t => [t.id, t])), [state.todos]);
+  // O(1) todo lookup map（056：brief 映射，字段足够标题反查与搜索）
+  const todoById = briefMap;
 
   // Apply filters from toolbar
   const filteredRecords = useMemo(() => {
@@ -73,14 +84,13 @@ export function RunningBoard({ searchText, hours }: RunningBoardProps = {}) {
       });
     }
 
-    // Search filter
+    // Search filter（056：brief 无 prompt 字段，搜索范围收缩为标题/模型/执行器）
     if (searchText?.trim()) {
       const q = searchText.toLowerCase();
       result = result.filter(r => {
         const todo = todoById.get(r.todo_id);
         return (
           (todo?.title?.toLowerCase().includes(q)) ||
-          (todo?.prompt?.toLowerCase().includes(q)) ||
           (r.model?.toLowerCase().includes(q)) ||
           (r.executor?.toLowerCase().includes(q))
         );

--- a/frontend/src/components/running-board/index.tsx
+++ b/frontend/src/components/running-board/index.tsx
@@ -53,7 +53,7 @@ export function RunningBoard({ searchText, hours }: RunningBoardProps = {}) {
       .then(briefs => {
         if (!cancelled) setBriefMap(new Map(briefs.map(b => [b.id, b])));
       })
-      .catch(() => {});
+      .catch((e) => console.error('运行面板 brief 加载失败:', e));
     // cancelled 防御快速切换：晚返回的响应若发现参数已变，直接丢弃
     return () => { cancelled = true; };
   }, [state.selectedWorkspace, records, scheduledTodos]);

--- a/frontend/src/components/running-board/index.tsx
+++ b/frontend/src/components/running-board/index.tsx
@@ -40,14 +40,20 @@ export function RunningBoard({ searchText, hours }: RunningBoardProps = {}) {
   // 056：全局 todos 桶已删除。运行面板的 todo 标题按 id 集轻量反查——
   // 记录/定时任务变化时，对其涉及的 todo_id 集合拉 brief 建映射。
   const [briefMap, setBriefMap] = useState<Map<number, TodoBrief>>(new Map());
-  useEffect(() => {
-    const wid = state.selectedWorkspace;
-    if (wid == null) { setBriefMap(new Map()); return; }
+  // CodeRabbit#8：useRunningBoard 每轮轮询都返回新数组引用，以 id 集合的稳定字符串
+  // 作依赖，集合没变就不重发 brief 请求，也不重建 Map 触发下游 memo 重算。
+  const briefIdsKey = useMemo(() => {
     const ids = [...new Set([
       ...records.map(r => r.todo_id),
       ...scheduledTodos.map(t => t.id),
     ])];
-    if (ids.length === 0) { setBriefMap(new Map()); return; }
+    ids.sort((a, b) => a - b);
+    return ids.join(',');
+  }, [records, scheduledTodos]);
+  useEffect(() => {
+    const wid = state.selectedWorkspace;
+    if (wid == null || briefIdsKey === '') { setBriefMap(new Map()); return; }
+    const ids = briefIdsKey.split(',').map(Number);
     let cancelled = false;
     db.getTodoBriefs(wid, { ids })
       .then(briefs => {
@@ -56,7 +62,7 @@ export function RunningBoard({ searchText, hours }: RunningBoardProps = {}) {
       .catch((e) => console.error('运行面板 brief 加载失败:', e));
     // cancelled 防御快速切换：晚返回的响应若发现参数已变，直接丢弃
     return () => { cancelled = true; };
-  }, [state.selectedWorkspace, records, scheduledTodos]);
+  }, [state.selectedWorkspace, briefIdsKey]);
 
   const handleCardClick = useCallback((record: ExecutionRecord) => {
     setDrawerRecord(record);

--- a/frontend/src/components/settings/BackupPanel.tsx
+++ b/frontend/src/components/settings/BackupPanel.tsx
@@ -416,10 +416,9 @@ export function BackupPanel() {
         return false;
       }
 
-      // v1 纯 workspace-scoped：getAllTodos 需逐空间拉取后合并，
-      // 用于备份导入去重时跨空间检查同名 todo
+      // 056：逐空间分批拉取后合并（备份导入去重需 title+prompt+workspace 判重，属 E 类全量）
       const allExisting = await Promise.all(
-        workspaces.map(ws => db.getAllTodos(ws.id).catch(() => []))
+        workspaces.map(ws => db.getAllTodosBatched(ws.id).catch(() => []))
       );
       const existingTodos = allExisting.flat();
       setExistingTodos(existingTodos.map((t) => ({ title: t.title, prompt: t.prompt, workspace_id: t.workspace_id ?? null })));

--- a/frontend/src/components/settings/BackupPanel.tsx
+++ b/frontend/src/components/settings/BackupPanel.tsx
@@ -417,6 +417,12 @@ export function BackupPanel() {
       }
 
       // 056：逐空间分批拉取后合并（备份导入去重需 title+prompt+workspace 判重，属 E 类全量）
+      // CodeRabbit#9：无工作空间时判重会静默失效（existingTodos 恒为空、重复项被当新建），
+      // 必须显式警告而不是继续导入。
+      if (workspaces.length === 0) {
+        message.warning('当前没有任何工作空间，无法校验重复事项；请先创建工作空间再导入');
+        return false;
+      }
       const allExisting = await Promise.all(
         workspaces.map(ws => db.getAllTodosBatched(ws.id).catch(() => []))
       );

--- a/frontend/src/components/settings/ExecutorsPanel.tsx
+++ b/frontend/src/components/settings/ExecutorsPanel.tsx
@@ -10,7 +10,7 @@ import { ProfilesPanel } from '@/components/settings/ProfilesPanel';
 import { InstallExecutorButton } from '@/components/settings/InstallExecutorButton';
 import { getExecutorInstallPrompt } from '@/components/settings/executorInstallPrompts';
 import * as db from '@/utils/database';
-import type { ExecutorConfig, ExecutionRecord } from '@/types';
+import type { ExecutorConfig, ExecutionRecord, TodoBrief } from '@/types';
 import { useApp } from '@/hooks/useApp';
 import { SessionManager } from '@/components/SessionManager';
 
@@ -95,7 +95,8 @@ export function ExecutorsPanel() {
 
   // 正在运行 tab 相关状态
   const { state } = useApp();
-  const { todos } = state;
+  // 056：运行记录的 todo 标题按 id 集轻量反查（替代原全局全量桶）
+  const [recordTodos, setRecordTodos] = useState<TodoBrief[]>([]);
   const [runningTab, setRunningTab] = useState<'executors' | 'running' | 'sessions'>('executors');
   const [selectedRecordIds, setSelectedRecordIds] = useState<number[]>([]);
   const [stoppingRecords, setStoppingRecords] = useState(false);
@@ -112,6 +113,14 @@ export function ExecutorsPanel() {
     try {
       const records = await db.getRunningExecutionRecords(state.selectedWorkspace ?? 0);
       setRunningRecords(records);
+      // 056：按记录的 todo_id 集合拉 brief 反查标题；失败时保留旧映射避免闪空
+      const todoIds = [...new Set(records.map(r => r.todo_id))];
+      if (todoIds.length > 0 && state.selectedWorkspace != null) {
+        const briefs = await db.getTodoBriefs(state.selectedWorkspace, { ids: todoIds }).catch(() => null);
+        if (briefs) setRecordTodos(briefs);
+      } else {
+        setRecordTodos([]);
+      }
     } catch (err) {
       console.error('加载运行中任务失败:', err);
     }
@@ -865,7 +874,7 @@ export function ExecutorsPanel() {
                     key: 'todo_title',
                     ellipsis: true,
                     render: (_: unknown, record: ExecutionRecord) => {
-                      const todo = todos.find(t => t.id === record.todo_id);
+                      const todo = recordTodos.find(t => t.id === record.todo_id);
                       return todo ? todo.title : `#${record.todo_id}`;
                     },
                   },

--- a/frontend/src/components/settings/workspace/DefaultResponseConfigPanel.tsx
+++ b/frontend/src/components/settings/workspace/DefaultResponseConfigPanel.tsx
@@ -4,7 +4,7 @@ import * as db from '@/utils/database';
 import { listLoops } from '@/utils/database/loops';
 import { EXECUTORS_FOR_PICKER } from '@/utils/executors';
 import { ExecutorPicker } from '@/components/todo-drawer/ExecutorPicker';
-import type { Todo } from '@/types';
+import type { TodoBrief } from '@/types';
 import type { LoopListItem } from '@/types/loop';
 import type { AgentBot } from '@/utils/database';
 import type { FeishuHistoryChat } from '@/types';
@@ -18,7 +18,7 @@ interface DefaultResponseConfigPanelProps {
 }
 
 export function DefaultResponseConfigPanel({ workspaceId, onChanged }: DefaultResponseConfigPanelProps) {
-  const [todos, setTodos] = useState<Todo[]>([]);
+  const [todos, setTodos] = useState<TodoBrief[]>([]);
   const [loops, setLoops] = useState<LoopListItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -36,7 +36,7 @@ export function DefaultResponseConfigPanel({ workspaceId, onChanged }: DefaultRe
     loadSettings();
     loadHistorySettings();
     // 按 workspace_id 过滤 Todo，使下拉列表仅显示当前工作空间内的事项
-    db.getAllTodos(workspaceId).then(setTodos).catch(() => {});
+    db.getTodoBriefs(workspaceId).then(setTodos).catch(() => {});
     // 加载当前工作空间的环路列表
     listLoops(workspaceId).then(setLoops).catch(() => {});
     // 加载当前工作空间的飞书 bot（一个工作空间一个 bot），用于历史拉取群配置

--- a/frontend/src/components/settings/workspace/WorkspaceSlashCommandsPanel.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceSlashCommandsPanel.tsx
@@ -4,7 +4,7 @@ import { PlusOutlined, DeleteOutlined, EditOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import * as db from '@/utils/database';
 import type { WorkspaceSlashCommand } from '@/utils/database';
-import type { Todo } from '@/types';
+import type { TodoBrief } from '@/types';
 import type { LoopListItem } from '@/types/loop';
 
 interface WorkspaceSlashCommandsPanelProps {
@@ -22,7 +22,7 @@ export function WorkspaceSlashCommandsPanel({
 }: WorkspaceSlashCommandsPanelProps) {
   const [commands, setCommands] = useState<WorkspaceSlashCommand[]>([]);
   const [loading, setLoading] = useState(false);
-  const [todos, setTodos] = useState<Todo[]>([]);
+  const [todos, setTodos] = useState<TodoBrief[]>([]);
   const [loops, setLoops] = useState<LoopListItem[]>([]);
 
   // Modal 状态
@@ -42,7 +42,7 @@ export function WorkspaceSlashCommandsPanel({
   };
 
   const loadTodos = () => {
-    db.getAllTodos(workspaceId).then(setTodos).catch(() => {});
+    db.getTodoBriefs(workspaceId).then(setTodos).catch(() => {});
   };
 
   const loadLoops = () => {

--- a/frontend/src/components/todo-list/TodoListPage.test.tsx
+++ b/frontend/src/components/todo-list/TodoListPage.test.tsx
@@ -21,7 +21,10 @@ vi.mock('@/constants', () => ({
 }));
 
 vi.mock('@/utils/database', () => ({
-  getTodoCenter: vi.fn().mockResolvedValue([]),
+  // 056：getTodoCenter 响应为分页结构 { items, total, page, page_size, bucket_counts, action_types }
+  getTodoCenter: vi.fn().mockResolvedValue({
+    items: [], total: 0, page: 1, page_size: 20, bucket_counts: {}, action_types: [],
+  }),
   deleteTodo: vi.fn().mockResolvedValue(undefined),
   executeTodo: vi.fn().mockResolvedValue(undefined),
 }));

--- a/frontend/src/components/todo-list/TodoListPage.tsx
+++ b/frontend/src/components/todo-list/TodoListPage.tsx
@@ -40,50 +40,80 @@ function readInitialView(): 'card' | 'list' {
   }
 }
 
-/** 按搜索词过滤：标题或 prompt 命中关键字（不区分大小写）。 */
-function filterBySearchKeyword(items: TodoCenterItem[], keyword: string): TodoCenterItem[] {
-  const kw = keyword.trim().toLowerCase();
-  if (!kw) return items;
-  return items.filter(todo => {
-    const title = (todo.title || '').toLowerCase();
-    const prompt = (todo.prompt || '').toLowerCase();
-    return title.includes(kw) || prompt.includes(kw);
-  });
-}
+/** 056：搜索防抖毫秒数——输入停顿后再发请求，避免逐字符打服务端。 */
+const SEARCH_DEBOUNCE_MS = 300;
 
-/** 列表数据加载 hook：响应 workspace/视图切换 + 跨组件刷新事件。 */
-function useTodoListData(workspaceId: number | null, viewMode: 'card' | 'list') {
+/** 列表数据加载 hook（056 服务端分页版）：翻页/排序/搜索变化时重新拉取对应页。 */
+function useTodoListData(workspaceId: number | null, viewMode: 'card' | 'list', searchKeyword: string) {
   const [items, setItems] = useState<TodoCenterItem[]>([]);
   const [loading, setLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [total, setTotal] = useState(0);
+  const [sortBy, setSortBy] = useState<string | undefined>(undefined);
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc' | undefined>(undefined);
+  // 搜索词防抖：rawSearchKeyword 即时更新，debouncedSearch 停顿后才变
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+
+  // 搜索输入停顿 SEARCH_DEBOUNCE_MS 后才落盘到 debouncedSearch，并重回第 1 页
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchKeyword.trim());
+      setPage(1);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [searchKeyword]);
 
   // reload 用 useCallback 包裹，使 effect 依赖稳定
   const reload = useCallback(async () => {
-    if (workspaceId == null) { setItems([]); return; }
+    if (workspaceId == null) { setItems([]); setTotal(0); return; }
     setLoading(true);
     try {
-      const data = await db.getTodoCenter(workspaceId);
-      setItems(data);
+      const data = await db.getTodoCenter(workspaceId, {
+        page,
+        pageSize,
+        search: debouncedSearch || undefined,
+        sortBy,
+        sortOrder,
+      });
+      setItems(data.items);
+      setTotal(data.total);
     } catch (e) {
       message.error(`加载事项列表失败：${e instanceof Error ? e.message : String(e)}`);
       setItems([]);
     } finally {
       setLoading(false);
     }
-  }, [workspaceId]);
+  }, [workspaceId, page, pageSize, debouncedSearch, sortBy, sortOrder]);
 
-  // 列表形态挂载/工作空间变化时拉数据；卡片形态不触发（其内部自管）
+  // 列表形态挂载/工作空间变化/分页参数变化时拉数据；卡片形态不触发（其内部自管）
   useEffect(() => {
     if (viewMode === 'list') reload();
-  }, [workspaceId, viewMode, reload]);
+  }, [viewMode, reload]);
 
-  // 跨组件刷新：TodoDrawer 保存、QuickCapture 创建后通过 custom event 通知
+  // 跨组件刷新：TodoDrawer 保存、QuickCapture 创建、WS 执行事件后重拉当前页
   useEffect(() => {
     const handler = () => { if (viewMode === 'list') reload(); };
     window.addEventListener(TODO_LIST_REFRESH_EVENT, handler);
     return () => window.removeEventListener(TODO_LIST_REFRESH_EVENT, handler);
   }, [viewMode, reload]);
 
-  return { items, loading, reload };
+  // 翻页/排序变化处理器（由 TodoListView 的 Table onChange 驱动）
+  const handleServerChange = useCallback(
+    (nextPage: number, nextPageSize: number, nextSortBy?: string, nextSortOrder?: 'asc' | 'desc') => {
+      setPage(nextPageSize !== pageSize ? 1 : nextPage); // 改页大小回第 1 页
+      setPageSize(nextPageSize);
+      setSortBy(nextSortBy);
+      setSortOrder(nextSortOrder);
+    },
+    [pageSize],
+  );
+
+  return {
+    items, loading, reload,
+    pagination: { current: page, pageSize, total },
+    onServerChange: handleServerChange,
+  };
 }
 
 interface TodoListPageProps {
@@ -117,8 +147,9 @@ export function TodoListPage({
   const [searchKeyword, setSearchKeyword] = useState('');
   // 刷新信号：每次点击刷新按钮自增，传递给 TodoCenterCardView 触发重新加载
   const [refreshKey, setRefreshKey] = useState(0);
-  // 列表数据：抽到独立 hook 管理加载/刷新/事件监听
-  const { items, loading, reload } = useTodoListData(workspaceId, viewMode);
+  // 列表数据：056 服务端分页 hook（搜索词传入后内部防抖）
+  const { items, loading, reload, pagination, onServerChange } =
+    useTodoListData(workspaceId, viewMode, searchKeyword);
 
   // 行操作 + 带参执行 Modal（已拆到 TodoListPageParts）
   const rowActions = useTodoRowActions({ workspaceId, onReload: reload });
@@ -135,8 +166,7 @@ export function TodoListPage({
     setRefreshKey(k => k + 1);
   }, [viewMode, reload]);
 
-  // 根据 viewMode 渲染卡片/列表内容
-  const listItems = filterBySearchKeyword(items, searchKeyword);
+  // 根据 viewMode 渲染卡片/列表内容（056：搜索已下推服务端，不再页内过滤）
   const headerExtra = (
     <TodoListHeader
       isMobile={isMobile}
@@ -170,9 +200,11 @@ export function TodoListPage({
           contentStyle={{ padding: 0, display: 'flex', flexDirection: 'column', height: 'calc(100% - 43px)' }}
         >
           <TodoListView
-            items={listItems}
+            items={items}
             loading={loading}
             tags={state.tags}
+            pagination={pagination}
+            onServerChange={onServerChange}
             onSelectTodo={onSelectTodo}
             onEditTodo={onEditTodo}
             onDeleteTodo={rowActions.handleDeleteTodo}

--- a/frontend/src/components/todo-list/TodoListView.tsx
+++ b/frontend/src/components/todo-list/TodoListView.tsx
@@ -24,7 +24,7 @@ import {
   ThunderboltOutlined,
 } from '@ant-design/icons';
 import { useApp } from '@/hooks/useApp';
-import { useResizableColumns, makeSorter } from '@/hooks/useResizableColumns';
+import { useResizableColumns } from '@/hooks/useResizableColumns';
 import { useBatchActions } from './useBatchActions'; // .tsx 含 JSX（批量 Modal）
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 import { ExpertBadge } from '@/components/ExpertBadge';
@@ -197,8 +197,8 @@ function buildTodoColumns(
       dataIndex: 'id',
       width: 70,
       fixed: 'left',
-      // 054：可排序列（ID 数值排序）
-      sorter: makeSorter<TodoCenterItem>('id'),
+      // 056：服务端排序（sorter: true 仅展示排序指示，数据由后端排好返回）
+      sorter: true,
       render: (id: number) => (
         <span style={{ fontFamily: 'monospace', color: 'var(--color-text-tertiary)' }}>
           #{id}
@@ -225,8 +225,8 @@ function buildTodoColumns(
       // scroll.x 时会被压成 0 宽（整列「消失」，用户曾因此报标题列丢失）
       width: 220,
       ellipsis: true,
-      // 054：可排序列（标题字符串排序）
-      sorter: makeSorter<TodoCenterItem>('title'),
+      // 056：服务端排序
+      sorter: true,
       render: (title: string, record) => (
         <a
           onClick={(e) => { e.stopPropagation(); callbacks.onSelectTodo(record.id); }}
@@ -240,8 +240,8 @@ function buildTodoColumns(
       title: '状态',
       dataIndex: 'status',
       width: 100,
-      // 054：可排序列（状态枚举字符串排序）
-      sorter: makeSorter<TodoCenterItem>('status'),
+      // 056：服务端排序
+      sorter: true,
       render: renderStatusTag,
     },
     {
@@ -294,16 +294,16 @@ function buildTodoColumns(
       title: '执行时间',
       dataIndex: 'last_execution_at',
       width: 130,
-      // 054：可排序列（ISO 时间字符串排序）
-      sorter: makeSorter<TodoCenterItem>('last_execution_at'),
+      // 056：聚合字段不支持服务端排序（该值由最近执行记录推导，不在 todos 表），
+      // 页内排序会误导为全局排序，故移除 sorter。
       render: (t?: string | null) => (t ? formatRelativeTime(t) : '-'),
     },
     {
       title: '更新时间',
       dataIndex: 'updated_at',
       width: 130,
-      // 054：可排序列（ISO 时间字符串排序）
-      sorter: makeSorter<TodoCenterItem>('updated_at'),
+      // 056：服务端排序
+      sorter: true,
       render: (t: string) => formatRelativeTime(t),
     },
     {
@@ -325,12 +325,16 @@ function handleRowClick(onSelectTodo: (id: number) => void, record: TodoCenterIt
 }
 
 interface TodoListViewProps {
-  /** 已经过滤后的列表数据（搜索/标签筛选由父组件完成）。 */
+  /** 当前页数据（服务端分页/搜索/排序均在后端完成）。 */
   items: TodoCenterItem[];
   /** 加载态：传入 true 时 table 显示 loading 蒙层。 */
   loading: boolean;
   /** 全量标签集（渲染 Tag 列用）。 */
   tags: TagType[];
+  /** 服务端分页元数据。 */
+  pagination: { current: number; pageSize: number; total: number };
+  /** 翻页/改页大小/排序变化回调（父组件据此重新拉取对应页）。 */
+  onServerChange: (page: number, pageSize: number, sortBy?: string, sortOrder?: 'asc' | 'desc') => void;
   /** 当前行点击跳转：由父组件 pushUrl('todos', { id })。 */
   onSelectTodo: (id: number) => void;
   /** 编辑事项入口（单行菜单「编辑」触发）。 */
@@ -371,6 +375,8 @@ export function TodoListView({
   items,
   loading,
   tags,
+  pagination,
+  onServerChange,
   onSelectTodo,
   onEditTodo,
   onDeleteTodo,
@@ -422,8 +428,23 @@ export function TodoListView({
           size="small"
           // 054：scroll.x 由 hook 动态计算（列宽求和），替代原硬编码 1720
           {...tableProps}
+          // 056：服务端分页/排序——onChange 把翻页与排序翻译给父组件重新拉取；
+          // tableProps.onChange（排序偏好持久化）先执行，保持 localStorage 口径。
+          onChange={(pag, filters, sorter, extra) => {
+            tableProps.onChange?.(pag, filters, sorter, extra);
+            const s = Array.isArray(sorter) ? sorter[0] : sorter;
+            const sortOrder = s?.order === 'ascend' ? 'asc' : s?.order === 'descend' ? 'desc' : undefined;
+            onServerChange(
+              pag.current ?? 1,
+              pag.pageSize ?? 20,
+              s?.field ? String(s.field) : undefined,
+              sortOrder,
+            );
+          }}
           pagination={{
-            pageSize: 20,
+            current: pagination.current,
+            pageSize: pagination.pageSize,
+            total: pagination.total,
             showSizeChanger: true,
             pageSizeOptions: ['20', '50', '100'],
             showTotal: (total) => `共 ${total} 项`,

--- a/frontend/src/components/todo-post/index.tsx
+++ b/frontend/src/components/todo-post/index.tsx
@@ -13,6 +13,7 @@ import {
   InfoCircleOutlined,
 } from "@ant-design/icons";
 import { useApp } from "@/hooks/useApp";
+import { useTodoById } from "@/hooks/useTodoById";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { PageCard } from "@/components/common/PageCard";
 import { LogDrawer } from './LogDrawer';
@@ -226,7 +227,8 @@ export function TodoPostPage({
     setLogDrawerOpen(true);
   };
 
-  const todo = state.todos.find((t) => t.id === todoId);
+  // 056：全局桶删除后按 id 定点查询（带共享缓存）
+  const todo = useTodoById(state.selectedWorkspace, todoId);
   const todoTitle = todo?.title || `事项 #${todoId}`;
 
   // 全局楼层号

--- a/frontend/src/hooks/useApp.tsx
+++ b/frontend/src/hooks/useApp.tsx
@@ -6,11 +6,10 @@
 
 import React, { useMemo, useCallback, useEffect } from 'react';
 import * as db from '@/utils/database';
-import type { Todo } from '@/types';
 
 // ─── Direct imports (needed within this file) ─────────────────
 
-import { useTodos, useVisibleTodos } from './useTodoContext';
+import { useTodos } from './useTodoContext';
 import type { TodoAction } from './useTodoContext';
 import { useExecution } from './useExecutionContext';
 import type { ExecutionAction } from './useExecutionContext';
@@ -33,14 +32,11 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
-// ─── DataLoader (按需加载第一个 workspace 的 todos) ───────────
+// ─── DataLoader (启动加载基础数据) ───────────
 //
-// 性能优化（perf/todo-by-workspace）：
-// - 不再启动时 getAllTodos() 拉全量；改为先拉 project_directories 选第一个
-//   workspace（按持久化的 selectedWorkspace > 第一个），然后只拉那一个桶。
-// - 多 workspace 用户切到新 workspace 时由 TodoList 等组件触发按需拉，本组件
-//   不主动拉取。
-// - tags 仍是全量加载（基数小，按 id 查找频率高，缓存整集合值得）。
+// 056（决策 2a）：全局 todos 桶已删除，启动不再预拉任何 todo——
+// 列表页自己按页拉取，单条详情走 useTodoById。
+// 这里只加载 tags（全量，基数小）与决定初始 workspace。
 
 function DataLoader() {
   const { dispatch: todoDispatch } = useTodos();
@@ -50,7 +46,7 @@ function DataLoader() {
   useEffect(() => {
     async function loadData() {
       try {
-        // 1. 先拉目录列表，用来决定第一个 workspace
+        // 1. 先拉目录列表，用来决定初始 workspace
         const dirs = await db.getProjectDirectories();
         // 持久化的 selectedWorkspace 若仍有效，优先用它；否则用第一个目录。
         const remembered = state.selectedWorkspace;
@@ -59,14 +55,11 @@ function DataLoader() {
             ? remembered
             : (dirs[0]?.id ?? null);
 
-        // 2. 并行加载：tags（全量）+ 第一个 workspace 的 todos（按 workspace_id）
-        const [tags, initialTodos] = await Promise.all([
-          db.getAllTags(),
-          initialId != null ? db.getAllTodos(initialId) : Promise.resolve([] as Todo[]),
-        ]);
+        // 2. 只拉 tags（全量，基数小）；初始 workspace 同步进选择态
+        const tags = await db.getAllTags();
         todoDispatch({ type: 'SET_TAGS', payload: tags });
-        if (initialId != null) {
-          todoDispatch({ type: 'SET_TODOS_BY_WORKSPACE', workspaceId: initialId, payload: initialTodos });
+        if (initialId != null && initialId !== state.selectedWorkspace) {
+          todoDispatch({ type: 'SELECT_WORKSPACE', payload: initialId });
         }
       } catch {
         // Non-fatal: app will show empty state
@@ -87,18 +80,13 @@ export function useApp() {
   const { state: todoState, dispatch: todoDispatch } = useTodos();
   const { state: execState, dispatch: execDispatch } = useExecution();
   const { state: uiState, dispatch: uiDispatch } = useUI();
-  // visibleTodos：按 selectedWorkspace 返回当前桶；null 时聚合所有桶。
-  // 把派生字段挂在 state 上，让 ~30 个老调用方读 state.todos 不用改。
-  const visibleTodos = useVisibleTodos();
 
-  // Merge all sub-states into a flat object. todosByWorkspace 故意不展开成 todos：
-  // 派生字段 `todos` 已经按 selectedWorkspace 过滤好，老调用方继续读 state.todos 即可。
+  // 056：state.todos 已删除——列表走服务端分页，单条走 useTodoById。
   const state = useMemo(() => ({
     ...todoState,
-    todos: visibleTodos,
     ...execState,
     ...uiState,
-  }), [todoState, visibleTodos, execState, uiState]);
+  }), [todoState, execState, uiState]);
 
   // Combined dispatch routes actions to the appropriate sub-dispatcher
   // based on the action's `type` discriminator field.
@@ -106,11 +94,9 @@ export function useApp() {
   const dispatch = useCallback((action: TodoAction | ExecutionAction | UIAction) => {
     const t = action.type;
     if (
-      t === 'SET_TODOS_BY_WORKSPACE' || t === 'SET_TAGS' || t === 'ADD_TODO' ||
-      t === 'UPDATE_TODO' || t === 'DELETE_TODO' || t === 'SELECT_TODO' ||
+      t === 'SET_TAGS' || t === 'SELECT_TODO' ||
       t === 'SELECT_TAG' || t === 'SELECT_WORKSPACE' ||
-      t === 'ADD_TAG' || t === 'DELETE_TAG' ||
-      t === 'UPDATE_TODO_STATUS'
+      t === 'ADD_TAG' || t === 'DELETE_TAG'
     ) {
       todoDispatch(action);
     } else if (

--- a/frontend/src/hooks/useConceptCounts.ts
+++ b/frontend/src/hooks/useConceptCounts.ts
@@ -53,10 +53,13 @@ export function useConceptCounts(workspaceId: number | null): UseConceptCountsRe
       // 并行拉取 6 个 API（Promise.all + 每个 promise 独立 catch），任一失败对应字段 null。
       // 不用串联 await：串行等待会放大首屏延迟（最慢 API × 6 → 最慢 API × 1）。
       // 每个 promise 自己 catch 为 null，Promise.all 因此永不 reject，无需 allSettled。
-      const [processes, loops, todos, tasks, executors, experts] = await Promise.all([
+      const [processes, loops, todoCount, todoIds, tasks, executors, experts] = await Promise.all([
         bundledApi.getProcesses().catch(() => null),
         dbLoops.listLoops(wsId).catch(() => null),
-        db.getAllTodos(wsId).catch(() => null),
+        // 056：计数走轻量 COUNT 接口，不再全表拉取取 length
+        db.getTodoCount(wsId).catch(() => null),
+        // 首个 todo id 用于快速开始第 3 步的存在性探测（id 轻量列表）
+        db.getTodoIds(wsId).catch(() => null),
         bundledApi.listTasks(wsId).catch(() => null),
         db.getExecutors().catch(() => null),
         db.getAllExperts().catch(() => null),
@@ -66,7 +69,7 @@ export function useConceptCounts(workspaceId: number | null): UseConceptCountsRe
       const nextCounts: ConceptCounts = {
         process: processes ? processes.length : null,
         loop: loops ? loops.length : null,
-        todo: todos ? todos.length : null,
+        todo: todoCount,
         task: tasks ? tasks.length : null,
         executor: executors ? executors.length : null,
         expert: experts ? experts.length : null,
@@ -77,7 +80,7 @@ export function useConceptCounts(workspaceId: number | null): UseConceptCountsRe
       const step1Done = processes ? processes.length > 0 : false;
       const step2Done = tasks ? tasks.length > 0 : false;
       // 简化：用首个 todo 查执行记录，避免 N+1。
-      const step3Done = await checkExecutionsExist(todos, wsId);
+      const step3Done = await checkExecutionsExist(todoIds, wsId);
       // 步骤 4：与步骤 3 同源判断（完整实现需扫审计 API，YAGNI 先简化）。
       const step4Done = step3Done;
 
@@ -106,12 +109,12 @@ export function useConceptCounts(workspaceId: number | null): UseConceptCountsRe
  * 简化：只查首个 todo 的执行记录分页 total。
  */
 async function checkExecutionsExist(
-  todos: Array<{ id: number }> | null,
+  todoIds: number[] | null,
   wsId: number,
 ): Promise<boolean> {
-  if (!todos || todos.length === 0) return false;
+  if (!todoIds || todoIds.length === 0) return false;
   try {
-    const page = await db.getExecutionRecords(todos[0].id, 1, 1, undefined, undefined, wsId);
+    const page = await db.getExecutionRecords(todoIds[0], 1, 1, undefined, undefined, wsId);
     return page.total > 0;
   } catch {
     return false;

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useApp } from './useApp';
 import type { LogEntry, TodoItem, ExecutionStats } from '@/types';
+import { TODO_LIST_REFRESH_EVENT } from '@/constants';
 
 // ─── 类型定义 ───────────────────────────────────────────────────
 
@@ -136,8 +137,8 @@ let sharedShouldReconnect = true;
  *  注意：存的是 ref 对象而非函数，因为 effect 只执行一次，但 onRefresh 函数的引用
  *  可能因 useCallback 依赖变化而改变。存 ref 对象后，触发时读 ref.current 总能拿到最新值。 */
 let sharedOnRefreshRefs: Array<React.MutableRefObject<(() => void) | undefined>> = [];
-/** 自动清除已结束任务的定时器集合 */
-let sharedRemoveTaskTimers = new Set<ReturnType<typeof setTimeout>>();
+/** 自动清除已结束任务的定时器：key=taskId（056 改为 Map，支持 Sync 时按任务撤销）。 */
+let sharedRemoveTaskTimers = new Map<string, ReturnType<typeof setTimeout>>();
 /** 全局 dispatch 函数（从第一个调用方的 useApp() 获取，后续复用） */
 let sharedDispatch: ReturnType<typeof useApp>['dispatch'] | null = null;
 /** 当前活跃的调用方数量（当计数归零时关闭 WS） */
@@ -183,14 +184,19 @@ function connectShared(dispatch: ReturnType<typeof useApp>['dispatch']) {
           data.tasks.forEach(task => {
             let parsedLogs: LogEntry[] = [];
             try { parsedLogs = JSON.parse(task.logs || '[]'); } catch {}
+            // 056（L6 修复）：Sync 把该任务重置为 running，撤销可能存在的自动移除定时器，
+            // 否则重连后旧定时器会把 Sync 恢复的任务再次移除（任务闪现/提前消失）。
+            cancelRemoveTimer(task.task_id);
             dispatch({ type: 'ADD_RUNNING_TASK', payload: { taskId: task.task_id, todoId: task.todo_id, todoTitle: task.todo_title, executor: task.executor || 'claudecode', logs: parsedLogs, status: 'running', startedAt: new Date().toISOString() } });
-            dispatch({ type: 'UPDATE_TODO_STATUS', payload: { id: task.todo_id, status: 'running' } });
           });
+          // 056：全局 todos 桶已删除，列表页改从服务端拉取——Sync 到达即通知列表刷新
+          window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
           break;
         }
         case 'Started': {
           dispatch({ type: 'ADD_RUNNING_TASK', payload: { taskId: data.task_id, todoId: data.todo_id, todoTitle: data.todo_title, executor: data.executor || 'claudecode', logs: [], status: 'running', startedAt: new Date().toISOString() } });
-          dispatch({ type: 'UPDATE_TODO_STATUS', payload: { id: data.todo_id, status: 'running' } });
+          // 056：状态不再写全局桶，改为通知列表页刷新（服务端数据源为准）
+          window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
           window.dispatchEvent(new CustomEvent('executionStarted', { detail: { todoId: data.todo_id } }));
           break;
         }
@@ -208,13 +214,15 @@ function connectShared(dispatch: ReturnType<typeof useApp>['dispatch']) {
         }
         case 'Finished': {
           dispatch({ type: 'FINISH_TASK', payload: { taskId: data.task_id, todoId: data.todo_id, success: data.success, result: data.result } });
-          dispatch({ type: 'UPDATE_TODO_STATUS', payload: { id: data.todo_id, status: data.success ? 'completed' : 'failed' } });
-          // 3 秒后自动从 runningTasks 中移除已结束的任务
+          // 3 秒后自动从 runningTasks 中移除已结束的任务；若期间 WS 重连收到 Sync，
+          // Sync 会撤销该定时器（任务被重置为 running），避免误移除。
           const timer = setTimeout(() => {
-            sharedRemoveTaskTimers.delete(timer);
+            sharedRemoveTaskTimers.delete(data.task_id);
             dispatch({ type: 'REMOVE_RUNNING_TASK', payload: data.task_id });
           }, 3000);
-          sharedRemoveTaskTimers.add(timer);
+          sharedRemoveTaskTimers.set(data.task_id, timer);
+          // 056：终态落定，通知列表页刷新（服务端数据源为准）
+          window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
           window.dispatchEvent(new CustomEvent('executionFinished', { detail: { todoId: data.todo_id, success: data.success } }));
           break;
         }
@@ -276,6 +284,15 @@ function teardownShared() {
   if (sharedWs) {
     sharedWs.close();
     sharedWs = null;
+  }
+}
+
+/** 056：撤销指定任务的自动移除定时器（Sync 重置 running 集时调用）。 */
+function cancelRemoveTimer(taskId: string) {
+  const timer = sharedRemoveTaskTimers.get(taskId);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    sharedRemoveTaskTimers.delete(taskId);
   }
 }
 

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -190,13 +190,13 @@ function connectShared(dispatch: ReturnType<typeof useApp>['dispatch']) {
             dispatch({ type: 'ADD_RUNNING_TASK', payload: { taskId: task.task_id, todoId: task.todo_id, todoTitle: task.todo_title, executor: task.executor || 'claudecode', logs: parsedLogs, status: 'running', startedAt: new Date().toISOString() } });
           });
           // 056：全局 todos 桶已删除，列表页改从服务端拉取——Sync 到达即通知列表刷新
-          window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
+          dispatchListRefreshDebounced();
           break;
         }
         case 'Started': {
           dispatch({ type: 'ADD_RUNNING_TASK', payload: { taskId: data.task_id, todoId: data.todo_id, todoTitle: data.todo_title, executor: data.executor || 'claudecode', logs: [], status: 'running', startedAt: new Date().toISOString() } });
           // 056：状态不再写全局桶，改为通知列表页刷新（服务端数据源为准）
-          window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
+          dispatchListRefreshDebounced();
           window.dispatchEvent(new CustomEvent('executionStarted', { detail: { todoId: data.todo_id } }));
           break;
         }
@@ -222,7 +222,7 @@ function connectShared(dispatch: ReturnType<typeof useApp>['dispatch']) {
           }, 3000);
           sharedRemoveTaskTimers.set(data.task_id, timer);
           // 056：终态落定，通知列表页刷新（服务端数据源为准）
-          window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
+          dispatchListRefreshDebounced();
           window.dispatchEvent(new CustomEvent('executionFinished', { detail: { todoId: data.todo_id, success: data.success } }));
           break;
         }
@@ -281,6 +281,11 @@ function teardownShared() {
   }
   sharedRemoveTaskTimers.forEach(clearTimeout);
   sharedRemoveTaskTimers.clear();
+  // 056：清掉未触发的刷新 debounce，避免 teardown 后还向已卸载页面发事件
+  if (refreshDebounceTimer) {
+    clearTimeout(refreshDebounceTimer);
+    refreshDebounceTimer = null;
+  }
   if (sharedWs) {
     sharedWs.close();
     sharedWs = null;
@@ -294,6 +299,22 @@ function cancelRemoveTimer(taskId: string) {
     clearTimeout(timer);
     sharedRemoveTaskTimers.delete(taskId);
   }
+}
+
+/** 列表刷新事件的共享 trailing debounce 定时器。 */
+let refreshDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** 列表刷新事件的 debounce 毫秒数（评审 I1：Loop 连续执行时 Started/Finished 密集触发，
+ *  每条都让各列表视图重拉一页，30 步 Loop = 60 次全视图 HTTP。合并为 trailing 一次）。 */
+const REFRESH_DEBOUNCE_MS = 500;
+
+/** 500ms trailing debounce 派发列表刷新事件：密集触发只保留最后一次。 */
+function dispatchListRefreshDebounced() {
+  if (refreshDebounceTimer) clearTimeout(refreshDebounceTimer);
+  refreshDebounceTimer = setTimeout(() => {
+    refreshDebounceTimer = null;
+    window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
+  }, REFRESH_DEBOUNCE_MS);
 }
 
 /**

--- a/frontend/src/hooks/useKanbanExecutionCache.ts
+++ b/frontend/src/hooks/useKanbanExecutionCache.ts
@@ -6,11 +6,12 @@
  */
 
 import { useState, useCallback } from 'react';
-import type { Todo, ExecutionRecord } from '@/types';
+import type { ExecutionRecord } from '@/types';
 import * as db from '@/utils/database';
 
 interface UseKanbanExecutionCacheOptions {
-  todos: Todo[];
+  // 056：只需要 id 做执行记录查询，类型放宽以兼容 TodoBrief
+  todos: Array<{ id: number }>;
   /** executionRecords from global store, keyed by todoId */
   storeRecords: Record<number, ExecutionRecord[]>;
   /** 当前选中的 workspace_id，透传到 API */
@@ -25,7 +26,7 @@ interface UseKanbanExecutionCacheResult {
   loadingRunIndex: Record<number, number | null>;
 
   // Actions
-  toggleResult: (todo: Todo) => Promise<string | null>;
+  toggleResult: (todo: { id: number }) => Promise<string | null>;
   handleSelectRun: (todoId: number, runIndex: number) => Promise<void>;
 
   // Get the best available record for a todo (store > API)
@@ -42,7 +43,7 @@ export function useKanbanExecutionCache({
   const [loadingRunIndex, setLoadingRunIndex] = useState<Record<number, number | null>>({});
 
   // 点击展开时从 API 拉取最新执行结果（不做本地缓存）
-  const toggleResult = useCallback(async (todo: Todo): Promise<string | null> => {
+  const toggleResult = useCallback(async (todo: { id: number }): Promise<string | null> => {
     // 优先走 store 数据，不需要额外请求
     const storeRecord = storeRecords[todo.id]?.[0];
     if (storeRecord?.result) return storeRecord.result;

--- a/frontend/src/hooks/useTodoById.ts
+++ b/frontend/src/hooks/useTodoById.ts
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Todo } from '@/types';
+import * as db from '@/utils/database';
+import { TODO_LIST_REFRESH_EVENT } from '@/constants';
+
+/**
+ * 056：按 id 定点查询 Todo 的共享缓存 hook。
+ *
+ * 背景：全局 `state.todos` 全量桶已删除（决策 2a）。过去「从全量桶 find 一条」
+ * 的消费点（运行记录抽屉补标题、纪念板、帖子页等）改为按需 by-id 查询。
+ *
+ * 设计要点：
+ * - 模块级 Map 缓存 + 请求中去重：同一 id 并发请求只发一次 HTTP。
+ * - TODO_LIST_REFRESH_EVENT 到达时清空缓存：列表保存/删除后详情数据可能已变。
+ * - 返回 (todo | null)：未加载完成或不存在都为 null，调用方自行降级展示。
+ */
+
+interface CacheEntry {
+  /** 已完成的查询结果；undefined 表示尚未加载 */
+  value?: Todo | null;
+  /** 进行中的请求 Promise，用于并发去重 */
+  inflight?: Promise<Todo | null>;
+}
+
+/** key = `${workspaceId}:${todoId}`（todo 按 workspace 隔离，跨 ws 同 id 不共享） */
+const cache = new Map<string, CacheEntry>();
+
+function cacheKey(workspaceId: number, todoId: number): string {
+  return `${workspaceId}:${todoId}`;
+}
+
+/** 查询单条 todo（带缓存与并发去重）。失败按 null 处理——by-id 是增强信息，缺失不应报错。 */
+function fetchTodo(workspaceId: number, todoId: number): Promise<Todo | null> {
+  const key = cacheKey(workspaceId, todoId);
+  const entry = cache.get(key) ?? {};
+  if (entry.value !== undefined) return Promise.resolve(entry.value);
+  if (entry.inflight) return entry.inflight;
+
+  const inflight = db
+    .getTodo(workspaceId, todoId)
+    .then((todo) => {
+      cache.set(key, { value: todo });
+      return todo as Todo | null;
+    })
+    .catch(() => {
+      // 失败也缓存 null：避免失败 id 被每个组件反复重试打爆后端；
+      // TODO_LIST_REFRESH_EVENT 到达时缓存会整体失效，给后续重试机会。
+      cache.set(key, { value: null });
+      return null;
+    });
+  cache.set(key, { inflight });
+  return inflight;
+}
+
+// 列表刷新事件到达时清空缓存（保存/删除/批量操作后，旧缓存可能已过期）。
+// 模块级注册一次即可——监听器只做 Map.clear()，无组件生命周期负担。
+if (typeof window !== 'undefined') {
+  window.addEventListener(TODO_LIST_REFRESH_EVENT, () => cache.clear());
+}
+
+/**
+ * 按 id 取单条 todo（响应式）。workspaceId/todoId 为 null 时返回 null 且不发请求。
+ *
+ * 注意：只在「只需要一两条」的场景使用；列表场景请走分页/批量接口，
+ * 避免逐条请求形成 N+1。
+ */
+export function useTodoById(workspaceId: number | null, todoId: number | null): Todo | null {
+  const [todo, setTodo] = useState<Todo | null>(null);
+  // cancelledRef 防御快速切换造成的竞态：晚返回的请求若发现参数已变，直接丢弃结果
+  const requestSeq = useRef(0);
+
+  const load = useCallback(async (wsId: number, id: number, seq: number) => {
+    const result = await fetchTodo(wsId, id);
+    // 只接受最新一次请求的结果，过期响应直接丢弃
+    if (seq === requestSeq.current) {
+      setTodo(result);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (workspaceId == null || todoId == null) {
+      setTodo(null);
+      return;
+    }
+    // 命中缓存时同步返回，避免闪烁
+    const entry = cache.get(cacheKey(workspaceId, todoId));
+    if (entry?.value !== undefined) {
+      setTodo(entry.value);
+      return;
+    }
+    const seq = ++requestSeq.current;
+    load(workspaceId, todoId, seq);
+    // 监听刷新事件：缓存清空后重新拉取本条
+    const onRefresh = () => {
+      const s = ++requestSeq.current;
+      load(workspaceId, todoId, s);
+    };
+    window.addEventListener(TODO_LIST_REFRESH_EVENT, onRefresh);
+    return () => window.removeEventListener(TODO_LIST_REFRESH_EVENT, onRefresh);
+  }, [workspaceId, todoId, load]);
+
+  return todo;
+}

--- a/frontend/src/hooks/useTodoById.ts
+++ b/frontend/src/hooks/useTodoById.ts
@@ -86,11 +86,12 @@ export function useTodoById(workspaceId: number | null, todoId: number | null): 
     const entry = cache.get(cacheKey(workspaceId, todoId));
     if (entry?.value !== undefined) {
       setTodo(entry.value);
-      return;
+    } else {
+      const seq = ++requestSeq.current;
+      load(workspaceId, todoId, seq);
     }
-    const seq = ++requestSeq.current;
-    load(workspaceId, todoId, seq);
-    // 监听刷新事件：缓存清空后重新拉取本条
+    // 无论缓存命中与否都订阅刷新事件（评审 I2 修复）：
+    // 命中路径之前 early return 不订阅，该 todo 被编辑后组件仍显示旧数据。
     const onRefresh = () => {
       const s = ++requestSeq.current;
       load(workspaceId, todoId, s);

--- a/frontend/src/hooks/useTodoById.ts
+++ b/frontend/src/hooks/useTodoById.ts
@@ -25,6 +25,10 @@ interface CacheEntry {
 /** key = `${workspaceId}:${todoId}`（todo 按 workspace 隔离，跨 ws 同 id 不共享） */
 const cache = new Map<string, CacheEntry>();
 
+/** CodeRabbit#12：缓存代际计数。clear() 时 +1；在途请求写回前比对代际，
+ *  代际不同说明结果产生于「清空」之前，属于陈旧数据，丢弃不写回。 */
+let cacheGeneration = 0;
+
 function cacheKey(workspaceId: number, todoId: number): string {
   return `${workspaceId}:${todoId}`;
 }
@@ -36,16 +40,18 @@ function fetchTodo(workspaceId: number, todoId: number): Promise<Todo | null> {
   if (entry.value !== undefined) return Promise.resolve(entry.value);
   if (entry.inflight) return entry.inflight;
 
+  const gen = cacheGeneration;
   const inflight = db
     .getTodo(workspaceId, todoId)
     .then((todo) => {
-      cache.set(key, { value: todo });
+      // 代际一致才写回：clear() 之后的晚到响应属于旧世界，不复活旧数据
+      if (gen === cacheGeneration) cache.set(key, { value: todo });
       return todo as Todo | null;
     })
     .catch(() => {
       // 失败也缓存 null：避免失败 id 被每个组件反复重试打爆后端；
       // TODO_LIST_REFRESH_EVENT 到达时缓存会整体失效，给后续重试机会。
-      cache.set(key, { value: null });
+      if (gen === cacheGeneration) cache.set(key, { value: null });
       return null;
     });
   cache.set(key, { inflight });
@@ -53,9 +59,12 @@ function fetchTodo(workspaceId: number, todoId: number): Promise<Todo | null> {
 }
 
 // 列表刷新事件到达时清空缓存（保存/删除/批量操作后，旧缓存可能已过期）。
-// 模块级注册一次即可——监听器只做 Map.clear()，无组件生命周期负担。
+// 模块级注册一次即可——监听器只做失效标记，无组件生命周期负担。
 if (typeof window !== 'undefined') {
-  window.addEventListener(TODO_LIST_REFRESH_EVENT, () => cache.clear());
+  window.addEventListener(TODO_LIST_REFRESH_EVENT, () => {
+    cacheGeneration += 1;
+    cache.clear();
+  });
 }
 
 /**

--- a/frontend/src/hooks/useTodoContext.tsx
+++ b/frontend/src/hooks/useTodoContext.tsx
@@ -1,19 +1,12 @@
 import React, { createContext, useContext, useReducer, useMemo, ReactNode } from 'react';
-import type { Todo, Tag } from '@/types';
-
-// 模块级空数组常量：useVisibleTodos 在桶不存在时复用此引用，
-// 避免每次渲染都 `?? []` 产生新数组，进而触发依赖 state.todos 的 useEffect 无限循环（issue: React error #185）。
-const EMPTY_TODOS: Todo[] = [];
+import type { Tag } from '@/types';
 
 // ─── Design Overview ──────────────────────────────────────────
 //
-// 分桶改造（2026-06-27）：
-// - `todos: Todo[]` → `todosByWorkspace: Record<number, Todo[]>`。
-//   每个工作空间的 todo 独立放在一个桶里，切换 workspace 时不重拉。
-// - `visibleTodos` 由 `useVisibleTodos()` selector 根据
-//   `selectedWorkspace` 合成，不再用 flat todos 过滤。
-// - 所有 mutation action（ADD / UPDATE / DELETE / UPDATE_STATUS）
-//   现在需要 **显式传递 workspaceId**，不再靠遍历扁平数组。
+// 056 简化（决策 2a）：
+// - `todosByWorkspace` 全量桶已彻底删除——列表数据一律走服务端分页/轻量接口，
+//   单条详情走 `useTodoById` 按需查询，不再在客户端维护全量镜像。
+// - 这里只保留 tags（基数小、按 id 高频查找）与选择态（selectedTodoId/TagId/Workspace）。
 //
 // selectedTodoId / selectedTagId 语义不变：
 // null = "nothing selected"。
@@ -21,9 +14,6 @@ const EMPTY_TODOS: Todo[] = [];
 // ─── State ───────────────────────────────────────────────────
 
 interface TodoState {
-  /** 按 workspace_id 分桶存储。key = workspace.id，value = 该空间下的 todo 列表。
-   *  切换 workspace 时不需要重新拉取（如果已经拉过）。 */
-  todosByWorkspace: Record<number, Todo[]>;
   tags: Tag[];
   /** null = no todo selected (list view); number = detail view */
   selectedTodoId: number | null;
@@ -37,28 +27,10 @@ interface TodoState {
 }
 
 // ─── Actions ─────────────────────────────────────────────────
-//
-// 分桶改造后，所有 mutation action 都必须携带 workspaceId（ADD / UPDATE / DELETE
-// 都要知道操作哪个桶）。跨桶操作在 reducer 内部遍历 todosByWorkspace 查找。
 
 type TodoAction =
-  // ── 替换整个桶（从后端拉完一整个 workspace 的数据后调用）─
-  | { type: 'SET_TODOS_BY_WORKSPACE'; workspaceId: number; payload: Todo[] }
-
   // ── 全量替换 tags（数据量极小，不分桶）──
   | { type: 'SET_TAGS'; payload: Tag[] }
-
-  // ── 新增 todo：必须携带 workspaceId，reducer 推入对应桶的顶部 ─
-  | { type: 'ADD_TODO'; workspaceId: number; payload: Todo }
-
-  // ── 更新单条 todo：遍历所有桶找到同 id 的替换 ─
-  | { type: 'UPDATE_TODO'; payload: Todo }
-
-  // ── 删除单条 todo：遍历所有桶找到同 id 的删除 ─
-  | { type: 'DELETE_TODO'; payload: number }
-
-  // ── 快速更新 todo status（Kanban 拖拽专用）─
-  | { type: 'UPDATE_TODO_STATUS'; payload: { id: number; status: Todo['status'] } }
 
   // ── 选择态 ─
   | { type: 'SELECT_TODO'; payload: number | null }
@@ -83,7 +55,6 @@ function getInitialWorkspace(): number | null {
 }
 
 const initialState: TodoState = {
-  todosByWorkspace: {},
   tags: [],
   selectedTodoId: null,
   selectedTagId: null,
@@ -94,76 +65,11 @@ const initialState: TodoState = {
 
 function reducer(state: TodoState, action: TodoAction): TodoState {
   switch (action.type) {
-    // 替换整个桶：同一个 workspace 的 todo 全量覆盖。
-    // 如果桶不存在则新建，已存在则替换。
-    case 'SET_TODOS_BY_WORKSPACE':
-      return {
-        ...state,
-        todosByWorkspace: {
-          ...state.todosByWorkspace,
-          [action.workspaceId]: action.payload,
-        },
-      };
-
     case 'SET_TAGS': return { ...state, tags: action.payload };
-
-    // 新增：推入对应桶的顶部（最新排最前）。
-    // 桶不存在时也创建新桶，避免丢失新增数据。
-    case 'ADD_TODO': {
-      const bucket = state.todosByWorkspace[action.workspaceId];
-      return {
-        ...state,
-        todosByWorkspace: {
-          ...state.todosByWorkspace,
-          [action.workspaceId]: bucket
-            ? [action.payload, ...bucket]
-            : [action.payload],
-        },
-      };
-    }
-
-    // 更新：遍历所有桶，替换同 id 的 todo。
-    // 效率 O(n*m)：todolist 总量一般 < 2000，可接受。
-    case 'UPDATE_TODO': {
-      const updated = action.payload;
-      const newBuckets: Record<number, Todo[]> = {};
-      let changed = false;
-      for (const [key, todos] of Object.entries(state.todosByWorkspace)) {
-        const wid = Number(key);
-        const idx = todos.findIndex(t => t.id === updated.id);
-        if (idx !== -1) {
-          const copy = [...todos];
-          copy[idx] = updated;
-          newBuckets[wid] = copy;
-          changed = true;
-        } else {
-          newBuckets[wid] = todos;
-        }
-      }
-      // 找不到时 TODO 可能刚被创建且桶还不存在 —— 尝试从 payload.workspace_id 推入
-      if (!changed && updated.workspace_id != null) {
-        const bucket = state.todosByWorkspace[updated.workspace_id] || [];
-        newBuckets[updated.workspace_id] = [
-          updated,
-          ...bucket.filter(t => t.id !== updated.id),
-        ];
-      }
-      return { ...state, todosByWorkspace: newBuckets };
-    }
-
-    // 删除：遍历所有桶删除同 id 的 todo。
-    case 'DELETE_TODO': {
-      const id = action.payload;
-      const newBuckets: Record<number, Todo[]> = {};
-      for (const [key, todos] of Object.entries(state.todosByWorkspace)) {
-        newBuckets[Number(key)] = todos.filter(t => t.id !== id);
-      }
-      return { ...state, todosByWorkspace: newBuckets };
-    }
 
     // 选择态：payload 与当前值相等时直接返回原 state，避免产生新引用触发依赖重渲染。
     // 这是阻断 React error #185 无限循环的第二道防线：即便上层 effect 无条件 dispatch，
-    // reducer 不产生新 state，下游 useMemo（如 useVisibleTodos）也不会重算。
+    // reducer 不产生新 state，下游 useMemo 也不会重算。
     case 'SELECT_TODO':
       if (action.payload === state.selectedTodoId) return state;
       return { ...state, selectedTodoId: action.payload };
@@ -185,19 +91,6 @@ function reducer(state: TodoState, action: TodoAction): TodoState {
 
     case 'ADD_TAG': return { ...state, tags: [...state.tags, action.payload] };
     case 'DELETE_TAG': return { ...state, tags: state.tags.filter(t => t.id !== action.payload) };
-
-    case 'UPDATE_TODO_STATUS': {
-      const { id, status } = action.payload;
-      const newBuckets: Record<number, Todo[]> = {};
-      for (const [key, todos] of Object.entries(state.todosByWorkspace)) {
-        newBuckets[Number(key)] = todos.map(t =>
-          t.id === id
-            ? { ...t, status: status as Todo['status'], updated_at: new Date().toISOString() }
-            : t,
-        );
-      }
-      return { ...state, todosByWorkspace: newBuckets };
-    }
 
     default: return state;
   }
@@ -221,28 +114,6 @@ export function useTodos() {
   const ctx = useContext(TodoContext);
   if (!ctx) throw new Error('useTodos must be used within TodoProvider');
   return ctx;
-}
-
-/**
- * 根据当前 selectedWorkspace 返回可见的 todo 列表。
- * - selectedWorkspace 非 null → 返回对应桶的 todos（无桶时返回空数组）。
- * - selectedWorkspace 为 null → 返回所有桶的 todos 扁平合并
- *   （极少数场景，如 BackupPanel 导入去重需要全局视图）。
- */
-export function useVisibleTodos(): Todo[] {
-  const { state } = useTodos();
-  const { selectedWorkspace, todosByWorkspace } = state;
-  // useMemo 稳定返回引用：仅当 selectedWorkspace 或 todosByWorkspace 变化时才重新计算。
-  // 之前未 memoize 时，桶不存在会每次渲染返回新 `[]`，导致 App.tsx 中依赖 state.todos 的
-  // useEffect 反复触发 dispatch SELECT_TODO null，而 reducer 不判等又产生新 state，
-  // 形成「渲染 → useEffect → dispatch → 新 state → 渲染」的无限循环（React error #185）。
-  return useMemo(() => {
-    if (selectedWorkspace != null) {
-      // 桶不存在时复用模块级 EMPTY_TODOS，保证相同输入下引用稳定。
-      return todosByWorkspace[selectedWorkspace] ?? EMPTY_TODOS;
-    }
-    return Object.values(todosByWorkspace).flat();
-  }, [selectedWorkspace, todosByWorkspace]);
 }
 
 export type { TodoAction };

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -329,6 +329,8 @@ export interface RecentCompletedTodo {
   prompt: string | null;
   executor: string | null;
   tag_ids: number[];
+  /** 所属工作空间（056 补充：纪念板据此反查项目名，免去前端按 id 二次查询）。 */
+  workspace_id?: number | null;
   completed_at: string;
   result: string | null;
   model: string | null;

--- a/frontend/src/types/todo.ts
+++ b/frontend/src/types/todo.ts
@@ -77,6 +77,39 @@ export interface TodoCenterItem extends Todo {
   bound_slash_command?: string | null;
 }
 
+/** 事项中心服务端分页响应（056）。bucket_counts 为各分类计数（应用 search/status/actionType 后、应用 bucket 前）。 */
+export interface TodoCenterPage {
+  items: TodoCenterItem[];
+  total: number;
+  page: number;
+  page_size: number;
+  bucket_counts: Record<string, number>;
+  /** 当前工作空间内出现过的 action_type 去重列表（来源筛选下拉数据源）。 */
+  action_types: string[];
+}
+
+/** 事项轻量摘要（056）：不含 prompt 大字段，看板/下拉/记录补标题用。 */
+export interface TodoBrief {
+  id: number;
+  title: string;
+  status: Todo['status'];
+  executor?: string | null;
+  updated_at: string;
+  archived_at?: string | null;
+  workspace_id?: number | null;
+  tag_ids: number[];
+  /** prompt 是否非空（看板「展开 prompt」的显示开关，内容按需另取）。 */
+  has_prompt: boolean;
+}
+
+/** 事项列表分页响应（056，旧全量接口改造后的结构）。 */
+export interface TodoListPage {
+  items: Todo[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
 /** 环节 — 从 todo 提升而来的独立实体，不再寄生在 Todo 上。 */
 export interface StepSummary {
   id: number;

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -27,7 +27,8 @@ export async function getTodoIds(workspaceId: number): Promise<number[]> {
 
 /**
  * 056：E 类「确实需要全量」场景的分批拉取（备份导入去重需要 prompt 判重）。
- * 逐页拉取直到末页；单页 200 条上限由后端强制，这里循环翻页。
+ * 翻页由响应的 total 驱动（CodeRabbit#14）：不以「本页条数 < 请求的 page_size」
+ * 判定末页——后端若调整 page_size 上限，该判定会提前终止造成静默截断。
  */
 export async function getAllTodosBatched(workspaceId: number): Promise<Todo[]> {
   const all: Todo[] = [];
@@ -35,7 +36,8 @@ export async function getAllTodosBatched(workspaceId: number): Promise<Todo[]> {
   for (;;) {
     const res = await getTodosPage(workspaceId, { page, pageSize: 200 });
     all.push(...res.items);
-    if (res.items.length < 200) break;
+    // 已拿够总数或本页为空（防御后端忽略 page 参数导致死循环）时结束
+    if (all.length >= res.total || res.items.length === 0) break;
     page += 1;
   }
   return all;

--- a/frontend/src/utils/database/todos.ts
+++ b/frontend/src/utils/database/todos.ts
@@ -1,19 +1,65 @@
 import { api, unwrap } from './client';
-import type { Todo, Tag, TodoTemplate, CustomTemplateStatus, ComputedBucket, TodoCenterItem, LoopRefSummary } from '@/types';
+import type { Todo, Tag, TodoTemplate, CustomTemplateStatus, ComputedBucket, TodoCenterItem, TodoCenterPage, TodoBrief, TodoListPage, LoopRefSummary } from '@/types';
 
 // Todo APIs — 所有 todo 端点嵌套在 /api/v1/workspaces/{ws}/todos 下（后端 ADR-7 纯 workspace 隔离）。
 // workspaceId 从 query/body 提升到 URL 路径段，调用方必须显式传入。
 
 /**
- * 列出指定工作空间下的 todos。
- * workspaceId 提升到路径段（v1 纯 workspace-scoped，不再支持跨空间列表）。
+ * 列出指定工作空间下的 todos（056：服务端强制分页）。
+ * 响应从全量数组改为分页结构；调用方若确实需要全量（如看板），
+ * 应改用不含大字段的 `getTodoBriefs`。
  */
-export async function getAllTodos(workspaceId: number, hours?: number): Promise<Todo[]> {
+export async function getTodosPage(
+  workspaceId: number,
+  options: { hours?: number; page?: number; pageSize?: number } = {},
+): Promise<TodoListPage> {
   const params: Record<string, number> = {};
-  if (hours !== undefined) {
-    params.hours = hours;
-  }
+  if (options.hours !== undefined) params.hours = options.hours;
+  if (options.page !== undefined) params.page = options.page;
+  if (options.pageSize !== undefined) params.page_size = options.pageSize;
   return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/todos`, { params }));
+}
+
+/** 056 轻量接口：工作空间内全部 todo id（日常视图，隐藏已归档）。 */
+export async function getTodoIds(workspaceId: number): Promise<number[]> {
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/todos/ids`));
+}
+
+/**
+ * 056：E 类「确实需要全量」场景的分批拉取（备份导入去重需要 prompt 判重）。
+ * 逐页拉取直到末页；单页 200 条上限由后端强制，这里循环翻页。
+ */
+export async function getAllTodosBatched(workspaceId: number): Promise<Todo[]> {
+  const all: Todo[] = [];
+  let page = 1;
+  for (;;) {
+    const res = await getTodosPage(workspaceId, { page, pageSize: 200 });
+    all.push(...res.items);
+    if (res.items.length < 200) break;
+    page += 1;
+  }
+  return all;
+}
+
+/** 056 轻量接口：工作空间内 todo 计数（COUNT(*)，不拉行）。 */
+export async function getTodoCount(workspaceId: number): Promise<number> {
+  const res = unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/todos/count`));
+  return (res as { count: number }).count;
+}
+
+/**
+ * 056 轻量接口：事项摘要（不含 prompt 大字段）。
+ * ids 省略时返回该 ws 全部 brief（看板全量渲染用，隐藏已归档）；
+ * 指定 ids 时按给定集合返回（含已归档，详情/记录补标题用）。
+ */
+export async function getTodoBriefs(
+  workspaceId: number,
+  options: { ids?: number[]; hours?: number } = {},
+): Promise<TodoBrief[]> {
+  const params: Record<string, string | number> = {};
+  if (options.ids && options.ids.length > 0) params.ids = options.ids.join(',');
+  if (options.hours !== undefined) params.hours = options.hours;
+  return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/todos/brief`, { params }));
 }
 
 export async function createTodo(
@@ -71,6 +117,11 @@ export async function updateTodo(
 
 export async function deleteTodo(workspaceId: number, id: number): Promise<void> {
   await api.delete(`/api/v1/workspaces/${workspaceId}/todos/${id}`);
+}
+
+/** 单字段改状态（056：看板拖拽用）——后端 force-status 端点只改 status，无需携带 prompt 全量字段。 */
+export async function updateTodoStatus(workspaceId: number, id: number, status: string): Promise<Todo> {
+  return unwrap(await api.put(`/api/v1/workspaces/${workspaceId}/todos/${id}/force-status`, { status }));
 }
 
 export async function updateTodoTags(workspaceId: number, todoId: number, tagIds: number[]): Promise<void> {
@@ -273,18 +324,32 @@ export async function updateScheduler(
 // ─── 事项中心（Todo Center）API ─────────────────────────────
 
 /**
- * 拉取事项中心列表（带 computed_bucket / loop 引用计数 / 最近执行聚合）。
+ * 拉取事项中心列表（056：服务端分页）。
  *
- * workspaceId 提升到路径段（v1 纯 workspace-scoped）。
- * 不传 bucket 时后端返回全部分类，前端按 computed_bucket 自行分桶并展示各 Tab 数量；
- * 传入 bucket 则服务端按分类过滤（分页前完成分桶，保证数量正确）。
+ * 分桶/搜索/排序/分页全部下推 SQL；返回含 total 与 bucket_counts（Tab 角标用）。
  */
 export async function getTodoCenter(
   workspaceId: number,
-  bucket?: ComputedBucket,
-): Promise<TodoCenterItem[]> {
+  options: {
+    bucket?: ComputedBucket;
+    search?: string;
+    page?: number;
+    pageSize?: number;
+    sortBy?: string;
+    sortOrder?: 'asc' | 'desc';
+    status?: string;
+    actionType?: string;
+  } = {},
+): Promise<TodoCenterPage> {
   const params: Record<string, string | number> = {};
-  if (bucket !== undefined) params.bucket = bucket;
+  if (options.bucket !== undefined) params.bucket = options.bucket;
+  if (options.search) params.search = options.search;
+  if (options.page !== undefined) params.page = options.page;
+  if (options.pageSize !== undefined) params.page_size = options.pageSize;
+  if (options.sortBy) params.sort_by = options.sortBy;
+  if (options.sortOrder) params.sort_order = options.sortOrder;
+  if (options.status && options.status !== 'all') params.status = options.status;
+  if (options.actionType && options.actionType !== 'all') params.action_type = options.actionType;
   return unwrap(await api.get(`/api/v1/workspaces/${workspaceId}/todos/center`, { params }));
 }
 

--- a/frontend/tests/check_056_pagination.spec.ts
+++ b/frontend/tests/check_056_pagination.spec.ts
@@ -1,0 +1,91 @@
+// 056：事项列表服务端分页验证（Playwright 临时调试脚本）
+// 验证点：
+// 1. 列表形态：分页控件展示总数、翻页后表格行变化
+// 2. 卡片形态：bucket Tab 角标计数、底部 Pagination
+// 3. 看板：brief 加载后卡片渲染
+import { test, expect } from '@playwright/test';
+
+const BASE = 'http://localhost:18088';
+
+test.describe('056 服务端分页', () => {
+  test('列表形态：分页控件与翻页', async ({ page }) => {
+    await page.goto(`${BASE}/#/todos?view=list`);
+    await page.waitForTimeout(2000);
+
+    // 切到列表形态（antd 把 title 放在 .ant-segmented-item-label 上）
+    const listBtn = page.locator('.ant-segmented-item-label[title="列表"]');
+    if (await listBtn.count() > 0) {
+      await listBtn.first().click();
+      await page.waitForTimeout(1500);
+    }
+
+    // 分页控件应展示「共 N 项」且 N > 0（dev 库有种子数据）
+    const totalText = page.locator('.ant-pagination-total-text');
+    await expect(totalText).toBeVisible({ timeout: 5000 });
+    const total = await totalText.textContent();
+    console.log('列表分页总数:', total);
+
+    // 表格应有行
+    const rows = page.locator('.ant-table-tbody tr.ant-table-row');
+    const rowCount = await rows.count();
+    console.log('当前页行数:', rowCount);
+    expect(rowCount).toBeGreaterThan(0);
+
+    // 行数应 ≤ 默认页大小 20（服务端分页的直接证据：不是全量）
+    expect(rowCount).toBeLessThanOrEqual(20);
+
+    // 翻页或页大小控件存在即视为分页生效（总数 ≤ 页大小时 antd 可能隐藏尺寸选择器）
+    const pagination = page.locator('.ant-pagination');
+    await expect(pagination).toBeVisible();
+
+    await page.screenshot({ path: 'tests/__screenshots__/056-list-pagination.png' });
+  });
+
+  test('卡片形态：bucket 角标与底部分页', async ({ page }) => {
+    await page.goto(`${BASE}/#/todos`);
+    await page.waitForTimeout(2000);
+
+    // 切到卡片形态（Segmented 为图标 + title 模式）
+    const cardBtn = page.locator('.ant-segmented-item[title="卡片视图"], .ant-segmented-item[title="卡片"]');
+    if (await cardBtn.count() > 0) {
+      await cardBtn.first().click();
+      await page.waitForTimeout(1500);
+    }
+
+    // bucket Tab 角标应显示数字（bucket_counts 后端聚合）
+    const manualTab = page.locator('[data-testid="todo-center-tab-manual"]');
+    await expect(manualTab).toBeVisible({ timeout: 5000 });
+    const manualText = await manualTab.textContent();
+    console.log('手动触发 Tab 角标:', manualText);
+
+    // 底部应有 Pagination 控件
+    const pagination = page.locator('.ant-pagination');
+    await expect(pagination.first()).toBeVisible();
+    const totalText = await pagination.first().locator('.ant-pagination-total-text').textContent();
+    console.log('卡片分页总数:', totalText);
+
+    await page.screenshot({ path: 'tests/__screenshots__/056-card-pagination.png' });
+  });
+
+  test('看板：brief 加载渲染', async ({ page }) => {
+    // 看板是 memorial 视图的一种 mode（/#/memorial?mode=kanban）
+    await page.goto(`${BASE}/#/memorial?mode=kanban`);
+    await page.waitForTimeout(2500);
+
+    // dev 库种子数据较旧（>24h），默认 24h 过滤会隐藏全部已完成卡；
+    // 切到 7d 时间窗让卡片可见（验证 brief 加载→渲染链路）。
+    const seg7d = page.locator('.ant-segmented-item:has-text("7d")');
+    if (await seg7d.count() > 0) {
+      await seg7d.first().click();
+      await page.waitForTimeout(2000);
+    }
+
+    // 看板卡片应渲染（dev 库有待执行事项）
+    const cards = page.locator('.kanban-card');
+    const count = await cards.count();
+    console.log('看板卡片数:', count);
+    expect(count).toBeGreaterThan(0);
+
+    await page.screenshot({ path: 'tests/__screenshots__/056-kanban-brief.png' });
+  });
+});

--- a/frontend/tests/check_056_pagination.spec.ts
+++ b/frontend/tests/check_056_pagination.spec.ts
@@ -25,11 +25,12 @@ test.describe('056 服务端分页', () => {
     const total = await totalText.textContent();
     console.log('列表分页总数:', total);
 
-    // 表格应有行
+    // 表格应有行（dev 库有种子数据；空库环境下跳过本用例——
+    // CodeRabbit#15：调试脚本依赖种子数据，干净环境不硬失败）
     const rows = page.locator('.ant-table-tbody tr.ant-table-row');
     const rowCount = await rows.count();
     console.log('当前页行数:', rowCount);
-    expect(rowCount).toBeGreaterThan(0);
+    test.skip(rowCount === 0, '当前环境无种子数据，跳过分页行数断言');
 
     // 行数应 ≤ 默认页大小 20（服务端分页的直接证据：不是全量）
     expect(rowCount).toBeLessThanOrEqual(20);


### PR DESCRIPTION
## 实现了什么

对应需求 056（docs/requirements/056-Todo列表服务端分页化与质量修复-需求.md），一次性交付 R1–R10（决策 1a/2a/3b/4a 已确认）：

**核心：Todo 列表全量查询彻底治理**
- **R1（正确性 bug）**：执行记录「先分页后按 workspace 内存过滤」导致多工作空间下条数稀释、total 失真。过滤下推 SQL 子查询（`todo_id IN (SELECT id FROM todos WHERE workspace_id=?)`），total 与数据同源，含回归测试。
- **R2**：`GET /todos/center` 分桶/搜索/排序/分页全部下推 SQL（bucket 用 CASE WHEN 表达式，与 Rust `compute_bucket` 有对拍测试防漂移）；新增 `/todos/ids`、`/todos/count`、`/todos/brief` 三个轻量接口；旧 `/todos` 强制分页（决策 3b），CLI 同步适配。
- **R3**：前端列表/卡片页改真服务端分页（翻页/排序/搜索/筛选一次请求一页）；**全局 `state.todos` 全量桶彻底删除**（决策 2a），10 个读取点改为 `useTodoById` 按需查询或 brief/count 轻量接口；看板保持全量渲染但换 brief（决策 1a，传输量约为整行 1/10），prompt 展开时按需拉取，拖拽改 `force-status` 单字段端点。
- **R4**：`get_todos`/`get_todos_by_workspace_id`/`get_todo_center` 三个全量函数从 db 层删除；云同步改 id 游标分批（500/批）；飞书卡片改 brief + 20 条截断。

**质量修复**
- **R5(L3)**：auto_update 在夏令时切换日 `and_local_timezone().unwrap()` panic → 三态安全映射 + 单测。
- **R6(L4)**：WS 同步、artifact 路径解析的 DB 错误不再被 `unwrap_or_default()` 静默吞掉。
- **R7(L5)**：flow 风格 YAML（`process: {name: x}`）guid 行级插入永远失败导致每次 PUT 都 warn 刷屏 → serde fallback 修复 + 进程内告警去重。
- **R8(L6)**：WS `Finished` 3 秒移除定时器与重连 Sync 竞争 → 定时器按 taskId 管理，Sync 到达即撤销。
- **R9(P3)**：dashboard 缓存升级：单飞刷新（并发过期只算一次）+ stale-on-error（刷新失败返旧值续 5s）+ 执行终态主动失效（跑完任务立刻看到新统计）。
- **R10(规范)**：`cargo clippy --all-targets -- -D warnings` **45 → 0 告警**；生产 unwrap 逐处处理。

## 与需求的对应关系

| 需求 | 状态 |
|------|------|
| R1 执行记录 ws 过滤下推 | ✅ 含分页稀释回归测试 |
| R2 todo-center 分页 + 轻量接口 | ✅ |
| R3 前端切换（1a/2a/3b） | ✅ |
| R4 全量函数删除 | ✅ |
| R5–R9 质量项 | ✅ 均有测试或实测验证 |
| R10 规范项 | ✅ -D warnings 通过 |

## 测试与验证结果

| 门禁 | 结果 |
|------|------|
| `cargo clippy --all-targets -- -D warnings` | ✅ 零告警（修复前 45 条） |
| `cargo test`（lib 1574 + 集成 293） | ✅ 全过 |
| `npx tsc --noEmit` | ✅ 零错误 |
| `npx vitest run` | ✅ 227/227 |
| Playwright `check_056_pagination.spec.ts` | ✅ 3/3（列表分页/卡片角标+分页/看板 brief） |
| API 实测 | 分页元数据、bucket 过滤、ids/count/brief、执行记录 ws 隔离（ws2 total=27 vs ws1 total=1）均正确 |

新增后端测试 12 个：SQL/Rust 分桶对拍、分页元数据、brief 归档语义、hours SQL 过滤、游标分批不重不漏、ids/count 语义、ws 过滤分页回归、DST×3、guid fallback×5。

## Breaking Changes

1. `GET /api/v1/workspaces/{ws}/todos` 响应从 `Todo[]` 变为 `{ items, total, page, page_size }`（决策 3b 已确认；CLI 已同步适配）。
2. `GET /todos/center` 响应从数组变为 `TodoCenterPage` 结构（054 新接口，仅前端内部使用）。

## 已知限制

- 看板/执行记录搜索不再匹配 prompt（brief 无此字段，决策 1a 的取舍）。
- 表格「执行时间」列不再可排序（聚合字段不在 todos 表）。
- 批量选择仅对当前页有效。

## 存量问题（与本 PR 无关）

- `git_sync::test_sync_repo_restores_deleted_file` 在本机失败：git 2.20 不支持 `git init -b`（需 ≥2.28），main 分支同样失败。
- `db_pool_concurrency_tests` 在本机曾现 v85 迁移对 fresh file-DB 的重复建表失败（main 同样复现，时序敏感；本次全量跑通过）。

设计文档：docs/design/056-Todo列表服务端分页化与质量修复-设计.md
实现总结：docs/requirements/056-Todo列表服务端分页化与质量修复-实现总结.md
