### PR TITLE
feat(process): 工艺卡片整卡可点——点击卡片主体弹出详情

### DIFF
--- a/frontend/src/components/ProcessPage.tsx
+++ b/frontend/src/components/ProcessPage.tsx
@@ -283,10 +283,17 @@ function ProcessListView({ workspaceId, onOpenLoop, processGuid, pushUrl }: Omit
 
   // 单张工艺卡片渲染（039 从网格 JSX 中抽出，控制列表渲染块的嵌套层级与函数长度）。
   // 040：寻址/高亮统一按 guid（name 可重复）；系统工艺展示「复制」按钮把模板转成可编辑的我的工艺。
+  // 工艺卡片点击体验：整卡可点——点击卡片主体等同点「详情」按钮弹出详情 Modal。
+  // 底部 actions 区（详情/安装/复制/编辑/分享）的按钮点击会冒泡到卡片 onClick，
+  // 必须用 .ant-card-actions 守卫放行，否则点「安装」会同时弹详情 Modal 互相遮挡。
   const renderProcessCard = (p: ProcessTemplate) => (
     <Card
       hoverable
       style={{ flex: 1 }}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest('.ant-card-actions')) return;
+        handleShowDetail(p.guid);
+      }}
       title={p.display_name || p.name}
       extra={
         <Space>

--- a/frontend/tests/process-card-click.spec.ts
+++ b/frontend/tests/process-card-click.spec.ts
@@ -1,0 +1,99 @@
+// 工艺卡片点击体验验证（feat/process-card-click-detail）：
+// 1. 点击卡片主体（标题/描述区）等同点击「详情」按钮 → 弹出详情 Modal；
+// 2. 点击卡片底部 actions 区的按钮（安装/详情等）不触发卡片点击——
+//    .ant-card-actions 守卫放行冒泡，避免「点安装却弹详情」互相遮挡。
+//
+// 运行前提：worktree make dev 已起（18088）。工艺列表与详情均 route mock，
+// 不依赖 dev 库预置数据。
+
+import { test, expect } from '@playwright/test';
+
+const BASE = 'http://localhost:18088';
+
+// mock 工艺列表（1 个用户工艺）+ 详情接口：列表有数据才能渲染卡片，
+// 详情返回最小可解析载荷（Modal 渲染断言不依赖流程图解析成功）。
+const PROCESS = {
+  id: 1,
+  guid: 'pw-card-click-guid',
+  name: 'pw-card-click',
+  display_name: '点击验证工艺',
+  description: '用于验证卡片点击弹详情的工艺',
+  category: 'software',
+  complexity: 'light',
+  version: '1.0.0',
+  source_path: '~/.ntd/processes/pw-card-click.yaml',
+  is_system: false,
+  created_at: null,
+  updated_at: null,
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/v1/bundled/processes**', (route) => {
+    const url = route.request().url();
+    // 列表接口（无 guid 路径段）返回数组；详情接口（含 guid 路径段）返回对象。
+    if (/\/processes\/[^/]+$/.test(url)) {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          code: 0,
+          data: { ...PROCESS, definition: 'name: pw-card-click\nversion: 1.0.0\n' },
+        }),
+      });
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 0, data: [PROCESS] }),
+      });
+    }
+  });
+});
+
+/** 打开工艺页并等待卡片渲染。 */
+async function openProcessPage(page: import('@playwright/test').Page) {
+  await page.goto(`${BASE}/#/processes`, { waitUntil: 'domcontentloaded' });
+  const card = page.locator('.ant-card').filter({ hasText: '点击验证工艺' }).first();
+  await expect(card).toBeVisible({ timeout: 10000 });
+  return card;
+}
+
+test('点击卡片主体弹出详情 Modal（等同点「详情」按钮）', async ({ page }) => {
+  const card = await openProcessPage(page);
+
+  // 点卡片标题区（非 actions 区）→ 详情 Modal 出现，含「流程图」Tab。
+  await card.locator('.ant-card-head-title').click();
+  const modal = page.locator('.ant-modal').filter({ hasText: '点击验证工艺' });
+  await expect(modal).toBeVisible({ timeout: 8000 });
+  await expect(modal.getByText('流程图', { exact: true }).first()).toBeVisible();
+});
+
+test('点击卡片描述区同样弹出详情 Modal', async ({ page }) => {
+  const card = await openProcessPage(page);
+
+  // 点正文描述（actions 区之外）→ 详情 Modal 出现。
+  await card.locator('.ant-card-body').click();
+  await expect(page.locator('.ant-modal').filter({ hasText: '点击验证工艺' })).toBeVisible({ timeout: 8000 });
+});
+
+test('点击卡片底部「安装」按钮：弹安装确认而非详情 Modal', async ({ page }) => {
+  const card = await openProcessPage(page);
+
+  // 点 actions 区「安装」：.ant-card-actions 守卫应放行按钮自身行为，
+  // 只弹安装确认 Modal（「安装工艺模板」标题）；详情 Modal（含「流程图」Tab）不得出现。
+  // 注意：安装确认文案含工艺名（将「点击验证工艺」安装到…），不能用工艺名区分 Modal，
+  // 详情 Modal 以「流程图」Tab 为唯一特征。
+  await card.getByRole('button', { name: '安装' }).click();
+  const installModal = page.locator('.ant-modal').filter({ hasText: '安装工艺模板' });
+  await expect(installModal).toBeVisible({ timeout: 8000 });
+  const detailModal = page.locator('.ant-modal').filter({ hasText: '流程图' });
+  await expect(detailModal).toHaveCount(0);
+});
+
+test('点击卡片底部「详情」按钮仍正常弹出详情 Modal', async ({ page }) => {
+  const card = await openProcessPage(page);
+
+  // actions 区「详情」按钮自身的行为不被守卫误伤。
+  await card.getByRole('button', { name: '详情' }).click();
+  await expect(page.locator('.ant-modal').filter({ hasText: '点击验证工艺' })).toBeVisible({ timeout: 8000 });
+});


### PR DESCRIPTION
## 变更内容

工艺卡片目前只有 hover 效果、点击无反应，体验断层。本 PR 让**整卡可点**：点击卡片主体（标题/描述/标签区）等同点击卡片底部 actions 区的「详情」按钮，弹出工艺详情 Modal。

## 实现要点

- `renderProcessCard` 增加 `onClick`：点击卡片主体 → `handleShowDetail(guid)`（与「详情」按钮同一入口）
- **`.ant-card-actions` 冒泡守卫**：底部 actions 区按钮（详情/安装/复制/编辑/分享）的点击会冒泡到卡片 onClick，用 `closest('.ant-card-actions')` 放行，避免点「安装」时同时弹详情 Modal 互相遮挡

## 验证（真实 Chromium，make dev :18088）

新增 `frontend/tests/process-card-click.spec.ts` 4 用例全部通过：
1. 点击卡片标题区 → 详情 Modal（含流程图 Tab）✅
2. 点击卡片描述区 → 详情 Modal ✅
3. 点击「安装」按钮 → 只弹安装确认、不弹详情 Modal（守卫生效）✅
4. 点击「详情」按钮 → 正常弹详情 Modal（守卫不误伤）✅

回归：`tsc --noEmit` 零错误；029-m6 / check_process_page 共 11 个工艺相关用例全过。