### PR TITLE
refactor(096-W2-3): 五元组参数对象化——ExecutionDeps 收敛 7 函数签名（allow 清零）

### DIFF
--- a/backend/src/executor_service/auto_review.rs
+++ b/backend/src/executor_service/auto_review.rs
@@ -18,13 +18,12 @@
 //! 为避免与 `run_todo_execution` 的内部逻辑产生循环引用，这里用一个简化的
 //! 同步路径：等 `run_todo_execution` 启动后创建的 record 进入终态，再解析 rating 回填。
 
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
 use tokio::sync::broadcast;
 
 use crate::db::Database;
 use crate::executor_service::ExecEvent;
-use crate::task_manager::TaskManager;
 
 use super::RunTodoExecutionRequest;
 
@@ -55,6 +54,7 @@ fn review_runtime() -> Option<&'static tokio::runtime::Runtime> {
 /// 同步运行自动评审。在原 todo 执行完成、update_execution_record 写入 success/failed 后调用。
 ///
 /// 参数:
+///   - `deps`: 执行链路共享依赖五元组（096-W2-PR3 参数对象化，9 参塌缩为 5 参）
 ///   - `step_review_prompt`: 环节内联评审模板正文（空 = 未设，回退环路/默认）
 ///   - `loop_review_template_id`: 环路级评审模板 ID（本参数优先于全局默认）
 ///
@@ -62,25 +62,17 @@ fn review_runtime() -> Option<&'static tokio::runtime::Runtime> {
 ///
 /// 实现: 由于 `run_auto_review_inner` 内部需要 await `run_todo_execution`（后者会
 /// 进一步 spawn）—— 整个 future 不是 Send —— 必须在独立 runtime 上 block_on。
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_auto_review(
-    db: Arc<Database>,
-    executor_registry: Arc<crate::adapters::ExecutorRegistry>,
-    tx: broadcast::Sender<ExecEvent>,
-    task_manager: Arc<TaskManager>,
-    config: Arc<std::sync::RwLock<crate::config::Config>>,
+    deps: super::types::ExecutionDeps,
     todo_id: i64,
     record_id: i64,
     step_review_prompt: Option<String>,
     loop_review_template_id: Option<i64>,
 ) {
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-    let db_c = db.clone();
-    let er_c = executor_registry.clone();
-    let tx_c = tx.clone();
-    let tx_outer = tx.clone();
-    let tm_c = task_manager.clone();
-    let cfg_c = config.clone();
+    // deps 整体 clone 进独立线程（Arc 字段廉价），tx 单独留一份给外层失败标记
+    let deps_c = deps.clone();
+    let tx_outer = deps.tx.clone();
     let runtime = match review_runtime() {
         Some(r) => r,
         None => {
@@ -90,7 +82,7 @@ pub(crate) async fn run_auto_review(
     };
     std::thread::spawn(move || {
         let result = runtime.block_on(run_auto_review_inner(
-            db_c, er_c, tx_c, tm_c, cfg_c,
+            deps_c,
             todo_id, record_id,
             step_review_prompt, loop_review_template_id,
         ));
@@ -103,14 +95,14 @@ pub(crate) async fn run_auto_review(
                 "auto-review for todo #{} record #{} failed: {}",
                 todo_id, record_id, e
             );
-            mark_review_failed(&db, &tx_outer, record_id, todo_id).await;
+            mark_review_failed(&deps.db, &tx_outer, record_id, todo_id).await;
         }
         Err(_) => {
             tracing::warn!(
                 "auto-review thread dropped reply for todo #{} record #{}",
                 todo_id, record_id
             );
-            mark_review_failed(&db, &tx_outer, record_id, todo_id).await;
+            mark_review_failed(&deps.db, &tx_outer, record_id, todo_id).await;
         }
     }
 }
@@ -152,19 +144,21 @@ async fn mark_review_skipped(
 /// auto_review 的内部实现：在独立 runtime 上同步跑评审实例并轮询终态。
 ///
 /// 拆分为 7 步独立 helper，每个 ≤ 30 行；任一步提前返回前都正确清理状态。
-#[allow(clippy::too_many_arguments)]
 async fn run_auto_review_inner(
-    db: Arc<Database>,
-    executor_registry: Arc<crate::adapters::ExecutorRegistry>,
-    tx: broadcast::Sender<ExecEvent>,
-    task_manager: Arc<TaskManager>,
-    config: Arc<std::sync::RwLock<crate::config::Config>>,
+    // 096-W2-PR3：五元组依赖已对象化（owned——本 future 被 move 进独立 runtime 线程）
+    deps: super::types::ExecutionDeps,
     todo_id: i64,
     record_id: i64,
     // 设计 034：环节内联评审模板正文（空 = 未设，回退环路/默认）
     step_review_prompt: Option<String>,
     loop_review_template_id: Option<i64>,
 ) -> Result<(), String> {
+    // 从 deps 解出与原签名同名的 owned 局部量（Arc::clone 廉价，仅原子计数自增），
+    // 保持函数体零改动（093-B3 既有范式）；
+    // executor_registry/task_manager/config 在 execute_review_instance 调用点收口后
+    // 本函数体内不再直接使用，故不解包（避免死局部量）
+    let db = deps.db.clone();
+    let tx = deps.tx.clone();
     // 1) 加载原 todo + 校验是否需要跳过 review。
     let original = load_original_todo(&db, todo_id).await?;
     if !should_review_todo(&original) {
@@ -193,11 +187,7 @@ async fn run_auto_review_inner(
 
     // 6) 执行评审实例（创建 todo_type=2 的评审实例 todo + 复用 run_todo_execution）。
     let review_record_id = match execute_review_instance(
-        &db,
-        &executor_registry,
-        &tx,
-        &task_manager,
-        &config,
+        &deps,
         &original,
         owning_template_id,
         &owning_template_name,
@@ -368,18 +358,21 @@ async fn mark_review_pending(
 ///
 /// 参数 `owning_template_id`：环节内联模板用 `INLINE_REVIEW_TEMPLATE_ID`（0），
 /// 查表模板用 `review_templates.id`。`owning_template_name` 供创建时写标题。
-#[allow(clippy::too_many_arguments)]
 async fn execute_review_instance(
-    db: &Arc<Database>,
-    executor_registry: &Arc<crate::adapters::ExecutorRegistry>,
-    tx: &broadcast::Sender<ExecEvent>,
-    task_manager: &Arc<TaskManager>,
-    config: &Arc<std::sync::RwLock<crate::config::Config>>,
+    // 096-W2-PR3：五元组依赖已对象化（借用现场按引用接参）
+    deps: &super::types::ExecutionDeps,
     original: &crate::models::Todo,
     owning_template_id: i64,
     owning_template_name: &str,
     composed_prompt: String,
 ) -> Result<i64, String> {
+    // 从 deps 解出与原签名同名的 owned 局部量（Arc::clone 廉价，仅原子计数自增），
+    // 保持函数体零改动（093-B3 既有范式）
+    let db = deps.db.clone();
+    let executor_registry = deps.executor_registry.clone();
+    let tx = deps.tx.clone();
+    let task_manager = deps.task_manager.clone();
+    let config = deps.config.clone();
     // 复用策略：同一 review_template 全局共享一条评审实例 todo,
     // 避免「每次评审都新建 todo」把 todos 表刷成同一评审 N 份。
     // - 已有 → 重置 prompt/executor/status（保留 id 和 execution_records 关联）

--- a/backend/src/executor_service/completion.rs
+++ b/backend/src/executor_service/completion.rs
@@ -15,11 +15,10 @@ use std::sync::Arc;
 
 use tokio::sync::broadcast;
 
-use crate::adapters::{CodeExecutor, ExecutorRegistry};
+use crate::adapters::CodeExecutor;
 use crate::db::Database;
 use crate::executor_service::ExecEvent;
 use crate::models::{ExecutionUsage, ParsedLogEntry};
-use crate::task_manager::TaskManager;
 
 use super::auto_review::run_auto_review;
 use super::log_capture::send_event;
@@ -421,11 +420,8 @@ pub(crate) async fn finalize_normal_completion(
     //   - trigger_type != "auto_review" 避免评审实例本身反向触发评审
     //   - 正常执行 (success/failed), 不是被中断
     maybe_run_auto_review(
-        &db,
-        &executor_registry,
-        &tx,
-        &task_manager,
-        &config,
+        // 096-W2-PR3：五元组依赖由 ctx 提取（execution_deps 方法），不再逐字段解包传递
+        &ctx.execution_deps(),
         todo_id,
         record_id,
         &trigger_type,
@@ -608,16 +604,12 @@ async fn broadcast_ticker_status(
 /// 处理成功后移除已处理 ID（保留期间新到达的记录），
 /// 若队列仍有剩余则继续处理下一批。
 /// 失败时保留队列不删除，退出循环避免死循环。
-#[allow(clippy::too_many_arguments)]
 fn spawn_flush_worker(
     ws_id: i64,
     debounce_secs: i64,
     debounce_count: i64,
-    db: Arc<Database>,
-    executor_registry: Arc<ExecutorRegistry>,
-    tx: broadcast::Sender<ExecEvent>,
-    task_manager: Arc<TaskManager>,
-    config: Arc<std::sync::RwLock<crate::config::Config>>,
+    // 096-W2-PR3：五元组依赖已对象化（ExecutionDeps），签名从 9 参塌缩为 5 参
+    deps: super::types::ExecutionDeps,
     refreshing_workspaces: Arc<tokio::sync::Mutex<std::collections::HashSet<i64>>>,
 ) {
     tokio::spawn(async move {
@@ -630,7 +622,7 @@ fn spawn_flush_worker(
         // 循环处理，直到队列为空或某次处理失败
         loop {
             // 非破坏性读取 pending 队列（不用 take_pending_record_ids）
-            let all_record_ids = match db.get_blackboard(ws_id).await {
+            let all_record_ids = match deps.db.get_blackboard(ws_id).await {
                 Ok(Some(board)) => {
                     serde_json::from_str::<Vec<i64>>(&board.pending_record_ids).unwrap_or_default()
                 }
@@ -655,7 +647,7 @@ fn spawn_flush_worker(
             }
 
             // 广播 refreshing=true 状态（用全队列长度，让 UI 看到真实剩余量）
-            let _ = tx.send(ExecEvent::BlackboardDebounceStatus {
+            let _ = deps.tx.send(ExecEvent::BlackboardDebounceStatus {
                 workspace_id: ws_id,
                 pending_count: all_record_ids.len() as u64,
                 threshold: debounce_count as u64,
@@ -665,11 +657,11 @@ fn spawn_flush_worker(
             });
 
             let update_result = crate::services::blackboard::update_blackboard_wiki(
-                db.clone(),
-                executor_registry.clone(),
-                tx.clone(),
-                task_manager.clone(),
-                config.clone(),
+                deps.db.clone(),
+                deps.executor_registry.clone(),
+                deps.tx.clone(),
+                deps.task_manager.clone(),
+                deps.config.clone(),
                 ws_id,
                 record_ids,
             )
@@ -693,7 +685,7 @@ fn spawn_flush_worker(
         // 旧实现写死 pending_count=0，但失败时队列实际仍有残留（update_blackboard_wiki
         // 失败不调 remove_specific_pending_record_ids），下一秒 ticker 会从 DB 读回真实值，
         // 造成 UI 在 0 和真实值之间反复跳；这里一次性广播真实值，避免抖动。
-        let final_pending_count = match db.get_blackboard(ws_id).await {
+        let final_pending_count = match deps.db.get_blackboard(ws_id).await {
             Ok(Some(board)) => {
                 serde_json::from_str::<Vec<i64>>(&board.pending_record_ids)
                     .map(|v| v.len() as u64)
@@ -703,7 +695,7 @@ fn spawn_flush_worker(
         };
 
         // 广播 refreshing=false 状态（携带真实 pending_count）
-        let _ = tx.send(ExecEvent::BlackboardDebounceStatus {
+        let _ = deps.tx.send(ExecEvent::BlackboardDebounceStatus {
             workspace_id: ws_id,
             pending_count: final_pending_count,
             threshold: debounce_count as u64,
@@ -725,7 +717,7 @@ fn spawn_flush_worker(
                 "worker 退出，队列仍有 {} 条残留，重启防抖 timer 触发下一轮: workspace_id={}",
                 final_pending_count, ws_id
             );
-            crate::services::blackboard_debouncer::restart_timer(ws_id, &db).await;
+            crate::services::blackboard_debouncer::restart_timer(ws_id, &deps.db).await;
         }
 
         // 释放 per-workspace 互斥锁
@@ -738,14 +730,10 @@ fn spawn_flush_worker(
 ///
 /// 若 workspace 已有 worker 运行中（refreshing_workspaces 包含），
 /// 不丢弃消息：worker 内部循环会自然处理新到达的记录。
-#[allow(clippy::too_many_arguments)]
 async fn handle_flush_msg(
     msg: crate::services::blackboard_debouncer::BlackboardFlushMsg,
-    db: &Arc<Database>,
-    executor_registry: &Arc<ExecutorRegistry>,
-    tx: &broadcast::Sender<ExecEvent>,
-    task_manager: &Arc<TaskManager>,
-    config: &Arc<std::sync::RwLock<crate::config::Config>>,
+    // 096-W2-PR3：五元组依赖已对象化（ExecutionDeps），借用现场按引用接参
+    deps: &super::types::ExecutionDeps,
     refreshing_workspaces: &Arc<tokio::sync::Mutex<std::collections::HashSet<i64>>>,
     known_workspaces: &mut Vec<i64>,
 ) {
@@ -754,7 +742,7 @@ async fn handle_flush_msg(
     // 优先检查黑板功能总开关：关闭时直接返回，不执行任何 wiki 维护操作。
     // 这是第二道防线（第一道在 push_pending_record 阻止新记录入队）：
     // 即使 timer 在用户禁用前已调度、在禁用后自然到期发送了 flush 消息，也在此拦截。
-    match db.get_blackboard_config(ws_id).await {
+    match deps.db.get_blackboard_config(ws_id).await {
         Ok(Some(cfg)) if !cfg.enabled => {
             tracing::debug!(
                 "黑板功能已禁用，跳过 flush 消息处理: workspace_id={}",
@@ -799,17 +787,14 @@ async fn handle_flush_msg(
     }
 
     // 读取 per-workspace 防抖配置
-    let (debounce_secs, debounce_count) = get_workspace_debounce(db, ws_id).await;
+    let (debounce_secs, debounce_count) = get_workspace_debounce(&deps.db, ws_id).await;
 
     spawn_flush_worker(
         ws_id,
         debounce_secs,
         debounce_count,
-        db.clone(),
-        executor_registry.clone(),
-        tx.clone(),
-        task_manager.clone(),
-        config.clone(),
+        // spawn move 闭包需要 owned deps，Arc 字段克隆廉价
+        deps.clone(),
         refreshing_workspaces.clone(),
     );
 }
@@ -823,11 +808,8 @@ async fn handle_flush_msg(
 /// 实现工作空间隔离。
 pub async fn blackboard_flush_listener(
     mut rx: tokio::sync::mpsc::Receiver<crate::services::blackboard_debouncer::BlackboardFlushMsg>,
-    db: Arc<Database>,
-    executor_registry: Arc<ExecutorRegistry>,
-    tx: broadcast::Sender<ExecEvent>,
-    task_manager: Arc<TaskManager>,
-    config: Arc<std::sync::RwLock<crate::config::Config>>,
+    // 096-W2-PR3：五元组依赖已对象化（ExecutionDeps），6 参塌缩为 2 参
+    deps: super::types::ExecutionDeps,
 ) {
     // 每秒 ticker 用于推送状态
     let mut ticker = tokio::time::interval(tokio::time::Duration::from_secs(1));
@@ -846,7 +828,7 @@ pub async fn blackboard_flush_listener(
     // 导致残留队列永久卡死。启动时统一检查所有 blackboard，若有非空 pending 队列
     // 则重启 timer，让它们在 debounce_secs 后重新触发 flush。
     {
-        let rescan_timer = db.clone();
+        let rescan_timer = deps.db.clone();
         tokio::spawn(async move {
             match rescan_timer.get_all_blackboards().await {
                 Ok(boards) => {
@@ -878,7 +860,7 @@ pub async fn blackboard_flush_listener(
             // 每秒 ticker：广播所有已知 workspace 的状态
             _ = ticker.tick() => {
                 broadcast_ticker_status(
-                    &db, &tx, &mut known_workspaces, &refreshing_workspaces,
+                    &deps.db, &deps.tx, &mut known_workspaces, &refreshing_workspaces,
                 ).await;
             }
 
@@ -887,7 +869,7 @@ pub async fn blackboard_flush_listener(
                 match msg {
                     Some(msg) => {
                         handle_flush_msg(
-                            msg, &db, &executor_registry, &tx, &task_manager, &config,
+                            msg, &deps,
                             &refreshing_workspaces, &mut known_workspaces,
                         ).await;
                     }
@@ -903,13 +885,9 @@ pub async fn blackboard_flush_listener(
 /// 设计 034 统一路径：所有 loop_stage 步骤（无论 min_rating 是否有值）都走统一评审，
 /// 查出 step 内联 `review_prompt` 和所属 loop 的 `review_template_id` 传给
 /// `run_auto_review`，由 `resolve_review_template` 实现三级回退。
-#[allow(clippy::too_many_arguments)]
 async fn maybe_run_auto_review(
-    db: &Arc<Database>,
-    executor_registry: &Arc<crate::adapters::ExecutorRegistry>,
-    tx: &broadcast::Sender<ExecEvent>,
-    task_manager: &Arc<TaskManager>,
-    config: &Arc<std::sync::RwLock<crate::config::Config>>,
+    // 096-W2-PR3：五元组依赖已对象化（ExecutionDeps），借用现场按引用接参
+    deps: &super::types::ExecutionDeps,
     todo_id: i64,
     record_id: i64,
     trigger_type: &str,
@@ -927,7 +905,7 @@ async fn maybe_run_auto_review(
         // loop_stage 触发：按当前 todo 反查启用中的 loop_step，取其中联的 review_prompt。
         // 一个 todo 至多被一个启用中的 step 引用，用 LIMIT 1 取首个。
         // 查询返回 None（无关联 step/step 未启用）→ auto_review 走默认模板，不阻塞评审。
-        db.find_loop_step_review_prompt_by_todo(todo_id)
+        deps.db.find_loop_step_review_prompt_by_todo(todo_id)
             .await
             .ok()       // 查询出错（如 DB 连接断开）转为 None，不阻断 auto_review 流程
             .flatten()  // 解开 Option<Option<String>> 的嵌套：外层 Option 是 Result 转换结果，
@@ -938,11 +916,7 @@ async fn maybe_run_auto_review(
     };
 
     run_auto_review(
-        db.clone(),
-        executor_registry.clone(),
-        tx.clone(),
-        task_manager.clone(),
-        config.clone(),
+        deps.clone(),
         todo_id,
         record_id,
         step_review_prompt,

--- a/backend/src/executor_service/types.rs
+++ b/backend/src/executor_service/types.rs
@@ -118,6 +118,20 @@ pub(crate) struct SpawnContext {
     pub expert_manager: Option<Arc<crate::expert::ExpertIndexManager>>,
 }
 
+impl SpawnContext {
+    /// 提取执行链路共享依赖五元组（096-W2-PR3）——
+    /// 五元组是 SpawnContext 字段的真子集，逐字段 Arc::clone 廉价（原子计数自增）。
+    pub(crate) fn execution_deps(&self) -> ExecutionDeps {
+        ExecutionDeps {
+            db: Arc::clone(&self.db),
+            executor_registry: Arc::clone(&self.executor_registry),
+            tx: self.tx.clone(),
+            task_manager: Arc::clone(&self.task_manager),
+            config: Arc::clone(&self.config),
+        }
+    }
+}
+
 /// select! 三种终态枚举，避免在三个分支里各重复「杀进程 + drain + finalize」
 /// 清理模板。child 仍由调用方持有，可继续调 kill_process_tree。
 pub(crate) enum RunOutcome {
@@ -176,4 +190,34 @@ pub(crate) struct TaskState {
     pub task_guard: crate::task_manager::TaskGuard,
     pub cancel_rx: tokio::sync::mpsc::Receiver<()>,
     pub todo: Option<crate::models::Todo>,
+}
+
+/// 执行链路共享依赖五元组（096-W2-PR3：Introduce Parameter Object）。
+///
+/// `(db, executor_registry, tx, task_manager, config)` 这组依赖在 completion 黑板
+/// 三函数、`maybe_run_auto_review`、auto_review 三函数共 7 个函数签名中原样排列出现
+/// （Data Clump 坏味道，各挂 `#[allow(too_many_arguments)]` 苟活）。聚合成对象后：
+/// - 各函数签名塌缩为 `deps: ExecutionDeps`（owned 现场）或 `&ExecutionDeps`（借用现场）；
+/// - 新增共享依赖只动本结构，不再波及 7 处签名与全部调用点。
+///
+/// 全字段 Arc 包装，clone 廉价；`Clone` derive 供 tokio::spawn move 闭包整体搬入。
+pub(crate) struct ExecutionDeps {
+    pub db: Arc<Database>,
+    pub executor_registry: Arc<ExecutorRegistry>,
+    pub tx: broadcast::Sender<ExecEvent>,
+    pub task_manager: Arc<crate::task_manager::TaskManager>,
+    pub config: Arc<std::sync::RwLock<crate::config::Config>>,
+}
+
+impl Clone for ExecutionDeps {
+    fn clone(&self) -> Self {
+        // 逐字段 Arc::clone：只增引用计数，不复制底层数据
+        Self {
+            db: Arc::clone(&self.db),
+            executor_registry: Arc::clone(&self.executor_registry),
+            tx: self.tx.clone(),
+            task_manager: Arc::clone(&self.task_manager),
+            config: Arc::clone(&self.config),
+        }
+    }
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -515,11 +515,14 @@ async fn build_app_state(
     let flush_rx = crate::services::blackboard_debouncer::init().await;
     tokio::spawn(crate::executor_service::completion::blackboard_flush_listener(
         flush_rx,
-        db.clone(),
-        executor_registry.clone(),
-        tx.clone(),
-        task_manager.clone(),
-        config.clone(),
+        // 096-W2-PR3：共享依赖五元组已对象化，调用点从 5 个实参塌缩为 1 个聚合对象
+        crate::executor_service::types::ExecutionDeps {
+            db: db.clone(),
+            executor_registry: executor_registry.clone(),
+            tx: tx.clone(),
+            task_manager: task_manager.clone(),
+            config: config.clone(),
+        },
     ));
 
     // 后台监听 todo 执行完成事件，派发给 loop_trigger_dispatcher


### PR DESCRIPTION
## 实现了什么

096 分步方案 **W2-PR3：五元组参数对象化续集**（依据 `docs/design/096-代码质量重构分步方案.md`，实证见扫描报告 B4 项）。W2 波次收尾 PR。

`(db, executor_registry, tx, task_manager, config)` 五元组在 7 个函数签名中原样排列（Data Clump 坏味道，各挂 `#[allow(clippy::too_many_arguments)]` 苟活）。本 PR 按 093-B3 已验证的 Introduce Parameter Object 手法收敛：

| 函数 | 现场形态 | 迁移后签名 |
|---|---|---|
| `spawn_flush_worker` / `blackboard_flush_listener` | owned（spawn move） | `deps: ExecutionDeps` |
| `run_auto_review` / `run_auto_review_inner` | owned（独立 runtime 线程） | `deps: ExecutionDeps` |
| `handle_flush_msg` / `maybe_run_auto_review` / `execute_review_instance` | 借用 | `deps: &ExecutionDeps` |

## 关键实现点

- **`ExecutionDeps` 定义于 `types.rs`**（093-B3 参数对象族的既有落点），逐字段 Arc，Clone 派生仅原子计数自增。
- **`SpawnContext::execution_deps()` 提取方法**：五元组恰是 SpawnContext 字段的真子集，`finalize_normal_completion` 调用点直接 `ctx.execution_deps()`，不再逐字段解包传递。
- **函数体零改动**：沿用 093-B3 既有范式——体内开头解包同名局部量；`run_auto_review_inner` 解包时发现 `executor_registry/task_manager/config` 在调用点收口后体内已无直接使用，未解包避免死局部量。
- **7 处 `#[allow(clippy::too_many_arguments)]` 全部删除**——签名参数数均降至 clippy 阈值内。
- 函数体无逻辑变化；黑板 worker/listener 的互斥、防抖、失败保留队列等语义全部保留。

## 测试与验证结果

- `cargo clippy --all-targets -- -D warnings`：**零告警**（含 needless_borrow 等细节 lint 全清）。
- `cargo test` 全量：**1670 通过**（唯一失败 `git_sync::test_sync_repo_restores_deleted_file` 为 main 存量问题，与本 PR 无关）。
- 目标文件 `too_many_arguments` allow 残留：**0**（验证标准达成）。

## 已知限制

- 下游 helper（`blackboard::update_blackboard_wiki` 等）的五元组签名不在本 PR 范围（扫描报告未列入，且跨模块影响面更大），留待后续专项评估。
- 回退方式：单 PR revert。
