### PR TITLE
feat(092): 任务委派执行 P2——自动接力 + continue_rounds 护栏 + 管家调度徽标

### DIFF
--- a/backend/src/db/task.rs
+++ b/backend/src/db/task.rs
@@ -134,3 +134,52 @@ impl Database {
         Ok(res.rows_affected)
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    /// 全新内存库（跑完所有迁移 + 种子）。
+    async fn fresh_db() -> Database {
+        Database::new(":memory:").await.expect("memory db must open")
+    }
+
+    /// increment_continue_rounds：从 0（委派任务初始）递增到 1、2，
+    /// 校验 read-modify-write 正确落库且每次返回递增后的新值。
+    #[tokio::test]
+    async fn test_increment_continue_rounds_increments_and_persists() {
+        let db = fresh_db().await;
+        // 委派任务建表即写 continue_rounds=0，是接力的真实载体，用它验证最贴近生产路径。
+        let task = db
+            .create_delegate_task("接力任务T", 1, "expert", "专家A", true)
+            .await
+            .expect("create delegate task");
+        assert_eq!(task.continue_rounds, 0, "新建委派任务初始计数应为 0");
+
+        // 第一轮 +1 → 1，并实际落库（get 回读校验，排除「只返回新值但没写库」的假阳性）。
+        let r1 = db.increment_continue_rounds(task.id).await.expect("increment #1");
+        assert_eq!(r1, 1);
+        assert_eq!(
+            db.get_task(task.id).await.expect("get").expect("task").continue_rounds,
+            1,
+            "递增后 DB 中应为 1"
+        );
+
+        // 第二轮 +1 → 2，验证不是幂等的「总是返回固定值」。
+        let r2 = db.increment_continue_rounds(task.id).await.expect("increment #2");
+        assert_eq!(r2, 2);
+    }
+
+    /// 任务不存在边界：返回 Ok(0)，调用方据此跳过接力（不报错、不 panic）。
+    /// 全新内存库无任何任务，999_999 必然缺失。
+    #[tokio::test]
+    async fn test_increment_continue_rounds_missing_task_returns_zero() {
+        let db = fresh_db().await;
+        let r = db
+            .increment_continue_rounds(999_999)
+            .await
+            .expect("missing task should not error");
+        assert_eq!(r, 0, "任务不存在时返回 0，调用方据此跳过接力");
+    }
+}

--- a/backend/src/db/task.rs
+++ b/backend/src/db/task.rs
@@ -152,7 +152,7 @@ mod tests {
         let db = fresh_db().await;
         // 委派任务建表即写 continue_rounds=0，是接力的真实载体，用它验证最贴近生产路径。
         let task = db
-            .create_delegate_task("接力任务T", 1, "expert", "专家A", true)
+            .create_delegate_task("接力任务T", "接力需求原文", 1, "expert", "专家A", true)
             .await
             .expect("create delegate task");
         assert_eq!(task.continue_rounds, 0, "新建委派任务初始计数应为 0");

--- a/backend/src/db/task.rs
+++ b/backend/src/db/task.rs
@@ -99,6 +99,25 @@ impl Database {
         Ok(())
     }
 
+    /// 自动接力轮数 +1 并返回递增后的新值（需求 092 P2 护栏用）。
+    ///
+    /// 采用 read-modify-write 而非 SQL 自增表达式：接力是顺序事件驱动的（上一轮完成
+    /// 回调才触发下一轮），同一任务的 continue_rounds 不存在并发递增，故无需原子自增；
+    /// 同时与本文件 update_task_status / update_task_description 的写法保持一致。
+    /// 任务不存在时返回 0（调用方据此跳过接力）。
+    pub async fn increment_continue_rounds(&self, id: i64) -> Result<i64, sea_orm::DbErr> {
+        let existing = tasks::Entity::find_by_id(id).one(&self.conn).await?;
+        let Some(task) = existing else {
+            return Ok(0);
+        };
+        let new_rounds = task.continue_rounds + 1;
+        let mut am: tasks::ActiveModel = task.into();
+        am.continue_rounds = ActiveValue::Set(new_rounds);
+        am.updated_at = ActiveValue::Set(Some(utc_timestamp()));
+        am.update(&self.conn).await?;
+        Ok(new_rounds)
+    }
+
     /// 硬删除单个任务。
     pub async fn delete_task(&self, id: i64) -> Result<(), sea_orm::DbErr> {
         tasks::Entity::delete_by_id(id).exec(&self.conn).await?;

--- a/backend/src/db/task_post.rs
+++ b/backend/src/db/task_post.rs
@@ -203,6 +203,21 @@ impl Database {
         Ok(1)
     }
 
+    /// 按 source_execution_id 取对应的智能体占位帖（需求 092 P2 自动接力用）。
+    ///
+    /// 一条讨论类执行只对应一条占位帖（trigger=discussion/discussion_auto）。completion
+    /// 回写后用此查询取回帖子的 task_id / expert_name / executor，供接力判断「本次执行者
+    /// 是否就是 assignee 管家」与定位所属委派任务。找不到（帖已删）返回 None，调用方跳过接力。
+    pub async fn get_task_post_by_source_execution(
+        &self,
+        record_id: i64,
+    ) -> Result<Option<task_posts::Model>, sea_orm::DbErr> {
+        task_posts::Entity::find()
+            .filter(task_posts::Column::SourceExecutionId.eq(record_id))
+            .one(&self.conn)
+            .await
+    }
+
     /// 硬删一条帖子（删 running 帖由调用方联动取消执行）。
     pub async fn delete_task_post(&self, id: i64) -> Result<u64, sea_orm::DbErr> {
         let res = task_posts::Entity::delete_by_id(id)

--- a/backend/src/db/task_post.rs
+++ b/backend/src/db/task_post.rs
@@ -632,5 +632,53 @@ mod tests {
         // 不存在的 id：静默 no-op，不报错（兜底分支）。
         db.soft_delete_todo(999999).await.expect("noop on missing");
     }
+
+    /// get_task_post_by_source_execution：按执行记录 id 反查占位帖。
+    /// 覆盖命中 / 未命中 / 与 source_execution_id=None 的人帖互不干扰（SQL NULL 不参与相等匹配，
+    /// 这是接力按 record 精确定位占位帖的前提）。
+    #[tokio::test]
+    async fn test_get_task_post_by_source_execution() {
+        let db = fresh_db().await;
+        let task_id = seed_task(&db).await;
+
+        // 占位帖带 source_execution_id=Some(42)（模拟 @ 触发 / 接力回写的 running 帖）。
+        let post = db
+            .create_task_post(NewPost {
+                task_id,
+                parent_post_id: None,
+                kind: KIND_AGENT,
+                author_name: "执行器A",
+                executor: Some("执行器A"),
+                expert_name: None,
+                content: "执行器A 正在干活…",
+                mentions_json: "[]",
+                status: STATUS_RUNNING,
+                source_execution_id: Some(42),
+                source_todo_id: None,
+            })
+            .await
+            .expect("create agent post");
+
+        // 命中：按 42 反查到刚建的占位帖。
+        let got = db
+            .get_task_post_by_source_execution(42)
+            .await
+            .expect("query")
+            .expect("post exists");
+        assert_eq!(got.id, post.id);
+        assert_eq!(got.source_execution_id, Some(42));
+
+        // 未命中：不存在的执行记录返回 None（帖已删 / 从未关联）。
+        assert!(db.get_task_post_by_source_execution(999).await.expect("query none").is_none());
+
+        // 区分：再建一条 source_execution_id=None 的普通人帖，按 42 仍只命中占位帖。
+        let _human = seed_main_post(&db, task_id, "普通人帖").await;
+        let only42 = db
+            .get_task_post_by_source_execution(42)
+            .await
+            .expect("query 42 again")
+            .expect("仍只命中占位帖");
+        assert_eq!(only42.id, post.id, "None 帖不应被 NULL 比较误中");
+    }
 }
 

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -393,6 +393,7 @@ pub(crate) async fn finalize_normal_completion(
     feishu_receive_id: Option<String>,
     feishu_receive_id_type: Option<String>,
     workspace_id: Option<i64>,
+    expert_manager: Option<Arc<crate::expert::ExpertIndexManager>>,
 ) {
     // ===== 自动评审 (auto-review) =====
     // 仅在以下条件同时满足时启动:
@@ -459,12 +460,31 @@ pub(crate) async fn finalize_normal_completion(
         }
     }
 
-    // ===== 讨论帖回写 (discussion) =====
-    // 任务讨论区 @触发的执行（trigger_type == "discussion"）：把结论回写到对应的智能体
-    // 占位帖，并软删载体 todo（隐藏兜底）。回写失败只记 warn，不影响执行本身的成功落定
-    // （帖子可由前端轮询兜底）。与 auto_review/blackboard 同级的并列分支，按 trigger_type 分派。
-    if trigger_type == "discussion" {
+    // ===== 讨论帖回写 (discussion / discussion_auto) =====
+    // 任务讨论区 @触发的执行（trigger_type ∈ {discussion, discussion_auto}）：把结论回写到
+    // 对应的智能体占位帖，并软删载体 todo（隐藏兜底）。回写失败只记 warn，不影响执行本身的
+    // 成功落定（帖子可由前端轮询兜底）。与 auto_review/blackboard 同级的并列分支，按 trigger_type 分派。
+    if trigger_type == "discussion" || trigger_type == "discussion_auto" {
         writeback_discussion_post(&db, &executor, record_id, success, &result_str).await;
+    }
+
+    // ===== 自动接力 (delegate relay，需求 092 P2) =====
+    // 仅讨论类执行（discussion/discussion_auto）成功后、且本路径持有专家索引时，尝试接力。
+    // continue_delegated_task 内部会再校验「delegate + auto_continue + 专家 assignee」，
+    // 不满足则静默跳过（环路任务 / 手动单跑 / 执行器委派都直接返回，零副作用）。
+    if success && (trigger_type == "discussion" || trigger_type == "discussion_auto") {
+        if let Some(em) = expert_manager {
+            let handles = crate::handlers::task_posts::DelegateRelayHandles {
+                db: &db,
+                executor_registry: &executor_registry,
+                tx: &tx,
+                task_manager: &task_manager,
+                config: &config,
+                expert_manager: &em,
+            };
+            crate::handlers::task_posts::continue_delegated_task(&handles, record_id, &result_str)
+                .await;
+        }
     }
 }
 

--- a/backend/src/executor_service/mod.rs
+++ b/backend/src/executor_service/mod.rs
@@ -124,6 +124,21 @@ pub async fn run_todo_execution(request: RunTodoExecutionRequest) -> ExecutionRe
     stages::dispatch_spawned_executor_task(spawned).await
 }
 
+/// 把 [`run_todo_execution`] 的 future 类型擦除为 `Pin<Box<dyn Future + Send>>`。
+///
+/// 存在意义（非可有可无）：completion 自动接力（需求 092 P2）会在 `finalize` 末段回调
+/// `continue_delegated_task → spawn_relay_execution → run_todo_execution`，而 `run_todo_execution`
+/// 内部又经 `dispatch → finalize` 回到接力，形成 coroutine 类型环。若接力处直接 `await`
+/// `run_todo_execution(...)`，编译器必须展开其 coroutine 类型，环即暴露、无法证明 Send
+/// （`error[E0391]: cycle detected`）。改调本包装：返回类型是 trait object，具体 coroutine
+/// 仅在本函数体内构造、不外泄到调用方的 coroutine 类型，环在此处终止。
+/// 适用前提：`run_todo_execution` 的 future 本身是 Send（它在 axum handler 中被 await，已满足）。
+pub fn run_todo_execution_boxed(
+    request: RunTodoExecutionRequest,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = ExecutionResult> + Send>> {
+    Box::pin(run_todo_execution(request))
+}
+
 /// Run a todo execution with parameter substitution.
 /// Replaces placeholders `{{key}}` in the message with corresponding values from params before execution.
 pub async fn run_todo_execution_with_params(

--- a/backend/src/executor_service/mod.rs
+++ b/backend/src/executor_service/mod.rs
@@ -151,3 +151,26 @@ pub async fn run_todo_execution_with_params(
     }
     run_todo_execution(request).await
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// run_todo_execution_boxed 的核心契约：返回类型擦除为 `Pin<Box<dyn Future + Send>>`。
+    /// 正是这条 Send 性质打破了「接力 → run_todo_execution → finalize → 接力」coroutine 类型环
+    /// （见其文档注释）。用编译期断言固化签名与 Send 约束——无需真实执行器即可验证此类型不变量；
+    /// 一旦有人改了返回类型（丢 `+ Send` / 改 `Output`），此处立即编译失败，锁死该包装的存在意义。
+    #[test]
+    fn run_todo_execution_boxed_returns_send_boxed_future() {
+        // 期望的返回类型：擦除后的 Send boxed future（与函数签名字面一致）。
+        type Ret = std::pin::Pin<Box<dyn std::future::Future<Output = ExecutionResult> + Send>>;
+
+        // 1) 该返回类型必须满足 Send：接力处 await 跨线程传递的硬性前提。
+        fn require_send<T: Send>() {}
+        require_send::<Ret>();
+
+        // 2) 函数指针精确匹配：run_todo_execution_boxed 的签名必须可赋值为
+        //    `fn(RunTodoExecutionRequest) -> Ret`，签名漂移则编译失败。
+        let _f: fn(RunTodoExecutionRequest) -> Ret = run_todo_execution_boxed;
+    }
+}

--- a/backend/src/executor_service/spawn_lifecycle.rs
+++ b/backend/src/executor_service/spawn_lifecycle.rs
@@ -503,6 +503,8 @@ async fn dispatch_completed(
             feishu_receive_id: runtime.feishu_receive_id,
             feishu_receive_id_type: runtime.feishu_receive_id_type,
             workspace_id: runtime.prepared.request.workspace_id,
+            // 092 P2：接力回写需要专家索引解析管家结论里的 @，从原 request 透传（Arc 浅克隆）。
+            expert_manager: runtime.prepared.request.expert_manager.clone(),
         },
     )
     .await;
@@ -677,6 +679,7 @@ pub(crate) async fn persist_and_finalize_completion(
         ctx.feishu_receive_id.clone(),
         ctx.feishu_receive_id_type.clone(),
         ctx.workspace_id,
+        ctx.expert_manager.clone(),
     )
     .await;
 }

--- a/backend/src/executor_service/types.rs
+++ b/backend/src/executor_service/types.rs
@@ -113,6 +113,9 @@ pub(crate) struct SpawnContext {
     pub feishu_receive_id_type: Option<String>,
     /// 工作空间 ID，用于 FeishuPushService 按 workspace 隔离推送目标
     pub workspace_id: Option<i64>,
+    /// 专家索引（需求 092 P2）：discussion_auto 接力回写时需要据此解析管家结论里的 @。
+    /// None 表示该执行路径无专家索引（与 RunTodoExecutionRequest.expert_manager 同源）。
+    pub expert_manager: Option<Arc<crate::expert::ExpertIndexManager>>,
 }
 
 /// select! 三种终态枚举，避免在三个分支里各重复「杀进程 + drain + finalize」

--- a/backend/src/handlers/task_posts.rs
+++ b/backend/src/handlers/task_posts.rs
@@ -830,7 +830,9 @@ fn plan_delegate_relay(
     x_is_assignee: bool,
     mentions: &[MentionDto],
 ) -> DelegateRelayAction {
-    if rounds > max {
+    // 护栏用 >=：continue_rounds 递增到 max 当轮即熔断，最多 max 轮接力（需求 AC8「达到 10 强制停止」）。
+    // 若用 >，rounds==max 不熔断、会放行第 max+1 跳，实际跑 max+1 轮（CodeRabbit #5）。
+    if rounds >= max {
         return DelegateRelayAction::HitLimit;
     }
     if x_is_assignee {
@@ -1121,11 +1123,19 @@ mod tests {
     use super::*;
     use crate::expert::{ExpertMetadata, ExpertSource, ExpertType};
 
-    /// plan_delegate_relay：轮数超上限 → HitLimit（护栏熔断，优先级最高）。
+    /// plan_delegate_relay：轮数达上限（rounds == max）即熔断 → HitLimit（护栏优先级最高）。
     #[test]
     fn test_plan_delegate_relay_hit_limit() {
-        let action = plan_delegate_relay(11, 10, true, &[]);
-        assert!(matches!(action, DelegateRelayAction::HitLimit));
+        // 刚好达上限：max == max 应立即熔断（>= 语义；若实现成 > 会漏过这一跳跑到 max+1 轮）。
+        assert!(matches!(
+            plan_delegate_relay(10, 10, true, &[]),
+            DelegateRelayAction::HitLimit
+        ));
+        // 超上限同样熔断。
+        assert!(matches!(
+            plan_delegate_relay(11, 10, false, &[]),
+            DelegateRelayAction::HitLimit
+        ));
     }
 
     /// 管家本人执行 + 结论含 @执行器/专家 → TriggerMention（接力下一跳）。
@@ -1154,8 +1164,8 @@ mod tests {
         assert!(matches!(action, DelegateRelayAction::WakeAssignee));
     }
 
-    /// 边界：rounds == max（未超）仍允许推进；> max 才熔断。
-    /// 体现「第 max 轮仍可触发一跳、max+1 轮强制停」的护栏语义。
+    /// 边界：rounds == max-1（未达上限）仍允许推进；rounds == max 才熔断。
+    /// 体现「最后一跳在 max-1 触发、达 max 当轮即停」的护栏语义（>= 口径，最多 max 轮）。
     #[test]
     fn test_plan_delegate_relay_boundary_at_max() {
         let with_mention = vec![MentionDto {
@@ -1163,18 +1173,18 @@ mod tests {
             name: "e".into(),
             display: "e".into(),
         }];
-        // rounds == max 不算超：管家含 @ → TriggerMention；无 @ → Finished。
+        // rounds == max-1 未达上限：管家含 @ → TriggerMention；无 @ → Finished。
         assert!(matches!(
-            plan_delegate_relay(10, 10, true, &with_mention),
+            plan_delegate_relay(9, 10, true, &with_mention),
             DelegateRelayAction::TriggerMention
         ));
         assert!(matches!(
-            plan_delegate_relay(10, 10, true, &[]),
+            plan_delegate_relay(9, 10, true, &[]),
             DelegateRelayAction::Finished
         ));
-        // rounds == max 但非管家 → 仍 WakeAssignee（护栏只管轮数，不管身份分支）。
+        // rounds == max-1 但非管家 → WakeAssignee（护栏只管轮数，不管身份分支）。
         assert!(matches!(
-            plan_delegate_relay(10, 10, false, &[]),
+            plan_delegate_relay(9, 10, false, &[]),
             DelegateRelayAction::WakeAssignee
         ));
     }

--- a/backend/src/handlers/task_posts.rs
+++ b/backend/src/handlers/task_posts.rs
@@ -623,8 +623,11 @@ pub async fn create_post(
 /// 补偿「执行在占位帖插入前就结束」的竞态：completion.rs 的 discussion 回写按
 /// `source_execution_id` 找占位帖，占位帖还没插入时会错过（返回 0）。这里在插入占位帖
 /// 之后复查 record 状态，若已非 running 则手动 finalize 回写，避免占位帖永久停在 running。
-async fn compensate_finished_execution(state: &AppState, record_id: i64) {
-    let Ok(Some(rec)) = state.db.get_execution_record(record_id).await else {
+/// 签名只取 `&Database`（它只用 `db`）而非 `&AppState`：这样 completion 接力路径
+/// （`spawn_relay_execution` 手里只有 `DelegateRelayHandles` 的 Arc 句柄、没有 AppState）
+/// 也能复用同一补偿逻辑，避免 060 人工触发与 092 接力两处各写一遍竞态补偿。
+async fn compensate_finished_execution(db: &Database, record_id: i64) {
+    let Ok(Some(rec)) = db.get_execution_record(record_id).await else {
         return;
     };
     // 仍 running：正常等 completion 回调即可，无需补偿。
@@ -634,8 +637,7 @@ async fn compensate_finished_execution(state: &AppState, record_id: i64) {
     let success = matches!(rec.status, ExecutionStatus::Success);
     // result/executor 从执行记录取，与 completion.rs 正常回写路径一致。
     let result = rec.result.unwrap_or_default();
-    if let Err(e) = state
-        .db
+    if let Err(e) = db
         .finalize_discussion_post(record_id, success, &result, rec.executor.as_deref())
         .await
     {
@@ -719,7 +721,7 @@ async fn create_agent_post(
             // 补偿极快完成的执行：trigger 与 insert 占位帖之间若执行已结束，completion.rs 的
             // discussion 回写会错过（此时占位帖刚插入）→ 占位帖永久 running。插入后复查 record，
             // 已结束则手动回写。
-            compensate_finished_execution(state, record_id).await;
+            compensate_finished_execution(state.db.as_ref(), record_id).await;
             post_val
         }
         Err(e) => {
@@ -1046,6 +1048,12 @@ async fn spawn_relay_execution(
             if let Err(e) = handles.db.create_task_post(np).await {
                 tracing::warn!(error = %e, task_id = task.id, "relay insert placeholder failed");
             }
+            // 竞态补偿：run_todo_execution 是 fire-and-forget（spawn 后立刻返回 record_id），
+            // 与 060 的 create_agent_post 同构——若执行在「返回 record_id」与「占位帖插入」之间
+            // 已结束，completion 的 discussion 回写会错过此刻还不存在的占位帖 → 永久 running。
+            // 插入后复查 record 状态，已结束则手动回写。（此竞态下接力轮被跳过，遵循失败容忍
+            // 哲学：用户可在讨论区手动 @ 推进，不阻断已落定的执行成功。）
+            compensate_finished_execution(handles.db.as_ref(), record_id).await;
         }
         None => {
             // 启动失败：软删 carrier todo + 写 failed 帖留痕（不阻塞接力链路已落定的部分）。

--- a/backend/src/handlers/task_posts.rs
+++ b/backend/src/handlers/task_posts.rs
@@ -7,26 +7,37 @@
 //!   → 写 running 占位帖」；执行完成时由 completion.rs 的 discussion 分支回写结论。
 //! - 执行系统是 Todo 中心的，必须借载体 Todo 承载 executor/prompt/expert_name。
 
+use std::sync::{Arc, RwLock};
+
 use axum::extract::{Path, Query, State};
 use axum::routing::get;
 use axum::Json;
 use axum::Router;
 use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
 
-use crate::adapters::find_executor;
+use crate::adapters::{find_executor, ExecutorRegistry};
+use crate::config::Config;
 use crate::db::Database;
 use crate::db::entity::{task_posts, tasks};
 use crate::db::task_post::{
-    NewPost, KIND_AGENT, KIND_HUMAN, STATUS_FAILED, STATUS_RUNNING,
+    NewPost, KIND_AGENT, KIND_HUMAN, STATUS_FAILED, STATUS_RUNNING, STATUS_SUCCESS,
 };
-use crate::executor_service::RunTodoExecutionRequest;
+use crate::expert::ExpertIndexManager;
+use crate::executor_service::{run_todo_execution_boxed, ExecEvent, RunTodoExecutionRequest};
 use crate::handlers::execution::start_todo_execution;
 use crate::handlers::{AppError, AppState};
 use crate::models::{ApiResponse, ExecutionStatus};
+use crate::task_manager::TaskManager;
 
 /// 讨论触发用的 trigger_type：completion.rs 据此回写智能体占位帖。
 /// 委派任务首帖也复用此值（首帖等同人工 @ 触发）；自动接力（P2）用 "discussion_auto"。
 pub(crate) const TRIGGER_DISCUSSION: &str = "discussion";
+
+/// 自动接力专用 trigger_type（需求 092 P2）：管家调度触发的执行用此值。
+/// completion.rs 对 discussion / discussion_auto 同样走讨论回写，并由 delegate_relay
+/// 推进下一轮接力；与人工 discussion 区分，便于日志/统计与防递归识别。
+pub(crate) const TRIGGER_DISCUSSION_AUTO: &str = "discussion_auto";
 
 /// 内联到 carrier prompt 的最近主楼层数；平衡「上下文充分」与「prompt 体积」。
 /// 被 @ 的 AI 既能看到即时上下文，又可用 ntd 命令拉取更多，故取较小的 5。
@@ -122,11 +133,18 @@ fn serialize_mentions(mentions: &[MentionDto]) -> String {
 
 /// 解析 @token 为结构化提及：先专家后执行器；都不中则忽略（当普通文本）。
 /// 同名歧义按需求§10/设计§6.4「先专家后执行器」消歧——单 token 的判定交给 [`classify_mention`]。
-async fn resolve_mentions(tokens: &[String], state: &AppState) -> Vec<MentionDto> {
+///
+/// 入参只取 `expert_manager`（不耦合整个 AppState）：一是本函数仅用它查专家，二是
+/// 需求 092 P2 的 completion 自动接力要复用同一份解析逻辑（那边只有 Arc 组件、无 AppState），
+/// 拆参后人工发帖与自动接力共用，零解析逻辑漂移。
+pub(crate) async fn resolve_mentions(
+    tokens: &[String],
+    expert_manager: &crate::expert::ExpertIndexManager,
+) -> Vec<MentionDto> {
     let mut out: Vec<MentionDto> = Vec::new();
     for tok in tokens {
         // get_expert_by_name 是 parking_lot 同步读；命中结果交给纯函数分类，保持本函数薄。
-        let expert = state.expert_manager.get_expert_by_name(tok);
+        let expert = expert_manager.get_expert_by_name(tok);
         if let Some(m) = classify_mention(tok, expert.as_ref()) {
             out.push(m);
         }
@@ -252,10 +270,11 @@ fn truncate_chars(s: &str, max_chars: usize) -> String {
 
 /// 按 workspace_id 反查项目目录；查不到或失败返回空串（执行器降级用默认 workspace）。
 /// 任务表不存 workspace_path，必须经此查 workspace 表补齐执行所需的真实路径。
-async fn resolve_ws_path(state: &AppState, ws_id: i64) -> String {
-    state
-        .db
-        .get_project_directory_by_id(ws_id)
+///
+/// 入参只取 `db`（不耦合 AppState）：需求 092 P2 的自动接力在 completion 路径触发，那边
+/// 只有 Arc<Database>、无 AppState；拆参后人工 @ 触发与自动接力共用同一份路径解析。
+async fn resolve_ws_path(db: &Database, ws_id: i64) -> String {
+    db.get_project_directory_by_id(ws_id)
         .await
         .ok()
         .flatten()
@@ -283,7 +302,7 @@ async fn trigger_discussion_execution(
     let expert_name = first_expert(mentions);
     let ws_id = task.workspace_id.unwrap_or(1);
     // 任务表不存 workspace_path，按 workspace_id 反查项目目录取真实路径（执行需要）。
-    let ws_path = resolve_ws_path(state, ws_id).await;
+    let ws_path = resolve_ws_path(state.db.as_ref(), ws_id).await;
     let title = format!("讨论触发 @{}", agent_author(mentions));
     let todo_id = state
         .db
@@ -525,7 +544,7 @@ pub(crate) async fn land_mention_post(
 ) -> Result<(serde_json::Value, Option<serde_json::Value>), AppError> {
     // 解析 @token 为结构化提及（先专家后执行器）；纯文本无 @ 时为空，仅写人帖、不触发执行。
     let tokens = extract_at_tokens(content);
-    let mut mentions = resolve_mentions(&tokens, state).await;
+    let mut mentions = resolve_mentions(&tokens, &state.expert_manager).await;
     // 强制触发目标注入：assignee 已校验存在，确保即便其名含空格/标点也一定能命中触发。
     if let Some(m) = force_mention {
         if !mentions.iter().any(|x| x.kind == m.kind && x.name == m.name) {
@@ -772,6 +791,319 @@ async fn validate_reply_parent(
 }
 
 // ---------------------------------------------------------------------------
+// 自动接力（需求 092 P2：管家调度中枢）
+// ---------------------------------------------------------------------------
+//
+// 接力中枢规则（设计 §5.2）：assignee 管家专家是调度中枢。每次讨论类执行
+// （trigger=discussion / discussion_auto）完成、回写结论帖之后，若任务为 delegate +
+// auto_continue + 专家 assignee，按「本次执行者是否就是 assignee」分两个子分支：
+//   - 是管家（@专家帖的 expert_name == assignee）→ 解析其结论里的 @：
+//       含 @yyy → 触发 yyy 执行（接力下一跳）；不含 @ → 管家判定完成，写说明帖终止。
+//   - 不是管家（被@者完成）→ 唤醒 assignee 管家决策下一步。
+// 护栏：continue_rounds 每轮 +1，达 MAX_DELEGATE_ROUNDS 强制停。循环由此有界，不会无限递归。
+
+/// 自动接力轮数硬上限（护栏）。集中常量便于将来演进为可配置（需求 §3 暂不做成本上限）。
+pub(crate) const MAX_DELEGATE_ROUNDS: i64 = 10;
+
+/// 接力纯决策结果：把「读库 + 计数」与「触发执行/写帖」解耦，纯决策可单测覆盖全部分支。
+enum DelegateRelayAction {
+    /// 已达轮数上限 → 写「达上限」说明帖，停止接力。
+    HitLimit,
+    /// 管家判定完成（结论不含 @）→ 写「已完成」说明帖，循环自然终止。
+    Finished,
+    /// 管家结论含 @ → 触发被@者执行（接力下一跳）。
+    TriggerMention,
+    /// 被@者完成 → 唤醒 assignee 管家决策。
+    WakeAssignee,
+}
+
+/// 纯决策函数（无 IO）：据轮数 / 执行者身份 / 结论里的 @ 决定下一步动作。
+///
+/// 抽成纯函数是为了把护栏与分派逻辑从异步编排中剥离，单测可覆盖四条分支，无需真实
+/// 执行器（与 060 触发逻辑同策略，不做端到端）。`mentions` 仅在 x_is_assignee 分支有意义
+/// （被@者完成时调用方传空 Vec，直接走 WakeAssignee）。
+fn plan_delegate_relay(
+    rounds: i64,
+    max: i64,
+    x_is_assignee: bool,
+    mentions: &[MentionDto],
+) -> DelegateRelayAction {
+    if rounds > max {
+        return DelegateRelayAction::HitLimit;
+    }
+    if x_is_assignee {
+        // 管家本轮执行：结论含 @某人 则触发其执行；不含 @ 视为管家判定完成。
+        let has_target = mentions
+            .iter()
+            .any(|m| m.kind == "executor" || m.kind == "expert");
+        if has_target {
+            DelegateRelayAction::TriggerMention
+        } else {
+            DelegateRelayAction::Finished
+        }
+    } else {
+        // 被@者完成：唤醒管家决定下一步（重试 / 换人 / 收尾）。
+        DelegateRelayAction::WakeAssignee
+    }
+}
+
+/// completion 自动接力所需的执行句柄。
+///
+/// completion 路径（SpawnContext）只有 Arc 组件、没有 AppState；用 struct 收口这 6 个句柄，
+/// 避免 continue_delegated_task 出现 6+ 参数长列表（CLAUDE.md 函数长度 / 可读性）。
+/// 全部以引用借用，触发执行时按需 .clone() 出 owned Arc。
+pub(crate) struct DelegateRelayHandles<'a> {
+    pub db: &'a Arc<Database>,
+    pub executor_registry: &'a Arc<ExecutorRegistry>,
+    pub tx: &'a broadcast::Sender<ExecEvent>,
+    pub task_manager: &'a Arc<TaskManager>,
+    pub config: &'a Arc<RwLock<Config>>,
+    pub expert_manager: &'a Arc<ExpertIndexManager>,
+}
+
+/// 自动接力入口（completion 回写讨论帖后调用）：读占位帖 / 任务元信息 → 计数 → 决策 → 推进。
+///
+/// 失败容忍：任一读库 / 触发失败只 tracing::warn 后返回，不影响本次执行已落定的成功状态
+/// （与 auto_review / 060 回写降级哲学一致，帖子由前端轮询兜底）。
+pub(crate) async fn continue_delegated_task(
+    handles: &DelegateRelayHandles<'_>,
+    record_id: i64,
+    result_str: &str,
+) {
+    // 1. 占位帖：task_id 定位委派任务，expert_name 判断本次执行者身份。
+    let Some(post) = load_relay_post(handles.db, record_id).await else {
+        return;
+    };
+    // 2. 任务元信息 + 前置校验（仅 delegate + auto_continue + 专家 assignee 才接力）。
+    let Some(task) = load_delegate_task(handles.db, post.task_id).await else {
+        return;
+    };
+    let Some(assignee) = task.assignee_name.clone() else {
+        return;
+    };
+    // 3. 护栏计数 +1（顺序事件驱动，无并发）；判定本次执行者是否管家本人。
+    let new_rounds = match handles.db.increment_continue_rounds(post.task_id).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, task_id = post.task_id, "increment continue_rounds failed");
+            return;
+        }
+    };
+    let x_is_assignee = post.expert_name.as_deref() == Some(assignee.as_str());
+    // 4. 仅管家本人执行时才解析其结论里的 @ 作为下一跳；被@者完成时无需解析。
+    let mentions = if x_is_assignee {
+        resolve_mentions(&extract_at_tokens(result_str), handles.expert_manager).await
+    } else {
+        Vec::new()
+    };
+    // 5. 纯决策 → 推进。
+    let action = plan_delegate_relay(new_rounds, MAX_DELEGATE_ROUNDS, x_is_assignee, &mentions);
+    execute_relay_action(handles, &task, &assignee, action, &mentions, result_str).await;
+}
+
+/// 取本次执行对应的占位帖（含 task_id / expert_name）；帖已删或查询失败返回 None。
+async fn load_relay_post(db: &Database, record_id: i64) -> Option<task_posts::Model> {
+    match db.get_task_post_by_source_execution(record_id).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error = %e, record_id, "load relay post failed");
+            None
+        }
+    }
+}
+
+/// 取任务并校验是「delegate + auto_continue + 专家 assignee」的接力任务；否则 None。
+/// 把前置条件收口在一处，让 continue_delegated_task 主干保持线性可读。
+async fn load_delegate_task(db: &Database, task_id: i64) -> Option<tasks::Model> {
+    let task = db.get_task(task_id).await.ok().flatten()?;
+    // 仅委派 + 开启自动接力 + 专家 assignee 才接力（执行器 P1 已禁用 auto_continue）。
+    let is_relay = task.execution_mode == "delegate"
+        && task.auto_continue != 0
+        && task.assignee_kind.as_deref() == Some("expert")
+        && task.assignee_name.is_some();
+    if is_relay { Some(task) } else { None }
+}
+
+/// 按纯决策结果推进：触发下一跳执行，或写终止说明帖。
+async fn execute_relay_action(
+    handles: &DelegateRelayHandles<'_>,
+    task: &tasks::Model,
+    assignee: &str,
+    action: DelegateRelayAction,
+    mentions: &[MentionDto],
+    result_str: &str,
+) {
+    match action {
+        DelegateRelayAction::HitLimit => {
+            let msg = format!(
+                "⚠️ 自动接力已达 {} 轮上限，停止调度。如需继续请在讨论区手动 @。",
+                MAX_DELEGATE_ROUNDS
+            );
+            insert_relay_note_post(handles, task, assignee, &msg).await;
+        }
+        DelegateRelayAction::Finished => {
+            insert_relay_note_post(handles, task, assignee, "✅ 任务已完成，管家停止调度。").await;
+        }
+        DelegateRelayAction::TriggerMention => {
+            // 管家结论含 @ → 触发被@者执行，喂入管家结论作为诉求上下文。
+            spawn_relay_execution(handles, task, mentions, result_str, TRIGGER_DISCUSSION_AUTO).await;
+        }
+        DelegateRelayAction::WakeAssignee => {
+            // 被@者完成 → 唤醒管家决策（@assignee，message=决策指令）。
+            let wake = wake_mention(assignee);
+            spawn_relay_execution(
+                handles,
+                task,
+                std::slice::from_ref(&wake),
+                &build_decision_directive(),
+                TRIGGER_DISCUSSION_AUTO,
+            )
+            .await;
+        }
+    }
+}
+
+/// 建载体 todo + 触发执行 + 写 running 占位帖（与 create_agent_post 同构，但走 completion 的
+/// Arc 句柄而非 AppState；trigger_type 由调用方传 discussion_auto）。
+///
+/// 豁免说明（>50 行）：线性管道——取执行器/专家 → 解析 ws_path → 拼 prompt/mentions →
+/// 建 carrier todo → 触发执行 → 取 record_id → 写占位帖；其中 RunTodoExecutionRequest 构造
+/// 是连续纯数据赋值（无分支），符合规范豁免场景 #1（纯数据构建）+ #2（线性管道），与
+/// trigger_discussion_execution 同一豁免理由。失败写 failed 帖 + 软删 carrier todo。
+async fn spawn_relay_execution(
+    handles: &DelegateRelayHandles<'_>,
+    task: &tasks::Model,
+    mentions: &[MentionDto],
+    directive: &str,
+    trigger_type: &str,
+) {
+    let executor_name = first_executor(mentions);
+    let expert_name = first_expert(mentions);
+    let author = agent_author(mentions);
+    let ws_id = task.workspace_id.unwrap_or(1);
+    let ws_path = resolve_ws_path(handles.db, ws_id).await;
+    // 复用 060 的 prompt 构建 + 历史注入，让接力执行与人工 @ 触发看到同等上下文。
+    let recent = fetch_recent_main_posts(handles.db, task.id).await;
+    let history = format_discussion_history(&recent);
+    let prompt = build_carrier_prompt(task, directive, &history);
+    let mentions_json = serialize_mentions(mentions);
+    let title = format!("接力触发 @{author}");
+    let todo_id = match handles
+        .db
+        .create_discussion_todo(title, prompt.clone(), executor_name, expert_name, ws_id, &ws_path)
+        .await
+    {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::warn!(error = %e, task_id = task.id, "relay create carrier todo failed");
+            return;
+        }
+    };
+    let request = RunTodoExecutionRequest {
+        db: handles.db.clone(),
+        executor_registry: handles.executor_registry.clone(),
+        tx: handles.tx.clone(),
+        task_manager: handles.task_manager.clone(),
+        config: handles.config.clone(),
+        todo_id,
+        message: prompt,
+        req_executor: executor_name.map(str::to_string),
+        req_model: None,
+        trigger_type: trigger_type.to_string(),
+        params: None,
+        resume_session_id: None,
+        resume_message: None,
+        source_todo_id: Some(todo_id),
+        source_todo_title: Some(format!("接力帖-任务{}", task.id)),
+        loop_step_execution_id: None,
+        step_id: None,
+        feishu_bot_id: None,
+        feishu_receive_id: None,
+        feishu_receive_id_type: None,
+        workspace_path: if ws_path.is_empty() { None } else { Some(ws_path) },
+        workspace_id: Some(ws_id),
+        expert_manager: Some(handles.expert_manager.clone()),
+    };
+    // 共享字段打包：成功/失败两分支仅 content/status/关联 id 不同，spec 收口避免重复构造。
+    let spec = AgentPostSpec {
+        task_id: task.id,
+        author: &author,
+        executor: executor_name,
+        expert_name,
+        mentions_json: &mentions_json,
+    };
+    // 关键：必须用类型擦除的 `run_todo_execution_boxed`（见其文档注释）而非直接 await
+    // run_todo_execution。否则「接力 → run_todo_execution → finalize → 接力」coroutine 类型环
+    // 会让编译器报 cycle detected / 无法证明 Send。boxed 包装把具体 future 藏在函数体内，
+    // 调用方只拿到 `Pin<Box<dyn Future + Send>>` 不透明类型，环在此处终止。
+    // run_todo_execution 内部已 spawn 执行器、很快返回 record_id，await 的是「建好执行任务」。
+    let exec = run_todo_execution_boxed(request).await;
+    match exec.record_id {
+        Some(record_id) => {
+            // 占位帖：running，关联执行记录与载体 todo。
+            let placeholder = format!("{author} 正在干活…");
+            let np = spec.into_post(&placeholder, STATUS_RUNNING, Some(record_id), Some(todo_id));
+            if let Err(e) = handles.db.create_task_post(np).await {
+                tracing::warn!(error = %e, task_id = task.id, "relay insert placeholder failed");
+            }
+        }
+        None => {
+            // 启动失败：软删 carrier todo + 写 failed 帖留痕（不阻塞接力链路已落定的部分）。
+            let _ = handles.db.soft_delete_todo(todo_id).await;
+            let failed = format!("{author} 接力触发失败");
+            let np = spec.into_post(&failed, STATUS_FAILED, None, None);
+            if let Err(e) = handles.db.create_task_post(np).await {
+                tracing::warn!(error = %e, task_id = task.id, "relay insert failed-post failed");
+            }
+        }
+    }
+}
+
+/// 写一条接力终止说明帖（达上限 / 已完成）：以 assignee 管家身份发，无执行关联、mentions 空。
+async fn insert_relay_note_post(
+    handles: &DelegateRelayHandles<'_>,
+    task: &tasks::Model,
+    assignee: &str,
+    message: &str,
+) {
+    let np = NewPost {
+        task_id: task.id,
+        parent_post_id: None,
+        kind: KIND_AGENT,
+        author_name: assignee,
+        executor: None,
+        expert_name: Some(assignee),
+        content: message,
+        mentions_json: "[]",
+        status: STATUS_SUCCESS,
+        source_execution_id: None,
+        source_todo_id: None,
+    };
+    if let Err(e) = handles.db.create_task_post(np).await {
+        tracing::warn!(error = %e, task_id = task.id, "relay insert note post failed");
+    }
+}
+
+/// 构造「唤醒管家」用的专家提及（单条，name=assignee）。
+fn wake_mention(name: &str) -> MentionDto {
+    MentionDto {
+        kind: "expert".to_string(),
+        name: name.to_string(),
+        display: name.to_string(),
+    }
+}
+
+/// 唤醒管家时的决策指令（作为 carrier prompt 的「诉求」段）。
+/// 管家 persona 由 inject_expert_context 按 expert_name=assignee 注入，这里只给协调者角色的行为约束。
+fn build_decision_directive() -> String {
+    "（系统自动唤醒：你是本任务的任务管家 / 协调者。）\n\
+     请基于上述任务需求与最近的讨论、执行结论，决定下一步：\n\
+     - 若还有事要做，请 @ 合适的专家或执行器去执行（回复中含 @某人 即自动触发其执行）；\n\
+     - 若任务已全部完成，请直接给出最终结论，不要 @ 任何人（不含 @ 则任务结束）。"
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
 // 单元测试（纯函数部分）
 // ---------------------------------------------------------------------------
 
@@ -780,6 +1112,64 @@ async fn validate_reply_parent(
 mod tests {
     use super::*;
     use crate::expert::{ExpertMetadata, ExpertSource, ExpertType};
+
+    /// plan_delegate_relay：轮数超上限 → HitLimit（护栏熔断，优先级最高）。
+    #[test]
+    fn test_plan_delegate_relay_hit_limit() {
+        let action = plan_delegate_relay(11, 10, true, &[]);
+        assert!(matches!(action, DelegateRelayAction::HitLimit));
+    }
+
+    /// 管家本人执行 + 结论含 @执行器/专家 → TriggerMention（接力下一跳）。
+    #[test]
+    fn test_plan_delegate_relay_trigger_mention() {
+        let mentions = vec![MentionDto {
+            kind: "executor".to_string(),
+            name: "codex".into(),
+            display: "Codex".into(),
+        }];
+        let action = plan_delegate_relay(1, 10, true, &mentions);
+        assert!(matches!(action, DelegateRelayAction::TriggerMention));
+    }
+
+    /// 管家本人执行 + 结论不含 @ → Finished（循环自然终止）。
+    #[test]
+    fn test_plan_delegate_relay_finished_when_no_mention() {
+        let action = plan_delegate_relay(1, 10, true, &[]);
+        assert!(matches!(action, DelegateRelayAction::Finished));
+    }
+
+    /// 被@者完成（executor≠assignee）→ WakeAssignee（唤醒管家决策）。
+    #[test]
+    fn test_plan_delegate_relay_wake_assignee() {
+        let action = plan_delegate_relay(1, 10, false, &[]);
+        assert!(matches!(action, DelegateRelayAction::WakeAssignee));
+    }
+
+    /// 边界：rounds == max（未超）仍允许推进；> max 才熔断。
+    /// 体现「第 max 轮仍可触发一跳、max+1 轮强制停」的护栏语义。
+    #[test]
+    fn test_plan_delegate_relay_boundary_at_max() {
+        let with_mention = vec![MentionDto {
+            kind: "expert".to_string(),
+            name: "e".into(),
+            display: "e".into(),
+        }];
+        // rounds == max 不算超：管家含 @ → TriggerMention；无 @ → Finished。
+        assert!(matches!(
+            plan_delegate_relay(10, 10, true, &with_mention),
+            DelegateRelayAction::TriggerMention
+        ));
+        assert!(matches!(
+            plan_delegate_relay(10, 10, true, &[]),
+            DelegateRelayAction::Finished
+        ));
+        // rounds == max 但非管家 → 仍 WakeAssignee（护栏只管轮数，不管身份分支）。
+        assert!(matches!(
+            plan_delegate_relay(10, 10, false, &[]),
+            DelegateRelayAction::WakeAssignee
+        ));
+    }
 
     /// 基本 @token 抽取：英文、CJK、含下划线的名字都能切出。
     #[test]

--- a/backend/src/handlers/tasks.rs
+++ b/backend/src/handlers/tasks.rs
@@ -779,4 +779,45 @@ mod tests {
         assert_eq!(task.continue_rounds, 0, "新建任务接力计数从 0 起");
         assert!(task.loop_id.is_none(), "委派任务不绑环路");
     }
+
+    // ---- task_title_from_requirement 纯函数单测（无 IO，同步 #[test]）----
+    // 覆盖：正常短文本 / 多行只取首行 / trim / 60 字符截断边界 / CJK 多字节安全 / 空串降级。
+
+    #[test]
+    fn test_task_title_from_requirement_short_returns_trimmed() {
+        // 普通短文本：原样返回首行内容，仅 trim 首尾空白。
+        assert_eq!(super::task_title_from_requirement("  帮我写个脚本  "), "帮我写个脚本");
+    }
+
+    #[test]
+    fn test_task_title_from_requirement_takes_first_line_only() {
+        // 多行需求：标题只取首行，避免换行符污染任务列表的标题展示。
+        assert_eq!(
+            super::task_title_from_requirement("第一行标题\n第二行详情\n第三行"),
+            "第一行标题"
+        );
+    }
+
+    #[test]
+    fn test_task_title_from_requirement_truncation_boundary() {
+        // 恰好 60 字符：不截断（边界 —— count > 60 才截，等于 60 原样）。
+        let exactly_60 = "啊".repeat(60);
+        assert_eq!(super::task_title_from_requirement(&exactly_60), exactly_60);
+        assert_eq!(super::task_title_from_requirement(&exactly_60).chars().count(), 60);
+
+        // 61 字符：截到 60 个原字符 + 1 个「…」省略号。
+        let sixty_one = "啊".repeat(61);
+        let title = super::task_title_from_requirement(&sixty_one);
+        assert_eq!(title.chars().count(), 61, "60 个原字符 + 1 个省略号");
+        assert!(title.ends_with('…'), "超长应以省略号收尾");
+        // 关键：CJK 截断按字符而非字节，不会落在多字节 UTF-8 中间导致 panic。
+        assert!(title.chars().take(60).all(|c| c == '啊'));
+    }
+
+    #[test]
+    fn test_task_title_from_requirement_empty_and_whitespace() {
+        // 空串 / 纯空白：lines().next() 为 None 时回退原串，trim 后为空，不 panic。
+        assert_eq!(super::task_title_from_requirement(""), "");
+        assert_eq!(super::task_title_from_requirement("   \n  "), "");
+    }
 }

--- a/docs/requirements/092-任务委派执行-P2-实现总结.md
+++ b/docs/requirements/092-任务委派执行-P2-实现总结.md
@@ -3,6 +3,7 @@
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | Claude (AI) | 2026-08-08 | P2（管家调度）：completion 自动接力 + continue_rounds 护栏（MAX 10）+ 前端「管家调度中 N/10」徽标 |
+| Claude (AI) | 2026-08-08 | `/review 992 993` 复审修复：接力竞态补偿 + 前后端护栏边界对齐 + 补 8 条单测 + 空 catch 修复（详见「复审修复」一节） |
 
 > 需求文档：`docs/requirements/092-任务委派执行-需求.md`；设计文档：`docs/design/092-任务委派执行-设计.md`。
 > 本 PR 为 **P2（自动接力 / 管家调度 + 护栏）**，叠在 [P1 PR #992](#992) 之上（base = `feat/092-任务委派执行`）。
@@ -109,9 +110,37 @@ error[E0391]: cycle detected when verify auto trait bounds for coroutine
 
 ---
 
+## 复审修复（`/review 992 993` follow-up）
+
+对两个轴（Standards / Spec）的复审结论逐项处置，**排除行数类意见**（`spawn_relay_execution` ~83 行、`CreateTaskModal.tsx` 239 行，按既定豁免维持）。
+
+### 已修复（真 bug / 硬性违规）
+
+| 项 | 问题 | 处置 |
+|----|------|------|
+| Spec (c)1 竞态 | `spawn_relay_execution` 占位帖在 `run_todo_execution_boxed().await` 之后才插入，缺 060 的竞态补偿；执行极快完成时 completion 的 discussion 回写会错过此时还不存在的占位帖 → 占位帖永久 running。 | `compensate_finished_execution` 签名由 `&AppState` 改为 `&Database`（它只用 `db`），让 060 人工触发与 092 接力共用同一补偿；在 `spawn_relay_execution` 占位帖插入后补调（与 `create_agent_post` 同构）。 |
+| Spec (c)2 / (a)2 边界 | 后端 `plan_delegate_relay` 用 `rounds > max`（严格），前端 `RelayBadge` 用 `rounds >= MAX`，导致 rounds=10（仍允许推进的最后一跳）提前变橙。 | 前端改为 `rounds > MAX_DELEGATE_ROUNDS`，与后端 / 设计 §5.2 口径一致。 |
+| Standards #1/#6 缺测 | 新增公开 DAO（`increment_continue_rounds`、`get_task_post_by_source_execution`）、`run_todo_execution_boxed`、`task_title_from_requirement` 缺单测。 | 补 **8 条单测**：`increment_continue_rounds`（递增落库 + 任务不存在→0 边界）、`get_task_post_by_source_execution`（命中/未命中/None 互不干扰）、`run_todo_execution_boxed`（编译期锁死 `Pin<Box<dyn Future+Send>>` 返回类型契约）、`task_title_from_requirement`（短文本/多行只取首行/trim/60 字符截断边界/CJK 多字节安全/空串降级）。 |
+| Standards #8 空 catch | `092-delegate-relay-badge.spec.ts` 的 `} catch {}` 静默吞错（前端禁止 #6）。 | 改为 `catch (e) { console.warn(...) }` 记录原因，便于排查 sqlite3 缺失 / 库占用等。 |
+
+### 评估后保留（判断性意见，与既有一致 / 合理 UX）
+
+| 项 | 复审意见 | 处置理由 |
+|----|---------|---------|
+| Standards #4 handler 业务判断 | 建议业务校验下沉 Service 层 | **保留**：与既有 `create_loop_task` 及全仓 handler 一致（任务创建无独立 Service 层）；单独迁出会造成风格割裂。属判断性而非硬性违规。 |
+| Standards #5 多表写入无事务 | `create_delegate_task` 跨表写未包事务 | **保留**：与 060 `land_mention_post` 同构（亦无事务）；失败模式是有界（孤立任务可在讨论区手动 @ 推进），且与既有的「帖子最终一致 + 轮询兜底」容忍哲学一致。跨切面事务改造应单独立项，不混入本 PR。 |
+| Spec (b)1 隐藏「再次执行」 | 视为范围蔓延 | **保留**：委派任务无环路，「再次执行」走 loop 路径不适用；保留按钮等于展示一个无功能按钮，属正确 UX 修正而非超纲。 |
+| Spec (b)2 metaRow 改处理人 | 视为范围蔓延 | **保留**：委派任务无工艺/版本，展示「工艺：— 版本：—」无信息量；改展示「处理人」是正确、有意义的信息。 |
+
+### 接力编排（`continue_delegated_task`）测试边界说明
+
+`continue_delegated_task` 为 `pub(crate)` 异步编排入口，其**决策逻辑**已被 `plan_delegate_relay` 5 条单测覆盖、其**db 门禁**（`load_relay_post`/`load_delegate_task`）依赖的 DAO 方法已补单测。异步编排胶水本身涉及真实 spawn 执行器，遵循 P2 / 060 既定策略**不做端到端提交测试**（成功路径会真实起子进程），仅覆盖纯决策 + 前置校验分支；这与既有 `land_mention_post` / `auto_review` 的测试边界一致。
+
+---
+
 ## 验证
 
-- **后端**：`cargo clippy --all-targets -- -D warnings` **零告警零错误**；`cargo test` **全量通过（0 failed）**，含新增 `plan_delegate_relay` 5 条单测。
+- **后端**：`cargo clippy --all-targets -- -D warnings` **零告警零错误**；`cargo test` **全量通过（0 failed）**，含 `plan_delegate_relay` 5 条 + 复审新增 8 条单测。
 - **前端**：`npx tsc --noEmit` **零错误**；`npm run build` 通过。
 - **Playwright**：`frontend/tests/092-delegate-relay-badge.spec.ts` **1/1 通过**（委派 + 专家 + 自动接力任务详情「管家调度中 0/10」徽标）。
 

--- a/docs/requirements/092-任务委派执行-P2-实现总结.md
+++ b/docs/requirements/092-任务委派执行-P2-实现总结.md
@@ -1,0 +1,135 @@
+# 092-任务委派执行-P2-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| Claude (AI) | 2026-08-08 | P2（管家调度）：completion 自动接力 + continue_rounds 护栏（MAX 10）+ 前端「管家调度中 N/10」徽标 |
+
+> 需求文档：`docs/requirements/092-任务委派执行-需求.md`；设计文档：`docs/design/092-任务委派执行-设计.md`。
+> 本 PR 为 **P2（自动接力 / 管家调度 + 护栏）**，叠在 [P1 PR #992](#992) 之上（base = `feat/092-任务委派执行`）。
+> P1 已交付委派地基（建表 + 前后端创建链路 + 切换 UI），但 `auto_continue` 仅入库不消费；P2 让该开关真正驱动事件式自动接力。
+
+---
+
+## 范围回顾
+
+- **P1（#992，已交付）** —— T1/T2/T3/T4/T8(UI)/T9、AC1/2/3/4/5/10：执行方式切换 + 委派创建链路；`auto_continue` 仅入库。
+- **P2（本 PR）** —— T6/T7、F5/F6/F7、AC6/7/8/9：
+  - `completion.rs` 在讨论类执行（`discussion` / `discussion_auto`）成功回写后，按「管家中枢规则」自动接力下一轮。
+  - `continue_rounds` 每轮 +1，达 `MAX_DELEGATE_ROUNDS = 10` 强制停 + 写说明帖。
+  - 详情页头部展示「管家调度中 N/10」进度徽标。
+
+---
+
+## 管家中枢规则（设计 §5.2 落地）
+
+assignee 管家专家是调度中枢。每次讨论类执行完成、回写结论帖之后（仅 `delegate + auto_continue + 专家 assignee`），按「本次执行者是否就是 assignee」分两支：
+
+| 本次执行者 | 结论含 @ | 动作 |
+|-----------|---------|------|
+| 是管家本人（expert_name == assignee） | 含 @yyy | 触发 yyy 执行（接力下一跳，trigger=`discussion_auto`） |
+| 是管家本人 | 不含 @ | 管家判定完成 → 写「✅ 已完成」说明帖，循环自然终止 |
+| 被@者（≠ assignee） | — | 唤醒 assignee 管家决策下一步 |
+
+护栏：`continue_rounds` 每轮 +1，`> MAX_DELEGATE_ROUNDS(10)` → 写「⚠️ 已达上限」说明帖停止。循环由此有界。
+
+---
+
+## P2 改动清单
+
+### 后端
+
+- **`db/task.rs`**：新增 `increment_continue_rounds(id) -> i64`（read-modify-write +1 并返回新值）。接力是顺序事件驱动（上一轮完成回调才触发下一轮），无并发递增，故无需原子自增；任务不存在返回 0（调用方据此跳过）。
+- **`db/task_post.rs`**：新增 `get_task_post_by_source_execution(record_id)`——按执行记录反查占位帖，接力据此定位 `task_id` 与本次执行者 `expert_name`。
+- **`executor_service/types.rs`**：`SpawnContext` 增 `expert_manager: Option<Arc<ExpertIndexManager>>` 字段——completion 路径原本拿不到专家索引，接力需要它来解析管家结论里的 @。
+- **`executor_service/spawn_lifecycle.rs`**：`SpawnContext` 构造处透传 `expert_manager`（从 `runtime.prepared.request.expert_manager` 浅克隆），`persist_and_finalize_completion` 末尾把它传给 `finalize_normal_completion`。
+- **`executor_service/mod.rs`**：新增 **`run_todo_execution_boxed`**——把 `run_todo_execution` 的 future 类型擦除为 `Pin<Box<dyn Future + Send>>`。**非可选**，见下方「关键技术决策」。
+- **`executor_service/completion.rs`**：
+  - `finalize_normal_completion` 增 `expert_manager` 参数。
+  - 讨论帖回写条件由 `== "discussion"` 扩为 `== "discussion" || == "discussion_auto"`（接力轮也需回写占位帖）。
+  - 末段新增「自动接力」分支：`success && 讨论类触发 && expert_manager.is_some()` → 组装 `DelegateRelayHandles` 调 `continue_delegated_task`。
+- **`handlers/task_posts.rs`**（接力中枢全部落在此处，复用 060 的私有 helpers，避免改 executor_service↔handlers 的耦合面）：
+  - 常量 `TRIGGER_DISCUSSION_AUTO = "discussion_auto"`、`MAX_DELEGATE_ROUNDS = 10`。
+  - `enum DelegateRelayAction { HitLimit, Finished, TriggerMention, WakeAssignee }`——纯决策结果。
+  - 纯函数 `plan_delegate_relay(rounds, max, x_is_assignee, mentions) -> DelegateRelayAction`——把护栏 + 分派逻辑从异步编排中剥离，可单测覆盖全分支。
+  - `DelegateRelayHandles<'a>`——收口 completion 路径 6 个 Arc 句柄，避免长参数列表。
+  - `continue_delegated_task`（编排入口）：读占位帖 → 校验接力任务 → 计数 +1 → 判定执行者身份 → 纯决策 → 推进。失败只 `warn`，不阻断已落定的执行成功。
+  - `spawn_relay_execution`：建 carrier todo + 触发执行 + 写 running 占位帖（成功）/ failed 帖（失败，软删 carrier todo）。复用 `build_carrier_prompt` / `fetch_recent_main_posts` / `AgentPostSpec` 等 060 helpers，让接力执行与人工 @ 触发看到同等上下文。
+  - `insert_relay_note_post`（达上限 / 已完成说明帖）、`wake_mention`（构造唤醒管家提及）、`build_decision_directive`（管家协调者行为约束）。
+
+### 前端
+
+- **`components/tasks/TaskDetailPanel.tsx`**：
+  - 常量 `MAX_DELEGATE_ROUNDS = 10`（与后端口径一致，集中一处）。
+  - `isAutoRelayTask` / `assigneeLabel` / `RelayBadge` 三个纯展示 helper。
+  - `DetailHeader` 标题行渲染 `<RelayBadge>`：委派 + 自动接力 + 专家任务显示「管家调度中 N/10」，未达上限 `processing` 蓝、达上限 `warning` 橙（与后端 HitLimit 说明帖呼应）。
+  - 委派任务的 metaRow 改展示「处理人：专家/执行器 名称」（环路任务的「工艺 / 版本」对委派无意义）。
+
+### 测试
+
+- 后端：`plan_delegate_relay` **5 条单测**——HitLimit（rounds>max）、TriggerMention（管家 + 含 @）、Finished（管家 + 无 @）、WakeAssignee（被@者）、边界（rounds==max 仍可推进 / >max 才熔断）。`cargo test` 全量 **0 failed**。
+- 前端：`frontend/tests/092-delegate-relay-badge.spec.ts`（Playwright）——走真实「新建委派 + 专家 + 自动接力」提交 → 进详情 → 断言「管家调度中 0/10」徽标可见。**1/1 通过**。`afterAll` 按标记硬删种子任务，避免专家结论含 @ 触发失控接力污染开发库。
+
+---
+
+## 关键技术决策：为什么必须有 `run_todo_execution_boxed`
+
+接力让调用链形成 **coroutine 类型环**：
+
+```
+continue_delegated_task → run_todo_execution → dispatch_spawned_executor_task
+  → finalize_normal_completion → continue_delegated_task → ...
+```
+
+`run_todo_execution` 内部经 `dispatch → finalize` 回到接力，接力又调 `run_todo_execution`。若接力处直接 `await run_todo_execution(...)`，编译器必须展开其 coroutine 类型，环即暴露，报：
+
+```
+error[E0391]: cycle detected when verify auto trait bounds for coroutine
+```
+
+**尝试过但不成立的方案**：
+- `Box::pin(run_todo_execution(request)).await`（具体类型）—— `Box<F>: Send ⟺ F: Send` 仍把同一个环暴露给 Send 求解器。
+- `tokio::spawn(run_todo_execution(request)).await` —— spawn 的实参类型必须已知，而它就是环上的 coroutine。
+
+**成立方案**：在 `executor_service/mod.rs` 内 `Box::pin(run_todo_execution(request))` 并擦除为 `Pin<Box<dyn Future<Output=ExecutionResult> + Send>>`，**且擦除发生在独立函数体内**。调用方（`spawn_relay_execution`）只拿到不透明的 trait object 类型，其具体 coroutine 不内联进调用方的 coroutine 类型，环在 `dyn Future` 处终止。Send 由 `+ Send` bound 直接成立（前提：`run_todo_execution` 的 future 本身 Send——它在 axum handler 中被 await，已满足）。
+
+> 维护提示：若将来有人在接力路径里直接 `await run_todo_execution`，会重新触发 `E0391`。接力处的执行触发**必须**走 `run_todo_execution_boxed`。
+
+---
+
+## 与需求/设计的对应
+
+| 需求项 | 实现位置 | P2 |
+|--------|---------|----|
+| T6 自动接力行为 | `continue_delegated_task` + `spawn_relay_execution` | ✅ |
+| T7 接力护栏（MAX 10） | `MAX_DELEGATE_ROUNDS` + `plan_delegate_relay` HitLimit | ✅ |
+| F5 管家中枢调度 | `continue_delegated_task` 按 x_is_assignee 分支 | ✅ |
+| F6 被@者完成唤醒管家 | `DelegateRelayAction::WakeAssignee` + `wake_mention` | ✅ |
+| F7 接力终止说明帖 | `insert_relay_note_post`（达上限 / 已完成） | ✅ |
+| AC6/7/8/9 接力 + 护栏 + 终止 + 徽标 | 后端接力 + 前端 RelayBadge | ✅ |
+
+---
+
+## 验证
+
+- **后端**：`cargo clippy --all-targets -- -D warnings` **零告警零错误**；`cargo test` **全量通过（0 failed）**，含新增 `plan_delegate_relay` 5 条单测。
+- **前端**：`npx tsc --noEmit` **零错误**；`npm run build` 通过。
+- **Playwright**：`frontend/tests/092-delegate-relay-badge.spec.ts` **1/1 通过**（委派 + 专家 + 自动接力任务详情「管家调度中 0/10」徽标）。
+
+---
+
+## 安全反思
+
+- **护栏兜底**：`MAX_DELEGATE_ROUNDS=10` 硬上限 + 每轮计数，纯决策函数优先判 `HitLimit`，杜绝无限接力。
+- **专家 assignee only**：`load_delegate_task` 二次校验 `assignee_kind=='expert'`（P1 已保证执行器无法开 auto_continue），接力不会在执行器委派上误触发。
+- **失败容忍**：接力任一步（读帖 / 计数 / 触发）失败只 `tracing::warn`，不影响本次执行已落定的成功状态；帖子由前端轮询兜底（与 auto_review / 060 回写降级哲学一致）。
+- **零新越权面**：接力完全复用 `run_todo_execution` + 060 的 `@` 触发链路，carrier todo 带 `workspace_id` 归属，未引入新的并发模型或越权路径。
+- **生产代码**：无 `.unwrap()`/`.expect()`/`panic!`（仅 `#[cfg(test)]`）。
+- **类型擦除安全性**：`run_todo_execution_boxed` 的 `dyn Future + Send` 由 `run_todo_execution` 本身 Send（axum 已证）保证，擦除不放宽任何安全约束。
+
+---
+
+## 已知限制
+
+- 与 060 / P1 一致：委派成功路径会真实 spawn 执行器，故后端未做端到端提交测试，仅覆盖纯决策（`plan_delegate_relay`）+ 接力前置校验分支；E2E 仅验证徽标渲染（接力行为本身由纯决策单测保证）。
+- 徽标显示的是**已完成轮数** `continue_rounds`（接力每推进一轮 +1）；「当前正在跑的第 N+1 轮」需结合讨论区 running 占位帖理解，徽标未单独表达「正在跑」态（YAGNI，running 帖已足够）。
+- `MAX_DELEGATE_ROUNDS` 当前为硬编码常量；需求 §3 明确不引入成本/次数可配置，故未做配置化。

--- a/docs/requirements/092-任务委派执行-P2-实现总结.md
+++ b/docs/requirements/092-任务委派执行-P2-实现总结.md
@@ -31,7 +31,7 @@ assignee 管家专家是调度中枢。每次讨论类执行完成、回写结�
 | 是管家本人 | 不含 @ | 管家判定完成 → 写「✅ 已完成」说明帖，循环自然终止 |
 | 被@者（≠ assignee） | — | 唤醒 assignee 管家决策下一步 |
 
-护栏：`continue_rounds` 每轮 +1，`> MAX_DELEGATE_ROUNDS(10)` → 写「⚠️ 已达上限」说明帖停止。循环由此有界。
+护栏：`continue_rounds` 每轮 +1，`>= MAX_DELEGATE_ROUNDS(10)` → 写「⚠️ 已达上限」说明帖停止。用 `>=`：递增到 10 当轮即熔断，最多 10 轮接力（需求 AC8「达到 10 强制停止」）；若用 `>` 会放行第 11 跳。
 
 ---
 
@@ -67,7 +67,7 @@ assignee 管家专家是调度中枢。每次讨论类执行完成、回写结�
 
 ### 测试
 
-- 后端：`plan_delegate_relay` **5 条单测**——HitLimit（rounds>max）、TriggerMention（管家 + 含 @）、Finished（管家 + 无 @）、WakeAssignee（被@者）、边界（rounds==max 仍可推进 / >max 才熔断）。`cargo test` 全量 **0 failed**。
+- 后端：`plan_delegate_relay` **5 条单测**——HitLimit（rounds>=max 熔断，含 rounds==max 与 >max）、TriggerMention（管家 + 含 @）、Finished（管家 + 无 @）、WakeAssignee（被@者）、边界（rounds==max-1 仍可推进 / ==max 才熔断）。`cargo test` 全量 **0 failed**。
 - 前端：`frontend/tests/092-delegate-relay-badge.spec.ts`（Playwright）——走真实「新建委派 + 专家 + 自动接力」提交 → 进详情 → 断言「管家调度中 0/10」徽标可见。**1/1 通过**。`afterAll` 按标记硬删种子任务，避免专家结论含 @ 触发失控接力污染开发库。
 
 ---
@@ -119,7 +119,7 @@ error[E0391]: cycle detected when verify auto trait bounds for coroutine
 | 项 | 问题 | 处置 |
 |----|------|------|
 | Spec (c)1 竞态 | `spawn_relay_execution` 占位帖在 `run_todo_execution_boxed().await` 之后才插入，缺 060 的竞态补偿；执行极快完成时 completion 的 discussion 回写会错过此时还不存在的占位帖 → 占位帖永久 running。 | `compensate_finished_execution` 签名由 `&AppState` 改为 `&Database`（它只用 `db`），让 060 人工触发与 092 接力共用同一补偿；在 `spawn_relay_execution` 占位帖插入后补调（与 `create_agent_post` 同构）。 |
-| Spec (c)2 / (a)2 边界 | 后端 `plan_delegate_relay` 用 `rounds > max`（严格），前端 `RelayBadge` 用 `rounds >= MAX`，导致 rounds=10（仍允许推进的最后一跳）提前变橙。 | 前端改为 `rounds > MAX_DELEGATE_ROUNDS`，与后端 / 设计 §5.2 口径一致。 |
+| Spec (c)2 / (a)2 边界 | `continue_rounds` 每轮 +1 后用 `rounds > max` 判定护栏：rounds==max 不熔断，会放行第 11 跳，实际跑 11 轮，偏离需求 AC8「达到 10 强制停止」。 | 后端 `plan_delegate_relay` 与前端 `RelayBadge` 统一改 `>= max`：递增到 10 当轮即熔断，最多 10 轮；同步更新 HitLimit / 边界两条单测（达 max 熔断、max-1 仍可推进）。 |
 | Standards #1/#6 缺测 | 新增公开 DAO（`increment_continue_rounds`、`get_task_post_by_source_execution`）、`run_todo_execution_boxed`、`task_title_from_requirement` 缺单测。 | 补 **8 条单测**：`increment_continue_rounds`（递增落库 + 任务不存在→0 边界）、`get_task_post_by_source_execution`（命中/未命中/None 互不干扰）、`run_todo_execution_boxed`（编译期锁死 `Pin<Box<dyn Future+Send>>` 返回类型契约）、`task_title_from_requirement`（短文本/多行只取首行/trim/60 字符截断边界/CJK 多字节安全/空串降级）。 |
 | Standards #8 空 catch | `092-delegate-relay-badge.spec.ts` 的 `} catch {}` 静默吞错（前端禁止 #6）。 | 改为 `catch (e) { console.warn(...) }` 记录原因，便于排查 sqlite3 缺失 / 库占用等。 |
 

--- a/frontend/src/components/tasks/TaskDetailPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailPanel.tsx
@@ -98,7 +98,10 @@ function assigneeLabel(task: TaskDetailData['task']): string {
 function RelayBadge({ task }: { task: TaskDetailData['task'] }) {
   if (!isAutoRelayTask(task)) return null;
   const rounds = task.continue_rounds ?? 0;
-  const atLimit = rounds >= MAX_DELEGATE_ROUNDS;
+  // 严格 >：与后端 plan_delegate_relay 的 `rounds > max` 护栏口径一致（设计 §5.2）。
+  // 计数在判定前已 +1，故达上限时 DB 里是 11（第 11 跳被熔断）——此时才转橙；
+  // 若用 >= 会在 rounds=10（仍被允许推进的最后一跳）提前变橙，与后端语义不符。
+  const atLimit = rounds > MAX_DELEGATE_ROUNDS;
   return (
     <Tag color={atLimit ? 'warning' : 'processing'}>
       管家调度中 {rounds}/{MAX_DELEGATE_ROUNDS}

--- a/frontend/src/components/tasks/TaskDetailPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailPanel.tsx
@@ -33,6 +33,11 @@ const { Text } = Typography;
 // 帖子页返回本任务-讨论 tab 时，URL 带 ?tab=discussion，Tabs 据此恢复选中态。
 const TAB_KEYS = ['overview', 'dag', 'exec', 'discussion'] as const;
 
+// 需求 092 P2：自动接力的轮数硬上限。必须与后端 MAX_DELEGATE_ROUNDS（completion 接力护栏）
+// 保持一致——前端只读 continue_rounds，不做护栏决策，仅据此展示进度与「已达上限」状态。
+// 集中为常量而非魔法数，便于双端口径变更时一处定位。
+const MAX_DELEGATE_ROUNDS = 10;
+
 // ====== 类型定义 ======
 
 interface TaskDetailPanelProps {
@@ -70,6 +75,37 @@ interface TaskDetailData {
 
 // ====== 子组件 ======
 
+/** 是否为「管家自动接力」任务：委派 + 开启自动接力 + 专家处理人（执行器 P1 已禁用接力）。 */
+function isAutoRelayTask(task: TaskDetailData['task']): boolean {
+  return task.execution_mode === 'delegate'
+    && !!task.auto_continue
+    && task.assignee_kind === 'expert';
+}
+
+/** 委派任务处理人展示文案：「专家/执行器 名称」；缺名回退「—」。 */
+function assigneeLabel(task: TaskDetailData['task']): string {
+  const kind = task.assignee_kind === 'expert' ? '专家'
+    : task.assignee_kind === 'executor' ? '执行器' : '处理人';
+  return task.assignee_name ? `${kind} ${task.assignee_name}` : '—';
+}
+
+/**
+ * 自动接力进度徽标（需求 092 P2）。仅管家接力任务显示，文案「管家调度中 N/MAX」：
+ * - 未达上限用 processing 蓝，直观表达「进行中」；
+ * - 达上限用 warning 橙，与后端 HitLimit 写的「已达上限」说明帖呼应，提示用户接管。
+ * 非接力任务（环路 / 手动单跑 / 执行器委派）返回 null，标题行不留空位。
+ */
+function RelayBadge({ task }: { task: TaskDetailData['task'] }) {
+  if (!isAutoRelayTask(task)) return null;
+  const rounds = task.continue_rounds ?? 0;
+  const atLimit = rounds >= MAX_DELEGATE_ROUNDS;
+  return (
+    <Tag color={atLimit ? 'warning' : 'processing'}>
+      管家调度中 {rounds}/{MAX_DELEGATE_ROUNDS}
+    </Tag>
+  );
+}
+
 /** 顶部条：标题 + 状态/复杂度 + 元信息 + 删除 + 再次执行。 */
 function DetailHeader({
   task, template, loopDetail, onExecute, onDelete,
@@ -90,11 +126,22 @@ function DetailHeader({
           {template?.complexity && (
             <Tag color={complexityColor(template.complexity)}>{complexityLabel(template.complexity)}</Tag>
           )}
+          {/* 管家自动接力任务的进度徽标（委派 + 自动接力 + 专家）。非此类任务返回 null。 */}
+          <RelayBadge task={task} />
         </div>
         <div className={styles.metaRow}>
-          <span>工艺：{template?.display_name ?? '—'}</span>
-          <span className={styles.metaDivider}>·</span>
-          <span>版本：{template?.version ?? '—'}</span>
+          {task.execution_mode === 'delegate' ? (
+            // 委派任务无工艺/版本概念，改展示处理人（专家/执行器 + 名称）。
+            <>
+              <span>处理人：{assigneeLabel(task)}</span>
+            </>
+          ) : (
+            <>
+              <span>工艺：{template?.display_name ?? '—'}</span>
+              <span className={styles.metaDivider}>·</span>
+              <span>版本：{template?.version ?? '—'}</span>
+            </>
+          )}
         </div>
       </div>
       <Space>

--- a/frontend/src/components/tasks/TaskDetailPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailPanel.tsx
@@ -98,10 +98,10 @@ function assigneeLabel(task: TaskDetailData['task']): string {
 function RelayBadge({ task }: { task: TaskDetailData['task'] }) {
   if (!isAutoRelayTask(task)) return null;
   const rounds = task.continue_rounds ?? 0;
-  // 严格 >：与后端 plan_delegate_relay 的 `rounds > max` 护栏口径一致（设计 §5.2）。
-  // 计数在判定前已 +1，故达上限时 DB 里是 11（第 11 跳被熔断）——此时才转橙；
-  // 若用 >= 会在 rounds=10（仍被允许推进的最后一跳）提前变橙，与后端语义不符。
-  const atLimit = rounds > MAX_DELEGATE_ROUNDS;
+  // >=：与后端 plan_delegate_relay 的 `rounds >= max` 护栏口径一致（设计 §5.2）。
+  // 计数在判定前已 +1，递增到 max(10) 当轮即被熔断（需求 AC8「达到 10 强制停止」），
+  // 故 rounds=10 时转橙，与后端 HitLimit 写的「已达上限」说明帖同步提示用户接管。
+  const atLimit = rounds >= MAX_DELEGATE_ROUNDS;
   return (
     <Tag color={atLimit ? 'warning' : 'processing'}>
       管家调度中 {rounds}/{MAX_DELEGATE_ROUNDS}

--- a/frontend/tests/092-delegate-relay-badge.spec.ts
+++ b/frontend/tests/092-delegate-relay-badge.spec.ts
@@ -1,0 +1,86 @@
+// 092-任务委派执行 P2：详情页「管家调度中 N/10」徽标验证。
+// 验证点（对应需求 092 验收标准 7）：委派 + 专家 + 自动接力任务，详情头部展示调度进度徽标。
+//
+// 策略说明：
+// - 走真实「新建任务」提交流程（非纯 UI 联动），因为徽标依赖后端落库的委派字段——
+//   委派任务一经创建即带 execution_mode=delegate + auto_continue=1 + continue_rounds=0，
+//   详情头部据此渲染徽标「管家调度中 0/10」。提交会用当前选中工作空间建任务，
+//   天然规避「种子任务所在工作空间与默认选中不一致」的可达性问题。
+// - 徽标在创建瞬间（continue_rounds=0）即可见；专家首跑尚未完成，故断言 N=0。
+// - afterAll 删除本次创建的任务：finalize 接力入口会据此跳过（任务不存在 → 不再推进），
+//   避免专家结论里若含 @ 触发失控接力链路，污染开发库。
+
+import { test, expect } from '@playwright/test';
+import { execSync } from 'child_process';
+
+const BASE = process.env.E2E_BASE_URL ?? 'http://localhost:18088';
+const DEV_DB = process.env.HOME + '/.ntd/data.dev.db';
+// 用带标记的唯一需求，便于失败定位与 afterAll 按前缀清理残留。
+const MARKER = 'E2E接力徽标校验任务';
+
+// 按标题前缀硬删任务（连带其讨论帖/载体 todo）。开发库自洽优先于精确归属。
+function cleanupSeededTasks() {
+  try {
+    const ids: string = execSync(
+      `sqlite3 "${DEV_DB}" "SELECT IFNULL(GROUP_CONCAT(id),'') FROM tasks WHERE title LIKE '%${MARKER}%';"`,
+    ).toString().trim();
+    if (!ids) return;
+    execSync(`sqlite3 "${DEV_DB}" "DELETE FROM task_posts WHERE task_id IN (${ids});"`);
+    execSync(`sqlite3 "${DEV_DB}" "DELETE FROM execution_records WHERE source_todo_id IN (SELECT id FROM todos WHERE title LIKE '%${MARKER}%');"`);
+    execSync(`sqlite3 "${DEV_DB}" "DELETE FROM todos WHERE title LIKE '%${MARKER}%';"`);
+    execSync(`sqlite3 "${DEV_DB}" "DELETE FROM tasks WHERE id IN (${ids});"`);
+  } catch {
+    // 清理失败不影响测试结论（仅开发库残留），静默吞掉。
+  }
+}
+
+test.describe('092 委派自动接力徽标', () => {
+  test.afterAll(() => cleanupSeededTasks());
+
+  test('委派+专家+自动接力任务详情展示「管家调度中 N/10」', async ({ page }) => {
+    await page.goto(`${BASE}/#/tasks`);
+    await page.waitForSelector('.ant-table-row, .ant-empty', { timeout: 15000 });
+
+    // 打开新建弹窗。
+    await page.getByRole('button', { name: /新建/ }).first().click();
+    const dialog = page.getByRole('dialog', { name: /新建任务/ });
+    await expect(dialog).toBeVisible();
+
+    // 切到委派（处理人类型默认「专家」，无需切换 Segmented）。
+    await dialog.locator('.ant-radio-button-wrapper', { hasText: '委派' }).click();
+    await expect(dialog.locator('[data-testid="create-task-assignee"]')).toBeVisible();
+
+    // 填需求（带唯一标记，便于定位新建出的任务行 + afterAll 清理）。
+    await dialog.locator('[data-testid="create-task-requirement"]').fill(MARKER);
+
+    // 选第一个专家（专家列表来自 getAllExperts，开发库已内置 50+ 专家）。
+    await dialog.locator('[data-testid="create-task-assignee"]').click();
+    const firstExpert = page.locator('.ant-select-item-option').first();
+    await firstExpert.waitFor({ state: 'visible' });
+    await firstExpert.click();
+
+    // 打开自动接力开关（仅专家可用；默认关闭，这里手动开启以触发徽标渲染条件）。
+    const autoSwitch = dialog.locator('[data-testid="create-task-auto-continue"]');
+    await expect(autoSwitch).not.toHaveClass(/ant-switch-checked/);
+    await autoSwitch.click();
+    await expect(autoSwitch).toHaveClass(/ant-switch-checked/);
+
+    // 提交：点「开始执行」。委派创建会立即建任务（执行在后台 spawn），故弹窗很快关闭。
+    await page.getByRole('button', { name: '开始执行' }).click();
+    await expect(dialog).toHaveCount(0, { timeout: 15000 });
+
+    // 列表刷新后，新建任务（按 id DESC）排在最前。定位带标记的行并点开详情。
+    const row = page.locator('.ant-table-row', { hasText: MARKER }).first();
+    await row.waitFor({ state: 'visible', timeout: 15000 });
+    await row.click();
+
+    // 详情头部出现后，断言管家调度徽标：文案「管家调度中 N/10」，N 为已完成的接力轮数。
+    // 创建瞬间首跑尚未完成 → N=0；用正则容纳「首跑恰好完成一轮」的竞态，避免误判。
+    const badge = page.locator('.ant-tag', { hasText: /管家调度中\s*\d+\s*\/\s*10/ });
+    await expect(badge).toBeVisible({ timeout: 15000 });
+    await expect(badge).toHaveText(/管家调度中\s*0\s*\/\s*10/);
+
+    // 截图留档（test-results 由 Playwright 管理且已 gitignore，不入库）。
+    await page.screenshot({ path: 'test-results/092-delegate-relay-badge.png' });
+  });
+});

--- a/frontend/tests/092-delegate-relay-badge.spec.ts
+++ b/frontend/tests/092-delegate-relay-badge.spec.ts
@@ -29,8 +29,10 @@ function cleanupSeededTasks() {
     execSync(`sqlite3 "${DEV_DB}" "DELETE FROM execution_records WHERE source_todo_id IN (SELECT id FROM todos WHERE title LIKE '%${MARKER}%');"`);
     execSync(`sqlite3 "${DEV_DB}" "DELETE FROM todos WHERE title LIKE '%${MARKER}%';"`);
     execSync(`sqlite3 "${DEV_DB}" "DELETE FROM tasks WHERE id IN (${ids});"`);
-  } catch {
-    // 清理失败不影响测试结论（仅开发库残留），静默吞掉。
+  } catch (e) {
+    // 清理失败不影响测试结论（仅开发库残留），但记录原因便于排查
+    // （如 sqlite3 未安装 / 库被占用 / 表已无残留），避免空 catch 吞错。
+    console.warn('[092 cleanup] 清理种子任务失败（开发库残留，通常可忽略）：', e);
   }
 }
 


### PR DESCRIPTION
## 概述

需求 092 的 **P2（自动接力 / 管家调度 + 护栏）**，叠在 [P1 PR #992](https://github.com/weibaohui/ntd/pull/992) 之上（本 PR base = `feat/092-任务委派执行`，P1 合入 main 后再 retarget 到 main）。

P1 已交付委派地基（建表 + 前后端创建链路 + 切换 UI），但 \`auto_continue\` 仅入库不消费。**P2 让该开关真正驱动事件式自动接力**。

> 实现总结：\`docs/requirements/092-任务委派执行-P2-实现总结.md\`
> 需求：\`docs/requirements/092-任务委派执行-需求.md\` · 设计：\`docs/design/092-任务委派执行-设计.md\`

## 管家中枢规则

assignee 管家专家是调度中枢。每次讨论类执行（\`discussion\` / \`discussion_auto\`）成功回写后（仅 \`delegate + auto_continue + 专家\`），按「本次执行者是否就是 assignee」分两支：

| 本次执行者 | 结论含 @ | 动作 |
|-----------|---------|------|
| 管家本人 | 含 @yyy | 触发 yyy 执行（trigger=\`discussion_auto\`） |
| 管家本人 | 不含 @ | 写「✅ 已完成」说明帖，自然终止 |
| 被@者（≠assignee） | — | 唤醒 assignee 决策下一步 |

护栏：\`continue_rounds\` 每轮 +1，\`> MAX_DELEGATE_ROUNDS(10)\` → 写「⚠️ 已达上限」说明帖停止。

## 改动要点

**后端**
- \`completion.rs\`：讨论类执行成功回写后调 \`continue_delegated_task\`；回写条件扩到 \`discussion || discussion_auto\`。
- \`handlers/task_posts.rs\`：接力中枢——\`plan_delegate_relay\` 纯决策 + \`MAX_DELEGATE_ROUNDS=10\` 护栏 + \`spawn_relay_execution\` / \`insert_relay_note_post\` / \`wake_mention\`。
- \`types.rs\` / \`spawn_lifecycle.rs\`：\`expert_manager\` 透传进 \`SpawnContext → finalize\`。
- \`executor_service/mod.rs\`：新增 \`run_todo_execution_boxed\`——**关键**，用 \`dyn Future + Send\` 类型擦除打断 \`接力 → run_todo_execution → finalize → 接力\` 的 coroutine 类型环（直接 await / Box::pin / tokio::spawn 均触发 \`E0391 cycle detected\`）。
- DAO：\`increment_continue_rounds\`、\`get_task_post_by_source_execution\`。

**前端**
- \`TaskDetailPanel\`：\`RelayBadge\`——委派+专家+自动接力任务详情头部展示「管家调度中 N/10」（达上限转 warning 橙）；委派 metaRow 改显处理人。

## 验证

| 项 | 结果 |
|----|------|
| \`cargo clippy --all-targets -- -D warnings\` | ✅ 零告警零错误 |
| \`cargo test\` | ✅ 全量 0 failed（含 \`plan_delegate_relay\` 5 条单测：HitLimit/TriggerMention/Finished/WakeAssignee/边界） |
| \`npx tsc --noEmit\` / \`npm run build\` | ✅ 零错误 |
| Playwright \`092-delegate-relay-badge.spec.ts\` | ✅ 1/1 通过（委派+专家+自动接力任务详情「管家调度中 0/10」徽标） |

## 安全反思
- 护栏兜底：\`MAX_DELEGATE_ROUNDS=10\` + 每轮计数，纯决策优先判 \`HitLimit\`，杜绝无限接力。
- 专家 assignee only：\`load_delegate_task\` 二次校验 \`assignee_kind=='expert'\`。
- 失败容忍：接力任一步失败只 \`warn\`，不阻断已落定的执行成功。
- 零新越权面：复用 \`run_todo_execution\` + 060 \`@\` 链路；生产代码无 \`unwrap\`/\`expect\`/\`panic\`。

## 已知限制
- 委派成功路径会真实 spawn 执行器，后端仅覆盖纯决策 + 前置校验分支（与 060/P1 测试策略一致），接力行为本身由纯决策单测保证。
- 徽标显示已完成轮数 \`continue_rounds\`；「正在跑」态由讨论区 running 占位帖表达（YAGNI）。