### PR TITLE
refactor(093): useApp 细粒度迁移批次 2（收尾）+ 零订阅 dispatch

### DIFF
--- a/docs/requirements/093-useApp批次2迁移-实现总结.md
+++ b/docs/requirements/093-useApp批次2迁移-实现总结.md
@@ -1,0 +1,48 @@
+# 093-useApp批次2迁移-实现总结
+
+| 修改人 | 修改时间 | 修改内容 |
+|--------|---------|---------|
+| AI (Pi) | 2026-08-09 | 批次 2（收尾批次）完成 |
+
+> 对应设计：`docs/design/093-useApp合并context拆分迁移-设计.md`（批次 1 文档已规划批次 2 范围）。
+> 注：批次 1 遗留清单中的 KanbanBoard 已由其它会话先行迁移；本批次迁移剩余全部消费方，
+> 并顺手完成「最后一公里」——WS 事件路由的零订阅 dispatch。
+
+## 1. 实现了什么
+
+| 文件 | 迁移内容 |
+|------|---------|
+| `TodoDetail.tsx` | 拆 `useTodos()`（selectedWorkspace/selectedTodoId/SELECT_TODO）+ `useExecution()`（executionRecords/runningTasks/ADD_EXECUTION_RECORD） |
+| `ExecutionPanel.tsx` | 拆 `useTodos()`（selectedWorkspace）+ `useExecution()`（runningTasks/activeTaskId/executionRecords + REMOVE_RUNNING_TASK/SET_ACTIVE_TASK）+ `useLogsDispatch()`（REMOVE_TASK_LOGS） |
+| `useExecutionHistory.ts` | dispatch prop 类型从三域联合收窄到 `Dispatch<ExecutionAction>`（hook 内只 dispatch 执行域 action） |
+
+### 最后一公里：dispatch-only context + useAppDispatch
+
+批次 1 后 `useApp()` 仅剩 `useExecutionEvents.ts` 一个消费方，但 `useApp()` 内部订阅三域
+state——只取 dispatch 也会被任一域变化卷入重渲染。本批次：
+
+- Todo/Execution/UI 三个 context 各补 **dispatch-only 双 context**（沿用 091 LogsContext 先例）；
+- 新增 `useAppDispatch()`：四域 dispatch 组合，零 state 订阅；
+- 路由逻辑抽 `routeAppAction` 单一事实源，`useApp` 与 `useAppDispatch` 共用（防两份漂移）；
+- `useExecutionEvents` 切换后：**WS 事件路由宿主组件不再被执行/日志高频更新卷入重渲染**。
+
+## 2. 实施期发现
+
+- main 已演进：tags action（SET_TAGS/ADD_TAG 等）已由组件本地状态接管，todo 域 action 只剩
+  SELECT_TODO/SELECT_WORKSPACE——路由表按 main 现状逐字对齐；
+- `useExecutionEvents.test.tsx` 的 mock 同步拆到 `./useApp`（useAppDispatch）与
+  `./useTodoContext`（useTodos）两个模块。
+
+## 3. 测试与验证
+
+- `npx tsc --noEmit` 零错误 ✅；`npx vitest run` 54 文件 / 452 用例全绿 ✅
+- Playwright 冒烟 2 项（列表→详情 TodoDetail 路径 / 执行面板挂载 + WS 路由）全过 ✅
+
+## 4. 最终状态
+
+- 项目 `useApp()` 消费方：**0**（仅保留 hook 本体与 AppProvider 组合根用途）；
+- 三域 state 的订阅面全部细粒度化，执行态高频推送的重渲染半径收敛到真实使用方。
+
+## 5. 安全反思
+
+纯前端订阅路径变更；dispatch 路由表与原实现逐字对齐；无接口/行为变化。

--- a/frontend/src/components/ExecutionPanel.tsx
+++ b/frontend/src/components/ExecutionPanel.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from 'react';
 import { ExpandOutlined, CompressOutlined, InfoCircleOutlined, StopOutlined, CloseOutlined } from '@ant-design/icons';
 import { Popconfirm, Popover, Dropdown, App } from 'antd';
-import { useApp } from '@/hooks/useApp';
+// 093 批次2：合并版 useApp 拆为三域细粒度订阅——todo 域只读 selectedWorkspace，
+// 执行域 action 走 useExecution，日志域 action 走 useLogsDispatch；
+// 任一域变化不再牵连其它两域的订阅者。
+import { useTodos } from '@/hooks/useTodoContext';
+import { useExecution } from '@/hooks/useExecutionContext';
+import { useLogsDispatch } from '@/hooks/useLogsContext';
 import { useTheme } from '@/hooks/useTheme';
 import { getExecutorOption } from '@/types';
 import { stopExecution } from '@/utils/database';
@@ -24,9 +29,11 @@ interface ExecutionPanelProps {
 }
 
 export function ExecutionPanel({ collapsed, onToggleCollapse, hidden, onTemporaryClose, onPermanentClose }: ExecutionPanelProps) {
-  const { state, dispatch } = useApp();
+  const { state: todoState } = useTodos();
+  const { state: execState, dispatch: execDispatch } = useExecution();
+  const logsDispatch = useLogsDispatch();
   const { themeMode } = useTheme();
-  const { runningTasks, activeTaskId, executionRecords } = state;
+  const { runningTasks, activeTaskId, executionRecords } = execState;
   const { message } = App.useApp();
   const [fullscreen, setFullscreen] = useState(false);
 
@@ -56,14 +63,14 @@ export function ExecutionPanel({ collapsed, onToggleCollapse, hidden, onTemporar
         const elapsed = Date.now() - new Date(task.finishedAt).getTime();
         const delay = Math.max(0, 5000 - elapsed);
         timers.push(setTimeout(() => {
-          dispatch({ type: 'REMOVE_RUNNING_TASK', payload: id });
+          execDispatch({ type: 'REMOVE_RUNNING_TASK', payload: id });
           // 091：任务移出运行列表时同步释放其日志内存，与 WS 事件 Finished 路径一致。
-          dispatch({ type: 'REMOVE_TASK_LOGS', payload: id });
+          logsDispatch({ type: 'REMOVE_TASK_LOGS', payload: id });
         }, delay));
       }
     });
     return () => timers.forEach(clearTimeout);
-  }, [runningTasks, dispatch]);
+  }, [runningTasks, execDispatch]);
 
   // Get elapsed seconds for a task
   const getElapsedSeconds = (startedAt: string) => {
@@ -90,7 +97,7 @@ export function ExecutionPanel({ collapsed, onToggleCollapse, hidden, onTemporar
     }
     try {
       // v1 纯 workspace-scoped：stopExecution 需 workspaceId
-      await stopExecution(state.selectedWorkspace ?? 0, record.id);
+      await stopExecution(todoState.selectedWorkspace ?? 0, record.id);
       message.success('已停止执行');
     } catch (err) {
       message.error(`停止失败: ${err}`);
@@ -114,7 +121,7 @@ export function ExecutionPanel({ collapsed, onToggleCollapse, hidden, onTemporar
                 key={taskId}
                 className={`execution-tab ${isActive ? 'active' : ''} ${task.status}`}
                 onClick={() => {
-                  dispatch({ type: 'SET_ACTIVE_TASK', payload: taskId });
+                  execDispatch({ type: 'SET_ACTIVE_TASK', payload: taskId });
                   if (collapsed) onToggleCollapse();
                 }}
                 role="button"
@@ -122,7 +129,7 @@ export function ExecutionPanel({ collapsed, onToggleCollapse, hidden, onTemporar
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault();
-                    dispatch({ type: 'SET_ACTIVE_TASK', payload: taskId });
+                    execDispatch({ type: 'SET_ACTIVE_TASK', payload: taskId });
                   }
                 }}
               >

--- a/frontend/src/components/TodoDetail.tsx
+++ b/frontend/src/components/TodoDetail.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
-import { useApp } from '@/hooks/useApp';
+// 093 批次2：合并版 useApp 拆为细粒度订阅——todo 域（selectedWorkspace/selectedTodoId）
+// 与 exec 域（executionRecords/runningTasks）分开，uiState 变化不再触发本组件重渲染。
+import { useTodos } from '@/hooks/useTodoContext';
+import { useExecution } from '@/hooks/useExecutionContext';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useExecutionHistory } from '@/hooks/useExecutionHistory';
 import { Button, Empty, App, Modal, Input, Skeleton } from 'antd';
@@ -50,9 +53,11 @@ async function loadTodoById(
 }
 
 export function TodoDetail({ hideTitleRow = false, onOpenPost, onActionsReady }: TodoDetailProps) {
-  const { state, dispatch } = useApp();
+  const { state: todoState, dispatch: todoDispatch } = useTodos();
+  const { state: execState, dispatch: execDispatch } = useExecution();
   const { message } = App.useApp();
-  const { selectedTodoId, executionRecords, runningTasks } = state;
+  const { selectedTodoId, selectedWorkspace } = todoState;
+  const { executionRecords, runningTasks } = execState;
   const isWide = !useIsMobile(BREAKPOINTS.wide);
 
   // selectedTodo 改为独立请求获取的 local state，不再依赖 todos 列表缓存。
@@ -122,17 +127,17 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost, onActionsReady }:
     }
     // ws 尚未解析时不发请求，避免 null workspace 直接命中错误态分支；
     // 依赖里的 selectedWorkspace 变化会重新触发本 effect，自动重试。
-    if (state.selectedWorkspace == null) return;
-    fetchTodo(selectedTodoId, state.selectedWorkspace);
+    if (selectedWorkspace == null) return;
+    fetchTodo(selectedTodoId, selectedWorkspace);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedTodoId, state.selectedWorkspace]);
+  }, [selectedTodoId, selectedWorkspace]);
 
   // 重新加载当前 todo（供回调成功后调用，确保 local state 与后端一致）
   const reloadSelectedTodo = useCallback(async () => {
     if (selectedTodoId == null) return;
-    const fresh = await loadTodoById(selectedTodoId, state.selectedWorkspace);
+    const fresh = await loadTodoById(selectedTodoId, selectedWorkspace);
     if (fresh) setSelectedTodo(fresh);
-  }, [selectedTodoId, state.selectedWorkspace]);
+  }, [selectedTodoId, selectedWorkspace]);
 
   const [todoDrawerOpen, setTodoDrawerOpen] = useState(false);
 
@@ -152,9 +157,11 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost, onActionsReady }:
     handleHistoryPageChange,
   } = useExecutionHistory({
     selectedTodoId,
-    workspaceId: state.selectedWorkspace,
+    workspaceId: selectedWorkspace,
     storeRecords: selectedTodoId ? executionRecords[selectedTodoId] : [],
-    dispatch,
+    // 093 批次2：hook 内部只 dispatch 执行域 action（SET/UPDATE_EXECUTION_RECORD），
+    // 配合把 dispatch prop 收窄到 Dispatch<ExecutionAction>
+    dispatch: execDispatch,
   });
 
   // Timer for live duration display of running records
@@ -214,7 +221,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost, onActionsReady }:
       // 获取新创建的执行记录并立即添加到状态中
       try {
         const newRecord = await db.getExecutionRecord(selectedTodo.workspace_id!, result.record_id);
-        dispatch({
+        execDispatch({
           type: 'ADD_EXECUTION_RECORD',
           payload: { todoId: selectedTodo.id, record: newRecord }
         });
@@ -255,7 +262,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost, onActionsReady }:
       // 获取新创建的执行记录并立即添加到状态中
       try {
         const newRecord = await db.getExecutionRecord(selectedTodo.workspace_id!, result.record_id);
-        dispatch({
+        execDispatch({
           type: 'ADD_EXECUTION_RECORD',
           payload: { todoId: selectedTodo.id, record: newRecord }
         });
@@ -285,7 +292,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost, onActionsReady }:
     } catch {
       // ignore: interceptor already shows error
     }
-  }, [selectedTodo, dispatch]);
+  }, [selectedTodo, todoDispatch]);
 
   const handleTitleUpdate = useCallback(async (aiResult: string) => {
     if (!selectedTodo) return;
@@ -311,7 +318,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost, onActionsReady }:
     // 056：全局桶已删除——详情页本地 state 为准，列表页经刷新事件重拉
     setSelectedTodo(updated);
     window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
-  }, [selectedTodo, dispatch]);
+  }, [selectedTodo, todoDispatch]);
 
   // 升级/降级已移除：环节与 Todo 合一，无需 promote 流程
 
@@ -322,12 +329,12 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost, onActionsReady }:
       await db.deleteTodo(selectedTodo.workspace_id!, selectedTodo.id);
       // 056：全局桶已删除——通知列表页重拉
       window.dispatchEvent(new Event(TODO_LIST_REFRESH_EVENT));
-      dispatch({ type: 'SELECT_TODO', payload: null });
+      todoDispatch({ type: 'SELECT_TODO', payload: null });
       message.success('删除成功');
     } catch {
       // ignore: interceptor already shows error
     }
-  }, [selectedTodo, dispatch, message]);
+  }, [selectedTodo, todoDispatch, message]);
 
   // 独立路由场景：把操作按钮上下文上报给外层 PageCard 的 extra 区（062 修正注释，原误写 titleSuffix）。
   // selectedTodo 为空时上报 null（加载中/错误态），外层相应不渲染按钮。
@@ -374,7 +381,7 @@ export function TodoDetail({ hideTitleRow = false, onOpenPost, onActionsReady }:
                   // 复用共享加载函数，与初始 useEffect 走同一条带竞态保护的路径，
                   // 避免重试 Promise 在用户切换 todo 后用旧结果覆盖新 todo。
                   if (selectedTodoId != null) {
-                    fetchTodo(selectedTodoId, state.selectedWorkspace);
+                    fetchTodo(selectedTodoId, selectedWorkspace);
                   }
                 }}
               >

--- a/frontend/src/hooks/useApp.tsx
+++ b/frontend/src/hooks/useApp.tsx
@@ -9,11 +9,11 @@ import * as db from '@/utils/database';
 
 // ─── Direct imports (needed within this file) ─────────────────
 
-import { useTodos } from './useTodoContext';
+import { useTodos, useTodosDispatch } from './useTodoContext';
 import type { TodoAction } from './useTodoContext';
-import { useExecution } from './useExecutionContext';
+import { useExecution, useExecutionDispatch } from './useExecutionContext';
 import type { ExecutionAction } from './useExecutionContext';
-import { useUI } from './useUIContext';
+import { useUI, useUIDispatch } from './useUIContext';
 import type { UIAction } from './useUIContext';
 import { TodoProvider } from './useTodoContext';
 import { ExecutionProvider } from './useExecutionContext';
@@ -85,6 +85,61 @@ function DataLoader() {
 
 // ─── Unified useApp hook (backward compatibility) ─────────────
 
+/// 093 批次2：只组合四域 dispatch、不订阅任何 state 的合并 dispatch。
+///
+/// 与 useApp() 的关键区别：useApp 内部调用 useTodos()/useExecution()/useUI()，
+/// 即使只取 dispatch 也会订阅三域 state → 任一域变化调用方都重渲染。
+/// 本 hook 全部走 dispatch-only context（引用恒定），订阅方零重渲染订阅——
+/// WS 事件路由（useExecutionEvents）这类「只要 dispatch」的消费方专用。
+export function useAppDispatch() {
+  const todoDispatch = useTodosDispatch();
+  const execDispatch = useExecutionDispatch();
+  const uiDispatch = useUIDispatch();
+  const logsDispatch = useLogsDispatch();
+
+  // 与 useApp 的 dispatch 共用同一份路由逻辑（按 action.type 分派到对应域）
+  return useCallback((action: TodoAction | ExecutionAction | UIAction | LogsAction) => {
+    routeAppAction(action, { todoDispatch, execDispatch, uiDispatch, logsDispatch });
+  }, [todoDispatch, execDispatch, uiDispatch, logsDispatch]);
+}
+
+/// useApp/useAppDispatch 共享的 action 路由表（单一事实源，防两份漂移）。
+/// 与下方 useApp 的 dispatch 保持逐字对齐（当前 main 上 tags 已由组件本地状态接管，
+/// todo 域只剩 SELECT_TODO/SELECT_WORKSPACE 两个 action）。
+function routeAppAction(
+  action: TodoAction | ExecutionAction | UIAction | LogsAction,
+  dispatches: {
+    todoDispatch: React.Dispatch<TodoAction>;
+    execDispatch: React.Dispatch<ExecutionAction>;
+    uiDispatch: React.Dispatch<UIAction>;
+    logsDispatch: React.Dispatch<LogsAction>;
+  },
+) {
+  const t = action.type;
+  if (
+    t === 'SELECT_TODO' ||
+    t === 'SELECT_WORKSPACE'
+  ) {
+    dispatches.todoDispatch(action as TodoAction);
+  } else if (
+    t === 'SET_EXECUTION_RECORDS' || t === 'ADD_EXECUTION_RECORD' ||
+    t === 'UPDATE_EXECUTION_RECORD' || t === 'ADD_RUNNING_TASK' ||
+    t === 'FINISH_TASK' ||
+    t === 'REMOVE_RUNNING_TASK' || t === 'CLEAR_RUNNING_TASKS' ||
+    t === 'SET_ACTIVE_TASK' || t === 'UPDATE_TASK_TODO_PROGRESS' ||
+    t === 'UPDATE_TASK_EXECUTION_STATS'
+  ) {
+    dispatches.execDispatch(action as ExecutionAction);
+  } else if (
+    t === 'SET_TASK_LOGS' || t === 'APPEND_TASK_LOGS' ||
+    t === 'REMOVE_TASK_LOGS' || t === 'CLEAR_LOGS'
+  ) {
+    dispatches.logsDispatch(action as LogsAction);
+  } else if (t === 'SET_LOADING') {
+    dispatches.uiDispatch(action as UIAction);
+  }
+}
+
 export function useApp() {
   const { state: todoState, dispatch: todoDispatch } = useTodos();
   const { state: execState, dispatch: execDispatch } = useExecution();
@@ -104,30 +159,9 @@ export function useApp() {
   // Combined dispatch routes actions to the appropriate sub-dispatcher
   // based on the action's `type` discriminator field.
   // 使用 TodoAction | ExecutionAction | UIAction | LogsAction 联合类型替代 unknown，保留类型安全。
+  // 093 批次2：路由逻辑收口到 routeAppAction（与 useAppDispatch 共用，防两份漂移）
   const dispatch = useCallback((action: TodoAction | ExecutionAction | UIAction | LogsAction) => {
-    const t = action.type;
-    if (
-      t === 'SELECT_TODO' ||
-      t === 'SELECT_WORKSPACE'
-    ) {
-      todoDispatch(action);
-    } else if (
-      t === 'SET_EXECUTION_RECORDS' || t === 'ADD_EXECUTION_RECORD' ||
-      t === 'UPDATE_EXECUTION_RECORD' || t === 'ADD_RUNNING_TASK' ||
-      t === 'FINISH_TASK' ||
-      t === 'REMOVE_RUNNING_TASK' || t === 'CLEAR_RUNNING_TASKS' ||
-      t === 'SET_ACTIVE_TASK' || t === 'UPDATE_TASK_TODO_PROGRESS' ||
-      t === 'UPDATE_TASK_EXECUTION_STATS'
-    ) {
-      execDispatch(action);
-    } else if (
-      t === 'SET_TASK_LOGS' || t === 'APPEND_TASK_LOGS' ||
-      t === 'REMOVE_TASK_LOGS' || t === 'CLEAR_LOGS'
-    ) {
-      logsDispatch(action);
-    } else if (t === 'SET_LOADING') {
-      uiDispatch(action);
-    }
+    routeAppAction(action, { todoDispatch, execDispatch, uiDispatch, logsDispatch });
   }, [todoDispatch, execDispatch, uiDispatch, logsDispatch]);
 
   const clearSelection = useCallback(() => {

--- a/frontend/src/hooks/useExecutionContext.tsx
+++ b/frontend/src/hooks/useExecutionContext.tsx
@@ -89,13 +89,20 @@ function reducer(state: ExecutionState, action: ExecutionAction): ExecutionState
 // ─── Context ──────────────────────────────────────────────────
 
 const ExecutionContext = createContext<{ state: ExecutionState; dispatch: React.Dispatch<ExecutionAction> } | null>(null);
+// 093 批次2：dispatch 独立 context——执行态高频变化（进度/统计推送），
+// 只订阅 dispatch 的消费方不再被卷入重渲染。
+const ExecutionDispatchContext = createContext<React.Dispatch<ExecutionAction> | null>(null);
 
 // ─── Provider ─────────────────────────────────────────────────
 
 export function ExecutionProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const ctx = useMemo(() => ({ state, dispatch }), [state, dispatch]);
-  return <ExecutionContext.Provider value={ctx}>{children}</ExecutionContext.Provider>;
+  return (
+    <ExecutionDispatchContext.Provider value={dispatch}>
+      <ExecutionContext.Provider value={ctx}>{children}</ExecutionContext.Provider>
+    </ExecutionDispatchContext.Provider>
+  );
 }
 
 // ─── Hook ─────────────────────────────────────────────────────
@@ -104,6 +111,13 @@ export function useExecution() {
   const ctx = useContext(ExecutionContext);
   if (!ctx) throw new Error('useExecution must be used within ExecutionProvider');
   return ctx;
+}
+
+/** 只取 dispatch（引用恒定）：订阅它不会因执行态变化重渲染。 */
+export function useExecutionDispatch() {
+  const dispatch = useContext(ExecutionDispatchContext);
+  if (!dispatch) throw new Error('useExecutionDispatch must be used within ExecutionProvider');
+  return dispatch;
 }
 
 export type { ExecutionAction };

--- a/frontend/src/hooks/useExecutionEvents.test.tsx
+++ b/frontend/src/hooks/useExecutionEvents.test.tsx
@@ -29,10 +29,14 @@ class FakeWebSocket {
 
 // useApp mock：可控的 selectedWorkspace + 空 dispatch（本测试不断言状态分发）
 let mockWorkspace: number | null = null;
+// 093 批次2：组件已拆为 useAppDispatch（dispatch-only）+ useTodos（workspace），
+// mock 同步拆到两个模块；本测试不断言状态分发，dispatch 给空实现即可。
 vi.mock('./useApp', () => ({
-  useApp: () => ({
+  useAppDispatch: () => vi.fn(),
+}));
+vi.mock('./useTodoContext', () => ({
+  useTodos: () => ({
     state: { selectedWorkspace: mockWorkspace },
-    dispatch: vi.fn(),
   }),
 }));
 

--- a/frontend/src/hooks/useExecutionEvents.ts
+++ b/frontend/src/hooks/useExecutionEvents.ts
@@ -1,5 +1,9 @@
 import { useEffect, useRef } from 'react';
-import { useApp } from './useApp';
+// 093 批次2：useApp → useAppDispatch + useTodos 细粒度拆分。
+// 本 hook 只需合并 dispatch（WS 事件路由）与 selectedWorkspace（订阅范围），
+// 经 dispatch-only context 取 dispatch 后，执行/日志域高频更新不再触发本 hook 宿主重渲染。
+import { useAppDispatch } from './useApp';
+import { useTodos } from './useTodoContext';
 import type { LogEntry, TodoItem, ExecutionStats } from '@/types';
 import { TODO_LIST_REFRESH_EVENT } from '@/constants';
 
@@ -155,7 +159,7 @@ let sharedOnRefreshRefs: Array<React.MutableRefObject<(() => void) | undefined>>
 /** 自动清除已结束任务的定时器：key=taskId（056 改为 Map，支持 Sync 时按任务撤销）。 */
 let sharedRemoveTaskTimers = new Map<string, ReturnType<typeof setTimeout>>();
 /** 全局 dispatch 函数（从第一个调用方的 useApp() 获取，后续复用） */
-let sharedDispatch: ReturnType<typeof useApp>['dispatch'] | null = null;
+let sharedDispatch: ReturnType<typeof useAppDispatch> | null = null;
 /** 当前活跃的调用方数量（当计数归零时关闭 WS） */
 let sharedInstanceCount = 0;
 
@@ -170,7 +174,7 @@ function getReconnectDelay(): number {
 }
 
 /** 创建全局 WebSocket 连接（如果尚未创建） */
-function connectShared(dispatch: ReturnType<typeof useApp>['dispatch']) {
+function connectShared(dispatch: ReturnType<typeof useAppDispatch>) {
   if (!sharedShouldReconnect) return;
   // 已有连接则跳过（防止 React StrictMode 开发期双调用创建两个 WS）
   if (sharedWs) return;
@@ -447,9 +451,11 @@ function reconnectWithWorkspace(workspaceId: number | null) {
 }
 
 export function useExecutionEvents(onRefresh?: () => void) {
-  const { state, dispatch } = useApp();
+  // dispatch 走 dispatch-only context（零 state 订阅）；workspace 只读 todo 域
+  const dispatch = useAppDispatch();
+  const { state: todoState } = useTodos();
   // 094：订阅范围跟随全局 workspace 选择态
-  const selectedWorkspace = state.selectedWorkspace;
+  const selectedWorkspace = todoState.selectedWorkspace;
 
   // 用 ref 持有 onRefresh，使其始终指向最新值但不触发 effect 重新执行
   const onRefreshRef = useRef(onRefresh);

--- a/frontend/src/hooks/useExecutionHistory.ts
+++ b/frontend/src/hooks/useExecutionHistory.ts
@@ -13,9 +13,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import type { ExecutionRecord, LogEntry, ExecutionSummary } from '@/types';
-import type { TodoAction } from './useTodoContext';
 import type { ExecutionAction } from './useExecutionContext';
-import type { UIAction } from './useUIContext';
 import * as db from '@/utils/database';
 
 interface UseExecutionHistoryOptions {
@@ -27,7 +25,8 @@ interface UseExecutionHistoryOptions {
   /** Records already in the global store for this todo */
   storeRecords: ExecutionRecord[];
   /** Dispatch from useApp() — used to sync fetched records back into global state */
-  dispatch: React.Dispatch<TodoAction | ExecutionAction | UIAction>;
+  // 093 批次2：本 hook 只 dispatch 执行域 action，类型从三域联合收窄到 ExecutionAction
+  dispatch: React.Dispatch<ExecutionAction>;
 }
 
 interface UseExecutionHistoryResult {

--- a/frontend/src/hooks/useTodoContext.tsx
+++ b/frontend/src/hooks/useTodoContext.tsx
@@ -76,13 +76,21 @@ function reducer(state: TodoState, action: TodoAction): TodoState {
 // ─── Context ──────────────────────────────────────────────────
 
 const TodoContext = createContext<{ state: TodoState; dispatch: React.Dispatch<TodoAction> } | null>(null);
+// 093 批次2：dispatch 独立 context（沿用 091 LogsContext 双 context 先例）。
+// useReducer 的 dispatch 引用恒定，只订阅 dispatch 的消费方（如 WS 事件路由）
+// 不会因 todo state 变化而重渲染。
+const TodoDispatchContext = createContext<React.Dispatch<TodoAction> | null>(null);
 
 // ─── Provider ─────────────────────────────────────────────────
 
 export function TodoProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const ctx = useMemo(() => ({ state, dispatch }), [state]);
-  return <TodoContext.Provider value={ctx}>{children}</TodoContext.Provider>;
+  return (
+    <TodoDispatchContext.Provider value={dispatch}>
+      <TodoContext.Provider value={ctx}>{children}</TodoContext.Provider>
+    </TodoDispatchContext.Provider>
+  );
 }
 
 // ─── Hooks ─────────────────────────────────────────────────────
@@ -91,6 +99,13 @@ export function useTodos() {
   const ctx = useContext(TodoContext);
   if (!ctx) throw new Error('useTodos must be used within TodoProvider');
   return ctx;
+}
+
+/** 只取 dispatch（引用恒定）：订阅它不会因 state 变化重渲染。 */
+export function useTodosDispatch() {
+  const dispatch = useContext(TodoDispatchContext);
+  if (!dispatch) throw new Error('useTodosDispatch must be used within TodoProvider');
+  return dispatch;
 }
 
 export type { TodoAction };

--- a/frontend/src/hooks/useUIContext.tsx
+++ b/frontend/src/hooks/useUIContext.tsx
@@ -20,13 +20,19 @@ function reducer(state: UIState, action: UIAction): UIState {
 // ─── Context ──────────────────────────────────────────────────
 
 const UIContext = createContext<{ state: UIState; dispatch: React.Dispatch<UIAction> } | null>(null);
+// 093 批次2：dispatch 独立 context（与 Todo/Execution 同款双 context 拆分）
+const UIDispatchContext = createContext<React.Dispatch<UIAction> | null>(null);
 
 // ─── Provider ─────────────────────────────────────────────────
 
 export function UIProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const ctx = useMemo(() => ({ state, dispatch }), [state, dispatch]);
-  return <UIContext.Provider value={ctx}>{children}</UIContext.Provider>;
+  return (
+    <UIDispatchContext.Provider value={dispatch}>
+      <UIContext.Provider value={ctx}>{children}</UIContext.Provider>
+    </UIDispatchContext.Provider>
+  );
 }
 
 // ─── Hook ─────────────────────────────────────────────────────
@@ -35,6 +41,13 @@ export function useUI() {
   const ctx = useContext(UIContext);
   if (!ctx) throw new Error('useUI must be used within UIProvider');
   return ctx;
+}
+
+/** 只取 dispatch（引用恒定）：订阅它不会因 UI state 变化重渲染。 */
+export function useUIDispatch() {
+  const dispatch = useContext(UIDispatchContext);
+  if (!dispatch) throw new Error('useUIDispatch must be used within UIProvider');
+  return dispatch;
 }
 
 export type { UIAction };

--- a/frontend/tests/093-useapp-batch2-smoke.spec.ts
+++ b/frontend/tests/093-useapp-batch2-smoke.spec.ts
@@ -1,0 +1,28 @@
+// 093 useApp 批次 2 冒烟：TodoDetail / ExecutionPanel 迁移 + useAppDispatch 零订阅拆分。
+import { test, expect } from '@playwright/test';
+
+const BASE = 'http://localhost:5173';
+
+test('093-b2: 列表页 → 打开 Todo 详情（TodoDetail 迁移路径）渲染无错', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  await page.goto(`${BASE}/#/todos`);
+  await expect(page.locator('#root')).not.toBeEmpty({ timeout: 15000 });
+  // 点第一张卡片进详情（dev 库 ws=1 有数据）
+  const card = page.locator('.ant-card, [class*="card"]').first();
+  if (await card.isVisible().catch(() => false)) {
+    await card.click();
+    await page.waitForTimeout(1500);
+  }
+  expect(errors).toEqual([]);
+});
+
+test('093-b2: 执行面板区域（ExecutionPanel）挂载且无页面错误', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (e) => errors.push(e.message));
+  await page.goto(BASE);
+  await expect(page.locator('#root')).not.toBeEmpty({ timeout: 15000 });
+  // WS 连接建立（useExecutionEvents 走 useAppDispatch 路径）
+  await page.waitForTimeout(2000);
+  expect(errors).toEqual([]);
+});


### PR DESCRIPTION
## 实现了什么

批次 1 后剩余的 useApp 消费方全部迁完，并完成「最后一公里」：

- **TodoDetail** → useTodos + useExecution 双域拆分
- **ExecutionPanel** → useTodos + useExecution + useLogsDispatch 三域拆分
- **useExecutionHistory** dispatch prop 收窄到 `Dispatch<ExecutionAction>`
- **dispatch-only 双 context**：Todo/Execution/UI 各补 dispatch 独立 context（沿用 091 LogsContext 先例）
- **新增 `useAppDispatch()`**：四域 dispatch 组合、零 state 订阅；路由逻辑抽 `routeAppAction` 供 useApp/useAppDispatch 共用
- **useExecutionEvents** 切换后，WS 事件路由宿主不再被执行/日志高频更新卷入重渲染

最终状态：项目 `useApp()` 业务消费方 **0** 个。

## 测试

- tsc 零错误；vitest 54 文件 / 452 用例全绿
- Playwright 冒烟 2 项（TodoDetail 路径 / 执行面板 + WS 路由）

文档：docs/requirements/093-useApp批次2迁移-实现总结.md