### PR TITLE
refactor(093): useApp 细粒度迁移批次 1——18 个消费方

### DIFF
--- a/docs/design/093-useApp合并context拆分迁移-设计.md
+++ b/docs/design/093-useApp合并context拆分迁移-设计.md
@@ -1,0 +1,81 @@
+# 093-useApp合并context拆分迁移-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本（批次 1） |
+| AI (Pi) | 2026-08-08 | 实施修订：Dashboard 实测跨 todo+exec 两域（解构访问 runningTasks），按双 hook 组合迁移；两个测试文件 mock 目标同步切换 |
+
+> 093 优化扫描专项第 4 项。091 已把 logs 拆出独立 LogsContext，但 `useApp()` 仍合并
+> todoState/execState/uiState 三个域——任一域变化，所有消费方重渲染。
+> 本设计把消费方分批迁移到细粒度 hooks（`useTodos`/`useExecution`/`useUI`）。
+
+## 1. 现状盘点（逐文件 grep 实证）
+
+真实消费方 **24 个文件**（此前估算 55 含 antd `App.useApp()` 误报）：
+
+| 消费内容 | 文件数 | 明细 |
+|---------|-------|------|
+| 仅 `state.selectedWorkspace` / `state.tags`（todo 域） | **18** | Dashboard、SettingsPage、ReferencingLoopsSection、WikiChatFloatingWindow、loop-list/index、LoopListView、RatingDistCard、LoopStatsCard、CronTodosCard、loop-kanban/index、MemorialBoard、RunningRecordDrawer、running-board/index、TodoListPage、TodoListView、TaskDetailPage、ExecutorsPanel、TodoCenterCardView |
+| todo + exec 域 | 3 | TodoDetail（ADD_EXECUTION_RECORD+SELECT_TODO）、KanbanBoard（executionRecords）、ExecutionPanel（exec + REMOVE_TASK_LOGS 走 logs 域） |
+| 全三域 | 2 | App.tsx（组合根）、useExecutionEvents.ts（WS 事件路由 dispatch） |
+
+重渲染放大机制：执行期间 `UPDATE_TASK_TODO_PROGRESS`/`UPDATE_TASK_EXECUTION_STATS`
+（每 10 条日志或工具调用即触发）→ execState 变更 → `useApp` 的合并 state 换新 →
+**全部 24 个消费方重渲染**，包括 18 个只读 workspace 的组件（它们根本不关心执行态）。
+
+## 2. 批次划分
+
+### 批次 1（本 PR）：18 个消费方（17 纯 todo 域 + Dashboard 双域组合）
+
+> 实施修订：Dashboard 经解构 `const { tags, runningTasks } = state` 实际跨 todo+exec 两域
+> （直接访问审计未覆盖解构模式，tsc 编译期暴露），按 `useTodos()` + `useExecution()`
+> 双 hook 组合迁移，仍免订阅 uiState。迁移时注意区分 antd `App.useApp()`（message API）
+> 与项目 `useApp()`——机械替换曾误伤两处，tsc 编译期拦截，已修复并加注释防再犯。
+
+### 批次 1 原清单（17 个纯 todo 域消费方）
+
+机械替换，零行为变化：
+
+```ts
+// 前
+import { useApp } from '@/hooks/useApp';
+const { state } = useApp();
+// 后
+import { useTodos } from '@/hooks/useTodoContext';
+const { state } = useTodos();
+```
+
+dispatch 使用方同样安全（`useTodos()` 返回的 dispatch 即 todo 域 dispatch，类型精确）：
+- WikiChatFloatingWindow：`SELECT_WORKSPACE`（todo 域 action）
+- MemorialBoard：`SELECT_TODO`（todo 域）
+- SettingsPage：`dispatch={dispatch}` 传给 TagsPanel（prop 类型 `any`，且 ADD_TAG/DELETE_TAG 是 todo 域 action）
+
+收益：这 18 个组件不再因 execState（任务进度/统计推送）与 uiState 变化重渲染；
+只剩 todo 域自身变化（切换 workspace/tag）才触发——这正是它们语义上关心的全部。
+
+### 批次 2（后续 PR）：跨域 4 文件
+
+TodoDetail（todo+exec）、KanbanBoard（todo+exec）、ExecutionPanel（exec+logs dispatch）、
+SettingsPage 之外的遗留。每处需显式组合两个 hooks，改动面与回归面更大，单独 PR。
+
+### 不迁移（永久保留 useApp）
+
+- `App.tsx`：组合根，真实消费全三域（runningTasks 决定执行面板、loading 决定骨架屏），拆分无收益；
+- `useExecutionEvents.ts`：WS 事件路由层，需向全域 dispatch，`useApp` 的合并 dispatch 正是为此设计。
+
+## 3. 影响模块
+
+仅前端 18 个组件文件 + 本设计文档。无接口/行为变化。
+
+## 4. 验证方案
+
+1. `npx tsc --noEmit` 零错误（dispatch action 类型不匹配会在编译期暴露）；
+2. `npx vitest run` 全绿；
+3. Playwright 冒烟：首页/列表页/看板/Dashboard 渲染正常，切换 workspace 联动正常；
+4. 重渲染收益验证（文字推演 + 可选 profiler）：执行任务产生日志流时，Dashboard 卡片等
+   18 个组件不再随 `UPDATE_TASK_EXECUTION_STATS` 重渲染。
+
+## 5. 安全反思
+
+纯前端状态订阅路径变更，无数据流/权限/接口变化；dispatch 的 action 路由目标域不变
+（useTodos 的 dispatch 就是 useApp 内部 todo 分支的同一个 reducer dispatch）。

--- a/docs/requirements/093-useApp合并context拆分迁移-实现总结.md
+++ b/docs/requirements/093-useApp合并context拆分迁移-实现总结.md
@@ -1,0 +1,44 @@
+# 093-useApp合并context拆分迁移-实现总结（批次 1）
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 批次 1 完成 |
+
+> 对应设计：`docs/design/093-useApp合并context拆分迁移-设计.md`。093 优化扫描专项第 4 项。
+
+## 1. 实现了什么
+
+`useApp()` 合并三个域 state（todo/exec/ui），任一域变化 → 全部消费方重渲染。执行期间
+`UPDATE_TASK_TODO_PROGRESS`/`UPDATE_TASK_EXECUTION_STATS`（每 10 条日志/工具调用即触发）
+会让只读 workspace 的组件白白重渲染。
+
+批次 1 迁移 **18 个消费方**到细粒度 hooks，它们不再因执行态推送重渲染：
+
+| 迁移方式 | 文件 |
+|---------|------|
+| `useApp()` → `useTodos()`（仅读 selectedWorkspace/tags） | loop-list/index、LoopListView、RatingDistCard、LoopStatsCard、CronTodosCard、loop-kanban/index、RunningRecordDrawer、running-board/index、TodoListPage、TodoListView、TaskDetailPage、ExecutorsPanel、TodoCenterCardView、ReferencingLoopsSection、WikiChatFloatingWindow（SELECT_WORKSPACE）、MemorialBoard（SELECT_TODO）、SettingsPage（dispatch 透传 TagsPanel，prop 类型 any 且 ADD_TAG/DELETE_TAG 属 todo 域） |
+| 双 hook 组合（实测跨域） | Dashboard：`useTodos()`（tags/selectedWorkspace）+ `useExecution()`（runningTasks），免订阅 uiState |
+
+## 2. 实施期发现（已补录设计文档）
+
+1. **Dashboard 跨域**：通过解构 `const { tags, runningTasks } = state` 访问执行域，直接访问审计（`state.X` grep）未覆盖解构模式，tsc 编译期暴露 → 双 hook 组合迁移。
+2. **antd `App.useApp()` 陷阱**：Dashboard/loop-kanban 用 antd message API `App.useApp()`，机械替换误伤 → tsc 拦截，已修复并在两处加「勿混淆」注释。
+3. **测试 mock 切换**：`TodoListPage.test.tsx`、`loop-list/index.test.tsx` 的 `vi.mock('@/hooks/useApp')` 随组件迁移改 mock `@/hooks/useTodoContext`（mock 形状不变）。
+
+## 3. 测试与验证结果
+
+- `npx tsc --noEmit`：零错误 ✅（dispatch action 域不匹配会在编译期暴露，本轮无）
+- `npx vitest run`：32 文件 / 277 用例全绿 ✅
+- Playwright 冒烟（`frontend/tests/093-useapp-batch1-smoke.spec.ts`，vite dev 5173 代理 18088）：
+  首屏/列表页/看板渲染正常、零页面错误 ✅
+- 残留审计：批次 1 文件无 `useApp()` 残留（Dashboard/loop-kanban 的两处为 antd `App.useApp()` message API，有意保留并注释）✅
+
+## 4. 已知限制 / 后续批次
+
+- **批次 2（后续 PR）**：TodoDetail（todo+exec）、KanbanBoard（todo+exec）、ExecutionPanel（exec+logs dispatch）。
+- **永久保留 useApp**：App.tsx（组合根，真实消费全三域）、useExecutionEvents.ts（WS 事件全域 dispatch 路由）。
+- 重渲染收益的量化（profiler 对比）未做，机制层面收益明确：18 个组件的渲染不再挂在 execState 变更链上。
+
+## 5. 安全反思
+
+纯前端状态订阅路径变更；dispatch 路由目标 reducer 不变（useTodos 的 dispatch 即 useApp 内部 todo 分支的同一个）；无接口/权限/数据流变化。

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -21,7 +21,9 @@ import {
 } from '@ant-design/icons';
 import { PageCard } from '@/components/common/PageCard';
 import dayjs from 'dayjs';
-import { useApp } from '@/hooks/useApp';
+// 093：细粒度 hooks 替代合并版 useApp——todo 域与执行域分开订阅，uiState 变化不再触发重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
+import { useExecution } from '@/hooks/useExecutionContext';
 import { useViewState } from '@/hooks/useViewState';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import * as db from '@/utils/database';
@@ -43,9 +45,13 @@ type DashboardTabKey = (typeof DASHBOARD_TABS)[number];
 type IconType = ComponentType<{ style?: CSSProperties }>;
 
 export function Dashboard() {
-  const { state } = useApp();
+  // 093：todo 域（tags）与执行域（runningTasks）分开订阅——Dashboard 真实需要两域，
+  // 但不再订阅与本组件无关的 uiState；antd 的 App.useApp() 是 message API，与本 hook 无关。
+  const { state: todoState } = useTodos();
+  const { state: execState } = useExecution();
   const { message } = App.useApp();
-  const { tags, runningTasks } = state;
+  const { tags } = todoState;
+  const { runningTasks } = execState;
   const { activeTab, pushUrl } = useViewState();
   // Dashboard 是全局运营视图，不依赖当前选中的 workspace；
   // 数据由 /api/v1/stats/dashboard 全库聚合返回。
@@ -85,8 +91,8 @@ export function Dashboard() {
       setStats(data);
       // 056：按最近执行记录的 todo_id 集合拉 brief 反查标题（替代全量 todos）
       const todoIds = [...new Set((data.recent_executions ?? []).map(r => r.todo_id))];
-      if (todoIds.length > 0 && state.selectedWorkspace != null) {
-        const briefs = await db.getTodoBriefs(state.selectedWorkspace, { ids: todoIds }).catch((e) => {
+      if (todoIds.length > 0 && todoState.selectedWorkspace != null) {
+        const briefs = await db.getTodoBriefs(todoState.selectedWorkspace, { ids: todoIds }).catch((e) => {
           console.error('最近执行记录的 todo 标题反查失败:', e);
           return [];
         });

--- a/frontend/src/components/MemorialBoard.tsx
+++ b/frontend/src/components/MemorialBoard.tsx
@@ -10,7 +10,9 @@ import {
 } from '@ant-design/icons';
 import { PageCard } from '@/components/common/PageCard';
 import { TimeRangeSegmented } from '@/components/common/TimeRangeSegmented';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { useViewState, type BoardMode } from '@/hooks/useViewState';
 import { KanbanBoard } from './KanbanBoard';
 import { RunningBoard } from './running-board';
@@ -26,7 +28,7 @@ import type { RecentCompletedTodo, Tag, ExecutionRecord, ProjectDirectory } from
 // 本文件不再内联 TIME_OPTIONS，避免与 kanban/constants 的历史重复问题重演。
 
 export function MemorialBoard() {
-  const { state, dispatch } = useApp();
+  const { state, dispatch } = useTodos();
   const { boardMode, replaceUrl, pushUrl } = useViewState();
   const handleBoardModeChange = (mode: BoardMode) => {
     replaceUrl('memorial', { mode });

--- a/frontend/src/components/RunningRecordDrawer.tsx
+++ b/frontend/src/components/RunningRecordDrawer.tsx
@@ -10,7 +10,9 @@ import {
 import { CopyButton } from '@/components/CopyButton';
 import XMarkdown from '@ant-design/x-markdown';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { useViewState } from '@/hooks/useViewState';
 import { useTodoById } from '@/hooks/useTodoById';
 import { formatLocalDateTime } from '@/utils/datetime';
@@ -133,7 +135,7 @@ export interface RunningRecordDrawerProps {
 }
 
 export function RunningRecordDrawer({ record, open, onClose, onRefresh }: RunningRecordDrawerProps) {
-  const { state } = useApp();
+  const { state } = useTodos();
   const { selectTodo } = useViewState();
   const [stopping, setStopping] = useState(false);
 

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -11,7 +11,9 @@ import {
   DesktopOutlined,
 } from '@ant-design/icons';
 import { PageCard } from '@/components/common/PageCard';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { useViewState } from '@/hooks/useViewState';
 import * as db from '@/utils/database';
 import type { Config, SlashCommandRule } from '@/types';
@@ -27,7 +29,7 @@ import { DEFAULT_EXECUTION_TIMEOUT_SECS } from '@/constants';
 
 /** 设置页，负责加载并保存系统配置以及各类管理面板。 */
 export function SettingsPage() {
-  const { state, dispatch } = useApp();
+  const { state, dispatch } = useTodos();
   const { tags } = state;
   const isMobile = useIsMobile();
 

--- a/frontend/src/components/TodoCenterCardView.tsx
+++ b/frontend/src/components/TodoCenterCardView.tsx
@@ -3,7 +3,9 @@ import { useCallback, useEffect, useState } from 'react';
 import { Empty, Pagination, Segmented, Select, Spin, message } from 'antd';
 import { AppstoreOutlined } from '@ant-design/icons';
 import { TODO_LIST_REFRESH_EVENT } from '@/constants';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { PageCard } from '@/components/common/PageCard';
 import { TodoCenterCard, sourceLabel } from '@/components/TodoCenterCard';
 import * as db from '@/utils/database';
@@ -56,7 +58,7 @@ export function TodoCenterCardView({
   extra,
   refreshKey,
 }: TodoCenterCardViewProps) {
-  const { state } = useApp();
+  const { state } = useTodos();
   // v1 纯 workspace-scoped：selectedWorkspace 必须有值才能拉 todos/center
   const workspaceId = state.selectedWorkspace ?? 0;
 

--- a/frontend/src/components/WikiChatFloatingWindow.tsx
+++ b/frontend/src/components/WikiChatFloatingWindow.tsx
@@ -9,7 +9,9 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { Button, Tooltip, Drawer, Modal, message } from 'antd';
 import { MessageOutlined, CloseOutlined } from '@ant-design/icons';
 import { useTheme } from '@/hooks/useTheme';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { getLastExecutor, setLastExecutor } from '@/constants';
 import { chatWithWiki } from '@/utils/database/blackboard';
@@ -36,7 +38,7 @@ interface WikiChatFloatingWindowProps {
 
 /** 全局 Wiki 对话漂浮窗口主组件 */
 export function WikiChatFloatingWindow({ defaultMode = 'minimized', forceMode, onClose }: WikiChatFloatingWindowProps) {
-  const { state, dispatch } = useApp();
+  const { state, dispatch } = useTodos();
   const { themeMode } = useTheme();
   const isDark = themeMode === 'dark';
   const isMobile = useIsMobile();

--- a/frontend/src/components/dashboard/cards/CronTodosCard.tsx
+++ b/frontend/src/components/dashboard/cards/CronTodosCard.tsx
@@ -5,7 +5,9 @@ import { ClockCircleOutlined } from '@ant-design/icons';
 import { getSchedulerTodos } from '@/utils/database/todos';
 import { formatRelativeTime } from '@/utils/datetime';
 import { useCardData } from '@/components/dashboard/useCardData';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { CardShell } from './CardShell';
 
 // 下次触发时间渲染成相对时间(如「2 小时后」);缺失则该 todo 未真正排程。
@@ -19,7 +21,7 @@ function NextRunTag({ next }: { next: string | null | undefined }) {
 }
 
 export function CronTodosCard() {
-  const { state } = useApp();
+  const { state } = useTodos();
   const wsId = state.selectedWorkspace ?? 0;
   // v1 纯 workspace-scoped：scheduler todos 按 workspace 隔离
   const { data, loading, error } = useCardData(() => getSchedulerTodos(wsId), [wsId]);

--- a/frontend/src/components/dashboard/cards/LoopStatsCard.tsx
+++ b/frontend/src/components/dashboard/cards/LoopStatsCard.tsx
@@ -5,7 +5,9 @@ import { Statistic, Row, Col, Tag } from 'antd';
 import { RetweetOutlined } from '@ant-design/icons';
 import { getLoopStats } from '@/utils/database/loops';
 import { useCardData } from '@/components/dashboard/useCardData';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { CardShell } from './CardShell';
 
 // trigger_type 枚举值 → 中文,提升可读性;未知值原样回退。
@@ -23,7 +25,7 @@ const TRIGGER_LABEL: Record<string, string> = {
 };
 
 export function LoopStatsCard({ hours }: { hours?: number }) {
-  const { state } = useApp();
+  const { state } = useTodos();
   const wsId = state.selectedWorkspace ?? 0;
   const { data, loading, error } = useCardData(() => getLoopStats(wsId, hours), [wsId, hours]);
   // 成功率 = success / total;total=0 时归 0,避免除零。

--- a/frontend/src/components/dashboard/cards/RatingDistCard.tsx
+++ b/frontend/src/components/dashboard/cards/RatingDistCard.tsx
@@ -4,7 +4,9 @@ import { Progress } from 'antd';
 import { StarOutlined } from '@ant-design/icons';
 import { getRecentCompletedTodos } from '@/utils/database/executions';
 import { useCardData } from '@/components/dashboard/useCardData';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { CardShell } from './CardShell';
 
 interface RatingBuckets {
@@ -50,7 +52,7 @@ function RatingBar({ label, count, total, color }: RatingBarProps) {
 }
 
 export function RatingDistCard() {
-  const { state } = useApp();
+  const { state } = useTodos();
   const wsId = state.selectedWorkspace ?? 0;
   const { data, loading, error } = useCardData(() => getRecentCompletedTodos(wsId), [wsId]);
   const buckets = bucketize((data ?? []).map((t) => t.rating));

--- a/frontend/src/components/loop-kanban/index.tsx
+++ b/frontend/src/components/loop-kanban/index.tsx
@@ -11,7 +11,9 @@ import {
   HistoryOutlined,
 } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import type { LoopExecutionDetail, LoopDetail } from '@/types/loop';
 import { StepExecList } from '@/components/loop-studio/executions/StepExecList';
 import { BlackboardDrawer } from '@/components/loop-studio/executions/BlackboardDrawer';
@@ -36,8 +38,9 @@ export function LoopKanban({ searchText: externalSearch, hours: externalHours, o
   const searchText = externalSearch ?? internalSearch;
   const hours = externalHours ?? internalHours;
 
+  // AntApp.useApp() 是 antd 的 message 上下文 API，与项目自建 useApp/useTodos 无关，勿混淆。
   const { message } = AntApp.useApp();
-  const { state } = useApp();
+  const { state } = useTodos();
 
   const { executions, loading } = useLoopExecutions(state.selectedWorkspace ?? null, hours);
   const wsId = state.selectedWorkspace ?? 0;

--- a/frontend/src/components/loop-list/LoopListView.tsx
+++ b/frontend/src/components/loop-list/LoopListView.tsx
@@ -10,7 +10,9 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { Table } from 'antd';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { useBatchActions } from '@/components/todo-list/useBatchActions';
 import { useResizableColumns } from '@/hooks/useResizableColumns';
 import type { Tag as TagType } from '@/types';
@@ -56,7 +58,7 @@ export function LoopListView({
   onToggleStatus,
   onRefresh,
 }: LoopListViewProps) {
-  const { state } = useApp();
+  const { state } = useTodos();
   const workspaceId = state.selectedWorkspace;
   // 行选中态：仅持有 id 列表，由 Table 的 rowSelection 受控
   const [selectedIds, setSelectedIds] = useState<number[]>([]);

--- a/frontend/src/components/loop-list/index.test.tsx
+++ b/frontend/src/components/loop-list/index.test.tsx
@@ -3,8 +3,10 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { LoopListPage } from './index';
 import type { LoopListItem } from '@/types/loop';
 
-vi.mock('@/hooks/useApp', () => ({
-  useApp: () => ({
+// 093：组件已从合并版 useApp 迁移到细粒度 useTodos，mock 目标同步切换；
+// mock 形状不变（useTodos 同样返回 { state, dispatch }，本组件只读 state）。
+vi.mock('@/hooks/useTodoContext', () => ({
+  useTodos: () => ({
     state: {
       selectedWorkspace: 1,
       tags: [],

--- a/frontend/src/components/loop-list/index.tsx
+++ b/frontend/src/components/loop-list/index.tsx
@@ -13,7 +13,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { message } from 'antd';
 import { RetweetOutlined } from '@ant-design/icons';
 import * as dbLoops from '@/utils/database/loops';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { PageCard } from '@/components/common/PageCard';
 import { WorkspaceLoopConfigPage } from '@/components/settings/workspace/WorkspaceLoopConfigPage';
 import { LoopListView } from './LoopListView';
@@ -73,7 +75,7 @@ export function LoopListPage({
   onLoopChanged,
   loopUpdateCount = 0,
 }: LoopListPageProps) {
-  const { state } = useApp();
+  const { state } = useTodos();
   const workspaceId = state.selectedWorkspace;
   const [searchKeyword, setSearchKeyword] = useState('');
 

--- a/frontend/src/components/running-board/index.tsx
+++ b/frontend/src/components/running-board/index.tsx
@@ -6,7 +6,9 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { Tabs, Skeleton, Card, Button } from 'antd';
 import { ReloadOutlined } from '@ant-design/icons';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useViewState } from '@/hooks/useViewState';
 import { RunningRecordDrawer } from '@/components/RunningRecordDrawer';
@@ -29,7 +31,7 @@ export interface RunningBoardProps {
 }
 
 export function RunningBoard({ searchText, hours }: RunningBoardProps = {}) {
-  const { state } = useApp();
+  const { state } = useTodos();
   const { selectTodo } = useViewState();
   const isMobile = useIsMobile();
   const [activeKey, setActiveKey] = useState<RunningBoardColumn>('running');

--- a/frontend/src/components/settings/ExecutorsPanel.tsx
+++ b/frontend/src/components/settings/ExecutorsPanel.tsx
@@ -11,7 +11,9 @@ import { InstallExecutorButton } from '@/components/settings/InstallExecutorButt
 import { getExecutorInstallPrompt } from '@/components/settings/executorInstallPrompts';
 import * as db from '@/utils/database';
 import type { ExecutorConfig, ExecutionRecord, TodoBrief } from '@/types';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { useAutoRefreshRunningBoard } from '@/hooks/useRunningBoard';
 import { SessionManager } from '@/components/SessionManager';
 
@@ -95,7 +97,7 @@ export function ExecutorsPanel() {
   const [usageStatsSaving, setUsageStatsSaving] = useState(false);
 
   // 正在运行 tab 相关状态
-  const { state } = useApp();
+  const { state } = useTodos();
   // 056：运行记录的 todo 标题按 id 集轻量反查（替代原全局全量桶）
   const [recordTodos, setRecordTodos] = useState<TodoBrief[]>([]);
   const [runningTab, setRunningTab] = useState<'executors' | 'running' | 'sessions'>('executors');

--- a/frontend/src/components/tasks/TaskDetailPage.tsx
+++ b/frontend/src/components/tasks/TaskDetailPage.tsx
@@ -8,7 +8,9 @@
 
 import { useState } from 'react';
 import { OrderedListOutlined } from '@ant-design/icons';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { PageCard } from '@/components/common/PageCard';
 import { TaskDetailPanel } from './TaskDetailPanel';
 
@@ -32,7 +34,7 @@ interface TaskDetailPageProps {
 export function TaskDetailPage({
   taskId, onBack, onSelectTodo, onLoopChanged,
 }: TaskDetailPageProps) {
-  const { state } = useApp();
+  const { state } = useTodos();
   const wsId = state.selectedWorkspace ?? 0;
   const [detailTitle, setDetailTitle] = useState<string>(`任务 #${taskId}`);
 

--- a/frontend/src/components/todo-detail/ReferencingLoopsSection.tsx
+++ b/frontend/src/components/todo-detail/ReferencingLoopsSection.tsx
@@ -4,7 +4,9 @@
 // 避免主 todos 列表为它 JOIN 放大；空引用时整体不渲染。
 
 import { useEffect, useState } from 'react';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { useViewState } from '@/hooks/useViewState';
 import { getReferencingLoops } from '@/utils/database/todos';
 import { ReferencingLoops } from '@/components/common/ReferencingLoops';
@@ -15,7 +17,7 @@ interface ReferencingLoopsSectionProps {
 }
 
 export function ReferencingLoopsSection({ todoId }: ReferencingLoopsSectionProps) {
-  const { state } = useApp();
+  const { state } = useTodos();
   // 028：环路详情独立路由 /#/loops/:id，用 pushUrl 让 history.back 回到事项详情
   const { pushUrl } = useViewState();
   // null = 尚未加载完成（不渲染，避免闪烁）；空数组 = 无引用（不渲染）

--- a/frontend/src/components/todo-list/TodoListPage.test.tsx
+++ b/frontend/src/components/todo-list/TodoListPage.test.tsx
@@ -3,8 +3,10 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { TodoListPage } from './TodoListPage';
 import type { TodoCenterItem } from '@/types';
 
-vi.mock('@/hooks/useApp', () => ({
-  useApp: () => ({
+// 093：组件已从合并版 useApp 迁移到细粒度 useTodos，mock 目标同步切换；
+// mock 形状不变（useTodos 同样返回 { state, dispatch }，本组件只读 state）。
+vi.mock('@/hooks/useTodoContext', () => ({
+  useTodos: () => ({
     state: {
       selectedWorkspace: 1,
       tags: [],

--- a/frontend/src/components/todo-list/TodoListPage.tsx
+++ b/frontend/src/components/todo-list/TodoListPage.tsx
@@ -14,7 +14,9 @@ import { useEffect, useState, useCallback } from 'react';
 import { message } from 'antd';
 import { UnorderedListOutlined } from '@ant-design/icons';
 import * as db from '@/utils/database';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { TODO_LIST_REFRESH_EVENT } from '@/constants';
 import { PageCard } from '@/components/common/PageCard';
@@ -137,7 +139,7 @@ export function TodoListPage({
   onOpenCreateModal,
   onEditTodo,
 }: TodoListPageProps) {
-  const { state } = useApp();
+  const { state } = useTodos();
   const workspaceId = state.selectedWorkspace;
   const isMobile = useIsMobile();
 

--- a/frontend/src/components/todo-list/TodoListView.tsx
+++ b/frontend/src/components/todo-list/TodoListView.tsx
@@ -23,7 +23,9 @@ import {
   PlayCircleOutlined,
   ThunderboltOutlined,
 } from '@ant-design/icons';
-import { useApp } from '@/hooks/useApp';
+// 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
+// 执行态（进度/统计推送）变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
 import { useResizableColumns } from '@/hooks/useResizableColumns';
 import { useBatchActions } from './useBatchActions'; // .tsx 含 JSX（批量 Modal）
 import { ExecutorBadge } from '@/components/ExecutorBadge';
@@ -384,7 +386,7 @@ export function TodoListView({
   onExecuteWithArgs,
   onRefresh,
 }: TodoListViewProps) {
-  const { state } = useApp();
+  const { state } = useTodos();
   const workspaceId = state.selectedWorkspace;
   // 行选中态裁剪：items 变化时清掉已消失行
   const { selectedIds, setSelectedIds } = useSelectedIdsClipping(items);

--- a/frontend/tests/093-useapp-batch1-smoke.spec.ts
+++ b/frontend/tests/093-useapp-batch1-smoke.spec.ts
@@ -1,0 +1,33 @@
+// 093 useApp 细粒度迁移批次 1 冒烟：18 个迁移组件覆盖的核心页面渲染与联动。
+// 走 vite dev server（5173，代理 /api 到 18088），验证迁移后组件行为零回归。
+import { test, expect } from '@playwright/test';
+
+const BASE = 'http://localhost:5173';
+
+test('093-b1: 首屏渲染且无页面错误（Dashboard/列表壳）', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  await page.goto(BASE);
+  await expect(page.locator('#root')).not.toBeEmpty({ timeout: 15000 });
+  // 左轨（Dashboard 入口所在壳层）应可见
+  await expect(page.getByTestId('left-rail-help').first()).toBeVisible();
+  expect(errors).toEqual([]);
+});
+
+test('093-b1: 任务列表页（TodoListPage/TodoCenterCardView）渲染', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  await page.goto(`${BASE}/#/todos`);
+  await expect(page.locator('#root')).not.toBeEmpty({ timeout: 15000 });
+  // dev 库 ws=1 有 10 条 todo，列表应渲染出内容（搜索框或卡片任一锚点）
+  await expect(page.locator('#root input, #root .ant-card').first()).toBeVisible({ timeout: 15000 });
+  expect(errors).toEqual([]);
+});
+
+test('093-b1: 看板视图（KanbanBoard 依赖 workspace 联动）渲染', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  await page.goto(`${BASE}/#/kanban`);
+  await expect(page.locator('#root')).not.toBeEmpty({ timeout: 15000 });
+  expect(errors).toEqual([]);
+});


### PR DESCRIPTION
## 实现了什么

`useApp()` 合并 todo/exec/ui 三域 state，任一域变化 → 全部消费方重渲染。执行期间的进度/统计推送（每 10 条日志或工具调用一次）让只读 workspace 的组件白白重渲染。

批次 1 迁移 **18 个消费方**：

- **17 个纯 todo 域** `useApp()` → `useTodos()`：loop-list×2、Dashboard 卡片×3、loop-kanban、RunningRecordDrawer、running-board、TodoListPage、TodoListView、TaskDetailPage、ExecutorsPanel、TodoCenterCardView、ReferencingLoopsSection、WikiChatFloatingWindow、MemorialBoard、SettingsPage
- **Dashboard 双 hook 组合**（实施期发现它经解构访问 runningTasks，真实跨 todo+exec）：`useTodos()` + `useExecution()`，免订阅 uiState

## 实施期发现（tsc 编译期兜底拦截，均已修复）

1. Dashboard 解构 `const { tags, runningTasks } = state` 跨域——直接访问审计未覆盖解构模式；
2. 机械替换误伤 antd `App.useApp()`（message API）两处——已修复并加「勿混淆」注释；
3. 两个测试文件 `vi.mock('@/hooks/useApp')` 随组件切换到 `@/hooks/useTodoContext`。

## 测试

- `npx tsc --noEmit` 零错误；`vitest run` 277 全绿
- Playwright 冒烟 3 项（首屏/列表/看板渲染 + 零页面错误）
- 残留审计：批次 1 文件无项目 `useApp()` 残留

## 后续

- 批次 2：TodoDetail、KanbanBoard、ExecutionPanel（跨 exec/logs 域，单独 PR）
- 永久保留：App.tsx（组合根）、useExecutionEvents.ts（WS 全域 dispatch 路由）