### PR TITLE
feat(109): PAT 可用性验证 + 列表形态 ?view= 直达路由

### DIFF
--- a/backend/src/contribution/gitcode.rs
+++ b/backend/src/contribution/gitcode.rs
@@ -1,10 +1,13 @@
-//! GitCode 平台集成：仅保留 PAT 验证所需的 HTTP 调用。
+//! GitCode 平台集成：PAT 验证与账号信息获取所需的 HTTP 调用。
 //!
 //! 贡献提交改为「ActionButton + 提示词」驱动：由 AI 执行器读取本地 PAT、
 //! 调用 GitCode API 完成 fork/建分支/写文件/建 PR，后端不再实现这些确定性调用。
-//! 这里只保留 `verify_pat`（保存 PAT 时验证其有效性）。
+//! 这里只保留 `verify_pat`（保存 PAT 时验证其有效性）与
+//! `fetch_user`（设置页「验证」按钮获取 PAT 所属账号用户名）。
 
 use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
 
 /// GitCode OpenAPI 基础地址（平台固定地址，不属于用户配置）。
 const API_BASE: &str = "https://api.gitcode.com";
@@ -20,6 +23,7 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 /// - [`VerifyError::Invalid`] 是用户输入问题（PAT 被服务端拒绝），映射 HTTP 400；
 /// - [`VerifyError::Upstream`] 是网络/上游故障（连不上、超时、读响应失败），映射 HTTP 500，
 ///   避免把「GitCode 抽风」误报成「PAT 无效」诱导用户无谓轮换令牌。
+#[derive(Debug)]
 pub enum VerifyError {
     /// PAT 被服务端拒绝（HTTP 非 2xx）—— 用户输入问题。
     Invalid(String),
@@ -27,28 +31,78 @@ pub enum VerifyError {
     Upstream(String),
 }
 
+/// GitCode `/user` 接口返回的账号信息（设置页「验证」按钮的展示数据）。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitUser {
+    /// 账号登录名（username），PAT 归属的直接证据。
+    pub username: String,
+    /// 显示名；上游缺失时与 username 相同，保证前端字段恒有值。
+    pub name: String,
+}
+
+/// `/user` 响应里真正用到的字段（serde 忽略其余未知字段，上游加字段不破坏解析）。
+#[derive(Debug, Deserialize)]
+struct UserResponse {
+    /// 账号登录名（GitCode 文档确认字段，与分享 prompt 里 {owner} 的口径一致）。
+    login: Option<String>,
+    /// 显示名；login 缺失时的回退项。
+    name: Option<String>,
+    /// 账号 id；实测为十六进制字符串（如 "68ce..."），故按 String 解析；
+    /// login/name 都缺失时的最终回退项（此时展示 #id 至少可辨识归属）。
+    id: Option<String>,
+}
+
 /// 验证 PAT 有效性：调用 `/user` 接口，返回 2xx 即视为有效。
 ///
 /// 不解析 login（账号身份由 AI 执行时实时获取），这里只确认 PAT 能通过认证。
 /// 带超时的客户端确保 GitCode 慢/挂时不会无限阻塞调用方。
 pub async fn verify_pat(pat: &str) -> Result<(), VerifyError> {
-    // 构造带超时的 Client；builder 失败极罕见（仅非法配置），归为上游故障。
-    let client = reqwest::Client::builder()
-        .connect_timeout(CONNECT_TIMEOUT)
-        .timeout(REQUEST_TIMEOUT)
-        .build()
-        .map_err(|e| VerifyError::Upstream(format!("构造 HTTP 客户端失败: {e}")))?;
+    let client = build_client()?;
     let response = client
         .get(format!("{API_BASE}/api/v5/user"))
         .bearer_auth(pat)
         .send()
         .await
-        // 连接失败/超时/DNS 等都属上游可达性问题，与 PAT 本身是否有效无关。
-        // reqwest 错误体只含 URL（PAT 在 Authorization 头，不会出现），可安全透传便于排障。
         .map_err(|e| VerifyError::Upstream(format!("请求用户信息失败: {e}")))?;
+    ensure_success(response).await?;
+    Ok(())
+}
+
+/// 获取 PAT 所属账号的用户名：调用 `/user` 并解析 `login`（回退 name / #id）。
+///
+/// 与 `verify_pat` 的区别：这里把响应体解析成账号信息返回，供设置页展示
+/// 「验证通过：@xxx」，让用户肉眼确认 PAT 归属，而不是只得到一个布尔结果。
+pub async fn fetch_user(pat: &str) -> Result<GitUser, VerifyError> {
+    let client = build_client()?;
+    let response = client
+        .get(format!("{API_BASE}/api/v5/user"))
+        .bearer_auth(pat)
+        .send()
+        .await
+        .map_err(|e| VerifyError::Upstream(format!("请求用户信息失败: {e}")))?;
+    let body = ensure_success(response).await?;
+    // 解析失败（上游结构变化）属上游故障而非 PAT 无效：不诱导用户轮换令牌。
+    let user: UserResponse = serde_json::from_str(&body)
+        .map_err(|e| VerifyError::Upstream(format!("解析用户信息失败: {e}")))?;
+    Ok(build_git_user(user))
+}
+
+/// 构造带超时的 HTTP 客户端（verify_pat 与 fetch_user 共用同一套超时参数）。
+fn build_client() -> Result<reqwest::Client, VerifyError> {
+    // builder 失败极罕见（仅非法配置），归为上游故障。
+    reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|e| VerifyError::Upstream(format!("构造 HTTP 客户端失败: {e}")))
+}
+
+/// 非 2xx 响应统一转 `VerifyError::Invalid`；2xx 返回响应体文本（供调用方解析）。
+///
+/// 非 2xx 尝试读 body 丰富错误信息，读失败也不改「无效」结论。
+async fn ensure_success(response: reqwest::Response) -> Result<String, VerifyError> {
     let status = response.status();
     if !status.is_success() {
-        // 非 2xx → PAT 被拒绝；尝试读 body 丰富错误信息，读失败也不改「无效」结论。
         let detail = response
             .text()
             .await
@@ -58,7 +112,26 @@ pub async fn verify_pat(pat: &str) -> Result<(), VerifyError> {
             "PAT 无效（HTTP {status}）: {detail}"
         )));
     }
-    Ok(())
+    response
+        .text()
+        .await
+        .map_err(|e| VerifyError::Upstream(format!("读取响应体失败: {e}")))
+}
+
+/// 把 `/user` 响应字段收敛为展示用 `GitUser`：
+/// login 优先（分享 prompt 的 {owner} 口径），name 次之，最后 #id（至少可辨识归属）。
+fn build_git_user(user: UserResponse) -> GitUser {
+    // name 先取出（Option），避免后续 or(user.name) 把字段 move 走导致无法再用。
+    let name = user.name;
+    let username = user
+        .login
+        .or(name.clone())
+        .or_else(|| user.id.map(|id| format!("#{id}")))
+        .unwrap_or_else(|| "unknown".to_string());
+    GitUser {
+        name: name.unwrap_or_else(|| username.clone()),
+        username,
+    }
 }
 
 /// 截断日志/错误信息里的响应体，避免超长 body 刷屏。
@@ -82,5 +155,50 @@ mod tests {
         let out = truncate_for_log(&long);
         assert!(out.contains("已截断"));
         assert!(out.chars().count() < 300);
+    }
+
+    #[test]
+    fn build_git_user_prefers_login() {
+        // login 存在时优先用 login（分享 prompt 的 {owner} 口径），name 独立保留。
+        let user = build_git_user(UserResponse {
+            login: Some("alice".to_string()),
+            name: Some("Alice".to_string()),
+            id: Some("68ce".to_string()),
+        });
+        assert_eq!(user.username, "alice");
+        assert_eq!(user.name, "Alice");
+    }
+
+    #[test]
+    fn build_git_user_falls_back_to_name() {
+        // 上游未返回 login 时回退 name，保证 username 恒有值。
+        let user = build_git_user(UserResponse {
+            login: None,
+            name: Some("Bob".to_string()),
+            id: Some("abc123".to_string()),
+        });
+        assert_eq!(user.username, "Bob");
+    }
+
+    #[test]
+    fn build_git_user_falls_back_to_id() {
+        // login/name 都缺失时回退 #id，至少可辨识 PAT 归属账号。
+        let user = build_git_user(UserResponse {
+            login: None,
+            name: None,
+            id: Some("abc123".to_string()),
+        });
+        assert_eq!(user.username, "#abc123");
+    }
+
+    #[test]
+    fn build_git_user_all_missing_falls_back_unknown() {
+        // 极端情况（字段全缺）也不 panic，用 unknown 占位。
+        let user = build_git_user(UserResponse {
+            login: None,
+            name: None,
+            id: None,
+        });
+        assert_eq!(user.username, "unknown");
     }
 }

--- a/backend/src/contribution/gitcode.rs
+++ b/backend/src/contribution/gitcode.rs
@@ -63,6 +63,8 @@ pub async fn verify_pat(pat: &str) -> Result<(), VerifyError> {
         .bearer_auth(pat)
         .send()
         .await
+        // 连接失败/超时/DNS 等都属上游可达性问题，与 PAT 本身是否有效无关。
+        // reqwest 错误体只含 URL（PAT 在 Authorization 头，不会出现），可安全透传便于排障。
         .map_err(|e| VerifyError::Upstream(format!("请求用户信息失败: {e}")))?;
     ensure_success(response).await?;
     Ok(())
@@ -79,6 +81,7 @@ pub async fn fetch_user(pat: &str) -> Result<GitUser, VerifyError> {
         .bearer_auth(pat)
         .send()
         .await
+        // 同 verify_pat：错误体只含 URL 不含 PAT，透传安全（论证见 verify_pat 处注释）。
         .map_err(|e| VerifyError::Upstream(format!("请求用户信息失败: {e}")))?;
     let body = ensure_success(response).await?;
     // 解析失败（上游结构变化）属上游故障而非 PAT 无效：不诱导用户轮换令牌。

--- a/backend/src/handlers/contribution.rs
+++ b/backend/src/handlers/contribution.rs
@@ -23,7 +23,7 @@ pub struct AuthStatus {
 pub struct VerifyResult {
     /// 账号登录名（GitCode /user 的 login 字段，分享 prompt 的 {owner} 口径）。
     pub username: String,
-    /// 显示名（可能为空字符串，前端展示时回退 username）。
+    /// 显示名；上游缺失时等于 username（build_git_user 兜底，前端无需再判空）。
     pub name: String,
 }
 

--- a/backend/src/handlers/contribution.rs
+++ b/backend/src/handlers/contribution.rs
@@ -18,6 +18,15 @@ pub struct AuthStatus {
     pub configured: bool,
 }
 
+/// PAT 验证响应：PAT 所属账号的用户名（证明令牌当前可用）。
+#[derive(Debug, Serialize)]
+pub struct VerifyResult {
+    /// 账号登录名（GitCode /user 的 login 字段，分享 prompt 的 {owner} 口径）。
+    pub username: String,
+    /// 显示名（可能为空字符串，前端展示时回退 username）。
+    pub name: String,
+}
+
 /// 保存 PAT 请求体。
 #[derive(Deserialize)]
 pub struct PatRequest {
@@ -40,6 +49,23 @@ pub async fn auth_status() -> ApiResponse<AuthStatus> {
     ApiResponse::ok(AuthStatus {
         configured: pat::load().is_some(),
     })
+}
+
+/// `GET /api/v1/contribution/verify`：验证已保存 PAT 并返回所属账号用户名。
+///
+/// 与保存时验证的区别：保存验证只确认「能过认证」，这里把 `/user` 响应的
+/// login 解析出来返回给前端展示，让用户肉眼确认 PAT 归属（验证入口在设置页）。
+pub async fn verify() -> Result<ApiResponse<VerifyResult>, AppError> {
+    // 未配置 PAT 时没有可验证对象，直接 400 提示先保存，避免对空凭据发起远程调用。
+    let cred = pat::load().ok_or_else(|| AppError::BadRequest("尚未配置 PAT".to_string()))?;
+    // 校验错误按原因分类映射：PAT 无效→400，网络/上游故障→500（避免误报诱导轮换令牌）。
+    let user = gitcode::fetch_user(&cred.pat)
+        .await
+        .map_err(map_verify_error)?;
+    Ok(ApiResponse::ok(VerifyResult {
+        username: user.username,
+        name: user.name,
+    }))
 }
 
 /// `POST /api/v1/contribution/pat`：验证并保存 PAT。
@@ -99,6 +125,7 @@ fn map_verify_error(err: gitcode::VerifyError) -> AppError {
 pub fn contribution_routes() -> Router<AppState> {
     Router::new()
         .route("/api/v1/contribution/auth/status", get(auth_status))
+        .route("/api/v1/contribution/verify", get(verify))
         .route("/api/v1/contribution/pat", post(save_pat))
         .route("/api/v1/contribution/logout", post(logout))
 }

--- a/docs/design/109-PAT验证与列表形态直达路由-设计.md
+++ b/docs/design/109-PAT验证与列表形态直达路由-设计.md
@@ -1,0 +1,145 @@
+# 109-PAT验证与列表形态直达路由-设计
+
+> 目标：① 在「设置 → 第三方授权」提供 PAT 可用性验证（获取 GitCode 用户名证明令牌有效）；
+> ② 为 任务/事项/环路/工艺 各列表形态提供独立 URL，支持直达指定形态展示。
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI 协作开发者 | 2026-02-13 | 初始版本：PAT 验证 + 列表形态 URL 直达设计 |
+
+---
+
+## 1. 背景与问题
+
+### 1.1 PAT 验证
+
+- 当前「第三方授权」面板（`/#/settings?tab=thirdParty`）已支持 GitCode PAT 的保存/清空；
+  保存时后端会调 `/user` 验证有效性，但**保存之后没有任何验证入口**：
+  - 用户无法确认已保存的 PAT 是否仍有效（令牌可能被吊销/过期）；
+  - 用户看不到 PAT 归属的账号身份（后端只查 2xx，不解析 `login` 字段）。
+- 仓库内分享 prompt（`contributePrompts.ts`）已确认 `GET https://api.gitcode.com/api/v5/user`
+  返回 `login` 字段即账号名，可作为「PAT 可用」的直接证据。
+
+### 1.2 列表形态直达路由
+
+四个页面都用 Segmented 切换展示形态，形态只存 `localStorage`，URL 不感知：
+
+| 页面 | URL | 形态 | localStorage 键 |
+|------|-----|------|-----------------|
+| 事项 | `/#/todos` | card / list / running | `ntd_items_view` |
+| 环路 | `/#/loops` | list / kanban | `ntd_loops_view` |
+| 任务 | `/#/tasks` | list / kanban / card | `ntd_tasks_view` |
+| 工艺 | `/#/processes` | mine / template | `ntd_process_list_scope` |
+
+问题：
+
+- 分享/收藏的 URL 永远落在「上次 localStorage 记忆的形态」，无法直达指定形态；
+- 无法用书签固定「任务-看板」等常用工作视角。
+
+## 2. 设计决策（已与用户确认）
+
+1. **验证按钮 + 显示用户名**：已配置状态下提供「验证」按钮，点击后后端读取已存 PAT
+   调 GitCode `/user`，返回账号用户名（login），前端展示成功状态与用户名；失败展示具体原因。
+2. **统一 `?view=` query 参数**：与现有 `?tab=`、`?processMode=` 风格一致，改动集中在
+   `useViewState`：
+   - `/#/todos?view=list|card|running`
+   - `/#/loops?view=list|kanban`
+   - `/#/tasks?view=list|kanban|card`
+   - `/#/processes?view=mine|template`
+3. **URL 为最高优先级，localStorage 兜底**：URL 带合法 `?view=` 时按 URL 渲染；
+   无参数或非法值回退 localStorage（保持旧行为）；切换形态时同时写 URL（replaceUrl 防历史栈膨胀）
+   与 localStorage。
+4. **不做旧 URL 兼容**：`?view=` 是全新参数，无历史包袱。
+
+## 3. 后端设计：PAT 验证接口
+
+### 3.1 `GET /api/v1/contribution/verify`
+
+- 读取本地已保存 PAT（`pat::load()`）；未配置返回 400「尚未配置 PAT」。
+- 调 GitCode `/api/v5/user`（带超时，复用现有客户端参数），解析响应 JSON：
+  - `login`（账号用户名，GitCode API 文档确认字段）为主；
+  - 缺失时回退 `name`，再缺失回退 `#id`（防御上游字段漂移）。
+- 响应：`{ "username": "xxx", "name": "xxx" }`；失败按既有 `map_verify_error` 分类
+  （PAT 无效 → 400，网络/上游故障 → 500）。
+
+### 3.2 实现位置
+
+| 文件 | 改动 |
+|------|------|
+| `backend/src/contribution/gitcode.rs` | 新增 `fetch_user(pat) -> Result<GitUser, VerifyError>`；抽出共用 `build_client()` 与错误响应解析 |
+| `backend/src/handlers/contribution.rs` | 新增 `verify` handler + 路由 `/api/v1/contribution/verify` + 单测 |
+
+### 3.3 安全要点
+
+- PAT 不落日志（沿用 `PatCredential` 手动 Debug 脱敏）；
+- 响应体只回用户名，不回 PAT；
+- 沿用 `truncate_for_log` 截断上游错误体，防超长刷屏。
+
+## 4. 前端设计：验证按钮
+
+`ThirdPartyPanel.tsx` GitCode Tab（已配置态）：
+
+- 状态行「已配置」旁新增「验证」按钮 + 结果展示区：
+  - 点击 → 调 `verifyContributionPat()` → 成功显示绿色 Tag「验证通过：@{username}」；
+  - 失败显示红色错误信息（区分「PAT 无效」与「网络故障」）；
+  - 验证中按钮 loading。
+- `contribution.ts` 新增 `verifyContributionPat(): Promise<{ username: string; name?: string }>`。
+
+## 5. 前端设计：`?view=` 路由
+
+### 5.1 `useViewState.ts`
+
+1. `NavOpts` 新增 `view?: string | null`（列表形态参数，仅 todos/loops/tasks/processes 生效）。
+2. `buildHashUrl`：四个视图构造 query 时追加 `view` 参数。
+3. 新增 `listView` state（URL `?view=` 原文），随 `syncStateFromOptions` / `syncFromHash`
+   同步（仅四个视图读取，其他视图置 null，避免跨视图串台）。
+4. 新增纯函数 `pickListView(raw, allowed, fallback)`：合法值取 raw，否则 fallback；
+   供四个页面统一校验，避免各写各的 includes 漂移。
+
+### 5.2 页面接入（模式一致）
+
+以事项页为例：
+
+```tsx
+// URL ?view= 优先（直达指定形态），无参数/非法值回退 localStorage 记忆
+const { listView, replaceUrl } = useViewState();
+const [storedView] = useState(readInitialView);
+const viewMode = pickListView(listView, ['list', 'running'], storedView);
+const handleViewChange = (m) => {
+  localStorage.setItem(VIEW_STORAGE_KEY, m); // 兜底记忆不变
+  replaceUrl('todos', { view: m });          // URL 同步，replaceUrl 不膨胀历史栈
+};
+```
+
+- 切换形态：`replaceUrl(view, { view })` → nav-change 广播 → 所有 useViewState 实例同步
+  listView → 页面派生 viewMode 更新。
+- 后退/前进：popstate → `syncFromHash` → listView 更新。
+- 详情 → 列表返回（`backToList` 等）：URL 回到无参数形态 → listView=null →
+  回退 localStorage（切换时已同步写入，行为一致）。
+- TasksPage `handleSelectTask(null)` 返回列表时补 `view: viewMode`，保持 URL 显式。
+
+## 6. 测试计划
+
+### 后端（cargo test）
+
+- `fetch_user` 响应解析：login / 回退 name / 回退 id / JSON 损坏 → 分类错误；
+- verify handler：未配置 PAT → 400；`map_verify_error` 已有测试覆盖。
+
+### 前端（vitest）
+
+- `buildHashUrl`：四个视图 + view 参数组合（含 tasks 详情 tab 与 view 并存）；
+- `pickListView`：合法值 / 非法值 / null 回退；
+- 既有 `useViewState.test.ts` 断言不回归。
+
+### 功能验证（Playwright）
+
+- `/#/settings?tab=thirdParty`：已配置态显示「验证」按钮，点击后展示用户名；
+- `/#/todos?view=list`、`/#/tasks?view=kanban`、`/#/loops?view=kanban`、
+  `/#/processes?view=template` 直达对应形态（Segmented 选中态正确）。
+
+## 7. 影响面
+
+- 后端：新增 1 个 GET 接口（无破坏性变更）。
+- 前端：`useViewState` 扩展（新增可选参数，向后兼容）；四个页面视图状态改为「URL 优先 +
+  localStorage 兜底」；第三方面板新增验证按钮。
+- 文档：本文 + 实现总结（`docs/requirements/109-...-实现总结.md`）。

--- a/docs/design/109-PAT验证与列表形态直达路由-设计.md
+++ b/docs/design/109-PAT验证与列表形态直达路由-设计.md
@@ -101,10 +101,12 @@
 以事项页为例：
 
 ```tsx
-// URL ?view= 优先（直达指定形态），无参数/非法值回退 localStorage 记忆
+// URL ?view= 优先（直达指定形态），无参数/非法值回退 localStorage 记忆。
+// allowed 必须含全部三种形态（含默认 card）：漏掉默认值会导致 localStorage
+// 记忆为 list/running 时 ?view=card 被误判非法、无法强制回卡片形态（review 修复）。
 const { listView, replaceUrl } = useViewState();
 const [storedView] = useState(readInitialView);
-const viewMode = pickListView(listView, ['list', 'running'], storedView);
+const viewMode = pickListView(listView, ['card', 'list', 'running'], storedView);
 const handleViewChange = (m) => {
   localStorage.setItem(VIEW_STORAGE_KEY, m); // 兜底记忆不变
   replaceUrl('todos', { view: m });          // URL 同步，replaceUrl 不膨胀历史栈

--- a/docs/requirements/109-PAT验证与列表形态直达路由-实现总结.md
+++ b/docs/requirements/109-PAT验证与列表形态直达路由-实现总结.md
@@ -1,0 +1,93 @@
+# 109-PAT验证与列表形态直达路由-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI 协作开发者 | 2026-02-13 | 初始版本：PAT 验证 + 列表形态 URL 直达实现总结 |
+
+---
+
+## 1. 实现了什么
+
+### 1.1 PAT 可用性验证（设置 → 第三方授权 → GitCode）
+
+- 新增后端接口 `GET /api/v1/contribution/verify`：读取本地已保存 PAT，调 GitCode
+  `/api/v5/user`，解析并返回账号用户名（`login`），证明令牌当前可用。
+- 前端「第三方授权」面板：已配置态显示「验证」按钮，点击后行内展示
+  「验证通过：@用户名（显示名）」（真实验证结果：`@daluomadetaiyang（大罗马的太阳）`）；
+  失败透出后端按原因分类的错误（PAT 无效→400、未配置→400、网络/上游→500）。
+- 实测发现并适配：GitCode `/user` 的 `id` 字段是十六进制**字符串**而非数字，
+  解析结构按 `Option<String>` 处理；`login` 缺失时回退 `name`、再回退 `#id`。
+
+### 1.2 列表形态直达路由（?view= 参数）
+
+四个列表页面的展示形态现在由 URL 驱动，可直接分享/书签直达指定形态：
+
+| 页面 | 直达 URL | 形态值域 |
+|------|---------|---------|
+| 事项 | `/#/todos?view=card\|list\|running` | card / list / running |
+| 环路 | `/#/loops?view=list\|kanban` | list / kanban |
+| 任务 | `/#/tasks?view=list\|kanban\|card` | list / kanban / card |
+| 工艺 | `/#/processes?view=mine\|template` | mine / template |
+
+优先级：**URL `?view=` 合法 → 用之；无参数/非法值 → localStorage 记忆兜底**（旧行为不变）。
+用户切换形态时 `replaceUrl` 写回 URL（不膨胀历史栈）+ 同步 localStorage。
+
+## 2. 与需求的对应关系
+
+| 原始需求 | 实现 |
+|---------|------|
+| 增加 PAT 可用性验证功能（获取用户名证明可用） | 1.1：verify 接口 + 验证按钮 + 用户名展示 |
+| 每种展示列表形式都有自己的访问路由，可直达指定形式 | 1.2：四个页面统一 `?view=` 直达路由 |
+
+## 3. 关键实现点
+
+### 后端
+
+- `backend/src/contribution/gitcode.rs`：抽出共用 `build_client()`/`ensure_success()`；
+  新增 `fetch_user()` 与 `build_git_user()`（login→name→#id 三级回退，全缺时 unknown）；
+  `id` 按 String 解析（实测十六进制字符串）。
+- `backend/src/handlers/contribution.rs`：新增 `verify` handler 与路由；
+  未配置 PAT → 400「尚未配置 PAT」；错误分类复用 `map_verify_error`。
+
+### 前端
+
+- `frontend/src/hooks/useViewState.ts`：`NavOpts.view` + `buildHashUrl` 追加 `?view=`；
+  新增 `listView` state（`syncStateFromOptions`/`syncFromHash` 同步，仅四个列表视图生效，
+  其他视图置 null 防跨视图串台）；新增纯函数 `pickListView(raw, allowed, fallback)`。
+- 四个页面统一模式：`storedView`（挂载时读一次 localStorage）+ 派生 `viewMode =
+  pickListView(listView, allowed, storedView)`；切换时 `replaceUrl(view, { view: m })`。
+  任务页返回列表时 URL 显式携带 `view`（`replaceUrl('tasks', { view: viewMode })`）。
+- `frontend/src/components/settings/ThirdPartyPanel.tsx`：验证按钮 + 结果 Tag；
+  清空 PAT 时同步清空旧验证结果。
+- `frontend/src/components/ProcessPage.tsx`：ProcessListView 改自取 useViewState
+  （去掉父级 pushUrl 注入），scope 由 URL 驱动，新增 `data-testid="process-scope-toggle"`。
+
+### 测试
+
+- 后端单测：`build_git_user` 四级回退路径 + 既有 `validate_pat`/`map_verify_error`。
+- 前端单测：`buildHashUrl` 四视图 `?view=` 组合（含 tasks 详情不带 view、
+  processes 编辑器态不带 view、空白 view 不生成残缺 URL）；`pickListView` 三条路径。
+- Playwright：`frontend/tests/109-pat-verify-view-routes.spec.ts`（6 用例全过）：
+  四视图直达形态（Segmented 选中态断言）、切换后 URL 同步 `?view=`、PAT 验证按钮链路。
+  更新 `028-list-detail-routes.spec.ts` 两处断言以匹配「切形态写回 URL」的新行为。
+
+## 4. 验证结果
+
+| 检查项 | 结果 |
+|--------|------|
+| `cargo clippy --all-targets -- -D warnings` | ✅ 零告警 |
+| `cargo test` | ✅ 2276 通过，0 失败 |
+| `npx tsc --noEmit` | ✅ 零错误 |
+| `npx vitest run` | ✅ 438 通过 |
+| Playwright 109 spec | ✅ 6/6 通过 |
+| Playwright 028 回归 | ✅ 11 通过 1 跳过（无数据） |
+| 真实接口验证 | ✅ `/api/v1/contribution/verify` 返回 `{"username":"daluomadetaiyang","name":"大罗马的太阳"}` |
+| UI 验证 | ✅ 「验证通过：@daluomadetaiyang（大罗马的太阳）」Tag 展示 |
+
+## 5. 已知限制与待改进点
+
+- GitCode `/user` 响应解析依赖字段 `login`/`name`/`id`，上游若改名会落入回退链
+  （`#id`/`unknown`），不会崩溃。
+- 「验证」为手动触发（设计确认选项 A）；如需自动验证可后续在 `loadStatus` 后追加调用。
+- 左栏导航切走再切回时 URL 不带 `?view=`（回退 localStorage），属设计内行为：
+  URL 参数是直达手段，localStorage 是会话记忆。

--- a/frontend/src/components/ProcessPage.tsx
+++ b/frontend/src/components/ProcessPage.tsx
@@ -19,7 +19,8 @@ import { CreateProcessMetaModal } from '@/components/process/CreateProcessMetaMo
 import { ShareToRepoButton, toHomePath } from '@/components/settings/contribute/ShareToRepoButton';
 import { buildProcessContributePrompt } from '@/components/settings/contribute/contributePrompts';
 // 029：pushUrl 用于"创建工艺"按钮导航到编辑器路由（/#/processes?processMode=new）。
-import { useViewState } from '@/hooks/useViewState';
+// 109：listView/replaceUrl 用于「我的/模板」形态直达路由（?view=mine|template）。
+import { useViewState, pickListView } from '@/hooks/useViewState';
 
 const { Title, Text, Paragraph } = Typography;
 
@@ -66,9 +67,7 @@ interface ProcessPageProps {
 
 export function ProcessPage({ workspaceId, onOpenLoop, processGuid, processMode = 'list' }: ProcessPageProps) {
   // 029：顶层分流，避免在 if return 后写 useState 造成条件 hooks。
-  // 列表态走现有逻辑（ProcessListView），编辑器态走占位（M3-M6 填实 ProcessEditor）。
-  // pushUrl 从 useViewState 取，用于"创建工艺"按钮导航到编辑器路由。
-  const { pushUrl } = useViewState();
+  // 列表态走 ProcessListView（内部自取 useViewState），编辑器态走 ProcessEditor/占位。
   // M3：edit 模式接真实 ProcessEditor，new 模式留占位给 M6
   if (processMode === 'edit' && processGuid) {
     return <ProcessEditor processGuid={processGuid} />;
@@ -76,7 +75,8 @@ export function ProcessPage({ workspaceId, onOpenLoop, processGuid, processMode 
   if (processMode === 'new') {
     return <ProcessEditorPlaceholder mode="new" name={null} />;
   }
-  return <ProcessListView workspaceId={workspaceId} onOpenLoop={onOpenLoop} processGuid={processGuid} pushUrl={pushUrl} />;
+  // 109：ProcessListView 内部自行取 useViewState（pushUrl/listView/replaceUrl），不再由父级注入。
+  return <ProcessListView workspaceId={workspaceId} onOpenLoop={onOpenLoop} processGuid={processGuid} />;
 }
 
 /**
@@ -108,8 +108,10 @@ function ProcessEditorPlaceholder({ mode, name }: { mode: 'new' | 'edit'; name: 
  *
  * 保留原有的工艺模板库列表、查看详情、安装为 Loop 等功能。
  * 029 新增：接收 pushUrl 用于"创建工艺"按钮导航到编辑器路由。
+ * 109：scope（我的/模板）改为 URL ?view= 优先 + localStorage 兜底，支持形态直达。
  */
-function ProcessListView({ workspaceId, onOpenLoop, processGuid, pushUrl }: Omit<ProcessPageProps, 'processMode'> & { pushUrl: (view: any, opts?: any) => void }) {
+function ProcessListView({ workspaceId, onOpenLoop, processGuid }: Omit<ProcessPageProps, 'processMode'>) {
+  const { pushUrl, listView, replaceUrl } = useViewState();
   const [processes, setProcesses] = useState<ProcessTemplate[]>([]);
   const [loading, setLoading] = useState(false);
   const [detail, setDetail] = useState<ProcessTemplateDetail | null>(null);
@@ -125,8 +127,10 @@ function ProcessListView({ workspaceId, onOpenLoop, processGuid, pushUrl }: Omit
   const [upgradingLoopId, setUpgradingLoopId] = useState<number | null>(null);
   // M6：新建工艺元信息 Modal 开关
   const [createModalOpen, setCreateModalOpen] = useState(false);
-  // 039：「我的/模板」视图范围，初始值从 localStorage 恢复（持久化用户上次选择）。
-  const [scope, setScope] = useState<ProcessScope>(readInitialScope);
+  // 039：「我的/模板」视图范围：URL ?view= 优先（直达指定范围），无参数/非法值
+  // 回退 localStorage 记忆（持久化用户上次选择）。storedScope 只在挂载时读一次。
+  const [storedScope] = useState<ProcessScope>(readInitialScope);
+  const scope = pickListView(listView, ['mine', 'template'], storedScope) as ProcessScope;
 
   const load = async () => {
     setLoading(true);
@@ -147,8 +151,7 @@ function ProcessListView({ workspaceId, onOpenLoop, processGuid, pushUrl }: Omit
     load();
   }, [scope]);
 
-  // 切换视图时持久化到 localStorage，刷新/重进页面后保持上次选择；
-  // 存储失败（隐私模式）静默忽略——视图切换本身不受影响，只是不记忆。
+  // 切换视图：写 localStorage 兜底 + replaceUrl 同步 URL（?view=），使范围可直达/分享。
   const handleScopeChange = (value: string | number) => {
     const next = value === 'template' ? 'template' : 'mine';
     try {
@@ -156,7 +159,7 @@ function ProcessListView({ workspaceId, onOpenLoop, processGuid, pushUrl }: Omit
     } catch {
       // 忽略持久化失败
     }
-    setScope(next);
+    replaceUrl('processes', { view: next });
   };
 
   const handleSearch = async (value: string) => {
@@ -391,11 +394,13 @@ function ProcessListView({ workspaceId, onOpenLoop, processGuid, pushUrl }: Omit
     >
 
       {/* 039：「我的/模板」视图切换，独占一行置于搜索栏上方；
-          用 Segmented 而非 Tabs 是因项目内同列表视图切换均用 Segmented（SkillsPanel 等），视觉更轻量。 */}
+          用 Segmented 而非 Tabs 是因项目内同列表视图切换均用 Segmented（SkillsPanel 等），视觉更轻量。
+          109：形态受 URL ?view= 驱动（mine|template），testid 供 Playwright 验证直达形态。 */}
       <div style={{ marginBottom: 12 }}>
         <Segmented<ProcessScope>
           value={scope}
           onChange={handleScopeChange}
+          data-testid="process-scope-toggle"
           options={[
             { label: '我的', value: 'mine' },
             { label: '模板', value: 'template' },

--- a/frontend/src/components/ProcessPage.tsx
+++ b/frontend/src/components/ProcessPage.tsx
@@ -130,7 +130,8 @@ function ProcessListView({ workspaceId, onOpenLoop, processGuid }: Omit<ProcessP
   // 039：「我的/模板」视图范围：URL ?view= 优先（直达指定范围），无参数/非法值
   // 回退 localStorage 记忆（持久化用户上次选择）。storedScope 只在挂载时读一次。
   const [storedScope] = useState<ProcessScope>(readInitialScope);
-  const scope = pickListView(listView, ['mine', 'template'], storedScope) as ProcessScope;
+  // 泛型版 pickListView 由 allowed/fallback 推导 ProcessScope，无需 as 断言
+  const scope = pickListView(listView, ['mine', 'template'], storedScope);
 
   const load = async () => {
     setLoading(true);

--- a/frontend/src/components/loop-list/index.tsx
+++ b/frontend/src/components/loop-list/index.tsx
@@ -20,7 +20,8 @@ import { PageCard } from '@/components/common/PageCard';
 import { WorkspaceLoopConfigPage } from '@/components/settings/workspace/WorkspaceLoopConfigPage';
 // LoopKanban：环路执行历史看板（8 列），kanban 视图复用。
 import { LoopKanban } from '@/components/loop-kanban';
-import { useViewState } from '@/hooks/useViewState';
+// 109：列表形态直达路由——useViewState 提供 listView（URL ?view= 原文）与 replaceUrl。
+import { useViewState, pickListView } from '@/hooks/useViewState';
 import { LoopListView } from './LoopListView';
 import {
   LoopListHeader,
@@ -29,7 +30,7 @@ import {
 } from './LoopListPageParts';
 import type { LoopListItem } from '@/types/loop';
 
-/** localStorage 键：记住用户上次选的列表/看板形态。 */
+/** localStorage 键：记住用户上次选的列表/看板形态（URL 无 ?view= 参数时的兜底）。 */
 const VIEW_STORAGE_KEY = 'ntd_loops_view';
 
 /** 读取持久化的视图模式，默认列表（环路管理默认 table）。 */
@@ -94,10 +95,13 @@ export function LoopListPage({
 }: LoopListPageProps) {
   const { state } = useTodos();
   const workspaceId = state.selectedWorkspace;
-  const { pushUrl } = useViewState();
+  // 109：pushUrl 用于看板点事项跳详情；listView 是 URL ?view= 原文；replaceUrl 用于形态写回。
+  const { pushUrl, listView, replaceUrl } = useViewState();
   const [searchKeyword, setSearchKeyword] = useState('');
-  // 视图模式：list 定义 table / kanban 执行历史看板（维度不同，切换会换数据对象）。
-  const [viewMode, setViewMode] = useState<'list' | 'kanban'>(readInitialView);
+  // 视图模式：URL ?view= 优先（直达指定形态），无参数/非法值回退 localStorage 记忆。
+  // storedView 只在挂载时读一次：URL 变化走 listView 同步，localStorage 只作无参数兜底。
+  const [storedView] = useState<'list' | 'kanban'>(readInitialView);
+  const viewMode = pickListView(listView, ['list', 'kanban'], storedView) as 'list' | 'kanban';
   // kanban 态时间窗：LoopKanban 受控，由本层下推 hours。
   const [hours, setHours] = useState(24);
 
@@ -105,9 +109,10 @@ export function LoopListPage({
   const { items, loading, reload } = useLoopListData(workspaceId, loopUpdateCount);
 
   const handleViewChange = useCallback((m: 'list' | 'kanban') => {
-    setViewMode(m);
+    // 写 localStorage 兜底 + replaceUrl 同步 URL（?view=），使形态可直达/分享。
     try { localStorage.setItem(VIEW_STORAGE_KEY, m); } catch { /* 静默降级 */ }
-  }, []);
+    replaceUrl('loops', { view: m });
+  }, [replaceUrl]);
 
   // kanban 态执行轨迹流程图点事项标题 → 跳事项详情。
   const handleOpenTodo = useCallback((todoId: number) => {

--- a/frontend/src/components/loop-list/index.tsx
+++ b/frontend/src/components/loop-list/index.tsx
@@ -101,7 +101,8 @@ export function LoopListPage({
   // 视图模式：URL ?view= 优先（直达指定形态），无参数/非法值回退 localStorage 记忆。
   // storedView 只在挂载时读一次：URL 变化走 listView 同步，localStorage 只作无参数兜底。
   const [storedView] = useState<'list' | 'kanban'>(readInitialView);
-  const viewMode = pickListView(listView, ['list', 'kanban'], storedView) as 'list' | 'kanban';
+  // 泛型版 pickListView 由 allowed/fallback 推导联合类型，无需 as 断言
+  const viewMode = pickListView(listView, ['list', 'kanban'], storedView);
   // kanban 态时间窗：LoopKanban 受控，由本层下推 hours。
   const [hours, setHours] = useState(24);
 

--- a/frontend/src/components/settings/ThirdPartyPanel.tsx
+++ b/frontend/src/components/settings/ThirdPartyPanel.tsx
@@ -4,7 +4,13 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { Alert, App, Button, Form, Input, Popconfirm, Space, Tabs, Tag, Typography } from 'antd';
-import { getContributionAuthStatus, logoutContribution, saveContributionPat } from '@/utils/database/contribution';
+import { CheckCircleOutlined } from '@ant-design/icons';
+import {
+  getContributionAuthStatus,
+  logoutContribution,
+  saveContributionPat,
+  verifyContributionPat,
+} from '@/utils/database/contribution';
 
 /** 设置页「第三方授权」Tab 的 key：SettingsPage 用它注册 tab，ContributeButton 用它跳转。 */
 export const THIRD_PARTY_SETTINGS_TAB = 'thirdParty';
@@ -28,8 +34,9 @@ export function ThirdPartyPanel() {
 }
 
 /**
- * GitCode PAT 管理表单：填写 / 保存 / 清空。
+ * GitCode PAT 管理表单：填写 / 保存 / 验证 / 清空。
  * 保存走后端验证接口（调 GitCode /user 确认有效后才落盘），
+ * 「验证」读取已保存 PAT 获取用户名，证明令牌当前可用；
  * 清空是破坏性操作，用 Popconfirm 二次确认，未配置时禁用。
  */
 function GitCodePatTab() {
@@ -39,6 +46,10 @@ function GitCodePatTab() {
   const [configured, setConfigured] = useState<boolean | null>(null);
   const [saving, setSaving] = useState(false);
   const [clearing, setClearing] = useState(false);
+  // 验证态：null=未验证过，'verifying'=验证中，其余为已成功验证的账号信息（含用户名）。
+  // 与 configured 分开管理：PAT 保存/清空后应清空旧验证结果，避免展示过期身份。
+  const [verifyResult, setVerifyResult] = useState<{ username: string; name: string } | null>(null);
+  const [verifying, setVerifying] = useState(false);
 
   // 拉取当前配置态：进入面板即查一次，保存/清空成功后刷新。
   const loadStatus = useCallback(async () => {
@@ -77,12 +88,28 @@ function GitCodePatTab() {
     }
   };
 
-  // 清空 PAT：调后端清除本地文件；成功后刷新配置态。
+  // 验证已保存的 PAT：后端读本地 PAT 调 GitCode /user，返回用户名即证明令牌可用。
+  // 失败不区分「无效/网络」在展示层细化——错误信息由后端按原因分类返回，直接透出。
+  const handleVerify = async () => {
+    setVerifying(true);
+    setVerifyResult(null);
+    try {
+      const result = await verifyContributionPat();
+      setVerifyResult(result);
+    } catch (err: any) {
+      message.error('PAT 验证失败: ' + (err?.message || String(err)));
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  // 清空 PAT：调后端清除本地文件；成功后刷新配置态并清空旧验证结果。
   const handleClear = async () => {
     setClearing(true);
     try {
       await logoutContribution();
       message.success('已清除 PAT');
+      setVerifyResult(null);
       await loadStatus();
     } catch (err: any) {
       message.error('清除 PAT 失败: ' + (err?.message || String(err)));
@@ -109,6 +136,29 @@ function GitCodePatTab() {
             <Tag color="green">已配置</Tag>
           ) : (
             <Tag>未配置</Tag>
+          )}
+          {/* 验证按钮：仅已配置态有意义（未配置时没有可验证的 PAT）。
+              验证结果以行内 Tag 呈现，让「PAT 当前可用 + 归属账号」一眼可辨。 */}
+          {configured === true && (
+            <>
+              <Button
+                size="small"
+                icon={<CheckCircleOutlined />}
+                loading={verifying}
+                onClick={handleVerify}
+                style={{ marginLeft: 12 }}
+              >
+                验证
+              </Button>
+              {verifyResult && !verifying && (
+                <Tag color="green" style={{ marginLeft: 8 }}>
+                  验证通过：@{verifyResult.username}
+                  {verifyResult.name && verifyResult.name !== verifyResult.username
+                    ? `（${verifyResult.name}）`
+                    : ''}
+                </Tag>
+              )}
+            </>
           )}
         </div>
 
@@ -152,7 +202,7 @@ function GitCodePatTab() {
         </Space>
 
         <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-          生成 PAT 请前往 GitCode「个人设置 → 访问令牌」。创建 PR 的完整链路（fork、建分支、写文件、建 PR）需要仓库读写与 PR 相关权限，请务必勾选相应权限后再保存，否则 AI 执行时会因权限不足失败。
+          生成 PAT 请前往 GitCode「个人设置 → 访问令牌」。创建 PR 的完整链路（fork、建分支、写文件、建 PR）需要仓库读写与 PR 相关权限，请务必勾选相应权限后再保存，否则 AI 执行时会因权限不足失败。保存后可点击「验证」确认令牌当前可用，并查看其归属账号。
         </Typography.Text>
       </Space>
     </div>

--- a/frontend/src/components/settings/ThirdPartyPanel.tsx
+++ b/frontend/src/components/settings/ThirdPartyPanel.tsx
@@ -80,6 +80,9 @@ function GitCodePatTab() {
       await saveContributionPat(values.pat!.trim());
       message.success('PAT 保存成功');
       form.resetFields();
+      // 旧验证结果随 PAT 换新立即过期（展示的还是上一个令牌的归属），
+      // 与状态注释「保存/清空后清空旧验证结果」的约定保持一致（review 修复）。
+      setVerifyResult(null);
       await loadStatus();
     } catch (err: any) {
       message.error('PAT 保存失败: ' + (err?.message || String(err)));
@@ -89,15 +92,17 @@ function GitCodePatTab() {
   };
 
   // 验证已保存的 PAT：后端读本地 PAT 调 GitCode /user，返回用户名即证明令牌可用。
-  // 失败不区分「无效/网络」在展示层细化——错误信息由后端按原因分类返回，直接透出。
+  // 失败不区分「无效/网络」在展示层细化——错误信息由后端按原因分类返回，直接透传。
+  // err 用 unknown 窄化取 message（api 层抛 Error，但防御非 Error 抛出物），不用 any。
   const handleVerify = async () => {
     setVerifying(true);
     setVerifyResult(null);
     try {
       const result = await verifyContributionPat();
       setVerifyResult(result);
-    } catch (err: any) {
-      message.error('PAT 验证失败: ' + (err?.message || String(err)));
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      message.error('PAT 验证失败: ' + msg);
     } finally {
       setVerifying(false);
     }

--- a/frontend/src/components/tasks/TasksPage.tsx
+++ b/frontend/src/components/tasks/TasksPage.tsx
@@ -79,7 +79,8 @@ export function TasksPage({ workspaceId }: TasksPageProps) {
   // 视图模式：URL ?view= 优先（直达指定形态），无参数/非法值回退 localStorage 记忆。
   // storedView 只在挂载时读一次：URL 变化走 listView 同步，localStorage 只作无参数兜底。
   const [storedView] = useState<TasksViewMode>(readInitialView);
-  const viewMode = pickListView(listView, ['list', 'kanban', 'card'], storedView) as TasksViewMode;
+  // 泛型版 pickListView 由 allowed/fallback 推导 TasksViewMode，无需 as 断言
+  const viewMode: TasksViewMode = pickListView(listView, ['list', 'kanban', 'card'], storedView);
 
   // 任务列表数据（三态视图共享）。
   const [tasks, setTasks] = useState<TaskItem[]>([]);

--- a/frontend/src/components/tasks/TasksPage.tsx
+++ b/frontend/src/components/tasks/TasksPage.tsx
@@ -23,7 +23,8 @@ import { CreateTaskModal } from '@/components/tasks/CreateTaskModal';
 import { TaskDetailPanel } from '@/components/tasks/TaskDetailPanel';
 import bundledApi from '@/api/bundled';
 import { listLoops } from '@/utils/database/loops';
-import { useViewState } from '@/hooks/useViewState';
+// 109：列表形态直达路由——useViewState 提供 listView（URL ?view= 原文）。
+import { useViewState, pickListView } from '@/hooks/useViewState';
 import type { LoopLite, TaskItem, TasksViewMode } from '@/components/tasks/constants';
 import { TASKS_VIEW_STORAGE_KEY } from '@/components/tasks/constants';
 
@@ -71,11 +72,14 @@ export function TasksPage({ workspaceId }: TasksPageProps) {
   // 因为 wsId 在 API 调用路径中是必填项，1 是开发环境默认工作空间。
   const wsId = workspaceId ?? 1;
 
-  // 视图路由：useViewState 提供 pushUrl/replaceUrl，用于驱动 URL hash。
-  const { pushUrl, replaceUrl } = useViewState();
+  // 视图路由：useViewState 提供 pushUrl/replaceUrl，用于驱动 URL hash；
+  // listView 是 URL ?view= 原文（列表形态直达路由）。
+  const { pushUrl, replaceUrl, listView } = useViewState();
 
-  // 视图模式：list/kanban/card，持久化到 localStorage。
-  const [viewMode, setViewMode] = useState<TasksViewMode>(readInitialView);
+  // 视图模式：URL ?view= 优先（直达指定形态），无参数/非法值回退 localStorage 记忆。
+  // storedView 只在挂载时读一次：URL 变化走 listView 同步，localStorage 只作无参数兜底。
+  const [storedView] = useState<TasksViewMode>(readInitialView);
+  const viewMode = pickListView(listView, ['list', 'kanban', 'card'], storedView) as TasksViewMode;
 
   // 任务列表数据（三态视图共享）。
   const [tasks, setTasks] = useState<TaskItem[]>([]);
@@ -108,10 +112,10 @@ export function TasksPage({ workspaceId }: TasksPageProps) {
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
 
-  // 切换视图时同步持久化。
+  // 切换视图：写 localStorage 兜底 + replaceUrl 同步 URL（?view=），使形态可直达/分享。
   const handleViewChange = (mode: TasksViewMode) => {
-    setViewMode(mode);
     persistView(mode);
+    replaceUrl('tasks', { view: mode });
   };
 
   // 拉取任务列表。
@@ -160,15 +164,15 @@ export function TasksPage({ workspaceId }: TasksPageProps) {
   const handleSelectTask = useCallback(
     (taskId: number | null, tab?: string) => {
       if (taskId == null) {
-        // 返回列表：replaceUrl 避免详情页占历史栈。
-        replaceUrl('tasks', {});
+        // 返回列表：replaceUrl 避免详情页占历史栈；带 view 参数保持 URL 显式表达当前形态。
+        replaceUrl('tasks', { view: viewMode });
         setSelectedTaskId(null);
       } else {
         pushUrl('tasks', { id: taskId, tab });
         setSelectedTaskId(taskId);
       }
     },
-    [pushUrl, replaceUrl],
+    [pushUrl, replaceUrl, viewMode],
   );
 
   // 新建任务 Modal 提交后回调：关闭 Modal + 刷新列表。

--- a/frontend/src/components/todo-list/TodoListPage.tsx
+++ b/frontend/src/components/todo-list/TodoListPage.tsx
@@ -153,8 +153,10 @@ export function TodoListPage({
 
   // 视图模式：URL ?view= 优先（直达指定形态），无参数/非法值回退 localStorage 记忆。
   // storedView 只在挂载时读一次：URL 变化走 listView 同步，localStorage 只作无参数兜底。
+  // 注意 allowed 必须包含全部三种形态（含默认 card）：否则 localStorage 记忆为 list/running 时，
+  // ?view=card 会被误判非法而无法强制卡片形态（review 修复）。
   const [storedView] = useState<'card' | 'list' | 'running'>(readInitialView);
-  const viewMode = pickListView(listView, ['list', 'running'], storedView) as 'card' | 'list' | 'running';
+  const viewMode = pickListView(listView, ['card', 'list', 'running'], storedView) as 'card' | 'list' | 'running';
   // 统一搜索词：卡片/列表两种形态共用一个搜索框
   const [searchKeyword, setSearchKeyword] = useState('');
   // 刷新信号：每次点击刷新按钮自增，传递给 TodoCenterCardView 触发重新加载

--- a/frontend/src/components/todo-list/TodoListPage.tsx
+++ b/frontend/src/components/todo-list/TodoListPage.tsx
@@ -18,6 +18,8 @@ import * as db from '@/utils/database';
 // 执行态（进度/统计推送）变化不再触发本组件重渲染。
 import { useTodos } from '@/hooks/useTodoContext';
 import { useIsMobile } from '@/hooks/useIsMobile';
+// 109：列表形态直达路由——useViewState 提供 listView（URL ?view= 原文）与 replaceUrl。
+import { useViewState, pickListView } from '@/hooks/useViewState';
 import { TODO_LIST_REFRESH_EVENT } from '@/constants';
 import { PageCard } from '@/components/common/PageCard';
 import { TodoCenterCardView } from '@/components/TodoCenterCardView';
@@ -31,7 +33,7 @@ import {
 } from './TodoListPageParts';
 import type { TodoCenterItem } from '@/types';
 
-/** localStorage 键：记住用户上次选的卡片/列表形态。 */
+/** localStorage 键：记住用户上次选的卡片/列表形态（URL 无 ?view= 参数时的兜底）。 */
 const VIEW_STORAGE_KEY = 'ntd_items_view';
 
 /** 读取持久化的视图模式，默认卡片（设计文档：默认卡片式事项中心）。 */
@@ -146,9 +148,13 @@ export function TodoListPage({
   const { state } = useTodos();
   const workspaceId = state.selectedWorkspace;
   const isMobile = useIsMobile();
+  // 109：listView 是 URL ?view= 原文（四个列表视图共用）；切换形态时用 replaceUrl 写回 URL。
+  const { listView, replaceUrl } = useViewState();
 
-  // 视图模式：默认卡片，用户切到列表后下次仍记住
-  const [viewMode, setViewMode] = useState<'card' | 'list' | 'running'>(readInitialView);
+  // 视图模式：URL ?view= 优先（直达指定形态），无参数/非法值回退 localStorage 记忆。
+  // storedView 只在挂载时读一次：URL 变化走 listView 同步，localStorage 只作无参数兜底。
+  const [storedView] = useState<'card' | 'list' | 'running'>(readInitialView);
+  const viewMode = pickListView(listView, ['list', 'running'], storedView) as 'card' | 'list' | 'running';
   // 统一搜索词：卡片/列表两种形态共用一个搜索框
   const [searchKeyword, setSearchKeyword] = useState('');
   // 刷新信号：每次点击刷新按钮自增，传递给 TodoCenterCardView 触发重新加载
@@ -160,11 +166,12 @@ export function TodoListPage({
   // 行操作 + 带参执行 Modal（已拆到 TodoListPageParts）
   const rowActions = useTodoRowActions({ workspaceId, onReload: reload });
 
-  // 持久化视图模式
+  // 持久化视图模式：写 localStorage 兜底 + replaceUrl 同步 URL（?view=），
+  // 使当前形态可分享/直达；replaceUrl 不膨胀浏览器历史栈（后退不逐次回退形态切换）。
   const handleViewChange = useCallback((m: 'card' | 'list' | 'running') => {
-    setViewMode(m);
     try { localStorage.setItem(VIEW_STORAGE_KEY, m); } catch { /* 静默降级 */ }
-  }, []);
+    replaceUrl('todos', { view: m });
+  }, [replaceUrl]);
 
   // 顶部刷新按钮：列表形态触发 reload，卡片形态刷新 key 驱动 TodoCenterCardView
   const handleReload = useCallback(() => {

--- a/frontend/src/components/todo-list/TodoListPage.tsx
+++ b/frontend/src/components/todo-list/TodoListPage.tsx
@@ -156,7 +156,8 @@ export function TodoListPage({
   // 注意 allowed 必须包含全部三种形态（含默认 card）：否则 localStorage 记忆为 list/running 时，
   // ?view=card 会被误判非法而无法强制卡片形态（review 修复）。
   const [storedView] = useState<'card' | 'list' | 'running'>(readInitialView);
-  const viewMode = pickListView(listView, ['card', 'list', 'running'], storedView) as 'card' | 'list' | 'running';
+  // 泛型版 pickListView 由 allowed/fallback 推导联合类型，无需 as 断言
+  const viewMode = pickListView(listView, ['card', 'list', 'running'], storedView);
   // 统一搜索词：卡片/列表两种形态共用一个搜索框
   const [searchKeyword, setSearchKeyword] = useState('');
   // 刷新信号：每次点击刷新按钮自增，传递给 TodoCenterCardView 触发重新加载

--- a/frontend/src/hooks/useViewState.test.ts
+++ b/frontend/src/hooks/useViewState.test.ts
@@ -94,6 +94,14 @@ describe('buildHashUrl 109 列表形态 ?view= 参数', () => {
     expect(buildHashUrl('tasks', { id: 5, tab: 'discussion' })).toBe('#/tasks/5?tab=discussion');
   });
 
+  it('test_buildHashUrl_view_param_is_trimmed', () => {
+    // review 修复：四视图的 ?view= 写入前统一 trim（与 appendListView 口径一致），
+    // 避免调用方误传 ' card ' 时 URL 携带空格、不同实例 listView 不一致
+    expect(buildHashUrl('tasks', { view: ' card ' })).toBe('#/tasks?view=card');
+    expect(buildHashUrl('todos', { view: ' list ' })).toBe('#/todos?view=list');
+    expect(buildHashUrl('processes', { view: ' mine ' })).toBe('#/processes?view=mine');
+  });
+
   it('test_buildHashUrl_processes_view_appends_query', () => {
     // 工艺「我的/模板」范围直达：/#/processes?view=template；
     // 编辑器态（new/edit）不携带形态参数，避免编辑器 URL 挂着无关 query

--- a/frontend/src/hooks/useViewState.test.ts
+++ b/frontend/src/hooks/useViewState.test.ts
@@ -1,8 +1,9 @@
 // useViewState 的 URL 构建逻辑单测（buildHashUrl 为纯函数，无 window 依赖）。
-// 覆盖本次新增：帖子页返回来源编码（?from=task&taskId=）与 tasks 视图 ?tab= 支持。
+// 覆盖本次新增：帖子页返回来源编码（?from=task&taskId=）、tasks 视图 ?tab= 支持、
+// 109 列表形态直达路由（?view= 参数）。
 
 import { describe, expect, it } from 'vitest';
-import { buildHashUrl, parsePostBackFrom } from './useViewState';
+import { buildHashUrl, parsePostBackFrom, pickListView } from './useViewState';
 
 describe('buildHashUrl 帖子页返回来源', () => {
   it('test_buildHashUrl_post_without_back_source_returns_plain_url', () => {
@@ -58,5 +59,63 @@ describe('parsePostBackFrom 返回来源解析', () => {
   it('test_parsePostBackFrom_without_from_returns_todo', () => {
     // 无 from 参数（或无关 query 如 ?tab=）→ 默认事项来源
     expect(parsePostBackFrom(new URLSearchParams('tab=discussion'))).toEqual({ from: 'todo', taskId: null });
+  });
+});
+
+describe('buildHashUrl 109 列表形态 ?view= 参数', () => {
+  it('test_buildHashUrl_todos_view_appends_query', () => {
+    // 事项列表形态直达：/#/todos?view=list
+    expect(buildHashUrl('todos', { view: 'list' })).toBe('#/todos?view=list');
+    expect(buildHashUrl('todos', { view: 'running' })).toBe('#/todos?view=running');
+  });
+
+  it('test_buildHashUrl_todos_without_view_stays_plain', () => {
+    // 无形态参数 → 不带 query（兼容旧 URL）；详情/帖子页也不携带形态参数
+    expect(buildHashUrl('todos')).toBe('#/todos');
+    expect(buildHashUrl('todos', { id: 7 })).toBe('#/todos/7');
+    expect(buildHashUrl('todos', { id: 7, recordId: 7 })).toBe('#/todos/7/posts/7');
+  });
+
+  it('test_buildHashUrl_todos_blank_view_omits_query', () => {
+    // 空白形态参数不生成残缺 query URL
+    expect(buildHashUrl('todos', { view: '  ' })).toBe('#/todos');
+  });
+
+  it('test_buildHashUrl_loops_view_appends_query', () => {
+    // 环路形态直达：/#/loops?view=kanban
+    expect(buildHashUrl('loops', { view: 'kanban' })).toBe('#/loops?view=kanban');
+    expect(buildHashUrl('loops')).toBe('#/loops');
+    expect(buildHashUrl('loops', { id: 3 })).toBe('#/loops/3');
+  });
+
+  it('test_buildHashUrl_tasks_view_appends_query', () => {
+    // 任务形态直达：/#/tasks?view=card；详情页只带 tab 不带 view
+    expect(buildHashUrl('tasks', { view: 'card' })).toBe('#/tasks?view=card');
+    expect(buildHashUrl('tasks', { id: 5, tab: 'discussion' })).toBe('#/tasks/5?tab=discussion');
+  });
+
+  it('test_buildHashUrl_processes_view_appends_query', () => {
+    // 工艺「我的/模板」范围直达：/#/processes?view=template；
+    // 编辑器态（new/edit）不携带形态参数，避免编辑器 URL 挂着无关 query
+    expect(buildHashUrl('processes', { view: 'template' })).toBe('#/processes?view=template');
+    expect(buildHashUrl('processes', { processMode: 'edit', guid: 'g1', view: 'template' }))
+      .toBe('#/processes?guid=g1&processMode=edit');
+  });
+});
+
+describe('pickListView 109 形态选择', () => {
+  it('test_pickListView_valid_raw_wins', () => {
+    // URL 参数合法 → 以 URL 为准（直达优先）
+    expect(pickListView('list', ['list', 'card'], 'card')).toBe('list');
+  });
+
+  it('test_pickListView_invalid_raw_falls_back', () => {
+    // URL 参数非法（含已废弃形态）→ 回退 localStorage 记忆
+    expect(pickListView('kanban', ['list', 'card'], 'card')).toBe('card');
+  });
+
+  it('test_pickListView_null_raw_falls_back', () => {
+    // URL 无形态参数 → 回退 localStorage 记忆（保持旧行为）
+    expect(pickListView(null, ['list', 'card'], 'list')).toBe('list');
   });
 });

--- a/frontend/src/hooks/useViewState.ts
+++ b/frontend/src/hooks/useViewState.ts
@@ -317,7 +317,9 @@ export function buildHashUrl(view: View, opts?: NavOpts): string {
     }
     const params = new URLSearchParams();
     if (typeof opts?.tab === 'string' && opts.tab.trim()) params.set('tab', opts.tab);
-    if (typeof opts?.view === 'string' && opts.view.trim()) params.set('view', opts.view);
+    // trim 后写入：与 todos/loops 的 appendListView 口径一致，避免「未 trim 值进 URL、
+    // syncFromHash 又 trim 复原」导致不同 useViewState 实例的 listView 短暂不一致（review 修复）。
+    if (typeof opts?.view === 'string' && opts.view.trim()) params.set('view', opts.view.trim());
     const qs = params.toString();
     return qs ? `#/tasks?${qs}` : `#/tasks`;
   }
@@ -347,7 +349,8 @@ export function buildHashUrl(view: View, opts?: NavOpts): string {
   // 避免编辑器 URL 上挂着与编辑无关的形态参数；list/缺省（列表态）才追加。
   if (view === 'processes' && opts?.processMode !== 'new' && opts?.processMode !== 'edit'
     && typeof opts?.view === 'string' && opts.view.trim()) {
-    params.set('view', opts.view);
+    // trim 后写入：与 appendListView/tasks 分支口径一致（review 修复）。
+    params.set('view', opts.view.trim());
   }
   const qs = params.toString();
   return qs ? `#${path}?${qs}` : `#${path}`;

--- a/frontend/src/hooks/useViewState.ts
+++ b/frontend/src/hooks/useViewState.ts
@@ -202,6 +202,27 @@ function getInitialProcessGuid(): string | null {
 }
 
 /**
+ * 109：从 hash query 解析列表形态参数（`?view=` 原文，不校验合法性）。
+ * 四个列表视图（todos/loops/tasks/processes）共用；合法性由各页面用
+ * `pickListView` 按视图值域校验，非法值一律回退 localStorage 记忆。
+ */
+function getInitialListView(): string | null {
+  const params = getHashSearchParams();
+  const view = params.get('view');
+  return view && view.trim() ? view.trim() : null;
+}
+
+/**
+ * 109：在「URL 形态参数」与「localStorage 记忆」之间选择实际形态。
+ * - raw 合法（在 allowed 内）→ 用 raw（URL 直达优先）；
+ * - raw 为 null/非法 → 回退 fallback（localStorage 记忆），保持旧行为。
+ * 抽成纯函数供四个列表页面共用，避免各写各的 includes 校验漂移。
+ */
+export function pickListView(raw: string | null, allowed: string[], fallback: string): string {
+  return raw && allowed.includes(raw) ? raw : fallback;
+}
+
+/**
  * 029：从 hash query 解析工艺编辑器模式。
  * - `'new'` / `'edit'` → 对应编辑器态
  * - 缺失或非法值 → `'list'`（默认列表页）
@@ -230,6 +251,13 @@ interface NavOpts {
   /** postBack='task' 时返回的目标任务 id。 */
   postBackTaskId?: number | null;
   tab?: string | null;
+  /**
+   * 109：列表形态参数（仅 todos/loops/tasks/processes 四个列表视图生效）。
+   * 值域随视图而异：todos=card|list|running、loops=list|kanban、
+   * tasks=list|kanban|card、processes=mine|template。
+   * 用独立 query key `view`，与 `tab`/`processMode` 互不冲突。
+   */
+  view?: string | null;
   workspace?: number | null;
   slug?: string | null;
   file?: string | null;
@@ -250,6 +278,9 @@ interface NavOpts {
  * 构造 hash URL。
  * - todos/loops 用 path 段（/todos、/todos/:id、/todos/:id/posts/:rid、/loops、/loops/:id）
  * - 其他视图用 query 参数（与 028 之前一致）
+ *
+ * 109：四个列表视图（todos/loops/tasks/processes）支持 `?view=` 列表形态参数，
+ * 直达指定形态展示；详情/帖子页不携带该参数（形态只对列表页有意义）。
  */
 export function buildHashUrl(view: View, opts?: NavOpts): string {
   // 事项命名空间：path 段驱动
@@ -266,23 +297,29 @@ export function buildHashUrl(view: View, opts?: NavOpts): string {
     if (opts?.id != null) {
       return `#/todos/${opts.id}`;
     }
-    return `#/todos`;
+    // 列表页：带形态参数 → `#/todos?view=list` 直达指定形态（109）
+    return appendListView(`#/todos`, opts?.view);
   }
   // 环路命名空间：path 段驱动
   if (view === 'loops') {
     if (opts?.id != null) {
       return `#/loops/${opts.id}`;
     }
-    return `#/loops`;
+    return appendListView(`#/loops`, opts?.view);
   }
   // 任务命名空间：path 段驱动，与 todos/loops 一致。
   // 支持 ?tab= query：帖子页返回任务-讨论 tab 时据此恢复 Tabs 选中态（对齐 Settings 页模式）。
+  // 109：列表页额外支持 ?view= 形态参数；详情页只带 tab，不带 view。
   if (view === 'tasks') {
     if (opts?.id != null) {
       const qs = typeof opts.tab === 'string' && opts.tab.trim() ? `?tab=${opts.tab}` : '';
       return `#/tasks/${opts.id}${qs}`;
     }
-    return `#/tasks`;
+    const params = new URLSearchParams();
+    if (typeof opts?.tab === 'string' && opts.tab.trim()) params.set('tab', opts.tab);
+    if (typeof opts?.view === 'string' && opts.view.trim()) params.set('view', opts.view);
+    const qs = params.toString();
+    return qs ? `#/tasks?${qs}` : `#/tasks`;
   }
   // 其他视图保持 query 参数风格
   const path = `/${view}`;
@@ -306,8 +343,23 @@ export function buildHashUrl(view: View, opts?: NavOpts): string {
   if (view === 'processes' && opts?.processMode && opts.processMode !== 'list') {
     params.set('processMode', opts.processMode);
   }
+  // 109：工艺列表形态参数（mine|template）。编辑器态（new/edit）不携带，
+  // 避免编辑器 URL 上挂着与编辑无关的形态参数；list/缺省（列表态）才追加。
+  if (view === 'processes' && opts?.processMode !== 'new' && opts?.processMode !== 'edit'
+    && typeof opts?.view === 'string' && opts.view.trim()) {
+    params.set('view', opts.view);
+  }
   const qs = params.toString();
   return qs ? `#${path}?${qs}` : `#${path}`;
+}
+
+/**
+ * 109：给列表页基础 URL 追加 `?view=` 形态参数（todos/loops 用）。
+ * 无参数/空白参数返回原 URL，避免生成 `#/todos?` 这类带空 query 的 URL。
+ */
+function appendListView(base: string, view?: string | null): string {
+  if (typeof view !== 'string' || !view.trim()) return base;
+  return `${base}?view=${encodeURIComponent(view.trim())}`;
 }
 
 const VIEW_TO_NAV_KEY: Record<View, string> = {
@@ -353,6 +405,9 @@ export function useViewState() {
   const [wikiSlug, setWikiSlug] = useState<string | null>(getInitialWikiSlug);
   const [blackboardFile, setBlackboardFile] = useState<string | null>(getInitialBlackboardFile);
   const [processGuid, setProcessGuid] = useState<string | null>(getInitialProcessGuid);
+  // 109：列表形态参数（?view= 原文）。四个列表视图的页面据此直达指定形态；
+  // 与 localStorage 的关系：URL 优先，无参数/非法值回退 localStorage（页面侧 pickListView）。
+  const [listView, setListView] = useState<string | null>(getInitialListView);
   // 029：工艺编辑器模式。list（默认）= 列表页，new/edit = 编辑器态。
   // 与 processGuid 配套：edit 模式下 processGuid 指向被编辑的工艺 guid（040 起按 guid 寻址）。
   const [processMode, setProcessMode] = useState<'list' | 'new' | 'edit'>(getInitialProcessMode);
@@ -361,7 +416,7 @@ export function useViewState() {
   const setters = {
     setActiveView, setTodoDetailId, setLoopDetailId, setTaskDetailId, setPostRecordId,
     setPostBackFrom, setPostBackTaskId,
-    setActiveTab, setWikiSlug, setBlackboardFile, setProcessGuid, setProcessMode,
+    setActiveTab, setWikiSlug, setBlackboardFile, setProcessGuid, setProcessMode, setListView,
   };
 
   const pushUrl = useCallback((view: View, opts?: NavOpts) => {
@@ -463,6 +518,9 @@ export function useViewState() {
     wikiSlug,
     blackboardFile,
     processGuid,
+    // 109：列表形态参数（?view= 原文）。仅 todos/loops/tasks/processes 四个列表视图消费，
+    // 其他视图恒为 null；页面用 pickListView(raw, allowed, localStorageFallback) 得出实际形态。
+    listView,
     // 029：工艺编辑器模式。list（默认）= 列表页，new/edit = 编辑器态。
     // ProcessPage 根据 mode 分流：list 渲染列表，new/edit 渲染 ProcessEditor。
     processMode,
@@ -495,12 +553,13 @@ function syncStateFromOptions(
     setBlackboardFile: (f: string | null) => void;
     setProcessGuid: (g: string | null) => void;
     setProcessMode: (m: 'list' | 'new' | 'edit') => void;
+    setListView: (v: string | null) => void;
   },
 ): void {
   const {
     setActiveView, setTodoDetailId, setLoopDetailId, setTaskDetailId, setPostRecordId,
     setPostBackFrom, setPostBackTaskId,
-    setActiveTab, setWikiSlug, setBlackboardFile, setProcessGuid, setProcessMode,
+    setActiveTab, setWikiSlug, setBlackboardFile, setProcessGuid, setProcessMode, setListView,
   } = setters;
   setActiveView(view);
   // todos: id+recordId 表示帖子页；仅 id 表示详情；都没有表示列表
@@ -518,6 +577,11 @@ function syncStateFromOptions(
   // 029：工艺编辑器模式仅在 processes view 下生效，其他 view 一律 fallback 到 'list'。
   // 避免跨视图串台：如 /#/dashboard?processMode=new 不应让 dashboard 渲染编辑器。
   setProcessMode(view === 'processes' ? (opts?.processMode ?? 'list') : 'list');
+  // 109：列表形态参数仅在四个列表视图下同步，其他视图一律清空，
+  // 避免跨视图串台（如 /#/dashboard?view=list 不应影响 dashboard）。
+  setListView(view === 'todos' || view === 'loops' || view === 'tasks' || view === 'processes'
+    ? (opts?.view ?? null)
+    : null);
 }
 
 /**
@@ -538,6 +602,7 @@ function syncFromHash(setters: {
   setBlackboardFile: (f: string | null) => void;
   setProcessGuid: (g: string | null) => void;
   setProcessMode: (m: 'list' | 'new' | 'edit') => void;
+  setListView: (v: string | null) => void;
 }): void {
   const segments = getHashPathSegments();
   const view = parseViewFromSegments(segments);
@@ -550,6 +615,9 @@ function syncFromHash(setters: {
   const rawProcessMode = params.get('processMode');
   const processMode: 'list' | 'new' | 'edit' =
     rawProcessMode === 'new' || rawProcessMode === 'edit' ? rawProcessMode : 'list';
+  // 109：列表形态参数原文（合法性由页面侧 pickListView 校验）。
+  const rawView = params.get('view');
+  const listView = rawView && rawView.trim() ? rawView.trim() : null;
 
   setters.setActiveView(view);
   // todos/loops/tasks 详情 id 仅在对应 view 下提取，避免跨视图串台
@@ -569,4 +637,8 @@ function syncFromHash(setters: {
   setters.setProcessGuid(view === 'processes' ? (guid || null) : null);
   // 029：工艺编辑器模式仅在 processes view 下生效，其他 view 即使带 ?processMode=new 也忽略。
   setters.setProcessMode(view === 'processes' ? processMode : 'list');
+  // 109：列表形态参数仅在四个列表视图下生效，其他 view 即使带 ?view= 也忽略（避免跨视图串台）。
+  setters.setListView(view === 'todos' || view === 'loops' || view === 'tasks' || view === 'processes'
+    ? listView
+    : null);
 }

--- a/frontend/src/hooks/useViewState.ts
+++ b/frontend/src/hooks/useViewState.ts
@@ -217,9 +217,11 @@ function getInitialListView(): string | null {
  * - raw 合法（在 allowed 内）→ 用 raw（URL 直达优先）；
  * - raw 为 null/非法 → 回退 fallback（localStorage 记忆），保持旧行为。
  * 抽成纯函数供四个列表页面共用，避免各写各的 includes 校验漂移。
+ * 泛型化让 T 由 allowed/fallback 字面量联合推导：调用点无需 as 断言，
+ * 且 allowed 写入不在 T 值域内的成员时编译期即报错（review 修复）。
  */
-export function pickListView(raw: string | null, allowed: string[], fallback: string): string {
-  return raw && allowed.includes(raw) ? raw : fallback;
+export function pickListView<T extends string>(raw: string | null, allowed: readonly T[], fallback: T): T {
+  return raw && (allowed as readonly string[]).includes(raw) ? (raw as T) : fallback;
 }
 
 /**

--- a/frontend/src/utils/database/contribution.ts
+++ b/frontend/src/utils/database/contribution.ts
@@ -10,11 +10,27 @@ export interface ContributionAuthStatus {
   configured: boolean;
 }
 
+/** PAT 验证结果：PAT 所属账号的用户名（证明令牌当前可用）。 */
+export interface ContributionVerifyResult {
+  /** 账号登录名（GitCode /user 的 login 字段） */
+  username: string;
+  /** 显示名；为空时前端展示回退 username */
+  name: string;
+}
+
 /**
  * 查询 PAT 配置态。
  */
 export async function getContributionAuthStatus(): Promise<ContributionAuthStatus> {
   return unwrap(await api.get('/api/v1/contribution/auth/status'));
+}
+
+/**
+ * 验证已保存的 PAT 并获取所属账号用户名（设置页「验证」按钮调用）。
+ * 后端读取本地 PAT 调 GitCode /user；未配置/无效/网络故障均抛错，由调用方展示。
+ */
+export async function verifyContributionPat(): Promise<ContributionVerifyResult> {
+  return unwrap(await api.get('/api/v1/contribution/verify'));
 }
 
 /**

--- a/frontend/tests/028-list-detail-routes.spec.ts
+++ b/frontend/tests/028-list-detail-routes.spec.ts
@@ -63,8 +63,9 @@ test.describe('028 列表详情独立路由', () => {
     await toggle.getByTitle('列表').click();
     await page.waitForTimeout(ROUTE_SETTLE_MS);
 
-    // URL 仍是列表（切形态不改变 URL）
-    await expect(page).toHaveURL(/\/#\/todos$/);
+    // 109 起：切换形态会把 ?view=list 写回 URL（replaceUrl，可直达/分享），
+    // 不再要求「切形态不改变 URL」——URL 带形态参数即列表形态的显式表达
+    await expect(page).toHaveURL(/\/#\/todos\?view=list$/);
 
     // Ant Design Table 应可见
     await expect(page.locator('.ant-table').first()).toBeVisible();
@@ -201,8 +202,8 @@ test.describe('028 列表详情独立路由', () => {
     await page.goBack();
     await page.waitForTimeout(ROUTE_SETTLE_MS);
 
-    // 应回到列表 URL
-    await expect(page).toHaveURL(/\/#\/todos$/);
+    // 应回到列表 URL（109 起形态参数随历史条目保留：无参数=localStorage 兜底，带参数=显式形态）
+    await expect(page).toHaveURL(/\/#\/todos(\?view=list)?$/);
   });
 
   test('事项卡片墙：点击卡片跳转到 /#/todos/:id（如有数据）', async ({ page }) => {

--- a/frontend/tests/109-pat-verify-view-routes.spec.ts
+++ b/frontend/tests/109-pat-verify-view-routes.spec.ts
@@ -42,6 +42,22 @@ test.describe('109 列表形态直达路由', () => {
     await expect(page.locator('.ant-table').first()).toBeVisible();
   });
 
+  test('事项：localStorage 记忆为 list 时 /#/todos?view=card 仍强制卡片形态', async ({ page }) => {
+    // 测试目的（review 修复用例）：URL ?view=card 必须压过 localStorage 记忆。
+    // 曾因 allowed 集合漏了 'card' 导致该场景回退到 localStorage（显示列表而非卡片）。
+    // 预置 localStorage 记忆为 list：仅 URL 参数被正确识别为 card 时才会选中「卡片视图」。
+    await page.addInitScript(() => {
+      localStorage.setItem('ntd_items_view', 'list');
+    });
+    await page.goto(`${BASE}/#/todos?view=card`);
+    await page.waitForTimeout(ROUTE_SETTLE_MS);
+
+    // Segmented 应选中「卡片视图」（桌面端 title），且不渲染列表 table
+    const toggle = page.getByTestId('todo-center-view-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle.locator('.ant-segmented-item-selected .ant-segmented-item-label')).toHaveAttribute('title', '卡片视图');
+  });
+
   test('事项：切到「执行监控」形态后 URL 同步 ?view=running', async ({ page }) => {
     // 测试目的：用户切换形态 → URL 被 replaceUrl 更新为 ?view=running，可分享直达
     await page.goto(`${BASE}/#/todos`);

--- a/frontend/tests/109-pat-verify-view-routes.spec.ts
+++ b/frontend/tests/109-pat-verify-view-routes.spec.ts
@@ -1,0 +1,120 @@
+// 109-PAT验证与列表形态直达路由：验证两个新能力。
+//
+// 设计文档：docs/design/109-PAT验证与列表形态直达路由-设计.md
+//
+// 覆盖范围：
+// 1. 四个列表视图（todos/loops/tasks/processes）的 ?view= 直达形态：URL 进入即渲染指定形态，
+//    Segmented 选中态正确；切换形态后 URL 同步携带 ?view=（replaceUrl，不膨胀历史栈）。
+// 2. 设置「第三方授权」页：已配置态显示「验证」按钮；点击后调用后端 verify 接口
+//    （真实 GitCode /user），成功展示用户名、失败展示错误信息。
+//
+// 注意：antd Segmented 的 options.title 渲染为 HTML title 属性（图标态无可见文本），
+// 断言/点击需走 [title=...] 选择器。
+//
+// 依赖：后端运行在 18088 端口；PAT 验证用例依赖本机 ~/.ntd/contribution_pat.json，
+// 存在即点击验证按钮并断言结果区出现（成功用户名或失败提示），不存在则断言按钮不渲染。
+
+import { test, expect } from '@playwright/test';
+
+const BASE = 'http://localhost:18088';
+
+/** 等待 hash 路由生效 + 页面渲染稳定的统一延迟。 */
+const ROUTE_SETTLE_MS = 900;
+
+test.describe('109 列表形态直达路由', () => {
+  test.beforeEach(async ({ page }) => {
+    // 进入应用首页，等待 LeftRail 出现表明应用已挂载
+    await page.goto(`${BASE}/`);
+    await page.waitForLoadState('domcontentloaded');
+  });
+
+  test('事项：/#/todos?view=list 直达列表形态', async ({ page }) => {
+    // 测试目的：URL 带 ?view=list 时事项页应直接渲染列表形态（table），而非默认卡片墙
+    await page.goto(`${BASE}/#/todos?view=list`);
+    await page.waitForTimeout(ROUTE_SETTLE_MS);
+
+    // Segmented 选中「列表」（桌面端 title='列表'）
+    const toggle = page.getByTestId('todo-center-view-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle.locator('.ant-segmented-item-selected .ant-segmented-item-label')).toHaveAttribute('title', '列表');
+
+    // 列表形态渲染 table 容器（antd Table 的 table 元素）
+    await expect(page.locator('.ant-table').first()).toBeVisible();
+  });
+
+  test('事项：切到「执行监控」形态后 URL 同步 ?view=running', async ({ page }) => {
+    // 测试目的：用户切换形态 → URL 被 replaceUrl 更新为 ?view=running，可分享直达
+    await page.goto(`${BASE}/#/todos`);
+    await page.waitForTimeout(ROUTE_SETTLE_MS);
+
+    const toggle = page.getByTestId('todo-center-view-toggle');
+    await toggle.locator('.ant-segmented-item-label[title="执行监控"]').click();
+    await page.waitForTimeout(ROUTE_SETTLE_MS);
+
+    // URL 携带形态参数；浏览器历史栈未被形态切换撑大（replaceUrl 替换当前条目）
+    await expect(page).toHaveURL(/#\/todos\?view=running$/);
+  });
+
+  test('环路：/#/loops?view=kanban 直达看板形态', async ({ page }) => {
+    // 测试目的：URL 带 ?view=kanban 时环路页直接渲染执行历史看板（LoopKanban）
+    await page.goto(`${BASE}/#/loops?view=kanban`);
+    await page.waitForTimeout(ROUTE_SETTLE_MS);
+
+    const toggle = page.getByTestId('loop-list-view-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle.locator('.ant-segmented-item-selected .ant-segmented-item-label')).toHaveAttribute('title', '看板');
+  });
+
+  test('任务：/#/tasks?view=card 直达卡片形态', async ({ page }) => {
+    // 测试目的：URL 带 ?view=card 时任务页直接渲染卡片墙（Segmented 选中「卡片」）
+    await page.goto(`${BASE}/#/tasks?view=card`);
+    await page.waitForTimeout(ROUTE_SETTLE_MS);
+
+    const toggle = page.getByTestId('tasks-view-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle.locator('.ant-segmented-item-selected .ant-segmented-item-label')).toHaveAttribute('title', '卡片');
+  });
+
+  test('工艺：/#/processes?view=template 直达模板范围', async ({ page }) => {
+    // 测试目的：URL 带 ?view=template 时工艺页 Segmented 选中「模板」并加载模板列表
+    await page.goto(`${BASE}/#/processes?view=template`);
+    await page.waitForTimeout(ROUTE_SETTLE_MS);
+
+    const toggle = page.getByTestId('process-scope-toggle');
+    await expect(toggle).toBeVisible();
+    await expect(toggle.locator('.ant-segmented-item-selected')).toContainText('模板');
+  });
+});
+
+test.describe('109 PAT 可用性验证', () => {
+  test('设置-第三方授权：已配置态展示「验证」按钮，点击后出现验证结果', async ({ page }) => {
+    // 测试目的：验证按钮仅在已配置态出现；点击后调用后端 /verify 接口，
+    // 无论 PAT 是否有效都会出现结果反馈（成功用户名 Tag 或失败 message），证明链路可用
+    await page.goto(`${BASE}/#/settings?tab=thirdParty`);
+    await page.waitForTimeout(ROUTE_SETTLE_MS);
+
+    const verifyBtn = page.getByRole('button', { name: '验证' });
+    const hasVerifyBtn = (await verifyBtn.count()) > 0;
+    // 本机未配置 PAT 时按钮不应渲染（与「未配置态只给保存」的互斥逻辑一致）
+    if (!hasVerifyBtn) {
+      // 无按钮时断言处于未配置态（存在「保存」按钮），用例仍通过（环境无关）
+      await expect(page.getByRole('button', { name: '保存' })).toBeVisible();
+      return;
+    }
+
+    await verifyBtn.click();
+    await page.waitForTimeout(ROUTE_SETTLE_MS * 2);
+
+    // 验证成功的标志：行内 Tag「验证通过：@用户名」；失败则以 antd message 展示，
+    // 两者必居其一（按钮恢复非 loading 态即结果已落定）
+    await expect(verifyBtn).not.toHaveAttribute('class', /ant-btn-loading/);
+    const successTag = page.locator('.ant-tag', { hasText: '验证通过' });
+    if ((await successTag.count()) > 0) {
+      // 成功路径：展示 PAT 归属用户名（@login），证明令牌当前可用
+      await expect(successTag.first()).toBeVisible();
+    } else {
+      // 失败路径：后端已按原因分类（无效/未配置/网络），message 容器出现即可
+      await expect(page.locator('.ant-message')).toBeVisible();
+    }
+  });
+});

--- a/frontend/tests/playwright.chrome.config.ts
+++ b/frontend/tests/playwright.chrome.config.ts
@@ -1,0 +1,21 @@
+// 本机 Playwright 本地运行配置：复用仓库基线配置，仅把浏览器改为系统 Chrome。
+//
+// 用途：Playwright 官方 CDN 在本机不可达、无法下载 chromium 时的本地验证通道
+// （`npx playwright test --config=tests/playwright.chrome.config.ts`）。
+// CI/他人环境仍用根目录 playwright.config.ts（下载官方 chromium）。
+//
+// 注意：本文件不匹配 testMatch（非 *.spec.ts），不会被默认套件加载。
+
+import { defineConfig } from '@playwright/test';
+import base from '../playwright.config';
+
+export default defineConfig({
+  ...base,
+  // 显式重写 testDir：本配置文件位于 tests/ 下，基线的相对 testDir 会解析错位
+  testDir: './',
+  testMatch: ['**/*.spec.ts'],
+  use: {
+    ...base.use,
+    channel: 'chrome',
+  },
+});


### PR DESCRIPTION
## 实现了什么

### ① 设置 → 第三方授权：PAT 可用性验证
- 后端新增 `GET /api/v1/contribution/verify`：读取已保存 PAT 调 GitCode `/api/v5/user`，
  解析 `login`（回退 `name`、`#id`）返回用户名；未配置 PAT → 400，PAT 无效 → 400，网络/上游 → 500。
- 前端已配置态显示「验证」按钮，点击后行内展示验证结果；清空 PAT 时同步清空旧结果。
- 实测适配：GitCode `/user` 的 `id` 是十六进制字符串（非数字），解析按 `String` 处理。

### ② 四个列表页面形态的 URL 直达路由（统一 `?view=` 参数）
| 页面 | 直达 URL |
|------|---------|
| 事项 | `/#/todos?view=card\|list\|running` |
| 环路 | `/#/loops?view=list\|kanban` |
| 任务 | `/#/tasks?view=list\|kanban\|card` |
| 工艺 | `/#/processes?view=mine\|template` |

- URL 合法值优先；无参数/非法值回退 localStorage 记忆（旧行为不变）。
- 切换形态时 `replaceUrl` 写回 URL（不膨胀浏览器历史栈），同步 localStorage 兜底。
- `useViewState` 新增 `listView` 状态（仅四视图生效，防跨视图串台）与纯函数 `pickListView`。

## 与需求的对应关系
- 「PAT 是否可用的验证性功能（获取用户名证明可用）」→ ① 验证按钮 + 用户名展示
- 「每种展示列表形式增加自己的访问路由，可直达指定形式」→ ② 四个页面 `?view=` 直达

## 测试与验证
- `cargo clippy --all-targets -- -D warnings`：零告警
- `cargo test`：2276 通过，0 失败
- `npx tsc --noEmit`：零错误；`npx vitest run`：438 通过
- Playwright `frontend/tests/109-pat-verify-view-routes.spec.ts`：6/6 通过（真实 GitCode 验证链路）
- 回归：`028-list-detail-routes.spec.ts` 11 通过 1 跳过（无数据），其中 2 处断言随
  「切形态写回 URL」的确认行为同步更新
- 真实接口验证：`/api/v1/contribution/verify` 返回
  `{"username":"daluomadetaiyang","name":"大罗马的太阳"}`；UI 展示「验证通过：@daluomadetaiyang（大罗马的太阳）」

## 已知限制
- 「验证」为手动触发（设计确认选项 A）。
- 左栏导航切走再切回时 URL 不带 `?view=`（回退 localStorage），属设计内行为。
- GitCode `/user` 字段若上游改名，落入回退链（`#id`/`unknown`），不会崩溃。