### PR TITLE
refactor(093-B4): Extractor 注册表化——新增执行器从改 5 处变为加 1 行

### DIFF
--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -22,6 +22,10 @@ pub struct ExecutorDef {
     pub session_dir: &'static str,
     /// Aliases that can be used to refer to this executor
     pub aliases: &'static [&'static str],
+    /// 093-B4：该执行器的事件提取器工厂（双解析体系收敛的注册点）。
+    /// 非捕获闭包强制转换为 fn 指针，因此可放入静态表；
+    /// 新增执行器只需在本表挂一行，不再修改任何 match。
+    pub create_extractor: fn() -> Box<dyn crate::execution_events::EventExtractor>,
 }
 
 impl ExecutorDef {
@@ -42,6 +46,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "claude",
         session_dir: "~/.claude",
         aliases: &["claude", "claude_code"],
+        create_extractor: || Box::new(crate::execution_events::impls::claude_code::ClaudeCodeExtractor::new()),
     },
     ExecutorDef {
         name: "codebuddy",
@@ -51,6 +56,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "codebuddy",
         session_dir: "~/.codebuddy",
         aliases: &["cbc"],
+        create_extractor: || Box::new(crate::execution_events::impls::codebuddy::CodebuddyExtractor::new()),
     },
     ExecutorDef {
         name: "opencode",
@@ -60,6 +66,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "opencode",
         session_dir: "~/.opencode",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::opencode::OpencodeExtractor::new()),
     },
     ExecutorDef {
         name: "atomcode",
@@ -69,6 +76,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "atomcode",
         session_dir: "~/.atomcode",
         aliases: &["atom"],
+        create_extractor: || Box::new(crate::execution_events::impls::atomcode::AtomcodeExtractor::new()),
     },
     ExecutorDef {
         name: "hermes",
@@ -78,6 +86,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "hermes",
         session_dir: "~/.hermes",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::hermes::HermesExtractor::new()),
     },
     ExecutorDef {
         name: "kimi",
@@ -87,6 +96,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "kimi",
         session_dir: "~/.kimi",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::kimi::KimiExtractor::new()),
     },
     ExecutorDef {
         name: "mobilecoder",
@@ -96,6 +106,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "mobile",
         session_dir: "~/.mobile-coder",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::mobilecoder::MobilecoderExtractor::new()),
     },
     ExecutorDef {
         name: "codex",
@@ -105,6 +116,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "codex",
         session_dir: "~/.codex",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::codex::CodexExtractor::new()),
     },
     ExecutorDef {
         name: "codewhale",
@@ -114,6 +126,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "codewhale",
         session_dir: "~/.codewhale",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::codewhale::CodewhaleExtractor::new()),
     },
     ExecutorDef {
         name: "pi",
@@ -123,6 +136,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "pi",
         session_dir: "~/.pi",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::pi::PiExtractor::new()),
     },
     ExecutorDef {
         name: "mimo",
@@ -132,6 +146,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "mimo",
         session_dir: "~/.local/share/mimocode",
         aliases: &["mimocode"],
+        create_extractor: || Box::new(crate::execution_events::impls::mimo::MimoExtractor::new()),
     },
     ExecutorDef {
         name: "zhanlu",
@@ -141,6 +156,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "zl",
         session_dir: "~/.local/share/zhanlu/storage",
         aliases: &["zhanlucode", "zl"],
+        create_extractor: || Box::new(crate::execution_events::impls::zhanlu::ZhanluExtractor::new()),
     },
     ExecutorDef {
         // Kilo: 与 Opencode/Zhanlu 一致的开源 AI 编程执行器。
@@ -153,6 +169,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "kilo",
         session_dir: "~/.kilo",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::kilo::KiloExtractor::new()),
     },
 ];
 
@@ -168,6 +185,13 @@ pub const DEFAULT_EXECUTOR: &str = "claudecode";
 /// Find executor definition by name or alias
 pub fn find_executor(name: &str) -> Option<&'static ExecutorDef> {
     EXECUTORS.iter().find(|e| e.matches(name))
+}
+
+/// 093-B4：按 ExecutorType 反查注册项。
+/// Extractor 工厂查表（create_pipeline_for_executor）与 display_name 查表
+/// （handlers/skills.rs）共用此入口——注册表是执行器元数据的唯一事实源。
+pub fn find_executor_by_type(executor_type: ExecutorType) -> Option<&'static ExecutorDef> {
+    EXECUTORS.iter().find(|e| e.executor_type == executor_type)
 }
 
 /// Parse executor string (with aliases) into `ExecutorType`.

--- a/backend/src/execution_events/pipeline.rs
+++ b/backend/src/execution_events/pipeline.rs
@@ -36,6 +36,15 @@ impl EventPipeline {
         }
     }
 
+    /// 093-B4：从已装箱的 trait 对象构造（注册表工厂返回 `Box<dyn EventExtractor>`）。
+    /// 与 `with_extractor` 并存：泛型版服务具名构造点，本版服务注册表查表路径。
+    pub fn with_boxed_extractor(extractor: Box<dyn EventExtractor>) -> Self {
+        Self {
+            extractor,
+            events: Vec::new(),
+        }
+    }
+
     /// 处理一行标准输出
     pub fn feed(&mut self, line: &str) {
         let new_events = self.extractor.extract(line);

--- a/backend/src/executor_service/log_capture.rs
+++ b/backend/src/executor_service/log_capture.rs
@@ -18,15 +18,11 @@ use tokio::task::JoinHandle;
 
 use crate::adapters::CodeExecutor;
 use crate::db::Database;
-use crate::execution_events::{
-    AtomcodeExtractor, ClaudeCodeExtractor, CodebuddyExtractor, CodewhaleExtractor,
-    CodexExtractor, DbLogEntry, EventPipeline, ExecutionEvent,
-    HermesExtractor, KiloExtractor, KimiExtractor, MimoExtractor, MobilecoderExtractor,
-    OpencodeExtractor, PiExtractor, ZhanluExtractor,
-};
+// 093-B4：13 个 Extractor 的直接导入已随 match 塌缩删除——构造职责移交注册表工厂。
+use crate::execution_events::{DbLogEntry, EventPipeline, ExecutionEvent};
 use crate::executor_service::ExecEvent;
 use crate::log_flusher::LogFlusher;
-use crate::models::{ExecutorType, ParsedLogEntry};
+use crate::models::ParsedLogEntry;
 
 /// 触发 `Output` 事件的 helper：忽略 send 失败（无订阅者 = 没人想看，不算错误）。
 pub(crate) fn send_event(tx: &broadcast::Sender<ExecEvent>, event: ExecEvent) {
@@ -38,52 +34,10 @@ pub(crate) fn send_event(tx: &broadcast::Sender<ExecEvent>, event: ExecEvent) {
 /// pub(crate) 是为了让 message_debounce.rs 中的 executor 默认响应路径也能复用
 /// 同一套 pipeline 创建逻辑，避免每个调用方各自硬编码 executor 类型 → 提取器映射。
 pub(crate) fn create_pipeline_for_executor(executor: &dyn CodeExecutor) -> Option<EventPipeline> {
-    let executor_type = executor.executor_type();
-
-    // 根据执行器类型选择合适的提取器
-    let pipeline = match executor_type {
-        ExecutorType::Claudecode => {
-            EventPipeline::with_extractor(ClaudeCodeExtractor::new())
-        }
-        ExecutorType::Kilo => {
-            EventPipeline::with_extractor(KiloExtractor::new())
-        }
-        ExecutorType::Opencode => {
-            EventPipeline::with_extractor(OpencodeExtractor::new())
-        }
-        ExecutorType::Codex => {
-            EventPipeline::with_extractor(CodexExtractor::new())
-        }
-        ExecutorType::Hermes => {
-            EventPipeline::with_extractor(HermesExtractor::new())
-        }
-        ExecutorType::Kimi => {
-            EventPipeline::with_extractor(KimiExtractor::new())
-        }
-        ExecutorType::Pi => {
-            EventPipeline::with_extractor(PiExtractor::new())
-        }
-        ExecutorType::Mobilecoder => {
-            EventPipeline::with_extractor(MobilecoderExtractor::new())
-        }
-        ExecutorType::Atomcode => {
-            EventPipeline::with_extractor(AtomcodeExtractor::new())
-        }
-        ExecutorType::Zhanlu => {
-            EventPipeline::with_extractor(ZhanluExtractor::new())
-        }
-        ExecutorType::Codewhale => {
-            EventPipeline::with_extractor(CodewhaleExtractor::new())
-        }
-        ExecutorType::Mimo => {
-            EventPipeline::with_extractor(MimoExtractor::new())
-        }
-        ExecutorType::Codebuddy => {
-            EventPipeline::with_extractor(CodebuddyExtractor::new())
-        }
-    };
-
-    Some(pipeline)
+    // 093-B4：13 臂 match 已收敛进注册表——ExecutorDef.create_extractor 工厂指针。
+    // 新增执行器只在 EXECUTORS 静态表挂一行，不再触碰本函数。
+    let def = crate::adapters::find_executor_by_type(executor.executor_type())?;
+    Some(EventPipeline::with_boxed_extractor((def.create_extractor)()))
 }
 
 /// 将 ExecutionEvent 转换为 ParsedLogEntry 并发送 Output 事件

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -149,21 +149,11 @@ pub(crate) fn resolve_skill_path_for_read(base: &Path, skill_name: &str) -> Resu
 }
 
 fn executor_label(et: ExecutorType) -> &'static str {
-    match et {
-        ExecutorType::Claudecode => "Claude Code",
-        ExecutorType::Hermes => "Hermes",
-        ExecutorType::Codex => "Codex",
-        ExecutorType::Codebuddy => "CodeBuddy",
-        ExecutorType::Opencode => "Opencode",
-        ExecutorType::Atomcode => "AtomCode",
-        ExecutorType::Kimi => "Kimi",
-        ExecutorType::Mobilecoder => "MobileCoder",
-        ExecutorType::Codewhale => "CodeWhale",
-        ExecutorType::Pi => "Pi",
-        ExecutorType::Mimo => "MiMo",
-        ExecutorType::Zhanlu => "Zhanlu",
-        ExecutorType::Kilo => "Kilo",
-    }
+    // 093-B4：原 13 臂 match 与 ExecutorDef.display_name 逐字重复，删除改查注册表；
+    // 查不到时回退规范名（as_str），比 panic 宽容且不会返回空串。
+    crate::adapters::find_executor_by_type(et)
+        .map(|d| d.display_name)
+        .unwrap_or_else(|| et.as_str())
 }
 
 // 仅用于本文件 tests 模块的数组完整性自检（元素齐全 / 无重复 / 含 Kilo）；
@@ -1465,6 +1455,24 @@ mod tests {
     #[test]
     fn test_executor_label_kilo() {
         assert_eq!(executor_label(ExecutorType::Kilo), "Kilo");
+    }
+
+    /// 093-B4：label 改查注册表后，补「每个 ExecutorType 都有注册项 + 工厂可构造」断言——
+    /// 这是「新增执行器忘注册/忘挂工厂」的回归守卫。
+    #[test]
+    fn test_every_executor_type_registered_with_factory() {
+        for et in [
+            ExecutorType::Claudecode, ExecutorType::Hermes, ExecutorType::Codex,
+            ExecutorType::Codebuddy, ExecutorType::Opencode, ExecutorType::Atomcode,
+            ExecutorType::Kimi, ExecutorType::Mobilecoder, ExecutorType::Codewhale,
+            ExecutorType::Pi, ExecutorType::Mimo, ExecutorType::Zhanlu, ExecutorType::Kilo,
+        ] {
+            let def = crate::adapters::find_executor_by_type(et)
+                .unwrap_or_else(|| panic!("{et:?} 未在 EXECUTORS 注册表"));
+            assert!(!def.display_name.is_empty());
+            // 工厂必须能构造出提取器（验证 create_extractor 已正确挂载）
+            let _extractor = (def.create_extractor)();
+        }
     }
 
     #[test]

--- a/docs/design/093-Extractor注册表化-设计.md
+++ b/docs/design/093-Extractor注册表化-设计.md
@@ -1,0 +1,72 @@
+# 093-Extractor注册表化-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+
+> 093 专项 B4（重构批次 4）。源自 skill 扫描诊断第 4 条：Repeated Switches + Shotgun Surgery——
+> `ExecutorType` 大 match 散落多处，新增执行器要同步修改 N 个文件。
+
+## 1. 现状与证据
+
+| 位置 | match 职责 | 处置 |
+|------|-----------|------|
+| `log_capture.rs::create_pipeline_for_executor` | 13 臂 match 构造对应 Extractor | **本 PR 收敛进注册表** |
+| `handlers/skills.rs::executor_label` | 13 臂 match 返回显示名 | **纯重复**（`ExecutorDef.display_name` 逐字相同），本 PR 删除改查表 |
+| `models/mod.rs::ExecutorType::as_str` | 枚举自身的规范名映射 | **保留**——这是枚举的固有方法，是单一事实源而非重复 |
+
+项目已有 `ExecutorDef` 静态注册表（`EXECUTORS: &[ExecutorDef]`，含 name/executor_type/binary_name/display_name/session_dir/aliases）——注册点早就存在，只是没挂 Extractor。
+
+## 2. 设计
+
+### C1：`ExecutorDef` 挂提取器工厂
+
+```rust
+pub struct ExecutorDef {
+    ...
+    /// 093-B4：该执行器的事件提取器工厂（双解析体系收敛的注册点）。
+    /// 非捕获闭包强制转换为 fn 指针，可放入静态表。
+    pub create_extractor: fn() -> Box<dyn EventExtractor>,
+}
+```
+
+`EXECUTORS` 13 个条目各挂 `|| Box::new(XxxExtractor::new())`。
+
+### C2：注册表查询 + pipeline 构造塌缩
+
+```rust
+/// 按 ExecutorType 反查注册项（registry 反向索引）
+pub fn find_executor_by_type(et: ExecutorType) -> Option<&'static ExecutorDef>
+```
+
+`create_pipeline_for_executor` 从 13 臂 match（~45 行）塌缩为：
+
+```rust
+let def = find_executor_by_type(executor.executor_type())?;
+Some(EventPipeline::with_boxed_extractor((def.create_extractor)()))
+```
+
+`EventPipeline` 新增 `with_boxed_extractor(Box<dyn EventExtractor>)` 构造（与既有 `with_extractor(impl)` 并存——注册表只能返回 trait 对象）。
+
+### C3：删除 `executor_label`
+
+`skills.rs` 的调用点改 `crate::adapters::find_executor(et.as_str()).map(|d| d.display_name).unwrap_or(et.as_str())`（找不到时回退规范名，比 panic 宽容）；其测试同步改为断言注册表覆盖（保留「新增执行器忘注册」的回归守卫语义）。
+
+## 3. 影响模块
+
+`adapters/mod.rs`（ExecutorDef+EXECUTORS+find_executor_by_type）、`execution_events/pipeline.rs`（+with_boxed_extractor）、`executor_service/log_capture.rs`（match 塌缩）、`handlers/skills.rs`（删 executor_label+测试改断言）。
+
+## 4. 收益与后续
+
+- 新增第 14 个执行器：从「改 5+ 处」变「EXECUTORS 加一行」；
+- 为双解析体系收敛铺路：旧 `parse_output_line` 删除后，执行器与解析的关联点只剩注册表一处。
+
+## 5. 验证方案
+
+1. 既有 log_capture / execution_events / skills 测试全绿；
+2. 新增断言：13 个 ExecutorType 全部能在注册表查到且工厂可构造（防漏挂）；
+3. clippy 零告警；假执行器冒烟（沿用 B2/B3 方法）。
+
+## 6. 安全反思
+
+纯构造路径重构；工厂返回的 Extractor 实例与原 match 构造完全一致；无接口/行为变化。

--- a/docs/requirements/093-Extractor注册表化-实现总结.md
+++ b/docs/requirements/093-Extractor注册表化-实现总结.md
@@ -1,0 +1,40 @@
+# 093-Extractor注册表化-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+
+> 对应设计：`docs/design/093-Extractor注册表化-设计.md`。093 专项 B4（重构批次 4），
+> 消除 Repeated Switches / Shotgun Surgery：新增执行器从「改 5+ 处」变「注册表加一行」。
+
+## 1. 实现了什么
+
+| 变化 | 位置 |
+|------|------|
+| `ExecutorDef` 新增 `create_extractor: fn() -> Box<dyn EventExtractor>` 工厂字段 | `adapters/mod.rs` |
+| `EXECUTORS` 13 条目全部挂载对应 Extractor 工厂（非捕获闭包→fn 指针入静态表） | `adapters/mod.rs` |
+| 新增 `find_executor_by_type()` 注册表反查 | `adapters/mod.rs` |
+| `EventPipeline::with_boxed_extractor()`（与泛型 `with_extractor` 并存） | `execution_events/pipeline.rs` |
+| `create_pipeline_for_executor`：13 臂 match（~45 行）→ 查表 3 行 | `log_capture.rs` |
+| 删除 `skills.rs::executor_label`（与 `ExecutorDef.display_name` 逐字重复的 13 臂 match） | `handlers/skills.rs` |
+
+## 2. 与设计对应 / 关键实现点
+
+- `models/mod.rs::ExecutorType::as_str` 按设计**保留**（枚举固有方法，是规范名单一事实源，非重复）；
+- `executor_label` 删除后查表 + `as_str()` 回退（比 panic 宽容，不返回空串）；
+- 新增回归守卫测试 `test_every_executor_type_registered_with_factory`：13 个 ExecutorType 全部可查表且工厂可构造——「新增执行器忘注册/忘挂工厂」编译期之外的最后防线。
+
+## 3. 测试与验证结果
+
+- `cargo clippy --all-targets -- -D warnings`：零告警 ✅
+- `cargo test --no-fail-fast`：1714 通过（唯一失败为预存量环境问题 git_sync）✅
+- 假执行器端到端冒烟：注册表工厂构造的 pipeline 全链路正确（session_start→assistant→text→session_end 落库）✅
+
+## 4. 收益与后续
+
+- 新增第 14 个执行器：`EXECUTORS` 加一行（name + 类型 + 工厂同挂一处），不再触碰任何 match；
+- 双解析体系彻底收敛的落点已就位：旧 `parse_output_line` 删除后，执行器↔解析关联只剩注册表。
+
+## 5. 安全反思
+
+纯构造路径重构；工厂产出实例与原 match 构造完全一致；无接口/行为变化。


### PR DESCRIPTION
## 实现了什么

消除 Repeated Switches / Shotgun Surgery：`ExecutorType` 大 match 散落，新增执行器要同步改多文件。

- `ExecutorDef` 挂 `create_extractor` 工厂指针（非捕获闭包→fn 指针入静态表），13 条目全挂载
- `create_pipeline_for_executor`：13 臂 match（~45 行）→ 注册表查表 3 行
- 删除 `skills.rs::executor_label`（与 `ExecutorDef.display_name` 逐字重复的 match）
- 新增 `find_executor_by_type` 反查 + `EventPipeline::with_boxed_extractor`
- 保留 `ExecutorType::as_str`（枚举固有方法，规范名唯一事实源，非重复）

## 回归守卫

新增测试：13 个 ExecutorType 全部可查表且工厂可构造——「新增执行器忘注册/忘挂工厂」的最后防线。

## 测试

- clippy 零告警；cargo test 1714 通过（唯一失败为预存量环境问题）
- 假执行器端到端冒烟：注册表工厂构造的 pipeline 全链路正确

## 后续

双解析体系彻底收敛的落点已就位：旧 parse_output_line 删除后，执行器↔解析关联只剩注册表一处。

文档：docs/design/093-Extractor注册表化-设计.md + docs/requirements/093-Extractor注册表化-实现总结.md