### PR TITLE
feat(112): running 视图顶栏接入搜索框与时间过滤（与卡片/列表同款同位置）

### DIFF
--- a/docs/design/112-事项执行监控时间过滤-设计.md
+++ b/docs/design/112-事项执行监控时间过滤-设计.md
@@ -3,6 +3,7 @@
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | AI | 2026-08-17 | 初始版本 |
+| AI | 2026-08-17 | 增加 running 搜索框接线（searchText 透传 RunningBoard） |
 
 > 对应需求：`docs/requirements/112-事项执行监控时间过滤-需求.md`
 
@@ -19,45 +20,49 @@
 2. **数据链路**：`TodoListPage` 把页级 `hours` state 透传给 `RunningBoard`。
 
 ```text
-TodoListPage（页级 state hours: number | null = null，111 已有）
+TodoListPage（页级 state hours: number | null = null、searchKeyword: string = ''，111 已有）
  ├─ TodoListHeader
  │    card/list 桌面态：搜索 → 时间分段 → 刷新 → 视图切换器 → 新建（现状不动）
- │    running 桌面态：时间分段 → 视图切换器 → 新建（本次新增时间分段）
+ │    running 桌面态：搜索 → 时间分段 → 视图切换器 → 新建（本次新增搜索框 + 时间分段）
  │    移动端：仅视图切换器 + 新建（现状不动）
- └─ running 分支：<RunningBoard hours={hours ?? undefined} />
-      └─ useRunningBoard(ws, hours)
-           └─ getRunningBoardData(ws, undefined, 200, hours) → GET .../running-board?hours=N
-      └─ filteredRecords：终态记录按 started_at/finished_at 收窗、运行中恒显（现状不动）
+ └─ running 分支：
+      <RunningBoard searchText={searchKeyword.trim() || undefined} hours={hours ?? undefined} />
+      ├─ filteredRecords：searchText 按 todo 标题/模型/执行器过滤（现状不动）
+      │                    hours 终态记录按 started_at/finished_at 收窗、运行中恒显（现状不动）
+      └─ filteredScheduledTodos：searchText 按标题/Prompt 过滤（现状不动）
+           useRunningBoard(ws, hours) → getRunningBoardData(ws, undefined, 200, hours)
 ```
 
 ### 位置一致性说明
 
-- 卡片/列表桌面态顺序：搜索 → **时间分段** → 刷新 → 视图切换器 → 新建。
-- running 桌面态顺序：**时间分段** → 视图切换器 → 新建。
-- running 无搜索框（RunningBoard 暂无搜索接线需求）与刷新按钮（统计栏自带刷新 + 实时 WS），
-  因此时间分段自然成为视图切换器左侧的第一项，槽位与卡片/列表一致。
+- 卡片/列表桌面态顺序：搜索 → 时间分段 → 刷新 → 视图切换器 → 新建。
+- running 桌面态顺序：搜索 → 时间分段 → 视图切换器 → 新建。
+- running 无刷新按钮（统计栏自带刷新 + 实时 WS），因此搜索与时间分段之后直接是视图切换器，
+  与卡片/列表的前两个槽位完全一致。
 
 ## 2. 改动文件
 
 | 文件 | 改动 |
 |------|------|
-| `frontend/src/components/todo-list/TodoListPageParts.tsx` | `TodoListHeader` 分支调整：isMobile 精简分支不变；running 桌面态新增时间分段；props 注释更新 |
-| `frontend/src/components/todo-list/TodoListPage.tsx` | running 分支传 `hours` 给 `RunningBoard`；hours state 注释更新 |
-| `frontend/src/components/todo-list/TodoListPage.test.tsx` | RunningBoard mock 增加 hours 渲染；running 用例改为断言渲染时间分段 + hours 透传 |
+| `frontend/src/components/todo-list/TodoListPageParts.tsx` | `TodoListHeader` 分支调整：isMobile 精简分支不变；running 桌面态新增搜索框 + 时间分段；props 注释更新 |
+| `frontend/src/components/todo-list/TodoListPage.tsx` | running 分支传 `searchText`/`hours` 给 `RunningBoard`；state 注释更新 |
+| `frontend/src/components/todo-list/TodoListPage.test.tsx` | RunningBoard mock 增加 searchText/hours 渲染；running 用例断言搜索框 + 时间分段渲染及透传 |
 | `frontend/tests/check_112_running_time_filter.spec.ts` | Playwright 回归用例（running 时间分段渲染、同槽位、切换生效） |
 
 不改动：`RunningBoard` / `useRunningBoard` / `getRunningBoardData` / 后端（零改动）。
 
 ## 3. 关键实现点
 
-- **null→undefined 归一**：`RunningBoard` 的 props 类型是 `hours?: number`，
-  而页级 state 是 `number | null`，透传时必须 `hours ?? undefined`，
+- **空值归一**：`RunningBoard` 的 props 类型是 `searchText?: string`/`hours?: number`，
+  而页级 state 是 `string`/`number | null`，透传时 `searchKeyword.trim() || undefined` 与
+  `hours ?? undefined`——空白搜索词与 null 时间窗都归一为 undefined（=不过滤），
   避免 null 值破坏 `useRunningBoard` 的 `latestHoursRef` 比较与 `getRunningBoardData` 的参数语义。
-- **过滤语义复用**：RunningBoard 的 `filteredRecords` 已有窗口逻辑
-  （`hours && hours > 0` 时对终态记录按 started_at/finished_at 与 cutoff 比较，运行中恒显），
-  本次不复制、不修改，只喂入 hours。
-- **三形态共享 state**：hours 仍由 `TodoListPage` 持有并传给 header，
-  running ↔ card/list 互切时时间窗自然保持，无需新增同步逻辑。
+- **过滤语义复用**：RunningBoard 的 `filteredRecords`/`filteredScheduledTodos` 已有
+  搜索与窗口逻辑（`searchText?.trim()` 按 todo 标题/模型/执行器、定时任务标题/Prompt 过滤；
+  `hours && hours > 0` 时对终态记录按 started_at/finished_at 与 cutoff 比较，运行中恒显），
+  本次不复制、不修改，只喂入 searchText/hours。
+- **三形态共享 state**：hours 与 searchKeyword 仍由 `TodoListPage` 持有并传给 header，
+  running ↔ card/list 互切时自然保持，无需新增同步逻辑。
 
 ## 4. 测试设计
 

--- a/docs/design/112-事项执行监控时间过滤-设计.md
+++ b/docs/design/112-事项执行监控时间过滤-设计.md
@@ -1,0 +1,80 @@
+# 112-事项执行监控时间过滤-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08-17 | 初始版本 |
+
+> 对应需求：`docs/requirements/112-事项执行监控时间过滤-需求.md`
+
+---
+
+## 1. 设计总览
+
+需求 111 在事项页接时间过滤时，把 running（执行监控）形态列为了非目标，
+但 `RunningBoard` 组件的 `hours` prop 与后端 running-board 接口的 hours 参数**当时就已存在**。
+本需求不需要任何新能力，只需接通两条既有链路：
+
+1. **渲染链路**：`TodoListHeader` 的 running 分支（桌面端）渲染 `TimeRangeSegmented showAll`，
+   放在视图切换器左侧——与卡片/列表形态「时间分段在视图切换器之前」的槽位一致。
+2. **数据链路**：`TodoListPage` 把页级 `hours` state 透传给 `RunningBoard`。
+
+```text
+TodoListPage（页级 state hours: number | null = null，111 已有）
+ ├─ TodoListHeader
+ │    card/list 桌面态：搜索 → 时间分段 → 刷新 → 视图切换器 → 新建（现状不动）
+ │    running 桌面态：时间分段 → 视图切换器 → 新建（本次新增时间分段）
+ │    移动端：仅视图切换器 + 新建（现状不动）
+ └─ running 分支：<RunningBoard hours={hours ?? undefined} />
+      └─ useRunningBoard(ws, hours)
+           └─ getRunningBoardData(ws, undefined, 200, hours) → GET .../running-board?hours=N
+      └─ filteredRecords：终态记录按 started_at/finished_at 收窗、运行中恒显（现状不动）
+```
+
+### 位置一致性说明
+
+- 卡片/列表桌面态顺序：搜索 → **时间分段** → 刷新 → 视图切换器 → 新建。
+- running 桌面态顺序：**时间分段** → 视图切换器 → 新建。
+- running 无搜索框（RunningBoard 暂无搜索接线需求）与刷新按钮（统计栏自带刷新 + 实时 WS），
+  因此时间分段自然成为视图切换器左侧的第一项，槽位与卡片/列表一致。
+
+## 2. 改动文件
+
+| 文件 | 改动 |
+|------|------|
+| `frontend/src/components/todo-list/TodoListPageParts.tsx` | `TodoListHeader` 分支调整：isMobile 精简分支不变；running 桌面态新增时间分段；props 注释更新 |
+| `frontend/src/components/todo-list/TodoListPage.tsx` | running 分支传 `hours` 给 `RunningBoard`；hours state 注释更新 |
+| `frontend/src/components/todo-list/TodoListPage.test.tsx` | RunningBoard mock 增加 hours 渲染；running 用例改为断言渲染时间分段 + hours 透传 |
+| `frontend/tests/check_112_running_time_filter.spec.ts` | Playwright 回归用例（running 时间分段渲染、同槽位、切换生效） |
+
+不改动：`RunningBoard` / `useRunningBoard` / `getRunningBoardData` / 后端（零改动）。
+
+## 3. 关键实现点
+
+- **null→undefined 归一**：`RunningBoard` 的 props 类型是 `hours?: number`，
+  而页级 state 是 `number | null`，透传时必须 `hours ?? undefined`，
+  避免 null 值破坏 `useRunningBoard` 的 `latestHoursRef` 比较与 `getRunningBoardData` 的参数语义。
+- **过滤语义复用**：RunningBoard 的 `filteredRecords` 已有窗口逻辑
+  （`hours && hours > 0` 时对终态记录按 started_at/finished_at 与 cutoff 比较，运行中恒显），
+  本次不复制、不修改，只喂入 hours。
+- **三形态共享 state**：hours 仍由 `TodoListPage` 持有并传给 header，
+  running ↔ card/list 互切时时间窗自然保持，无需新增同步逻辑。
+
+## 4. 测试设计
+
+### 4.1 前端单测（Vitest，更新 `TodoListPage.test.tsx`）
+
+- `TodoListPage.test.tsx`：running 形态渲染「全部」分段；默认 RunningBoard 收到 hours=null；
+  点击 24h 后 RunningBoard 收到 hours=24（mock 桩把 hours 渲染出来断言）。
+
+### 4.2 Playwright 功能验证（见测试文档）
+
+- 独立 vite 实例（5173，API/WS 代理到用户正在使用的 18088 dev 后端，不重启 18088）：
+  running 顶栏出现时间分段；与卡片视图同槽位（同一 header 行、视图切换器左侧）；切换 24h 选中态生效。
+
+## 5. 兼容性与安全
+
+- **无接口变更**：后端零改动，hours 参数为既有可选参数。
+- **无写入语义变化**：仅 SELECT 查询条件变化，不触碰任何写路径。
+- **越权无新增面**：hours 叠加在既有 workspace 隔离之上。
+- **XSS/SQL 注入**：无新增用户输入处理；hours 仅作为非负整数透传。
+

--- a/docs/requirements/112-事项执行监控时间过滤-实现总结.md
+++ b/docs/requirements/112-事项执行监控时间过滤-实现总结.md
@@ -1,0 +1,64 @@
+# 112-事项执行监控时间过滤-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08-17 | 初始版本 — 对应需求 112 / 设计 112 |
+
+---
+
+## 1. 实现了什么
+
+事项页（`/#/todos`）执行监控（running）视图顶栏补齐与卡片/列表同款的时间过滤分段
+（全部/6h/12h/24h/3d/7d），位于视图切换器左侧同一槽位；顶栏时间窗透传给 `RunningBoard`，
+由其既有逻辑（运行中记录恒显、终态记录按 started_at/finished_at 收窗）过滤执行记录。
+
+### 与需求的对应关系
+
+| 需求条目 | 实现 | 状态 |
+|---------|------|------|
+| running 顶栏渲染同款时间分段（切换器左侧同槽位） | `TodoListHeader` 新增 running 桌面态分支，渲染 `TimeRangeSegmented showAll` | ✅ |
+| hours 透传 RunningBoard | `TodoListPage` running 分支 `<RunningBoard hours={hours ?? undefined} />` | ✅ |
+| 三形态共用页级 state、切换不丢失、不持久化 | hours state 维持 111 现状（`useState<number \| null>(null)`），零改动 | ✅ |
+| 移动端保持精简 | isMobile 分支不渲染时间分段，未改动 | ✅ |
+| RunningBoard 过滤语义零改动 | 只接线不改组件 | ✅ |
+| 后端零改动 | 无任何 backend 文件变更 | ✅ |
+
+## 2. 关键实现点
+
+- **同槽位复用**：卡片/列表桌面态顺序为「搜索 → 时间分段 → 刷新 → 切换器 → 新建」；
+  running 无搜索与刷新（统计栏自带刷新 + 实时 WS），时间分段自然成为切换器左侧第一项，
+  与卡片/列表的槽位一致。
+- **null→undefined 归一**：RunningBoard props 类型为 `hours?: number`，
+  页级 state 为 `number | null`，透传用 `hours ?? undefined`，null 语义（全部）保持。
+- **不改过滤逻辑**：RunningBoard 的 `filteredRecords` 窗口过滤与
+  `getRunningBoardData(ws, undefined, 200, hours)` 的 hours 下推均为 111 之前既有的能力，
+  本次仅补上数据通路。
+
+## 3. 测试与验证结果
+
+| 验证 | 结果 |
+|------|------|
+| `npx tsc --noEmit` | ✅ 零错误（TSC_EXIT: 0） |
+| `npx vitest run src/components/todo-list` | ✅ 4 文件 23 用例全过（含更新后的 running 用例：渲染「全部」、默认 hours=null、点 24h 后透传 24） |
+| `npm run build` | ✅ 构建成功（9.3s，仅既存 chunk 体积提示，无新增告警） |
+| Playwright `tests/check_112_running_time_filter.spec.ts` | ✅ 3 用例通过（独立 vite 5173 实例，API/WS 代理到用户正在使用的 18088 dev 后端，未重启 18088）：默认「全部」渲染；running 与 card 时间分段同槽位（切换器左侧同一行）；切 24h/切回「全部」选中态生效 |
+
+验证环境说明：本需求在独立 worktree（`nothing-todo-112`，分支 `feat/112-todos-running-time-filter`）
+开发；Playwright 验证跑在 worktree 内启动的 vite dev（5173，`/api` 与 WS 代理到 18088），
+全程未触碰用户正在使用的 18088 实例与开发数据库。截图证据：
+`frontend/tests/__screenshots__/112-running-time-filter.png`（已 gitignore，发布到 PR 评论）。
+
+## 4. 安全反思
+
+- 纯前端展示层接线：不新增网络请求类型、不改 workspace 隔离、不写任何数据，无越权面。
+- 无新增用户输入处理：hours 仅作为既有非负整数参数透传，无 XSS/SQL 注入面。
+- RunningBoard 既有 hours 语义（运行中恒显）保持不变，未扩大或缩小任何数据可见范围。
+
+## 5. 已知限制与待改进
+
+- running 与 card/list 的时间口径不同（执行记录 started_at/finished_at vs 事项 created_at），
+  属 111 已声明的维度区分，同一档位下两侧集合不同是预期行为。
+- running 视图仍无搜索框（RunningBoard 的 searchText 能力未接线），如需与卡片/列表
+  搜索心智对齐可另提需求。
+- 长时间运行中的记录不受时间窗影响（RunningBoard 现状语义），本期不改。
+

--- a/docs/requirements/112-事项执行监控时间过滤-实现总结.md
+++ b/docs/requirements/112-事项执行监控时间过滤-实现总结.md
@@ -3,21 +3,23 @@
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | AI | 2026-08-17 | 初始版本 — 对应需求 112 / 设计 112 |
+| AI | 2026-08-17 | 增加 running 搜索框实现（透传 searchText）、验证结果与限制更新 |
 
 ---
 
 ## 1. 实现了什么
 
-事项页（`/#/todos`）执行监控（running）视图顶栏补齐与卡片/列表同款的时间过滤分段
-（全部/6h/12h/24h/3d/7d），位于视图切换器左侧同一槽位；顶栏时间窗透传给 `RunningBoard`，
-由其既有逻辑（运行中记录恒显、终态记录按 started_at/finished_at 收窗）过滤执行记录。
+事项页（`/#/todos`）执行监控（running）视图顶栏补齐与卡片/列表同款的**搜索框 + 时间过滤分段**
+（搜索 → 时间分段 → 视图切换器，同一槽位）；搜索词与时间窗分别透传给 `RunningBoard` 的
+`searchText`/`hours` prop，由其既有逻辑过滤执行记录与定时任务
+（搜索：todo 标题/模型/执行器、定时任务标题/Prompt；时间：运行中恒显、终态按 started_at/finished_at 收窗）。
 
 ### 与需求的对应关系
 
 | 需求条目 | 实现 | 状态 |
 |---------|------|------|
-| running 顶栏渲染同款时间分段（切换器左侧同槽位） | `TodoListHeader` 新增 running 桌面态分支，渲染 `TimeRangeSegmented showAll` | ✅ |
-| hours 透传 RunningBoard | `TodoListPage` running 分支 `<RunningBoard hours={hours ?? undefined} />` | ✅ |
+| running 顶栏渲染同款搜索框 + 时间分段（切换器左侧同槽位） | `TodoListHeader` 新增 running 桌面态分支，渲染搜索 Input + `TimeRangeSegmented showAll` | ✅ |
+| searchText/hours 透传 RunningBoard | `TodoListPage` running 分支 `<RunningBoard searchText={searchKeyword.trim() \|\| undefined} hours={hours ?? undefined} />` | ✅ |
 | 三形态共用页级 state、切换不丢失、不持久化 | hours state 维持 111 现状（`useState<number \| null>(null)`），零改动 | ✅ |
 | 移动端保持精简 | isMobile 分支不渲染时间分段，未改动 | ✅ |
 | RunningBoard 过滤语义零改动 | 只接线不改组件 | ✅ |
@@ -26,12 +28,13 @@
 ## 2. 关键实现点
 
 - **同槽位复用**：卡片/列表桌面态顺序为「搜索 → 时间分段 → 刷新 → 切换器 → 新建」；
-  running 无搜索与刷新（统计栏自带刷新 + 实时 WS），时间分段自然成为切换器左侧第一项，
-  与卡片/列表的槽位一致。
-- **null→undefined 归一**：RunningBoard props 类型为 `hours?: number`，
-  页级 state 为 `number | null`，透传用 `hours ?? undefined`，null 语义（全部）保持。
-- **不改过滤逻辑**：RunningBoard 的 `filteredRecords` 窗口过滤与
-  `getRunningBoardData(ws, undefined, 200, hours)` 的 hours 下推均为 111 之前既有的能力，
+  running 无刷新按钮（统计栏自带刷新 + 实时 WS），搜索与时间分段之后直接是视图切换器，
+  前两个槽位与卡片/列表完全一致。
+- **空值归一**：RunningBoard props 类型为 `searchText?: string`/`hours?: number`，
+  页级 state 为 `string`/`number | null`，透传用 `searchKeyword.trim() || undefined` 与
+  `hours ?? undefined`——空白搜索词与 null 时间窗都保持「不过滤」语义。
+- **不改过滤逻辑**：RunningBoard 的 `filteredRecords`/`filteredScheduledTodos` 搜索与
+  窗口过滤、`getRunningBoardData(ws, undefined, 200, hours)` 的 hours 下推均为既有能力，
   本次仅补上数据通路。
 
 ## 3. 测试与验证结果
@@ -39,9 +42,9 @@
 | 验证 | 结果 |
 |------|------|
 | `npx tsc --noEmit` | ✅ 零错误（TSC_EXIT: 0） |
-| `npx vitest run src/components/todo-list` | ✅ 4 文件 23 用例全过（含更新后的 running 用例：渲染「全部」、默认 hours=null、点 24h 后透传 24） |
-| `npm run build` | ✅ 构建成功（9.3s，仅既存 chunk 体积提示，无新增告警） |
-| Playwright `tests/check_112_running_time_filter.spec.ts` | ✅ 3 用例通过（独立 vite 5173 实例，API/WS 代理到用户正在使用的 18088 dev 后端，未重启 18088）：默认「全部」渲染；running 与 card 时间分段同槽位（切换器左侧同一行）；切 24h/切回「全部」选中态生效 |
+| `npx vitest run src/components/todo-list` | ✅ 4 文件 24 用例全过（running 用例：渲染「全部」、默认 hours=null、点 24h 透传 24；搜索用例：关键词 trim 透传 searchText、全空白归一为空） |
+| `npm run build` | ✅ 构建成功（仅既存 chunk 体积提示，无新增告警） |
+| Playwright `tests/check_112_running_time_filter.spec.ts` | ✅ 4 用例通过（先跑在独立 vite 5173 实例，随后对 worktree 构建的 18088 实例复跑）：默认「全部」渲染；running 与 card 时间分段同槽位；切 24h/切回「全部」；搜索框位于时间分段左侧 + 无匹配关键词时统计栏收窄为 0、清空恢复 |
 
 验证环境说明：本需求在独立 worktree（`nothing-todo-112`，分支 `feat/112-todos-running-time-filter`）
 开发；Playwright 验证跑在 worktree 内启动的 vite dev（5173，`/api` 与 WS 代理到 18088），
@@ -58,7 +61,7 @@
 
 - running 与 card/list 的时间口径不同（执行记录 started_at/finished_at vs 事项 created_at），
   属 111 已声明的维度区分，同一档位下两侧集合不同是预期行为。
-- running 视图仍无搜索框（RunningBoard 的 searchText 能力未接线），如需与卡片/列表
-  搜索心智对齐可另提需求。
 - 长时间运行中的记录不受时间窗影响（RunningBoard 现状语义），本期不改。
+- running 搜索与卡片/列表共享同一页级关键词：在 running 输入后切到卡片形态，搜索词继续生效
+  （与 111 三形态共享 state 的设计一致）。
 

--- a/docs/requirements/112-事项执行监控时间过滤-需求.md
+++ b/docs/requirements/112-事项执行监控时间过滤-需求.md
@@ -3,6 +3,7 @@
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | AI | 2026-08-17 | 初始版本 — 补齐 111 在事项页 running（执行监控）形态未接入的时间过滤 |
+| AI | 2026-08-17 | 增加 running 形态搜索框（与卡片/列表同款同位置，透传 RunningBoard searchText） |
 
 ---
 
@@ -26,18 +27,19 @@
 
 ## 2. 目标（What，必须可验证）
 
-- [ ] running 视图顶栏（桌面端）渲染与卡片/列表同款的 `TimeRangeSegmented showAll`
-      时间过滤分段，位置与卡片/列表保持一致（视图切换器左侧同一槽位）。
+- [ ] running 视图顶栏（桌面端）渲染与卡片/列表同款的搜索框与 `TimeRangeSegmented showAll`
+      时间过滤分段，位置与卡片/列表保持一致（搜索 → 时间分段 → 视图切换器）。
+- [ ] 顶栏搜索词透传给 `RunningBoard` 的 `searchText` prop，执行记录与定时任务按
+      标题/模型/执行器/Prompt 实时过滤；关键词 trim 后为空视为不搜索。
 - [ ] 顶栏时间窗透传给 `RunningBoard` 的 `hours` prop，执行记录按窗口过滤：
       运行中记录恒显（现状语义），终态记录按 `started_at`/`finished_at` 收窗。
-- [ ] card/list/running 三形态共用 `TodoListPage` 页级 `hours` state，
-      切换形态时间窗不丢失；时间选择不持久化（与 111 一致）。
-- [ ] 默认「全部」（`hours=null`），刷新页面回到「全部」。
+- [ ] card/list/running 三形态共用 `TodoListPage` 页级 `hours`/`searchKeyword` state，
+      切换形态不丢失；时间选择不持久化（与 111 一致）。
+- [ ] 默认「全部」（`hours=null`）与空搜索词，刷新页面回到默认。
 
 ## 3. 非目标（Explicitly Out of Scope）
 
 - ❌ 移动端 header：保持精简（仅视图切换器 + 新建），与卡片/列表形态的移动端行为一致。
-- ❌ running 视图不加搜索框（RunningBoard 的 searchText 能力本次不接线）。
 - ❌ 不改 RunningBoard 的过滤语义（运行中恒显、终态按 started_at/finished_at 收窗的现状不变）。
 - ❌ 不改后端任何 API（running-board 接口已支持 hours 参数，无需变更）。
 - ❌ 不持久化时间窗到 localStorage。
@@ -45,21 +47,24 @@
 
 ## 4. 使用场景 / 用户路径
 
-1. 用户打开 `/#/todos?view=running`，顶栏出现「全部」时间分段（默认选中）。
-2. 用户点击「24h」：执行监控面板只显示最近 24 小时内的终态执行记录 + 全部运行中记录。
-3. 用户切到卡片形态：时间窗保持（同一页级 state），卡片墙按 created_at 同窗收窄；
-   切回 running：时间窗仍在。
-4. 用户点回「全部」：running 视图恢复全量执行记录。
+1. 用户打开 `/#/todos?view=running`，顶栏出现搜索框与「全部」时间分段（默认选中）。
+2. 用户在搜索框输入关键词：执行监控面板按 todo 标题/模型/执行器、定时任务标题/Prompt
+   实时收窄；清空恢复全量。
+3. 用户点击「24h」：执行监控面板只显示最近 24 小时内的终态执行记录 + 全部运行中记录。
+4. 用户切到卡片形态：搜索词/时间窗保持（同一页级 state），卡片墙同口径生效；
+   切回 running：搜索词/时间窗仍在。
+5. 用户点回「全部」并清空搜索：running 视图恢复全量执行记录。
 
 ## 5. 功能需求清单（Checklist）
 
-- [ ] `TodoListHeader` 的 running 分支（桌面端）渲染 `TimeRangeSegmented showAll`，
-      位于视图切换器（Segmented）左侧，与卡片/列表的「时间分段在切换器之前」槽位一致。
-- [ ] 移动端分支保持精简（isMobile 时不渲染时间分段），不改动。
-- [ ] `TodoListPage` running 分支向 `RunningBoard` 传 `hours={hours ?? undefined}`
-      （RunningBoard props 类型为 `hours?: number`，null 必须归一为 undefined）。
-- [ ] 注释同步更新：`TodoListPage`/`TodoListPageParts` 中「running 不渲染/不传 hours」的旧注释改为新行为。
-- [ ] 更新 `TodoListPage.test.tsx`：running 形态渲染时间分段、切换档位后 hours 透传进 RunningBoard。
+- [ ] `TodoListHeader` 的 running 分支（桌面端）渲染搜索框 + `TimeRangeSegmented showAll`，
+      顺序与卡片/列表一致（搜索 → 时间分段 → 视图切换器）。
+- [ ] 移动端分支保持精简（isMobile 时不渲染搜索/时间分段），不改动。
+- [ ] `TodoListPage` running 分支向 `RunningBoard` 传 `searchText={searchKeyword.trim() || undefined}`
+      与 `hours={hours ?? undefined}`（props 为可选类型，空/null 必须归一为 undefined）。
+- [ ] 注释同步更新：`TodoListPage`/`TodoListPageParts` 中「running 不渲染/不传搜索、hours」的旧注释改为新行为。
+- [ ] 更新 `TodoListPage.test.tsx`：running 形态渲染搜索框与时间分段、输入关键词/切换档位后
+      searchText/hours 透传进 RunningBoard。
 
 ## 6. 约束条件（非常关键）
 
@@ -82,10 +87,11 @@
 
 ## 9. 验收标准（Acceptance Criteria）
 
-- 如果用户打开 `/#/todos?view=running`（桌面端），则顶栏在视图切换器左侧出现
-  「全部/6h/12h/24h/3d/7d」时间分段，默认「全部」。
+- 如果用户打开 `/#/todos?view=running`（桌面端），则顶栏出现搜索框与
+  「全部/6h/12h/24h/3d/7d」时间分段（搜索框在时间分段左侧），默认「全部」+ 空搜索词。
+- 如果用户在搜索框输入关键词，则 running 面板按标题/模型/执行器等实时收窄；清空恢复全量。
 - 如果用户选择「24h」，则 running 面板请求带 `hours=24`，终态执行记录按窗口收窄、运行中记录恒显。
-- 如果用户在 running 选择时间窗后切到卡片形态再切回，则时间窗保持；刷新页面回到「全部」。
+- 如果用户在 running 选择时间窗/输入关键词后切到卡片形态再切回，则两者保持；刷新页面回到默认。
 - 如果 `npx tsc --noEmit`、`npm run test`（vitest）、Playwright 验证全部通过，则质量门槛达标。
 
 ## 10. 风险与已知不确定点

--- a/docs/requirements/112-事项执行监控时间过滤-需求.md
+++ b/docs/requirements/112-事项执行监控时间过滤-需求.md
@@ -1,0 +1,97 @@
+# 112-事项执行监控时间过滤-需求
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08-17 | 初始版本 — 补齐 111 在事项页 running（执行监控）形态未接入的时间过滤 |
+
+---
+
+## 1. 背景（Why）
+
+需求 111 为事项页（`/#/todos`）的「卡片」「列表」两种形态接入了时间过滤分段
+（公共组件 `TimeRangeSegmented`：全部/6h/12h/24h/3d/7d，按事项 `created_at` 过滤，默认「全部」），
+但当时明确把「执行监控」（running）形态列为非目标：
+
+> 事项页「执行监控」（running）形态：RunningBoard 自带统计栏与时间窗，不接入本过滤。
+
+实际使用中发现：用户切到 running 视图后，顶栏只有视图切换器与新建按钮，
+**没有任何时间过滤控件**，与卡片/列表形态的控制心智不一致；
+执行记录日积月累后，running 视图无法按时间窗收窄历史记录，只能全量浏览。
+
+同时 RunningBoard 组件**本身已具备时间过滤能力**（props `hours` 已存在并透传到
+`getRunningBoardData` 的 hours 参数，另有前端 `filteredRecords` 窗口过滤），
+只是 TodoListPage 的 running 分支既没渲染分段控件、也没把 hours 传进去，属于纯接线缺口。
+
+---
+
+## 2. 目标（What，必须可验证）
+
+- [ ] running 视图顶栏（桌面端）渲染与卡片/列表同款的 `TimeRangeSegmented showAll`
+      时间过滤分段，位置与卡片/列表保持一致（视图切换器左侧同一槽位）。
+- [ ] 顶栏时间窗透传给 `RunningBoard` 的 `hours` prop，执行记录按窗口过滤：
+      运行中记录恒显（现状语义），终态记录按 `started_at`/`finished_at` 收窗。
+- [ ] card/list/running 三形态共用 `TodoListPage` 页级 `hours` state，
+      切换形态时间窗不丢失；时间选择不持久化（与 111 一致）。
+- [ ] 默认「全部」（`hours=null`），刷新页面回到「全部」。
+
+## 3. 非目标（Explicitly Out of Scope）
+
+- ❌ 移动端 header：保持精简（仅视图切换器 + 新建），与卡片/列表形态的移动端行为一致。
+- ❌ running 视图不加搜索框（RunningBoard 的 searchText 能力本次不接线）。
+- ❌ 不改 RunningBoard 的过滤语义（运行中恒显、终态按 started_at/finished_at 收窗的现状不变）。
+- ❌ 不改后端任何 API（running-board 接口已支持 hours 参数，无需变更）。
+- ❌ 不持久化时间窗到 localStorage。
+- ❌ 不修改 `TIME_RANGE_OPTIONS` 档位（公共组件已是唯一事实源）。
+
+## 4. 使用场景 / 用户路径
+
+1. 用户打开 `/#/todos?view=running`，顶栏出现「全部」时间分段（默认选中）。
+2. 用户点击「24h」：执行监控面板只显示最近 24 小时内的终态执行记录 + 全部运行中记录。
+3. 用户切到卡片形态：时间窗保持（同一页级 state），卡片墙按 created_at 同窗收窄；
+   切回 running：时间窗仍在。
+4. 用户点回「全部」：running 视图恢复全量执行记录。
+
+## 5. 功能需求清单（Checklist）
+
+- [ ] `TodoListHeader` 的 running 分支（桌面端）渲染 `TimeRangeSegmented showAll`，
+      位于视图切换器（Segmented）左侧，与卡片/列表的「时间分段在切换器之前」槽位一致。
+- [ ] 移动端分支保持精简（isMobile 时不渲染时间分段），不改动。
+- [ ] `TodoListPage` running 分支向 `RunningBoard` 传 `hours={hours ?? undefined}`
+      （RunningBoard props 类型为 `hours?: number`，null 必须归一为 undefined）。
+- [ ] 注释同步更新：`TodoListPage`/`TodoListPageParts` 中「running 不渲染/不传 hours」的旧注释改为新行为。
+- [ ] 更新 `TodoListPage.test.tsx`：running 形态渲染时间分段、切换档位后 hours 透传进 RunningBoard。
+
+## 6. 约束条件（非常关键）
+
+- **组件约束**：不新增第二份时间档位常量，一律复用 `TimeRangeSegmented` 与 `TIME_RANGE_OPTIONS`。
+- **状态约束**：时间窗 state 仍由 `TodoListPage` 持有（111 已有），不把 state 下沉/复制进 RunningBoard。
+- **行为约束**：RunningBoard 的过滤逻辑（`filteredRecords` 的 cutoff 判定、运行中恒显）零改动，
+      仅新增数据通路。
+
+## 7. 可修改 / 不可修改项
+
+- ❌ 不可修改：卡片/列表形态的时间过滤行为与位置（111 已验收）。
+- ❌ 不可修改：RunningBoard 内部过滤语义与自带统计栏/刷新按钮。
+- ✅ 可调整：running 分支 header 内元素顺序的注释表述与单测断言方式。
+
+## 8. 接口与数据约定
+
+- 无新增/变更 API：`GET /api/v1/workspaces/{ws_id}/executions/running-board?hours=N` 已存在
+  （`getRunningBoardData(workspaceId, page, limit, hours)`），本次仅接线。
+- hours 语义沿用现状：`hours=null`（前端归一为 undefined）表示不过滤；正整数表示时间窗小时数。
+
+## 9. 验收标准（Acceptance Criteria）
+
+- 如果用户打开 `/#/todos?view=running`（桌面端），则顶栏在视图切换器左侧出现
+  「全部/6h/12h/24h/3d/7d」时间分段，默认「全部」。
+- 如果用户选择「24h」，则 running 面板请求带 `hours=24`，终态执行记录按窗口收窄、运行中记录恒显。
+- 如果用户在 running 选择时间窗后切到卡片形态再切回，则时间窗保持；刷新页面回到「全部」。
+- 如果 `npx tsc --noEmit`、`npm run test`（vitest）、Playwright 验证全部通过，则质量门槛达标。
+
+## 10. 风险与已知不确定点
+
+- **时间窗与执行维度的口径差异**：卡片/列表按事项 `created_at` 过滤，running 按执行记录的
+  `started_at`/`finished_at` 过滤——两者数据维度本就不同（111 已声明维度区分），
+  同一「24h」档位在两种视图下覆盖的集合不同属预期行为。
+- **运行中记录恒显**：running 视图里长时间运行的记录不受时间窗影响，用户可能在收窄窗口后
+  仍看到较老的运行中记录，这是 RunningBoard 现状语义，本期不改。

--- a/docs/testing/112-事项执行监控时间过滤-测试.md
+++ b/docs/testing/112-事项执行监控时间过滤-测试.md
@@ -4,6 +4,7 @@
 |--------|---------|---------|
 | AI | 2026-08-17 | 初始版本 |
 | AI | 2026-08-17 | 补充质量门禁与 Playwright 执行结果 |
+| AI | 2026-08-17 | 增加 running 搜索框用例（单测 + Playwright #4/#5） |
 
 > 对应需求：`docs/requirements/112-事项执行监控时间过滤-需求.md`；设计：`docs/design/112-事项执行监控时间过滤-设计.md`
 
@@ -14,7 +15,8 @@
 | 测试 | 位置 | 覆盖点 |
 |------|------|--------|
 | `TodoListPage` 111 时间过滤 → running 用例（更新） | `frontend/src/components/todo-list/TodoListPage.test.tsx` | running 形态渲染「全部」时间分段；默认 RunningBoard 收到 hours=null；点击 24h 后收到 hours=24 |
-| RunningBoard mock 桩（更新） | 同上 | 桩组件渲染 props.hours，供断言透传链路 |
+| `TodoListPage` running 搜索用例（新增） | 同上 | running 形态渲染搜索框；关键词 trim 后透传 RunningBoard（searchText）；全空白归一为空（不搜索） |
+| RunningBoard mock 桩（更新） | 同上 | 桩组件渲染 props.searchText/hours，供断言透传链路 |
 
 ## 2. 质量门禁（执行结果，PR 中更新）
 
@@ -36,6 +38,8 @@
 | 1 | running 顶栏时间分段渲染 | 打开 `/#/todos?view=running` | 顶栏出现「全部/6h/12h/24h/3d/7d」，默认选中「全部」 |
 | 2 | 与卡片视图同槽位 | 分别测 card 与 running 视图 | 时间分段与视图切换器同一 header 行、位于其左侧（x < 切换器 x） |
 | 3 | 切换档位生效 | 点击 24h / 切回全部 | Segmented 选中态切换为 24h，切回后恢复「全部」；面板无报错 |
+| 4 | 搜索框同款同位置 | running 视图 | 搜索框可见、位于时间分段左侧（搜索 → 时间，与卡片/列表一致） |
+| 5 | 搜索实时过滤 | 输入无匹配关键词 / 清空 | 统计栏「共 N 条」收窄为 0；清空后恢复初始总数 |
 
 ## 4. 未覆盖项与说明
 

--- a/docs/testing/112-事项执行监控时间过滤-测试.md
+++ b/docs/testing/112-事项执行监控时间过滤-测试.md
@@ -1,0 +1,45 @@
+# 112-事项执行监控时间过滤-测试
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08-17 | 初始版本 |
+| AI | 2026-08-17 | 补充质量门禁与 Playwright 执行结果 |
+
+> 对应需求：`docs/requirements/112-事项执行监控时间过滤-需求.md`；设计：`docs/design/112-事项执行监控时间过滤-设计.md`
+
+---
+
+## 1. 单元测试（Vitest）
+
+| 测试 | 位置 | 覆盖点 |
+|------|------|--------|
+| `TodoListPage` 111 时间过滤 → running 用例（更新） | `frontend/src/components/todo-list/TodoListPage.test.tsx` | running 形态渲染「全部」时间分段；默认 RunningBoard 收到 hours=null；点击 24h 后收到 hours=24 |
+| RunningBoard mock 桩（更新） | 同上 | 桩组件渲染 props.hours，供断言透传链路 |
+
+## 2. 质量门禁（执行结果，PR 中更新）
+
+| 门禁 | 结果 |
+|------|------|
+| `cd frontend && npx tsc --noEmit` | ✅ 零错误（TSC_EXIT: 0） |
+| `cd frontend && npx vitest run src/components/todo-list` | ✅ 4 文件 23 用例全过 |
+| `cd frontend && npm run build` | ✅ 构建成功（9.3s，仅既存 chunk 体积提示，无新增告警） |
+| `npx playwright test tests/check_112_running_time_filter.spec.ts`（CHECK_BASE_URL=5173） | ✅ 3 用例通过（4.2s） |
+
+## 3. 功能实测（Playwright）
+
+> 说明：本需求在独立 worktree（`nothing-todo-112`）开发；UI 验证使用独立 vite 实例
+> （5173，`/api` 与 WS 代理到 18088 dev 后端，只读验证），不重启、不干扰用户正在使用的 18088 实例。
+> 截图证据发布到 PR 评论，不提交仓库（`frontend/tests/__screenshots__/` 已 gitignore）。
+
+| # | 用例 | 方法 | 预期结果 |
+|---|------|------|---------|
+| 1 | running 顶栏时间分段渲染 | 打开 `/#/todos?view=running` | 顶栏出现「全部/6h/12h/24h/3d/7d」，默认选中「全部」 |
+| 2 | 与卡片视图同槽位 | 分别测 card 与 running 视图 | 时间分段与视图切换器同一 header 行、位于其左侧（x < 切换器 x） |
+| 3 | 切换档位生效 | 点击 24h / 切回全部 | Segmented 选中态切换为 24h，切回后恢复「全部」；面板无报错 |
+
+## 4. 未覆盖项与说明
+
+- 移动端（窄屏）header：与卡片/列表一致保持精简，本需求明确不接入，不做 Playwright 覆盖。
+- 时间窗对执行记录数据的实际收窄效果：依赖 dev 数据库既有执行记录的分布，
+  数据口径由 RunningBoard 既有逻辑保证（未改动），用单测链路断言替代数据造数。
+

--- a/frontend/src/components/todo-list/TodoListPage.test.tsx
+++ b/frontend/src/components/todo-list/TodoListPage.test.tsx
@@ -73,8 +73,13 @@ vi.mock('@/components/todo-list/TodoListView', () => ({
 
 // 111：running 形态渲染 RunningBoard（自带统计栏+实时 WS），测试中替换为静态桩，
 // 避免真实组件在 jsdom 里拉数据/建 WS。
+// 112：桩组件把收到的 hours prop 渲染出来，供断言时间窗是否透传进 RunningBoard。
 vi.mock('@/components/running-board', () => ({
-  RunningBoard: () => <div data-testid="mock-running-board" />,
+  RunningBoard: (props: { hours?: number }) => (
+    <div data-testid="mock-running-board">
+      <div data-testid="mock-running-hours">{String(props.hours ?? null)}</div>
+    </div>
+  ),
 }));
 
 vi.mock('@/components/common/PageCard', () => ({
@@ -202,7 +207,7 @@ describe('TodoListPage', () => {
       });
     });
 
-    it('执行监控（running）形态不渲染时间分段', () => {
+    it('执行监控（running）形态渲染时间分段并把 hours 透传给 RunningBoard', () => {
       window.history.replaceState(null, '', '#/todos?view=running');
       render(
         <TodoListPage
@@ -213,8 +218,13 @@ describe('TodoListPage', () => {
         />,
       );
       expect(screen.getByTestId('mock-running-board')).toBeInTheDocument();
-      // running 态 header 精简：不渲染「全部」（RunningBoard 自带时间统计）
-      expect(screen.queryByText('全部')).not.toBeInTheDocument();
+      // 112：running 态 header 与卡片/列表同一位置渲染时间分段（「全部」可见）
+      expect(screen.getByText('全部')).toBeInTheDocument();
+      // 默认 null=全部：RunningBoard 收到的 hours 归一为 null 语义（undefined）
+      expect(screen.getByTestId('mock-running-hours')).toHaveTextContent('null');
+      // 点击 24h 后时间窗透传进 RunningBoard，由其既有逻辑过滤执行记录
+      fireEvent.click(screen.getByText('24h'));
+      expect(screen.getByTestId('mock-running-hours')).toHaveTextContent('24');
     });
   });
 });

--- a/frontend/src/components/todo-list/TodoListPage.test.tsx
+++ b/frontend/src/components/todo-list/TodoListPage.test.tsx
@@ -73,11 +73,12 @@ vi.mock('@/components/todo-list/TodoListView', () => ({
 
 // 111：running 形态渲染 RunningBoard（自带统计栏+实时 WS），测试中替换为静态桩，
 // 避免真实组件在 jsdom 里拉数据/建 WS。
-// 112：桩组件把收到的 hours prop 渲染出来，供断言时间窗是否透传进 RunningBoard。
+// 112：桩组件把收到的 hours/searchText prop 渲染出来，供断言时间窗/搜索词是否透传进 RunningBoard。
 vi.mock('@/components/running-board', () => ({
-  RunningBoard: (props: { hours?: number }) => (
+  RunningBoard: (props: { hours?: number; searchText?: string }) => (
     <div data-testid="mock-running-board">
       <div data-testid="mock-running-hours">{String(props.hours ?? null)}</div>
+      <div data-testid="mock-running-search">{props.searchText ?? ''}</div>
     </div>
   ),
 }));
@@ -225,6 +226,28 @@ describe('TodoListPage', () => {
       // 点击 24h 后时间窗透传进 RunningBoard，由其既有逻辑过滤执行记录
       fireEvent.click(screen.getByText('24h'));
       expect(screen.getByTestId('mock-running-hours')).toHaveTextContent('24');
+    });
+
+    it('执行监控（running）形态渲染搜索框并把关键词透传给 RunningBoard', () => {
+      window.history.replaceState(null, '', '#/todos?view=running');
+      render(
+        <TodoListPage
+          onSelectTodo={mockOnSelectTodo}
+          onSelectLoop={mockOnSelectLoop}
+          onOpenCreateModal={mockOnOpenCreateModal}
+          onEditTodo={mockOnEditTodo}
+        />,
+      );
+      // 搜索框与卡片/列表同款（同一 data-testid），默认空词
+      const searchInput = screen.getByTestId('items-page-search');
+      expect(searchInput).toBeInTheDocument();
+      expect(screen.getByTestId('mock-running-search')).toHaveTextContent('');
+      // 输入关键词：trim 后透传进 RunningBoard（与列表形态防抖 trim 口径一致）
+      fireEvent.change(searchInput, { target: { value: '  abc  ' } });
+      expect(screen.getByTestId('mock-running-search')).toHaveTextContent('abc');
+      // 全空白视为无搜索（归一为 undefined，桩渲染为空串）
+      fireEvent.change(searchInput, { target: { value: '   ' } });
+      expect(screen.getByTestId('mock-running-search')).toHaveTextContent('');
     });
   });
 });

--- a/frontend/src/components/todo-list/TodoListPage.tsx
+++ b/frontend/src/components/todo-list/TodoListPage.tsx
@@ -228,8 +228,9 @@ export function TodoListPage({
         />
       ) : viewMode === 'running' ? (
         // 执行监控态：复用 RunningBoard（执行记录 6 列 + 实时 WS + 评审流水线 + 自带统计栏/刷新）。
-        // 112：顶栏时间窗透传给 RunningBoard（其内置 hours 过滤：运行中记录恒显，
-        // 终态记录按 started_at/finished_at 收窗），与卡片/列表按 todo created_at 的口径属不同维度。
+        // 112：顶栏搜索词/时间窗透传给 RunningBoard（其内置 searchText 过滤：按 todo 标题/模型/
+        // 执行器与定时任务标题/Prompt 前端实时过滤；hours 过滤：运行中记录恒显、
+        // 终态记录按 started_at/finished_at 收窗），与卡片/列表的 created_at 口径属不同维度。
         <PageCard
           icon={<UnorderedListOutlined />}
           title="事项"
@@ -237,7 +238,12 @@ export function TodoListPage({
           style={{ flex: 1, height: '100%' }}
           contentStyle={{ height: 'calc(100% - 43px)', overflow: 'hidden' }}
         >
-          <RunningBoard hours={hours ?? undefined} />
+          <RunningBoard
+            // 搜索词 trim 后为空则归一为 undefined（与列表形态防抖后 trim 的口径一致）；
+            // hours 同理归一（RunningBoard props 为可选 number，null 语义=全部）
+            searchText={searchKeyword.trim() || undefined}
+            hours={hours ?? undefined}
+          />
         </PageCard>
       ) : (
         <PageCard

--- a/frontend/src/components/todo-list/TodoListPage.tsx
+++ b/frontend/src/components/todo-list/TodoListPage.tsx
@@ -173,7 +173,7 @@ export function TodoListPage({
   const viewMode = pickListView(listView, ['card', 'list', 'running'], storedView);
   // 统一搜索词：卡片/列表两种形态共用一个搜索框
   const [searchKeyword, setSearchKeyword] = useState('');
-  // 111：时间窗（card/list 共享）：null=全部不过滤，与任务页口径一致；
+  // 111：时间窗（card/list/running 三形态共享）：null=全部不过滤，与任务页口径一致；
   // 不持久化——离开页面回到默认「全部」，避免用户忘记过滤态导致老数据「消失」。
   const [hours, setHours] = useState<number | null>(null);
   // 刷新信号：每次点击刷新按钮自增，传递给 TodoCenterCardView 触发重新加载
@@ -228,7 +228,8 @@ export function TodoListPage({
         />
       ) : viewMode === 'running' ? (
         // 执行监控态：复用 RunningBoard（执行记录 6 列 + 实时 WS + 评审流水线 + 自带统计栏/刷新）。
-        // 不传 searchText/hours：RunningBoard 自带统计栏+刷新+实时，全量执行记录（与 card 的 todo 定义维度区分）。
+        // 112：顶栏时间窗透传给 RunningBoard（其内置 hours 过滤：运行中记录恒显，
+        // 终态记录按 started_at/finished_at 收窗），与卡片/列表按 todo created_at 的口径属不同维度。
         <PageCard
           icon={<UnorderedListOutlined />}
           title="事项"
@@ -236,7 +237,7 @@ export function TodoListPage({
           style={{ flex: 1, height: '100%' }}
           contentStyle={{ height: 'calc(100% - 43px)', overflow: 'hidden' }}
         >
-          <RunningBoard />
+          <RunningBoard hours={hours ?? undefined} />
         </PageCard>
       ) : (
         <PageCard

--- a/frontend/src/components/todo-list/TodoListPageParts.tsx
+++ b/frontend/src/components/todo-list/TodoListPageParts.tsx
@@ -38,8 +38,8 @@ interface TodoListHeaderProps {
 }
 
 /**
- * 顶部 header：搜索框 + 刷新 + Segmented + 新建。
- * 桌面端展开全部；移动端精简（去掉搜索/刷新，保留 Segmented + 新建）。
+ * 顶部 header：搜索框 + 时间分段 + 刷新 + Segmented + 新建。
+ * 桌面端展开全部（running 形态无刷新按钮，统计栏自带）；移动端精简（保留 Segmented + 新建）。
  * 拆出独立组件避免 TodoListPage 主函数膨胀。
  */
 export function TodoListHeader({
@@ -86,12 +86,22 @@ export function TodoListHeader({
     );
   }
 
-  // 运行态桌面 header：RunningBoard 自带统计栏刷新与实时 WS，因此不放搜索框与刷新按钮；
-  // 但时间分段仍渲染在视图切换器左侧，与卡片/列表形态保持同一槽位，
-  // hours 由 TodoListPage 透传给 RunningBoard，对其执行记录按时间窗过滤（112）。
+  // 运行态桌面 header：RunningBoard 自带统计栏刷新与实时 WS，因此不放刷新按钮；
+  // 但搜索框与时间分段仍渲染在与卡片/列表相同的槽位（搜索 → 时间 → 切换器 → 新建），
+  // 关键词/时间窗由 TodoListPage 透传给 RunningBoard，对其执行记录实时过滤（112）。
   if (viewMode === 'running') {
     return (
       <>
+        <Input
+          allowClear
+          size="small"
+          placeholder="搜索标题或 Prompt"
+          prefix={<SearchOutlined />}
+          value={searchKeyword}
+          onChange={(e) => onSearchChange(e.target.value)}
+          style={{ width: 200 }}
+          data-testid="items-page-search"
+        />
         <TimeRangeSegmented showAll value={hours} onChange={onHoursChange} />
         {segmented}
         {createBtn}

--- a/frontend/src/components/todo-list/TodoListPageParts.tsx
+++ b/frontend/src/components/todo-list/TodoListPageParts.tsx
@@ -28,7 +28,7 @@ interface TodoListHeaderProps {
   viewMode: 'card' | 'list' | 'running';
   searchKeyword: string;
   loading: boolean;
-  /** 111：时间窗（null=全部）；card/list 共用，running 形态不渲染。 */
+  /** 111：时间窗（null=全部）；card/list/running 三形态共用，running 透传给 RunningBoard 过滤执行记录。 */
   hours: number | null;
   onHoursChange: (h: number | null) => void;
   onSearchChange: (kw: string) => void;
@@ -75,10 +75,24 @@ export function TodoListHeader({
     </Button>
   );
 
-  // 精简 header：移动端或运行态，只保留 Segmented + 新建（RunningBoard 自带统计栏+刷新+实时 WS）。
-  if (isMobile || viewMode === 'running') {
+  // 移动端精简 header：只保留 Segmented + 新建（与卡片/列表形态的移动端行为一致，
+  // 时间分段与搜索在窄屏下均不展示，避免顶栏溢出）。
+  if (isMobile) {
     return (
       <>
+        {segmented}
+        {createBtn}
+      </>
+    );
+  }
+
+  // 运行态桌面 header：RunningBoard 自带统计栏刷新与实时 WS，因此不放搜索框与刷新按钮；
+  // 但时间分段仍渲染在视图切换器左侧，与卡片/列表形态保持同一槽位，
+  // hours 由 TodoListPage 透传给 RunningBoard，对其执行记录按时间窗过滤（112）。
+  if (viewMode === 'running') {
+    return (
+      <>
+        <TimeRangeSegmented showAll value={hours} onChange={onHoursChange} />
         {segmented}
         {createBtn}
       </>

--- a/frontend/tests/check_112_running_time_filter.spec.ts
+++ b/frontend/tests/check_112_running_time_filter.spec.ts
@@ -1,4 +1,5 @@
-// check_112_running_time_filter.spec.ts — 112：事项执行监控（running）视图顶栏时间过滤回归用例。
+// check_112_running_time_filter.spec.ts — 112：事项执行监控（running）视图顶栏
+// 搜索框 + 时间过滤回归用例。
 //
 // 运行方式：
 //   本 spec 默认验证 18088 dev 实例（与仓库其他 spec 一致，需 make dev 重建前端产物）；
@@ -64,5 +65,37 @@ test('running 视图切换 24h 后选中态生效并可切回「全部」', asyn
 
   // 截图留证（目录已 gitignore，发布到 PR 评论）
   await page.screenshot({ path: 'tests/__screenshots__/112-running-time-filter.png' });
+});
+
+test('running 视图搜索框与卡片/列表同款同位置，输入关键词实时过滤', async ({ page }) => {
+  await page.goto(`${BASE}/#/todos?view=running`);
+  await expect(page.locator('.running-board-stats')).toBeVisible({ timeout: 20000 });
+
+  // 搜索框存在（与卡片/列表同款控件、同一 data-testid）
+  const search = page.getByTestId('items-page-search');
+  await expect(search).toBeVisible();
+
+  // 位置断言：搜索框位于时间分段左侧（与卡片/列表顺序一致：搜索 → 时间）
+  const timeSeg = page.locator('.ant-segmented').first();
+  const s = await search.boundingBox();
+  const t = await timeSeg.boundingBox();
+  expect(s).not.toBeNull();
+  expect(t).not.toBeNull();
+  expect(s!.x).toBeLessThan(t!.x);
+  // 同一行：纵向区间有交集
+  expect(s!.y).toBeLessThan(t!.y + t!.height!);
+  expect(s!.y + s!.height!).toBeGreaterThan(t!.y);
+
+  // 实时过滤：记录统计栏「共 N 条」的初始值，输入无匹配关键词后收窄为 0
+  const totalStrong = page.locator('.running-stat-item', { hasText: '共' }).locator('strong');
+  const before = await totalStrong.textContent();
+  expect(before).toBeTruthy();
+
+  await search.fill('zzz-no-such-todo-112');
+  await expect(totalStrong).toHaveText('0');
+
+  // 清空后恢复初始总数（不持久化、可逆）
+  await search.fill('');
+  await expect(totalStrong).toHaveText(before!);
 });
 

--- a/frontend/tests/check_112_running_time_filter.spec.ts
+++ b/frontend/tests/check_112_running_time_filter.spec.ts
@@ -1,0 +1,68 @@
+// check_112_running_time_filter.spec.ts — 112：事项执行监控（running）视图顶栏时间过滤回归用例。
+//
+// 运行方式：
+//   本 spec 默认验证 18088 dev 实例（与仓库其他 spec 一致，需 make dev 重建前端产物）；
+//   本地开发验证可用 CHECK_BASE_URL=http://localhost:5173 指定独立 vite 实例
+//   （vite /api 与 WS 代理到 18088 dev 后端），避免为验证而重启他人正在使用的 dev 实例。
+import { test, expect, type Page } from '@playwright/test';
+
+// 验证目标实例：默认 18088（embedded 构建产物）；本地验证用环境变量切换到 vite dev。
+const BASE = process.env.CHECK_BASE_URL ?? 'http://localhost:18088';
+
+/** 测量顶栏时间分段与视图切换器的相对位置：时间分段必须与切换器同一行且在其左侧。 */
+async function measureHeaderLayout(page: Page) {
+  // 顶栏第一个 .ant-segmented 即时间分段（在视图切换器之前渲染，DOM 顺序稳定）；
+  // 视图切换器用稳定 data-testid 锚定，避免依赖 DOM 顺序。
+  const timeSeg = page.locator('.ant-segmented').first();
+  const viewToggle = page.locator('[data-testid="todo-center-view-toggle"]');
+  const t = await timeSeg.boundingBox();
+  const v = await viewToggle.boundingBox();
+  if (!t || !v) throw new Error('顶栏时间分段或视图切换器不可见');
+  return { time: t, toggle: v };
+}
+
+test('running 视图顶栏渲染时间过滤分段，默认「全部」', async ({ page }) => {
+  await page.goto(`${BASE}/#/todos?view=running`);
+  // RunningBoard 数据加载完成后出现统计栏（API 经代理打到 dev 后端）
+  await expect(page.locator('.running-board-stats')).toBeVisible({ timeout: 20000 });
+
+  // 与卡片/列表同款的时间分段控件出现，「全部」为默认选中项
+  await expect(page.getByText('全部', { exact: true })).toBeVisible();
+  await expect(page.locator('.ant-segmented-item-selected', { hasText: '全部' }).first()).toBeVisible();
+});
+
+test('running 与 card 视图的时间分段位于同一槽位（切换器左侧同一行）', async ({ page }) => {
+  // 卡片形态基准：时间分段与视图切换器同行且在其左侧
+  await page.goto(`${BASE}/#/todos?view=card`);
+  await expect(page.locator('[data-testid="todo-center-view-toggle"]')).toBeVisible();
+  const card = await measureHeaderLayout(page);
+  expect(card.time.x).toBeLessThan(card.toggle.x);
+  // 同一行判定：两个元素纵向区间有交集
+  expect(card.time.y).toBeLessThan(card.toggle.y + card.toggle.height);
+  expect(card.time.y + card.time.height).toBeGreaterThan(card.toggle.y);
+
+  // running 形态：同槽位（左侧 + 同一行）
+  await page.goto(`${BASE}/#/todos?view=running`);
+  await expect(page.locator('[data-testid="todo-center-view-toggle"]')).toBeVisible();
+  const running = await measureHeaderLayout(page);
+  expect(running.time.x).toBeLessThan(running.toggle.x);
+  expect(running.time.y).toBeLessThan(running.toggle.y + running.toggle.height);
+  expect(running.time.y + running.time.height).toBeGreaterThan(running.toggle.y);
+});
+
+test('running 视图切换 24h 后选中态生效并可切回「全部」', async ({ page }) => {
+  await page.goto(`${BASE}/#/todos?view=running`);
+  await expect(page.locator('.running-board-stats')).toBeVisible({ timeout: 20000 });
+
+  // 切换 24h：Segmented 选中态跟随，同时 hours 已透传 RunningBoard（面板无报错）
+  await page.getByText('24h', { exact: true }).click();
+  await expect(page.locator('.ant-segmented-item-selected', { hasText: '24h' }).first()).toBeVisible();
+
+  // 切回「全部」恢复默认
+  await page.getByText('全部', { exact: true }).click();
+  await expect(page.locator('.ant-segmented-item-selected', { hasText: '全部' }).first()).toBeVisible();
+
+  // 截图留证（目录已 gitignore，发布到 PR 评论）
+  await page.screenshot({ path: 'tests/__screenshots__/112-running-time-filter.png' });
+});
+


### PR DESCRIPTION
## 需求背景

事项页 `/#/todos?view=running`（执行监控）顶栏此前没有搜索框与时间过滤控件。
本 PR 给 running 视图补上与卡片/列表**同款、同一位置**的搜索框 + 时间过滤分段
（顺序：搜索 → 时间分段 → 视图切换器 → 新建），并把关键词/时间窗分别透传给
`RunningBoard` 的 `searchText`/`hours` prop（其过滤能力此前已存在，只是没接线）。

对应文档（编号 112）：
- 需求：`docs/requirements/112-事项执行监控时间过滤-需求.md`
- 设计：`docs/design/112-事项执行监控时间过滤-设计.md`
- 测试：`docs/testing/112-事项执行监控时间过滤-测试.md`
- 实现总结：`docs/requirements/112-事项执行监控时间过滤-实现总结.md`

## 改动内容

| 文件 | 改动 |
|------|------|
| `frontend/src/components/todo-list/TodoListPageParts.tsx` | `TodoListHeader` running 桌面态分支：搜索框 + `TimeRangeSegmented showAll`（与卡片/列表同槽位）；移动端精简分支不变 |
| `frontend/src/components/todo-list/TodoListPage.tsx` | running 分支透传 `searchText={searchKeyword.trim() \|\| undefined}` 与 `hours={hours ?? undefined}` |
| `frontend/src/components/todo-list/TodoListPage.test.tsx` | RunningBoard 桩渲染 searchText/hours；running 搜索用例（trim 透传、全空白归一） |
| `frontend/tests/check_112_running_time_filter.spec.ts` | Playwright 回归 4 用例（渲染、同槽位、档位切换、搜索框位置 + 实时过滤） |

后端零改动；`RunningBoard`/`useRunningBoard`/`getRunningBoardData` 过滤逻辑零改动（仅接线）。

## 验证结果

| 门禁 | 结果 |
|------|------|
| `npx tsc --noEmit` | ✅ 零错误 |
| `npx vitest run src/components/todo-list` | ✅ 4 文件 24 用例全过 |
| `npm run build` | ✅ 构建成功，无新增告警 |
| `npx playwright test tests/check_112_running_time_filter.spec.ts`（18088 worktree 构建） | ✅ 4 用例通过（3.3s） |

## 已知限制

- running 与 card/list 的时间口径不同（执行记录 started_at/finished_at vs 事项 created_at），属 111 已声明的维度区分。
- running 搜索与卡片/列表共享同一页级关键词（三形态共享 state 的设计，与 111 一致）。
- 运行中的执行记录恒显（RunningBoard 现状语义），不受时间窗影响。

