### PR TITLE
feat(113): 分享类 action 统一为每类一个事项并修复软删边界

### DIFF
--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -1343,6 +1343,11 @@ impl Database {
         if let Some(m) = existing {
             let mut am: todos::ActiveModel = m.into();
             am.deleted_at = ActiveValue::Set(Some(crate::models::utc_timestamp()));
+            // 113：软删除同时清空 action 标识，释放 (action_type, action_key, workspace_id)
+            // 唯一索引占用——否则软删行占死该键，同 key action 再次执行会 UNIQUE 冲突。
+            // 对非 action 事项（本路径的讨论载体 todo）这两列本就是 NULL，清空无副作用。
+            am.action_type = ActiveValue::Set(None);
+            am.action_key = ActiveValue::Set(None);
             am.update(&self.conn).await?;
         }
         Ok(())
@@ -1428,11 +1433,16 @@ impl Database {
         self.exec_update(am).await
     }
 
+    /// 软删除事项（置 deleted_at，事项中心/列表自动隐藏）。
+    /// 113：同时清空 action_type/action_key——软删行若不释放 (action_type, action_key,
+    /// workspace_id) 唯一索引，删除后再次分享/执行同 key action 会新建撞索引报错。
     pub async fn delete_todo(&self, id: i64) -> Result<(), sea_orm::DbErr> {
         let now = crate::models::utc_timestamp();
         let am = todos::ActiveModel {
             id: ActiveValue::Unchanged(id),
             deleted_at: ActiveValue::Set(Some(now)),
+            action_type: ActiveValue::Set(None),
+            action_key: ActiveValue::Set(None),
             ..Default::default()
         };
         self.exec_update(am).await
@@ -1445,6 +1455,9 @@ impl Database {
         let now = crate::models::utc_timestamp();
         let res = todos::Entity::update_many()
             .col_expr(todos::Column::DeletedAt, Some(now).into())
+            // 113：与 delete_todo 同口径，批量删除也释放 action 唯一索引占用
+            .col_expr(todos::Column::ActionType, None::<String>.into())
+            .col_expr(todos::Column::ActionKey, None::<String>.into())
             .filter(todos::Column::Id.is_in(ids.to_vec()))
             .filter(todos::Column::DeletedAt.is_null())
             .exec(&self.conn)
@@ -2128,6 +2141,121 @@ mod todo_center_tests {
         assert!(db.get_todo(id).await.unwrap().unwrap().webhook_enabled);
         assert!(db.update_todo_webhook(id, false).await.unwrap());
         assert!(!db.get_todo(id).await.unwrap().unwrap().webhook_enabled);
+    }
+
+    // -------- 113：软删除释放 action 唯一键 --------
+
+    /// 113：delete_todo 软删除后 action_type/action_key 被清空，
+    /// 不再占用 (action_type, action_key, workspace_id) 唯一索引。
+    #[tokio::test]
+    async fn test_delete_todo_clears_action_keys() {
+        let db = fresh_db().await;
+        let id = seed_todo(&db, "动作项").await;
+        // 直接 SQL 置 action 标识，模拟 find_or_create_todo 落库后的形态
+        db.exec(&format!(
+            "UPDATE todos SET action_type='expert_contribute', action_key='default' WHERE id={id}"
+        ))
+        .await
+        .expect("set action keys");
+
+        db.delete_todo(id).await.expect("delete");
+
+        let row = db
+            .conn
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                format!("SELECT action_type, action_key FROM todos WHERE id={id}"),
+            ))
+            .await
+            .expect("query row")
+            .expect("row exists");
+        let at: Option<String> = row.try_get_by_index(0).expect("action_type readable");
+        let ak: Option<String> = row.try_get_by_index(1).expect("action_key readable");
+        assert_eq!(at, None, "软删后 action_type 应清空");
+        assert_eq!(ak, None, "软删后 action_key 应清空");
+    }
+
+    /// 113：batch_delete_todos 批量软删同样清空 action 标识。
+    #[tokio::test]
+    async fn test_batch_delete_todos_clears_action_keys() {
+        let db = fresh_db().await;
+        let id1 = seed_todo(&db, "批量动作一").await;
+        let id2 = seed_todo(&db, "批量动作二").await;
+        // 两行分属不同 workspace：同键同 workspace 本就违反唯一索引（业务上也不会出现），
+        // 测试目的是验证批量软删后 action 标识被清空
+        db.exec(&format!(
+            "UPDATE todos SET action_type='skill_contribute', action_key='default', workspace_id=1 WHERE id={id1}"
+        ))
+        .await
+        .expect("set action keys");
+        db.exec(&format!(
+            "UPDATE todos SET action_type='skill_contribute', action_key='default', workspace_id=2 WHERE id={id2}"
+        ))
+        .await
+        .expect("set action keys");
+
+        let affected = db.batch_delete_todos(&[id1, id2]).await.expect("batch delete");
+        assert_eq!(affected, 2, "应删除两行");
+
+        let row = db
+            .conn
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                format!("SELECT COUNT(*) FROM todos WHERE id IN ({id1},{id2}) AND action_type IS NOT NULL"),
+            ))
+            .await
+            .expect("query")
+            .expect("row");
+        let remaining: i64 = row.try_get_by_index(0).expect("count readable");
+        assert_eq!(remaining, 0, "批量软删后不应残留 action_type");
+    }
+
+    /// 113：soft_delete_todo（内部软删路径）同样清空 action 标识。
+    #[tokio::test]
+    async fn test_soft_delete_todo_clears_action_keys() {
+        let db = fresh_db().await;
+        let id = seed_todo(&db, "内部软删项").await;
+        db.exec(&format!(
+            "UPDATE todos SET action_type='process_contribute', action_key='default' WHERE id={id}"
+        ))
+        .await
+        .expect("set action keys");
+
+        db.soft_delete_todo(id).await.expect("soft delete");
+
+        let row = db
+            .conn
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                format!("SELECT action_type, action_key FROM todos WHERE id={id}"),
+            ))
+            .await
+            .expect("query row")
+            .expect("row exists");
+        let at: Option<String> = row.try_get_by_index(0).expect("action_type readable");
+        assert_eq!(at, None, "内部软删后 action_type 应清空");
+    }
+
+    /// 113：删除 action 事项后，同 (action_type, action_key, workspace_id) 可再次创建——
+    /// 这是「删除后再次分享不再 UNIQUE 冲突」的直接回归防线。
+    #[tokio::test]
+    async fn test_recreate_same_action_key_after_delete_succeeds() {
+        let db = fresh_db().await;
+        let id = seed_todo(&db, "动作项").await;
+        db.exec(&format!(
+            "UPDATE todos SET action_type='expert_contribute', action_key='default', workspace_id=1 WHERE id={id}"
+        ))
+        .await
+        .expect("set action keys");
+
+        db.delete_todo(id).await.expect("delete");
+
+        // 同键再插入：若唯一索引仍被软删行占用会 UNIQUE 报错，此处成功即修复生效
+        db.exec(
+            "INSERT INTO todos (title, prompt, status, action_type, action_key, workspace_id)              VALUES ('新事项','p','pending','expert_contribute','default',1)",
+        )
+        .await
+        .expect("同 action 键重建应成功（唯一索引已释放）");
     }
 
     /// get_todo_center 把普通事项分到 Manual，已归档事项分到 Archived，

--- a/docs/design/113-分享事项统一-设计.md
+++ b/docs/design/113-分享事项统一-设计.md
@@ -1,0 +1,81 @@
+# 113-分享事项统一-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08 | 初始版本：分享类 action 事项统一为「一类 action 一个事项」+ 软删除边界修复 |
+
+---
+
+# 1. 背景（Why）
+
+用户观察到行为差异：
+
+- **标题优化**：action_type=title_optimize + 固定 action_key="default"，整个动作类共用一个事项（事项中心只有 1 个，重复点击只新增执行记录）。
+- **专家/工艺/技能/事项模板分享**：action_key 传资源标识（专家名 / 工艺 guid / 技能名 / todo-{id}），**每个资源一个事项**。资源越多事项中心越膨胀，用户感知为「每次分享都产生一个新事项」。
+
+调查结论（证据见 113 实现总结）：
+
+1. 后端 find_or_create_todo（backend/src/handlers/action.rs）按 action_type + action_key + workspace_id 查找，找到即复用；唯一索引 idx_todos_action_type_key_workspace（V46/V48 迁移）兜底防并发。**同一资源重复点击不会新建事项**，差异 100% 在前端 action_key 取值粒度。
+2. 分享类按资源隔离是 027 设计文档的决策（组件注释「action_key 资源名，用于执行记录去重」），标题优化则是固定 key 的代表。
+
+# 2. 目标（What）
+
+- [ ] 4 类分享（专家 / 工艺 / 技能 / 事项模板）的 action_key 统一固定为 "default"，每类 action 全工作空间只 1 个事项，与标题优化口径一致。
+- [ ] 修复软删除边界：删除（软删）action 事项后再次分享不应报唯一索引冲突，而是创建全新事项。
+
+# 3. 非目标
+
+- 不合并存量已创建的资源级 action 事项（保留用户已有数据；新逻辑只影响新创建）。
+- 不修改其他 ActionButton 使用点（安装 / 升级 / 黑板推荐 / 专家创建等，各自有独立语义）。
+- 不做「删除后恢复已删事项」——删除即彻底退出事项中心（现状语义），再次分享创建新事项。
+
+# 4. 设计
+
+## 4.1 前端：分享 actionKey 统一固定（对齐标题优化）
+
+frontend/src/components/settings/contribute/ShareToRepoButton.tsx：
+
+- **移除 actionKey prop**（类型层面禁止再传资源名），内部向 ActionButton 传固定常量 "default"，并注释说明统一决策。
+- 6 个调用点同步删除 actionKey 传参：
+  - settings/experts/ContributeButton.tsx（专家详情 Modal + 专家模板 Tab 共用）
+  - ProcessPage.tsx（工艺页卡片）
+  - settings/templates/ProcessTemplatesTab.tsx
+  - skills/SkillCardView.tsx
+  - settings/templates/SkillTemplatesTab.tsx
+  - settings/templates/TodoTemplatesTab.tsx
+
+效果：expert_contribute/default、process_contribute/default、skill_contribute/default、todo_contribute/default 四个事项承载全部分享执行，执行记录按 params（resource_name / remote_path）区分资源。
+
+## 4.2 前端：事项中心来源标签补全
+
+TodoCenterCard.tsx 的 sourceLabel 映射补 4 个 action_type 中文标签（事项中心「快捷」Tag 与来源筛选下拉目前对分享类显示原始英文串）：
+
+expert_contribute → 专家贡献、process_contribute → 工艺分享、skill_contribute → 技能分享、todo_contribute → 模板分享
+
+## 4.3 后端：软删除释放 action 唯一键（修复边界）
+
+现状问题：软删除（置 deleted_at）只标记不清理；find_or_create_todo 查找过滤 deleted_at IS NULL 找不到 → 新建时 update_todo_full 写入 action_type/action_key 触发唯一索引 UNIQUE constraint failed，表现为「删除后再次分享报错」。
+
+修复：**软删除时同时清空 action_type、action_key**，让该行退出唯一索引覆盖范围（部分索引 WHERE action_type IS NOT NULL AND action_key IS NOT NULL），下次分享可正常新建。
+
+改动点（backend/src/db/todo.rs，3 个软删路径统一行为）：
+
+| 函数 | 改动 |
+|------|------|
+| delete_todo | 置 deleted_at 的同时清空 action_type/action_key |
+| batch_delete_todos | 同上（批量路径） |
+| soft_delete_todo | 同上（讨论载体等内部路径，防御性一致） |
+
+不选「查找时去掉 deleted_at 过滤 + 复用已删事项」的原因：执行链路 get_todo 同样过滤 deleted_at IS NULL，复用需恢复（undelete）动作，语义是「复活旧事项带旧历史」，不如「删除即清理、再分享即新事项」直观。
+
+# 5. 安全与兼容性
+
+- 清空 action_type/action_key 仅影响软删行：所有查询路径均过滤 deleted_at IS NULL，不可见行无读取方；restore_todo 只恢复 archived_at，不涉及软删行，无冲突。
+- 唯一索引仍保障未删除 action 事项不重复创建。
+- 前端移除 prop 由 tsc 全量校验，漏改调用点直接编译报错。
+
+# 6. 测试计划
+
+- **后端单测**（todo.rs tests）：删除后 action_type/action_key 被清空；批量删除同样清空；清空后同键可再次创建（唯一索引不再占用）。
+- **后端**：cargo clippy --all-targets -- -D warnings 零告警 + cargo test 全绿。
+- **前端**：npx tsc --noEmit 零错误；回归 026-expert-contribution.spec.ts、027-resource-contribute.spec.ts（分享入口 UI 行为不变）。

--- a/docs/requirements/113-分享事项统一-实现总结.md
+++ b/docs/requirements/113-分享事项统一-实现总结.md
@@ -1,0 +1,65 @@
+# 113-分享事项统一-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08 | 实现分享类 action 事项统一 + 软删除边界修复 |
+
+---
+
+# 1. 需求与设计
+
+- 需求来源：用户观察「专家/工艺分享每次点击好像都产生新事项」，而标题优化一类 action 只用一个事项，要求统一。
+- 设计文档：docs/design/113-分享事项统一-设计.md。
+
+# 2. 调查结论（为什么会有这个现象）
+
+后端 find_or_create_todo（backend/src/handlers/action.rs）按 action_type + action_key + workspace_id 查找或创建 todo，唯一索引 idx_todos_action_type_key_workspace 兜底。因此：
+
+1. **同一资源重复点击不会新建事项**——每次只新增执行记录（实证：开发库 expert_contribute/joke-expert 单事项 4 条执行记录）。
+2. **不同资源各占一个事项**——分享按钮的 action_key 传资源标识（专家名/工艺 guid/技能名/todo-id），标题优化传固定 "default"。差异 100% 在前端 action_key 取值粒度。
+
+# 3. 改动清单
+
+## 前端（对齐标题优化口径：一类 action 一个事项）
+
+| 文件 | 改动 |
+|------|------|
+| frontend/src/components/settings/contribute/ShareToRepoButton.tsx | 移除 actionKey prop，内部固定 SHARE_ACTION_KEY='default'（类型层面禁止再按资源传 key） |
+| frontend/src/components/settings/experts/ContributeButton.tsx | 删除 actionKey={expert.name} |
+| frontend/src/components/ProcessPage.tsx | 删除 actionKey={p.guid} |
+| frontend/src/components/settings/templates/ProcessTemplatesTab.tsx | 删除 actionKey={record.guid} |
+| frontend/src/components/skills/SkillCardView.tsx | 删除 actionKey={skill.name} |
+| frontend/src/components/settings/templates/SkillTemplatesTab.tsx | 删除 actionKey={record.name} |
+| frontend/src/components/settings/templates/TodoTemplatesTab.tsx | 删除 actionKey={`todo-{id}`} |
+| frontend/src/components/TodoCenterCard.tsx | sourceLabel 补 expert/process/skill/todo_contribute 四个中文标签（来源 Tag + 筛选下拉可读） |
+
+效果：expert_contribute/default、process_contribute/default、skill_contribute/default、todo_contribute/default 四个事项承载全部分享执行；资源区分靠执行记录 params（resource_name/remote_path）。
+
+## 后端（软删除释放 action 唯一键）
+
+| 文件 | 改动 |
+|------|------|
+| backend/src/db/todo.rs delete_todo | 软删同时清空 action_type/action_key |
+| backend/src/db/todo.rs batch_delete_todos | 同上（批量路径） |
+| backend/src/db/todo.rs soft_delete_todo | 同上（内部路径防御一致） |
+
+修复前：删除 action 事项后再次分享，find 不到（查找过滤 deleted_at IS NULL）→ 新建时撞唯一索引 UNIQUE constraint failed 报错。修复后：删除即释放键位，再次分享创建全新事项。
+
+# 4. 测试与验证
+
+## 后端
+
+- 新增 4 个单测（todo_center_tests）：delete_todo / batch_delete_todos / soft_delete_todo 清空 action 标识 + 删除后同键重建成功（唯一索引释放回归防线）。
+- cargo test 全量通过；cargo clippy --all-targets -- -D warnings 零告警。
+
+## 前端
+
+- npx tsc --noEmit 零错误；npm run build 成功。
+- Playwright 回归：026-expert-contribution.spec.ts（4 用例）、027-resource-contribute.spec.ts（3 用例）全过——分享入口渲染与提示词行为不变。
+- 新增 frontend/tests/113-share-source-labels.spec.ts（route mock，确定性）：事项中心 4 类分享事项渲染中文来源标签（专家贡献/工艺分享/技能分享/模板分享），且不出现原始英文 action_type。
+
+# 5. 兼容性与遗留
+
+- 存量已创建的资源级 action 事项（如开发库 id 65/94/95/96/97）不自动合并，保留用户历史；新分享只影响新创建。
+- 每个工作空间独立一份 action 事项（V48 workspace 级索引，设计如此，非本需求范围）。
+- 事项标题仍为后端生成的 "Action: {type}/{key}"（与标题优化一致），资源信息在执行记录 params 中。

--- a/frontend/src/components/ProcessPage.tsx
+++ b/frontend/src/components/ProcessPage.tsx
@@ -346,7 +346,6 @@ function ProcessListView({ workspaceId, onOpenLoop, processGuid }: Omit<ProcessP
               <span key="share">
                 <ShareToRepoButton
                   actionType="process_contribute"
-                  actionKey={p.guid}
                   params={{
                     resource_name: p.name,
                     version: p.version,

--- a/frontend/src/components/TodoCenterCard.tsx
+++ b/frontend/src/components/TodoCenterCard.tsx
@@ -33,6 +33,12 @@ export function sourceLabel(actionType?: string | null): string | null {
     blackboard_propose: '黑板推荐',
     title_optimize: '标题优化',
     prompt_optimize: 'Prompt 优化',
+    // 113：分享类 action 统一 key 后事项中心只显示 4 个分享事项，
+    // 中文标签让「快捷」来源 Tag 与来源筛选下拉可读（否则显示原始英文串）
+    expert_contribute: '专家贡献',
+    process_contribute: '工艺分享',
+    skill_contribute: '技能分享',
+    todo_contribute: '模板分享',
   };
   return map[actionType] ?? actionType;
 }

--- a/frontend/src/components/settings/contribute/ShareToRepoButton.tsx
+++ b/frontend/src/components/settings/contribute/ShareToRepoButton.tsx
@@ -12,6 +12,11 @@ import { useViewState } from '@/hooks/useViewState';
 import { getContributionAuthStatus } from '@/utils/database/contribution';
 import { THIRD_PARTY_SETTINGS_TAB } from '@/components/settings/ThirdPartyPanel';
 
+// 113：分享类 action 统一固定 actionKey（与标题优化 title_optimize/default 同口径）——
+// 一类分享只占一个事项（expert/process/skill/todo_contribute 各 1 个），
+// 重复分享只新增执行记录，资源区分靠 params（resource_name/remote_path），不再按资源建事项。
+const SHARE_ACTION_KEY = 'default';
+
 /**
  * 把定义目录的绝对路径转成 ~/ 相对路径，避免在 prompt/执行记录里暴露家目录下的用户名。
  * 资源目录都在 ~/.ntd/ 下（~/.ntd/experts/、~/.ntd/processes/、~/.ntd/bundled/ 等）。
@@ -32,7 +37,6 @@ export function toHomePath(absPath: string): string {
  */
 export function ShareToRepoButton({
   actionType,
-  actionKey,
   params,
   buildPrompt,
   panelTitle,
@@ -43,8 +47,6 @@ export function ShareToRepoButton({
 }: {
   /** ActionButton action_type（按资源区分：expert/process/todo/skill_contribute） */
   actionType: string;
-  /** ActionButton action_key（资源名，用于执行记录去重） */
-  actionKey: string;
   /** 提示词占位符参数（{{key}} 替换），与 buildPrompt 的占位符一一对应 */
   params: Record<string, string>;
   /** 提示词构建函数（按资源类型），在渲染 ActionButton 时调用 */
@@ -108,7 +110,8 @@ export function ShareToRepoButton({
     return (
       <ActionButton
         actionType={actionType}
-        actionKey={actionKey}
+        // 113：固定 key，一类分享共用一个事项；actionType 负责区分四类资源
+        actionKey={SHARE_ACTION_KEY}
         prompt={buildPrompt()}
         params={finalParams}
         icon={<ShareAltOutlined />}

--- a/frontend/src/components/settings/experts/ContributeButton.tsx
+++ b/frontend/src/components/settings/experts/ContributeButton.tsx
@@ -36,7 +36,6 @@ export function ContributeButton({
   return (
     <ShareToRepoButton
       actionType={CONTRIBUTE_ACTION_TYPE}
-      actionKey={expert.name}
       params={{
         expert_name: expert.name,
         version: expert.version,

--- a/frontend/src/components/settings/templates/ProcessTemplatesTab.tsx
+++ b/frontend/src/components/settings/templates/ProcessTemplatesTab.tsx
@@ -125,7 +125,6 @@ export function ProcessTemplatesTab({ refreshTick }: { refreshTick?: number }) {
           {!record.is_system && record.source_path && (
             <ShareToRepoButton
               actionType="process_contribute"
-              actionKey={record.guid}
               params={{
                 resource_name: record.name,
                 version: record.version,

--- a/frontend/src/components/settings/templates/SkillTemplatesTab.tsx
+++ b/frontend/src/components/settings/templates/SkillTemplatesTab.tsx
@@ -68,7 +68,6 @@ export function SkillTemplatesTab({ refreshTick }: { refreshTick?: number }) {
       render: (_: unknown, record: BundledSkillMeta) => (
         <ShareToRepoButton
           actionType="skill_contribute"
-          actionKey={record.name}
           params={{
             resource_name: record.short_name,
             version: record.version || '',

--- a/frontend/src/components/settings/templates/TodoTemplatesTab.tsx
+++ b/frontend/src/components/settings/templates/TodoTemplatesTab.tsx
@@ -145,7 +145,6 @@ export function TodoTemplatesTab() {
                     {!record.is_system && (
                       <ShareToRepoButton
                         actionType="todo_contribute"
-                        actionKey={`todo-${record.id}`}
                         params={{
                           resource_name: record.title,
                           version: '',

--- a/frontend/src/components/skills/SkillCardView.tsx
+++ b/frontend/src/components/skills/SkillCardView.tsx
@@ -185,7 +185,6 @@ function SkillCard({ skill, executors, onClick, shareDir }: {
           >
             <ShareToRepoButton
               actionType="skill_contribute"
-              actionKey={skill.name}
               params={{
                 resource_name: skill.name,
                 version: skill.version || '',

--- a/frontend/tests/113-share-source-labels.spec.ts
+++ b/frontend/tests/113-share-source-labels.spec.ts
@@ -1,0 +1,51 @@
+// 113 分享事项统一：事项中心来源标签渲染中文（专家贡献/工艺分享/技能分享/模板分享）。
+// 用 route mock 固定中心接口返回 4 类分享 action 事项，不依赖开发库数据，可稳定回归。
+import { test, expect } from '@playwright/test';
+
+test('事项中心分享类来源标签为中文', async ({ page }) => {
+  const mkItem = (id: number, actionType: string | null, title: string) => ({
+    id, title, status: 'completed', computed_bucket: 'manual',
+    action_type: actionType, workspace_id: 1,
+    used_by_loop_step_count: 0, created_at: '2026-08-01T00:00:00.000Z', updated_at: '2026-08-01T00:00:00.000Z',
+  });
+  await page.route('**/todos/center*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        code: 0,
+        data: {
+          items: [
+            mkItem(1, 'expert_contribute', '分享专家测试'),
+            mkItem(2, 'process_contribute', '分享工艺测试'),
+            mkItem(3, 'skill_contribute', '分享技能测试'),
+            mkItem(4, 'todo_contribute', '分享模板测试'),
+            mkItem(5, null, '普通事项'),
+          ],
+          total: 5, page: 1, page_size: 200,
+          bucket_counts: { manual: 5 },
+          action_types: ['expert_contribute', 'process_contribute', 'skill_contribute', 'todo_contribute'],
+        },
+      }),
+    }),
+  );
+
+  await page.goto('/#/todos');
+  // 轮询等第一个中文标签出现，替代固定等待（加载完成前断言会误报）
+  const expertTag = page.locator('.todo-center-card-tags .ant-tag', { hasText: '专家贡献' }).first();
+  await expect(expertTag).toBeVisible({ timeout: 10000 });
+
+  const texts = await page.locator('.todo-center-card-tags .ant-tag').allTextContents();
+  const joined = texts.join('|');
+  console.log('卡片标签:', JSON.stringify(texts));
+  // 4 类分享 action_type 均应映射为中文标签（113 统一后事项中心只显示这几个分享事项）
+  expect(joined).toContain('专家贡献');
+  expect(joined).toContain('工艺分享');
+  expect(joined).toContain('技能分享');
+  expect(joined).toContain('模板分享');
+  // 不得回退显示原始英文 action_type
+  expect(joined).not.toContain('expert_contribute');
+  expect(joined).not.toContain('process_contribute');
+  expect(joined).not.toContain('skill_contribute');
+  expect(joined).not.toContain('todo_contribute');
+});


### PR DESCRIPTION
## 背景
用户观察到专家/工艺分享 action 按钮每个资源产生一个事项，而标题优化一类 action 只用一个事项，要求统一。

## 调查结论
后端按 action_type + action_key + workspace_id 查找或创建事项（唯一索引兜底）：
- 同一资源重复点击**不会**新建事项，只新增执行记录（实证：单事项 4 条执行记录）
- 差异在前端 action_key 取值粒度：标题优化固定 "default"，分享类传资源标识

## 改动
- **前端**：ShareToRepoButton 移除 actionKey prop 固定 "default"（6 处调用点清理），4 类分享各只占 1 个事项；sourceLabel 补 4 类分享中文标签
- **后端**：软删除同时清空 action_type/action_key，释放唯一索引占用，修复删除后再次分享 UNIQUE 冲突

## 验证
- cargo test 全量通过（1776+ 用例 0 失败），clippy -D warnings 零告警
- tsc --noEmit 零错误，npm run build 成功
- Playwright：026（4 用例）/027（3 用例）回归全过；新增 113-share-source-labels.spec.ts（route mock 确定性验证中文来源标签）
- 设计文档 docs/design/113-分享事项统一-设计.md；实现总结 docs/requirements/113-分享事项统一-实现总结.md