### PR TITLE
feat(executor): Codex 会话入库 + 支持继续对话（codex exec resume <session_id>）

### DIFF
--- a/backend/src/adapters/codex.rs
+++ b/backend/src/adapters/codex.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 use serde_json::Value;
 
 use super::helpers;
@@ -12,15 +15,24 @@ use crate::models::utc_timestamp;
 ///   - Codex：error 关键字 → "stderr" log_type；其他 → "info"
 ///
 /// 这种反向分类是历史行为，必须保留 override，不能直接删除该方法。
-// `BaseExecutor` 已经 `#[derive(Clone)]`，组合字段无需手写 Clone impl。
+///
+/// `session_id` 缓存从 `thread.started` 事件提取的 thread_id（当前版本 Codex 输出
+/// 会话 ID 的唯一位置），它是 `codex exec resume <session_id>` 的会话凭据；
+/// 旧版本 `session_configured` 事件的 session_id 字段也一并兼容。
+// `BaseExecutor` 已经 `#[derive(Clone)]`，组合字段无需手写 Clone impl；
+// session_id 用 Arc 包裹，克隆体共享同一份缓存，与 codebuddy/claude_code 一致。
 #[derive(Clone)]
 pub struct CodexExecutor {
     base: BaseExecutor,
+    session_id: Arc<Mutex<Option<String>>>,
 }
 
 impl CodexExecutor {
     pub fn new(path: String) -> Self {
-        Self { base: BaseExecutor::new(path) }
+        Self {
+            base: BaseExecutor::new(path),
+            session_id: Arc::new(Mutex::new(None)),
+        }
     }
 
     /// item.started / item.completed：从顶层 json.item 提取 inner_type，再分发。
@@ -256,8 +268,54 @@ impl CodeExecutor for CodexExecutor {
         *self.base.model.lock() = model;
     }
 
-    fn command_args_with_session(&self, message: &str, _session_id: Option<&str>, _is_resume: bool) -> Vec<String> {
-        self.command_args(message)
+    /// 带 session 的 argv 构造：resume 时走 `codex exec resume [flags] <sid> <message>`。
+    ///
+    /// 设计取舍：
+    /// - Codex CLI 的 resume 是独立子命令（`codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]`），
+    ///   OPTIONS 与 exec 共享（clap 解析与位置无关），故直接复用 exec 的 flag 集合。
+    /// - `is_resume=true` 但 sid 为 None 时静默回退新会话：handler 层
+    ///   （`resolve_resume_session_id`）已拦截 None 返回 400，此处只是防御。
+    /// - sid 在前、prompt 殿后，与 CLI 的位置参数定义一致。
+    fn command_args_with_session(&self, message: &str, session_id: Option<&str>, is_resume: bool) -> Vec<String> {
+        if !is_resume {
+            return self.command_args(message);
+        }
+        let Some(sid) = session_id else {
+            return self.command_args(message);
+        };
+        let mut args = vec!["exec".to_string(), "resume".to_string()];
+        // 模型注入与 command_args 保持同源：执行前 set_exec_model 写入的期望值在这里拼 -m。
+        if let Some(m) = self.base.model.lock().clone() {
+            args.push("-m".to_string());
+            args.push(m);
+        }
+        args.push("--json".to_string());
+        args.push("--dangerously-bypass-approvals-and-sandbox".to_string());
+        args.push("--skip-git-repo-check".to_string());
+        args.push(sid.to_string());
+        args.push(message.to_string());
+        args
+    }
+
+    /// Codex CLI 原生支持 `codex exec resume <session_id>`（设计文档 §5 记录了验证限制），
+    /// 声明可恢复后 handler 层才会放行 resume 请求。
+    fn supports_resume(&self) -> bool {
+        true
+    }
+
+    /// 从 stdout 行提取 session_id：命中 thread.started.thread_id（新格式）或
+    /// session_configured.session_id（旧格式）则更新缓存并返回，否则回退已缓存值。
+    /// EventPipeline 正常路径用不到本方法，它是 pipeline 无事件产出时的兑底。
+    fn extract_session_id(&self, line: &str) -> Option<String> {
+        if let Some(sid) = extract_sid_from_line(line) {
+            *self.session_id.lock() = Some(sid.clone());
+            return Some(sid);
+        }
+        self.session_id.lock().clone()
+    }
+
+    fn get_session_id(&self) -> Option<String> {
+        self.session_id.lock().clone()
     }
 
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry> {
@@ -276,8 +334,12 @@ impl CodeExecutor for CodexExecutor {
         if event_type == "turn.completed" || event_type == "turn.started" {
             return self.handle_turn_event(event_type, &json);
         }
-        // thread.started 单独路径
+        // thread.started 单独路径：除展示条目外同步缓存 thread_id —— 它是 resume 凭据，
+        // EventPipeline 回退路径（`update_session_id_once`）依赖本缓存回写 DB。
         if event_type == "thread.started" {
+            if let Some(tid) = json.get("thread_id").and_then(Value::as_str) {
+                *self.session_id.lock() = Some(tid.to_string());
+            }
             return Some(helpers::entry("system", "Codex thread started"));
         }
         // 通用路径：先存 model，再尝试 usage，再按 event_type 分发
@@ -314,6 +376,24 @@ impl CodeExecutor for CodexExecutor {
 
     fn get_model(&self) -> Option<String> {
         self.base.model.lock().clone()
+    }
+}
+
+/// 从一行 JSON 中提取会话 ID：新格式 `thread.started` 取 `thread_id`，
+/// 旧格式 `session_configured`/`task_started` 取 `session_id`。
+/// 非 JSON 行或不含会话字段时返回 None（调用方回退缓存值）。
+fn extract_sid_from_line(line: &str) -> Option<String> {
+    if line.is_empty() {
+        return None;
+    }
+    let json: Value = serde_json::from_str(line).ok()?;
+    let (event_type, event) = extract_codex_event(&json)?;
+    match event_type {
+        "thread.started" => event.get("thread_id").and_then(Value::as_str).map(str::to_string),
+        "session_configured" | "task_started" => {
+            event.get("session_id").and_then(Value::as_str).map(str::to_string)
+        }
+        _ => None,
     }
 }
 
@@ -452,5 +532,108 @@ mod tests {
         assert_eq!(usage.input_tokens, 46503);
         assert_eq!(usage.output_tokens, 90);
         assert_eq!(usage.cache_read_input_tokens, Some(45824));
+    }
+
+    // ====================== 059 R2：resume（继续对话）能力测试 ======================
+
+    #[test]
+    fn test_supports_resume_true() {
+        // Codex CLI 原生支持 `codex exec resume <session_id>`，必须为 true 才能通过 handler 层校验
+        let executor = CodexExecutor::new("codex".to_string());
+        assert!(executor.supports_resume());
+    }
+
+    #[test]
+    fn test_command_args_with_session_resume_builds_exec_resume() {
+        // resume 场景：argv 必须是 `exec resume [flags] <sid> <message>`，
+        // 且保留 --json / bypass / skip-git-repo-check，与新会话行为一致
+        let executor = CodexExecutor::new("codex".to_string());
+        let args = executor.command_args_with_session("continue task", Some("019f13f6-4be4"), true);
+        assert_eq!(args[0], "exec");
+        assert_eq!(args[1], "resume");
+        assert!(args.iter().any(|a| a == "--json"));
+        assert!(args.iter().any(|a| a == "--dangerously-bypass-approvals-and-sandbox"));
+        assert!(args.iter().any(|a| a == "--skip-git-repo-check"));
+        // sid 与 message 是两个位置参数，sid 在前、message 殿后
+        assert_eq!(args[args.len() - 2], "019f13f6-4be4");
+        assert_eq!(args.last().unwrap(), "continue task");
+    }
+
+    #[test]
+    fn test_command_args_with_session_resume_injects_model() {
+        // 注入模型后 resume 也要拼 -m，与新会话的模型注入行为同源
+        let executor = CodexExecutor::new("codex".to_string());
+        executor.set_exec_model(Some("gpt-5-codex".to_string()));
+        let args = executor.command_args_with_session("go on", Some("sid_m"), true);
+        let model_value = args.windows(2).find(|w| w[0] == "-m").map(|w| w[1].clone());
+        assert_eq!(model_value.as_deref(), Some("gpt-5-codex"));
+    }
+
+    #[test]
+    fn test_command_args_with_session_new_execution_unchanged() {
+        // 非 resume：与 command_args 完全一致，不引入 resume 子命令
+        let executor = CodexExecutor::new("codex".to_string());
+        let args = executor.command_args_with_session("hello", Some("sid_x"), false);
+        assert_eq!(args, executor.command_args("hello"));
+        assert!(!args.iter().any(|a| a == "resume"));
+    }
+
+    #[test]
+    fn test_command_args_with_session_resume_without_sid_degrades() {
+        // 防御：is_resume=true 但 sid 为 None 时静默回退新会话
+        // （handler 层已拦截 None 返回 400，正常不会走到这里）
+        let executor = CodexExecutor::new("codex".to_string());
+        let args = executor.command_args_with_session("hello", None, true);
+        assert_eq!(args, executor.command_args("hello"));
+    }
+
+    #[test]
+    fn test_extract_session_id_from_thread_started() {
+        // 真实输出格式：thread.started 携 thread_id，应返回并写入缓存
+        let executor = CodexExecutor::new("codex".to_string());
+        let line = r#"{"type":"thread.started","thread_id":"019f13f6-4be4-74f1-8b77-74fe3878091c"}"#;
+        assert_eq!(
+            executor.extract_session_id(line),
+            Some("019f13f6-4be4-74f1-8b77-74fe3878091c".to_string())
+        );
+        assert_eq!(
+            executor.get_session_id(),
+            Some("019f13f6-4be4-74f1-8b77-74fe3878091c".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_session_id_from_legacy_session_configured() {
+        // 旧格式兼容：早期 codex 用 session_configured + session_id
+        let executor = CodexExecutor::new("codex".to_string());
+        let line = r#"{"type":"session_configured","session_id":"legacy_sid_9","model":"o3"}"#;
+        assert_eq!(executor.extract_session_id(line), Some("legacy_sid_9".to_string()));
+    }
+
+    #[test]
+    fn test_extract_session_id_fallback_to_cached() {
+        // 非会话事件行（如 agent_message）：回退到 parse_output_line 已缓存的值
+        let executor = CodexExecutor::new("codex".to_string());
+        let thread = r#"{"type":"thread.started","thread_id":"tid_cached"}"#;
+        let _ = executor.parse_output_line(thread);
+        let msg = r#"{"type":"item.completed","item":{"id":"i1","type":"agent_message","text":"ok"}}"#;
+        assert_eq!(executor.extract_session_id(msg), Some("tid_cached".to_string()));
+    }
+
+    #[test]
+    fn test_extract_session_id_empty_before_thread_started() {
+        // thread.started 未到达前：空行返回 None，不应误报不存在的 sid
+        let executor = CodexExecutor::new("codex".to_string());
+        assert_eq!(executor.extract_session_id(""), None);
+    }
+
+    #[test]
+    fn test_parse_output_line_thread_started_caches_session_id() {
+        // parse_output_line 的 thread.started 分支：展示条目照常，副作用缓存 thread_id
+        let executor = CodexExecutor::new("codex".to_string());
+        let line = r#"{"type":"thread.started","thread_id":"tid_parse"}"#;
+        let entry = executor.parse_output_line(line).unwrap();
+        assert_eq!(entry.log_type, "system");
+        assert_eq!(executor.get_session_id(), Some("tid_parse".to_string()));
     }
 }

--- a/backend/src/adapters/codex.rs
+++ b/backend/src/adapters/codex.rs
@@ -305,7 +305,7 @@ impl CodeExecutor for CodexExecutor {
 
     /// 从 stdout 行提取 session_id：命中 thread.started.thread_id（新格式）或
     /// session_configured.session_id（旧格式）则更新缓存并返回，否则回退已缓存值。
-    /// EventPipeline 正常路径用不到本方法，它是 pipeline 无事件产出时的兑底。
+    /// EventPipeline 正常路径用不到本方法，它是 pipeline 无事件产出时的兜底。
     fn extract_session_id(&self, line: &str) -> Option<String> {
         if let Some(sid) = extract_sid_from_line(line) {
             *self.session_id.lock() = Some(sid.clone());

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -159,7 +159,8 @@ pub static EXECUTORS: &[ExecutorDef] = &[
 /// 支持继续对话的执行器集合（与前端 RESUMABLE_EXECUTORS 保持一致）
 /// Issue 058：codebuddy 补齐 resume 三要素（supports_resume / command_args_with_session /
 /// session_id 缓存）后加入集合，与前端 executors.tsx 的 resumable: true 同步。
-pub const RESUMABLE_EXECUTORS: &[&str] = &["claudecode", "codebuddy", "kimi", "opencode", "mobilecoder", "hermes", "codewhale", "pi", "mimo", "zhanlu", "kilo"];
+/// Issue 059：codex 修复 thread_id 入库并补齐 resume 三要素后加入集合。
+pub const RESUMABLE_EXECUTORS: &[&str] = &["claudecode", "codebuddy", "codex", "kimi", "opencode", "mobilecoder", "hermes", "codewhale", "pi", "mimo", "zhanlu", "kilo"];
 
 /// 默认执行器
 pub const DEFAULT_EXECUTOR: &str = "claudecode";
@@ -617,6 +618,22 @@ mod tests {
         // 否则 handlers/execution.rs 的 resume 校验会 400 拒绝
         let executor = ExecutorRegistry::create_executor("codebuddy", "codebuddy").unwrap();
         assert!(executor.supports_resume(), "Codebuddy executor should support resume");
+    }
+
+    #[test]
+    fn test_resumable_executors_contains_codex() {
+        // Issue 059：codex 支持继续对话后必须登记进 RESUMABLE_EXECUTORS，
+        // 与前端 executors.tsx 的 resumable: true 保持同步
+        assert!(RESUMABLE_EXECUTORS.contains(&"codex"),
+            "codex should be in RESUMABLE_EXECUTORS; current list: {:?}", RESUMABLE_EXECUTORS);
+    }
+
+    #[test]
+    fn test_create_executor_codex_supports_resume() {
+        // 注册表工厂产出的 codex 实例必须声明 supports_resume，
+        // 否则 handlers/execution.rs 的 resume 校验会 400 拒绝
+        let executor = ExecutorRegistry::create_executor("codex", "codex").unwrap();
+        assert!(executor.supports_resume(), "Codex executor should support resume");
     }
 
     #[test]

--- a/backend/src/execution_events/impls/codex.rs
+++ b/backend/src/execution_events/impls/codex.rs
@@ -95,6 +95,20 @@ impl CodexExtractor {
                 }
             }
 
+            // Thread 事件：thread.started 是当前版本 Codex 输出会话 ID 的唯一位置
+            // （docs/samples/codex/output.txt 实证），thread_id 即 `codex exec resume`
+            // 的会话凭据。is_none() 判重保证只记首次，与旧格式 session_configured 路径先到先赢。
+            "thread.started" => {
+                if let Some(tid) = json.get("thread_id").and_then(|v| v.as_str()) {
+                    if self.metadata.session_id.is_none() {
+                        self.metadata.session_id = Some(tid.to_string());
+                        events.push(ExecutionEvent::SessionStart {
+                            session_id: tid.to_string(),
+                        });
+                    }
+                }
+            }
+
             // Turn 事件
             "turn.completed" => {
                 // 提取 usage
@@ -353,5 +367,47 @@ mod tests {
     fn test_empty_line() {
         let mut extractor = CodexExtractor::new();
         assert!(extractor.extract("").is_empty());
+    }
+
+    // ====================== 059 R1：thread_id 入库测试 ======================
+
+    #[test]
+    fn test_thread_started_extracts_session_id() {
+        // 真实输出格式（docs/samples/codex/output.txt）：thread.started 携 thread_id，
+        // 必须产出 SessionStart 并写入 metadata，否则 execution_records.session_id 恒为 NULL
+        let mut extractor = CodexExtractor::new();
+        let json = r#"{"type":"thread.started","thread_id":"019f13f6-4be4-74f1-8b77-74fe3878091c"}"#;
+        let events = extractor.extract(json);
+        assert!(events.iter().any(|e| matches!(e, ExecutionEvent::SessionStart { session_id } if session_id == "019f13f6-4be4-74f1-8b77-74fe3878091c")));
+        assert_eq!(extractor.metadata().session_id.as_deref(), Some("019f13f6-4be4-74f1-8b77-74fe3878091c"));
+    }
+
+    #[test]
+    fn test_thread_started_dedup_repeated_events() {
+        // resume 后 CLI 会重吐 thread.started：判重保证只记一次，避免刷屏与重复回写
+        let mut extractor = CodexExtractor::new();
+        let json = r#"{"type":"thread.started","thread_id":"tid_1"}"#;
+        let first = extractor.extract(json);
+        let second = extractor.extract(json);
+        assert_eq!(first.iter().filter(|e| matches!(e, ExecutionEvent::SessionStart { .. })).count(), 1);
+        assert!(second.iter().all(|e| !matches!(e, ExecutionEvent::SessionStart { .. })));
+    }
+
+    #[test]
+    fn test_legacy_session_configured_still_extracts() {
+        // 旧格式回归保护：早期 codex 用 session_configured + session_id，不能因新增分支失效
+        let mut extractor = CodexExtractor::new();
+        let json = r#"{"type":"session_configured","session_id":"legacy_sid_1","model":"o3"}"#;
+        let events = extractor.extract(json);
+        assert!(events.iter().any(|e| matches!(e, ExecutionEvent::SessionStart { session_id } if session_id == "legacy_sid_1")));
+    }
+
+    #[test]
+    fn test_thread_started_without_thread_id_no_session() {
+        // 缺 thread_id 字段时不应误提取，metadata 保持 None
+        let mut extractor = CodexExtractor::new();
+        let events = extractor.extract(r#"{"type":"thread.started"}"#);
+        assert!(events.iter().all(|e| !matches!(e, ExecutionEvent::SessionStart { .. })));
+        assert!(extractor.metadata().session_id.is_none());
     }
 }

--- a/docs/design/059-Codex会话入库与继续对话-设计.md
+++ b/docs/design/059-Codex会话入库与继续对话-设计.md
@@ -1,0 +1,85 @@
+# 059-Codex 会话入库与继续对话-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| pi (AI) | 2026-08-04 | 初始版本 |
+
+## 1. 总体思路
+
+沿用 058（CodeBuddy）验证过的模式，但 Codex 多一步「修入库」：extractor 补 `thread.started`/`thread_id` 提取后，适配器按统一三要素（session_id 缓存 + `supports_resume` + `command_args_with_session`）对齐，最后前后端集合登记。
+
+## 2. 现状与缺口
+
+| 环节 | 现状 | 缺口 |
+|------|------|------|
+| extractor 入库 | 只认 `session_configured`/`task_started` 的 `session_id`；真实输出 `thread.started`/`thread_id` 落入 `_` → Info | **不入库** |
+| `supports_resume()` | 未覆盖 → false，handler 400 | 需覆盖 |
+| `command_args_with_session()` | 桩实现，忽略 session | 需拼 `exec resume` |
+| `extract_session_id()`/`get_session_id()` | 未覆盖 | 回退路径回写需要 |
+| 后端 `RESUMABLE_EXECUTORS` / 前端 `resumable` | 均无 codex | 需登记 |
+
+真实输出证据（`docs/samples/codex/output.txt` 第 9 行）：
+`{"type":"thread.started","thread_id":"019f13f6-4be4-74f1-8b77-74fe3878091c"}`
+
+## 3. 详细改动
+
+### 3.1 `execution_events/impls/codex.rs`（入库）
+
+新增 match 分支（置于 `turn.started` 附近）：
+
+```rust
+"thread.started" => {
+    // thread_id 即 codex exec resume 的会话凭据
+    if let Some(tid) = json.get("thread_id").and_then(|v| v.as_str()) {
+        if self.metadata.session_id.is_none() {
+            self.metadata.session_id = Some(tid.to_string());
+            events.push(ExecutionEvent::SessionStart { session_id: tid.to_string() });
+        }
+    }
+}
+```
+
+旧 `session_configured`/`task_started` 路径保留：早期 codex 版本用该格式，两条路径都受 `session_id.is_none()` 判重保护，先到先赢。
+
+### 3.2 `adapters/codex.rs`（可继续对话）
+
+- 结构体加 `session_id: Arc<Mutex<Option<String>>>`（Arc 共享语义同 BaseExecutor，Clone 自动派生）。
+- `parse_output_line` 的 `thread.started` 分支：除产出既有 "Codex thread started" 条目外，缓存 `thread_id`。
+- `supports_resume()` → `true`。
+- `command_args_with_session(message, session_id, is_resume)`：
+  - `is_resume && Some(sid)`：`exec resume [-m <model>] --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check <sid> <message>`。
+  - 其余情况：回退 `command_args(message)`（新会话，与现状一致）。
+  - argv 顺序依据：`codex exec resume [OPTIONS] [SESSION_ID] [PROMPT]`，OPTIONS 与 exec 共享（clap 解析与位置无关），sid 在前、prompt 殿后。
+- `extract_session_id(line)`：命中 `thread.started`.`thread_id` 或旧格式 `session_id` 则更新缓存并返回；否则返回缓存。
+- `get_session_id()` → 缓存克隆。
+
+### 3.3 登记
+
+- `mod.rs` `RESUMABLE_EXECUTORS` 插 `"codex"`（紧跟 codebuddy 后，保持同类聚集）。
+- `executors.tsx` codex 条目追加 `resumable: true`。
+
+## 4. 测试设计
+
+extractor 新增：
+
+| 用例 | 断言 |
+|------|------|
+| `thread.started` 带 thread_id | 产出 SessionStart，metadata.session_id = tid |
+| 重复 `thread.started` | 只产出一次 SessionStart（判重） |
+| 旧格式 `session_configured` | 仍产出 SessionStart（回归保护） |
+
+adapter 新增：
+
+| 用例 | 断言 |
+|------|------|
+| resume + sid | argv = `exec resume ... <sid> <msg>`，含 `--json`/bypass/skip-git 与 `-m`（注入模型时） |
+| 非 resume | argv 不含 `resume`，与 `command_args` 一致 |
+| resume + None sid | 回退新会话 argv（防御） |
+| `supports_resume` | true |
+| `extract_session_id` thread.started / 旧格式 / 空行 | 返回并缓存 / 返回并缓存 / 回退缓存或 None |
+
+mod.rs 新增：RESUMABLE_EXECUTORS 含 codex、`create_executor("codex")` 的 supports_resume 断言。
+
+## 5. 验证限制说明
+
+本机未安装 codex 二进制，CLI 级实测（真实 resume 会话关联）无法执行；`exec resume` 参数语义依据 Codex CLI 公开文档与 samples 格式确认。端到端验证以「resume API → 记录 argv → argv 符合 `exec resume [flags] <sid> <msg>`」为准，CLI 行为待有 codex 环境时复核。

--- a/docs/requirements/059-Codex会话入库与继续对话-实现总结.md
+++ b/docs/requirements/059-Codex会话入库与继续对话-实现总结.md
@@ -1,0 +1,40 @@
+# 059-Codex 会话入库与继续对话-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| pi (AI) | 2026-08-05 | 初始版本 |
+
+## 1. 需求对应
+
+| 需求条目 | 实现 | 状态 |
+|---------|------|------|
+| R1 extractor 补齐 thread_id 提取 | `backend/src/execution_events/impls/codex.rs` 新增 `thread.started` 分支 | ✅ |
+| R2 适配器 resume 三要素 | `backend/src/adapters/codex.rs` session_id 缓存 + `supports_resume` + `command_args_with_session` + `extract_session_id`/`get_session_id` | ✅ |
+| R3 前后端集合登记 | `backend/src/adapters/mod.rs` + `frontend/src/utils/executors.tsx` | ✅ |
+
+## 2. 关键实现点
+
+1. **修入库**：extractor 新增 `thread.started` 分支提取 `thread_id` → `metadata.session_id` + `SessionStart` 事件（`is_none()` 判重只记首次）。真实输出证据 `docs/samples/codex/output.txt` 第 9 行。旧格式 `session_configured`+`session_id` 路径保留，两条路径先到先赢。
+2. **resume argv**：`codex exec resume [-m <model>] --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check <session_id> <message>`——`exec resume` 独立子命令，flags 与 exec 共享，sid 在前 prompt 殿后；`-m` 与 `command_args` 同源（`set_exec_model` 注入）。非 resume 或 sid 为 None 回退既有 `command_args`。
+3. **session_id 缓存**：适配器 `parse_output_line` 的 `thread.started` 分支同步缓存 thread_id（展示条目行为不变）；`extract_session_id` 复用自由函数 `extract_sid_from_line` 兼容新旧两种格式，未命中回退缓存。
+4. **登记**：后端 `RESUMABLE_EXECUTORS` 插 `"codex"`；前端 codex 条目 `resumable: true`（Set 自动派生）。
+
+## 3. 测试与验证
+
+### 单元/集成测试
+
+- `cargo clippy --all-targets -- -D warnings`：零告警 ✅
+- `cargo test`：1612 通过（较 main +16：extractor 4、adapter 10、mod.rs 2）；唯一失败 `git_sync::tests::test_sync_repo_restores_deleted_file` 为存量环境问题（系统 git 不支持 `git init -b`，main 上同样失败）✅
+- `npx tsc --noEmit`：零错误 ✅
+
+### 功能验证（dev 环境）
+
+1. **前端入口**：`frontend/tests/check_codex_resume.spec.ts` 通过——预置 codex 记录（success + thread_id 形式 session_id）帖子页出现回复输入框。
+2. **resume API**：`POST /api/v1/workspaces/1/executions/44/resume` → 200（改动前必 400），新记录生成。
+3. **argv 正确性**：新记录 command 实测为 `codex exec resume --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check 019f13f6-4be4-74f1-8b77-74fe3878091c <message>`，与设计完全一致；session_id 正确继承未被覆盖。
+
+## 4. 已知限制与说明
+
+- **本机无 codex 二进制**，CLI 级真实会话恢复未能实测；`exec resume` 参数语义依据 Codex CLI 公开文档与仓库 samples 确认，待有 codex 环境时复核（设计文档 §5 已记录）。
+- **预存现象（非本次引入）**：执行器二进制缺失时执行记录停留在 running（无 pid、无日志）。用 kilo（已支持 resume、本机同样缺二进制）对照复现，行为完全一致，属 spawn 失败处理的 executor 无关存量行为，建议另行立项排查。
+- **AtomCode 维持不可恢复**：atomcode 4.25.7 headless 仅支持 `-c/--continue`（继续最近一次会话）与 TUI 内 `/resume`，无 resume-by-id 能力，ntd 侧无法正确实现 per-record 继续对话。

--- a/docs/requirements/059-Codex会话入库与继续对话-需求.md
+++ b/docs/requirements/059-Codex会话入库与继续对话-需求.md
@@ -1,0 +1,51 @@
+# 059-Codex 会话入库与继续对话-需求
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| pi (AI) | 2026-08-04 | 初始版本 |
+
+## 1. 背景与问题
+
+继 058（CodeBuddy 继续对话）后排查全部 13 个执行器的 resume 链路，发现 **Codex 存在「双重缺失」**：
+
+1. **session_id 实际不入库**：`CodexExtractor` 只从 `session_configured` / `task_started` 事件的 `session_id` 字段提取会话 ID，但当前版本 Codex CLI 的真实输出（见 `docs/samples/codex/output.txt`）是 `{"type":"thread.started","thread_id":"019f13f6-..."}` —— extractor 没有 `thread.started` 分支，该事件落入 `_` 兜底变成 Info 日志，`session_id` 永远提取不到，`execution_records.session_id` 恒为 NULL。
+2. **不能继续对话**：`CodexExecutor` 未覆盖 `supports_resume()`（默认 false），`command_args_with_session()` 是忽略 session 的桩实现；前端 codex 条目也无 `resumable` 标志。
+
+Codex CLI 原生支持恢复会话：`codex exec resume [SESSION_ID] [PROMPT]`（`--json` 等 exec 选项同样适用），`thread_id` 即 resume 凭据。
+
+**同时确认 AtomCode 不在本次范围**：atomcode 4.25.7 headless 模式仅支持 `-c/--continue`（继续最近一次会话）与 TUI 内 `/resume`，无「按 session id 恢复」的 CLI 能力，ntd 侧无法正确实现 per-record resume，维持不可恢复。
+
+## 2. 需求条目
+
+### R1 extractor 补齐 thread_id 提取（入库）
+
+`backend/src/execution_events/impls/codex.rs`：
+
+- 新增 `thread.started` 事件分支：提取 `thread_id` 写入 `metadata.session_id` 并产出 `SessionStart` 事件（仅首次），使 `execution_records.session_id` 能回写真实会话 ID。
+- 保留既有 `session_configured` / `task_started` + `session_id` 旧格式路径，向后兼容。
+
+### R2 适配器实现 resume 三要素
+
+`backend/src/adapters/codex.rs` 的 `CodexExecutor`：
+
+- 新增 `session_id: Arc<Mutex<Option<String>>>` 状态字段；解析 `thread.started`（新格式）与 `session_configured`（旧格式）时缓存会话 ID。
+- 覆盖 `supports_resume()` 返回 `true`。
+- 覆盖 `command_args_with_session()`：resume 时构造 `codex exec resume [flags] <session_id> <message>`（保留 `-m` 模型注入、`--json`、`--dangerously-bypass-approvals-and-sandbox`、`--skip-git-repo-check`）；非 resume 走既有 `command_args`。
+- 覆盖 `extract_session_id()` / `get_session_id()`，覆盖 EventPipeline 回退路径的 DB 回写。
+
+### R3 前后端集合登记
+
+- `backend/src/adapters/mod.rs` `RESUMABLE_EXECUTORS` 加入 `"codex"`。
+- `frontend/src/utils/executors.tsx` codex 条目加 `resumable: true`。
+
+## 3. 边界与非目标
+
+- AtomCode 不做（CLI 无 resume-by-id 能力，见背景）。
+- 不改动 codex 其余事件解析逻辑与多 agent（collab_tool_call）提取。
+
+## 4. 验收标准
+
+1. codex 执行记录的 `session_id` 列为真实 thread_id（入库）。
+2. 非 running 且有 session_id 的 codex 记录前端出现「继续对话」回复框。
+3. resume 请求产生的新记录 argv 为 `codex exec resume ... <session_id> <message>`。
+4. `cargo clippy --all-targets -- -D warnings` 零告警、`cargo test` 通过、`npx tsc --noEmit` 零错误。

--- a/frontend/src/utils/executors.tsx
+++ b/frontend/src/utils/executors.tsx
@@ -60,7 +60,9 @@ export const EXECUTORS: ExecutorOption[] = [
   { value: 'atomcode',   label: 'AtomCode',  color: '#e84393', icon: <FaSquare color="#e84393" size={14} /> },
   { value: 'hermes',     label: 'Hermes',    color: '#0984e3', icon: <FaSquare color="#0984e3" size={14} />, resumable: true },
   { value: 'kimi',       label: 'Kimi',      color: '#d63031', icon: <FaSquare color="#d63031" size={14} />, resumable: true },
-  { value: 'codex',      label: 'Codex',     color: '#488597', icon: <FaSquare color="#488597" size={14} /> },
+  // Issue 059：Codex CLI 支持 `codex exec resume <session_id>`，后端已修复 thread_id
+  // 入库并补齐 resume 三要素，此处开放前端「继续对话」入口（RESUMABLE_EXECUTORS 自动派生）。
+  { value: 'codex',      label: 'Codex',     color: '#488597', icon: <FaSquare color="#488597" size={14} />, resumable: true },
   { value: 'codewhale',  label: 'CodeWhale', color: '#00cec9', icon: <FaSquare color="#00cec9" size={14} />, resumable: true },
   { value: 'pi',        label: 'Pi',        color: '#8e44ad', icon: <FaSquare color="#8e44ad" size={14} />, resumable: true },
   { value: 'mimo',      label: 'MiMo',      color: '#ff6b6b', icon: <FaSquare color="#ff6b6b" size={14} />, resumable: true },

--- a/frontend/tests/check_codex_resume.spec.ts
+++ b/frontend/tests/check_codex_resume.spec.ts
@@ -1,0 +1,25 @@
+// Issue 059：验证 Codex 执行记录出现「继续对话」回复输入框。
+//
+// 验证逻辑：
+// - todo 8 下预置 codex 执行记录（success + 带 thread_id 形式的 session_id）：
+//   应渲染 ReplyRow（回复输入框）。
+// - ReplyRow 的判显条件是 supportsResume(record)：status 非 running +
+//   有 session_id + executor 在 RESUMABLE_EXECUTORS 集合内（codex 已于 059 加入）。
+// - 复用 058 的 atomcode 记录作为对照组（如仍存在），不出现回复框。
+//
+// 运行前提：make dev 已启动（http://localhost:18088），且 dev DB 已插入上述记录。
+import { test, expect } from '@playwright/test';
+
+test('codex 执行记录显示继续对话输入框', async ({ page }) => {
+  // 帖子页按全局选中的工作空间拉取执行记录，直接访问 URL 时默认为 #0
+  // 会报「todo 不属于工作空间」。用 addInitScript 在每次页面加载前写入
+  // localStorage（SPA 只在启动时读一次 selected_workspace，goto 后 evaluate 太晚）。
+  await page.addInitScript(() => localStorage.setItem('selected_workspace', '1'));
+
+  // codex 记录（id=44）的帖子页应出现回复输入框
+  await page.goto('http://localhost:18088/#/todos/8/posts/44');
+  await page.waitForTimeout(3000);
+  const codexReply = page.locator('input[placeholder="输入回复内容..."]');
+  expect(await codexReply.count()).toBe(1);
+  await page.screenshot({ path: 'test-results/codex-resume.png', fullPage: true });
+});

--- a/frontend/tests/check_codex_resume.spec.ts
+++ b/frontend/tests/check_codex_resume.spec.ts
@@ -5,7 +5,7 @@
 //   应渲染 ReplyRow（回复输入框）。
 // - ReplyRow 的判显条件是 supportsResume(record)：status 非 running +
 //   有 session_id + executor 在 RESUMABLE_EXECUTORS 集合内（codex 已于 059 加入）。
-// - 复用 058 的 atomcode 记录作为对照组（如仍存在），不出现回复框。
+//   反向对照（atomcode 不显示回复框）由 058 的 check_codebuddy_resume.spec.ts 覆盖。
 //
 // 运行前提：make dev 已启动（http://localhost:18088），且 dev DB 已插入上述记录。
 import { test, expect } from '@playwright/test';


### PR DESCRIPTION
## 实现了什么

Codex 执行器对齐「会话入库 + 继续对话」（继 #984 CodeBuddy 后的全量排查收尾）：

1. **修入库**：Codex 真实输出以 `thread.started` 事件携带 `thread_id`（证据：`docs/samples/codex/output.txt` 第 9 行），但 `CodexExtractor` 只认旧格式 `session_configured.session_id`——该事件落入 `_` 兜底，`execution_records.session_id` **恒为 NULL**。本 PR 补 `thread.started` 分支提取 `thread_id`（判重只记首次，旧格式路径保留兼容）。
2. **可继续对话**：`CodexExecutor` 补齐 resume 三要素（session_id 缓存、`supports_resume()=true`、`command_args_with_session()` 构造 `codex exec resume [flags] <sid> <message>`），前后端集合登记。

**排查结论**（13 个执行器）：其余 11 个已支持 resume；**atomcode 维持不可恢复**——atomcode 4.25.7 headless 仅有 `-c/--continue`（继续最近一次会话）与 TUI 内 `/resume`，无 resume-by-id 能力，per-record 继续对话无法正确实现。

## 与需求的对应关系

文档：`docs/requirements/059-Codex会话入库与继续对话-需求.md`、`docs/design/059-...-设计.md`、实现总结同目录。

| 需求条目 | 实现 |
|---------|------|
| R1 extractor 补齐 thread_id 提取 | `execution_events/impls/codex.rs` 新增 `thread.started` 分支 |
| R2 适配器 resume 三要素 | `adapters/codex.rs` session_id 缓存 + supports_resume + command_args_with_session + extract_session_id/get_session_id |
| R3 前后端登记 | `adapters/mod.rs` RESUMABLE_EXECUTORS + `executors.tsx` resumable: true |

## 关键实现点

- resume argv：`codex exec resume [-m <model>] --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check <session_id> <message>`——`exec resume` 独立子命令、flags 与 exec 共享，sid 在前 prompt 殿后；`-m` 与 `command_args` 同源（set_exec_model 注入）。
- 非 resume 或 sid 为 None 时回退既有 `command_args`（handler 层已先行拦截 None）。
- `extract_sid_from_line` 自由函数兼容新（thread_id）旧（session_id）两种格式，extractor 与 adapter 双路径覆盖，EventPipeline 回退路径也能回写 DB。

## 测试与验证结果

- ✅ `cargo clippy --all-targets -- -D warnings` 零告警；`cargo test` 1612 通过（+16 新用例：extractor 4、adapter 10、mod.rs 2）；`npx tsc --noEmit` 零错误。
- ⚠️ 唯一失败 `git_sync::tests::test_sync_repo_restores_deleted_file` 为存量环境问题（系统 git 不支持 `git init -b`，main 上同样失败），与本次无关。
- ✅ Playwright（`frontend/tests/check_codex_resume.spec.ts`）：codex 记录（success + session_id）帖子页出现回复输入框。
- ✅ resume API 端到端：`POST /executions/{id}/resume` → 200（改动前必 400）；新记录实测 command 为 `codex exec resume --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check <thread_id> <message>`，与设计完全一致；session_id 正确继承未被覆盖。

## 已知限制

- 本机无 codex 二进制，CLI 真实会话恢复未实测；`exec resume` 参数语义依据公开文档与仓库 samples 确认，待有 codex 环境时复核。
- 测试中观察到**存量问题（非本次引入）**：执行器二进制缺失时执行记录停留在 running（无 pid/日志），已用 kilo 对照复现确认 executor 无关，建议另行立项排查。
