### PR TITLE
refactor(096-W2-1): REPLACE(REPLACE(...)) 时间过滤 13 处替换——started_at 索引恢复命中（SCAN→SEARCH）

### DIFF
--- a/backend/src/db/dashboard.rs
+++ b/backend/src/db/dashboard.rs
@@ -231,8 +231,33 @@ pub(super) fn assemble_dashboard_response(
 pub(super) struct DashboardQueryContext<'a> {
     pub conn: &'a dyn ConnectionTrait,
     pub backend: DbBackend,
+    /// 「N 小时前」UTC cutoff（T/Z 毫秒级 ISO 字面量，由 `utc_timestamp_minus_hours` 生成）。
+    /// 供 execution_records 各统计查询以 `started_at >= ?` 参数绑定使用——裸列比较保持
+    /// idx_execution_records_started_at 索引命中（096-W2 替代 REPLACE(REPLACE(...)) 旧写法）。
+    pub time_cutoff: String,
+    /// 热力图固定 cutoff：当年 1 月 1 日 00:00:00（T/Z ISO 字面量，与存储格式同构）。
+    /// 热力图时间范围不受 hours 过滤影响，独立成字段。
+    pub heatmap_cutoff: String,
+    /// skills 统计专用的时间过滤表达式（`datetime('now',...)` SQL 片段，存量口径）。
+    /// 注意：该片段与 T/Z 存储格式做字符串比较存在精度退化（' ' < 'T'），
+    /// 属存量行为，本结构仅为兼容保留；新代码应使用 `time_cutoff` 参数绑定。
     pub time_filter: String,
-    pub heatmap_filter: String,
+}
+
+impl DashboardQueryContext<'_> {
+    /// 构造绑定了单个时间 cutoff 参数的 Statement。
+    ///
+    /// 9 处 execution_records 统计查询的统一入口：SQL 中以 `started_at >= ?` 占位，
+    /// cutoff 经参数绑定传入（096-W2）——替代 `REPLACE(REPLACE(...)) >= datetime('now',...)`
+    /// 拼接写法，裸列比较保持索引命中，同时消除 SQL 拼接。
+    pub(super) fn stmt_with_cutoff(&self, sql: impl Into<String>, cutoff: &str) -> Statement {
+        Statement::from_sql_and_values(self.backend, sql.into(), vec![cutoff.to_string().into()])
+    }
+
+    /// `time_cutoff` 绑定的便捷入口（绝大多数查询的口径）。
+    pub(super) fn stmt_with_time_cutoff(&self, sql: impl Into<String>) -> Statement {
+        self.stmt_with_cutoff(sql, &self.time_cutoff)
+    }
 }
 
 /// 查询 Todo 统计（总数、各状态计数、定时任务数）。
@@ -269,8 +294,7 @@ pub(super) async fn fetch_todo_stats(
 pub(super) async fn fetch_execution_overall(
     ctx: &DashboardQueryContext<'_>,
 ) -> Result<(i64, i64, i64, u64, u64, u64, u64, f64, u64, u64), sea_orm::DbErr> {
-    let sql = format!(
-        "SELECT \
+    let sql = "SELECT \
         COUNT(*) as total, \
         COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success, \
         COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed, \
@@ -282,12 +306,10 @@ pub(super) async fn fetch_execution_overall(
         COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN json_extract(usage, '$.duration_ms') ELSE 0 END), 0) as total_duration, \
         COALESCE(SUM(CASE WHEN json_extract(usage, '$.duration_ms') IS NOT NULL THEN 1 ELSE 0 END), 0) as duration_count \
         FROM execution_records \
-        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {}",
-        ctx.time_filter
-    );
+        WHERE started_at >= ?";
 
     if let Some(row) = ctx.conn
-        .query_one(Statement::from_string(ctx.backend, sql))
+        .query_one(ctx.stmt_with_time_cutoff(sql))
         .await?
     {
         let t: i64 = row.try_get_by("total").unwrap_or(0);
@@ -334,8 +356,7 @@ pub(super) async fn fetch_executor_distribution(
     ctx: &DashboardQueryContext<'_>,
     executor_todo_counts: &HashMap<String, i64>,
 ) -> Result<Vec<ExecutorCount>, sea_orm::DbErr> {
-    let sql = format!(
-        "SELECT \
+    let sql = "SELECT \
         COALESCE(executor, 'claudecode') as executor, \
         COUNT(*) as execution_count, \
         COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
@@ -344,13 +365,11 @@ pub(super) async fn fetch_executor_distribution(
         COALESCE(SUM(COALESCE(json_extract(usage, '$.output_tokens'), 0)), 0) as output_tokens, \
         COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
         FROM execution_records \
-        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} \
-        GROUP BY COALESCE(executor, 'claudecode')",
-        ctx.time_filter
-    );
+        WHERE started_at >= ? \
+        GROUP BY COALESCE(executor, 'claudecode')";
 
     let mut distribution: Vec<ExecutorCount> = ctx.conn
-        .query_all(Statement::from_string(ctx.backend, sql))
+        .query_all(ctx.stmt_with_time_cutoff(sql))
         .await?
         .into_iter()
         .filter_map(|row| {
@@ -383,8 +402,7 @@ pub(super) async fn fetch_executor_distribution(
 pub(super) async fn fetch_model_distribution(
     ctx: &DashboardQueryContext<'_>,
 ) -> Result<Vec<ModelCount>, sea_orm::DbErr> {
-    let sql = format!(
-        "SELECT \
+    let sql = "SELECT \
         COALESCE(model, 'unknown') as model, \
         COUNT(*) as execution_count, \
         COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
@@ -395,13 +413,11 @@ pub(super) async fn fetch_model_distribution(
         COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
         COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
         FROM execution_records \
-        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} \
-        GROUP BY COALESCE(model, 'unknown')",
-        ctx.time_filter
-    );
+        WHERE started_at >= ? \
+        GROUP BY COALESCE(model, 'unknown')";
 
     let mut distribution: Vec<ModelCount> = ctx.conn
-        .query_all(Statement::from_string(ctx.backend, sql))
+        .query_all(ctx.stmt_with_time_cutoff(sql))
         .await?
         .into_iter()
         .filter_map(|row| {
@@ -438,20 +454,17 @@ pub(super) async fn fetch_model_distribution(
 pub(super) async fn fetch_trigger_distribution(
     ctx: &DashboardQueryContext<'_>,
 ) -> Result<Vec<TriggerTypeCount>, sea_orm::DbErr> {
-    let sql = format!(
-        "SELECT \
+    let sql = "SELECT \
         COALESCE(trigger_type, 'manual') as trigger_type, \
         COUNT(*) as count, \
         COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
         COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) as failed_count \
         FROM execution_records \
-        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} \
-        GROUP BY COALESCE(trigger_type, 'manual')",
-        ctx.time_filter
-    );
+        WHERE started_at >= ? \
+        GROUP BY COALESCE(trigger_type, 'manual')";
 
     let mut distribution: Vec<TriggerTypeCount> = ctx.conn
-        .query_all(Statement::from_string(ctx.backend, sql))
+        .query_all(ctx.stmt_with_time_cutoff(sql))
         .await?
         .into_iter()
         .filter_map(|row| {
@@ -476,19 +489,16 @@ pub(super) async fn fetch_trigger_distribution(
 pub(super) async fn fetch_executor_durations(
     ctx: &DashboardQueryContext<'_>,
 ) -> Result<Vec<ExecutorDuration>, sea_orm::DbErr> {
-    let sql = format!(
-        "SELECT \
+    let sql = "SELECT \
         COALESCE(executor, 'claudecode') as executor, \
         ROUND(AVG(json_extract(usage, '$.duration_ms')), 0) as avg_duration, \
         COUNT(*) as execution_count \
         FROM execution_records \
-        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} AND json_extract(usage, '$.duration_ms') IS NOT NULL \
-        GROUP BY COALESCE(executor, 'claudecode')",
-        ctx.time_filter
-    );
+        WHERE started_at >= ? AND json_extract(usage, '$.duration_ms') IS NOT NULL \
+        GROUP BY COALESCE(executor, 'claudecode')";
 
     let mut stats: Vec<ExecutorDuration> = ctx.conn
-        .query_all(Statement::from_string(ctx.backend, sql))
+        .query_all(ctx.stmt_with_time_cutoff(sql))
         .await?
         .into_iter()
         .filter_map(|row| {
@@ -510,19 +520,16 @@ pub(super) async fn fetch_executor_durations(
 pub(super) async fn fetch_model_cache_stats(
     ctx: &DashboardQueryContext<'_>,
 ) -> Result<Vec<ModelCacheStat>, sea_orm::DbErr> {
-    let sql = format!(
-        "SELECT \
+    let sql = "SELECT \
         COALESCE(model, 'unknown') as model, \
         COALESCE(SUM(COALESCE(json_extract(usage, '$.input_tokens'), 0)), 0) as input_tokens, \
         COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_read_input_tokens'), 0)), 0) as cache_read \
         FROM execution_records \
-        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} AND model IS NOT NULL \
-        GROUP BY COALESCE(model, 'unknown')",
-        ctx.time_filter
-    );
+        WHERE started_at >= ? AND model IS NOT NULL \
+        GROUP BY COALESCE(model, 'unknown')";
 
     let mut stats: Vec<ModelCacheStat> = ctx.conn
-        .query_all(Statement::from_string(ctx.backend, sql))
+        .query_all(ctx.stmt_with_time_cutoff(sql))
         .await?
         .into_iter()
         .filter_map(|row| {
@@ -560,15 +567,15 @@ pub(super) async fn fetch_daily_stats(
         COALESCE(SUM(COALESCE(json_extract(usage, '$.cache_creation_input_tokens'), 0)), 0) as cache_creation, \
         COALESCE(SUM(COALESCE(json_extract(usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
         FROM execution_records \
-        WHERE started_at IS NOT NULL AND LENGTH(started_at) >= 10 AND REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} \
+        WHERE started_at IS NOT NULL AND LENGTH(started_at) >= 10 AND started_at >= ? \
         GROUP BY SUBSTR(started_at, 1, 10) \
         ORDER BY day DESC \
         LIMIT {}",
-        ctx.heatmap_filter, heatmap_limit
+        heatmap_limit
     );
 
     let rows = ctx.conn
-        .query_all(Statement::from_string(ctx.backend, sql))
+        .query_all(ctx.stmt_with_cutoff(sql, &ctx.heatmap_cutoff))
         .await?;
 
     let mut daily_executions = Vec::with_capacity(rows.len());
@@ -608,8 +615,7 @@ pub(super) async fn fetch_tag_distribution(
     tags: &[crate::models::Tag],
     tag_todo_counts: &HashMap<i64, i64>,
 ) -> Result<Vec<TagCount>, sea_orm::DbErr> {
-    let sql = format!(
-        "SELECT \
+    let sql = "SELECT \
         tt.tag_id, \
         COUNT(*) as execution_count, \
         COALESCE(SUM(CASE WHEN er.status = 'success' THEN 1 ELSE 0 END), 0) as success_count, \
@@ -619,13 +625,11 @@ pub(super) async fn fetch_tag_distribution(
         COALESCE(SUM(COALESCE(json_extract(er.usage, '$.total_cost_usd'), 0.0)), 0.0) as cost \
         FROM execution_records er \
         INNER JOIN todo_tags tt ON tt.todo_id = er.todo_id \
-        WHERE er.todo_id IS NOT NULL AND REPLACE(REPLACE(er.started_at, 'T', ' '), 'Z', '') >= {} \
-        GROUP BY tt.tag_id",
-        ctx.time_filter
-    );
+        WHERE er.todo_id IS NOT NULL AND er.started_at >= ? \
+        GROUP BY tt.tag_id";
 
     let tag_rows = ctx.conn
-        .query_all(Statement::from_string(ctx.backend, sql))
+        .query_all(ctx.stmt_with_time_cutoff(sql))
         .await?;
 
     let mut tag_exec_stats: HashMap<i64, (i64, i64, i64, u64, u64, f64)> = HashMap::new();
@@ -672,16 +676,13 @@ pub(super) async fn fetch_tag_distribution(
 pub(super) async fn fetch_recent_executions(
     ctx: &DashboardQueryContext<'_>,
 ) -> Result<Vec<ExecutionRecord>, sea_orm::DbErr> {
-    let sql = format!(
-        "SELECT id, todo_id, executor, trigger_type, status, started_at, finished_at, usage, task_id, session_id, result, resume_message FROM execution_records \
-        WHERE REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= {} \
-        ORDER BY started_at DESC LIMIT 10",
-        ctx.time_filter
-    );
+    let sql = "SELECT id, todo_id, executor, trigger_type, status, started_at, finished_at, usage, task_id, session_id, result, resume_message FROM execution_records \
+        WHERE started_at >= ? \
+        ORDER BY started_at DESC LIMIT 10";
 
     use crate::db::entity::execution_records;
     let records: Vec<ExecutionRecord> = ctx.conn
-        .query_all(Statement::from_string(ctx.backend, sql))
+        .query_all(ctx.stmt_with_time_cutoff(sql))
         .await?
         .into_iter()
         .map(|row| {
@@ -1035,6 +1036,83 @@ mod tests {
         assert_eq!(resp.top_model_tokens, Some(200));
         assert!(resp.skills_stats.is_none());
         assert!(resp.backup_stats.is_none());
+    }
+
+    // ─── 096-W2：参数化时间过滤的 DB 级验证 ───
+
+    async fn fresh_db() -> crate::db::Database {
+        crate::db::Database::new(":memory:").await.expect("memory db must open")
+    }
+
+    /// 构造仅用于测试的查询上下文：time_cutoff 取 24h 前（T/Z 毫秒级，与生产同口径），
+    /// 其余字段给占位值（被测函数不消费）。
+    fn test_ctx(db: &crate::db::Database) -> DashboardQueryContext<'_> {
+        DashboardQueryContext {
+            conn: &db.conn,
+            backend: sea_orm::DbBackend::Sqlite,
+            time_cutoff: crate::models::utc_timestamp_minus_hours(24),
+            heatmap_cutoff: "2026-01-01T00:00:00.000Z".to_string(),
+            time_filter: String::new(),
+        }
+    }
+
+    /// 参数化 `started_at >= ?` 的 ±1 小时边界：窗口内命中、窗口外排除。
+    /// 以 fetch_recent_executions 为代表（单表直返，断言最直观）；数据用生产 T/Z ISO 格式。
+    #[tokio::test]
+    async fn test_fetch_recent_executions_cutoff_boundary() {
+        let db = fresh_db().await;
+        db.exec(
+            "INSERT INTO execution_records (todo_id, status, trigger_type, started_at) \
+             VALUES (NULL, 'success', 'manual', strftime('%Y-%m-%dT%H:%M:%SZ','now','-23 hours'))",
+        )
+        .await
+        .expect("insert recent");
+        db.exec(
+            "INSERT INTO execution_records (todo_id, status, trigger_type, started_at) \
+             VALUES (NULL, 'success', 'manual', strftime('%Y-%m-%dT%H:%M:%SZ','now','-25 hours'))",
+        )
+        .await
+        .expect("insert old");
+
+        let ctx = test_ctx(&db);
+        let records = fetch_recent_executions(&ctx).await.expect("fetch recent");
+        assert_eq!(records.len(), 1, "25 小时前的记录应被 24h cutoff 排除");
+        let started = records[0].started_at.as_str();
+        assert!(started >= ctx.time_cutoff.as_str(), "命中记录应不早于 cutoff");
+    }
+
+    /// 查询计划实证：`started_at >= ?` 裸列比较必须命中 idx_execution_records_started_at，
+    /// 而非全表扫描（REPLACE(REPLACE(...)) 旧写法的核心问题即索引失效）。
+    #[tokio::test]
+    async fn test_started_at_filter_query_plan_uses_index() {
+        let db = fresh_db().await;
+        // 插几行数据，避免优化器对空表退化为 SCAN 的边界形态
+        for i in 0..3 {
+            db.exec(&format!(
+                "INSERT INTO execution_records (todo_id, status, trigger_type, started_at) \
+                 VALUES (NULL, 'success', 'manual', '2026-08-1{i}T00:00:00Z')"
+            ))
+            .await
+            .expect("insert rows");
+        }
+        let rows = db
+            .conn
+            .query_all(Statement::from_sql_and_values(
+                sea_orm::DbBackend::Sqlite,
+                "EXPLAIN QUERY PLAN SELECT COUNT(*) FROM execution_records WHERE started_at >= ?",
+                vec![crate::models::utc_timestamp_minus_hours(24).into()],
+            ))
+            .await
+            .expect("explain query plan");
+        let plan = rows
+            .iter()
+            .filter_map(|r| r.try_get_by::<String, _>("detail").ok())
+            .collect::<Vec<_>>()
+            .join("; ");
+        assert!(
+            plan.contains("idx_execution_records_started_at"),
+            "started_at 裸列过滤应命中索引而非全表扫描，实际计划: {plan}"
+        );
     }
 }
 

--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -232,11 +232,9 @@ impl Database {
         };
 
         let filter = if let Some(h) = query.hours.filter(|&h| h > 0) {
-            // hours 已验证 > 0，format! 是构建 SQL 字面量的唯一途径
-            let time_expr = sea_orm::sea_query::Expr::cust(format!(
-                "REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= datetime('now', '-{} hours')", h
-            ));
-            filter.add(time_expr)
+            // 096-W2：预计算 UTC cutoff 做裸列 gte 绑定（093 同款口径）——
+            // 替代 REPLACE(REPLACE(...)) >= datetime('now',...) 旧写法，started_at 索引保持命中
+            filter.and(execution_records::Column::StartedAt.gte(crate::models::utc_timestamp_minus_hours(h)))
         } else {
             filter
         };
@@ -1013,15 +1011,19 @@ impl Database {
         let backend = self.conn.get_database_backend();
         // default 30 days = 720 hours (matches frontend)
         let hours = hours.unwrap_or(720);
+        // 096-W2：cutoff 预计算为 T/Z ISO 字面量（与存储格式同构，字典序=时间序），
+        // 供各统计查询 `started_at >= ?` 参数绑定——裸列比较保持索引命中。
+        let time_cutoff = crate::models::utc_timestamp_minus_hours(hours);
+        // 热力图固定范围：当年 1 月 1 日起（不受 hours 过滤影响），同构 T/Z 字面量
+        let heatmap_cutoff = format!("{}-01-01T00:00:00.000Z", chrono::Utc::now().format("%Y"));
+        // skills 统计仍消费 datetime('now') 表达式（存量口径，精度退化问题见 ctx 字段注释）
         let time_filter = format!("datetime('now', '-{} hours')", hours);
-        // 热力图使用固定时间范围：当年1月1日到12月31日，不受过滤条件影响
-        // 热力图固定用字符串字面量，无需 format! 拼接
-        let heatmap_filter = "datetime(strftime('%Y', 'now') || '-01-01 00:00:00')".to_string();
         crate::db::dashboard::DashboardQueryContext {
             conn: &self.conn,
             backend,
+            time_cutoff,
+            heatmap_cutoff,
             time_filter,
-            heatmap_filter,
         }
     }
 
@@ -2313,6 +2315,47 @@ mod center_aggregate_tests {
         let map = db.get_consecutive_failure_counts_for_todos(&[t]).await.unwrap();
         // 计数 0 时 todo 不在 map 中（GROUP BY 不产生 0 行），unwrap_or(0) 表达「无连续失败」
         assert_eq!(map.get(&t).copied().unwrap_or(0), 0, "最近一条 success 应计数 0");
+    }
+
+    /// 096-W2：get_execution_records 的 hours 过滤（参数化 `started_at >= ?`）±1 小时边界。
+    /// 数据用生产契约的 T/Z ISO 格式（应用层 utc_timestamp 写入；秒级为触发器兜底形态）。
+    #[tokio::test]
+    async fn test_get_execution_records_hours_filter_boundary() {
+        let db = fresh_db().await;
+        let t = seed_todo(&db, "T").await;
+        // 23 小时前（24h 窗口内，应命中）与 25 小时前（窗口外，应排除）
+        db.exec(&format!(
+            "INSERT INTO execution_records (todo_id, status, trigger_type, started_at) \
+             VALUES ({t}, 'success', 'manual', strftime('%Y-%m-%dT%H:%M:%SZ','now','-23 hours'))"
+        ))
+        .await
+        .expect("insert recent exec");
+        db.exec(&format!(
+            "INSERT INTO execution_records (todo_id, status, trigger_type, started_at) \
+             VALUES ({t}, 'success', 'manual', strftime('%Y-%m-%dT%H:%M:%SZ','now','-25 hours'))"
+        ))
+        .await
+        .expect("insert old exec");
+
+        let query = |hours: Option<u32>| ExecutionRecordQuery {
+            todo_id: Some(t),
+            step_id: None,
+            workspace_id: None,
+            limit: 20,
+            offset: 0,
+            status: None,
+            hours,
+        };
+        // 不过滤 → 两条全返回（对照组，确认排除效果来自 hours 而非其他条件）
+        let (_, total_all) = db.get_execution_records(query(None)).await.expect("query all");
+        assert_eq!(total_all, 2);
+        // hours=24 → 仅窗口内一条；total 与分页数据一致（过滤下推 SQL 而非内存裁剪）
+        let (records, total) = db.get_execution_records(query(Some(24))).await.expect("query 24h");
+        assert_eq!(total, 1, "25 小时前的记录应被 24h 窗口排除");
+        assert_eq!(records.len(), 1);
+        // hours=0 按契约视为不过滤（filter(|&h| h > 0) 短路）
+        let (_, total_zero) = db.get_execution_records(query(Some(0))).await.expect("query h0");
+        assert_eq!(total_zero, 2, "hours=0 应退化为不过滤");
     }
 
     /// 连续失败计数：全部 failed（无非 failed 断点）→ 计数全部。

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -885,11 +885,9 @@ impl Database {
             .filter(loop_executions::Column::LoopId.eq(loop_id))
             .order_by_desc(loop_executions::Column::StartedAt);
         if let Some(h) = hours.filter(|&h| h > 0) {
-            // hours 已验证 > 0，format! 是构建 SQL 字面量的唯一途径
-            let time_expr = sea_orm::sea_query::Expr::cust(format!(
-                "REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= datetime('now', '-{} hours')", h
-            ));
-            query = query.filter(time_expr);
+            // 096-W2：预计算 UTC cutoff 做裸列 gte 绑定（093 同款口径）——
+            // 替代 REPLACE(REPLACE(...)) >= datetime('now',...) 旧写法，started_at 索引保持命中
+            query = query.filter(loop_executions::Column::StartedAt.gte(crate::models::utc_timestamp_minus_hours(h)));
         }
         query.limit(limit).offset(offset).all(&self.conn).await
     }
@@ -1617,10 +1615,11 @@ impl Database {
         workspace_id: Option<i64>,
         hours: Option<u32>,
     ) -> Result<(i64, i64, i64), sea_orm::DbErr> {
-        use sea_orm::{ConnectionTrait, DbBackend, Statement};
+        use sea_orm::ConnectionTrait;
         let ws_filter = workspace_id
             .map(|id| format!("AND l.workspace_id = {}", id))
             .unwrap_or_default();
+        let (time_clause, cutoff) = Self::loop_exec_time_filter(hours, "le.started_at");
         let sql = format!(
             "SELECT \
             COUNT(*) AS total, \
@@ -1629,12 +1628,12 @@ impl Database {
             FROM loop_executions le \
             JOIN loops l ON l.id = le.loop_id \
             WHERE {} {}",
-            Self::loop_exec_time_filter(hours, "le.started_at"),
+            time_clause,
             ws_filter
         );
         let row = self
             .conn
-            .query_one(Statement::from_string(DbBackend::Sqlite, sql))
+            .query_one(Self::loop_stats_statement(sql, cutoff))
             .await?
             .ok_or_else(|| sea_orm::DbErr::RecordNotFound("loop exec summary returned no rows".into()))?;
         Ok((
@@ -1650,10 +1649,11 @@ impl Database {
         workspace_id: Option<i64>,
         hours: Option<u32>,
     ) -> Result<Vec<crate::models::LoopTriggerTypeCount>, sea_orm::DbErr> {
-        use sea_orm::{ConnectionTrait, DbBackend, Statement};
+        use sea_orm::ConnectionTrait;
         let ws_filter = workspace_id
             .map(|id| format!("AND l.workspace_id = {}", id))
             .unwrap_or_default();
+        let (time_clause, cutoff) = Self::loop_exec_time_filter(hours, "le.started_at");
         let sql = format!(
             "SELECT \
             COALESCE(le.trigger_type, 'manual') AS trigger_type, \
@@ -1665,12 +1665,12 @@ impl Database {
             WHERE {} {} \
             GROUP BY COALESCE(le.trigger_type, 'manual') \
             ORDER BY count DESC",
-            Self::loop_exec_time_filter(hours, "le.started_at"),
+            time_clause,
             ws_filter
         );
         let rows = self
             .conn
-            .query_all(Statement::from_string(DbBackend::Sqlite, sql))
+            .query_all(Self::loop_stats_statement(sql, cutoff))
             .await?;
         let mut out = Vec::with_capacity(rows.len());
         for row in rows {
@@ -1692,12 +1692,13 @@ impl Database {
         workspace_id: Option<i64>,
         hours: Option<u32>,
     ) -> Result<(u64, u64, f64), sea_orm::DbErr> {
-        use sea_orm::{ConnectionTrait, DbBackend, Statement};
+        use sea_orm::ConnectionTrait;
         // le.started_at 用于时间过滤;LEFT JOIN 保证无 step/record 的 execution 行不丢失,
         // 其 token 经 COALESCE 兜底为 0。
         let ws_filter = workspace_id
             .map(|id| format!("AND l.workspace_id = {}", id))
             .unwrap_or_default();
+        let (time_clause, cutoff) = Self::loop_exec_time_filter(hours, "le.started_at");
         let sql = format!(
             "SELECT \
             COALESCE(SUM(COALESCE(json_extract(er.usage, '$.input_tokens'), 0)), 0) AS input_tokens, \
@@ -1708,12 +1709,12 @@ impl Database {
             LEFT JOIN loop_step_executions lse ON lse.loop_execution_id = le.id \
             LEFT JOIN execution_records er ON er.id = lse.execution_record_id \
             WHERE {} {}",
-            Self::loop_exec_time_filter(hours, "le.started_at"),
+            time_clause,
             ws_filter
         );
         let row = self
             .conn
-            .query_one(Statement::from_string(DbBackend::Sqlite, sql))
+            .query_one(Self::loop_stats_statement(sql, cutoff))
             .await?
             .ok_or_else(|| sea_orm::DbErr::RecordNotFound("loop token totals returned no rows".into()))?;
         // 用 i64 中转再 as u64:token 量级远低于 i64 上限,SQLite 整数返回 i64 最稳妥。
@@ -1723,15 +1724,35 @@ impl Database {
         Ok((input as u64, output as u64, cost))
     }
 
-    /// 构建 loop_executions 时间过滤 SQL 片段(impl 关联函数,无 self)。
-    /// hours=None/0 → 全时段("1=1");否则按 started_at 文本列回退 N 小时。
-    /// col 允许传别名前缀(如 "le.started_at"),适配 JOIN 查询的表别名。
-    fn loop_exec_time_filter(hours: Option<u32>, col: &str) -> String {
+    /// 构建 loop_executions 时间过滤 SQL 片段与配套 cutoff 值（impl 关联函数，无 self）。
+    ///
+    /// 096-W2 参数绑定版契约：
+    /// - hours=Some(h>0) → (`"{col} >= ?"`, Some(cutoff))：调用点把 cutoff 经
+    ///   `Statement::from_sql_and_values` 绑定——裸列比较保持 started_at 索引命中，
+    ///   替代 REPLACE(REPLACE(...)) >= datetime('now',...) 旧写法；
+    /// - hours=None/0 → (`"1=1"`, None)：全时段占位，无参数绑定。
+    ///
+    /// col 允许传别名前缀（如 "le.started_at"），适配 JOIN 查询的表别名。
+    fn loop_exec_time_filter(hours: Option<u32>, col: &str) -> (String, Option<String>) {
         match hours.filter(|&h| h > 0) {
-            Some(h) => format!(
-                "REPLACE(REPLACE({col}, 'T', ' '), 'Z', '') >= datetime('now', '-{h} hours')"
+            Some(h) => (
+                format!("{col} >= ?"),
+                Some(crate::models::utc_timestamp_minus_hours(h)),
             ),
-            None => "1=1".to_string(),
+            None => ("1=1".to_string(), None),
+        }
+    }
+
+    /// 按可选 cutoff 构造 Statement：有值走参数绑定（`?` 占位），无值退化为纯文本。
+    /// loop 统计三个 raw SQL 查询共用，避免各自重复 match 分支。
+    fn loop_stats_statement(sql: String, cutoff: Option<String>) -> sea_orm::Statement {
+        match cutoff {
+            Some(c) => sea_orm::Statement::from_sql_and_values(
+                sea_orm::DbBackend::Sqlite,
+                sql,
+                vec![c.into()],
+            ),
+            None => sea_orm::Statement::from_string(sea_orm::DbBackend::Sqlite, sql),
         }
     }
 
@@ -2567,6 +2588,28 @@ mod loop_stats_tests {
         assert_eq!(stats.total_executions, 0);
         assert!(stats.trigger_type_distribution.is_empty());
         assert_eq!(stats.total_input_tokens, 0);
+    }
+
+    /// 096-W2：loop_exec_time_filter 参数绑定版契约——
+    /// Some(h>0) 返回 `?` 占位片段 + cutoff 值（T/Z ISO 格式），None/0 返回 1=1 占位且无绑定值。
+    #[test]
+    fn test_loop_exec_time_filter_param_binding_contract() {
+        // hours=None → 全时段占位，无参数（调用点据此走纯文本 Statement）
+        let (clause, cutoff) = Database::loop_exec_time_filter(None, "le.started_at");
+        assert_eq!(clause, "1=1");
+        assert!(cutoff.is_none());
+        // hours=Some(0) → 与 None 同义（filter(|&h| h > 0) 短路）
+        let (clause, cutoff) = Database::loop_exec_time_filter(Some(0), "le.started_at");
+        assert_eq!(clause, "1=1");
+        assert!(cutoff.is_none());
+        // hours=Some(24) → 裸列占位片段 + T/Z ISO cutoff（字符串序=时间序的格式契约）
+        let (clause, cutoff) = Database::loop_exec_time_filter(Some(24), "le.started_at");
+        assert_eq!(clause, "le.started_at >= ?");
+        let cutoff = cutoff.expect("Some(h>0) 必须给出 cutoff");
+        assert!(
+            cutoff.ends_with('Z') && cutoff.contains('T'),
+            "cutoff 应为 T/Z ISO 格式（与存储格式同构），实际: {cutoff}"
+        );
     }
 }
 

--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -1928,12 +1928,14 @@ impl Database {
         workspace_id: Option<i64>,
     ) -> Result<Vec<crate::models::RecentCompletedTodo>, sea_orm::DbErr> {
         let backend = self.conn.get_database_backend();
-        let time_filter = format!("datetime('now', '-{} hours')", hours);
+        // 096-W2：预计算 UTC cutoff 做裸列参数绑定（`er.finished_at >= ?`）——
+        // 替代 REPLACE(REPLACE(...)) >= datetime('now',...) 旧写法，消除列上函数调用
+        let time_cutoff = crate::models::utc_timestamp_minus_hours(hours);
 
         let mut conditions = vec![
             "t.deleted_at IS NULL".to_string(),
             "t.status IN ('completed', 'failed')".to_string(),
-            format!("REPLACE(REPLACE(er.finished_at, 'T', ' '), 'Z', '') >= {}", time_filter),
+            "er.finished_at >= ?".to_string(),
         ];
         // 按 workspace_id 过滤：仅显示该工作空间下的事项
         if let Some(wid) = workspace_id {
@@ -1958,7 +1960,12 @@ impl Database {
 
         let rows = self
             .conn
-            .query_all(Statement::from_string(backend, sql))
+            .query_all(Statement::from_sql_and_values(
+                backend,
+                sql,
+                // 与 conditions 中唯一的 `er.finished_at >= ?` 占位一一对应
+                vec![time_cutoff.into()],
+            ))
             .await?;
 
         let todo_ids: Vec<i64> = rows
@@ -2923,6 +2930,51 @@ mod todo_center_tests {
             .unwrap();
         assert_eq!(items2.len(), 1);
         assert_eq!(page2, 3, "旧 /todos 分页同样返回有效页码（评审 F2）");
+    }
+
+    /// 096-W2：get_recent_completed_todos 的 hours 过滤（参数化 `er.finished_at >= ?`）±1 小时边界。
+    /// 数据用生产契约的 T/Z ISO 格式；函数语义是「每 todo 取最新一条执行记录」。
+    #[tokio::test]
+    async fn test_get_recent_completed_todos_hours_boundary() {
+        let db = fresh_db().await;
+        // todo_recent：最新执行完成于 23 小时前（24h 窗口内，应命中）
+        let recent = seed_todo(&db, "最近完成").await;
+        // todo_old：最新执行完成于 25 小时前（窗口外，应排除）
+        let old = seed_todo(&db, "较早完成").await;
+        // 两 todo 状态都置为 completed（函数只统计 completed/failed 终态）
+        db.exec("UPDATE todos SET status = 'completed'")
+            .await
+            .expect("mark completed");
+        db.exec(&format!(
+            "INSERT INTO execution_records (todo_id, status, trigger_type, started_at, finished_at) \
+             VALUES ({recent}, 'success', 'manual', \
+             strftime('%Y-%m-%dT%H:%M:%SZ','now','-23 hours','-5 minutes'), \
+             strftime('%Y-%m-%dT%H:%M:%SZ','now','-23 hours'))"
+        ))
+        .await
+        .expect("insert recent record");
+        db.exec(&format!(
+            "INSERT INTO execution_records (todo_id, status, trigger_type, started_at, finished_at) \
+             VALUES ({old}, 'success', 'manual', \
+             strftime('%Y-%m-%dT%H:%M:%SZ','now','-25 hours','-5 minutes'), \
+             strftime('%Y-%m-%dT%H:%M:%SZ','now','-25 hours'))"
+        ))
+        .await
+        .expect("insert old record");
+
+        let items = db
+            .get_recent_completed_todos(24, None)
+            .await
+            .expect("query recent completed");
+        assert_eq!(items.len(), 1, "25 小时前完成的应被 24h 窗口排除");
+        assert_eq!(items[0].title, "最近完成");
+
+        // 窗口放大到 26 小时 → 两条都命中（验证排除效果来自 hours 参数而非其他条件）
+        let items = db
+            .get_recent_completed_todos(26, None)
+            .await
+            .expect("query wider window");
+        assert_eq!(items.len(), 2);
     }
 }
 


### PR DESCRIPTION
## 实现了什么

096 分步方案 **W2-PR1：`REPLACE(REPLACE(...))` 时间过滤 hack 清除**（依据 `docs/design/096-代码质量重构分步方案.md`，实证见扫描报告 A5 项）。W2 波次首个 PR。

execution_records/loop_executions 的「最近 N 小时」过滤原用 `REPLACE(REPLACE(started_at, 'T', ' '), 'Z', '') >= datetime('now', '-N hours')`——**列上套函数使索引失效**。本 PR 将 13 处全部替换为 `started_at >= ?` 参数绑定（cutoff 由既有 `models::utc_timestamp_minus_hours` 预计算，093 已确立的口径）。

## 改动面（13 处 + 3 形态）

| 形态 | 位置 | 改法 |
|---|---|---|
| SeaORM `Expr::cust` 拼接 ×2 | `execution.rs` get_execution_records、`loop_.rs` list_loop_executions | `Column::StartedAt.gte(cutoff)` 绑定（todo.rs:630 已有同款先例） |
| raw SQL 片段函数 ×1（3 调用点） | `loop_.rs::loop_exec_time_filter` | 改返回 `(片段, Option<cutoff>)`，调用点经 `from_sql_and_values` 绑定；新增 `loop_stats_statement` 收口三分支 |
| dashboard raw SQL ×9 | `dashboard.rs` 8 处 time_filter + 1 处 heatmap | `DashboardQueryContext` 新增 `time_cutoff`/`heatmap_cutoff` 字段 + `stmt_with_time_cutoff` 统一入口；9 条 SQL 静态化、参数绑定 |
| todo raw SQL ×1 | `todo.rs` get_recent_completed_todos（finished_at 列） | 同上参数绑定 |

## 关键实现点

- **格式契约**：cutoff 为 T/Z 毫秒级 ISO（与存储格式同构，字典序=时间序）；093 已论证秒级/毫秒级混比误差 <1s，对 hours 级过滤可忽略。
- **行为等价**：`hours=None/0` 退化为不过滤（1=1 占位）等既有语义全部保留；skills 统计 4 处消费的 `time_filter`（datetime 表达式）**原样保留**——其精度退化为存量行为，不在本 PR 夹带修复（已在字段注释中标注，留待专项）。
- **删除字段**：`heatmap_filter`（唯一消费点已迁走）；`todo.rs` 的 `time_filter` 局部变量。

## 测试与验证结果

- **新增 5 项测试**：execution list hours ±1h 边界（含 hours=0 退化）、todo 最近完成 ±1h 边界（含 26h 放宽对照）、dashboard fetch_recent cutoff 边界、`loop_exec_time_filter` 参数绑定契约、**EXPLAIN QUERY PLAN 索引命中断言**（防回潮）。
- `cargo clippy --all-targets -- -D warnings`：**零告警**。
- `cargo test` 全量：**1670 通过**；唯一失败 `git_sync::test_sync_repo_restores_deleted_file` 为 main 存量失败（git stash 对照已确认），与本 PR 无关。
- **EXPLAIN 实证**（dev 数据库）：
  - 旧：`SCAN execution_records USING COVERING INDEX idx_execution_records_started_at`（索引仅当覆盖表，全扫）
  - 新：`SEARCH execution_records USING COVERING INDEX idx_execution_records_started_at (started_at>?)`（**索引范围查找真命中**）

## 已知限制

- skills 统计的 `time_filter` 精度退化（空格 vs T 格式比较）为存量行为，本 PR 未动，建议后续专项评估。
- 回退方式：单 PR revert。
