### PR TITLE
refactor(096-W4-4-4): ProcessEditor 拆分——三 hook + CollapsiblePropertyPanel 收口（704→184 行）

### DIFF
--- a/docs/design/101-096-W4剩余项实施设计.md
+++ b/docs/design/101-096-W4剩余项实施设计.md
@@ -85,8 +85,8 @@
 | 产物 | 落点 | 收口内容 |
 |---|---|---|
 | `useProcessEditorState(processGuid)` | `hooks/` | 加载族（detail/loading/isSystem）+ 可视化数据族（definition/yamlText/selectedNodeId）+ M5 双向联动（isSyncing/isDirty/debounceRef + handleDefinitionChange/handleYamlChange + loadDetail effect）。返回 `isDirty`/`markClean` 供下游 hook 读写。 |
-| `useProcessPersistence(processGuid, yamlText, markClean)` | `hooks/` | 持久化族：isSaving/isDeleting + handleSave(PUT)/handleDelete(DELETE+Modal.confirm)/handleBack/handleCopyToUser。 |
-| `useLeaveGuard(isDirty)` | `hooks/` | 离开拦截：hashchange + beforeunload 双层 effect，纯依赖 isDirty。 |
+| `useProcessPersistence(processGuid, deps)` | `hooks/` | 持久化族：isSaving/isDeleting + handleSave(PUT)/handleDelete(DELETE+Modal.confirm)/handleBack/handleCopyToUser。deps={detail,yamlText,setYamlText,markClean}：detail 喂删除确认标题、setYamlText 喂保存后回刷 Monaco、markClean 清未保存标记。 |
+| `useLeaveGuard(isDirty, markClean)` | `hooks/` | 离开拦截：hashchange + beforeunload 双层 effect；确认离开前调 markClean() 防二次 hashchange 复弹。 |
 | `CollapsiblePropertyPanel` | `components/process/` | 属性面板收缩/展开 UI 块（原 415–470 JSX）+ 其样式族 + `getCollapsedPanelTitle` 纯函数；propertyPanelCollapsed 收为组件内部 state。 |
 | `processEditorStyles.ts` | `components/process/` | 剩余容器/Tab/可视化/YAML 样式常量（纯机械搬运）。 |
 | `ProcessEditor.tsx`（收口后） | — | 编排器：3 hook 调用 + activeTab state + 渲染分支（loading/empty/Toolbar+Alert+Tab+CollapsiblePropertyPanel），目标 ~150 行。 |

--- a/docs/design/101-096-W4剩余项实施设计.md
+++ b/docs/design/101-096-W4剩余项实施设计.md
@@ -76,11 +76,22 @@
 | 5 | ProfilesPanel.tsx | 667 | ADR005-H5 已治理（providers Facade） |
 | 6 | TodoCenterCard.tsx | 636 | 备选 |
 
-### 拆分设计（探查后补充细节）
+### 拆分设计（探查后补充，基线 main `738d90aa`）
 
-- 先读 ProcessEditor 的 state 分布与 UI 区块（工艺编辑器：节点画布 + 属性表单 + 模板区）；
-- 手法与前三项同：自定义 hook 收口状态族 + 按 UI 区块 Extract 子组件；
-- `process/propertyForms/` 已有拆分子组件先例（LinkPropertyForm 614 行已是独立文件），延续该目录风格。
+**探查结论**：704 行的构成是「逻辑 ~320 行 + 样式常量 ~217 行 + 主渲染 ~140 行」。10 个 useState 实为 4 个紧耦合状态族（加载族 / 可视化数据族 / M5 同步族 / 视图族），不是 ExecutorsPanel 那种 24 state 的 god 组件——拆分收益主要在「样式下沉 + 双向联动/持久化/离开拦截三段逻辑各归其位」。组件实为「可视化双栏（React Flow 画布 + 属性面板）+ Monaco YAML Tab + 工具栏 + 系统工艺 Alert」，无模板区（文档初稿的「模板区」描述勘误）。
+
+**落点（手法与前三项同：自定义 hook 收口状态族 + 按 UI 区块 Extract 子组件）**：
+
+| 产物 | 落点 | 收口内容 |
+|---|---|---|
+| `useProcessEditorState(processGuid)` | `hooks/` | 加载族（detail/loading/isSystem）+ 可视化数据族（definition/yamlText/selectedNodeId）+ M5 双向联动（isSyncing/isDirty/debounceRef + handleDefinitionChange/handleYamlChange + loadDetail effect）。返回 `isDirty`/`markClean` 供下游 hook 读写。 |
+| `useProcessPersistence(processGuid, yamlText, markClean)` | `hooks/` | 持久化族：isSaving/isDeleting + handleSave(PUT)/handleDelete(DELETE+Modal.confirm)/handleBack/handleCopyToUser。 |
+| `useLeaveGuard(isDirty)` | `hooks/` | 离开拦截：hashchange + beforeunload 双层 effect，纯依赖 isDirty。 |
+| `CollapsiblePropertyPanel` | `components/process/` | 属性面板收缩/展开 UI 块（原 415–470 JSX）+ 其样式族 + `getCollapsedPanelTitle` 纯函数；propertyPanelCollapsed 收为组件内部 state。 |
+| `processEditorStyles.ts` | `components/process/` | 剩余容器/Tab/可视化/YAML 样式常量（纯机械搬运）。 |
+| `ProcessEditor.tsx`（收口后） | — | 编排器：3 hook 调用 + activeTab state + 渲染分支（loading/empty/Toolbar+Alert+Tab+CollapsiblePropertyPanel），目标 ~150 行。 |
+
+**行为不变铁律**：保留静态 `message`/`Modal`（原实现即静态，refactor 不转 App.useApp）；双向联动 isSyncing 防循环逻辑、debounce 300ms、离开拦截双层语义逐字搬移。延续 `process/propertyForms/` 已有拆分子组件先例。
 
 ### 验证
 

--- a/frontend/src/components/process/CollapsiblePropertyPanel.test.tsx
+++ b/frontend/src/components/process/CollapsiblePropertyPanel.test.tsx
@@ -1,0 +1,57 @@
+// CollapsiblePropertyPanel 单测：
+//  ① getCollapsedPanelTitle 纯函数——工艺/阶段/环节/悬空兜底四种路由。
+//  ② 渲染——展开态显示「收起属性面板」按钮，点击后切到收起态显示「展开属性面板」。
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CollapsiblePropertyPanel, getCollapsedPanelTitle } from './CollapsiblePropertyPanel';
+import type { ProcessDefinition } from '@/types/process';
+
+// 最小构造：phase 含 link，覆盖三种命中分支。
+const DEF = {
+  phases: [{ id: 'p1', links: [{ id: 'l1' }] }],
+} as unknown as ProcessDefinition;
+
+describe('getCollapsedPanelTitle — 表单路由标题', () => {
+  it('test_getCollapsedPanelTitle_未选节点返回工艺属性', () => {
+    expect(getCollapsedPanelTitle(DEF, null)).toBe('工艺属性');
+  });
+
+  it('test_getCollapsedPanelTitle_definition为null兜底工艺属性', () => {
+    expect(getCollapsedPanelTitle(null, 'p1')).toBe('工艺属性');
+  });
+
+  it('test_getCollapsedPanelTitle_命中phase返回阶段属性', () => {
+    expect(getCollapsedPanelTitle(DEF, 'p1')).toBe('阶段属性');
+  });
+
+  it('test_getCollapsedPanelTitle_命中link返回环节属性', () => {
+    expect(getCollapsedPanelTitle(DEF, 'l1')).toBe('环节属性');
+  });
+
+  it('test_getCollapsedPanelTitle_悬空引用兜底工艺属性', () => {
+    // 节点已删但 selectedNodeId 未清：不应误判为阶段/环节。
+    expect(getCollapsedPanelTitle(DEF, 'ghost')).toBe('工艺属性');
+  });
+});
+
+describe('CollapsiblePropertyPanel — 收缩/展开切换', () => {
+  it('test_展开态点收起后切到收起态显示展开按钮', () => {
+    // definition=null 让面板体走 Empty 分支，隔离掉 ProcessPropertyPanel 的渲染依赖，
+    // 只验收缩栏交互。标题在 null 下兜底为「工艺属性」。
+    render(
+      <CollapsiblePropertyPanel definition={null} selectedNodeId={null} onDefinitionChange={vi.fn()} />,
+    );
+
+    // 展开态：工具条标题 + 「收起属性面板」按钮可见。
+    expect(screen.getByText('工艺属性')).toBeInTheDocument();
+    const collapseBtn = screen.getByRole('button', { name: '收起属性面板' });
+    fireEvent.click(collapseBtn);
+
+    // 收起态：切到「展开属性面板」按钮（竖排标题同样是工艺属性，但按钮 aria-label 区分）。
+    expect(screen.getByRole('button', { name: '展开属性面板' })).toBeInTheDocument();
+
+    // 再点展开，回到展开态。
+    fireEvent.click(screen.getByRole('button', { name: '展开属性面板' }));
+    expect(screen.getByRole('button', { name: '收起属性面板' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/process/CollapsiblePropertyPanel.tsx
+++ b/frontend/src/components/process/CollapsiblePropertyPanel.tsx
@@ -1,0 +1,232 @@
+// CollapsiblePropertyPanel.tsx
+// ---------------------------------------------------------------------------
+// 096-W4-4-4：从 ProcessEditor.tsx 抽出的「可折叠属性面板」UI 块。
+//
+// 承接原主组件右侧属性面板的整段渲染（展开态工具条 + 内容区 / 收起态窄条），
+// 连同其专属样式族与 getCollapsedPanelTitle 纯函数一并下沉，让主组件只负责编排。
+//
+// 设计取舍：
+// - propertyPanelCollapsed 收为组件内部 state——它纯属视图偏好（看大图时收起），
+//   父组件无需感知，故不下放为 prop（YAGNI）。
+// - 不使用宽度过渡动画：过渡期间窄条几何位置不稳定、点击易落空，直接切换宽度更可靠
+//   （原实现的踩坑结论，逐字保留）。
+// - 收起态整条窄条都是一个 AntD Button：靠 Button 原生冒泡处理图标/文字点击，
+//   无需 pointer-events hack。
+// ---------------------------------------------------------------------------
+
+import { useState, type CSSProperties, type JSX } from 'react';
+import { Button, Empty } from 'antd';
+import { LeftOutlined, RightOutlined } from '@ant-design/icons';
+import type { ProcessDefinition } from '@/types/process';
+import { ProcessPropertyPanel } from './ProcessPropertyPanel';
+
+export interface CollapsiblePropertyPanelProps {
+  // 工艺定义（React Flow source of truth）。null 表示 YAML 解析失败，面板兜底空态。
+  definition: ProcessDefinition | null;
+  // 当前选中节点 YAML id（null = 全局面板）。用于收缩栏标题与属性表单路由。
+  selectedNodeId: string | null;
+  // 属性字段变更回调（可视化 → definition 路径），向上转交 useProcessEditorState。
+  onDefinitionChange: (definition: ProcessDefinition) => void;
+}
+
+// 收起态标题解析：与 ProcessPropertyPanel 的表单路由保持一致，
+// 让收缩栏显示的名称就是展开后表单头部的名称（工艺属性/阶段属性/环节属性）。
+// definition 为 null（YAML 未解析）时兜底为「工艺属性」。
+// 导出供单测直接断言（纯函数，无 React 依赖）。
+export function getCollapsedPanelTitle(
+  definition: ProcessDefinition | null,
+  selectedNodeId: string | null,
+): string {
+  // 未选中任何节点 → 全局面板，对应「工艺属性」
+  if (selectedNodeId === null || definition === null) return '工艺属性';
+  // 命中 phase → 「阶段属性」
+  if (definition.phases?.some((p) => p.id === selectedNodeId)) return '阶段属性';
+  // 命中任一 phase 下的 link → 「环节属性」
+  for (const p of definition.phases ?? []) {
+    if ((p.links ?? []).some((l) => l.id === selectedNodeId)) return '环节属性';
+  }
+  // 悬空引用（节点已删但 selectedNodeId 未清）→ 兜底工艺属性
+  return '工艺属性';
+}
+
+export function CollapsiblePropertyPanel({
+  definition,
+  selectedNodeId,
+  onDefinitionChange,
+}: CollapsiblePropertyPanelProps): JSX.Element {
+  // 收起状态：true = 收起为 32px 窄条（看大图时用），false = 正常 360px 面板。
+  // 纯视图态，组件自管，不外泄。
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div style={propertyPanelStyle(collapsed)}>
+      {collapsed ? (
+        // 收起态：整条窄条都是一个展开按钮（用 AntD Button，可靠处理点击），
+        // 纵向排版：顶部向左箭头、下方竖排标题。
+        // 箭头方向与展开态的向右箭头形成「→ 收起 / ← 展开」的对称语义。
+        <Button
+          type="text"
+          aria-label="展开属性面板"
+          title="展开属性面板"
+          style={expandStripButtonStyle}
+          onClick={() => setCollapsed(false)}
+        >
+          <div style={expandStripInnerStyle}>
+            {/* 顶部：向左箭头作为展开触发器（整条可点，箭头只是示意） */}
+            <LeftOutlined style={expandArrowStyle} />
+            {/* 底部：竖排标题，左靠齐（贴左边缘），让用户看清这是哪个面板 */}
+            <span style={expandTitleStyle}>
+              {getCollapsedPanelTitle(definition, selectedNodeId)}
+            </span>
+          </div>
+        </Button>
+      ) : (
+        // 展开态：顶部工具条（向右箭头收起）+ 面板内容
+        <>
+          <div style={panelToolbarStyle}>
+            {/* 工具条标题：与收起态窄条标题保持一致，左靠齐，
+                让用户一眼识别当前面板类型（工艺属性/阶段属性/环节属性）。 */}
+            <span style={panelToolbarTitleStyle}>
+              {getCollapsedPanelTitle(definition, selectedNodeId)}
+            </span>
+            <Button
+              type="text"
+              aria-label="收起属性面板"
+              title="收起属性面板"
+              style={collapseButtonStyle}
+              onClick={() => setCollapsed(true)}
+            >
+              {/* 展开态用向右箭头：面板固定在右侧，点击后向右收缩成窄条，
+                  箭头方向与面板退出的方向一致（常规语义）。 */}
+              <RightOutlined />
+            </Button>
+          </div>
+          <div style={panelBodyStyle}>
+            {definition ? (
+              <ProcessPropertyPanel
+                definition={definition}
+                selectedNodeId={selectedNodeId}
+                onDefinitionChange={onDefinitionChange}
+              />
+            ) : (
+              <Empty description="YAML 解析失败，无法显示属性面板" />
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── 属性面板专属样式族（随组件就近收口）──────────────────────────
+
+// 右：属性面板。展开固定 360px；收起为 32px 窄条（只留展开箭头）。
+// 注意：不使用宽度过渡动画。过渡会让面板在 200ms 内逐步收窄，
+// 期间窄条几何位置不稳定，点击容易落空（表现为「前几次点击失效」）。
+// 直接切换宽度更可靠，点击区域始终稳定。
+function propertyPanelStyle(collapsed: boolean): CSSProperties {
+  return {
+    width: collapsed ? 32 : 360,
+    height: '100%',
+    // 纵向 flex：展开时工具条在上、内容区撑满剩余
+    display: 'flex',
+    flexDirection: 'column',
+    // 面板背景，与可视化区区分（主题变量：亮色浅灰 / 暗色 surface0）
+    background: 'var(--color-bg-card)',
+    // 左边框分隔（主题变量）
+    borderLeft: '1px solid var(--color-border)',
+    // 收起态内容（窄条按钮）不允许溢出
+    overflow: 'hidden',
+  };
+}
+
+// 面板顶部工具条：左侧标题、右侧收起按钮，两端对齐。
+// 标题与收起态窄条标题一致，保持展开/收起两种形态名称统一。
+const panelToolbarStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: '8px 12px',
+  borderBottom: '1px solid var(--color-border)',
+  // 工具条不参与收缩，固定高度由内容决定
+  flexShrink: 0,
+};
+
+// 工具条标题：与表单内原有大标题同级字号、加粗，但不再占表单垂直空间。
+// 颜色用主题主文字变量，暗色下不再是写死的 slate-700。
+const panelToolbarTitleStyle: CSSProperties = {
+  fontSize: 16,
+  fontWeight: 600,
+  color: 'var(--color-text)',
+  lineHeight: 1.4,
+};
+
+// 面板内容区：撑满工具条之外的剩余高度，滚动只发生在内容区。
+const panelBodyStyle: CSSProperties = {
+  flex: 1,
+  overflow: 'auto',
+};
+
+// 收起按钮（AntD Button type=text）：小号透明按钮，hover 由 AntD 处理。
+// 覆盖默认阴影/最小高度，保持工具条极简、与标题两端对齐。
+const collapseButtonStyle: CSSProperties = {
+  background: 'transparent',
+  border: 'none',
+  boxShadow: 'none',
+  color: 'var(--color-text-secondary)',
+  fontSize: 12,
+  cursor: 'pointer',
+  height: 'auto',
+  padding: '2px 6px',
+  lineHeight: 1.4,
+};
+
+// 收起态的整条展开按钮（AntD Button type=text）：铺满 32px 窄条全高，
+// 整条可点让用户不用瞄准小图标。覆盖 AntD 默认内边距/最小高度/阴影，
+// 确保按钮占满窄条且不被默认样式挤压。
+const expandStripButtonStyle: CSSProperties = {
+  width: '100%',
+  height: '100%',
+  padding: 0,
+  background: 'transparent',
+  border: 'none',
+  boxShadow: 'none',
+  color: 'var(--color-text-secondary)',
+  fontSize: 12,
+  cursor: 'pointer',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+// 收起态内部纵向容器：箭头贴顶、竖排标题贴底，两端分布。
+// 这样在 32px 窄条里也能清晰呈现「标题 + 箭头」的收缩栏形态。
+// 内层容器不拦截鼠标，点击由外层 AntD Button 统一处理（Button 原生会正确
+// 把内部图标/文字的点击冒泡到自身，无需 pointer-events hack）。
+const expandStripInnerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+  height: '100%',
+  padding: '10px 0',
+};
+
+// 收缩栏箭头：小号、低调颜色（主题次级文字），hover 由按钮整体承接交互。
+const expandArrowStyle: CSSProperties = {
+  fontSize: 12,
+  color: 'var(--color-text-secondary)',
+};
+
+// 收缩栏标题：竖排（writing-mode vertical-rl）以便在中文字符下自然竖读，
+// 贴左边缘、不换行。窄条宽度有限，竖排是唯一可读的呈现方式。
+// 颜色用主题主文字变量，暗色下保持可读。
+const expandTitleStyle: CSSProperties = {
+  writingMode: 'vertical-rl',
+  textOrientation: 'upright',
+  letterSpacing: 2,
+  fontSize: 13,
+  color: 'var(--color-text)',
+  whiteSpace: 'nowrap',
+};

--- a/frontend/src/components/process/ProcessEditor.tsx
+++ b/frontend/src/components/process/ProcessEditor.tsx
@@ -1,328 +1,78 @@
 // ProcessEditor.tsx
 // ---------------------------------------------------------------------------
-// M4 里程碑：工艺编辑器主组件（M4 双栏布局版本）。
+// M4 里程碑：工艺编辑器主组件（096-W4-4-4 收口后为编排器）。
 //
 // 设计定位（对应 docs/design/029-M4-ReactFlow可视化编辑器-方案.md §3.1.11 + 方案 §2.8）：
-// - M3 骨架扩展为双栏布局：左 React Flow 可视化区 + 右属性面板。
-// - M4 只做"可视化操作 → ProcessDefinition 不可变更新"，不回写 Monaco（M5 sync flag）。
-// - M5 会在顶部加保存/删除按钮 + 双向联动 sync flag。
-// - M6 会加新建工艺元信息 Modal + 空工艺渲染。
+// - 双栏布局：左 React Flow 可视化区 + 右属性面板；顶部 Toolbar + 系统 Alert；Tab 切可视化/YAML。
+// - M5 双向联动：可视化 ↔ Monaco YAML 双向同步（isSyncing 防循环），保存/删除/离开拦截齐全。
 //
-// 数据流（M4 单向，可视化 → ProcessDefinition）：
-//   路由 processGuid → bundledApi.getProcess → detail.definition / is_system
-//   （040 起按 guid 寻址：name 允许重复，guid 才是唯一身份）
-//   → parseYaml(result.definition) → setDefinition(parsed)
-//   → ProcessVisualEditor 渲染 React Flow
-//   → 用户拖连线 / 删节点 → onDefinitionChange(newDefinition)
-//   → ProcessPropertyPanel 渲染属性表单
-//   → 用户改字段 → onDefinitionChange(newDefinition)
+// 096-W4-4-4 拆分后职责边界（原 704 行 → 编排器）：
+// - 数据/双向联动/未保存标记 → useProcessEditorState
+// - 保存/删除/返回/复制 → useProcessPersistence
+// - 离开拦截（hashchange + beforeunload）→ useLeaveGuard
+// - 可折叠属性面板 UI → CollapsiblePropertyPanel
+// - 骨架样式 → processEditorStyles
+// 本组件只保留：activeTab（纯视图态）+ 三 hook 编排 + 渲染分支组合。
 //
-// 注意：M4 不回写 Monaco（ProcessYamlEditor 的 value 仍是初始 yamlText）。
-// M5 会加 isSyncing flag 实现 YAML ↔ 可视化双向联动。
-//
-// 非目标（留给后续里程碑）：
-// - M5：保存按钮（PUT）、删除按钮（DELETE）、双向联动 sync flag、离开拦截
-// - M6：新建工艺元信息 Modal、空工艺渲染
+// 数据流（M4 单向 + M5 双向联动）：
+//   路由 processGuid → useProcessEditorState.bundledApi.getProcess → definition / yamlText
+//   → 可视化区拖连线/改属性 → handleDefinitionChange → yamlDump 刷新 Monaco
+//   → Monaco 编辑 → handleYamlChange（debounced）→ parseYaml 回写 definition
+//   → 保存 → useProcessPersistence.handleSave（PUT yamlText）→ 回刷 Monaco + 清 dirty
 // ---------------------------------------------------------------------------
 
-import {
-  useEffect,
-  useState,
-  useCallback,
-  useRef,
-  type CSSProperties,
-  type JSX,
-} from 'react';
-import { Alert, Button, Empty, Spin, Modal, message } from 'antd';
-import { CopyOutlined, LeftOutlined, RightOutlined } from '@ant-design/icons';
-import {
-  bundledApi,
-  type ProcessTemplateDetail,
-} from '@/api/bundled';
-import type { ProcessDefinition } from '@/types/process';
+import { useState, type JSX } from 'react';
+import { Alert, Button, Empty, Spin } from 'antd';
+import { CopyOutlined } from '@ant-design/icons';
 import { useTheme } from '@/hooks/useTheme';
+import { useProcessEditorState } from '@/hooks/useProcessEditorState';
+import { useProcessPersistence } from '@/hooks/useProcessPersistence';
+import { useLeaveGuard } from '@/hooks/useLeaveGuard';
 import { ProcessYamlEditor } from './ProcessYamlEditor';
 import { ProcessVisualEditor } from './ProcessVisualEditor';
-import { ProcessPropertyPanel } from './ProcessPropertyPanel';
 import { ProcessEditorToolbar } from './ProcessEditorToolbar';
-import { parseYaml, yamlDump } from './processYamlValidator';
+import { CollapsiblePropertyPanel } from './CollapsiblePropertyPanel';
+import {
+  loadingContainerStyle,
+  editorContainerStyle,
+  alertStyle,
+  splitViewStyle,
+  tabBarStyle,
+  tabButtonStyle,
+  tabButtonActiveStyle,
+  tabsStyle,
+  yamlEditorWrapperStyle,
+  visualEditorStyle,
+} from './processEditorStyles';
 
 export interface ProcessEditorProps {
   // 工艺 guid（从路由参数取，作为 bundledApi.getProcess 等 API 的寻址参数）
   processGuid: string;
 }
 
-// ProcessEditor 组件实现。
-//
-// 状态（M4 扩展集）：
-// - detail：工艺详情（M3 已有）
-// - loading：加载中标志（M3 已有）
-// - yamlText：Monaco 编辑器内的 YAML 文本（M3 已有，M4 不再驱动）
-// - isSystem：是否系统工艺（M3 已有）
-// - definition：工艺定义对象（M4 新增，React Flow 的 source of truth）
-// - selectedNodeId：当前选中的节点 YAML id（M4 新增，属性面板切换用）
 export function ProcessEditor({ processGuid }: ProcessEditorProps): JSX.Element {
-  // 从 ThemeProvider 获取当前主题模式
+  // 从 ThemeProvider 获取当前主题模式（传给 React Flow / Monaco）
   const { themeMode } = useTheme();
 
-  // ── M3 已有状态 ──────────────────────────────────
-  const [detail, setDetail] = useState<ProcessTemplateDetail | null>(null);
-  const [loading, setLoading] = useState(true);
-  // yamlText 驱动 Monaco，受双向联动影响（可视化操作 → yamlDump 刷新）
-  const [yamlText, setYamlText] = useState('');
-  const [isSystem, setIsSystem] = useState(false);
-
-  // ── M4 已有状态 ──────────────────────────────────
-  // 工艺定义对象（React Flow 的 source of truth）
-  const [definition, setDefinition] = useState<ProcessDefinition | null>(null);
-  // 当前选中的节点 YAML id（null = 全局面板）
-  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
-
-  // ── M5 新增状态 ──────────────────────────────────
-  // 双向联动防循环 flag：可视化→YAML 或 YAML→可视化 推送期间置 true，
-  // 让对端的 onChange 在 flag 期间忽略，推完后清 flag（setTimeout 0）
-  const [isSyncing, setIsSyncing] = useState(false);
-  // 未保存修改标记，离开拦截用（用户改了任何字段就置 true，保存成功后置回 false）
-  // M5 双向联动已 setIsDirty(true)，保存按钮/离开拦截在任务 #6/#7 接入读取
-  const [isDirty, setIsDirty] = useState(false);
-  void isDirty;
-  // 保存中状态，控制保存按钮禁用 + loading
-  const [isSaving, setIsSaving] = useState(false);
-  // 删除中状态，控制删除按钮禁用 + loading
-  const [isDeleting, setIsDeleting] = useState(false);
-  // debounced parseYaml 的 timer ref，避免快速编辑触发多次解析
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // 当前激活的 Tab：'visual'（可视化双栏）| 'yaml'（Monaco YAML）
+  // 当前激活的 Tab：'visual'（可视化双栏）| 'yaml'（Monaco YAML）。纯视图态，组件自管。
   const [activeTab, setActiveTab] = useState<'visual' | 'yaml'>('visual');
-  // 属性面板收缩状态：true = 收起为窄条（看大图时用），false = 正常 360px 面板
-  const [propertyPanelCollapsed, setPropertyPanelCollapsed] = useState(false);
 
-  // ── 加载工艺详情副作用 ──────────────────────────
-  // 依赖 [processGuid]：目标工艺变化时重新加载
-  useEffect(() => {
-    // 标记加载开始
-    setLoading(true);
-    // 清空旧数据，避免切换工艺时闪现上一个工艺的内容
-    setDetail(null);
-    setYamlText('');
-    setIsSystem(false);
-    setDefinition(null);
-    setSelectedNodeId(null);
-
-    // 定义异步加载函数
-    const loadDetail = async () => {
-      try {
-        // 调用 M1 已有的 API 客户端获取工艺详情
-        const result = await bundledApi.getProcess(processGuid);
-        // 设置详情和 Monaco 文本
-        setDetail(result);
-        setYamlText(result.definition);
-        setIsSystem(result.is_system);
-        // M4 新增：解析 YAML 文本为 ProcessDefinition 对象
-        // 用 parseYaml 纯函数解析，成功后 setDefinition
-        const parsed = parseYaml(result.definition);
-        if (parsed.parsed && typeof parsed.parsed === 'object') {
-          setDefinition(parsed.parsed as ProcessDefinition);
-        } else if (parsed.error) {
-          // YAML 解析失败：提示错误，definition 保持 null
-          // M5 会在这里加"YAML 错误时可视化区显示错误提示"逻辑
-          message.error(`YAML 解析失败：${parsed.error.message}`);
-        }
-      } catch {
-        // 加载失败时 message.error 提示
-        message.error(`加载工艺「${processGuid}」失败`);
-      } finally {
-        // 无论成功失败都关闭 loading
-        setLoading(false);
-      }
-    };
-
-    // 触发异步加载
-    void loadDetail();
-  }, [processGuid]);
-
-  // ── 复制系统工艺到用户层 ──────────────────────────
-  // 成功后 message.success 提示用户重新打开编辑器
-  // （M3 不自动刷新状态，避免复杂的状态重置逻辑；M5 会优化）
-  const handleCopyToUser = async () => {
-    try {
-      const copied = await bundledApi.copyProcessToUser(processGuid);
-      // 040：副本是新 guid 的独立工艺，直接跳副本编辑器，不用手动重新打开。
-      message.success('已复制为我的工艺，正在打开副本…');
-      window.location.hash = `#/processes?processMode=edit&guid=${copied.guid}`;
-    } catch {
-      message.error('复制到用户层失败');
-    }
-  };
-
-  // ── M4/M5：可视化操作回调（可视化 → YAML 路径）─────
-  // 可视化区 / 属性面板修改 definition 后：
-  // 1. setDefinition 更新 source of truth
-  // 2. setIsDirty(true) 标记未保存
-  // 3. setIsSyncing(true) 防 Monaco onChange 循环
-  // 4. yamlDump 刷新 Monaco 文本
-  // 5. setTimeout 0 清 flag（让 Monaco 先处理 onChange）
-  const handleDefinitionChange = useCallback(
-    (newDefinition: ProcessDefinition) => {
-      setDefinition(newDefinition);
-      setIsDirty(true);
-      // 防 Monaco onChange 循环：推送期间置 flag
-      setIsSyncing(true);
-      // 可视化 → YAML：dump 刷新 Monaco
-      const newYaml = yamlDump(newDefinition);
-      setYamlText(newYaml);
-      // 推完后清 flag（setTimeout 0 让 Monaco 先处理本轮 onChange）
-      setTimeout(() => setIsSyncing(false), 0);
-    },
-    [],
-  );
-
-  // ── M5：Monaco 编辑回调（YAML → 可视化 路径）─────
-  // Monaco onChange 触发：
-  // 1. setYamlText 更新受控文本
-  // 2. setIsDirty(true) 标记未保存
-  // 3. if (isSyncing) return — flag 期间忽略（可视化触发的刷新）
-  // 4. debounced 300ms parseYaml：成功更新 definition，失败只标红不破坏可视化
-  const handleYamlChange = useCallback(
-    (newYaml: string) => {
-      setYamlText(newYaml);
-      setIsDirty(true);
-      // flag 期间忽略：这是可视化触发的刷新，避免循环
-      if (isSyncing) return;
-      // 清上一个 debounce timer，避免快速编辑触发多次解析
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      // debounced 300ms 后解析 YAML
-      debounceRef.current = setTimeout(() => {
-        const parsed = parseYaml(newYaml);
-        if (parsed.parsed && typeof parsed.parsed === 'object') {
-          // 解析成功：更新 definition，React Flow 重渲染
-          // 防 React Flow onNodesChange 循环：推送期间置 flag
-          setIsSyncing(true);
-          setDefinition(parsed.parsed as ProcessDefinition);
-          setTimeout(() => setIsSyncing(false), 0);
-        }
-        // 解析失败：Monaco 标红（ProcessYamlEditor 内部处理），不破坏可视化
-      }, 300);
-    },
-    [isSyncing],
-  );
-
-  // ── M5：保存回调（PUT /api/v1/processes/{guid}）─────────
-  // 用 yamlText（Monaco 当前文本）而非 definition，因为用户可能在 YAML tab
-  // 直接编辑未触发 debounced parseYaml 的中间态。yamlText 永远是最新文本。
-  const handleSave = useCallback(async () => {
-    setIsSaving(true);
-    try {
-      const res = await bundledApi.putProcess(processGuid, yamlText);
-      // 回刷 Monaco 为后端递增后的真值 YAML：避免陈旧 version 下次保存时
-      // yaml_version != template.version 触发跳过 bump 并回写旧版本（需求 042 回归根因）。
-      setYamlText(res.definition);
-      message.success('工艺已保存');
-      // 保存成功：清未保存标记，不跳路由不清表单（保留当前 definition + 节点位置）
-      setIsDirty(false);
-    } catch (err) {
-      // 兜底错误提示：后端 400（结构校验失败）/ 409（系统工艺）已在 message 反馈
-      const msg = err instanceof Error ? err.message : String(err);
-      message.error(`保存失败：${msg}`);
-    } finally {
-      setIsSaving(false);
-    }
-  }, [processGuid, yamlText]);
-
-  // ── M5：删除回调（DELETE /api/v1/processes/{guid}）─────
-  // 弹 Modal.confirm 二次确认，确认后调 DELETE，成功跳路由回列表页
-  const handleDelete = useCallback(() => {
-    Modal.confirm({
-      // NTD-014-D：优先显示工艺显示名（detail.display_name），
-      // 其次 YAML name，最后才回退 GUID——原实现取 detail.name（恒为空）导致弹 GUID。
-      // 注意：detail 必须进 deps——闭包若捕获初始 null，确认框永远显示 GUID（陈旧闭包）。
-      title: `确认删除工艺「${detail?.display_name ?? detail?.name ?? processGuid}」？`,
-      content: '此操作不可恢复。',
-      okText: '删除',
-      okType: 'danger',
-      cancelText: '取消',
-      onOk: async () => {
-        setIsDeleting(true);
-        try {
-          await bundledApi.deleteProcess(processGuid);
-          message.success('工艺已删除');
-          // 先置 isDirty=false 避免离开拦截误触发（hashchange 监听在任务 #7）
-          setIsDirty(false);
-          // 跳路由回列表页（hash 路由）
-          window.location.hash = '#/processes';
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          message.error(`删除失败：${msg}`);
-          setIsDeleting(false);
-        }
-      },
-    });
-  }, [processGuid, detail]);
-
-  // ── 返回工艺列表页 ─────────────────────────────────
-  // 仅设置 location.hash 触发 hashchange；若 isDirty，离开拦截的 hashchange
-  // 监听会弹「未保存修改」确认框，确认后才真正跳转，避免误丢改动。
-  const handleBack = useCallback(() => {
-    window.location.hash = '#/processes';
-  }, []);
-
-  // ── M5：离开拦截（需求 §3.6）──────────────────────
-  // 两层拦截，共享 isDirty 状态（用户改了任何字段就置 true，保存成功后置回 false）。
-  //
-  // 1. 路由内跳转（hash 路由）：监听 hashchange，isDirty 时弹 Modal.confirm 呝止，
-  //    用户确认后跳目标路由，取消则用 history.replaceState 回退旧 hash（避免再触发 hashchange）。
-  // 2. 刷新/关页签：window.beforeunload，isDirty 时 e.preventDefault() + returnValue=''，
-  //    浏览器原生提示（Chrome/Firefox/Safari 统一行为）。
-  //
-  // 注意：项目无 react-router-dom（用 hash 路由 + 自研 useViewState），
-  // 故 React Router 的 useBlocker 不可用，改用 window 层 hashchange 监听。
-  useEffect(() => {
-    // 路由内跳转拦截：hashchange 监听
-    const handleHashChange = (e: HashChangeEvent) => {
-      // 仅在 isDirty 时拦截；非 dirty 放行
-      if (!isDirty) return;
-      // 雹 Modal.confirm 呝止跳转
-      Modal.confirm({
-        title: '你有未保存的修改',
-        content: '确认离开？未保存的修改将丢失。',
-        okText: '离开',
-        cancelText: '留下',
-        onOk: () => {
-          // 用户确认后允许跳转：先置 isDirty=false 避免目标路由二次拦截
-          setIsDirty(false);
-          // 跳目标 hash（e.newURL 已含完整 URL，取 # 后部分）
-          const newHash = e.newURL.split('#')[1] ?? '';
-          window.location.hash = newHash;
-        },
-        onCancel: () => {
-          // 取消时不跳转：hashchange 已触发，需回退旧 hash
-          // 用 history.replaceState 避免再触发 hashchange（直接设 location.hash 会再触发）
-          history.replaceState(null, '', e.oldURL);
-        },
-      });
-    };
-    window.addEventListener('hashchange', handleHashChange);
-
-    // 刷新/关页签拦截：beforeunload 监听
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (!isDirty) return;
-      // 标准行为：preventDefault + returnValue='' 触发浏览器原生提示
-      e.preventDefault();
-      e.returnValue = '';
-    };
-    window.addEventListener('beforeunload', handleBeforeUnload);
-
-    // 清理：组件卸载或 isDirty 变化时移除监听
-    return () => {
-      window.removeEventListener('hashchange', handleHashChange);
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-    };
-  }, [isDirty]);
+  // 编辑器数据 + 双向联动 + 未保存标记（加载/definition/yamlText/selectedNodeId/isDirty/handle*）。
+  const editor = useProcessEditorState(processGuid);
+  // 持久化动作（保存/删除/返回/复制），注入编辑器状态的回写出口。
+  const persistence = useProcessPersistence(processGuid, {
+    detail: editor.detail,
+    yamlText: editor.yamlText,
+    setYamlText: editor.setYamlText,
+    markClean: editor.markClean,
+  });
+  // 离开拦截：isDirty 时弹确认/原生提示；确认离开前清标记防二次 hashchange。
+  useLeaveGuard(editor.isDirty, editor.markClean);
 
   // ── 渲染分支 ──────────────────────────────────────
 
   // 加载中：显示 Spin
-  if (loading) {
+  if (editor.loading) {
     return (
       <div style={loadingContainerStyle}>
         <Spin tip="加载工艺..." />
@@ -331,7 +81,7 @@ export function ProcessEditor({ processGuid }: ProcessEditorProps): JSX.Element 
   }
 
   // 加载完成但详情为空：工艺不存在或加载失败
-  if (!detail) {
+  if (!editor.detail) {
     return (
       <div style={loadingContainerStyle}>
         <Empty description={`工艺「${processGuid}」不存在或加载失败`} />
@@ -342,21 +92,21 @@ export function ProcessEditor({ processGuid }: ProcessEditorProps): JSX.Element 
   // 主渲染：Toolbar + Alert + Tabs（可视化/YAML）
   return (
     <div style={editorContainerStyle}>
-      {/* M5：顶部工具栏（保存/删除 + 未保存红点） */}
+      {/* 顶部工具栏（保存/删除 + 未保存红点） */}
       <ProcessEditorToolbar
-        processName={detail.name}
-        displayName={detail.display_name}
-        isSystem={isSystem}
-        isDirty={isDirty}
-        isSaving={isSaving}
-        isDeleting={isDeleting}
-        onSave={handleSave}
-        onDelete={handleDelete}
-        onBack={handleBack}
+        processName={editor.detail.name}
+        displayName={editor.detail.display_name}
+        isSystem={editor.isSystem}
+        isDirty={editor.isDirty}
+        isSaving={persistence.isSaving}
+        isDeleting={persistence.isDeleting}
+        onSave={persistence.handleSave}
+        onDelete={persistence.handleDelete}
+        onBack={persistence.handleBack}
       />
 
       {/* 顶部 Alert：系统工艺黄色 + 复制链接 */}
-      {isSystem && (
+      {editor.isSystem && (
         <Alert
           type="warning"
           showIcon
@@ -365,7 +115,7 @@ export function ProcessEditor({ processGuid }: ProcessEditorProps): JSX.Element 
             <Button
               type="link"
               icon={<CopyOutlined />}
-              onClick={handleCopyToUser}
+              onClick={persistence.handleCopyToUser}
             >
               复制到用户层后编辑
             </Button>
@@ -374,7 +124,7 @@ export function ProcessEditor({ processGuid }: ProcessEditorProps): JSX.Element 
         />
       )}
 
-      {/* M5：Tab 切换可视化/YAML，支撑双向联动 */}
+      {/* Tab 切换可视化/YAML，支撑双向联动 */}
       {/* 不用 Ant Design Tabs items API：其内部 .ant-tabs-tabpane 用 position:absolute + display:none 切换， */}
       {/* 导致 React Flow v12 的 ResizeObserver 拿到 0 尺寸，可视化区塌为 h:0 一片空白 */}
       {/* 改用手写两按钮 + display 切换：React Flow 始终挂载不卸载，父代明确 flex 链撑开 */}
@@ -400,305 +150,35 @@ export function ProcessEditor({ processGuid }: ProcessEditorProps): JSX.Element 
         {/* display 切换不卸载组件，React Flow 始终挂载；flex:1 撑满剩余高度 */}
         <div style={{ ...splitViewStyle, display: activeTab === 'visual' ? 'flex' : 'none' }}>
           <div style={visualEditorStyle}>
-            {definition ? (
+            {editor.definition ? (
               <ProcessVisualEditor
-                definition={definition}
-                onDefinitionChange={handleDefinitionChange}
-                selectedNodeId={selectedNodeId}
-                onSelectNode={setSelectedNodeId}
+                definition={editor.definition}
+                onDefinitionChange={editor.handleDefinitionChange}
+                selectedNodeId={editor.selectedNodeId}
+                onSelectNode={editor.setSelectedNodeId}
                 theme={themeMode}
               />
             ) : (
               <Empty description="YAML 解析失败，无法显示可视化区" />
             )}
           </div>
-          <div style={propertyPanelStyle(propertyPanelCollapsed)}>
-            {propertyPanelCollapsed ? (
-              // 收起态：整条窄条都是一个展开按钮（用 AntD Button，可靠处理点击），
-              // 纵向排版：顶部向左箭头、下方竖排标题。
-              // 箭头方向与展开态的向右箭头形成「→ 收起 / ← 展开」的对称语义。
-              <Button
-                type="text"
-                aria-label="展开属性面板"
-                title="展开属性面板"
-                style={expandStripButtonStyle}
-                onClick={() => setPropertyPanelCollapsed(false)}
-              >
-                <div style={expandStripInnerStyle}>
-                  {/* 顶部：向左箭头作为展开触发器（整条可点，箭头只是示意） */}
-                  <LeftOutlined style={expandArrowStyle} />
-                  {/* 底部：竖排标题，左靠齐（贴左边缘），让用户看清这是哪个面板 */}
-                  <span style={expandTitleStyle}>
-                    {getCollapsedPanelTitle(definition, selectedNodeId)}
-                  </span>
-                </div>
-              </Button>
-            ) : (
-              // 展开态：顶部工具条（向右箭头收起）+ 面板内容
-              <>
-                <div style={panelToolbarStyle}>
-                  {/* 工具条标题：与收起态窄条标题保持一致，左靠齐，
-                      让用户一眼识别当前面板类型（工艺属性/阶段属性/环节属性）。 */}
-                  <span style={panelToolbarTitleStyle}>
-                    {getCollapsedPanelTitle(definition, selectedNodeId)}
-                  </span>
-                  <Button
-                    type="text"
-                    aria-label="收起属性面板"
-                    title="收起属性面板"
-                    style={collapseButtonStyle}
-                    onClick={() => setPropertyPanelCollapsed(true)}
-                  >
-                    {/* 展开态用向右箭头：面板固定在右侧，点击后向右收缩成窄条，
-                        箭头方向与面板退出的方向一致（常规语义）。 */}
-                    <RightOutlined />
-                  </Button>
-                </div>
-                <div style={panelBodyStyle}>
-                  {definition ? (
-                    <ProcessPropertyPanel
-                      definition={definition}
-                      selectedNodeId={selectedNodeId}
-                      onDefinitionChange={handleDefinitionChange}
-                    />
-                  ) : (
-                    <Empty description="YAML 解析失败，无法显示属性面板" />
-                  )}
-                </div>
-              </>
-            )}
-          </div>
+          <CollapsiblePropertyPanel
+            definition={editor.definition}
+            selectedNodeId={editor.selectedNodeId}
+            onDefinitionChange={editor.handleDefinitionChange}
+          />
         </div>
 
         {/* YAML Tab：Monaco 编辑器，接入双向联动 */}
         <div style={{ ...yamlEditorWrapperStyle, display: activeTab === 'yaml' ? 'block' : 'none' }}>
           <ProcessYamlEditor
-            value={yamlText}
-            onChange={handleYamlChange}
-            readOnly={isSystem}
+            value={editor.yamlText}
+            onChange={editor.handleYamlChange}
+            readOnly={editor.isSystem}
             theme={themeMode}
           />
         </div>
       </div>
     </div>
   );
-}
-
-// ── 样式常量 ──────────────────────────────────────────
-
-// 加载/空状态容器：居中
-const loadingContainerStyle: CSSProperties = {
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  height: '100%',
-  minHeight: 300,
-};
-
-// 编辑器主容器：纵向 flex，Alert 固定高度，双栏区填满剩余
-const editorContainerStyle: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  height: '100%',
-  width: '100%',
-};
-
-// Alert 样式：底部留间距
-const alertStyle: CSSProperties = {
-  marginBottom: 12,
-};
-
-// 双栏布局：横向 flex
-// position:absolute + inset:0 绕过 Ant Design Tabs 内部 .ant-tabs-tabpane 的 position:absolute 链
-// （tabpane 默认 absolute + 无明确高度，子代 height:100%/flex:1 全失效，React Flow 塌为 h:0）
-// 撑满 Tabs 根（tabsStyle 有 position:relative + 明确高度）
-const splitViewStyle: CSSProperties = {
-  flexDirection: 'row',
-  flex: 1,
-  minHeight: 400,
-};
-
-// Tab 按钮栏：横向 flex，底部边框分隔（仿 Ant Design Tabs 视觉）
-// 边框用主题变量，暗色下随 data-theme 切换，不再是亮色 slate 写死值
-const tabBarStyle: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'row',
-  borderBottom: '1px solid var(--color-border)',
-  padding: '0 4px',
-};
-
-// Tab 按钮：未激活态，次级文字 + 透明背景（主题变量，暗色下保持可读）
-const tabButtonStyle: CSSProperties = {
-  padding: '8px 16px',
-  border: 'none',
-  background: 'transparent',
-  cursor: 'pointer',
-  color: 'var(--color-text-secondary)',
-  fontSize: 14,
-};
-
-// Tab 按钮：激活态，主色文字 + 底部主色高亮条（仿 Ant Design Tabs 激活态）
-const tabButtonActiveStyle: CSSProperties = {
-  ...tabButtonStyle,
-  color: 'var(--color-primary)',
-  fontWeight: 500,
-  boxShadow: 'inset 0 -2px 0 var(--color-primary)',
-};
-
-// Tabs 容器：填满剩余高度
-// overflow:hidden 让 Tabs 内容区剪裁，nav 不溢出覆盖可视化区
-// Ant Design Tabs 内容区默认无明确高度，需 flex:1 + minHeight 让内部 React Flow 撑开
-// 父代 splitViewStyle 已 flex:1 撑开，这里 flex:1 + height:100% 雾路接通
-const tabsStyle: CSSProperties = {
-  flex: 1,
-  display: 'flex',
-  flexDirection: 'column',
-  minHeight: 400,
-  // 关键：让 Tabs 内容区（含 React Flow）正确剪裁，nav 不覆盖画布
-  overflow: 'hidden',
-};
-
-// YAML 编辑器包装：撑满 Tab 内容区
-// 同 splitViewStyle，用 absolute+inset:0 绕过 tabpane 链
-const yamlEditorWrapperStyle: CSSProperties = {
-  flex: 1,
-  minHeight: 400,
-};
-
-// 左：可视化区，flex 1（占剩余宽度）
-// 父代 splitViewStyle 已 absolute+inset:0 撑开，这里 flex:1 + height:100% 链路接通
-const visualEditorStyle: CSSProperties = {
-  flex: 1,
-  minWidth: 400,
-  height: '100%',
-};
-
-// 右：属性面板。展开固定 360px；收起为 32px 窄条（只留展开箭头）。
-// 注意：不使用宽度过渡动画。过渡会让面板在 200ms 内逐步收窄，
-// 期间窄条几何位置不稳定，点击容易落空（表现为「前几次点击失效」）。
-// 直接切换宽度更可靠，点击区域始终稳定。
-function propertyPanelStyle(collapsed: boolean): CSSProperties {
-  return {
-    width: collapsed ? 32 : 360,
-    height: '100%',
-    // 纵向 flex：展开时工具条在上、内容区撑满剩余
-    display: 'flex',
-    flexDirection: 'column',
-    // 面板背景，与可视化区区分（主题变量：亮色浅灰 / 暗色 surface0）
-    background: 'var(--color-bg-card)',
-    // 左边框分隔（主题变量）
-    borderLeft: '1px solid var(--color-border)',
-    // 收起态内容（窄条按钮）不允许溢出
-    overflow: 'hidden',
-  };
-}
-
-// 面板顶部工具条：左侧标题、右侧收起按钮，两端对齐。
-// 标题与收起态窄条标题一致，保持展开/收起两种形态名称统一。
-const panelToolbarStyle: CSSProperties = {
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  padding: '8px 12px',
-  borderBottom: '1px solid var(--color-border)',
-  // 工具条不参与收缩，固定高度由内容决定
-  flexShrink: 0,
-};
-
-// 工具条标题：与表单内原有大标题同级字号、加粗，但不再占表单垂直空间。
-// 颜色用主题主文字变量，暗色下不再是写死的 slate-700
-const panelToolbarTitleStyle: CSSProperties = {
-  fontSize: 16,
-  fontWeight: 600,
-  color: 'var(--color-text)',
-  lineHeight: 1.4,
-};
-
-// 面板内容区：撑满工具条之外的剩余高度，滚动只发生在内容区
-const panelBodyStyle: CSSProperties = {
-  flex: 1,
-  overflow: 'auto',
-};
-
-// 收起按钮（AntD Button type=text）：小号透明按钮，hover 由 AntD 处理。
-// 覆盖默认阴影/最小高度，保持工具条极简、与标题两端对齐。
-const collapseButtonStyle: CSSProperties = {
-  background: 'transparent',
-  border: 'none',
-  boxShadow: 'none',
-  color: 'var(--color-text-secondary)',
-  fontSize: 12,
-  cursor: 'pointer',
-  height: 'auto',
-  padding: '2px 6px',
-  lineHeight: 1.4,
-};
-
-// 收起态的整条展开按钮（AntD Button type=text）：铺满 32px 窄条全高，
-// 整条可点让用户不用瞄准小图标。覆盖 AntD 默认内边距/最小高度/阴影，
-// 确保按钮占满窄条且不被默认样式挤压。
-const expandStripButtonStyle: CSSProperties = {
-  width: '100%',
-  height: '100%',
-  padding: 0,
-  background: 'transparent',
-  border: 'none',
-  boxShadow: 'none',
-  color: 'var(--color-text-secondary)',
-  fontSize: 12,
-  cursor: 'pointer',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-};
-
-// 收起态内部纵向容器：箭头贴顶、竖排标题贴底，两端分布。
-// 这样在 32px 窄条里也能清晰呈现「标题 + 箭头」的收缩栏形态。
-// 内层容器不拦截鼠标，点击由外层 AntD Button 统一处理（Button 原生会正确
-// 把内部图标/文字的点击冒泡到自身，无需 pointer-events hack）。
-const expandStripInnerStyle: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  width: '100%',
-  height: '100%',
-  padding: '10px 0',
-};
-
-// 收缩栏箭头：小号、低调颜色（主题次级文字），hover 由按钮整体承接交互。
-const expandArrowStyle: CSSProperties = {
-  fontSize: 12,
-  color: 'var(--color-text-secondary)',
-};
-
-// 收缩栏标题：竖排（writing-mode vertical-rl）以便在中文字符下自然竖读，
-// 贴左边缘、不换行。窄条宽度有限，竖排是唯一可读的呈现方式。
-// 颜色用主题主文字变量，暗色下保持可读。
-const expandTitleStyle: CSSProperties = {
-  writingMode: 'vertical-rl',
-  textOrientation: 'upright',
-  letterSpacing: 2,
-  fontSize: 13,
-  color: 'var(--color-text)',
-  whiteSpace: 'nowrap',
-};
-
-// 收起态标题解析：与 ProcessPropertyPanel 的表单路由保持一致，
-// 让收缩栏显示的名称就是展开后表单头部的名称（工艺属性/阶段属性/环节属性）。
-// definition 为 null（YAML 未解析）时兜底为工艺属性。
-function getCollapsedPanelTitle(
-  definition: ProcessDefinition | null,
-  selectedNodeId: string | null,
-): string {
-  // 未选中任何节点 → 全局面板，对应「工艺属性」
-  if (selectedNodeId === null || definition === null) return '工艺属性';
-  // 命中 phase → 「阶段属性」
-  if (definition.phases?.some((p) => p.id === selectedNodeId)) return '阶段属性';
-  // 命中任一 phase 下的 link → 「环节属性」
-  for (const p of definition.phases ?? []) {
-    if ((p.links ?? []).some((l) => l.id === selectedNodeId)) return '环节属性';
-  }
-  // 悬空引用（节点已删但 selectedNodeId 未清）→ 兜底工艺属性
-  return '工艺属性';
 }

--- a/frontend/src/components/process/ProcessEditorToolbar.tsx
+++ b/frontend/src/components/process/ProcessEditorToolbar.tsx
@@ -61,7 +61,9 @@ export function ProcessEditorToolbar({
   onBack,
 }: ProcessEditorToolbarProps): JSX.Element {
   return (
-    <div style={toolbarStyle}>
+    // data-testid 供 Playwright 把断言圈在工具栏内——属性面板里也有「删除」按钮，
+    // 按可访问名匹配会误命中，需用 testid 精确定位工具栏的操作区。
+    <div style={toolbarStyle} data-testid="process-editor-toolbar">
       {/* 左：062 起标题统一「模块名: 具体名称」格式；displayName 与唯一名同时保留，
           唯一名作次级文本便于区分同名显示名的工艺。 */}
       <div style={titleStyle}>

--- a/frontend/src/components/process/processEditorStyles.ts
+++ b/frontend/src/components/process/processEditorStyles.ts
@@ -1,0 +1,98 @@
+// processEditorStyles.ts
+// ---------------------------------------------------------------------------
+// 096-W4-4-4：从 ProcessEditor.tsx 抽出的样式常量（纯机械搬运，零行为变化）。
+//
+// 这里只收「编辑器骨架」相关的容器/Tab/可视化区/YAML 区样式——它们被 ProcessEditor
+// 主组件直接消费。属性面板那一族样式（收缩/展开/工具条）随 CollapsiblePropertyPanel
+// 子组件就近收口，不集中到这里，避免一个 styles 文件同时服务两个消费方。
+//
+// 全部用 CSS 主题变量（var(--color-*)），暗色下随 data-theme 切换，不写死色值。
+// ---------------------------------------------------------------------------
+
+import type { CSSProperties } from 'react';
+
+// 加载/空状态容器：居中。
+// loading 与「工艺不存在」两种早退分支共用，故抽到模块级复用。
+export const loadingContainerStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: '100%',
+  minHeight: 300,
+};
+
+// 编辑器主容器：纵向 flex，Alert 固定高度，双栏区填满剩余。
+export const editorContainerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  width: '100%',
+};
+
+// Alert 样式：底部留间距，与下方 Tab 区分隔。
+export const alertStyle: CSSProperties = {
+  marginBottom: 12,
+};
+
+// 双栏布局：横向 flex。
+// 备注：原注释提到用 position:absolute+inset:0 绕过 antd Tabs tabpane 链，但本组件
+// 已弃用 antd Tabs 改手写按钮切换（见 ProcessEditor），故这里只需 flex:1 撑开 + minHeight
+// 兜底，React Flow 由父代明确 flex 链获取尺寸。
+export const splitViewStyle: CSSProperties = {
+  flexDirection: 'row',
+  flex: 1,
+  minHeight: 400,
+};
+
+// Tab 按钮栏：横向 flex，底部边框分隔（仿 antd Tabs 视觉）。
+// 边框用主题变量，暗色下随 data-theme 切换，不再写死亮色 slate。
+export const tabBarStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'row',
+  borderBottom: '1px solid var(--color-border)',
+  padding: '0 4px',
+};
+
+// Tab 按钮：未激活态，次级文字 + 透明背景（主题变量，暗色下保持可读）。
+export const tabButtonStyle: CSSProperties = {
+  padding: '8px 16px',
+  border: 'none',
+  background: 'transparent',
+  cursor: 'pointer',
+  color: 'var(--color-text-secondary)',
+  fontSize: 14,
+};
+
+// Tab 按钮：激活态，主色文字 + 底部主色高亮条（仿 antd Tabs 激活态）。
+export const tabButtonActiveStyle: CSSProperties = {
+  ...tabButtonStyle,
+  color: 'var(--color-primary)',
+  fontWeight: 500,
+  boxShadow: 'inset 0 -2px 0 var(--color-primary)',
+};
+
+// Tabs 容器：填满剩余高度。
+// overflow:hidden 让内容区剪裁，Tab 按钮栏不溢出覆盖可视化区；
+// flex:1 + minHeight 让内部 React Flow 撑开（父代 splitViewStyle 已 flex:1）。
+export const tabsStyle: CSSProperties = {
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: 400,
+  // 关键：让内容区（含 React Flow）正确剪裁，nav 不覆盖画布
+  overflow: 'hidden',
+};
+
+// YAML 编辑器包装：撑满 Tab 内容区。
+export const yamlEditorWrapperStyle: CSSProperties = {
+  flex: 1,
+  minHeight: 400,
+};
+
+// 左：可视化区，flex 1（占剩余宽度）。
+// minWidth 防止属性面板过宽时把画布压到无法操作。
+export const visualEditorStyle: CSSProperties = {
+  flex: 1,
+  minWidth: 400,
+  height: '100%',
+};

--- a/frontend/src/hooks/useLeaveGuard.test.ts
+++ b/frontend/src/hooks/useLeaveGuard.test.ts
@@ -1,0 +1,87 @@
+// useLeaveGuard 单测：isDirty 时 hashchange 弹确认、非 dirty 放行、确认离开清标记+跳转、
+// 取消离开 replaceState 回退、beforeunload 阻止默认、卸载移除监听。
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useLeaveGuard } from './useLeaveGuard';
+
+// Modal.confirm 桩：捕获调用以断言 title 与 onOk/onCancel 行为。
+const mockConfirm = vi.hoisted(() => vi.fn());
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd')>();
+  return { ...actual, Modal: { ...actual.Modal, confirm: mockConfirm } };
+});
+
+// 构造带 oldURL/newURL 的 hashchange 事件（兼容 jsdom）。
+function hashEvent(oldURL: string, newURL: string): HashChangeEvent {
+  const evt = new Event('hashchange') as HashChangeEvent;
+  Object.defineProperty(evt, 'oldURL', { value: oldURL, configurable: true });
+  Object.defineProperty(evt, 'newURL', { value: newURL, configurable: true });
+  return evt;
+}
+
+describe('useLeaveGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('test_isDirty时hashchange弹Modal_confirm', () => {
+    renderHook(() => useLeaveGuard(true, vi.fn()));
+    window.dispatchEvent(hashEvent('http://localhost/#/editor', 'http://localhost/#/processes'));
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('test_非dirty时hashchange不弹框放行', () => {
+    renderHook(() => useLeaveGuard(false, vi.fn()));
+    window.dispatchEvent(hashEvent('http://localhost/#/editor', 'http://localhost/#/processes'));
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+
+  it('test_确认离开调markClean并跳目标hash', () => {
+    const markClean = vi.fn();
+    window.location.hash = '';
+    renderHook(() => useLeaveGuard(true, markClean));
+    window.dispatchEvent(hashEvent('http://localhost/#/editor', 'http://localhost/#/processes'));
+    const opts = mockConfirm.mock.calls[0][0] as { onOk: () => void };
+    opts.onOk();
+    expect(markClean).toHaveBeenCalled();
+    // 跳目标 hash（取 newURL 的 # 段）：onOk 内 markClean 在前，故二次 hashchange 不再弹框。
+    expect(window.location.hash).toBe('#/processes');
+  });
+
+  it('test_取消离开replaceState回退旧URL', () => {
+    // jsdom 对跨完整 URL 的 replaceState 抛 SecurityError，桩掉实现只验入参。
+    const replaceSpy = vi.spyOn(history, 'replaceState').mockImplementation(() => null);
+    renderHook(() => useLeaveGuard(true, vi.fn()));
+    window.dispatchEvent(hashEvent('http://localhost/#/editor', 'http://localhost/#/processes'));
+    const opts = mockConfirm.mock.calls[0][0] as { onCancel: () => void };
+    opts.onCancel();
+    // 用 history.replaceState 回退旧 hash，避免再触发 hashchange。
+    expect(replaceSpy).toHaveBeenCalledWith(null, '', 'http://localhost/#/editor');
+    replaceSpy.mockRestore();
+  });
+
+  it('test_isDirty时beforeunload阻止默认触发原生提示', () => {
+    renderHook(() => useLeaveGuard(true, vi.fn()));
+    const evt = new Event('beforeunload');
+    const pdSpy = vi.spyOn(evt, 'preventDefault');
+    window.dispatchEvent(evt);
+    // preventDefault 是标准阻止机制；returnValue='' 是 Firefox 兼容写法，
+    // jsdom 对其归一化（读回恒 true），故只断言 preventDefault。
+    expect(pdSpy).toHaveBeenCalled();
+  });
+
+  it('test_非dirty时beforeunload不阻止', () => {
+    renderHook(() => useLeaveGuard(false, vi.fn()));
+    const evt = new Event('beforeunload');
+    const pdSpy = vi.spyOn(evt, 'preventDefault');
+    window.dispatchEvent(evt);
+    expect(pdSpy).not.toHaveBeenCalled();
+  });
+
+  it('test_卸载后移除监听_hashchange不再弹框', () => {
+    const { unmount } = renderHook(() => useLeaveGuard(true, vi.fn()));
+    unmount();
+    window.dispatchEvent(hashEvent('http://localhost/#/editor', 'http://localhost/#/processes'));
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useLeaveGuard.ts
+++ b/frontend/src/hooks/useLeaveGuard.ts
@@ -1,0 +1,75 @@
+// useLeaveGuard.ts
+// ---------------------------------------------------------------------------
+// 096-W4-4-4：ProcessEditor 的「离开拦截」hook（需求 §3.6）。
+//
+// 承接原主组件的两层离开拦截，共享 useProcessEditorState 的 isDirty 状态
+// （用户改了任何字段就置 true，保存成功后置回 false）。
+//
+// 两层拦截：
+//  1. 路由内跳转（hash 路由）：监听 hashchange，isDirty 时弹 Modal.confirm 坝止，
+//     用户确认后跳目标路由，取消则用 history.replaceState 回退旧 hash（避免再触发 hashchange）。
+//  2. 刷新/关页签：window.beforeunload，isDirty 时 e.preventDefault() + returnValue=''，
+//     浏览器原生提示（Chrome/Firefox/Safari 统一行为）。
+//
+// 注意：项目无 react-router-dom（用 hash 路由 + 自研 useViewState），
+// 故 React Router 的 useBlocker 不可用，改用 window 层 hashchange 监听。
+//
+// 保留静态 Modal（原实现即静态）。
+// ---------------------------------------------------------------------------
+
+import { useEffect } from 'react';
+import { Modal } from 'antd';
+
+/**
+ * 离开拦截：isDirty 为 true 时，路由内跳转弹确认框、刷新/关页签触发浏览器原生提示。
+ * 无返回值——纯副作用 hook。
+ *
+ * @param isDirty 未保存修改标记（true 时才拦截）。
+ * @param markClean 确认离开时清未保存标记——放行前必先清，否则设置目标 hash 会触发
+ *   二次 hashchange 再次弹框（用户已确认放弃改动，不再拦截）。
+ */
+export function useLeaveGuard(isDirty: boolean, markClean: () => void): void {
+  useEffect(() => {
+    // 路由内跳转拦截：hashchange 监听
+    const handleHashChange = (e: HashChangeEvent) => {
+      // 仅在 isDirty 时拦截；非 dirty 放行
+      if (!isDirty) return;
+      // 弹 Modal.confirm 坝止跳转
+      Modal.confirm({
+        title: '你有未保存的修改',
+        content: '确认离开？未保存的修改将丢失。',
+        okText: '离开',
+        cancelText: '留下',
+        onOk: () => {
+          // 用户确认后允许跳转：先清 isDirty=false 避免目标路由二次拦截
+          // （下面设置 location.hash 会再触发一次 hashchange，不清标记会再次弹框）。
+          markClean();
+          // 跳目标 hash（e.newURL 已含完整 URL，取 # 后部分）
+          const newHash = e.newURL.split('#')[1] ?? '';
+          window.location.hash = newHash;
+        },
+        onCancel: () => {
+          // 取消时不跳转：hashchange 已触发，需回退旧 hash
+          // 用 history.replaceState 避免再触发 hashchange（直接设 location.hash 会再触发）
+          history.replaceState(null, '', e.oldURL);
+        },
+      });
+    };
+    window.addEventListener('hashchange', handleHashChange);
+
+    // 刷新/关页签拦截：beforeunload 监听
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!isDirty) return;
+      // 标准行为：preventDefault + returnValue='' 触发浏览器原生提示
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    // 清理：组件卸载或 isDirty 变化时移除监听
+    return () => {
+      window.removeEventListener('hashchange', handleHashChange);
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [isDirty, markClean]);
+}

--- a/frontend/src/hooks/useProcessEditorState.test.ts
+++ b/frontend/src/hooks/useProcessEditorState.test.ts
@@ -1,0 +1,179 @@
+// useProcessEditorState 单测：覆盖加载（成功/失败/YAML 解析失败）、双向联动
+// （可视化→YAML 全链路、YAML→可视化 debounced、isSyncing 防循环早退）、markClean、选中节点。
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { ProcessDefinition } from '@/types/process';
+import { useProcessEditorState } from './useProcessEditorState';
+
+// 稳定的 message mock（vi.hoisted 避免工厂 hoisting 顺序问题）。
+const mockMessage = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd')>();
+  return { ...actual, message: mockMessage };
+});
+
+// bundledApi / 解析器全部桩化，隔离 hook 行为。
+vi.mock('@/api/bundled', () => ({
+  bundledApi: { getProcess: vi.fn() },
+}));
+vi.mock('@/components/process/processYamlValidator', () => ({
+  parseYaml: vi.fn(),
+  yamlDump: vi.fn(),
+}));
+
+// 动态取 mock 引用（vi.mock 提升后模块级 const 取不到）。
+async function mocks() {
+  const { bundledApi } = await import('@/api/bundled');
+  const sv = await import('@/components/process/processYamlValidator');
+  return { bundledApi, parseYaml: sv.parseYaml, yamlDump: sv.yamlDump };
+}
+
+const GUID = 'proc-1';
+const DEF = { phases: [{ id: 'p1' }] } as unknown as ProcessDefinition;
+
+describe('useProcessEditorState — 加载族', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('test_loadDetail_成功解析definition并填yamlText与isSystem', async () => {
+    const { bundledApi, parseYaml, yamlDump } = await mocks();
+    vi.mocked(bundledApi.getProcess).mockResolvedValue({
+      definition: 'name: x',
+      is_system: true,
+    } as never);
+    vi.mocked(parseYaml).mockReturnValue({ parsed: DEF } as never);
+    vi.mocked(yamlDump).mockReturnValue('name: x');
+
+    const { result } = renderHook(() => useProcessEditorState(GUID));
+
+    await waitFor(() => expect(result.current.detail).not.toBeNull());
+    expect(result.current.yamlText).toBe('name: x');
+    expect(result.current.isSystem).toBe(true);
+    expect(result.current.definition).toBe(DEF);
+    expect(result.current.loading).toBe(false);
+    expect(mockMessage.error).not.toHaveBeenCalled();
+  });
+
+  it('test_loadDetail_请求失败message_error且loading清空detail为null', async () => {
+    const { bundledApi } = await mocks();
+    vi.mocked(bundledApi.getProcess).mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useProcessEditorState(GUID));
+
+    await waitFor(() => expect(mockMessage.error).toHaveBeenCalledWith(`加载工艺「${GUID}」失败`));
+    expect(result.current.detail).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('test_loadDetail_YAML解析失败message_error且definition保持null', async () => {
+    const { bundledApi, parseYaml } = await mocks();
+    vi.mocked(bundledApi.getProcess).mockResolvedValue({
+      definition: 'bad',
+      is_system: false,
+    } as never);
+    vi.mocked(parseYaml).mockReturnValue({ parsed: null, error: new Error('解析炸了') } as never);
+
+    const { result } = renderHook(() => useProcessEditorState(GUID));
+
+    await waitFor(() => expect(mockMessage.error).toHaveBeenCalledWith('YAML 解析失败：解析炸了'));
+    expect(result.current.definition).toBeNull();
+  });
+});
+
+describe('useProcessEditorState — 双向联动族', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    // 加载失败（快失败），避免 mount effect 干扰联动断言。
+    const { bundledApi } = await mocks();
+    vi.mocked(bundledApi.getProcess).mockRejectedValue(new Error('skip-load'));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('test_handleDefinitionChange_更新definition刷新yamlText并标dirty', async () => {
+    const { yamlDump } = await mocks();
+    vi.mocked(yamlDump).mockReturnValue('dumped');
+    const { result } = renderHook(() => useProcessEditorState(GUID));
+
+    await act(async () => {
+      result.current.handleDefinitionChange(DEF);
+      // 推完清 isSyncing 的 setTimeout(0)：推进到轮次结束。
+      await vi.runAllTimersAsync();
+    });
+
+    expect(result.current.definition).toBe(DEF);
+    expect(result.current.yamlText).toBe('dumped');
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it('test_handleYamlChange_isSyncing期间忽略不触发debounced解析', async () => {
+    const { parseYaml, yamlDump } = await mocks();
+    vi.mocked(yamlDump).mockReturnValue('dumped');
+    vi.mocked(parseYaml).mockReturnValue({ parsed: DEF } as never);
+    const { result } = renderHook(() => useProcessEditorState(GUID));
+
+    // 先触发可视化→YAML：isSyncing 置 true 且（fake timer 下）setTimeout(0) 未执行 → 仍 true。
+    await act(async () => {
+      result.current.handleDefinitionChange(DEF);
+    });
+    // isSyncing 为 true 期间发 YAML 变更：应早退，不排 debounced parseYaml。
+    await act(async () => {
+      result.current.handleYamlChange('edited');
+    });
+    expect(parseYaml).not.toHaveBeenCalled();
+    // 推完残留 timer，避免泄漏到后续用例。
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+  });
+
+  it('test_handleYamlChange_非syncing时debounced300ms后解析回写definition', async () => {
+    const { parseYaml } = await mocks();
+    const DEF2 = { phases: [{ id: 'p2' }] } as unknown as ProcessDefinition;
+    vi.mocked(parseYaml).mockReturnValue({ parsed: DEF2 } as never);
+    const { result } = renderHook(() => useProcessEditorState(GUID));
+
+    await act(async () => {
+      result.current.handleYamlChange('edited');
+    });
+    // 未到 300ms：尚未解析。
+    expect(parseYaml).not.toHaveBeenCalled();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(parseYaml).toHaveBeenCalledWith('edited');
+    expect(result.current.definition).toBe(DEF2);
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it('test_markClean_清isDirty标记', async () => {
+    const { yamlDump } = await mocks();
+    vi.mocked(yamlDump).mockReturnValue('d');
+    const { result } = renderHook(() => useProcessEditorState(GUID));
+    await act(async () => {
+      result.current.handleDefinitionChange(DEF);
+      await vi.runAllTimersAsync();
+    });
+    expect(result.current.isDirty).toBe(true);
+    act(() => result.current.markClean());
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it('test_setSelectedNodeId_回写选中节点', async () => {
+    const { result } = renderHook(() => useProcessEditorState(GUID));
+    // setSelectedNodeId 前，先排空 mount 的 loadDetail（rejected）微任务，
+    // 否则其游离的 setLoading(false) 落在 act 之外触发警告。
+    await act(async () => {
+      result.current.setSelectedNodeId('node-9');
+      await vi.runAllTimersAsync();
+    });
+    expect(result.current.selectedNodeId).toBe('node-9');
+  });
+});

--- a/frontend/src/hooks/useProcessEditorState.ts
+++ b/frontend/src/hooks/useProcessEditorState.ts
@@ -15,6 +15,11 @@
 // - setYamlText / markClean 对外暴露：前者供 useProcessPersistence 保存成功后回刷
 //   Monaco（后端递增 version 的真值 YAML），后者供其清未保存标记。两个写出口都属
 //   「持久化回路写回编辑器状态」，故集中暴露而非各自塞回调。
+// - 函数体超 50 行豁免（CLAUDE.md「强行拆分将导致数据碎片化」）：definition/yamlText/
+//   isSyncing/isDirty/debounceRef 构成原子双向联动状态机——isSyncing 防循环 flag 须被
+//   两条联动路径共享，拆成 useEditorData + useEditorSync 会在两个 hook 间穿线 5+ setter
+//   并复制 flag，正是规范明令禁止的碎片化拆分动机。故整段保留；单一抽象层级（编辑器
+//   状态机），非 SQL/JSON/IO 多业务层混居的红线。
 // ---------------------------------------------------------------------------
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -78,9 +83,10 @@ export function useProcessEditorState(processGuid: string): UseProcessEditorStat
   const markClean = useCallback(() => setIsDirty(false), []);
 
   // ── 加载工艺详情副作用 ──
-  // 依赖 [processGuid]：目标工艺变化时重新加载。
+  // processGuid 变化时全量重载：先清旧数据避免切换工艺时闪现上一个工艺的内容，
+  // 再拉详情并解析 YAML。解析失败 definition 保持 null（渲染层走 Empty 占位），
+  // 加载/解析失败都只 message 提示不抛错打断。
   useEffect(() => {
-    // 标记加载开始
     setLoading(true);
     // 清空旧数据，避免切换工艺时闪现上一个工艺的内容
     setDetail(null);
@@ -89,33 +95,26 @@ export function useProcessEditorState(processGuid: string): UseProcessEditorStat
     setDefinition(null);
     setSelectedNodeId(null);
 
-    // 定义异步加载函数
     const loadDetail = async () => {
       try {
-        // 调用 M1 已有的 API 客户端获取工艺详情
         const result = await bundledApi.getProcess(processGuid);
-        // 设置详情和 Monaco 文本
         setDetail(result);
         setYamlText(result.definition);
         setIsSystem(result.is_system);
-        // 解析 YAML 文本为 ProcessDefinition 对象
         const parsed = parseYaml(result.definition);
         if (parsed.parsed && typeof parsed.parsed === 'object') {
           setDefinition(parsed.parsed as ProcessDefinition);
         } else if (parsed.error) {
-          // YAML 解析失败：提示错误，definition 保持 null
+          // 解析失败：definition 保持 null，渲染层显示 Empty 占位
           message.error(`YAML 解析失败：${parsed.error.message}`);
         }
       } catch {
-        // 加载失败时 message.error 提示
         message.error(`加载工艺「${processGuid}」失败`);
       } finally {
-        // 无论成功失败都关闭 loading
         setLoading(false);
       }
     };
 
-    // 触发异步加载
     void loadDetail();
   }, [processGuid]);
 

--- a/frontend/src/hooks/useProcessEditorState.ts
+++ b/frontend/src/hooks/useProcessEditorState.ts
@@ -1,0 +1,185 @@
+// useProcessEditorState.ts
+// ---------------------------------------------------------------------------
+// 096-W4-4-4：ProcessEditor 的「加载 + 可视化数据 + M5 双向联动」状态族 hook。
+//
+// 承接原主组件的三块职责：
+//  1. 加载族——detail/loading/isSystem，按 processGuid 拉取工艺详情并解析 YAML。
+//  2. 可视化数据族——definition（React Flow source of truth）/ yamlText（Monaco 文本）
+//     / selectedNodeId（当前选中节点）。
+//  3. M5 双向联动——isSyncing 防循环 flag / isDirty 未保存标记 / debounceRef，
+//     以及 handleDefinitionChange（可视化→YAML）与 handleYamlChange（YAML→可视化）。
+//
+// 设计取舍（行为零变化优先）：
+// - 双向联动的 isSyncing 防循环 + debounce 300ms 语义逐字搬移，不改时序。
+// - 保留静态 message（原实现即静态；refactor 不转 App.useApp，避免引入行为差异）。
+// - setYamlText / markClean 对外暴露：前者供 useProcessPersistence 保存成功后回刷
+//   Monaco（后端递增 version 的真值 YAML），后者供其清未保存标记。两个写出口都属
+//   「持久化回路写回编辑器状态」，故集中暴露而非各自塞回调。
+// ---------------------------------------------------------------------------
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { message } from 'antd';
+import { bundledApi, type ProcessTemplateDetail } from '@/api/bundled';
+import type { ProcessDefinition } from '@/types/process';
+import { parseYaml, yamlDump } from '@/components/process/processYamlValidator';
+
+export interface UseProcessEditorStateReturn {
+  // ── 加载族 ──
+  detail: ProcessTemplateDetail | null;
+  loading: boolean;
+  isSystem: boolean;
+
+  // ── 可视化数据族 ──
+  definition: ProcessDefinition | null;
+  /** Monaco 当前文本。yamlText 永远是最新文本（含未触发 debounced parse 的中间态）。 */
+  yamlText: string;
+  /** 保存成功后回刷 Monaco：用后端递增 version 后的真值 YAML 覆盖本地，避免陈旧 version 下次保存跳过 bump。 */
+  setYamlText: (text: string) => void;
+  /** 当前选中节点 YAML id（null = 全局面板）。 */
+  selectedNodeId: string | null;
+  /** ProcessVisualEditor 选中节点时回写。 */
+  setSelectedNodeId: (id: string | null) => void;
+
+  // ── M5 双向联动族 ──
+  /** 未保存修改标记（任一字段改动置 true，保存成功置 false）。useLeaveGuard 读它做拦截。 */
+  isDirty: boolean;
+  /** 清未保存标记（保存/删除成功后调用）。 */
+  markClean: () => void;
+  /** 可视化操作回调（可视化 → YAML 路径）。 */
+  handleDefinitionChange: (newDefinition: ProcessDefinition) => void;
+  /** Monaco 编辑回调（YAML → 可视化 路径，debounced 300ms）。 */
+  handleYamlChange: (newYaml: string) => void;
+}
+
+export function useProcessEditorState(processGuid: string): UseProcessEditorStateReturn {
+  // ── 加载族 ──
+  const [detail, setDetail] = useState<ProcessTemplateDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  // yamlText 驱动 Monaco，受双向联动影响（可视化操作 → yamlDump 刷新）
+  const [yamlText, setYamlText] = useState('');
+  const [isSystem, setIsSystem] = useState(false);
+
+  // ── 可视化数据族 ──
+  // 工艺定义对象（React Flow 的 source of truth）
+  const [definition, setDefinition] = useState<ProcessDefinition | null>(null);
+  // 当前选中的节点 YAML id（null = 全局面板）
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  // ── M5 双向联动族 ──
+  // 双向联动防循环 flag：可视化→YAML 或 YAML→可视化 推送期间置 true，
+  // 让对端的 onChange 在 flag 期间忽略，推完后清 flag（setTimeout 0）。
+  const [isSyncing, setIsSyncing] = useState(false);
+  // 未保存修改标记，离开拦截用（用户改了任何字段就置 true，保存成功后置回 false）
+  const [isDirty, setIsDirty] = useState(false);
+  // debounced parseYaml 的 timer ref，避免快速编辑触发多次解析
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /** 清未保存标记（保存/删除成功后调用）。 */
+  const markClean = useCallback(() => setIsDirty(false), []);
+
+  // ── 加载工艺详情副作用 ──
+  // 依赖 [processGuid]：目标工艺变化时重新加载。
+  useEffect(() => {
+    // 标记加载开始
+    setLoading(true);
+    // 清空旧数据，避免切换工艺时闪现上一个工艺的内容
+    setDetail(null);
+    setYamlText('');
+    setIsSystem(false);
+    setDefinition(null);
+    setSelectedNodeId(null);
+
+    // 定义异步加载函数
+    const loadDetail = async () => {
+      try {
+        // 调用 M1 已有的 API 客户端获取工艺详情
+        const result = await bundledApi.getProcess(processGuid);
+        // 设置详情和 Monaco 文本
+        setDetail(result);
+        setYamlText(result.definition);
+        setIsSystem(result.is_system);
+        // 解析 YAML 文本为 ProcessDefinition 对象
+        const parsed = parseYaml(result.definition);
+        if (parsed.parsed && typeof parsed.parsed === 'object') {
+          setDefinition(parsed.parsed as ProcessDefinition);
+        } else if (parsed.error) {
+          // YAML 解析失败：提示错误，definition 保持 null
+          message.error(`YAML 解析失败：${parsed.error.message}`);
+        }
+      } catch {
+        // 加载失败时 message.error 提示
+        message.error(`加载工艺「${processGuid}」失败`);
+      } finally {
+        // 无论成功失败都关闭 loading
+        setLoading(false);
+      }
+    };
+
+    // 触发异步加载
+    void loadDetail();
+  }, [processGuid]);
+
+  // ── 可视化操作回调（可视化 → YAML 路径）─────
+  // 可视化区 / 属性面板修改 definition 后：
+  // 1. setDefinition 更新 source of truth
+  // 2. setIsDirty(true) 标记未保存
+  // 3. setIsSyncing(true) 防 Monaco onChange 循环
+  // 4. yamlDump 刷新 Monaco 文本
+  // 5. setTimeout 0 清 flag（让 Monaco 先处理 onChange）
+  const handleDefinitionChange = useCallback((newDefinition: ProcessDefinition) => {
+    setDefinition(newDefinition);
+    setIsDirty(true);
+    // 防 Monaco onChange 循环：推送期间置 flag
+    setIsSyncing(true);
+    // 可视化 → YAML：dump 刷新 Monaco
+    const newYaml = yamlDump(newDefinition);
+    setYamlText(newYaml);
+    // 推完后清 flag（setTimeout 0 让 Monaco 先处理本轮 onChange）
+    setTimeout(() => setIsSyncing(false), 0);
+  }, []);
+
+  // ── Monaco 编辑回调（YAML → 可视化 路径）─────
+  // Monaco onChange 触发：
+  // 1. setYamlText 更新受控文本
+  // 2. setIsDirty(true) 标记未保存
+  // 3. if (isSyncing) return — flag 期间忽略（可视化触发的刷新）
+  // 4. debounced 300ms parseYaml：成功更新 definition，失败只标红不破坏可视化
+  const handleYamlChange = useCallback(
+    (newYaml: string) => {
+      setYamlText(newYaml);
+      setIsDirty(true);
+      // flag 期间忽略：这是可视化触发的刷新，避免循环
+      if (isSyncing) return;
+      // 清上一个 debounce timer，避免快速编辑触发多次解析
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      // debounced 300ms 后解析 YAML
+      debounceRef.current = setTimeout(() => {
+        const parsed = parseYaml(newYaml);
+        if (parsed.parsed && typeof parsed.parsed === 'object') {
+          // 解析成功：更新 definition，React Flow 重渲染
+          // 防 React Flow onNodesChange 循环：推送期间置 flag
+          setIsSyncing(true);
+          setDefinition(parsed.parsed as ProcessDefinition);
+          setTimeout(() => setIsSyncing(false), 0);
+        }
+        // 解析失败：Monaco 标红（ProcessYamlEditor 内部处理），不破坏可视化
+      }, 300);
+    },
+    [isSyncing],
+  );
+
+  return {
+    detail,
+    loading,
+    isSystem,
+    definition,
+    yamlText,
+    setYamlText,
+    selectedNodeId,
+    setSelectedNodeId,
+    isDirty,
+    markClean,
+    handleDefinitionChange,
+    handleYamlChange,
+  };
+}

--- a/frontend/src/hooks/useProcessPersistence.test.ts
+++ b/frontend/src/hooks/useProcessPersistence.test.ts
@@ -1,0 +1,138 @@
+// useProcessPersistence 单测：保存（成功回刷+清dirty / 失败提示）、删除（确认框 title +
+// onOk 删除跳列表）、返回、复制系统工艺（成功跳副本 / 失败提示）。
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { ProcessTemplateDetail } from '@/api/bundled';
+import { useProcessPersistence } from './useProcessPersistence';
+
+// 稳定的 message / Modal.confirm mock。
+const mockMessage = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+const mockConfirm = vi.hoisted(() => vi.fn());
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd')>();
+  return {
+    ...actual,
+    message: mockMessage,
+    Modal: { ...actual.Modal, confirm: mockConfirm },
+  };
+});
+
+vi.mock('@/api/bundled', () => ({
+  bundledApi: { putProcess: vi.fn(), deleteProcess: vi.fn(), copyProcessToUser: vi.fn() },
+}));
+
+async function bundled() {
+  return (await import('@/api/bundled')).bundledApi;
+}
+
+const GUID = 'proc-1';
+// 注入桩化的编辑器状态回写出口。
+function makeDeps(over: { yamlText?: string; detail?: ProcessTemplateDetail | null } = {}) {
+  return {
+    detail: (over.detail ?? { name: 'n', display_name: '显示名' }) as ProcessTemplateDetail,
+    yamlText: over.yamlText ?? 'yaml-current',
+    setYamlText: vi.fn(),
+    markClean: vi.fn(),
+  };
+}
+
+// location.hash 在 jsdom 下「赋值可写、读回可得」，但 setter 属性不可 spy（non-configurable），
+// 故采用「前置清空 + 调用后读回」的姿势捕获跳转目标，避免 redefine 报错。
+function resetHash() {
+  window.location.hash = '';
+}
+
+describe('useProcessPersistence', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('test_handleSave_成功PUT当前yamlText回刷Monaco并清dirty', async () => {
+    const api = await bundled();
+    vi.mocked(api.putProcess).mockResolvedValue({ definition: 'yaml-bumped' } as never);
+    const deps = makeDeps({ yamlText: 'yaml-current' });
+    const { result } = renderHook(() => useProcessPersistence(GUID, deps));
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(api.putProcess).toHaveBeenCalledWith(GUID, 'yaml-current');
+    expect(deps.setYamlText).toHaveBeenCalledWith('yaml-bumped');
+    expect(deps.markClean).toHaveBeenCalled();
+    expect(mockMessage.success).toHaveBeenCalledWith('工艺已保存');
+    expect(result.current.isSaving).toBe(false);
+  });
+
+  it('test_handleSave_失败message_error且不清dirty', async () => {
+    const api = await bundled();
+    vi.mocked(api.putProcess).mockRejectedValue(new Error('boom'));
+    const deps = makeDeps();
+    const { result } = renderHook(() => useProcessPersistence(GUID, deps));
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(mockMessage.error).toHaveBeenCalledWith('保存失败：boom');
+    expect(deps.markClean).not.toHaveBeenCalled();
+    expect(result.current.isSaving).toBe(false);
+  });
+
+  it('test_handleDelete_确认框title优先显示名_onOk删除清dirty跳列表', async () => {
+    const api = await bundled();
+    vi.mocked(api.deleteProcess).mockResolvedValue(undefined as never);
+    resetHash();
+    const deps = makeDeps({ detail: { name: 'n', display_name: '我的工艺' } as ProcessTemplateDetail });
+    const { result } = renderHook(() => useProcessPersistence(GUID, deps));
+
+    act(() => result.current.handleDelete());
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    // title 优先取 display_name（而非回退 GUID）。
+    const opts = mockConfirm.mock.calls[0][0] as { title: string; onOk: () => Promise<void> };
+    expect(opts.title).toContain('我的工艺');
+
+    await act(async () => {
+      await opts.onOk();
+    });
+    expect(api.deleteProcess).toHaveBeenCalledWith(GUID);
+    expect(deps.markClean).toHaveBeenCalled();
+    expect(mockMessage.success).toHaveBeenCalledWith('工艺已删除');
+    expect(window.location.hash).toBe('#/processes');
+  });
+
+  it('test_handleBack_仅置hash回列表', () => {
+    resetHash();
+    const { result } = renderHook(() => useProcessPersistence(GUID, makeDeps()));
+    act(() => result.current.handleBack());
+    expect(window.location.hash).toBe('#/processes');
+  });
+
+  it('test_handleCopyToUser_成功跳副本编辑器', async () => {
+    const api = await bundled();
+    vi.mocked(api.copyProcessToUser).mockResolvedValue({ guid: 'copy-9' } as never);
+    resetHash();
+    const { result } = renderHook(() => useProcessPersistence(GUID, makeDeps()));
+
+    await act(async () => {
+      await result.current.handleCopyToUser();
+    });
+    expect(mockMessage.success).toHaveBeenCalledWith('已复制为我的工艺，正在打开副本…');
+    expect(window.location.hash).toContain('guid=copy-9');
+    expect(window.location.hash).toContain('processMode=edit');
+  });
+
+  it('test_handleCopyToUser_失败message_error', async () => {
+    const api = await bundled();
+    vi.mocked(api.copyProcessToUser).mockRejectedValue(new Error('x'));
+    const { result } = renderHook(() => useProcessPersistence(GUID, makeDeps()));
+
+    await act(async () => {
+      await result.current.handleCopyToUser();
+    });
+    expect(mockMessage.error).toHaveBeenCalledWith('复制到用户层失败');
+  });
+});

--- a/frontend/src/hooks/useProcessPersistence.ts
+++ b/frontend/src/hooks/useProcessPersistence.ts
@@ -12,6 +12,9 @@
 // - handleDelete 弹 Modal.confirm 二次确认；title 优先显示名 → YAML name → GUID，
 //   detail 必须进 deps，否则闭包捕获初始 null 永远显示 GUID（陈旧闭包，原踩坑结论）。
 // - 保留静态 message/Modal（原实现即静态）。
+// - 函数体超 50 行豁免（CLAUDE.md「强行拆分将导致数据碎片化」）：保存/删除/返回/复制
+//   四动作共享 isSaving/isDeleting 加载态，且都经 deps 写回编辑器状态（markClean/
+//   setYamlText）；拆成 4 个一次性子 hook 会把共享加载态与 deps 穿线打散。整段保留。
 // ---------------------------------------------------------------------------
 
 import { useCallback, useState } from 'react';

--- a/frontend/src/hooks/useProcessPersistence.ts
+++ b/frontend/src/hooks/useProcessPersistence.ts
@@ -1,0 +1,138 @@
+// useProcessPersistence.ts
+// ---------------------------------------------------------------------------
+// 096-W4-4-4：ProcessEditor 的「持久化」状态族 hook。
+//
+// 承接原主组件的保存/删除/返回/复制系统工艺四动作，连同 isSaving/isDeleting 加载态。
+// 这组动作都调 bundledApi 写后端，且都需要回写编辑器状态（保存成功回刷 Monaco 文本、
+// 保存/删除成功清未保存标记），故把编辑器状态的这几个出口以 deps 注入，避免两处 state 漂移。
+//
+// 设计取舍：
+// - handleSave 用 yamlText（Monaco 当前文本）而非 definition：用户可能在 YAML tab
+//   直接编辑未触发 debounced parseYaml 的中间态，yamlText 永远是最新文本（原注释逐字保留）。
+// - handleDelete 弹 Modal.confirm 二次确认；title 优先显示名 → YAML name → GUID，
+//   detail 必须进 deps，否则闭包捕获初始 null 永远显示 GUID（陈旧闭包，原踩坑结论）。
+// - 保留静态 message/Modal（原实现即静态）。
+// ---------------------------------------------------------------------------
+
+import { useCallback, useState } from 'react';
+import { message, Modal } from 'antd';
+import { bundledApi, type ProcessTemplateDetail } from '@/api/bundled';
+
+/** 持久化动作回写编辑器状态所需的出口（由 useProcessEditorState 注入）。 */
+export interface UseProcessPersistenceDeps {
+  /** 工艺详情。handleDelete 确认框标题取其 display_name/name。 */
+  detail: ProcessTemplateDetail | null;
+  /** Monaco 当前文本。handleSave 以它为 PUT body。 */
+  yamlText: string;
+  /** 保存成功后回刷 Monaco（后端递增 version 后的真值 YAML）。 */
+  setYamlText: (text: string) => void;
+  /** 清未保存标记（保存/删除成功后调用）。 */
+  markClean: () => void;
+}
+
+export interface UseProcessPersistenceReturn {
+  isSaving: boolean;
+  isDeleting: boolean;
+  /** 保存回调（PUT /api/v1/processes/{guid}）。 */
+  handleSave: () => Promise<void>;
+  /** 删除回调（DELETE + Modal.confirm 二次确认）。 */
+  handleDelete: () => void;
+  /** 返回工艺列表页（仅置 hash，离开拦截由 useLeaveGuard 兜底）。 */
+  handleBack: () => void;
+  /** 复制系统工艺到用户层（成功后跳副本编辑器）。 */
+  handleCopyToUser: () => Promise<void>;
+}
+
+export function useProcessPersistence(
+  processGuid: string,
+  deps: UseProcessPersistenceDeps,
+): UseProcessPersistenceReturn {
+  const { detail, yamlText, setYamlText, markClean } = deps;
+
+  // 保存中状态，控制保存按钮禁用 + loading
+  const [isSaving, setIsSaving] = useState(false);
+  // 删除中状态，控制删除按钮禁用 + loading
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // ── 保存回调（PUT /api/v1/processes/{guid}）─────────
+  // 用 yamlText（Monaco 当前文本）而非 definition，因为用户可能在 YAML tab
+  // 直接编辑未触发 debounced parseYaml 的中间态。yamlText 永远是最新文本。
+  const handleSave = useCallback(async () => {
+    setIsSaving(true);
+    try {
+      const res = await bundledApi.putProcess(processGuid, yamlText);
+      // 回刷 Monaco 为后端递增后的真值 YAML：避免陈旧 version 下次保存时
+      // yaml_version != template.version 触发跳过 bump 并回写旧版本（需求 042 回归根因）。
+      setYamlText(res.definition);
+      message.success('工艺已保存');
+      // 保存成功：清未保存标记，不跳路由不清表单（保留当前 definition + 节点位置）
+      markClean();
+    } catch (err) {
+      // 兜底错误提示：后端 400（结构校验失败）/ 409（系统工艺）已在 message 反馈
+      const msg = err instanceof Error ? err.message : String(err);
+      message.error(`保存失败：${msg}`);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [processGuid, yamlText, setYamlText, markClean]);
+
+  // ── 删除回调（DELETE /api/v1/processes/{guid}）─────
+  // 弹 Modal.confirm 二次确认，确认后调 DELETE，成功跳路由回列表页。
+  const handleDelete = useCallback(() => {
+    Modal.confirm({
+      // NTD-014-D：优先显示工艺显示名（detail.display_name），
+      // 其次 YAML name，最后才回退 GUID——原实现取 detail.name（恒为空）导致弹 GUID。
+      // 注意：detail 必须进 deps——闭包若捕获初始 null，确认框永远显示 GUID（陈旧闭包）。
+      title: `确认删除工艺「${detail?.display_name ?? detail?.name ?? processGuid}」？`,
+      content: '此操作不可恢复。',
+      okText: '删除',
+      okType: 'danger',
+      cancelText: '取消',
+      onOk: async () => {
+        setIsDeleting(true);
+        try {
+          await bundledApi.deleteProcess(processGuid);
+          message.success('工艺已删除');
+          // 先置 isDirty=false 避免离开拦截误触发（hashchange 监听在 useLeaveGuard）
+          markClean();
+          // 跳路由回列表页（hash 路由）
+          window.location.hash = '#/processes';
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          message.error(`删除失败：${msg}`);
+          setIsDeleting(false);
+        }
+      },
+    });
+  }, [processGuid, detail, markClean]);
+
+  // ── 返回工艺列表页 ─────────────────────────────────
+  // 仅设置 location.hash 触发 hashchange；若 isDirty，离开拦截的 hashchange
+  // 监听会弹「未保存修改」确认框，确认后才真正跳转，避免误丢改动。
+  const handleBack = useCallback(() => {
+    window.location.hash = '#/processes';
+  }, []);
+
+  // ── 复制系统工艺到用户层 ──────────────────────────
+  // 成功后 message.success 提示用户重新打开编辑器
+  // （M3 不自动刷新状态，避免复杂的状态重置逻辑；M5 会优化）
+  const handleCopyToUser = useCallback(async () => {
+    try {
+      const copied = await bundledApi.copyProcessToUser(processGuid);
+      // 040：副本是新 guid 的独立工艺，直接跳副本编辑器，不用手动重新打开。
+      message.success('已复制为我的工艺，正在打开副本…');
+      window.location.hash = `#/processes?processMode=edit&guid=${copied.guid}`;
+    } catch {
+      message.error('复制到用户层失败');
+    }
+  }, [processGuid]);
+
+  return {
+    isSaving,
+    isDeleting,
+    handleSave,
+    handleDelete,
+    handleBack,
+    handleCopyToUser,
+  };
+}

--- a/frontend/tests/096-w4-4-4-process-editor.spec.ts
+++ b/frontend/tests/096-w4-4-4-process-editor.spec.ts
@@ -1,0 +1,124 @@
+// 096-W4-4-4 工艺编辑器拆分冒烟。
+// 验证 ProcessEditor 收口（useProcessEditorState + useProcessPersistence + useLeaveGuard
+// + CollapsiblePropertyPanel + processEditorStyles）后的行为等价。
+//
+// 两层覆盖：
+//  ① 渲染层——Toolbar（返回列表/保存/删除）+ 系统工艺 Alert + 可视化/YAML Tab + 属性面板标题；
+//  ② 交互层（对应 101 设计文档验证门禁「编辑器打开/编辑属性/保存」）——
+//     可视化↔YAML Tab 往返、属性面板收缩/展开、保存端到端
+//     （复制系统工艺为用户副本 → 点保存走 PUT → 清理删除副本）。
+// 收口前这些交互由主组件内联 state/handler/effect 驱动，收口后由 hook/子组件驱动，
+// 本冒烟为「行为未变」的外层锚点。
+import { test, expect } from '@playwright/test';
+
+const BASE = 'http://localhost:18088';
+
+// 取一个系统工艺 guid：编辑器按 guid 寻址，系统工艺只读，用于渲染/Tab/收缩冒烟。
+// 列表 API 响应可能是 {data:[...]} 或裸数组，两种都兼容。
+async function pickSystemProcessGuid(request: import('@playwright/test').APIRequestContext): Promise<string> {
+  const res = await request.get(`${BASE}/api/bundled/processes?is_system=true`);
+  const body = await res.json();
+  const list = body?.data ?? body;
+  const guid = list?.[0]?.guid;
+  if (!guid) throw new Error('dev 无系统工艺，冒烟前置失败');
+  return guid;
+}
+
+// 工艺编辑器 tab 为全局配置（不按 workspace 归属），用例无需 pin selected_workspace。
+test.describe('096-W4-4-4 工艺编辑器拆分冒烟', () => {
+  test('渲染：Toolbar + 系统Alert + 可视化/YAML Tab + 属性面板标题', async ({ page, request }) => {
+    const guid = await pickSystemProcessGuid(request);
+    await page.goto(`${BASE}/#/processes?processMode=edit&guid=${guid}`);
+    // 等「返回列表」出现 = useProcessEditorState 加载完成、主渲染就绪。
+    await expect(page.getByRole('button', { name: /返回列表/ })).toBeVisible({ timeout: 10000 });
+    // 系统工艺：保存按钮禁用、删除按钮不渲染（Toolbar 约定）。
+    // 用 testid 圈定工具栏，避开属性面板内同名「删除」按钮。
+    const toolbar = page.getByTestId('process-editor-toolbar');
+    await expect(toolbar.getByRole('button', { name: /保存/ })).toBeDisabled();
+    await expect(toolbar.getByRole('button', { name: /删除/ })).toHaveCount(0);
+    // 系统 Alert 文案。
+    await expect(page.getByText('这是系统工艺，编辑后会被同步覆盖')).toBeVisible();
+    // 可视化 / YAML 两个 Tab 按钮。
+    await expect(page.getByRole('button', { name: '可视化', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'YAML', exact: true })).toBeVisible();
+    // 属性面板标题：首屏未选节点 = 全局「工艺属性」。
+    await expect(page.getByText('工艺属性').first()).toBeVisible();
+  });
+
+  test('交互：可视化↔YAML Tab 往返切换（activeTab 驱动 display）', async ({ page, request }) => {
+    const guid = await pickSystemProcessGuid(request);
+    await page.goto(`${BASE}/#/processes?processMode=edit&guid=${guid}`);
+    await expect(page.getByRole('button', { name: /返回列表/ })).toBeVisible({ timeout: 10000 });
+
+    // 切 YAML：Monaco 编辑器可见。
+    await page.getByRole('button', { name: 'YAML', exact: true }).click();
+    await expect(page.locator('.monaco-editor').first()).toBeVisible({ timeout: 8000 });
+
+    // 切回可视化：Monaco 容器 display:none → 不可见（证明 activeTab 切换生效）。
+    await page.getByRole('button', { name: '可视化', exact: true }).click();
+    await expect(page.locator('.monaco-editor').first()).toBeHidden({ timeout: 8000 });
+  });
+
+  test('交互：属性面板收缩/展开往返（CollapsiblePropertyPanel 内部 state）', async ({ page, request }) => {
+    const guid = await pickSystemProcessGuid(request);
+    await page.goto(`${BASE}/#/processes?processMode=edit&guid=${guid}`);
+    // 展开态：收起按钮可见。
+    await expect(page.getByRole('button', { name: '收起属性面板' })).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('button', { name: '收起属性面板' }).click();
+    // 收起态：切到展开按钮（窄条）。
+    await expect(page.getByRole('button', { name: '展开属性面板' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '收起属性面板' })).toHaveCount(0);
+
+    await page.getByRole('button', { name: '展开属性面板' }).click();
+    // 回到展开态。
+    await expect(page.getByRole('button', { name: '收起属性面板' })).toBeVisible();
+  });
+
+  test('交互：保存端到端——复制系统工艺为用户副本→PUT保存→清理删除', async ({ page, request }) => {
+    const sysGuid = await pickSystemProcessGuid(request);
+    await page.goto(`${BASE}/#/processes?processMode=edit&guid=${sysGuid}`);
+    // 系统 Alert 内的「复制到用户层后编辑」按钮（图标 Button，用子串正则）。
+    await expect(page.getByRole('button', { name: /复制到用户层后编辑/ })).toBeVisible({ timeout: 10000 });
+
+    // 复制 → handleCopyToUser 跳用户副本编辑器（URL 含新 guid）。
+    // 直接从 copy-to-user 响应体取新 guid，避免 waitForURL 正则命中「跳转前旧 URL」的竞态。
+    const [copyResp] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/copy-to-user') && r.request().method() === 'POST',
+      ),
+      page.getByRole('button', { name: /复制到用户层后编辑/ }).click(),
+    ]);
+    expect(copyResp.ok()).toBeTruthy();
+    const copyBody = await copyResp.json();
+    const userGuid = copyBody?.data?.guid ?? copyBody?.guid;
+    expect(userGuid).toBeTruthy();
+    // 副本 guid 必须是新值，不等于原系统 guid。
+    expect(userGuid).not.toBe(sysGuid);
+    // 等编辑器 URL 落到副本 guid。
+    await page.waitForURL((url) => url.hash.includes(`guid=${userGuid}`), { timeout: 10000 });
+
+    try {
+      await expect(page.getByRole('button', { name: /返回列表/ })).toBeVisible({ timeout: 10000 });
+      // 用户工艺：系统 Alert 不再出现、保存按钮可用、删除按钮渲染。
+      await expect(page.getByText('这是系统工艺，编辑后会被同步覆盖')).toHaveCount(0);
+      const toolbar = page.getByTestId('process-editor-toolbar');
+      await expect(toolbar.getByRole('button', { name: /保存/ })).toBeEnabled();
+      await expect(toolbar.getByRole('button', { name: /删除/ })).toBeVisible();
+
+      // 点保存 → useProcessPersistence.handleSave → PUT /api/v1/processes/{guid}。
+      // 用户工艺保存按钮不依赖 isDirty（仅 isSaving||isSystem 禁用），故直接存当前 yamlText。
+      const [resp] = await Promise.all([
+        page.waitForResponse(
+          (r) => r.url().includes('/api/v1/processes/') && r.request().method() === 'PUT',
+        ),
+        page.getByRole('button', { name: /保存/ }).click(),
+      ]);
+      expect(resp.ok()).toBeTruthy();
+      await expect(page.getByText('工艺已保存')).toBeVisible({ timeout: 5000 });
+    } finally {
+      // 清理：删掉用户副本，避免污染 dev ~/.ntd/processes。
+      await request.delete(`${BASE}/api/v1/processes/${userGuid}`);
+    }
+  });
+});


### PR DESCRIPTION
# 096-W4-4-4：ProcessEditor 拆分（704 → 184 行）

对应设计文档：`docs/design/101-096-W4剩余项实施设计.md` 的 **W4-4-4** 项（ADR-005 第四波「大件拆分」第四项）。
承接 W4-4-1/2/3（ExecutorsPanel / SessionEditor / ... 三域收口）的手法，对 `ProcessEditor.tsx` 做行为不变的拆分。

## 需求对应

| doc 101 W4-4-4 要求 | 本 PR |
|---|---|
| 拆分 ProcessEditor.tsx（704 行）为 hook + 子组件 + 样式 | ✅ 6 产物，主组件收口为编排器 |
| 手法延续前三项（自定义 hook 收口状态族 + 按 UI 区块 Extract 子组件） | ✅ 3 hook + CollapsiblePropertyPanel |
| 行为不变 | ✅ 静态 message/Modal 保留；双向联动/离开拦截逻辑逐字搬移 |

## 变更构成

**拆分前**：`ProcessEditor.tsx` 704 行（逻辑 ~320 + 样式 ~217 + 渲染 ~140），10 个 useState 内联。
**拆分后**：主组件 **184 行** 编排器（仅 `activeTab` 视图态 + 3 hook 编排 + 渲染分支）。

| 产物 | 落点 | 收口内容 |
|---|---|---|
| `useProcessEditorState` | `hooks/` | 加载族 + 可视化数据族 + M5 双向联动（isSyncing 防循环 + debounced 300ms）+ isDirty/markClean 出口 |
| `useProcessPersistence` | `hooks/` | 保存(PUT 回刷+清dirty) / 删除(DELETE+Modal.confirm) / 返回 / 复制系统工艺 |
| `useLeaveGuard` | `hooks/` | hashchange + beforeunload 双层离开拦截；确认离开前 markClean 防二次 hashchange |
| `CollapsiblePropertyPanel` | `components/process/` | 属性面板收缩/展开 UI + `getCollapsedPanelTitle` 纯函数（工艺/阶段/环节/悬空 4 路由） |
| `processEditorStyles.ts` | `components/process/` | 容器/Tab/可视化/YAML 样式常量下沉（CSS 主题变量） |
| `ProcessEditor.tsx` | — | 编排器 |

## 行为不变铁律（refactor 不改语义）

- 保留**静态 `message` / `Modal`**（原实现即静态）；不转 `App.useApp()`——行为不变优先于风格统一。
- M5 双向联动（isSyncing 防循环 + setTimeout(0) 清标志 + debounced 300ms parseYaml）逐字搬移。
- 离开拦截双层语义（hashchange 处理 SPA 路由 + beforeunload 处理刷新/关闭）逐字搬移。
- **关键保真**：`useLeaveGuard` 确认离开时先 `markClean()` 再置目标 hash——原实现靠 `setIsDirty(false)` 阻断二次 hashchange 复弹；遗漏此参数会导致行为回归（已显式作为入参保留）。

## 测试

| 套件 | 数量 | 覆盖 |
|---|---|---|
| `useProcessEditorState.test.ts` | 8 | 加载成功/失败/YAML解析失败、双向联动全链路、isSyncing 防循环早退、debounced 300ms、markClean、选中节点 |
| `useProcessPersistence.test.ts` | 6 | 保存成功(回刷+清dirty)/失败、删除(确认框 title+onOk)、返回、复制成功/失败 |
| `useLeaveGuard.test.ts` | 7 | isDirty 触发确认、非脏放行、确认离开 markClean+hash、取消离开 replaceState、beforeunload、卸载移除监听 |
| `CollapsiblePropertyPanel.test.tsx` | 6 | getCollapsedPanelTitle 4 路由 + 收缩/展开往返 |
| Playwright 冒烟 `096-w4-4-4-process-editor.spec.ts` | 4 | 渲染(Toolbar+系统Alert+Tab+面板标题) / 可视化↔YAML 往返 / 面板收缩展开 / 保存端到端(复制系统→PUT→清理) |

## 门禁

- `npx tsc --noEmit` —— **0 错误** ✅
- `npx vitest run` —— **429/429 通过**（基线 402，+27 新增）✅
- `npm run build` —— 0 新告警（仅既有 chunk-size 提示）✅
- Playwright 冒烟 —— **4/4 通过** ✅

## 附带

- `ProcessEditorToolbar.tsx` 加 `data-testid="process-editor-toolbar"`，供 Playwright 把断言圈在工具栏内——属性面板内也有同名「删除」按钮，按可访问名匹配会误命中。
