### PR TITLE
fix: 飞书默认响应未绑定工作空间时提示不友好（NTD-015）

### DIFF
--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -769,6 +769,30 @@ fn executor_start_message(executor_type: &str, message_preview: &str) -> String 
     format!("⏳ {} 开始处理：{}{}", executor_type, preview, suffix)
 }
 
+/// 工作空间缺失/未绑定时的飞书错误文案，按 wid 区分两种情况：
+///
+/// - `wid == 0`：agent_bots.workspace_id 的「未绑定」哨兵值（见 db/todo.rs 的 0 哨兵约定），
+///   此时用户没做任何配置，提示应该引导去绑定而不是报「工作空间 0 不存在」这种误导性文案。
+/// - `wid > 0`：工作空间记录本身已不存在（悬空 id，如工作空间被删除），提示重新切换。
+///
+/// 两种情况都附上 /help 操作路径（工作空间页可切换工作空间 + 执行器 + 推送级别），
+/// 让用户按提示就能自助恢复，而不是停在「0 不存在」这种无法行动的报错上。
+fn workspace_missing_message(executor_type: &str, wid: i64) -> String {
+    // wid==0 是未绑定哨兵：报「不存在」会把用户引向错误方向，必须明确说「还没绑定」
+    if wid == 0 {
+        executor_error_message(
+            executor_type,
+            "尚未绑定工作空间，请在飞书发送 /help，点选工作空间并切换，再选择执行器和推送范围",
+        )
+    } else {
+        // wid>0 但查不到：工作空间被删或数据不一致，引导重新切换即可
+        executor_error_message(
+            executor_type,
+            &format!("工作空间 {} 不存在（可能已被删除），请在飞书发送 /help 重新切换", wid),
+        )
+    }
+}
+
 /// 执行失败时发回飞书的错误文本，原因原样透传。
 ///
 /// 调用方传入具体原因（超时秒数 / spawn 失败 / wait 失败 / 非零退出码+输出片段），
@@ -1237,7 +1261,9 @@ impl MessageDebounce {
                 Ok(Some(pd)) => pd.path,
                 Ok(None) => {
                     tracing::warn!("[debounce] workspace {} not found", wid);
-                    send_msg(executor_error_message(executor_type, &format!("工作空间 {} 不存在", wid)));
+                    // wid=0 是未绑定哨兵、wid>0 是悬空 id，统一走友好提示（引导 /help 绑定/切换），
+                    // 不再报「工作空间 0 不存在」这种无法行动的误导性文案
+                    send_msg(workspace_missing_message(executor_type, wid));
                     return Err(None);
                 }
                 Err(e) => {
@@ -1596,6 +1622,31 @@ mod executor_feedback_tests {
     fn test_executor_error_message_format() {
         let msg = executor_error_message("pi", "执行超时（300s）");
         assert_eq!(msg, "❌ pi 执行失败：执行超时（300s）");
+    }
+
+    /// 工作空间缺失提示（wid=0 未绑定哨兵）：必须引导去绑定而非报「0 不存在」，
+    /// 因为 0 不是真实工作空间 id，用户看到「0 不存在」会一头雾水，无法行动。
+    #[test]
+    fn test_workspace_missing_message_unbound_zero() {
+        let msg = workspace_missing_message("pi", 0);
+        // 关键断言：不能出现「工作空间 0 不存在」这种误导性文案
+        assert!(!msg.contains("工作空间 0 不存在"));
+        assert!(msg.contains("尚未绑定工作空间"));
+        // 必须给出可操作的 /help 路径：工作空间页可切换工作空间 + 执行器 + 推送级别
+        assert!(msg.contains("/help"));
+        assert!(msg.contains("切换"));
+        assert!(msg.contains("执行器"));
+    }
+
+    /// 工作空间缺失提示（wid>0 悬空 id，如工作空间被删除）：保留真实 id 便于排查，
+    /// 并附重新切换的引导，让用户能自助恢复。
+    #[test]
+    fn test_workspace_missing_message_stale_id() {
+        let msg = workspace_missing_message("pi", 42);
+        // 悬空 id 要保留真实 id，方便用户/排查者知道是哪个工作空间出了问题
+        assert!(msg.contains("工作空间 42 不存在"));
+        assert!(msg.contains("/help"));
+        assert!(msg.contains("重新切换"));
     }
 
     /// 成功但无输出时的结束标志，让用户知道执行跑完了只是没产出文本，

--- a/docs/bugs/015-未绑定工作空间提示不友好/015-未绑定工作空间提示不友好-缺陷说明.md
+++ b/docs/bugs/015-未绑定工作空间提示不友好/015-未绑定工作空间提示不友好-缺陷说明.md
@@ -1,0 +1,99 @@
+# NTD-015 飞书默认响应未绑定工作空间时提示不友好 — 缺陷说明
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| HermesAgent | 2026-08-12 | 初始版本（用户反馈：未绑定工作空间时报「工作空间 0 不存在」，提示不友好） |
+
+---
+
+## 1. Bug 基本信息（Identity）
+
+- Bug ID：`NTD-015`
+- 所属系统 / 服务：`backend`（`message_debounce.rs` / `feishu_listener.rs` 默认响应链路）
+- 首次发现时间：2026-08-12
+- 发现来源：用户反馈（飞书私聊使用 pi 执行器时收到错误提示）
+- 当前状态：已确认存在
+
+## 2. Bug 是否被确认存在（Existence）
+
+- [x] Bug 已被稳定复现
+
+### 2.1 复现环境
+
+- 环境类型：开发环境（端口 18088，`~/.ntd/data.dev.db`）
+- 系统版本 / Commit ID：`main`（f83344c）
+- 相关配置项：`agent_bots.workspace_id = 0`（bot 未绑定工作空间时的默认哨兵值）
+
+## 3. 触发条件（Trigger Conditions）
+
+### 3.1 前置条件
+
+- 飞书机器人（agent_bots 记录）存在，但 `workspace_id = 0`（从未绑定工作空间）
+- 该 bot 的 workspace_settings 中 `default_response_type = 'executor'` 且 `default_response_executor = 'pi'`
+
+### 3.2 输入条件
+
+- 用户在飞书私聊中给 bot 发送任意非斜杠、非命令的普通消息（触发默认响应 executor 分支）
+
+## 4. 实际行为（Observed Behavior）
+
+- **现象**：用户收到 `❌ pi 执行失败：工作空间 0 不存在`
+- **返回结果 / 错误信息**：`❌ pi 执行失败：工作空间 0 不存在`
+- **日志**：`[debounce] workspace 0 not found`
+- **发生频率**：必现（未绑定工作空间时每次触发默认响应 executor 必现）
+
+## 5. 期望行为（Expected Behavior）
+
+- 未绑定工作空间（wid=0 或查不到）时，应提示用户去绑定工作空间，给出可操作指引：
+  「尚未绑定工作空间，请在飞书发送 /help，点选工作空间并切换，再选择执行器和推送范围」
+- 工作空间 id 非 0 但已不存在（悬空 id，如工作空间被删除）时，应提示工作空间不存在并引导重新切换
+
+## 6. 行为偏差定义（Deviation）
+
+> **在【bot 未绑定工作空间且默认响应为 executor】的触发条件下，系统实际执行了【报「工作空间 0 不存在」】，
+> 但期望执行的是【提示用户先绑定工作空间并给出 /help 操作指引】**
+
+## 7. 影响范围（Impact）
+
+- 受影响模块 / 功能：飞书默认响应 executor 分支（`handle_default_response_executor`）
+- 受影响用户或场景：首次配置飞书 bot、尚未绑定工作空间就尝试直接对话的用户
+- 风险：无数据错误 / 数据丢失 / 安全风险 / 服务不可用；仅影响提示可读性
+- 影响范围是否已知完全：是
+
+## 8. 已知边界与非问题（Non-Issues）
+
+- 以下条件下当前行为是正确的：
+  - 工作空间 id 存在且有效：正常执行，不受本 Bug 影响
+  - todo / loop 类型默认响应：走不同分支，不受本 Bug 影响
+- 以下相似现象不属于本 Bug：
+  - 前端或 API 层报「工作空间 N 不存在」（那些是正常的参数校验 400 响应，语义正确）
+  - 执行器本身超时 / 非零退出的错误提示（那些提示已包含原因，语义正确）
+- 不需要在本 Bug 中解决的问题：
+  - bot 绑定工作空间后 workspace_settings 的迁移 / 补齐（由绑定流程负责）
+
+## 9. 事实证据（Facts & Evidence）
+
+- 数据库证据（dev 库）：
+  - `agent_bots` 表：`id=1, workspace_id=1`（当前开发库已绑定），复现时用户侧 bot 为 `workspace_id=0`
+  - `project_directories` 表仅有 `id=1`（临时工作空间 /tmp），`id=0` 不存在
+- 代码证据：
+  - `backend/src/services/message_debounce.rs:1235-1241`：`get_project_directory_by_id(wid)` 返回 `Ok(None)` 时
+    发送 `工作空间 {wid} 不存在`
+  - `backend/src/db/agent_bot.rs:115-118`：`get_agent_bot_workspace_id` 直接返回 `workspace_id` 列值，
+    bot 未绑定时为列默认值 0
+
+## 10. 不确定点与待澄清事项（Uncertainties）
+
+- 无关键未决项。
+
+## 11. AI 阅读与处理约束（强制）
+
+1. 仅基于本文档中的事实
+2. 不补充隐含业务规则
+3. 不将 Bug 解释为需求变更
+4. 若 Bug 是否成立存在歧义，必须中止并请求澄清
+5. 本文档 **不是修复指令**
+
+## 12. 进入下一阶段的判定（Gate）
+
+- [x] Bug 描述完整，事实清晰，可进入分析阶段


### PR DESCRIPTION
## 背景

用户反馈：飞书 bot 未绑定工作空间时，直接对话触发默认响应 executor（pi），收到 `❌ pi 执行失败：工作空间 0 不存在`。

`0` 是 `agent_bots.workspace_id` 的「未绑定」哨兵值（NOT NULL DEFAULT 0），并非真实工作空间 id。报「工作空间 0 不存在」把用户引向错误方向——不是 0 号工作空间有问题，而是根本没绑定，用户看到后无法行动。

## 改动

**backend/src/services/message_debounce.rs**

- 新增纯函数 `workspace_missing_message(executor_type, wid)`，按 wid 区分两种情况：
  - `wid == 0`（未绑定哨兵）：提示「尚未绑定工作空间，请在飞书发送 /help，点选工作空间并切换，再选择执行器和推送范围」——直接给出可操作路径
  - `wid > 0`（悬空 id，如工作空间被删除）：保留真实 id 便于排查，附「请在飞书发送 /help 重新切换」引导
- `handle_default_response_executor` 的 `Ok(None)` 分支改用该函数

**docs/bugs/015-未绑定工作空间提示不友好/015-未绑定工作空间提示不友好-缺陷说明.md** — 新增缺陷说明（NTD-015）

## 测试

- 新增 2 个单元测试：`test_workspace_missing_message_unbound_zero` / `test_workspace_missing_message_stale_id`
- `cargo test --lib executor_feedback_tests`：15 passed
- `cargo clippy --all-targets -- -D warnings`：零告警
- `cargo test` 全量：1679 passed，0 failed

## 对应需求/缺陷

- NTD-015 缺陷说明：docs/bugs/015-未绑定工作空间提示不友好/