### PR TITLE
docs(096): 补录代码质量全景扫描报告与四波分步重构方案

### DIFF
--- a/docs/design/096-代码质量重构分步方案.md
+++ b/docs/design/096-代码质量重构分步方案.md
@@ -1,0 +1,187 @@
+# 096-代码质量重构分步方案
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (zhanlu) | 2026-08-11 | 初始版本 |
+
+> 依据：`docs/代码质量全景扫描报告-20260811.md`（4 路深扫、行号级实据）。
+> 本方案把扫描发现落为可执行的四波实施计划：每波含目标、手法、步骤、验证、风险与回退。
+> 执行纪律沿用项目规范：分支隔离、先文档后代码、clippy 零告警、全量测试护航、PR 评审。
+
+---
+
+## 波次总览
+
+| 波次 | 主题 | 预估净减/收益 | 风险 |
+|------|------|---------------|------|
+| W1 | 纯删减收口（4 个独立 PR） | 约 -400 行死代码/重复代码 | 极低 |
+| W2 | 局部重构收口（3 个独立 PR） | impls 层 -40% 体量；索引恢复可用 | 低 |
+| W3 | God 模块拆分（4 个独立 PR，风险升序） | 4 个 2000+ 行文件降至 300-500 行级 | 中 |
+| W4 | 结构债与前端 God 组件（专项窗口期） | todo 加字段从 10+ 处降为 2-3 处 | 中-高 |
+
+每波内 PR 互不依赖，可并行；跨波次按序推进（W2 依赖 W1 的清理面，W3 依赖 W2 的收口面）。
+
+---
+
+## W1 纯删减收口（4 个 PR）
+
+### W1-PR1：删除 12 处 `extract_stderr` 多余 override
+
+- **实证**：`execution_events/extractor.rs:33-48` 默认实现 vs `impls/` 下 12 文件逐字相同
+  （claude_code/kimi/kilo/opencode/pi/hermes/zhanlu/mimo/mobilecoder/codebuddy/codewhale/default）；
+  仅 codex（统一 Info）与 atomcode（委托 extract）有真实差异，保留。
+- **手法**：Remove Dead Code
+- **步骤**：
+  1. 逐文件删除 12 处 override 函数体；
+  2. 保留 codex/atomcode 两处真实差异实现，并加注释说明「与默认不同」的原因；
+  3. 逐文件跑对应执行器提取器测试。
+- **验证**：`cargo test --lib execution_events::` 全过；clippy 零告警。
+- **风险**：极低（删除后与默认实现行为逐字一致）。
+- **回退**：单 PR revert。
+
+### W1-PR2：execution_events 死代码簇清理
+
+- **实证清单**（grep 全仓零生产调用）：
+  - `pipeline.rs:66-70 feed_batch`、`:188-190 latest_event`、`:206-208 to_db_logs`、`:221-236 filter_events/thinking_events/tool_call_events`；
+  - `extractor.rs:66-122 SimpleExtractor`（无构造点）、`reset()` 与 14 个 `executor_name()`（调用链悬空）；
+  - `metadata.rs:100-116 mark_success/mark_failed/set_exit_code`（只写不读）、`:129-159 summary()`；
+  - `impls/hermes.rs has_done`、`impls/pi.rs pending_tool_calls`（只写不读）；
+  - `pre_spawn.rs:266-270 SelectedExecutor.session_id_for_executor`（`#[allow(dead_code)]` 自认"留未来"，YAGNI 违反）。
+- **手法**：Remove Dead Code
+- **步骤**：逐项删除 → 编译器找齐引用 → 清理关联测试。
+- **验证**：全量 lib 测试无回归；clippy 无新增 dead_code 告警。
+- **风险**：低（版本控制可找回）。
+- **注意**：`executor_name()` 删除前先确认 profiles/generators.rs:114 的同名方法属另一 trait，不误伤。
+
+### W1-PR3：`extract_session_from_logs` 等跨文件重复收口
+
+- **实证**：`message_debounce.rs:796-808` ≡ `blackboard.rs:616-628`（连注释逐字同）；
+  `blackboard.rs:634 inject_wiki_expert_context` 自述"与 pre_spawn::inject_expert_context 一致，但独立实现"。
+- **手法**：Extract Function + Move Function 上移公共 helper（如 `executor_service::session_util`）。
+- **步骤**：抽公共函数 → 两处改调用 → 行为 diff 核对（两份现实现逐字比对归档）。
+- **验证**：两调用路径的既有测试全过。
+- **风险**：低（纯函数、仅 3 个调用点）。
+
+### W1-PR4：前端 `BackupPanel` 三域复制收口
+
+- **实证**：三组完全同构的备份状态 ×3（15 个 useState）+ 9 个 handler 逐字重复（~150 行）+ 下载套路 ×5。
+- **手法**：抽 `useBackupDomain({ getStatus, updateAuto, trigger, deleteFile })` hook + `downloadBlob` util。
+- **步骤**：
+  1. 新建 `frontend/src/components/settings/useBackupDomain.ts`；
+  2. 三域分别改为一行 hook 调用（props 形状不变，子组件零改动）；
+  3. 删除被替换的 state/handler。
+- **验证**：`npx tsc --noEmit` 零错误；vitest 全过；Playwright 备份面板冒烟（脚本入 frontend/tests/）。
+- **风险**：低（纯本文件重组）。
+
+---
+
+## W2 局部重构收口（3 个 PR）
+
+### W2-PR1：`REPLACE(REPLACE(...))` 时间过滤替换（14 处）
+
+- **实证**：`db/execution.rs:237`、`db/loop_.rs:890,1732`、`db/todo.rs:1936`、`db/dashboard.rs` 9 处；
+  替代函数 `utc_timestamp_minus_hours` 已存在（models/mod.rs:1368 注释自述旧写法使索引失效）。
+- **手法**：Substitute Algorithm——`started_at >= ?` 参数绑定。
+- **步骤**：
+  1. 先 Extract Function 收敛为 `recent_hours_filter(col, hours)` 单一口径；
+  2. 逐点替换 14 处；
+  3. 每处替换后跑对应 DAO 测试（时间过滤正确性用例：边界值 ±1 小时）。
+- **验证**：db 层测试全过；**附带验证查询计划**（`EXPLAIN QUERY PLAN` 确认 started_at 索引被命中）。
+- **风险**：低-中（时间格式契约——`utc_timestamp` 毫秒级 ISO 与存量数据比较，已有测试锁定格式）。
+- **回退**：单 PR revert。
+
+### W2-PR2：impls 层同构治理（泛型基类）
+
+- **实证**：`opencode.rs ≈ kilo.rs` 整文件 ~170 行逐字；`extract()` 入口骨架 ×12 文件；
+  `session_id 首现模式 ×15 处`；zhanlu/mimo/mobilecoder tool_use/step_finish 分支同构。
+- **手法**：Extract Superclass（泛型 `StepProtocolExtractor<E: StepProtocolEvent>`）+
+  Move Function（`ExecutionMetadata::claim_session`）+ Extract Function（`extract_tool_pair`/`extract_tokens_cost` 自由函数）。
+- **步骤**：
+  1. 先收 `claim_session`（15 处调用点塌缩，独立 commit）；
+  2. 抽泛型基类，kilo/opencode 先行迁移验证（两事件结构体本就同构）；
+  3. zhanlu/mimo/mobilecoder 以共享自由函数收敛分支差异；
+  4. 各执行器协议测试（真实 JSONL 样本）全程护航。
+- **验证**：`execution_events::` 全测试过；逐执行器 sample 行 diff 比对（治理前后事件输出一致）。
+- **风险**：中（协议解析是核心路径——必须逐执行器回归）。
+- **收益**：impls 层 -40% 体量；新增执行器从"复制 250 行"降为"实现 3 个差异点"。
+
+### W2-PR3：五元组参数对象化续集（B3 治理漏网区）
+
+- **实证**：`(db, executor_registry, tx, task_manager, config)` 五元组 ×7 函数
+  （completion.rs:907 maybe_run_auto_review、:612 spawn_flush_worker、:742 handle_flush_msg、:824 blackboard_flush_listener、auto_review.rs:66/156/372），均挂 `#[allow(too_many_arguments)]`。
+- **手法**：Introduce Parameter Object（`ExecutionDeps`，对齐 093-B3 既有范式）。
+- **步骤**：定义 `ExecutionDeps` → 逐函数迁移（每函数独立 commit）→ 删除对应 allow。
+- **验证**：clippy 无 too_many_arguments 残留（本区）；全量测试过。
+- **风险**：低（B3 已验证的手法复用）。
+
+---
+
+## W3 God 模块拆分（4 个 PR，按风险升序）
+
+### W3-PR1：completion.rs 黑板服务搬离（最易，纯搬运）
+
+- **实证**：`completion.rs:518-899` 整块黑板 ticker/worker/listener（~380 行）与"执行终态"无关；
+  pub 入口仅 `blackboard_flush_listener`。
+- **手法**：Move Function 整组迁 `services/blackboard_flush.rs`（与 `blackboard_debouncer` 邻居内聚）。
+- **步骤**：整段剪切 → 调整 use 路径 → 入口 re-export 兼容 → 编译器找齐。
+- **验证**：全量测试过；黑板防抖功能冒烟（dev 实例触发一次黑板写入观察 flush）。
+- **风险**：低（无逻辑改动）。
+
+### W3-PR2：session.rs 扫描器多态化完成
+
+- **实证**：2890 行仅 4 个真 handler；`SCANNERS` 注册表只转发，6 个 `scan_*` 函数体重复
+  "遍历目录→逐行解析→聚合→push" 模式；`session.rs:1206` 注释自承多态是空壳。
+- **手法**：Move Function 把 scan_X/get_X_detail 函数体搬进各 `impl SessionScanner`；
+  重复骨架 Extract Function 为 trait 提供的通用 helper。
+- **步骤**：逐执行器迁移（每源一个 commit：claude_code→codex→hermes→kimi→atomcode→pi）→ handler 只留参数解析。
+- **验证**：session 列表/详情/统计 API 响应 diff 比对（迁移前后一致）；handlers 测试全过。
+- **风险**：中（解析逻辑细碎，逐源回归）。
+- **收益**：session.rs 2890 → 约 300 行。
+
+### W3-PR3：loop_runner `run_inner_from` 拆分（496 行巨函数）
+
+- **实证**：`loop_runner.rs:632-1127`；12 个局部可变状态；新旧两分支（L953-975 vs L1043-1071）逐字重复。
+- **手法**：Extract Function 按 5 阶段拆（`load_run_context`/`recover_resume_state`/`execute_step_cycle`/`finalize_run`）+ Form Template Method 收敛新旧分支。
+- **步骤**：
+  1. 先把逐字重复的两分支收敛为单一路径（差异参数化）——独立验证；
+  2. 再按阶段拆函数，每拆一段跑 700+ 行既有测试（L1735-2460 是行为锚点）；
+  3. `LoopRunOutcome` 协议不变为硬约束。
+- **验证**：loop_runner 全测试过；dev 实例跑一个真实 loop 验证终态正确。
+- **风险**：中-高（核心调度逻辑）——必须小步多 commit，每步测试。
+
+### W3-PR4：FeishuListener 拆分（最重，最后做）
+
+- **实证**：2600 行 7 类职责；`feishu_push` 依赖 `send_card_raw/send_raw`（DIP 违反）；
+  `handle_new` 失败回复样板 ×7、`handle_stop` 嵌套 7 层。
+- **手法**：Extract Class ×3：`FeishuApiClient`（发送+凭证，供 push 与 listener 共用）→
+  `SlashCommandHandler` → `CardActionHandler`；Listener 只留连接管理与消息编排。
+- **步骤**：
+  1. 先拆 `FeishuApiClient`（最独立，push 立即可改依赖——DIP 修复点）；
+  2. `handle_new/handle_stop` 先用 Guard Clause + `reply_and_unreact` 卫语句收敛样板（独立 commit）；
+  3. 再拆命令/卡片两个 handler 类。
+- **验证**：feishu 相关测试全过；**真实飞书通路冒烟**（/new、/stop、/list、卡片按钮回调各一次）。
+- **风险**：高（飞书是生产通路）——安排在生产低峰窗口，冒烟清单逐项过。
+
+---
+
+## W4 结构债与前端 God 组件（专项窗口期，逐项独立 PR）
+
+| 项 | 实证 | 手法 | 风险 |
+|---|---|---|---|
+| todo 字段变更成本（Shotgun Surgery 极值） | 加字段需动 10+ 处（entity→model_to_todo 24 字段手映射→update_todo_full 16 分支→CLI 19 字段构造 ×2…） | `From`/`Combine Functions into Transform` 收敛转换；SeaORM `DerivePartialModel` 收敛查询/更新 | 中-高（纵穿 5 层） |
+| models/mod.rs 拆分 | 73 struct 混居 15+ 领域 | 按领域拆文件 + `pub use` 兼容过渡 | 低（机械但面广） |
+| 状态字符串枚举族 | loop 状态裸串 ~35 处（两处平行真相）、trigger_type ×6、push_level、todo_type 魔术数 | Replace Type Code with Subclasses + serde 兼容层 | 中（DB/API 契约兼容） |
+| 前端 God 组件 ×4 | SkillMarketplace（视图组 useReducer）、ExecutorsPanel（updateExecutorField+pending 合并）、MessagesPage（filters reducer）、BlackboardPage（useBlackboardWiki + 防抖订阅去重） | 每组件一 PR：useReducer 收敛 + custom hook 抽取 | 低-中（UI 不变，Playwright 护航） |
+| blackboard_debouncer 全局静态三件套 | `RwLock<Option<...>>` + OnceLock 四层包装，初始化顺序耦合 | DI 实例化（AppState 持有）+ 薄 facade 迁移 | 中 |
+| 三处 spawn 平行实现收敛 | message_debounce:1226 ∥ blackboard:753 ∥ run_todo_execution | Extract Class `DirectExecutorSession` | 中-高（与 W3-PR4 联动） |
+| usage_stats 策略注册表 | 新增执行器要加 load/parse 一对 + 登记（霰弹阵列） | `&[&dyn UsageSource]` 注册表（SCANNERS 范式） | 低-中 |
+
+---
+
+## 执行纪律（每 PR 必守）
+
+1. 分支隔离：`refactor/096-<主题>`；不直接在 main 写代码；
+2. 先文档后代码：W3/W4 的 PR 须先补设计小节（本方案对应章节展开）；
+3. 每 PR：clippy 改动文件零告警 + 全量 lib 测试无回归 + 前端 tsc/vitest/Playwright（涉前端时）；
+4. 行为等价是硬约束：重构 PR 不得夹带行为变化（除非单独声明并配测试）；
+5. CodeRabbit 评审全处理后再合并；合并后清理分支。

--- a/docs/代码质量全景扫描报告-20260811.md
+++ b/docs/代码质量全景扫描报告-20260811.md
@@ -1,0 +1,148 @@
+# 代码质量全景扫描报告（2026-08-11）
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (zhanlu) | 2026-08-11 | 初始版本（code-refactor + design-patterns 双 skill 框架，4 路并行深扫 + 量化验证） |
+
+> 扫描覆盖：后端 `executor_service/` + `execution_events/`（1.2 万行）、`services/`（feishu_listener/loop_runner/message_debounce 等）、`db/` + `handlers/` + `cli/`（2.1 万行）、前端 5 个 God 组件候选。所有发现均有行号级实据。
+> 与既有 093 待办清单的关系在各条目末标注【清单已登记/新发现】。
+
+---
+
+## 1. 全景量化
+
+| 指标 | 现状 | 判读 |
+|---|---|---|
+| 后端最大文件 | db/loop_.rs 3010 行 / db/todo.rs 2983 行 / handlers/bundled.rs 2965 行 | 超 500 行警戒线 5-6 倍 |
+| 前端最大组件 | BlackboardPage 1286 行（22 useState）/ SkillMarketplace 1216 行（23 useState） | God Component 成型 |
+| `unwrap()` 存量（非测试） | 1134 处 | 与清单登记的 1112 口径一致 |
+| log_type 裸字符串比较 | ~35 处跨 3 模块 | Primitive Obsession 实证 |
+| `#[allow(too_many_arguments)]` | 55 处（B3 后审计值） | 参数对象化未走完 |
+| 近 20 次提交改动集散点 | message_debounce.rs（≥10 需求域）、loop_runner.rs（≥12 需求域） | Divergent Change git 实锤 |
+
+**总体判断**：骨架已经多轮 093-Bx 治理（参数对象化、注册表、提取器管线），纪律良好；剩余债务集中在**执行器协议的同构复制**（impls 层）、**几处 God 模块**（FeishuListener / loop_runner / completion.rs 黑板错位）、**db/models 层的字段变更成本**（Shotgun Surgery）三块。
+
+---
+
+## 2. 高严重度发现（按价值排序）
+
+### 🔴 A 组：立即可做（低风险、纯删减/收口）
+
+**A1. `extract_stderr` 的 12 处 override 与 trait 默认实现逐字相同【新发现】**
+- 位置：`execution_events/extractor.rs:33-48` vs `impls/` 下 12 个文件（claude_code/kimi/kilo/opencode/pi/hermes/zhanlu/mimo/mobilecoder/codebuddy/codewhale/default）
+- 证据：12 处均为 `trim → 空判 → contains("error") → Error else Info`，与默认实现逐字符相同；仅 codex/atomcode 有真实差异
+- 手法：Remove Dead Code（删 override 让默认实现生效）——**约 -180 行，零风险**
+- 影响面：小
+
+**A2. "session_id 首现即置元数据并发 SessionStart" 模式 ×15 处【新发现】**
+- 位置：`impls/` 下 15 处（claude_code.rs 单文件内就 4 次）
+- 手法：Move Function 到 `ExecutionMetadata::claim_session(sid) -> Option<ExecutionEvent>`，调用点塌为一行
+- 影响面：中
+
+**A3. `extract_session_from_logs` 跨文件逐字重复【新发现】**
+- 位置：`message_debounce.rs:796-808` ≡ `blackboard.rs:616-628`（连注释都一致）；另 `blackboard.rs:634` 注释自述"与 pre_spawn::inject_expert_context 一致，但独立实现"
+- 手法：Extract Function 上移公共 helper
+- 影响面：小
+
+**A4. 死代码簇（execution_events 区）【新发现】**
+- `pipeline.rs`：`feed_batch`/`latest_event`/`to_db_logs`/`filter_events` 等仅测试引用；`extractor.rs` `SimpleExtractor` 无构造点、`reset()` 调用链悬空；`metadata.rs` `mark_success/mark_failed/summary()` 只写不读；`hermes.rs has_done`、`pi.rs pending_tool_calls` 只写不读；`pre_spawn.rs:266` `session_id_for_executor` 以 `#[allow(dead_code)]` 自认"留未来"（YAGNI 违反）
+- 手法：Remove Dead Code 逐项删除
+- 影响面：小
+
+**A5. `REPLACE(REPLACE(...))` 时间过滤 hack 14 处——已有替代方案未清除【清单已登记，本次确认 4 文件 14 处】**
+- 关键罪证：`models/mod.rs:1368-1375` 注释自己写明"列上套函数使索引失效"且已提供 `utc_timestamp_minus_hours`，14 处原封未动；两处经 `Expr::cust` 混入 SeaORM 查询
+- 手法：Substitute Algorithm（`started_at >= ?` 参数绑定）——**附带索引恢复的性能收益**
+- 影响面：中（4 个 db 文件）
+
+**A6. 前端 `BackupPanel` 三域逐字复制（前端最严重同构）【新发现】**
+- 15 个 state 三组完全同构 + 9 个 handler 逐字重复（约 150 行）+ 文件下载套路 5 处重复
+- 手法：抽 `useBackupDomain(getStatus, updateAuto, trigger, deleteFile)` hook + `downloadBlob` util——**删 ~180 行，27→约 12 个 state**
+- 影响面：小（纯本文件）
+
+### 🔴 B 组：执行器协议同构复制重灾区（合并治理可削 impls 层 ~40% 体量）
+
+**B1. `impls/opencode.rs` ≈ `impls/kilo.rs` 整文件复制【新发现】**
+- ~170 行 match 逐字相同，仅事件结构体类型不同；头注释自述"复用"实为粘贴
+- 手法：Extract Superclass（泛型 `StepProtocolExtractor<E>`）或 Parameterize Function 合并为一个提取器按名参数化
+
+**B2. `extract()` 入口骨架 ×12 文件 + zhanlu/mimo/mobilecoder 分支同构【新发现】**
+- 统一模板 `trim → 空判 → starts_with('{') → from_str → 兜底 Info`；tool_use/step_finish 的 JSON 导航链三处同构
+- 手法：Extract Function 上移泛型 helper / 共享 `extract_tool_pair(part)` 自由函数
+- 收益：新增执行器从"复制 250 行"降为"实现 3 个差异点"；与清单「双解析体系收敛」**互补**（清单项删旧 trait 方法，本项收 impls 层重复）
+
+### 🔴 C 组：God 模块/巨函数（需要专项窗口期）
+
+**C1. `loop_runner.rs::run_inner_from` —— 全库最长函数（496 行，12 个局部可变状态）【新发现】**
+- 新旧「工艺分支/兼容分支」计数+重试+触发逻辑逐字重复两段
+- 手法：Extract Function 按 5 阶段拆 + Form Template Method 收敛两分支
+
+**C2. `FeishuListener` God Object（2600 行，75+ 函数，7 类职责）【新发现】**
+- WS 连接管理 + 凭证/token + 消息编排 + 斜杠命令 + 卡片回调 + 卡片组装 + HTTP 发送 SDK 七合一；`feishu_push` 被迫依赖连接管理器发消息（DIP 违反实证）
+- 手法：Extract Class 拆 `FeishuApiClient`（发送+凭证）/`SlashCommandHandler`/`CardActionHandler`
+- 附带：`handle_new` 的「失败回复+删 reaction」样板 ×7 次、`handle_stop` 嵌套 7 层
+
+**C3. 三处「spawn + 流式读 + 超时 + session 提取」平行实现【新发现】**
+- `message_debounce.rs::handle_default_response_executor`（276 行）∥ `blackboard.rs::spawn_executor_for_chat_streaming` ∥ `executor_service::run_todo_execution`
+- 执行器行为变更要同步改三处（霰弹实证）
+- 手法：Extract Class 提炼 `DirectExecutorSession`
+
+**C4. `completion.rs:518-899` 黑板监听服务整块错位（~380 行与执行完成无关）【新发现】**
+- 文件头自述 7 项职责全是终态分支，47% 篇幅却是黑板 ticker/worker/listener
+- 手法：Move Function 整组迁 `services/blackboard_flush.rs`——纯搬运，pub 入口仅一个
+
+**C5. `handlers/session.rs` 扫描器空壳：SCANNERS 注册表只转发，6 个 scan_X 函数仍在 handler 层【新发现】**
+- 2890 行中仅 4 个真 handler，其余 ~55 个函数是磁盘扫描+JSONL 解析；多态抽象未竟
+- 手法：Move Function 把 scan_X 函数体搬进各 `impl SessionScanner`（handler 降至 ~300 行）
+- 同类分层违规：`handlers/backup.rs`（zip 打包+cron 调度+扫描闭包 ×3 逐字重复）、`handlers/bundled.rs`（git 同步/导入/安装全链路）
+
+### 🔴 D 组：数据层结构债
+
+**D1. todos 表加字段需动 10+ 处（Shotgun Surgery 极值）【新发现，清单"models 拆分"的放大器】**
+- 触点链：entity → `Todo` struct → `model_to_todo`（24 字段手映射）→ `TodoUpdate`（17 字段）→ `update_todo_full`（16 个 if let 分支）→ `batch_copy`（18 字段）→ `TodoBackup` 构造 ×2 → `merge_backup` 双分支 → Create/UpdateRequest → CLI 两处 19 字段字面构造
+- 手法：`From`/`Combine Functions into Transform` 收敛转换；SeaORM 派生宏收敛 update 分支
+- **这是全项目改动成本最高的结构性债务**
+
+**D2. `models/mod.rs` 73 struct + 4 enum 混居 15+ 领域【清单已登记，本次量化】**
+- 还塞了业务函数（`replace_placeholders`/`build_trigger_params` 含字面量）
+- 手法：按领域拆文件 + `pub use` 兼容过渡（机械但面广）
+
+**D3. 状态字符串全链路裸奔【清单已登记（log_type），本次发现更广泛的同族问题】**
+- `loop_runner.rs` 状态字面量 ~35 处（`task_status_for_loop_status` 与 L1095-1100 两处平行真相）；`trigger_type` 裸串比较 6 处（写错字面量静默失效）；`PendingMessage.todo_id` 复用存 loop_id（字段语义重载自述）；`push_level != "all"`、`content.contains("开始处理")` 中文文案当协议判定
+- 手法：Replace Type Code with Subclasses（`LoopExecutionStatus`/`TriggerType`/`PushLevel` 枚举 + serde 兼容层）
+
+### 🔴 E 组：前端 God 组件（清单已登记方向，本次给出具体收敛分组）
+
+| 组件 | 实际 useState | 核心问题 | 首选手法 |
+|---|---|---|---|
+| BackupPanel | 27 | **三域逐字复制**（见 A6） | `useBackupDomain` |
+| MessagesPage | 24 | 10 个筛选/分页 state（loadMessages 依赖数组正好 10 项） | filters 收敛 useReducer + `useFeishuMessages` |
+| SkillMarketplace | 23 | 视图/筛选/分页组，三个 switch 函数各手动联动 4-5 个 setter（漏重置页码已出过 bug，L598 注释为证） | useReducer + `useMarketplaceData` |
+| ExecutorsPanel | 23 | 4 个 pending-by-name state + 5 处同构行内保存 | `updateExecutorField(name, patch)` |
+| BlackboardPage | 22 | 4 功能区 + 防抖订阅逐字重复两段（L803-811 ≡ L855-863） | `useBlackboardWiki` + `useBlackboardDebounceStatus` |
+
+### 🔴 F 组：其他值得登记的中危项
+
+- `blackboard_debouncer` 全局静态三件套（`RwLock<Option<...>>` + OnceLock 四层包装，初始化顺序耦合、测试污染）→ DI 实例化【新发现】
+- `(db, registry, tx, task_manager, config)` 五元组 ×7 函数（auto_review/黑板链，B3 治理漏网）→ Introduce Parameter Object【清单"参数对象化"续集】
+- `ExecEvent::Finished` 13 字段字面构造 ×7 处 + feishu 三元组 ×4 处（trigger_type 后补时前 6 处统一传 None 的 Shotgun 实锤）→ Builder/工厂【新发现】
+- `usage_stats.rs` 执行器解析霰弹阵列（新增执行器要加 load/parse 一对 + 登记）→ 策略注册表（SCANNERS 同款范式可仿）【新发现】
+- `spawn_run` 内联时长计算与同文件公共函数双份 + `block_in_place` 反模式【新发现】
+- `runtime.prepared.request.X` 三层穿透 10+ 次 + 同数据双事实源（曾因 #660 出回归）→ Hide Delegate 窄接口【清单 Message Chains 项的具体落点】
+
+---
+
+## 3. 建议执行顺序
+
+| 波次 | 内容 | 性质 |
+|---|---|---|
+| **第 1 波（小步快跑）** | A1（删 12 处 override）、A4（死代码簇）、A3（重复 helper）、A6（BackupPanel） | 纯删减/收口，各 PR 独立，零风险 |
+| **第 2 波（收口见效）** | A5（REPLACE hack）、A2（session_id 模式）、B1+B2（impls 同构治理）、F 组五元组参数对象 | 局部重构，测试护航 |
+| **第 3 波（专项拆分）** | C4（黑板错位搬离，最易）→ C5（session 扫描器）→ C1（run_inner_from）→ C2（FeishuListener） | 每个独立 PR，按风险升序 |
+| **第 4 波（结构债）** | D1（字段变更成本）→ D2（models 拆分）→ D3（状态枚举族）→ E 组前端 God 组件逐个 | 跨层联动，需专项窗口 |
+
+## 4. 不应误报的正面观察
+
+- 参数对象已广泛应用（`TodoCenterPageQuery`/`ExecutionRecordQuery`/`SpawnContext` 等，093-B3 成果）
+- `process/` 子目录（artifact_capture/gate_evaluator/transition_resolver）函数短小纯函数化，是全仓质量参照范式
+- `db/dashboard.rs` 已独立拆分（方向正确，仅 skills/backup 统计遗留 execution.rs）
+- 长函数普遍带 ≤30 行自我约束注释——纪律已在，问题集中在文件级组织与层级归属


### PR DESCRIPTION
## 背景

分支 `docs/quality-scan-20260811` 上的两份 096 波次源文档一直未合入 main，而 main 已合入的 docs/design/101-096-W4剩余项实施设计.md 等多处引用这两个文件路径——main 上是悬空引用。

## 内容

- `docs/代码质量全景扫描报告-20260811.md`（148 行）：12 项高严重度发现
- `docs/design/096-代码质量重构分步方案.md`（187 行）：W1 纯删减 / W2 局部收口 / W3 God 模块拆分 / W4 结构债

纯新增两文件，无代码改动。096-W1～W4 各项均已按此方案执行完毕（W4 最后一项见 #1051），源文档归位便于追溯。