### PR TITLE
fix(093): 修复首屏 md-editor 回潮——5 处静态 x-markdown 换 LazyXMarkdown

### DIFF
--- a/frontend/src/components/RunningRecordDrawer.tsx
+++ b/frontend/src/components/RunningRecordDrawer.tsx
@@ -8,7 +8,10 @@ import {
   RightOutlined,
 } from '@ant-design/icons';
 import { CopyButton } from '@/components/CopyButton';
-import XMarkdown from '@ant-design/x-markdown';
+// 093：x-markdown 换懒加载封装。本组件经 TodoListPage → RunningBoard 静态进入
+// 首屏依赖图，静态 import 会把 1.1MB 的 vendor-md-editor chunk 拖回首屏 preload
+// （098「运行视图归事项」接链引入的回归）。
+import { LazyXMarkdown as XMarkdown } from '@/components/common/LazyXMarkdown';
 import { ExecutorBadge } from '@/components/ExecutorBadge';
 // 093：本组件只消费 todo 域状态，用细粒度 useTodos 替代合并版 useApp，
 // 执行态（进度/统计推送）变化不再触发本组件重渲染。

--- a/frontend/src/components/skills/SkillDetailDrawer.tsx
+++ b/frontend/src/components/skills/SkillDetailDrawer.tsx
@@ -5,7 +5,8 @@ import {
   FileTextOutlined, DownloadOutlined, InfoCircleOutlined,
   SwapOutlined, DeleteOutlined, FolderOutlined,
 } from '@ant-design/icons';
-import XMarkdown from '@ant-design/x-markdown';
+// 093：x-markdown 换懒加载封装——Drawer 打开时才加载 markdown 渲染树。
+import { LazyXMarkdown as XMarkdown } from '@/components/common/LazyXMarkdown';
 import * as db from '@/utils/database';
 import { formatSize, formatTime, EXECUTOR_COLORS } from './helpers';
 import { EXECUTORS, type ExecutorSkills } from '@/types';

--- a/frontend/src/components/skills/SkillFilePreview.tsx
+++ b/frontend/src/components/skills/SkillFilePreview.tsx
@@ -3,7 +3,8 @@ import { Spin, Typography, Tag, Space, Button, message } from 'antd';
 import {
   DownloadOutlined, CopyOutlined, FileOutlined,
 } from '@ant-design/icons';
-import XMarkdown from '@ant-design/x-markdown';
+// 093：x-markdown 换懒加载封装——预览打开时才加载 markdown 渲染树。
+import { LazyXMarkdown as XMarkdown } from '@/components/common/LazyXMarkdown';
 import type { SkillFileInfo } from '@/utils/database/skills';
 import { formatSize, formatTime, getFileColor } from './helpers';
 

--- a/frontend/src/components/skills/SkillMarketplace.tsx
+++ b/frontend/src/components/skills/SkillMarketplace.tsx
@@ -20,7 +20,9 @@ import {
   UnorderedListOutlined, ArrowLeftOutlined, StarOutlined,
   LinkOutlined, DownOutlined,
 } from '@ant-design/icons';
-import XMarkdown from '@ant-design/x-markdown';
+// 093：x-markdown 换懒加载封装——本组件经 SkillsPanel 懒加载，markdown 预览
+// 仅在打开详情时才需要，静态 import 会让 chunk 边界失效。
+import { LazyXMarkdown as XMarkdown } from '@/components/common/LazyXMarkdown';
 import { bundledApi, type BundledSkillMeta, type BundledSkillFile, type SkillSourceMeta, } from '@/api/bundled';
 import type { ExecutorSkills } from '@/types';
 import { EXECUTORS } from '@/types';

--- a/frontend/src/components/tasks/discussion/PostCard.tsx
+++ b/frontend/src/components/tasks/discussion/PostCard.tsx
@@ -4,7 +4,8 @@
 
 import { Card, Tag, Space, Button, Spin, Typography, Popconfirm, theme } from 'antd';
 import { DeleteOutlined, MessageOutlined } from '@ant-design/icons';
-import XMarkdown from '@ant-design/x-markdown';
+// 093：x-markdown 换懒加载封装，避免 markdown 依赖树（~600KB）被静态链锚定。
+import { LazyXMarkdown as XMarkdown } from '@/components/common/LazyXMarkdown';
 import type { TaskPost } from '@/types';
 
 const { Text } = Typography;


### PR DESCRIPTION
## 问题

全量 Playwright 回归发现 `093-first-screen-bundle` 两条用例失败（单跑也失败，真实回归）：首屏 preload 重新出现 `vendor-md-editor`（1.1MB chunk）。

## 根因

098「运行视图归事项」(#e0818920，8/11) 把 RunningBoard 挂进 TodoListPage，接上静态链：

```
App.tsx（091 有意静态引 TodoListPage）
  → TodoListPage.tsx:25 → running-board
  → RunningRecordDrawer.tsx:11 静态 import XMarkdown
  → vendor-md-editor（1.1MB）回到首屏 preload
```

093/#999（8/8）已建 `LazyXMarkdown` 懒加载封装治理此问题，但该封装未覆盖 RunningRecordDrawer 等 5 处后续新增/遗漏的静态引用，098 接链后回归发生。

## 修复

5 处静态 `import XMarkdown from '@ant-design/x-markdown'` 统一替换为既有 `@/components/common/LazyXMarkdown` 封装（default 与命名导出同源组件，props 零改动，仅 import 行替换）：

- `RunningRecordDrawer.tsx`（首屏回归主链）
- `PostCard.tsx`（讨论帖正文）
- `SkillMarketplace.tsx` / `SkillFilePreview.tsx` / `SkillDetailDrawer.tsx`（技能市场预览，虽不在首屏链但同属治理漏网）

## 验证

| 项 | 结果 |
|---|---|
| `dist/index.html` preload | ✅ 无 md-editor/monaco/flow |
| 093 spec | ✅ 3/3（修复前 2 失败） |
| vitest | ✅ 429 全过 |
| tsc | ✅ 零错误 |
| 060 讨论区 / 096-w4 技能市场 spec | ✅ 通过（覆盖改动组件） |

dev 实例重启后实测首屏 HTML 已无重型 chunk preload。

注：`check_skill_file_browser` 2 条失败经 stash 验证为存量问题（spec 未钉 `selected_workspace`，卡片列表加载失败，与本次改动无关）。