### PR TITLE
perf(093): WS 重连日志改尾部窗口查询 + 聚合计数

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -787,37 +787,129 @@ impl Database {
             .all(&self.conn)
             .await?;
 
+        // 093：metadata 解析收敛到 parsed_log_entry_from_parts，不再在此重复一份
         let logs: Vec<ParsedLogEntry> = entries
             .into_iter()
-            .map(|m| {
-                let (usage, tool_name, tool_input_json) = m
-                    .metadata
-                    .as_deref()
-                    .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
-                    .map(|v| {
-                        (
-                            v.get("usage")
-                                .and_then(|u| serde_json::from_value(u.clone()).ok()),
-                            v.get("tool_name")
-                                .and_then(|n| n.as_str().map(String::from)),
-                            v.get("tool_input_json")
-                                .and_then(|t| t.as_str().map(String::from)),
-                        )
-                    })
-                    .unwrap_or((None, None, None));
-
-                ParsedLogEntry {
-                    timestamp: m.timestamp,
-                    log_type: m.log_type,
-                    content: m.content,
-                    usage,
-                    tool_name,
-                    tool_input_json,
-                }
-            })
+            .map(|m| Self::parsed_log_entry_from_parts(m.timestamp, m.log_type, m.content, m.metadata.as_deref()))
             .collect();
 
         Ok((logs, total))
+    }
+
+    /// 把 execution_logs 行的四个字段组装成 `ParsedLogEntry`（093 抽取的共享映射）。
+    ///
+    /// metadata 列是 JSON 串 `{"usage":..,"tool_name":..,"tool_input_json":..}`，
+    /// 解析失败（历史脏数据 / 缺字段）一律降级为 None 而非报错——日志是只读展示数据，
+    /// 单行 metadata 损坏不应拖垮整页查询。
+    fn parsed_log_entry_from_parts(
+        timestamp: String,
+        log_type: String,
+        content: String,
+        metadata: Option<&str>,
+    ) -> ParsedLogEntry {
+        // metadata 只读不消费，用 &str 避免调用方为传参克隆一份 JSON 串
+        let (usage, tool_name, tool_input_json) = metadata
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+            .map(|v| {
+                (
+                    v.get("usage")
+                        .and_then(|u| serde_json::from_value(u.clone()).ok()),
+                    v.get("tool_name")
+                        .and_then(|n| n.as_str().map(String::from)),
+                    v.get("tool_input_json")
+                        .and_then(|t| t.as_str().map(String::from)),
+                )
+            })
+            .unwrap_or((None, None, None));
+        ParsedLogEntry { timestamp, log_type, content, usage, tool_name, tool_input_json }
+    }
+
+    /// 093：批量统计多个 record 的日志总行数（WS 重连 Sync 的 `log_total` 数据源）。
+    ///
+    /// 单条 GROUP BY 聚合替代旧实现「全量读回再 Vec::len」：长跑任务数万行日志时，
+    /// 重连不再需要把整表读进内存只为计数。
+    pub async fn count_execution_logs_for_records(
+        &self,
+        record_ids: &[i64],
+    ) -> Result<std::collections::HashMap<i64, i64>, sea_orm::DbErr> {
+        if record_ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        // in_clause 生成参数化占位符，杜绝字符串拼接注入面
+        let (placeholders, values) = Self::in_clause(record_ids);
+        let sql = format!(
+            "SELECT record_id, COUNT(*) AS cnt FROM execution_logs \
+             WHERE record_id IN ({placeholders}) GROUP BY record_id"
+        );
+        let rows = self
+            .conn
+            .query_all(sea_orm::Statement::from_sql_and_values(
+                sea_orm::DbBackend::Sqlite,
+                sql,
+                values,
+            ))
+            .await?;
+        // COUNT(*) 在无匹配行时该 record 不出现在结果集——调用方以 get().unwrap_or(0) 读
+        Ok(rows
+            .iter()
+            .filter_map(|r| {
+                Some((
+                    r.try_get_by::<i64, _>("record_id").ok()?,
+                    r.try_get_by::<i64, _>("cnt").ok()?,
+                ))
+            })
+            .collect())
+    }
+
+    /// 093：批量取多个 record 的「尾部 cap 条」日志（WS 重连 Sync 的日志摘要数据源）。
+    ///
+    /// 窗口函数单查询完成「每个 record 各取最新 cap 条」，避免按 record 逐条查询的 N+1；
+    /// 外层按 record_id, id ASC 归序，与旧实现「内存截尾后升序」语义完全一致，前端无感知。
+    /// cap 参数化（生产传 RECONNECT_LOG_CAP=200，测试用小值验证边界）。
+    pub async fn get_tail_execution_logs_for_records(
+        &self,
+        record_ids: &[i64],
+        cap: i64,
+    ) -> Result<std::collections::HashMap<i64, Vec<ParsedLogEntry>>, sea_orm::DbErr> {
+        if record_ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+        let (placeholders, mut values) = Self::in_clause(record_ids);
+        // cap 拼在 WHERE rn <= ? 处，作为最后一个绑定值
+        values.push(cap.into());
+        let sql = format!(
+            "SELECT id, record_id, timestamp, log_type, content, metadata FROM ( \
+               SELECT id, record_id, timestamp, log_type, content, metadata, \
+                      ROW_NUMBER() OVER (PARTITION BY record_id ORDER BY id DESC) AS rn \
+               FROM execution_logs WHERE record_id IN ({placeholders}) \
+             ) WHERE rn <= ? ORDER BY record_id, id ASC"
+        );
+        let rows = self
+            .conn
+            .query_all(sea_orm::Statement::from_sql_and_values(
+                sea_orm::DbBackend::Sqlite,
+                sql,
+                values,
+            ))
+            .await?;
+        let mut map: std::collections::HashMap<i64, Vec<ParsedLogEntry>> =
+            std::collections::HashMap::with_capacity(record_ids.len());
+        for r in &rows {
+            // 单行字段读取失败时跳过该行而不是整批失败——日志是展示数据，可用性优先
+            let (Ok(record_id), Ok(timestamp), Ok(log_type), Ok(content), Ok(metadata)) = (
+                r.try_get_by::<i64, _>("record_id"),
+                r.try_get_by::<String, _>("timestamp"),
+                r.try_get_by::<String, _>("log_type"),
+                r.try_get_by::<String, _>("content"),
+                r.try_get_by::<Option<String>, _>("metadata"),
+            ) else {
+                continue;
+            };
+            map.entry(record_id)
+                .or_default()
+                .push(Self::parsed_log_entry_from_parts(timestamp, log_type, content, metadata.as_deref()));
+        }
+        Ok(map)
     }
 
     /// 获取所有执行日志（用于 WebSocket 同步等场景，请谨慎使用）
@@ -831,50 +923,10 @@ impl Database {
         Ok(logs)
     }
 
-    /// 批量获取多个 record_id 的所有执行日志（避免 WebSocket 同步时的 N+1 查询）
-    pub async fn get_all_execution_logs_for_records(
-        &self,
-        record_ids: &[i64],
-    ) -> Result<std::collections::HashMap<i64, Vec<ParsedLogEntry>>, sea_orm::DbErr> {
-        if record_ids.is_empty() {
-            return Ok(std::collections::HashMap::new());
-        }
-        let entries = execution_logs::Entity::find()
-            .filter(execution_logs::Column::RecordId.is_in(record_ids.iter().copied()))
-            .order_by_asc(execution_logs::Column::Id)
-            .all(&self.conn)
-            .await?;
-
-        let mut map: std::collections::HashMap<i64, Vec<ParsedLogEntry>> =
-            std::collections::HashMap::with_capacity(record_ids.len());
-        for m in entries {
-            let (usage, tool_name, tool_input_json) = m
-                .metadata
-                .as_deref()
-                .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
-                .map(|v| {
-                    (
-                        v.get("usage")
-                            .and_then(|u| serde_json::from_value(u.clone()).ok()),
-                        v.get("tool_name")
-                            .and_then(|n| n.as_str().map(String::from)),
-                        v.get("tool_input_json")
-                            .and_then(|t| t.as_str().map(String::from)),
-                    )
-                })
-                .unwrap_or((None, None, None));
-
-            map.entry(m.record_id).or_default().push(ParsedLogEntry {
-                timestamp: m.timestamp,
-                log_type: m.log_type,
-                content: m.content,
-                usage,
-                tool_name,
-                tool_input_json,
-            });
-        }
-        Ok(map)
-    }
+    // 093：原 `get_all_execution_logs_for_records`（全量读回 + 内存截尾）已删除。
+    // WS 重连 Sync 路径改用 `count_execution_logs_for_records`（聚合计数）
+    // + `get_tail_execution_logs_for_records`（窗口函数取尾部 cap 条）组合，
+    // 长跑任务重连不再全量读表。全量读取场景请显式使用分页 `get_execution_logs`。
 
     /// 根据 session_id 获取所有执行记录（按 started_at 排序）
     pub async fn get_execution_records_by_session(
@@ -1836,6 +1888,75 @@ mod center_aggregate_tests {
         ))
         .await
         .expect("insert exec");
+    }
+
+    /// 093：插一条执行日志，content 可指定（断言尾部内容用），metadata 给 NULL 走默认降级路径。
+    async fn seed_log(db: &Database, record_id: i64, content: &str) {
+        db.exec(&format!(
+            "INSERT INTO execution_logs (record_id, timestamp, log_type, content) \
+             VALUES ({record_id}, '2026-07-08T09:00:00Z', 'info', '{content}')"
+        ))
+        .await
+        .expect("insert log");
+    }
+
+    /// count_execution_logs_for_records：GROUP BY 聚合计数（093 WS 重连 log_total 数据源）。
+    /// 覆盖：多 record 各自计数、无日志 record 不出现、空入参返空。
+    #[tokio::test]
+    async fn test_count_execution_logs_for_records_groups_by_record() {
+        let db = fresh_db().await;
+        let t = seed_todo(&db, "T").await;
+        seed_exec(&db, t, "running", "manual").await; // record id=1
+        seed_exec(&db, t, "running", "manual").await; // record id=2
+        for i in 0..3 {
+            seed_log(&db, 1, &format!("r1-{i}")).await;
+        }
+        seed_log(&db, 2, "r2-0").await;
+        let map = db.count_execution_logs_for_records(&[1, 2, 9999]).await.unwrap();
+        assert_eq!(map.get(&1).copied(), Some(3));
+        assert_eq!(map.get(&2).copied(), Some(1));
+        // COUNT 聚合对无匹配行的 record 不产出分组——调用方以 unwrap_or(0) 读
+        assert!(!map.contains_key(&9999), "无日志的 record 不应出现在聚合结果中");
+        assert!(
+            db.count_execution_logs_for_records(&[]).await.unwrap().is_empty(),
+            "空入参应返回空 map"
+        );
+    }
+
+    /// get_tail_execution_logs_for_records：窗口函数取尾部 cap 条（093 WS 重连日志摘要源）。
+    /// 覆盖：cap=2 取尾部 2 条且按 id 升序、跨 record 互不串扰、metadata JSON 正常解析。
+    #[tokio::test]
+    async fn test_get_tail_execution_logs_for_records_returns_tail_asc() {
+        let db = fresh_db().await;
+        let t = seed_todo(&db, "T").await;
+        seed_exec(&db, t, "running", "manual").await; // record id=1
+        seed_exec(&db, t, "running", "manual").await; // record id=2
+        for i in 0..5 {
+            seed_log(&db, 1, &format!("r1-{i}")).await;
+        }
+        seed_log(&db, 2, "r2-only").await;
+        // 给尾部将命中的一行补上 metadata，验证 JSON 解析经共享 helper 走通
+        db.exec(
+            "UPDATE execution_logs SET metadata = '{\"tool_name\":\"Bash\"}' \
+             WHERE record_id = 1 AND content = 'r1-4'",
+        )
+        .await
+        .expect("update metadata");
+
+        let map = db.get_tail_execution_logs_for_records(&[1, 2], 2).await.unwrap();
+        let r1 = map.get(&1).expect("record 1 应有尾部日志");
+        // 5 行取尾 2：r1-3、r1-4；外层按 id ASC 归序，与旧内存截尾语义一致
+        let contents: Vec<&str> = r1.iter().map(|l| l.content.as_str()).collect();
+        assert_eq!(contents, ["r1-3", "r1-4"], "应取尾部 2 条且升序");
+        assert_eq!(r1[1].tool_name.as_deref(), Some("Bash"), "metadata 应被解析");
+        // record 2 仅 1 行，cap 超过总量时返回全部
+        let r2 = map.get(&2).expect("record 2 应有日志");
+        assert_eq!(r2.len(), 1, "cap 超过总量应返回全部");
+        assert_eq!(r2[0].content, "r2-only", "跨 record 不应串扰");
+        assert!(
+            db.get_tail_execution_logs_for_records(&[], 2).await.unwrap().is_empty(),
+            "空入参应返回空 map"
+        );
     }
 
     /// get_execution_records_by_ids：按 id 批量取执行记录并按 id 索引；

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -188,28 +188,37 @@ pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade)
             .filter_map(|r| r.task_id.clone().map(|tid| (tid, r)))
             .collect();
         let record_ids: Vec<i64> = record_map.values().map(|r| r.id).collect();
-        let logs_map = state
-            .db
-            .get_all_execution_logs_for_records(&record_ids)
-            .await
-            .unwrap_or_else(|e| {
-                tracing::error!("[ws-events] 查询执行日志失败，Sync 降级为空日志: {e}");
-                std::collections::HashMap::new()
-            });
         // reconnect 时每个任务只回传最近 RECONNECT_LOG_CAP 条日志，避免长跑任务的全量日志
         // 把首帧撑爆（既卡 serde 序列化，也卡 WS 推送）。完整历史前端通过 REST 分页按需拉取（091）。
         const RECONNECT_LOG_CAP: usize = 200;
+        // 093：尾部摘要与全量条数拆成两个定向查询——窗口函数只读尾部 cap 行 + GROUP BY 聚合计数，
+        // 替代旧实现「全量读进内存再 split_off 丢弃 99%」；长跑任务（数万行）重连不再全表扫。
+        // 两个查询各自独立降级（WS 已升级无法回 HTTP 错误，沿用 056 决策的 error 日志 + 空 map），
+        // 互不影响：尾部查询失败时前端只见空日志，计数查询失败时只见 log_total=0。
+        let tails_map = state
+            .db
+            .get_tail_execution_logs_for_records(&record_ids, RECONNECT_LOG_CAP as i64)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::error!("[ws-events] 查询尾部执行日志失败，Sync 降级为空日志: {e}");
+                std::collections::HashMap::new()
+            });
+        let counts_map = state
+            .db
+            .count_execution_logs_for_records(&record_ids)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::error!("[ws-events] 统计执行日志条数失败，Sync 降级为 0: {e}");
+                std::collections::HashMap::new()
+            });
         // 收集「task_id → 最近 N 条日志」，统一交给 spawn_blocking 做 CPU 密集的 JSON 序列化，
         // 不占住 WS 升级后的 async 任务（091 性能优化）。
         let logs_to_serialize = running_tasks
             .iter()
             .filter_map(|t| {
                 let record = record_map.get(&t.task_id)?;
-                // logs_map 按 id 升序，取尾部即最近 N 条。
-                let mut logs = logs_map.get(&record.id).cloned().unwrap_or_default();
-                if logs.len() > RECONNECT_LOG_CAP {
-                    logs = logs.split_off(logs.len() - RECONNECT_LOG_CAP);
-                }
+                // tails_map 已在 SQL 层截尾并按 id 升序归位，语义与旧内存截尾完全一致。
+                let logs = tails_map.get(&record.id).cloned().unwrap_or_default();
                 Some((t.task_id.clone(), logs))
             })
             .collect::<Vec<_>>();
@@ -225,11 +234,11 @@ pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade)
             if let Some(json) = serialized.get(&task.task_id) {
                 task.logs = json.clone();
             }
-            // 091：log_total 用 logs_map 的「全量」条数（logs_map 未被 RECONNECT_LOG_CAP 截断），
+            // 091/093：log_total 来自 COUNT(*) 聚合计数（原 logs_map 全量条数），
             // 告知前端「还有更多历史」——前端只收到最近 N 条，但能据此提示「共 M 条」，
             // 完整历史走执行记录详情页分页。无对应 record（DB 查询降级）时记 0。
             if let Some(record) = record_map.get(&task.task_id) {
-                task.log_total = logs_map.get(&record.id).map(|v| v.len() as i64).unwrap_or(0);
+                task.log_total = counts_map.get(&record.id).copied().unwrap_or(0);
             }
         }
         let sync_event = ExecEvent::Sync { tasks: running_tasks };

--- a/docs/design/093-WS重连日志尾取-设计.md
+++ b/docs/design/093-WS重连日志尾取-设计.md
@@ -1,0 +1,89 @@
+# 093-WS重连日志尾取-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+
+> 093 优化扫描专项第 2 项。设计 1（首屏 bundle）见 `093-首屏bundle瘦身-设计.md`。
+
+## 1. 背景与问题
+
+WebSocket 建连/重连时，`events_handler`（`handlers/mod.rs:190-233`）为构造 `Sync` 快照调用
+`db.get_all_execution_logs_for_records(&record_ids)`，把**每个运行中任务的全部历史日志**
+读进内存并逐行解析 metadata JSON，目的却只是：
+
+1. 取每个任务**最近 200 条**（`RECONNECT_LOG_CAP`）序列化进 `Sync.tasks[].logs`；
+2. 算每个任务的**全量条数** `log_total`（供前端提示「共 N 条 · 仅显示最近 M 条」）。
+
+长跑任务日志可达数万行（`execution_logs` 每行一条），一次重连 = 全量行读取 + 全量
+JSON 反序列化 + 大 Vec 分配，随后 99% 被 `split_off` 丢弃。多标签页同时重连时放大 N 倍。
+
+`get_all_execution_logs_for_records` 全仓仅此一个调用点（091 后列表/详情页均走分页查询）。
+
+## 2. 设计
+
+### C1：DAO 层新增两个定向查询（`db/execution.rs`）
+
+**`count_execution_logs_for_records(record_ids) -> HashMap<i64, i64>`**
+
+```sql
+SELECT record_id, COUNT(*) AS cnt FROM execution_logs
+WHERE record_id IN (?) GROUP BY record_id
+```
+
+用既有 `Database::in_clause`（`db/mod.rs:202`）构造占位符与绑定值，`query_all` + `try_get_by` 读取。
+
+**`get_tail_execution_logs_for_records(record_ids, cap) -> HashMap<i64, Vec<ParsedLogEntry>>`**
+
+窗口函数单查询取每个 record 的尾部 cap 条，避免 N+1（运行中任务数 = N 次往返）：
+
+```sql
+SELECT id, record_id, timestamp, log_type, content, metadata FROM (
+  SELECT id, record_id, timestamp, log_type, content, metadata,
+         ROW_NUMBER() OVER (PARTITION BY record_id ORDER BY id DESC) AS rn
+  FROM execution_logs WHERE record_id IN (?)
+) WHERE rn <= ? ORDER BY record_id, id ASC
+```
+
+- SQLite 3.25+ 支持窗口函数，sqlx bundled SQLite 版本远高于此，无兼容性风险。
+- 结果按 `id ASC` 归序（窗口内是 DESC 取尾部，外层再正序排列），与旧实现的「尾 N 条、升序」语义完全一致，前端无感知。
+- `cap` 参数化绑定，不写死 200，测试可用小 cap 验证。
+
+**顺带重构**：`get_execution_logs` 与旧 `get_all_execution_logs_for_records` 中重复的
+`metadata JSON → (usage, tool_name, tool_input_json)` 解析段抽成私有 helper
+`parsed_log_entry_from_model`，三处共用（本设计落地后旧方法删除，实为两处 + 新查询从行构造 entry 的解析）。
+
+### C2：删除 `get_all_execution_logs_for_records`
+
+唯一调用点切换到 C1 两个新方法后，该方法成为死代码，按仓库死代码清理惯例（057 专项）随本 PR 删除，不留兼容壳。
+
+### C3：`events_handler` 切换（`handlers/mod.rs`）
+
+- `logs_map`（全量）→ `tails_map`（尾部 200 条）+ `counts_map`（全量条数）；
+- `logs_to_serialize` 直接用 `tails_map`（DB 已截断，去掉 `split_off` 内存截断逻辑）；
+- `log_total` 取 `counts_map`；`RECONNECT_LOG_CAP` 常量语义不变；
+- 错误处理沿用现有范式：查询失败记 `tracing::error!` 后降级为空 map（WS 已升级无法回 HTTP 错误，见 056 决策），两个查询各自独立降级，互不影响。
+
+## 3. 影响模块
+
+| 层 | 文件 |
+|----|------|
+| 后端 DB | `backend/src/db/execution.rs`（+2 方法 -1 方法 +1 私有 helper +单测） |
+| 后端 handler | `backend/src/handlers/mod.rs`（events_handler 约 20 行改动） |
+
+前端零改动（`Sync` 事件 schema 不变）。
+
+## 4. 验证方案
+
+1. 新增单测（`db/execution.rs` 既有 `#[cfg(test)]` 区范式，`fresh_db()` 内存库 + seed helper）：
+   - `count_execution_logs_for_records`：多 record 不同行数、缺失 record 不出现、空入参返空；
+   - `get_tail_execution_logs_for_records`：cap=2 时取尾部 2 条且按 id 升序、cap 超过总量返回全部、跨 record 互不串扰、空入参返空。
+2. `cargo clippy --all-targets -- -D warnings` 零告警；`cargo test` 全绿。
+3. 手工/Playwright 冒烟：启动 `make dev`，跑一个任务产生日志后刷新页面（触发 WS 重连 Sync），执行面板日志与「共 N 条」提示正常。
+4. 量级对照（文字推演）：1 个 5 万行日志的任务重连，旧路径读 5 万行 + 5 万次 JSON 解析；新路径 1 次 COUNT 聚合 + 200 行读取。
+
+## 5. 安全反思
+
+- 两条新 SQL 均参数化绑定（IN 占位符 + cap），无字符串拼接注入面；
+- 降级路径与现状一致（空 map），不引入新的失败模式；
+- 无权限面变化：WS 事件流本就推送这些日志，只是减少了读取范围。

--- a/docs/requirements/093-WS重连日志尾取-实现总结.md
+++ b/docs/requirements/093-WS重连日志尾取-实现总结.md
@@ -1,0 +1,52 @@
+# 093-WS重连日志尾取-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+
+> 对应设计：`docs/design/093-WS重连日志尾取-设计.md`。093 优化扫描专项第 2 项。
+
+## 1. 实现了什么
+
+WS 建连/重连的 `Sync` 快照不再全量读取运行中任务的历史日志：
+
+- 旧路径：`get_all_execution_logs_for_records` 把每个运行中任务**全部日志行**读进内存 + 逐行解析 metadata JSON，随后 `split_off` 丢弃 99% 只留尾部 200 条；
+- 新路径：`get_tail_execution_logs_for_records`（窗口函数 `ROW_NUMBER() PARTITION BY record_id ORDER BY id DESC`，单查询取每任务尾部 cap 条）+ `count_execution_logs_for_records`（`GROUP BY` 聚合计数出 `log_total`）。
+
+量级对照：1 个 5 万行日志的任务重连，旧路径读 5 万行 + 5 万次 JSON 解析；新路径 1 次聚合 + 200 行读取。多标签页重连的放大效应同步消除。
+
+## 2. 与设计的对应关系
+
+| 设计项 | 落地 | 状态 |
+|--------|------|------|
+| C1 DAO 两个定向查询 | `count_execution_logs_for_records` + `get_tail_execution_logs_for_records`（`db/execution.rs`） | ✅ |
+| C1 顺带重构 | metadata JSON 解析抽 `parsed_log_entry_from_parts`（`get_execution_logs` 与尾部查询共用，消除两处重复） | ✅ |
+| C2 删除死代码 | `get_all_execution_logs_for_records` 已删（全仓唯一调用点即本次改造的 WS 路径） | ✅ |
+| C3 handler 切换 | `events_handler`（`handlers/mod.rs`）两个查询各自独立降级（error 日志 + 空 map），`Sync` schema 不变、前端零改动 | ✅ |
+
+## 3. 关键实现点
+
+- **窗口函数语义对齐**：内层 `ROW_NUMBER() ... ORDER BY id DESC` 取尾部，外层 `ORDER BY record_id, id ASC` 归序——与旧实现「内存截尾后升序」完全一致，前端无感知。
+- **cap 参数化**：生产传 `RECONNECT_LOG_CAP=200`，测试用小值验证边界；IN 占位符走既有 `Database::in_clause`，无字符串拼接注入面。
+- **SQLite 兼容性**：窗口函数需 SQLite 3.25+，sqlx bundled 版本远高于此。
+- **clippy 适配**：helper 的 `metadata` 参数用 `Option<&str>` 而非 `Option<String>`（只读不消费，避免调用方克隆 JSON 串），过 `needless_pass_by_value`。
+
+## 4. 测试与验证结果
+
+- 新增单测 2 例（`center_aggregate_tests` 区）：
+  - `test_count_execution_logs_for_records_groups_by_record`：多 record 计数 / 无日志 record 不出现 / 空入参返空；
+  - `test_get_tail_execution_logs_for_records_returns_tail_asc`：cap=2 尾部升序 / 跨 record 隔离 / metadata 解析 / cap 超总量返回全部 / 空入参返空。
+- `cargo clippy --all-targets -- -D warnings`：零告警 ✅
+- `cargo test --no-fail-fast`：1709 通过，唯一失败 `git_sync::tests::test_sync_repo_restores_deleted_file` 为**预存量环境问题**（本机 git 版本过老不支持 `git init -b`，与 main 分支表现一致，与本 PR 无关）✅
+- Playwright 冒烟（`frontend/tests/093-ws-sync-smoke.spec.ts`，`make dev` 18088 实例）：注入 WS 抓包确认收到 `Sync` 帧、页面无报错渲染 ✅；`backend.dev.log` 无 ERROR ✅
+
+## 5. 已知限制
+
+- 无运行中任务时 `record_ids` 为空，两个新 DAO 早退返空（单测覆盖）——该快路径行为与旧实现一致。
+- WS 广播侧「逐客户端重复序列化同一事件」是扫描中的另一个独立优化点，不在本 PR 范围。
+
+## 6. 安全反思
+
+- 两条新 SQL 全部参数化绑定（IN 占位符 + cap），无注入面；
+- 降级行为与现状一致（WS 已升级无法回 HTTP 错误，记 error 日志后空 map 降级）；
+- 仅收窄读取范围，无权限面变化。

--- a/frontend/tests/093-ws-sync-smoke.spec.ts
+++ b/frontend/tests/093-ws-sync-smoke.spec.ts
@@ -1,0 +1,34 @@
+// 093 WS 重连日志尾取（后端）冒烟：验证 Sync 事件链路在新 DAO 下工作正常。
+// 覆盖点：WS 建连收到 Sync（新 DAO 路径：尾部窗口查询 + COUNT 聚合）、页面无报错渲染。
+import { test, expect } from '@playwright/test';
+
+const BASE = 'http://localhost:18088';
+
+test('093-ws: WS 建连收到 Sync 事件且页面正常渲染', async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (e) => pageErrors.push(e.message));
+
+  // 在页面加载前注入 WS 抓包：包装 WebSocket 构造函数记录收到的 Sync 帧
+  await page.addInitScript(() => {
+    (window as any).__syncFrames = 0;
+    const OrigWS = window.WebSocket;
+    (window as any).WebSocket = class extends OrigWS {
+      constructor(url: string | URL, protocols?: string | string[]) {
+        super(url, protocols);
+        this.addEventListener('message', (ev) => {
+          // Sync 帧是 JSON 且 type=Sync；握手 "Connected" 文本帧跳过
+          if (typeof ev.data === 'string' && ev.data.includes('"type":"Sync"')) {
+            (window as any).__syncFrames += 1;
+          }
+        });
+      }
+    };
+  });
+
+  await page.goto(BASE);
+  await expect(page.locator('#root')).not.toBeEmpty({ timeout: 15000 });
+
+  // 等待 WS 建连并收到 Sync 快照（走新 DAO：空任务集也应正常发 Sync 帧）
+  await page.waitForFunction(() => (window as any).__syncFrames > 0, null, { timeout: 15000 });
+  expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
## 实现了什么

WS 建连/重连的 `Sync` 快照不再全量读取运行中任务的历史日志：

- 旧：`get_all_execution_logs_for_records` 全量读回 + 逐行解析 metadata JSON，随后内存截尾丢弃 99%（只留尾部 200 条）；
- 新：窗口函数 `ROW_NUMBER() PARTITION BY record_id` 单查询取尾部 cap 条 + `GROUP BY` 聚合计数出 `log_total`。

量级对照：1 个 5 万行日志的任务重连，旧路径 5 万行读取 + 5 万次 JSON 解析 → 新路径 1 次聚合 + 200 行读取。前端零改动（`Sync` schema 不变）。

## 改动

- `db/execution.rs`：+`count_execution_logs_for_records` / +`get_tail_execution_logs_for_records` / 删除死代码 `get_all_execution_logs_for_records`（唯一调用点即本路径）；metadata 解析抽 shared helper
- `handlers/mod.rs`：`events_handler` 切换，两个查询独立降级（error 日志 + 空 map，沿用 056 决策）
- 文档：`docs/design/093-WS重连日志尾取-设计.md`、`docs/requirements/093-WS重连日志尾取-实现总结.md`

## 测试

- 新增单测 2 例（聚合计数 / 窗口尾取边界：升序、跨 record 隔离、cap 超总量、空入参）
- `cargo clippy --all-targets -- -D warnings` 零告警
- `cargo test` 1709 通过；唯一失败 `git_sync::tests::test_sync_repo_restores_deleted_file` 为预存量环境问题（本机 git 过老不支持 `git init -b`，main 上同样失败，与本 PR 无关）
- Playwright WS Sync 冒烟通过（`frontend/tests/093-ws-sync-smoke.spec.ts`）