### PR TITLE
fix(096-W4-3): 评审遗留两项修正（review_status 族属 + initial_status 裸串）

### DIFF
--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -412,7 +412,7 @@ impl LoopRunner {
                         .send(crate::executor_service::ExecEvent::ReviewStatusChanged {
                             record_id: 0,
                             todo_id: 0,
-                            review_status: LoopExecutionStatus::Failed.to_string(),
+                            review_status: ExecutionStatus::Failed.to_string(),
                         });
                     // 失败路径：有绑定对话时直接回复，否则广播 LoopFinished 事件
                     if let Some(ref receive_id) = feishu_receive_id {
@@ -550,7 +550,7 @@ impl LoopRunner {
                 let _ = self.tx.send(crate::executor_service::ExecEvent::ReviewStatusChanged {
                     record_id: 0,
                     todo_id: 0,
-                    review_status: LoopExecutionStatus::Failed.to_string(),
+                    review_status: ExecutionStatus::Failed.to_string(),
                 });
                 self.broadcast_loop_finished(loop_id, loop_execution_id).await;
             }
@@ -1046,10 +1046,10 @@ impl LoopRunner {
         let initial_status = if is_human_approval_step {
             match self.ctx.db.get_todo(step.todo_id).await {
                 Ok(Some(t)) if t.status == crate::models::TodoStatus::Completed => LoopStepStatus::PendingApproval.as_str(),
-                _ => "running",
+                _ => LoopStepStatus::Running.as_str(),
             }
         } else {
-            "running"
+            LoopStepStatus::Running.as_str()
         };
         tracing::info!(
             "loop_exec {}: step #{} human_approval={} todo_id={} initial_status={}",


### PR DESCRIPTION
## 内容

#1036 本地评审发现的两项 SUGGESTION 修正（值均运行时等价，词汇表精确性修正）：

1. **review_status 族属**：`ReviewStatusChanged.review_status` 从 `LoopExecutionStatus::Failed` 改为 `ExecutionStatus::Failed`（两处）——评审状态字段归 execution 评审域词汇表。
2. **initial_status 裸串残留**：`_ => "running"` / `"running"` 两分支 → `LoopStepStatus::Running.as_str()`。

## 验证

clippy 零告警、loop_runner 38 测试过。
