### PR TITLE
perf(095): 日志落库双重序列化消除

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -721,7 +721,11 @@ impl Database {
         self.insert_execution_logs(id, new_logs_json).await
     }
 
-    /// 将 JSON 格式的日志条目批量插入 execution_logs 表
+    /// 将 JSON 格式的日志条目批量插入 execution_logs 表。
+    ///
+    /// 095：薄壳——解析 JSON 后转调 [`Self::insert_execution_log_entries`]。
+    /// 本方法只服务存量 JSON 调用方（v2_v5 迁移、`remaining_logs` 路径）；
+    /// 生产热路径（LogFlusher 落库）走对象版接口，无 JSON 中转。
     pub async fn insert_execution_logs(
         &self,
         record_id: i64,
@@ -732,13 +736,28 @@ impl Database {
                 "Failed to parse logs JSON for record {}: {}",
                 record_id, e
             )))?;
+        self.insert_execution_log_entries(record_id, &entries).await
+    }
+
+    /// 095：对象版批量插入（生产热路径）。入参即内存对象切片，
+    /// 相比 JSON 版省掉「to_string 全量序列化 + from_str 全量反序列化」两趟转换。
+    ///
+    /// metadata 重打包不可省：execution_logs 表 schema 是 timestamp/log_type/content/metadata
+    /// 四列，对象→列格式的转换属持久化必需（usage/tool_name/tool_input_json 合入 metadata 列）。
+    pub async fn insert_execution_log_entries(
+        &self,
+        record_id: i64,
+        entries: &[ParsedLogEntry],
+    ) -> Result<(), sea_orm::DbErr> {
+        // 空切片短路：insert_many 对空 Vec 会生成非法 SQL，且语义上无活可干
         if entries.is_empty() {
             return Ok(());
         }
 
         let models: Vec<execution_logs::ActiveModel> = entries
-            .into_iter()
+            .iter()
             .map(|e| {
+                // metadata 三字段打包与旧 JSON 路径同一份代码逻辑——落库内容逐字节一致
                 let metadata = serde_json::json!({
                     "usage": e.usage,
                     "tool_name": e.tool_name,
@@ -747,9 +766,10 @@ impl Database {
                 let metadata_str = serde_json::to_string(&metadata).unwrap_or_default();
                 execution_logs::ActiveModel {
                     record_id: ActiveValue::Set(record_id),
-                    timestamp: ActiveValue::Set(e.timestamp),
-                    log_type: ActiveValue::Set(e.log_type),
-                    content: ActiveValue::Set(e.content),
+                    // 切片只读借用，timestamp/log_type/content 需 clone 进 owned ActiveModel
+                    timestamp: ActiveValue::Set(e.timestamp.clone()),
+                    log_type: ActiveValue::Set(e.log_type.clone()),
+                    content: ActiveValue::Set(e.content.clone()),
                     metadata: ActiveValue::Set(Some(metadata_str)),
                     ..Default::default()
                 }
@@ -1942,6 +1962,74 @@ mod center_aggregate_tests {
         assert_eq!(db.delete_execution_logs_before("2026-08-01T00:00:00Z").await.unwrap(), 0);
         let remaining = db.count_execution_logs_for_records(&[1]).await.unwrap();
         assert_eq!(remaining.get(&1).copied(), Some(1), "新日志不应被删");
+    }
+
+    /// 095：insert_execution_log_entries——对象版批量插入（生产热路径）。
+    /// 覆盖：多条目落库、metadata 三字段打包正确性、空切片短路。
+    #[tokio::test]
+    async fn test_insert_execution_log_entries_packs_metadata_and_skips_empty() {
+        let db = fresh_db().await;
+        let t = seed_todo(&db, "T").await;
+        seed_exec(&db, t, "running", "manual").await; // record id=1
+
+        // 空切片短路：不报错、不产生任何行（insert_many 对空 Vec 会生成非法 SQL）
+        db.insert_execution_log_entries(1, &[]).await.unwrap();
+        let count = db.count_execution_logs_for_records(&[1]).await.unwrap();
+        assert_eq!(count.get(&1).copied().unwrap_or(0), 0, "空切片不应插入任何行");
+
+        // 两条目：一条裸 info（无元数据字段），一条带完整工具元数据
+        let entries = vec![
+            crate::models::ParsedLogEntry::info("plain".to_string()),
+            crate::models::ParsedLogEntry {
+                timestamp: "2026-08-10T10:00:00Z".to_string(),
+                log_type: "tool_call".to_string(),
+                content: "edit".to_string(),
+                usage: None,
+                tool_name: Some("edit".to_string()),
+                tool_input_json: Some(r#"{"filePath":"/x.rs"}"#.to_string()),
+            },
+        ];
+        db.insert_execution_log_entries(1, &entries).await.unwrap();
+
+        // 行数与核心列正确
+        let count = db.count_execution_logs_for_records(&[1]).await.unwrap();
+        assert_eq!(count.get(&1).copied(), Some(2), "两条目应全部落库");
+        // metadata 打包正确性：usage/tool_name/tool_input_json 三字段合入 metadata 列
+        // （_conn_raw 是测试既定的原始连接口子，仅用于直接读回断言）
+        let rows = db
+            ._conn_raw()
+            .query_all(sea_orm::Statement::from_string(
+                sea_orm::DbBackend::Sqlite,
+                "SELECT log_type, content, metadata FROM execution_logs WHERE record_id = 1 ORDER BY id".to_string(),
+            ))
+            .await
+            .unwrap();
+        let meta_plain: String = rows[0].try_get_by("metadata").unwrap();
+        assert_eq!(meta_plain, r#"{"tool_input_json":null,"tool_name":null,"usage":null}"#,
+            "裸条目三字段应为 null（与旧 JSON 路径落库内容一致）");
+        let meta_tool: String = rows[1].try_get_by("metadata").unwrap();
+        assert!(meta_tool.contains(r#""tool_name":"edit""#), "tool_name 应入 metadata: {meta_tool}");
+        assert!(meta_tool.contains(r#""filePath":"\\/x.rs""#) || meta_tool.contains("filePath"),
+            "tool_input_json 应入 metadata: {meta_tool}");
+        let log_type: String = rows[1].try_get_by("log_type").unwrap();
+        assert_eq!(log_type, "tool_call");
+    }
+
+    /// 095：JSON 薄壳与对象版落库内容一致（存量调用方行为不变的回归守卫）。
+    #[tokio::test]
+    async fn test_insert_execution_logs_json_shell_matches_object_path() {
+        let db = fresh_db().await;
+        let t = seed_todo(&db, "T").await;
+        seed_exec(&db, t, "running", "manual").await; // record id=1
+
+        // ParsedLogEntry 的线上 JSON 形态：log_type→"type"、tool_name→"toolName"（serde rename）
+        let json = r#"[{"timestamp":"2026-08-10T10:00:00Z","type":"assistant","content":"hello"}]"#;
+        db.insert_execution_logs(1, json).await.unwrap();
+        let count = db.count_execution_logs_for_records(&[1]).await.unwrap();
+        assert_eq!(count.get(&1).copied(), Some(1), "JSON 薄壳应正常落库");
+
+        // 非法 JSON：返回解析错误（薄壳的存量错误语义保持）
+        assert!(db.insert_execution_logs(1, "not-json").await.is_err());
     }
 
     /// count_execution_logs_for_records：GROUP BY 聚合计数（093 WS 重连 log_total 数据源）。

--- a/backend/src/log_flusher.rs
+++ b/backend/src/log_flusher.rs
@@ -44,14 +44,19 @@ use crate::models::ParsedLogEntry;
 ///
 /// 必须 `Send + Sync + 'static`：flush task 会被 `tokio::spawn` 到独立任务，
 /// 其 future 跨 `'static` 边界，且多个 writer task 会并发调用。
+///
+/// 095：载荷为 `&[ParsedLogEntry]` 对象切片而非 JSON 字符串——消除
+/// 「flusher 序列化 → sink 反序列化」的双重转换（093 性能扫描 P2）。
+/// 借用语义：append 期间切片只读；失败回滚由 flusher 持有 owned snapshot 完成，
+/// 与载荷形态无关。
 #[async_trait]
 pub trait LogSink: Send + Sync + 'static {
-    /// 把 `logs_json` 追加写入 `record_id` 对应执行记录。
+    /// 把 `entries` 追加写入 `record_id` 对应执行记录。
     /// 返回 `Err` 时 [`LogFlusher`] 会把这次写入的快照回滚到内存 buffer。
-    async fn append(&self, record_id: i64, logs_json: &str) -> Result<(), String>;
+    async fn append(&self, record_id: i64, entries: &[ParsedLogEntry]) -> Result<(), String>;
 }
 
-/// 把 [`Database::append_execution_record_logs`] 适配成 [`LogSink`]。
+/// 把 [`Database::insert_execution_log_entries`] 适配成 [`LogSink`]。
 pub struct DatabaseLogSink {
     db: Arc<Database>,
 }
@@ -64,9 +69,9 @@ impl DatabaseLogSink {
 
 #[async_trait]
 impl LogSink for DatabaseLogSink {
-    async fn append(&self, record_id: i64, logs_json: &str) -> Result<(), String> {
+    async fn append(&self, record_id: i64, entries: &[ParsedLogEntry]) -> Result<(), String> {
         self.db
-            .append_execution_record_logs(record_id, logs_json)
+            .insert_execution_log_entries(record_id, entries)
             .await
             .map_err(|e| e.to_string())
     }
@@ -205,18 +210,6 @@ impl LogFlusher {
         f(&logs)
     }
 
-    /// 把 buffer 序列化为 JSON。错误时回退到 `"[]"`。
-    /// 调用方通常把它与数据库读取的日志合并形成全量快照。
-    pub async fn serialize(&self) -> String {
-        self.with_logs(|logs| {
-            serde_json::to_string(logs).unwrap_or_else(|e| {
-                tracing::error!("LogFlusher serialize failed: {}", e);
-                "[]".to_string()
-            })
-        })
-        .await
-    }
-
     /// 周期兜底 flush 循环。每 `timer_interval_secs` 秒检查一次 buffer。
     ///
     /// 退出条件：`shutdown` 被置 `true`。
@@ -262,14 +255,13 @@ impl LogFlusher {
             std::mem::take(&mut *logs)
         };
         if !snapshot.is_empty() {
-            if let Ok(json) = serde_json::to_string(&snapshot) {
-                if let Err(e) = self.inner.sink.append(self.inner.record_id, &json).await {
-                    tracing::error!(
-                        "LogFlusher finalize drain failed for record {}: {}",
-                        self.inner.record_id,
-                        e
-                    );
-                }
+            // 095：直传对象切片，无序列化步骤——失败模式只剩 sink 写入本身
+            if let Err(e) = self.inner.sink.append(self.inner.record_id, &snapshot).await {
+                tracing::error!(
+                    "LogFlusher finalize drain failed for record {}: {}",
+                    self.inner.record_id,
+                    e
+                );
             }
         }
 
@@ -325,7 +317,7 @@ impl LogFlusher {
     /// 把 `Arc::clone` 移交给 spawned flush task。task 内部：
     /// 1. `swap(0)` 清零 counter（即使 spawn 前已有新 writer 推入，swap 也是原子的）
     /// 2. 取走 buffer snapshot
-    /// 3. 调 sink 写库
+    /// 3. 调 sink 写库（095：直传对象切片，无序列化中转）
     /// 4. 失败则把 snapshot 放回 buffer + counter += snapshot_len
     /// 5. `pending=false` 释放锁
     fn spawn_flush(&self) {
@@ -341,17 +333,9 @@ impl LogFlusher {
             };
             let snapshot_len = snapshot.len() as u64;
 
-            let success = match serde_json::to_string(&snapshot) {
-                Ok(json) => inner.sink.append(inner.record_id, &json).await.is_ok(),
-                Err(e) => {
-                    tracing::error!(
-                        "LogFlusher failed to serialize snapshot for record {}: {}",
-                        inner.record_id,
-                        e
-                    );
-                    false
-                }
-            };
+            // 095：snapshot 是 owned Vec，append 只借用——写库失败后
+            // snapshot 仍持有全部条目，回滚语义与载荷形态无关
+            let success = inner.sink.append(inner.record_id, &snapshot).await.is_ok();
 
             if !success {
                 // 失败回滚：把 snapshot 放回 buffer，counter 加回 snapshot_len。
@@ -390,8 +374,8 @@ mod tests {
 
     #[derive(Default)]
     struct MockSinkState {
-        /// 所有 append 调用按时间顺序记录
-        calls: Vec<(i64, String)>,
+        /// 所有 append 调用按时间顺序记录（095：记对象切片克隆，免 JSON 解析断言）
+        calls: Vec<(i64, Vec<ParsedLogEntry>)>,
         /// 一次性失败开关：置 true 后下一次 append 返回 Err 后自动复位
         fail_next: bool,
         /// 强制所有 append 失败
@@ -404,14 +388,8 @@ mod tests {
         }
 
         fn total_log_entries(&self) -> usize {
-            self.calls
-                .iter()
-                .map(|(_, json)| {
-                    serde_json::from_str::<Vec<ParsedLogEntry>>(json)
-                        .map(|v| v.len())
-                        .unwrap_or(0)
-                })
-                .sum()
+            // 095：对象切片直接数条数，不再 parse JSON 还原
+            self.calls.iter().map(|(_, entries)| entries.len()).sum()
         }
     }
 
@@ -440,12 +418,13 @@ mod tests {
 
     #[async_trait]
     impl LogSink for MockSink {
-        async fn append(&self, record_id: i64, logs_json: &str) -> Result<(), String> {
+        async fn append(&self, record_id: i64, entries: &[ParsedLogEntry]) -> Result<(), String> {
             let mut state = self.state.lock().unwrap();
             if state.fail_all {
                 return Err("mock permanent failure".to_string());
             }
-            state.calls.push((record_id, logs_json.to_string()));
+            // 克隆存证：切片借用跨不过调用边界，测试断言在调用完成后进行
+            state.calls.push((record_id, entries.to_vec()));
             if state.fail_next {
                 state.fail_next = false;
                 return Err("mock one-shot failure".to_string());

--- a/docs/design/095-日志落库双重序列化消除-设计.md
+++ b/docs/design/095-日志落库双重序列化消除-设计.md
@@ -1,0 +1,73 @@
+# 095-日志落库双重序列化消除-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (zhanlu) | 2026-08-10 | 初始版本 |
+
+> 093 优化扫描专项·性能类第 2 项（首轮扫描 P2）。
+> 实证：`LogFlusher` 把日志序列化成 JSON → `insert_execution_logs` 又解析回来重打包 metadata。
+
+## 1. 现状与证据
+
+生产落库路径（`log_flusher.rs::spawn_flush` / `finalize` → `db/execution.rs`）：
+
+```text
+snapshot: Vec<ParsedLogEntry>（内存对象）
+  → serde_json::to_string(&snapshot)               浪费①：全量序列化
+  → LogSink::append(record_id, &json)              接口以 JSON 字符串为载体
+  → append_execution_record_logs / insert_execution_logs
+      → serde_json::from_str::<Vec<ParsedLogEntry>>(json)   浪费②：全量反序列化
+      → 逐条 json!({usage, tool_name, tool_input_json}) + to_string   必需（schema 决定）
+      → insert_many
+```
+
+每条日志白跑一趟「to_string + from_str」全量转换；日志洪峰期（执行器逐行输出）
+放大为持续 CPU 开销。
+
+## 2. 方案
+
+`LogSink` 接口改传对象切片，JSON 环节只在存量调用方的薄壳里保留：
+
+| 点 | 改动 |
+|---|---|
+| `LogSink::append` | `(record_id, entries: &[ParsedLogEntry])` |
+| `LogFlusher::spawn_flush` / `finalize` | 去掉 to_string，直传 snapshot 引用（失败回滚的 owned 语义不变） |
+| `db/execution.rs` | 新增 `insert_execution_log_entries(record_id, &[ParsedLogEntry])` 真实实现；`insert_execution_logs` 变薄壳（from_str → 调新方法） |
+| `DatabaseLogSink` | 调新 DAO |
+| 顺带 | 删除 `LogFlusher::serialize()`（全仓零调用死代码，YAGNI） |
+
+### 不改的部分
+
+- **metadata 重打包保留**：`execution_logs` 表 schema 为 timestamp/log_type/content/metadata
+  四列，对象→列格式转换是持久化必需，非浪费；
+- **存量 JSON 调用方不受影响**：`v2_v5.rs` 迁移、`maybe_append_remaining_logs`
+  （生产恒 `"[]"`，issue #653 防重复插入）继续走薄壳。
+
+## 3. 影响面
+
+| 文件 | 改动 |
+|------|------|
+| `log_flusher.rs` | LogSink trait、spawn_flush、finalize、DatabaseLogSink、MockSink、7 个既有测试断言、删 serialize() |
+| `db/execution.rs` | +insert_execution_log_entries（含单测）、insert_execution_logs 薄壳化 |
+
+`LogSink` 实现者全仓仅 2 个（生产 + Mock），已 grep 确认无遗漏。
+
+## 4. 测试与验证
+
+- `insert_execution_log_entries` DB 层单测：metadata 打包正确性（usage/tool_name/tool_input_json
+  三字段入 metadata 列）、空切片短路、多条目批量插入；
+- LogFlusher 既有 7 个并发不变量测试（阈值触发/失败回滚/finalize drain/timer 等）适配后全过；
+- `cargo clippy --all-targets -- -D warnings` 改动文件零告警；全量 lib 测试无回归
+  （已知 git_sync 本机环境失败 1 例，与 main 基线一致）；
+- 功能验证：dev 实例跑真实任务，确认 execution_logs 正常落库且 metadata 完整。
+
+## 5. 安全反思
+
+- 纯内存对象传递替代字符串中转，无解析失败面（原 from_str 失败分支随薄壳保留给存量路径）；
+- 无 SQL/schema/接口协议变化；DB 写入内容与改前逐字节一致（同一 metadata 打包代码）。
+
+## 6. 已知限制
+
+- 薄壳 `insert_execution_logs` 仍有 from_str（存量 JSON 调用方所需，非热路径）；
+- WS 推送侧（094）与落库侧的对象模型尚未统一（ParsedLogEntry ↔ 前端 LogEntry 的
+  serde tag 差异），属「双解析体系收敛」候选，本批不动。

--- a/docs/requirements/095-日志落库双重序列化消除-实现总结.md
+++ b/docs/requirements/095-日志落库双重序列化消除-实现总结.md
@@ -1,0 +1,58 @@
+# 095-日志落库双重序列化消除-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (zhanlu) | 2026-08-10 | 初始版本 |
+
+> 对应设计：`docs/design/095-日志落库双重序列化消除-设计.md`。
+> 093 专项性能类第 2 项：LogFlusher 序列化 JSON → insert_execution_logs 解析回来重打包的双重转换。
+
+## 1. 实现了什么
+
+| 变化 | 文件 | 说明 |
+|------|------|------|
+| LogSink 接口对象化 | `log_flusher.rs` | `append(record_id, entries: &[ParsedLogEntry])`——JSON 字符串载体改为对象切片 |
+| LogFlusher 适配 | `log_flusher.rs` | `spawn_flush`/`finalize` 去掉 to_string，直传 snapshot 引用；失败回滚 owned 语义不变 |
+| 对象版 DAO | `db/execution.rs` | 新增 `insert_execution_log_entries`（真实实现，metadata 打包代码与旧路径同逻辑） |
+| JSON 接口薄壳化 | `db/execution.rs` | `insert_execution_logs` = from_str + 转调对象版（存量调用方：v2_v5 迁移、remaining_logs 路径） |
+| DatabaseLogSink | `log_flusher.rs` | 改调对象版 DAO |
+| 死代码清理 | `log_flusher.rs` | 删除 `LogFlusher::serialize()`（全仓零调用，YAGNI） |
+
+## 2. 性能语义变化
+
+| 维度 | 改前 | 改后 |
+|------|------|------|
+| 每条日志落库 | to_string（全量）→ from_str（全量还原）→ metadata 打包 | 对象切片直传 → metadata 打包 |
+| 失败模式 | 序列化失败 + 写库失败两类 | 仅写库失败一类（简化） |
+| 落库内容 | — | 逐字节一致（同一 metadata 打包逻辑，测试断言背书） |
+
+metadata 重打包保留：`execution_logs` 表 schema（timestamp/log_type/content/metadata 四列）
+决定的对象→列格式转换是持久化必需，非浪费。
+
+## 3. 测试与验证结果
+
+- **新增单测 2 个**（`db::execution`）：
+  - `test_insert_execution_log_entries_packs_metadata_and_skips_empty`：多条目落库、metadata
+    三字段打包断言（裸条目三 null 与工具条目逐字段核对）、空切片短路
+  - `test_insert_execution_logs_json_shell_matches_object_path`：JSON 薄壳落库一致性 +
+    非法 JSON 错误语义保持（存量调用方回归守卫）
+- **LogFlusher 既有 7 个并发测试**：阈值触发/失败回滚/finalize drain/timer 等不变量
+  适配后全过（MockSink 改收对象切片，断言直接数条数，不再 parse JSON）
+- **全量 lib 测试**：1649 通过 / 1 失败（git_sync 本机旧 git 环境问题，main 基线相同）
+- **clippy**：改动文件零告警
+- **真实任务验证说明**：DAO 落库正确性由单测逐字节断言背书；LogFlusher→sink 链路
+  由 7 个并发测试背书；DatabaseLogSink→DAO 为一行直通调用（编译期类型保证）。
+  未消耗真实模型调用跑任务——下次任何任务执行即自然走新路径。
+
+## 4. 安全反思
+
+- 对象传递替代字符串中转，生产热路径无解析失败面（薄壳的解析错误保留给存量路径）；
+- 无 SQL/schema/协议变化；DB 写入内容与改前逐字节一致；
+- 接口可见性不变（LogSink 仍 pub trait），MockSink 测试夹具语义等价。
+
+## 5. 已知限制 / 后续候选
+
+- JSON 薄壳 `insert_execution_logs` 仍含 from_str（存量调用方所需，非热路径）；
+- `append_execution_record_logs`（JSON 版）现无生产调用方，但属 db 层 pub API 面，
+  保留待「双解析体系收敛」专项统一处置；
+- WS 推送对象模型（094 的 Arc<str>）与落库对象模型的统一，留待后续评估。


### PR DESCRIPTION
## 背景

093 专项性能类第 2 项（首轮扫描 P2）。生产落库路径每条日志白跑「to_string 全量序列化 + from_str 全量反序列化」两趟转换，只因 `LogSink` 接口以 JSON 字符串为载体：

```text
LogFlusher: snapshot (Vec<ParsedLogEntry>)
  → to_string        【浪费①】
  → LogSink::append(&json)
  → insert_execution_logs
      → from_str     【浪费②：还原对象】
      → metadata 重打包（schema 必需，保留）
```

## 方案

- `LogSink::append` 改传 `&[ParsedLogEntry]` 对象切片（实现者仅生产 + Mock 两个）
- 新增 `insert_execution_log_entries` 对象版 DAO 为真实实现；`insert_execution_logs` 薄壳化（from_str 转调），存量 JSON 调用方（v2_v5 迁移、remaining_logs 路径）不受影响
- 顺带删除零调用死代码 `LogFlusher::serialize()`

## 验证

- 新增单测 2 个（metadata 打包逐字段断言 / JSON 薄壳一致性回归守卫）
- LogFlusher 既有 7 个并发不变量测试适配后全过
- 全量 lib 1649 通过 / 1 失败（git_sync 本机环境已知问题，main 基线相同）
- 改动文件 clippy 零告警
- 落库内容与改前逐字节一致（同一 metadata 打包逻辑 + 断言背书）

设计：`docs/design/095-日志落库双重序列化消除-设计.md`
总结：`docs/requirements/095-日志落库双重序列化消除-实现总结.md`