### PR TITLE
feat(114): 飞书直连执行器对话绕过推送级别限制

### DIFF
--- a/backend/src/executor_service/events.rs
+++ b/backend/src/executor_service/events.rs
@@ -92,9 +92,10 @@ pub enum ExecEvent {
         /// 要发送的文本内容
         content: String,
     },
-    /// 私聊直达流式消息：管家聊天场景下，执行过程中每条日志直接推送给触发用户。
-    /// 与 DirectCardMessage 的区别：后者是开始/结束等关键节点的卡片消息，
-    /// 前者是执行过程中流式输出的日志消息（push_level="all" 时发送）。
+    /// 私聊直达流式消息：飞书直连对话场景（dm_chat/butler_chat）下，执行过程中每条日志
+    /// 直接推送给触发用户。与 DirectCardMessage 的区别：后者是开始/结束等关键节点的卡片，
+    /// 前者是执行过程中流式输出的日志。114 设计决策：本事件绕过 push_level 限制（因为
+    /// 是"用户主动聊天"的即时对话，与 ntd 主动触发的通知不同）。
     DirectStreamMessage {
         /// Feishu bot_id
         bot_id: i64,

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -85,18 +85,11 @@ impl FeishuPushService {
                                     continue;
                                 }
 
-                                // 执行器直接输出：executor 默认响应场景下，过程日志直接推送给触发用户。
-                                // 与 DirectCardMessage 的区别：后者是开始/结束等关键节点的卡片消息，
-                                // 前者是执行过程中流式输出的纯文本消息。
-                                // 受 push_level 控制：仅当配置为 "all" 时才发送过程消息，
-                                // "result_only" 和 "disabled" 时不发过程消息。
+                                // 飞书直连对话过程流式输出：绕过 push_level 过滤，直接推送给触发用户。
+                                // 设计决策（114）：push_level 只作用于 ntd 主动触发的事项/环路通知，
+                                // 直连对话是"用户主动聊"，过程消息理应完整可见；与 DirectCardMessage
+                                // （开始/错误等关键节点卡片）绕过 push_level 的策略一致。
                                 if let ExecEvent::DirectStreamMessage { bot_id, receive_id, receive_id_type, entry } = &ev {
-                                    // 先查该 bot 的 push_level 配置
-                                    let push_level = Self::get_bot_push_level(&db, *bot_id).await;
-                                    if push_level != "all" {
-                                        debug!("[feishu-push] executor direct output skipped for bot {} due to push_level={}", bot_id, push_level);
-                                        continue;
-                                    }
                                     // tool_call 类型：递增计数器并传入编号，用于显示 "🔧 工具 #N: 工具名"
                                     let tool_idx = if entry.log_type == "tool_call"
                                         || entry.log_type == "tool_use"

--- a/backend/src/services/feishu_push.rs
+++ b/backend/src/services/feishu_push.rs
@@ -102,9 +102,9 @@ impl FeishuPushService {
                                     } else {
                                         None
                                     };
-                                    // 使用无标题卡片样式发送过程消息，支持 markdown 格式（不显示"执行器输出"标题）
-                                    let Some(text) = render_log_entry("", entry, tool_idx) else { continue };
-                                    let card_json = render_card_message(&text);
+                                    // 114：恒推送——卡片构造刻意不接收 push_level（见 build_direct_stream_card 注释）；
+                                    // None 表示该条日志无可展示内容，跳过（与渲染层过滤口径一致）
+                                    let Some(card_json) = build_direct_stream_card(entry, tool_idx) else { continue };
                                     let res = FeishuApiClient::send_card_raw(&feishu_listener.bot_credentials, &feishu_listener.token_manager, *bot_id, receive_id, receive_id_type, &card_json).await;
                                     if let Err(e) = res {
                                         warn!("[feishu-push] executor direct output (card) failed for bot {}: {}", bot_id, e);
@@ -601,6 +601,21 @@ fn render_card_message(content: &str) -> String {
     render_card(&card, "")
 }
 
+/// 构造直连对话流式消息的出站卡片（114：恒推送，与 push_level 无关）。
+///
+/// 从 select! 循环 arm 中抽出：arm 持有 counters/listener 借用且 send_card_raw 是
+/// 静态网络调用，无法单测；本函数承载该分支全部可纯测的决策（渲染文本 → 包装卡片）。
+/// 刻意不接收 push_level 入参——签名里没有级别参数，就是「直连对话不受推送级别
+/// 约束」（设计 114 §2）的编译器级表达：恢复任何按级别拦截都必须改签名，
+/// 会先撞坏 direct_stream_card_tests 的用例。
+fn build_direct_stream_card(
+    entry: &crate::models::ParsedLogEntry,
+    tool_call_index: Option<usize>,
+) -> Option<String> {
+    let text = render_log_entry("", entry, tool_call_index)?;
+    Some(render_card_message(&text))
+}
+
 /// 将 Finished 事件格式化为卡片 JSON 字符串
 fn format_finished_card(event: &ExecEvent) -> Option<String> {
     match event {
@@ -631,6 +646,42 @@ fn format_finished_card(event: &ExecEvent) -> Option<String> {
             Some(render_card(&card, ""))
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod direct_stream_card_tests {
+    //! 114 推送侧决策锁定（评审修复补充，对应设计 §4.1 的测试意图）。
+    //! 设计原承诺「disabled/result_only/all 三级别参数化用例走到 send_card_raw」；
+    //! 但 send_card_raw 是静态网络调用、select! arm 持有运行时借用，单测无法触达。
+    //! 等价锁定：build_direct_stream_card 签名刻意没有 push_level 参数——
+    //! 恢复任何按级别拦截都必须改签名，先撞坏这组用例。
+
+    use super::build_direct_stream_card;
+    use crate::models::ParsedLogEntry;
+
+    /// 普通文本日志：恒产出卡片且内容透传（114 后与推送级别无关）
+    #[test]
+    fn test_build_direct_stream_card_文本日志产出含内容卡片() {
+        let entry = ParsedLogEntry::new("text", "正在分析依赖");
+        let card = build_direct_stream_card(&entry, None).expect("非空文本必须产出卡片");
+        assert!(card.contains("正在分析依赖"));
+    }
+
+    /// 空白内容：返回 None，对应推送循环 arm 里 let-else 的 continue 跳过分支
+    #[test]
+    fn test_build_direct_stream_card_空白内容不产出卡片() {
+        let entry = ParsedLogEntry::new("text", "   ");
+        assert!(build_direct_stream_card(&entry, None).is_none());
+    }
+
+    /// 工具调用：编号透传渲染（🔧 工具 #N），确保 counters → 卡片链路不断
+    #[test]
+    fn test_build_direct_stream_card_工具调用透传编号() {
+        let entry = ParsedLogEntry::new("tool_call", "ls -la");
+        let card = build_direct_stream_card(&entry, Some(3)).expect("工具调用必须产出卡片");
+        assert!(card.contains("#3"), "卡片应包含工具编号 #3：{card}");
     }
 }
 

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -1233,35 +1233,25 @@ async fn resolve_executor_session(
 }
 
 
-/// 阶段⑤：查 push_level，仅当配置为 "all" 时返回私聊直推目标。
+/// 阶段⑤：构造私聊过程消息直推目标。
 ///
-/// 在发送端判断（而非 FeishuPushService 端），避免流式读取每条日志都查一次 DB。
-/// 查询失败 / 未配置都降级为不直推（None）——过程消息不直推不影响结果消息推送。
-async fn resolve_direct_output(
-    db: &Arc<Database>,
+/// 设计决策（114）：推送级别（disabled/result_only/all）仅作用于 ntd 主动触发的
+/// 事项/环路通知，飞书直连对话属于"用户主动发起的即时对话"，过程流式消息不应
+/// 受推送级别限制——用户在聊天就理应看到执行过程，与 DirectCardMessage（开始/
+/// 错误等关键节点卡片）绕过 push_level 的逻辑保持一致。
+///
+/// 本函数改为同步纯函数：移除 db 查询，调用点也去掉 .await；发送端始终直推。
+fn resolve_direct_output(
     bot_id: i64,
     receive_id: String,
     receive_id_type: &str,
 ) -> Option<DirectOutputInfo> {
-    // 默认 result_only：未配置 push target 时只推最终结果，不打扰过程
-    let push_level = match db.get_feishu_push_target(bot_id).await {
-        Ok(Some(target)) => target.push_level,
-        Ok(None) => "result_only".to_string(),
-        Err(e) => {
-            tracing::warn!("[debounce] failed to get push_level for bot {}: {}", bot_id, e);
-            "result_only".to_string()
-        }
-    };
-    // 仅 "all" 直推过程消息；其他级别过程消息只落库不进私聊
-    if push_level == "all" {
-        Some(DirectOutputInfo {
-            bot_id,
-            receive_id,
-            receive_id_type: receive_id_type.to_string(),
-        })
-    } else {
-        None
-    }
+    // 飞书直连对话场景：无条件构造直推目标，不再读取 push_level
+    Some(DirectOutputInfo {
+        bot_id,
+        receive_id,
+        receive_id_type: receive_id_type.to_string(),
+    })
 }
 
 
@@ -1478,8 +1468,9 @@ impl MessageDebounce {
         // 回执展示用户原文（而非注入管家 prompt 后的文本）：专家规则属于内部实现，
         // 不应刷屏暴露给用户。
         send_msg(executor_start_message(executor_type, message));
+        // 114：飞书直连对话绕过 push_level，直接构造过程消息直推目标
         let direct_output_info =
-            resolve_direct_output(db, bot_id, receive_id.clone(), receive_id_type).await;
+            resolve_direct_output(bot_id, receive_id.clone(), receive_id_type);
         // pipeline 在闭包外创建：闭包逐行借用它做有状态解析，产生与 todo 执行同格式的事件
         let mut pipeline = log_capture::create_pipeline_for_executor(executor.as_ref())
             .unwrap_or_else(|| EventPipeline::new(executor.executor_type().as_str()));
@@ -2206,5 +2197,45 @@ mod butler_expert_tests {
         .await
         .unwrap();
         assert_eq!(load_butler_expert_name(&db, Some(1)).await, None);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod resolve_direct_output_tests {
+    //! 114 设计决策锁定：飞书直连对话（dm_chat/butler_chat）场景下，
+    //! 过程消息直推目标应无条件构造，绕过 push_level（disabled/result_only/all）限制。
+    //! push_level 只作用于 ntd 主动触发的事项/环路通知，不限制"用户主动聊天"。
+    use super::resolve_direct_output;
+
+    /// 基础用例：任意 bot_id / receive_id / receive_id_type 都返回 Some，且字段透传
+    #[test]
+    fn test_always_returns_some_open_id() {
+        let info = resolve_direct_output(42, "ou_user123".to_string(), "open_id")
+            .expect("114 后 resolve_direct_output 必须恒返回 Some");
+        assert_eq!(info.bot_id, 42);
+        assert_eq!(info.receive_id, "ou_user123");
+        assert_eq!(info.receive_id_type, "open_id");
+    }
+
+    /// 群聊 chat_id 场景：同样无条件 Some，字段透传
+    #[test]
+    fn test_always_returns_some_chat_id() {
+        let info = resolve_direct_output(7, "oc_group456".to_string(), "chat_id")
+            .expect("114 后 resolve_direct_output 必须恒返回 Some");
+        assert_eq!(info.bot_id, 7);
+        assert_eq!(info.receive_id, "oc_group456");
+        assert_eq!(info.receive_id_type, "chat_id");
+    }
+
+    /// 114 前的行为锁定（反向断言防止回退）：
+    /// resolve_direct_output 不再接受 db 参数（已改为同步纯函数），
+    /// 编译器层面保证了它没有能力读取 push_level 配置。
+    /// 这里用「参数签名检查」等价表述：函数签名是 3 参数同步函数。
+    #[test]
+    fn test_signature_is_sync_no_db_param() {
+        // 直接调用 3 参数同步版本：能编译通过就证明签名正确，无 db、无 async、无 .await
+        let result = resolve_direct_output(1, "r".to_string(), "open_id");
+        assert!(result.is_some());
     }
 }

--- a/backend/src/services/message_debounce.rs
+++ b/backend/src/services/message_debounce.rs
@@ -2210,7 +2210,7 @@ mod resolve_direct_output_tests {
 
     /// 基础用例：任意 bot_id / receive_id / receive_id_type 都返回 Some，且字段透传
     #[test]
-    fn test_always_returns_some_open_id() {
+    fn test_resolve_direct_output_私聊open_id恒构造直推目标() {
         let info = resolve_direct_output(42, "ou_user123".to_string(), "open_id")
             .expect("114 后 resolve_direct_output 必须恒返回 Some");
         assert_eq!(info.bot_id, 42);
@@ -2220,7 +2220,7 @@ mod resolve_direct_output_tests {
 
     /// 群聊 chat_id 场景：同样无条件 Some，字段透传
     #[test]
-    fn test_always_returns_some_chat_id() {
+    fn test_resolve_direct_output_群聊chat_id恒构造直推目标() {
         let info = resolve_direct_output(7, "oc_group456".to_string(), "chat_id")
             .expect("114 后 resolve_direct_output 必须恒返回 Some");
         assert_eq!(info.bot_id, 7);
@@ -2233,7 +2233,7 @@ mod resolve_direct_output_tests {
     /// 编译器层面保证了它没有能力读取 push_level 配置。
     /// 这里用「参数签名检查」等价表述：函数签名是 3 参数同步函数。
     #[test]
-    fn test_signature_is_sync_no_db_param() {
+    fn test_resolve_direct_output_同步三参签名无db参数() {
         // 直接调用 3 参数同步版本：能编译通过就证明签名正确，无 db、无 async、无 .await
         let result = resolve_direct_output(1, "r".to_string(), "open_id");
         assert!(result.is_some());

--- a/docs/design/114-飞书直连绕过推送级别-设计.md
+++ b/docs/design/114-飞书直连绕过推送级别-设计.md
@@ -1,0 +1,116 @@
+# 114-飞书直连绕过推送级别-设计
+
+> 目标：push_level（关闭推送 / 仅结论 / 全部）仅作用于 ntd 主动触发的事项/环路推送；
+> 用户在飞书里直接与执行器对话（单聊直聊 / 群聊管家）时，过程流式消息不受该限制。
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI 协作开发者 | 2026-08-17 | 初始版本：明确推送级别的作用域边界 |
+
+---
+
+## 1. 背景与问题
+
+当前推送级别（`push_level`）有三档取值，存储在 `feishu_push_targets.push_level`：
+- `disabled` — 关闭推送
+- `result_only` — 仅结论（只推 `Finished` / `LoopFinished`）
+- `all` — 全部（除 `TodoProgress` / `ExecutionStats` 噪音）
+
+用户可以在前端「智能助手 → 配置抽屉 → 推送规则 Tab」修改这一配置。
+
+**问题**：`push_level` 被同时应用于两种本质不同的推送场景：
+
+| 场景 | 语义 | 当前是否受 push_level 限制 |
+|---|---|---|
+| **ntd 主动跑事项 / 环路** | 后台任务的"通知"：用户没主动操作，ntd 自己跑起来，推送是"我做完了告诉你"的形式。用户显然有权让这类通知静音/仅结论。 | ✅ 合理：`should_send` + `get_bot_push_level` 过滤 |
+| **飞书直连对话（dm_chat / butler_chat）** | 用户主动发消息给 bot → 执行器回复。属于"即时对话"，push_level 应该只影响被动通知、不该阻拦用户自己发起的对话过程消息。 | ❌ 不合理：`result_only` / `disabled` 时用户看不到过程流 |
+
+结果体验：用户明明在跟 bot 聊天，却只能看到"开始处理"卡片，过程消息全部被过滤，对话体验被打断。
+
+## 2. 推送级别作用域重定义（核心决策）
+
+**重定义后的规则**：
+
+| 场景 | push_level 是否生效 | 说明 |
+|---|---|---|
+| 事项（Todo）完成 → `Finished`（工作区推送目标、binding chat） | ✅ 生效 | 典型的后台通知 |
+| 环路（Loop）完成 → `LoopFinished`（工作区推送目标） | ✅ 生效 | 典型的后台通知 |
+| 事项/环路执行中 → `Started` / `Output`（工作区推送目标） | ✅ 生效 | 仍受 push_level 控制 |
+| 飞书直连对话 → `DirectCardMessage`（开始/错误/结束） | ❌ 不生效 | 已经绕过，保持不变 |
+| 飞书直连对话 → `DirectStreamMessage`（过程流式消息） | ❌ 不生效 | **本次改动：绕过** |
+
+**两个关键论据**：
+1. `DirectStreamMessage` 的**唯一发出点**是 `handle_butler_chat` 的 `emit_direct_stream`，即 100% 来自「用户主动在飞书聊天」场景，不与 ntd 主动触发混用。
+2. `DirectCardMessage`（关键节点卡片）**已经**绕过 push_level，两者行为需要一致——同一场景不应该一半绕过一半不绕过。
+
+## 3. 改动清单（4 个文件 + 测试）
+
+### 3.1 `backend/src/services/message_debounce.rs`
+
+**`resolve_direct_output` 重构（第 1240-1265 行）**：
+- **删除**：`db.get_feishu_push_target(bot_id)` 的查询与 `push_level == "all"` 判定
+- **改为**：无条件返回 `Some(DirectOutputInfo { ... })`
+- **副作用**：`db: &Arc<Database>` 参数不再需要；由 `async fn` 改为同步 `fn`；调用点去掉 `.await`
+
+**调用点 `handle_butler_chat`（第 1482 行）**：
+```rust
+// 改动前：
+let direct_output_info =
+    resolve_direct_output(db, bot_id, receive_id.clone(), receive_id_type).await;
+
+// 改动后：
+let direct_output_info =
+    resolve_direct_output(bot_id, receive_id.clone(), receive_id_type);
+```
+
+### 3.2 `backend/src/services/feishu_push.rs`
+
+**`DirectStreamMessage` 分支（第 93-122 行）**：
+- **删除**：`get_bot_push_level(&db, *bot_id).await` 查询与 `push_level != "all"` 判定
+- 删除后逻辑：收到事件后直接走 `tool_call` 计数器处理 + `render_log_entry` + `send_card_raw`
+- 与 `DirectCardMessage` 分支的风格对齐：顶部匹配到就发、`continue`
+
+双保险验证：改动前发送端已只在 `push_level=all` 时才发 `DirectStreamMessage`，推送端的二次检查是冗余防线。现在发送端直接永远发，推送端也必须同步撤除这道防线，否则行为退化为「发了事件但被推送端丢弃」。
+
+### 3.3 `backend/src/executor_service/events.rs`
+
+**`DirectStreamMessage` 注释（第 95-97 行）**：
+把"push_level=all 时发送"的过时描述改为"飞书直连对话场景专用，绕过 push_level 限制"，与 `DirectCardMessage` 注释风格一致。
+
+### 3.4 前端零改动
+
+- 推送级别 UI（`AssistantConfigDrawer`）：不动，文案仍然是"推送级别"，只是实际生效范围收窄到 ntd 主动触发场景。
+- `/help` 帮助页：帮助页只是说明如何打开配置抽屉，不描述 push_level 的生效范围，无需改动。
+
+## 4. 测试更新
+
+### 4.1 `feishu_push_binding_tests`（`feishu_push.rs:644+`）
+
+- 检查是否有用例断言 `push_level != "all"` 时 `DirectStreamMessage` 被跳过：如有，反转断言为"被发送"。
+- 补充 3 组参数化用例：`push_level = disabled / result_only / all`，任意级别下 `DirectStreamMessage` 都走到 `send_card_raw`。
+
+### 4.2 `services_tests.rs`
+
+- 第 398-399 行附近的 `DirectStreamMessage` 注释如有过时描述，同步更新。
+
+### 4.3 `message_debounce.rs` 单测
+
+- 如果有单测覆盖 `resolve_direct_output`，移除对 db 的 mock，改用纯函数直接构造 `DirectOutputInfo`。
+
+## 5. 行为变化总览
+
+| 用户场景 | 改动前 | 改动后 |
+|---|---|---|
+| 飞书私聊 bot，push_level=disabled | 只能看到"开始处理"卡片，后续过程全黑屏 | 完整卡片 + 流式过程消息（工具调用编号）+ 最终结果 |
+| 飞书群聊 @bot，push_level=result_only | 只能看到"开始处理"卡片，过程流缺失 | 完整卡片 + 流式过程消息 + 最终结果 |
+| 飞书私聊/群聊，push_level=all | 正常 | 不变 |
+| ntd 调度器自动跑 todo / loop | 按 push_level 推送 | 不变 |
+| 前端点「执行事项」→ 推送到飞书 | 按 push_level 推送 | 不变 |
+| 斜杠规则触发环路 → 推送到飞书 | 按 push_level 推送（`LoopFinished` 走工作区目标路径） | 不变 |
+
+## 6. 验证清单
+
+1. `cd backend && cargo clippy --all-targets -- -D warnings` 零告警；
+2. `cd backend && cargo test` 全绿（含 `feishu_push_binding_tests` 的新断言）；
+3. 飞书实际联调（如能）：push_level=disabled 时单聊 bot 能看到开始卡片 + 过程流 + 结束；
+4. 反向确认：push_level=disabled 时手动触发 todo 执行，飞书侧**不**收到任何通知（验证工作区推送路径仍被限制）。

--- a/docs/design/114-飞书直连绕过推送级别-设计.md
+++ b/docs/design/114-飞书直连绕过推送级别-设计.md
@@ -6,6 +6,7 @@
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | AI 协作开发者 | 2026-08-17 | 初始版本：明确推送级别的作用域边界 |
+| AI 协作开发者 | 2026-08-17 | 评审修复：§4.1 测试策略按可测缝隙调整为 `build_direct_stream_card` 抽取方案（原因见该节） |
 
 ---
 
@@ -86,8 +87,9 @@ let direct_output_info =
 
 ### 4.1 `feishu_push_binding_tests`（`feishu_push.rs:644+`）
 
-- 检查是否有用例断言 `push_level != "all"` 时 `DirectStreamMessage` 被跳过：如有，反转断言为"被发送"。
-- 补充 3 组参数化用例：`push_level = disabled / result_only / all`，任意级别下 `DirectStreamMessage` 都走到 `send_card_raw`。
+- 检查是否有用例断言 `push_level != "all"` 时 `DirectStreamMessage` 被跳过：如有，反转断言为"被发送"。（核实结果：无此类存量用例，无需反转）
+- ~~补充 3 组参数化用例：`push_level = disabled / result_only / all`，任意级别下 `DirectStreamMessage` 都走到 `send_card_raw`。~~
+  **评审修复调整**：`send_card_raw` 是静态网络调用、select! arm 持有运行时借用，参数化用例无法在单测中触达。等价方案：抽出 `build_direct_stream_card` 纯函数承载该分支可测决策，其签名刻意不接收 push_level（恢复级别拦截必改签名），由 `direct_stream_card_tests` 3 个用例锁定；残余风险与后续彻底闭环路径见实现总结 §4.2。
 
 ### 4.2 `services_tests.rs`
 

--- a/docs/requirements/036-飞书直连绕过推送级别-实现总结.md
+++ b/docs/requirements/036-飞书直连绕过推送级别-实现总结.md
@@ -1,0 +1,88 @@
+# 036-飞书直连绕过推送级别-实现总结
+
+> 对应需求：飞书直连执行器对话（单聊/群聊管家）不经过推送级别（disabled/result_only/all）限制；推送级别仅作用于 ntd 主动触发的事项/环路通知场景。
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI 协作开发者 | 2026-08-17 | 初始版本：发送端 + 推送端双重闸门撤除 + 单元测试补充 |
+
+---
+
+## 1. 实现了什么
+
+### 1.1 核心行为变更
+
+**推送级别作用域收窄**：`feishu_push_targets.push_level`（三档：`disabled` / `result_only` / `all`）从"同时管后台通知与聊天"收窄为**只管 ntd 主动触发的事项/环路通知**，飞书直连对话场景（`dm_chat` 单聊 / `butler_chat` 群聊管家）的过程流式消息始终推送，不再被限制。
+
+### 1.2 代码改动一览
+
+| 文件 | 关键改动 | 行数 |
+|---|---|---|
+| [message_debounce.rs](file:///Users/weibh/projects/rust/nothing-todo/backend/src/services/message_debounce.rs#L1236-L1255) | `resolve_direct_output`：从「查 DB 判 push_level=all 才返回 Some」改为「同步纯函数，无条件构造直推目标」。删除 `db` 参数、`async` 关键字。 | 原 27 行 → 现 20 行 |
+| [message_debounce.rs](file:///Users/weibh/projects/rust/nothing-todo/backend/src/services/message_debounce.rs#L1471-L1473) | 调用点：去掉 `.await`，去掉 `db` 参数 | 1 行 |
+| [feishu_push.rs](file:///Users/weibh/projects/rust/nothing-todo/backend/src/services/feishu_push.rs#L88-L115) | `DirectStreamMessage` 分支：删除 `get_bot_push_level` 查询 + `push_level != "all"` continue 的二次检查闸门 | 原 35 行 → 现 28 行 |
+| [events.rs](file:///Users/weibh/projects/rust/nothing-todo/backend/src/executor_service/events.rs#L95-L98) | `DirectStreamMessage` 注释：从 "push_level=all 时发送"改为"114 决策：绕过 push_level" | 3 行注释 |
+| [message_debounce.rs](file:///Users/weibh/projects/rust/nothing-todo/backend/src/services/message_debounce.rs#L2203-L2241) | 新增测试模块 `resolve_direct_output_tests`：3 个用例锁定新行为 | 39 行新增 |
+
+### 1.3 两道闸门撤除前后对照
+
+直连对话过程流消息发出前要经过两道闸门：
+
+| 闸门位置 | 114 前 | 114 后 |
+|---|---|---|
+| 发送端 `resolve_direct_output`（message_debounce.rs） | 查 `db.get_feishu_push_target(bot_id)`，仅 `push_level == "all"` → Some，否则 None（不发事件） | 同步纯函数无条件 Some |
+| 推送端 `DirectStreamMessage` 分支（feishu_push.rs） | 二次查 `get_bot_push_level`，非 `all` → continue（丢弃事件） | 直接发送 |
+
+**撤除理由**：两道闸门对飞书直连场景都是多余的——直连是"用户主动发起对话"，用户主动发消息问 bot 就理应看到完整执行过程（包括工具调用编号与输出）。与 `DirectCardMessage`（开始/错误等关键节点）早已绕过 push_level 的行为保持一致。
+
+### 1.4 ntd 主动触发场景保持不变（验证）
+
+- `Finished` 事件的 binding chat 直发（feishu_push.rs line 127-158）：仍过 `get_bot_push_level` + `should_send` → 不动
+- `Finished` / `Started` / `Output` / `LoopFinished` 的 workspace push target 主路径（feishu_push.rs line 176-257）：仍过 `should_send(per-target push_level)` → 不动
+- `feishu_push_binding_tests` 模块 8 个 `should_send` 断言（Finished/Started/LoopFinished × disabled/result_only/all）：全部保持原样，通过测试证明作用域不变
+
+## 2. 与需求的对应关系
+
+| 需求条目 | 对应实现 |
+|---|---|
+| 飞书与执行器对话不经过推送级别限制 | `resolve_direct_output` 纯函数化 + `DirectStreamMessage` 分支撤除二次检查 |
+| 推送级别仍对 ntd 事项/环路生效 | 两道闸门只针对 `DirectStreamMessage` 路径，`Finished/LoopFinished/Started/Output` 路径的 `should_send` 完全不动 |
+| 关闭推送 / 仅结论 / 全部 三档作为事项、环路的提示 | 通过 feishu_push_binding_tests 的全部断言 + services_tests 的 4 个 `should_send` 用例锁定原行为 |
+
+## 3. 关键实现点
+
+### 3.1 发送端同步化
+
+**为什么改同步**：原来 `async fn resolve_direct_output` 唯一做异步的就是一次 `db.get_feishu_push_target().await`；去掉 DB 查询后再保留 `async` 就只增加调用方的 `.await` 与 future 开销，语义上没有任何异步操作。改为同步 `fn` 让调用方直接构造结构体，也让编译器层面保证了函数没有能力触碰 push_level 配置。
+
+### 3.2 推送端双保险同步撤除
+
+只改发送端不改推送端的后果：发送端"永远发"，但推送端仍在查 push_level=all 才放行 → 结果就是 `result_only` / `disabled` 用户发送端的事件**被静默丢弃**，等价于完全没推（而且没有日志说明为什么丢弃，只有 debug!）。因此两道闸门必须成对撤除，这是关键耦合点。
+
+### 3.3 测试从 DB-mock 转向签名锁定
+
+`resolve_direct_output` 原本是 DB 依赖函数，测试需要 mock push_target 行才能覆盖 disabled/result_only/all × 返回 None/Some 的组合；现在它是纯函数，测试也变成：
+- 直接断言「总是 Some」
+- 用"无 db 参数、同步调用"的编译期事实锁定"它没有能力读 push_level"
+
+## 4. 已知限制与待改进
+
+### 4.1 push_level UI 文案可能引起混淆
+
+前端 `AssistantConfigDrawer` 仍然展示"推送级别"三选一（disabled/result_only/all），而且帮助卡片 `/help` 说明文案里也没有标注"推送级别不对聊天直连生效"。
+- **风险**：用户配 disabled 后仍然在飞书聊天时看到过程流，会怀疑"推送级别配置为什么不生效"
+- **缓解**：本次不改 UI（遵循 YAGNI），建议后续在 Select 下方加一行提示：「推送级别仅对事项/环路通知生效，与 bot 主动聊天不受此限制」
+
+### 4.2 推送端单测覆盖缺口
+
+`feishu_push.rs` 的推送循环 `start()` 本身是 async runtime 内的 select! 循环，没有独立的纯函数接口暴露"DirectStreamMessage 是否放行"给单测，因此新增行为（任意 push_level 下发）只能通过发送端测试 + 代码走读验证，没有推送端级别的参数化断言。后续如重构 `start()`，可拆 `fn process_event(event: ExecEvent, ...)` 纯函数出口。
+
+## 5. 验证与结果
+
+| 验证项 | 命令 / 方法 | 结果 |
+|---|---|---|
+| 后端 lint | `cargo clippy --all-targets -- -D warnings` | ✅ 零告警（3m 11s） |
+| 后端单元测试 | `cargo test` | ✅ 1779 passed; 0 failed; 2 ignored |
+| 新增 resolve_direct_output 三测试 | `cargo test --lib` 过滤 | ✅ 3/3 全过：open_id 透传 / chat_id 透传 / 签名同步无 db |
+| feishu_push_binding_tests 原 8 断言 | 随 `cargo test` 一起跑 | ✅ 全过（证明 Finished/Started/LoopFinished 的 push_level 约束未松动） |
+| services_tests should_send 4 用例 | 随 `cargo test` 一起跑 | ✅ 全过（disabled 永不发 / result_only 仅 Finished / all 全部 / unknown 永不发） |

--- a/docs/requirements/114-飞书直连绕过推送级别-实现总结.md
+++ b/docs/requirements/114-飞书直连绕过推送级别-实现总结.md
@@ -1,10 +1,11 @@
-# 036-飞书直连绕过推送级别-实现总结
+# 114-飞书直连绕过推送级别-实现总结
 
 > 对应需求：飞书直连执行器对话（单聊/群聊管家）不经过推送级别（disabled/result_only/all）限制；推送级别仅作用于 ntd 主动触发的事项/环路通知场景。
 
 | 修改人 | 修改时间 | 修改内容 |
 |--------|---------|---------|
 | AI 协作开发者 | 2026-08-17 | 初始版本：发送端 + 推送端双重闸门撤除 + 单元测试补充 |
+| AI 协作开发者 | 2026-08-17 | 评审修复：编号统一为 114（原误用已被占用的 036）、修复机器本地死链、测试改名补被测函数名、抽 `build_direct_stream_card` 补推送侧测试缝隙、补需求文档 |
 
 ---
 
@@ -16,13 +17,13 @@
 
 ### 1.2 代码改动一览
 
-| 文件 | 关键改动 | 行数 |
-|---|---|---|
-| [message_debounce.rs](file:///Users/weibh/projects/rust/nothing-todo/backend/src/services/message_debounce.rs#L1236-L1255) | `resolve_direct_output`：从「查 DB 判 push_level=all 才返回 Some」改为「同步纯函数，无条件构造直推目标」。删除 `db` 参数、`async` 关键字。 | 原 27 行 → 现 20 行 |
-| [message_debounce.rs](file:///Users/weibh/projects/rust/nothing-todo/backend/src/services/message_debounce.rs#L1471-L1473) | 调用点：去掉 `.await`，去掉 `db` 参数 | 1 行 |
-| [feishu_push.rs](file:///Users/weibh/projects/rust/nothing-todo/backend/src/services/feishu_push.rs#L88-L115) | `DirectStreamMessage` 分支：删除 `get_bot_push_level` 查询 + `push_level != "all"` continue 的二次检查闸门 | 原 35 行 → 现 28 行 |
-| [events.rs](file:///Users/weibh/projects/rust/nothing-todo/backend/src/executor_service/events.rs#L95-L98) | `DirectStreamMessage` 注释：从 "push_level=all 时发送"改为"114 决策：绕过 push_level" | 3 行注释 |
-| [message_debounce.rs](file:///Users/weibh/projects/rust/nothing-todo/backend/src/services/message_debounce.rs#L2203-L2241) | 新增测试模块 `resolve_direct_output_tests`：3 个用例锁定新行为 | 39 行新增 |
+| 文件 | 关键改动 |
+|---|---|
+| `backend/src/services/message_debounce.rs` | `resolve_direct_output`：从「查 DB 判 push_level=all 才返回 Some」改为「同步纯函数，无条件构造直推目标」。删除 `db` 参数、`async` 关键字；调用点去掉 `.await` |
+| `backend/src/services/feishu_push.rs` | `DirectStreamMessage` 分支：删除 `get_bot_push_level` 查询 + `push_level != "all"` continue 的二次检查闸门；评审修复抽出 `build_direct_stream_card` 纯函数（渲染→卡片，不接收 push_level） |
+| `backend/src/executor_service/events.rs` | `DirectStreamMessage` 注释：从 "push_level=all 时发送"改为"114 决策：绕过 push_level" |
+| `backend/src/services/message_debounce.rs`（测试） | 新增测试模块 `resolve_direct_output_tests`：3 个用例锁定恒 Some 行为（评审修复后按 `test_resolve_direct_output_*` 规范命名） |
+| `backend/src/services/feishu_push.rs`（测试） | 评审修复新增 `direct_stream_card_tests`：3 个用例锁定卡片构造缝隙（见 §4.2） |
 
 ### 1.3 两道闸门撤除前后对照
 
@@ -73,9 +74,9 @@
 - **风险**：用户配 disabled 后仍然在飞书聊天时看到过程流，会怀疑"推送级别配置为什么不生效"
 - **缓解**：本次不改 UI（遵循 YAGNI），建议后续在 Select 下方加一行提示：「推送级别仅对事项/环路通知生效，与 bot 主动聊天不受此限制」
 
-### 4.2 推送端单测覆盖缺口
+### 4.2 推送端单测覆盖缺口（评审修复后部分收窄）
 
-`feishu_push.rs` 的推送循环 `start()` 本身是 async runtime 内的 select! 循环，没有独立的纯函数接口暴露"DirectStreamMessage 是否放行"给单测，因此新增行为（任意 push_level 下发）只能通过发送端测试 + 代码走读验证，没有推送端级别的参数化断言。后续如重构 `start()`，可拆 `fn process_event(event: ExecEvent, ...)` 纯函数出口。
+`feishu_push.rs` 的推送循环 `start()` 是 async runtime 内的 select! 循环，`send_card_raw` 为静态网络调用，单测无法直接断言「任意 push_level 都走到发送」。评审修复抽出 `build_direct_stream_card` 纯函数作为可测缝隙：签名刻意不接收 push_level——恢复任何按级别拦截都必须改签名，会先撞坏 `direct_stream_card_tests` 的 3 个用例。残余风险：若有人在 select! arm 内重新内联级别判断（而非走该函数），单测不报警，只能靠 code review 拦截。后续如重构 `start()`，可拆 `fn process_event(event: ExecEvent, ...)` 出口彻底闭环。
 
 ## 5. 验证与结果
 

--- a/docs/requirements/114-飞书直连绕过推送级别-需求.md
+++ b/docs/requirements/114-飞书直连绕过推送级别-需求.md
@@ -1,0 +1,41 @@
+# 114-飞书直连绕过推送级别-需求
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI | 2026-08-17 | 补建需求文档（评审修复：初始 PR 仅含设计与总结，违反「新功能需有对应需求文档」；需求口径已在会话中澄清，本文档按实际澄清内容补记） |
+
+---
+
+## 1. 背景（Why）
+
+推送级别（`feishu_push_targets.push_level`，三档 `disabled` / `result_only` / `all`）原本同时作用于两种本质不同的场景：
+
+1. **ntd 主动触发的事项/环路通知**——用户没有主动操作，ntd 调度/前端触发执行后把结果推到飞书。用户显然有权让这类通知静音或只看结论，push_level 在此**合理**。
+2. **飞书直连执行器对话**（`dm_chat` 单聊直聊 / `butler_chat` 群聊管家）——用户主动发消息给 bot，执行器回复。这是"即时对话"，用户正在聊天却看不到执行过程，体验断裂。push_level 在此**不合理**。
+
+问题表现：push_level 配成 `result_only` / `disabled` 的用户在飞书跟 bot 聊天时，只能看到"开始处理"卡片，过程流式消息全部被拦。
+
+## 2. 目标（What，必须可验证）
+
+- [ ] 飞书单聊直聊 bot（`dm_chat`）时，任意 push_level 配置下都能收到完整的过程流式消息。
+- [ ] 飞书群聊 @bot 管家（`butler_chat`）时，任意 push_level 配置下都能收到完整的过程流式消息。
+- [ ] ntd 主动触发场景的推送行为**完全不变**：`Finished`/`Started`/`Output`/`LoopFinished` 仍按各 push target 的 push_level 经 `should_send` 过滤。
+- [ ] 前端推送级别配置 UI 与 `/help` 文案不变（生效范围收窄不要求 UI 同步改动）。
+
+## 3. 非目标（Explicitly Out of Scope）
+
+- 不改 push_level 的三档语义与存储（`feishu_push_targets.push_level` 结构不动）。
+- 不改 `DirectCardMessage`（开始/错误等关键节点卡片）——其本就绕过 push_level。
+- 不改前端 `AssistantConfigDrawer` 推送级别下拉文案（YAGNI，已知限制见实现总结 §4.1）。
+- 不涉及飞书以外的推送通道。
+
+## 4. 使用场景 / 用户路径
+
+1. 用户把 bot 推送级别配为 `disabled`，随后在飞书私聊该 bot「帮我查一下依赖」→ 应看到开始卡片 + 流式过程（含工具调用编号）+ 最终结果。
+2. 用户在群聊 @bot（管家模式）触发执行，push_level=`result_only` → 过程流式消息照常出现在群聊。
+3. 调度器凌晨自动跑一个 todo，push_level=`result_only` → 仅推送 Finished 结论卡片，行为与 114 之前一致。
+
+## 5. 验收标准
+
+- 单测锁定：直推目标构造（`resolve_direct_output`）与卡片构造（`build_direct_stream_card`）不依赖 push_level；`should_send` 对 ntd 主动事件 × 三档级别的既有断言全部保持通过。
+- 存量行为回归：`cargo test` 全绿，`feishu_push_binding_tests` 8 个 `should_send` 断言不变。


### PR DESCRIPTION
## 背景

推送级别（`disabled` / `result_only` / `all`）原本同时作用于两种本质不同的场景：

1. **ntd 主动触发的事项/环路通知** — 用户没主动操作，ntd 自己跑起来推送结果，用户显然有权让这类通知静音/仅结论。push_level 在此**合理**。
2. **飞书直连执行器对话**（`dm_chat` 单聊直聊 / `butler_chat` 群聊管家） — 用户主动发消息给 bot → 执行器回复。属于"即时对话"，过程流式消息不应被 push_level 阻拦。push_level 在此**不合理**。

问题表现：用户在飞书跟 bot 聊天，但 push_level 配成 `result_only` / `disabled` 时只能看到"开始处理"卡片，过程消息全黑屏，对话体验被打断。

## 改动方案

**推送级别作用域收窄**：仅作用于 ntd 主动触发的事项/环路通知，飞书直连对话场景的过程流式消息（`DirectStreamMessage`）始终推送。

撤除两道闸门（缺一不可，否则会出现"发了事件但被推送端丢弃"的静默丢消息）：

| 闸门 | 文件 | 改动 |
|---|---|---|
| 发送端 | `message_debounce.rs::resolve_direct_output` | 从「查 DB 判 `push_level == "all"` 才返回 Some」改为「同步纯函数无条件 Some」，去掉 `db` 参数与 `async` |
| 推送端 | `feishu_push.rs::DirectStreamMessage` 分支 | 删除 `get_bot_push_level` 二次检查与 `continue`，直接发送 |

**保持不变**（ntd 主动触发场景仍受 push_level 控制）：
- `Finished` 事件的 binding chat 直发路径
- `Finished` / `Started` / `Output` / `LoopFinished` 的 workspace push target 主路径
- `should_send` + `get_bot_push_level` 函数本身

## 行为变化

| 场景 | 改动前 | 改动后 |
|---|---|---|
| 飞书私聊 bot，push_level=disabled | 只能看到"开始处理"卡片，过程全黑屏 | 完整卡片 + 流式过程消息 + 最终结果 |
| 飞书群聊 @bot，push_level=result_only | 只能看到"开始处理"卡片，过程流缺失 | 完整卡片 + 流式过程消息 + 最终结果 |
| 飞书私聊/群聊，push_level=all | 正常 | 不变 |
| ntd 调度器自动跑 todo / loop | 按 push_level 推送 | **不变** |
| 前端点「执行事项」→ 推送到飞书 | 按 push_level 推送 | **不变** |
| 斜杠规则触发环路 → 推送到飞书 | 按 push_level 推送 | **不变** |

## 关键论据

1. `DirectStreamMessage` 的**唯一发出点**是 `handle_butler_chat` 的 `emit_direct_stream`，即 100% 来自「用户主动在飞书聊天」场景，不与 ntd 主动触发混用。
2. `DirectCardMessage`（开始/错误等关键节点卡片）**已经**绕过 push_level，两者行为需要一致——同一场景不应该一半绕过一半不绕过。

## 测试

发送端 `resolve_direct_output_tests` 3 个用例（`message_debounce.rs`）：
- `test_resolve_direct_output_私聊open_id恒构造直推目标` / `test_resolve_direct_output_群聊chat_id恒构造直推目标` — 恒返回 Some 且字段透传
- `test_resolve_direct_output_同步三参签名无db参数` — 同步三参调用可编译即证明无 db/async 能力（编译期事实的等价表述，非运行时断言）

推送端 `direct_stream_card_tests` 3 个用例（评审修复新增，`feishu_push.rs`）：
- 抽出 `build_direct_stream_card` 纯函数作为可测缝隙：签名刻意不接收 push_level，恢复任何级别拦截必改签名、先撞坏测试
- 覆盖：文本日志产出含内容卡片 / 空白内容不产出（对应 arm 的 continue 分支）/ 工具调用编号透传

存量测试全部通过（证明 ntd 主动触发场景的 push_level 约束未松动）：
- `feishu_push_binding_tests` 8 个 `should_send` 断言（Finished/Started/LoopFinished × disabled/result_only/all）
- `services_tests` 4 个 `should_send` 用例

## 评审修复（commit e70796b2）

| # | 评审发现 | 修复 |
|---|---|---|
| 1 | 实现总结撞号 036（已被「验收标准归环节」占用）且与设计文档 114 编号分裂 | 重命名为 `114-飞书直连绕过推送级别-实现总结.md` |
| 2 | 缺需求文档（新功能必须有） | 补 `docs/requirements/114-飞书直连绕过推送级别-需求.md` |
| 3 | 设计 §4.1 承诺的推送端三级别参数化用例未交付 | 抽 `build_direct_stream_card` 纯函数补 `direct_stream_card_tests`；设计文档按可测缝隙口径修订（原因与残余风险见实现总结 §4.2） |
| 4 | 测试名不含被测函数名 | 3 个用例按 `test_<被测函数名>_<场景>` 规范改名 |
| 5 | 实现总结含 `file:///Users/weibh/...` 机器本地死链 | 全部改为仓库相对路径 |

## 验证

- `cd backend && cargo clippy --all-targets -- -D warnings` → **零告警**
- `cd backend && cargo test` → **1782 passed / 0 failed / 2 ignored**（lib，含新增 6 个用例）；集成测试全绿

## 关联文档

- 需求文档：[114-飞书直连绕过推送级别-需求.md](docs/requirements/114-飞书直连绕过推送级别-需求.md)
- 设计文档：[114-飞书直连绕过推送级别-设计.md](docs/design/114-飞书直连绕过推送级别-设计.md)
- 实现总结：[114-飞书直连绕过推送级别-实现总结.md](docs/requirements/114-飞书直连绕过推送级别-实现总结.md)

## 已知限制

前端 `AssistantConfigDrawer` 的"推送级别"下拉文案未改（按 YAGNI 暂不动）。用户配 disabled 后聊天仍能看到过程流，可能怀疑配置不生效——建议后续在 Select 下方加一行提示「推送级别仅对事项/环路通知生效，与 bot 主动聊天不受此限制」。
