### PR TITLE
refactor(103): 后端状态字面量枚举化——路线 A（D5/D6/D7 三域）

### DIFF
--- a/backend/src/db/execution.rs
+++ b/backend/src/db/execution.rs
@@ -1669,15 +1669,17 @@ impl Database {
 
     // ===== 自动评审辅助方法 =====
 
-    /// 写入/更新原执行记录的 last_review_status 字段（pending/success/failed/interrupted/skipped）.
+    /// 写入/更新原执行记录的 last_review_status 字段。
+    /// 形参收 ReviewStatus 枚举（D7 收口）——杜绝调用方传裸串拼写错误导致的 silent drift；
+    /// DB 仍存 String（as_str 锁原字面量），行为逐字节不变。
     pub async fn set_record_last_review_status(
         &self,
         record_id: i64,
-        status: &str,
+        status: crate::models::ReviewStatus,
     ) -> Result<(), sea_orm::DbErr> {
         let am = execution_records::ActiveModel {
             id: ActiveValue::Unchanged(record_id),
-            last_review_status: ActiveValue::Set(Some(status.to_string())),
+            last_review_status: ActiveValue::Set(Some(status.as_str().to_string())),
             ..Default::default()
         };
         self.exec_update(am).await
@@ -1698,17 +1700,17 @@ impl Database {
 
     /// 评审实例完成时调用: 把评审实例的 source_execution_record_id 指向"原那条",
     /// 并把 last_review_status 设为终态 (success/failed/interrupted).
-    /// 同步更新原记录的 last_review_status.
+    /// 同步更新原记录的 last_review_status. final_status 收 ReviewStatus 枚举（D7 收口）。
     pub async fn link_review_to_source(
         &self,
         review_record_id: i64,
         source_record_id: i64,
-        final_status: &str,
+        final_status: crate::models::ReviewStatus,
     ) -> Result<(), sea_orm::DbErr> {
         let am = execution_records::ActiveModel {
             id: ActiveValue::Unchanged(review_record_id),
             source_execution_record_id: ActiveValue::Set(Some(source_record_id)),
-            last_review_status: ActiveValue::Set(Some(final_status.to_string())),
+            last_review_status: ActiveValue::Set(Some(final_status.as_str().to_string())),
             ..Default::default()
         };
         self.exec_update(am).await

--- a/backend/src/db/loop_.rs
+++ b/backend/src/db/loop_.rs
@@ -1070,13 +1070,14 @@ impl Database {
     pub async fn finalize_phase_executions(
         &self,
         loop_execution_id: i64,
-        status: &str,
+        status: crate::models::LoopPhaseExecutionStatus,
     ) -> Result<(), sea_orm::DbErr> {
         use sea_orm::{ConnectionTrait, Statement};
-        let phase_status = if status == "success" {
-            "success"
-        } else {
-            "failed"
+        // 收尾语义：仅 success 让 phase 成功，其余（failed/partial/capped 等，由调用方按 loop
+        // 终态映射后传入）一律归 failed——保留原 `if status=="success"` 的二值归一，逐字节不变。
+        let phase_status = match status {
+            crate::models::LoopPhaseExecutionStatus::Success => "success",
+            _ => "failed",
         };
         let sql = format!(
             "UPDATE loop_phase_executions SET status = '{}', finished_at = ?1 \
@@ -3011,7 +3012,7 @@ mod loop_phase_finalization_tests {
         let db = fresh_db().await;
         let (exec_id, _phase_id) = seed_running_phase(&db).await;
 
-        db.finalize_phase_executions(exec_id, "success")
+        db.finalize_phase_executions(exec_id, crate::models::LoopPhaseExecutionStatus::Success)
             .await
             .expect("finalize");
 
@@ -3034,7 +3035,7 @@ mod loop_phase_finalization_tests {
         let db = fresh_db().await;
         let (exec_id, _phase_id) = seed_running_phase(&db).await;
 
-        db.finalize_phase_executions(exec_id, "failed")
+        db.finalize_phase_executions(exec_id, crate::models::LoopPhaseExecutionStatus::Failed)
             .await
             .expect("finalize");
 

--- a/backend/src/db/process_artifact.rs
+++ b/backend/src/db/process_artifact.rs
@@ -88,17 +88,20 @@ impl Database {
             gate_type: ActiveValue::Set(gate_type.to_string()),
             gate_name: ActiveValue::Set(gate_name.to_string()),
             config: ActiveValue::Set(config.to_string()),
-            status: ActiveValue::Set("pending".to_string()),
+            // 初始态 pending 走 D6 枚举（LoopGateStatus），与 update 写入侧共享同一词汇表。
+            status: ActiveValue::Set(crate::models::LoopGateStatus::Pending.as_str().to_string()),
             ..Default::default()
         };
         am.insert(&self.conn).await
     }
 
     /// 更新门禁评价结果（状态、结果 JSON、评价时间、评价者）。
+    /// status 收 LoopGateStatus 枚举（D6 收口）——杜绝调用方传裸串拼写错误；
+    /// DB 仍存 String（as_str 锁原字面量），行为逐字节不变。
     pub async fn update_loop_step_execution_gate(
         &self,
         id: i64,
-        status: &str,
+        status: crate::models::LoopGateStatus,
         result: Option<&str>,
         evaluated_by: Option<&str>,
     ) -> Result<(), sea_orm::DbErr> {
@@ -107,7 +110,7 @@ impl Database {
             .await?;
         if let Some(c) = existing {
             let mut am: loop_step_execution_gates::ActiveModel = c.into();
-            am.status = ActiveValue::Set(status.to_string());
+            am.status = ActiveValue::Set(status.as_str().to_string());
             am.result = ActiveValue::Set(result.map(|s| s.to_string()));
             am.evaluated_at = ActiveValue::Set(Some(utc_timestamp()));
             am.evaluated_by = ActiveValue::Set(evaluated_by.map(|s| s.to_string()));

--- a/backend/src/executor_service/auto_review.rs
+++ b/backend/src/executor_service/auto_review.rs
@@ -114,13 +114,15 @@ async fn mark_review_failed(
     record_id: i64,
     todo_id: i64,
 ) {
+    use crate::models::ReviewStatus;
+    // review 状态走枚举，杜绝拼写 silent drift；事件字段仍 String（对外契约不变）。
     let _ = db
-        .set_record_last_review_status(record_id, "failed")
+        .set_record_last_review_status(record_id, ReviewStatus::Failed)
         .await;
     let _ = tx.send(ExecEvent::ReviewStatusChanged {
         record_id,
         todo_id,
-        review_status: "failed".to_string(),
+        review_status: ReviewStatus::Failed.as_str().to_string(),
     });
 }
 
@@ -131,13 +133,14 @@ async fn mark_review_skipped(
     record_id: i64,
     todo_id: i64,
 ) {
+    use crate::models::ReviewStatus;
     let _ = db
-        .set_record_last_review_status(record_id, "skipped")
+        .set_record_last_review_status(record_id, ReviewStatus::Skipped)
         .await;
     let _ = tx.send(ExecEvent::ReviewStatusChanged {
         record_id,
         todo_id,
-        review_status: "skipped".to_string(),
+        review_status: ReviewStatus::Skipped.as_str().to_string(),
     });
 }
 
@@ -231,7 +234,7 @@ async fn load_and_validate_record(
     todo_id: i64,
     record_id: i64,
 ) -> Result<crate::models::ExecutionRecord, String> {
-    use crate::models::ExecutionStatus;
+    use crate::models::{ExecutionStatus, ReviewStatus};
     let record = match db.get_execution_record(record_id).await {
         Ok(Some(r)) => r,
         Ok(None) => return Err(format!("record #{} not found", record_id)),
@@ -241,7 +244,11 @@ async fn load_and_validate_record(
         mark_review_skipped(db, tx, record_id, todo_id).await;
         return Err("skipped: record not in terminal state".to_string());
     }
-    if record.last_review_status.as_deref() == Some("success") {
+    // 已评审过的记录不重复评审——last_review_status 列经 from_db 解析回枚举再比较，
+    // 避免裸串 "success" 与写入侧枚举脱钩（典型 Primitive Obsession 修复）。
+    if record.last_review_status.as_deref().and_then(ReviewStatus::from_db)
+        == Some(ReviewStatus::Success)
+    {
         // 避免重复评审；不算错误，直接返回。
         return Err("skipped: already reviewed".to_string());
     }
@@ -341,12 +348,15 @@ async fn mark_review_pending(
     record_id: i64,
     todo_id: i64,
 ) {
-    let _ = db.set_record_last_review_status(record_id, "pending").await;
+    use crate::models::ReviewStatus;
+    let _ = db
+        .set_record_last_review_status(record_id, ReviewStatus::Pending)
+        .await;
     let _ = db.set_record_last_reviewed_at(record_id).await;
     let _ = tx.send(ExecEvent::ReviewStatusChanged {
         record_id,
         todo_id,
-        review_status: "pending".to_string(),
+        review_status: ReviewStatus::Pending.as_str().to_string(),
     });
 }
 
@@ -456,16 +466,18 @@ async fn poll_review_to_terminal(
     let max_wait = std::time::Duration::from_secs(300);
     let poll = std::time::Duration::from_millis(500);
     let start = std::time::Instant::now();
+    // review 终态走 ReviewStatus 枚举（D7）——超时分支与正常 break 后的映射统一收口。
+    use crate::models::ReviewStatus;
     let final_review = loop {
         if start.elapsed() > max_wait {
             tracing::warn!("auto-review record #{} timed out", review_record_id);
             let _ = db
-                .set_record_last_review_status(record_id, "failed")
+                .set_record_last_review_status(record_id, ReviewStatus::Failed)
                 .await;
             let _ = tx.send(ExecEvent::ReviewStatusChanged {
                 record_id,
                 todo_id,
-                review_status: "failed".to_string(),
+                review_status: ReviewStatus::Failed.as_str().to_string(),
             });
             return;
         }
@@ -477,29 +489,32 @@ async fn poll_review_to_terminal(
         tokio::time::sleep(poll).await;
     };
 
-    let review_status_str = match final_review.status {
-        ExecutionStatus::Success => "success",
-        ExecutionStatus::Failed => "failed",
-        _ => "interrupted",
+    // 执行终态 → review 终态：Success/Failed 直映，其余（Running 不会到这、超时已 return）
+    // 归 Interrupted——不能默认 Failed，否则把「未完成」误标成「评审不通过」。
+    let review_status = match final_review.status {
+        ExecutionStatus::Success => ReviewStatus::Success,
+        ExecutionStatus::Failed => ReviewStatus::Failed,
+        _ => ReviewStatus::Interrupted,
     };
     let rating = parse_rating_from_result(final_review.result.as_deref());
     if let Some(r) = rating {
         let _ = db.update_execution_record_rating(record_id, Some(r)).await;
     }
     let _ = db
-        .link_review_to_source(review_record_id, record_id, review_status_str)
+        .link_review_to_source(review_record_id, record_id, review_status)
         .await;
     let _ = db
-        .set_record_last_review_status(record_id, review_status_str)
+        .set_record_last_review_status(record_id, review_status)
         .await;
+    // 事件字段仍 String（对外契约不变），枚举经 as_str() 回到原字面量。
     let _ = tx.send(ExecEvent::ReviewStatusChanged {
         record_id,
         todo_id,
-        review_status: review_status_str.to_string(),
+        review_status: review_status.as_str().to_string(),
     });
     tracing::info!(
         "auto-review done: original_todo=#{} record=#{} review_record=#{} status={} rating={:?}",
-        todo_id, record_id, review_record_id, review_status_str, rating
+        todo_id, record_id, review_record_id, review_status, rating
     );
 }
 

--- a/backend/src/handlers/process.rs
+++ b/backend/src/handlers/process.rs
@@ -977,12 +977,15 @@ pub async fn approve_gate(
     let step_exec = load_pending_step_execution(&state, loop_id, eid, seid).await?;
     validate_pending_human_gate(&state, seid, gid).await?;
 
+    use crate::models::LoopGateStatus;
     // 布尔审批映射为环节终态与展示评分：通过→success/100，拒绝→failed/0。
     // 评分 0 配合 resume 的 status 判定（不再用 rating>=min_rating），拒绝不会误判为通过。
-    let (gate_status, final_status, rating) = if req.approved {
-        ("passed", "success", 100)
+    // gate_status 走 D6 枚举（LoopGateStatus）；final_status 是 step 终态（D4，
+    // approve_step_execution 形参仍 &str，不在本 PR 范围）。
+    let (gate_status, final_status, rating): (LoopGateStatus, &str, i32) = if req.approved {
+        (LoopGateStatus::Passed, "success", 100)
     } else {
-        ("failed", "failed", 0)
+        (LoopGateStatus::Failed, "failed", 0)
     };
     state
         .db
@@ -1060,12 +1063,16 @@ fn ensure_step_approvable(status: &str) -> Result<(), AppError> {
 /// 校验门禁可经人工审批（纯函数，便于单测）。
 /// 只允许 human_approval 类型走本接口，防止借道篡改 AI 评审/脚本校验的结果。
 fn ensure_gate_approvable(gate_type: &str, gate_status: &str) -> Result<(), AppError> {
+    use crate::models::LoopGateStatus;
     if gate_type != "human_approval" {
         return Err(AppError::BadRequest(
             "该门禁不是人工审批类型".to_string(),
         ));
     }
-    if gate_status != "pending" {
+    // 只允许 pending 态门禁走审批：已评价（passed/failed）或未知值一律拒绝，
+    // 防止覆盖终态。读比较走 D6 枚举 from_db，与 gate_evaluator 同口径；
+    // 形参仍 &str 以保留纯函数的单测边界（测试直接喂字面量）。
+    if LoopGateStatus::from_db(gate_status) != Some(LoopGateStatus::Pending) {
         return Err(AppError::BadRequest(
             "该门禁已被评价".to_string(),
         ));

--- a/backend/src/models/execution.rs
+++ b/backend/src/models/execution.rs
@@ -45,6 +45,50 @@ impl std::str::FromStr for ExecutionStatus {
     }
 }
 
+/// `execution_records.last_review_status` 取值族（5 态）。
+/// 自动评审对原执行记录的复核结果；`Interrupted` 表示执行非成功非失败（如超时、取消），
+/// 不能默认归为 Failed——否则会把「未完成」误标成「评审不通过」。
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewStatus {
+    Pending,
+    Success,
+    Failed,
+    Interrupted,
+    Skipped,
+}
+
+impl ReviewStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Success => "success",
+            Self::Failed => "failed",
+            Self::Interrupted => "interrupted",
+            Self::Skipped => "skipped",
+        }
+    }
+
+    /// DB 读取侧解析：未知值回退 None（调用方按场景兜底），不写死默认态。
+    /// 与 loop_ 域统一用 from_db（Option），不沿用本文件 D2 的 FromStr 历史范式。
+    pub fn from_db(s: &str) -> Option<Self> {
+        Some(match s {
+            "pending" => Self::Pending,
+            "success" => Self::Success,
+            "failed" => Self::Failed,
+            "interrupted" => Self::Interrupted,
+            "skipped" => Self::Skipped,
+            _ => return None,
+        })
+    }
+}
+
+impl std::fmt::Display for ReviewStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutionRecord {
     pub id: i64,
@@ -441,4 +485,52 @@ pub fn utc_timestamp_minus_hours(hours: u32) -> String {
     (chrono::Utc::now() - chrono::Duration::hours(i64::from(hours)))
         .format("%Y-%m-%dT%H:%M:%S%.3fZ")
         .to_string()
+}
+
+// 测试模块允许 unwrap/expect/panic：单测里 panic 即断言失败，语义正当；
+// clippy::unwrap_used 默认对 #[cfg(test)] 不豁免，故显式 allow（同 loop_.rs 范式）。
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    /// ReviewStatus 枚举族契约（5 态）——as_str/from_db 往返恒等 + 全集锁定。
+    /// 新增状态须同步枚举；删除属破坏性变更需评审。
+    #[test]
+    fn test_review_status_roundtrip_and_full_set() {
+        let all = [
+            (ReviewStatus::Pending, "pending"),
+            (ReviewStatus::Success, "success"),
+            (ReviewStatus::Failed, "failed"),
+            (ReviewStatus::Interrupted, "interrupted"),
+            (ReviewStatus::Skipped, "skipped"),
+        ];
+        for (variant, db_str) in all {
+            assert_eq!(variant.as_str(), db_str, "as_str 与 DB 字面量必须一致");
+            assert_eq!(
+                ReviewStatus::from_db(db_str),
+                Some(variant),
+                "from_db 必须能解析全部枚举值"
+            );
+        }
+        // 未知值返回 None（调用方按场景兜底，不写死默认态）
+        assert_eq!(ReviewStatus::from_db("unknown_x"), None);
+        assert_eq!(ReviewStatus::from_db(""), None);
+    }
+
+    /// serde 形态与存量 DB/前端 JSON 的 snake_case 字面量一致；
+    /// interrupted/skipped 是本族独有值，须锁定字面。
+    #[test]
+    fn test_review_status_serde_snake_case_compatible() {
+        assert_eq!(
+            serde_json::to_string(&ReviewStatus::Interrupted).unwrap(),
+            r#""interrupted""#
+        );
+        assert_eq!(
+            serde_json::to_string(&ReviewStatus::Skipped).unwrap(),
+            r#""skipped""#
+        );
+        let back: ReviewStatus = serde_json::from_str(r#""interrupted""#).unwrap();
+        assert_eq!(back, ReviewStatus::Interrupted);
+    }
 }

--- a/backend/src/models/loop_.rs
+++ b/backend/src/models/loop_.rs
@@ -109,6 +109,87 @@ impl std::fmt::Display for LoopStepStatus {
     }
 }
 
+/// `loop_phase_executions.status` 取值族（5 态）。
+/// 环节（phase）执行状态；区别于 step（`LoopStepStatus`）与 gate（`LoopGateStatus`）。
+/// 当前生产写入侧只写 running/success/failed，pending/skipped 为覆盖列可能值而定义（同 D3 phantom 值思路）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopPhaseExecutionStatus {
+    Pending,
+    Running,
+    Success,
+    Failed,
+    Skipped,
+}
+
+impl LoopPhaseExecutionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Success => "success",
+            Self::Failed => "failed",
+            Self::Skipped => "skipped",
+        }
+    }
+
+    /// DB 读取侧解析：未知值回退 None（调用方按场景兜底），不写死默认态。
+    pub fn from_db(s: &str) -> Option<Self> {
+        Some(match s {
+            "pending" => Self::Pending,
+            "running" => Self::Running,
+            "success" => Self::Success,
+            "failed" => Self::Failed,
+            "skipped" => Self::Skipped,
+            _ => return None,
+        })
+    }
+}
+
+impl std::fmt::Display for LoopPhaseExecutionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// `loop_step_execution_gates.status` 取值族（3 态）。
+/// 门禁结果：`Passed`（通过）≠ phase/step 的 `Success`，二者字面与语义均不同，不可合并——
+/// 合并会让「gate 误置 success」这种语义错误通过编译。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopGateStatus {
+    Pending,
+    Passed,
+    Failed,
+}
+
+impl LoopGateStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Passed => "passed",
+            Self::Failed => "failed",
+        }
+    }
+
+    /// DB 读取侧解析：未知值回退 None。
+    /// 注意 success 不属于 gate 族（gate 用 passed）——解析为 None 防止两族混淆。
+    pub fn from_db(s: &str) -> Option<Self> {
+        Some(match s {
+            "pending" => Self::Pending,
+            "passed" => Self::Passed,
+            "failed" => Self::Failed,
+            _ => return None,
+        })
+    }
+}
+
+impl std::fmt::Display for LoopGateStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
 /// Loop 列表行(左栏一行)。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoopListItem {
@@ -641,6 +722,42 @@ mod loop_dto_tests {
         assert_eq!(LoopStepStatus::from_db("skipped"), None);
     }
 
+    /// LoopPhaseExecutionStatus 枚举族契约（5 态）——as_str/from_db 往返恒等 + 全集锁定。
+    #[test]
+    fn test_loop_phase_execution_status_roundtrip_and_full_set() {
+        let all = [
+            (LoopPhaseExecutionStatus::Pending, "pending"),
+            (LoopPhaseExecutionStatus::Running, "running"),
+            (LoopPhaseExecutionStatus::Success, "success"),
+            (LoopPhaseExecutionStatus::Failed, "failed"),
+            (LoopPhaseExecutionStatus::Skipped, "skipped"),
+        ];
+        for (variant, db_str) in all {
+            assert_eq!(variant.as_str(), db_str);
+            assert_eq!(LoopPhaseExecutionStatus::from_db(db_str), Some(variant));
+        }
+        // 未知值返回 None
+        assert_eq!(LoopPhaseExecutionStatus::from_db("unknown_x"), None);
+        assert_eq!(LoopPhaseExecutionStatus::from_db(""), None);
+    }
+
+    /// LoopGateStatus 枚举族契约（3 态）；passed 独有，区别于 success。
+    #[test]
+    fn test_loop_gate_status_roundtrip_and_full_set() {
+        let all = [
+            (LoopGateStatus::Pending, "pending"),
+            (LoopGateStatus::Passed, "passed"),
+            (LoopGateStatus::Failed, "failed"),
+        ];
+        for (variant, db_str) in all {
+            assert_eq!(variant.as_str(), db_str);
+            assert_eq!(LoopGateStatus::from_db(db_str), Some(variant));
+        }
+        // success 不属于 gate 族（gate 用 passed）——解析为 None 防止两族混淆
+        assert_eq!(LoopGateStatus::from_db("success"), None);
+        assert_eq!(LoopGateStatus::from_db(""), None);
+    }
+
     /// serde 兼容层：枚举序列化形态与存量 DB/前端 JSON 的 snake_case 字面量一致
     #[test]
     fn test_status_enum_serde_snake_case_compatible() {
@@ -654,5 +771,16 @@ mod loop_dto_tests {
         );
         let back: LoopExecutionStatus = serde_json::from_str(r#""partial""#).unwrap();
         assert_eq!(back, LoopExecutionStatus::Partial);
+        // D5/D6 的独有值同样走 snake_case——skipped/passed 必须与 DB/前端字面一致
+        assert_eq!(
+            serde_json::to_string(&LoopPhaseExecutionStatus::Skipped).unwrap(),
+            r#""skipped""#
+        );
+        assert_eq!(
+            serde_json::to_string(&LoopGateStatus::Passed).unwrap(),
+            r#""passed""#
+        );
+        let gate_back: LoopGateStatus = serde_json::from_str(r#""passed""#).unwrap();
+        assert_eq!(gate_back, LoopGateStatus::Passed);
     }
 }

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -526,11 +526,15 @@ impl LoopRunner {
                 let loop_status = le.ok().flatten().map(|l| l.status).unwrap_or_else(|| LoopExecutionStatus::Failed.to_string());
                 // loop 终态 → phase 终态（D5 收口）：loop success 才让 phase success，其余归 failed，
                 // 与 finalize_phase 内部二值归一语义一致；调用方负责 D3→D5 映射。
-                let phase_status = if loop_status == LoopExecutionStatus::Success.as_str() {
-                    LoopPhaseExecutionStatus::Success
-                } else {
-                    LoopPhaseExecutionStatus::Failed
-                };
+                // 读比较走 D3 枚举 from_db，与本 PR 其余读点（gate_evaluator/phase_driver）同口径，
+                // 避免裸串 "success" 与写入侧脱钩；未知值 → None → 归 Failed（与原 String 比较等价）。
+                let phase_status =
+                    if LoopExecutionStatus::from_db(&loop_status) == Some(LoopExecutionStatus::Success)
+                    {
+                        LoopPhaseExecutionStatus::Success
+                    } else {
+                        LoopPhaseExecutionStatus::Failed
+                    };
                 let _ = self.ctx.db.finalize_phase_executions(loop_execution_id, phase_status).await;
                 self.sync_task_status(loop_execution_id).await;
                 self.broadcast_loop_finished(loop_id, loop_execution_id).await;
@@ -680,13 +684,15 @@ impl LoopRunner {
                 loop_execution_id, final_status, completed, failed, None,
             ).await;
             // 终态化所有 running phase（BUG-004）：与 run_inner 路径一致。
-            // loop 终态 → phase 终态（D5 收口）：success→success，否则 failed。
-            // final_status 仍是 &str 喂 finish_loop_execution（D3 列），phase 单独按 D5 枚举传。
-            let phase_status = if completed > 0 {
-                LoopPhaseExecutionStatus::Success
-            } else {
-                LoopPhaseExecutionStatus::Failed
-            };
+            // loop 终态 → phase 终态（D5 收口）：直接从 final_status 派生（单一真相源），
+            // 不再重复 completed>0 判定——避免与上面 final_status 的派生逻辑隐式耦合。
+            // final_status 仍是 &str 喂 finish_loop_execution（D3 列），读比较走 from_db。
+            let phase_status =
+                if LoopExecutionStatus::from_db(final_status) == Some(LoopExecutionStatus::Success) {
+                    LoopPhaseExecutionStatus::Success
+                } else {
+                    LoopPhaseExecutionStatus::Failed
+                };
             let _ = self.ctx.db.finalize_phase_executions(loop_execution_id, phase_status).await;
             info!("resume: loop_execution #{} ended with status {}", loop_execution_id, final_status);
             // 就地终态化同样要完成收尾：同步任务状态 + 广播 LoopFinished（NTD-005）。

--- a/backend/src/services/loop_runner.rs
+++ b/backend/src/services/loop_runner.rs
@@ -24,7 +24,7 @@ use crate::db::Database;
 use crate::executor_service::{run_todo_execution_with_params, RunTodoExecutionRequest};
 use crate::models::ExecutionStatus;
 // 096-W4-3：loop 域状态枚举族（裸串收敛的单一词汇表，DB 仍走 String 协议）
-use crate::models::{LoopExecutionStatus, LoopStepStatus};
+use crate::models::{LoopExecutionStatus, LoopPhaseExecutionStatus, LoopStepStatus};
 use crate::task_manager::TaskManager;
 use crate::db::entity::{loop_steps};
 
@@ -523,8 +523,15 @@ impl LoopRunner {
                 // 终态化所有 running phase（BUG-004）：无论是否走 run_inner 的 finish 路径，
                 // 兜底把 phase 从 running 终态化。
                 let le = self.ctx.db.get_loop_execution(loop_execution_id).await;
-                let final_status = le.ok().flatten().map(|l| l.status).unwrap_or_else(|| LoopExecutionStatus::Failed.to_string());
-                let _ = self.ctx.db.finalize_phase_executions(loop_execution_id, &final_status).await;
+                let loop_status = le.ok().flatten().map(|l| l.status).unwrap_or_else(|| LoopExecutionStatus::Failed.to_string());
+                // loop 终态 → phase 终态（D5 收口）：loop success 才让 phase success，其余归 failed，
+                // 与 finalize_phase 内部二值归一语义一致；调用方负责 D3→D5 映射。
+                let phase_status = if loop_status == LoopExecutionStatus::Success.as_str() {
+                    LoopPhaseExecutionStatus::Success
+                } else {
+                    LoopPhaseExecutionStatus::Failed
+                };
+                let _ = self.ctx.db.finalize_phase_executions(loop_execution_id, phase_status).await;
                 self.sync_task_status(loop_execution_id).await;
                 self.broadcast_loop_finished(loop_id, loop_execution_id).await;
             }
@@ -673,8 +680,14 @@ impl LoopRunner {
                 loop_execution_id, final_status, completed, failed, None,
             ).await;
             // 终态化所有 running phase（BUG-004）：与 run_inner 路径一致。
-            // final_status 此分支为 &str（670 行 as_str() 产出），直接传参不再取引用
-            let _ = self.ctx.db.finalize_phase_executions(loop_execution_id, final_status).await;
+            // loop 终态 → phase 终态（D5 收口）：success→success，否则 failed。
+            // final_status 仍是 &str 喂 finish_loop_execution（D3 列），phase 单独按 D5 枚举传。
+            let phase_status = if completed > 0 {
+                LoopPhaseExecutionStatus::Success
+            } else {
+                LoopPhaseExecutionStatus::Failed
+            };
+            let _ = self.ctx.db.finalize_phase_executions(loop_execution_id, phase_status).await;
             info!("resume: loop_execution #{} ended with status {}", loop_execution_id, final_status);
             // 就地终态化同样要完成收尾：同步任务状态 + 广播 LoopFinished（NTD-005）。
             self.sync_task_status(loop_execution_id).await;
@@ -875,9 +888,14 @@ impl LoopRunner {
             .map_err(|e| e.to_string())?;
 
         // 终态化所有 running phase（BUG-004）：loop success 后 phase 不应停留在 running。
+        // loop 终态 → phase 终态（D5 收口）：仅 Success 让 phase success，其余（Failed/Partial/capped）归 failed。
+        let phase_status = match final_status {
+            LoopExecutionStatus::Success => LoopPhaseExecutionStatus::Success,
+            _ => LoopPhaseExecutionStatus::Failed,
+        };
         self.ctx
             .db
-            .finalize_phase_executions(loop_execution_id, final_status.as_str())
+            .finalize_phase_executions(loop_execution_id, phase_status)
             .await
             .map_err(|e| e.to_string())?;
 

--- a/backend/src/services/process/gate_evaluator.rs
+++ b/backend/src/services/process/gate_evaluator.rs
@@ -111,14 +111,15 @@ pub async fn evaluate_step_gates(
 
         match result {
             Ok(gate_result) => {
+                use crate::models::LoopGateStatus;
                 // human_approval 未通过是「等待人工」而非失败：持久化为 pending，
                 // 避免 UI 把待审批门禁渲染成 failed（审批动作才会把它推进 passed/failed）。
                 let status = if gate_result.passed {
-                    "passed"
+                    LoopGateStatus::Passed
                 } else if gate_def.gate_type == "human_approval" {
-                    "pending"
+                    LoopGateStatus::Pending
                 } else {
-                    "failed"
+                    LoopGateStatus::Failed
                 };
                 db.update_loop_step_execution_gate(
                     gate_model.id,
@@ -137,14 +138,16 @@ pub async fn evaluate_step_gates(
                 }
 
                 let mut updated = gate_model;
-                updated.status = status.to_string();
+                // Model.status 字段仍是 String（DB 协议不变），枚举经 as_str() 回写。
+                updated.status = status.as_str().to_string();
                 updated.result = gate_result.detail.clone();
                 gate_records.push(updated);
             }
             Err(gate_err) => {
                 // 评估失败视为门禁失败。
+                use crate::models::LoopGateStatus;
                 let err_msg = gate_err.to_string();
-                let status = "failed";
+                let status = LoopGateStatus::Failed;
                 db.update_loop_step_execution_gate(
                     gate_model.id,
                     status,
@@ -156,7 +159,7 @@ pub async fn evaluate_step_gates(
 
                 all_passed = false;
                 let mut updated = gate_model;
-                updated.status = status.to_string();
+                updated.status = status.as_str().to_string();
                 updated.result = Some(err_msg);
                 gate_records.push(updated);
             }
@@ -183,8 +186,12 @@ async fn find_pending_gate(
         .list_loop_step_execution_gates(step_execution_id)
         .await
         .map_err(|e| crate::services::process::ProcessError::Db(Box::new(e)))?;
+    use crate::models::LoopGateStatus;
+    // 只匹配 pending：经 from_db 解析回枚举再比较，避免裸串与写入侧脱钩。
     Ok(existing.into_iter().find(|g| {
-        g.status == "pending" && g.gate_type == gate_def.gate_type && g.gate_name == gate_def.name
+        LoopGateStatus::from_db(&g.status) == Some(LoopGateStatus::Pending)
+            && g.gate_type == gate_def.gate_type
+            && g.gate_name == gate_def.name
     }))
 }
 

--- a/backend/src/services/process/phase_driver.rs
+++ b/backend/src/services/process/phase_driver.rs
@@ -315,22 +315,32 @@ async fn update_phase_execution(
         return Ok(());
     };
 
+    use crate::models::LoopPhaseExecutionStatus;
     // 检查是否已有 phase execution 记录。
     let existing = loop_phase_executions_for_execution(db, loop_execution_id, phase_id).await?;
     if let Some(pex) = existing {
         // 已有记录：步骤完成且未挂起时，更新为 success（或 failed）。
         // 人工挂起时保持 running，不标失败（BUG-004：挂起不应让 phase 终态化）。
-        if pex.status == "running" && !human_pending {
-            let new_status = if gates_passed { "success" } else { "failed" };
+        // pex.status 经 from_db 解析回枚举再比较，避免裸串与写入侧脱钩。
+        if LoopPhaseExecutionStatus::from_db(&pex.status) == Some(LoopPhaseExecutionStatus::Running)
+            && !human_pending
+        {
+            // new_status 由枚举 as_str() 产出（D5 收口）；update_phase_status 形参仍是 &str，
+            // 故在此降回字面——DB 列协议不变，枚举只在判定/构造侧收口。
+            let new_status = if gates_passed {
+                LoopPhaseExecutionStatus::Success.as_str()
+            } else {
+                LoopPhaseExecutionStatus::Failed.as_str()
+            };
             update_phase_status(db, pex.id, new_status).await?;
         }
     } else {
-        // 新阶段：创建 running 记录。
+        // 新阶段：创建 running 记录（初始态走 D5 枚举，与终态判定共享词汇表）。
         let now = crate::models::utc_timestamp();
         let am = crate::db::entity::loop_phase_executions::ActiveModel {
             loop_execution_id: ActiveValue::Set(loop_execution_id),
             phase_id: ActiveValue::Set(phase_id),
-            status: ActiveValue::Set("running".to_string()),
+            status: ActiveValue::Set(LoopPhaseExecutionStatus::Running.as_str().to_string()),
             started_at: ActiveValue::Set(Some(now)),
             ..Default::default()
         };

--- a/docs/design/103-状态字面量枚举化-设计.md
+++ b/docs/design/103-状态字面量枚举化-设计.md
@@ -76,7 +76,7 @@ impl std::fmt::Display for LoopGateStatus {
 
 - `gate_evaluator.rs:117-159` status 局部变量（`&str` 三值 passed/failed/pending）→ `LoopGateStatus`。
 - `db/process_artifact.rs` `update_loop_step_execution_gate` 形参 `&str` → `LoopGateStatus`；`create_loop_step_execution_gate` 的初始 `pending` 同走 `LoopGateStatus::Pending.as_str()`。
-- `handlers/process.rs` approve 分支的 gate 状态（`"success"`→`LoopGateStatus::Passed`）。
+- `handlers/process.rs` approve 分支的 gate 状态（`"passed"`→`LoopGateStatus::Passed`；`"success"` 是 D4 step 终态 `final_status`，§6 白名单不动）。
 - `gate_evaluator.rs:187` `g.status == "pending"` → `LoopGateStatus::from_db(&g.status) == Some(LoopGateStatus::Pending)`。
 
 ### D5

--- a/docs/design/103-状态字面量枚举化-设计.md
+++ b/docs/design/103-状态字面量枚举化-设计.md
@@ -1,0 +1,136 @@
+# 103 - 后端状态字面量枚举化（路线 A：D5 / D6 / D7）
+
+> 关联：[ADR-005](../decisions/ADR-005-重构与设计模式改进-决策.md) H1。本设计取代同号的全量方案（已弃用，存档于 `refactor/103-h1-status-enum` 分支 commit `b0a182d0`，保留作 D5/D6/D7 定义参考）。
+
+## 1. 背景与方案演进
+
+ADR-005 H1 指出 `backend/src` 下 `"pending"/"running"/"success"/"failed"/"cancelled"` 等状态字面量散落约 360 处 / 53 文件，属 Primitive Obsession——拼写错误编译期发现不了，是 silent-bug 温床。
+
+初版设计设想新建 central `models/status.rs`，集中 7 枚举全量替换（一个枚举覆盖全部）。**复核 main（`5cb91b34`）推翻了这个判断**，原因有二：
+
+1. **这些字面量承载 7 个相互独立的状态域**，分属不同 DB 表的不同列，值域各异（`partial`/`skipped`/`passed`/`interrupted`/`pending_approval` 等独有值）。同一个 `"running"` 在 `loop_runner.rs` 相邻几行可能分属 loop / step / phase 三个域，不能用一个枚举覆盖。
+2. **096-W4 波次已以 per-domain 架构落地其中 4 域**：D1 `TodoStatus`（`models/todo.rs`）、D2 `ExecutionStatus`（`models/execution.rs`）、D3 `LoopExecutionStatus`、D4 `LoopStepStatus`（`models/loop_.rs`）。且 D3 main 版（7 态含 Paused/CappedStep/CappedToken）比全量方案（5 态含 phantom Cancelled）**更完整**。
+
+因此全量方案的 central 架构、命名（`LoopStepExecutionStatus` vs main `LoopStepStatus`）、值域与 main 冲突，**不可合并**。
+
+**路线 A（本设计）**：放弃 central，依附 main 的 per-domain 架构，**只补 main 尚未枚举化的 3 域**——D5（phase）、D6（gate）、D7（review）。D1–D4 不碰（main 已做）。
+
+## 2. 目标
+
+- `models/loop_.rs` 新增 `LoopPhaseExecutionStatus`(D5) + `LoopGateStatus`(D6)；`models/execution.rs` 新增 `ReviewStatus`(D7)。配 `as_str`/`from_db`/`Display` + 枚举族契约单测。
+- 枚举化三域的生产写入点（DB 写入函数形参 `&str`→枚举、裸串调用、读取比较）。
+- **行为逐字节不变**：DB 存的串、API 返回 JSON、SQL 条件值不动；前端 `types/`/`constants.ts` 不动。
+
+## 3. 三域定义
+
+| 域 | DB 列 | 枚举 | 落点 | 值域 | 独有值 |
+|---|---|---|---|---|---|
+| D5 | `loop_phase_executions.status` | `LoopPhaseExecutionStatus` | `models/loop_.rs` | pending / running / success / failed / skipped | `skipped` |
+| D6 | `loop_step_execution_gates.status` | `LoopGateStatus` | `models/loop_.rs` | pending / **passed** / failed | `passed`（≠ success） |
+| D7 | `execution_records.last_review_status` | `ReviewStatus` | `models/execution.rs` | pending / success / failed / interrupted / skipped | `interrupted`、`skipped` |
+
+> **D6 的 `passed` 与 D5/D3 的 `success` 不可合并**：门禁通过（passed）与执行成功（success）语义不同、字面也不同。合并会让「gate 误置 success」这种语义错误通过编译。
+
+> D5 值域含 `pending`/`skipped` 是为覆盖列的可能取值（`from_db` 接受）；当前生产写入侧只写 `running`/`success`/`failed`，与 D3 的 phantom 值同理——定义但不强求写入点。
+
+## 4. 枚举范式
+
+仿 main loop_ 域（`LoopExecutionStatus`/`LoopStepStatus`），统一三域：
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopGateStatus {
+    Pending,
+    Passed,
+    Failed,
+}
+
+impl LoopGateStatus {
+    /// DB 写入侧 / SQL 值用。
+    pub fn as_str(&self) -> &'static str { /* match → "pending"/"passed"/"failed" */ }
+
+    /// DB 读取侧解析：未知值回退 None（调用方按场景兜底），不写死默认态。
+    pub fn from_db(s: &str) -> Option<Self> { /* match → _ return None */ }
+}
+
+impl std::fmt::Display for LoopGateStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "{}", self.as_str()) }
+}
+```
+
+- DB 层保持 String 协议（不动 SeaORM 实体）；写入侧 `Enum::X.as_str().to_string()`，读取侧 `from_db`。
+- D5/D6/D7 **统一 `from_db`（Option）**，不沿用 D2 的 `FromStr`（D2 是历史范式，不强求对齐）。
+- **不用 `DeriveActiveEnum`**：列是 `String`/`Option<String>`（migration 是 `TEXT DEFAULT '...'`，无 CHECK），用 DeriveActiveEnum 会牵动所有 entity 写入、破坏「逐字节不变」。
+
+## 5. 替换编排（D7 → D6 → D5，由清晰到复杂）
+
+### D7（最清晰，先做）
+
+- `db/execution.rs:1673` `set_record_last_review_status(record_id, status: &str)` → 形参 `ReviewStatus`，内部 `ActiveValue::Set(Some(status.as_str().to_string()))`。
+- `auto_review.rs` 6 处调用（118/135/344/463/493）裸串 → `ReviewStatus::Failed`/`Skipped`/`Pending` 等。
+- `auto_review.rs:481-483` `match final_review.status { Success=>"success", Failed=>"failed", _=>"interrupted" }` → 返回 `ReviewStatus`（`_` 分支 → `Interrupted`，覆盖超时等非成功非失败终态）。
+- `auto_review.rs:244` `record.last_review_status.as_deref() == Some("success")` → `ReviewStatus::from_db(...).is_some_and(|s| s == ReviewStatus::Success)`。
+
+### D6
+
+- `gate_evaluator.rs:117-159` status 局部变量（`&str` 三值 passed/failed/pending）→ `LoopGateStatus`。
+- `db/process_artifact.rs` `update_loop_step_execution_gate` 形参 `&str` → `LoopGateStatus`；`create_loop_step_execution_gate` 的初始 `pending` 同走 `LoopGateStatus::Pending.as_str()`。
+- `handlers/process.rs` approve 分支的 gate 状态（`"success"`→`LoopGateStatus::Passed`）。
+- `gate_evaluator.rs:187` `g.status == "pending"` → `LoopGateStatus::from_db(&g.status) == Some(LoopGateStatus::Pending)`。
+
+### D5
+
+- `db/loop_.rs:1076` `finalize_phase_executions` 入参 `status: &str` → `LoopPhaseExecutionStatus`；line 1076 的 `if status == "success"` 二值分支改用入参枚举的 `Success`/`Failed` 直接折叠。
+- `phase_driver.rs:323/324/333` `pex.status == "running"/"success"/"failed"` → `LoopPhaseExecutionStatus::from_db` 比较；新 phase 创建态走 `LoopPhaseExecutionStatus::Running.as_str()`。
+- `loop_runner.rs` 三处 `finalize_phase_executions` 调用：原传 D3(`LoopExecutionStatus`) 裸串，现按 `Success→Success / 其余→Failed` 折叠成 `LoopPhaseExecutionStatus` 传入（与 finalize 内部原 `if status=="success"` 二值分支同义）。
+
+## 6. 白名单（绝不动）
+
+- **`db/execution.rs` 的几十处 `success/failed/running`**：D2 域 SQL 聚合别名（`AS success`）与 SQL 内嵌值（`WHERE status='running'`），不是 D7。这是同名跨域陷阱，替换前必须按列判域。
+- **`delivery_state.rs` 的 `GateEntry.status`**：渲染 `delivery-state.md` 的展示结构体（非 DB 列），同 `cli/commands.rs::status_icon` 渲染层，保留字面量。
+- **`approval_status` 子域**（`loop_step_executions.approval_status`：NULL/pending/approved）——独立于 status 族。
+- **SQL 字符串内嵌的状态值**：保留字面量，不用 `format!` 拼接（行为不变优先，拼 SQL 增注入风险）。
+- **`db/migration/`**、测试夹具 JSON。
+- 域外列：`sessions.status`、`agent_progress.status`、`sync_records.status`、`tasks.status`、`loops.status`(enabled/paused)。
+
+## 7. 行为不变铁律
+
+- DB 列存的字符串不变（`as_str` 锁原字面量）。
+- API 返回 JSON 不变（serde `snake_case` + 现有契约测试兜底）。
+- SQL `WHERE`/`SET` 里的值不变。
+- 前端 `frontend/src/types/`、`constants.ts` 不动。
+
+## 8. 测试
+
+**枚举族契约单测**（仿 `loop_.rs` 既有范式，命名 `test_<enum>_<场景>`）：`as_str` 锁字面量 + `from_db` 全集往返恒等 + 非法值返回 None + serde snake_case 双向，合并到少量用例里（`test_<enum>_roundtrip_and_full_set` + `test_<enum>_serde_snake_case_compatible`）。
+
+**不新增独立 round-trip 文件（YAGNI）**：`as_str`/`from_db` 全集往返恒等已由枚举族单测锁定；DB 写入→读回路径由 main 既有 `finalize_phase_executions`(D5)、gate(D6) 测试与 `auto_review`(D7) 链路覆盖。各域独有值（`skipped`/`passed`/`interrupted`）的字面由 `as_str` + serde 单测断言兜底。
+
+**现有契约测试不动**（回归网）：`api_integration_test.rs`、`loop_step_execution_status_tests.rs`、`business_logic_tests.rs`。
+
+## 9. 验收清单
+
+- [x] `cargo build --release --workspace` 零错误。
+- [x] `cargo test --workspace`：1694 单测 + 全部集成测试套件全绿；doctest 3 个 `ignore` 片段正常跳过（0 failed）。注：`--include-ignored` 会强制编译 main 既有的 `ignore` 片段（`handlers/mod.rs`、`adapters/mod.rs`），与本 PR 无关（两文件 diff 为空）。
+- [x] `cargo clippy --all-targets -- -D warnings` 零告警。
+- [x] D5/D6/D7 三域生产裸串归零（白名单除外）。
+- [x] 域外未触动：`git diff --stat backend/src/{db/migration,adapters} frontend/src/` 为空。
+
+## 10. 文件清单
+
+- 改 `backend/src/models/loop_.rs`（+`LoopPhaseExecutionStatus`(D5) +`LoopGateStatus`(D6) 及单测）
+- 改 `backend/src/models/execution.rs`（+`ReviewStatus`(D7) 及单测）
+- 改 `backend/src/db/execution.rs`（`set_record_last_review_status` + `link_review_to_source` 形参 `&str`→`ReviewStatus`）
+- 改 `backend/src/db/loop_.rs`（`finalize_phase_executions` 形参 `&str`→`LoopPhaseExecutionStatus`）
+- 改 `backend/src/db/process_artifact.rs`（`update_loop_step_execution_gate` 形参 + create 初始 pending → `LoopGateStatus`）
+- 改 `backend/src/executor_service/auto_review.rs`（D7 调用 / match / 读比较）
+- 改 `backend/src/services/process/gate_evaluator.rs`（D6）、`phase_driver.rs`（D5）
+- 改 `backend/src/services/loop_runner.rs`（三处 finalize 调用 D3→D5 折叠映射）
+- 改 `backend/src/handlers/process.rs`（approve 分支 gate 状态枚举化）
+
+## 11. 风险
+
+1. **D5/D6 同名 `passed/failed` 跨域误判**：`phase_driver.rs` 同时含 D5 phase 生产代码与 D6 gate 测试夹具。对策——按变量名（`pex`=phase / `g`/`gate`=gate）与所在函数定域。
+2. **`db/loop_.rs` SQL 值与别名混淆**：`AS success`（别名）与 `le.status='success'`（值）相邻。对策——别名绝不动，值按 §6 保留。
+3. **D7 `match ExecutionStatus → ReviewStatus` 映射要覆盖 `interrupted`**：执行非成功非失败（如超时、取消）须落 `Interrupted`，不能默认 `Failed`。


### PR DESCRIPTION
# 103 - 后端状态字面量枚举化（路线 A：D5 / D6 / D7）

> 关联：ADR-005 H1（后端状态字面量全量枚举化）。本 PR 取**路线 A**。

## 为什么是路线 A（H1 全量方案为何弃用）

ADR-005 H1 初版设想新建 central `models/status.rs`、用 7 枚举全量替换约 360 处状态裸串。**复核 main（`5cb91b34`，096-W4 波次）后推翻该判断**：

1. 这些字面量承载 **7 个相互独立的状态域**，分属不同 DB 表不同列，值域各异（`partial`/`skipped`/`passed`/`interrupted`/`pending_approval` 等独有值）。同一个 `"running"` 在 `loop_runner.rs` 相邻几行可能分属 loop/step/phase 三个域，不能用单一枚举覆盖。
2. **096-W4 已以 per-domain 架构落地其中 4 域**：D1 `TodoStatus`、D2 `ExecutionStatus`、D3 `LoopExecutionStatus`、D4 `LoopStepStatus`。且 main 的 D3（7 态含 Paused/CappedStep/CappedToken）比全量方案（5 态含 phantom Cancelled）**更完整**。

因此全量方案的 central 架构、命名（`LoopStepExecutionStatus` vs main `LoopStepStatus`）、值域与 main 冲突，**不可合并**。

**路线 A**：放弃 central，依附 main 的 per-domain 架构，**只补 main 尚未枚举化的 3 域**——D5（phase）、D6（gate）、D7（review）。D1–D4 不碰（main 已做）。全量方案存档于 `refactor/103-h1-status-enum` 分支 commit `b0a182d0`，保留作枚举定义参考。

## 本 PR 范围

| 域 | DB 列 | 新枚举 | 值域 |
|---|---|---|---|
| D5 | `loop_phase_executions.status` | `LoopPhaseExecutionStatus` | pending / running / success / failed / skipped |
| D6 | `loop_step_execution_gates.status` | `LoopGateStatus` | pending / **passed** / failed |
| D7 | `execution_records.last_review_status` | `ReviewStatus` | pending / success / failed / interrupted / skipped |

枚举化三域的**生产写入点**（DB 写入函数形参 `&str`→枚举、裸串调用）与**读取比较**（`== "pending"` → `from_db`）。D6 的 `passed` 与 D5/D3 的 `success` 不合并（门禁通过 ≠ 执行成功，字面也不同；合并会让「gate 误置 success」这种语义错误通过编译）。

## 行为不变铁律（逐字节）

- DB 列存的字符串不变（`as_str` 锁原字面量）。
- API 返回 JSON 不变（serde `snake_case` + 现有契约测试兜底）。
- SQL `WHERE`/`SET` 里的值不变。
- 前端 `frontend/src/types/`、`constants.ts` 不动。
- DB 层保持 String 协议（**不用** `DeriveActiveEnum`——列是 `TEXT`，无 CHECK，强转会牵动所有 entity 写入、破坏逐字节不变）。

## 三道门禁

```
cd backend
cargo clippy --all-targets -- -D warnings     ✅ 零告警
cargo test --workspace                          ✅ 1692 单测 + 全部集成测试套件全绿
cargo build --release --workspace               ✅ Finished (5m32s)
```

> doctest：3 个 `ignore` 片段（`handlers/mod.rs`、`adapters/mod.rs` 的示意代码块）正常跳过，0 failed。注：`--include-ignored` 会强制编译这些 main 既有的 `ignore` 片段致其报错，与本 PR 无关——两文件相对 origin/main 的 diff 为空。

## 残量审计（D5/D6/D7 生产裸串归零，余者皆白名单）

- D7 `auto_review.rs`：仅剩注释（解释本次修复）。
- D6 `handlers/process.rs:985`：`final_status`（D4 step 终态，`approve_step_execution` 形参，**不在本 PR 范围**）；`gate_status` 已是 `LoopGateStatus`。
- D6 `gate_evaluator.rs` / `handlers/process.rs` 其余 `"failed"/"passed"/"pending"`：均在 `#[cfg(test)]`，是锁定 DB 字面量的断言/夹具。
- 白名单（绝不动）：D2 域 SQL 聚合别名（`AS success`）与 SQL 内嵌值（`WHERE status='running'`）；`delivery_state.rs` 渲染层；`approval_status` 子域；`db/migration/`；域外列（`sessions`/`agent_progress`/`sync_records`/`tasks`/`loops.status`）。

## 域外未触动证据

```
$ git diff --stat origin/main -- backend/src/db/migration backend/src/adapters frontend/src
（空）
```

## 提交结构（5 commits，便于 review/回滚）

1. `docs(103)`：路线 A 设计文档
2. `refactor(103)`：三域枚举 + 契约单测（地基）
3. `refactor(103-D7)`：review 写入/读取点
4. `refactor(103-D6)`：gate 写入/读取点
5. `refactor(103-D5)`：phase 写入点 + D3→D5 调用映射

## 风险（已在实现中处置）

1. **D5/D6 同名 `passed/failed` 跨域误判**——按变量名（`pex`=phase / `g`/`gate`=gate）定域。
2. **`db/loop_.rs` SQL 值与别名混淆**——别名绝不动，SQL 内嵌值按白名单保留。
3. **D7 `match → ReviewStatus` 覆盖 `interrupted`**——执行非成功非失败（超时/取消）落 `Interrupted`，不默认 `Failed`。

详见 `docs/design/103-状态字面量枚举化-设计.md`。
