### PR TITLE
fix(012): kilo 系执行器非零退出码误判失败——pipeline 事件回授

### DIFF
--- a/backend/src/adapters/kilo.rs
+++ b/backend/src/adapters/kilo.rs
@@ -199,6 +199,19 @@ impl CodeExecutor for KiloExecutor {
         self.base.model.lock().clone()
     }
 
+    /// NTD-012：pipeline 路径下同步 step 生命周期标记。
+    /// EventPipeline 命中 step_start/step_finish 后旧 `parse_output_line` 被跳过，
+    /// 本钩子把已解析事件回授给执行器，保持 `check_success` 的非零退出码容忍语义。
+    /// 语义与旧 handler 逐字对齐：step_start 重置、step_finish 置位。
+    fn on_pipeline_event(&self, event: &crate::execution_events::ExecutionEvent) {
+        use crate::execution_events::ExecutionEvent as E;
+        match event {
+            E::StepStart { .. } => *self.has_successful_finish.lock() = false,
+            E::StepFinish { .. } => *self.has_successful_finish.lock() = true,
+            _ => {}
+        }
+    }
+
     fn check_success(&self, exit_code: i32) -> bool {
         if exit_code == 0 {
             return true;

--- a/backend/src/adapters/mimo.rs
+++ b/backend/src/adapters/mimo.rs
@@ -268,6 +268,19 @@ impl CodeExecutor for MimoExecutor {
     /// MiMo 可能返回非零退出码（如被信号打断），但只要收到了 step_finish 事件就算成功。
     /// 这是因为 MiMo 内部使用小米模型，某些错误（如模型响应超时）会导致非零退出码，
     /// 但实际任务已经完成，此时以 step_finish 事件为准。
+    /// NTD-012：pipeline 路径下同步 step 生命周期标记。
+    /// EventPipeline 命中 step_start/step_finish 后旧 `parse_output_line` 被跳过，
+    /// 本钩子把已解析事件回授给执行器，保持 `check_success` 的非零退出码容忍语义。
+    /// 语义与旧 handler 逐字对齐：step_start 重置、step_finish 置位。
+    fn on_pipeline_event(&self, event: &crate::execution_events::ExecutionEvent) {
+        use crate::execution_events::ExecutionEvent as E;
+        match event {
+            E::StepStart { .. } => *self.has_successful_finish.lock() = false,
+            E::StepFinish { .. } => *self.has_successful_finish.lock() = true,
+            _ => {}
+        }
+    }
+
     fn check_success(&self, exit_code: i32) -> bool {
         if exit_code == 0 {
             return true;

--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -357,6 +357,16 @@ pub trait CodeExecutor: Send + Sync {
     /// 解析输出行，返回解析后的日志条目
     fn parse_output_line(&self, line: &str) -> Option<ParsedLogEntry>;
 
+    /// NTD-012：pipeline 命中时回授结构化事件，维持执行器内部生命周期状态。
+    ///
+    /// 背景：stdout 每行先试 EventPipeline，命中即跳过旧 `parse_output_line`。
+    /// kilo/mimo/opencode/zhanlu 的 step_finish 副作用（has_successful_finish 标记）
+    /// 不再触发，非零退出码容忍（check_success）随之失效，成功任务被误判失败。
+    /// 本钩子在事件广播前把已解析好的 ExecutionEvent 回授给执行器——比重新调
+    /// parse_output_line 便宜（无二次 JSON 解析，也不产生重复日志条目）。
+    /// 默认空实现：不依赖流式副作用状态的执行器（claude_code/codex/hermes 等）无需理会。
+    fn on_pipeline_event(&self, _event: &crate::execution_events::ExecutionEvent) {}
+
     /// 解析 stderr 行，返回解析后的日志条目。返回 None 表示作为普通 stderr 处理。
     ///
     /// 默认返回 `None`，与 main 一致；具体 executor 若希望复用关键字分类（"error"

--- a/backend/src/adapters/opencode.rs
+++ b/backend/src/adapters/opencode.rs
@@ -205,6 +205,19 @@ impl CodeExecutor for OpencodeExecutor {
         self.base.model.lock().clone()
     }
 
+    /// NTD-012：pipeline 路径下同步 step 生命周期标记。
+    /// EventPipeline 命中 step_start/step_finish 后旧 `parse_output_line` 被跳过，
+    /// 本钩子把已解析事件回授给执行器，保持 `check_success` 的非零退出码容忍语义。
+    /// 语义与旧 handler 逐字对齐：step_start 重置、step_finish 置位。
+    fn on_pipeline_event(&self, event: &crate::execution_events::ExecutionEvent) {
+        use crate::execution_events::ExecutionEvent as E;
+        match event {
+            E::StepStart { .. } => *self.has_successful_finish.lock() = false,
+            E::StepFinish { .. } => *self.has_successful_finish.lock() = true,
+            _ => {}
+        }
+    }
+
     fn check_success(&self, exit_code: i32) -> bool {
         if exit_code == 0 {
             return true;

--- a/backend/src/adapters/zhanlu.rs
+++ b/backend/src/adapters/zhanlu.rs
@@ -206,6 +206,19 @@ impl CodeExecutor for ZhanluExecutor {
         self.base.model.lock().clone()
     }
 
+    /// NTD-012：pipeline 路径下同步 step 生命周期标记。
+    /// EventPipeline 命中 step_start/step_finish 后旧 `parse_output_line` 被跳过，
+    /// 本钩子把已解析事件回授给执行器，保持 `check_success` 的非零退出码容忍语义。
+    /// 语义与旧 handler 逐字对齐：step_start 重置、step_finish 置位。
+    fn on_pipeline_event(&self, event: &crate::execution_events::ExecutionEvent) {
+        use crate::execution_events::ExecutionEvent as E;
+        match event {
+            E::StepStart { .. } => *self.has_successful_finish.lock() = false,
+            E::StepFinish { .. } => *self.has_successful_finish.lock() = true,
+            _ => {}
+        }
+    }
+
     fn check_success(&self, exit_code: i32) -> bool {
         if exit_code == 0 {
             return true;

--- a/backend/src/executor_service/log_capture.rs
+++ b/backend/src/executor_service/log_capture.rs
@@ -126,6 +126,10 @@ pub(crate) fn parse_and_broadcast(
     tx: &broadcast::Sender<ExecEvent>,
     task_id: &str,
     workspace_id: Option<i64>,
+    // NTD-012：pipeline 命中后旧 parse_output_line 被跳过，执行器的流式副作用
+    // （如 kilo 系的 has_successful_finish）随之失效；每个新事件在广播前回授给
+    // 执行器，让其内部状态与事件流保持同步（零重复解析）。
+    executor: &dyn crate::adapters::CodeExecutor,
 ) -> Vec<ParsedLogEntry> {
     let line_trimmed = line.trim();
     if line_trimmed.is_empty() {
@@ -146,6 +150,9 @@ pub(crate) fn parse_and_broadcast(
 
     let mut results = Vec::new();
     for event in &new_events {
+        // NTD-012：先回授再按类型广播——即使某类事件不转发（如 Info/Progress），
+        // 执行器也能观察到完整的生命周期序列（StepStart 重置依赖这一点）。
+        executor.on_pipeline_event(event);
         match event {
             ExecutionEvent::Info { message } => {
                 // 空的或纯 JSON 行作为 info，不转发
@@ -196,6 +203,8 @@ fn try_parse_stderr_with_pipeline(
     tx: &broadcast::Sender<ExecEvent>,
     task_id: &str,
     workspace_id: Option<i64>,
+    // NTD-012：与 stdout 路径同理，stderr 经 pipeline 产出的事件也要回授执行器。
+    executor: &dyn crate::adapters::CodeExecutor,
 ) -> Vec<ParsedLogEntry> {
     let line_trimmed = line.trim();
     if line_trimmed.is_empty() {
@@ -213,7 +222,11 @@ fn try_parse_stderr_with_pipeline(
 
     pipeline.events()[len_before..]
         .iter()
-        .map(|event| emit_broadcast_event(event, tx, task_id, workspace_id))
+        .map(|event| {
+            // NTD-012：stderr 事件同样回授执行器（部分执行器版本把 step_finish 打到 stderr）
+            executor.on_pipeline_event(event);
+            emit_broadcast_event(event, tx, task_id, workspace_id)
+        })
         .collect()
 }
 
@@ -249,7 +262,7 @@ where
                 }
                 // 优先尝试用 EventPipeline 解析
                 let parsed_list =
-                    try_parse_stderr_with_pipeline(&mut pipeline, &line, &tx, &task_id, workspace_id);
+                    try_parse_stderr_with_pipeline(&mut pipeline, &line, &tx, &task_id, workspace_id, executor.as_ref());
 
                 if !parsed_list.is_empty() {
                     for parsed in parsed_list {
@@ -344,7 +357,7 @@ where
         while let Ok(Some(line)) = reader.next_line().await {
             // 优先尝试用 EventPipeline 解析
             let parsed_list =
-                parse_and_broadcast(&mut pipeline, &line, &tx_clone, &tid, wid);
+                parse_and_broadcast(&mut pipeline, &line, &tx_clone, &tid, wid, executor_clone.as_ref());
 
             if !parsed_list.is_empty() {
                 for parsed in parsed_list {
@@ -746,5 +759,40 @@ mod tests {
         assert_eq!(stats.tool_calls, 5); // overridden
         assert_eq!(stats.conversation_turns, 0);
         assert_eq!(stats.thinking_count, 0);
+    }
+
+    /// NTD-012 回归：pipeline 处理 step_finish 后必须回授执行器生命周期状态。
+    ///
+    /// 还原真实运行时组合：KiloExtractor 完整解析 step-finish（pipeline 恒命中、
+    /// 旧 parse_output_line 被跳过）→ 若缺少回授，has_successful_finish 不置位，
+    /// check_success(144) 把成功任务误判为失败。修复后事件回授置位 flag。
+    #[test]
+    fn test_parse_and_broadcast_syncs_executor_success_flag() {
+        use crate::adapters::kilo::KiloExecutor;
+        use crate::execution_events::impls::kilo::KiloExtractor;
+
+        let executor = KiloExecutor::new("kilo".to_string());
+        let mut pipeline = EventPipeline::with_extractor(KiloExtractor::new());
+        let (tx, _rx) = broadcast::channel(16);
+
+        // 修复前的事实：未走任何解析时，非零退出码判定为失败
+        assert!(!executor.check_success(144), "step_finish 未到达前应判失败");
+
+        let finish_line = r#"{"type":"step-finish","timestamp":1700000000002,"part":{"type":"step-finish","reason":"stop","tokens":{"total":200,"input":150,"output":50,"reasoning":0,"cache":{"read":10,"write":5}},"cost":0.0025}}"#;
+        let out = parse_and_broadcast(&mut pipeline, finish_line, &tx, "t1", None, &executor);
+        assert!(!out.is_empty(), "KiloExtractor 应完整解析 step-finish（pipeline 命中）");
+        assert!(
+            executor.check_success(144),
+            "step_finish 经 pipeline 回授后置位 flag，非零退出码应判成功（NTD-012）"
+        );
+
+        // step-start 重置语义同样经回授生效（与旧 handler 逐字对齐）
+        let start_line = r#"{"type":"step-start","timestamp":1777471473403,"sessionID":"ses_abc123"}"#;
+        let out2 = parse_and_broadcast(&mut pipeline, start_line, &tx, "t1", None, &executor);
+        assert!(!out2.is_empty());
+        assert!(
+            !executor.check_success(144),
+            "新一轮 step_start 应重置 flag（回授覆盖重置路径）"
+        );
     }
 }

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -1035,8 +1035,9 @@ fn process_executor_stdout_line(
         return;
     }
     // 非私聊场景：走标准流程，调用 parse_and_broadcast 发送 Output 事件
+    // NTD-012：传入 executor 让 pipeline 事件回授（step_finish 成功标记等生命周期状态同步）
     let parsed_list = log_capture::parse_and_broadcast(
-        pipeline, line, tx, task_id, workspace_id,
+        pipeline, line, tx, task_id, workspace_id, executor.as_ref(),
     );
     if !parsed_list.is_empty() {
         result.logs.extend(parsed_list);

--- a/docs/bugs/012-kilo系执行器非零退出码被误判失败/012-kilo系执行器非零退出码被误判失败-修复总结.md
+++ b/docs/bugs/012-kilo系执行器非零退出码被误判失败/012-kilo系执行器非零退出码被误判失败-修复总结.md
@@ -1,0 +1,44 @@
+# 012-kilo系执行器非零退出码被误判失败-修复总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+
+> 缺陷说明 / 缺陷分析见同目录前文。本缺陷在 093 优化扫描专项第 5 项（执行器双解析体系盘点）中发现。
+
+## 1. 修复方案（对应分析文档方案 C）
+
+新增 `CodeExecutor::on_pipeline_event` 观察钩子，把 pipeline 已解析的 `ExecutionEvent` 在广播前回授给执行器，恢复被跳过的流式副作用状态同步：
+
+| 文件 | 改动 |
+|------|------|
+| `adapters/mod.rs` | trait 新增 `on_pipeline_event` 默认空实现（不依赖流式状态的 9 个执行器无感） |
+| `adapters/{kilo,mimo,opencode,zhanlu}.rs` | 实现钩子：`StepStart → flag=false`、`StepFinish → flag=true`（与旧 handler 语义逐字对齐） |
+| `executor_service/log_capture.rs` | `parse_and_broadcast` / `try_parse_stderr_with_pipeline` 增加 `executor` 参数，事件广播前回授；stdout/stderr 两个 reader 调用点同步 |
+| `services/message_debounce.rs` | 标准广播路径调用点同步传 executor |
+
+## 2. 为什么选这个方案
+
+- **零重复解析**：事件已由 pipeline 解析，回授只是方法调用；备选方案 A（命中后再调旧 `parse_output_line`）每行二次 JSON 解析且会产生重复日志条目；
+- **语义零漂移**：钩子实现与旧 handler 的 flag 操作逐字对齐，`check_success` 判定逻辑不变；
+- **影响面可控**：默认空实现，其余 9 个执行器与全部调用方行为不变。
+
+## 3. 验证结果
+
+- **回归测试** `test_parse_and_broadcast_syncs_executor_success_flag`（log_capture 测试区）：
+  真实组合 `KiloExtractor` pipeline 处理 step-finish → 断言 `check_success(144)` 由 false 变 true；
+  step-start 重置路径同样覆盖。
+- **有效性反证**：临时注释回授调用后该测试稳定失败（证明测试确实守着缺陷，非空断言），恢复后通过。
+- `cargo clippy --all-targets -- -D warnings`：零告警 ✅
+- `cargo test --no-fail-fast`：1708 通过；唯一失败 `git_sync::test_sync_repo_restores_deleted_file` 为预存量环境问题（本机 git 过老不支持 `git init -b`，main 同样失败）✅
+
+## 4. 已知残留与后续
+
+- **pi 执行器**的 `full_text`/`session_id` 缓存同属旧路径副作用，但其 `get_final_result` 有 logs 兜底（降级但正确），不构成功能缺陷，未在本 PR 处理。
+- **双解析体系彻底收敛**（删除旧 `parse_output_line`/`parse_stderr_line` trait 方法）是 093 专项后续多 PR 工程，需逐执行器核对协议覆盖差异（盘点矩阵见缺陷分析文档）。
+- `parse_for_direct_stream`（飞书私聊直连路径）未接回授：该路径无进程退出码判定场景，刻意不接，避免无谓耦合。
+
+## 5. 安全反思
+
+- 钩子只读事件不写外部状态（4 个实现仅操作内存 flag，parking_lot Mutex 无 await 持锁问题）；
+- 无接口/权限/数据流变化；误判方向是把成功判失败，修复不产生反向误判（无 step_finish 的真实失败仍判失败，回归测试覆盖）。

--- a/docs/bugs/012-kilo系执行器非零退出码被误判失败/012-kilo系执行器非零退出码被误判失败-缺陷分析.md
+++ b/docs/bugs/012-kilo系执行器非零退出码被误判失败/012-kilo系执行器非零退出码被误判失败-缺陷分析.md
@@ -1,0 +1,66 @@
+# 012-kilo系执行器非零退出码被误判失败-缺陷分析
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+
+## 1. 根因
+
+项目存在新旧两套输出解析体系（093 扫描确认的架构问题）：
+
+- **旧**：`CodeExecutor::parse_output_line` → `ParsedLogEntry`（各 adapter 实现，含**副作用**）
+- **新**：`EventExtractor` → `EventPipeline` → `ExecutionEvent`（`execution_events/impls/`）
+
+运行时路径（`executor_service/log_capture.rs:344-392`）：**pipeline 优先，命中即 `continue`，旧路径被跳过**。
+
+问题出在 4 个执行器（kilo/mimo/opencode/zhanlu）的 `parse_output_line` 携带关键副作用：
+
+```rust
+// adapters/kilo.rs:95-101（mimo/opencode/zhanlu 同构）
+fn handle_step_finish(...) {
+    *self.has_successful_finish.lock() = true;   // ← 副作用：成功标记
+    ...
+}
+
+fn check_success(&self, exit_code: i32) -> bool {
+    if exit_code == 0 { return true; }
+    *self.has_successful_finish.lock()           // ← 退出判定时读取
+}
+```
+
+而这 4 个执行器的新 Extractor **完整处理 step_finish**（发出 StepFinish/Tokens/Cost 事件）→
+pipeline 恒命中 → `parse_output_line` 永不被调用 → `has_successful_finish` 永远保持 `false`
+→ 非零退出时 `check_success` 返回 `false` → **误判失败**。
+
+## 2. 为什么单测没拦住
+
+各 adapter 的既有单测直接调用 `parse_output_line`（旧路径），flag 正常置位；
+没有任何测试走「pipeline 处理 step_finish → check_success」的真实运行时组合路径。
+
+## 3. 证据链
+
+1. `log_capture.rs:347` `parse_and_broadcast(...)` 返回非空即 `continue`（跳过旧路径）；
+2. `execution_events/impls/kilo.rs:58` step_finish 分支产出 `StepFinish`+`Tokens`+`Cost` 事件（非空）；
+3. `kilo.rs:202-207` `check_success` 非零退出码依赖 flag；
+4. flag 全链路唯一写入点是 `parse_output_line` → `handle_step_finish`；
+5. `spawn_lifecycle.rs:641` 完成判定时 `executor.check_success(exit_code)`。
+
+## 4. 修复方案选型
+
+| 方案 | 判断 |
+|------|------|
+| A. pipeline 命中后也回退调用 `parse_output_line` | ❌ 每行二次 JSON 解析，且会让日志条目重复（旧路径也产出 entry） |
+| B. `check_success` 改为完成时扫 logs 找 step_finish | ❌ 改 4 个执行器的判定语义，且 logs snapshot 在 `resolve_exit_outcome` 之后才提取（`spawn_lifecycle.rs:615-624`），顺序要倒过来，影响面大 |
+| C. **trait 加 `on_pipeline_event` 观察钩子**（采用） | ✅ pipeline 事件本来就已解析好，回授给执行器同步状态，零重复解析；默认空实现，其余 9 个执行器无感 |
+
+### 采用方案 C 的改动点
+
+1. `CodeExecutor` trait 新增默认空方法 `on_pipeline_event(&self, _event: &ExecutionEvent)`；
+2. kilo/mimo/opencode/zhanlu 实现该钩子：`StepStart → flag=false`，`StepFinish → flag=true`（与旧 handler 语义逐字对齐）；
+3. `log_capture::parse_and_broadcast` 与 `try_parse_stderr_with_pipeline` 增加 `executor` 参数，事件广播前回授；`message_debounce.rs:1038` 调用点同步适配。
+
+## 5. 已知残留（不在本缺陷范围，记录在案）
+
+pi 执行器的 `full_text`/`session_id` 缓存也是旧路径副作用，pipeline 命中后同样跳过——但
+`get_final_result` 有 logs 兜底分支（`pi.rs:377-386` 注释明示），属「降级但正确」，不构成功能缺陷。
+双解析体系的彻底收敛（删旧 trait 方法）是 093 专项后续多 PR 工程。

--- a/docs/bugs/012-kilo系执行器非零退出码被误判失败/012-kilo系执行器非零退出码被误判失败-缺陷说明.md
+++ b/docs/bugs/012-kilo系执行器非零退出码被误判失败/012-kilo系执行器非零退出码被误判失败-缺陷说明.md
@@ -1,0 +1,45 @@
+# 012-kilo系执行器非零退出码被误判失败-缺陷说明
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+
+## 1. Bug 基本信息
+
+- Bug ID：NTD-012
+- 所属系统：backend（executor_service / adapters）
+- 首次发现时间：2026-08-08
+- 发现来源：代码审查（093 优化扫描专项第 5 项「执行器双解析体系」盘点过程中）
+- 当前状态：已确认存在
+
+## 2. Bug 是否被确认存在
+
+- [x] Bug 已被稳定复现（代码路径推演 + 单元级复现测试）
+
+### 2.1 复现环境
+
+- 环境类型：生产 / 开发均存在
+- Commit：main @ 67c5d924（091 性能优化合入后）
+- 相关配置：使用 kilo / mimo / opencode / zhanlu 四个执行器之一
+
+## 3. 触发条件（最小条件集合）
+
+1. 任务使用 kilo / mimo / opencode / zhanlu 执行器；
+2. 执行器正常输出 JSONL（`step_finish` 事件被新 EventPipeline 成功解析——**这是 pipeline 引入后的恒成立条件**）；
+3. 进程以非零退出码结束（kilo 已知会返回 144 等；mimo 文档记载模型超时也会非零退出）。
+
+## 4. 现象（What）
+
+- **期望**：进程非零退出但收到了 `step_finish` 事件 → 任务判定为**成功**（4 个执行器 `check_success` 的明确设计语义：「非零退出码但有 finish 事件就算成功」）。
+- **实际**：任务被判定为**失败**。
+
+## 5. 影响范围
+
+- 受影响的执行器：kilo、mimo、opencode、zhanlu（4 个共享同一协议族的执行器）。
+- 不受影响：claude_code、codex、hermes、kimi、pi、atomcode、codebuddy、codewhale、mobilecoder（`check_success` 不依赖流式副作用状态）。
+- 用户可感知后果：任务实际完成但状态被标记失败，可能触发不必要的自动返工/重试逻辑。
+
+## 6. 边界（何时不成立）
+
+- 退出码为 0 时不受影响（`check_success` 首行直接返回 true）。
+- 进程被 kill / 无 step_finish 事件的真实失败场景不受影响（误判方向是把成功判成失败，不是反过来）。


### PR DESCRIPTION
## 缺陷（093 扫描盘点双解析体系时发现，代码路径推演 + 单测复现确认）

kilo / mimo / opencode / zhanlu 四个执行器的 `check_success` 设计语义是「非零退出码（如 144）但收到 step_finish 事件即算成功」。但运行时每行输出先试 EventPipeline，命中即跳过旧 `parse_output_line`——而这四个执行器的新 Extractor **完整处理 step_finish**，pipeline 恒命中 → 旧路径的 `has_successful_finish` 副作用永不再触发 → 非零退出恒判失败。

**用户可感知后果**：任务实际完成却被标记失败，可能触发不必要的自动返工。

## 修复

新增 `CodeExecutor::on_pipeline_event` 观察钩子（默认空实现），pipeline 事件广播前回授给执行器同步生命周期状态：

- 4 个执行器实现 `StepStart → flag=false / StepFinish → flag=true`（与旧 handler 逐字对齐）
- `parse_and_broadcast` / `try_parse_stderr_with_pipeline` 广播前回授；3 个调用点适配
- 零重复解析（事件已解析好，回授仅一次方法调用）；其余 9 个执行器行为不变

## 验证

- 回归测试 `test_parse_and_broadcast_syncs_executor_success_flag`：真实 pipeline 组合下 `check_success(144)` 由 false→true，step_start 重置路径同覆盖
- **反证有效**：临时注释回授调用后测试稳定失败，恢复后通过
- clippy 零告警；cargo test 1708 通过（唯一失败为预存量环境问题：本机 git 过老不支持 `git init -b`，main 同样失败）

## 文档

`docs/bugs/012-kilo系执行器非零退出码被误判失败/`（缺陷说明 / 缺陷分析 / 修复总结三件套）。pi 执行器同类副作用（full_text 缓存）有 logs 兜底、降级但正确，记录在案未处理；双解析体系彻底收敛为后续多 PR 工程。