### PR TITLE
feat(110): 群聊管家修订——单聊纯执行器直聊，管家概念仅保留群聊

### DIFF
--- a/backend/src/db/entity/feishu_messages.rs
+++ b/backend/src/db/entity/feishu_messages.rs
@@ -23,7 +23,7 @@ pub struct Model {
     pub created_at: Option<String>,
     /// 消息接收时，智能体所属的工作空间 ID
     pub workspace_id: Option<i64>,
-    /// 处理类型（如：butler_chat、slash_command、slash_command_loop；
+    /// 处理类型（如：dm_chat 单聊直聊、butler_chat 群聊管家、slash_command、slash_command_loop；
     /// 历史值：default_response、default_response_executor、feishu_project_bind）
     pub processed_type: Option<String>,
     /// 处理结果 ID（executor 类型时为 execution_record_id，todo 类型时为 todo_id）

--- a/backend/src/db/entity/workspace_settings.rs
+++ b/backend/src/db/entity/workspace_settings.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 /// 工作空间设置表：存储每个工作空间的独立配置
 ///
-/// 空间管家配置（108）：未命中斜杠命令的消息交给管家处理——
-/// 管家 = 一个专家（人设与规则）+ 一个执行器（实际干活的进程）。
+/// 聊天直连配置（108 修订）：未命中斜杠命令的消息进聊天直连——
+/// 单聊与「对话执行器」纯直聊；群聊由群聊管家处理（专家人设 + 执行器）。
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
 #[sea_orm(table_name = "workspace_settings")]
 pub struct Model {
@@ -12,11 +12,12 @@ pub struct Model {
     pub id: i64,
     /// 工作空间 ID（唯一）
     pub workspace_id: i64,
-    /// 空间管家的专家名（对应 ExpertIndexManager 中的专家 name，不是 id）。
-    /// None 表示未配置管家专家：管家通路退化为纯执行器聊天（无专家 prompt 注入）；
+    /// 群聊管家的专家名（对应 ExpertIndexManager 中的专家 name，不是 id）。
+    /// 仅群聊消费（butler_chat 注入）；单聊直聊（dm_chat）不读此字段。
+    /// None 表示未配置：群聊管家退化为纯执行器聊天（无专家 prompt 注入）；
     /// 空串 "" 表示显式清空（语义同 None，保留写入侧「清空」与「不动」的区分）。
     pub butler_expert_name: Option<String>,
-    /// 空间管家的执行器类型（如 claudecode / pi）。
+    /// 对话执行器类型（如 claudecode / pi）：单聊直聊与群聊管家共用的执行进程。
     /// None 或空串 "" 都表示未配置管家（前端清空选择时提交空串）：
     /// 未命中斜杠命令的消息收到配置引导提示，不执行任何东西。
     /// 下游读取方统一按「空=未配置」过滤（resolve_butler_executor / workspace_butler_executor）。

--- a/backend/src/db/feishu_message.rs
+++ b/backend/src/db/feishu_message.rs
@@ -212,8 +212,8 @@ impl Database {
             );
         }
 
-        // 按处理类型类别筛选：前端传语义关键字(slash/butler/loop 等)，后端用包含匹配落到具体 processed_type。
-        // slash→slash_command(+loop)、butler→butler_chat、loop→*_loop；
+        // 按处理类型类别筛选：前端传语义关键字(slash/butler/dm/loop 等)，后端用包含匹配落到具体 processed_type。
+        // slash→slash_command(+loop)、butler→butler_chat（群聊管家）、dm→dm_chat（单聊直聊）、loop→*_loop；
         // 历史值 default_response*（108 前产生）仍可按原文匹配。
         // 同样转义防通配符(虽来自固定下拉，保持一致并防御直接调 API 的任意输入)。
         if let Some(pt) = processed_type {

--- a/backend/src/db/workspace.rs
+++ b/backend/src/db/workspace.rs
@@ -240,13 +240,54 @@ fn executor_session_lock(workspace_id: i64) -> Arc<Mutex<()>> {
         .clone()
 }
 
+/// session 存储的 chat 维度（110 修订）：单聊与群聊各自独立的会话上下文。
+///
+/// 背景：session 键原本只有 (workspace, executor)，单聊与群聊互相 resume 对方的
+/// 会话——110 把单聊（纯直聊）/群聊（管家+专家人设）语义分家后，两种上下文
+/// 互串会造成专家人设污染单聊裸会话（或反之），故按 chat scope 分键存储。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutorSessionScope {
+    /// 单聊（dm_chat）：用户与执行器的一对一对话
+    Dm,
+    /// 群聊（butler_chat）：群聊管家对话
+    Group,
+}
+
+impl ExecutorSessionScope {
+    /// 从消息 chat_type 解析：p2p→Dm，其余（含未知类型兜底）→Group——
+    /// 与 FeishuListener::chat_trigger_type 的分流口径保持一致，
+    /// 避免 session 键与 trigger_type 落在两个不同的维度上。
+    pub fn from_chat_type(chat_type: &str) -> Self {
+        if chat_type == "p2p" { Self::Dm } else { Self::Group }
+    }
+
+    /// JSON map 的键前缀：`dm`/`group`，拼上执行器名成复合键（如 `dm:pi`）。
+    /// 选冒号分隔是因为执行器名不含冒号（ExecutorType::as_str 是 ASCII 标识符），
+    /// 不存在歧义碰撞。
+    fn key_prefix(self) -> &'static str {
+        match self {
+            Self::Dm => "dm",
+            Self::Group => "group",
+        }
+    }
+
+    /// 拼 JSON 复合键
+    fn scoped_key(self, executor: &str) -> String {
+        format!("{}:{}", self.key_prefix(), executor)
+    }
+}
+
 impl Database {
-    /// 获取指定工作空间指定执行器的私聊会话 session_id。
+    /// 获取指定工作空间指定执行器在指定 chat 维度的会话 session_id。
     ///
     /// 返回值：
     /// - `Ok(None)`：工作空间不存在
-    /// - `Ok(Some(None))`：工作空间存在但该执行器没有 session
-    /// - `Ok(Some(Some(sid)))`：工作空间存在且该执行器有 session
+    /// - `Ok(Some(None))`：工作空间存在但该维度执行器没有 session
+    /// - `Ok(Some(Some(sid)))`：有 session
+    ///
+    /// 兼容：110 前的存量 JSON 键是裸执行器名（无 scope 前缀）。scoped 键缺失时
+    /// 回退读裸键——升级后单聊继续 resume 原会话（110 前会话主体是单聊直聊），
+    /// 群聊首次会开新会话，无需数据迁移。
     ///
     /// 并发安全：持 per-workspace 互斥锁，与 set_executor_session 互斥，
     /// 防止并发请求读取到过期的 session_id。
@@ -254,6 +295,7 @@ impl Database {
         &self,
         workspace_id: i64,
         executor: &str,
+        scope: ExecutorSessionScope,
     ) -> Result<Option<Option<String>>, sea_orm::DbErr> {
         let lock = executor_session_lock(workspace_id);
         let _guard = lock.lock().await;
@@ -267,20 +309,27 @@ impl Database {
             None => return Ok(None),
         };
 
-        // 解析 JSON 获取对应执行器的 session
+        // 解析 JSON 获取对应维度的 session
         let sessions: HashMap<String, Option<String>> =
             serde_json::from_str(sessions_json.as_deref().unwrap_or("{}"))
             .unwrap_or_default();
 
-        Ok(sessions.get(executor).cloned())
+        // scoped 键优先；缺失时回退裸键（110 前存量，见函数注释兼容说明）
+        Ok(sessions
+            .get(&scope.scoped_key(executor))
+            .or_else(|| sessions.get(executor))
+            .cloned())
     }
 
-    /// 更新指定工作空间指定执行器的私聊会话 session_id。
+    /// 更新指定工作空间指定执行器在指定 chat 维度的会话 session_id。
     ///
     /// 流程：
     /// 1. 读取现有 sessions JSON
-    /// 2. 更新对应执行器的 session
+    /// 2. 清同执行器裸键（110 前存量）+ 写 scoped 复合键
     /// 3. 写回数据库
+    ///
+    /// 顺手清裸键：首次写入即完成该执行器的键迁移，避免裸键残留导致
+    /// 后续读取回退到旧会话。remove 忽略不存在的情况（首次写入无裸键可清）。
     ///
     /// 并发安全：持 per-workspace 互斥锁，与 get_executor_session 互斥，
     /// 防止并发请求的 session_id 互相覆盖。
@@ -288,6 +337,7 @@ impl Database {
         &self,
         workspace_id: i64,
         executor: &str,
+        scope: ExecutorSessionScope,
         session_id: Option<String>,
     ) -> Result<(), sea_orm::DbErr> {
         // 持 per-workspace 互斥锁串行化「读-改-写」，与 get_executor_session 互斥。
@@ -306,8 +356,9 @@ impl Database {
             serde_json::from_str(dir.executor_sessions.as_deref().unwrap_or("{}"))
             .unwrap_or_default();
 
-        // 更新该执行器的 session
-        sessions.insert(executor.to_string(), session_id);
+        // 键迁移：清裸键 + 写 scoped 键（理由见函数注释）
+        sessions.remove(executor);
+        sessions.insert(scope.scoped_key(executor), session_id);
 
         // 序列化并写回
         let now = crate::models::utc_timestamp();
@@ -325,4 +376,139 @@ impl Database {
 fn is_unique_constraint_error(err: &sea_orm::DbErr) -> bool {
     let err_str = format!("{:?}", err);
     err_str.contains("UNIQUE constraint failed")
+}
+
+#[cfg(test)]
+// session 读写走真实 SQLite（:memory:），断言 JSON 键迁移与维度隔离的真实行为；
+// 测试断言用 expect 直接失败即可，与项目内其他 DB 测试的豁免口径一致。
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod executor_session_tests {
+    //! 验证 110 修订的 session chat 维度隔离：
+    //! 单聊（Dm）与群聊（Group）各自独立读写互不串扰；旧裸键回退兼容；写时键迁移。
+
+    use super::ExecutorSessionScope;
+    use crate::db::Database;
+
+    /// 建 workspace 并返回 id（每个用例独立库独立行，避免相互影响）
+    async fn new_workspace(db: &Database) -> i64 {
+        db.create_workspace("/tmp/ws-test", Some("ws"), false, false)
+            .await
+            .expect("create workspace must succeed")
+    }
+
+    /// 核心行为：单聊与群聊 session 互相隔离——写群聊不影响单聊读，反之亦然。
+    /// 这是 110 修复的目标（原实现单聊群聊共用一键，专家人设上下文互串）。
+    #[tokio::test]
+    async fn test_executor_session_dm_and_group_are_isolated() {
+        let db = Database::new(":memory:").await.unwrap();
+        let wid = new_workspace(&db).await;
+
+        // 单聊写入 session-a
+        db.set_executor_session(wid, "pi", ExecutorSessionScope::Dm, Some("ses-dm".to_string()))
+            .await
+            .unwrap();
+        // 群聊写入 session-b（同执行器！）
+        db.set_executor_session(wid, "pi", ExecutorSessionScope::Group, Some("ses-group".to_string()))
+            .await
+            .unwrap();
+
+        // 各读各的：互不串扰
+        assert_eq!(
+            db.get_executor_session(wid, "pi", ExecutorSessionScope::Dm).await.unwrap(),
+            Some(Some("ses-dm".to_string())),
+            "单聊维度应读到单聊 session，不被群聊写入覆盖"
+        );
+        assert_eq!(
+            db.get_executor_session(wid, "pi", ExecutorSessionScope::Group).await.unwrap(),
+            Some(Some("ses-group".to_string())),
+            "群聊维度应读到群聊 session，不被单聊写入覆盖"
+        );
+    }
+
+    /// 清空只影响本维度：群聊 /new 不误伤单聊会话（用户在群里点新会话，私聊上下文保留）。
+    #[tokio::test]
+    async fn test_executor_session_clear_is_scoped() {
+        let db = Database::new(":memory:").await.unwrap();
+        let wid = new_workspace(&db).await;
+        db.set_executor_session(wid, "pi", ExecutorSessionScope::Dm, Some("ses-dm".to_string()))
+            .await
+            .unwrap();
+        db.set_executor_session(wid, "pi", ExecutorSessionScope::Group, Some("ses-group".to_string()))
+            .await
+            .unwrap();
+
+        // 清群聊维度
+        db.set_executor_session(wid, "pi", ExecutorSessionScope::Group, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            db.get_executor_session(wid, "pi", ExecutorSessionScope::Group).await.unwrap(),
+            Some(None),
+            "群聊维度应已清空"
+        );
+        assert_eq!(
+            db.get_executor_session(wid, "pi", ExecutorSessionScope::Dm).await.unwrap(),
+            Some(Some("ses-dm".to_string())),
+            "单聊维度不受群聊清空影响"
+        );
+    }
+
+    /// 兼容：110 前存量 JSON 键是裸执行器名。scoped 键缺失时回退读裸键——
+    /// 升级后单聊（110 前会话的主体）继续 resume 原会话，不断档。
+    /// 直接用 SQL 铺裸键数据，模拟旧版本写入的存量。
+    #[tokio::test]
+    async fn test_executor_session_falls_back_to_legacy_bare_key() {
+        let db = Database::new(":memory:").await.unwrap();
+        let wid = new_workspace(&db).await;
+        // 模拟 110 前 set 写下的裸键 JSON
+        db.exec(&format!(
+            "UPDATE workspaces SET executor_sessions = '{{\"pi\": \"ses-legacy\"}}' WHERE id = {wid}"
+        ))
+        .await
+        .unwrap();
+
+        // scoped 键缺失 → 回退裸键（两个维度都回退：读侧无法判断旧会话属于哪边，
+        // 单聊是旧会话主体，群聊首次读也拿到它只是开一次带上下文的会话，无害）
+        assert_eq!(
+            db.get_executor_session(wid, "pi", ExecutorSessionScope::Dm).await.unwrap(),
+            Some(Some("ses-legacy".to_string())),
+            "scoped 键缺失时应回退读裸键（110 前存量）"
+        );
+    }
+
+    /// 键迁移：首次 scoped 写入顺手清掉裸键——避免后续读取永远回退到旧会话。
+    #[tokio::test]
+    async fn test_executor_session_write_migrates_legacy_bare_key() {
+        let db = Database::new(":memory:").await.unwrap();
+        let wid = new_workspace(&db).await;
+        db.exec(&format!(
+            "UPDATE workspaces SET executor_sessions = '{{\"pi\": \"ses-legacy\"}}' WHERE id = {wid}"
+        ))
+        .await
+        .unwrap();
+
+        // scoped 写入新 session
+        db.set_executor_session(wid, "pi", ExecutorSessionScope::Dm, Some("ses-new".to_string()))
+            .await
+            .unwrap();
+
+        // 裸键已被清：群聊维度读不到 legacy。返回 None（而非 Some(None)）——
+        // group:pi 键从未写入、裸键已删，两个 get 都落空；None 语义即「无 session」，
+        // 调用方（resolve_executor_session）对 None 与 Some(None) 同样降级为新会话
+        assert_eq!(
+            db.get_executor_session(wid, "pi", ExecutorSessionScope::Group).await.unwrap(),
+            None,
+            "scoped 写入后裸键应被迁移清除，群聊维度不应回退到旧会话"
+        );
+    }
+
+    /// from_chat_type 与 chat_trigger_type 分流口径一致：p2p→Dm，其余→Group。
+    #[test]
+    fn test_executor_session_scope_from_chat_type() {
+        assert_eq!(ExecutorSessionScope::from_chat_type("p2p"), ExecutorSessionScope::Dm);
+        assert_eq!(ExecutorSessionScope::from_chat_type("group"), ExecutorSessionScope::Group);
+        // 未知类型兜底群聊，与 listener 的 chat_trigger_type 同口径
+        assert_eq!(ExecutorSessionScope::from_chat_type("unknown"), ExecutorSessionScope::Group);
+    }
 }

--- a/backend/src/executor_service/events.rs
+++ b/backend/src/executor_service/events.rs
@@ -81,7 +81,7 @@ pub enum ExecEvent {
         review_status: String,
     },
     /// 私聊直达卡片消息：消息经 executor 处理后直接把结果发回飞书，不存储执行记录。
-    /// 用于空间管家聊天（butler_chat）场景（开始/结束/错误等关键节点）。
+    /// 用于聊天直连（dm_chat 单聊直聊 / butler_chat 群聊管家）场景（开始/结束/错误等关键节点）。
     DirectCardMessage {
         /// Feishu bot_id
         bot_id: i64,

--- a/backend/src/handlers/agent_bot.rs
+++ b/backend/src/handlers/agent_bot.rs
@@ -860,9 +860,9 @@ pub async fn get_workspace_settings(
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct UpdateWorkspaceSettingsRequest {
-    /// 空间管家的专家名（108）：Some(含空串=清空) 覆写；None 不动。
+    /// 群聊管家的专家名（108 修订：仅群聊注入）：Some(含空串=清空) 覆写；None 不动。
     pub butler_expert_name: Option<String>,
-    /// 空间管家的执行器（108）：Some(含空串=清空) 覆写；None 不动。
+    /// 对话执行器（108 修订：单聊/群聊共用）：Some(含空串=清空) 覆写；None 不动。
     pub butler_executor: Option<String>,
     /// 工作空间级共识 prompt（需求 022）。
     /// Some(含空串) 覆写；None 不动。用户清空时前端传空串。

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -728,9 +728,11 @@ mod placeholder_tests {
     }
 
     #[test]
-    fn test_build_trigger_params_butler_chat() {
+    fn test_build_trigger_params_chat() {
+        // 108 修订：非斜杠消息返回中性 "chat"——dm/butler 的区分由
+        // debounce_push_butler_chat 按 chat_type 落值，本函数只标记「非斜杠」
         let (trigger_type, params) = build_trigger_params("hello world");
-        assert_eq!(trigger_type, "butler_chat");
+        assert_eq!(trigger_type, "chat");
         assert_eq!(params.get("content"), Some(&"hello world".to_string()));
         assert_eq!(params.get("message"), Some(&"hello world".to_string()));
         assert_eq!(params.get("raw_message"), Some(&"hello world".to_string()));
@@ -740,7 +742,7 @@ mod placeholder_tests {
     #[test]
     fn test_build_trigger_params_slash_only_no_body() {
         let (trigger_type, params) = build_trigger_params("/help");
-        assert_eq!(trigger_type, "butler_chat");
+        assert_eq!(trigger_type, "chat");
         assert_eq!(params.get("content"), Some(&"/help".to_string()));
         assert_eq!(params.get("message"), Some(&"/help".to_string()));
         assert!(params.get("slash_command").is_none());

--- a/backend/src/models/todo.rs
+++ b/backend/src/models/todo.rs
@@ -690,11 +690,13 @@ pub fn replace_placeholders(text: &str, params: &std::collections::HashMap<Strin
 }
 
 /// Build standard trigger params from message content.
-/// This unifies how params are constructed across slash commands and butler chat.
+/// This unifies how params are constructed across slash commands and chat dispatch.
 ///
 /// Returns (trigger_type, params):
 /// - For slash commands (content starts with '/'): trigger_type = "slash_command"
-/// - For other messages: trigger_type = "butler_chat"（108：非斜杠消息统一走空间管家）
+/// - For other messages: trigger_type = "chat"（108 修订：非斜杠消息进聊天直连出口；
+///   真正的 dm_chat/butler_chat 区分由 debounce_push_butler_chat 按 chat_type 落值，
+///   这里只给一个中性的「非斜杠」标记——本函数唯一的非测试调用方只消费 params）
 ///
 /// Standard params always include:
 /// - `content`: the message body
@@ -725,5 +727,5 @@ pub fn build_trigger_params(content: &str) -> (String, std::collections::HashMap
     params.insert("content".to_string(), trimmed.to_string());
     params.insert("message".to_string(), trimmed.to_string());
     params.insert("raw_message".to_string(), trimmed.to_string());
-    ("butler_chat".to_string(), params)
+    ("chat".to_string(), params)
 }

--- a/backend/src/services/feishu_card.rs
+++ b/backend/src/services/feishu_card.rs
@@ -562,17 +562,17 @@ pub struct HelpCardState {
     pub page: usize,
     /// 所有工作空间（工作空间页切换用）
     pub workspaces: Vec<WorkspaceItem>,
-    /// 已注册的可用执行器列表（工作空间页切换管家执行器用）。
+    /// 已注册的可用执行器列表（工作空间页切换对话执行器用）。
     /// listener 从 executor_registry.list_executors() 拉出，卡片层只读渲染成按钮排。
     pub available_executors: Vec<ExecutorOption>,
 }
 
-/// 可选执行器项（工作空间页「管家执行器」按钮排）。
+/// 可选执行器项（工作空间页「对话执行器」按钮排）。
 #[derive(Debug, Clone)]
 pub struct ExecutorOption {
     /// 执行器名（ExecutorType::as_str，如 "pi" / "claudecode"）
     pub name: String,
-    /// 是否为当前工作空间已配的管家执行器（primary 高亮）
+    /// 是否为当前工作空间已配的对话执行器（primary 高亮）
     pub is_current: bool,
 }
 
@@ -796,7 +796,7 @@ fn pagination_buttons(kind: &str, page: usize, total_pages: usize) -> Vec<CardBu
     nav_btns
 }
 
-/// 工作空间页：当前工作空间 + 列表[切换] + 管家执行器按钮排 + 推送级别 3 按钮。
+/// 工作空间页：当前工作空间 + 列表[切换] + 对话执行器按钮排 + 推送级别 3 按钮。
 fn build_workspace_page(mut builder: CardBuilder, state: &HelpCardState) -> CardBuilder {
     builder = builder.markdown(&match &state.workspace {
         Some(w) => format!("**当前工作空间** {}（执行器 {}）", w.name, w.executor),
@@ -812,9 +812,9 @@ fn build_workspace_page(mut builder: CardBuilder, state: &HelpCardState) -> Card
         );
     }
     builder = builder.divider();
-    // 管家执行器选择（108）：换行列出所有已注册执行器，当前配的 primary 高亮，
-    // 点击即设为该 workspace 的管家执行器（写 workspace_settings.butler_executor 单字段）。
-    builder = builder.markdown("**管家执行器**");
+    // 对话执行器选择（108 修订：单聊直聊/群聊管家共用）：换行列出所有已注册执行器，
+    // 当前配的 primary 高亮，点击即设（写 workspace_settings.butler_executor 单字段）。
+    builder = builder.markdown("**对话执行器**");
     if state.available_executors.is_empty() {
         builder = builder.markdown("_暂无已注册执行器_");
     } else {
@@ -1445,7 +1445,7 @@ mod tests {
         assert!(json.contains("pi"), "应显示执行器");
     }
 
-    /// 工作空间页「管家执行器」按钮排（108）：默认响应机制退役后文案为「管家执行器」，
+    /// 工作空间页「对话执行器」按钮排（108 修订）：文案为「对话执行器」（单聊/群聊共用），
     /// available_executors 非空时每个执行器渲染成 act:/setbutlerexecutor 按钮，当前配的 primary 高亮。
     /// 底部 note「💡 直接发消息即可让 AI 执行任务」已删除，断言其不出现在任何页。
     #[test]
@@ -1461,7 +1461,7 @@ mod tests {
         };
         let json = render_card_map(&build_help_console_card(&state), "sk").to_string();
         // 新文案落地
-        assert!(json.contains("管家执行器"), "应使用新文案「管家执行器」");
+        assert!(json.contains("对话执行器"), "应使用新文案「对话执行器」");
         // 旧文案不应残留——默认响应机制已退役，两处旧词都必须消失
         assert!(!json.contains("默认响应执行器"), "旧文案「默认响应执行器」应已移除");
         assert!(!json.contains("**默认执行器**"), "旧文案「默认执行器」段落标题应已移除");
@@ -1473,7 +1473,7 @@ mod tests {
         assert!(!json.contains("点按钮原地操作"), "底部 note 已删除，不应再出现");
     }
 
-    /// 管家执行器按钮排的空列表边界：available_executors 为空时显示占位文案，
+    /// 对话执行器按钮排的空列表边界：available_executors 为空时显示占位文案，
     /// 且不生成任何 act:/setbutlerexecutor 动作（无按钮可点，避免点击空值）。
     #[test]
     fn test_build_help_console_card_workspace_butler_executor_empty_list() {
@@ -1487,7 +1487,7 @@ mod tests {
         assert!(json.contains("暂无已注册执行器"), "空列表应显示占位文案");
         assert!(
             !json.contains("act:/setbutlerexecutor"),
-            "空列表不应生成管家执行器按钮动作"
+            "空列表不应生成对话执行器按钮动作"
         );
     }
 

--- a/backend/src/services/feishu_card_actions.rs
+++ b/backend/src/services/feishu_card_actions.rs
@@ -138,7 +138,8 @@ pub(crate) fn format_record_time(started_at: &str) -> String {
     ) -> ActionOutcome {
         match action {
             CardAction::Push(level) => CardActionHandler::act_push(context, level).await,
-            CardAction::New => CardActionHandler::act_new(context).await,
+            // New 需要 msg 推断会话维度（110：session 按 dm/group 隔离，清对应维度）
+            CardAction::New => CardActionHandler::act_new(context, msg).await,
             CardAction::Stop => CardActionHandler::act_stop(context).await,
             CardAction::Bind(workspace_id) => CardActionHandler::act_bind(context, *workspace_id).await,
             // RunTodo/RunLoop/RunTask 需要回信给点击者，多传 msg 用于解析 receive target
@@ -181,9 +182,12 @@ pub(crate) fn format_record_time(started_at: &str) -> String {
         }
     }
 
-    /// 开启新会话：清当前 workspace 对话执行器的 session（108：session 键是 (workspace, 执行器)，
-    /// 未配置管家时清兜底 claudecode 的 session——清了不存在的 session 无害）。
-    pub(crate) async fn act_new(context: &ListenerMessageContext<'_>) -> ActionOutcome {
+    /// 开启新会话：清当前 workspace 对话执行器的 session（110：session 键是
+    /// (workspace, 执行器, chat 维度)，未配置管家时清兜底 claudecode 的 session——
+    /// 清了不存在的 session 无害）。
+    /// scope 由卡片回调消息推断：channel 非空=群聊（与 resolve_receive_target 同口径），
+    /// 帮助卡片的「新会话」按钮在哪类会话里点就清哪个维度的 session。
+    pub(crate) async fn act_new(context: &ListenerMessageContext<'_>, msg: &ChannelMessage) -> ActionOutcome {
         let Some(wid) = context.db.get_agent_bot_workspace_id(context.bot_id).await.ok().flatten() else {
             return ActionOutcome { success: false, message: "未设置工作空间".to_string() };
         };
@@ -192,8 +196,15 @@ pub(crate) fn format_record_time(started_at: &str) -> String {
         let executor = CardActionHandler::workspace_butler_executor(context.db, context.bot_id)
             .await
             .unwrap_or_else(|| "claudecode".to_string());
-        // set (wid, executor, None)：None 即清除该键，下次对话从全新 session 开始
-        match context.db.set_executor_session(wid, &executor, None).await {
+        // 卡片回调的 chat_type 是 "card_callback" 而非 p2p/group，无法直接喂
+        // from_chat_type——按 resolve_receive_target 的口径从 channel 推断会话类型
+        let scope = if msg.channel.is_empty() {
+            crate::db::workspace::ExecutorSessionScope::Dm
+        } else {
+            crate::db::workspace::ExecutorSessionScope::Group
+        };
+        // set (wid, executor, scope, None)：None 即清除该维度键，下次对话从全新 session 开始
+        match context.db.set_executor_session(wid, &executor, scope, None).await {
             Ok(_) => ActionOutcome { success: true, message: "已开启新会话".to_string() },
             Err(e) => ActionOutcome { success: false, message: format!("失败：{e}") },
         }

--- a/backend/src/services/feishu_card_actions.rs
+++ b/backend/src/services/feishu_card_actions.rs
@@ -43,7 +43,7 @@ pub(crate) fn format_record_time(started_at: &str) -> String {
 
         // cmd: 前缀 - 把卡片点击转成命令执行。
         // 构造一条虚拟命令消息复用 handle_message 的完整分发链路（内置命令 try_route_builtin_command
-        // + 自定义规则/空间管家 route_slash_or_butler），与用户在会话里手动发送该命令效果一致。
+        // + 自定义规则/聊天直连 route_slash_or_butler），与用户在会话里手动发送该命令效果一致。
         if let Some(cmd_text) = CardActionHandler::parse_card_command(action) {
             tracing::info!(
                 "[feishu:{}] card cmd → redispatch as message: {:?}",
@@ -145,13 +145,13 @@ pub(crate) fn format_record_time(started_at: &str) -> String {
             CardAction::RunTodo(todo_id) => CardActionHandler::act_run_todo(context, msg, *todo_id).await,
             CardAction::RunLoop(loop_id) => CardActionHandler::act_run_loop(context, msg, *loop_id).await,
             CardAction::RunTask(task_id) => CardActionHandler::act_run_task(context, msg, *task_id).await,
-            // 管家执行器切换只改配置不执行任务，无需回信目标
+            // 对话执行器切换只改配置不执行任务，无需回信目标
             CardAction::SetButlerExecutor(name) => CardActionHandler::act_set_butler_executor(context, name).await,
         }
     }
 
     /// act 动作执行后刷新到的目标 Tab。
-    /// 设置类动作（绑定/推送/管家执行器）结果落在工作空间页，执行类动作回到各自列表页。
+    /// 设置类动作（绑定/推送/对话执行器）结果落在工作空间页，执行类动作回到各自列表页。
     pub(crate) fn action_target_group(action: &CardAction) -> &'static str {
         match action {
             CardAction::Bind(_) | CardAction::Push(_) | CardAction::SetButlerExecutor(_) => "workspace",
@@ -162,7 +162,7 @@ pub(crate) fn format_record_time(started_at: &str) -> String {
         }
     }
 
-    /// bot 所属 workspace 的管家执行器（如 dev 的 pi）。
+    /// bot 所属 workspace 的对话执行器（如 dev 的 pi）。
     /// 返回 None 表示未配置管家（含空串），调用方按「管家不可用」处理。
     pub(crate) async fn workspace_butler_executor(db: &Database, bot_id: i64) -> Option<String> {
         // bot → workspace 两跳查询；任一跳失败/缺行都折成 None——
@@ -181,7 +181,7 @@ pub(crate) fn format_record_time(started_at: &str) -> String {
         }
     }
 
-    /// 开启新会话：清当前 workspace 管家执行器的 session（108：session 键是 (workspace, 执行器)，
+    /// 开启新会话：清当前 workspace 对话执行器的 session（108：session 键是 (workspace, 执行器)，
     /// 未配置管家时清兜底 claudecode 的 session——清了不存在的 session 无害）。
     pub(crate) async fn act_new(context: &ListenerMessageContext<'_>) -> ActionOutcome {
         let Some(wid) = context.db.get_agent_bot_workspace_id(context.bot_id).await.ok().flatten() else {
@@ -413,9 +413,9 @@ pub(crate) fn format_record_time(started_at: &str) -> String {
         }
     }
 
-    /// 把当前 workspace 的「管家执行器」设为指定 executor（108）。
+    /// 把当前 workspace 的「对话执行器」设为指定 executor（108 修订：单聊/群聊共用）。
     /// 只写 workspace_settings.butler_executor 单字段——默认响应机制已退役，
-    /// 管家执行器是唯一消费该字段的通路，不再有 type 联动。
+    /// 聊天直连是唯一消费该字段的通路，不再有 type 联动。
     /// executor 名必须是已注册的（ExecutorType::as_str），否则视为无效拒绝写入。
     pub(crate) async fn act_set_butler_executor(context: &ListenerMessageContext<'_>, executor_name: &str) -> ActionOutcome {
         let Some(wid) = context.db.get_agent_bot_workspace_id(context.bot_id).await.ok().flatten() else {
@@ -441,7 +441,7 @@ pub(crate) fn format_record_time(started_at: &str) -> String {
         )
         .await
         {
-            Ok(_) => ActionOutcome { success: true, message: format!("管家执行器已设为 {executor_name}") },
+            Ok(_) => ActionOutcome { success: true, message: format!("对话执行器已设为 {executor_name}") },
             Err(e) => ActionOutcome { success: false, message: format!("设置失败：{e}") },
         }
     }
@@ -608,7 +608,7 @@ mod tests {
             CardActionHandler::parse_card_action("act:/push result_only"),
             Some(CardAction::Push("result_only".to_string()))
         );
-        // 管家执行器（108）：新 verb 与旧 verb 别名都要解析为 SetButlerExecutor，
+        // 对话执行器（108）：新 verb 与旧 verb 别名都要解析为 SetButlerExecutor，
         // 旧别名保证历史控制台卡片上的按钮不失效
         assert_eq!(
             CardActionHandler::parse_card_action("act:/setbutlerexecutor pi"),

--- a/backend/src/services/feishu_listener.rs
+++ b/backend/src/services/feishu_listener.rs
@@ -609,11 +609,12 @@ impl FeishuListener {
         });
     }
 
-    /// 阶段 6b：空间管家——所有未命中斜杠命令的消息的统一出口（108）。
+    /// 阶段 6b：聊天直连出口（108 修订）。
     ///
-    /// 已配置管家（butler_executor 非空）→ 推 butler_chat 消息进 debounce，
-    /// 由执行器聊天通路注入管家专家 prompt 后与用户对话；
-    /// 未配置 → 回复配置引导提示。提示不是兜底执行：不触发任何 todo/loop/执行器。
+    /// 单聊（p2p）未命中斜杠 → 与「对话执行器」直聊（dm_chat，不注入专家）；
+    /// 群聊（group）未命中斜杠 → 群聊管家（butler_chat，注入管家专家 prompt）。
+    /// 两者共用 butler_executor 字段选执行器；未配置 → 回复配置引导提示
+    /// （提示不是兜底执行：不触发任何 todo/loop/执行器）。
     async fn dispatch_butler_chat(
         context: &ListenerMessageContext<'_>,
         msg: &ChannelMessage,
@@ -627,7 +628,7 @@ impl FeishuListener {
         if prep.content.is_empty() {
             return;
         }
-        // 管家配置挂在工作空间上：bot 未绑定工作空间时无法路由，
+        // 对话执行器配置挂在工作空间上：bot 未绑定工作空间时无法路由，
         // 提示用户先完成绑定（提示本身不执行任何任务）。
         let workspace_id = match context.db.get_agent_bot_workspace_id(context.bot_id).await {
             Ok(Some(id)) => id,
@@ -641,7 +642,7 @@ impl FeishuListener {
             }
         };
 
-        // 读取工作空间的管家配置；DB 失败与「无配置」对用户同等表现为未配置提示，
+        // 读取工作空间的对话执行器配置；DB 失败与「无配置」对用户同等表现为未配置提示，
         // 但日志里区分出来便于排查。
         let settings = crate::db::workspace_setting::get_workspace_settings(context.db, workspace_id)
             .await
@@ -661,22 +662,33 @@ impl FeishuListener {
                 Some(workspace_id),
                 prep.is_mention,
             ),
-            None => Self::reply_butler_hint(
-                context,
-                msg,
-                prep.chat_type,
-                "🤖 本工作空间尚未配置空间管家，请在工作空间设置中选择管家专家与执行器。",
-            ).await,
+            // 提示语按场景分：单聊配的是「对话执行器」，群聊配的是「群聊管家」——
+            // 用户按收到的提示去找对应的配置项，不混用概念
+            None => {
+                let hint = if prep.chat_type == "p2p" {
+                    "🤖 尚未配置对话执行器，请在工作空间设置中选择执行器后再对话。"
+                } else {
+                    "🤖 本群尚未配置群聊管家，请在工作空间设置中选择管家执行器。"
+                };
+                Self::reply_butler_hint(context, msg, prep.chat_type, hint).await;
+            }
         }
     }
 
-    /// 从工作空间设置解析管家执行器：无设置行 / 字段 NULL / 空串统一视为未配置。
-    /// 抽成纯函数便于单测——dispatch_butler_chat 的「提示 vs 推管家」分支全挂在这个
-    /// 解析结果上，是管家通路的唯一判据。
+    /// 从工作空间设置解析对话执行器：无设置行 / 字段 NULL / 空串统一视为未配置。
+    /// 抽成纯函数便于单测——dispatch_butler_chat 的「提示 vs 直聊」分支全挂在这个
+    /// 解析结果上，是聊天直连通路的唯一判据（108 修订：单聊/群聊共用此执行器）。
     fn resolve_butler_executor(
         settings: Option<crate::db::entity::workspace_settings::Model>,
     ) -> Option<String> {
         settings?.butler_executor.filter(|e| !e.is_empty())
+    }
+
+    /// 聊天直连的 trigger_type 落值（108 修订）：p2p→dm_chat（单聊直聊）、
+    /// 其余（群聊）→butler_chat（群聊管家）。下游 dispatch_execution 据此分流
+    /// 专家注入（仅 butler_chat 注入），消息监控据标签区分两种对话。
+    fn chat_trigger_type(chat_type: &str) -> &'static str {
+        if chat_type == "p2p" { "dm_chat" } else { "butler_chat" }
     }
 
     /// 阶段 6b 的提示回复出口：按 chat_type 解析 receive target 后发文本。
@@ -702,7 +714,9 @@ impl FeishuListener {
         .await;
     }
 
-    /// 阶段 6b-i：把管家聊天消息塞进 debounce
+    /// 阶段 6b-i：把聊天直连消息塞进 debounce（108 修订：单聊/群聊共用）
+    /// trigger_type 按 chat_type 拆分：p2p→dm_chat（纯直聊）、group→butler_chat（管家），
+    /// 消息监控可分开展示两种对话；dispatch_execution 把两者路由到同一 handler。
     #[allow(clippy::too_many_arguments)] // 参数来自上游 handler 的独立数据源，合并为 struct 增加认知负担
     fn debounce_push_butler_chat(
         debounce: &Arc<MessageDebounce>,
@@ -720,10 +734,10 @@ impl FeishuListener {
             chat_type: chat_type.to_string(),
             sender: msg.sender.clone(),
             content: content.to_string(),
-            todo_id: 0, // 管家聊天不绑定 todo
+            todo_id: 0, // 聊天直连不绑定 todo
             todo_prompt: String::new(),
             executor: Some(butler_executor.to_string()),
-            trigger_type: "butler_chat".to_string(),
+            trigger_type: Self::chat_trigger_type(chat_type).to_string(),
             params: None,
             message_id: Some(msg.id.clone()),
             resume_session_id: None,
@@ -931,6 +945,21 @@ mod tests {
             FeishuListener::resolve_butler_executor(Some(settings_with_butler(Some("pi".to_string())))),
             Some("pi".to_string())
         );
+    }
+
+    /// trigger_type 按 chat_type 分流（108 修订核心行为）：p2p→dm_chat、群聊→butler_chat。
+    /// 抽出落值表达式为纯函数，让分流规则可被直接单测（改动词/加场景先改测试）。
+    #[test]
+    fn test_chat_trigger_type_p2p_is_dm_chat() {
+        assert_eq!(FeishuListener::chat_trigger_type("p2p"), "dm_chat");
+    }
+
+    #[test]
+    fn test_chat_trigger_type_group_is_butler_chat() {
+        // 非明确 p2p 一律按群聊处理：飞书 chat_type 只有 p2p/group 两种，
+        // 用 else 分支兜底避免未来新增类型时静默落错 trigger_type
+        assert_eq!(FeishuListener::chat_trigger_type("group"), "butler_chat");
+        assert_eq!(FeishuListener::chat_trigger_type("unknown"), "butler_chat");
     }
 
     #[tokio::test]

--- a/backend/src/services/feishu_slash_commands.rs
+++ b/backend/src/services/feishu_slash_commands.rs
@@ -329,8 +329,10 @@ impl SlashCommandHandler {
             return;
         };
 
-        // 清空执行器 session：设置为 None
-        if let Err(e) = db.set_executor_session(workspace_id, &executor_name, None).await {
+        // 清空执行器 session（110：按 chat 维度清——/new 在哪个会话里发就清哪个维度的
+        // session，单聊 /new 不误伤群聊管家会话，反之亦然）：设置为 None
+        let scope = crate::db::workspace::ExecutorSessionScope::from_chat_type(chat_type);
+        if let Err(e) = db.set_executor_session(workspace_id, &executor_name, scope, None).await {
             tracing::error!("[feishu:{}] /new clear executor session failed: {e}", bot_id);
             FeishuApiClient::send_text(
                 credentials,
@@ -348,10 +350,11 @@ impl SlashCommandHandler {
         }
 
         tracing::info!(
-            "[feishu:{}] /new command: cleared executor session for {}, workspace={}",
+            "[feishu:{}] /new command: cleared executor session for {}, workspace={}, scope={:?}",
             bot_id,
             executor_name,
-            workspace_id
+            workspace_id,
+            scope
         );
         FeishuApiClient::send_text(
             credentials,

--- a/backend/src/services/feishu_slash_commands.rs
+++ b/backend/src/services/feishu_slash_commands.rs
@@ -156,7 +156,7 @@ impl SlashCommandHandler {
     ///
     /// 支持两种场景：
     /// 1. 项目绑定场景：清除绑定的 todo/loop 会话
-    /// 2. 空间管家场景（108）：清除管家执行器的会话
+    /// 2. 聊天直连场景（108 修订）：清除对话执行器的会话
     pub(crate) async fn handle_new(context: FeishuCommandContext<'_>) {
         let FeishuCommandContext {
             db,
@@ -219,7 +219,7 @@ impl SlashCommandHandler {
                 return;
             }
             Ok(None) => {
-                // 没有绑定项目，尝试空间管家场景
+                // 没有绑定项目，尝试聊天直连场景
             }
             Err(e) => {
                 tracing::error!("[feishu:{}] /new query binding failed: {e}", bot_id);
@@ -239,7 +239,7 @@ impl SlashCommandHandler {
             }
         }
 
-        // 空间管家场景：获取 workspace 和管家执行器配置
+        // 聊天直连场景：获取 workspace 和对话执行器配置
         let workspace_id = match db.get_agent_bot_workspace_id(bot_id).await {
             Ok(Some(wid)) => wid,
             Ok(None) => {
@@ -286,7 +286,7 @@ impl SlashCommandHandler {
                     bot_id,
                     &receive_id,
                     receive_id_type,
-                    "📭 尚未配置空间管家，无可清空的会话。",
+                    "📭 尚未配置对话执行器，无可清空的会话。",
                 )
                 .await;
                 if let Some(rid) = reaction_id {
@@ -312,7 +312,7 @@ impl SlashCommandHandler {
             }
         };
 
-        // 未配置管家（含空串）→ 没有可清空的会话，直接提示
+        // 未配置对话执行器（含空串）→ 没有可清空的会话，直接提示
         let Some(executor_name) = settings.butler_executor.filter(|e| !e.is_empty()) else {
             FeishuApiClient::send_text(
                 credentials,
@@ -320,7 +320,7 @@ impl SlashCommandHandler {
                 bot_id,
                 &receive_id,
                 receive_id_type,
-                "📭 尚未配置空间管家，无可清空的会话。",
+                "📭 尚未配置对话执行器，无可清空的会话。",
             )
             .await;
             if let Some(rid) = reaction_id {
@@ -656,23 +656,23 @@ impl SlashCommandHandler {
             .collect()
     }
 
-    /// 当前 workspace 摘要（名 + 管家执行器，108）。
+    /// 当前 workspace 摘要（名 + 对话执行器，108 修订）。
     ///
-    /// 管家执行器展示语义：无设置行 / 字段 NULL / 空串 / DB 读取失败统一显示
-    /// 「未配置管家」。读取失败与显式空值同口径是有意的——这是控制台卡片上的
+    /// 对话执行器展示语义：无设置行 / 字段 NULL / 空串 / DB 读取失败统一显示
+    /// 「未配置」。读取失败与显式空值同口径是有意的——这是控制台卡片上的
     /// 一行展示文案而非路由判据（路由判据在 feishu_listener::resolve_butler_executor，
     /// 失败时走提示分支），为展示文案区分错误态只会让卡片渲染出非预期文案，
     /// 降级为「未配置」既不误导用户也不阻断卡片刷新。
     pub(crate) async fn build_workspace_summary(db: &Database, workspace_id: i64) -> Option<WorkspaceSummary> {
         let name = db.get_workspace_name_by_id(workspace_id).await.ok().flatten()?;
-        // 读失败（ok() 吞掉 Err）与空值同走「未配置管家」占位，理由见函数注释
+        // 读失败（ok() 吞掉 Err）与空值同走「未配置」占位，理由见函数注释
         let executor = crate::db::workspace_setting::get_workspace_settings(db, workspace_id)
             .await
             .ok()
             .flatten()
             .and_then(|s| s.butler_executor)
             .filter(|e| !e.is_empty())
-            .unwrap_or_else(|| "未配置管家".to_string());
+            .unwrap_or_else(|| "未配置".to_string());
         Some(WorkspaceSummary { id: workspace_id, name, executor })
     }
 

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -594,8 +594,11 @@ impl MessageDebounce {
                 )
                 .await
             }
-            // 108：空间管家聊天（原 default_response_executor 的继任者）
-            "butler_chat" => {
+            // 108 修订：单聊直聊（dm_chat）与群聊管家（butler_chat）共用执行器直连通路，
+            // 唯一差异是专家注入——群聊注入 butler_expert_name（管家人设），单聊不注入
+            // （单聊是「我跟执行器说话」的一对一心智，套管家/专家属多余）。
+            // 两个 trigger_type 都路由到同一 handler，由 handler 内按 msg.chat_type 分流。
+            "dm_chat" | "butler_chat" => {
                 let (rid, rtype) = Self::feishu_reply_target(msg);
                 Self::handle_butler_chat(
                     db,
@@ -611,6 +614,9 @@ impl MessageDebounce {
                     msg.workspace_id,
                     merged_content,
                     resolved.resume_session_id.clone(),
+                    // 专家注入判据：仅群聊注入，单聊恒 None（纯执行器对话）
+                    if msg.chat_type == "group" { msg.workspace_id } else { None },
+                    &msg.chat_type,
                 )
                 .await
             }
@@ -1076,7 +1082,7 @@ fn emit_direct_stream(
 /// 用极大 duration 表达「永不超时」，与 todo pipeline 的 `timeout_enabled = v > 0` 对齐）。
 fn read_execution_timeout_secs(config: &Arc<std::sync::RwLock<crate::config::Config>>) -> u64 {
     // 锁中毒=有线程 panic 过，但配置值本身仍可读：恢复内部守卫降级读取，
-    // 不让一次无关 panic 击穿飞书管家聊天链路（生产代码禁 expect，见禁止清单 #1）
+    // 不让一次无关 panic 击穿飞书聊天直连链路（生产代码禁 expect，见禁止清单 #1）
     config
         .read()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -1294,14 +1300,14 @@ async fn persist_executor_session(
 }
 
 // ============================================================================
-// 斜杠规则与空间管家处理器：环路触发（slash_command_loop）与管家聊天（butler_chat）
+// 斜杠规则与聊天直连处理器：环路触发（slash_command_loop）与聊天直连（dm_chat/butler_chat，108 修订共用一个 handler）
 // ============================================================================
 
-/// 读取工作空间的管家专家名（108）。
+/// 读取群聊管家的专家名（108 修订：仅群聊消费）。
 ///
-/// 返回 None 的三种情况——无 workspace_id / 未配置（含空串）/ DB 读取失败——
-/// 对调用方同等含义「不注入专家 prompt」。DB 失败静默降级是有意的：
-/// 专家注入是增强能力，不应因一次读取抖动阻断管家聊天主流程；
+/// 返回 None 的情况——workspace_id 为 None（单聊直聊，调用方传 None 即跳过注入）/
+/// 未配置（含空串）/ DB 读取失败——对调用方同等含义「不注入专家 prompt」。
+/// DB 失败静默降级是有意的：专家注入是增强能力，不应因一次读取抖动阻断聊天主流程；
 /// warn 日志保留排查线索。
 async fn load_butler_expert_name(db: &Database, workspace_id: Option<i64>) -> Option<String> {
     let wid = workspace_id?;
@@ -1387,8 +1393,13 @@ impl MessageDebounce {
         })
     }
 
-    /// 处理空间管家聊天（butler_chat）：执行器对话 + 管家专家 prompt 注入（108）
-    /// 直接调用执行器进行交互，不创建执行记录
+    /// 处理聊天直连（108 修订）：执行器对话，群聊（butler_chat）额外注入管家专家 prompt。
+    ///
+    /// 单聊（dm_chat）= 纯执行器对话：session 连续、流式回推，不注入任何专家；
+    /// 群聊（butler_chat）= 群聊管家：面向多人的共享助手，注入 butler_expert_name
+    /// 定义行为准则。两者共用本 handler，差异收敛在 expert_workspace_id——
+    /// 调用方对单聊传 None（load_butler_expert_name 见 None 直接跳过注入）。
+    /// 直接调用执行器进行交互，不创建执行记录。
     #[allow(clippy::too_many_arguments)] // 参数来自上游 handler 的独立数据源，合并为 struct 增加认知负担
     async fn handle_butler_chat(
         db: &Arc<Database>,
@@ -1404,6 +1415,12 @@ impl MessageDebounce {
         workspace_id: Option<i64>,
         message: &str,
         resume_session_id: Option<String>,
+        // 专家注入的查库维度：群聊传 workspace_id（读管家专家），单聊传 None（跳过注入）。
+        // 与 workspace_id 分开传是因为两者语义不同——执行器运行目录用 workspace_id，
+        // 专家注入开关用本参数，单聊两者恰好一个 Some 一个 None。
+        expert_workspace_id: Option<i64>,
+        // 日志标识用：群聊 "butler_chat" / 单聊 "dm_chat"，便于在 tracing 里区分通路。
+        trigger_label: &str,
     ) -> Result<crate::executor_service::ExecutionResult, Option<String>> {
         let executor_type = executor_type.unwrap_or("claudecode");
 
@@ -1456,17 +1473,20 @@ impl MessageDebounce {
         let mut pipeline = log_capture::create_pipeline_for_executor(executor.as_ref())
             .unwrap_or_else(|| EventPipeline::new(executor.executor_type().as_str()));
         let mut logs: Vec<ParsedLogEntry> = Vec::new();
-        // 管家专家注入（108）：执行时现读 workspace_settings 的 butler_expert_name，
-        // 配置变更立即生效且 PendingMessage 结构零改动；专家未配置/已卸载/读取失败时
-        // inject 原样返回（静默回退），管家退化为纯执行器聊天，不阻断主流程。
+        // 管家专家注入（108 修订：仅群聊）：执行时现读 workspace_settings 的
+        // butler_expert_name，配置变更立即生效且 PendingMessage 结构零改动；
+        // 单聊由调用方传 expert_workspace_id=None，这里天然跳过注入（纯直聊）。
+        // 专家未配置/已卸载/读取失败时 inject 原样返回（静默回退），不阻断主流程。
         // 注入对象是 debounce 合并后的整段消息（多条合并为一次执行，只注入一次），
         // 且只进入发给执行器的文本——上面的开始回执与日志展示的都是用户原文。
-        let butler_expert = load_butler_expert_name(db, workspace_id).await;
+        let butler_expert = load_butler_expert_name(db, expert_workspace_id).await;
         let exec_message = crate::expert::inject_expert_message(
             expert_manager,
             butler_expert.as_deref(),
             message,
-            "butler chat: ",
+            // caller_tag 带 trigger_label：运维日志里区分专家注入失败来自群聊管家还是单聊
+            // （单聊本就不注入，出现该前缀的 warn 只可能来自群聊通路，缩小排查面）
+            &format!("{trigger_label}: "),
         );
         let outcome = DirectExecutorSession::spawn_and_stream(
             SessionSpawnConfig {
@@ -1624,7 +1644,7 @@ mod merge_pending_messages_tests {
     }
 }
 
-/// 飞书管家聊天（butler_chat）的反馈消息格式化与超时运行逻辑测试。
+/// 飞书聊天直连（dm_chat/butler_chat）的反馈消息格式化与超时运行逻辑测试。
 ///
 /// 这组测试覆盖 `handle_butler_chat` 里抽出来的纯逻辑：
 /// 三类飞书反馈消息（开始/错误/空结束）的格式，以及带超时地运行子进程
@@ -2110,16 +2130,28 @@ mod p2p_queue_tests {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod butler_expert_tests {
-    //! 验证管家专家名的读取口径（108）：
-    //! 无 workspace / 无配置行 / 空串 / DB 失败统一返回 None（不注入），
-    //! 只有显式配置了非空专家名才返回 Some。
+    //! 验证群聊管家专家名的读取口径（108 修订）：
+    //! 无 workspace（单聊直聊的调用方式）/ 无配置行 / 空串 / DB 失败统一返回 None
+    //! （不注入），只有显式配置了非空专家名才返回 Some。
+    //! 单聊跳过注入的机制正是「调用方传 None」→ 本函数短路。
     use super::load_butler_expert_name;
     use crate::db::Database;
 
-    /// workspace_id 为 None（如历史遗留消息）→ None，不查库
+    /// workspace_id 为 None（单聊直聊路径：dispatch_execution 对 p2p 传 None）→ None，不查库。
+    /// 这是 108 修订的核心行为锁定：单聊无论管家专家配了什么，都不注入。
     #[tokio::test]
     async fn test_load_butler_expert_name_none_workspace() {
         let db = Database::new(":memory:").await.unwrap();
+        // 预置专家配置，确保「None 跳过」不是因为没配置，而是参数本身短路
+        crate::db::workspace_setting::upsert_workspace_settings(
+            &db,
+            1,
+            Some("workspace-butler".to_string()),
+            Some("claudecode".to_string()),
+            None,
+        )
+        .await
+        .unwrap();
         assert_eq!(load_butler_expert_name(&db, None).await, None);
     }
 

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -616,6 +616,7 @@ impl MessageDebounce {
                     resolved.resume_session_id.clone(),
                     // 专家注入判据：仅群聊注入，单聊恒 None（纯执行器对话）
                     if msg.chat_type == "group" { msg.workspace_id } else { None },
+                    // chat_type 由 handler 派生 session scope 与日志标签（110 修订）
                     &msg.chat_type,
                 )
                 .await
@@ -1191,11 +1192,13 @@ async fn resolve_executor_instance(
 /// 阶段③：确定本次执行使用的 session_id。
 ///
 /// 优先用调用方传入的 resume_session_id（绑定 todo 场景）；否则从 DB 读 workspace
-/// 已保存的 session（私聊多轮对话 resume）。DB 读失败只记日志不致命——降级为新会话。
+/// 已保存的 session（按 chat 维度隔离，110 修订：单聊/群聊互不串扰）。
+/// DB 读失败只记日志不致命——降级为新会话。
 async fn resolve_executor_session(
     db: &Arc<Database>,
     workspace_id: Option<i64>,
     executor_type: &str,
+    scope: crate::db::workspace::ExecutorSessionScope,
     resume_session_id: Option<String>,
 ) -> Option<String> {
     // 调用方显式传入的优先：绑定 todo 等「指明要 resume 某 session」的场景
@@ -1204,7 +1207,7 @@ async fn resolve_executor_session(
     }
     // 否则查 workspace 级别的保存 session；4 个分支全部非致命，最坏降级为 None（新会话）
     let wid = workspace_id?;
-    match db.get_executor_session(wid, executor_type).await {
+    match db.get_executor_session(wid, executor_type, scope).await {
         // 用 Some(&sid) 复刻原实现的日志格式（原日志打印 session_id = Some(sid)）
         Ok(Some(Some(sid))) => {
             tracing::info!(
@@ -1268,12 +1271,14 @@ async fn resolve_direct_output(
 ///
 /// best-effort：提取不到 / 保存失败都只记日志——session 持久化不影响主流程结果。
 /// 调用方仅在 status.success() 时调用。
+/// scope（110 修订）：session 按 chat 维度隔离存储，单聊/群聊互不串扰。
 async fn persist_executor_session(
     db: &Arc<Database>,
     executor: &Arc<dyn crate::adapters::CodeExecutor>,
     logs: &[ParsedLogEntry],
     workspace_id: Option<i64>,
     executor_type: &str,
+    scope: crate::db::workspace::ExecutorSessionScope,
 ) {
     // 没有 workspace_id 无法持久化（session 绑定在 workspace 维度）
     let Some(wid) = workspace_id else {
@@ -1286,13 +1291,14 @@ async fn persist_executor_session(
         return;
     };
     tracing::info!(
-        "[debounce] extracted session_id={} for executor={}, saving to DB",
+        "[debounce] extracted session_id={} for executor={} (scope={:?}), saving to DB",
         new_session_id,
-        executor_type
+        executor_type,
+        scope
     );
-    // 保存失败只 warn：下次私聊会重新开 session，体验退化为非 resume，不阻塞主流程
+    // 保存失败只 warn：下次会重新开 session，体验退化为非 resume，不阻塞主流程
     if let Err(e) = db
-        .set_executor_session(wid, executor_type, Some(new_session_id))
+        .set_executor_session(wid, executor_type, scope, Some(new_session_id))
         .await
     {
         tracing::warn!("[debounce] 保存 executor session 失败: {:?}", e);
@@ -1419,9 +1425,14 @@ impl MessageDebounce {
         // 与 workspace_id 分开传是因为两者语义不同——执行器运行目录用 workspace_id，
         // 专家注入开关用本参数，单聊两者恰好一个 Some 一个 None。
         expert_workspace_id: Option<i64>,
-        // 日志标识用：群聊 "butler_chat" / 单聊 "dm_chat"，便于在 tracing 里区分通路。
-        trigger_label: &str,
+        // 消息来源 chat_type（"p2p"/"group"）：session scope（110 单聊/群聊会话隔离）、
+        // 日志通路标签（dm_chat/butler_chat）都由它派生——一个来源派生两个用途，
+        // 避免调用方分别传 scope/label 两个可漂移参数（review 修复）。
+        chat_type: &str,
     ) -> Result<crate::executor_service::ExecutionResult, Option<String>> {
+        // 派生量集中在此：scope 驱动 session 读写隔离，label 仅用于 tracing 前缀
+        let session_scope = crate::db::workspace::ExecutorSessionScope::from_chat_type(chat_type);
+        let trigger_label = if chat_type == "p2p" { "dm_chat" } else { "butler_chat" };
         let executor_type = executor_type.unwrap_or("claudecode");
 
         // 统一的飞书回复出口：开始/结束/错误三类消息都走 DirectCardMessage，
@@ -1444,7 +1455,7 @@ impl MessageDebounce {
         let executor =
             resolve_executor_instance(executor_registry, executor_type, &send_msg).await?;
         let session_id =
-            resolve_executor_session(db, workspace_id, executor_type, resume_session_id.clone())
+            resolve_executor_session(db, workspace_id, executor_type, session_scope, resume_session_id.clone())
                 .await;
 
         tracing::info!(
@@ -1554,7 +1565,7 @@ impl MessageDebounce {
 
         // ⑧ 成功时持久化 session（best-effort，失败只 warn）
         if outcome.success {
-            persist_executor_session(db, &executor, &logs, workspace_id, executor_type).await;
+            persist_executor_session(db, &executor, &logs, workspace_id, executor_type, session_scope).await;
         }
 
         Ok(crate::executor_service::ExecutionResult {

--- a/docs/design/110-群聊管家-修订设计.md
+++ b/docs/design/110-群聊管家-修订设计.md
@@ -52,9 +52,22 @@
 | `feishu_listener.rs` | `chat_trigger_type()` 纯函数：p2p→`dm_chat`、其余→`butler_chat`；提示语按 chat_type 分流 |
 | `message_debounce.rs` | `dispatch_execution` 双 trigger_type 路由到同一 `handle_butler_chat`；专家注入判据=群聊传 workspace_id、单聊传 None |
 | `models/todo.rs` | `build_trigger_params` 非斜杠返回中性 `"chat"`（dm/butler 区分由 chat_trigger_type 落值） |
+| `db/workspace.rs` | session 键加 chat 维度（review 修复，见下节） |
 | 前端设置面板 | 「空间管家」卡→「对话与群聊管家」：执行器字段在前（共用），专家字段标注「仅群聊生效」 |
-| 前端消息监控 | 标签 `butler_chat`=群聊管家、新增 `dm_chat`=单聊对话；筛选下拉增「单聊对话」（dm 关键字） |
+| 前端消息监控 | 标签 `butler_chat`=群聊管家、新增 `dm_chat`=单聊对话；筛选下拉增「单聊对话」（dm 关键字）；Tag 颜色 map 同步 |
 | 帮助卡片 | 「管家执行器」→「对话执行器」文案与 action 回执同步 |
+
+### 会话按 chat 维度隔离（review 修复）
+
+原 session 键只有 `(workspace, executor)`，单聊与群聊互相 resume 对方会话——110
+语义分家后，群聊管家的专家人设上下文会污染单聊裸会话（或反之）。修复：
+
+- `workspaces.executor_sessions` JSON 键从裸执行器名改为复合键 `dm:<executor>` /
+  `group:<executor>`（`ExecutorSessionScope` enum），DB 列零迁移
+- 读兼容：scoped 键缺失时回退裸键（110 前存量），升级后单聊继续 resume 原会话
+- 写迁移：首次 scoped 写入顺手清裸键，避免后续读取回退旧会话
+- `/new` 与帮助卡片「新会话」按钮按当前会话类型只清对应维度
+- 5 个单测锁定：维度隔离 / 清空只影响本维度 / 裸键回退 / 写时迁移 / from_chat_type 口径
 
 ### 专家注入的分流机制
 

--- a/docs/design/110-群聊管家-修订设计.md
+++ b/docs/design/110-群聊管家-修订设计.md
@@ -1,0 +1,82 @@
+# 110-群聊管家-修订设计
+
+> 目标：修订 108 的「空间管家」概念——管家仅管理**群聊**；单聊未命中斜杠命令时
+> 直接与「对话执行器」对话（纯直聊，不注入专家）。
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI 协作开发者 | 2026-08-16 | 初始版本：108 概念修订（空间管家→群聊管家 + 单聊直聊） |
+
+---
+
+## 1. 背景与问题
+
+108 把所有未命中斜杠的消息（不分单聊/群聊）统一交给「空间管家」：
+`butler_executor` 直聊 + `butler_expert_name` 专家注入。
+
+复盘发现概念错位：
+
+- **单聊套管家多此一举**：单聊是「我跟执行器说话」的一对一心智。`handle_butler_chat`
+  底层本来就是执行器直聊（session 连续、流式回推、`/new` 清会话），「管家」附加的只有
+  专家注入——对单聊没有增加能力，反而让「工作空间要配管家才能聊」多一道心智门槛。
+- **群聊才是管家的正确落点**：群里 bot 是面向多人的共享助手，面对多样消息需要专家
+  规则定义行为（该回应什么、不该回应什么、收到特定内容做什么），这才是「管家」语义。
+- **webhook 无涉**：todo webhook 是「明确具体事项」的触发，与聊天零重叠，不动；
+  环路 webhook 已在 044 删除（端点返回 410 Gone），无需再处理。
+
+## 2. 修订后的路由模型
+
+```
+飞书消息
+ ├─ 内置斜杠命令（精确匹配）→ 照旧
+ ├─ 自定义斜杠规则（精确匹配）→ 照旧
+ └─ 未命中（含未知 /xxx）
+     ├─ 单聊（p2p）  → dm_chat：与「对话执行器」纯直聊（不注入专家）
+     └─ 群聊（group）→ butler_chat：群聊管家（专家人设 + 执行器）
+```
+
+| 维度 | 单聊 dm_chat | 群聊 butler_chat |
+|------|-------------|-----------------|
+| 执行器 | `butler_executor`（共用字段） | `butler_executor`（共用字段） |
+| 专家注入 | 恒不注入 | 注入 `butler_expert_name`（可选） |
+| 会话连续 | ✅ resume | ✅ resume |
+| 未配置执行器 | 提示「尚未配置对话执行器」 | 提示「本群尚未配置群聊管家」 |
+
+## 3. 实现要点（DB 零改动）
+
+列名与字段复用，只收窄语义——`butler_executor` 改称「对话执行器」（单聊/群聊共用），
+`butler_expert_name` 收窄为「仅群聊注入」。无迁移、无 API 字段变更。
+
+| 文件 | 改动 |
+|------|------|
+| `feishu_listener.rs` | `chat_trigger_type()` 纯函数：p2p→`dm_chat`、其余→`butler_chat`；提示语按 chat_type 分流 |
+| `message_debounce.rs` | `dispatch_execution` 双 trigger_type 路由到同一 `handle_butler_chat`；专家注入判据=群聊传 workspace_id、单聊传 None |
+| `models/todo.rs` | `build_trigger_params` 非斜杠返回中性 `"chat"`（dm/butler 区分由 chat_trigger_type 落值） |
+| 前端设置面板 | 「空间管家」卡→「对话与群聊管家」：执行器字段在前（共用），专家字段标注「仅群聊生效」 |
+| 前端消息监控 | 标签 `butler_chat`=群聊管家、新增 `dm_chat`=单聊对话；筛选下拉增「单聊对话」（dm 关键字） |
+| 帮助卡片 | 「管家执行器」→「对话执行器」文案与 action 回执同步 |
+
+### 专家注入的分流机制
+
+`dispatch_execution` 在调用 `handle_butler_chat` 时按 `msg.chat_type` 决定
+`expert_workspace_id`：群聊传 `workspace_id`（查管家专家），单聊传 `None`
+（`load_butler_expert_name` 见 None 直接短路，不查库不注入）。
+用参数而非在 handler 里再判 chat_type，是为了让「单聊不注入」成为调用侧的显式决策，
+handler 保持纯粹的注入执行。
+
+## 4. 测试
+
+- `test_chat_trigger_type_p2p_is_dm_chat` / `test_chat_trigger_type_group_is_butler_chat`：
+  分流规则锁定（含未知 chat_type 兜底群聊的边界）
+- `test_load_butler_expert_name_none_workspace`：预置专家配置下 None 仍不注入——
+  锁定「单聊跳过注入是参数短路，不是没配置」
+- `build_trigger_params` 测试更新：非斜杠返回 `"chat"`
+- 既有 `resolve_butler_executor` 四测不变（执行器解析口径未动）
+
+## 5. 影响面
+
+- 单聊用户可感知变化：原「空间管家」人设不再注入单聊（如需人设，群聊或 todo 执行
+  时的专家绑定仍可用）；对话本身行为不变（同一执行器、同一会话）。
+- 群聊用户无变化。
+- 运维可观测性：tracing 中专家注入 warn 前缀带 `dm_chat:`/`butler_chat:` 区分通路。
+- 消息监控新增 `dm` 筛选关键字；`butler` 关键字继续匹配 `butler_chat`。

--- a/docs/testing/108-空间管家-测试.md
+++ b/docs/testing/108-空间管家-测试.md
@@ -3,8 +3,12 @@
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | Claude | 2026-08-16 | 初始版本 |
+| Claude | 2026-08-16 | 110 修订同步：空间管家→群聊管家，断言描述对齐现行实现 |
 
 > 对应需求：`docs/requirements/108-空间管家-需求.md`；设计：`docs/design/108-空间管家-设计.md`
+> ⚠️ 110 修订（`docs/design/110-群聊管家-修订设计.md`）：管家概念收窄为**仅群聊**——
+> 单聊未命中斜杠改为 `dm_chat` 纯执行器直聊（不注入专家）；`butler_executor` 改称
+> 「对话执行器」（单聊/群聊共用）。下表描述已按修订后口径更新。
 
 ---
 
@@ -16,13 +20,14 @@
 | `test_v95_carry_does_not_overwrite_existing_butler_executor` | `db/migration/v95.rs` | 承接不覆盖已写入的新值 |
 | `test_v95_is_idempotent_on_fresh_db` | `db/migration/v95.rs` | 全新库重跑幂等跳过 |
 | `test_consolidated_schema_matches_incremental` | `db/mod.rs` | 合并 schema 与增量链漂移守卫（随 V95 更新） |
-| `test_upsert_butler_fields_roundtrip_and_clear` | `db/workspace_setting.rs` | 管家字段写入/None 保持/空串清空 |
+| `test_upsert_workspace_settings_butler_fields_roundtrip_and_clear` | `db/workspace_setting.rs` | 管家字段写入/None 保持/空串清空 |
 | `test_update_workspace_delegate_max_rounds_*` | `db/workspace_setting.rs` | 新建行不再带默认响应类型默认值 |
-| `test_load_butler_expert_*`（4 个） | `services/message_debounce.rs` | 管家专家读取：无 workspace/无行/已配置/空串 |
-| `test_resolve_butler_executor_*`（4 个） | `services/feishu_listener.rs` | 管家执行器解析纯函数：无设置行/NULL/空串/已配置——dispatch_butler_chat 的「提示 vs 推管家」分支判据 |
-| `test_parse_card_action` 系列 | `services/feishu_card_actions.rs` | act:/setbutlerexecutor 解析 + 旧 verb setexecutor 别名兼容 |
-| `test_build_trigger_params_butler_chat` | `models/mod.rs` | 非斜杠内容 trigger_type = butler_chat |
-| `test_build_help_console_card_workspace_butler_executor_label` | `services/feishu_card.rs` | 卡片「管家执行器」文案 + act:/setbutlerexecutor 按钮 |
+| `test_load_butler_expert_name_*`（4 个） | `services/message_debounce.rs` | 群聊管家专家读取：None 短路（单聊路径，预置配置下仍不注入）/无行/已配置/空串 |
+| `test_resolve_butler_executor_*`（4 个） | `services/feishu_listener.rs` | 对话执行器解析纯函数：无设置行/NULL/空串/已配置——dispatch_butler_chat 的「提示 vs 直聊」分支判据 |
+| `test_chat_trigger_type_p2p_is_dm_chat` / `test_chat_trigger_type_group_is_butler_chat` | `services/feishu_listener.rs` | 110 修订核心分流：p2p→dm_chat、群聊（含未知类型兜底）→butler_chat |
+| `test_parse_card_action` 系列 | `services/feishu_card_actions.rs` | act:/setbutlerexecutor 解析 + 旧 verb setexecutor 别名兼容 + 缺参拒绝 |
+| `test_build_trigger_params_chat` | `models/mod.rs` | 非斜杠内容返回中性 "chat"（dm/butler 区分由 chat_trigger_type 落值） |
+| `test_build_help_console_card_workspace_butler_executor_label` | `services/feishu_card.rs` | 卡片「对话执行器」文案 + act:/setbutlerexecutor 按钮 |
 | `parse_slash_command` 既有测试 | `services/feishu_listener.rs` | 斜杠解析精确匹配（保持不变） |
 
 ## 2. 质量门禁（执行结果）
@@ -30,7 +35,7 @@
 | 门禁 | 结果 |
 |------|------|
 | `cargo clippy --all-targets -- -D warnings` | ✅ 零告警零错误 |
-| `cargo test`（lib + 全部集成套件） | ✅ 1765 passed, 0 failed |
+| `cargo test`（lib + 全部集成套件） | ✅ 1776 passed, 0 failed（110 修订后） |
 | `cd frontend && npx tsc --noEmit` | ✅ 零错误 |
 | `cd frontend && npm run build` | ✅ 构建成功（无新增告警） |
 | 内置专家包校验（validate_expert.py） | ✅ workspace-butler 合法 |
@@ -43,10 +48,11 @@
 | 2 | 内置管家专家加载 | `GET /api/v1/experts` | ✅ 返回 workspace-butler |
 | 3 | 设置 API 读写 | PUT 管家专家+执行器 → GET 回读 | ✅ butler_expert_name/butler_executor 持久化；空串=清空 |
 | 4 | SmartCreate 路由移除 | `POST /api/v1/workspaces/2/todos/smart` | ✅ 405（路由不存在） |
-| 5 | 管家配置面板 | agent-browser 打开 消息→配置 抽屉 | ✅ 「空间管家」卡渲染：专家下拉可选中 workspace-butler、执行器可选、保存后重开回显正确 |
-| 6 | 历史消息标签 | 消息监控台历史消息 | ✅ 旧 `default_response_executor` 消息仍显示「默认响应-执行器」（历史保留） |
+| 5 | 配置面板（110 修订后） | agent-browser 打开 消息→配置 抽屉 | ✅ 「对话与群聊管家」卡渲染：对话执行器在前（单聊/群聊共用）、群聊管家专家标注仅群聊生效、保存后重开回显正确 |
+| 6 | 历史消息标签 | 消息监控台历史消息 | ✅ 旧 `default_response_executor` 消息仍显示「默认响应-执行器」（历史保留）；110 后新消息按 dm_chat（单聊对话）/butler_chat（群聊管家）分标 |
+| 7 | 消息筛选（110 修订后） | 消息监控处理类型下拉 + API | ✅ 下拉含「群聊管家/单聊对话」；`processed_type=dm`/`butler` LIKE 匹配正常 |
 
 ## 4. 未覆盖项与说明
 
-- **真实飞书消息四连测**（精确斜杠/未命中斜杠/普通消息/未配管家）：依赖真实飞书 bot 收发，本环境无法自动化；路由逻辑已由单测覆盖（parse 精确匹配、dispatch 分支、未配置提示分支），建议在带 bot 的环境人工回归一轮。
-- **管家真实对话质量**（专家 prompt 注入后的 AI 行为）：属模型行为层，需在配置管家的工作空间里实际对话观察。
+- **真实飞书消息四连测**（精确斜杠/未命中斜杠/普通消息/未配管家）：依赖真实飞书 bot 收发，本环境无法自动化；路由逻辑已由单测覆盖（parse 精确匹配、dispatch 分支、chat_trigger_type 分流、未配置提示分支），建议在带 bot 的环境人工回归一轮。
+- **管家真实对话质量**（专家 prompt 注入后的 AI 行为）：属模型行为层，需在配置管家的工作空间里实际对话观察。注意 110 后仅群聊注入专家，单聊为纯执行器对话。

--- a/frontend/src/components/message-monitor/MessageCard.tsx
+++ b/frontend/src/components/message-monitor/MessageCard.tsx
@@ -9,7 +9,8 @@ const { Text } = Typography;
 const processedTypeLabel = (type: string | null): string => {
   const map: Record<string, string> = {
     // 108：butler_chat 为现行值；default_response* 为历史值（默认响应机制已退役）
-    'butler_chat': '空间管家',
+    'butler_chat': '群聊管家',
+    'dm_chat': '单聊对话',
     'default_response': '默认响应-事项',
     'default_response_executor': '默认响应-执行器',
     'default_response_loop': '默认响应-环路',

--- a/frontend/src/components/message-monitor/MessageCard.tsx
+++ b/frontend/src/components/message-monitor/MessageCard.tsx
@@ -26,6 +26,9 @@ const processedTypeColor = (type: string | null): string => {
     // butler_chat 沿用 purple：与历史 default_response_executor（同为执行器直聊）视觉连续，
     // 用户看旧消息/新消息不需要重新建立颜色心智
     'butler_chat': 'purple',
+    // dm_chat（108 修订：单聊纯直聊）同属执行器直聊族，用 blue 与群聊 purple 区分——
+    // 单聊/群聊是两种对话场景，颜色区分让消息流里一眼可辨
+    'dm_chat': 'blue',
     'default_response': 'default',
     'default_response_executor': 'purple',
     'default_response_loop': 'cyan',

--- a/frontend/src/components/message-monitor/MessageConfigDrawer.tsx
+++ b/frontend/src/components/message-monitor/MessageConfigDrawer.tsx
@@ -31,7 +31,7 @@ export function MessageConfigDrawer({ open, workspaceId, onClose, onChanged }: M
         <Divider style={{ margin: '16px 0' }} />
 
         <div style={{ marginBottom: 16 }}>
-          <h4 style={{ margin: '0 0 12px', fontSize: 14, fontWeight: 500 }}>空间管家</h4>
+          <h4 style={{ margin: '0 0 12px', fontSize: 14, fontWeight: 500 }}>对话与群聊管家</h4>
           <WorkspaceSettingsPanel
             workspaceId={workspaceId}
             onChanged={onChanged}

--- a/frontend/src/components/message-monitor/MessageDetailDrawer.tsx
+++ b/frontend/src/components/message-monitor/MessageDetailDrawer.tsx
@@ -8,7 +8,8 @@ const processedTypeLabel = (type: string | null): string => {
   const map: Record<string, string> = {
     // butler_chat 是 108 起的现行处理类型；default_response* 是 108 前历史值，
     // 仅为 DB 存量消息的展示保留（与 MessageCard 的映射保持同键同文案）
-    'butler_chat': '空间管家',
+    'butler_chat': '群聊管家',
+    'dm_chat': '单聊对话',
     'default_response': '默认响应-事项',
     'default_response_executor': '默认响应-执行器',
     'default_response_loop': '默认响应-环路',

--- a/frontend/src/components/message-monitor/MessageTimeline.tsx
+++ b/frontend/src/components/message-monitor/MessageTimeline.tsx
@@ -125,12 +125,14 @@ export function MessageTimeline({
             { value: 'all', label: '全部类型' },
             // 匹配 slash_command / slash_command_loop（斜杠规则显式触发）
             { value: 'slash', label: '斜杠命令' },
-            // 匹配 butler_chat：108 起非斜杠消息的现行处理类型
-            { value: 'butler', label: '空间管家' },
+            // 匹配 butler_chat：群聊管家（108 修订：仅群聊消息走管家）
+            { value: 'butler', label: '群聊管家' },
+            // 匹配 dm_chat：单聊直聊（108 修订：单聊未命中斜杠=纯执行器对话，无专家）
+            { value: 'dm', label: '单聊对话' },
             // 匹配 *_loop：包含斜杠环路与 108 前的默认响应环路历史值
             { value: 'loop', label: '环路' },
-            // 匹配 default_response_executor（108 前历史值）——现行执行器聊天是
-            // butler_chat，归入「空间管家」；本项仅为查询旧库存量消息保留
+            // 匹配 default_response_executor（108 前历史值）——现行聊天是 dm_chat/
+            // butler_chat；本项仅为查询旧库存量消息保留
             { value: 'executor', label: '执行器(历史)' },
           ]}
         />

--- a/frontend/src/components/settings/executors/RunningRecordsTable.tsx
+++ b/frontend/src/components/settings/executors/RunningRecordsTable.tsx
@@ -16,7 +16,8 @@ import type { UseRunningRecordsReturn } from '@/hooks/useRunningRecords';
 const triggerTypeMap: Record<string, string> = {
   manual: '手动',
   slash_command: '斜杠命令',
-  butler_chat: '空间管家',
+  butler_chat: '群聊管家',
+  dm_chat: '单聊对话',
   default_response: '默认响应',
   scheduler: '定时',
 };

--- a/frontend/src/components/settings/workspace/WorkspaceSettingsPanel.tsx
+++ b/frontend/src/components/settings/workspace/WorkspaceSettingsPanel.tsx
@@ -17,9 +17,9 @@ interface WorkspaceSettingsPanelProps {
   onChanged?: () => void;
 }
 
-// 108 空间管家：本面板承载工作空间级设置——管家配置（专家+执行器）、
-// 委派接力上限、历史消息处理与拉取群。默认响应机制（todo/loop/executor 三选一）
-// 已整体退役，未命中斜杠命令的消息统一由空间管家处理。
+// 108 修订（群聊管家）：本面板承载工作空间级设置——对话执行器（单聊直聊/群聊管家共用）、
+// 群聊管家专家（仅群聊注入）、委派接力上限、历史消息处理与拉取群。
+// 默认响应机制（todo/loop/executor 三选一）已整体退役，未命中斜杠命令的消息进聊天直连。
 export function WorkspaceSettingsPanel({ workspaceId, onChanged }: WorkspaceSettingsPanelProps) {
   const [experts, setExperts] = useState<ExpertMetadata[]>([]);
   const [loading, setLoading] = useState(false);
@@ -153,21 +153,34 @@ export function WorkspaceSettingsPanel({ workspaceId, onChanged }: WorkspaceSett
 
   return (
     <>
-      <Card size="small" loading={loading} title="空间管家">
+      <Card size="small" loading={loading} title="对话与群聊管家">
         <Paragraph type="secondary" style={{ marginBottom: 16, fontSize: 13 }}>
-          未命中斜杠命令的消息由空间管家处理：管家 = 专家（人设与规则，可选）+ 执行器（实际对话进程）。
-          不配专家则管家是纯执行器聊天；不配执行器则消息收到配置引导提示。
+          未命中斜杠命令的消息进聊天直连：单聊直接与「对话执行器」对话（多轮会话）；
+          群聊由「群聊管家」处理——管家 = 专家（人设与规则，仅群聊生效，可选）+ 执行器。
+          不配执行器时，未命中消息收到配置引导提示。
         </Paragraph>
         <Form form={form} layout="vertical">
           <Form.Item
+            name="butler_executor"
+            label="对话执行器"
+            tooltip="单聊直聊与群聊管家共用的执行进程；不配置时，未命中斜杠命令的消息将收到配置引导提示"
+          >
+            <ExecutorPicker
+              executor={executorValue || ''}
+              executorOptions={EXECUTORS_FOR_PICKER}
+              onChange={v => form.setFieldValue('butler_executor', v)}
+            />
+          </Form.Item>
+
+          <Form.Item
             name="butler_expert_name"
-            label="管家专家"
-            tooltip="为管家注入专家的人设与行为规则；不选则管家退化为纯执行器聊天"
+            label="群聊管家专家"
+            tooltip="仅群聊生效：为群聊管家注入专家的人设与行为规则；单聊始终是纯执行器对话，不读此配置"
           >
             <Select
               showSearch
               allowClear
-              placeholder="选择管家专家（可选）"
+              placeholder="选择群聊管家专家（可选，仅群聊生效）"
               filterOption={(input, option) =>
                 // label 拼上专家 ID：显示名是中文时可按英文 ID 搜（反之亦然）
                 (option?.label as string)?.toLowerCase().includes(input.toLowerCase())
@@ -184,18 +197,6 @@ export function WorkspaceSettingsPanel({ workspaceId, onChanged }: WorkspaceSett
                 </Select.Option>
               ))}
             </Select>
-          </Form.Item>
-
-          <Form.Item
-            name="butler_executor"
-            label="管家执行器"
-            tooltip="管家对话使用的执行器；不配置时，未命中斜杠命令的消息将收到配置引导提示"
-          >
-            <ExecutorPicker
-              executor={executorValue || ''}
-              executorOptions={EXECUTORS_FOR_PICKER}
-              onChange={v => form.setFieldValue('butler_executor', v)}
-            />
           </Form.Item>
 
           {/* 委派接力上限（需求 092）：工作空间级默认，任务级可单独覆盖。 */}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -136,12 +136,14 @@ export const TRIGGER_LABELS: Record<string, string> = {
 };
 
 /** 触发类型颜色（独立于 STATUS_COLORS，值碰巧相同但语义不同）。
- *  与 TRIGGER_LABELS 同键共用：粉色 #ec4899 与历史执行器聊天色系区分。 */
+ *  与 TRIGGER_LABELS 同键共用：粉色 #ec4899 与历史执行器聊天色系区分；
+ *  蓝色 #3b82f6 单聊直聊（dm_chat 当前不落 execution_records，键为防御性对齐 labels）。 */
 export const TRIGGER_COLORS: Record<string, string> = {
   manual: '#3b82f6',
   cron: '#8b5cf6',
   slash_command: '#f59e0b',
   butler_chat: '#ec4899',
+  dm_chat: '#3b82f6',
   default_response: '#22c55e',
 };
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -130,7 +130,8 @@ export const TRIGGER_LABELS: Record<string, string> = {
   manual: '手动',
   cron: '定时',
   slash_command: '命令',
-  butler_chat: '空间管家',
+  butler_chat: '群聊管家',
+  dm_chat: '单聊对话',
   default_response: '默认回复',
 };
 

--- a/frontend/src/utils/database/bots.ts
+++ b/frontend/src/utils/database/bots.ts
@@ -55,7 +55,7 @@ export interface UpdateWorkspaceSlashCommandParams {
 
 export interface WorkspaceSettings {
   workspace_id: number;
-  // 空间管家（108）：专家名（空=纯执行器聊天）+ 执行器（空=未配置管家）
+  // 聊天直连（108 修订）：专家名（仅群聊注入，空=群聊无专家人设）+ 执行器（单聊/群聊共用，空=未配置）
   butler_expert_name: string | null;
   butler_executor: string | null;
   // 工作空间级共识 prompt（需求 022）：该 workspace 下所有 todo 执行时作为前置 prompt 注入。
@@ -69,7 +69,7 @@ export interface WorkspaceSettings {
 }
 
 export interface UpdateWorkspaceSettingsParams {
-  // 空间管家（108）：传值（含空串=清空）覆写，不传保持原值。
+  // 聊天直连（108 修订）：传值（含空串=清空）覆写，不传保持原值。
   butler_expert_name?: string;
   butler_executor?: string;
   // 工作空间级共识 prompt：传入则覆写，不传则保持原值。


### PR DESCRIPTION
## 实现了什么

修订 108 的「空间管家」概念——**管家仅管理群聊**；单聊未命中斜杠命令时直接与「对话执行器」纯直聊（不注入专家）。

### 概念修正动因（108 复盘）

- **单聊套管家多此一举**：单聊是「我跟执行器说话」的一对一心智。`handle_butler_chat` 底层本来就是执行器直聊（session 连续、流式回推、`/new` 清会话），「管家」附加的只有专家注入——对单聊没增加能力，反而多一道「配管家才能聊」的心智门槛
- **群聊才是管家的正确落点**：群里 bot 是面向多人的共享助手，需要专家规则定义行为（该回应什么、收到特定内容做什么）
- **webhook 无涉**：todo webhook=明确事项触发不动；环路 webhook 已在 044 删除（410 Gone）

### 修订后路由模型

```
飞书消息
 ├─ 内置斜杠命令（精确匹配）→ 照旧
 ├─ 自定义斜杠规则（精确匹配）→ 照旧
 └─ 未命中（含未知 /xxx）
     ├─ 单聊（p2p）  → dm_chat：与「对话执行器」纯直聊（不注入专家）
     └─ 群聊（group）→ butler_chat：群聊管家（专家人设 + 执行器）
```

## 与需求的对应关系

设计文档 `docs/design/110-群聊管家-修订设计.md`（含概念修正完整论证）。

## 实现要点（DB 零改动，字段语义收窄）

- `butler_executor` 改称「对话执行器」：单聊直聊/群聊管家共用
- `butler_expert_name` 收窄为「仅群聊注入」：dispatch_execution 对 p2p 传 None，`load_butler_expert_name` 见 None 短路
- `chat_trigger_type()` 纯函数分流 trigger_type（p2p→dm_chat / group→butler_chat）
- 前端设置面板重组：对话执行器在前 + 群聊管家专家标注「仅群聊生效」
- 消息监控：新增 dm_chat=单聊对话标签与 dm 筛选关键字

## 测试与验证

- `cargo clippy --all-targets -- -D warnings`：零告警
- `cargo test` 全套通过（lib 1776，含 +2 新测试：chat_trigger_type 分流锁定、None 短路强化为预置专家下仍不注入）
- `npx tsc --noEmit` 零错误；`npx vitest run` 439 通过
- agent-browser 实测：设置面板「对话与群聊管家」卡渲染正确（执行器在前、专家标注仅群聊）、消息监控筛选下拉「群聊管家|单聊对话」、dm/butler 筛选 API LIKE 匹配正常

## 对用户的可感知变化

- 单聊：原「空间管家」人设不再注入（对话本身行为不变——同一执行器、同一会话）
- 群聊：无变化
