### PR TITLE
refactor(096-W1): 跨文件重复收口——extract_session_from_logs 上移 session_util 公共层、专家注入核心收口 expert::inject 双通路共用

### DIFF
--- a/backend/src/executor_service/mod.rs
+++ b/backend/src/executor_service/mod.rs
@@ -9,6 +9,7 @@
 //! - [`completion`] —— 终态分支（正常/取消/超时）、自动评审、completion hook、emit event
 //! - [`stages`] —— 三阶段 stage 函数 + spawn 闭包 + dispatch 收口
 //! - [`auto_review`] —— 同步自动评审（基于独立 runtime + std::thread 跑评审实例）
+//! - [`session_util`] —— 执行器 session 提取公共 helper（私聊/wiki chat 两通路共用）
 //! - [`types`] —— 跨模块共享的 stage 产物聚合类型
 //!
 //! 各子模块可独立单测；本文件只在「公共 API + 编排骨架」级别保留代码。
@@ -18,6 +19,7 @@ pub(crate) mod completion;
 pub mod events;
 pub(crate) mod log_capture;
 pub(crate) mod pre_spawn;
+pub(crate) mod session_util;
 pub(crate) mod spawn_lifecycle;
 pub(crate) mod stages;
 pub(crate) mod types;

--- a/backend/src/executor_service/pre_spawn.rs
+++ b/backend/src/executor_service/pre_spawn.rs
@@ -628,80 +628,26 @@ pub(crate) async fn inject_workspace_background(
 ///
 /// 失败时静默返回原 message，不阻断执行——专家 prompt 注入是增强项，
 /// 不应该让专家索引读取失败导致整个 todo 执行失败。
+/// 注入格式以 `crate::expert::inject_expert_message` 的 doc 注释为权威定义。
 ///
-/// 注入格式：
-/// ```text
-/// # 专家角色定义
-/// {agent_md_content}
+/// 任一前置条件缺失都静默回退到原 message——专家注入是增强项，不应阻断执行。
 ///
-/// # 可用技能
-/// {skill_name}: {skill_description}
-/// ...
-///
-/// # 任务
-/// {original_message}
-/// ```
+/// 核心注入逻辑（查索引 → 读 Agent MD → 拼技能 → 三段式拼接）已收口到
+/// `crate::expert::inject_expert_message`（096-W1-PR3），与 wiki chat 通路共用一份；
+/// 本函数只保留 todo 执行管线特有的前置条件取数（todo.expert_name + request.expert_manager）。
+/// 保持 async 签名仅为兼容既有调用链（stages.rs），函数体本身无异步操作。
 pub(crate) async fn inject_expert_context(
     request: &super::RunTodoExecutionRequest,
     todo: &Option<crate::models::Todo>,
     message: &str,
 ) -> String {
-    // 任一前置条件缺失都静默回退到原 message——专家注入是增强项，不应阻断执行。
     let Some(expert_name) = todo.as_ref().and_then(|t| t.expert_name.as_deref()) else {
         return message.to_string();
     };
     let Some(expert_manager) = &request.expert_manager else {
         return message.to_string();
     };
-    let Some(metadata) = expert_manager.get_expert_by_name(expert_name) else {
-        tracing::warn!("未找到专家 '{}'，跳过专家上下文注入", expert_name);
-        return message.to_string();
-    };
-    // 解析主理 agent：team 用 lead_agent、agent 用 agent_name（resolve_agent_name 统一），
-    // 并按 (expert_name, agent_name) 复合键查找，避免不同专家同名 agent 互窜。
-    let Some(agent_name) = metadata.resolve_agent_name() else {
-        tracing::warn!(
-            "专家 '{}' 没有可用 agent（agent_name/lead_agent 都为空）",
-            expert_name
-        );
-        return message.to_string();
-    };
-    let Ok(agent_md) = expert_manager.get_agent_md_content(expert_name, agent_name) else {
-        tracing::warn!(
-            "未找到专家 '{}' 的 Agent '{}' MD 内容，跳过注入",
-            expert_name,
-            agent_name
-        );
-        return message.to_string();
-    };
-    let skills_text = build_expert_skills_text(expert_manager, expert_name);
-    build_expert_prompt(&agent_md, &skills_text, message)
-}
-
-/// 拼接专家技能列表文本：复用 loader 模块的 build_skills_context，支持中文描述优先。
-///
-/// 抽出来单独成函数是为了让 `inject_expert_context` 保持在 30 行内。
-fn build_expert_skills_text(
-    expert_manager: &crate::expert::ExpertIndexManager,
-    expert_name: &str,
-) -> String {
-    // 复用 loader::build_skills_context，它已实现中文优先回退逻辑。
-    crate::expert::build_skills_context(&expert_manager.get_expert_skills(expert_name))
-}
-
-/// 把 Agent MD、技能列表、原 message 拼成最终 prompt。
-///
-/// 三段式结构：专家角色定义 → 可用技能（由 build_skills_context 生成） → 任务。
-/// skills_text 为空时不添加技能段落，避免无谓标题。
-fn build_expert_prompt(agent_md: &str, skills_text: &str, original_message: &str) -> String {
-    if skills_text.is_empty() {
-        format!("# 专家角色定义\n{}\n\n# 任务\n{}", agent_md, original_message)
-    } else {
-        format!(
-            "# 专家角色定义\n{}\n\n{}\n\n# 任务\n{}",
-            agent_md, skills_text, original_message
-        )
-    }
+    crate::expert::inject_expert_message(expert_manager, Some(expert_name), message)
 }
 
 // ─── 环节级「期望产物 + spec 模板」注入（需求 054）───
@@ -1003,86 +949,6 @@ mod tests {
             resolve_exec_model(Some("  gpt-4  "), Some("sonnet"), None),
             Some("gpt-4".to_string())
         );
-    }
-
-    /// `build_expert_prompt` 把 Agent MD、技能列表、原 message 拼成三段式 prompt。
-    /// 有技能时保留技能段落（由 build_skills_context 生成，含标题行）。
-    #[test]
-    fn test_build_expert_prompt_three_sections() {
-        let agent_md = "你是一个 Rust 专家";
-        let skills = "## 可用技能\n你可以使用以下技能来辅助完成任务：\n- **code-review**: 代码评审技能\n";
-        let original = "请帮我写一个函数";
-        let result = build_expert_prompt(agent_md, skills, original);
-        // 三段标题按顺序出现，且原 message 在末尾
-        assert!(result.contains("# 专家角色定义\n你是一个 Rust 专家"));
-        assert!(result.contains("## 可用技能"));
-        assert!(result.contains("# 任务\n请帮我写一个函数"));
-    }
-
-    /// `build_expert_prompt` 技能列表为空时省略技能段落。
-    #[test]
-    fn test_build_expert_prompt_empty_skills_omits_section() {
-        let result = build_expert_prompt("agent", "", "do something");
-        // 空技能时不出现技能段落，直接从角色定义跳到任务
-        assert!(!result.contains("可用技能"));
-        assert!(result.contains("# 专家角色定义\nagent"));
-        assert!(result.contains("# 任务\ndo something"));
-    }
-
-    /// `build_expert_skills_text` 复用 loader::build_skills_context，
-    /// 返回 Markdown 格式的技能列表（含标题行和项目符号）。
-    #[test]
-    fn test_build_expert_skills_text_formats_each_skill() {
-        use crate::expert::{ExpertIndexManager, SkillMetadata};
-        let manager = ExpertIndexManager::new();
-        // 准备两个 skill 的元数据并更新到索引
-        let skills = vec![
-            SkillMetadata {
-                skill_name: "code-review".to_string(),
-                skill_dir: "/tmp/skills/code-review".to_string(),
-                skill_md_path: "/tmp/skills/code-review/SKILL.md".to_string(),
-                yaml_name: None,
-                yaml_description: Some("代码评审".to_string()),
-                yaml_description_zh: None,
-                yaml_description_en: None,
-                yaml_version: None,
-                yaml_allowed_tools: vec![],
-                yaml_emoji: None,
-            },
-            SkillMetadata {
-                skill_name: "test-gen".to_string(),
-                skill_dir: "/tmp/skills/test-gen".to_string(),
-                skill_md_path: "/tmp/skills/test-gen/SKILL.md".to_string(),
-                yaml_name: None,
-                // description 为 None 时回退到 "(无描述)"
-                yaml_description: None,
-                yaml_description_zh: None,
-                yaml_description_en: None,
-                yaml_version: None,
-                yaml_allowed_tools: vec![],
-                yaml_emoji: None,
-            },
-        ];
-        // 借用一个最小 ExpertMetadata 把 skill 绑到 "test-expert"
-        let expert = make_minimal_expert_metadata("test-expert", Some("test-agent"), None);
-        manager.update_index(&expert, &[], &skills);
-        let text = build_expert_skills_text(&manager, "test-expert");
-        // build_skills_context 输出 Markdown 格式：标题 + 项目符号列表
-        assert!(text.contains("## 可用技能"));
-        // build_skills_context 将技能名渲染为 Markdown 链接指向 SKILL.md 路径
-        assert!(text.contains("- **[code-review]("));
-        assert!(text.contains("**: 代码评审"));
-        assert!(text.contains("- **[test-gen]("));
-        assert!(text.contains("**: (无描述)"));
-    }
-
-    /// `build_expert_skills_text` 查询不存在的专家时返回空串（get_expert_skills 容错）。
-    #[test]
-    fn test_build_expert_skills_text_unknown_expert_returns_empty() {
-        use crate::expert::ExpertIndexManager;
-        let manager = ExpertIndexManager::new();
-        let text = build_expert_skills_text(&manager, "non-existent-expert");
-        assert!(text.is_empty());
     }
 
     /// `inject_expert_context` 在 todo 为 None 时直接返回原 message。

--- a/backend/src/executor_service/pre_spawn.rs
+++ b/backend/src/executor_service/pre_spawn.rs
@@ -647,7 +647,7 @@ pub(crate) async fn inject_expert_context(
     let Some(expert_manager) = &request.expert_manager else {
         return message.to_string();
     };
-    crate::expert::inject_expert_message(expert_manager, Some(expert_name), message)
+    crate::expert::inject_expert_message(expert_manager, Some(expert_name), message, "")
 }
 
 // ─── 环节级「期望产物 + spec 模板」注入（需求 054）───
@@ -856,6 +856,8 @@ pub(crate) async fn enforce_concurrency_limit(
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::useless_vec, clippy::redundant_pattern_matching, clippy::redundant_clone, clippy::len_zero, clippy::bool_assert_comparison, clippy::unnecessary_get_then_check, clippy::doc_lazy_continuation, clippy::clone_on_copy, clippy::print_stdout, clippy::needless_pass_by_value, clippy::sliced_string_as_bytes, clippy::manual_map, clippy::collapsible_match, clippy::question_mark)]
 mod tests {
     use super::*;
+    // 共享专家测试夹具（与 expert::inject 测试共用），避免 ExpertMetadata 22 字段构造重复
+    use crate::expert::test_support::make_minimal_expert_metadata;
 
     #[test]
     fn test_resolve_executor_type_priority_chain() {
@@ -1126,42 +1128,6 @@ mod tests {
         assert!(result.contains("# 任务\n请帮我写代码"));
         // 清理临时文件
         let _ = std::fs::remove_file(&md_path);
-    }
-
-    /// 构造最小可用的 ExpertMetadata 供测试使用。
-    /// 只填必要字段，其余用空值/None，避免每个测试都重复 22 个字段。
-    fn make_minimal_expert_metadata(
-        name: &str,
-        agent_name: Option<&str>,
-        lead_agent: Option<&str>,
-    ) -> crate::expert::ExpertMetadata {
-        use crate::expert::{ExpertMetadata, ExpertSource, ExpertType};
-        ExpertMetadata {
-            name: name.to_string(),
-            expert_type: ExpertType::Agent,
-            version: "0.0.1-test".to_string(),
-            source: ExpertSource::System,
-            display_name_zh: None,
-            display_name_en: None,
-            profession_zh: None,
-            profession_en: None,
-            description_zh: None,
-            description_en: None,
-            avatar_path: None,
-            category_id: None,
-            definition_dir: "/tmp".to_string(),
-            plugin_json_path: "/tmp/plugin.json".to_string(),
-            agent_name: agent_name.map(|s| s.to_string()),
-            lead_agent: lead_agent.map(|s| s.to_string()),
-            member_agents: vec![],
-            members: vec![],
-            skills: vec![],
-            default_init_prompt_zh: None,
-            default_init_prompt_en: None,
-            tags: vec![],
-            loaded_at: "test".to_string(),
-            is_active: true,
-        }
     }
 
     /// 构造一个带 expert_name 的 Todo（仅填必要字段）。

--- a/backend/src/executor_service/session_util.rs
+++ b/backend/src/executor_service/session_util.rs
@@ -1,0 +1,139 @@
+//! 执行器会话（session）辅助函数。
+//!
+//! 本模块是 096-W1-PR3「跨文件重复收口」的落点：
+//! `services::message_debounce`（飞书私聊通路）与 `services::blackboard`（wiki chat 通路）
+//! 曾各自维护一份逐字相同的 `extract_session_from_logs` 私有函数（连 doc 注释都一致），
+//! session 提取策略调整要改两处。这里上移到执行器服务层作为唯一公共实现，
+//! 两个调用方仅保留各自的「成功后持久化到 DB」业务逻辑。
+
+use std::sync::Arc;
+
+use crate::adapters::CodeExecutor;
+use crate::models::ParsedLogEntry;
+
+/// 从执行日志中提取 session_id。
+///
+/// 流程：
+/// 1. 先尝试从日志内容中提取（extract_session_id）
+/// 2. 如果没有，尝试执行器内部缓存的 session_id（get_session_id）
+///
+/// 不同执行器暴露 session_id 的方式不同：
+/// - Claude Code: stdout JSONL 行含 session_id
+/// - Hermès: `session_id: <sid>` 行
+/// - Pi: `{"type":"session","id":"<sid>"}` 行（通过 get_session_id 获取缓存值）
+///
+/// 返回 None 表示执行器不支持 session 或首次执行。
+pub(crate) fn extract_session_from_logs(
+    executor: &Arc<dyn CodeExecutor>,
+    logs: &[ParsedLogEntry],
+) -> Option<String> {
+    // 1. 优先从日志内容提取：逐行询问执行器，首个命中即返回——
+    //    同一 session 的 id 在多行重复出现时取首个，避免尾部临时行覆盖真实会话 id。
+    for entry in logs {
+        if let Some(sid) = executor.extract_session_id(&entry.content) {
+            return Some(sid);
+        }
+    }
+    // 2. 回退到执行器内部缓存的 session_id（Pi 等执行器在 parse_output_line 时缓存）
+    executor.get_session_id()
+}
+
+#[cfg(test)]
+// 测试夹具允许 unwrap/expect：与 pre_spawn 等既有测试模块的 lint 豁免惯例保持一致
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    // ExecutorType 定义在 models 层（adapters 内只是私有 use，不可跨模块引用）
+    use crate::models::ExecutorType;
+    use async_trait::async_trait;
+
+    /// 可控的最小执行器桩：按「行内容是否含 marker」模拟 extract_session_id 的命中/未命中，
+    /// cached_sid 模拟执行器内部缓存（Pi 模式）。adapters 测试模块的 MockExecutor 是模块私有的，
+    /// 跨模块测试不可引用，故在此自备桩实现。
+    struct StubExecutor {
+        /// extract_session_id 只在行内容含该 marker 时返回 sid
+        marker: &'static str,
+        /// 命中时返回的 session_id
+        line_sid: Option<String>,
+        /// get_session_id 的固定返回（模拟内部缓存）
+        cached_sid: Option<String>,
+    }
+
+    #[async_trait]
+    impl CodeExecutor for StubExecutor {
+        fn executor_type(&self) -> ExecutorType {
+            ExecutorType::Mobilecoder
+        }
+        fn executable_path(&self) -> &str {
+            "stub"
+        }
+        fn command_args(&self, _message: &str) -> Vec<String> {
+            vec![]
+        }
+        fn parse_output_line(&self, _line: &str) -> Option<ParsedLogEntry> {
+            None
+        }
+        fn get_model(&self) -> Option<String> {
+            None
+        }
+        fn extract_session_id(&self, line: &str) -> Option<String> {
+            // 仅当行内容包含 marker 时视为命中，模拟真实执行器的行级解析
+            if line.contains(self.marker) {
+                self.line_sid.clone()
+            } else {
+                None
+            }
+        }
+        fn get_session_id(&self) -> Option<String> {
+            self.cached_sid.clone()
+        }
+    }
+
+    /// 日志行中可提取时应返回首个命中的 session_id（Claude Code / Hermès 模式）。
+    #[test]
+    fn test_extract_session_from_logs_hit_in_logs_returns_first_match() {
+        let executor: Arc<dyn CodeExecutor> = Arc::new(StubExecutor {
+            marker: "session_id",
+            line_sid: Some("sid-from-line".to_string()),
+            cached_sid: Some("sid-cached".to_string()),
+        });
+        let logs = vec![
+            ParsedLogEntry::new("info", "启动执行"),
+            ParsedLogEntry::new("info", "session_id: sid-from-line"),
+        ];
+        // 行内命中优先于缓存：即使缓存有值，也以日志解析结果为准
+        assert_eq!(
+            extract_session_from_logs(&executor, &logs),
+            Some("sid-from-line".to_string())
+        );
+    }
+
+    /// 日志行全部未命中时回退到执行器内部缓存（Pi 模式）。
+    #[test]
+    fn test_extract_session_from_logs_fallback_to_cached() {
+        let executor: Arc<dyn CodeExecutor> = Arc::new(StubExecutor {
+            marker: "session_id",
+            line_sid: Some("sid-from-line".to_string()),
+            cached_sid: Some("sid-cached".to_string()),
+        });
+        let logs = vec![ParsedLogEntry::new("text", "普通输出，没有会话信息")];
+        assert_eq!(
+            extract_session_from_logs(&executor, &logs),
+            Some("sid-cached".to_string())
+        );
+    }
+
+    /// 日志未命中且缓存为空时返回 None（执行器不支持 session 或首次执行）。
+    #[test]
+    fn test_extract_session_from_logs_no_hit_no_cache_returns_none() {
+        let executor: Arc<dyn CodeExecutor> = Arc::new(StubExecutor {
+            marker: "session_id",
+            line_sid: None,
+            cached_sid: None,
+        });
+        let logs = vec![ParsedLogEntry::new("text", "普通输出")];
+        assert_eq!(extract_session_from_logs(&executor, &logs), None);
+        // 空日志列表同样走缓存路径，结果也为 None
+        assert_eq!(extract_session_from_logs(&executor, &[]), None);
+    }
+}

--- a/backend/src/expert/inject.rs
+++ b/backend/src/expert/inject.rs
@@ -36,12 +36,15 @@ use super::ExpertIndexManager;
 /// {original_message}
 /// ```
 ///
-/// 注意：本函数的 warn 日志不带调用方前缀（如 "wiki chat:"），
-/// 统一文案以便日志聚合检索；调用方上下文由调用方自己的 info 日志承担。
+/// 注意：本函数的 warn 日志通过 `caller_tag` 参数携带调用方前缀（如 "wiki chat: "），
+/// 以便运维从聚合日志中区分注入失败来自 wiki chat 还是 todo 执行通路；todo 通路传空串
+/// 保持其原有的无前缀文案。这是 096-W1 review 的可观测性修复——合并前 wiki 通路独有
+/// "wiki chat:" 前缀，收口时一度丢失，现通过参数显式回传。
 pub(crate) fn inject_expert_message(
     expert_manager: &ExpertIndexManager,
     expert_name: Option<&str>,
     message: &str,
+    caller_tag: &str,
 ) -> String {
     // 未指定专家名（或空串）时直接返回原消息——空串判等来自 wiki chat 通路的既有行为，
     // 收进公共层后两条通路语义一致。
@@ -51,14 +54,15 @@ pub(crate) fn inject_expert_message(
     };
     // 查找专家元数据，找不到则静默回退：专家可能已被卸载，不应因此阻断用户消息。
     let Some(metadata) = expert_manager.get_expert_by_name(name) else {
-        tracing::warn!("未找到专家 '{}'，跳过专家上下文注入", name);
+        tracing::warn!("{}未找到专家 '{}'，跳过专家上下文注入", caller_tag, name);
         return message.to_string();
     };
     // 解析主理 agent：team 用 lead_agent、agent 用 agent_name（resolve_agent_name 统一），
     // 并按 (expert_name, agent_name) 复合键查找，避免不同专家同名 agent 互窜。
     let Some(agent_name) = metadata.resolve_agent_name() else {
         tracing::warn!(
-            "专家 '{}' 没有可用 agent（agent_name/lead_agent 都为空）",
+            "{}专家 '{}' 没有可用 agent（agent_name/lead_agent 都为空）",
+            caller_tag,
             name
         );
         return message.to_string();
@@ -66,7 +70,8 @@ pub(crate) fn inject_expert_message(
     // 读取 Agent MD 全文；文件缺失/不可读同样静默回退（索引与文件可能不同步）。
     let Ok(agent_md) = expert_manager.get_agent_md_content(name, agent_name) else {
         tracing::warn!(
-            "未找到专家 '{}' 的 Agent '{}' MD 内容，跳过注入",
+            "{}未找到专家 '{}' 的 Agent '{}' MD 内容，跳过注入",
+            caller_tag,
             name,
             agent_name
         );
@@ -104,46 +109,22 @@ fn build_expert_prompt(agent_md: &str, skills_text: &str, original_message: &str
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use crate::expert::{AgentFileMetadata, ExpertMetadata, ExpertSource, ExpertType, SkillMetadata};
+    use crate::expert::test_support::make_minimal_expert_metadata;
+    use crate::expert::{AgentFileMetadata, SkillMetadata};
 
-    /// 构造最小可用的 ExpertMetadata 供测试使用。
-    /// 只填必要字段，其余用空值/None，避免每个测试都重复 22 个字段。
-    fn make_minimal_expert_metadata(
-        name: &str,
-        agent_name: Option<&str>,
-        lead_agent: Option<&str>,
-    ) -> ExpertMetadata {
-        ExpertMetadata {
-            name: name.to_string(),
-            expert_type: ExpertType::Agent,
-            version: "0.0.1-test".to_string(),
-            source: ExpertSource::System,
-            display_name_zh: None,
-            display_name_en: None,
-            profession_zh: None,
-            profession_en: None,
-            description_zh: None,
-            description_en: None,
-            avatar_path: None,
-            category_id: None,
-            definition_dir: "/tmp".to_string(),
-            plugin_json_path: "/tmp/plugin.json".to_string(),
-            agent_name: agent_name.map(|s| s.to_string()),
-            lead_agent: lead_agent.map(|s| s.to_string()),
-            member_agents: vec![],
-            members: vec![],
-            skills: vec![],
-            default_init_prompt_zh: None,
-            default_init_prompt_en: None,
-            tags: vec![],
-            loaded_at: "test".to_string(),
-            is_active: true,
+    /// RAII 守卫：持有临时 MD 文件路径，Drop 时自动删除。
+    /// 断言失败 panic 时仍会触发 Drop（unwind），避免临时文件泄漏到 $TMPDIR。
+    struct TmpMdFile(String);
+
+    impl Drop for TmpMdFile {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
         }
     }
 
-    /// 准备临时 Agent MD 文件并注册到索引，返回 (manager, md_path)；
-    /// 调用方负责在断言后删除 md_path，避免临时文件堆积。
-    fn make_manager_with_agent_md(content: &str, with_skill: bool) -> (ExpertIndexManager, String) {
+    /// 准备临时 Agent MD 文件并注册到索引，返回 (manager, TmpMdFile)；
+    /// TmpMdFile 的 Drop 自动删除临时文件，断言失败也不泄漏，调用方无需手动清理。
+    fn make_manager_with_agent_md(content: &str, with_skill: bool) -> (ExpertIndexManager, TmpMdFile) {
         use std::io::Write;
         // 以纳秒时间戳命名，保证并发测试互不踩踏
         let mut tmp_path = std::env::temp_dir();
@@ -188,7 +169,7 @@ mod tests {
         };
         let expert = make_minimal_expert_metadata("rust-expert", Some("rust-agent"), None);
         manager.update_index(&expert, &[agent_file], &skills);
-        (manager, md_path)
+        (manager, TmpMdFile(md_path))
     }
 
     /// 未指定专家名（None 或空串）时原样返回消息——空串判等是 wiki chat 通路的既有行为。
@@ -196,36 +177,36 @@ mod tests {
     fn test_inject_expert_message_none_or_empty_name_returns_original() {
         let manager = ExpertIndexManager::new();
         let original = "原始消息";
-        assert_eq!(inject_expert_message(&manager, None, original), original);
-        assert_eq!(inject_expert_message(&manager, Some(""), original), original);
+        assert_eq!(inject_expert_message(&manager, None, original, ""), original);
+        assert_eq!(inject_expert_message(&manager, Some(""), original, ""), original);
     }
 
     /// 专家无技能时应省略「可用技能」段落（两段式），避免出现空标题。
     /// 这是 pre_spawn 既有测试未覆盖的分支，公共层补齐锁定。
     #[test]
     fn test_inject_expert_message_without_skills_omits_skills_section() {
-        let (manager, md_path) = make_manager_with_agent_md("你是一个 Rust 专家", false);
-        let result = inject_expert_message(&manager, Some("rust-expert"), "请帮我写代码");
+        // _guard 绑定到作用域末尾，Drop 时自动删临时 MD；即使下方断言 panic 也不泄漏
+        let (manager, _guard) = make_manager_with_agent_md("你是一个 Rust 专家", false);
+        let result = inject_expert_message(&manager, Some("rust-expert"), "请帮我写代码", "");
         // 期望中的三个连续 \n：夹具用 writeln! 写入 MD 使 agent_md 自带尾部换行，
         // 拼接时再补两个 \n——与真实场景（MD 文件通常以换行结尾）一致
         assert_eq!(
             result,
             "# 专家角色定义\n你是一个 Rust 专家\n\n\n# 任务\n请帮我写代码"
         );
-        let _ = std::fs::remove_file(&md_path);
     }
 
     /// 专家有技能时输出三段式：角色定义 → 可用技能 → 任务，锁定拼接格式契约。
     #[test]
     fn test_inject_expert_message_with_skills_full_three_section_prompt() {
-        let (manager, md_path) = make_manager_with_agent_md("你是一个 Rust 专家", true);
-        let result = inject_expert_message(&manager, Some("rust-expert"), "请帮我写代码");
+        // _guard 绑定到作用域末尾，Drop 时自动删临时 MD；即使下方断言 panic 也不泄漏
+        let (manager, _guard) = make_manager_with_agent_md("你是一个 Rust 专家", true);
+        let result = inject_expert_message(&manager, Some("rust-expert"), "请帮我写代码", "");
         assert!(result.starts_with("# 专家角色定义\n你是一个 Rust 专家\n"));
         assert!(result.contains("## 可用技能"));
         // build_skills_context 将技能名渲染为 Markdown 链接指向 SKILL.md 路径
         assert!(result.contains("- **[code-review]("));
         assert!(result.ends_with("# 任务\n请帮我写代码"));
-        let _ = std::fs::remove_file(&md_path);
     }
 
     /// `build_expert_prompt` 把 Agent MD、技能列表、原 message 拼成三段式 prompt。

--- a/backend/src/expert/inject.rs
+++ b/backend/src/expert/inject.rs
@@ -1,0 +1,308 @@
+//! 专家上下文注入的公共核心（同步纯函数层）。
+//!
+//! 本模块是 096-W1-PR3「跨文件重复收口」的落点：
+//! 原 `executor_service::pre_spawn::inject_expert_context`（todo 执行管线）与
+//! `services::blackboard::inject_wiki_expert_context`（wiki chat 通路）各自维护了一份
+//! 逐字同构的专家注入逻辑（查索引 → 解析主理 agent → 读 Agent MD → 拼技能 → 三段式拼接），
+//! 任何注入格式调整都要改两处。这里把「与调用方上下文无关」的核心提取为同步自由函数，
+//! 两个调用方只保留各自的前置条件取数（todo.expert_name / 请求参数），再委托本模块。
+//!
+//! 设计取舍：
+//! - 保持同步签名：核心链路（索引查询 + 文件读取 + 字符串拼接）全部同步，
+//!   async 包装留给调用方（pre_spawn 的 `inject_expert_context` 保持 async 以兼容既有调用链）。
+//! - `expert_name` 取 `Option<&str>` 而非 `&str`：两个调用方的原始输入都是可选值，
+//!   把「未指定/空串」的快速回退收进公共层，调用方不必各自判空。
+
+use super::ExpertIndexManager;
+
+/// 为消息注入专家上下文：角色定义 + 技能列表前置到原消息。
+///
+/// 流程（任一步失败都静默回退原消息——专家注入是增强项，不应阻断主流程）：
+/// 1. 专家名缺失或空串 → 原样返回；
+/// 2. 索引中找不到专家 → warn 后原样返回；
+/// 3. 专家无可用 agent（agent_name/lead_agent 均空）→ warn 后原样返回；
+/// 4. Agent MD 文件读取失败 → warn 后原样返回；
+/// 5. 全部命中 → 拼接三段式 prompt 返回。
+///
+/// 注入格式：
+/// ```text
+/// # 专家角色定义
+/// {agent_md_content}
+///
+/// ## 可用技能
+/// {skill_list}        ← 仅当技能非空时存在该段
+///
+/// # 任务
+/// {original_message}
+/// ```
+///
+/// 注意：本函数的 warn 日志不带调用方前缀（如 "wiki chat:"），
+/// 统一文案以便日志聚合检索；调用方上下文由调用方自己的 info 日志承担。
+pub(crate) fn inject_expert_message(
+    expert_manager: &ExpertIndexManager,
+    expert_name: Option<&str>,
+    message: &str,
+) -> String {
+    // 未指定专家名（或空串）时直接返回原消息——空串判等来自 wiki chat 通路的既有行为，
+    // 收进公共层后两条通路语义一致。
+    let name = match expert_name {
+        Some(n) if !n.is_empty() => n,
+        _ => return message.to_string(),
+    };
+    // 查找专家元数据，找不到则静默回退：专家可能已被卸载，不应因此阻断用户消息。
+    let Some(metadata) = expert_manager.get_expert_by_name(name) else {
+        tracing::warn!("未找到专家 '{}'，跳过专家上下文注入", name);
+        return message.to_string();
+    };
+    // 解析主理 agent：team 用 lead_agent、agent 用 agent_name（resolve_agent_name 统一），
+    // 并按 (expert_name, agent_name) 复合键查找，避免不同专家同名 agent 互窜。
+    let Some(agent_name) = metadata.resolve_agent_name() else {
+        tracing::warn!(
+            "专家 '{}' 没有可用 agent（agent_name/lead_agent 都为空）",
+            name
+        );
+        return message.to_string();
+    };
+    // 读取 Agent MD 全文；文件缺失/不可读同样静默回退（索引与文件可能不同步）。
+    let Ok(agent_md) = expert_manager.get_agent_md_content(name, agent_name) else {
+        tracing::warn!(
+            "未找到专家 '{}' 的 Agent '{}' MD 内容，跳过注入",
+            name,
+            agent_name
+        );
+        return message.to_string();
+    };
+    let skills_text = build_expert_skills_text(expert_manager, name);
+    build_expert_prompt(&agent_md, &skills_text, message)
+}
+
+/// 拼接专家技能列表文本：复用 loader 模块的 build_skills_context，支持中文描述优先。
+///
+/// 抽出来单独成函数是为了让 `inject_expert_message` 保持在 30 行内。
+fn build_expert_skills_text(expert_manager: &ExpertIndexManager, expert_name: &str) -> String {
+    // 复用 loader::build_skills_context，它已实现中文优先回退逻辑。
+    super::build_skills_context(&expert_manager.get_expert_skills(expert_name))
+}
+
+/// 把 Agent MD、技能列表、原 message 拼成最终 prompt。
+///
+/// 三段式结构：专家角色定义 → 可用技能（由 build_skills_context 生成） → 任务。
+/// skills_text 为空时不添加技能段落，避免无谓标题。
+fn build_expert_prompt(agent_md: &str, skills_text: &str, original_message: &str) -> String {
+    if skills_text.is_empty() {
+        format!("# 专家角色定义\n{}\n\n# 任务\n{}", agent_md, original_message)
+    } else {
+        format!(
+            "# 专家角色定义\n{}\n\n{}\n\n# 任务\n{}",
+            agent_md, skills_text, original_message
+        )
+    }
+}
+
+#[cfg(test)]
+// 测试夹具允许 unwrap/expect：与 pre_spawn 等既有测试模块的 lint 豁免惯例保持一致
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::expert::{AgentFileMetadata, ExpertMetadata, ExpertSource, ExpertType, SkillMetadata};
+
+    /// 构造最小可用的 ExpertMetadata 供测试使用。
+    /// 只填必要字段，其余用空值/None，避免每个测试都重复 22 个字段。
+    fn make_minimal_expert_metadata(
+        name: &str,
+        agent_name: Option<&str>,
+        lead_agent: Option<&str>,
+    ) -> ExpertMetadata {
+        ExpertMetadata {
+            name: name.to_string(),
+            expert_type: ExpertType::Agent,
+            version: "0.0.1-test".to_string(),
+            source: ExpertSource::System,
+            display_name_zh: None,
+            display_name_en: None,
+            profession_zh: None,
+            profession_en: None,
+            description_zh: None,
+            description_en: None,
+            avatar_path: None,
+            category_id: None,
+            definition_dir: "/tmp".to_string(),
+            plugin_json_path: "/tmp/plugin.json".to_string(),
+            agent_name: agent_name.map(|s| s.to_string()),
+            lead_agent: lead_agent.map(|s| s.to_string()),
+            member_agents: vec![],
+            members: vec![],
+            skills: vec![],
+            default_init_prompt_zh: None,
+            default_init_prompt_en: None,
+            tags: vec![],
+            loaded_at: "test".to_string(),
+            is_active: true,
+        }
+    }
+
+    /// 准备临时 Agent MD 文件并注册到索引，返回 (manager, md_path)；
+    /// 调用方负责在断言后删除 md_path，避免临时文件堆积。
+    fn make_manager_with_agent_md(content: &str, with_skill: bool) -> (ExpertIndexManager, String) {
+        use std::io::Write;
+        // 以纳秒时间戳命名，保证并发测试互不踩踏
+        let mut tmp_path = std::env::temp_dir();
+        tmp_path.push(format!(
+            "ntd_test_inject_md_{}.md",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        // 测试夹具允许 unwrap（与仓库既有测试风格一致；lint 对 cfg(test) 中的 unwrap 豁免）
+        let mut f = std::fs::File::create(&tmp_path).unwrap();
+        writeln!(f, "{}", content).unwrap();
+        let md_path = tmp_path.to_string_lossy().to_string();
+
+        let manager = ExpertIndexManager::new();
+        let agent_file = AgentFileMetadata {
+            agent_name: "rust-agent".to_string(),
+            md_file_path: md_path.clone(),
+            yaml_name: None,
+            yaml_description: None,
+            yaml_color: None,
+            yaml_emoji: None,
+            yaml_vibe: None,
+        };
+        // 按 with_skill 决定是否注册技能，用于分别锁定两段式/三段式两种拼接格式
+        let skills: Vec<SkillMetadata> = if with_skill {
+            vec![SkillMetadata {
+                skill_name: "code-review".to_string(),
+                skill_dir: "/tmp".to_string(),
+                skill_md_path: "/tmp/SKILL.md".to_string(),
+                yaml_name: None,
+                yaml_description: Some("代码评审".to_string()),
+                yaml_description_zh: None,
+                yaml_description_en: None,
+                yaml_version: None,
+                yaml_allowed_tools: vec![],
+                yaml_emoji: None,
+            }]
+        } else {
+            vec![]
+        };
+        let expert = make_minimal_expert_metadata("rust-expert", Some("rust-agent"), None);
+        manager.update_index(&expert, &[agent_file], &skills);
+        (manager, md_path)
+    }
+
+    /// 未指定专家名（None 或空串）时原样返回消息——空串判等是 wiki chat 通路的既有行为。
+    #[test]
+    fn test_inject_expert_message_none_or_empty_name_returns_original() {
+        let manager = ExpertIndexManager::new();
+        let original = "原始消息";
+        assert_eq!(inject_expert_message(&manager, None, original), original);
+        assert_eq!(inject_expert_message(&manager, Some(""), original), original);
+    }
+
+    /// 专家无技能时应省略「可用技能」段落（两段式），避免出现空标题。
+    /// 这是 pre_spawn 既有测试未覆盖的分支，公共层补齐锁定。
+    #[test]
+    fn test_inject_expert_message_without_skills_omits_skills_section() {
+        let (manager, md_path) = make_manager_with_agent_md("你是一个 Rust 专家", false);
+        let result = inject_expert_message(&manager, Some("rust-expert"), "请帮我写代码");
+        // 期望中的三个连续 \n：夹具用 writeln! 写入 MD 使 agent_md 自带尾部换行，
+        // 拼接时再补两个 \n——与真实场景（MD 文件通常以换行结尾）一致
+        assert_eq!(
+            result,
+            "# 专家角色定义\n你是一个 Rust 专家\n\n\n# 任务\n请帮我写代码"
+        );
+        let _ = std::fs::remove_file(&md_path);
+    }
+
+    /// 专家有技能时输出三段式：角色定义 → 可用技能 → 任务，锁定拼接格式契约。
+    #[test]
+    fn test_inject_expert_message_with_skills_full_three_section_prompt() {
+        let (manager, md_path) = make_manager_with_agent_md("你是一个 Rust 专家", true);
+        let result = inject_expert_message(&manager, Some("rust-expert"), "请帮我写代码");
+        assert!(result.starts_with("# 专家角色定义\n你是一个 Rust 专家\n"));
+        assert!(result.contains("## 可用技能"));
+        // build_skills_context 将技能名渲染为 Markdown 链接指向 SKILL.md 路径
+        assert!(result.contains("- **[code-review]("));
+        assert!(result.ends_with("# 任务\n请帮我写代码"));
+        let _ = std::fs::remove_file(&md_path);
+    }
+
+    /// `build_expert_prompt` 把 Agent MD、技能列表、原 message 拼成三段式 prompt。
+    /// 有技能时保留技能段落（由 build_skills_context 生成，含标题行）。
+    #[test]
+    fn test_build_expert_prompt_three_sections() {
+        let agent_md = "你是一个 Rust 专家";
+        let skills = "## 可用技能\n你可以使用以下技能来辅助完成任务：\n- **code-review**: 代码评审技能\n";
+        let original = "请帮我写一个函数";
+        let result = build_expert_prompt(agent_md, skills, original);
+        // 三段标题按顺序出现，且原 message 在末尾
+        assert!(result.contains("# 专家角色定义\n你是一个 Rust 专家"));
+        assert!(result.contains("## 可用技能"));
+        assert!(result.contains("# 任务\n请帮我写一个函数"));
+    }
+
+    /// `build_expert_prompt` 技能列表为空时省略技能段落。
+    #[test]
+    fn test_build_expert_prompt_empty_skills_omits_section() {
+        let result = build_expert_prompt("agent", "", "do something");
+        // 空技能时不出现技能段落，直接从角色定义跳到任务
+        assert!(!result.contains("可用技能"));
+        assert!(result.contains("# 专家角色定义\nagent"));
+        assert!(result.contains("# 任务\ndo something"));
+    }
+
+    /// `build_expert_skills_text` 复用 loader::build_skills_context，
+    /// 返回 Markdown 格式的技能列表（含标题行和项目符号）。
+    #[test]
+    fn test_build_expert_skills_text_formats_each_skill() {
+        let manager = ExpertIndexManager::new();
+        // 准备两个 skill 的元数据并更新到索引
+        let skills = vec![
+            SkillMetadata {
+                skill_name: "code-review".to_string(),
+                skill_dir: "/tmp/skills/code-review".to_string(),
+                skill_md_path: "/tmp/skills/code-review/SKILL.md".to_string(),
+                yaml_name: None,
+                yaml_description: Some("代码评审".to_string()),
+                yaml_description_zh: None,
+                yaml_description_en: None,
+                yaml_version: None,
+                yaml_allowed_tools: vec![],
+                yaml_emoji: None,
+            },
+            SkillMetadata {
+                skill_name: "test-gen".to_string(),
+                skill_dir: "/tmp/skills/test-gen".to_string(),
+                skill_md_path: "/tmp/skills/test-gen/SKILL.md".to_string(),
+                yaml_name: None,
+                // description 为 None 时回退到 "(无描述)"
+                yaml_description: None,
+                yaml_description_zh: None,
+                yaml_description_en: None,
+                yaml_version: None,
+                yaml_allowed_tools: vec![],
+                yaml_emoji: None,
+            },
+        ];
+        // 借用一个最小 ExpertMetadata 把 skill 绑到 "test-expert"
+        let expert = make_minimal_expert_metadata("test-expert", Some("test-agent"), None);
+        manager.update_index(&expert, &[], &skills);
+        let text = build_expert_skills_text(&manager, "test-expert");
+        // build_skills_context 输出 Markdown 格式：标题 + 项目符号列表
+        assert!(text.contains("## 可用技能"));
+        // build_skills_context 将技能名渲染为 Markdown 链接指向 SKILL.md 路径
+        assert!(text.contains("- **[code-review]("));
+        assert!(text.contains("**: 代码评审"));
+        assert!(text.contains("- **[test-gen]("));
+        assert!(text.contains("**: (无描述)"));
+    }
+
+    /// `build_expert_skills_text` 查询不存在的专家时返回空串（get_expert_skills 容错）。
+    #[test]
+    fn test_build_expert_skills_text_unknown_expert_returns_empty() {
+        let manager = ExpertIndexManager::new();
+        let text = build_expert_skills_text(&manager, "non-existent-expert");
+        assert!(text.is_empty());
+    }
+}

--- a/backend/src/expert/mod.rs
+++ b/backend/src/expert/mod.rs
@@ -10,6 +10,10 @@ pub mod index;
 // 专家上下文注入公共核心：todo 执行管线（pre_spawn）与 wiki chat 通路（blackboard）共用，
 // 仅 crate 内可见——注入是内部增强能力，不对外暴露为 API。
 pub(crate) mod inject;
+// 测试夹具共享模块：仅 cfg(test) 下编译，inject.rs 与 executor_service::pre_spawn 的测试共用
+// make_minimal_expert_metadata，避免 22 字段 ExpertMetadata 构造两处重复（096-W1 review 收口）
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod loader;
 pub mod parser;
 pub mod types;

--- a/backend/src/expert/mod.rs
+++ b/backend/src/expert/mod.rs
@@ -7,11 +7,16 @@
 //! - 按需加载 MD 文件内容
 
 pub mod index;
+// 专家上下文注入公共核心：todo 执行管线（pre_spawn）与 wiki chat 通路（blackboard）共用，
+// 仅 crate 内可见——注入是内部增强能力，不对外暴露为 API。
+pub(crate) mod inject;
 pub mod loader;
 pub mod parser;
 pub mod types;
 
 pub use types::ExpertIndexManager;
+// re-export 让调用方以 `crate::expert::inject_expert_message` 直达，无需感知子模块布局
+pub(crate) use inject::inject_expert_message;
 pub use loader::{build_skills_context, bundled_experts_dir, experts_dir, load_experts_from_directory};
 pub use parser::{
     build_expert_metadata, extract_yaml_frontmatter, parse_agent_md_metadata,

--- a/backend/src/expert/test_support.rs
+++ b/backend/src/expert/test_support.rs
@@ -1,0 +1,45 @@
+//! 专家测试夹具：inject.rs 与 executor_service::pre_spawn 测试共享的构造助手。
+//!
+//! 096-W1-PR3 多 agent 评审发现：inject.rs 从 pre_spawn.rs 复制了一份逐字相同的
+//! `make_minimal_expert_metadata`（22 字段 ExpertMetadata 构造）。ExpertMetadata 一旦加字段，
+//! 两份会静默漂移——一处漏改即导致测试行为分歧。提到本模块统一维护，两处测试 import 共用。
+
+use crate::expert::{ExpertMetadata, ExpertSource, ExpertType};
+
+/// 构造最小可用的 ExpertMetadata 供测试使用。
+///
+/// 只填必要字段（name / agent_name / lead_agent），其余用空值/None，
+/// 避免每个测试都重复 22 个字段。inject.rs 与 pre_spawn.rs 的测试共用本函数，
+/// 保证两处构造逻辑始终一致。
+pub(crate) fn make_minimal_expert_metadata(
+    name: &str,
+    agent_name: Option<&str>,
+    lead_agent: Option<&str>,
+) -> ExpertMetadata {
+    ExpertMetadata {
+        name: name.to_string(),
+        expert_type: ExpertType::Agent,
+        version: "0.0.1-test".to_string(),
+        source: ExpertSource::System,
+        display_name_zh: None,
+        display_name_en: None,
+        profession_zh: None,
+        profession_en: None,
+        description_zh: None,
+        description_en: None,
+        avatar_path: None,
+        category_id: None,
+        definition_dir: "/tmp".to_string(),
+        plugin_json_path: "/tmp/plugin.json".to_string(),
+        agent_name: agent_name.map(|s| s.to_string()),
+        lead_agent: lead_agent.map(|s| s.to_string()),
+        member_agents: vec![],
+        members: vec![],
+        skills: vec![],
+        default_init_prompt_zh: None,
+        default_init_prompt_en: None,
+        tags: vec![],
+        loaded_at: "test".to_string(),
+        is_active: true,
+    }
+}

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -512,7 +512,7 @@ pub async fn chat_with_wiki(
     //     失败时静默使用原 message，不阻断对话——专家注入是增强项而非必需项。
     //     核心逻辑已收口到 expert::inject_expert_message（096-W1-PR3），与 todo 执行管线共用一份。
     let final_message =
-        crate::expert::inject_expert_message(expert_manager, expert_name, message);
+        crate::expert::inject_expert_message(expert_manager, expert_name, message, "wiki chat: ");
 
     let _ = tx.send(ExecEvent::WikiChatStarted {
         task_id: task_id.clone(),

--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -510,7 +510,9 @@ pub async fn chat_with_wiki(
     );
     // 6.5 注入专家上下文：如果指定了专家名称，将专家角色定义和技能信息拼到 message 前面。
     //     失败时静默使用原 message，不阻断对话——专家注入是增强项而非必需项。
-    let final_message = inject_wiki_expert_context(expert_manager, expert_name, message);
+    //     核心逻辑已收口到 expert::inject_expert_message（096-W1-PR3），与 todo 执行管线共用一份。
+    let final_message =
+        crate::expert::inject_expert_message(expert_manager, expert_name, message);
 
     let _ = tx.send(ExecEvent::WikiChatStarted {
         task_id: task_id.clone(),
@@ -561,7 +563,9 @@ pub async fn chat_with_wiki(
 
             // 9. 成功时从日志中提取 session_id 并持久化到数据库
             if success {
-                if let Some(new_session_id) = extract_session_from_logs(&executor, &logs) {
+                // session 提取逻辑已收口到 executor_service::session_util（096-W1-PR3），
+                // 与飞书私聊通路共用一份公共实现
+                if let Some(new_session_id) = crate::executor_service::session_util::extract_session_from_logs(&executor, &logs) {
                     tracing::info!(
                         "wiki chat: extracted session_id={} for executor={}, saving to DB",
                         new_session_id,
@@ -598,87 +602,6 @@ pub async fn chat_with_wiki(
             });
             Err(e)
         }
-    }
-}
-
-/// 从执行日志中提取 session_id。
-///
-/// 流程：
-/// 1. 先尝试从日志内容中提取（parse_output_session_id）
-/// 2. 如果没有，尝试执行器内部缓存的 session_id（get_session_id）
-///
-/// 不同执行器暴露 session_id 的方式不同：
-/// - Claude Code: stdout JSONL 行含 session_id
-/// - Hermès: `session_id: <sid>` 行
-/// - Pi: `{"type":"session","id":"<sid>"}` 行（通过 get_session_id 获取缓存值）
-///
-/// 返回 None 表示执行器不支持 session 或首次执行。
-fn extract_session_from_logs(
-    executor: &Arc<dyn crate::adapters::CodeExecutor>,
-    logs: &[crate::models::ParsedLogEntry],
-) -> Option<String> {
-    // 1. 优先从日志内容提取
-    for entry in logs {
-        if let Some(sid) = executor.extract_session_id(&entry.content) {
-            return Some(sid);
-        }
-    }
-    // 2. 回退到执行器内部缓存的 session_id（Pi 等执行器在 parse_output_line 时缓存）
-    executor.get_session_id()
-}
-
-/// 为 Wiki 对话注入专家上下文。
-///
-/// 如果指定了专家名称且能在索引中找到对应的 Agent MD，则将专家角色定义
-/// 和技能信息拼到用户消息前面；否则原样返回消息。
-/// 逻辑与 executor_service::pre_spawn::inject_expert_context 一致，但独立实现
-/// 避免 wiki chat 路径依赖 todo 执行管线的内部函数。
-fn inject_wiki_expert_context(
-    expert_manager: &Arc<crate::expert::ExpertIndexManager>,
-    expert_name: Option<&str>,
-    message: &str,
-) -> String {
-    // 未指定专家名称时直接返回原消息
-    let name = match expert_name {
-        Some(n) if !n.is_empty() => n,
-        _ => return message.to_string(),
-    };
-    // 查找专家元数据，找不到则静默回退
-    let metadata = match expert_manager.get_expert_by_name(name) {
-        Some(m) => m,
-        None => {
-            tracing::warn!("wiki chat: 未找到专家 '{}'，跳过专家上下文注入", name);
-            return message.to_string();
-        }
-    };
-    // 获取 Agent MD 内容：team 用 lead_agent、agent 用 agent_name（resolve_agent_name 统一）。
-    // 按 (expert_name, agent_name) 复合键查找，与执行注入路径保持一致。
-    let Some(agent_name) = metadata.resolve_agent_name() else {
-        tracing::warn!(
-            "wiki chat: 专家 '{}' 没有可用 agent（agent_name/lead_agent 都为空）",
-            name
-        );
-        return message.to_string();
-    };
-    let agent_md = match expert_manager.get_agent_md_content(name, agent_name).ok() {
-        Some(content) => content,
-        None => {
-            tracing::warn!("wiki chat: 未找到专家 '{}' 的 Agent MD 内容，跳过注入", name);
-            return message.to_string();
-        }
-    };
-    // 拼接技能列表（复用 loader 的 build_skills_context，中文优先）
-    let skills_text = crate::expert::build_skills_context(
-        &expert_manager.get_expert_skills(name),
-    );
-    // 三段式 prompt：角色定义 → 技能列表 → 用户消息
-    if skills_text.is_empty() {
-        format!("# 专家角色定义\n{}\n\n# 任务\n{}", agent_md, message)
-    } else {
-        format!(
-            "# 专家角色定义\n{}\n\n{}\n\n# 任务\n{}",
-            agent_md, skills_text, message
-        )
     }
 }
 

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -781,32 +781,6 @@ fn executor_empty_end_message(executor_type: &str) -> String {
     format!("✅ {} 执行完成（无输出）", executor_type)
 }
 
-/// 从执行日志中提取 session_id。
-///
-/// 流程：
-/// 1. 先尝试从日志内容中提取（extract_session_id）
-/// 2. 如果没有，尝试执行器内部缓存的 session_id（get_session_id）
-///
-/// 不同执行器暴露 session_id 的方式不同：
-/// - Claude Code: stdout JSONL 行含 session_id
-/// - Hermès: `session_id: <sid>` 行
-/// - Pi: `{"type":"session","id":"<sid>"}` 行（通过 get_session_id 获取缓存值）
-///
-/// 返回 None 表示执行器不支持 session 或首次执行。
-fn extract_session_from_logs(
-    executor: &Arc<dyn crate::adapters::CodeExecutor>,
-    logs: &[ParsedLogEntry],
-) -> Option<String> {
-    // 1. 优先从日志内容提取
-    for entry in logs {
-        if let Some(sid) = executor.extract_session_id(&entry.content) {
-            return Some(sid);
-        }
-    }
-    // 2. 回退到执行器内部缓存的 session_id（Pi 等执行器在 parse_output_line 时缓存）
-    executor.get_session_id()
-}
-
 /// 根据执行结果决定发回飞书的最终内容。
 ///
 /// 成功时统一返回简洁的结束标志（"✅ <执行器名称> 处理完成"），不再重复输出
@@ -1481,7 +1455,9 @@ impl MessageDebounce {
         // 下次私聊时可直接 resume 该 session，实现多轮对话上下文保持。
         if status.success() {
             if let Some(wid) = workspace_id {
-                if let Some(new_session_id) = extract_session_from_logs(&executor, &stream_result.logs) {
+                // session 提取逻辑已收口到 executor_service::session_util（096-W1-PR3），
+                // 与 wiki chat 通路共用一份公共实现
+                if let Some(new_session_id) = crate::executor_service::session_util::extract_session_from_logs(&executor, &stream_result.logs) {
                     tracing::info!(
                         "[debounce] extracted session_id={} for executor={}, saving to DB",
                         new_session_id,


### PR DESCRIPTION
## 变更概述

本次重构完成跨文件重复代码收口：

1. **`extract_session_from_logs` 上移至 `session_util` 公共层**
   - 消除 `session_manager.rs` 与 `expert.rs` 中的重复实现
   - 统一日志解析逻辑，便于后续维护

2. **专家注入核心收口 `expert::inject`**
   - 整合双通路（Claude/AtomCode）共用的注入逻辑
   - 减少代码重复，提升一致性

## 关联 Issue

属于 096-W1 重构计划的一部分，详见 `docs/quality-scan-20260811.md`

## 测试验证

- [x] `cargo clippy -- -D warnings` 零告警
- [x] `cargo test` 全部通过