### PR TITLE
refactor(adr005/H2): 拆分 message_debounce 280 行编排函数为 8 个阶段 helper

### DIFF
--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -1149,6 +1149,328 @@ fn emit_direct_stream(
 }
 
 // ============================================================================
+// handle_default_response_executor 的阶段拆分（ADR-005 / H2）
+// ============================================================================
+//
+// 这组 async 函数把原 280 行编排体（命中 CLAUDE.md「多 return 路径 + 副作用混杂」
+// 红线）拆成 7 个职责单一的阶段。每个失败分支自行发飞书提示后返回 Err(None)，
+// 编排体用 ? 向上传播——副作用与返回的耦合被收敛进单一阶段内部（线性错误处理），
+// 编排体本身回归成一段 stepdown 叙事。行为与原实现逐分支一致，签名零改动。
+
+/// 阶段①：解析直连执行器要使用的工作空间目录。
+///
+/// 三种失败（未传 workspace_id / 工作空间不存在 / DB 读失败）都已自行发飞书提示，
+/// 返回 Err(None) 让编排体直接 bail。
+async fn resolve_executor_workspace(
+    db: &Arc<Database>,
+    workspace_id: Option<i64>,
+    executor_type: &str,
+    send_msg: &(dyn Fn(String) + Sync),
+) -> Result<String, Option<String>> {
+    // workspace_id 缺失：用户未绑定工作空间，提示去 /help 绑定而非报「不存在」
+    let Some(wid) = workspace_id else {
+        tracing::warn!("[debounce] no workspace_id for executor default response");
+        send_msg(executor_error_message(executor_type, "未配置工作空间"));
+        return Err(None);
+    };
+    match db.get_project_directory_by_id(wid).await {
+        Ok(Some(pd)) => Ok(pd.path),
+        Ok(None) => {
+            // wid>0 但查不到：悬空 id（工作空间被删），引导重新切换
+            tracing::warn!("[debounce] workspace {} not found", wid);
+            send_msg(workspace_missing_message(executor_type, wid));
+            Err(None)
+        }
+        Err(e) => {
+            // DB 层失败：原样透传原因，让用户区分「读取失败」与「未配置」
+            tracing::error!("[debounce] failed to get workspace {}: {}", wid, e);
+            send_msg(executor_error_message(
+                executor_type,
+                &format!("读取工作空间失败：{}", e),
+            ));
+            Err(None)
+        }
+    }
+}
+
+/// 阶段②：把执行器类型名解析成已注册的执行器实例。
+///
+/// 类型未知 / 未注册时自行发飞书提示并返回 Err(None)。
+/// 只返回执行器实例——ExecutorType 枚举在编排体后续不再使用。
+async fn resolve_executor_instance(
+    registry: &Arc<crate::adapters::ExecutorRegistry>,
+    executor_type: &str,
+    send_msg: &(dyn Fn(String) + Sync),
+) -> Result<Arc<dyn crate::adapters::CodeExecutor>, Option<String>> {
+    // 类型名 → 枚举：用户配置的 executor 字符串可能是任意值，未知时提示具体类型名
+    let exec_type = match parse_executor_type(executor_type) {
+        Some(t) => t,
+        None => {
+            tracing::warn!("[debounce] unknown executor type: {}", executor_type);
+            send_msg(executor_error_message(
+                executor_type,
+                &format!("未知执行器类型：{}", executor_type),
+            ));
+            return Err(None);
+        }
+    };
+    // 枚举 → 实例：注册表里没有说明该执行器未配置，提示去注册
+    match registry.get(exec_type).await {
+        Some(e) => Ok(e),
+        None => {
+            tracing::warn!("[debounce] executor {} not found", executor_type);
+            send_msg(executor_error_message(executor_type, "执行器未注册"));
+            Err(None)
+        }
+    }
+}
+
+/// 阶段③：确定本次执行使用的 session_id。
+///
+/// 优先用调用方传入的 resume_session_id（绑定 todo 场景）；否则从 DB 读 workspace
+/// 已保存的 session（私聊多轮对话 resume）。DB 读失败只记日志不致命——降级为新会话。
+async fn resolve_executor_session(
+    db: &Arc<Database>,
+    workspace_id: Option<i64>,
+    executor_type: &str,
+    resume_session_id: Option<String>,
+) -> Option<String> {
+    // 调用方显式传入的优先：绑定 todo 等「指明要 resume 某 session」的场景
+    if let Some(sid) = resume_session_id {
+        return Some(sid);
+    }
+    // 否则查 workspace 级别的保存 session；4 个分支全部非致命，最坏降级为 None（新会话）
+    let wid = workspace_id?;
+    match db.get_executor_session(wid, executor_type).await {
+        // 用 Some(&sid) 复刻原实现的日志格式（原日志打印 session_id = Some(sid)）
+        Ok(Some(Some(sid))) => {
+            tracing::info!(
+                "[debounce] resumed executor session for {}: {:?}",
+                executor_type,
+                Some(&sid)
+            );
+            Some(sid)
+        }
+        Ok(Some(None)) => {
+            tracing::debug!("[debounce] no saved session for executor {}", executor_type);
+            None
+        }
+        Ok(None) => {
+            tracing::debug!("[debounce] workspace not found for session lookup");
+            None
+        }
+        Err(e) => {
+            tracing::warn!("[debounce] failed to get executor session: {}", e);
+            None
+        }
+    }
+}
+
+/// 阶段④：构建执行器命令（带 session_id）并 spawn 子进程。
+///
+/// spawn 失败（程序不存在 / 无权限等）自行发飞书提示并返回 Err(None)。
+async fn spawn_executor_child(
+    executor: &Arc<dyn crate::adapters::CodeExecutor>,
+    workspace_path: &str,
+    message: &str,
+    session_id: Option<&str>,
+    executor_type: &str,
+    send_msg: &(dyn Fn(String) + Sync),
+) -> Result<tokio::process::Child, Option<String>> {
+    // is_resume 由是否有 session_id 推导：有 session 则让执行器续上下文而非新开会话
+    let is_resume = session_id.is_some();
+    let command_args = executor.command_args_with_session(message, session_id, is_resume);
+    let program = executor.executable_path();
+    tracing::info!(
+        "[debounce] spawning: {} {:?} (cwd={:?})",
+        program,
+        command_args,
+        workspace_path
+    );
+    // 三个 stdio 全 piped：stdout/stderr 由我们读取，stdin 在编排体里 take()后 drop 关闭
+    let mut cmd = tokio::process::Command::new(program);
+    cmd.args(&command_args)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .stdin(std::process::Stdio::piped())
+        .current_dir(workspace_path);
+    match cmd.spawn() {
+        Ok(c) => Ok(c),
+        Err(e) => {
+            tracing::error!("[debounce] failed to spawn executor {}: {}", executor_type, e);
+            send_msg(executor_error_message(
+                executor_type,
+                &format!("启动进程失败：{}", e),
+            ));
+            Err(None)
+        }
+    }
+}
+
+/// 阶段⑤：查 push_level，仅当配置为 "all" 时返回私聊直推目标。
+///
+/// 在发送端判断（而非 FeishuPushService 端），避免流式读取每条日志都查一次 DB。
+/// 查询失败 / 未配置都降级为不直推（None）——过程消息不直推不影响结果消息推送。
+async fn resolve_direct_output(
+    db: &Arc<Database>,
+    bot_id: i64,
+    receive_id: String,
+    receive_id_type: &str,
+) -> Option<DirectOutputInfo> {
+    // 默认 result_only：未配置 push target 时只推最终结果，不打扰过程
+    let push_level = match db.get_feishu_push_target(bot_id).await {
+        Ok(Some(target)) => target.push_level,
+        Ok(None) => "result_only".to_string(),
+        Err(e) => {
+            tracing::warn!("[debounce] failed to get push_level for bot {}: {}", bot_id, e);
+            "result_only".to_string()
+        }
+    };
+    // 仅 "all" 直推过程消息；其他级别过程消息只落库不进私聊
+    if push_level == "all" {
+        Some(DirectOutputInfo {
+            bot_id,
+            receive_id,
+            receive_id_type: receive_id_type.to_string(),
+        })
+    } else {
+        None
+    }
+}
+
+/// 阶段⑥：读 config 超时，带超时地等子进程退出（超时则 kill 回收）。
+///
+/// 超时 / wait 失败自行发飞书提示并返回 Err(None)；成功返回退出状态。
+async fn await_executor_exit(
+    child: tokio::process::Child,
+    config: &Arc<std::sync::RwLock<crate::config::Config>>,
+    executor_type: &str,
+    send_msg: &(dyn Fn(String) + Sync),
+) -> Result<std::process::ExitStatus, Option<String>> {
+    // 与 todo pipeline 共用全局超时旋钮 execution_timeout_secs；0 表示不限制（→ None）
+    let timeout_secs = {
+        #[allow(clippy::expect_used)]
+        // 中毒=有线程 panic，继续无意义；与全仓 RwLock 处置约定一致
+        let cfg = config
+            .read()
+            .expect("config RwLock poisoned in handle_default_response_executor");
+        cfg.execution_timeout_secs
+    };
+    let timeout = direct_executor_timeout(timeout_secs);
+    match wait_child_with_timeout(child, timeout).await {
+        Ok(s) => {
+            tracing::info!(
+                "[debounce] executor {} finished, exit_code={:?}",
+                executor_type,
+                s.code()
+            );
+            Ok(s)
+        }
+        Err(ExecutorRunError::Timeout { secs }) => {
+            tracing::error!("[debounce] executor {} timed out after {}s", executor_type, secs);
+            send_msg(executor_error_message(executor_type, &format!("执行超时（{}s）", secs)));
+            Err(None)
+        }
+        Err(ExecutorRunError::WaitFailed(msg)) => {
+            tracing::error!(
+                "[debounce] failed to wait for executor {}: {}",
+                executor_type,
+                msg
+            );
+            send_msg(executor_error_message(
+                executor_type,
+                &format!("等待进程失败：{}", msg),
+            ));
+            Err(None)
+        }
+    }
+}
+
+/// 阶段⑦的输出打包：避免 stream / stderr / result_text 三个值在调用链里裸传递。
+struct ExecutorOutput {
+    /// 流式解析结果：logs 用于提取结果 + session，raw_stdout 用于诊断兜底
+    stream: StdoutStreamResult,
+    /// 子进程 stderr 全文：非零退出时拼进错误消息
+    stderr: String,
+    /// 从 logs 提取的最终结果文本（执行器产出的结论）
+    result_text: Option<String>,
+}
+
+/// 阶段⑦：join 流式读取、读 stderr、计算最终结果文本。
+///
+/// 纯收集，无致命分支：stream_task panic 时降级为空结果，stderr 读取失败只丢 stderr。
+async fn collect_executor_output(
+    stream_task: JoinHandle<StdoutStreamResult>,
+    stderr_handle: Option<tokio::process::ChildStderr>,
+    executor_type: &str,
+) -> ExecutorOutput {
+    // join 流式读取：task panic 时按空结果处理（与原 unwrap_or 一致）
+    let stream = stream_task.await.unwrap_or(StdoutStreamResult {
+        logs: Vec::new(),
+        raw_stdout: String::new(),
+    });
+    // 读 stderr：read_to_end 失败只丢 stderr 内容，不影响主流程结果
+    let stderr = match stderr_handle {
+        Some(mut reader) => {
+            let mut buf = Vec::new();
+            let _ = reader.read_to_end(&mut buf).await;
+            String::from_utf8_lossy(&buf).to_string()
+        }
+        None => String::new(),
+    };
+    // stderr 非空才打日志：按 char 截 2000，避免按字节切片切断多字节中文
+    if !stderr.is_empty() {
+        let stderr_preview: String = stderr.chars().take(2000).collect();
+        tracing::info!("[debounce] executor {} stderr:\n{}", executor_type, stderr_preview);
+    }
+    // stdout 预览：同样按 char 截 2000，与 stderr 预览同语义
+    let stdout_preview: String = stream.raw_stdout.chars().take(2000).collect();
+    tracing::info!("[debounce] executor {} stdout:\n{}", executor_type, stdout_preview);
+    // 从日志提取最终结果（与 todo 执行路径一致）
+    let result_text = crate::executor_service::completion::get_final_result_from_logs(&stream.logs);
+    ExecutorOutput {
+        stream,
+        stderr,
+        result_text,
+    }
+}
+
+/// 阶段⑧：执行成功时从日志提取 session_id 并持久化到 DB（实现多轮对话 resume）。
+///
+/// best-effort：提取不到 / 保存失败都只记日志——session 持久化不影响主流程结果。
+/// 调用方仅在 status.success() 时调用。
+async fn persist_executor_session(
+    db: &Arc<Database>,
+    executor: &Arc<dyn crate::adapters::CodeExecutor>,
+    logs: &[ParsedLogEntry],
+    workspace_id: Option<i64>,
+    executor_type: &str,
+) {
+    // 没有 workspace_id 无法持久化（session 绑定在 workspace 维度）
+    let Some(wid) = workspace_id else {
+        return;
+    };
+    // session 提取逻辑收口在 session_util（096-W1-PR3），与 wiki chat 通路共用一份实现
+    let Some(new_session_id) =
+        crate::executor_service::session_util::extract_session_from_logs(executor, logs)
+    else {
+        return;
+    };
+    tracing::info!(
+        "[debounce] extracted session_id={} for executor={}, saving to DB",
+        new_session_id,
+        executor_type
+    );
+    // 保存失败只 warn：下次私聊会重新开 session，体验退化为非 resume，不阻塞主流程
+    if let Err(e) = db
+        .set_executor_session(wid, executor_type, Some(new_session_id))
+        .await
+    {
+        tracing::warn!("[debounce] 保存 executor session 失败: {:?}", e);
+    }
+}
+
+// ============================================================================
 // 默认响应处理器：处理 loop 和 executor 类型的默认响应
 // ============================================================================
 
@@ -1255,74 +1577,15 @@ impl MessageDebounce {
             });
         };
 
-        // 获取工作空间路径
-        let workspace_path = if let Some(wid) = workspace_id {
-            match db.get_project_directory_by_id(wid).await {
-                Ok(Some(pd)) => pd.path,
-                Ok(None) => {
-                    tracing::warn!("[debounce] workspace {} not found", wid);
-                    // wid=0 是未绑定哨兵、wid>0 是悬空 id，统一走友好提示（引导 /help 绑定/切换），
-                    // 不再报「工作空间 0 不存在」这种无法行动的误导性文案
-                    send_msg(workspace_missing_message(executor_type, wid));
-                    return Err(None);
-                }
-                Err(e) => {
-                    tracing::error!("[debounce] failed to get workspace {}: {}", wid, e);
-                    send_msg(executor_error_message(executor_type, &format!("读取工作空间失败：{}", e)));
-                    return Err(None);
-                }
-            }
-        } else {
-            tracing::warn!("[debounce] no workspace_id for executor default response");
-            send_msg(executor_error_message(executor_type, "未配置工作空间"));
-            return Err(None);
-        };
-
-        // 获取执行器
-        let exec_type = match parse_executor_type(executor_type) {
-            Some(t) => t,
-            None => {
-                tracing::warn!("[debounce] unknown executor type: {}", executor_type);
-                send_msg(executor_error_message(executor_type, &format!("未知执行器类型：{}", executor_type)));
-                return Err(None);
-            }
-        };
-        let executor = match executor_registry.get(exec_type).await {
-            Some(e) => e,
-            None => {
-                tracing::warn!("[debounce] executor {} not found", executor_type);
-                send_msg(executor_error_message(executor_type, "执行器未注册"));
-                return Err(None);
-            }
-        };
-
-        // 确定本次使用的 session_id：
-        // 1. 优先使用调用方传入的 resume_session_id（如绑定 todo 场景）
-        // 2. 否则从 workspace 的 executor_sessions 中读取（私聊多轮对话场景）
-        let mut session_id = resume_session_id.clone();
-        if session_id.is_none() {
-            if let Some(wid) = workspace_id {
-                match db.get_executor_session(wid, executor_type).await {
-                    Ok(Some(Some(sid))) => {
-                        session_id = Some(sid);
-                        tracing::info!(
-                            "[debounce] resumed executor session for {}: {:?}",
-                            executor_type,
-                            session_id
-                        );
-                    }
-                    Ok(Some(None)) => {
-                        tracing::debug!("[debounce] no saved session for executor {}", executor_type);
-                    }
-                    Ok(None) => {
-                        tracing::debug!("[debounce] workspace not found for session lookup");
-                    }
-                    Err(e) => {
-                        tracing::warn!("[debounce] failed to get executor session: {}", e);
-                    }
-                }
-            }
-        }
+        // ①②③ 解析运行上下文：workspace 路径 / 执行器实例 / session_id。
+        // 任一失败 helper 已发飞书提示并返回 Err(None)，这里用 ? 直接 bail。
+        let workspace_path =
+            resolve_executor_workspace(db, workspace_id, executor_type, &send_msg).await?;
+        let executor =
+            resolve_executor_instance(executor_registry, executor_type, &send_msg).await?;
+        let session_id =
+            resolve_executor_session(db, workspace_id, executor_type, resume_session_id.clone())
+                .await;
 
         tracing::info!(
             "[debounce] executor {} direct response in workspace {:?}, message len={}, session={:?}",
@@ -1332,173 +1595,84 @@ impl MessageDebounce {
             session_id.as_deref().map(|s| s.chars().take(20).collect::<String>())
         );
 
-        // 构建执行器命令（带 session_id，支持 resume 多轮对话）
-        let is_resume = session_id.is_some();
-        let command_args = executor.command_args_with_session(message, session_id.as_deref(), is_resume);
-        let program = executor.executable_path();
-        tracing::info!(
-            "[debounce] spawning: {} {:?} (cwd={:?})",
-            program, command_args, workspace_path
-        );
-        let mut cmd = tokio::process::Command::new(program);
-        cmd.args(&command_args)
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .stdin(std::process::Stdio::piped())
-            .current_dir(&workspace_path);
+        // ④ 构建执行器命令（带 session_id）并 spawn 子进程
+        let mut child = spawn_executor_child(
+            &executor,
+            &workspace_path,
+            message,
+            session_id.as_deref(),
+            executor_type,
+            &send_msg,
+        )
+        .await?;
 
-        let mut child = match cmd.spawn() {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::error!("[debounce] failed to spawn executor {}: {}", executor_type, e);
-                send_msg(executor_error_message(executor_type, &format!("启动进程失败：{}", e)));
-                return Err(None);
-            }
-        };
-
-        // 提取 stdout 句柄用于流式读取：与 todo 执行路径一致，逐行解析并通过
-        // EventPipeline 发送 ExecEvent::Output 事件，让 FeishuPushService 按 push_level 推送。
+        // ⑤ 提取 stdout/stderr 句柄、生成 task_id、发"开始处理"、关 stdin、查直推目标、
+        // spawn 流式读取。这段留体内：stream_task 的 tokio::spawn move 了 stdout_handle /
+        // tx / executor / task_id 多个本地值，抽出要么造巨参 helper、要么引入中间 struct，
+        // 收益不抵成本（YAGNI）。
         let stdout_handle = child.stdout.take();
-        // 提取 stderr 句柄：非零退出时把 stderr 内容带进错误消息
         let stderr_handle = child.stderr.take();
-
-        // 为流式 Output 事件生成 task_id（提前生成，供 streaming reader 和返回值共用）
+        // task_id 提前生成：流式读取任务和最终返回值共用同一个 id
         let task_id = format!("executor-{}-{}", executor_type, uuid::Uuid::new_v4());
-
-        // spawn 成功立即发"开始处理"标志，让飞书侧知道请求已被接收并在跑
+        // spawn 成功立即回执"开始处理"，让飞书侧知道请求已被接收并在跑
         send_msg(executor_start_message(executor_type, message));
-
-        // stdin 处理：take() 并 drop 关闭 stdin，避免 CLI 进程挂起等待 EOF。
-        // 注意：这里不写 stdin payload——debounce 流式路径不是 worktree 场景，
-        // pi 的 "y" 应答只在切换 worktree 目录时才有意义，乱写会污染 stdin。
+        // take() 并 drop 关闭 stdin，避免 CLI 进程挂起等待 EOF。不写 stdin payload：
+        // debounce 流式路径不是 worktree 场景，pi 的 "y" 应答只在切 worktree 目录时才有意义。
         if child.stdin.take().is_some() {
             tracing::debug!("[debounce] stdin 已关闭");
         }
-
-        // 启动流式读取任务：并发读取 stdout 并通过 EventPipeline 发送 Output 事件。
-        // 复用 log_capture 的 pipeline 创建和解析逻辑，确保与 todo 执行产生完全相同格式的事件。
-        // FeishuPushService 按 push_level 配置推送（"all" 时推送过程事件到飞书）。
-        let tx_for_stream = tx.clone();
-        let executor_for_stream = executor.clone();
-        let tid_for_stream = task_id.clone();
-        // 一对一私聊场景：先查一次 push_level，仅当配置为 "all" 时才发送过程消息。
-        // 在发送端判断而非 FeishuPushService 端判断，避免每条日志都查一次 DB。
-        let push_level = match db.get_feishu_push_target(bot_id).await {
-            Ok(Some(target)) => target.push_level,
-            Ok(None) => "result_only".to_string(),
-            Err(e) => {
-                tracing::warn!("[debounce] failed to get push_level for bot {}: {}", bot_id, e);
-                "result_only".to_string()
+        let direct_output_info =
+            resolve_direct_output(db, bot_id, receive_id.clone(), receive_id_type).await;
+        // 并发读 stdout：复用 log_capture 的 pipeline 解析，产生与 todo 执行同格式的事件，
+        // FeishuPushService 按 push_level 推送（"all" 时推送过程事件到飞书）
+        let stream_task = tokio::spawn({
+            let tx = tx.clone();
+            let executor = executor.clone();
+            let tid = task_id.clone();
+            async move {
+                stream_executor_stdout(
+                    stdout_handle,
+                    &executor,
+                    &tx,
+                    &tid,
+                    workspace_id,
+                    direct_output_info,
+                )
+                .await
             }
-        };
-        let direct_output_info = if push_level == "all" {
-            Some(DirectOutputInfo {
-                bot_id,
-                receive_id: receive_id.clone(),
-                receive_id_type: receive_id_type.to_string(),
-            })
-        } else {
-            None
-        };
-        let stream_task = tokio::spawn(async move {
-            stream_executor_stdout(
-                stdout_handle, &executor_for_stream, &tx_for_stream, &tid_for_stream,
-                workspace_id, direct_output_info,
-            ).await
         });
 
-        // 带超时地等待子进程退出（stdout 已被流式读取，此处只管 wait + timeout + kill）
-        let timeout_secs = {
-            #[allow(clippy::expect_used)]
-            let cfg = config
-                .read()
-                .expect("config RwLock poisoned in handle_default_response_executor");
-            cfg.execution_timeout_secs
-        };
-        let timeout = direct_executor_timeout(timeout_secs);
-        let status = match wait_child_with_timeout(child, timeout).await {
-            Ok(s) => {
-                tracing::info!("[debounce] executor {} finished, exit_code={:?}", executor_type, s.code());
-                s
-            }
-            Err(ExecutorRunError::Timeout { secs }) => {
-                tracing::error!("[debounce] executor {} timed out after {}s", executor_type, secs);
-                send_msg(executor_error_message(executor_type, &format!("执行超时（{}s）", secs)));
-                return Err(None);
-            }
-            Err(ExecutorRunError::WaitFailed(msg)) => {
-                tracing::error!("[debounce] failed to wait for executor {}: {}", executor_type, msg);
-                send_msg(executor_error_message(executor_type, &format!("等待进程失败：{}", msg)));
-                return Err(None);
-            }
-        };
+        // ⑥ 带超时地等子进程退出（超时则 kill 回收，避免孤儿进程）
+        let status = await_executor_exit(child, config, executor_type, &send_msg).await?;
 
-        // 等待流式读取任务完成，收集解析结果和原始 stdout
-        let stream_result = stream_task.await.unwrap_or(StdoutStreamResult {
-            logs: Vec::new(),
-            raw_stdout: String::new(),
-        });
+        // ⑦ join 流式读取 + 读 stderr + 提取最终结果
+        let output = collect_executor_output(stream_task, stderr_handle, executor_type).await;
 
-        // 读取 stderr：非零退出时用于诊断失败原因
-        let stderr_text = match stderr_handle {
-            Some(mut reader) => {
-                let mut buf = Vec::new();
-                let _ = reader.read_to_end(&mut buf).await;
-                String::from_utf8_lossy(&buf).to_string()
-            }
-            None => String::new(),
-        };
-        if !stderr_text.is_empty() {
-            // 按 char 截断日志预览，避免按字节切片切断多字节中文导致 panic
-            let stderr_preview: String = stderr_text.chars().take(2000).collect();
-            tracing::info!(
-                "[debounce] executor {} stderr:\n{}",
-                executor_type,
-                stderr_preview
-            );
-        }
-
-        // 从流式解析收集的日志中提取最终结果（与 todo 执行路径一致）
-        // 按 char 截断日志预览，避免按字节切片切断多字节中文导致 panic
-        let stdout_preview: String = stream_result.raw_stdout.chars().take(2000).collect();
-        tracing::info!(
-            "[debounce] executor {} stdout:\n{}",
-            executor_type,
-            stdout_preview
-        );
-        let result_text = crate::executor_service::completion::get_final_result_from_logs(&stream_result.logs);
-
-        // 构建结束消息：成功有解析结果就用结果；无结果但退出 0 且有 stdout 就用 stdout 兜底；
-        // 非 0 退出走错误通道带退出码+输出片段
+        // 构建结束消息：当前仅记日志——最后一条 assistant 消息已是结论，发飞书会重复。
+        // 按 char 截 200 预览，避免按字节切片切断多字节中文。
         let content = build_executor_end_content(
-            executor_type, &status, result_text, &stream_result.raw_stdout, &stderr_text,
+            executor_type,
+            &status,
+            output.result_text,
+            &output.stream.raw_stdout,
+            &output.stderr,
         );
-
         tracing::info!(
             "[debounce] executor {} result_text={:?}",
             executor_type,
             content.chars().take(200).collect::<String>()
         );
-        // 注释掉发送给飞书：最后一条 assistant 消息已经是结论，FeiShu 推送会导致重复
-        // send_msg(content);
 
-        // 执行成功时从日志中提取 session_id 并持久化到数据库，
-        // 下次私聊时可直接 resume 该 session，实现多轮对话上下文保持。
+        // ⑧ 成功时持久化 session（best-effort，失败只 warn）
         if status.success() {
-            if let Some(wid) = workspace_id {
-                // session 提取逻辑已收口到 executor_service::session_util（096-W1-PR3），
-                // 与 wiki chat 通路共用一份公共实现
-                if let Some(new_session_id) = crate::executor_service::session_util::extract_session_from_logs(&executor, &stream_result.logs) {
-                    tracing::info!(
-                        "[debounce] extracted session_id={} for executor={}, saving to DB",
-                        new_session_id,
-                        executor_type
-                    );
-                    if let Err(e) = db.set_executor_session(wid, executor_type, Some(new_session_id)).await {
-                        tracing::warn!("[debounce] 保存 executor session 失败: {:?}", e);
-                    }
-                }
-            }
+            persist_executor_session(
+                db,
+                &executor,
+                &output.stream.logs,
+                workspace_id,
+                executor_type,
+            )
+            .await;
         }
 
         Ok(crate::executor_service::ExecutionResult {

--- a/docs/design/101-飞书直连执行器编排拆分-设计.md
+++ b/docs/design/101-飞书直连执行器编排拆分-设计.md
@@ -1,0 +1,250 @@
+# 101 - 飞书直连执行器编排函数拆分（ADR-005 / H2）
+
+> 关联：[ADR-005 重构与设计模式改进](../decisions/ADR-005-重构与设计模式改进-决策.md) 的 **H2** 项。
+> 范围：仅 `backend/src/services/message_debounce.rs` 内 `handle_default_response_executor` 一个函数的内部拆分，**行为不变**。
+
+---
+
+## 1. 背景与问题
+
+`handle_default_response_executor`（`message_debounce.rs:1229-1508`）是飞书消息「直连执行器」通路的核心编排：用户在飞书发消息 → 不建 todo / 不建执行记录 → 直接 spawn 一个执行器（如 claude code）→ 流式读 stdout → 把结果推回飞书。
+
+**问题**：单函数 **280 行**，命中 [CLAUDE.md 函数红线](../../CLAUDE.md)——
+
+> 🚫 无论多少行，只要命中一条就必须重构：**存在多个 return 路径且夹杂副作用**。
+
+该函数有 6 个返回点（5 个 `Err(None)` 提前返回 + 1 个 `Ok`），每个提前返回前都调用 `send_msg(...)`（经 `tx.send(ExecEvent::DirectCardMessage)` 发飞书消息），即「返回路径与副作用（发消息 + DB 写 + tx.send）混杂」。
+
+ADR-005 已将其定为 🔴 HIGH。
+
+## 2. 现状与安全性前提（决定怎么拆、靠什么保证不坏）
+
+**关键事实**：这个编排函数本身**不是单测覆盖对象**——它 spawn 真实执行器进程、依赖真实 DB + broadcast channel + ExecutorRegistry，属集成测试范畴，CI 里没有覆盖它的端到端用例。
+
+团队对此的既有处理方式（见文件内多处注释）是：**持续把「可测的纯逻辑」从编排主体里抽成独立函数并单测**。已被抽出并测试的有：
+
+| 已抽出的 helper | 位置 | 覆盖它的测试 |
+|---|---|---|
+| `direct_executor_timeout` | `:750` | `executor_feedback_tests` |
+| `executor_start_message` / `workspace_missing_message` / `executor_error_message` | `:764/780/800` | `executor_feedback_tests` |
+| `build_executor_end_content` | `:821` | `executor_feedback_tests`（注释明说「为了能单测才抽出」） |
+| `run_executor_with_timeout` / `wait_child_with_timeout` | `:877/929` | `executor_feedback_tests`（用 echo/sleep 真进程验证超时 kill） |
+| `stream_executor_stdout` / `process_executor_stdout_line` | `:970/1012` | 编排内调用，事件格式由 `execution_events_integration_test` 间接覆盖 |
+
+文件现有 3 个 test mod（`:1511 / :1597 / :1793`）覆盖这些已抽出的纯逻辑。
+
+**因此本次重构的安全性支柱**：
+
+1. **行为不变的机械抽取**——只把代码从编排函数搬到新 helper，不改动任何执行顺序、日志、错误文案、副作用时机。
+2. **现有测试全绿**——`executor_feedback_tests` / `merge_pending_messages_tests` / 第 3 个 mod 不受影响（它们测的 helper 签名与行为不变）。
+3. **`cargo clippy --all-targets -- -D warnings` 零告警**。
+4. **公开签名不变**——`handle_default_response_executor` 的方法签名（12 参数、返回类型）保持原样，调用方 `dispatch_execution`（`:531`）零改动。
+
+## 3. 拆分方案
+
+把 280 行编排体按**线性阶段**切成 8 个职责单一的 helper（自由 `async fn`，与 `wait_child_with_timeout` 同风格，放在 impl 外的辅助区），编排函数瘦身为一段 stepdown 叙事。
+
+### 3.1 阶段 → helper 映射
+
+| 阶段 | 原行号 | 新 helper | 职责 | 失败行为 |
+|---|---|---|---|---|
+| ① 解析工作空间路径 | 1258-1279 | `resolve_executor_workspace` | DB 查 workspace.path | 自行 `send_msg` + `Err(None)` |
+| ② 解析执行器实例 | 1281-1297 | `resolve_executor_instance` | `parse_executor_type` + `registry.get` | 自行 `send_msg` + `Err(None)` |
+| ③ 解析 session_id | 1299-1325 | `resolve_executor_session` | 优先 resume_session_id，否则 DB 读已存 session | 只记日志，不致命，返回 `Option<String>` |
+| ④ spawn 子进程 | 1335-1357 | `spawn_executor_child` | 构建命令 + `cmd.spawn()` | 自行 `send_msg` + `Err(None)` |
+| ⑤ 查直推目标 | 1386-1402 | `resolve_direct_output` | 查 push_level，仅 `"all"` 返回 `DirectOutputInfo` | 查失败降级为 `None` |
+| ⑥ 带超时等待退出 | 1410-1434 | `await_executor_exit` | 读 config 超时 + `wait_child_with_timeout` | 超时/wait 失败自行 `send_msg` + `Err(None)` |
+| ⑦ 收集输出 | 1436-1468 | `collect_executor_output` | join stream_task + 读 stderr + `get_final_result_from_logs` | 纯收集，不致命 |
+| ⑧ 持久化 session | 1485-1502 | `persist_executor_session` | 成功时 `extract_session_from_logs` + `set_executor_session` | best-effort，失败只记日志 |
+
+> 已有的 `build_executor_end_content`（结束内容决策，⑦之后）保持复用，不再动。
+> 阶段⑤的「take 句柄 / 生成 task_id / 发开始消息 / 关 stdin / spawn stream_task」留在编排体内——它们要么是 move 语义强耦合（stream_task move 了 stdout_handle / tx clone / executor clone / task_id clone），要么只有一两行，抽出反而增加数据结构搬运（YAGNI）。
+
+### 3.2 helper 签名（草拟，实现时以编译器校准为准）
+
+```rust
+// —— 统一的飞书回复闭包类型：捕获 tx/bot_id/receive_id/receive_id_type，
+// —— 是 Fn（不改状态）+ Sync（捕获值皆 Sync），用 trait 对象按引用传递，
+// —— 避免每个 helper 各自重建一份发送逻辑。
+type SendCard<'a> = &'a (dyn Fn(String) + Sync);
+
+async fn resolve_executor_workspace(
+    db: &Arc<Database>,
+    workspace_id: Option<i64>,
+    executor_type: &str,
+    send_msg: SendCard<'_>,
+) -> Result<std::path::PathBuf, Option<String>>;
+
+async fn resolve_executor_instance(
+    registry: &Arc<crate::adapters::ExecutorRegistry>,
+    executor_type: &str,
+    send_msg: SendCard<'_>,
+) -> Result<Arc<dyn crate::adapters::CodeExecutor>, Option<String>>;
+
+async fn resolve_executor_session(
+    db: &Arc<Database>,
+    workspace_id: Option<i64>,
+    executor_type: &str,
+    resume_session_id: Option<String>,
+) -> Option<String>;
+
+async fn spawn_executor_child(
+    executor: &Arc<dyn crate::adapters::CodeExecutor>,
+    workspace_path: &std::path::Path,
+    message: &str,
+    session_id: Option<&str>,
+    executor_type: &str,
+    send_msg: SendCard<'_>,
+) -> Result<tokio::process::Child, Option<String>>;
+
+async fn resolve_direct_output(
+    db: &Arc<Database>,
+    bot_id: i64,
+    receive_id: String,
+    receive_id_type: &str,
+) -> Option<DirectOutputInfo>;
+
+async fn await_executor_exit(
+    child: tokio::process::Child,
+    config: &Arc<std::sync::RwLock<crate::config::Config>>,
+    executor_type: &str,
+    send_msg: SendCard<'_>,
+) -> Result<std::process::ExitStatus, Option<String>>;
+
+/// 阶段⑦的输出打包（避免 3 个返回值裸传递）
+struct ExecutorOutput {
+    stream: StdoutStreamResult,   // logs + raw_stdout
+    stderr: String,
+    result_text: Option<String>,  // get_final_result_from_logs 的结果
+}
+
+async fn collect_executor_output(
+    stream_task: tokio::task::JoinHandle<StdoutStreamResult>,
+    stderr_handle: Option<tokio::process::ChildStderr>,
+    executor_type: &str,
+) -> ExecutorOutput;
+
+async fn persist_executor_session(
+    db: &Arc<Database>,
+    executor: &Arc<dyn crate::adapters::CodeExecutor>,
+    logs: &[crate::models::ParsedLogEntry],
+    workspace_id: Option<i64>,
+    executor_type: &str,
+);
+```
+
+### 3.3 重构后的编排体（stepdown 叙事形态）
+
+> **关于行数**：下图是剥离注释/日志后的「骨架」示意。实际实现因 CLAUDE.md 强制的逐行注释 + 两段 `tracing::info!`（含 20/200 char 截断）+ 12 参数签名，纯代码约 **85 行**，超过 50 行推荐值。按 **CLAUDE.md 线性管道豁免（场景 2）** 接受：编排体只剩单一 `Ok` 返回，5 个提前 bail 由 `?` 透传 helper 的 `Err(None)`（副作用已在 helper 内完成），嵌套 ≤2，逐阶段顺序调用——正是「无分支的流水线」。触发 H2 的红线（多 return 路径 + 副作用混杂）已消除。详见第 8 节验收口径。
+
+```rust
+#[allow(clippy::too_many_arguments)] // 参数来自上游 handler 的独立数据源
+async fn handle_default_response_executor(
+    /* 12 个参数，签名完全不变 */
+) -> Result<crate::executor_service::ExecutionResult, Option<String>> {
+    let executor_type = executor_type.unwrap_or("claudecode");
+
+    // 统一飞书回复出口：开始/错误消息都走 DirectCardMessage（绕过 workspace 过滤直发用户）。
+    // 每次 clone receive_id：换来多个分支复用同一发送出口，语义与原实现一致。
+    let send_msg = |content: String| {
+        let _ = tx.send(ExecEvent::DirectCardMessage {
+            bot_id, receive_id: receive_id.clone(),
+            receive_id_type: receive_id_type.to_string(), content,
+        });
+    };
+
+    // ①②③ 解析 workspace / 执行器 / session——任一环失败 helper 已发提示并返回 Err(None)
+    let workspace_path = resolve_executor_workspace(db, workspace_id, executor_type, &send_msg).await?;
+    let executor = resolve_executor_instance(executor_registry, executor_type, &send_msg).await?;
+    let session_id = resolve_executor_session(db, workspace_id, executor_type, resume_session_id.clone()).await;
+
+    tracing::info!(
+        "[debounce] executor {} direct response in workspace {:?}, message len={}, session={:?}",
+        executor_type, workspace_path, message.len(),
+        session_id.as_deref().map(|s| s.chars().take(20).collect::<String>()),
+    );
+
+    // ④ spawn 子进程
+    let mut child = spawn_executor_child(
+        &executor, &workspace_path, message, session_id.as_deref(), executor_type, &send_msg,
+    ).await?;
+
+    // ⑤ take 句柄 / task_id / 发开始 / 关 stdin / 查直推 / spawn 流式读取（move 强耦合，留体内）
+    let stdout_handle = child.stdout.take();
+    let stderr_handle = child.stderr.take();
+    let task_id = format!("executor-{}-{}", executor_type, uuid::Uuid::new_v4());
+    send_msg(executor_start_message(executor_type, message));
+    if child.stdin.take().is_some() { tracing::debug!("[debounce] stdin 已关闭"); }
+    let direct_output_info = resolve_direct_output(db, bot_id, receive_id.clone(), receive_id_type).await;
+    let stream_task = tokio::spawn({
+        let (tx, executor, tid) = (tx.clone(), executor.clone(), task_id.clone());
+        async move {
+            stream_executor_stdout(stdout_handle, &executor, &tx, &tid, workspace_id, direct_output_info).await
+        }
+    });
+
+    // ⑥ 带超时等待退出
+    let status = await_executor_exit(child, config, executor_type, &send_msg).await?;
+
+    // ⑦ 收集输出（stream + stderr + 结果文本）
+    let output = collect_executor_output(stream_task, stderr_handle, executor_type).await;
+
+    // 结束内容：当前仅记日志（最后一条 assistant 消息已是结论，发飞书会重复）
+    let _content = build_executor_end_content(
+        executor_type, &status, output.result_text, &output.stream.raw_stdout, &output.stderr,
+    );
+    tracing::info!("[debounce] executor {} result_text={:?}",
+        executor_type, _content.chars().take(200).collect::<String>());
+
+    // ⑧ 成功时持久化 session（best-effort）
+    if status.success() {
+        persist_executor_session(db, &executor, &output.stream.logs, workspace_id, executor_type).await;
+    }
+
+    Ok(crate::executor_service::ExecutionResult { task_id, record_id: None })
+}
+```
+
+## 4. 关键设计决策
+
+1. **`send_msg` 用 `&(dyn Fn(String) + Sync)` 传递**：4 个 helper（①②④⑥）失败时要发飞书提示。把闭包按 trait 对象引用传入，避免在每个 helper 里重建发送逻辑、也避免把 4 个捕获值（tx/bot_id/receive_id/receive_id_type）反复当参数搬。闭包本身是 `Fn + Sync`（捕获值 `&Sender`/`i64`/`&String`/`&str` 皆 Sync），动态分发在「每条飞书消息几次调用」的冷路径上开销可忽略。
+2. **新 helper 全部是自由 `async fn`**（impl 外），与 `wait_child_with_timeout` / `stream_executor_stdout` 一致——它们都不需要 `&self`。放回同一辅助区（`process_executor_stdout_line` 之后、`impl MessageDebounce` 之前/之后的现有辅助带）。
+3. **阶段⑤留在编排体内**：`stream_task` 的 `tokio::spawn` move 了 stdout_handle / tx / executor / task_id 多个本地值，强行抽出要么造一个巨参 helper，要么引入中间 struct，收益 < 成本（YAGNI）。
+4. **`ExecutorOutput` 小 struct**：阶段⑦有 3 个产出（StdoutStreamResult / stderr / result_text），用 struct 打包比 3 个返回值清晰，也给⑧的 session 提取一个稳定的取值入口。
+5. **公开签名与调用方零改动**：`handle_default_response_executor` 签名不变，`dispatch_execution`（`:531`）无需改动——降低 PR 影响面。
+
+## 5. 不变式（行为契约，重构必须逐条保持）
+
+- [x] 6 个返回点的**触发条件与返回值**不变（5 个 `Err(None)` 提前返回 + 末尾 `Ok`）。
+- [x] 每个提前返回前的 **`send_msg` 文案**逐字不变（用既有 `workspace_missing_message` / `executor_error_message`）。
+- [x] 所有 `tracing::info!/warn!/error!/debug!` 的**内容与相对顺序**不变（含 `result_text` 的 200 char 截断、stderr 的 2000 char 截断、session preview 的 20 char 截断）。
+- [x] 副作用顺序不变：发开始消息 → spawn stream_task → 等退出 → join stream → 读 stderr → （成功时）写 session。
+- [x] `_task_manager` 仍未被使用（保留 `_` 前缀）。
+- [x] config 读超时仍用 `#[allow(clippy::expect_used)]` + 「RwLock poisoned」注释。
+- [x] `record_id: None`（executor 通路不存执行记录）不变。
+
+## 6. 测试与验证计划
+
+- **不新增编排函数的单测**：它 spawn 真实进程，无法在单测里可靠复现；为它造 mock 需引入 `Database`/`ExecutorRegistry` 的 trait 抽象，属过度设计（YAGNI），且团队既有约定是「测已抽出的纯逻辑」。
+- **本次抽取未引入新的纯决策**（消息格式、超时、结束内容等纯逻辑已在历史 PR 抽出并测试），故无新的可测纯函数。
+- 验证步骤：
+  1. `cd backend && cargo clippy --all-targets -- -D warnings`（零告警零错误，含新 helper 的参数数量/类型）。
+  2. `cd backend && cargo test`（`executor_feedback_tests` / `merge_pending_messages_tests` / 第 3 mod 全绿——它们覆盖被复用的 helper）。
+  3. 人工 diff 复核：阶段搬运逐条对照「不变式」清单。
+  4. （可选，需本地执行器）`make dev` 后在飞书私聊触发一次直连执行器，观察开始/结果/超时三类消息与重构前一致。
+
+## 7. 风险与回滚
+
+- **风险：低**。纯搬运，无逻辑变更；签名不变；现有测试兜底。
+- **风险点**：`send_msg` 闭包的 `Sync` 约束、`await_executor_exit` 消费 `child`（move）的所有权流转、`stream_task` 的 move 捕获——这些是编译期可捕获的，clippy + build 能挡住。
+- **回滚**：单 PR，`git revert` 即可。建议编码时**一个阶段一次 commit**（①②③一个、④⑤一个、⑥⑦⑧一个、编排体重组一个），便于出问题时 bisect。
+
+## 8. 验收清单
+
+- [x] `handle_default_response_executor` 编排体回归 stepdown 叙事；纯代码约 **85 行**（>50），按 CLAUDE.md **线性管道豁免（场景 2）**——单一 `Ok` 返回 + `?` 透传 helper 的 `Err(None)`（副作用已在 helper 内完成），嵌套 ≤2，逐阶段顺序调用。触发 H2 的红线（多 return 路径 + 副作用混杂）已消除。
+- [x] 8 个新 helper 各自单一职责、带「为什么抽出」注释；纯代码均 ≤28 行，唯 `await_executor_exit` **37 行**——3 臂 match（Ok/Timeout/WaitFailed）的线性错误处理，按 **豁免 #4「卫语句堆积」**，强行拆分每个臂只被调用一次（YAGNI）。
+- [x] 6 个返回点 / 文案 / 日志 / 副作用顺序逐条对照不变式清单一致。
+- [x] `cargo clippy --all-targets -- -D warnings` 零告警。
+- [x] `cargo test` 全绿（本模块 28 个单测 + 全量 1679 单测 + 集成测试 0 失败）。
+- [x] 公开方法签名与 `dispatch_execution` 调用方零改动。
+- [x] PR 描述对应 ADR-005 / H2，附本设计文档链接。


### PR DESCRIPTION
## 概述

落地 [ADR-005](../blob/2c08abcf/docs/decisions/ADR-005-重构与设计模式改进-决策.md) 的 **H2**：把 `handle_default_response_executor`（飞书直连执行器编排，原 280 行）拆成 8 个单一职责 helper + 一个 stepdown 叙事编排体。

> 设计文档：[`docs/design/101-飞书直连执行器编排拆分-设计.md`](../blob/2c08abcf/docs/design/101-飞书直连执行器编排拆分-设计.md)

## 为什么拆

原函数命中 **CLAUDE.md 函数红线**：

> 🚫 无论多少行，只要命中一条就必须重构：**存在多个 return 路径且夹杂副作用**。

280 行、6 个返回点（5 个 `Err(None)` 提前返回 + 1 个 `Ok`），每个提前返回前都 `send_msg` 发飞书消息——返回路径与副作用（发消息 + DB 写 + tx.send）混杂。

## 怎么拆

按线性阶段抽成 8 个自由 `async fn`（与文件既有 `wait_child_with_timeout` 同风格）：

| 阶段 | helper | 职责 |
|---|---|---|
| ① | `resolve_executor_workspace` | DB 查 workspace.path |
| ② | `resolve_executor_instance` | parse_executor_type + registry.get |
| ③ | `resolve_executor_session` | 优先 resume，否则 DB 读已存 session |
| ④ | `spawn_executor_child` | 构建命令 + cmd.spawn() |
| ⑤ | `resolve_direct_output` | 查 push_level，仅 "all" 返回直推目标 |
| ⑥ | `await_executor_exit` | 读超时 + wait_child_with_timeout |
| ⑦ | `collect_executor_output` | join stream + 读 stderr + 提取结果（`ExecutorOutput` 打包） |
| ⑧ | `persist_executor_session` | 成功时 extract + set session（best-effort） |

`send_msg` 闭包统一用 `&(dyn Fn(String) + Sync)` 按引用传入 4 个失败即发消息的 helper，避免每个 helper 重建发送逻辑。

## 行数口径（如实）

| 函数 | 纯代码行 | 说明 |
|---|---|---|
| 编排体 `handle_default_response_executor` | ~85 | CLAUDE.md **线性管道豁免（场景 2）**：单一 `Ok` 返回 + `?` 透传 helper 的 `Err(None)`（副作用已在 helper 内），嵌套 ≤2 |
| 7 个 helper | ≤28 | 达标 |
| `await_executor_exit` | 37 | 3 臂 match（Ok/Timeout/WaitFailed）线性错误处理，**豁免 #4「卫语句堆积」** |

> 触发 H2 的红线（多 return + 副作用混杂）已消除。85 行的编排体是「逐阶段顺序调用 + 两段截断日志 + 12 参数签名」的流水线，强行再拆会变成每个 helper 只被调用一次的参数搬运（YAGNI）。

## 不变式（行为逐条保持）

- 6 个返回点的触发条件与返回值不变；提前返回的飞书文案逐字不变（复用既有 `workspace_missing_message` / `executor_error_message`）。
- 所有 `tracing` 日志内容与相对顺序不变（含 20/200/2000 char 截断）。
- 副作用顺序不变：发开始消息 → spawn stream_task → 等退出 → join stream → 读 stderr →（成功时）写 session。
- **公开签名零改动**，调用方 `dispatch_execution`（:531）不受影响。

## 验证

```
cd backend
cargo clippy --all-targets -- -D warnings   # ✅ 零告警零错误
cargo test --lib services::message_debounce # ✅ 28 passed
cargo test                                  # ✅ 1679 单测 + 集成测试 0 失败
```

不新增编排函数单测：它 spawn 真实执行器进程，单测无法可靠复现；团队既有约定是「测已抽出的纯逻辑」（`executor_feedback_tests` 等 3 个 mod 覆盖被复用的 helper，本次未引入新的纯决策）。

## 依赖

基于 #1034（ADR-005 报告）。合并 #1034 后本 PR 仅显示 H2 一个提交。
