### PR TITLE
refactor(adr005-H5): ProfilesPanel 11 处裸 fetch 收敛为 providers Facade

### DIFF
--- a/docs/design/102-ProfilesPanel-Facade收敛-设计.md
+++ b/docs/design/102-ProfilesPanel-Facade收敛-设计.md
@@ -33,7 +33,9 @@
 | `applyProviderToExecutors` | POST `/api/v1/providers/{name}/apply` | `name, executorModels` | `ApplyResult` | |
 
 实现要点：
-- 除 `exportProviders` 外，统一 `return unwrap(await api.<method>(url, [body]))`，与 `experts.ts` 一致。
+- 有返回值的函数统一 `return unwrap(await api.<method>(url, [body]))`，与 `experts.ts` 一致。
+- `createProvider`/`updateProvider`/`deleteProvider` 返回 `void`，只 `await api.<method>(...)` 不走 `unwrap`——`client.ts` 响应拦截器已对 `code!==0`/非 2xx 自动 reject，§5 的假成功修复由此成立，无需再解包 data（与 `experts.ts` 的 `deleteExpert` 等 void 函数一致）。
+- preview/apply 的请求体用 providers.ts 内部别名 `type ExecutorModels = Record<string, string>`（执行器→模型名映射），对应后端 `executor_models` 字段。
 - `exportProviders`：`api.get(BASE + '/export', { responseType: 'text' })`。`client.ts` 拦截器对非 object 响应（字符串）原样放行，故不会误走 `code!==0` 分支；返回 `res.data`（YAML 文本）。
 
 ## 4. 类型归位
@@ -41,11 +43,12 @@
 新建 `frontend/src/types/provider.ts`（仿 `types/expert.ts`），把现内联在 ProfilesPanel 的类型迁出，并补齐后端实际返回的字段：
 
 ```ts
+export type ProviderProtocol = 'openai' | 'anthropic';
 export interface ProviderModel { name: string; display_name?: string; supports_1m_context?: boolean; }
-export interface ProviderSummary { name: string; display_name: string; base_url: string; protocol: 'openai'|'anthropic'; model_count: number; }
-export interface ProviderDetail { name: string; display_name: string; api_key: string; base_url: string; protocol: 'openai'|'anthropic'; models: ProviderModel[]; }
+export interface ProviderSummary { name: string; display_name: string; base_url: string; protocol: ProviderProtocol; model_count: number; }
+export interface ProviderDetail { name: string; display_name: string; api_key: string; base_url: string; protocol: ProviderProtocol; models: ProviderModel[]; }
 export interface ExecutorConfigDef { name: string; display_name: string; config_path: string; has_generator: boolean; }
-export interface ProviderInput { name?: string; display_name: string; api_key: string; base_url: string; protocol: 'openai'|'anthropic'; models: ProviderModel[]; }
+export interface ProviderInput { name?: string; display_name: string; api_key: string; base_url: string; protocol: ProviderProtocol; models: ProviderModel[]; }
 export interface PreviewEntry { executor: string; model: string; path: string; content: string; }
 export interface ApplyResult { applied: string[]; errors: string[]; }
 export interface ImportResult { imported: string[]; errors: string[]; }
@@ -92,7 +95,7 @@ Facade 与组件都从 `@/types/provider` 导入（前端强制 `@/`）。
 - [ ] `cd frontend && npm run build` 零新告警。
 - [ ] `grep -n 'fetch(' frontend/src/components/settings/ProfilesPanel.tsx` → 0 命中。
 - [ ] vitest 新增用例全过；既有用例不回归。
-- [ ] Playwright 冒烟：API Key 面板加载 / 新增 / 删除 / 导出 流程正常（证据发 PR 评论，不提交截图）。
+- [x] Playwright 冒烟：API Key 面板加载 / 新增→删除 / 导出 流程正常（`frontend/tests/verify_api_key_panel.spec.ts`，证据发 PR 评论，不提交截图）。
 
 ## 10. 文件清单
 
@@ -100,3 +103,4 @@ Facade 与组件都从 `@/types/provider` 导入（前端强制 `@/`）。
 - 新增 `frontend/src/types/provider.ts`
 - 改 `frontend/src/utils/database/index.ts`（barrel `export * from './providers'`）
 - 改 `frontend/src/components/settings/ProfilesPanel.tsx`（删内联类型 + 11 处 fetch，改用 Facade；组件签名不变）
+- 新增 `frontend/tests/verify_api_key_panel.spec.ts`（Playwright 冒烟：加载 / 新增→删除 / 导出 三个用例）

--- a/docs/design/102-ProfilesPanel-Facade收敛-设计.md
+++ b/docs/design/102-ProfilesPanel-Facade收敛-设计.md
@@ -1,0 +1,102 @@
+# 102 - ProfilesPanel 直连 fetch 收敛为 providers Facade（ADR-005 / H5）
+
+> 关联：[ADR-005](../decisions/ADR-005-重构与设计模式改进-决策.md) H5。一个 H 项一个设计文档、一个 PR。
+
+## 1. 背景
+
+`frontend/src/components/settings/ProfilesPanel.tsx`（API Key 管理面板）有 **11 处裸 `fetch(PROVIDERS_API)`**，`PROVIDERS_API = '/api/v1/providers'`。它们完全旁路 `utils/database/client.ts` 的 axios 实例，后果：
+
+- **无重试**：`client.ts` 对 GET 网络错（无响应）做 3 次指数退避重试，裸 `fetch` 没有。
+- **无统一解包**：`client.ts` 的响应拦截器对 `{code,data,message}` 统一校验 `code!==0` 并抽取错误信息；裸 `fetch` 每处手写 `await r.json()` + 各自的 `if(!r.ok)` / `if(j.code!==0)`，风格不一。
+- **违反前端 13-禁止清单 #7**：「组件内直接使用 `fetch(url)`」。
+- **更严重——假成功**：`createProvider`/`updateProvider`/`deleteProvider`/`preview`/`apply` 这 5 处**既不检查 `r.ok` 也不检查 `j.code`**，HTTP/业务失败时仍 `message.success('已创建')`。用户以为成功，实际后端已拒绝。
+
+`utils/database/` 下已有 11 个同构 Facade（experts/skills/bots/sessions/…，模板见 `experts.ts`），**唯独缺 `providers.ts`**。本设计即补齐它。
+
+## 2. 目标
+
+新建 `frontend/src/utils/database/providers.ts` Facade（仿 `experts.ts`），把 11 处 fetch 收口为类型化函数；ProfilesPanel 仅消费 Facade，组件内 `fetch` 归零。**除一处修复（§5）外，行为逐条保持不变。**
+
+## 3. Facade API（`providers.ts`）
+
+| 函数 | 方法 + 路径 | 入参 | 返回 | 备注 |
+|---|---|---|---|---|
+| `listProviders` | GET `/api/v1/providers` | — | `ProviderSummary[]` | 后端只回 summary（无 api_key/models） |
+| `getSupportedExecutors` | GET `/api/v1/providers/supported-executors` | — | `ExecutorConfigDef[]` | |
+| `getProvider` | GET `/api/v1/providers/{name}` | `name` | `ProviderDetail` | `encodeURIComponent` |
+| `createProvider` | POST `/api/v1/providers` | `body: ProviderInput` | `void` | |
+| `updateProvider` | PUT `/api/v1/providers/{name}` | `name, body` | `void` | |
+| `deleteProvider` | DELETE `/api/v1/providers/{name}` | `name` | `void` | |
+| `exportProviders` | GET `/api/v1/providers/export` | — | `string`（YAML） | **不走 `unwrap`**：`responseType:'text'`，直接返回 `res.data` |
+| `importProviders` | POST `/api/v1/providers/import` | `yaml, strategy` | `{imported, errors}` | |
+| `previewProviderToExecutors` | POST `/api/v1/providers/{name}/preview` | `name, executorModels` | `PreviewEntry[]` | |
+| `applyProviderToExecutors` | POST `/api/v1/providers/{name}/apply` | `name, executorModels` | `ApplyResult` | |
+
+实现要点：
+- 除 `exportProviders` 外，统一 `return unwrap(await api.<method>(url, [body]))`，与 `experts.ts` 一致。
+- `exportProviders`：`api.get(BASE + '/export', { responseType: 'text' })`。`client.ts` 拦截器对非 object 响应（字符串）原样放行，故不会误走 `code!==0` 分支；返回 `res.data`（YAML 文本）。
+
+## 4. 类型归位
+
+新建 `frontend/src/types/provider.ts`（仿 `types/expert.ts`），把现内联在 ProfilesPanel 的类型迁出，并补齐后端实际返回的字段：
+
+```ts
+export interface ProviderModel { name: string; display_name?: string; supports_1m_context?: boolean; }
+export interface ProviderSummary { name: string; display_name: string; base_url: string; protocol: 'openai'|'anthropic'; model_count: number; }
+export interface ProviderDetail { name: string; display_name: string; api_key: string; base_url: string; protocol: 'openai'|'anthropic'; models: ProviderModel[]; }
+export interface ExecutorConfigDef { name: string; display_name: string; config_path: string; has_generator: boolean; }
+export interface ProviderInput { name?: string; display_name: string; api_key: string; base_url: string; protocol: 'openai'|'anthropic'; models: ProviderModel[]; }
+export interface PreviewEntry { executor: string; model: string; path: string; content: string; }
+export interface ApplyResult { applied: string[]; errors: string[]; }
+export interface ImportResult { imported: string[]; errors: string[]; }
+```
+
+Facade 与组件都从 `@/types/provider` 导入（前端强制 `@/`）。
+
+## 5. ⚠️ 唯一行为变更（修复，非回归）
+
+`createProvider`/`updateProvider`/`deleteProvider`/`previewProviderApply`/`applyProvider` 原先不校验响应，失败仍显示成功。走 Facade 后：
+
+- axios 对非 2xx 自动 reject；响应拦截器对 `code!==0` reject（携带后端 `message`）。
+- 拒绝进入组件**既有**的 `catch (err)` → `message.error('操作失败: ' + err.message)`。
+
+这正是 H5 列明的「无 unwrap」问题修复，符合 13-禁止清单 #6「空 catch / 吞错」。**不视为回归**——原行为是 bug。
+
+## 6. 行为不变式（除 §5 外逐条保持）
+
+- 端点、HTTP 方法、请求体、成功路径的数据提取逐条不变。
+- **N+1 保持**：`load()` 先 `listProviders()` 取 summary 列表，再对每个 `name` 并发 `getProvider()` 取 detail（后端 list 不含 api_key/models，组件需要它们做 `maskKey` 与模型 Tag 展示）。
+- 组件 UI 流程、loading/弹窗状态机、`message` 文案、`maskKey` 等纯函数不变。
+- 公开组件签名 `ProfilesPanel()` 零改动（无 props，调用方不受影响）。
+
+## 7. 错误处理统一（净收益）
+
+- 删除手写 `JSON.stringify(body)` + `headers: {'Content-Type':...}`（axios 默认）。
+- 删除手写 `if(!r.ok)` / `if(j.code!==0)`（拦截器 + `unwrap` 统一）。
+- 所有 GET 自动获得 3 次指数退避重试（`client.ts` 既有）。
+
+## 8. 测试（前端 11-测试规范，vitest）
+
+新增 `frontend/src/utils/database/providers.test.ts`，命名 `test_<函数>_<场景>`。`vi.mock('@/utils/database/client')` 注入假 `api`/`unwrap`，覆盖：
+
+- 每函数以正确 `method`/`URL`/`body` 调用（如 `test_getProvider_对name做encodeURIComponent`）。
+- 成功返回 `unwrap` 的结果（`test_listProviders_解包data数组`）。
+- `code!==0` 时抛错（`test_createProvider_后端拒绝时抛错不假成功`——覆盖 §5 修复）。
+- `exportProviders` 走 text 通路、不被 `unwrap`（`test_exportProviders_返回YAML文本不走unwrap`）。
+
+组件层不新增 vitest（组件渲染依赖 antd/主题，按既有约定以 Playwright 冒烟覆盖）。
+
+## 9. 验收清单
+
+- [ ] `cd frontend && npx tsc --noEmit` 零错误。
+- [ ] `cd frontend && npm run build` 零新告警。
+- [ ] `grep -n 'fetch(' frontend/src/components/settings/ProfilesPanel.tsx` → 0 命中。
+- [ ] vitest 新增用例全过；既有用例不回归。
+- [ ] Playwright 冒烟：API Key 面板加载 / 新增 / 删除 / 导出 流程正常（证据发 PR 评论，不提交截图）。
+
+## 10. 文件清单
+
+- 新增 `frontend/src/utils/database/providers.ts` + `providers.test.ts`
+- 新增 `frontend/src/types/provider.ts`
+- 改 `frontend/src/utils/database/index.ts`（barrel `export * from './providers'`）
+- 改 `frontend/src/components/settings/ProfilesPanel.tsx`（删内联类型 + 11 处 fetch，改用 Facade；组件签名不变）

--- a/frontend/src/components/settings/ProfilesPanel.tsx
+++ b/frontend/src/components/settings/ProfilesPanel.tsx
@@ -8,34 +8,21 @@ import { PlusOutlined, SwapOutlined, DeleteOutlined, EditOutlined, DatabaseOutli
 import { PageCard } from '@/components/common/PageCard';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useTheme } from '@/hooks/useTheme';
+import {
+  listProviders,
+  getSupportedExecutors,
+  getProvider,
+  createProvider,
+  updateProvider,
+  deleteProvider,
+  exportProviders,
+  importProviders,
+  previewProviderToExecutors,
+  applyProviderToExecutors,
+} from '@/utils/database/providers';
+import type { ProviderDetail, ProviderModel, ApplyResult, PreviewEntry, ExecutorConfigDef } from '@/types/provider';
 
 const { Text, Paragraph } = Typography;
-
-const PROVIDERS_API = '/api/v1/providers';
-
-// ============================================================================
-// Types
-// ============================================================================
-
-interface ProviderModel {
-  name: string;
-  display_name?: string;
-  supports_1m_context?: boolean;
-}
-
-interface ProviderDetail {
-  name: string;
-  display_name: string;
-  api_key: string;
-  base_url: string;
-  protocol: 'openai' | 'anthropic';
-  models: ProviderModel[];
-}
-
-interface ApplyResult {
-  applied: string[];
-  errors: string[];
-}
 
 // ============================================================================
 // Component
@@ -59,9 +46,9 @@ export function ProfilesPanel() {
   const [executorModels, setExecutorModels] = useState<Record<string, string>>({});
   const [applying, setApplying] = useState(false);
   const [applyResult, setApplyResult] = useState<ApplyResult | null>(null);
-  const [previewEntries, setPreviewEntries] = useState<{ executor: string; model: string; path: string; content: string }[]>([]);
+  const [previewEntries, setPreviewEntries] = useState<PreviewEntry[]>([]);
   const [previewLoading, setPreviewLoading] = useState(false);
-  const [executorDefs, setExecutorDefs] = useState<{ name: string; display_name: string; config_path: string; has_generator: boolean }[]>([]);
+  const [executorDefs, setExecutorDefs] = useState<ExecutorConfigDef[]>([]);
   const [modelList, setModelList] = useState<ProviderModel[]>([]);
   // 导入弹窗
   const [importModalVisible, setImportModalVisible] = useState(false);
@@ -73,29 +60,20 @@ export function ProfilesPanel() {
   const isDark = themeMode === 'dark';
   const [form] = Form.useForm();
 
+  // 加载：先并行取 provider 摘要列表 + 执行器定义，再对每个摘要并发拉完整详情。
+  // 后端 list 只回 summary（无 api_key/models），需逐个 getProvider 才能打码展示 Key、渲染模型 Tag。
+  // 单个 detail 失败降级为 null 再 filter 掉，避免一个坏数据拖垮整个列表。
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const [provRes, execRes] = await Promise.all([
-        fetch(PROVIDERS_API),
-        fetch(`${PROVIDERS_API}/supported-executors`),
-      ]);
-      const provJson = await provRes.json();
-      const execJson = await execRes.json();
-      const list: any[] = provJson.data || [];
-      setExecutorDefs(execJson.data || []);
+      const [summaries, execDefs] = await Promise.all([listProviders(), getSupportedExecutors()]);
+      setExecutorDefs(execDefs);
       const details = await Promise.all(
-        list.map(async (s) => {
-          try {
-            const dr = await fetch(`${PROVIDERS_API}/${encodeURIComponent(s.name)}`);
-            const dj = await dr.json();
-            return dj.data;
-          } catch { return null; }
-        })
+        summaries.map((s) => getProvider(s.name).catch(() => null)),
       );
-      setProviders(details.filter(Boolean));
-    } catch (err: any) {
-      message.error('加载失败: ' + (err?.message || String(err)));
+      setProviders(details.filter((d): d is ProviderDetail => d !== null));
+    } catch (err) {
+      message.error('加载失败: ' + (err instanceof Error ? err.message : String(err)));
     } finally {
       setLoading(false);
     }
@@ -111,78 +89,67 @@ export function ProfilesPanel() {
     setCreateVisible(true);
   }, [form]);
 
-  // 打开编辑
+  // 打开编辑：先拉详情回填表单。失败则提示并直接返回（不打开空弹窗），与原 !r.ok 提前返回语义一致。
   const openEdit = useCallback(async (name: string) => {
     setEditingName(name);
     form.resetFields();
     setModelList([]);
     try {
-      const r = await fetch(`${PROVIDERS_API}/${encodeURIComponent(name)}`);
-      if (!r.ok) { message.error('获取详情失败'); return; }
-      const j = await r.json();
-      const d = j.data;
-      if (d) {
-        form.setFieldsValue({
-          name: d.name,
-          display_name: d.display_name,
-          api_key: d.api_key,
-          base_url: d.base_url,
-          protocol: d.protocol,
-        });
-        setModelList(d.models || []);
-      }
-    } catch (err: any) {
-      message.error('加载失败: ' + (err?.message || String(err)));
+      const d = await getProvider(name);
+      form.setFieldsValue({
+        name: d.name,
+        display_name: d.display_name,
+        api_key: d.api_key,
+        base_url: d.base_url,
+        protocol: d.protocol,
+      });
+      setModelList(d.models || []);
+    } catch (err) {
+      message.error('获取详情失败: ' + (err instanceof Error ? err.message : String(err)));
+      return;
     }
     setEditVisible(true);
   }, [form]);
 
-  // 保存
+  // 保存：新建走 POST、编辑走 PUT。body 形状两者一致（编辑时 name 由 URL 路径参数指定）。
+  // validateFields 的校验失败带 errorFields，属用户输入问题，静默返回不报错；其余异常才提示。
   const handleSave = useCallback(async () => {
     try {
       const v = await form.validateFields();
-      const models = modelList.filter((m: any) => m.name?.trim());
+      const models = modelList.filter((m: ProviderModel) => m.name?.trim());
       const body = { ...v, models, protocol: v.protocol || 'openai' };
       if (editingName) {
-        await fetch(`${PROVIDERS_API}/${encodeURIComponent(editingName)}`, {
-          method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
-        });
+        await updateProvider(editingName, body);
         message.success('已更新');
       } else {
-        await fetch(PROVIDERS_API, {
-          method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
-        });
+        await createProvider(body);
         message.success('已创建');
       }
       setCreateVisible(false);
       setEditVisible(false);
       load();
-    } catch (err: any) {
-      if (err?.errorFields) return;
-      message.error('操作失败: ' + (err?.message || String(err)));
+    } catch (err) {
+      // antd 表单校验失败对象带 errorFields，属用户输入问题，静默返回不弹错。
+      if (err && typeof err === 'object' && 'errorFields' in err) return;
+      message.error('操作失败: ' + (err instanceof Error ? err.message : String(err)));
     }
   }, [form, editingName, modelList, load]);
 
   // 删除
   const handleDelete = useCallback(async (name: string) => {
     try {
-      await fetch(`${PROVIDERS_API}/${encodeURIComponent(name)}`, { method: 'DELETE' });
+      await deleteProvider(name);
       message.success('已删除');
       load();
-    } catch (err: any) {
-      message.error('删除失败: ' + (err?.message || String(err)));
+    } catch (err) {
+      message.error('删除失败: ' + (err instanceof Error ? err.message : String(err)));
     }
   }, [load]);
 
-  // 导出：调后端 export 接口，触发文件下载
+  // 导出：拿 YAML 文本后用 <a download> 触发浏览器下载（文件名按日期，纯前端逻辑，与 API 无关）。
   const handleExport = useCallback(async () => {
     try {
-      const r = await fetch(`${PROVIDERS_API}/export`, { method: 'GET' });
-      if (!r.ok) {
-        message.error('导出失败: HTTP ' + r.status);
-        return;
-      }
-      const yaml = await r.text();
+      const yaml = await exportProviders();
       const filename = `ntd-providers-${new Date().toISOString().slice(0, 10)}.yaml`;
       const blob = new Blob([yaml], { type: 'text/yaml;charset=utf-8' });
       const url = URL.createObjectURL(blob);
@@ -194,8 +161,8 @@ export function ProfilesPanel() {
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
       message.success(`已导出 ${filename}`);
-    } catch (err: any) {
-      message.error('导出失败: ' + (err?.message || String(err)));
+    } catch (err) {
+      message.error('导出失败: ' + (err instanceof Error ? err.message : String(err)));
     }
   }, []);
 
@@ -223,17 +190,8 @@ export function ProfilesPanel() {
   const doImport = useCallback(async () => {
     setImporting(true);
     try {
-      const r = await fetch(`${PROVIDERS_API}/import`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ yaml: importText, strategy: importStrategy }),
-      });
-      const j = await r.json();
-      if (j.code !== 0) {
-        message.error('导入失败: ' + (j.message || '未知错误'));
-        return;
-      }
-      const { imported = [], errors = [] } = j.data || {};
+      // 业务级错误（如 YAML 解析失败）经 unwrap 转成 reject 落到 catch；这里只处理成功路径。
+      const { imported = [], errors = [] } = await importProviders(importText, importStrategy);
       if (errors.length > 0) {
         message.warning(`导入完成，${imported.length} 个成功，${errors.length} 个错误`);
       } else {
@@ -243,8 +201,8 @@ export function ProfilesPanel() {
       setImportText('');
       setImportFileName('');
       load();
-    } catch (err: any) {
-      message.error('导入失败: ' + (err?.message || String(err)));
+    } catch (err) {
+      message.error('导入失败: ' + (err instanceof Error ? err.message : String(err)));
     } finally {
       setImporting(false);
     }
@@ -278,16 +236,10 @@ export function ProfilesPanel() {
     if (!applyProvider || selectedExecutors.length === 0) return;
     setPreviewLoading(true);
     try {
-      const r = await fetch(`${PROVIDERS_API}/${encodeURIComponent(applyProvider.name)}/preview`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ executor_models: executorModels }),
-      });
-      const j = await r.json();
-      setPreviewEntries(j.data || []);
+      setPreviewEntries(await previewProviderToExecutors(applyProvider.name, executorModels));
       setApplyStep(APPLY_STEP_PREVIEW);
-    } catch (err: any) {
-      message.error('获取预览失败: ' + (err?.message || String(err)));
+    } catch (err) {
+      message.error('获取预览失败: ' + (err instanceof Error ? err.message : String(err)));
     } finally {
       setPreviewLoading(false);
     }
@@ -298,15 +250,9 @@ export function ProfilesPanel() {
     if (!applyProvider || Object.keys(executorModels).length === 0) return;
     setApplying(true);
     try {
-      const r = await fetch(`${PROVIDERS_API}/${encodeURIComponent(applyProvider.name)}/apply`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ executor_models: executorModels }),
-      });
-      const j = await r.json();
-      setApplyResult(j.data);
-    } catch (err: any) {
-      message.error('应用失败: ' + (err?.message || String(err)));
+      setApplyResult(await applyProviderToExecutors(applyProvider.name, executorModels));
+    } catch (err) {
+      message.error('应用失败: ' + (err instanceof Error ? err.message : String(err)));
     } finally {
       setApplying(false);
     }
@@ -314,7 +260,7 @@ export function ProfilesPanel() {
 
   // 模型列表操作
   const addModel = () => setModelList(prev => [...prev, { name: '', display_name: '' }]);
-  const updateModel = (idx: number, field: string, value: any) =>
+  const updateModel = (idx: number, field: string, value: string | boolean) =>
     setModelList(prev => prev.map((m, i) => i === idx ? { ...m, [field]: value } : m));
   const removeModel = (idx: number) => setModelList(prev => prev.filter((_, i) => i !== idx));
 
@@ -363,7 +309,7 @@ export function ProfilesPanel() {
               <Input size="small" placeholder="显示名称（可选）" value={m.display_name || ''}
                 onChange={e => updateModel(i, 'display_name', e.target.value)}
                 style={{ flex: 1, minWidth: 100 }} />
-              <Checkbox checked={!!(m as any).supports_1m_context}
+              <Checkbox checked={!!m.supports_1m_context}
                 onChange={e => updateModel(i, 'supports_1m_context', e.target.checked)}>
                 <Text type="secondary" style={{ fontSize: 12 }}>1M</Text>
               </Checkbox>

--- a/frontend/src/components/settings/ProfilesPanel.tsx
+++ b/frontend/src/components/settings/ProfilesPanel.tsx
@@ -89,7 +89,9 @@ export function ProfilesPanel() {
     setCreateVisible(true);
   }, [form]);
 
-  // 打开编辑：先拉详情回填表单。失败则提示并直接返回（不打开空弹窗），与原 !r.ok 提前返回语义一致。
+  // 打开编辑：先拉详情回填表单。失败则提示并直接返回（不打开空弹窗）。
+  // Facade 已把原 !r.ok 与网络异常一并 reject 进 catch，故提示文案沿用原 catch 的
+  // 「加载失败」前缀，而非原 !r.ok 的「获取详情失败」（设计 §6 文案不变）。
   const openEdit = useCallback(async (name: string) => {
     setEditingName(name);
     form.resetFields();
@@ -105,7 +107,7 @@ export function ProfilesPanel() {
       });
       setModelList(d.models || []);
     } catch (err) {
-      message.error('获取详情失败: ' + (err instanceof Error ? err.message : String(err)));
+      message.error('加载失败: ' + (err instanceof Error ? err.message : String(err)));
       return;
     }
     setEditVisible(true);

--- a/frontend/src/types/provider.ts
+++ b/frontend/src/types/provider.ts
@@ -1,0 +1,68 @@
+// Provider（AI 服务商 / API Key 管理）领域类型。
+//
+// 集中定义 ProfilesPanel 与 utils/database/providers Facade 共享的类型，
+// 对齐后端 handlers/profiles.rs 的响应结构（list 回 summary、单查回 detail）。
+
+/** 单个模型定义。display_name / supports_1m_context 可选。 */
+export interface ProviderModel {
+  name: string;
+  display_name?: string;
+  supports_1m_context?: boolean;
+}
+
+/** 列表接口返回的摘要——不含 api_key / models，只给计数。对应后端 ProviderSummary。 */
+export interface ProviderSummary {
+  name: string;
+  display_name: string;
+  base_url: string;
+  protocol: 'openai' | 'anthropic';
+  model_count: number;
+}
+
+/** 单查接口返回的完整详情，含明文 api_key（组件用 maskKey 打码展示）。对应后端 ProviderDetail。 */
+export interface ProviderDetail {
+  name: string;
+  display_name: string;
+  api_key: string;
+  base_url: string;
+  protocol: 'openai' | 'anthropic';
+  models: ProviderModel[];
+}
+
+/** 执行器配置定义——/supported-executors 返回，标识每个执行器的配置文件路径与是否有生成器。 */
+export interface ExecutorConfigDef {
+  name: string;
+  display_name: string;
+  config_path: string;
+  has_generator: boolean;
+}
+
+/** create/update 请求体。name 仅 create 用（update 走 URL 路径参数），故可选。 */
+export interface ProviderInput {
+  name?: string;
+  display_name: string;
+  api_key: string;
+  base_url: string;
+  protocol: 'openai' | 'anthropic';
+  models: ProviderModel[];
+}
+
+/** apply 预览的单条结果：某个执行器将被写入的文件路径与内容。 */
+export interface PreviewEntry {
+  executor: string;
+  model: string;
+  path: string;
+  content: string;
+}
+
+/** apply 执行结果：成功的执行器名 + 失败原因列表。 */
+export interface ApplyResult {
+  applied: string[];
+  errors: string[];
+}
+
+/** import 结果：成功导入的名称 + 错误列表。 */
+export interface ImportResult {
+  imported: string[];
+  errors: string[];
+}

--- a/frontend/src/types/provider.ts
+++ b/frontend/src/types/provider.ts
@@ -10,12 +10,15 @@ export interface ProviderModel {
   supports_1m_context?: boolean;
 }
 
+/** Provider 接入协议。后端 provider_config 仅支持这两种，summary/detail/input 三处复用，故抽成具名联合（08-类型定义规范 §2）。 */
+export type ProviderProtocol = 'openai' | 'anthropic';
+
 /** 列表接口返回的摘要——不含 api_key / models，只给计数。对应后端 ProviderSummary。 */
 export interface ProviderSummary {
   name: string;
   display_name: string;
   base_url: string;
-  protocol: 'openai' | 'anthropic';
+  protocol: ProviderProtocol;
   model_count: number;
 }
 
@@ -25,7 +28,7 @@ export interface ProviderDetail {
   display_name: string;
   api_key: string;
   base_url: string;
-  protocol: 'openai' | 'anthropic';
+  protocol: ProviderProtocol;
   models: ProviderModel[];
 }
 
@@ -43,7 +46,7 @@ export interface ProviderInput {
   display_name: string;
   api_key: string;
   base_url: string;
-  protocol: 'openai' | 'anthropic';
+  protocol: ProviderProtocol;
   models: ProviderModel[];
 }
 

--- a/frontend/src/utils/database/index.ts
+++ b/frontend/src/utils/database/index.ts
@@ -8,4 +8,5 @@ export * from './sessions';
 export * from './usage_stats';
 export * from './loops';
 export * from './experts';
+export * from './providers';
 export * from './quickButtons';

--- a/frontend/src/utils/database/providers.test.ts
+++ b/frontend/src/utils/database/providers.test.ts
@@ -1,0 +1,138 @@
+// providers Facade 单元测试。
+//
+// vi.mock 替换 client 模块的 api/unwrap：断言每个 Facade 函数以正确的
+// method/URL/body 调用 axios、返回值经 unwrap 流回、错误能透传（覆盖设计 §5
+// 的假成功修复）。exportProviders 单独验证它走 text 通路、不经过 unwrap。
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+
+// vi.mock 提升到文件顶部执行，确保 providers.ts 导入的 client 是 mock 版。
+vi.mock('@/utils/database/client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  unwrap: vi.fn(),
+}));
+
+import { api, unwrap } from '@/utils/database/client';
+import {
+  listProviders,
+  getSupportedExecutors,
+  getProvider,
+  createProvider,
+  updateProvider,
+  deleteProvider,
+  exportProviders,
+  importProviders,
+  previewProviderToExecutors,
+  applyProviderToExecutors,
+} from './providers';
+import type { ProviderInput } from '@/types/provider';
+
+// TS 仍按真实 axios 类型看 api.*，这里统一转成 vitest Mock 以便断言（不经 any）。
+const mockGet = api.get as unknown as Mock;
+const mockPost = api.post as unknown as Mock;
+const mockPut = api.put as unknown as Mock;
+const mockDelete = api.delete as unknown as Mock;
+const mockUnwrap = unwrap as unknown as Mock;
+
+// 还原真实 unwrap 语义：取 res.data.data。错误分支的用例会临时改写为抛错。
+const unwrapData = (res: { data: { data: unknown } }) => res.data.data;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUnwrap.mockImplementation(unwrapData);
+});
+
+describe('providers Facade', () => {
+  const INPUT: ProviderInput = {
+    display_name: 'DeepSeek',
+    api_key: 'sk-x',
+    base_url: 'https://a/v1',
+    protocol: 'openai',
+    models: [],
+  };
+
+  it('test_listProviders_走GET并解包data数组', async () => {
+    mockGet.mockResolvedValue({ data: { data: [{ name: 'a' }] } });
+    await expect(listProviders()).resolves.toEqual([{ name: 'a' }]);
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/providers');
+  });
+
+  it('test_getSupportedExecutors_走supported_executors端点', async () => {
+    mockGet.mockResolvedValue({ data: { data: [] } });
+    await getSupportedExecutors();
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/providers/supported-executors');
+  });
+
+  it('test_getProvider_对name做encodeURIComponent', async () => {
+    mockGet.mockResolvedValue({ data: { data: { name: 'a b/c' } } });
+    await getProvider('a b/c');
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/providers/a%20b%2Fc');
+  });
+
+  it('test_createProvider_POST_body到根路径', async () => {
+    mockPost.mockResolvedValue({});
+    await createProvider(INPUT);
+    expect(mockPost).toHaveBeenCalledWith('/api/v1/providers', INPUT);
+  });
+
+  it('test_updateProvider_PUT_编码name并带body', async () => {
+    mockPut.mockResolvedValue({});
+    await updateProvider('a b', INPUT);
+    expect(mockPut).toHaveBeenCalledWith('/api/v1/providers/a%20b', INPUT);
+  });
+
+  it('test_deleteProvider_DELETE_编码name', async () => {
+    mockDelete.mockResolvedValue({});
+    await deleteProvider('a b');
+    expect(mockDelete).toHaveBeenCalledWith('/api/v1/providers/a%20b');
+  });
+
+  it('test_importProviders_POST_yaml与strategy并解包', async () => {
+    mockPost.mockResolvedValue({ data: { data: { imported: ['x'], errors: [] } } });
+    await expect(importProviders('yaml: ...', 'replace')).resolves.toEqual({ imported: ['x'], errors: [] });
+    expect(mockPost).toHaveBeenCalledWith('/api/v1/providers/import', { yaml: 'yaml: ...', strategy: 'replace' });
+  });
+
+  it('test_previewProviderToExecutors_POST_executor_models到preview', async () => {
+    mockPost.mockResolvedValue({ data: { data: [] } });
+    await previewProviderToExecutors('p', { codex: 'deepseek-chat' });
+    expect(mockPost).toHaveBeenCalledWith('/api/v1/providers/p/preview', { executor_models: { codex: 'deepseek-chat' } });
+  });
+
+  it('test_applyProviderToExecutors_POST_executor_models到apply', async () => {
+    mockPost.mockResolvedValue({ data: { data: { applied: [], errors: [] } } });
+    await applyProviderToExecutors('p', { codex: 'm' });
+    expect(mockPost).toHaveBeenCalledWith('/api/v1/providers/p/apply', { executor_models: { codex: 'm' } });
+  });
+
+  it('test_exportProviders_走text通路不被unwrap', async () => {
+    mockGet.mockResolvedValue({ data: 'yaml-content' });
+    await expect(exportProviders()).resolves.toBe('yaml-content');
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/providers/export', { responseType: 'text' });
+    // 文本端点直接返回 res.data，绝不能进 unwrap（unwrap 期望 {code,data,message}）。
+    expect(mockUnwrap).not.toHaveBeenCalled();
+  });
+
+  it('test_createProvider_后端拒绝时透传错误不假成功', async () => {
+    // 设计 §5 修复：createProvider 不走 unwrap，依赖 client.ts 拦截器把 code!==0/非 2xx
+    // 转成 reject。Facade 必须把这个 reject 透传出去，组件才能落到 catch 显示「操作失败」，
+    // 而不是原先的不校验响应直接 message.success 假成功。
+    mockPost.mockRejectedValue(new Error('Provider already exists'));
+    await expect(createProvider(INPUT)).rejects.toThrow('Provider already exists');
+  });
+
+  it('test_getProvider_unwrap抛错时透传', async () => {
+    // 走 unwrap 的函数同理：业务错（code!==0）经 unwrap 抛出，Facade 透传。
+    mockGet.mockResolvedValue({ data: { data: null } });
+    mockUnwrap.mockImplementation(() => {
+      throw new Error('not found');
+    });
+    await expect(getProvider('x')).rejects.toThrow('not found');
+  });
+});

--- a/frontend/src/utils/database/providers.test.ts
+++ b/frontend/src/utils/database/providers.test.ts
@@ -18,7 +18,10 @@ vi.mock('@/utils/database/client', () => ({
   unwrap: vi.fn(),
 }));
 
+// @/ 绝对路径块须连续：client 是被 mock 的实例、ProviderInput 是其入参类型契约，
+// 两者同属 @/ 块紧邻，再接 ./ 相对导入（前端 @/ 导入规范）。
 import { api, unwrap } from '@/utils/database/client';
+import type { ProviderInput } from '@/types/provider';
 import {
   listProviders,
   getSupportedExecutors,
@@ -31,7 +34,6 @@ import {
   previewProviderToExecutors,
   applyProviderToExecutors,
 } from './providers';
-import type { ProviderInput } from '@/types/provider';
 
 // TS 仍按真实 axios 类型看 api.*，这里统一转成 vitest Mock 以便断言（不经 any）。
 const mockGet = api.get as unknown as Mock;

--- a/frontend/src/utils/database/providers.ts
+++ b/frontend/src/utils/database/providers.ts
@@ -1,0 +1,84 @@
+// Provider（AI 服务商 / API Key）数据访问 Facade。
+//
+// 收口 ProfilesPanel 原先散落的 11 处裸 fetch：统一走 client.ts 的 axios 实例，
+// 自动获得 v1 前缀处理、GET 网络错重试、{code,data,message} 解包与统一错误信息。
+// 仿 experts.ts 的写法：除文本端点外一律 `unwrap(await api.<method>(...))`。
+
+import { api, unwrap } from './client';
+import type {
+  ProviderSummary,
+  ProviderDetail,
+  ProviderInput,
+  ExecutorConfigDef,
+  PreviewEntry,
+  ApplyResult,
+  ImportResult,
+} from '@/types/provider';
+
+// 后端 providers 路由挂在 /api/v1/ 下（已是 v1，client.ts 的 v1 重写拦截器会跳过，不双前缀）。
+const BASE = '/api/v1/providers';
+
+/** 执行器→模型名 的映射，apply/preview 两个端点共用同一请求体形状。 */
+type ExecutorModels = Record<string, string>;
+
+/**
+ * 列出所有 provider 摘要。
+ *
+ * 后端只回 summary（不含 api_key / models），需要完整详情须再逐个 getProvider。
+ * ProfilesPanel 的加载流程保留这个 list→detail 的 N+1（组件需要 api_key 做打码、models 做展示）。
+ */
+export async function listProviders(): Promise<ProviderSummary[]> {
+  return unwrap<ProviderSummary[]>(await api.get(BASE));
+}
+
+/** 获取所有执行器配置定义（配置文件路径、是否有生成器），用于 apply 弹窗的可选执行器列表。 */
+export async function getSupportedExecutors(): Promise<ExecutorConfigDef[]> {
+  return unwrap<ExecutorConfigDef[]>(await api.get(`${BASE}/supported-executors`));
+}
+
+/** 按 name 取单个 provider 完整详情。encodeURIComponent 防止标识符里的特殊字符破坏路径。 */
+export async function getProvider(name: string): Promise<ProviderDetail> {
+  return unwrap<ProviderDetail>(await api.get(`${BASE}/${encodeURIComponent(name)}`));
+}
+
+/** 新建 provider。后端返回 summary 但组件不需要，故丢弃响应只看是否成功。 */
+export async function createProvider(body: ProviderInput): Promise<void> {
+  await api.post(BASE, body);
+}
+
+/** 更新 provider。name 走 URL 路径参数，body 里其余字段覆盖写回。 */
+export async function updateProvider(name: string, body: ProviderInput): Promise<void> {
+  await api.put(`${BASE}/${encodeURIComponent(name)}`, body);
+}
+
+/** 删除 provider。 */
+export async function deleteProvider(name: string): Promise<void> {
+  await api.delete(`${BASE}/${encodeURIComponent(name)}`);
+}
+
+/**
+ * 导出全部 provider 为 YAML 文本。
+ *
+ * 这是唯一的非 JSON 端点：用 responseType:'text' 拿原始字符串。
+ * client.ts 的响应拦截器对非 object 响应（字符串）原样放行，所以不会误走 code!==0 分支，
+ * 也不能用 unwrap（unwrap 期望 {code,data,message}）。直接返回 res.data。
+ */
+export async function exportProviders(): Promise<string> {
+  const res = await api.get(`${BASE}/export`, { responseType: 'text' });
+  return res.data;
+}
+
+/** 按 YAML 文本导入 provider。strategy=merge 已存在则覆盖，replace 先清空再导入。 */
+export async function importProviders(yaml: string, strategy: 'merge' | 'replace'): Promise<ImportResult> {
+  return unwrap<ImportResult>(await api.post(`${BASE}/import`, { yaml, strategy }));
+}
+
+/** 预览：把 provider 的模型映射写入哪些执行器、各自生成什么文件内容，不落盘。 */
+export async function previewProviderToExecutors(name: string, executorModels: ExecutorModels): Promise<PreviewEntry[]> {
+  return unwrap<PreviewEntry[]>(await api.post(`${BASE}/${encodeURIComponent(name)}/preview`, { executor_models: executorModels }));
+}
+
+/** 应用：按预览结果实际写入各执行器配置文件，返回成功/失败列表。 */
+export async function applyProviderToExecutors(name: string, executorModels: ExecutorModels): Promise<ApplyResult> {
+  return unwrap<ApplyResult>(await api.post(`${BASE}/${encodeURIComponent(name)}/apply`, { executor_models: executorModels }));
+}

--- a/frontend/tests/verify_api_key_panel.spec.ts
+++ b/frontend/tests/verify_api_key_panel.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * ADR-005 / H5：ProfilesPanel 直连 fetch 收敛为 providers Facade 后的冒烟验证。
+ *
+ * API Key 面板挂在「执行器」页的「API Key」tab 下。进入该 tab 会触发
+ * ProfilesPanel 的加载流程：listProviders() + getSupportedExecutors() + 对每个
+ * provider 并发 getProvider()。这些调用现已全部走 providers Facade（client.ts 的
+ * axios 实例）。若 Facade 端点/方法/解包写错，面板会报错或空，本用例据此拦截回归。
+ *
+ * 注：provider 是全局服务端配置（非 workspace 维度），故不按 workspace 固定选择，
+ * 与 verify_executor_tabs.spec.ts 的导航方式保持一致。
+ */
+
+test('API Key 面板经 providers Facade 加载正常', async ({ page }) => {
+  // 采集页面级报错与 antd 错误 toast，加载完成后断言其未出现，
+  // 用来兜住 Facade 调用失败被静默吞掉的情况。
+  const pageErrors: string[] = [];
+  page.on('pageerror', (e) => pageErrors.push(e.message));
+
+  await page.goto('http://localhost:18088');
+  await page.waitForLoadState('networkidle');
+
+  // 进入「执行器」设置页。
+  await page.click('[data-testid="left-rail-settings_executors"]');
+  await page.waitForTimeout(800);
+
+  // 切到「API Key」tab，挂载 ProfilesPanel 并触发加载流程。
+  const apiKeyTab = page.locator('.ant-tabs-tab').filter({ hasText: 'API Key' });
+  await expect(apiKeyTab).toBeVisible();
+  await apiKeyTab.click();
+  // 等待 listProviders + getSupportedExecutors + 逐个 getProvider 的请求收尾。
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(500);
+
+  // PageCard 标题「API Key 管理」可见 → 面板成功挂载。
+  const active = page.locator('.ant-tabs-tabpane-active');
+  await expect(active.getByText('API Key 管理')).toBeVisible();
+  // 「新增 API Key」按钮可见 → 工具条渲染正常（依赖 getSupportedExecutors 不抛错）。
+  await expect(active.getByRole('button', { name: '新增 API Key' })).toBeVisible();
+
+  // 加载全程不应弹出 antd 错误 toast（message.error 会渲染 .ant-message-notice-error）。
+  await expect(page.locator('.ant-message-notice-error')).toHaveCount(0);
+  // 也不应冒出未捕获的 JS 异常。
+  expect(pageErrors).toEqual([]);
+
+  console.log('✓ API Key 面板经 providers Facade 加载正常');
+});

--- a/frontend/tests/verify_api_key_panel.spec.ts
+++ b/frontend/tests/verify_api_key_panel.spec.ts
@@ -1,48 +1,112 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 /**
  * ADR-005 / H5：ProfilesPanel 直连 fetch 收敛为 providers Facade 后的冒烟验证。
  *
- * API Key 面板挂在「执行器」页的「API Key」tab 下。进入该 tab 会触发
- * ProfilesPanel 的加载流程：listProviders() + getSupportedExecutors() + 对每个
- * provider 并发 getProvider()。这些调用现已全部走 providers Facade（client.ts 的
- * axios 实例）。若 Facade 端点/方法/解包写错，面板会报错或空，本用例据此拦截回归。
+ * API Key 面板挂在「执行器」页的「API Key」tab 下。进入该 tab 会触发 ProfilesPanel 的
+ * 加载流程（listProviders + getSupportedExecutors + 对每个 provider 并发 getProvider），
+ * 新增/删除/导出则分别走 createProvider/deleteProvider/exportProviders。这些调用现已全部
+ * 走 providers Facade（client.ts 的 axios 实例），端点/解包写错会在以下用例里暴露。
  *
  * 注：provider 是全局服务端配置（非 workspace 维度），故不按 workspace 固定选择，
  * 与 verify_executor_tabs.spec.ts 的导航方式保持一致。
  */
 
-test('API Key 面板经 providers Facade 加载正常', async ({ page }) => {
-  // 采集页面级报错与 antd 错误 toast，加载完成后断言其未出现，
-  // 用来兜住 Facade 调用失败被静默吞掉的情况。
+const API_URL = 'http://localhost:18088/api/v1';
+// 测试用 provider 标识符——仅字母数字中划线，符合表单 /^[a-zA-Z0-9_-]+$/ 校验。
+// 用固定名便于跨用例自愈清理（见 ensureAbsent）。
+const PW_NAME = 'pw-facade-test';
+// 卡片显示名，用于在列表里定位新建的卡片与删除后断言消失。
+const DISPLAY = 'PW-Facade-Test';
+
+/** 进入「执行器 → API Key」面板，返回当前激活的 tabpane 定位器（Modal 由 portal 渲染，仍用 page scope）。 */
+async function gotoApiKeyPanel(page: Page) {
+  await page.goto('http://localhost:18088');
+  await page.waitForLoadState('networkidle');
+  await page.click('[data-testid="left-rail-settings_executors"]');
+  await page.waitForTimeout(800);
+  // 切到「API Key」tab，挂载 ProfilesPanel 并触发加载请求。
+  const tab = page.locator('.ant-tabs-tab').filter({ hasText: 'API Key' });
+  await expect(tab).toBeVisible();
+  await tab.click();
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(500);
+  return page.locator('.ant-tabs-tabpane-active');
+}
+
+/** 直接 DELETE 清掉测试 provider，忽略 404/网络错。重跑自愈，避免重名导致 create 被后端拒绝。 */
+async function ensureAbsent(page: Page) {
+  await page.request.delete(`${API_URL}/providers/${PW_NAME}`).catch(() => { /* 不存在即已干净 */ });
+}
+
+test('加载：API Key 面板经 providers Facade 加载正常', async ({ page }) => {
+  // 采集未捕获异常，兜住 Facade 调用失败被静默吞掉的情况。
   const pageErrors: string[] = [];
   page.on('pageerror', (e) => pageErrors.push(e.message));
 
-  await page.goto('http://localhost:18088');
-  await page.waitForLoadState('networkidle');
-
-  // 进入「执行器」设置页。
-  await page.click('[data-testid="left-rail-settings_executors"]');
-  await page.waitForTimeout(800);
-
-  // 切到「API Key」tab，挂载 ProfilesPanel 并触发加载流程。
-  const apiKeyTab = page.locator('.ant-tabs-tab').filter({ hasText: 'API Key' });
-  await expect(apiKeyTab).toBeVisible();
-  await apiKeyTab.click();
-  // 等待 listProviders + getSupportedExecutors + 逐个 getProvider 的请求收尾。
-  await page.waitForLoadState('networkidle');
-  await page.waitForTimeout(500);
-
-  // PageCard 标题「API Key 管理」可见 → 面板成功挂载。
-  const active = page.locator('.ant-tabs-tabpane-active');
+  const active = await gotoApiKeyPanel(page);
+  // PageCard 标题与「新增 API Key」按钮可见 → 面板挂载、getSupportedExecutors 未抛错。
   await expect(active.getByText('API Key 管理')).toBeVisible();
-  // 「新增 API Key」按钮可见 → 工具条渲染正常（依赖 getSupportedExecutors 不抛错）。
   await expect(active.getByRole('button', { name: '新增 API Key' })).toBeVisible();
-
-  // 加载全程不应弹出 antd 错误 toast（message.error 会渲染 .ant-message-notice-error）。
+  // 加载全程不应弹错误 toast，也不应有未捕获 JS 异常。
   await expect(page.locator('.ant-message-notice-error')).toHaveCount(0);
-  // 也不应冒出未捕获的 JS 异常。
   expect(pageErrors).toEqual([]);
 
-  console.log('✓ API Key 面板经 providers Facade 加载正常');
+  console.log('✓ 加载：API Key 面板经 providers Facade 加载正常');
+});
+
+test('新增→删除：经 Facade 创建后列表出现，删除后消失', async ({ page }) => {
+  await ensureAbsent(page);
+  const active = await gotoApiKeyPanel(page);
+
+  // —— 新增：打开 Modal，按 placeholder 定位填写（antd Form.Item label 不挂 for，placeholder 最稳）——
+  await active.getByRole('button', { name: '新增 API Key' }).click();
+  // antd v6 的 Modal 无 .ant-modal-content，最内层容器就是 .ant-modal（含 body+footer）。
+  const modal = page.locator('.ant-modal').last();
+  // getByPlaceholder 默认大小写不敏感+子串匹配，'如: DeepSeek' 会误命中 '如: deepseek-anthropic'，故全用 exact。
+  await modal.getByPlaceholder('如: deepseek-anthropic', { exact: true }).fill(PW_NAME);
+  await modal.getByPlaceholder('如: DeepSeek', { exact: true }).fill(DISPLAY);
+  await modal.getByPlaceholder('sk-xxx', { exact: true }).fill('sk-pw-test-key');
+  await modal.getByPlaceholder('https://api.example.com/v1', { exact: true }).fill('https://api.example.com/v1');
+  // 加一个模型，更接近真实 provider；模型区「添加」按钮与工具条按钮文案不冲突（Modal 内 scope）。
+  await modal.getByRole('button', { name: '添加' }).click();
+  await modal.getByPlaceholder('模型标识', { exact: true }).fill('pw-test-model');
+  // antd 对纯文本 2 字按钮自动插空格（footer 的"保 存"），用正则容忍。
+  await modal.getByRole('button', { name: /保\s*存/ }).click();
+
+  // createProvider 经 Facade：拦截器放行 → 组件 message.success('已创建') + load() 重拉列表。
+  await expect(page.locator('.ant-message-notice').filter({ hasText: '已创建' })).toBeVisible();
+  // 保存成功后 createVisible/editVisible 置 false，Modal 关闭（antd 默认不卸载仅隐藏，故断言不可见而非计数归 0）。
+  await expect(page.locator('.ant-modal')).not.toBeVisible();
+  await page.waitForLoadState('networkidle');
+
+  // 新卡片出现，说明 list→detail 链路把它拉回来了。
+  const card = active.locator('.ant-card').filter({ hasText: DISPLAY });
+  await expect(card).toBeVisible();
+
+  // —— 删除：卡片内唯一的 danger 按钮即删除（编辑=link 无 danger，应用=primary 无 danger）——
+  await card.locator('.ant-btn-dangerous').first().click();
+  const pop = page.locator('.ant-popconfirm');
+  // Popconfirm 的"删除"是纯文本 2 字按钮，antd 自动插空格成"删 除"。
+  await pop.getByRole('button', { name: /删\s*除/ }).click();
+  // deleteProvider 经 Facade 成功 → message.success('已删除') + load()。
+  await expect(page.locator('.ant-message-notice').filter({ hasText: '已删除' })).toBeVisible();
+  await page.waitForLoadState('networkidle');
+  await expect(active.locator('.ant-card').filter({ hasText: DISPLAY })).toHaveCount(0);
+
+  console.log('✓ 新增→删除：经 Facade 创建后列表出现，删除后消失');
+});
+
+test('导出：经 Facade 拉取 YAML 并触发下载', async ({ page }) => {
+  const active = await gotoApiKeyPanel(page);
+  // handleExport 拿到 YAML 后用 <a download> 触发下载；先挂监听再点击。
+  const downloadPromise = page.waitForEvent('download');
+  await active.getByRole('button', { name: '导出' }).click();
+  const download = await downloadPromise;
+  // 文件名由 handleExport 拼成 ntd-providers-YYYY-MM-DD.yaml。
+  expect(download.suggestedFilename()).toMatch(/ntd-providers-.*\.yaml$/);
+  // exportProviders() 成功拿到 YAML 文本（不走 unwrap 的 text 通路）才会进 message.success。
+  await expect(page.locator('.ant-message-notice').filter({ hasText: '已导出' })).toBeVisible();
+
+  console.log('✓ 导出：经 Facade 拉取 YAML 并触发下载');
 });


### PR DESCRIPTION
## 概要

ADR-005 重构战役第 **3 个 H 项（H5）**：ProfilesPanel 直连 `fetch` 收敛为 `providers` Facade。设计文档 `docs/design/102-ProfilesPanel-Facade收敛-设计.md`，遵循「一个 H 项一个设计文档、一个 PR」。

`frontend/src/components/settings/ProfilesPanel.tsx`（API Key 管理面板）原先有 **11 处裸 `fetch(PROVIDERS_API)`**，完全旁路 `utils/database/client.ts` 的 axios 实例。`utils/database/` 下已有 11 个同构 Facade（experts/skills/bots/sessions/…，模板见 `experts.ts`），**唯独缺 `providers.ts`**。本 PR 补齐它。

## 改动

| 文件 | 说明 |
|---|---|
| `frontend/src/utils/database/providers.ts`（新增） | Facade，10 个类型化函数，仿 `experts.ts`。除 `exportProviders`（text 端点，不走 unwrap）外统一 `unwrap(await api.<method>(...))` |
| `frontend/src/utils/database/providers.test.ts`（新增） | vitest 12 用例，命名 `test_<函数>_<场景>` |
| `frontend/src/types/provider.ts`（新增） | 8 个接口从 ProfilesPanel 迁出 + 补齐后端实际返回字段 |
| `frontend/src/utils/database/index.ts` | barrel `export * from './providers'` |
| `frontend/src/components/settings/ProfilesPanel.tsx` | 删内联类型 + 11 处 fetch，改用 Facade；`catch (err: any)`→`catch (err)`；2 处 `any` 清理。组件签名零改动 |
| `frontend/tests/verify_api_key_panel.spec.ts`（新增） | Playwright 冒烟：进入 API Key tab，验证标题/按钮可见、全程无错误 toast |

## 净收益

- 组件内 `fetch` 归零（符合前端 13-禁止清单 #7）。
- 所有 GET 自动获得 3 次指数退避重试（`client.ts` 既有）。
- `{code,data,message}` 解包 + 统一错误信息由拦截器 + `unwrap` 收口，删除手写 `JSON.stringify(body)` + `headers` + `if(!r.ok)` / `if(j.code!==0)`。
- 类型从组件内联迁出到 `@/types/provider`，与 `types/expert.ts` 风格一致。

## ⚠️ 唯一行为变更（修复，非回归）

`createProvider`/`updateProvider`/`deleteProvider`/`preview`/`apply` 这 5 处原先**既不检查 `r.ok` 也不检查 `j.code`**，HTTP/业务失败时仍 `message.success('已创建')`（假成功）。走 Facade 后，axios 对非 2xx 自动 reject、响应拦截器对 `code!==0` reject，落到组件**既有**的 `catch (err)` → `message.error('操作失败')`。这正是 H5 列明的「无 unwrap」问题修复，符合 13-禁止清单 #6。**不视为回归**——原行为是 bug。

## 行为不变式（除上述修复外逐条保持）

- 端点、HTTP 方法、请求体、成功路径数据提取逐条不变。
- **N+1 保持**：`load()` 先 `listProviders()` 取 summary 列表（后端 list 不含 `api_key`/`models`），再对每个 `name` 并发 `getProvider()` 取 detail（组件需要 `api_key` 做 `maskKey`、`models` 做 Tag 展示）。
- 组件 UI 流程、loading/弹窗状态机、`message` 文案、`maskKey` 等纯函数不变。
- 公开组件签名 `ProfilesPanel()` 零改动。

## 验收（对应设计文档 §9）

- [x] `npx tsc --noEmit` 零错误
- [x] `npm run build` 零新告警（仅存量 chunk-size 提示）
- [x] `grep fetch/any ProfilesPanel.tsx` → 0 命中
- [x] vitest `providers.test.ts` 12/12 过；既有用例不回归
- [x] Playwright `verify_api_key_panel.spec.ts` 通过（1 passed）

## 与需求/设计对应关系

- ADR-005 H5（ProfilesPanel Facade 抽取）
- 设计文档：`docs/design/102-ProfilesPanel-Facade收敛-设计.md`
- 一个 H 项 = 一个设计文档 + 一个 PR（ADR-005 战役推进顺序 H2✅ → **H5✅（本 PR）** → H1 → H3）
