### PR TITLE
fix(060): 讨论区执行明细完成后 404——execution_records 加 workspace_id 直接归属

### DIFF
--- a/backend/src/db/entity/execution_records.rs
+++ b/backend/src/db/entity/execution_records.rs
@@ -62,6 +62,8 @@ pub struct Model {
     pub loop_step_execution_id: Option<i64>,
     /// 当本次执行是环节执行时，指向 steps 表的 id。
     pub step_id: Option<i64>,
+    /// record 直接归属的 workspace（v89 新增）。归属校验用它，不再经 todo 间接关联。
+    pub workspace_id: Option<i64>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -74,6 +74,9 @@ pub struct NewExecutionRecord<'a> {
     pub loop_step_execution_id: Option<i64>,
     /// 环节 id（指向 steps 表），环节独立执行时使用
     pub step_id: Option<i64>,
+    /// record 直接归属的 workspace（v89）：写入 execution_records.workspace_id，
+    /// 归属校验改用它，不再经 todo 间接关联。
+    pub workspace_id: Option<i64>,
 }
 
 pub struct UpdateExecutionRecordRequest<'a> {
@@ -193,6 +196,7 @@ impl From<execution_records::Model> for ExecutionRecord {
             worktree_path: m.worktree_path,
             loop_step_execution_id: m.loop_step_execution_id,
             step_id: m.step_id,
+            workspace_id: m.workspace_id,
         }
     }
 }
@@ -455,6 +459,7 @@ impl Database {
             source_todo_title: ActiveValue::Set(record.source_todo_title.map(|s| s.to_string())),
             loop_step_execution_id: ActiveValue::Set(record.loop_step_execution_id),
             step_id: ActiveValue::Set(record.step_id),
+            workspace_id: ActiveValue::Set(record.workspace_id),
             ..Default::default()
         };
         let inserted = am.insert(&self.conn).await?;

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -196,6 +196,7 @@ impl From<execution_records::Model> for ExecutionRecord {
             worktree_path: m.worktree_path,
             loop_step_execution_id: m.loop_step_execution_id,
             step_id: m.step_id,
+            // 保留持久化归属：软删/迁移 todo 后，详情授权仍可用 record 自身 ws（v89 解耦）
             workspace_id: m.workspace_id,
         }
     }
@@ -459,6 +460,7 @@ impl Database {
             source_todo_title: ActiveValue::Set(record.source_todo_title.map(|s| s.to_string())),
             loop_step_execution_id: ActiveValue::Set(record.loop_step_execution_id),
             step_id: ActiveValue::Set(record.step_id),
+            // 写入 record 直接归属：把授权链路与 todo 生命周期解耦的前提（v89 核心）
             workspace_id: ActiveValue::Set(record.workspace_id),
             ..Default::default()
         };

--- a/backend/src/db/migration/consolidated_schema.rs
+++ b/backend/src/db/migration/consolidated_schema.rs
@@ -64,7 +64,7 @@ pub const CONSOLIDATED_SCHEMA: &[&str] = &[
             trigger_type TEXT DEFAULT 'manual',
             pid INTEGER,
             task_id TEXT,
-            session_id TEXT, todo_progress TEXT, execution_stats TEXT, resume_message TEXT, source_todo_id INTEGER, source_todo_title TEXT, rating INTEGER, source_execution_record_id INTEGER, last_review_status TEXT, last_reviewed_at TEXT, worktree_path TEXT, loop_step_execution_id BIGINT, step_id BIGINT, agent_runs TEXT,
+            session_id TEXT, todo_progress TEXT, execution_stats TEXT, resume_message TEXT, source_todo_id INTEGER, source_todo_title TEXT, rating INTEGER, source_execution_record_id INTEGER, last_review_status TEXT, last_reviewed_at TEXT, worktree_path TEXT, loop_step_execution_id BIGINT, step_id BIGINT, agent_runs TEXT, workspace_id INTEGER,
             FOREIGN KEY (todo_id) REFERENCES todos(id) ON DELETE CASCADE
         )"#,
     r#"CREATE TABLE executors (

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -49,6 +49,8 @@ mod v86;
 mod v87;
 /// v88：新建 task_posts 表（需求 060 任务讨论区）。
 mod v88;
+/// v89：execution_records 新增 workspace_id 列（BUG：讨论区执行明细完成后 404）。
+mod v89;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -169,6 +171,9 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         // V88 在 V87 之后：新建 task_posts 表，支撑需求 060「任务讨论区」
         // （论坛跟帖 + @专家/@执行器 触发执行后结论回帖）。
         Box::new(v88::V88TaskDiscussionPosts),
+        // V89 在 V88 之后：execution_records 新增 workspace_id 列——record 直接归属 workspace，
+        // 消除经 carrier todo 间接关联导致讨论区执行明细完成后 404 的 bug。
+        Box::new(v89::V89AddExecutionRecordsWorkspaceId),
     ]
 }
 

--- a/backend/src/db/migration/v89.rs
+++ b/backend/src/db/migration/v89.rs
@@ -1,0 +1,60 @@
+//! 迁移 v89：execution_records 新增 workspace_id 列。
+//!
+//! 背景（BUG：讨论区执行明细完成后 404）：execution record 的 workspace 归属原本经
+//! carrier todo 间接关联（`verify_execution_belongs_to_ws` → `record.todo_id` →
+//! `todo.workspace_id`）。060 讨论区在执行完成时软删 carrier todo，软删后 `get_todo`
+//! 过滤 `deleted_at IS NULL` 返回 None，导致按 recordId 查执行明细时归属校验 NotFound
+//! （执行中能打开、完成后 404）。
+//!
+//! 修复：给 execution_records 加 workspace_id 列，record 直接归属 workspace；归属校验
+//! 改用 record 自身字段，与 todo 是否被软删彻底解耦。
+//!
+//! 回填：历史 record 无 workspace_id，用关联 todo 的 workspace_id 补齐（todos 为软删，
+//! 行仍在，SELECT 能查到）。
+//!
+//! 幂等：`add_column_if_missing` 探测列存在性；回填 UPDATE 带 `WHERE workspace_id IS NULL`，
+//! 任意中间状态可重入。
+
+use crate::db::{Database, migration::Migration};
+use crate::db::migration::add_column_if_missing;
+use async_trait::async_trait;
+use tracing::info;
+
+/// v89：execution_records 新增 workspace_id，record 直接归属 workspace。
+pub struct V89AddExecutionRecordsWorkspaceId;
+
+#[async_trait]
+impl Migration for V89AddExecutionRecordsWorkspaceId {
+    fn version(&self) -> i64 {
+        89
+    }
+
+    fn name(&self) -> &'static str {
+        "add_execution_records_workspace_id"
+    }
+
+    /// 加列 + 回填历史数据。
+    ///
+    /// 回填子查询 `SELECT workspace_id FROM todos WHERE id = execution_records.todo_id`：
+    /// todos 软删行仍在能查到；todo 不存在或 todo.workspace_id 为 NULL 时返回 NULL，
+    /// 该 record 保持 NULL（归属校验 Forbidden，与未归属数据现有契约一致）。
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 加列：record 直接存 workspace_id，消除经 todo 的间接归属。
+        add_column_if_missing(
+            db,
+            "execution_records",
+            "workspace_id",
+            "ALTER TABLE execution_records ADD COLUMN workspace_id INTEGER",
+        )
+        .await?;
+        // 回填历史 record：从关联 todo 的 workspace_id 补齐。幂等（只填 IS NULL 的）。
+        db.exec(
+            "UPDATE execution_records \
+             SET workspace_id = (SELECT workspace_id FROM todos WHERE id = execution_records.todo_id) \
+             WHERE workspace_id IS NULL",
+        )
+        .await?;
+        info!("v89: execution_records.workspace_id 列已添加并回填历史数据");
+        Ok(())
+    }
+}

--- a/backend/src/db/migration/v89.rs
+++ b/backend/src/db/migration/v89.rs
@@ -30,7 +30,8 @@ impl Migration for V89AddExecutionRecordsWorkspaceId {
     }
 
     fn name(&self) -> &'static str {
-        "add_execution_records_workspace_id"
+        // 与 v67（同表加列先例 V67AddExecutionRecordsAgentRuns）一致：struct 名即迁移名
+        "V89AddExecutionRecordsWorkspaceId"
     }
 
     /// 加列 + 回填历史数据。

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -676,6 +676,7 @@ mod tests {
             source_todo_title: None,
             loop_step_execution_id: None,
             step_id: None,
+            workspace_id: None, // v89 新增字段：本 helper 不测归属，None 即可
         })
         .await
         .unwrap()
@@ -1698,6 +1699,7 @@ mod tests {
             source_todo_title: None,
             loop_step_execution_id: None,
             step_id: None,
+            workspace_id: None, // v89 新增字段：orphan 测试不关心归属
         }).await.unwrap();
 
         // Detach task_id from todo so the record becomes "orphan" (running but todo.task_id IS NULL)

--- a/backend/src/executor_service/auto_review.rs
+++ b/backend/src/executor_service/auto_review.rs
@@ -437,7 +437,7 @@ async fn execute_review_instance(
         feishu_receive_id: None,
             feishu_receive_id_type: None,
         workspace_path: None,
-        workspace_id: None,
+        workspace_id: original.workspace_id, // v89: 评审 record 归属原 todo 的 ws，不经间接关联
         // auto_review 创建的评审 todo 不继承原 todo 的 expert_name，
         // 传 None 跳过专家上下文注入，避免给评审 instance 错误加载原 todo 的专家
         expert_manager: None,

--- a/backend/src/executor_service/pre_spawn.rs
+++ b/backend/src/executor_service/pre_spawn.rs
@@ -504,6 +504,7 @@ async fn create_record_or_reject(
             source_todo_title: request.source_todo_title.as_deref(),
             loop_step_execution_id: request.loop_step_execution_id,
             step_id: request.step_id,
+            // 透传请求携带的 workspace：持久化层据此写入 record 直接归属，不重新依赖 todo（v89）
             workspace_id: request.workspace_id,
         })
         .await

--- a/backend/src/executor_service/pre_spawn.rs
+++ b/backend/src/executor_service/pre_spawn.rs
@@ -504,6 +504,7 @@ async fn create_record_or_reject(
             source_todo_title: request.source_todo_title.as_deref(),
             loop_step_execution_id: request.loop_step_execution_id,
             step_id: request.step_id,
+            workspace_id: request.workspace_id,
         })
         .await
     {

--- a/backend/src/handlers/execution.rs
+++ b/backend/src/handlers/execution.rs
@@ -912,6 +912,7 @@ mod resume_session_id_tests {
             todo_progress: None,
             agent_runs: None,
             execution_stats: None,
+            workspace_id: None, // v89 新增字段：测试 make_record 不关心归属
             resume_message: None,
             source_todo_id: None,
             source_todo_title: None,

--- a/backend/src/handlers/webhook.rs
+++ b/backend/src/handlers/webhook.rs
@@ -92,7 +92,7 @@ async fn trigger_todo_webhook_internal(
             feishu_receive_id: None,
             feishu_receive_id_type: None,
             workspace_path: todo.workspace_path.clone(),
-            workspace_id: None,
+            workspace_id: todo.workspace_id, // v89: 直接归属 ws，避免 carrier todo 软删后归属链断裂
             // webhook 触发路径：注入专家上下文，外部触发也需尊重 todo 的专家绑定
             expert_manager: Some(state.expert_manager.clone()),
         },

--- a/backend/src/handlers/workspace_guard.rs
+++ b/backend/src/handlers/workspace_guard.rs
@@ -305,7 +305,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_verify_execution_uses_record_workspace_id_after_todo_soft_deleted() {
+    async fn test_verify_execution_belongs_to_ws_ignores_carrier_todo_soft_delete() {
         // 复刻 060 讨论区 bug：record 直接归属 ws，其 carrier todo 在执行完成后
         // 被软删。旧实现经 todo_id 间接关联 → get_todo 过滤 deleted_at → NotFound(404)；
         // v89 改用 record.workspace_id → 即便 todo 已软删，仍按 ws 正确放行。

--- a/backend/src/handlers/workspace_guard.rs
+++ b/backend/src/handlers/workspace_guard.rs
@@ -96,21 +96,32 @@ pub async fn verify_todos_belong_to_ws(
 
 /// 校验 execution record 属于指定 workspace。
 ///
-/// `execution_records` 表没有 `workspace_id` 列，只能经其 `todo_id` 间接关联到
-/// workspace —— 因此先查 record 拿 `todo_id`，再复用 `verify_todo_belongs_to_ws`，
-/// 保证「record 属于 ws」与「record 的 todo 属于 ws」语义一致。
+/// v89 起 `execution_records` 自带 `workspace_id` 列（record 创建时由写入点回填），
+/// 直接比对 record 自身归属即可。此前 record 经 `todo_id` 间接关联 ws，但讨论区
+/// carrier todo 在执行完成后会被软删（`get_todo` 过滤 `deleted_at`），导致间接归属
+/// 链断裂、record 误判 NotFound 而 404。改用 record 自身字段后，归属判断与 todo
+/// 是否存在彻底解耦。
 pub async fn verify_execution_belongs_to_ws(
     db: &Database,
     record_id: i64,
     ws_id: i64,
 ) -> Result<(), AppError> {
+    // get_execution_record 返回 Option；None → record 不存在，统一映射 NotFound，
+    // 不向调用方泄露存在性细节。
     let record = db
         .get_execution_record(record_id)
         .await?
         .ok_or(AppError::NotFound)?;
-    // record.todo_id 是 i64（非 Option），直接交给 todo 校验；
-    // record 不存在已在上一步映射为 NotFound。
-    verify_todo_belongs_to_ws(db, record.todo_id, ws_id).await
+    // 直接比对 record 自身 workspace_id（v89 新列），不再经 todo 间接关联：
+    // 否则 carrier todo 被软删后会误判 NotFound（060 讨论区「执行明细完成后 404」根因）。
+    if workspace_id_matches(record.workspace_id, ws_id) {
+        Ok(())
+    } else {
+        Err(AppError::Forbidden(format!(
+            "execution #{} 不属于工作空间 #{}",
+            record_id, ws_id
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -188,10 +199,12 @@ mod tests {
             .expect("create todo must succeed")
     }
 
-    /// 建一条 execution record，挂在指定 todo 下。
-    async fn create_record_for_todo(db: &Database, todo_id: i64) -> i64 {
+    /// 建一条 execution record，直接归属 ws_id（v89：record 自带 workspace_id，
+    /// 与生产写入点行为一致，不再经 todo 间接关联）。
+    async fn create_record_for_todo(db: &Database, todo_id: i64, ws_id: i64) -> i64 {
         db.create_execution_record(NewExecutionRecord {
             todo_id: Some(todo_id),
+            workspace_id: Some(ws_id),
             command: "cmd",
             executor: "claudecode",
             trigger_type: "manual",
@@ -272,8 +285,8 @@ mod tests {
         let db = Database::new(":memory:").await.expect("db must open");
         let ws = create_workspace(&db, "/tmp/ws-a").await;
         let todo_id = create_todo_in_ws(&db, ws).await;
-        let record_id = create_record_for_todo(&db, todo_id).await;
-        // record 的 todo 属于该 ws → record 也属于该 ws，放行
+        let record_id = create_record_for_todo(&db, todo_id, ws).await;
+        // record 直接归属该 ws（v89）→ 放行，与 todo 是否存在无关
         assert!(verify_execution_belongs_to_ws(&db, record_id, ws).await.is_ok());
     }
 
@@ -283,10 +296,33 @@ mod tests {
         let ws_a = create_workspace(&db, "/tmp/ws-a").await;
         let ws_b = create_workspace(&db, "/tmp/ws-b").await;
         let todo_id = create_todo_in_ws(&db, ws_a).await;
-        let record_id = create_record_for_todo(&db, todo_id).await;
-        // 用 ws_b 访问 ws_a 的 record → 间接跨 ws（record→todo→ws），返回 Forbidden
+        let record_id = create_record_for_todo(&db, todo_id, ws_a).await;
+        // 用 ws_b 访问 ws_a 的 record → record 归属 ws_a，跨 ws，返回 Forbidden
         assert!(matches!(
             verify_execution_belongs_to_ws(&db, record_id, ws_b).await,
+            Err(AppError::Forbidden(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_verify_execution_uses_record_workspace_id_after_todo_soft_deleted() {
+        // 复刻 060 讨论区 bug：record 直接归属 ws，其 carrier todo 在执行完成后
+        // 被软删。旧实现经 todo_id 间接关联 → get_todo 过滤 deleted_at → NotFound(404)；
+        // v89 改用 record.workspace_id → 即便 todo 已软删，仍按 ws 正确放行。
+        let db = Database::new(":memory:").await.expect("db must open");
+        let ws = create_workspace(&db, "/tmp/ws-bug").await;
+        let todo_id = create_todo_in_ws(&db, ws).await;
+        // record 直接归属 ws（与生产写入点一致）
+        let record_id = create_record_for_todo(&db, todo_id, ws).await;
+        // 软删 carrier todo，模拟讨论执行完成后的清理（task_post finalize 阶段）
+        db.soft_delete_todo(todo_id)
+            .await
+            .expect("soft delete todo must succeed");
+        // 旧实现此处返回 NotFound；新实现用 record.workspace_id 仍 Ok —— bug 修复核心断言
+        assert!(verify_execution_belongs_to_ws(&db, record_id, ws).await.is_ok());
+        // 跨 ws 访问仍被拒绝：软删 todo 不应成为越权缺口
+        assert!(matches!(
+            verify_execution_belongs_to_ws(&db, record_id, ws + 1).await,
             Err(AppError::Forbidden(_))
         ));
     }

--- a/backend/src/handlers/workspace_guard.rs
+++ b/backend/src/handlers/workspace_guard.rs
@@ -305,6 +305,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_verify_execution_belongs_to_ws_not_found() {
+        // 不存在的 record id → NotFound，与其他 verify_* 一致，不向调用方泄露存在性
+        let db = Database::new(":memory:").await.expect("db must open");
+        let ws = create_workspace(&db, "/tmp/ws-nf").await;
+        assert!(matches!(
+            verify_execution_belongs_to_ws(&db, 99999, ws).await.unwrap_err(),
+            AppError::NotFound
+        ));
+    }
+
+    #[tokio::test]
     async fn test_verify_execution_belongs_to_ws_ignores_carrier_todo_soft_delete() {
         // 复刻 060 讨论区 bug：record 直接归属 ws，其 carrier todo 在执行完成后
         // 被软删。旧实现经 todo_id 间接关联 → get_todo 过滤 deleted_at → NotFound(404)；

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -452,6 +452,9 @@ pub struct ExecutionRecord {
     /// 已废弃，曾用于环节独立执行。现始终为 None。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub step_id: Option<i64>,
+    /// record 直接归属的 workspace（v89 新增）。归属校验用它，不再经 todo 间接关联。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -1166,7 +1166,7 @@ impl LoopRunner {
             feishu_receive_id: None,
             feishu_receive_id_type: None,
             workspace_path,
-            workspace_id: None,
+            workspace_id: todo.workspace_id, // v89: 直接归属 ws，避免 carrier todo 软删后归属链断裂
             // loop 环节执行路径：注入专家上下文，让 loop 内 todo 也尊重 expert_name 绑定
             expert_manager: Some(self.ctx.expert_manager.clone()),
         };
@@ -1537,7 +1537,7 @@ impl LoopRunner {
             feishu_receive_id: None,
             feishu_receive_id_type: None,
             workspace_path: handler_todo.workspace_path.clone(),
-            workspace_id: None,
+            workspace_id: handler_todo.workspace_id, // v89: 直接归属 ws，避免 carrier todo 软删后归属链断裂
             // loop 异常处理执行路径：注入专家上下文，让 handler todo 也尊重其 expert_name 绑定
             expert_manager: Some(self.ctx.expert_manager.clone()),
         };

--- a/backend/src/services/process/artifact_capture.rs
+++ b/backend/src/services/process/artifact_capture.rs
@@ -391,6 +391,7 @@ mod tests {
             todo_progress: None,
             agent_runs: None,
             execution_stats: None,
+            workspace_id: None, // v89 新增字段：测试 make_record 不关心归属
             resume_message: None,
             source_todo_id: None,
             source_todo_title: None,

--- a/backend/tests/db_feature_supplement_tests.rs
+++ b/backend/tests/db_feature_supplement_tests.rs
@@ -1203,6 +1203,8 @@ async fn test_get_execution_records_by_workspace_joins_todos() {
     for (todo_id, task_id) in &[(t1_id, "tk1"), (t2_id, "tk2")] {
         db.create_execution_record(NewExecutionRecord {
             todo_id: Some(*todo_id),
+            // v89：record 直接归属 ws1（与生产写入点一致），验证 ws 隔离查询
+            workspace_id: Some(ws1),
             command: "cmd",
             executor: "pi",
             trigger_type: "manual",
@@ -1229,6 +1231,8 @@ async fn test_get_execution_records_by_workspace_joins_todos() {
         .unwrap();
     db.create_execution_record(NewExecutionRecord {
         todo_id: Some(t3_id),
+        // v89：record 直接归属 ws2，与 ws1 的记录完全隔离
+        workspace_id: Some(ws2),
         command: "cmd",
         executor: "pi",
         trigger_type: "manual",

--- a/docs/requirements/060-讨论区执行明细完成后404-修复-实现总结.md
+++ b/docs/requirements/060-讨论区执行明细完成后404-修复-实现总结.md
@@ -1,0 +1,80 @@
+# 0. 文件修改记录表
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| Claude | 2026-08-06 | 初始版本（讨论区「执行明细」完成后 404 修复实现总结） |
+
+---
+
+# 实现总结：讨论区「执行明细」完成后 404 修复（060 回归）
+
+## 1. 背景
+
+**现象**：任务讨论区点「执行明细 #X」→ URL `/#/todos/:carrierTodoId/posts/:recordId` → 前端 `GET /api/v1/workspaces/{ws}/executions/{recordId}` → 报「加载执行记录失败: Not found」。**执行过程中能打开，执行完成后打不开**。在另一台主机跑测试时发现。
+
+这是 060 任务讨论区引入的**回归 bug**。
+
+## 2. 根因链（已代码定位）
+
+1. handler `get_execution_record`（`execution.rs`）调 `verify_execution_belongs_to_ws(record_id, ws)`
+2. 该 guard（`workspace_guard.rs` 旧实现）取 `record.todo_id` → `verify_todo_belongs_to_ws` → `db.get_todo`
+3. `get_todo` 过滤 `deleted_at IS NULL`
+4. 060 讨论执行完成时 `finalize_discussion_post` **软删 carrier todo**（`task_post.rs`）
+5. 软删后 `get_todo(carrier_todo_id)` → None → `NotFound` → 前端 404
+
+**核心矛盾**：execution record 的 workspace 归属**经 carrier todo 间接关联**（execution_records 原无 workspace_id 列），而 carrier todo 完成后被软删，归属链断裂。`workspace_guard.rs` 旧注释自承「execution_records 没有 workspace_id 列，只能经 todo_id 间接关联」是设计债；`task_post.rs` 旧注释「执行记录不受影响，仍可跳转」是基于该设计债的错误假设。
+
+## 3. 修复方案（用户选定 B：根治）
+
+给 execution_records 加 `workspace_id` 列，record 直接归属 ws；guard 改用 record 自身字段，与 todo 是否被软删彻底解耦。
+
+### 层 1 — DB schema
+- 新增 `db/migration/v89.rs`：`V89AddExecutionRecordsWorkspaceId`，用幂等 `add_column_if_missing` 加 `workspace_id INTEGER`，紧跟 `UPDATE ... SET workspace_id = (SELECT workspace_id FROM todos WHERE id = execution_records.todo_id) WHERE workspace_id IS NULL` 回填历史数据（todos 为软删、行还在，SELECT 能查到 → 060 历史 record 正确回填）。
+- `db/migration/mod.rs`：注册 v89（接 v88 之后，`all_migrations()` 末尾）。
+- `db/migration/consolidated_schema.rs`：`CREATE TABLE execution_records` 末尾加 `workspace_id INTEGER`（满足漂移守卫 `test_consolidated_schema_matches_incremental`，两路建库 schema 一致）。
+
+### 层 2 — 实体 + 业务模型
+- `db/entity/execution_records.rs`：Model 加 `workspace_id: Option<i64>`。
+- `models/mod.rs`：`ExecutionRecord` 加 `workspace_id: Option<i64>`（serde `skip_serializing_if = "Option::is_none"`）。
+- `db/execution.rs`：`From<Model>` impl 加映射；`dashboard.rs` 用 `..Model::default()` 自动兼容新字段。
+
+### 层 3 — 写入点（让新 record 带 ws）
+- `db/execution.rs`：`NewExecutionRecord` 加字段；`create_execution_record` ActiveModel 写入。
+- `executor_service/pre_spawn.rs`（唯一生产写入点）：`workspace_id: request.workspace_id`。
+- 4 处 `RunTodoExecutionRequest` 生产构造点补全（此前 `workspace_id: None` 会产生无归属新 record，埋下同样 bug）：
+  - `handlers/webhook.rs` → `todo.workspace_id`
+  - `services/loop_runner.rs`（loop 环节）→ `todo.workspace_id`
+  - `services/loop_runner.rs`（loop 异常处理）→ `handler_todo.workspace_id`
+  - `executor_service/auto_review.rs` → `original.workspace_id`（直传 Option，比 `Some(ws)` 保留 None 语义更准确）
+
+### 层 4 — 归属校验改造（核心修复点）
+- `workspace_guard.rs::verify_execution_belongs_to_ws`：改为直接比对 `record.workspace_id`，删除 `verify_todo_belongs_to_ws` 间接调用。6 个调用点签名不变、零改动。doc 注释更新为「record 直接归属」。
+
+### 层 5 — 测试
+- 测试 helper 补字段：`workspace_guard.rs::create_record_for_todo` 参数化（写真实 ws）、`db/mod.rs` 2 处、`execution.rs`/`artifact_capture.rs` 的 `make_record`、集成测试 `db_feature_supplement_tests.rs` 2 处。
+- 新增 `test_verify_execution_uses_record_workspace_id_after_todo_soft_deleted`：复刻 bug 场景（record 带 ws + carrier todo 软删），断言 guard 仍 Ok、跨 ws 仍 Forbidden。
+
+## 4. 验证
+
+| 项 | 结果 |
+|----|------|
+| `cargo clippy --all-targets -- -D warnings` | ✅ 零告警 |
+| `cargo test`（全量） | ✅ lib 1647 passed / 0 failed；全部集成测试 target 0 failed |
+| 漂移守卫 `test_consolidated_schema_matches_incremental` | ✅ 通过（v89 增量与合并 schema 一致） |
+| 新增 bug 复刻测试 `test_verify_execution_uses_record_workspace_id_after_todo_soft_deleted` | ✅ 通过 |
+
+## 5. 关键设计取舍
+
+- **nullable 列 + 回填**：`workspace_id` 允许 NULL，安全过渡；回填用 `todos.workspace_id`（软删行在），历史 record（含 060 discussion）正确归属。极少数 `todos.workspace_id IS NULL` 的远古数据 → record.workspace_id 仍 NULL → guard Forbidden（与现有 `workspace_id_matches(None)=false` 契约一致，安全不越权）。
+- **auto_review 用 `original.workspace_id` 直传 Option**：而非初稿的 `Some(ws)`（ws=`unwrap_or(0)`）。直传保留 None 语义——原 todo 无 ws 时评审 record 也 None，避免把 None 误填成 `Some(0)`（0 非真实 ws）。
+- **读路径子查询优化留后续**：`get_execution_records_by_workspace` 等仍用 `todo_id IN (SELECT ... WHERE workspace_id)` 间接查。加列后可简化为 `WHERE execution_records.workspace_id = ?`（性能优化、非正确性），本次不动避免蔓延。
+
+## 6. 风险与回滚
+
+- **回滚**：纯加列 + 逻辑改，无破坏性 schema 变更。migration v89 是幂等 ADD COLUMN，revert 后旧代码忽略该列无副作用；整体 revert 需回退本 commit（新代码读不到字段会编译错，提示同步回退）。
+- **不影响**：6 个 `verify_execution` 调用点签名不变；前端 TS 接口开放匹配，多返回字段透明；查询路径未经 `record.workspace_id` 不受影响。
+
+## 7. 不在本次范围
+
+- 6 处读路径子查询简化（性能优化，后续 PR）。
+- 前端无需改动。

--- a/docs/requirements/060-讨论区执行明细完成后404-修复-实现总结.md
+++ b/docs/requirements/060-讨论区执行明细完成后404-修复-实现总结.md
@@ -67,7 +67,7 @@
 
 - **nullable 列 + 回填**：`workspace_id` 允许 NULL，安全过渡；回填用 `todos.workspace_id`（软删行在），历史 record（含 060 discussion）正确归属。极少数 `todos.workspace_id IS NULL` 的远古数据 → record.workspace_id 仍 NULL → guard Forbidden（与现有 `workspace_id_matches(None)=false` 契约一致，安全不越权）。
 - **auto_review 用 `original.workspace_id` 直传 Option**：而非初稿的 `Some(ws)`（ws=`unwrap_or(0)`）。直传保留 None 语义——原 todo 无 ws 时评审 record 也 None，避免把 None 误填成 `Some(0)`（0 非真实 ws）。
-- **读路径子查询优化留后续**：`get_execution_records_by_workspace` 等仍用 `todo_id IN (SELECT ... WHERE workspace_id)` 间接查。加列后可简化为 `WHERE execution_records.workspace_id = ?`（性能优化、非正确性），本次不动避免蔓延。
+- **读路径归属一致性留后续**：`get_execution_records` / `get_execution_records_by_workspace` / `get_running_records_by_workspace` 仍按 `todos.workspace_id`（+ `deleted_at IS NULL`）过滤。ntd 支持 todo 跨 ws 迁移（`todo.rs` 批量迁移），迁移后 `record.workspace_id`（写入快照）与 `todos.workspace_id`（当前）会 diverge，理论上存在「列表按新 ws 可见、详情按旧 ws Forbidden」的不一致。**本次不改读路径**：直接换用 `record.workspace_id` 会改变「软删 todo 历史记录的列表可见性」（现不显示 → 显示）这一产品行为；更优解是在 todo 迁移/改 ws 时同步刷新其 `execution_records.workspace_id`，让 record 归属跟随 todo。需独立设计 + 测试，留后续 PR。
 
 ## 6. 风险与回滚
 
@@ -76,5 +76,5 @@
 
 ## 7. 不在本次范围
 
-- 6 处读路径子查询简化（性能优化，后续 PR）。
+- **读路径归属一致性**（CodeRabbit 评审指出）：3 处列表/running 查询（`execution.rs` 的 `workspace_todo_subquery` / `get_execution_records_by_workspace` / `get_running_records_by_workspace`）仍按 `todos.workspace_id` 过滤，todo 跨 ws 迁移后会与 `record.workspace_id` diverge。后续修复方向：在 todo 迁移/改 ws 时同步刷新 `execution_records.workspace_id`（而非改读路径，避免软删可见性行为变化）。
 - 前端无需改动。

--- a/docs/requirements/060-讨论区执行明细完成后404-修复-实现总结.md
+++ b/docs/requirements/060-讨论区执行明细完成后404-修复-实现总结.md
@@ -52,7 +52,7 @@
 
 ### 层 5 — 测试
 - 测试 helper 补字段：`workspace_guard.rs::create_record_for_todo` 参数化（写真实 ws）、`db/mod.rs` 2 处、`execution.rs`/`artifact_capture.rs` 的 `make_record`、集成测试 `db_feature_supplement_tests.rs` 2 处。
-- 新增 `test_verify_execution_uses_record_workspace_id_after_todo_soft_deleted`：复刻 bug 场景（record 带 ws + carrier todo 软删），断言 guard 仍 Ok、跨 ws 仍 Forbidden。
+- 新增 `test_verify_execution_belongs_to_ws_ignores_carrier_todo_soft_delete`：复刻 bug 场景（record 带 ws + carrier todo 软删），断言 guard 仍 Ok、跨 ws 仍 Forbidden。
 
 ## 4. 验证
 
@@ -61,7 +61,7 @@
 | `cargo clippy --all-targets -- -D warnings` | ✅ 零告警 |
 | `cargo test`（全量） | ✅ lib 1647 passed / 0 failed；全部集成测试 target 0 failed |
 | 漂移守卫 `test_consolidated_schema_matches_incremental` | ✅ 通过（v89 增量与合并 schema 一致） |
-| 新增 bug 复刻测试 `test_verify_execution_uses_record_workspace_id_after_todo_soft_deleted` | ✅ 通过 |
+| 新增 bug 复刻测试 `test_verify_execution_belongs_to_ws_ignores_carrier_todo_soft_delete` | ✅ 通过 |
 
 ## 5. 关键设计取舍
 


### PR DESCRIPTION
## 问题

任务讨论区点「执行明细 #X」，**执行过程中能打开，执行完成后报「加载执行记录失败: Not found」**（404）。在另一台主机跑测试时发现。这是 060 任务讨论区引入的**回归 bug**。

## 根因

execution record 的 workspace 归属**经 carrier todo 间接关联**（`execution_records` 原无 `workspace_id` 列）；060 讨论执行完成时 `finalize_discussion_post` **软删 carrier todo** → `get_todo` 过滤 `deleted_at` 返回 None → `verify_execution_belongs_to_ws` 取 `record.todo_id` 走间接校验，误判 **NotFound**。

核心矛盾：record 归属依赖一条执行完即被删的 todo，链路必然断裂。

## 修复（方案 B：根治）

给 `execution_records` 加 `workspace_id` 列，record **直接归属 ws**；guard 改用 record 自身字段，与 todo 是否软删彻底解耦。

| 层 | 改动 |
|----|------|
| **1 schema** | migration `v89`（幂等 `ADD COLUMN` + 回填历史：`todos` 软删行还在 → 060 历史 record 正确回填 ws）；`consolidated_schema` 同步 |
| **2 实体/模型** | entity `Model` + `ExecutionRecord` + `From` impl 加字段；`dashboard.rs` 用 `..Model::default()` 自动兼容 |
| **3 写入点** | `NewExecutionRecord` 加字段 + `pre_spawn` 生产点 + **4 处 `RunTodoExecutionRequest` 生产构造补全**（webhook / loop×2 / auto_review，此前 `None` 会埋下同样 bug） |
| **4 归属校验** | `verify_execution_belongs_to_ws` 改用 `record.workspace_id` 直接比对，删除间接 `verify_todo` 调用（**6 调用点签名不变、零改动**） |
| **5 测试** | 新增 bug 复刻单测 `test_verify_execution_belongs_to_ws_ignores_carrier_todo_soft_delete`（record 带 ws + carrier todo 软删 → 仍 Ok、跨 ws 仍 Forbidden） |

## 验证

- `cargo clippy --all-targets -- -D warnings` ✅ 零告警
- `cargo test` ✅ 全绿（lib **1647 passed / 0 failed** + 全部集成测试 target 0 failed）
- 漂移守卫 `test_consolidated_schema_matches_incremental` ✅（v89 增量与合并 schema 一致）

详见 `docs/requirements/060-讨论区执行明细完成后404-修复-实现总结.md`。

## 风险与回滚

- nullable 列 + 回填，安全过渡；极少数 `todos.workspace_id IS NULL` 远古数据 → record 仍 NULL → guard Forbidden（与 `workspace_id_matches(None)=false` 契约一致，不越权）。
- migration v89 幂等 ADD COLUMN，revert 后旧代码忽略该列无副作用。

## 不在本次范围

- 6 处读路径子查询简化（`get_execution_records_by_workspace` 等可改用 `WHERE workspace_id = ?`，性能优化、非正确性，后续 PR）。
- 前端无需改动（TS 接口开放匹配，多字段透明）。
