### PR TITLE
feat: 专家贡献——OAuth 登录并提交为官方仓库 Issue

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,13 +91,22 @@ jobs:
         if: matrix.use-cross == true
         env:
           # Mount frontend/dist + ntd-skills for rust-embed + .git for vergen
-          CROSS_CONTAINER_OPTS: "-v ${{ github.workspace }}/frontend/dist:/frontend/dist:ro -v ${{ github.workspace }}/ntd-skills:/ntd-skills:ro -v ${{ github.workspace }}/.git:/project/.git:ro"
+          # -e 显式把 NTD_GITCODE_* 传进 cross 容器（编译期 option_env! 读取）
+          CROSS_CONTAINER_OPTS: "-v ${{ github.workspace }}/frontend/dist:/frontend/dist:ro -v ${{ github.workspace }}/ntd-skills:/ntd-skills:ro -v ${{ github.workspace }}/.git:/project/.git:ro -e NTD_GITCODE_CLIENT_ID -e NTD_GITCODE_CLIENT_SECRET"
           # Point GIT_DIR to where .git is mounted inside the container
           GIT_DIR: /project/.git
+          # 专家贡献 OAuth 凭据：编译期注入。pull_request 事件下 secrets 为空，
+          # 后端会因空值降级为「贡献功能禁用」；仅 tag/release 构建拿到真实凭据。
+          NTD_GITCODE_CLIENT_ID: ${{ secrets.NTD_GITCODE_CLIENT_ID }}
+          NTD_GITCODE_CLIENT_SECRET: ${{ secrets.NTD_GITCODE_CLIENT_SECRET }}
         run: cd backend && cross build --release --target ${{ matrix.target }}
 
       - name: Build (native)
         if: matrix.use-cross == false
+        env:
+          # 专家贡献 OAuth 凭据：编译期注入（macOS 原生构建），同上空值降级。
+          NTD_GITCODE_CLIENT_ID: ${{ secrets.NTD_GITCODE_CLIENT_ID }}
+          NTD_GITCODE_CLIENT_SECRET: ${{ secrets.NTD_GITCODE_CLIENT_SECRET }}
         run: cd backend && cargo build --release --target ${{ matrix.target }}
 
       - name: Prepare binary for upload

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@
 export PATH := $(HOME)/.cargo/bin:$(PATH)
 CARGO_ENV := . $(HOME)/.cargo/env &&
 
+# 编译期 GitCode OAuth 凭据：从用户 shell rc 文件提取 export 行并加载。
+# make 的 recipe 用 /bin/sh 执行，不会自动加载 zshrc/bashrc；而 zshrc 含 zsh 专有
+# 语法无法直接 source，故用 grep 只提取需要的两行，避免引入 .env 文件。
+# 提取结果是 `export NTD_GITCODE_CLIENT_ID="..." export NTD_GITCODE_CLIENT_SECRET="..."`
+# 形式的 shell 语句，插到 cargo 命令前即可让 option_env! 读到凭据。
+GITCODE_OAUTH_ENV := $(shell grep -h '^export NTD_GITCODE_CLIENT' $(HOME)/.zshrc $(HOME)/.bashrc 2>/dev/null)
+
 # Setup: install all dependencies for frontend and backend
 setup:
 	@echo "=== Setting up ntd ==="
@@ -42,7 +49,7 @@ install:  build
 # Build frontend and embed into Rust binary
 build:
 	cd frontend && npm run build
-	cd backend && $(CARGO_ENV) cargo build --release
+	cd backend && $(CARGO_ENV) $(GITCODE_OAUTH_ENV) cargo build --release
 
 # Clean all build artifacts
 clean:
@@ -78,7 +85,7 @@ dev: stop
 	@echo "[1/2] Building frontend..."
 	cd frontend && npm run build
 	@echo "[2/2] Building & running backend..."
-	cd backend && $(CARGO_ENV) NTD_MODE=dev RUST_BACKTRACE=1 RUST_LOG=info cargo run -- server start 2>&1 | tee ../backend.dev.log &
+	cd backend && $(CARGO_ENV) $(GITCODE_OAUTH_ENV) NTD_MODE=dev RUST_BACKTRACE=1 RUST_LOG=info cargo run -- server start 2>&1 | tee ../backend.dev.log &
 	@mkdir -p $$HOME/.ntd && echo $$! > $$HOME/.ntd/dev.pid
 	@echo "==========================================="
 	@echo "  Dev mode: http://localhost:18088"

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,10 @@ CARGO_ENV := . $(HOME)/.cargo/env &&
 # 编译期 GitCode OAuth 凭据：从用户 shell rc 文件提取 export 行并加载。
 # make 的 recipe 用 /bin/sh 执行，不会自动加载 zshrc/bashrc；而 zshrc 含 zsh 专有
 # 语法无法直接 source，故用 grep 只提取需要的两行，避免引入 .env 文件。
-# 提取结果是 `export NTD_GITCODE_CLIENT_ID="..." export NTD_GITCODE_CLIENT_SECRET="..."`
-# 形式的 shell 语句，插到 cargo 命令前即可让 option_env! 读到凭据。
-GITCODE_OAUTH_ENV := $(shell grep -h '^export NTD_GITCODE_CLIENT' $(HOME)/.zshrc $(HOME)/.bashrc 2>/dev/null)
+# 提取结果去掉 `export` 关键字，得到 `NAME=value NAME=value` 列表，作为 cargo 命令前
+# 的环境变量前缀（不能用 `export` 语句，否则 shell 会把后面的 NTD_MODE/RUST_* 等参数
+# 也当变量名，报 `export: --: not a valid identifier`）。
+GITCODE_OAUTH_ENV := $(shell grep -h '^export NTD_GITCODE_CLIENT' $(HOME)/.zshrc $(HOME)/.bashrc 2>/dev/null | sed 's/^export //')
 
 # Setup: install all dependencies for frontend and backend
 setup:

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1767,6 +1767,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "chrono-tz",
  "clap",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -50,6 +50,8 @@ semver = "1"
 # MIME 类型推断库：根据文件扩展名返回标准 MIME，避免手写 if-else 漏覆盖、大小写敏感等问题。
 # 选用 2.x，与既有 `mime` 生态（http::HeaderValue）兼容。
 mime_guess = "2"
+# base64 编码：贡献 PR 时把专家文件内容编码后通过 GitCode contents API 写入 fork 仓库。
+base64 = "0.22"
 sea-orm = { version = "1", features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros", "with-chrono", "with-json"] }
 sqlx = { version = "0.7", default-features = false, features = ["sqlite", "runtime-tokio-rustls"] }
 # wait-timeout：给 WorktreeService 的 git 子命令加超时，避免 git 在持有锁 / I/O 卡顿时无限阻塞。

--- a/backend/build.rs
+++ b/backend/build.rs
@@ -13,6 +13,12 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let dist_path = PathBuf::from(&manifest_dir).join("../frontend/dist");
 
+    // 让 cargo 跟踪贡献 OAuth 凭据环境变量：值变化时触发重编。
+    // option_env! 在编译期读取，若不声明 rerun-if-env-changed，
+    // 改了 env 但源码未变时 cargo 不会重编，凭据注入会静默失效。
+    println!("cargo:rerun-if-env-changed=NTD_GITCODE_CLIENT_ID");
+    println!("cargo:rerun-if-env-changed=NTD_GITCODE_CLIENT_SECRET");
+
     if dist_path.exists() {
         println!("cargo:rerun-if-changed={}", dist_path.display());
     }

--- a/backend/src/contribution/gitcode.rs
+++ b/backend/src/contribution/gitcode.rs
@@ -20,8 +20,9 @@ const TOKEN_URL: &str = "https://gitcode.com/oauth/token";
 const API_BASE: &str = "https://api.gitcode.com";
 /// 创建贡献 Issue 时打上的固定标签，便于官方仓库后台筛选。
 const CONTRIBUTION_LABEL: &str = "expert-contribution";
-/// 创建 Issue 时申请的 OAuth 权限范围：仅 issue，遵循最小权限。
-const ISSUE_SCOPE: &str = "all_issue";
+/// 发起贡献 PR 所需的 OAuth 权限范围：用户信息 + 仓库读写（fork/写文件/建分支）+ PR。
+/// 比纯 issue 更宽，因为 PR 需要 fork 官方仓库并向 fork 写入专家文件。
+const PR_SCOPE: &str = "all_user all_projects all_pr all_repository";
 
 /// 贡献功能是否启用：`client_id` 与 `client_secret` 均已注入且非空。
 ///
@@ -76,7 +77,7 @@ pub fn build_authorize_url(client_id: &str, redirect_uri: &str, state: &str) -> 
         .append_pair("client_id", client_id)
         .append_pair("redirect_uri", redirect_uri)
         .append_pair("response_type", "code")
-        .append_pair("scope", ISSUE_SCOPE)
+        .append_pair("scope", PR_SCOPE)
         .append_pair("state", state);
     url.to_string()
 }
@@ -253,6 +254,200 @@ fn extract_issue_url(resp: &serde_json::Value, owner: &str, repo: &str, number: 
         .unwrap_or_else(|| format!("https://gitcode.com/{owner}/{repo}/issues/{number}"))
 }
 
+/// 创建 PR 的结果（返回给前端）。
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PrResult {
+    /// PR 编号
+    pub pr_number: String,
+    /// PR 网页链接
+    pub pr_url: String,
+    /// PR 标题
+    pub title: String,
+}
+
+/// 获取当前授权用户的 username（作为 fork 后的 owner）。
+pub async fn get_current_username(access_token: &str) -> Result<String, String> {
+    let response = reqwest::Client::new()
+        .get(format!("{API_BASE}/api/v5/user"))
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .map_err(|_| "请求用户信息失败".to_string())?;
+    let status = response.status();
+    let body_text = response
+        .text()
+        .await
+        .map_err(|_| "读取用户响应失败".to_string())?;
+    if !status.is_success() {
+        return Err(format!(
+            "获取用户信息失败（HTTP {status}）: {}",
+            truncate_for_log(&body_text)
+        ));
+    }
+    let resp: serde_json::Value =
+        serde_json::from_str(&body_text).map_err(|_| "解析用户响应失败".to_string())?;
+    resp.get("login")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| "用户响应缺少 login 字段".to_string())
+}
+
+/// 确保官方仓库已 fork 到当前用户：fork 成功或「已 fork」都视为就绪。
+pub async fn ensure_fork(access_token: &str, owner: &str, repo: &str) -> Result<(), String> {
+    let response = reqwest::Client::new()
+        .post(format!("{API_BASE}/api/v5/repos/{owner}/{repo}/forks"))
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .map_err(|_| "请求 fork 仓库失败".to_string())?;
+    let status = response.status();
+    let body_text = response
+        .text()
+        .await
+        .map_err(|_| "读取 fork 响应失败".to_string())?;
+    if status.is_success() {
+        return Ok(());
+    }
+    // 已 fork 过（409/422）视为成功，复用现有 fork；其余错误上抛。
+    if status == reqwest::StatusCode::CONFLICT || status == reqwest::StatusCode::UNPROCESSABLE_ENTITY {
+        return Ok(());
+    }
+    Err(format!(
+        "fork 仓库失败（HTTP {status}）: {}",
+        truncate_for_log(&body_text)
+    ))
+}
+
+/// 在仓库上创建分支。
+pub async fn create_branch(
+    access_token: &str,
+    owner: &str,
+    repo: &str,
+    branch_name: &str,
+    refs: &str,
+) -> Result<(), String> {
+    let response = reqwest::Client::new()
+        .post(format!("{API_BASE}/api/v5/repos/{owner}/{repo}/branches"))
+        .bearer_auth(access_token)
+        .json(&serde_json::json!({"branch_name": branch_name, "refs": refs}))
+        .send()
+        .await
+        .map_err(|_| "请求创建分支失败".to_string())?;
+    let status = response.status();
+    let body_text = response
+        .text()
+        .await
+        .map_err(|_| "读取建分支响应失败".to_string())?;
+    if !status.is_success() {
+        return Err(format!(
+            "创建分支 {branch_name} 失败（HTTP {status}）: {}",
+            truncate_for_log(&body_text)
+        ));
+    }
+    Ok(())
+}
+
+/// 向仓库分支写入一个文件（content 为 base64 编码的字节内容）。
+pub async fn create_file(
+    access_token: &str,
+    owner: &str,
+    repo: &str,
+    branch: &str,
+    path: &str,
+    content_base64: &str,
+    message: &str,
+) -> Result<(), String> {
+    let url = contents_url(owner, repo, path)?;
+    let response = reqwest::Client::new()
+        .post(&url)
+        .bearer_auth(access_token)
+        .form(&[
+            ("content", content_base64),
+            ("message", message),
+            ("branch", branch),
+        ])
+        .send()
+        .await
+        .map_err(|_| "请求写入文件失败".to_string())?;
+    let status = response.status();
+    let body_text = response
+        .text()
+        .await
+        .map_err(|_| "读取写文件响应失败".to_string())?;
+    if !status.is_success() {
+        return Err(format!(
+            "写入文件 {path} 失败（HTTP {status}）: {}",
+            truncate_for_log(&body_text)
+        ));
+    }
+    Ok(())
+}
+
+/// 构造 contents API 完整 URL，path 各段做 URL 编码（防空格/中文等破坏 URL）。
+fn contents_url(owner: &str, repo: &str, path: &str) -> Result<String, String> {
+    let mut url = reqwest::Url::parse(&format!("{API_BASE}/api/v5/repos/{owner}/{repo}/contents"))
+        .map_err(|_| "构造 contents URL 失败".to_string())?;
+    {
+        let mut segs = url
+            .path_segments_mut()
+            .map_err(|_| "无法修改 URL 路径".to_string())?;
+        for seg in path.split('/') {
+            segs.push(seg);
+        }
+    }
+    Ok(url.to_string())
+}
+
+/// 创建 Pull Request：head 为源（fork 的 `owner:branch`），base 为目标分支。
+pub async fn create_pr(
+    access_token: &str,
+    owner: &str,
+    repo: &str,
+    title: &str,
+    body: &str,
+    head: &str,
+    base: &str,
+) -> Result<PrResult, String> {
+    let response = reqwest::Client::new()
+        .post(format!("{API_BASE}/api/v5/repos/{owner}/{repo}/pulls"))
+        .bearer_auth(access_token)
+        .json(&serde_json::json!({"title": title, "body": body, "head": head, "base": base}))
+        .send()
+        .await
+        .map_err(|_| "请求创建 PR 失败".to_string())?;
+    let status = response.status();
+    let body_text = response
+        .text()
+        .await
+        .map_err(|_| "读取 PR 响应失败".to_string())?;
+    if !status.is_success() {
+        return Err(format!(
+            "创建 PR 失败（HTTP {status}）: {}",
+            truncate_for_log(&body_text)
+        ));
+    }
+    let resp: serde_json::Value =
+        serde_json::from_str(&body_text).map_err(|_| "解析 PR 响应失败".to_string())?;
+    // number 提取逻辑与 issue 通用（兼容数字/字符串），复用同一函数。
+    let pr_number = extract_issue_number(&resp);
+    let pr_url = resp
+        .get("html_url")
+        .and_then(|v| v.as_str())
+        .or_else(|| resp.get("url").and_then(|v| v.as_str()))
+        .map(String::from)
+        .unwrap_or_else(|| format!("https://gitcode.com/{owner}/{repo}/pulls/{pr_number}"));
+    let title = resp
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or(title)
+        .to_string();
+    Ok(PrResult {
+        pr_number,
+        pr_url,
+        title,
+    })
+}
+
 /// 截断日志/错误信息里的响应体，避免超长 body 刷屏。
 fn truncate_for_log(s: &str) -> String {
     const MAX: usize = 200;
@@ -311,7 +506,8 @@ mod tests {
         assert!(url.starts_with("https://gitcode.com/oauth/authorize?"));
         assert!(url.contains("client_id=cid"));
         assert!(url.contains("response_type=code"));
-        assert!(url.contains("scope=all_issue"));
+        // scope 已改为 PR 所需权限组合，值经 URL 编码（空格变 +），只断言前缀。
+        assert!(url.contains("scope=all_user"));
         assert!(url.contains("state=s123"));
     }
 
@@ -370,5 +566,12 @@ mod tests {
         let out = truncate_for_log(&long);
         assert!(out.contains("已截断"));
         assert!(out.chars().count() < 300);
+    }
+
+    #[test]
+    fn contents_url_encodes_path_segments() {
+        let url = contents_url("o", "r", "a b/c.md").unwrap();
+        // 空格被编码为 %20，`/` 作为路径分隔保留。
+        assert!(url.ends_with("/contents/a%20b/c.md"));
     }
 }

--- a/backend/src/contribution/gitcode.rs
+++ b/backend/src/contribution/gitcode.rs
@@ -1,0 +1,265 @@
+//! GitCode 平台集成：凭据常量、owner/repo 解析、OAuth 与 Issue 的 HTTP 调用。
+
+use serde::Deserialize;
+
+use super::{now_unix, GitCodeToken};
+
+/// 编译期注入的 OAuth `client_id`：未设置环境变量 `NTD_CONTRIB_CLIENT_ID` 时为 `None`。
+///
+/// 使用 `option_env!` 而非 `env!`：凭据缺失时编译通过、功能降级禁用，
+/// 不会因为没配置凭据而编译失败。
+pub const CLIENT_ID: Option<&str> = option_env!("NTD_CONTRIB_CLIENT_ID");
+/// 编译期注入的 OAuth `client_secret`：同上，未设置为 `None`。
+pub const CLIENT_SECRET: Option<&str> = option_env!("NTD_CONTRIB_CLIENT_SECRET");
+
+/// GitCode OAuth 授权端点（平台固定地址，不属于用户配置）。
+const AUTHORIZE_URL: &str = "https://gitcode.com/oauth/authorize";
+/// GitCode OAuth token 端点。
+const TOKEN_URL: &str = "https://gitcode.com/oauth/token";
+/// GitCode OpenAPI 基础地址。
+const API_BASE: &str = "https://api.gitcode.com";
+/// 创建贡献 Issue 时打上的固定标签，便于官方仓库后台筛选。
+const CONTRIBUTION_LABEL: &str = "expert-contribution";
+/// 创建 Issue 时申请的 OAuth 权限范围：仅 issue，遵循最小权限。
+const ISSUE_SCOPE: &str = "all_issue";
+
+/// 贡献功能是否启用：`client_id` 与 `client_secret` 均已注入。
+pub fn contribution_enabled() -> bool {
+    CLIENT_ID.is_some() && CLIENT_SECRET.is_some()
+}
+
+/// 从 bundled 仓库 `url` 解析 `(owner, repo)`。
+///
+/// 支持 `https://gitcode.com/weibaohui/ntd-resource.git` 与不带 `.git` 的形式；
+/// 解析失败（非 http(s)、段数不足、owner/repo 为空）返回 `None`。
+pub fn parse_owner_repo(url: &str) -> Option<(String, String)> {
+    // 仅处理 http(s)，剥离协议前缀。
+    let without_scheme = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    // 按 '/' 切分，过滤空段；末尾两段分别为 owner 与 repo。
+    let segments: Vec<&str> = without_scheme
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .collect();
+    // 至少需要 host + owner + repo 三段。
+    if segments.len() < 3 {
+        return None;
+    }
+    let owner = segments[segments.len() - 2].to_string();
+    let repo = segments[segments.len() - 1].trim_end_matches(".git").to_string();
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner, repo))
+}
+
+/// 拼装 OAuth 授权跳转 URL（query 参数由 `reqwest::Url` 自动做 URL 编码）。
+pub fn build_authorize_url(client_id: &str, redirect_uri: &str, state: &str) -> String {
+    // AUTHORIZE_URL 是编译期常量，parse 失败只可能是代码错误；
+    // 用 let-else 返回空串，避免生产代码使用 expect/panic。
+    let Ok(mut url) = reqwest::Url::parse(AUTHORIZE_URL) else {
+        return String::new();
+    };
+    url.query_pairs_mut()
+        .append_pair("client_id", client_id)
+        .append_pair("redirect_uri", redirect_uri)
+        .append_pair("response_type", "code")
+        .append_pair("scope", ISSUE_SCOPE)
+        .append_pair("state", state);
+    url.to_string()
+}
+
+/// GitCode token 接口响应体。
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    refresh_token: String,
+    expires_in: i64,
+    scope: Option<String>,
+}
+
+impl TokenResponse {
+    /// 把 token 接口响应转换为带绝对过期时间的 `GitCodeToken`。
+    fn into_token(self, now: i64) -> GitCodeToken {
+        GitCodeToken {
+            access_token: self.access_token,
+            refresh_token: self.refresh_token,
+            // 绝对过期时间 = 当前时间 + 相对有效期；用绝对值便于持久化后离线判断。
+            expires_at: now + self.expires_in,
+            scope: self.scope,
+        }
+    }
+}
+
+/// 用授权码换取访问令牌。
+///
+/// GitCode 约定：`grant_type`/`code`/`client_id` 走 query，`client_secret` 走 form-data。
+pub async fn exchange_code_for_token(code: &str) -> Result<GitCodeToken, String> {
+    let client_id = CLIENT_ID.ok_or_else(|| "未配置 client_id".to_string())?;
+    let client_secret = CLIENT_SECRET.ok_or_else(|| "未配置 client_secret".to_string())?;
+    let now = now_unix();
+    let response = reqwest::Client::new()
+        .post(TOKEN_URL)
+        .query(&[
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("client_id", client_id),
+        ])
+        .form(&[("client_secret", client_secret)])
+        .send()
+        .await
+        .map_err(|_| "请求 token 端点失败".to_string())?;
+    // 用 status 而非 error_for_status 的错误原文：后者 Display 含带 code 的完整 URL，
+    // 若透传会把一次性授权码泄露到前端页面/日志。
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!("换取 token 失败（HTTP {status}）"));
+    }
+    let resp: TokenResponse = response
+        .json()
+        .await
+        .map_err(|_| "解析 token 响应失败".to_string())?;
+    Ok(resp.into_token(now))
+}
+
+/// 用 refresh_token 刷新访问令牌。
+pub async fn refresh_access_token(refresh_token: &str) -> Result<GitCodeToken, String> {
+    let now = now_unix();
+    let response = reqwest::Client::new()
+        .post(TOKEN_URL)
+        .query(&[
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token),
+        ])
+        .send()
+        .await
+        .map_err(|_| "请求刷新 token 失败".to_string())?;
+    // 同上：refresh_token 也在 query 里，错误原文不得透传。
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!("刷新 token 失败（HTTP {status}）"));
+    }
+    let resp: TokenResponse = response
+        .json()
+        .await
+        .map_err(|_| "解析刷新响应失败".to_string())?;
+    Ok(resp.into_token(now))
+}
+
+/// GitCode 创建 Issue 响应体（字段名以真实 API 为准，用 Option 容错）。
+#[derive(Debug, Deserialize)]
+struct CreateIssueResponse {
+    number: Option<i64>,
+    html_url: Option<String>,
+    url: Option<String>,
+    title: Option<String>,
+}
+
+/// 创建 Issue 的结果（返回给前端）。
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct IssueResult {
+    /// Issue 编号
+    pub issue_number: i64,
+    /// Issue 网页链接
+    pub issue_url: String,
+    /// Issue 标题
+    pub title: String,
+}
+
+/// 调用 GitCode API 创建 Issue。
+///
+/// 端点歧义说明：官方文档「创建 Issue」标题写作 `/repos/:owner/issues`，
+/// 其余 Issue 接口均为 `/repos/:owner/:repo/issues`；此处采用与其余接口一致的
+/// `/repos/{owner}/{repo}/issues`，若真实请求 404 再据验证结果调整。
+/// `labels` 沿用 Gitee `/api/v5` 语义（逗号分隔字符串），真实验证时确认。
+pub async fn create_issue(
+    owner: &str,
+    repo: &str,
+    access_token: &str,
+    title: &str,
+    body: &str,
+) -> Result<IssueResult, String> {
+    let resp: CreateIssueResponse = reqwest::Client::new()
+        .post(format!("{API_BASE}/api/v5/repos/{owner}/{repo}/issues"))
+        .bearer_auth(access_token)
+        .json(&serde_json::json!({
+            "title": title,
+            "body": body,
+            "labels": CONTRIBUTION_LABEL,
+        }))
+        .send()
+        .await
+        .map_err(|e| format!("请求创建 Issue 失败: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("创建 Issue 失败: {e}"))?
+        .json()
+        .await
+        .map_err(|e| format!("解析 Issue 响应失败: {e}"))?;
+
+    // 优先用官方返回的链接，缺失时用编号拼网页链接兜底。
+    let number = resp.number.unwrap_or(0);
+    let issue_url = resp
+        .html_url
+        .or(resp.url)
+        .unwrap_or_else(|| format!("https://gitcode.com/{owner}/{repo}/issues/{number}"));
+    let title = resp.title.unwrap_or_else(|| title.to_string());
+    Ok(IssueResult {
+        issue_number: number,
+        issue_url,
+        title,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_owner_repo_https_with_git() {
+        let (owner, repo) =
+            parse_owner_repo("https://gitcode.com/weibaohui/ntd-resource.git").unwrap();
+        assert_eq!(owner, "weibaohui");
+        assert_eq!(repo, "ntd-resource");
+    }
+
+    #[test]
+    fn parse_owner_repo_https_without_git() {
+        let (owner, repo) = parse_owner_repo("https://gitcode.com/weibaohui/ntd-resource").unwrap();
+        assert_eq!(owner, "weibaohui");
+        assert_eq!(repo, "ntd-resource");
+    }
+
+    #[test]
+    fn parse_owner_repo_http() {
+        let (owner, repo) = parse_owner_repo("http://gitcode.com/a/b").unwrap();
+        assert_eq!(owner, "a");
+        assert_eq!(repo, "b");
+    }
+
+    #[test]
+    fn parse_owner_repo_nested_path_uses_last_two() {
+        let (owner, repo) = parse_owner_repo("https://host/org/group/repo.git").unwrap();
+        assert_eq!(owner, "group");
+        assert_eq!(repo, "repo");
+    }
+
+    #[test]
+    fn parse_owner_repo_rejects_ssh_and_invalid() {
+        assert!(parse_owner_repo("git@gitcode.com:weibaohui/ntd-resource.git").is_none());
+        assert!(parse_owner_repo("").is_none());
+        assert!(parse_owner_repo("https://host/onlyowner").is_none());
+        assert!(parse_owner_repo("https://host/").is_none());
+    }
+
+    #[test]
+    fn build_authorize_url_contains_expected_params() {
+        let url = build_authorize_url("cid", "http://localhost:18088/cb", "s123");
+        assert!(url.starts_with("https://gitcode.com/oauth/authorize?"));
+        assert!(url.contains("client_id=cid"));
+        assert!(url.contains("response_type=code"));
+        assert!(url.contains("scope=all_issue"));
+        assert!(url.contains("state=s123"));
+    }
+}

--- a/backend/src/contribution/gitcode.rs
+++ b/backend/src/contribution/gitcode.rs
@@ -158,20 +158,11 @@ pub async fn refresh_access_token(refresh_token: &str) -> Result<GitCodeToken, S
     Ok(resp.into_token(now))
 }
 
-/// GitCode 创建 Issue 响应体（字段名以真实 API 为准，用 Option 容错）。
-#[derive(Debug, Deserialize)]
-struct CreateIssueResponse {
-    number: Option<i64>,
-    html_url: Option<String>,
-    url: Option<String>,
-    title: Option<String>,
-}
-
 /// 创建 Issue 的结果（返回给前端）。
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct IssueResult {
-    /// Issue 编号
-    pub issue_number: i64,
+    /// Issue 编号（GitCode 沿用 Gitee 语义，编号是字符串，如 "I5YJX2"）
+    pub issue_number: String,
     /// Issue 网页链接
     pub issue_url: String,
     /// Issue 标题
@@ -191,7 +182,7 @@ pub async fn create_issue(
     title: &str,
     body: &str,
 ) -> Result<IssueResult, String> {
-    let resp: CreateIssueResponse = reqwest::Client::new()
+    let response = reqwest::Client::new()
         .post(format!("{API_BASE}/api/v5/repos/{owner}/{repo}/issues"))
         .bearer_auth(access_token)
         .json(&serde_json::json!({
@@ -201,25 +192,75 @@ pub async fn create_issue(
         }))
         .send()
         .await
-        .map_err(|e| format!("请求创建 Issue 失败: {e}"))?
-        .error_for_status()
-        .map_err(|e| format!("创建 Issue 失败: {e}"))?
-        .json()
-        .await
-        .map_err(|e| format!("解析 Issue 响应失败: {e}"))?;
+        .map_err(|_| "请求创建 Issue 失败".to_string())?;
 
-    // 优先用官方返回的链接，缺失时用编号拼网页链接兜底。
-    let number = resp.number.unwrap_or(0);
-    let issue_url = resp
-        .html_url
-        .or(resp.url)
-        .unwrap_or_else(|| format!("https://gitcode.com/{owner}/{repo}/issues/{number}"));
-    let title = resp.title.unwrap_or_else(|| title.to_string());
+    let status = response.status();
+    // 先取原始文本：非 2xx 或非 JSON 时能带上 body 帮助定位（响应是用户自己的 issue，不含凭据）。
+    let body_text = response
+        .text()
+        .await
+        .map_err(|_| "读取 Issue 响应失败".to_string())?;
+
+    if !status.is_success() {
+        return Err(format!(
+            "创建 Issue 失败（HTTP {status}）: {}",
+            truncate_for_log(&body_text)
+        ));
+    }
+
+    // 解析为通用 JSON 再宽松提取字段；GitCode 的 number 是字符串，不能用 i64 强反序列化。
+    let resp: serde_json::Value = serde_json::from_str(&body_text).map_err(|_| {
+        format!("解析 Issue 响应失败（非 JSON）: {}", truncate_for_log(&body_text))
+    })?;
+
+    let issue_number = extract_issue_number(&resp);
+    let issue_url = extract_issue_url(&resp, owner, repo, &issue_number);
+    let title = resp
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or(title)
+        .to_string();
+
     Ok(IssueResult {
-        issue_number: number,
+        issue_number,
         issue_url,
         title,
     })
+}
+
+/// 从响应里提取 Issue 编号：优先 `number`，其次 `id`；数字或字符串都兼容。
+fn extract_issue_number(resp: &serde_json::Value) -> String {
+    resp.get("number")
+        .and_then(number_value_to_string)
+        .or_else(|| resp.get("id").and_then(number_value_to_string))
+        .unwrap_or_else(|| "?".to_string())
+}
+
+/// 把数字或字符串类型的 JSON 值统一转为字符串（GitCode 的 number 是字符串）。
+fn number_value_to_string(v: &serde_json::Value) -> Option<String> {
+    if let Some(s) = v.as_str() {
+        return Some(s.to_string());
+    }
+    v.as_i64().map(|n| n.to_string())
+}
+
+/// 提取 Issue 网页链接：优先官方返回的 html_url / url，缺失时用编号拼兜底。
+fn extract_issue_url(resp: &serde_json::Value, owner: &str, repo: &str, number: &str) -> String {
+    resp.get("html_url")
+        .and_then(|v| v.as_str())
+        .or_else(|| resp.get("url").and_then(|v| v.as_str()))
+        .map(String::from)
+        .unwrap_or_else(|| format!("https://gitcode.com/{owner}/{repo}/issues/{number}"))
+}
+
+/// 截断日志/错误信息里的响应体，避免超长 body 刷屏。
+fn truncate_for_log(s: &str) -> String {
+    const MAX: usize = 200;
+    if s.chars().count() <= MAX {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(MAX).collect();
+    format!("{head}...（已截断，共 {} 字符）", s.chars().count())
 }
 
 #[cfg(test)]
@@ -279,5 +320,55 @@ mod tests {
         assert!(credential_present(Some("x")));
         assert!(!credential_present(Some("")));
         assert!(!credential_present(None));
+    }
+
+    #[test]
+    fn extract_issue_number_prefers_string_number() {
+        let v = serde_json::json!({"number": "I5YJX2"});
+        assert_eq!(extract_issue_number(&v), "I5YJX2");
+    }
+
+    #[test]
+    fn extract_issue_number_accepts_numeric_number() {
+        let v = serde_json::json!({"number": 123});
+        assert_eq!(extract_issue_number(&v), "123");
+    }
+
+    #[test]
+    fn extract_issue_number_falls_back_to_id() {
+        let v = serde_json::json!({"id": 456});
+        assert_eq!(extract_issue_number(&v), "456");
+    }
+
+    #[test]
+    fn extract_issue_number_missing_returns_placeholder() {
+        let v = serde_json::json!({});
+        assert_eq!(extract_issue_number(&v), "?");
+    }
+
+    #[test]
+    fn extract_issue_url_prefers_html_url() {
+        let v = serde_json::json!({"html_url": "https://gitcode.com/o/r/issues/I1"});
+        assert_eq!(
+            extract_issue_url(&v, "o", "r", "I1"),
+            "https://gitcode.com/o/r/issues/I1"
+        );
+    }
+
+    #[test]
+    fn extract_issue_url_falls_back_to_constructed() {
+        let v = serde_json::json!({});
+        assert_eq!(
+            extract_issue_url(&v, "o", "r", "I1"),
+            "https://gitcode.com/o/r/issues/I1"
+        );
+    }
+
+    #[test]
+    fn truncate_for_log_truncates_long_text() {
+        let long = "x".repeat(300);
+        let out = truncate_for_log(&long);
+        assert!(out.contains("已截断"));
+        assert!(out.chars().count() < 300);
     }
 }

--- a/backend/src/contribution/gitcode.rs
+++ b/backend/src/contribution/gitcode.rs
@@ -4,13 +4,13 @@ use serde::Deserialize;
 
 use super::{now_unix, GitCodeToken};
 
-/// 编译期注入的 OAuth `client_id`：未设置环境变量 `NTD_CONTRIB_CLIENT_ID` 时为 `None`。
+/// 编译期注入的 OAuth `client_id`：未设置环境变量 `NTD_GITCODE_CLIENT_ID` 时为 `None`。
 ///
 /// 使用 `option_env!` 而非 `env!`：凭据缺失时编译通过、功能降级禁用，
 /// 不会因为没配置凭据而编译失败。
-pub const CLIENT_ID: Option<&str> = option_env!("NTD_CONTRIB_CLIENT_ID");
+pub const CLIENT_ID: Option<&str> = option_env!("NTD_GITCODE_CLIENT_ID");
 /// 编译期注入的 OAuth `client_secret`：同上，未设置为 `None`。
-pub const CLIENT_SECRET: Option<&str> = option_env!("NTD_CONTRIB_CLIENT_SECRET");
+pub const CLIENT_SECRET: Option<&str> = option_env!("NTD_GITCODE_CLIENT_SECRET");
 
 /// GitCode OAuth 授权端点（平台固定地址，不属于用户配置）。
 const AUTHORIZE_URL: &str = "https://gitcode.com/oauth/authorize";
@@ -23,9 +23,20 @@ const CONTRIBUTION_LABEL: &str = "expert-contribution";
 /// 创建 Issue 时申请的 OAuth 权限范围：仅 issue，遵循最小权限。
 const ISSUE_SCOPE: &str = "all_issue";
 
-/// 贡献功能是否启用：`client_id` 与 `client_secret` 均已注入。
+/// 贡献功能是否启用：`client_id` 与 `client_secret` 均已注入且非空。
+///
+/// 判空原因：CI 在 pull_request 事件下 `secrets` 会展开为空字符串，
+/// 此时 `option_env!` 读到 `Some("")` 而非 `None`；若不判空会误判 enabled=true。
 pub fn contribution_enabled() -> bool {
-    CLIENT_ID.is_some() && CLIENT_SECRET.is_some()
+    credential_present(CLIENT_ID) && credential_present(CLIENT_SECRET)
+}
+
+/// 判断单个凭据是否有效注入（`Some` 且非空）。
+///
+/// 抽成纯函数便于单测：`option_env!` 的结果在编译期固化，无法在测试里改变，
+/// 但判空逻辑本身可独立验证。
+fn credential_present(value: Option<&str>) -> bool {
+    matches!(value, Some(v) if !v.is_empty())
 }
 
 /// 从 bundled 仓库 `url` 解析 `(owner, repo)`。
@@ -261,5 +272,12 @@ mod tests {
         assert!(url.contains("response_type=code"));
         assert!(url.contains("scope=all_issue"));
         assert!(url.contains("state=s123"));
+    }
+
+    #[test]
+    fn credential_present_requires_some_and_non_empty() {
+        assert!(credential_present(Some("x")));
+        assert!(!credential_present(Some("")));
+        assert!(!credential_present(None));
     }
 }

--- a/backend/src/contribution/issue.rs
+++ b/backend/src/contribution/issue.rs
@@ -40,6 +40,13 @@ fn walk_dir(base: &Path, dir: &Path, out: &mut Vec<ExpertFile>) -> Result<(), St
         .map_err(|e| format!("读取目录 {} 失败: {e}", dir.display()))?;
     for entry in entries.flatten() {
         let path = entry.path();
+        // 跳过同步/来源产生的元数据：时间戳文件、skill 来源目录、git 目录，
+        // 它们不是专家内容本身，不应随贡献提交到官方仓库。
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if matches!(name.as_ref(), ".downloaded_at" | ".clawhub" | ".git") {
+            continue;
+        }
         // file_type 不跟随符号链接：symlink 的 is_dir 为 false，不会递归进去。
         let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
         if is_dir {
@@ -186,5 +193,21 @@ mod tests {
         assert!(draft.files.iter().any(|f| f == ".codebuddy-plugin/plugin.json"));
         assert!(draft.files.iter().any(|f| f == "agents/demo.md"));
         assert!(draft.files.iter().any(|f| f == "skills/my-skill/SKILL.md"));
+    }
+
+    #[test]
+    fn collect_expert_files_skips_sync_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let expert = build_sample_expert(dir.path());
+        // 追加同步/来源元数据，应被过滤。
+        fs::write(dir.path().join(".downloaded_at"), "2026-01-01").unwrap();
+        let clawhub = dir.path().join(".clawhub");
+        fs::create_dir_all(&clawhub).unwrap();
+        fs::write(clawhub.join("origin.json"), "{}").unwrap();
+
+        let files = collect_expert_files(&expert).unwrap();
+        let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+        assert!(!paths.contains(&".downloaded_at"));
+        assert!(!paths.iter().any(|p| p.contains(".clawhub")));
     }
 }

--- a/backend/src/contribution/issue.rs
+++ b/backend/src/contribution/issue.rs
@@ -1,56 +1,79 @@
-//! 读取本地专家目录，组装贡献 Issue 的标题与 Markdown body。
+//! 读取本地专家目录，打包为 PR 提交内容：文件清单 + 简短 PR 描述。
+//!
+//! PR 方案下专家以真实文件提交（含二进制头像等），正文只放简短的元信息表格与文件清单。
 
 use std::path::Path;
 
-use crate::expert::loader::resolve_within;
 use crate::expert::{ExpertMetadata, ExpertType};
 
-/// 贡献 Issue 草稿：标题 + Markdown body + 已打包的文件清单。
+/// 贡献草稿（预览用）：标题 + 简短描述 + 文件清单。
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct IssueDraft {
-    /// Issue 标题
+    /// PR 标题
     pub title: String,
-    /// Issue Markdown 正文
+    /// PR 简短描述（Markdown）
     pub body: String,
-    /// 已打包进 body 的文件相对路径清单（用于前端预览展示）
+    /// 待提交文件的相对路径清单
     pub files: Vec<String>,
 }
 
-/// 组装专家贡献 Issue 草稿。
-///
-/// body 依次内嵌 plugin.json、agents/*.md、skills/*/SKILL.md 的完整文本；
-/// 每个文件用 <details> 折叠，正文只保留元信息表格 + 文件清单，避免正文冗长。
-pub fn build_issue_draft(expert: &ExpertMetadata) -> Result<IssueDraft, String> {
+/// 单个待提交文件：相对路径 + 原始字节内容（提交时 base64 编码）。
+pub struct ExpertFile {
+    /// 相对专家根目录的路径，如 `agents/demo.md`
+    pub path: String,
+    /// 文件原始字节内容
+    pub content: Vec<u8>,
+}
+
+/// 遍历专家目录，收集所有文件（含二进制头像等），按路径排序返回。
+pub fn collect_expert_files(expert: &ExpertMetadata) -> Result<Vec<ExpertFile>, String> {
     let dir = Path::new(&expert.definition_dir);
-    let title = format!("[专家贡献] {} v{}", expert.name, expert.version);
-
-    // 先收集所有文件并生成各自的折叠块；缺失文件（如专家无 skill）跳过。
     let mut files = Vec::new();
-    let mut sections = Vec::new();
-    collect_file(dir, ".codebuddy-plugin/plugin.json", &mut files, &mut sections)?;
-    for rel in list_agent_md_files(dir) {
-        collect_file(dir, &rel, &mut files, &mut sections)?;
-    }
-    for skill_rel in &expert.skills {
-        let skill_md_rel = format!("{skill_rel}/SKILL.md");
-        collect_file(dir, &skill_md_rel, &mut files, &mut sections)?;
-    }
-
-    let body = build_body(expert, &files, &sections);
-    Ok(IssueDraft { title, body, files })
+    walk_dir(dir, dir, &mut files)?;
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(files)
 }
 
-/// 组装 body：元信息表格 + 文件清单 + 各文件折叠块。
-fn build_body(expert: &ExpertMetadata, files: &[String], sections: &[String]) -> String {
-    let mut body = build_header(expert, files);
-    for section in sections {
-        body.push_str(section);
+/// 递归遍历目录收集文件；不跟随符号链接，避免死循环与越界。
+fn walk_dir(base: &Path, dir: &Path, out: &mut Vec<ExpertFile>) -> Result<(), String> {
+    let entries = std::fs::read_dir(dir)
+        .map_err(|e| format!("读取目录 {} 失败: {e}", dir.display()))?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // file_type 不跟随符号链接：symlink 的 is_dir 为 false，不会递归进去。
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        if is_dir {
+            walk_dir(base, &path, out)?;
+            continue;
+        }
+        let rel = path
+            .strip_prefix(base)
+            .map_err(|e| format!("计算相对路径失败: {e}"))?;
+        let content = std::fs::read(&path)
+            .map_err(|e| format!("读取文件 {} 失败: {e}", path.display()))?;
+        out.push(ExpertFile {
+            path: rel.to_string_lossy().to_string(),
+            content,
+        });
     }
-    body
+    Ok(())
 }
 
-/// 组装 body 头部：元信息表格 + 文件清单。
-fn build_header(expert: &ExpertMetadata, files: &[String]) -> String {
+/// 组装贡献草稿：标题 + 简短描述 + 文件清单。
+pub fn build_issue_draft(expert: &ExpertMetadata) -> Result<IssueDraft, String> {
+    let files = collect_expert_files(expert)?;
+    let title = format!("[专家贡献] {} v{}", expert.name, expert.version);
+    let body = build_pr_body(expert, &files);
+    let file_paths: Vec<String> = files.into_iter().map(|f| f.path).collect();
+    Ok(IssueDraft {
+        title,
+        body,
+        files: file_paths,
+    })
+}
+
+/// 组装简短 PR 描述：元信息表格 + 文件清单（不含文件内容，内容以真实文件提交）。
+fn build_pr_body(expert: &ExpertMetadata, files: &[ExpertFile]) -> String {
     let mut s = String::from("## 专家贡献\n\n> 由 ntd 用户提交，等待官方审核合入。\n\n");
     s.push_str("| 属性 | 值 |\n|---|---|\n");
     s.push_str(&format!("| 名称 | `{}` |\n", expert.name));
@@ -60,9 +83,9 @@ fn build_header(expert: &ExpertMetadata, files: &[String]) -> String {
         s.push_str(&format!("| 说明 | {} |\n", desc));
     }
     s.push('\n');
-    s.push_str(&format!("**包含文件（{} 个）**：\n", files.len()));
+    s.push_str(&format!("**提交文件（{} 个）**：\n", files.len()));
     for f in files {
-        s.push_str(&format!("- `{f}`\n"));
+        s.push_str(&format!("- `{}`\n", f.path));
     }
     s.push('\n');
     s
@@ -74,60 +97,6 @@ fn expert_type_label(t: &ExpertType) -> &'static str {
         ExpertType::Agent => "agent（单个专家）",
         ExpertType::Team => "team（专家团队）",
     }
-}
-
-/// 读取单个文件，生成折叠块并记录到文件清单。
-fn collect_file(
-    dir: &Path,
-    rel: &str,
-    files: &mut Vec<String>,
-    sections: &mut Vec<String>,
-) -> Result<(), String> {
-    // resolve_within 校验 rel 仍在专家目录内，防 plugin.json 里的 .. 逃逸。
-    let Some(full) = resolve_within(dir, rel) else {
-        // 文件缺失（如专家无 skill）不视为错误：跳过即可。
-        return Ok(());
-    };
-    let content = std::fs::read_to_string(&full).map_err(|e| format!("读取 {rel} 失败: {e}"))?;
-    files.push(rel.to_string());
-    sections.push(build_details_block(rel, &content));
-    Ok(())
-}
-
-/// 生成单个文件的 <details> 折叠块，内嵌带语言标签的 markdown 代码块。
-fn build_details_block(rel: &str, content: &str) -> String {
-    // 按扩展名选语言标签，便于 issue 页面语法高亮。
-    let lang = match rel.rsplit('.').next() {
-        Some("json") => "json",
-        Some("md") => "markdown",
-        _ => "",
-    };
-    format!(
-        "<details>\n<summary>📄 {rel}（点击展开）</summary>\n\n```{lang}\n{content}\n```\n\n</details>\n\n"
-    )
-}
-
-/// 扫描 `agents/` 目录，返回相对专家根目录的 .md 文件路径（已排序）。
-fn list_agent_md_files(expert_dir: &Path) -> Vec<String> {
-    let agents_dir = expert_dir.join("agents");
-    let mut result = Vec::new();
-    let Ok(entries) = std::fs::read_dir(&agents_dir) else {
-        return result;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        if path.extension().and_then(|e| e.to_str()) != Some("md") {
-            continue;
-        }
-        if let Ok(rel) = path.strip_prefix(expert_dir) {
-            result.push(rel.to_string_lossy().to_string());
-        }
-    }
-    result.sort();
-    result
 }
 
 #[cfg(test)]
@@ -183,31 +152,39 @@ mod tests {
     }
 
     #[test]
-    fn build_issue_draft_contains_plugin_agent_and_skill() {
+    fn collect_expert_files_includes_plugin_agent_skill_and_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        // 追加一个二进制头像文件，验证非文本文件也被收集。
+        let avatar_dir = dir.path().join("avatars");
+        fs::create_dir_all(&avatar_dir).unwrap();
+        fs::write(avatar_dir.join("logo.png"), [0x89, 0x50, 0x4e, 0x47]).unwrap();
+
+        let expert = build_sample_expert(dir.path());
+        let files = collect_expert_files(&expert).unwrap();
+
+        let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+        assert!(paths.contains(&".codebuddy-plugin/plugin.json"));
+        assert!(paths.contains(&"agents/demo.md"));
+        assert!(paths.contains(&"skills/my-skill/SKILL.md"));
+        assert!(paths.contains(&"avatars/logo.png"));
+        // 二进制文件字节被完整读取。
+        let png = files.iter().find(|f| f.path == "avatars/logo.png").unwrap();
+        assert_eq!(png.content, vec![0x89, 0x50, 0x4e, 0x47]);
+    }
+
+    #[test]
+    fn build_issue_draft_has_table_and_file_list() {
         let dir = tempfile::tempdir().unwrap();
         let expert = build_sample_expert(dir.path());
         let draft = build_issue_draft(&expert).unwrap();
 
-        // 标题以固定前缀开头并带版本号。
         assert!(draft.title.starts_with("[专家贡献] demo v1.0.0"));
-        // body 含元信息表格、<details> 折叠块与三个文件内容。
+        // 正文含元信息表格与文件清单。
         assert!(draft.body.contains("| 名称 | `demo` |"));
-        assert!(draft.body.contains("<details>"));
-        assert!(draft.body.contains("我是 demo 专家"));
-        assert!(draft.body.contains("我是技能"));
-        // files 清单包含 plugin.json 与 agent md 与 skill md。
+        assert!(draft.body.contains("**提交文件（"));
+        // files 清单包含各文件路径。
         assert!(draft.files.iter().any(|f| f == ".codebuddy-plugin/plugin.json"));
         assert!(draft.files.iter().any(|f| f == "agents/demo.md"));
         assert!(draft.files.iter().any(|f| f == "skills/my-skill/SKILL.md"));
-    }
-
-    #[test]
-    fn build_issue_draft_skips_missing_skill() {
-        let dir = tempfile::tempdir().unwrap();
-        let mut expert = build_sample_expert(dir.path());
-        // 指向一个不存在的 skill，应被跳过而非报错。
-        expert.skills = vec!["skills/ghost".to_string()];
-        let draft = build_issue_draft(&expert).unwrap();
-        assert!(!draft.files.iter().any(|f| f.contains("ghost")));
     }
 }

--- a/backend/src/contribution/issue.rs
+++ b/backend/src/contribution/issue.rs
@@ -18,40 +18,51 @@ pub struct IssueDraft {
 
 /// 组装专家贡献 Issue 草稿。
 ///
-/// body 依次内嵌 plugin.json、agents/*.md、skills/*/SKILL.md 的完整文本，
-/// 供官方维护者 review 后重建目录合入。
+/// body 依次内嵌 plugin.json、agents/*.md、skills/*/SKILL.md 的完整文本；
+/// 每个文件用 <details> 折叠，正文只保留元信息表格 + 文件清单，避免正文冗长。
 pub fn build_issue_draft(expert: &ExpertMetadata) -> Result<IssueDraft, String> {
     let dir = Path::new(&expert.definition_dir);
-
     let title = format!("[专家贡献] {} v{}", expert.name, expert.version);
-    let mut body = build_header(expert);
+
+    // 先收集所有文件并生成各自的折叠块；缺失文件（如专家无 skill）跳过。
     let mut files = Vec::new();
-
-    // 1. plugin.json（专家能加载说明必然存在）
-    append_file(&mut body, &mut files, dir, ".codebuddy-plugin/plugin.json")?;
-
-    // 2. agents/*.md（扫描目录，覆盖 plugin.agents 未声明的情况）
+    let mut sections = Vec::new();
+    collect_file(dir, ".codebuddy-plugin/plugin.json", &mut files, &mut sections)?;
     for rel in list_agent_md_files(dir) {
-        append_file(&mut body, &mut files, dir, &rel)?;
+        collect_file(dir, &rel, &mut files, &mut sections)?;
     }
-
-    // 3. skills/*/SKILL.md（路径来自 plugin.json 的 skills 字段）
     for skill_rel in &expert.skills {
         let skill_md_rel = format!("{skill_rel}/SKILL.md");
-        append_file(&mut body, &mut files, dir, &skill_md_rel)?;
+        collect_file(dir, &skill_md_rel, &mut files, &mut sections)?;
     }
 
+    let body = build_body(expert, &files, &sections);
     Ok(IssueDraft { title, body, files })
 }
 
-/// 组装 body 头部（专家元信息）。
-fn build_header(expert: &ExpertMetadata) -> String {
+/// 组装 body：元信息表格 + 文件清单 + 各文件折叠块。
+fn build_body(expert: &ExpertMetadata, files: &[String], sections: &[String]) -> String {
+    let mut body = build_header(expert, files);
+    for section in sections {
+        body.push_str(section);
+    }
+    body
+}
+
+/// 组装 body 头部：元信息表格 + 文件清单。
+fn build_header(expert: &ExpertMetadata, files: &[String]) -> String {
     let mut s = String::from("## 专家贡献\n\n> 由 ntd 用户提交，等待官方审核合入。\n\n");
-    s.push_str(&format!("- 专家名称：`{}`\n", expert.name));
-    s.push_str(&format!("- 类型：{}\n", expert_type_label(&expert.expert_type)));
-    s.push_str(&format!("- 版本：`{}`\n", expert.version));
+    s.push_str("| 属性 | 值 |\n|---|---|\n");
+    s.push_str(&format!("| 名称 | `{}` |\n", expert.name));
+    s.push_str(&format!("| 类型 | {} |\n", expert_type_label(&expert.expert_type)));
+    s.push_str(&format!("| 版本 | `{}` |\n", expert.version));
     if let Some(desc) = expert.description_zh.as_ref().or(expert.description_en.as_ref()) {
-        s.push_str(&format!("- 说明：{}\n", desc));
+        s.push_str(&format!("| 说明 | {} |\n", desc));
+    }
+    s.push('\n');
+    s.push_str(&format!("**包含文件（{} 个）**：\n", files.len()));
+    for f in files {
+        s.push_str(&format!("- `{f}`\n"));
     }
     s.push('\n');
     s
@@ -65,12 +76,12 @@ fn expert_type_label(t: &ExpertType) -> &'static str {
     }
 }
 
-/// 读取单个文件并以 markdown 代码块追加到 body；同时记录到文件清单。
-fn append_file(
-    body: &mut String,
-    files: &mut Vec<String>,
+/// 读取单个文件，生成折叠块并记录到文件清单。
+fn collect_file(
     dir: &Path,
     rel: &str,
+    files: &mut Vec<String>,
+    sections: &mut Vec<String>,
 ) -> Result<(), String> {
     // resolve_within 校验 rel 仍在专家目录内，防 plugin.json 里的 .. 逃逸。
     let Some(full) = resolve_within(dir, rel) else {
@@ -78,20 +89,22 @@ fn append_file(
         return Ok(());
     };
     let content = std::fs::read_to_string(&full).map_err(|e| format!("读取 {rel} 失败: {e}"))?;
-    push_code_block(body, rel, &content);
     files.push(rel.to_string());
+    sections.push(build_details_block(rel, &content));
     Ok(())
 }
 
-/// 把文本以带语言标签的 markdown 代码块追加到 body。
-fn push_code_block(body: &mut String, rel: &str, content: &str) {
+/// 生成单个文件的 <details> 折叠块，内嵌带语言标签的 markdown 代码块。
+fn build_details_block(rel: &str, content: &str) -> String {
     // 按扩展名选语言标签，便于 issue 页面语法高亮。
     let lang = match rel.rsplit('.').next() {
         Some("json") => "json",
         Some("md") => "markdown",
         _ => "",
     };
-    body.push_str(&format!("### {rel}\n\n```{lang}\n{content}\n```\n\n"));
+    format!(
+        "<details>\n<summary>📄 {rel}（点击展开）</summary>\n\n```{lang}\n{content}\n```\n\n</details>\n\n"
+    )
 }
 
 /// 扫描 `agents/` 目录，返回相对专家根目录的 .md 文件路径（已排序）。
@@ -177,8 +190,9 @@ mod tests {
 
         // 标题以固定前缀开头并带版本号。
         assert!(draft.title.starts_with("[专家贡献] demo v1.0.0"));
-        // body 含元信息与三个文件内容。
-        assert!(draft.body.contains("专家名称"));
+        // body 含元信息表格、<details> 折叠块与三个文件内容。
+        assert!(draft.body.contains("| 名称 | `demo` |"));
+        assert!(draft.body.contains("<details>"));
         assert!(draft.body.contains("我是 demo 专家"));
         assert!(draft.body.contains("我是技能"));
         // files 清单包含 plugin.json 与 agent md 与 skill md。

--- a/backend/src/contribution/issue.rs
+++ b/backend/src/contribution/issue.rs
@@ -1,0 +1,199 @@
+//! 读取本地专家目录，组装贡献 Issue 的标题与 Markdown body。
+
+use std::path::Path;
+
+use crate::expert::loader::resolve_within;
+use crate::expert::{ExpertMetadata, ExpertType};
+
+/// 贡献 Issue 草稿：标题 + Markdown body + 已打包的文件清单。
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct IssueDraft {
+    /// Issue 标题
+    pub title: String,
+    /// Issue Markdown 正文
+    pub body: String,
+    /// 已打包进 body 的文件相对路径清单（用于前端预览展示）
+    pub files: Vec<String>,
+}
+
+/// 组装专家贡献 Issue 草稿。
+///
+/// body 依次内嵌 plugin.json、agents/*.md、skills/*/SKILL.md 的完整文本，
+/// 供官方维护者 review 后重建目录合入。
+pub fn build_issue_draft(expert: &ExpertMetadata) -> Result<IssueDraft, String> {
+    let dir = Path::new(&expert.definition_dir);
+
+    let title = format!("[专家贡献] {} v{}", expert.name, expert.version);
+    let mut body = build_header(expert);
+    let mut files = Vec::new();
+
+    // 1. plugin.json（专家能加载说明必然存在）
+    append_file(&mut body, &mut files, dir, ".codebuddy-plugin/plugin.json")?;
+
+    // 2. agents/*.md（扫描目录，覆盖 plugin.agents 未声明的情况）
+    for rel in list_agent_md_files(dir) {
+        append_file(&mut body, &mut files, dir, &rel)?;
+    }
+
+    // 3. skills/*/SKILL.md（路径来自 plugin.json 的 skills 字段）
+    for skill_rel in &expert.skills {
+        let skill_md_rel = format!("{skill_rel}/SKILL.md");
+        append_file(&mut body, &mut files, dir, &skill_md_rel)?;
+    }
+
+    Ok(IssueDraft { title, body, files })
+}
+
+/// 组装 body 头部（专家元信息）。
+fn build_header(expert: &ExpertMetadata) -> String {
+    let mut s = String::from("## 专家贡献\n\n> 由 ntd 用户提交，等待官方审核合入。\n\n");
+    s.push_str(&format!("- 专家名称：`{}`\n", expert.name));
+    s.push_str(&format!("- 类型：{}\n", expert_type_label(&expert.expert_type)));
+    s.push_str(&format!("- 版本：`{}`\n", expert.version));
+    if let Some(desc) = expert.description_zh.as_ref().or(expert.description_en.as_ref()) {
+        s.push_str(&format!("- 说明：{}\n", desc));
+    }
+    s.push('\n');
+    s
+}
+
+/// 专家类型的中文标签。
+fn expert_type_label(t: &ExpertType) -> &'static str {
+    match t {
+        ExpertType::Agent => "agent（单个专家）",
+        ExpertType::Team => "team（专家团队）",
+    }
+}
+
+/// 读取单个文件并以 markdown 代码块追加到 body；同时记录到文件清单。
+fn append_file(
+    body: &mut String,
+    files: &mut Vec<String>,
+    dir: &Path,
+    rel: &str,
+) -> Result<(), String> {
+    // resolve_within 校验 rel 仍在专家目录内，防 plugin.json 里的 .. 逃逸。
+    let Some(full) = resolve_within(dir, rel) else {
+        // 文件缺失（如专家无 skill）不视为错误：跳过即可。
+        return Ok(());
+    };
+    let content = std::fs::read_to_string(&full).map_err(|e| format!("读取 {rel} 失败: {e}"))?;
+    push_code_block(body, rel, &content);
+    files.push(rel.to_string());
+    Ok(())
+}
+
+/// 把文本以带语言标签的 markdown 代码块追加到 body。
+fn push_code_block(body: &mut String, rel: &str, content: &str) {
+    // 按扩展名选语言标签，便于 issue 页面语法高亮。
+    let lang = match rel.rsplit('.').next() {
+        Some("json") => "json",
+        Some("md") => "markdown",
+        _ => "",
+    };
+    body.push_str(&format!("### {rel}\n\n```{lang}\n{content}\n```\n\n"));
+}
+
+/// 扫描 `agents/` 目录，返回相对专家根目录的 .md 文件路径（已排序）。
+fn list_agent_md_files(expert_dir: &Path) -> Vec<String> {
+    let agents_dir = expert_dir.join("agents");
+    let mut result = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&agents_dir) else {
+        return result;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        if let Ok(rel) = path.strip_prefix(expert_dir) {
+            result.push(rel.to_string_lossy().to_string());
+        }
+    }
+    result.sort();
+    result
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// 在临时目录构造一个最小专家目录，返回构造好的 ExpertMetadata。
+    fn build_sample_expert(dir: &Path) -> ExpertMetadata {
+        let plugin_dir = dir.join(".codebuddy-plugin");
+        fs::create_dir_all(&plugin_dir).unwrap();
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            r#"{"name":"demo","version":"1.0.0","expertType":"agent"}"#,
+        )
+        .unwrap();
+
+        let agents_dir = dir.join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(agents_dir.join("demo.md"), "# 我是 demo 专家").unwrap();
+
+        let skill_dir = dir.join("skills").join("my-skill");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(skill_dir.join("SKILL.md"), "# 我是技能").unwrap();
+
+        ExpertMetadata {
+            name: "demo".to_string(),
+            expert_type: ExpertType::Agent,
+            version: "1.0.0".to_string(),
+            source: crate::expert::ExpertSource::User,
+            display_name_zh: None,
+            display_name_en: None,
+            profession_zh: None,
+            profession_en: None,
+            description_zh: Some("示例专家".to_string()),
+            description_en: None,
+            avatar_path: None,
+            category_id: None,
+            definition_dir: dir.to_string_lossy().to_string(),
+            plugin_json_path: plugin_dir.join("plugin.json").to_string_lossy().to_string(),
+            agent_name: Some("demo".to_string()),
+            lead_agent: None,
+            member_agents: vec![],
+            members: vec![],
+            skills: vec!["skills/my-skill".to_string()],
+            default_init_prompt_zh: None,
+            default_init_prompt_en: None,
+            tags: vec![],
+            loaded_at: "now".to_string(),
+            is_active: true,
+        }
+    }
+
+    #[test]
+    fn build_issue_draft_contains_plugin_agent_and_skill() {
+        let dir = tempfile::tempdir().unwrap();
+        let expert = build_sample_expert(dir.path());
+        let draft = build_issue_draft(&expert).unwrap();
+
+        // 标题以固定前缀开头并带版本号。
+        assert!(draft.title.starts_with("[专家贡献] demo v1.0.0"));
+        // body 含元信息与三个文件内容。
+        assert!(draft.body.contains("专家名称"));
+        assert!(draft.body.contains("我是 demo 专家"));
+        assert!(draft.body.contains("我是技能"));
+        // files 清单包含 plugin.json 与 agent md 与 skill md。
+        assert!(draft.files.iter().any(|f| f == ".codebuddy-plugin/plugin.json"));
+        assert!(draft.files.iter().any(|f| f == "agents/demo.md"));
+        assert!(draft.files.iter().any(|f| f == "skills/my-skill/SKILL.md"));
+    }
+
+    #[test]
+    fn build_issue_draft_skips_missing_skill() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut expert = build_sample_expert(dir.path());
+        // 指向一个不存在的 skill，应被跳过而非报错。
+        expert.skills = vec!["skills/ghost".to_string()];
+        let draft = build_issue_draft(&expert).unwrap();
+        assert!(!draft.files.iter().any(|f| f.contains("ghost")));
+    }
+}

--- a/backend/src/contribution/mod.rs
+++ b/backend/src/contribution/mod.rs
@@ -49,3 +49,58 @@ pub(crate) fn now_unix() -> i64 {
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
 }
+
+/// 编排 PR 提交流程：fork → 建分支 → 写文件 → 建 PR。
+///
+/// 返回创建好的 PR 结果；任一步失败则上抛错误（此时 fork/分支可能已创建，
+/// 属无害残留，用户下次重试会复用 fork、以新时间戳分支重新提交）。
+pub async fn submit_pr(
+    token: &GitCodeToken,
+    owner: &str,
+    repo: &str,
+    expert: &crate::expert::ExpertMetadata,
+    title: &str,
+    body: &str,
+) -> Result<gitcode::PrResult, String> {
+    let access_token = &token.access_token;
+
+    // 1. 取当前用户 username，作为 fork 后的 owner。
+    let username = gitcode::get_current_username(access_token).await?;
+    // 2. fork 官方仓库到用户账号（幂等：已 fork 则复用）。
+    gitcode::ensure_fork(access_token, owner, repo).await?;
+    // 3. 收集专家目录全部文件（含二进制头像）。
+    let files = issue::collect_expert_files(expert)?;
+
+    // 4. 用时间戳保证分支名唯一，避免与历史贡献分支冲突。
+    let branch = format!("contrib/{}-{}", expert.name, now_unix());
+    gitcode::create_branch(access_token, &username, repo, &branch, "main").await?;
+
+    // 5. 逐个把文件写入 fork 分支。
+    let message = format!("贡献专家 {} v{}", expert.name, expert.version);
+    for f in &files {
+        let content_b64 = encode_base64(&f.content);
+        gitcode::create_file(access_token, &username, repo, &branch, &f.path, &content_b64, &message)
+            .await?;
+    }
+
+    // 6. 创建 PR：head = "{username}:{branch}"，base 固定 main。
+    let head = format!("{username}:{branch}");
+    gitcode::create_pr(access_token, owner, repo, title, body, &head, "main").await
+}
+
+/// base64 编码字节内容（GitCode contents API 要求 content 为 base64）。
+fn encode_base64(bytes: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_base64_encodes_standard() {
+        // "abc" 的标准 base64 为 "YWJj"。
+        assert_eq!(encode_base64(b"abc"), "YWJj");
+    }
+}

--- a/backend/src/contribution/mod.rs
+++ b/backend/src/contribution/mod.rs
@@ -1,0 +1,51 @@
+//! 专家贡献模块：把本地专家以 Issue 形式提交回官方 GitCode 仓库。
+//!
+//! 职责划分：
+//! - `gitcode.rs`：GitCode 平台常量、owner/repo 解析、OAuth 授权 URL 拼装、
+//!   token 交换/刷新、创建 Issue 的 HTTP 调用。
+//! - `oauth.rs`：OAuth state 管理（防 CSRF）与 token 本地持久化。
+//! - `issue.rs`：读取本地专家目录，组装贡献 Issue 的标题与 Markdown body。
+//! Handler 层在 `handlers/contribution.rs`。
+
+pub mod gitcode;
+pub mod issue;
+pub mod oauth;
+
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// GitCode OAuth 访问令牌（持久化到 `~/.ntd/contribution_token.json`）。
+#[derive(Clone, Serialize, Deserialize)]
+pub struct GitCodeToken {
+    /// 访问令牌，用于调用 GitCode API
+    pub access_token: String,
+    /// 刷新令牌，access_token 过期后用其换取新令牌
+    pub refresh_token: String,
+    /// 过期时间（Unix 秒），由 token 接口的 expires_in + 当前时间计算
+    pub expires_at: i64,
+    /// 授权范围（如 all_issue）
+    pub scope: Option<String>,
+}
+
+impl std::fmt::Debug for GitCodeToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // 手动实现 Debug：令牌字段一律脱敏，防止误用 {:?}/dbg! 把明文 token 打进日志。
+        f.debug_struct("GitCodeToken")
+            .field("access_token", &"[redacted]")
+            .field("refresh_token", &"[redacted]")
+            .field("expires_at", &self.expires_at)
+            .field("scope", &self.scope)
+            .finish()
+    }
+}
+
+/// 当前 Unix 秒。
+///
+/// 用 `unwrap_or(0)` 而非 `unwrap`：系统时钟异常时回退到 epoch，
+/// 仅影响 token 过期判断（会误判为已过期并触发刷新），不会 panic。
+pub(crate) fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}

--- a/backend/src/contribution/oauth.rs
+++ b/backend/src/contribution/oauth.rs
@@ -1,0 +1,155 @@
+//! OAuth 辅助：state 管理（防 CSRF）与 token 本地持久化。
+
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use dashmap::DashMap;
+
+use super::{now_unix, GitCodeToken};
+
+/// OAuth state 存储：`state -> 过期时间戳`（Unix 秒）。
+///
+/// 用全局 `DashMap` 而非 `AppState` 字段：单进程 daemon 足够，
+/// 且避免为每个请求 clone 大型 AppState。state 一次性使用，回调时移除。
+static OAUTH_STATES: LazyLock<DashMap<String, i64>> = LazyLock::new(DashMap::new);
+
+/// state 有效期（秒）：过期后即使匹配也拒绝，降低 CSRF 窗口。
+const STATE_TTL_SECS: i64 = 600;
+
+/// 生成随机 state 并记录过期时间，返回给前端拼进授权 URL。
+pub fn generate_state() -> String {
+    let state = uuid::Uuid::new_v4().to_string();
+    let expires = now_unix() + STATE_TTL_SECS;
+    OAUTH_STATES.insert(state.clone(), expires);
+    // 顺手清理已过期条目，防止长期运行内存缓慢增长。
+    let now = now_unix();
+    OAUTH_STATES.retain(|_, exp| *exp > now);
+    state
+}
+
+/// 校验并一次性消费 state：存在且未过期返回 `true`。
+pub fn consume_state(state: &str) -> bool {
+    // DashMap::remove 返回 (key, value) 元组，这里只关心过期时间。
+    match OAUTH_STATES.remove(state) {
+        Some((_, expires)) => expires > now_unix(),
+        None => false,
+    }
+}
+
+/// token 文件路径：`~/.ntd/contribution_token.json`。
+fn token_file_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".ntd").join("contribution_token.json"))
+}
+
+/// 读取持久化的 token；不存在或解析失败返回 `None`。
+pub fn load_token() -> Option<GitCodeToken> {
+    let path = token_file_path()?;
+    load_token_from(&path)
+}
+
+/// 持久化 token 到 `~/.ntd/contribution_token.json`，文件权限收紧为 0600。
+pub fn save_token(token: &GitCodeToken) -> Result<(), String> {
+    let path = token_file_path().ok_or_else(|| "无法获取 home 目录".to_string())?;
+    save_token_to(&path, token)
+}
+
+/// 删除持久化的 token（退出登录）。
+pub fn clear_token() {
+    if let Some(path) = token_file_path() {
+        // 删除失败仅影响下次登录（会重新走授权），忽略即可。
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// token 是否仍有效（未过期）。
+pub fn token_is_valid(token: &GitCodeToken) -> bool {
+    token.expires_at > now_unix()
+}
+
+/// 从指定路径读取 token（抽出路径参数便于单测，避免依赖真实 home 目录）。
+fn load_token_from(path: &Path) -> Option<GitCodeToken> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// 持久化 token 到指定路径（抽出路径参数便于单测）。
+fn save_token_to(path: &Path, token: &GitCodeToken) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("创建目录失败: {e}"))?;
+    }
+    let json = serde_json::to_string(token).map_err(|e| format!("序列化 token 失败: {e}"))?;
+    write_owner_only(path, json.as_bytes()).map_err(|e| format!("写入 token 失败: {e}"))?;
+    Ok(())
+}
+
+/// 以 0600 权限原子创建并写入文件，避免「先写 0644 再 chmod」的窗口期泄露令牌。
+fn write_owner_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        // mode(0o600) 在 open 时即生效，文件创建即私有，无 TOCTOU 窗口。
+        let mut opts = std::fs::OpenOptions::new();
+        opts.create(true).write(true).truncate(true).mode(0o600);
+        let mut file = opts.open(path)?;
+        file.write_all(bytes)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, bytes)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn sample_token() -> GitCodeToken {
+        GitCodeToken {
+            access_token: "at".to_string(),
+            refresh_token: "rt".to_string(),
+            expires_at: now_unix() + 3600,
+            scope: Some("all_issue".to_string()),
+        }
+    }
+
+    #[test]
+    fn save_and_load_token_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("token.json");
+        let token = sample_token();
+        save_token_to(&path, &token).unwrap();
+        let loaded = load_token_from(&path).unwrap();
+        assert_eq!(loaded.access_token, "at");
+        assert_eq!(loaded.refresh_token, "rt");
+        assert_eq!(loaded.expires_at, token.expires_at);
+    }
+
+    #[test]
+    fn load_token_missing_file_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_token_from(&dir.path().join("nope.json")).is_none());
+    }
+
+    #[test]
+    fn token_is_valid_respects_expiry() {
+        let mut token = sample_token();
+        assert!(token_is_valid(&token));
+        token.expires_at = now_unix() - 1;
+        assert!(!token_is_valid(&token));
+    }
+
+    #[test]
+    fn generate_and_consume_state_succeeds_once() {
+        let state = generate_state();
+        assert!(consume_state(&state));
+        // state 一次性使用：第二次消费必须失败。
+        assert!(!consume_state(&state));
+    }
+
+    #[test]
+    fn consume_unknown_state_fails() {
+        assert!(!consume_state("does-not-exist"));
+    }
+}

--- a/backend/src/handlers/bundled.rs
+++ b/backend/src/handlers/bundled.rs
@@ -56,7 +56,7 @@ impl Subdir {
 
 /// Skills 市场元数据缓存（启动时扫描一次，后续直接读内存）
 ///
-/// 每次请求 `/api/bundled/skills` 都重新扫描磁盘会导致 10-20 秒延迟，
+/// 每次请求 `/api/v1/bundled/skills` 都重新扫描磁盘会导致 10-20 秒延迟，
 /// 用户体验很差。缓存后在内存中直接返回，延迟降到毫秒级。
 ///
 /// 缓存在以下时机失效/刷新：
@@ -323,7 +323,7 @@ pub(crate) async fn run_bundled_sync(
 
 /// 手动触发同步
 ///
-/// POST /api/bundled/sync
+/// POST /api/v1/bundled/sync
 pub async fn sync_bundled(
     State(state): State<AppState>,
     Json(req): Json<SyncRequest>,
@@ -349,7 +349,7 @@ pub async fn sync_bundled(
 
 /// 获取同步状态
 ///
-/// GET /api/bundled/status?subdir=experts
+/// GET /api/v1/bundled/status?subdir=experts
 pub async fn get_bundled_status(
     State(state): State<AppState>,
     Query(query): Query<StatusQuery>,
@@ -786,7 +786,7 @@ async fn reload_experts_from_bundled(state: &AppState) -> Result<(), String> {
 
 /// 获取当前配置
 ///
-/// GET /api/bundled/config
+/// GET /api/v1/bundled/config
 pub async fn get_bundled_config(
     State(state): State<AppState>,
 ) -> Result<ApiResponse<BundledSourceConfig>, AppError> {
@@ -796,7 +796,7 @@ pub async fn get_bundled_config(
 
 /// 更新配置
 ///
-/// PUT /api/bundled/config
+/// PUT /api/v1/bundled/config
 #[derive(Debug, Deserialize)]
 pub struct UpdateConfigRequest {
     /// 远程仓库地址
@@ -847,28 +847,10 @@ async fn update_last_sync_time(state: &AppState) {
     }).save();
 }
 
-/// 路由定义
-pub fn bundled_routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/bundled/sync", axum::routing::post(sync_bundled))
-        .route("/api/bundled/status", axum::routing::get(get_bundled_status))
-        .route("/api/bundled/config", axum::routing::get(get_bundled_config))
-        .route("/api/bundled/config", axum::routing::put(update_bundled_config))
-        // 技能市场 API
-        .route("/api/bundled/skills", axum::routing::get(list_bundled_skills))
-        // 来源分页：与技能分页职责分离，按「来源」本身切片，
-        // 来源网格据此渲染，避免按技能切片后派生来源导致每页来源数量稀少
-        .route("/api/bundled/skill-sources", axum::routing::get(list_bundled_skill_sources))
-        .route("/api/bundled/skills/{name}/content", axum::routing::get(get_bundled_skill_content))
-        // 读单文件内容：与 content 同命名空间，让市场页文件浏览器能预览 SKILL.md 以外的文件
-        .route("/api/bundled/skills/{name}/file", axum::routing::get(get_bundled_skill_file))
-        .route("/api/bundled/skills/install", axum::routing::post(install_bundled_skill))
-}
-
-/// V1 路由定义：内置资源同步相关 API（API 重构过渡期）
+/// V1 路由定义：内置资源同步相关 API
 ///
-/// 与 `bundled_routes()` 共存，路由前缀改为 /api/v1/bundled，全路径注册。
-/// 新旧路由在顶层通过不同的 Router merge 组装，此处不走嵌套前缀。
+/// 全路径注册版本化路由（前缀 /api/v1/bundled），遵循 REST 集合语义。
+/// 旧 `/api/bundled/*` 路由已随 api-routing-redesign 移除，不再注册。
 pub fn v1_routes() -> Router<AppState> {
     Router::new()
         // 手动触发 git 同步（post /api/v1/bundled/sync）
@@ -1073,7 +1055,7 @@ fn default_page_size() -> u32 {
     20
 }
 
-/// GET /api/bundled/skills - 列出技能市场中的所有技能
+/// GET /api/v1/bundled/skills - 列出技能市场中的所有技能
 ///
 /// 优先从内存缓存返回（毫秒级），缓存未初始化时触发异步预热并等待结果。
 /// 支持嵌套目录结构（如 awesome-skills-zh/lark-doc/SKILL.md）。
@@ -1266,9 +1248,9 @@ pub struct ListSkillSourcesQuery {
     pub keyword: Option<String>,
 }
 
-/// GET /api/bundled/skill-sources - 列出技能来源（分页）
+/// GET /api/v1/bundled/skill-sources - 列出技能来源（分页）
 ///
-/// 与 `/api/bundled/skills` 职责分离：
+/// 与 `/api/v1/bundled/skills` 职责分离：
 /// - `/skills` 按「技能」切片，用于「全部技能」模式
 /// - `/skill-sources` 按「来源」切片，用于「按来源浏览」来源网格
 ///
@@ -1552,7 +1534,7 @@ fn count_files_and_size(dir: &std::path::Path) -> (u32, u64) {
     (count, size)
 }
 
-/// GET /api/bundled/skills/:name/content - 获取技能的 SKILL.md 内容和文件列表
+/// GET /api/v1/bundled/skills/:name/content - 获取技能的 SKILL.md 内容和文件列表
 ///
 /// 读取 bundled/skills/{name}/SKILL.md 的文本内容，
 /// 并列出目录下所有文件，用于前端详情 Drawer 展示。
@@ -1607,7 +1589,7 @@ pub struct BundledSkillFileQuery {
     pub path: String,
 }
 
-/// GET /api/bundled/skills/{name}/file - 读取 bundled 技能内某个文件的内容
+/// GET /api/v1/bundled/skills/{name}/file - 读取 bundled 技能内某个文件的内容
 ///
 /// 市场页文件浏览器预览非 SKILL.md 文件时调用。磁盘 IO 下放到 `read_bundled_skill_file`
 /// 并整体塞进 `spawn_blocking`，避免 read_to_string 阻塞 tokio reactor worker。
@@ -1769,7 +1751,7 @@ fn collect_files_list(base_dir: &std::path::Path, current_dir: &std::path::Path)
     files
 }
 
-/// POST /api/bundled/skills/install - 安装技能到执行器
+/// POST /api/v1/bundled/skills/install - 安装技能到执行器
 ///
 /// 将 bundled/skills/{skill_name} 目录复制到目标执行器的 skills 目录。
 /// 如果目标已存在同名技能，返回冲突提示（不自动覆盖）。

--- a/backend/src/handlers/contribution.rs
+++ b/backend/src/handlers/contribution.rs
@@ -185,9 +185,13 @@ async fn get_valid_token() -> Result<GitCodeToken, AppError> {
 }
 
 /// 拼 OAuth 回调地址：本机 + 当前端口。
+///
+/// 用 `127.0.0.1` 而非 `localhost`：与 GitCode OAuth 应用注册的 redirect_uri
+/// 保持一致（GitCode 对 localhost 形式校验不通过）；路径 `/api/v1/gitcode/oauth/callback`
+/// 也与注册值逐字符对齐，否则 authorize 阶段会报「回调地址错误」。
 fn build_redirect_uri(state: &AppState) -> String {
     let port = state.config_snapshot(|c| c.port);
-    format!("http://localhost:{port}/api/v1/contribution/oauth/callback")
+    format!("http://127.0.0.1:{port}/api/v1/gitcode/oauth/callback")
 }
 
 /// 构造 OAuth 失败提示页（HTML）。
@@ -214,7 +218,7 @@ pub fn contribution_routes() -> Router<AppState> {
     Router::new()
         .route("/api/v1/contribution/auth/status", get(auth_status))
         .route("/api/v1/contribution/oauth/url", get(oauth_url))
-        .route("/api/v1/contribution/oauth/callback", get(oauth_callback))
+        .route("/api/v1/gitcode/oauth/callback", get(oauth_callback))
         .route(
             "/api/v1/contribution/experts/{name}/preview",
             post(preview),

--- a/backend/src/handlers/contribution.rs
+++ b/backend/src/handlers/contribution.rs
@@ -1,0 +1,256 @@
+//! 专家贡献 API 路由：OAuth 登录、预览、提交 Issue。
+
+use axum::extract::{Path, Query, State};
+use axum::response::{Html, IntoResponse, Redirect, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::contribution::{gitcode, issue, oauth, GitCodeToken};
+use crate::handlers::{AppError, AppState};
+use crate::models::ApiResponse;
+
+/// 登录态查询响应。
+#[derive(Debug, Serialize)]
+pub struct AuthStatus {
+    /// 贡献功能是否启用（凭据是否已注入）
+    pub enabled: bool,
+    /// 是否已登录（本地已存在 token）
+    pub logged_in: bool,
+}
+
+/// OAuth 授权 URL 响应。
+#[derive(Debug, Serialize)]
+pub struct OAuthUrlResponse {
+    pub url: String,
+}
+
+/// OAuth 回调 query 参数。
+#[derive(Debug, Deserialize)]
+pub struct OAuthCallbackParams {
+    /// 授权码（用户拒绝授权时缺失）
+    pub code: Option<String>,
+    /// 防 CSRF 的随机串
+    #[serde(default)]
+    pub state: String,
+    /// 授权失败原因（GitCode 回传）
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// 提交 Issue 请求体。
+#[derive(Debug, Deserialize)]
+pub struct SubmitRequest {
+    /// 覆盖默认标题（用户预览时可改）
+    pub title: Option<String>,
+    /// 覆盖默认正文（用户预览时可改）
+    pub body: Option<String>,
+}
+
+/// `GET /api/v1/contribution/auth/status`：查询登录态与功能开关。
+pub async fn auth_status() -> ApiResponse<AuthStatus> {
+    let enabled = gitcode::contribution_enabled();
+    // 仅当凭据已注入且本地存在 token 才视为已登录；
+    // token 是否过期在 submit 时再校验/刷新，避免此处额外 IO。
+    let logged_in = enabled && oauth::load_token().is_some();
+    ApiResponse::ok(AuthStatus { enabled, logged_in })
+}
+
+/// `GET /api/v1/contribution/oauth/url`：生成 GitCode 授权跳转 URL。
+pub async fn oauth_url(
+    State(state): State<AppState>,
+) -> Result<ApiResponse<OAuthUrlResponse>, AppError> {
+    // 未注入凭据时直接拒绝，避免生成不可用的授权链接。
+    if !gitcode::contribution_enabled() {
+        return Err(AppError::BadRequest("贡献功能未配置".to_string()));
+    }
+    let client_id = gitcode::CLIENT_ID.ok_or(AppError::Internal("client_id 缺失".to_string()))?;
+    let redirect_uri = build_redirect_uri(&state);
+    let oauth_state = oauth::generate_state();
+    let url = gitcode::build_authorize_url(client_id, &redirect_uri, &oauth_state);
+    Ok(ApiResponse::ok(OAuthUrlResponse { url }))
+}
+
+/// `GET /api/v1/contribution/oauth/callback`：处理 GitCode 回跳。
+///
+/// 始终返回 HTML（成功跳转、失败提示），因为这是浏览器直接访问的端点。
+pub async fn oauth_callback(Query(params): Query<OAuthCallbackParams>) -> Response {
+    // 用户拒绝授权：GitCode 会回传 error，code 为空。
+    if let Some(err) = &params.error {
+        return oauth_error_page(&format!("授权失败：{err}"));
+    }
+    // 校验 state，一次性消费，防 CSRF。
+    if !oauth::consume_state(&params.state) {
+        return oauth_error_page("登录校验失败（state 不匹配或已过期），请重新发起");
+    }
+    match gitcode::exchange_code_for_token(params.code.as_deref().unwrap_or_default()).await {
+        Ok(token) => match oauth::save_token(&token) {
+            Ok(()) => Redirect::to("/#/experts").into_response(),
+            Err(e) => oauth_error_page(&format!("保存登录态失败：{e}")),
+        },
+        Err(e) => {
+            // e 已在 gitcode.rs 脱敏（仅含 HTTP 状态码），可安全记日志；页面用固定文案，
+            // 不把底层错误原文（可能含授权码）回显给浏览器。
+            tracing::warn!("OAuth 换取 token 失败: {e}");
+            oauth_error_page("换取登录态失败，请重新发起登录")
+        }
+    }
+}
+
+/// `POST /api/v1/contribution/experts/{name}/preview`：组装 Issue 草稿（不提交）。
+pub async fn preview(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<ApiResponse<issue::IssueDraft>, AppError> {
+    let expert = state
+        .expert_manager
+        .get_expert_by_name(&name)
+        .ok_or(AppError::NotFound)?;
+    let draft = issue::build_issue_draft(&expert).map_err(AppError::Internal)?;
+    Ok(ApiResponse::ok(draft))
+}
+
+/// `POST /api/v1/contribution/experts/{name}/submit`：提交 Issue。
+pub async fn submit(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(req): Json<SubmitRequest>,
+) -> Result<ApiResponse<gitcode::IssueResult>, AppError> {
+    // 1. 组装默认草稿；用户预览时可能覆盖标题/正文。
+    let expert = state
+        .expert_manager
+        .get_expert_by_name(&name)
+        .ok_or(AppError::NotFound)?;
+    let draft = issue::build_issue_draft(&expert).map_err(AppError::Internal)?;
+    let title = req.title.unwrap_or(draft.title);
+    let body = req.body.unwrap_or(draft.body);
+    // 校验覆盖字段长度：防止绕过「打包本地文件」向官方仓库提交任意超长内容。
+    validate_submit_payload(&title, &body)?;
+
+    // 2. 从 bundled url 解析贡献目标仓库。
+    let (owner, repo) = resolve_target(&state)?;
+
+    // 3. 取有效 token（过期自动刷新）。
+    let token = get_valid_token().await?;
+
+    // 4. 调用 GitCode 创建 Issue。
+    let result = gitcode::create_issue(&owner, &repo, &token.access_token, &title, &body)
+        .await
+        .map_err(AppError::Internal)?;
+
+    Ok(ApiResponse::ok(result))
+}
+
+/// `POST /api/v1/contribution/logout`：清除本地登录态。
+pub async fn logout() -> ApiResponse<String> {
+    oauth::clear_token();
+    ApiResponse::ok("已退出登录".to_string())
+}
+
+/// Issue 标题长度上限（在 GitCode 标题约束内）。
+const TITLE_MAX_CHARS: usize = 255;
+/// Issue 正文长度上限：足以容纳完整专家文件，同时防滥用超长提交。
+const BODY_MAX_CHARS: usize = 100_000;
+
+/// 校验提交字段长度，防止绕过「打包本地文件」提交任意内容。
+fn validate_submit_payload(title: &str, body: &str) -> Result<(), AppError> {
+    if title.chars().count() > TITLE_MAX_CHARS {
+        return Err(AppError::BadRequest("标题过长（最多 255 字）".to_string()));
+    }
+    if body.chars().count() > BODY_MAX_CHARS {
+        return Err(AppError::BadRequest("正文过长".to_string()));
+    }
+    Ok(())
+}
+
+/// 从 config 的 bundled url 解析贡献目标 owner/repo。
+fn resolve_target(state: &AppState) -> Result<(String, String), AppError> {
+    let url = state.config_snapshot(|c| c.bundled_source.url.clone());
+    gitcode::parse_owner_repo(&url)
+        .ok_or_else(|| AppError::Internal(format!("无法从 bundled url 解析 owner/repo: {url}")))
+}
+
+/// 取有效 token：有效直接返回，过期则用 refresh_token 刷新并持久化。
+async fn get_valid_token() -> Result<GitCodeToken, AppError> {
+    let token = oauth::load_token()
+        .ok_or_else(|| AppError::Forbidden("未登录，请先登录 GitCode".to_string()))?;
+    if oauth::token_is_valid(&token) {
+        return Ok(token);
+    }
+    let refreshed = gitcode::refresh_access_token(&token.refresh_token)
+        .await
+        .map_err(|_| AppError::Forbidden("登录态已过期，请重新登录".to_string()))?;
+    oauth::save_token(&refreshed).map_err(AppError::Internal)?;
+    Ok(refreshed)
+}
+
+/// 拼 OAuth 回调地址：本机 + 当前端口。
+fn build_redirect_uri(state: &AppState) -> String {
+    let port = state.config_snapshot(|c| c.port);
+    format!("http://localhost:{port}/api/v1/contribution/oauth/callback")
+}
+
+/// 构造 OAuth 失败提示页（HTML）。
+fn oauth_error_page(msg: &str) -> Response {
+    let html = format!(
+        "<!doctype html><html><head><meta charset=\"utf-8\"><title>登录失败</title></head>\
+         <body style=\"font-family:sans-serif;padding:40px\">\
+         <h2>GitCode 登录失败</h2><p>{}</p>\
+         <p><a href=\"/#/experts\">返回专家页</a></p></body></html>",
+        html_escape(msg)
+    );
+    Html(html).into_response()
+}
+
+/// 简单 HTML 转义，防止错误信息注入标签。
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// 专家贡献路由。
+pub fn contribution_routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/v1/contribution/auth/status", get(auth_status))
+        .route("/api/v1/contribution/oauth/url", get(oauth_url))
+        .route("/api/v1/contribution/oauth/callback", get(oauth_callback))
+        .route(
+            "/api/v1/contribution/experts/{name}/preview",
+            post(preview),
+        )
+        .route(
+            "/api/v1/contribution/experts/{name}/submit",
+            post(submit),
+        )
+        .route("/api/v1/contribution/logout", post(logout))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn html_escape_escapes_special_chars() {
+        assert_eq!(html_escape("<b>&</b>"), "&lt;b&gt;&amp;&lt;/b&gt;");
+    }
+
+    #[test]
+    fn html_escape_passthrough_plain_text() {
+        assert_eq!(html_escape("hello world"), "hello world");
+    }
+
+    #[test]
+    fn validate_submit_payload_accepts_within_limits() {
+        assert!(validate_submit_payload("ok", "body").is_ok());
+    }
+
+    #[test]
+    fn validate_submit_payload_rejects_overlong_title_and_body() {
+        let long_title = "x".repeat(TITLE_MAX_CHARS + 1);
+        assert!(validate_submit_payload(&long_title, "body").is_err());
+
+        let long_body = "y".repeat(BODY_MAX_CHARS + 1);
+        assert!(validate_submit_payload("title", &long_body).is_err());
+    }
+}

--- a/backend/src/handlers/contribution.rs
+++ b/backend/src/handlers/contribution.rs
@@ -110,12 +110,12 @@ pub async fn preview(
     Ok(ApiResponse::ok(draft))
 }
 
-/// `POST /api/v1/contribution/experts/{name}/submit`：提交 Issue。
+/// `POST /api/v1/contribution/experts/{name}/submit`：提交 PR。
 pub async fn submit(
     State(state): State<AppState>,
     Path(name): Path<String>,
     Json(req): Json<SubmitRequest>,
-) -> Result<ApiResponse<gitcode::IssueResult>, AppError> {
+) -> Result<ApiResponse<gitcode::PrResult>, AppError> {
     // 1. 组装默认草稿；用户预览时可能覆盖标题/正文。
     let expert = state
         .expert_manager
@@ -133,8 +133,8 @@ pub async fn submit(
     // 3. 取有效 token（过期自动刷新）。
     let token = get_valid_token().await?;
 
-    // 4. 调用 GitCode 创建 Issue。
-    let result = gitcode::create_issue(&owner, &repo, &token.access_token, &title, &body)
+    // 4. 走 PR 链路：fork → 建分支 → 写文件 → 建 PR。
+    let result = crate::contribution::submit_pr(&token, &owner, &repo, &expert, &title, &body)
         .await
         .map_err(AppError::Internal)?;
 

--- a/backend/src/handlers/experts.rs
+++ b/backend/src/handlers/experts.rs
@@ -19,7 +19,7 @@ use crate::expert::{
 };
 use crate::expert::loader::resolve_within;
 
-/// `GET /api/experts`：获取所有专家列表
+/// `GET /api/v1/experts`：获取所有专家列表
 ///
 /// 返回所有已加载的专家元数据，按分类分组。前端可用于专家选择面板。
 pub async fn get_experts(
@@ -29,7 +29,7 @@ pub async fn get_experts(
     Ok(ApiResponse::ok(experts))
 }
 
-/// `GET /api/experts/:name`：获取单个专家详情
+/// `GET /api/v1/experts/:name`：获取单个专家详情
 ///
 /// 返回指定名称的专家完整元数据。
 pub async fn get_expert(
@@ -43,7 +43,7 @@ pub async fn get_expert(
     Ok(ApiResponse::ok(expert))
 }
 
-/// `GET /api/experts/:name/plugin-json`：获取专家的原始 plugin.json 内容
+/// `GET /api/v1/experts/:name/plugin-json`：获取专家的原始 plugin.json 内容
 ///
 /// 返回 plugin.json 文件的原始文本内容，用于前端编辑。
 pub async fn get_expert_plugin_json(
@@ -61,7 +61,7 @@ pub async fn get_expert_plugin_json(
     Ok(ApiResponse::ok(content))
 }
 
-/// `GET /api/experts/:name/agent-md`：获取专家的 Agent MD 内容
+/// `GET /api/v1/experts/:name/agent-md`：获取专家的 Agent MD 内容
 ///
 /// 根据专家类型自动定位：
 /// - 单个专家：使用 agent_name 字段定位
@@ -92,7 +92,7 @@ pub async fn get_expert_agent_md(
     Ok(ApiResponse::ok(md_content))
 }
 
-/// `GET /api/experts/:name/skills`：获取专家关联的所有 Skill 元数据
+/// `GET /api/v1/experts/:name/skills`：获取专家关联的所有 Skill 元数据
 ///
 /// 返回专家绑定的技能列表，用于前端展示可用技能。
 pub async fn get_expert_skills(
@@ -108,7 +108,7 @@ pub async fn get_expert_skills(
     Ok(ApiResponse::ok(skills))
 }
 
-/// `GET /api/experts/:name/avatar`：获取专家头像
+/// `GET /api/v1/experts/:name/avatar`：获取专家头像
 ///
 /// 根据专家的 avatar_path 字段定位头像文件并返回。
 /// 如果头像不存在，返回 404。
@@ -150,7 +150,7 @@ pub async fn get_expert_avatar(
     ))
 }
 
-/// `DELETE /api/experts/:name`：删除专家
+/// `DELETE /api/v1/experts/:name`：删除专家
 ///
 /// 删除指定专家：
 /// 1. 从内存索引中移除专家及其所有关联数据（agent_files、skills 等）
@@ -206,7 +206,7 @@ fn validate_agent_name(name: &str) -> Result<(), AppError> {
     Ok(())
 }
 
-/// `PUT /api/experts/:name`：更新专家
+/// `PUT /api/v1/experts/:name`：更新专家
 ///
 /// 更新指定专家的 plugin.json 和 agent.md 内容。
 /// 专家名称不可修改，如需改名请删除后重新创建。
@@ -270,7 +270,7 @@ pub async fn update_expert(
     }
 }
 
-/// `GET /api/experts/:name/members/:member_id/avatar`：获取团队成员头像
+/// `GET /api/v1/experts/:name/members/:member_id/avatar`：获取团队成员头像
 ///
 /// 团队成员的头像路径存储在成员的 avatar_path 字段中（相对专家定义目录）。
 /// 通过 expert_name 定位专家，再在 members 中按 member_id 查找对应成员，
@@ -332,7 +332,7 @@ fn infer_image_mime(path: &Path) -> &'static str {
     }
 }
 
-/// `POST /api/experts/create`：创建新专家
+/// `POST /api/v1/experts`：创建新专家（集合路径，取代旧 `POST /api/v1/experts/create`，旧路由仍保留兼容）
 ///
 /// 根据传入的 plugin_json 和 agent_md 内容创建新专家。
 /// 流程：
@@ -434,7 +434,7 @@ pub async fn create_expert(
     }
 }
 
-/// `POST /api/experts/reload`：重新加载所有专家定义
+/// `POST /api/v1/experts/reload`：重新加载所有专家定义
 ///
 /// 清空现有索引，重新扫描 ~/.ntd/experts/ 目录加载专家定义。
 /// 返回加载结果（成功数量和错误列表）。
@@ -515,7 +515,7 @@ pub struct WorkbuddyImportResult {
 
 // ── 导出 API ──────────────────────────────────────────────────────────
 
-/// `GET /api/experts/:name/export`：导出专家为 zip 文件
+/// `GET /api/v1/experts/:name/export`：导出专家为 zip 文件
 ///
 /// 将指定专家的整个目录打包为 zip 文件下载。
 /// 流式传输，不一次性加载整个 zip 到内存。
@@ -618,7 +618,7 @@ fn add_dir_to_zip<W: std::io::Write + std::io::Seek>(
 
 // ── 导入 API ──────────────────────────────────────────────────────────
 
-/// `POST /api/experts/import`：从 zip 文件导入专家
+/// `POST /api/v1/experts/import`：从 zip 文件导入专家
 ///
 /// 接收 multipart/form-data 上传的 zip 文件，解压并导入为新专家。
 /// 如果专家已存在则返回错误，不覆盖。
@@ -900,7 +900,7 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
 
 // ── 从目录导入 API ──────────────────────────────────────────────────
 
-/// `POST /api/experts/import-from-directory`：从本地目录导入专家
+/// `POST /api/v1/experts/import-from-directory`：从本地目录导入专家
 ///
 /// 接收 JSON body 指定的绝对路径，校验后复制到专家目录。
 /// 如果专家已存在则返回错误，不覆盖。
@@ -989,41 +989,10 @@ fn import_expert_from_dir(
     })
 }
 
-/// 专家 API 路由定义
-pub fn expert_routes() -> axum::Router<AppState> {
-    use axum::routing::{delete, get, post, put};
-
-    Router::new()
-        .route("/api/experts", get(get_experts))
-        .route("/api/experts/create", post(create_expert))
-        .route("/api/experts/{name}", get(get_expert))
-        .route("/api/experts/{name}", put(update_expert))
-        .route("/api/experts/{name}/plugin-json", get(get_expert_plugin_json))
-        .route("/api/experts/{name}/agent-md", get(get_expert_agent_md))
-        .route("/api/experts/{name}/skills", get(get_expert_skills))
-        .route("/api/experts/{name}/avatar", get(get_expert_avatar))
-        .route(
-            "/api/experts/{name}/members/{member_id}/avatar",
-            get(get_expert_member_avatar),
-        )
-        .route("/api/experts/{name}/export", get(export_expert))
-        .route("/api/experts/{name}", delete(delete_expert))
-        .route("/api/experts/reload", post(reload_experts))
-        .route("/api/experts/import", post(import_expert))
-        .route(
-            "/api/experts/import-from-directory",
-            post(import_expert_from_directory),
-        )
-        .route(
-            "/api/experts/import-from-workbuddy",
-            post(import_from_workbuddy),
-        )
-}
-
-/// V1 专家 API 路由定义（API 重构过渡期）
+/// V1 专家 API 路由定义
 ///
-/// 与 `expert_routes()` 共存，路由前缀改为 /api/v1/experts，全路径注册。
-/// 新旧路由在顶层通过不同的 Router merge 组装，此处不走嵌套前缀。
+/// 全路径注册版本化路由（前缀 /api/v1/experts），遵循 REST 集合语义。
+/// 旧 `/api/experts/*` 路由已随 api-routing-redesign 移除，不再注册。
 pub fn v1_routes() -> axum::Router<AppState> {
     use axum::routing::{get, post};
 
@@ -1073,7 +1042,7 @@ pub fn v1_routes() -> axum::Router<AppState> {
 const WORKBUDDY_EXPERTS_RELATIVE_PATH: &str =
     ".workbuddy/plugins/marketplaces/experts/plugins";
 
-/// `POST /api/experts/import-from-workbuddy`：从 WorkBuddy 目录批量导入专家
+/// `POST /api/v1/experts/import-from-workbuddy`：从 WorkBuddy 目录批量导入专家
 ///
 /// 扫描 WorkBuddy 默认目录下的所有专家子目录，逐个导入到 NTD 专家目录。
 /// 已存在的专家会被跳过，不会覆盖。

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -394,8 +394,7 @@ pub async fn create_app(
     Router::new()
         .merge(mount_v1_domain_routes())
         // project_directory::v1_routes() 已包含在 action::v1_routes() 中，
-        // 不再单独 merge，避免路由重复注册。旧版本 project_directory::routes()
-        // 在 mount_domain_routes() 中保留供过渡期使用。
+        // 不再单独 merge，避免路由重复注册。
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024))
         .layer(CompressionLayer::new())
         .layer(cors_layer())

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -160,6 +160,7 @@ pub mod action;
 pub mod blackboard;
 pub mod experts;
 pub mod bundled;
+pub mod contribution;
 pub mod process;
 pub mod tasks;
 pub mod task_posts;
@@ -431,6 +432,8 @@ fn mount_v1_domain_routes() -> Router<AppState> {
         .merge(tasks::task_routes())
         // 任务讨论区（论坛跟帖 + @专家/@执行器 触发执行后回帖，需求 060）
         .merge(task_posts::task_post_routes())
+        // 专家贡献（OAuth 登录 + 预览 + 提交为 Issue）
+        .merge(contribution::contribution_routes())
         // v1 版本化 API 由 action::v1_routes() 统一聚合
         .merge(action::v1_routes())
 }

--- a/backend/src/handlers/project_directory.rs
+++ b/backend/src/handlers/project_directory.rs
@@ -94,14 +94,6 @@ pub async fn delete_project_directory(
     Ok(ApiResponse::ok(()))
 }
 
-pub fn routes() -> Router<AppState> {
-    Router::new()
-        .route("/api/project-directories", get(list_project_directories))
-        .route("/api/project-directories", post(create_project_directory))
-        .route("/api/project-directories/{id}", put(update_project_directory))
-        .route("/api/project-directories/{id}", delete(delete_project_directory))
-}
-
 /// API v1 路由：项目目录相关端点。
 ///
 /// 将 /api 前缀替换为 /api/v1，参数模式与旧路由保持一致。

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -42,6 +42,11 @@ pub mod expert;
 ///
 /// 提供从远程 Git 仓库同步内置资源（专家、模板、Skills）的能力。
 pub mod git_sync;
+/// 专家贡献模块
+///
+/// 提供把本地专家以 Issue 形式提交回官方 GitCode 仓库的能力
+/// （OAuth 登录 + 预览 + 创建 Issue）。
+pub mod contribution;
 
 use rust_embed::RustEmbed;
 

--- a/docs/design/026-专家贡献-设计.md
+++ b/docs/design/026-专家贡献-设计.md
@@ -1,0 +1,183 @@
+# 026-专家贡献-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08-13 | 初始版本：专家以 Issue 形式贡献回官方仓库的设计方案 |
+
+---
+
+# 1. 设计目标
+
+在 ntd 内为用户提供「把本地专家一键提交为官方仓库 Issue」的完整链路：OAuth 登录 GitCode → 预览 Issue 内容 → 提交 → 返回 Issue 链接。全程用户不接触 git / fork / PR。
+
+对应需求：`docs/requirements/026-专家贡献-需求.md`。
+
+# 2. 总体架构与数据流
+
+```
+用户点击「分享到官方仓库」
+  └─ 前端 GET /api/v1/contribution/auth/status
+       ├─ 未登录：
+       │    GET /api/v1/contribution/oauth/url  ──> { url }
+       │    window.location.href = url  ──跳转──> GitCode 授权页
+       │    用户授权 ──> GitCode 302 ──> GET /api/v1/contribution/oauth/callback?code=&state=
+       │        后端校验 state → 用 code+client_secret 换 token → 持久化到 ~/.ntd
+       │        后端 302 回跳前端 /#/experts
+       └─ 已登录：
+            POST /api/v1/contribution/experts/{name}/preview  ──> { title, body, files }
+            前端预览 Modal（可编辑描述）
+            用户确认 ──> POST /api/v1/contribution/experts/{name}/submit ──> { issue_url, issue_number }
+            前端提示 + 提供 Issue 链接
+```
+
+外部依赖（GitCode 平台，均已查证 docs.gitcode.com）：
+- 授权：`GET https://gitcode.com/oauth/authorize?client_id=&redirect_uri=&response_type=code&scope=&state=`
+- 换 token：`POST https://gitcode.com/oauth/token?grant_type=authorization_code&code=&client_id=&client_secret=...`
+- 刷新：`POST https://gitcode.com/oauth/token?grant_type=refresh_token&refresh_token=...`
+- 创建 Issue：`POST https://api.gitcode.com/api/v5/repos/{owner}/{repo}/issues`（`Authorization: Bearer <token>`）
+
+# 3. 凭据与配置方案（本次不新增 config.yaml 字段）
+
+| 项 | 来源 | 说明 |
+|---|---|---|
+| `client_id` / `client_secret` | 编译期环境变量注入 | `option_env!("NTD_CONTRIB_CLIENT_ID")` / `NTD_CONTRIB_CLIENT_SECRET`；未注入返回 `None`，功能禁用 |
+| 贡献目标 `owner` / `repo` | 复用 `BundledSourceConfig.url` 解析 | 默认 `https://gitcode.com/weibaohui/ntd-resource.git` → `weibaohui` / `ntd-resource` |
+| GitCode 平台端点 | 常量硬编码 | `api.gitcode.com`、`gitcode.com/oauth/*` |
+| `redirect_uri` | 运行时按现有 `port` 拼 | `http://localhost:{port}/api/v1/contribution/oauth/callback` |
+
+编译期注入（`backend/src/contribution/gitcode.rs`）：
+```rust
+// option_env! 未设置时返回 None：编译通过、功能降级禁用，不因缺少凭据而编译失败。
+pub const CLIENT_ID: Option<&str> = option_env!("NTD_CONTRIB_CLIENT_ID");
+pub const CLIENT_SECRET: Option<&str> = option_env!("NTD_CONTRIB_CLIENT_SECRET");
+```
+> 说明：client_secret 打进分发的二进制后对本地用户可被提取，靠三道护栏兜底：OAuth 应用固定 `redirect_uri`（第三方改不了回调地址）、授权码一次性、后端校验 `state`。此为本地开源应用的固有属性，风险可接受。
+
+# 4. 后端设计
+
+## 4.1 新增模块结构
+
+```
+backend/src/contribution/
+  mod.rs        # 模块声明、公共类型（GitCodeToken 等）
+  gitcode.rs    # 平台常量 + owner/repo 解析 + GitCode HTTP 调用（换 token/刷新/建 issue）
+  oauth.rs      # OAuth state 生成/校验（内存 DashMap）+ token 持久化到 ~/.ntd
+  issue.rs      # 读取专家目录 → 组装 Issue 标题与 body（Markdown）
+
+backend/src/handlers/contribution.rs   # Handler + contribution_routes()
+```
+
+## 4.2 关键实现点
+
+### 4.2.1 `owner` / `repo` 解析（纯函数，可单测）
+
+```rust
+// 从 BundledSourceConfig.url 解析 owner/repo：
+// "https://gitcode.com/weibaohui/ntd-resource.git" → ("weibaohui", "ntd-resource")
+// 剥离协议前缀、去掉结尾 .git、取路径倒数两段；解析失败返回 None（功能禁用）。
+pub fn parse_owner_repo(url: &str) -> Option<(String, String)>
+```
+
+### 4.2.2 OAuth state（防 CSRF，内存存储）
+
+使用 `dashmap::DashMap<String, i64>`（state → 过期时间戳），进程内全局 `Lazy` 单例（对齐现有 `SkillsMarketCache` 的全局注册模式，不改 `AppState`）。生成时写入（10 分钟过期），回调时 `remove` 并校验存在且未过期。进程重启丢失 state 仅影响进行中的登录，可接受。
+
+### 4.2.3 token 持久化
+
+`~/.ntd/contribution_token.json`，结构：
+```json
+{ "access_token": "...", "refresh_token": "...", "expires_at": 1750000000, "scope": "..." }
+```
+- Unix 下写文件后 `chmod 0600`。
+- 读取时判断 `expires_at` 是否过期：过期则用 `refresh_token` 调 GitCode 刷新，成功后覆盖写盘。
+- 日志/错误信息禁止打印 token。
+
+### 4.2.4 Issue body 组装（`issue.rs`）
+
+输入专家 `name` → 经 `expert_manager.get_expert_by_name` 取 `definition_dir` → 读取：
+1. `.codebuddy-plugin/plugin.json` 全文；
+2. `agents/*.md`（由 plugin.json 的 `agents` 字段或扫描 `agents/` 目录定位，路径经 `resolve_within` 校验防逃逸）各文件全文；
+3. `skills/*/SKILL.md` 各文件全文。
+
+组装为固定 Markdown（标题 `[专家贡献] <name> v<version>`，label `expert-contribution`，body 含名称/类型/版本/说明 + 各文件代码块）。返回 `IssueDraft { title, body, files }`。
+
+### 4.2.5 创建 Issue（`gitcode.rs`）
+
+`POST {API_BASE}/api/v5/repos/{owner}/{repo}/issues`，`Authorization: Bearer <token>`，body `{ title, body, labels: ["expert-contribution"] }`。成功返回 `{ issue_url, issue_number, title }`。
+> 端点歧义：GitCode 文档「创建 Issue」标题写 `/repos/:owner/issues`，其余 Issue 接口为 `/repos/:owner/:repo/issues`。实现时以真实请求验证，取能成功创建的那个，并在实现总结中记录结论。
+
+## 4.3 路由与 Handler
+
+新增 `handlers/contribution.rs`，导出 `contribution_routes()`，在 `mount_v1_domain_routes()` 中 `.merge(contribution::contribution_routes())`。前端 axios 拦截器会把 `/api/contribution/*` 重写为 `/api/v1/contribution/*`，故后端统一注册在 `/api/v1/contribution/*` 下：
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/api/v1/contribution/auth/status` | `{ enabled, logged_in, username }` |
+| GET | `/api/v1/contribution/oauth/url` | `{ url }`（含 state） |
+| GET | `/api/v1/contribution/oauth/callback` | 校验 state → 换 token → 302 回跳 `/#/experts` |
+| POST | `/api/v1/contribution/experts/{name}/preview` | `{ title, body, files }` |
+| POST | `/api/v1/contribution/experts/{name}/submit` | 请求 `{ title, body }` → `{ issue_url, issue_number, title }` |
+| POST | `/api/v1/contribution/logout` | 清除本地 token |
+
+所有 Handler 遵循现有规范：`Result<ApiResponse<T>, AppError>`、参数用 `Path`/`Json`/`Query` 提取、生产代码无 `unwrap/expect/panic`。
+
+# 5. 前端设计
+
+## 5.1 API 模块
+
+新增 `frontend/src/utils/database/contribution.ts`（与 `experts.ts` 同目录、同风格），在 `index.ts` 增 `export * from './contribution'`：
+
+```ts
+getContributionAuthStatus(): Promise<{ enabled: boolean; logged_in: boolean; username?: string }>
+getOAuthUrl(): Promise<{ url: string }>
+previewExpertIssue(name): Promise<{ title: string; body: string; files: string[] }>
+submitExpertIssue(name, data: { title: string; body: string }): Promise<{ issue_url: string; issue_number: number; title: string }>
+logoutContribution(): Promise<void>
+```
+
+## 5.2 UI 改动（双入口）
+
+1. **独立「专家」页**：`ExpertsPanel.tsx` 的详情弹窗 `ExpertDetailModal` 操作区（导出/删除旁）新增「分享到官方仓库」按钮。
+2. **模板管理「专家模板」Tab**：`ExpertsTemplatesTab.tsx` 列表行内新增「分享」操作（与编辑/删除并列）。
+
+入口在 `enabled=false`（未注入凭据）时隐藏/置灰并 tooltip「贡献功能未配置」。
+
+## 5.3 预览确认 Modal
+
+新增组件 `ContributeModal`（`frontend/src/components/settings/experts/ContributeModal.tsx`）：
+- 展示只读标题（后端生成）、可编辑描述、只读文件清单；
+- 「提交」→ `submitExpertIssue`；成功 → `message.success` + 可点击 Issue 链接；失败 → `message.error`。
+
+## 5.4 交互流程
+
+1. 点「分享」→ 查 `auth/status`：
+   - `logged_in=false` → `getOAuthUrl()` → `window.location.href = url` 跳 GitCode 授权；授权后后端回调换 token 并 302 回 `/#/experts`；用户回到专家页再点「分享」，此时已登录，直接进入预览。
+   - `logged_in=true` → `previewExpertIssue(name)` → 打开 `ContributeModal`。
+2. 确认提交 → `submitExpertIssue` → 展示结果。
+
+> 已知取舍：OAuth 授权后需要用户回到专家页再点一次「分享」（首版不保存待分享专家上下文，避免引入 localStorage 状态机复杂度）。此为可接受的 MVP 取舍，后续可优化为回调后自动弹预览。
+
+# 6. 安全设计
+
+- `client_secret` 只经编译期环境变量注入，不进源码 / config.yaml / 前端 / 日志 / 错误信息。
+- OAuth 回调校验 `state`（一次性、10 分钟过期）防 CSRF。
+- 读取专家目录内文件复用 `resolve_within`，防 `..`/绝对路径/符号链接逃逸。
+- token 文件 `~/.ntd/contribution_token.json` 设 0600；日志脱敏。
+- 提交前由后端读取专家目录，前端只传专家 `name` 与可选 `title/body`，不传文件路径。
+
+# 7. 测试计划
+
+- **后端单测**：
+  - `parse_owner_repo`：https / ssh / 带 `.git` / 异常 url / 空串 等分支。
+  - `issue.rs`：用 `tempfile` 构造最小专家目录，断言 Markdown 标题、body 含 plugin.json / agent / skill 内容，及 `files` 清单。
+  - token 过期判断：过期 / 未过期 / 无 token。
+  - state 生成与校验：匹配 / 不匹配 / 过期。
+- **编译与静态检查**：`cargo clippy --all-targets -- -D warnings` 零告警；`cd frontend && npx tsc --noEmit` 零错误。
+- **功能验证**：OAuth 换 token 与创建 Issue 依赖真实 GitCode 账号/仓库，无法全自动化；以「未配置凭据时功能禁用、接口返回 enabled=false」的自动化断言 + 人工真实验证（配置环境变量后跑通一次完整链路）组合验收。前端 UI 用 Playwright 验证预览 Modal 渲染与禁用态。
+
+# 8. 关键决策记录
+
+- **提 Issue 而非 PR**：普通用户零 git 学习成本，官方仓库保留人工 review 门槛（详见需求文档 §1）。
+- **secret 编译期注入、不写 config.yaml**：维护者明确要求；secret 只随官方产物分发，本地/源码无明文。
+- **owner/repo 复用 `BundledSourceConfig.url`、平台地址常量**：不新增 config.yaml 字段，贡献目标自动跟随同步源。
+- **OAuth state 用内存 DashMap**：单进程 daemon 足够，避免引入 HMAC 依赖。

--- a/docs/design/026-专家贡献-设计.md
+++ b/docs/design/026-专家贡献-设计.md
@@ -40,7 +40,7 @@
 
 | 项 | 来源 | 说明 |
 |---|---|---|
-| `client_id` / `client_secret` | 编译期环境变量注入 | `option_env!("NTD_CONTRIB_CLIENT_ID")` / `NTD_CONTRIB_CLIENT_SECRET`；未注入返回 `None`，功能禁用 |
+| `client_id` / `client_secret` | 编译期环境变量注入 | `option_env!("NTD_GITCODE_CLIENT_ID")` / `NTD_GITCODE_CLIENT_SECRET`；未注入返回 `None`，功能禁用 |
 | 贡献目标 `owner` / `repo` | 复用 `BundledSourceConfig.url` 解析 | 默认 `https://gitcode.com/weibaohui/ntd-resource.git` → `weibaohui` / `ntd-resource` |
 | GitCode 平台端点 | 常量硬编码 | `api.gitcode.com`、`gitcode.com/oauth/*` |
 | `redirect_uri` | 运行时按现有 `port` 拼 | `http://localhost:{port}/api/v1/contribution/oauth/callback` |
@@ -48,8 +48,8 @@
 编译期注入（`backend/src/contribution/gitcode.rs`）：
 ```rust
 // option_env! 未设置时返回 None：编译通过、功能降级禁用，不因缺少凭据而编译失败。
-pub const CLIENT_ID: Option<&str> = option_env!("NTD_CONTRIB_CLIENT_ID");
-pub const CLIENT_SECRET: Option<&str> = option_env!("NTD_CONTRIB_CLIENT_SECRET");
+pub const CLIENT_ID: Option<&str> = option_env!("NTD_GITCODE_CLIENT_ID");
+pub const CLIENT_SECRET: Option<&str> = option_env!("NTD_GITCODE_CLIENT_SECRET");
 ```
 > 说明：client_secret 打进分发的二进制后对本地用户可被提取，靠三道护栏兜底：OAuth 应用固定 `redirect_uri`（第三方改不了回调地址）、授权码一次性、后端校验 `state`。此为本地开源应用的固有属性，风险可接受。
 

--- a/docs/design/026-专家贡献-设计.md
+++ b/docs/design/026-专家贡献-设计.md
@@ -20,7 +20,7 @@
        ├─ 未登录：
        │    GET /api/v1/contribution/oauth/url  ──> { url }
        │    window.location.href = url  ──跳转──> GitCode 授权页
-       │    用户授权 ──> GitCode 302 ──> GET /api/v1/contribution/oauth/callback?code=&state=
+       │    用户授权 ──> GitCode 302 ──> GET /api/v1/gitcode/oauth/callback?code=&state=
        │        后端校验 state → 用 code+client_secret 换 token → 持久化到 ~/.ntd
        │        后端 302 回跳前端 /#/experts
        └─ 已登录：
@@ -43,7 +43,7 @@
 | `client_id` / `client_secret` | 编译期环境变量注入 | `option_env!("NTD_GITCODE_CLIENT_ID")` / `NTD_GITCODE_CLIENT_SECRET`；未注入返回 `None`，功能禁用 |
 | 贡献目标 `owner` / `repo` | 复用 `BundledSourceConfig.url` 解析 | 默认 `https://gitcode.com/weibaohui/ntd-resource.git` → `weibaohui` / `ntd-resource` |
 | GitCode 平台端点 | 常量硬编码 | `api.gitcode.com`、`gitcode.com/oauth/*` |
-| `redirect_uri` | 运行时按现有 `port` 拼 | `http://localhost:{port}/api/v1/contribution/oauth/callback` |
+| `redirect_uri` | 运行时按现有 `port` 拼 | `http://127.0.0.1:{port}/api/v1/gitcode/oauth/callback` |
 
 编译期注入（`backend/src/contribution/gitcode.rs`）：
 ```rust
@@ -114,7 +114,7 @@ pub fn parse_owner_repo(url: &str) -> Option<(String, String)>
 |------|------|------|
 | GET | `/api/v1/contribution/auth/status` | `{ enabled, logged_in, username }` |
 | GET | `/api/v1/contribution/oauth/url` | `{ url }`（含 state） |
-| GET | `/api/v1/contribution/oauth/callback` | 校验 state → 换 token → 302 回跳 `/#/experts` |
+| GET | `/api/v1/gitcode/oauth/callback` | 校验 state → 换 token → 302 回跳 `/#/experts` |
 | POST | `/api/v1/contribution/experts/{name}/preview` | `{ title, body, files }` |
 | POST | `/api/v1/contribution/experts/{name}/submit` | 请求 `{ title, body }` → `{ issue_url, issue_number, title }` |
 | POST | `/api/v1/contribution/logout` | 清除本地 token |

--- a/docs/requirements/026-专家贡献-实现总结.md
+++ b/docs/requirements/026-专家贡献-实现总结.md
@@ -33,7 +33,7 @@
 - **创建 Issue 端点歧义**：GitCode 文档「创建 Issue」标题写 `/repos/:owner/issues`，实现采用 `/repos/{owner}/{repo}/issues`（与其余 Issue 接口一致），需真实验证确认；`labels` 字段格式（字符串 vs 数组）同样待真实调用确认。
 - **OAuth 后需再点一次分享**：回调后 302 回专家页，未保存「待分享专家」上下文，用户需再点一次；后续可优化为回调后自动弹预览。
 - **二进制资源不随 Issue 提交**：头像等图片无法用文本携带（需求已列为非目标）。
-- **`redirect_uri` 回环地址**：需维护者在 GitCode 注册 OAuth 应用时确认允许 `http://localhost:18088/...` 与 `8088`。
+- **`redirect_uri` 回环地址**：GitCode 要求用 `127.0.0.1`（非 `localhost`）形式，已对齐 `http://127.0.0.1:18088/api/v1/gitcode/oauth/callback`；生产 `8088` 端口需在 OAuth 应用额外配置。
 
 ## 5. 测试与验证
 

--- a/docs/requirements/026-专家贡献-实现总结.md
+++ b/docs/requirements/026-专家贡献-实现总结.md
@@ -18,7 +18,7 @@
 | 提交前预览确认 | 前端 `ContributeButton`：预览 Modal 展示标题（可编辑）+ 正文（可编辑）+ 文件清单（只读） |
 | 双入口 | 独立「专家」页详情 Modal 操作区 + 「专家模板」Tab 操作列，均复用 `ContributeButton` |
 | 后端读取专家目录组装固定格式 Issue | `contribution::issue`：内嵌 plugin.json + agents/*.md + skills/*/SKILL.md |
-| 凭据编译期注入、不写 config.yaml | `option_env!("NTD_CONTRIB_CLIENT_ID")` / `NTD_CONTRIB_CLIENT_SECRET`；owner/repo 复用 `BundledSourceConfig.url` 解析；平台地址常量 |
+| 凭据编译期注入、不写 config.yaml | `option_env!("NTD_GITCODE_CLIENT_ID")` / `NTD_GITCODE_CLIENT_SECRET`；owner/repo 复用 `BundledSourceConfig.url` 解析；平台地址常量 |
 
 ## 3. 关键实现点
 
@@ -45,6 +45,6 @@
 
 ## 6. 上线前置（需维护者人工完成）
 
-1. 在 GitCode 注册 OAuth 应用，`redirect_uri` 指向本机回调；将 `client_id`/`client_secret` 配置进 GitHub Actions Secrets（`NTD_CONTRIB_CLIENT_ID`/`NTD_CONTRIB_CLIENT_SECRET`）。
+1. 在 GitCode 注册 OAuth 应用，`redirect_uri` 指向本机回调；将 `client_id`/`client_secret` 配置进 GitHub Actions Secrets（`NTD_GITCODE_CLIENT_ID`/`NTD_GITCODE_CLIENT_SECRET`）。
 2. 在 `weibaohui/ntd-resource` 仓库预建 `expert-contribution` label。
 3. 用真实账号跑通一次完整链路，确认创建 Issue 端点与 `labels` 字段格式。

--- a/docs/requirements/026-专家贡献-实现总结.md
+++ b/docs/requirements/026-专家贡献-实现总结.md
@@ -1,0 +1,50 @@
+# 026-专家贡献-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08-13 | 初始版本：专家以 Issue 形式贡献回官方仓库 |
+
+---
+
+## 1. 实现了什么
+
+为「专家」资源新增一条最小化操作的贡献通道：用户在专家 UI 点「分享到官方仓库」，通过 OAuth 单点登录 GitCode，预览 Issue 内容后一键提交为官方仓库（`weibaohui/ntd-resource`）的 Issue，由维护者人工合入后，复用现有单向同步分发。
+
+## 2. 与需求的对应关系
+
+| 需求条目 | 实现 |
+|---|---|
+| OAuth 单点登录 | 后端 `contribution::gitcode` + `oauth`：授权 URL 拼装、回调换 token、refresh 刷新、`state` 防 CSRF、token 持久化（0600） |
+| 提交前预览确认 | 前端 `ContributeButton`：预览 Modal 展示标题（可编辑）+ 正文（可编辑）+ 文件清单（只读） |
+| 双入口 | 独立「专家」页详情 Modal 操作区 + 「专家模板」Tab 操作列，均复用 `ContributeButton` |
+| 后端读取专家目录组装固定格式 Issue | `contribution::issue`：内嵌 plugin.json + agents/*.md + skills/*/SKILL.md |
+| 凭据编译期注入、不写 config.yaml | `option_env!("NTD_CONTRIB_CLIENT_ID")` / `NTD_CONTRIB_CLIENT_SECRET`；owner/repo 复用 `BundledSourceConfig.url` 解析；平台地址常量 |
+
+## 3. 关键实现点
+
+- **后端新增模块**：`backend/src/contribution/`（`mod.rs`/`gitcode.rs`/`oauth.rs`/`issue.rs`）+ `backend/src/handlers/contribution.rs`，6 个路由挂在 `/api/v1/contribution/*` 下。
+- **凭据与目标仓库**：`client_id`/`client_secret` 编译期注入，缺失则 `enabled=false`（功能禁用、编译仍通过）；`owner`/`repo` 从 `BundledSourceConfig.url`（`https://gitcode.com/weibaohui/ntd-resource.git`）解析，`parse_owner_repo` 为纯函数便于单测。
+- **OAuth state**：进程内 `DashMap` 存储，10 分钟过期、一次性消费。
+- **token 持久化**：`~/.ntd/contribution_token.json`，Unix 下用 `OpenOptions::mode(0o600)` 原子创建（消除 TOCTOU），`GitCodeToken` 自定义 `Debug` 脱敏。
+- **安全**：`resolve_within` 防路径逃逸；token 端点错误改用 HTTP status 不泄露含 code 的 URL；`submit` 限制 title ≤255 / body ≤100000 字符；回调 HTML 转义。
+
+## 4. 已知限制与待改进点
+
+- **创建 Issue 端点歧义**：GitCode 文档「创建 Issue」标题写 `/repos/:owner/issues`，实现采用 `/repos/{owner}/{repo}/issues`（与其余 Issue 接口一致），需真实验证确认；`labels` 字段格式（字符串 vs 数组）同样待真实调用确认。
+- **OAuth 后需再点一次分享**：回调后 302 回专家页，未保存「待分享专家」上下文，用户需再点一次；后续可优化为回调后自动弹预览。
+- **二进制资源不随 Issue 提交**：头像等图片无法用文本携带（需求已列为非目标）。
+- **`redirect_uri` 回环地址**：需维护者在 GitCode 注册 OAuth 应用时确认允许 `http://localhost:18088/...` 与 `8088`。
+
+## 5. 测试与验证
+
+- 后端：`cargo clippy --all-targets -- -D warnings` 零告警；`cargo test --lib contribution` 17 个单测通过（owner/repo 解析、Issue 草稿组装、token 持久化/过期、state、长度校验、HTML 转义）。
+- 前端：`npx tsc --noEmit` 零错误；`npm run build` 成功。
+- Playwright：`tests/026-expert-contribution.spec.ts` 验证专家详情 Modal 分享按钮渲染 + 未配置凭据时降级提示。
+- 安全：`security_review` 无 CRITICAL/HIGH，发现的 2 medium + 2 low 均已修复。
+- 全量 `cargo test` 中 5 个失败为存量模块（`executor_service::pre_spawn`/`wiki::fs`）的 `PermissionDenied` 环境问题，与本次改动无关。
+
+## 6. 上线前置（需维护者人工完成）
+
+1. 在 GitCode 注册 OAuth 应用，`redirect_uri` 指向本机回调；将 `client_id`/`client_secret` 配置进 GitHub Actions Secrets（`NTD_CONTRIB_CLIENT_ID`/`NTD_CONTRIB_CLIENT_SECRET`）。
+2. 在 `weibaohui/ntd-resource` 仓库预建 `expert-contribution` label。
+3. 用真实账号跑通一次完整链路，确认创建 Issue 端点与 `labels` 字段格式。

--- a/docs/requirements/026-专家贡献-需求.md
+++ b/docs/requirements/026-专家贡献-需求.md
@@ -1,0 +1,129 @@
+# 026-专家贡献-需求
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08-13 | 初始版本：专家以 Issue 形式贡献回官方仓库 |
+| AI | 2026-08-13 | client_id/client_secret 改为编译期环境变量注入，不写入 config.yaml |
+| AI | 2026-08-13 | 明确本次不新增 config.yaml 字段：owner/repo 复用 BundledSourceConfig.url，平台地址用常量 |
+
+---
+
+# 1. 背景（Why）
+
+ntd 的专家/模板资源目前是**单向同步**：从远端仓库 `https://gitcode.com/weibaohui/ntd-resource.git`（GitCode，即 atomgit，同一平台两个域名）通过 `git clone` / `git fetch` + `git reset --hard` 拉取到本地 `~/.ntd/bundled/`，本地用户对专家的修改、新建**无法回传远端**。
+
+本需求为「专家」这一种资源建立一个**最小化操作的贡献通道**：用户通过 OAuth 单点登录 GitCode 后，把本地某个专家以**固定格式的 Issue** 提交到官方仓库，由维护者人工 review 合入；合入后复用现有单向同步即可分发给所有用户。
+
+选择「提 Issue + 人工合入」而非「直接 PR / git push」的原因：普通用户无需掌握 git / fork / branch / PR，操作成本最低，同时保留官方仓库的内容质量门槛。
+
+# 2. 目标（What，必须可验证）
+
+- [ ] 用户能在专家相关 UI 发起「提交为 Issue」操作（本期双入口：独立「专家」页 + 设置→模板管理→「专家模板」Tab）。
+- [ ] 用户通过 OAuth 单点登录 GitCode；登录态在后端持久化，`access_token` 过期时自动用 `refresh_token` 刷新。
+- [ ] 提交前弹窗**预览**：展示将要发布的 Issue 标题、描述与打包内容摘要，用户可编辑描述后确认提交。
+- [ ] 后端读取用户本地专家目录，按固定 Markdown 格式打包（plugin.json + agent 定义 + skills），用用户 token 调用 GitCode API 在 `weibaohui/ntd-resource` 仓库创建 Issue，返回 Issue 链接。
+- [ ] 提交失败有明确错误提示，且不泄露 `client_secret` / `access_token` 等敏感信息。
+
+# 3. 非目标（Explicitly Out of Scope）
+
+- 不实现直接 `git push` / fork / 创建 PR 的通道。
+- 本期仅支持「专家」一种资源；事项模板 / Skill / 工艺模板的贡献**不在本期范围**（留作后续扩展）。
+- 不做 Issue 后续处理进度跟踪（用户提交后仅拿到 Issue 链接，不在 ntd 内追踪是否已合入）。
+- 不做二进制资源（如头像 `avatar` 图片）随 Issue 上传。
+- 不做多账号管理与账号切换（单 token）。
+
+# 4. 使用场景 / 用户路径
+
+1. 用户在本地修改了一个专家（或新建了专家），觉得好用，希望分享给其他用户。
+2. 在专家卡片 / 列表点击「分享到官方仓库」。
+3. 若未登录：浏览器跳转 GitCode 授权页，用户授权后回跳 ntd，登录态建立。
+4. 弹出预览框：展示 Issue 标题、描述、将打包的文件清单；用户可修改描述、确认。
+5. 确认后提交；成功后提示「已提交为 Issue #N」，并提供 Issue 链接供用户打开查看。
+
+# 5. 功能需求清单（Checklist）
+
+- [ ] **后端 OAuth**：生成 GitCode 授权 URL（含 `state` 防 CSRF）；处理回调（校验 `state`、用 `code` + `client_secret` 换取 `access_token` / `refresh_token`）；token 持久化到本地（`~/.ntd/` 下，不进入源码）；提供刷新 token 逻辑；提供登录态查询与退出接口。
+- [ ] **后端 Issue 提交**：根据专家 `name` 定位本地专家目录，读取 `.codebuddy-plugin/plugin.json`、`agents/*.md`、`skills/*/SKILL.md` 文本内容，按固定 Markdown 模板组装 Issue body；调用 GitCode「创建 Issue」API，附带固定 label（如 `expert-contribution`）；返回 `issue_url` / `issue_number` / `title`。
+- [ ] **后端预览**：提供「组装 Issue 内容但不提交」的预览接口，返回 `title` 与 `body`，供前端预览框展示。
+- [ ] **配置**：`client_id` / `client_secret` 通过编译期环境变量（`option_env!`，如 `NTD_CONTRIB_CLIENT_ID` / `NTD_CONTRIB_CLIENT_SECRET`）注入，绝不进入源码、`config.yaml`、前端或日志；未注入时功能禁用（`option_env!` 返回 `None`，编译仍通过）。**本次不新增任何 `config.yaml` 字段**：贡献目标 `owner` / `repo` 复用现有 `BundledSourceConfig.url`（默认 `https://gitcode.com/weibaohui/ntd-resource.git`）解析得到；GitCode API base / OAuth 端点（`api.gitcode.com`、`gitcode.com/oauth/*`）作为平台常量硬编码。
+- [ ] **前端 API 模块**：新增 `frontend/src/utils/database/contribution.ts`（与 `experts.ts` 同目录），封装 OAuth 状态查询、预览、提交、退出等接口（复用 `@/utils/database/client` 的 `api` + `unwrap`），并在 `index.ts` 中导出。
+- [ ] **前端入口**：独立「专家」页卡片与「专家模板」Tab 列表行内均提供「分享/提交」入口；未登录时引导登录；已登录时直接进入预览。
+- [ ] **前端预览框**：`Modal` 展示标题 + 可编辑描述 + 只读内容摘要；确认后调用提交接口；成功展示 Issue 链接。
+
+# 6. 约束条件（非常关键）
+
+- **安全约束**：
+  - `client_secret` 仅通过编译期环境变量注入，禁止进入源码、`config.yaml`、前端、日志、错误信息。
+  - OAuth 回调必须校验 `state`，防 CSRF。
+  - 读取专家目录内文件必须复用 `resolve_within` 做路径逃逸防护，禁止根据前端传入的任意路径直接读文件。
+  - `access_token` / `refresh_token` 持久化到 `~/.ntd/`，权限设为仅当前用户可读；日志禁止打印 token。
+- **架构约束**：
+  - OAuth token 交换必须由后端完成（前端不能持有 `client_secret`）。
+  - 新增后端模块遵循现有分层（Handler / Service），路由在 `handlers/mod.rs` 或对应子模块的 `router()` 中注册。
+  - 不修改现有单向同步（`git_sync`）的只读语义。
+  - 不新增 `config.yaml` 配置字段（复用现有 `BundledSourceConfig.url`，平台地址用常量）。
+- **技术约束**：
+  - Rust：`cargo clippy --all-targets -- -D warnings` 零告警；生产代码禁止 `.unwrap()` / `.expect()` / `panic!`。
+  - 前端：`npx tsc --noEmit` 零错误；`frontend/src` 内跨目录导入用 `@/` 别名。
+  - 单函数体 ≤ 30 行；每个公开函数有单元测试。
+- **性能约束**：Issue body 组装为纯文本拼接，单专家文件体量小，无额外性能要求；外部 API 调用（换 token / 建 Issue）用后端 `reqwest` 完成，不阻塞前端。
+
+# 7. 可修改 / 不可修改项
+
+- ❌ 不可修改：
+  - 贡献目标仓库复用现有 `BundledSourceConfig.url` 解析（默认 `weibaohui/ntd-resource`）；本次不新增 `config.yaml` 字段。
+  - `client_id` / `client_secret` 只能通过编译期环境变量注入，不得写入 `config.yaml`、源码或日志。
+  - OAuth 必须走后端中转，不允许前端直接持有 `client_secret`。
+  - 现有单向同步（`git_sync` 只读）语义不得被破坏。
+- ✅ 可调整：
+  - Issue body 固定格式的排版与字段取舍。
+  - 固定 label 的命名（需维护者在官方仓库预先创建）。
+  - 入口按钮的文案与摆放细节。
+  - token 在 `~/.ntd/` 下的具体存储文件名与结构。
+
+# 8. 接口与数据约定（如适用）
+
+## 8.1 ntd 内部新增接口（建议路径，实现阶段可微调）
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/api/contribution/auth/status` | 查询登录态：`{ logged_in: bool, username?: string }` |
+| GET | `/api/contribution/oauth/url` | 获取 GitCode 授权跳转 URL：`{ url: string }` |
+| GET | `/api/contribution/oauth/callback?code=&state=` | OAuth 回调：校验 state、换 token、持久化，返回收尾页 |
+| POST | `/api/contribution/experts/{name}/preview` | 组装 Issue 内容（不提交）：`{ title: string, body: string, files: string[] }` |
+| POST | `/api/contribution/experts/{name}/submit` | 提交 Issue：请求 `{ title?, body? }`，返回 `{ issue_url, issue_number, title }` |
+| POST | `/api/contribution/logout` | 清除本地登录态 |
+
+## 8.2 GitCode 外部接口（已查证 docs.gitcode.com）
+
+- 授权：`GET https://gitcode.com/oauth/authorize?client_id=&redirect_uri=&response_type=code&scope=&state=`
+- 换 token：`POST https://gitcode.com/oauth/token?grant_type=authorization_code&code=&client_id=&client_secret=` → `{ access_token, refresh_token, expires_in, scope }`
+- 刷新：`POST https://gitcode.com/oauth/token?grant_type=refresh_token&refresh_token=`
+- 创建 Issue：`POST https://api.gitcode.com/api/v5/repos/{owner}/{repo}/issues`，头 `Authorization: Bearer <token>`，body 含 `title`、`body`、`labels`（详见 §10 不确定点）。
+
+## 8.3 Issue 固定格式（示例）
+
+- 标题：`[专家贡献] <name> v<version>`
+- label：`expert-contribution`
+- body（Markdown）：专家名称 / 类型 / 版本 / 说明，随后依次以代码块内嵌 `plugin.json`、各 `agents/*.md`、各 `skills/*/SKILL.md` 完整内容。
+
+# 9. 验收标准（Acceptance Criteria）
+
+- 如果用户在专家 UI 点击「分享」且未登录，则浏览器跳转到 GitCode 授权页，授权后回到 ntd 且登录态建立（`auth/status` 返回 `logged_in: true`）。
+- 如果已登录用户点击「分享」，则弹出预览框，且预览框内容与后端 `preview` 接口返回一致，用户可编辑描述。
+- 如果用户确认提交，则后端在 `weibaohui/ntd-resource` 仓库创建出带 `expert-contribution` 标签的 Issue，标题以 `[专家贡献]` 开头，body 内包含该专家的 `plugin.json` 与 agent/skill 文本内容。
+- 如果用户提交成功，则前端展示 Issue 链接，用户点击可在浏览器打开。
+- 如果提交失败（未登录 / token 失效 / GitCode 返回错误），则前端给出可读的错误提示，且日志与错误信息中不出现 `client_secret` / `access_token`。
+- 如果 `access_token` 已过期，则后端用 `refresh_token` 自动刷新后再提交，无需用户重新登录（`refresh_token` 有效期内）。
+
+# 10. 风险与已知不确定点
+
+- **创建 Issue 的精确端点存在歧义**：GitCode 文档「创建 Issue」标题显示 `POST /api/v5/repos/:owner/issues`，但其余 Issue 接口均为 `/repos/:owner/:repo/issues`。实现阶段需以真实请求验证，并写入设计文档确认。
+- **OAuth `redirect_uri` 对 `localhost` 回环地址的支持**：ntd 为本地应用（开发 `http://localhost:18088`，生产 `http://localhost:8088`），需验证 GitCode OAuth 应用允许配置回环地址。
+- **前置人工准备**：维护者需先在 GitCode 注册 OAuth 应用取得 `client_id` / `client_secret`，在 GitHub Actions 的 Secrets 中配置 `NTD_CONTRIB_CLIENT_ID` / `NTD_CONTRIB_CLIENT_SECRET`（构建时注入到二进制），并在 `ntd-resource` 仓库预建 `expert-contribution` label。
+- **Issue body 长度限制**：单个专家若含大量 skill / 超长文本，可能触及 GitCode Issue body 上限；实现时需评估并对超长内容做截断或提示。
+- **二进制资源缺失**：头像等二进制文件无法通过 Issue 文本携带，属已知限制（见 §3 非目标）。
+
+# 11. 非目标（补充确认）
+
+本需求仅落地「专家 → 提交为 Issue」的完整链路（登录 + 预览 + 提交 + 反馈），不包含 Issue 处理进度回显、不包含对事项模板 / Skill / 工艺模板的贡献支持；这些功能在链路验证通过后按同模式扩展。

--- a/docs/requirements/026-专家贡献-需求.md
+++ b/docs/requirements/026-专家贡献-需求.md
@@ -89,7 +89,7 @@ ntd 的专家/模板资源目前是**单向同步**：从远端仓库 `https://g
 |------|------|------|
 | GET | `/api/contribution/auth/status` | 查询登录态：`{ logged_in: bool, username?: string }` |
 | GET | `/api/contribution/oauth/url` | 获取 GitCode 授权跳转 URL：`{ url: string }` |
-| GET | `/api/contribution/oauth/callback?code=&state=` | OAuth 回调：校验 state、换 token、持久化，返回收尾页 |
+| GET | `/api/gitcode/oauth/callback?code=&state=` | OAuth 回调：校验 state、换 token、持久化，返回收尾页 |
 | POST | `/api/contribution/experts/{name}/preview` | 组装 Issue 内容（不提交）：`{ title: string, body: string, files: string[] }` |
 | POST | `/api/contribution/experts/{name}/submit` | 提交 Issue：请求 `{ title?, body? }`，返回 `{ issue_url, issue_number, title }` |
 | POST | `/api/contribution/logout` | 清除本地登录态 |
@@ -119,7 +119,7 @@ ntd 的专家/模板资源目前是**单向同步**：从远端仓库 `https://g
 # 10. 风险与已知不确定点
 
 - **创建 Issue 的精确端点存在歧义**：GitCode 文档「创建 Issue」标题显示 `POST /api/v5/repos/:owner/issues`，但其余 Issue 接口均为 `/repos/:owner/:repo/issues`。实现阶段需以真实请求验证，并写入设计文档确认。
-- **OAuth `redirect_uri` 对 `localhost` 回环地址的支持**：ntd 为本地应用（开发 `http://localhost:18088`，生产 `http://localhost:8088`），需验证 GitCode OAuth 应用允许配置回环地址。
+- **OAuth `redirect_uri` 回环地址形式**：GitCode 对 `localhost` 形式校验不通过，需用 `http://127.0.0.1:18088/api/v1/gitcode/oauth/callback`（开发）注册；生产（`8088`）若需使用贡献功能，需在 OAuth 应用再配置对应端口的回调地址。
 - **前置人工准备**：维护者需先在 GitCode 注册 OAuth 应用取得 `client_id` / `client_secret`，在 GitHub Actions 的 Secrets 中配置 `NTD_GITCODE_CLIENT_ID` / `NTD_GITCODE_CLIENT_SECRET`（构建时注入到二进制），并在 `ntd-resource` 仓库预建 `expert-contribution` label。
 - **Issue body 长度限制**：单个专家若含大量 skill / 超长文本，可能触及 GitCode Issue body 上限；实现时需评估并对超长内容做截断或提示。
 - **二进制资源缺失**：头像等二进制文件无法通过 Issue 文本携带，属已知限制（见 §3 非目标）。

--- a/docs/requirements/026-专家贡献-需求.md
+++ b/docs/requirements/026-专家贡献-需求.md
@@ -45,7 +45,7 @@ ntd 的专家/模板资源目前是**单向同步**：从远端仓库 `https://g
 - [ ] **后端 OAuth**：生成 GitCode 授权 URL（含 `state` 防 CSRF）；处理回调（校验 `state`、用 `code` + `client_secret` 换取 `access_token` / `refresh_token`）；token 持久化到本地（`~/.ntd/` 下，不进入源码）；提供刷新 token 逻辑；提供登录态查询与退出接口。
 - [ ] **后端 Issue 提交**：根据专家 `name` 定位本地专家目录，读取 `.codebuddy-plugin/plugin.json`、`agents/*.md`、`skills/*/SKILL.md` 文本内容，按固定 Markdown 模板组装 Issue body；调用 GitCode「创建 Issue」API，附带固定 label（如 `expert-contribution`）；返回 `issue_url` / `issue_number` / `title`。
 - [ ] **后端预览**：提供「组装 Issue 内容但不提交」的预览接口，返回 `title` 与 `body`，供前端预览框展示。
-- [ ] **配置**：`client_id` / `client_secret` 通过编译期环境变量（`option_env!`，如 `NTD_CONTRIB_CLIENT_ID` / `NTD_CONTRIB_CLIENT_SECRET`）注入，绝不进入源码、`config.yaml`、前端或日志；未注入时功能禁用（`option_env!` 返回 `None`，编译仍通过）。**本次不新增任何 `config.yaml` 字段**：贡献目标 `owner` / `repo` 复用现有 `BundledSourceConfig.url`（默认 `https://gitcode.com/weibaohui/ntd-resource.git`）解析得到；GitCode API base / OAuth 端点（`api.gitcode.com`、`gitcode.com/oauth/*`）作为平台常量硬编码。
+- [ ] **配置**：`client_id` / `client_secret` 通过编译期环境变量（`option_env!`，如 `NTD_GITCODE_CLIENT_ID` / `NTD_GITCODE_CLIENT_SECRET`）注入，绝不进入源码、`config.yaml`、前端或日志；未注入时功能禁用（`option_env!` 返回 `None`，编译仍通过）。**本次不新增任何 `config.yaml` 字段**：贡献目标 `owner` / `repo` 复用现有 `BundledSourceConfig.url`（默认 `https://gitcode.com/weibaohui/ntd-resource.git`）解析得到；GitCode API base / OAuth 端点（`api.gitcode.com`、`gitcode.com/oauth/*`）作为平台常量硬编码。
 - [ ] **前端 API 模块**：新增 `frontend/src/utils/database/contribution.ts`（与 `experts.ts` 同目录），封装 OAuth 状态查询、预览、提交、退出等接口（复用 `@/utils/database/client` 的 `api` + `unwrap`），并在 `index.ts` 中导出。
 - [ ] **前端入口**：独立「专家」页卡片与「专家模板」Tab 列表行内均提供「分享/提交」入口；未登录时引导登录；已登录时直接进入预览。
 - [ ] **前端预览框**：`Modal` 展示标题 + 可编辑描述 + 只读内容摘要；确认后调用提交接口；成功展示 Issue 链接。
@@ -120,7 +120,7 @@ ntd 的专家/模板资源目前是**单向同步**：从远端仓库 `https://g
 
 - **创建 Issue 的精确端点存在歧义**：GitCode 文档「创建 Issue」标题显示 `POST /api/v5/repos/:owner/issues`，但其余 Issue 接口均为 `/repos/:owner/:repo/issues`。实现阶段需以真实请求验证，并写入设计文档确认。
 - **OAuth `redirect_uri` 对 `localhost` 回环地址的支持**：ntd 为本地应用（开发 `http://localhost:18088`，生产 `http://localhost:8088`），需验证 GitCode OAuth 应用允许配置回环地址。
-- **前置人工准备**：维护者需先在 GitCode 注册 OAuth 应用取得 `client_id` / `client_secret`，在 GitHub Actions 的 Secrets 中配置 `NTD_CONTRIB_CLIENT_ID` / `NTD_CONTRIB_CLIENT_SECRET`（构建时注入到二进制），并在 `ntd-resource` 仓库预建 `expert-contribution` label。
+- **前置人工准备**：维护者需先在 GitCode 注册 OAuth 应用取得 `client_id` / `client_secret`，在 GitHub Actions 的 Secrets 中配置 `NTD_GITCODE_CLIENT_ID` / `NTD_GITCODE_CLIENT_SECRET`（构建时注入到二进制），并在 `ntd-resource` 仓库预建 `expert-contribution` label。
 - **Issue body 长度限制**：单个专家若含大量 skill / 超长文本，可能触及 GitCode Issue body 上限；实现时需评估并对超长内容做截断或提示。
 - **二进制资源缺失**：头像等二进制文件无法通过 Issue 文本携带，属已知限制（见 §3 非目标）。
 

--- a/docs/user-guide/settings/project-directories.md
+++ b/docs/user-guide/settings/project-directories.md
@@ -95,11 +95,11 @@ Todo还有一个 `worktree_enabled`字段：
 
 ## 6.相关 API
 
-`project_directory::routes()`挂载在 `/api/project-directories` 下，标准 CRUD：
+`project_directory::v1_routes()`挂载在 `/api/v1/project-directories` 下，标准 CRUD：
 
 | Method | Path |用途 |
 |--------|------|------|
-| GET | `/api/project-directories` |列出全部 |
-| POST | `/api/project-directories` |新增（body `{path, name}`，`name`必填） |
-| PUT | `/api/project-directories/{id}` |修改（body `{name}`） |
-| DELETE | `/api/project-directories/{id}` |删除 |
+| GET | `/api/v1/project-directories` |列出全部 |
+| POST | `/api/v1/project-directories` |新增（body `{path, name}`，`name`必填） |
+| PUT | `/api/v1/project-directories/{id}` |修改（body `{name}`） |
+| DELETE | `/api/v1/project-directories/{id}` |删除 |

--- a/frontend/src/api/bundled.ts
+++ b/frontend/src/api/bundled.ts
@@ -1,5 +1,5 @@
 // 内置资源同步 API
-// 对应后端 /api/bundled/* 接口
+// 对应后端 /api/v1/bundled/* 接口
 // 统一管理专家、事项模板、Skills 的远程仓库同步
 
 import { api, unwrap } from '@/utils/database/client';
@@ -323,7 +323,7 @@ export const bundledApi = {
     // 后端返回 {code, data, message} 包裹，必须用 unwrap 取出 data，
     // 否则调用方拿到的会是整个 axios response，字段访问全部失效。
     // 同步策略已固定为「以远程为准」，不再由前端传参。
-    return unwrap(await api.post('/api/bundled/sync', {
+    return unwrap(await api.post('/api/v1/bundled/sync', {
       subdir: params.subdir || 'all',
     }));
   },
@@ -332,21 +332,21 @@ export const bundledApi = {
    * 查询同步状态
    */
   async getStatus(subdir: Subdir = 'all'): Promise<BundledStatus> {
-    return unwrap(await api.get('/api/bundled/status', { params: { subdir } }));
+    return unwrap(await api.get('/api/v1/bundled/status', { params: { subdir } }));
   },
 
   /**
    * 获取配置
    */
   async getConfig(): Promise<BundledConfig> {
-    return unwrap(await api.get('/api/bundled/config'));
+    return unwrap(await api.get('/api/v1/bundled/config'));
   },
 
   /**
    * 更新配置
    */
   async updateConfig(config: Partial<BundledConfig>): Promise<BundledConfig> {
-    return unwrap(await api.put('/api/bundled/config', config));
+    return unwrap(await api.put('/api/v1/bundled/config', config));
   },
 
   // ---------------------------------------------------------------------------
@@ -371,7 +371,7 @@ export const bundledApi = {
     keyword?: string;
   }): Promise<BundledSkillsResponse> {
     // axios 会自动忽略 undefined 字段，所以前端只下发「显式传了」的过滤参数
-    return unwrap(await api.get('/api/bundled/skills', { params }));
+    return unwrap(await api.get('/api/v1/bundled/skills', { params }));
   },
 
   /**
@@ -389,7 +389,7 @@ export const bundledApi = {
     /** 来源关键字筛选：不区分大小写匹配 name / display_name / description */
     keyword?: string;
   }): Promise<BundledSkillSourcesResponse> {
-    return unwrap(await api.get('/api/bundled/skill-sources', { params }));
+    return unwrap(await api.get('/api/v1/bundled/skill-sources', { params }));
   },
 
   /**
@@ -397,7 +397,7 @@ export const bundledApi = {
    * 用于详情 Drawer 展示
    */
   async getSkillContent(skillName: string): Promise<BundledSkillContentResponse> {
-    return unwrap(await api.get(`/api/bundled/skills/${encodeURIComponent(skillName)}/content`));
+    return unwrap(await api.get(`/api/v1/bundled/skills/${encodeURIComponent(skillName)}/content`));
   },
 
   /**
@@ -406,7 +406,7 @@ export const bundledApi = {
    */
   async getSkillFileContent(skillName: string, path: string): Promise<{ path: string; content: string }> {
     // path 作为 query 参数透传，axios 会自动 encode；skillName 含 `/` 需手动 encode 进路径段
-    return unwrap(await api.get(`/api/bundled/skills/${encodeURIComponent(skillName)}/file`, {
+    return unwrap(await api.get(`/api/v1/bundled/skills/${encodeURIComponent(skillName)}/file`, {
       params: { path },
     }));
   },
@@ -416,7 +416,7 @@ export const bundledApi = {
    * 将 bundled/skills/{skill_name} 复制到目标执行器的 skills 目录
    */
   async installSkill(skillName: string, executor: string): Promise<InstallSkillResponse> {
-    return unwrap(await api.post('/api/bundled/skills/install', {
+    return unwrap(await api.post('/api/v1/bundled/skills/install', {
       skill_name: skillName,
       executor,
     }));

--- a/frontend/src/components/settings/experts/ContributeButton.tsx
+++ b/frontend/src/components/settings/experts/ContributeButton.tsx
@@ -1,0 +1,148 @@
+// 专家「分享到官方仓库」按钮：OAuth 登录引导 + 预览确认 + 提交 Issue。
+// 独立「专家」页与「专家模板」Tab 复用，保证两条入口交互一致。
+
+import { useState } from 'react';
+import { App, Button, Input, Modal, Space, Tag, Tooltip } from 'antd';
+import { ShareAltOutlined } from '@ant-design/icons';
+import type { ExpertMetadata } from '@/types/expert';
+import {
+  getContributionAuthStatus,
+  getContributionOAuthUrl,
+  previewExpertIssue,
+  submitExpertIssue,
+  type ContributionIssueDraft,
+} from '@/utils/database/contribution';
+
+/**
+ * 分享按钮组件。
+ *
+ * 交互流程：
+ * 1. 点击后查询登录态：未配置凭据 → 提示；未登录 → 跳 GitCode 授权页；已登录 → 拉预览草稿。
+ * 2. 弹出预览 Modal：标题/正文可编辑，文件清单只读；确认后提交并展示 Issue 链接。
+ */
+export function ContributeButton({
+  expert,
+  size = 'middle',
+}: {
+  expert: ExpertMetadata;
+  size?: 'small' | 'middle';
+}) {
+  const { message } = App.useApp();
+  const [loading, setLoading] = useState(false);
+  const [draft, setDraft] = useState<ContributionIssueDraft | null>(null);
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  // 点击分享：未配置提示、未登录跳授权、已登录拉预览。
+  const handleClick = async () => {
+    setLoading(true);
+    try {
+      const status = await getContributionAuthStatus();
+      if (!status.enabled) {
+        message.warning('贡献功能未配置（缺少 OAuth 凭据）');
+        return;
+      }
+      if (!status.logged_in) {
+        const { url } = await getContributionOAuthUrl();
+        // 跳 GitCode 授权页；授权成功后后端 302 回专家页，用户再点一次分享即可进入预览。
+        window.location.href = url;
+        return;
+      }
+      const d = await previewExpertIssue(expert.name);
+      setDraft(d);
+      setTitle(d.title);
+      setBody(d.body);
+    } catch (err: any) {
+      message.error('发起分享失败: ' + (err?.message || String(err)));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 确认提交 Issue。
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      const result = await submitExpertIssue(expert.name, { title, body });
+      setDraft(null);
+      message.success({
+        content: (
+          <span>
+            已提交为 Issue #{result.issue_number}，{' '}
+            <a href={result.issue_url} target="_blank" rel="noreferrer">点击查看</a>
+          </span>
+        ),
+        duration: 10,
+      });
+    } catch (err: any) {
+      message.error('提交失败: ' + (err?.message || String(err)));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Tooltip title="分享到官方仓库">
+        <Button
+          type="text"
+          size={size}
+          icon={<ShareAltOutlined />}
+          onClick={handleClick}
+          loading={loading}
+          style={{ color: 'var(--color-text-secondary)' }}
+        >
+          分享
+        </Button>
+      </Tooltip>
+
+      <Modal
+        open={draft !== null}
+        onCancel={() => setDraft(null)}
+        onOk={handleSubmit}
+        okText="提交"
+        cancelText="取消"
+        confirmLoading={submitting}
+        title="提交到官方仓库"
+        width={680}
+        centered
+      >
+        {draft && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 4 }}>
+                Issue 标题
+              </div>
+              <Input value={title} onChange={(e) => setTitle(e.target.value)} />
+            </div>
+            <div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 4 }}>
+                将打包以下文件（{draft.files.length} 个）
+              </div>
+              <Space wrap size={4}>
+                {draft.files.map((f) => (
+                  <Tag key={f} style={{ fontSize: 11 }}>{f}</Tag>
+                ))}
+              </Space>
+            </div>
+            <div>
+              <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 4 }}>
+                Issue 正文（可编辑）
+              </div>
+              <Input.TextArea
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                autoSize={{ minRows: 8, maxRows: 20 }}
+                style={{ fontSize: 12, fontFamily: 'monospace' }}
+              />
+            </div>
+            <div style={{ fontSize: 12, color: 'var(--color-text-secondary)' }}>
+              提交后由官方维护者审核，合入后其他用户可通过同步获取。
+            </div>
+          </div>
+        )}
+      </Modal>
+    </>
+  );
+}

--- a/frontend/src/components/settings/experts/ContributeButton.tsx
+++ b/frontend/src/components/settings/experts/ContributeButton.tsx
@@ -1,4 +1,4 @@
-// 专家「分享到官方仓库」按钮：OAuth 登录引导 + 预览确认 + 提交 Issue。
+// 专家「分享到官方仓库」按钮：OAuth 登录引导 + 预览确认 + 提交 PR。
 // 独立「专家」页与「专家模板」Tab 复用，保证两条入口交互一致。
 
 import { useState } from 'react';
@@ -9,7 +9,7 @@ import {
   getContributionAuthStatus,
   getContributionOAuthUrl,
   previewExpertIssue,
-  submitExpertIssue,
+  submitExpertPr,
   type ContributionIssueDraft,
 } from '@/utils/database/contribution';
 
@@ -18,7 +18,7 @@ import {
  *
  * 交互流程：
  * 1. 点击后查询登录态：未配置凭据 → 提示；未登录 → 跳 GitCode 授权页；已登录 → 拉预览草稿。
- * 2. 弹出预览 Modal：标题/正文可编辑，文件清单只读；确认后提交并展示 Issue 链接。
+ * 2. 弹出预览 Modal：标题/描述可编辑，文件清单只读；确认后提交并展示 PR 链接。
  */
 export function ContributeButton({
   expert,
@@ -60,17 +60,17 @@ export function ContributeButton({
     }
   };
 
-  // 确认提交 Issue。
+  // 确认提交 PR。
   const handleSubmit = async () => {
     setSubmitting(true);
     try {
-      const result = await submitExpertIssue(expert.name, { title, body });
+      const result = await submitExpertPr(expert.name, { title, body });
       setDraft(null);
       message.success({
         content: (
           <span>
-            已提交为 Issue #{result.issue_number}，{' '}
-            <a href={result.issue_url} target="_blank" rel="noreferrer">点击查看</a>
+            已提交 PR #{result.pr_number}，{' '}
+            <a href={result.pr_url} target="_blank" rel="noreferrer">点击查看</a>
           </span>
         ),
         duration: 10,
@@ -104,7 +104,7 @@ export function ContributeButton({
         okText="提交"
         cancelText="取消"
         confirmLoading={submitting}
-        title="提交到官方仓库"
+        title="提交 PR"
         width={680}
         centered
       >
@@ -112,7 +112,7 @@ export function ContributeButton({
           <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
             <div>
               <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 4 }}>
-                Issue 标题
+                PR 标题
               </div>
               <Input value={title} onChange={(e) => setTitle(e.target.value)} />
             </div>
@@ -128,7 +128,7 @@ export function ContributeButton({
             </div>
             <div>
               <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginBottom: 4 }}>
-                Issue 正文（可编辑）
+                PR 描述（可编辑）
               </div>
               <Input.TextArea
                 value={body}

--- a/frontend/src/components/settings/experts/ExpertDetailModal.tsx
+++ b/frontend/src/components/settings/experts/ExpertDetailModal.tsx
@@ -24,6 +24,7 @@ import {
   getMemberAvatarUrl,
   getCategoryName,
 } from '@/types/expert';
+import { ContributeButton } from './ContributeButton';
 
 const { Paragraph, Text } = Typography;
 
@@ -213,6 +214,7 @@ export function ExpertDetailModal({
               flexShrink: 0,
               alignSelf: isMobile ? 'flex-end' : 'auto',
             }}>
+              <ContributeButton expert={expert} />
               <Tooltip title="导出为 zip 包">
                 <Button
                   type="text"

--- a/frontend/src/components/settings/templates/ExpertsTemplatesTab.tsx
+++ b/frontend/src/components/settings/templates/ExpertsTemplatesTab.tsx
@@ -26,6 +26,7 @@ import {
 } from '@ant-design/icons';
 import * as db from '@/utils/database';
 import type { ExpertMetadata } from '@/types/expert';
+import { ContributeButton } from '@/components/settings/experts/ContributeButton';
 import {
   getExpertDisplayName,
   getExpertDescription,
@@ -154,7 +155,7 @@ export function ExpertsTemplatesTab() {
               {
                 title: '操作',
                 key: 'actions',
-                width: 200,
+                width: 240,
                 render: (_, record: ExpertMetadata) => (
                   <Space>
                     <Button
@@ -169,6 +170,7 @@ export function ExpertsTemplatesTab() {
                       icon={<EditOutlined />}
                       onClick={() => handleOpenEdit(record)}
                     />
+                    <ContributeButton expert={record} size="small" />
                     <Popconfirm
                       title="确定删除此专家？"
                       onConfirm={() => handleDelete(record.name)}

--- a/frontend/src/components/skills/SkillMarketplace.tsx
+++ b/frontend/src/components/skills/SkillMarketplace.tsx
@@ -1203,7 +1203,7 @@ function formatStars(n: number): string {
 // ─────────────────────────────────────────────────────────────────────────────
 // 文件浏览：复用 SkillFileBrowserModal。
 // bundled 的 content 接口返回 SKILL.md 文本 + 全量文件元信息（path+size）；
-// 单文件内容由 GET /api/bundled/skills/{name}/file 按需读取，
+// 单文件内容由 GET /api/v1/bundled/skills/{name}/file 按需读取，
 // 所以 loadContent 对 SKILL.md 走缓存，其他文件调 getSkillFileContent。
 // ─────────────────────────────────────────────────────────────────────────────
 function toSkillFileInfos(files: BundledSkillFile[]): SkillFileInfo[] {

--- a/frontend/src/components/todo-drawer/ExpertSkillSelector.tsx
+++ b/frontend/src/components/todo-drawer/ExpertSkillSelector.tsx
@@ -1,7 +1,7 @@
 // ─── 专家技能选择器 ──────────────────────────────────────────
 //
 // 在 TodoDrawer 中选中专家后，展示该专家关联的技能列表。
-// 数据来源：后端 /api/experts/:name/skills 接口，返回 SkillMetadata[]。
+// 数据来源：后端 /api/v1/experts/:name/skills 接口，返回 SkillMetadata[]。
 // 与执行器版的 SkillSelector 不同，这里聚焦"专家绑定了哪些技能"，
 // 由组件内部自行管理加载状态与折叠状态，父组件只需传入 expertName。
 //

--- a/frontend/src/help/pages/experts-create.md
+++ b/frontend/src/help/pages/experts-create.md
@@ -10,7 +10,7 @@ flowchart LR
   User["点击 AI 创建专家"] --> ActionButton["ActionButton Drawer"]
   ActionButton -->|"填写 description 模板"| Execute["执行 AI 生成"]
   Execute -->|"completedView"| ExpertCreateCompleted["ExpertCreateCompleted"]
-  ExpertCreateCompleted -->|"handleCreate<br>db.createExpert"| API["POST /api/v1/experts/create"]
+  ExpertCreateCompleted -->|"handleCreate<br>db.createExpert"| API["POST /api/v1/experts"]
   API --> onCreated["onCreated → loadExperts"]
 ```
 
@@ -63,6 +63,6 @@ stateDiagram-v2
 
 ## 开发指导
 - **前端入口**：`frontend/src/components/settings/ExpertCreateModal.tsx` 的 `ExpertCreateModal` 组件，复用 `ActionButton` 交互流程；完成态由 `ExpertCreateCompleted.tsx` 渲染
-- **后端入口**：`backend/src/handlers/experts.rs` 处理 `POST /api/v1/experts/create`，写入 `plugin.json` 和 `agent.md`
+- **后端入口**：`backend/src/handlers/experts.rs` 处理 `POST /api/v1/experts`，写入 `plugin.json` 和 `agent.md`
 - **注意**：`parseResult` 用正则 `` ```json `` 和 `` ```markdown `` 提取 AI 输出块，若任一缺失则 `raw=true` 展示原始文本供用户手动修正
 - **扩展**：新增 AI 模板字段时改 `EXPERT_CREATE_PROMPT` 和 `ExpertCreateCompleted` 的解析逻辑

--- a/frontend/src/help/pages/loop-list-open-config.md
+++ b/frontend/src/help/pages/loop-list-open-config.md
@@ -10,7 +10,7 @@
 flowchart LR
   U[用户点击配置按钮] --> OC["handleOpenLoopConfig"]
   OC --> GD["getProjectDirectories()"]
-  GD --> API["GET /api/project-directories"]
+  GD --> API["GET /api/v1/project-directories"]
   API --> H1[project_directories handler]
   H1 --> DB[(project_directories 表)]
   GD --> FIND["dirs.find id === workspaceId"]
@@ -28,7 +28,7 @@ flowchart TD
   Header["LoopListHeader Button onClick"] -->|"onOpenConfig"| LLP["LoopListPage handleOpenLoopConfig"]
   LLP -->|"useLoopConfig"| CFG["useLoopConfig handleOpenLoopConfig"]
   CFG -->|"getProjectDirectories"| DBT["database/todos getProjectDirectories"]
-  DBT -->|"unwrap"| API["api.get /api/project-directories"]
+  DBT -->|"unwrap"| API["api.get /api/v1/project-directories"]
   CFG -->|"setCurrentWorkspace + setLoopConfigOpen true"| ST["useLoopConfig state"]
   LLP -->|"loopConfigOpen && currentWorkspace"| WCP["WorkspaceLoopConfigPage workspace onBack"]
   WCP --> RTP["ReviewTemplatesPanel workspaceId"]
@@ -78,6 +78,6 @@ stateDiagram-v2
 ## 开发指导
 
 - **前端入口**：`frontend/src/components/loop-list/LoopListPageParts.tsx` 的 `useLoopConfig` hook（`handleOpenLoopConfig`/`handleCloseLoopConfig`），渲染分支在 `frontend/src/components/loop-list/index.tsx` 的 `LoopListPage`（`if (loopConfigOpen && currentWorkspace) return <WorkspaceLoopConfigPage ...>`）。配置页本体在 `frontend/src/components/settings/workspace/WorkspaceLoopConfigPage.tsx`。
-- **后端入口**：仅 `getProjectDirectories`（`GET /api/project-directories`）取工作空间目录，环路配置页本体是前端 `ReviewTemplatesPanel`（评审模板管理），不直接落环路后端接口。
+- **后端入口**：仅 `getProjectDirectories`（`GET /api/v1/project-directories`）取工作空间目录，环路配置页本体是前端 `ReviewTemplatesPanel`（评审模板管理），不直接落环路后端接口。
 - **注意**：`handleOpenLoopConfig` 在 `workspaceId == null` 时直接 return；工作空间切换时 `LoopListPage` 的 `useEffect([workspaceId, handleCloseLoopConfig])` 会自动关闭配置页回列表态；`handleCloseLoopConfig` 同步清 `currentWorkspace` 避免残留引用。
 - **扩展**：要在配置页加环路相关设置，在 `WorkspaceLoopConfigPage` 内新增子面板，需要工作空间上下文时复用 `workspace.id`；`ReviewTemplatesPanel` 与环路「评审模板」概念在 044 后已解耦，保留是为了给工艺门禁制评审提供模板管理入口。

--- a/frontend/src/help/pages/settings-skills.md
+++ b/frontend/src/help/pages/settings-skills.md
@@ -16,8 +16,8 @@ flowchart LR
   SkillsPanel -->|"activeView=version-update"| SkillVersionUpdate["SkillVersionUpdate"]
   SkillsOverview -->|"db.getSkillsList"| API1["GET /api/v1/skills"]
   SkillsOverview -->|"db.syncSkill"| API2["POST /api/v1/skills/sync"]
-  SkillMarketplace -->|"bundledApi.getSkills"| API3["GET /api/bundled/skills"]
-  SkillMarketplace -->|"bundledApi.installSkill"| API4["POST /api/bundled/skills/install"]
+  SkillMarketplace -->|"bundledApi.getSkills"| API3["GET /api/v1/bundled/skills"]
+  SkillMarketplace -->|"bundledApi.installSkill"| API4["POST /api/v1/bundled/skills/install"]
   SkillVersionUpdate -->|"db.getSkillVersionUpdates"| API5["GET /api/v1/skills/version-update"]
   SkillVersionUpdate -->|"db.getSkillsComparison"| API6["GET /api/v1/skills/compare"]
   SkillVersionUpdate -->|"db.syncSkill"| API2

--- a/frontend/src/help/pages/settings-tab-templates.md
+++ b/frontend/src/help/pages/settings-tab-templates.md
@@ -7,10 +7,10 @@
 
 ```mermaid
 flowchart LR
-  TemplatesPanel["TemplatesPanel.tsx"] -->|"bundledApi.getStatus"| API1["GET /api/bundled/status?subdir"]
-  TemplatesPanel -->|"bundledApi.sync"| API2["POST /api/bundled/sync"]
-  TemplatesPanel -->|"bundledApi.getConfig"| API3["GET /api/bundled/config"]
-  TemplatesPanel -->|"bundledApi.updateConfig"| API4["PUT /api/bundled/config"]
+  TemplatesPanel["TemplatesPanel.tsx"] -->|"bundledApi.getStatus"| API1["GET /api/v1/bundled/status?subdir"]
+  TemplatesPanel -->|"bundledApi.sync"| API2["POST /api/v1/bundled/sync"]
+  TemplatesPanel -->|"bundledApi.getConfig"| API3["GET /api/v1/bundled/config"]
+  TemplatesPanel -->|"bundledApi.updateConfig"| API4["PUT /api/v1/bundled/config"]
   TemplatesPanel --> ExpertsTemplatesTab["templates/ExpertsTemplatesTab"]
   TemplatesPanel --> TodoTemplatesTab["templates/TodoTemplatesTab"]
   TemplatesPanel --> SkillTemplatesTab["templates/SkillTemplatesTab"]
@@ -85,6 +85,6 @@ stateDiagram-v2
 
 ## 开发指导
 - **前端入口**：`frontend/src/components/settings/TemplatesPanel.tsx` 的 `TemplatesPanel` 组件；内部 Tabs 分专家/事项/技能/工艺模板，各子 Tab 由 `templates/` 下独立组件承载
-- **后端入口**：`backend/src/handlers/bundled.rs` 处理 `/api/bundled/*` 系列接口
+- **后端入口**：`backend/src/handlers/bundled.rs` 处理 `/api/v1/bundled/*` 系列接口
 - **注意**：同步前需检查 `git_available`，未安装 git 时展示 `InstallGitButton`；`handleSync` 的结果用 `SyncResult.is_first_clone` 区分首次克隆与后续 fetch
 - **扩展**：新增模板子目录类型时 `Subdir` union 追加值，`TemplatesPanel` 内部 Tabs 新增对应子 Tab 组件

--- a/frontend/src/help/pages/skills-marketplace.md
+++ b/frontend/src/help/pages/skills-marketplace.md
@@ -7,10 +7,10 @@
 
 ```mermaid
 flowchart LR
-  SkillMarketplace["SkillMarketplace.tsx"] -->|"loadSkills<br>bundledApi.getSkills"| API1["GET /api/bundled/skills?page&page_size&source&keyword"]
-  SkillMarketplace -->|"loadSources<br>bundledApi.getSkillSources"| API2["GET /api/bundled/skill-sources?page&page_size&keyword"]
-  SkillMarketplace -->|"handleCardClick<br>bundledApi.getSkillContent"| API3["GET /api/bundled/skills/{name}/content"]
-  SkillMarketplace -->|"handleInstall<br>bundledApi.installSkill"| API4["POST /api/bundled/skills/install"]
+  SkillMarketplace["SkillMarketplace.tsx"] -->|"loadSkills<br>bundledApi.getSkills"| API1["GET /api/v1/bundled/skills?page&page_size&source&keyword"]
+  SkillMarketplace -->|"loadSources<br>bundledApi.getSkillSources"| API2["GET /api/v1/bundled/skill-sources?page&page_size&keyword"]
+  SkillMarketplace -->|"handleCardClick<br>bundledApi.getSkillContent"| API3["GET /api/v1/bundled/skills/{name}/content"]
+  SkillMarketplace -->|"handleInstall<br>bundledApi.installSkill"| API4["POST /api/v1/bundled/skills/install"]
   SkillMarketplace -->|"loadInstalled<br>db.getSkillsList"| API5["GET /api/v1/skills"]
 ```
 
@@ -81,6 +81,6 @@ stateDiagram-v2
 
 ## 开发指导
 - **前端入口**：`frontend/src/components/skills/SkillMarketplace.tsx` 的 `SkillMarketplace` 组件
-- **后端入口**：`backend/src/handlers/bundled.rs` 处理 `/api/bundled/skills` 系列接口
+- **后端入口**：`backend/src/handlers/bundled.rs` 处理 `/api/v1/bundled/skills` 系列接口
 - **注意**：`loadSkills` 与 `loadSources` 共用 `reqGenRef` 做竞态守卫，快速翻页/切换视图时过期请求静默丢弃；`handleCardClick` 用独立的 `detailReqIdRef` 防止详情内容覆盖
 - **扩展**：新增来源只需在 `~/.ntd/bundled/skills/` 下放置来源目录及 `metadata.json`，后端扫描即自动识别；前端 `ALL_SKILLS_PAGE_SIZE` 控制每页条数（默认 30）

--- a/frontend/src/types/expert.ts
+++ b/frontend/src/types/expert.ts
@@ -1,7 +1,7 @@
 // ─── 专家系统类型定义 ────────────────────────────────────────
 //
 // 兼容 WorkBuddy 的 plugin.json 格式，支持单个专家和专家团队两种类型。
-// 数据来源：后端 /api/experts 接口，从 ~/.ntd/experts/ 目录加载。
+// 数据来源：后端 /api/v1/experts 接口，从 ~/.ntd/experts/ 目录加载。
 
 /** 专家类型：单个专家 或 专家团队 */
 export type ExpertType = 'agent' | 'team';

--- a/frontend/src/utils/database/contribution.ts
+++ b/frontend/src/utils/database/contribution.ts
@@ -23,8 +23,8 @@ export interface ContributionIssueDraft {
 
 /** 提交 Issue 结果 */
 export interface ContributionIssueResult {
-  /** Issue 编号 */
-  issue_number: number;
+  /** Issue 编号（GitCode 编号为字符串，如 "I5YJX2"） */
+  issue_number: string;
   /** Issue 网页链接 */
   issue_url: string;
   /** Issue 标题 */

--- a/frontend/src/utils/database/contribution.ts
+++ b/frontend/src/utils/database/contribution.ts
@@ -21,13 +21,13 @@ export interface ContributionIssueDraft {
   files: string[];
 }
 
-/** 提交 Issue 结果 */
-export interface ContributionIssueResult {
-  /** Issue 编号（GitCode 编号为字符串，如 "I5YJX2"） */
-  issue_number: string;
-  /** Issue 网页链接 */
-  issue_url: string;
-  /** Issue 标题 */
+/** 提交 PR 结果 */
+export interface ContributionPrResult {
+  /** PR 编号 */
+  pr_number: string;
+  /** PR 网页链接 */
+  pr_url: string;
+  /** PR 标题 */
   title: string;
 }
 
@@ -46,19 +46,19 @@ export async function getContributionOAuthUrl(): Promise<{ url: string }> {
 }
 
 /**
- * 组装某专家的贡献 Issue 草稿（不提交），供预览框展示。
+ * 组装某专家的贡献 PR 草稿（不提交），供预览框展示。
  */
 export async function previewExpertIssue(name: string): Promise<ContributionIssueDraft> {
   return unwrap(await api.post(`/api/v1/contribution/experts/${encodeURIComponent(name)}/preview`));
 }
 
 /**
- * 提交某专家的贡献 Issue。
+ * 提交某专家的贡献 PR。
  */
-export async function submitExpertIssue(
+export async function submitExpertPr(
   name: string,
   data: { title: string; body: string },
-): Promise<ContributionIssueResult> {
+): Promise<ContributionPrResult> {
   return unwrap(await api.post(`/api/v1/contribution/experts/${encodeURIComponent(name)}/submit`, data));
 }
 

--- a/frontend/src/utils/database/contribution.ts
+++ b/frontend/src/utils/database/contribution.ts
@@ -1,0 +1,70 @@
+// 专家贡献 API：OAuth 登录态、预览、提交 Issue。
+// 对应后端 /api/v1/contribution/* 接口。
+
+import { api, unwrap } from './client';
+
+/** 贡献功能登录态 */
+export interface ContributionAuthStatus {
+  /** 功能是否启用（后端凭据是否已注入） */
+  enabled: boolean;
+  /** 是否已登录（本地已存在 token） */
+  logged_in: boolean;
+}
+
+/** 贡献 Issue 草稿（预览用） */
+export interface ContributionIssueDraft {
+  /** Issue 标题 */
+  title: string;
+  /** Issue Markdown 正文 */
+  body: string;
+  /** 已打包的文件相对路径清单 */
+  files: string[];
+}
+
+/** 提交 Issue 结果 */
+export interface ContributionIssueResult {
+  /** Issue 编号 */
+  issue_number: number;
+  /** Issue 网页链接 */
+  issue_url: string;
+  /** Issue 标题 */
+  title: string;
+}
+
+/**
+ * 查询登录态与功能开关。
+ */
+export async function getContributionAuthStatus(): Promise<ContributionAuthStatus> {
+  return unwrap(await api.get('/api/v1/contribution/auth/status'));
+}
+
+/**
+ * 获取 GitCode OAuth 授权跳转 URL。
+ */
+export async function getContributionOAuthUrl(): Promise<{ url: string }> {
+  return unwrap(await api.get('/api/v1/contribution/oauth/url'));
+}
+
+/**
+ * 组装某专家的贡献 Issue 草稿（不提交），供预览框展示。
+ */
+export async function previewExpertIssue(name: string): Promise<ContributionIssueDraft> {
+  return unwrap(await api.post(`/api/v1/contribution/experts/${encodeURIComponent(name)}/preview`));
+}
+
+/**
+ * 提交某专家的贡献 Issue。
+ */
+export async function submitExpertIssue(
+  name: string,
+  data: { title: string; body: string },
+): Promise<ContributionIssueResult> {
+  return unwrap(await api.post(`/api/v1/contribution/experts/${encodeURIComponent(name)}/submit`, data));
+}
+
+/**
+ * 清除本地登录态（退出 GitCode 登录）。
+ */
+export async function logoutContribution(): Promise<void> {
+  await api.post('/api/v1/contribution/logout');
+}

--- a/frontend/src/utils/database/experts.ts
+++ b/frontend/src/utils/database/experts.ts
@@ -117,7 +117,9 @@ export async function deleteExpert(name: string): Promise<void> {
  * 后端会自动创建目录结构并加载到索引中。
  */
 export async function createExpertFromAi(pluginJson: string, agentMd: string): Promise<void> {
-  await api.post('/api/v1/experts/create', {
+  // 创建走 POST 集合路径 /api/v1/experts（REST 语义，见 docs/design/api-routing-redesign.md）；
+  // /api/v1/experts/create 已随路由重构移除，POST 会命中 {name} 路由（name="create"）导致 405。
+  await api.post('/api/v1/experts', {
     plugin_json: pluginJson,
     agent_md: agentMd,
   });

--- a/frontend/src/utils/database/index.ts
+++ b/frontend/src/utils/database/index.ts
@@ -8,4 +8,5 @@ export * from './sessions';
 export * from './usage_stats';
 export * from './loops';
 export * from './experts';
+export * from './contribution';
 export * from './quickButtons';

--- a/frontend/tests/026-expert-contribution.spec.ts
+++ b/frontend/tests/026-expert-contribution.spec.ts
@@ -1,0 +1,27 @@
+// 专家贡献功能 UI 验证（需求 026）。
+// 覆盖两个入口的「分享」按钮渲染，以及未配置 OAuth 凭据时的降级提示。
+// 说明：OAuth 登录与创建 Issue 依赖真实 GitCode 账号，无法自动化；
+// 本用例只验证 UI 渲染与「未配置凭据」降级路径（本地未注入凭据，enabled=false）。
+
+import { test, expect } from '@playwright/test';
+
+test('专家详情 Modal 展示分享按钮，未配置凭据时点击给出提示', async ({ page }) => {
+  // 进入专家页。
+  await page.goto('/#/experts');
+
+  // 专家卡片用 role="button" 渲染；等待至少一张卡片可见。
+  const firstCard = page.locator('div[role="button"]').first();
+  await firstCard.waitFor({ state: 'visible', timeout: 15000 });
+
+  // 点击第一张专家卡片，打开详情 Modal。
+  await firstCard.click();
+
+  // 详情 Modal 的操作区应出现「分享」按钮。
+  const shareButton = page.getByRole('button', { name: '分享' });
+  await shareButton.waitFor({ state: 'visible', timeout: 5000 });
+  await expect(shareButton).toBeVisible();
+
+  // 本地未注入凭据（enabled=false），点击分享应提示「未配置」，而非跳转授权。
+  await shareButton.click();
+  await expect(page.getByText('贡献功能未配置')).toBeVisible();
+});


### PR DESCRIPTION
## 背景

ntd 的专家/模板资源目前是单向同步（远端 GitCode 仓库 → 本地），用户本地修改/新建的专家无法贡献回官方仓库。本 PR 为「专家」试点一条**最小化操作**的贡献通道：OAuth 登录 GitCode → 预览 → 一键提交为官方仓库 Issue，由维护者人工合入后复用现有单向同步分发。

## 实现了什么

- **后端 `contribution` 模块**：OAuth（授权 URL / 回调换 token / refresh 刷新 / `state` 防 CSRF）+ 预览 + 创建 Issue，6 个路由挂 `/api/v1/contribution/*`
- **凭据方案**：`client_id`/`client_secret` 编译期环境变量注入（`NTD_CONTRIB_CLIENT_ID`/`NTD_CONTRIB_CLIENT_SECRET`），**不写 config.yaml**；`owner`/`repo` 复用 `BundledSourceConfig.url` 解析；平台地址常量
- **前端**：`ContributeButton`（预览确认 Modal，标题/正文可编辑 + 文件清单只读）+ 双入口（独立「专家」页详情 Modal + 「专家模板」Tab 操作列）

## 与需求对应

对应 `docs/requirements/026-专家贡献-需求.md`，设计见 `docs/design/026-专家贡献-设计.md`。

## 测试与验证

- 后端：`cargo clippy --all-targets -- -D warnings` 零告警；`cargo test --lib contribution` 17 单测通过
- 前端：`npx tsc --noEmit` 零错误；`npm run build` 成功
- Playwright：`tests/026-expert-contribution.spec.ts`（分享按钮渲染 + 未配置凭据降级提示）
- 安全：`security_review` 无 CRITICAL/HIGH，2 medium + 2 low 已全部修复

## 已知限制 / 待改进

- GitCode「创建 Issue」端点存在文档歧义（`/repos/:owner/issues` vs `/repos/:owner/:repo/issues`），实现取后者，需真实验证；`labels` 格式待确认
- OAuth 回调后用户需再点一次分享（未保存待分享上下文），后续可优化为自动弹预览

## 上线前置（需人工）

1. GitCode 注册 OAuth 应用，配置 `redirect_uri` 指向本机回调；`client_id`/`client_secret` 进 GitHub Actions Secrets
2. `weibaohui/ntd-resource` 仓库预建 `expert-contribution` label
3. 真实验证创建 Issue 端点与 `labels` 字段格式
