### PR TITLE
feat(093): 任务详情环路Tab按执行方式显隐——委派任务隐藏执行环路/执行历史

### DIFF
--- a/docs/design/093-任务详情环路Tab按执行方式显隐-设计.md
+++ b/docs/design/093-任务详情环路Tab按执行方式显隐-设计.md
@@ -3,6 +3,7 @@
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | AI (Claude) | 2026-08-08 | 初始版本 |
+| AI (Claude) | 2026-08-08 | 评审修订：`activeKey` 兜底简化为 `tabItems.some()` 就地判断（YAGNI，去中间数组） |
 
 对应需求：用户提出（会话中已确认方案）——「执行历史、执行环路，只有在创建任务时选用了『工艺环路』才有意义，不需要显示的时候就别显示了」。本改动为 UI 精炼（非新功能），按 CLAUDE.md 约定不单独建需求文档。
 
@@ -31,11 +32,9 @@
 
    实现形态：
    ```ts
-   // 实际渲染的 Tab key 集合（委派任务不含 dag/exec）。
-   const visibleTabKeys = tabItems.map((t) => t.key);
    // resolvedTab 可能指向因委派而隐藏的 Tab（URL 残留 ?tab=dag），
-   // 此时回退到默认 Tab，避免 Tabs 无选中态导致内容区空白。
-   const activeTabKey = visibleTabKeys.includes(resolvedTab)
+   // 就地校验 tabItems 是否含该 key（不额外构造 key 数组），命中即回退默认 Tab。
+   const activeTabKey = tabItems.some((t) => t.key === resolvedTab)
      ? resolvedTab
      : (isDelegate ? 'discussion' : 'overview');
    ```

--- a/docs/design/093-任务详情环路Tab按执行方式显隐-设计.md
+++ b/docs/design/093-任务详情环路Tab按执行方式显隐-设计.md
@@ -1,0 +1,68 @@
+# 093-任务详情环路Tab按执行方式显隐-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Claude) | 2026-08-08 | 初始版本 |
+
+对应需求：用户提出（会话中已确认方案）——「执行历史、执行环路，只有在创建任务时选用了『工艺环路』才有意义，不需要显示的时候就别显示了」。本改动为 UI 精炼（非新功能），按 CLAUDE.md 约定不单独建需求文档。
+
+## 1. 总体思路
+
+任务详情面板 `TaskDetailPanel` 当前固定展示 4 个 Tab：概览 / 执行环路(DAG) / 执行历史 / 讨论。其中「执行环路」「执行历史」强依赖任务绑定的环路（`task.loop_id`）：
+
+- 工艺环路任务（`execution_mode === 'loop'`）：有 `loop_id`，两 Tab 有实际内容。
+- 委派任务（`execution_mode === 'delegate'`）：`loop_id` 为空，两 Tab 内部只能渲染空状态（「暂无关联环路」「暂无执行环路」），对用户无意义反而造成困惑。
+
+方案：按 `task.execution_mode` 条件组装 `tabItems`——委派任务不再 push 这两个 Tab，只保留「概览」「讨论」。该判断口径与现有委派相关 UI（Header 处理人、隐藏「再次执行」、默认 Tab 落「讨论」）完全一致，不引入新概念。
+
+不改动后端、不改动数据模型、不改动 `DAGTab`/`ExecHistoryTab` 内部逻辑（其空状态分支保留作异常态防御）。
+
+## 2. 前端改动
+
+### 2.1 `frontend/src/components/tasks/TaskDetailPanel.tsx` — 条件组装 Tab
+
+当前 `tabItems`（L387-424）无条件全量构造 4 项。改动点：
+
+1. **派生委派标记**：在 `const { task, template } = detail;`（L383）之后，新增 `const isDelegate = task.execution_mode === 'delegate';`。复用既有口径，避免在多处重复字面量。
+
+2. **条件 push 环路相关 Tab**：「执行环路」(`dag`) 与「执行历史」(`exec`) 两项仅在 `!isDelegate` 时加入 `tabItems`。「概览」「讨论」始终加入。
+
+3. **`activeKey` 兜底**：现有 `resolvedTab`（L288-291）依据 `TAB_KEYS` 白名单解析 URL `?tab=`，但 `TAB_KEYS` 始终含 `dag`/`exec`。委派任务若 URL 带 `?tab=dag`，解析出的 key 指向已隐藏的 Tab，Ant Design `Tabs` 会落到无选中态、内容区空白。因此在 `tabItems` 构造之后加一道校验：若 `resolvedTab` 不在当前实际渲染的 Tab key 集合中，回退到默认（委派→`discussion`，否则→`overview`）。
+
+   实现形态：
+   ```ts
+   // 实际渲染的 Tab key 集合（委派任务不含 dag/exec）。
+   const visibleTabKeys = tabItems.map((t) => t.key);
+   // resolvedTab 可能指向因委派而隐藏的 Tab（URL 残留 ?tab=dag），
+   // 此时回退到默认 Tab，避免 Tabs 无选中态导致内容区空白。
+   const activeTabKey = visibleTabKeys.includes(resolvedTab)
+     ? resolvedTab
+     : (isDelegate ? 'discussion' : 'overview');
+   ```
+   `<Tabs>` 的 `activeKey={resolvedTab}` 改为 `activeKey={activeTabKey}`。
+
+### 2.2 不改动项
+
+- `DAGTab`（`TaskDetailTabs.tsx`）的 `loopDetail` 空态分支保留：工艺环路任务异常缺 loop 时仍能优雅降级，而非崩白。
+- `ExecHistoryTab`（`TaskDetailTabs.tsx`）的 `loopId === 0` 空态分支保留，同理。
+- 「再次执行」按钮、Header 元信息行等既有委派判断不变。
+
+## 3. 影响面与兼容
+
+- 改动集中在单文件 `TaskDetailPanel.tsx`，纯前端条件渲染，无接口/数据变更。
+- 委派任务详情 Tab 数从 4 → 2（概览、讨论），工艺环路任务不变（仍 4 个）。
+- URL `?tab=` 兼容：历史链接若指向 `dag`/`exec` 且任务为委派，自动回退到默认 Tab，不会出现空白。
+- 默认选中态不受影响：委派任务原本就默认落「讨论」（L290-291），隐藏后仍落「讨论」；环路任务落「概览」。
+
+## 4. 测试计划
+
+- 前端类型检查：`cd frontend && npx tsc --noEmit` 零错误。
+- Playwright（脚本置于 `frontend/tests/`）：
+  - 打开一个委派任务详情，断言 Tab 条只有「概览」「讨论」，无「执行环路」「执行历史」。
+  - 打开一个工艺环路任务详情，断言 4 个 Tab 齐全。
+  - 委派任务 URL 带 `?tab=dag` 时，内容区不空白（回退到默认 Tab）。
+
+## 5. 安全反思
+
+- 纯前端展示层调整，无鉴权、无输入处理、无 SQL/网络面。
+- `execution_mode` 来自后端任务详情接口（受信任的库内数据），前端仅据其决定 Tab 显隐，无注入或越权风险。

--- a/docs/requirements/093-任务详情环路Tab按执行方式显隐-实现总结.md
+++ b/docs/requirements/093-任务详情环路Tab按执行方式显隐-实现总结.md
@@ -4,6 +4,7 @@
 |--------|---------|---------|
 | AI (Claude) | 2026-08-08 | 初始版本 |
 | AI (Claude) | 2026-08-08 | 评审修订：`activeKey` 兜底简化为 `some()`；Playwright spec 改为自管 fixture 造数/清理（独立可运行）；环路用例补 count===4 断言 |
+| AI (Claude) | 2026-08-08 | CodeRabbit 评审修订：fixture 每次运行唯一标记 + `last_insert_rowid()` 取 id + 按 id 清理（并发安全）；补 `?tab=exec` 回退用例 |
 
 设计：`docs/design/093-任务详情环路Tab按执行方式显隐-设计.md`。本改动为 UI 精炼（非新功能），需求由用户会话提出并确认，未单独建需求文档。
 
@@ -19,7 +20,7 @@
 |---------|------|------|
 | 委派任务不展示「执行环路」「执行历史」 | `TaskDetailPanel` 按 `execution_mode` 条件组装 `tabItems`，委派任务不 push 这两项 | Playwright 093-1（断言仅 2 Tab、无环路相关） |
 | 工艺环路任务仍展示环路相关 Tab | 环路任务（`!isDelegate`）照常纳入两 Tab | Playwright 093-2 |
-| URL 残留 `?tab=dag/exec` 时不空白 | `activeTabKey` 校验实际可见 Tab key 集合，命中隐藏项即回退默认 Tab | Playwright 093-3（`?tab=dag` → 回退「讨论」，内容区有发送按钮） |
+| URL 残留 `?tab=dag/exec` 时不空白 | `activeTabKey` 校验实际可见 Tab key 集合，命中隐藏项即回退默认 Tab | Playwright 093-3（`?tab=dag`、`?tab=exec` 均回退「讨论」，内容区有发送按钮） |
 
 ## 3. 关键实现点
 
@@ -34,7 +35,7 @@
 - 前端构建：`npm run build` 成功（chunk 体积告警为 monaco/antd/md-editor 既有，与本次改动无关）。
 - Playwright：`tests/093-task-detail-loop-tabs-by-mode.spec.ts` 3/3 通过；回归 `tests/060-task-discussion-forum.spec.ts` 1/1 通过（讨论 Tab 渲染未受影响）。
 - vitest：`src/components/tasks/` 47/47 通过（`helpers` / `constants` / `TaskDetailTabs` / 讨论工具均无回归）。
-- 数据独立（评审修订）：spec 在 `beforeAll` 自行向 dev 库插入委派任务 fixture（唯一标记 `093-pw-fixture-delegate`，`execution_mode=delegate`），`afterAll` 按标记清理；工艺环路任务动态发现 dev 库第一条 loop 任务，无则 `test.skip`。不再硬编码任务 id、不依赖预置数据，满足前端规范 11-测试规范 §4（独立可运行）。
+- 数据独立（评审修订）：spec 在 `beforeAll` 自行向 dev 库插入委派任务 fixture（每次运行唯一标记 `093-pw-fixture-delegate-<pid>-<ts>`，`execution_mode=delegate`），用 `last_insert_rowid()` 取回 id；`afterAll` 按该 id 精确清理——并发 run 之间不会共享或误删。工艺环路任务动态发现 dev 库第一条 loop 任务，无则 `test.skip`。满足前端规范 11-测试规范 §4（独立可运行）。
 
 ## 5. 安全反思
 

--- a/docs/requirements/093-任务详情环路Tab按执行方式显隐-实现总结.md
+++ b/docs/requirements/093-任务详情环路Tab按执行方式显隐-实现总结.md
@@ -3,6 +3,7 @@
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | AI (Claude) | 2026-08-08 | 初始版本 |
+| AI (Claude) | 2026-08-08 | 评审修订：`activeKey` 兜底简化为 `some()`；Playwright spec 改为自管 fixture 造数/清理（独立可运行）；环路用例补 count===4 断言 |
 
 设计：`docs/design/093-任务详情环路Tab按执行方式显隐-设计.md`。本改动为 UI 精炼（非新功能），需求由用户会话提出并确认，未单独建需求文档。
 
@@ -33,7 +34,7 @@
 - 前端构建：`npm run build` 成功（chunk 体积告警为 monaco/antd/md-editor 既有，与本次改动无关）。
 - Playwright：`tests/093-task-detail-loop-tabs-by-mode.spec.ts` 3/3 通过；回归 `tests/060-task-discussion-forum.spec.ts` 1/1 通过（讨论 Tab 渲染未受影响）。
 - vitest：`src/components/tasks/` 47/47 通过（`helpers` / `constants` / `TaskDetailTabs` / 讨论工具均无回归）。
-- 数据准备：dev 库（`~/.ntd/data.dev.db`）原仅有 loop 任务，本次直接插入委派任务 fixture（id=52，`execution_mode=delegate`，`loop_id=NULL`，workspace 3）用于 093-1/093-3；环路任务用既有数据 id=15（`loop_id=21`）用于 093-2。fixture 与 060 spec 复用既有任务的做法一致。
+- 数据独立（评审修订）：spec 在 `beforeAll` 自行向 dev 库插入委派任务 fixture（唯一标记 `093-pw-fixture-delegate`，`execution_mode=delegate`），`afterAll` 按标记清理；工艺环路任务动态发现 dev 库第一条 loop 任务，无则 `test.skip`。不再硬编码任务 id、不依赖预置数据，满足前端规范 11-测试规范 §4（独立可运行）。
 
 ## 5. 安全反思
 
@@ -42,4 +43,4 @@
 
 ## 6. 已知限制
 
-- 委派任务 fixture（id=52）与 093 spec 的委派断言强绑定：若 dev 库重建清空，需重新插入一个 `execution_mode=delegate` 任务并同步更新 spec 顶部的 `DELEGATE_TASK_ID`（与 060 依赖 task 39 同性质的 dev 数据依赖）。
+- 工艺环路用例仍依赖 dev 库存在至少一条 loop 任务（loop 任务需工艺 install 产生，spec 不便造数）；无则在用例内 `test.skip`，不影响委派两用例。委派 fixture 已由 spec 自管造数/清理，不再有 id 绑定。

--- a/docs/requirements/093-任务详情环路Tab按执行方式显隐-实现总结.md
+++ b/docs/requirements/093-任务详情环路Tab按执行方式显隐-实现总结.md
@@ -1,0 +1,45 @@
+# 093-任务详情环路Tab按执行方式显隐-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Claude) | 2026-08-08 | 初始版本 |
+
+设计：`docs/design/093-任务详情环路Tab按执行方式显隐-设计.md`。本改动为 UI 精炼（非新功能），需求由用户会话提出并确认，未单独建需求文档。
+
+## 1. 实现了什么
+
+任务详情面板（`TaskDetailPanel`）此前对所有任务都展示固定 4 个 Tab：概览 / 执行环路 / 执行历史 / 讨论。但「执行环路」「执行历史」强依赖任务绑定的环路——委派任务（创建时选「委派」而非「工艺环路」，`execution_mode === 'delegate'`）没有环路，这两个 Tab 此前只能渲染成空状态（「暂无关联环路」「暂无执行环路」），对用户无意义且易误导。
+
+现在按执行方式条件组装 Tab：**委派任务只展示「概览」「讨论」两个 Tab**，「执行环路」「执行历史」不再出现；工艺环路任务仍保留全部 4 个 Tab。
+
+## 2. 与需求的对应关系
+
+| 需求目标 | 实现 | 验证 |
+|---------|------|------|
+| 委派任务不展示「执行环路」「执行历史」 | `TaskDetailPanel` 按 `execution_mode` 条件组装 `tabItems`，委派任务不 push 这两项 | Playwright 093-1（断言仅 2 Tab、无环路相关） |
+| 工艺环路任务仍展示环路相关 Tab | 环路任务（`!isDelegate`）照常纳入两 Tab | Playwright 093-2 |
+| URL 残留 `?tab=dag/exec` 时不空白 | `activeTabKey` 校验实际可见 Tab key 集合，命中隐藏项即回退默认 Tab | Playwright 093-3（`?tab=dag` → 回退「讨论」，内容区有发送按钮） |
+
+## 3. 关键实现点
+
+- **判断口径一致**：用 `task.execution_mode === 'delegate'` 作为委派标记，与 Header 处理人、隐藏「再次执行」、默认 Tab 落「讨论」等既有委派分支完全一致，不引入新概念。
+- **条件组装保持顺序**：用 `...(!isDelegate ? [dag, exec] : [])` 在「概览」与「讨论」之间条件展开，委派任务展开为空数组等价于这两项不出现，Tab 顺序不变。
+- **`activeKey` 兜底**：`resolvedTab` 依据 `TAB_KEYS` 白名单解析 URL `?tab=`，而白名单恒含 `dag`/`exec`；委派任务若 URL 残留 `?tab=dag`，解析出的 key 会指向已隐藏的 Tab，Ant Design `Tabs` 随即落到无选中态、内容区空白。新增 `activeTabKey` 校验：若不在实际可见 Tab key 集合中，回退默认（委派→`discussion`，否则→`overview`）。
+- **不动空态防御**：`DAGTab`/`ExecHistoryTab` 内部的 `loopDetail` 空 / `loopId===0` 空态分支保留——工艺环路任务异常缺 loop 时仍能优雅降级，而非崩白。
+
+## 4. 测试与验证结果
+
+- 前端类型检查：`npx tsc --noEmit` 零错误。
+- 前端构建：`npm run build` 成功（chunk 体积告警为 monaco/antd/md-editor 既有，与本次改动无关）。
+- Playwright：`tests/093-task-detail-loop-tabs-by-mode.spec.ts` 3/3 通过；回归 `tests/060-task-discussion-forum.spec.ts` 1/1 通过（讨论 Tab 渲染未受影响）。
+- vitest：`src/components/tasks/` 47/47 通过（`helpers` / `constants` / `TaskDetailTabs` / 讨论工具均无回归）。
+- 数据准备：dev 库（`~/.ntd/data.dev.db`）原仅有 loop 任务，本次直接插入委派任务 fixture（id=52，`execution_mode=delegate`，`loop_id=NULL`，workspace 3）用于 093-1/093-3；环路任务用既有数据 id=15（`loop_id=21`）用于 093-2。fixture 与 060 spec 复用既有任务的做法一致。
+
+## 5. 安全反思
+
+- 纯前端展示层调整，无鉴权、无输入处理、无 SQL/网络面。
+- `execution_mode` 来自后端任务详情接口（受信任的库内数据），前端仅据其决定 Tab 显隐，无注入或越权风险。
+
+## 6. 已知限制
+
+- 委派任务 fixture（id=52）与 093 spec 的委派断言强绑定：若 dev 库重建清空，需重新插入一个 `execution_mode=delegate` 任务并同步更新 spec 顶部的 `DELEGATE_TASK_ID`（与 060 依赖 task 39 同性质的 dev 数据依赖）。

--- a/frontend/src/components/tasks/TaskDetailPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailPanel.tsx
@@ -384,6 +384,12 @@ export function TaskDetailPanel({
   const lpId = task.loop_id ?? detail.loop?.id ?? 0;
   const lpWsId = task.workspace_id ?? detail.loop?.workspace_id ?? null;
 
+  // 委派任务（创建时选「委派」而非「工艺环路」）未绑定环路，没有「执行环路」「执行历史」可展示：
+  // 此前这两个 Tab 会渲染成空状态（「暂无关联环路」「暂无执行环路」），对用户无意义且易误导。
+  // 这里按 execution_mode 条件组装——委派任务只保留「概览」「讨论」；判断口径与 Header 处理人、
+  // 隐藏「再次执行」、默认 Tab 落「讨论」等既有委派分支完全一致，不引入新概念。
+  const isDelegate = task.execution_mode === 'delegate';
+
   const tabItems = [
     {
       key: 'overview',
@@ -395,18 +401,22 @@ export function TaskDetailPanel({
         />
       ),
     },
-    {
-      key: 'dag',
-      label: `执行环路 (${loopDetail?.steps?.length ?? 0})`,
-      children: <DAGTab loopDetail={loopDetail} steps={detail.steps ?? []} onOpenTodo={onOpenTodo} />,
-    },
-    {
-      key: 'exec',
-      label: '执行历史',
-      children: (
-        <ExecHistoryTab loopId={lpId} workspaceId={lpWsId} loopName={loopDetail?.name ?? task.title} />
-      ),
-    },
+    // 「执行环路」「执行历史」强依赖 task.loop_id：仅工艺环路任务才纳入这两个 Tab。
+    // 委派任务展开为空数组，等价于这两项不出现（顺序仍夹在「概览」与「讨论」之间）。
+    ...(!isDelegate ? [
+      {
+        key: 'dag',
+        label: `执行环路 (${loopDetail?.steps?.length ?? 0})`,
+        children: <DAGTab loopDetail={loopDetail} steps={detail.steps ?? []} onOpenTodo={onOpenTodo} />,
+      },
+      {
+        key: 'exec',
+        label: '执行历史',
+        children: (
+          <ExecHistoryTab loopId={lpId} workspaceId={lpWsId} loopName={loopDetail?.name ?? task.title} />
+        ),
+      },
+    ] : []),
     {
       // 任务讨论区（需求 060）：论坛跟帖 + @专家/@执行器 触发执行后回帖。
       // forceRender：保证「讨论」Tab 非 active 时 DiscussionTab 仍挂载、持续上报 running 数，角标才可见。
@@ -423,6 +433,14 @@ export function TaskDetailPanel({
     },
   ];
 
+  // 实际渲染的 Tab key 集合（委派任务不含 dag/exec）。resolvedTab 依据 TAB_KEYS 白名单解析 URL ?tab=，
+  // 而该白名单恒含 dag/exec；委派任务若 URL 残留 ?tab=dag，解析出的 key 会指向已隐藏的 Tab，Ant Design
+  // Tabs 随即落到无选中态、内容区空白。此处校验命中即回退默认 Tab，避免空白页。
+  const visibleTabKeys: string[] = tabItems.map((t) => t.key);
+  const activeTabKey = visibleTabKeys.includes(resolvedTab)
+    ? resolvedTab
+    : (isDelegate ? 'discussion' : 'overview');
+
   return (
     <div className={styles.panel}>
       <DetailHeader
@@ -432,7 +450,7 @@ export function TaskDetailPanel({
       <div className={styles.tabsWrap}>
         <Tabs
           items={tabItems}
-          activeKey={resolvedTab}
+          activeKey={activeTabKey}
           onChange={(key) => replaceUrl('tasks', { id: task.id, tab: key })}
           style={{ height: '100%' }}
           tabBarExtraContent={loopLoading ? <Spin size="small" style={{ marginRight: 16 }} /> : undefined}

--- a/frontend/src/components/tasks/TaskDetailPanel.tsx
+++ b/frontend/src/components/tasks/TaskDetailPanel.tsx
@@ -433,11 +433,10 @@ export function TaskDetailPanel({
     },
   ];
 
-  // 实际渲染的 Tab key 集合（委派任务不含 dag/exec）。resolvedTab 依据 TAB_KEYS 白名单解析 URL ?tab=，
-  // 而该白名单恒含 dag/exec；委派任务若 URL 残留 ?tab=dag，解析出的 key 会指向已隐藏的 Tab，Ant Design
-  // Tabs 随即落到无选中态、内容区空白。此处校验命中即回退默认 Tab，避免空白页。
-  const visibleTabKeys: string[] = tabItems.map((t) => t.key);
-  const activeTabKey = visibleTabKeys.includes(resolvedTab)
+  // resolvedTab 依据 TAB_KEYS 白名单解析 URL ?tab=，而该白名单恒含 dag/exec；委派任务若 URL 残留 ?tab=dag，
+  // 解析出的 key 会指向已隐藏的 Tab，Ant Design Tabs 随即落到无选中态、内容区空白。就地校验 tabItems 是否
+  // 含该 key（不额外构造 key 数组），命中即回退默认 Tab，避免空白页。
+  const activeTabKey = tabItems.some((t) => t.key === resolvedTab)
     ? resolvedTab
     : (isDelegate ? 'discussion' : 'overview');
 

--- a/frontend/tests/093-task-detail-loop-tabs-by-mode.spec.ts
+++ b/frontend/tests/093-task-detail-loop-tabs-by-mode.spec.ts
@@ -1,0 +1,71 @@
+// 093-任务详情环路Tab按执行方式显隐 Playwright 验证（设计 093）。
+// 验证点：
+// 1. 委派任务（execution_mode=delegate）详情只展示「概览」「讨论」两 Tab，无「执行环路」「执行历史」；
+// 2. 工艺环路任务（execution_mode=loop）详情仍展示「执行环路」「执行历史」两 Tab；
+// 3. 委派任务 URL 残留 ?tab=dag 时，不出现内容区空白——自动回退到默认 Tab（讨论）。
+//
+// 运行前提：make dev 已起（18088）。
+// 数据依赖（dev 库 ~/.ntd/data.dev.db，均属 workspace 3）：
+//   - 委派任务 fixture id=52（execution_mode=delegate, loop_id=NULL），为本验证直接插入；
+//   - 工艺环路任务 id=15（execution_mode=loop, loop_id=21），dev 库既有数据。
+// 这与 060 spec 复用 dev 库既有任务（如 id=39）的做法一致。
+
+import { test, expect, type Page } from '@playwright/test';
+
+const BASE = 'http://localhost:18088';
+// 委派任务 fixture：execution_mode=delegate，无 loop_id → 不应出现环路相关 Tab。
+const DELEGATE_TASK_ID = 52;
+// 工艺环路任务：execution_mode=loop，loop_id=21 → 应出现环路相关 Tab。
+const LOOP_TASK_ID = 15;
+
+// 等待任务详情 Tab 栏渲染完成，返回各 Tab 的可见文本（便于按文案断言）。
+// 用 innerText 逐个收集，避免 locator.allTextItems 受 Badge/图标节点干扰。
+async function getTabTexts(page: Page): Promise<string[]> {
+  await page.waitForSelector('.ant-tabs-tab', { timeout: 15000 });
+  const tabs = page.locator('.ant-tabs-tab');
+  const count = await tabs.count();
+  const texts: string[] = [];
+  for (let i = 0; i < count; i++) {
+    texts.push((await tabs.nth(i).innerText()) ?? '');
+  }
+  return texts;
+}
+
+test('委派任务详情：只展示概览与讨论，无环路相关 Tab', async ({ page }) => {
+  await page.goto(`${BASE}/#/tasks/${DELEGATE_TASK_ID}`);
+  const texts = await getTabTexts(page);
+
+  // 委派任务应恰好 2 个 Tab：概览、讨论。
+  expect(texts.length).toBe(2);
+  const joined = texts.join('|');
+  expect(joined).toContain('概览');
+  expect(joined).toContain('讨论');
+  // 关键断言：环路相关 Tab 不应出现。
+  expect(texts.some((t) => t.includes('执行环路'))).toBe(false);
+  expect(texts.some((t) => t.includes('执行历史'))).toBe(false);
+});
+
+test('工艺环路任务详情：仍展示执行环路/执行历史 Tab', async ({ page }) => {
+  await page.goto(`${BASE}/#/tasks/${LOOP_TASK_ID}`);
+  const texts = await getTabTexts(page);
+
+  // 环路任务应保留环路相关 Tab（label 形如「执行环路 (N)」「执行历史」）。
+  expect(texts.some((t) => t.includes('执行环路'))).toBe(true);
+  expect(texts.some((t) => t.includes('执行历史'))).toBe(true);
+});
+
+test('委派任务 URL 残留 ?tab=dag：回退默认 Tab，内容区不空白', async ({ page }) => {
+  // resolvedTab 会把 ?tab=dag 解析为 'dag'（TAB_KEYS 白名单含该项），但委派任务已隐藏该 Tab。
+  // 若无 activeKey 兜底，Tabs 会落到无选中态、内容区空白；此处验证兜底回退到「讨论」。
+  await page.goto(`${BASE}/#/tasks/${DELEGATE_TASK_ID}?tab=dag`);
+  await page.waitForSelector('.ant-tabs-tab', { timeout: 15000 });
+
+  // 激活的 Tab 应回退为「讨论」（委派任务默认 Tab）。
+  const activeTab = page.locator('.ant-tabs-tab-active');
+  await expect(activeTab).toBeVisible();
+  const activeText = (await activeTab.innerText()) ?? '';
+  expect(activeText).toContain('讨论');
+
+  // 内容区不空白：讨论 Tab forceRender 挂载，发送按钮可见（DiscussionComposer 已渲染）。
+  await expect(page.getByRole('button', { name: '发送' })).toBeVisible({ timeout: 10000 });
+});

--- a/frontend/tests/093-task-detail-loop-tabs-by-mode.spec.ts
+++ b/frontend/tests/093-task-detail-loop-tabs-by-mode.spec.ts
@@ -1,25 +1,62 @@
 // 093-任务详情环路Tab按执行方式显隐 Playwright 验证（设计 093）。
 // 验证点：
 // 1. 委派任务（execution_mode=delegate）详情只展示「概览」「讨论」两 Tab，无「执行环路」「执行历史」；
-// 2. 工艺环路任务（execution_mode=loop）详情仍展示「执行环路」「执行历史」两 Tab；
+// 2. 工艺环路任务（execution_mode=loop）详情仍展示全部 4 个 Tab（设计 §4「4 个 Tab 齐全」）；
 // 3. 委派任务 URL 残留 ?tab=dag 时，不出现内容区空白——自动回退到默认 Tab（讨论）。
 //
 // 运行前提：make dev 已起（18088）。
-// 数据依赖（dev 库 ~/.ntd/data.dev.db，均属 workspace 3）：
-//   - 委派任务 fixture id=52（execution_mode=delegate, loop_id=NULL），为本验证直接插入；
-//   - 工艺环路任务 id=15（execution_mode=loop, loop_id=21），dev 库既有数据。
-// 这与 060 spec 复用 dev 库既有任务（如 id=39）的做法一致。
+// 数据独立（前端规范 11-测试规范 §4「测试必须独立可运行，不依赖外部状态」）：
+//   - 委派任务：beforeAll 向 dev 库插入 fixture，afterAll 按唯一标记清理，不依赖任何预置数据；
+//   - 工艺环路任务：dev 库通常已有 loop 任务，动态取第一条；若无则跳过（loop 任务需工艺 install 产生，本 spec 不便造数）。
 
 import { test, expect, type Page } from '@playwright/test';
+import { execSync } from 'child_process';
+import * as path from 'path';
 
 const BASE = 'http://localhost:18088';
-// 委派任务 fixture：execution_mode=delegate，无 loop_id → 不应出现环路相关 Tab。
-const DELEGATE_TASK_ID = 52;
-// 工艺环路任务：execution_mode=loop，loop_id=21 → 应出现环路相关 Tab。
-const LOOP_TASK_ID = 15;
+// dev 库路径（CLAUDE.md 开发环境约定），用 HOME 展开避免硬编码用户目录。
+const DEV_DB = path.join(process.env.HOME ?? '', '.ntd', 'data.dev.db');
+// 委派 fixture 所属工作空间：与 dev 库现有 loop 任务一致，便于在同一 ws 内校验。
+const WS_ID = 3;
+// 唯一标记：afterAll 按此前缀精确清理本 spec 插入的行，绝不动到既有数据。
+const FIXTURE_TITLE = '093-pw-fixture-delegate';
 
-// 等待任务详情 Tab 栏渲染完成，返回各 Tab 的可见文本（便于按文案断言）。
-// 用 innerText 逐个收集，避免 locator.allTextItems 受 Badge/图标节点干扰。
+let delegateTaskId = 0;
+let loopTaskId = 0;
+
+test.beforeAll(() => {
+  // 插入委派任务 fixture：execution_mode=delegate，loop_id 默认 NULL → 不应出现环路相关 Tab。
+  execSync(
+    `sqlite3 "${DEV_DB}" "INSERT INTO tasks ` +
+      `(title, description, status, workspace_id, execution_mode, assignee_kind, assignee_name, ` +
+      `auto_continue, continue_rounds, created_at, updated_at) ` +
+      `VALUES ('${FIXTURE_TITLE}', 'Playwright 验证委派任务', 'pending', ${WS_ID}, ` +
+      `'delegate', 'executor', 'codex', 0, 0, datetime('now'), datetime('now'));"`,
+  );
+  // 读回自增 id，供用例导航。
+  delegateTaskId = Number(
+    execSync(
+      `sqlite3 "${DEV_DB}" "SELECT id FROM tasks WHERE title='${FIXTURE_TITLE}' ORDER BY id DESC LIMIT 1;"`,
+    )
+      .toString()
+      .trim(),
+  );
+
+  // 动态发现一条工艺环路任务（loop 且 loop_id 非空）；找不到则 loopTaskId 留 0，用例内 skip。
+  const loopOut = execSync(
+    `sqlite3 "${DEV_DB}" "SELECT id FROM tasks WHERE execution_mode='loop' AND loop_id IS NOT NULL ORDER BY id LIMIT 1;"`,
+  )
+    .toString()
+    .trim();
+  loopTaskId = loopOut ? Number(loopOut) : 0;
+});
+
+test.afterAll(() => {
+  // 仅清理本 spec 插入的 fixture（按标题精确匹配），其余数据原样保留。
+  execSync(`sqlite3 "${DEV_DB}" "DELETE FROM tasks WHERE title='${FIXTURE_TITLE}';"`);
+});
+
+// 等待任务详情 Tab 栏渲染完成，返回各 Tab 的可见文本。逐个 innerText 收集，避免 Badge/图标节点干扰。
 async function getTabTexts(page: Page): Promise<string[]> {
   await page.waitForSelector('.ant-tabs-tab', { timeout: 15000 });
   const tabs = page.locator('.ant-tabs-tab');
@@ -32,7 +69,7 @@ async function getTabTexts(page: Page): Promise<string[]> {
 }
 
 test('委派任务详情：只展示概览与讨论，无环路相关 Tab', async ({ page }) => {
-  await page.goto(`${BASE}/#/tasks/${DELEGATE_TASK_ID}`);
+  await page.goto(`${BASE}/#/tasks/${delegateTaskId}`);
   const texts = await getTabTexts(page);
 
   // 委派任务应恰好 2 个 Tab：概览、讨论。
@@ -45,11 +82,17 @@ test('委派任务详情：只展示概览与讨论，无环路相关 Tab', asyn
   expect(texts.some((t) => t.includes('执行历史'))).toBe(false);
 });
 
-test('工艺环路任务详情：仍展示执行环路/执行历史 Tab', async ({ page }) => {
-  await page.goto(`${BASE}/#/tasks/${LOOP_TASK_ID}`);
+test('工艺环路任务详情：仍展示全部 4 个 Tab', async ({ page }) => {
+  // dev 库无 loop 任务时跳过：loop 任务需工艺 install 产生，本 spec 不便造数。
+  test.skip(!loopTaskId, 'dev 库无工艺环路任务，跳过该用例');
+  await page.goto(`${BASE}/#/tasks/${loopTaskId}`);
   const texts = await getTabTexts(page);
 
-  // 环路任务应保留环路相关 Tab（label 形如「执行环路 (N)」「执行历史」）。
+  // 设计 §4 测试计划：断言 4 个 Tab 齐全（概览/执行环路/执行历史/讨论）。
+  expect(texts.length).toBe(4);
+  const joined = texts.join('|');
+  expect(joined).toContain('概览');
+  expect(joined).toContain('讨论');
   expect(texts.some((t) => t.includes('执行环路'))).toBe(true);
   expect(texts.some((t) => t.includes('执行历史'))).toBe(true);
 });
@@ -57,7 +100,7 @@ test('工艺环路任务详情：仍展示执行环路/执行历史 Tab', async 
 test('委派任务 URL 残留 ?tab=dag：回退默认 Tab，内容区不空白', async ({ page }) => {
   // resolvedTab 会把 ?tab=dag 解析为 'dag'（TAB_KEYS 白名单含该项），但委派任务已隐藏该 Tab。
   // 若无 activeKey 兜底，Tabs 会落到无选中态、内容区空白；此处验证兜底回退到「讨论」。
-  await page.goto(`${BASE}/#/tasks/${DELEGATE_TASK_ID}?tab=dag`);
+  await page.goto(`${BASE}/#/tasks/${delegateTaskId}?tab=dag`);
   await page.waitForSelector('.ant-tabs-tab', { timeout: 15000 });
 
   // 激活的 Tab 应回退为「讨论」（委派任务默认 Tab）。

--- a/frontend/tests/093-task-detail-loop-tabs-by-mode.spec.ts
+++ b/frontend/tests/093-task-detail-loop-tabs-by-mode.spec.ts
@@ -2,7 +2,7 @@
 // 验证点：
 // 1. 委派任务（execution_mode=delegate）详情只展示「概览」「讨论」两 Tab，无「执行环路」「执行历史」；
 // 2. 工艺环路任务（execution_mode=loop）详情仍展示全部 4 个 Tab（设计 §4「4 个 Tab 齐全」）；
-// 3. 委派任务 URL 残留 ?tab=dag 时，不出现内容区空白——自动回退到默认 Tab（讨论）。
+// 3. 委派任务 URL 残留 ?tab=dag 或 ?tab=exec 时，都不出现内容区空白——自动回退到默认 Tab（讨论）。
 //
 // 运行前提：make dev 已起（18088）。
 // 数据独立（前端规范 11-测试规范 §4「测试必须独立可运行，不依赖外部状态」）：
@@ -18,25 +18,23 @@ const BASE = 'http://localhost:18088';
 const DEV_DB = path.join(process.env.HOME ?? '', '.ntd', 'data.dev.db');
 // 委派 fixture 所属工作空间：与 dev 库现有 loop 任务一致，便于在同一 ws 内校验。
 const WS_ID = 3;
-// 唯一标记：afterAll 按此前缀精确清理本 spec 插入的行，绝不动到既有数据。
-const FIXTURE_TITLE = '093-pw-fixture-delegate';
+// 每次运行唯一的 fixture 标记：CI 多 worker / 多次跑时，不同 run 不会共享或误删彼此的记录。
+const FIXTURE_TITLE = `093-pw-fixture-delegate-${process.pid}-${Date.now()}`;
 
 let delegateTaskId = 0;
 let loopTaskId = 0;
 
 test.beforeAll(() => {
   // 插入委派任务 fixture：execution_mode=delegate，loop_id 默认 NULL → 不应出现环路相关 Tab。
-  execSync(
-    `sqlite3 "${DEV_DB}" "INSERT INTO tasks ` +
-      `(title, description, status, workspace_id, execution_mode, assignee_kind, assignee_name, ` +
-      `auto_continue, continue_rounds, created_at, updated_at) ` +
-      `VALUES ('${FIXTURE_TITLE}', 'Playwright 验证委派任务', 'pending', ${WS_ID}, ` +
-      `'delegate', 'executor', 'codex', 0, 0, datetime('now'), datetime('now'));"`,
-  );
-  // 读回自增 id，供用例导航。
+  // 同一 sqlite3 连接内用 last_insert_rowid() 取回本 run 刚插入行的 id，避免按标题反查在并发 run 间错拿。
   delegateTaskId = Number(
     execSync(
-      `sqlite3 "${DEV_DB}" "SELECT id FROM tasks WHERE title='${FIXTURE_TITLE}' ORDER BY id DESC LIMIT 1;"`,
+      `sqlite3 "${DEV_DB}" "INSERT INTO tasks ` +
+        `(title, description, status, workspace_id, execution_mode, assignee_kind, assignee_name, ` +
+        `auto_continue, continue_rounds, created_at, updated_at) ` +
+        `VALUES ('${FIXTURE_TITLE}', 'Playwright 验证委派任务', 'pending', ${WS_ID}, ` +
+        `'delegate', 'executor', 'codex', 0, 0, datetime('now'), datetime('now')); ` +
+        `SELECT last_insert_rowid();"`,
     )
       .toString()
       .trim(),
@@ -52,8 +50,10 @@ test.beforeAll(() => {
 });
 
 test.afterAll(() => {
-  // 仅清理本 spec 插入的 fixture（按标题精确匹配），其余数据原样保留。
-  execSync(`sqlite3 "${DEV_DB}" "DELETE FROM tasks WHERE title='${FIXTURE_TITLE}';"`);
+  // 仅删除本 run 创建的那一行（按 id），绝不按标题批量删，避免误伤并发 run 的 fixture。
+  if (delegateTaskId) {
+    execSync(`sqlite3 "${DEV_DB}" "DELETE FROM tasks WHERE id=${delegateTaskId};"`);
+  }
 });
 
 // 等待任务详情 Tab 栏渲染完成，返回各 Tab 的可见文本。逐个 innerText 收集，避免 Badge/图标节点干扰。
@@ -97,18 +97,22 @@ test('工艺环路任务详情：仍展示全部 4 个 Tab', async ({ page }) =>
   expect(texts.some((t) => t.includes('执行历史'))).toBe(true);
 });
 
-test('委派任务 URL 残留 ?tab=dag：回退默认 Tab，内容区不空白', async ({ page }) => {
-  // resolvedTab 会把 ?tab=dag 解析为 'dag'（TAB_KEYS 白名单含该项），但委派任务已隐藏该 Tab。
-  // 若无 activeKey 兜底，Tabs 会落到无选中态、内容区空白；此处验证兜底回退到「讨论」。
-  await page.goto(`${BASE}/#/tasks/${delegateTaskId}?tab=dag`);
-  await page.waitForSelector('.ant-tabs-tab', { timeout: 15000 });
+// 委派任务已隐藏 dag/exec 两 Tab，URL 残留其中任一都应回退默认 Tab、不出现空白。
+// 两 Tab 走同一套兜底逻辑，这里各跑一次以覆盖「只误放行其中一个」的回归。
+for (const hiddenTab of ['dag', 'exec'] as const) {
+  test(`委派任务 URL 残留 ?tab=${hiddenTab}：回退默认 Tab，内容区不空白`, async ({ page }) => {
+    // resolvedTab 会把 ?tab=<hiddenTab> 解析成对应 key（TAB_KEYS 白名单含 dag/exec），但委派任务已隐藏该 Tab。
+    // 若无 activeKey 兜底，Tabs 会落到无选中态、内容区空白；此处验证兜底回退到「讨论」。
+    await page.goto(`${BASE}/#/tasks/${delegateTaskId}?tab=${hiddenTab}`);
+    await page.waitForSelector('.ant-tabs-tab', { timeout: 15000 });
 
-  // 激活的 Tab 应回退为「讨论」（委派任务默认 Tab）。
-  const activeTab = page.locator('.ant-tabs-tab-active');
-  await expect(activeTab).toBeVisible();
-  const activeText = (await activeTab.innerText()) ?? '';
-  expect(activeText).toContain('讨论');
+    // 激活的 Tab 应回退为「讨论」（委派任务默认 Tab）。
+    const activeTab = page.locator('.ant-tabs-tab-active');
+    await expect(activeTab).toBeVisible();
+    const activeText = (await activeTab.innerText()) ?? '';
+    expect(activeText).toContain('讨论');
 
-  // 内容区不空白：讨论 Tab forceRender 挂载，发送按钮可见（DiscussionComposer 已渲染）。
-  await expect(page.getByRole('button', { name: '发送' })).toBeVisible({ timeout: 10000 });
-});
+    // 内容区不空白：讨论 Tab forceRender 挂载，发送按钮可见（DiscussionComposer 已渲染）。
+    await expect(page.getByRole('button', { name: '发送' })).toBeVisible({ timeout: 10000 });
+  });
+}


### PR DESCRIPTION
## 背景

任务详情面板此前对所有任务都展示固定 4 个 Tab：概览 / 执行环路 / 执行历史 / 讨论。其中「执行环路」「执行历史」强依赖任务绑定的环路——委派任务（创建时选「委派」而非「工艺环路」）没有环路，这两个 Tab 只能渲染成空状态（「暂无关联环路」「暂无执行环路」），对用户无意义且易误导。

> 用户原话：「执行历史、执行环路，只有在创建任务的时候选用了『工艺环路』的时候才有意义，不需要显示的时候就别显示了。」

## 改动

按 `execution_mode` 条件组装 Tab（单文件 `TaskDetailPanel.tsx`）：

- **委派任务**只展示「概览」「讨论」两个 Tab，「执行环路」「执行历史」不再出现。
- **工艺环路任务**仍保留全部 4 个 Tab。
- 判断口径 `task.execution_mode === 'delegate'`，与 Header 处理人、隐藏「再次执行」、默认 Tab 落「讨论」等既有委派分支一致。
- 新增 `activeKey` 兜底：URL 残留 `?tab=dag/exec` 指向已隐藏 Tab 时，回退默认 Tab，避免 Ant Design Tabs 无选中态导致内容区空白。
- 不动 `DAGTab`/`ExecHistoryTab` 内部空态分支，保留作异常态防御。

## 与需求对应

| 需求 | 实现 | 验证 |
|------|------|------|
| 委派任务不展示环路相关 Tab | `tabItems` 按 `execution_mode` 条件组装 | Playwright 093-1 |
| 环路任务仍展示环路相关 Tab | 环路任务照常纳入两 Tab | Playwright 093-2 |
| `?tab=dag/exec` 不空白 | `activeTabKey` 校验可见 key 集合，回退默认 | Playwright 093-3 |

## 验证

- `npx tsc --noEmit`：零错误
- `npm run build`：成功（chunk 体积告警为 monaco/antd 既有，非本次引入）
- Playwright `tests/093-*.spec.ts`：**3/3 通过**；回归 `tests/060-*.spec.ts`：**1/1 通过**
- vitest `src/components/tasks/`：**47/47 通过**

## 文档

- 设计：`docs/design/093-任务详情环路Tab按执行方式显隐-设计.md`
- 总结：`docs/requirements/093-任务详情环路Tab按执行方式显隐-实现总结.md`
