### PR TITLE
perf(093): 首屏 bundle 瘦身——preload 7.2MB→2.3MB（-68%）

### DIFF
--- a/docs/design/093-首屏bundle瘦身-设计.md
+++ b/docs/design/093-首屏bundle瘦身-设计.md
@@ -1,0 +1,122 @@
+# 093-首屏bundle瘦身-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+| AI (Pi) | 2026-08-08 | 实施修订：补录构建期实测发现的三个隐藏依赖边（§1.3），manualChunks 最终函数式方案以 §2-C1 修订版为准 |
+
+> 本专项源自 093 全量优化扫描（架构 + 性能），无独立需求文档。与 091 的关系：091 完成了页面级 React.lazy 与 manualChunks 拆分，但构建产物证据表明拆分未生效于首屏——本专项修复「拆而仍载」的根因。
+
+## 1. 背景与问题（构建产物实测证据）
+
+`frontend/dist/index.html` 的 modulepreload 列表（Vite 只为**入口 chunk 的静态依赖**注入 preload）：
+
+```html
+<script type="module" src="/assets/index-*.js"></script>          <!-- 862 KB -->
+<link rel="modulepreload" href="/assets/vendor-antd-*.js">       <!-- 1.40 MB -->
+<link rel="modulepreload" href="/assets/vendor-monaco-*.js">     <!-- 3.28 MB ❌ -->
+<link rel="modulepreload" href="/assets/vendor-md-editor-*.js">  <!-- 1.18 MB ❌ -->
+<link rel="modulepreload" href="/assets/vendor-flow-*.js">       <!-- 270 KB ❌ -->
+<link rel="modulepreload" href="/assets/vendor-misc-*.js">
+<link rel="modulepreload" href="/assets/vendor-icons-*.js">
+<link rel="modulepreload" href="/assets/vendor-antd-icons-*.js">
+```
+
+首屏被迫并行下载 ~7.2MB JS（gzip 前），其中 monaco / md-editor / flow 共 ~4.7MB 本应按需加载。两条独立根因：
+
+### 1.1 根因 A：manualChunks 对象写法导致 helper 提升
+
+入口 chunk 产物中存在 `import{_ as we}from"./vendor-monaco-*.js"` —— Rollup 对象式 `manualChunks` 会把被列出模块的关联模块/共享 helper 合并进对应 vendor chunk，入口为了拿一个 helper 被迫静态依赖整个 monaco chunk（3.3MB）。vendor-flow 同理（扫描确认入口无任何静态 import 链指向 `@xyflow/react`/`monaco-editor`/`@monaco-editor/react`）。
+
+### 1.2 根因 B：真实的静态导入链（扫描确认）
+
+以下链路把 markdown 渲染/编辑库锚定进首屏静态图：
+
+| 依赖 | 静态链（main.tsx 起可达） |
+|------|--------------------------|
+| `@ant-design/x-markdown` | `App.tsx` → `TodoDetailPage` → `TodoDetailActions` → `ActionButton` → `ChatView`（`import XMarkdown`，ChatView.tsx:13） |
+| `@ant-design/x-markdown` | `App.tsx` → `HelpPage`（App.tsx:45 静态 import）→ `HelpContentRenderer`（:8） |
+| `@ant-design/x-markdown` | `App.tsx` → `WikiChatFloatingWindow`（App.tsx:44 静态）→ `ChatMessageItem`（:9） |
+| `@ant-design/x-markdown` | `App.tsx` → `TodoDetailPage` → `TodoDetail` → `todo-detail/PromptDisplay`（:2）/ `CollapsibleConclusion`（:22） |
+| `@uiw/react-md-editor` | `App.tsx` → `TodoDrawer`（App.tsx:38 静态）→ `todo-drawer/PromptEditor` → `MdEditor.tsx:2` |
+
+`BlackboardPage` / `WikiViewPage` 本身已是 lazy 页面，其 XMarkdown 引用不构成首屏链，但为彻底切断「未来谁静态引一下就回潮」的可能，一并改造。
+
+### 1.3 实施期补录：三个扫描未覆盖的隐藏依赖边（构建产物实测）
+
+1. **`vite/preload-helper` 提升**：函数式 manualChunks 下，Vite 注入的 `__vitePreload` helper（id 为 `\0vite/preload-helper.js`）被 Rollup 并入 vendor-monaco chunk，入口 `import{_ as xe}from"./vendor-monaco-*.js"` 只为引这 1KB helper。→ 显式归入 `vendor-runtime`（1.1KB）。
+2. **merslim → dagre 静态链**：`App.tsx` → `HelpPage`（静态）→ `HelpContentRenderer` → `MermaidDiagram` → `merslim`（外部依赖 dagre）→ vendor-flow 被 preload。此前扫描漏判原因：merslim 的布局代码（`rankSeparation` 等）在 node_modules 内，不在 src 扫描面。→ `HelpContentRenderer` 中 MermaidDiagram 改 React.lazy（仅 mermaid 围栏代码块使用时加载）。
+3. **React 与 antd 生态的 chunk 循环依赖**：函数式归类若把 react 留给自然分包，会被并入 vendor-antd；react-icons 顶层执行 `React.createContext` → `undefined.createContext` 白屏。同理 antd ⇄ @ant-design/icons 拆成两个 chunk 会形成 `Cannot access 'Yt' before initialization` 的 TDZ 循环。→ react/react-dom/scheduler/react-is 锚定 `vendor-react`；antd 全家桶（含 icons/cssinjs/rc-*/@rc-component）**必须同一 chunk**。
+
+## 2. 设计（三个正交改动，可分 commit）
+
+### C1：`vite.config.ts` manualChunks 改函数式
+
+对象式 `manualChunks: { 'vendor-monaco': ['monaco-editor'] }` 在 Rollup 4 已弃用（构建时有 deprecation warning），且是 helper 提升的来源。改为函数式，只按模块路径精确归类，**不吞并依赖**：
+
+```ts
+manualChunks(id) {
+  if (id.includes('vite/preload-helper')) return 'vendor-runtime';       // §1.3-1
+  if (!id.includes('node_modules')) return undefined;                    // 项目源码交给 Rollup 按 lazy 边界自然分包
+  if (/\/node_modules\/(react|react-dom|scheduler|react-is)\//.test(id)) return 'vendor-react'; // §1.3-3 防循环依赖
+  if (id.includes('/monaco-editor/')) return 'vendor-monaco';
+  if (id.includes('/@xyflow/') || id.includes('/dagre/')) return 'vendor-flow';
+  if (id.includes('/@ant-design/x-markdown/')) return 'vendor-md-editor'; // 必须先于 antd 广义匹配
+  if (id.includes('/@uiw/react-md-editor/') || id.includes('/@uiw/react-markdown-preview/')) return 'vendor-md-editor';
+  // antd 全家桶（含 @ant-design/icons）同一 chunk，拆分必成 TDZ 循环（§1.3-3）
+  if (id.includes('/antd/') || id.includes('/@ant-design/') || id.includes('/rc-') || id.includes('/@rc-component/')) return 'vendor-antd';
+  if (id.includes('/react-icons/')) return 'vendor-icons';
+  if (id.includes('/qrcode/') || id.includes('/react-countup/') || id.includes('/react-js-cron/')) return 'vendor-misc';
+  return undefined;
+}
+```
+
+- 匹配顺序即优先级：`x-markdown` 必须先于 `/antd/` 广义匹配；`react` 按目录边界精确匹配，不误伤 `react-icons` 等同缀包。
+- `vendor-monaco` 仍保留命名 chunk：monaco 通过 `ProcessYamlEditor` 的动态 `import('monaco-editor')` 加载（091 已改），函数式归类后入口不再静态依赖它。
+- 不引入 `onlyExplicitManualChunks` 显式开关：函数式写法下 Rollup 默认不合并依赖；保持配置面最小。
+
+### C2：新增 `LazyXMarkdown` 共享懒加载包装组件
+
+新建 `frontend/src/components/common/LazyXMarkdown.tsx`：
+
+- `const XMarkdown = lazy(() => import('@ant-design/x-markdown'))` —— 包的 default 导出与命名导出 `XMarkdown` 是同一组件（见包 `es/index.d.ts`：`export { default, default as XMarkdown }`），因此 default / 命名两种引用方式的调用方都能无缝替换。
+- props 直接透传：`React.ComponentProps<typeof XMarkdown>`，调用方零类型改动。
+- `Suspense` fallback：以 `whiteSpace: pre-wrap` 的纯文本展示原始 markdown —— 本地 embedded 场景 chunk 加载为毫秒级，fallback 只是一瞬；纯文本兜底也保证 loading 期间内容可读。
+- 替换全部 7 处静态引用：`ChatView.tsx`、`todo-detail/PromptDisplay.tsx`、`todo-detail/CollapsibleConclusion.tsx`、`wiki-chat/ChatMessageItem.tsx`、`help/HelpContentRenderer.tsx`、`BlackboardPage.tsx`、`WikiViewPage.tsx`。
+- `HelpContentRenderer.tsx:9` 的 `import type { ComponentProps } ...` 是类型导入，构建期擦除，不产生运行时边，保留。
+
+### C2.5（实施新增）：`HelpContentRenderer` 的 MermaidDiagram 懒加载
+
+对应 §1.3-2：`MermaidDiagram` → merslim → dagre 是把 vendor-flow 错进首屏的静态链。改为 `lazy(() => import('./MermaidDiagram'))` + Suspense（fallback 为 mermaid 源码 `<pre>`）。仅帮助内容含 ```mermaid 围栏时才加载 ~87KB chunk。
+
+### C3：`MdEditor.tsx` 内部懒加载 `@uiw/react-md-editor`
+
+- `MdEditor.tsx` 本身就是项目内统一封装层（3 个调用方：`PromptEditor`、`DiscussionComposer`、`PromptMdField`），在封装层内部把 `MDEditor` 改为 `lazy(() => import('@uiw/react-md-editor'))` + `Suspense`，3 个调用方零改动。
+- `editorRef` 透传：React 19 下函数组件 ref 走 prop，lazy 不破坏 ref 转发。
+- fallback：antd `Spin` 居中的占位容器，高度沿用 `height` prop，避免抽屉打开瞬间布局跳动。
+
+## 3. 影响模块
+
+| 层 | 文件 |
+|----|------|
+| 构建 | `frontend/vite.config.ts` |
+| 新增 | `frontend/src/components/common/LazyXMarkdown.tsx`（含单测） |
+| 修改 | `MdEditor.tsx`、`ChatView.tsx`、`todo-detail/PromptDisplay.tsx`、`todo-detail/CollapsibleConclusion.tsx`、`wiki-chat/ChatMessageItem.tsx`、`help/HelpContentRenderer.tsx`、`BlackboardPage.tsx`、`WikiViewPage.tsx` |
+
+## 4. 不做的事（YAGNI 边界）
+
+- 不拆 `react`/`react-dom` vendor chunk（沿用 091 决策，它们在入口）。
+- 不动 `BlackboardPage` 等 lazy 页面的内部结构，仅替换 XMarkdown 引用方式。
+- 不引入 preact/htm 等替代渲染库 —— 问题是加载时机，不是库的体积。
+
+## 5. 验证方案
+
+1. `cd frontend && npx tsc --noEmit` 零错误。
+2. `npm run build` 后检查 `dist/index.html`：
+   - modulepreload **不得**包含 `vendor-monaco` / `vendor-md-editor` / `vendor-flow`；
+   - 入口 chunk 无 `from"./vendor-monaco-*.js"` 静态 import；
+   - 记录首屏 preload 总体积（目标：< 3MB，gzip 前）。
+3. 新增单测 `LazyXMarkdown.test.tsx`（vitest + testing-library）：验证 fallback 纯文本 → 异步加载后渲染 markdown 内容。
+4. `npx vitest run` 既有测试全绿。
+5. Playwright（`make dev` 起 18088 后）：首页正常渲染；Todo 详情页结论区 markdown 渲染正常；打开 TodoDrawer 编辑器可用；帮助页渲染正常。spec 放 `frontend/tests/`。
+6. 回归确认：工艺页（ProcessPage）Monaco YAML 编辑器首次打开仍可加载（动态 chunk 未被误删）。

--- a/docs/requirements/093-首屏bundle瘦身-实现总结.md
+++ b/docs/requirements/093-首屏bundle瘦身-实现总结.md
@@ -1,0 +1,62 @@
+# 093-首屏bundle瘦身-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+
+> 对应设计：`docs/design/093-首屏bundle瘦身-设计.md`。本专项源自全量优化扫描（架构+性能），无独立需求文档。
+
+## 1. 实现了什么
+
+修复 091 懒加载拆分「拆而仍载」的遗留根因，首屏 JS preload 从 **~7.2MB 降到 2.31MB（-68%）**：
+
+| 指标 | 优化前 | 优化后 |
+|------|--------|--------|
+| 首屏 preload 总量（min 前） | ~7.2 MB | **2.31 MB** |
+| 其中 monaco | 3.28 MB（首屏 preload） | 0（工艺页按需） |
+| 其中 md-editor 系 | 1.18 MB（首屏 preload） | 0（编辑/渲染时按需） |
+| 其中 flow（xyflow+dagre） | 270 KB（首屏 preload） | 0（工艺/loop 页按需） |
+| 入口 index chunk | 862 KB | 769 KB（merslim 迁出） |
+
+优化后首屏 preload 清单（全部为首屏合法依赖）：`index 769KB + vendor-antd 1282KB + vendor-react 195KB + vendor-misc 60KB + vendor-icons 3KB + vendor-runtime 1.1KB`。
+
+## 2. 与设计的对应关系
+
+| 设计项 | 落地内容 | 状态 |
+|--------|---------|------|
+| C1 manualChunks 函数式 | `vite.config.ts` 改函数式；新增 `vendor-runtime`（preload-helper 锚定）与 `vendor-react`（防 TDZ 循环）；antd 全家桶合并单 chunk | ✅ |
+| C2 LazyXMarkdown | 新增 `components/common/LazyXMarkdown.tsx` + 单测 4 例；替换全部 7 处静态引用 | ✅ |
+| C2.5 MermaidDiagram 懒加载（实施新增） | `HelpContentRenderer.tsx` 改 lazy + Suspense（merslim→dagre 是 vendor-flow 首屏锚定的真实来源） | ✅ |
+| C3 MdEditor 懒加载 | `components/MdEditor.tsx` 封装层内部 lazy，3 个调用方零改动；`PromptMdField.test.tsx` 3 例改 waitFor 适配异步就绪 | ✅ |
+
+## 3. 关键实现点
+
+- **三个隐藏依赖边**（扫描不可见、构建产物实测才暴露，已补录设计文档 §1.3）：
+  1. `vite/preload-helper` 被 Rollup 并入 3.8MB vendor-monaco → 显式归入 1.1KB `vendor-runtime`；
+  2. `merslim`（帮助页 mermaid 渲染库）外部依赖 dagre → MermaidDiagram 懒加载；
+  3. react 自然分包并入 vendor-antd 后，react-icons 顶层 `React.createContext` 白屏；antd⇄icons 拆分会 TDZ → react 锚定 `vendor-react`，antd 全家桶单 chunk。
+- **LazyXMarkdown 契约**：x-markdown 的 default 与命名导出是同一组件（包 `es/index.d.ts` 实证），故 7 处两种引用形态统一替换；fallback 用 `pre-wrap` 纯文本保证加载一瞬内容可读。
+- **MdEditor ref 透传**：React 19 函数组件 ref 走 prop，lazy 不破坏 `editorRef` 转发链（PromptMdField 光标插入功能依赖）。
+
+## 4. 测试与验证结果
+
+- `npx tsc --noEmit`：零错误 ✅
+- `npx vitest run`：33 文件 / 281 用例全绿（含新增 LazyXMarkdown 4 例、适配改造的 PromptMdField 3 例）✅
+- `npm run build`：通过；`dist/index.html` preload 列表无 vendor-monaco / vendor-md-editor / vendor-flow；入口 chunk 无指向它们的静态 import ✅
+- Playwright（`frontend/tests/093-first-screen-bundle.spec.ts`，对 18088 dev 实例）3 项全过 ✅：
+  1. HTML preload 清单断言（无重型 chunk、antd 仍在防误伤）；
+  2. 首屏渲染 + 首批网络请求无重型 chunk；
+  3. 帮助抽屉（LazyXMarkdown + 懒加载 MermaidDiagram 叠加路径）markdown 正常渲染。
+
+## 5. 已知限制 / 待改进
+
+- `vendor-antd` 仍 1.28MB（gzip 391KB）：antd 全量引入是历史形态，按组件按需引入需评估 antd v6 的 ESM tree-shaking 实际收益，留待后续专项。
+- 入口 index chunk 769KB 主要是业务代码（App 静态壳 + Dashboard/TodoList 等首屏页面），可再做页面级拆分，但收益递减，未做。
+- monaco chunk 3.83MB 仍在产物中但仅工艺 YAML 编辑器打开时加载；`chunkSizeWarningLimit: 500` 的构建告警因此仍在，属预期（告警阈值未调，保留提醒价值）。
+- 截图证据按规范发 PR 评论，不入库。
+
+## 6. 安全反思
+
+- 纯构建配置 + 组件加载方式变更，无新接口、无权限面变化、无输入处理逻辑变更。
+- XMarkdown 的 DOMPurify 配置（`BlackboardPage` 的 `ALLOWED_URI_REGEXP`）原样透传，懒加载不改变 sanitize 行为。
+- Suspense fallback 渲染的是用户已有权限查看的本地内容，无信息泄露面。

--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -27,7 +27,8 @@ import { Button, Skeleton, message, Modal, Form, InputNumber, Space, Progress, I
 import { ReloadOutlined, SettingOutlined, UnorderedListOutlined, MenuOutlined, DeleteOutlined } from '@ant-design/icons';
 import { PageCard } from '@/components/common/PageCard';
 import { TfiBlackboard } from 'react-icons/tfi';
-import { XMarkdown } from '@ant-design/x-markdown';
+// 093：本页面虽是 lazy 页面，仍统一走懒加载包装，杜绝未来被静态引用时回潮。
+import { LazyXMarkdown } from '@/components/common/LazyXMarkdown';
 import { useTheme } from '@/hooks/useTheme';
 import { useViewState } from '@/hooks/useViewState';
 import { useIsMobile } from '@/hooks/useIsMobile';
@@ -1238,7 +1239,7 @@ function BlackboardContent(props: BlackboardContentProps) {
         color: isDark ? '#e0e0e0' : '#333',
       }}
     >
-      <XMarkdown
+      <LazyXMarkdown
         // 强制纯文本：XMarkdown 默认会注入 inline style，
         // className 包一层让主题色与外层容器保持一致
         className={isDark ? 'x-markdown-dark' : 'x-markdown-light'}

--- a/frontend/src/components/ChatView.tsx
+++ b/frontend/src/components/ChatView.tsx
@@ -10,7 +10,8 @@ import {
   RightOutlined,
   MessageOutlined,
 } from '@ant-design/icons';
-import XMarkdown from '@ant-design/x-markdown';
+// 093：改走共享懒加载包装，切断「首屏静态链 → vendor-md-editor(1.18MB)」的依赖边。
+import { LazyXMarkdown } from '@/components/common/LazyXMarkdown';
 import type { LogEntry, ChatMessage } from '@/types';
 // 策略模式实现：解析日志为聊天消息
 import { parseLogsToMessages } from '@/utils/logParserStrategy';
@@ -115,7 +116,7 @@ function CollapsibleCard({
 function ThinkingBlock({ content, timestamp }: { content: string; timestamp?: string }) {
   return (
     <CollapsibleCard type="thinking" timestamp={timestamp}>
-      <XMarkdown content={content} />
+      <LazyXMarkdown content={content} />
     </CollapsibleCard>
   );
 }
@@ -174,7 +175,7 @@ function ToolBlock({
 function ResultBlock({ content, timestamp }: { content: string; timestamp?: string }) {
   return (
     <CollapsibleCard type="output" timestamp={timestamp}>
-      <XMarkdown content={content} />
+      <LazyXMarkdown content={content} />
     </CollapsibleCard>
   );
 }
@@ -216,7 +217,7 @@ function ChatBubble({ message }: { message: ChatMessage }) {
       </div>
       <div className="chat-bubble">
         <div className="chat-bubble-content">
-          <XMarkdown content={content} />
+          <LazyXMarkdown content={content} />
         </div>
         {timestamp && <div className="chat-bubble-time">{formatTimeFull(timestamp)}</div>}
       </div>

--- a/frontend/src/components/MdEditor.tsx
+++ b/frontend/src/components/MdEditor.tsx
@@ -1,5 +1,12 @@
+import { lazy, Suspense } from 'react';
+import { Spin } from 'antd';
 import { useTheme } from '@/hooks/useTheme';
-import MDEditor from '@uiw/react-md-editor';
+
+// 093：@uiw/react-md-editor（vendor-md-editor chunk 的另一半来源，gzip 前 ~600KB）
+// 原本是顶层静态 import，经 TodoDrawer → PromptEditor 静态链锚定进首屏。
+// 改为封装层内部 lazy：3 个调用方（PromptEditor / DiscussionComposer /
+// PromptMdField）零改动，编辑器 chunk 只在用户真正打开编辑界面时才下载。
+const MDEditor = lazy(() => import('@uiw/react-md-editor'));
 
 interface MdEditorProps {
   value: string;
@@ -17,15 +24,30 @@ export function MdEditor({
 }: MdEditorProps) {
   const { themeMode } = useTheme();
 
+  // 高度解析提前算好，让 Suspense fallback 占位与编辑器最终高度一致，
+  // 避免 chunk 加载完成瞬间抽屉/表单布局跳动（CLS）。
+  const resolvedMinHeight = typeof height === 'number' ? height : (height || '100%');
+
   return (
     <div data-color-mode={themeMode} style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      <MDEditor
-        value={value}
-        onChange={(val) => onChange(val || '')}
-        preview="edit"
-        style={{ flex: 1, minHeight: typeof height === 'number' ? height : (height || '100%') }}
-        ref={editorRef}
-      />
+      <Suspense
+        fallback={
+          // 编辑器是重交互组件，加载一瞬用 Spin 表达「正在就绪」比纯文本更贴切；
+          // minHeight 与最终渲染一致，占位只影响视觉不影响布局。
+          <div style={{ flex: 1, minHeight: resolvedMinHeight, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Spin />
+          </div>
+        }
+      >
+        <MDEditor
+          value={value}
+          onChange={(val) => onChange(val || '')}
+          preview="edit"
+          style={{ flex: 1, minHeight: resolvedMinHeight }}
+          // React 19 下函数组件 ref 走 prop 透传，lazy 包装不破坏 ref 转发链。
+          ref={editorRef}
+        />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/src/components/WikiViewPage.tsx
+++ b/frontend/src/components/WikiViewPage.tsx
@@ -7,7 +7,8 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { Skeleton, message } from 'antd';
-import { XMarkdown } from '@ant-design/x-markdown';
+// 093：本页面虽是 lazy 页面，仍统一走懒加载包装，杜绝未来被静态引用时回潮。
+import { LazyXMarkdown } from '@/components/common/LazyXMarkdown';
 import { useTheme } from '@/hooks/useTheme';
 import { PageCard } from '@/components/common/PageCard';
 import { useViewState } from '@/hooks/useViewState';
@@ -113,7 +114,7 @@ export function WikiViewPage() {
               color: isDark ? '#e0e0e0' : '#333',
             }}
           >
-            <XMarkdown
+            <LazyXMarkdown
               content={content}
             />
           </div>

--- a/frontend/src/components/common/LazyXMarkdown.test.tsx
+++ b/frontend/src/components/common/LazyXMarkdown.test.tsx
@@ -1,0 +1,42 @@
+// LazyXMarkdown 单元测试 —— 覆盖 093 懒加载包装的核心契约：
+// 1. Suspense 阶段展示纯文本兜底（内容可读、不闪加载圈）；
+// 2. 异步 chunk 就绪后切换为真正的 XMarkdown 渲染（markdown 转 HTML）；
+// 3. content 形态与 children 形态两种输入都能工作（替换存量 7 处调用的前提）。
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { LazyXMarkdown } from './LazyXMarkdown';
+
+describe('LazyXMarkdown', () => {
+  it('renders markdown content after async chunk loads (content prop form)', async () => {
+    render(<LazyXMarkdown content={'**加粗文本**'} />);
+    // 等异步 import 完成、真组件接管后，markdown 应被渲染为 <strong> 标签
+    await waitFor(() => {
+      expect(screen.getByText('加粗文本').tagName).toBe('STRONG');
+    });
+  });
+
+  it('renders markdown content from string children form', async () => {
+    // ChatMessageItem 等调用方使用 children 形态传文本，两种形态必须等价支持
+    render(<LazyXMarkdown>{'# 标题文本'}</LazyXMarkdown>);
+    await waitFor(() => {
+      expect(screen.getByText('标题文本')).toBeInTheDocument();
+    });
+  });
+
+  it('shows plain-text fallback before chunk resolves', () => {
+    // 不 await 任何加载，首次渲染同步快照应是纯文本兜底：
+    // 文本原样可读（含 markdown 语法符号），证明 fallback 没有把内容吞掉
+    const { container } = render(<LazyXMarkdown content={'**未加载时的原文**'} />);
+    expect(container.textContent).toContain('未加载时的原文');
+  });
+
+  it('forwards className to the underlying renderer', async () => {
+    // 透传契约：BlackboardPage 等调用方依赖 className 控制排版
+    render(<LazyXMarkdown content={'正文'} className="custom-md" />);
+    await waitFor(() => {
+      expect(screen.getByText('正文')).toBeInTheDocument();
+    });
+    expect(document.querySelector('.custom-md')).not.toBeNull();
+  });
+});

--- a/frontend/src/components/common/LazyXMarkdown.tsx
+++ b/frontend/src/components/common/LazyXMarkdown.tsx
@@ -1,0 +1,55 @@
+import { lazy, Suspense } from 'react';
+
+/**
+ * LazyXMarkdown — `@ant-design/x-markdown` 的懒加载共享包装（093）。
+ *
+ * 为什么存在：x-markdown 及其 markdown 依赖树约 600KB（gzip 前 1.18MB 的
+ * vendor-md-editor chunk 的一半来源），而首屏静态链（App.tsx → TodoDetailPage /
+ * HelpPage / WikiChatFloatingWindow → 各消费组件）把它锚定进了入口依赖图，
+ * 导致用户打开首屏就必须下载。改为 React.lazy 后，该 chunk 只在首个 markdown
+ * 内容真正渲染时才按需加载。
+ *
+ * 实现要点：
+ * - 包导出核实：x-markdown 的 `es/index.d.ts` 为
+ *   `export { default, default as XMarkdown }`，default 与命名导出是同一组件，
+ *   因此无论调用方原来写 `import XMarkdown from` 还是 `import { XMarkdown } from`，
+ *   都可直接替换为本组件，渲染行为完全一致。
+ * - props 类型用 `React.ComponentProps<typeof XMarkdown>` 从 lazy 组件反推，
+ *   与源组件 props 保持强一致（content / children / components / className 等全透传），
+ *   调用方迁移时零类型改动。
+ * - fallback 用纯文本兜底而非 Spin：markdown 正文在 chunk 加载的一瞬（本地 embedded
+ *   场景为毫秒级）以 `pre-wrap` 纯文本呈现，内容始终可读，不会出现「内容区突然变
+ *   加载圈再变回文字」的视觉跳动；fallback 高度与最终渲染接近，布局位移最小。
+ */
+
+// lazy 工厂顶格声明：模块加载只发生一次，后续渲染复用已解析的组件引用。
+const XMarkdown = lazy(() => import('@ant-design/x-markdown'));
+
+/** 与源组件完全一致的 props 类型（从 lazy 组件引用反推，避免手抄接口漂移）。 */
+type LazyXMarkdownProps = React.ComponentProps<typeof XMarkdown>;
+
+/** 从 props 中提取纯文本兜底内容：源组件支持 content 字符串与 string children 两种形态。 */
+function plainTextOf(props: LazyXMarkdownProps): string {
+  // content 是 x-markdown 的主输入形态，优先取它。
+  if (typeof props.content === 'string') return props.content;
+  // children 形态（如 `<XMarkdown>{text}</XMarkdown>`）仅兜底字符串；
+  // 富节点 children 在 fallback 阶段无法安全降级，返回空串（加载一瞬后由真组件接管）。
+  if (typeof props.children === 'string') return props.children;
+  return '';
+}
+
+export function LazyXMarkdown(props: LazyXMarkdownProps) {
+  return (
+    <Suspense
+      fallback={
+        // pre-wrap 保留 markdown 原文的换行与缩进，loading 态也可读；
+        // margin: 0 抵消浏览器对 pre 类排版的默认外边距，避免撑开父容器。
+        <div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', margin: 0 }}>
+          {plainTextOf(props)}
+        </div>
+      }
+    >
+      <XMarkdown {...props} />
+    </Suspense>
+  );
+}

--- a/frontend/src/components/process/propertyForms/PromptMdField.test.tsx
+++ b/frontend/src/components/process/propertyForms/PromptMdField.test.tsx
@@ -8,7 +8,9 @@
 // mock 掉 useTheme：MdEditor 内部只消费 themeMode，mock 后无需包 ThemeProvider，保持用例聚焦。
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+// 093：MdEditor 改为懒加载后，编辑器 DOM 不再随首次 render 同步出现，
+// 三个依赖编辑器节点的用例统一改为 waitFor 等 Suspense 就绪后再断言。
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 // mock useTheme，返回固定亮色模式，避免 ThemeProvider 依赖与 jsdom matchMedia 缺失问题
 vi.mock('@/hooks/useTheme', () => ({
@@ -21,22 +23,33 @@ import { PromptMdField, buildAppendedText } from './PromptMdField';
 const TEST_PARAMS = [{ key: '{{original_output}}', desc: '执行输出' }];
 
 describe('PromptMdField 渲染与编辑', () => {
-  it('渲染 MD 编辑器且受控值透传到内部 textarea', () => {
+  it('渲染 MD 编辑器且受控值透传到内部 textarea', async () => {
     const { container } = render(
       <PromptMdField value="初始提示词" onChange={() => {}} />,
     );
-    // .w-md-editor 是 @uiw/react-md-editor 的根容器 class，作为「已换成 MD 控件」的断言锚点
-    expect(container.querySelector('.w-md-editor')).not.toBeNull();
+    // .w-md-editor 是 @uiw/react-md-editor 的根容器 class，作为「已换成 MD 控件」的断言锚点；
+    // 093 懒加载后需等待动态 import 解析完成才会出现；
+    // jsdom 下首载 vendor chunk 实测约 1s，超出 waitFor 默认 1s 上限，显式放宽到 10s
+    await waitFor(
+      () => expect(container.querySelector('.w-md-editor')).not.toBeNull(),
+      { timeout: 10000 },
+    );
     // 受控值必须出现在内部 textarea 上，保证既有 prompt 文本原样回显
     const textarea = container.querySelector('textarea');
     expect(textarea).not.toBeNull();
     expect(textarea!.value).toBe('初始提示词');
   });
 
-  it('编辑内容时 onChange 原样透传新文本', () => {
+  it('编辑内容时 onChange 原样透传新文本', async () => {
     const onChange = vi.fn();
     const { container } = render(
       <PromptMdField value="" onChange={onChange} />,
+    );
+    // 093：懒加载下 textarea 异步就绪，先 waitFor 再取节点触发输入；
+    // 10s 超时理由同上（jsdom 首载 vendor chunk ~1s，留余量防 CI 抖动）
+    await waitFor(
+      () => expect(container.querySelector('textarea')).not.toBeNull(),
+      { timeout: 10000 },
     );
     const textarea = container.querySelector('textarea');
     // 模拟用户输入：fireEvent.change 触发 @uiw 内部 onChange → 组件 onChange
@@ -52,7 +65,7 @@ describe('PromptMdField 参数条', () => {
     expect(screen.queryByText('可用参数:')).toBeNull();
   });
 
-  it('点击参数在光标处插入而非尾部追加', () => {
+  it('点击参数在光标处插入而非尾部追加', async () => {
     const onChange = vi.fn();
     const { container } = render(
       <PromptMdField
@@ -61,8 +74,12 @@ describe('PromptMdField 参数条', () => {
         params={TEST_PARAMS}
       />,
     );
+    // 093：懒加载下 textarea 异步就绪，先 waitFor 再设置光标位置（10s 超时理由同上）
+    await waitFor(
+      () => expect(container.querySelector('textarea')).not.toBeNull(),
+      { timeout: 10000 },
+    );
     const textarea = container.querySelector('textarea');
-    expect(textarea).not.toBeNull();
     // 把光标移到 "hello " 与 "world" 之间（index 6），模拟用户在文本中间点击参数
     textarea!.selectionStart = 6;
     textarea!.selectionEnd = 6;

--- a/frontend/src/components/todo-detail/CollapsibleConclusion.tsx
+++ b/frontend/src/components/todo-detail/CollapsibleConclusion.tsx
@@ -19,7 +19,8 @@ import { useEffect, useRef, useState } from 'react';
 import { Button, message as antdMessage } from 'antd';
 import type { MessageInstance } from 'antd/es/message/interface';
 import { CaretDownOutlined, CaretUpOutlined } from '@ant-design/icons';
-import XMarkdown from '@ant-design/x-markdown';
+// 093：懒加载包装，避免 x-markdown 依赖树进入首屏静态图。
+import { LazyXMarkdown } from '@/components/common/LazyXMarkdown';
 import { CopyButton } from '@/components/CopyButton';
 
 // 折叠状态在 localStorage 中的 key 前缀；按 recordId 区分避免互相串扰
@@ -200,7 +201,7 @@ export function CollapsibleConclusion({
           className="conclusion-content"
           data-testid="conclusion-content"
         >
-          <XMarkdown content={result} />
+          <LazyXMarkdown content={result} />
         </div>
       )}
     </div>

--- a/frontend/src/components/todo-detail/PromptDisplay.tsx
+++ b/frontend/src/components/todo-detail/PromptDisplay.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import XMarkdown from '@ant-design/x-markdown';
+// 093：懒加载包装，避免 x-markdown 依赖树进入首屏静态图。
+import { LazyXMarkdown } from '@/components/common/LazyXMarkdown';
 
 /** 可展开的 Prompt 内容展示组件 */
 export function PromptDisplay({ content }: { content: string }) {
@@ -33,7 +34,7 @@ export function PromptDisplay({ content }: { content: string }) {
             overflow: 'auto',
           }}
         >
-          <XMarkdown content={content} />
+          <LazyXMarkdown content={content} />
         </div>
       )}
     </div>

--- a/frontend/src/components/wiki-chat/ChatMessageItem.tsx
+++ b/frontend/src/components/wiki-chat/ChatMessageItem.tsx
@@ -6,7 +6,9 @@
  */
 
 import { MessageOutlined } from '@ant-design/icons';
-import { XMarkdown } from '@ant-design/x-markdown';
+// 093：懒加载包装（default 与命名导出是同一组件，children 形态等价），
+// 切断 WikiChatFloatingWindow 静态链对 vendor-md-editor 的首屏锚定。
+import { LazyXMarkdown } from '@/components/common/LazyXMarkdown';
 import { LOG_TYPE_COLORS_LIGHT, LOG_TYPE_COLORS_DARK, LOG_TYPE_LABELS } from '@/constants';
 import type { LogEntry } from '@/types';
 
@@ -156,7 +158,7 @@ export function ChatMessageItem({ message, mobile = false, isDark }: ChatMessage
           wordBreak: 'break-word',
         }}
       >
-        <XMarkdown>{message.content}</XMarkdown>
+        <LazyXMarkdown>{message.content}</LazyXMarkdown>
         <div style={{ marginTop: 8, fontSize: mobile ? 12 : 11, color: colors.hintColor, display: 'flex', justifyContent: 'space-between' }}>
           <span>{message.success ? '✅ 执行成功' : '❌ 执行失败'}</span>
           {message.durationSecs != null && <span>用时 {message.durationSecs.toFixed(1)}s</span>}

--- a/frontend/src/help/HelpContentRenderer.tsx
+++ b/frontend/src/help/HelpContentRenderer.tsx
@@ -5,9 +5,17 @@
 // 2. XMarkdown 的 components prop 按 HTML tagName 映射，code 组件接收 lang/block props。
 // 3. 拦截 ```mermaid 代码块，交给 MermaidDiagram 渲染；其他代码块走默认渲染。
 
-import XMarkdown from '@ant-design/x-markdown';
+// 093：运行时组件改懒加载包装（HelpPage 被 App.tsx 静态引用，是首屏链之一）；
+// 下方 type 导入在构建期擦除，不产生运行时依赖边，可保留。
+import { lazy, Suspense } from 'react';
+import { LazyXMarkdown } from '@/components/common/LazyXMarkdown';
 import type { ComponentProps } from '@ant-design/x-markdown/lib/XMarkdown/interface';
-import { MermaidDiagram } from './MermaidDiagram';
+
+// 093：MermaidDiagram 依赖 merslim → dagre（~270KB vendor-flow chunk 的首屏锚定来源）。
+// mermaid 图只在帮助内容含 ```mermaid 围栏时才需要，懒加载后帮助页首屏不再背负布局库。
+const MermaidDiagram = lazy(() =>
+  import('./MermaidDiagram').then((m) => ({ default: m.MermaidDiagram })),
+);
 
 interface HelpContentRendererProps {
   /** md 源码。 */
@@ -33,14 +41,20 @@ export function HelpContentRenderer({ source }: HelpContentRendererProps) {
         ? children.join('')
         : String(children ?? '');
     if (lang === 'mermaid') {
-      return <MermaidDiagram chart={text} />;
+      // Suspense 兜底用原始 mermaid 源码的 <pre>：本地 embedded 场景 chunk 加载仅毫秒级，
+      // 纯文本兜底保证加载一瞬内容可读，且与图表容器高度接近、布局不跳动。
+      return (
+        <Suspense fallback={<pre>{text}</pre>}>
+          <MermaidDiagram chart={text} />
+        </Suspense>
+      );
     }
     // 非 mermaid 代码块：用原生 <code> 渲染，保留 lang 用于语法高亮
     return <code className={props.className}>{children}</code>;
   }
 
   return (
-    <XMarkdown
+    <LazyXMarkdown
       content={source}
       components={{ code: CodeRenderer }}
     />

--- a/frontend/tests/093-first-screen-bundle.spec.ts
+++ b/frontend/tests/093-first-screen-bundle.spec.ts
@@ -1,0 +1,53 @@
+// 093 首屏 bundle 瘦身验证（docs/design/093-首屏bundle瘦身-设计.md §5）。
+//
+// 验证点：
+// 1. 首页 HTML 的 modulepreload 不再包含 vendor-monaco / vendor-md-editor / vendor-flow；
+// 2. 首屏可正常渲染（React 应用挂载成功）；
+// 3. 含 markdown 的区域（LazyXMarkdown）异步加载后真正渲染出 HTML；
+// 4. 帮助页（懒加载 MermaidDiagram + LazyXMarkdown 叠加路径）渲染正常。
+//
+// 依赖：make dev 已起 18088（embedded 模式直接服务 dist 产物，与生产同路径）。
+
+import { test, expect } from '@playwright/test';
+
+const BASE = 'http://localhost:18088';
+
+test('093: 首屏 HTML 不再 preload monaco/md-editor/flow 三个重型 chunk', async ({ request }) => {
+  // 直接取 HTML 文本断言 preload 列表——这是本专项的核心验收，比页面行为更直接
+  const html = await (await request.get(`${BASE}/`)).text();
+  expect(html).not.toMatch(/modulepreload[^>]*vendor-monaco/);
+  expect(html).not.toMatch(/modulepreload[^>]*vendor-md-editor/);
+  expect(html).not.toMatch(/modulepreload[^>]*vendor-flow/);
+  // 但 antd 等首屏必需 chunk 必须仍在，防止「一刀切全不 preload」的误伤
+  expect(html).toMatch(/modulepreload[^>]*vendor-antd/);
+});
+
+test('093: 首屏正常渲染，monaco/md-editor/flow chunk 不在首批网络请求中', async ({ page }) => {
+  const firstScreenRequests: string[] = [];
+  page.on('request', (req) => firstScreenRequests.push(req.url()));
+
+  await page.goto(BASE);
+  // React 根节点挂出内容即视为首屏成功
+  await expect(page.locator('#root')).not.toBeEmpty({ timeout: 15000 });
+
+  // 首屏阶段（goto 完成即断言）不应触发重型 chunk 下载；
+  // 注意不能等太久——用户后续操作（如打开抽屉）触发加载是合法行为
+  const heavy = firstScreenRequests.filter((u) =>
+    /vendor-monaco|vendor-md-editor|vendor-flow/.test(u),
+  );
+  expect(heavy).toEqual([]);
+});
+
+test('093: 帮助页 markdown 经懒加载后正常渲染', async ({ page }) => {
+  await page.goto(BASE);
+  await expect(page.locator('#root')).not.toBeEmpty({ timeout: 15000 });
+
+  // 帮助页不是 hash 路由，而是 LeftRail 的「帮助」按钮触发的抽屉（App.tsx: HelpPage 组件）；
+  // 通过 data-testid 点击进入，这是 093 懒加载改造的重点回归路径（LazyXMarkdown + 懒加载 MermaidDiagram 叠加）
+  await page.getByTestId('left-rail-help').first().click();
+  // antd Drawer/Modal 内容 portal 到 body 而非 #root 内，选择器不能带 #root 前缀。
+  // LazyXMarkdown 异步 chunk 就绪后，帮助正文应渲染出真实 HTML（而非停留在纯文本兜底）
+  await expect(
+    page.locator('.ant-modal h1, .ant-modal h2, .ant-modal p, .ant-drawer h1, .ant-drawer h2, .ant-drawer p').first(),
+  ).toBeVisible({ timeout: 15000 });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,22 +15,47 @@ export default defineConfig({
     chunkSizeWarningLimit: 500,
     rollupOptions: {
       output: {
-        manualChunks: {
-          // react / react-dom 不单独拆：Vite 默认把它们打入主 chunk，
-          // 这里留 manualChunks 占位会产生 0 KB 的空 vendor-react 文件。
-          // 真正需要拆分的是 antd / 图标 / markdown 编辑器这种大型第三方库。
-          'vendor-antd': ['antd'],
-          'vendor-antd-icons': ['@ant-design/icons'],
-          'vendor-md-editor': ['@uiw/react-md-editor', '@ant-design/x-markdown'],
-
-          'vendor-icons': ['react-icons'],
-          'vendor-misc': ['qrcode', 'react-countup', 'react-js-cron'],
-          // 091：monaco-editor 体量巨大（核心 + 各语言子包），且仅工艺 YAML 编辑器使用。
-          // ProcessYamlEditor 已改为动态 import('monaco-editor')，这里再用 manualChunks
-          // 把它锚定到稳定命名 chunk，确保不被并入主 bundle 或工艺页 chunk。
-          'vendor-monaco': ['monaco-editor'],
-          // 091：@xyflow/react（React Flow）+ dagre 布局仅工艺可视化页使用，独立成 chunk。
-          'vendor-flow': ['@xyflow/react', 'dagre'],
+        // 093：manualChunks 从对象式改为函数式。
+        // 对象式会把被列模块的关联模块（含 Rollup 共享 helper）合并进 vendor chunk，
+        // 实测入口 chunk 出现 `import{_ as we}from"./vendor-monaco-*.js"`，导致首屏
+        // 被迫 preload 3.3MB monaco；函数式只按模块路径精确归类、不吞并依赖，
+        // helper 与未被匹配的依赖回退到 Rollup 按 lazy 边界自然分包。
+        manualChunks(id) {
+          // Vite 注入的 modulepreload helper（__vitePreload，id 形如 \0vite/preload-helper.js）
+          // 是入口与所有 lazy chunk 的共同依赖。不显式归类时 Rollup 会把它随手并入某个
+          // vendor chunk（实测落进 3.8MB 的 vendor-monaco），入口为引这一个 helper 被迫
+          // preload 整个 vendor。显式锚定到独立小 chunk，入口只 preload 几 KB。
+          if (id.includes('vite/preload-helper')) return 'vendor-runtime';
+          // 项目源码一律返回 undefined，让 React.lazy 的动态边界决定分包；
+          // 只有 node_modules 里的第三方库才做命名 vendor 归类。
+          if (!id.includes('node_modules')) return undefined;
+          // React 运行时必须显式锚定到独立 chunk。不指定时 Rollup 会把 react 自然并入
+          // 最大引用方 vendor-antd，而 react-icons 等库顶层执行 `React.createContext()`，
+          // chunk 间形成循环依赖后模块尚未初始化就读取 → 运行时
+          // "Cannot read properties of undefined (reading 'createContext')"，应用白屏。
+          // 路径按目录边界精确匹配，'/node_modules/react/' 不会误伤 react-icons 等同缀包。
+          if (/\/node_modules\/(react|react-dom|scheduler|react-is)\//.test(id)) return 'vendor-react';
+          // monaco 体量最大（核心+各语言子包 ~3.3MB），仅工艺 YAML 编辑器经
+          // 动态 import('monaco-editor') 按需加载，锚定到稳定命名 chunk 防回潮。
+          if (id.includes('/monaco-editor/')) return 'vendor-monaco';
+          // @xyflow/react（React Flow）+ dagre 布局仅工艺可视化页使用。
+          if (id.includes('/@xyflow/') || id.includes('/dagre/')) return 'vendor-flow';
+          // markdown 渲染/编辑器经 093 懒加载后按需加载；x-markdown 与 md-editor
+          // 共用一份 markdown 依赖树，归同一 chunk 避免重复下载。
+          // 注意必须先于下方 antd 广义匹配返回（x-markdown 路径也含 '@ant-design'）。
+          if (id.includes('/@ant-design/x-markdown/')) return 'vendor-md-editor';
+          if (id.includes('/@uiw/react-md-editor/') || id.includes('/@uiw/react-markdown-preview/')) return 'vendor-md-editor';
+          // antd 全家桶（含 @ant-design/icons、cssinjs、rc-*、@rc-component/*）必须归
+          // 同一个 chunk：antd ⇄ icons ⇄ cssinjs 相互引用，拆开后 chunk 间形成循环依赖，
+          // 模块未初始化就被读取 → 运行时 TDZ 报错白屏（本分支实测验证）。
+          if (id.includes('/antd/') || id.includes('/@ant-design/') || id.includes('/rc-') || id.includes('/@rc-component/')) return 'vendor-antd';
+          if (id.includes('/react-icons/')) return 'vendor-icons';
+          // 小组件库按使用面归堆：qrcode（设置页）、react-countup（Dashboard）、
+          // react-js-cron（调度 UI）各自体积小，合并减少请求数。
+          if (id.includes('/qrcode/') || id.includes('/react-countup/') || id.includes('/react-js-cron/')) return 'vendor-misc';
+          // 其余第三方依赖（react/react-dom/axios/dayjs 等）不强制归类，
+          // 由 Rollup 按静态/动态引用关系自然落 chunk，避免 helper 提升问题复发。
+          return undefined;
         },
       },
     },


### PR DESCRIPTION
## 实现了什么

修复 091 懒加载拆分「拆而仍载」的遗留根因：`index.html` 实测把 **vendor-monaco(3.3MB) / vendor-md-editor(1.18MB) / vendor-flow(270KB)** 全部 modulepreload，首屏 ~7.2MB。本 PR 后首屏 preload **2.31MB（-68%）**，三个重型 chunk 全部回归按需加载。

## 根因（构建产物实证，详见设计文档 §1.3）

1. **manualChunks 对象写法**：Rollup 把 `vite/preload-helper` 并入 3.8MB 的 vendor-monaco，入口为引这 1KB helper 被迫 preload 整个 monaco；
2. **静态导入链**：`ChatView`/`HelpPage`/`WikiChatFloatingWindow`/`TodoDrawer` 等首屏静态组件直接 import x-markdown / @uiw/react-md-editor；`HelpContentRenderer` 静态引入的 `MermaidDiagram` → merslim → dagre，是 vendor-flow 被 preload 的真实来源；
3. **chunk 循环依赖**（实施期实测发现）：react 自然分包并入 vendor-antd 时，react-icons 顶层 `React.createContext` 白屏；antd ⇄ @ant-design/icons 拆分必现 TDZ。

## 改动

- `vite.config.ts`：manualChunks 对象式 → 函数式；新增 `vendor-runtime`（preload-helper 锚定，1.1KB）、`vendor-react`（防循环）；antd 全家桶合并单 chunk
- 新增 `LazyXMarkdown` 共享懒加载包装（fallback 纯文本可读），替换全部 7 处静态引用
- `MdEditor` 封装层内部懒加载，3 个调用方零改动
- `MermaidDiagram` 懒加载（仅帮助内容含 mermaid 围栏时加载）
- 文档：`docs/design/093-首屏bundle瘦身-设计.md`、`docs/requirements/093-首屏bundle瘦身-实现总结.md`

## 测试与验证

- `npx tsc --noEmit` 零错误；`vitest run` 281 全绿（新增 4 例 + 适配 3 例）
- Playwright `frontend/tests/093-first-screen-bundle.spec.ts` 3 项全过（preload 清单断言 / 首屏无重型 chunk 请求 / 帮助页 markdown 懒加载渲染）
- 优化后首屏 preload：index 769KB + vendor-antd 1282KB + vendor-react 195KB + misc 60KB + icons 3KB + runtime 1KB

## 已知限制

- vendor-antd 1.28MB（gzip 391KB）按需引入留待后续专项；monaco chunk 仍在产物中但仅工艺 YAML 编辑器打开时加载（构建体积告警保留，属预期）。