### PR TITLE
fix(019): zhanlu 执行时通过 --dir 注入生效目录

### DIFF
--- a/backend/src/adapters/mod.rs
+++ b/backend/src/adapters/mod.rs
@@ -241,6 +241,38 @@ pub fn default_final_result_with_think_stripping(logs: &[ParsedLogEntry]) -> Opt
     }
 }
 
+/// 把执行器的目录参数插进 argv（NTD-019）。
+///
+/// 只在两个条件同时满足时才动 argv：执行器声明了目录 flag（`dir_arg()` 为
+/// `Some`，目前仅 zhanlu 的 `--dir`——zl 不跟随进程 cwd），且本次执行有生效
+/// 目录（worktree 路径 / workspace path / wiki 目录）。任一缺失、或 argv 为空
+/// （没有 message 锚点）时原样返回——其余 10 家执行器的 argv 逐字节不变。
+///
+/// 插入位置取最后一个元素之前：所有适配器的 argv 都以 message 收尾（位置参数），
+/// clap 系 CLI 的 flag 必须在位置参数之前才稳妥，不赌 trailing flag 可解析。
+pub fn insert_dir_arg(
+    args: Vec<String>,
+    dir_flag: Option<&str>,
+    dir: Option<&str>,
+) -> Vec<String> {
+    // let-else 解包「flag 与目录齐备」：目录参数缺一不可，缺任一个都等于没有
+    // 目录信息可传，保持现状（仅进程 cwd）比传半个参数更安全。
+    let (Some(flag), Some(dir)) = (dir_flag, dir) else {
+        return args;
+    };
+    // argv 为空说明连 message 都没有，没有可锚定的插入点；防御分支，正常不会走到。
+    if args.is_empty() {
+        return args;
+    }
+    let mut args = args;
+    // 插在 message（最后一个位置参数）之前：先插 dir 再插 flag，两次同位插入
+    // 让 flag 落在 dir 前面，得到 `... --dir /path <message>` 的目标形态。
+    let at = args.len() - 1;
+    args.insert(at, dir.to_string());
+    args.insert(at, flag.to_string());
+    args
+}
+
 /// 共享的执行器基础状态：path + 可选 model。
 ///
 /// `BaseExecutor` 解决 Issue #504 提到的 10 个 executor 适配器高度重复的问题。
@@ -362,6 +394,14 @@ pub trait CodeExecutor: Send + Sync {
     /// `is_resume` 为 true 时表示恢复已有会话，false 表示新执行并指定 session_id
     fn command_args_with_session(&self, message: &str, _session_id: Option<&str>, _is_resume: bool) -> Vec<String> {
         self.command_args(message)
+    }
+
+    /// CLI 目录参数差异点（NTD-019）：返回 `Some(flag)` 表示该执行器不跟随进程
+    /// cwd、需要 argv 显式携带工作目录（zhanlu 的 `--dir`），spawn 层会把
+    /// `flag <生效目录>` 插到 argv 的 message 之前；返回 `None`（默认）表示
+    /// 只依赖进程 cwd，argv 不注入目录。默认值让其余 10 家执行器零改动。
+    fn dir_arg(&self) -> Option<&'static str> {
+        None
     }
 
     /// 该执行器是否支持通过 session_id 恢复对话
@@ -1020,5 +1060,55 @@ mod tests {
         *exec.base.model.lock() = Some("claude-3-5-sonnet".to_string());
         // 通过 trait 方法读出
         assert_eq!(exec.get_model(), Some("claude-3-5-sonnet".to_string()));
+    }
+
+    #[test]
+    fn test_insert_dir_arg_目录参数插在message之前() {
+        // 模拟 zhanlu 的 argv 形态：message 是最后一个位置参数，
+        // --dir 必须落在 message 前、其余 flag 之后。
+        let args = vec![
+            "run".to_string(),
+            "--format".to_string(),
+            "json".to_string(),
+            "--dangerously-skip-permissions".to_string(),
+            "写代码".to_string(),
+        ];
+        let out = insert_dir_arg(args, Some("--dir"), Some("/tmp/ws"));
+        assert_eq!(
+            out,
+            vec![
+                "run".to_string(),
+                "--format".to_string(),
+                "json".to_string(),
+                "--dangerously-skip-permissions".to_string(),
+                "--dir".to_string(),
+                "/tmp/ws".to_string(),
+                "写代码".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_insert_dir_arg_执行器无目录flag时argv原样() {
+        // dir_arg()=None 的执行器（其余 10 家）：即使有目录也不注入，argv 逐字节不变
+        let args = vec!["-p".to_string(), "hello".to_string()];
+        let out = insert_dir_arg(args.clone(), None, Some("/tmp/ws"));
+        assert_eq!(out, args);
+    }
+
+    #[test]
+    fn test_insert_dir_arg_无生效目录时argv原样() {
+        // effective_workspace_path=None（未配置工作空间/非 UTF-8 路径退化）：
+        // 有 flag 也没有目录可传，保持现状（仅进程 cwd）
+        let args = vec!["run".to_string(), "hello".to_string()];
+        let out = insert_dir_arg(args.clone(), Some("--dir"), None);
+        assert_eq!(out, args);
+    }
+
+    #[test]
+    fn test_insert_dir_arg_空argv不注入() {
+        // 防御分支：没有 message 锚点时不硬插，返回空 argv
+        let out = insert_dir_arg(vec![], Some("--dir"), Some("/tmp"));
+        assert!(out.is_empty());
     }
 }

--- a/backend/src/adapters/step_protocol.rs
+++ b/backend/src/adapters/step_protocol.rs
@@ -74,6 +74,13 @@ impl StepProtocolFlavor {
     fn reports_model(self) -> bool {
         !matches!(self, Self::Mimo)
     }
+
+    /// CLI 目录参数差异点（NTD-019）：zl run 以 `--dir <path>` 为工作目录、
+    /// 不跟随进程 cwd，因此仅 Zhanlu 需要 argv 显式携带目录；同族其余三家
+    /// （kilo/opencode/mimo）跟随 cwd，返回 None 保持 argv 不动。
+    fn dir_flag(self) -> Option<&'static str> {
+        matches!(self, Self::Zhanlu).then_some("--dir")
+    }
 }
 
 /// Step 协议族统一执行器。
@@ -260,6 +267,12 @@ impl CodeExecutor for StepProtocolExecutor {
 
     fn supports_resume(&self) -> bool {
         true
+    }
+
+    /// 目录参数委托给 flavor（NTD-019）：仅 Zhanlu 返回 Some("--dir")，
+    /// spawn 层据此把生效目录插进 argv；同族其余 flavor 维持 trait 默认 None。
+    fn dir_arg(&self) -> Option<&'static str> {
+        self.flavor.dir_flag()
     }
 
     /// 执行前注入期望模型，写入 base.model，供 command_args_with_session 拼 -m。
@@ -576,6 +589,16 @@ mod tests {
         let args = exec.command_args_with_session("hello", None, false);
         let model_value = args.windows(2).find(|w| w[0] == "-m").map(|w| w[1].clone());
         assert_eq!(model_value, Some("xiaomi/mimo-v2.5-pro".to_string()));
+    }
+
+    /// NTD-019 目录参数差异：仅 zhanlu 需要 `--dir`（zl 不跟随进程 cwd），
+    /// 同族其余三家跟随 cwd，必须保持 None 让 argv 不被注入目录。
+    #[test]
+    fn test_dir_arg_仅zhanlu返回flag其余flavor为none() {
+        assert_eq!(StepProtocolExecutor::zhanlu("z".into()).dir_arg(), Some("--dir"));
+        assert_eq!(StepProtocolExecutor::kilo("k".into()).dir_arg(), None);
+        assert_eq!(StepProtocolExecutor::opencode("o".into()).dir_arg(), None);
+        assert_eq!(StepProtocolExecutor::mimo("m".into()).dir_arg(), None);
     }
 
     /// executor_type 与注册名一一对应

--- a/backend/src/executor_service/spawn_lifecycle.rs
+++ b/backend/src/executor_service/spawn_lifecycle.rs
@@ -16,7 +16,7 @@ use command_group::AsyncCommandGroup;
 use tokio::io::AsyncWriteExt;
 use tokio::task::JoinHandle;
 
-use crate::adapters::CodeExecutor;
+use crate::adapters::{insert_dir_arg, CodeExecutor};
 use crate::db::Database;
 use crate::executor_service::ExecEvent;
 use crate::models::ParsedLogEntry;
@@ -221,12 +221,23 @@ pub(crate) fn build_executor_command(
 
 /// `build_executor_command` + `group_spawn` 两步合一：argv 已就绪，直接
 /// 创建进程组让 kill 时能整组杀，避免留下 zombie 子进程。
+///
+/// spawn 前补一道目录参数注入（NTD-019）：zhanlu 系 CLI 不跟随进程 cwd，
+/// 需要 `--dir <生效目录>` 显式指定。注入放这里而不是 argv 构造期
+/// （pre_spawn），是因为 effective_workspace_path 此时才最终确定——
+/// worktree 启用时要传 worktree 路径，argv 构造期只能拿到 todo.workspace_path。
 pub(crate) fn spawn_executor_child(
     runtime: &SpawnRuntime,
 ) -> Result<command_group::AsyncGroupChild, std::io::Error> {
+    // dir_arg() 为 None 的执行器（其余 10 家）insert_dir_arg 原样返回，argv 零变化。
+    let command_args = insert_dir_arg(
+        runtime.prepared.command_args.clone(),
+        runtime.executor_spawn.dir_arg(),
+        runtime.effective_workspace_path.as_deref(),
+    );
     let mut cmd = build_executor_command(
         &runtime.prepared.executable_path,
-        &runtime.prepared.command_args,
+        &command_args,
         runtime.effective_workspace_path.as_deref(),
     );
     cmd.group_spawn()

--- a/backend/src/services/executor_session.rs
+++ b/backend/src/services/executor_session.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 use command_group::AsyncCommandGroup;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
-use crate::adapters::CodeExecutor;
+use crate::adapters::{insert_dir_arg, CodeExecutor};
 
 /// 直连执行 session 的 spawn 配置（A/B 调用方各自组装，通路差异不进本结构）。
 pub(crate) struct SessionSpawnConfig {
@@ -100,6 +100,14 @@ impl DirectExecutorSession {
         let is_resume = session_id.is_some();
         let command_args =
             executor.command_args_with_session(&message, session_id.as_deref(), is_resume);
+        // 目录参数注入（NTD-019）：zhanlu 不跟随进程 cwd，把 cwd 同源的目录
+        // 以 `--dir <path>` 插进 argv。to_str() 失败（非 UTF-8 路径）时不注入，
+        // 退化为仅 current_dir 的现状语义，不 panic。
+        let command_args = insert_dir_arg(
+            command_args,
+            executor.dir_arg(),
+            cwd.to_str(),
+        );
         let program = executor.executable_path();
         tracing::info!(
             "[session] spawning {}: {:?} (cwd={:?}, tag={})",

--- a/docs/bugs/019-zhanlu执行器未进入工作空间目录/019-zhanlu执行器未进入工作空间目录-修复总结.md
+++ b/docs/bugs/019-zhanlu执行器未进入工作空间目录/019-zhanlu执行器未进入工作空间目录-修复总结.md
@@ -1,0 +1,55 @@
+# NTD-019 zhanlu 执行器执行时未进入工作空间目录 — 修复总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| Claude | 2026-08-18 | 初始版本 |
+
+---
+
+## 1. 修复方案（一句话）
+
+在两个 spawn 点把生效目录以 `--dir <path>` 注入 zhanlu 的 argv（插在 message 位置参数之前），进程 cwd 照旧设置；其余 10 家执行器 argv 逐字节不变。方案选型与根因见同目录《缺陷分析》。
+
+## 2. 改动清单
+
+| 文件 | 改动 | 说明 |
+|------|------|------|
+| `backend/src/adapters/mod.rs` | trait 新增默认方法 `dir_arg()` + 纯函数 `insert_dir_arg()` | 默认 `None` 让其余执行器零改动；注入位置取 message 前 |
+| `backend/src/adapters/step_protocol.rs` | `StepProtocolFlavor::dir_flag()` + `StepProtocolExecutor::dir_arg()` 覆写 | 仅 Zhanlu 返回 `Some("--dir")`，kilo/opencode/mimo 为 `None` |
+| `backend/src/executor_service/spawn_lifecycle.rs` | `spawn_executor_child` 注入 | 目录用 `runtime.effective_workspace_path`（worktree 启用时为 worktree 路径） |
+| `backend/src/services/executor_session.rs` | `spawn_and_stream` 注入 | 目录用 `SessionSpawnConfig.cwd`（飞书直连对话 / Wiki 对话通路） |
+
+覆盖的触发通路：事项执行、飞书单聊/群聊直连对话（dm_chat / butler_chat）、黑板 Wiki 对话、环路步骤（经事项执行主链路）。
+
+## 3. 行为对照
+
+| 场景 | 修复前 | 修复后 |
+|------|--------|--------|
+| zhanlu + 工作空间 | argv 无目录，zl 不跟随 cwd，落错目录 | `zl run --format json --dir <workspace> ... "<message>"` |
+| zhanlu + worktree 启用 | 同上 | `--dir <worktree 路径>`（与 cwd 同源） |
+| zhanlu + Wiki 对话 | argv 无目录 | `--dir <wiki 目录>` |
+| zhanlu + 未配置工作空间 | argv 无目录，仅 cwd | 不注入（无目录可传），与现状一致 |
+| 其余 10 家执行器 | 仅 cwd | 仅 cwd，argv 逐字节不变（单测锁定） |
+| 非 UTF-8 路径 | 仅 cwd | `to_str()` 失败不注入，退化为现状，不 panic |
+
+## 4. 测试
+
+新增 5 个单测（全部通过）：
+
+- `adapters::tests::test_insert_dir_arg_目录参数插在message之前` — 锁定插入位置与最终 argv 形态
+- `adapters::tests::test_insert_dir_arg_执行器无目录flag时argv原样` — 其余执行器零变化
+- `adapters::tests::test_insert_dir_arg_无生效目录时argv原样` — 无目录不注入
+- `adapters::tests::test_insert_dir_arg_空argv不注入` — 防御分支
+- `step_protocol::tests::test_dir_arg_仅zhanlu返回flag其余flavor为none` — flavor 差异
+
+回归：既有 `effective_workspace_path` 系列、`executor_session` spawn 骨架测试全部保持通过，证明默认路径零行为变化。
+
+## 5. 验证记录
+
+- `cd backend && cargo clippy --all-targets -- -D warnings` → 零告警零错误
+- `cd backend && cargo test` → 1791 passed / 0 failed / 2 ignored
+- 本机未安装 `zl` 二进制，端到端（飞书发消息 → zhanlu 汇报 pwd）待用户在装有 zl 的环境实测；argv 形态已由单测锁定。
+
+## 6. 环境备注（与本缺陷无关但影响验证）
+
+- `frontend/dist` 与 `backend/target` 曾被清理，导致 `make dev` 构建失败（rust_embed 找不到 dist 目录 → `Assets::get` 缺失 → 4 个编译错误）。本次已通过 `cd frontend && npm run build` 重建 dist 后全部编译通过。

--- a/docs/bugs/019-zhanlu执行器未进入工作空间目录/019-zhanlu执行器未进入工作空间目录-缺陷分析.md
+++ b/docs/bugs/019-zhanlu执行器未进入工作空间目录/019-zhanlu执行器未进入工作空间目录-缺陷分析.md
@@ -1,0 +1,95 @@
+# NTD-019 zhanlu 执行器执行时未进入工作空间目录 — 缺陷分析
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| Claude | 2026-08-18 | 初始版本 |
+
+---
+
+## 1. 根因（Root Cause）
+
+目录在 ntd 内部的传递链是「进程 cwd」单通道：
+
+```
+生效目录(effective_workspace_path / wiki 目录)
+  └→ tokio::process::Command::current_dir()      ← 唯一传递方式
+       └→ 子进程继承 cwd
+            └→ 执行器 CLI 自行决定是否使用 cwd
+```
+
+- 事项执行通路：`spawn_lifecycle.rs` `spawn_executor_child` → `build_executor_command(workspace_path)` 设置 `current_dir`。
+- 直连对话 / Wiki 对话通路：`executor_session.rs` `spawn_and_stream` 设置 `current_dir`。
+- 全部 11 个适配器的 argv 拼装（`command_args` / `command_args_with_session`）都**不含目录参数**。
+
+zhanlu（`zl`）的目录语义与这条链不兼容：`zl run` 以 `--dir <path>` 为准、不跟随进程 cwd。于是 cwd 设置了但 zl 不读，目录在「ntd → zl」边界断裂。
+
+## 2. 为什么 argv 里没有目录
+
+现有 `CodeExecutor` trait 的 argv 拼装方法（`command_args(&self, message)` / `command_args_with_session(&self, message, session_id, is_resume)`）**拿不到目录**：目录不是执行器的构造期属性，而是每次执行期的上下文。当初设计时所有目标 CLI 都跟随 cwd，argv 不需要目录；zhanlu 是第一个例外。
+
+## 3. 方案选型
+
+### 候选 A：给 trait 方法加 cwd 参数（改签名）
+
+把 `command_args_with_session` 加一个 `dir: Option<&str>` 参数，由各适配器自行拼进 argv。
+
+- 否决理由 ①：波及全部 11 个适配器与其测试，只有 1 家需要该参数，噪声极大。
+- 否决理由 ②（决定性）：**事项执行通路的 argv 构造发生在 worktree 创建之前**（`pre_spawn.rs` `select_executor_and_build_command` 先拼 argv，`stages.rs` 之后才解析 `effective_workspace_path = worktree 路径 > todo.workspace_path`）。在 argv 构造点拿到的目录是 todo.workspace_path，worktree 启用时会传错目录；要传对必须把 argv 构造推迟到 spawn 期，重构面失控。
+
+### 候选 B：`set_exec_cwd` 仿照 `set_exec_model` 的注入模式
+
+在执行前把目录写进执行器实例内部状态，argv 拼装时读取。
+
+- 否决理由：registry 的执行器实例是 per-type 单例（Arc 共享），`set_exec_model` 靠「注入与构建之间无 await」保原子（`pre_spawn.rs:282-284` 注释）；同样把注入挪到 spawn 期（worktree 之后）才能拿对目录，等于绕开既有原子性约定，引入并发覆盖风险。
+
+### 候选 C（采用）：spawn 层注入目录参数
+
+trait 加一个**默认方法** `dir_arg(&self) -> Option<&'static str>`（默认 `None`），只有 zhanlu 所在的 `StepProtocolExecutor`（Zhanlu flavor）返回 `Some("--dir")`；两个 spawn 点在拿到最终生效目录之后，把 `--dir <生效目录>` 插入 argv：
+
+- 时机正确：注入发生在 `effective_workspace_path` 解析完成之后，worktree 场景天然传 worktree 路径。
+- 波及面最小：不改任何既有方法签名，其余 10 家 `dir_arg()` 返回 `None`，argv 逐字节不变。
+- 直连对话通路（`executor_session.rs`）与 Wiki 对话通路（同文件）注入点用 `SessionSpawnConfig.cwd`，语义与进程 cwd 完全同源。
+
+### 插入位置：message 之前
+
+所有适配器的 argv 都以 message 作为**最后一个位置参数**。clap 系 CLI 的 flag 必须出现在位置参数之前才稳妥（trailing flag 是否可解析取决于各家实现，不赌）。因此插入点取 `argv.len() - 1`（message 前一位），仅当 `dir_arg()` 为 `Some` 且生效目录存在时才动 argv。
+
+## 4. 修复设计（候选 C 落地）
+
+### 4.1 trait 默认方法（`adapters/mod.rs`）
+
+```rust
+fn dir_arg(&self) -> Option<&'static str> { None }
+```
+
+语义：返回 `Some(flag)` 表示该执行器不跟随进程 cwd，spawn 层把 `flag <生效目录>` 插到 argv 的 message 之前；`None` 表示只依赖进程 cwd。
+
+### 4.2 flavor 差异点（`step_protocol.rs`）
+
+`StepProtocolFlavor::dir_flag(self)`：仅 `Zhanlu` 返回 `Some("--dir")`；kilo/opencode/mimo 返回 `None`。`StepProtocolExecutor` 覆写 `dir_arg` 委托给 flavor。
+
+### 4.3 注入函数（`adapters/mod.rs`）
+
+`insert_dir_arg(args, dir_flag, dir) -> Vec<String>` 纯函数：flag 或 dir 缺一、argv 为空时原样返回；否则在 message 前插入 `flag`、`dir` 两元素。
+
+### 4.4 两个注入点
+
+| 通路 | 文件 | 目录来源 |
+|------|------|---------|
+| 事项执行 | `spawn_lifecycle.rs` `spawn_executor_child` | `runtime.effective_workspace_path` |
+| 直连对话 / Wiki 对话 | `executor_session.rs` `spawn_and_stream` | `SessionSpawnConfig.cwd` |
+
+进程 cwd 照旧设置（`current_dir`），`--dir` 与 cwd 双通道一致——即使 zl 未来改为跟随 cwd 也不会错。
+
+## 5. 风险与边界
+
+- **非 UTF-8 路径**：`PathBuf::to_str()` 失败时不注入 `--dir`（退化为现状的仅 cwd），不 panic。
+- **无工作空间的执行**：`effective_workspace_path = None` 时不注入，argv 与现状一致。
+- **zl 解析顺序**：采用「message 之前」的保守插入顺序；如 zl 实测要求其他位置（如 `run` 子命令前），只需调整 `insert_dir_arg` 一处。
+- **并发**：注入读取的是 runtime/config 内的只读值，不触碰执行器共享状态，无 `set_exec_model` 类原子性约束。
+
+## 6. 测试策略
+
+- `adapters/mod.rs`：`insert_dir_arg` 单测——插入位置（message 前）、flag 为 None 原样、dir 为 None 原样、空 argv 原样。
+- `step_protocol.rs`：`dir_arg` 单测——仅 Zhanlu 返回 `Some("--dir")`，kilo/opencode/mimo 为 `None`。
+- 既有回归：`spawn_lifecycle.rs` 的 `effective_workspace_path` 系列、`executor_session.rs` 的 spawn 骨架测试保持通过，证明默认路径（其余执行器）零行为变化。

--- a/docs/bugs/019-zhanlu执行器未进入工作空间目录/019-zhanlu执行器未进入工作空间目录-缺陷说明.md
+++ b/docs/bugs/019-zhanlu执行器未进入工作空间目录/019-zhanlu执行器未进入工作空间目录-缺陷说明.md
@@ -1,0 +1,98 @@
+# NTD-019 zhanlu 执行器执行时未进入工作空间目录 — 缺陷说明
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| Claude | 2026-08-18 | 初始版本（用户反馈：飞书消息跟执行器对话，执行器没有进入到工作空间的目录下） |
+
+---
+
+## 1. Bug 基本信息（Identity）
+
+- Bug ID：`NTD-019`
+- 所属系统 / 服务：`backend`（`backend/src/adapters/step_protocol.rs`、`backend/src/executor_service/spawn_lifecycle.rs`、`backend/src/services/executor_session.rs`）
+- 首次发现时间：2026-08-18
+- 发现来源：用户反馈（飞书消息与执行器对话时发现执行器不在工作空间目录）
+- 当前状态：已确认存在
+
+## 2. Bug 是否被确认存在（Existence）
+
+- [x] Bug 已被稳定复现
+- [ ] Bug 存在但不可稳定复现
+- [ ] Bug 是否存在尚不确定（禁止进入 AI 分析阶段）
+
+### 2.1 复现环境
+
+- 环境类型：开发环境（端口 18088，`make dev`）；执行器为 zhanlu（`zl`）
+- 系统版本 / Commit ID：`main`（ca72bc9e）
+- 相关配置项：
+  - 工作空间配置了有效 `path`（如 `/Users/mac/sticky-notes`）
+  - 执行器配置为 `zhanlu`（事项的 executor 字段，或工作空间对话执行器 butler_executor）
+- 复现方式：任一触发通路（飞书直连对话 / 事项执行）让 zhanlu 干活，让其汇报当前目录或读取工作空间内文件——不在工作空间目录内
+
+## 3. 触发条件（Trigger Conditions）
+
+### 3.1 前置条件
+
+- 执行器选择 zhanlu（`zl` 二进制）
+- 工作空间已配置路径
+
+### 3.2 输入条件
+
+- 以下任一通路触发 zhanlu 执行：
+  - 事项（todo）执行：executor_service 主链路
+  - 飞书单聊/群聊直连对话（dm_chat / butler_chat）
+  - 黑板 Wiki 对话
+
+## 4. 实际行为（Observed Behavior）
+
+- ntd 把生效目录（workspace path，worktree 启用时为 worktree 路径）设置为子进程 cwd（`Command::current_dir`），但 zhanlu 的 argv 中**没有任何目录参数**：
+  - `step_protocol.rs` `command_args`：`zl run --format json --dangerously-skip-permissions "<message>"`
+  - `step_protocol.rs` `command_args_with_session`：`zl run --format json [-m <model>] [-s <sid>] --dangerously-skip-permissions "<message>"`
+- `zl run` 的目录语义是「以 `--dir <path>` 参数为准」，不跟随进程 cwd，因此 zhanlu 实际工作目录不是工作空间目录。
+- **发生频率**：必现（zhanlu 的每次执行）。
+
+## 5. 期望行为（Expected Behavior）
+
+- zhanlu 执行时通过 `zl run --dir <生效目录> ...` 显式接收目录（用户确认的 CLI 形态：`zl run --dir xxx`）。
+- 生效目录与现有 cwd 语义一致：worktree 路径优先，回退 workspace path。
+- 其余执行器（claudecode/codex/pi/kilo/opencode/mimo 等 10 家）行为不变——它们跟随进程 cwd，不注入目录参数。
+
+## 6. 行为偏差定义（Deviation）
+
+- ntd 已把目录信息写进进程 cwd，但 zhanlu 不读 cwd、只认 `--dir`，目录传递在「ntd → zl」边界断裂；表现为执行器在工作空间外的目录工作，对工作空间文件的读写、git 操作均不生效。
+
+## 7. 影响范围（Impact）
+
+- 影响面：所有使用 zhanlu 执行器的通路（事项执行 / 飞书直连对话 / Wiki 对话 / 环路步骤）。
+- 严重级别：高（执行器完全不在目标目录工作，产出文件落错位置）。
+- 不影响其余 10 个执行器（argv 不变）。
+
+## 8. 已知边界与非问题（Non-Issues）
+
+- 本机 dev 未安装 `zl` 二进制（仅残留 `~/.local/share/zhanlu` 数据目录），无法本地端到端复现；以 argv 代码事实 + 用户确认的 CLI 用法为判定依据。
+- worktree 场景：`--dir` 应使用 worktree 路径（与 cwd 同源），不是缺陷但属于修复必须覆盖的边界。
+- wiki 对话场景 cwd 是 wiki 目录（`~/.ntd/workspace/<id>/wiki`），`--dir` 跟随该目录，属既有设计而非偏差。
+
+## 9. 事实证据（Facts & Evidence）
+
+- `grep -rn -- '--dir' backend/src` 零命中——全部 11 个执行器适配器都不传目录参数。
+- zhanlu argv 拼装唯一出处：`backend/src/adapters/step_protocol.rs:222`（`command_args`）与 `:235`（`command_args_with_session`），与 kilo/opencode/mimo 共用。
+- 目录仅经进程 cwd 传递的两处 spawn 点：`backend/src/services/executor_session.rs:118`（直连对话/Wiki 对话）、`backend/src/executor_service/spawn_lifecycle.rs:216-218`（事项执行）。
+- zl CLI 用法（用户确认）：`zl run --dir xxx`。
+
+## 10. 不确定点与待澄清事项（Uncertainties）
+
+- `--dir` 与 message 位置参数的先后顺序对 zl 解析器的影响未实测（修复采用「目录参数插在 message 之前」的保守顺序，见缺陷分析 §方案）。
+
+## 11. AI 阅读与处理约束（强制）
+
+- 只注入目录参数，不改动其余执行器的 argv 与 spawn 行为。
+- 不改 `CodeExecutor` 既有方法签名（避免波及 11 个适配器）。
+- 补齐单测：目录参数插入位置、flavor 差异（仅 Zhanlu）、flag/目录缺失时 argv 原样。
+
+## 12. 进入下一阶段的判定（Gate）
+
+- [x] Bug 描述完整，事实清晰，已进入分析 / 修复阶段
+- [x] zhanlu argv 包含 `--dir <生效目录>`（插在 message 之前）
+- [x] 其余执行器 argv 逐字节不变（单测锁定：`test_insert_dir_arg_执行器无目录flag时argv原样` 等 4 例）
+- [x] `cargo clippy --all-targets -- -D warnings` 零告警；`cargo test` 1791 passed / 0 failed


### PR DESCRIPTION
## 缺陷对应

NTD-019：zhanlu 执行器执行时未进入工作空间目录（`zl run` 以 `--dir <path>` 为工作目录、不跟随进程 cwd，而 ntd 此前只设进程 cwd）。

文档：`docs/bugs/019-zhanlu执行器未进入工作空间目录/`（缺陷说明 / 缺陷分析 / 修复总结）

## 修复方式

spawn 层注入目录参数，不动 `CodeExecutor` 既有方法签名（避免波及 11 个适配器）：

- `adapters/mod.rs`：trait 默认方法 `dir_arg()`（默认 `None`）+ 纯函数 `insert_dir_arg()`（插在 message 位置参数之前）
- `step_protocol.rs`：仅 Zhanlu flavor 返回 `Some("--dir")`
- `spawn_lifecycle.rs` `spawn_executor_child`：目录用 `effective_workspace_path`（worktree 启用时自动传 worktree 路径——这也是不放在 argv 构造期注入的原因）
- `executor_session.rs` `spawn_and_stream`：目录用 `config.cwd`（飞书直连对话 / Wiki 对话通路）

进程 cwd 照旧设置，`--dir` 与 cwd 双通道一致。

## 行为边界

- 其余 10 家执行器 argv 逐字节不变（单测锁定）
- 未配置工作空间 / 非 UTF-8 路径：不注入，退化为现状
- Wiki 对话：`--dir` 跟随 wiki 目录（既有设计）

## 验证

- `cargo clippy --all-targets -- -D warnings` 零告警
- `cargo test` **1791 passed / 0 failed / 2 ignored**（含新增 5 个单测：`test_insert_dir_arg_*` 4 例 + `test_dir_arg_仅zhanlu返回flag其余flavor为none`）
- 本机未装 `zl`，端到端待装有 zl 的环境实测（argv 形态已由单测锁定：`zl run --format json --dangerously-skip-permissions --dir <path> "<message>"`）

## 环境备注

`frontend/dist` + `backend/target` 曾被清理导致 `make dev` 失败（rust_embed 无 dist → `Assets::get` 编译错），已用 `npm run build` 重建后验证。
