### PR TITLE
refactor(096-W4-6): 直连执行 spawn 骨架收敛 DirectExecutorSession（A+B，C 保留）

### DIFF
--- a/backend/src/services/blackboard.rs
+++ b/backend/src/services/blackboard.rs
@@ -26,6 +26,9 @@ use crate::config::Config;
 use crate::db::Database;
 use crate::executor_service::{ExecEvent, RunTodoExecutionRequest};
 use crate::handlers::AppError;
+use crate::services::executor_session::{
+    DirectExecutorSession, SessionError, SessionSpawnConfig,
+};
 use crate::task_manager::TaskManager;
 use crate::wiki::{init_wiki_dir, list_topics, append_log_entry};
 
@@ -664,16 +667,14 @@ async fn resolve_wiki_timeout_secs(db: &Arc<Database>, workspace_id: i64) -> u64
 
 /// spawn 执行器子进程，流式读取 stdout，逐行解析并推送 WikiChatOutput 事件。
 ///
-/// 与 handle_default_response_executor 的 spawn 逻辑保持一致：
-/// - stdout 用 piped 收集日志
-/// - stderr 丢弃（避免污染结果解析）
-/// - stdin 用 piped（部分执行器需要预写 payload）
-/// - cwd 设为 wiki 目录
+/// 096-W4-6：进程生命周期骨架（build 命令 / spawn / 关 stdin / select! 逐行读 /
+/// 超时 kill / wait）已收敛到 `DirectExecutorSession`，本函数只保留 wiki chat
+/// 通路语义：
+/// - 逐行裸 `parse_output_line`，命中即推 `WikiChatOutput`（前端 WebSocket 实时收）
+/// - typed error 映射回本通路原有错误文案
 ///
-/// 返回：(解析出的日志条目列表, 原始 stdout 文本, 原始 stderr 文本, 是否成功退出)
-/// 同时通过 broadcast channel 实时推送每一行日志，前端 WebSocket 可收到。
-///
-/// 超时保护由调用方传入（来自 per-workspace 配置 wiki_timeout_secs），
+/// 返回：(解析出的日志条目列表, 原始 stdout 文本, 原始 stderr 文本, 是否成功退出)。
+/// 超时保护由调用方传入（来自 per-workspace 配置 wiki_timeout_secs，保证 > 0），
 /// 超时后 kill 子进程并返回错误。
 ///
 /// 参数较多但均为生成子进程所必需的上下文，拆 struct 反而割裂调用点可读性，
@@ -689,147 +690,47 @@ async fn spawn_executor_for_chat_streaming(
     session_id: Option<String>,
     timeout_secs: u64,
 ) -> Result<(Vec<crate::models::ParsedLogEntry>, String, String, bool), AppError> {
-    use tokio::io::{AsyncBufReadExt, BufReader};
-    use crate::executor_service::events::ExecEvent;
-
-    let program = executor.executable_path();
-    // 使用带 session 的命令参数（执行器不支持时自动忽略）
-    let command_args = executor.command_args_with_session(message, session_id.as_deref(), session_id.is_some());
-
-    tracing::info!(
-        "wiki chat spawn: task_id={}, {} {:?} (cwd={:?})",
-        task_id,
-        program,
-        command_args,
-        cwd
-    );
-
-    let mut cmd = tokio::process::Command::new(program);
-    cmd.args(&command_args)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .stdin(std::process::Stdio::piped())
-        .current_dir(cwd);
-
-    let mut child = cmd.spawn().map_err(|e| {
-        AppError::Internal(format!("启动执行器失败: {}", e))
-    })?;
-
-    // stdin 处理：take() 并 drop 关闭 stdin，避免 CLI 进程挂起等待 EOF。
-    // 注意：这里不写 stdin payload——blackboard wiki chat 不是 worktree 场景，
-    // pi 的 "y" 应答只在切换 worktree 目录时才有意义，乱写会污染 stdin。
-    if child.stdin.take().is_some() {
-        tracing::debug!("[blackboard] stdin 已关闭");
-    }
-
-    // 取出 stdout 和 stderr，用 BufReader 逐行读取
-    let stdout = child.stdout.take().ok_or_else(|| {
-        AppError::Internal("无法获取执行器 stdout".to_string())
-    })?;
-    let stderr = child.stderr.take().ok_or_else(|| {
-        AppError::Internal("无法获取执行器 stderr".to_string())
-    })?;
-    let mut stdout_reader = BufReader::new(stdout).lines();
-    let mut stderr_reader = BufReader::new(stderr).lines();
-
-    // 收集解析后的日志和原始 stdout/stderr
+    // 逐行语义闭包：wiki chat 用裸 parse_output_line（无 EventPipeline），命中即推
+    // WikiChatOutput 并累积 parsed_logs——收敛前内联在 select! 主循环里。
     let mut parsed_logs: Vec<crate::models::ParsedLogEntry> = Vec::new();
-    let mut raw_stdout_lines: Vec<String> = Vec::new();
-    let mut raw_stderr_lines: Vec<String> = Vec::new();
-
-    // 超时保护：用 per-workspace 配置值，超时后 kill 子进程避免僵尸进程
-    let timeout_fut = tokio::time::sleep(std::time::Duration::from_secs(timeout_secs));
-    tokio::pin!(timeout_fut);
-
-    loop {
-        tokio::select! {
-            // 读取下一行 stdout
-            line_result = stdout_reader.next_line() => {
-                match line_result {
-                    Ok(Some(line)) => {
-                        raw_stdout_lines.push(line.clone());
-                        // 解析成 ParsedLogEntry，成功则推送事件
-                        if let Some(entry) = executor.parse_output_line(&line) {
-                            // 推送 WikiChatOutput 事件（前端通过 WebSocket 收到）
-                            let _ = tx.send(ExecEvent::WikiChatOutput {
-                                task_id: task_id.to_string(),
-                                workspace_id,
-                                entry: entry.clone(),
-                            });
-                            parsed_logs.push(entry);
-                        }
-                    }
-                    // stdout 读完了，等待子进程退出并返回结果
-                    Ok(None) => {
-                        let status = child.wait().await.map_err(|e| {
-                            AppError::Internal(format!("等待执行器退出失败: {}", e))
-                        })?;
-                        let stdout_raw = raw_stdout_lines.join("\n");
-                        let stderr_raw = raw_stderr_lines.join("\n");
-                        let success = status.success();
-                        tracing::info!(
-                            "wiki chat executor finished: task_id={}, exit_code={:?}, stdout_len={}, stderr_len={}",
-                            task_id,
-                            status.code(),
-                            stdout_raw.len(),
-                            stderr_raw.len()
-                        );
-                        if !stderr_raw.is_empty() {
-                            tracing::warn!(
-                                "wiki chat executor stderr: task_id={}, stderr={}",
-                                task_id,
-                                stderr_raw
-                            );
-                        }
-                        return Ok((parsed_logs, stdout_raw, stderr_raw, success));
-                    }
-                    Err(e) => {
-                        let stderr_raw = raw_stderr_lines.join("\n");
-                        return Err(AppError::Internal(format!(
-                            "读取执行器 stdout 失败: {}\nstderr: {}",
-                            e, stderr_raw
-                        )));
-                    }
-                }
+    let outcome = DirectExecutorSession::spawn_and_stream(
+        SessionSpawnConfig {
+            executor: executor.clone(),
+            message: message.to_string(),
+            cwd: cwd.to_path_buf(),
+            session_id: session_id.clone(),
+            timeout_secs,
+            // tracing 关联用 task_id：session 的 spawn/finish/timeout 日志能对回本通路
+            log_tag: task_id.to_string(),
+        },
+        |line: &str| {
+            // 命中解析才推事件；未命中（非结构化行）只进 raw_stdout 由骨架收集
+            if let Some(entry) = executor.parse_output_line(line) {
+                let _ = tx.send(ExecEvent::WikiChatOutput {
+                    task_id: task_id.to_string(),
+                    workspace_id,
+                    entry: entry.clone(),
+                });
+                parsed_logs.push(entry);
             }
-            // 读取下一行 stderr
-            line_result = stderr_reader.next_line() => {
-                match line_result {
-                    Ok(Some(line)) => {
-                        let line_clone = line.clone();
-                        raw_stderr_lines.push(line);
-                        tracing::debug!(
-                            "wiki chat executor stderr: task_id={}, line={}",
-                            task_id,
-                            line_clone
-                        );
-                    }
-                    Ok(None) => {
-                        // stderr 读完了，继续等待 stdout
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "wiki chat executor stderr read error: task_id={}, error={}",
-                            task_id,
-                            e
-                        );
-                    }
-                }
-            }
-            // 超时
-            _ = &mut timeout_fut => {
-                tracing::error!(
-                    "wiki chat executor timed out after {}s, killing child: task_id={}",
-                    timeout_secs,
-                    task_id
-                );
-                let _ = child.kill().await;
-                let stderr_raw = raw_stderr_lines.join("\n");
-                return Err(AppError::Internal(format!(
-                    "执行器超时（{}秒），请稍后重试或简化问题\nstderr: {}",
-                    timeout_secs, stderr_raw
-                )));
-            }
+        },
+    )
+    .await
+    // typed error → 本通路原有文案（逐字保留，前端/调用方依赖错误语义）
+    .map_err(|e| match e {
+        SessionError::Spawn(err) => AppError::Internal(format!("启动执行器失败: {}", err)),
+        SessionError::Timeout { secs, stderr } => AppError::Internal(format!(
+            "执行器超时（{}秒），请稍后重试或简化问题\nstderr: {}",
+            secs, stderr
+        )),
+        SessionError::WaitFailed(msg) => {
+            AppError::Internal(format!("等待执行器退出失败: {}", msg))
         }
-    }
+        SessionError::StdoutReadFailed { source, stderr } => AppError::Internal(format!(
+            "读取执行器 stdout 失败: {}\nstderr: {}",
+            source, stderr
+        )),
+    })?;
+
+    Ok((parsed_logs, outcome.raw_stdout, outcome.raw_stderr, outcome.success))
 }

--- a/backend/src/services/executor_session.rs
+++ b/backend/src/services/executor_session.rs
@@ -49,6 +49,8 @@ pub(crate) struct SessionOutcome {
     pub(crate) raw_stderr: String,
     /// 子进程是否成功退出（status.success()）
     pub(crate) success: bool,
+    /// 退出码（被信号杀死时为 None）——A 通路非零退出的用户文案要报「退出码 N」
+    pub(crate) exit_code: Option<i32>,
 }
 
 /// typed error：A/B 调用方各自映射回原有错误文案，不共用字符串（避免通路语义耦合）。
@@ -188,7 +190,10 @@ where
                         if !raw_stderr.is_empty() {
                             tracing::warn!("[session] stderr: tag={}, stderr={}", log_tag, raw_stderr);
                         }
-                        return Ok(SessionOutcome { raw_stdout, raw_stderr, success: status.success() });
+                        // 退出位与退出码一次性取出后再构造返回值：status 后续不再使用
+                        let success = status.success();
+                        let exit_code = status.code();
+                        return Ok(SessionOutcome { raw_stdout, raw_stderr, success, exit_code });
                     }
                     Err(e) => {
                         let stderr = raw_stderr_lines.join("\n");
@@ -288,6 +293,7 @@ mod tests {
         assert_eq!(outcome.raw_stdout, "line1\nline2");
         assert_eq!(outcome.raw_stderr, "");
         assert!(outcome.success);
+        assert_eq!(outcome.exit_code, Some(0), "正常退出应为退出码 0");
     }
 
     /// 启动失败：程序不存在 → SessionError::Spawn（调用方据此映射各自文案）。
@@ -355,5 +361,6 @@ mod tests {
         .await
         .unwrap();
         assert!(!outcome.success);
+        assert_eq!(outcome.exit_code, Some(3), "exit 3 的退出码应透传给调用方");
     }
 }

--- a/backend/src/services/executor_session.rs
+++ b/backend/src/services/executor_session.rs
@@ -175,6 +175,9 @@ where
     // 排空模式（评审修复）：计时器到点时若进程其实已退出、只是管道还在排空，
     // 不误判超时（A 原实现的超时只包 child.wait()，不存在排空误判）。
     let mut drain_mode = false;
+    // stderr EOF/读失败后禁用该分支（评审修复）：next_line() 在 EOF 后持续立即
+    // 返回 Ok(None)，不禁用会让 select! 在 stdout 未结束时空转占满 CPU
+    let mut stderr_done = false;
 
     loop {
         tokio::select! {
@@ -204,7 +207,15 @@ where
                     // stdout 读完了：等子进程退出并打包返回（stderr 可能仍有未消费缓冲，
                     // 与 B 原实现一致——拿到多少算多少，不为凑齐 stderr 阻塞返回）
                     Ok(None) => {
-                        let status = child.wait().await.map_err(|e| SessionError::WaitFailed(e.to_string()))?;
+                        // wait 失败也要 kill 回收：child 未开 kill_on_drop，直接 drop
+                        // 会让执行器进程变孤儿继续跑（评审修复）
+                        let status = match child.wait().await {
+                            Ok(s) => s,
+                            Err(e) => {
+                                let _ = child.kill().await;
+                                return Err(SessionError::WaitFailed(e.to_string()));
+                            }
+                        };
                         let raw_stderr = raw_stderr_lines.join("\n");
                         let raw_stdout = raw_stdout_lines.join("\n");
                         tracing::info!(
@@ -220,22 +231,29 @@ where
                         return Ok(SessionOutcome { raw_stdout, raw_stderr, success, exit_code });
                     }
                     Err(e) => {
+                        // stdout 读失败即放弃本次执行：先 kill 回收，再上抛（评审修复，
+                        // 与超时分支同姿势——不留孤儿进程）
+                        let _ = child.kill().await;
                         let stderr = raw_stderr_lines.join("\n");
                         return Err(SessionError::StdoutReadFailed { source: e, stderr });
                     }
                 }
             }
-            // 读取下一行 stderr：只收集不回调（stderr 是诊断通道，无通路语义）
-            line_result = stderr_reader.next_line() => {
+            // 读取下一行 stderr：只收集不回调（stderr 是诊断通道，无通路语义）；
+            // EOF/读失败后经 stderr_done 禁用本分支，防忙循环
+            line_result = stderr_reader.next_line(), if !stderr_done => {
                 match line_result {
                     Ok(Some(line)) => {
                         raw_stderr_lines.push(line);
                     }
-                    // stderr EOF：继续等 stdout 主流
-                    Ok(None) => {}
-                    // stderr 读失败不致命：丢掉 stderr 诊断信息，主流继续（B 原语义）
+                    // stderr EOF：关闭本分支，继续等 stdout 主流
+                    Ok(None) => {
+                        stderr_done = true;
+                    }
+                    // stderr 读失败不致命：关闭本分支，丢掉诊断信息，主流继续（B 原语义）
                     Err(e) => {
                         tracing::warn!("[session] stderr read error: tag={}, error={}", log_tag, e);
+                        stderr_done = true;
                     }
                 }
             }

--- a/backend/src/services/executor_session.rs
+++ b/backend/src/services/executor_session.rs
@@ -1,0 +1,359 @@
+//! DirectExecutorSession：飞书默认响应（message_debounce）与 wiki chat（blackboard）
+//! 两条直连执行通路共用的「spawn 子进程 + 逐行流读 + 超时 kill」骨架（096-W4-6）。
+//!
+//! 收口边界（详见 docs/design/101 W4-6 段）：
+//! 本模块只管进程生命周期与 I/O：build 命令（command_args_with_session、piped stdio、
+//! current_dir）→ spawn 普通 child → 关 stdin → select! 逐行读 stdout/stderr →
+//! 超时 kill → wait → 返回原始文本与退出成功位。
+//!
+//! 逐行「语义」（A 的 EventPipeline 解析 + 私聊直推 vs B 的裸 parse_output_line +
+//! WikiChatOutput）经 `on_line` 闭包交还调用方——session 不持有通路知识。
+//!
+//! 主执行链路（executor_service/spawn_lifecycle：进程组 + LogFlusher + cancel +
+//! worktree）是架构独立的生命周期模块，非本骨架的平行副本，刻意不迁移（doc 101 逃生口）。
+//!
+//! timeout_secs == 0 表示不限时（与 A 的 direct_executor_timeout、C 的
+//! configure_timeout_sleep 三方既有语义一致：0 = 禁用）。
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+use crate::adapters::CodeExecutor;
+
+/// 直连执行 session 的 spawn 配置（A/B 调用方各自组装，通路差异不进本结构）。
+pub(crate) struct SessionSpawnConfig {
+    /// 目标执行器：提供 executable_path 与 command_args_with_session
+    pub(crate) executor: Arc<dyn CodeExecutor>,
+    /// 发给执行器的完整消息文本
+    pub(crate) message: String,
+    /// 子进程工作目录
+    pub(crate) cwd: PathBuf,
+    /// 续接会话 id（None = 新会话）；有无同时决定 is_resume 的推导
+    pub(crate) session_id: Option<String>,
+    /// 超时秒数；0 = 不限时
+    pub(crate) timeout_secs: u64,
+    /// 仅用于 tracing 关联的标识（各通路传自己的 task_id），不参与任何行为
+    pub(crate) log_tag: String,
+}
+
+/// session 结束时交还调用方的原始产出；logs 由调用方在 on_line 闭包里自行累积。
+/// Debug 仅供测试 unwrap 断言用。
+#[derive(Debug)]
+pub(crate) struct SessionOutcome {
+    /// stdout 原文（逐行 join），供错误诊断与结果兜底
+    pub(crate) raw_stdout: String,
+    /// stderr 原文（逐行 join），供非零退出时拼进错误消息
+    pub(crate) raw_stderr: String,
+    /// 子进程是否成功退出（status.success()）
+    pub(crate) success: bool,
+}
+
+/// typed error：A/B 调用方各自映射回原有错误文案，不共用字符串（避免通路语义耦合）。
+/// Debug 仅供测试断言用。
+#[derive(Debug)]
+pub(crate) enum SessionError {
+    /// 子进程启动失败
+    Spawn(std::io::Error),
+    /// 超时（已 kill 回收）；携带 stderr 供 B 的超时文案拼接
+    Timeout { secs: u64, stderr: String },
+    /// 等待子进程退出失败
+    WaitFailed(String),
+    /// 读 stdout 出错；携带已收集的 stderr 供错误消息拼接
+    StdoutReadFailed {
+        source: std::io::Error,
+        stderr: String,
+    },
+}
+
+/// A/B 平行实现（~286 行）的统一骨架持有者。无字段：纯命名空间性质的入口。
+pub(crate) struct DirectExecutorSession;
+
+impl DirectExecutorSession {
+    /// spawn + 逐行流读（on_line 回调交还调用方）+ 超时 kill + wait 的统一骨架。
+    ///
+    /// 成功路径：stdout EOF 后 wait 子进程，返回原始文本与退出位；
+    /// 超时路径：kill 子进程后返回 `SessionError::Timeout`（避免孤儿/僵尸进程）。
+    pub(crate) async fn spawn_and_stream<F>(
+        config: SessionSpawnConfig,
+        mut on_line: F,
+    ) -> Result<SessionOutcome, SessionError>
+    where
+        F: FnMut(&str),
+    {
+        // ── 构建并启动子进程（收敛 A 的 spawn_executor_child 与 B 的内联段）──
+        let SessionSpawnConfig {
+            executor,
+            message,
+            cwd,
+            session_id,
+            timeout_secs,
+            log_tag,
+        } = config;
+        // is_resume 由是否有 session_id 推导：有 session 则让执行器续上下文而非新开会话
+        let is_resume = session_id.is_some();
+        let command_args =
+            executor.command_args_with_session(&message, session_id.as_deref(), is_resume);
+        let program = executor.executable_path();
+        tracing::info!(
+            "[session] spawning {}: {:?} (cwd={:?}, tag={})",
+            program,
+            command_args,
+            cwd,
+            log_tag
+        );
+
+        // 三个 stdio 全 piped：stdout/stderr 由骨架读取，stdin 随即 take+drop 关闭
+        let mut cmd = tokio::process::Command::new(program);
+        cmd.args(&command_args)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .stdin(std::process::Stdio::piped())
+            .current_dir(&cwd);
+        let mut child = cmd.spawn().map_err(SessionError::Spawn)?;
+
+        // take() 并 drop 关闭 stdin，避免 CLI 进程执行完后挂起等待 EOF。
+        // 两条通路均非 worktree 场景，不预写 payload（pi 的 "y" 应答只在切
+        // worktree 目录时才有意义，乱写会污染 stdin——A/B 原注释同源结论）。
+        drop(child.stdin.take());
+
+        // piped 模式下 take 理论上必为 Some；防御性兜底为空流（立即 EOF → 走 wait 路径，
+        // 返回空 raw 文本），与 A 原实现的「无 stdout → 空结果」降级语义一致。
+        let stdout: Box<dyn tokio::io::AsyncRead + Unpin + Send> = match child.stdout.take() {
+            Some(s) => Box::new(s),
+            None => Box::new(tokio::io::empty()),
+        };
+        let stderr: Box<dyn tokio::io::AsyncRead + Unpin + Send> = match child.stderr.take() {
+            Some(s) => Box::new(s),
+            None => Box::new(tokio::io::empty()),
+        };
+
+        stream_lines_until_exit(child, stdout, stderr, timeout_secs, &log_tag, &mut on_line).await
+    }
+}
+
+/// select! 主循环：逐行读 stdout（回调调用方）/ stderr（收集）/ 超时（kill），
+/// 直到 stdout EOF 后 wait 子进程返回。骨架逐字源自 B（blackboard）——最自洽的一份。
+///
+/// 函数体超 50 行豁免（CLAUDE.md「强行拆分将导致数据碎片化」）：tokio::select! 的
+/// 三个分支是宏内联状态机，共享 raw_stdout_lines / raw_stderr_lines / child 的可变
+/// 借用，把分支抽成独立函数需把这套状态在每次轮转间穿线传递。
+async fn stream_lines_until_exit<F>(
+    mut child: tokio::process::Child,
+    stdout: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+    stderr: Box<dyn tokio::io::AsyncRead + Unpin + Send>,
+    timeout_secs: u64,
+    log_tag: &str,
+    on_line: &mut F,
+) -> Result<SessionOutcome, SessionError>
+where
+    F: FnMut(&str),
+{
+    // BufReader 逐行读：executor 输出天然按行组织（JSONL / 人类可读日志都是）
+    let mut stdout_reader = BufReader::new(stdout).lines();
+    let mut stderr_reader = BufReader::new(stderr).lines();
+
+    // 收集容器：raw 文本按行 push、结束时 join，避免反复 String concat
+    let mut raw_stdout_lines: Vec<String> = Vec::new();
+    let mut raw_stderr_lines: Vec<String> = Vec::new();
+
+    // 0 = 不限时：用极大 duration（u64::MAX 秒 ≈ 5.8 亿年）模拟「永不超时」，
+    // select! 该分支永不命中（与 C 的 configure_timeout_sleep 同一手法）
+    let effective_secs = if timeout_secs == 0 { u64::MAX } else { timeout_secs };
+    let timeout_fut = tokio::time::sleep(Duration::from_secs(effective_secs));
+    tokio::pin!(timeout_fut);
+
+    loop {
+        tokio::select! {
+            // 读取下一行 stdout：这是主数据流，EOF 即子进程产出完毕
+            line_result = stdout_reader.next_line() => {
+                match line_result {
+                    Ok(Some(line)) => {
+                        raw_stdout_lines.push(line.clone());
+                        // 逐行语义（解析 + 事件推送）交还调用方闭包
+                        on_line(&line);
+                    }
+                    // stdout 读完了：等子进程退出并打包返回（stderr 可能仍有未消费缓冲，
+                    // 与 B 原实现一致——拿到多少算多少，不为凑齐 stderr 阻塞返回）
+                    Ok(None) => {
+                        let status = child.wait().await.map_err(|e| SessionError::WaitFailed(e.to_string()))?;
+                        let raw_stderr = raw_stderr_lines.join("\n");
+                        let raw_stdout = raw_stdout_lines.join("\n");
+                        tracing::info!(
+                            "[session] finished: tag={}, exit_code={:?}, stdout_len={}, stderr_len={}",
+                            log_tag, status.code(), raw_stdout.len(), raw_stderr.len()
+                        );
+                        if !raw_stderr.is_empty() {
+                            tracing::warn!("[session] stderr: tag={}, stderr={}", log_tag, raw_stderr);
+                        }
+                        return Ok(SessionOutcome { raw_stdout, raw_stderr, success: status.success() });
+                    }
+                    Err(e) => {
+                        let stderr = raw_stderr_lines.join("\n");
+                        return Err(SessionError::StdoutReadFailed { source: e, stderr });
+                    }
+                }
+            }
+            // 读取下一行 stderr：只收集不回调（stderr 是诊断通道，无通路语义）
+            line_result = stderr_reader.next_line() => {
+                match line_result {
+                    Ok(Some(line)) => {
+                        raw_stderr_lines.push(line);
+                    }
+                    // stderr EOF：继续等 stdout 主流
+                    Ok(None) => {}
+                    // stderr 读失败不致命：丢掉 stderr 诊断信息，主流继续（B 原语义）
+                    Err(e) => {
+                        tracing::warn!("[session] stderr read error: tag={}, error={}", log_tag, e);
+                    }
+                }
+            }
+            // 超时：kill 子进程避免僵尸，错误携带已收集的 stderr 供调用方拼文案
+            _ = &mut timeout_fut => {
+                tracing::error!(
+                    "[session] timed out after {}s, killing child: tag={}",
+                    timeout_secs, log_tag
+                );
+                let _ = child.kill().await;
+                let stderr = raw_stderr_lines.join("\n");
+                return Err(SessionError::Timeout { secs: timeout_secs, stderr });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::models::{ExecutorType, ParsedLogEntry};
+
+    /// 最小 CodeExecutor 桩：program/args 固定，仅实现无默认值的 trait 方法。
+    /// command_args_with_session 走默认实现（委托 command_args），让 session 的
+    /// session_id/is_resume 分支不被桩的额外行为干扰。
+    struct StubExecutor {
+        program: String,
+        args: Vec<String>,
+    }
+
+    impl CodeExecutor for StubExecutor {
+        fn executor_type(&self) -> ExecutorType {
+            // 仅作 registry 键与日志标识，session 骨架不依赖具体变体
+            ExecutorType::default()
+        }
+        fn executable_path(&self) -> &str {
+            &self.program
+        }
+        fn command_args(&self, _message: &str) -> Vec<String> {
+            self.args.clone()
+        }
+        fn parse_output_line(&self, _line: &str) -> Option<ParsedLogEntry> {
+            None
+        }
+        fn get_model(&self) -> Option<String> {
+            None
+        }
+    }
+
+    /// 组装最小 config：cwd 用临时目录（sh/echo 对目录无要求），message 空串
+    /// （桩的 command_args 忽略 message，参数由 args 显式控制断言面）。
+    fn make_config(program: &str, args: &[&str], timeout_secs: u64) -> SessionSpawnConfig {
+        SessionSpawnConfig {
+            executor: Arc::new(StubExecutor {
+                program: program.to_string(),
+                args: args.iter().map(|s| s.to_string()).collect(),
+            }),
+            message: String::new(),
+            cwd: std::env::temp_dir(),
+            session_id: None,
+            timeout_secs,
+            log_tag: "test".to_string(),
+        }
+    }
+
+    /// 成功路径：stdout 逐行进 on_line 回调、raw_stdout 为行 join、success=true。
+    #[tokio::test]
+    async fn test_spawn_and_stream_成功路径逐行回调并返回success() {
+        let mut lines_seen: Vec<String> = Vec::new();
+        let outcome = DirectExecutorSession::spawn_and_stream(
+            make_config("/bin/sh", &["-c", "echo line1; echo line2"], 10),
+            |line| lines_seen.push(line.to_string()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(lines_seen, vec!["line1".to_string(), "line2".to_string()]);
+        assert_eq!(outcome.raw_stdout, "line1\nline2");
+        assert_eq!(outcome.raw_stderr, "");
+        assert!(outcome.success);
+    }
+
+    /// 启动失败：程序不存在 → SessionError::Spawn（调用方据此映射各自文案）。
+    #[tokio::test]
+    async fn test_spawn_and_stream_程序不存在返回spawn失败() {
+        let result =
+            DirectExecutorSession::spawn_and_stream(make_config("/nonexistent/definitely-not-here", &[], 10), |_| {})
+                .await;
+        assert!(matches!(result, Err(SessionError::Spawn(_))));
+    }
+
+    /// 超时路径：kill 子进程并返回 Timeout{secs}，已读到的 stderr 随错误带出
+    /// （B 通路超时文案需要拼 stderr）。
+    #[tokio::test]
+    async fn test_spawn_and_stream_超时kill返回timeout携带stderr() {
+        let result = DirectExecutorSession::spawn_and_stream(
+            make_config("/bin/sh", &["-c", "echo boom >&2; sleep 30"], 1),
+            |_| {},
+        )
+        .await;
+        match result {
+            Err(SessionError::Timeout { secs, stderr }) => {
+                assert_eq!(secs, 1);
+                assert!(stderr.contains("boom"), "超时错误应携带已收集的 stderr");
+            }
+            other => panic!("应为 Timeout，实际为其他结果（ok={}）", other.is_ok()),
+        }
+    }
+
+    /// stderr 捕获：stdout/stderr 同时产出时两路各自收集不串流。
+    #[tokio::test]
+    async fn test_spawn_and_stream_stderr独立捕获不串stdout() {
+        let outcome = DirectExecutorSession::spawn_and_stream(
+            make_config("/bin/sh", &["-c", "echo out; echo err 1>&2"], 10),
+            |_| {},
+        )
+        .await
+        .unwrap();
+        assert_eq!(outcome.raw_stdout, "out");
+        assert_eq!(outcome.raw_stderr, "err");
+        assert!(outcome.success);
+    }
+
+    /// timeout_secs=0 表示不限时：正常完成的进程不受「立即超时」误伤
+    /// （u64::MAX sleep 永不命中的语义回归锚点）。
+    #[tokio::test]
+    async fn test_spawn_and_stream_超时0不限时正常完成() {
+        let outcome = DirectExecutorSession::spawn_and_stream(
+            make_config("/bin/sh", &["-c", "sleep 1; echo done"], 0),
+            |_| {},
+        )
+        .await
+        .unwrap();
+        assert_eq!(outcome.raw_stdout, "done");
+        assert!(outcome.success);
+    }
+
+    /// 非零退出码：success=false（调用方按各自语义决定是否视为失败）。
+    #[tokio::test]
+    async fn test_spawn_and_stream_非零退出success为false() {
+        let outcome = DirectExecutorSession::spawn_and_stream(
+            make_config("/bin/sh", &["-c", "exit 3"], 10),
+            |_| {},
+        )
+        .await
+        .unwrap();
+        assert!(!outcome.success);
+    }
+}

--- a/backend/src/services/executor_session.rs
+++ b/backend/src/services/executor_session.rs
@@ -167,6 +167,15 @@ where
     let timeout_fut = tokio::time::sleep(Duration::from_secs(effective_secs));
     tokio::pin!(timeout_fut);
 
+    // on_line panic 隔离（评审修复）：A 原实现把逐行解析放在独立 tokio::spawn 任务里，
+    // panic 被 JoinHandle 降级为空结果，不会击穿 debounce 任务；收敛后闭包内联进本循环，
+    // 用 catch_unwind 恢复同等隔离——且比原来更强：panic 前已解析的 logs 由调用方保留，
+    // raw 收集不受影响。panic 后置 poisoned，后续行只收集不再回调（原「任务死一次即止」语义）。
+    let mut on_line_poisoned = false;
+    // 排空模式（评审修复）：计时器到点时若进程其实已退出、只是管道还在排空，
+    // 不误判超时（A 原实现的超时只包 child.wait()，不存在排空误判）。
+    let mut drain_mode = false;
+
     loop {
         tokio::select! {
             // 读取下一行 stdout：这是主数据流，EOF 即子进程产出完毕
@@ -174,8 +183,23 @@ where
                 match line_result {
                     Ok(Some(line)) => {
                         raw_stdout_lines.push(line.clone());
-                        // 逐行语义（解析 + 事件推送）交还调用方闭包
-                        on_line(&line);
+                        // 逐行语义（解析 + 事件推送）交还调用方闭包；
+                        // panic 只废掉回调本身，骨架继续读流（见 on_line_poisoned 注释）
+                        if !on_line_poisoned {
+                            let callback = std::panic::AssertUnwindSafe(|| on_line(&line));
+                            if let Err(payload) = std::panic::catch_unwind(callback) {
+                                on_line_poisoned = true;
+                                let reason = payload
+                                    .downcast_ref::<&str>()
+                                    .map(|s| (*s).to_string())
+                                    .or_else(|| payload.downcast_ref::<String>().cloned())
+                                    .unwrap_or_else(|| "unknown".to_string());
+                                tracing::error!(
+                                    "[session] on_line callback panicked, disabling callback (tag={}, reason={})",
+                                    log_tag, reason
+                                );
+                            }
+                        }
                     }
                     // stdout 读完了：等子进程退出并打包返回（stderr 可能仍有未消费缓冲，
                     // 与 B 原实现一致——拿到多少算多少，不为凑齐 stderr 阻塞返回）
@@ -215,8 +239,18 @@ where
                     }
                 }
             }
-            // 超时：kill 子进程避免僵尸，错误携带已收集的 stderr 供调用方拼文案
-            _ = &mut timeout_fut => {
+            // 超时：以「进程是否退出」为准（评审修复）。进程已退出只是管道还在排空时
+            // 切入排空模式（禁用计时分支），读完 stdout EOF 正常返回，不误判超时；
+            // 真未退出才 kill 回收，错误携带已收集的 stderr 供调用方拼文案。
+            _ = &mut timeout_fut, if !drain_mode => {
+                if let Ok(Some(_status)) = child.try_wait() {
+                    tracing::info!(
+                        "[session] timer fired but child already exited, draining remaining output: tag={}",
+                        log_tag
+                    );
+                    drain_mode = true;
+                    continue;
+                }
                 tracing::error!(
                     "[session] timed out after {}s, killing child: tag={}",
                     timeout_secs, log_tag
@@ -325,7 +359,7 @@ mod tests {
 
     /// stderr 捕获：stdout/stderr 同时产出时两路各自收集不串流。
     #[tokio::test]
-    async fn test_spawn_and_stream_stderr独立捕获不串stdout() {
+    async fn test_spawn_and_stream_双流分流捕获不串流() {
         let outcome = DirectExecutorSession::spawn_and_stream(
             make_config("/bin/sh", &["-c", "echo out; echo err 1>&2"], 10),
             |_| {},
@@ -348,6 +382,28 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(outcome.raw_stdout, "done");
+        assert!(outcome.success);
+    }
+
+    /// on_line panic 隔离（评审修复的回归锚点）：回调 panic 后骨架不击穿，
+    /// 正常返回完整 raw 文本，回调仅触发到 panic 行为止。
+    #[tokio::test]
+    async fn test_spawn_and_stream_回调panic不击穿骨架() {
+        let mut lines_seen: Vec<String> = Vec::new();
+        let outcome = DirectExecutorSession::spawn_and_stream(
+            make_config("/bin/sh", &["-c", "echo l1; echo l2; echo l3"], 10),
+            |line| {
+                // 第二行模拟解析器 panic：骨架应隔离它并继续收集
+                if line == "l2" {
+                    panic!("模拟解析器 panic");
+                }
+                lines_seen.push(line.to_string());
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(lines_seen, vec!["l1".to_string()], "panic 行之后的回调应被禁用");
+        assert_eq!(outcome.raw_stdout, "l1\nl2\nl3", "raw 收集不受回调 panic 影响");
         assert!(outcome.success);
     }
 

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use dashmap::DashMap;
-use tokio::io::AsyncReadExt;
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
@@ -839,88 +838,6 @@ fn build_executor_end_content(
     }
 }
 
-/// `run_executor_with_timeout` 的失败原因。
-///
-/// 区分"超时"和"wait 本身出错"是因为两者的用户提示不同：超时基本是 provider
-/// 挂起，wait 失败更可能是本地进程/系统层问题。调用方据此拼错误消息。
-// 096-W4-6 后该枚举仅剩 run_executor_with_timeout（测试保留）消费，
-// 生产链路已改走 executor_session::SessionError
-#[derive(Debug)]
-#[allow(dead_code)]
-enum ExecutorRunError {
-    /// 子进程在 `timeout` 内未退出，已被 kill 回收。
-    Timeout { secs: u64 },
-    /// `child.wait()` 本身返回了错误（例如系统层 IO 失败）。
-    WaitFailed(String),
-}
-
-/// 带超时地运行子进程：并发读取 stdout + `child.wait()` 与计时器竞赛。
-///
-/// 不用 `Child::wait_with_output`——它按值消费 `child`，超时分支就拿不到句柄
-/// 去 kill，pi 会变成孤儿进程继续占资源。这里改成先 `take()` 出 stdout
-/// 在独立 task 里 `read_to_end`，再用 `&mut child.wait()` 参与超时竞赛；
-/// 超时则 `start_kill`（发 SIGKILL）+ `wait` 回收僵尸，返回 `Timeout`。
-/// 成功则把 (退出状态, stdout 字节) 一起返回给上层解析。
-///
-/// `timeout` 为 `Some` 时按上述超时竞赛执行；为 `None` 时表示用户把
-/// `execution_timeout_secs` 设为 `0`（不限制），此时直接 `child.wait()` 等到进程退出，
-/// 不包 `tokio::time::timeout`、不 kill——语义与 todo pipeline 的
-/// `timeout_enabled = v > 0` 对齐。
-///
-/// 注意：生产代码已改用 `DirectExecutorSession::spawn_and_stream`（096-W4-6）替代此函数，
-/// 保留此函数仅供测试覆盖超时/kill 行为。
-#[allow(dead_code)]
-async fn run_executor_with_timeout(
-    mut child: tokio::process::Child,
-    timeout: Option<std::time::Duration>,
-) -> Result<(std::process::ExitStatus, Vec<u8>), ExecutorRunError> {
-    // 先把 stdout 拿走，独立 task 里读完整缓冲。这样 wait 的计时竞赛只管
-    // 进程退出，不阻塞在 stdout 读取上；超时分支也还能 kill child。
-    let stdout_handle = child.stdout.take();
-    let stdout_task = stdout_handle.map(|mut reader| {
-        tokio::spawn(async move {
-            let mut buf = Vec::new();
-            // 读取失败时返回已收到的部分；调用方按字节解析，不因读错误整体失败
-            let _ = reader.read_to_end(&mut buf).await;
-            buf
-        })
-    });
-
-    // Some → 计时竞赛；None → 无超时等待。两条分支成功后都要 join stdout task。
-    // 错误分支用 `return Err(..)` 提前退出，故此处 `wait_outcome` 即 `ExitStatus`。
-    let wait_outcome = match timeout {
-        Some(t) => match tokio::time::timeout(t, child.wait()).await {
-            Ok(Ok(status)) => status,
-            // wait 本身出错：本地进程/系统层问题，带上错误信息让用户看得到
-            Ok(Err(e)) => return Err(ExecutorRunError::WaitFailed(e.to_string())),
-            Err(_) => {
-                // 超时：先 SIGKILL 再 wait 回收，避免 pi 孤儿进程；两步失败都不致命，用 _ 忽略
-                let _ = child.start_kill();
-                let _ = child.wait().await;
-                // 此处故意不 join stdout_task：kill 后子进程管道关闭，read_to_end 收到 EOF
-                // 自行结束，task 变 detached 但不会泄漏；超时路径本就不要输出，buf 随 task 丢弃。
-                return Err(ExecutorRunError::Timeout { secs: t.as_secs() });
-            }
-        },
-        None => match child.wait().await {
-            Ok(status) => status,
-            // wait 本身出错的情况与 Some 分支一致，复用同一个错误变体
-            Err(e) => return Err(ExecutorRunError::WaitFailed(e.to_string())),
-        },
-    };
-
-    // 进程已退出，join 读 stdout 的 task 拿完整输出；task 若 panic 则当无输出。
-    // 用 async block 而非闭包，才能在里面 await join handle。
-    let buf = match stdout_task {
-        Some(task) => task.await.unwrap_or_default(),
-        None => Vec::new(),
-    };
-    Ok((wait_outcome, buf))
-}
-
-
-
-
 /// 一对一私聊场景下，过程消息直接推送的目标信息
 struct DirectOutputInfo {
     bot_id: i64,
@@ -1085,12 +1002,12 @@ fn emit_direct_stream(
 /// 飞书直连执行器与 todo 执行路径共用同一把旋钮；0 = 不限制（session 骨架内部
 /// 用极大 duration 表达「永不超时」，与 todo pipeline 的 `timeout_enabled = v > 0` 对齐）。
 fn read_execution_timeout_secs(config: &Arc<std::sync::RwLock<crate::config::Config>>) -> u64 {
-    #[allow(clippy::expect_used)]
-    // 中毒=有线程 panic，继续无意义；与全仓 RwLock 处置约定一致
-    let cfg = config
+    // 锁中毒=有线程 panic 过，但配置值本身仍可读：恢复内部守卫降级读取，
+    // 不让一次无关 panic 击穿飞书默认响应链路（生产代码禁 expect，见禁止清单 #1）
+    config
         .read()
-        .expect("config RwLock poisoned in handle_default_response_executor");
-    cfg.execution_timeout_secs
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .execution_timeout_secs
 }
 
 /// 096-W4-6：session typed error → 飞书错误提示 + Err(None)（编排体保持线性 ? 上抛）。
@@ -1611,6 +1528,78 @@ mod merge_pending_messages_tests {
 mod executor_feedback_tests {
     use super::*;
 
+    use tokio::io::AsyncReadExt;
+#[derive(Debug)]
+#[allow(dead_code)]
+enum ExecutorRunError {
+    /// 子进程在 `timeout` 内未退出，已被 kill 回收。
+    Timeout { secs: u64 },
+    /// `child.wait()` 本身返回了错误（例如系统层 IO 失败）。
+    WaitFailed(String),
+}
+
+/// 带超时地运行子进程：并发读取 stdout + `child.wait()` 与计时器竞赛。
+///
+/// 不用 `Child::wait_with_output`——它按值消费 `child`，超时分支就拿不到句柄
+/// 去 kill，pi 会变成孤儿进程继续占资源。这里改成先 `take()` 出 stdout
+/// 在独立 task 里 `read_to_end`，再用 `&mut child.wait()` 参与超时竞赛；
+/// 超时则 `start_kill`（发 SIGKILL）+ `wait` 回收僵尸，返回 `Timeout`。
+/// 成功则把 (退出状态, stdout 字节) 一起返回给上层解析。
+///
+/// `timeout` 为 `Some` 时按上述超时竞赛执行；为 `None` 时表示用户把
+/// `execution_timeout_secs` 设为 `0`（不限制），此时直接 `child.wait()` 等到进程退出，
+/// 不包 `tokio::time::timeout`、不 kill——语义与 todo pipeline 的
+/// `timeout_enabled = v > 0` 对齐。
+///
+async fn run_executor_with_timeout(
+    mut child: tokio::process::Child,
+    timeout: Option<std::time::Duration>,
+) -> Result<(std::process::ExitStatus, Vec<u8>), ExecutorRunError> {
+    // 先把 stdout 拿走，独立 task 里读完整缓冲。这样 wait 的计时竞赛只管
+    // 进程退出，不阻塞在 stdout 读取上；超时分支也还能 kill child。
+    let stdout_handle = child.stdout.take();
+    let stdout_task = stdout_handle.map(|mut reader| {
+        tokio::spawn(async move {
+            let mut buf = Vec::new();
+            // 读取失败时返回已收到的部分；调用方按字节解析，不因读错误整体失败
+            let _ = reader.read_to_end(&mut buf).await;
+            buf
+        })
+    });
+
+    // Some → 计时竞赛；None → 无超时等待。两条分支成功后都要 join stdout task。
+    // 错误分支用 `return Err(..)` 提前退出，故此处 `wait_outcome` 即 `ExitStatus`。
+    let wait_outcome = match timeout {
+        Some(t) => match tokio::time::timeout(t, child.wait()).await {
+            Ok(Ok(status)) => status,
+            // wait 本身出错：本地进程/系统层问题，带上错误信息让用户看得到
+            Ok(Err(e)) => return Err(ExecutorRunError::WaitFailed(e.to_string())),
+            Err(_) => {
+                // 超时：先 SIGKILL 再 wait 回收，避免 pi 孤儿进程；两步失败都不致命，用 _ 忽略
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+                // 此处故意不 join stdout_task：kill 后子进程管道关闭，read_to_end 收到 EOF
+                // 自行结束，task 变 detached 但不会泄漏；超时路径本就不要输出，buf 随 task 丢弃。
+                return Err(ExecutorRunError::Timeout { secs: t.as_secs() });
+            }
+        },
+        None => match child.wait().await {
+            Ok(status) => status,
+            // wait 本身出错的情况与 Some 分支一致，复用同一个错误变体
+            Err(e) => return Err(ExecutorRunError::WaitFailed(e.to_string())),
+        },
+    };
+
+    // 进程已退出，join 读 stdout 的 task 拿完整输出；task 若 panic 则当无输出。
+    // 用 async block 而非闭包，才能在里面 await join handle。
+    let buf = match stdout_task {
+        Some(task) => task.await.unwrap_or_default(),
+        None => Vec::new(),
+    };
+    Ok((wait_outcome, buf))
+}
+
+
     /// 短消息：开始标志应包含执行器名 + 原文 preview，前缀 ⏳ 与全仓 status_icon 约定一致。
     #[test]
     fn test_executor_start_message_basic() {
@@ -1634,6 +1623,39 @@ mod executor_feedback_tests {
     fn test_executor_error_message_format() {
         let msg = executor_error_message("pi", "执行超时（300s）");
         assert_eq!(msg, "❌ pi 执行失败：执行超时（300s）");
+    }
+
+    /// session typed error → 飞书错误文案映射（096-W4-6）：四个分支的前缀与原因透传
+    /// 必须与原 spawn_executor_child / await_executor_exit 的文案逐字一致——
+    /// 这是「typed error 各通路映射回原有文案」收敛承诺的回归锚点。
+    #[test]
+    fn test_session_error_to_feishu_四分支错误文案映射() {
+        let sent = std::sync::Mutex::new(Vec::<String>::new());
+        let send = |content: String| sent.lock().unwrap().push(content);
+        session_error_to_feishu(
+            SessionError::Spawn(std::io::Error::new(std::io::ErrorKind::NotFound, "no such file")),
+            "pi",
+            &send,
+        );
+        session_error_to_feishu(
+            SessionError::Timeout { secs: 300, stderr: String::new() },
+            "pi",
+            &send,
+        );
+        session_error_to_feishu(SessionError::WaitFailed("boom".to_string()), "pi", &send);
+        session_error_to_feishu(
+            SessionError::StdoutReadFailed {
+                source: std::io::Error::new(std::io::ErrorKind::BrokenPipe, "eof"),
+                stderr: String::new(),
+            },
+            "pi",
+            &send,
+        );
+        let sent = sent.into_inner().unwrap();
+        assert_eq!(sent[0], "❌ pi 执行失败：启动进程失败：no such file");
+        assert_eq!(sent[1], "❌ pi 执行失败：执行超时（300s）");
+        assert_eq!(sent[2], "❌ pi 执行失败：等待进程失败：boom");
+        assert_eq!(sent[3], "❌ pi 执行失败：读取进程输出失败：eof");
     }
 
     /// 工作空间缺失提示（wid=0 未绑定哨兵）：必须引导去绑定而非报「0 不存在」，

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -824,15 +824,21 @@ fn build_executor_end_content(
         // 进程退出 0：统一发简洁结束标志，过程内容已实时推送，不再重复输出
         format!("✅ {} 处理完成", executor_type)
     } else {
+        // 退出码不能 {:?} 给用户看（会渲染成 Rust 调试格式 Some(1)）：
+        // 被信号杀死时 code() 为 None，给可读文案（评审修复）
+        let code_text = match exit_code {
+            Some(code) => code.to_string(),
+            None => "未知（进程被信号终止）".to_string(),
+        };
         // 非零退出：用 stderr 展示错误信息（执行器错误信息通常走 stderr），
         // stderr 为空则只报退出码。
         let diagnostic = stderr.chars().take(STDERR_PREVIEW_CHAR_LIMIT).collect::<String>();
         if diagnostic.trim().is_empty() {
-            executor_error_message(executor_type, &format!("退出码 {:?}", exit_code))
+            executor_error_message(executor_type, &format!("退出码 {}", code_text))
         } else {
             executor_error_message(
                 executor_type,
-                &format!("退出码 {:?}\n{}", exit_code, diagnostic),
+                &format!("退出码 {}\n{}", code_text, diagnostic),
             )
         }
     }
@@ -1775,7 +1781,7 @@ async fn run_executor_with_timeout(
         // 关键断言：这一行不 panic 即说明按 char 截断生效
         let content = build_executor_end_content("pi", false, Some(1), None, "", &chinese);
         assert!(
-            content.starts_with("❌ pi 执行失败：退出码 Some(1)"),
+            content.starts_with("❌ pi 执行失败：退出码 1"),
             "should start with error prefix, got: {}",
             content
         );

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -1,8 +1,9 @@
 use std::collections::{HashMap, VecDeque};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use dashmap::DashMap;
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use tokio::io::AsyncReadExt;
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
@@ -16,6 +17,9 @@ use crate::executor_service::{
 use crate::executor_service::ExecEvent;
 use crate::models::ParsedLogEntry;
 use crate::service_context::ServiceContext;
+use crate::services::executor_session::{
+    DirectExecutorSession, SessionError, SessionSpawnConfig,
+};
 use crate::task_manager::TaskManager;
 
 #[derive(Debug, Clone)]
@@ -740,20 +744,6 @@ pub fn merge_pending_messages(messages: &[PendingMessage]) -> String {
 // 用户侧表现为"发了消息毫无反馈"。这一组纯函数/小函数把可测的逻辑抽出来：
 // 三类反馈消息（开始/错误/空结束）的格式 + 带超时地运行子进程并在超时时 kill 回收。
 
-/// 把 config 里的 `execution_timeout_secs` 解析成直连执行器要用的超时。
-///
-/// 飞书直连执行器与 todo 执行路径共用同一把全局超时旋钮（`execution_timeout_secs`），
-/// 不再维护独立的写死阈值。`0` 在 todo pipeline 里表示「不限制」
-/// （`timeout_enabled = v > 0`），这里遵循同一语义：`0` → `None`，走无超时等待分支。
-/// 原因是 `tokio::time::timeout(Duration::from_secs(0), ..)` 会立刻返回 `Elapsed`，
-/// 若把 0 直接当超时传进去，所有直连调用会被瞬间判死。
-fn direct_executor_timeout(secs: u64) -> Option<std::time::Duration> {
-    if secs == 0 {
-        None
-    } else {
-        Some(std::time::Duration::from_secs(secs))
-    }
-}
 
 /// 开始执行时发回飞书的标志文本。
 ///
@@ -818,9 +808,12 @@ fn executor_empty_end_message(executor_type: &str) -> String {
 /// 把这段决策从 `handle_default_response_executor` 主体抽成纯函数，是为了能直接单测
 /// 非零退出 + 多字节中文 stdout 的截断行为——原来内联时 `&stdout[..1500]` 按字节切片，
 /// 落在中文中间会 panic，反而把"执行器非零退出"变成 debounce 任务崩溃。
+/// 096-W4-6 起入参从 `&ExitStatus` 改为 success + exit_code 两个标量：
+/// DirectExecutorSession 不透传 ExitStatus（B 通路用不到），A 通路只需退出位与退出码。
 fn build_executor_end_content(
     executor_type: &str,
-    status: &std::process::ExitStatus,
+    success: bool,
+    exit_code: Option<i32>,
     _result_text: Option<String>,
     _stdout: &str,
     stderr: &str,
@@ -828,7 +821,7 @@ fn build_executor_end_content(
     // 非零退出时 stderr 给用户的预览上限，按 char 计：与开始消息 preview 同语义，
     // 避免 `&str[..n]` 这种按字节切片切到多字节字符中间触发 panic。
     const STDERR_PREVIEW_CHAR_LIMIT: usize = 1500;
-    if status.success() {
+    if success {
         // 进程退出 0：统一发简洁结束标志，过程内容已实时推送，不再重复输出
         format!("✅ {} 处理完成", executor_type)
     } else {
@@ -836,11 +829,11 @@ fn build_executor_end_content(
         // stderr 为空则只报退出码。
         let diagnostic = stderr.chars().take(STDERR_PREVIEW_CHAR_LIMIT).collect::<String>();
         if diagnostic.trim().is_empty() {
-            executor_error_message(executor_type, &format!("退出码 {:?}", status.code()))
+            executor_error_message(executor_type, &format!("退出码 {:?}", exit_code))
         } else {
             executor_error_message(
                 executor_type,
-                &format!("退出码 {:?}\n{}", status.code(), diagnostic),
+                &format!("退出码 {:?}\n{}", exit_code, diagnostic),
             )
         }
     }
@@ -850,7 +843,10 @@ fn build_executor_end_content(
 ///
 /// 区分"超时"和"wait 本身出错"是因为两者的用户提示不同：超时基本是 provider
 /// 挂起，wait 失败更可能是本地进程/系统层问题。调用方据此拼错误消息。
+// 096-W4-6 后该枚举仅剩 run_executor_with_timeout（测试保留）消费，
+// 生产链路已改走 executor_session::SessionError
 #[derive(Debug)]
+#[allow(dead_code)]
 enum ExecutorRunError {
     /// 子进程在 `timeout` 内未退出，已被 kill 回收。
     Timeout { secs: u64 },
@@ -871,7 +867,7 @@ enum ExecutorRunError {
 /// 不包 `tokio::time::timeout`、不 kill——语义与 todo pipeline 的
 /// `timeout_enabled = v > 0` 对齐。
 ///
-/// 注意：生产代码已改用 `wait_child_with_timeout` + `stream_executor_stdout` 替代此函数，
+/// 注意：生产代码已改用 `DirectExecutorSession::spawn_and_stream`（096-W4-6）替代此函数，
 /// 保留此函数仅供测试覆盖超时/kill 行为。
 #[allow(dead_code)]
 async fn run_executor_with_timeout(
@@ -922,80 +918,8 @@ async fn run_executor_with_timeout(
     Ok((wait_outcome, buf))
 }
 
-/// 仅等待子进程退出（不读 stdout），超时则 kill 回收
-///
-/// 与 run_executor_with_timeout 的区别：不负责读取 stdout，因为 stdout 句柄
-/// 在调用前已被 take() 走用于流式读取。此函数只做 wait + timeout + kill。
-async fn wait_child_with_timeout(
-    mut child: tokio::process::Child,
-    timeout: Option<std::time::Duration>,
-) -> Result<std::process::ExitStatus, ExecutorRunError> {
-    match timeout {
-        // Some → 计时竞赛；None → 无超时等待
-        Some(t) => match tokio::time::timeout(t, child.wait()).await {
-            Ok(Ok(status)) => Ok(status),
-            Ok(Err(e)) => Err(ExecutorRunError::WaitFailed(e.to_string())),
-            Err(_) => {
-                // 超时：SIGKILL + wait 回收，避免孤儿进程
-                let _ = child.start_kill();
-                let _ = child.wait().await;
-                Err(ExecutorRunError::Timeout { secs: t.as_secs() })
-            }
-        },
-        None => match child.wait().await {
-            Ok(status) => Ok(status),
-            Err(e) => Err(ExecutorRunError::WaitFailed(e.to_string())),
-        },
-    }
-}
 
-/// 流式读取执行器 stdout 的结果
-///
-/// logs：解析后的日志条目，用于提取最终结果（get_final_result_from_logs）
-/// raw_stdout：原始 stdout 文本，用于错误诊断和兜底回复
-struct StdoutStreamResult {
-    logs: Vec<ParsedLogEntry>,
-    raw_stdout: String,
-}
 
-/// 流式读取执行器 stdout：逐行解析并发送 Output 事件
-///
-/// 复用 log_capture.rs 的 EventPipeline 创建和解析逻辑，确保 executor 直连执行
-/// 与 todo 执行产生完全相同格式的事件。发送的 ExecEvent::Output 会被
-/// FeishuPushService 按 push_level 推送到飞书（"all" 时推送过程事件）。
-///
-/// `direct_output_info` 为 Some 时，每条解析出的日志额外发一条
-/// DirectStreamMessage 直接推送给触发用户（一对一私聊场景），
-/// 这样即使 push target 未配置该用户，用户也能在聊天中看到执行过程。
-async fn stream_executor_stdout<R: tokio::io::AsyncRead + Unpin + Send>(
-    stdout_handle: Option<R>,
-    executor: &Arc<dyn crate::adapters::CodeExecutor>,
-    tx: &broadcast::Sender<ExecEvent>,
-    task_id: &str,
-    workspace_id: Option<i64>,
-    direct_output_info: Option<DirectOutputInfo>,
-) -> StdoutStreamResult {
-    let Some(stdout) = stdout_handle else {
-        return StdoutStreamResult { logs: Vec::new(), raw_stdout: String::new() };
-    };
-    // 复用 log_capture 的 pipeline 创建逻辑，确保与 todo 执行路径一致
-    let mut pipeline = log_capture::create_pipeline_for_executor(executor.as_ref())
-        .unwrap_or_else(|| EventPipeline::new(executor.executor_type().as_str()));
-    let mut reader = BufReader::new(stdout).lines();
-    let mut result = StdoutStreamResult { logs: Vec::new(), raw_stdout: String::new() };
-
-    while let Ok(Some(line)) = reader.next_line().await {
-        process_executor_stdout_line(
-            &line, &mut pipeline, executor, tx, task_id, workspace_id,
-            direct_output_info.as_ref(), &mut result,
-        );
-    }
-    finalize_pipeline_by_path(
-        &mut pipeline, tx, task_id, workspace_id,
-        direct_output_info.as_ref(), &mut result,
-    );
-    result
-}
 
 /// 一对一私聊场景下，过程消息直接推送的目标信息
 struct DirectOutputInfo {
@@ -1017,10 +941,9 @@ fn process_executor_stdout_line(
     task_id: &str,
     workspace_id: Option<i64>,
     direct_output: Option<&DirectOutputInfo>,
-    result: &mut StdoutStreamResult,
+    logs: &mut Vec<ParsedLogEntry>,
 ) {
-    result.raw_stdout.push_str(line);
-    result.raw_stdout.push('\n');
+    // 096-W4-6：raw_stdout 收集移交 DirectExecutorSession 骨架，这里只累积解析结果 logs。
     // 一对一私聊场景：手动解析，只发送 DirectStreamMessage，不调用 parse_and_broadcast（避免发送 Output 导致重复）
     if let Some(info) = direct_output {
         let parsed_list = parse_for_direct_stream(pipeline, line);
@@ -1028,13 +951,13 @@ fn process_executor_stdout_line(
             for entry in &parsed_list {
                 emit_direct_stream(tx, info, entry.clone());
             }
-            result.logs.extend(parsed_list);
+            logs.extend(parsed_list);
             return;
         }
         // 回退到 executor 自定义解析
         let Some(parsed) = executor.parse_output_line(line) else { return };
         emit_direct_stream(tx, info, parsed.clone());
-        result.logs.push(parsed);
+        logs.push(parsed);
         return;
     }
     // 非私聊场景：走标准流程，调用 parse_and_broadcast 发送 Output 事件
@@ -1043,7 +966,7 @@ fn process_executor_stdout_line(
         pipeline, line, tx, task_id, workspace_id, executor.as_ref(),
     );
     if !parsed_list.is_empty() {
-        result.logs.extend(parsed_list);
+        logs.extend(parsed_list);
         return;
     }
     // 回退到 executor 自定义解析（非 JSONL 格式的行）
@@ -1056,7 +979,7 @@ fn process_executor_stdout_line(
             workspace_id,
         },
     );
-    result.logs.push(parsed);
+    logs.push(parsed);
 }
 
 /// 手动解析 pipeline：只返回解析结果，不发送 Output 事件（由调用方决定发送方式）
@@ -1093,7 +1016,7 @@ fn finalize_pipeline_by_path(
     task_id: &str,
     workspace_id: Option<i64>,
     direct_output: Option<&DirectOutputInfo>,
-    result: &mut StdoutStreamResult,
+    logs: &mut Vec<ParsedLogEntry>,
 ) {
     let len_before = pipeline.len();
     pipeline.finalize();
@@ -1108,7 +1031,7 @@ fn finalize_pipeline_by_path(
                 | crate::execution_events::ExecutionEvent::Result { .. } => {
                     let parsed = crate::execution_events::DbLogEntry::from_event_to_parsed_log_entry(event);
                     emit_direct_stream(tx, info, parsed.clone());
-                    result.logs.push(parsed);
+                    logs.push(parsed);
                 }
                 _ => {}
             }
@@ -1116,7 +1039,7 @@ fn finalize_pipeline_by_path(
         }
         // 非私聊场景：走标准流程，发送 Output 事件
         let parsed = log_capture::emit_broadcast_event(event, tx, task_id, workspace_id);
-        result.logs.push(parsed);
+        logs.push(parsed);
     }
 }
 
@@ -1156,6 +1079,50 @@ fn emit_direct_stream(
 // 红线）拆成 7 个职责单一的阶段。每个失败分支自行发飞书提示后返回 Err(None)，
 // 编排体用 ? 向上传播——副作用与返回的耦合被收敛进单一阶段内部（线性错误处理），
 // 编排体本身回归成一段 stepdown 叙事。行为与原实现逐分支一致，签名零改动。
+
+/// 读全局超时旋钮 execution_timeout_secs。
+///
+/// 飞书直连执行器与 todo 执行路径共用同一把旋钮；0 = 不限制（session 骨架内部
+/// 用极大 duration 表达「永不超时」，与 todo pipeline 的 `timeout_enabled = v > 0` 对齐）。
+fn read_execution_timeout_secs(config: &Arc<std::sync::RwLock<crate::config::Config>>) -> u64 {
+    #[allow(clippy::expect_used)]
+    // 中毒=有线程 panic，继续无意义；与全仓 RwLock 处置约定一致
+    let cfg = config
+        .read()
+        .expect("config RwLock poisoned in handle_default_response_executor");
+    cfg.execution_timeout_secs
+}
+
+/// 096-W4-6：session typed error → 飞书错误提示 + Err(None)（编排体保持线性 ? 上抛）。
+///
+/// Spawn/Timeout/WaitFailed 三个分支的文案与原 spawn_executor_child /
+/// await_executor_exit 逐字一致；StdoutReadFailed 是新增分支——原实现 stdout 读错误
+/// 只静默结束循环，doc 101 已声明的行为微变：上抛让用户可见，避免「看似跑完实则丢输出」。
+fn session_error_to_feishu(
+    e: SessionError,
+    executor_type: &str,
+    send_msg: &(dyn Fn(String) + Sync),
+) -> Option<String> {
+    match e {
+        SessionError::Spawn(err) => {
+            tracing::error!("[debounce] failed to spawn executor {}: {}", executor_type, err);
+            send_msg(executor_error_message(executor_type, &format!("启动进程失败：{}", err)));
+        }
+        SessionError::Timeout { secs, .. } => {
+            tracing::error!("[debounce] executor {} timed out after {}s", executor_type, secs);
+            send_msg(executor_error_message(executor_type, &format!("执行超时（{}s）", secs)));
+        }
+        SessionError::WaitFailed(msg) => {
+            tracing::error!("[debounce] failed to wait for executor {}: {}", executor_type, msg);
+            send_msg(executor_error_message(executor_type, &format!("等待进程失败：{}", msg)));
+        }
+        SessionError::StdoutReadFailed { source, .. } => {
+            tracing::error!("[debounce] failed to read executor {} stdout: {}", executor_type, source);
+            send_msg(executor_error_message(executor_type, &format!("读取进程输出失败：{}", source)));
+        }
+    }
+    None
+}
 
 /// 阶段①：解析直连执行器要使用的工作空间目录。
 ///
@@ -1266,46 +1233,6 @@ async fn resolve_executor_session(
     }
 }
 
-/// 阶段④：构建执行器命令（带 session_id）并 spawn 子进程。
-///
-/// spawn 失败（程序不存在 / 无权限等）自行发飞书提示并返回 Err(None)。
-async fn spawn_executor_child(
-    executor: &Arc<dyn crate::adapters::CodeExecutor>,
-    workspace_path: &str,
-    message: &str,
-    session_id: Option<&str>,
-    executor_type: &str,
-    send_msg: &(dyn Fn(String) + Sync),
-) -> Result<tokio::process::Child, Option<String>> {
-    // is_resume 由是否有 session_id 推导：有 session 则让执行器续上下文而非新开会话
-    let is_resume = session_id.is_some();
-    let command_args = executor.command_args_with_session(message, session_id, is_resume);
-    let program = executor.executable_path();
-    tracing::info!(
-        "[debounce] spawning: {} {:?} (cwd={:?})",
-        program,
-        command_args,
-        workspace_path
-    );
-    // 三个 stdio 全 piped：stdout/stderr 由我们读取，stdin 在编排体里 take()后 drop 关闭
-    let mut cmd = tokio::process::Command::new(program);
-    cmd.args(&command_args)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .stdin(std::process::Stdio::piped())
-        .current_dir(workspace_path);
-    match cmd.spawn() {
-        Ok(c) => Ok(c),
-        Err(e) => {
-            tracing::error!("[debounce] failed to spawn executor {}: {}", executor_type, e);
-            send_msg(executor_error_message(
-                executor_type,
-                &format!("启动进程失败：{}", e),
-            ));
-            Err(None)
-        }
-    }
-}
 
 /// 阶段⑤：查 push_level，仅当配置为 "all" 时返回私聊直推目标。
 ///
@@ -1338,102 +1265,8 @@ async fn resolve_direct_output(
     }
 }
 
-/// 阶段⑥：读 config 超时，带超时地等子进程退出（超时则 kill 回收）。
-///
-/// 超时 / wait 失败自行发飞书提示并返回 Err(None)；成功返回退出状态。
-async fn await_executor_exit(
-    child: tokio::process::Child,
-    config: &Arc<std::sync::RwLock<crate::config::Config>>,
-    executor_type: &str,
-    send_msg: &(dyn Fn(String) + Sync),
-) -> Result<std::process::ExitStatus, Option<String>> {
-    // 与 todo pipeline 共用全局超时旋钮 execution_timeout_secs；0 表示不限制（→ None）
-    let timeout_secs = {
-        #[allow(clippy::expect_used)]
-        // 中毒=有线程 panic，继续无意义；与全仓 RwLock 处置约定一致
-        let cfg = config
-            .read()
-            .expect("config RwLock poisoned in handle_default_response_executor");
-        cfg.execution_timeout_secs
-    };
-    let timeout = direct_executor_timeout(timeout_secs);
-    match wait_child_with_timeout(child, timeout).await {
-        Ok(s) => {
-            tracing::info!(
-                "[debounce] executor {} finished, exit_code={:?}",
-                executor_type,
-                s.code()
-            );
-            Ok(s)
-        }
-        Err(ExecutorRunError::Timeout { secs }) => {
-            tracing::error!("[debounce] executor {} timed out after {}s", executor_type, secs);
-            send_msg(executor_error_message(executor_type, &format!("执行超时（{}s）", secs)));
-            Err(None)
-        }
-        Err(ExecutorRunError::WaitFailed(msg)) => {
-            tracing::error!(
-                "[debounce] failed to wait for executor {}: {}",
-                executor_type,
-                msg
-            );
-            send_msg(executor_error_message(
-                executor_type,
-                &format!("等待进程失败：{}", msg),
-            ));
-            Err(None)
-        }
-    }
-}
 
-/// 阶段⑦的输出打包：避免 stream / stderr / result_text 三个值在调用链里裸传递。
-struct ExecutorOutput {
-    /// 流式解析结果：logs 用于提取结果 + session，raw_stdout 用于诊断兜底
-    stream: StdoutStreamResult,
-    /// 子进程 stderr 全文：非零退出时拼进错误消息
-    stderr: String,
-    /// 从 logs 提取的最终结果文本（执行器产出的结论）
-    result_text: Option<String>,
-}
 
-/// 阶段⑦：join 流式读取、读 stderr、计算最终结果文本。
-///
-/// 纯收集，无致命分支：stream_task panic 时降级为空结果，stderr 读取失败只丢 stderr。
-async fn collect_executor_output(
-    stream_task: JoinHandle<StdoutStreamResult>,
-    stderr_handle: Option<tokio::process::ChildStderr>,
-    executor_type: &str,
-) -> ExecutorOutput {
-    // join 流式读取：task panic 时按空结果处理（与原 unwrap_or 一致）
-    let stream = stream_task.await.unwrap_or(StdoutStreamResult {
-        logs: Vec::new(),
-        raw_stdout: String::new(),
-    });
-    // 读 stderr：read_to_end 失败只丢 stderr 内容，不影响主流程结果
-    let stderr = match stderr_handle {
-        Some(mut reader) => {
-            let mut buf = Vec::new();
-            let _ = reader.read_to_end(&mut buf).await;
-            String::from_utf8_lossy(&buf).to_string()
-        }
-        None => String::new(),
-    };
-    // stderr 非空才打日志：按 char 截 2000，避免按字节切片切断多字节中文
-    if !stderr.is_empty() {
-        let stderr_preview: String = stderr.chars().take(2000).collect();
-        tracing::info!("[debounce] executor {} stderr:\n{}", executor_type, stderr_preview);
-    }
-    // stdout 预览：同样按 char 截 2000，与 stderr 预览同语义
-    let stdout_preview: String = stream.raw_stdout.chars().take(2000).collect();
-    tracing::info!("[debounce] executor {} stdout:\n{}", executor_type, stdout_preview);
-    // 从日志提取最终结果（与 todo 执行路径一致）
-    let result_text = crate::executor_service::completion::get_final_result_from_logs(&stream.logs);
-    ExecutorOutput {
-        stream,
-        stderr,
-        result_text,
-    }
-}
 
 /// 阶段⑧：执行成功时从日志提取 session_id 并持久化到 DB（实现多轮对话 resume）。
 ///
@@ -1595,67 +1428,79 @@ impl MessageDebounce {
             session_id.as_deref().map(|s| s.chars().take(20).collect::<String>())
         );
 
-        // ④ 构建执行器命令（带 session_id）并 spawn 子进程
-        let mut child = spawn_executor_child(
-            &executor,
-            &workspace_path,
-            message,
-            session_id.as_deref(),
-            executor_type,
-            &send_msg,
-        )
-        .await?;
-
-        // ⑤ 提取 stdout/stderr 句柄、生成 task_id、发"开始处理"、关 stdin、查直推目标、
-        // spawn 流式读取。这段留体内：stream_task 的 tokio::spawn move 了 stdout_handle /
-        // tx / executor / task_id 多个本地值，抽出要么造巨参 helper、要么引入中间 struct，
-        // 收益不抵成本（YAGNI）。
-        let stdout_handle = child.stdout.take();
-        let stderr_handle = child.stderr.take();
-        // task_id 提前生成：流式读取任务和最终返回值共用同一个 id
+        // ④⑤⑥⑦ 进程生命周期收敛进 DirectExecutorSession（096-W4-6）：spawn → 关 stdin →
+        // 逐行解析推送 → 超时 kill → wait。飞书侧前置动作（task_id、开始回执、直推目标
+        // 解析）与逐行语义（EventPipeline 有状态解析 + 私聊直推分支）留在本通路闭包里。
+        let timeout_secs = read_execution_timeout_secs(config);
+        // task_id 提前生成：逐行事件和最终返回值共用同一个 id
         let task_id = format!("executor-{}-{}", executor_type, uuid::Uuid::new_v4());
-        // spawn 成功立即回执"开始处理"，让飞书侧知道请求已被接收并在跑
+        // spawn 前发"开始处理"回执（原实现 spawn 成功后才发；session 把 spawn 失败也收进
+        // 一次调用，回执提前到调用前——spawn 失败分支紧随其后发错误提示，用户不会误解为
+        // "已在处理"，时序差异仅在失败场景多收一条开始提示）
         send_msg(executor_start_message(executor_type, message));
-        // take() 并 drop 关闭 stdin，避免 CLI 进程挂起等待 EOF。不写 stdin payload：
-        // debounce 流式路径不是 worktree 场景，pi 的 "y" 应答只在切 worktree 目录时才有意义。
-        if child.stdin.take().is_some() {
-            tracing::debug!("[debounce] stdin 已关闭");
-        }
         let direct_output_info =
             resolve_direct_output(db, bot_id, receive_id.clone(), receive_id_type).await;
-        // 并发读 stdout：复用 log_capture 的 pipeline 解析，产生与 todo 执行同格式的事件，
-        // FeishuPushService 按 push_level 推送（"all" 时推送过程事件到飞书）
-        let stream_task = tokio::spawn({
-            let tx = tx.clone();
-            let executor = executor.clone();
-            let tid = task_id.clone();
-            async move {
-                stream_executor_stdout(
-                    stdout_handle,
+        // pipeline 在闭包外创建：闭包逐行借用它做有状态解析，产生与 todo 执行同格式的事件
+        let mut pipeline = log_capture::create_pipeline_for_executor(executor.as_ref())
+            .unwrap_or_else(|| EventPipeline::new(executor.executor_type().as_str()));
+        let mut logs: Vec<ParsedLogEntry> = Vec::new();
+        let outcome = DirectExecutorSession::spawn_and_stream(
+            SessionSpawnConfig {
+                executor: executor.clone(),
+                message: message.to_string(),
+                cwd: PathBuf::from(&workspace_path),
+                session_id: session_id.clone(),
+                timeout_secs,
+                // tracing 关联用 task_id：session 的 spawn/finish/timeout 日志能对回本通路
+                log_tag: task_id.clone(),
+            },
+            |line: &str| {
+                // 逐行语义：pipeline 解析 + Output/DirectStreamMessage 推送 + logs 累积
+                // （私聊直推 vs 标准广播的分支收敛在 process_executor_stdout_line 内）
+                process_executor_stdout_line(
+                    line,
+                    &mut pipeline,
                     &executor,
-                    &tx,
-                    &tid,
+                    tx,
+                    &task_id,
                     workspace_id,
-                    direct_output_info,
-                )
-                .await
-            }
-        });
+                    direct_output_info.as_ref(),
+                    &mut logs,
+                );
+            },
+        )
+        .await
+        // typed error → 本通路原有飞书提示文案（helper 内各分支自行 send_msg 后返回 None）
+        .map_err(|e| session_error_to_feishu(e, executor_type, &send_msg))?;
 
-        // ⑥ 带超时地等子进程退出（超时则 kill 回收，避免孤儿进程）
-        let status = await_executor_exit(child, config, executor_type, &send_msg).await?;
-
-        // ⑦ join 流式读取 + 读 stderr + 提取最终结果
-        let output = collect_executor_output(stream_task, stderr_handle, executor_type).await;
+        // ⑦' pipeline 收尾：flush SessionEnd 等残余事件（原 stream 任务内的后置步骤）
+        finalize_pipeline_by_path(
+            &mut pipeline,
+            tx,
+            &task_id,
+            workspace_id,
+            direct_output_info.as_ref(),
+            &mut logs,
+        );
+        // 从日志提取最终结果（与 todo 执行路径一致）
+        let result_text = crate::executor_service::completion::get_final_result_from_logs(&logs);
+        // stdout/stderr 预览：按 char 截 2000，避免按字节切片切断多字节中文
+        let stdout_preview: String = outcome.raw_stdout.chars().take(2000).collect();
+        tracing::info!("[debounce] executor {} stdout:\n{}", executor_type, stdout_preview);
+        if !outcome.raw_stderr.is_empty() {
+            let stderr_preview: String = outcome.raw_stderr.chars().take(2000).collect();
+            tracing::info!("[debounce] executor {} stderr:\n{}", executor_type, stderr_preview);
+        }
 
         // 构建结束消息：当前仅记日志——最后一条 assistant 消息已是结论，发飞书会重复。
         // 按 char 截 200 预览，避免按字节切片切断多字节中文。
         let content = build_executor_end_content(
             executor_type,
-            &status,
-            output.result_text,
-            &output.stream.raw_stdout,
-            &output.stderr,
+            outcome.success,
+            outcome.exit_code,
+            result_text,
+            &outcome.raw_stdout,
+            &outcome.raw_stderr,
         );
         tracing::info!(
             "[debounce] executor {} result_text={:?}",
@@ -1664,15 +1509,8 @@ impl MessageDebounce {
         );
 
         // ⑧ 成功时持久化 session（best-effort，失败只 warn）
-        if status.success() {
-            persist_executor_session(
-                db,
-                &executor,
-                &output.stream.logs,
-                workspace_id,
-                executor_type,
-            )
-            .await;
+        if outcome.success {
+            persist_executor_session(db, &executor, &logs, workspace_id, executor_type).await;
         }
 
         Ok(crate::executor_service::ExecutionResult {
@@ -1881,50 +1719,27 @@ mod executor_feedback_tests {
         assert!(out.contains("hi"), "stdout should contain hi, got: {}", out);
     }
 
-    /// `0` 必须解析成 `None`：`tokio::time::timeout` 吃 0 秒会立刻 Elapsed，
-    /// 0 走 None 分支才能正确表达「不限制」语义。
-    #[test]
-    fn test_direct_executor_timeout_zero_is_none() {
-        assert!(direct_executor_timeout(0).is_none(), "0 must map to None (no timeout)");
-    }
-
-    /// 正值必须解析成 `Some(Duration)`，且秒数原样透传。
-    #[test]
-    fn test_direct_executor_timeout_positive_is_some() {
-        let d = direct_executor_timeout(3600).expect("positive secs must map to Some");
-        assert_eq!(d.as_secs(), 3600);
-    }
 
     /// 成功时有解析结果：统一返回简洁结束标志，result_text 已通过过程消息实时推送。
     #[test]
     fn test_build_executor_end_content_success_with_result_text() {
-        let status = std::process::Command::new("sh")
-            .args(["-c", "true"])
-            .status()
-            .expect("spawn sh true");
-        let content = build_executor_end_content("pi", &status, Some("最终答案".to_string()), "ignored stdout", "");
+        // 096-W4-6：status 改为 success + exit_code 标量，测试不再需要真起 sh 进程
+        let content =
+            build_executor_end_content("pi", true, Some(0), Some("最终答案".to_string()), "ignored stdout", "");
         assert_eq!(content, "✅ pi 处理完成");
     }
 
     /// 退出 0 + 有原始 stdout：统一返回简洁结束标志，stdout 已通过过程消息实时推送。
     #[test]
     fn test_build_executor_end_content_success_returns_marker() {
-        let status = std::process::Command::new("sh")
-            .args(["-c", "true"])
-            .status()
-            .expect("spawn sh true");
-        let content = build_executor_end_content("pi", &status, None, "hello world", "");
+        let content = build_executor_end_content("pi", true, Some(0), None, "hello world", "");
         assert_eq!(content, "✅ pi 处理完成");
     }
 
     /// 退出 0 + stdout 为空：统一返回简洁结束标志，与有输出时保持一致。
     #[test]
     fn test_build_executor_end_content_success_empty_returns_marker() {
-        let status = std::process::Command::new("sh")
-            .args(["-c", "true"])
-            .status()
-            .expect("spawn sh true");
-        let content = build_executor_end_content("pi", &status, None, "   \n  ", "");
+        let content = build_executor_end_content("pi", true, Some(0), None, "   \n  ", "");
         assert_eq!(content, "✅ pi 处理完成");
     }
 
@@ -1935,12 +1750,8 @@ mod executor_feedback_tests {
     fn test_build_executor_end_content_nonzero_chinese_no_panic() {
         // 1600 个全中文字符，确保命中截断分支
         let chinese = "执行出错".repeat(400);
-        let status = std::process::Command::new("sh")
-            .args(["-c", "exit 1"])
-            .status()
-            .expect("spawn sh exit 1");
         // 关键断言：这一行不 panic 即说明按 char 截断生效
-        let content = build_executor_end_content("pi", &status, None, "", &chinese);
+        let content = build_executor_end_content("pi", false, Some(1), None, "", &chinese);
         assert!(
             content.starts_with("❌ pi 执行失败：退出码 Some(1)"),
             "should start with error prefix, got: {}",

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -5,6 +5,8 @@ pub mod blackboard;
 pub mod blackboard_debouncer;
 // 黑板防抖 flush 监听与调度（096-W3-PR1 从 executor_service::completion 整族搬入）
 pub mod blackboard_flush;
+// 096-W4-6：飞书默认响应与 wiki chat 两通路共用的 spawn+流读+超时骨架（DirectExecutorSession）
+pub mod executor_session;
 pub mod feishu_api_client;
 pub mod feishu_card;
 pub mod feishu_card_actions;

--- a/docs/design/101-096-W4剩余项实施设计.md
+++ b/docs/design/101-096-W4剩余项实施设计.md
@@ -178,7 +178,9 @@ pub(crate) enum SessionError {
 
 ### 风险与回退
 
-**中**（探查后由「中-高」下调：高风险的主链路 C 已移出 scope，且 A 的飞书通路无自动化端到端测试，靠既有单测 + 行为不变铁律护航）。三处已知的行为微变，PR 如实声明：① A 的 stderr 从「退出后读」改为「select! 内联读」——顺带消除 stderr 管道写满 64KB 时子进程阻塞的潜在死锁；② A 的 stdout 读错误从「静默结束循环」改为「SessionError 上抛」；③ A 的「开始处理」回执从 spawn 成功后提前到 spawn 前——仅失败场景多收一条开始提示（紧随错误提示，不产生误导）。B/A 各一 commit，可分别 revert。
+**中**（探查后由「中-高」下调：高风险的主链路 C 已移出 scope，且 A 的飞书通路无自动化端到端测试，靠既有单测 + 行为不变铁律护航）。四处已知的行为微变，PR 如实声明：① A 的 stderr 从「退出后读」改为「select! 内联读」——顺带消除 stderr 管道写满 64KB 时子进程阻塞的潜在死锁；② A 的 stdout 读错误从「静默结束循环」改为「SessionError 上抛」；③ A 的「开始处理」回执从 spawn 成功后提前到 spawn 前——仅失败场景多收一条开始提示（紧随错误提示，不产生误导）；④ B 的 `timeout_secs=0` 从「立即超时」改为「不限时」——与 A/C 语义对齐，且 `resolve_wiki_timeout_secs` 钳制 >0 使该值现状不可达。
+
+**评审修复（首轮 /review 后）**：两处未声明的健壮性回归在 session 骨架内修复——① A 原「逐行解析跑在独立 tokio::spawn 任务、panic 被 JoinHandle 降级」的隔离语义，经 `catch_unwind` 恢复（且更强：panic 前已解析的 logs 保留、raw 收集不受影响，panic 后禁用回调继续读流，有回归单测）；② 超时判定以「进程是否退出」为准（`try_wait` 甄别），进程已退出只是管道排空时不误判 Timeout（A 原实现超时只包 `child.wait()`，无排空误判）。B/A 各一 commit，可分别 revert。
 
 ---
 

--- a/docs/design/101-096-W4剩余项实施设计.md
+++ b/docs/design/101-096-W4剩余项实施设计.md
@@ -117,45 +117,58 @@ tsc 零错误；vitest 全过；Playwright 冒烟（工艺编辑器打开/编辑
 
 **霰弹实证**：执行器行为变更（如新增 env 注入、超时策略调整、session 提取协议变化）要同步改 A/B/C 三处。例：W1-PR1 的 extract_stderr 差异、W1-PR3 的 session 提取，均涉及多处平行代码的同步修改。
 
-### 收敛设计
+### 收敛设计（探查后修正，基线 main `71830ca6`）
+
+**探查结论——doc 初稿「三处平行」前提修正为「A+B 两处真平行，C 架构独立」**：
+
+- A（`message_debounce`）已拆成 4 个本地 helper（spawn_executor_child / wait_child_with_timeout / stream_executor_stdout / collect_executor_output），流式解析用 **EventPipeline**（log_capture，带状态）+ DirectOutputInfo 私聊直推分支；普通 `tokio::process::Child`；超时经全局配置 `execution_timeout_secs`。
+- B（`blackboard`）单函数 154 行内联 select!，流式是裸 `executor.parse_output_line` 逐行推 `WikiChatOutput`；普通 `Child`；超时来自 per-workspace `wiki_timeout_secs` 参数。
+- C（`executor_service/spawn_lifecycle.rs`，818 行）**不是 A/B 的平行副本**：进程组（`AsyncGroupChild`）+ LogFlusher 批量落库管线 + cancel（mpsc）+ worktree 清理 + 3-way dispatch，是 #660/093-B3 重构后的独立生命周期模块，不共享 A/B 的逐行 select! 骨架。强行收敛要么阉割 C 语义（回归），要么把 session 撑成 god 对象——**命中本节预留的逃生口（「C 若耦合过深可保留——在 PR 中如实声明」），C 保持不动**。
+
+**A/B 的真重复骨架**（~286 行）：build command（`command_args_with_session` + piped stdio + current_dir）→ spawn 普通 child → take+drop 关 stdin（两者均非 worktree，不写 payload）→ 逐行读 stdout/stderr → 超时 kill → 返回 logs/raw 文本/success。**差异点**：A 的 EventPipeline 解析 + 私聊直推 vs B 的裸解析 + WikiChatOutput——逐行语义不同，故 session 只收口「进程生命周期 + I/O 骨架」，**逐行解析经 `on_line` 闭包交还调用方**（session 不持有通路知识，SRP）。
 
 **新建 `services/executor_session.rs`：`DirectExecutorSession`**
 
 ```text
-pub(crate) struct DirectExecutorSession {
-    /// 产物流：日志条目 / 最终输出 / session_id / 是否超时
-}
-
-impl DirectExecutorSession {
-    /// spawn + 流式读 + 超时 + session 提取 的统一骨架
-    pub(crate) async fn spawn_and_stream(config: SessionSpawnConfig) -> Result<SessionOutcome>
-}
-
 pub(crate) struct SessionSpawnConfig {
     executor: Arc<dyn CodeExecutor>,
     message: String,
     cwd: PathBuf,
-    task_id: String,
-    workspace_id: i64,
-    tx: broadcast::Sender<ExecEvent>,
     session_id: Option<String>,
     timeout_secs: u64,
-    /// 通路差异点（飞书/wiki chat/主链路）经少量参数化承接
+}
+
+impl DirectExecutorSession {
+    /// spawn + 逐行读（on_line 回调交还调用方）+ 超时 kill + wait 的统一骨架
+    pub(crate) async fn spawn_and_stream<F: FnMut(&str)>(
+        config: SessionSpawnConfig, on_line: F,
+    ) -> Result<SessionOutcome, SessionError>
+}
+
+pub(crate) struct SessionOutcome { raw_stdout: String, raw_stderr: String, success: bool }
+
+pub(crate) enum SessionError {
+    Spawn(std::io::Error),
+    Timeout { secs: u64 },
+    WaitFailed(String),
+    StdoutReadFailed { source: std::io::Error, stderr: String },
 }
 ```
 
+（`tx`/`task_id`/`workspace_id`/logs 不进 session：它们是各通路事件语义的原料，由调用方闭包捕获；logs 由调用方在闭包里自行累积。typed error 让 A/B 各自映射原有错误文案，不共用字符串。）
+
 **迁移顺序（风险升序）**：
-1. B（blackboard wiki chat）先行迁移验证——通路最简单（单函数 154 行）；
-2. A（message_debounce 飞书默认响应）跟进——12 参函数体塌缩为 SessionSpawnConfig 组装 + 一行调用；
-3. C（主执行链路 spawn_lifecycle 内联段）最后——与主链路的事务/事件管线耦合最深，单独 commit。
+1. B（blackboard wiki chat）先行迁移验证——通路最简单（单函数 154 行 → 组装 config + 一次调用 + outcome 适配 tuple）；
+2. A（message_debounce 飞书默认响应）跟进——编排体保留 send_msg/persist_executor_session 前后置，`on_line` 闭包承接 EventPipeline 解析 + 私聊直推；删除 4 个本地 helper（须先核查 `wait_child_with_timeout` 等是否另有调用方）；
+3. C（主执行链路 spawn_lifecycle）**不迁移**（探查结论：架构独立非平行副本，命中逃生口）。
 
 ### 步骤
 
-1. 定义 `SessionSpawnConfig` + `SessionOutcome` + `DirectExecutorSession::spawn_and_stream`（以 B 的实现为模板——它最完整）；
+1. 定义 `SessionSpawnConfig` + `SessionOutcome` + `SessionError` + `DirectExecutorSession::spawn_and_stream`（以 B 的 select! 为模板——最自洽），带单测（spawn 成功/失败、超时 kill、stderr 捕获、on_line 逐行回调）；
 2. B 迁移 + wiki chat 通路测试；
-3. A 迁移 + 飞书通路测试；
-4. C 内联段收敛（若评估后耦合过深可保留——在 PR 中如实声明）；
-5. 三通路回归：对应既有测试全过 + 真实通路冒烟（wiki chat 发一条消息、飞书默认响应一条——飞书无凭证环境下以 wiki chat 冒烟为下限）。
+3. A 迁移 + 飞书通路测试（helper 删除前核查另有调用方）；
+4. C 不动（探查结论命中逃生口，PR 如实声明）；
+5. 回归：既有测试全过 + wiki chat 真实通路冒烟（飞书无凭证环境下以 wiki chat 冒烟为下限）。
 
 ### 验证
 
@@ -163,7 +176,7 @@ pub(crate) struct SessionSpawnConfig {
 
 ### 风险与回退
 
-**中-高**（方案原评）：执行器子进程生命周期管理是核心路径，超时/取消/session 续接任何一环偏差都会影响在途任务。分通路独立 commit（B/A 各一、C 一），可分别 revert；C 若耦合过深允许保留现状并在 PR 声明（部分达成）。
+**中**（探查后由「中-高」下调：高风险的主链路 C 已移出 scope，且 A 的飞书通路无自动化端到端测试，靠既有单测 + 行为不变铁律护航）。两处已知的行为微变，PR 如实声明：① A 的 stderr 从「退出后读」改为「select! 内联读」——顺带消除 stderr 管道写满 64KB 时子进程阻塞的潜在死锁；② A 的 stdout 读错误从「静默结束循环」改为「SessionError 上抛」。B/A 各一 commit，可分别 revert。
 
 ---
 

--- a/docs/design/101-096-W4剩余项实施设计.md
+++ b/docs/design/101-096-W4剩余项实施设计.md
@@ -136,6 +136,7 @@ pub(crate) struct SessionSpawnConfig {
     cwd: PathBuf,
     session_id: Option<String>,
     timeout_secs: u64,
+    log_tag: String,          // 实现新增：仅 tracing 关联标识（各通路传自己的 task_id）
 }
 
 impl DirectExecutorSession {
@@ -145,17 +146,18 @@ impl DirectExecutorSession {
     ) -> Result<SessionOutcome, SessionError>
 }
 
-pub(crate) struct SessionOutcome { raw_stdout: String, raw_stderr: String, success: bool }
+// 实现比初稿多一个 exit_code：A 通路非零退出的用户文案要报「退出码 N」
+pub(crate) struct SessionOutcome { raw_stdout: String, raw_stderr: String, success: bool, exit_code: Option<i32> }
 
 pub(crate) enum SessionError {
     Spawn(std::io::Error),
-    Timeout { secs: u64 },
+    Timeout { secs: u64, stderr: String },   // stderr 供 B 的超时文案拼接（实现补充）
     WaitFailed(String),
     StdoutReadFailed { source: std::io::Error, stderr: String },
 }
 ```
 
-（`tx`/`task_id`/`workspace_id`/logs 不进 session：它们是各通路事件语义的原料，由调用方闭包捕获；logs 由调用方在闭包里自行累积。typed error 让 A/B 各自映射原有错误文案，不共用字符串。）
+（`tx`/`task_id`/`workspace_id`/logs 不进 session：它们是各通路事件语义的原料，由调用方闭包捕获；logs 由调用方在闭包里自行累积；`log_tag` 是唯一例外——纯 tracing 标识不参与行为。typed error 让 A/B 各自映射原有错误文案，不共用字符串。）
 
 **迁移顺序（风险升序）**：
 1. B（blackboard wiki chat）先行迁移验证——通路最简单（单函数 154 行 → 组装 config + 一次调用 + outcome 适配 tuple）；
@@ -176,7 +178,7 @@ pub(crate) enum SessionError {
 
 ### 风险与回退
 
-**中**（探查后由「中-高」下调：高风险的主链路 C 已移出 scope，且 A 的飞书通路无自动化端到端测试，靠既有单测 + 行为不变铁律护航）。两处已知的行为微变，PR 如实声明：① A 的 stderr 从「退出后读」改为「select! 内联读」——顺带消除 stderr 管道写满 64KB 时子进程阻塞的潜在死锁；② A 的 stdout 读错误从「静默结束循环」改为「SessionError 上抛」。B/A 各一 commit，可分别 revert。
+**中**（探查后由「中-高」下调：高风险的主链路 C 已移出 scope，且 A 的飞书通路无自动化端到端测试，靠既有单测 + 行为不变铁律护航）。三处已知的行为微变，PR 如实声明：① A 的 stderr 从「退出后读」改为「select! 内联读」——顺带消除 stderr 管道写满 64KB 时子进程阻塞的潜在死锁；② A 的 stdout 读错误从「静默结束循环」改为「SessionError 上抛」；③ A 的「开始处理」回执从 spawn 成功后提前到 spawn 前——仅失败场景多收一条开始提示（紧随错误提示，不产生误导）。B/A 各一 commit，可分别 revert。
 
 ---
 

--- a/docs/requirements/101-直连执行session收敛-实现总结.md
+++ b/docs/requirements/101-直连执行session收敛-实现总结.md
@@ -63,6 +63,13 @@ B（wiki chat）两处真平行（~286 行同构骨架）收敛进新建的
 - **补测**：`test_session_error_to_feishu_四分支错误文案映射` 锁定错误文案逐字一致
   承诺；`test_spawn_and_stream_双流分流捕获不串流` 改名消除歧义。
 
+**CodeRabbit 评审修复（第二轮）**：① `WaitFailed`/`StdoutReadFailed` 两条错误路径
+返回前先 kill 回收子进程（child 未开 kill_on_drop，直接 drop 会留孤儿进程）；② stderr
+EOF/读失败后禁用对应 select! 分支——`next_line()` 在 EOF 后持续立即返回 `Ok(None)`，
+不禁用会在 stdout 未结束时空转占满 CPU（B 原实现即有此 bug，随骨架收敛一并修掉）；
+③ 非零退出文案的退出码不再以 Rust 调试格式（`Some(1)`）示人，被信号终止时给
+「未知（进程被信号终止）」可读文案，测试断言同步更新。
+
 ## 验证
 
 - `cargo clippy --all-targets -- -D warnings` 零告警；`cargo test` 全量 28 套件

--- a/docs/requirements/101-直连执行session收敛-实现总结.md
+++ b/docs/requirements/101-直连执行session收敛-实现总结.md
@@ -29,7 +29,7 @@ B（wiki chat）两处真平行（~286 行同构骨架）收敛进新建的
   worktree 的独立生命周期模块（#660/093-B3 重构产物），非 A/B 的平行副本；强行收敛
   要么阉割 C 语义要么把 session 撑成 god 对象。PR 如实声明。
 
-## 行为微变（三处，均在设计文档声明）
+## 行为微变（四处，均在设计文档声明）
 
 1. A 的 stderr 从「退出后 read_to_end」改为「select! 内联读」——顺带消除 stderr
    管道写满 64KB 时子进程阻塞的潜在死锁。
@@ -37,12 +37,37 @@ B（wiki chat）两处真平行（~286 行同构骨架）收敛进新建的
    （用户可见的「读取进程输出失败」提示）。
 3. A 的「开始处理」回执从 spawn 成功后提前到 spawn 前——仅失败场景多收一条开始
    提示（紧随错误提示，不产生误导）。
+4. B 的 `timeout_secs=0` 从「立即超时」改为「不限时」（与 A/C 语义对齐；
+   `resolve_wiki_timeout_secs` 钳制 >0 使该值现状不可达）。
+
+## 删除 helper 的调用方核查（设计步骤 3 的留痕）
+
+删除前 grep 全仓核查：`spawn_executor_child` / `await_executor_exit` /
+`collect_executor_output` / `wait_child_with_timeout` / `stream_executor_stdout` /
+`direct_executor_timeout` 六个函数均只被 A 链（编排体或彼此）调用，无第三方调用方；
+`run_executor_with_timeout` 是独立的 legacy 测试保留代码（自有测试），不属 A 链。
+
+## 评审修复（首轮 /review 后补齐）
+
+- **A 的 panic 隔离恢复**：原实现逐行解析在独立 tokio::spawn 任务里、panic 被降级；
+  收敛后闭包内联会击穿 debounce 任务——session 骨架用 `catch_unwind` 恢复隔离
+  （且更强：panic 前已解析 logs 保留、raw 收集不受影响、panic 后禁用回调继续读流），
+  新增回归单测 `test_spawn_and_stream_回调panic不击穿骨架`。
+- **超时判定以进程退出为准**：计时器到点先 `try_wait` 甄别「已退出、管道仍在排空」，
+  排空场景切入 drain 模式正常返回，不再误判 Timeout（对齐 A 原实现超时只包
+  `child.wait()` 的覆盖范围）。
+- **生产代码禁 expect**：`read_execution_timeout_secs` 的 RwLock 中毒改为
+  `unwrap_or_else(|p| p.into_inner())` 降级读取（禁止清单 #1）。
+- **死代码下沉测试**：`ExecutorRunError` + `run_executor_with_timeout` 整组搬进
+  `#[cfg(test)]`，删除新增的 `#[allow(dead_code)]`（禁止清单 #13）。
+- **补测**：`test_session_error_to_feishu_四分支错误文案映射` 锁定错误文案逐字一致
+  承诺；`test_spawn_and_stream_双流分流捕获不串流` 改名消除歧义。
 
 ## 验证
 
 - `cargo clippy --all-targets -- -D warnings` 零告警；`cargo test` 全量 28 套件
-  通过（含 executor_session 新增 7 个单测：成功/启动失败/超时 kill 携带 stderr/
-  stderr 不串流/不限时/非零退出/exit_code 透传）。
+  通过（含 executor_session 新增 7 个单测：成功路径/启动失败/超时 kill 携带 stderr/
+  双流分流/不限时/非零退出/回调 panic 隔离）。
 - wiki chat 真实通路冒烟（dev 实例 ws1，claude 执行器）：
   `POST /api/v1/workspaces/1/wiki/chat` → `{"content":"收到","success":true,"duration_secs":6}`；
   `backend.dev.log` 确认 `[session] spawning` / `[session] finished: exit_code=Some(0)`

--- a/docs/requirements/101-直连执行session收敛-实现总结.md
+++ b/docs/requirements/101-直连执行session收敛-实现总结.md
@@ -1,0 +1,50 @@
+# 101 — 直连执行 session 收敛（096-W4-6）实现总结
+
+> 对应设计：`docs/design/101-096-W4剩余项实施设计.md` W4-6 段。
+> 分支：`refactor/096-w4-6-direct-executor-session`。
+
+## 做了什么
+
+三处「spawn 子进程 + 流式读 stdout/stderr + 超时控制」实现中，A（飞书默认响应）与
+B（wiki chat）两处真平行（~286 行同构骨架）收敛进新建的
+`backend/src/services/executor_session.rs::DirectExecutorSession`：
+
+| 通 路 | 迁移前 | 迁移后 |
+|---|---|---|
+| B `blackboard::spawn_executor_for_chat_streaming` | 单函数 154 行内联 select! | 组装 config + on_line 闭包 + 错误映射（~70 行） |
+| A `message_debounce::handle_default_response_executor` | spawn/await/collect/stream 等 6 个本地 helper + StdoutStreamResult/ExecutorOutput 中间结构 | 一次 `spawn_and_stream` 调用；on_line 闭包承接 EventPipeline 解析 + 私聊直推 |
+| C `executor_service/spawn_lifecycle` | — | **不迁移**（见下） |
+
+净变化：B 迁移 commit +447/−172；A 迁移 commit +147/−329。
+
+## 关键设计
+
+- **session 只管进程生命周期与 I/O**：build 命令（`command_args_with_session` + piped
+  stdio + current_dir）→ spawn → 关 stdin → select! 逐行读 → 超时 kill → wait。
+  逐行「语义」（A 的 EventPipeline + 直推 vs B 的裸 parse_output_line + WikiChatOutput）
+  经 `on_line: FnMut(&str)` 闭包交还调用方——session 不持有通路知识（SRP）。
+- **typed error**（`SessionError`）：A/B 各自映射回原有错误文案，不共用字符串。
+- **`timeout_secs == 0` = 不限时**：session 内用极大 duration 表达，与 A/C 既有语义一致。
+- **C 保留（doc 101 逃生口）**：spawn_lifecycle 是进程组 + LogFlusher + cancel +
+  worktree 的独立生命周期模块（#660/093-B3 重构产物），非 A/B 的平行副本；强行收敛
+  要么阉割 C 语义要么把 session 撑成 god 对象。PR 如实声明。
+
+## 行为微变（三处，均在设计文档声明）
+
+1. A 的 stderr 从「退出后 read_to_end」改为「select! 内联读」——顺带消除 stderr
+   管道写满 64KB 时子进程阻塞的潜在死锁。
+2. A 的 stdout 读错误从「静默结束循环」改为上抛 `SessionError::StdoutReadFailed`
+   （用户可见的「读取进程输出失败」提示）。
+3. A 的「开始处理」回执从 spawn 成功后提前到 spawn 前——仅失败场景多收一条开始
+   提示（紧随错误提示，不产生误导）。
+
+## 验证
+
+- `cargo clippy --all-targets -- -D warnings` 零告警；`cargo test` 全量 28 套件
+  通过（含 executor_session 新增 7 个单测：成功/启动失败/超时 kill 携带 stderr/
+  stderr 不串流/不限时/非零退出/exit_code 透传）。
+- wiki chat 真实通路冒烟（dev 实例 ws1，claude 执行器）：
+  `POST /api/v1/workspaces/1/wiki/chat` → `{"content":"收到","success":true,"duration_secs":6}`；
+  `backend.dev.log` 确认 `[session] spawning` / `[session] finished: exit_code=Some(0)`
+  两条骨架 tracing 落印。
+- 飞书通路无凭证环境，靠既有单测（executor_feedback_tests 等）+ 错误文案逐字保留护航。


### PR DESCRIPTION
## 对应设计

docs/design/101-096-W4剩余项实施设计.md W4-6 段（探查后修正版）。doc 101 最后一项。

## 探查结论（前提修正）

doc 初稿「三处平行 spawn」实为 **A+B 两处真平行（~286 行同构骨架），C 架构独立**：

- A `message_debounce::handle_default_response_executor`（飞书默认响应）
- B `blackboard::spawn_executor_for_chat_streaming`（wiki chat）
- C `executor_service/spawn_lifecycle`（主执行链路）是进程组 + LogFlusher + cancel + worktree 的独立生命周期模块（#660/093-B3 重构产物），**非 A/B 平行副本——命中 doc 101 预留逃生口，C 不迁移**。

## 改动

| commit | 内容 |
|---|---|
| 16545016 | 新建 `services/executor_session.rs`（`DirectExecutorSession`）+ 迁移 B（154 行 select! → config + on_line 闭包 + 错误映射，文案逐字保留） |
| 9d6c2494 | 迁移 A：编排体 ④⑤⑥⑦ 阶段收敛为一次 `spawn_and_stream`；删除 6 个本地 helper 与 StdoutStreamResult/ExecutorOutput；SessionOutcome 增加 exit_code |
| 893f877e | docs 同步（实现偏差标注 + 实现总结） |
| b45f8f1b | **评审修复**（两轴五项，见下） |

净变化约 +850/−600。session 只管进程生命周期与 I/O；逐行语义经 `on_line` 闭包交还调用方（A 的 EventPipeline+私聊直推 vs B 的裸解析+WikiChatOutput）；typed error 让两通路各自映射原有文案。

## 评审修复（b45f8f1b，/review 两轴结论全处理）

**Spec 轴**：
- A 的 panic 隔离恢复：原实现逐行解析在独立 tokio::spawn 任务里、panic 被降级；收敛后闭包内联会击穿 debounce 任务——session 骨架用 `catch_unwind` 恢复隔离（更强：partial logs 保留、panic 后禁用回调继续读流），新增回归单测
- 超时判定以「进程是否退出」为准：计时器到点先 `try_wait` 甄别「已退出、管道仍在排空」，排空场景切入 drain 模式正常返回，不再误判 Timeout（对齐 A 原实现超时只包 `child.wait()` 的覆盖范围）
- B 的 0 秒语义变化补入声明（`resolve_wiki_timeout_secs` 钳制 >0 使其不可达）；helper 删除前调用方核查结论补入文档留痕；单测计数勘误

**Standards 轴**：
- `read_execution_timeout_secs` 生产 `.expect()` 改为 RwLock 中毒恢复式降级读取（禁止清单 #1）
- `ExecutorRunError` + `run_executor_with_timeout` 整组搬进 `#[cfg(test)]`，删除新增的 `#[allow(dead_code)]`（禁止清单 #13）
- 补 `test_session_error_to_feishu_四分支错误文案映射`（锁定文案逐字一致承诺）；stderr 分流测试改名消歧义

## 行为微变（四处，设计文档已声明）

1. A 的 stderr 从「退出后读」改为「select! 内联读」——消除 stderr 管道 64KB 写满死锁隐患
2. A 的 stdout 读错误从「静默结束循环」上抛为 `StdoutReadFailed`（用户可见）
3. A 的「开始处理」回执提前到 spawn 前——仅失败场景多收一条开始提示
4. B 的 `timeout_secs=0` 从「立即超时」改为「不限时」（现状不可达：resolver 钳制 >0）

## 验证

- `cargo clippy --all-targets -- -D warnings` 零告警
- `cargo test` 全量 28 套件通过（lib 1708，含 executor_session 7 个单测：成功路径/启动失败/超时 kill 携带 stderr/双流分流/不限时/非零退出/回调 panic 隔离）
- wiki chat 真实通路冒烟（dev 实例 ws1 + claude）：`POST /api/v1/workspaces/1/wiki/chat` → `"content":"收到","success":true,"duration_secs":6`；backend.dev.log 确认 `[session] spawning` / `[session] finished: exit_code=Some(0)` 骨架 tracing 落印
- 飞书通路无凭证环境，靠既有单测 + 错误文案逐字保留护航（新增文案映射单测锁定）
