### PR TITLE
feat(114): 事项/任务/环路列表全列表头排序统一

### DIFF
--- a/backend/src/db/todo.rs
+++ b/backend/src/db/todo.rs
@@ -34,6 +34,34 @@ const TODO_CENTER_BUCKET_EXPR: &str = "CASE \
     WHEN t.webhook_enabled = 1 THEN 'event_driven' \
     ELSE 'manual' END";
 
+/// 114：类型排序键，与 TodoListView 类型列渲染优先级严格一致（评审 > 异常处理 > 快捷 > 事项）。
+/// todo_type 为 NULL 视为 0（普通事项，COALESCE 兜底）；action_type 非空视为「快捷」。
+/// CASE 输出 0..=3 让 SQLite 按数值排序，升/降序都符合用户对类型分组的直觉。
+const TODO_CENTER_TYPE_EXPR: &str = "CASE \
+    WHEN COALESCE(t.todo_type, 0) = 2 THEN 2 \
+    WHEN COALESCE(t.todo_type, 0) = 3 THEN 3 \
+    WHEN t.action_type IS NOT NULL AND t.action_type != '' THEN 1 \
+    ELSE 0 END";
+
+/// 114：最近执行记录的 status（相关子查询取该 todo 的 MAX(id) 记录）。
+/// 口径必须与 execution.rs get_latest_execution_summaries_for_todos 一致——
+/// 聚合展示用「id 最大 = 最近一条」（自增主键）；若改用时间排序，补录历史记录时
+/// 排序结果会与页面展示的「最近执行」不一致。命中 idx_execution_records_todo_id。
+const TODO_CENTER_LAST_EXEC_STATUS_EXPR: &str = "(SELECT er2.status FROM execution_records er2 \
+    WHERE er2.todo_id = t.id ORDER BY er2.id DESC LIMIT 1)";
+
+/// 114：最近执行记录的展示时间（MAX(id) 口径），优先 finished_at 回退 started_at，
+/// 与 LatestExecutionSummary::display_at 语义一致。无执行记录时为 NULL。
+const TODO_CENTER_LAST_EXEC_AT_EXPR: &str = "(SELECT COALESCE(er2.finished_at, er2.started_at) \
+    FROM execution_records er2 WHERE er2.todo_id = t.id ORDER BY er2.id DESC LIMIT 1)";
+
+/// 114：引用环路数（enabled=1 的 loop_steps 计数）。
+/// 环路列/工艺列的展示数据都来自 referencing_loops（get_referencing_loops_for_todos 的
+/// enabled=1 口径），排序键用同一计数子查询保证排序与展示一致；与 computed_bucket 的
+/// loop_driven 判断同源。无引用时为 NULL，DESC 时沉底。
+const TODO_CENTER_LOOP_REF_COUNT_EXPR: &str =
+    "(SELECT COUNT(*) FROM loop_steps ls WHERE ls.todo_id = t.id AND ls.enabled = 1)";
+
 /// ComputedBucket → SQL 表达式输出字符串（与 serde snake_case 保持一致）。
 fn center_bucket_str(b: ComputedBucket) -> &'static str {
     match b {
@@ -52,6 +80,19 @@ fn center_sort_column(sort_by: Option<&str>) -> &'static str {
         Some("updated_at") => "t.updated_at",
         Some("title") => "t.title COLLATE NOCASE",
         Some("status") => "t.status",
+        // 114：类型列（前端无 dataIndex，antd 用 key='type' 作排序 field）
+        Some("type") => TODO_CENTER_TYPE_EXPR,
+        // 114：最近执行状态/时间（聚合列，相关子查询——见常量注释的口径对齐说明）
+        Some("last_execution_status") => TODO_CENTER_LAST_EXEC_STATUS_EXPR,
+        Some("last_execution_at") => TODO_CENTER_LAST_EXEC_AT_EXPR,
+        // 114：普通字段列（NULL 由 SQLite 排最小，DESC 时沉底）
+        Some("executor") => "t.executor",
+        Some("expert_name") => "t.expert_name",
+        // 114：调度列（无 dataIndex，antd 用 key='scheduler'）——按 cron 配置存在性排序
+        Some("scheduler") => "t.scheduler_config",
+        // 114：环路/工艺列（展示同源 referencing_loops），按引用环路数排序
+        Some("loop") => TODO_CENTER_LOOP_REF_COUNT_EXPR,
+        Some("process") => TODO_CENTER_LOOP_REF_COUNT_EXPR,
         Some("computed_bucket") => TODO_CENTER_BUCKET_EXPR,
         _ => "t.id",
     }
@@ -2782,6 +2823,252 @@ mod todo_center_tests {
             vec![archived_id, manual_id, time_id],
             "ASC 应按 bucket 名字典序 archived < manual < time_driven"
         );
+    }
+
+    /// 114：center_sort_column 白名单新增分支映射 + 非法输入回退默认 id。
+    /// 白名单是 SQL 拼接的唯一安全途径（参数绑定不能绑标识符），映射错误=注入面扩大。
+    #[test]
+    fn test_center_sort_column_new_branches() {
+        // 新增三个分支必须返回对应常量（与实现同步改，防止拼写漂移）
+        assert_eq!(center_sort_column(Some("type")), TODO_CENTER_TYPE_EXPR);
+        assert_eq!(
+            center_sort_column(Some("last_execution_status")),
+            TODO_CENTER_LAST_EXEC_STATUS_EXPR
+        );
+        assert_eq!(
+            center_sort_column(Some("last_execution_at")),
+            TODO_CENTER_LAST_EXEC_AT_EXPR
+        );
+        // 114：全列排序——普通字段/复合列分支映射到预期表达式
+        assert_eq!(center_sort_column(Some("executor")), "t.executor");
+        assert_eq!(center_sort_column(Some("expert_name")), "t.expert_name");
+        assert_eq!(center_sort_column(Some("scheduler")), "t.scheduler_config");
+        assert_eq!(center_sort_column(Some("loop")), TODO_CENTER_LOOP_REF_COUNT_EXPR);
+        assert_eq!(center_sort_column(Some("process")), TODO_CENTER_LOOP_REF_COUNT_EXPR);
+        // 白名单外输入（含注入尝试）一律回退 t.id，不进入 SQL
+        assert_eq!(center_sort_column(Some("evil; DROP TABLE todos")), "t.id");
+        assert_eq!(center_sort_column(None), "t.id");
+        // 既有分支不回归
+        assert_eq!(center_sort_column(Some("title")), "t.title COLLATE NOCASE");
+    }
+
+    /// 114：sort_by=last_execution_at 的排序口径 = MAX(id) 记录的 COALESCE(finished_at, started_at)，
+    /// 与展示层 get_latest_execution_summaries_for_todos 严格一致。
+    /// b 的两条记录时间乱序写入（id 更大的那条时间更旧）：若按时间取「最近一条」会得 07-03
+    /// （DESC 时 b 在 a 前），按 MAX(id) 得 07-01（DESC 时 a 在 b 前）——断言可区分两种口径。
+    #[tokio::test]
+    async fn test_center_page_sort_by_last_execution_at() {
+        let db = fresh_db().await;
+        // a：唯一执行记录 finished=07-02（07-01 开始）
+        let a = seed_todo(&db, "a").await;
+        db.exec(&format!(
+            "INSERT INTO execution_records (todo_id, status, trigger_type, started_at, finished_at) \
+             VALUES ({a}, 'success', 'manual', '2026-07-01T00:00:00Z', '2026-07-02T00:00:00Z')"
+        ))
+        .await
+        .unwrap();
+        // b：两条记录——id 最大的那条 finished=07-01（更旧），id 小的反而 07-03（更新）
+        let b = seed_todo(&db, "b").await;
+        db.exec(&format!(
+            "INSERT INTO execution_records (todo_id, status, trigger_type, started_at, finished_at) \
+             VALUES ({b}, 'success', 'manual', '2026-07-03T00:00:00Z', '2026-07-03T01:00:00Z')"
+        ))
+        .await
+        .unwrap();
+        db.exec(&format!(
+            "INSERT INTO execution_records (todo_id, status, trigger_type, started_at, finished_at) \
+             VALUES ({b}, 'failed', 'manual', '2026-07-01T00:00:00Z', '2026-07-01T01:00:00Z')"
+        ))
+        .await
+        .unwrap();
+        // c：无执行记录 → 子查询 NULL
+        let c = seed_todo(&db, "c").await;
+
+        // DESC：按 MAX(id) 口径 a(07-02) > b(07-01) > c(NULL 沉底)
+        let (items, _, _, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None,
+                bucket: None,
+                search: None,
+                status: None,
+                action_type: None,
+                sort_by: Some("last_execution_at"),
+                sort_desc: true,
+                page: 1,
+                page_size: 20,
+                hours: None,
+            })
+            .await
+            .map(center_tuple)
+            .unwrap();
+        let order: Vec<i64> = items.iter().map(|i| i.todo.id).collect();
+        assert_eq!(order, vec![a, b, c], "DESC 应 a > b > c(无记录沉底)，口径为 MAX(id)");
+        // 展示时间与排序键同源：b 的 last_execution_at 必须是 id 最大记录的 07-01
+        let item_b = items.iter().find(|i| i.todo.id == b).unwrap();
+        assert_eq!(
+            item_b.last_execution_at.as_deref(),
+            Some("2026-07-01T01:00:00Z"),
+            "last_execution_at 展示与排序必须同口径（MAX(id) 记录）"
+        );
+
+        // ASC：NULL 最小 → c 排最前
+        let (items2, _, _, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None,
+                bucket: None,
+                search: None,
+                status: None,
+                action_type: None,
+                sort_by: Some("last_execution_at"),
+                sort_desc: false,
+                page: 1,
+                page_size: 20,
+                hours: None,
+            })
+            .await
+            .map(center_tuple)
+            .unwrap();
+        let order2: Vec<i64> = items2.iter().map(|i| i.todo.id).collect();
+        assert_eq!(order2, vec![c, b, a], "ASC 应 c(NULL 最小) 最前，其后 b > a");
+    }
+
+    /// 114：sort_by=type 按 CASE 权重排序：异常处理(3) > 评审(2) > 快捷(1) > 事项(0)。
+    /// 权重与 TodoListView 类型列渲染优先级一致（评审/异常优先判断、action_type 快捷次之）。
+    #[tokio::test]
+    async fn test_center_page_sort_by_type() {
+        let db = fresh_db().await;
+        // 普通事项：todo_type NULL → COALESCE 按 0（事项）
+        let normal = seed_todo(&db, "普通").await;
+        // 评审：todo_type=2
+        let review = seed_todo(&db, "评审").await;
+        db.exec(&format!("UPDATE todos SET todo_type = 2 WHERE id = {review}"))
+            .await
+            .unwrap();
+        // 异常处理：todo_type=3
+        let abnormal = seed_todo(&db, "异常").await;
+        db.exec(&format!("UPDATE todos SET todo_type = 3 WHERE id = {abnormal}"))
+            .await
+            .unwrap();
+        // 快捷：action_type 非空且 todo_type 非 2/3
+        let quick = seed_todo(&db, "快捷").await;
+        db.exec(&format!("UPDATE todos SET action_type = 'at' WHERE id = {quick}"))
+            .await
+            .unwrap();
+
+        // DESC：3 > 2 > 1 > 0
+        let (items, _, _, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None,
+                bucket: None,
+                search: None,
+                status: None,
+                action_type: None,
+                sort_by: Some("type"),
+                sort_desc: true,
+                page: 1,
+                page_size: 20,
+                hours: None,
+            })
+            .await
+            .map(center_tuple)
+            .unwrap();
+        let order: Vec<i64> = items.iter().map(|i| i.todo.id).collect();
+        assert_eq!(order, vec![abnormal, review, quick, normal], "DESC 应按 3>2>1>0");
+
+        // ASC：0 < 1 < 2 < 3
+        let (items2, _, _, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None,
+                bucket: None,
+                search: None,
+                status: None,
+                action_type: None,
+                sort_by: Some("type"),
+                sort_desc: false,
+                page: 1,
+                page_size: 20,
+                hours: None,
+            })
+            .await
+            .map(center_tuple)
+            .unwrap();
+        let order2: Vec<i64> = items2.iter().map(|i| i.todo.id).collect();
+        assert_eq!(order2, vec![normal, quick, review, abnormal], "ASC 应按 0<1<2<3");
+    }
+
+    /// 114：sort_by=loop/process 按引用环路数（enabled=1 的 loop_steps）排序，
+    /// 与 referencing_loops 展示口径同源。禁用 step 不计入；无引用沉底（DESC）。
+    #[tokio::test]
+    async fn test_center_page_sort_by_loop_ref_count() {
+        let db = fresh_db().await;
+        // a：2 条 enabled 引用 + 1 条 disabled 引用（禁用不计）
+        let a = seed_todo(&db, "a").await;
+        // b：1 条 enabled 引用
+        let b = seed_todo(&db, "b").await;
+        // c：无引用
+        let c = seed_todo(&db, "c").await;
+        for (todo_id, enabled) in [(a, 1), (a, 1), (a, 0), (b, 1)] {
+            // loop_steps.loop_id/name 为 NOT NULL，先建一条环路再挂 step
+            db.exec("INSERT INTO loops (name) VALUES ('L')").await.unwrap();
+            let row = db
+                .conn
+                .query_one(Statement::from_string(
+                    DbBackend::Sqlite,
+                    "SELECT last_insert_rowid() AS id",
+                ))
+                .await
+                .expect("query loop id")
+                .expect("row exists");
+            let loop_id: i64 = row.try_get_by("id").expect("id readable");
+            db.exec(&format!(
+                "INSERT INTO loop_steps (loop_id, name, todo_id, enabled) \
+                 VALUES ({loop_id}, 's', {todo_id}, {enabled})"
+            ))
+            .await
+            .unwrap();
+        }
+
+        // DESC：a(2) > b(1) > c(NULL 沉底)
+        for sort_by in ["loop", "process"] {
+            let (items, _, _, _, _) = db
+                .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                    workspace_id: None,
+                    bucket: None,
+                    search: None,
+                    status: None,
+                    action_type: None,
+                    sort_by: Some(sort_by),
+                    sort_desc: true,
+                    page: 1,
+                    page_size: 20,
+                    hours: None,
+                })
+                .await
+                .map(center_tuple)
+                .unwrap();
+            let order: Vec<i64> = items.iter().map(|i| i.todo.id).collect();
+            assert_eq!(order, vec![a, b, c], "{sort_by} DESC 应按引用数 a>b>c");
+        }
+
+        // ASC：c(NULL 最小) 最前
+        let (items2, _, _, _, _) = db
+            .get_todo_center_page(crate::db::TodoCenterPageQuery {
+                workspace_id: None,
+                bucket: None,
+                search: None,
+                status: None,
+                action_type: None,
+                sort_by: Some("loop"),
+                sort_desc: false,
+                page: 1,
+                page_size: 20,
+                hours: None,
+            })
+            .await
+            .map(center_tuple)
+            .unwrap();
+        let order2: Vec<i64> = items2.iter().map(|i| i.todo.id).collect();
+        assert_eq!(order2, vec![c, b, a], "loop ASC 应 c 最前");
     }
 
     /// 056 评审补测：搜索词含 LIKE 通配符（%/_）时被转义，不作为通配符匹配。

--- a/docs/design/114-列表表格排序统一-设计.md
+++ b/docs/design/114-列表表格排序统一-设计.md
@@ -1,0 +1,112 @@
+# 114-列表表格排序统一-设计
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08-17 | 初始版本 |
+| AI | 2026-08-17 | 全列排序扩展 + useResizableColumns 取消排序卡死修复 |
+
+> 对应需求：`docs/requirements/114-列表表格排序统一-需求.md`。
+
+## 1. 背景与现状
+
+三大业务列表排序能力现状（054/056 已落地）：
+
+| 列表 | 方式 | 排序列 | 本次改动 |
+|------|------|--------|---------|
+| 事项 `#/todos?view=list` | 服务端（056） | ID/标题/状态/更新时间 → **12 列全排（除操作）** | 扩充 8 列 |
+| 任务 `#/tasks?view=list` | 客户端（054） | 6 列 → **8 列全排（除操作）** | 补工艺/最近执行 |
+| 环路 `#/loops?view=list` | 客户端（054） | 7 列 → **9 列全排（除操作）** | 补工艺/最近执行 |
+
+## 2. 设计
+
+### C1：后端 `center_sort_column` 白名单扩展（todo.rs）
+
+新增 SQL 常量（口径对齐依据见各常量注释）：
+
+| 常量 | 用途 |
+|------|------|
+| `TODO_CENTER_TYPE_EXPR` | 类型列：CASE 权重（评审 2 > 异常 3 > 快捷 1 > 事项 0，与 TodoListView 渲染优先级一致） |
+| `TODO_CENTER_LAST_EXEC_STATUS_EXPR` | 最近执行状态：`(SELECT er2.status FROM execution_records er2 WHERE er2.todo_id = t.id ORDER BY er2.id DESC LIMIT 1)` |
+| `TODO_CENTER_LAST_EXEC_AT_EXPR` | 执行时间：同上取 `COALESCE(finished_at, started_at)`（`display_at` 语义） |
+| `TODO_CENTER_LOOP_REF_COUNT_EXPR` | 环路/工艺列：`(SELECT COUNT(*) FROM loop_steps ls WHERE ls.todo_id = t.id AND ls.enabled = 1)` |
+
+白名单新增分支：`type / last_execution_status / last_execution_at / executor / expert_name / scheduler / loop / process`。
+
+**口径对齐依据（重要）**：
+1. 聚合展示 `get_latest_execution_summaries_for_todos`（execution.rs:364）取「最近一条」用 **`MAX(id)`**（自增主键，非时间排序），展示时间 `display_at` = finished_at 回退 started_at。排序子查询必须同口径（`ORDER BY er2.id DESC LIMIT 1`），否则补录历史记录场景下排序与展示不一致。
+2. 环路/工艺列展示数据来自 `get_referencing_loops_for_todos`（enabled=1 口径），排序键用同源计数子查询；与 computed_bucket 的 loop_driven 判断同源。
+3. 类型列 CASE 权重与 TodoListView 渲染分支顺序一致（todo_type=2 评审 → 3 异常处理 → action_type 快捷 → 事项）。
+
+**索引支撑**：执行记录子查询命中 `idx_execution_records_todo_id`（v1.rs:175）；loop_steps 计数走 todo_id 过滤，量级小。
+
+**NULL 语义**：无执行记录/无引用的行子查询为 NULL——SQLite 排序 NULL 最小（ASC 最前、DESC 沉底），与展示「-」直觉一致。
+
+### C2：useResizableColumns 取消排序卡死修复（核心 bug）
+
+**现象**：点击默认排序列（ID，初始受控 descend）后请求无 sort_by，再点仍无效，三态循环卡死。
+
+**根因**（antd useSorter.js `generateSorterInfo`）：
+- antd 三态循环 `null → ascend → descend → null`；
+- **取消排序时**（activeSorters 为空）antd 为 legacy 兼容传入**空 sorter 对象**（`{ field: undefined, order: undefined, columnKey: undefined }`）；
+- 原 hook 收到空 sorter 后回退 `DEFAULT_SORT`（{id, descend}）→ 重新注入 ID 列 descend → 下次点击又从 descend 取消 → **死循环**。
+
+**修复**：取消时保存「无排序」状态（`{ field: '', order: null }`），不回退默认：
+
+```ts
+// antd 取消排序时 activeSorters 为空，onChange 传「空 sorter」（legacy 兼容），
+// 此时必须保存「无排序」而非回退 DEFAULT_SORT——否则默认列永远处于受控
+// descend，点击取消被覆盖回 descend，三态循环卡死。
+const nextSort: SortState = s?.order
+  ? { field, order: s.order }
+  : { field: '', order: null };
+```
+
+同时 TodoListView / hook 的 field 提取补 `columnKey` 兜底：无 dataIndex 的列（类型/调度/环路/工艺）antd 的 `sorter.field` 为 undefined，必须回退 `columnKey`（归一化 key），否则排序偏好丢失。
+
+### C3：前端列定义
+
+- **TodoListView**：12 列 `sorter: true`（ID/类型/标题/状态/执行器/专家/调度/环路/工艺/最近执行/执行时间/更新时间），操作列保持不可排。
+- **TasksTableView**：补「工艺」（`makeSorter('template_name')`）、「最近执行」（`makeSorter('latest_execution_status')`）。
+- **LoopListViewParts**：补「工艺」（`compareValues(loopProcessText(a), loopProcessText(b))`，按展示文本排）、「最近执行」（`makeSorter('last_execution_status')`）。
+
+### C4：后端测试（4 个新增）
+
+1. `test_center_sort_column_new_branches`：白名单全分支映射 + 非法输入回退；
+2. `test_center_page_sort_by_last_execution_at`：MAX(id) 口径区分测试（b 的两条记录时间乱序写入，断言排序用 id 序）+ NULL 沉底/前置；
+3. `test_center_page_sort_by_type`：CASE 权重 3>2>1>0 双向；
+4. `test_center_page_sort_by_loop_ref_count`：loop/process 按引用数排序（禁用 step 不计）。
+
+## 3. 影响模块
+
+| 层 | 文件 | 改动 |
+|----|------|------|
+| 后端 | `backend/src/db/todo.rs` | +4 常量、白名单 +8 分支、4 个测试 |
+| 前端 | `frontend/src/components/todo-list/TodoListView.tsx` | 8 列加 sorter + columnKey 兜底 |
+| 前端 | `frontend/src/components/tasks/TasksTableView.tsx` | 补 2 列 |
+| 前端 | `frontend/src/components/loop-list/LoopListViewParts.tsx` | 补 2 列 |
+| 前端 | `frontend/src/hooks/useResizableColumns.tsx` | 取消排序修复 + columnKey 兜底 |
+| 测试 | `frontend/tests/check_114_sort.spec.ts` / `check_114_other.spec.ts` | 新增验证 spec |
+
+无迁移、无接口 schema 变化（sort_by 是既有参数，仅扩展取值）。
+
+## 4. 不做的事（范围边界）
+
+- 其他页面表格不加排序（需求 §3 用户确认范围）
+- 操作列不排序；不做多列排序与拖拽排序
+
+## 5. 验证方案
+
+1. `cargo clippy --all-targets -- -D warnings` 零告警；`cargo test` 全绿（1779+ 通过）。
+2. `npx tsc --noEmit` 零错误。
+3. Playwright（check_114_sort / check_114_other）：
+   - 事项表 12 列全部可排，每列 asc/desc 请求参数正确；
+   - 更新时间/执行时间 desc 首行与 API 直查一致（跨页排序正确）；
+   - 任务/环路补充列可排，点击无异常；
+   - 既有 spec 全量无回归（环境相关用例除外）。
+4. 用户手工点击确认无问题。
+
+## 6. 安全反思
+
+- 排序字段仍走 `center_sort_column` 白名单——子查询/表达式是常量而非用户输入，SQL 注入面不新增；
+- 子查询只读不写，无数据风险；回滚 = 移除白名单分支，无状态；
+- hook 改动只影响排序偏好存储（无排序状态），不触及列宽与数据。

--- a/docs/requirements/114-列表表格排序统一-实现总结.md
+++ b/docs/requirements/114-列表表格排序统一-实现总结.md
@@ -1,0 +1,57 @@
+# 114-列表表格排序统一-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08-17 | 初始版本 |
+
+> 对应设计：`docs/design/114-列表表格排序统一-设计.md`、需求：`docs/requirements/114-列表表格排序统一-需求.md`。
+
+## 1. 实现了什么
+
+三大业务列表（事项/任务/环路）的表头排序能力补齐与统一：
+
+1. **事项表全列服务端排序**：056 只有 ID/标题/状态/更新时间 4 列，本次扩至 12 列（除「操作」按钮列）——
+   新增 类型 / 执行器 / 专家 / 调度 / 环路 / 工艺 / 最近执行 / 执行时间；
+2. **任务表补齐**：工艺（按模板名）、最近执行 2 列（客户端排序）；
+3. **环路表补齐**：工艺（按展示文本）、最近执行 2 列（客户端排序）；
+4. **useResizableColumns 取消排序卡死修复**：antd 取消排序时传空 sorter，原 hook 回退默认排序导致默认列三态循环卡死。
+
+## 2. 与设计的对应关系
+
+| 设计项 | 落地 | 状态 |
+|--------|------|------|
+| C1 白名单扩展 | `center_sort_column` +8 分支、4 个 SQL 常量（type CASE / MAX(id) 子查询 ×2 / loop_steps 计数） | ✅ |
+| C2 hook 修复 | 取消时保存「无排序」+ field/columnKey 双兜底 | ✅ |
+| C3 前端列定义 | TodoListView 12 列 / TasksTableView +2 / LoopListViewParts +2 | ✅ |
+| C4 后端测试 | 4 个新增（白名单/执行时间口径/类型权重/引用计数） | ✅ |
+
+## 3. 关键实现点
+
+- **MAX(id) 口径对齐**：聚合展示 `get_latest_execution_summaries_for_todos` 用「id 最大 = 最近一条」（自增主键），排序子查询必须同口径而非按时间——测试 `test_center_page_sort_by_last_execution_at` 用乱序写入的记录验证两者差异，防止口径漂移。
+- **antd 取消排序空 sorter（legacy 兼容）**：useSorter.js `generateSorterInfo` 在 activeSorters 为空时传 `{ field: undefined, order: undefined }`。这是默认列三态卡死的根因（原 hook 回退 DEFAULT_SORT 重新注入 descend）。修复后取消 → 无排序 → 后端默认 ID 倒序，语义与视觉一致。
+- **columnKey 兜底**：无 dataIndex 的列（类型/调度/环路/工艺）`sorter.field` 为 undefined，需回退 `columnKey`，否则 sort_by 参数丢失（Playwright 实测发现）。
+- **类型列 CASE 权重**：评审(2) > 异常处理(3) > 快捷(1) > 事项(0)，与 TodoListView 渲染分支顺序一致。
+- **NULL 沉底**：无执行记录/无引用行 DESC 沉底、ASC 前置，与展示「-」直觉一致。
+
+## 4. 测试与验证结果
+
+- `cargo clippy --all-targets -- -D warnings`：零告警 ✅
+- `cargo test`：lib 1779 通过（含 4 个新增），集成测试 28 通过 ✅
+- `npx tsc --noEmit`：零错误 ✅
+- Playwright（worktree dev 环境实测）：
+  - `check_114_sort.spec.ts`：12 列全部可排，每列 asc/desc 请求参数正确；更新时间/执行时间 desc 首行与 API 直查一致 ✅
+  - `check_114_other.spec.ts`：任务 8 列 / 环路 9 列可排，工艺/最近执行补充列生效 ✅
+  - 用户手工点击确认无问题 ✅
+- 已知环境问题（与本 PR 无关）：vitest 的 `useResizableColumns.test.tsx` / `tablePrefs.test.ts` / `loop-list/index.test.tsx` 在 Node 22 下因实验性 localStorage（`--localstorage-file` 未提供）失败，main 分支同样失败；既有 Playwright spec 全量结果见 PR 评论。
+
+## 5. 已知限制 / 后续候选
+
+- 执行记录子查询排序在万行级 todo 下逐行求值，量级可接受；数据量再增长可评估 `(todo_id, id)` 复合索引；
+- 任务/环路为客户端排序（数据全量），与事项表服务端排序语义不同但交互一致；
+- 其他页面表格（仪表盘/设置页等）排序不在本次范围（用户确认）。
+
+## 6. 安全反思
+
+- 排序字段白名单是 SQL 拼接的唯一入口，新分支均为常量表达式，注入面不新增；
+- 子查询只读不写，回滚 = 移除白名单分支，无状态；
+- localStorage 读取沿用既有 JSON.parse 容错 + 白名单校验，无新风险。

--- a/docs/requirements/114-列表表格排序统一-需求.md
+++ b/docs/requirements/114-列表表格排序统一-需求.md
@@ -1,0 +1,87 @@
+# 0. 文件修改记录表
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08-17 | 初始版本 — 事项表排序列扩充，三大列表表头排序统一 |
+| AI | 2026-08-17 | 范围修订：全列排序（操作列除外）+ hook 取消排序卡死修复 |
+
+# 1. 背景（Why）
+
+1. 事项列表（`#/todos?view=list`）的 056 服务端排序只开放了 ID/标题/状态/更新时间 四列；
+   用户期望「类型」「最近执行」「执行时间」也能表头排序，进一步要求**全列（操作列除外）可排**。
+2. 三大业务列表（事项/任务/环路）的排序能力需统一：任务、环路已具备客户端排序（054），
+   事项表全列补齐后对齐。
+3. **范围边界（用户确认）**：只涉及事项、任务、环路三个列表，其他页面表格不改造。
+
+# 2. 目标（What，必须可验证）
+
+- [x] G1：事项表全部 12 个语义列（除「操作」按钮列）支持表头服务端排序
+- [x] G2：任务/环路表补齐剩余列（工艺/最近执行），三大列表语义列全覆盖
+- [x] G3：排序三态（升/降/取消）完整循环，取消后回到无排序（后端默认 ID 倒序）
+- [x] G4：排序状态持久化（localStorage），刷新恢复
+
+# 3. 非目标（Explicitly Out of Scope）
+
+- 其他页面的表格（仪表盘最近执行、工艺环路、会话管理、智能助手、设置页模板/执行器/云同步等）不加排序
+- 卡片形态（TodoCenterCardView / RunningBoard 看板）不加排序
+- 不做多列排序，维持单排序；不做拖拽排序
+- 操作列（纯按钮列）不排序；不新增列、不改列的 render 逻辑
+
+# 4. 使用场景 / 用户路径
+
+1. 用户进入事项列表（列表形态），点击任意语义列表头 → 服务端排序（跨页正确），再点切换方向、三态循环
+2. 用户点击任务/环路列表「工艺」「最近执行」表头 → 客户端排序
+3. 用户刷新页面 → 上次排序偏好恢复（hook 既有能力）
+
+# 5. 功能需求清单（Checklist）
+
+- [x] FR1：后端 `center_sort_column` 白名单扩展全列：type / last_execution_status / last_execution_at / executor / expert_name / scheduler / loop / process
+- [x] FR2：聚合排序子查询口径与展示一致（MAX(id) 口径；finished_at 回退 started_at；loop_steps enabled=1 计数）
+- [x] FR3：TodoListView 全部语义列 `sorter: true`（12 列）
+- [x] FR4：TasksTableView / LoopListViewParts 补齐「工艺」「最近执行」列
+- [x] FR5：`useResizableColumns` 取消排序卡死修复（antd 取消时传空 sorter → 不回退默认排序）
+- [x] FR6：后端白名单单测 + 排序集成测试（4 个新增）
+
+# 6. 约束条件
+
+- 技术：antd Table（sorter 三态）、React 19、TypeScript；后端 Rust/Axum/SQLite
+- 架构：事项表服务端排序（跨页正确）；任务/环路客户端排序（数据全量在前端）
+- 安全：排序字段一律白名单校验（`center_sort_column` 是 SQL 拼接的唯一安全途径）
+- 性能：聚合排序子查询复用 `idx_execution_records_todo_finished` / `idx_execution_records_todo_id` 索引
+
+# 7. 可修改 / 不可修改项
+
+- ❌ 不可修改：三大列表既有排序列与行为、后端分页参数、rowSelection 批量行为
+- ✅ 可调整：事项表新增排序列范围、排序字段白名单
+
+# 8. 接口与数据约定
+
+**后端 `/todos/center` 排序字段（全列）**：
+
+| sort_by | SQL 排序键 |
+|---------|-----------|
+| id / updated_at / title / status | 既有字段 |
+| type | 类型 CASE（评审>异常处理>快捷>事项，与渲染优先级一致） |
+| last_execution_status / last_execution_at | MAX(id) 执行记录子查询（status / COALESCE(finished_at,started_at)） |
+| executor / expert_name | 直接字段 |
+| scheduler | t.scheduler_config（有调度排前） |
+| loop / process | 引用环路数（loop_steps enabled=1 计数） |
+
+# 9. 验收标准
+
+- 如果用户点击事项表任意语义列表头，则全部分页按该列排序（跨页正确），三态循环完整
+- 如果用户点击「类型」表头，则评审/异常处理/快捷/事项分组排序正确
+- 如果排序字段非法（非白名单），则后端回退默认排序，不报错
+- 如果用户刷新页面，则排序偏好恢复（hook 既有能力）
+- 如果用户取消排序（第三态），则回到无排序（后端默认 ID 倒序），不再卡死在默认列
+
+# 10. 风险与已知不确定点
+
+- 聚合子查询排序在万行级数据量下每行执行一次相关子查询——有既有索引覆盖，需 EXPLAIN 抽查
+- NULL 语义：无执行记录/无引用的行，DESC 时沉底、ASC 时排前（与展示「-」直觉一致）
+
+# 11. 非目标
+
+- 不新增列、不改变 render 逻辑
+- 不改三大主列表既有排序列
+- 不处理其他页面表格与卡片/看板形态排序

--- a/frontend/src/components/loop-list/LoopListViewParts.tsx
+++ b/frontend/src/components/loop-list/LoopListViewParts.tsx
@@ -22,7 +22,7 @@ import {
 } from '@ant-design/icons';
 import { formatRelativeTime } from '@/utils/datetime';
 import { formatProcessText } from '@/utils/processText';
-import { makeSorter } from '@/hooks/useResizableColumns';
+import { makeSorter, compareValues } from '@/hooks/useResizableColumns';
 import type { LoopListItem } from '@/types/loop';
 
 /** 环路状态 → 中文 + 颜色；与 LoopStudioDetailPanel 的状态展示保持一致。 */
@@ -140,6 +140,8 @@ export function buildColumns({
       key: 'process',
       width: 240,
       ellipsis: true,
+      // 114：补齐排序——按展示文本（loopProcessText）比较，排序与看到的文案一致。
+      sorter: (a: LoopListItem, b: LoopListItem) => compareValues(loopProcessText(a), loopProcessText(b)),
       // 三列表统一格式：#工艺id-工艺名称-工艺版本；手工环路显示 '-'。
       render: (_v, record) => loopProcessText(record),
     },
@@ -172,6 +174,8 @@ export function buildColumns({
       title: '最近执行',
       dataIndex: 'last_execution_status',
       width: 100,
+      // 114：补齐排序（客户端枚举字符串比较）
+      sorter: makeSorter<LoopListItem>('last_execution_status'),
       render: (s?: string | null) => s ? <Tag color={s === 'success' ? 'success' : s === 'failed' ? 'error' : 'processing'}>{s}</Tag> : '-',
     },
     {

--- a/frontend/src/components/tasks/TasksTableView.tsx
+++ b/frontend/src/components/tasks/TasksTableView.tsx
@@ -122,6 +122,9 @@ function buildColumns(
       key: 'process',
       width: 220,
       ellipsis: true,
+      // 114：补齐排序——按工艺模板名比较（委派/环路两种执行方式共用 template_name 字段），
+      // 无模板的任务空串兜底排前。
+      sorter: makeSorter<TaskItem>('template_name'),
       // NTD-013：工艺列按执行方式分支——委派走共享 TaskExecutionInfoTag（防文案漂移），
       // 环路走三段式 #工艺id-名称-版本（仅 Table 用三段式，Kanban/Card 仅工艺名，故由 loopTag 传入）。
       render: (_, task) => (
@@ -140,6 +143,8 @@ function buildColumns(
       dataIndex: 'latest_execution_status',
       key: 'latest_execution_status',
       width: 110,
+      // 114：补齐排序（客户端枚举字符串比较）
+      sorter: makeSorter<TaskItem>('latest_execution_status'),
       render: (status?: string) =>
         status ? (
           <Tag color={statusColor(status)}>{STATUS_LABEL[status] ?? status}</Tag>

--- a/frontend/src/components/todo-list/TodoListView.tsx
+++ b/frontend/src/components/todo-list/TodoListView.tsx
@@ -191,6 +191,8 @@ function buildTodoColumns(
       title: '类型',
       key: 'type',
       width: 100,
+      // 114：服务端排序——后端按类型 CASE 权重（评审>异常处理>快捷>事项）排序
+      sorter: true,
       render: (_: unknown, record: TodoCenterItem) => {
         const td = record.todo_type ?? 0;
         const at = record.action_type;
@@ -230,6 +232,8 @@ function buildTodoColumns(
       title: '执行器',
       dataIndex: 'executor',
       width: 110,
+      // 114：服务端排序（t.executor 字段，无执行器的行 DESC 时沉底）
+      sorter: true,
       render: (executor?: string) =>
         executor ? <ExecutorBadge executor={executor} /> : '-',
     },
@@ -237,6 +241,8 @@ function buildTodoColumns(
       title: '专家',
       dataIndex: 'expert_name',
       width: 100,
+      // 114：服务端排序（t.expert_name 字段）
+      sorter: true,
       render: (name?: string | null) => name ? <ExpertBadge expertName={name} /> : '-',
     },
     {
@@ -244,6 +250,8 @@ function buildTodoColumns(
       key: 'scheduler',
       width: 70,
       align: 'center',
+      // 114：服务端排序（按 cron 配置存在性，有调度的行排前）
+      sorter: true,
       render: (_, record) => renderSchedulerColumn(record),
     },
     {
@@ -251,6 +259,8 @@ function buildTodoColumns(
       key: 'loop',
       width: 160,
       ellipsis: true,
+      // 114：服务端排序（引用环路数，与展示口径同源）
+      sorter: true,
       render: (_, record) => renderLoopColumn(record.referencing_loops),
     },
     {
@@ -258,20 +268,25 @@ function buildTodoColumns(
       key: 'process',
       width: 160,
       ellipsis: true,
+      // 114：服务端排序（与环路列同源，按引用环路数）
+      sorter: true,
       render: (_, record) => renderProcessColumn(record.referencing_loops),
     },
     {
       title: '最近执行',
       dataIndex: 'last_execution_status',
       width: 100,
+      // 114：服务端排序——子查询取 MAX(id) 执行记录的状态（与展示口径一致）
+      sorter: true,
       render: (status?: string | null) => renderStatusTag(status),
     },
     {
       title: '执行时间',
       dataIndex: 'last_execution_at',
       width: 130,
-      // 056：聚合字段不支持服务端排序（该值由最近执行记录推导，不在 todos 表），
-      // 页内排序会误导为全局排序，故移除 sorter。
+      // 114：恢复服务端排序——056 因聚合字段无法排序而移除，现由后端相关子查询
+      // （MAX(id) 记录、finished_at 回退 started_at，与展示口径一致）支撑，跨页排序正确。
+      sorter: true,
       render: (t?: string | null) => (t ? formatRelativeTime(t) : '-'),
     },
     {
@@ -412,10 +427,13 @@ export function TodoListView({
             tableProps.onChange?.(pag, filters, sorter, extra);
             const s = Array.isArray(sorter) ? sorter[0] : sorter;
             const sortOrder = s?.order === 'ascend' ? 'asc' : s?.order === 'descend' ? 'desc' : undefined;
+            // 无 dataIndex 的列（「类型」列只有 key）sorter.field 为 undefined，
+            // 回退 columnKey 才能把 sort_by=type 传给后端（114 修复）。
+            const sortBy = s?.field != null ? String(s.field) : s?.columnKey != null ? String(s.columnKey) : undefined;
             onServerChange(
               pag.current ?? 1,
               pag.pageSize ?? 20,
-              s?.field ? String(s.field) : undefined,
+              sortBy,
               sortOrder,
             );
           }}

--- a/frontend/src/hooks/useResizableColumns.tsx
+++ b/frontend/src/hooks/useResizableColumns.tsx
@@ -81,9 +81,15 @@ export function useResizableColumns<T>(
     (_pagination, _filters, sorter) => {
       // antd 单排序时 sorter 为对象；多排序为数组（本设计只用单排序）。
       const s = Array.isArray(sorter) ? sorter[0] : sorter;
-      const nextSort: SortState = s?.field
-        ? { field: String(s.field), order: s.order ?? null }
-        : DEFAULT_SORT;
+      // 无 dataIndex 的列（如事项表「类型」列）sorter.field 为 undefined，
+      // 必须回退 columnKey（antd 归一化的 key），否则排序偏好丢失、持久化失效。
+      const field = s?.field != null ? String(s.field) : s?.columnKey != null ? String(s.columnKey) : '';
+      // antd 取消排序（三态最后一步）时 activeSorters 为空，onChange 传「空 sorter」
+      // （legacy 兼容），此时必须保存「无排序」而非回退 DEFAULT_SORT——
+      // 否则默认列永远处于受控 descend，点击取消被覆盖回 descend，三态循环卡死。
+      const nextSort: SortState = s?.order
+        ? { field, order: s.order }
+        : { field: '', order: null };
       setPrefs(prev => {
         const next = { ...prev, sort: nextSort };
         setTablePrefs(tableKey, next);

--- a/frontend/tests/check_114_other.spec.ts
+++ b/frontend/tests/check_114_other.spec.ts
@@ -1,0 +1,34 @@
+// 114 验证：任务/环路表格补充列可排
+import { test, expect } from '@playwright/test';
+
+test('114 任务表：工艺/最近执行列可排', async ({ page }) => {
+  await page.goto('http://localhost:18088/#/tasks?view=list', { waitUntil: 'networkidle' });
+  await page.waitForTimeout(1500);
+  const headers = await page.locator('.ant-table-thead th').allTextContents();
+  const sortable = await page.locator('.ant-table-thead th .ant-table-column-sorters').count();
+  console.log('任务表头:', JSON.stringify(headers.map(h => h.trim())));
+  console.log('任务可排序列数:', sortable);
+  // 工艺与最近执行应可排
+  for (const label of ['工艺', '最近执行']) {
+    const th = page.locator('.ant-table-thead th', { hasText: label }).first();
+    expect(await th.locator('.ant-table-column-sorters').count()).toBe(1);
+  }
+  // 点击工艺表头两次（asc→desc），行序应变化（客户端排序）
+  const firstBefore = await page.locator('.ant-table-row').first().locator('td').nth(1).innerText();
+  const th = page.locator('.ant-table-thead th', { hasText: '工艺' }).first();
+  await th.click(); await page.waitForTimeout(600);
+  await th.click(); await page.waitForTimeout(600);
+  const firstAfter = await page.locator('.ant-table-row').first().locator('td').nth(1).innerText();
+  console.log(`工艺排序前后首行ID: ${firstBefore} -> ${firstAfter}`);
+});
+
+test('114 环路表：工艺/最近执行列可排', async ({ page }) => {
+  await page.goto('http://localhost:18088/#/loops?view=list', { waitUntil: 'networkidle' });
+  await page.waitForTimeout(1500);
+  const sortable = await page.locator('.ant-table-thead th .ant-table-column-sorters').count();
+  console.log('环路可排序列数:', sortable);
+  for (const label of ['工艺', '最近执行']) {
+    const th = page.locator('.ant-table-thead th', { hasText: label }).first();
+    expect(await th.locator('.ant-table-column-sorters').count()).toBe(1);
+  }
+});

--- a/frontend/tests/check_114_sort.spec.ts
+++ b/frontend/tests/check_114_sort.spec.ts
@@ -1,0 +1,72 @@
+// 114 功能验证：事项表全列（除操作列）表头服务端排序
+import { test, expect } from '@playwright/test';
+
+const SORT_COLUMNS: [string, string][] = [
+  ['ID', 'id'],
+  ['类型', 'type'],
+  ['标题', 'title'],
+  ['状态', 'status'],
+  ['执行器', 'executor'],
+  ['专家', 'expert_name'],
+  ['调度', 'scheduler'],
+  ['环路', 'loop'],
+  ['工艺', 'process'],
+  ['最近执行', 'last_execution_status'],
+  ['执行时间', 'last_execution_at'],
+  ['更新时间', 'updated_at'],
+];
+
+test('114 事项表：12 列全部可排 + 请求参数正确', async ({ page }) => {
+  const reqs: string[] = [];
+  page.on('request', (r) => { if (r.url().includes('/todos/center')) reqs.push(r.url()); });
+  await page.goto('http://localhost:18088/#/todos?view=list', { waitUntil: 'networkidle' });
+  await page.waitForTimeout(1500);
+
+  const sortable = await page.locator('.ant-table-thead th .ant-table-column-sorters').count();
+  expect(sortable).toBe(12);
+
+  for (const [label, sortBy] of SORT_COLUMNS) {
+    const h = page.locator('.ant-table-thead th', { hasText: label }).first();
+    // 起点状态未知（localStorage 持久化），循环点击最多 3 次覆盖「取消→升→降」三态
+    let ascSeen = false;
+    let descSeen = false;
+    for (let i = 0; i < 3; i++) {
+      await h.click();
+      await page.waitForTimeout(700);
+      const url = reqs[reqs.length - 1] ?? '';
+      if (url.includes(`sort_by=${sortBy}`)) {
+        if (url.includes('sort_order=asc')) ascSeen = true;
+        if (url.includes('sort_order=desc')) descSeen = true;
+        if (ascSeen && descSeen) break;
+      }
+    }
+    expect(ascSeen, `${label} 应出现 asc 请求`).toBe(true);
+    expect(descSeen, `${label} 应出现 desc 请求`).toBe(true);
+  }
+  expect(await page.locator('.ant-table-thead th.ant-table-column-sort').count()).toBe(1);
+});
+
+test('114 事项表：更新时间/执行时间倒序首行与 API 一致', async ({ page }) => {
+  const reqs: string[] = [];
+  page.on('request', (r) => { if (r.url().includes('/todos/center')) reqs.push(r.url()); });
+  await page.goto('http://localhost:18088/#/todos?view=list', { waitUntil: 'networkidle' });
+  await page.waitForTimeout(1200);
+  for (const [label, sortBy] of [['更新时间', 'updated_at'], ['执行时间', 'last_execution_at']] as const) {
+    const h = page.locator('.ant-table-thead th', { hasText: label }).first();
+    let descSeen = false;
+    for (let i = 0; i < 3; i++) {
+      await h.click();
+      await page.waitForTimeout(800);
+      const url = reqs[reqs.length - 1] ?? '';
+      if (url.includes(`sort_by=${sortBy}`) && url.includes('sort_order=desc')) { descSeen = true; break; }
+    }
+    expect(descSeen, `${label} 应到达 desc`).toBe(true);
+    const firstRowId = (await page.locator('.ant-table-row').first().locator('td').nth(1).innerText()).replace('#', '');
+    const resp = await page.request.get(
+      `http://localhost:18088/api/v1/workspaces/1/todos/center?page=1&page_size=20&sort_by=${sortBy}&sort_order=desc`
+    );
+    const json = await resp.json();
+    expect(Number(firstRowId), `${label} 首行应匹配 API`).toBe(json.data.items[0].id);
+    console.log(`${label} desc 首行 id: ${firstRowId} | API: ${json.data.items[0].id}`);
+  }
+});


### PR DESCRIPTION
## 需求
事项列表（#/todos）表头排序扩充至全列（除操作列），并统一任务/环路列表的表头排序能力。

## 改动内容

### 事项表：服务端排序 4 列 → 12 列
新增可排序列：**类型 / 执行器 / 专家 / 调度 / 环路 / 工艺 / 最近执行 / 执行时间**（原有 ID/标题/状态/更新时间保留）。

后端  白名单 +8 分支：
- ：CASE 权重（评审 > 异常处理 > 快捷 > 事项，与渲染优先级一致）
-  / ： 执行记录子查询（与  展示口径严格一致，finished_at 回退 started_at）
-  /  / ：直接字段
-  / ：引用环路数（ enabled=1 计数，与展示口径同源）

### 任务/环路表：补齐剩余列
- 任务表：工艺（按模板名）、最近执行
- 环路表：工艺（按展示文本）、最近执行

### Bug 修复：useResizableColumns 取消排序卡死
antd 取消排序（三态最后一步）时  传空 sorter（legacy 兼容），原 hook 回退 DEFAULT_SORT 导致默认列永远处于受控 descend、三态循环卡死。修复为保存「无排序」状态；同时无 dataIndex 列（类型/调度/环路/工艺）排序 field 回退 。

## 测试
-  零告警； lib 1779 通过（含 4 个新增）、集成 28 通过
-  零错误
- Playwright 实测（18088 dev）：事项表 12 列全部可排，每列 asc/desc 请求参数正确，更新时间/执行时间 desc 首行与 API 直查一致；任务 8 列 / 环路 9 列可排；用户手工点击确认无问题
- 已知环境问题（与本次无关）：vitest 3 个文件在 Node 22 下因实验性 localStorage 失败（main 分支同样失败）

## 文档
- 
- 
- 