### PR TITLE
refactor(096-W4-4-1): BlackboardPage 拆分——设置弹窗/Wiki 数据族/防抖订阅三线下沉（1286→855 行）

### DIFF
--- a/frontend/src/components/BlackboardPage.tsx
+++ b/frontend/src/components/BlackboardPage.tsx
@@ -22,8 +22,8 @@
  *   └──────────────────────────┘
  */
 
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Button, Skeleton, message, Modal, Form, InputNumber, Space, Progress, Input, Tabs, Menu, Drawer, Switch } from 'antd';
+import { useState, useCallback, useMemo } from 'react';
+import { Button, Skeleton, message, Modal, Space, Progress, Menu, Drawer } from 'antd';
 import { ReloadOutlined, SettingOutlined, UnorderedListOutlined, MenuOutlined, DeleteOutlined } from '@ant-design/icons';
 import { PageCard } from '@/components/common/PageCard';
 import { TfiBlackboard } from 'react-icons/tfi';
@@ -32,41 +32,14 @@ import { LazyXMarkdown } from '@/components/common/LazyXMarkdown';
 import { useTheme } from '@/hooks/useTheme';
 import { useViewState } from '@/hooks/useViewState';
 import { useIsMobile } from '@/hooks/useIsMobile';
-import type { BlackboardDebounceStatus } from '@/hooks/useExecutionEvents';
-import { updateBlackboardConfig, getBlackboard, deleteWikiFile } from '@/utils/database/blackboard';
+import { getBlackboard, deleteWikiFile } from '@/utils/database/blackboard';
 import { normalizeBlackboardMarkdown } from '@/utils/markdown';
 import { ProposalButton } from '@/components/blackboard-proposal/ProposalButton';
-
-/** 黑板 API 返回的配置形状（与后端 BlackboardResponse 对应，不含内容） */
-interface BlackboardData {
-  id: number;
-  workspace_id: number;
-  updated_at: string | null;
-  /** 黑板更新防抖周期（秒）*/
-  blackboard_debounce_secs: number;
-  /** 黑板更新防抖条数阈值 */
-  blackboard_debounce_count: number;
-  /** Wiki 更新提示词模板（单阶段） */
-  wiki_prompt: string;
-  /** Wiki 对话使用的执行器名称，空/undefined 表示使用默认值 claudecode */
-  wiki_chat_executor?: string | null;
-  /** Wiki 执行超时（秒），控制 Wiki 任务与 Wiki 对话的最长存活时间 */
-  wiki_timeout_secs: number;
-  /** 黑板功能总开关 */
-  enabled: boolean;
-}
-
-/** Wiki 文件列表项（对应后端 WikiFileItem） */
-interface WikiFileItem {
-  slug: string;
-  file_type: 'index' | 'topic' | 'log' | string;
-}
-
-/** Wiki 文件内容（对应后端 WikiFileContent） */
-interface WikiFileContent {
-  slug: string;
-  content: string;
-}
+// 096-W4-4：类型/API/hook 已抽离至 blackboard/ 子目录与 hooks/ 目录
+import type { WikiFileContent, WikiFileItem } from '@/components/blackboard/types';
+import { BlackboardSettingsModal } from '@/components/blackboard/BlackboardSettingsModal';
+import { useBlackboardWiki } from '@/hooks/useBlackboardWiki';
+import { useBlackboardDebounceStatus } from '@/hooks/useBlackboardDebounceStatus';
 
 /** ntd://todo/{id} 协议的前缀，用于解析 LLM 注入的内部链接 */
 const NTD_TODO_PROTOCOL_PREFIX = 'ntd://todo/';
@@ -76,42 +49,6 @@ const URL_WORKSPACE_PARAM = 'workspace';
 
 /** 默认工作空间 ID（首屏兜底，避免 URL 未带参时无 workspace） */
 const DEFAULT_WORKSPACE_ID = 1;
-
-/**
- * Wiki 提示词默认值（单阶段）：与后端 `build_wiki_prompt()` 内置模板保持一致。
- *
- * ⚠️ 注意：此为前端副本，后端 `backend/src/services/blackboard.rs` 的
- * `build_wiki_prompt()` 函数中也有一份，修改时需同步更新两处。
- * 用于在 UI 上展示默认提示词内容，以及"恢复默认"时回填。
- */
-const DEFAULT_WIKI_PROMPT = `你是一个工作空间黑板维护者。你的任务是分析新的执行记录，更新 Wiki 页面。
-
-你拥有以下工具，可以直接在执行过程中调用：
-- \`ls ~/.ntd/workspace/{{workspace_id}}/wiki/topics/\`：列出现有主题页面
-- \`cat ~/.ntd/workspace/{{workspace_id}}/wiki/topics/<slug>.md\`：读取页面内容
-- \`ntd todo execution get <id>\`：获取指定执行记录的完整结论（result 字段）
-
-待分析的执行记录 ID 列表：
-{{pending_record_ids}}
-
-请按以下步骤操作：
-1. 列出现有主题页面，了解当前 Wiki 结构
-2. 逐个调用 \`ntd todo execution get <id>\` 获取每条执行记录的结论
-3. 分析每条结论涉及哪些主题领域
-4. 对于新主题：创建 \`~/.ntd/workspace/{{workspace_id}}/wiki/topics/<slug>.md\`
-5. 对于已有主题：编辑文件，追加/更新结论（保持已有内容）
-6. 每个页面结构：
-   - # 标题（中文）
-   - ## 已确认
-   - ## 新发现
-   - ## 待解决问题
-   - ## 矛盾/风险
-   - ## 下一步建议
-7. 每条结论标注来源，使用 \`ntd todo execution get <record_id>\` 返回结果中的 \`todo_id\` 和 \`id\` 字段，
-   生成 app 内链接：(来源: [record_{record_id}](/#/todos/{todo_id}/posts/{record_id}))
-
-完成后输出简短确认即可，无需输出 YAML/JSON。`;
-
 
 /** Markdown 链接组件 props 形状（XMarkdown ComponentProps 简化版） */
 interface MarkdownLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
@@ -236,45 +173,6 @@ function useEffectiveWorkspaceId(propWorkspaceId: number | null | undefined): nu
   }, [propWorkspaceId]);
 }
 
-/** 拉取黑板内容的纯函数，便于测试与复用。
- *  原生 fetch 不经 axios 拦截器，手动写 v1 路径。 */
-async function fetchBlackboardData(workspaceId: number): Promise<BlackboardData> {
-  const res = await fetch(`/api/v1/workspaces/${workspaceId}/blackboard`);
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { data?: BlackboardData };
-  if (!json.data) {
-    throw new Error('Empty response body');
-  }
-  return json.data;
-}
-
-/** 拉取单个 Wiki 文件内容（原生 fetch，手动写 v1 路径） */
-async function fetchWikiFileContent(workspaceId: number, slug: string): Promise<WikiFileContent> {
-  const res = await fetch(`/api/v1/workspaces/${workspaceId}/wiki/files/${encodeURIComponent(slug)}`);
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { data?: WikiFileContent };
-  if (!json.data) {
-    throw new Error('Empty response body');
-  }
-  return json.data;
-}
-
-/** 拉取 Wiki 文件列表（原生 fetch，手动写 v1 路径） */
-async function fetchWikiFiles(workspaceId: number): Promise<WikiFileItem[]> {
-  const res = await fetch(`/api/v1/workspaces/${workspaceId}/wiki/files`);
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { data?: WikiFileItem[] };
-  return json.data ?? [];
-}
-
-
-
 export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?: number | null }) {
   // 主题：决定黑板容器背景与文字色
   const { themeMode } = useTheme();
@@ -283,198 +181,21 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
   const workspaceId = useEffectiveWorkspaceId(propWorkspaceId);
   // 移动端检测
   const isMobile = useIsMobile();
-  // 用于同步 URL
-  const { replaceUrl, blackboardFile } = useViewState();
+  // 用于同步 URL（handleSelectSlug 切页时写回）
+  const { replaceUrl } = useViewState();
 
-  // Wiki 化数据状态
-  const [files, setFiles] = useState<WikiFileItem[]>([]);
-  const [currentFile, setCurrentFile] = useState<WikiFileContent | null>(null);
-  const [currentSlug, setCurrentSlug] = useState<string>('');
-  const [filesLoading, setFilesLoading] = useState(true);
-  const [fileLoading, setFileLoading] = useState(false);
-  // 旧版数据（配置用）
-  const [configData, setConfigData] = useStateBlackboardData();
+  // Wiki 数据族 + 竞态防护 + 配置加载已收口至 useBlackboardWiki（096-W4-4）；
+  // 含 files/currentFile/currentSlug/loading 族、workspace 切换清空重拉、URL 同步。
+  const {
+    files, currentFile, currentSlug, filesLoading, fileLoading,
+    configData, setConfigData, setCurrentSlug, fetchFiles, refresh,
+  } = useBlackboardWiki(workspaceId);
 
-  // 防切换竞态：ref 始终持有「最新一次渲染」的 workspaceId / currentSlug。
-  // fetch 回调在 await 前捕获闭包里的旧 key，resolve 后与 ref 比较——
-  // 不一致说明期间已切换工作空间/文件，晚到的响应直接丢弃，避免覆盖新工作空间的数据。
-  // 与 useLoopExecutions/useExecutionHistory 的 cancelledRef 思路一致（latest-wins）。
-  const latestWorkspaceIdRef = useRef(workspaceId);
-  latestWorkspaceIdRef.current = workspaceId;
-  const latestSlugRef = useRef(currentSlug);
-  latestSlugRef.current = currentSlug;
-  // 设置弹窗状态
+  // 设置弹窗仅保留开关（表单 state 与保存逻辑下沉到 BlackboardSettingsModal）
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [settingsSaving, setSettingsSaving] = useState(false);
-  const [debounceSecs, setDebounceSecs] = useState<number | null>(600);
-  const [debounceCount, setDebounceCount] = useState<number | null>(10);
-  const [wikiPrompt, setWikiPrompt] = useState<string>('');
-  // Wiki 执行超时（秒）：与后端 DEFAULT_WIKI_TIMEOUT_SECS=300 一致，清空时回退默认
-  const [wikiTimeoutSecs, setWikiTimeoutSecs] = useState<number | null>(300);
-  const [bbEnabled, setBbEnabled] = useState<boolean>(true);
-  const [activeTab, setActiveTab] = useState<'debounce' | 'prompt'>('debounce');
+  const handleOpenSettings = useCallback(() => setSettingsOpen(true), []);
   // 移动端目录 Drawer 开关状态
   const [menuDrawerOpen, setMenuDrawerOpen] = useState(false);
-
-  /**
-   * 打开设置弹窗：从已加载的黑板数据中读取 per-workspace 配置。
-   * 配置现在由 GET /api/workspaces/{workspaceId}/blackboard 接口随内容一并返回，
-   * 不再需要单独调用 db.getConfig()（getConfig 是全局配置，与黑板配置无关）。
-   */
-  const handleOpenSettings = useCallback(() => {
-    if (configData) {
-      setDebounceSecs(configData.blackboard_debounce_secs ?? 600);
-      setDebounceCount(configData.blackboard_debounce_count ?? 10);
-      setWikiPrompt(configData.wiki_prompt ?? '');
-      setWikiTimeoutSecs(configData.wiki_timeout_secs ?? 300);
-      setBbEnabled(configData.enabled ?? true);
-    } else {
-      setDebounceSecs(600);
-      setDebounceCount(10);
-      setWikiPrompt('');
-      setWikiTimeoutSecs(300);
-      setBbEnabled(true);
-    }
-    setActiveTab('debounce');
-    setSettingsOpen(true);
-  }, [configData]);
-
-  // 保存设置
-  const handleSaveSettings = useCallback(async () => {
-    setSettingsSaving(true);
-    try {
-      await updateBlackboardConfig(workspaceId, {
-        // 用户清空输入时 null → 用默认值，避免后端意外覆盖
-        blackboard_debounce_secs: debounceSecs ?? 600,
-        blackboard_debounce_count: debounceCount ?? 10,
-        wiki_prompt: wikiPrompt,
-        wiki_timeout_secs: wikiTimeoutSecs ?? 300,
-        enabled: bbEnabled,
-      });
-      // 保存成功后同步更新 data，避免下次打开弹窗读到旧值
-      if (configData) {
-        setConfigData({
-          ...configData,
-          blackboard_debounce_secs: debounceSecs ?? 600,
-          blackboard_debounce_count: debounceCount ?? 10,
-          wiki_prompt: wikiPrompt,
-          wiki_timeout_secs: wikiTimeoutSecs ?? 300,
-          enabled: bbEnabled,
-        });
-      }
-      message.success('设置已保存');
-      setSettingsOpen(false);
-    } catch (err) {
-      message.error('保存失败: ' + (err instanceof Error ? err.message : String(err)));
-    } finally {
-      setSettingsSaving(false);
-    }
-  }, [workspaceId, debounceSecs, debounceCount, wikiPrompt, wikiTimeoutSecs, bbEnabled, configData]);
-
-  // 恢复默认提示词：把 wikiPrompt 设为内置默认值。
-  // 区别于"留空"的语义——留空表示后端使用内置默认；填入默认值表示用户显式采用内置模板。
-  const handleRestorePrompt = useCallback(() => {
-    setWikiPrompt(DEFAULT_WIKI_PROMPT);
-  }, []);
-
-  // 拉取页面列表
-  const fetchFiles = useCallback(async () => {
-    // 捕获本次请求所属的工作空间，resolve 后与最新值比较，防止切换后旧响应覆盖新数据
-    const ws = workspaceId;
-    try {
-      setFilesLoading(true);
-      const list = await fetchWikiFiles(ws);
-      if (latestWorkspaceIdRef.current !== ws) return; // 已切换到别的工作空间，丢弃
-      setFiles(list);
-      // 计算默认 slug：优先 topic，其次 log，都没有则空
-      const defaultSlug = list.find(f => f.file_type === 'topic')?.slug
-        ?? list.find(f => f.file_type === 'log')?.slug
-        ?? '';
-      // 用函数式更新读取最新 currentSlug，避免将其放入依赖数组而每次切页重拉列表
-      setCurrentSlug(prev => (list.some(p => p.slug === prev) ? prev : defaultSlug));
-    } catch (err) {
-      if (latestWorkspaceIdRef.current !== ws) return; // 切换后的错误也不弹窗
-      console.error('获取页面列表失败:', err);
-      message.error('获取页面列表失败');
-    } finally {
-      // 仅当仍是本次请求的工作空间时才动 loading，避免把新工作空间的 loading 提前置 false
-      if (latestWorkspaceIdRef.current === ws) setFilesLoading(false);
-    }
-  }, [workspaceId]);
-
-  // 拉取当前页面详情
-  const fetchCurrentFile = useCallback(async () => {
-    // 捕获本次请求所属的工作空间 + slug，resolve 后与最新值比较，防切换竞态
-    const ws = workspaceId;
-    const slug = currentSlug;
-    // 空 slug 不发起请求：初始态或切换工作空间清空后，slug 为空字符串，
-    // 此时请求会得到 404 或意外数据，应直接跳过。
-    if (!slug) {
-      setFileLoading(false);
-      return;
-    }
-    try {
-      setFileLoading(true);
-      const file = await fetchWikiFileContent(ws, slug);
-      if (latestWorkspaceIdRef.current !== ws || latestSlugRef.current !== slug) return;
-      setCurrentFile(file);
-    } catch (err) {
-      if (latestWorkspaceIdRef.current !== ws || latestSlugRef.current !== slug) return;
-      console.error('获取页面详情失败:', err);
-      setCurrentFile(null);
-    } finally {
-      if (latestWorkspaceIdRef.current === ws && latestSlugRef.current === slug) setFileLoading(false);
-    }
-  }, [workspaceId, currentSlug]);
-
-  // 拉取配置（旧版接口，只用于设置弹窗）
-  const fetchConfig = useCallback(async () => {
-    const ws = workspaceId;
-    try {
-      const fetched = await fetchBlackboardData(ws);
-      if (latestWorkspaceIdRef.current !== ws) return; // 已切换，丢弃旧响应
-      setConfigData(fetched);
-    } catch (err) {
-      if (latestWorkspaceIdRef.current !== ws) return;
-      console.error('获取黑板配置失败:', err);
-    }
-  }, [workspaceId, setConfigData]);
-
-  // workspace 切换时先清空隔离数据，避免加载失败或加载窗口期暴露上一工作空间内容
-  // 注意：不设 currentSlug = ''，否则 Menu 收到 selectedKeys={['']} 会崩溃
-  //（Ant Design Menu.js:40 prefixCls → Cannot read properties of null）。
-  // files 已清空 → Menu 不渲染（files.length === 0 显示"暂无页面"），
-  // fetchFiles 异步完成后会自动设回有效 slug。
-  useEffect(() => {
-    setFiles([]);
-    setCurrentFile(null);
-    setConfigData(null);
-  }, [workspaceId]);
-
-  // 副作用：workspaceId 变化时重拉
-  useEffect(() => {
-    fetchFiles();
-    fetchConfig();
-  }, [fetchFiles, fetchConfig]);
-
-  // URL 中的 blackboardFile 变化时，同步到 currentSlug（支持浏览器前进后退）
-  useEffect(() => {
-    if (blackboardFile) {
-      setCurrentSlug(blackboardFile);
-    }
-  }, [blackboardFile]);
-
-  // 副作用：currentSlug 变化时重拉页面详情
-  // 守卫已在 fetchCurrentFile 内部处理空 slug 场景
-  useEffect(() => {
-    fetchCurrentFile();
-  }, [fetchCurrentFile]);
-
-  // 刷新：重新拉取列表和当前页面
-  const handleRefresh = useCallback(() => {
-    fetchFiles();
-    fetchCurrentFile();
-  }, [fetchFiles, fetchCurrentFile]);
 
   // 移动端选择目录后关闭 Drawer，同时同步 URL
   const handleSelectSlug = useCallback((slug: string) => {
@@ -497,13 +218,13 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
           <MobileHeaderExtra
             onMenuClick={() => setMenuDrawerOpen(true)}
             onOpenSettings={handleOpenSettings}
-            onRefresh={handleRefresh}
+            onRefresh={refresh}
           />
         ) : (
           <DesktopHeaderExtra
             workspaceId={workspaceId}
             onOpenSettings={handleOpenSettings}
-            onRefresh={handleRefresh}
+            onRefresh={refresh}
           />
         )
       }
@@ -525,153 +246,19 @@ export function BlackboardPage({ workspaceId: propWorkspaceId }: { workspaceId?:
         onTopicDeleted={fetchFiles}
       />
 
-      {/* 黑板设置弹窗：Tab1 防抖设置，Tab2 提示词设置 */}
-      <Modal
-        title="黑板设置"
+      {/* 黑板设置弹窗：整组下沉至 BlackboardSettingsModal（096-W4-4） */}
+      <BlackboardSettingsModal
         open={settingsOpen}
-        onOk={handleSaveSettings}
-        onCancel={() => setSettingsOpen(false)}
-        okText="保存"
-        confirmLoading={settingsSaving}
-        destroyOnHidden
-        width={isMobile ? '90%' : 640}
-      >
-        <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <span style={{ fontSize: 14, fontWeight: 500 }}>启用黑板</span>
-          <Switch checked={bbEnabled} onChange={setBbEnabled} />
-        </div>
-        <Tabs
-          activeKey={activeTab}
-          onChange={(key) => setActiveTab(key as 'debounce' | 'prompt')}
-          items={[
-            {
-              key: 'debounce',
-              label: '防抖设置',
-              children: (
-                <DebounceSettingsTab
-                  debounceSecs={debounceSecs}
-                  setDebounceSecs={setDebounceSecs}
-                  debounceCount={debounceCount}
-                  setDebounceCount={setDebounceCount}
-                  wikiTimeoutSecs={wikiTimeoutSecs}
-                  setWikiTimeoutSecs={setWikiTimeoutSecs}
-                />
-              ),
-            },
-            {
-              key: 'prompt',
-              label: '提示词设置',
-              children: (
-                <PromptSettingsTab
-                  wikiPrompt={wikiPrompt}
-                  setWikiPrompt={setWikiPrompt}
-                  onRestorePrompt={handleRestorePrompt}
-                />
-              ),
-            },
-          ]}
-        />
-      </Modal>
+        onClose={() => setSettingsOpen(false)}
+        workspaceId={workspaceId}
+        configData={configData}
+        onSaved={setConfigData}
+        isMobile={isMobile}
+      />
     </PageCard>
   );
 }
 
-// ─── 设置弹窗子组件（避免 Tabs children 深层嵌套）─────────────────
-
-interface DebounceSettingsTabProps {
-  debounceSecs: number | null;
-  setDebounceSecs: (v: number | null) => void;
-  debounceCount: number | null;
-  setDebounceCount: (v: number | null) => void;
-  /** Wiki 执行超时（秒） */
-  wikiTimeoutSecs: number | null;
-  setWikiTimeoutSecs: (v: number | null) => void;
-}
-
-/** 防抖设置 Tab：防抖周期 + 触发条数 + Wiki 执行超时，受父组件状态控制 */
-function DebounceSettingsTab({ debounceSecs, setDebounceSecs, debounceCount, setDebounceCount, wikiTimeoutSecs, setWikiTimeoutSecs }: DebounceSettingsTabProps) {
-  return (
-    <Form layout="vertical" style={{ marginTop: 16 }}>
-      <Form.Item label="防抖周期">
-        <InputNumber
-          value={debounceSecs}
-          // 用户清空输入时 value=null，不立即回填默认值，只透传 null 给 state；
-          // 保存时由 handleSaveSettings 用 ?? 兜底，避免删值瞬间被 600 覆盖
-          onChange={(v) => setDebounceSecs(v)}
-          min={10}
-          max={3600}
-          addonAfter="秒"
-          style={{ width: 200 }}
-        />
-      </Form.Item>
-      <Form.Item label="触发条数">
-        <InputNumber
-          value={debounceCount}
-          onChange={(v) => setDebounceCount(v)}
-          min={1}
-          max={100}
-          addonAfter="条"
-          style={{ width: 200 }}
-        />
-      </Form.Item>
-      <Form.Item
-        label="Wiki 执行超时"
-        // 后端会把输入值钳制到 [60, 3600]，这里同步展示边界提示；
-        // 默认 300 秒（5 分钟），慢模型可调大避免被强制超时
-        extra="Wiki 自动维护与 Wiki 对话的最长执行时长（后端会自动钳制到 60–3600 秒），默认 300 秒"
-      >
-        <InputNumber
-          value={wikiTimeoutSecs}
-          onChange={(v) => setWikiTimeoutSecs(v)}
-          min={60}
-          max={3600}
-          addonAfter="秒"
-          style={{ width: 200 }}
-        />
-      </Form.Item>
-      <Form.Item extra="达到条数阈值或周期到期时，统一处理 pending 的 todo，减少频繁的 LLM 调用" />
-    </Form>
-  );
-}
-
-interface PromptSettingsTabProps {
-  wikiPrompt: string;
-  setWikiPrompt: (v: string) => void;
-  onRestorePrompt: () => void;
-}
-
-/** 提示词设置 Tab：单阶段 Wiki 提示词 */
-function PromptSettingsTab({
-  wikiPrompt, setWikiPrompt,
-  onRestorePrompt,
-}: PromptSettingsTabProps) {
-  return (
-    <div style={{ marginTop: 16 }}>
-      <div style={{ marginBottom: 20 }}>
-        <Space style={{ marginBottom: 8 }}>
-          <Button onClick={onRestorePrompt}>恢复默认</Button>
-          <span style={{ color: '#888', fontSize: 12 }}>
-            Wiki 提示词（单阶段：分析记录 + 直接编辑文件）
-          </span>
-        </Space>
-        <Input.TextArea
-          value={wikiPrompt}
-          onChange={(e) => setWikiPrompt(e.target.value)}
-          rows={16}
-          placeholder="留空使用内置默认，如需自定义请直接在此输入"
-        />
-      </div>
-    </div>
-  );
-}
-
-/**
- * useState 黑板数据的轻封装：未来若加缓存/打点只改这里。
- * 单独抽 hook 是为了让上层组件更可测。
- */
-function useStateBlackboardData() {
-  return useState<BlackboardData | null>(null);
-}
 
 // ─── 桌面端 Header Extra（进度条 + 操作按钮 + 队列弹窗）─────────────────
 
@@ -798,17 +385,8 @@ interface MobileDebounceIndicatorProps {
  * - 无状态：不渲染
  */
 function MobileDebounceIndicator({ workspaceId }: MobileDebounceIndicatorProps) {
-  const [status, setStatus] = useState<BlackboardDebounceStatus | null>(null);
-
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const s = (e as CustomEvent<BlackboardDebounceStatus>).detail;
-      if (s.workspace_id !== workspaceId) return;
-      setStatus(s);
-    };
-    window.addEventListener('blackboardDebounceStatus', handler);
-    return () => window.removeEventListener('blackboardDebounceStatus', handler);
-  }, [workspaceId]);
+  // 防抖状态订阅已收口至 useBlackboardDebounceStatus（096-W4-4，两组件共用单份）
+  const status = useBlackboardDebounceStatus(workspaceId);
 
   if (!status) return null;
 
@@ -849,18 +427,9 @@ interface BlackboardDebounceBarProps {
  * - 点击整体弹出详情，同时显示时间和条数数据
  */
 function BlackboardDebounceBar({ workspaceId }: BlackboardDebounceBarProps) {
-  const [status, setStatus] = useState<BlackboardDebounceStatus | null>(null);
+  // 防抖状态订阅已收口至 useBlackboardDebounceStatus（096-W4-4）
+  const status = useBlackboardDebounceStatus(workspaceId);
   const [showDetail, setShowDetail] = useState(false);
-
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const s = (e as CustomEvent<BlackboardDebounceStatus>).detail;
-      if (s.workspace_id !== workspaceId) return;
-      setStatus(s);
-    };
-    window.addEventListener('blackboardDebounceStatus', handler);
-    return () => window.removeEventListener('blackboardDebounceStatus', handler);
-  }, [workspaceId]);
 
   if (!status) return null;
 

--- a/frontend/src/components/WikiViewPage.tsx
+++ b/frontend/src/components/WikiViewPage.tsx
@@ -14,24 +14,8 @@ import { PageCard } from '@/components/common/PageCard';
 import { useViewState } from '@/hooks/useViewState';
 import { TfiBlackboard } from 'react-icons/tfi';
 
-/** Wiki 文件内容 */
-interface WikiFileContent {
-  slug: string;
-  content: string;
-}
-
-/** 拉取单个 Wiki 文件内容（原生 fetch，手动写 v1 路径） */
-async function fetchWikiFileContent(workspaceId: number, slug: string): Promise<WikiFileContent> {
-  const res = await fetch(`/api/v1/workspaces/${workspaceId}/wiki/files/${encodeURIComponent(slug)}`);
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { data?: WikiFileContent };
-  if (!json.data) {
-    throw new Error('Empty response body');
-  }
-  return json.data;
-}
+// 096-W4-4：类型与拉取函数统一引用黑板域共享层（原本地定义为逐字重复）
+import { fetchWikiFileContent } from '@/components/blackboard/api';
 
 export function WikiViewPage() {
   const { themeMode } = useTheme();

--- a/frontend/src/components/blackboard/BlackboardSettingsModal.tsx
+++ b/frontend/src/components/blackboard/BlackboardSettingsModal.tsx
@@ -1,0 +1,274 @@
+/**
+ * BlackboardSettingsModal — 黑板设置弹窗（096-W4-4：从 BlackboardPage 主组件拆出）。
+ *
+ * 承接整块设置族逻辑：8 个表单 state + 保存/恢复默认 handler + Modal/Tab JSX。
+ * 主组件只持有 open 开关，表单数据在弹窗内聚（打开时从 configData 初始化，
+ * 保存成功后经 onSaved 回写父组件缓存）。
+ *
+ * 函数体与 JSX 逐字搬自原实现，行为等价。
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Button, Form, Input, InputNumber, Modal, Space, Switch, Tabs, message } from 'antd';
+import { updateBlackboardConfig } from '@/utils/database/blackboard';
+import type { BlackboardData } from './types';
+
+/**
+ * Wiki 提示词默认值（单阶段）：与后端 `build_wiki_prompt()` 内置模板保持一致。
+ *
+ * ⚠️ 注意：此为前端副本，后端 `backend/src/services/blackboard.rs` 的
+ * `build_wiki_prompt()` 函数中也有一份，修改时需同步更新两处。
+ * 用于在 UI 上展示默认提示词内容，以及"恢复默认"时回填。
+ */
+const DEFAULT_WIKI_PROMPT = `你是一个工作空间黑板维护者。你的任务是分析新的执行记录，更新 Wiki 页面。
+
+你拥有以下工具，可以直接在执行过程中调用：
+- \`ls ~/.ntd/workspace/{{workspace_id}}/wiki/topics/\`：列出现有主题页面
+- \`cat ~/.ntd/workspace/{{workspace_id}}/wiki/topics/<slug>.md\`：读取页面内容
+- \`ntd todo execution get <id>\`：获取指定执行记录的完整结论（result 字段）
+
+待分析的执行记录 ID 列表：
+{{pending_record_ids}}
+
+请按以下步骤操作：
+1. 列出现有主题页面，了解当前 Wiki 结构
+2. 逐个调用 \`ntd todo execution get <id>\` 获取每条执行记录的结论
+3. 分析每条结论涉及哪些主题领域
+4. 对于新主题：创建 \`~/.ntd/workspace/{{workspace_id}}/wiki/topics/<slug>.md\`
+5. 对于已有主题：编辑文件，追加/更新结论（保持已有内容）
+6. 每个页面结构：
+   - # 标题（中文）
+   - ## 已确认
+   - ## 新发现
+   - ## 待解决问题
+   - ## 矛盾/风险
+   - ## 下一步建议
+7. 每条结论标注来源，使用 \`ntd todo execution get <record_id>\` 返回结果中的 \`todo_id\` 和 \`id\` 字段，
+   生成 app 内链接：(来源: [record_{record_id}](/#/todos/{todo_id}/posts/{record_id}))
+
+完成后输出简短确认即可，无需输出 YAML/JSON。`;
+
+export interface BlackboardSettingsModalProps {
+  open: boolean;
+  onClose: () => void;
+  workspaceId: number;
+  /** 黑板配置（打开弹窗时的表单初始化源；null 时用默认值兜底） */
+  configData: BlackboardData | null;
+  /** 保存成功后回写父组件的 configData 缓存 */
+  onSaved: (updated: BlackboardData) => void;
+  isMobile: boolean;
+}
+
+export function BlackboardSettingsModal({
+  open,
+  onClose,
+  workspaceId,
+  configData,
+  onSaved,
+  isMobile,
+}: BlackboardSettingsModalProps) {
+  const [settingsSaving, setSettingsSaving] = useState(false);
+  const [debounceSecs, setDebounceSecs] = useState<number | null>(600);
+  const [debounceCount, setDebounceCount] = useState<number | null>(10);
+  const [wikiPrompt, setWikiPrompt] = useState<string>('');
+  // Wiki 执行超时（秒）：与后端 DEFAULT_WIKI_TIMEOUT_SECS=300 一致，清空时回退默认
+  const [wikiTimeoutSecs, setWikiTimeoutSecs] = useState<number | null>(300);
+  const [bbEnabled, setBbEnabled] = useState<boolean>(true);
+  const [activeTab, setActiveTab] = useState<'debounce' | 'prompt'>('debounce');
+
+  // 打开弹窗时从已加载的黑板数据初始化表单（原 handleOpenSettings 的内联逻辑下沉）。
+  // 配置由 GET /api/workspaces/{workspaceId}/blackboard 接口随内容一并返回（configData prop）。
+  useEffect(() => {
+    if (!open) return;
+    if (configData) {
+      setDebounceSecs(configData.blackboard_debounce_secs ?? 600);
+      setDebounceCount(configData.blackboard_debounce_count ?? 10);
+      setWikiPrompt(configData.wiki_prompt ?? '');
+      setWikiTimeoutSecs(configData.wiki_timeout_secs ?? 300);
+      setBbEnabled(configData.enabled ?? true);
+    } else {
+      setDebounceSecs(600);
+      setDebounceCount(10);
+      setWikiPrompt('');
+      setWikiTimeoutSecs(300);
+      setBbEnabled(true);
+    }
+    setActiveTab('debounce');
+  }, [open, configData]);
+
+  // 保存设置
+  const handleSaveSettings = useCallback(async () => {
+    setSettingsSaving(true);
+    try {
+      await updateBlackboardConfig(workspaceId, {
+        // 用户清空输入时 null → 用默认值，避免后端意外覆盖
+        blackboard_debounce_secs: debounceSecs ?? 600,
+        blackboard_debounce_count: debounceCount ?? 10,
+        wiki_prompt: wikiPrompt,
+        wiki_timeout_secs: wikiTimeoutSecs ?? 300,
+        enabled: bbEnabled,
+      });
+      // 保存成功后回写父组件缓存，避免下次打开弹窗读到旧值
+      if (configData) {
+        onSaved({
+          ...configData,
+          blackboard_debounce_secs: debounceSecs ?? 600,
+          blackboard_debounce_count: debounceCount ?? 10,
+          wiki_prompt: wikiPrompt,
+          wiki_timeout_secs: wikiTimeoutSecs ?? 300,
+          enabled: bbEnabled,
+        });
+      }
+      message.success('设置已保存');
+      onClose();
+    } catch (err) {
+      message.error('保存失败: ' + (err instanceof Error ? err.message : String(err)));
+    } finally {
+      setSettingsSaving(false);
+    }
+  }, [workspaceId, debounceSecs, debounceCount, wikiPrompt, wikiTimeoutSecs, bbEnabled, configData, onSaved, onClose]);
+
+  // 恢复默认提示词：把 wikiPrompt 设为内置默认值。
+  // 区别于"留空"的语义——留空表示后端使用内置默认；填入默认值表示用户显式采用内置模板。
+  const handleRestorePrompt = useCallback(() => {
+    setWikiPrompt(DEFAULT_WIKI_PROMPT);
+  }, []);
+
+  return (
+    <Modal
+      title="黑板设置"
+      open={open}
+      onOk={handleSaveSettings}
+      onCancel={onClose}
+      okText="保存"
+      confirmLoading={settingsSaving}
+      destroyOnHidden
+      width={isMobile ? '90%' : 640}
+    >
+      <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ fontSize: 14, fontWeight: 500 }}>启用黑板</span>
+        <Switch checked={bbEnabled} onChange={setBbEnabled} />
+      </div>
+      <Tabs
+        activeKey={activeTab}
+        onChange={(key) => setActiveTab(key as 'debounce' | 'prompt')}
+        items={[
+          {
+            key: 'debounce',
+            label: '防抖设置',
+            children: (
+              <DebounceSettingsTab
+                debounceSecs={debounceSecs}
+                setDebounceSecs={setDebounceSecs}
+                debounceCount={debounceCount}
+                setDebounceCount={setDebounceCount}
+                wikiTimeoutSecs={wikiTimeoutSecs}
+                setWikiTimeoutSecs={setWikiTimeoutSecs}
+              />
+            ),
+          },
+          {
+            key: 'prompt',
+            label: '提示词设置',
+            children: (
+              <PromptSettingsTab
+                wikiPrompt={wikiPrompt}
+                setWikiPrompt={setWikiPrompt}
+                onRestorePrompt={handleRestorePrompt}
+              />
+            ),
+          },
+        ]}
+      />
+    </Modal>
+  );
+}
+
+// ─── 设置弹窗子组件（避免 Tabs children 深层嵌套）─────────────────
+
+interface DebounceSettingsTabProps {
+  debounceSecs: number | null;
+  setDebounceSecs: (v: number | null) => void;
+  debounceCount: number | null;
+  setDebounceCount: (v: number | null) => void;
+  /** Wiki 执行超时（秒） */
+  wikiTimeoutSecs: number | null;
+  setWikiTimeoutSecs: (v: number | null) => void;
+}
+
+/** 防抖设置 Tab：防抖周期 + 触发条数 + Wiki 执行超时，受父组件状态控制 */
+function DebounceSettingsTab({ debounceSecs, setDebounceSecs, debounceCount, setDebounceCount, wikiTimeoutSecs, setWikiTimeoutSecs }: DebounceSettingsTabProps) {
+  return (
+    <Form layout="vertical" style={{ marginTop: 16 }}>
+      <Form.Item label="防抖周期">
+        <InputNumber
+          value={debounceSecs}
+          // 用户清空输入时 value=null，不立即回填默认值，只透传 null 给 state；
+          // 保存时由 handleSaveSettings 用 ?? 兜底，避免删值瞬间被 600 覆盖
+          onChange={(v) => setDebounceSecs(v)}
+          min={10}
+          max={3600}
+          addonAfter="秒"
+          style={{ width: 200 }}
+        />
+      </Form.Item>
+      <Form.Item label="触发条数">
+        <InputNumber
+          value={debounceCount}
+          onChange={(v) => setDebounceCount(v)}
+          min={1}
+          max={100}
+          addonAfter="条"
+          style={{ width: 200 }}
+        />
+      </Form.Item>
+      <Form.Item
+        label="Wiki 执行超时"
+        // 后端会把输入值钳制到 [60, 3600]，这里同步展示边界提示；
+        // 默认 300 秒（5 分钟），慢模型可调大避免被强制超时
+        extra="Wiki 自动维护与 Wiki 对话的最长执行时长（后端会自动钳制到 60–3600 秒），默认 300 秒"
+      >
+        <InputNumber
+          value={wikiTimeoutSecs}
+          onChange={(v) => setWikiTimeoutSecs(v)}
+          min={60}
+          max={3600}
+          addonAfter="秒"
+          style={{ width: 200 }}
+        />
+      </Form.Item>
+      <Form.Item extra="达到条数阈值或周期到期时，统一处理 pending 的 todo，减少频繁的 LLM 调用" />
+    </Form>
+  );
+}
+
+interface PromptSettingsTabProps {
+  wikiPrompt: string;
+  setWikiPrompt: (v: string) => void;
+  onRestorePrompt: () => void;
+}
+
+/** 提示词设置 Tab：单阶段 Wiki 提示词 */
+function PromptSettingsTab({
+  wikiPrompt, setWikiPrompt,
+  onRestorePrompt,
+}: PromptSettingsTabProps) {
+  return (
+    <div style={{ marginTop: 16 }}>
+      <div style={{ marginBottom: 20 }}>
+        <Space style={{ marginBottom: 8 }}>
+          <Button onClick={onRestorePrompt}>恢复默认</Button>
+          <span style={{ color: '#888', fontSize: 12 }}>
+            Wiki 提示词（单阶段：分析记录 + 直接编辑文件）
+          </span>
+        </Space>
+        <Input.TextArea
+          value={wikiPrompt}
+          onChange={(e) => setWikiPrompt(e.target.value)}
+          rows={16}
+          placeholder="留空使用内置默认，如需自定义请直接在此输入"
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/blackboard/api.ts
+++ b/frontend/src/components/blackboard/api.ts
@@ -1,0 +1,46 @@
+/**
+ * 黑板域数据拉取函数（096-W4-4：从 BlackboardPage 抽离为共享 API 层）。
+ *
+ * 顺带收敛：`fetchWikiFileContent` 原在 BlackboardPage 与 WikiViewPage 各存一份
+ * 逐字相同的定义，此处为唯一事实源。
+ *
+ * 均使用原生 fetch 并手动写 v1 路径（不经 axios 实例，与黑板域既有约定一致）。
+ */
+
+import type { BlackboardData, WikiFileContent, WikiFileItem } from './types';
+
+/** 拉取黑板配置数据（设置弹窗与队列查看的数据源） */
+export async function fetchBlackboardData(workspaceId: number): Promise<BlackboardData> {
+  const res = await fetch(`/api/v1/workspaces/${workspaceId}/blackboard`);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  const json = (await res.json()) as { data?: BlackboardData };
+  if (!json.data) {
+    throw new Error('Empty response body');
+  }
+  return json.data;
+}
+
+/** 拉取单个 Wiki 文件内容 */
+export async function fetchWikiFileContent(workspaceId: number, slug: string): Promise<WikiFileContent> {
+  const res = await fetch(`/api/v1/workspaces/${workspaceId}/wiki/files/${encodeURIComponent(slug)}`);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  const json = (await res.json()) as { data?: WikiFileContent };
+  if (!json.data) {
+    throw new Error('Empty response body');
+  }
+  return json.data;
+}
+
+/** 拉取 Wiki 文件列表 */
+export async function fetchWikiFiles(workspaceId: number): Promise<WikiFileItem[]> {
+  const res = await fetch(`/api/v1/workspaces/${workspaceId}/wiki/files`);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  const json = (await res.json()) as { data?: WikiFileItem[] };
+  return json.data ?? [];
+}

--- a/frontend/src/components/blackboard/types.ts
+++ b/frontend/src/components/blackboard/types.ts
@@ -1,0 +1,34 @@
+/**
+ * 黑板域共享类型（096-W4-4：从 BlackboardPage 抽离，供页面/弹窗/Hook 共同引用）。
+ */
+
+/** 黑板 API 返回的配置形状（与后端 BlackboardResponse 对应，不含内容） */
+export interface BlackboardData {
+  id: number;
+  workspace_id: number;
+  updated_at: string | null;
+  /** 黑板更新防抖周期（秒）*/
+  blackboard_debounce_secs: number;
+  /** 黑板更新防抖条数阈值 */
+  blackboard_debounce_count: number;
+  /** Wiki 更新提示词模板（单阶段） */
+  wiki_prompt: string;
+  /** Wiki 对话使用的执行器名称，空/undefined 表示使用默认值 claudecode */
+  wiki_chat_executor?: string | null;
+  /** Wiki 执行超时（秒），控制 Wiki 任务与 Wiki 对话的最长存活时间 */
+  wiki_timeout_secs: number;
+  /** 黑板功能总开关 */
+  enabled: boolean;
+}
+
+/** Wiki 文件列表项（对应后端 WikiFileItem） */
+export interface WikiFileItem {
+  slug: string;
+  file_type: 'index' | 'topic' | 'log' | string;
+}
+
+/** Wiki 文件内容（对应后端 WikiFileContent） */
+export interface WikiFileContent {
+  slug: string;
+  content: string;
+}

--- a/frontend/src/hooks/useBlackboardDebounceStatus.test.ts
+++ b/frontend/src/hooks/useBlackboardDebounceStatus.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBlackboardDebounceStatus } from './useBlackboardDebounceStatus';
+import type { BlackboardDebounceStatus } from '@/hooks/useExecutionEvents';
+
+/** 派发一个 blackboardDebounceStatus CustomEvent（模拟 useExecutionEvents 的桥接输出） */
+function fireStatus(detail: Partial<BlackboardDebounceStatus> & { workspace_id: number }) {
+  const full = {
+    pending_count: 0,
+    threshold: 10,
+    debounce_secs: 600,
+    remaining_secs: -1,
+    refreshing: false,
+    ...detail,
+  } as BlackboardDebounceStatus;
+  window.dispatchEvent(new CustomEvent('blackboardDebounceStatus', { detail: full }));
+}
+
+describe('useBlackboardDebounceStatus', () => {
+  it('接收匹配 workspace 的事件并更新状态', () => {
+    const { result } = renderHook(() => useBlackboardDebounceStatus(1));
+    expect(result.current).toBeNull();
+
+    act(() => {
+      fireStatus({ workspace_id: 1, pending_count: 5, threshold: 10 });
+    });
+    expect(result.current?.pending_count).toBe(5);
+  });
+
+  it('过滤其他 workspace 的事件（多空间并存不串台）', () => {
+    const { result } = renderHook(() => useBlackboardDebounceStatus(1));
+    act(() => {
+      fireStatus({ workspace_id: 2, pending_count: 9 });
+    });
+    expect(result.current).toBeNull();
+  });
+
+  it('workspaceId 变化时重新订阅（旧空间事件不再接收）', () => {
+    const { result, rerender } = renderHook(({ id }) => useBlackboardDebounceStatus(id), {
+      initialProps: { id: 1 },
+    });
+    act(() => {
+      fireStatus({ workspace_id: 1, pending_count: 3 });
+    });
+    expect(result.current?.pending_count).toBe(3);
+
+    rerender({ id: 2 });
+    // 状态保留最后一次值（hook 不主动清空——与原实现行为一致）；
+    // 但新事件只认 workspace 2
+    act(() => {
+      fireStatus({ workspace_id: 1, pending_count: 99 });
+    });
+    expect(result.current?.pending_count).toBe(3);
+    act(() => {
+      fireStatus({ workspace_id: 2, pending_count: 7 });
+    });
+    expect(result.current?.pending_count).toBe(7);
+  });
+
+  it('卸载时移除监听（不再接收事件）', () => {
+    const { result, unmount } = renderHook(() => useBlackboardDebounceStatus(1));
+    unmount();
+    act(() => {
+      fireStatus({ workspace_id: 1, pending_count: 42 });
+    });
+    // 卸载后 setStatus 不被调用：状态停留在卸载前的 null
+    expect(result.current).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useBlackboardDebounceStatus.ts
+++ b/frontend/src/hooks/useBlackboardDebounceStatus.ts
@@ -1,0 +1,34 @@
+/**
+ * useBlackboardDebounceStatus — 黑板防抖状态订阅 hook（096-W4-4 产物）。
+ *
+ * 原 BlackboardPage 中 MobileDebounceIndicator 与 BlackboardDebounceBar 各持有一份
+ * 逐字相同的 `blackboardDebounceStatus` 事件订阅（addEventListener + workspace_id
+ * 过滤 + setStatus + 卸载清理，约 9 行 ×2）。收敛为单份：任何 UI 想消费防抖状态，
+ * 直接调用本 hook，不再复制订阅样板。
+ *
+ * 事件源：`useExecutionEvents` 把后端 WS 事件桥接为 window CustomEvent。
+ */
+
+import { useEffect, useState } from 'react';
+import type { BlackboardDebounceStatus } from '@/hooks/useExecutionEvents';
+
+/**
+ * 订阅指定工作空间的黑板防抖状态。
+ * 仅接收 `workspace_id === workspaceId` 的事件；无事件时为 null（调用方通常据此不渲染）。
+ */
+export function useBlackboardDebounceStatus(workspaceId: number): BlackboardDebounceStatus | null {
+  const [status, setStatus] = useState<BlackboardDebounceStatus | null>(null);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const s = (e as CustomEvent<BlackboardDebounceStatus>).detail;
+      // 只关心当前工作空间的事件——多工作空间并存时避免串台
+      if (s.workspace_id !== workspaceId) return;
+      setStatus(s);
+    };
+    window.addEventListener('blackboardDebounceStatus', handler);
+    return () => window.removeEventListener('blackboardDebounceStatus', handler);
+  }, [workspaceId]);
+
+  return status;
+}

--- a/frontend/src/hooks/useBlackboardWiki.ts
+++ b/frontend/src/hooks/useBlackboardWiki.ts
@@ -1,0 +1,169 @@
+/**
+ * useBlackboardWiki — 黑板 Wiki 数据族 hook（096-W4-4 产物）。
+ *
+ * 承接原 BlackboardPage 主组件的整块数据逻辑：
+ * - 文件列表 / 当前文件内容 / 黑板配置（设置弹窗数据源）的加载与缓存；
+ * - 工作空间切换时的数据清空与重拉；
+ * - URL `blackboardFile` 参数与当前 slug 的双向同步入口；
+ * - latest-wins 竞态防护（切换工作空间/文件后晚到的响应直接丢弃）。
+ *
+ * 函数体逐字搬自主组件原实现，行为等价。
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { message } from 'antd';
+import { useViewState } from '@/hooks/useViewState';
+import { fetchBlackboardData, fetchWikiFileContent, fetchWikiFiles } from '@/components/blackboard/api';
+import type { BlackboardData, WikiFileContent, WikiFileItem } from '@/components/blackboard/types';
+
+export interface BlackboardWikiState {
+  files: WikiFileItem[];
+  currentFile: WikiFileContent | null;
+  currentSlug: string;
+  filesLoading: boolean;
+  fileLoading: boolean;
+  /** 黑板配置（设置弹窗的数据源；保存成功后由弹窗经 setConfigData 回写） */
+  configData: BlackboardData | null;
+  setConfigData: (d: BlackboardData | null) => void;
+  /** 切换当前页（slug）；URL 同步由调用方负责（保持与原实现分工一致） */
+  setCurrentSlug: React.Dispatch<React.SetStateAction<string>>;
+  /** 重拉文件列表（主题删除后调用——列表更新会自动切到剩余 topic） */
+  fetchFiles: () => Promise<void>;
+  /** 刷新：重拉列表 + 当前页面内容 */
+  refresh: () => void;
+}
+
+export function useBlackboardWiki(workspaceId: number): BlackboardWikiState {
+  // Wiki 化数据状态
+  const [files, setFiles] = useState<WikiFileItem[]>([]);
+  const [currentFile, setCurrentFile] = useState<WikiFileContent | null>(null);
+  const [currentSlug, setCurrentSlug] = useState<string>('');
+  const [filesLoading, setFilesLoading] = useState(true);
+  const [fileLoading, setFileLoading] = useState(false);
+  // 旧版数据（配置用）
+  const [configData, setConfigData] = useState<BlackboardData | null>(null);
+
+  // URL 中的 blackboardFile（浏览器前进后退同步源）
+  const { blackboardFile } = useViewState();
+
+  // 防切换竞态：ref 始终持有「最新一次渲染」的 workspaceId / currentSlug。
+  // fetch 回调在 await 前捕获闭包里的旧 key，resolve 后与 ref 比较——
+  // 不一致说明期间已切换工作空间/文件，晚到的响应直接丢弃，避免覆盖新工作空间的数据。
+  // 与 useLoopExecutions/useExecutionHistory 的 cancelledRef 思路一致（latest-wins）。
+  const latestWorkspaceIdRef = useRef(workspaceId);
+  latestWorkspaceIdRef.current = workspaceId;
+  const latestSlugRef = useRef(currentSlug);
+  latestSlugRef.current = currentSlug;
+
+  // 拉取页面列表
+  const fetchFiles = useCallback(async () => {
+    // 捕获本次请求所属的工作空间，resolve 后与最新值比较，防止切换后旧响应覆盖新数据
+    const ws = workspaceId;
+    try {
+      setFilesLoading(true);
+      const list = await fetchWikiFiles(ws);
+      if (latestWorkspaceIdRef.current !== ws) return; // 已切换到别的工作空间，丢弃
+      setFiles(list);
+      // 计算默认 slug：优先 topic，其次 log，都没有则空
+      const defaultSlug = list.find(f => f.file_type === 'topic')?.slug
+        ?? list.find(f => f.file_type === 'log')?.slug
+        ?? '';
+      // 用函数式更新读取最新 currentSlug，避免将其放入依赖数组而每次切页重拉列表
+      setCurrentSlug(prev => (list.some(p => p.slug === prev) ? prev : defaultSlug));
+    } catch (err) {
+      if (latestWorkspaceIdRef.current !== ws) return; // 切换后的错误也不弹窗
+      console.error('获取页面列表失败:', err);
+      message.error('获取页面列表失败');
+    } finally {
+      // 仅当仍是本次请求的工作空间时才动 loading，避免把新工作空间的 loading 提前置 false
+      if (latestWorkspaceIdRef.current === ws) setFilesLoading(false);
+    }
+  }, [workspaceId]);
+
+  // 拉取当前页面详情
+  const fetchCurrentFile = useCallback(async () => {
+    // 捕获本次请求所属的工作空间 + slug，resolve 后与最新值比较，防切换竞态
+    const ws = workspaceId;
+    const slug = currentSlug;
+    // 空 slug 不发起请求：初始态或切换工作空间清空后，slug 为空字符串，
+    // 此时请求会得到 404 或意外数据，应直接跳过。
+    if (!slug) {
+      setFileLoading(false);
+      return;
+    }
+    try {
+      setFileLoading(true);
+      const file = await fetchWikiFileContent(ws, slug);
+      if (latestWorkspaceIdRef.current !== ws || latestSlugRef.current !== slug) return;
+      setCurrentFile(file);
+    } catch (err) {
+      if (latestWorkspaceIdRef.current !== ws || latestSlugRef.current !== slug) return;
+      console.error('获取页面详情失败:', err);
+      setCurrentFile(null);
+    } finally {
+      if (latestWorkspaceIdRef.current === ws && latestSlugRef.current === slug) setFileLoading(false);
+    }
+  }, [workspaceId, currentSlug]);
+
+  // 拉取配置（旧版接口，只用于设置弹窗）
+  const fetchConfig = useCallback(async () => {
+    const ws = workspaceId;
+    try {
+      const fetched = await fetchBlackboardData(ws);
+      if (latestWorkspaceIdRef.current !== ws) return; // 已切换，丢弃旧响应
+      setConfigData(fetched);
+    } catch (err) {
+      if (latestWorkspaceIdRef.current !== ws) return;
+      console.error('获取黑板配置失败:', err);
+    }
+  }, [workspaceId]);
+
+  // workspace 切换时先清空隔离数据，避免加载失败或加载窗口期暴露上一工作空间内容
+  // 注意：不设 currentSlug = ''，否则 Menu 收到 selectedKeys={['']} 会崩溃
+  //（Ant Design Menu.js:40 prefixCls → Cannot read properties of null）。
+  // files 已清空 → Menu 不渲染（files.length === 0 显示"暂无页面"），
+  // fetchFiles 异步完成后会自动设回有效 slug。
+  useEffect(() => {
+    setFiles([]);
+    setCurrentFile(null);
+    setConfigData(null);
+  }, [workspaceId]);
+
+  // 副作用：workspaceId 变化时重拉
+  useEffect(() => {
+    fetchFiles();
+    fetchConfig();
+  }, [fetchFiles, fetchConfig]);
+
+  // URL 中的 blackboardFile 变化时，同步到 currentSlug（支持浏览器前进后退）
+  useEffect(() => {
+    if (blackboardFile) {
+      setCurrentSlug(blackboardFile);
+    }
+  }, [blackboardFile]);
+
+  // 副作用：currentSlug 变化时重拉页面详情
+  // 守卫已在 fetchCurrentFile 内部处理空 slug 场景
+  useEffect(() => {
+    fetchCurrentFile();
+  }, [fetchCurrentFile]);
+
+  // 刷新：重新拉取列表和当前页面
+  const refresh = useCallback(() => {
+    fetchFiles();
+    fetchCurrentFile();
+  }, [fetchFiles, fetchCurrentFile]);
+
+  return {
+    files,
+    currentFile,
+    currentSlug,
+    filesLoading,
+    fileLoading,
+    configData,
+    setConfigData,
+    setCurrentSlug,
+    fetchFiles,
+    refresh,
+  };
+}

--- a/frontend/tests/096-w4-blackboard-split.spec.ts
+++ b/frontend/tests/096-w4-blackboard-split.spec.ts
@@ -1,0 +1,55 @@
+// 096-W4-4 冒烟：BlackboardPage 拆分（useBlackboardWiki / SettingsModal / DebounceStatus hook）后的行为等价验证。
+// 验证点：页面装配、文件列表渲染、设置弹窗开合与表单初始化、保存链路——
+// 这些路径的 state 全部经过了 hook/子组件下沉，本冒烟即为外层行为锚点。
+import { test, expect } from '@playwright/test';
+
+test.describe('BlackboardPage 拆分冒烟', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:18088/#/blackboard?workspace=1');
+    // 页面标题出现即组件树就绪
+    await page.getByText('黑板', { exact: true }).first().waitFor();
+  });
+
+  test('页面装配：标题/操作按钮/布局渲染', async ({ page }) => {
+    // 设置与刷新按钮存在（handleOpenSettings / refresh 已由 hook 与单行 callback 承接）
+    await expect(page.getByTitle('设置').first()).toBeVisible();
+    await expect(page.getByTitle('刷新').first().or(page.getByRole('button', { name: '刷新' }))).toBeVisible();
+  });
+
+  test('文件列表加载渲染（useBlackboardWiki 数据通路）', async ({ page }) => {
+    // 初始拉取完成后 Skeleton 消失、目录区容器渲染（有数据出树、无数据出空态——两者都算链路走通）
+    await expect(page.locator('.ant-skeleton-active')).toHaveCount(0, { timeout: 10000 });
+    await expect(page.locator('.ant-menu, .ant-empty').first()).toBeVisible();
+  });
+
+  test('设置弹窗：打开→表单初始化→关闭（state 下沉后行为）', async ({ page }) => {
+    await page.getByTitle('设置').first().click();
+    // 弹窗打开，启用开关与 Tabs 渲染（表单 state 由弹窗内 useEffect 从 configData 初始化）
+    const modal = page.locator('.ant-modal');
+    await expect(modal.getByText('黑板设置')).toBeVisible();
+    await expect(modal.getByText('启用黑板')).toBeVisible();
+    await expect(modal.getByRole('tab', { name: '防抖设置' })).toBeVisible();
+    await expect(modal.getByRole('tab', { name: '提示词设置' })).toBeVisible();
+    // 防抖周期输入框应有初始化值（configData 或默认 600）
+    const input = modal.locator('input').first();
+    await expect(input).toBeVisible();
+    // 切换到提示词 Tab
+    await modal.getByRole('tab', { name: '提示词设置' }).click();
+    await expect(modal.getByRole('button', { name: '恢复默认' })).toBeVisible();
+    // 关闭
+    await modal.getByRole('button', { name: 'Cancel' }).or(page.locator('.ant-modal-close')).first().click().catch(async () => {
+      await page.keyboard.press('Escape');
+    });
+  });
+
+  test('设置保存链路：修改防抖周期并保存成功（into_active 回写）', async ({ page }) => {
+    await page.getByTitle('设置').first().click();
+    const modal = page.locator('.ant-modal');
+    await expect(modal.getByText('黑板设置')).toBeVisible();
+    // 直接保存（表单已有初始化值），验证保存链路（updateBlackboardConfig + onSaved 回写）
+    // antd Modal 的 OK 按钮中文两字可能被插空格，用 footer 主按钮定位最稳
+    await modal.locator('.ant-modal-footer button.ant-btn-primary').click();
+    // 成功提示出现证明保存链路走通
+    await expect(page.getByText('设置已保存')).toBeVisible({ timeout: 8000 });
+  });
+});


### PR DESCRIPTION
## 实现了什么

096 分步方案 **W4-4（前端 God 组件拆分）第一项：BlackboardPage**（1286 行、29 useState；扫描报告 E 组实证含防抖订阅逐字重复两段）。

三线下沉（主组件 1286 → 855 行，页面状态 29 → 2 个 UI state）：

| 新建设施 | 承接内容 |
|---|---|
| `hooks/useBlackboardWiki.ts` | Wiki 数据族 5 state + latest-wins 竞态 ref 族 + fetch/清空/URL 同步 useEffect 族（逐字搬迁） |
| `hooks/useBlackboardDebounceStatus.ts` | MobileDebounceIndicator ≡ BlackboardDebounceBar 两处逐字订阅（9 行×2）收敛单份，+4 项单测 |
| `blackboard/BlackboardSettingsModal.tsx` | 设置族 8 state + 保存/恢复 handler + Modal/两 Tab 子组件整组下沉（主组件仅剩 open 开关） |
| `blackboard/types.ts` + `api.ts` | 3 接口 + 3 fetch 函数；**顺带统一 WikiViewPage 的逐字重复定义** |

另删除 `useStateBlackboardData` 无价值包装（useState 直接转发，YAGNI）。

## 测试与验证结果

- `npx tsc --noEmit`：**零错误**；`npm run build` 通过。
- `vitest run`：**44 文件 / 366 用例全过**（含新增 hook 4 项）。
- **Playwright 冒烟**（新增 `tests/096-w4-blackboard-split.spec.ts`，dev 实例实测）：**4/4 通过**——页面装配、列表加载（useBlackboardWiki 数据通路）、设置弹窗开合与表单初始化、保存链路（updateBlackboardConfig + onSaved 回写）。

## 已知限制

- 无行为变化声明项。回退方式：单 PR revert。
