### PR TITLE
perf(093): todo 列表排序索引 + hours 过滤参数化

### DIFF
--- a/backend/src/db/migration/consolidated_schema.rs
+++ b/backend/src/db/migration/consolidated_schema.rs
@@ -1,4 +1,4 @@
-//! 合并版最终 schema（v1-v90 全部应用后的状态），供全新库一次性建表（bootstrap）。
+//! 合并版最终 schema（全部迁移应用后的状态），供全新库一次性建表（bootstrap）。
 //! 自动生成：全新库跑完增量迁移后 dump sqlite_master。
 //! 改动任何迁移后需重新生成：`cargo test --test dbg_gen_schema -- --ignored`
 
@@ -384,23 +384,6 @@ pub const CONSOLIDATED_SCHEMA: &[&str] = &[
             color TEXT DEFAULT '#1890ff',
             created_at TEXT
         )"#,
-    // tasks：需求 092 追加委派执行 5 列。追加列必须与 v91 的 ALTER 逐字一致，并按 SQLite
-    // ALTER ADD COLUMN 实际生成的「, coldef」单行格式接在原闭合括号缩进处（见 agent_bots
-    // 同款写法），否则 test_consolidated_schema_matches_incremental 会判 schema 漂移。
-    r#"CREATE TABLE tasks (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            title TEXT NOT NULL DEFAULT '',
-            description TEXT NOT NULL DEFAULT '',
-            status TEXT NOT NULL DEFAULT 'pending',
-            workspace_id INTEGER,
-            template_id INTEGER,
-            loop_id INTEGER,
-            created_by TEXT DEFAULT '',
-            created_at TEXT,
-            updated_at TEXT
-        , execution_mode TEXT NOT NULL DEFAULT 'loop', assignee_kind TEXT, assignee_name TEXT, auto_continue INTEGER NOT NULL DEFAULT 0, continue_rounds INTEGER NOT NULL DEFAULT 0, delegate_max_rounds INTEGER)"#,
-    // task_posts：任务讨论帖表（需求 060，与 v88 迁移同构）。字段语义见 entity/task_posts.rs；
-    // 外键均 ON DELETE CASCADE，删任务/删父帖时连带清理，避免孤儿帖。
     r#"CREATE TABLE task_posts (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 task_id INTEGER NOT NULL,
@@ -419,6 +402,18 @@ pub const CONSOLIDATED_SCHEMA: &[&str] = &[
                 FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
                 FOREIGN KEY (parent_post_id) REFERENCES task_posts(id) ON DELETE CASCADE
             )"#,
+    r#"CREATE TABLE tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL DEFAULT '',
+            description TEXT NOT NULL DEFAULT '',
+            status TEXT NOT NULL DEFAULT 'pending',
+            workspace_id INTEGER,
+            template_id INTEGER,
+            loop_id INTEGER,
+            created_by TEXT DEFAULT '',
+            created_at TEXT,
+            updated_at TEXT
+        , execution_mode TEXT NOT NULL DEFAULT 'loop', assignee_kind TEXT, assignee_name TEXT, auto_continue INTEGER NOT NULL DEFAULT 0, continue_rounds INTEGER NOT NULL DEFAULT 0, delegate_max_rounds INTEGER)"#,
     r#"CREATE TABLE todo_tags (
             todo_id INTEGER,
             tag_id INTEGER,
@@ -525,15 +520,18 @@ pub const CONSOLIDATED_SCHEMA: &[&str] = &[
     r#"CREATE INDEX idx_execution_records_task_id ON execution_records(task_id)"#,
     r#"CREATE INDEX idx_execution_records_todo_finished ON execution_records(todo_id, finished_at DESC)"#,
     r#"CREATE INDEX idx_execution_records_todo_id ON execution_records(todo_id)"#,
+    r#"CREATE INDEX idx_execution_records_workspace_id ON execution_records(workspace_id)"#,
     r#"CREATE INDEX idx_executors_name ON executors(name)"#,
     r#"CREATE UNIQUE INDEX idx_feishu_bindings_active ON feishu_project_bindings(bot_id, chat_id) WHERE chat_id != '__pending__' AND enabled = 1"#,
     r#"CREATE INDEX idx_feishu_bindings_bot_id ON feishu_project_bindings(bot_id)"#,
     r#"CREATE INDEX idx_feishu_bindings_record_id ON feishu_project_bindings(latest_record_id)"#,
+    r#"CREATE INDEX idx_feishu_messages_bot_chat ON feishu_messages(bot_id, chat_id, created_at DESC)"#,
     r#"CREATE INDEX idx_feishu_messages_chat_id ON feishu_messages(chat_id)"#,
     r#"CREATE INDEX idx_feishu_messages_created_at ON feishu_messages(created_at)"#,
     r#"CREATE INDEX idx_loop_executions_loop_id ON loop_executions(loop_id)"#,
     r#"CREATE INDEX idx_loop_executions_started_at ON loop_executions(started_at DESC)"#,
     r#"CREATE INDEX idx_loop_executions_status ON loop_executions(status)"#,
+    r#"CREATE INDEX idx_loop_executions_task_id ON loop_executions(task_id)"#,
     r#"CREATE INDEX idx_loop_hooks_loop_id ON loop_hooks(loop_id)"#,
     r#"CREATE INDEX idx_loop_hooks_source_stage ON loop_hooks(source_step_id)"#,
     r#"CREATE INDEX idx_loop_phase_executions_exec ON loop_phase_executions(loop_execution_id)"#,
@@ -543,11 +541,15 @@ pub const CONSOLIDATED_SCHEMA: &[&str] = &[
     r#"CREATE INDEX idx_loop_step_artifacts_exec ON loop_step_artifacts(loop_step_execution_id)"#,
     r#"CREATE INDEX idx_loop_step_artifacts_name ON loop_step_artifacts(loop_step_execution_id, name)"#,
     r#"CREATE INDEX idx_loop_step_execution_gates_exec ON loop_step_execution_gates(loop_step_execution_id)"#,
+    r#"CREATE INDEX idx_loop_step_executions_loop_exec ON loop_step_executions(loop_execution_id, sequence_index)"#,
     r#"CREATE INDEX idx_loop_steps_loop_id ON loop_steps(loop_id)"#,
     r#"CREATE INDEX idx_loop_steps_loop_order ON loop_steps(loop_id, order_index)"#,
+    r#"CREATE INDEX idx_loop_steps_todo_id ON loop_steps(todo_id)"#,
     r#"CREATE INDEX idx_loop_tags_loop_id ON loop_tags(loop_id)"#,
+    r#"CREATE INDEX idx_loops_process_template_id ON loops(process_template_id)"#,
     r#"CREATE INDEX idx_loops_status ON loops(status)"#,
     r#"CREATE INDEX idx_loops_updated_at ON loops(updated_at DESC)"#,
+    r#"CREATE INDEX idx_loops_workspace_id ON loops(workspace_id)"#,
     r#"CREATE INDEX idx_process_template_versions_guid
              ON process_template_versions(guid)"#,
     r#"CREATE INDEX idx_process_templates_category ON process_templates(category)"#,
@@ -555,13 +557,16 @@ pub const CONSOLIDATED_SCHEMA: &[&str] = &[
     r#"CREATE INDEX idx_process_templates_workspace ON process_templates(workspace_id)"#,
     r#"CREATE INDEX idx_project_directories_path ON project_directories(path)"#,
     r#"CREATE INDEX idx_skill_invocations_executor ON skill_invocations(executor)"#,
+    r#"CREATE INDEX idx_skill_invocations_invoked_at ON skill_invocations(invoked_at)"#,
     r#"CREATE INDEX idx_skill_invocations_skill_name ON skill_invocations(skill_name)"#,
     r#"CREATE INDEX idx_skill_invocations_todo_id ON skill_invocations(todo_id)"#,
     r#"CREATE INDEX idx_step_tags_step_id ON step_tags(step_id)"#,
     r#"CREATE INDEX idx_steps_source_todo ON steps(source_todo_id)"#,
     r#"CREATE INDEX idx_sync_records_created_at ON sync_records(created_at DESC)"#,
-    // task_posts 按 task 取帖子流是高频点查，必须走索引（需求 060）。
+    r#"CREATE INDEX idx_task_posts_source_execution_id ON task_posts(source_execution_id)"#,
     r#"CREATE INDEX idx_task_posts_task_id ON task_posts(task_id)"#,
+    r#"CREATE INDEX idx_task_posts_task_parent ON task_posts(task_id, parent_post_id, id)"#,
+    r#"CREATE INDEX idx_tasks_workspace_id ON tasks(workspace_id)"#,
     r#"CREATE INDEX idx_todo_tags_todo_id ON todo_tags(todo_id)"#,
     r#"CREATE UNIQUE INDEX idx_todos_action_type_key_workspace ON todos (action_type, action_key, workspace_id) WHERE action_type IS NOT NULL AND action_key IS NOT NULL"#,
     r#"CREATE INDEX idx_todos_archived_at ON todos(archived_at)"#,
@@ -572,24 +577,12 @@ pub const CONSOLIDATED_SCHEMA: &[&str] = &[
     r#"CREATE INDEX idx_todos_status ON todos(status)"#,
     r#"CREATE INDEX idx_todos_task_id ON todos(task_id)"#,
     r#"CREATE INDEX idx_todos_todo_type ON todos(todo_type)"#,
+    r#"CREATE INDEX idx_todos_updated_at ON todos(updated_at DESC)"#,
+    r#"CREATE INDEX idx_todos_workspace_id ON todos(workspace_id)"#,
     r#"CREATE INDEX idx_usage_daily_stats_date ON usage_daily_stats(date)"#,
     r#"CREATE INDEX idx_usage_daily_stats_stats_type ON usage_daily_stats(stats_type)"#,
     r#"CREATE INDEX idx_usage_executor_daily_stats_date ON usage_executor_daily_stats(date)"#,
     r#"CREATE INDEX idx_usage_executor_daily_stats_executor ON usage_executor_daily_stats(executor)"#,
     r#"CREATE INDEX idx_usage_model_breakdowns_daily_stat_id ON usage_model_breakdowns(daily_stat_id)"#,
     r#"CREATE UNIQUE INDEX uk_process_templates_guid ON process_templates(guid)"#,
-    // —— V90 性能索引（091 性能优化）：服务高频读路径，SQL 不带 IF NOT EXISTS，
-    // 与增量迁移 V90 的 `CREATE INDEX IF NOT EXISTS ...` 经 SQLite 规范化后一致。
-    r#"CREATE INDEX idx_execution_records_workspace_id ON execution_records(workspace_id)"#,
-    r#"CREATE INDEX idx_feishu_messages_bot_chat ON feishu_messages(bot_id, chat_id, created_at DESC)"#,
-    r#"CREATE INDEX idx_loop_executions_task_id ON loop_executions(task_id)"#,
-    r#"CREATE INDEX idx_loop_step_executions_loop_exec ON loop_step_executions(loop_execution_id, sequence_index)"#,
-    r#"CREATE INDEX idx_loop_steps_todo_id ON loop_steps(todo_id)"#,
-    r#"CREATE INDEX idx_loops_process_template_id ON loops(process_template_id)"#,
-    r#"CREATE INDEX idx_loops_workspace_id ON loops(workspace_id)"#,
-    r#"CREATE INDEX idx_skill_invocations_invoked_at ON skill_invocations(invoked_at)"#,
-    r#"CREATE INDEX idx_task_posts_source_execution_id ON task_posts(source_execution_id)"#,
-    r#"CREATE INDEX idx_task_posts_task_parent ON task_posts(task_id, parent_post_id, id)"#,
-    r#"CREATE INDEX idx_tasks_workspace_id ON tasks(workspace_id)"#,
-    r#"CREATE INDEX idx_todos_workspace_id ON todos(workspace_id)"#,
 ];

--- a/backend/src/db/migration/mod.rs
+++ b/backend/src/db/migration/mod.rs
@@ -57,6 +57,8 @@ mod v90;
 mod v91;
 /// v92：tasks/workspace_settings 各加 delegate_max_rounds 列（需求 092 护栏配置化）。
 mod v92;
+/// v93：todos.updated_at 排序索引（093 优化专项：列表 ORDER BY 不再全表扫 + filesort）。
+mod v93;
 
 pub use v2_v5::read_applied_versions;
 pub use v2_v5::drop_column_if_exists;
@@ -187,6 +189,9 @@ pub(super) fn all_migrations() -> Vec<Box<dyn Migration>> {
         // V92 在 V91 之后：tasks/workspace_settings 各加 delegate_max_rounds 列，
         // 把接力上限从写死常量改为「任务覆盖 → 工作空间默认 → 兜底」三级可配置。
         Box::new(v92::V92DelegateMaxRounds),
+        // V93 在 V92 之后：todos.updated_at 排序索引；配套 hours 过滤参数化后
+        // 列表查询「排序 + 时间窗」都走该索引 range scan。
+        Box::new(v93::V93AddTodosUpdatedAtIndex),
     ]
 }
 

--- a/backend/src/db/migration/v93.rs
+++ b/backend/src/db/migration/v93.rs
@@ -1,0 +1,89 @@
+//! 数据库迁移 V93：为 todos.updated_at 增加排序索引。
+//!
+//! ## 背景
+//! Todo 列表/看板是最高频读路径：`get_todos_page_by_workspace` 与 `get_todo_briefs`
+//! 都按 `ORDER BY updated_at DESC` 分页，但 todos 表现有 10 个索引均无 updated_at
+//! （V90 补高频过滤列时独漏排序键；loops 表早有 `idx_loops_updated_at` 先例）。
+//! 每页查询全表扫 + filesort，随数据量增长线性变慢。
+//! 配套改动（同 PR）：hours 过滤从列上套 REPLACE 函数改为参数化裸列比较，
+//! 使本索引同时覆盖「排序 + 时间窗过滤」两条路径。
+//!
+//! ## 幂等
+//! `CREATE INDEX IF NOT EXISTS`，已存在则静默跳过。
+
+use async_trait::async_trait;
+
+use super::super::Database;
+use super::Migration;
+
+pub(super) struct V93AddTodosUpdatedAtIndex;
+
+#[async_trait]
+impl Migration for V93AddTodosUpdatedAtIndex {
+    fn version(&self) -> i64 {
+        93
+    }
+
+    fn name(&self) -> &'static str {
+        "add_todos_updated_at_index"
+    }
+
+    /// 在 updated_at 上建 DESC 索引，与 loops 表 `idx_loops_updated_at` 先例对齐
+    /// （SQLite 对 ASC 索引也能反向扫，功能等价，统一风格优先）。
+    async fn up(&self, db: &Database) -> Result<(), sea_orm::DbErr> {
+        db.exec(
+            "CREATE INDEX IF NOT EXISTS idx_todos_updated_at ON todos(updated_at DESC)",
+        )
+        .await?;
+        tracing::info!("V93: todos.updated_at 索引已创建");
+        Ok(())
+    }
+}
+
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::migration::table_has_column;
+    use crate::db::Database;
+
+    /// 验证 V93 创建索引（通过查询 sqlite_master 间接确认）。
+    #[tokio::test]
+    async fn test_v93_creates_updated_at_index() {
+        use sea_orm::ConnectionTrait;
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+
+        let migration = V93AddTodosUpdatedAtIndex;
+        migration.up(&db).await.expect("V93 migration must succeed");
+
+        // 确认索引存在
+        let row = db
+            .conn
+            .query_one(sea_orm::Statement::from_string(
+                sea_orm::DbBackend::Sqlite,
+                "SELECT COUNT(*) AS cnt FROM sqlite_master \
+                 WHERE type='index' AND name='idx_todos_updated_at'"
+                    .to_string(),
+            ))
+            .await
+            .expect("query must succeed")
+            .expect("row must exist");
+        let cnt: i64 = row.try_get_by("cnt").expect("cnt readable");
+        assert_eq!(cnt, 1, "idx_todos_updated_at 索引应存在");
+    }
+
+    /// 幂等：重复执行不报错。
+    #[tokio::test]
+    async fn test_v93_is_idempotent() {
+        let db = Database::new(":memory:")
+            .await
+            .expect(":memory: db must open");
+        let migration = V93AddTodosUpdatedAtIndex;
+        migration.up(&db).await.expect("first run");
+        migration.up(&db).await.expect("second run (idempotent)");
+        // table_has_column 仅作占位断言，确认库仍可用
+        assert!(table_has_column(&db, "todos", "updated_at").await.unwrap());
+    }
+}

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -543,10 +543,11 @@ impl Database {
             }
         }
         if let Some(h) = hours.filter(|&h| h > 0) {
-            // hours 已验证 > 0 的 u32，format! 是构建 SQL 时间表达式的唯一途径
-            sql.push_str(&format!(
-                " AND REPLACE(REPLACE(updated_at, 'T', ' '), 'Z', '') >= datetime('now', '-{h} hours')"
-            ));
+            // 093：cutoff 在 Rust 侧算好走参数绑定，裸列比较让 idx_todos_updated_at 生效；
+            // 旧写法在列上套 REPLACE 函数，索引恒失效且 datetime('now') 每行求值。
+            // 生产数据统一 T/Z ISO（应用层毫秒 / 触发器秒级），字符串序=时间序（设计 §1.3）。
+            sql.push_str(" AND updated_at >= ?");
+            values.push(crate::models::utc_timestamp_minus_hours(h).into());
         }
         sql.push_str(" ORDER BY updated_at DESC");
         let rows = self
@@ -624,9 +625,9 @@ impl Database {
             cond = cond.and(todos::Column::WorkspaceId.eq(wid));
         }
         if let Some(h) = hours.filter(|&h| h > 0) {
-            cond = cond.and(sea_orm::sea_query::Expr::cust(format!(
-                "REPLACE(REPLACE(updated_at, 'T', ' '), 'Z', '') >= datetime('now', '-{h} hours')"
-            )));
+            // 093：同上——参数化裸列比较，走 idx_todos_updated_at range scan；
+            // NULL updated_at 行在两种写法下都被排除（NULL 比较结果为 NULL），语义不变。
+            cond = cond.and(todos::Column::UpdatedAt.gte(crate::models::utc_timestamp_minus_hours(h)));
         }
         // 先计数再钳页码（CodeRabbit#2）：大 OFFSET 是外部可触发的慢查询
         let total: i64 = todos::Entity::find()
@@ -2650,15 +2651,18 @@ mod todo_center_tests {
         let db = fresh_db().await;
         let recent = seed_todo(&db, "最近").await;
         let old = seed_todo(&db, "老旧").await;
-        // seed_todo 最小列集不带 updated_at（生产由触发器写入），测试显式赋值
+        // seed_todo 最小列集不带 updated_at（生产由触发器写入），测试显式赋值。
+        // 093：格式必须与生产触发器一致（%Y-%m-%dT%H:%M:%SZ 的 T/Z ISO）——
+        // hours 过滤已参数化为 `updated_at >= ?` 裸列比较，datetime('now') 的
+        // 空格分隔格式会在字符串比较中误判（' ' < 'T'），不再被容忍。
         db.exec(&format!(
-            "UPDATE todos SET updated_at = datetime('now') WHERE id = {recent}"
+            "UPDATE todos SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = {recent}"
         ))
         .await
         .unwrap();
-        // 把 old 的 updated_at 改到 10 天前
+        // 把 old 的 updated_at 改到 10 天前（同样用 ISO 格式）
         db.exec(&format!(
-            "UPDATE todos SET updated_at = datetime('now', '-240 hours') WHERE id = {old}"
+            "UPDATE todos SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now','-240 hours') WHERE id = {old}"
         ))
         .await
         .unwrap();

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1365,9 +1365,42 @@ pub fn utc_timestamp() -> String {
     chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string()
 }
 
+/// 093：返回「hours 小时前」的 UTC cutoff，格式与 `utc_timestamp` 完全一致。
+///
+/// 用途：列表 hours 过滤从 `REPLACE(REPLACE(updated_at,...)>= datetime('now',...)`
+/// （列上套函数使索引失效）改为 `updated_at >= ?` 参数绑定裸列比较。
+/// 存储侧格式考据（生产统一 T/Z ISO，见 093 设计文档 §1.3）：
+/// 应用层写入走 `utc_timestamp()`（毫秒精度），触发器兜底走 `%Y-%m-%dT%H:%M:%SZ`
+/// （秒级精度）；两种形态与本 cutoff 做字符串比较在秒级等价于时间比较，
+/// 毫秒边界误差 <1s，对 hours 级过滤可忽略。
+pub fn utc_timestamp_minus_hours(hours: u32) -> String {
+    (chrono::Utc::now() - chrono::Duration::hours(i64::from(hours)))
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string()
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::useless_vec, clippy::redundant_pattern_matching, clippy::redundant_clone, clippy::len_zero, clippy::bool_assert_comparison, clippy::unnecessary_get_then_check, clippy::doc_lazy_continuation, clippy::clone_on_copy, clippy::print_stdout, clippy::needless_pass_by_value, clippy::sliced_string_as_bytes, clippy::manual_map, clippy::collapsible_match, clippy::question_mark)]
 mod tests {
+    /// 093：cutoff helper 的格式契约（与 utc_timestamp 同格式）与时间偏移正确性。
+    #[test]
+    fn test_utc_timestamp_minus_hours_format_and_offset() {
+        let cutoff = super::utc_timestamp_minus_hours(24);
+        // 格式形状必须与 utc_timestamp 一致（毫秒精度 T/Z ISO），否则与存量数据比较失真
+        let re = regex::Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$").unwrap();
+        assert!(re.is_match(&cutoff), "cutoff 格式应为毫秒级 ISO：{cutoff}");
+        // 与「现在」做字符串比较应恒小（同格式 ISO 字符串序 = 时间序），且差值≈24h
+        let now = super::utc_timestamp();
+        assert!(cutoff < now, "24 小时前的 cutoff 应小于当前时间戳");
+        // 解析回时间类型验证差值在容差内（防格式对了但偏移算错）
+        let parsed = chrono::DateTime::parse_from_rfc3339(&cutoff).unwrap();
+        let delta = chrono::Utc::now() - parsed.with_timezone(&chrono::Utc);
+        assert!(
+            delta.num_hours() >= 23 && delta.num_hours() <= 25,
+            "偏移应在 24h±1h 容差内，实际 {delta}"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/backend/tests/dbg_gen_schema.rs
+++ b/backend/tests/dbg_gen_schema.rs
@@ -43,7 +43,8 @@ async fn gen_consolidated_schema() {
         .collect();
 
     let mut out = String::new();
-    out.push_str("//! 合并版最终 schema（v1-v87 全部应用后的状态），供全新库一次性建表（bootstrap）。\n");
+    // 版本号不写死：生成时刻的最新版本即真相，避免头部注释随迁移增长而漂移失真
+    out.push_str("//! 合并版最终 schema（全部迁移应用后的状态），供全新库一次性建表（bootstrap）。\n");
     out.push_str("//! 自动生成：全新库跑完增量迁移后 dump sqlite_master。\n");
     out.push_str("//! 改动任何迁移后需重新生成：`cargo test --test dbg_gen_schema -- --ignored`\n\n");
     out.push_str("pub const CONSOLIDATED_SCHEMA: &[&str] = &[\n");
@@ -59,7 +60,12 @@ async fn gen_consolidated_schema() {
     }
     out.push_str("];\n");
 
-    let path = "/Users/weibh/projects/rust/nothing-todo/backend/src/db/migration/consolidated_schema.rs";
+    // 路径必须相对 CARGO_MANIFEST_DIR（backend/ 目录）推导：原硬编码绝对路径只在
+    // 原作者机器存在，其他人跑生成器会直接 panic（本分支实测）。
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/db/migration/consolidated_schema.rs"
+    );
     fs::write(path, &out).expect("write consolidated_schema.rs");
     eprintln!("GEN OK: {} tables, {} indexes, {} bytes -> {path}", tables.len(), indexes.len(), out.len());
 }

--- a/docs/design/093-todo列表排序索引-设计.md
+++ b/docs/design/093-todo列表排序索引-设计.md
@@ -1,0 +1,101 @@
+# 093-todo列表排序索引-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+
+> 093 优化扫描专项第 3 项。前两项见 `093-首屏bundle瘦身-设计.md`、`093-WS重连日志尾取-设计.md`。
+
+## 1. 背景与问题
+
+Todo 列表/看板是最高频读路径，两个互相关联的问题：
+
+### 1.1 `ORDER BY updated_at DESC` 无索引支撑
+
+`get_todos_page_by_workspace`（列表分页）、`get_todo_briefs`（看板）都按 `updated_at DESC` 排序分页，但 `todos` 表 10 个索引中**没有 updated_at 索引**（`loops` 表已有 `idx_loops_updated_at`，todos 遗漏）。每页查询 = 全表扫 + filesort。V90（091 专项）补了 `todos(workspace_id)` 等 11 个索引，独漏排序键。
+
+### 1.2 hours 过滤在列上套函数，即使有索引也用不上
+
+两处（`db/todo.rs:548` 原生 SQL、`db/todo.rs:628` SeaORM 条件）：
+
+```sql
+REPLACE(REPLACE(updated_at, 'T', ' '), 'Z', '') >= datetime('now', '-{h} hours')
+```
+
+对列做 `REPLACE` 函数运算使索引失效（无法走 range scan），且 `datetime('now', ...)` 每行求值。
+
+### 1.3 为什么现在可以安全参数化（数据格式考据）
+
+旧写法用 REPLACE 归一化是防御混合格式。实测现状：
+
+| 写入方 | 格式 | 出处 |
+|--------|------|------|
+| 应用层 `ActiveModel` | `%Y-%m-%dT%H:%M:%S%.3fZ` | `models::utc_timestamp()` |
+| SQLite 触发器（仅 NULL/空时兜底） | `strftime('%Y-%m-%dT%H:%M:%SZ')` | `migration/v1.rs:226` |
+
+生产库统一为「T/Z ISO」形态，仅精度差（触发器秒级 vs 应用毫秒级）：直接字符串比较在秒级正确，毫秒边界误差 <1s，对 hours 级过滤可忽略。**唯一**写空格格式（`datetime('now')`）的是测试代码（`todo.rs:2655/2661`），应随本 PR 改成与生产一致的 ISO。
+
+NULL 语义不变：旧表达式对 NULL 行比较结果为 NULL（排除），`updated_at >= ?` 同样排除 NULL 行。
+
+## 2. 设计
+
+### C1：迁移 V93 加排序索引
+
+新建 `db/migration/v93.rs`（模板照抄 `v59.rs`）：
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_todos_updated_at ON todos(updated_at DESC)
+```
+
+- 选 `DESC` 与 `loops` 表现存 `idx_loops_updated_at` 先例对齐（SQLite 对 ASC 索引也能反向扫，功能等价，统一风格优先）。
+- 单列表而非 `(workspace_id, updated_at)` 复合：全局列表（无 ws 过滤）与看板（有 ws 过滤）共用此排序键，单列是两者的最大公约数；既有 `idx_todos_workspace_id` 继续服务 ws 过滤。
+- 注册进 `migration/mod.rs` V92 之后；跑 `dbg_gen_schema` 重生成 `consolidated_schema.rs`；漂移守卫 `test_consolidated_schema_matches_incremental` 必须通过。
+- 迁移单测照 v59 范式：索引存在性（sqlite_master）+ 幂等（重复执行不报错）。
+
+### C2：hours 过滤参数化
+
+`models/mod.rs` 新增（与 `utc_timestamp` 相邻，同一格式串）：
+
+```rust
+/// 与 utc_timestamp 同格式，取「hours 小时前」的 UTC  cutoff。
+pub fn utc_timestamp_minus_hours(hours: u32) -> String
+```
+
+两处调用点改为参数绑定：
+
+- `todo.rs:548`（原生 SQL）：`sql.push_str(" AND updated_at >= ?")` + `values.push(cutoff.into())`；
+- `todo.rs:628`（SeaORM）：`cond.and(todos::Column::UpdatedAt.gte(cutoff))`。
+
+效果：`updated_at >= ?` 是裸列比较，配合 C1 索引走 range scan；`ORDER BY ... DESC LIMIT n` 直接读索引尾部。
+
+### C3：既有测试格式对齐
+
+`test_todos_page_by_workspace_hours_and_total` 的 `datetime('now')` 改为 `strftime('%Y-%m-%dT%H:%M:%SZ','now')`（与生产触发器同格式），并补一条「边界外旧行被排除」断言。该测试同时成为 C2 的回归保障。
+
+### C4：`utc_timestamp_minus_hours` 单测
+
+格式形状（正则 `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$`）+ 与 `Utc::now()` 的差值在容差内。
+
+## 3. 影响模块
+
+| 层 | 文件 |
+|----|------|
+| 迁移 | `db/migration/v93.rs`（新）、`migration/mod.rs`（注册）、`consolidated_schema.rs`（生成器重生成） |
+| DB | `db/todo.rs`（2 处查询改造 + 1 处测试格式对齐） |
+| models | `models/mod.rs`（+1 helper +单测） |
+
+## 4. 不做的事（范围边界）
+
+同款 `REPLACE(REPLACE(...)) >= datetime(...)` 反模式还存在于 `execution.rs:237`、`loop_.rs` ×2、`dashboard.rs` ×4、`todo.rs:1935`（finished_at/started_at 列）。那些是聚合统计查询（全表扫由聚合语义决定，索引收益不同），**不在本 PR**，列入后续专项候选。
+
+## 5. 验证方案
+
+1. 迁移：V93 单测（存在性 + 幂等）+ 漂移守卫 + 全新库 bootstrap 路径验证。
+2. 查询：`test_todos_page_by_workspace_hours_and_total` 改格式后通过即证明参数化正确；`EXPLAIN QUERY PLAN` 人工核对走 `idx_todos_updated_at`（开发库验证，文字记录入实现总结）。
+3. `cargo clippy --all-targets -- -D warnings` 零告警；`cargo test` 全绿（预存量环境失败 `git_sync::test_sync_repo_restores_deleted_file` 除外，见 PR#1000 说明）。
+4. `make dev` 起 18088，列表页选「最近 24 小时」过滤，结果正确且无异常日志。
+
+## 6. 安全反思
+
+- 过滤值改参数绑定后**消除了**原来的 `format!` 拼接（原 `h: u32` 类型已免疫注入，改后连类型依赖都不再需要）；
+- 索引只增不删，无数据迁移风险；回滚 = drop index，无状态。

--- a/docs/requirements/093-todo列表排序索引-实现总结.md
+++ b/docs/requirements/093-todo列表排序索引-实现总结.md
@@ -1,0 +1,56 @@
+# 093-todo列表排序索引-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+
+> 对应设计：`docs/design/093-todo列表排序索引-设计.md`。093 优化扫描专项第 3 项。
+
+## 1. 实现了什么
+
+Todo 列表/看板（最高频读路径）的排序与时间窗过滤从「全表扫 + filesort」改为索引 range scan：
+
+1. **新增 `idx_todos_updated_at ON todos(updated_at DESC)`**（迁移 V93）——此前 todos 表 10 个索引独漏排序键；
+2. **hours 过滤参数化**：`REPLACE(REPLACE(updated_at,'T',' '),'Z','') >= datetime('now','-N hours')`（列上套函数，索引恒失效）→ Rust 侧算 cutoff，`updated_at >= ?` 参数绑定裸列比较；
+3. **新增 `models::utc_timestamp_minus_hours`**：cutoff 与存储格式（`utc_timestamp` 毫秒级 ISO / 触发器秒级 ISO）严格同构，字符串序=时间序。
+
+## 2. 与设计的对应关系
+
+| 设计项 | 落地 | 状态 |
+|--------|------|------|
+| C1 迁移 V93 | `db/migration/v93.rs`（仿 v59 模板，存在性+幂等单测）+ 注册 + `consolidated_schema.rs` 重生成 | ✅ |
+| C2 hours 参数化 | `db/todo.rs` 两处（`get_todo_briefs` 原生 SQL / `get_todos_page_by_workspace` SeaORM） | ✅ |
+| C3 测试格式对齐 | `test_todos_page_by_workspace_hours_and_total` 的 `datetime('now')` 改 `strftime('%Y-%m-%dT%H:%M:%SZ')`（与生产触发器同格式） | ✅ |
+| C4 cutoff helper | `models::utc_timestamp_minus_hours` + 格式/偏移单测 | ✅ |
+
+### 顺带修复（实施期发现的工具链 bug）
+
+- `tests/dbg_gen_schema.rs`：**硬编码原作者机器绝对路径**（`/Users/weibh/...`），其他人运行必 panic → 改 `env!("CARGO_MANIFEST_DIR")` 相对推导；头部注释版本号硬编码 `v1-v87` 失真 → 改版本中立表述。
+- 发现生成器工作方式：`Database::new(":memory:")` 走 bootstrap 直接建 consolidated DDL 并盖章最新版本，**新索引必须先手写进 `CONSOLIDATED_SCHEMA` 再跑生成器**归一化（与 091 文档记载的流程一致）。
+
+## 3. 关键实现点
+
+- **NULL 语义不变**：新旧写法对 `updated_at IS NULL` 行都排除（NULL 比较结果为 NULL）。
+- **格式混排边界**：生产库并存毫秒级（应用层）与秒级（触发器）两种 ISO 形态，字符串比较在秒级等价，毫秒边界误差 <1s，hours 级过滤可忽略（设计 §1.3 有完整考据）。
+- **EXPLAIN QUERY PLAN 实测**（1000 行样本库）：`SEARCH todos USING INDEX idx_todos_updated_at (updated_at>?)`——range scan 命中，排序由索引序天然满足，无 filesort。
+
+## 4. 测试与验证结果
+
+- `cargo clippy --all-targets -- -D warnings`：零告警 ✅
+- `cargo test --no-fail-fast`：1710 通过；唯一失败 `git_sync::test_sync_repo_restores_deleted_file` 为预存量环境问题（本机 git 过老不支持 `git init -b`，main 上同样失败）✅
+- 漂移守卫 `test_consolidated_schema_matches_incremental` 与 v67→latest 升级链测试通过 ✅
+- `make dev` 真实库（`~/.ntd/data.dev.db`）端到端验证 ✅：
+  - V93 迁移落库日志可见，schema_version=93；
+  - `GET /api/v1/workspaces/1/todos?hours=96` → total=2（id 8,27，与手工 SQL 推算一致）；`hours=48` → 0（ws 内最近一条在 91h 前，正确排除）；`hours=720` → 10（全量）；
+  - `GET /api/v1/workspaces/1/todos/brief?hours=96` → id [8,27]；无过滤 → 10。
+
+## 5. 已知限制 / 后续候选
+
+- 同款 `REPLACE(REPLACE(...)) >= datetime(...)` 反模式仍存在于 `execution.rs:237`、`loop_.rs:844/1686`、`dashboard.rs` ×4、`todo.rs:1935`（execution_records 的 started_at/finished_at 列）——聚合统计查询为主，列入后续专项候选（设计 §4 已声明不在本 PR）。
+- 复合索引 `(workspace_id, updated_at)` 可进一步覆盖看板过滤+排序，当前数据量（万行级）单列已足，留待数据量增长后评估。
+
+## 6. 安全反思
+
+- 过滤值从 `format!` 拼接（原靠 `u32` 类型免疫注入）改为参数绑定，注入面彻底归零；
+- 迁移只增索引不改数据，回滚 = `DROP INDEX`，无状态风险；
+- 无接口 schema 变化，前端零改动。


### PR DESCRIPTION
## 实现了什么

Todo 列表/看板（最高频读路径）的排序与时间窗过滤改为索引 range scan：

1. **迁移 V93**：`idx_todos_updated_at ON todos(updated_at DESC)`——todos 表 10 个索引独漏排序键（loops 早有先例）；
2. **hours 过滤参数化**：`REPLACE(REPLACE(updated_at,...)>= datetime('now',...)`（列上套函数索引恒失效）→ `updated_at >= ?` 裸列参数绑定；
3. **`models::utc_timestamp_minus_hours`**：cutoff 与存储格式严格同构（考据：应用层毫秒 ISO + 触发器秒级 ISO，字符串序=时间序，边界误差 <1s 可忽略，设计 §1.3）。

EXPLAIN QUERY PLAN 实测：`SEARCH todos USING INDEX idx_todos_updated_at (updated_at>?)`，排序走索引序无 filesort。

## 改动

- `db/migration/v93.rs`（新）+ 注册 + `consolidated_schema.rs` 重生成
- `db/todo.rs` 两处查询改造 + 既有测试格式对齐生产触发器格式
- `models/mod.rs` +1 helper（含单测）
- **顺带修复**：`dbg_gen_schema.rs` 硬编码原作者机器绝对路径（`/Users/weibh/...`，他人运行必 panic）→ `CARGO_MANIFEST_DIR` 相对推导
- 文档：设计 + 实现总结

## 测试

- `cargo clippy --all-targets -- -D warnings` 零告警；`cargo test` 1710 通过（唯一失败为预存量环境问题：本机 git 过老不支持 `git init -b`，main 上同样失败）
- 漂移守卫 + v67→latest 升级链通过；V93 存在性/幂等单测
- dev 真实库端到端：`hours=96` → id [8,27]（与手工推算一致）、`hours=48` → 0（正确排除 91h 前旧行）、`hours=720` → 10；`brief` 路径同步验证

## 范围边界

同款 REPLACE 反模式在 execution/loop_/dashboard 的聚合查询中仍存在，列入后续专项（设计 §4）。