### PR TITLE
fix(060): 讨论区帖子页「暂无执行记录」空态——session 查询改用 record.workspace_id + 前端冷启动 ws 守卫

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -860,12 +860,13 @@ impl Database {
         session_id: &str,
         workspace_id: Option<i64>,
     ) -> Result<Vec<ExecutionRecord>, sea_orm::DbErr> {
-        // V1 隔离：同一 session 可能含跨 ws 记录（todo 被移过空间），按子查询过滤只留本 ws
+        // V1 隔离：同一 session 可能含跨 ws 记录，按 record 自身归属过滤只留本 ws。
+        // 用 execution_records.workspace_id（v89 新列）而非经 todos 子查询间接关联——
+        // 060 讨论执行完成会软删 carrier todo，旧子查询过滤 deleted_at 导致软删后
+        // 查不到本 session 记录（帖子页「暂无执行记录」）。record 直接归属与 todo 生命周期解耦。
         let filter = execution_records::Column::SessionId.eq(session_id);
         let filter = if let Some(wid) = workspace_id {
-            filter.and(execution_records::Column::TodoId.in_subquery(
-                workspace_todo_subquery(wid),
-            ))
+            filter.and(execution_records::Column::WorkspaceId.eq(wid))
         } else {
             filter
         };
@@ -1952,5 +1953,104 @@ mod center_aggregate_tests {
         seed_exec(&db, t2, "success", "manual").await;
         let map2 = db.get_last_webhook_trigger_for_todos(&[t2]).await.unwrap();
         assert!(!map2.contains_key(&t2), "纯手动执行不应出现在 webhook 触发 map");
+    }
+}
+
+/// get_execution_records_by_session 测试：软删 todo 的 session 记录仍应能查到（v89 归属解耦）。
+///
+/// 背景：060 讨论区执行完成会软删 carrier todo。旧实现按
+/// `todo_id IN (SELECT id FROM todos WHERE workspace_id=? AND deleted_at IS NULL)` 过滤，
+/// 软删后子查询排除该 todo → session 查询返回空 → 帖子页「暂无执行记录」。
+/// v89 给 execution_records 加了 workspace_id 列，本查询改用 record 自身归属，与 todo 生命周期解耦。
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::useless_vec, clippy::redundant_pattern_matching, clippy::redundant_clone, clippy::len_zero, clippy::bool_assert_comparison, clippy::unnecessary_get_then_check, clippy::doc_lazy_continuation, clippy::clone_on_copy, clippy::print_stdout, clippy::needless_pass_by_value, clippy::sliced_string_as_bytes, clippy::manual_map, clippy::collapsible_match, clippy::question_mark)]
+mod session_query_tests {
+    use super::*;
+
+    /// 建 workspace + 归属于它的 todo + 一条带 session_id 的 execution record，
+    /// 返回 (workspace_id, todo_id, record_id)。
+    async fn seed_session_record(
+        db: &Database,
+        path: &str,
+        session_id: &str,
+    ) -> (i64, i64, i64) {
+        // 直接写 project_directories 表造 workspace，避免依赖 create_todo 等业务入口
+        let ws = db
+            .create_project_directory(path, None, false, false)
+            .await
+            .expect("create workspace");
+        // todo 归属 ws：旧实现的子查询要求 todo.workspace_id=ws 且未软删
+        db.exec(&format!(
+            "INSERT INTO todos (title, prompt, status, workspace_id) \
+             VALUES ('t-{path}', 'p', 'pending', {ws})"
+        ))
+        .await
+        .expect("insert todo");
+        let todo_row = db
+            .conn
+            .query_one(Statement::from_string(
+                sea_orm::DbBackend::Sqlite,
+                format!("SELECT id FROM todos WHERE title = 't-{path}'"),
+            ))
+            .await
+            .expect("query todo id")
+            .expect("todo exists");
+        let todo_id: i64 = todo_row.try_get_by_index(0).expect("todo id readable");
+        // record 直接归属 ws（v89 语义，与生产写入点一致）
+        db.exec(&format!(
+            "INSERT INTO execution_records (todo_id, workspace_id, session_id, status, trigger_type) \
+             VALUES ({todo_id}, {ws}, '{session_id}', 'success', 'manual')"
+        ))
+        .await
+        .expect("insert record");
+        let record_row = db
+            .conn
+            .query_one(Statement::from_string(
+                sea_orm::DbBackend::Sqlite,
+                "SELECT id FROM execution_records ORDER BY id DESC LIMIT 1".to_string(),
+            ))
+            .await
+            .expect("query record id")
+            .expect("record exists");
+        let record_id: i64 = record_row.try_get_by_index(0).expect("record id readable");
+        (ws, todo_id, record_id)
+    }
+
+    #[tokio::test]
+    async fn test_get_execution_records_by_session_returns_record_when_todo_soft_deleted() {
+        let db = Database::new(":memory:").await.expect("db must open");
+        let session = "sess-bug-1";
+        let (ws, todo_id, record_id) = seed_session_record(&db, "/tmp/ws-bug", session).await;
+        // 软删 carrier todo，模拟 060 讨论执行完成后的清理（task_post finalize 阶段）
+        db.soft_delete_todo(todo_id).await.expect("soft delete todo");
+        // 修复前：todo 被软删 → 旧子查询排除 → 返回空；修复后：按 record.workspace_id 直接命中
+        let records = db
+            .get_execution_records_by_session(session, Some(ws))
+            .await
+            .expect("query must succeed");
+        assert_eq!(records.len(), 1, "软删 todo 的 session 记录仍应查到");
+        assert_eq!(records[0].id, record_id);
+    }
+
+    #[tokio::test]
+    async fn test_get_execution_records_by_session_cross_workspace_excluded() {
+        let db = Database::new(":memory:").await.expect("db must open");
+        // 记录归属 ws_a；用另一个 ws 查同 session → V1 隔离，应返回空
+        let (_ws_a, _todo, _record) = seed_session_record(&db, "/tmp/ws-a", "sess-x").await;
+        let other_ws = db
+            .create_project_directory("/tmp/ws-other", None, false, false)
+            .await
+            .expect("create other ws");
+        let records = db
+            .get_execution_records_by_session("sess-x", Some(other_ws))
+            .await
+            .expect("query must succeed");
+        assert!(records.is_empty(), "跨 ws 不应命中（V1 隔离）");
+        // 无 workspace 过滤时（None）应能命中——session 本身不受 ws 限制
+        let all = db
+            .get_execution_records_by_session("sess-x", None)
+            .await
+            .expect("query must succeed");
+        assert_eq!(all.len(), 1, "不过滤 ws 时同 session 记录应全部返回");
     }
 }

--- a/docs/requirements/060-讨论区帖子页空态-修复-实现总结.md
+++ b/docs/requirements/060-讨论区帖子页空态-修复-实现总结.md
@@ -1,0 +1,78 @@
+# 0. 文件修改记录表
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| Claude | 2026-08-06 | 初始版本（讨论区帖子页「暂无执行记录」空态修复实现总结） |
+
+---
+
+# 实现总结：讨论区帖子页执行记录空态修复（060 回归）
+
+## 1. 背景
+
+**现象**：访问 `http://localhost:18088/#/todos/7/posts/7`（讨论区帖子页）显示「事项 #7 … **暂无执行记录**」，而非实际的讨论/执行内容。
+
+讨论区（060）执行完成时会**软删 carrier todo**。帖子页按 `session_id` 加载同 session 的所有执行记录，软删后 session 查询查不到记录 → 空态。
+
+## 2. 根因链（已代码定位 + 实测复现）
+
+### 根因一：后端 session 查询仍经 todos 子查询间接归属（#987 遗留缺口）
+
+1. 帖子页 `TodoPostPage.loadSessionRecords` → `GET /api/v1/workspaces/{ws}/executions/{recordId}` 拿到记录（有 `session_id`）→ `GET .../executions/session/{session_id}`。
+2. `get_execution_records_by_session`（`db/execution.rs`）过滤条件：
+   `session_id = ? AND todo_id IN (SELECT id FROM todos WHERE workspace_id=? AND deleted_at IS NULL)`。
+3. 060 讨论执行完成时软删 carrier todo → 子查询 `deleted_at IS NULL` 排除它 → **返回空数组**。
+
+**实测**（dev 库 `~/.ntd/data.dev.db`）：
+- `GET /executions/7` → 200（单条查询不走 todo 子查询，能拿到）
+- `GET /executions/session/cb2b8bab-…` → 200 但 **0 条**
+- todo 7 `deleted_at = 2026-08-06T12:13:43.147Z`（已软删）
+
+**为什么是 #987 的缺口**：#987 给 `execution_records` 加了 `workspace_id` 列（v89），并把**单条归属校验**改成直接用 `record.workspace_id`，与 todo 软删解耦；但 **session 查询仍走 todos 子查询**，没跟上新方案。
+
+### 根因二：前端冷启动深链时 workspace 未解析，用 ws=0 请求 403
+
+1. `TodoPostPage.loadSessionRecords` 用 `state.selectedWorkspace ?? 0`。
+2. 冷启动直接输入 `/#/todos/:id/posts/:rid` 时，`DataLoader`（`useApp.tsx`）**异步**解析初始 workspace（从 localStorage / 第一个目录），初始值为 `null`。
+3. `null ?? 0` → 请求 `GET /api/v1/workspaces/0/executions/7` → **403** → 前端 catch → 空态。
+4. 且 `loadSessionRecords` 的 effect 只依赖 `[recordId]`，workspace 就绪后**不会重跑**。
+
+**实测**（浏览器 network）：首请求 `workspaces/0/executions/7 (XHR) 403`；后续 ws=1 的请求（executions/7 → 200、session → 200）证明后端修复后数据可用，但页面 state 已停在空态。
+
+## 3. 修复方案
+
+### 层 1 — 后端：session 查询改用 record.workspace_id 直接归属（`db/execution.rs`）
+
+`get_execution_records_by_session` 的 workspace 过滤从「todos 子查询」改为 `execution_records::Column::WorkspaceId.eq(wid)`，与 #987 的归属解耦方案对齐：
+- 软删 todo 的 record 仍能按 `record.workspace_id` 命中；
+- 跨 ws 隔离语义不变（record.workspace_id 必须等于请求的 ws，`None` 时不加过滤）。
+
+### 层 2 — 前端：冷启动 workspace 守卫 + effect 依赖补全（`todo-post/index.tsx`）
+
+- `loadSessionRecords`：`selectedWorkspace == null` 时直接返回，**不再回退到 0**；等 workspace 就绪后由 effect 重跑补拉。
+- effect 依赖从 `[recordId]` 改为 `[recordId, state.selectedWorkspace]`（对齐 `TodoDetail` 的既有模式）。
+
+## 4. 测试
+
+### 新增单元测试（`db/execution.rs::session_query_tests`）
+
+| 用例 | 覆盖场景 | 修复前 |
+|------|---------|--------|
+| `test_get_execution_records_by_session_returns_record_when_todo_soft_deleted` | 复刻 bug：record 带 ws + carrier todo 软删 → 仍查到 | ❌ 返回空（RED 复现） |
+| `test_get_execution_records_by_session_cross_workspace_excluded` | V1 隔离：跨 ws 查同 session 返回空；`None` 不过滤时全量返回 | ✅ 通过（防回归越权） |
+
+### 验证
+
+| 项 | 结果 |
+|----|------|
+| `cargo clippy --all-targets -- -D warnings` | 零告警 |
+| `cargo test`（lib + 全部集成测试 target） | 0 failed |
+| `npx tsc --noEmit`（前端） | 零错误 |
+| API 实测 | `GET /executions/session/cb2b8bab-…` → 200，1 条（id 7） |
+| agent-browser 冷启动复现 | 清空 `selected_workspace` 后直达 `/#/todos/7/posts/7` → 正常渲染讨论内容（结论 + 命令详情），网络无 ws=0 403 |
+
+## 5. 影响面与安全反思
+
+- **后端**：仅改 `get_execution_records_by_session` 一处查询。`workspace_todo_subquery` 仍被列表查询（`get_execution_records`）与 running 查询（`get_running_execution_records`）使用，未改动——「已删 todo 的执行记录是否展示在列表/运行中」属独立产品决策，不在本次范围。
+- **归属安全**：`record.workspace_id` 必须等于请求 ws 才返回，跨 ws 仍被拒绝（单测覆盖）；`workspace_id IS NULL` 的旧数据按未归属处理（与 `verify_execution_belongs_to_ws` 的 NULL→拒绝契约一致）。`session_id` 走 SeaORM 参数绑定，无注入面。
+- **前端**：仅加 null 守卫与 effect 依赖，仍走 workspace-scoped API，无越权或行为回退。

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,7 +54,7 @@ function AppContent() {
   const { state, dispatch, clearSelection } = useApp();
   // 028：路由统一为 /#/todos + /#/todos/:id + /#/todos/:id/posts/:rid + /#/loops + /#/loops/:id
   // todoDetailId / loopDetailId / postRecordId 均来自 path 段，刷新可恢复
-  const { activeView, todoDetailId, loopDetailId, taskDetailId, postRecordId, activePanel, processGuid, processMode, showView, pushUrl, replaceUrl, backToList } = useViewState();
+  const { activeView, todoDetailId, loopDetailId, taskDetailId, postRecordId, postBackFrom, postBackTaskId, activePanel, processGuid, processMode, showView, pushUrl, replaceUrl, backToList } = useViewState();
   const { themeMode, toggleTheme } = useTheme();
   // 底部执行日志面板的显隐开关：来自设置-界面显示，关掉后即使有运行中任务也不渲染面板。
   const { visible: consolePanelVisible, setVisible: setConsolePanelVisible } = useConsolePanel();
@@ -332,7 +332,15 @@ function AppContent() {
             <TodoPostPage
               todoId={todoDetailId}
               recordId={postRecordId}
-              onBack={() => replaceUrl('todos', { id: todoDetailId })}
+              onBack={() => {
+                // 帖子页返回区分来源：从任务-讨论 tab 跳入 → 回到该任务的讨论 tab（?tab=discussion）；
+                // 否则回父事项详情（旧逻辑）。用 replaceUrl 不污染浏览器历史。
+                if (postBackFrom === 'task' && postBackTaskId != null) {
+                  replaceUrl('tasks', { id: postBackTaskId, tab: 'discussion' });
+                } else {
+                  replaceUrl('todos', { id: todoDetailId });
+                }
+              }}
             />
           )}
 

--- a/frontend/src/components/tasks/TaskDetailPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailPanel.tsx
@@ -17,6 +17,7 @@ import {
 import bundledApi from '@/api/bundled';
 import * as dbLoops from '@/utils/database/loops';
 import { useProjectDirectories } from '@/utils/workspaceDisplay';
+import { useViewState } from '@/hooks/useViewState';
 import type { LoopDetail } from '@/types/loop';
 import { complexityColor, complexityLabel, statusColor } from './constants';
 import {
@@ -27,6 +28,10 @@ import { DiscussionTab } from './discussion/DiscussionTab';
 import styles from './TaskDetailPanel.module.css';
 
 const { Text } = Typography;
+
+// Tabs key 白名单：?tab= query 的合法值，非法值一律回退到「概览」。
+// 帖子页返回本任务-讨论 tab 时，URL 带 ?tab=discussion，Tabs 据此恢复选中态。
+const TAB_KEYS = ['overview', 'dag', 'exec', 'discussion'] as const;
 
 // ====== 类型定义 ======
 
@@ -127,6 +132,12 @@ export function TaskDetailPanel({
   // 否则二次渲染多一个 hook → React「Rendered more hooks than during the previous render」崩溃。
   const [discussionRunning, setDiscussionRunning] = useState(0);
   const { dirs: projectDirs } = useProjectDirectories();
+  // URL ?tab= 驱动 Tabs 选中态（对齐 Settings 页模式）：帖子页返回任务-讨论 tab 时
+  // 返回 URL 带 ?tab=discussion，此处解析出 activeTab 落到对应 Tab；非法值回退「概览」。
+  const { activeTab, pushUrl } = useViewState();
+  const resolvedTab = activeTab && (TAB_KEYS as readonly string[]).includes(activeTab)
+    ? activeTab
+    : 'overview';
 
   // 拉取任务详情（含基本 loop 信息）。
   useEffect(() => {
@@ -251,6 +262,8 @@ export function TaskDetailPanel({
       <div className={styles.tabsWrap}>
         <Tabs
           items={tabItems}
+          activeKey={resolvedTab}
+          onChange={(key) => pushUrl('tasks', { id: task.id, tab: key })}
           style={{ height: '100%' }}
           tabBarExtraContent={loopLoading ? <Spin size="small" style={{ marginRight: 16 }} /> : undefined}
         />

--- a/frontend/src/components/tasks/TaskDetailPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailPanel.tsx
@@ -134,7 +134,8 @@ export function TaskDetailPanel({
   const { dirs: projectDirs } = useProjectDirectories();
   // URL ?tab= 驱动 Tabs 选中态（对齐 Settings 页模式）：帖子页返回任务-讨论 tab 时
   // 返回 URL 带 ?tab=discussion，此处解析出 activeTab 落到对应 Tab；非法值回退「概览」。
-  const { activeTab, pushUrl } = useViewState();
+  // 切 tab 用 replaceUrl：只更新 URL 不压 history，避免浏览器后退逐个回退 tab 而非离开页面。
+  const { activeTab, replaceUrl } = useViewState();
   const resolvedTab = activeTab && (TAB_KEYS as readonly string[]).includes(activeTab)
     ? activeTab
     : 'overview';
@@ -263,7 +264,7 @@ export function TaskDetailPanel({
         <Tabs
           items={tabItems}
           activeKey={resolvedTab}
-          onChange={(key) => pushUrl('tasks', { id: task.id, tab: key })}
+          onChange={(key) => replaceUrl('tasks', { id: task.id, tab: key })}
           style={{ height: '100%' }}
           tabBarExtraContent={loopLoading ? <Spin size="small" style={{ marginRight: 16 }} /> : undefined}
         />

--- a/frontend/src/components/tasks/discussion/DiscussionTab.tsx
+++ b/frontend/src/components/tasks/discussion/DiscussionTab.tsx
@@ -26,9 +26,11 @@ export function DiscussionTab({ taskId, workspaceId, onRunningCountChange }: Dis
 
   const { pushUrl } = useViewState();
   // 点击「执行明细」→ 跳转到该执行记录的帖子详情页（事项侧执行对话流），由 PostCard 调用。
+  // 带 postBack='task' + postBackTaskId：帖子页返回按钮据此回到本任务-讨论 tab，而不是事项详情。
   const handleOpenExecution = useCallback(
-    (todoId: number, recordId: number) => pushUrl('todos', { id: todoId, recordId }),
-    [pushUrl],
+    (todoId: number, recordId: number) =>
+      pushUrl('todos', { id: todoId, recordId, postBack: 'task', postBackTaskId: taskId }),
+    [pushUrl, taskId],
   );
 
   // running 帖数量上报父组件（TaskDetailPanel 用于「讨论」Tab 角标，M4）。

--- a/frontend/src/components/todo-post/index.tsx
+++ b/frontend/src/components/todo-post/index.tsx
@@ -64,10 +64,14 @@ export function TodoPostPage({
   const loadSessionRecords = async () => {
     // 捕获本次请求所属的 recordId，resolve 后与最新值比较，丢弃切换后的 stale 响应
     const id = recordId;
+    // v1 纯 workspace-scoped：execution 查询需 workspaceId。
+    // selectedWorkspace 冷启动深链（/#/todos/:id/posts/:rid）时可能尚未解析（null），
+    // 直接返回不请求；等下方 effect 依赖里的 selectedWorkspace 就绪后自动重跑补拉。
+    // 不能回退到 0——record 归属真实 ws，用 0 请求会 403 触发空态。
+    const wsId = state.selectedWorkspace;
+    if (wsId == null) return;
     setLoading(true);
     try {
-      // v1 纯 workspace-scoped：execution 查询需 workspaceId
-      const wsId = state.selectedWorkspace ?? 0;
       // 1. 获取目标记录
       const targetRecord = await db.getExecutionRecord(wsId, id);
       // 2. 如果有 session_id，拉取同 session 的所有记录
@@ -91,8 +95,11 @@ export function TodoPostPage({
   };
 
   useEffect(() => {
+    // 依赖里加入 selectedWorkspace：冷启动直达帖子页时 ws 尚未解析（null），
+    // loadSessionRecords 提前返回不请求；DataLoader 解析出 workspace 后本 effect
+    // 因依赖变化重跑，自动补拉同 session 记录，避免首帧用 ws=0 请求 403 空态。
     loadSessionRecords();
-  }, [recordId]);
+  }, [recordId, state.selectedWorkspace]);
 
   // 加载日志
   const loadLogsForRecord = async (rId: number, page: number) => {

--- a/frontend/src/hooks/useViewState.test.ts
+++ b/frontend/src/hooks/useViewState.test.ts
@@ -1,0 +1,40 @@
+// useViewState 的 URL 构建逻辑单测（buildHashUrl 为纯函数，无 window 依赖）。
+// 覆盖本次新增：帖子页返回来源编码（?from=task&taskId=）与 tasks 视图 ?tab= 支持。
+
+import { describe, expect, it } from 'vitest';
+import { buildHashUrl } from './useViewState';
+
+describe('buildHashUrl 帖子页返回来源', () => {
+  it('test_buildHashUrl_post_without_back_source_returns_plain_url', () => {
+    // 无 postBack：事项侧进入帖子页，URL 不带返回来源 query（默认返回事项详情）
+    expect(buildHashUrl('todos', { id: 7, recordId: 7 })).toBe('#/todos/7/posts/7');
+  });
+
+  it('test_buildHashUrl_post_from_task_appends_from_query', () => {
+    // 从任务-讨论 tab 跳入帖子页：URL 带 ?from=task&taskId=，返回按钮据此回任务讨论 tab
+    expect(buildHashUrl('todos', { id: 7, recordId: 7, postBack: 'task', postBackTaskId: 5 }))
+      .toBe('#/todos/7/posts/7?from=task&taskId=5');
+  });
+
+  it('test_buildHashUrl_post_with_task_back_but_missing_task_id_omits_query', () => {
+    // 来源声明了 task 但 taskId 缺失：不追加 query，避免生成残缺 URL
+    expect(buildHashUrl('todos', { id: 7, recordId: 7, postBack: 'task' })).toBe('#/todos/7/posts/7');
+  });
+
+  it('test_buildHashUrl_post_with_todo_back_source_omits_query', () => {
+    // postBack='todo' 显式声明事项来源：与缺省一致，不带 query
+    expect(buildHashUrl('todos', { id: 7, recordId: 7, postBack: 'todo' })).toBe('#/todos/7/posts/7');
+  });
+});
+
+describe('buildHashUrl tasks 视图 tab 参数', () => {
+  it('test_buildHashUrl_task_with_tab_appends_tab_query', () => {
+    // 帖子页返回任务讨论 tab 的落点：/#/tasks/:id?tab=discussion
+    expect(buildHashUrl('tasks', { id: 5, tab: 'discussion' })).toBe('#/tasks/5?tab=discussion');
+  });
+
+  it('test_buildHashUrl_task_without_tab_stays_plain', () => {
+    expect(buildHashUrl('tasks', { id: 5 })).toBe('#/tasks/5');
+    expect(buildHashUrl('tasks')).toBe('#/tasks');
+  });
+});

--- a/frontend/src/hooks/useViewState.test.ts
+++ b/frontend/src/hooks/useViewState.test.ts
@@ -2,7 +2,7 @@
 // 覆盖本次新增：帖子页返回来源编码（?from=task&taskId=）与 tasks 视图 ?tab= 支持。
 
 import { describe, expect, it } from 'vitest';
-import { buildHashUrl } from './useViewState';
+import { buildHashUrl, parsePostBackFrom } from './useViewState';
 
 describe('buildHashUrl 帖子页返回来源', () => {
   it('test_buildHashUrl_post_without_back_source_returns_plain_url', () => {
@@ -36,5 +36,27 @@ describe('buildHashUrl tasks 视图 tab 参数', () => {
   it('test_buildHashUrl_task_without_tab_stays_plain', () => {
     expect(buildHashUrl('tasks', { id: 5 })).toBe('#/tasks/5');
     expect(buildHashUrl('tasks')).toBe('#/tasks');
+  });
+});
+
+describe('parsePostBackFrom 返回来源解析', () => {
+  it('test_parsePostBackFrom_task_with_valid_id_returns_task', () => {
+    expect(parsePostBackFrom(new URLSearchParams('from=task&taskId=5'))).toEqual({ from: 'task', taskId: 5 });
+  });
+
+  it('test_parsePostBackFrom_task_missing_id_falls_back_to_todo', () => {
+    // from=task 但缺 taskId：来源无效，回退事项详情
+    expect(parsePostBackFrom(new URLSearchParams('from=task'))).toEqual({ from: 'todo', taskId: null });
+  });
+
+  it('test_parsePostBackFrom_task_invalid_id_falls_back_to_todo', () => {
+    // taskId 非数字（NaN）→ 回退；非正数（0）→ 回退
+    expect(parsePostBackFrom(new URLSearchParams('from=task&taskId=abc'))).toEqual({ from: 'todo', taskId: null });
+    expect(parsePostBackFrom(new URLSearchParams('from=task&taskId=0'))).toEqual({ from: 'todo', taskId: null });
+  });
+
+  it('test_parsePostBackFrom_without_from_returns_todo', () => {
+    // 无 from 参数（或无关 query 如 ?tab=）→ 默认事项来源
+    expect(parsePostBackFrom(new URLSearchParams('tab=discussion'))).toEqual({ from: 'todo', taskId: null });
   });
 });

--- a/frontend/src/hooks/useViewState.ts
+++ b/frontend/src/hooks/useViewState.ts
@@ -169,11 +169,21 @@ function getInitialPostRecordId(): number | null {
 }
 
 /**
+ * 是否为帖子页 URL：path 段 `todos/:id/posts/:rid`。
+ * 帖子页返回来源（?from=task&taskId=）只在该 URL 形态下有意义，
+ * todos 列表/详情即使带 ?from= 也应忽略，避免无关 query 污染状态。
+ */
+function isTodosPostUrl(): boolean {
+  const segs = getHashPathSegments();
+  return segs[0] === 'todos' && segs[2] === 'posts';
+}
+
+/**
  * 从 query 解析帖子页返回来源。
  * `from=task&taskId=<id>` → 从任务-讨论 tab 跳入，返回时回到该任务讨论 tab；
  * 否则默认 'todo'（返回事项详情）。taskId 非法（非正数）时视为无效来源。
  */
-function parsePostBackFrom(params: URLSearchParams): { from: 'todo' | 'task'; taskId: number | null } {
+export function parsePostBackFrom(params: URLSearchParams): { from: 'todo' | 'task'; taskId: number | null } {
   if (params.get('from') !== 'task') return { from: 'todo', taskId: null };
   const raw = params.get('taskId');
   const n = Number(raw);
@@ -353,12 +363,12 @@ export function useViewState() {
   const [loopDetailId, setLoopDetailId] = useState<number | null>(getInitialLoopDetailId);
   const [taskDetailId, setTaskDetailId] = useState<number | null>(getInitialTaskDetailId);
   const [postRecordId, setPostRecordId] = useState<number | null>(getInitialPostRecordId);
-  // 帖子页返回来源：from=task 时回到对应任务讨论 tab，否则回事项详情
+  // 帖子页返回来源：仅帖子页 URL 解析 ?from=task，其他视图一律 'todo'（回事项详情）
   const [postBackFrom, setPostBackFrom] = useState<'todo' | 'task'>(
-    () => parsePostBackFrom(getHashSearchParams()).from,
+    () => (isTodosPostUrl() ? parsePostBackFrom(getHashSearchParams()).from : 'todo'),
   );
   const [postBackTaskId, setPostBackTaskId] = useState<number | null>(
-    () => parsePostBackFrom(getHashSearchParams()).taskId,
+    () => (isTodosPostUrl() ? parsePostBackFrom(getHashSearchParams()).taskId : null),
   );
   const [activeTab, setActiveTab] = useState<string | null>(getInitialTab);
   const [boardMode, setBoardMode] = useState<BoardMode>(getInitialBoardMode);
@@ -432,13 +442,15 @@ export function useViewState() {
    */
   const backToList = useCallback(() => {
     // 帖子页返回：区分来源——从任务-讨论 tab 跳入则回到该任务的讨论 tab，
-    // 否则回父事项详情（保留列表状态恢复策略）
+    // 否则回父事项详情（保留列表状态恢复策略）。
+    // 统一用 replaceUrl：与桌面端 TodoPostPage onBack 一致，避免 pushUrl 在
+    // 「帖子页 → 来源页」之间留下多余 history 条目（浏览器后退不会回到帖子页）。
     if (activeView === 'todos' && todoDetailId != null && postRecordId != null) {
       if (postBackFrom === 'task' && postBackTaskId != null) {
-        pushUrl('tasks', { id: postBackTaskId, tab: 'discussion' });
+        replaceUrl('tasks', { id: postBackTaskId, tab: 'discussion' });
         return;
       }
-      pushUrl('todos', { id: todoDetailId });
+      replaceUrl('todos', { id: todoDetailId });
       return;
     }
     // 事项/环路/任务详情返回列表
@@ -571,10 +583,12 @@ function syncFromHash(setters: {
   // todos/loops/tasks 详情 id 仅在对应 view 下提取，避免跨视图串台
   setters.setTodoDetailId(view === 'todos' ? getPathIdAt(segments, 1) : null);
   setters.setPostRecordId(view === 'todos' && segments[2] === 'posts' ? getPathIdAt(segments, 3) : null);
-  // 帖子页返回来源：仅 todos 帖子 URL 解析 ?from=task&taskId=，其他视图一律清空
+  // 帖子页返回来源：仅 todos 帖子 URL 解析 ?from=task&taskId=，
+  // 列表/详情/其他视图一律清空（回事项详情默认分支）
+  const isPost = view === 'todos' && segments[2] === 'posts';
   const postBack = parsePostBackFrom(params);
-  setters.setPostBackFrom(view === 'todos' ? postBack.from : 'todo');
-  setters.setPostBackTaskId(view === 'todos' ? postBack.taskId : null);
+  setters.setPostBackFrom(isPost ? postBack.from : 'todo');
+  setters.setPostBackTaskId(isPost ? postBack.taskId : null);
   setters.setLoopDetailId(view === 'loops' ? getPathIdAt(segments, 1) : null);
   setters.setTaskDetailId(view === 'tasks' ? getPathIdAt(segments, 1) : null);
   setters.setActiveTab(tab || null);

--- a/frontend/src/hooks/useViewState.ts
+++ b/frontend/src/hooks/useViewState.ts
@@ -168,6 +168,19 @@ function getInitialPostRecordId(): number | null {
   return getPathIdAt(segs, 3);
 }
 
+/**
+ * 从 query 解析帖子页返回来源。
+ * `from=task&taskId=<id>` → 从任务-讨论 tab 跳入，返回时回到该任务讨论 tab；
+ * 否则默认 'todo'（返回事项详情）。taskId 非法（非正数）时视为无效来源。
+ */
+function parsePostBackFrom(params: URLSearchParams): { from: 'todo' | 'task'; taskId: number | null } {
+  if (params.get('from') !== 'task') return { from: 'todo', taskId: null };
+  const raw = params.get('taskId');
+  const n = Number(raw);
+  const taskId = raw && Number.isFinite(n) && n > 0 ? n : null;
+  return { from: taskId != null ? 'task' : 'todo', taskId };
+}
+
 function getInitialTab(): string | null {
   const params = getHashSearchParams();
   const tab = params.get('tab');
@@ -217,6 +230,13 @@ interface NavOpts {
   id?: number | null;
   /** 帖子记录 id（todos 用，构造 /todos/:id/posts/:recordId）。 */
   recordId?: number | null;
+  /**
+   * 帖子页返回来源：`'task'` = 从任务-讨论 tab 跳入，帖子 URL 带 `?from=task&taskId=`，
+   * 返回按钮据此回到该任务的讨论 tab；`'todo'`/缺省 = 返回事项详情。
+   */
+  postBack?: 'todo' | 'task' | null;
+  /** postBack='task' 时返回的目标任务 id。 */
+  postBackTaskId?: number | null;
   tab?: string | null;
   mode?: BoardMode;
   workspace?: number | null;
@@ -240,11 +260,17 @@ interface NavOpts {
  * - todos/loops 用 path 段（/todos、/todos/:id、/todos/:id/posts/:rid、/loops、/loops/:id）
  * - 其他视图用 query 参数（与 028 之前一致）
  */
-function buildHashUrl(view: View, opts?: NavOpts): string {
+export function buildHashUrl(view: View, opts?: NavOpts): string {
   // 事项命名空间：path 段驱动
   if (view === 'todos') {
     if (opts?.id != null && opts?.recordId != null) {
-      return `#/todos/${opts.id}/posts/${opts.recordId}`;
+      // 帖子页 URL。从任务-讨论 tab 跳入时带返回来源 query（?from=task&taskId=），
+      // 帖子页返回按钮据此回到对应任务的讨论 tab；否则默认返回事项详情。
+      let url = `#/todos/${opts.id}/posts/${opts.recordId}`;
+      if (opts?.postBack === 'task' && opts?.postBackTaskId != null) {
+        url += `?from=task&taskId=${opts.postBackTaskId}`;
+      }
+      return url;
     }
     if (opts?.id != null) {
       return `#/todos/${opts.id}`;
@@ -258,10 +284,12 @@ function buildHashUrl(view: View, opts?: NavOpts): string {
     }
     return `#/loops`;
   }
-  // 任务命名空间：path 段驱动，与 todos/loops 一致
+  // 任务命名空间：path 段驱动，与 todos/loops 一致。
+  // 支持 ?tab= query：帖子页返回任务-讨论 tab 时据此恢复 Tabs 选中态（对齐 Settings 页模式）。
   if (view === 'tasks') {
     if (opts?.id != null) {
-      return `#/tasks/${opts.id}`;
+      const qs = typeof opts.tab === 'string' && opts.tab.trim() ? `?tab=${opts.tab}` : '';
+      return `#/tasks/${opts.id}${qs}`;
     }
     return `#/tasks`;
   }
@@ -325,6 +353,13 @@ export function useViewState() {
   const [loopDetailId, setLoopDetailId] = useState<number | null>(getInitialLoopDetailId);
   const [taskDetailId, setTaskDetailId] = useState<number | null>(getInitialTaskDetailId);
   const [postRecordId, setPostRecordId] = useState<number | null>(getInitialPostRecordId);
+  // 帖子页返回来源：from=task 时回到对应任务讨论 tab，否则回事项详情
+  const [postBackFrom, setPostBackFrom] = useState<'todo' | 'task'>(
+    () => parsePostBackFrom(getHashSearchParams()).from,
+  );
+  const [postBackTaskId, setPostBackTaskId] = useState<number | null>(
+    () => parsePostBackFrom(getHashSearchParams()).taskId,
+  );
   const [activeTab, setActiveTab] = useState<string | null>(getInitialTab);
   const [boardMode, setBoardMode] = useState<BoardMode>(getInitialBoardMode);
   const [wikiSlug, setWikiSlug] = useState<string | null>(getInitialWikiSlug);
@@ -337,6 +372,7 @@ export function useViewState() {
   // setters 集中传入 syncFromHash，避免每个回调都重复一遍
   const setters = {
     setActiveView, setTodoDetailId, setLoopDetailId, setTaskDetailId, setPostRecordId,
+    setPostBackFrom, setPostBackTaskId,
     setActiveTab, setBoardMode, setWikiSlug, setBlackboardFile, setProcessGuid, setProcessMode,
   };
 
@@ -395,8 +431,13 @@ export function useViewState() {
    *   - 其他视图                       → 该视图根路径
    */
   const backToList = useCallback(() => {
-    // 帖子页优先返回父事项详情（保留列表状态恢复策略）
+    // 帖子页返回：区分来源——从任务-讨论 tab 跳入则回到该任务的讨论 tab，
+    // 否则回父事项详情（保留列表状态恢复策略）
     if (activeView === 'todos' && todoDetailId != null && postRecordId != null) {
+      if (postBackFrom === 'task' && postBackTaskId != null) {
+        pushUrl('tasks', { id: postBackTaskId, tab: 'discussion' });
+        return;
+      }
       pushUrl('todos', { id: todoDetailId });
       return;
     }
@@ -405,7 +446,7 @@ export function useViewState() {
     if (activeView === 'loops') { replaceUrl('loops'); return; }
     if (activeView === 'tasks') { replaceUrl('tasks'); return; }
     pushUrl(activeView);
-  }, [activeView, todoDetailId, postRecordId, pushUrl, replaceUrl]);
+  }, [activeView, todoDetailId, postRecordId, postBackFrom, postBackTaskId, pushUrl, replaceUrl]);
 
   // MobileHeader 需要知道当前是否处于「详情态」以决定返回按钮显隐；
   // 由 todoDetailId/loopDetailId/taskDetailId 派生，保持兼容旧 activePanel: 'detail' | 'list' 接口。
@@ -423,6 +464,9 @@ export function useViewState() {
     loopDetailId,
     taskDetailId,
     postRecordId,
+    // 帖子页返回来源（from=task 时返回对应任务讨论 tab）
+    postBackFrom,
+    postBackTaskId,
     // 派生：仅用于 MobileHeader 返回按钮显隐
     activePanel,
     activeTab,
@@ -455,6 +499,8 @@ function syncStateFromOptions(
     setLoopDetailId: (id: number | null) => void;
     setTaskDetailId: (id: number | null) => void;
     setPostRecordId: (id: number | null) => void;
+    setPostBackFrom: (f: 'todo' | 'task') => void;
+    setPostBackTaskId: (id: number | null) => void;
     setActiveTab: (t: string | null) => void;
     setBoardMode: (m: BoardMode) => void;
     setWikiSlug: (s: string | null) => void;
@@ -465,12 +511,16 @@ function syncStateFromOptions(
 ): void {
   const {
     setActiveView, setTodoDetailId, setLoopDetailId, setTaskDetailId, setPostRecordId,
+    setPostBackFrom, setPostBackTaskId,
     setActiveTab, setBoardMode, setWikiSlug, setBlackboardFile, setProcessGuid, setProcessMode,
   } = setters;
   setActiveView(view);
   // todos: id+recordId 表示帖子页；仅 id 表示详情；都没有表示列表
   setTodoDetailId(view === 'todos' ? (opts?.id ?? null) : null);
   setPostRecordId(view === 'todos' ? (opts?.recordId ?? null) : null);
+  // 帖子页返回来源只在 todos 帖子 URL 上有意义；其他视图一律清空（回事项详情默认分支）
+  setPostBackFrom(view === 'todos' && opts?.postBack === 'task' ? 'task' : 'todo');
+  setPostBackTaskId(view === 'todos' && opts?.postBack === 'task' ? (opts?.postBackTaskId ?? null) : null);
   setLoopDetailId(view === 'loops' ? (opts?.id ?? null) : null);
   setTaskDetailId(view === 'tasks' ? (opts?.id ?? null) : null);
   setActiveTab(opts?.tab ?? null);
@@ -494,6 +544,8 @@ function syncFromHash(setters: {
   setLoopDetailId: (id: number | null) => void;
   setTaskDetailId: (id: number | null) => void;
   setPostRecordId: (id: number | null) => void;
+  setPostBackFrom: (f: 'todo' | 'task') => void;
+  setPostBackTaskId: (id: number | null) => void;
   setActiveTab: (t: string | null) => void;
   setBoardMode: (m: BoardMode) => void;
   setWikiSlug: (s: string | null) => void;
@@ -519,6 +571,10 @@ function syncFromHash(setters: {
   // todos/loops/tasks 详情 id 仅在对应 view 下提取，避免跨视图串台
   setters.setTodoDetailId(view === 'todos' ? getPathIdAt(segments, 1) : null);
   setters.setPostRecordId(view === 'todos' && segments[2] === 'posts' ? getPathIdAt(segments, 3) : null);
+  // 帖子页返回来源：仅 todos 帖子 URL 解析 ?from=task&taskId=，其他视图一律清空
+  const postBack = parsePostBackFrom(params);
+  setters.setPostBackFrom(view === 'todos' ? postBack.from : 'todo');
+  setters.setPostBackTaskId(view === 'todos' ? postBack.taskId : null);
   setters.setLoopDetailId(view === 'loops' ? getPathIdAt(segments, 1) : null);
   setters.setTaskDetailId(view === 'tasks' ? getPathIdAt(segments, 1) : null);
   setters.setActiveTab(tab || null);


### PR DESCRIPTION
## 现象

访问 `http://localhost:18088/#/todos/7/posts/7`（讨论区帖子页）显示「暂无执行记录」，而非实际讨论内容。

## 根因（两个独立 bug 叠加）

### 根因 1：后端 session 查询（#987 遗留缺口）
`get_execution_records_by_session` 仍用旧的「todos 子查询」过滤 workspace：
`session_id = ? AND todo_id IN (SELECT id FROM todos WHERE workspace_id=? AND deleted_at IS NULL)`

060 讨论执行完成会**软删 carrier todo** → 子查询排除它 → session 接口返回空 → 前端空态。

#987 已给 `execution_records` 加 `workspace_id` 列（v89）并让**单条归属校验**直接用它，但 **session 查询没跟上**，仍是遗留缺口。

### 根因 2：前端冷启动 workspace 未解析
`TodoPostPage` 用 `state.selectedWorkspace ?? 0`，深链直达时 workspace 还是 `null` → 请求 `workspaces/0/executions/7` → **403** 空态；且 effect 只依赖 `[recordId]`，workspace 就绪后不重跑。

## 修复

### Commit 1 — 帖子页空态
| 层 | 改动 |
|----|------|
| 后端 | `get_execution_records_by_session` 改用 `execution_records.workspace_id` 直接过滤，与 #987 归属解耦方案对齐；跨 ws 隔离语义不变 |
| 前端 | `loadSessionRecords` 加 null 守卫（不再回退到 0）；effect 依赖补 `state.selectedWorkspace`（对齐 `TodoDetail` 既有模式） |

### Commit 2 — 帖子页返回按钮区分来源
帖子页（`/#/todos/:id/posts/:rid`）返回按钮此前固定回事项详情，从**任务-讨论 tab**的「执行明细」跳入时也回事项详情，与来源不符。改为**从哪里来回哪里去**：
- `useViewState`：帖子 URL 编码返回来源（`postBack='task'` → `?from=task&taskId=`），`tasks` 视图支持 `?tab=`；`backToList` 按来源分派
- `DiscussionTab`：「执行明细」跳转带 `postBack='task'` + `postBackTaskId`
- `App.tsx`：帖子页 `onBack` 按来源分派——task → 回任务讨论 tab，否则回事项详情
- `TaskDetailPanel`：Tabs 改 URL 驱动（`activeKey` 读 `?tab=`，onChange `replaceUrl` 写回不压历史）

## 验证

- `cargo clippy --all-targets -- -D warnings`：零告警
- `cargo test` 全量：0 failed（含新增 `session_query_tests` 2 例，先 RED 复现再 GREEN）
- `npx tsc --noEmit`：零错误
- vitest：新增 `buildHashUrl` + `parsePostBackFrom` 共 10 例单测通过
- agent-browser 实测：
  - 冷启动直达帖子页 → 正常渲染讨论内容，网络无 ws=0 403
  - 任务-讨论 → 执行明细 → 返回 → 落在该任务讨论 tab
  - 事项详情 → 执行记录 → 返回 → 回事项详情
  - 深链刷新 `?from=task` 后返回仍正确回任务讨论 tab
  - tab 切换 `replaceUrl` 不压浏览器历史（`history.length` 不变）

## 安全反思

- 跨 ws 隔离保留（`record.workspace_id` 必须等于请求 ws），新增单测覆盖越权场景
- `workspace_id IS NULL` 旧数据按未归属处理（与 verify 契约一致）
- session_id 走 SeaORM 参数绑定，无注入面
- 列表/running 查询未改动（「已删 todo 记录是否入列表」属独立产品决策，不在本次范围）
- 返回来源仅存于 URL query，手工构造可跳到不存在任务（空态引导），不涉及数据越权
