### PR TITLE
docs(adr005): 重构与设计模式改进报告（ADR-005）

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -121,7 +121,7 @@ AI 在执行某个功能时（编号 X），必须按以下顺序读取文档：
 | 025-M2 | 工艺管理-M2-实现总结.md | process-management-m2-summary.md |
 | 025-M3 | 工艺管理-M3-需求.md | process-management-m3-requirements.md |
 
-### docs/decisions/（4 份）
+### docs/decisions/（5 份）
 
 | 编号 | 文件 | 原名 |
 |------|------|------|
@@ -129,6 +129,7 @@ AI 在执行某个功能时（编号 X），必须按以下顺序读取文档：
 | ADR-002 | 优化建议-决策.md | OPTIMIZATION_RECOMMENDATIONS.md |
 | ADR-003 | 代码质量审计-决策.md | code-quality-audit-2026-07.md |
 | ADR-004 | 死代码扫描-决策.md | dead-code-scan.md |
+| ADR-005 | 重构与设计模式改进-决策.md | refactor-design-improvements-2026-08.md |
 
 ### docs/bugs/（2 个缺陷）
 

--- a/docs/decisions/ADR-005-重构与设计模式改进-决策.md
+++ b/docs/decisions/ADR-005-重构与设计模式改进-决策.md
@@ -5,8 +5,12 @@
 **审计范围**：后端 Rust（296 文件）+ 前端 TS/TSX（382 文件），`main` @ `91edaa9f`。
 **方法**：三套方法论并行加载——`codebase-design`（深模块/seam/删除测试）、`design-patterns`（GoF 62 + SOLID + 反模式）、`code-refactor`（Fowler 24 坏味道 + 重构手法）；由 3 个子代理分头取证（后端 / 前端 / 跨切面），每条发现均带 `文件:行号`，本文已去重合并。
 
-**严重度**：🔴 HIGH（系统性技术债 / 红线违规，每次改动都在还利息）/ 🟡 MED（特定模块的可维护性瓶颈）/ 🟢 LOW（锦上添花，顺手做）。
+**严重度**：🔴 HIGH（系统性技术债 / 红线违规，每次改动都在还利息）/ 🟠 MED（特定模块的可维护性瓶颈）/ 🟡 LOW（锦上添花，顺手做）。
 **工作量**：S（<1 人日）/ M（1–3 人日）/ L（>3 人日或需设计讨论）。
+
+> **修复进度**（每项一个 PR，复杂项先出设计文档；本报告见 #1034）：
+> - ✅ H2 — #1035（`message_debounce` 280 行编排拆 8 个 helper，待合并）
+> - ⏳ 其余 H1/H3/H4/H5、M1–M16、L1–L8 — 未开始，按下方「推进路线图」分波推进
 
 ---
 
@@ -36,30 +40,30 @@
 | **H3** | `models/mod.rs:536`(595)/`completion.rs:185 persist_agent_runs`(312)/`log_capture.rs:108`(249)/`feishu_push.rs:43`(233)/`pre_spawn.rs:482`(232)/`message_debounce.rs:158 push`(217) 等 84 个 | **Long Method**：84 个函数 >100 行（规范 50） | 🔴 | 优先拆 §1.3 所列 8 个（均非豁免场景），余者渐进 | L |
 | **H4** | `handlers/`（18/34 无测）/ `services/`（12/20）/ 前端 18/20 大组件无单测 | 测试覆盖缺口：集成测试覆盖主路径，错误分支/边界无单测 | 🔴 | 优先给大文件补关键分支单测 + 前端补 vitest | L |
 | **H5** | `ProfilesPanel.tsx:80-301`（11 处裸 `fetch`） | 绕过 axios 拦截器（无 retry、v1 前缀硬写、无 unwrap） | 🔴 | 抽 `utils/database/providers.ts` Facade | M |
-| M1 | `execution_events/impls/` 8 个 `extract()` 外壳（codex:262/kimi:165/pi:330/hermes/codewhale/atomcode/claude_code:205/codebuddy:167） | **Duplicated Code** ~130 行逐字重复 | 🟡 | **Template Method**：trait 默认 `extract` + `parse_json` 钩子 | M |
-| M2 | 13 文件 24 处 `localStorage.setItem` | 散落持久化、无 schema、键名 `ntd_`/裸键混用 | 🟡 | 抽 `usePersistentState` + `STORAGE_KEYS` 表 | M |
-| M3 | 11 处 `let cancelled=false` + `reqGenRef`/`fetchSeqRef`/`cancelledRef` 3 变体 | **Duplicated Code**：latest-wins 竞态守卫 | 🟡 | 抽 `useLatestRequest`/`useSeqRequest` hook | M |
-| M4 | `executor_service/auto_review.rs`（多处 `Result<_,String>`）↔ `services/auto_review.rs` | **Primitive Obsession**（字符串错误）+ 同名碰撞 Shotgun Surgery | 🟡 | thiserror `AutoReviewError` + 合并或改名 | S–M |
-| M5 | `db/loop_.rs`(3053)/`db/todo.rs`(3035)/`db/execution.rs`(2488) | **Large Class**：God Repository，65/56/67 个函数堆一文件 | 🟡 | 按写入/读取/聚合/关联拆子模块 | L |
-| M6 | `handlers/bundled.rs`(2965 行 / 107 函数) | **Large Class**：4 类资源 Git 同步塞一文件，已有 `Subdir` enum 未按变体分文件 | 🟡 | 按 `Subdir` 变体拆 handler | M |
-| M7 | 5 文件 6 处复制 `<a download>` 骨架（ExpertsPanel:135/ProfilesPanel:189/ImportExportModal:96,208/SkillDetailDrawer:88/SkillFilePreview:140） | `utils/download.ts` 已存在却未全员采用 | 🟡 | 改用 `downloadBlob/downloadByUrl` | S |
-| M8 | 96 处 `message.error(...err instanceof Error...)` | **Duplicated Code**：错误格式化模板 | 🟡 | 抽 `utils/notify.ts:notifyError(prefix,err)` | S |
-| M9 | 4 处 `page/pageSize/statusFilter` 四件套（SessionManager:27/TodoCenterCardView:70/TodoListPage:56/loop-studio/executions:48） | **Duplicated Code**：分页+筛选套路 | 🟡 | 抽 `usePagedQuery` hook | M |
-| M10 | `SkillMarketplace.tsx`(1216 行 / 29 useState / 5 类状态) | **God Component** | 🟡 | 拆 `<MarketToolbar>/<SkillList>/<SkillDetailDrawer>/<InstallModal>` | L |
-| M11 | 17 处 `#[allow(dead_code)]`，`adapters/pi.rs` 集中 6 处 | 死代码 / 未使用可疑项 | 🟡 | 逐条核对，删真死代码、重构 pi.rs | S |
-| M12 | `react-icons` 全仓仅 4 文件 4 处（`TfiBlackboard`/`FaSquare`） | 冗余依赖（已有 `@ant-design/icons`） | 🟡 | 剔除 `react-icons`，换 antd 图标或内联 SVG | S |
-| M13 | `process/` 下 12 处 `as unknown as Record<...>` | 类型定义不精确，靠断言绕过 | 🟡 | 补 `process`/`link`/`phase` 类型字段 | M |
-| M14 | 10 处 `eslint-disable react-hooks/exhaustive-deps` | React bug 高发区，依赖数组手维护 | 🟡 | 改写依赖数组或 `useEvent` 模式 | S |
-| M15 | `TODO_LIST_REFRESH_EVENT`/`EXECUTION_SYNC_EVENT` 共 ~11 处 `window.dispatchEvent` | 用 window 事件替代 React 数据流（Observer 误用） | 🟡 | 升级为 Context 内 `refreshToken` dispatch | M |
-| M16 | `BlackboardPage.tsx`(1286 行 / 11 子组件同文件) | 大文件无目录边界（已在当 facade 用） | 🟡 | 拆 `components/blackboard/` 目录 | M |
-| L1 | 8 个 impl 的 result 分支 `usage/tokens/cost` 提取 | 字段名不同但结构同构 | 🟢 | 依赖 M1 落地后抽 `extract_usage_from` | S |
-| L2 | `auto_review.rs:446 poll_review_to_terminal`（58 行） | Long Method | 🟢 | 拆「终态判定/rating 解析/写回」3 helper | S |
-| L3 | `todo-post/index.tsx:209` 与 `download.ts:21` 同公式 | ISO 时间戳片段重复 | 🟢 | 改用 `backupTimestamp()` | S |
-| L4 | `worktree.rs:437,439,588,590` / `custom_template.rs:52` | `GIT_AUTHOR_EMAIL`/host 黑名单字面量 | 🟢 | 抽 `const` | S |
-| L5 | `Cargo.toml` lint 阶段 2 未推进（263+ 处注释待清理） | unwrap/expect 仍在 `warn` | 🟢 | 按模块分批迁 `?`，逐步升 `deny` | L |
-| L6 | `api/bundled.ts` 与 `utils/database/*` 双入口 | 业务 API 分布不一致 | 🟢 | 按子域并入 `utils/database/` | M |
-| L7 | `App.tsx:317-549` 等 11 处 `workspace={selectedWorkspace}` | Prop Drilling（Context 已存在） | 🟢 | 消费方直接 `useApp()` 取 | S |
-| L8 | `useExecutionEvents.ts`(507 行) 类型/纯函数/hook/单例混堆 | **Large Class**（God Module） | 🟢 | 拆 `utils/sse/` + 类型文件 | M |
+| M1 | `execution_events/impls/` 8 个 `extract()` 外壳（codex:262/kimi:165/pi:330/hermes/codewhale/atomcode/claude_code:205/codebuddy:167） | **Duplicated Code** ~130 行逐字重复 | 🟠 | **Template Method**：trait 默认 `extract` + `parse_json` 钩子 | M |
+| M2 | 13 文件 24 处 `localStorage.setItem` | 散落持久化、无 schema、键名 `ntd_`/裸键混用 | 🟠 | 抽 `usePersistentState` + `STORAGE_KEYS` 表 | M |
+| M3 | 11 处 `let cancelled=false` + `reqGenRef`/`fetchSeqRef`/`cancelledRef` 3 变体 | **Duplicated Code**：latest-wins 竞态守卫 | 🟠 | 抽 `useLatestRequest`/`useSeqRequest` hook | M |
+| M4 | `executor_service/auto_review.rs`（多处 `Result<_,String>`）↔ `services/auto_review.rs` | **Primitive Obsession**（字符串错误）+ 同名碰撞 Shotgun Surgery | 🟠 | thiserror `AutoReviewError` + 合并或改名 | S–M |
+| M5 | `db/loop_.rs`(3053)/`db/todo.rs`(3035)/`db/execution.rs`(2488) | **Large Class**：God Repository，65/56/67 个函数堆一文件 | 🟠 | 按写入/读取/聚合/关联拆子模块 | L |
+| M6 | `handlers/bundled.rs`(2965 行 / 107 函数) | **Large Class**：4 类资源 Git 同步塞一文件，已有 `Subdir` enum 未按变体分文件 | 🟠 | 按 `Subdir` 变体拆 handler | M |
+| M7 | 5 文件 6 处复制 `<a download>` 骨架（ExpertsPanel:135/ProfilesPanel:189/ImportExportModal:96,208/SkillDetailDrawer:88/SkillFilePreview:140） | `utils/download.ts` 已存在却未全员采用 | 🟠 | 改用 `downloadBlob/downloadByUrl` | S |
+| M8 | 96 处 `message.error(...err instanceof Error...)` | **Duplicated Code**：错误格式化模板 | 🟠 | 抽 `utils/notify.ts:notifyError(prefix,err)` | S |
+| M9 | 4 处 `page/pageSize/statusFilter` 四件套（SessionManager:27/TodoCenterCardView:70/TodoListPage:56/loop-studio/executions:48） | **Duplicated Code**：分页+筛选套路 | 🟠 | 抽 `usePagedQuery` hook | M |
+| M10 | `SkillMarketplace.tsx`(1216 行 / 29 useState / 5 类状态) | **God Component** | 🟠 | 拆 `<MarketToolbar>/<SkillList>/<SkillDetailDrawer>/<InstallModal>` | L |
+| M11 | 17 处 `#[allow(dead_code)]`，`adapters/pi.rs` 集中 6 处 | 死代码 / 未使用可疑项 | 🟠 | 逐条核对，删真死代码、重构 pi.rs | S |
+| M12 | `react-icons` 全仓仅 4 文件 4 处（`TfiBlackboard`/`FaSquare`） | 冗余依赖（已有 `@ant-design/icons`） | 🟠 | 剔除 `react-icons`，换 antd 图标或内联 SVG | S |
+| M13 | `process/` 下 12 处 `as unknown as Record<...>` | 类型定义不精确，靠断言绕过 | 🟠 | 补 `process`/`link`/`phase` 类型字段 | M |
+| M14 | 10 处 `eslint-disable react-hooks/exhaustive-deps` | React bug 高发区，依赖数组手维护 | 🟠 | 改写依赖数组或 `useEvent` 模式 | S |
+| M15 | `TODO_LIST_REFRESH_EVENT`/`EXECUTION_SYNC_EVENT` 共 ~11 处 `window.dispatchEvent` | 用 window 事件替代 React 数据流（Observer 误用） | 🟠 | 升级为 Context 内 `refreshToken` dispatch | M |
+| M16 | `BlackboardPage.tsx`(1286 行 / 11 子组件同文件) | 大文件无目录边界（已在当 facade 用） | 🟠 | 拆 `components/blackboard/` 目录 | M |
+| L1 | 8 个 impl 的 result 分支 `usage/tokens/cost` 提取 | 字段名不同但结构同构 | 🟡 | 依赖 M1 落地后抽 `extract_usage_from` | S |
+| L2 | `auto_review.rs:446 poll_review_to_terminal`（58 行） | Long Method | 🟡 | 拆「终态判定/rating 解析/写回」3 helper | S |
+| L3 | `todo-post/index.tsx:209` 与 `download.ts:21` 同公式 | ISO 时间戳片段重复 | 🟡 | 改用 `backupTimestamp()` | S |
+| L4 | `worktree.rs:437,439,588,590` / `custom_template.rs:52` | `GIT_AUTHOR_EMAIL`/host 黑名单字面量 | 🟡 | 抽 `const` | S |
+| L5 | `Cargo.toml` lint 阶段 2 未推进（263+ 处注释待清理） | unwrap/expect 仍在 `warn` | 🟡 | 按模块分批迁 `?`，逐步升 `deny` | L |
+| L6 | `api/bundled.ts` 与 `utils/database/*` 双入口 | 业务 API 分布不一致 | 🟡 | 按子域并入 `utils/database/` | M |
+| L7 | `App.tsx:317-549` 等 11 处 `workspace={selectedWorkspace}` | Prop Drilling（Context 已存在） | 🟡 | 消费方直接 `useApp()` 取 | S |
+| L8 | `useExecutionEvents.ts`(507 行) 类型/纯函数/hook/单例混堆 | **Large Class**（God Module） | 🟡 | 拆 `utils/sse/` + 类型文件 | M |
 
 ---
 
@@ -67,9 +71,9 @@
 
 ### 1.1 架构与分层（整体良好，残留见 M5/M6）
 
-- ✅ handler 不写 SQL、service 不渗 HTTP（grep 双 0 命中）。
-- ✅ Strategy + Factory 已就位（`adapters/mod.rs:28,40`），Repeated Switches 已治（`handlers/skills.rs:151`）。
-- 🟡 残留 Large Class：`db/{loop_,todo,execution}.rs` 各 2500–3000 行（M5）、`handlers/bundled.rs` 2965 行/107 函数（M6）。两者都已有「拆分依据」可循——db 按职责四分、bundled 按已有 `Subdir` enum 分文件。
+- handler 不写 SQL、service 不渗 HTTP（grep 双 0 命中）。
+- Strategy + Factory 已就位（`adapters/mod.rs:28,40`），Repeated Switches 已治（`handlers/skills.rs:151`）。
+- 🟠 残留 Large Class：`db/{loop_,todo,execution}.rs` 各 2500–3000 行（M5）、`handlers/bundled.rs` 2965 行/107 函数（M6）。两者都已有「拆分依据」可循——db 按职责四分、bundled 按已有 `Subdir` enum 分文件。
 
 ### 1.2 execution_events 执行器适配器（重点，已基本治理，剩 M1 收尾）
 
@@ -161,7 +165,7 @@ Top 大组件：`BlackboardPage.tsx`(1286)、`SkillMarketplace.tsx`(1216)、`Exe
 按「先小后大、先高 ROI 后需讨论、依赖前置」分波推进，每项一个 PR（复杂项先出设计文档）。可参照 096-W1 的 PR 模板：一个工具/hook 文件 + vitest 单测（`test_<函数>_<场景>` 命名）。
 
 ### 第一波：已有正确实现，只是没贯彻（S，立竿见影）
-- ✅ 候选 M7（download.ts 全员采用）、L3（backupTimestamp 复用）、L7（selectedWorkspace prop drilling）、M12（剔除 react-icons）、L4（常量抽取）、M8（notifyError）。
+- 候选 M7（download.ts 全员采用）、L3（backupTimestamp 复用）、L7（selectedWorkspace prop drilling）、M12（剔除 react-icons）、L4（常量抽取）、M8（notifyError）。
 - 这些和团队正在做的 096 dedup 节奏完全合拍，可顺路带。
 
 ### 第二波：抽 hook 收口（M，ROI 随时间递增）

--- a/docs/decisions/ADR-005-重构与设计模式改进-决策.md
+++ b/docs/decisions/ADR-005-重构与设计模式改进-决策.md
@@ -155,7 +155,7 @@ Top 大组件：`BlackboardPage.tsx`(1286)、`SkillMarketplace.tsx`(1216)、`Exe
 
 ### 3.3 技术债标记（M11/M14）
 
-- 后端 `#[allow(dead_code)]` 17 处，`adapters/pi.rs` 集中 6 处（pi.rs 集中度过高本身需重构）。真 TODO 仅 1 条（`feishu_history_fetcher.rs:416`）。
+- 后端 `#[allow(dead_code)]` 17 处，`adapters/pi.rs` 集中 6 处（pi.rs 集中度过高本身需重构）。与 [ADR-004 死代码扫描](./ADR-004-死代码扫描-决策.md) 互补：ADR-004 治「真死代码」清单（逐条删留），本项 M11 标记的是「抑制告警的标注点」——其中确属死代码者以 ADR-004 为准。真 TODO 仅 1 条（`feishu_history_fetcher.rs:416`）。
 - 前端 `eslint-disable react-hooks/exhaustive-deps` 10 处（`useViewState.ts:374/382/396` 等），是 React bug 高发区；`as any`/`as unknown as` 12 处；`@ts-ignore` 0 处（质量良好）。
 
 ---

--- a/docs/decisions/ADR-005-重构与设计模式改进-决策.md
+++ b/docs/decisions/ADR-005-重构与设计模式改进-决策.md
@@ -21,7 +21,7 @@
 
 **但存在三类系统性技术债**，是本报告的核心：
 
-1. **状态字面量未枚举化**——248 处字符串散落 15 个文件，拼写错误编译期发现不了（见 H1）。
+1. **状态字面量未枚举化**——382 处字符串散落 57 个文件，拼写错误编译期发现不了（见 H1）。
 2. **大文件 + 大函数 + 0 单测的耦合黑洞**——db/handlers/services 三层各有 2500–3000 行 God 文件，84 个函数超 100 行（规范限 50），且这些大文件恰好单测最薄（见 H2/H3/H4）。
 3. **前端「已有正确实现却没贯彻到所有调用点」**——`download.ts`、`useBackupDomain`、`cancelledRef` 都已存在，但同类套路仍在多处复制粘贴（见 M3/M7/M9）。
 
@@ -31,9 +31,9 @@
 
 | # | 位置 | 坏味道 / 缺失模式 | 严重度 | 推荐手法 | 工作量 |
 |---|---|---|---|---|---|
-| **H1** | `loop_runner.rs`(48)/`db/execution.rs`(26)/`db/loop_.rs`(23)/`cli/commands.rs`(22) 等 15 文件 | **Primitive Obsession**：`"pending"/"running"/"success"...` 字面量 248 处 | 🔴 | 抽 `ExecutionStatus` 枚举 + `as_str()/from_str()`，全量替换 | L |
+| **H1** | `loop_runner.rs`(63)/`db/execution.rs`(43)/`db/loop_.rs`(30)/`cli/commands.rs`(27) 等 57 文件 | **Primitive Obsession**：`"pending"/"running"/"success"...` 字面量 382 处 | 🔴 | 抽 `ExecutionStatus` 枚举 + `as_str()/from_str()`，全量替换 | L |
 | **H2** | `services/message_debounce.rs:1229` `handle_default_response_executor`（280 行） | **Long Method** + 项目红线（多 return + 副作用混杂：send_msg+db+tx.send） | 🔴 | Extract Function ×5–6，拆成 ≤30 行 helper | M |
-| **H3** | `models/mod.rs:536`(595)/`completion.rs:185 persist_agent_runs`(312)/`log_capture.rs:108`(249)/`feishu_push.rs:43`(233)/`pre_spawn.rs:482`(232)/`message_debounce.rs:158 push`(217) 等 84 个 | **Long Method**：84 个函数 >100 行（规范 50） | 🔴 | 优先拆标星 6 个（均非豁免场景），余者渐进 | L |
+| **H3** | `models/mod.rs:536`(595)/`completion.rs:185 persist_agent_runs`(312)/`log_capture.rs:108`(249)/`feishu_push.rs:43`(233)/`pre_spawn.rs:482`(232)/`message_debounce.rs:158 push`(217) 等 84 个 | **Long Method**：84 个函数 >100 行（规范 50） | 🔴 | 优先拆 §1.3 所列 8 个（均非豁免场景），余者渐进 | L |
 | **H4** | `handlers/`（18/34 无测）/ `services/`（12/20）/ 前端 18/20 大组件无单测 | 测试覆盖缺口：集成测试覆盖主路径，错误分支/边界无单测 | 🔴 | 优先给大文件补关键分支单测 + 前端补 vitest | L |
 | **H5** | `ProfilesPanel.tsx:80-301`（11 处裸 `fetch`） | 绕过 axios 拦截器（无 retry、v1 前缀硬写、无 unwrap） | 🔴 | 抽 `utils/database/providers.ts` Facade | M |
 | M1 | `execution_events/impls/` 8 个 `extract()` 外壳（codex:262/kimi:165/pi:330/hermes/codewhale/atomcode/claude_code:205/codebuddy:167） | **Duplicated Code** ~130 行逐字重复 | 🟡 | **Template Method**：trait 默认 `extract` + `parse_json` 钩子 | M |
@@ -42,7 +42,7 @@
 | M4 | `executor_service/auto_review.rs`（多处 `Result<_,String>`）↔ `services/auto_review.rs` | **Primitive Obsession**（字符串错误）+ 同名碰撞 Shotgun Surgery | 🟡 | thiserror `AutoReviewError` + 合并或改名 | S–M |
 | M5 | `db/loop_.rs`(3053)/`db/todo.rs`(3035)/`db/execution.rs`(2488) | **Large Class**：God Repository，65/56/67 个函数堆一文件 | 🟡 | 按写入/读取/聚合/关联拆子模块 | L |
 | M6 | `handlers/bundled.rs`(2965 行 / 107 函数) | **Large Class**：4 类资源 Git 同步塞一文件，已有 `Subdir` enum 未按变体分文件 | 🟡 | 按 `Subdir` 变体拆 handler | M |
-| M7 | 6 文件复制 `<a download>` 骨架（ExpertsPanel:135/ProfilesPanel:189/ImportExportModal:96,208/SkillDetailDrawer:88/SkillFilePreview:140） | `utils/download.ts` 已存在却未全员采用 | 🟡 | 改用 `downloadBlob/downloadByUrl` | S |
+| M7 | 5 文件 6 处复制 `<a download>` 骨架（ExpertsPanel:135/ProfilesPanel:189/ImportExportModal:96,208/SkillDetailDrawer:88/SkillFilePreview:140） | `utils/download.ts` 已存在却未全员采用 | 🟡 | 改用 `downloadBlob/downloadByUrl` | S |
 | M8 | 96 处 `message.error(...err instanceof Error...)` | **Duplicated Code**：错误格式化模板 | 🟡 | 抽 `utils/notify.ts:notifyError(prefix,err)` | S |
 | M9 | 4 处 `page/pageSize/statusFilter` 四件套（SessionManager:27/TodoCenterCardView:70/TodoListPage:56/loop-studio/executions:48） | **Duplicated Code**：分页+筛选套路 | 🟡 | 抽 `usePagedQuery` hook | M |
 | M10 | `SkillMarketplace.tsx`(1216 行 / 29 useState / 5 类状态) | **God Component** | 🟡 | 拆 `<MarketToolbar>/<SkillList>/<SkillDetailDrawer>/<InstallModal>` | L |
@@ -108,7 +108,7 @@ Top 大组件：`BlackboardPage.tsx`(1286)、`SkillMarketplace.tsx`(1216)、`Exe
 
 096-W1 的 `useBackupDomain` + `download.ts` 已证明收口姿势被团队认可。下列同类套路尚未收口：
 
-- **M7 下载骨架**：`download.ts` 已有 `downloadBlob/downloadByUrl`，但 6 个文件仍逐字复制 `<a download>` 7 行骨架（ExpertsPanel:135 与 ProfilesPanel:189 几乎逐字相同）。工作量 S，每文件 5 分钟。
+- **M7 下载骨架**：`download.ts` 已有 `downloadBlob/downloadByUrl`，但 5 个文件（6 处）仍逐字复制 `<a download>` 7 行骨架（ExpertsPanel:135 与 ProfilesPanel:189 几乎逐字相同）。工作量 S，每文件 5 分钟。
 - **M3 latest-wins 守卫**：防「快速切换旧请求覆盖新数据」的逻辑出现 3 变体 × 11 处（简单 boolean / `useRef(false)` / 序号 seq）。抽 `useLatestRequest()`（简单）+ `useSeqRequest()`（序号）。**注：ADR-003 #5/#13 已为 BlackboardPage 等 4 处加过守卫，但每处仍各写一遍——抽 hook 是收尾**。
 - **M9 分页+筛选**：`page/pageSize/statusFilter` 四件套 + 「改 filter 重置 page=1」+ 依赖数组 reload，4 处同构。抽 `usePagedQuery`。
 - **M8 错误提示**：96 处 `message.error(...err instanceof Error ? err.message : String(err)...)`。抽 `utils/notify.ts:notifyError(prefix,err)`，统一走 antd `App.useApp()` 实例。
@@ -131,7 +131,7 @@ Top 大组件：`BlackboardPage.tsx`(1286)、`SkillMarketplace.tsx`(1216)、`Exe
 
 ### 3.1 状态字符串未枚举化（H1，最大系统性债）
 
-`backend/src` 下 `"pending"|"running"|"completed"|"failed"|"success"|"cancelled"` 字面量 **248 处**，`loop_runner.rs`(48)/`db/execution.rs`(26)/`db/loop_.rs`(23)/`cli/commands.rs`(22)/`models/mod.rs`(19)…举例：`loop_runner.rs:79-81` 用字符串匹配做状态机转换 `"success"|"partial" => "success"`，`phase_driver.rs:323-333` 直接 `ActiveValue::Set("running")`。**拼写错误编译期发现不了**，是潜伏的 silent-bug 源。
+`backend/src` 下 `"pending"|"running"|"completed"|"failed"|"success"|"cancelled"` 字面量 **382 处**（计数口径：`git grep -hoE '"(pending|running|completed|failed|success|cancelled)"'` 于 `backend/src` 全树，大小写敏感、含 models/migrations/tests，共 57 文件），`loop_runner.rs`(63)/`db/execution.rs`(43)/`db/loop_.rs`(30)/`cli/commands.rs`(27)/`models/mod.rs`(35)…举例：`loop_runner.rs:79-81` 用字符串匹配做状态机转换 `"success"|"partial" => "success"`，`phase_driver.rs:323-333` 直接 `ActiveValue::Set("running")`。**拼写错误编译期发现不了**，是潜伏的 silent-bug 源。
 
 抽 `ExecutionStatus` 枚举 + `as_str()/from_str()`，全量替换。工作量大但机械、风险低（行为不变），且应与 M5（db 拆分）协同——动 db 文件时顺手枚举化。
 
@@ -174,7 +174,7 @@ Top 大组件：`BlackboardPage.tsx`(1286)、`SkillMarketplace.tsx`(1216)、`Exe
 - M4（auto_review error enum + 改名消碰撞）。
 
 ### 第四波：大件拆分（L，需设计讨论）
-- H1（状态枚举化，248 处）——与 M5 协同：动 db 文件时顺手枚举化。
+- H1（状态枚举化，382 处）——与 M5 协同：动 db 文件时顺手枚举化。
 - M5（db 三大 God Repo 按职责拆）、M6（bundled.rs 按 Subdir 拆）。
 - M10（SkillMarketplace 拆）、M16（BlackboardPage 拆目录）。
 

--- a/docs/decisions/ADR-005-重构与设计模式改进-决策.md
+++ b/docs/decisions/ADR-005-重构与设计模式改进-决策.md
@@ -1,0 +1,197 @@
+# 重构与设计模式改进报告（2026-08）
+
+> 本报告聚焦**可维护性与设计**，与 [ADR-003 代码质量审计](./ADR-003-代码质量审计-决策.md)（正确性 bug）互补：ADR-003 治「会出错的地方」，本报告治「难改、难读、难测的地方」。
+
+**审计范围**：后端 Rust（296 文件）+ 前端 TS/TSX（382 文件），`main` @ `91edaa9f`。
+**方法**：三套方法论并行加载——`codebase-design`（深模块/seam/删除测试）、`design-patterns`（GoF 62 + SOLID + 反模式）、`code-refactor`（Fowler 24 坏味道 + 重构手法）；由 3 个子代理分头取证（后端 / 前端 / 跨切面），每条发现均带 `文件:行号`，本文已去重合并。
+
+**严重度**：🔴 HIGH（系统性技术债 / 红线违规，每次改动都在还利息）/ 🟡 MED（特定模块的可维护性瓶颈）/ 🟢 LOW（锦上添花，顺手做）。
+**工作量**：S（<1 人日）/ M（1–3 人日）/ L（>3 人日或需设计讨论）。
+
+---
+
+## 总体评价
+
+仓库**底子扎实**，证据如下，这些优点在动手重构时应当保留：
+
+- 后端分层干净：handler 不写 SQL、service 不渗 HTTP（`grep` 验证 0 命中）；执行器侧已用 `EXECUTORS: &[ExecutorDef]` 静态表 + `create_extractor` 工厂指针（`adapters/mod.rs:28,40`）实现 Strategy + Factory，新增执行器只改一行；`executor_label` 已从 13 臂 match 改为单点查表（`handlers/skills.rs:151`），Repeated Switches 已治理。
+- 096-W1/W2 去重成效显著：`step_protocol.rs`（362 行）把 kilo+opencode 两份各 170 行协议塌缩为 `StepProtocolExtractor::new(name)`；`step_json.rs`（193 行）抽出 zhanlu/mimo/mobilecoder 三家共用提取函数。**执行器适配器这一原最大嫌疑区，实际已被治理得相当干净**。
+- 风格克制：前端 0 个 `@ts-ignore`、0 个 `console.log` 残留；后端生产代码真 TODO 仅 1 条；`services/process/` 是 15/15 全测标杆目录。
+- 错误处理整体合格：所有生产 unwrap/expect 均带 `#[allow]` + 就近注释，且属 LazyLock 常量 / OnceLock 一次性初始化 / Mutex 中毒等合理 4 类场景。
+
+**但存在三类系统性技术债**，是本报告的核心：
+
+1. **状态字面量未枚举化**——248 处字符串散落 15 个文件，拼写错误编译期发现不了（见 H1）。
+2. **大文件 + 大函数 + 0 单测的耦合黑洞**——db/handlers/services 三层各有 2500–3000 行 God 文件，84 个函数超 100 行（规范限 50），且这些大文件恰好单测最薄（见 H2/H3/H4）。
+3. **前端「已有正确实现却没贯彻到所有调用点」**——`download.ts`、`useBackupDomain`、`cancelledRef` 都已存在，但同类套路仍在多处复制粘贴（见 M3/M7/M9）。
+
+---
+
+## 改进总表（按严重度，已去重）
+
+| # | 位置 | 坏味道 / 缺失模式 | 严重度 | 推荐手法 | 工作量 |
+|---|---|---|---|---|---|
+| **H1** | `loop_runner.rs`(48)/`db/execution.rs`(26)/`db/loop_.rs`(23)/`cli/commands.rs`(22) 等 15 文件 | **Primitive Obsession**：`"pending"/"running"/"success"...` 字面量 248 处 | 🔴 | 抽 `ExecutionStatus` 枚举 + `as_str()/from_str()`，全量替换 | L |
+| **H2** | `services/message_debounce.rs:1229` `handle_default_response_executor`（280 行） | **Long Method** + 项目红线（多 return + 副作用混杂：send_msg+db+tx.send） | 🔴 | Extract Function ×5–6，拆成 ≤30 行 helper | M |
+| **H3** | `models/mod.rs:536`(595)/`completion.rs:185 persist_agent_runs`(312)/`log_capture.rs:108`(249)/`feishu_push.rs:43`(233)/`pre_spawn.rs:482`(232)/`message_debounce.rs:158 push`(217) 等 84 个 | **Long Method**：84 个函数 >100 行（规范 50） | 🔴 | 优先拆标星 6 个（均非豁免场景），余者渐进 | L |
+| **H4** | `handlers/`（18/34 无测）/ `services/`（12/20）/ 前端 18/20 大组件无单测 | 测试覆盖缺口：集成测试覆盖主路径，错误分支/边界无单测 | 🔴 | 优先给大文件补关键分支单测 + 前端补 vitest | L |
+| **H5** | `ProfilesPanel.tsx:80-301`（11 处裸 `fetch`） | 绕过 axios 拦截器（无 retry、v1 前缀硬写、无 unwrap） | 🔴 | 抽 `utils/database/providers.ts` Facade | M |
+| M1 | `execution_events/impls/` 8 个 `extract()` 外壳（codex:262/kimi:165/pi:330/hermes/codewhale/atomcode/claude_code:205/codebuddy:167） | **Duplicated Code** ~130 行逐字重复 | 🟡 | **Template Method**：trait 默认 `extract` + `parse_json` 钩子 | M |
+| M2 | 13 文件 24 处 `localStorage.setItem` | 散落持久化、无 schema、键名 `ntd_`/裸键混用 | 🟡 | 抽 `usePersistentState` + `STORAGE_KEYS` 表 | M |
+| M3 | 11 处 `let cancelled=false` + `reqGenRef`/`fetchSeqRef`/`cancelledRef` 3 变体 | **Duplicated Code**：latest-wins 竞态守卫 | 🟡 | 抽 `useLatestRequest`/`useSeqRequest` hook | M |
+| M4 | `executor_service/auto_review.rs`（多处 `Result<_,String>`）↔ `services/auto_review.rs` | **Primitive Obsession**（字符串错误）+ 同名碰撞 Shotgun Surgery | 🟡 | thiserror `AutoReviewError` + 合并或改名 | S–M |
+| M5 | `db/loop_.rs`(3053)/`db/todo.rs`(3035)/`db/execution.rs`(2488) | **Large Class**：God Repository，65/56/67 个函数堆一文件 | 🟡 | 按写入/读取/聚合/关联拆子模块 | L |
+| M6 | `handlers/bundled.rs`(2965 行 / 107 函数) | **Large Class**：4 类资源 Git 同步塞一文件，已有 `Subdir` enum 未按变体分文件 | 🟡 | 按 `Subdir` 变体拆 handler | M |
+| M7 | 6 文件复制 `<a download>` 骨架（ExpertsPanel:135/ProfilesPanel:189/ImportExportModal:96,208/SkillDetailDrawer:88/SkillFilePreview:140） | `utils/download.ts` 已存在却未全员采用 | 🟡 | 改用 `downloadBlob/downloadByUrl` | S |
+| M8 | 96 处 `message.error(...err instanceof Error...)` | **Duplicated Code**：错误格式化模板 | 🟡 | 抽 `utils/notify.ts:notifyError(prefix,err)` | S |
+| M9 | 4 处 `page/pageSize/statusFilter` 四件套（SessionManager:27/TodoCenterCardView:70/TodoListPage:56/loop-studio/executions:48） | **Duplicated Code**：分页+筛选套路 | 🟡 | 抽 `usePagedQuery` hook | M |
+| M10 | `SkillMarketplace.tsx`(1216 行 / 29 useState / 5 类状态) | **God Component** | 🟡 | 拆 `<MarketToolbar>/<SkillList>/<SkillDetailDrawer>/<InstallModal>` | L |
+| M11 | 17 处 `#[allow(dead_code)]`，`adapters/pi.rs` 集中 6 处 | 死代码 / 未使用可疑项 | 🟡 | 逐条核对，删真死代码、重构 pi.rs | S |
+| M12 | `react-icons` 全仓仅 4 文件 4 处（`TfiBlackboard`/`FaSquare`） | 冗余依赖（已有 `@ant-design/icons`） | 🟡 | 剔除 `react-icons`，换 antd 图标或内联 SVG | S |
+| M13 | `process/` 下 12 处 `as unknown as Record<...>` | 类型定义不精确，靠断言绕过 | 🟡 | 补 `process`/`link`/`phase` 类型字段 | M |
+| M14 | 10 处 `eslint-disable react-hooks/exhaustive-deps` | React bug 高发区，依赖数组手维护 | 🟡 | 改写依赖数组或 `useEvent` 模式 | S |
+| M15 | `TODO_LIST_REFRESH_EVENT`/`EXECUTION_SYNC_EVENT` 共 ~11 处 `window.dispatchEvent` | 用 window 事件替代 React 数据流（Observer 误用） | 🟡 | 升级为 Context 内 `refreshToken` dispatch | M |
+| M16 | `BlackboardPage.tsx`(1286 行 / 11 子组件同文件) | 大文件无目录边界（已在当 facade 用） | 🟡 | 拆 `components/blackboard/` 目录 | M |
+| L1 | 8 个 impl 的 result 分支 `usage/tokens/cost` 提取 | 字段名不同但结构同构 | 🟢 | 依赖 M1 落地后抽 `extract_usage_from` | S |
+| L2 | `auto_review.rs:446 poll_review_to_terminal`（58 行） | Long Method | 🟢 | 拆「终态判定/rating 解析/写回」3 helper | S |
+| L3 | `todo-post/index.tsx:209` 与 `download.ts:21` 同公式 | ISO 时间戳片段重复 | 🟢 | 改用 `backupTimestamp()` | S |
+| L4 | `worktree.rs:437,439,588,590` / `custom_template.rs:52` | `GIT_AUTHOR_EMAIL`/host 黑名单字面量 | 🟢 | 抽 `const` | S |
+| L5 | `Cargo.toml` lint 阶段 2 未推进（263+ 处注释待清理） | unwrap/expect 仍在 `warn` | 🟢 | 按模块分批迁 `?`，逐步升 `deny` | L |
+| L6 | `api/bundled.ts` 与 `utils/database/*` 双入口 | 业务 API 分布不一致 | 🟢 | 按子域并入 `utils/database/` | M |
+| L7 | `App.tsx:317-549` 等 11 处 `workspace={selectedWorkspace}` | Prop Drilling（Context 已存在） | 🟢 | 消费方直接 `useApp()` 取 | S |
+| L8 | `useExecutionEvents.ts`(507 行) 类型/纯函数/hook/单例混堆 | **Large Class**（God Module） | 🟢 | 拆 `utils/sse/` + 类型文件 | M |
+
+---
+
+## 一、后端（Rust）
+
+### 1.1 架构与分层（整体良好，残留见 M5/M6）
+
+- ✅ handler 不写 SQL、service 不渗 HTTP（grep 双 0 命中）。
+- ✅ Strategy + Factory 已就位（`adapters/mod.rs:28,40`），Repeated Switches 已治（`handlers/skills.rs:151`）。
+- 🟡 残留 Large Class：`db/{loop_,todo,execution}.rs` 各 2500–3000 行（M5）、`handlers/bundled.rs` 2965 行/107 函数（M6）。两者都已有「拆分依据」可循——db 按职责四分、bundled 按已有 `Subdir` enum 分文件。
+
+### 1.2 execution_events 执行器适配器（重点，已基本治理，剩 M1 收尾）
+
+去重已见成效（step_protocol / step_json）。**唯一显著残留**是 8 个 impl 的 `extract()` 分发外壳逐字重复（trim 守卫 → `starts_with('{')` → `serde_json::from_str` → Ok 委派 / Err 回退 Info），约 130 行。
+
+这是教科书级的 **Template Method** 缺失。trait `EventExtractor` 已对 `extract_stderr`/`reset` 提供默认实现，唯独核心 `extract` 没有——补一个默认 `extract` + 抽象 `parse_json(&Value)` 钩子（另给 claude_code 这类强类型反序列化的留 `parse_typed<D>`），即可把新执行器的成本从「抄一份 24 行壳」降到「只写 parse_json」。落地后再顺手做 L1（usage/cost 提取的字段映射表）。
+
+> **深模块视角**：当前每个 extractor 的 interface（trait 方法）和 implementation（壳+解析）几乎等大 → shallow。抽 Template Method 后，壳成为 trait 的深实现，子类只暴露真正变化的 `parse_json` 这个小而深的 seam，leverage 与 locality 同时提升。
+
+### 1.3 复杂度热点（H2 + H3 标星项）
+
+`handle_default_response_executor`（`message_debounce.rs:1229`，280 行）是本次最严重单点：揉了 workspace 解析 + 执行器查找 + 执行调度 + 飞书回复编排 + 错误文案五种抽象层级，命中 CLAUDE.md 红线「多个 return 路径且夹杂副作用」。同文件 `process_executor_stdout_line`/`run_executor_with_timeout` 已是「骨架+helper」范例，照此拆 5–6 个 ≤30 行 helper 即可从红线违规降到合规。
+
+其余必拆项（H3）：`completion.rs:185 persist_agent_runs`(312)、`log_capture.rs:108 try_parse_stderr_with_pipeline`(249)、`feishu_push.rs:43 start`(233)、`feishu/channel.rs:113 listen`(233)、`pre_spawn.rs:482 create_record_or_reject`(232)、`message_debounce.rs:158 push`(217)、`cli/commands.rs:798 handle_todo`(211)、`loop_runner.rs:245 spawn_run`(200)。`models/mod.rs:536 with_usage`(595) 与 migration 的 `up`(397/215) 属纯数据构建/迁移，可豁免。
+
+### 1.4 错误处理（M4）
+
+`executor_service/auto_review.rs` 全用 `Result<_, String>`（`:155/211/233/253/281/368`…），`format!("load record: {}", e)` 丢失类型信息，调用方只能 `tracing::warn`。而全 backend 已有十余个 thiserror enum（SchedulerError/WorktreeError/GitSyncError…），唯独这片用 String。补 `AutoReviewError` enum（`TemplateNotFound`/`RecordNotTerminal`/`DbError`/`ExecutionProducedNoRecord`）。
+
+同时该文件与 `services/auto_review.rs`（纯逻辑）同名且 `executor_service` 反向 `use crate::services::auto_review::*`（`:305/454`）——改评审语义要跨两文件，典型 Shotgun Surgery。建议把 services 那份并入 executor_service，或改名 `review_logic.rs` 消碰撞。
+
+---
+
+## 二、前端（React/TS）
+
+### 2.1 组件复杂度（M10/M16 + H5）
+
+Top 大组件：`BlackboardPage.tsx`(1286)、`SkillMarketplace.tsx`(1216)、`ExecutorsPanel.tsx`(942)、`ProfilesPanel.tsx`(719)、`ProcessEditor.tsx`(704)。
+
+- **ProfilesPanel（H5）** 最紧迫：11 处裸 `fetch(PROVIDERS_API)` 完全旁路 `utils/database/client.ts` 的 axios 实例（已内置 v1 重写、3 次退避重试、`{code,data,message}` 解包）。后果：网络抖动直接报错、v1 前缀靠硬写、每处手写 `if(!r.ok)`。抽 `utils/database/providers.ts` Facade 后该面板可瘦 100+ 行。
+- **SkillMarketplace（M10）**：单组件塞 5 类状态 + 两个独立竞态守卫（`detailReqIdRef`+`reqGenRef`），是 God Component。
+- **BlackboardPage（M16）**：一文件 11 个子组件，已在当 facade 用，但缺目录边界 → 拆 `components/blackboard/`。
+- **ProcessEditor.tsx:103-156**：单个 useEffect 跨 53 行（清旧数据+异步加载+YAML 解析+错误提示+loading 兜底），注释自己列了 5 步——典型该拆 3 子函数的 Linear Pipeline。
+
+### 2.2 自定义 Hook 复用（M3/M7/M8/M9，团队已有模板）
+
+096-W1 的 `useBackupDomain` + `download.ts` 已证明收口姿势被团队认可。下列同类套路尚未收口：
+
+- **M7 下载骨架**：`download.ts` 已有 `downloadBlob/downloadByUrl`，但 6 个文件仍逐字复制 `<a download>` 7 行骨架（ExpertsPanel:135 与 ProfilesPanel:189 几乎逐字相同）。工作量 S，每文件 5 分钟。
+- **M3 latest-wins 守卫**：防「快速切换旧请求覆盖新数据」的逻辑出现 3 变体 × 11 处（简单 boolean / `useRef(false)` / 序号 seq）。抽 `useLatestRequest()`（简单）+ `useSeqRequest()`（序号）。**注：ADR-003 #5/#13 已为 BlackboardPage 等 4 处加过守卫，但每处仍各写一遍——抽 hook 是收尾**。
+- **M9 分页+筛选**：`page/pageSize/statusFilter` 四件套 + 「改 filter 重置 page=1」+ 依赖数组 reload，4 处同构。抽 `usePagedQuery`。
+- **M8 错误提示**：96 处 `message.error(...err instanceof Error ? err.message : String(err)...)`。抽 `utils/notify.ts:notifyError(prefix,err)`，统一走 antd `App.useApp()` 实例。
+
+### 2.3 状态管理 / 数据流（M2/M15 + L7）
+
+- **M2 localStorage 散落 24 处**：键名 `ntd_`/裸键混用、无类型、无迁移路径、各自 try/catch。唯一已收口的是 `utils/common/tablePrefs.ts`。抽 `usePersistentState<T>` + 集中 `STORAGE_KEYS` 表。
+- **M15 window 事件跨组件刷新**：`TODO_LIST_REFRESH_EVENT`（App.tsx+TodoDetail.tsx 共 8 处发/监听）+ `EXECUTION_SYNC_EVENT`，用 `window.dispatchEvent` 绕过 React 数据流。`useTodoContext` 已存在 → 加 `refreshToken` state + `triggerRefresh()` dispatch，订阅方 `useEffect([refreshToken])` 自动重拉。可测试、可断言、不污染 window。
+- **L7 selectedWorkspace prop drilling**：`App.tsx` 通过 prop 下发到 11 处，但子组件又用 `useApp()` 重取。让消费方直接 `useApp()` 删 prop。
+
+### 2.4 API / 类型 / 工具层（H5 + M12/M13 + L3/L6）
+
+- 类型层基本对齐（`types/` 9 个领域文件被 `utils/database/*` 复用），无 any 滥用。残留：M13（`process/` 下 12 处 `as unknown as`，根因 process/link/phase 类型不精确）、M12（`react-icons` 仅 4 处用 2 个图标，应剔除换 antd 图标）。
+- L3：`todo-post/index.tsx:209` 手写 `new Date().toISOString().replace(/[:.]/g,'-').slice(0,19)`，与 `download.ts:21 backupTimestamp()` 逐字同构。
+- 导入规范（强制 `@/`）执行良好，仅 7 处 `../`，其中 `todo-post↔todo-detail` 3 处跨目录值得改（L7 顺手）。
+
+---
+
+## 三、跨切面 / 系统性（H1 + H3 + H4 + M11/M14 + L4/L5）
+
+### 3.1 状态字符串未枚举化（H1，最大系统性债）
+
+`backend/src` 下 `"pending"|"running"|"completed"|"failed"|"success"|"cancelled"` 字面量 **248 处**，`loop_runner.rs`(48)/`db/execution.rs`(26)/`db/loop_.rs`(23)/`cli/commands.rs`(22)/`models/mod.rs`(19)…举例：`loop_runner.rs:79-81` 用字符串匹配做状态机转换 `"success"|"partial" => "success"`，`phase_driver.rs:323-333` 直接 `ActiveValue::Set("running")`。**拼写错误编译期发现不了**，是潜伏的 silent-bug 源。
+
+抽 `ExecutionStatus` 枚举 + `as_str()/from_str()`，全量替换。工作量大但机械、风险低（行为不变），且应与 M5（db 拆分）协同——动 db 文件时顺手枚举化。
+
+### 3.2 大文件 + 大函数 + 0 单测的耦合（H3 + H4）
+
+84 个函数超 100 行（规范 50）。最危险的耦合是「大文件恰好单测最薄」：
+
+| 后端大文件（无单测） | 行数 | 前端大组件（无单测） | 行数 |
+|---|---|---|---|
+| `handlers/experts.rs` | 1224 | `BlackboardPage.tsx` | 1286 |
+| `handlers/agent_bot.rs` | 1066 | `SkillMarketplace.tsx` | 1216 |
+| `handlers/todo.rs` | 945 | `ExecutorsPanel.tsx` | 942 |
+| `handlers/sync.rs` | 843 | `ProfilesPanel.tsx` | 719 |
+| `services/blackboard.rs` | 834 | `ProcessEditor.tsx` | 704 |
+
+后端 handlers 由 `api_integration_test.rs` 整体集成覆盖主路径，但**错误分支/边界无单测**；前端 18/20 大组件全无单测（仅 `TodoCenterCard.tsx`/`TodoListView.tsx` 有）。`services/process/`（15/15 全测）是可复制的标杆。
+
+### 3.3 技术债标记（M11/M14）
+
+- 后端 `#[allow(dead_code)]` 17 处，`adapters/pi.rs` 集中 6 处（pi.rs 集中度过高本身需重构）。真 TODO 仅 1 条（`feishu_history_fetcher.rs:416`）。
+- 前端 `eslint-disable react-hooks/exhaustive-deps` 10 处（`useViewState.ts:374/382/396` 等），是 React bug 高发区；`as any`/`as unknown as` 12 处；`@ts-ignore` 0 处（质量良好）。
+
+---
+
+## 推进路线图
+
+按「先小后大、先高 ROI 后需讨论、依赖前置」分波推进，每项一个 PR（复杂项先出设计文档）。可参照 096-W1 的 PR 模板：一个工具/hook 文件 + vitest 单测（`test_<函数>_<场景>` 命名）。
+
+### 第一波：已有正确实现，只是没贯彻（S，立竿见影）
+- ✅ 候选 M7（download.ts 全员采用）、L3（backupTimestamp 复用）、L7（selectedWorkspace prop drilling）、M12（剔除 react-icons）、L4（常量抽取）、M8（notifyError）。
+- 这些和团队正在做的 096 dedup 节奏完全合拍，可顺路带。
+
+### 第二波：抽 hook 收口（M，ROI 随时间递增）
+- M3（useLatestRequest）、M9（usePagedQuery）、M2（usePersistentState）。每个一个 PR + 单测，参考 `useBackupDomain` 样板。
+- 这类是「后续每次新功能都会重新踩的坑」，越早做越省事。
+
+### 第三波：后端结构化（M，行为不变）
+- H2（message_debounce 拆 280 行 God Method）——红线违规，优先。
+- M1（extractor Template Method）——抽完顺手做 L1（usage/cost 字段映射）、L2（poll 拆分）。
+- M4（auto_review error enum + 改名消碰撞）。
+
+### 第四波：大件拆分（L，需设计讨论）
+- H1（状态枚举化，248 处）——与 M5 协同：动 db 文件时顺手枚举化。
+- M5（db 三大 God Repo 按职责拆）、M6（bundled.rs 按 Subdir 拆）。
+- M10（SkillMarketplace 拆）、M16（BlackboardPage 拆目录）。
+
+### 第五波：持续质量
+- H4（补单测，优先大文件错误分支 + 前端 vitest）。
+- M11（dead_code 逐条核对）、M13（process 类型补全）、M14（exhaustive-deps 修复）、M15（window event → Context）、L5（lint 阶段 2）、L6（api/bundled 重组）。
+
+**依赖关系**：L1 依赖 M1；H1 宜先于/协同 M5；M10/M16 的大组件拆分可在补单测（H4）后更安全。
+
+---
+
+## 方法论说明
+
+本报告的分析视角来自三套 skill 的显式应用：
+
+- **`codebase-design`**：用「深模块/seam/删除测试/接口即测试面」判断抽象是否 earn its keep。如执行器 `EXECUTORS` 表 + 工厂指针是深模块正面案例；8 个 extractor 的壳+解析等大是 shallow，靠 Template Method 加深（见 1.2）。
+- **`design-patterns`**：用 GoF 62 + SOLID + 反模式命名问题。命中 Template Method（M1）、Facade（H5/M15）、Strategy（TodoCenterCard mainAction）、God Object/Large Class（M5/M6/M10/M16）、Primitive Obsession（H1/M4）、Shotgun Surgery（M4）、Duplicated Code（M3/M7/M8/M9）。
+- **`code-refactor`**：用 Fowler 24 坏味道 + 重构手法给出修法。Long Method→Extract Function（H2/H3）、Duplicated Code→Extract/Template Method/Pull Up、Primitive Obsession→Replace Primitive with Object、Large Class→Extract Class、Repeated Switches→Replace Conditional with Polymorphism。
+
+> **判断准则**（引自 design-patterns）：重构后代码是否更**易读、易测、易改**？否则不动。本报告所有建议均以此过滤——例如 migration `up`、纯数据构建 `with_usage` 虽超长但属可豁免场景，未列入必拆。


### PR DESCRIPTION
## 概述

新增 **ADR-005 重构与设计模式改进报告**，登记进 `docs/README.md` 索引。本报告是上一阶段「用 codebase-design / design-patterns / code-refactor 三套方法论扫一遍项目」的交付物，也是后续 H 项逐一实现的依据。

> 本 PR **仅文档，无代码改动**。

## 方法

三个并行子代理分别取证后端 / 前端 / 跨切面，每个发现都落到 `file:line` 并标注坏味道 / 模式 / 严重度 / 推荐手法 / 工作量。与 ADR-003（正确性 bug）互补：ADR-003 治「错」，ADR-005 治「乱 / 重 / 重复」。

## 三条系统性技术债

1. **状态字面量散落未枚举化**（H1）—— 任务/执行/loop 状态在 Rust 后端是裸字符串（`backend/src` 下 6 个状态字面量 **382 处 / 57 文件**，计数口径 `git grep -hoE '"(pending|running|completed|failed|success|cancelled)"'`），前后端各拼各的，无单一事实源。
2. **大文件 + 长函数 + 零单测三连耦合**（H3/H4）—— `message_debounce.rs` 1800 行、`cli.rs` 2k+ 行；编排函数 spawn 真实进程无法单测，可测纯逻辑未充分抽出。
3. **前端「正确实现已存在但未传播」**（H5 + MED）—— `download.ts` / `useBackupDomain` / `cancelledRef` 三个正确范式各只在一处用，别处还在手写重复套路。

## 改进项总览（共 29 项）

| 级别 | 项 | 说明 |
|------|----|------|
| 🔴 HIGH ×5 | H1 | 状态字面量 → 枚举（后端 enum + 前端 union，382 处 / 57 文件） |
| 🔴 HIGH | H2 | `message_debounce` 280 行编排函数拆分（命中 CLAUDE.md 红线） |
| 🔴 HIGH | H3 | 8 个长函数（按文件分组拆分） |
| 🔴 HIGH | H4 | 高价值文件补单测（随各重构 PR 流转） |
| 🔴 HIGH | H5 | 前端 `ProfilesPanel` Facade 收敛 |
| 🟡 MED ×16 | — | 重复套路收敛、长函数拆分、纯函数可测化等 |
| 🟢 LOW ×8 | — | 死代码、注释噪音、命名等 |

## 落地节奏（5 波）

- Wave 1：低风险 S 项（下载 util、cancelledRef 传播等）
- Wave 2：H5 ProfilesPanel Facade
- Wave 3：H1 状态枚举
- Wave 4：H3 长函数（按文件分多个 PR）
- Wave 5：测试与质量收口

## 文件

- `docs/decisions/ADR-005-重构与设计模式改进-决策.md`（新增）
- `docs/README.md`（索引：4 → 5 份）

## 评审修订

`/review 1034` 后按两轴评审 + 对 `origin/main` 独立复核，三个提交分别修正：

**bc3349b1 — 计数/口径（Spec 轴确认项）**
- H1 计数补口径：`248 处/15 文件` → `382 处/57 文件`（含 `git grep` 方法），并修正例证文件数。
- M7「6 文件」→「5 文件 6 处」（ImportExportModal 占 2 处）。
- H3 表格「标星 6 个」与 §1.3 所列 8 个必拆项统一为 8。
- （H2 行号 `:1229` 经复核对 `origin/main` 属实，不改；子代理「应为 1551」是比对了 H2 重构后的工作区，误报。）

**8a0f6657 — 文档惯例对齐（Standards 轴判断项，向 ADR-003 看齐）**
- severity emoji：`🔴/🟡/🟢` → `🔴/🟠/🟡`（🟡 在 ADR-003=LOW，原 ADR-005 误作 MED，跨文档歧义）。图例 + §1.1 + 24 个表格行同步。
- ✅ 语义：ADR-003 约定 ✅=「已修/已核实」。移除 ADR-005 里把 ✅ 当「优点/候选」的 3 处误用，仅在新增「修复进度」块按 003 惯例使用。
- 新增「修复进度」块（仿 ADR-003 顶部）：H2 → #1035 已提交，余项按路线图推进。

**9b442bce — M11 补 ADR-004 交叉引用（Spec 轴遗漏项）**
- M11（`#[allow(dead_code)]`）落在 ADR-004（死代码扫描）领域，但全文未提 ADR-004。补一句：ADR-004 治「真死代码」逐条删留清单，M11 标记「抑制告警的标注点」，互补不重复。

## 后续

每个 H 项一个设计文档 + 一个 PR。H2 已在 #1035 跟进（基于本报告）。
