### PR TITLE
docs(096): W4 剩余项实施设计（101）——W4-4-3/W4-4-4/W4-6 执行级设计

### DIFF
--- a/docs/design/101-096-W4剩余项实施设计.md
+++ b/docs/design/101-096-W4剩余项实施设计.md
@@ -1,0 +1,163 @@
+# 101 — 096-W4 剩余项实施设计（W4-4-3 / W4-4-4 / W4-6）
+
+> 依据：`docs/design/096-代码质量重构分步方案.md`（W4 波次）+ `docs/代码质量全景扫描报告-20260811.md`（E 组 / C3 实证）。
+> 本文档是三项剩余工作的执行级设计：拆分边界、文件落点、步骤、验证与风险。
+> 撰写时点：2026-08-13（W4-4-1 BlackboardPage、W4-4-2 SkillMarketplace 已完成后的基线）。
+
+## 总览
+
+| 项 | 对象 | 现状 | 手法 | 风险 |
+|---|---|---|---|---|
+| W4-4-3 | `ExecutorsPanel.tsx` | 942 行、24 useState、4 个 pending-by-name state + 5 处同构行内保存 | 自定义 hook 族 + 行内保存收敛 | 中 |
+| W4-4-4 | `ProcessEditor.tsx` | 704 行（前端 God 组件盘点第 4 位） | 子组件拆 UI 区块 + hook 收口 | 中 |
+| W4-6 | spawn 三平行实现 | `message_debounce::handle_default_response_executor`（~132 行）∥ `blackboard::spawn_executor_for_chat_streaming`（~154 行）∥ `run_todo_execution` 链路 | Extract Class `DirectExecutorSession` | 中-高 |
+
+---
+
+## W4-4-3：ExecutorsPanel.tsx 拆分
+
+### 实证（当前行号，main `391dd400` 基线）
+
+- 942 行、24 个 useState，四类职责混居：
+  1. **执行器列表族**（27-31）：`executors` / `executorsLoading` / `detectResults` / `detectingExecutor` / `testingExecutor` / `batchDetecting`
+  2. **行内编辑族**（35-42）：`savingExecutor` / `settingDefaultExecutor` / `executorModels` / `modelsLoading`——**4 个 pending-by-name state**（扫描 E 组实证）
+  3. **行内保存同构 ×5**（365-437）：5 处 `onBlur + onPressEnter` 双触发保存块，逐字同构（blur 时保存、Enter 时 blur）
+  4. **全局配置族**（69-83）：`configSaving` / `executionTimeoutSecs` / `usageStatsEnabled` / `usageStatsCron` / `usageStatsLoading` / `usageStatsSaving`
+  5. **运行监控族**（88-92）：`recordTodos` / `runningTab` / `selectedRecordIds` / `stoppingRecords` / `runningRecords`
+
+### 拆分设计
+
+**落点**（延续 W4-4 前两项的 hook 收口范式）：
+
+| 新建设施 | 承接 |
+|---|---|
+| `hooks/useExecutorAdmin.ts` | 执行器列表族 + 检测/测试/批量检测 handler 族（`detectingExecutor`/`testingExecutor` 两 pending-by-name 内聚） |
+| `hooks/useExecutorFieldSaver.ts` | **行内保存收敛核心**：`saveExecutorField(name, patch)` 单函数 + 同构 blur/Enter 双触发的封装 hook `useInlineFieldSave(name, saver)`——5 处同构块各塌为一行调用 |
+| `hooks/useRunningRecords.ts` | 运行监控族（recordTodos/runningRecords/selectedRecordIds/stoppingRecords + runningTab） |
+| `components/settings/executors/GlobalConfigSection.tsx` | 全局配置族（超时/usage_stats  cron 两块表单 UI + 保存逻辑）子组件化 |
+
+**关键设计决策**：
+
+- **行内保存同构收敛**（本项核心实证）：5 处 `onBlur={async (e) => {...save...}}` + `onPressEnter={(e) => blur()}` 逐字同构块，收敛为
+  `useInlineFieldSave(executorName, fieldSaver)` 返回 `{ onBlur, onPressEnter, saving }` 三件套——
+  新增行内编辑字段时不再复制双触发样板。
+- pending-by-name 4 个 state（`savingExecutor`/`settingDefaultExecutor` 等 `string | null`）保留原语义（同名互斥 loading），仅内聚进 hook，不强行 useReducer 化（行为零风险优先）。
+
+### 步骤
+
+1. 建 `useExecutorAdmin`（列表+检测/测试 handler 搬迁）；
+2. 建 `useExecutorFieldSaver`（收敛 5 处同构行内保存，含 saving 态）；
+3. 建 `useRunningRecords` + `GlobalConfigSection` 子组件；
+4. 主组件改调用（目标 942 → ~550 行）。
+
+### 验证
+
+`npx tsc --noEmit` 零错误；vitest 全过；Playwright 冒烟（设置→执行器面板：列表渲染/行内编辑保存/检测按钮/默认切换）。
+
+### 风险与回退
+
+中：行内保存的 blur/Enter 双触发时序敏感（保存竞态由原实现的 savingExecutor 互斥保证，搬迁时逐字保留）。单 PR revert。
+
+---
+
+## W4-4-4：ProcessEditor.tsx 拆分（第 4 组件）
+
+### 盘点确认（main `391dd400` 基线）
+
+方案快照的第 4 组件（TodoTable/ExpertManager/FeishuBotManager/LoopsPage）已经历多轮治理演变。
+当前前端行数排名（排除已拆/已治理项）：
+
+| 排名 | 文件 | 行数 | 备注 |
+|---|---|---|---|
+| 1 | SkillMarketplace.tsx | 1216 | W4-4-2 拆分中（#1043） |
+| 2 | ExecutorsPanel.tsx | 942 | W4-4-3（本设计上一节） |
+| 3 | BlackboardPage.tsx | 855 | W4-4-1 已拆 |
+| 4 | **ProcessEditor.tsx** | **704** | **本项对象** |
+| 5 | ProfilesPanel.tsx | 667 | ADR005-H5 已治理（providers Facade） |
+| 6 | TodoCenterCard.tsx | 636 | 备选 |
+
+### 拆分设计（探查后补充细节）
+
+- 先读 ProcessEditor 的 state 分布与 UI 区块（工艺编辑器：节点画布 + 属性表单 + 模板区）；
+- 手法与前三项同：自定义 hook 收口状态族 + 按 UI 区块 Extract 子组件；
+- `process/propertyForms/` 已有拆分子组件先例（LinkPropertyForm 614 行已是独立文件），延续该目录风格。
+
+### 验证
+
+tsc 零错误；vitest 全过；Playwright 冒烟（工艺编辑器打开/编辑属性/保存）。
+
+### 风险与回退
+
+中（编辑器画布交互复杂）。单 PR revert。
+
+---
+
+## W4-6：spawn 三平行收敛 `DirectExecutorSession`
+
+### 实证（当前行号，main 基线）
+
+三处「spawn 子进程 + 流式读 stdout/stderr + 超时控制 + session 提取」平行实现：
+
+| 实现 | 位置 | 体量 | 特征 |
+|---|---|---|---|
+| A | `services/message_debounce.rs::handle_default_response_executor`（1551 起） | ~132 行 | 12 参（挂 allow）；飞书默认响应通路；内含 `spawn_executor_child`（1272）+ 流式读 + 超时 + `session_util::extract_session_from_logs`（W1-PR3 收口点） |
+| B | `services/blackboard.rs::spawn_executor_for_chat_streaming`（682 起） | ~154 行 | 9 参；wiki chat 通路；同构骨架 |
+| C | `executor_service::run_todo_execution` 链路 | 编排壳 23 行 | 主执行通路（spawn_lifecycle/run_inner 已治理）——平行的「spawn+读流」核心在 spawn_lifecycle 内 |
+
+**霰弹实证**：执行器行为变更（如新增 env 注入、超时策略调整、session 提取协议变化）要同步改 A/B/C 三处。例：W1-PR1 的 extract_stderr 差异、W1-PR3 的 session 提取，均涉及多处平行代码的同步修改。
+
+### 收敛设计
+
+**新建 `services/executor_session.rs`：`DirectExecutorSession`**
+
+```text
+pub(crate) struct DirectExecutorSession {
+    /// 产物流：日志条目 / 最终输出 / session_id / 是否超时
+}
+
+impl DirectExecutorSession {
+    /// spawn + 流式读 + 超时 + session 提取 的统一骨架
+    pub(crate) async fn spawn_and_stream(config: SessionSpawnConfig) -> Result<SessionOutcome>
+}
+
+pub(crate) struct SessionSpawnConfig {
+    executor: Arc<dyn CodeExecutor>,
+    message: String,
+    cwd: PathBuf,
+    task_id: String,
+    workspace_id: i64,
+    tx: broadcast::Sender<ExecEvent>,
+    session_id: Option<String>,
+    timeout_secs: u64,
+    /// 通路差异点（飞书/wiki chat/主链路）经少量参数化承接
+}
+```
+
+**迁移顺序（风险升序）**：
+1. B（blackboard wiki chat）先行迁移验证——通路最简单（单函数 154 行）；
+2. A（message_debounce 飞书默认响应）跟进——12 参函数体塌缩为 SessionSpawnConfig 组装 + 一行调用；
+3. C（主执行链路 spawn_lifecycle 内联段）最后——与主链路的事务/事件管线耦合最深，单独 commit。
+
+### 步骤
+
+1. 定义 `SessionSpawnConfig` + `SessionOutcome` + `DirectExecutorSession::spawn_and_stream`（以 B 的实现为模板——它最完整）；
+2. B 迁移 + wiki chat 通路测试；
+3. A 迁移 + 飞书通路测试；
+4. C 内联段收敛（若评估后耦合过深可保留——在 PR 中如实声明）；
+5. 三通路回归：对应既有测试全过 + 真实通路冒烟（wiki chat 发一条消息、飞书默认响应一条——飞书无凭证环境下以 wiki chat 冒烟为下限）。
+
+### 验证
+
+`cargo clippy --all-targets -- -D warnings` 零告警；全量测试过；wiki chat 真实通路冒烟（dev 实例 /wiki chat 发消息走通）。
+
+### 风险与回退
+
+**中-高**（方案原评）：执行器子进程生命周期管理是核心路径，超时/取消/session 续接任何一环偏差都会影响在途任务。分通路独立 commit（B/A 各一、C 一），可分别 revert；C 若耦合过深允许保留现状并在 PR 声明（部分达成）。
+
+---
+
+## 执行纪律（延续 096 方案）
+
+- 每项独立 PR；先设计后代码（本文档即设计依据）；
+- `cargo clippy --all-targets -- -D warnings` 零告警 + 全量测试护航；前端 `npx tsc --noEmit` 零错误 + Playwright 冒烟；
+- CodeRabbit 评审全处理后合入，合并后清理分支。


### PR DESCRIPTION
## 内容

096 方案 W4 波次剩余三项的执行级设计文档（`docs/design/101-096-W4剩余项实施设计.md`），按 096 执行纪律「先文档后代码」要求先行入库：

| 项 | 对象 | 设计要点 |
|---|---|---|
| W4-4-3 | `ExecutorsPanel.tsx`（942 行、24 state） | 五族归域 + 5 处同构行内保存收敛为 `useInlineFieldSave`（onBlur/onPressEnter 双触发样板单点化） |
| W4-4-4 | `ProcessEditor.tsx`（704 行） | 第 4 组件盘点确认（main `391dd400` 基线行数排名），hook 收口 + UI 区块拆子组件 |
| W4-6 | spawn 三平行收敛 | A（message_debounce 132 行）/B（blackboard wiki chat 154 行）/C（主链路）实测体量；`DirectExecutorSession` + `SessionSpawnConfig`/`SessionOutcome` 接口设计；迁移顺序 B→A→C 风险升序 |

每项含：实证行号（当前基线实测）、拆分/收敛边界、步骤分解、验证方式、风险与回退。

## 说明

纯文档 PR，无代码改动。后续三项开工即以本文档为设计依据。
