### PR TITLE
refactor(096-W1-4): 前端 BackupPanel 三域复制收口（useBackupDomain + download util，面板 -207 行）

### DIFF
--- a/frontend/src/components/settings/BackupPanel.tsx
+++ b/frontend/src/components/settings/BackupPanel.tsx
@@ -6,6 +6,8 @@ import { TodoBackupTab } from './backup/TodoBackupTab';
 import { SkillBackupTab } from './backup/SkillBackupTab';
 import { DatabaseBackupTab } from './backup/DatabaseBackupTab';
 import { ImportExportModals, BackupDataYaml, ImportItem } from './backup/ImportExportModals';
+import { useBackupDomain } from './useBackupDomain';
+import { backupTimestamp, downloadBlob, downloadByUrl } from '@/utils/download';
 import type { ProjectDirectory } from '@/utils/database/todos';
 
 // 备份子 tab 的合法 key——每个子 tab 对应 URL 里的一个 sub 参数，支持深链直达
@@ -49,46 +51,36 @@ export function BackupPanel() {
     setBackupSubInHash(key as BackupSubKey);
   }, []);
 
-  // Database backup state
-  const [backupStatus, setBackupStatus] = useState<{
-    auto_backup_enabled: boolean;
-    auto_backup_cron: string;
-    auto_backup_max_files: number;
-    last_backup: string | null;
-    files: { name: string; size: number; created_at: string }[];
-  } | null>(null);
-  const [autoBackupEnabled, setAutoBackupEnabled] = useState(false);
-  const [autoBackupCron, setAutoBackupCron] = useState('0 0 3 * * *');
-  const [autoBackupMaxFiles, setAutoBackupMaxFiles] = useState(30);
-  const [backupLoading, setBackupLoading] = useState(false);
+  // 三个备份域（database/todo/skill）的状态与操作已由 useBackupDomain 收口（096-W1-PR4）：
+  // 原为 5 个 useState ×3 + 4 个 handler ×3 + 初始加载 useEffect ×3 的逐字同构复制，
+  // 现每域只剩一份差异配置（4 个端点 + 保存文案 + 错开的默认 cron 时刻）。
+  const databaseDomain = useBackupDomain({
+    getStatus: db.getDatabaseBackupStatus,
+    updateAuto: db.updateAutoBackup,
+    trigger: db.triggerLocalBackup,
+    deleteFile: db.deleteBackupFile,
+    saveSuccessText: '自动备份配置已保存',
+    defaultCron: '0 0 3 * * *',
+  });
+  const todoDomain = useBackupDomain({
+    getStatus: db.getTodoBackupStatus,
+    updateAuto: db.updateTodoAutoBackup,
+    trigger: db.triggerTodoBackup,
+    deleteFile: db.deleteTodoBackupFile,
+    saveSuccessText: 'Todo自动备份配置已保存',
+    defaultCron: '0 0 4 * * *',
+  });
+  const skillDomain = useBackupDomain({
+    getStatus: db.getSkillBackupStatus,
+    updateAuto: db.updateSkillAutoBackup,
+    trigger: db.triggerSkillBackup,
+    deleteFile: db.deleteSkillBackupFile,
+    saveSuccessText: 'Skill自动备份配置已保存',
+    defaultCron: '0 0 5 * * *',
+  });
+
+  // 日志清理配置为数据库域独有（非三域同构部分），保留在组件层
   const [logCleanupDays, setLogCleanupDays] = useState<number | null>(30);
-
-  // Todo backup state
-  const [todoBackupStatus, setTodoBackupStatus] = useState<{
-    auto_backup_enabled: boolean;
-    auto_backup_cron: string;
-    auto_backup_max_files: number;
-    last_backup: string | null;
-    files: { name: string; size: number; created_at: string }[];
-  } | null>(null);
-  const [autoTodoBackupEnabled, setAutoTodoBackupEnabled] = useState(false);
-  const [autoTodoBackupCron, setAutoTodoBackupCron] = useState('0 0 4 * * *');
-  const [autoTodoBackupMaxFiles, setAutoTodoBackupMaxFiles] = useState(30);
-  const [todoBackupLoading, setTodoBackupLoading] = useState(false);
-
-  // Skill backup state
-  const [skillBackupStatus, setSkillBackupStatus] = useState<{
-    auto_backup_enabled: boolean;
-    auto_backup_cron: string;
-    auto_backup_max_files: number;
-    last_backup: string | null;
-    files: { name: string; size: number; created_at: string }[];
-    executor_skills: { executor: string; skills_count: number; skills_dir_exists: boolean }[];
-  } | null>(null);
-  const [autoSkillBackupEnabled, setAutoSkillBackupEnabled] = useState(false);
-  const [autoSkillBackupCron, setAutoSkillBackupCron] = useState('0 0 5 * * *');
-  const [autoSkillBackupMaxFiles, setAutoSkillBackupMaxFiles] = useState(30);
-  const [skillBackupLoading, setSkillBackupLoading] = useState(false);
 
   // Import/Export state
   const [importing, setImporting] = useState(false);
@@ -138,17 +130,8 @@ export function BackupPanel() {
     return map;
   };
 
-  // Load status
+  // Load status（三域状态的初始加载已收口进 useBackupDomain，这里只剩日志清理配置）
   useEffect(() => {
-    db.getDatabaseBackupStatus()
-      .then((status) => {
-        setBackupStatus(status);
-        setAutoBackupEnabled(status.auto_backup_enabled);
-        setAutoBackupCron(status.auto_backup_cron);
-        setAutoBackupMaxFiles(status.auto_backup_max_files);
-      })
-      .catch(() => {});
-
     db.getLogCleanupStatus()
       .then((status) => {
         setLogCleanupDays(status.cleanup_days);
@@ -156,54 +139,12 @@ export function BackupPanel() {
       .catch(() => {});
   }, []);
 
-  useEffect(() => {
-    db.getTodoBackupStatus()
-      .then((status) => {
-        setTodoBackupStatus(status);
-        setAutoTodoBackupEnabled(status.auto_backup_enabled);
-        setAutoTodoBackupCron(status.auto_backup_cron);
-        setAutoTodoBackupMaxFiles(status.auto_backup_max_files);
-      })
-      .catch(() => {});
-  }, []);
-
-  useEffect(() => {
-    db.getSkillBackupStatus()
-      .then((status) => {
-        setSkillBackupStatus(status);
-        setAutoSkillBackupEnabled(status.auto_backup_enabled);
-        setAutoSkillBackupCron(status.auto_backup_cron);
-        setAutoSkillBackupMaxFiles(status.auto_backup_max_files);
-      })
-      .catch(() => {});
-  }, []);
-
-  // Handlers - Database backup
-  const handleTriggerBackup = async () => {
-    setBackupLoading(true);
-    try {
-      const msg = await db.triggerLocalBackup();
-      message.success(msg);
-      const status = await db.getDatabaseBackupStatus();
-      setBackupStatus(status);
-    } catch (err: any) {
-      message.error(err?.message || '备份失败');
-    } finally {
-      setBackupLoading(false);
-    }
-  };
-
-  const handleOptimizeDatabase = async () => {
-    setBackupLoading(true);
-    try {
-      const msg = await db.optimizeDatabase();
-      message.success(msg);
-    } catch (err: any) {
-      message.error(err?.message || '优化失败');
-    } finally {
-      setBackupLoading(false);
-    }
-  };
+  // 数据库域附加操作（优化/日志清理，非三域同构部分）：
+  // 复用 databaseDomain.runWithLoading 共享同一 loading 灯——与原实现复用 setBackupLoading 一致。
+  const handleOptimizeDatabase = () =>
+    databaseDomain.runWithLoading(async () => {
+      message.success(await db.optimizeDatabase());
+    }, '优化失败');
 
   const handleDownloadDatabase = async () => {
     try {
@@ -211,174 +152,32 @@ export function BackupPanel() {
       const response = await fetch('/api/v1/backup/database/download');
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-      a.download = `ntd-database-${timestamp}.db`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      downloadBlob(blob, `ntd-database-${backupTimestamp()}.db`);
       message.success('数据库下载成功');
     } catch (err: any) {
       message.error(err?.message || '下载失败');
     }
   };
 
-  const handleSaveAutoBackup = async () => {
-    setBackupLoading(true);
-    try {
-      await db.updateAutoBackup(autoBackupEnabled, autoBackupCron, autoBackupMaxFiles);
-      message.success('自动备份配置已保存');
-    } catch (err: any) {
-      message.error(err?.message || '保存失败');
-    } finally {
-      setBackupLoading(false);
-    }
-  };
-
-  const handleDeleteBackup = async (filename: string) => {
-    try {
-      await db.deleteBackupFile(filename);
-      message.success('已删除');
-      const status = await db.getDatabaseBackupStatus();
-      setBackupStatus(status);
-    } catch (err: any) {
-      message.error(err?.message || '删除失败');
-    }
-  };
-
-  const handleDownloadBackupFile = (filename: string) => {
-    const url = db.downloadBackupFileUrl(filename);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-  };
-
   // Log cleanup handlers
-  const handleSaveLogCleanup = async () => {
-    setBackupLoading(true);
-    try {
+  const handleSaveLogCleanup = () =>
+    databaseDomain.runWithLoading(async () => {
       await db.updateLogCleanup(logCleanupDays);
       message.success('日志清理配置已保存');
-    } catch (err: any) {
-      message.error(err?.message || '保存失败');
-    } finally {
-      setBackupLoading(false);
-    }
-  };
+    }, '保存失败');
 
-  const handleTriggerLogCleanup = async () => {
-    setBackupLoading(true);
-    try {
-      const result = await db.triggerLogCleanup();
-      message.success(result);
-    } catch (err: any) {
-      message.error(err?.message || '清理失败');
-    } finally {
-      setBackupLoading(false);
-    }
-  };
+  const handleTriggerLogCleanup = () =>
+    databaseDomain.runWithLoading(async () => {
+      message.success(await db.triggerLogCleanup());
+    }, '清理失败');
 
-  // Todo backup handlers
-  const handleTriggerTodoBackup = async () => {
-    setTodoBackupLoading(true);
-    try {
-      const msg = await db.triggerTodoBackup();
-      message.success(msg);
-      const status = await db.getTodoBackupStatus();
-      setTodoBackupStatus(status);
-    } catch (err: any) {
-      message.error(err?.message || '备份失败');
-    } finally {
-      setTodoBackupLoading(false);
-    }
-  };
-
-  const handleSaveTodoAutoBackup = async () => {
-    setTodoBackupLoading(true);
-    try {
-      await db.updateTodoAutoBackup(autoTodoBackupEnabled, autoTodoBackupCron, autoTodoBackupMaxFiles);
-      message.success('Todo自动备份配置已保存');
-    } catch (err: any) {
-      message.error(err?.message || '保存失败');
-    } finally {
-      setTodoBackupLoading(false);
-    }
-  };
-
-  const handleDeleteTodoBackup = async (filename: string) => {
-    try {
-      await db.deleteTodoBackupFile(filename);
-      message.success('已删除');
-      const status = await db.getTodoBackupStatus();
-      setTodoBackupStatus(status);
-    } catch (err: any) {
-      message.error(err?.message || '删除失败');
-    }
-  };
-
-  const handleDownloadTodoBackupFile = (filename: string) => {
-    const url = db.downloadTodoBackupFileUrl(filename);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-  };
-
-  // Skill backup handlers
-  const handleTriggerSkillBackup = async () => {
-    setSkillBackupLoading(true);
-    try {
-      const msg = await db.triggerSkillBackup();
-      message.success(msg);
-      const status = await db.getSkillBackupStatus();
-      setSkillBackupStatus(status);
-    } catch (err: any) {
-      message.error(err?.message || '备份失败');
-    } finally {
-      setSkillBackupLoading(false);
-    }
-  };
-
-  const handleSaveSkillAutoBackup = async () => {
-    setSkillBackupLoading(true);
-    try {
-      await db.updateSkillAutoBackup(autoSkillBackupEnabled, autoSkillBackupCron, autoSkillBackupMaxFiles);
-      message.success('Skill自动备份配置已保存');
-    } catch (err: any) {
-      message.error(err?.message || '保存失败');
-    } finally {
-      setSkillBackupLoading(false);
-    }
-  };
-
-  const handleDeleteSkillBackup = async (filename: string) => {
-    try {
-      await db.deleteSkillBackupFile(filename);
-      message.success('已删除');
-      const status = await db.getSkillBackupStatus();
-      setSkillBackupStatus(status);
-    } catch (err: any) {
-      message.error(err?.message || '删除失败');
-    }
-  };
-
-  const handleDownloadSkillBackupFile = (filename: string) => {
-    const url = db.downloadSkillBackupFileUrl(filename);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-  };
+  // 三域备份文件的下载 handler：URL 直达下载，各域仅 URL builder 不同
+  const handleDownloadBackupFile = (filename: string) =>
+    downloadByUrl(db.downloadBackupFileUrl(filename), filename);
+  const handleDownloadTodoBackupFile = (filename: string) =>
+    downloadByUrl(db.downloadTodoBackupFileUrl(filename), filename);
+  const handleDownloadSkillBackupFile = (filename: string) =>
+    downloadByUrl(db.downloadSkillBackupFileUrl(filename), filename);
 
   // Export handlers
   const handleExportBackup = async () => {
@@ -392,15 +191,7 @@ export function BackupPanel() {
       }
       const yamlText = await response.text();
       const blob = new Blob([yamlText], { type: 'application/x-yaml' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-      a.download = `aietodo-backup-${timestamp}.yaml`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      downloadBlob(blob, `aietodo-backup-${backupTimestamp()}.yaml`);
       message.success('备份导出成功');
     } catch (err: any) {
       message.error(err?.message || '导出失败');
@@ -533,18 +324,20 @@ export function BackupPanel() {
             key: 'todo',
             label: '事项备份',
             children: (
+              // props 形状保持不变（096-W1-PR4 硬约束：子组件零改动），
+              // 仅数据源从散置 state/handler 换成 todoDomain 聚合返回值
               <TodoBackupTab
-                todoBackupStatus={todoBackupStatus}
-                autoTodoBackupEnabled={autoTodoBackupEnabled}
-                autoTodoBackupCron={autoTodoBackupCron}
-                autoTodoBackupMaxFiles={autoTodoBackupMaxFiles}
-                todoBackupLoading={todoBackupLoading}
-                setAutoTodoBackupEnabled={setAutoTodoBackupEnabled}
-                setAutoTodoBackupCron={setAutoTodoBackupCron}
-                setAutoTodoBackupMaxFiles={setAutoTodoBackupMaxFiles}
-                onTriggerBackup={handleTriggerTodoBackup}
-                onSaveAutoBackup={handleSaveTodoAutoBackup}
-                onDeleteBackup={handleDeleteTodoBackup}
+                todoBackupStatus={todoDomain.status}
+                autoTodoBackupEnabled={todoDomain.enabled}
+                autoTodoBackupCron={todoDomain.cron}
+                autoTodoBackupMaxFiles={todoDomain.maxFiles}
+                todoBackupLoading={todoDomain.loading}
+                setAutoTodoBackupEnabled={todoDomain.setEnabled}
+                setAutoTodoBackupCron={todoDomain.setCron}
+                setAutoTodoBackupMaxFiles={todoDomain.setMaxFiles}
+                onTriggerBackup={todoDomain.triggerBackup}
+                onSaveAutoBackup={todoDomain.saveAutoBackup}
+                onDeleteBackup={todoDomain.deleteBackup}
                 onDownloadBackupFile={handleDownloadTodoBackupFile}
                 onExportBackup={handleExportBackup}
                 onImportFile={handleImportFile}
@@ -556,17 +349,17 @@ export function BackupPanel() {
             label: 'Skill备份',
             children: (
               <SkillBackupTab
-                skillBackupStatus={skillBackupStatus}
-                autoSkillBackupEnabled={autoSkillBackupEnabled}
-                autoSkillBackupCron={autoSkillBackupCron}
-                autoSkillBackupMaxFiles={autoSkillBackupMaxFiles}
-                skillBackupLoading={skillBackupLoading}
-                setAutoSkillBackupEnabled={setAutoSkillBackupEnabled}
-                setAutoSkillBackupCron={setAutoSkillBackupCron}
-                setAutoSkillBackupMaxFiles={setAutoSkillBackupMaxFiles}
-                onTriggerBackup={handleTriggerSkillBackup}
-                onSaveAutoBackup={handleSaveSkillAutoBackup}
-                onDeleteBackup={handleDeleteSkillBackup}
+                skillBackupStatus={skillDomain.status}
+                autoSkillBackupEnabled={skillDomain.enabled}
+                autoSkillBackupCron={skillDomain.cron}
+                autoSkillBackupMaxFiles={skillDomain.maxFiles}
+                skillBackupLoading={skillDomain.loading}
+                setAutoSkillBackupEnabled={skillDomain.setEnabled}
+                setAutoSkillBackupCron={skillDomain.setCron}
+                setAutoSkillBackupMaxFiles={skillDomain.setMaxFiles}
+                onTriggerBackup={skillDomain.triggerBackup}
+                onSaveAutoBackup={skillDomain.saveAutoBackup}
+                onDeleteBackup={skillDomain.deleteBackup}
                 onDownloadBackupFile={handleDownloadSkillBackupFile}
               />
             ),
@@ -576,19 +369,19 @@ export function BackupPanel() {
             label: '数据库备份',
             children: (
               <DatabaseBackupTab
-                backupStatus={backupStatus}
-                autoBackupEnabled={autoBackupEnabled}
-                autoBackupCron={autoBackupCron}
-                autoBackupMaxFiles={autoBackupMaxFiles}
-                backupLoading={backupLoading}
+                backupStatus={databaseDomain.status}
+                autoBackupEnabled={databaseDomain.enabled}
+                autoBackupCron={databaseDomain.cron}
+                autoBackupMaxFiles={databaseDomain.maxFiles}
+                backupLoading={databaseDomain.loading}
                 logCleanupDays={logCleanupDays}
-                setAutoBackupEnabled={setAutoBackupEnabled}
-                setAutoBackupCron={setAutoBackupCron}
-                setAutoBackupMaxFiles={setAutoBackupMaxFiles}
+                setAutoBackupEnabled={databaseDomain.setEnabled}
+                setAutoBackupCron={databaseDomain.setCron}
+                setAutoBackupMaxFiles={databaseDomain.setMaxFiles}
                 setLogCleanupDays={setLogCleanupDays}
-                onTriggerBackup={handleTriggerBackup}
-                onSaveAutoBackup={handleSaveAutoBackup}
-                onDeleteBackup={handleDeleteBackup}
+                onTriggerBackup={databaseDomain.triggerBackup}
+                onSaveAutoBackup={databaseDomain.saveAutoBackup}
+                onDeleteBackup={databaseDomain.deleteBackup}
                 onDownloadBackupFile={handleDownloadBackupFile}
                 onDownloadDatabase={handleDownloadDatabase}
                 onOptimizeDatabase={handleOptimizeDatabase}

--- a/frontend/src/components/settings/useBackupDomain.test.ts
+++ b/frontend/src/components/settings/useBackupDomain.test.ts
@@ -12,6 +12,9 @@ vi.mock('antd', () => ({
   message: { success: vi.fn(), error: vi.fn() },
 }));
 
+// 挂载 getStatus 失败时 hook 会 console.warn 排查；测试里静音避免输出噪音
+vi.spyOn(console, 'warn').mockImplementation(() => {});
+
 /** 构造一个最小合法状态对象——字段值刻意异于默认值，便于断言「回填自服务端」 */
 function makeStatus(overrides: Partial<BackupDomainStatusBase> = {}): BackupDomainStatusBase {
   return {
@@ -44,7 +47,7 @@ beforeEach(() => {
 });
 
 describe('useBackupDomain 初始加载', () => {
-  it('挂载时调用 getStatus 并回填 enabled/cron/maxFiles/status', async () => {
+  it('test_useBackupDomain_挂载回填表单与状态', async () => {
     const config = makeConfig();
     const { result } = renderHook(() => useBackupDomain(config));
 
@@ -58,22 +61,25 @@ describe('useBackupDomain 初始加载', () => {
     expect(result.current.maxFiles).toBe(7);
   });
 
-  it('getStatus 失败时静默保持默认值', async () => {
+  it('test_useBackupDomain_初始加载失败静默保持默认值', async () => {
     const config = makeConfig({ getStatus: vi.fn().mockRejectedValue(new Error('网络错误')) });
     const { result } = renderHook(() => useBackupDomain(config));
 
-    // 给 rejected promise 一个 flush 窗口；随后断言状态仍为默认且无任何错误提示
+    // 给 rejected promise 一个 flush 窗口；随后断言状态仍为默认且无用户可见错误提示
     await act(async () => {});
     expect(result.current.status).toBeNull();
     expect(result.current.enabled).toBe(false);
     expect(result.current.cron).toBe('0 0 9 * * *');
     expect(result.current.maxFiles).toBe(30);
+    // 静默语义：失败不弹用户提示（message.error 不触发）
     expect(message.error).not.toHaveBeenCalled();
+    // 规范要求空 catch 至少记录：失败经 console.warn 留痕（钉死该修复，防回退成空 catch）
+    expect(console.warn).toHaveBeenCalled();
   });
 });
 
 describe('useBackupDomain.triggerBackup', () => {
-  it('成功：提示后端文案并刷新状态，loading 翻转后复位', async () => {
+  it('test_triggerBackup_成功提示文案刷新状态并翻转loading', async () => {
     // 可控 deferred：把 trigger 卡在 pending，稳定捕获 loading=true 的中间态
     let resolveTrigger!: (v: string) => void;
     const config = makeConfig({
@@ -96,7 +102,7 @@ describe('useBackupDomain.triggerBackup', () => {
     expect(config.getStatus).toHaveBeenCalledTimes(2);
   });
 
-  it('失败：透传后端错误文案，loading 复位', async () => {
+  it('test_triggerBackup_失败透传后端错误文案', async () => {
     const config = makeConfig({ trigger: vi.fn().mockRejectedValue(new Error('磁盘已满')) });
     const { result } = renderHook(() => useBackupDomain(config));
     await waitFor(() => expect(result.current.status).not.toBeNull());
@@ -110,7 +116,7 @@ describe('useBackupDomain.triggerBackup', () => {
     expect(config.getStatus).toHaveBeenCalledTimes(1);
   });
 
-  it('失败且无后端文案时用兜底文案', async () => {
+  it('test_triggerBackup_无后端文案时用兜底', async () => {
     const config = makeConfig({ trigger: vi.fn().mockRejectedValue({}) });
     const { result } = renderHook(() => useBackupDomain(config));
     await waitFor(() => expect(result.current.status).not.toBeNull());
@@ -118,12 +124,13 @@ describe('useBackupDomain.triggerBackup', () => {
     await act(async () => {
       await result.current.triggerBackup();
     });
+    // 非 Error、无 message 的对象 → 回落操作级兜底文案（extractErrorMessage 的非对象/无 message 分支）
     expect(message.error).toHaveBeenCalledWith('备份失败');
   });
 });
 
 describe('useBackupDomain.saveAutoBackup', () => {
-  it('以当前表单值调 updateAuto 并提示域文案；不刷新状态', async () => {
+  it('test_saveAutoBackup_以表单值保存且不刷新状态', async () => {
     const config = makeConfig();
     const { result } = renderHook(() => useBackupDomain(config));
     await waitFor(() => expect(result.current.status).not.toBeNull());
@@ -145,20 +152,33 @@ describe('useBackupDomain.saveAutoBackup', () => {
 });
 
 describe('useBackupDomain.deleteBackup', () => {
-  it('删除指定文件、提示已删除并刷新状态', async () => {
-    const config = makeConfig();
+  it('test_deleteBackup_删除不翻转loading且成功刷新', async () => {
+    // 用 deferred 把 deleteFile 卡在 pending，稳定捕获「删除进行中」的 loading 态——
+    // 钉死原语义：删除不点亮 loading 灯（若误走 runWithLoading，pending 时 loading 会变 true 而回归）。
+    let resolveDelete!: (v: unknown) => void;
+    const config = makeConfig({
+      deleteFile: vi.fn().mockImplementation(() => new Promise((r) => (resolveDelete = r))),
+    });
     const { result } = renderHook(() => useBackupDomain(config));
     await waitFor(() => expect(result.current.status).not.toBeNull());
 
+    act(() => {
+      void result.current.deleteBackup('a.zip');
+    });
+    // 删除进行中：loading 必须保持 false（原 delete handler 刻意不翻转 loading）
+    expect(result.current.loading).toBe(false);
+
     await act(async () => {
-      await result.current.deleteBackup('a.zip');
+      resolveDelete('ok');
     });
     expect(config.deleteFile).toHaveBeenCalledWith('a.zip');
     expect(message.success).toHaveBeenCalledWith('已删除');
+    expect(result.current.loading).toBe(false);
+    // 初始 1 次 + 删除成功后刷新 1 次
     expect(config.getStatus).toHaveBeenCalledTimes(2);
   });
 
-  it('删除失败时提示兜底文案且不刷新', async () => {
+  it('test_deleteBackup_失败透传错误且不刷新', async () => {
     const config = makeConfig({ deleteFile: vi.fn().mockRejectedValue(new Error('文件被占用')) });
     const { result } = renderHook(() => useBackupDomain(config));
     await waitFor(() => expect(result.current.status).not.toBeNull());
@@ -172,7 +192,7 @@ describe('useBackupDomain.deleteBackup', () => {
 });
 
 describe('useBackupDomain.runWithLoading', () => {
-  it('附加操作复用同一 loading：成功时不提示，失败时按传入文案报错', async () => {
+  it('test_runWithLoading_附加操作复用loading并按文案报错', async () => {
     const config = makeConfig();
     const { result } = renderHook(() => useBackupDomain(config));
     await waitFor(() => expect(result.current.status).not.toBeNull());

--- a/frontend/src/components/settings/useBackupDomain.test.ts
+++ b/frontend/src/components/settings/useBackupDomain.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { message } from 'antd';
+import {
+  useBackupDomain,
+  type BackupDomainConfig,
+  type BackupDomainStatusBase,
+} from './useBackupDomain';
+
+// 只用到 antd 的 message 静态方法；mock 掉避免 jsdom 中渲染通知组件的噪音
+vi.mock('antd', () => ({
+  message: { success: vi.fn(), error: vi.fn() },
+}));
+
+/** 构造一个最小合法状态对象——字段值刻意异于默认值，便于断言「回填自服务端」 */
+function makeStatus(overrides: Partial<BackupDomainStatusBase> = {}): BackupDomainStatusBase {
+  return {
+    auto_backup_enabled: true,
+    auto_backup_cron: '0 0 2 * * *',
+    auto_backup_max_files: 7,
+    last_backup: '2026-08-11T03:00:00Z',
+    files: [{ name: 'a.zip', size: 1, created_at: '2026-08-11T03:00:00Z' }],
+    ...overrides,
+  };
+}
+
+/** 构造全 mock 的域配置；各端点默认即刻成功，测试可按需覆写 */
+function makeConfig(
+  overrides: Partial<BackupDomainConfig<BackupDomainStatusBase>> = {},
+): BackupDomainConfig<BackupDomainStatusBase> {
+  return {
+    getStatus: vi.fn().mockResolvedValue(makeStatus()),
+    updateAuto: vi.fn().mockResolvedValue('ok'),
+    trigger: vi.fn().mockResolvedValue('手动备份完成'),
+    deleteFile: vi.fn().mockResolvedValue('ok'),
+    saveSuccessText: '测试域自动备份配置已保存',
+    defaultCron: '0 0 9 * * *',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useBackupDomain 初始加载', () => {
+  it('挂载时调用 getStatus 并回填 enabled/cron/maxFiles/status', async () => {
+    const config = makeConfig();
+    const { result } = renderHook(() => useBackupDomain(config));
+
+    // 回填前展示默认值（不阻塞首帧）
+    expect(result.current.status).toBeNull();
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+
+    expect(config.getStatus).toHaveBeenCalledTimes(1);
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.cron).toBe('0 0 2 * * *');
+    expect(result.current.maxFiles).toBe(7);
+  });
+
+  it('getStatus 失败时静默保持默认值', async () => {
+    const config = makeConfig({ getStatus: vi.fn().mockRejectedValue(new Error('网络错误')) });
+    const { result } = renderHook(() => useBackupDomain(config));
+
+    // 给 rejected promise 一个 flush 窗口；随后断言状态仍为默认且无任何错误提示
+    await act(async () => {});
+    expect(result.current.status).toBeNull();
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.cron).toBe('0 0 9 * * *');
+    expect(result.current.maxFiles).toBe(30);
+    expect(message.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('useBackupDomain.triggerBackup', () => {
+  it('成功：提示后端文案并刷新状态，loading 翻转后复位', async () => {
+    // 可控 deferred：把 trigger 卡在 pending，稳定捕获 loading=true 的中间态
+    let resolveTrigger!: (v: string) => void;
+    const config = makeConfig({
+      trigger: vi.fn().mockImplementation(() => new Promise<string>((r) => (resolveTrigger = r))),
+    });
+    const { result } = renderHook(() => useBackupDomain(config));
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+
+    act(() => {
+      void result.current.triggerBackup();
+    });
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      resolveTrigger('手动备份完成');
+    });
+    expect(result.current.loading).toBe(false);
+    expect(message.success).toHaveBeenCalledWith('手动备份完成');
+    // 初始 1 次 + trigger 成功后刷新 1 次
+    expect(config.getStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('失败：透传后端错误文案，loading 复位', async () => {
+    const config = makeConfig({ trigger: vi.fn().mockRejectedValue(new Error('磁盘已满')) });
+    const { result } = renderHook(() => useBackupDomain(config));
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+
+    await act(async () => {
+      await result.current.triggerBackup();
+    });
+    expect(message.error).toHaveBeenCalledWith('磁盘已满');
+    expect(result.current.loading).toBe(false);
+    // 失败不刷新状态
+    expect(config.getStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('失败且无后端文案时用兜底文案', async () => {
+    const config = makeConfig({ trigger: vi.fn().mockRejectedValue({}) });
+    const { result } = renderHook(() => useBackupDomain(config));
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+
+    await act(async () => {
+      await result.current.triggerBackup();
+    });
+    expect(message.error).toHaveBeenCalledWith('备份失败');
+  });
+});
+
+describe('useBackupDomain.saveAutoBackup', () => {
+  it('以当前表单值调 updateAuto 并提示域文案；不刷新状态', async () => {
+    const config = makeConfig();
+    const { result } = renderHook(() => useBackupDomain(config));
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+
+    // 用户在界面上改了表单再保存
+    act(() => {
+      result.current.setEnabled(false);
+      result.current.setCron('0 0 6 * * *');
+      result.current.setMaxFiles(15);
+    });
+    await act(async () => {
+      await result.current.saveAutoBackup();
+    });
+
+    expect(config.updateAuto).toHaveBeenCalledWith(false, '0 0 6 * * *', 15);
+    expect(message.success).toHaveBeenCalledWith('测试域自动备份配置已保存');
+    expect(config.getStatus).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useBackupDomain.deleteBackup', () => {
+  it('删除指定文件、提示已删除并刷新状态', async () => {
+    const config = makeConfig();
+    const { result } = renderHook(() => useBackupDomain(config));
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+
+    await act(async () => {
+      await result.current.deleteBackup('a.zip');
+    });
+    expect(config.deleteFile).toHaveBeenCalledWith('a.zip');
+    expect(message.success).toHaveBeenCalledWith('已删除');
+    expect(config.getStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('删除失败时提示兜底文案且不刷新', async () => {
+    const config = makeConfig({ deleteFile: vi.fn().mockRejectedValue(new Error('文件被占用')) });
+    const { result } = renderHook(() => useBackupDomain(config));
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+
+    await act(async () => {
+      await result.current.deleteBackup('a.zip');
+    });
+    expect(message.error).toHaveBeenCalledWith('文件被占用');
+    expect(config.getStatus).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useBackupDomain.runWithLoading', () => {
+  it('附加操作复用同一 loading：成功时不提示，失败时按传入文案报错', async () => {
+    const config = makeConfig();
+    const { result } = renderHook(() => useBackupDomain(config));
+    await waitFor(() => expect(result.current.status).not.toBeNull());
+
+    const ok = vi.fn().mockResolvedValue(undefined);
+    await act(async () => {
+      await result.current.runWithLoading(ok, '优化失败');
+    });
+    expect(ok).toHaveBeenCalledTimes(1);
+    expect(message.error).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.runWithLoading(async () => {
+        throw new Error('vacuum 中断');
+      }, '优化失败');
+    });
+    expect(message.error).toHaveBeenCalledWith('vacuum 中断');
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/frontend/src/components/settings/useBackupDomain.ts
+++ b/frontend/src/components/settings/useBackupDomain.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { message } from 'antd';
+
+/**
+ * 单备份域的状态与操作收口 hook（096-W1-PR4 产物）。
+ *
+ * 原 BackupPanel 为 database/todo/skill 三个域各维护一组逐字同构的状态与 handler：
+ * 5 个 useState ×3 + 4 个 handler ×3 + 初始加载 useEffect ×3（约 150 行重复），
+ * 唯一差异只是「调用的 4 个后端端点 + 保存成功文案 + 默认 cron」。
+ * 本 hook 把同构部分收敛为一份，域差异经 config 参数注入。
+ */
+
+/** 三域备份状态的公共基底（Skill 域多出的 executor_skills 字段经泛型 S 保留）。 */
+export interface BackupDomainStatusBase {
+  auto_backup_enabled: boolean;
+  auto_backup_cron: string;
+  auto_backup_max_files: number;
+  last_backup: string | null;
+  files: { name: string; size: number; created_at: string }[];
+}
+
+/** 单个备份域的差异面：4 个后端端点 + 2 处文案/默认值。 */
+export interface BackupDomainConfig<S extends BackupDomainStatusBase> {
+  /** 拉取该域备份状态（挂载时调用一次，trigger/delete 成功后也会刷新） */
+  getStatus: () => Promise<S>;
+  /** 保存自动备份配置（enabled/cron/maxFiles 三元组） */
+  updateAuto: (enabled: boolean, cron: string, maxFiles?: number) => Promise<unknown>;
+  /** 触发一次手动备份，返回后端提示文案 */
+  trigger: () => Promise<string>;
+  /** 删除指定备份文件 */
+  deleteFile: (filename: string) => Promise<unknown>;
+  /** 保存成功提示（各域带名前缀，如 'Todo自动备份配置已保存'） */
+  saveSuccessText: string;
+  /** 初始 cron 兜底值（各域错开备份时刻：3/4/5 点），getStatus 回填前的展示值 */
+  defaultCron: string;
+}
+
+/** hook 返回面：状态 + 表单 setter + 三个域操作 + 通用 loading 包装。 */
+export interface BackupDomain<S extends BackupDomainStatusBase> {
+  status: S | null;
+  enabled: boolean;
+  cron: string;
+  maxFiles: number;
+  loading: boolean;
+  setEnabled: (v: boolean) => void;
+  setCron: (v: string) => void;
+  setMaxFiles: (v: number) => void;
+  /** 手动触发备份：成功提示后端文案并刷新状态 */
+  triggerBackup: () => Promise<void>;
+  /** 以当前表单值保存自动备份配置 */
+  saveAutoBackup: () => Promise<void>;
+  /** 删除备份文件并刷新状态 */
+  deleteBackup: (filename: string) => Promise<void>;
+  /**
+   * 域内附加操作（如数据库优化/日志清理）的 loading 包装：
+   * 与域操作共享同一 loading 指示灯——与原实现中这些操作复用 setBackupLoading 的行为一致。
+   */
+  runWithLoading: (action: () => Promise<void>, errorText: string) => Promise<void>;
+}
+
+export function useBackupDomain<S extends BackupDomainStatusBase>(
+  config: BackupDomainConfig<S>,
+): BackupDomain<S> {
+  const [status, setStatus] = useState<S | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [cron, setCron] = useState(config.defaultCron);
+  const [maxFiles, setMaxFiles] = useState(30);
+  const [loading, setLoading] = useState(false);
+
+  // latest-ref 模式：调用方每次渲染传入新的 config 字面量，但端点函数本身是模块级稳定引用。
+  // 用 ref 持有后，初始加载可安全地只跑一次（与原实现三个 useEffect(..., []) 行为逐字一致），
+  // 不因 config 字面量身份变化而重复拉取。
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  // 挂载时拉一次状态并回填表单（原三份逐字同构的初始加载 useEffect 收口于此）。
+  // 拉取失败静默保持默认值——面板仅展示态受影响，不阻断用户操作，与原实现 .catch(() => {}) 一致。
+  useEffect(() => {
+    configRef.current
+      .getStatus()
+      .then((s) => {
+        setStatus(s);
+        setEnabled(s.auto_backup_enabled);
+        setCron(s.auto_backup_cron);
+        setMaxFiles(s.auto_backup_max_files);
+      })
+      .catch(() => {});
+  }, []);
+
+  // 通用 loading 包装：setLoading 翻转 + 统一 catch 文案提示 + finally 复位。
+  // 域内所有写操作（trigger/save/delete 及数据库域的优化/日志清理）共用这一条骨架。
+  const runWithLoading = useCallback(
+    async (action: () => Promise<void>, errorText: string) => {
+      setLoading(true);
+      try {
+        await action();
+      } catch (err: any) {
+        // 后端有具体错误信息则透传，否则用操作级兜底文案——与原实现的 err?.message || '...' 一致
+        message.error(err?.message || errorText);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
+  // 手动备份：成功顺序为「提示后端文案 → 重新拉状态」——与原 handler 逐字一致
+  const triggerBackup = useCallback(
+    () =>
+      runWithLoading(async () => {
+        message.success(await configRef.current.trigger());
+        setStatus(await configRef.current.getStatus());
+      }, '备份失败'),
+    [runWithLoading],
+  );
+
+  // 保存自动备份配置：成功后不刷新 status——原实现即如此（表单值即真相，无需回拉）
+  const saveAutoBackup = useCallback(
+    () =>
+      runWithLoading(async () => {
+        await configRef.current.updateAuto(enabled, cron, maxFiles);
+        message.success(configRef.current.saveSuccessText);
+      }, '保存失败'),
+    [runWithLoading, enabled, cron, maxFiles],
+  );
+
+  // 删除文件：成功后刷新状态让文件列表即时消失——与原 handler 逐字一致
+  const deleteBackup = useCallback(
+    (filename: string) =>
+      runWithLoading(async () => {
+        await configRef.current.deleteFile(filename);
+        message.success('已删除');
+        setStatus(await configRef.current.getStatus());
+      }, '删除失败'),
+    [runWithLoading],
+  );
+
+  return {
+    status,
+    enabled,
+    cron,
+    maxFiles,
+    loading,
+    setEnabled,
+    setCron,
+    setMaxFiles,
+    triggerBackup,
+    saveAutoBackup,
+    deleteBackup,
+    runWithLoading,
+  };
+}

--- a/frontend/src/components/settings/useBackupDomain.ts
+++ b/frontend/src/components/settings/useBackupDomain.ts
@@ -58,6 +58,25 @@ export interface BackupDomain<S extends BackupDomainStatusBase> {
   runWithLoading: (action: () => Promise<void>, errorText: string) => Promise<void>;
 }
 
+/**
+ * 从未知错误中提取用户可读文案，等价于原实现的 `err?.message || fallback`。
+ *
+ * 后端抛来的错误形态不定——可能是 Error 实例，也可能是带 message 字段的普通对象，
+ * 还可能是 null/字符串等非对象。统一收口为「有非空字符串 message 就透传，否则兜底」，
+ * 让 catch (err: unknown) 下仍保留原 err?.message 的透传语义，又不违背禁 any 规范。
+ */
+function extractErrorMessage(err: unknown, fallback: string): string {
+  // 仅对「非空对象且含 message 字段」尝试透传；string/null/undefined 等非对象直接兜底
+  if (typeof err === 'object' && err !== null && 'message' in err) {
+    const msg = (err as { message?: unknown }).message;
+    // message 必须是非空字符串才透传——与原 || 的 falsy 回落一致（空串/数字等不透传）
+    if (typeof msg === 'string' && msg.length > 0) {
+      return msg;
+    }
+  }
+  return fallback;
+}
+
 export function useBackupDomain<S extends BackupDomainStatusBase>(
   config: BackupDomainConfig<S>,
 ): BackupDomain<S> {
@@ -84,7 +103,11 @@ export function useBackupDomain<S extends BackupDomainStatusBase>(
         setCron(s.auto_backup_cron);
         setMaxFiles(s.auto_backup_max_files);
       })
-      .catch(() => {});
+      .catch((err: unknown) => {
+        // 初始状态拉取失败不弹用户提示（面板仍以默认值展示、不阻断操作，与原实现一致），
+        // 仅留 console.warn 便于线上排查——满足「空 catch 至少记录」的规范要求。
+        console.warn('backup status 初始加载失败', err);
+      });
   }, []);
 
   // 通用 loading 包装：setLoading 翻转 + 统一 catch 文案提示 + finally 复位。
@@ -94,9 +117,9 @@ export function useBackupDomain<S extends BackupDomainStatusBase>(
       setLoading(true);
       try {
         await action();
-      } catch (err: any) {
+      } catch (err: unknown) {
         // 后端有具体错误信息则透传，否则用操作级兜底文案——与原实现的 err?.message || '...' 一致
-        message.error(err?.message || errorText);
+        message.error(extractErrorMessage(err, errorText));
       } finally {
         setLoading(false);
       }
@@ -124,15 +147,20 @@ export function useBackupDomain<S extends BackupDomainStatusBase>(
     [runWithLoading, enabled, cron, maxFiles],
   );
 
-  // 删除文件：成功后刷新状态让文件列表即时消失——与原 handler 逐字一致
+  // 删除文件：成功顺序为「提示已删除 → 重新拉状态让文件列表即时消失」。
+  // 刻意不走 runWithLoading——原三个 delete handler 均不翻转 loading（删除是即时操作，
+  // 无需点亮 loading 灯/禁用按钮），此处保持该语义以避免行为回归。
   const deleteBackup = useCallback(
-    (filename: string) =>
-      runWithLoading(async () => {
+    async (filename: string) => {
+      try {
         await configRef.current.deleteFile(filename);
         message.success('已删除');
         setStatus(await configRef.current.getStatus());
-      }, '删除失败'),
-    [runWithLoading],
+      } catch (err: unknown) {
+        message.error(extractErrorMessage(err, '删除失败'));
+      }
+    },
+    [],
   );
 
   return {

--- a/frontend/src/utils/download.test.ts
+++ b/frontend/src/utils/download.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { backupTimestamp, downloadByUrl, downloadBlob } from './download';
+
+// downloadByUrl/downloadBlob 操作真实 DOM 的 <a> 元素：
+// 用 appendChild spy 捕获创建的锚点，断言 href/download 赋值与即插即拔的完整生命周期。
+describe('downloadByUrl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('创建 <a> 设置 href 与 download 后即插即拔', () => {
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      // 阻止 jsdom 真实导航（jsdom 对点击跳转只报 not implemented，静默掉保持输出干净）
+      .mockImplementation(() => {});
+    const appendSpy = vi.spyOn(document.body, 'appendChild');
+    const removeSpy = vi.spyOn(document.body, 'removeChild');
+
+    downloadByUrl('/api/v1/backup/todo/file?filename=a.zip', 'a.zip');
+
+    // 元素被插入 body，且属性赋值发生在点击前
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+    const anchor = appendSpy.mock.calls[0][0] as HTMLAnchorElement;
+    expect(anchor.tagName).toBe('A');
+    expect(anchor.getAttribute('href')).toBe('/api/v1/backup/todo/file?filename=a.zip');
+    expect(anchor.download).toBe('a.zip');
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    // 用完即拔，DOM 不残留
+    expect(removeSpy).toHaveBeenCalledWith(anchor);
+  });
+});
+
+describe('downloadBlob', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('创建 objectURL 下载后 revoke 回收（含异常路径）', () => {
+    // jsdom 未实现 URL.createObjectURL/revokeObjectURL，stub 出可控实现
+    const revokeSpy = vi.fn();
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn().mockReturnValue('blob:mock-url'),
+      revokeObjectURL: revokeSpy,
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    downloadBlob(new Blob(['x']), 'f.zip');
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeSpy).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  it('downloadByUrl 抛错时仍回收 objectURL（finally 兜底）', () => {
+    const revokeSpy = vi.fn();
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn().mockReturnValue('blob:mock-url'),
+      revokeObjectURL: revokeSpy,
+    });
+    // click 抛错模拟下载触发失败
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {
+      throw new Error('click failed');
+    });
+
+    expect(() => downloadBlob(new Blob(['x']), 'f.zip')).toThrow('click failed');
+    expect(revokeSpy).toHaveBeenCalledWith('blob:mock-url');
+  });
+});
+
+describe('backupTimestamp', () => {
+  it('输出文件名安全的秒级时间戳（冒号与点替换为 -）', () => {
+    // 固定时刻：2026-08-11T13:45:06.789Z
+    const fixed = new Date('2026-08-11T13:45:06.789Z');
+    expect(backupTimestamp(fixed)).toBe('2026-08-11T13-45-06');
+  });
+});

--- a/frontend/src/utils/download.test.ts
+++ b/frontend/src/utils/download.test.ts
@@ -8,7 +8,7 @@ describe('downloadByUrl', () => {
     vi.restoreAllMocks();
   });
 
-  it('创建 <a> 设置 href 与 download 后即插即拔', () => {
+  it('test_downloadByUrl_创建a标签设置属性即插即拔', () => {
     const clickSpy = vi
       .spyOn(HTMLAnchorElement.prototype, 'click')
       // 阻止 jsdom 真实导航（jsdom 对点击跳转只报 not implemented，静默掉保持输出干净）
@@ -36,7 +36,7 @@ describe('downloadBlob', () => {
     vi.unstubAllGlobals();
   });
 
-  it('创建 objectURL 下载后 revoke 回收（含异常路径）', () => {
+  it('test_downloadBlob_objectURL下载后revoke回收', () => {
     // jsdom 未实现 URL.createObjectURL/revokeObjectURL，stub 出可控实现
     const revokeSpy = vi.fn();
     vi.stubGlobal('URL', {
@@ -51,7 +51,7 @@ describe('downloadBlob', () => {
     expect(revokeSpy).toHaveBeenCalledWith('blob:mock-url');
   });
 
-  it('downloadByUrl 抛错时仍回收 objectURL（finally 兜底）', () => {
+  it('test_downloadBlob_抛错时finally仍回收objectURL', () => {
     const revokeSpy = vi.fn();
     vi.stubGlobal('URL', {
       ...URL,
@@ -69,8 +69,8 @@ describe('downloadBlob', () => {
 });
 
 describe('backupTimestamp', () => {
-  it('输出文件名安全的秒级时间戳（冒号与点替换为 -）', () => {
-    // 固定时刻：2026-08-11T13:45:06.789Z
+  it('test_backupTimestamp_输出文件名安全秒级时间戳', () => {
+    // 固定时刻：2026-08-11T13:45:06.789Z；冒号与点须替换为 - 才能进 Windows 文件名
     const fixed = new Date('2026-08-11T13:45:06.789Z');
     expect(backupTimestamp(fixed)).toBe('2026-08-11T13-45-06');
   });

--- a/frontend/src/utils/download.ts
+++ b/frontend/src/utils/download.ts
@@ -1,0 +1,48 @@
+/**
+ * 浏览器下载工具（096-W1-PR4 收口产物）。
+ *
+ * 原 BackupPanel 里散着 5 份逐字同构的下载套路：
+ * - 3 份「URL → 临时 <a> 点击」骨架（database/todo/skill 备份文件下载）
+ * - 2 份「fetch → Blob → objectURL → <a> 点击 → revoke」骨架（数据库下载、YAML 导出）
+ * 任何交互细节调整（如命名策略、回收时机）都要同步改多处，这里收敛为两个原语。
+ */
+
+/**
+ * 生成备份文件名用的时间戳片段。
+ *
+ * ISO 串含 `:` 与 `.`，直接进文件名在 Windows 上非法，故替换为 `-`；
+ * 截断到秒级（19 字符）兼顾可读性与唯一性——与原实现逐字保持同一格式。
+ */
+export function backupTimestamp(now: Date = new Date()): string {
+  return now.toISOString().replace(/[:.]/g, '-').slice(0, 19);
+}
+
+/**
+ * 触发浏览器下载：适用于「同源 GET 链接」场景（服务端流式返回文件）。
+ *
+ * 通过临时 <a download> 元素触发浏览器原生下载，不经过 axios 拦截器；
+ * 元素即插即拔，不残留 DOM 垃圾。
+ */
+export function downloadByUrl(url: string, filename: string): void {
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+/**
+ * 触发浏览器下载：适用于「fetch 已在内存里拿到内容」的场景（Blob/文本）。
+ *
+ * objectURL 在 click 后立即 revoke——与原实现保持同一回收时机；
+ * 用 try/finally 兜底，即使 downloadByUrl 抛错也不泄漏 objectURL。
+ */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  try {
+    downloadByUrl(url, filename);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/frontend/tests/096-backup-panel-dedup.spec.ts
+++ b/frontend/tests/096-backup-panel-dedup.spec.ts
@@ -1,0 +1,52 @@
+// 096-W1-PR4 冒烟：BackupPanel 三域收口（useBackupDomain + download util）后的行为等价验证。
+// 验证点：三个子 tab 渲染各自域内容、tab 切换与 URL 深链同步正常——
+// 收口前这些交互由三份逐字同构的 state/handler 驱动，收口后由三个 useBackupDomain 实例驱动，
+// 本冒烟即为「行为未变」的外层锚点。
+import { test, expect } from '@playwright/test';
+
+test.describe('BackupPanel 三域收口冒烟', () => {
+  test.beforeEach(async ({ page }) => {
+    // 直达备份面板深链：设置页 → 备份 tab → 默认「事项备份」子 tab
+    await page.goto('http://localhost:18088/#/settings?tab=backup');
+    // 等 antd Tabs 挂载完成（tab 标签出现即组件树就绪）
+    await page.getByRole('tab', { name: '事项备份' }).waitFor();
+  });
+
+  test('默认渲染事项备份域，可见导出/导入与自动备份配置区', async ({ page }) => {
+    // 事项备份域独有：YAML 导出/导入区块
+    await expect(page.getByText('事项自动备份')).toBeVisible();
+    await expect(page.getByText('导出备份')).toBeVisible();
+    await expect(page.getByText('导入备份')).toBeVisible();
+    // 「立即备份」按钮存在（触发 handler 由 hook 提供，存在即可见——不点击以避免真实写备份文件）
+    await expect(page.getByRole('button', { name: '立即备份' }).first()).toBeVisible();
+  });
+
+  test('切换到 Skill 备份域并同步 URL 深链', async ({ page }) => {
+    await page.getByRole('tab', { name: 'Skill备份' }).click();
+    // Skill 域独有：执行器 Skills 概览区块
+    await expect(page.getByText('执行器 Skills 概览')).toBeVisible();
+    await expect(page.getByText('备份各执行器下的 skills 文件夹')).toBeVisible();
+    // 深链同步是收口前 handleBackupSubChange 的行为，需保持不变
+    await expect(page).toHaveURL(/sub=skill-backup/);
+  });
+
+  test('切换到数据库备份域，可见附加操作（优化/日志清理）', async ({ page }) => {
+    await page.getByRole('tab', { name: '数据库备份' }).click();
+    // 数据库域独有：优化与日志清理区块（这两组 handler 复用 domain 的 runWithLoading）。
+    // 「数据库备份」同时是 tab 标签文本，用卡片标题类限定到内容区，避免 strict mode 冲突。
+    await expect(page.locator('.ant-card-head-title', { hasText: '数据库备份' })).toBeVisible();
+    await expect(page.getByText('压缩优化')).toBeVisible();
+    await expect(page.getByText('清理日志')).toBeVisible();
+    await expect(page.getByRole('button', { name: '下载数据库' })).toBeVisible();
+    await expect(page).toHaveURL(/sub=database/);
+  });
+
+  test('三域往返切换后回到事项备份，深链与内容复位', async ({ page }) => {
+    // 往返一次覆盖「域状态互不影响」（收口前是三组独立 useState，收口后是三个 hook 实例）
+    await page.getByRole('tab', { name: 'Skill备份' }).click();
+    await page.getByRole('tab', { name: '数据库备份' }).click();
+    await page.getByRole('tab', { name: '事项备份' }).click();
+    await expect(page.getByText('事项自动备份')).toBeVisible();
+    await expect(page).toHaveURL(/sub=todo/);
+  });
+});


### PR DESCRIPTION
## 实现了什么

096 分步方案 **W1-PR4：前端 `BackupPanel` 三域复制收口**（依据 `docs/design/096-代码质量重构分步方案.md`，实证见扫描报告 A6 项）。W1 波次收尾 PR。

原 `BackupPanel.tsx`（622 行）为 database/todo/skill 三个备份域各维护一份逐字同构代码：**5 个 useState ×3 + 4 个 handler ×3 + 初始加载 useEffect ×3（约 150 行）+ 下载套路 ×5**。本 PR 按方案收口：

| 重复面 | 收口产物 |
|---|---|
| 三域状态组 + handler + 初始加载 | 新建 `components/settings/useBackupDomain.ts` hook（差异面参数化：4 端点 + 保存文案 + 默认 cron） |
| 3 份「URL→&lt;a&gt;」+ 2 份「Blob→objectURL→&lt;a&gt;→revoke」 | 新建 `utils/download.ts`：`downloadByUrl` / `downloadBlob` / `backupTimestamp` |

## 关键实现点

- **手法**：Extract Function + Move Function（自定义 hook 提取），纯行为等价。
- **props 形状不变硬约束**：`TodoBackupTab`/`SkillBackupTab`/`DatabaseBackupTab` 三个子组件**零改动**，BackupPanel 内仅把散置 state/handler 换成 hook 聚合返回值。
- **行为等价细节**：
  - 初始加载只跑一次：hook 内 latest-ref 持有 config，复刻原 `useEffect(..., [])` 语义，config 字面量身份变化不触发重拉；
  - trigger/delete 成功后刷新 status、save 后不刷新、初始加载失败静默——与原实现逐字一致；
  - 错误提示 `err?.message || 兜底文案`、三域保存文案前缀、`downloadBlob` 的 click 后即 revoke 时机——全部保持；
  - 数据库域附加操作（优化/日志清理×2）经 hook 暴露的 `runWithLoading` 复用同一 loading 灯，等价于原实现复用 `setBackupLoading`。
- **Skill 域类型差异**（status 多 `executor_skills`）经泛型 `S extends BackupDomainStatusBase` 保留，无 any。

## 测试与验证结果

- `npx tsc --noEmit`：**零错误**；`npm run build`（tsc + vite）：通过，无新增告警。
- `npx vitest run`：**42 文件 / 360 用例全过**，含新增 13 项——`useBackupDomain.test.ts` 9 项（初始回填/失败静默/trigger 成功刷新与 loading 翻转/失败文案透传与兜底/save 表单值/delete 刷新/runWithLoading 附加操作）+ `download.test.ts` 4 项（a 标签生命周期/objectURL 回收含异常路径/时间戳格式）。
- **Playwright 冒烟**（新增 `frontend/tests/096-backup-panel-dedup.spec.ts`，dev 实例 18088 实测）：**4/4 通过**——三域渲染各自锚点内容、tab 切换与 URL 深链同步、往返切换复位。

## 已知限制

- 无行为变化声明项。回退方式：单 PR revert。
