### PR TITLE
fix(process): 创建工艺在 IP 直连（非 secure context）报 crypto.randomUUID 失败

### DIFF
--- a/frontend/src/components/process/CreateProcessMetaModal.tsx
+++ b/frontend/src/components/process/CreateProcessMetaModal.tsx
@@ -18,6 +18,7 @@ import {
   useCallback,
 } from 'react';
 import { Modal, Form, Input, Select, message } from 'antd';
+import { generateUUID } from '@/utils/uuid';
 import { bundledApi } from '@/api/bundled';
 import { buildEmptyProcessYaml, type ProcessMetaInput } from './buildEmptyProcessYaml';
 
@@ -84,7 +85,8 @@ export function CreateProcessMetaModal({
       const meta: ProcessMetaInput = {
         name: values.name,
         // 040：新建工艺即时生成 guid 写入 YAML，作为其稳定身份
-        guid: crypto.randomUUID(),
+        // 用降级工具：secure context 走 crypto.randomUUID，IP 直连回退 getRandomValues
+        guid: generateUUID(),
         display_name: values.display_name,
         description: values.description,
         category: values.category,

--- a/frontend/src/components/process/buildEmptyProcessYaml.ts
+++ b/frontend/src/components/process/buildEmptyProcessYaml.ts
@@ -18,7 +18,7 @@ import { yamlDump } from './processYamlValidator';
 export interface ProcessMetaInput {
   // 工艺标识名（文件名/展示用，040 起不再唯一）
   name: string;
-  // 040：稳定身份（UUID v4），随文件走；由调用方（Modal）用 crypto.randomUUID() 生成
+  // 040：稳定身份（UUID v4），随文件走；由调用方（Modal）用 generateUUID() 生成（兼容 IP 直连非 secure context）
   guid: string;
   // 列表页显示名（必填）
   display_name: string;

--- a/frontend/src/utils/uuid.test.ts
+++ b/frontend/src/utils/uuid.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { bytesToUUIDv4, generateUUID } from './uuid';
+
+// v4 UUID 正则：version 位为 4，variant 位为 8/9/a/b
+const V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('bytesToUUIDv4', () => {
+  it('全零字节置位后 version=4 variant=8', () => {
+    // 固定输入断言固定输出，验证 version/variant 置位公式正确（无随机性干扰）
+    expect(bytesToUUIDv4(new Uint8Array(16))).toBe('00000000-0000-4000-8000-000000000000');
+  });
+
+  it('保留随机位、置位后仍符合 v4 格式', () => {
+    const bytes = new Uint8Array([
+      0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+      0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+    ]);
+    // b[6]=0xde → 0x4e（version 位置 4），b[8]=0x11 → 0x91（variant 位置 10），其余位原样保留
+    expect(bytesToUUIDv4(bytes)).toBe('12345678-9abc-4ef0-9122-334455667788');
+  });
+
+  it('不修改传入的缓冲区（无副作用）', () => {
+    const bytes = new Uint8Array(16).fill(0xff);
+    bytesToUUIDv4(bytes);
+    // 调用后原缓冲区应保持不变（函数内部 slice 复制）
+    expect(bytes.every((x) => x === 0xff)).toBe(true);
+  });
+});
+
+describe('generateUUID', () => {
+  it('产出符合 v4 格式', () => {
+    expect(generateUUID()).toMatch(V4_REGEX);
+  });
+
+  it('两次调用产生不同值', () => {
+    // 碰撞概率忽略不计；防回归（如误把 id 写成常量）
+    expect(generateUUID()).not.toBe(generateUUID());
+  });
+});

--- a/frontend/src/utils/uuid.ts
+++ b/frontend/src/utils/uuid.ts
@@ -1,0 +1,40 @@
+/**
+ * UUID v4 生成工具。
+ *
+ * 背景：`crypto.randomUUID()` 仅在 secure context（https 或 localhost）可用。当通过
+ * 非 localhost 的 IP 直连访问开发/测试服务（如 http://192.168.x.x:18088）时，
+ * `crypto.randomUUID` 不存在，「创建工艺」等需要即时生成 guid 的场景会报
+ * `crypto.randomUUID is not a function`。这里做降级：secure context 走原生 API，
+ * 否则用 `crypto.getRandomValues`（所有 http/https context 均可用）手搓 RFC 4122 v4。
+ */
+
+/**
+ * 按 RFC 4122 把 16 字节随机数格式化为 v4 UUID。
+ *
+ * 抽成纯函数便于单测：给定固定字节可断言 version/variant 置位正确，无需 mock crypto。
+ * 复制一份字节再改——`getRandomValues` 可能复用调用方传入的缓冲区，避免副作用。
+ */
+export function bytesToUUIDv4(bytes: Uint8Array): string {
+  const b = bytes.slice();
+  // 版本号位：高 4 位置为 0100（v4）
+  b[6] = (b[6] & 0x0f) | 0x40;
+  // variant 位：高 2 位置为 10（RFC 4122 变体）
+  b[8] = (b[8] & 0x3f) | 0x80;
+  const hex = Array.from(b, (x) => x.toString(16).padStart(2, '0'));
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
+}
+
+/**
+ * 生成一个 RFC 4122 v4 UUID。
+ *
+ * 优先 `crypto.randomUUID`（secure context，原生最快最稳）；不可用时回退
+ * `bytesToUUIDv4(crypto.getRandomValues(...))`，覆盖 IP 直连等非 secure context。
+ */
+export function generateUUID(): string {
+  // secure context（https / localhost）：原生 randomUUID
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // 非 secure context（http + IP）：getRandomValues 仍可用，手搓 v4
+  return bytesToUUIDv4(crypto.getRandomValues(new Uint8Array(16)));
+}


### PR DESCRIPTION
## 问题

创建工艺点「确定」报错：`创建失败：crypto.randomUUID is not a function`。

## 根因

`CreateProcessMetaModal` 用 `crypto.randomUUID()` 生成工艺 guid。该 API **仅在 secure context（https 或 localhost）可用**。通过 IP 直连开发/测试服务（如 `http://192.168.x.x:18088`，非 secure context）访问时 `crypto.randomUUID` 不存在 → 抛错。

## 修复

新增 `frontend/src/utils/uuid.ts`：
- `generateUUID()`：secure context 走原生 `crypto.randomUUID`；否则降级 `crypto.getRandomValues`（所有 http/https context 均可用）手搓 RFC 4122 v4。
- 抽 `bytesToUUIDv4(bytes)` 纯函数，便于单测置位公式（无需 mock crypto）。

调用点 `CreateProcessMetaModal.tsx` 改用 `generateUUID()`。

## 验证

- `npx vitest run src/utils/uuid.test.ts` ✅ 5 passed（固定字节断言 version/variant 置位、无副作用、v4 格式、唯一性）
- `npx tsc --noEmit` ✅ 零错误

## 影响范围

仅前端工艺 guid 生成 1 处调用；不引入新依赖（用原生 Web Crypto 降级）。
