### PR TITLE
chore: 删除 #982 复活的 3 个死类型（恢复 #979 清理成果）

### DIFF
--- a/frontend/src/types/todo.ts
+++ b/frontend/src/types/todo.ts
@@ -110,32 +110,11 @@ export interface TodoListPage {
   page_size: number;
 }
 
-/** 环节 — 从 todo 提升而来的独立实体，不再寄生在 Todo 上。 */
-export interface StepSummary {
-  id: number;
-  title: string;
-  prompt: string;
-  executor?: string;
-  acceptance_criteria?: string | null;
-  source_todo_id?: number;
-  /** 被多少个 loop step 引用 */
-  used_by_loop_step_count: number;
-  /** 标签 ID 列表（单选，复用 Todo 的标签体系） */
-  tag_ids: number[];
-  created_at?: string;
-  updated_at?: string;
-}
-
 export interface Tag {
   id: number;
   name: string;
   color: string;
   created_at: string;
-}
-
-export interface TodoTag {
-  todo_id: number;
-  tag_id: number;
 }
 
 export interface TodoItem {
@@ -155,15 +134,6 @@ export interface TodoTemplate {
   last_sync_at?: string | null;
   created_at: string | null;
   updated_at: string | null;
-}
-
-export interface CustomTemplateStatus {
-  subscribed: boolean;
-  source_url: string | null;
-  last_sync_at: string | null;
-  auto_sync_enabled: boolean;
-  auto_sync_cron: string;
-  templates: TodoTemplate[];
 }
 
 // 复用 database/todos.ts 中的定义，避免多处定义造成漂移


### PR DESCRIPTION
## 背景

#982 是内容已全数经 #971/#976 交付的陈旧分支，合并后对 main 的唯一净增量是 `frontend/src/types/todo.ts` 中 30 行类型定义——正是 #979（057 死代码清理，`0519eaad`）前一天明确删除的未使用导出。

## 删除内容（-30 行）

| 类型 | 死代码证据 |
|------|-----------|
| `StepSummary` | 前端词边界搜索零引用；后端无对应 struct；环节实体化未实施 |
| `TodoTag` | 前端零引用；`updateTodoTags` 使用 `tagIds: number[]` |
| `CustomTemplateStatus` | 前端零引用；其 API 调用函数已被 #979 删除 |

删除后 `todo.ts` 与 `0519eaad` 清理后状态逐字节一致。

## 后续

若实施环节独立实体化，`StepSummary` 应随该功能 PR 与消费方同批提交（YAGNI）。

## 验证

- ✅ `tsc --noEmit` 零错误
- ✅ `vitest run` 232 全过