### PR TITLE
perf(094): WS 广播预序列化 + workspace 过滤

### DIFF
--- a/backend/src/executor_service/events.rs
+++ b/backend/src/executor_service/events.rs
@@ -187,3 +187,45 @@ WikiChatFinished {
     duration_secs: i64,
 },
 }
+
+impl ExecEvent {
+    /// 094：事件的 workspace 归属，供 WS 广播按 workspace 过滤。
+    ///
+    /// 返回 None 的语义分两类（对 WS 客户端均全推）：
+    /// - 全局事件（Sync/ReviewStatusChanged）：本身不含 workspace 敏感信息；
+    /// - 飞书直发事件（DirectCardMessage/DirectStreamMessage）：已被 is_feishu_direct
+    ///   拦截在 WS channel 之外，None 仅为防御兜底。
+    ///
+    /// 全枚举匹配：新增变体漏处理时编译器报 non-exhaustive，天然守卫。
+    pub fn workspace_id(&self) -> Option<i64> {
+        match self {
+            // Option<i64> 组：执行生命周期事件，透传原字段
+            ExecEvent::Started { workspace_id, .. }
+            | ExecEvent::Output { workspace_id, .. }
+            | ExecEvent::Finished { workspace_id, .. }
+            | ExecEvent::TodoProgress { workspace_id, .. }
+            | ExecEvent::ExecutionStats { workspace_id, .. }
+            | ExecEvent::LoopFinished { workspace_id, .. } => *workspace_id,
+            // i64 必填组：黑板/WikiChat 系列，包 Some
+            ExecEvent::BlackboardDebounceStatus { workspace_id, .. }
+            | ExecEvent::WikiChatStarted { workspace_id, .. }
+            | ExecEvent::WikiChatOutput { workspace_id, .. }
+            | ExecEvent::WikiChatFinished { workspace_id, .. } => Some(*workspace_id),
+            // 全局/飞书专用组：无 workspace 归属
+            ExecEvent::Sync { .. }
+            | ExecEvent::ReviewStatusChanged { .. }
+            | ExecEvent::DirectCardMessage { .. }
+            | ExecEvent::DirectStreamMessage { .. } => None,
+        }
+    }
+
+    /// 094：飞书专用定向事件判定。这类事件只服务 FeishuPushService 的 bot 定向发送，
+    /// 前端 WS 客户端无对应消费分支——forwarder 据此拦截，不再推入 WS channel
+    /// （消除带宽浪费，也让「WS 消息 = 前端可消费消息」的语义单一化）。
+    pub fn is_feishu_direct(&self) -> bool {
+        matches!(
+            self,
+            ExecEvent::DirectCardMessage { .. } | ExecEvent::DirectStreamMessage { .. }
+        )
+    }
+}

--- a/backend/src/executor_service/events.rs
+++ b/backend/src/executor_service/events.rs
@@ -189,33 +189,36 @@ WikiChatFinished {
 }
 
 impl ExecEvent {
-    /// 094：事件的 workspace 归属，供 WS 广播按 workspace 过滤。
+    /// 094：事件的 workspace 作用域，供 WS 广播按连接声明过滤。
     ///
-    /// 返回 None 的语义分两类（对 WS 客户端均全推）：
-    /// - 全局事件（Sync/ReviewStatusChanged）：本身不含 workspace 敏感信息；
-    /// - 飞书直发事件（DirectCardMessage/DirectStreamMessage）：已被 is_feishu_direct
-    ///   拦截在 WS channel 之外，None 仅为防御兜底。
-    ///
-    /// 全枚举匹配：新增变体漏处理时编译器报 non-exhaustive，天然守卫。
-    pub fn workspace_id(&self) -> Option<i64> {
+    /// 三态区分的动机（CodeRabbit #1011 评审）：`Option<i64>` 把「未归属」与「全局」
+    /// 混在一个 None 里，且 DB 层 `workspace_id=0` 是「未分配工作空间」的哨兵值
+    /// （loop_runner.rs 的既有约定：Some(0) 与 None 语义等价），必须显式区分：
+    /// - `Workspace(N)`（N>0）：归属确定 workspace，仅推给声明该 workspace 的连接；
+    /// - `Unscoped`：未归属任务/loop（None 或 Some(0)）——不推给任何带参连接，
+    ///   与 todo 列表的 workspace 过滤语义对齐（未归属在任何 workspace 视图均不显示）；
+    /// - `Global`：无 workspace 概念的全局事件（Sync/ReviewStatusChanged），全推。
+    pub fn event_scope(&self) -> EventScope {
         match self {
-            // Option<i64> 组：执行生命周期事件，透传原字段
+            // 生命周期组：Option<i64> 字段——None 与 Some(0) 经 scope_from_optional 归一为
+            // Unscoped（DB 层 0 是「未分配」哨兵，见 loop_runner.rs 的等价约定）
             ExecEvent::Started { workspace_id, .. }
             | ExecEvent::Output { workspace_id, .. }
             | ExecEvent::Finished { workspace_id, .. }
             | ExecEvent::TodoProgress { workspace_id, .. }
             | ExecEvent::ExecutionStats { workspace_id, .. }
-            | ExecEvent::LoopFinished { workspace_id, .. } => *workspace_id,
-            // i64 必填组：黑板/WikiChat 系列，包 Some
+            | ExecEvent::LoopFinished { workspace_id, .. } => scope_from_optional(*workspace_id),
+            // 黑板/WikiChat 组：i64 必填字段——0 同样按未归属哨兵处理
             ExecEvent::BlackboardDebounceStatus { workspace_id, .. }
             | ExecEvent::WikiChatStarted { workspace_id, .. }
             | ExecEvent::WikiChatOutput { workspace_id, .. }
-            | ExecEvent::WikiChatFinished { workspace_id, .. } => Some(*workspace_id),
-            // 全局/飞书专用组：无 workspace 归属
-            ExecEvent::Sync { .. }
-            | ExecEvent::ReviewStatusChanged { .. }
-            | ExecEvent::DirectCardMessage { .. }
-            | ExecEvent::DirectStreamMessage { .. } => None,
+            | ExecEvent::WikiChatFinished { workspace_id, .. } => scope_from_optional(Some(*workspace_id)),
+            // 全局组：无 workspace 概念
+            ExecEvent::Sync { .. } | ExecEvent::ReviewStatusChanged { .. } => EventScope::Global,
+            // 飞书专用组：在 forwarder 已被 is_feishu_direct 拦截，Global 仅为防御兜底
+            ExecEvent::DirectCardMessage { .. } | ExecEvent::DirectStreamMessage { .. } => {
+                EventScope::Global
+            }
         }
     }
 
@@ -227,5 +230,29 @@ impl ExecEvent {
             self,
             ExecEvent::DirectCardMessage { .. } | ExecEvent::DirectStreamMessage { .. }
         )
+    }
+}
+
+/// 094：事件作用域三态（见 `ExecEvent::event_scope` doc）。
+/// Copy/Eq 供匹配判定零成本使用。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventScope {
+    /// 无 workspace 概念的全局事件：全量转发
+    Global,
+    /// 归属确定 workspace（N>0）：仅推给声明该 workspace 的连接
+    Workspace(i64),
+    /// 未归属（workspace_id 为 None 或哨兵 0）：不推给任何带参连接
+    Unscoped,
+}
+
+/// Option<i64> workspace_id → EventScope 的归一化：
+/// None 与 Some(0) 都是「未分配工作空间」（loop_runner.rs 既有约定），统一为 Unscoped；
+/// 只有 Some(N>0) 才是真正的 workspace 归属。
+/// pub(crate)：handlers 的 Sync 握手过滤（sync_task_visible）复用同一归一口径。
+pub(crate) fn scope_from_optional(workspace_id: Option<i64>) -> EventScope {
+    match workspace_id {
+        // 仅 Some(N>0) 算真实归属——Some(0) 落到下一臂（哨兵语义见 fn doc）
+        Some(id) if id > 0 => EventScope::Workspace(id),
+        _ => EventScope::Unscoped,
     }
 }

--- a/backend/src/executor_service/mod.rs
+++ b/backend/src/executor_service/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod stages;
 pub(crate) mod types;
 pub(crate) mod worktree;
 
-pub use events::ExecEvent;
+pub use events::{EventScope, ExecEvent};
 
 use std::sync::Arc;
 use tokio::sync::broadcast;

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -171,10 +171,26 @@ pub mod workspace_guard;
 
 // WebSocket handler
 // 094：query 参数 workspace_id 声明客户端关注的 workspace——只推该 workspace 事件
-// + 全局事件（None 归属）；不带参数的旧客户端全推（兼容口）。
+// + 全局事件（Global 作用域）；不带参数的旧客户端全推（兼容口）。
 #[derive(Debug, serde::Deserialize)]
 pub struct EventsQuery {
     workspace_id: Option<i64>,
+}
+
+/// 094：Sync 握手的任务可见性谓词（抽出为纯函数以便单测，CodeRabbit #1011）。
+///
+/// - `task_record_ws`：任务 execution_record 的 workspace_id（None 外层 = 查不到 record
+///   的异常任务，决策 2a 保守保留——DB 降级时宁多勿漏）；
+/// - 有 record 时按 EventScope 归一后判定：仅 Workspace(conn) 可见——
+///   Unscoped（None/哨兵 0 的未归属任务）对带参连接不可见，与主循环过滤语义一致。
+fn sync_task_visible(task_record_ws: Option<Option<i64>>, conn_ws: i64) -> bool {
+    match task_record_ws {
+        None => true,
+        Some(ws) => matches!(
+            crate::executor_service::events::scope_from_optional(ws),
+            crate::executor_service::EventScope::Workspace(id) if id == conn_ws
+        ),
+    }
 }
 
 pub async fn events_handler(
@@ -182,9 +198,12 @@ pub async fn events_handler(
     ws: WebSocketUpgrade,
     axum::extract::Query(query): axum::extract::Query<EventsQuery>,
 ) -> Response {
+    // conn_workspace 在 upgrade 前落定：闭包 move 进异步任务后 query 已不可达；
+    // 无效参数（非数字）在 Query 抽取阶段即 400 拒绝，不会进入本函数
     let conn_workspace = query.workspace_id;
     ws.on_upgrade(move |mut ws| async move {
-        // 094：订阅 WS 专用 channel（预序列化信封），不再订阅原始 ExecEvent channel
+        // 094：订阅 WS 专用 channel（预序列化信封），不再订阅原始 ExecEvent channel——
+        // 序列化已在 forwarder 全局做一次，本任务零序列化开销
         let mut rx = state.ws_tx.subscribe();
 
         // 连接时发送当前实际运行的任务列表
@@ -207,13 +226,10 @@ pub async fn events_handler(
             .filter_map(|r| r.task_id.clone().map(|tid| (tid, r)))
             .collect();
         // 094：声明了 workspace 的连接，Sync 只回该 workspace 的运行任务；
-        // 查不到 record 的异常任务保守保留（决策 2a：DB 降级时宁多勿漏）。
+        // 谓词语义（含无 record 保守保留、0 哨兵未归属不可见）见 sync_task_visible。
         if let Some(ws_id) = conn_workspace {
             running_tasks.retain(|t| {
-                record_map
-                    .get(&t.task_id)
-                    .map(|r| r.workspace_id == Some(ws_id))
-                    .unwrap_or(true)
+                sync_task_visible(record_map.get(&t.task_id).map(|r| r.workspace_id), ws_id)
             });
         }
         // record_ids 从过滤后的 running_tasks 反查：尾部日志/计数两个查询
@@ -307,8 +323,8 @@ pub async fn events_handler(
                 recv = rx.recv() => {
                     match recv {
                         Ok(envelope) => {
-                            // 094：workspace 匹配判定（三态真值表见 envelope_matches）
-                            if !ws_broadcast::envelope_matches(conn_workspace, envelope.workspace_id) {
+                            // 094：作用域匹配判定（Global/Workspace/Unscoped 语义见 envelope_matches）
+                            if !ws_broadcast::envelope_matches(conn_workspace, envelope.scope) {
                                 continue;
                             }
                             if ws
@@ -916,7 +932,8 @@ mod app_state_config_helpers_tests {
     /// `Database::new` / `TodoScheduler::new` 是 async 的,所以整体包在
     /// `#[tokio::test]` 的 runtime 里。三个被测方法本身是 sync 的,放到
     /// `block_on` 闭包外执行,避免对 runtime 类型造成约束。
-    async fn build_minimal_state_async() -> AppState {
+    // pub(crate)：094 的 events_handler 测试（events_handler_tests 模块）复用本夹具
+    pub(crate) async fn build_minimal_state_async() -> AppState {
         // 内存数据库:不依赖外部文件,跑得快,适合单测。
         let db = Arc::new(crate::db::Database::new(":memory:").await.unwrap());
 
@@ -1250,5 +1267,72 @@ mod create_app_refactor_tests {
             BODY_LINES_BUDGET,
             sig_line,
         );
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::useless_vec, clippy::redundant_pattern_matching, clippy::redundant_clone, clippy::len_zero, clippy::bool_assert_comparison, clippy::unnecessary_get_then_check, clippy::doc_lazy_continuation, clippy::clone_on_copy, clippy::print_stdout, clippy::needless_pass_by_value, clippy::sliced_string_as_bytes, clippy::manual_map, clippy::collapsible_match, clippy::question_mark)]
+mod events_handler_tests {
+    //! 094：events_handler 新增分支的覆盖（CodeRabbit #1011 评审项）。
+    //! 实时事件过滤由 ws_broadcast::envelope_matches 单测背书；本模块覆盖
+    //! Sync retain 谓词全分支 + query 参数解析的 HTTP 层行为。
+    use super::app_state_config_helpers_tests::build_minimal_state_async;
+    use super::{events_routes, sync_task_visible};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    /// sync_task_visible 全分支：record 匹配/跨 workspace/0 哨兵未归属/无 record 保守保留
+    #[test]
+    fn test_events_handler_sync_task_visible_all_branches() {
+        // 有 record 且归属匹配 → 可见
+        assert!(sync_task_visible(Some(Some(1)), 1));
+        // 有 record 跨 workspace → 不可见（隔离核心）
+        assert!(!sync_task_visible(Some(Some(2)), 1));
+        // 有 record 但 workspace_id=0（未归属哨兵）→ 带参连接不可见
+        assert!(!sync_task_visible(Some(Some(0)), 1));
+        // 有 record 但 workspace_id=None（未归属）→ 同样不可见
+        assert!(!sync_task_visible(Some(None), 1));
+        // 无 record 的异常任务 → 保守保留（决策 2a：DB 降级时宁多勿漏）
+        assert!(sync_task_visible(None, 1));
+    }
+
+    /// 无效 workspace_id 查询参数：Query 反序列化拒绝，不得进入 handler（400 而非 500/panic）
+    #[tokio::test]
+    async fn test_events_handler_rejects_invalid_workspace_id() {
+        let state = build_minimal_state_async().await;
+        let app = events_routes().with_state(state);
+        let resp = app
+            .oneshot(Request::builder().uri("/api/events?workspace_id=abc").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        // axum Query 抽取失败 → 400 Bad Request（在 WS upgrade 之前，无连接泄漏）
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// 有效参数但无 upgrade 头：不得升级，返回 4xx（WS 握手缺失由 axum 拒绝）
+    #[tokio::test]
+    async fn test_events_handler_without_upgrade_header_not_upgraded() {
+        let state = build_minimal_state_async().await;
+        let app = events_routes().with_state(state);
+        let resp = app
+            .oneshot(Request::builder().uri("/api/events?workspace_id=1").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        // axum 对缺 upgrade 头的 WS 路由返回 426 Upgrade Required（或 400）——
+        // 不断言具体码位（axum 版本相关），只锁「非 2xx 且非 500」契约
+        assert!(resp.status().is_client_error(), "got: {}", resp.status());
+    }
+
+    /// 无参数连接（兼容口）：query 缺失同样不得 panic，无 upgrade 头返回 4xx
+    #[tokio::test]
+    async fn test_events_handler_without_query_param_accepted() {
+        let state = build_minimal_state_async().await;
+        let app = events_routes().with_state(state);
+        let resp = app
+            .oneshot(Request::builder().uri("/api/events").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert!(resp.status().is_client_error(), "got: {}", resp.status());
     }
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -27,6 +27,10 @@ pub struct AppState {
     pub db: Arc<Database>,
     pub executor_registry: Arc<ExecutorRegistry>,
     pub tx: broadcast::Sender<ExecEvent>,
+    /// 094：WS 专用广播 channel（预序列化信封）。与 tx 的关系：tx 是事件总线
+    /// （飞书推送等订阅），ws_tx 只服务 WS 客户端——forwarder 任务把 tx 的事件
+    /// 过滤飞书专用、预序列化一次后桥接过来，WS 客户端零序列化共享 Arc<str>。
+    pub ws_tx: broadcast::Sender<ws_broadcast::WsEnvelope>,
     pub scheduler: Arc<TodoScheduler>,
     pub task_manager: Arc<TaskManager>,
     /// In-memory copy of the persisted Config. Wrapped in `std::sync::RwLock`
@@ -159,14 +163,29 @@ pub mod tasks;
 pub mod task_posts;
 pub mod quick_button;
 pub mod profiles;
+/// 094：WS 广播通路（预序列化信封 + forwarder），详见模块 doc
+pub mod ws_broadcast;
 /// workspace 归属校验 helper：v1 路由的租户边界守卫（verify_*_belongs_to_ws）。
 /// 所有 workspace-scoped handler 统一调用，避免跨工作空间越权读写。
 pub mod workspace_guard;
 
 // WebSocket handler
-pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
-    ws.on_upgrade(|mut ws| async move {
-        let mut rx = state.tx.subscribe();
+// 094：query 参数 workspace_id 声明客户端关注的 workspace——只推该 workspace 事件
+// + 全局事件（None 归属）；不带参数的旧客户端全推（兼容口）。
+#[derive(Debug, serde::Deserialize)]
+pub struct EventsQuery {
+    workspace_id: Option<i64>,
+}
+
+pub async fn events_handler(
+    State(state): State<AppState>,
+    ws: WebSocketUpgrade,
+    axum::extract::Query(query): axum::extract::Query<EventsQuery>,
+) -> Response {
+    let conn_workspace = query.workspace_id;
+    ws.on_upgrade(move |mut ws| async move {
+        // 094：订阅 WS 专用 channel（预序列化信封），不再订阅原始 ExecEvent channel
+        let mut rx = state.ws_tx.subscribe();
 
         // 连接时发送当前实际运行的任务列表
         // 批量获取执行记录，避免 N+1 查询
@@ -187,7 +206,22 @@ pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade)
             .into_iter()
             .filter_map(|r| r.task_id.clone().map(|tid| (tid, r)))
             .collect();
-        let record_ids: Vec<i64> = record_map.values().map(|r| r.id).collect();
+        // 094：声明了 workspace 的连接，Sync 只回该 workspace 的运行任务；
+        // 查不到 record 的异常任务保守保留（决策 2a：DB 降级时宁多勿漏）。
+        if let Some(ws_id) = conn_workspace {
+            running_tasks.retain(|t| {
+                record_map
+                    .get(&t.task_id)
+                    .map(|r| r.workspace_id == Some(ws_id))
+                    .unwrap_or(true)
+            });
+        }
+        // record_ids 从过滤后的 running_tasks 反查：尾部日志/计数两个查询
+        // 也随 Sync 过滤收敛，不为其他 workspace 的任务白跑 SQL
+        let record_ids: Vec<i64> = running_tasks
+            .iter()
+            .filter_map(|t| record_map.get(&t.task_id).map(|r| r.id))
+            .collect();
         // reconnect 时每个任务只回传最近 RECONNECT_LOG_CAP 条日志，避免长跑任务的全量日志
         // 把首帧撑爆（既卡 serde 序列化，也卡 WS 推送）。完整历史前端通过 REST 分页按需拉取（091）。
         const RECONNECT_LOG_CAP: usize = 200;
@@ -249,7 +283,8 @@ pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade)
                 .await;
         }
 
-        // 循环从 broadcast channel 读取事件并推到 WebSocket。
+        // 循环从 WS 专用 channel 读取预序列化信封并按 workspace 匹配推送（094）。
+        // 序列化已在 forwarder 全局做一次，此处仅 Arc 共享 + 一次 memcpy。
         //
         // 注意 `rx.recv()` 在 channel 容量耗尽时返回 `RecvError::Lagged(n)`:
         // ring buffer 已被覆盖,n 条旧事件丢失(包括可能错过的 Finished 等
@@ -271,13 +306,13 @@ pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade)
             tokio::select! {
                 recv = rx.recv() => {
                     match recv {
-                        Ok(event) => {
-                            let json = serde_json::to_string(&event).unwrap_or_default();
-                            if json.is_empty() {
+                        Ok(envelope) => {
+                            // 094：workspace 匹配判定（三态真值表见 envelope_matches）
+                            if !ws_broadcast::envelope_matches(conn_workspace, envelope.workspace_id) {
                                 continue;
                             }
                             if ws
-                                .send(axum::extract::ws::Message::Text(json.into()))
+                                .send(axum::extract::ws::Message::Text(envelope.json.as_ref().into()))
                                 .await
                                 .is_err()
                             {
@@ -289,7 +324,7 @@ pub async fn events_handler(State(state): State<AppState>, ws: WebSocketUpgrade)
                                 "[ws-events] client lagged, skipped {} events; resubscribing to skip backlog",
                                 n
                             );
-                            rx = state.tx.subscribe();
+                            rx = state.ws_tx.subscribe();
                         }
                         Err(broadcast::error::RecvError::Closed) => {
                             tracing::info!("[ws-events] broadcast channel closed, closing WebSocket");
@@ -443,6 +478,16 @@ async fn build_app_state(
     let (push_service, push_mutator) = FeishuPushService::new(db.clone(), feishu_listener.clone());
     push_service.start(tx.subscribe());
 
+    // 094：WS 专用 channel + forwarder。容量与 tx 同配置——同一事件洪峰量级，
+    // WS 客户端的 Lagged 容忍度已在 events_handler 用 resubscribe 处理。
+    // config 读守卫与 main.rs 建 tx 时同款（RwLock 读 panic 容忍恢复）。
+    let broadcast_capacity = config
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .broadcast_channel_capacity;
+    let (ws_tx, _) = broadcast::channel(broadcast_capacity);
+    ws_broadcast::spawn_ws_forwarder(&tx, ws_tx.clone());
+
     // feishu_listener 按引用传入避免 clone 整个 Arc；函数内部只 clone 内部字段
     spawn_feishu_history_fetcher(ctx.clone(), db.clone(), &feishu_listener, debounce.clone());
     ensure_default_review_template_blocking(&db);
@@ -477,6 +522,7 @@ async fn build_app_state(
         db,
         executor_registry,
         tx: tx.clone(),
+        ws_tx,
         scheduler,
         task_manager,
         config,
@@ -901,11 +947,14 @@ mod app_state_config_helpers_tests {
         );
 
         let (feishu_push_mutator, _rx2) = broadcast::channel(1);
+        // 094：测试最小态补 ws_tx（forwarder 不启动——测试不依赖事件桥接）
+        let (ws_tx, _rx3) = broadcast::channel(1);
 
         AppState {
             db,
             executor_registry: Arc::new(ExecutorRegistry::default()),
             tx: ctx.tx.clone(),
+            ws_tx,
             scheduler,
             task_manager: ctx.task_manager.clone(),
             config: ctx.config.clone(),

--- a/backend/src/handlers/ws_broadcast.rs
+++ b/backend/src/handlers/ws_broadcast.rs
@@ -1,0 +1,176 @@
+//! 094：WS 广播通路——预序列化信封 + forwarder 任务。
+//!
+//! 背景：原 `events_handler` 主循环让每个 WS 客户端各自 `serde_json::to_string(&event)`，
+//! N 个标签页 = N 次序列化同一事件；且不区分 workspace，全量事件推给全量客户端。
+//!
+//! 本模块把「序列化 + workspace 归属」收敛到单一 forwarder 任务：
+//! 订阅现有 ExecEvent channel → 过滤飞书专用事件 → 序列化一次 →
+//! 发 `WsEnvelope`（json 为 `Arc<str>`，全客户端共享零拷贝）。
+//! 原 ExecEvent channel 的 12 个发送点与飞书推送订阅侧因此零改动。
+
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+use crate::executor_service::ExecEvent;
+
+/// WS 广播信封：事件 JSON 文本 + workspace 过滤键。
+///
+/// `json` 用 `Arc<str>` 而非 String：广播语义下同一事件要发给 N 个客户端，
+/// Arc 共享让 clone 只是引用计数自增，序列化产物全局唯一一份。
+#[derive(Debug, Clone)]
+pub struct WsEnvelope {
+    /// 事件归属的 workspace；None = 全局事件（Sync/ReviewStatusChanged 等），全量转发
+    pub workspace_id: Option<i64>,
+    /// 预序列化的事件 JSON（与 ExecEvent 的 serde tag 格式一致）
+    pub json: Arc<str>,
+}
+
+/// 连接声明与事件归属的匹配判定（events_handler 主循环的唯一过滤规则）。
+///
+/// 三态真值表（经用户确认的决策 1a/3a）：
+/// - 连接未声明 workspace（None）→ 全推（兼容旧客户端/第三方接入）；
+/// - 连接声明 Some(ws)，事件为全局（None）→ 推（全局事件不含 workspace 敏感信息）；
+/// - 连接声明 Some(ws)，事件归属 Some(ev_ws)→ 仅相等才推（跨 workspace 隔离）。
+pub fn envelope_matches(conn_workspace: Option<i64>, envelope_workspace: Option<i64>) -> bool {
+    match (conn_workspace, envelope_workspace) {
+        (None, _) => true,
+        (Some(_), None) => true,
+        (Some(conn), Some(ev)) => conn == ev,
+    }
+}
+
+/// 启动 WS 转发任务：ExecEvent channel → WS channel 的单向桥。
+///
+/// 在 `build_app_state` 中随 AppState 初始化启动；进程级单例（多实例会重复推送）。
+/// Lagged 策略与 feishu_push 对齐：warn 并继续（WS 客户端对事件丢失的容忍度
+/// 高于飞书推送——前端有 Sync 握手兜底重建状态，且 Lagged 本身意味着客户端
+/// 已经跟不上，跳积压比追积压更符合实时性诉求）。
+pub fn spawn_ws_forwarder(
+    // 引用取向：函数体只做 subscribe()（ Sender 的 &self 方法），
+    // 调用方保留 owned 句柄写 AppState，无消费即不取所有权
+    tx: &broadcast::Sender<ExecEvent>,
+    ws_tx: broadcast::Sender<WsEnvelope>,
+) {
+    // subscribe 必须在 spawn 之前：保证转发从启动点之后的事件开始，
+    // 不受 channel 里积压历史事件影响（ring buffer 语义，订阅即定位到当前 head）
+    let mut rx = tx.subscribe();
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    // 飞书专用定向事件不进 WS channel：前端无消费分支，纯带宽浪费
+                    if event.is_feishu_direct() {
+                        continue;
+                    }
+                    // workspace_id 提取先于序列化：过滤键与载荷分离，
+                    // 即使序列化失败也能决定归属（防御性取值顺序）
+                    let workspace_id = event.workspace_id();
+                    // 序列化失败理论不可达（serde_json 对纯数据枚举不失败）；
+                    // 失败时跳过本条而非 panic——单事件丢失由前端 Sync 兜底，
+                    // forwarder 进程级崩溃会让全量 WS 推送停摆，绝不允许
+                    let Ok(json) = serde_json::to_string(&event) else {
+                        tracing::error!("[ws-forwarder] 事件序列化失败，跳过本条: {event:?}");
+                        continue;
+                    };
+                    let envelope = WsEnvelope {
+                        workspace_id,
+                        json: Arc::from(json.as_str()),
+                    };
+                    // send 失败 = 当前零订阅者（无 WS 客户端在线），正常场景，吞掉即可
+                    let _ = ws_tx.send(envelope);
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    // 见函数 doc：warn 并继续，不重订阅（与 feishu_push 对齐）
+                    tracing::warn!("[ws-forwarder] lagged, skipped {n} events");
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    // 上游 channel 关闭 = 进程关停中，退出任务
+                    tracing::info!("[ws-forwarder] ExecEvent channel closed, forwarder exiting");
+                    break;
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::useless_vec, clippy::redundant_pattern_matching, clippy::redundant_clone, clippy::len_zero, clippy::bool_assert_comparison, clippy::unnecessary_get_then_check, clippy::doc_lazy_continuation, clippy::clone_on_copy, clippy::print_stdout, clippy::needless_pass_by_value, clippy::sliced_string_as_bytes, clippy::manual_map, clippy::collapsible_match, clippy::question_mark)]
+mod tests {
+    use super::*;
+    use crate::models::ParsedLogEntry;
+
+    /// envelope_matches 三态真值表全枚举（决策 1a/3a 的行为契约）
+    #[test]
+    fn test_envelope_matches_truth_table() {
+        // 无参数连接：全推（兼容）
+        assert!(envelope_matches(None, None));
+        assert!(envelope_matches(None, Some(1)));
+        // 有参数连接 + 全局事件：推
+        assert!(envelope_matches(Some(1), None));
+        // 有参数连接 + 归属事件：仅相等推
+        assert!(envelope_matches(Some(1), Some(1)));
+        assert!(!envelope_matches(Some(1), Some(2)));
+    }
+
+    /// ExecEvent::workspace_id 全 13 变体提取矩阵（漏变体编译期即报 non-exhaustive，
+    /// 本测试锁运行时取值语义：Option 透传 / i64 包 Some / 全局组 None）
+    #[test]
+    fn test_workspace_id_all_variants() {
+        let entry = ParsedLogEntry::new("info", "x");
+        let cases: Vec<(ExecEvent, Option<i64>)> = vec![
+            // Option<i64> 组：透传（Some 与 None 各取代表）
+            (ExecEvent::Started { task_id: "t".into(), todo_id: 1, todo_title: "t".into(), executor: "e".into(), workspace_id: Some(7) }, Some(7)),
+            (ExecEvent::Output { task_id: "t".into(), entry: entry.clone(), workspace_id: None }, None),
+            (ExecEvent::Finished { task_id: "t".into(), todo_id: 1, todo_title: "t".into(), executor: "e".into(), success: true, result: None, feishu_bot_id: None, feishu_receive_id: None, feishu_receive_id_type: None, workspace_id: Some(3), duration_secs: 0, total_tokens: 0, trigger_type: None }, Some(3)),
+            (ExecEvent::TodoProgress { task_id: "t".into(), progress: vec![], workspace_id: Some(2) }, Some(2)),
+            (ExecEvent::ExecutionStats { task_id: "t".into(), stats: crate::models::ExecutionStats { tool_calls: 0, conversation_turns: 0, thinking_count: 0 }, workspace_id: Some(5) }, Some(5)),
+            (ExecEvent::LoopFinished { loop_execution_id: 1, loop_id: 1, loop_title: "l".into(), status: "success".into(), total_steps: 1, completed_steps: 1, failed_steps: 0, duration_secs: 0, total_tokens: 0, workspace_id: Some(9) }, Some(9)),
+            // i64 必填组：包 Some
+            (ExecEvent::BlackboardDebounceStatus { workspace_id: 4, pending_count: 0, threshold: 1, debounce_secs: 1, remaining_secs: -1, refreshing: false }, Some(4)),
+            (ExecEvent::WikiChatStarted { task_id: "t".into(), workspace_id: 6, executor: "e".into(), message: "m".into() }, Some(6)),
+            (ExecEvent::WikiChatOutput { task_id: "t".into(), workspace_id: 8, entry }, Some(8)),
+            (ExecEvent::WikiChatFinished { task_id: "t".into(), workspace_id: 10, success: true, result: None, duration_secs: 0 }, Some(10)),
+            // 全局/飞书专用组：None
+            (ExecEvent::Sync { tasks: vec![] }, None),
+            (ExecEvent::ReviewStatusChanged { record_id: 1, todo_id: 1, review_status: "approved".into() }, None),
+            (ExecEvent::DirectCardMessage { bot_id: 1, receive_id: "r".into(), receive_id_type: "open_id".into(), content: "c".into() }, None),
+            (ExecEvent::DirectStreamMessage { bot_id: 1, receive_id: "r".into(), receive_id_type: "open_id".into(), entry: ParsedLogEntry::new("info", "x") }, None),
+        ];
+        assert_eq!(cases.len(), 14, "变体覆盖数（含 Output 的 None 代表）");
+        for (event, expected) in cases {
+            assert_eq!(event.workspace_id(), expected, "{event:?}");
+        }
+    }
+
+    /// is_feishu_direct：仅 DirectCard/DirectStream 两变体为 true
+    #[test]
+    fn test_is_feishu_direct_only_direct_variants() {
+        assert!(ExecEvent::DirectCardMessage { bot_id: 1, receive_id: "r".into(), receive_id_type: "open_id".into(), content: "c".into() }.is_feishu_direct());
+        assert!(ExecEvent::DirectStreamMessage { bot_id: 1, receive_id: "r".into(), receive_id_type: "open_id".into(), entry: ParsedLogEntry::new("info", "x") }.is_feishu_direct());
+        assert!(!ExecEvent::Sync { tasks: vec![] }.is_feishu_direct());
+        assert!(!ExecEvent::Started { task_id: "t".into(), todo_id: 1, todo_title: "t".into(), executor: "e".into(), workspace_id: None }.is_feishu_direct());
+    }
+
+    /// forwarder 端到端：飞书专用被拦截、正常事件携带正确 workspace_id 与 JSON 文本
+    #[tokio::test]
+    async fn test_spawn_ws_forwarder_filters_and_preserializes() {
+        let (tx, _) = broadcast::channel(8);
+        let (ws_tx, mut ws_rx) = broadcast::channel(8);
+        spawn_ws_forwarder(&tx, ws_tx);
+
+        // 飞书专用事件：不应出现在 WS channel
+        tx.send(ExecEvent::DirectCardMessage { bot_id: 1, receive_id: "r".into(), receive_id_type: "open_id".into(), content: "c".into() }).unwrap();
+        // 正常事件：应转发且 workspace_id/JSON 正确
+        tx.send(ExecEvent::Started { task_id: "t".into(), todo_id: 1, todo_title: "T".into(), executor: "e".into(), workspace_id: Some(42) }).unwrap();
+
+        let env = tokio::time::timeout(std::time::Duration::from_secs(2), ws_rx.recv())
+            .await
+            .expect("应收到正常事件信封")
+            .unwrap();
+        assert_eq!(env.workspace_id, Some(42));
+        // 预序列化文本即前端收到的线上格式（serde tag=type）
+        assert!(env.json.contains("\"type\":\"Started\""), "json: {}", env.json);
+        // DirectCardMessage 已被拦截：channel 中无更多消息
+        assert!(ws_rx.try_recv().is_err(), "飞书专用事件不应进入 WS channel");
+    }
+}

--- a/backend/src/handlers/ws_broadcast.rs
+++ b/backend/src/handlers/ws_broadcast.rs
@@ -11,31 +11,44 @@
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
-use crate::executor_service::ExecEvent;
+use crate::executor_service::{EventScope, ExecEvent};
 
-/// WS 广播信封：事件 JSON 文本 + workspace 过滤键。
+/// WS 广播信封：事件 JSON 文本 + 作用域过滤键。
 ///
 /// `json` 用 `Arc<str>` 而非 String：广播语义下同一事件要发给 N 个客户端，
 /// Arc 共享让 clone 只是引用计数自增，序列化产物全局唯一一份。
 #[derive(Debug, Clone)]
 pub struct WsEnvelope {
-    /// 事件归属的 workspace；None = 全局事件（Sync/ReviewStatusChanged 等），全量转发
-    pub workspace_id: Option<i64>,
+    /// 事件作用域（Global/Workspace/Unscoped 三态语义见 EventScope doc）
+    pub scope: EventScope,
     /// 预序列化的事件 JSON（与 ExecEvent 的 serde tag 格式一致）
     pub json: Arc<str>,
 }
 
-/// 连接声明与事件归属的匹配判定（events_handler 主循环的唯一过滤规则）。
+/// 连接声明与事件作用域的匹配判定（events_handler 主循环的唯一过滤规则）。
 ///
-/// 三态真值表（经用户确认的决策 1a/3a）：
-/// - 连接未声明 workspace（None）→ 全推（兼容旧客户端/第三方接入）；
-/// - 连接声明 Some(ws)，事件为全局（None）→ 推（全局事件不含 workspace 敏感信息）；
-/// - 连接声明 Some(ws)，事件归属 Some(ev_ws)→ 仅相等才推（跨 workspace 隔离）。
-pub fn envelope_matches(conn_workspace: Option<i64>, envelope_workspace: Option<i64>) -> bool {
-    match (conn_workspace, envelope_workspace) {
-        (None, _) => true,
-        (Some(_), None) => true,
-        (Some(conn), Some(ev)) => conn == ev,
+/// 行为契约（CodeRabbit #1011 评审修订后）：
+/// - 连接未声明 workspace（None）→ 全推（兼容旧客户端/第三方接入，含未归属事件）；
+/// - 连接声明 Some(ws)，事件 Global → 推（无 workspace 敏感信息）；
+/// - 连接声明 Some(ws)，事件 Workspace(ev) → 仅相等才推（跨 workspace 隔离）；
+/// - 连接声明 Some(ws)，事件 Unscoped（未归属：None/哨兵 0）→ 不推——
+///   与 todo 列表的 workspace 过滤语义对齐（未归属在任何 workspace 视图均不显示），
+///   同时避免未归属 loop/任务的标题日志流进所有面板。
+pub fn envelope_matches(conn_workspace: Option<i64>, scope: EventScope) -> bool {
+    match conn_workspace {
+        // 无参连接全推：旧前端/第三方客户端的兼容口，本服务单用户本地工具定位，
+        // 不构成新暴露面（决策 1a 时用户已确认）
+        None => true,
+        Some(conn) => match scope {
+            // 全局事件无 workspace 敏感信息（Sync 是连接级握手产物不进 channel，
+            // 实际走到这的只有 ReviewStatusChanged 类），带参连接照常收
+            EventScope::Global => true,
+            // 归属事件严格相等才推——跨 workspace 隔离的核心判定
+            EventScope::Workspace(ev) => conn == ev,
+            // 未归属事件（None/哨兵 0）不推带参连接：与 todo 列表过滤语义对齐，
+            // 未归属任务在任何 workspace 视图本就不显示（CodeRabbit 安全评审项）
+            EventScope::Unscoped => false,
+        },
     }
 }
 
@@ -62,9 +75,9 @@ pub fn spawn_ws_forwarder(
                     if event.is_feishu_direct() {
                         continue;
                     }
-                    // workspace_id 提取先于序列化：过滤键与载荷分离，
+                    // 作用域提取先于序列化：过滤键与载荷分离，
                     // 即使序列化失败也能决定归属（防御性取值顺序）
-                    let workspace_id = event.workspace_id();
+                    let scope = event.event_scope();
                     // 序列化失败理论不可达（serde_json 对纯数据枚举不失败）；
                     // 失败时跳过本条而非 panic——单事件丢失由前端 Sync 兜底，
                     // forwarder 进程级崩溃会让全量 WS 推送停摆，绝不允许
@@ -73,7 +86,7 @@ pub fn spawn_ws_forwarder(
                         continue;
                     };
                     let envelope = WsEnvelope {
-                        workspace_id,
+                        scope,
                         json: Arc::from(json.as_str()),
                     };
                     // send 失败 = 当前零订阅者（无 WS 客户端在线），正常场景，吞掉即可
@@ -99,46 +112,54 @@ mod tests {
     use super::*;
     use crate::models::ParsedLogEntry;
 
-    /// envelope_matches 三态真值表全枚举（决策 1a/3a 的行为契约）
+    /// envelope_matches 行为契约全枚举（CodeRabbit #1011 修订版）：
+    /// 无参全推 / Global 全推 / Workspace 相等才推 / Unscoped 不推带参连接
     #[test]
-    fn test_envelope_matches_truth_table() {
-        // 无参数连接：全推（兼容）
-        assert!(envelope_matches(None, None));
-        assert!(envelope_matches(None, Some(1)));
+    fn test_envelope_matches_scope_matrix() {
+        // 无参数连接：全推（兼容口，含未归属事件）
+        assert!(envelope_matches(None, EventScope::Global));
+        assert!(envelope_matches(None, EventScope::Workspace(1)));
+        assert!(envelope_matches(None, EventScope::Unscoped));
         // 有参数连接 + 全局事件：推
-        assert!(envelope_matches(Some(1), None));
+        assert!(envelope_matches(Some(1), EventScope::Global));
         // 有参数连接 + 归属事件：仅相等推
-        assert!(envelope_matches(Some(1), Some(1)));
-        assert!(!envelope_matches(Some(1), Some(2)));
+        assert!(envelope_matches(Some(1), EventScope::Workspace(1)));
+        assert!(!envelope_matches(Some(1), EventScope::Workspace(2)));
+        // 有参数连接 + 未归属事件：不推（CodeRabbit 安全评审项——
+        // 未归属 loop/任务的标题日志不应流进任何带参面板）
+        assert!(!envelope_matches(Some(1), EventScope::Unscoped));
     }
 
-    /// ExecEvent::workspace_id 全 13 变体提取矩阵（漏变体编译期即报 non-exhaustive，
-    /// 本测试锁运行时取值语义：Option 透传 / i64 包 Some / 全局组 None）
+    /// event_scope 全 14 变体提取矩阵（漏变体编译期即报 non-exhaustive）：
+    /// 锁三态归类语义——Some(N>0)→Workspace、None/Some(0)→Unscoped、全局组→Global
     #[test]
-    fn test_workspace_id_all_variants() {
+    fn test_event_scope_all_variants() {
         let entry = ParsedLogEntry::new("info", "x");
-        let cases: Vec<(ExecEvent, Option<i64>)> = vec![
-            // Option<i64> 组：透传（Some 与 None 各取代表）
-            (ExecEvent::Started { task_id: "t".into(), todo_id: 1, todo_title: "t".into(), executor: "e".into(), workspace_id: Some(7) }, Some(7)),
-            (ExecEvent::Output { task_id: "t".into(), entry: entry.clone(), workspace_id: None }, None),
-            (ExecEvent::Finished { task_id: "t".into(), todo_id: 1, todo_title: "t".into(), executor: "e".into(), success: true, result: None, feishu_bot_id: None, feishu_receive_id: None, feishu_receive_id_type: None, workspace_id: Some(3), duration_secs: 0, total_tokens: 0, trigger_type: None }, Some(3)),
-            (ExecEvent::TodoProgress { task_id: "t".into(), progress: vec![], workspace_id: Some(2) }, Some(2)),
-            (ExecEvent::ExecutionStats { task_id: "t".into(), stats: crate::models::ExecutionStats { tool_calls: 0, conversation_turns: 0, thinking_count: 0 }, workspace_id: Some(5) }, Some(5)),
-            (ExecEvent::LoopFinished { loop_execution_id: 1, loop_id: 1, loop_title: "l".into(), status: "success".into(), total_steps: 1, completed_steps: 1, failed_steps: 0, duration_secs: 0, total_tokens: 0, workspace_id: Some(9) }, Some(9)),
-            // i64 必填组：包 Some
-            (ExecEvent::BlackboardDebounceStatus { workspace_id: 4, pending_count: 0, threshold: 1, debounce_secs: 1, remaining_secs: -1, refreshing: false }, Some(4)),
-            (ExecEvent::WikiChatStarted { task_id: "t".into(), workspace_id: 6, executor: "e".into(), message: "m".into() }, Some(6)),
-            (ExecEvent::WikiChatOutput { task_id: "t".into(), workspace_id: 8, entry }, Some(8)),
-            (ExecEvent::WikiChatFinished { task_id: "t".into(), workspace_id: 10, success: true, result: None, duration_secs: 0 }, Some(10)),
-            // 全局/飞书专用组：None
-            (ExecEvent::Sync { tasks: vec![] }, None),
-            (ExecEvent::ReviewStatusChanged { record_id: 1, todo_id: 1, review_status: "approved".into() }, None),
-            (ExecEvent::DirectCardMessage { bot_id: 1, receive_id: "r".into(), receive_id_type: "open_id".into(), content: "c".into() }, None),
-            (ExecEvent::DirectStreamMessage { bot_id: 1, receive_id: "r".into(), receive_id_type: "open_id".into(), entry: ParsedLogEntry::new("info", "x") }, None),
+        let cases: Vec<(ExecEvent, EventScope)> = vec![
+            // 生命周期组（Option<i64>）：N>0 归属
+            (ExecEvent::Started { task_id: "t".into(), todo_id: 1, todo_title: "t".into(), executor: "e".into(), workspace_id: Some(7) }, EventScope::Workspace(7)),
+            // None → Unscoped（未归属 loop 路径）
+            (ExecEvent::Output { task_id: "t".into(), entry: entry.clone(), workspace_id: None }, EventScope::Unscoped),
+            // Some(0) 哨兵 → Unscoped（DB 默认值语义：未分配工作空间）
+            (ExecEvent::Finished { task_id: "t".into(), todo_id: 1, todo_title: "t".into(), executor: "e".into(), success: true, result: None, feishu_bot_id: None, feishu_receive_id: None, feishu_receive_id_type: None, workspace_id: Some(0), duration_secs: 0, total_tokens: 0, trigger_type: None }, EventScope::Unscoped),
+            (ExecEvent::TodoProgress { task_id: "t".into(), progress: vec![], workspace_id: Some(2) }, EventScope::Workspace(2)),
+            (ExecEvent::ExecutionStats { task_id: "t".into(), stats: crate::models::ExecutionStats { tool_calls: 0, conversation_turns: 0, thinking_count: 0 }, workspace_id: Some(5) }, EventScope::Workspace(5)),
+            (ExecEvent::LoopFinished { loop_execution_id: 1, loop_id: 1, loop_title: "l".into(), status: "success".into(), total_steps: 1, completed_steps: 1, failed_steps: 0, duration_secs: 0, total_tokens: 0, workspace_id: Some(9) }, EventScope::Workspace(9)),
+            // 黑板/WikiChat 组（i64 必填）：0 同按未归属哨兵
+            (ExecEvent::BlackboardDebounceStatus { workspace_id: 4, pending_count: 0, threshold: 1, debounce_secs: 1, remaining_secs: -1, refreshing: false }, EventScope::Workspace(4)),
+            (ExecEvent::WikiChatStarted { task_id: "t".into(), workspace_id: 0, executor: "e".into(), message: "m".into() }, EventScope::Unscoped),
+            (ExecEvent::WikiChatOutput { task_id: "t".into(), workspace_id: 8, entry }, EventScope::Workspace(8)),
+            (ExecEvent::WikiChatFinished { task_id: "t".into(), workspace_id: 10, success: true, result: None, duration_secs: 0 }, EventScope::Workspace(10)),
+            // 全局组
+            (ExecEvent::Sync { tasks: vec![] }, EventScope::Global),
+            (ExecEvent::ReviewStatusChanged { record_id: 1, todo_id: 1, review_status: "approved".into() }, EventScope::Global),
+            // 飞书专用组：防御兜底 Global（实际在 forwarder 已被拦截）
+            (ExecEvent::DirectCardMessage { bot_id: 1, receive_id: "r".into(), receive_id_type: "open_id".into(), content: "c".into() }, EventScope::Global),
+            (ExecEvent::DirectStreamMessage { bot_id: 1, receive_id: "r".into(), receive_id_type: "open_id".into(), entry: ParsedLogEntry::new("info", "x") }, EventScope::Global),
         ];
-        assert_eq!(cases.len(), 14, "变体覆盖数（含 Output 的 None 代表）");
+        assert_eq!(cases.len(), 14, "全 14 变体覆盖");
         for (event, expected) in cases {
-            assert_eq!(event.workspace_id(), expected, "{event:?}");
+            assert_eq!(event.event_scope(), expected, "{event:?}");
         }
     }
 
@@ -151,7 +172,7 @@ mod tests {
         assert!(!ExecEvent::Started { task_id: "t".into(), todo_id: 1, todo_title: "t".into(), executor: "e".into(), workspace_id: None }.is_feishu_direct());
     }
 
-    /// forwarder 端到端：飞书专用被拦截、正常事件携带正确 workspace_id 与 JSON 文本
+    /// forwarder 端到端：飞书专用被拦截、正常事件携带正确作用域与 JSON 文本
     #[tokio::test]
     async fn test_spawn_ws_forwarder_filters_and_preserializes() {
         let (tx, _) = broadcast::channel(8);
@@ -160,14 +181,14 @@ mod tests {
 
         // 飞书专用事件：不应出现在 WS channel
         tx.send(ExecEvent::DirectCardMessage { bot_id: 1, receive_id: "r".into(), receive_id_type: "open_id".into(), content: "c".into() }).unwrap();
-        // 正常事件：应转发且 workspace_id/JSON 正确
+        // 正常事件：应转发且 scope/JSON 正确
         tx.send(ExecEvent::Started { task_id: "t".into(), todo_id: 1, todo_title: "T".into(), executor: "e".into(), workspace_id: Some(42) }).unwrap();
 
         let env = tokio::time::timeout(std::time::Duration::from_secs(2), ws_rx.recv())
             .await
             .expect("应收到正常事件信封")
             .unwrap();
-        assert_eq!(env.workspace_id, Some(42));
+        assert_eq!(env.scope, EventScope::Workspace(42));
         // 预序列化文本即前端收到的线上格式（serde tag=type）
         assert!(env.json.contains("\"type\":\"Started\""), "json: {}", env.json);
         // DirectCardMessage 已被拦截：channel 中无更多消息

--- a/docs/design/094-WS广播预序列化与workspace过滤-设计.md
+++ b/docs/design/094-WS广播预序列化与workspace过滤-设计.md
@@ -3,6 +3,7 @@
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | AI (zhanlu) | 2026-08-10 | 初始版本 |
+| AI (zhanlu) | 2026-08-10 | 按 CodeRabbit 评审：forwarder 启动位置/签名同步最终实现、流程图声明 text 语言、变体数 13→14、workspace_id 升级为 EventScope 三态（区分未归属与全局） |
 
 > 093 优化扫描专项·性能类第 1 项（首轮扫描 P1）。
 > 实证：每条执行事件 N 个 WS 客户端（标签页）各自序列化一次；所有 workspace 的事件推给所有客户端。
@@ -41,16 +42,16 @@ WS 客户端收到后前端 switch 无对应分支，纯带宽浪费。
 
 ### 入选：forwarder + WS 专用 channel（最小侵入）
 
-```
+```text
 ExecEvent channel (state.tx)      ← 现有链路零改动（12 发送点 + 飞书订阅侧）
    │
-   ▼ forwarder 任务（main.rs 启动）
+   ▼ forwarder 任务（handlers/mod.rs::build_app_state 启动）
    跳过飞书专用事件 → serde_json::to_string 一次 → ws_tx.send(WsEnvelope)
    │
-WsEnvelope { workspace_id: Option<i64>, json: Arc<str> }   ← 全局唯一序列化产物
+WsEnvelope { scope: EventScope, json: Arc<str> }   ← 全局唯一序列化产物
    │
    ▼ events_handler（/api/events?workspace_id=N）
-   envelope.workspace_id 与连接声明匹配才转发；Arc<str> 全客户端共享
+   envelope.scope 与连接声明匹配才转发；Arc<str> 全客户端共享
 ```
 
 ### 落选：改原 channel 为 envelope
@@ -84,7 +85,7 @@ impl ExecEvent {
 }
 ```
 
-13 变体全枚举（漏一个编译器会报 non-exhaustive，天然守卫）。
+14 变体全枚举（漏一个编译器会报 non-exhaustive，天然守卫）。
 
 ### C2：WsEnvelope + forwarder（handlers/mod.rs 或独立模块）
 
@@ -97,7 +98,7 @@ pub struct WsEnvelope {
 }
 
 /// 启动转发任务：订阅 ExecEvent channel → 过滤飞书专用 → 预序列化 → 发 WS channel
-pub fn spawn_ws_forwarder(tx: broadcast::Sender<ExecEvent>, ws_tx: broadcast::Sender<WsEnvelope>);
+pub fn spawn_ws_forwarder(tx: &broadcast::Sender<ExecEvent>, ws_tx: broadcast::Sender<WsEnvelope>);
 ```
 
 `AppState` 增加 `ws_tx: broadcast::Sender<WsEnvelope>`；容量复用现有
@@ -124,8 +125,8 @@ pub fn spawn_ws_forwarder(tx: broadcast::Sender<ExecEvent>, ws_tx: broadcast::Se
 | 文件 | 改动 |
 |------|------|
 | `executor_service/events.rs` | +2 方法 +全变体单测 |
-| `handlers/mod.rs` | WsEnvelope、forwarder、handler 过滤 |
-| `main.rs` | 启动 forwarder；AppState.ws_tx 初始化 |
+| `handlers/ws_broadcast.rs`（新模块） | WsEnvelope、envelope_matches、spawn_ws_forwarder |
+| `handlers/mod.rs` | AppState.ws_tx 接线、build_app_state 启动 forwarder、handler 过滤 |
 | `handlers/*`（AppState 构造点） | 补 ws_tx 字段（编译器找齐） |
 | `frontend/src/hooks/useExecutionEvents.ts` | URL 参数 + 切换重连 |
 

--- a/docs/design/094-WS广播预序列化与workspace过滤-设计.md
+++ b/docs/design/094-WS广播预序列化与workspace过滤-设计.md
@@ -1,0 +1,162 @@
+# 094-WS广播预序列化与workspace过滤-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (zhanlu) | 2026-08-10 | 初始版本 |
+
+> 093 优化扫描专项·性能类第 1 项（首轮扫描 P1）。
+> 实证：每条执行事件 N 个 WS 客户端（标签页）各自序列化一次；所有 workspace 的事件推给所有客户端。
+
+## 1. 现状与证据
+
+### 1.1 逐客户端重复序列化
+
+`handlers/mod.rs::events_handler` 主循环（~L275）：
+
+```rust
+Ok(event) => {
+    let json = serde_json::to_string(&event).unwrap_or_default();  // 每客户端各序列化一次
+    ws.send(Message::Text(json.into()))                            // 每客户端各分配一份 String
+}
+```
+
+N 个标签页 = 同一事件 N 次序列化 + N 次堆分配。执行器日志洪峰期（Output 事件每秒数十条）
+放大为 CPU 尖峰。
+
+### 1.2 无 workspace 过滤
+
+- 主循环：`broadcast::Receiver<ExecEvent>` 收到什么发什么，不看 `workspace_id`；
+- Sync 握手：`task_manager.get_all_task_infos()` 全量返回，不按 workspace 过滤
+  （`TaskInfo` 无 workspace 字段，需经 execution_record 反查）；
+- 前端 `useExecutionEvents.ts`：`new WebSocket("/api/events")` 无参数，
+  全局 dispatch 不按 workspace 区分——**跨 workspace 的任务标题/日志流对任意面板可见
+  （轻度租户信息泄露），本设计顺带消除**。
+
+### 1.3 附带浪费
+
+`DirectCardMessage`/`DirectStreamMessage` 是飞书专用事件（bot_id/receive_id 定向），
+WS 客户端收到后前端 switch 无对应分支，纯带宽浪费。
+
+## 2. 方案选型
+
+### 入选：forwarder + WS 专用 channel（最小侵入）
+
+```
+ExecEvent channel (state.tx)      ← 现有链路零改动（12 发送点 + 飞书订阅侧）
+   │
+   ▼ forwarder 任务（main.rs 启动）
+   跳过飞书专用事件 → serde_json::to_string 一次 → ws_tx.send(WsEnvelope)
+   │
+WsEnvelope { workspace_id: Option<i64>, json: Arc<str> }   ← 全局唯一序列化产物
+   │
+   ▼ events_handler（/api/events?workspace_id=N）
+   envelope.workspace_id 与连接声明匹配才转发；Arc<str> 全客户端共享
+```
+
+### 落选：改原 channel 为 envelope
+
+`state.tx: broadcast::Sender<(ExecEvent, Arc<str>)>` 一步到位，但 12 个发送文件 +
+`feishu_push` 订阅侧全要改，侵入面 3 倍于入选方案，且飞书路径不需要 JSON（白序列化）。
+落选理由：YAGNI + 最小侵入。
+
+### 关键取舍
+
+- **预序列化时机**：forwarder 无条件序列化（即使零 WS 客户端）。
+  序列化微秒级，换来 channel 消息语义单一，值得；
+- **零拷贝级别**：`Arc<str>` 共享，WS 发送时 `Message::text(&*json)` 一次 memcpy。
+  彻底零拷贝（Bytes/Utf8Bytes 直进 channel）留作后续——memcpy 相对序列化成本可忽略；
+- **兼容性**：无 `workspace_id` 参数的连接全推（旧前端/第三方客户端行为不变）；
+- **全局事件**：`workspace_id()` 返回 None 的变体（ReviewStatusChanged 等）全推——
+  这些事件不含 workspace 敏感信息（经用户确认的决策点 3a）；
+- **Sync 异常任务**：DB 降级查不到 record 的任务保守保留（决策点 2a）。
+
+## 3. 设计明细
+
+### C1：`ExecEvent` 查询方法（events.rs）
+
+```rust
+impl ExecEvent {
+    /// 事件的 workspace 归属：None = 全局事件（Sync/ReviewStatusChanged/飞书直发）
+    pub fn workspace_id(&self) -> Option<i64>;
+
+    /// 飞书专用事件（DirectCardMessage/DirectStreamMessage）：WS 客户端不消费
+    pub fn is_feishu_direct(&self) -> bool;
+}
+```
+
+13 变体全枚举（漏一个编译器会报 non-exhaustive，天然守卫）。
+
+### C2：WsEnvelope + forwarder（handlers/mod.rs 或独立模块）
+
+```rust
+/// WS 广播信封：json 为预序列化产物（全局一份），workspace_id 为过滤键
+#[derive(Debug, Clone)]
+pub struct WsEnvelope {
+    pub workspace_id: Option<i64>,
+    pub json: Arc<str>,
+}
+
+/// 启动转发任务：订阅 ExecEvent channel → 过滤飞书专用 → 预序列化 → 发 WS channel
+pub fn spawn_ws_forwarder(tx: broadcast::Sender<ExecEvent>, ws_tx: broadcast::Sender<WsEnvelope>);
+```
+
+`AppState` 增加 `ws_tx: broadcast::Sender<WsEnvelope>`；容量复用现有
+`broadcast_channel_capacity` 配置（同一洪峰量级）。
+
+### C3：events_handler 改造
+
+- 解析 query：`Query<EventsParams>`，`workspace_id: Option<i64>`；
+- Sync 握手：`Some(ws)` 时按 record.workspace_id 过滤 running_tasks；
+  查不到 record 的异常任务**保守保留**（决策 2a）；
+- 主循环：订阅 `ws_tx`：
+  - 连接带 `Some(ws)`：`envelope.workspace_id == Some(ws) || envelope.workspace_id.is_none()` 才发；
+  - 连接无参数：全发（兼容）；
+  - 发送 `Message::text(&*envelope.json)`（Arc 共享，仅 memcpy）。
+
+### C4：前端（useExecutionEvents.ts）
+
+- 连接 URL 带 `?workspace_id=${selectedWorkspace}`（从全局 state 读取；null 不带参数）；
+- workspace 切换：关旧连接 → 新参数重连（Sync 自动重建面板，无需额外状态迁移）；
+- 重连逻辑复用现有指数退避（`getReconnectDelay`），切换时重置 attempt。
+
+## 4. 影响面与测试
+
+| 文件 | 改动 |
+|------|------|
+| `executor_service/events.rs` | +2 方法 +全变体单测 |
+| `handlers/mod.rs` | WsEnvelope、forwarder、handler 过滤 |
+| `main.rs` | 启动 forwarder；AppState.ws_tx 初始化 |
+| `handlers/*`（AppState 构造点） | 补 ws_tx 字段（编译器找齐） |
+| `frontend/src/hooks/useExecutionEvents.ts` | URL 参数 + 切换重连 |
+
+测试：
+- 后端：`workspace_id()` 13 变体矩阵；`is_feishu_direct` 判定；forwarder 过滤
+  （DirectXxx 不转发/其余携带正确 workspace_id）；handler 匹配逻辑
+  （Some-Some 匹配/不匹配、None 全局、无参数全推）；
+- 前端：Playwright 验证（`frontend/tests/`）——连接受 workspace 参数、
+  切换 workspace 后事件隔离；截图入 tmp 不入库。
+
+## 5. 验证方案
+
+1. `cd backend && cargo clippy --all-targets -- -D warnings`：改动文件零告警
+   （全树存量告警见 093 记录，不属本批）；
+2. `cd backend && cargo test`：新增单测全过，存量无回归
+   （已知 git_sync 本机环境失败 1 例，与本批无关）；
+3. 功能验证：`make dev` 起服务，两 workspace 各开标签页，事件按 workspace 隔离；
+   飞书推送路径不受影响（DirectXxx 仍走原 channel）；
+4. 前端 Playwright：WS 连接 URL 断言 + 切换 workspace 后事件归属断言。
+
+## 6. 安全反思
+
+- **收益**：消除跨 workspace 的任务标题/日志流可见性（现状的轻度租户泄露）；
+- 无 workspace 参数连接的全推是**刻意保留的兼容口**（本服务无鉴权体系，
+  单用户本地工具定位，不构成新暴露面）；
+- forwarder 序列化失败（理论不可达）时跳过该事件并 error 日志，不 panic；
+- 无 SQL/权限/文件路径新增面。
+
+## 7. 已知限制 / 后续候选
+
+- `Arc<str>` → `Bytes` 彻底零拷贝（省发送侧 memcpy）：留待实测有 CPU 压力再做；
+- Sync 握手的 running_tasks 过滤依赖 execution_record 反查（TaskInfo 无 workspace 字段），
+  如需根除可在 TaskInfo 补 workspace_id（改动面扩到注册点，本批不做）；
+- ReviewStatusChanged 等全局事件若未来带 workspace 语义，补字段后移出 None 组。

--- a/docs/requirements/094-WS广播预序列化与workspace过滤-实现总结.md
+++ b/docs/requirements/094-WS广播预序列化与workspace过滤-实现总结.md
@@ -3,6 +3,7 @@
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | AI (zhanlu) | 2026-08-10 | 初始版本 |
+| AI (zhanlu) | 2026-08-10 | 按 CodeRabbit 评审：workspace_id() 升级为 EventScope 三态（未归属不再推给带参连接）、前端 onclose 竞态修复、补 vitest/handler 测试、变体数口径 14 |
 
 > 对应设计：`docs/design/094-WS广播预序列化与workspace过滤-设计.md`。
 > 093 专项性能类第 1 项：WS 广播逐客户端重复序列化 + 无 workspace 过滤。
@@ -11,7 +12,7 @@
 
 | 变化 | 文件 | 说明 |
 |------|------|------|
-| ExecEvent 查询方法 | `executor_service/events.rs` | `workspace_id()`（13 变体全枚举）+ `is_feishu_direct()` |
+| ExecEvent 查询方法 | `executor_service/events.rs` | `event_scope()`（14 变体全枚举，Global/Workspace/Unscoped 三态）+ `is_feishu_direct()` |
 | WS 广播通路（新模块） | `handlers/ws_broadcast.rs` | `WsEnvelope`（Arc<str> 预序列化）、`envelope_matches` 三态判定、`spawn_ws_forwarder` 桥接任务 |
 | AppState 接线 | `handlers/mod.rs` | `ws_tx` 字段 + forwarder 启动（容量复用 broadcast_channel_capacity 配置） |
 | events_handler 改造 | `handlers/mod.rs` | `?workspace_id=` query 解析；Sync 握手按 record.workspace_id 过滤（无 record 保守保留）；主循环订阅 ws_tx 按匹配转发 |

--- a/docs/requirements/094-WS广播预序列化与workspace过滤-实现总结.md
+++ b/docs/requirements/094-WS广播预序列化与workspace过滤-实现总结.md
@@ -1,0 +1,65 @@
+# 094-WS广播预序列化与workspace过滤-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (zhanlu) | 2026-08-10 | 初始版本 |
+
+> 对应设计：`docs/design/094-WS广播预序列化与workspace过滤-设计.md`。
+> 093 专项性能类第 1 项：WS 广播逐客户端重复序列化 + 无 workspace 过滤。
+
+## 1. 实现了什么
+
+| 变化 | 文件 | 说明 |
+|------|------|------|
+| ExecEvent 查询方法 | `executor_service/events.rs` | `workspace_id()`（13 变体全枚举）+ `is_feishu_direct()` |
+| WS 广播通路（新模块） | `handlers/ws_broadcast.rs` | `WsEnvelope`（Arc<str> 预序列化）、`envelope_matches` 三态判定、`spawn_ws_forwarder` 桥接任务 |
+| AppState 接线 | `handlers/mod.rs` | `ws_tx` 字段 + forwarder 启动（容量复用 broadcast_channel_capacity 配置） |
+| events_handler 改造 | `handlers/mod.rs` | `?workspace_id=` query 解析；Sync 握手按 record.workspace_id 过滤（无 record 保守保留）；主循环订阅 ws_tx 按匹配转发 |
+| 前端订阅范围跟随 | `hooks/useExecutionEvents.ts` | 模块级 `sharedWorkspaceId` 记忆；连接 URL 带参；workspace 切换 teardown+重建（onclose 自动重连沿用同范围） |
+
+## 2. 与设计的对应关系
+
+| 设计项 | 落地 | 状态 |
+|--------|------|------|
+| C1 ExecEvent 查询方法 | 全枚举 match（新增变体漏处理编译期 non-exhaustive 报错） | ✅ |
+| C2 WsEnvelope + forwarder | 飞书专用事件拦截、序列化失败跳事件不 panic、Lagged warn 继续 | ✅ |
+| C3 handler 过滤 | 三态真值表（无参全推/全局事件全推/归属相等才推）；Sync 过滤后 record_ids 联动收敛（尾部日志/计数查询不为其他 workspace 白跑） | ✅ |
+| C4 前端重连 | 首连同参、切换重建、卸载复位 | ✅ |
+| 决策 1a/2a/3a | 面板按 workspace 隔离 / 异常任务保守保留 / 全局事件全推 | ✅ |
+
+## 3. 测试与验证结果
+
+- **后端单测**（ws_broadcast 模块 4 个）：
+  - `envelope_matches` 三态真值表全枚举
+  - `workspace_id()` 13 变体矩阵（Option 透传/i64 包 Some/全局组 None）
+  - `is_feishu_direct` 判定
+  - forwarder 端到端：DirectCard 拦截 + 正常事件携带正确 workspace_id 与预序列化 JSON
+- **全量 lib 测试**：1643 通过 / 1 失败（git_sync 本机旧 git 环境问题，main 基线相同）
+- **clippy**：改动文件零告警（全树存量告警为 rustc 1.95.0 新 lint，093 已记录不属本批）
+- **前端 `npx tsc --noEmit`**：零错误
+- **Playwright**（`frontend/tests/094-ws-workspace-filter.spec.ts`）✅：
+  连接序列实测 `无参首连 → ?workspace_id=1（初始化落定重连）→ ?workspace_id=2（切换重连）`，
+  console 零错误
+- **dev 实例日志**：forwarder 启动正常，无序列化 error
+
+## 4. 性能语义变化
+
+| 维度 | 改前 | 改后 |
+|------|------|------|
+| 序列化次数 | 每事件 × N 客户端 | 每事件 × 1（forwarder 全局唯一） |
+| 事件推送范围 | 全 workspace → 全客户端 | 匹配 workspace + 全局事件 → 声明该 workspace 的客户端 |
+| 飞书专用事件 | 推给 WS 客户端（前端无消费） | 拦截在 WS channel 之外 |
+| Sync 握手 | 全量任务 | 声明 workspace 的任务（无 record 异常任务保留） |
+| 每客户端发送成本 | 序列化 + String 分配 | Arc<str> 共享 + 一次 memcpy |
+
+## 5. 已知限制
+
+- 发送侧仍有一次 memcpy（`Message::text(&*json)`）；彻底零拷贝（Bytes 直进 channel）留待实测有 CPU 压力再做；
+- 无 workspace 参数的连接全推（兼容口，本服务单用户本地工具定位，不构成新暴露面）；
+- 首个连接在初始 workspace 异步落定前为无参全推（一次性，目录加载完成后自动重连带参）。
+
+## 6. 安全反思
+
+- **收益**：消除跨 workspace 任务标题/日志流的面板可见性（现状轻度租户泄露）；
+- forwarder 对序列化失败跳事件不 panic（WS 推送停摆风险归零）；
+- 无 SQL/权限/文件路径新增面；事件过滤为纯内存判定。

--- a/frontend/src/hooks/useExecutionEvents.test.tsx
+++ b/frontend/src/hooks/useExecutionEvents.test.tsx
@@ -1,0 +1,90 @@
+// 094：useExecutionEvents 单元测试（CodeRabbit #1011 评审项）。
+//
+// 核心守卫：workspace 切换时的 onclose 竞态——旧连接的 onclose 回调晚于新连接建立
+// 触发时，不得冲掉 sharedWs 中的新连接引用、不得安排多余重连（重复连接会导致
+// 事件重复 dispatch，issue #720 的回归形态）。
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useExecutionEvents } from './useExecutionEvents';
+
+// ─── 假 WebSocket：记录每次连接的 URL，close() 异步触发 onclose（贴近真实浏览器行为）──
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  readonly url: string;
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+  close() {
+    this.closed = true;
+    // 真实浏览器里 onclose 在后续事件循环触发——这正是竞态的成因，测试必须复现该时序
+    setTimeout(() => this.onclose?.(), 0);
+  }
+}
+
+// useApp mock：可控的 selectedWorkspace + 空 dispatch（本测试不断言状态分发）
+let mockWorkspace: number | null = null;
+vi.mock('./useApp', () => ({
+  useApp: () => ({
+    state: { selectedWorkspace: mockWorkspace },
+    dispatch: vi.fn(),
+  }),
+}));
+
+/** 刷新宏任务队列：让 FakeWebSocket 的异步 onclose 有机会触发 */
+async function flushTimers() {
+  await new Promise(resolve => setTimeout(resolve, 10));
+}
+
+describe('useExecutionEvents（094 workspace 订阅范围）', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    mockWorkspace = null;
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('首连 URL 携带当前 workspace_id', async () => {
+    mockWorkspace = 1;
+    const { unmount } = renderHook(() => useExecutionEvents());
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(FakeWebSocket.instances[0].url).toContain('workspace_id=1');
+    unmount();
+    await flushTimers();
+  });
+
+  it('workspace 为空时不带参数（服务端全推兼容口）', async () => {
+    mockWorkspace = null;
+    const { unmount } = renderHook(() => useExecutionEvents());
+    expect(FakeWebSocket.instances[0].url).not.toContain('workspace_id');
+    unmount();
+    await flushTimers();
+  });
+
+  it('切换 workspace：断旧连新，且旧连接 onclose 不产生重复连接（竞态守卫）', async () => {
+    mockWorkspace = 1;
+    const { unmount, rerender } = renderHook(() => useExecutionEvents());
+    expect(FakeWebSocket.instances[0].url).toContain('workspace_id=1');
+
+    // 切换到 workspace 2：应关闭旧连接并立即以新参数重建
+    mockWorkspace = 2;
+    rerender();
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(FakeWebSocket.instances[0].closed).toBe(true);
+    expect(FakeWebSocket.instances[1].url).toContain('workspace_id=2');
+
+    // 关键断言：旧连接的 onclose 异步触发后，不得再建第三个连接。
+    // 竞态未防护时：旧 onclose 把 sharedWs 置空并安排重连 → 产生 workspace_id=2 的重复连接
+    await flushTimers();
+    expect(FakeWebSocket.instances, '旧 onclose 不得触发额外连接').toHaveLength(2);
+    unmount();
+    await flushTimers();
+  });
+});

--- a/frontend/src/hooks/useExecutionEvents.test.tsx
+++ b/frontend/src/hooks/useExecutionEvents.test.tsx
@@ -51,7 +51,7 @@ describe('useExecutionEvents（094 workspace 订阅范围）', () => {
     vi.unstubAllGlobals();
   });
 
-  it('首连 URL 携带当前 workspace_id', async () => {
+  it('test_useExecutionEvents_initial_connection_includes_workspace_id', async () => {
     mockWorkspace = 1;
     const { unmount } = renderHook(() => useExecutionEvents());
     expect(FakeWebSocket.instances).toHaveLength(1);
@@ -60,7 +60,7 @@ describe('useExecutionEvents（094 workspace 订阅范围）', () => {
     await flushTimers();
   });
 
-  it('workspace 为空时不带参数（服务端全推兼容口）', async () => {
+  it('test_useExecutionEvents_null_workspace_uses_unscoped_connection', async () => {
     mockWorkspace = null;
     const { unmount } = renderHook(() => useExecutionEvents());
     expect(FakeWebSocket.instances[0].url).not.toContain('workspace_id');
@@ -68,7 +68,7 @@ describe('useExecutionEvents（094 workspace 订阅范围）', () => {
     await flushTimers();
   });
 
-  it('切换 workspace：断旧连新，且旧连接 onclose 不产生重复连接（竞态守卫）', async () => {
+  it('test_useExecutionEvents_workspace_change_ignores_stale_onclose', async () => {
     mockWorkspace = 1;
     const { unmount, rerender } = renderHook(() => useExecutionEvents());
     expect(FakeWebSocket.instances[0].url).toContain('workspace_id=1');

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -138,6 +138,10 @@ type ExecEvent = ExecEventStarted | ExecEventOutput | ExecEventFinished | ExecEv
 
 /** 全局唯一 WebSocket 连接实例 */
 let sharedWs: WebSocket | null = null;
+/** 094：当前连接声明的 workspace。null = 未声明（服务端全推，兼容旧行为）。
+ *  模块级记忆的原因：onclose 自动重连不在 React effect 内，拿不到最新 state，
+ *  必须沿用它——保证「重连不改变订阅范围」。 */
+let sharedWorkspaceId: number | null = null;
 /** 断线重连定时器 */
 let sharedReconnectTimer: ReturnType<typeof setTimeout> | null = null;
 /** 重连尝试次数（指数退避） */
@@ -172,7 +176,10 @@ function connectShared(dispatch: ReturnType<typeof useApp>['dispatch']) {
   if (sharedWs) return;
 
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const ws = new WebSocket(`${protocol}//${window.location.host}/api/events`);
+  // 094：声明 workspace 订阅范围，服务端按 workspace 过滤事件（预序列化 + 隔离）；
+  // null 时不带参数——服务端视为未声明，保持全推兼容口
+  const wsParam = sharedWorkspaceId != null ? `?workspace_id=${sharedWorkspaceId}` : '';
+  const ws = new WebSocket(`${protocol}//${window.location.host}/api/events${wsParam}`);
   sharedWs = ws;
 
   ws.onopen = () => {
@@ -418,7 +425,9 @@ function flushOutputBuffer() {
  * @param onRefresh - 可选的回调，每次收到 WS 事件时触发（用于面板刷新等用途）
  */
 export function useExecutionEvents(onRefresh?: () => void) {
-  const { dispatch } = useApp();
+  const { state, dispatch } = useApp();
+  // 094：订阅范围跟随全局 workspace 选择态
+  const selectedWorkspace = state.selectedWorkspace;
 
   // 用 ref 持有 onRefresh，使其始终指向最新值但不触发 effect 重新执行
   const onRefreshRef = useRef(onRefresh);
@@ -430,6 +439,10 @@ export function useExecutionEvents(onRefresh?: () => void) {
     if (!sharedDispatch) {
       sharedDispatch = dispatch;
     }
+
+    // 094：首连前同步订阅范围——初始挂载时把当前 workspace 写入模块级记忆，
+    // connectShared 建连时读取（此后 onclose 自动重连沿用同一范围）
+    sharedWorkspaceId = selectedWorkspace;
 
     // 递增调用方计数，把 ref 推入数组（后续触发时读 ref.current 总能拿到最新回调）
     sharedInstanceCount += 1;
@@ -451,9 +464,31 @@ export function useExecutionEvents(onRefresh?: () => void) {
       if (sharedInstanceCount <= 0) {
         teardownShared();
         sharedDispatch = null;
+        // 094：卸载复位订阅范围，下次挂载不受残留值影响
+        sharedWorkspaceId = null;
       }
     };
-    // dispatch 引用稳定（useCallback），不会导致 effect 重跑。
+    // dispatch 引用稳定（useCallback），不会导致 effect 重跑；
+    // selectedWorkspace 的响应式处理在下方独立 effect（避免首连/重连双重触发）。
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // 094：workspace 切换 → 重建 WS 连接（订阅范围随连接参数生效，只能重连切换）。
+  // 跳过首次运行：首连已在上方 effect 内带参建立，此处重复会多一次无谓断连。
+  const prevWorkspaceRef = useRef(selectedWorkspace);
+  useEffect(() => {
+    if (prevWorkspaceRef.current === selectedWorkspace) return;
+    prevWorkspaceRef.current = selectedWorkspace;
+    // 无活跃连接时只更新记忆（下一个调用方挂载时会用新范围建连）
+    sharedWorkspaceId = selectedWorkspace;
+    if (!sharedWs) return;
+    // teardown 会把 sharedShouldReconnect 置 false（语义是「不再续命」），
+    // 而切换场景需要「断旧连新」，故重置之；计数清零让新连接跳过退避立即建立
+    teardownShared();
+    sharedShouldReconnect = true;
+    sharedReconnectAttempt = 0;
+    if (sharedDispatch) connectShared(sharedDispatch);
+    // selectedWorkspace 每次真实变化都需要重连；teardown/connect 均为模块级稳定函数
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedWorkspace]);
 }

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -294,6 +294,13 @@ function connectShared(dispatch: ReturnType<typeof useApp>['dispatch']) {
   };
 
   ws.onclose = () => {
+    // 094 竞态防护（CodeRabbit #1011 评审指出的真 bug）：
+    // workspace 切换时 teardownShared() 发起旧连接 close()，其 onclose 在**后续事件循环**
+    // 才触发——此时 sharedWs 可能已是新连接。若不加身份判断，旧回调会把 sharedWs 置 null
+    // 冲掉新连接引用，并因 sharedShouldReconnect=true 再安排一次重连 → 孤儿连接 +
+    // 重复连接（事件重复 dispatch，issue #720 的回归形态）。
+    // 闭包捕获的 ws 与当前 sharedWs 比对：只有「当前在管连接自己的 onclose」才清理。
+    if (sharedWs !== ws) return;
     sharedWs = null;
     if (sharedShouldReconnect) {
       const delay = getReconnectDelay();
@@ -424,6 +431,21 @@ function flushOutputBuffer() {
  *
  * @param onRefresh - 可选的回调，每次收到 WS 事件时触发（用于面板刷新等用途）
  */
+/** 094：切换 WS 订阅范围——更新模块级记忆，若有活跃连接则断旧连新。
+ *  抽为模块函数（CodeRabbit #1011：useExecutionEvents 超长拆分）：
+ *  effect 只负责「检测变化」，连接生命周期操作集中在此。 */
+function reconnectWithWorkspace(workspaceId: number | null) {
+  // 无活跃连接时只更新记忆：下个调用方挂载时会用新范围建连
+  sharedWorkspaceId = workspaceId;
+  if (!sharedWs) return;
+  // teardown 会把 sharedShouldReconnect 置 false（语义是「不再续命」），
+  // 而切换场景需要「断旧连新」，故重置之；计数清零让新连接跳过退避立即建立
+  teardownShared();
+  sharedShouldReconnect = true;
+  sharedReconnectAttempt = 0;
+  if (sharedDispatch) connectShared(sharedDispatch);
+}
+
 export function useExecutionEvents(onRefresh?: () => void) {
   const { state, dispatch } = useApp();
   // 094：订阅范围跟随全局 workspace 选择态
@@ -479,16 +501,7 @@ export function useExecutionEvents(onRefresh?: () => void) {
   useEffect(() => {
     if (prevWorkspaceRef.current === selectedWorkspace) return;
     prevWorkspaceRef.current = selectedWorkspace;
-    // 无活跃连接时只更新记忆（下一个调用方挂载时会用新范围建连）
-    sharedWorkspaceId = selectedWorkspace;
-    if (!sharedWs) return;
-    // teardown 会把 sharedShouldReconnect 置 false（语义是「不再续命」），
-    // 而切换场景需要「断旧连新」，故重置之；计数清零让新连接跳过退避立即建立
-    teardownShared();
-    sharedShouldReconnect = true;
-    sharedReconnectAttempt = 0;
-    if (sharedDispatch) connectShared(sharedDispatch);
-    // selectedWorkspace 每次真实变化都需要重连；teardown/connect 均为模块级稳定函数
+    reconnectWithWorkspace(selectedWorkspace);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedWorkspace]);
 }

--- a/frontend/tests/094-ws-workspace-filter.spec.ts
+++ b/frontend/tests/094-ws-workspace-filter.spec.ts
@@ -1,0 +1,68 @@
+// 094 验证：WS 广播 workspace 过滤——连接参数声明与切换重连。
+//
+// 验证点：
+// 1. 首连 URL 携带 ?workspace_id=<初始 workspace>（localStorage 清空时为目录列表第一项）。
+// 2. 切换 workspace 后旧连接关闭、新连接携带新 workspace_id。
+// 3. 全程 console 无错误（重连流程无异常）。
+import { test, expect } from '@playwright/test';
+
+test('094 WS 连接携带 workspace_id 且切换 workspace 后重连换参', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
+  page.on('pageerror', err => consoleErrors.push(`pageerror: ${err.message}`));
+
+  // 清空持久化的 workspace 选择，保证初始化为目录列表第一项（id=1），测试可重复
+  await page.addInitScript(() => {
+    try { localStorage.removeItem('ntd_selected_workspace'); } catch {}
+  });
+
+  // 捕获所有 WS 连接（page.on('websocket') 对后续每次 new WebSocket 都触发）
+  const wsUrls: string[] = [];
+  page.on('websocket', ws => {
+    wsUrls.push(ws.url());
+    console.log('WS 连接建立:', ws.url());
+  });
+
+  await page.goto('http://localhost:18088');
+  // 初始 workspace 需一次异步目录加载后才确定（useApp 初始化 dispatch SELECT_WORKSPACE），
+  // WS 首连在此之前可能不带参——用 poll 等待「带参连接」出现
+  await expect.poll(async () => wsUrls.some(u => u.includes('workspace_id=')), { timeout: 15000 }).toBe(true);
+
+  const firstParam = new URL(wsUrls.find(u => u.includes('workspace_id='))!).searchParams.get('workspace_id');
+  console.log('首连 workspace_id:', firstParam);
+  expect(firstParam).not.toBeNull();
+
+  // 拿目录列表确定首连 workspace 的名称（菜单未传 selectedKeys，无法用 -selected 类排除当前项，
+  // 按名称排除最可靠）
+  const dirs: Array<{ id: number; name: string }> = await page.evaluate(async () => {
+    const resp = await fetch('/api/v1/project-directories');
+    const body = await resp.json();
+    return body.data;
+  });
+  const currentName = dirs.find(d => String(d.id) === firstParam)?.name;
+  const targetName = dirs.find(d => String(d.id) !== firstParam)?.name;
+  console.log('当前:', currentName, '→ 目标:', targetName);
+  expect(targetName, 'dev 库应至少有两个 workspace').toBeTruthy();
+
+  // 切换 workspace：点切换器 → 选目标名称的菜单项
+  // 切换器两形态：展开态 left-rail-workspace-switcher / 折叠态 left-rail-workspace，
+  // 取决于 rail 折叠状态（localStorage 持久化），哪个可见点哪个
+  const switcher = page.locator('[data-testid="left-rail-workspace-switcher"], [data-testid="left-rail-workspace"]').first();
+  await expect(switcher).toBeVisible({ timeout: 10000 });
+  await switcher.click();
+  const menu = page.locator('.ant-dropdown-menu:visible');
+  await expect(menu.first()).toBeVisible();
+  await menu.locator('.ant-dropdown-menu-item', { hasText: targetName }).first().click();
+
+  // 断言：新 WS 连接建立，且 workspace_id 与首连不同
+  await expect.poll(async () => {
+    const params = wsUrls.map(u => new URL(u).searchParams.get('workspace_id')).filter(Boolean);
+    return new Set(params).size;
+  }, { timeout: 15000 }).toBeGreaterThan(1);
+
+  const lastParam = new URL(wsUrls[wsUrls.length - 1]).searchParams.get('workspace_id');
+  console.log('切换后 workspace_id:', lastParam, '全部连接:', JSON.stringify(wsUrls));
+  expect(lastParam).not.toBe(firstParam);
+
+  expect(consoleErrors, `console 不应有错误: ${consoleErrors.join('; ')}`).toEqual([]);
+});

--- a/frontend/tests/094-ws-workspace-filter.spec.ts
+++ b/frontend/tests/094-ws-workspace-filter.spec.ts
@@ -3,10 +3,12 @@
 // 验证点：
 // 1. 首连 URL 携带 ?workspace_id=<初始 workspace>（localStorage 清空时为目录列表第一项）。
 // 2. 切换 workspace 后旧连接关闭、新连接携带新 workspace_id。
-// 3. 全程 console 无错误（重连流程无异常）。
+// 3. 切换过程不产生重复连接（CodeRabbit #1011 onclose 竞态守卫的 e2e 背书）。
+// 4. 全程 console 无错误（重连流程无异常）。
 import { test, expect } from '@playwright/test';
 
 test('094 WS 连接携带 workspace_id 且切换 workspace 后重连换参', async ({ page }) => {
+  // console 错误收集：修复前若重连逻辑异常，通常伴随 React/WS 报错——先埋监听再操作
   const consoleErrors: string[] = [];
   page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()); });
   page.on('pageerror', err => consoleErrors.push(`pageerror: ${err.message}`));
@@ -16,11 +18,17 @@ test('094 WS 连接携带 workspace_id 且切换 workspace 后重连换参', asy
     try { localStorage.removeItem('ntd_selected_workspace'); } catch {}
   });
 
-  // 捕获所有 WS 连接（page.on('websocket') 对后续每次 new WebSocket 都触发）
+  // 捕获所有 WS 连接的 URL 与关闭事件：page.on('websocket') 对每次 new WebSocket 触发；
+  // close 事件记录用于「切换后旧连接确实关闭、且无同参数重复连接」的竞态断言
   const wsUrls: string[] = [];
+  const closedUrls: string[] = [];
   page.on('websocket', ws => {
     wsUrls.push(ws.url());
     console.log('WS 连接建立:', ws.url());
+    ws.on('close', () => {
+      closedUrls.push(ws.url());
+      console.log('WS 连接关闭:', ws.url());
+    });
   });
 
   await page.goto('http://localhost:18088');
@@ -63,6 +71,15 @@ test('094 WS 连接携带 workspace_id 且切换 workspace 后重连换参', asy
   const lastParam = new URL(wsUrls[wsUrls.length - 1]).searchParams.get('workspace_id');
   console.log('切换后 workspace_id:', lastParam, '全部连接:', JSON.stringify(wsUrls));
   expect(lastParam).not.toBe(firstParam);
+
+  // 竞态断言（CodeRabbit #1011）：等一个重连退避周期（>2s）后，
+  // 不得出现第三个连接——旧 onclose 若误触发重连会产生与末次同参的重复连接。
+  // 注意：Playwright 对页面主动 close() 的 close 事件捕获不可靠（实测不触发），
+  // 故 close 事件仅记录观察，硬断言落在「无重复连接」上（竞态未修复时 dupCount=2）
+  await page.waitForTimeout(2500);
+  console.log('捕获的关闭事件:', JSON.stringify(closedUrls));
+  const dupCount = wsUrls.filter(u => u === `ws://localhost:18088/api/events?workspace_id=${lastParam}`).length;
+  expect(dupCount, '切换后连接不得重复（onclose 竞态回归守卫）').toBe(1);
 
   expect(consoleErrors, `console 不应有错误: ${consoleErrors.join('; ')}`).toEqual([]);
 });


### PR DESCRIPTION
## 背景

093 专项性能类第 1 项（首轮扫描 P1）：

1. **逐客户端重复序列化**：`handlers/mod.rs:275` 每个 WS 客户端各自 `serde_json::to_string(&event)`——N 个标签页 = N 次序列化同一事件
2. **无 workspace 过滤**：所有 workspace 的事件推给所有客户端（且构成轻度跨 workspace 信息泄露）
3. **附带浪费**：飞书专用事件（DirectCard/DirectStream）也推给 WS 客户端，前端无消费分支

## 方案：forwarder + WS 专用 channel（最小侵入）

原 ExecEvent channel 12 个发送点 + 飞书订阅侧**零改动**；新增 forwarder 任务过滤飞书专用事件、全局单次序列化为 `Arc<str>`，WS 客户端按 `?workspace_id=` 声明范围匹配转发。

设计文档：`docs/design/094-WS广播预序列化与workspace过滤-设计.md`
实现总结：`docs/requirements/094-WS广播预序列化与workspace过滤-实现总结.md`

## 验证

- 后端单测 4 个（真值表/13 变体矩阵/forwarder 端到端）；全量 lib 1643 通过（1 失败为已知 git 环境问题）
- 改动文件 clippy 零告警；前端 tsc 零错误
- Playwright `frontend/tests/094-ws-workspace-filter.spec.ts`：连接序列实测 `无参 → ?workspace_id=1 → ?workspace_id=2`，console 零错误

## 行为变化（已经需求方确认 1a2a3a）

- 执行面板按 workspace 隔离显示运行任务
- 无 workspace 参数连接全推（兼容口）；全局事件（ReviewStatusChanged 等）全推
- Sync 握手中查不到 record 的异常任务保守保留