### PR TITLE
feat(executor): CodeBuddy 支持继续对话（--resume <session_id>）

### DIFF
--- a/backend/src/adapters/codebuddy.rs
+++ b/backend/src/adapters/codebuddy.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+use parking_lot::Mutex;
+
 use super::helpers;
 use super::{BaseExecutor, CodeExecutor, ExecutorType, ParsedLogEntry};
 use super::claude_protocol::{ClaudeMessage, ClaudeContentBlock};
@@ -6,21 +9,36 @@ use crate::models::utc_timestamp;
 /// Codebuddy executor。
 ///
 /// 与 ClaudeCode 结构对称（path + model），统一通过 `BaseExecutor` 共享状态。
-// `BaseExecutor` 已经 `#[derive(Clone)]`，组合字段无需手写 Clone impl。
+/// `session_id` 缓存从 system 事件提取的真实会话 ID：首次执行由 CodeBuddy CLI
+/// 自己生成并随 system 事件吐出，resume 时由 DB 读出经 `--resume` 传回 CLI。
+// `BaseExecutor` 已经 `#[derive(Clone)]`，组合字段无需手写 Clone impl；
+// session_id 用 Arc 包裹，克隆体共享同一份缓存，与 claude_code 保持一致。
 #[derive(Clone)]
 pub struct CodebuddyExecutor {
     base: BaseExecutor,
+    session_id: Arc<Mutex<Option<String>>>,
 }
 
 impl CodebuddyExecutor {
     pub fn new(path: String) -> Self {
-        Self { base: BaseExecutor::new(path) }
+        Self {
+            base: BaseExecutor::new(path),
+            session_id: Arc::new(Mutex::new(None)),
+        }
     }
 
-    /// 处理 system 事件：把 model 写入 base.state，content 显示 session init 摘要。
+    /// 处理 system 事件：把 model / session_id 写入缓存，content 显示 session init 摘要。
+    ///
+    /// session_id 必须在此缓存：它是「继续对话」的唯一凭据，resume 链路在
+    /// EventPipeline 回退路径（`update_session_id_once`）依赖本缓存回写 DB。
     fn handle_system(&self, model: Option<&String>, session_id: Option<&String>, subtype: Option<&String>) -> Option<ParsedLogEntry> {
         if let Some(m) = model {
             *self.base.model.lock() = Some(m.clone());
+        }
+        // 缓存 session_id：供 get_session_id / extract_session_id 复用，
+        // resume 场景下 CLI 重吐同一 sid，重复写入值相同，无需判重。
+        if let Some(sid) = session_id {
+            *self.session_id.lock() = Some(sid.clone());
         }
         Some(helpers::entry("system", format!("Session init: {:?}", session_id.or(subtype))))
     }
@@ -166,6 +184,58 @@ impl CodeExecutor for CodebuddyExecutor {
         ]
     }
 
+    /// 带 session 的 argv 构造：resume 时在 stream-json 之后插入 `--resume <sid>`。
+    ///
+    /// 设计取舍（与 claude_code 对齐）：
+    /// - 首次执行不传 `--session-id`，让 CLI 自生成真实 sid，再由 system 事件回收；
+    ///   若外部强行指定 sid 可能与 CLI 内部生成规则冲突。
+    /// - `is_resume=true` 但 sid 为 None 时静默降级为新会话：handler 层
+    ///   （`resolve_resume_session_id`）已拦截 None 并返回 400，此处只是防御。
+    /// - `--resume` 放在 stream-json 之后、`--verbose` 之前，与 claude_code 的 argv
+    ///   布局保持一致，降低维护者对照两个适配器时的认知成本。
+    fn command_args_with_session(&self, message: &str, session_id: Option<&str>, is_resume: bool) -> Vec<String> {
+        let mut args = vec![
+            "-p".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+        ];
+        if is_resume {
+            if let Some(sid) = session_id {
+                args.push("--resume".to_string());
+                args.push(sid.to_string());
+            }
+        }
+        args.push("--verbose".to_string());
+        args.push("--permission-mode".to_string());
+        args.push("bypassPermissions".to_string());
+        args.push(message.to_string());
+        args
+    }
+
+    /// CodeBuddy CLI 原生支持 `-r/--resume <sessionId>`（已在设计文档验证），
+    /// 声明可恢复后 handler 层才会放行 resume 请求。
+    fn supports_resume(&self) -> bool {
+        true
+    }
+
+    /// 从 stdout 行提取 session_id：命中 system 事件则更新缓存并返回，
+    /// 否则回退到已缓存值（handle_system 在 parse_output_line 路径写入）。
+    /// EventPipeline 正常路径用不到本方法，它是 pipeline 无事件产出时的兜底。
+    fn extract_session_id(&self, line: &str) -> Option<String> {
+        if !line.is_empty() {
+            // 两层匹配合并为一层：外层 JSON 解析，内层直接命中带 session_id 的 System 变体。
+            if let Ok(ClaudeMessage::System { session_id: Some(sid), .. }) = serde_json::from_str::<ClaudeMessage>(line) {
+                *self.session_id.lock() = Some(sid.clone());
+                return Some(sid);
+            }
+        }
+        self.session_id.lock().clone()
+    }
+
+    fn get_session_id(&self) -> Option<String> {
+        self.session_id.lock().clone()
+    }
+
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
         if line.is_empty() {
             return None;
@@ -308,5 +378,102 @@ mod tests {
     fn test_get_model_before_system() {
         let executor = CodebuddyExecutor::new("codebuddy".to_string());
         assert!(executor.get_model().is_none());
+    }
+
+    // ====================== resume（继续对话）能力测试 ======================
+    // 对应需求 058 R1：session_id 缓存 + supports_resume + command_args_with_session。
+
+    #[test]
+    fn test_supports_resume_true() {
+        // CodeBuddy CLI 原生支持 --resume <sessionId>，必须为 true 才能通过 handler 层校验
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
+        assert!(executor.supports_resume());
+    }
+
+    #[test]
+    fn test_command_args_with_session_resume_includes_resume_flag() {
+        // resume 场景：argv 必须携带 `--resume <sid>`，且位于 stream-json 之后、--verbose 之前
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
+        let args = executor.command_args_with_session("continue please", Some("sess_cb_1"), true);
+        let pos_resume = args.iter().position(|a| a == "--resume").expect("should contain --resume");
+        assert_eq!(args[pos_resume + 1], "sess_cb_1");
+        let pos_format = args.iter().position(|a| a == "stream-json").unwrap();
+        let pos_verbose = args.iter().position(|a| a == "--verbose").unwrap();
+        assert!(pos_format < pos_resume && pos_resume < pos_verbose);
+        // message 仍是最后一个参数，避免被 CLI 当作 flag 值
+        assert_eq!(args.last().unwrap(), "continue please");
+    }
+
+    #[test]
+    fn test_command_args_with_session_new_execution_ignores_sid() {
+        // 新执行（is_resume=false）即使带了 sid 也不传 --resume / --session-id：
+        // 首次执行让 CLI 自生成真实 sid，避免外部指定与内部生成规则冲突
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
+        let args = executor.command_args_with_session("hello", Some("sess_cb_2"), false);
+        assert!(!args.iter().any(|a| a == "--resume" || a == "--session-id"));
+        assert!(!args.iter().any(|a| a == "sess_cb_2"));
+    }
+
+    #[test]
+    fn test_command_args_with_session_resume_without_sid_degrades() {
+        // 防御：is_resume=true 但 sid 为 None 时静默降级为新会话
+        // （handler 层已拦截 None 返回 400，正常不会走到这里）
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
+        let args = executor.command_args_with_session("hello", None, true);
+        assert!(!args.iter().any(|a| a == "--resume"));
+    }
+
+    #[test]
+    fn test_extract_session_id_from_system_line() {
+        // system 事件携带 session_id：应返回并写入缓存
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
+        let line = r#"{"type":"system","subtype":"init","session_id":"37814b2c-c93e-44ca-8462-bd7fc8d8105c","model":"m"}"#;
+        assert_eq!(
+            executor.extract_session_id(line),
+            Some("37814b2c-c93e-44ca-8462-bd7fc8d8105c".to_string())
+        );
+        assert_eq!(
+            executor.get_session_id(),
+            Some("37814b2c-c93e-44ca-8462-bd7fc8d8105c".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_session_id_fallback_to_cached() {
+        // 非 system 行（如 assistant）不含 sid：回退到 handle_system 已缓存的值。
+        // 这覆盖 log_capture 回退路径——pipeline 无事件产出时仍能把 sid 回写 DB。
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
+        let sys = r#"{"type":"system","session_id":"sess_cached","model":"m"}"#;
+        let _ = executor.parse_output_line(sys);
+        let assistant = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}"#;
+        assert_eq!(
+            executor.extract_session_id(assistant),
+            Some("sess_cached".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_session_id_empty_line_before_system() {
+        // system 事件未到达前：空行返回 None，不应误报一个不存在的 sid
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
+        assert_eq!(executor.extract_session_id(""), None);
+    }
+
+    #[test]
+    fn test_get_session_id_before_system() {
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
+        assert!(executor.get_session_id().is_none());
+    }
+
+    #[test]
+    fn test_parse_output_line_system_caches_session_id() {
+        // parse_output_line → handle_system 的副作用：session_id 被缓存，
+        // 同时 system 条目照常产生（维持现状的日志展示行为）
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
+        let line = r#"{"type":"system","session_id":"sess_parse","model":"claude-3-5-sonnet"}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "system");
+        assert_eq!(executor.get_session_id(), Some("sess_parse".to_string()));
+        assert_eq!(executor.get_model(), Some("claude-3-5-sonnet".to_string()));
     }
 }

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -157,7 +157,9 @@ pub static EXECUTORS: &[ExecutorDef] = &[
 ];
 
 /// 支持继续对话的执行器集合（与前端 RESUMABLE_EXECUTORS 保持一致）
-pub const RESUMABLE_EXECUTORS: &[&str] = &["claudecode", "kimi", "opencode", "mobilecoder", "hermes", "codewhale", "pi", "mimo", "zhanlu", "kilo"];
+/// Issue 058：codebuddy 补齐 resume 三要素（supports_resume / command_args_with_session /
+/// session_id 缓存）后加入集合，与前端 executors.tsx 的 resumable: true 同步。
+pub const RESUMABLE_EXECUTORS: &[&str] = &["claudecode", "codebuddy", "kimi", "opencode", "mobilecoder", "hermes", "codewhale", "pi", "mimo", "zhanlu", "kilo"];
 
 /// 默认执行器
 pub const DEFAULT_EXECUTOR: &str = "claudecode";
@@ -599,6 +601,22 @@ mod tests {
     fn test_resumable_executors_contains_kilo() {
         assert!(RESUMABLE_EXECUTORS.contains(&"kilo"),
             "kilo should be in RESUMABLE_EXECUTORS; current list: {:?}", RESUMABLE_EXECUTORS);
+    }
+
+    #[test]
+    fn test_resumable_executors_contains_codebuddy() {
+        // Issue 058：codebuddy 支持继续对话后必须登记进 RESUMABLE_EXECUTORS，
+        // 与前端 executors.tsx 的 resumable: true 保持同步
+        assert!(RESUMABLE_EXECUTORS.contains(&"codebuddy"),
+            "codebuddy should be in RESUMABLE_EXECUTORS; current list: {:?}", RESUMABLE_EXECUTORS);
+    }
+
+    #[test]
+    fn test_create_executor_codebuddy_supports_resume() {
+        // 注册表工厂产出的 codebuddy 实例必须声明 supports_resume，
+        // 否则 handlers/execution.rs 的 resume 校验会 400 拒绝
+        let executor = ExecutorRegistry::create_executor("codebuddy", "codebuddy").unwrap();
+        assert!(executor.supports_resume(), "Codebuddy executor should support resume");
     }
 
     #[test]

--- a/backend/tests/adapter_extended_tests.rs
+++ b/backend/tests/adapter_extended_tests.rs
@@ -621,7 +621,19 @@ mod codebuddy_executor_extended_tests {
 
     #[test]
     fn test_supports_resume() {
+        // Issue 058：CodeBuddy CLI 原生支持 --resume <sessionId>，适配器已补齐
+        // resume 三要素（supports_resume / command_args_with_session / session_id 缓存），
+        // 断言从「不支持」反转为「支持」。
         let executor = CodebuddyExecutor::new("codebuddy".to_string());
-        assert!(!executor.supports_resume());
+        assert!(executor.supports_resume());
+    }
+
+    #[test]
+    fn test_command_args_with_session_resume() {
+        // resume 场景：argv 必须携带 `--resume <sid>`，否则 CLI 会开新会话而非继续对话
+        let executor = CodebuddyExecutor::new("codebuddy".to_string());
+        let args = executor.command_args_with_session("go on", Some("sess_ext_1"), true);
+        let pos = args.iter().position(|a| a == "--resume").expect("should contain --resume");
+        assert_eq!(args[pos + 1], "sess_ext_1");
     }
 }

--- a/docs/design/058-CodeBuddy支持继续对话-设计.md
+++ b/docs/design/058-CodeBuddy支持继续对话-设计.md
@@ -1,0 +1,71 @@
+# 058-CodeBuddy 支持继续对话-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| pi (AI) | 2026-08-04 | 初始版本 |
+
+## 1. 总体思路
+
+完全复刻 `ClaudeCodeExecutor` 已验证的 resume 模式到 `CodebuddyExecutor`：两者同为 Claude Protocol（stream-json NDJSON），CLI 参数语义一致（`--resume <sessionId>`）。改动是「适配器状态 + 3 个 trait 方法覆盖 + 2 处集合登记」，无架构变更。
+
+## 2. resume 链路现状（无需改动的部分）
+
+```
+前端继续对话按钮 → POST /execution-records/{id}/resume
+  → handlers/execution.rs::resume_execution
+      ├─ executor.supports_resume()          ← 缺口 1（默认 false，直接 400）
+      ├─ resolve_resume_session_id(record)   ← 依赖 DB session_id，已由
+      │     CodebuddyExtractor SessionStart 事件回写，无需改动 ✓
+      └─ start_todo_execution(resume_session_id)
+            → pre_spawn::build_executor_command_args
+                  └─ executor.command_args_with_session(msg, Some(sid), true)  ← 缺口 2
+```
+
+执行期日志链路（`log_capture::spawn_stdout_reader`）：EventPipeline 优先解析，`pipeline.metadata().session_id` 首次出现即回写 DB；pipeline 无事件产出时回退 `executor.extract_session_id(line)` ← 缺口 3。
+
+## 3. 详细改动
+
+### 3.1 `backend/src/adapters/codebuddy.rs`
+
+- 结构体新增 `session_id: Arc<Mutex<Option<String>>>`（`#[derive(Clone)]` 由 BaseExecutor 同款 Arc 共享语义覆盖）。
+- `handle_system`：除缓存 model 外，同步缓存 `session_id`（副作用与 Claude Code 对齐；日志条目行为不变，见需求 3 边界）。
+- `supports_resume()` → `true`。
+- `command_args_with_session(message, session_id, is_resume)`：
+  - argv 顺序与 claude_code 对齐：`-p --output-format stream-json [--resume <sid>] --verbose --permission-mode bypassPermissions <message>`。
+  - 仅 `is_resume && session_id.is_some()` 时插 `--resume`；`is_resume=true` 但 sid 为 None 时静默降级为新会话（与 claude_code 行为一致——理论上 handler 层已拦截 None，这里只是防御）。
+  - 非 resume 不传 `--session-id`：首次执行让 CLI 自生成，避免冲突。
+- `extract_session_id(line)`：行内解析出 system.session_id 则更新缓存并返回；否则返回缓存值（handle_system 已写入）。
+- `get_session_id()` → 缓存克隆。
+
+### 3.2 `backend/src/adapters/mod.rs`
+
+`RESUMABLE_EXECUTORS` 加入 `"codebuddy"`（该常量当前仅测试引用，作为前后端同步的权威声明）。
+
+### 3.3 `frontend/src/utils/executors.tsx`
+
+`EXECUTORS` codebuddy 条目追加 `resumable: true`；`RESUMABLE_EXECUTORS` Set 由 filter 自动派生，无需手改。
+
+### 3.4 resume 后 session_id 不被覆盖
+
+resume 场景 `initial_session_id = Some(sid)` → `session_id_updated` 初始即 true → 执行期跳过 DB 覆盖；且 codebuddy resume 后 system 事件携带的仍是同一 session_id，语义自洽。
+
+## 4. 测试设计
+
+新增单元测试（codebuddy.rs）：
+
+| 用例 | 断言 |
+|------|------|
+| resume + sid | argv 含 `--resume <sid>`，位置在 stream-json 之后 |
+| 新执行（is_resume=false，带 sid） | argv 不含 `--resume` |
+| resume + None sid | argv 不含 `--resume`（防御降级） |
+| `supports_resume` | true |
+| `extract_session_id` 从 system 行 | 返回并缓存 sid |
+| `extract_session_id` 空行/无 sid 行 | 回退缓存值或 None |
+| `get_session_id` 初始 | None |
+
+mod.rs 新增：`RESUMABLE_EXECUTORS` 含 codebuddy 的断言测试。
+
+## 5. 验证记录（设计期实测）
+
+- `codebuddy -p --output-format stream-json --resume 00000000-... "hi"` → `{"type":"error","error":"No conversation found with session ID: ..."}`：flag 被接受，错误可观测。
+- 真实会话 `f3c866f3-...` resume → 后续事件 `session_id` 一致，会话成功关联（本机未登录导致模型调用失败，属环境问题，与 resume 机制无关）。

--- a/docs/requirements/058-CodeBuddy支持继续对话-实现总结.md
+++ b/docs/requirements/058-CodeBuddy支持继续对话-实现总结.md
@@ -1,0 +1,46 @@
+# 058-CodeBuddy 支持继续对话-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| pi (AI) | 2026-08-04 | 初始版本 |
+
+## 1. 需求对应
+
+| 需求条目 | 实现 | 状态 |
+|---------|------|------|
+| R1 后端适配器 resume 三要素 | `backend/src/adapters/codebuddy.rs` | ✅ |
+| R2 RESUMABLE_EXECUTORS 登记 | `backend/src/adapters/mod.rs` | ✅ |
+| R3 前端开放继续对话入口 | `frontend/src/utils/executors.tsx` | ✅ |
+
+## 2. 关键实现点
+
+1. **`CodebuddyExecutor` 新增 `session_id: Arc<Mutex<Option<String>>>`**：`handle_system` 解析 system 事件时同步缓存真实 session_id（与 `ClaudeCodeExecutor` 同款模式，克隆体共享 Arc 状态）。
+2. **`supports_resume()` → true**：放行 `handlers/execution.rs` 的 resume 校验。
+3. **`command_args_with_session()`**：`is_resume && sid.is_some()` 时在 `stream-json` 之后、`--verbose` 之前插 `--resume <sid>`（与 claude_code argv 布局一致）；首次执行不传 `--session-id`，由 CLI 自生成；resume 但无 sid 时静默降级（handler 层已先行拦截）。
+4. **`extract_session_id()` / `get_session_id()`**：覆盖 EventPipeline 无事件产出时的回退回写路径。
+5. **前端 codebuddy 条目加 `resumable: true`**：`RESUMABLE_EXECUTORS` Set 自动派生，`supportsResume(record)` 放行，帖子页渲染回复输入框。
+6. **存量集成测试反转**：`adapter_extended_tests.rs::test_supports_resume` 原断言「不支持 resume」，同步反转为「支持」并补 argv 断言。
+
+## 3. 测试与验证
+
+### 单元/集成测试
+
+- `cargo clippy --all-targets -- -D warnings`：零告警 ✅
+- `cargo test`：1599 通过；新增 10 个用例（codebuddy.rs 8 个、mod.rs 2 个、adapter_extended_tests.rs 1 改 1 增）。
+- 存量失败 `git_sync::tests::test_sync_repo_restores_deleted_file` 与本次无关（main 上同样失败，根因是系统 git 版本不支持 `git init -b`）。
+- 前端 `npx tsc --noEmit`：零错误 ✅
+
+### 功能验证（dev 环境，Playwright + 真实 API）
+
+预置记录：todo 8 下 id=40（codebuddy + session）、id=41（atomcode + session，对照组）。
+
+1. **前端入口**：`frontend/tests/check_codebuddy_resume.spec.ts` 通过——codebuddy 记录帖子页出现回复输入框，atomcode 记录不出现。
+2. **resume API**：`POST /api/v1/workspaces/1/executions/40/resume` → 200，新记录 id=42。
+3. **argv 正确性**：记录 42 实际命令为 `codebuddy -p --output-format stream-json --resume cb-sess-verify-058 --verbose --permission-mode bypassPermissions <message>`，`--resume` 位置符合设计。
+4. **CLI 可达性**：CodeBuddy 返回 `{"type":"error","error":"No conversation found with session ID: cb-sess-verify-058"}`（假 sid 的预期错误），证明 flag 被 CLI 正确接收处理；新记录继承原 session_id 未被覆盖。
+5. **设计期真机验证**：真实会话 `f3c866f3-...` resume 后事件流 session_id 一致，会话成功关联。
+
+## 4. 已知限制
+
+- 本机 codebuddy 未登录时 print 模式模型调用报 "Authentication required"，属环境问题，与 resume 机制无关。
+- resume 一个不存在的 session_id 时 CLI 输出 `{"type":"error"}` 行，当前按 text 条目落库（与 claude_code 行为一致），未做特化展示。

--- a/docs/requirements/058-CodeBuddy支持继续对话-需求.md
+++ b/docs/requirements/058-CodeBuddy支持继续对话-需求.md
@@ -1,0 +1,48 @@
+# 058-CodeBuddy 支持继续对话-需求
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| pi (AI) | 2026-08-04 | 初始版本 |
+
+## 1. 背景与问题
+
+ntd 的执行记录支持「继续对话」（resume）：基于某条历史执行记录的 `session_id`，让执行器恢复原会话上下文继续追问。目前 Claude Code、Kimi、Opencode 等 10 个执行器已支持，但 **CodeBuddy 不在可恢复执行器集合中**，其执行记录上无法发起继续对话。
+
+实测确认 CodeBuddy 执行的 stdout 第一行就是 system init 事件，携带真实 `session_id`（如 `37814b2c-c93e-44ca-8462-bd7fc8d8105c`），且该 session_id 已经由 `CodebuddyExtractor`（EventPipeline）提取并回写到 `execution_records.session_id`——即**数据链路已通，缺的只是「把 session_id 用回 CLI」的适配层实现**。
+
+已验证 CodeBuddy CLI 原生支持恢复会话：
+
+- `-r, --resume [sessionId]`：恢复指定 session 的对话（print 模式 `-p` + `stream-json` 下可用）。
+- 传入不存在的 session id 时输出 `{"type":"error","error":"No conversation found with session ID: ..."}`，错误可观测。
+- 传入真实 session id 时，后续事件携带同一 `session_id`，会话成功恢复。
+
+## 2. 需求条目
+
+### R1 后端适配器实现 resume 三要素
+
+`backend/src/adapters/codebuddy.rs` 的 `CodebuddyExecutor`：
+
+- 新增 `session_id: Arc<Mutex<Option<String>>>` 状态字段，在解析 system 事件时缓存真实 session_id（与 `ClaudeCodeExecutor` 同款模式）。
+- 覆盖 `supports_resume()` 返回 `true`。
+- 覆盖 `command_args_with_session()`：`is_resume=true` 且有 session_id 时，在 argv 中插入 `--resume <session_id>`；首次执行（非 resume）不传 `--session-id`，由 CLI 自行生成。
+- 覆盖 `extract_session_id()` / `get_session_id()`，保证 EventPipeline 回退路径也能回写 session_id。
+
+### R2 后端可恢复执行器集合登记
+
+`backend/src/adapters/mod.rs` 的 `RESUMABLE_EXECUTORS` 常量加入 `"codebuddy"`，与前端保持同步。
+
+### R3 前端开放「继续对话」入口
+
+`frontend/src/utils/executors.tsx` 的 `EXECUTORS` 中 codebuddy 条目增加 `resumable: true`，使 `supportsResume(record)` 对 codebuddy 执行记录返回 true，前端展示继续对话按钮。
+
+## 3. 边界与非目标
+
+- 不做 CodeBuddy session 目录扫描器（`handlers/session.rs` 的 session 浏览功能），那是独立特性。
+- 不为 codebuddy 增加 `--model` 注入（`set_exec_model`），属另一需求（执行器指定模型）。
+- 不改动 codebuddy system 事件的日志展示行为（`Session init` 条目维持现状）。
+
+## 4. 验收标准
+
+1. codebuddy 执行记录（非 running、DB 有 session_id）上，前端出现「继续对话」入口并可发起。
+2. 发起继续对话后，后端实际执行的 argv 含 `--resume <session_id>`。
+3. `cargo clippy --all-targets -- -D warnings` 零告警、`cargo test` 全通过、`npx tsc --noEmit` 零错误。

--- a/frontend/src/utils/executors.tsx
+++ b/frontend/src/utils/executors.tsx
@@ -52,7 +52,9 @@ export function setDefaultExecutorCache(name: string): void {
 
 export const EXECUTORS: ExecutorOption[] = [
   { value: 'claudecode', label: 'Claude',    color: '#e17055', icon: <FaSquare color="#e17055" size={14} />, resumable: true },
-  { value: 'codebuddy',  label: 'CodeBuddy', color: '#00b894', icon: <FaSquare color="#00b894" size={14} /> },
+  // Issue 058：CodeBuddy CLI 原生支持 --resume <sessionId>，后端适配器已补齐
+  // resume 三要素，此处开放前端「继续对话」入口（RESUMABLE_EXECUTORS 由本标志自动派生）。
+  { value: 'codebuddy',  label: 'CodeBuddy', color: '#00b894', icon: <FaSquare color="#00b894" size={14} />, resumable: true },
   { value: 'opencode',   label: 'Opencode',  color: '#fdcb6e', icon: <FaSquare color="#fdcb6e" size={14} />, resumable: true },
   { value: 'mobilecoder', label: 'MobileCoder', color: '#6c5ce7', icon: <FaSquare color="#6c5ce7" size={14} />, resumable: true },
   { value: 'atomcode',   label: 'AtomCode',  color: '#e84393', icon: <FaSquare color="#e84393" size={14} /> },

--- a/frontend/tests/check_codebuddy_resume.spec.ts
+++ b/frontend/tests/check_codebuddy_resume.spec.ts
@@ -1,0 +1,36 @@
+// Issue 058：验证 CodeBuddy 执行记录出现「继续对话」回复输入框。
+//
+// 验证逻辑：
+// - todo 8 下预置两条执行记录（均 success + 带 session_id）：
+//   - id=40 codebuddy → 应渲染 ReplyRow（回复输入框）
+//   - id=41 atomcode（不支持 resume 的对照组）→ 不应渲染
+// - ReplyRow 的判显条件是 supportsResume(record)：status 非 running +
+//   有 session_id + executor 在 RESUMABLE_EXECUTORS 集合内。
+//
+// 运行前提：make dev 已启动（http://localhost:18088），且 dev DB 已插入上述记录。
+import { test, expect } from '@playwright/test';
+
+test('codebuddy 执行记录显示继续对话输入框，atomcode 不显示', async ({ page }) => {
+  // ReplyRow 渲染在帖子页（/#/todos/:id/posts/:rid）的 ThreadGroup 末尾记录下方。
+  // todo 8 下预置两条 success + 带 session_id 的记录：
+  //   id=40 codebuddy → 应渲染回复输入框（resumable）
+  //   id=41 atomcode（对照组，不支持 resume）→ 不应渲染
+
+  // 帖子页按全局选中的工作空间拉取执行记录，直接访问 URL 时默认为 #0
+  // 会报「todo 不属于工作空间」。用 addInitScript 在每次页面加载前写入
+  // localStorage（SPA 只在启动时读一次 selected_workspace，goto 后 evaluate 太晚）。
+  await page.addInitScript(() => localStorage.setItem('selected_workspace', '1'));
+
+  // 正向：codebuddy 记录的帖子页应出现回复输入框
+  await page.goto('http://localhost:18088/#/todos/8/posts/40');
+  await page.waitForTimeout(3000);
+  const codebuddyReply = page.locator('input[placeholder="输入回复内容..."]');
+  expect(await codebuddyReply.count()).toBe(1);
+  await page.screenshot({ path: 'test-results/codebuddy-resume.png', fullPage: true });
+
+  // 反向：atomcode 记录的帖子页不应出现回复输入框
+  await page.goto('http://localhost:18088/#/todos/8/posts/41');
+  await page.waitForTimeout(3000);
+  const atomcodeReply = page.locator('input[placeholder="输入回复内容..."]');
+  expect(await atomcodeReply.count()).toBe(0);
+});


### PR DESCRIPTION
## 实现了什么

CodeBuddy 执行器支持「继续对话」（resume）：在某条 codebuddy 执行记录上回复时，后端以 `--resume <session_id>` 唤起 CodeBuddy CLI 恢复原会话上下文。

**问题根因**：codebuddy 的 session_id 本已由 `CodebuddyExtractor`（SessionStart 事件）回写到 `execution_records.session_id`（即执行日志第一行的 `[session_start] session_id: ...`），数据链路已通；缺的是适配层「把 session_id 用回 CLI」的实现——resume 请求被 `supports_resume()` 默认值 false 直接 400 拦截，前端也无 `resumable` 标志不渲染回复框。

已实测 CodeBuddy CLI 的 `-r/--resume <sessionId>` 在 `-p` + `stream-json` 模式下可用：真实 session 恢复后事件流 session_id 一致；不存在的 sid 返回 `{"type":"error","error":"No conversation found..."}` 可观测错误。

## 与需求的对应关系

需求/设计文档：`docs/requirements/058-CodeBuddy支持继续对话-需求.md`、`docs/design/058-CodeBuddy支持继续对话-设计.md`、实现总结同目录。

| 需求条目 | 实现 |
|---------|------|
| R1 适配器 resume 三要素 | `backend/src/adapters/codebuddy.rs`：session_id 缓存 + `supports_resume()` + `command_args_with_session()` + `extract_session_id()`/`get_session_id()` |
| R2 后端集合登记 | `backend/src/adapters/mod.rs` `RESUMABLE_EXECUTORS` 加 `"codebuddy"` |
| R3 前端开放入口 | `frontend/src/utils/executors.tsx` codebuddy 条目加 `resumable: true` |

## 关键实现点

- 完全复刻 `ClaudeCodeExecutor` 已验证的 resume 模式（同为 Claude Protocol，CLI 参数语义一致），无架构变更。
- argv 布局与 claude_code 对齐：`-p --output-format stream-json [--resume <sid>] --verbose --permission-mode bypassPermissions <message>`。
- 首次执行不传 `--session-id`，由 CLI 自生成后从 system 事件回收；resume 但无 sid 时静默降级（handler 层已先行拦截返回 400）。
- 存量集成测试 `adapter_extended_tests.rs::test_supports_resume` 原断言「不支持 resume」，同步反转为「支持」并补 argv 断言。

## 测试与验证结果

- ✅ `cargo clippy --all-targets -- -D warnings` 零告警；`cargo test` 1599 通过（新增 10 用例）；`npx tsc --noEmit` 零错误。
- ⚠️ 唯一失败 `git_sync::tests::test_sync_repo_restores_deleted_file` 为存量问题（main 上同样失败，根因是系统 git 版本不支持 `git init -b`），与本次无关。
- ✅ Playwright（`frontend/tests/check_codebuddy_resume.spec.ts`）：预置 codebuddy / atomcode（对照组）两条带 session 的记录，codebuddy 记录帖子页出现回复输入框、atomcode 不出现。
- ✅ 真实 API 端到端：`POST /api/v1/workspaces/1/executions/{id}/resume` → 200；新记录实际命令含 `--resume <sid>` 且位置正确；CLI 正确接收并处理该 flag；新记录继承原 session_id 未被覆盖。

## 已知限制

- resume 不存在的 session_id 时 CLI 输出 `{"type":"error"}` 行，当前按 text 条目落库（与 claude_code 行为一致），未做特化展示。
- 不做 codebuddy session 目录扫描器（session 浏览功能）与 `--model` 注入，均属独立需求（YAGNI）。
