### PR TITLE
feat(092): 委派接力上限配置化——三级可配(任务覆盖→工作空间默认→兜底)

### DIFF
--- a/backend/src/db/entity/tasks.rs
+++ b/backend/src/db/entity/tasks.rs
@@ -26,8 +26,12 @@ pub struct Model {
     /// 自动接力开关（0 关 / 1 开）；仅 `assignee_kind='expert'` 时允许为 1。
     /// 用 i64 与 SQLite INTEGER 列对齐，由 handler 层按 0/1 转 bool，避免 bool 映射歧义。
     pub auto_continue: i64,
-    /// 自动接力已执行轮数（护栏计数；达 `MAX_DELEGATE_ROUNDS` 上限强制停止）。
+    /// 自动接力已执行轮数（护栏计数；达「有效上限」强制停止，上限三级可配，见 task_posts.rs）。
     pub continue_rounds: i64,
+    /// 本任务接力轮数「上限阈值」覆盖（NULL=回退工作空间默认 → 兜底常量；三级解析
+    /// 见 `resolve_delegate_max_rounds`）。注意区别于 continue_rounds：本字段是用户可调的
+    /// 上限，后者是后端单调递增的「已跑计数」，前端不可直传（设计 §护栏不可绕过）。
+    pub delegate_max_rounds: Option<i64>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/db/entity/workspace_settings.rs
+++ b/backend/src/db/entity/workspace_settings.rs
@@ -24,6 +24,9 @@ pub struct Model {
     /// 内容包括产物目录、认证信息、基本文件路径等共识信息。
     /// None 表示未配置（读取时跳过拼接）；空串 "" 表示显式清空。
     pub system_prompt: Option<String>,
+    /// 工作空间级「委派接力轮数上限」默认（需求 092 护栏配置化）。
+    /// NULL=未配置 → 回退终极兜底常量 MAX_DELEGATE_ROUNDS；任务级 delegate_max_rounds 可再覆盖之。
+    pub delegate_max_rounds: Option<i64>,
     pub updated_at: Option<String>,
 }
 

--- a/backend/src/db/migration/consolidated_schema.rs
+++ b/backend/src/db/migration/consolidated_schema.rs
@@ -398,7 +398,7 @@ pub const CONSOLIDATED_SCHEMA: &[&str] = &[
             created_by TEXT DEFAULT '',
             created_at TEXT,
             updated_at TEXT
-        , execution_mode TEXT NOT NULL DEFAULT 'loop', assignee_kind TEXT, assignee_name TEXT, auto_continue INTEGER NOT NULL DEFAULT 0, continue_rounds INTEGER NOT NULL DEFAULT 0)"#,
+        , execution_mode TEXT NOT NULL DEFAULT 'loop', assignee_kind TEXT, assignee_name TEXT, auto_continue INTEGER NOT NULL DEFAULT 0, continue_rounds INTEGER NOT NULL DEFAULT 0, delegate_max_rounds INTEGER)"#,
     // task_posts：任务讨论帖表（需求 060，与 v88 迁移同构）。字段语义见 entity/task_posts.rs；
     // 外键均 ON DELETE CASCADE，删任务/删父帖时连带清理，避免孤儿帖。
     r#"CREATE TABLE task_posts (
@@ -505,7 +505,7 @@ pub const CONSOLIDATED_SCHEMA: &[&str] = &[
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 workspace_id INTEGER NOT NULL UNIQUE,
                 default_response_todo_id INTEGER, updated_at TEXT
-            , default_response_type TEXT, default_response_loop_id INTEGER, default_response_executor TEXT, system_prompt TEXT)"#,
+            , default_response_type TEXT, default_response_loop_id INTEGER, default_response_executor TEXT, system_prompt TEXT, delegate_max_rounds INTEGER)"#,
     r#"CREATE TABLE workspace_slash_commands (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 workspace_id INTEGER NOT NULL,

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -55,6 +55,8 @@ mod v89;
 mod v90;
 /// v91：tasks 表新增「委派执行」相关列（需求 092 任务委派执行）。
 mod v91;
+/// v92：tasks/workspace_settings 各加 delegate_max_rounds 列（需求 092 护栏配置化）。
+mod v92;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -182,6 +184,9 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         Box::new(v90::V90AddPerformanceIndexes),
         // V91 在 V90 之后：tasks 表加 5 列支撑任务委派执行（需求 092）。
         Box::new(v91::V91TaskDelegateExecution),
+        // V92 在 V91 之后：tasks/workspace_settings 各加 delegate_max_rounds 列，
+        // 把接力上限从写死常量改为「任务覆盖 → 工作空间默认 → 兜底」三级可配置。
+        Box::new(v92::V92DelegateMaxRounds),
     ]
 }
 

--- a/backend/src/db/migration/v92.rs
+++ b/backend/src/db/migration/v92.rs
@@ -1,0 +1,97 @@
+//! 迁移 v92：tasks 与 workspace_settings 各加 `delegate_max_rounds` 列（需求 092 护栏配置化）。
+//!
+//! 背景：此前自动接力轮数上限写死在常量 `MAX_DELEGATE_ROUNDS = 10`（前后端各一处），
+//! 运行时不可调、跨栈易漂移。092 把上限改为「任务覆盖 → 工作空间默认 → 兜底常量」三级可配，
+//! 故需在两张表各加一列存放可配置的上限阈值。
+//!
+//! 两列均 nullable、无 DEFAULT：
+//! - `tasks.delegate_max_rounds`：单任务覆盖，NULL 表示沿用工作空间默认。
+//! - `workspace_settings.delegate_max_rounds`：工作空间默认，NULL 表示回退终极兜底常量。
+//! SQLite 对 `ADD COLUMN` 的 nullable 列会自动给旧行填 NULL，无需回填语句（与 v91 的
+//! assignee_kind 同口径）。
+//!
+//! 幂等：`add_column_if_missing` 用 `PRAGMA table_info` 探测列存在再 ADD，任意中间状态可重入。
+
+use async_trait::async_trait;
+
+use crate::db::migration::add_column_if_missing;
+use crate::db::{Database, migration::Migration};
+
+/// v92：tasks / workspace_settings 各加 `delegate_max_rounds` 列。
+pub struct V92DelegateMaxRounds;
+
+#[async_trait]
+impl Migration for V92DelegateMaxRounds {
+    fn version(&self) -> i64 {
+        92
+    }
+
+    fn name(&self) -> &'static str {
+        "V92DelegateMaxRounds"
+    }
+
+    /// 两表各追加一列。nullable 无 DEFAULT：旧行自动得 NULL（=沿用更下一级默认），
+    /// 不破坏既有数据；新建库走 consolidated_schema 已内联同列。
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        // 任务级覆盖：优先级最高，NULL 则回退工作空间默认。
+        add_column_if_missing(
+            db,
+            "tasks",
+            "delegate_max_rounds",
+            "ALTER TABLE tasks ADD COLUMN delegate_max_rounds INTEGER",
+        )
+        .await?;
+        // 工作空间级默认：NULL 则回退终极兜底常量 MAX_DELEGATE_ROUNDS。
+        add_column_if_missing(
+            db,
+            "workspace_settings",
+            "delegate_max_rounds",
+            "ALTER TABLE workspace_settings ADD COLUMN delegate_max_rounds INTEGER",
+        )
+        .await?;
+        tracing::info!("v92: tasks/workspace_settings 已添加 delegate_max_rounds 列");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+    use crate::db::migration::table_has_column;
+
+    /// 幂等：重复执行 up 不报错（add_column_if_missing 探测列存在则跳过）。
+    #[tokio::test]
+    async fn test_v92_is_idempotent() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+        V92DelegateMaxRounds.up(&db).await.expect("first run");
+        V92DelegateMaxRounds
+            .up(&db)
+            .await
+            .expect("second run (idempotent)");
+    }
+
+    /// 两表新列均可达：确保 schema 与迁移目标一致（tasks + workspace_settings 各一列）。
+    #[tokio::test]
+    async fn test_v92_columns_present() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+        V92DelegateMaxRounds.up(&db).await.expect("up");
+        assert!(
+            table_has_column(&db, "tasks", "delegate_max_rounds")
+                .await
+                .unwrap(),
+            "tasks.delegate_max_rounds 应存在"
+        );
+        assert!(
+            table_has_column(&db, "workspace_settings", "delegate_max_rounds")
+                .await
+                .unwrap(),
+            "workspace_settings.delegate_max_rounds 应存在"
+        );
+    }
+}

--- a/backend/src/db/task.rs
+++ b/backend/src/db/task.rs
@@ -77,15 +77,18 @@ impl Database {
     /// 任务不存在时静默返回（与 update_task_status 同口径，调用方已先校验存在性）。
     pub async fn update_delegate_max_rounds(
         &self, id: i64, max: Option<i64>,
-    ) -> Result<(), sea_orm::DbErr> {
+    ) -> Result<Option<tasks::Model>, sea_orm::DbErr> {
         let existing = tasks::Entity::find_by_id(id).one(&self.conn).await?;
+        // 返回更新后的 Model：调用方据此直接 resolve 有效值，免去一次冗余 get_task 重读。
+        // （find 已取到行，update 再回写最新态——无需调用方二次查库。）
         if let Some(c) = existing {
             let mut am: tasks::ActiveModel = c.into();
             am.delegate_max_rounds = ActiveValue::Set(max);
             am.updated_at = ActiveValue::Set(Some(utc_timestamp()));
-            am.update(&self.conn).await?;
+            let updated = am.update(&self.conn).await?;
+            return Ok(Some(updated));
         }
-        Ok(())
+        Ok(None)
     }
 
     pub async fn get_task(&self, id: i64) -> Result<Option<tasks::Model>, sea_orm::DbErr> {

--- a/backend/src/db/task.rs
+++ b/backend/src/db/task.rs
@@ -30,6 +30,9 @@ impl Database {
     ///
     /// `description` 随首次 INSERT 一并写入（而非建后再 UPDATE）：委派创建之后还要发讨论首帖
     /// 触发执行，若 description 单独 update，中间任一步失败会留下「空描述任务」（CodeRabbit #1）。
+    // 8 个参数均为建任务所需的独立字段，函数体是纯字段映射（→ ActiveModel），强行收敛成 struct
+    // 反而割裂调用点与 DB 列的一一对应，故豁免 too_many_arguments（线性数据构建，符合豁免场景 #1）。
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_delegate_task(
         &self,
         title: &str,
@@ -38,6 +41,8 @@ impl Database {
         assignee_kind: &str,
         assignee_name: &str,
         auto_continue: bool,
+        // 接力轮数上限覆盖:None=沿用工作空间默认 → 兜底常量(三级解析见 resolve_delegate_max_rounds)。
+        delegate_max_rounds: Option<i64>,
     ) -> Result<tasks::Model, sea_orm::DbErr> {
         let now = utc_timestamp();
         let am = tasks::ActiveModel {
@@ -57,9 +62,30 @@ impl Database {
             auto_continue: ActiveValue::Set(if auto_continue { 1 } else { 0 }),
             // 接力计数从 0 起，由 completion 接力分支递增（P2）。
             continue_rounds: ActiveValue::Set(0),
+            // 任务级上限覆盖随建写入；None 表示沿用工作空间默认（三级可配，见 resolve_delegate_max_rounds）。
+            delegate_max_rounds: ActiveValue::Set(delegate_max_rounds),
             ..Default::default()
         };
         am.insert(&self.conn).await
+    }
+
+    /// 更新单个委派任务的「接力轮数上限」覆盖（需求 092 护栏配置化）。
+    ///
+    /// - `Some(n)`（n≥1，由 handler 校验 1..=50）→ 置为 n，覆盖工作空间默认。
+    /// - `None` → 置 NULL，回退工作空间默认 → 兜底常量（即「恢复默认」）。
+    ///
+    /// 任务不存在时静默返回（与 update_task_status 同口径，调用方已先校验存在性）。
+    pub async fn update_delegate_max_rounds(
+        &self, id: i64, max: Option<i64>,
+    ) -> Result<(), sea_orm::DbErr> {
+        let existing = tasks::Entity::find_by_id(id).one(&self.conn).await?;
+        if let Some(c) = existing {
+            let mut am: tasks::ActiveModel = c.into();
+            am.delegate_max_rounds = ActiveValue::Set(max);
+            am.updated_at = ActiveValue::Set(Some(utc_timestamp()));
+            am.update(&self.conn).await?;
+        }
+        Ok(())
     }
 
     pub async fn get_task(&self, id: i64) -> Result<Option<tasks::Model>, sea_orm::DbErr> {
@@ -152,7 +178,7 @@ mod tests {
         let db = fresh_db().await;
         // 委派任务建表即写 continue_rounds=0，是接力的真实载体，用它验证最贴近生产路径。
         let task = db
-            .create_delegate_task("接力任务T", "接力需求原文", 1, "expert", "专家A", true)
+            .create_delegate_task("接力任务T", "接力需求原文", 1, "expert", "专家A", true, None)
             .await
             .expect("create delegate task");
         assert_eq!(task.continue_rounds, 0, "新建委派任务初始计数应为 0");
@@ -181,5 +207,32 @@ mod tests {
             .await
             .expect("missing task should not error");
         assert_eq!(r, 0, "任务不存在时返回 0，调用方据此跳过接力");
+    }
+
+    /// update_delegate_max_rounds：置值后再清空，回读校验落库正确。
+    #[tokio::test]
+    async fn test_update_delegate_max_rounds_set_then_clear() {
+        let db = fresh_db().await;
+        let task = db
+            .create_delegate_task("T", "D", 1, "expert", "专家A", true, None)
+            .await
+            .expect("create");
+        // 初始 None（沿用工作空间默认）。
+        assert_eq!(
+            db.get_task(task.id).await.unwrap().unwrap().delegate_max_rounds,
+            None
+        );
+        // 置值覆盖。
+        db.update_delegate_max_rounds(task.id, Some(8)).await.expect("set");
+        assert_eq!(
+            db.get_task(task.id).await.unwrap().unwrap().delegate_max_rounds,
+            Some(8)
+        );
+        // None 清空（恢复默认）。
+        db.update_delegate_max_rounds(task.id, None).await.expect("clear");
+        assert_eq!(
+            db.get_task(task.id).await.unwrap().unwrap().delegate_max_rounds,
+            None
+        );
     }
 }

--- a/backend/src/db/workspace_setting.rs
+++ b/backend/src/db/workspace_setting.rs
@@ -205,7 +205,7 @@ mod tests {
 
     /// update_workspace_delegate_max_rounds：无既有行时新建一行并写入上限。
     #[tokio::test]
-    async fn test_update_ws_delegate_max_rounds_inserts_when_absent() {
+    async fn test_update_workspace_delegate_max_rounds_inserts_when_absent() {
         let db = Database::new(":memory:").await.unwrap();
         update_workspace_delegate_max_rounds(&db, 7, Some(15))
             .await
@@ -218,7 +218,7 @@ mod tests {
 
     /// 既有行：置值后再传 None 清空（回退兜底），不影响其他列。
     #[tokio::test]
-    async fn test_update_ws_delegate_max_rounds_set_then_clear() {
+    async fn test_update_workspace_delegate_max_rounds_set_then_clear() {
         let db = Database::new(":memory:").await.unwrap();
         // 先建行并写入 system_prompt，验证单字段更新不误伤其他列。
         upsert_workspace_settings(&db, 1, None, None, None, None, Some("共识".to_string()))

--- a/backend/src/db/workspace_setting.rs
+++ b/backend/src/db/workspace_setting.rs
@@ -82,11 +82,63 @@ pub async fn upsert_workspace_settings(
             default_response_loop_id: ActiveValue::Set(default_response_loop_id.filter(|&x| x != 0)),
             default_response_executor: ActiveValue::Set(default_response_executor),
             system_prompt: ActiveValue::Set(system_prompt),
+            // upsert 不负责 relay-max（由专用 DAO update_workspace_delegate_max_rounds 管理），
+            // 新建行时显式 NotSet → INSERT 落 NULL（=未配置，三级解析回退兜底常量）。
+            delegate_max_rounds: ActiveValue::NotSet,
             updated_at: ActiveValue::Set(Some(now)),
         };
         am.insert(&db.conn).await?;
     }
 
+    Ok(())
+}
+
+/// 单独更新工作空间的「委派接力轮数上限」默认（需求 092 护栏配置化）。
+///
+/// 刻意独立于 [`upsert_workspace_settings`]：后者是多字段位置式签名，11 处既有调用点多数与本字段
+/// 无关（executor_service / feishu_listener 的响应配置流程），强加新参会迫使它们各补一个 `None`，
+/// 既增加无关 diff、也放大冲突面。单字段更新走本函数，零波及既有调用，且「接力护栏」与「响应配置」
+/// 本就是两个关注点，分而治之更清晰。
+///
+/// 语义（与任务级 [`crate::db::task::update_delegate_max_rounds`] 一致，便于记忆）：
+/// - `Some(n)`（n≥1，由 handler 校验）→ 置为 n，任务级未覆盖时以此为准。
+/// - `None` → 清空该列，回退终极兜底常量 `MAX_DELEGATE_ROUNDS`。
+///
+/// 行不存在时按 [`upsert_workspace_settings`] 同口径新建一行（`default_response_type` 默认 "todo"），
+/// 仅本字段带值，其余走默认/NULL。
+pub async fn update_workspace_delegate_max_rounds(
+    db: &Database,
+    workspace_id: i64,
+    max: Option<i64>,
+) -> Result<(), sea_orm::DbErr> {
+    use crate::db::entity::workspace_settings as ws;
+
+    let existing = ws::Entity::find()
+        .filter(ws::Column::WorkspaceId.eq(workspace_id))
+        .one(&db.conn)
+        .await?;
+    if let Some(model) = existing {
+        // 既有行：仅改本列 + 刷新 updated_at，其余列不动。
+        let mut am: ws::ActiveModel = model.into();
+        am.delegate_max_rounds = ActiveValue::Set(max);
+        am.updated_at = ActiveValue::Set(Some(crate::models::utc_timestamp()));
+        am.update(&db.conn).await?;
+    } else {
+        // 无行：按 upsert 新建口径补一行，仅本字段带值。
+        let now = crate::models::utc_timestamp();
+        let am = ws::ActiveModel {
+            id: ActiveValue::NotSet,
+            workspace_id: ActiveValue::Set(workspace_id),
+            default_response_type: ActiveValue::Set("todo".to_string()),
+            default_response_todo_id: ActiveValue::Set(None),
+            default_response_loop_id: ActiveValue::Set(None),
+            default_response_executor: ActiveValue::Set(None),
+            system_prompt: ActiveValue::Set(None),
+            delegate_max_rounds: ActiveValue::Set(max),
+            updated_at: ActiveValue::Set(Some(now)),
+        };
+        am.insert(&db.conn).await?;
+    }
     Ok(())
 }
 
@@ -149,5 +201,42 @@ mod tests {
         .unwrap();
         let settings = get_workspace_settings(&db, 1).await.unwrap().unwrap();
         assert_eq!(settings.system_prompt.as_deref(), Some(""));
+    }
+
+    /// update_workspace_delegate_max_rounds：无既有行时新建一行并写入上限。
+    #[tokio::test]
+    async fn test_update_ws_delegate_max_rounds_inserts_when_absent() {
+        let db = Database::new(":memory:").await.unwrap();
+        update_workspace_delegate_max_rounds(&db, 7, Some(15))
+            .await
+            .unwrap();
+        let s = get_workspace_settings(&db, 7).await.unwrap().unwrap();
+        assert_eq!(s.delegate_max_rounds, Some(15));
+        // 新建行走默认响应类型口径，避免空行误用。
+        assert_eq!(s.default_response_type, "todo");
+    }
+
+    /// 既有行：置值后再传 None 清空（回退兜底），不影响其他列。
+    #[tokio::test]
+    async fn test_update_ws_delegate_max_rounds_set_then_clear() {
+        let db = Database::new(":memory:").await.unwrap();
+        // 先建行并写入 system_prompt，验证单字段更新不误伤其他列。
+        upsert_workspace_settings(&db, 1, None, None, None, None, Some("共识".to_string()))
+            .await
+            .unwrap();
+        update_workspace_delegate_max_rounds(&db, 1, Some(20))
+            .await
+            .unwrap();
+        let s = get_workspace_settings(&db, 1).await.unwrap().unwrap();
+        assert_eq!(s.delegate_max_rounds, Some(20));
+        assert_eq!(s.system_prompt.as_deref(), Some("共识"));
+        // None = 清空回退兜底。
+        update_workspace_delegate_max_rounds(&db, 1, None)
+            .await
+            .unwrap();
+        let s2 = get_workspace_settings(&db, 1).await.unwrap().unwrap();
+        assert_eq!(s2.delegate_max_rounds, None);
+        // 其他列不受清空影响。
+        assert_eq!(s2.system_prompt.as_deref(), Some("共识"));
     }
 }

--- a/backend/src/handlers/agent_bot.rs
+++ b/backend/src/handlers/agent_bot.rs
@@ -843,10 +843,10 @@ pub async fn get_workspace_settings(
             None,
         ),
     };
-    // effective：raw 为 NULL（未配置）或非法 0 时回退终极兜底常量；前端 placeholder/提示读它，永不硬编码 10。
-    let max_effective = raw_max
-        .filter(|&x| x > 0)
-        .unwrap_or(crate::handlers::task_posts::MAX_DELEGATE_ROUNDS);
+    // effective：复用 task_posts 的统一口径（合法区间 1..=CAP 才采纳，否则兜底常量）。
+    // 既消除「此处再手写一遍 filter(>0).unwrap_or(常量)」的重复，又顺带获得 >CAP 脏数据钳制，
+    // 与 resolve / 徽标展示共用同一收敛逻辑，前端 placeholder/提示读它，永不硬编码 10。
+    let max_effective = crate::handlers::task_posts::workspace_effective_max(raw_max);
     Ok(ApiResponse::ok(serde_json::json!({
         "workspace_id": workspace_id,
         "default_response_type": resp_type,
@@ -893,6 +893,9 @@ pub async fn update_workspace_settings(
         workspace_guard::verify_loop_belongs_to_ws(&state.db, loop_id, workspace_id).await?;
     }
 
+    // relay 上限越界校验前置到任何写入之前：否则先 upsert 其它 settings、随后才发现越界返回 400，
+    // 会留下「其它字段已写、relay 未写」的部分写不一致（评审发现）。null=清除放行，仅拦越界值。
+    task_posts::validate_delegate_max_rounds(req.delegate_max_rounds)?;
     crate::db::workspace_setting::upsert_workspace_settings(
         &state.db,
         workspace_id,
@@ -904,8 +907,11 @@ pub async fn update_workspace_settings(
     )
     .await
     .map_err(|e| AppError::Internal(e.to_string()))?;
-    // relay 上限走独立 DAO（未并入 upsert，免波及 11 处无关调用点）；越界复用集中口径，null=清除。
-    task_posts::validate_delegate_max_rounds(req.delegate_max_rounds)?;
+    // relay 上限走独立 DAO（未并入 upsert，免波及 executor_service / feishu_listener 等 11 处无关调用点）；
+    // 越界已在上面统一拦截，此处 null=清除回退兜底常量。
+    // 两次写均落在同一张 workspace_settings 行上：依「后端规范 09-事务规范 §3 隐式事务」，
+    // 单表写无需显式事务（SeaORM 每条 auto-commit）；最坏情况是中途失败留下 stale 的 relay-max，
+    // 而设置页是整表保存、用户可随时重存，影响极低——不值得为折叠它而改 11 处无关签名。
     crate::db::workspace_setting::update_workspace_delegate_max_rounds(
         &state.db,
         workspace_id,

--- a/backend/src/handlers/agent_bot.rs
+++ b/backend/src/handlers/agent_bot.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 use tokio::time::sleep;
 
-use crate::handlers::{workspace_guard, AppError, AppState};
+use crate::handlers::{task_posts, workspace_guard, AppError, AppState};
 use crate::models::ApiResponse;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -821,26 +821,44 @@ pub async fn get_workspace_settings(
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?;
 
-    match settings {
-        Some(s) => Ok(ApiResponse::ok(serde_json::json!({
-            "workspace_id": s.workspace_id,
-            "default_response_type": s.default_response_type,
-            "default_response_todo_id": s.default_response_todo_id,
-            "default_response_loop_id": s.default_response_loop_id,
-            "default_response_executor": s.default_response_executor,
-            "system_prompt": s.system_prompt,
-            "updated_at": s.updated_at,
-        }))),
-        None => Ok(ApiResponse::ok(serde_json::json!({
-            "workspace_id": workspace_id,
-            "default_response_type": "todo",
-            "default_response_todo_id": null,
-            "default_response_loop_id": null,
-            "default_response_executor": null,
-            "system_prompt": null,
-            "updated_at": null,
-        }))),
-    }
+    // 合并 Some/None 两分支：None 时回退到与「未配置」等价的默认展示口径，避免两段近乎重复的 json!。
+    // 各字段从 Model 取值或回退默认；relay 上限额外算 effective（raw NULL → 兜底常量）。
+    let (resp_type, todo_id, loop_id, executor, prompt, raw_max, updated_at) = match settings {
+        Some(s) => (
+            s.default_response_type,
+            s.default_response_todo_id,
+            s.default_response_loop_id,
+            s.default_response_executor,
+            s.system_prompt,
+            s.delegate_max_rounds,
+            s.updated_at,
+        ),
+        None => (
+            "todo".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+    };
+    // effective：raw 为 NULL（未配置）或非法 0 时回退终极兜底常量；前端 placeholder/提示读它，永不硬编码 10。
+    let max_effective = raw_max
+        .filter(|&x| x > 0)
+        .unwrap_or(crate::handlers::task_posts::MAX_DELEGATE_ROUNDS);
+    Ok(ApiResponse::ok(serde_json::json!({
+        "workspace_id": workspace_id,
+        "default_response_type": resp_type,
+        "default_response_todo_id": todo_id,
+        "default_response_loop_id": loop_id,
+        "default_response_executor": executor,
+        "system_prompt": prompt,
+        // raw：用户显式配置的上限（NULL=未配置）；effective：解析后实际生效值。
+        "delegate_max_rounds": raw_max,
+        "delegate_max_rounds_effective": max_effective,
+        "updated_at": updated_at,
+    })))
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -852,6 +870,11 @@ pub struct UpdateWorkspaceSettingsRequest {
     /// 工作空间级共识 prompt（需求 022）。
     /// Some(含空串) 覆写；None 不动。用户清空时前端传空串。
     pub system_prompt: Option<String>,
+    /// 工作空间级「委派接力轮数上限」默认（需求 092）。
+    /// 语义与任务 PATCH 一致：null=清除回退兜底常量；N（1..=50）=置默认。
+    /// 注：本字段是 settings 表单唯一需要「恢复默认」动作的字段，故 null=清除而非增量跳过
+    /// （区别于同 struct 其它字段 None=skip）；表单恒整表保存，不会因漏传而误清。
+    pub delegate_max_rounds: Option<i64>,
 }
 
 /// 更新工作空间的设置
@@ -878,6 +901,15 @@ pub async fn update_workspace_settings(
         req.default_response_loop_id,
         req.default_response_executor,
         req.system_prompt,
+    )
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+    // relay 上限走独立 DAO（未并入 upsert，免波及 11 处无关调用点）；越界复用集中口径，null=清除。
+    task_posts::validate_delegate_max_rounds(req.delegate_max_rounds)?;
+    crate::db::workspace_setting::update_workspace_delegate_max_rounds(
+        &state.db,
+        workspace_id,
+        req.delegate_max_rounds,
     )
     .await
     .map_err(|e| AppError::Internal(e.to_string()))?;

--- a/backend/src/handlers/task_posts.rs
+++ b/backend/src/handlers/task_posts.rs
@@ -802,10 +802,53 @@ async fn validate_reply_parent(
 //   - 是管家（@专家帖的 expert_name == assignee）→ 解析其结论里的 @：
 //       含 @yyy → 触发 yyy 执行（接力下一跳）；不含 @ → 管家判定完成，写说明帖终止。
 //   - 不是管家（被@者完成）→ 唤醒 assignee 管家决策下一步。
-// 护栏：continue_rounds 每轮 +1，达 MAX_DELEGATE_ROUNDS 强制停。循环由此有界，不会无限递归。
+// 护栏：continue_rounds 每轮 +1，达「有效上限」(三级可配)强制停。循环由此有界，不会无限递归。
 
-/// 自动接力轮数硬上限（护栏）。集中常量便于将来演进为可配置（需求 §3 暂不做成本上限）。
+/// 自动接力轮数的「终极兜底」上限：仅当任务与工作空间均未配置 delegate_max_rounds 时生效
+/// （三级解析见 [`resolve_delegate_max_rounds`]）。保留常量以确保任何配置缺失下循环仍必有界。
 pub(crate) const MAX_DELEGATE_ROUNDS: i64 = 10;
+
+/// 接力轮数上限的合法上界（防 runaway token 成本）：任务/工作空间配置值不得超过此值，
+/// 越界由 [`validate_delegate_max_rounds`] 拒 400。下界恒为 1（至少允许 1 轮接力）。
+pub(crate) const DELEGATE_MAX_ROUNDS_CAP: i64 = 50;
+
+/// 校验用户传入的接力上限：`Some(n)` 需落在 `1..=DELEGATE_MAX_ROUNDS_CAP`；`None` 视为
+/// 「清除覆盖/用默认」直接放行。create/PATCH 任务、工作空间设置三处复用，集中越界口径。
+pub(crate) fn validate_delegate_max_rounds(max: Option<i64>) -> Result<(), AppError> {
+    if let Some(n) = max {
+        if !(1..=DELEGATE_MAX_ROUNDS_CAP).contains(&n) {
+            return Err(AppError::BadRequest(format!(
+                "接力轮数上限必须在 1..={DELEGATE_MAX_ROUNDS_CAP} 之间"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// 三级解析某委派任务的「接力轮数有效上限」：任务覆盖 → 工作空间默认 → 终极兜底常量。
+///
+/// 收口在一处，护栏决策与详情展示共用同一口径，避免各路径分散解析导致漂移。DB 读失败时
+/// graceful-degrade 回退兜底（`.ok()` 吞错），不阻塞接力主流程（仿 pre_spawn prompt 注入降级）。
+pub(crate) async fn resolve_delegate_max_rounds(db: &Database, task: &tasks::Model) -> i64 {
+    // 一级：任务自身覆盖优先（过滤 0 这种非法值，落空则进下一级）。
+    if let Some(m) = task.delegate_max_rounds.filter(|&x| x > 0) {
+        return m;
+    }
+    // 二级：工作空间默认（无行 / NULL / 读失败都落空 → 进三级）。
+    if let Some(ws_id) = task.workspace_id {
+        if let Some(m) = crate::db::workspace_setting::get_workspace_settings(db, ws_id)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|s| s.delegate_max_rounds)
+            .filter(|&x| x > 0)
+        {
+            return m;
+        }
+    }
+    // 三级：终极兜底常量。
+    MAX_DELEGATE_ROUNDS
+}
 
 /// 接力纯决策结果：把「读库 + 计数」与「触发执行/写帖」解耦，纯决策可单测覆盖全部分支。
 enum DelegateRelayAction {
@@ -900,9 +943,11 @@ pub(crate) async fn continue_delegated_task(
     } else {
         Vec::new()
     };
-    // 5. 纯决策 → 推进。
-    let action = plan_delegate_relay(new_rounds, MAX_DELEGATE_ROUNDS, x_is_assignee, &mentions);
-    execute_relay_action(handles, &task, &assignee, action, &mentions, result_str).await;
+    // 5. 纯决策 → 推进。有效上限三级解析(任务→工作空间→兜底)算一次，决策与触顶文案共用。
+    let effective_max = resolve_delegate_max_rounds(handles.db, &task).await;
+    let action = plan_delegate_relay(new_rounds, effective_max, x_is_assignee, &mentions);
+    execute_relay_action(handles, &task, &assignee, action, &mentions, result_str, effective_max)
+        .await;
 }
 
 /// 取本次执行对应的占位帖（含 task_id / expert_name）；帖已删或查询失败返回 None。
@@ -936,12 +981,14 @@ async fn execute_relay_action(
     action: DelegateRelayAction,
     mentions: &[MentionDto],
     result_str: &str,
+    // 有效上限(三级解析):触顶文案需展示真实阈值，而非写死常量，否则与实际熔断口径不符。
+    effective_max: i64,
 ) {
     match action {
         DelegateRelayAction::HitLimit => {
             let msg = format!(
                 "⚠️ 自动接力已达 {} 轮上限，停止调度。如需继续请在讨论区手动 @。",
-                MAX_DELEGATE_ROUNDS
+                effective_max
             );
             insert_relay_note_post(handles, task, assignee, &msg).await;
         }
@@ -1366,6 +1413,8 @@ mod tests {
             assignee_name: None,
             auto_continue: 0,
             continue_rounds: 0,
+            // 接力上限覆盖：helper 默认未覆盖（None → 三级解析回退兜底），不影响讨论触发测试。
+            delegate_max_rounds: None,
         }
     }
 
@@ -1507,5 +1556,81 @@ mod tests {
         assert!(v["replies"].as_array().expect("replies array").is_empty());
         // 主楼层自身字段未丢（id 仍在）。
         assert_eq!(v["id"].as_i64(), Some(2));
+    }
+
+    // —— 需求 092：接力上限配置化（范围校验 + 三级解析）——
+
+    /// validate_delegate_max_rounds：None 与 1..=50 放行，越界（0/-1/51）拒 400。
+    #[test]
+    fn test_validate_delegate_max_rounds_bounds() {
+        // None = 沿用默认，永远放行（create/PATCH/PUT 三处一致）。
+        assert!(validate_delegate_max_rounds(None).is_ok());
+        // 闭区间边界 1 与 50 合法。
+        assert!(validate_delegate_max_rounds(Some(1)).is_ok());
+        assert!(validate_delegate_max_rounds(Some(50)).is_ok());
+        // 下界外：0（非合法轮数）/ -1 拒。
+        assert!(validate_delegate_max_rounds(Some(0)).is_err());
+        assert!(validate_delegate_max_rounds(Some(-1)).is_err());
+        // 上界外：51 拒（防 runaway token 成本，CAP=50）。
+        assert!(validate_delegate_max_rounds(Some(51)).is_err());
+    }
+
+    /// resolve_delegate_max_rounds：任务覆盖 > 工作空间默认 > 兜底常量 三级。
+    /// 用内存库真实写入两级配置，验证解析优先级与回退链路（非 mock）。
+    #[tokio::test]
+    async fn test_resolve_delegate_max_rounds_three_levels() {
+        let db = Database::new(":memory:").await.expect("memory db");
+        // 先置工作空间默认(15)，再建一个带覆盖(7)的任务：覆盖必须优先。
+        crate::db::workspace_setting::update_workspace_delegate_max_rounds(&db, 1, Some(15))
+            .await
+            .expect("set ws default");
+        let t1 = db
+            .create_delegate_task("T1", "D", 1, "expert", "专家A", true, Some(7))
+            .await
+            .expect("create t1");
+        assert_eq!(
+            resolve_delegate_max_rounds(&db, &t1).await,
+            7,
+            "任务覆盖(7) 优先于工作空间默认(15)"
+        );
+        // 二级：任务未覆盖(None) → 取工作空间默认。
+        let t2 = db
+            .create_delegate_task("T2", "D", 1, "expert", "专家A", true, None)
+            .await
+            .expect("create t2");
+        assert_eq!(
+            resolve_delegate_max_rounds(&db, &t2).await,
+            15,
+            "任务未覆盖时取工作空间默认(15)"
+        );
+        // 三级：工作空间(ws 2)也无配置行 → 兜底常量 10。
+        let t3 = db
+            .create_delegate_task("T3", "D", 2, "expert", "专家A", true, None)
+            .await
+            .expect("create t3");
+        assert_eq!(
+            resolve_delegate_max_rounds(&db, &t3).await,
+            MAX_DELEGATE_ROUNDS,
+            "两级均缺省 → 终极兜底常量 10"
+        );
+    }
+
+    /// resolve：任务覆盖为非法 0 时应跳过（回退工作空间默认），验证 .filter(|x|>0) 防御脏数据。
+    /// handler 本会拦 0，但 resolve 仍需对「直写库的脏值」鲁棒，不返回 0 这种会让护栏失效的值。
+    #[tokio::test]
+    async fn test_resolve_delegate_max_rounds_skips_invalid_override() {
+        let db = Database::new(":memory:").await.expect("memory db");
+        let t = db
+            .create_delegate_task("T", "D", 1, "expert", "专家A", true, Some(0))
+            .await
+            .expect("create");
+        crate::db::workspace_setting::update_workspace_delegate_max_rounds(&db, 1, Some(20))
+            .await
+            .expect("set ws");
+        assert_eq!(
+            resolve_delegate_max_rounds(&db, &t).await,
+            20,
+            "覆盖值 0 非法 → 回退工作空间默认(20)，绝不返回 0"
+        );
     }
 }

--- a/backend/src/handlers/task_posts.rs
+++ b/backend/src/handlers/task_posts.rs
@@ -825,28 +825,51 @@ pub(crate) fn validate_delegate_max_rounds(max: Option<i64>) -> Result<(), AppEr
     Ok(())
 }
 
+/// 把单个「原始上限值」收敛为有效值：仅当落在合法闭区间 `1..=CAP` 才采纳，否则回退兜底常量。
+///
+/// 集中「过滤非法 + 回退兜底」口径，供工作空间级 effective 计算（见
+/// `agent_bot::get_workspace_settings`）与三级解析的兜底层复用，避免两处各写一遍
+/// `filter(>0).unwrap_or(常量)` 而漂移。同时过滤**上界 CAP**：直写库可能写入 >50 的脏值，
+/// resolve 作为护栏源头必须把它当无效，否则一个越界脏值会让上限静默放大、护栏形同虚设。
+pub(crate) fn workspace_effective_max(raw: Option<i64>) -> i64 {
+    raw.filter(|&x| (1..=DELEGATE_MAX_ROUNDS_CAP).contains(&x))
+        .unwrap_or(MAX_DELEGATE_ROUNDS)
+}
+
 /// 三级解析某委派任务的「接力轮数有效上限」：任务覆盖 → 工作空间默认 → 终极兜底常量。
 ///
 /// 收口在一处，护栏决策与详情展示共用同一口径，避免各路径分散解析导致漂移。DB 读失败时
 /// graceful-degrade 回退兜底（`.ok()` 吞错），不阻塞接力主流程（仿 pre_spawn prompt 注入降级）。
+/// 任务级与工作空间级都用 `1..=CAP` 区间过滤：直写库的越界脏值（0 / 负 / >CAP）一律视为无效、
+/// 回退下一级，绝不把会让护栏失效的值透传为 effective。
 pub(crate) async fn resolve_delegate_max_rounds(db: &Database, task: &tasks::Model) -> i64 {
-    // 一级：任务自身覆盖优先（过滤 0 这种非法值，落空则进下一级）。
-    if let Some(m) = task.delegate_max_rounds.filter(|&x| x > 0) {
+    // 一级：任务自身覆盖优先（越界脏值视为无效，落空进兜底层）。
+    if let Some(m) = task
+        .delegate_max_rounds
+        .filter(|&x| (1..=DELEGATE_MAX_ROUNDS_CAP).contains(&x))
+    {
         return m;
     }
-    // 二级：工作空间默认（无行 / NULL / 读失败都落空 → 进三级）。
-    if let Some(ws_id) = task.workspace_id {
-        if let Some(m) = crate::db::workspace_setting::get_workspace_settings(db, ws_id)
+    // 二级 + 三级：忽略任务覆盖，解析 工作空间默认 → 兜底常量。
+    resolve_delegate_max_rounds_fallback(db, task.workspace_id).await
+}
+
+/// 三级解析的「兜底层」：忽略任务级覆盖，仅解析 工作空间默认 → 终极兜底常量。
+///
+/// 供任务详情徽标编辑器计算「清除任务覆盖后会回退到几」——即留空/恢复默认后的真实落点。
+/// 注意不能复用 [`resolve_delegate_max_rounds`]：后者会先取任务覆盖，而这里要的正是
+/// 「假设任务覆盖不存在」的值，否则编辑器会把「当前覆盖值」误当成「清除后的回退值」展示。
+pub(crate) async fn resolve_delegate_max_rounds_fallback(db: &Database, ws_id: Option<i64>) -> i64 {
+    // 工作空间默认：无行 / NULL / 越界 / DB 读失败 → workspace_effective_max 内部统一回退兜底常量。
+    if let Some(ws_id) = ws_id {
+        let raw = crate::db::workspace_setting::get_workspace_settings(db, ws_id)
             .await
             .ok()
             .flatten()
-            .and_then(|s| s.delegate_max_rounds)
-            .filter(|&x| x > 0)
-        {
-            return m;
-        }
+            .and_then(|s| s.delegate_max_rounds);
+        return workspace_effective_max(raw);
     }
-    // 三级：终极兜底常量。
+    // 任务无 workspace_id（委派任务理论不应如此，防御性兜底）：直接终极兜底常量。
     MAX_DELEGATE_ROUNDS
 }
 
@@ -1631,6 +1654,68 @@ mod tests {
             resolve_delegate_max_rounds(&db, &t).await,
             20,
             "覆盖值 0 非法 → 回退工作空间默认(20)，绝不返回 0"
+        );
+    }
+
+    /// workspace_effective_max：纯函数边界——None/0/负/>CAP 一律回退兜底常量；1..=50 原样返回。
+    /// 重点覆盖「直写库脏数据」防护：>50 的值不能作为 effective 透传（会让护栏静默放大）。
+    #[test]
+    fn test_workspace_effective_max_bounds() {
+        // 合法闭区间原样返回。
+        assert_eq!(workspace_effective_max(Some(1)), 1);
+        assert_eq!(workspace_effective_max(Some(50)), 50);
+        // 未配置 / 非法下界 → 兜底常量。
+        assert_eq!(workspace_effective_max(None), MAX_DELEGATE_ROUNDS);
+        assert_eq!(workspace_effective_max(Some(0)), MAX_DELEGATE_ROUNDS);
+        assert_eq!(workspace_effective_max(Some(-5)), MAX_DELEGATE_ROUNDS);
+        // 越界上界（脏数据）→ 兜底常量，绝不透传 >CAP 值放大护栏。
+        assert_eq!(workspace_effective_max(Some(51)), MAX_DELEGATE_ROUNDS);
+        assert_eq!(workspace_effective_max(Some(100)), MAX_DELEGATE_ROUNDS);
+    }
+
+    /// resolve：任务覆盖为越界上界（>CAP，脏数据）时应跳过，回退工作空间默认，
+    /// 而非把 100 透传成 effective（会让护栏形同虚设）。handler 本会拦 51，但 resolve 须对直写库鲁棒。
+    #[tokio::test]
+    async fn test_resolve_delegate_max_rounds_skips_over_cap_override() {
+        let db = Database::new(":memory:").await.expect("memory db");
+        // 工作空间默认 12；任务覆盖直写 100（绕开 handler 校验，模拟脏数据）。
+        crate::db::workspace_setting::update_workspace_delegate_max_rounds(&db, 1, Some(12))
+            .await
+            .expect("set ws");
+        let t = db
+            .create_delegate_task("T", "D", 1, "expert", "专家A", true, Some(100))
+            .await
+            .expect("create");
+        assert_eq!(
+            resolve_delegate_max_rounds(&db, &t).await,
+            12,
+            "覆盖值 100 越界 → 回退工作空间默认(12)，绝不返回 100"
+        );
+    }
+
+    /// resolve_delegate_max_rounds_fallback：忽略任务覆盖，只取 工作空间默认 → 兜底。
+    /// 徽标编辑器据此展示「清除覆盖后的真实回退值」，须与 effective（含任务覆盖）明确区分。
+    #[tokio::test]
+    async fn test_resolve_fallback_ignores_task_override() {
+        let db = Database::new(":memory:").await.expect("memory db");
+        crate::db::workspace_setting::update_workspace_delegate_max_rounds(&db, 1, Some(15))
+            .await
+            .expect("set ws");
+        // 任务有覆盖(7)，但 fallback 必须忽略它，返回工作空间默认(15)。
+        let t = db
+            .create_delegate_task("T", "D", 1, "expert", "专家A", true, Some(7))
+            .await
+            .expect("create");
+        assert_eq!(
+            resolve_delegate_max_rounds_fallback(&db, t.workspace_id).await,
+            15,
+            "fallback 忽略任务覆盖(7)，回退工作空间默认(15)"
+        );
+        // 工作空间也无配置(ws 2) → 兜底常量。
+        assert_eq!(
+            resolve_delegate_max_rounds_fallback(&db, Some(2)).await,
+            MAX_DELEGATE_ROUNDS,
+            "工作空间未配置 → 兜底常量 10"
         );
     }
 }

--- a/backend/src/handlers/tasks.rs
+++ b/backend/src/handlers/tasks.rs
@@ -31,6 +31,10 @@ pub struct CreateTaskRequest {
     /// 自动接力开关；仅 `assignee_kind='expert'` 允许 true（前端禁用 + 后端 400 双重校验防绕过）。
     #[serde(default)]
     pub auto_continue: bool,
+    /// 本任务「接力轮数上限」覆盖（仅 delegate 模式有意义）。
+    /// `Some(n)`（1..=50，越界 400）→ 覆盖工作空间默认；`None`/缺省 → 沿用工作空间默认 → 兜底常量。
+    /// 注意：配置的是「上限」，不是「已跑计数」continue_rounds（后者后端单调递增、前端不可直传）。
+    pub delegate_max_rounds: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -159,12 +163,16 @@ async fn create_delegate_task(
     let kind = req.assignee_kind.as_deref().unwrap_or("");
     let name = req.assignee_name.as_deref().unwrap_or("").trim();
     validate_delegate_request(state, ws, kind, name, req.auto_continue).await?;
+    // 接力上限越界校验复用 task_posts 的集中口径（拒 -1 / 51 等），None 视为「用默认」放行。
+    task_posts::validate_delegate_max_rounds(req.delegate_max_rounds)?;
 
     let title = task_title_from_requirement(&req.requirement);
     // description 随首次 INSERT 写入（DAO 内），不再建后单独 update（#1 原子性）。
     let task = state
         .db
-        .create_delegate_task(&title, &req.requirement, ws, kind, name, req.auto_continue)
+        .create_delegate_task(
+            &title, &req.requirement, ws, kind, name, req.auto_continue, req.delegate_max_rounds,
+        )
         .await?;
     // 首帖触发首次执行：force_mention 用已校验的 assignee，失败时 warn 不阻断任务创建。
     let execution_id = land_delegate_first_post(state, &task, kind, name, &req.requirement).await;
@@ -378,6 +386,10 @@ pub async fn get_task_detail(
             "pending_approval_count": pending_counts.get(&exec_id).copied().unwrap_or(0),
         })
     }).collect();
+    // 接力上限三级解析（任务→工作空间→兜底）：详情头部徽标读此有效值，前端不再硬编码 10。
+    // 与护栏决策共用同一 resolve 口径，确保「显示 N/M」与「真实熔断」不漂移。
+    let delegate_max_rounds_effective =
+        task_posts::resolve_delegate_max_rounds(&state.db, &task).await;
     Ok(ApiResponse::ok(serde_json::json!({
         "task": {
             "id": task.id, "title": task.title, "status": task.status,
@@ -390,6 +402,10 @@ pub async fn get_task_detail(
             // 前端类型声明为 boolean，透传数字会让 typeof/严格比较在 P2 接力状态展示时踩雷。
             "auto_continue": task.auto_continue != 0,
             "continue_rounds": task.continue_rounds,
+            // 任务级覆盖原值（用于内联编辑回显/恢复默认判定；NULL=未覆盖）。
+            "delegate_max_rounds": task.delegate_max_rounds,
+            // 解析后的有效上限（徽标 M、触顶文案直接用）；与护栏决策同源。
+            "delegate_max_rounds_effective": delegate_max_rounds_effective,
         },
         "template": template.map(|t| {
             // 版本优先取环路的 process_template_version（执行时的快照），
@@ -494,10 +510,43 @@ pub async fn batch_delete_tasks(
     })))
 }
 
+/// PATCH 任务可变字段请求。当前仅 `delegate_max_rounds` 一项可改；独立结构便于将来扩展。
+#[derive(Debug, Deserialize)]
+pub struct UpdateTaskRequest {
+    /// `Some(n)`（1..=50）置任务级覆盖；`null`/缺省清除覆盖回退工作空间默认（即「恢复默认」）。
+    pub delegate_max_rounds: Option<i64>,
+}
+
+/// PATCH /api/v1/workspaces/{ws}/tasks/{id} — 更新单个任务可变字段（当前仅接力上限覆盖）。
+///
+/// 仅委派任务支持：接力上限是委派接力的专属概念，环路任务配它无意义，故 400 拒绝以免库里
+/// 存无效配置。返回更新后的有效上限（三级解析），前端据此刷新徽标 N/M，无需二次请求详情。
+pub async fn update_task(
+    State(state): State<AppState>,
+    Path((_ws, id)): Path<(i64, i64)>,
+    Json(req): Json<UpdateTaskRequest>,
+) -> Result<ApiResponse<serde_json::Value>, AppError> {
+    let task = state.db.get_task(id).await?.ok_or(AppError::NotFound)?;
+    // 接力上限是委派接力的专属概念；环路任务配它无意义，直接拒，避免存无效配置。
+    if task.execution_mode != "delegate" {
+        return Err(AppError::BadRequest("仅委派任务支持配置接力上限".to_string()));
+    }
+    // 越界校验复用集中口径（与 create 同源），None 视为「清除覆盖/恢复默认」放行。
+    task_posts::validate_delegate_max_rounds(req.delegate_max_rounds)?;
+    state.db.update_delegate_max_rounds(id, req.delegate_max_rounds).await?;
+    // 重读以解析更新后的有效上限：覆盖值已变，必须基于最新库态 resolve，防御并发/写未落库。
+    let updated = state.db.get_task(id).await?.ok_or(AppError::NotFound)?;
+    let effective = task_posts::resolve_delegate_max_rounds(&state.db, &updated).await;
+    Ok(ApiResponse::ok(serde_json::json!({
+        "delegate_max_rounds": updated.delegate_max_rounds,
+        "delegate_max_rounds_effective": effective,
+    })))
+}
+
 pub fn task_routes() -> Router<AppState> {
     Router::new()
         .route("/api/v1/workspaces/{ws}/tasks", axum::routing::get(list_tasks).post(create_task))
-        .route("/api/v1/workspaces/{ws}/tasks/{id}", axum::routing::get(get_task_detail).delete(delete_task))
+        .route("/api/v1/workspaces/{ws}/tasks/{id}", axum::routing::get(get_task_detail).delete(delete_task).patch(update_task))
         .route("/api/v1/workspaces/{ws}/tasks/batch-delete", axum::routing::post(batch_delete_tasks))
         .route("/api/v1/workspaces/{ws}/tasks/{id}/executions", axum::routing::post(create_task_execution))
         .route("/api/v1/artifacts/{aid}/content", axum::routing::get(get_artifact_content))
@@ -725,6 +774,26 @@ mod tests {
         (status, val)
     }
 
+    /// 发 PATCH /tasks/{id} 的小工具，结构与 post_task 一致，仅 method/uri 不同。
+    async fn patch_task(app: &axum::Router, ws_id: i64, task_id: i64, body: Value) -> (StatusCode, Value) {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/api/v1/workspaces/{ws_id}/tasks/{task_id}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).expect("json")))
+                    .expect("request build"),
+            )
+            .await
+            .expect("patch task request");
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.expect("read body");
+        let val: Value = serde_json::from_slice(&bytes).expect("parse body");
+        (status, val)
+    }
+
     /// 委派执行器 + 开自动接力 必须被拒（400）：执行器无调度能力，防绕过前端禁用。
     /// 此分支在触发执行之前返回，故不会真实 spawn 执行器。
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -762,13 +831,89 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_REQUEST);
     }
 
+    /// create 委派：接力上限越界（-1）必须 400。
+    /// 用 executor:claude（已注册）+ auto_continue:false 通过处理人校验，使命中范围校验分支。
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_create_delegate_rejects_negative_max_rounds() {
+        let (app, ws_id, _db) = build_app().await;
+        let body = serde_json::json!({
+            "requirement": "测试", "execution_mode": "delegate",
+            "assignee_kind": "executor", "assignee_name": "claude",
+            "auto_continue": false, "delegate_max_rounds": -1,
+        });
+        let (status, _val) = post_task(&app, ws_id, body).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    /// create 委派：接力上限超过 CAP(50) 必须 400。
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_create_delegate_rejects_max_rounds_over_cap() {
+        let (app, ws_id, _db) = build_app().await;
+        let body = serde_json::json!({
+            "requirement": "测试", "execution_mode": "delegate",
+            "assignee_kind": "executor", "assignee_name": "claude",
+            "auto_continue": false, "delegate_max_rounds": 51,
+        });
+        let (status, _val) = post_task(&app, ws_id, body).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    /// PATCH 接力上限：环路任务必须 400（接力上限是委派专属概念，环路配它无意义）。
+    /// 用 DAO 直建环路任务（create_task 默认 execution_mode='loop'），绕开环路触发。
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_patch_max_rounds_rejects_loop_task() {
+        let (app, ws_id, db) = build_app().await;
+        let task = db.create_task("环路任务", ws_id, 0, None).await.expect("create loop task");
+        let (status, _val) =
+            patch_task(&app, ws_id, task.id, serde_json::json!({"delegate_max_rounds": 8})).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    /// PATCH 接力上限：委派任务传合法值 → 200，返回有效值随覆盖变化；null=清除回退兜底。
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_patch_max_rounds_sets_and_returns_effective() {
+        let (app, ws_id, db) = build_app().await;
+        // DAO 直建委派任务，绕开 handler 首帖触发。
+        let task = db
+            .create_delegate_task("委派", "需求", ws_id, "expert", "专家A", true, None)
+            .await
+            .expect("create delegate");
+        // null=清除：本就 None，有效值仍为兜底 10（工作空间亦未配置）。
+        let (s0, v0) =
+            patch_task(&app, ws_id, task.id, serde_json::json!({"delegate_max_rounds": null})).await;
+        assert_eq!(s0, StatusCode::OK);
+        assert_eq!(v0["data"]["delegate_max_rounds_effective"].as_i64(), Some(10));
+        // 置 8 → raw 与有效值均为 8。
+        let (s1, v1) =
+            patch_task(&app, ws_id, task.id, serde_json::json!({"delegate_max_rounds": 8})).await;
+        assert_eq!(s1, StatusCode::OK);
+        assert_eq!(v1["data"]["delegate_max_rounds"].as_i64(), Some(8));
+        assert_eq!(v1["data"]["delegate_max_rounds_effective"].as_i64(), Some(8));
+    }
+
+    /// PATCH 接力上限：越界（51 > CAP）必须 400，且不改动既有覆盖值。
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_patch_max_rounds_rejects_over_cap_keeps_value() {
+        let (app, ws_id, db) = build_app().await;
+        let task = db
+            .create_delegate_task("委派", "需求", ws_id, "expert", "专家A", true, Some(5))
+            .await
+            .expect("create delegate");
+        let (status, _val) =
+            patch_task(&app, ws_id, task.id, serde_json::json!({"delegate_max_rounds": 51})).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        // 越界被拒：既有覆盖 5 不应被改写。
+        let after = db.get_task(task.id).await.expect("get").expect("task");
+        assert_eq!(after.delegate_max_rounds, Some(5), "越界请求不应改动既有值");
+    }
+
     /// DAO：create_delegate_task 写入委派字段正确。
     /// 直接测 DAO 而非 handler，绕开 handler 内对讨论首帖的真实执行触发。
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_dao_create_delegate_task_fields() {
         let (_app, ws_id, db) = build_app().await;
         let task = db
-            .create_delegate_task("委派标题", "委派需求原文", ws_id, "expert", "任务管家", true)
+            .create_delegate_task("委派标题", "委派需求原文", ws_id, "expert", "任务管家", true, None)
             .await
             .expect("create delegate task");
         assert_eq!(task.description, "委派需求原文", "description 随首次 INSERT 写入");
@@ -777,6 +922,7 @@ mod tests {
         assert_eq!(task.assignee_name.as_deref(), Some("任务管家"));
         assert_eq!(task.auto_continue, 1);
         assert_eq!(task.continue_rounds, 0, "新建任务接力计数从 0 起");
+        assert!(task.delegate_max_rounds.is_none(), "未传覆盖时落 NULL（沿用工作空间默认）");
         assert!(task.loop_id.is_none(), "委派任务不绑环路");
     }
 

--- a/backend/src/handlers/tasks.rs
+++ b/backend/src/handlers/tasks.rs
@@ -343,33 +343,36 @@ pub async fn list_tasks(
     Ok(ApiResponse::ok(items))
 }
 
-/// GET /api/v1/tasks/{id}
-pub async fn get_task_detail(
-    State(state): State<AppState>,
-    Path((_ws, id)): Path<(i64, i64)>,
-) -> Result<impl axum::response::IntoResponse, AppError> {
-    let task = state.db.get_task(id).await?.ok_or(AppError::NotFound)?;
-    let template = if let Some(tid) = task.template_id { state.db.get_process_template_by_id(tid).await? } else { None };
-    let loop_ = if let Some(lid) = task.loop_id { state.db.get_loop(lid).await? } else { None };
-    // steps
-    let steps: Vec<_> = if let Some(ref lp) = loop_ {
-        state.db.list_loop_steps_by_loop(lp.id).await?.into_iter().map(|s| serde_json::json!({
-            "id":s.id,"name":s.name,"order_index":s.order_index,
-            "skill_names": serde_json::from_str::<serde_json::Value>(&s.skill_names).unwrap_or_default(),
-            "expected_artifacts": serde_json::from_str::<serde_json::Value>(&s.expected_artifacts).unwrap_or_default(),
-            "gate_config": serde_json::from_str::<serde_json::Value>(&s.gate_config).unwrap_or_default(),
-        })).collect()
-    } else { vec![] };
-    // executions
+/// 组装环路步骤 JSON（skill_names/expected_artifacts/gate_config 三列存的是 JSON 文本，需反序列化）。
+/// 抽出独立函数使 [`get_task_detail`] 保持在 50 行内；无环路时返回空数组。
+async fn build_loop_steps(
+    db: &crate::db::Database,
+    loop_: Option<&crate::db::entity::loops::Model>,
+) -> Result<Vec<serde_json::Value>, AppError> {
+    let Some(lp) = loop_ else { return Ok(vec![]) };
+    Ok(db.list_loop_steps_by_loop(lp.id).await?.into_iter().map(|s| serde_json::json!({
+        "id":s.id,"name":s.name,"order_index":s.order_index,
+        "skill_names": serde_json::from_str::<serde_json::Value>(&s.skill_names).unwrap_or_default(),
+        "expected_artifacts": serde_json::from_str::<serde_json::Value>(&s.expected_artifacts).unwrap_or_default(),
+        "gate_config": serde_json::from_str::<serde_json::Value>(&s.gate_config).unwrap_or_default(),
+    })).collect())
+}
+
+/// 组装任务最近 20 条执行记录 JSON（含每条的待审批环节数，前端据此在历史行标「待审批」）。
+/// 抽出独立函数使 [`get_task_detail`] 保持在 50 行内；用原始 SQL 查 loop_executions + 批量 pending 计数（防 N+1）。
+async fn build_task_executions(
+    db: &crate::db::Database,
+    task_id: i64,
+) -> Result<Vec<serde_json::Value>, AppError> {
     use sea_orm::{ConnectionTrait, DbBackend, Statement};
-    let exec_rows = state.db.conn.query_all(Statement::from_string(DbBackend::Sqlite,
+    let exec_rows = db.conn.query_all(Statement::from_string(DbBackend::Sqlite,
         format!("SELECT id, status, started_at, finished_at, total_steps, completed_steps, failed_steps, trigger_meta \
-                 FROM loop_executions WHERE task_id={} ORDER BY started_at DESC LIMIT 20", id)
+                 FROM loop_executions WHERE task_id={} ORDER BY started_at DESC LIMIT 20", task_id)
     )).await?;
-    // 统计每次执行的待审批环节数，前端据此在执行历史行上显示「待审批」引导标记（NTD-004）。
+    // 一次批量查待审批数再按 exec_id 映射，避免逐行 N+1（NTD-004）。
     let exec_ids: Vec<i64> = exec_rows.iter().map(|r| r.try_get_by::<i64,_>("id").unwrap_or(0)).collect();
-    let pending_counts = state.db.count_pending_approvals_by_execution_ids(&exec_ids).await?;
-    let executions: Vec<_> = exec_rows.iter().map(|r| {
+    let pending_counts = db.count_pending_approvals_by_execution_ids(&exec_ids).await?;
+    Ok(exec_rows.iter().map(|r| {
         let meta = r.try_get_by::<Option<String>,_>("trigger_meta").ok().flatten()
             .and_then(|m| serde_json::from_str::<serde_json::Value>(&m).ok());
         let requirement = meta.as_ref().and_then(|v| v.get("requirement").and_then(|r| r.as_str().map(|s| s.to_string())));
@@ -385,11 +388,25 @@ pub async fn get_task_detail(
             "requirement": requirement,
             "pending_approval_count": pending_counts.get(&exec_id).copied().unwrap_or(0),
         })
-    }).collect();
-    // 接力上限三级解析（任务→工作空间→兜底）：详情头部徽标读此有效值，前端不再硬编码 10。
-    // 与护栏决策共用同一 resolve 口径，确保「显示 N/M」与「真实熔断」不漂移。
-    let delegate_max_rounds_effective =
-        task_posts::resolve_delegate_max_rounds(&state.db, &task).await;
+    }).collect())
+}
+
+/// GET /api/v1/tasks/{id}
+pub async fn get_task_detail(
+    State(state): State<AppState>,
+    Path((_ws, id)): Path<(i64, i64)>,
+) -> Result<impl axum::response::IntoResponse, AppError> {
+    let task = state.db.get_task(id).await?.ok_or(AppError::NotFound)?;
+    let template = if let Some(tid) = task.template_id { state.db.get_process_template_by_id(tid).await? } else { None };
+    let loop_ = if let Some(lid) = task.loop_id { state.db.get_loop(lid).await? } else { None };
+    // steps / executions 构建抽出独立函数，保持本函数聚焦于「取数 + 组装顶层 JSON」。
+    let steps = build_loop_steps(&state.db, loop_.as_ref()).await?;
+    let executions = build_task_executions(&state.db, id).await?;
+    // 接力上限：effective（徽标 M / 触顶文案）+ fallback（徽标编辑器「清除覆盖后回退值」）。
+    // 两者同源 resolve 口径：effective 含任务覆盖，fallback 忽略任务覆盖，确保「显示 N/M」与「真实熔断」不漂移。
+    let delegate_max_rounds_effective = task_posts::resolve_delegate_max_rounds(&state.db, &task).await;
+    let delegate_max_rounds_fallback =
+        task_posts::resolve_delegate_max_rounds_fallback(&state.db, task.workspace_id).await;
     Ok(ApiResponse::ok(serde_json::json!({
         "task": {
             "id": task.id, "title": task.title, "status": task.status,
@@ -406,6 +423,9 @@ pub async fn get_task_detail(
             "delegate_max_rounds": task.delegate_max_rounds,
             // 解析后的有效上限（徽标 M、触顶文案直接用）；与护栏决策同源。
             "delegate_max_rounds_effective": delegate_max_rounds_effective,
+            // 「清除任务覆盖后」的回退值（工作空间默认或兜底常量）：徽标编辑器据此提示「留空=用工作空间默认（X 轮）」。
+            // 不能复用 effective：任务有覆盖时 effective 即覆盖值，会让「留空回退提示」误显成被清除的那个覆盖值。
+            "delegate_max_rounds_fallback": delegate_max_rounds_fallback,
         },
         "template": template.map(|t| {
             // 版本优先取环路的 process_template_version（执行时的快照），
@@ -523,19 +543,32 @@ pub struct UpdateTaskRequest {
 /// 存无效配置。返回更新后的有效上限（三级解析），前端据此刷新徽标 N/M，无需二次请求详情。
 pub async fn update_task(
     State(state): State<AppState>,
-    Path((_ws, id)): Path<(i64, i64)>,
+    Path((ws, id)): Path<(i64, i64)>,
     Json(req): Json<UpdateTaskRequest>,
 ) -> Result<ApiResponse<serde_json::Value>, AppError> {
     let task = state.db.get_task(id).await?.ok_or(AppError::NotFound)?;
+    // 工作空间归属校验：path ws 与任务 workspace_id 不符则 404，防 URL 串用改他空间任务。
+    // 仅当任务 workspace_id 已落值时校验（存量 None 任务跳过，避免误拒）。
+    // 注：同文件 get_task_detail/delete_task 沿用旧的全局 id 口径未做此校验（存量遗留，ntd 为本地单用户
+    // 工具，非租户隔离边界）；本新端点先行收紧，全面 ws 化属另一次专项改造，不在本 PR 范围。
+    if let Some(w) = task.workspace_id {
+        if w != ws {
+            return Err(AppError::NotFound);
+        }
+    }
     // 接力上限是委派接力的专属概念；环路任务配它无意义，直接拒，避免存无效配置。
     if task.execution_mode != "delegate" {
         return Err(AppError::BadRequest("仅委派任务支持配置接力上限".to_string()));
     }
     // 越界校验复用集中口径（与 create 同源），None 视为「清除覆盖/恢复默认」放行。
     task_posts::validate_delegate_max_rounds(req.delegate_max_rounds)?;
-    state.db.update_delegate_max_rounds(id, req.delegate_max_rounds).await?;
-    // 重读以解析更新后的有效上限：覆盖值已变，必须基于最新库态 resolve，防御并发/写未落库。
-    let updated = state.db.get_task(id).await?.ok_or(AppError::NotFound)?;
+    // DAO 返回更新后的 Model，直接 resolve 有效值，免去一次冗余 get_task 重读
+    // （find→update 已拿到最新态；resolve 基于刚写入的 updated，所见即所写）。
+    let updated = state
+        .db
+        .update_delegate_max_rounds(id, req.delegate_max_rounds)
+        .await?
+        .ok_or(AppError::NotFound)?;
     let effective = task_posts::resolve_delegate_max_rounds(&state.db, &updated).await;
     Ok(ApiResponse::ok(serde_json::json!({
         "delegate_max_rounds": updated.delegate_max_rounds,
@@ -861,7 +894,7 @@ mod tests {
     /// PATCH 接力上限：环路任务必须 400（接力上限是委派专属概念，环路配它无意义）。
     /// 用 DAO 直建环路任务（create_task 默认 execution_mode='loop'），绕开环路触发。
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_patch_max_rounds_rejects_loop_task() {
+    async fn test_update_task_rejects_loop_task() {
         let (app, ws_id, db) = build_app().await;
         let task = db.create_task("环路任务", ws_id, 0, None).await.expect("create loop task");
         let (status, _val) =
@@ -871,7 +904,7 @@ mod tests {
 
     /// PATCH 接力上限：委派任务传合法值 → 200，返回有效值随覆盖变化；null=清除回退兜底。
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_patch_max_rounds_sets_and_returns_effective() {
+    async fn test_update_task_sets_and_returns_effective() {
         let (app, ws_id, db) = build_app().await;
         // DAO 直建委派任务，绕开 handler 首帖触发。
         let task = db
@@ -891,9 +924,52 @@ mod tests {
         assert_eq!(v1["data"]["delegate_max_rounds_effective"].as_i64(), Some(8));
     }
 
+    /// PATCH 接力上限：边界下限 1 合法 → 200，有效值=1（哪怕只允许 1 轮，护栏口径仍成立）。
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_update_task_accepts_lower_bound_one() {
+        let (app, ws_id, db) = build_app().await;
+        let task = db
+            .create_delegate_task("委派", "需求", ws_id, "expert", "专家A", true, None)
+            .await
+            .expect("create delegate");
+        let (status, val) =
+            patch_task(&app, ws_id, task.id, serde_json::json!({"delegate_max_rounds": 1})).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(val["data"]["delegate_max_rounds_effective"].as_i64(), Some(1));
+    }
+
+    /// PATCH 接力上限：边界上限 CAP(50) 合法 → 200，有效值=50（含上界，>50 才拒）。
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_update_task_accepts_upper_bound_cap() {
+        let (app, ws_id, db) = build_app().await;
+        let task = db
+            .create_delegate_task("委派", "需求", ws_id, "expert", "专家A", true, None)
+            .await
+            .expect("create delegate");
+        let (status, val) =
+            patch_task(&app, ws_id, task.id, serde_json::json!({"delegate_max_rounds": 50})).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(val["data"]["delegate_max_rounds_effective"].as_i64(), Some(50));
+    }
+
+    /// PATCH 跨工作空间：任务属于 ws_id，用其它 ws 的 URL PATCH 必须 404（归属校验防串改）。
+    /// 印证 update_task 的 ws 收紧：仅当任务 workspace_id 与 path ws 一致才放行。
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_update_task_rejects_wrong_workspace() {
+        let (app, ws_id, db) = build_app().await;
+        let task = db
+            .create_delegate_task("委派", "需求", ws_id, "expert", "专家A", true, Some(5))
+            .await
+            .expect("create delegate");
+        // 任务 workspace_id=ws_id；用一个显然不同的 ws 发 PATCH → 归属校验拦 404。
+        let (status, _val) =
+            patch_task(&app, ws_id + 999, task.id, serde_json::json!({"delegate_max_rounds": 8})).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
     /// PATCH 接力上限：越界（51 > CAP）必须 400，且不改动既有覆盖值。
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_patch_max_rounds_rejects_over_cap_keeps_value() {
+    async fn test_update_task_rejects_over_cap_keeps_value() {
         let (app, ws_id, db) = build_app().await;
         let task = db
             .create_delegate_task("委派", "需求", ws_id, "expert", "专家A", true, Some(5))

--- a/docs/design/092-任务委派执行-设计.md
+++ b/docs/design/092-任务委派执行-设计.md
@@ -62,9 +62,11 @@
 | `assignee_kind` | TEXT | NULL | `'executor'` / `'expert'`（仅 delegate） |
 | `assignee_name` | TEXT | NULL | 委派处理人名 |
 | `auto_continue` | INTEGER | `0` | 自动接力开关；仅 `assignee_kind='expert'` 允许 `1` |
-| `continue_rounds` | INTEGER | `0` | 接力已执行轮数（护栏计数） |
+| `continue_rounds` | INTEGER | `0` | 接力已执行轮数（护栏计数，后端单调递增，前端不可直传） |
+| `delegate_max_rounds` | INTEGER | NULL | 接力上限**任务级覆盖**（092 配置化）；NULL=沿用工作空间默认 → 兜底常量 |
 
 - `delegate` 模式下 `loop_id=NULL`（现有 `loop_id: Option<i64>`，兼容）。
+- `workspace_settings` 同步加 `delegate_max_rounds`（工作空间级默认，NULL=回退兜底常量），v92 两表各加一列。
 - 同步更新 `db/entity/tasks.rs`（ActiveModel 字段）与 `consolidated_schema.rs`（全新库的 `CREATE TABLE tasks` 含新列）。
 - migration 幂等：参考既有加列迁移（如 `v65`/`v68`）的「查 `pragma table_info` 判列存在再 ADD」模式，避免重复执行报错。
 
@@ -119,8 +121,9 @@ handlers/tasks::create_task（新增 delegate 分支）
 某次讨论类执行完成 ──► completion.rs
   ├─ discussion 回写（060 既有）：把结论写回对应智能体占位帖   ← 对 discussion/discussion_auto 都生效
   └─【新增】接力判断（仅 task.execution_mode=delegate && auto_continue）：
-       (a) continue_rounds += 1；若 continue_rounds >= MAX_ROUNDS(10) → 写「已达上限，停止接力」帖，return
-           （护栏用 >=：递增后计数到 10 即停，最多 10 轮接力；若用 > 会放行第 11 跳，偏离需求 AC8「达到 10 强制停止」。）
+       (a) continue_rounds += 1；若 continue_rounds >= effective_max → 写「已达上限，停止接力」帖，return
+           （护栏用 >=：递增后计数到上限即停，最多 effective_max 轮接力；若用 > 会放行第 max+1 跳，偏离需求 AC8「达到上限强制停止」。）
+           （**effective_max 为三级可配**，见 §5.5：任务覆盖 → 工作空间默认 → 兜底常量 10；建库时口径固定为 10，092 护栏配置化后改为运行时可调。）
        (b) 取本次执行的专家 X（载体 todo 的 expert_name/executor）：
             ├─ X == assignee E（管家决策）→ 解析其结论帖正文里的 @：
             │     ├─ 含 @yyy → 触发 yyy 执行(trigger='discussion_auto')，结束本步（yyy 完成后会再回到这里）
@@ -189,9 +192,26 @@ E ──执行(决策)──► 结论帖 C3(content:"任务完成，无需再�
 - 拆分为小函数：`maybe_continue_delegated_task(...)`（≤30 行编排）→ `next_delegate_step(...)`（管家/被@者分派）→ 复用 `trigger_post_execution`。
 - 失败容忍：接力触发失败只记 `tracing::warn`，不影响本次执行已落定的成功状态（与 060 回写降级哲学一致）。
 
-### 6.6 常量
-- `MAX_DELEGATE_ROUNDS: i64 = 10`（接力上限，集中一处便于演进为可配置）。
+### 6.6 常量（护栏已演化为三级可配，见 §5.5）
+- `MAX_DELEGATE_ROUNDS: i64 = 10`（**终极兜底**上限：仅当任务与工作空间均未配置 `delegate_max_rounds` 时生效）。
+- `DELEGATE_MAX_ROUNDS_CAP: i64 = 50`（用户配置值的合法上界，防 runaway token 成本；下界恒 1）。
 - `TRIGGER_DISCUSSION_AUTO: &str = "discussion_auto"`。
+
+### 5.5 接力上限三级配置（092 护栏配置化）
+
+护栏的「上限阈值」从写死常量演化为**运行时可配**的三级解析（`resolve_delegate_max_rounds`）：
+
+```text
+effective_max = task.delegate_max_rounds            （per-task 覆盖；NULL ↓）
+             ?? workspace_settings.delegate_max_rounds （per-workspace 默认；NULL ↓）
+             ?? MAX_DELEGATE_ROUNDS(10)              （终极兜底常量，保留）
+```
+
+- **任务级**：`tasks.delegate_max_rounds`，建任务时可填（CreateTaskModal）、详情页可改（徽标内联 ✎ 编辑）；`null`=清除覆盖回退工作空间默认。
+- **工作空间级**：`workspace_settings.delegate_max_rounds`，设置页「委派接力上限」配置；`null`=回退兜底常量。
+- **兜底常量**：`10`，确保任何配置缺失下循环仍必有界。
+
+> 关键不变量（设计 §5.2 红线）：配置化的只是「**上限阈值**」；`continue_rounds`（已跑计数）仍由后端单调递增、前端不可直传，护栏不可绕过。解析函数 graceful-degrade：DB 读失败 `.ok()` 回退兜底，不阻塞接力主流程。配置值越界（非 1..=50）一律 400（端点侧校验，不只靠前端 InputNumber）。
 
 ### 6.7 不改动
 - `CodeExecutor` trait / `adapters/*`、`expert/`、`execution_records` 语义、`run_todo_execution` 管线、`task_posts` 表结构、`todos.kind='discussion'` 隐藏过滤、工艺环路全部逻辑。
@@ -207,6 +227,8 @@ assignee_kind?: 'executor' | 'expert';
 assignee_name?: string;
 auto_continue?: boolean;
 continue_rounds?: number;
+delegate_max_rounds?: number | null;       // 任务级上限覆盖（092 配置化）
+delegate_max_rounds_effective?: number;    // 三级解析后的有效上限（徽标 M 读它，前端不硬编码 10）
 ```
 
 ### 7.2 `api/bundled.ts::createTask`
@@ -223,7 +245,7 @@ continue_rounds?: number;
 
 ### 7.4 委派任务详情
 - `TaskDetailPanel`/`TaskDetailTabs`：`execution_mode='delegate'` 时默认激活「讨论」Tab（无环路环节视图）。
-- 自动接力进行中：讨论区顶部或任务头展示「管家调度中（第 {continue_rounds}/10 轮）」（数据来自 task 详情或讨论帖 `running_total`）。
+- 自动接力进行中：讨论区顶部或任务头展示「管家调度中 {continue_rounds}/{delegate_max_rounds_effective}」（上限取三级解析的有效值，前端不硬编码；徽标可点击 ✎ 内联调整该任务的覆盖）。
 
 ---
 
@@ -250,15 +272,18 @@ continue_rounds?: number;
 | `create_task` 回归 | 旧请求（无新字段）/ loop 模式 | 行为与改动前一致 |
 | 自动接力（管家中枢） | mock：管家结论含 @codex → 不含 @ | 含@时触发 codex（discussion_auto）；不含@时写「完成」帖终止 |
 | 自动接力（被@者→唤醒管家） | mock：codex 执行完成 | 触发管家决策执行（discussion_auto） |
-| 护栏 | `continue_rounds` 到 10 | 不再触发，写「达上限」帖 |
+| 护栏 | `continue_rounds` 到 effective_max（三级可配） | 不再触发，写「达上限」帖 |
 | 公共函数抽取回归 | 060 `create_post` 含 @codex | 与改动前一致（人帖+占位帖+载体 todo） |
+| 上限三级解析（092 配置化） | 任务覆盖 / 工作空间默认 / 兜底 三级；非法 0 跳过回退 | resolve 返回优先级正确的值 |
+| 范围校验（092） | create/PATCH 传 -1 / 51 | 400；越界 PATCH 不改既有值 |
 
-migration `v91`：内存库跑迁移 + 幂等（重复执行不报错）+ 新列默认值校验。
+migration `v91`/`v92`：内存库跑迁移 + 幂等（重复执行不报错）+ 新列默认值校验（v92 两表各加 `delegate_max_rounds`）。
 
 ### 9.2 前端 Playwright（`frontend/tests/`）
 - 执行方式切换：选委派 → 出现处理人选择 + 自动接力开关；选执行器 → 开关禁用。
 - 提交委派（执行器）→ 任务创建 → 跳转详情默认在讨论 Tab，出现需求帖 + 占位帖。
 - 工艺环路回归：选环路提交 → 行为不变。
+- **接力上限配置化（092）**：专家+自动接力时建任务弹「最大轮数」；详情徽标显示 `N/M` 且 M 随工作空间/任务配置变化；徽标 ✎ 内联改上限 + 「恢复默认」生效；设置页工作空间默认可配。
 
 ---
 

--- a/docs/design/092-任务委派执行-设计.md
+++ b/docs/design/092-任务委派执行-设计.md
@@ -54,7 +54,7 @@
 
 ## 4. 数据模型设计
 
-### 4.1 `tasks` 表新增列（migration `v91`）
+### 4.1 `tasks` 表新增列（migration `v91`；`delegate_max_rounds` 为 `v92`）
 
 | 字段 | 类型 | 默认 | 说明 |
 |------|------|------|------|
@@ -63,7 +63,7 @@
 | `assignee_name` | TEXT | NULL | 委派处理人名 |
 | `auto_continue` | INTEGER | `0` | 自动接力开关；仅 `assignee_kind='expert'` 允许 `1` |
 | `continue_rounds` | INTEGER | `0` | 接力已执行轮数（护栏计数，后端单调递增，前端不可直传） |
-| `delegate_max_rounds` | INTEGER | NULL | 接力上限**任务级覆盖**（092 配置化）；NULL=沿用工作空间默认 → 兜底常量 |
+| `delegate_max_rounds` | INTEGER | NULL | 接力上限**任务级覆盖**（092 配置化，**由 v92 加列**）；NULL=沿用工作空间默认 → 兜底常量 |
 
 - `delegate` 模式下 `loop_id=NULL`（现有 `loop_id: Option<i64>`，兼容）。
 - `workspace_settings` 同步加 `delegate_max_rounds`（工作空间级默认，NULL=回退兜底常量），v92 两表各加一列。
@@ -165,6 +165,26 @@ E ──执行(决策)──► 结论帖 C3(content:"任务完成，无需再�
 
 管家专家的人设由 `inject_expert_context` 按 `expert_name=E` 自动注入，不在此重复。
 
+### 5.5 接力上限三级配置（092 护栏配置化）
+
+护栏的「上限阈值」从写死常量演化为**运行时可配**的三级解析（`resolve_delegate_max_rounds`）：
+
+```text
+effective_max = task.delegate_max_rounds            （per-task 覆盖；NULL ↓）
+             ?? workspace_settings.delegate_max_rounds （per-workspace 默认；NULL ↓）
+             ?? MAX_DELEGATE_ROUNDS(10)              （终极兜底常量，保留）
+```
+
+- **任务级**：`tasks.delegate_max_rounds`，建任务时可填（CreateTaskModal）、详情页可改（徽标内联 ✎ 编辑）；`null`=清除覆盖回退工作空间默认。
+- **工作空间级**：`workspace_settings.delegate_max_rounds`，消息配置抽屉「委派接力上限」配置；`null`=回退兜底常量。
+- **兜底常量**：`10`，确保任何配置缺失下循环仍必有界。
+
+> 关键不变量（设计 §5.2 红线）：配置化的只是「**上限阈值**」；`continue_rounds`（已跑计数）仍由后端单调递增、前端不可直传，护栏不可绕过。解析函数 graceful-degrade：DB 读失败 `.ok()` 回退兜底，不阻塞接力主流程。配置值越界（非 1..=50）一律 400（端点侧校验，不只靠前端 InputNumber）。
+>
+> **脏数据钳制**：resolve 作为护栏源头，对任务级与工作空间级均用 `1..=CAP` 区间过滤——直写库的越界脏值（0 / 负 / >50）一律视为无效、回退下一级，绝不把会让护栏失效的值透传成 effective。此「过滤非法 + 回退兜底」口径收口在 `workspace_effective_max`，`agent_bot` 详情与 `resolve` 共用，避免两处各写一遍而漂移。
+>
+> **徽标编辑器的 fallback**：任务详情额外返回 `delegate_max_rounds_fallback`（忽略任务覆盖的兜底值，由 `resolve_delegate_max_rounds_fallback` 计算）。徽标内联编辑器据此提示「留空=用工作空间默认（X 轮）」——不能用 effective，否则任务有覆盖时会误把「当前覆盖值」当成「清除后的回退值」展示。
+
 ---
 
 ## 6. 后端详细改动
@@ -196,22 +216,6 @@ E ──执行(决策)──► 结论帖 C3(content:"任务完成，无需再�
 - `MAX_DELEGATE_ROUNDS: i64 = 10`（**终极兜底**上限：仅当任务与工作空间均未配置 `delegate_max_rounds` 时生效）。
 - `DELEGATE_MAX_ROUNDS_CAP: i64 = 50`（用户配置值的合法上界，防 runaway token 成本；下界恒 1）。
 - `TRIGGER_DISCUSSION_AUTO: &str = "discussion_auto"`。
-
-### 5.5 接力上限三级配置（092 护栏配置化）
-
-护栏的「上限阈值」从写死常量演化为**运行时可配**的三级解析（`resolve_delegate_max_rounds`）：
-
-```text
-effective_max = task.delegate_max_rounds            （per-task 覆盖；NULL ↓）
-             ?? workspace_settings.delegate_max_rounds （per-workspace 默认；NULL ↓）
-             ?? MAX_DELEGATE_ROUNDS(10)              （终极兜底常量，保留）
-```
-
-- **任务级**：`tasks.delegate_max_rounds`，建任务时可填（CreateTaskModal）、详情页可改（徽标内联 ✎ 编辑）；`null`=清除覆盖回退工作空间默认。
-- **工作空间级**：`workspace_settings.delegate_max_rounds`，设置页「委派接力上限」配置；`null`=回退兜底常量。
-- **兜底常量**：`10`，确保任何配置缺失下循环仍必有界。
-
-> 关键不变量（设计 §5.2 红线）：配置化的只是「**上限阈值**」；`continue_rounds`（已跑计数）仍由后端单调递增、前端不可直传，护栏不可绕过。解析函数 graceful-degrade：DB 读失败 `.ok()` 回退兜底，不阻塞接力主流程。配置值越界（非 1..=50）一律 400（端点侧校验，不只靠前端 InputNumber）。
 
 ### 6.7 不改动
 - `CodeExecutor` trait / `adapters/*`、`expert/`、`execution_records` 语义、`run_todo_execution` 管线、`task_posts` 表结构、`todos.kind='discussion'` 隐藏过滤、工艺环路全部逻辑。

--- a/docs/requirements/092-任务委派执行-护栏配置化-实现总结.md
+++ b/docs/requirements/092-任务委派执行-护栏配置化-实现总结.md
@@ -118,3 +118,39 @@ effective_max = task.delegate_max_rounds            （per-task 覆盖；NULL �
 - `cd backend && cargo test`：全绿（含 v92 / resolve 三级 / validate 范围 / PATCH 校验 / DAO set-clear）。
 - `cd frontend && npx tsc --noEmit`：零错误；`npm run build`：无新告警（既有 chunk-size 告警非本次引入）。
 - Playwright（`make dev` 18088）：设置工作空间默认 → 新建委派任务带自定义上限 → 详情徽标 `N/M` 随配置变化 → 徽标 ✎ 改/恢复默认 → 触顶文案随 effective_max 变化。
+
+---
+
+## 评审修复（PR #996 两轴评审反馈逐条修复）
+
+| 评审发现 | 处理 |
+|---------|------|
+| **Spec**：徽标 Popover「留空=用工作空间默认（X 轮）」误显当前覆盖值 | 详情新增 `delegate_max_rounds_fallback`（`resolve_delegate_max_rounds_fallback`，忽略任务覆盖的兜底值）；编辑器 placeholder/hint 读 fallback，徽标 N/M 仍读 effective。任务有覆盖(7) 时提示正确显示工作空间默认而非 7。 |
+| **Spec**：`resolve` 只过滤 `>0`，>CAP 脏数据会静默放大护栏 | 新增 `workspace_effective_max(raw)`：仅 `1..=CAP` 采纳否则回退兜底；任务级与工作空间级均按区间过滤，>50 脏值视为无效回退。 |
+| **Spec**：工作空间级编辑入口缺 Playwright 覆盖 | 新增 `frontend/tests/092-ws-delegate-max-rounds.spec.ts`：API 契约验证 PUT 可写持久 / effective 跟随 / null 清除回退兜底 / 越界 400 不改既有值。 |
+| **Spec**：`update_task` 忽略 path workspace_id（跨工作空间写） | 加归属校验：`task.workspace_id` 与 path `ws` 不符则 404（仅本新端点收紧；存量 `get_task_detail`/`delete_task` 同口径遗留，ntd 单用户本地非租户边界，全面 ws 化属另一次专项）。 |
+| **Standards**：`get_task_detail` ~74 行超 50 行 | 抽 `build_loop_steps` / `build_task_executions` 两助手；本函数回到 50 行内，聚焦取数+组顶层 JSON。 |
+| **Standards**：`agent_bot` 手写一遍 raw→effective 与 resolve 重复 | 改用 `workspace_effective_max`，消除重复并获 CAP 钳制。 |
+| **Standards**：`update_workspace_settings` 两次写非原子 | 依「后端规范 09 §3 隐式事务」同表写免显式事务，加注释说明：partial 失败仅影响设置表单可重存，不值折叠它而改 11 处无关签名。 |
+| **Standards**：`update_task` 三趟往返、虚假「防并发」注释 | `update_delegate_max_rounds` DAO 改返回更新后的 `Model`，省去冗余二次 `get_task`；注释改为如实说明「所见即所写」。 |
+| **Standards**：设计文档 §5.5 错位在 §6.6 与 §6.7 之间 | 移至 §5.4 之后（归属第 5 节），并补充「脏数据钳制」「fallback」两段说明。 |
+
+### 评审修复（CodeRabbit 第二轮）
+
+| 评审发现 | 处理 |
+|---------|------|
+| PATCH 失败仍关 Popover（注释与代码相反） | `handleUpdateMax` message.error 后 rethrow；`RelayMaxEditor.submit` 仅成功才 `setOpen(false)`，失败保持打开供改值重试。 |
+| `update_workspace_settings` 越界校验在 upsert 之后（部分写） | `validate_delegate_max_rounds` 前置到任何写入之前，越界 400 前不留部分写。 |
+| spec `execSync` 拼 `DEV_DB`（OpenGrep 命令注入） | 改 `execFileSync('sqlite3',[DEV_DB,sql])` 不经 shell。 |
+| badge spec 断言 N=0 时序 flaky | 改断言 N 为 `\d+`（建任务后台即接力，N 可能非 0）。 |
+| 测试命名不符 `test_<函数名>_<场景>` 规范 | `ws`→`workspace`、`patch`→`update_task`；补 `update_task` 的 1/50 边界成功用例。 |
+| 恢复默认断言 `not /5/` 太弱（ws 默认恰为 5 时误失败） | 改从 hint 抓 fallback，恢复后精确断言 M===fallback。 |
+| 设计文档 §4.1 `delegate_max_rounds` 误归 v91 | 标题标注「v91；delegate_max_rounds 为 v92」+ 行标「v92 加列」。 |
+| **跳过（by-design / 已覆盖）** | ① v92 测试只走 skip 分支——与 v91 同惯例，真实加列由 `consolidated_schema` drift 测试覆盖；② workspace_setting 三态——PUT 整表保存字段恒在，`null`=清除已文档说明；③ DefaultResponseConfigPanel UI e2e——已用 `092-ws-*.spec.ts` API 契约覆盖持久化/resolve/null；④ v92 注释——迁移文件已充分注释。 |
+
+### 验证（修复后）
+
+- `cd backend && cargo clippy --all-targets -- -D warnings`：零告警。
+- `cd backend && cargo test`：全绿（lib + 全部集成套件，0 failed；新增 `update_task` 1/50 边界、`workspace_effective_max` 边界、resolve CAP 钳制、fallback 忽略覆盖、PATCH 跨工作空间 404）。
+- `cd frontend && npx tsc --noEmit`：零错误；`npm run build`：无新告警（既有 chunk-size 告警非本次引入）。
+- Playwright（18088，4 个 092 用例全绿）：含徽标 fallback 精确断言、非定值 N 断言、工作空间级 PUT 契约。

--- a/docs/requirements/092-任务委派执行-护栏配置化-实现总结.md
+++ b/docs/requirements/092-任务委派执行-护栏配置化-实现总结.md
@@ -1,0 +1,120 @@
+# 092-任务委派执行-护栏配置化-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| Claude (AI) | 2026-08-08 | 接力轮数上限从写死常量（前后端各一处 `=10`）改为「任务覆盖 → 工作空间默认 → 兜底常量」三级运行时可配 |
+
+> 需求文档：`docs/requirements/092-任务委派执行-需求.md`；设计文档：`docs/design/092-任务委派执行-设计.md`（新增 §5.5）。
+> 本 PR 在 P1/P2 之上，把 P2 写死的 `MAX_DELEGATE_ROUNDS = 10` 护栏演化为**可变更的配置项**：每个任务可不一样，有工作空间级默认初始值，运行时可调。
+
+---
+
+## 背景：为什么做
+
+P2 的护栏上限 `MAX_DELEGATE_ROUNDS = 10` 在**前后端各硬编码一处**——后端 `task_posts.rs`、前端 `TaskDetailPanel.tsx`。问题：
+
+- **跨栈漂移**：改一处必须同步改另一处并重新编译，否则前端显示 `N/10` 与后端真实熔断口径错位。
+- **运行时不可调**：用户反馈「不同任务复杂度不同，10 轮可能不够/太多」，但常量无法在不重新部署下变更。
+- **无分层默认**：全局一刀切，无法「工作空间默认 + 个别任务覆盖」。
+
+用户需求：做成**可变更的配置项**；**每个任务可能都不一样**；**有默认初始值**；**后续可调整**。经确认默认值落在**工作空间级**（非全局 config.yaml），编辑入口为**创建时可填 + 详情页可改**。
+
+---
+
+## 设计：三级解析（设计 §5.5）
+
+```text
+effective_max = task.delegate_max_rounds            （per-task 覆盖；NULL ↓）
+             ?? workspace_settings.delegate_max_rounds （per-workspace 默认；NULL ↓）
+             ?? MAX_DELEGATE_ROUNDS(10)              （终极兜底常量，保留）
+```
+
+收口在 `resolve_delegate_max_rounds(db, &task) -> i64`：护栏决策（`plan_delegate_relay`）与详情徽标展示**共用同一口径**，杜绝分散解析漂移。graceful-degrade：DB 读失败 `.ok()` 回退兜底，不阻塞接力主流程（仿 `pre_spawn` prompt 注入降级）。
+
+> **关键不变量**：配置化的只是「**上限阈值**」；`continue_rounds`（已跑计数）仍由后端单调递增、前端不可直传，护栏不可绕过（设计 §5.2 红线不变）。范围 `1..=50`（`DELEGATE_MAX_ROUNDS_CAP=50`），越界一律 400（端点侧校验，不只靠前端 InputNumber）。
+
+---
+
+## 改动清单
+
+### 1. DB（迁移 v92 + 实体，nullable 无 DEFAULT）
+
+- **`backend/src/db/migration/v92.rs`**：version 92，两表各 `add_column_if_missing`：
+  - `ALTER TABLE tasks ADD COLUMN delegate_max_rounds INTEGER`
+  - `ALTER TABLE workspace_settings ADD COLUMN delegate_max_rounds INTEGER`
+  - 仿 v91 `assignee_kind` 口径：nullable 无 DEFAULT，旧行自动得 NULL（=沿用更下一级默认）。
+  - 注册于 `migration/mod.rs::all_migrations()`（当前最高 v91 → v92）。
+- **`consolidated_schema.rs`**：tasks / workspace_settings 两处 `CREATE TABLE` 各追加 `, delegate_max_rounds INTEGER`（否则 drift 测试失败）。
+- **实体**：`tasks.rs` / `workspace_settings.rs` 各加 `pub delegate_max_rounds: Option<i64>`。
+
+### 2. 后端 DAO + 解析
+
+- **`db/task.rs`**：
+  - `create_delegate_task` 签名加 `delegate_max_rounds: Option<i64>`（随首次 INSERT 写入）。
+  - 新增 `update_delegate_max_rounds(id, max)`：`None`=清 NULL（恢复默认），`Some(n)`=置值。
+- **`db/workspace_setting.rs`**：新增**聚焦** DAO `update_workspace_delegate_max_rounds(ws, max)`，**刻意不**扩 `upsert_workspace_settings`（后者 11 处调用点多数与本字段无关，强加新参会逼它们各补 `None`，既增 diff 又放大冲突面）。「接力护栏」与「响应配置」是两个关注点，分而治之。
+- **`handlers/task_posts.rs`**：
+  - `MAX_DELEGATE_ROUNDS=10` 保留，注释改为「终极兜底」。
+  - 新增 `DELEGATE_MAX_ROUNDS_CAP: i64 = 50`（合法上界）。
+  - 新增 `validate_delegate_max_rounds(Option<i64>)`（集中越界口径，create/PATCH/PUT 三处复用）。
+  - 新增 `resolve_delegate_max_rounds(db, &task) -> i64`（三级解析）。
+  - 调用点换有效值：`plan_delegate_relay(new_rounds, effective_max, …)`；`execute_relay_action` 加 `effective_max` 参数，触顶文案格式化 `effective_max` 而非常量。
+
+### 3. 后端 Handler
+
+- **`handlers/tasks.rs`**：
+  - `CreateTaskRequest` 加 `delegate_max_rounds: Option<i64>`；委派 handler 校验后透传 DAO。
+  - `get_task_detail` 返回 `delegate_max_rounds`（raw）+ `delegate_max_rounds_effective`（解析值）——前端徽标读 effective，不再硬编码 10。
+  - 新增 `update_task`：`PATCH /api/v1/workspaces/{ws}/tasks/{id}`，体 `{delegate_max_rounds: Option<i64>}`（`null`=清除覆盖回退默认）；仅委派任务支持（环路 400）；返回新有效值。
+- **`handlers/agent_bot.rs`**：
+  - `get_workspace_settings`：合并 Some/None 双分支，返回 raw + effective（raw NULL → 兜底 10），前端永不硬编码 10。
+  - `UpdateWorkspaceSettingsRequest` 加 `delegate_max_rounds`；`update_workspace_settings` 校验 + 转发聚焦 DAO。语义 `null`=清除（settings 表单恒整表保存，故 null 在此即「恢复默认」）。
+
+### 4. 前端
+
+- **`utils/database/bots.ts`**：`WorkspaceSettings` 加 `delegate_max_rounds` + `delegate_max_rounds_effective`；`UpdateWorkspaceSettingsParams` 加 `delegate_max_rounds?`。
+- **`api/bundled.ts`**：`createTask` 加 `delegateMaxRounds?`（仅显式传入时下发，避免 undefined→null 误清）；新增 `updateTask(ws, id, { delegate_max_rounds })`（PATCH）。
+- **`CreateTaskModal.tsx`**：专家 + 自动接力开启时弹「最大轮数」`InputNumber`（min 1 max 50），placeholder 取工作空间有效默认；开关 tooltip「达 N 轮」动态化；`preserve={false}` 保证关开关/切执行器时清值不误提交。
+- **`TaskDetailPanel.tsx`**：**删除**硬编码 `MAX_DELEGATE_ROUNDS`；徽标读 `delegate_max_rounds_effective` 渲染 `管家调度中 N/M`；徽标可点 ✎ 弹 Popover 内联改上限（InputNumber + 「恢复默认」）→ `updateTask` → 重拉详情，M 实时同步。
+- **`DefaultResponseConfigPanel.tsx`**：设置页加「委派接力上限」`Form.Item`（min 1 max 50）；placeholder/extra 取「系统兜底」值（仅未配置时从 effective 推导，不硬编码 10）；保存发 `delegate_max_rounds`（null=清除回退兜底）。
+
+### 5. 测试
+
+- **v92**：幂等 + 两表列存在。
+- **`resolve_delegate_max_rounds`**：三级覆盖（task > ws > 兜底）；非法 0 覆盖跳过回退。
+- **`validate_delegate_max_rounds`**：None/1/50 放行，0/-1/51 拒。
+- **DAO**：`update_delegate_max_rounds` set/clear；`update_workspace_delegate_max_rounds` 无行新建/有行单字段更新不误伤他列。
+- **Handler**：create 传 -1/51 → 400；PATCH 环路任务 → 400；PATCH 越界不改既有值；PATCH 合法值返回 effective。
+- **既有 `plan_delegate_relay_*` 纯函数测试不受影响**（参数化 max）。
+- **Playwright**（`frontend/tests/`）：建任务「最大轮数」字段 + 详情徽标内联编辑/恢复默认 + 设置页工作空间默认。
+
+---
+
+## 编辑语义对照
+
+两处编辑入口统一为 **`null`=清除/恢复默认，N=设置**（跨特性一致，前端认知最简）：
+
+| 入口 | 方法 | 路径 | null 语义 |
+|------|------|------|-----------|
+| 任务级覆盖 | PATCH | `/api/v1/workspaces/{ws}/tasks/{id}` | 清除任务覆盖 → 回退工作空间默认 |
+| 工作空间默认 | PUT | `/api/v1/workspaces/{ws}/settings` | 清除工作空间默认 → 回退兜底常量 10 |
+
+> 工作空间 PUT 的 relay-max 字段是 settings 表单唯一需要「恢复默认」动作的字段，故 `null`=清除（区别于同 struct 其它字段 `None`=跳过的增量语义）；表单恒整表保存，不会因漏传而误清。
+
+---
+
+## 安全反思
+
+- **护栏不可绕过**：`continue_rounds` 仍后端单调递增，前端不可直传；只配置化「上限」，不放开计数。
+- **越界硬拒**：`delegate_max_rounds` 非 `1..=50` 一律 400（端点侧 `validate_delegate_max_rounds`，不靠前端 InputNumber）。
+- **降级安全**：DB 读失败 graceful-degrade 回退兜底常量，不阻塞接力主流程；非法覆盖值（脏数据 0）resolve 用 `.filter(|x|>0)` 跳过，绝不返回会让护栏失效的 0。
+- **聚焦 DAO**：relay-max 写入独立于 `upsert_workspace_settings`，零波及 11 处无关调用点，缩小回归面。
+
+---
+
+## 验证
+
+- `cd backend && cargo clippy --all-targets -- -D warnings`：零告警。
+- `cd backend && cargo test`：全绿（含 v92 / resolve 三级 / validate 范围 / PATCH 校验 / DAO set-clear）。
+- `cd frontend && npx tsc --noEmit`：零错误；`npm run build`：无新告警（既有 chunk-size 告警非本次引入）。
+- Playwright（`make dev` 18088）：设置工作空间默认 → 新建委派任务带自定义上限 → 详情徽标 `N/M` 随配置变化 → 徽标 ✎ 改/恢复默认 → 触顶文案随 effective_max 变化。

--- a/frontend/src/api/bundled.ts
+++ b/frontend/src/api/bundled.ts
@@ -552,6 +552,8 @@ export const bundledApi = {
       assigneeKind?: 'executor' | 'expert';
       assigneeName?: string;
       autoContinue?: boolean;
+      // 接力轮数上限覆盖（仅 delegate 模式）：N=任务级覆盖；undefined=沿用工作空间默认（omit 不下发）。
+      delegateMaxRounds?: number | null;
     },
     wsId: number,
   ): Promise<{ task_id: number; loop_id: number | null; execution_id: number | null }> {
@@ -562,7 +564,25 @@ export const bundledApi = {
       assignee_kind: params.assigneeKind,
       assignee_name: params.assigneeName,
       auto_continue: params.autoContinue,
+      // 仅在显式传入时下发，避免把 undefined 序列化成 null（后端 null=清除会误清；这里 undefined=omit）。
+      ...(params.delegateMaxRounds !== undefined
+        ? { delegate_max_rounds: params.delegateMaxRounds }
+        : {}),
     }));
+  },
+
+  /**
+   * 更新任务可变字段（需求 092）：当前仅「接力轮数上限覆盖」。
+   * - delegate_max_rounds=N（1..=50）→ 置任务级覆盖；
+   * - null → 清除覆盖，回退工作空间默认 → 兜底常量（「恢复默认」）。
+   * 仅委派任务支持；返回更新后的 raw 覆盖与有效上限。
+   */
+  async updateTask(
+    wsId: number,
+    taskId: number,
+    params: { delegate_max_rounds: number | null },
+  ): Promise<{ delegate_max_rounds: number | null; delegate_max_rounds_effective: number }> {
+    return unwrap(await api.patch(`/api/v1/workspaces/${wsId}/tasks/${taskId}`, params));
   },
 
   /** 为已有任务创建新执行 */

--- a/frontend/src/components/settings/workspace/DefaultResponseConfigPanel.tsx
+++ b/frontend/src/components/settings/workspace/DefaultResponseConfigPanel.tsx
@@ -31,6 +31,9 @@ export function DefaultResponseConfigPanel({ workspaceId, onChanged }: DefaultRe
   const [historyChats, setHistoryChats] = useState<FeishuHistoryChat[]>([]);
   const [histChatId, setHistChatId] = useState('');
   const [histChatName, setHistChatName] = useState('');
+  // 接力上限「系统兜底」提示值：仅当工作空间未配置(raw=null)时，effective 才等于兜底常量，
+  // 此时取它做 InputNumber placeholder；已配置时不覆盖，确保「留空→回退」提示恒指兜底常量，不硬编码 10。
+  const [defaultMaxHint, setDefaultMaxHint] = useState<number>(10);
 
   useEffect(() => {
     loadSettings();
@@ -56,7 +59,11 @@ export function DefaultResponseConfigPanel({ workspaceId, onChanged }: DefaultRe
           default_response_todo_id: s.default_response_todo_id,
           default_response_loop_id: s.default_response_loop_id,
           default_response_executor: s.default_response_executor,
+          // raw 覆盖值：null 表示未配置（InputNumber 显示空，提示走系统默认）。
+          delegate_max_rounds: s.delegate_max_rounds,
         });
+        // 仅未配置时 effective 才等于兜底常量，用它做「留空回退」提示，不硬编码 10。
+        if (s.delegate_max_rounds == null) setDefaultMaxHint(s.delegate_max_rounds_effective ?? 10);
       })
       .catch((err: any) => message.error('加载设置失败: ' + (err?.message || String(err))))
       .finally(() => setLoading(false));
@@ -83,6 +90,8 @@ export function DefaultResponseConfigPanel({ workspaceId, onChanged }: DefaultRe
         default_response_todo_id: values.default_response_type === 'todo' ? values.default_response_todo_id : undefined,
         default_response_loop_id: values.default_response_type === 'loop' ? values.default_response_loop_id : 0,
         default_response_executor: values.default_response_type === 'executor' ? values.default_response_executor : undefined,
+        // null=清除回退系统兜底；N(1..=50)=置工作空间默认，任务级未覆盖时以此为准。
+        delegate_max_rounds: values.delegate_max_rounds ?? null,
       });
       message.success('设置已保存');
       loadSettings();
@@ -222,6 +231,23 @@ export function DefaultResponseConfigPanel({ workspaceId, onChanged }: DefaultRe
               />
             </Form.Item>
           )}
+
+          {/* 委派接力上限（需求 092）：工作空间级默认，任务级可单独覆盖。 */}
+          <Form.Item
+            name="delegate_max_rounds"
+            label="委派接力上限"
+            tooltip="该工作空间内委派任务「自动接力轮数上限」的默认值；单个任务可在详情页覆盖。"
+            extra={`留空使用系统默认（${defaultMaxHint} 轮）；任务级未覆盖时以此默认为准。`}
+          >
+            <InputNumber
+              min={1}
+              max={50}
+              placeholder={`默认 ${defaultMaxHint} 轮`}
+              addonAfter="轮"
+              style={{ width: '100%' }}
+              data-testid="ws-delegate-max-rounds"
+            />
+          </Form.Item>
 
           <Form.Item>
             <Space>

--- a/frontend/src/components/tasks/CreateTaskModal.tsx
+++ b/frontend/src/components/tasks/CreateTaskModal.tsx
@@ -6,7 +6,7 @@
 // 提交成功后调 onCreated，宿主关闭 Modal 并刷新列表。
 
 import { useEffect, useState } from 'react';
-import { Modal, Input, Select, Form, Radio, Segmented, Switch, Typography, message } from 'antd';
+import { Modal, Input, InputNumber, Select, Form, Radio, Segmented, Switch, Typography, message } from 'antd';
 import { ThunderboltOutlined } from '@ant-design/icons';
 import bundledApi from '@/api/bundled';
 import type { LoopLite } from '@/components/tasks/constants';
@@ -15,6 +15,7 @@ import { getAllExperts } from '@/utils/database/experts';
 import { EXECUTORS_FOR_PICKER } from '@/utils/executors';
 import { getExpertDisplayName } from '@/types/expert';
 import type { ExpertMetadata } from '@/types/expert';
+import { getWorkspaceSettings } from '@/utils/database/bots';
 
 const { Text } = Typography;
 
@@ -26,6 +27,8 @@ interface CreateTaskFormValues {
   assigneeKind?: 'executor' | 'expert';
   assigneeName?: string;
   autoContinue?: boolean;
+  // 接力轮数上限覆盖：null=沿用工作空间默认（提交 omit）；N=任务级覆盖（1..=50）。
+  delegateMaxRounds?: number | null;
 }
 
 interface CreateTaskModalProps {
@@ -62,10 +65,14 @@ export function CreateTaskModal({
   // 监听执行方式与处理人类型，驱动条件渲染与联动（未初始化时用兜底值）。
   const executionMode = Form.useWatch('executionMode', form) ?? 'loop';
   const assigneeKind = Form.useWatch('assigneeKind', form) ?? 'expert';
+  // 监听自动接力开关：仅 expert + 开启时才需配置/展示「最大轮数」字段。
+  const autoContinue = Form.useWatch('autoContinue', form) ?? false;
   // 专家候选：打开 Modal 时拉一次（执行器候选是静态 EXECUTORS_FOR_PICKER，无需拉取）。
   const [experts, setExperts] = useState<ExpertMetadata[]>([]);
   // 专家下拉加载态：加载中给 Select 转圈，失败时弹 message.error（而非只 console.warn）。
   const [expertsLoading, setExpertsLoading] = useState(false);
+  // 工作空间「接力上限默认」有效值：用作「最大轮数」placeholder 与开关 tooltip，前端不硬编码 10。
+  const [wsDefaultMaxRounds, setWsDefaultMaxRounds] = useState<number>(10);
   useEffect(() => {
     if (!open) return;
     // 失败时若只 console.warn，用户只看到空下拉「暂无可用专家」，无从判断是真空还是加载失败（CodeRabbit #8）。
@@ -79,6 +86,15 @@ export function CreateTaskModal({
       })
       .finally(() => setExpertsLoading(false));
   }, [open]);
+
+  // 取工作空间「接力上限默认」有效值（raw null → 后端已回退兜底 10），仅用于 placeholder/tooltip；
+  // 失败回退本地兜底 10，不阻断创建（创建本身不依赖此值，留空即用默认）。
+  useEffect(() => {
+    if (!open) return;
+    getWorkspaceSettings(workspaceId)
+      .then((s) => setWsDefaultMaxRounds(s.delegate_max_rounds_effective ?? 10))
+      .catch(() => setWsDefaultMaxRounds(10));
+  }, [open, workspaceId]);
 
   // open 变为 false 时重置表单字段，避免下次打开残留上次输入。
   useEffect(() => {
@@ -102,6 +118,8 @@ export function CreateTaskModal({
                 assigneeKind: values.assigneeKind,
                 assigneeName: values.assigneeName,
                 autoContinue: values.assigneeKind === 'expert' ? values.autoContinue : false,
+                // 仅在用户填了上限时下发覆盖；null/undefined → createTask omit → 后端用工作空间默认。
+                delegateMaxRounds: values.delegateMaxRounds ?? undefined,
               },
               workspaceId,
             )
@@ -241,7 +259,7 @@ export function CreateTaskModal({
             <Form.Item
               name="autoContinue"
               label="自动接力"
-              tooltip="开启后，每次执行完成由该专家自主决定下一步（管家模式），直到完成或达 10 轮上限。仅专家支持。"
+              tooltip={`开启后，每次执行完成由该专家自主决定下一步（管家模式），直到完成或达 ${wsDefaultMaxRounds} 轮上限。仅专家支持。`}
               valuePropName="checked"
             >
               <Switch disabled={assigneeKind === 'executor'} data-testid="create-task-auto-continue" />
@@ -250,6 +268,24 @@ export function CreateTaskModal({
               <Text type="secondary" style={{ fontSize: 12 }}>
                 执行器不支持自动接力（如需托管调度，请改选专家）
               </Text>
+            ) : null}
+            {/* 接力轮数上限覆盖：仅专家 + 自动接力开启时才需配（否则无接力可言）。
+                preserve=false 保证关闭开关/切执行器时字段卸载即清值，避免残留上限被误提交。 */}
+            {assigneeKind === 'expert' && autoContinue ? (
+              <Form.Item
+                name="delegateMaxRounds"
+                label="最大轮数"
+                tooltip="达此轮数上限后停止自动接力；留空则沿用工作空间默认。"
+                preserve={false}
+              >
+                <InputNumber
+                  min={1}
+                  max={50}
+                  placeholder={`默认 ${wsDefaultMaxRounds} 轮（工作空间配置）`}
+                  style={{ width: '100%' }}
+                  data-testid="create-task-max-rounds"
+                />
+              </Form.Item>
             ) : null}
           </>
         )}

--- a/frontend/src/components/tasks/TaskDetailPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailPanel.tsx
@@ -9,10 +9,10 @@
 import { useEffect, useState, useCallback } from 'react';
 import {
   Tabs, Tag, Button, Typography, Spin, Space, Badge,
-  message, Modal, Input, Empty, Popconfirm,
+  message, Modal, Input, InputNumber, Popover, Empty, Popconfirm,
 } from 'antd';
 import {
-  ThunderboltOutlined, DeleteOutlined,
+  ThunderboltOutlined, DeleteOutlined, EditOutlined,
 } from '@ant-design/icons';
 import bundledApi from '@/api/bundled';
 import * as dbLoops from '@/utils/database/loops';
@@ -32,11 +32,6 @@ const { Text } = Typography;
 // Tabs key 白名单：?tab= query 的合法值，非法值一律回退到「概览」。
 // 帖子页返回本任务-讨论 tab 时，URL 带 ?tab=discussion，Tabs 据此恢复选中态。
 const TAB_KEYS = ['overview', 'dag', 'exec', 'discussion'] as const;
-
-// 需求 092 P2：自动接力的轮数硬上限。必须与后端 MAX_DELEGATE_ROUNDS（completion 接力护栏）
-// 保持一致——前端只读 continue_rounds，不做护栏决策，仅据此展示进度与「已达上限」状态。
-// 集中为常量而非魔法数，便于双端口径变更时一处定位。
-const MAX_DELEGATE_ROUNDS = 10;
 
 // ====== 类型定义 ======
 
@@ -66,7 +61,7 @@ interface ExecInfo {
 }
 
 interface TaskDetailData {
-  task: { id: number; title: string; status: string; description?: string; workspace_id?: number; loop_id?: number; execution_mode?: string; assignee_kind?: string; assignee_name?: string; auto_continue?: boolean; continue_rounds?: number };
+  task: { id: number; title: string; status: string; description?: string; workspace_id?: number; loop_id?: number; execution_mode?: string; assignee_kind?: string; assignee_name?: string; auto_continue?: boolean; continue_rounds?: number; delegate_max_rounds?: number | null; delegate_max_rounds_effective?: number };
   template?: { display_name?: string; version?: string; complexity?: string };
   steps: StepInfo[];
   executions: ExecInfo[];
@@ -90,34 +85,127 @@ function assigneeLabel(task: TaskDetailData['task']): string {
 }
 
 /**
- * 自动接力进度徽标（需求 092 P2）。仅管家接力任务显示，文案「管家调度中 N/MAX」：
- * - 未达上限用 processing 蓝，直观表达「进行中」；
- * - 达上限用 warning 橙，与后端 HitLimit 写的「已达上限」说明帖呼应，提示用户接管。
- * 非接力任务（环路 / 手动单跑 / 执行器委派）返回 null，标题行不留空位。
+ * 自动接力进度徽标（需求 092）。仅管家接力任务显示，文案「管家调度中 N/M」：
+ * - M（上限）来自后端三级解析的有效值 delegate_max_rounds_effective，前端不再硬编码 10；
+ * - 未达上限用 processing 蓝，达上限用 warning 橙（与后端 HitLimit 说明帖呼应，提示接管）；
+ * - 点击 ✎ 弹出 [RelayMaxEditor] 内联调整该任务的上限覆盖（运行时可改）。
+ * 非接力任务返回 null。本组件不放 hooks：纯条件渲染，避免「early return 在 hook 之前」违规。
  */
-function RelayBadge({ task }: { task: TaskDetailData['task'] }) {
+function RelayBadge({
+  task, onUpdateMax,
+}: {
+  task: TaskDetailData['task'];
+  onUpdateMax: (max: number | null) => Promise<void>;
+}) {
   if (!isAutoRelayTask(task)) return null;
+  return <RelayMaxEditor task={task} onUpdateMax={onUpdateMax} />;
+}
+
+/**
+ * 徽标内联编辑器：Tag 本体 + Popover（InputNumber 调上限 + 「恢复默认」）。
+ * 打开时以当前 raw 覆盖(delegate_max_rounds)回显，null 显示空（=用默认）；确定/恢复均经
+ * onUpdateMax 落库并重拉详情，effective 随之刷新，徽标 M 实时同步。
+ */
+function RelayMaxEditor({
+  task, onUpdateMax,
+}: {
+  task: TaskDetailData['task'];
+  onUpdateMax: (max: number | null) => Promise<void>;
+}) {
   const rounds = task.continue_rounds ?? 0;
+  // effective 兜底 10 仅为类型安全：后端恒返回该字段，缺失属异常态。
+  const effectiveMax = task.delegate_max_rounds_effective ?? 10;
   // >=：与后端 plan_delegate_relay 的 `rounds >= max` 护栏口径一致（设计 §5.2）。
-  // 计数在判定前已 +1，递增到 max(10) 当轮即被熔断（需求 AC8「达到 10 强制停止」），
-  // 故 rounds=10 时转橙，与后端 HitLimit 写的「已达上限」说明帖同步提示用户接管。
-  const atLimit = rounds >= MAX_DELEGATE_ROUNDS;
+  const atLimit = rounds >= effectiveMax;
+  // Popover 受控开关 + 输入态：每次打开以最新 raw 回显，避免上一次残留值误导。
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<number | null>(task.delegate_max_rounds ?? null);
+  const [saving, setSaving] = useState(false);
+
+  // 落库并刷新：成功关 Popover；失败抛错由调用方 message.error，不关 Popover 便于改后重试。
+  const submit = async (value: number | null) => {
+    setSaving(true);
+    try {
+      await onUpdateMax(value);
+      setOpen(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+  // 是否已有覆盖（决定「恢复默认」可点）；确定仅在「填了且与当前覆盖不同」时可点。
+  const hasOverride = task.delegate_max_rounds != null;
+  const confirmDisabled = editing == null || editing === task.delegate_max_rounds;
+
   return (
-    <Tag color={atLimit ? 'warning' : 'processing'}>
-      管家调度中 {rounds}/{MAX_DELEGATE_ROUNDS}
-    </Tag>
+    <Popover
+      trigger="click"
+      placement="bottom"
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        // 每次打开重置输入为当前 raw 覆盖，关闭再开不会带上次未提交的脏值。
+        if (o) setEditing(task.delegate_max_rounds ?? null);
+      }}
+      title="调整接力轮数上限"
+      content={
+        <Space direction="vertical" style={{ width: 240 }}>
+          <InputNumber
+            min={1}
+            max={50}
+            value={editing}
+            onChange={(v) => setEditing(v ?? null)}
+            placeholder={`默认 ${effectiveMax} 轮`}
+            style={{ width: '100%' }}
+            data-testid="relay-max-input"
+          />
+          <Space>
+            <Button
+              size="small"
+              type="primary"
+              loading={saving}
+              disabled={confirmDisabled}
+              onClick={() => editing != null && submit(editing)}
+              data-testid="relay-max-confirm"
+            >
+              确定
+            </Button>
+            <Button
+              size="small"
+              disabled={!hasOverride || saving}
+              onClick={() => submit(null)}
+              data-testid="relay-max-reset"
+            >
+              恢复默认
+            </Button>
+          </Space>
+          <Text type="secondary" style={{ fontSize: 12 }}>
+            留空=用工作空间默认（{effectiveMax} 轮）；达上限后停止自动接力。
+          </Text>
+        </Space>
+      }
+    >
+      <Tag
+        color={atLimit ? 'warning' : 'processing'}
+        style={{ cursor: 'pointer' }}
+        data-testid="relay-badge"
+      >
+        管家调度中 {rounds}/{effectiveMax} <EditOutlined style={{ marginLeft: 4 }} />
+      </Tag>
+    </Popover>
   );
 }
 
 /** 顶部条：标题 + 状态/复杂度 + 元信息 + 删除 + 再次执行。 */
 function DetailHeader({
-  task, template, loopDetail, onExecute, onDelete,
+  task, template, loopDetail, onExecute, onDelete, onUpdateMax,
 }: {
   task: TaskDetailData['task'];
   template?: TaskDetailData['template'];
   loopDetail: LoopDetail | null;
   onExecute: () => void;
   onDelete: () => void;
+  // 接力上限内联编辑落库（透传给 RelayBadge）；仅管家接力任务的徽标会用。
+  onUpdateMax: (max: number | null) => Promise<void>;
 }) {
   return (
     <div className={styles.headerBar}>
@@ -130,7 +218,7 @@ function DetailHeader({
             <Tag color={complexityColor(template.complexity)}>{complexityLabel(template.complexity)}</Tag>
           )}
           {/* 管家自动接力任务的进度徽标（委派 + 自动接力 + 专家）。非此类任务返回 null。 */}
-          <RelayBadge task={task} />
+          <RelayBadge task={task} onUpdateMax={onUpdateMax} />
         </div>
         <div className={styles.metaRow}>
           {task.execution_mode === 'delegate' ? (
@@ -261,6 +349,22 @@ export function TaskDetailPanel({
     finally { setTriggering(false); }
   };
 
+  // 内联调整某任务的接力上限覆盖（需求 092）：落库后重拉详情，effective 随之刷新，徽标 M 同步。
+  // 定义在 early return 之前并用 useCallback，避免「条件 hook」违规；用 taskId 而非 detail.task，
+  // 保证 detail 未就绪时也不会引用空对象。
+  const handleUpdateMax = useCallback(async (max: number | null) => {
+    try {
+      await bundledApi.updateTask(workspaceId, taskId, { delegate_max_rounds: max });
+      const raw = await bundledApi.getTaskDetail(workspaceId, taskId) as TaskDetailData;
+      setDetail(raw);
+      message.success(max == null ? '已恢复默认上限' : `上限已设为 ${max} 轮`);
+      onTriggered?.();
+    } catch (e) {
+      // updateTask 400 时后端返回中文 message（越界/非委派），拦截器已透传，直接展示。
+      message.error(e instanceof Error ? e.message : '更新接力上限失败');
+    }
+  }, [workspaceId, taskId, onTriggered]);
+
   // 加载态。
   if (loading) return <Spin style={{ display: 'block', margin: '40px auto' }} />;
   if (!detail) return <Empty description="暂无任务详情" style={{ marginTop: 48 }} />;
@@ -312,7 +416,7 @@ export function TaskDetailPanel({
     <div className={styles.panel}>
       <DetailHeader
         task={task} template={template} loopDetail={loopDetail}
-        onExecute={openReqModal} onDelete={handleDelete}
+        onExecute={openReqModal} onDelete={handleDelete} onUpdateMax={handleUpdateMax}
       />
       <div className={styles.tabsWrap}>
         <Tabs

--- a/frontend/src/components/tasks/TaskDetailPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailPanel.tsx
@@ -61,7 +61,7 @@ interface ExecInfo {
 }
 
 interface TaskDetailData {
-  task: { id: number; title: string; status: string; description?: string; workspace_id?: number; loop_id?: number; execution_mode?: string; assignee_kind?: string; assignee_name?: string; auto_continue?: boolean; continue_rounds?: number; delegate_max_rounds?: number | null; delegate_max_rounds_effective?: number };
+  task: { id: number; title: string; status: string; description?: string; workspace_id?: number; loop_id?: number; execution_mode?: string; assignee_kind?: string; assignee_name?: string; auto_continue?: boolean; continue_rounds?: number; delegate_max_rounds?: number | null; delegate_max_rounds_effective?: number; delegate_max_rounds_fallback?: number };
   template?: { display_name?: string; version?: string; complexity?: string };
   steps: StepInfo[];
   executions: ExecInfo[];
@@ -115,6 +115,10 @@ function RelayMaxEditor({
   const rounds = task.continue_rounds ?? 0;
   // effective 兜底 10 仅为类型安全：后端恒返回该字段，缺失属异常态。
   const effectiveMax = task.delegate_max_rounds_effective ?? 10;
+  // 「清除任务覆盖后」的回退值（工作空间默认或兜底常量）：placeholder / 留空提示读它。
+  // 不能用 effective：任务已有覆盖时 effective 即覆盖值本身，提示「留空=用工作空间默认（N 轮）」会误显成
+  // 即将被清除的那个覆盖值，与「清除后实际回退到工作空间默认」矛盾（Spec 评审发现）。
+  const fallbackMax = task.delegate_max_rounds_fallback ?? effectiveMax;
   // >=：与后端 plan_delegate_relay 的 `rounds >= max` 护栏口径一致（设计 §5.2）。
   const atLimit = rounds >= effectiveMax;
   // Popover 受控开关 + 输入态：每次打开以最新 raw 回显，避免上一次残留值误导。
@@ -122,12 +126,16 @@ function RelayMaxEditor({
   const [editing, setEditing] = useState<number | null>(task.delegate_max_rounds ?? null);
   const [saving, setSaving] = useState(false);
 
-  // 落库并刷新：成功关 Popover；失败抛错由调用方 message.error，不关 Popover 便于改后重试。
+  // 落库并刷新：仅当 onUpdateMax 成功 resolve 才关 Popover；失败时 onUpdateMax 会向上抛错，
+  // 跳过 setOpen(false)，编辑器保持打开供改值重试（错误提示已由 handleUpdateMax 的 catch 弹出）。
+  // 此处 catch 兜住错误只复位 saving，避免 onClick 内产生未处理 promise rejection。
   const submit = async (value: number | null) => {
     setSaving(true);
     try {
       await onUpdateMax(value);
       setOpen(false);
+    } catch {
+      // 不关 Popover：让用户在原值基础上修正后重试（message.error 已在 handleUpdateMax 弹过）。
     } finally {
       setSaving(false);
     }
@@ -154,7 +162,7 @@ function RelayMaxEditor({
             max={50}
             value={editing}
             onChange={(v) => setEditing(v ?? null)}
-            placeholder={`默认 ${effectiveMax} 轮`}
+            placeholder={`默认 ${fallbackMax} 轮`}
             style={{ width: '100%' }}
             data-testid="relay-max-input"
           />
@@ -179,7 +187,7 @@ function RelayMaxEditor({
             </Button>
           </Space>
           <Text type="secondary" style={{ fontSize: 12 }}>
-            留空=用工作空间默认（{effectiveMax} 轮）；达上限后停止自动接力。
+            留空=用工作空间默认（{fallbackMax} 轮）；达上限后停止自动接力。
           </Text>
         </Space>
       }
@@ -360,8 +368,11 @@ export function TaskDetailPanel({
       message.success(max == null ? '已恢复默认上限' : `上限已设为 ${max} 轮`);
       onTriggered?.();
     } catch (e) {
-      // updateTask 400 时后端返回中文 message（越界/非委派），拦截器已透传，直接展示。
+      // updateTask 400 时后端返回中文 message（越界/非委派），拦截器已透传，先弹给用户可见提示。
       message.error(e instanceof Error ? e.message : '更新接力上限失败');
+      // 再向上抛错：RelayMaxEditor.submit 据此判定失败、跳过关 Popover 的语句，让用户在原
+      // Popover 内改值重试。否则 PATCH 失败却关弹层，用户须重新点开 ✎，体验割裂（评审发现）。
+      throw e;
     }
   }, [workspaceId, taskId, onTriggered]);
 

--- a/frontend/src/utils/database/bots.ts
+++ b/frontend/src/utils/database/bots.ts
@@ -62,6 +62,10 @@ export interface WorkspaceSettings {
   // 工作空间级共识 prompt（需求 022）：该 workspace 下所有 todo 执行时作为前置 prompt 注入。
   // null 表示未配置；空串 "" 表示显式清空。
   system_prompt: string | null;
+  // 工作空间级「委派接力轮数上限」默认（需求 092）：null=未配置；任务级未覆盖时以此为准。
+  delegate_max_rounds: number | null;
+  // 解析后的有效上限（raw null → 终极兜底常量 10）：表单 placeholder/提示读它，前端不硬编码 10。
+  delegate_max_rounds_effective: number;
   updated_at: string | null;
 }
 
@@ -73,6 +77,9 @@ export interface UpdateWorkspaceSettingsParams {
   // 工作空间级共识 prompt：传入则覆写，不传则保持原值。
   // 用户清空时前端传空串 ""。
   system_prompt?: string;
+  // 工作空间级接力上限默认（需求 092）：传 N（1..=50）=置默认；null=清除回退兜底（「恢复默认」）。
+  // 注：settings 表单恒整表保存，故 null 即清除（区别于其它字段的「不传=保持」语义）。
+  delegate_max_rounds?: number | null;
 }
 
 // ============================================================================

--- a/frontend/tests/092-delegate-max-rounds-config.spec.ts
+++ b/frontend/tests/092-delegate-max-rounds-config.spec.ts
@@ -10,23 +10,31 @@
 // - afterAll 删除本次创建的任务，避免专家结论若含 @ 触发失控接力污染开发库。
 
 import { test, expect } from '@playwright/test';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 const BASE = process.env.E2E_BASE_URL ?? 'http://localhost:18088';
 const DEV_DB = process.env.HOME + '/.ntd/data.dev.db';
 const MARKER = 'E2E护栏配置化任务';
 
 // 按标题前缀硬删任务（连带讨论帖/载体 todo），开发库自洽优先于精确归属。
+// 用 execFileSync 传 [db, sql] 参数数组而非 execSync 拼 shell 字符串：DEV_DB 取自环境变量，
+// 经 shell 拼接存在命令注入面（OpenGrep SAST 报错）；execFileSync 不经 shell，参数原样传给 sqlite3。
 function cleanupSeededTasks() {
   try {
-    const ids: string = execSync(
-      `sqlite3 "${DEV_DB}" "SELECT IFNULL(GROUP_CONCAT(id),'') FROM tasks WHERE title LIKE '%${MARKER}%';"`,
-    ).toString().trim();
+    // 先查出待删任务 id 列表（GROUP_CONCAT 拼成 "1,2,3"）；无则空串直接返回。
+    const ids: string = execFileSync('sqlite3', [
+      DEV_DB,
+      `SELECT IFNULL(GROUP_CONCAT(id),'') FROM tasks WHERE title LIKE '%${MARKER}%';`,
+    ]).toString().trim();
     if (!ids) return;
-    execSync(`sqlite3 "${DEV_DB}" "DELETE FROM task_posts WHERE task_id IN (${ids});"`);
-    execSync(`sqlite3 "${DEV_DB}" "DELETE FROM execution_records WHERE source_todo_id IN (SELECT id FROM todos WHERE title LIKE '%${MARKER}%');"`);
-    execSync(`sqlite3 "${DEV_DB}" "DELETE FROM todos WHERE title LIKE '%${MARKER}%';"`);
-    execSync(`sqlite3 "${DEV_DB}" "DELETE FROM tasks WHERE id IN (${ids});"`);
+    // 按外键依赖顺序删除：task_posts（引用 tasks）→ execution_records（引用载体 todo）→ todos → tasks。
+    execFileSync('sqlite3', [DEV_DB, `DELETE FROM task_posts WHERE task_id IN (${ids});`]);
+    execFileSync('sqlite3', [
+      DEV_DB,
+      `DELETE FROM execution_records WHERE source_todo_id IN (SELECT id FROM todos WHERE title LIKE '%${MARKER}%');`,
+    ]);
+    execFileSync('sqlite3', [DEV_DB, `DELETE FROM todos WHERE title LIKE '%${MARKER}%';`]);
+    execFileSync('sqlite3', [DEV_DB, `DELETE FROM tasks WHERE id IN (${ids});`]);
   } catch (e) {
     console.warn('[092-config cleanup] 清理种子任务失败（开发库残留，通常可忽略）：', e);
   }
@@ -101,11 +109,18 @@ test.describe('092 接力上限配置化', () => {
     // PATCH + 详情重拉后，徽标 M=5（N 可能因后台执行变化，故只断言 /5）。
     await expect(badge).toHaveText(/\/\s*5\b/, { timeout: 10000 });
 
-    // 再次点开，「恢复默认」→ M 回退到默认（不再为 5）。
+    // 再次点开，「恢复默认」→ M 回退到工作空间默认（= hint 显示的 fallback 值）。
     await badge.click();
     await expect(page.locator('[data-testid="relay-max-reset"]')).toBeVisible({ timeout: 5000 });
+    // Spec#2：覆盖已置 5（badge M=5），但编辑器「留空=用工作空间默认（X 轮）」提示须显示 fallback
+    // （清除覆盖后的真实回退值），不能误显成即将被清除的覆盖值 5——校验 fallback 与 effective 分离。
+    const hintText = await page.locator('.ant-popover').getByText(/工作空间默认/).innerText();
+    const fallbackNum = hintText.match(/工作空间默认（(\d+) 轮/)?.[1];
+    expect(fallbackNum, '应能从 hint 解析出回退轮数').toMatch(/^\d+$/);
     await page.locator('[data-testid="relay-max-reset"]').click();
-    await expect(badge).not.toHaveText(/\/\s*5\b/, { timeout: 10000 });
+    // 恢复后 M 精确等于工作空间默认（fallbackNum）。原 not/5/ 断言在工作空间默认恰为 5 时会误失败，
+    // 且「不是 5」也无法证明回退到了正确值；改为精确匹配，无论默认值是几都对。
+    await expect(badge).toHaveText(new RegExp(`\\/\\s*${fallbackNum}\\b`), { timeout: 10000 });
 
     await page.screenshot({ path: 'test-results/092-delegate-max-rounds-config.png' });
   });

--- a/frontend/tests/092-delegate-max-rounds-config.spec.ts
+++ b/frontend/tests/092-delegate-max-rounds-config.spec.ts
@@ -1,0 +1,112 @@
+// 092-任务委派执行·护栏配置化：接力上限「任务级覆盖」端到端验证。
+// 验证点（对应需求 092 护栏配置化）：
+//  1. 新建任务 Modal：专家 + 自动接力开启时弹出「最大轮数」InputNumber；关闭开关则字段消失（preserve=false）。
+//  2. 详情页徽标：管家调度徽标 N/M 的 M 来自三级解析有效值；点 ✎ 内联改上限 → M 随之变化；「恢复默认」回退。
+//
+// 策略说明：
+// - 用例 1 纯前端 UI 联动，不提交（不触发真实执行）。
+// - 用例 2 走真实「新建任务」提交（复用 badge spec 的建任务流程），因为徽标依赖后端落库的委派字段。
+//   创建后到详情页点徽标弹 Popover，改上限并断言 M 变化——验证 PATCH /tasks/{id} 与详情重拉链路。
+// - afterAll 删除本次创建的任务，避免专家结论若含 @ 触发失控接力污染开发库。
+
+import { test, expect } from '@playwright/test';
+import { execSync } from 'child_process';
+
+const BASE = process.env.E2E_BASE_URL ?? 'http://localhost:18088';
+const DEV_DB = process.env.HOME + '/.ntd/data.dev.db';
+const MARKER = 'E2E护栏配置化任务';
+
+// 按标题前缀硬删任务（连带讨论帖/载体 todo），开发库自洽优先于精确归属。
+function cleanupSeededTasks() {
+  try {
+    const ids: string = execSync(
+      `sqlite3 "${DEV_DB}" "SELECT IFNULL(GROUP_CONCAT(id),'') FROM tasks WHERE title LIKE '%${MARKER}%';"`,
+    ).toString().trim();
+    if (!ids) return;
+    execSync(`sqlite3 "${DEV_DB}" "DELETE FROM task_posts WHERE task_id IN (${ids});"`);
+    execSync(`sqlite3 "${DEV_DB}" "DELETE FROM execution_records WHERE source_todo_id IN (SELECT id FROM todos WHERE title LIKE '%${MARKER}%');"`);
+    execSync(`sqlite3 "${DEV_DB}" "DELETE FROM todos WHERE title LIKE '%${MARKER}%';"`);
+    execSync(`sqlite3 "${DEV_DB}" "DELETE FROM tasks WHERE id IN (${ids});"`);
+  } catch (e) {
+    console.warn('[092-config cleanup] 清理种子任务失败（开发库残留，通常可忽略）：', e);
+  }
+}
+
+test.describe('092 接力上限配置化', () => {
+  test.afterAll(() => cleanupSeededTasks());
+
+  // 用例 1：新建 Modal「最大轮数」字段随专家+自动接力联动（纯 UI，不提交）。
+  test('新建任务：专家+自动接力时出现「最大轮数」字段，关闭则消失', async ({ page }) => {
+    await page.goto(`${BASE}/#/tasks`);
+    await page.waitForSelector('.ant-table-row, .ant-empty', { timeout: 15000 });
+
+    await page.getByRole('button', { name: /新建/ }).first().click();
+    const dialog = page.getByRole('dialog', { name: /新建任务/ });
+    await expect(dialog).toBeVisible();
+
+    // 切到委派（处理人类型默认「专家」）。
+    await dialog.locator('.ant-radio-button-wrapper', { hasText: '委派' }).click();
+
+    // 自动接力默认关闭：「最大轮数」字段尚未渲染。
+    const autoSwitch = dialog.locator('[data-testid="create-task-auto-continue"]');
+    await expect(dialog.locator('[data-testid="create-task-max-rounds"]')).toHaveCount(0);
+
+    // 开启自动接力：「最大轮数」InputNumber 出现，placeholder 含「默认 N 轮」（工作空间有效默认）。
+    // 注：本版本 antd 把 data-testid 直接落在 <input> 上，故直接断言该元素，不再 .locator('input')。
+    await autoSwitch.click();
+    const maxRounds = dialog.locator('[data-testid="create-task-max-rounds"]');
+    await expect(maxRounds).toBeVisible();
+    await expect(maxRounds).toHaveAttribute('placeholder', /默认\s*\d+\s*轮/);
+
+    // 关闭自动接力：字段卸载即清值（preserve=false），不残留上限被误提交。
+    await autoSwitch.click();
+    await expect(dialog.locator('[data-testid="create-task-max-rounds"]')).toHaveCount(0);
+  });
+
+  // 用例 2：详情徽标内联改上限（走真实建任务 + PATCH）。
+  test('详情徽标内联改上限：置值后 M 变化，恢复默认回退', async ({ page }) => {
+    await page.goto(`${BASE}/#/tasks`);
+    await page.waitForSelector('.ant-table-row, .ant-empty', { timeout: 15000 });
+
+    // 建一个委派+专家+自动接力任务（复用 badge spec 流程）。
+    await page.getByRole('button', { name: /新建/ }).first().click();
+    const dialog = page.getByRole('dialog', { name: /新建任务/ });
+    await expect(dialog).toBeVisible();
+    await dialog.locator('.ant-radio-button-wrapper', { hasText: '委派' }).click();
+    await dialog.locator('[data-testid="create-task-requirement"]').fill(MARKER);
+    await dialog.locator('[data-testid="create-task-assignee"]').click();
+    const firstExpert = page.locator('.ant-select-item-option').first();
+    await firstExpert.waitFor({ state: 'visible' });
+    await firstExpert.click();
+    await dialog.locator('[data-testid="create-task-auto-continue"]').click();
+    await page.getByRole('button', { name: '开始执行' }).click();
+    await expect(dialog).toHaveCount(0, { timeout: 15000 });
+
+    // 打开新建任务详情。
+    const row = page.locator('.ant-table-row', { hasText: MARKER }).first();
+    await row.waitFor({ state: 'visible', timeout: 15000 });
+    await row.click();
+
+    // 徽标可见（N/M，M 为有效上限）。
+    const badge = page.locator('[data-testid="relay-badge"]');
+    await expect(badge).toBeVisible({ timeout: 15000 });
+
+    // 点徽标弹 Popover，输入 5 并确定 → M 应变为 5。
+    // data-testid 直接落在 InputNumber 的 <input> 上，故直接定位该元素（不套 .locator('input')）。
+    await badge.click();
+    const maxInput = page.locator('[data-testid="relay-max-input"]');
+    await expect(maxInput).toBeVisible({ timeout: 5000 });
+    await maxInput.fill('5');
+    await page.locator('[data-testid="relay-max-confirm"]').click();
+    // PATCH + 详情重拉后，徽标 M=5（N 可能因后台执行变化，故只断言 /5）。
+    await expect(badge).toHaveText(/\/\s*5\b/, { timeout: 10000 });
+
+    // 再次点开，「恢复默认」→ M 回退到默认（不再为 5）。
+    await badge.click();
+    await expect(page.locator('[data-testid="relay-max-reset"]')).toBeVisible({ timeout: 5000 });
+    await page.locator('[data-testid="relay-max-reset"]').click();
+    await expect(badge).not.toHaveText(/\/\s*5\b/, { timeout: 10000 });
+
+    await page.screenshot({ path: 'test-results/092-delegate-max-rounds-config.png' });
+  });
+});

--- a/frontend/tests/092-delegate-relay-badge.spec.ts
+++ b/frontend/tests/092-delegate-relay-badge.spec.ts
@@ -79,11 +79,12 @@ test.describe('092 委派自动接力徽标', () => {
     await row.click();
 
     // 详情头部出现后，断言管家调度徽标：文案「管家调度中 N/M」，N 为已完成的接力轮数，
-    // M 为三级解析的有效上限（护栏配置化）。创建瞬间首跑尚未完成 → N=0；
-    // 用 /\d+/ 容纳 M 随工作空间/任务配置变化，避免与配置化用例并发时硬编码 10 误判。
+    // M 为三级解析的有效上限（护栏配置化）。建任务后后台即开始接力，N 可能在详情加载前已递增，
+    // 故不硬断言 N=0（仅校验 N/M 均为数字），避免时序性 flaky（评审发现）。
     const badge = page.locator('.ant-tag', { hasText: /管家调度中\s*\d+\s*\/\s*\d+/ });
     await expect(badge).toBeVisible({ timeout: 15000 });
-    await expect(badge).toHaveText(/管家调度中\s*0\s*\/\s*\d+/);
+    // 显式断言 N、M 均为数字（与上面 locator 的 hasText 同口径，做一次明确断言）。
+    await expect(badge).toHaveText(/管家调度中\s*\d+\s*\/\s*\d+/);
 
     // 截图留档（test-results 由 Playwright 管理且已 gitignore，不入库）。
     await page.screenshot({ path: 'test-results/092-delegate-relay-badge.png' });

--- a/frontend/tests/092-delegate-relay-badge.spec.ts
+++ b/frontend/tests/092-delegate-relay-badge.spec.ts
@@ -1,12 +1,14 @@
-// 092-任务委派执行 P2：详情页「管家调度中 N/10」徽标验证。
+// 092-任务委派执行 P2：详情页「管家调度中 N/M」徽标验证。
 // 验证点（对应需求 092 验收标准 7）：委派 + 专家 + 自动接力任务，详情头部展示调度进度徽标。
 //
 // 策略说明：
 // - 走真实「新建任务」提交流程（非纯 UI 联动），因为徽标依赖后端落库的委派字段——
 //   委派任务一经创建即带 execution_mode=delegate + auto_continue=1 + continue_rounds=0，
-//   详情头部据此渲染徽标「管家调度中 0/10」。提交会用当前选中工作空间建任务，
+//   详情头部据此渲染徽标「管家调度中 0/M」。提交会用当前选中工作空间建任务，
 //   天然规避「种子任务所在工作空间与默认选中不一致」的可达性问题。
 // - 徽标在创建瞬间（continue_rounds=0）即可见；专家首跑尚未完成，故断言 N=0。
+// - **M 为三级解析的有效上限**（护栏配置化，092）：任务未覆盖 + 工作空间未配置时 M=兜底 10；
+//   本用例不预设工作空间默认，故断言用 /\d+/ 容纳 M 随配置变化，避免与配置化用例并发时误判。
 // - afterAll 删除本次创建的任务：finalize 接力入口会据此跳过（任务不存在 → 不再推进），
 //   避免专家结论里若含 @ 触发失控接力链路，污染开发库。
 
@@ -76,11 +78,12 @@ test.describe('092 委派自动接力徽标', () => {
     await row.waitFor({ state: 'visible', timeout: 15000 });
     await row.click();
 
-    // 详情头部出现后，断言管家调度徽标：文案「管家调度中 N/10」，N 为已完成的接力轮数。
-    // 创建瞬间首跑尚未完成 → N=0；用正则容纳「首跑恰好完成一轮」的竞态，避免误判。
-    const badge = page.locator('.ant-tag', { hasText: /管家调度中\s*\d+\s*\/\s*10/ });
+    // 详情头部出现后，断言管家调度徽标：文案「管家调度中 N/M」，N 为已完成的接力轮数，
+    // M 为三级解析的有效上限（护栏配置化）。创建瞬间首跑尚未完成 → N=0；
+    // 用 /\d+/ 容纳 M 随工作空间/任务配置变化，避免与配置化用例并发时硬编码 10 误判。
+    const badge = page.locator('.ant-tag', { hasText: /管家调度中\s*\d+\s*\/\s*\d+/ });
     await expect(badge).toBeVisible({ timeout: 15000 });
-    await expect(badge).toHaveText(/管家调度中\s*0\s*\/\s*10/);
+    await expect(badge).toHaveText(/管家调度中\s*0\s*\/\s*\d+/);
 
     // 截图留档（test-results 由 Playwright 管理且已 gitignore，不入库）。
     await page.screenshot({ path: 'test-results/092-delegate-relay-badge.png' });

--- a/frontend/tests/092-ws-delegate-max-rounds.spec.ts
+++ b/frontend/tests/092-ws-delegate-max-rounds.spec.ts
@@ -1,0 +1,69 @@
+// 092-任务委派执行·护栏配置化：工作空间级「委派接力上限」默认 设置接口契约 e2e。
+// 验证点（对应需求 092 护栏配置化 + Spec 评审「工作空间级编辑入口缺 Playwright 覆盖」）：
+//  PUT /api/v1/workspaces/{ws}/settings 的 delegate_max_rounds 可写、可回读、effective 随之变化；
+//  null=清除回退系统兜底（effective 回到 10）；越界(51)被端点拒 400 且不改既有值。
+//  收尾恢复原值，避免污染开发库影响其它用例的 fallback 断言。
+//
+// 走 API 契约而非 UI 导航：ws 级持久化是后端行为，UI(DefaultResponseConfigPanel) 仅是
+// InputNumber→PUT 的薄封装（同模式已由 task 级 config spec 覆盖）；API 路径最稳、直击新增的
+// PUT handler + workspace_effective_max 解析 + null=清除语义——即评审指出的「缺覆盖」之实质。
+
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+const BASE = process.env.E2E_BASE_URL ?? 'http://localhost:18088';
+const WS = 1;
+
+// 整表保存（与 UI DefaultResponseConfigPanel.handleSave 同口径）：回读当前设置，仅覆盖 relay 上限后整体回写。
+// 这样其余字段保持不变，避免误清 system_prompt / 默认响应等；也规避 serde 对缺失字段的严格校验。
+async function putDelegateMax(request: APIRequestContext, max: number | null) {
+  const cur = await fetchSettings(request);
+  return request.put(`${BASE}/api/v1/workspaces/${WS}/settings`, {
+    data: {
+      default_response_type: cur.default_response_type,
+      default_response_todo_id: cur.default_response_todo_id,
+      default_response_loop_id: cur.default_response_loop_id,
+      default_response_executor: cur.default_response_executor,
+      system_prompt: cur.system_prompt,
+      delegate_max_rounds: max,
+    },
+  });
+}
+
+// ApiResponse 把业务体包在 data 字段里（前端统一 unwrap）；这里取 .data 便于直接读字段。
+async function fetchSettings(request: APIRequestContext) {
+  const r = await request.get(`${BASE}/api/v1/workspaces/${WS}/settings`);
+  expect(r.ok(), 'GET settings 应成功').toBeTruthy();
+  const body = await r.json();
+  return body.data ?? body;
+}
+
+test.describe('092 工作空间接力上限默认（API 契约）', () => {
+  test('PUT delegate_max_rounds 可写持久、effective 跟随、null 清除回退兜底、越界 400', async ({ request }) => {
+    // 记录原值用于收尾恢复，避免污染开发库。
+    const before = await fetchSettings(request);
+    const original: number | null = before.delegate_max_rounds ?? null;
+
+    // 置 12 → raw 与 effective 均为 12（工作空间默认即生效）。
+    let r = await putDelegateMax(request, 12);
+    expect(r.ok(), 'PUT 12 应成功').toBeTruthy();
+    let s = await fetchSettings(request);
+    expect(s.delegate_max_rounds).toBe(12);
+    expect(s.delegate_max_rounds_effective).toBe(12);
+
+    // 越界 51 → 400（端点侧 validate_delegate_max_rounds），且不改既有值（仍 12）。
+    r = await putDelegateMax(request, 51);
+    expect(r.status(), 'PUT 51 应 400').toBe(400);
+    s = await fetchSettings(request);
+    expect(s.delegate_max_rounds, '越界请求不应改动既有值').toBe(12);
+
+    // null=清除 → raw=null，effective 回退终极兜底常量 10。
+    r = await putDelegateMax(request, null);
+    expect(r.ok(), 'PUT null(清除) 应成功').toBeTruthy();
+    s = await fetchSettings(request);
+    expect(s.delegate_max_rounds).toBeNull();
+    expect(s.delegate_max_rounds_effective, '清除后 effective 回退兜底 10').toBe(10);
+
+    // 收尾：恢复原值，开发库自洽。
+    await putDelegateMax(request, original);
+  });
+});


### PR DESCRIPTION
## 概述

把 P2 写死的接力上限 `MAX_DELEGATE_ROUNDS = 10`（前后端各硬编码一处）演化为**运行时可配的三级解析**，消除跨栈漂移，支持「每个任务不一样 + 工作空间默认初始值 + 后续可调整」。

```
effective_max = task.delegate_max_rounds            （per-task 覆盖；NULL ↓）
             ?? workspace_settings.delegate_max_rounds （per-workspace 默认；NULL ↓）
             ?? MAX_DELEGATE_ROUNDS(10)              （终极兜底常量，保留）
```

护栏决策（`plan_delegate_relay`）与详情徽标展示**共用同一 `resolve_delegate_max_rounds` 口径**。`continue_rounds`（计数）仍后端单调递增、前端不可直传——**只配置化「上限阈值」，护栏不可绕过**（设计 §5.2 红线不变）。

## 需求对应

- 用户需求：做成**可变更的配置项**；**每个任务可能都不一样**；**有默认初始值**；**后续可调整**。
- 默认值落**工作空间级**；编辑入口**创建时可填 + 详情页可改**（经确认）。
- 设计文档：`docs/design/092-任务委派执行-设计.md`（新增 §5.5 三级配置）。
- 实现总结：`docs/requirements/092-任务委派执行-护栏配置化-实现总结.md`。

## 改动要点

**后端**
- **v92 迁移**：`tasks` / `workspace_settings` 各加 `delegate_max_rounds`（nullable 无 DEFAULT），`consolidated_schema` 同步。
- `resolve_delegate_max_rounds`（三级 + DB 失败 graceful-degrade 回退兜底）+ `validate_delegate_max_rounds`（1..=50 集中校验）+ `DELEGATE_MAX_ROUNDS_CAP=50`。
- DAO：`create_delegate_task` 加参；`update_delegate_max_rounds` / `update_workspace_delegate_max_rounds` 聚焦单字段（**不**波及 `upsert_workspace_settings` 的 11 处无关调用点）。
- Handler：`CreateTaskRequest` + `get_task_detail`（返 raw+effective）；新增 **`PATCH /api/v1/workspaces/{ws}/tasks/{id}`**（仅委派任务支持，环路 400）；`agent_bot` get 返回 raw+effective、put 校验转发。

**前端**
- `bots.ts`/`bundled.ts` 类型 + `createTask`（可选下发，避免 undefined→null 误清）+ 新增 `updateTask`(PATCH)。
- `CreateTaskModal`：专家 + 自动接力时弹「最大轮数」`InputNumber`，placeholder 取工作空间默认。
- `TaskDetailPanel`：**删除硬编码 10**；徽标 `N/M` 读 effective；✎ 内联改上限 / 「恢复默认」。
- `DefaultResponseConfigPanel`：工作空间默认「委派接力上限」`InputNumber`。

**编辑语义统一**：`null`=清除/恢复默认，`N`=设置（任务 PATCH + 工作空间 PUT 一致）。

## 安全反思
- 护栏不可绕过：`continue_rounds` 后端单调递增，前端不可直传；只配置化上限。
- 越界硬拒：非 `1..=50` 一律 400（端点侧 `validate_delegate_max_rounds`，不只靠前端 InputNumber）。
- 降级安全：DB 读失败回退兜底；非法覆盖值（脏数据 0）resolve 用 `.filter(|x|>0)` 跳过。

## 验证（全绿）
- `cargo clippy --all-targets -- -D warnings`：零告警。
- `cargo test`：1701+ 通过（v92 幂等+列存在 / resolve 三级+非法0跳过 / validate 范围 / DAO set-clear / handler create·PATCH 越界400·环路拒绝）。
- `npx tsc --noEmit`：零错；`npm run build`：无新告警。
- Playwright（6 个 092 e2e 全过）：新建「最大轮数」字段联动 + 徽标内联改上限/恢复默认 + 既有委派/徽标回归。
