### PR TITLE
refactor(093-B5): handler 层 SQL 下沉为 DAO，消除 2 处 format! 拼接

### DIFF
--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -22,6 +22,10 @@ pub struct ExecutorDef {
     pub session_dir: &'static str,
     /// Aliases that can be used to refer to this executor
     pub aliases: &'static [&'static str],
+    /// 093-B4：该执行器的事件提取器工厂（双解析体系收敛的注册点）。
+    /// 非捕获闭包强制转换为 fn 指针，因此可放入静态表；
+    /// 新增执行器只需在本表挂一行，不再修改任何 match。
+    pub create_extractor: fn() -> Box<dyn crate::execution_events::EventExtractor>,
 }
 
 impl ExecutorDef {
@@ -42,6 +46,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "claude",
         session_dir: "~/.claude",
         aliases: &["claude", "claude_code"],
+        create_extractor: || Box::new(crate::execution_events::impls::claude_code::ClaudeCodeExtractor::new()),
     },
     ExecutorDef {
         name: "codebuddy",
@@ -51,6 +56,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "codebuddy",
         session_dir: "~/.codebuddy",
         aliases: &["cbc"],
+        create_extractor: || Box::new(crate::execution_events::impls::codebuddy::CodebuddyExtractor::new()),
     },
     ExecutorDef {
         name: "opencode",
@@ -60,6 +66,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "opencode",
         session_dir: "~/.opencode",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::opencode::OpencodeExtractor::new()),
     },
     ExecutorDef {
         name: "atomcode",
@@ -69,6 +76,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "atomcode",
         session_dir: "~/.atomcode",
         aliases: &["atom"],
+        create_extractor: || Box::new(crate::execution_events::impls::atomcode::AtomcodeExtractor::new()),
     },
     ExecutorDef {
         name: "hermes",
@@ -78,6 +86,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "hermes",
         session_dir: "~/.hermes",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::hermes::HermesExtractor::new()),
     },
     ExecutorDef {
         name: "kimi",
@@ -87,6 +96,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "kimi",
         session_dir: "~/.kimi",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::kimi::KimiExtractor::new()),
     },
     ExecutorDef {
         name: "mobilecoder",
@@ -96,6 +106,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "mobile",
         session_dir: "~/.mobile-coder",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::mobilecoder::MobilecoderExtractor::new()),
     },
     ExecutorDef {
         name: "codex",
@@ -105,6 +116,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "codex",
         session_dir: "~/.codex",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::codex::CodexExtractor::new()),
     },
     ExecutorDef {
         name: "codewhale",
@@ -114,6 +126,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "codewhale",
         session_dir: "~/.codewhale",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::codewhale::CodewhaleExtractor::new()),
     },
     ExecutorDef {
         name: "pi",
@@ -123,6 +136,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "pi",
         session_dir: "~/.pi",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::pi::PiExtractor::new()),
     },
     ExecutorDef {
         name: "mimo",
@@ -132,6 +146,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "mimo",
         session_dir: "~/.local/share/mimocode",
         aliases: &["mimocode"],
+        create_extractor: || Box::new(crate::execution_events::impls::mimo::MimoExtractor::new()),
     },
     ExecutorDef {
         name: "zhanlu",
@@ -141,6 +156,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "zl",
         session_dir: "~/.local/share/zhanlu/storage",
         aliases: &["zhanlucode", "zl"],
+        create_extractor: || Box::new(crate::execution_events::impls::zhanlu::ZhanluExtractor::new()),
     },
     ExecutorDef {
         // Kilo: 与 Opencode/Zhanlu 一致的开源 AI 编程执行器。
@@ -153,6 +169,7 @@ pub static EXECUTORS: &[ExecutorDef] = &[
         default_path: "kilo",
         session_dir: "~/.kilo",
         aliases: &[],
+        create_extractor: || Box::new(crate::execution_events::impls::kilo::KiloExtractor::new()),
     },
 ];
 
@@ -168,6 +185,13 @@ pub const DEFAULT_EXECUTOR: &str = "claudecode";
 /// Find executor definition by name or alias
 pub fn find_executor(name: &str) -> Option<&'static ExecutorDef> {
     EXECUTORS.iter().find(|e| e.matches(name))
+}
+
+/// 093-B4：按 ExecutorType 反查注册项。
+/// Extractor 工厂查表（create_pipeline_for_executor）与 display_name 查表
+/// （handlers/skills.rs）共用此入口——注册表是执行器元数据的唯一事实源。
+pub fn find_executor_by_type(executor_type: ExecutorType) -> Option<&'static ExecutorDef> {
+    EXECUTORS.iter().find(|e| e.executor_type == executor_type)
 }
 
 /// Parse executor string (with aliases) into `ExecutorType`.

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -762,6 +762,24 @@ impl Database {
         Ok(())
     }
 
+    /// 093-B5：删除早于 cutoff 的执行日志，返回实际删除行数。
+    ///
+    /// 从 `handlers/backup.rs::cleanup_old_logs` 下沉的 DAO（分层规范：handler 不写 SQL）。
+    /// 两个修法一并落地：cutoff 走参数绑定（原 format! 拼接，违反禁止清单 #4）；
+    /// 行数取 `ExecResult::rows_affected`（原额外跑一条 `SELECT changes()`）。
+    /// cutoff 与 timestamp 列同为 ISO8601 字符串，字典序即时间序。
+    pub async fn delete_execution_logs_before(&self, cutoff: &str) -> Result<u64, sea_orm::DbErr> {
+        let res = self
+            .conn
+            .execute(sea_orm::Statement::from_sql_and_values(
+                sea_orm::DbBackend::Sqlite,
+                "DELETE FROM execution_logs WHERE timestamp < ?",
+                [cutoff.into()],
+            ))
+            .await?;
+        Ok(res.rows_affected())
+    }
+
     /// 分页获取执行日志
     pub async fn get_execution_logs(
         &self,
@@ -1898,6 +1916,25 @@ mod center_aggregate_tests {
         ))
         .await
         .expect("insert log");
+    }
+
+    /// 093-B5：delete_execution_logs_before——参数化删除 + rows_affected 返回真实行数。
+    #[tokio::test]
+    async fn test_delete_execution_logs_before_cutoff() {
+        let db = fresh_db().await;
+        let t = seed_todo(&db, "T").await;
+        seed_exec(&db, t, "success", "manual").await; // record id=1
+        // 两条旧日志（10 天前）+ 一条新日志（现在）
+        db.exec("INSERT INTO execution_logs (record_id, timestamp, log_type, content) VALUES (1, '2026-07-01T00:00:00Z', 'info', 'old1')").await.unwrap();
+        db.exec("INSERT INTO execution_logs (record_id, timestamp, log_type, content) VALUES (1, '2026-07-02T00:00:00Z', 'info', 'old2')").await.unwrap();
+        db.exec("INSERT INTO execution_logs (record_id, timestamp, log_type, content) VALUES (1, '2026-08-08T00:00:00Z', 'info', 'new')").await.unwrap();
+
+        let deleted = db.delete_execution_logs_before("2026-08-01T00:00:00Z").await.unwrap();
+        assert_eq!(deleted, 2, "应删除两条旧日志");
+        // 幂等边界：再删一次为 0；新日志仍在
+        assert_eq!(db.delete_execution_logs_before("2026-08-01T00:00:00Z").await.unwrap(), 0);
+        let remaining = db.count_execution_logs_for_records(&[1]).await.unwrap();
+        assert_eq!(remaining.get(&1).copied(), Some(1), "新日志不应被删");
     }
 
     /// count_execution_logs_for_records：GROUP BY 聚合计数（093 WS 重连 log_total 数据源）。

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -771,12 +771,19 @@ impl Database {
     pub async fn delete_execution_logs_before(&self, cutoff: &str) -> Result<u64, sea_orm::DbErr> {
         let res = self
             .conn
+            // from_sql_and_values 走参数绑定：cutoff 不进 SQL 文本，
+            // 从根上消除拼接注入面（禁止清单 #4），也不再依赖调用方的格式转义
             .execute(sea_orm::Statement::from_sql_and_values(
+                // 本项目的生产/开发/测试库均为 SQLite，固定 DbBackend::Sqlite
+                // 而非从连接探测——省一次运行时判断，语义显式
                 sea_orm::DbBackend::Sqlite,
                 "DELETE FROM execution_logs WHERE timestamp < ?",
                 [cutoff.into()],
             ))
+            // `?` 传播错误：handler 侧原样转成 String 错误文案，语义与旧路径一致
             .await?;
+        // rows_affected 取自同一 statement 的执行结果；旧实现另跑 SELECT changes()
+        // 在连接池下可能落到不同连接而取错行数，此处一并修正
         Ok(res.rows_affected())
     }
 
@@ -1924,7 +1931,7 @@ mod center_aggregate_tests {
         let db = fresh_db().await;
         let t = seed_todo(&db, "T").await;
         seed_exec(&db, t, "success", "manual").await; // record id=1
-        // 两条旧日志（10 天前）+ 一条新日志（现在）
+        // 造 2 旧 1 新三条日志：验证边界「早于 cutoff 才删」两侧都覆盖到
         db.exec("INSERT INTO execution_logs (record_id, timestamp, log_type, content) VALUES (1, '2026-07-01T00:00:00Z', 'info', 'old1')").await.unwrap();
         db.exec("INSERT INTO execution_logs (record_id, timestamp, log_type, content) VALUES (1, '2026-07-02T00:00:00Z', 'info', 'old2')").await.unwrap();
         db.exec("INSERT INTO execution_logs (record_id, timestamp, log_type, content) VALUES (1, '2026-08-08T00:00:00Z', 'info', 'new')").await.unwrap();

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -837,8 +837,11 @@ impl Database {
         limit: u64,
     ) -> Result<Vec<loop_executions::Model>, sea_orm::DbErr> {
         loop_executions::Entity::find()
+            // task_id 走 SeaORM 表达式编译期生成参数绑定，替代原 format! 拼接
             .filter(loop_executions::Column::TaskId.eq(task_id))
+            // 详情页语义是「最近」：按开始时间倒序，最新的排最前
             .order_by_desc(loop_executions::Column::StartedAt)
+            // limit 由调用方给（现固定 20）：DAO 不硬编码页大小，保持复用性
             .limit(limit)
             .all(&self.conn)
             .await
@@ -851,14 +854,19 @@ impl Database {
         &self,
         step_execution_id: i64,
     ) -> Result<Option<String>, sea_orm::DbErr> {
+        // 第一跳：step_execution 找不到说明 artifact 挂着孤儿外键，
+        // 转 RecordNotFound 让 handler 映射 404——与原 handler 内联实现语义逐字一致
         let se = loop_step_executions::Entity::find_by_id(step_execution_id)
             .one(&self.conn)
             .await?
             .ok_or(sea_orm::DbErr::RecordNotFound("step_exec not found".into()))?;
+        // 第二跳：loop_execution 断链同样报 NotFound（数据异常，不外露为 panic）
         let le = loop_executions::Entity::find_by_id(se.loop_execution_id)
             .one(&self.conn)
             .await?
             .ok_or(sea_orm::DbErr::RecordNotFound("loop_exec not found".into()))?;
+        // 第三跳取 loops.workspace_path；保留 Option 原样返回
+        // （调用方 unwrap_or_default 兜空串，与原 handler 行为一致）
         let lp = loops::Entity::find_by_id(le.loop_id)
             .one(&self.conn)
             .await?
@@ -2402,7 +2410,8 @@ mod loop_stats_tests {
     async fn test_list_recent_loop_executions_for_task() {
         let db = fresh_db().await;
         let lp = seed_loop_status(&db, "L", "enabled").await;
-        // 两条挂在 task 7、一条挂在 task 8（task_id 直插，绕开 seed helper 的列集）
+        // 两条挂在 task 7、一条挂在 task 8（task_id 直插，绕开 seed helper 的列集）；
+        // 时间梯度 -2h/-1h/now：同时验证「按 task 过滤」与「倒序」两个断言的数据前提
         for (task, expr) in [(7, "datetime('now','-2 hours')"), (7, "datetime('now','-1 hours')"), (8, "datetime('now')")] {
             db.exec(&format!(
                 "INSERT INTO loop_executions (loop_id, trigger_type, status, started_at, task_id) \
@@ -2436,7 +2445,7 @@ mod loop_stats_tests {
 
         let path = db.get_artifact_workspace_path(se_id).await.unwrap();
         assert_eq!(path, Some("/ws/path".to_string()));
-        // 断链：不存在的 step_execution_id → RecordNotFound
+        // 断链边界：不存在的 step_execution_id → RecordNotFound（handler 据此映射 404）
         assert!(db.get_artifact_workspace_path(99999).await.is_err());
     }
 

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -2407,7 +2407,7 @@ mod loop_stats_tests {
 
     /// 093-B5：list_recent_loop_executions_for_task——按 task_id 过滤、started_at 倒序、limit 生效。
     #[tokio::test]
-    async fn test_list_recent_loop_executions_for_task() {
+    async fn test_list_recent_loop_executions_for_task_filters_orders_and_limits() {
         let db = fresh_db().await;
         let lp = seed_loop_status(&db, "L", "enabled").await;
         // 两条挂在 task 7、一条挂在 task 8（task_id 直插，绕开 seed helper 的列集）；
@@ -2430,8 +2430,12 @@ mod loop_stats_tests {
     }
 
     /// 093-B5：get_artifact_workspace_path——三级跳返回 loop 的 workspace_path；断链报 NotFound。
+    /// 断链覆盖说明（CodeRabbit #1010 评审）：仅第一级（step_execution 不存在）可测——
+    /// 后两级断链（loop_execution/loop 缺失）在 PRAGMA foreign_keys=ON + ON DELETE CASCADE
+    /// 下不可达（孤儿行插不进、父行删除会级联清子行），对应 RecordNotFound 分支为
+    /// 防御性代码，防未来 FK 策略变化，非当前可达路径。
     #[tokio::test]
-    async fn test_get_artifact_workspace_path() {
+    async fn test_get_artifact_workspace_path_returns_path_and_errors_when_chain_is_broken() {
         let db = fresh_db().await;
         db.exec("INSERT INTO loops (name, workspace_path) VALUES ('L', '/ws/path')").await.expect("insert loop");
         let loop_id = max_id(&db, "loops").await;

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -828,6 +828,44 @@ impl Database {
         loop_executions::Entity::find_by_id(id).one(&self.conn).await
     }
 
+    /// 093-B5：任务详情页用的「最近 N 条 loop 执行记录」（从 handlers/tasks.rs 下沉）。
+    /// 原 handler 侧是 `format!("... WHERE task_id={}")` 拼接 SQL（违反禁止清单 #4），
+    /// 下沉同时改为 SeaORM 参数绑定查询。
+    pub async fn list_recent_loop_executions_for_task(
+        &self,
+        task_id: i64,
+        limit: u64,
+    ) -> Result<Vec<loop_executions::Model>, sea_orm::DbErr> {
+        loop_executions::Entity::find()
+            .filter(loop_executions::Column::TaskId.eq(task_id))
+            .order_by_desc(loop_executions::Column::StartedAt)
+            .limit(limit)
+            .all(&self.conn)
+            .await
+    }
+
+    /// 093-B5：由 artifact 反查所属工作空间路径（从 handlers/tasks.rs 下沉的三级跳查询）。
+    /// artifact → step_execution → loop_execution → loop 取 workspace_path；
+    /// 纯搬移不改逻辑（保持逐跳 find 与原 NotFound 语义），JOIN 优化留待后续。
+    pub async fn get_artifact_workspace_path(
+        &self,
+        step_execution_id: i64,
+    ) -> Result<Option<String>, sea_orm::DbErr> {
+        let se = loop_step_executions::Entity::find_by_id(step_execution_id)
+            .one(&self.conn)
+            .await?
+            .ok_or(sea_orm::DbErr::RecordNotFound("step_exec not found".into()))?;
+        let le = loop_executions::Entity::find_by_id(se.loop_execution_id)
+            .one(&self.conn)
+            .await?
+            .ok_or(sea_orm::DbErr::RecordNotFound("loop_exec not found".into()))?;
+        let lp = loops::Entity::find_by_id(le.loop_id)
+            .one(&self.conn)
+            .await?
+            .ok_or(sea_orm::DbErr::RecordNotFound("loop not found".into()))?;
+        Ok(lp.workspace_path)
+    }
+
     pub async fn list_loop_executions(
         &self,
         loop_id: i64,
@@ -2357,6 +2395,49 @@ mod loop_stats_tests {
         ))
         .await
         .expect("insert step_execution");
+    }
+
+    /// 093-B5：list_recent_loop_executions_for_task——按 task_id 过滤、started_at 倒序、limit 生效。
+    #[tokio::test]
+    async fn test_list_recent_loop_executions_for_task() {
+        let db = fresh_db().await;
+        let lp = seed_loop_status(&db, "L", "enabled").await;
+        // 两条挂在 task 7、一条挂在 task 8（task_id 直插，绕开 seed helper 的列集）
+        for (task, expr) in [(7, "datetime('now','-2 hours')"), (7, "datetime('now','-1 hours')"), (8, "datetime('now')")] {
+            db.exec(&format!(
+                "INSERT INTO loop_executions (loop_id, trigger_type, status, started_at, task_id) \
+                 VALUES ({lp}, 'manual', 'success', {expr}, {task})"
+            ))
+            .await
+            .expect("insert loop_execution");
+        }
+        let rows = db.list_recent_loop_executions_for_task(7, 20).await.unwrap();
+        assert_eq!(rows.len(), 2, "只应返回 task 7 的记录");
+        // 倒序：新的（-1h）在前
+        assert!(rows[0].started_at > rows[1].started_at, "应按 started_at 倒序");
+        // limit 生效
+        let limited = db.list_recent_loop_executions_for_task(7, 1).await.unwrap();
+        assert_eq!(limited.len(), 1);
+    }
+
+    /// 093-B5：get_artifact_workspace_path——三级跳返回 loop 的 workspace_path；断链报 NotFound。
+    #[tokio::test]
+    async fn test_get_artifact_workspace_path() {
+        let db = fresh_db().await;
+        db.exec("INSERT INTO loops (name, workspace_path) VALUES ('L', '/ws/path')").await.expect("insert loop");
+        let loop_id = max_id(&db, "loops").await;
+        let le = seed_loop_execution(&db, loop_id, "manual", "running", "datetime('now')").await;
+        let todo = seed_todo(&db, "T").await;
+        let step = seed_loop_step(&db, loop_id, todo, "s1").await;
+        // execution_record_id 有外键约束，必须先 seed 真实记录再关联
+        let record_id = seed_execution_record(&db, "{}").await;
+        link_step_execution(&db, le, step, todo, record_id).await;
+        let se_id = max_id(&db, "loop_step_executions").await;
+
+        let path = db.get_artifact_workspace_path(se_id).await.unwrap();
+        assert_eq!(path, Some("/ws/path".to_string()));
+        // 断链：不存在的 step_execution_id → RecordNotFound
+        assert!(db.get_artifact_workspace_path(99999).await.is_err());
     }
 
     /// set_step_execution_min_rating：阈值回写后能被读出；

--- a/backend/src/db/process_template.rs
+++ b/backend/src/db/process_template.rs
@@ -5,7 +5,43 @@ use sea_orm::{
 use crate::db::Database;
 use crate::db::entity::process_templates;
 
+/// 093-B5：工艺统计聚合行（`get_process_template_stats` 的返回元素）。
+/// 字段与 handlers/process.rs 的 get_process_stats 响应字段一一对应。
+#[derive(Debug, Clone)]
+pub struct ProcessTemplateStatRow {
+    pub name: String,
+    pub display_name: String,
+    pub complexity: String,
+    pub loop_count: i64,
+}
+
 impl Database {
+    /// 093-B5：模板安装次数聚合（从 handlers/process.rs 下沉的 raw SQL）。
+    /// 按模板 LEFT JOIN loops 统计安装环路数，按次数倒序；分层规范：handler 不写 SQL。
+    pub async fn get_process_template_stats(
+        &self,
+    ) -> Result<Vec<ProcessTemplateStatRow>, sea_orm::DbErr> {
+        let rows = self
+            .conn
+            .query_all(sea_orm::Statement::from_string(
+                sea_orm::DbBackend::Sqlite,
+                "SELECT pt.name, pt.display_name, pt.complexity, COUNT(l.id) AS loop_count \
+                 FROM process_templates pt \
+                 LEFT JOIN loops l ON l.process_template_id = pt.id \
+                 GROUP BY pt.id ORDER BY loop_count DESC".to_string(),
+            ))
+            .await?;
+        Ok(rows
+            .iter()
+            .map(|row| ProcessTemplateStatRow {
+                name: row.try_get_by("name").unwrap_or_default(),
+                display_name: row.try_get_by("display_name").unwrap_or_default(),
+                complexity: row.try_get_by("complexity").unwrap_or_default(),
+                loop_count: row.try_get_by("loop_count").unwrap_or(0),
+            })
+            .collect())
+    }
+
     /// 按 ID 查找工艺模板。
     pub async fn get_process_template_by_id(
         &self,
@@ -319,6 +355,27 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    /// 093-B5：get_process_template_stats——模板聚合并按安装环路数倒序；无环路模板 loop_count=0。
+    #[tokio::test]
+    async fn test_get_process_template_stats_aggregates_loop_count() {
+        let db = Database::new(":memory:").await.unwrap();
+        seed_two_templates(&db).await;
+        // 给系统模板挂两条环路（用户模板不挂）
+        let sys = db.get_process_template_by_name("sys-tpl").await.unwrap().unwrap();
+        for name in ["L1", "L2"] {
+            db.exec(&format!(
+                "INSERT INTO loops (name, process_template_id) VALUES ('{name}', {})", sys.id
+            ))
+            .await
+            .unwrap();
+        }
+        let stats = db.get_process_template_stats().await.unwrap();
+        assert_eq!(stats.len(), 2);
+        assert_eq!(stats[0].name, "sys-tpl", "按 loop_count 倒序，sys-tpl 应在前");
+        assert_eq!(stats[0].loop_count, 2);
+        assert_eq!(stats[1].loop_count, 0, "无环路模板 LEFT JOIN 计数为 0");
     }
 
     #[tokio::test]

--- a/backend/src/db/process_template.rs
+++ b/backend/src/db/process_template.rs
@@ -24,7 +24,10 @@ impl Database {
         let rows = self
             .conn
             .query_all(sea_orm::Statement::from_string(
+                // 固定 Sqlite 后端：项目全部环境均为 SQLite，语义显式且省运行时探测
                 sea_orm::DbBackend::Sqlite,
+                // SQL 为无参静态文本（聚合无输入），保留 raw SQL 而非改查询构建器：
+                // LEFT JOIN + GROUP BY 的语义在 SQL 文本里更直观，且无注入面
                 "SELECT pt.name, pt.display_name, pt.complexity, COUNT(l.id) AS loop_count \
                  FROM process_templates pt \
                  LEFT JOIN loops l ON l.process_template_id = pt.id \
@@ -34,9 +37,12 @@ impl Database {
         Ok(rows
             .iter()
             .map(|row| ProcessTemplateStatRow {
+                // try_get_by + unwrap_or_default：列缺失/NULL 时给空串而非报错，
+                // 与 handler 旧内联实现的宽容读取口径逐字一致
                 name: row.try_get_by("name").unwrap_or_default(),
                 display_name: row.try_get_by("display_name").unwrap_or_default(),
                 complexity: row.try_get_by("complexity").unwrap_or_default(),
+                // COUNT 聚合正常路径恒非 NULL；unwrap_or(0) 仅作防御性兜底
                 loop_count: row.try_get_by("loop_count").unwrap_or(0),
             })
             .collect())
@@ -362,7 +368,8 @@ mod tests {
     async fn test_get_process_template_stats_aggregates_loop_count() {
         let db = Database::new(":memory:").await.unwrap();
         seed_two_templates(&db).await;
-        // 给系统模板挂两条环路（用户模板不挂）
+        // 给系统模板挂两条环路（用户模板不挂）：覆盖「有/无环路」两种计数形态，
+        // 才能同时断言 LEFT JOIN 计数与 ORDER BY 倒序
         let sys = db.get_process_template_by_name("sys-tpl").await.unwrap().unwrap();
         for name in ["L1", "L2"] {
             db.exec(&format!(

--- a/backend/src/execution_events/pipeline.rs
+++ b/backend/src/execution_events/pipeline.rs
@@ -36,6 +36,15 @@ impl EventPipeline {
         }
     }
 
+    /// 093-B4：从已装箱的 trait 对象构造（注册表工厂返回 `Box<dyn EventExtractor>`）。
+    /// 与 `with_extractor` 并存：泛型版服务具名构造点，本版服务注册表查表路径。
+    pub fn with_boxed_extractor(extractor: Box<dyn EventExtractor>) -> Self {
+        Self {
+            extractor,
+            events: Vec::new(),
+        }
+    }
+
     /// 处理一行标准输出
     pub fn feed(&mut self, line: &str) {
         let new_events = self.extractor.extract(line);

--- a/backend/src/executor_service/log_capture.rs
+++ b/backend/src/executor_service/log_capture.rs
@@ -18,15 +18,11 @@ use tokio::task::JoinHandle;
 
 use crate::adapters::CodeExecutor;
 use crate::db::Database;
-use crate::execution_events::{
-    AtomcodeExtractor, ClaudeCodeExtractor, CodebuddyExtractor, CodewhaleExtractor,
-    CodexExtractor, DbLogEntry, EventPipeline, ExecutionEvent,
-    HermesExtractor, KiloExtractor, KimiExtractor, MimoExtractor, MobilecoderExtractor,
-    OpencodeExtractor, PiExtractor, ZhanluExtractor,
-};
+// 093-B4：13 个 Extractor 的直接导入已随 match 塌缩删除——构造职责移交注册表工厂。
+use crate::execution_events::{DbLogEntry, EventPipeline, ExecutionEvent};
 use crate::executor_service::ExecEvent;
 use crate::log_flusher::LogFlusher;
-use crate::models::{ExecutorType, ParsedLogEntry};
+use crate::models::ParsedLogEntry;
 
 /// 触发 `Output` 事件的 helper：忽略 send 失败（无订阅者 = 没人想看，不算错误）。
 pub(crate) fn send_event(tx: &broadcast::Sender<ExecEvent>, event: ExecEvent) {
@@ -38,52 +34,10 @@ pub(crate) fn send_event(tx: &broadcast::Sender<ExecEvent>, event: ExecEvent) {
 /// pub(crate) 是为了让 message_debounce.rs 中的 executor 默认响应路径也能复用
 /// 同一套 pipeline 创建逻辑，避免每个调用方各自硬编码 executor 类型 → 提取器映射。
 pub(crate) fn create_pipeline_for_executor(executor: &dyn CodeExecutor) -> Option<EventPipeline> {
-    let executor_type = executor.executor_type();
-
-    // 根据执行器类型选择合适的提取器
-    let pipeline = match executor_type {
-        ExecutorType::Claudecode => {
-            EventPipeline::with_extractor(ClaudeCodeExtractor::new())
-        }
-        ExecutorType::Kilo => {
-            EventPipeline::with_extractor(KiloExtractor::new())
-        }
-        ExecutorType::Opencode => {
-            EventPipeline::with_extractor(OpencodeExtractor::new())
-        }
-        ExecutorType::Codex => {
-            EventPipeline::with_extractor(CodexExtractor::new())
-        }
-        ExecutorType::Hermes => {
-            EventPipeline::with_extractor(HermesExtractor::new())
-        }
-        ExecutorType::Kimi => {
-            EventPipeline::with_extractor(KimiExtractor::new())
-        }
-        ExecutorType::Pi => {
-            EventPipeline::with_extractor(PiExtractor::new())
-        }
-        ExecutorType::Mobilecoder => {
-            EventPipeline::with_extractor(MobilecoderExtractor::new())
-        }
-        ExecutorType::Atomcode => {
-            EventPipeline::with_extractor(AtomcodeExtractor::new())
-        }
-        ExecutorType::Zhanlu => {
-            EventPipeline::with_extractor(ZhanluExtractor::new())
-        }
-        ExecutorType::Codewhale => {
-            EventPipeline::with_extractor(CodewhaleExtractor::new())
-        }
-        ExecutorType::Mimo => {
-            EventPipeline::with_extractor(MimoExtractor::new())
-        }
-        ExecutorType::Codebuddy => {
-            EventPipeline::with_extractor(CodebuddyExtractor::new())
-        }
-    };
-
-    Some(pipeline)
+    // 093-B4：13 臂 match 已收敛进注册表——ExecutorDef.create_extractor 工厂指针。
+    // 新增执行器只在 EXECUTORS 静态表挂一行，不再触碰本函数。
+    let def = crate::adapters::find_executor_by_type(executor.executor_type())?;
+    Some(EventPipeline::with_boxed_extractor((def.create_extractor)()))
 }
 
 /// 将 ExecutionEvent 转换为 ParsedLogEntry 并发送 Output 事件

--- a/backend/src/handlers/backup.rs
+++ b/backend/src/handlers/backup.rs
@@ -12,7 +12,7 @@ use zip::write::FileOptions;
 use zip::ZipWriter;
 use std::io::Seek;
 use std::io::Write;
-use sea_orm::{ConnectionTrait, DbBackend, Statement};
+
 
 use crate::handlers::{AppError, AppState};
 use crate::models::{ApiResponse, BackupData, TagBackup, TodoBackup, utc_timestamp};
@@ -713,22 +713,13 @@ pub async fn cleanup_old_logs(db: &Database, days: usize) -> Result<u64, String>
     let cutoff = chrono::Utc::now() - chrono::Duration::days(days as i64);
     let cutoff_str = cutoff.format("%Y-%m-%dT%H:%M:%S").to_string();
 
-    // 使用 DELETE FROM execution_logs WHERE timestamp < cutoff
-    // 由于 timestamp 格式是 ISO8601 字符串，可以直接字符串比较
-    let sql = format!(
-        "DELETE FROM execution_logs WHERE timestamp < '{}'",
-        cutoff_str
-    );
-
-    db.exec(&sql).await.map_err(|e| format!("Failed to cleanup logs: {}", e))?;
-
-    // 获取实际删除的行数
-    let changes: u64 = db.conn
-        .query_one(Statement::from_string(DbBackend::Sqlite, "SELECT changes()".to_string()))
+    // 093-B5：SQL 已下沉为 DAO（参数绑定 + rows_affected 取行数），
+    // handler 不再拼接/直查 SQL（分层规范 + 禁止清单 #4）；
+    // timestamp 列是 ISO8601 字符串，字典序即时间序。
+    let changes = db
+        .delete_execution_logs_before(&cutoff_str)
         .await
-        .map_err(|e| format!("Failed to get changes count: {}", e))?
-        .and_then(|row| row.try_get_by_index::<i64>(0).ok())
-        .unwrap_or(0) as u64;
+        .map_err(|e| format!("Failed to cleanup logs: {}", e))?;
 
     Ok(changes)
 }

--- a/backend/src/handlers/process.rs
+++ b/backend/src/handlers/process.rs
@@ -765,21 +765,13 @@ fn validate_process_name(name: &str) -> Result<(), AppError> {
 pub async fn get_process_stats(
     State(state): State<AppState>,
 ) -> Result<impl axum::response::IntoResponse, AppError> {
-    use sea_orm::{ConnectionTrait, DbBackend, Statement};
-    // 按模板聚合安装次数（loops.process_template_id GROUP BY）
-    let sql = "SELECT pt.name, pt.display_name, pt.complexity, COUNT(l.id) AS loop_count
-        FROM process_templates pt
-        LEFT JOIN loops l ON l.process_template_id = pt.id
-        GROUP BY pt.id ORDER BY loop_count DESC";
-    let rows = state.db.conn.query_all(Statement::from_string(DbBackend::Sqlite, sql)).await?;
+    // 093-B5：聚合 SQL 已下沉为 db.get_process_template_stats()，handler 只做字段映射
+    let rows = state.db.get_process_template_stats().await?;
     let mut stats = Vec::new();
     for row in rows {
-        let name: String = row.try_get_by("name").unwrap_or_default();
-        let display_name: String = row.try_get_by("display_name").unwrap_or_default();
-        let complexity: String = row.try_get_by("complexity").unwrap_or_default();
-        let loop_count: i64 = row.try_get_by("loop_count").unwrap_or(0);
         stats.push(serde_json::json!({
-            "name": name, "display_name": display_name, "complexity": complexity, "loop_count": loop_count
+            "name": row.name, "display_name": row.display_name,
+            "complexity": row.complexity, "loop_count": row.loop_count
         }));
     }
     Ok(ApiResponse::ok(serde_json::json!({

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -1460,7 +1460,7 @@ mod tests {
     /// 093-B4：label 改查注册表后，补「每个 ExecutorType 都有注册项 + 工厂可构造」断言——
     /// 这是「新增执行器忘注册/忘挂工厂」的回归守卫。
     #[test]
-    fn test_every_executor_type_registered_with_factory() {
+    fn test_find_executor_by_type_returns_registered_definitions_with_factories() {
         for et in [
             ExecutorType::Claudecode, ExecutorType::Hermes, ExecutorType::Codex,
             ExecutorType::Codebuddy, ExecutorType::Opencode, ExecutorType::Atomcode,

--- a/backend/src/handlers/skills.rs
+++ b/backend/src/handlers/skills.rs
@@ -149,21 +149,11 @@ pub(crate) fn resolve_skill_path_for_read(base: &Path, skill_name: &str) -> Resu
 }
 
 fn executor_label(et: ExecutorType) -> &'static str {
-    match et {
-        ExecutorType::Claudecode => "Claude Code",
-        ExecutorType::Hermes => "Hermes",
-        ExecutorType::Codex => "Codex",
-        ExecutorType::Codebuddy => "CodeBuddy",
-        ExecutorType::Opencode => "Opencode",
-        ExecutorType::Atomcode => "AtomCode",
-        ExecutorType::Kimi => "Kimi",
-        ExecutorType::Mobilecoder => "MobileCoder",
-        ExecutorType::Codewhale => "CodeWhale",
-        ExecutorType::Pi => "Pi",
-        ExecutorType::Mimo => "MiMo",
-        ExecutorType::Zhanlu => "Zhanlu",
-        ExecutorType::Kilo => "Kilo",
-    }
+    // 093-B4：原 13 臂 match 与 ExecutorDef.display_name 逐字重复，删除改查注册表；
+    // 查不到时回退规范名（as_str），比 panic 宽容且不会返回空串。
+    crate::adapters::find_executor_by_type(et)
+        .map(|d| d.display_name)
+        .unwrap_or_else(|| et.as_str())
 }
 
 // 仅用于本文件 tests 模块的数组完整性自检（元素齐全 / 无重复 / 含 Kilo）；
@@ -1465,6 +1455,24 @@ mod tests {
     #[test]
     fn test_executor_label_kilo() {
         assert_eq!(executor_label(ExecutorType::Kilo), "Kilo");
+    }
+
+    /// 093-B4：label 改查注册表后，补「每个 ExecutorType 都有注册项 + 工厂可构造」断言——
+    /// 这是「新增执行器忘注册/忘挂工厂」的回归守卫。
+    #[test]
+    fn test_every_executor_type_registered_with_factory() {
+        for et in [
+            ExecutorType::Claudecode, ExecutorType::Hermes, ExecutorType::Codex,
+            ExecutorType::Codebuddy, ExecutorType::Opencode, ExecutorType::Atomcode,
+            ExecutorType::Kimi, ExecutorType::Mobilecoder, ExecutorType::Codewhale,
+            ExecutorType::Pi, ExecutorType::Mimo, ExecutorType::Zhanlu, ExecutorType::Kilo,
+        ] {
+            let def = crate::adapters::find_executor_by_type(et)
+                .unwrap_or_else(|| panic!("{et:?} 未在 EXECUTORS 注册表"));
+            assert!(!def.display_name.is_empty());
+            // 工厂必须能构造出提取器（验证 create_extractor 已正确挂载）
+            let _extractor = (def.create_extractor)();
+        }
     }
 
     #[test]

--- a/backend/src/handlers/tasks.rs
+++ b/backend/src/handlers/tasks.rs
@@ -364,29 +364,25 @@ async fn build_task_executions(
     db: &crate::db::Database,
     task_id: i64,
 ) -> Result<Vec<serde_json::Value>, AppError> {
-    use sea_orm::{ConnectionTrait, DbBackend, Statement};
-    let exec_rows = db.conn.query_all(Statement::from_string(DbBackend::Sqlite,
-        format!("SELECT id, status, started_at, finished_at, total_steps, completed_steps, failed_steps, trigger_meta \
-                 FROM loop_executions WHERE task_id={} ORDER BY started_at DESC LIMIT 20", task_id)
-    )).await?;
+    // 093-B5：原始拼接 SQL 已下沉为 DAO（参数绑定）；handler 只做 JSON 映射
+    let exec_rows = db.list_recent_loop_executions_for_task(task_id, 20).await?;
     // 一次批量查待审批数再按 exec_id 映射，避免逐行 N+1（NTD-004）。
-    let exec_ids: Vec<i64> = exec_rows.iter().map(|r| r.try_get_by::<i64,_>("id").unwrap_or(0)).collect();
+    let exec_ids: Vec<i64> = exec_rows.iter().map(|r| r.id).collect();
     let pending_counts = db.count_pending_approvals_by_execution_ids(&exec_ids).await?;
     Ok(exec_rows.iter().map(|r| {
-        let meta = r.try_get_by::<Option<String>,_>("trigger_meta").ok().flatten()
-            .and_then(|m| serde_json::from_str::<serde_json::Value>(&m).ok());
+        // entity 的 trigger_meta 是 String（非 Option），空串解析失败自然落 None
+        let meta = serde_json::from_str::<serde_json::Value>(&r.trigger_meta).ok();
         let requirement = meta.as_ref().and_then(|v| v.get("requirement").and_then(|r| r.as_str().map(|s| s.to_string())));
-        let exec_id = r.try_get_by::<i64,_>("id").unwrap_or(0);
         serde_json::json!({
-            "id": exec_id,
-            "status": r.try_get_by::<String,_>("status").unwrap_or_default(),
-            "started_at": r.try_get_by::<Option<String>,_>("started_at").ok().flatten(),
-            "finished_at": r.try_get_by::<Option<String>,_>("finished_at").ok().flatten(),
-            "total_steps": r.try_get_by::<i32,_>("total_steps").unwrap_or(0),
-            "completed_steps": r.try_get_by::<i32,_>("completed_steps").unwrap_or(0),
-            "failed_steps": r.try_get_by::<i32,_>("failed_steps").unwrap_or(0),
+            "id": r.id,
+            "status": r.status,
+            "started_at": r.started_at,
+            "finished_at": r.finished_at,
+            "total_steps": r.total_steps,
+            "completed_steps": r.completed_steps,
+            "failed_steps": r.failed_steps,
             "requirement": requirement,
-            "pending_approval_count": pending_counts.get(&exec_id).copied().unwrap_or(0),
+            "pending_approval_count": pending_counts.get(&r.id).copied().unwrap_or(0),
         })
     }).collect())
 }
@@ -463,14 +459,11 @@ async fn resolve_artifact_workspace(
     db: &crate::db::Database,
     art: &crate::db::entity::loop_step_artifacts::Model,
 ) -> Result<String, sea_orm::DbErr> {
-    use sea_orm::EntityTrait;
-    let se = crate::db::entity::loop_step_executions::Entity::find_by_id(art.loop_step_execution_id).one(&db.conn).await?
-        .ok_or(sea_orm::DbErr::RecordNotFound("step_exec not found".into()))?;
-    let le = crate::db::entity::loop_executions::Entity::find_by_id(se.loop_execution_id).one(&db.conn).await?
-        .ok_or(sea_orm::DbErr::RecordNotFound("loop_exec not found".into()))?;
-    let lp = crate::db::entity::loops::Entity::find_by_id(le.loop_id).one(&db.conn).await?
-        .ok_or(sea_orm::DbErr::RecordNotFound("loop not found".into()))?;
-    Ok(lp.workspace_path.unwrap_or_default())
+    // 093-B5：三级跳查询已下沉为 db.get_artifact_workspace_path（纯搬移，语义不变）
+    Ok(db
+        .get_artifact_workspace_path(art.loop_step_execution_id)
+        .await?
+        .unwrap_or_default())
 }
 
 async fn read_workspace_file(ws: &str, rel: &str) -> String {
@@ -657,7 +650,9 @@ mod tests {
         let sql = format!(
             "UPDATE loops SET process_template_id = {template_id}, {version_sql} WHERE id = {loop_id}"
         );
-        db.conn
+        // 093-B5：测试侧直写 SQL 走 _conn_raw()（该口子的既定用途：测试构造边界数据），
+        // 不再经 db.conn 转义口
+        db._conn_raw()
             .execute(Statement::from_string(DbBackend::Sqlite, sql))
             .await
             .expect("bind loop template must succeed");

--- a/docs/design/093-Extractor注册表化-设计.md
+++ b/docs/design/093-Extractor注册表化-设计.md
@@ -1,0 +1,72 @@
+# 093-Extractor注册表化-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+
+> 093 专项 B4（重构批次 4）。源自 skill 扫描诊断第 4 条：Repeated Switches + Shotgun Surgery——
+> `ExecutorType` 大 match 散落多处，新增执行器要同步修改 N 个文件。
+
+## 1. 现状与证据
+
+| 位置 | match 职责 | 处置 |
+|------|-----------|------|
+| `log_capture.rs::create_pipeline_for_executor` | 13 臂 match 构造对应 Extractor | **本 PR 收敛进注册表** |
+| `handlers/skills.rs::executor_label` | 13 臂 match 返回显示名 | **纯重复**（`ExecutorDef.display_name` 逐字相同），本 PR 删除改查表 |
+| `models/mod.rs::ExecutorType::as_str` | 枚举自身的规范名映射 | **保留**——这是枚举的固有方法，是单一事实源而非重复 |
+
+项目已有 `ExecutorDef` 静态注册表（`EXECUTORS: &[ExecutorDef]`，含 name/executor_type/binary_name/display_name/session_dir/aliases）——注册点早就存在，只是没挂 Extractor。
+
+## 2. 设计
+
+### C1：`ExecutorDef` 挂提取器工厂
+
+```rust
+pub struct ExecutorDef {
+    ...
+    /// 093-B4：该执行器的事件提取器工厂（双解析体系收敛的注册点）。
+    /// 非捕获闭包强制转换为 fn 指针，可放入静态表。
+    pub create_extractor: fn() -> Box<dyn EventExtractor>,
+}
+```
+
+`EXECUTORS` 13 个条目各挂 `|| Box::new(XxxExtractor::new())`。
+
+### C2：注册表查询 + pipeline 构造塌缩
+
+```rust
+/// 按 ExecutorType 反查注册项（registry 反向索引）
+pub fn find_executor_by_type(et: ExecutorType) -> Option<&'static ExecutorDef>
+```
+
+`create_pipeline_for_executor` 从 13 臂 match（~45 行）塌缩为：
+
+```rust
+let def = find_executor_by_type(executor.executor_type())?;
+Some(EventPipeline::with_boxed_extractor((def.create_extractor)()))
+```
+
+`EventPipeline` 新增 `with_boxed_extractor(Box<dyn EventExtractor>)` 构造（与既有 `with_extractor(impl)` 并存——注册表只能返回 trait 对象）。
+
+### C3：删除 `executor_label`
+
+`skills.rs` 的调用点改 `crate::adapters::find_executor(et.as_str()).map(|d| d.display_name).unwrap_or(et.as_str())`（找不到时回退规范名，比 panic 宽容）；其测试同步改为断言注册表覆盖（保留「新增执行器忘注册」的回归守卫语义）。
+
+## 3. 影响模块
+
+`adapters/mod.rs`（ExecutorDef+EXECUTORS+find_executor_by_type）、`execution_events/pipeline.rs`（+with_boxed_extractor）、`executor_service/log_capture.rs`（match 塌缩）、`handlers/skills.rs`（删 executor_label+测试改断言）。
+
+## 4. 收益与后续
+
+- 新增第 14 个执行器：从「改 5+ 处」变「EXECUTORS 加一行」；
+- 为双解析体系收敛铺路：旧 `parse_output_line` 删除后，执行器与解析的关联点只剩注册表一处。
+
+## 5. 验证方案
+
+1. 既有 log_capture / execution_events / skills 测试全绿；
+2. 新增断言：13 个 ExecutorType 全部能在注册表查到且工厂可构造（防漏挂）；
+3. clippy 零告警；假执行器冒烟（沿用 B2/B3 方法）。
+
+## 6. 安全反思
+
+纯构造路径重构；工厂返回的 Extractor 实例与原 match 构造完全一致；无接口/行为变化。

--- a/docs/design/093-Extractor注册表化-设计.md
+++ b/docs/design/093-Extractor注册表化-设计.md
@@ -3,6 +3,7 @@
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | AI (Pi) | 2026-08-08 | 初始版本 |
+| AI (zhanlu) | 2026-08-10 | 按 CodeRabbit 评审同步文档与代码：executor_label 实为「删 match 留壳查 find_executor_by_type」，非整函数删除 |
 
 > 093 专项 B4（重构批次 4）。源自 skill 扫描诊断第 4 条：Repeated Switches + Shotgun Surgery——
 > `ExecutorType` 大 match 散落多处，新增执行器要同步修改 N 个文件。
@@ -48,9 +49,17 @@ Some(EventPipeline::with_boxed_extractor((def.create_extractor)()))
 
 `EventPipeline` 新增 `with_boxed_extractor(Box<dyn EventExtractor>)` 构造（与既有 `with_extractor(impl)` 并存——注册表只能返回 trait 对象）。
 
-### C3：删除 `executor_label`
+### C3：`executor_label` 删除硬编码 match，保留函数作为注册表查询包装
 
-`skills.rs` 的调用点改 `crate::adapters::find_executor(et.as_str()).map(|d| d.display_name).unwrap_or(et.as_str())`（找不到时回退规范名，比 panic 宽容）；其测试同步改为断言注册表覆盖（保留「新增执行器忘注册」的回归守卫语义）。
+`skills.rs` 的 `executor_label(et)` 原是与 `ExecutorDef.display_name` 逐字重复的 13 臂 match。
+实施时**保留函数壳**（调用点零改动），函数体改查注册表：
+`crate::adapters::find_executor_by_type(et).map(|d| d.display_name).unwrap_or_else(|| et.as_str())`
+（找不到时回退规范名，比 panic 宽容）；其测试同步改为断言注册表覆盖
+（保留「新增执行器忘注册」的回归守卫语义）。
+
+> 注（CodeRabbit #1010 评审）：初版本节写「删除 executor_label」且示例误用
+> `find_executor(et.as_str())`——按名字符串反查对枚举语义不对（别名/大小写歧义），
+> 实际落地为按 ExecutorType 反查 `find_executor_by_type`，特此更正。
 
 ## 3. 影响模块
 

--- a/docs/design/093-handler层SQL下沉-设计.md
+++ b/docs/design/093-handler层SQL下沉-设计.md
@@ -1,0 +1,65 @@
+# 093-handler层SQL下沉与注入面消除-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本（B5 重定范围） |
+
+> 093 专项 B5（重构批次 5）。skill 扫描原计划「Database 拆 Repository（loop_ 先行）」，
+> 实施前重论证（skill 终极原则：不为模式而模式）：
+> - `Database` 跨文件 impl 是 Rust 惯用的领域分文件组织，测试已可用内存库整体替换，
+>   全量 Repository 拆分（330 方法、全仓调用面）收益/风险比不佳——**不做**；
+> - 真实痛点是 `Database.conn` 转义口：`pub(super)` 声明在 `db/mod.rs` 顶层 = 全 crate 可见，
+>   handlers 直接写 SQL 绕过分层（违反后端规范 02 分层 + 禁止清单 #4 SQL 拼接）。
+
+## 1. 现状证据（27 处 `.conn` 转义口使用）
+
+| 文件 | 处数 | 性质 |
+|------|------|------|
+| `handlers/backup.rs:718-731` | 1 | `DELETE FROM execution_logs WHERE timestamp < '{cutoff}'` **format! 拼接** + `SELECT changes()` |
+| `handlers/process.rs:774` | 1 | 模板安装次数聚合查询（raw SQL） |
+| `handlers/tasks.rs:368` | 1 | `WHERE task_id={}` **format! 拼接**（i64 类型安全但违反禁止清单） |
+| `handlers/tasks.rs:467-471` | 3 | 三级实体 find（artifact→step_exec→loop_exec→loop 取 workspace_path） |
+| `handlers/tasks.rs:660` | 1 | 测试 helper（`bind_loop_template`） |
+| `services/process/installer.rs` | 13 | 模板安装的实体 insert 族 |
+| `services/process/phase_driver.rs` | 4 | phase 执行记录 insert/find/update |
+| `services/loop_runner.rs` | 2 | 实体直查 |
+| `services/process/audit.rs` | 1 | 实体直查 |
+
+## 2. 本 PR 范围（C1-C3）
+
+### C1：handlers 层 4 处下沉为 db 领域方法
+
+| 新 DAO 方法 | 位置 | 收编的 handler SQL |
+|------------|------|-------------------|
+| `delete_execution_logs_before(cutoff) -> Result<u64>` | `db/execution.rs` | backup.rs 的 DELETE+changes()；**改参数绑定**，用 `ExecResult::rows_affected` 替代 `SELECT changes()` 二次查询 |
+| `get_process_template_stats() -> Vec<TemplateStatRow>` | `db/process_template.rs` | process.rs 聚合查询 |
+| `list_recent_loop_executions_for_task(task_id, limit) -> Vec<Model>` | `db/loop_.rs` | tasks.rs:368 的 format! 拼接 SQL，**改参数绑定** |
+| `get_artifact_workspace_path(step_exec_id) -> Result<Option<String>>` | `db/loop_.rs` | tasks.rs:467 三级 find（纯搬移，不改逻辑） |
+
+### C2：测试 helper 迁移
+
+`tasks.rs` 测试 `bind_loop_template` 的 `db.conn.execute(...)` 改走 `db._conn_raw()`（该口子的既定用途）。
+
+### C3：services 层残留登记
+
+installer.rs 13 处 / phase_driver.rs 4 处 / loop_runner.rs 2 处 / audit.rs 1 处的 `.conn` 直操
+**不在本 PR 搬移**——installer 的实体 insert 族若直接搬入会制造 11+ 参 DAO（刚在 B3 消灭的
+Long Parameter List 换地方复发），需先设计参数对象，列为 B6 候选。
+conn 可见性收口（`pub(self)`）随 B6 完成后再启用（届时编译器强制清零）。
+
+## 3. 影响模块
+
+- `db/execution.rs`、`db/process_template.rs`、`db/loop_.rs`：+4 领域方法（+单测）
+- `handlers/backup.rs`、`handlers/process.rs`、`handlers/tasks.rs`：SQL 删除/改调 DAO
+
+## 4. 验证方案
+
+1. 4 个新 DAO 各配单测（内存库 seed → 断言返回）；handlers 既有集成测试全绿；
+2. `EXPLAIN`/行为对照：tasks 详情页执行记录列表、备份清理行数、工艺统计接口输出不变；
+3. clippy 零告警；假执行器冒烟（备份清理 API 手工 curl 验证行数正确）。
+
+## 5. 安全反思
+
+- **消除 2 处 SQL format! 拼接**（backup cutoff / tasks task_id）为参数绑定——
+  虽两处当前均为类型安全值（i64/内部生成时间戳），但违反自家禁止清单 #4，属必须清零项；
+- DAO 下沉后 handler 不再触碰 SQL，分层边界由「约定」变「结构」。

--- a/docs/requirements/093-Extractor注册表化-实现总结.md
+++ b/docs/requirements/093-Extractor注册表化-实现总结.md
@@ -3,6 +3,7 @@
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | AI (Pi) | 2026-08-08 | 初始版本 |
+| AI (zhanlu) | 2026-08-10 | 按 CodeRabbit 评审同步文档与代码：executor_label 实为「删 match 留壳查 find_executor_by_type」，非整函数删除 |
 
 > 对应设计：`docs/design/093-Extractor注册表化-设计.md`。093 专项 B4（重构批次 4），
 > 消除 Repeated Switches / Shotgun Surgery：新增执行器从「改 5+ 处」变「注册表加一行」。
@@ -16,12 +17,12 @@
 | 新增 `find_executor_by_type()` 注册表反查 | `adapters/mod.rs` |
 | `EventPipeline::with_boxed_extractor()`（与泛型 `with_extractor` 并存） | `execution_events/pipeline.rs` |
 | `create_pipeline_for_executor`：13 臂 match（~45 行）→ 查表 3 行 | `log_capture.rs` |
-| 删除 `skills.rs::executor_label`（与 `ExecutorDef.display_name` 逐字重复的 13 臂 match） | `handlers/skills.rs` |
+| `executor_label` 删除硬编码 match（与 `ExecutorDef.display_name` 逐字重复），**保留函数**作为注册表查询包装（调用点零改动） | `handlers/skills.rs` |
 
 ## 2. 与设计对应 / 关键实现点
 
 - `models/mod.rs::ExecutorType::as_str` 按设计**保留**（枚举固有方法，是规范名单一事实源，非重复）；
-- `executor_label` 删除后查表 + `as_str()` 回退（比 panic 宽容，不返回空串）；
+- `executor_label` 函数体改查表（`find_executor_by_type`）+ `as_str()` 回退（比 panic 宽容，不返回空串）；函数壳保留，调用点零改动；
 - 新增回归守卫测试 `test_every_executor_type_registered_with_factory`：13 个 ExecutorType 全部可查表且工厂可构造——「新增执行器忘注册/忘挂工厂」编译期之外的最后防线。
 
 ## 3. 测试与验证结果

--- a/docs/requirements/093-Extractor注册表化-实现总结.md
+++ b/docs/requirements/093-Extractor注册表化-实现总结.md
@@ -1,0 +1,40 @@
+# 093-Extractor注册表化-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+
+> 对应设计：`docs/design/093-Extractor注册表化-设计.md`。093 专项 B4（重构批次 4），
+> 消除 Repeated Switches / Shotgun Surgery：新增执行器从「改 5+ 处」变「注册表加一行」。
+
+## 1. 实现了什么
+
+| 变化 | 位置 |
+|------|------|
+| `ExecutorDef` 新增 `create_extractor: fn() -> Box<dyn EventExtractor>` 工厂字段 | `adapters/mod.rs` |
+| `EXECUTORS` 13 条目全部挂载对应 Extractor 工厂（非捕获闭包→fn 指针入静态表） | `adapters/mod.rs` |
+| 新增 `find_executor_by_type()` 注册表反查 | `adapters/mod.rs` |
+| `EventPipeline::with_boxed_extractor()`（与泛型 `with_extractor` 并存） | `execution_events/pipeline.rs` |
+| `create_pipeline_for_executor`：13 臂 match（~45 行）→ 查表 3 行 | `log_capture.rs` |
+| 删除 `skills.rs::executor_label`（与 `ExecutorDef.display_name` 逐字重复的 13 臂 match） | `handlers/skills.rs` |
+
+## 2. 与设计对应 / 关键实现点
+
+- `models/mod.rs::ExecutorType::as_str` 按设计**保留**（枚举固有方法，是规范名单一事实源，非重复）；
+- `executor_label` 删除后查表 + `as_str()` 回退（比 panic 宽容，不返回空串）；
+- 新增回归守卫测试 `test_every_executor_type_registered_with_factory`：13 个 ExecutorType 全部可查表且工厂可构造——「新增执行器忘注册/忘挂工厂」编译期之外的最后防线。
+
+## 3. 测试与验证结果
+
+- `cargo clippy --all-targets -- -D warnings`：零告警 ✅
+- `cargo test --no-fail-fast`：1714 通过（唯一失败为预存量环境问题 git_sync）✅
+- 假执行器端到端冒烟：注册表工厂构造的 pipeline 全链路正确（session_start→assistant→text→session_end 落库）✅
+
+## 4. 收益与后续
+
+- 新增第 14 个执行器：`EXECUTORS` 加一行（name + 类型 + 工厂同挂一处），不再触碰任何 match；
+- 双解析体系彻底收敛的落点已就位：旧 `parse_output_line` 删除后，执行器↔解析关联只剩注册表。
+
+## 5. 安全反思
+
+纯构造路径重构；工厂产出实例与原 match 构造完全一致；无接口/行为变化。

--- a/docs/requirements/093-handler层SQL下沉-实现总结.md
+++ b/docs/requirements/093-handler层SQL下沉-实现总结.md
@@ -1,0 +1,52 @@
+# 093-handler层SQL下沉与注入面消除-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-08 | 初始版本 |
+
+> 对应设计：`docs/design/093-handler层SQL下沉-设计.md`。093 专项 B5（重构批次 5，重定范围版）。
+
+## 1. 范围重定说明（与设计文档一致）
+
+skill 扫描原计划「Database 拆 Repository（loop_ 先行）」。实施前重论证（不为模式而模式）：
+`Database` 跨文件 impl 是 Rust 惯用的领域分文件组织，全量拆分 330 方法收益/风险比不佳。
+**真实痛点**是 `Database.conn` 转义口（`pub(super)` 声明于 crate 顶层模块 = 全 crate 可见），
+handlers 直接写 SQL 绕过分层（违反后端规范 02 + 禁止清单 #4）。本 PR 收编 handlers 层全部 4 处。
+
+## 2. 实现了什么
+
+### 新增 4 个 DAO（各配单测）
+
+| DAO | 位置 | 收编的 handler SQL |
+|-----|------|-------------------|
+| `delete_execution_logs_before(cutoff) -> u64` | `db/execution.rs` | backup.rs 的 format! 拼接 DELETE + `SELECT changes()` 二次查询 → **参数绑定 + rows_affected** |
+| `get_process_template_stats()` | `db/process_template.rs` | process.rs 聚合查询原样下沉 |
+| `list_recent_loop_executions_for_task(task_id, limit)` | `db/loop_.rs` | tasks.rs `WHERE task_id={}` format! 拼接 → **SeaORM 参数绑定** |
+| `get_artifact_workspace_path(step_exec_id)` | `db/loop_.rs` | tasks.rs 三级实体 find 纯搬移 |
+
+### handler 侧
+
+- `backup.rs::cleanup_old_logs`：SQL 全删，调 DAO；
+- `process.rs::get_process_stats`：只做 JSON 映射；
+- `tasks.rs::build_task_executions` / `resolve_artifact_workspace`：调 DAO + 字段映射；
+- `tasks.rs` 测试 helper `bind_loop_template`：改走 `_conn_raw()`（该口子既定用途）。
+
+## 3. 测试与验证结果
+
+- 新增单测 4 例：日志清理行数/幂等/保留新日志、模板聚合倒序与 LEFT JOIN 零计数、
+  任务执行记录过滤/倒序/limit、artifact 三级跳取路径/断链 NotFound ✅
+- `cargo clippy --all-targets -- -D warnings`：零告警 ✅
+- `cargo test --no-fail-fast`：1718 通过（唯一失败为预存量环境问题 git_sync，本机 git 过老）✅
+
+## 4. 已知限制 / B6 候选
+
+- `services/process/installer.rs`（13 处）/`phase_driver.rs`（4 处）/`loop_runner.rs`（2 处）/
+  `audit.rs`（1 处）的 `.conn` 实体直操**未搬移**——installer 的 insert 族直接搬入会制造
+  11+ 参 DAO（B3 刚消灭的 Long Parameter List 换地复发），需先设计参数对象，列为 B6；
+- `conn` 可见性收口（`pub(self)`）随 B6 清零后启用，届时编译器强制无转义口。
+
+## 5. 安全反思
+
+- 本 PR **消除 2 处 SQL format! 拼接**（backup cutoff、tasks task_id）为参数绑定，
+  虽原值类型安全（i64/内部时间戳），但自家禁止清单 #4 要求清零；
+- handler 不再触碰 SQL，分层边界由约定变结构；无接口/行为变化。


### PR DESCRIPTION
## 范围重定（与原 B5 计划不同，理由见设计文档）

扫描原计划「Database 拆 Repository（330 方法）」——实施前重论证放弃：跨文件 impl 是 Rust 惯用组织，全量拆分收益/风险比不佳（不为模式而模式）。**真实痛点**是 `Database.conn` 转义口（`pub(super)` 在 crate 顶层模块 = 全 crate 可见），handlers 直写 SQL 绕分层。本 PR 收编 handlers 层全部 4 处。

## 改动

**新增 4 个 DAO（各配单测）**：
- `delete_execution_logs_before`：backup.rs 的 format! 拼接 DELETE + `SELECT changes()` 二次查询 → 参数绑定 + `rows_affected`
- `get_process_template_stats`：process.rs 聚合查询下沉
- `list_recent_loop_executions_for_task`：tasks.rs `WHERE task_id={}` format! 拼接 → SeaORM 参数绑定
- `get_artifact_workspace_path`：三级实体 find 搬移

**handler 侧**：backup/process/tasks 不再触碰 SQL；测试 helper 迁 `_conn_raw()`。

## 测试

- 4 个新 DAO 单测（行数/幂等/倒序/limit/断链 NotFound 等边界）
- clippy 零告警；cargo test 1718 通过（唯一失败为预存量环境问题）

## B6 候选（记录在案）

services/process（installer 13 处等）的 `.conn` 实体直操需先设计参数对象再搬移；完成后 `conn` 改 `pub(self)` 由编译器强制清零转义口。