### PR TITLE
refactor(096-W1-1): 删除 12 处多余的 extract_stderr override（-173 行零风险删减）

### DIFF
--- a/backend/src/execution_events/impls/atomcode.rs
+++ b/backend/src/execution_events/impls/atomcode.rs
@@ -292,6 +292,8 @@ impl EventExtractor for AtomcodeExtractor {
         events
     }
 
+    // 096-W1：本 override 与 trait 默认实现**有意不同**，勿删——
+    // 委托 extract() 走完整管线（协议帧解析），而非默认的 error 关键字分流。
     fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
         // atomcode 的 stderr 由 try_parse_stderr_with_pipeline 通过 pipeline.feed()
         // 驱动 extract()，本方法仅在 fallback 路径被调用。为保持一致，委托给 extract()

--- a/backend/src/execution_events/impls/atomcode.rs
+++ b/backend/src/execution_events/impls/atomcode.rs
@@ -603,4 +603,37 @@ mod tests {
             "missing StepFinish event"
         );
     }
+
+    // ====================== 096-W1：extract_stderr override 回归保护 ======================
+
+    // 钉住 Atomcode extract_stderr 的差异化行为：委托 extract() 走协议帧解析管线。
+    // trait 默认实现按 "error" 关键字分流 Error/Info，但 Atomcode 的 stderr 是协议帧格式，
+    // 必须走 extract() 才能提取 Tokens/StepFinish 等结构化事件。若删掉 override 回退默认，
+    // 含 [tokens] 的 stderr 行会被当作普通 Info 文本，tokens 就丢了。
+    #[test]
+    fn test_extract_stderr_delegates_to_extract_pipeline() {
+        let mut ext = AtomcodeExtractor::new();
+        // 协议帧行——默认实现会包装为 Info，override 委托 extract() 产出 Tokens
+        let event = ext.extract_stderr("[tokens] prompt=120 completion=45");
+        match event.as_ref() {
+            Some(ExecutionEvent::Tokens { input, output, .. }) => {
+                assert_eq!(*input, 120);
+                assert_eq!(*output, 45);
+            }
+            // 命中此分支说明 override 被删、回退成了默认实现（当成 Info 文本）
+            Some(ExecutionEvent::Info { .. }) => {
+                panic!("stderr 的 [tokens] 行应走 extract() 管线产出 Tokens，而非默认实现包装为 Info")
+            }
+            None => panic!("预期 Tokens 事件，实际返回 None"),
+            Some(_) => panic!("预期 Tokens 事件，实际返回其他事件类型"),
+        }
+    }
+
+    // 空行委托 extract() 返回空，.next() 为 None，不应产出事件
+    #[test]
+    fn test_extract_stderr_empty_line_returns_none() {
+        let mut ext = AtomcodeExtractor::new();
+        assert!(ext.extract_stderr("").is_none());
+        assert!(ext.extract_stderr("   ").is_none());
+    }
 }

--- a/backend/src/execution_events/impls/claude_code.rs
+++ b/backend/src/execution_events/impls/claude_code.rs
@@ -247,23 +247,6 @@ impl EventExtractor for ClaudeCodeExtractor {
         }
     }
 
-    fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            return None;
-        }
-
-        if trimmed.to_lowercase().contains("error") {
-            Some(ExecutionEvent::Error {
-                message: trimmed.to_string(),
-            })
-        } else {
-            Some(ExecutionEvent::Info {
-                message: trimmed.to_string(),
-            })
-        }
-    }
-
     fn metadata(&self) -> &ExecutionMetadata {
         &self.metadata
     }

--- a/backend/src/execution_events/impls/codebuddy.rs
+++ b/backend/src/execution_events/impls/codebuddy.rs
@@ -184,16 +184,6 @@ impl EventExtractor for CodebuddyExtractor {
         vec![ExecutionEvent::Info { message: trimmed.to_string() }]
     }
 
-    fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
-        let trimmed = line.trim();
-        if trimmed.is_empty() { return None; }
-        if trimmed.to_lowercase().contains("error") {
-            Some(ExecutionEvent::Error { message: trimmed.to_string() })
-        } else {
-            Some(ExecutionEvent::Info { message: trimmed.to_string() })
-        }
-    }
-
     fn metadata(&self) -> &ExecutionMetadata { &self.metadata }
     fn metadata_mut(&mut self) -> &mut ExecutionMetadata { &mut self.metadata }
 }

--- a/backend/src/execution_events/impls/codewhale.rs
+++ b/backend/src/execution_events/impls/codewhale.rs
@@ -149,16 +149,6 @@ impl EventExtractor for CodewhaleExtractor {
         vec![ExecutionEvent::Info { message: trimmed.to_string() }]
     }
 
-    fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
-        let trimmed = line.trim();
-        if trimmed.is_empty() { return None; }
-        if trimmed.to_lowercase().contains("error") {
-            Some(ExecutionEvent::Error { message: trimmed.to_string() })
-        } else {
-            Some(ExecutionEvent::Info { message: trimmed.to_string() })
-        }
-    }
-
     fn metadata(&self) -> &ExecutionMetadata { &self.metadata }
     fn metadata_mut(&mut self) -> &mut ExecutionMetadata { &mut self.metadata }
 }

--- a/backend/src/execution_events/impls/codex.rs
+++ b/backend/src/execution_events/impls/codex.rs
@@ -291,6 +291,8 @@ impl EventExtractor for CodexExtractor {
         }
     }
 
+    // 096-W1：本 override 与 trait 默认实现**有意不同**，勿删——
+    // 默认实现按 "error" 关键字分流 Error/Info，Codex 统一 Info（误报率高）。
     fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
         let trimmed = line.trim();
         if trimmed.is_empty() {

--- a/backend/src/execution_events/impls/codex.rs
+++ b/backend/src/execution_events/impls/codex.rs
@@ -412,4 +412,33 @@ mod tests {
         assert!(events.iter().all(|e| !matches!(e, ExecutionEvent::SessionStart { .. })));
         assert!(extractor.metadata().session_id.is_none());
     }
+
+    // ====================== 096-W1：extract_stderr override 回归保护 ======================
+
+    // 钉住 Codex extract_stderr 的差异化行为：含 error 关键字的 stderr 行统一判为 Info。
+    // trait 默认实现（extractor.rs:33-48）会将其分流为 Error 事件，Codex 因 stderr 误报率高
+    // 而 override 为恒 Info。若有人误删 override 回退默认实现，本测试会失败。
+    #[test]
+    fn test_extract_stderr_error_keyword_returns_info() {
+        let mut extractor = CodexExtractor::new();
+        // 含 "error" 关键字——默认实现会返回 Error，Codex override 必须返回 Info
+        let event = extractor.extract_stderr("Error: compilation failed");
+        match event.as_ref() {
+            Some(ExecutionEvent::Info { message }) => assert_eq!(message.as_str(), "Error: compilation failed"),
+            // 命中此分支说明 override 被删、回退成了默认的 error 关键字分流
+            Some(ExecutionEvent::Error { .. }) => {
+                panic!("含 error 关键字的 stderr 不应判为 Error（Codex override 统一 Info）")
+            }
+            None => panic!("预期 Info 事件，实际返回 None"),
+            Some(_) => panic!("预期 Info 事件，实际返回其他事件类型"),
+        }
+    }
+
+    // 空行/纯空白行不应产出事件，避免 stderr 空行噪声污染事件流
+    #[test]
+    fn test_extract_stderr_empty_line_returns_none() {
+        let mut extractor = CodexExtractor::new();
+        assert!(extractor.extract_stderr("").is_none());
+        assert!(extractor.extract_stderr("   \t  ").is_none());
+    }
 }

--- a/backend/src/execution_events/impls/default.rs
+++ b/backend/src/execution_events/impls/default.rs
@@ -55,24 +55,6 @@ impl EventExtractor for DefaultExtractor {
         }
     }
 
-    fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            return None;
-        }
-
-        // 检查是否包含 error 关键字
-        if trimmed.to_lowercase().contains("error") {
-            Some(ExecutionEvent::Error {
-                message: trimmed.to_string(),
-            })
-        } else {
-            Some(ExecutionEvent::Info {
-                message: trimmed.to_string(),
-            })
-        }
-    }
-
     fn metadata(&self) -> &ExecutionMetadata {
         &self.metadata
     }

--- a/backend/src/execution_events/impls/hermes.rs
+++ b/backend/src/execution_events/impls/hermes.rs
@@ -213,23 +213,6 @@ impl EventExtractor for HermesExtractor {
         self.parse_line(line)
     }
 
-    fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            return None;
-        }
-
-        if trimmed.to_lowercase().contains("error") {
-            Some(ExecutionEvent::Error {
-                message: trimmed.to_string(),
-            })
-        } else {
-            Some(ExecutionEvent::Info {
-                message: trimmed.to_string(),
-            })
-        }
-    }
-
     fn metadata(&self) -> &ExecutionMetadata {
         &self.metadata
     }

--- a/backend/src/execution_events/impls/kilo.rs
+++ b/backend/src/execution_events/impls/kilo.rs
@@ -218,23 +218,6 @@ impl EventExtractor for KiloExtractor {
         }
     }
 
-    fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            return None;
-        }
-
-        if trimmed.to_lowercase().contains("error") {
-            Some(ExecutionEvent::Error {
-                message: trimmed.to_string(),
-            })
-        } else {
-            Some(ExecutionEvent::Info {
-                message: trimmed.to_string(),
-            })
-        }
-    }
-
     fn metadata(&self) -> &ExecutionMetadata {
         &self.metadata
     }

--- a/backend/src/execution_events/impls/kimi.rs
+++ b/backend/src/execution_events/impls/kimi.rs
@@ -187,23 +187,6 @@ impl EventExtractor for KimiExtractor {
         }
     }
 
-    fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            return None;
-        }
-
-        if trimmed.to_lowercase().contains("error") {
-            Some(ExecutionEvent::Error {
-                message: trimmed.to_string(),
-            })
-        } else {
-            Some(ExecutionEvent::Info {
-                message: trimmed.to_string(),
-            })
-        }
-    }
-
     fn metadata(&self) -> &ExecutionMetadata {
         &self.metadata
     }

--- a/backend/src/execution_events/impls/mimo.rs
+++ b/backend/src/execution_events/impls/mimo.rs
@@ -148,16 +148,6 @@ impl EventExtractor for MimoExtractor {
         vec![ExecutionEvent::Info { message: trimmed.to_string() }]
     }
 
-    fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
-        let trimmed = line.trim();
-        if trimmed.is_empty() { return None; }
-        if trimmed.to_lowercase().contains("error") {
-            Some(ExecutionEvent::Error { message: trimmed.to_string() })
-        } else {
-            Some(ExecutionEvent::Info { message: trimmed.to_string() })
-        }
-    }
-
     fn metadata(&self) -> &ExecutionMetadata { &self.metadata }
     fn metadata_mut(&mut self) -> &mut ExecutionMetadata { &mut self.metadata }
 }

--- a/backend/src/execution_events/impls/mobilecoder.rs
+++ b/backend/src/execution_events/impls/mobilecoder.rs
@@ -161,18 +161,6 @@ impl EventExtractor for MobilecoderExtractor {
         }]
     }
 
-    fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            return None;
-        }
-        if trimmed.to_lowercase().contains("error") {
-            Some(ExecutionEvent::Error { message: trimmed.to_string() })
-        } else {
-            Some(ExecutionEvent::Info { message: trimmed.to_string() })
-        }
-    }
-
     fn metadata(&self) -> &ExecutionMetadata { &self.metadata }
     fn metadata_mut(&mut self) -> &mut ExecutionMetadata { &mut self.metadata }
 }

--- a/backend/src/execution_events/impls/opencode.rs
+++ b/backend/src/execution_events/impls/opencode.rs
@@ -220,23 +220,6 @@ impl EventExtractor for OpencodeExtractor {
         }
     }
 
-    fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            return None;
-        }
-
-        if trimmed.to_lowercase().contains("error") {
-            Some(ExecutionEvent::Error {
-                message: trimmed.to_string(),
-            })
-        } else {
-            Some(ExecutionEvent::Info {
-                message: trimmed.to_string(),
-            })
-        }
-    }
-
     fn metadata(&self) -> &ExecutionMetadata {
         &self.metadata
     }

--- a/backend/src/execution_events/impls/pi.rs
+++ b/backend/src/execution_events/impls/pi.rs
@@ -357,24 +357,6 @@ impl EventExtractor for PiExtractor {
         }]
     }
 
-    fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            return None;
-        }
-
-        // 检查是否包含 error 关键字
-        if trimmed.to_lowercase().contains("error") {
-            Some(ExecutionEvent::Error {
-                message: trimmed.to_string(),
-            })
-        } else {
-            Some(ExecutionEvent::Info {
-                message: trimmed.to_string(),
-            })
-        }
-    }
-
     fn metadata(&self) -> &ExecutionMetadata {
         &self.metadata
     }

--- a/backend/src/execution_events/impls/zhanlu.rs
+++ b/backend/src/execution_events/impls/zhanlu.rs
@@ -167,16 +167,6 @@ impl EventExtractor for ZhanluExtractor {
         vec![ExecutionEvent::Info { message: trimmed.to_string() }]
     }
 
-    fn extract_stderr(&mut self, line: &str) -> Option<ExecutionEvent> {
-        let trimmed = line.trim();
-        if trimmed.is_empty() { return None; }
-        if trimmed.to_lowercase().contains("error") {
-            Some(ExecutionEvent::Error { message: trimmed.to_string() })
-        } else {
-            Some(ExecutionEvent::Info { message: trimmed.to_string() })
-        }
-    }
-
     fn metadata(&self) -> &ExecutionMetadata { &self.metadata }
     fn metadata_mut(&mut self) -> &mut ExecutionMetadata { &mut self.metadata }
 }


### PR DESCRIPTION
依据：`docs/代码质量全景扫描报告-20260811.md` A1 项；方案：`docs/design/096-代码质量重构分步方案.md` W1-PR1。

## 实证

`execution_events/extractor.rs:33-48` 的 trait 默认实现与 `impls/` 下 12 个文件的 override **逐字相同**（trim → 空判 → error 关键字分流 Error/Info）：claude_code/kimi/kilo/opencode/pi/hermes/zhanlu/mimo/mobilecoder/codebuddy/codewhale/default。

## 处置

- 删除 12 处 override（-173 行纯删减），默认实现生效，行为零变化
- **保留并标注** 2 处真实差异：
  - `codex.rs`：统一 Info（error 关键字误报率高）
  - `atomcode.rs`：委托 extract() 走完整管线
  两处加「有意不同，勿删」注释防后续误清理

## 验证

- `execution_events::` 129 测试全过
- 全量 lib 1657 通过 / 1 失败（git_sync 本机环境已知问题，基线一致）
- clippy 改动文件零告警